### PR TITLE
Refactor odoc generation and fix the private doc alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,9 @@ next
   whether a multi valued variable is allowed is determined by the quoting and
   substitution context it appears in. (#849, fix #701, @rgrinberg)
 
+- Fix documentation generation for private libraries. (#864, fix #856,
+  @rgrinberg)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -22,13 +22,13 @@ type target =
   | Lib of Lib.t
   | Pkg of Package.Name.t
 
-type typ = Module | Mld
+type source = Module | Mld
 
 type odoc =
   { odoc_input: Path.t
   ; html_dir: Path.t
   ; html_file: Path.t
-  ; typ: typ
+  ; source: source
   }
 
 module Gen (S : sig val sctx : SC.t end) = struct
@@ -163,7 +163,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
   let setup_html (odoc_file : odoc) ~requires =
     let deps = Dep.deps requires in
     let to_remove, jbuilder_keep =
-      match odoc_file.typ with
+      match odoc_file.source with
       | Mld -> odoc_file.html_file, []
       | Module ->
         let jbuilder_keep =
@@ -283,7 +283,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
       { odoc_input
       ; html_dir
       ; html_file = html_dir ++ "index.html"
-      ; typ = Module
+      ; source = Module
       }
     | Pkg _ ->
       { odoc_input
@@ -294,7 +294,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
           |> String.drop_prefix ~prefix:"page-"
           |> Option.value_exn
         )
-      ; typ = Mld
+      ; source = Mld
       }
 
   let static_html = [ css_file; toplevel_index ]

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -161,7 +161,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
       Arg_spec.S (List.concat_map (Path.Set.to_list paths)
                     ~f:(fun dir -> [Arg_spec.A "-I"; Path dir])))
 
-  let to_html (odoc_file : odoc) ~deps ~requires =
+  let setup_html (odoc_file : odoc) ~deps ~requires =
     let to_remove, jbuilder_keep =
       match odoc_file.typ with
       | Mld -> odoc_file.html_file, []
@@ -329,7 +329,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
         let html_files =
           let closure = Lib.closure libs in
           let deps = Dep.deps closure in
-          List.map odocs ~f:(to_html ~deps ~requires:closure) in
+          List.map odocs ~f:(setup_html ~deps ~requires:closure) in
         List.iter (
           Dep.html_alias (Pkg pkg)
           :: List.map ~f:(fun lib -> Dep.html_alias (Lib lib)) libs

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -534,7 +534,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
            | _ -> None
          ))
        |> List.map ~f:(fun (lib : Lib.t) ->
-         Build_system.Alias.stamp_file (Dep.alias (Lib lib)))
+         Build_system.Alias.stamp_file (Dep.html_alias (Lib lib)))
        |> Path.Set.of_list
       )
 

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -366,7 +366,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
       let lib, lib_db = SC.Scope_key.of_string sctx lib_unique_name_or_pkg in
       begin match Lib.DB.find lib_db lib with
       | Error _ -> ()
-      | Ok lib  -> Option.iter (Lib.package lib) ~f:setup_html_rules
+      | Ok lib  -> setup_lib_html_rules lib ~requires:(Lib.closure [lib])
       end;
       Option.iter
         (Package.Name.Map.find (SC.packages sctx)

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -28,7 +28,6 @@ type odoc =
   { odoc_input: Path.t
   ; html_dir: Path.t
   ; html_file: Path.t
-  ; html_alias: Build_system.Alias.t
   ; typ: typ
   }
 
@@ -272,7 +271,6 @@ module Gen (S : sig val sctx : SC.t end) = struct
     pkg_libs
 
   let create_odoc ~target odoc_input =
-    let html_alias = Dep.html_alias target in
     let html_base = Paths.html target in
     match target with
     | Lib _ ->
@@ -286,7 +284,6 @@ module Gen (S : sig val sctx : SC.t end) = struct
       ; html_dir
       ; html_file = html_dir ++ "index.html"
       ; typ = Module
-      ; html_alias
       }
     | Pkg _ ->
       { odoc_input
@@ -298,7 +295,6 @@ module Gen (S : sig val sctx : SC.t end) = struct
           |> Option.value_exn
         )
       ; typ = Mld
