### PR TITLE
?extra_targets --> Arg_spec.Hidden_targets

### DIFF
--- a/src/arg_spec.mli
+++ b/src/arg_spec.mli
@@ -38,7 +38,8 @@ type 'a t =
   | Target   of Path.t
   | Path     of Path.t
   | Paths    of Path.t list
-  | Hidden_deps of Path.t list
+  | Hidden_deps    of Path.t list
+  | Hidden_targets of Path.t list
   (** Register dependencies but produce no argument *)
   | Dyn      of ('a -> nothing t)
 

--- a/src/build.ml
+++ b/src/build.ml
@@ -211,14 +211,8 @@ let prog_and_args ?(dir=Path.root) prog args =
     >>>
     arr fst))
 
-let run ~context ?(dir=context.Context.build_dir) ?stdout_to ?(extra_targets=[])
-      prog args =
-  let extra_targets =
-    match stdout_to with
-    | None -> extra_targets
-    | Some fn -> fn :: extra_targets
-  in
-  let targets = Arg_spec.add_targets args extra_targets in
+let run ~context ?(dir=context.Context.build_dir) ?stdout_to prog args =
+  let targets = Arg_spec.add_targets args (Option.to_list stdout_to) in
   prog_and_args ~dir prog args
   >>>
   Targets targets

--- a/src/build.mli
+++ b/src/build.mli
@@ -133,7 +133,6 @@ val run
   :  context:Context.t
   -> ?dir:Path.t (* default: [context.build_dir] *)
   -> ?stdout_to:Path.t
-  -> ?extra_targets:Path.t list
   -> Action.Prog.t
   -> 'a Arg_spec.t list
   -> ('a, Action.t) t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -471,10 +471,6 @@ module Gen(P : Install_rules.Params) = struct
            (SC.expand_and_eval_set sctx ~scope ~dir lib.library_flags ~standard:[])
          >>>
          Build.run ~context:ctx (Ok compiler)
-           ~extra_targets:(
-             match mode with
-             | Byte -> []
-             | Native -> [lib_archive lib ~dir ~ext:ctx.ext_lib])
            [ Dyn (fun (_, _, flags, _) -> As flags)
            ; A "-a"; A "-o"; Target target
            ; As stubs_flags
@@ -484,6 +480,10 @@ module Gen(P : Install_rules.Params) = struct
                | Normal -> []
                | Ppx_deriver | Ppx_rewriter -> ["-linkall"])
            ; Dyn (fun (cm_files, _, _, _) -> Deps cm_files)
+           ; Hidden_targets
+               (match mode with
+                | Byte -> []
+                | Native -> [lib_archive lib ~dir ~ext:ctx.ext_lib])
            ]))
 
   let build_c_file (lib : Library.t) ~scope ~dir ~includes c_name =
@@ -652,7 +652,6 @@ module Gen(P : Install_rules.Params) = struct
                lib.c_library_flags ~standard:[]
              >>>
              Build.run ~context:ctx
-               ~extra_targets:targets
                (Ok ctx.ocamlmklib)
                [ As (Utils.g ())
                ; if custom then A "-custom" else As []
@@ -667,6 +666,7 @@ module Gen(P : Install_rules.Params) = struct
                    else
                      As cclibs
                  )
+               ; Hidden_targets targets
                ])
         in
         let static = stubs_archive lib ~dir in

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -28,12 +28,12 @@ let gen_rules sctx ~dir ~scope (t : Jbuild.Menhir.t) =
   let menhir_binary =
     SC.resolve_program sctx "menhir" ~hint:"opam install menhir"
   in
-  (* [extra_targets] is to tell Jbuilder about generated files that do
-     not appear in the menhir command line. *)
-  let menhir ~extra_targets args =
+  (* [hidden_targets] is to tell Jbuilder about generated files that
+     do not appear in the menhir command line. *)
+  let menhir args =
     flags
     >>>
-    Build.run ~extra_targets
+    Build.run
       menhir_binary
       ~dir
       ~context:(SC.context sctx)
@@ -48,16 +48,16 @@ let gen_rules sctx ~dir ~scope (t : Jbuild.Menhir.t) =
     List.concat_map t.modules ~f:(fun name ->
       add_rule_get_targets (
         menhir
-          ~extra_targets:(targets name)
           [ Dyn (fun x -> As x)
           ; Dep (mly name)
+          ; Hidden_targets (targets name)
           ]))
   | Some merge_into ->
     add_rule_get_targets (
       menhir
-        ~extra_targets:(targets merge_into)
         [ A "--base" ; A merge_into
         ; Dyn (fun x -> As x)
         ; Deps (List.map ~f:mly t.modules)
-        ]
+        ; Hidden_targets (targets merge_into)
+      ]
     )

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -175,11 +175,12 @@ module Gen (S : sig val sctx : SC.t end) = struct
          Build.remove_tree to_remove
          :: Build.mkdir odoc_file.html_dir
          :: Build.run ~context ~dir:Paths.html_root
-              odoc ~extra_targets:[odoc_file.html_file]
+              odoc
               [ A "html"
               ; odoc_include_flags requires
               ; A "-o"; Path Paths.html_root
               ; Dep odoc_file.odoc_input
+              ; Hidden_targets [odoc_file.html_file]
               ]
          :: jbuilder_keep
        )
@@ -213,9 +214,10 @@ module Gen (S : sig val sctx : SC.t end) = struct
     SC.add_rule sctx
       (Build.run ~context
          ~dir:context.build_dir
-         ~extra_targets:[css_file]
          odoc
-         [ A "css"; A "-o"; Path Paths.html_root ])
+         [ A "css"; A "-o"; Path Paths.html_root
+         ; Hidden_targets [css_file]
+         ])
 
   let sp = Printf.sprintf
 


### PR DESCRIPTION
This PR replaces the `?extra_targets` argument of `Build.run` by `Arg_spec.Hidden_targets`. The latter allows to specify targets that do not appear on the command line through `Arg_spec`, similarly to `Hidden_deps`. I find it a bit more homogeneous this way.