### PR TITLE
Simplify the API for parsing remaining arguments of constructors

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -30,7 +30,7 @@ struct
   let rec t sexp =
     let path = Path.t and string = String.t in
     sum
-      [ cstr_rest "run" (Program.t @> nil) string (fun prog args -> Run (prog, args))
+      [ cstr "run" (Program.t @> rest string) (fun prog args -> Run (prog, args))
       ; cstr "chdir"    (path @> t @> nil)        (fun dn t -> Chdir (dn, t))
       ; cstr "setenv"   (string @> string @> t @> nil)   (fun k v t -> Setenv (k, v, t))
       ; cstr "with-stdout-to"  (path @> t @> nil) (fun fn t -> Redirect (Stdout, fn, t))
@@ -39,7 +39,7 @@ struct
       ; cstr "ignore-stdout"   (t @> nil)      (fun t -> Ignore (Stdout, t))
       ; cstr "ignore-stderr"   (t @> nil)      (fun t -> Ignore (Stderr, t))
       ; cstr "ignore-outputs"  (t @> nil)      (fun t -> Ignore (Outputs, t))
-      ; cstr_rest "progn"      nil t         (fun l -> Progn l)
+      ; cstr "progn"           (rest t)        (fun l -> Progn l)
       ; cstr "echo"           (string @> nil)         (fun x -> Echo x)
       ; cstr "cat"            (path @> nil)         (fun x -> Cat x)
       ; cstr "copy" (path @> path @> nil)              (fun src dst -> Copy (src, dst))

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -1265,7 +1265,7 @@ module Stanzas = struct
           (fun glob -> [Copy_files {add_line_directive = false; glob}])
       ; cstr "copy_files#" (Copy_files.v1 @> nil)
           (fun glob -> [Copy_files {add_line_directive = true; glob}])
-      ; cstr_rest_loc "env" nil Env.rule
+      ; cstr_loc "env" (rest Env.rule)
           (fun loc rules -> [Env { loc; rules }])
       (* Just for validation and error messages *)
       ; cstr "jbuild_version" (Jbuild_version.t @> nil) (fun _ -> [])

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -129,6 +129,7 @@ module Of_sexp : sig
     :  'a t
     -> ('b, 'c) Constructor_args_spec.t
     -> ('a -> 'b, 'c) Constructor_args_spec.t
+  val rest : 'a t -> ('a list -> 'b, 'b) Constructor_args_spec.t
 
   (** Field that takes multiple values *)
   val field_multi
@@ -147,12 +148,6 @@ module Of_sexp : sig
     -> 'b list record_parser
 
   val cstr : string -> ('a, 'b) Constructor_args_spec.t -> 'a -> 'b Constructor_spec.t
-  val cstr_rest
-    :  string
-    -> ('a, 'b list -> 'c) Constructor_args_spec.t
-    -> 'b t
-    -> 'a
-    -> 'c Constructor_spec.t
 
   val cstr_record : string -> 'a record_parser -> 'a Constructor_spec.t
 
@@ -161,13 +156,6 @@ module Of_sexp : sig
     -> ('a, 'b) Constructor_args_spec.t
     -> (Loc.t -> 'a)
     -> 'b Constructor_spec.t
-
-  val cstr_rest_loc
-    :  string
-    -> ('a, 'b list -> 'c) Constructor_args_spec.t
-    -> 'b t
-    -> (Loc.t -> 'a)
-    -> 'c Constructor_spec.t
 
   val sum
     :  'a Constructor_spec.t list


### PR DESCRIPTION
This way we don't need to duplicate all the functions.