### PR TITLE
Add the runtime dependencies of the transitive closure of used ppx rewriters

### DIFF
--- a/src/gen_meta.mli
+++ b/src/gen_meta.mli
@@ -7,6 +7,6 @@ val gen
   -> version:string option
   -> stanzas:(Path.t * Jbuild.Stanza.t) list
   -> resolve_lib_dep_names:(dir:Path.t -> Jbuild.Lib_dep.t list -> string list)
-  -> ppx_runtime_deps_for_deprecated_method_exn:
+  -> all_ppx_runtime_deps_exn:
        (dir:Path.t -> Jbuild.Lib_dep.t list -> String_set.t)
   -> Meta.t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -906,8 +906,7 @@ Add it to your jbuild file to remove this warning.
             ~version
             ~stanzas:(SC.stanzas_to_consider_for_install sctx)
             ~resolve_lib_dep_names:(SC.Libs.best_lib_dep_names_exn sctx)
-            ~ppx_runtime_deps_for_deprecated_method_exn:
-              (SC.Libs.ppx_runtime_deps_for_deprecated_method_exn sctx)
+            ~all_ppx_runtime_deps_exn:(SC.Libs.all_ppx_runtime_deps_exn sctx)
         in
         SC.add_rule sctx
           (Build.fanout meta_contents template

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -398,6 +398,8 @@ module Lib_dep = struct
       |> String_set.elements
 
   let direct s = Direct s
+
+  let of_pp pp = Direct (Pp.to_string pp)
 end
 
 module Lib_deps = struct

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -92,6 +92,7 @@ module Lib_dep : sig
 
   val to_lib_names : t -> string list
   val direct : string -> t
+  val of_pp : Pp.t -> t
 end
 
 module Lib_deps : sig

--- a/src/lib_db.mli
+++ b/src/lib_db.mli
@@ -30,7 +30,9 @@ val best_lib_dep_names_exn
   -> Jbuild.Lib_dep.t list
   -> string list
 
-val ppx_runtime_deps_for_deprecated_method_exn
+(** [all_ppx_runtime_deps_exn t ~dir deps] takes the transitive closure of [deps] and
+    return the set of all the ppx runtime dependencies of these libraries. *)
+val all_ppx_runtime_deps_exn
   :  t
   -> dir:Path.t
   -> Jbuild.Lib_dep.t list

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -229,8 +229,8 @@ module Libs = struct
 
   let best_lib_dep_names_exn t ~dir deps = best_lib_dep_names_exn t.libs ~dir deps
 
-  let ppx_runtime_deps_for_deprecated_method_exn t ~dir lib_deps =
-    ppx_runtime_deps_for_deprecated_method_exn t.libs ~dir lib_deps
+  let all_ppx_runtime_deps_exn t ~dir lib_deps =
+    all_ppx_runtime_deps_exn t.libs ~dir lib_deps
 
   let vrequires t ~dir ~item =
     let fn = Path.relative dir (item ^ ".requires.sexp") in

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -103,7 +103,7 @@ module Libs : sig
   val find : t -> from:Path.t -> string -> Lib.t option
   val best_lib_dep_names_exn : t -> dir:Path.t -> Lib_dep.t list -> string list
 
-  val ppx_runtime_deps_for_deprecated_method_exn
+  val all_ppx_runtime_deps_exn
     :  t
     -> dir:Path.t
     -> Jbuild.Lib_dep.t list

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -17,7 +17,7 @@
   package "ppd" (
     directory = "ppd"
     description = "pp'd with a rewriter"
-    requires = "foobar"
+    requires = "foobar foobar.baz foobar.runtime-lib2"
     archive(byte) = "foobar_ppd.cma"
     archive(native) = "foobar_ppd.cmxa"
     plugin(byte) = "foobar_ppd.cma"
@@ -36,7 +36,7 @@
     ppx_runtime_deps = "foobar.baz"
     # This line makes things transparent for people mixing preprocessors
     # and normal dependencies
-    requires(-ppx_driver) = "foobar.baz foobar_runtime_lib2"
+    requires(-ppx_driver) = "foobar.baz foobar.runtime-lib2"
     ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
   )
   package "rewriter2" (


### PR DESCRIPTION
This fixes the test added in #449.

I realized that the the function that compute the runtime deps of the transitive closure was trying to be too clever and add scoping issues... I rewrote it