### PR TITLE
Add tests for reach_for_running

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -741,7 +741,7 @@ let exec_run_direct ~ectx ~dir ~env ~stdout_to ~stderr_to prog args =
   Process.run Strict ~dir ~env
     ~stdout_to ~stderr_to
     ~purpose:ectx.purpose
-    (Path.reach_for_running ~from:dir prog) args
+    prog args
 
 let exec_run ~stdout_to ~stderr_to =
   let stdout_to = get_std_output stdout_to in

--- a/src/process.ml
+++ b/src/process.ml
@@ -232,7 +232,8 @@ let run_internal ?dir ?(stdout_to=Terminal) ?(stderr_to=Terminal) ~env ~purpose
   if display = Verbose then
     Format.eprintf "@{<kwd>Running@}[@{<id>%d@}]: %s@." id
       (Colors.strip_colors_for_stderr command_line);
-  let prog = Path.reach_for_running prog ~from:(Option.value ~default:Path.build_dir dir) in
+  let prog = Path.reach_for_running prog
+               ~from:(Option.value ~default:Path.root dir) in
   let argv = Array.of_list (prog :: args) in
   let output_filename, stdout_fd, stderr_fd, to_close =
     match stdout_to, stderr_to with

--- a/src/process.ml
+++ b/src/process.ml
@@ -112,7 +112,11 @@ module Fancy = struct
     | x :: rest -> x :: colorize_args rest
 
   let command_line ~prog ~args ~dir ~stdout_to ~stderr_to =
-    let prog = Path.to_string prog in
+    let prog =
+      match dir with
+      | None -> Path.to_string prog
+      | Some from -> Path.reach_for_running prog ~from
+    in
     let quote = quote_for_shell in
     let prog = colorize_prog (quote prog) in
     let s =

--- a/src/process.ml
+++ b/src/process.ml
@@ -112,11 +112,7 @@ module Fancy = struct
     | x :: rest -> x :: colorize_args rest
 
   let command_line ~prog ~args ~dir ~stdout_to ~stderr_to =
-    let prog =
-      match dir with
-      | None -> Path.to_string prog
-      | Some from -> Path.reach_for_running prog ~from
-    in
+    let prog = Path.reach_for_running ?from:dir prog in
     let quote = quote_for_shell in
     let prog = colorize_prog (quote prog) in
     let s =
@@ -236,8 +232,7 @@ let run_internal ?dir ?(stdout_to=Terminal) ?(stderr_to=Terminal) ~env ~purpose
   if display = Verbose then
     Format.eprintf "@{<kwd>Running@}[@{<id>%d@}]: %s@." id
       (Colors.strip_colors_for_stderr command_line);
-  let prog = Path.reach_for_running prog
-               ~from:(Option.value ~default:Path.root dir) in
+  let prog = Path.reach_for_running ?from:dir prog in
   let argv = Array.of_list (prog :: args) in
   let output_filename, stdout_fd, stderr_fd, to_close =
     match stdout_to, stderr_to with
@@ -352,11 +347,11 @@ let run_capture_line ?dir ~env ?(purpose=Internal_job) fail_mode prog args =
     | [x] -> x
     | l ->
       let cmdline =
-        let prog_display p = String.concat (p :: args) ~sep:" " in
+        let prog = Path.reach_for_running ?from:dir prog in
+        let prog_display = String.concat (prog :: args) ~sep:" " in
         match dir with
-        | None -> prog_display (Path.to_string prog)
-        | Some dir -> sprintf "cd %s && %s" (Path.to_string dir)
-                        (prog_display (Path.reach_for_running prog ~from:dir))
+        | None -> prog_display
+        | Some dir -> sprintf "cd %s && %s" (Path.to_string dir) prog_display
       in
       match l with
       | [] ->

--- a/src/process.ml
+++ b/src/process.ml
@@ -232,7 +232,7 @@ let run_internal ?dir ?(stdout_to=Terminal) ?(stderr_to=Terminal) ~env ~purpose
   if display = Verbose then
     Format.eprintf "@{<kwd>Running@}[@{<id>%d@}]: %s@." id
       (Colors.strip_colors_for_stderr command_line);
-  let prog = Path.to_string prog in
+  let prog = Path.reach_for_running prog ~from:(Option.value ~default:Path.build_dir dir) in
   let argv = Array.of_list (prog :: args) in
   let output_filename, stdout_fd, stderr_fd, to_close =
     match stdout_to, stderr_to with
@@ -347,11 +347,11 @@ let run_capture_line ?dir ~env ?(purpose=Internal_job) fail_mode prog args =
     | [x] -> x
     | l ->
       let cmdline =
-        let prog = Path.to_string prog in
-        let s = String.concat (prog :: args) ~sep:" " in
+        let prog_display p = String.concat (p :: args) ~sep:" " in
         match dir with
