### PR TITLE
Add a configuration file and a quiet mode

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -13,7 +13,6 @@ type common =
   ; debug_findlib         : bool
   ; debug_backtraces      : bool
   ; dev_mode              : bool
-  ; verbose               : bool
   ; workspace_file        : string option
   ; root                  : string
   ; target_prefix         : string
@@ -26,6 +25,7 @@ type common =
   ; ignore_promoted_rules : bool
   ; (* Original arguments for the external-lib-deps hint *)
     orig_args             : string list
+  ; config                : Config.t
   }
 
 let prefix_target common s = common.target_prefix ^ s
@@ -36,7 +36,6 @@ let set_common c ~targets =
   Clflags.debug_findlib := c.debug_findlib;
   Clflags.debug_backtraces := c.debug_backtraces;
   Clflags.dev_mode := c.dev_mode;
-  Clflags.verbose := c.verbose;
   Clflags.capture_outputs := c.capture_outputs;
   if c.root <> Filename.current_dir_name then
     Sys.chdir c.root;
@@ -83,6 +82,20 @@ module Main = struct
       ?x:common.x
       ~ignore_promoted_rules:common.ignore_promoted_rules
       ()
+end
+
+module Log = struct
+  include Jbuilder.Log
+
+  let create common =
+    Log.create ~display:common.config.display ()
+end
+
+module Scheduler = struct
+  include Jbuilder.Scheduler
+
+  let go ?log ~common fiber =
+    Scheduler.go ?log ~config:common.config fiber
 end
 
 type target =
@@ -158,6 +171,17 @@ let help_secs =
   ; `P "Check bug reports at https://github.com/ocaml/dune/issues"
   ]
 
+type config_file =
+  | No_config
+  | Default
+  | This of string
+
+let incompatible a b =
+  `Error (true,
+          sprintf
+            "Cannot use %s and %s simultaneously"
+            a b)
+
 let common =
   let dump_opt name value =
     match value with
@@ -170,7 +194,6 @@ let common =
         debug_findlib
         debug_backtraces
         dev_mode
-        verbose
         no_buffer
         workspace_file
         diff_command
@@ -179,8 +202,10 @@ let common =
         (root,
          only_packages,
          ignore_promoted_rules,
+         config_file,
          orig)
         x
+        display
     =
     let root, to_cwd =
       match root with
@@ -194,12 +219,22 @@ let common =
         ; orig
         ]
     in
+    let config =
+      match config_file with
+      | No_config  -> Config.default
+      | This fname -> Config.load_config_file ~fname
+      | Default    -> Config.load_user_config_file ()
+    in
+    let config =
+      match display with
+      | None -> config
+      | Some display -> { display }
+    in
     { concurrency
     ; debug_dep_path
     ; debug_findlib
     ; debug_backtraces
     ; dev_mode
-    ; verbose
     ; capture_outputs = not no_buffer
     ; workspace_file
     ; root
@@ -213,6 +248,7 @@ let common =
         Option.map only_packages
           ~f:(fun s -> String_set.of_list (String.split s ~on:','))
     ; x
+    ; config
     }
   in
   let docs = copts_sect in
@@ -261,11 +297,34 @@ let common =
          & info ["dev"] ~docs
              ~doc:{|Use stricter compilation flags by default.|})
   in
-  let verbose =
-    Arg.(value
-         & flag
-         & info ["verbose"] ~docs
-             ~doc:"Print detailed information about commands being run")
+  let display =
+    let verbose =
+      Arg.(value
+           & flag
+           & info ["verbose"] ~docs
+               ~doc:"Print detailed information about commands being run")
+    in
+    let display =
+      let arg =
+        Arg.conv ~docv:"MODE"
+          (Arg.parser_of_kind_of_string ~kind:"a display mode"
+             Config.Display.of_string,
+           fun ppf x ->
+             Format.pp_print_string ppf (Config.Display.to_string x))
+      in
+      Arg.(value
+           & opt (some arg) None
+           & info ["display"] ~docs
+               ~doc:"Control the display mode of Jbuilder")
+    in
+    let merge verbose display =
+      match verbose, display with
+      | false , None   -> `Ok None
+      | false , Some x -> `Ok (Some x)
+      | true  , None   -> `Ok (Some Config.Display.Verbose)
+      | true  , Some _ -> incompatible "--display" "--verbose"
+    in
+    Term.(ret (const merge $ verbose $ display))
   in
   let no_buffer =
     Arg.(value
@@ -290,15 +349,6 @@ let common =
          & info ["workspace"] ~docs ~docv:"FILE"
              ~doc:"Use this specific workspace file instead of looking it up.")
   in
-  let root =
-    Arg.(value
-         & opt (some dir) None
-         & info ["root"] ~docs ~docv:"DIR"
-             ~doc:{|Use this directory as workspace root instead of guessing it.
-                    Note that this option doesn't change the interpretation of
-                    targets given on the command line. It is only intended
-                    for scripts.|})
-  in
   let auto_promote =
     Arg.(value
          & flag
@@ -313,44 +363,75 @@ let common =
              ~doc:"Force actions associated to aliases to be re-executed even
                    if their dependencies haven't changed.")
   in
-  let ignore_promoted_rules =
-    Arg.(value
-         & flag
-         & info ["ignore-promoted-rules"] ~docs
-             ~doc:"Ignore rules with (mode promote)")
-  in
-  let for_release = "for-release-of-packages" in
-  let frop =
-    Arg.(value
-         & opt (some string) None
-         & info ["p"; for_release] ~docs ~docv:"PACKAGES"
-             ~doc:{|Shorthand for $(b,--root . --only-packages PACKAGE --promote ignore).
-                    You must use this option in your $(i,<package>.opam) files, in order
-                    to build only what's necessary when your project contains multiple
-                    packages as well as getting reproducible builds.|})
-  in
-  let root_and_only_packages =
-    let merge root only_packages ignore_promoted_rules release =
-      let fail opt =
-        `Error (true,
-                sprintf
-                  "Cannot use -p/--%s and %s simultaneously"
-                  for_release opt)
+  let merged_options =
+    let root =
+      Arg.(value
+           & opt (some dir) None
+           & info ["root"] ~docs ~docv:"DIR"
+               ~doc:{|Use this directory as workspace root instead of guessing it.
+                      Note that this option doesn't change the interpretation of
+                      targets given on the command line. It is only intended
+                      for scripts.|})
+    in
+    let ignore_promoted_rules =
+      Arg.(value
+           & flag
+           & info ["ignore-promoted-rules"] ~docs
+               ~doc:"Ignore rules with (mode promote)")
+    in
+    let config_file =
+      let config_file =
+        Arg.(value
+             & opt (some file) None
+             & info ["config-file"] ~docs
+                 ~doc:"Load this configuration file instead of the default one.")
       in
