### PR TITLE
Make Lib.t abstract

### DIFF
--- a/src/import.ml
+++ b/src/import.ml
@@ -446,6 +446,13 @@ end
 module Option = struct
   type 'a t = 'a option
 
+  module Infix = struct
+    let (>>=) t f =
+      match t with
+      | None -> None
+      | Some a -> f a
+  end
+
   let map t ~f =
     match t with
     | None -> None
@@ -480,6 +487,10 @@ module Option = struct
     match x, y with
     | Some x, Some y -> Some (x, y)
     | _ -> None
+
+  let to_list = function
+    | None -> []
+    | Some x -> [x]
 end
 
 type ('a, 'b) eq = Eq : ('a, 'a) eq

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -104,17 +104,18 @@ let ml_archives t ~mode ~ext_lib =
     let l =
       [Path.relative dir (lib.name ^ Mode.compiled_lib_ext mode)]
     in
-    match mode with
-    | Byte -> l
-    | Native -> Path.relative dir (lib.name ^ ext_lib) :: l
+    match mode, ext_lib with
+    | Byte, _
+    | Native, None -> l
+    | Native, Some ext_lib -> Path.relative dir (lib.name ^ ext_lib) :: l
 
 let archive_files ts ~mode ~ext_lib =
   List.concat_map ts ~f:(fun lib ->
-    ml_archives lib ~mode ~ext_lib @
+    ml_archives lib ~mode ~ext_lib:(Some ext_lib) @
     Option.to_list (stub_archives lib ~ext_lib))
 
 let jsoo_archives t =
-  ml_archives t ~mode:Mode.Byte ~ext_lib:".cma"
+  ml_archives t ~mode:Mode.Byte ~ext_lib:None
   |> List.map ~f:(Path.extend_basename ~suffix:".js")
 
 let jsoo_runtime_files ts =

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -11,6 +11,9 @@ module T = struct
     | Internal of Internal.t
     | External of FP.t
 
+  let internal i = Internal i
+  let external_ i = External i
+
   let best_name = function
     | External pkg -> FP.name pkg
     | Internal (_, lib) -> Jbuild.Library.best_name lib
@@ -24,13 +27,28 @@ module Set = Set.Make(T)
 let lib_obj_dir dir lib =
   Path.relative dir ("." ^ lib.Jbuild.Library.name ^ ".objs")
 
-let dir = function
-  | Internal (dir, _) -> dir
-  | External pkg -> FP.dir pkg
+let get_internal = function
+  | Internal x -> Some x
+  | External _ -> None
+
+let to_either = function
+  | Internal x -> Inl x
+  | External x -> Inr x
+
+let src_dir = function
+  | External _ -> None
+  | Internal (dir, _) -> Some dir
 
 let obj_dir = function
-  | Internal (dir, lib) -> lib_obj_dir dir lib
   | External pkg -> FP.dir pkg
+  | Internal (dir, lib) -> lib_obj_dir dir lib
+
+let src_or_obj_dir t =
+  match src_dir t with
+  | None -> obj_dir t
+  | Some dir -> dir
+
+let is_local lib = Path.is_local (obj_dir lib)
 
 let include_paths ts ~stdlib_dir =
   List.fold_left ts ~init:Path.Set.empty ~f:(fun acc t ->
@@ -45,7 +63,7 @@ let include_flags ts ~stdlib_dir =
 let c_include_flags ts ~stdlib_dir =
   let dirs =
     List.fold_left ts ~init:Path.Set.empty ~f:(fun acc t ->
-      Path.Set.add (dir t) acc)
+      Path.Set.add (src_or_obj_dir t) acc)
     |> Path.Set.remove stdlib_dir
   in
   Arg_spec.S (List.concat_map (Path.Set.elements dirs) ~f:(fun dir ->
@@ -70,22 +88,34 @@ let link_flags ts ~mode ~stdlib_dir =
        | Internal (dir, lib) ->
          Dep (Path.relative dir (lib.name ^ Mode.compiled_lib_ext mode))))
 
