### PR TITLE
Fix display when output is not a tty

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1287,6 +1287,15 @@ module Help = struct
                executed by Jbuilder, with some colors to help differentiate
                programs.|}
            ])
+    ; `P {|Note that when the selected display mode is $(b,progress) and the
+           output is not a terminal then the $(b,quiet) mode is selected
+           instead. This rule doesn't apply when running Jbuilder inside Emacs.
+           Jbuilder detects whether it is executed from inside Emacs or not by
+           looking at the environment variable $(b,INSIDE_EMACS) that is set by
+           Emacs. If you want the same behavior with another editor, you can set
+           this variable. If your editor already sets another variable,
+           please open a ticket on the ocaml/dune github project so that we can
+           add support for it.|}
     ; `S "JOBS"
     ; `P {|Syntax: $(b,\(jobs NUMBER\))|}
     ; `P {|Set the maximum number of jobs Jbuilder might run in parallel.

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -234,6 +234,10 @@ let common =
         ; concurrency
         }
     in
+    let config =
+      Config.adapt_display config
+        ~output_is_a_tty:(Lazy.force Ansi_color.stderr_supports_colors)
+    in
     { debug_dep_path
     ; debug_findlib
     ; debug_backtraces

--- a/src/config.ml
+++ b/src/config.ml
@@ -85,3 +85,17 @@ let load_user_config_file () =
     load_config_file ~fname:user_config_file
   else
     default
+
+let inside_emacs =
+  match Sys.getenv "INSIDE_EMACS" with
+  | (_ : string) -> true
+  | exception Not_found -> false
+
+let adapt_display config ~output_is_a_tty =
+  if config.display = Progress &&
+     not output_is_a_tty &&
+     not inside_emacs
+  then
+    { config with display = Quiet }
+  else
+    config

--- a/src/config.mli
+++ b/src/config.mli
@@ -15,6 +15,9 @@ val dev_null : Path.t
     nothing in it if it knows to generate this file. *)
 val jbuilder_keep_fname : string
 
+(** Are we running inside an emacs shell? *)
+val inside_emacs : bool
+
 (** Jbuilder configuration *)
 
 module Display : sig
@@ -49,3 +52,7 @@ val default : t
 val user_config_file : string
 val load_user_config_file : unit -> t
 val load_config_file : fname:string -> t
+
+(** Set display mode to [Quiet] if it is [Progress], the output is not
+    a tty and we are not running inside emacs. *)
+val adapt_display : t -> output_is_a_tty:bool -> t

--- a/src/main.ml
+++ b/src/main.ml
@@ -140,12 +140,22 @@ let bootstrap () =
       ]
       anon "Usage: boot.exe [-j JOBS] [--dev]\nOptions are:";
     Clflags.debug_dep_path := true;
-    let config = Config.load_user_config_file () in
+    let config =
+      (* Only load the configuration with --dev *)
+      if !Clflags.dev_mode then
+        Config.load_user_config_file ()
+      else
+        Config.default
+    in
     let config =
       Config.merge config
         { display     = !display
         ; concurrency = !concurrency
         }
+    in
+    let config =
+      Config.adapt_display config
+        ~output_is_a_tty:(Lazy.force Ansi_color.stderr_supports_colors)
     in
     let log = Log.create ~display:config.display () in
     Scheduler.go ~log ~config


### PR DESCRIPTION
If using progress mode, the output is not a tty and we are not running inside emacs, then switch to quiet mode