### PR TITLE
Add support for optional ppx preprocessors

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -173,10 +173,9 @@ let common =
   let enable_optional_pps =
     Arg.(value
          & opt (some (list string)) None
-         & info ["enable-optional-pps"] ~docs ~docv:"PACKAGES"
-             ~doc:{|Enable ppx preprocessor $(b,PACKAGES) specified as optional
-                    in jbuild files.  $(b,PACKAGES) is a comma-separated list of
-                    package names.|})
+         & info ["enable-optional-pps"] ~docs ~docv:"PPX-REWRITERS"
+             ~doc:{|Enable ppx preprocessors specified as optional in jbuild files.
+                    $(b,PPX-REWRITERS) is a comma-separated list of package names.|})
   in
   let ddep_path =
     Arg.(value

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -741,14 +741,17 @@ Preprocessing with ppx rewriters
 ``<ppx-rewriters-and-flags>`` is expected to be a list where each element is
 either a command line flag if starting with a ``-`` or the name of a library.
 Additionnally, any sub-list will be treated as a list of command line arguments.
+Optional ppx rewriters are specified by starting the library name with a ``?``.
 So for instance from the following ``preprocess`` field:
 
    .. code:: scheme
 
-       (preprocess (pps (ppx1 -foo ppx2 (-bar 42))))
+       (preprocess (pps (ppx1 -foo ppx2 (-bar 42) ?ppx3 ?ppx4)))
 
 The list of libraries will be ``ppx1`` and ``ppx2`` and the command line
-arguments will be: ``-foo -bar 42``.
+arguments will be: ``-foo -bar 42``.  ``ppx3`` and ``ppx4`` will be
+included if ``--enable-optional-pps=ppx3,ppx4`` is passed to
+``jbuilder``.
 
 Libraries listed here should be libraries implementing an OCaml AST rewriter and
 registering themselves using the `ocaml-migrate-parsetree.driver API

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -990,7 +990,7 @@ Add it to your jbuild file to remove this warning.
 end
 
 let gen ~contexts ?(filter_out_optional_stanzas_with_missing_deps=true)
-      ?only_packages ?enable_optional_pps conf =
+      ?only_packages ?(enable_optional_pps=String_set.empty) conf =
   let open Future in
   let { Jbuild_load. file_tree; tree; jbuilds; packages } = conf in
   let aliases = Alias.Store.create () in
@@ -1024,11 +1024,10 @@ let gen ~contexts ?(filter_out_optional_stanzas_with_missing_deps=true)
              | _ -> true)))
     in
     let stanzas =
-      let spec = Option.value ~default:String_set.empty enable_optional_pps in
       let filter_pps b =
         { b with
           Buildable.preprocess =
-            Preprocess_map.filter_optional spec b.Buildable.preprocess
+            Preprocess_map.filter_optional ~enabled:enable_optional_pps b.Buildable.preprocess
         }
       in
       List.map stanzas ~f:(fun (dir, pkgs_ctx, stanzas) ->

--- a/src/gen_rules.mli
+++ b/src/gen_rules.mli
@@ -5,6 +5,7 @@ val gen
   :  contexts:Context.t list
   -> ?filter_out_optional_stanzas_with_missing_deps:bool (* default: true *)
   -> ?only_packages:String_set.t
+  -> ?enable_optional_pps:String_set.t
   -> Jbuild_load.conf
   -> (Build_interpret.Rule.t list *
      (* Evaluated jbuilds per context names *)

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -190,12 +190,20 @@ module Pp_or_flags = struct
     | List (_, l) -> Flags (List.map l ~f:string)
 
   let split l =
-    let pps, flags =
-      List.partition_map l ~f:(function
-        | PP pp  -> Inl pp
-        | Flags s -> Inr s)
+    let rec flags fs = function (* collect flags together *)
+      | Flags f :: t -> flags (f :: fs) t
+      | rest -> (List.concat @@ List.rev @@ fs), rest
     in
-    (pps, List.concat flags)
+    let rec pps = function
+      | [] -> []
+      | (Flags _ :: _) as fs -> (* starts with flags (no pp) *)
+        let fs, ps = flags [] fs in
+        (None,fs) :: pps ps
+      | PP pp :: t -> (* get pp + associated flags *)
+        let fs, ps = flags [] t in
+        (Some(pp), fs) :: pps ps
+    in
+    pps l
 end
 
 module Dep_conf = struct
@@ -235,7 +243,8 @@ module Dep_conf = struct
 end
 
 module Preprocess = struct
-  type pps = { pps : Pp.t list; flags : string list }
+  type pp = { pps : Pp.t option; flags : string list }
+  type pps = pp list
   type t =
     | No_preprocessing
     | Action of Action.Unexpanded.t
@@ -246,24 +255,30 @@ module Preprocess = struct
       [ cstr "no_preprocessing" nil No_preprocessing
       ; cstr "action" (Action.Unexpanded.t @> nil) (fun x -> Action x)
       ; cstr "pps" (list Pp_or_flags.t @> nil) (fun l ->
-          let pps, flags = Pp_or_flags.split l in
-          Pps { pps; flags })
+          let pps_and_flags = Pp_or_flags.split l in
+          Pps (List.map pps_and_flags ~f:(fun (pps, flags) -> { pps; flags })))
       ]
 
   let pps = function
-    | Pps { pps; _ } -> pps
+    | Pps pps -> List.filter_map pps ~f:(fun pps -> pps.pps)
+    | _ -> []
+
+  let flags = function
+    | Pps pps -> List.concat @@ List.map pps ~f:(fun pps -> pps.flags)
     | _ -> []
 
   let filter_optional ~enabled pp =
-    let disable_optional pp =
-      if Pp.is_optional pp && not (String_set.mem (Pp.to_string pp) enabled) then None
-      else Some(pp)
+    let disable_optional pps =
+      match pps with
+      | { pps=Some(pp); _ } when Pp.is_optional pp &&
+                            not (String_set.mem (Pp.to_string pp) enabled) -> None
+      | _ -> Some(pps)
     in
     match pp with
-    | Pps { pps; flags } ->
+    | Pps pps ->
       let pps = List.filter_map pps ~f:disable_optional in
       if pps = [] then No_preprocessing
-      else Pps { pps; flags }
+      else Pps pps
     | _ -> pp
 end
 
@@ -326,8 +341,8 @@ module Lint = struct
   let t =
     sum
       [ cstr "pps" (list Pp_or_flags.t @> nil) (fun l ->
-          let pps, flags = Pp_or_flags.split l in
-          Pps { pps; flags })
+          let pps_and_flags = Pp_or_flags.split l in
+          Pps (List.map pps_and_flags ~f:(fun (pps, flags) -> { Preprocess. pps; flags })))
       ]
 end
 

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -53,7 +53,7 @@ module Preprocess_map : sig
   val pps : t -> Pp.t list
 
   (* filter out optional pps which have not been enabled *)
-  val filter_optional : String_set.t -> t -> t
+  val filter_optional : enabled:String_set.t -> t -> t
 end
 
 module Js_of_ocaml : sig

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -33,15 +33,16 @@ module Pp : sig
 end
 
 module Preprocess : sig
-  type pps =
-    { pps   : Pp.t list
-    ; flags : string list
-    }
+  type pp
+  type pps
 
   type t =
     | No_preprocessing
     | Action of Action.Unexpanded.t
     | Pps    of pps
+
+  val pps : t -> Pp.t list
+  val flags : t -> string list
 end
 
 module Preprocess_map : sig

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -29,6 +29,7 @@ module Pp : sig
   type t
   val of_string : string -> t
   val to_string : t -> string
+  val is_optional : t -> bool
 end
 
 module Preprocess : sig
@@ -50,6 +51,9 @@ module Preprocess_map : sig
   val find : string -> t -> Preprocess.t
 
   val pps : t -> Pp.t list
+
+  (* filter out optional pps which have not been enabled *)
+  val filter_optional : String_set.t -> t -> t
 end
 
 module Js_of_ocaml : sig

--- a/src/main.ml
+++ b/src/main.ml
@@ -18,6 +18,7 @@ let setup ?(log=Log.no_log) ?filter_out_optional_stanzas_with_missing_deps
       ?(use_findlib=true)
       ?only_packages
       ?extra_ignored_subtrees
+      ?enable_optional_pps
       () =
   let conf = Jbuild_load.load ?extra_ignored_subtrees () in
   Option.iter only_packages ~f:(fun set ->
@@ -48,6 +49,7 @@ let setup ?(log=Log.no_log) ?filter_out_optional_stanzas_with_missing_deps
   Gen_rules.gen conf ~contexts
     ?only_packages
     ?filter_out_optional_stanzas_with_missing_deps
+    ?enable_optional_pps
   >>= fun (rules, stanzas) ->
   let build_system = Build_system.create ~contexts ~file_tree:conf.file_tree ~rules in
   return { build_system

--- a/src/main.mli
+++ b/src/main.mli
@@ -18,6 +18,7 @@ val setup
   -> ?workspace:Workspace.t
   -> ?workspace_file:string
   -> ?only_packages:String_set.t
+  -> ?enable_optional_pps:String_set.t
   -> unit
   -> setup Future.t
 val external_lib_deps

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -13,7 +13,9 @@ type t =
 
 let ppx_flags sctx ~dir ~src_dir { preprocess; libname; _ } =
   match preprocess with
-  | Pps { pps; flags } ->
+  | Pps _ as pps ->
+    let flags = Jbuild.Preprocess.flags pps in
+    let pps = Jbuild.Preprocess.pps pps in
     let exe = SC.PP.get_ppx_driver sctx pps ~dir ~dep_kind:Optional in
     let command =
       List.map (Path.reach exe ~from:src_dir

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -877,7 +877,9 @@ module PP = struct
                ~dep_kind
                ~targets:(Static [dst])
                ~scope))
-      | Pps { pps; flags } ->
+      | Pps _ as pps ->
+        let flags = Preprocess.flags pps in
+        let pps = Preprocess.pps pps in
         let ppx_exe = get_ppx_driver sctx pps ~dir ~dep_kind in
         pped_module m ~dir ~f:(fun kind src dst ->
           add_rule sctx


### PR DESCRIPTION
(mainly to support bisect_ppx, but possibly useful elsewhere).

They are specified in a `(preprocess (pps (?ppx)))` stanza.  The
'?' marks them as optional.

A command line argument '--enable-optional-pps=...' takes a comma
separated list of ppx packages to enable.

Note; jbuild.ml; Preprocess_map.filter_optional.  In the
Per_module.Per_module branch, it is possible we could end up with
an empty set of preprocessors (this case is checked in the For_all
branch).  If this is a problem, we probably want a String_map.filter_map
function to be added into import.ml.