### PR TITLE
Tweaks to Actions

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -49,6 +49,7 @@ let set_common c ~targets =
       ]
 
 let restore_cwd_and_execve common prog argv env =
+  let env = Env.to_unix env in
   let prog =
     if Filename.is_relative prog then
       Filename.concat common.root prog

--- a/src/action.ml
+++ b/src/action.ml
@@ -888,7 +888,7 @@ and exec_list l ~ectx ~dir ~env ~stdout_to ~stderr_to =
     exec t ~ectx ~dir ~env ~stdout_to ~stderr_to >>= fun () ->
     exec_list rest ~ectx ~dir ~env ~stdout_to ~stderr_to
 
-let exec ~targets ?context t =
+let exec ~targets ~context t =
   let env =
     match (context : Context.t option) with
     | None -> Env.initial ()

--- a/src/action.mli
+++ b/src/action.mli
@@ -112,7 +112,7 @@ module Unexpanded : sig
     -> Partial.t
 end
 
-val exec : targets:Path.Set.t -> ?context:Context.t -> t -> unit Fiber.t
+val exec : targets:Path.Set.t -> context:Context.t option -> t -> unit Fiber.t
 
 (* Return a sandboxed version of an action *)
 val sandbox

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -191,7 +191,7 @@ module Rule = struct
     }
 
   let make ?(sandbox=false) ?(mode=Jbuild.Rule.Mode.Not_a_rule_stanza)
-        ?context ?(locks=[]) ?loc build =
+        ~context ?(locks=[]) ?loc build =
     let targets = targets build in
     let dir =
       match targets with

--- a/src/build_interpret.mli
+++ b/src/build_interpret.mli
@@ -25,7 +25,7 @@ module Rule : sig
   val make
     :  ?sandbox:bool
     -> ?mode:Jbuild.Rule.Mode.t
-    -> ?context:Context.t
+    -> context:Context.t option
     -> ?locks:Path.t list
     -> ?loc:Loc.t
     -> (unit, Action.t) Build.t

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -140,6 +140,7 @@ module Alias : sig
   val add_action
     :  build_system
     -> t
+    -> context:Context.t
     -> ?locks:Path.t list
     -> stamp:Sexp.t
     -> (unit, Action.t) Build.t

--- a/src/context.ml
+++ b/src/context.ml
@@ -433,7 +433,7 @@ let env_for_exec t =
         (Config.local_install_man_dir ~context:t.name)
     ]
   in
-  Env.to_unix (Env.extend t.env ~vars:(Env.Map.of_list_exn vars))
+  Env.extend t.env ~vars:(Env.Map.of_list_exn vars)
 
 let compiler t (mode : Mode.t) =
   match mode with

--- a/src/context.mli
+++ b/src/context.mli
@@ -130,7 +130,7 @@ val opam_config_var : t -> string -> string option Fiber.t
 val install_prefix : t -> Path.t Fiber.t
 val install_ocaml_libdir : t -> Path.t option Fiber.t
 
-val env_for_exec : t -> string array
+val env_for_exec : t -> Env.t
 
 (** Return the compiler needed for this compilation mode *)
 val compiler : t -> Mode.t -> Path.t option

--- a/src/env.ml
+++ b/src/env.ml
@@ -69,6 +69,9 @@ let add t ~var ~value =
 let extend t ~vars =
   make (Map.union t.vars vars ~f:(fun _ _ v -> Some v))
 
+let extend_env x y =
+  extend x ~vars:y.vars
+
 let sexp_of_t t =
   let open Sexp.To_sexp in
   (list (pair string string)) (Map.to_list t.vars)

--- a/src/env.mli
+++ b/src/env.mli
@@ -17,6 +17,8 @@ val get : t -> Var.t -> string option
 
 val extend : t -> vars:string Map.t -> t
 
+val extend_env : t -> t -> t
+
 val add : t -> var:Var.t -> value:string -> t
 
 val diff : t -> t -> t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -227,7 +227,7 @@ let add_alias_deps t alias deps =
   Alias.add_deps t.build_system alias deps
 
 let add_alias_action t alias ?locks ~stamp action =
-  Alias.add_action t.build_system alias ?locks ~stamp action
+  Alias.add_action t.build_system ~context:t.context alias ?locks ~stamp action
 
 let eval_glob t ~dir re = Build_system.eval_glob t.build_system ~dir re
 let load_dir t ~dir = Build_system.load_dir t.build_system ~dir

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -209,13 +209,13 @@ let add_rule t ?sandbox ?mode ?locks ?loc build =
   let build = Build.O.(>>>) build t.chdir in
   Build_system.add_rule t.build_system
     (Build_interpret.Rule.make ?sandbox ?mode ?locks ?loc
-       ~context:t.context build)
+       ~context:(Some t.context) build)
 
 let add_rule_get_targets t ?sandbox ?mode ?locks ?loc build =
   let build = Build.O.(>>>) build t.chdir in
   let rule =
     Build_interpret.Rule.make ?sandbox ?mode ?locks ?loc
-      ~context:t.context build
+      ~context:(Some t.context) build
   in
   Build_system.add_rule t.build_system rule;
   List.map rule.targets ~f:Build_interpret.Target.path


### PR DESCRIPTION
This is work extracted from my branch that allows users to run actions in the installed environment.

The first commit gets rid of passing the context optionally. I find that it's hard to debug why the context is missing when we aren't passing it explicitly. Now, it's much easier to grep for `~context:` and see what's happening to the flow.

The last commit makes the context available for all alias actions. This will be useful because we must know which context are we in to run in something in the installed env of that context.