### PR TITLE
Don't pass library include flags to odoc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,10 @@ next
 - Use the host's PATH variable when running actions during cross compilation
   (#649, fixes #625 @rgrinberg)
 
+- Fix incorrect include (`-I`) flags being passed to odoc. These flags should be
+  directories that include .odoc files, rather than the include flags of the
+  libraries. (#652 fixes #651 @rgrinberg)
+
 1.0+beta19.1 (21/03/2018)
 -------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
-next
-----
+1.0+beta20-rc1 (24/03/2018)
+---------------------------
 
 - Add a `documentation` stanza. This stanza allows one to attach .mld files to
   opam packages. (#570 @rgrinberg)

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -763,7 +763,7 @@ module Gen(P : Install_rules.Params) = struct
         SC.add_rule sctx build
       );
 
-    Odoc.setup_library_odoc_rules lib ~dir ~requires ~modules ~dep_graphs ~scope
+    Odoc.setup_library_odoc_rules lib ~requires ~modules ~dep_graphs ~scope
     ;
 
     let flags =

--- a/src/odoc.boot.ml
+++ b/src/odoc.boot.ml
@@ -1,7 +1,7 @@
 
 module Gen (S : sig val sctx : Super_context.t end) = struct
 
-  let setup_library_odoc_rules _ ~dir:_ ~scope:_ ~modules:_ ~requires:_
+  let setup_library_odoc_rules _ ~scope:_ ~modules:_ ~requires:_
         ~dep_graphs:_ = ()
 
   let init ~modules_by_lib:_ ~mlds_of_dir:_ = ()

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -203,7 +203,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
       Build.memoize "includes"
         (requires
          >>> Dep.deps
-         >>^ Lib.L.include_flags ~stdlib_dir:context.stdlib_dir)
+         >>^ odoc_include_flags)
     in
     let modules_and_odoc_files =
       List.map (Module.Name.Map.values modules) ~f:(

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -107,7 +107,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
            Ocamldep.Dep_graph.deps_of dep_graphs.impl m)
        >>^ List.map ~f:(Module.odoc_file ~doc_dir))
 
-  let compile_module (m : Module.t) ~dir ~obj_dir ~includes ~dep_graphs
+  let compile_module (m : Module.t) ~obj_dir ~includes ~dep_graphs
         ~doc_dir ~pkg_or_lnu =
     let odoc_file = Module.odoc_file m ~doc_dir in
     SC.add_rule sctx
@@ -117,7 +117,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
        >>>
        Build.run ~context ~dir:doc_dir odoc
          [ A "compile"
-         ; A "-I"; Path dir
+         ; A "-I"; Path doc_dir
          ; Dyn (fun x -> x)
          ; As ["--pkg"; pkg_or_lnu]
          ; A "-o"; Target odoc_file
@@ -189,7 +189,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
 
   let toplevel_index = Paths.html_root ++ "index.html"
 
-  let setup_library_odoc_rules (library : Library.t) ~dir ~scope ~modules
+  let setup_library_odoc_rules (library : Library.t) ~scope ~modules
         ~requires ~(dep_graphs:Ocamldep.Dep_graph.t Ml_kind.Dict.t) =
     let lib =
       Option.value_exn (Lib.DB.find_even_when_hidden (Scope.libs scope)
@@ -207,7 +207,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
     in
     let modules_and_odoc_files =
       List.map (Module.Name.Map.values modules) ~f:(
-        compile_module ~dir ~obj_dir ~includes ~dep_graphs
+        compile_module ~obj_dir ~includes ~dep_graphs
           ~doc_dir ~pkg_or_lnu)
     in
     Dep.setup_deps (Lib lib) (List.map modules_and_odoc_files ~f:snd

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -6,7 +6,6 @@ module Gen (S : sig val sctx : Super_context.t end) : sig
 
   val setup_library_odoc_rules
     :  Library.t
-    -> dir:Path.t
     -> scope:Scope.t
     -> modules:Module.t Module.Name.Map.t
     -> requires:(unit, Lib.t list) Build.t


### PR DESCRIPTION
We should pass directories where we store .odoc files instead.

cc @trefis