### PR TITLE
Restore stronger check for overlapping libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@ next
 - Accept and ignore `ppx.driver` fields in library stanzas, in
   preparation for the generic ppx driver system (#588)
 
+- Change the default behavior regarding the check for overlaps between
+  local and installed libraries. Now even if there is no link time
+  conflict, we don't allow an external dependency to overlap with a
+  local library, unless the user specifies `allow_overlapping_dependencies`
+  in the jbuild file (#587, fixes #562)
+
 1.0+beta18 (25/02/2018)
 -----------------------
 

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -177,6 +177,9 @@ modules you want.
   such modules to avoid surprises. ``<modules>`` must be a subset of
   the modules listed in the ``(modules ...)`` field.
 
+- ``(allow_overlapping_dependencies)`` allows external dependencies to
+  overlap with libraries that are present in the workspace
+
 Note that when binding C libraries, Jbuilder doesn't provide special support for
 tools such as ``pkg-config``, however it integrates easily with `configurator
 <https://github.com/janestreet/configurator>`__ by using ``(c_flags (:include
@@ -261,6 +264,9 @@ binary at the same place as where ``ocamlc`` was found, or when there is a
    specifying `OCaml flags`_
 
 - ``(modules_without_implementation <modules>)`` is the same as the
+  corresponding field of `library`_
+
+- ``(allow_overlapping_dependencies)`` is the same as the
   corresponding field of `library`_
 
 executables

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -547,7 +547,10 @@ module Gen(P : Install_rules.Params) = struct
             |> String.concat ~sep:"\n")
          >>> Build.write_file_dyn (Path.relative dir file.name)));
 
-    let compile_info = Lib.DB.get_compile_info (Scope.libs scope) lib.name in
+    let compile_info =
+      Lib.DB.get_compile_info (Scope.libs scope) lib.name
+        ~allow_overlaps:lib.buildable.allow_overlapping_dependencies
+    in
     let requires, real_requires =
       SC.Libs.requires sctx compile_info
         ~dir ~has_dot_merlin:true
@@ -796,6 +799,7 @@ module Gen(P : Install_rules.Params) = struct
       Lib.DB.resolve_user_written_deps (Scope.libs scope)
         exes.buildable.libraries
         ~pps:(Jbuild.Preprocess_map.pps exes.buildable.preprocess)
+        ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
     in
     let requires, real_requires =
       SC.Libs.requires sctx ~dir

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -475,6 +475,7 @@ module Buildable = struct
     ; ocamlc_flags             : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags           : Ordered_set_lang.Unexpanded.t
     ; js_of_ocaml              : Js_of_ocaml.t
+    ; allow_overlapping_dependencies : bool
     }
 
   let modules_field name =
@@ -486,8 +487,6 @@ module Buildable = struct
     >>= fun preprocess ->
     field "preprocessor_deps" (list Dep_conf.t) ~default:[]
     >>= fun preprocessor_deps ->
-    (* CR-someday jdimino: remove this. There are still a few Jane Street packages using
-       this *)
     field "lint" Lint.t ~default:Lint.default
     >>= fun lint ->
     modules_field "modules"
@@ -499,7 +498,10 @@ module Buildable = struct
     field_oslu "flags"          >>= fun flags          ->
     field_oslu "ocamlc_flags"   >>= fun ocamlc_flags   ->
     field_oslu "ocamlopt_flags" >>= fun ocamlopt_flags ->
-    field "js_of_ocaml" (Js_of_ocaml.t) ~default:Js_of_ocaml.default >>= fun js_of_ocaml ->
+    field "js_of_ocaml" (Js_of_ocaml.t) ~default:Js_of_ocaml.default
+    >>= fun js_of_ocaml ->
+    field_b "allow_overlapping_dependencies"
+    >>= fun allow_overlapping_dependencies ->
     return
       { loc
       ; preprocess
@@ -512,6 +514,7 @@ module Buildable = struct
       ; ocamlc_flags
       ; ocamlopt_flags
       ; js_of_ocaml
+      ; allow_overlapping_dependencies
       }
 
   let single_preprocess t =
@@ -866,7 +869,8 @@ module Rule = struct
             return (fallback, mode))
            ~f:(function
              | true, Some _ ->
-               Error "Cannot use both (fallback) and (mode ...) at the same time.\n\
+               Error "Cannot use both (fallback) and (mode ...) at the \
+                      same time.\n\
                       (fallback) is the same as (mode fallback), \
                       please use the latter in new code."
              | false, Some mode -> Ok mode

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -143,6 +143,7 @@ module Buildable : sig
     ; ocamlc_flags             : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags           : Ordered_set_lang.Unexpanded.t
     ; js_of_ocaml              : Js_of_ocaml.t
+    ; allow_overlapping_dependencies : bool
     }
 
   (** Preprocessing specification used by all modules or [No_preprocessing] *)


### PR DESCRIPTION
Let's consider the following case:

- library `a` is part of the workspace
- `a` depends on `b` which is only installed
- `b` depends on `c` which is both installed and present in the workspace

before beta18, this was an error. In beta18 it isn't an error anymore, this allows in particular to lint Base without having to create a big workspace. However the new behavior is confusing for users, so we restore the pre-beta18 behavior by default and add an option `allow_soft_conflicts` to get the beta18 behavior.

