### PR TITLE
Compact Travis macOS targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,42 +12,30 @@ script: bash -ex .travis-ci.sh build
 matrix:
   include:
   - os: linux
-    env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
+    env: OCAML_VERSIONS=4.02.3
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.03 OCAML_RELEASE=0 WITH_OPAM=0
+    env: OCAML_VERSIONS=4.03.0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.04 OCAML_RELEASE=2 WITH_OPAM=0
+    env: OCAML_VERSIONS=4.04.2
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
+    env: OCAML_VERSIONS=4.05.0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=0
+    env: OCAML_VERSIONS=4.06.0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
+    env: OPAM_OCAML_VERSION=4.05.0
     stage: Test
     addons:
       apt:
         packages:
         - aspcud
   - os: osx
-    env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
-    stage: Build_macOS
+    env: OCAML_VERSIONS="4.02.3 4.03.0 4.04.2"
+    stage: macOS
   - os: osx
-    env: OCAML_VERSION=4.03 OCAML_RELEASE=0 WITH_OPAM=0
-    stage: Build_macOS
-  - os: osx
-    env: OCAML_VERSION=4.04 OCAML_RELEASE=2 WITH_OPAM=0
-    stage: Build_macOS
-  - os: osx
-    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=0
-    stage: Build_macOS
-  - os: osx
-    env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=0
-    stage: Build_macOS
-  - os: osx
-    env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
-    stage: Test_macOS
+    env: OCAML_VERSIONS="4.05.0 4.06.0" OPAM_OCAML_VERSION=4.05.0
+    stage: macOS


### PR DESCRIPTION
In the light of the recent Travis problems with macOS, I did some refactoring of the way we run tests, principally noting that macOS build workers should be regarded as a precious commodity and fully utilised when they're available. To this end, I've tweaked the Travis scripts so that you specify a list of `OCAML_VERSIONS` to test and optionally an `OPAM_OCAML_VERSION` for running the full tests.

On Linux, nothing's changed in practice, but on macOS this allows one build worker to test several compilers. It's split into two jobs to ensure that when the compilers are fully built the job completes within the permitted time for a single worker.

The job will take a long time to run here because the compilers will be refreshed - https://travis-ci.org/dra27/jbuilder/builds/336529494 shows the macOS worker testing 4.02.3, 4.03.0 and 4.04.2 in the same time as Linux worker took to test just 4.06.0! That's not an argument for using this feature for Linux, though - we quite often get 5 Linux workers starting at once, so worker parallelism is more important. I've never seen more than two macOS jobs run simultaneously.