### PR TITLE
Avoid catching wildcard exceptions when calling Findlib.find

### DIFF
--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -22,8 +22,6 @@ module Package_not_available : sig
   val explain : Format.formatter -> reason -> unit
 end
 
-exception Package_not_available of Package_not_available.t
-
 module External_dep_conflicts_with_local_lib : sig
   type t =
     { package             : string
@@ -33,7 +31,11 @@ module External_dep_conflicts_with_local_lib : sig
     }
 end
 
-exception External_dep_conflicts_with_local_lib of External_dep_conflicts_with_local_lib.t
+type error =
+  | Package_not_available of Package_not_available.t
+  | External_dep_conflicts_with_local_lib of External_dep_conflicts_with_local_lib.t
+
+exception Findlib of error
 
 (** Findlib database *)
 type t

--- a/src/lib_db.ml
+++ b/src/lib_db.ml
@@ -45,7 +45,7 @@ let find_exn t ~from name =
 
 let find t ~from name =
   match find_exn t ~from name with
-  | exception _ -> None
+  | exception (Findlib.Findlib _) -> None
   | x -> Some x
 
 let find_internal t ~from name =
@@ -165,7 +165,7 @@ let interpret_lib_dep t ~dir lib_dep =
             List.map (String_set.elements required) ~f:(find_exn t ~from:dir)
           with
           | l           -> Some l
-          | exception _ -> None)
+          | exception (Findlib.Findlib _) -> None)
     with
     | Some l -> Inl l
     | None ->

--- a/src/main.ml
+++ b/src/main.ml
@@ -113,7 +113,7 @@ let report_error ?(map_fname=fun x->x) ppf exn ~backtrace =
   | Fatal_error msg ->
     Format.fprintf ppf "%s\n" (String.capitalize_ascii msg);
     false
-  | Findlib.Package_not_available { package; required_by; reason } ->
+  | Findlib.Findlib (Findlib.Package_not_available { package; required_by; reason }) ->
     Format.fprintf ppf
       "@{<error>Error@}: External library %S %s.\n" package
       (match reason with
@@ -142,8 +142,8 @@ let report_error ?(map_fname=fun x->x) ppf exn ~backtrace =
       (List.map !Clflags.external_lib_deps_hint ~f:quote_for_shell
        |> String.concat ~sep:" ");
     false
-  | Findlib.External_dep_conflicts_with_local_lib
-      { package; required_by; required_locally_in; defined_locally_in } ->
+  | Findlib.Findlib (Findlib.External_dep_conflicts_with_local_lib {
+    package; required_by; required_locally_in; defined_locally_in }) ->
     Format.fprintf ppf
       "@{<error>Error@}: Conflict between internal and external version of library %S:\n\
        - it is defined locally in %s\n\


### PR DESCRIPTION
But to avoid making the catch statements verbose, move all findlib exceptions to
a variant.