### PR TITLE
Add a jbuilder transition package

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -79,8 +79,8 @@ case "$TARGET" in
       fi
       opam list
       echo "version: \"1.0+dev$DATE\"" >> dune.opam
-      opam pin add jbuilder . --no-action --yes
       opam pin add dune     . --no-action --yes
+      opam pin add jbuilder . --no-action --yes
       opam install utop ppx_driver odoc ocaml-migrate-parsetree js_of_ocaml-ppx js_of_ocaml-compiler --yes
       echo -en "travis_fold:end:opam.deps\r"
     fi

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -79,20 +79,8 @@ case "$TARGET" in
       fi
       opam list
       echo "version: \"1.0+dev$DATE\"" >> dune.opam
-      mkdir -p ../jbuilder
-      cat > ../jbuilder/jbuilder.opam <<EOF
-version: "1.0+dev$DATE"
-opam-version: "1.2"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-homepage: "https://github.com/ocaml/dune"
-bug-reports: "https://github.com/ocaml/dune/issues"
-dev-repo: "https://github.com/ocaml/dune.git"
-license: "Apache-2.0"
-depends: [ "dune" ]
-EOF
-      opam pin add jbuilder ../jbuilder --no-action --yes
-      opam pin add dune     .           --no-action --yes
+      opam pin add jbuilder . --no-action --yes
+      opam pin add dune     . --no-action --yes
       opam install utop ppx_driver odoc ocaml-migrate-parsetree js_of_ocaml-ppx js_of_ocaml-compiler --yes
       echo -en "travis_fold:end:opam.deps\r"
     fi

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -91,8 +91,8 @@ dev-repo: "https://github.com/ocaml/dune.git"
 license: "Apache-2.0"
 depends: [ "dune" ]
 EOF
-      opam pin add dune     .           --no-action --yes
       opam pin add jbuilder ../jbuilder --no-action --yes
+      opam pin add dune     .           --no-action --yes
       opam install utop ppx_driver odoc ocaml-migrate-parsetree js_of_ocaml-ppx js_of_ocaml-compiler --yes
       echo -en "travis_fold:end:opam.deps\r"
     fi

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -79,6 +79,7 @@ case "$TARGET" in
       fi
       opam list
       echo "version: \"1.0+dev$DATE\"" >> dune.opam
+      echo "depends: [\"dune\"]" >> jbuilder.opam
       opam pin add dune     . --no-action --yes
       opam pin add jbuilder . --no-action --yes
       opam install utop ppx_driver odoc ocaml-migrate-parsetree js_of_ocaml-ppx js_of_ocaml-compiler --yes

--- a/bin/dune
+++ b/bin/dune
@@ -1,9 +1,11 @@
 (executable
  ((name        main)
   (public_name dune)
+  (package     dune)
   (libraries (unix dune cmdliner))
   (preprocess no_preprocessing)))
 
 (install
  ((section bin)
+  (package dune)
   (files   ((main.exe as jbuilder)))))

--- a/doc/dune
+++ b/doc/dune
@@ -7,6 +7,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune.1))))
 
 (rule
@@ -16,6 +17,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-config.5))))
 
 (include dune.inc)

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -6,6 +6,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-build.1))))
 
 (rule
@@ -15,6 +16,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-clean.1))))
 
 (rule
@@ -24,6 +26,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-exec.1))))
 
 (rule
@@ -33,6 +36,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-external-lib-deps.1))))
 
 (rule
@@ -42,6 +46,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-help.1))))
 
 (rule
@@ -51,6 +56,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-install.1))))
 
 (rule
@@ -60,6 +66,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-installed-libraries.1))))
 
 (rule
@@ -69,6 +76,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-printenv.1))))
 
 (rule
@@ -78,6 +86,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-promote.1))))
 
 (rule
@@ -87,6 +96,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-rules.1))))
 
 (rule
@@ -96,6 +106,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-runtest.1))))
 
 (rule
@@ -105,6 +116,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-subst.1))))
 
 (rule
@@ -114,6 +126,7 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-uninstall.1))))
 
 (rule
@@ -123,5 +136,6 @@
 
 (install
  ((section man)
+  (package dune)
   (files (dune-utop.1))))
 

--- a/doc/update-jbuild.sh
+++ b/doc/update-jbuild.sh
@@ -17,6 +17,7 @@ for cmd in $CMDS; do
 
 (install
  ((section man)
+  (package dune)
   (files (dune-$cmd.1))))
 EOF
 done

--- a/dune.opam
+++ b/dune.opam
@@ -12,3 +12,4 @@ build: [
   ["./boot.exe" "-j" jobs]
 ]
 available: [ ocaml-version >= "4.02.3" ]
+conflicts: [ "jbuilder" {!= "transition"} ]

--- a/jbuilder.descr
+++ b/jbuilder.descr
@@ -1,0 +1,2 @@
+This is a transition package, jbuilder is now named dune. Use the dune
+package instead.

--- a/jbuilder.opam
+++ b/jbuilder.opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+version: "transition"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "https://github.com/ocaml/dune.git"
+license: "MIT"
+build: ["dune" "--version"]
+# CR-soon diml: uncomment this once we have a dune package in opam.
+# We have to wait otherwise "opam pin add jbuilder --dev" fails with
+# an error that is hard to understand.
+# depends: ["dune"]
+post-messages: [
+  "Jbuilder has been renamed and the jbuilder package is now a transition"
+  "package. Use the dune package instead."
+  ""
+  "If you want to try the development version of Dune before the 1.0.0 is"
+  "released, run the following command:"
+  ""
+  "$ opam pin add dune https://github.com/ocaml/dune.git"
+]

--- a/vendor/boot/opamBaseParser.ml
+++ b/vendor/boot/opamBaseParser.ml
@@ -1,6 +1,6 @@
 open OpamParserTypes
 let main _lex _lexbuf fn =
-  assert (fn = "dune.opam");
+  assert (fn = "dune.opam" || fn = "jbuilder.opam");
   { file_contents = []
   ; file_name     = fn
   }


### PR DESCRIPTION
This should help with #792. Now when running `opam pin add jbuilder --dev`, the installation fails if dune is not installed with the following message:

```
=-=- jbuilder.transition troubleshooting =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
=> Jbuilder has been renamed and the jbuilder package is now a transition package.
=> Use the dune package instead.
=> 
=> If you want to try the development version of Dune before the 1.0.0 is released, run the following command:
=> 
=> $ opam pin add dune https://github.com/ocaml/dune.git
```


