### PR TITLE
Rm -rf safety

### DIFF
--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -489,6 +489,10 @@ let rm_rf =
     Unix.rmdir dir
   in
   fun t ->
+    if not (is_local t) then (
+      Exn.code_error "Path.rm_rf called on external dir"
+        ["t", sexp_of_t t]
+    );
     let fn = to_string t in
     match Unix.lstat fn with
     | exception Unix.Unix_error(ENOENT, _, _) -> ()

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -161,5 +161,8 @@ Path.append (Path.of_string "/root") (Path.relative Path.build_dir "foo")
 
 Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")
 [%%expect{|
-- : unit = ()
+Exception: Stdune__Exn.Code_error <abstr>.
+Raised at file "src/stdune/exn.ml", line 30, characters 37-131
+Called from file "src/stdune/path.ml", line 496, characters 4-127
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -158,3 +158,8 @@ Path.append (Path.of_string "/root") (Path.relative Path.build_dir "foo")
 [%%expect{|
 - : Stdune.Path.t = /root/_build/foo
 |}]
+
+Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")
+[%%expect{|
+- : unit = ()
+|}]


### PR DESCRIPTION
Just a little safety with what we're deleting. Relevant given the recent camlp5 issue.

I also had some close calls with this in development myself from all the path tweaking.