+let stub_archives t ~ext_lib =
+  match t with
+  | External _ -> None
+  | Internal (dir, lib) ->
+    if Jbuild.Library.has_stubs lib then
+      Some (Jbuild.Library.stubs_archive lib ~dir ~ext_lib)
+    else
+      None
+
+let ml_archives t ~mode ~ext_lib =
+  match t with
+  | External pkg -> FP.archives pkg mode
+  | Internal (dir, lib) ->
+    let l =
+      [Path.relative dir (lib.name ^ Mode.compiled_lib_ext mode)]
+    in
+    match mode with
+    | Byte -> l
+    | Native -> Path.relative dir (lib.name ^ ext_lib) :: l
+
 let archive_files ts ~mode ~ext_lib =
-  List.concat_map ts ~f:(function
-    | External pkg -> FP.archives pkg mode
-    | Internal (dir, lib) ->
-      let l =
-        [Path.relative dir (lib.name ^ Mode.compiled_lib_ext mode)]
-      in
-      let l =
-        match mode with
-        | Byte -> l
-        | Native -> Path.relative dir (lib.name ^ ext_lib) :: l
-      in
-      if Jbuild.Library.has_stubs lib then
-        Jbuild.Library.stubs_archive lib ~dir ~ext_lib :: l
-      else
-        l)
+  List.concat_map ts ~f:(fun lib ->
+    ml_archives lib ~mode ~ext_lib @
+    Option.to_list (stub_archives lib ~ext_lib))
+
+let jsoo_archives t =
+  ml_archives t ~mode:Mode.Byte ~ext_lib:".cma"
+  |> List.map ~f:(Path.extend_basename ~suffix:".js")
 
 let jsoo_runtime_files ts =
   List.concat_map ts ~f:(function
@@ -93,15 +123,23 @@ let jsoo_runtime_files ts =
       List.map (FP.jsoo_runtime pkg) ~f:(Path.relative (FP.dir pkg))
     | Internal (dir, lib) ->
       List.map lib.buildable.js_of_ocaml.javascript_files ~f:(Path.relative dir))
-(*
-let ppx_runtime_libraries ts =
-  List.fold_left ts ~init:String_set.empty ~f:(fun acc t ->
+
+let ppx_runtime_libraries t =
+  String_set.of_list (
     match t with
-    | Internal (_, lib) ->
-      String_set.union acc (String_set.of_list lib.ppx_runtime_libraries)
-    | External pkg ->
-      String_set.union acc (String_set.of_list pkg.ppx_runtime_deps))
-*)
+    | Internal (_, lib) -> lib.ppx_runtime_libraries
+    | External pkg -> List.map ~f:FP.name (FP.ppx_runtime_deps pkg)
+  )
+
+let requires = function
+  | Internal (_, lib) ->
+    lib.buildable.libraries
+  | External pkg ->
+    List.map ~f:(fun fp -> Jbuild.Lib_dep.direct (FP.name fp)) (FP.requires pkg)
+
+let scope = function
+  | Internal (dir, _) -> `Dir dir
+  | External _ -> `External
 
 let remove_dups_preserve_order libs =
   let rec loop seen libs acc =
@@ -120,3 +158,29 @@ let remove_dups_preserve_order libs =
 let public_name = function
   | External pkg -> Some (FP.name pkg)
   | Internal (_, lib) -> Option.map lib.public ~f:(fun p -> p.name)
+
+let unique_id = function
+  | External pkg -> FP.name pkg
+  | Internal (dir, lib) ->
+    match lib.public with
+    | Some p -> p.name
+    | None -> Path.to_string dir ^ "\000" ^ lib.name
+
+type local =
+  { src: Path.t
+  ; name: string
+  }
+
+let local = function
+  | Internal (dir, lib) -> Some { src = dir; name = lib.name }
+  | External _ -> None
+
+let exists_name t ~f =
+  match t with
+  | External pkg -> f (FP.name pkg)
+  | Internal (_, lib) ->
+    (f lib.name) || (
+      match lib.public with
+      | None -> false
+      | Some p -> f p.name
+    )

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -4,9 +4,18 @@ module Internal : sig
   type t = Path.t * Jbuild.Library.t
 end
 
