### PR TITLE
Simplify the constructor parsing API

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -49,7 +49,7 @@ struct
       *)
       ; cstr "copy#" (path @> path @> nil) (fun src dst ->
           Copy_and_add_line_directive (src, dst))
-      ; cstr_loc "copy-and-add-line-directive" (path @> path @> nil) (fun loc src dst ->
+      ; cstr "copy-and-add-line-directive" (cstr_loc (path @> path @> nil)) (fun loc src dst ->
           Loc.warn loc "copy-and-add-line-directive is deprecated, use copy# instead";
           Copy_and_add_line_directive (src, dst))
       ; cstr "copy#" (path @> path @> nil) (fun src dst ->

--- a/src/action.ml
+++ b/src/action.ml
@@ -30,7 +30,7 @@ struct
   let rec t sexp =
     let path = Path.t and string = String.t in
     sum
-      [ cstr_rest "run" (Program.t @> nil) string (fun prog args -> Run (prog, args))
+      [ cstr "run" (Program.t @> rest string) (fun prog args -> Run (prog, args))
       ; cstr "chdir"    (path @> t @> nil)        (fun dn t -> Chdir (dn, t))
       ; cstr "setenv"   (string @> string @> t @> nil)   (fun k v t -> Setenv (k, v, t))
       ; cstr "with-stdout-to"  (path @> t @> nil) (fun fn t -> Redirect (Stdout, fn, t))
@@ -39,7 +39,7 @@ struct
       ; cstr "ignore-stdout"   (t @> nil)      (fun t -> Ignore (Stdout, t))
       ; cstr "ignore-stderr"   (t @> nil)      (fun t -> Ignore (Stderr, t))
       ; cstr "ignore-outputs"  (t @> nil)      (fun t -> Ignore (Outputs, t))
-      ; cstr_rest "progn"      nil t         (fun l -> Progn l)
+      ; cstr "progn"           (rest t)        (fun l -> Progn l)
       ; cstr "echo"           (string @> nil)         (fun x -> Echo x)
       ; cstr "cat"            (path @> nil)         (fun x -> Cat x)
       ; cstr "copy" (path @> path @> nil)              (fun src dst -> Copy (src, dst))

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -1252,12 +1252,12 @@ module Stanzas = struct
       [ cstr "library"     (Library.v1 project @> nil) (fun x -> [Library x])
       ; cstr "executable"  (Executables.v1_single project @> nil) execs
       ; cstr "executables" (Executables.v1_multi  project @> nil) execs
-      ; cstr_loc "rule"      (Rule.v1     @> nil) (fun loc x -> [Rule { x with loc }])
-      ; cstr_loc "ocamllex" (Rule.ocamllex_v1 @> nil)
+      ; cstr "rule"        (cstr_loc (Rule.v1 @> nil)) (fun loc x -> [Rule { x with loc }])
+      ; cstr "ocamllex"    (cstr_loc (Rule.ocamllex_v1 @> nil))
           (fun loc x -> rules (Rule.ocamllex_to_rule loc x))
-      ; cstr_loc "ocamlyacc" (Rule.ocamlyacc_v1 @> nil)
+      ; cstr "ocamlyacc"   (cstr_loc (Rule.ocamlyacc_v1 @> nil))
           (fun loc x -> rules (Rule.ocamlyacc_to_rule loc x))
-      ; cstr_loc "menhir" (Menhir.v1 @> nil)
+      ; cstr "menhir"      (cstr_loc (Menhir.v1 @> nil))
           (fun loc x -> [Menhir { x with loc }])
       ; cstr "install"     (Install_conf.v1 project @> nil) (fun x -> [Install     x])
       ; cstr "alias"       (Alias_conf.v1 project @> nil)   (fun x -> [Alias       x])
@@ -1265,11 +1265,11 @@ module Stanzas = struct
           (fun glob -> [Copy_files {add_line_directive = false; glob}])
       ; cstr "copy_files#" (Copy_files.v1 @> nil)
           (fun glob -> [Copy_files {add_line_directive = true; glob}])
-      ; cstr_loc "env" (rest Env.rule)
+      ; cstr "env" (cstr_loc (rest Env.rule))
           (fun loc rules -> [Env { loc; rules }])
       (* Just for validation and error messages *)
       ; cstr "jbuild_version" (Jbuild_version.t @> nil) (fun _ -> [])
-      ; cstr_loc "include" (relative_file @> nil) (fun loc fn ->
+      ; cstr "include" (cstr_loc (relative_file @> nil)) (fun loc fn ->
           let include_stack = (loc, file) :: include_stack in
           let dir = Path.parent_exn file in
           let file = Path.relative dir fn in

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -1265,7 +1265,7 @@ module Stanzas = struct
           (fun glob -> [Copy_files {add_line_directive = false; glob}])
       ; cstr "copy_files#" (Copy_files.v1 @> nil)
           (fun glob -> [Copy_files {add_line_directive = true; glob}])
-      ; cstr_rest_loc "env" nil Env.rule
+      ; cstr_loc "env" (rest Env.rule)
           (fun loc rules -> [Env { loc; rules }])
       (* Just for validation and error messages *)
       ; cstr "jbuild_version" (Jbuild_version.t @> nil) (fun _ -> [])

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -129,7 +129,14 @@ module Of_sexp : sig
     :  'a t
     -> ('b, 'c) Constructor_args_spec.t
     -> ('a -> 'b, 'c) Constructor_args_spec.t
+
+  (** Parse all remaining arguments using the following parser *)
   val rest : 'a t -> ('a list -> 'b, 'b) Constructor_args_spec.t
+
+  (** Capture the location of the constructor *)
+  val cstr_loc
+    :  ('a, 'b) Constructor_args_spec.t
+    -> (Loc.t -> 'a, 'b) Constructor_args_spec.t
 
   (** Field that takes multiple values *)
   val field_multi
@@ -147,15 +154,15 @@ module Of_sexp : sig
     -> 'a
     -> 'b list record_parser
 
-  val cstr : string -> ('a, 'b) Constructor_args_spec.t -> 'a -> 'b Constructor_spec.t
-
-  val cstr_record : string -> 'a record_parser -> 'a Constructor_spec.t
-
-  val cstr_loc
+  val cstr
     :  string
     -> ('a, 'b) Constructor_args_spec.t
-    -> (Loc.t -> 'a)
+    -> 'a
     -> 'b Constructor_spec.t
+  val cstr_record
+    :  string
+    -> 'a record_parser
+    -> 'a Constructor_spec.t
 
   val sum
     :  'a Constructor_spec.t list

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -129,6 +129,7 @@ module Of_sexp : sig
     :  'a t
     -> ('b, 'c) Constructor_args_spec.t
     -> ('a -> 'b, 'c) Constructor_args_spec.t
+  val rest : 'a t -> ('a list -> 'b, 'b) Constructor_args_spec.t
 
   (** Field that takes multiple values *)
   val field_multi
@@ -147,12 +148,6 @@ module Of_sexp : sig
     -> 'b list record_parser
 
   val cstr : string -> ('a, 'b) Constructor_args_spec.t -> 'a -> 'b Constructor_spec.t
-  val cstr_rest
-    :  string
-    -> ('a, 'b list -> 'c) Constructor_args_spec.t
-    -> 'b t
-    -> 'a
-    -> 'c Constructor_spec.t
 
   val cstr_record : string -> 'a record_parser -> 'a Constructor_spec.t
 
@@ -161,13 +156,6 @@ module Of_sexp : sig
     -> ('a, 'b) Constructor_args_spec.t
     -> (Loc.t -> 'a)
     -> 'b Constructor_spec.t
-
-  val cstr_rest_loc
-    :  string
-    -> ('a, 'b list -> 'c) Constructor_args_spec.t
-    -> 'b t
-    -> (Loc.t -> 'a)
-    -> 'c Constructor_spec.t
 
   val sum
     :  'a Constructor_spec.t list

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -133,6 +133,9 @@ module Of_sexp : sig
   (** Parse all remaining arguments using the following parser *)
   val rest : 'a t -> ('a list -> 'b, 'b) Constructor_args_spec.t
 
+  (** Parse all remaining arguments using the following record parser *)
+  val rest_as_record : 'a record_parser -> ('a -> 'b, 'b) Constructor_args_spec.t
+
   (** Capture the location of the constructor *)
   val cstr_loc
     :  ('a, 'b) Constructor_args_spec.t
@@ -159,10 +162,6 @@ module Of_sexp : sig
     -> ('a, 'b) Constructor_args_spec.t
     -> 'a
     -> 'b Constructor_spec.t
-  val cstr_record
-    :  string
-    -> 'a record_parser
-    -> 'a Constructor_spec.t
 
   val sum
     :  'a Constructor_spec.t list

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -95,7 +95,7 @@ type item = Context of Sexp.Ast.t | Profile of Loc.t * string
 let item_of_sexp =
   sum
     [ cstr "context" (raw @> nil) (fun x -> Context x)
-    ; cstr_loc "profile" (string @> nil) (fun loc x -> Profile (loc, x))
+    ; cstr "profile" (cstr_loc (string @> nil)) (fun loc x -> Profile (loc, x))
     ]
 
 let t ?x ?profile:cmdline_profile sexps =

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -63,10 +63,12 @@ module Context = struct
     | List (_, List _ :: _) as sexp -> Opam (record (Opam.t ~profile) sexp)
     | sexp ->
       sum
-        [ cstr_record "default"
-            (Default.t ~profile >>= fun x -> return (Default x))
-        ; cstr_record "opam"
-            (Opam.t ~profile >>= fun x -> return (Opam x))
+        [ cstr "default"
+            (rest_as_record (Default.t ~profile))
+            (fun x -> Default x)
+        ; cstr "opam"
+            (rest_as_record (Opam.t ~profile))
+            (fun x -> Opam x)
         ]
         sexp
 


### PR DESCRIPTION
We now have a single `cstr` function and the various variants to capture the location of the constructor, to have variadic constructors or to have inline records are just argument specifications. This allows to use all the variants with `field_multi` or `dup_field_multi` without having to add more variants of these two functions.

This is needed to implement the parsing of `(using ...)` stanzas in `dune` files.