### PR TITLE
Move env var handling outside of Context.t

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -697,7 +697,7 @@ end
 type exec_context =
   { context : Context.t option
   ; purpose : Process.purpose
-  ; env     : string array
+  ; env     : Env.t
   }
 
 let exec_run_direct ~ectx ~dir ~env_extra ~stdout_to ~stderr_to prog args =
@@ -715,8 +715,9 @@ let exec_run_direct ~ectx ~dir ~env_extra ~stdout_to ~stderr_to prog args =
      invalid_prefix ("_build/" ^ target.name);
      invalid_prefix ("_build/install/" ^ target.name);
   end;
-  let env = Env.extend_env ~vars:env_extra ~env:ectx.env in
-  Process.run Strict ~dir:(Path.to_string dir) ~env ~stdout_to ~stderr_to
+  let env = Env.extend ectx.env ~vars:env_extra in
+  Process.run Strict ~dir:(Path.to_string dir) ~env:(Env.to_unix env)
+    ~stdout_to ~stderr_to
     ~purpose:ectx.purpose
     (Path.reach_for_running ~from:dir prog) args
 
@@ -892,7 +893,7 @@ and exec_list l ~ectx ~dir ~env_extra ~stdout_to ~stderr_to =
 let exec ~targets ?context t =
   let env =
     match (context : Context.t option) with
-    | None -> Lazy.force Env.initial_env
+    | None -> Env.initial ()
     | Some c -> c.env
   in
   let targets = Path.Set.to_list targets in

--- a/src/action.ml
+++ b/src/action.ml
@@ -716,7 +716,7 @@ let exec_run_direct ~ectx ~dir ~env_extra ~stdout_to ~stderr_to prog args =
      invalid_prefix ("_build/install/" ^ target.name);
   end;
   let env = Env.extend ectx.env ~vars:env_extra in
-  Process.run Strict ~dir:(Path.to_string dir) ~env:(Env.to_unix env)
+  Process.run Strict ~dir:(Path.to_string dir) ~env
     ~stdout_to ~stderr_to
     ~purpose:ectx.purpose
     (Path.reach_for_running ~from:dir prog) args

--- a/src/context.ml
+++ b/src/context.ml
@@ -123,9 +123,9 @@ let opam_config_var ~env ~cache var =
 let which ~cache ~path x =
   Hashtbl.find_or_add cache x ~f:(Bin.which ~path)
 
-let create ~(kind : Kind.t) ~path ~base_env ~env_extra ~name ~merlin
+let create ~(kind : Kind.t) ~path ~env_extra ~name ~merlin
       ~targets () =
-  let env = Env.extend base_env ~vars:env_extra in
+  let env = Env.extend (Env.initial ()) ~vars:env_extra in
   let opam_var_cache = Hashtbl.create 128 in
   (match kind with
    | Opam { root; _ } ->
@@ -346,13 +346,7 @@ let create ~(kind : Kind.t) ~path ~base_env ~env_extra ~name ~merlin
 let opam_config_var t var = opam_config_var ~env:t.env ~cache:t.opam_var_cache var
 
 let default ?(merlin=true) ~targets () =
-  let env = Env.initial () in
-  let path =
-    match Env.get_var env "PATH" with
-    | Some s -> Bin.parse_path s
-    | None -> []
-  in
-  create ~kind:Default ~path ~base_env:env ~env_extra:Env.Map.empty
+  create ~kind:Default ~path:Bin.path ~env_extra:Env.Map.empty
     ~name:"default" ~merlin ~targets ()
 
 let create_for_opam ?root ~targets ~switch ~name ?(merlin=false) () =
@@ -391,9 +385,8 @@ let create_for_opam ?root ~targets ~switch ~name ?(merlin=false) () =
       | None -> Bin.path
       | Some s -> Bin.parse_path s
     in
-    let env = Env.initial () in
     create ~kind:(Opam { root; switch }) ~targets
-      ~path ~base_env:env ~env_extra:vars ~name ~merlin ()
+      ~path ~env_extra:vars ~name ~merlin ()
 
 let create ?merlin def =
   match (def : Workspace.Context.t) with

--- a/src/context.ml
+++ b/src/context.ml
@@ -110,8 +110,7 @@ let opam_config_var ~env ~cache var =
     match Bin.opam with
     | None -> Fiber.return None
     | Some fn ->
-      Process.run_capture (Accept All) (Path.to_string fn)
-        ~env:(Env.to_unix env)
+      Process.run_capture (Accept All) (Path.to_string fn) ~env
         ["config"; "var"; var]
       >>| function
       | Ok s ->
@@ -146,7 +145,7 @@ let create ~(kind : Kind.t) ~path ~env_extra ~name ~merlin
       match Sys.getenv "OCAMLFIND_CONF" with
       | s -> Fiber.return (Path.absolute s)
       | exception Not_found ->
-        Process.run_capture_line ~env:(Env.to_unix env) Strict
+        Process.run_capture_line ~env Strict
           (Path.to_string fn) ["printconf"; "conf"]
         >>| Path.absolute)
   in
