### PR TITLE
enforce O_CLOEXEC on Windows

### DIFF
--- a/src/future.ml
+++ b/src/future.ml
@@ -588,8 +588,6 @@ module Scheduler = struct
       wait_for_unfinished_jobs ();
       exec_at_exit_handlers ())
 
-  let ocaml_version = Scanf.sscanf Sys.ocaml_version "%u.%u" (fun a b -> a, b)
-
   let get_std_output ~default = function
     | Terminal -> (default, None)
     | File fn ->
@@ -601,7 +599,9 @@ module Scheduler = struct
       | Channel oc ->
         flush oc;
         let fd = Unix.descr_of_out_channel oc in
-        if Sys.win32 = false || ocaml_version >= (4,5) then
+        (* Since OCaml 4.05.0 HANDLES passed to CreateProcess are
+           duplicated by default. *)
+        if Sys.(win32 = false || (ocaml_major,ocaml_minor) >= (4,5)) then
           (fd, Option.some_if tail desc)
         else begin
           let fd' = Unix.dup fd in

--- a/src/import.ml
+++ b/src/import.ml
@@ -311,6 +311,9 @@ module Sys = struct
           remove fn
     else
       remove
+
+  let ocaml_major,ocaml_minor =
+    Scanf.sscanf ocaml_version "%u.%u" (fun a b -> a, b)
 end
 
 module Filename = struct

--- a/src/io.ml
+++ b/src/io.ml
@@ -2,11 +2,94 @@ open Import
 
 module P = Pervasives
 
+module W32_io = struct
+
+  (* Pervasives.open* support neither O_CLOEXEC nor O_SHARE_DELETE *)
+
+  let trans accu = function
+  |	Open_rdonly -> Unix.O_RDONLY::accu
+  |	Open_wronly -> Unix.O_WRONLY::accu
+  |	Open_creat -> Unix.O_CREAT::accu
+  |	Open_trunc -> Unix.O_TRUNC::accu
+  |	Open_excl -> Unix.O_EXCL::accu
+  |	Open_nonblock -> Unix.O_NONBLOCK::accu
+  |	Open_append
+  |	Open_binary
+  |	Open_text -> accu
+
+  let sys_exn e fln =
+    let msg = fln ^ ":" ^ Unix.error_message e in
+    raise (Sys_error msg)
+
+  let eclose ecode fd fln =
+    (try Unix.close fd with Unix.Unix_error _ -> ());
+    sys_exn ecode fln
+
+  let open_gen mode perm fln =
+    let init = [Unix.O_SHARE_DELETE ; Unix.O_CLOEXEC] in
+    let m = List.fold_left ~f:trans ~init mode in
+    match Unix.openfile fln m perm with
+    | exception (Unix.Unix_error(x,_,_)) -> sys_exn x fln
+    | fd ->
+      if List.mem Open_append ~set:mode then (
+        try
+          let _ : int = Unix.lseek fd 0 Unix.SEEK_END in
+          ()
+        with
+        | Unix.Unix_error(e,_,_) -> eclose e fd fln
+      );
+      fd
+
+  let open_out_gen mode perm fln =
+    let fd = open_gen mode perm fln in
+    match Unix.out_channel_of_descr fd with
+    | exception (Unix.Unix_error(e,_,_)) -> eclose e fd fln
+    | oc ->
+      if List.mem Open_text ~set:mode then (
+        try
+          set_binary_mode_out oc false
+        with
+        | x -> close_out oc ; raise x
+      );
+      oc
+
+  let open_out name =
+    open_out_gen [Open_wronly; Open_creat; Open_trunc; Open_text] 0o666 name
+
+  let open_out_bin name =
+    open_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary] 0o666 name
+
+  let open_in_gen mode perm fln =
+    let fd = open_gen mode perm fln in
+    match Unix.in_channel_of_descr fd with
+    | exception (Unix.Unix_error(e,_,_)) -> eclose e fd fln
+    | ic ->
+      if List.mem Open_text ~set:mode then (
+        try
+          set_binary_mode_in ic false
+        with
+        | x -> close_in ic ; raise x
+      );
+      ic
+
+  let open_in name =
+    open_in_gen [Open_rdonly; Open_text] 0 name
+
+  let open_in_bin name =
+    open_in_gen [Open_rdonly; Open_binary] 0 name
+end
+
+let open_in,open_in_bin,open_out,open_out_bin =
+  if Sys.win32 then
+    W32_io.(open_in,open_in_bin,open_out,open_out_bin)
+  else
+    P.(open_in,open_in_bin,open_out,open_out_bin)
+
 let open_in ?(binary=true) fn =
-  if binary then P.open_in_bin fn else P.open_in fn
+  if binary then open_in_bin fn else open_in fn
 
 let open_out ?(binary=true) fn =
-  if binary then P.open_out_bin fn else P.open_out fn
+  if binary then open_out_bin fn else open_out fn
 
 let close_in  = close_in
 let close_out = close_out

--- a/src/io.ml
+++ b/src/io.ml
@@ -2,48 +2,49 @@ open Import
 
 module P = Pervasives
 
-module W32_io = struct
+module Win32_io = struct
 
   (* Pervasives.open* support neither O_CLOEXEC nor O_SHARE_DELETE *)
 
