### PR TITLE
Pass ocamlc explicitly to configurator using DUNE_CONFIGURATOR

### DIFF
--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -427,7 +427,14 @@ let main ?(args=[]) ~name f =
   let dest_dir = ref None in
   let args =
     Arg.align
-      ([ "-ocamlc", Arg.String (fun s -> ocamlc := Some s),
+      ([ "-ocamlc", Arg.String (fun s ->
+         Option.iter !ocamlc ~f:(fun _ ->
+           Format.eprintf
+             "ocamlc is already passed through DUNE_CONFIGURATOR. \
+              There's no need to pass it manually through -ocamlc.@."
+         );
+         ocamlc := Some s
+       ),
          "PATH ocamlc command to use. \
           This value is set automatically when configurator is invoked by dune."
        ; "-verbose", Arg.Set verbose,

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -422,22 +422,15 @@ let main ?(args=[]) ~name f =
   let ocamlc  = ref (
     match Sys.getenv "DUNE_CONFIGURATOR" with
     | s -> Some s
-    | exception Not_found -> None) in
+    | exception Not_found ->
+      die "Configurator scripts must be ran with jbuilder. \
+           To manually run a script, use $ jbuilder exec."
+  ) in
   let verbose = ref false in
   let dest_dir = ref None in
   let args =
     Arg.align
-      ([ "-ocamlc", Arg.String (fun s ->
-         Option.iter !ocamlc ~f:(fun _ ->
-           Format.eprintf
-             "ocamlc is already passed through DUNE_CONFIGURATOR. \
-              There's no need to pass it manually through -ocamlc.@."
-         );
-         ocamlc := Some s
-       ),
-         "PATH ocamlc command to use. \
-          This value is set automatically when configurator is invoked by dune."
-       ; "-verbose", Arg.Set verbose,
+      ([ "-verbose", Arg.Set verbose,
          " be verbose"
        ; "-dest-dir", Arg.String (fun s -> dest_dir := Some s),
          "DIR save temporary files to this directory"

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -419,7 +419,10 @@ module Pkg_config = struct
 end
 
 let main ?(args=[]) ~name f =
-  let ocamlc  = ref (Sys.getenv_opt "DUNE_CONFIGURATOR") in
+  let ocamlc  = ref (
+    match Sys.getenv "DUNE_CONFIGURATOR" with
+    | s -> Some s
+    | exception Not_found -> None) in
   let verbose = ref false in
   let dest_dir = ref None in
   let args =

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -419,13 +419,14 @@ module Pkg_config = struct
 end
 
 let main ?(args=[]) ~name f =
-  let ocamlc  = ref None  in
+  let ocamlc  = ref (Sys.getenv_opt "DUNE_CONFIGURATOR") in
   let verbose = ref false in
   let dest_dir = ref None in
   let args =
     Arg.align
       ([ "-ocamlc", Arg.String (fun s -> ocamlc := Some s),
-         "PATH ocamlc command to use"
+         "PATH ocamlc command to use. \
+          This value is set automatically when configurator is invoked by dune."
        ; "-verbose", Arg.Set verbose,
          " be verbose"
        ; "-dest-dir", Arg.String (fun s -> dest_dir := Some s),

--- a/src/context.ml
+++ b/src/context.ml
@@ -303,6 +303,7 @@ let create ~(kind : Kind.t) ~path ~env ~name ~merlin ~targets () =
                "lib")
         ; extend_var "MANPATH"
             (Config.local_install_man_dir ~context:name)
+        ; "DUNE_CONFIGURATOR", (Path.to_string ocamlc)
         ]
       in
       Env.extend env ~vars:(Env.Map.of_list_exn vars)

--- a/test/blackbox-tests/test-cases/configurator/config/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/config/run.ml
@@ -1,6 +1,10 @@
 module Configurator = Configurator.V1
 
 let () =
+  begin match Sys.getenv_opt "DUNE_CONFIGURATOR" with
+  | None -> failwith "DUNE_CONFIGURATOR is not passed"
+  | Some _ -> print_endline "DUNE_CONFIGURATOR is present"
+  end;
   Configurator.main ~name:"config" (fun t ->
     match Configurator.ocaml_config_var t "version" with
     | None -> failwith "version is absent"

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -1,5 +1,6 @@
 Show that config values are present
   $ jbuilder exec config/run.exe
+  DUNE_CONFIGURATOR is present
   version is present
 
 We're able to compile C program sucessfully


### PR DESCRIPTION
The simplest way of obsoleting the `-ocamlc` flag. Some notes:

* We are likely to still want to keep `-ocamlc` for debugging, but ideally, warn the user that this isn't necessary. Should we use the `INSIDE_DUNE` variable in configurator to issue a warning when this flag is passed?

* Ideally, `DUNE_CONFIGURATOR` would be an s-expression containing all the config info dune wants to pass to configurator. But there's a couple of issues with this. The first one is that it's tough to write an sexp parser in configurator since the `Sexp` module is in dune itself. And the second issue is that we'd prefer to share the configuration record, but that would require a dependency between dune and configurator. To solve this, I guess we could make `Sexp` part of usexp (or a separate, internal lib) and then have dune depend on configurator to get the record definition. Not sure if this is right however.

Anyway, the contents of `DUNE_CONFIGURATOR` is an implementation detail and is easy to safely change. So we can always punt these decisions until later.