-type t =
-  | Internal of Internal.t
-  | External of Findlib.Package.t
+type t
+
+val internal : Internal.t -> t
+val external_ : Findlib.Package.t -> t
+
+val to_either : t -> (Internal.t, Findlib.Package.t) either
+
+val get_internal : t -> Internal.t option
+val is_local : t -> bool
+
+val src_dir : t -> Path.t option
+val obj_dir : t -> Path.t
 
 module Set : Set.S with type elt := t
 
@@ -26,6 +35,7 @@ val link_flags : t list -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
 val archive_files : t list -> mode:Mode.t -> ext_lib:string -> Path.t list
 
 val jsoo_runtime_files : t list -> Path.t list
+val jsoo_archives : t -> Path.t list
 
 (** [public_name] if present, [name] if not *)
 val best_name : t -> string
@@ -34,7 +44,19 @@ val describe : t -> string
 
 val remove_dups_preserve_order : t list -> t list
 
-(*val ppx_runtime_libraries : t list -> String_set.t
-*)
+val ppx_runtime_libraries : t -> String_set.t
+val requires : t -> Jbuild.Lib_deps.t
+val scope : t -> [`Dir of Path.t | `External]
 
 val public_name : t -> string option
+
+type local =
+  { src: Path.t
+  ; name: string
+  }
+
+val local : t -> local option
+
+val unique_id : t -> string
+
+val exists_name : t -> f:(string -> bool) -> bool

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -161,7 +161,7 @@ let setup_library_rules sctx (lib : Library.t) ~dir ~modules ~mld_files
       ~requires ~(dep_graphs:Ocamldep.Dep_graph.t Ml_kind.Dict.t) =
   let doc_dir = SC.Doc.dir sctx (dir, lib) in
   let obj_dir = Lib.lib_obj_dir dir lib in
-  let lib_unique_name = SC.unique_library_name sctx (Internal (dir, lib)) in
+  let lib_unique_name = SC.unique_library_name sctx (Lib.internal (dir, lib)) in
   let lib_name = Library.best_name lib in
   let odoc = get_odoc sctx in
   let includes =
@@ -278,6 +278,6 @@ let gen_rules sctx ~dir:_ rest =
         data = scope
       ; required_by = [Alias (Path.of_string "doc")]
       } in
-    match Lib_db.Scope.find scope lib with
-    | None | Some (External _) -> ()
-    | Some (Internal (dir, _)) -> SC.load_dir sctx ~dir
+    let open Option.Infix in
+    Option.iter (Lib_db.Scope.find scope lib >>= Lib.src_dir)
+      ~f:(fun dir -> SC.load_dir sctx ~dir)


### PR DESCRIPTION
Making it private as a first step. There's a few cases where I'm not really sure how to make the distinction go away without pattern matching:

## generating the .merlin

`S` and `B` for internal and `PKG` for external packages. I guess we could get rid of `PKG` directives entirely if we just have `val lib_obj_dir : t -> Path.t` and `val src_dir : t -> Path.t option`. Not sure if this desirable though.

## jsoo

Jsoo's incremental compilation special cases external libraries. Perhaps we could keep the internal lib js artifacts in the global js dir?

## stamp files for globs

For external libs we just take globs for things like header files, while for internal libs we are careful to only use the files listed in the library definition

## transitive closure

There's special casing for deep traversal here which only makes sense for external packages. I suppose we can have a predicate to check if a package is external and generalize `FP.requires` and `lib.buildables`. But the latter is useless without the dir to resolve the scope, so it's messy anyway.