### PR TITLE
Remove all {test} deps in jbuilder

### DIFF
--- a/jbuilder.opam
+++ b/jbuilder.opam
@@ -21,12 +21,5 @@ depends: [
   # it is only a runtime dependency so that reinstalling ocamlfind
   # doesn't resintall jbuilder
   "ocamlfind" {build}
-  "menhir" {test}
-  "reason" {test}
-  "ocaml-migrate-parsetree" {test}
-  "ppx_driver" {test}
-  "odoc" {test}
-  "js_of_ocaml-compiler" {test}
-  "utop" {test}
 ]
 available: [ ocaml-version >= "4.02.3" ]


### PR DESCRIPTION
The test deps themselves depend on jbuilder to build. This is not possible with
opam

cc @diml @dra27 