### PR TITLE
Make `Findlib.package` abstract

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -842,6 +842,9 @@ let rules =
          | _  -> resolve_targets_exn ~log common setup targets |> request_of_targets setup
        in
        Build_system.build_rules setup.build_system ~request ~recursive >>= fun rules ->
+       let sexp_of_action action =
+         Action.for_shell action |> Action.For_shell.sexp_of_t
+       in
        let print oc =
          let ppf = Format.formatter_of_out_channel oc in
          Sexp.prepare_formatter ppf;
@@ -855,7 +858,7 @@ let rules =
                (fun ppf ->
                   Path.Set.iter rule.deps ~f:(fun dep ->
                     Format.fprintf ppf "@ %s" (Path.to_string dep)))
-               Sexp.pp_split_strings (Action.sexp_of_t rule.action))
+               Sexp.pp_split_strings (sexp_of_action rule.action))
          end else begin
            List.iter rules ~f:(fun (rule : Build_system.Rule.t) ->
              let sexp =
@@ -867,7 +870,7 @@ let rules =
                    ; (match rule.context with
                       | None -> []
                       | Some c -> ["context", Atom c.name])
-                   ; [ "action" , Action.sexp_of_t rule.action ]
+                   ; [ "action" , sexp_of_action rule.action ]
                    ])
              in
              Format.fprintf ppf "%a@," Sexp.pp_split_strings sexp)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -497,14 +497,15 @@ let installed_libraries =
          Fiber.return ()
        end else begin
          let pkgs = Findlib.all_packages findlib in
-         let max_len = List.longest_map pkgs ~f:(fun p -> p.name) in
+         let max_len = List.longest_map pkgs ~f:Findlib.Package.name in
          List.iter pkgs ~f:(fun pkg ->
            let ver =
-             match pkg.Findlib.version with
+             match Findlib.Package.version pkg with
              | "" -> "n/a"
              | v  -> v
            in
-           Printf.printf "%-*s (version: %s)\n" max_len pkg.name ver);
+           Printf.printf "%-*s (version: %s)\n" max_len
+             (Findlib.Package.name pkg) ver);
          Fiber.return ()
        end)
   in

--- a/src/action.mli
+++ b/src/action.mli
@@ -42,7 +42,18 @@ include Action_intf.Helpers
   with type t       := t
 
 val t : t Sexp.Of_sexp.t
-val sexp_of_t : t Sexp.To_sexp.t
+
+module For_shell : sig
+  include Action_intf.Ast
+    with type program := string
+    with type path    := string
+    with type string  := string
+
+  val sexp_of_t : t Sexp.To_sexp.t
+end
+
+(** Convert the action to a format suitable for printing *)
+val for_shell : t -> For_shell.t
 
 (** Return the list of directories the action chdirs to *)
 val chdirs : t -> Path.Set.t

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -92,12 +92,12 @@ let file_of_lib t ~from ~lib ~file =
         ~required_by:[With_required_by.Entry.jbuild_file_in ~dir:from]
     with
     | Some pkg ->
-      Ok (Path.relative pkg.dir file)
+      Ok (Path.relative (Findlib.Package.dir pkg) file)
     | None ->
       Error
         { fail = fun () ->
             ignore (Findlib.find_exn t.context.findlib lib
                       ~required_by:[With_required_by.Entry.jbuild_file_in ~dir:from]
-                    : Findlib.package);
+                    : Findlib.Package.t);
             assert false
         }

--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -47,23 +47,39 @@ val create
 
 val path : t -> Path.t list
 
-type package =
-  { name             : string
-  ; dir              : Path.t
-  ; version          : string
-  ; description      : string
-  ; archives         : Path.t list Mode.Dict.t
-  ; plugins          : Path.t list Mode.Dict.t
-  ; jsoo_runtime     : string list
-  ; requires         : package list
-  ; ppx_runtime_deps : package list
-  }
+module Package : sig
+  (** Representation of a findlib package *)
+  type t
 
-val find     : t -> required_by:With_required_by.Entry.t list -> string -> package option
-val find_exn : t -> required_by:With_required_by.Entry.t list -> string -> package
+  val name        : t -> string
+  val dir         : t -> Path.t
+  val version     : t -> string
+  val description : t -> string
 
+  (** Package files *)
+  val archives     : t -> Mode.t -> Path.t list
+  val plugins      : t -> Mode.t -> Path.t list
+  val jsoo_runtime : t -> string list
+
+  val requires         : t -> t list
+  val ppx_runtime_deps : t -> t list
+end
+
+val find
+  :  t
+  -> required_by:With_required_by.Entry.t list
+  -> string
+  -> Package.t option
+val find_exn
+  :  t
+  -> required_by:With_required_by.Entry.t list
+  -> string
+  -> Package.t
+
+(** Same as [Option.is_some (find t ...)] *)
 val available : t -> required_by:With_required_by.Entry.t list -> string -> bool
 
