### PR TITLE
Use Sys.{win32,cygwin} rather than Sys.os_type

### DIFF
--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1,7 +1,8 @@
 let is_dir_sep =
-  match Sys.os_type with
-  | "Win32" | "Cygwin" -> fun c -> c = '/' || c = '\\' || c = ':'
-  | _ -> fun c -> c = '/'
+  if Sys.win32 || Sys.cygwin then
+    fun c -> c = '/' || c = '\\' || c = ':'
+  else
+    fun c -> c = '/'
 
 let explode_path =
   let rec start acc path i =


### PR DESCRIPTION
The former functions are optimized away while the latter isn't.
