### PR TITLE
Tweak order in Map.of_list error

### DIFF
--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -78,8 +78,8 @@ module Make(Key : Comparable.S) : S with type key = Key.t = struct
       | [] -> Result.Ok acc
       | (k, v) :: l ->
         match find acc k with
-        | None    -> loop (add acc k v) l
-        | Some v' -> Error (k, v, v')
+        | None       -> loop (add acc k v) l
+        | Some v_old -> Error (k, v_old, v)
     in
     fun l -> loop empty l
 


### PR DESCRIPTION
We should show the key that came earlier in the list first. The error in #638 confused me initially.