### PR TITLE
Add test for behavior of templates and arguments with spaces

### DIFF
--- a/test/blackbox-tests/test-cases/quoting/filename-space/dune
+++ b/test/blackbox-tests/test-cases/quoting/filename-space/dune
@@ -1,0 +1,8 @@
+
+(alias
+ ((name unquoted)
+  (action (echo ${read:foo bar.txt}))))
+
+(alias
+ ((name quoted)
+  (action (echo "${read:foo bar.txt}"))))

--- a/test/blackbox-tests/test-cases/quoting/filename-space/foo bar.txt
+++ b/test/blackbox-tests/test-cases/quoting/filename-space/foo bar.txt
@@ -1,0 +1,1 @@
+filename contains spaces

--- a/test/blackbox-tests/test-cases/quoting/run.t
+++ b/test/blackbox-tests/test-cases/quoting/run.t
@@ -24,3 +24,11 @@ The targets should only be interpreted as a single path when quoted
   $ dune runtest --root quotes-multi
   Entering directory 'quotes-multi'
   lines: foo bar baz
+
+  $ dune build @quoted --root filename-space
+  Entering directory 'filename-space'
+  filename contains spaces
+
+  $ dune build @unquoted --root filename-space
+  Entering directory 'filename-space'
+  ${read:foo bar.txt}


### PR DESCRIPTION
(echo "${read:foo bar}") vs. (echo ${read:foo bar}) handles the argument
differently

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>