### PR TITLE
Make "path already scanned" message deterministic

### DIFF
--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -199,6 +199,11 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) path =
             Left fn)
       in
       let files = String.Set.of_list files in
+      let sub_dirs =
+        List.sort
+          ~compare:(fun (a, _, _) (b, _, _) -> String.compare a b)
+          sub_dirs
+      in
       let project =
         match Dune_project.load ~dir:path ~files with
         | Some _ as x -> x


### PR DESCRIPTION
Hi!

When a symlink loop is detected, the following message is printed:

> Path X has already been scanned. Cannot scan it again through symlink Y

However, the actual symlink that is displayed depends on the order in with `readdir` outputs the contents (which depends on FS internals).

This sorts the directory list so that the message is deterministic.

It can be tested by adding for example a `List.rev` call after `Path.readdir`: the affected version will return a different version in the `github764` test.

Thanks!