### PR TITLE
Detect circular sym links

### DIFF
--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -157,10 +157,7 @@ let ignore_file fn ~is_directory =
 
 let load ?(extra_ignored_subtrees=Path.Set.empty) path =
   let rec walk seen_real_paths path ~project ~ignored : Dir.t =
-    let realpath =
-      try Path.of_string (Unix.readlink (Path.to_string path))
-      with Unix.Unix_error (_, _, _) -> path
-    in
+    let realpath = Path.follow_symlink path in
     if List.mem realpath ~set:seen_real_paths then
       die "Path %s has already been scanned. \
            Cannot scan it again through symlink %s"

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -155,33 +155,46 @@ let ignore_file fn ~is_directory =
   (is_directory && (fn.[0] = '.' || fn.[0] = '_')) ||
   (fn.[0] = '.' && fn.[1] = '#')
 
+module File = struct
+  type t =
+    { ino : int
+    ; dev : int
+    }
+
+  let compare a b =
+    match Int.compare a.ino b.ino with
+    | Eq -> Int.compare a.dev b.dev
+    | ne -> ne
+
+  let dummy = { ino = 0; dev = 0 }
+
+  let of_stats (st : Unix.stats) =
+    { ino = st.st_ino
+    ; dev = st.st_dev
+    }
+end
+
+module File_map = Map.Make(File)
+
 let load ?(extra_ignored_subtrees=Path.Set.empty) path =
-  let rec walk seen_real_paths path ~project ~ignored : Dir.t =
-    let realpath =
-      Path.follow_symlink path
-      |> Result.map_error ~f:(function
-        | `Maximum_depth_exceeded ->
-          die "maximum symlink depth exceeded while scanning %s"
-            (Path.to_string_maybe_quoted path)
-        | `Cycle_detected ->
-          die "cycle detected while scanning %s"
-            (Path.to_string_maybe_quoted path))
-      |> Result.ok_exn in
-    if List.mem realpath ~set:seen_real_paths then
-      die "Path %s has already been scanned. \
-           Cannot scan it again through symlink %s"
-        (Path.to_string_maybe_quoted realpath)
-        (Path.to_string_maybe_quoted path);
+  let rec walk path ~dirs_visited ~project ~ignored : Dir.t =
     let contents = lazy (
       let files, sub_dirs =
         Path.readdir path
         |> List.filter_partition_map ~f:(fun fn ->
           let path = Path.relative path fn in
-          let is_directory = Path.is_directory path in
+          let is_directory, file =
+            match Unix.stat (Path.to_string path) with
+            | exception _ -> (false, File.dummy)
+            | { st_kind = S_DIR; _ } as st ->
+              (true, File.of_stats st)
+            | _ ->
+              (false, File.dummy)
+          in
           if ignore_file fn ~is_directory then
             Skip
           else if is_directory then
-            Right (fn, path)
+            Right (fn, path, file)
           else
             Left fn)
       in
@@ -218,14 +231,27 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) path =
           (dune_file, ignored_subdirs)
       in
       let sub_dirs =
-        List.fold_left sub_dirs ~init:String.Map.empty ~f:(fun acc (fn, path) ->
-          let ignored =
-            ignored
-            || String.Set.mem ignored_subdirs fn
-            || Path.Set.mem extra_ignored_subtrees path
-          in
-          String.Map.add acc fn
-            (walk (realpath :: seen_real_paths) path ~project ~ignored))
+        List.fold_left sub_dirs ~init:String.Map.empty
+          ~f:(fun acc (fn, path, file) ->
+            let dirs_visited =
+              if Sys.win32 then
+                dirs_visited
+              else
+                match File_map.find dirs_visited file with
+                | None -> File_map.add dirs_visited file path
+                | Some first_path ->
+                  die "Path %s has already been scanned. \
+                       Cannot scan it again through symlink %s"
+                    (Path.to_string_maybe_quoted first_path)
+                    (Path.to_string_maybe_quoted path)
+            in
+            let ignored =
+              ignored
+              || String.Set.mem ignored_subdirs fn
+              || Path.Set.mem extra_ignored_subtrees path
+            in
+            String.Map.add acc fn
+              (walk path ~dirs_visited ~project ~ignored))
       in
       { Dir. files; sub_dirs; dune_file; project })
     in
@@ -234,7 +260,14 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) path =
     ; ignored
     }
   in
-  let root = walk [] path ~ignored:false ~project:None in
+  let root =
+    walk path
+      ~dirs_visited:(File_map.singleton
+                       (File.of_stats (Unix.stat (Path.to_string path)))
+                       path)
+      ~ignored:false
+      ~project:None
+  in
   let dirs = Hashtbl.create 1024      in
   Hashtbl.add dirs Path.root root;
   { root; dirs }

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -143,3 +143,5 @@ val pp : Format.formatter -> t -> unit
 val build_dir_exists : unit -> bool
 
 val ensure_build_dir_exists : unit -> unit
+
+val follow_symlink : t -> t

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -144,4 +144,6 @@ val build_dir_exists : unit -> bool
 
 val ensure_build_dir_exists : unit -> unit
 
