### PR TITLE
Cosmetic changes for default package entry point.

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -1007,7 +1007,9 @@ module Gen(P : Install_rules.Params) = struct
     Odoc.init ~modules_by_lib:(fun ~dir lib ->
       let m = modules_by_lib ~dir lib in
       match m.alias_module with
-      | Some m -> [m]
+      | Some alias_mod ->
+        [Option.value ~default:alias_mod
+           (Module.Name.Map.find m.modules m.main_module_name)]
       | None -> Module.Name.Map.values m.modules
     ) ~mlds_of_dir
 end

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -410,18 +410,25 @@ module Gen (S : sig val sctx : SC.t end) = struct
     |> List.sort ~compare:(fun (x, _) (y, _) ->
       String.compare (Lib.name x) (Lib.name y))
     |> List.iter ~f:(fun (lib, modules) ->
-      Buffer.add_string b (
-        sprintf
-          "{1 Library %s}\n\
-           This library exposes the following toplevel modules: \
-           {!modules:%s}.\n"
-          (Lib.name lib)
-          (modules
-           |> List.sort ~compare:(fun x y ->
-             Module.Name.compare (Module.name x) (Module.name y))
-           |> List.map ~f:(fun m -> Module.Name.to_string (Module.name m))
-           |> String.concat ~sep:" ")
-      )
+      Buffer.add_string b (sprintf "{1 Library %s}\n" (Lib.name lib));
+      match modules with
+      | [ x ] ->
+        Buffer.add_string b (
+          sprintf
+            "The entry point of this library is the module {!module-%s}.\n"
+            (Module.Name.to_string (Module.name x))
+        )
+      | _ ->
+        Buffer.add_string b (
+          sprintf
+            "This library exposes the following toplevel modules: \
+             {!modules:%s}"
+            (modules
+             |> List.sort ~compare:(fun x y ->
+               Module.Name.compare (Module.name x) (Module.name y))
+             |> List.map ~f:(fun m -> Module.Name.to_string (Module.name m))
+             |> String.concat ~sep:" ")
+        )
     );
     Buffer.contents b
 


### PR DESCRIPTION
When a package has no `index.mld` and contains a library `foo` with a hand-written `foo.ml`, the generated `index.html` says:
```
Library foo
This library exposes the following toplevel modules:
Foo_

.
```

I changed that to link to `Foo` and print only on one line.