### PR TITLE
Alias0.dir is always in build_dir

### DIFF
--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -233,6 +233,11 @@ module Alias0 = struct
 
   let make name ~dir =
     assert (not (String.contains name '/'));
+    if not (Path.is_in_build_dir dir) then
+      Exn.code_error "Alias0.make: Invalid alias"
+        [ "name", Sexp.To_sexp.string name
+        ; "dir", Path.sexp_of_t dir
+        ];
     { dir; name }
 
   let stamp_file t =

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -238,9 +238,10 @@ module Alias0 = struct
 
   let suffix = "-" ^ String.make 32 '0'
 
-  let of_path path =
+  let of_user_written_path ~loc path =
     if not (Path.is_in_build_dir path) then
-      die "Invalid alias!\nTried to reference alias %S"
+      Loc.fail loc "Invalid alias!\n\
+                    Tried to reference path outside build dir: %S"
         (Path.to_string_maybe_quoted path);
     make ~dir:(Path.parent path) (Path.basename path)
 

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -99,7 +99,7 @@ module Alias : sig
 
   val make : string -> dir:Path.t -> t
 
-  val of_path : Path.t -> t
+  val of_user_written_path : loc:Loc.t -> Path.t -> t
 
   (** The following always holds:
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -457,7 +457,9 @@ module Deps = struct
   open Dep_conf
 
   let make_alias t ~scope ~dir s =
-    Alias.of_path (Path.relative dir (expand_vars t ~scope ~dir s))
+    let loc = String_with_vars.loc s in
+    Alias.of_user_written_path ~loc
+      (Path.relative ~error_loc:loc dir (expand_vars t ~scope ~dir s))
 
   let dep t ~scope ~dir = function
     | File  s ->

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -7,6 +7,14 @@
     (progn (run ${exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
 (alias
+ ((name bad-alias-error)
+  (deps ((package dune) (files_recursively_in test-cases/bad-alias-error)))
+  (action
+   (chdir
+    test-cases/bad-alias-error
+    (progn (run ${exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
+
+(alias
  ((name byte-code-only)
   (deps ((package dune) (files_recursively_in test-cases/byte-code-only)))
   (action
@@ -446,6 +454,7 @@
  ((name runtest)
   (deps
    ((alias aliases)
+    (alias bad-alias-error)
     (alias byte-code-only)
     (alias c-stubs)
     (alias configurator)
@@ -499,6 +508,7 @@
  ((name runtest-no-deps)
   (deps
    ((alias aliases)
+    (alias bad-alias-error)
     (alias byte-code-only)
     (alias c-stubs)
     (alias configurator)

--- a/test/blackbox-tests/test-cases/bad-alias-error/absolute-path/jbuild
+++ b/test/blackbox-tests/test-cases/bad-alias-error/absolute-path/jbuild
@@ -1,0 +1,3 @@
+(alias
+ ((name runtest)
+  (deps ((alias /foo/bar)))))

--- a/test/blackbox-tests/test-cases/bad-alias-error/outside-workspace/jbuild
+++ b/test/blackbox-tests/test-cases/bad-alias-error/outside-workspace/jbuild
@@ -1,0 +1,4 @@
+
+(alias
+ ((name runtest)
+  (deps ((alias ${ROOT}/../../../foobar)))))

--- a/test/blackbox-tests/test-cases/bad-alias-error/run.t
+++ b/test/blackbox-tests/test-cases/bad-alias-error/run.t
@@ -1,5 +1,7 @@
   $ dune runtest --root absolute-path 2>&1 | grep -v Entering
-  Invalid alias!
-  Tried to reference alias "/foo/bar"
+  File "jbuild", line 3, characters 16-24:
+  Error: Invalid alias!
+  Tried to reference path outside build dir: "/foo/bar"
   $ dune runtest --root outside-workspace 2>&1 | grep -v Entering
-  Path outside the workspace: ./../../../foobar from _build/default
+  File "jbuild", line 4, characters 16-39:
+  Error: path outside the workspace: ./../../../foobar from _build/default

--- a/test/blackbox-tests/test-cases/bad-alias-error/run.t
+++ b/test/blackbox-tests/test-cases/bad-alias-error/run.t
@@ -1,0 +1,5 @@
+  $ dune runtest --root absolute-path 2>&1 | grep -v Entering
+  Invalid alias!
+  Tried to reference alias "/foo/bar"
+  $ dune runtest --root outside-workspace 2>&1 | grep -v Entering
+  Path outside the workspace: ./../../../foobar from _build/default


### PR DESCRIPTION
This is useful to catch bugs in implementing #744 

The 2nd commit feels a bit heavy handed but it's nice to have the extra safety of this. Another approach to help maintain this invariant would be to have some phantom types for paths to distinguish build vs. otherwise.