### PR TITLE
Block strings + remove block/sexp comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,13 @@ next
 - Allow setting custom build directories using the `--build-dir` flag or
   `DUNE_BUILD_DIR` environment variable (#846, fix #291, @diml @rgrinberg)
 
+- In dune files, remove support for block (`#| ... |#)`) and sexp
+  (`#;`) comments. These were very rarely used and complicate the
+  language (#837, @diml)
+
+- In dune files, add support for block strings, allowing to nicely
+  format blocks of texts (#837, @diml)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/doc/project-layout-specification.rst
+++ b/doc/project-layout-specification.rst
@@ -26,81 +26,116 @@ files. If no version is specified, the latest one will be used.
 Metadata format
 ===============
 
-Most configuration files read by Jbuilder are using the S-expression
-syntax, which is very simple.  It is described below.
+All configuration files read by Dune are using a syntax similar to the
+one of S-expressions, which is very simple. The Dune langauge can
+represent three kinds of values: atoms, strings and lists. By
+combining these, it is possible to construct arbitrarily complex
+project descriptions.
 
-Note that the format is completely static. However you can do
-meta-programming on jbuilds files by writing them in :ref:`ocaml-syntax`.
-
-
-Lexical conventions of s-expressions
-------------------------------------
-
-Whitespace, which consists of space, newline, horizontal tab, and form
-feed, is ignored unless within an OCaml-string, where it is treated
-according to OCaml-conventions.  The left parenthesis opens a new
-list, the right one closes it.  Lists can be empty.
-
-The double quote denotes the beginning and end of a string using
-similar lexing conventions to the ones of OCaml (see the OCaml-manual
-for details).  Differences are:
-
-- octal escape sequences (``\o123``) are not supported;
-- backslash that's not a part of any escape sequence is kept as it is
-  instead of resulting in parse error;
-- a backslash followed by a space does not form an escape sequence, so
-  it’s interpreted as is, while it is interpreted as just a space by
-  OCaml.
-
-All characters other than double quotes, left- and right parentheses,
-whitespace, carriage return, and comment-introducing characters or
-sequences (see next paragraph) are considered part of a contiguous
-string.
+A Dune configuration file is a sequence of atoms, strings or lists
+separated by spaces, newlines and comments. The other sections of this
+manual describe how each configuration file is interpreted. We
+describe below the syntax of the language.
 
 Comments
 --------
 
-There are three kinds of comments:
+The Dune language only has end of line comments. End of line comments
+are introduced with a semicolon and span up to the end of the end of
+the current line. Everything from the semicolon to the end of the line
+is ignored. For instance:
 
-- line comments are introduced with ``;``, and end at the newline;
-- sexp comments are introduced with ``#;``, and end at the end of the
-  following s-expression;
-- block comments are introduced with ``#|`` and end with ``|#``.
-  These can be nested, and double-quotes within them must be balanced
-  and be lexically correct OCaml strings.
+.. code::
 
-Grammar of s-expressions
-------------------------
+   ; This is a comment
 
-S-expressions are either sequences of non-whitespace characters
-(= atoms), doubly quoted strings or lists. The lists can recursively
-contain further s-expressions or be empty, and must be balanced,
-i.e. parentheses must match.
+Atoms
+-----
 
-Examples
---------
+An atom is a non-empty contiguous sequences of character other than
+special characters. Special characters are:
 
-::
+- spaces, horizontal tabs, newlines and form feed
+- opening and closing parenthesis
+- double quotes
+- semicolons
 
-    this_is_an_atom_123'&^%!  ; this is a comment
-    "another atom in an OCaml-string \"string in a string\" \123"
+For instance ``hello`` or ``+`` are valid atoms.
 
-    ; empty list follows below
-    ()
+Strings
+-------
 
-    ; a more complex example
-    (
-      (
-        list in a list  ; comment within a list
-        (list in a list in a list)
-        42 is the answer to all questions
-        #; (this S-expression
-             (has been commented out)
-           )
-        #| Block comments #| can be "nested" |# |#
-      )
-    )
+A string is a sequence of characters surrounded by double quotes. A
+string represent the exact text between the double quotes, except for
+escape sequences. Escape sequence are introduced by the a backslash
+character. Dune recognizes and interprets the following escape
+sequences:
 
+- ``\n`` to represent a newline character
+- ``\r`` to represent a cariage return (character with ASCII code 13)
+- ``\b`` to represent ASCII character 8
+- ``\t`` to represent a horizontal tab
+- ``\NNN``, a backslash followed by three decimal characters to
+  represent the character with ASCII code ``NNN``
+- ``\xHH``, a backslach followed by two hexidecimal characters to
+  represent the character with ASCII code ``HH`` in hexadecimal
+- ``\\``, a double backslash to represent a single backslash
+
+Additionally, a backslash that comes just before the end of the line
+is used to skip the newline up to the next non-space character. For
+instance the following two strings represent the same text:
+
+.. code::
+
+   "abcdef"
+   "abc\
+      def"
+
+In most places where Dune expect a string, it will also accept an
+atom. As a result it possible to write most Dune configuration file
+using very few double quotes. This is very convenient in practice.
+
+End of line strings
+-------------------
+
+End of line strings are another way to write strings. The are a
+convenient way to write blocks of text inside a Dune file.
+
+End of line strings are introduced by ``"\|`` or ``"\>`` and span up
+the end of the current line. If the next line starts as well by
+``"\|`` or ``"\>`` it is the continuation of the same string. For
+readability, it is necessary that the text that follows the delimiter
+is either empty or starts with a space that is ignored.
+
+For instance:
+
+.. code::
+
+   "\| this is a block
+   "\| of text
+
+represent the same text as the string ``"this is a block\nof text"``.
+
+Escape sequences are interpreted in text that follows ``"\|`` but not
+in text that follows ``"\>``. Both delimiters can be mixed inside the
+same block of text.
+
+Lists
+-----
+
+Lists are sequences of values enclosed by parentheses. For instance
+``(x y z)`` is a list containing the three atoms ``x``, ``y`` and
+``z``. Lists can be empty, for instance: ``()``.
+
+Lists can be nested, allowing to represent arbitrarily complex
+descriptions. For instance:
+
+.. code::
+
+   (html
+    (head (title "Hello world!"))
+    (body
+      This is a simple example of using S-expressions))
 
 .. _opam-files:
 

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -195,6 +195,9 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) path =
             | [fn] ->
               let dune_file, ignored_subdirs =
                 Dune_file.load (Path.relative path fn)
+                  ~lexer:(match fn with
+                    | "jbuild" -> Sexp.Lexer.jbuild_token
+                    | _        -> Sexp.Lexer.token)
               in
               (Some dune_file, ignored_subdirs)
             | _ ->

--- a/src/usexp/lexer.mli
+++ b/src/usexp/lexer.mli
@@ -15,6 +15,7 @@ end
 type t = Lexing.lexbuf -> Token.t
 
 val token : t
+val jbuild_token : t
 
 module Error : sig
   type t =

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -102,6 +102,7 @@ module Lexer : sig
   type t = Lexing.lexbuf -> Token.t
 
   val token : t
+  val jbuild_token : t
 end
 
 module Parser : sig

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -15,6 +15,14 @@
     (progn (run ${exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
 (alias
+ ((name block-strings)
+  (deps ((package dune) (files_recursively_in test-cases/block-strings)))
+  (action
+   (chdir
+    test-cases/block-strings
+    (progn (run ${exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
+
+(alias
  ((name byte-code-only)
   (deps ((package dune) (files_recursively_in test-cases/byte-code-only)))
   (action
@@ -521,6 +529,7 @@
   (deps
    ((alias aliases)
     (alias bad-alias-error)
+    (alias block-strings)
     (alias byte-code-only)
     (alias c-stubs)
     (alias configurator)
@@ -583,6 +592,7 @@
   (deps
    ((alias aliases)
     (alias bad-alias-error)
+    (alias block-strings)
     (alias byte-code-only)
     (alias c-stubs)
     (alias configurator)

--- a/test/blackbox-tests/test-cases/block-strings/dune
+++ b/test/blackbox-tests/test-cases/block-strings/dune
@@ -1,0 +1,48 @@
+; Example script taken from re2
+
+; With normal strings
+(alias
+ ((name old)
+  (action (echo "\
+ARFLAGS=rsc
+CXX=g++
+CXXFLAGS=\"-Wall -O3 -g -pthread\"
+if ! ${.ARCH_SIXTYFOUR}; then
+  CXX=\"$CXX -m32\"
+fi
+${.MAKE} -s -C libre2 clean
+${.MAKE} -s -C libre2 \\
+  ARFLAGS=\"$ARFLAGS\" \\
+  CXX=\"$CXX\" \\
+  CXXFLAGS=\"$CXXFLAGS\" \\
+  obj/libre2.a obj/so/libre2.so
+cp libre2/obj/libre2.a libre2_c_stubs.a
+cp libre2/obj/so/libre2.so dllre2_c_stubs.so
+${.MAKE} -s -C libre2 clean
+"))))
+
+; With block strings
+(alias
+ ((name new)
+  (action (echo "\> ARFLAGS=rsc
+                "\> CXX=g++
+                "\> CXXFLAGS="-Wall -O3 -g -pthread"
+                "\> if ! ${.ARCH_SIXTYFOUR}; then
+                "\>   CXX="$CXX -m32"
+                "\> fi
+                "\> ${.MAKE} -s -C libre2 clean
+                "\> ${.MAKE} -s -C libre2 \
+                "\>   ARFLAGS="$ARFLAGS" \
+                "\>   CXX="$CXX" \
+                "\>   CXXFLAGS="$CXXFLAGS" \
+                "\>   obj/libre2.a obj/so/libre2.so
+                "\> cp libre2/obj/libre2.a libre2_c_stubs.a
+                "\> cp libre2/obj/so/libre2.so dllre2_c_stubs.so
+                "\> ${.MAKE} -s -C libre2 clean
+))))
+
+(alias
+ ((name quoting-test)
+  (action (echo "\| normal: \065
+                "\> raw:    \065
+))))

--- a/test/blackbox-tests/test-cases/block-strings/run.t
+++ b/test/blackbox-tests/test-cases/block-strings/run.t
@@ -1,0 +1,37 @@
+  $ dune build @old
+  ARFLAGS=rsc
+  CXX=g++
+  CXXFLAGS="-Wall -O3 -g -pthread"
+  if ! ${.ARCH_SIXTYFOUR}; then
+    CXX="$CXX -m32"
+  fi
+  ${.MAKE} -s -C libre2 clean
+  ${.MAKE} -s -C libre2 \
+    ARFLAGS="$ARFLAGS" \
+    CXX="$CXX" \
+    CXXFLAGS="$CXXFLAGS" \
+    obj/libre2$ext_lib obj/so/libre2$ext_dll
+  cp libre2/obj/libre2$ext_lib libre2_c_stubs$ext_lib
+  cp libre2/obj/so/libre2$ext_dll dllre2_c_stubs$ext_dll
+  ${.MAKE} -s -C libre2 clean
+
+  $ dune build @new
+  ARFLAGS=rsc
+  CXX=g++
+  CXXFLAGS="-Wall -O3 -g -pthread"
+  if ! ${.ARCH_SIXTYFOUR}; then
+    CXX="$CXX -m32"
+  fi
+  ${.MAKE} -s -C libre2 clean
+  ${.MAKE} -s -C libre2 \
+    ARFLAGS="$ARFLAGS" \
+    CXX="$CXX" \
+    CXXFLAGS="$CXXFLAGS" \
+    obj/libre2$ext_lib obj/so/libre2$ext_dll
+  cp libre2/obj/libre2$ext_lib libre2_c_stubs$ext_lib
+  cp libre2/obj/so/libre2$ext_dll dllre2_c_stubs$ext_dll
+  ${.MAKE} -s -C libre2 clean
+
+  $ dune build @quoting-test
+  normal: A
+  raw:    \065

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -39,32 +39,59 @@ val of_sexp : int list Stdune.Sexp.Of_sexp.t = <fun>
 val x : int list = [1; 2]
 |}]
 
+type parse_result_diff =
+  { jbuild : (Sexp.Ast.t list, string) result
+  ; dune   : (Sexp.Ast.t list, string) result
+  }
+
+type parse_result =
+  | Same of (Sexp.Ast.t list, string) result
+  | Different of parse_result_diff
+
 let parse s =
-  try
-    Sexp.parse_string ~fname:"" ~mode:Many s
-  with Sexp.Parse_error e ->
-    failwith (Sexp.Parse_error.message e)
+  let f ~lexer =
+    try
+      Ok (Sexp.parse_string ~fname:"" ~mode:Many ~lexer s)
+    with Sexp.Parse_error e ->
+      Error (Sexp.Parse_error.message e)
+  in
+  let jbuild = f ~lexer:Sexp.Lexer.jbuild_token in
+  let dune   = f ~lexer:Sexp.Lexer.token        in
+  if jbuild <> dune then
+    Different { jbuild; dune }
+  else
+    Same jbuild
 [%%expect{|
-val parse : string -> Usexp.Ast.t list = <fun>
+type parse_result_diff = {
+  jbuild : (Stdune.Sexp.Ast.t list, string) Stdune.result;
+  dune : (Stdune.Sexp.Ast.t list, string) Stdune.result;
+}
+type parse_result =
+    Same of (Stdune.Sexp.Ast.t list, string) Stdune.result
+  | Different of parse_result_diff
+val parse : string -> parse_result = <fun>
 |}]
 
 parse {| # ## x##y x||y a#b|c#d copy# |}
 [%%expect{|
-- : Usexp.Ast.t list = [#; ##; x##y; x||y; a#b|c#d; copy#]
+- : parse_result = Same (Ok [#; ##; x##y; x||y; a#b|c#d; copy#])
 |}]
 
 
 parse {|x #| comment |# y|}
 [%%expect{|
-- : Usexp.Ast.t list = [x; y]
+- : parse_result =
+Different {jbuild = Ok [x; y]; dune = Ok [x; #|; comment; |#; y]}
 |}]
 
 parse {|x#|y|}
 [%%expect{|
-Exception: Failure "atoms cannot contain #|".
+- : parse_result =
+Different {jbuild = Error "jbuild_atoms cannot contain #|"; dune = Ok [x#|y]}
 |}]
 
 parse {|x|#y|}
 [%%expect{|
-Exception: Failure "atoms cannot contain |#".
+- : parse_result =
+Different {jbuild = Error "jbuild_atoms cannot contain |#"; dune = Ok [x|#y]}
 |}]


### PR DESCRIPTION
This PR proposes two changes in the syntax of dune files. The syntax of jbuild files is untouched.

### 1. Remove block/sexp comments

These were pretty much never used and they make the lexical conventions of the language more complicated. I think end of line comments are enough.

### 2. Add block strings

It is currently painful to write blocks of text in dune files as there is no syntax for raw strings where things don't need to be escaped. I find the usual syntax used in programming languages for raw strings quite painful as it's impossible to indent blocks of text properly. This PR proposes a syntax for *block* or *end of line* strings which solves this problem.

The syntax is as follow: everything that appears after a `"\|` on a line is a string. If the next line starts with spaces and `"\|` again, it is the continuation of the string. For readability, we require that this delimiter is either followed by a newline or one space that is ignored. Escape sequences are still interpreted interpreted, however it is possible to disable this behavior on a line by line basis by using `"\>` rather than `"\|`. In the end, a block of text looks like this:

```(alias
 ((name new)
  (action (echo "\| ARFLAGS=rsc
                "\| CXX=g++
                "\| CXXFLAGS="-Wall -O3 -g -pthread"
                "\| if ! ${ARCH_SIXTYFOUR}; then
                "\|   CXX="$CXX -m32"
                "\| fi
                "\| ${MAKE} -s -C libre2 clean
                "\| ${MAKE} -s -C libre2 \
                "\|   ARFLAGS="$ARFLAGS" \
                "\|   CXX="$CXX" \
                "\|   CXXFLAGS="$CXXFLAGS" \
                "\|   obj/libre2.a obj/so/libre2.so
                "\| cp libre2/obj/libre2.a libre2_c_stubs.a
                "\| cp libre2/obj/so/libre2.so dllre2_c_stubs.so
                "\| ${MAKE} -s -C libre2 clean
))))
```

Which IMO is much nicer that what we had to write previously:

```
(alias
 ((name old)
  (action (echo "\
ARFLAGS=rsc
CXX=g++
CXXFLAGS=\"-Wall -O3 -g -pthread\"
if ! ${ARCH_SIXTYFOUR}; then
  CXX=\"$CXX -m32\"
fi
${MAKE} -s -C libre2 clean
${MAKE} -s -C libre2 \
  ARFLAGS=\"$ARFLAGS\" \
  CXX=\"$CXX\" \
  CXXFLAGS=\"$CXXFLAGS\" \
  obj/libre2.a obj/so/libre2.so
cp libre2/obj/libre2.a libre2_c_stubs.a
cp libre2/obj/so/libre2.so dllre2_c_stubs.so
${MAKE} -s -C libre2 clean
"))))
```

I chose this syntax since it doesn't reserve another character.