### PR TITLE
Doc related fixes

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -104,7 +104,7 @@ module Gen(P : Install_rules.Params) = struct
              \n\
              \nThis will become an error in the future."
             (let tag = Sexp.unsafe_atom_of_string
-                       "modules_without_implementation" in
+                         "modules_without_implementation" in
              Sexp.to_string (List [ tag
                                   ; Sexp.To_sexp.(list string) should_be_listed
                                   ]))

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -22,22 +22,29 @@ module type Key = sig
   module Map : Map.S with type key = t
 end
 
-module Make(Key : Key)(Value : Value with type key = Key.t) : sig
-  (** Evaluate an ordered set. [standard] is the interpretation of [:standard] inside the
-      DSL. *)
+module type S = sig
+  (** Evaluate an ordered set. [standard] is the interpretation of [:standard]
+      inside the DSL. *)
+  type value
+  type 'a map
+
   val eval
     :  t
-    -> parse:(loc:Loc.t -> string -> Value.t)
-    -> standard:Value.t list
-    -> Value.t list
+    -> parse:(loc:Loc.t -> string -> value)
+    -> standard:value list
+    -> value list
 
   (** Same as [eval] but the result is unordered *)
   val eval_unordered
     :  t
-    -> parse:(loc:Loc.t -> string -> Value.t)
-    -> standard:Value.t Key.Map.t
-    -> Value.t Key.Map.t
+    -> parse:(loc:Loc.t -> string -> value)
+    -> standard:value map
+    -> value map
 end
+
+module Make(Key : Key)(Value : Value with type key = Key.t)
+  : S with type value = Value.t
+       and type 'a map = 'a Key.Map.t
 
 val standard : t
 val is_standard : t -> bool
@@ -63,3 +70,5 @@ module Unexpanded : sig
     -> f:(String_with_vars.t -> string)
     -> expanded
 end with type expanded := t
+
+module String : S with type value = string and type 'a map = 'a String_map.t

--- a/src/scope.mli
+++ b/src/scope.mli
@@ -12,7 +12,7 @@ val info : t -> Jbuild.Scope_info.t
 val libs : t -> Lib.DB.t
 
 (** Scope databases *)
- module DB : sig
+module DB : sig
   type scope = t
 
   type t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -669,16 +669,6 @@ module Action = struct
     | fail :: _ -> Build.fail fail >>> build
 end
 
-module Eval_strings = Ordered_set_lang.Make(struct
-    type t = string
-    let compare = String.compare
-    module Map = String_map
-  end)(struct
-    type t = string
-    type key = string
-    let key x = x
-  end)
-
 let expand_and_eval_set t ~scope ~dir ?extra_vars set ~standard =
   let open Build.O in
   let f = expand_vars t ~scope ~dir ?extra_vars in
@@ -688,11 +678,11 @@ let expand_and_eval_set t ~scope ~dir ?extra_vars set ~standard =
     let set =
       Ordered_set_lang.Unexpanded.expand set ~files_contents:String_map.empty ~f
     in
-    Build.return (Eval_strings.eval set ~standard ~parse)
+    Build.return (Ordered_set_lang.String.eval set ~standard ~parse)
   | files ->
     let paths = List.map files ~f:(Path.relative dir) in
     Build.all (List.map paths ~f:Build.read_sexp)
     >>^ fun sexps ->
     let files_contents = List.combine files sexps |> String_map.of_list_exn in
     let set = Ordered_set_lang.Unexpanded.expand set ~files_contents ~f in
-    Eval_strings.eval set ~standard ~parse
+    Ordered_set_lang.String.eval set ~standard ~parse


### PR DESCRIPTION
Little fixes from my odoc PR. If the duplication of signatures in Ordered_set_lang is long in the tooth, we can always create an `_intf` module.