### PR TITLE
Speed up merlin generation

### DIFF
--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -41,11 +41,9 @@ module Dot_file = struct
     let serialize_path = Path.reach ~from:remaindir in
     Buffer.clear b;
     Path.Set.iter obj_dirs ~f:(fun p ->
-      printf "B %s\n" (serialize_path p)
-    );
+      printf "B %s\n" (serialize_path p));
     Path.Set.iter src_dirs ~f:(fun p ->
-      printf "S %s\n" (serialize_path p)
-    );
+      printf "S %s\n" (serialize_path p));
     begin match ppx with
     | [] -> ()
     | ppx ->
@@ -58,9 +56,7 @@ module Dot_file = struct
     | [] -> ()
     | flags ->
       print "FLG";
-      List.iter flags ~f:(fun f ->
-        printf " %s" (quote_for_shell f)
-      );
+      List.iter flags ~f:(fun f -> printf " %s" (quote_for_shell f));
       print "\n"
     end;
     Buffer.contents b
@@ -136,20 +132,16 @@ let dot_merlin sctx ~dir ~scope ({ requires; flags; _ } as t) =
               ( Path.Set.add src_dirs (Lib.src_dir lib)
               , Path.Set.add build_dirs (
                   Lib.obj_dir lib
-                  |> Path.drop_optional_build_context
-                )
-              )
-            ) in
+                  |> Path.drop_optional_build_context)))
+        in
         Dot_file.to_string
           ~remaindir
           ~ppx:(ppx_flags sctx ~dir ~scope ~src_dir:remaindir t)
           ~flags
           ~src_dirs:(Path.Set.union src_dirs t.source_dirs)
-          ~obj_dirs:(Path.Set.union obj_dirs t.objs_dirs)
-      )
+          ~obj_dirs:(Path.Set.union obj_dirs t.objs_dirs))
       >>>
-      Build.write_file_dyn merlin_file
-    )
+      Build.write_file_dyn merlin_file)
 
 let merge_two a b =
   { requires = Lib.Set.union a.requires b.requires

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -49,7 +49,10 @@ module Dot_file = struct
     begin match ppx with
     | [] -> ()
     | ppx ->
-      printf "FLG -ppx %s\n" (Filename.quote (String.concat ~sep:" " ppx));
+      printf "FLG -ppx %s\n"
+        (List.map ppx ~f:quote_for_shell
+         |> String.concat ~sep:" "
+         |> Filename.quote)
     end;
     begin match flags with
     | [] -> ()

--- a/test/blackbox-tests/test-cases/github759/run.t
+++ b/test/blackbox-tests/test-cases/github759/run.t
@@ -1,17 +1,17 @@
   $ jbuilder build foo.cma
   $ cat .merlin
   B _build/default/.foo.objs
-  FLG -open Foo -w -40
   S .
+  FLG -open Foo -w -40
   $ rm -f .merlin
   $ jbuilder build foo.cma
   $ cat .merlin
   B _build/default/.foo.objs
-  FLG -open Foo -w -40
   S .
+  FLG -open Foo -w -40
   $ echo toto > .merlin
   $ jbuilder build foo.cma
   $ cat .merlin
   B _build/default/.foo.objs
-  FLG -open Foo -w -40
   S .
+  FLG -open Foo -w -40

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -5,29 +5,29 @@
       ocamlopt sanitize-dot-merlin/sanitize_dot_merlin.exe
   sanitize_dot_merlin alias print-merlins
   # Processing exe/.merlin
-  B ../_build/default/exe/.x.eobjs
-  B ../_build/default/lib/.foo.objs
   B $LIB_PREFIX/lib/bytes
   B $LIB_PREFIX/lib/findlib
   B $LIB_PREFIX/lib/ocaml
-  FLG -w -40
-  S .
-  S ../lib
+  B ../_build/default/exe/.x.eobjs
+  B ../lib/.foo.objs
   S $LIB_PREFIX/lib/bytes
   S $LIB_PREFIX/lib/findlib
   S $LIB_PREFIX/lib/ocaml
+  S ../_build/default/lib
+  S .
+  FLG -w -40
   # Processing lib/.merlin
+  B $LIB_PREFIX/lib/bytes
+  B $LIB_PREFIX/lib/findlib
+  B $LIB_PREFIX/lib/ocaml
   B ../_build/default/lib/.bar.objs
   B ../_build/default/lib/.foo.objs
-  B $LIB_PREFIX/lib/bytes
-  B $LIB_PREFIX/lib/findlib
-  B $LIB_PREFIX/lib/ocaml
-  FLG -open Foo -w -40 -open Bar -w -40
-  FLG -ppx '$PPX/fooppx@./ppx.exe --as-ppx --cookie '\''library-name="foo"'\'''
-  S .
   S $LIB_PREFIX/lib/bytes
   S $LIB_PREFIX/lib/findlib
   S $LIB_PREFIX/lib/ocaml
+  S .
+  FLG -ppx '$PPX/fooppx@./ppx.exe --as-ppx --cookie library-name="foo"'
+  FLG -open Foo -w -40 -open Bar -w -40
 
 Make sure a ppx directive is generated
 

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -26,7 +26,7 @@
   S $LIB_PREFIX/lib/findlib
   S $LIB_PREFIX/lib/ocaml
   S .
-  FLG -ppx '$PPX/fooppx@./ppx.exe --as-ppx --cookie library-name="foo"'
+  FLG -ppx '$PPX/fooppx@./ppx.exe --as-ppx --cookie '\''library-name="foo"'\'''
   FLG -open Foo -w -40 -open Bar -w -40
 
 Make sure a ppx directive is generated


### PR DESCRIPTION
Generate the string all at once and reuse buffer. I'm not sure how much this helps performance since the old approach wasn't slow. But this piece of code does run on 0 rebuilds so it's worth tweaking. Also, this cleanup makes it easier to fix the order of paths following the symbolic path fix.