### PR TITLE
Make Module.t private and add Module.make

### DIFF
--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -179,14 +179,11 @@ include Sub_system.Register_end_point(
     let main_module_name = Module.Name.of_string name in
     let modules =
       Module.Name.Map.singleton main_module_name
-        { Module.
-          name = main_module_name
-        ; impl = Some { name   = main_module_filename
-                      ; syntax = OCaml
-                      }
-        ; intf = None
-        ; obj_name = name
-        }
+        (Module.make main_module_name
+           ~impl:{ name   = main_module_filename
+                 ; syntax = OCaml
+                 }
+           ~obj_name:name)
     in
 
     let extra_vars =

--- a/src/module.mli
+++ b/src/module.mli
@@ -32,15 +32,24 @@ module File : sig
   val to_ocaml : t -> t
 end
 
-type t =
-  { name      : Name.t (** Name of the module. This is always the basename of the filename
-                           without the extension. *)
+(** Representation of a module. It is guaranteed that at least one of
+   [impl] or [intf] is set. *)
+type t = private
+  { name      : Name.t (** Name of the module. This is always the
+                           basename of the filename without the
+                           extension. *)
   ; impl      : File.t option
   ; intf      : File.t option
-
-  ; obj_name  : string (** Object name. It is different from [name] for wrapped
-                           modules. *)
+  ; obj_name  : string (** Object name. It is different from [name]
+                          for wrapped modules. *)
   }
+
+val make
+  :  ?impl:File.t
+  -> ?intf:File.t
+  -> ?obj_name:string
+  -> Name.t
+  -> t
 
 val name : t -> Name.t
 
@@ -67,5 +76,7 @@ val iter : t -> f:(Ml_kind.t -> File.t -> unit) -> unit
 
 val has_impl : t -> bool
 
-(** Set the [obj_name] field of the module. [wrapper] might be a library name. *)
-val set_obj_name : t -> wrapper:string option -> t
+(** Prefix the object name with the library name. *)
+val with_wrapper : t -> libname:string -> t
+
+val map_files : t -> f:(Ml_kind.t -> File.t -> File.t) -> t

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -55,6 +55,8 @@ module To_sexp = struct
   let record_fields (l : field list) =
     List (List.filter_map l ~f:(fun (k, v) ->
       Option.map v ~f:(fun v -> List[Atom (Atom.of_string k); v])))
+
+  let unknown _ = unsafe_atom_of_string "<unknown>"
 end
 
 module Of_sexp = struct

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -46,6 +46,8 @@ module To_sexp : sig
   val field_o : string -> 'a t-> 'a option -> field
 
   val record_fields : field list t
+
+  val unknown : _ t
 end with type sexp := t
 
 module Loc = Usexp.Loc

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -54,14 +54,12 @@ let setup sctx ~dir ~(libs : Library.t list) ~scope =
     let modules =
       Module.Name.Map.singleton
         main_module_name
-        { Module.
-          name = main_module_name
-        ; impl = Some { Module.File.
-                        name = main_module_filename
-                      ; syntax = Module.Syntax.OCaml
-                      }
-        ; intf = None
-        ; obj_name = exe_name } in
+        (Module.make main_module_name
+           ~impl:{ name = main_module_filename
+                 ; syntax = Module.Syntax.OCaml
+                 }
+           ~obj_name:exe_name)
+    in
     let utop_exe_dir = utop_exe_dir ~dir in
     let requires =
       let open Result.O in


### PR DESCRIPTION
This PR makes `Module.t` private and adds `Module.make`. The code is a bit nicer overall and  we can enforce that at least one of `impl` or `intf` is set.

One difference is that now `Module.make` always computes `obj_name`, even if it's sometimes never used. However I think the API is better this way.

/cc @fpottier 