### PR TITLE
Get rid of Jbuild.Scope_info and use Dune_project instead

### DIFF
--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -5,6 +5,8 @@ module Lang = struct
   type t =
     | Jbuilder
     | Dune of Syntax.Version.t
+
+  let latest = Dune (0, 1)
 end
 
 module Name : sig
@@ -117,6 +119,14 @@ type t =
   ; root     : Path.t
   ; version  : string option
   ; packages : Package.t Package.Name.Map.t
+  }
+
+let anonymous =
+  { lang     = Lang.latest
+  ; name     = Name.anonymous_root
+  ; packages = Package.Name.Map.empty
+  ; root     = Path.root
+  ; version  = None
   }
 
 let filename = "dune-project"

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -27,9 +27,6 @@ module Name : sig
   (** Convert to/from an encoded string that is suitable to use in filenames *)
   val encode : t -> string
   val decode : string -> t
-
-  (** [Anonymous Path.root] *)
-  val anonymous_root : t
 end
 
 type t =
@@ -46,3 +43,7 @@ val load : dir:Path.t -> files:String.Set.t -> t option
 
 (** "dune-project" *)
 val filename : string
+
+(** Represent the scope at the root of the workspace when the root of
+    the workspace contains no [dune-project] or [<package>.opam] files. *)
+val anonymous : t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -1034,7 +1034,7 @@ let gen ~contexts ~build_system
       ?(external_lib_deps_mode=false)
       ?only_packages conf =
   let open Fiber.O in
-  let { Jbuild_load. file_tree; jbuilds; packages; scopes } = conf in
+  let { Jbuild_load. file_tree; jbuilds; packages; projects } = conf in
   let packages =
     match only_packages with
     | None -> packages
@@ -1076,7 +1076,7 @@ let gen ~contexts ~build_system
         ?host
         ~build_system
         ~context
-        ~scopes
+        ~projects
         ~file_tree
         ~packages
         ~external_lib_deps_mode

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -46,8 +46,8 @@ module Gen(P : Install_params) = struct
 
   let version_from_dune_project (pkg : Package.t) =
     let dir = Path.append (SC.build_dir sctx) pkg.path in
-    let scope = Scope.info (SC.find_scope_by_dir sctx dir) in
-    scope.version
+    let project = Scope.project (SC.find_scope_by_dir sctx dir) in
+    project.version
 
   type version_method =
     | File of string

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -9,29 +9,6 @@ module Jbuild_version : sig
   val latest_stable : t
 end
 
-module Scope_info : sig
-  module Name = Dune_project.Name
-
-  type t =
-    { name     : Name.t
-    ; packages : Package.t Package.Name.Map.t
-    ; root     : Path.t
-    ; version  : string option
-    ; project  : Dune_project.t option
-    }
-
-  val make : Dune_project.t -> t
-
-  (** The anonymous represent the scope at the root of the workspace
-      when the root of the workspace contains no [<package>.opam]
-      files. *)
-  val anonymous : t
-
-  (** [resolve t package_name] looks up [package_name] in [t] and returns the
-      package description if it exists, otherwise it returns an error. *)
-  val resolve : t -> Package.Name.t -> (Package.t, string) result
-end
-
 (** Ppx preprocessors  *)
 module Pp : sig
   type t = private string
@@ -233,7 +210,7 @@ module Library : sig
     ; optional                 : bool
     ; buildable                : Buildable.t
     ; dynlink                  : bool
-    ; scope_name               : Scope_info.Name.t
+    ; project_name             : Dune_project.Name.t
     ; sub_systems              : Sub_system_info.t Sub_system_name.Map.t
     }
 
@@ -397,7 +374,7 @@ module Stanzas : sig
   val parse
     :  ?default_version:Jbuild_version.t
     -> file:Path.t
-    -> Scope_info.t
+    -> Dune_project.t
     -> Sexp.Ast.t list
     -> t
 end

--- a/src/jbuild_load.mli
+++ b/src/jbuild_load.mli
@@ -6,14 +6,14 @@ module Jbuilds : sig
   val eval
     :  t
     -> context:Context.t
