### PR TITLE
Add File_tree.Dir.dune_file

### DIFF
--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -129,17 +129,15 @@ let rule_loc ~file_tree ~loc ~dir =
   | Some loc -> loc
   | None ->
     let dir = Path.drop_optional_build_context dir in
-    let fname =
-      if File_tree.file_exists file_tree dir "dune" then
-        "dune"
-      else if File_tree.file_exists file_tree dir "jbuild" then
-        "jbuild"
-      else
-        "_unknown_"
+    let file =
+      match
+        Option.bind (File_tree.find_dir file_tree dir)
+          ~f:File_tree.Dir.dune_file
+      with
+      | Some file -> file
+      | None      -> Path.relative dir "_unknown_"
     in
-    Loc.in_file
-      (Path.to_string
-         (Path.drop_optional_build_context (Path.relative dir fname)))
+    Loc.in_file (Path.to_string file)
 
 module Internal_rule = struct
   module Id : sig

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -38,6 +38,15 @@ module Dir = struct
       let acc = f t acc in
       String.Map.fold (sub_dirs t) ~init:acc ~f:(fun t acc ->
         fold t ~traverse_ignored_dirs ~init:acc ~f)
+
+  let dune_file t =
+    let (lazy { files; _ }) = t.contents in
+    if String.Set.mem files "dune" then
+      Some (Path.relative t.path "dune")
+    else if String.Set.mem files "jbuild" then
+      Some (Path.relative t.path "jbuild")
+    else
+      None
 end
 
 type t =

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -22,6 +22,9 @@ module Dir : sig
     -> init:'a
     -> f:(t -> 'a -> 'a)
     -> 'a
+
+  (** Return the dune (or jbuild) file in this directory *)
+  val dune_file : t -> Path.t option
 end
 
 (** A [t] value represent a view of the source tree. It is lazily


### PR DESCRIPTION
This factorizes a bit the code and will make adding support for `.dune-fs` files simpler, since the user will be allowed to make a `dune` file be raw data