### PR TITLE
[WIP] Add a vendor command

### DIFF
--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -26,6 +26,9 @@ end
 val do_build     : t -> Path.t list -> (unit Future.t, Build_error.t) result
 val do_build_exn : t -> Path.t list -> unit Future.t
 
+(** Returns the set of transitive dependencies required to build the given targets. *)
+val transitive_deps_exn : t -> Path.t list -> Path.Set.t Future.t
+
 (** Return all the library dependencies (as written by the user) needed to build these
     targets *)
 val all_lib_deps : t -> Path.t list -> Build.lib_deps Path.Map.t

--- a/src/main.ml
+++ b/src/main.ml
@@ -6,6 +6,7 @@ type setup =
   ; stanzas      : (Path.t * Jbuild_types.Stanzas.t) list String_map.t
   ; contexts     : Context.t list
   ; packages     : Package.t String_map.t
+  ; file_tree    : File_tree.t
   }
 
 let package_install_file { packages; _ } pkg =
@@ -54,6 +55,7 @@ let setup ?(log=Log.no_log) ?filter_out_optional_stanzas_with_missing_deps
          ; stanzas
          ; contexts
          ; packages = conf.packages
+         ; file_tree = conf.file_tree
          }
 
 let external_lib_deps ?log ~packages () =

--- a/src/main.mli
+++ b/src/main.mli
@@ -6,6 +6,7 @@ type setup =
     stanzas      : (Path.t * Jbuild_types.Stanzas.t) list String_map.t
   ; contexts     : Context.t list
   ; packages     : Package.t String_map.t
+  ; file_tree    : File_tree.t
   }
 
 (* Returns [Error ()] if [pkg] is unknown *)


### PR DESCRIPTION
This patch adds a `vendor` command. Given a list of targets it creates a directory structure that is a stripped down version of the workspace containing only the minimum number of files needed to build these targets.

For instance, applied to jbuilder itself:

```sh
$ git clean -dfx
$ find . |wc -l
2389
$ jbuilder vendor bin/main.exe --dest-dir /tmp/blah
[...]
$ cd /tmp/blah
$ find . | wc -l
133
$ jbuilder build bin/main.exe
[...]
# Success!
```