### PR TITLE
Move Io to stdune

### DIFF
--- a/src/configurator/configurator.ml
+++ b/src/configurator/configurator.ml
@@ -1,7 +1,6 @@
 open Stdune
 let sprintf = Printf.sprintf
 let eprintf = Printf.eprintf
-module Io = Jbuilder.Io
 
 let ( ^/ ) = Filename.concat
 

--- a/src/configurator/jbuild
+++ b/src/configurator/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name configurator)
   (flags (:standard -safe-string))
-  (libraries (jbuilder stdune))
+  (libraries (stdune ocaml_config))
   (preprocess no_preprocessing)))
 
 (jbuild_version 1)

--- a/src/stdune/io.ml
+++ b/src/stdune/io.ml
@@ -1,5 +1,3 @@
-open Import
-
 module P = Pervasives
 
 let open_in ?(binary=true) fn =
@@ -12,10 +10,10 @@ let close_in  = close_in
 let close_out = close_out
 
 let with_file_in ?binary fn ~f =
-  protectx (open_in ?binary fn) ~finally:close_in ~f
+  Exn.protectx (open_in ?binary fn) ~finally:close_in ~f
 
 let with_file_out ?binary fn ~f =
-  protectx (open_out ?binary fn) ~finally:close_out ~f
+  Exn.protectx (open_out ?binary fn) ~finally:close_out ~f
 
 let with_lexbuf_from_file fn ~f =
   with_file_in fn ~f:(fun ic ->
@@ -68,10 +66,10 @@ let copy_channels =
 let copy_file ~src ~dst =
   with_file_in src ~f:(fun ic ->
     let perm = (Unix.fstat (Unix.descr_of_in_channel ic)).st_perm in
-    protectx (P.open_out_gen
-                [Open_wronly; Open_creat; Open_trunc; Open_binary]
-                perm
-                dst)
+    Exn.protectx (P.open_out_gen
+                    [Open_wronly; Open_creat; Open_trunc; Open_binary]
+                    perm
+                    dst)
       ~finally:close_out
       ~f:(fun oc ->
         copy_channels ic oc))

--- a/src/stdune/io.mli
+++ b/src/stdune/io.mli
@@ -1,7 +1,5 @@
 (** IO operations *)
 
-open Stdune
-
 val open_in  : ?binary:bool (* default true *) -> string -> in_channel
 val open_out : ?binary:bool (* default true *) -> string -> out_channel
 

--- a/src/stdune/jbuild
+++ b/src/stdune/jbuild
@@ -1,4 +1,4 @@
 (library
  ((name stdune)
   (synopsis "Standard library of Dune")
-  (libraries (caml))))
+  (libraries (caml unix))))

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -15,6 +15,7 @@ module Result     = Result
 module Set        = Set
 module Staged     = Staged
 module String     = String
+module Io         = Io
 
 external reraise : exn -> _ = "%reraise"
 


### PR DESCRIPTION
This allows configurator to drop the dependency on jbuilder itself. Unless the goal is to make stdune without IO, I don't see downsides.