### PR TITLE
Add a simple workaround for #563

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ next
 
 - Ignore errors during the generation of the .merlin (#569, fixes #568 and #51)
 
+- Add a workaround for when a library normally installed by the
+  compiler is not installed but still has a META file (#574, fixes
+  #563)
+
 1.0+beta18 (25/02/2018)
 -----------------------
 


### PR DESCRIPTION
For packages that are builtin, we check that least one of the archives is present.