### PR TITLE
Use 4.06.1 in jbuild-workspace.dev

### DIFF
--- a/jbuild-workspace.dev
+++ b/jbuild-workspace.dev
@@ -3,5 +3,5 @@
 (context (opam (switch 4.03.0)))
 (context (opam (switch 4.04.2)))
 (context (opam (switch 4.05.0)))
-(context (opam (switch 4.06.0)))
+(context (opam (switch 4.06.1)))
 (context (opam (switch 4.07.0+trunk)))


### PR DESCRIPTION
We should use the latest point release for a particular release