### PR TITLE
Intern module name

### DIFF
--- a/src/module.mli
+++ b/src/module.mli
@@ -1,7 +1,7 @@
 open! Import
 
 module Name : sig
-  type t = private string
+  type t
 
   val add_suffix : t -> string -> t
 


### PR DESCRIPTION
I wasn't so sure about this before because you'd think we rely on the order of `Module.Name.{Map.Set}` somewhere or perhaps marshal the module names. But this seems to work.