### PR TITLE
Fix flags in output-obj test

### DIFF
--- a/test/blackbox-tests/test-cases/output-obj/jbuild
+++ b/test/blackbox-tests/test-cases/output-obj/jbuild
@@ -33,7 +33,7 @@
 (rule
  ((targets (dynamic.exe))
   (deps (dynamic.c))
-  (action (run ${CC} -o ${@} ${<} -ldl))))
+  (action (run ${CC} -o ${@} ${<} ${ocaml-config:native_c_libraries}))))
 
 (alias
  ((name runtest)


### PR DESCRIPTION
I found this while debugging `-output-complete-obj` on FreeBSD