### PR TITLE
Make sure all_lib_deps_by_context doesn't report invalid contexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ next
   compiler might read `.cm*` files recursively (#666, fixes #660,
   @emillon)
 
+- Fix a bug causing `jbuilder external-lib-deps` to crash (#723,
+  @diml)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -1285,6 +1285,7 @@ let all_lib_deps_by_context t ~request =
       | None -> acc
       | Some (context, _) -> (context, deps) :: acc)
   |> String.Map.of_list_multi
+  |> String.Map.filteri ~f:(fun ctx _ -> String.Map.mem t.contexts ctx)
   |> String.Map.map ~f:(function
     | [] -> String.Map.empty
     | x :: l -> List.fold_left l ~init:x ~f:Build.merge_lib_deps)


### PR DESCRIPTION
This fixes a bug reported by @samoht on slack