### PR TITLE
Fix meta generation for ppx runtime deps

### DIFF
--- a/src/gen_meta.mli
+++ b/src/gen_meta.mli
@@ -7,4 +7,6 @@ val gen
   -> version:string option
   -> stanzas:(Path.t * Jbuild.Stanza.t) list
   -> resolve_lib_dep_names:(dir:Path.t -> Jbuild.Lib_dep.t list -> string list)
+  -> ppx_runtime_deps_for_deprecated_method_exn:
+       (dir:Path.t -> Jbuild.Lib_dep.t list -> String_set.t)
   -> Meta.t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -906,6 +906,8 @@ Add it to your jbuild file to remove this warning.
             ~version
             ~stanzas:(SC.stanzas_to_consider_for_install sctx)
             ~resolve_lib_dep_names:(SC.Libs.best_lib_dep_names_exn sctx)
+            ~ppx_runtime_deps_for_deprecated_method_exn:
+              (SC.Libs.ppx_runtime_deps_for_deprecated_method_exn sctx)
         in
         SC.add_rule sctx
           (Build.fanout meta_contents template

--- a/src/lib_db.mli
+++ b/src/lib_db.mli
@@ -30,6 +30,12 @@ val best_lib_dep_names_exn
   -> Jbuild.Lib_dep.t list
   -> string list
 
+val ppx_runtime_deps_for_deprecated_method_exn
+  :  t
+  -> dir:Path.t
+  -> Jbuild.Lib_dep.t list
+  -> String_set.t
+
 type resolved_select =
   { src_fn : string
   ; dst_fn : string

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -229,6 +229,9 @@ module Libs = struct
 
   let best_lib_dep_names_exn t ~dir deps = best_lib_dep_names_exn t.libs ~dir deps
 
+  let ppx_runtime_deps_for_deprecated_method_exn t ~dir lib_deps =
+    ppx_runtime_deps_for_deprecated_method_exn t.libs ~dir lib_deps
+
   let vrequires t ~dir ~item =
     let fn = Path.relative dir (item ^ ".requires.sexp") in
     Build.Vspec.T (fn, t.libs_vfile)

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -103,6 +103,12 @@ module Libs : sig
   val find : t -> from:Path.t -> string -> Lib.t option
   val best_lib_dep_names_exn : t -> dir:Path.t -> Lib_dep.t list -> string list
 
+  val ppx_runtime_deps_for_deprecated_method_exn
+    :  t
+    -> dir:Path.t
+    -> Jbuild.Lib_dep.t list
+    -> String_set.t
+
   val load_requires     : t -> dir:Path.t -> item:string -> (unit, Lib.t list) Build.t
   val load_runtime_deps : t -> dir:Path.t -> item:string -> (unit, Lib.t list) Build.t
 

--- a/test/blackbox-tests/test-cases/meta-gen/jbuild
+++ b/test/blackbox-tests/test-cases/meta-gen/jbuild
@@ -14,12 +14,26 @@
   (synopsis "sub library with modes set to byte")))
 
 (library
+ ((name foobar_runtime_lib2)
+  (public_name foobar.runtime-lib2)
+  (synopsis "sub library with modes set to byte")))
+
+(library
  ((name foobar_rewriter)
   (synopsis "ppx rewriter")
-  (libraries (foobar))
+  (libraries (foobar foobar_rewriter2))
   (public_name foobar.rewriter)
   (ppx_runtime_libraries (foobar_baz))
   (kind ppx_rewriter)))
