### PR TITLE
Move sexpable signature to Stdune.Sexp

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -10,16 +10,10 @@ module Outputs = struct
     | Outputs -> "outputs"
 end
 
-module type Sexpable = sig
-  type t
-  val t : t Sexp.Of_sexp.t
-  val sexp_of_t : t Sexp.To_sexp.t
-end
-
 module Make_ast
-    (Program : Sexpable)
-    (Path    : Sexpable)
-    (String  : Sexpable)
+    (Program : Sexp.Sexpable)
+    (Path    : Sexp.Sexpable)
+    (String  : Sexp.Sexpable)
     (Ast : Action_intf.Ast
      with type program := Program.t
      with type path    := Path.t

--- a/src/action.mli
+++ b/src/action.mli
@@ -87,8 +87,7 @@ module Unexpanded : sig
     with type path    := String_with_vars.t
     with type string  := String_with_vars.t
 
-  val t : t Sexp.Of_sexp.t
-  val sexp_of_t : t Sexp.To_sexp.t
+  include Sexp.Sexpable with type t := t
 
   module Partial : sig
     include Action_intf.Ast

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -3,7 +3,7 @@ open Import
 let parse_sub_systems sexps =
   List.filter_map sexps ~f:(fun sexp ->
     let name, ver, data =
-      Sexp.Of_sexp.(triple string (located Syntax.Version.t_of_sexp) raw) sexp
+      Sexp.Of_sexp.(triple string (located Syntax.Version.t) raw) sexp
     in
     match Sub_system_name.get name with
     | None ->

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -52,8 +52,8 @@ val is_standard : t -> bool
 module Unexpanded : sig
   type expanded = t
   type t
-  val t : t Sexp.Of_sexp.t
-  val sexp_of_t : t Sexp.To_sexp.t
+
+  include Sexp.Sexpable with type t := t
   val standard : t
 
   val field : ?default:t -> string -> t Sexp.Of_sexp.record_parser

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -452,3 +452,9 @@ module Of_sexp = struct
                     String.uncapitalize name) }
           "Unknown value %s" s
 end
+
+module type Sexpable = sig
+  type t
+  val t : t Of_sexp.t
+  val sexp_of_t : t To_sexp.t
+end

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -169,3 +169,9 @@ module Of_sexp : sig
 
   val enum : (string * 'a) list -> 'a t
 end
+
+module type Sexpable = sig
+  type t
+  val t : t Of_sexp.t
+  val sexp_of_t : t To_sexp.t
+end

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -7,7 +7,7 @@ module Version = struct
 
   let sexp_of_t t = Sexp.unsafe_atom_of_string (to_string t)
 
-  let t_of_sexp : t Sexp.Of_sexp.t = function
+  let t : t Sexp.Of_sexp.t = function
     | Atom (loc, A s) -> begin
         try
           Scanf.sscanf s "%u.%u" (fun a b -> (a, b))

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -9,8 +9,7 @@ module Version : sig
       [Z <= Y]. *)
   type t = int * int
 
-  val sexp_of_t : t Sexp.To_sexp.t
-  val t_of_sexp : t Sexp.Of_sexp.t
+  include Sexp.Sexpable with type t := t
 
   (** Whether the parser can read the data or not *)
   val can_read : parser_version:t -> data_version:t -> bool


### PR DESCRIPTION
@diml we can change `val t` to `t_of_sexp` everywhere if you'd like. I also prefer the symmetric convention.