-        | None -> s
-        | Some dir -> sprintf "cd %s && %s" (Path.to_string dir) s
+        | None -> prog_display (Path.to_string prog)
+        | Some dir -> sprintf "cd %s && %s" (Path.to_string dir)
+                        (prog_display (Path.reach_for_running prog ~from:dir))
       in
       match l with
       | [] ->

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -302,7 +302,7 @@ let reach t ~from =
   | Local t, Local from ->
     Local.reach t ~from
 
-let reach_for_running t ~from =
+let reach_for_running ?(from=root) t =
   match kind t, kind from with
   | External _, _ -> t
   | Local _, External _ ->

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -70,7 +70,9 @@ val absolute : string -> t
 val to_absolute_filename : t -> root:string -> string
 
 val reach : t -> from:t -> string
-val reach_for_running : t -> from:t -> string
+
+(** [from] defaults to [Path.root] *)
+val reach_for_running : ?from:t -> t -> string
 
 val descendant : t -> of_:t -> t option
 val is_descendant : t -> of_:t -> bool

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -70,7 +70,7 @@ val absolute : string -> t
 val to_absolute_filename : t -> root:string -> string
 
 val reach : t -> from:t -> string
-val reach_for_running : t -> from:t -> t
+val reach_for_running : t -> from:t -> string
 
 val descendant : t -> of_:t -> t option
 val is_descendant : t -> of_:t -> bool

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -1,6 +1,6 @@
   $ env -u OCAMLRUNPARAM jbuilder runtest simple
            run alias simple/runtest (exit 2)
-  (cd _build/default/simple && _build/default/simple/.foo_simple.inline-tests/run.exe)
+  (cd _build/default/simple && ./.foo_simple.inline-tests/run.exe)
   Fatal error: exception File "simple/.foo_simple.inline-tests/run.ml", line 1, characters 10-16: Assertion failed
   [1]
 

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -1,6 +1,6 @@
   $ env -u OCAMLRUNPARAM jbuilder runtest simple
            run alias simple/runtest (exit 2)
-  (cd _build/default/simple && ./.foo_simple.inline-tests/run.exe)
+  (cd _build/default/simple && _build/default/simple/.foo_simple.inline-tests/run.exe)
   Fatal error: exception File "simple/.foo_simple.inline-tests/run.ml", line 1, characters 10-16: Assertion failed
   [1]
 

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -284,3 +284,31 @@ Path.is_in_build_dir Path.build_dir
 [%%expect{|
 - : bool = false
 |}]
+
+Path.reach_for_running Path.build_dir ~from:Path.root
+[%%expect{|
+- : Stdune.Path.t = ./_build
+|}]
+
+Path.(reach_for_running (relative build_dir "foo/baz")
+        ~from:(relative build_dir "foo/bar/baz"))
+[%%expect{|
+- : Stdune.Path.t = ../../baz
+|}]
+
+Path.(reach_for_running (Path.absolute "/fake/path")
+        ~from:(relative build_dir "foo/bar/baz"))
+[%%expect{|
+- : Stdune.Path.t = /fake/path
+|}]
+
+Path.(reach_for_running (relative build_dir "foo/baz")
+        ~from:(Path.absolute "/fake/path"))
+[%%expect{|
+Exception: Stdune__Exn.Code_error <abstr>.
+|}]
+
+Path.(reach_for_running (relative root "foo") ~from:(Path.relative root "foo"))
+[%%expect{|
+- : Stdune.Path.t = ./.
+|}]

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -287,19 +287,19 @@ Path.is_in_build_dir Path.build_dir
 
 Path.reach_for_running Path.build_dir ~from:Path.root
 [%%expect{|
-- : Stdune.Path.t = ./_build
+- : string = "./_build"
 |}]
 
 Path.(reach_for_running (relative build_dir "foo/baz")
         ~from:(relative build_dir "foo/bar/baz"))
 [%%expect{|
-- : Stdune.Path.t = ../../baz
+- : string = "../../baz"
 |}]
 
 Path.(reach_for_running (Path.absolute "/fake/path")
         ~from:(relative build_dir "foo/bar/baz"))
 [%%expect{|
-- : Stdune.Path.t = /fake/path
+- : string = "/fake/path"
 |}]
 
 Path.(reach_for_running (relative build_dir "foo/baz")
@@ -310,5 +310,5 @@ Exception: Stdune__Exn.Code_error <abstr>.
 
 Path.(reach_for_running (relative root "foo") ~from:(Path.relative root "foo"))
 [%%expect{|
-- : Stdune.Path.t = ./.
+- : string = "./."
 |}]


### PR DESCRIPTION

@diml why is it necessary to add the `./` prefix?

Also, what do you think of getting rid of this function and simply having `Process.run` add the `./` if necessary after the `to_string` conversion. I belive that's the only place where we use this function anyway.