### PR TITLE
Move they '@' scope encoding to common module

### DIFF
--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -111,14 +111,7 @@ let gen_rules sctx components =
   match components with
   | [key] ->
     let exe = ppx_exe sctx ~key in
-    let (key, lib_db) =
-      match String.rsplit2 key ~on:'@' with
-      | None ->
-        (key, SC.public_libs sctx)
-      | Some (key, scope) ->
-        (key, Scope.libs (SC.find_scope_by_name sctx
-                            (Scope_info.Name.of_string scope)))
-    in
+    let (key, lib_db) = SC.Scope_key.of_string sctx key in
     let names =
       match key with
       | "+none+" -> []
@@ -183,8 +176,7 @@ let get_ppx_driver sctx ~scope pps =
   let key =
     match db with
     | Installed | Public -> key
-    | Private scope_name ->
-      sprintf "%s@%s" key (Scope_info.Name.to_string scope_name)
+    | Private scope_name -> SC.Scope_key.to_string key scope_name
   in
   let sctx = SC.host sctx in
   ppx_exe sctx ~key

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -370,6 +370,19 @@ module Pkg_version = struct
     Build.vpath spec
 end
 
+module Scope_key = struct
+  let of_string sctx key =
+    match String.rsplit2 key ~on:'@' with
+    | None ->
+      (key, public_libs sctx)
+    | Some (key, scope) ->
+      ( key
+      , Scope.libs (find_scope_by_name sctx (Scope_info.Name.of_string scope)))
+
+  let to_string key scope =
+    sprintf "%s@%s" key (Scope_info.Name.to_string scope)
+end
+
 let parse_bang var : bool * string =
   let len = String.length var in
   if len > 0 && var.[0] = '!' then

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -197,3 +197,9 @@ end
 module Pkg_version : sig
   val set : t -> Package.t -> (unit, string option) Build.t -> (unit, string option) Build.t
 end
+
+module Scope_key : sig
+  val of_string : t -> string -> string * Lib.DB.t
+
+  val to_string : string -> Scope_info.Name.t -> string
+end


### PR DESCRIPTION
This encoding will also be used by odoc so it's best to share it