### PR TITLE
Get rid of jbuild_file_in

### DIFF
--- a/src/dep_path.ml
+++ b/src/dep_path.ml
@@ -8,8 +8,6 @@ module Entry = struct
     | Preprocess of string list
     | Loc of Loc.t
 
-  let jbuild_file_in ~dir = Path (Utils.jbuild_file_in ~dir)
-
   let to_string = function
     | Path p -> Utils.describe_target p
     | Alias p -> "alias " ^ Utils.describe_target p

--- a/src/dep_path.mli
+++ b/src/dep_path.mli
@@ -10,9 +10,6 @@ module Entry : sig
     | Preprocess of string list
     | Loc of Loc.t
 
-  (** [jbuild_file_in ~dir = Path (Path.relative dir "jbuild")] *)
-  val jbuild_file_in : dir:Path.t -> t
-
   val to_string : t -> string
   val pp : Format.formatter -> t -> unit
 end

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -191,7 +191,8 @@ module Gen(P : Install_rules.Params) = struct
        >>>
        SC.Action.run
          sctx
-         rule.action
+         (snd rule.action)
+         ~loc:(fst rule.action)
          ~dir
          ~dep_kind:Required
          ~targets
@@ -919,7 +920,8 @@ module Gen(P : Install_rules.Params) = struct
       Sexp.List
         [ Sexp.unsafe_atom_of_string "user-alias"
         ; S.list   Jbuild.Dep_conf.sexp_of_t   alias_conf.deps
-        ; S.option Action.Unexpanded.sexp_of_t alias_conf.action
+        ; S.option Action.Unexpanded.sexp_of_t
+            (Option.map alias_conf.action ~f:snd)
         ]
     in
     add_alias
@@ -931,10 +933,11 @@ module Gen(P : Install_rules.Params) = struct
        >>>
        match alias_conf.action with
        | None -> Build.progn []
-       | Some action ->
+       | Some (loc, action) ->
          SC.Action.run
            sctx
            action
+           ~loc
            ~dir
            ~dep_kind:Required
            ~targets:Alias
@@ -948,9 +951,7 @@ module Gen(P : Install_rules.Params) = struct
     (* This interprets "rule" and "copy_files" stanzas. *)
     let files = text_files ~dir:ctx_dir in
     let all_modules = modules_by_dir ~dir:ctx_dir in
