### PR TITLE
Remove primed Lib_db.find_scope

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -959,7 +959,7 @@ module Gen(P : Params) = struct
         in
         let meta_contents =
           version >>^ fun version ->
-          let scope = Lib_db.find_scope (SC.libs sctx) ~dir:path in
+          let scope = (Lib_db.find_scope (SC.libs sctx) ~dir:path).data in
           Gen_meta.gen ~package:pkg.name
             ~scope
             ~version
@@ -1049,7 +1049,7 @@ module Gen(P : Params) = struct
           else
             pps
         in
-        let scope = Lib_db.find_scope' (SC.libs sctx) ~dir in
+        let scope = Lib_db.find_scope (SC.libs sctx) ~dir in
         let ppx_exe = SC.PP.get_ppx_driver sctx ~scope pps in
         [ppx_exe]
     in

--- a/src/lib_db.mli
+++ b/src/lib_db.mli
@@ -74,8 +74,7 @@ val local_public_libs : t -> Path.t String_map.t
 (** Unique name, even for internal libraries *)
 val unique_library_name : t -> Lib.t -> string
 
-val find_scope : t -> dir:Path.t -> Scope.t
-val find_scope' : t -> dir:Path.t -> Scope.t With_required_by.t
+val find_scope : t -> dir:Path.t -> Scope.t With_required_by.t
 
 (** Includes the private libraries not belonging to any named scope. Corresopnds
     to the context's build root path.*)

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -94,7 +94,7 @@ let create
           src_dir = dir
         ; ctx_dir
         ; stanzas
-        ; scope = Lib_db.find_scope' libs ~dir:ctx_dir
+        ; scope = Lib_db.find_scope libs ~dir:ctx_dir
         })
   in
   let stanzas_to_consider_for_install =
@@ -120,7 +120,7 @@ let create
       (struct
         open Sexp.Of_sexp
         let t dir sexp =
-          let scope = Lib_db.find_scope' libs ~dir in
+          let scope = Lib_db.find_scope libs ~dir in
           List.map (list string sexp) ~f:(Lib_db.Scope.find_exn scope)
       end)
   in


### PR DESCRIPTION
Two versions aren't really necessary as mostly the primed version was used.