### PR TITLE
Fix DB.all returning duplicate libs

### DIFF
--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -45,9 +45,9 @@ module Gen(P : Install_params) = struct
 
   let init_meta () =
     let public_libs = Lib.DB.all (SC.public_libs sctx) in
-    List.iter public_libs ~f:gen_lib_dune_file;
-    List.map public_libs ~f:(fun lib ->
-      (Findlib.root_package_name (Lib.name lib), lib))
+    Lib.Set.iter public_libs ~f:gen_lib_dune_file;
+    Lib.Set.to_list public_libs
+    |> List.map ~f:(fun lib -> (Findlib.root_package_name (Lib.name lib), lib))
     |> String_map.of_list_multi
     |> String_map.merge (SC.packages sctx) ~f:(fun _name pkg libs ->
       let pkg  = Option.value_exn pkg          in

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -30,6 +30,8 @@ val jsoo_runtime : t -> Path.t list
     the process *)
 val unique_id : t -> int
 
+module Set : Set.S with type elt = t
+
 module Status : sig
   type t =
     | Installed
@@ -265,7 +267,7 @@ module DB : sig
   (** Return the list of all libraries in this database. If
       [recursive] is true, also include libraries in parent databases
       recursively. *)
-  val all : ?recursive:bool -> t -> lib list
+  val all : ?recursive:bool -> t -> Set.t
 end with type lib := t
 
 (** {1 Transitive closure} *)


### PR DESCRIPTION
DB.all will return duplicate libraries in cases when it has 2 names for the same
library. This fix changes all to return a set of values. This is to indicate and
guarantee the uniqueness.