-    let modules_partitioner =
-      Modules_partitioner.create ~dir:src_dir ~all_modules
-    in
+    let modules_partitioner = Modules_partitioner.create ~all_modules in
     List.filter_map stanzas ~f:(fun stanza ->
       let dir = ctx_dir in
       match (stanza : Stanza.t) with

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -279,13 +279,14 @@ module Preprocess = struct
   type pps = { pps : (Loc.t * Pp.t) list; flags : string list }
   type t =
     | No_preprocessing
-    | Action of Action.Unexpanded.t
+    | Action of Loc.t * Action.Unexpanded.t
     | Pps    of pps
 
   let t =
     sum
       [ cstr "no_preprocessing" nil No_preprocessing
-      ; cstr "action" (Action.Unexpanded.t @> nil) (fun x -> Action x)
+      ; cstr "action" (located Action.Unexpanded.t @> nil)
+          (fun (loc, x) -> Action (loc, x))
       ; cstr "pps" (list Pp_or_flags.t @> nil) (fun l ->
           let pps, flags = Pp_or_flags.split l in
           Pps { pps; flags })
@@ -983,7 +984,7 @@ module Rule = struct
   type t =
     { targets  : Targets.t
     ; deps     : Dep_conf.t list
-    ; action   : Action.Unexpanded.t
+    ; action   : Loc.t * Action.Unexpanded.t
     ; mode     : Mode.t
     ; locks    : String_with_vars.t list
     ; loc      : Loc.t
@@ -992,10 +993,10 @@ module Rule = struct
   let v1 sexp =
     let loc = Sexp.Ast.loc sexp in
     match sexp with
-    | List (_, (Atom _ :: _)) ->
+    | List (loc, (Atom _ :: _)) ->
       { targets  = Infer
       ; deps     = []
-      ; action   = Action.Unexpanded.t sexp
+      ; action   = (loc, Action.Unexpanded.t sexp)
       ; mode     = Standard
       ; locks    = []
       ; loc      = loc
@@ -1004,7 +1005,7 @@ module Rule = struct
       record
         (field "targets" (list file_in_current_dir)    >>= fun targets ->
          field "deps"    (list Dep_conf.t) ~default:[] >>= fun deps ->
-         field "action"  Action.Unexpanded.t           >>= fun action ->
+         field "action"  (located Action.Unexpanded.t) >>= fun action ->
          field "locks"   (list String_with_vars.t) ~default:[] >>= fun locks ->
          map_validate
            (field_b "fallback" >>= fun fallback ->
@@ -1057,14 +1058,15 @@ module Rule = struct
       { targets = Static [dst]
       ; deps    = [File (S.virt_text __POS__ src)]
       ; action  =
-          Chdir
-            (S.virt_var __POS__ "ROOT",
-             Run (S.virt_text __POS__ "ocamllex",
-                  [ S.virt_text __POS__ "-q"
-                  ; S.virt_text __POS__ "-o"
-                  ; S.virt_var __POS__ "@"
-                  ; S.virt_var __POS__"<"
-                  ]))
+          (loc,
+           Chdir
+             (S.virt_var __POS__ "ROOT",
+              Run (S.virt_text __POS__ "ocamllex",
+                   [ S.virt_text __POS__ "-q"
+                   ; S.virt_text __POS__ "-o"
+                   ; S.virt_var __POS__ "@"
+                   ; S.virt_var __POS__"<"
+                   ])))
       ; mode
       ; locks = []
       ; loc
@@ -1077,10 +1079,11 @@ module Rule = struct
       { targets = Static [name ^ ".ml"; name ^ ".mli"]
       ; deps    = [File (S.virt_text __POS__ src)]
       ; action  =
-          Chdir
-            (S.virt_var __POS__ "ROOT",
-             Run (S.virt_text __POS__ "ocamlyacc",
-                  [S.virt_var __POS__ "<"]))
+          (loc,
+           Chdir
+             (S.virt_var __POS__ "ROOT",
+              Run (S.virt_text __POS__ "ocamlyacc",
+                   [S.virt_var __POS__ "<"])))
       ; mode
       ; locks = []
       ; loc
@@ -1139,7 +1142,7 @@ module Alias_conf = struct
   type t =
     { name    : string
     ; deps    : Dep_conf.t list
-    ; action  : Action.Unexpanded.t option
+    ; action  : (Loc.t * Action.Unexpanded.t) option
     ; locks   : String_with_vars.t list
     ; package : Package.t option
     }
@@ -1149,7 +1152,7 @@ module Alias_conf = struct
       (field "name" string                              >>= fun name ->
        field "deps" (list Dep_conf.t) ~default:[]       >>= fun deps ->
        field_o "package" (Scope_info.package pkgs)      >>= fun package ->
-       field_o "action" Action.Unexpanded.t  >>= fun action ->
+       field_o "action" (located Action.Unexpanded.t)   >>= fun action ->
        field "locks" (list String_with_vars.t) ~default:[] >>= fun locks ->
        return
          { name

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -58,7 +58,7 @@ module Preprocess : sig
 
   type t =
     | No_preprocessing
-    | Action of Action.Unexpanded.t
+    | Action of Loc.t * Action.Unexpanded.t
     | Pps    of pps
 end
 
@@ -320,7 +320,7 @@ module Rule : sig
   type t =
     { targets  : Targets.t
     ; deps     : Dep_conf.t list
-    ; action   : Action.Unexpanded.t
+    ; action   : Loc.t * Action.Unexpanded.t
     ; mode     : Mode.t
     ; locks    : String_with_vars.t list
     ; loc      : Loc.t
@@ -348,7 +348,7 @@ module Alias_conf : sig
   type t =
     { name    : string
     ; deps    : Dep_conf.t list
-    ; action  : Action.Unexpanded.t option
+    ; action  : (Loc.t * Action.Unexpanded.t) option
     ; locks   : String_with_vars.t list
     ; package : Package.t option
     }

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -17,10 +17,10 @@ let in_build_dir ~ctx =
   let init = Path.relative ctx.Context.build_dir ".js" in
   List.fold_left ~init ~f:Path.relative
 
-let runtime_file ~sctx ~dir fname =
+let runtime_file ~sctx fname =
   match
     Artifacts.file_of_lib (SC.artifacts sctx)
-      ~loc:(Loc.in_file (Utils.jbuild_file_in ~dir |> Path.to_string))
+      ~loc:Loc.none
       ~lib:"js_of_ocaml-compiler" ~file:fname
   with
   | Error _ ->
@@ -32,7 +32,7 @@ let runtime_file ~sctx ~dir fname =
 
 let js_of_ocaml_rule ~sctx ~dir ~flags ~spec ~target =
   let jsoo = SC.resolve_program sctx ~hint:install_jsoo_hint "js_of_ocaml" in
-  let runtime = runtime_file ~sctx ~dir "runtime.js" in
+  let runtime = runtime_file ~sctx "runtime.js" in
   Build.run ~context:(SC.context sctx) ~dir
     jsoo
     [ Arg_spec.Dyn flags

--- a/src/modules_partitioner.ml
+++ b/src/modules_partitioner.ml
@@ -1,14 +1,12 @@
 open Import
 
 type t =
-  { dir          : Path.t
-  ; all_modules  : Module.t Module.Name.Map.t
+  { all_modules  : Module.t Module.Name.Map.t
   ; mutable used : Loc.t list Module.Name.Map.t
   }
 
-let create ~dir ~all_modules =
-  { dir
-  ; all_modules
+let create ~all_modules =
+  { all_modules
   ; used = Module.Name.Map.empty
   }
 
@@ -27,13 +25,11 @@ let acknowledge t ~loc ~modules =
   already_used
 
 let emit_warnings t =
-  let loc =
-    Utils.jbuild_file_in ~dir:t.dir
-    |> Path.to_string
-    |> Loc.in_file
-  in
   Module.Name.Map.iteri t.used ~f:(fun name locs ->
-    if List.length locs > 1 then
+    match locs with
+    | [] | [_] -> ()
+    | loc :: _ ->
+      let loc = Loc.in_file loc.start.pos_fname in
       Loc.warn loc
         "Module %a is used in several stanzas:@\n\
          @[<v>%a@]@\n\

--- a/src/modules_partitioner.mli
+++ b/src/modules_partitioner.mli
@@ -1,12 +1,11 @@
 (** Checks modules partitioning inside a directory *)
 
-open Stdune
+open! Stdune
 
 type t
 
 val create
-  :  dir:Path.t
-  -> all_modules:Module.t Module.Name.Map.t
+  :  all_modules:Module.t Module.Name.Map.t
   -> t
 
 (** [acknowledge t ~loc ~modules] registers the fact that [modules]

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -246,7 +246,7 @@ let lint_module sctx ~dir ~dep_kind ~lint ~lib_name ~scope = Staged.stage (
     Per_module.map lint ~f:(function
       | Preprocess.No_preprocessing ->
         (fun ~source:_ ~ast:_ -> ())
-      | Action action ->
+      | Action (loc, action) ->
         (fun ~source ~ast:_ ->
            let action = Action.Unexpanded.Chdir (root_var, action) in
            Module.iter source ~f:(fun _ (src : Module.File.t) ->
@@ -256,6 +256,7 @@ let lint_module sctx ~dir ~dep_kind ~lint ~lib_name ~scope = Staged.stage (
                 >>^ (fun _ -> [src_path])
                 >>> SC.Action.run sctx
                       action
+                      ~loc
                       ~dir
                       ~dep_kind
                       ~targets:(Static [])
@@ -309,7 +310,7 @@ let pp_and_lint_modules sctx ~dir ~dep_kind ~modules ~lint ~preprocess
            let ast = setup_reason_rules sctx ~dir m in
            lint_module ~ast ~source:m;
            ast)
-      | Action action ->
+      | Action (loc, action) ->
         (fun m ->
            let ast =
              pped_module m ~dir ~f:(fun _kind src dst ->
@@ -325,6 +326,7 @@ let pp_and_lint_modules sctx ~dir ~dep_kind ~modules ~lint ~preprocess
                         target_var,
                         Chdir (root_var,
                                action)))
+                    ~loc
                     ~dir
                     ~dep_kind
                     ~targets:(Static [dst])

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -601,7 +601,7 @@ module Action = struct
         | "^" -> Some (Paths (deps_written_by_user, Split))
         | _ -> None)
 
-  let run sctx ?(extra_vars=String.Map.empty)
+  let run sctx ~loc ?(extra_vars=String.Map.empty)
         t ~dir ~dep_kind ~targets:targets_written_by_user ~scope
     : (Path.t list, Action.t) Build.t =
     let map_exe = map_exe sctx in
@@ -652,9 +652,9 @@ module Action = struct
     let targets = Pset.to_list targets in
     List.iter targets ~f:(fun target ->
       if Path.parent target <> dir then
-        Loc.fail (Loc.in_file (Utils.describe_target (Utils.jbuild_file_in ~dir)))
-          "A rule in this jbuild has targets in a different directory \
-           than the current one, this is not allowed by Jbuilder at the moment:\n%s"
+        Loc.fail loc
+          "This action has targets in a different directory than the current \
+           one, this is not allowed by Jbuilder at the moment:\n%s"
           (List.map targets ~f:(fun target ->
              sprintf "- %s" (Utils.describe_target target))
            |> String.concat ~sep:"\n"));

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -190,6 +190,7 @@ module Action : sig
   (** The arrow takes as input the list of actual dependencies *)
   val run
     :  t
+    -> loc:Loc.t
     -> ?extra_vars:Action.Var_expansion.t String.Map.t
     -> Action.Unexpanded.t
     -> dir:Path.t

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -64,8 +64,6 @@ let signal_name =
     | exception Not_found -> sprintf "%d\n" n
     | s -> s
 
-let jbuild_file_in ~dir = Path.relative dir "jbuild"
-
 type target_kind =
   | Regular of string * Path.t
   | Alias   of string * Path.t

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -12,9 +12,6 @@ val bash_exn : needed_to:string -> Path.t
 (** Convert a signal number to a name: INT, TERM, ... *)
 val signal_name : int -> string
 
-(** [jbuild_file_in ~dir = Path.relative dir "jbuild"]. *)
-val jbuild_file_in : dir:Path.t -> Path.t
-
 (** Nice description of a target *)
 val describe_target : Path.t -> string
 


### PR DESCRIPTION
And use more precise locations instead. This is in preparation of supporting `dune` files; since we will accept both `dune` and `jbuild` files, this function will become problematic.