### PR TITLE
Rename utop generated file to .ml-gen

### DIFF
--- a/src/utop.ml
+++ b/src/utop.ml
@@ -5,7 +5,7 @@ open! No_io
 
 let exe_name = "_utop"
 let main_module_name = "Utop"
-let main_module_filename = exe_name ^ ".ml"
+let main_module_filename = exe_name ^ ".ml-gen"
 
 let pp_ml fmt include_dirs =
   let pp_include fmt =

--- a/test/blackbox-tests/test-cases/utop/run.t
+++ b/test/blackbox-tests/test-cases/utop/run.t
@@ -1,5 +1,5 @@
   $ $JBUILDER utop -j1 --display short --root . forutop -- init_forutop.ml
-      ocamldep forutop/_utop.ml.d
+      ocamldep forutop/_utop.ml-gen.d
       ocamldep forutop/forutop.ml.d
         ocamlc forutop/.forutop.objs/forutop.{cmi,cmo,cmt}
         ocamlc forutop/._utop.eobjs/_utop.{cmi,cmo,cmt}


### PR DESCRIPTION
This will prevent accidental inclusions of it globs