### PR TITLE
Remove all hard coded uses of "_build"

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -123,7 +123,8 @@ let request_of_targets (setup : Main.setup) targets =
         | None -> (contexts, dir)
         | Some ("install", _) ->
           die "Invalid alias: %s.\n\
-               There are no aliases in _build/install."
+               There are no aliases in %s."
+            (Path.to_string_maybe_quoted Path.(relative build_dir "install"))
             (Path.to_string_maybe_quoted path)
         | Some (ctx, dir) -> ([ctx], dir)
       in

--- a/src/action.ml
+++ b/src/action.ml
@@ -647,7 +647,7 @@ module Promotion = struct
       Io.copy_file ~src ~dst
   end
 
-  let db_file = Path.relative_to_build_dir ".to-promote"
+  let db_file = Path.relative Path.build_dir ".to-promote"
 
   let dump_db db =
     if Path.build_dir_exists () then begin
@@ -729,14 +729,14 @@ let exec_run_direct ~ectx ~dir ~env ~stdout_to ~stderr_to prog args =
    | Some { Context.for_host = None; _ } -> ()
    | Some ({ Context.for_host = Some host; _ } as target) ->
      let invalid_prefix prefix =
-       match Path.descendant prog ~of_:(Path.of_string prefix) with
+       match Path.descendant prog ~of_:prefix with
        | None -> ()
        | Some _ ->
          die "Context %s has a host %s.@.It's not possible to execute binary %a \
               in it.@.@.This is a bug and should be reported upstream."
            target.name host.name Path.pp prog in
-     invalid_prefix ("_build/" ^ target.name);
-     invalid_prefix ("_build/install/" ^ target.name);
+     invalid_prefix (Path.relative Path.build_dir target.name);
+     invalid_prefix (Path.relative Path.build_dir ("install/" ^ target.name));
   end;
   Process.run Strict ~dir ~env
     ~stdout_to ~stderr_to

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -14,7 +14,7 @@ let misc_dir = Path.(relative build_dir) ".misc"
 module Promoted_to_delete = struct
   let db = ref []
 
-  let fn = Path.relative_to_build_dir ".to-delete-in-source-tree"
+  let fn = Path.relative Path.build_dir ".to-delete-in-source-tree"
 
   let add p = db := p :: !db
 
@@ -599,7 +599,7 @@ let make_local_parent_dirs t paths ~map_path =
       end
     | _ -> ())
 
-let sandbox_dir = Path.of_string "_build/.sandbox"
+let sandbox_dir = Path.relative Path.build_dir ".sandbox"
 
 let locks : (Path.t, Fiber.Mutex.t) Hashtbl.t = Hashtbl.create 32
 
@@ -1106,7 +1106,7 @@ let stamp_file_for_files_of t ~dir ~ext =
 module Trace = struct
   type t = (Path.t, Digest.t) Hashtbl.t
 
-  let file = Path.relative_to_build_dir ".db"
+  let file = Path.relative Path.build_dir ".db"
 
   let dump (trace : t) =
     let sexp =

--- a/src/config.ml
+++ b/src/config.ml
@@ -1,7 +1,7 @@
 open! Import
 
 let local_install_dir =
-  let dir = Path.(relative root) "_build/install" in
+  let dir = Path.relative Path.build_dir "install" in
   fun ~context -> Path.relative dir context
 
 let local_install_bin_dir ~context =

--- a/src/context.ml
+++ b/src/context.ml
@@ -197,7 +197,7 @@ let create ~(kind : Kind.t) ~path ~env ~name ~merlin ~targets () =
       | Some fn -> fn
     in
 
-    let build_dir = Path.of_string (sprintf "_build/%s" name) in
+    let build_dir = Path.relative Path.build_dir name in
     let ocamlpath =
       match
         let var = "OCAMLPATH" in

--- a/src/jbuild_load.ml
+++ b/src/jbuild_load.ml
@@ -24,7 +24,7 @@ module Jbuilds = struct
     ; ignore_promoted_rules : bool
     }
 
-  let generated_jbuilds_dir = Path.(relative root) "_build/.jbuilds"
+  let generated_jbuilds_dir = Path.relative Path.build_dir ".jbuilds"
 
   let ensure_parent_dir_exists path =
     match Path.kind path with

--- a/src/log.ml
+++ b/src/log.ml
@@ -13,7 +13,7 @@ let no_log = None
 
 let create ?(display=Config.default.display) () =
   Path.ensure_build_dir_exists ();
-  let oc = Io.open_out (Path.relative_to_build_dir "log") in
+  let oc = Io.open_out (Path.relative Path.build_dir "log") in
   Printf.fprintf oc "# %s\n# OCAMLPARAM: %s\n%!"
     (String.concat (List.map (Array.to_list Sys.argv) ~f:quote_for_shell) ~sep:" ")
     (match Env.get Env.initial "OCAMLPARAM" with

--- a/src/main.ml
+++ b/src/main.ml
@@ -259,7 +259,8 @@ let bootstrap () =
          ()
        >>= fun { build_system = bs; _ } ->
        Build_system.do_build bs
-         ~request:(Build.path (Path.of_string "_build/default/dune.install")))
+         ~request:(Build.path (
+           Path.relative Path.build_dir "default/dune.install")))
   in
   try
     main ()

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -457,8 +457,6 @@ let build_dir_exists () = is_directory build_dir
 
 let ensure_build_dir_exists () = Local.mkdir_p build_dir
 
-let relative_to_build_dir = relative build_dir
-
 let extend_basename t ~suffix = t ^ suffix
 
 let insert_after_build_dir_exn =

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -150,5 +150,3 @@ val pp : Format.formatter -> t -> unit
 val build_dir_exists : unit -> bool
 
 val ensure_build_dir_exists : unit -> unit
-
-val relative_to_build_dir : string -> t

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -183,7 +183,7 @@ module Cached_digest = struct
 
   let remove fn = Hashtbl.remove cache fn
 
-  let db_file = Path.relative_to_build_dir ".digest-db"
+  let db_file = Path.relative Path.build_dir ".digest-db"
 
   let dump () =
     let module Pmap = Path.Map in


### PR DESCRIPTION
Always route these cases through Path.build_dir.

I also got rid of Path.relative_to_buil_dir as I don't think it buys as much anymore.