### PR TITLE
Remove readonly attribute on Windows before unlink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,8 @@ next
   `META.pkg.template`. This feature was unused and was making the code
   complicated (#370)
 
+- Remove read-only attribute on Windows before unlink (#247)
+
 1.0+beta16 (05/11/2017)
 -----------------------
 

--- a/src/action.ml
+++ b/src/action.ml
@@ -735,6 +735,7 @@ let rec exec t ~ectx ~dir ~env_extra ~stdout_to ~stderr_to =
       match Unix.readlink dst with
       | target ->
         if target <> src then begin
+          (* @@DRA Win32 remove read-only attribute needed when symlinking enabled *)
           Unix.unlink dst;
           Unix.symlink src dst
         end


### PR DESCRIPTION
The legacy DOS readonly attribute is a tedious difference on Windows, because a user may have permission to delete a file, but unlink fails because the attribute is set.
