### PR TITLE
Add ?macros argument when import constants

### DIFF
--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -283,12 +283,13 @@ module C_define = struct
       | String of string
   end
 
-  let import t ?c_flags ?link_flags ~includes vars =
+  let import t ?prelude ?c_flags ?link_flags ~includes vars =
     let buf = Buffer.create 1024 in
     let pr fmt = Printf.bprintf buf (fmt ^^ "\n") in
     let includes = "stdio.h" :: includes in
     List.iter includes ~f:(pr "#include <%s>");
     pr "";
+    Option.iter prelude ~f:(pr "%s");
     pr "int main()";
     pr "{";
     List.iter vars ~f:(fun (name, (kind : Type.t)) ->

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -44,6 +44,9 @@ module C_define : sig
   *)
   val import
     :  t
+    -> ?prelude: string
+    (** Define extra code be used with extracting values below. Note that the
+        compiled code is never executed. *)
     -> ?c_flags:   string list
     -> ?link_flags:string list
     -> includes:   string list

--- a/test/blackbox-tests/test-cases/configurator/import-define/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/import-define/run.ml
@@ -4,10 +4,11 @@ let () =
   let module C_define = Configurator.C_define in
   Configurator.main ~name:"c_test" (fun t ->
     C_define.import t
+      ~prelude:{|#define CONFIGURATOR_TESTING "foobar"|}
       ~includes:["caml/config.h"]
       [ "CAML_CONFIG_H", C_define.Type.Switch
       ; "Page_log", C_define.Type.Int
-      ; "__func__", C_define.Type.String
+      ; "CONFIGURATOR_TESTING", C_define.Type.String
       ]
     |> List.iter (fun (n, v) ->
       Printf.printf "%s=%s\n"

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -11,4 +11,4 @@ Importing #define's from code is successful
   $ jbuilder exec import-define/run.exe
   CAML_CONFIG_H=true
   Page_log=12
-  __func__=main
+  CONFIGURATOR_TESTING=foobar


### PR DESCRIPTION
A user can now define their own macros to use with extracting compile time info.

We need this ability for proper tests in the #678 to make sure that extracting string constants works the same way. `__func__` doesn't work like a proper macro because it isn't expanded by the preprocessor.