### PR TITLE
Move the addition of <lib>.a dependencies to Lib.archive_files

### DIFF
--- a/src/lib.ml
+++ b/src/lib.ml
@@ -76,6 +76,11 @@ let archive_files ts ~mode ~ext_lib =
       let l =
         [Path.relative dir (lib.name ^ Mode.compiled_lib_ext mode)]
       in
+      let l =
+        match mode with
+        | Byte -> l
+        | Native -> Path.relative dir (lib.name ^ ext_lib) :: l
+      in
       if Jbuild.Library.has_stubs lib then
         Jbuild.Library.stubs_archive lib ~dir ~ext_lib :: l
       else

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -21,6 +21,8 @@ val c_include_flags : t list -> stdlib_dir:Path.t -> _ Arg_spec.t
 
 val link_flags : t list -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
 
+(** All the library archive files (.a, .cmxa, _stubs.a, ...)  that
+    should be linked in when linking an executable. *)
 val archive_files : t list -> mode:Mode.t -> ext_lib:string -> Path.t list
 
 val jsoo_runtime_files : t list -> Path.t list

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -834,14 +834,9 @@ module PP = struct
     add_rule sctx
       (libs
        >>>
-       Build.dyn_paths (Build.arr (fun libs ->
-         List.rev_append
-           (Lib.archive_files ~mode ~ext_lib:ctx.ext_lib libs)
-           (List.filter_map libs ~f:(function
-              | Lib.Internal (dir, lib) ->
-                Some (Path.relative dir (lib.name ^ ctx.ext_lib))
-              | External _ ->
-                None))))
+       Build.dyn_paths
+         (Build.arr
+            (Lib.archive_files ~mode ~ext_lib:ctx.ext_lib))
        >>>
        Build.run ~context:ctx (Ok compiler)
          [ A "-o" ; Target target

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -15,6 +15,7 @@
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml .js/stdlib/stdlib.cma.js
+   js_of_ocaml bin/technologic.bc.runtime.js
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
    js_of_ocaml lib/.x.objs/x__Y.cmo.js
         ocamlc lib/.x.objs/x.{cmi,cmo,cmt}
@@ -23,7 +24,6 @@
         ocamlc bin/.technologic.eobjs/z.{cmi,cmo,cmt}
       ocamlopt lib/x.{a,cmxa}
    js_of_ocaml lib/x.cma.js
-   js_of_ocaml bin/technologic.bc.runtime.js
    js_of_ocaml bin/.technologic.eobjs/z.cmo.js
         ocamlc bin/.technologic.eobjs/technologic.{cmi,cmo,cmt}
       ocamlopt lib/x.cmxs


### PR DESCRIPTION
I realized that the addition of dependencies on `<lib>.a` files when linking an executable was replicated in a few places instead of being in `Lib.archive_files`. This patch changes that. I also updated a bit the code adding dependencies on `<module>.o` files to use the list of modules directly rather that `Path.change_extension`.