### PR TITLE
Register more dependencies statically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@ next
 - Fix error messaage when a public library is defined twice. Before
   jbuilder would raise an uncaught exception (Fixes #661, @diml)
 
+- Fix several cases where `external-lib-deps` was returning too little
+  dependencies (#667, fixes #644 @diml)
+
 1.0+beta19.1 (21/03/2018)
 -------------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -72,12 +72,12 @@ let restore_cwd_and_execve common prog argv env =
 module Main = struct
   include Jbuilder.Main
 
-  let setup ~log ?filter_out_optional_stanzas_with_missing_deps common =
+  let setup ~log ?external_lib_deps_mode common =
     setup
       ~log
       ?workspace_file:common.workspace_file
       ?only_packages:common.only_packages
-      ?filter_out_optional_stanzas_with_missing_deps
+      ?external_lib_deps_mode
       ?x:common.x
       ~ignore_promoted_rules:common.ignore_promoted_rules
       ~capture_outputs:common.capture_outputs
@@ -752,7 +752,7 @@ let external_lib_deps =
     set_common common ~targets:[];
     let log = Log.create common in
     Scheduler.go ~log ~common
-      (Main.setup ~log common ~filter_out_optional_stanzas_with_missing_deps:false
+      (Main.setup ~log common ~external_lib_deps_mode:true
        >>= fun setup ->
        let targets = resolve_targets_exn ~log common setup targets in
        let request = request_of_targets setup targets in
@@ -858,7 +858,7 @@ let rules =
     set_common common ~targets;
     let log = Log.create common in
     Scheduler.go ~log ~common
-      (Main.setup ~log common ~filter_out_optional_stanzas_with_missing_deps:false
+      (Main.setup ~log common ~external_lib_deps_mode:true
        >>= fun setup ->
        let request =
          match targets with

--- a/src/arg_spec.mli
+++ b/src/arg_spec.mli
@@ -38,6 +38,8 @@ type 'a t =
   | Target   of Path.t
   | Path     of Path.t
   | Paths    of Path.t list
+  | Hidden_deps of Path.t list
+  (** Register dependencies but produce no argument *)
   | Dyn      of ('a -> nothing t)
 
 val add_deps    : _ t list -> Path.Set.t -> Path.Set.t

--- a/src/cm_kind.ml
+++ b/src/cm_kind.ml
@@ -28,4 +28,10 @@ module Dict = struct
     ; cmo = f ~cm_kind:Cmo
     ; cmx = f ~cm_kind:Cmx
     }
+
+  let make_all x =
+    { cmi = x
+    ; cmo = x
+    ; cmx = x
+    }
 end

--- a/src/cm_kind.mli
+++ b/src/cm_kind.mli
@@ -17,4 +17,6 @@ module Dict : sig
   val get : 'a t -> cm_kind -> 'a
 
   val of_func : (cm_kind:cm_kind -> 'a) -> 'a t
+
+  val make_all : 'a -> 'a t
 end with type cm_kind := t

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -137,40 +137,41 @@ let link_exe
         artifacts modules ~ext:ctx.ext_obj))
   in
   SC.add_rule sctx
-    (Build.fanout4
-       requires
+    (Build.fanout3
        (register_native_objs_deps modules_and_cm_files >>^ snd)
        (Ocaml_flags.get flags mode)
        link_flags
      >>>
-     Build.dyn_paths (Build.arr (fun (libs, _, _, _) ->
-       Lib.L.archive_files libs ~mode ~ext_lib:ctx.ext_lib))
+     Build.of_result_map requires ~f:(fun libs ->
+       Build.paths (Lib.L.archive_files libs ~mode ~ext_lib:ctx.ext_lib))
      >>>
      Build.run ~context:ctx
        (Ok compiler)
-       [ Dyn (fun (_, _, flags,_) -> As flags)
+       [ Dyn (fun (_, flags,_) -> As flags)
        ; A "-o"; Target exe
        ; As linkage.flags
-       ; Dyn (fun (_, _, _, link_flags) -> As link_flags)
-       ; Dyn (fun (libs, _, _, _) ->
+       ; Dyn (fun (_, _, link_flags) -> As link_flags)
+       ; Arg_spec.of_result_map requires ~f:(fun libs ->
            Lib.L.link_flags libs ~mode ~stdlib_dir:ctx.stdlib_dir)
-       ; Dyn (fun (_, cm_files, _, _) -> Deps cm_files)
+       ; Dyn (fun (cm_files, _, _) -> Deps cm_files)
        ]);
   if linkage.ext = ".bc" then
-    let rules = Js_of_ocaml_rules.build_exe sctx ~dir ~js_of_ocaml ~src:exe in
-    let libs_and_cm_and_flags =
-      (requires &&& (modules_and_cm_files >>^ snd))
-      &&&
-      SC.expand_and_eval_set sctx ~scope ~dir js_of_ocaml.flags
-        ~standard:(Js_of_ocaml_rules.standard ())
+    let rules =
+      Js_of_ocaml_rules.build_exe sctx ~dir ~js_of_ocaml ~src:exe ~requires
     in
-    SC.add_rules sctx (List.map rules ~f:(fun r -> libs_and_cm_and_flags >>> r))
+    let cm_and_flags =
+      Build.fanout
+        (modules_and_cm_files >>^ snd)
+        (SC.expand_and_eval_set sctx ~scope ~dir js_of_ocaml.flags
+           ~standard:(Js_of_ocaml_rules.standard ()))
+    in
+    SC.add_rules sctx (List.map rules ~f:(fun r -> cm_and_flags >>> r))
 
 let build_and_link_many
       ~dir ~obj_dir ~programs ~modules
       ~scope
       ~linkages
-      ?(requires=Build.return [])
+      ?(requires=Ok [])
       ?already_used
       ?(flags=Ocaml_flags.empty)
       ?link_flags

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -1,5 +1,7 @@
 (** Compilation and linking of executables *)
 
+open Import
+
 module Program : sig
   type t =
     { name             : string
@@ -43,7 +45,7 @@ val build_and_link
   -> modules:Module.t Module.Name.Map.t
   -> scope:Scope.t
   -> linkages:Linkage.t list
-  -> ?requires:(unit, Lib.L.t) Build.t
+  -> ?requires:Lib.t list Or_exn.t
   -> ?already_used:Module.Name.Set.t
   -> ?flags:Ocaml_flags.t
   -> ?link_flags:(unit, string list) Build.t
@@ -58,7 +60,7 @@ val build_and_link_many
   -> modules:Module.t Module.Name.Map.t
   -> scope:Scope.t
   -> linkages:Linkage.t list
-  -> ?requires:(unit, Lib.L.t) Build.t
+  -> ?requires:Lib.t list Or_exn.t
   -> ?already_used:Module.Name.Set.t
   -> ?flags:Ocaml_flags.t
   -> ?link_flags:(unit, string list) Build.t
@@ -73,7 +75,7 @@ val link_exe
   :  dir:Path.t
   -> obj_dir:Path.t
   -> scope:Scope.t
-  -> requires:(unit, Lib.t list) Build.t
+  -> requires:Lib.t list Or_exn.t
   -> name:string
   -> linkage:Linkage.t
   -> top_sorted_modules:(unit, Module.t list) Build.t

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -174,6 +174,19 @@ let root_package_name s =
   | None -> s
   | Some i -> String.sub s ~pos:0 ~len:i
 
+let dummy_package t ~name =
+  let dir =
+    match t.path with
+    | [] -> t.stdlib_dir
+    | dir :: _ -> Path.relative dir (root_package_name name)
+  in
+  { Package.
+    meta_file = Path.relative dir "META"
+  ; name      = name
+  ; dir       = dir
+  ; vars      = String_map.empty
+  }
+
 (* Parse a single package from a META file *)
 let parse_package t ~meta_file ~name ~parent_dir ~vars =
   let pkg_dir = Vars.get vars "directory" Ps.empty in

--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -55,6 +55,9 @@ val all_packages  : t -> Package.t list
 (** List all the packages that are not available in this database *)
 val all_unavailable_packages : t -> (string * Unavailable_reason.t) list
 
+(** A dummy package. This is used to implement [external-lib-deps] *)
+val dummy_package : t -> name:string -> Package.t
+
 module Config : sig
   type t
   val load : Path.t -> toolchain:string -> context:string -> t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -1027,7 +1027,7 @@ module type Gen = sig
 end
 
 let gen ~contexts ~build_system
-      ?(filter_out_optional_stanzas_with_missing_deps=true)
+      ?(external_lib_deps_mode=false)
       ?only_packages conf =
   let open Fiber.O in
   let { Jbuild_load. file_tree; jbuilds; packages; scopes } = conf in
@@ -1075,7 +1075,7 @@ let gen ~contexts ~build_system
         ~scopes
         ~file_tree
         ~packages
-        ~filter_out_optional_stanzas_with_missing_deps
+        ~external_lib_deps_mode
         ~stanzas
     in
     let module M = Gen(struct let sctx = sctx end) in

--- a/src/gen_rules.mli
+++ b/src/gen_rules.mli
@@ -5,7 +5,7 @@ open Jbuild
 val gen
   :  contexts:Context.t list
   -> build_system:Build_system.t
-  -> ?filter_out_optional_stanzas_with_missing_deps:bool (* default: true *)
+  -> ?external_lib_deps_mode:bool (* default: false *)
   -> ?only_packages:Package.Name.Set.t
   -> Jbuild_load.conf
   -> (Path.t * Scope_info.t * Stanzas.t) list String_map.t Fiber.t

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -196,18 +196,16 @@ include Sub_system.Register_end_point(
 
     let runner_libs =
       let open Result.O in
-      Build.of_result
-        (Result.concat_map backends
-           ~f:(fun (backend : Backend.t) -> backend.runner_libraries)
-         >>= fun libs ->
-         Lib.DB.find_many (Scope.libs scope) [lib.name]
-         >>= fun lib ->
-         Result.all
-           (List.map info.libraries
-              ~f:(Lib.DB.resolve (Scope.libs scope)))
-         >>= fun more_libs ->
-         Lib.closure (lib @ libs @ more_libs)
-         >>| Build.return)
+      Result.concat_map backends
+        ~f:(fun (backend : Backend.t) -> backend.runner_libraries)
+      >>= fun libs ->
+      Lib.DB.find_many (Scope.libs scope) [lib.name]
+      >>= fun lib ->
+      Result.all
+        (List.map info.libraries
+           ~f:(Lib.DB.resolve (Scope.libs scope)))
+      >>= fun more_libs ->
+      Lib.closure (lib @ libs @ more_libs)
     in
 
     (* Generate the runner file *)

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -196,7 +196,7 @@ include Sub_system.Register_end_point(
 
     let runner_libs =
       let open Result.O in
-      Lib.Compile.make
+      Build.of_result
         (Result.concat_map backends
            ~f:(fun (backend : Backend.t) -> backend.runner_libraries)
          >>= fun libs ->
@@ -206,8 +206,8 @@ include Sub_system.Register_end_point(
            (List.map info.libraries
               ~f:(Lib.DB.resolve (Scope.libs scope)))
          >>= fun more_libs ->
-         Ok (lib @ libs @ more_libs))
-      |> Super_context.Libs.requires sctx ~dir ~has_dot_merlin:false
+         Lib.closure (lib @ libs @ more_libs)
+         >>| Build.return)
     in
 
     (* Generate the runner file *)

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -25,7 +25,8 @@ let runtime_file ~sctx ~dir fname =
   with
   | Error _ ->
     Arg_spec.Dyn (fun _ ->
-      Utils.library_not_found ~context:(SC.context sctx).name ~hint:install_jsoo_hint
+      Utils.library_not_found ~context:(SC.context sctx).name
+        ~hint:install_jsoo_hint
         "js_of_ocaml-compiler")
   | Ok f -> Arg_spec.Dep f
 
@@ -40,22 +41,22 @@ let js_of_ocaml_rule ~sctx ~dir ~flags ~spec ~target =
     ; spec
     ]
 
-let standalone_runtime_rule ~sctx ~dir ~javascript_files ~target =
+let standalone_runtime_rule ~sctx ~dir ~javascript_files ~target ~requires =
   let spec =
     Arg_spec.S
-      [ Arg_spec.Dyn (fun ((libs,_),_) ->
+      [ Arg_spec.of_result_map requires ~f:(fun libs ->
           Arg_spec.Deps (Lib.L.jsoo_runtime_files libs))
       ; Arg_spec.Deps javascript_files
       ]
   in
-  Build.arr (fun (libs_and_cm,flags) -> (libs_and_cm, "--runtime-only" :: flags))
+  Build.arr (fun (cm_files, flags) -> (cm_files, "--runtime-only" :: flags))
   >>>
   js_of_ocaml_rule ~sctx ~dir ~flags:(fun (_,flags) -> As flags) ~target ~spec
 
-let exe_rule ~sctx ~dir ~javascript_files ~src ~target =
+let exe_rule ~sctx ~dir ~javascript_files ~src ~target ~requires =
   let spec =
     Arg_spec.S
-      [ Arg_spec.Dyn (fun ((libs,_),_) ->
+      [ Arg_spec.of_result_map requires ~f:(fun libs ->
           Arg_spec.Deps (Lib.L.jsoo_runtime_files libs))
       ; Arg_spec.Deps javascript_files
       ; Arg_spec.Dep src
@@ -66,27 +67,28 @@ let exe_rule ~sctx ~dir ~javascript_files ~src ~target =
 let jsoo_archives lib =
   List.map (Lib.archives lib).byte ~f:(Path.extend_basename ~suffix:".js")
 
-let link_rule ~sctx ~dir ~runtime ~target =
+let link_rule ~sctx ~dir ~runtime ~target ~requires =
   let ctx = SC.context sctx in
-  let get_all ((libs,cm),_) =
-    let all_libs =
-      List.concat_map libs ~f:(fun (lib : Lib.t) ->
-        let jsoo_archives = jsoo_archives lib in
-        if Lib.is_local lib then (
-          jsoo_archives
-        ) else (
-          let lib_name = Lib.name lib in
-          List.map ~f:(fun js ->
-            in_build_dir ~ctx [lib_name ; Path.basename js]) jsoo_archives
+  let get_all (cm, _) =
+    Arg_spec.of_result_map requires ~f:(fun libs ->
+      let all_libs =
+        List.concat_map libs ~f:(fun (lib : Lib.t) ->
+          let jsoo_archives = jsoo_archives lib in
+          if Lib.is_local lib then (
+            jsoo_archives
+          ) else (
+            let lib_name = Lib.name lib in
+            List.map ~f:(fun js ->
+              in_build_dir ~ctx [lib_name ; Path.basename js]) jsoo_archives
+          )
         )
-      )
-    in
-    (* Special case for the stdlib because it is not referenced in the META *)
-    let all_libs = in_build_dir ~ctx ["stdlib"; "stdlib.cma.js"] :: all_libs in
-    let all_other_modules =
-      List.map cm ~f:(fun m -> Path.extend_basename m ~suffix:".js")
-    in
-    Arg_spec.Deps (List.concat [all_libs;all_other_modules])
+      in
+      (* Special case for the stdlib because it is not referenced in the META *)
+      let all_libs = in_build_dir ~ctx ["stdlib"; "stdlib.cma.js"] :: all_libs in
+      let all_other_modules =
+        List.map cm ~f:(fun m -> Path.extend_basename m ~suffix:".js")
+      in
+      Arg_spec.Deps (List.concat [all_libs;all_other_modules]))
   in
   let jsoo_link = SC.resolve_program sctx ~hint:install_jsoo_hint "jsoo_link" in
   Build.run ~context:(SC.context sctx) ~dir
@@ -97,19 +99,23 @@ let link_rule ~sctx ~dir ~runtime ~target =
     ; Arg_spec.Dyn get_all
     ]
 
-let build_cm sctx ~scope ~dir ~js_of_ocaml ~src ~target =
+let build_cm sctx ~scope ~dir ~(js_of_ocaml:Jbuild.Js_of_ocaml.t) ~src ~target =
   if separate_compilation_enabled ()
   then
     let itarget = Path.extend_basename src ~suffix:".js" in
     let spec = Arg_spec.Dep src in
     let flags =
-      SC.expand_and_eval_set sctx ~scope ~dir js_of_ocaml.Jbuild.Js_of_ocaml.flags
+      SC.expand_and_eval_set sctx ~scope ~dir js_of_ocaml.flags
         ~standard:(standard ())
     in
     [ flags
       >>>
-      js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags -> As flags) ~spec ~target:itarget ]
-    @ (if target = itarget then [] else [Build.symlink ~src:itarget ~dst:target])
+      js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags ->
+        As flags) ~spec ~target:itarget ]
+    @ (if target = itarget then
+         []
+       else
+         [Build.symlink ~src:itarget ~dst:target])
   else []
 
 let setup_separate_compilation_rules sctx components =
@@ -141,19 +147,20 @@ let setup_separate_compilation_rules sctx components =
           SC.add_rule sctx
             (Build.return (standard ())
              >>>
-             js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags -> As flags) ~spec ~target)
+             js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags ->
+               As flags) ~spec ~target)
         )
 
-let build_exe sctx ~dir ~js_of_ocaml ~src =
+let build_exe sctx ~dir ~js_of_ocaml ~src ~requires =
   let {Jbuild.Js_of_ocaml.javascript_files; _} = js_of_ocaml in
   let javascript_files = List.map javascript_files ~f:(Path.relative dir) in
   let mk_target ext = Path.extend_basename src ~suffix:ext in
   let target = mk_target ".js" in
   let standalone_runtime = mk_target ".runtime.js" in
   if separate_compilation_enabled () then
-    [ link_rule ~sctx ~dir ~runtime:standalone_runtime ~target
+    [ link_rule ~sctx ~dir ~runtime:standalone_runtime ~target ~requires
     ; standalone_runtime_rule ~sctx ~dir ~javascript_files
-        ~target:standalone_runtime
+        ~target:standalone_runtime ~requires
     ]
   else
-    [ exe_rule ~sctx ~dir ~javascript_files ~src ~target ]
+    [ exe_rule ~sctx ~dir ~javascript_files ~src ~target ~requires ]

--- a/src/js_of_ocaml_rules.mli
+++ b/src/js_of_ocaml_rules.mli
@@ -1,5 +1,6 @@
 (** Generate rules for js_of_ocaml *)
 
+open Import
 open Jbuild
 
 val build_cm
@@ -16,7 +17,8 @@ val build_exe
   -> dir:Path.t
   -> js_of_ocaml:Js_of_ocaml.t
   -> src:Path.t
-  -> ((Lib.t list * Path.t list) * string list, Action.t) Build.t list
+  -> requires:Lib.t list Or_exn.t
+  -> (Path.t list * string list, Action.t) Build.t list
 
 val setup_separate_compilation_rules
   :  Super_context.t

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -926,16 +926,6 @@ module Compile = struct
     ; sub_systems       : Sub_system0.Instance.t Lazy.t Sub_system_name.Map.t
     }
 
-  let make libs =
-    { direct_requires   = libs
-    ; requires          = libs >>= closure
-    ; resolved_selects  = []
-    ; pps               = Ok []
-    ; optional          = false
-    ; user_written_deps = []
-    ; sub_systems       = Sub_system_name.Map.empty
-    }
-
   let for_lib db (t : lib) =
     { direct_requires   = t.requires
     ; requires          = t.requires >>= closure_with_overlap_checks db

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -67,7 +67,7 @@ module Info = struct
     }
 
   let user_written_deps t =
-    List.fold_left t.virtual_deps
+    List.fold_left (t.virtual_deps @ t.ppx_runtime_deps)
       ~init:(Deps.to_lib_deps t.requires)
       ~f:(fun acc s -> Jbuild.Lib_dep.Direct s :: acc)
 

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1013,14 +1013,20 @@ module DB = struct
         | Some x -> x)
       ~all:(fun () -> String_map.keys map)
 
-  let create_from_findlib findlib =
+  let create_from_findlib ?(external_lib_deps_mode=false) findlib =
     create ()
       ~resolve:(fun name ->
         match Findlib.find findlib name with
         | Ok pkg -> Found (Info.of_findlib_package pkg)
         | Error e ->
           match e with
-          | Not_found -> Not_found
+          | Not_found ->
+            if external_lib_deps_mode then
+              Found
+                (Info.of_findlib_package
+                   (Findlib.dummy_package findlib ~name))
+            else
+              Not_found
           | Hidden pkg ->
             Hidden (Info.of_findlib_package pkg,
                     "unsatisfied 'exist_if'"))

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -257,7 +257,10 @@ module DB : sig
     -> (Path.t * Jbuild.Library.t) list
     -> t
 
-  val create_from_findlib : Findlib.t -> t
+  val create_from_findlib
+    :  ?external_lib_deps_mode:bool
+    -> Findlib.t
+    -> t
 
   val find : t -> string -> (lib, Error.Library_not_available.Reason.t) result
   val find_many

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -193,10 +193,6 @@ type sub_system = ..
 module Compile : sig
   type t
 
-  (** Create a compilation context from a list of libraries. The list
-      doesn't have to be transitively closed. *)
-  val make : L.t Or_exn.t -> t
-
   (** Return the list of dependencies needed for compiling this library *)
   val requires : t -> L.t Or_exn.t
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -29,7 +29,7 @@ let setup_env ~capture_outputs =
   Env.add env ~var:"INSIDE_DUNE" ~value:"1"
 
 let setup ?(log=Log.no_log)
-      ?filter_out_optional_stanzas_with_missing_deps
+      ?external_lib_deps_mode
       ?workspace ?(workspace_file="jbuild-workspace")
       ?only_packages
       ?extra_ignored_subtrees
@@ -92,7 +92,7 @@ let setup ?(log=Log.no_log)
     ~build_system
     ~contexts
     ?only_packages
-    ?filter_out_optional_stanzas_with_missing_deps
+    ?external_lib_deps_mode
   >>= fun stanzas ->
   Scheduler.set_status_line_generator gen_status_line
   >>>
@@ -113,7 +113,7 @@ let find_context_exn t ~name =
 
 let external_lib_deps ?log ~packages () =
   Scheduler.go ?log
-    (setup () ~filter_out_optional_stanzas_with_missing_deps:false
+    (setup () ~external_lib_deps_mode:true
      >>| fun setup ->
      let context = find_context_exn setup ~name:"default" in
      let install_files =

--- a/src/main.mli
+++ b/src/main.mli
@@ -18,7 +18,7 @@ val package_install_file : setup -> Package.Name.t -> (Path.t, unit) result
     it. *)
 val setup
   :  ?log:Log.t
-  -> ?filter_out_optional_stanzas_with_missing_deps:bool
+  -> ?external_lib_deps_mode:bool
   -> ?workspace:Workspace.t
   -> ?workspace_file:string
   -> ?only_packages:Package.Name.Set.t

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -2,10 +2,7 @@
 
 open Import
 
-(** Setup rules to build a single module.
-
-    [lib_file_deps] represent the dependencies on files of library
-    dependencies. *)
+(** Setup rules to build a single module. *)
 val build_module
   :  Super_context.t
   -> ?sandbox:bool
@@ -17,8 +14,7 @@ val build_module
   -> dir:Path.t
   -> obj_dir:Path.t
   -> dep_graphs:Ocamldep.Dep_graphs.t
-  -> requires:Lib.t list Or_exn.t
-  -> lib_file_deps:(unit, unit) Build.t Cm_kind.Dict.t
+  -> includes:string list Arg_spec.t Cm_kind.Dict.t
   -> alias_module:Module.t option
   -> unit
 

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -1,9 +1,11 @@
 (** OCaml module compilation *)
 
+open Import
+
 (** Setup rules to build a single module.
 
-    [requires] must declare dependencies on files of libraries.
-*)
+    [lib_file_deps] represent the dependencies on files of library
+    dependencies. *)
 val build_module
   :  Super_context.t
   -> ?sandbox:bool
@@ -15,7 +17,8 @@ val build_module
   -> dir:Path.t
   -> obj_dir:Path.t
   -> dep_graphs:Ocamldep.Dep_graphs.t
-  -> requires:(unit, Lib.t list) Build.t Cm_kind.Dict.t
+  -> requires:Lib.t list Or_exn.t
+  -> lib_file_deps:(unit, unit) Build.t Cm_kind.Dict.t
   -> alias_module:Module.t option
   -> unit
 
@@ -30,6 +33,6 @@ val build_modules
   -> obj_dir:Path.t
   -> dep_graphs:Ocamldep.Dep_graphs.t
   -> modules:Module.t Module.Name.Map.t
-  -> requires:(unit, Lib.t list) Build.t
+  -> requires:Lib.t list Or_exn.t
   -> alias_module:Module.t option
   -> unit

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -1,5 +1,6 @@
 (** Odoc rules *)
 
+open Import
 open Jbuild
 
 module Gen (S : sig val sctx : Super_context.t end) : sig
@@ -8,7 +9,7 @@ module Gen (S : sig val sctx : Super_context.t end) : sig
     :  Library.t
     -> scope:Scope.t
     -> modules:Module.t Module.Name.Map.t
-    -> requires:(unit, Lib.t list) Build.t
+    -> requires:Lib.t list Or_exn.t
     -> dep_graphs:Ocamldep.Dep_graphs.t
     -> unit
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -74,10 +74,12 @@ let create
       ~file_tree
       ~packages
       ~stanzas
-      ~filter_out_optional_stanzas_with_missing_deps
+      ~external_lib_deps_mode
       ~build_system
   =
-  let installed_libs = Lib.DB.create_from_findlib context.findlib in
+  let installed_libs =
+    Lib.DB.create_from_findlib context.findlib ~external_lib_deps_mode
+  in
   let internal_libs =
     List.concat_map stanzas ~f:(fun (dir, _, stanzas) ->
       let ctx_dir = Path.append context.build_dir dir in
@@ -109,7 +111,7 @@ let create
         })
   in
   let stanzas_to_consider_for_install =
-    if filter_out_optional_stanzas_with_missing_deps then
+    if not external_lib_deps_mode then
       List.concat_map stanzas ~f:(fun { ctx_dir; stanzas; scope; _ } ->
         List.filter_map stanzas ~f:(fun stanza ->
           let keep =

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -304,15 +304,13 @@ module Libs = struct
        |> Path.Set.of_list)
 
   let file_deps t libs ~ext =
-    Build.of_result_map libs ~f:(fun libs ->
-      Build.paths
-        (List.rev_map libs ~f:(fun (lib : Lib.t) ->
-           if Lib.is_local lib then
-             Alias.stamp_file
-               (lib_files_alias ~dir:(Lib.src_dir lib) ~name:(Lib.name lib) ~ext)
-           else
-             Build_system.stamp_file_for_files_of t.build_system
-               ~dir:(Lib.obj_dir lib) ~ext)))
+    List.rev_map libs ~f:(fun (lib : Lib.t) ->
+      if Lib.is_local lib then
+        Alias.stamp_file
+          (lib_files_alias ~dir:(Lib.src_dir lib) ~name:(Lib.name lib) ~ext)
+      else
+        Build_system.stamp_file_for_files_of t.build_system
+          ~dir:(Lib.obj_dir lib) ~ext)
 end
 
 module Deps = struct

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -138,15 +138,15 @@ module Libs : sig
     -> Lib.Compile.t
     -> dir:Path.t
     -> has_dot_merlin:bool
-    -> f:((unit, Lib.L.t) Build.t -> 'a)
+    -> f:(unit -> 'a)
     -> 'a
 
   (** Generate the rules for the [(select ...)] forms in library dependencies *)
   val gen_select_rules : t -> dir:Path.t -> Lib.Compile.t -> unit
 
-  (** [file_deps ~ext] is an arrow that record dependencies on all the
-      files with extension [ext] of the libraries given as input. *)
-  val file_deps : t -> ext:string -> (Lib.t list, Lib.t list) Build.t
+  (** [file_deps t libs ~ext] is an arrow that record dependencies on
+      all the files with extension [ext] of libraries [libs]. *)
+  val file_deps : t -> Lib.L.t Or_exn.t -> ext:string -> ('a, 'a) Build.t
 
   (** Setup the alias that depends on all files with a given extension
       for a library *)

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -144,9 +144,9 @@ module Libs : sig
   (** Generate the rules for the [(select ...)] forms in library dependencies *)
   val gen_select_rules : t -> dir:Path.t -> Lib.Compile.t -> unit
 
-  (** [file_deps t libs ~ext] is an arrow that record dependencies on
+  (** [file_deps t libs ~ext] returns a list of path dependencies for
       all the files with extension [ext] of libraries [libs]. *)
-  val file_deps : t -> Lib.L.t Or_exn.t -> ext:string -> ('a, 'a) Build.t
+  val file_deps : t -> Lib.L.t -> ext:string -> Path.t list
 
   (** Setup the alias that depends on all files with a given extension
       for a library *)

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -27,7 +27,7 @@ val create
   -> file_tree:File_tree.t
   -> packages:Package.t Package.Name.Map.t
   -> stanzas:(Path.t * Scope_info.t * Stanzas.t) list
-  -> filter_out_optional_stanzas_with_missing_deps:bool
+  -> external_lib_deps_mode:bool
   -> build_system:Build_system.t
   -> t
 

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -130,14 +130,16 @@ val resolve_program
   -> Action.Prog.t
 
 module Libs : sig
-  (** Returns the closed list of dependencies for a dependency list in
-      a stanza. *)
-  val requires
+  (** Make sure all rules produces by [f] record the library
+      dependencies for [jbuilder external-lib-deps] and depend on the
+      generation of the .merlin file. *)
+  val with_lib_deps
     :  t
+    -> Lib.Compile.t
     -> dir:Path.t
     -> has_dot_merlin:bool
-    -> Lib.Compile.t
-    -> (unit, Lib.L.t) Build.t
+    -> f:((unit, Lib.L.t) Build.t -> 'a)
+    -> 'a
 
   (** Generate the rules for the [(select ...)] forms in library dependencies *)
   val gen_select_rules : t -> dir:Path.t -> Lib.Compile.t -> unit

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -63,10 +63,12 @@ let setup sctx ~dir ~(libs : Library.t list) ~scope =
         ; obj_name = "" } in
     let utop_exe_dir = utop_exe_dir ~dir in
     let requires =
-      Lib.DB.find_many (Scope.libs scope)
-        ("utop" :: List.map libs ~f:(fun (lib : Library.t) -> lib.name))
-      |> Lib.Compile.make
-      |> Super_context.Libs.requires sctx ~dir ~has_dot_merlin:false
+      let open Result.O in
+      Build.of_result
+        (Lib.DB.find_many (Scope.libs scope)
+           ("utop" :: List.map libs ~f:(fun (lib : Library.t) -> lib.name))
+         >>= Lib.closure
+         >>| Build.return)
     in
     Exe.build_and_link sctx
       ~dir:utop_exe_dir

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -4,14 +4,14 @@
       ocamldep test.ml.d
       ocamldep dummy.ml.d
         ocamlc .foo.objs/dummy.{cmi,cmo,cmt}
-        ocamlc .test.eobjs/lexer1.{cmi,cmo,cmt}
-        ocamlc .test.eobjs/test.{cmi,cmo,cmt}
+      ocamlopt .foo.objs/dummy.{cmx,o}
+      ocamlopt foo.{a,cmxa}
         ocamlc bar.o
     ocamlmklib dllfoo_stubs.so,libfoo_stubs.a
-      ocamlopt .foo.objs/dummy.{cmx,o}
+        ocamlc .test.eobjs/lexer1.{cmi,cmo,cmt}
       ocamlopt .test.eobjs/lexer1.{cmx,o}
+        ocamlc .test.eobjs/test.{cmi,cmo,cmt}
       ocamlopt .test.eobjs/test.{cmx,o}
-      ocamlopt foo.{a,cmxa}
       ocamlopt test.exe
   $ jbuilder build @bar-source --display short
   #line 1 "include/bar.h"

--- a/test/blackbox-tests/test-cases/cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation/run.t
@@ -8,14 +8,14 @@
       ocamldep bin/blah.ml.d
       ocamldep lib/p.ml.d
         ocamlc lib/.p.objs/p.{cmi,cmo,cmt}
-        ocamlc bin/.blah.eobjs/blah.{cmi,cmo,cmt}
+      ocamlopt lib/.p.objs/p.{cmx,o}
+      ocamlopt lib/p.{a,cmxa}
         ocamlc lib/p.cma [default.foo]
         ocamlc bin/.blah.eobjs/blah.{cmi,cmo,cmt} [default.foo]
       ocamlopt bin/.blah.eobjs/blah.{cmx,o} [default.foo]
       ocamlopt bin/blah.exe [default.foo]
-      ocamlopt lib/.p.objs/p.{cmx,o}
+        ocamlc bin/.blah.eobjs/blah.{cmi,cmo,cmt}
       ocamlopt bin/.blah.eobjs/blah.{cmx,o}
-      ocamlopt lib/p.{a,cmxa}
       ocamlopt bin/blah.exe
           blah file [default.foo]
           blah file

--- a/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
+++ b/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
@@ -1,14 +1,14 @@
   $ jbuilder runtest --display short
       ocamldep bar.ml.d
-      ocamldep foo_byte.ml.d
-        ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
-        ocamlc foo_byte.cma
       ocamldep foo.ml.d
       ocamldep foo.mli.d
         ocamlc .foo.objs/foo.{cmi,cmti}
       ocamlopt .foo.objs/foo.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs
+      ocamldep foo_byte.ml.d
+        ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
+        ocamlc foo_byte.cma
         ocamlc .foo.objs/foo.{cmo,cmt}
         ocamlc foo.cma
         ocamlc .bar.eobjs/bar.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/github568/run.t
+++ b/test/blackbox-tests/test-cases/github568/run.t
@@ -2,9 +2,9 @@
       ocamldep test1.ml.d
       ocamldep lib1.ml.d
         ocamlc .lib1.objs/lib1.{cmi,cmo,cmt}
-        ocamlc .test1.eobjs/test1.{cmi,cmo,cmt}
       ocamlopt .lib1.objs/lib1.{cmx,o}
-      ocamlopt .test1.eobjs/test1.{cmx,o}
       ocamlopt lib1.{a,cmxa}
+        ocamlc .test1.eobjs/test1.{cmi,cmo,cmt}
+      ocamlopt .test1.eobjs/test1.{cmx,o}
       ocamlopt test1.exe
          test1 alias runtest

--- a/test/blackbox-tests/test-cases/github644/run.t
+++ b/test/blackbox-tests/test-cases/github644/run.t
@@ -6,6 +6,13 @@
 
 These should print something:
 
-  $ jbuilder external-lib-deps @runtest
+  $ jbuilder external-lib-deps --display quiet @runtest
+  These are the external library dependencies in the default context:
+  - ocaml-migrate-parsetree.driver-main
+  - ppx_that_doesn't_exist
 
-  $ jbuilder external-lib-deps --missing @runtest
+  $ jbuilder external-lib-deps --display quiet --missing @runtest
+  Error: The following libraries are missing in the default context:
+  - ppx_that_doesn't_exist
+  Hint: try: opam install ppx_that_doesn't_exist
+  [1]

--- a/test/blackbox-tests/test-cases/intf-only/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/run.t
@@ -8,15 +8,15 @@ Successes:
       ocamldep intf.mli.d
         ocamlc .foo.objs/foo__Intf.{cmi,cmti}
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
-      ocamlopt .foo.objs/foo.{cmx,o}
-      ocamlopt foo.{a,cmxa}
-      ocamlopt foo.cmxs
-        ocamlc foo.cma
         ocamlc test/.bar.objs/bar.{cmi,cmo,cmt}
+        ocamlc test/bar.cma
+      ocamlopt .foo.objs/foo.{cmx,o}
       ocamlopt test/.bar.objs/bar.{cmx,o}
       ocamlopt test/bar.{a,cmxa}
       ocamlopt test/bar.cmxs
-        ocamlc test/bar.cma
+        ocamlc foo.cma
+      ocamlopt foo.{a,cmxa}
+      ocamlopt foo.cmxs
 
 Errors:
 

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -6,12 +6,12 @@
           odoc _doc/_odoc/pkg/bar/page-index.odoc
           odoc _doc/_html/bar/index.html
           odoc _doc/_html/odoc.css
-      ocamldep foo.ml.d
-        ocamlc .foo.objs/foo.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/foo/foo.odoc
       ocamldep foo_byte.ml.d
         ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
+      ocamldep foo.ml.d
+        ocamlc .foo.objs/foo.{cmi,cmo,cmt}
+          odoc _doc/_odoc/lib/foo/foo.odoc
       ocamldep foo2.ml.d
         ocamlc .foo.objs/foo2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo2.odoc

--- a/test/blackbox-tests/test-cases/scope-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-bug/run.t
@@ -1,24 +1,24 @@
   $ jbuilder build --display short @install
       ocamldep alib/alib.ml.d
       ocamldep alib/main.ml.d
-        ocamlc alib/.alib.objs/alib__.{cmi,cmo,cmt}
-      ocamlopt alib/.alib.objs/alib__.{cmx,o}
       ocamldep blib/blib.ml.d
       ocamldep blib/sub/sub.ml.d
         ocamlc blib/sub/.sub.objs/sub.{cmi,cmo,cmt}
-      ocamlopt blib/sub/.sub.objs/sub.{cmx,o}
-      ocamlopt blib/sub/sub.{a,cmxa}
-      ocamlopt blib/sub/sub.cmxs
-        ocamlc blib/sub/sub.cma
         ocamlc blib/.blib.objs/blib.{cmi,cmo,cmt}
+        ocamlc blib/blib.cma
+        ocamlc alib/.alib.objs/alib__.{cmi,cmo,cmt}
+      ocamlopt alib/.alib.objs/alib__.{cmx,o}
+      ocamlopt blib/sub/.sub.objs/sub.{cmx,o}
       ocamlopt blib/.blib.objs/blib.{cmx,o}
       ocamlopt blib/blib.{a,cmxa}
       ocamlopt blib/blib.cmxs
-        ocamlc blib/blib.cma
+        ocamlc blib/sub/sub.cma
         ocamlc alib/.alib.objs/alib.{cmi,cmo,cmt}
       ocamlopt alib/.alib.objs/alib.{cmx,o}
         ocamlc alib/.alib.objs/alib__Main.{cmi,cmo,cmt}
       ocamlopt alib/.alib.objs/alib__Main.{cmx,o}
       ocamlopt alib/alib.{a,cmxa}
       ocamlopt alib/alib.cmxs
+      ocamlopt blib/sub/sub.{a,cmxa}
+      ocamlopt blib/sub/sub.cmxs
         ocamlc alib/alib.cma

--- a/test/blackbox-tests/test-cases/utop/run.t
+++ b/test/blackbox-tests/test-cases/utop/run.t
@@ -2,7 +2,7 @@
       ocamldep forutop/.utop/utop.ml.d
       ocamldep forutop/forutop.ml.d
         ocamlc forutop/.forutop.objs/forutop.{cmi,cmo,cmt}
-        ocamlc forutop/.utop/utop.{cmi,cmo,cmt}
         ocamlc forutop/forutop.cma
+        ocamlc forutop/.utop/utop.{cmi,cmo,cmt}
         ocamlc forutop/.utop/utop.exe
   hello in utop


### PR DESCRIPTION
Most of the dependencies on files of library dependencies used to be declared dynamically. For instance the dependencies on `<lib-dir>/*.cmi` for every library dependency. As a result `jbuilder external-lib-deps` was quite often broken.

This PR changes that by passing the `requires` variable as a value of type `(Lib.t list, exn) result` instead of `(unit, Lib.t list) Build.t`. This usually simplify a bit the code as we have to go less through the build arrow. The dependency on the `.merlin` file and the `Build.record_lib_deps` that used to be encoded in `requires` are now done with `prefix_rules`.

One negative consequence of these changes is that we often have to pass two arguments instead of one to various functions that call the compiler: we have to pass `requires` as well as the dependencies on of the files of library dependencies. So the last few commits add `Arg_spec.Hidden_deps`, which allows to declare additional dependencies that are not present on the command line. This is used to represent include directory: we can pack together the `-I` flags and the file dependencies.

