### PR TITLE
Remove aliases of Path.{Set,Map}

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -953,11 +953,10 @@ let sandbox t ~sandboxed ~deps ~targets =
     ]
 
 module Infer = struct
-  module S = Path.Set
   module Outcome = struct
     type t =
-      { deps    : S.t
-      ; targets : S.t
+      { deps    : Path.Set.t
+      ; targets : Path.Set.t
       }
   end
   open Outcome
@@ -1036,43 +1035,43 @@ module Infer = struct
       { deps = Pset.diff deps targets; targets }
   end [@@inline always]
 
-  include Make(Ast)(S)(Outcome)(struct
-      let ( +@ ) acc fn = { acc with targets = S.add acc.targets fn }
-      let ( +< ) acc fn = { acc with deps    = S.add acc.deps    fn }
+  include Make(Ast)(Path.Set)(Outcome)(struct
+      let ( +@ ) acc fn = { acc with targets = Path.Set.add acc.targets fn }
+      let ( +< ) acc fn = { acc with deps    = Path.Set.add acc.deps    fn }
       let ( +<! ) acc prog =
         match prog with
         | Ok p -> acc +< p
         | Error _ -> acc
     end)
 
-  module Partial = Make(Unexpanded.Partial.Past)(S)(Outcome)(struct
+  module Partial = Make(Unexpanded.Partial.Past)(Path.Set)(Outcome)(struct
       let ( +@ ) acc fn =
         match fn with
-        | Left  fn -> { acc with targets = S.add acc.targets fn }
+        | Left  fn -> { acc with targets = Path.Set.add acc.targets fn }
         | Right _  -> acc
       let ( +< ) acc fn =
         match fn with
-        | Left  fn -> { acc with deps    = S.add acc.deps fn }
+        | Left  fn -> { acc with deps    = Path.Set.add acc.deps fn }
         | Right _  -> acc
       let ( +<! ) acc fn =
         match (fn : Unexpanded.Partial.program) with
-        | Left  (This fn) -> { acc with deps = S.add acc.deps fn }
+        | Left  (This fn) -> { acc with deps = Path.Set.add acc.deps fn }
         | Left  (Search _) | Right _ -> acc
     end)
 
-  module Partial_with_all_targets = Make(Unexpanded.Partial.Past)(S)(Outcome)(struct
+  module Partial_with_all_targets = Make(Unexpanded.Partial.Past)(Path.Set)(Outcome)(struct
       let ( +@ ) acc fn =
         match fn with
-        | Left  fn -> { acc with targets = S.add acc.targets fn }
+        | Left  fn -> { acc with targets = Path.Set.add acc.targets fn }
         | Right sw ->
           Loc.fail (SW.loc sw) "Cannot determine this target statically."
       let ( +< ) acc fn =
         match fn with
-        | Left  fn -> { acc with deps    = S.add acc.deps fn }
+        | Left  fn -> { acc with deps    = Path.Set.add acc.deps fn }
         | Right _  -> acc
       let ( +<! ) acc fn =
         match (fn : Unexpanded.Partial.program) with
-        | Left  (This fn) -> { acc with deps = S.add acc.deps fn }
+        | Left  (This fn) -> { acc with deps = Path.Set.add acc.deps fn }
         | Left  (Search _) | Right _ -> acc
     end)
 

--- a/src/arg_spec.ml
+++ b/src/arg_spec.ml
@@ -1,7 +1,5 @@
 open Import
 
-module Pset = Path.Set
-
 type 'a t =
   | A        of string
   | As       of string list
@@ -19,9 +17,9 @@ type 'a t =
 let rec add_deps ts set =
   List.fold_left ts ~init:set ~f:(fun set t ->
     match t with
-    | Dep fn -> Pset.add set fn
+    | Dep fn -> Path.Set.add set fn
     | Deps        fns
-    | Hidden_deps fns -> Pset.union set (Pset.of_list fns)
+    | Hidden_deps fns -> Path.Set.union set (Path.Set.of_list fns)
     | S ts
     | Concat (_, ts) -> add_deps ts set
     | _ -> set)
@@ -56,7 +54,7 @@ let expand ~dir ts x =
     | Target _ | Hidden_targets _ -> die "Target not allowed under Dyn"
     | Dyn _ -> assert false
     | Hidden_deps l ->
-      dyn_deps := Pset.union !dyn_deps (Pset.of_list l);
+      dyn_deps := Path.Set.union !dyn_deps (Path.Set.of_list l);
       []
   in
   let rec loop = function

--- a/src/build.ml
+++ b/src/build.ml
@@ -1,7 +1,5 @@
 open Import
 
-module Pset = Path.Set
-
 module Vspec = struct
   type 'a t = T : Path.t * 'a Vfile_kind.t -> 'a t
 end
@@ -26,7 +24,7 @@ module Repr = struct
     | Second : ('a, 'b) t -> ('c * 'a, 'c * 'b) t
     | Split : ('a, 'b) t * ('c, 'd) t -> ('a * 'c, 'b * 'd) t
     | Fanout : ('a, 'b) t * ('a, 'c) t -> ('a, 'b * 'c) t
-    | Paths : Pset.t -> ('a, 'a) t
+    | Paths : Path.Set.t -> ('a, 'a) t
     | Paths_for_rule : Path.Set.t -> ('a, 'a) t
     | Paths_glob : glob_state ref -> ('a, Path.t list) t
     (* The reference gets decided in Build_interpret.deps *)
@@ -134,8 +132,8 @@ let rec all = function
     >>>
     arr (fun (x, y) -> x :: y)
 
-let path p = Paths (Pset.singleton p)
-let paths ps = Paths (Pset.of_list ps)
+let path p = Paths (Path.Set.singleton p)
+let paths ps = Paths (Path.Set.of_list ps)
 let path_set ps = Paths ps
 let paths_glob ~loc ~dir re = Paths_glob (ref (G_unevaluated (loc, dir, re)))
 let vpath vp = Vpath vp
@@ -206,7 +204,7 @@ let get_prog = function
     >>> dyn_paths (arr (function Error _ -> [] | Ok x -> [x]))
 
 let prog_and_args ?(dir=Path.root) prog args =
-  Paths (Arg_spec.add_deps args Pset.empty)
+  Paths (Arg_spec.add_deps args Path.Set.empty)
   >>>
   (get_prog prog &&&
    (arr (Arg_spec.expand ~dir args)

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -1,8 +1,6 @@
 open Import
 open Build.Repr
 
-module Pset = Path.Set
-module Pmap = Path.Map
 module Vspec = Build.Vspec
 
 module Target = struct
@@ -15,8 +13,8 @@ module Target = struct
     | Vfile (Vspec.T (p, _)) -> p
 
   let paths ts =
-    List.fold_left ts ~init:Pset.empty ~f:(fun acc t ->
-      Pset.add acc (path t))
+    List.fold_left ts ~init:Path.Set.empty ~f:(fun acc t ->
+      Path.Set.add acc (path t))
 end
 
 module Static_deps = struct
@@ -62,20 +60,20 @@ let static_deps t ~all_targets ~file_tree =
     | Second t -> loop t acc
     | Split (a, b) -> loop a (loop b acc)
     | Fanout (a, b) -> loop a (loop b acc)
-    | Paths fns -> { acc with action_deps = Pset.union fns acc.action_deps }
+    | Paths fns -> { acc with action_deps = Path.Set.union fns acc.action_deps }
     | Paths_for_rule fns ->
-      { acc with rule_deps = Pset.union fns acc.rule_deps }
+      { acc with rule_deps = Path.Set.union fns acc.rule_deps }
     | Paths_glob state -> begin
         match !state with
         | G_evaluated l ->
-          { acc with action_deps = Pset.union acc.action_deps (Pset.of_list l) }
+          { acc with action_deps = Path.Set.union acc.action_deps (Path.Set.of_list l) }
         | G_unevaluated (loc, dir, re) ->
           let targets = all_targets ~dir in
           let result =
-            Pset.filter targets ~f:(fun path ->
+            Path.Set.filter targets ~f:(fun path ->
               Re.execp re (Path.basename path))
           in
-          if Pset.is_empty result then begin
+          if Path.Set.is_empty result then begin
             match inspect_path file_tree dir with
             | None ->
               Loc.warn loc "Directory %s doesn't exist."
@@ -89,8 +87,8 @@ let static_deps t ~all_targets ~file_tree =
               (* diml: we should probably warn in this case as well *)
               ()
           end;
-          state := G_evaluated (Pset.to_list result);
-          let action_deps = Pset.union result acc.action_deps in
+          state := G_evaluated (Path.Set.to_list result);
+          let action_deps = Path.Set.union result acc.action_deps in
           { acc with action_deps }
       end
     | If_file_exists (p, state) -> begin
@@ -99,7 +97,7 @@ let static_deps t ~all_targets ~file_tree =
         | Undecided (then_, else_) ->
           let dir = Path.parent_exn p in
           let targets = all_targets ~dir in
-          if Pset.mem targets p then begin
+          if Path.Set.mem targets p then begin
             state := Decided (true, then_);
             loop then_ acc
           end else begin
@@ -108,15 +106,15 @@ let static_deps t ~all_targets ~file_tree =
           end
       end
     | Dyn_paths t -> loop t acc
-    | Vpath (Vspec.T (p, _)) -> { acc with rule_deps = Pset.add acc.rule_deps p }
-    | Contents p -> { acc with rule_deps = Pset.add acc.rule_deps p }
-    | Lines_of p -> { acc with rule_deps = Pset.add acc.rule_deps p }
+    | Vpath (Vspec.T (p, _)) -> { acc with rule_deps = Path.Set.add acc.rule_deps p }
+    | Contents p -> { acc with rule_deps = Path.Set.add acc.rule_deps p }
+    | Lines_of p -> { acc with rule_deps = Path.Set.add acc.rule_deps p }
     | Record_lib_deps _ -> acc
     | Fail _ -> acc
     | Memo m -> loop m.t acc
     | Catch (t, _) -> loop t acc
   in
-  loop (Build.repr t) { rule_deps = Pset.empty; action_deps = Pset.empty }
+  loop (Build.repr t) { rule_deps = Path.Set.empty; action_deps = Path.Set.empty }
 
 let lib_deps =
   let rec loop : type a b. (a, b) t -> Build.lib_deps -> Build.lib_deps

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -184,11 +184,10 @@ module Cached_digest = struct
   let db_file = Path.relative Path.build_dir ".digest-db"
 
   let dump () =
-    let module Pmap = Path.Map in
     let sexp =
       Sexp.List (
-        Hashtbl.foldi cache ~init:Pmap.empty ~f:(fun key data acc ->
-          Pmap.add acc key data)
+        Hashtbl.foldi cache ~init:Path.Map.empty ~f:(fun key data acc ->
+          Path.Map.add acc key data)
         |> Path.Map.to_list
         |> List.map ~f:(fun (path, file) ->
           Sexp.List [ Quoted_string (Path.to_string path)


### PR DESCRIPTION
They save very little in terms of typing but grepping harder than it should be

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>