### PR TITLE
Add test to show that jbuilder mishandles ${null}

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -1061,7 +1061,11 @@ module Infer = struct
 
   module Unexp = Make(Unexpanded.Uast)(S_unexp)(Outcome_unexp)(struct
       open Outcome_unexp
-      let ( +@ ) acc fn = { acc with targets = fn :: acc.targets }
+      let ( +@ ) acc fn =
+        if SW.is_var fn ~name:"null" then
+          acc
+        else
+          { acc with targets = fn :: acc.targets }
       let ( +< ) acc _ = acc
       let ( +<! )= ( +< )
     end)

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -198,3 +198,8 @@ let to_string t =
     |> String.concat ~sep:""
 
 let sexp_of_t t = Sexp.To_sexp.string (to_string t)
+
+let is_var t ~name =
+  match t.items with
+  | [Var (_, v)] -> v = name
+  | _ -> false

--- a/src/string_with_vars.mli
+++ b/src/string_with_vars.mli
@@ -43,6 +43,8 @@ val iter : t -> f:(Loc.t -> string -> unit) -> unit
 (** [iter t ~f] iterates [f] over all variables of [t], the text
    portions being ignored. *)
 
+val is_var : t -> name:string -> bool
+
 module type EXPANSION = sig
   type t
   (** The value to which variables are expanded. *)

--- a/test/blackbox-tests/jbuild
+++ b/test/blackbox-tests/jbuild
@@ -480,3 +480,12 @@
      (run ${exe:cram.exe} run.t)
      (diff? run.t run.t.corrected))))))
 
+(alias
+ ((name runtest)
+  (deps ((package jbuilder)
+         (files_recursively_in test-cases/null-dep)))
+  (action
+   (chdir test-cases/null-dep
+    (progn
+     (run ${exe:cram.exe} run.t)
+     (diff? run.t run.t.corrected))))))

--- a/test/blackbox-tests/test-cases/null-dep/jbuild
+++ b/test/blackbox-tests/test-cases/null-dep/jbuild
@@ -1,0 +1,5 @@
+(jbuild_version 1)
+
+(alias
+ ((name runtest)
+  (action (with-stdout-to ${null} (echo "hello world")))))

--- a/test/blackbox-tests/test-cases/null-dep/run.t
+++ b/test/blackbox-tests/test-cases/null-dep/run.t
@@ -1,4 +1,1 @@
   $ jbuilder runtest --debug-dependency-path
-  File "jbuild", line 5, characters 26-33:
-  Warning: Aliases must not have targets, this target will be ignored.
-  This will become an error in the future.

--- a/test/blackbox-tests/test-cases/null-dep/run.t
+++ b/test/blackbox-tests/test-cases/null-dep/run.t
@@ -1,0 +1,4 @@
+  $ jbuilder runtest --debug-dependency-path
+  File "jbuild", line 5, characters 26-33:
+  Warning: Aliases must not have targets, this target will be ignored.
+  This will become an error in the future.


### PR DESCRIPTION
Jbuilder incorrectly infers ${null} to be a target