### PR TITLE
Rename Path.readdir to Path.readdir_unsorted

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -676,7 +676,7 @@ module Promotion = struct
   let do_promote db =
     let by_targets = group_by_targets db  in
     let potential_build_contexts =
-      match Path.readdir Path.build_dir with
+      match Path.readdir_unsorted Path.build_dir with
       | exception _ -> []
       | files ->
         List.filter_map files ~f:(fun fn ->

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -408,7 +408,7 @@ let get_dir_status t ~dir =
       Dir_status.Loaded Path.Set.empty
     else if not (Path.is_local dir) then
       Dir_status.Loaded
-        (match Path.readdir dir with
+        (match Path.readdir_unsorted dir with
          | exception _ -> Path.Set.empty
          | files ->
            Path.Set.of_list (List.map files ~f:(Path.relative dir)))
@@ -637,7 +637,7 @@ let remove_old_artifacts t ~dir ~subdirs_to_keep =
      Hashtbl.mem t.files (Path.relative dir Config.jbuilder_keep_fname) then
     ()
   else
-    match Path.readdir dir with
+    match Path.readdir_unsorted dir with
     | exception _ -> ()
     | files ->
       List.iter files ~f:(fun fn ->

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -180,7 +180,7 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) path =
   let rec walk path ~dirs_visited ~project ~ignored : Dir.t =
     let contents = lazy (
       let files, sub_dirs =
-        Path.readdir path
+        Path.readdir_unsorted path
         |> List.filter_partition_map ~f:(fun fn ->
           let path = Path.relative path fn in
           let is_directory, file =

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -465,7 +465,7 @@ let explode_exn t =
 let exists t =
   try Sys.file_exists (to_string t)
   with Sys_error _ -> false
-let readdir t = Sys.readdir (to_string t) |> Array.to_list
+let readdir_unsorted t = Sys.readdir (to_string t) |> Array.to_list
 let is_directory t =
   try Sys.is_directory (to_string t)
   with Sys_error _ -> false

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -128,7 +128,7 @@ val split_first_component : t -> (string * t) option
 val insert_after_build_dir_exn : t -> string -> t
 
 val exists : t -> bool
-val readdir : t -> string list
+val readdir_unsorted : t -> string list
 val is_directory : t -> bool
 val rmdir : t -> unit
 val unlink : t -> unit


### PR DESCRIPTION
As `Sys.readdir`, it returns entries in an nondeterministic order. This can cause problems if caller relies on the list being sorted.

See #820.

Thanks!