+(** [root_package_name "foo.*"] is "foo" *)
 val root_package_name : string -> string
 
 (** [local_public_libs] is a map from public library names to where they are defined in
@@ -71,19 +87,19 @@ val root_package_name : string -> string
 val closure
   :  required_by:With_required_by.Entry.t list
   -> local_public_libs:Path.t String_map.t
-  -> package list
-  -> package list
+  -> Package.t list
+  -> Package.t list
 val closed_ppx_runtime_deps_of
   :  required_by:With_required_by.Entry.t list
   -> local_public_libs:Path.t String_map.t
-  -> package list
-  -> package list
+  -> Package.t list
+  -> Package.t list
 
 val root_packages : t -> string list
-val all_packages  : t -> package list
+val all_packages  : t -> Package.t list
 val all_unavailable_packages : t -> Package_not_available.t list
 
-val stdlib_with_archives : t -> package
+val stdlib_with_archives : t -> Package.t
 
 module Config : sig
   type t

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -126,13 +126,13 @@ end
       in
       let includes =
         List.fold_left pkgs ~init:Path.Set.empty ~f:(fun acc pkg ->
-          Path.Set.add pkg.Findlib.dir acc)
+          Path.Set.add (Findlib.Package.dir pkg) acc)
         |> Path.Set.elements
         |> List.concat_map ~f:(fun path ->
           [ "-I"; Path.to_string path ])
       in
       let cmas =
-        List.concat_map pkgs ~f:(fun pkg -> pkg.archives.byte)
+        List.concat_map pkgs ~f:(fun pkg -> Findlib.Package.archives pkg Byte)
       in
       let args =
         List.concat

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -6,7 +6,7 @@ end
 
 type t =
   | Internal of Internal.t
-  | External of Findlib.package
+  | External of Findlib.Package.t
 
 module Set : Set.S with type elt := t
 

--- a/src/lib_db.mli
+++ b/src/lib_db.mli
@@ -38,7 +38,7 @@ module Scope : sig
   val interpret_lib_deps
     :  t With_required_by.t
     -> Jbuild.Lib_dep.t list
-    -> Lib.Internal.t list * Findlib.package list * fail option
+    -> Lib.Internal.t list * Findlib.Package.t list * fail option
 
   val resolve_selects
     :  t With_required_by.t

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -59,7 +59,7 @@ let dot_merlin sctx ~dir ~scope ({ requires; flags; _ } as t) =
               let bpath = Path.reach (Lib.lib_obj_dir path lib) ~from:remaindir in
               ("S " ^ spath) :: ("B " ^ bpath) :: internals, externals
             | Lib.External pkg ->
-              internals, ("PKG " ^ pkg.name) :: externals
+              internals, ("PKG " ^ Findlib.Package.name pkg) :: externals
           )
         in
         let source_dirs =

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -363,7 +363,8 @@ module Libs = struct
       List.fold_left libs ~init:[] ~f:(fun acc (lib : Lib.t) ->
         match lib with
         | External pkg ->
-          Build_system.stamp_file_for_files_of t.build_system ~dir:pkg.dir ~ext :: acc
+          Build_system.stamp_file_for_files_of t.build_system
+            ~dir:(Findlib.Package.dir pkg) ~ext :: acc
         | Internal lib ->
           Alias.stamp_file (lib_files_alias lib ~ext) :: acc)))
 
@@ -794,7 +795,7 @@ module PP = struct
         let libs, drivers =
           List.partition_map libs ~f:(fun lib ->
             if (match lib with
-              | External pkg -> is_driver pkg.name
+              | External pkg -> is_driver (Findlib.Package.name pkg)
               | Internal (_, lib) ->
                 is_driver lib.name ||
                 match lib.public with

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -6,13 +6,14 @@ open Jbuilder
 open Import
 
 let print_pkg ppf pkg =
-  Format.fprintf ppf "<package:%s>" pkg.Findlib.name
+  Format.fprintf ppf "<package:%s>" (Findlib.Package.name pkg)
 ;;
 
 #install_printer print_pkg;;
 
 [%%expect{|
-val print_pkg : Format.formatter -> Jbuilder.Findlib.package -> unit = <fun>
+val print_pkg : Format.formatter -> Jbuilder.Findlib.Package.t -> unit =
+  <fun>
 |}]
 
 let findlib =
@@ -29,14 +30,14 @@ val findlib : Jbuilder.Findlib.t = <abstr>
 let pkg = Findlib.find_exn findlib ~required_by:[] "foo";;
 
 [%%expect{|
-val pkg : Jbuilder.Findlib.package = <package:foo>
+val pkg : Jbuilder.Findlib.Package.t = <package:foo>
 |}]
 
 (* "foo" should depend on "baz" *)
-pkg.requires;;
+Findlib.Package.requires pkg;;
 
 [%%expect{|
-- : Jbuilder.Findlib.package list = [<package:baz>]
+- : Jbuilder.Findlib.Package.t list = [<package:baz>]
 |}]
 
 (* +-----------------------------------------------------------------+


### PR DESCRIPTION
This PR only makes the `Findlib.package` abstract.

Making this type abstract will make refactoring library manage easier. The next step is to make `Lib.t` abstract as well.