+
+;; The ppx runtime libraries to this for library must end up in the requires(-ppx_driver)
+;; of foobar.rewriter
+(library
+ ((name foobar_rewriter2)
+  (synopsis "ppx rewriter expander")
+  (libraries (foobar))
+  (public_name foobar.rewriter2)
+  (ppx_runtime_libraries (foobar_runtime_lib2))))
 
 (alias
  ((name runtest)

--- a/test/blackbox-tests/test-cases/meta-gen/jbuild
+++ b/test/blackbox-tests/test-cases/meta-gen/jbuild
@@ -16,7 +16,7 @@
 (library
  ((name foobar_runtime_lib2)
   (public_name foobar.runtime-lib2)
-  (synopsis "sub library with modes set to byte")))
+  (synopsis "runtime library for foobar.rewriter2")))
 
 (library
  ((name foobar_rewriter)

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -44,7 +44,7 @@
   )
   package "runtime-lib2" (
     directory = "runtime-lib2"
-    description = "sub library with modes set to byte"
+    description = "runtime library for foobar.rewriter2"
     requires = ""
     archive(byte) = "foobar_runtime_lib2.cma"
     archive(native) = "foobar_runtime_lib2.cmxa"

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -17,7 +17,7 @@
   package "rewriter" (
     directory = "rewriter"
     description = "ppx rewriter"
-    requires(ppx_driver) = "foobar"
+    requires(ppx_driver) = "foobar foobar.rewriter2"
     archive(ppx_driver,byte) = "foobar_rewriter.cma"
     archive(ppx_driver,native) = "foobar_rewriter.cmxa"
     plugin(ppx_driver,byte) = "foobar_rewriter.cma"
@@ -27,8 +27,29 @@
     ppx_runtime_deps = "foobar.baz"
     # This line makes things transparent for people mixing preprocessors
     # and normal dependencies
-    requires(-ppx_driver) = "foobar.baz"
+    requires(-ppx_driver) = "foobar.baz foobar_runtime_lib2"
     ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
+  )
+  package "rewriter2" (
+    directory = "rewriter2"
+    description = "ppx rewriter expander"
+    requires = "foobar"
+    archive(byte) = "foobar_rewriter2.cma"
+    archive(native) = "foobar_rewriter2.cmxa"
+    plugin(byte) = "foobar_rewriter2.cma"
+    plugin(native) = "foobar_rewriter2.cmxs"
+    # This is what jbuilder uses to find out the runtime dependencies of
+    # a preprocessor
+    ppx_runtime_deps = "foobar.runtime-lib2"
+  )
+  package "runtime-lib2" (
+    directory = "runtime-lib2"
+    description = "sub library with modes set to byte"
+    requires = ""
+    archive(byte) = "foobar_runtime_lib2.cma"
+    archive(native) = "foobar_runtime_lib2.cmxa"
+    plugin(byte) = "foobar_runtime_lib2.cma"
+    plugin(native) = "foobar_runtime_lib2.cmxs"
   )
   package "sub" (
     directory = "sub"

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -6,17 +6,13 @@
           odoc _doc/odoc.css
         ocamlc foo_byte.{cmi,cmo,cmt}
           odoc _doc/foo.byte/page-index.odoc
-          odoc _doc/foo.byte/page-test.odoc
         ocamlc foo.{cmi,cmo,cmt}
           odoc _doc/foo/page-index.odoc
-          odoc _doc/foo/page-test.odoc
           odoc _doc/foo.byte/foo_byte.odoc
           odoc _doc/foo/foo.odoc
           odoc _doc/foo.byte/index.html
-          odoc _doc/foo.byte/test.html
           odoc _doc/foo.byte/Foo_byte/.jbuilder-keep,_doc/foo.byte/Foo_byte/index.html
           odoc _doc/foo/index.html
-          odoc _doc/foo/test.html
           odoc _doc/foo/Foo/.jbuilder-keep,_doc/foo/Foo/index.html
   $ $JBUILDER runtest -j1 --root .
   <!DOCTYPE html>


### PR DESCRIPTION
This PR does the following:
- it generates a `ppx_runtime_deps` variable even for normal libraries (i.e. not with `(kind ppx_rewriter)` or `(kind ppx_deriver)`)
-  it uses the transitive closure for `requires(-ppx_driver)`, since `ocamlfind` won't scan the dependencies of the ppx rewriter itself

I added a test and successfully built `bin_prot`, which is otherwise failing with master

Fix #440 