### PR TITLE
Change Meta.load to return the simplified meta

### DIFF
--- a/src/import.ml
+++ b/src/import.ml
@@ -11,7 +11,14 @@ let ksprintf = Printf.ksprintf
 let initial_cwd = Sys.getcwd ()
 
 module String_set = Set.Make(String)
-module String_map = Map.Make(String)
+module String_map = struct
+  include Map.Make(String)
+
+  let pp f fmt t =
+    Format.pp_print_list (fun fmt (k, v) ->
+      Format.fprintf fmt "@[<hov 2>(%s@ =@ %a)@]" k f v
+    ) fmt (to_list t)
+end
 
 module Int_set = Set.Make(Int)
 module Int_map = Map.Make(Int)

--- a/src/meta.mli
+++ b/src/meta.mli
@@ -25,8 +25,6 @@ and predicate =
   | Pos of string
   | Neg of string
 
-val load : string -> entry list
-
 module Simplified : sig
   module Rules : sig
     type t =
@@ -42,10 +40,10 @@ module Simplified : sig
     }
 end
 
-val simplify : t -> Simplified.t
+val load : fn:string -> name:string -> Simplified.t
 
 (** Builtin META files for libraries distributed with the compiler. For when ocamlfind is
     not installed. *)
-val builtins : stdlib_dir:Path.t -> t String_map.t
+val builtins : stdlib_dir:Path.t -> Simplified.t String_map.t
 
 val pp : Format.formatter -> entry list -> unit

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -10,6 +10,7 @@ let print_pkg ppf pkg =
 ;;
 
 #install_printer print_pkg;;
+#install_printer String_map.pp;;
 
 [%%expect{|
 val print_pkg : Format.formatter -> Jbuilder.Findlib.Package.t -> unit =
@@ -50,16 +51,19 @@ Findlib.Package.requires pkg;;
 open Meta
 
 let meta =
-  { name = "foo"
-  ; entries = Meta.load "test/unit-tests/findlib-db/foo/META"
-  }
+  Meta.load ~name:"foo" ~fn:"test/unit-tests/findlib-db/foo/META"
 
 [%%expect{|
-val meta : Jbuilder.Meta.t =
-  {name = "foo";
-   entries =
-    [Rule {var = "requires"; predicates = []; action = Set; value = "bar"};
-     Rule
-      {var = "requires"; predicates = [Pos "ppx_driver"]; action = Set;
-       value = "baz"}]}
+val meta : Jbuilder.Meta.Simplified.t =
+  {Jbuilder.Meta.Simplified.name = "foo";
+   vars =
+    (requires =
+      {Jbuilder.Meta.Simplified.Rules.set_rules =
+        [{Jbuilder__Meta.var = "requires"; predicates = [];
+          action = Jbuilder__Meta.Set; value = "bar"};
+         {Jbuilder__Meta.var = "requires";
+          predicates = [Jbuilder__Meta.Pos "ppx_driver"];
+          action = Jbuilder__Meta.Set; value = "baz"}];
+       add_rules = []});
+   subs = []}
 |}]


### PR DESCRIPTION
It's always simplified anyway. If we're simplifying some things a late too eagerly, we could also make the simplification itself as lazy.