### PR TITLE
Path.is_in_build_dir test

### DIFF
--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -280,3 +280,8 @@ Path.drop_build_context Path.build_dir
 [%%expect{|
 - : Stdune.Path.t option = None
 |}]
+
+Path.is_in_build_dir Path.build_dir
+[%%expect{|
+- : bool = false
+|}]


### PR DESCRIPTION
This function returns false on Path.build_dir which is somewhat surprising.

@diml, originally I thought this was just a bug, but it seems like we're relying on this to make sure that `_build/.universe-state` is built without any explicit rule for doing so. E.g:

```ocaml
let universe = Path.relative Path.build_dir ".universe-state"
assert (not (Path.is_in_build_dir (Path.parent universe)))
```

This seems a bit odd to me, but in case we should document this in a test if we indeed rely on this.