### PR TITLE
Allow to define that can appear multiple times

### DIFF
--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -100,6 +100,13 @@ module Of_sexp : sig
     -> 'a option record_parser
   val field_b : string -> bool record_parser
 
+  (** A field that can appear multiple times *)
+  val dup_field
+    :  string
+    -> ?short:'a Short_syntax.t
+    -> 'a t
+    -> 'a list record_parser
+
   val map_validate
     :  'a record_parser
     -> f:('a -> ('b, string) Result.result)
@@ -130,6 +137,14 @@ module Of_sexp : sig
     -> ('a, 'b) Constructor_args_spec.t
     -> 'a
     -> 'b record_parser
+
+  (** A field that can appear multiple times and each time takes
+      multiple values *)
+  val dup_field_multi
+    :  string
+    -> ('a, 'b) Constructor_args_spec.t
+    -> 'a
+    -> 'b list record_parser
 
   val cstr : string -> ('a, 'b) Constructor_args_spec.t -> 'a -> 'b Constructor_spec.t
   val cstr_rest

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -31,3 +31,10 @@ Exception:
 Stdune__Sexp.Of_sexp.Of_sexp (<abstr>,
  "Field \"foo\" is present too many times", None).
 |}]
+
+let of_sexp = record (dup_field "foo" int)
+let x = of_sexp sexp
+[%%expect{|
+val of_sexp : int list Stdune.Sexp.Of_sexp.t = <fun>
+val x : int list = [1; 2]
+|}]


### PR DESCRIPTION
This PR adds the necessary support in `Sexp.Of_sexp` for fields that might appear multiple times. This is to support `(using <plugin> <version>)` in `dune-project` since they might appear multiple times. This PR is based on #779.