### PR TITLE
Built-in threads META: don't force errors on absence of -thread/-vmthread

### DIFF
--- a/src/meta.ml
+++ b/src/meta.ml
@@ -256,8 +256,6 @@ let builtins ~stdlib_dir ~version:ocaml_version =
         ; requires ~preds:[Pos "mt"; Pos "mt_posix"] ["threads.posix"]
         ; directory "+"
         ; rule "type_of_threads" [] Set "posix"
-        ; rule "error" [Neg "mt"] Set "Missing -thread or -vmthread switch"
-        ; rule "error" [Neg "mt_vm"; Neg "mt_posix"] Set "Missing -thread or -vmthread switch"
         ; Package (simple "vm" ["unix"] ~dir:"+vmthreads" ~archive_name:"threads")
         ; Package (simple "posix" ["unix"] ~dir:"+threads" ~archive_name:"threads")
         ]


### PR DESCRIPTION
This is the Jbuilder counterpart to https://gitlab.camlcity.org/gerd/lib-findlib/merge_requests/9, summarized here: https://github.com/ocaml/opam-repository/pull/11071#issuecomment-353131128. The Jbuilder version of this doesn't currently break Lwt, because, as I understand it, since Lwt also requires `ocamlfind` at the moment, Jbuilder doesn't use its internal `META` files in any build involving Lwt.

Perhaps this PR should wait in case there are any unforeseen objections from Findlib.