### PR TITLE
Make sure quotes are preserved (Win32)

### DIFF
--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -57,7 +57,10 @@ let starts_with s ~prefix =
 let exec fmt =
   ksprintf (fun cmd ->
     print_endline cmd;
-    Sys.command cmd)
+    (* To make sure quotes are preserved in Win32, the whole command
+       must be wrapped with a extra pair of quotes. *)
+    if Sys.win32 then Sys.command ("\"" ^ cmd ^ "\"")
+    else Sys.command cmd)
     fmt
 
 let path_sep =


### PR DESCRIPTION
To avoid the complicated rules (which we cannot guarantee to be
satisfied in all contexts) Windows has about preserving quotes
https://www.borngeek.com/2011/03/22/calls-to-system-in-windows/
it is better to wrap the whole command in quotes.

See https://github.com/janestreet/jbuilder/issues/322#issuecomment-345070464 for the discussion.