-      ; html_alias
       }
 
   let static_html = [ css_file; toplevel_index ]

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -327,17 +327,9 @@ module Gen (S : sig val sctx : SC.t end) = struct
             :: (List.map libs ~f:(fun lib -> odocs (Lib lib)))
           ) in
         let html_files =
-          let closure =
-            match Lib.closure libs with
-            | Ok closure -> closure
-            | Error _ ->
-              (* CR diml for rgrinberg: this branch needs a comment, I
-                 don't understand why we fallback to not taking the
-                 transitive closure in case of error. *)
-              libs
-          in
-          let deps = Dep.deps (Ok closure) in
-          List.map odocs ~f:(to_html ~deps ~requires:(Ok closure)) in
+          let closure = Lib.closure libs in
+          let deps = Dep.deps closure in
+          List.map odocs ~f:(to_html ~deps ~requires:closure) in
         List.iter (
           Dep.html_alias (Pkg pkg)
           :: List.map ~f:(fun lib -> Dep.html_alias (Lib lib)) libs

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -22,6 +22,16 @@ type target =
   | Lib of Lib.t
   | Pkg of Package.Name.t
 
+type typ = Module | Mld
+
+type odoc =
+  { odoc_input: Path.t
+  ; html_dir: Path.t
+  ; html_file: Path.t
+  ; html_alias: Build_system.Alias.t
+  ; typ: typ
+  }
+
 module Gen (S : sig val sctx : SC.t end) = struct
   open S
 
@@ -137,16 +147,6 @@ module Gen (S : sig val sctx : SC.t end) = struct
          ; Dep (Mld.odoc_input m)
          ]);
     odoc_file
