### PR TITLE
Add a test for dependency cycles

### DIFF
--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -277,3 +277,13 @@
      (progn
       (run ${exe:cram.exe} run.t)
       (diff? run.t run.t.corrected)))))))
+
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in test-cases/loop)))
+  (action
+   (chdir test-cases/loop
+    (setenv JBUILDER ${bin:jbuilder}
+     (progn
+      (run ${exe:cram.exe} run.t)
+      (diff? run.t run.t.corrected)))))))

--- a/test/blackbox-tests/test-cases/loop/jbuild
+++ b/test/blackbox-tests/test-cases/loop/jbuild
@@ -1,0 +1,7 @@
+(jbuild_version 1)
+
+(rule (copy ${read:x} a))
+(rule (copy ${read:y} b))
+
+(rule (progn (run true) (with-stdout-to x (echo b))))
+(rule (progn (run true) (with-stdout-to y (echo a))))

--- a/test/blackbox-tests/test-cases/loop/run.t
+++ b/test/blackbox-tests/test-cases/loop/run.t
@@ -1,0 +1,5 @@
+  $ $JBUILDER build --root . -j 1 a
+          true x
+          true y
+  Error: wait: : No child processes
+  [1]


### PR DESCRIPTION
I just realized that the way loop detection is implemented is not very robust. I'm fixing this in the continue-on-error-branch