### PR TITLE
META file includes private libraries

### DIFF
--- a/test/blackbox-tests/test-cases/meta-gen/jbuild
+++ b/test/blackbox-tests/test-cases/meta-gen/jbuild
@@ -7,9 +7,12 @@
   (synopsis "contains \"quotes\"")))
 
 (library
+ ((name privatelib)))
+
+(library
  ((name foobar_baz)
   (public_name foobar.baz)
-  (libraries (bytes))
+  (libraries (bytes privatelib))
   (modes (byte))
   (synopsis "sub library with modes set to byte")))
 

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -8,7 +8,7 @@
   package "baz" (
     directory = "baz"
     description = "sub library with modes set to byte"
-    requires = "bytes"
+    requires = "bytes privatelib"
     archive(byte) = "foobar_baz.cma"
     archive(native) = "foobar_baz.cmxa"
     plugin(byte) = "foobar_baz.cma"


### PR DESCRIPTION
This is incorrect as those aren't installed.

@diml this is a pretty serious bug that was discovered in https://github.com/mirage/ocaml-git/pull/280#issuecomment-370039966

I suppose the fix is to exclude these private names and include the .cm files in the libraries that depend on the private stuff.

I'm not really sure when this regression was introduced either. I recall this case working fine before. I wonder when this regression was introduced.