@@ -208,9 +207,7 @@ let create ~(kind : Kind.t) ~path ~env_extra ~name ~merlin
             | None -> args
             | Some s -> "-toolchain" :: s :: args
           in
-          Process.run_capture_lines
-            ~env:(Env.to_unix env)
-            Strict (Path.to_string fn) args
+          Process.run_capture_lines ~env Strict (Path.to_string fn) args
           >>| List.map ~f:Path.absolute
         | None ->
           (* If there no ocamlfind in the PATH, check if we have opam
@@ -233,7 +230,7 @@ let create ~(kind : Kind.t) ~path ~env_extra ~name ~merlin
     Fiber.fork_and_join
       findlib_path
       (fun () ->
-         Process.run_capture_lines ~env:(Env.to_unix env) Strict
+         Process.run_capture_lines ~env Strict
            (Path.to_string ocamlc) ["-config"]
          >>| fun lines ->
          let open Result.O in
@@ -409,7 +406,7 @@ let install_ocaml_libdir t =
     (* If ocamlfind is present, it has precedence over everything else. *)
     match which t "ocamlfind" with
     | Some fn ->
-      (Process.run_capture_line ~env:(Env.to_unix t.env) Strict
+      (Process.run_capture_line ~env:t.env Strict
          (Path.to_string fn) ["printconf"; "destdir"]
        >>| fun s ->
        Some (Path.absolute s))

--- a/src/context.ml
+++ b/src/context.ml
@@ -251,7 +251,7 @@ let create ~(kind : Kind.t) ~path ~env_extra ~name ~merlin
       && version >= (4, 03, 0)
       && version <  (4, 05, 0) then
         let value =
-          match Env.get_var env "OCAMLPARAM" with
+          match Env.get env "OCAMLPARAM" with
           | None -> "color=always,_"
           | Some s -> "color=always," ^ s
         in
@@ -274,7 +274,7 @@ let create ~(kind : Kind.t) ~path ~env_extra ~name ~merlin
       ; build_dir
       ; path
       ; toplevel_path =
-          Option.map (Env.get_var env "OCAML_TOPLEVEL_PATH") ~f:Path.absolute
+          Option.map (Env.get env "OCAML_TOPLEVEL_PATH") ~f:Path.absolute
 
       ; ocaml_bin  = dir
       ; ocaml      = (match which "ocaml" with Some p -> p | None -> prog_not_found_in_path "ocaml")
@@ -422,7 +422,7 @@ let env_for_exec t =
   let cwd = Sys.getcwd () in
   let extend_var var v =
     let v = Filename.concat cwd (Path.to_string v) in
-    match Env.get_var t.env var with
+    match Env.get t.env var with
     | None -> (var, v)
     | Some prev -> (var, sprintf "%s%c%s" v sep prev)
   in

--- a/src/context.mli
+++ b/src/context.mli
@@ -63,7 +63,7 @@ type t =
   ; ocamlmklib : Path.t
 
   ; (** Environment variables *)
-    env : string array
+    env : Env.t
 
   ; (** Diff between the base environment and [env] *)
     env_extra : string Env.Map.t

--- a/src/context.mli
+++ b/src/context.mli
@@ -30,13 +30,6 @@ module Kind : sig
   type t = Default | Opam of Opam.t
 end
 
-module Env_var : sig
-  type t = string
-  val compare : t -> t -> Ordering.t
-end
-
-module Env_var_map : Map.S with type key := Env_var.t
-
 type t =
   { name : string
   ; kind : Kind.t
@@ -73,7 +66,7 @@ type t =
     env : string array
 
   ; (** Diff between the base environment and [env] *)
-    env_extra : string Env_var_map.t
+    env_extra : string Env.Map.t
 
   ; findlib : Findlib.t
   ; findlib_toolchain : string option
@@ -135,16 +128,12 @@ val create
 
 val which : t -> string -> Path.t option
 
-val extend_env : vars:string Env_var_map.t -> env:string array -> string array
-
 val opam_config_var : t -> string -> string option Fiber.t
 
 val install_prefix : t -> Path.t Fiber.t
 val install_ocaml_libdir : t -> Path.t option Fiber.t
 
 val env_for_exec : t -> string array
-
-val initial_env : string array Lazy.t
 
 (** Return the compiler needed for this compilation mode *)
 val compiler : t -> Mode.t -> Path.t option

--- a/src/context.mli
+++ b/src/context.mli
@@ -65,9 +65,6 @@ type t =
   ; (** Environment variables *)
     env : Env.t
 
-  ; (** Diff between the base environment and [env] *)
-    env_extra : string Env.Map.t
-
   ; findlib : Findlib.t
   ; findlib_toolchain : string option
 

--- a/src/env.ml
+++ b/src/env.ml
@@ -55,7 +55,7 @@ let get_env_base env var =
   in
   loop 0
 
-let get_var t v =
+let get t v =
   match Map.find t.extra v with
   | None -> get_env_base t.base v
   | Some _ as v -> v

--- a/src/env.ml
+++ b/src/env.ml
@@ -1,9 +1,5 @@
 open Import
 
-let initial_env = lazy (
-  Lazy.force Colors.setup_env_for_colors;
-  Unix.environment ())
-
 module Var = struct
   type t = string
   let compare a b =
@@ -14,7 +10,39 @@ module Var = struct
 
 end
 
-let get_env env var =
+module Map = Map.Make(Var)
+
+type t =
+  { base : string array
+  ; extra : string Map.t
+  ; combined : string array Lazy.t
+  }
+
+let make ~base ~extra =
+  { base
+  ; extra
+  ; combined = lazy (
+      if Map.is_empty extra then
+        base
+      else
+        let imported =
+          Array.to_list base
+          |> List.filter ~f:(fun s ->
+            match String.index s '=' with
+            | None -> true
+            | Some i ->
+              let key = String.sub s ~pos:0 ~len:i in
+              not (Map.mem extra key))
+        in
+        List.rev_append
+          (List.map (Map.to_list extra)
+             ~f:(fun (k, v) -> sprintf "%s=%s" k v))
+          imported
+        |> Array.of_list
+    )
+  }
+
+let get_env_base env var =
   let rec loop i =
     if i = Array.length env then
       None
@@ -27,25 +55,28 @@ let get_env env var =
   in
   loop 0
 
-module Map = Map.Make(Var)
+let get_var t v =
+  match Map.find t.extra v with
+  | None -> get_env_base t.base v
+  | Some _ as v -> v
 
-let extend_env ~vars ~env =
-  if Map.is_empty vars then
-    env
-  else
-    let imported =
-      Array.to_list env
-      |> List.filter ~f:(fun s ->
-        match String.index s '=' with
-        | None -> true
-        | Some i ->
-          let key = String.sub s ~pos:0 ~len:i in
-          not (Map.mem vars key))
-    in
-    List.rev_append
-      (List.map (Map.to_list vars)
-         ~f:(fun (k, v) -> sprintf "%s=%s" k v))
-      imported
-    |> Array.of_list
+let to_unix t = Lazy.force t.combined
 
+let initial =
+  let i =
+    lazy (
+      make
+        ~base:(Lazy.force Colors.setup_env_for_colors;
+               Unix.environment ())
+        ~extra:Map.empty
+    ) in
+  fun () -> Lazy.force i
 
+let extend t ~vars =
+  make ~base:t.base
+    ~extra:(
+      Map.merge t.extra vars ~f:(fun _ v1 v2 ->
+        match v2 with
+        | Some _ -> v2
+        | None -> v1)
+    )

--- a/src/env.ml
+++ b/src/env.ml
@@ -80,3 +80,6 @@ let extend t ~vars =
         | Some _ -> v2
         | None -> v1)
     )
+
+let add t ~var ~value =
+  make ~base:t.base ~extra:(Map.add t.extra var value)

--- a/src/env.ml
+++ b/src/env.ml
@@ -1,0 +1,51 @@
+open Import
+
+let initial_env = lazy (
+  Lazy.force Colors.setup_env_for_colors;
+  Unix.environment ())
+
+module Var = struct
+  type t = string
+  let compare a b =
+    if Sys.win32 then
+      String.compare (String.lowercase a) (String.lowercase b)
+    else
+      String.compare a b
+
+end
+
+let get_env env var =
+  let rec loop i =
+    if i = Array.length env then
+      None
+    else
+      let entry = env.(i) in
+      match String.lsplit2 entry ~on:'=' with
+      | Some (key, value) when Var.compare key var = Eq ->
+        Some value
+      | _ -> loop (i + 1)
+  in
+  loop 0
+
+module Map = Map.Make(Var)
+
+let extend_env ~vars ~env =
+  if Map.is_empty vars then
+    env
+  else
+    let imported =
+      Array.to_list env
+      |> List.filter ~f:(fun s ->
+        match String.index s '=' with
+        | None -> true
+        | Some i ->
+          let key = String.sub s ~pos:0 ~len:i in
+          not (Map.mem vars key))
+    in
+    List.rev_append
+      (List.map (Map.to_list vars)
+         ~f:(fun (k, v) -> sprintf "%s=%s" k v))
+      imported
+    |> Array.of_list
+
+

--- a/src/env.ml
+++ b/src/env.ml
@@ -41,10 +41,18 @@ let of_unix arr =
   |> List.map ~f:(fun s ->
     match String.lsplit2 s ~on:'=' with
     | None ->
-      Sexp.code_error "Env.of_unix doesn't support env vars without '='"
+      Sexp.code_error "Env.of_unix: entry without '=' found in the environ"
         ["var", Sexp.To_sexp.string s]
     | Some (k, v) -> (k, v))
-  |> Map.of_list_exn
+  |> Map.of_list
+  |> function
+  | Ok x -> x
+  | Error (var, v1, v2) ->
+    Sexp.code_error "Env.of_unix: duplicated variable found in the environment"
+      [ "var"   , Sexp.To_sexp.string var
+      ; "value1", Sexp.To_sexp.string v1
+      ; "value2", Sexp.To_sexp.string v2
+      ]
 
 let initial =
   let i =

--- a/src/env.ml
+++ b/src/env.ml
@@ -2,11 +2,12 @@ open Import
 
 module Var = struct
   type t = string
-  let compare a b =
-    if Sys.win32 then
-      String.compare (String.lowercase a) (String.lowercase b)
-    else
-      String.compare a b
+  let compare =
+    if Sys.win32 then (
+      fun a b -> String.compare (String.lowercase a) (String.lowercase b)
+    ) else (
+      String.compare
+    )
 
   let equal a b =
     match compare a b with

--- a/src/env.ml
+++ b/src/env.ml
@@ -35,10 +35,7 @@ let make vars =
   }
 
 let get t k =
-  List.find_map t.vars ~f:(fun (k', v) ->
-    match Var.compare k k' with
-    | Ordering.Eq -> Some v
-    | _ -> None)
+  List.find_map t.vars ~f:(fun (k', v) -> Option.some_if (Var.equal k k') v)
 
 let to_unix t =
   match t.unix with

--- a/src/env.mli
+++ b/src/env.mli
@@ -18,3 +18,7 @@ val get : t -> Var.t -> string option
 val extend : t -> vars:string Map.t -> t
 
 val add : t -> var:Var.t -> value:string -> t
+
+val diff : t -> t -> t
+
+val sexp_of_t : t -> Sexp.t

--- a/src/env.mli
+++ b/src/env.mli
@@ -2,12 +2,17 @@ open Import
 
 module Var : sig
   type t = string
+  val compare : t -> t -> Ordering.t
 end
+
+type t
 
 module Map : Map.S with type key = Var.t
 
-val initial_env : string array Lazy.t
+val initial : unit -> t
 
-val extend_env : vars:string Map.t -> env:string array -> string array
+val to_unix : t -> string array
 
-val get_env : string array -> string -> string option
+val get_var : t -> Var.t -> string option
+
+val extend : t -> vars:string Map.t -> t

--- a/src/env.mli
+++ b/src/env.mli
@@ -13,6 +13,6 @@ val initial : unit -> t
 
 val to_unix : t -> string array
 
-val get_var : t -> Var.t -> string option
+val get : t -> Var.t -> string option
 
 val extend : t -> vars:string Map.t -> t

--- a/src/env.mli
+++ b/src/env.mli
@@ -1,0 +1,13 @@
+open Import
+
+module Var : sig
+  type t = string
+end
+
+module Map : Map.S with type key = Var.t
+
+val initial_env : string array Lazy.t
+
+val extend_env : vars:string Map.t -> env:string array -> string array
+
+val get_env : string array -> string -> string option

--- a/src/env.mli
+++ b/src/env.mli
@@ -16,3 +16,5 @@ val to_unix : t -> string array
 val get : t -> Var.t -> string option
 
 val extend : t -> vars:string Map.t -> t
+
+val add : t -> var:Var.t -> value:string -> t

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -148,7 +148,8 @@ end
            in
          ]}
       *)