-      match release, root, only_packages, ignore_promoted_rules with
-      | Some _, Some _, _, _ -> fail "--root"
-      | Some _, _, Some _, _ -> fail "--only-packages"
-      | Some _, _, _, true   -> fail "--ignore-promoted-rules"
-      | Some pkgs, None, None, false ->
+      let no_config =
+        Arg.(value
+             & flag
+             & info ["no-config"] ~docs
+                 ~doc:"Do not load the configuration file")
+      in
+      let merge config_file no_config =
+        match config_file, no_config with
+        | None   , false -> `Ok (None                , Default)
+        | Some fn, false -> `Ok (Some "--config-file", This fn)
+        | None   , true  -> `Ok (Some "--no-config"  , No_config)
+        | Some _ , true  -> incompatible "--no-config" "--config-file"
+      in
+      Term.(ret (const merge $ config_file $ no_config))
+    in
+    let for_release = "for-release-of-packages" in
+    let frop =
+      Arg.(value
+           & opt (some string) None
+           & info ["p"; for_release] ~docs ~docv:"PACKAGES"
+               ~doc:{|Shorthand for $(b,--root . --only-packages PACKAGE
+                      --promote ignore --no-config).
+                      You must use this option in your $(i,<package>.opam) files, in order
+                      to build only what's necessary when your project contains multiple
+                      packages as well as getting reproducible builds.|})
+    in
+    let merge root only_packages ignore_promoted_rules
+          (config_file_opt, config_file) release =
+      let fail opt = incompatible ("-p/--" ^ for_release) opt in
+      match release, root, only_packages, ignore_promoted_rules, config_file_opt with
+      | Some _, Some _, _, _, _      -> fail "--root"
+      | Some _, _, Some _, _, _      -> fail "--only-packages"
+      | Some _, _, _, true  , _      -> fail "--ignore-promoted-rules"
+      | Some _, _, _, _     , Some s -> fail s
+      | Some pkgs, None, None, false, None ->
         `Ok (Some ".",
              Some pkgs,
              true,
+             No_config,
              ["-p"; pkgs]
             )
