### PR TITLE
Use relative paths in the output of `jbuilder rules`

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -842,6 +842,9 @@ let rules =
          | _  -> resolve_targets_exn ~log common setup targets |> request_of_targets setup
        in
        Build_system.build_rules setup.build_system ~request ~recursive >>= fun rules ->
+       let sexp_of_action action =
+         Action.for_shell action |> Action.For_shell.sexp_of_t
+       in
        let print oc =
          let ppf = Format.formatter_of_out_channel oc in
          Sexp.prepare_formatter ppf;
@@ -855,7 +858,7 @@ let rules =
                (fun ppf ->
                   Path.Set.iter rule.deps ~f:(fun dep ->
                     Format.fprintf ppf "@ %s" (Path.to_string dep)))
-               Sexp.pp_split_strings (Action.sexp_of_t rule.action))
+               Sexp.pp_split_strings (sexp_of_action rule.action))
          end else begin
            List.iter rules ~f:(fun (rule : Build_system.Rule.t) ->
              let sexp =
@@ -867,7 +870,7 @@ let rules =
                    ; (match rule.context with
                       | None -> []
                       | Some c -> ["context", Atom c.name])
-                   ; [ "action" , Action.sexp_of_t rule.action ]
+                   ; [ "action" , sexp_of_action rule.action ]
                    ])
              in
              Format.fprintf ppf "%a@," Sexp.pp_split_strings sexp)

--- a/src/action.mli
+++ b/src/action.mli
@@ -42,7 +42,18 @@ include Action_intf.Helpers
   with type t       := t
 
 val t : t Sexp.Of_sexp.t
-val sexp_of_t : t Sexp.To_sexp.t
+
+module For_shell : sig
+  include Action_intf.Ast
+    with type program := string
+    with type path    := string
+    with type string  := string
+
+  val sexp_of_t : t Sexp.To_sexp.t
+end
+
+(** Convert the action to a format suitable for printing *)
+val for_shell : t -> For_shell.t
 
 (** Return the list of directories the action chdirs to *)
 val chdirs : t -> Path.Set.t


### PR DESCRIPTION
Before:

```
$ jbuilder rules doc/jbuilder.1
((deps (_build/install/default/bin/jbuilder))
 (targets (_build/default/doc/jbuilder.1))
 (context default)
 (action
  (chdir
   _build/default/doc
   (with-stdout-to
    _build/default/doc/jbuilder.1
    (run _build/install/default/bin/jbuilder --help=groff)))))
```

after (only the last line differs):

```
$ ./_build/install/default/bin/jbuilder rules doc/jbuilder.1
((deps (_build/install/default/bin/jbuilder))
 (targets (_build/default/doc/jbuilder.1))
 (context default)
 (action
  (chdir
   _build/default/doc
   (with-stdout-to
    jbuilder.1
    (run ../../install/default/bin/jbuilder --help=groff)))))
```

The latter looks more intuitive to me
