### PR TITLE
Add tests of js_of_ocaml flag

### DIFF
--- a/test/blackbox-tests/test-cases/gen-opam-install-file/jbuild
+++ b/test/blackbox-tests/test-cases/gen-opam-install-file/jbuild
@@ -4,6 +4,7 @@
  ((name foo)
   (modules (foo))
   (install_c_headers (cfoo))
+  (js_of_ocaml ((javascript_files (foo.js))))
   (wrapped false)
   (public_name foo)))
 

--- a/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
+++ b/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
@@ -23,6 +23,7 @@
     "_build/install/default/lib/foo/foo.cmxa"
     "_build/install/default/lib/foo/foo.a"
     "_build/install/default/lib/foo/foo.cmxs"
+    "_build/install/default/lib/foo/foo.js"
     "_build/install/default/lib/foo/cfoo.h"
     "_build/install/default/lib/foo/byte/foo_byte.cmi" {"byte/foo_byte.cmi"}
     "_build/install/default/lib/foo/byte/foo_byte.cmt" {"byte/foo_byte.cmt"}

--- a/test/blackbox-tests/test-cases/meta-gen/jbuild
+++ b/test/blackbox-tests/test-cases/meta-gen/jbuild
@@ -15,6 +15,7 @@
 
 (library
  ((name foobar_runtime_lib2)
+  (js_of_ocaml ((javascript_files (foobar_runtime.js foobar_runtime2.js))))
   (public_name foobar.runtime-lib2)
   (synopsis "runtime library for foobar.rewriter2")))
 

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -59,6 +59,9 @@
     archive(native) = "foobar_runtime_lib2.cmxa"
     plugin(byte) = "foobar_runtime_lib2.cma"
     plugin(native) = "foobar_runtime_lib2.cmxs"
+    linkopts(javascript) = "+foobar/foobar_runtime.js
+                            +foobar/foobar_runtime2.js"
+    jsoo_runtime = "foobar_runtime.js foobar_runtime2.js"
   )
   package "sub" (
     directory = "sub"


### PR DESCRIPTION
Make sure that adding js runtime files reflects correctly in the META and
.install files