-val follow_symlink : t -> t
+val follow_symlink
+  :  t
+  -> (t, [ `Cycle_detected | `Maximum_depth_exceeded ]) Result.t

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -143,7 +143,3 @@ val pp : Format.formatter -> t -> unit
 val build_dir_exists : unit -> bool
 
 val ensure_build_dir_exists : unit -> unit
-
-val follow_symlink
-  :  t
-  -> (t, [ `Cycle_detected | `Maximum_depth_exceeded ]) Result.t

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -218,6 +218,16 @@
     (progn (run ${exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
 (alias
+ ((name github764)
+  (deps ((package dune) (files_recursively_in test-cases/github764)))
+  (action
+   (chdir
+    test-cases/github764
+    (progn
+     (run ${exe:cram.exe} -skip-platforms win -test run.t)
+     (diff? run.t run.t.corrected))))))
+
+(alias
  ((name ignored_subdirs)
   (deps ((package dune) (files_recursively_in test-cases/ignored_subdirs)))
   (action
@@ -511,6 +521,7 @@
     (alias github734)
     (alias github759)
     (alias github761)
+    (alias github764)
     (alias ignored_subdirs)
     (alias include-loop)
     (alias inline_tests)
@@ -567,6 +578,7 @@
     (alias github734)
     (alias github759)
     (alias github761)
+    (alias github764)
     (alias ignored_subdirs)
     (alias include-loop)
     (alias inline_tests)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -104,6 +104,7 @@ let exclusions =
   ; make "menhir"~external_deps:true
   ; make "utop"~external_deps:true
   ; make "configurator" ~skip_platforms:[Win]
+  ; make "github764" ~skip_platforms:[Win]
   ]
 
 let all_tests = lazy (

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -1,6 +1,28 @@
-  $ mkdir -p c1 && cd c1 && ln -s . x && ln -s . y && jbuilder build
+  $ rm -rf x c* symlink*
+
+  $ mkdir -p c1
+  $ cd c1 && ln -s . x
+  $ cd c1 && ln -s . y
+  $ cd c1 && dune build
   Path . has already been scanned. Cannot scan it again through symlink x
   [1]
-  $ mkdir -p c2 && cd c2 && ln -s x ../../ && jbuilder build
-  $ mkdir -p c3 && cd c3 && ln -s x y && ln -s y x && jbuilder build
-  $ cd symlink-outside-root && ln -s ../sample-exe sample && jbuilder exec --root . -- sample/foo.exe
+
+  $ mkdir -p c2/{a,b}
+  $ cd c2 && ln -s ../b a/x
+  $ cd c2 && ln -s ../a b/x
+  $ cd c2 && dune build
+  Path a has already been scanned. Cannot scan it again through symlink a/x/x
+  [1]
+
+  $ mkdir symlink-outside-root
+  $ cd symlink-outside-root && ln -s ../sample-exe sample
+  $ cd symlink-outside-root && jbuilder exec --root . -- sample/foo.exe
+  foo
+
+  $ mkdir -p symlink-outside-root2/{root,other/{a,b}}
+  $ cd symlink-outside-root2 && ln -s ../b other/a/x
+  $ cd symlink-outside-root2 && ln -s ../a other/b/x
+  $ cd symlink-outside-root2 && ln -s ../other root/src
+  $ cd symlink-outside-root2/root && dune build
+  Path b has already been scanned. Cannot scan it again through symlink src/a/x/x/x
+  [1]

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -1,0 +1,3 @@
+  $ ln -s . x && ln -s . y && jbuilder build
+  Path . has already been scanned. Cannot scan it again through symlink x
+  [1]

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -1,5 +1,3 @@
-  $ rm -rf x c* symlink*
-
   $ mkdir -p c1
   $ cd c1 && ln -s . x
   $ cd c1 && ln -s . y

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -3,3 +3,4 @@
   [1]
   $ mkdir -p c2 && cd c2 && ln -s x ../../ && jbuilder build
   $ mkdir -p c3 && cd c3 && ln -s x y && ln -s y x && jbuilder build
+  $ cd symlink-outside-root && ln -s ../sample-exe sample && jbuilder exec --root . -- sample/foo.exe

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -7,7 +7,7 @@
   Path . has already been scanned. Cannot scan it again through symlink x
   [1]
 
-  $ mkdir -p c2/{a,b}
+  $ mkdir -p c2/a c2/b
   $ cd c2/a && ln -s ../b x
   $ cd c2/b && ln -s ../a x
   $ cd c2 && dune build
@@ -19,7 +19,9 @@
   $ cd symlink-outside-root && jbuilder exec --root . -- sample/foo.exe
   foo
 
-  $ mkdir -p symlink-outside-root2/{root,other/{a,b}}
+  $ mkdir -p symlink-outside-root2/root
+  $ mkdir -p symlink-outside-root2/root/other/a
+  $ mkdir -p symlink-outside-root2/root/other/b
   $ cd symlink-outside-root2/other/a && ln -s ../b x
   $ cd symlink-outside-root2/other/b && ln -s ../a x
   $ cd symlink-outside-root2/root && ln -s ../other src
@@ -27,7 +29,8 @@
   Path src/a has already been scanned. Cannot scan it again through symlink src/a/x/x
   [1]
 
-  $ mkdir -p symlink-outside-root3/{root,other}
+  $ mkdir -p symlink-outside-root3/root
+  $ mkdir -p symlink-outside-root3/other
   $ cd symlink-outside-root3/root  && ln -s ../other src
   $ cd symlink-outside-root3/other && ln -s ../other foo
   $ cd symlink-outside-root3/root && dune build

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -1,3 +1,5 @@
-  $ ln -s . x && ln -s . y && jbuilder build
+  $ mkdir -p c1 && cd c1 && ln -s . x && ln -s . y && jbuilder build
   Path . has already been scanned. Cannot scan it again through symlink x
   [1]
+  $ mkdir -p c2 && cd c2 && ln -s x ../../ && jbuilder build
+  $ mkdir -p c3 && cd c3 && ln -s x y && ln -s y x && jbuilder build

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -26,3 +26,10 @@
   $ cd symlink-outside-root2/root && dune build
   Path b has already been scanned. Cannot scan it again through symlink src/a/x/x/x
   [1]
+
+  $ mkdir -p symlink-outside-root3/{root,other}
+  $ cd symlink-outside-root3 && ln -s ../other root/src
+  $ cd symlink-outside-root3 && ln -s ../other other/foo
+  $ cd symlink-outside-root3/root && dune build
+  Path other has already been scanned. Cannot scan it again through symlink src/foo
+  [1]

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -24,12 +24,12 @@
   $ cd symlink-outside-root2 && ln -s ../a other/b/x
   $ cd symlink-outside-root2 && ln -s ../other root/src
   $ cd symlink-outside-root2/root && dune build
-  Path b has already been scanned. Cannot scan it again through symlink src/a/x/x/x
+  Path src/a has already been scanned. Cannot scan it again through symlink src/a/x/x
   [1]
 
   $ mkdir -p symlink-outside-root3/{root,other}
   $ cd symlink-outside-root3 && ln -s ../other root/src
   $ cd symlink-outside-root3 && ln -s ../other other/foo
   $ cd symlink-outside-root3/root && dune build
-  Path other has already been scanned. Cannot scan it again through symlink src/foo
+  Path src has already been scanned. Cannot scan it again through symlink src/foo
   [1]

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -8,8 +8,8 @@
   [1]
 
   $ mkdir -p c2/{a,b}
-  $ cd c2 && ln -s ../b a/x
-  $ cd c2 && ln -s ../a b/x
+  $ cd c2/a && ln -s ../b x
+  $ cd c2/b && ln -s ../a x
   $ cd c2 && dune build
   Path a has already been scanned. Cannot scan it again through symlink a/x/x
   [1]
@@ -20,16 +20,16 @@
   foo
 
   $ mkdir -p symlink-outside-root2/{root,other/{a,b}}
-  $ cd symlink-outside-root2 && ln -s ../b other/a/x
-  $ cd symlink-outside-root2 && ln -s ../a other/b/x
-  $ cd symlink-outside-root2 && ln -s ../other root/src
+  $ cd symlink-outside-root2/other/a && ln -s ../b x
+  $ cd symlink-outside-root2/other/b && ln -s ../a x
+  $ cd symlink-outside-root2/root && ln -s ../other src
   $ cd symlink-outside-root2/root && dune build
   Path src/a has already been scanned. Cannot scan it again through symlink src/a/x/x
   [1]
 
   $ mkdir -p symlink-outside-root3/{root,other}
-  $ cd symlink-outside-root3 && ln -s ../other root/src
-  $ cd symlink-outside-root3 && ln -s ../other other/foo
+  $ cd symlink-outside-root3/root  && ln -s ../other src
+  $ cd symlink-outside-root3/other && ln -s ../other foo
   $ cd symlink-outside-root3/root && dune build
   Path src has already been scanned. Cannot scan it again through symlink src/foo
   [1]

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -20,8 +20,8 @@
   foo
 
   $ mkdir -p symlink-outside-root2/root
-  $ mkdir -p symlink-outside-root2/root/other/a
-  $ mkdir -p symlink-outside-root2/root/other/b
+  $ mkdir -p symlink-outside-root2/other/a
+  $ mkdir -p symlink-outside-root2/other/b
   $ cd symlink-outside-root2/other/a && ln -s ../b x
   $ cd symlink-outside-root2/other/b && ln -s ../a x
   $ cd symlink-outside-root2/root && ln -s ../other src

--- a/test/blackbox-tests/test-cases/github764/sample-exe/dune
+++ b/test/blackbox-tests/test-cases/github764/sample-exe/dune
@@ -1,0 +1,2 @@
+(executable
+ ((name foo)))

--- a/test/blackbox-tests/test-cases/github764/sample-exe/foo.ml
+++ b/test/blackbox-tests/test-cases/github764/sample-exe/foo.ml
@@ -1,0 +1,1 @@
+let () = print_endline "foo"


### PR DESCRIPTION
Fix #764

@diml any way to add tests for this? I tried adding Louis' example but dune errors out too early when it sees the symlink before actually running any tests.