### PR TITLE
Improve configurator tests

### DIFF
--- a/test/blackbox-tests/test-cases/configurator/import-define/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/import-define/run.ml
@@ -3,15 +3,18 @@ module Configurator = Configurator.V1
 let () =
   let module C_define = Configurator.C_define in
   Configurator.main ~name:"c_test" (fun t ->
-    assert (
-      C_define.import t
-        ~includes:["caml/config.h"]
-        [ "CAML_CONFIG_H", C_define.Type.Switch
-        ; "Page_log", C_define.Type.Int
-        ] =
-      [ "CAML_CONFIG_H", C_define.Value.Switch true
-      ; "Page_log", Int 12
+    C_define.import t
+      ~includes:["caml/config.h"]
+      [ "CAML_CONFIG_H", C_define.Type.Switch
+      ; "Page_log", C_define.Type.Int
+      ; "__func__", C_define.Type.String
       ]
-    );
-    print_endline "Successfully import #define's"
+    |> List.iter (fun (n, v) ->
+      Printf.printf "%s=%s\n"
+        n (match v with
+          | C_define.Value.String s -> s
+          | Int i -> string_of_int i
+          | Switch b -> string_of_bool b
+        )
+    )
   )

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -9,4 +9,6 @@ We're able to compile C program sucessfully
 
 Importing #define's from code is successful
   $ jbuilder exec import-define/run.exe
-  Successfully import #define's
+  CAML_CONFIG_H=true
+  Page_log=12
+  __func__=main


### PR DESCRIPTION
* Don't use asserts to test extracted values. Just print them and relying on
  diffing for comparison

* Use a string constant type.