### PR TITLE
Do not load the user configuration file when INSIDE_DUNE is set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+next
+----
+
+- Do not load the user configuration file when running inside dune
+  (#..., @diml)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -235,7 +235,11 @@ let common =
       match config_file with
       | No_config  -> Config.default
       | This fname -> Config.load_config_file ~fname
-      | Default    -> Config.load_user_config_file ()
+      | Default    ->
+        if Config.inside_dune then
+          Config.default
+        else
+          Config.load_user_config_file ()
     in
     let config =
       Config.merge config


### PR DESCRIPTION
Otherwise the tests end up running with `-j something` if you have `(jobs ...)` in the configuration file.