### PR TITLE
configurator: add write_lines function

### DIFF
--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -483,13 +483,18 @@ let write_flags fname s =
   let sexp = Usexp.List(List.map ~f:Usexp.atom_or_quoted_string s) in
   Io.write_file path (Usexp.to_string sexp)
 
+let write_lines fname s =
+  let path = Path.of_string fname in
+  let buf = String.concat ~sep:"\n" s in
+  Io.write_file path buf
+
 let main ?(args=[]) ~name f =
   let ocamlc  = ref (
     match Sys.getenv "DUNE_CONFIGURATOR" with
     | s -> Some s
     | exception Not_found ->
-      die "Configurator scripts must be ran with jbuilder. \
-           To manually run a script, use $ jbuilder exec."
+      die "Configurator scripts must be run with Dune. \
+           To manually run a script, use $ dune exec."
   ) in
   let verbose = ref false in
   let dest_dir = ref None in

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -88,9 +88,14 @@ module Pkg_config : sig
 end with type configurator := t
 
 val write_flags : string -> string list -> unit
-(** [write_flags fname s] write the list of strings [s] to the file
+(** [write_flags fname s] writes the list of strings [s] to the file
    [fname] in an appropriate format so that it can used in jbuild
-   files with "(:include [fname])". *)
+   files with [(:include [fname])]. *)
+
+val write_lines : string -> string list -> unit
+(** [write_lines fname s] writes the list of string [s] to the file
+   [fname] with one line per string so that it can be used in jbuild
+   action rules with [${read-lines:<path>}]. *)
 
 (** Typical entry point for configurator programs *)
 val main


### PR DESCRIPTION
The `write_flags` only works with `(:include` directives, and it
is also useful to be able to write a list of lines so that the
discovered information can be used in variable expansion actions.

For example, ocaml-yaml discovers CFLAGS and then directly has
`(run ${CC} ${read-lines:cflags})` actions that use this new
write_lines function to list cflags instead of s-expressions.
They must be line-by-line or else variable expansion doesnt work
since CFLAGS contain spaces.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>