### PR TITLE
Unit tests for current Path.append behavior

### DIFF
--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -128,3 +128,33 @@ Path.insert_after_build_dir_exn (Path.relative Path.build_dir "qux") "foobar"
 [%%expect{|
 - : Stdune.Path.t = _build/foobar/qux
 |}]
+
+Path.append Path.build_dir (Path.relative Path.root "foo")
+[%%expect{|
+- : Stdune.Path.t = _build/foo
+|}]
+
+Path.append Path.build_dir (Path.relative Path.build_dir "foo")
+[%%expect{|
+- : Stdune.Path.t = _build/_build/foo
+|}]
+
+Path.append Path.root (Path.relative Path.build_dir "foo")
+[%%expect{|
+- : Stdune.Path.t = _build/foo
+|}]
+
+Path.append Path.root (Path.relative Path.root "foo")
+[%%expect{|
+- : Stdune.Path.t = foo
+|}]
+
+Path.append (Path.of_string "/root") (Path.relative Path.root "foo")
+[%%expect{|
+- : Stdune.Path.t = /root/foo
+|}]
+
+Path.append (Path.of_string "/root") (Path.relative Path.build_dir "foo")
+[%%expect{|
+- : Stdune.Path.t = /root/_build/foo
+|}]


### PR DESCRIPTION
It's worth adding tests for these as the behavior might change. Some things that I'd like to consider:

* `Path.(append build_dir (relative build_dir "bar"))` should return `Path.relative build_dir "bar"`

* `Path.append source_dir build_dir` should result in an error (there are better ways to go from `_build/foo/bar` to `foo/bar`).

* Mixing external paths and build paths should also perhaps result in an error

