### PR TITLE
Place module list on its own line (take 2)

### DIFF
--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -413,8 +413,8 @@ module Gen (S : sig val sctx : SC.t end) = struct
       Buffer.add_string b (
         sprintf
           "{1 Library %s}\n\
-           This library exposes the following toplevel modules: \
-           {!modules:%s}.\n"
+           This library exposes the following toplevel modules:\n\
+           {!modules:%s}\n"
           (Lib.name lib)
           (modules
            |> List.sort ~compare:(fun x y ->


### PR DESCRIPTION
See eb05f4f64362653690fffb25b9fda5e1e2fab8d4 and https://github.com/ocaml/dune/pull/367#issuecomment-352209790.

This came up again because odoc's new parser is now merged into odoc `master`, but Dune had a regression in the meantime.

odoc's CI runs Jbuilder `master` against odoc `master`, but you may also want to do that in Dune's CI.