### PR TITLE
Display a warning for bad jbuild-ignore lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,11 +65,12 @@ next
   `META.pkg.template`. This feature was unused and was making the code
   complicated (#370)
 
-
 - Remove read-only attribute on Windows before unlink (#247)
 
 - Use /Fo instead of -o when invoking the Microsoft C compiler to eliminate
   deprecation warning when compiling C++ sources (#354)
+
+- Display a warning for invalid lines in jbuild-ignore (#389)
 
 1.0+beta16 (05/11/2017)
 -----------------------

--- a/src/import.ml
+++ b/src/import.ml
@@ -65,6 +65,18 @@ module List = struct
       | None -> filter_map l ~f
       | Some x -> x :: filter_map l ~f
 
+  let filteri l ~f =
+    let rec filteri l i =
+      match l with
+      | [] -> []
+      | x :: l ->
+        let i' = succ i in
+        if f i x
+        then x :: filteri l i'
+        else filteri l i'
+    in
+    filteri l 0
+
   let concat_map l ~f = concat (map l ~f)
 
   let rev_partition_map =


### PR DESCRIPTION
This is technically a regression introduced in beta15 by #268, but I think that the new behaviour is probably what was wanted originally (it's consistent with how the manual describes jbuild-ignore files too). Prior to #268, you could specify subdirectories in jbuild-ignore files (like, say, .gitignore).

This patch displays a warning for any item in jbuild-ignore which refers to a subdirectory (i.e. `foo` is permitted but `foo/bar` is not).

The alternative would be to restore the pre-beta15 behaviour but in many ways forcing jbuild-ignore to be spread over the tree feels better in terms of composability.