### PR TITLE
Set the target's PATH when cross compiling

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -300,13 +300,20 @@ let create ~(kind : Kind.t) ~path ~env ~name ~merlin ~targets () =
             (Path.relative
                (Config.local_install_dir ~context:name)
                "lib")
-        ; extend_var "PATH"
-            (Config.local_install_bin_dir ~context:name)
         ; extend_var "MANPATH"
             (Config.local_install_man_dir ~context:name)
         ]
       in
       Env.extend env ~vars:(Env.Map.of_list_exn vars)
+      |> Env.update ~var:"PATH" ~f:(fun _ ->
+        match host with
+        | None ->
+          let _key, path =
+            extend_var "PATH" (Config.local_install_bin_dir ~context:name) in
+          Some path
+        | Some host ->
+          Env.get host.env "PATH"
+      )
     in
     let stdlib_dir = Path.of_string (Ocaml_config.standard_library ocfg) in
     let natdynlink_supported = Ocaml_config.natdynlink_supported ocfg in

--- a/src/env.ml
+++ b/src/env.ml
@@ -77,3 +77,6 @@ let diff x y =
     | Some _ -> None
     | None -> vx)
   |> make
+
+let update t ~var ~f =
+  make (Map.update t.vars var ~f)

--- a/src/env.mli
+++ b/src/env.mli
@@ -23,4 +23,7 @@ val add : t -> var:Var.t -> value:string -> t
 
 val diff : t -> t -> t
 
+val update : t -> var:string -> f:(string option -> string option) -> t
+
 val sexp_of_t : t -> Sexp.t
+


### PR DESCRIPTION
Fix #625 

I'm not sure if my approach or the much simpler one where we simply we t.env is the right one. It feels a bit yicky to just throw away the old PATH so I did the slightly more complicated thing.