-      Process.run Strict ~dir:(Path.to_string dir) ~env:context.env
+      Process.run Strict ~dir:(Path.to_string dir)
+        ~env:(Env.to_unix context.env)
         (Path.to_string context.ocaml)
         args
       >>= fun () ->

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -149,7 +149,7 @@ end
          ]}
       *)
       Process.run Strict ~dir:(Path.to_string dir)
-        ~env:(Env.to_unix context.env)
+        ~env:context.env
         (Path.to_string context.ocaml)
         args
       >>= fun () ->

--- a/src/process.ml
+++ b/src/process.ml
@@ -243,7 +243,7 @@ let run_internal ?dir ?(stdout_to=Terminal) ?(stderr_to=Terminal) ?env ~purpose
       Unix.create_process prog argv
         Unix.stdin stdout stderr
     | Some env ->
-      Unix.create_process_env prog argv env
+      Unix.create_process_env prog argv (Env.to_unix env)
         Unix.stdin stdout stderr
   in
   let pid =

--- a/src/process.mli
+++ b/src/process.mli
@@ -41,7 +41,7 @@ val run
   :  ?dir:string
   -> ?stdout_to:std_output_to
   -> ?stderr_to:std_output_to
-  -> ?env:string array
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (unit, 'a) failure_mode
   -> string
@@ -51,7 +51,7 @@ val run
 (** Run a command and capture its output *)
 val run_capture
   :  ?dir:string
-  -> ?env:string array
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (string, 'a) failure_mode
   -> string
@@ -59,7 +59,7 @@ val run_capture
   -> 'a Fiber.t
 val run_capture_line
   :  ?dir:string
-  -> ?env:string array
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (string, 'a) failure_mode
   -> string
@@ -67,7 +67,7 @@ val run_capture_line
   -> 'a Fiber.t
 val run_capture_lines
   :  ?dir:string
-  -> ?env:string array
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (string list, 'a) failure_mode
   -> string


### PR DESCRIPTION
Extracted from my bisect PR. The environment handling is moved to its own module to hide the complexity of handling both forms of an env map. I'm not sure if the laziness is even necessary btw, seems like having a `type t = string array` should be good enough for most cases.