### PR TITLE
Better behavior when aliases have targets

### DIFF
--- a/src/action.mli
+++ b/src/action.mli
@@ -126,6 +126,9 @@ module Infer : sig
 
   (** If [all_targets] is [true] and a target cannot be determined statically, fail *)
   val partial : all_targets:bool -> Unexpanded.Partial.t -> Outcome.t
+
+  (** Return the list of targets of an unexpanded action. *)
+  val unexpanded_targets : Unexpanded.t -> String_with_vars.t list
 end
 
 module Promotion : sig

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -796,7 +796,7 @@ Add it to your jbuild file to remove this warning.
            action
            ~dir
            ~dep_kind:Required
-           ~targets:(Static [])
+           ~targets:Alias
            ~scope)
 
   (* +-----------------------------------------------------------------+

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -169,6 +169,7 @@ module Action : sig
   type targets =
     | Static of Path.t list
     | Infer
+    | Alias (** This action is for an alias *)
 
   (** The arrow takes as input the list of actual dependencies *)
   val run


### PR DESCRIPTION
The build of cppo is broken with master: it define an alias that produce targets. As a result, we end up with an action that has targets in several directories: the user targets + the alias stamp file.

This PR change the code to ignore such targets and report a warning. I also factorized a bit the code in `Action.Infer`.

BTW, the warning could now be avoided in cppo by using `(ignore-stdout ..)` instead of redirecting it to a file.