### PR TITLE
Extend backend tests to track the dune.sexp file generated

### DIFF
--- a/src/usexp/usexp.ml
+++ b/src/usexp/usexp.ml
@@ -17,7 +17,7 @@ module Atom = struct
 
  let is_valid str =
    let len = String.length str in
-   len = 0 ||
+   len > 0 &&
    let rec loop ix =
      match str.[ix] with
      | '"' | '(' | ')' | ';' | '\\' -> true

--- a/src/usexp/usexp.ml
+++ b/src/usexp/usexp.ml
@@ -21,8 +21,8 @@ module Atom = struct
    let rec loop ix =
      match str.[ix] with
      | '"' | '(' | ')' | ';' | '\\' -> true
-     | '|' -> ix > 0 && let next = ix - 1 in Char.equal str.[next] '#' || loop next
-     | '#' -> ix > 0 && let next = ix - 1 in Char.equal str.[next] '|' || loop next
+     | '|' -> ix > 0 && let next = ix - 1 in str.[next] = '#' || loop next
+     | '#' -> ix > 0 && let next = ix - 1 in str.[next] = '|' || loop next
      | '\000' .. '\032' | '\127' .. '\255' -> true
      | _ -> ix > 0 && loop (ix - 1)
    in

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -2,8 +2,8 @@
 
 module Atom : sig
   type t = private A of string [@@unboxed]
-  (** Acceptable atoms are composed of chars in the range [' ' .. '~']
-     and must be nonempty. *)
+  (** Acceptable atoms are composed of chars in the range ['!' .. '~'] excluding
+      [' ' '"' '(' ')' ';' '\\'], and must be nonempty. *)
 
   val is_valid : string -> bool
   (** [is_valid s] checks that [s] respects the constraints to be an atom. *)

