### PR TITLE
Move SC.Doc to Odoc module

### DIFF
--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -173,18 +173,6 @@ module Deps : sig
     -> (unit, Path.t list) Build.t
 end
 
-module Doc : sig
-  val root : t -> Path.t
-
-  val dir : t -> Library.t -> Path.t
-
-  val deps : t -> (Lib.t list, Lib.t list) Build.t
-
-  val static_deps : t -> Library.t -> ('a, 'a) Build.t
-
-  val setup_deps : t -> Library.t -> Path.t list -> unit
-end
-
 (** Interpret action written in jbuild files *)
 module Action : sig
   type targets =


### PR DESCRIPTION
It longer has a reason to exist in super context. Since it doesn't access anything private to a super context anymore.