-    -> (Path.t * Jbuild.Scope_info.t * Jbuild.Stanzas.t) list Fiber.t
+    -> (Path.t * Dune_project.t * Jbuild.Stanzas.t) list Fiber.t
 end
 
 type conf =
   { file_tree : File_tree.t
   ; jbuilds   : Jbuilds.t
   ; packages  : Package.t Package.Name.Map.t
-  ; scopes    : Jbuild.Scope_info.t list
+  ; projects  : Dune_project.t list
   }
 
 val load

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -9,15 +9,15 @@ module Status = struct
   type t =
     | Installed
     | Public  of Package.t
-    | Private of Jbuild.Scope_info.Name.t
+    | Private of Dune_project.Name.t
 
   let pp ppf t =
     Format.pp_print_string ppf
       (match t with
        | Installed -> "installed"
        | Public _ -> "public"
-       | Private s ->
-         sprintf "private (%s)" (Jbuild.Scope_info.Name.to_string_hum s))
+       | Private name ->
+         sprintf "private (%s)" (Dune_project.Name.to_string_hum name))
 
   let is_private = function
     | Private _ -> true
@@ -88,7 +88,7 @@ module Info = struct
     in
     let status =
       match conf.public with
-      | None   -> Status.Private conf.scope_name
+      | None   -> Status.Private conf.project_name
       | Some p -> Public p.package
     in
     let foreign_archives =

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -38,7 +38,7 @@ module Status : sig
   type t =
     | Installed
     | Public  of Package.t
-    | Private of Jbuild.Scope_info.Name.t
+    | Private of Dune_project.Name.t
 
   val pp : t Fmt.t
 end

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -1,23 +1,23 @@
 open Import
 
 type t =
-  { info : Jbuild.Scope_info.t
-  ; db   : Lib.DB.t
+  { project : Dune_project.t
+  ; db      : Lib.DB.t
   }
 
-let root t = t.info.root
-let name t = t.info.name
-let info t = t.info
+let root t = t.project.root
+let name t = t.project.name
+let project t = t.project
 let libs t = t.db
 
 module DB = struct
   type scope = t
 
-  module Scope_name_map = Map.Make(Jbuild.Scope_info.Name)
+  module Project_name_map = Map.Make(Dune_project.Name)
 
   type t =
     { by_dir  : (Path.t, scope) Hashtbl.t
-    ; by_name : scope Scope_name_map.t
+    ; by_name : scope Project_name_map.t
     ; context : string
     }
 
@@ -38,7 +38,7 @@ module DB = struct
     loop dir
 
   let find_by_name t name =
-    match Scope_name_map.find t.by_name name with
+    match Project_name_map.find t.by_name name with
     | Some x -> x
     | None ->
       Exn.code_error "Scope.DB.find_by_name"
@@ -46,38 +46,38 @@ module DB = struct
         ; "context", Sexp.To_sexp.string t.context
         ; "names",
           Sexp.To_sexp.(list Dune_project.Name.sexp_of_t)
-            (Scope_name_map.keys t.by_name)
+            (Project_name_map.keys t.by_name)
         ]
 
-  let create ~scopes ~context ~installed_libs internal_libs =
-    let scopes_info_by_name =
-      List.map scopes ~f:(fun (scope : Jbuild.Scope_info.t) ->
-        (scope.name, scope))
-      |> Scope_name_map.of_list
+  let create ~projects ~context ~installed_libs internal_libs =
+    let projects_by_name =
+      List.map projects ~f:(fun (project : Dune_project.t) ->
+        (project.name, project))
+      |> Project_name_map.of_list
       |> function
       | Ok x -> x
-      | Error (_name, scope1, scope2) ->
-        let to_sexp (scope : Jbuild.Scope_info.t) =
+      | Error (_name, project1, project2) ->
+        let to_sexp (project : Dune_project.t) =
           Sexp.To_sexp.(pair Dune_project.Name.sexp_of_t Path.sexp_of_t)
-            (scope.name, scope.root)
+            (project.name, project.root)
         in
