### PR TITLE
Fix generation of the alias module with 4.02

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 1.0+beta18 (25/02/2018)
 -----------------------
 
+- Fix generation of the implicit alias module with 4.02. With 4.02 it
+  must have an implementation while with OCaml >= 4.03 it can be an
+  interface only module (#549)
+
 - Let the parser distinguish quoted strings from atoms.  This makes
   possible to use "${v}" to concatenate the list of values provided by
   a split-variable.  Concatenating split-variables with text is also

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -321,12 +321,18 @@ module Gen(P : Params) = struct
               String_map.mem main_module_name modules) then
             None
           else if String_map.mem main_module_name modules then
+            let file ext =
+              Some { Module.File.
+                     name   = sprintf "%s__%s-gen" lib.name ext
+                   ; syntax = OCaml
+                   }
+            in
+            (* The tests don't pass with 4.02 if we don't do that *)
+            let needs_impl = ctx.version < (4, 03, 0) in
             Some
               { Module.name = main_module_name ^ "__"
-              ; impl = None
-              ; intf = Some { name   = lib.name ^ "__.mli-gen"
-                            ; syntax = OCaml
-                            }
+              ; impl = if     needs_impl then file ".ml"  else None
+              ; intf = if not needs_impl then file ".mli" else None
               ; obj_name = lib.name ^ "__"
               }
           else

--- a/test/unit-tests/jbuild
+++ b/test/unit-tests/jbuild
@@ -49,7 +49,7 @@
 (alias
  ((name runtest)
   (deps (path.mlt
-         (glob_files ${SCOPE_ROOT}/src/*.cmi)
+         (glob_files ${SCOPE_ROOT}/src/.jbuilder.objs/*.cmi)
          (glob_files ${SCOPE_ROOT}/vendor/re/*.cmi)))
   (action (chdir ${SCOPE_ROOT}
            (progn


### PR DESCRIPTION
I found this while working on #548. The `Lib__` module needs to have an implementation with OCaml 4.02. This bug is present since #490.