### PR TITLE
Use /Fo instead of -o when invoking CL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,7 +65,11 @@ next
   `META.pkg.template`. This feature was unused and was making the code
   complicated (#370)
 
+
 - Remove read-only attribute on Windows before unlink (#247)
+
+- Use /Fo instead of -o when invoking the Microsoft C compiler to eliminate
+  deprecation warning when compiling C++ sources (#354)
 
 1.0+beta16 (05/11/2017)
 -----------------------

--- a/src/arg_spec.ml
+++ b/src/arg_spec.ml
@@ -6,6 +6,7 @@ type 'a t =
   | A        of string
   | As       of string list
   | S        of 'a t list
+  | Concat   of string * 'a t list
   | Dep      of Path.t
   | Deps     of Path.t list
   | Target   of Path.t
@@ -18,14 +19,16 @@ let rec add_deps ts set =
     match t with
     | Dep  fn  -> Pset.add fn set
     | Deps fns -> Pset.union set (Pset.of_list fns)
-    | S ts -> add_deps ts set
+    | S ts
+    | Concat (_, ts) -> add_deps ts set
     | _ -> set)
 
 let rec add_targets ts acc =
   List.fold_left ts ~init:acc ~f:(fun acc t ->
     match t with
     | Target fn  -> fn :: acc
-    | S ts -> add_targets ts acc
+    | S ts
+    | Concat (_, ts) -> add_targets ts acc
     | _ -> acc)
 
 let expand ~dir ts x =
@@ -45,6 +48,7 @@ let expand ~dir ts x =
     | Paths fns ->
       List.map fns ~f:(Path.reach ~from:dir)
     | S ts -> List.concat_map ts ~f:loop_dyn
+    | Concat (sep, ts) -> [String.concat ~sep (loop_dyn (S ts))]
     | Target _ -> die "Target not allowed under Dyn"
     | Dyn _ -> assert false
   in
@@ -54,6 +58,7 @@ let expand ~dir ts x =
     | (Dep fn | Path fn) -> [Path.reach fn ~from:dir]
     | (Deps fns | Paths fns) -> List.map fns ~f:(Path.reach ~from:dir)
     | S ts -> List.concat_map ts ~f:loop
+    | Concat (sep, ts) -> [String.concat ~sep (loop (S ts))]
     | Target fn -> [Path.reach fn ~from:dir]
     | Dyn f -> loop_dyn (f x)
   in

--- a/src/arg_spec.mli
+++ b/src/arg_spec.mli
@@ -4,6 +4,7 @@ type 'a t =
   | A        of string
   | As       of string list
   | S        of 'a t list
+  | Concat   of string * 'a t list (** Concatenation with a custom separator *)
   | Dep      of Path.t (** A path that is a dependency *)
   | Deps     of Path.t list
   | Target   of Path.t


### PR DESCRIPTION
The `-o` option in the Microsoft C Compiler is deprecated (and has been for a very long time). The warning is tedious, so use /Fo instead. The only problem with this is that `-o foo.obj` must become `/Fofoo.obj` with no space, which requires a little support in `Arg_spec`.

This appears principally when compiling C++ sources, as these aren't compiled by OCaml (which already handles these differences).

Still to do is suppressing the tedious display of the source file being compiled (see https://github.com/ocaml/ocaml/pull/407) but that hasn't (yet) been annoying me as much as the deprecation warning!
