### PR TITLE
Fix encoding of inline_tests

### DIFF
--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -89,14 +89,13 @@ module Backend = struct
       let lib x = string (Lib.name x) in
       let f x = string (Lib.name x.lib) in
       ((1, 0),
-       record
-         [ "runner_libraries", list lib (Result.ok_exn t.runner_libraries)
-         ; "flags"           , Ordered_set_lang.Unexpanded.sexp_of_t
-                                 t.info.flags
-         ; "generate_runner" , option Action.Unexpanded.sexp_of_t
-                                 t.info.generate_runner
-         ; "extends"         , option (list f)
-                                 (Option.map t.extends ~f:Result.ok_exn)
+       record_fields
+         [ field "runner_libraries" (list lib)
+             (Result.ok_exn t.runner_libraries)
+         ; field "flags" Ordered_set_lang.Unexpanded.sexp_of_t t.info.flags
+         ; field_o "generate_runner" Action.Unexpanded.sexp_of_t
+             t.info.generate_runner
+         ; field_o "extends" (list f) (Option.map t.extends ~f:Result.ok_exn)
          ])
   end
   include M

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -104,6 +104,15 @@ module To_sexp = struct
     string_map f
       (Hashtbl.foldi h ~init:String_map.empty ~f:(fun key data acc ->
          String_map.add acc key data))
+
+  type field = string * Usexp.t option
+
+  let field name f v = (name, Some (f v))
+  let field_o name f v = (name, Option.map ~f v)
+
+  let record_fields (l : field list) =
+    List (List.filter_map l ~f:(fun (k, v) ->
+      Option.map v ~f:(fun v -> List[Atom (Atom.of_string k); v])))
 end
 
 module Of_sexp = struct

--- a/src/sexp.mli
+++ b/src/sexp.mli
@@ -46,6 +46,13 @@ module To_sexp : sig
   include Combinators with type 'a t = 'a -> t
 
   val record : (string * sexp) list -> sexp
+
+  type field
+
+  val field : string -> 'a t -> 'a -> field
+  val field_o : string -> 'a t-> 'a option -> field
+
+  val record_fields : field list t
 end with type sexp := t
 
 module Of_sexp : sig

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -34,12 +34,11 @@
         -diff-cmd
         -))
       (generate_runner
-       ((progn
-         (echo "let () = print_int 41")
-         (echo "\n")
-         (echo "let () = print_int 42")
-         (echo "\n")
-         (echo "let () = print_int 43;;"))))
-      (extends ())))))
+       (progn
+        (echo "let () = print_int 41")
+        (echo "\n")
+        (echo "let () = print_int 42")
+        (echo "\n")
+        (echo "let () = print_int 43;;")))))))
            run alias dune-file/runtest
   414243


### PR DESCRIPTION
Encode optional fields as records where optional keys that are None will be
omitted in the resultant sexp. This will match reading the keys back with field_o