### PR TITLE
Fix 'make install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ boot.exe: bootstrap.ml
 	ocaml bootstrap.ml
 
 install:
-	$(BIN) install $(INSTALL_ARGS)
+	$(BIN) install $(INSTALL_ARGS) dune
 
 uninstall:
-	$(BIN) uninstall $(INSTALL_ARGS)
+	$(BIN) uninstall $(INSTALL_ARGS) dune
 
 reinstall: uninstall reinstall
 


### PR DESCRIPTION
Currently it doesn't work as `make` only builds the `dune` package and not the `jbuilder` one.