### PR TITLE
Do not pass -I <stdlib-dir>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ next
   `library`/`executables` stanza. Now it is called once per file
   (#486)
 
+- Make sure to not pass `-I <stdlib-dir>` to the compiler. It is
+  useless and it causes problems in some cases (#488)
+
 1.0+beta17 (01/02/2018)
 -----------------------
 

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -708,7 +708,8 @@ Add it to your jbuild file to remove this warning.
          [ Dyn (fun (_, flags,_) -> As flags)
          ; A "-o"; Target exe
          ; Dyn (fun (_, _, link_flags) -> As (link_custom @ link_flags))
-         ; Dyn (fun ((libs, _), _, _) -> Lib.link_flags libs ~mode)
+         ; Dyn (fun ((libs, _), _, _) -> Lib.link_flags libs ~mode
+                                           ~stdlib_dir:ctx.stdlib_dir)
          ; Dyn (fun ((_, cm_files), _, _) -> Deps cm_files)
          ]);
     if mode = Mode.Byte then

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -23,12 +23,13 @@ let dir = function
   | Internal (dir, _) -> dir
   | External pkg -> pkg.dir
 
-let include_paths ts =
+let include_paths ts ~stdlib_dir =
   List.fold_left ts ~init:Path.Set.empty ~f:(fun acc t ->
     Path.Set.add (dir t) acc)
+  |> Path.Set.remove stdlib_dir
 
-let include_flags ts =
-  let dirs = include_paths ts in
+let include_flags ts ~stdlib_dir =
+  let dirs = include_paths ts ~stdlib_dir in
   Arg_spec.S (List.concat_map (Path.Set.elements dirs) ~f:(fun dir ->
     [Arg_spec.A "-I"; Path dir]))
 
@@ -49,9 +50,9 @@ let describe = function
   | External pkg ->
     sprintf "%s (external)" pkg.name
 
-let link_flags ts ~mode =
+let link_flags ts ~mode ~stdlib_dir =
   Arg_spec.S
-    (include_flags ts ::
+    (include_flags ts ~stdlib_dir ::
      List.map ts ~f:(fun t ->
        match t with
        | External pkg ->

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -12,13 +12,12 @@ module Set : Set.S with type elt := t
 
 (*val deps : t -> string list*)
 
-val include_paths : t list -> Path.Set.t
-
-val include_flags : t list -> _ Arg_spec.t
+val include_paths : t list -> stdlib_dir:Path.t -> Path.Set.t
+val include_flags : t list -> stdlib_dir:Path.t -> _ Arg_spec.t
 
 val c_include_flags : t list -> _ Arg_spec.t
 
-val link_flags : t list -> mode:Mode.t -> _ Arg_spec.t
+val link_flags : t list -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
 
 val archive_files : t list -> mode:Mode.t -> ext_lib:string -> Path.t list
 

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -62,7 +62,7 @@ let build_cm sctx ?sandbox ~dynlink ~flags ~cm_kind ~dep_graphs
            ~extra_targets
            [ Dyn (fun (_, ocaml_flags) -> As ocaml_flags)
            ; cmt_args
-           ; Dyn (fun (libs, _) -> Lib.include_flags libs)
+           ; Dyn (fun (libs, _) -> Lib.include_flags libs ~stdlib_dir:ctx.stdlib_dir)
            ; As extra_args
            ; if dynlink || cm_kind <> Cmx then As [] else A "-nodynlink"
            ; A "-no-alias-deps"

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -164,10 +164,11 @@ let setup_library_rules sctx (lib : Library.t) ~dir ~modules ~mld_files
   let lib_name = Library.best_name lib in
   let odoc = get_odoc sctx in
   let includes =
+    let ctx = SC.context sctx in
     Build.memoize "includes"
       (requires
        >>> SC.Doc.deps sctx
-       >>^ Lib.include_flags)
+       >>^ Lib.include_flags ~stdlib_dir:ctx.stdlib_dir)
   in
   let mld_files =
     all_mld_files sctx ~dir ~lib ~lib_name ~modules mld_files

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -845,7 +845,7 @@ module PP = struct
        >>>
        Build.run ~context:ctx (Ok compiler)
          [ A "-o" ; Target target
-         ; Dyn (Lib.link_flags ~mode)
+         ; Dyn (Lib.link_flags ~mode ~stdlib_dir:ctx.stdlib_dir)
          ])
 
   let gen_rules sctx components =

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -23,7 +23,11 @@ let add_module_rules sctx ~dir lib_requires =
   let utop_ml =
     lib_requires
     >>^ (fun libs ->
-      let include_paths = Path.Set.elements (Lib.include_paths libs) in
+      let include_paths =
+        let ctx = Super_context.context sctx in
+        Path.Set.elements
+          (Lib.include_paths libs ~stdlib_dir:ctx.stdlib_dir)
+      in
       let b = Buffer.create 64 in
       let fmt = Format.formatter_of_buffer b in
       pp_ml fmt include_paths;


### PR DESCRIPTION
Make sure we don't pass `-I <stdlib-dir>` to the compiler. This path is always implicitly added and passing it doesn't play nice with #472 