### PR TITLE
[WIP] Only display bang deprecation warning once

### DIFF
--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -464,6 +464,8 @@ let parse_bang var : bool * string =
   else
     (false, var)
 
+let bang_deprecations = Hashtbl.create 16
+
 module Action = struct
   open Build.O
   module U = Action.Unexpanded
@@ -532,8 +534,11 @@ module Action = struct
         let open Action.Var_expansion in
         let has_bang, var = parse_bang key in
         if has_bang then
-          Loc.warn loc "The use of the variable prefix '!' is deprecated, \
-                        simply use '${%s}'@." var;
+          if not (Hashtbl.mem bang_deprecations loc) then begin
+            Loc.warn loc "The use of the variable prefix '!' is deprecated, \
+                          simply use '${%s}'@." var;
+            Hashtbl.add bang_deprecations ~key:loc ~data:()
+          end;
         match String.lsplit2 var ~on:':' with
         | Some ("path-no-dep", s) -> Some (path_exp (Path.relative dir s))
         | Some ("exe"     , s) ->


### PR DESCRIPTION
I was just fixing up a `jbuild` file to get rid of `${!` uses, but Dune was warning me about the same location on multiple occasions.

[ ] The global is in the wrong place
[ ] The locations being reported are weird - the stop location is vaguely correct, but the start is normally rubbish (or just a sentinel)
[ ] It may be worth generalising this - though I'm not sure if there are other situations where warnings like this get displayed multiple times

For reference, here are the warnings, and offending lines, from a slightly customised build of opam:

```
[src/core/jbuild LL16-21]
   (action (with-stdout-to ${@} (run ocaml ../../shell/subst_var.ml PACKAGE_VERSION "<error>" ${!^})))))

(rule
  ((targets (opamCoreConfig.ml))
   (deps (opamCoreConfig.ml.in ../../shell/subst_var.ml))
   (action (with-stdout-to ${@} (run ocaml ../../shell/subst_var.ml DEVELOPER false ${!^})))))
```
gives two warnings (note second location particularly):
```
File "src/core/jbuild", line 16, characters 84-99:
Warning: The use of the variable prefix '!' is deprecated, simply use '${^}'

File "src/core/jbuild", line 16, characters 84-292:
Warning: The use of the variable prefix '!' is deprecated, simply use '${^}'
```
Similar thing going here:
```
[src/state/jbuild LL7-14]
   (synopsis "OCaml Package Manager instance management library")
   (flags (:standard (:include ../ocaml-flags-standard.sexp) (:include ../ocaml-context-flags.sexp)))
   (wrapped false)))

(rule
  ((targets (opamScript.ml))
   (deps    (../../shell/crunch.ml complete.sh complete.zsh prompt.sh))
   (action  (with-stdout-to ${@} (run ocaml ${!^})))))
```
gives this warning (again, whacky location):
```
File "src/state/jbuild", line 7, characters 13-346:
Warning: The use of the variable prefix '!' is deprecated, simply use '${^}'
```
and here
```
[src_ext/extlib/src/jbuild LL1-7]
   (synopsis "OCaml Package Manager instance management library")
   (flags (:standard (:include ../ocaml-flags-standard.sexp) (:include ../ocaml-context-flags.sexp)))
   (wrapped false)))

(rule
  ((targets (opamScript.ml))
   (deps    (../../shell/crunch.ml complete.sh complete.zsh prompt.sh))
   (action  (with-stdout-to ${@} (run ocaml ${!^})))))
```
giving
```
File "src_ext/extlib/src/jbuild", line 1, characters 0-182:
Warning: The use of the variable prefix '!' is deprecated, simply use '${read-lines:compat-level}'
```
Finally
```
[src/jbuild L6; edited to add dummy extra expansion]
   (action (with-stdout-to ${@} (run ocaml ../shell/subst_var.ml CONF_OCAMLFLAGS "" ${!^} "" ${!^} "")))))
```
gives two warnings at least on the correct line:
```
File "src/jbuild", line 6, characters 81-89:
Warning: The use of the variable prefix '!' is deprecated, simply use '${^}'

File "src/jbuild", line 6, characters 90-98:
Warning: The use of the variable prefix '!' is deprecated, simply use '${^}'
```