### PR TITLE
New action constructor running in installed environment

### DIFF
--- a/src/action.mli
+++ b/src/action.mli
@@ -132,6 +132,7 @@ module Infer : sig
     type t =
       { deps    : Path.Set.t
       ; targets : Path.Set.t
+      ; aliases : String_set.t
       }
   end
 

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -22,6 +22,7 @@ module type Ast = sig
 
   type t =
     | Run            of program * string list
+    | Install_run    of program * string list
     | Chdir          of path * t
     | Setenv         of string * string * t
     | Redirect       of Outputs.t * path * t

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -440,3 +440,13 @@
      (progn
       (run ${exe:cram.exe} run.t)
       (diff? run.t run.t.corrected)))))))
+
+(alias
+ ((name runtest)
+  (deps ((files_recursively_in test-cases/install-run)))
+  (action
+   (chdir test-cases/install-run
+    (setenv JBUILDER ${bin:jbuilder}
+     (progn
+      (run ${exe:cram.exe} run.t)
+      (diff? run.t run.t.corrected)))))))

--- a/test/blackbox-tests/test-cases/install-run/bar.ml
+++ b/test/blackbox-tests/test-cases/install-run/bar.ml
@@ -1,0 +1,1 @@
+print_endline "bar";

--- a/test/blackbox-tests/test-cases/install-run/foo.ml
+++ b/test/blackbox-tests/test-cases/install-run/foo.ml
@@ -1,0 +1,3 @@
+
+let () =
+  ignore (Sys.command "bar")

--- a/test/blackbox-tests/test-cases/install-run/jbuild
+++ b/test/blackbox-tests/test-cases/install-run/jbuild
@@ -1,0 +1,18 @@
+(jbuild_version 1)
+
+(executable
+ ((name bar)
+  (public_name bar)
+  (package foo)
+  (modules (bar))))
+
+(executable
+ ((name foo)
+  (public_name foo)
+  (package foo)
+  (modules (foo))
+  (libraries (unix))))
+
+(alias
+ ((name runtest)
+  (action (install-run ./foo.exe))))

--- a/test/blackbox-tests/test-cases/install-run/run.t
+++ b/test/blackbox-tests/test-cases/install-run/run.t
@@ -1,0 +1,11 @@
+  $ $JBUILDER runtest -j1 --display short --root .
+      ocamldep foo.ml.d
+        ocamlc .foo.eobjs/foo.{cmi,cmo,cmt}
+      ocamlopt .foo.eobjs/foo.{cmx,o}
+      ocamlopt foo.exe
+      ocamldep bar.ml.d
+        ocamlc .bar.eobjs/bar.{cmi,cmo,cmt}
+      ocamlopt .bar.eobjs/bar.{cmx,o}
+      ocamlopt bar.exe
+           foo alias runtest
+  bar


### PR DESCRIPTION
Here's a very simple prototype that addresses the issues raised in #614. We should be able to compile things using `$ jbuilder exec ocamlfind ...`. The idea isn't fully baked so I haven't tried very hard to make a decent implementation. The main issue that needs to be addressed:

How to depend on less than the entire install. As a starter, it would be better to depend on `@install` in the current scope I suppose. But ideally it would be nice to depend on which libraries/binaries we want. But depending on the entire scope is still useful. For use cases such as @stedolan's use case.

That being said, I'd welcome comments about the implementation as well. I'm not really sure about how to add the dependency on `@install` alias in a clean way. I can't even refer to aliases in `Action` as it would introduce a circular dependency. In the old alias system, those were independent of the build_system, so that was a bit better. But anyway, there's probably different ways of addressing this.