-
-  type typ = Module | Mld
-
-  type odoc =
-    { odoc_input: Path.t
-    ; html_dir: Path.t
-    ; html_file: Path.t
-    ; html_alias: Build_system.Alias.t
-    ; typ: typ
-    }
 
   let odoc_include_flags requires =
     Arg_spec.of_result_map requires ~f:(fun libs ->

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -35,6 +35,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
   open S
 
   let context = SC.context sctx
+  let stanzas = SC.stanzas sctx
 
   module Paths = struct
     let root = context.Context.build_dir ++ "_doc"
@@ -461,7 +462,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
   let init ~modules_by_lib ~mlds_of_dir =
     let docs_by_package =
       let map = lazy (
-        SC.stanzas sctx
+        stanzas
         |> List.concat_map ~f:(fun (w : SC.Dir_with_jbuild.t) ->
           List.filter_map w.stanzas ~f:(function
             | Documentation (d : Jbuild.Documentation.t) ->
@@ -484,7 +485,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
           | o -> o
       end) in
       let lib_to_library = lazy (
-        SC.stanzas sctx
+        stanzas
         |> List.concat_map ~f:(fun (w : SC.Dir_with_jbuild.t) ->
           List.filter_map w.stanzas ~f:(function
             | Jbuild.Library (l : Library.t) ->
@@ -522,7 +523,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
     Super_context.add_alias_deps
       sctx
       (Build_system.Alias.private_doc ~dir:context.build_dir)
-      (SC.stanzas sctx
+      (stanzas
        |> List.concat_map ~f:(fun (w : SC.Dir_with_jbuild.t) ->
          List.filter_map w.stanzas ~f:(function
            | Jbuild.Library (l : Jbuild.Library.t) ->

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -138,12 +138,14 @@ module Gen (S : sig val sctx : SC.t end) = struct
          ]);
     odoc_file
 
+  type typ = Module | Mld
+
   type odoc =
     { odoc_input: Path.t
     ; html_dir: Path.t
     ; html_file: Path.t
     ; html_alias: Build_system.Alias.t
-    ; typ: [`Module | `Mld]
+    ; typ: typ
     }
 
   let odoc_include_flags requires =
@@ -162,8 +164,8 @@ module Gen (S : sig val sctx : SC.t end) = struct
   let to_html (odoc_file : odoc) ~deps ~requires =
     let to_remove, jbuilder_keep =
       match odoc_file.typ with
-      | `Mld -> odoc_file.html_file, []
-      | `Module ->
+      | Mld -> odoc_file.html_file, []
+      | Module ->
         let jbuilder_keep =
           Build.create_file (odoc_file.html_dir ++ Config.jbuilder_keep_fname) in
         odoc_file.html_dir, [jbuilder_keep]
@@ -291,7 +293,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
       { odoc_input
       ; html_dir
       ; html_file = html_dir ++ "index.html"
-      ; typ = `Module
+      ; typ = Module
       ; html_alias
       }
     | Pkg _ ->
@@ -303,7 +305,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
           |> String.drop_prefix ~prefix:"page-"
           |> Option.value_exn
         )
-      ; typ = `Mld
+      ; typ = Mld
       ; html_alias
       }
 

--- a/test/blackbox-tests/test-cases/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/multiple-private-libs/run.t
@@ -1,9 +1,12 @@
 This test checks that there is no clash when two private libraries have the same name
 
   $ dune build --display short @doc-private
+          odoc _doc/_html/odoc.css
       ocamldep a/test.ml.d
         ocamlc a/.test.objs/test.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/test@a/test.odoc
+          odoc _doc/_html/test@a/Test/.jbuilder-keep,_doc/_html/test@a/Test/index.html
       ocamldep b/test.ml.d
         ocamlc b/.test.objs/test.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/test@b/test.odoc
+          odoc _doc/_html/test@b/Test/.jbuilder-keep,_doc/_html/test@b/Test/index.html

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -6,6 +6,9 @@
           odoc _doc/_odoc/pkg/bar/page-index.odoc
           odoc _doc/_html/bar/index.html
           odoc _doc/_html/odoc.css
+      ocamldep foo_byte.ml.d
+        ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
+          odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
       ocamldep foo.ml.d
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo.odoc
@@ -13,12 +16,9 @@
         ocamlc .foo.objs/foo2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo2.odoc
           odoc _doc/_html/foo/Foo/.jbuilder-keep,_doc/_html/foo/Foo/index.html
-      ocamldep foo_byte.ml.d
-        ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
-          odoc _doc/_html/foo/Foo_byte/.jbuilder-keep,_doc/_html/foo/Foo_byte/index.html
           odoc _doc/_odoc/pkg/foo/page-index.odoc
           odoc _doc/_html/foo/index.html
+          odoc _doc/_html/foo/Foo_byte/.jbuilder-keep,_doc/_html/foo/Foo_byte/index.html
           odoc _doc/_html/foo/Foo2/.jbuilder-keep,_doc/_html/foo/Foo2/index.html
   $ dune runtest --display short
   <!DOCTYPE html>

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -6,9 +6,6 @@
           odoc _doc/_odoc/pkg/bar/page-index.odoc
           odoc _doc/_html/bar/index.html
           odoc _doc/_html/odoc.css
-      ocamldep foo_byte.ml.d
-        ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
       ocamldep foo.ml.d
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo.odoc
@@ -16,9 +13,12 @@
         ocamlc .foo.objs/foo2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo2.odoc
           odoc _doc/_html/foo/Foo/.jbuilder-keep,_doc/_html/foo/Foo/index.html
+      ocamldep foo_byte.ml.d
+        ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
+          odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
+          odoc _doc/_html/foo/Foo_byte/.jbuilder-keep,_doc/_html/foo/Foo_byte/index.html
           odoc _doc/_odoc/pkg/foo/page-index.odoc
           odoc _doc/_html/foo/index.html
-          odoc _doc/_html/foo/Foo_byte/.jbuilder-keep,_doc/_html/foo/Foo_byte/index.html
           odoc _doc/_html/foo/Foo2/.jbuilder-keep,_doc/_html/foo/Foo2/index.html
   $ dune runtest --display short
   <!DOCTYPE html>


### PR DESCRIPTION
private-doc needed to collect the html alias of each library rather than the odoc alias. The rest are just small refactorings.

@diml I think I addressed the comment that you've left for me in the source. Failing when the transitive closure is absent indeed makes sense. Even if we can still technically continue and generate suboptimal docs.

There are still many inefficiencies abound in the doc generation, but I'm thinking that this isn't an issue for people in practice. As long as the rules minimize the weight they add on normal builds.