-        Exn.code_error "Scope.DB.create got two scopes with the same name"
-          [ "scope1", to_sexp scope1
-          ; "scope2", to_sexp scope2
+        Exn.code_error "Scope.DB.create got two projects with the same name"
+          [ "project1", to_sexp project1
+          ; "project2", to_sexp project2
           ]
     in
-    let libs_by_scope_name =
+    let libs_by_project_name =
       List.map internal_libs ~f:(fun (dir, (lib : Jbuild.Library.t)) ->
-        (lib.scope_name, (dir, lib)))
-      |> Scope_name_map.of_list_multi
+        (lib.project_name, (dir, lib)))
+      |> Project_name_map.of_list_multi
     in
-    let by_name_cell = ref Scope_name_map.empty in
+    let by_name_cell = ref Project_name_map.empty in
     let public_libs =
       let public_libs =
         List.filter_map internal_libs ~f:(fun (_dir, lib) ->
           match lib.public with
           | None -> None
-          | Some p -> Some (p.name, lib.scope_name))
+          | Some p -> Some (p.name, lib.project_name))
         |> String.Map.of_list
         |> function
         | Ok x -> x
@@ -102,26 +102,26 @@ module DB = struct
         ~resolve:(fun name ->
           match String.Map.find public_libs name with
           | None -> Not_found
-          | Some scope_name ->
+          | Some project_name ->
             let scope =
-              Option.value_exn (Scope_name_map.find !by_name_cell scope_name)
+              Option.value_exn (Project_name_map.find !by_name_cell project_name)
             in
             Redirect (Some scope.db, name))
         ~all:(fun () -> String.Map.keys public_libs)
     in
     let by_name =
-      Scope_name_map.merge scopes_info_by_name libs_by_scope_name
-        ~f:(fun _name info libs ->
-          let info = Option.value_exn info         in
+      Project_name_map.merge projects_by_name libs_by_project_name
+        ~f:(fun _name project libs ->
+          let project = Option.value_exn project in
           let libs = Option.value libs ~default:[] in
           let db =
             Lib.DB.create_from_library_stanzas libs ~parent:public_libs
           in
-          Some { info; db })
+          Some { project; db })
     in
     by_name_cell := by_name;
     let by_dir = Hashtbl.create 1024 in
-    Scope_name_map.iter by_name ~f:(fun scope ->
-      Hashtbl.add by_dir scope.info.root scope);
+    Project_name_map.iter by_name ~f:(fun scope ->
+      Hashtbl.add by_dir scope.project.root scope);
     ({ by_name; by_dir; context }, public_libs)
 end

--- a/src/scope.mli
+++ b/src/scope.mli
@@ -1,14 +1,14 @@
 (** Scopes *)
 
+(** A scope is a project + a library database  *)
+
 open Stdune
 
-(** Representation of a Scope. It contain a library database for all
-    the private libraries in the scope. *)
 type t
 
 val root : t -> Path.t
 val name : t -> Dune_project.Name.t
-val info : t -> Jbuild.Scope_info.t
+val project : t -> Dune_project.t
 
 (** Return the library database associated to this scope *)
 val libs : t -> Lib.DB.t
@@ -22,7 +22,7 @@ module DB : sig
   (** Return the new scope database as well as the public libraries
       database *)
   val create
-    :  scopes:Jbuild.Scope_info.t list
+    :  projects:Dune_project.t list
     -> context:string
     -> installed_libs:Lib.DB.t
     -> (Path.t * Jbuild.Library.t) list

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -23,10 +23,10 @@ type t
 val create
   :  context:Context.t
   -> ?host:t
-  -> scopes:Scope_info.t list
+  -> projects:Dune_project.t list
   -> file_tree:File_tree.t
   -> packages:Package.t Package.Name.Map.t
-  -> stanzas:(Path.t * Scope_info.t * Stanzas.t) list
+  -> stanzas:(Path.t * Dune_project.t * Stanzas.t) list
   -> external_lib_deps_mode:bool
   -> build_system:Build_system.t
   -> t
@@ -224,5 +224,5 @@ end
 module Scope_key : sig
   val of_string : t -> string -> string * Lib.DB.t
 
-  val to_string : string -> Scope_info.Name.t -> string
+  val to_string : string -> Dune_project.Name.t -> string
 end


### PR DESCRIPTION
This PR just refactors the code to remove `Jbuild.Scope_info` and use `Dune_project` instead.