### PR TITLE
Remove ~has_dot_merlin flag

### DIFF
--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -787,7 +787,7 @@ module Gen(P : Install_rules.Params) = struct
         ~allow_overlaps:lib.buildable.allow_overlapping_dependencies
     in
     SC.Libs.gen_select_rules sctx compile_info ~dir;
-    SC.Libs.with_lib_deps sctx compile_info ~dir ~has_dot_merlin:true
+    SC.Libs.with_lib_deps sctx compile_info ~dir
       ~f:(fun () ->
         library_rules lib ~modules_partitioner ~dir ~files ~scope ~compile_info)
 
@@ -900,7 +900,7 @@ module Gen(P : Install_rules.Params) = struct
         ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
     in
     SC.Libs.gen_select_rules sctx compile_info ~dir;
-    SC.Libs.with_lib_deps sctx compile_info ~dir ~has_dot_merlin:true
+    SC.Libs.with_lib_deps sctx compile_info ~dir
       ~f:(fun () ->
         executables_rules exes ~dir ~all_modules
           ?modules_partitioner ~scope ~compile_info)

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -272,7 +272,7 @@ module Libs = struct
                  raise (Lib.Error (No_solution_found_for_select e))
              }))
 
-  let with_lib_deps t compile_info ~dir ~has_dot_merlin ~f =
+  let with_lib_deps t compile_info ~dir ~f =
     let prefix =
       Build.record_lib_deps (Lib.Compile.user_written_deps compile_info)
         ~kind:(if Lib.Compile.optional compile_info then
@@ -281,7 +281,7 @@ module Libs = struct
                  Required)
     in
     let prefix =
-      if t.context.merlin && has_dot_merlin then
+      if t.context.merlin then
         Build.path (Path.relative dir ".merlin-exists")
         >>>
         prefix

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -137,7 +137,6 @@ module Libs : sig
     :  t
     -> Lib.Compile.t
     -> dir:Path.t
-    -> has_dot_merlin:bool
     -> f:(unit -> 'a)
     -> 'a
 


### PR DESCRIPTION
it was introduced to avoid generaitng a needless .merlin file for utop levels.
But now that we have a better mechanism for that, it serves no purpose.

Fix #684 . On second glance, this argument definitely doesn't seem useful anymore.