### PR TITLE
Strengthen the lexing of escape sequences

### DIFF
--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -95,3 +95,15 @@ parse {|x|#y|}
 - : parse_result =
 Different {jbuild = Error "jbuild_atoms cannot contain |#"; dune = Ok [x|#y]}
 |}]
+
+parse {|"\a"|}
+[%%expect{|
+- : parse_result =
+Different {jbuild = Ok ["\\a"]; dune = Error "unknown escape sequence"}
+|}]
+
+parse {|"\%{x}"|}
+[%%expect{|
+- : parse_result =
+Different {jbuild = Ok ["\\%{x}"]; dune = Error "unknown escape sequence"}
+|}]


### PR DESCRIPTION
Things like `\a` are no longer allowed. Before they would be interpreted as a literal `\a`. This will allow to introduce new escape sequences in the future if needed.
