### PR TITLE
Compute transitive modules depencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ next
   versioned API, and no external dependencies. (#673, #678 #692, #695
   @rgrinberg)
 
+- Register the transitive dependencies of compilation units as the
+  compiler might read `.cm*` files recursively (#666, fixes #660,
+  @emillon)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -40,6 +40,7 @@ module type Ast = sig
     | Mkdir          of path
     | Digest_files   of path list
     | Diff           of Diff.t
+    | Merge_files_into of path list * string list * path
 end
 
 module type Helpers = sig

--- a/src/build.ml
+++ b/src/build.ml
@@ -278,3 +278,9 @@ let mkdir dir =
 let progn ts =
   all ts >>^ fun actions ->
   Action.Progn actions
+
+let merge_files_dyn ~target =
+  dyn_paths (arr fst)
+  >>^ (fun (sources, extras) ->
+    Action.Merge_files_into (sources, extras, target))
+  >>> action_dyn ~targets:[target] ()

--- a/src/build.mli
+++ b/src/build.mli
@@ -234,3 +234,5 @@ val merge_lib_deps : lib_deps -> lib_deps -> lib_deps
 
 (**/**)
 val paths_for_rule : Path.Set.t -> ('a, 'a) t
+
+val merge_files_dyn : target:Path.t -> (Path.t list * string list, Action.t) t

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -139,9 +139,13 @@ let rules ~(ml_kind:Ml_kind.t) ~dir ~modules
               );
             let build_paths dependencies =
               let dependency_file_path m =
-                Option.map
-                  (Module.file ~dir m Ml_kind.Intf)
-                 ~f:all_deps_path
+                let path =
+                  match Module.file ~dir m Ml_kind.Intf with
+                  | Some _ as x -> x
+                  | None when Option.is_some alias_module -> None
+                  | None -> Module.file ~dir m Ml_kind.Impl
+                in
+                Option.map path ~f:all_deps_path
               in
               List.filter_map dependencies ~f:dependency_file_path
             in

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -489,3 +489,13 @@
     (progn
      (run ${exe:cram.exe} run.t)
      (diff? run.t run.t.corrected))))))
+
+(alias
+ ((name runtest)
+  (deps ((package jbuilder)
+         (files_recursively_in test-cases/github660)))
+  (action
+   (chdir test-cases/github660
+    (progn
+     (run ${exe:cram.exe} run.t)
+     (diff? run.t run.t.corrected))))))

--- a/test/blackbox-tests/test-cases/github660/explicit-interfaces/jbuild
+++ b/test/blackbox-tests/test-cases/github660/explicit-interfaces/jbuild
@@ -1,0 +1,8 @@
+(jbuild_version 1)
+
+(alias
+ ((name runtest)
+  (deps (main.exe))
+  (action (run ${<}))))
+
+(executable ((name main)))

--- a/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib.ml
+++ b/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib.ml
@@ -1,0 +1,1 @@
+module Sub = Lib_sub

--- a/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib.mli
+++ b/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib.mli
@@ -1,0 +1,1 @@
+module Sub = Lib_sub

--- a/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib_sub.ml
+++ b/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib_sub.ml
@@ -1,0 +1,1 @@
+let hello = "hello"

--- a/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib_sub.mli
+++ b/test/blackbox-tests/test-cases/github660/explicit-interfaces/lib_sub.mli
@@ -1,0 +1,1 @@
+val hello : string

--- a/test/blackbox-tests/test-cases/github660/explicit-interfaces/main.ml
+++ b/test/blackbox-tests/test-cases/github660/explicit-interfaces/main.ml
@@ -1,0 +1,3 @@
+let () =
+  print_endline Lib.Sub.hello;
+  ()

--- a/test/blackbox-tests/test-cases/github660/no-interfaces/jbuild
+++ b/test/blackbox-tests/test-cases/github660/no-interfaces/jbuild
@@ -1,0 +1,8 @@
+(jbuild_version 1)
+
+(alias
+ ((name runtest)
+  (deps (main.exe))
+  (action (run ${<}))))
+
+(executable ((name main)))

--- a/test/blackbox-tests/test-cases/github660/no-interfaces/lib.ml
+++ b/test/blackbox-tests/test-cases/github660/no-interfaces/lib.ml
@@ -1,0 +1,1 @@
+module Sub = Lib_sub

--- a/test/blackbox-tests/test-cases/github660/no-interfaces/lib_sub.ml
+++ b/test/blackbox-tests/test-cases/github660/no-interfaces/lib_sub.ml
@@ -1,0 +1,1 @@
+let hello = "hello"

--- a/test/blackbox-tests/test-cases/github660/no-interfaces/main.ml
+++ b/test/blackbox-tests/test-cases/github660/no-interfaces/main.ml
@@ -1,0 +1,3 @@
+let () =
+  print_endline Lib.Sub.hello;
+  ()

--- a/test/blackbox-tests/test-cases/github660/run.t
+++ b/test/blackbox-tests/test-cases/github660/run.t
@@ -1,0 +1,22 @@
+When there are explicit interfaces, modules must be rebuilt.
+
+  $ jbuilder runtest --root explicit-interfaces --display quiet -j1 2>&1 | grep -v Entering
+          main alias runtest
+  hello
+  $ echo 'let x = 1' >> explicit-interfaces/lib_sub.ml
+  $ jbuilder runtest --root explicit-interfaces --display quiet -j1 2>&1 | grep -v Entering | grep -v ocamlopt
+  File "_none_", line 1:
+  Error: Files .main.eobjs/main.cmx and .main.eobjs/lib_sub.cmx
+         make inconsistent assumptions over implementation Lib_sub
+
+When there are no interfaces, the situation is the same, but it is not possible
+to rely on these.
+
+  $ jbuilder runtest --root no-interfaces --display quiet -j1 2>&1 | grep -v Entering
+          main alias runtest
+  hello
+  $ echo 'let x = 1' >> no-interfaces/lib_sub.ml
+  $ jbuilder runtest --root no-interfaces --display quiet -j1 2>&1 | grep -v Entering | grep -v ocamlopt
+  File "_none_", line 1:
+  Error: Files .main.eobjs/main.cmx and .main.eobjs/lib_sub.cmx
+         make inconsistent assumptions over interface Lib_sub

--- a/test/blackbox-tests/test-cases/github660/run.t
+++ b/test/blackbox-tests/test-cases/github660/run.t
@@ -16,6 +16,5 @@ to rely on these.
   hello
   $ echo 'let x = 1' >> no-interfaces/lib_sub.ml
   $ jbuilder runtest --root no-interfaces --display quiet -j1 2>&1 | grep -v Entering | grep -v ocamlopt
-  File "_none_", line 1:
-  Error: Files .main.eobjs/main.cmx and .main.eobjs/lib_sub.cmx
-         make inconsistent assumptions over interface Lib_sub
+          main alias runtest
+  hello

--- a/test/blackbox-tests/test-cases/github660/run.t
+++ b/test/blackbox-tests/test-cases/github660/run.t
@@ -5,9 +5,8 @@ When there are explicit interfaces, modules must be rebuilt.
   hello
   $ echo 'let x = 1' >> explicit-interfaces/lib_sub.ml
   $ jbuilder runtest --root explicit-interfaces --display quiet -j1 2>&1 | grep -v Entering | grep -v ocamlopt
-  File "_none_", line 1:
-  Error: Files .main.eobjs/main.cmx and .main.eobjs/lib_sub.cmx
-         make inconsistent assumptions over implementation Lib_sub
+          main alias runtest
+  hello
 
 When there are no interfaces, the situation is the same, but it is not possible
 to rely on these.

--- a/test/blackbox-tests/test-cases/menhir/run.t
+++ b/test/blackbox-tests/test-cases/menhir/run.t
@@ -8,10 +8,10 @@
       ocamldep src/test_base.ml.d
         menhir src/test_menhir1.{ml,mli}
       ocamldep src/test_menhir1.ml.d
+      ocamldep src/test_base.mli.d
       ocamldep src/test_menhir1.mli.d
         ocamlc src/.test.eobjs/test_menhir1.{cmi,cmti}
         ocamlc src/.test.eobjs/lexer1.{cmi,cmo,cmt}
-      ocamldep src/test_base.mli.d
         ocamlc src/.test.eobjs/test_base.{cmi,cmti}
         ocamlc src/.test.eobjs/lexer2.{cmi,cmo,cmt}
         ocamlc src/.test.eobjs/test.{cmi,cmo,cmt}


### PR DESCRIPTION
This work in progress PR is an attempt to fix #660.

@diml let me know how we should do that. From what I understood, the plan is to compute transitive dependencies of modules, so in the linked bug, add a dependency from `Main` to `Lib_sub`?