### PR TITLE
Set dune language version to 1.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 0.1)
+(lang dune 1.0)
 (name dune)

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -176,10 +176,10 @@ let load_dune_project ~dir packages =
        Loc.fail loc "%s is not a supported langauge. \
                      Only the dune language is supported." s);
     (match version with
-     | _, "0.1" -> ()
+     | _, "1.0" -> ()
      | loc, s ->
        Loc.fail loc "Unsupported version of the dune language. \
-                     The only supported version is 0.1." s);
+                     The only supported version is 1.0." s);
     let sexp = Sexp.Parser.parse lb ~mode:Many_as_one in
     parse ~dir packages sexp)
 

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/dune-project
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/dune-project
@@ -1,1 +1,1 @@
-(lang dune 0.1)
+(lang dune 1.0)


### PR DESCRIPTION
It seems better to start with `1.0`.