### PR TITLE
Share more results when preprocessing modules

### DIFF
--- a/src/import.ml
+++ b/src/import.ml
@@ -141,6 +141,8 @@ module Hashtbl = struct
 end
 
 module Map = struct
+  module type OrderedType = MoreLabels.Map.OrderedType
+
   module type S = sig
     include MoreLabels.Map.S
 
@@ -155,7 +157,7 @@ module Map = struct
     val values : 'a t -> 'a list
   end
 
-  module Make(Key : MoreLabels.Map.OrderedType) : S with type key = Key.t = struct
+  module Make(Key : OrderedType) : S with type key = Key.t = struct
     include MoreLabels.Map.Make(Key)
 
     let add_multi t ~key ~data =

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -45,13 +45,16 @@ module Preprocess : sig
     | Pps    of pps
 end
 
+module Per_module : Per_item.S with type key = string
+
 module Preprocess_map : sig
-  type t
+  type t = Preprocess.t Per_module.t
 
   val no_preprocessing : t
   val default : t
 
-  (** [find module_name] find the preprocessing specification for a given module *)
+  (** [find module_name] find the preprocessing specification for a
+      given module *)
   val find : string -> t -> Preprocess.t
 
   val pps : t -> Pp.t list

--- a/src/per_item.ml
+++ b/src/per_item.ml
@@ -1,0 +1,63 @@
+open Import
+
+module type S = sig
+  type key
+
+  type 'a t
+
+  val for_all : 'a -> 'a t
+  val of_mapping
+    :  (key list * 'a) list
+    -> default:'a
+    -> ('a t, key * 'a * 'a) result
+  val get : 'a t -> key -> 'a
+  val is_constant : _ t -> bool
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+  val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
+end
+
+module Make(Key : Map.OrderedType) : S with type key = Key.t = struct
+  module Map = Map.Make(Key)
+
+  type key = Key.t
+
+  type 'a t =
+    { map    : int Map.t
+    ; values : 'a array
+    }
+
+  let for_all x =
+    { map    = Map.empty
+    ; values = [|x|]
+    }
+
+  let of_mapping l ~default =
+    let values =
+      Array.of_list (default :: List.map l ~f:snd)
+    in
+    List.mapi l ~f:(fun i (keys, _) ->
+      List.map keys ~f:(fun key -> (key, i + 1)))
+    |> List.concat
+    |> Map.of_alist
+    |> function
+    | Ok map ->
+      Ok { map; values }
+    | Error (key, x, y) ->
+      Error (key, values.(x), values.(y))
+
+  let get t key =
+    let index =
+      match Map.find key t.map with
+      | None   -> 0
+      | Some i -> i
+    in
+    t.values.(index)
+
+  let map t ~f =
+    { t with values = Array.map t.values ~f }
+
+  let fold t ~init ~f =
+    Array.fold_right t.values ~init ~f
+
+  let is_constant t = Array.length t.values = 1
+end

--- a/src/per_item.mli
+++ b/src/per_item.mli
@@ -1,0 +1,36 @@
+(** Module used to represent the [(per_xxx ...)] forms
+
+    The main different between this module and a plain [Map] is that
+    the [map] operation applies transformations only once per distinct
+    value.
+*)
+
+open Import
+
+module type S = sig
+  type key
+
+  type 'a t
+
+  (** Create a mapping where all keys map to the same value *)
+  val for_all : 'a -> 'a t
+
+  (** Create a mapping from a list of bindings *)
+  val of_mapping
+    :  (key list * 'a) list
+    -> default:'a
+    -> ('a t, key * 'a * 'a) result
+
+  (** Get the configuration for the given item *)
+  val get : 'a t -> key -> 'a
+
+  (** Returns [true] if the mapping returns the same value for all
+      keys. Note that the mapping might still be constant if
+      [is_constant] returns [false]. *)
+  val is_constant : _ t -> bool
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+  val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
+end
+
+module Make(Key : Map.OrderedType) : S with type key = Key.t


### PR DESCRIPTION
Currently, if we have something like `(preprocess (pps (a b c)))` and 20 modules, we are going to call `get_ppx_driver ... ["a"; "b"; "c"]` once for every .ml and .mli files, so 40 times in total.

After this patch, we only call it once.