-      | None, _, _, _ ->
+      | None, _, _, _, _ ->
         `Ok (root,
              only_packages,
              ignore_promoted_rules,
+             config_file,
              List.concat
                [ dump_opt "--root" root
                ; dump_opt "--only-packages" only_packages
@@ -358,12 +439,18 @@ let common =
                    ["--ignore-promoted-rules"]
                  else
                    []
-               ])
+               ; (match config_file with
+                  | This fn   -> ["--config-file"; fn]
+                  | No_config -> ["--no-config"]
+                  | Default   -> [])
+               ]
+            )
     in
     Term.(ret (const merge
                $ root
                $ only_packages
                $ ignore_promoted_rules
+               $ config_file
                $ frop))
   in
   let x =
@@ -384,21 +471,21 @@ let common =
         $ dfindlib
         $ dbacktraces
         $ dev
-        $ verbose
         $ no_buffer
         $ workspace_file
         $ diff_command
         $ auto_promote
         $ force
-        $ root_and_only_packages
+        $ merged_options
         $ x
+        $ display
        )
 
 let installed_libraries =
   let doc = "Print out libraries installed on the system." in
   let go common na =
     set_common common ~targets:[];
-    Scheduler.go ~log:(Log.create ())
+    Scheduler.go ~log:(Log.create common) ~common
       (Context.create (Default [Native])  >>= fun ctxs ->
        let ctx = List.hd ctxs in
        let findlib = ctx.findlib in
@@ -529,7 +616,7 @@ let resolve_targets ~log common (setup : Main.setup) user_targets =
         end
       )
     in
-    if !Clflags.verbose then begin
+    if common.config.display = Verbose then begin
       Log.info log "Actual targets:";
       let targets =
         List.concat_map targets ~f:(function
@@ -564,8 +651,8 @@ let build_targets =
   let name_ = Arg.info [] ~docv:"TARGET" in
   let go common targets =
     set_common common ~targets;
-    let log = Log.create () in
-    Scheduler.go ~log
+    let log = Log.create common in
+    Scheduler.go ~log ~common
       (Main.setup ~log common >>= fun setup ->
        let targets = resolve_targets_exn ~log common setup targets in
        do_build setup targets) in
@@ -590,8 +677,8 @@ let runtest =
         | "" | "." -> "@runtest"
         | dir when dir.[String.length dir - 1] = '/' -> sprintf "@%sruntest" dir
         | dir -> sprintf "@%s/runtest" dir));
-    let log = Log.create () in
-    Scheduler.go ~log
+    let log = Log.create common in
+    Scheduler.go ~log ~common
       (Main.setup ~log common >>= fun setup ->
        let check_path = check_path setup.contexts in
        let targets =
@@ -645,8 +732,8 @@ let external_lib_deps =
   in
   let go common only_missing targets =
     set_common common ~targets:[];
-    let log = Log.create () in
-    Scheduler.go ~log
+    let log = Log.create common in
+    Scheduler.go ~log ~common
       (Main.setup ~log common ~filter_out_optional_stanzas_with_missing_deps:false
        >>= fun setup ->
        let targets = resolve_targets_exn ~log common setup targets in
@@ -748,8 +835,8 @@ let rules =
   in
   let go common out recursive makefile_syntax targets =
     set_common common ~targets;
-    let log = Log.create () in
-    Scheduler.go ~log
+    let log = Log.create common in
+    Scheduler.go ~log ~common
       (Main.setup ~log common ~filter_out_optional_stanzas_with_missing_deps:false
        >>= fun setup ->
        let request =
@@ -842,8 +929,8 @@ let install_uninstall ~what =
   let go common prefix_from_command_line libdir_from_command_line pkgs =
     set_common common ~targets:[];
     let opam_installer = opam_installer () in
-    let log = Log.create () in
-    Scheduler.go ~log
+    let log = Log.create common in
+    Scheduler.go ~log ~common
       (Main.setup ~log common >>= fun setup ->
        let pkgs =
          match pkgs with
@@ -952,8 +1039,8 @@ let exec =
   in
   let go common context prog no_rebuild args =
     set_common common ~targets:[];
-    let log = Log.create () in
-    let setup = Scheduler.go ~log (Main.setup ~log common) in
+    let log = Log.create common in
+    let setup = Scheduler.go ~log ~common (Main.setup ~log common) in
     let context = Main.find_context_exn setup ~name:context in
     let prog_where =
       match Filename.analyze_program_name prog with
@@ -987,7 +1074,7 @@ let exec =
         match Lazy.force targets with
         | [] -> ()
         | targets ->
-          Scheduler.go ~log (do_build setup targets);
+          Scheduler.go ~log ~common (do_build setup targets);
           Build_system.finalize setup.build_system
       end;
       match prog_where with
@@ -1086,7 +1173,7 @@ let subst =
   in
   let go common name =
     set_common common ~targets:[];
-    Scheduler.go (Watermarks.subst ?name ())
+    Scheduler.go ~common (Watermarks.subst ?name ())
   in
   ( Term.(const go
           $ common
@@ -1107,7 +1194,7 @@ let utop =
   let go common dir ctx_name args =
     let utop_target = dir |> Path.of_string |> Utop.utop_exe |> Path.to_string in
     set_common common ~targets:[utop_target];
-    let log = Log.create () in
+    let log = Log.create common in
     let (build_system, context, utop_path) =
       (Main.setup ~log common >>= fun setup ->
        let context = Main.find_context_exn setup ~name:ctx_name in
@@ -1120,7 +1207,7 @@ let utop =
        in
        do_build setup [File target] >>| fun () ->
        (setup.build_system, context, Path.to_string target)
-      ) |> Scheduler.go ~log in
+      ) |> Scheduler.go ~log ~common in
     Build_system.finalize build_system;
     restore_cwd_and_execve common utop_path (Array.of_list (utop_path :: args))
       (Context.env_for_exec context)

--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -31,6 +31,7 @@ end
 let dirs =
   [ "src/result"       , Some "Result"
   ; "src/fiber"        , Some "Fiber"
+  ; "src/xdg"          , Some "Xdg"
   ; "vendor/boot"      , None
   ; "vendor/usexp/src" , Some "Usexp"
   ; "src"              , None

--- a/doc/jbuild
+++ b/doc/jbuild
@@ -9,6 +9,15 @@
  ((section man)
   (files (jbuilder.1))))
 
+(rule
+ ((targets (dune-config.5))
+  (action  (with-stdout-to ${@}
+            (run ${bin:jbuilder} help config --man-format=groff)))))
+
+(install
+ ((section man)
+  (files (dune-config.5))))
+
 (include jbuild.inc)
 
 (rule

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -8,11 +8,16 @@ type t
 
 (** {2 Creation} *)
 
+type hook =
+  | Rule_started
+  | Rule_completed
+
 (** Create a new build system. [file_tree] represent the source
     tree. *)
 val create
   :  contexts:Context.t list
   -> file_tree:File_tree.t
+  -> hook:(hook -> unit)
   -> t
 
 type extra_sub_directories_to_keep =

--- a/src/clflags.ml
+++ b/src/clflags.ml
@@ -1,7 +1,6 @@
 let concurrency = ref 4
 (*let ocaml_comp_flags = ref ["-g"]*)
 let g = ref true
-let verbose = ref false
 let debug_findlib = ref false
 let warnings = ref "-40"
 let debug_dep_path = ref false

--- a/src/clflags.mli
+++ b/src/clflags.mli
@@ -9,9 +9,6 @@ val concurrency : int ref
 (** [-g] *)
 val g : bool ref
 
-(** Print executed commands verbosely *)
-val verbose : bool ref
-
 (** Print dependency path in case of error *)
 val debug_dep_path : bool ref
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -18,3 +18,60 @@ let local_install_lib_dir ~context ~package =
 let dev_null = Path.of_string (if Sys.win32 then "nul" else "/dev/null")
 
 let jbuilder_keep_fname = ".jbuilder-keep"
+
+open Sexp.Of_sexp
+
+module Display = struct
+  type t =
+    | Progress
+    | Short
+    | Verbose
+    | Quiet
+
+  let all = [Progress; Short; Verbose; Quiet]
+
+  let t =
+    enum
+      [ "progress" , Progress
+      ; "verbose"  , Verbose
+      ; "short"    , Short
+      ; "quiet"    , Quiet
+      ]
+
+  let of_string = function
+    | "progress" -> Some Progress
+    | "verbose"  -> Some Verbose
+    | "short"    -> Some Short
+    | "quiet"    -> Some Quiet
+    | _          -> None
+
+  let to_string = function
+    | Progress -> "progress"
+    | Verbose  -> "verbose"
+    | Short    -> "short"
+    | Quiet    -> "quiet"
+end
+
+type t =
+  { display : Display.t
+  }
+
+let default =
+  { display = Progress
+  }
+
+let t =
+  record
+    (field "display" Display.t >>= fun display ->
+     return { display })
+
+let user_config_file = Filename.concat Xdg.config_dir "dune/config"
+
+let load_config_file ~fname =
+  t (Sexp.load_many_as_one ~fname)
+
+let load_user_config_file () =
+  if Sys.file_exists user_config_file then
+    load_config_file ~fname:user_config_file
+  else
+    default

--- a/src/config.ml
+++ b/src/config.ml
@@ -28,28 +28,14 @@ module Display = struct
     | Verbose
     | Quiet
 
-  let all = [Progress; Short; Verbose; Quiet]
-
-  let t =
-    enum
+  let all =
       [ "progress" , Progress
       ; "verbose"  , Verbose
       ; "short"    , Short
       ; "quiet"    , Quiet
       ]
 
-  let of_string = function
-    | "progress" -> Some Progress
-    | "verbose"  -> Some Verbose
-    | "short"    -> Some Short
-    | "quiet"    -> Some Quiet
-    | _          -> None
-
-  let to_string = function
-    | Progress -> "progress"
-    | Verbose  -> "verbose"
-    | Short    -> "short"
-    | Quiet    -> "quiet"
+  let t = enum all
 end
 
 type t =

--- a/src/config.mli
+++ b/src/config.mli
@@ -25,9 +25,7 @@ module Display : sig
     | Quiet    (** Only display errors            *)
 
   val t : t Sexp.Of_sexp.t
-  val all : t list
-  val of_string : string -> t option
-  val to_string : t -> string
+  val all : (string * t) list
 end
 
 type t =

--- a/src/config.mli
+++ b/src/config.mli
@@ -14,3 +14,29 @@ val dev_null : Path.t
 (** When this file is present in a directory jbuilder will delete
     nothing in it if it knows to generate this file. *)
 val jbuilder_keep_fname : string
+
+(** Jbuilder configuration *)
+
+module Display : sig
+  type t =
+    | Progress (** Single interactive status line *)
+    | Short    (** One line per command           *)
+    | Verbose  (** Display all commands fully     *)
+    | Quiet    (** Only display errors            *)
+
+  val t : t Sexp.Of_sexp.t
+  val all : t list
+  val of_string : string -> t option
+  val to_string : t -> string
+end
+
+type t =
+  { display : Display.t
+  }
+
+val t : t Sexp.Of_sexp.t
+
+val default : t
+val user_config_file : string
+val load_user_config_file : unit -> t
+val load_config_file : fname:string -> t

--- a/src/import.ml
+++ b/src/import.ml
@@ -575,3 +575,9 @@ module Fmt = struct
 
   let failwith fmt = kstrf failwith fmt
 end
+
+(* This is ugly *)
+type printer =
+  { print : 'a. ('a, Format.formatter, unit, unit) format4 -> 'a } [@@unboxed]
+let printer = ref { print = fun fmt -> Format.eprintf fmt }
+let print_to_console fmt = (!printer).print fmt

--- a/src/jbuild
+++ b/src/jbuild
@@ -6,6 +6,7 @@
   (libraries   (unix
                 result
                 fiber
+                xdg
 		jbuilder_re
 		jbuilder_opam_file_format
                 usexp))

--- a/src/loc.ml
+++ b/src/loc.ml
@@ -59,4 +59,4 @@ let print ppf { start; stop } =
     start.pos_fname start.pos_lnum start_c stop_c
 
 let warn t fmt =
-  Format.eprintf ("%a@{<warning>Warning@}: " ^^ fmt ^^ "@.") print t
+  print_to_console ("%a@{<warning>Warning@}: " ^^ fmt ^^ "@.") print t

--- a/src/log.mli
+++ b/src/log.mli
@@ -4,7 +4,7 @@ type t
 
 val no_log : t
 
-val create : unit -> t
+val create : ?display:Config.Display.t -> unit -> t
 
 (** Print an information message in the log *)
 val info  : t -> string -> unit

--- a/src/main.ml
+++ b/src/main.ml
@@ -122,10 +122,9 @@ let bootstrap () =
     let display = ref None in
     let display_mode =
       Arg.Symbol
-        (List.map Config.Display.all ~f:Config.Display.to_string,
+        (List.map Config.Display.all ~f:fst,
          fun s ->
-           display := Some (Config.Display.of_string s
-                            |> Option.value_exn))
+           display := Some (List.assoc s Config.Display.all))
     in
     Arg.parse
       [ "-j"           , Set_int Clflags.concurrency, "JOBS concurrency"

--- a/src/main.ml
+++ b/src/main.ml
@@ -54,8 +54,18 @@ let setup ?(log=Log.no_log)
   let contexts = List.concat contexts in
   List.iter contexts ~f:(fun (ctx : Context.t) ->
     Log.infof log "@[<1>Jbuilder context:@,%a@]@." Sexp.pp (Context.sexp_of_t ctx));
+  let rule_done  = ref 0 in
+  let rule_total = ref 0 in
+  let gen_status_line () =
+    Some (sprintf "Done: %u/%u" !rule_done !rule_total)
+  in
+  let hook (hook : Build_system.hook) =
+    match hook with
+    | Rule_started   -> incr rule_total
+    | Rule_completed -> incr rule_done
+  in
   let build_system =
-    Build_system.create ~contexts ~file_tree:conf.file_tree
+    Build_system.create ~contexts ~file_tree:conf.file_tree ~hook
   in
   Gen_rules.gen conf
     ~build_system
@@ -63,6 +73,8 @@ let setup ?(log=Log.no_log)
     ?only_packages
     ?filter_out_optional_stanzas_with_missing_deps
   >>= fun stanzas ->
+  Scheduler.set_status_line_generator gen_status_line
+  >>>
   Fiber.return
     { build_system
     ; stanzas
@@ -107,16 +119,30 @@ let bootstrap () =
       Scheduler.go (Watermarks.subst () ~name:"jbuilder");
       exit 0
     in
+    let display = ref None in
+    let display_mode =
+      Arg.Symbol
+        (List.map Config.Display.all ~f:Config.Display.to_string,
+         fun s ->
+           display := Some (Config.Display.of_string s
+                            |> Option.value_exn))
+    in
     Arg.parse
       [ "-j"           , Set_int Clflags.concurrency, "JOBS concurrency"
       ; "--dev"        , Set Clflags.dev_mode       , " set development mode"
-      ; "--verbose"    , Set Clflags.verbose        , " print detailed information about commands being run"
+      ; "--display"    , display_mode               , " print detailed information about commands being run"
       ; "--subst"      , Unit subst                 , " substitute watermarks in source files"
       ]
       anon "Usage: boot.exe [-j JOBS] [--dev]\nOptions are:";
     Clflags.debug_dep_path := true;
-    let log = Log.create () in
-    Scheduler.go ~log
+    let config = Config.load_user_config_file () in
+    let config =
+      match !display with
+      | None -> config
+      | Some display -> { display }
+    in
+    let log = Log.create ~display:config.display () in
+    Scheduler.go ~log ~config
       (setup ~log ~workspace:{ merlin_context = Some "default"
                              ; contexts = [Default [Native]] }
          ~use_findlib:false

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -22,6 +22,14 @@ let load ~fname ~mode =
     in
     loop Parser.Stack.empty)
 
+let load_many_as_one ~fname =
+  match load ~fname ~mode:Many with
+  | [] -> Ast.List (Loc.in_file fname, [])
+  | x :: l ->
+    let last = Option.value (List.last l) ~default:x in
+    let loc = { (Ast.loc x) with stop = (Ast.loc last).stop } in
+    Ast.List (loc, x :: l)
+
 let ocaml_script_prefix = "(* -*- tuareg -*- *)"
 let ocaml_script_prefix_len = String.length ocaml_script_prefix
 

--- a/src/sexp.mli
+++ b/src/sexp.mli
@@ -5,6 +5,7 @@ include module type of struct include Usexp end with module Loc := Usexp.Loc
 val code_error : string -> (string * t) list -> _
 
 val load : fname:string -> mode:'a Parser.Mode.t -> 'a
+val load_many_as_one : fname:string -> Ast.t
 
 type sexps_or_ocaml_script =
   | Sexps of Ast.t list

--- a/src/xdg/jbuild
+++ b/src/xdg/jbuild
@@ -1,0 +1,3 @@
+(jbuild_version 1)
+
+(library ((name xdg)))

--- a/src/xdg/xdg.ml
+++ b/src/xdg/xdg.ml
@@ -1,0 +1,37 @@
+let home =
+  try
+    Sys.getenv "HOME"
+  with Not_found ->
+    try
+      (Unix.getpwuid (Unix.getuid ())).Unix.pw_dir
+    with Unix.Unix_error _ | Not_found ->
+      if Sys.win32 then
+        try
+          Sys.getenv "AppData"
+        with Not_found ->
+          ""
+      else
+        ""
+
+let ( / ) = Filename.concat
+
+let get env_var unix_default win32_default =
+  try
+    Sys.getenv env_var
+  with Not_found ->
+    if Sys.win32 then win32_default else unix_default
+
+let cache_dir =
+  get "XDG_CACHE_HOME"
+    (home / ".cache")
+    (home / "Local Settings" / "Cache")
+
+let config_dir =
+  get "XDG_CONFIG_HOME"
+    (home / ".config")
+    (home / "Local Settings")
+
+let data_dir =
+  get "XDG_DATA_HOME"
+    (home / ".local" / "share")
+    (try Sys.getenv "AppData" with Not_found -> "")

--- a/src/xdg/xdg.mli
+++ b/src/xdg/xdg.mli
@@ -1,0 +1,13 @@
+(** Implement the XDG specification
+
+    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+*)
+
+(** The directory where the application should read/write config files. *)
+val config_dir : string
+
+(** The directory where the application should read/write data files. *)
+val data_dir : string
+
+(** The directory where the application should read/write cached files. *)
+val cache_dir : string

--- a/test/blackbox-tests/test-cases/aliases/run.t
+++ b/test/blackbox-tests/test-cases/aliases/run.t
@@ -1,22 +1,22 @@
-  $ $JBUILDER clean -j1 --root .
-  $ $JBUILDER build -j1 --root . @just-in-src
+  $ $JBUILDER clean -j1 --display short --root .
+  $ $JBUILDER build -j1 --display short --root . @just-in-src
   running in src
-  $ $JBUILDER clean -j1 --root .
-  $ $JBUILDER build -j1 --root . @everywhere
+  $ $JBUILDER clean -j1 --display short --root .
+  $ $JBUILDER build -j1 --display short --root . @everywhere
   running in src/foo/bar
   running in src/foo/baz
   running in src
-  $ $JBUILDER clean -j1 --root .
-  $ $JBUILDER build -j1 --root . @x
+  $ $JBUILDER clean -j1 --display short --root .
+  $ $JBUILDER build -j1 --display short --root . @x
   running in src/foo/bar
   running in src/foo/baz
   running in src
-  $ $JBUILDER build -j1 --root . @plop
+  $ $JBUILDER build -j1 --display short --root . @plop
   From the command line:
   Error: Alias plop is empty.
   It is not defined in . or any of its descendants.
   [1]
-  $ $JBUILDER build -j1 --root . @truc/x
+  $ $JBUILDER build -j1 --display short --root . @truc/x
   From the command line:
   Error: Don't know about directory truc!
   [1]

--- a/test/blackbox-tests/test-cases/c-stubs/run.t
+++ b/test/blackbox-tests/test-cases/c-stubs/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER exec -j1 ./qnativerun/run.exe --root .
+  $ $JBUILDER exec -j1 ./qnativerun/run.exe --display short --root .
       ocamldep qnativerun/run.ml.d
         ocamlc q/q_stub.o
       ocamldep q/q.ml.d
@@ -11,4 +11,4 @@
       ocamlopt q/q.{a,cmxa}
       ocamlopt qnativerun/run.exe
   42
-#  $ $JBUILDER exec -j1 ./qbyterun/run.bc --root .
+#  $ $JBUILDER exec -j1 ./qbyterun/run.bc --display short --root .

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build -j1 test.exe .merlin --root . --debug-dependency-path
+  $ $JBUILDER build -j1 test.exe .merlin --display short --root . --debug-dependency-path
       ocamllex lexers/lexer1.ml
       ocamldep test.ml.d
       ocamldep lexer1.ml.d
@@ -13,6 +13,6 @@
       ocamlopt foo.{a,cmxa}
       ocamlopt test.{cmx,o}
       ocamlopt test.exe
-  $ $JBUILDER build -j1 @bar-source --root .
+  $ $JBUILDER build -j1 @bar-source --display short --root .
   #line 1 "include/bar.h"
   int foo () {return 42;}

--- a/test/blackbox-tests/test-cases/cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation/run.t
@@ -1,4 +1,4 @@
-  $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf $JBUILDER build --root . -j1 -x foo file @install
+  $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf $JBUILDER build --display short --root . -j1 -x foo file @install
       ocamldep bin/blah.ml.d [default.foo]
       ocamldep lib/p.ml.d [default.foo]
       ocamldep bin/blah.ml.d

--- a/test/blackbox-tests/test-cases/exec-cmd/run.t
+++ b/test/blackbox-tests/test-cases/exec-cmd/run.t
@@ -1,22 +1,22 @@
-  $ $JBUILDER clean -j1 --root .
-  $ $JBUILDER exec --no-build ./foo.exe -j1 --root .
+  $ $JBUILDER clean -j1 --display short --root .
+  $ $JBUILDER exec --no-build ./foo.exe -j1 --display short --root .
   Error: Program "./foo.exe" isn't built yet you need to buid it first or remove the --no-build option.
   [1]
-  $ $JBUILDER exec ./foo.exe -j1 --root .
+  $ $JBUILDER exec ./foo.exe -j1 --display short --root .
       ocamldep foo.ml.d
         ocamlc foo.{cmi,cmo,cmt}
       ocamlopt foo.{cmx,o}
       ocamlopt foo.exe
   Foo
-  $ $JBUILDER exec --dev ./foo.exe -j1 --root .
+  $ $JBUILDER exec --dev ./foo.exe -j1 --display short --root .
         ocamlc foo.{cmi,cmo,cmt}
       ocamlopt foo.{cmx,o}
       ocamlopt foo.exe
   Foo
-  $ $JBUILDER exec bar --no-build -j1 --root .
+  $ $JBUILDER exec bar --no-build -j1 --display short --root .
   Error: Program "bar" isn't built yet you need to buid it first or remove the --no-build option.
   [1]
-  $ $JBUILDER exec bar -j1 --root .
+  $ $JBUILDER exec bar -j1 --display short --root .
       ocamldep bar.ml.d
         ocamlc bar.{cmi,cmo,cmt}
       ocamlopt bar.{cmx,o}

--- a/test/blackbox-tests/test-cases/force-test/run.t
+++ b/test/blackbox-tests/test-cases/force-test/run.t
@@ -1,12 +1,12 @@
-  $ $JBUILDER clean -j1 --root .
-  $ $JBUILDER runtest -j1 --root .
+  $ $JBUILDER clean -j1 --display short --root .
+  $ $JBUILDER runtest -j1 --display short --root .
       ocamldep f.ml.d
         ocamlc f.{cmi,cmo,cmt}
       ocamlopt f.{cmx,o}
       ocamlopt f.exe
              f alias runtest
   Foo Bar
-  $ $JBUILDER runtest -j1 --root .
-  $ $JBUILDER runtest --force -j1 --root .
+  $ $JBUILDER runtest -j1 --display short --root .
+  $ $JBUILDER runtest --force -j1 --display short --root .
              f alias runtest
   Foo Bar

--- a/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
+++ b/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER runtest -j1 --root .
+  $ $JBUILDER runtest -j1 --display short --root .
       ocamldep bar.ml.d
       ocamldep foo_byte.ml.d
       ocamldep foo.ml.d

--- a/test/blackbox-tests/test-cases/github20/run.t
+++ b/test/blackbox-tests/test-cases/github20/run.t
@@ -1,1 +1,1 @@
-  $ $JBUILDER build -j1 .merlin --root .
+  $ $JBUILDER build -j1 .merlin --display short --root .

--- a/test/blackbox-tests/test-cases/github24/run.t
+++ b/test/blackbox-tests/test-cases/github24/run.t
@@ -1,1 +1,1 @@
-  $ $JBUILDER build -j1 @install --root . --debug-dependency-path
+  $ $JBUILDER build -j1 @install --display short --root . --debug-dependency-path

--- a/test/blackbox-tests/test-cases/github25/root/run.t
+++ b/test/blackbox-tests/test-cases/github25/root/run.t
@@ -6,14 +6,14 @@ problem. So jbuilder shouldn't crash because of "plop.ca-marche-pas"
 
 We need ocamlfind to run this test
 
-  $ $JBUILDER build -j1 @install --root . --only hello
+  $ $JBUILDER build -j1 @install --display short --root . --only hello
         ocamlc hello.{cmi,cmo,cmt}
       ocamlopt hello.{cmx,o}
         ocamlc hello.cma
       ocamlopt hello.{a,cmxa}
       ocamlopt hello.cmxs
 
-  $ $JBUILDER build -j1 @install --root . --only pas-de-bol
+  $ $JBUILDER build -j1 @install --display short --root . --only pas-de-bol
   Error: External library "plop.ca-marche-pas" is unavailable.
   -> required by jbuild
   External library "plop.ca-marche-pas" is not available because it depends on the following libraries that are not available:

--- a/test/blackbox-tests/test-cases/include-loop/run.t
+++ b/test/blackbox-tests/test-cases/include-loop/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build --root . -j 1
+  $ $JBUILDER build --display short --root . -j 1
   File "jbuild", line 2, characters 0-15:
   Error: Recursive inclusion of jbuild files detected:
   File a.inc is included from c.inc:2

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build -j1 --root . --dev bin/technologic.bc.js @install lib/x.cma.js lib/x__Y.cmo.js bin/z.cmo.js
+  $ $JBUILDER build -j1 --display short --root . --dev bin/technologic.bc.js @install lib/x.cma.js lib/x__Y.cmo.js bin/z.cmo.js
         ocamlc lib/stubs.o
       ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
         ocamlc lib/x__.{cmi,cmo,cmt}
@@ -34,7 +34,7 @@
   use it
   break it
   fix it
-  $ $JBUILDER build -j1 --root . bin/technologic.bc.js @install
+  $ $JBUILDER build -j1 --display short --root . bin/technologic.bc.js @install
         ocamlc lib/x__.{cmi,cmo,cmt}
         ocamlc lib/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/x__.{cmx,o}

--- a/test/blackbox-tests/test-cases/lib-available/run.t
+++ b/test/blackbox-tests/test-cases/lib-available/run.t
@@ -1,3 +1,3 @@
-  $ $JBUILDER build -j1 @runtest --root . --debug-dependency-path 2>&1 | sed "s/ cmd /  sh /"
+  $ $JBUILDER build -j1 @runtest --display short --root . --debug-dependency-path 2>&1 | sed "s/ cmd /  sh /"
             sh alias runtest
             sh alias runtest

--- a/test/blackbox-tests/test-cases/loop/run.t
+++ b/test/blackbox-tests/test-cases/loop/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build --root . -j 1 a
+  $ $JBUILDER build --display short --root . -j 1 a
           true x
           true y
   Dependency cycle between the following files:
@@ -11,14 +11,14 @@ This second example is slightly more complicated as we request result1
 but the cycle doesn't involve result1. We must make sure the output
 does show a cycle.
 
-  $ $JBUILDER build --root . -j 1 result1
+  $ $JBUILDER build --display short --root . -j 1 result1
   Dependency cycle between the following files:
       _build/default/result2
   --> _build/default/input
   --> _build/default/result2
   [1]
 
-  $ $JBUILDER build --root . -j 1 result1 --debug-dependency-path
+  $ $JBUILDER build --display short --root . -j 1 result1 --debug-dependency-path
   Dependency cycle between the following files:
       _build/default/result2
   --> _build/default/input

--- a/test/blackbox-tests/test-cases/menhir/run.t
+++ b/test/blackbox-tests/test-cases/menhir/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build -j1 src/test.exe --root . --debug-dependency-path
+  $ $JBUILDER build -j1 src/test.exe --display short --root . --debug-dependency-path
       ocamllex src/lexer1.ml
       ocamllex src/lexer2.ml
       ocamldep src/test.ml.d

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER runtest --force -j1 --root .
+  $ $JBUILDER runtest --force -j1 --display short --root .
   description = "contains \"quotes\""
   requires = "bytes"
   archive(byte) = "foobar.cma"

--- a/test/blackbox-tests/test-cases/misc/run.t
+++ b/test/blackbox-tests/test-cases/misc/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER runtest -j1 --root .
+  $ $JBUILDER runtest -j1 --display short --root .
   File "jbuild", line 54, characters 10-209:
   Warning: Directory _build/default/dir-that-doesnt-exist doesn't exist.
           diff alias runtest

--- a/test/blackbox-tests/test-cases/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/multiple-private-libs/run.t
@@ -1,6 +1,6 @@
 This test checks that there is no clash when two private libraries have the same name
 
-  $ $JBUILDER build -j1 --root . @doc
+  $ $JBUILDER build -j1 --display short --root . @doc
           odoc _doc/odoc.css
           odoc _doc/test@a/page-index.odoc
       ocamldep a/test.ml.d

--- a/test/blackbox-tests/test-cases/ocaml-syntax/run.t
+++ b/test/blackbox-tests/test-cases/ocaml-syntax/run.t
@@ -1,2 +1,2 @@
-  $ $JBUILDER runtest --force -j1 --root .
+  $ $JBUILDER runtest --force -j1 --display short --root .
   ocaml syntax

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build @doc -j1 --root .
+  $ $JBUILDER build @doc -j1 --display short --root .
       ocamldep foo_byte.ml.d
           odoc _doc/foo.byte/page-index.odoc
           odoc _doc/foo.byte/page-test.odoc
@@ -16,7 +16,7 @@
           odoc _doc/foo/index.html
           odoc _doc/foo/test.html
           odoc _doc/foo/Foo/.jbuilder-keep,_doc/foo/Foo/index.html
-  $ $JBUILDER runtest -j1 --root .
+  $ $JBUILDER runtest -j1 --display short --root .
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
     <head>

--- a/test/blackbox-tests/test-cases/ppx-rewriter/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build ./w_omp_driver.exe -j1 --root .
+  $ $JBUILDER build ./w_omp_driver.exe -j1 --display short --root .
       ocamldep ppx/fooppx.ml.d
         ocamlc ppx/fooppx.{cmi,cmo,cmt}
       ocamlopt ppx/fooppx.{cmx,o}
@@ -9,7 +9,7 @@
         ocamlc w_omp_driver.{cmi,cmo,cmt}
       ocamlopt w_omp_driver.{cmx,o}
       ocamlopt w_omp_driver.exe
-  $ $JBUILDER build ./w_ppx_driver.exe -j1 --root .
+  $ $JBUILDER build ./w_ppx_driver.exe -j1 --display short --root .
       ocamlopt .ppx/ppx_driver.runner/ppx.exe
            ppx w_ppx_driver.pp.ml
       ocamldep w_ppx_driver.pp.ml.d
@@ -17,4 +17,4 @@
       ocamlopt w_ppx_driver.{cmx,o}
       ocamlopt w_ppx_driver.exe
 This test is broken because ppx_driver doesn't support migrate custom arguments
-#  $ $JBUILDER build ./w_ppx_driver_flags.exe -j1 --root .
+#  $ $JBUILDER build ./w_ppx_driver_flags.exe -j1 --display short --root .

--- a/test/blackbox-tests/test-cases/promote/run.t
+++ b/test/blackbox-tests/test-cases/promote/run.t
@@ -1,30 +1,30 @@
   $ printf titi > x
 
-  $ $JBUILDER build --root . -j1 --diff-command false @blah 2>&1 | sed 's/.*false.*/DIFF/'
+  $ $JBUILDER build --display short --root . -j1 --diff-command false @blah 2>&1 | sed 's/.*false.*/DIFF/'
             sh (internal) (exit 1)
   DIFF
   $ cat x
   titi
 
-  $ $JBUILDER promote --root .
+  $ $JBUILDER promote --display short --root .
   Promoting _build/default/x.gen to x.
   $ cat x
   toto
 
-  $ $JBUILDER build --root . -j1 --diff-command false @blah
+  $ $JBUILDER build --display short --root . -j1 --diff-command false @blah
   $ cat x
   toto
 
 Otherwise this test fails on OSX
-  $ jbuilder clean --root . -j1
+  $ $JBUILDER clean --display short --root . -j1
 
   $ printf titi > x
-  $ $JBUILDER build --root . -j1 --diff-command false @blah --auto-promote 2>&1 | sed 's/.*false.*/DIFF/'
+  $ $JBUILDER build --display short --root . -j1 --diff-command false @blah --auto-promote 2>&1 | sed 's/.*false.*/DIFF/'
             sh (internal) (exit 1)
   DIFF
   Promoting _build/default/x.gen to x.
   $ cat x
   toto
-  $ $JBUILDER build --root . -j1 --diff-command false @blah
+  $ $JBUILDER build --display short --root . -j1 --diff-command false @blah
   $ cat x
   toto

--- a/test/blackbox-tests/test-cases/reason/run.t
+++ b/test/blackbox-tests/test-cases/reason/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build @runtest @install-file -j1 --root .
+  $ $JBUILDER build @runtest @install-file -j1 --display short --root .
          refmt bar.re.ml
       ocamldep pp/reasononlypp.depends.ocamldep-output
       ocamldep ppx/reasonppx.depends.ocamldep-output

--- a/test/blackbox-tests/test-cases/redirections/run.t
+++ b/test/blackbox-tests/test-cases/redirections/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER runtest -j1 --root . 2>&1 | sed "s/ cmd /  sh /"
+  $ $JBUILDER runtest -j1 --display short --root . 2>&1 | sed "s/ cmd /  sh /"
             sh stderr,stdout
             sh both
             sh stderr,stdout

--- a/test/blackbox-tests/test-cases/scope-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-bug/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build -j1 --root . @install
+  $ $JBUILDER build -j1 --display short --root . @install
       ocamldep alib/alib.ml.d
       ocamldep alib/main.ml.d
         ocamlc alib/alib__.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER build -j1 --root . @install
+  $ $JBUILDER build -j1 --display short --root . @install
         ocamlc a/ppx/a.{cmi,cmo,cmt}
         ocamlc a/kernel/a_kernel.{cmi,cmo,cmt}
       ocamlopt a/ppx/a.{cmx,o}

--- a/test/blackbox-tests/test-cases/select/run.t
+++ b/test/blackbox-tests/test-cases/select/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER runtest -j1 --root .
+  $ $JBUILDER runtest -j1 --display short --root .
       ocamldep bar.ml.d
       ocamldep bar_no_unix.ml.d
       ocamldep bar_unix.ml.d

--- a/test/blackbox-tests/test-cases/utop/run.t
+++ b/test/blackbox-tests/test-cases/utop/run.t
@@ -1,4 +1,4 @@
-  $ $JBUILDER utop -j1 --root . forutop -- init_forutop.ml
+  $ $JBUILDER utop -j1 --display short --root . forutop -- init_forutop.ml
       ocamldep forutop/.utop/utop.ml.d
       ocamldep forutop/forutop.ml.d
         ocamlc forutop/forutop.{cmi,cmo,cmt}


### PR DESCRIPTION
Once we don't stop at the first error, the output becomes messy. This PR adds display modes:

- `quiet`: only print errors
- `progress`: interactive display showing the number of rules processed so far and the number of parallel jobs running. This is the new default
- `short`: current default
- `verbose`: same as current `--verbose`

The display mode can be selected via the `--display` command line argument, or via the configuration file `~/.config/dune/config`.

TODO:
- [ ] Document display modes in the manual
- [ ] Document the configuration file in the manual