### PR TITLE
Fix unquoted list variables.

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -307,10 +307,10 @@ module Var_expansion = struct
     | Paths   (l, _) -> concat (List.map l ~f:(string_of_path ~dir))
 
   let to_path dir = function
-    | Strings (l, _) -> path_of_string dir (concat l)
+    | Strings ([l], _) -> path_of_string dir l
     | Paths ([p], _) -> p
-    | Paths (l,   _) ->
-      path_of_string dir (concat (List.map l ~f:(string_of_path ~dir)))
+    | Paths (_, _) -> die "paths must be quoted"
+    | Strings (_, _) -> die "strings must be quoted"
 
   let to_prog_and_args dir exp : Unresolved.Program.t * string list =
     let module P = Unresolved.Program in

--- a/test/blackbox-tests/test-cases/quoting/run.t
+++ b/test/blackbox-tests/test-cases/quoting/run.t
@@ -2,9 +2,7 @@ This behavior is surprising, we should get an error about the fact
 that ${@} is not quoted and doesn't contain exactly 1 element
 
   $ dune build --root bad x 2>&1 | grep -v Entering
-  Error: Rule failed to generate the following targets:
-  - x
-  - y
+  Paths must be quoted
 
 
 The targets should only be interpreted as a single path when quoted


### PR DESCRIPTION
This is the naive attempt to fix #699. It still needs some fixing to give proper locs in the case when the error occurs, but I'm not so certain we're taking the right approach here. I don't really like that `expand` and `partial_expand` have so much duplicate code and the way "multivalued" expansions are handled. I don't have suggestions how to improve this but I will try to improve the expansion code.