### PR TITLE
Add inferred mli target

### DIFF
--- a/src/module.ml
+++ b/src/module.ml
@@ -87,6 +87,9 @@ let cmt_file t ~obj_dir (kind : Ml_kind.t) =
 
 let odoc_file t ~doc_dir = obj_file t ~obj_dir:doc_dir~ext:".odoc"
 
+let inferred_mli t ~obj_dir =
+  Path.relative obj_dir (t.obj_name ^ ".inferred.mli")
+
 let cmti_file t ~obj_dir =
   match t.intf with
   | None   -> obj_file t ~obj_dir ~ext:".cmt"

--- a/src/module.mli
+++ b/src/module.mli
@@ -60,6 +60,8 @@ val cm_file_unsafe : t -> obj_dir:Path.t -> Cm_kind.t -> Path.t
 
 val odoc_file : t -> doc_dir:Path.t -> Path.t
 
+val inferred_mli : t -> obj_dir:Path.t -> Path.t
+
 (** Either the .cmti, or .cmt if the module has no interface *)
 val cmti_file : t -> obj_dir:Path.t -> Path.t
 

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -103,7 +103,7 @@ let build_cm sctx ?sandbox ~dynlink ~flags ~cm_kind ~dep_graphs
           (other_cm_files >>>
            Ocaml_flags.get_for_cm flags ~cm_kind >>>
            Build.run ~stdout_to:dst ~context:ctx (Ok compiler)
-             (shared_flags @ [ A "-i"; Dep src]))
+             (Arg_spec.A "-short-paths" :: shared_flags @ [ A "-i"; Dep src]))
       end;
       SC.add_rule sctx ?sandbox
         (Build.paths extra_deps >>>


### PR DESCRIPTION
@diml this is WIP. An issue that I've come up with is that the inferred mli for module aliases is very ugly. With lots of `Alias__` everywhere. Anyway to fix this? I think this makes this feature quite a bit less useful.

I'm thinking of the correct approach to setup rules to copy the .mli to the source dir. I see 2 options:

* Set inferred.mli rules for all contexts and then add a copy rule from the default context. I think this is the cleanest approach because it would work with a potential `--context` argument.

* Setup the inferred rule only for the default context and directly write the inferred mli into the source dir. This is less clean, but given your performance concerns with adding extra rules, this approach will avoid setting up quite a bit of such pointless rules. Especially for multi context workspaces.