-  let trans accu = function
-  |	Open_rdonly -> Unix.O_RDONLY::accu
-  |	Open_wronly -> Unix.O_WRONLY::accu
-  |	Open_creat -> Unix.O_CREAT::accu
-  |	Open_trunc -> Unix.O_TRUNC::accu
-  |	Open_excl -> Unix.O_EXCL::accu
-  |	Open_nonblock -> Unix.O_NONBLOCK::accu
-  |	Open_append
-  |	Open_binary
-  |	Open_text -> accu
-
-  let sys_exn e fln =
-    let msg = fln ^ ":" ^ Unix.error_message e in
+  let sys_exn e fn =
+    let msg = fn ^ ":" ^ Unix.error_message e in
     raise (Sys_error msg)
 
-  let eclose ecode fd fln =
+  let eclose ecode fd fn =
     (try Unix.close fd with Unix.Unix_error _ -> ());
-    sys_exn ecode fln
+    sys_exn ecode fn
 
-  let open_gen mode perm fln =
+  let open_gen mode perm fn =
     let init = [Unix.O_SHARE_DELETE ; Unix.O_CLOEXEC] in
+    let trans acc = function
+    |	Open_rdonly -> Unix.O_RDONLY::acc
+    |	Open_wronly -> Unix.O_WRONLY::acc
+    |	Open_creat -> Unix.O_CREAT::acc
+    |	Open_trunc -> Unix.O_TRUNC::acc
+    |	Open_excl -> Unix.O_EXCL::acc
+    |	Open_nonblock -> Unix.O_NONBLOCK::acc
+    |	Open_append (* lseek must be used, if the HANDLE might be passed
+                     to a child process. The not implemented support of
+                     Unix.O_APPEND (FILE_APPEND_DATA) would probably not work
+                     in this case anyway *)
+    |	Open_binary (* Open_binary/Open_text are handled in open_(in|out)_gen *)
+    |	Open_text -> acc in
     let m = List.fold_left ~f:trans ~init mode in
-    match Unix.openfile fln m perm with
-    | exception (Unix.Unix_error(x,_,_)) -> sys_exn x fln
+    match Unix.openfile fn m perm with
+    | exception (Unix.Unix_error(x,_,_)) -> sys_exn x fn
     | fd ->
       if List.mem Open_append ~set:mode then (
         try
-          let _ : int = Unix.lseek fd 0 Unix.SEEK_END in
-          ()
+          ignore (Unix.lseek fd 0 Unix.SEEK_END : int)
         with
-        | Unix.Unix_error(e,_,_) -> eclose e fd fln
+        | Unix.Unix_error(e,_,_) -> eclose e fd fn
       );
       fd
 
-  let open_out_gen mode perm fln =
-    let fd = open_gen mode perm fln in
+  let open_out_gen mode perm fn =
+    let fd = open_gen mode perm fn in
     match Unix.out_channel_of_descr fd with
-    | exception (Unix.Unix_error(e,_,_)) -> eclose e fd fln
+    | exception (Unix.Unix_error(e,_,_)) -> eclose e fd fn
     | oc ->
       if List.mem Open_text ~set:mode then (
         try
@@ -59,10 +60,10 @@ module W32_io = struct
   let open_out_bin name =
     open_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary] 0o666 name
 
-  let open_in_gen mode perm fln =
-    let fd = open_gen mode perm fln in
+  let open_in_gen mode perm fn =
+    let fd = open_gen mode perm fn in
     match Unix.in_channel_of_descr fd with
-    | exception (Unix.Unix_error(e,_,_)) -> eclose e fd fln
+    | exception (Unix.Unix_error(e,_,_)) -> eclose e fd fn
     | ic ->
       if List.mem Open_text ~set:mode then (
         try
@@ -81,7 +82,7 @@ end
 
 let open_in,open_in_bin,open_out,open_out_bin =
   if Sys.win32 then
-    W32_io.(open_in,open_in_bin,open_out,open_out_bin)
+    Win32_io.(open_in,open_in_bin,open_out,open_out_bin)
   else
     P.(open_in,open_in_bin,open_out,open_out_bin)
 


### PR DESCRIPTION
1. The `Pervasives.open*` functions, don't open files with `O_CLOEXEC` on Windows (for whatever reason the Windows and *nix implementation differs at this point).
2. Currently all inheritable handles are also inherited to processes created with `Unix.create_process*`. There is no option to disable it.
3. Some windows programs are picky and fail, if a file is already opened by a parallel process (it depends which flags are passed to `CreateFile` in each process).

1)-3) combined with parallelism lead to a mess. Example:

```ocaml
let ch = open_out "test.c" in
output_string ch "int foo(void) { return 0; }";
flush ch;
let _ = Unix.create_process "sleep" [|"sleep";"10"|] Unix.stdin Unix.stdout Unix.stderr in
close_out ch;
let e = Sys.command "cl.exe -c test.c" in
Printf.printf "exit_status:%d\n!" e
```

Although `ch` is closed, when `Sys.command is` called, it's still open inside the `sleep` process and "cl.exe" will likely fail. Similar situations are easily triggered under Windows and compilation will only succeed with `jbuilder -j 1`.

As a workaround `Unix.openfile` is used instead of `Pervasives.open*` and all files are opened with `O_CLOEXEC`. (You have to pass inheritable handles to `Unix.create_process`. But the racy parts are now contained in `go_rec`).