--- a/test/blackbox-tests/test-cases/inline_tests/dune-file/jbuild
+++ b/test/blackbox-tests/test-cases/inline_tests/dune-file/jbuild
@@ -3,7 +3,7 @@
   (public_name foo)
   (modules ())
   (inline_tests.backend
-   ((runner_libraries (ppx_inline_test.runner.lib))
+   ((runner_libraries (str))
     (generate_runner
      (progn
       (echo "let () = print_int 41")

--- a/test/blackbox-tests/test-cases/inline_tests/dune-file/jbuild
+++ b/test/blackbox-tests/test-cases/inline_tests/dune-file/jbuild
@@ -1,0 +1,26 @@
+(library
+ ((name foo)
+  (public_name foo)
+  (modules ())
+  (inline_tests.backend
+   ((runner_libraries (ppx_inline_test.runner.lib))
+    (generate_runner
+     (progn
+      (echo "let () = print_int 41")
+      (echo "\n")
+      (echo "let () = print_int 42")
+      (echo "\n")
+      (echo "let () = print_int 43;;")))
+    (flags (inline-test-runner ${library-name}
+             -source-tree-root ${ROOT} -diff-cmd -))))))
+
+(library
+ ((name foo_tests)
+  (inline_tests ((backend foo)))))
+
+(alias
+ ((name runtest)
+  (deps (foo.dune))
+  (action (echo "${read:foo.dune}"))))
+
+(jbuild_version 1)

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -25,7 +25,7 @@
    1
    ((inline_tests.backend
      1.0
-     ((runner_libraries (ppx_inline_test.runner.lib))
+     ((runner_libraries (str))
       (flags
        (inline-test-runner
         ${library-name}

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -19,3 +19,27 @@
   $ $JBUILDER runtest many-backends-choose -j1 --display quiet --root .
            run alias many-backends-choose/runtest
   backend_mbc1
+
+  $ $JBUILDER runtest dune-file -j1 --display quiet --root .
+  (dune
+   1
+   ((inline_tests.backend
+     1.0
+     ((runner_libraries (ppx_inline_test.runner.lib))
+      (flags
+       (inline-test-runner
+        ${library-name}
+        -source-tree-root
+        ${ROOT}
+        -diff-cmd
+        -))
+      (generate_runner
+       ((progn
+         (echo let () = print_int 41)
+         (echo "\n")
+         (echo let () = print_int 42)
+         (echo "\n")
+         (echo let () = print_int 43;;))))
+      (extends ())))))
+           run alias dune-file/runtest
+  414243

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -35,11 +35,11 @@
         -))
       (generate_runner
        ((progn
-         (echo let () = print_int 41)
+         (echo "let () = print_int 41")
          (echo "\n")
-         (echo let () = print_int 42)
+         (echo "let () = print_int 42")
          (echo "\n")
-         (echo let () = print_int 43;;))))
+         (echo "let () = print_int 43;;"))))
       (extends ())))))
            run alias dune-file/runtest
   414243

--- a/test/unit-tests/jbuild
+++ b/test/unit-tests/jbuild
@@ -9,6 +9,15 @@
 
 (ocamllex (expect_test))
 
+(executable
+ ((name sexp_tests)
+  (modules (sexp_tests))
+  (libraries (stdune usexp))))
+
+(alias
+ ((name runtest)
+  (action (run ./sexp_tests.exe))))
+
 (alias
  ((name runtest)
   (deps (tests.mlt

--- a/test/unit-tests/sexp_tests.ml
+++ b/test/unit-tests/sexp_tests.ml
@@ -18,12 +18,27 @@ let () =
         | Atom (_, A s') -> s = s'
         | _              -> false
       in
-      if Usexp.Atom.is_valid s && not parser_recognizes_as_atom then begin
+      let printed_as_atom =
+        match Usexp.atom_or_quoted_string s with
+        | Atom _ -> true
+        | _      -> false
+      in
+      if Usexp.Atom.is_valid s <> parser_recognizes_as_atom then begin
         Printf.eprintf
           "Usexp.Atom.is_valid error:\n\
            - s = %S\n\
-           - Usexp.Atom.is_Valid s = %B\n"
-          s (Usexp.Atom.is_valid s);
+           - Usexp.Atom.is_valid s = %B\n\
+           - parser_recognizes_as_atom = %B\n"
+          s (Usexp.Atom.is_valid s) parser_recognizes_as_atom;
+        exit 1
+      end;
+      if printed_as_atom && not parser_recognizes_as_atom then begin
+        Printf.eprintf
+          "Usexp.Atom.atom_or_quoted_string error:\n\
+           - s = %S\n\
+           - printed_as_atom = %B\n\
+           - parser_recognizes_as_atom = %B\n"
+          s printed_as_atom parser_recognizes_as_atom;
         exit 1
       end
     done

--- a/test/unit-tests/sexp_tests.ml
+++ b/test/unit-tests/sexp_tests.ml
@@ -1,0 +1,30 @@
+open! Stdune
+
+let () = Printexc.record_backtrace true
+
+(* Test that all strings of length <= 3 such that [Usexp.Atom.is_valid
+   s] are recignized as atoms by the parser *)
+let () =
+  for len = 0 to 3 do
+    let s = Bytes.create len in
+    for i = 0 to 1 lsl (len * 8) - 1 do
+      if len > 0 then Bytes.set s 0 (Char.chr ( i        land 0xff));
+      if len > 1 then Bytes.set s 1 (Char.chr ((i lsr 4) land 0xff));
+      if len > 2 then Bytes.set s 2 (Char.chr ((i lsr 8) land 0xff));
+      let s = Bytes.unsafe_to_string s in
+      let parser_recognizes_as_atom =
+        match Usexp.parse_string ~fname:"" ~mode:Single s with
+        | exception _    -> false
+        | Atom (_, A s') -> s = s'
+        | _              -> false
+      in
+      if Usexp.Atom.is_valid s && not parser_recognizes_as_atom then begin
+        Printf.eprintf
+          "Usexp.Atom.is_valid error:\n\
+           - s = %S\n\
+           - Usexp.Atom.is_Valid s = %B\n"
+          s (Usexp.Atom.is_valid s);
+        exit 1
+      end
+    done
+  done


### PR DESCRIPTION
The test in this PR shows that while the backends ends up being read and correctly interpreted, the generated .dune file incorrectly escapes the action field.

This problem seems to be present when serializing anything that might incorrectly interpreted as an Atom. A fix seems to be using a more robust check for valid atoms and restricting them to include comment characters, spaces, etc.

Here's one such valid function https://github.com/janestreet/sexplib0/blob/e4b0084877eb79e84c90afd14c07aff34ef619a4/sexp.ml#L60

cc @trefis @xclerc 