### PR TITLE
Rewrite the findlib predicate stuff

### DIFF
--- a/src/interned.ml
+++ b/src/interned.ml
@@ -1,0 +1,45 @@
+open Import
+
+module type S = sig
+  type t
+
+  val make : string -> t
+  val compare : t -> t -> int
+
+  module Set : sig
+    include Set.S with type elt = t
+
+    val make : string list -> t
+  end
+
+  module Map : Map.S with type key = t
+end
+
+module Int = struct
+  type t = int
+  let compare : int -> int -> int = compare
+end
+module Int_set = Set.Make(Int)
+module Int_map = Map.Make(Int)
+
+module Make() = struct
+  include Int
+
+  let table = Hashtbl.create 1024
+  let next = ref 0
+
+  let make s =
+    Hashtbl.find_or_add table s ~f:(fun _ ->
+      let n = !next in
+      next := n + 1;
+      n)
+
+  module Set = struct
+    include Int_set
+
+    let make l =
+      List.fold_left l ~init:empty ~f:(fun acc s -> add (make s) acc)
+  end
+
+  module Map = Int_map
+end

--- a/src/interned.mli
+++ b/src/interned.mli
@@ -1,0 +1,20 @@
+(** Interned strings *)
+
+open! Import
+
+module type S = sig
+  type t
+
+  val make : string -> t
+  val compare : t -> t -> int
+
+  module Set : sig
+    include Set.S with type elt = t
+
+    val make : string list -> t
+  end
+
+  module Map : Map.S with type key = t
+end
+
+module Make() : S

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -18,7 +18,7 @@ let choose byte native = function
 let compiled_unit_ext = choose ".cmo" ".cmx"
 let compiled_lib_ext = choose ".cma" ".cmxa"
 
-let findlib_predicate = choose "byte" "native"
+let variant = choose Variant.byte Variant.native
 
 let cm_kind = choose Cm_kind.Cmo Cmx
 

--- a/src/mode.mli
+++ b/src/mode.mli
@@ -13,7 +13,7 @@ val exe_ext : t -> string
 val cm_kind : t -> Cm_kind.t
 val of_cm_kind : Cm_kind.t -> t
 
-val findlib_predicate : t -> string
+val variant : t -> Variant.t
 
 module Dict : sig
   type mode = t

--- a/src/variant.ml
+++ b/src/variant.ml
@@ -1,0 +1,8 @@
+include Interned.Make()
+
+let ppx_driver = make "ppx_driver"
+let mt         = make "mt"
+let mt_posix   = make "mt_posix"
+let byte       = make "byte"
+let native     = make "native"
+let plugin     = make "plugin"

--- a/src/variant.mli
+++ b/src/variant.mli
@@ -1,0 +1,17 @@
+(** Library variants *)
+
+(** Library variants allow to select the implementation of a library
+    at link time.
+
+    They are directly mapped to findlib predicates.
+*)
+
+include Interned.S
+
+(** Well-known variants *)
+val ppx_driver : t
+val mt         : t
+val mt_posix   : t
+val byte       : t
+val native     : t
+val plugin     : t


### PR DESCRIPTION
- intern predicate names. We will use this more in the future when we support library variants
- add a Variant module, in preparation for library variants