### PR TITLE
Refactor a bit the Of_sexp API

### DIFF
--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -73,18 +73,16 @@ module Extension : sig
   (** One version of an extension *)
   type t
 
-  (** [make version args_spec f] defines one version of an
-      extension. Users will enable this extension by writing:
+  (** [make version parser] defines one version of an extension. Users will
+      enable this extension by writing:
 
       {[ (using <name> <version> <args>) ]}
 
-      in their [dune-project] file. [args_spec] is used to describe
-      what [<args>] might be.
-  *)
+      in their [dune-project] file. [parser] is used to describe
+      what [<args>] might be.  *)
   val make
     :  Syntax.Version.t
-    -> ('a, Stanza.Parser.t list) Sexp.Of_sexp.Constructor_args_spec.t
-    -> (project -> 'a)
+    -> (project -> Stanza.Parser.t list Sexp.Of_sexp.cstr_parser)
     -> t
 
   (** Register all the supported versions of an extension *)

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -52,7 +52,7 @@ module Dune_file = struct
           dn
       in
       sum
-        [ cstr "ignored_subdirs" (list sub_dir @> nil) String.Set.of_list
+        [ "ignored_subdirs", next (list sub_dir) >>| String.Set.of_list
         ]
     in
     fun sexps ->

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -27,7 +27,7 @@ module Backend = struct
       let short = None
       let parse =
         record
-          (record_loc >>= fun loc ->
+          (list_loc >>= fun loc ->
            field "runner_libraries" (list (located string)) ~default:[]
            >>= fun runner_libraries ->
            Ordered_set_lang.Unexpanded.field "flags" >>= fun flags ->
@@ -135,7 +135,7 @@ include Sub_system.Register_end_point(
     let short = Some empty
     let parse =
       record
-        (record_loc >>= fun loc ->
+        (list_loc >>= fun loc ->
          field "deps" (list Dep_conf.t) ~default:[] >>= fun deps ->
          Ordered_set_lang.Unexpanded.field "flags" >>= fun flags ->
          field_o "backend" (located string) >>= fun backend ->

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -35,8 +35,10 @@ let of_sexp =
       of_sexp_error sexp "Unsupported version, only version 1 is supported"
   in
   sum
-    [ cstr "dune" (version @> list raw @> nil)
-        (fun () l -> parse_sub_systems l)
+    [ "dune",
+      (next version >>= fun () ->
+       next (list raw) >>| fun l ->
+       parse_sub_systems l)
     ]
 
 let load fname = of_sexp (Io.Sexp.load ~mode:Single fname)

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -37,7 +37,7 @@ module Driver = struct
       let short = None
       let parse =
         record
-          (record_loc >>= fun loc ->
+          (list_loc >>= fun loc ->
            Ordered_set_lang.Unexpanded.field "flags"      >>= fun      flags ->
            Ordered_set_lang.Unexpanded.field "lint_flags" >>= fun lint_flags ->
            field "main" string >>= fun main ->

--- a/src/stanza.ml
+++ b/src/stanza.ml
@@ -3,5 +3,5 @@ open Stdune
 type t = ..
 
 module Parser = struct
-  type nonrec t = t list Sexp.Of_sexp.Constructor_spec.t
+  type nonrec t = string * t list Sexp.Of_sexp.cstr_parser
 end

--- a/src/stanza.mli
+++ b/src/stanza.mli
@@ -9,5 +9,5 @@ module Parser : sig
 
       Each stanza in a configuration file might produce several values
       of type [t], hence the [t list] here. *)
-  type nonrec t = t list Sexp.Of_sexp.Constructor_spec.t
+  type nonrec t = string * t list Sexp.Of_sexp.cstr_parser
 end

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -594,10 +594,11 @@ let t = function
   | s ->
     let open Sexp.Of_sexp in
     sum
-      [ cstr "In_build_dir" (Local.t @> nil) in_build_dir
-      ; cstr "In_source_tree" (Local.t @> nil) in_source_tree
-      ; cstr "External" (External.t @> nil) external_
-      ] s
+      [ "In_build_dir"  , next Local.t    >>| in_build_dir
+      ; "In_source_tree", next Local.t    >>| in_source_tree
+      ; "External"      , next External.t >>| external_
+      ]
+      s
 
 let sexp_of_t t =
   let constr f x y = Sexp.To_sexp.(pair string f) (x, y) in


### PR DESCRIPTION
This PR changes the Sexp.Of_sexp API to use the same `list_parser` monad to parse both records and constructors. I find the new API simpler as there are less functions and operators. Additionally, the parsing code is a bit nicer as well since the variable to which the result is bound is closer to the delcaration of the argument.

i.e. instead of:

```ocaml
sum 
  [ cstr name (arg1 @> arg2 @> arg3 @> nil) (fun x y z -> ...) ]
```

we now have:

```ocaml
sum
  [ name,
    (arg1 >>= fun x ->
     arg2 >>= fun y ->
     arg3 >>= fun z ->
     return (...))
  ]
```