### PR TITLE
Add a blackbox test suite for configurator

### DIFF
--- a/src/configurator/jbuild
+++ b/src/configurator/jbuild
@@ -1,5 +1,6 @@
 (library
  ((name configurator)
+  (public_name jbuilder.configurator)
   (libraries (stdune ocaml_config))
   (flags (:standard -safe-string (:include flags/flags.sexp)))
   (preprocess no_preprocessing)))

--- a/src/ocaml-config/jbuild
+++ b/src/ocaml-config/jbuild
@@ -2,5 +2,6 @@
 
 (library
  ((name      ocaml_config)
+  (public_name jbuilder.ocaml_config)
   (libraries (stdune usexp))
   (synopsis  "Interpret the output of 'ocamlc -config'")))

--- a/src/ocaml-config/jbuild
+++ b/src/ocaml-config/jbuild
@@ -4,4 +4,4 @@
  ((name      ocaml_config)
   (public_name jbuilder.ocaml_config)
   (libraries (stdune usexp))
-  (synopsis  "Interpret the output of 'ocamlc -config'")))
+  (synopsis  "[Internal] Interpret the output of 'ocamlc -config'")))

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -1,4 +1,6 @@
-(** Represent the output of [ocamlc -config] *)
+(** Represent the output of [ocamlc -config].
+
+    This library is internal to jbuilder and guarantees no API stability. *)
 
 open Stdune
 

--- a/src/stdune/caml/caml.ml
+++ b/src/stdune/caml/caml.ml
@@ -1,3 +1,5 @@
+(** This library is internal to jbuilder and guarantees no API stability. *)
+
 module Filename = Filename
 module String   = String
 module Char     = Char

--- a/src/stdune/caml/jbuild
+++ b/src/stdune/caml/jbuild
@@ -1,4 +1,4 @@
 (library
  ((name caml)
   (public_name jbuilder.caml)
-  (synopsis "Wrapped version of the OCaml stdlib")))
+  (synopsis "[Internal] Wrapped version of the OCaml stdlib")))

--- a/src/stdune/caml/jbuild
+++ b/src/stdune/caml/jbuild
@@ -1,3 +1,4 @@
 (library
  ((name caml)
+  (public_name jbuilder.caml)
   (synopsis "Wrapped version of the OCaml stdlib")))

--- a/src/stdune/jbuild
+++ b/src/stdune/jbuild
@@ -1,5 +1,5 @@
 (library
  ((name stdune)
   (public_name jbuilder.stdune)
-  (synopsis "Standard library of Dune")
+  (synopsis "[Internal] Standard library of Dune")
   (libraries (caml unix))))

--- a/src/stdune/jbuild
+++ b/src/stdune/jbuild
@@ -1,4 +1,5 @@
 (library
  ((name stdune)
+  (public_name jbuilder.stdune)
   (synopsis "Standard library of Dune")
   (libraries (caml unix))))

--- a/src/usexp/jbuild
+++ b/src/usexp/jbuild
@@ -1,6 +1,8 @@
 (jbuild_version 1)
 
-(library ((name usexp)))
+(library
+ ((name usexp)
+  (public_name jbuilder.usexp)))
 
 (rule
  (with-stdout-to table.ml.gen (run gen/gen_parser_automaton.exe)))

--- a/src/usexp/jbuild
+++ b/src/usexp/jbuild
@@ -2,6 +2,7 @@
 
 (library
  ((name usexp)
+  (synopsis "[Internal] S-expression library")
   (public_name jbuilder.usexp)))
 
 (rule

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -1,4 +1,6 @@
-(** Parsing of s-expressions *)
+(** Parsing of s-expressions.
+
+    This library is internal to jbuilder and guarantees no API stability.*)
 
 module Atom : sig
   type t = private A of string [@@unboxed]

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -459,3 +459,13 @@
     (progn
      (run ${exe:cram.exe} run.t)
      (diff? run.t run.t.corrected))))))
+
+(alias
+ ((name runtest)
+  (deps ((package jbuilder)
+         (files_recursively_in test-cases/configurator)))
+  (action
+   (chdir test-cases/configurator
+    (progn
+     (run ${exe:cram.exe} run.t)
+     (diff? run.t run.t.corrected))))))

--- a/test/blackbox-tests/test-cases/configurator/c_test/jbuild
+++ b/test/blackbox-tests/test-cases/configurator/c_test/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(executable
+ ((name run)
+  (libraries (jbuilder.configurator))))

--- a/test/blackbox-tests/test-cases/configurator/c_test/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/c_test/run.ml
@@ -1,0 +1,15 @@
+
+let () =
+  Configurator.main ~name:"c_test" (fun t ->
+    let c_result =
+      Configurator.c_test t {c|
+#include <stdio.h>
+int main()
+{
+   printf("Hello, World!");
+   return 0;
+}
+|c} in
+    assert c_result;
+    print_endline "Successfully compiled c program"
+  )

--- a/test/blackbox-tests/test-cases/configurator/config/jbuild
+++ b/test/blackbox-tests/test-cases/configurator/config/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(executable
+ ((name run)
+  (libraries (jbuilder.configurator))))

--- a/test/blackbox-tests/test-cases/configurator/config/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/config/run.ml
@@ -1,0 +1,6 @@
+let () =
+  Configurator.main ~name:"config" (fun t ->
+    match Configurator.ocaml_config_var t "version" with
+    | None -> failwith "version is absent"
+    | Some _ -> print_endline "version is present"
+  )

--- a/test/blackbox-tests/test-cases/configurator/import-define/jbuild
+++ b/test/blackbox-tests/test-cases/configurator/import-define/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(executable
+ ((name run)
+  (libraries (jbuilder.configurator))))

--- a/test/blackbox-tests/test-cases/configurator/import-define/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/import-define/run.ml
@@ -1,0 +1,15 @@
+let () =
+  let module C_define = Configurator.C_define in
+  Configurator.main ~name:"c_test" (fun t ->
+    assert (
+      C_define.import t
+        ~includes:["caml/config.h"]
+        [ "CAML_CONFIG_H", C_define.Type.Switch
+        ; "Page_log", C_define.Type.Int
+        ] =
+      [ "CAML_CONFIG_H", C_define.Value.Switch true
+      ; "Page_log", Int 12
+      ]
+    );
+    print_endline "Successfully import #define's"
+  )

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -1,2 +1,3 @@
   $ jbuilder exec config/run.exe
   version is present
+  $ jbuilder exec c_test/run.exe

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -1,3 +1,8 @@
+Show that config values are present
   $ jbuilder exec config/run.exe
   version is present
+
+We're able to compile C program sucessfully
   $ jbuilder exec c_test/run.exe
+  Successfully compiled c program
+

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -6,3 +6,6 @@ We're able to compile C program sucessfully
   $ jbuilder exec c_test/run.exe
   Successfully compiled c program
 
+Importing #define's from code is successful
+  $ jbuilder exec import-define/run.exe
+  Successfully import #define's

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -1,0 +1,2 @@
+  $ jbuilder exec config/run.exe
+  version is present


### PR DESCRIPTION
This is now possible after the recent improvements to the black box tests.

One slightly undesirable thing is that it also forces us to declare all the sub libraries as public as well. But I think that this is basically unavoidable and will come eventually. I don't think that the other libraries should delay the release of configurator.

@dra27 is there a convenient string valued defined we can use in the tests (for completeness).