### PR TITLE
Add rule to generate findlib.conf per context

### DIFF
--- a/src/bin.mli
+++ b/src/bin.mli
@@ -1,5 +1,7 @@
 (** OCaml binaries *)
 
+val path_sep : char
+
 (** Contents of [PATH] *)
 val path : Path.t list
 


### PR DESCRIPTION
This isn't for merging, more like just an experiment to see how we can address some issues with testing. There are 2 issues I'd like to solve:

1) Make it easier to test local packages like configurator in our blackbox tests. Currently, configurator is completely unavailable to our black box tests.

2) Make it easier to test the classical ppx/findlib pipelines. It would be nice to build some jbuilder created packages using findlib. Especially with ppx, so that we can test our compatibility pipeline.

This PR sketches an idea how such a thing might work. We could generate a findlib.conf for every context use this file in conjunction with `OCAMLFIND_CONF`. This will make our local packages available as if they're normal findlib packages.

The approach here has some issues however:

1) We end up exposing all the dependencies in a particular switch when we append its path. It would be really nice if this was more controlled and we only exposed the transitive closure of a few dependencies that we choose.

2) We get duplicate package warnings like this:

```
findlib: [WARNING] Package jbuilder has multiple definitions in /Users/rgrinberg/reps/dune/_build/install/default/lib/jbuilder/META, /Users/rgrinberg/.opam/4.05.0/lib/jbuilder/META
```

At the moment, I'm not sure how harmful they are. But it would be nice to a bit more explicit about the packages that we choose.