### PR TITLE
Change @doc to only build public docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-1.0+beta18 (14/02/2018)
+1.0+beta18 (next)
 -----------------------
 
 - Split calls to ocamldep. Before ocamldep would be called once per
@@ -32,6 +32,10 @@
 
 - Fix a regression in `external-lib-deps` introduced in 1.0+beta17
   (#512, fixes #485)
+
+- `@doc` alias will now build only documentation for public libraries. A new
+  `@doc-private` alias has been added to build documentation for private
+  libraries.
 
 1.0+beta17 (01/02/2018)
 -----------------------

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -225,7 +225,7 @@ module Alias0 = struct
   let dep t = Build.path (stamp_file t)
 
   let is_standard = function
-    | "runtest" | "install" | "doc" | "lint" -> true
+    | "runtest" | "install" | "doc" | "doc-private" | "lint" -> true
     | _ -> false
 
   open Build.O
@@ -272,11 +272,12 @@ module Alias0 = struct
              It is not defined in %s or any of its descendants."
           name (Path.to_string_maybe_quoted src_dir)
 
-  let default = make "DEFAULT"
-  let runtest = make "runtest"
-  let install = make "install"
-  let doc     = make "doc"
-  let lint    = make "lint"
+  let default     = make "DEFAULT"
+  let runtest     = make "runtest"
+  let install     = make "install"
+  let doc         = make "doc"
+  let private_doc = make "doc-private"
+  let lint        = make "lint"
 end
 
 module Dir_status = struct

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -100,11 +100,12 @@ module Alias : sig
 
   val fully_qualified_name : t -> Path.t
 
-  val default : dir:Path.t -> t
-  val runtest : dir:Path.t -> t
-  val install : dir:Path.t -> t
-  val doc     : dir:Path.t -> t
-  val lint    : dir:Path.t -> t
+  val default     : dir:Path.t -> t
+  val runtest     : dir:Path.t -> t
+  val install     : dir:Path.t -> t
+  val doc         : dir:Path.t -> t
+  val private_doc : dir:Path.t -> t
+  val lint        : dir:Path.t -> t
 
   (** Return the underlying stamp file *)
   val stamp_file : t -> Path.t

--- a/test/blackbox-tests/test-cases/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/multiple-private-libs/run.t
@@ -1,6 +1,6 @@
 This test checks that there is no clash when two private libraries have the same name
 
-  $ $JBUILDER build -j1 --display short --root . @doc
+  $ $JBUILDER build -j1 --display short --root . @doc-private
           odoc _doc/odoc.css
           odoc _doc/test@a/page-index.odoc
       ocamldep a/test.ml.d


### PR DESCRIPTION
Private docs can still be built using the new @doc-private alias

cc @trefis 