### PR TITLE
Make Sexp.Of_sexp.t abstract

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -329,7 +329,7 @@ module Unexpanded = struct
     let open Sexp.Of_sexp in
     peek raw >>= function
     | Atom _ | Quoted_string _ as sexp ->
-      of_sexp_errorf sexp
+      of_sexp_errorf (Sexp.Ast.loc sexp)
         "if you meant for this to be executed with bash, write (bash \"...\") instead"
     | List _ -> t
 
@@ -593,7 +593,8 @@ module Promotion = struct
            Path.t >>= fun dst ->
            return { src; dst })
       | sexp ->
-        Sexp.Of_sexp.of_sexp_errorf sexp "(<file> as <file>) expected"
+        Sexp.Of_sexp.of_sexp_errorf (Sexp.Ast.loc sexp)
+          "(<file> as <file>) expected"
 
     let sexp_of_t { src; dst } =
       Sexp.List [Path.sexp_of_t src; Sexp.unsafe_atom_of_string "as";

--- a/src/action.ml
+++ b/src/action.ml
@@ -21,78 +21,78 @@ module Make_ast
 struct
   include Ast
 
-  let rec t sexp =
+  let t =
     let path = Path.t and string = String.t in
-    sum
-      [ "run",
-        (next Program.t >>= fun prog ->
-         rest string    >>| fun args ->
-         Run (prog, args))
-      ; "chdir",
-        (next path >>= fun dn ->
-         next t    >>| fun t ->
-         Chdir (dn, t))
-      ; "setenv",
-        (next string >>= fun k ->
-         next string >>= fun v ->
-         next t      >>| fun t ->
-         Setenv (k, v, t))
-      ; "with-stdout-to",
-        (next path >>= fun fn ->
-         next t    >>| fun t ->
-         Redirect (Stdout, fn, t))
-      ; "with-stderr-to",
-        (next path >>= fun fn ->
-         next t    >>| fun t  ->
-         Redirect (Stderr, fn, t))
-      ; "with-outputs-to",
-        (next path >>= fun fn ->
-         next t    >>| fun t  ->
-         Redirect (Outputs, fn, t))
-      ; "ignore-stdout",
-        (next t >>| fun t -> Ignore (Stdout, t))
-      ; "ignore-stderr",
-        (next t >>| fun t -> Ignore (Stderr, t))
-      ; "ignore-outputs",
-        (next t >>| fun t -> Ignore (Outputs, t))
-      ; "progn",
-        (rest t >>| fun l -> Progn l)
-      ; "echo",
-        (next string >>= fun x ->
-         rest string >>| fun xs ->
-         Echo (x :: xs))
-      ; "cat",
-        (next path >>| fun x -> Cat x)
-      ; "copy",
-        (next path >>= fun src ->
-         next path >>| fun dst ->
-         Copy (src, dst))
-      ; "copy#",
-        (next path >>= fun src ->
-         next path >>| fun dst ->
-         Copy_and_add_line_directive (src, dst))
-      ; "copy-and-add-line-directive",
-        (next path >>= fun src ->
-         next path >>| fun dst ->
-         Copy_and_add_line_directive (src, dst))
-      ; "system",
-        (next string >>| fun cmd -> System cmd)
-      ; "bash",
-        (next string >>| fun cmd -> Bash cmd)
-      ; "write-file",
-        (next path >>= fun fn ->
-         next string >>| fun s ->
-         Write_file (fn, s))
-      ; "diff",
-        (next path >>= fun file1 ->
-         next path >>| fun file2 ->
-         Diff { optional = false; file1; file2 })
-      ; "diff?",
-        (next path >>= fun file1 ->
-         next path >>| fun file2 ->
-         Diff { optional = true; file1; file2 })
-      ]
-      sexp
+    Sexp.Of_sexp.fix (fun t ->
+      sum
+        [ "run",
+          (next Program.t >>= fun prog ->
+           rest string    >>| fun args ->
+           Run (prog, args))
+        ; "chdir",
+          (next path >>= fun dn ->
+           next t    >>| fun t ->
+           Chdir (dn, t))
+        ; "setenv",
+          (next string >>= fun k ->
+           next string >>= fun v ->
+           next t      >>| fun t ->
+           Setenv (k, v, t))
+        ; "with-stdout-to",
+          (next path >>= fun fn ->
+           next t    >>| fun t ->
+           Redirect (Stdout, fn, t))
+        ; "with-stderr-to",
+          (next path >>= fun fn ->
+           next t    >>| fun t  ->
+           Redirect (Stderr, fn, t))
+        ; "with-outputs-to",
+          (next path >>= fun fn ->
+           next t    >>| fun t  ->
+           Redirect (Outputs, fn, t))
+        ; "ignore-stdout",
+          (next t >>| fun t -> Ignore (Stdout, t))
+        ; "ignore-stderr",
+          (next t >>| fun t -> Ignore (Stderr, t))
+        ; "ignore-outputs",
+          (next t >>| fun t -> Ignore (Outputs, t))
+        ; "progn",
+          (rest t >>| fun l -> Progn l)
+        ; "echo",
+          (next string >>= fun x ->
+           rest string >>| fun xs ->
+           Echo (x :: xs))
+        ; "cat",
+          (next path >>| fun x -> Cat x)
+        ; "copy",
+          (next path >>= fun src ->
+           next path >>| fun dst ->
+           Copy (src, dst))
+        ; "copy#",
+          (next path >>= fun src ->
+           next path >>| fun dst ->
+           Copy_and_add_line_directive (src, dst))
+        ; "copy-and-add-line-directive",
+          (next path >>= fun src ->
+           next path >>| fun dst ->
+           Copy_and_add_line_directive (src, dst))
+        ; "system",
+          (next string >>| fun cmd -> System cmd)
+        ; "bash",
+          (next string >>| fun cmd -> Bash cmd)
+        ; "write-file",
+          (next path >>= fun fn ->
+           next string >>| fun s ->
+           Write_file (fn, s))
+        ; "diff",
+          (next path >>= fun file1 ->
+           next path >>| fun file2 ->
+           Diff { optional = false; file1; file2 })
+        ; "diff?",
+          (next path >>= fun file1 ->
+           next path >>| fun file2 ->
+           Diff { optional = true; file1; file2 })
+        ])
 
   let rec sexp_of_t : _ -> Sexp.t =
     let path = Path.sexp_of_t and string = String.sexp_of_t in
@@ -224,7 +224,7 @@ module Prog = struct
 
   type t = (Path.t, Not_found.t) result
 
-  let t sexp = Ok (Path.t sexp)
+  let t : t Sexp.Of_sexp.t = Sexp.Of_sexp.Parser.map ~f:Result.ok Path.t
 
   let sexp_of_t = function
     | Ok s -> Path.sexp_of_t s
@@ -325,12 +325,11 @@ module Unexpanded = struct
 
   include Make_ast(String_with_vars)(String_with_vars)(String_with_vars)(Uast)
 
-  let t sexp =
-    match sexp with
-    | Atom _ | Quoted_string _ ->
+  let t = Sexp.Of_sexp.make (function
+    | Atom _ | Quoted_string _ as sexp ->
       of_sexp_errorf sexp
         "if you meant for this to be executed with bash, write (bash \"...\") instead"
-    | List _ -> t sexp
+    | List _ as sexp -> Sexp.Of_sexp.parse t sexp)
 
   let check_mkdir loc path =
     if not (Path.is_managed path) then
@@ -582,13 +581,14 @@ module Promotion = struct
       ; dst : Path.t
       }
 
-    let t = function
+    let t = Sexp.Of_sexp.make (function
       | Sexp.Ast.List (_, [src; Atom (_, A "as"); dst]) ->
-        { src = Path.t src
-        ; dst = Path.t dst
+        let open Sexp.Of_sexp in
+        { src = parse Path.t src
+        ; dst = parse Path.t dst
         }
       | sexp ->
-        Sexp.Of_sexp.of_sexp_errorf sexp "(<file> as <file>) expected"
+        Sexp.Of_sexp.of_sexp_errorf sexp "(<file> as <file>) expected")
 
     let sexp_of_t { src; dst } =
       Sexp.List [Path.sexp_of_t src; Sexp.unsafe_atom_of_string "as";
@@ -620,7 +620,7 @@ module Promotion = struct
   let load_db () =
     if Path.exists db_file then
       Io.Sexp.load db_file ~mode:Many
-      |> List.map ~f:File.t
+      |> List.map ~f:(Sexp.Of_sexp.parse File.t)
     else
       []
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -19,7 +19,7 @@ module Promoted_to_delete = struct
   let load () =
     if Path.exists fn then
       Io.Sexp.load fn ~mode:Many
-      |> List.map ~f:Path.t
+      |> List.map ~f:(Sexp.Of_sexp.parse Path.t)
     else
       []
 
@@ -1220,7 +1220,7 @@ let update_universe t =
   Utils.Cached_digest.remove universe_file;
   let n =
     if Path.exists universe_file then
-      Sexp.Of_sexp.int (Io.Sexp.load ~mode:Single universe_file) + 1
+      Sexp.Of_sexp.(parse int) (Io.Sexp.load ~mode:Single universe_file) + 1
     else
       0
   in

--- a/src/config.ml
+++ b/src/config.ml
@@ -65,7 +65,7 @@ module Concurrency = struct
   let t =
     plain_string (fun ~loc s ->
       match of_string s with
-      | Error m -> of_sexp_errorf_loc loc "%s" m
+      | Error m -> of_sexp_errorf loc "%s" m
       | Ok s -> s)
 
   let to_string = function

--- a/src/config.ml
+++ b/src/config.ml
@@ -63,10 +63,10 @@ module Concurrency = struct
           error
 
   let t =
-    Parser.map_validate string ~f:(fun s ->
+    plain_string (fun ~loc s ->
       match of_string s with
-      | Error m -> Sexp.Of_sexp.Parser.error m
-      | Ok _ as s -> s)
+      | Error m -> of_sexp_errorf_loc loc "%s" m
+      | Ok s -> s)
 
   let to_string = function
     | Auto -> "auto"

--- a/src/config.ml
+++ b/src/config.ml
@@ -62,10 +62,11 @@ module Concurrency = struct
         else
           error
 
-  let t sexp =
-    match of_string (string sexp) with
-    | Ok t -> t
-    | Error msg -> of_sexp_error sexp msg
+  let t =
+    Parser.map_validate string ~f:(fun s ->
+      match of_string s with
+      | Error m -> Sexp.Of_sexp.Parser.error m
+      | Ok _ as s -> s)
 
   let to_string = function
     | Auto -> "auto"
@@ -114,7 +115,7 @@ let user_config_file =
     "dune/config"
 
 let load_config_file p =
-  t (Io.Sexp.load p ~mode:Many_as_one)
+  (Sexp.Of_sexp.parse t) (Io.Sexp.load p ~mode:Many_as_one)
 
 let load_user_config_file () =
   if Path.exists user_config_file then

--- a/src/context.ml
+++ b/src/context.ml
@@ -425,7 +425,7 @@ let create_for_opam ?root ~env ~targets ~profile ~switch ~name
     >>= fun s ->
     let vars =
       Usexp.parse_string ~fname:"<opam output>" ~mode:Single s
-      |> Sexp.Of_sexp.(list (pair string string))
+      |> Sexp.Of_sexp.(parse (list (pair string string)))
       |> Env.Map.of_list_multi
       |> Env.Map.mapi ~f:(fun var values ->
         match List.rev values with

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -70,12 +70,12 @@ end = struct
     else
       None
 
-  let named_of_sexp sexp =
-    let s = string sexp in
-    if validate s then
-      Named s
-    else
-      of_sexp_error sexp "invalid project name"
+  let named_of_sexp =
+    Sexp.Of_sexp.Parser.map_validate string ~f:(fun s ->
+      if validate s then
+        Ok (Named s)
+      else
+        Sexp.Of_sexp.Parser.error "invalid project name")
 
   let encode = function
     | Named     s -> s
@@ -142,7 +142,9 @@ module Lang = struct
         ; version = (ver_loc, ver)
         } = first_line
     in
-    let ver = Syntax.Version.t (Atom (ver_loc, Sexp.Atom.of_string ver)) in
+    let ver =
+      Sexp.Of_sexp.parse Syntax.Version.t
+        (Atom (ver_loc, Sexp.Atom.of_string ver)) in
     match Hashtbl.find langs name with
     | None ->
       Loc.fail name_loc "Unknown language %S.%s" name
@@ -196,7 +198,7 @@ let anonymous = lazy(
     ; packages      = Package.Name.Map.empty
     ; root          = get_local_path Path.root
     ; version       = None
-    ; stanza_parser = (fun _ -> assert false)
+    ; stanza_parser = Sexp.Of_sexp.make (fun _ -> assert false)
     ; project_file  = None
     }
   in
@@ -237,7 +239,7 @@ let parse ~dir ~lang_stanzas ~packages ~file =
        ; root = get_local_path dir
        ; version
        ; packages
-       ; stanza_parser = (fun _ -> assert false)
+       ; stanza_parser = Sexp.Of_sexp.make (fun _ -> assert false)
        ; project_file  = Some file
        }
      in
@@ -263,7 +265,7 @@ let load_dune_project ~dir packages =
   Io.with_lexbuf_from_file fname ~f:(fun lb ->
     let lang_stanzas = Lang.parse (Dune_lexer.first_line lb) in
     let sexp = Sexp.Parser.parse lb ~mode:Many_as_one in
-    parse ~dir ~lang_stanzas ~packages ~file:fname sexp)
+    Sexp.Of_sexp.parse (parse ~dir ~lang_stanzas ~packages ~file:fname) sexp)
 
 let make_jbuilder_project ~dir packages =
   let t =
@@ -272,7 +274,7 @@ let make_jbuilder_project ~dir packages =
     ; root = get_local_path dir
     ; version = None
     ; packages
-    ; stanza_parser = (fun _ -> assert false)
+    ; stanza_parser = Sexp.Of_sexp.make (fun _ -> assert false)
     ; project_file = None
     }
   in

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -75,7 +75,7 @@ end = struct
       if validate s then
         Named s
       else
-        Sexp.Of_sexp.of_sexp_errorf_loc loc "invalid project name")
+        Sexp.Of_sexp.of_sexp_errorf loc "invalid project name")
 
   let encode = function
     | Named     s -> s

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -82,7 +82,7 @@ module Extension : sig
       what [<args>] might be.  *)
   val make
     :  Syntax.Version.t
-    -> (project -> Stanza.Parser.t list Sexp.Of_sexp.cstr_parser)
+    -> (project -> Stanza.Parser.t list Sexp.Of_sexp.t)
     -> t
 
   (** Register all the supported versions of an extension *)

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -47,7 +47,7 @@ module Dune_file = struct
              | "" | "." | ".." -> true
              | _ -> false
           then
-            of_sexp_errorf_loc loc "Invalid sub-directory name %S" dn
+            of_sexp_errorf loc "Invalid sub-directory name %S" dn
           else
             dn)
       in

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -41,18 +41,18 @@ module Dune_file = struct
     let stanza =
       let open Sexp.Of_sexp in
       let sub_dir =
-        Parser.map_validate string ~f:(fun dn ->
+        plain_string (fun ~loc dn ->
           if Filename.dirname dn <> Filename.current_dir_name ||
              match dn with
              | "" | "." | ".." -> true
              | _ -> false
           then
-            Parser.errorf "Invalid sub-directory name %S" dn
+            of_sexp_errorf_loc loc "Invalid sub-directory name %S" dn
           else
-            Ok dn)
+            dn)
       in
       sum
-        [ "ignored_subdirs", next (list sub_dir) >>| String.Set.of_list
+        [ "ignored_subdirs", list sub_dir >>| String.Set.of_list
         ]
     in
     fun sexps ->

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -32,7 +32,7 @@ let of_sexp =
     plain_string (fun ~loc -> function
       | "1" -> ()
       | _ ->
-        of_sexp_errorf_loc loc
+        of_sexp_errorf loc
           "Unsupported version, only version 1 is supported")
   in
   sum

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -24,19 +24,21 @@ let parse_sub_systems sexps =
       Syntax.Versioned_parser.find_exn M.parsers ~loc:vloc
         ~data_version:ver
     in
-    M.T (Sexp.Of_sexp.parse parser.parse data))
+    M.T (Sexp.Of_sexp.parse parser data))
 
 let of_sexp =
   let open Sexp.Of_sexp in
   let version =
-    Parser.map_validate string ~f:(function
-      | "1" -> Ok ()
-      | _  -> Parser.error "Unsupported version, only version 1 is supported")
+    plain_string (fun ~loc -> function
+      | "1" -> ()
+      | _ ->
+        of_sexp_errorf_loc loc
+          "Unsupported version, only version 1 is supported")
   in
   sum
     [ "dune",
-      (next version >>= fun () ->
-       next (list raw) >>| fun l ->
+      (version >>= fun () ->
+       list raw >>| fun l ->
        parse_sub_systems l)
     ]
 

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -3,7 +3,7 @@ open Import
 let parse_sub_systems sexps =
   List.filter_map sexps ~f:(fun sexp ->
     let name, ver, data =
-      Sexp.Of_sexp.(triple string (located Syntax.Version.t) raw) sexp
+      Sexp.Of_sexp.(parse (triple string (located Syntax.Version.t) raw)) sexp
     in
     match Sub_system_name.get name with
     | None ->
@@ -24,15 +24,14 @@ let parse_sub_systems sexps =
       Syntax.Versioned_parser.find_exn M.parsers ~loc:vloc
         ~data_version:ver
     in
-    M.T (parser.parse data))
+    M.T (Sexp.Of_sexp.parse parser.parse data))
 
 let of_sexp =
   let open Sexp.Of_sexp in
-  let version sexp =
-    match string sexp with
-    | "1" -> ()
-    | _  ->
-      of_sexp_error sexp "Unsupported version, only version 1 is supported"
+  let version =
+    Parser.map_validate string ~f:(function
+      | "1" -> Ok ()
+      | _  -> Parser.error "Unsupported version, only version 1 is supported")
   in
   sum
     [ "dune",
@@ -41,7 +40,7 @@ let of_sexp =
        parse_sub_systems l)
     ]
 
-let load fname = of_sexp (Io.Sexp.load ~mode:Single fname)
+let load fname = Sexp.Of_sexp.parse of_sexp (Io.Sexp.load ~mode:Single fname)
 
 let gen confs =
   let sexps =

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -20,71 +20,78 @@ module Jbuild_version = struct
   let latest_stable = V1
 end
 
-let invalid_module_name name sexp =
-  of_sexp_error sexp (sprintf "invalid module name: %S" name)
+let invalid_module_name =
+  Parser.errorf "invalid module name: %S"
 
-let module_name sexp =
-  let name = string sexp in
-  match name with
-  | "" -> invalid_module_name name sexp
-  | s ->
-    (match s.[0] with
-     | 'A'..'Z' | 'a'..'z' -> ()
-     | _ -> invalid_module_name name sexp);
-    String.iter s ~f:(function
-      | 'A'..'Z' | 'a'..'z' | '0'..'9' | '\'' | '_' -> ()
-      | _ -> invalid_module_name name sexp);
-    String.capitalize s
+let module_name =
+  Parser.map_validate string ~f:(fun name ->
+    match name with
+    | "" -> invalid_module_name name
+    | s ->
+      try
+        (match s.[0] with
+         | 'A'..'Z' | 'a'..'z' -> ()
+         | _ -> raise_notrace Exit);
+        String.iter s ~f:(function
+          | 'A'..'Z' | 'a'..'z' | '0'..'9' | '\'' | '_' -> ()
+          | _ -> raise_notrace Exit);
+        Ok (String.capitalize s)
+      with Exit ->
+        invalid_module_name name)
 
-let module_names sexp = String.Set.of_list (list module_name sexp)
+let module_names =
+  Sexp.Of_sexp.Parser.map ~f:String.Set.of_list (list module_name)
 
-let invalid_lib_name sexp =
-  of_sexp_error sexp "invalid library name"
+let invalid_lib_name = Parser.error "invalid library name"
 
-let library_name sexp =
-  match string sexp with
-  | "" -> invalid_lib_name sexp
-  | s ->
-    if s.[0] = '.' then invalid_lib_name sexp;
-    String.iter s ~f:(function
-      | 'A'..'Z' | 'a'..'z' | '_' | '.' | '0'..'9' -> ()
-      | _ -> invalid_lib_name sexp);
-    s
+let library_name =
+  Parser.map_validate string ~f:(function
+    | "" -> invalid_lib_name
+    | s ->
+      if s.[0] = '.' then invalid_lib_name
+      else
+        try
+          String.iter s ~f:(function
+            | 'A'..'Z' | 'a'..'z' | '_' | '.' | '0'..'9' -> ()
+            | _ -> raise_notrace Exit);
+          Ok s
+        with Exit -> invalid_lib_name)
 
-let file sexp =
-  match string sexp with
-  | "." | ".." ->
-    of_sexp_error sexp "'.' and '..' are not valid filenames"
-  | fn -> fn
+let file =
+  Parser.map_validate string ~f:(function
+    | "." | ".." -> Parser.error "'.' and '..' are not valid filenames"
+    | fn -> Ok fn)
 
-let file_in_current_dir sexp =
-  match string sexp with
-  | "." | ".." ->
-    of_sexp_error sexp "'.' and '..' are not valid filenames"
-  | fn ->
-    if Filename.dirname fn <> Filename.current_dir_name then
-      of_sexp_error sexp "file in current directory expected";
-    fn
+let file_in_current_dir =
+  Parser.map_validate string ~f:(function
 
-let relative_file sexp =
-  let fn = file sexp in
-  if not (Filename.is_relative fn) then
-    of_sexp_error sexp "relative filename expected";
-  fn
+    | "." | ".." -> Parser.error "'.' and '..' are not valid filenames"
+    | fn ->
+      if Filename.dirname fn <> Filename.current_dir_name then
+        Parser.error "file in current directory expected"
+      else
+        Ok fn)
+
+let relative_file =
+  Parser.map_validate file ~f:(fun fn ->
+    if Filename.is_relative fn then
+      Ok fn
+    else
+      Parser.error "relative filename expected")
 
 let c_name, cxx_name =
-  let make what ext sexp =
-    let s = string sexp in
-    if match s with
-      | "" | "." | ".."  -> true
-      | _ -> Filename.basename s <> s then
-      of_sexp_errorf sexp
-        "%S is not a valid %s name.\n\
-         Hint: To use %s files from another directory, use a \
-         (copy_files <dir>/*.c) stanza instead."
-        s what what ext
-    else
-      s
+  let make what ext =
+    Parser.map_validate string ~f:(fun s ->
+      if match s with
+        | "" | "." | ".."  -> true
+        | _ -> Filename.basename s <> s then
+        Parser.errorf
+          "%S is not a valid %s name.\n\
+           Hint: To use %s files from another directory, use a \
+           (copy_files <dir>/*.%s) stanza instead."
+          s what what ext
+      else
+        Ok s)
   in
   (make "C"   "c",
    make "C++" "cpp")
@@ -144,10 +151,12 @@ module Pkg = struct
                  (hint name_s (Package.Name.Map.keys project.packages
                                |> List.map ~f:Package.Name.to_string)))
 
-  let t p sexp =
-    match resolve p (Package.Name.of_string (string sexp)) with
-    | Ok p -> p
-    | Error s -> Loc.fail (Sexp.Ast.loc sexp) "%s" s
+  let t p =
+    let open Parser.O in
+    Package.Name.t >>= fun name ->
+    match resolve p name with
+    | Ok x -> Parser.return x
+    | Error e -> Parser.fail "%s" e
 
   let field p =
     map_validate (field_o "package" string) ~f:(function
@@ -183,9 +192,9 @@ module Pp_or_flags = struct
     else
       PP (loc, Pp.of_string s)
 
-  let t = function
+  let t = Sexp.Of_sexp.make (function
     | Atom (loc, A s) | Quoted_string (loc, s) -> of_string ~loc s
-    | List (_, l) -> Flags (List.map l ~f:string)
+    | List (_, l) -> Flags (List.map l ~f:(parse string)))
 
   let split l =
     let pps, flags =
@@ -219,10 +228,10 @@ module Dep_conf = struct
         ; "universe"             , return Universe
         ]
     in
-    fun sexp ->
+    Sexp.Of_sexp.make (fun sexp ->
       match sexp with
-      | Atom _ | Quoted_string _ -> File (String_with_vars.t sexp)
-      | List _ -> t sexp
+      | Atom _ | Quoted_string _ -> File (parse String_with_vars.t sexp)
+      | List _ -> parse t sexp)
 
   open Sexp
   let sexp_of_t = function
@@ -274,20 +283,20 @@ end
 module Per_module = struct
   include Per_item.Make(Module.Name)
 
-  let t ~default a sexp =
+  let t ~default a = Sexp.Of_sexp.make (fun sexp ->
     match sexp with
     | List (_, Atom (_, A "per_module") :: rest) -> begin
-      List.map rest ~f:(fun sexp ->
-        let pp, names = pair a module_names sexp in
-        (List.map ~f:Module.Name.of_string (String.Set.to_list names), pp))
-      |> of_mapping ~default
-      |> function
-      | Ok t -> t
-      | Error (name, _, _) ->
-        of_sexp_error sexp (sprintf "module %s present in two different sets"
-                              (Module.Name.to_string name))
-    end
-    | sexp -> for_all (a sexp)
+        List.map rest ~f:(fun sexp ->
+          let pp, names = parse (pair a module_names) sexp in
+          (List.map ~f:Module.Name.of_string (String.Set.to_list names), pp))
+        |> of_mapping ~default
+        |> function
+        | Ok t -> t
+        | Error (name, _, _) ->
+          of_sexp_error sexp (sprintf "module %s present in two different sets"
+                                (Module.Name.to_string name))
+      end
+    | sexp -> for_all (parse a sexp))
 end
 
 module Preprocess_map = struct
@@ -368,7 +377,7 @@ module Lib_dep = struct
               name);
           { required
           ; forbidden
-          ; file = file fsexp
+          ; file = parse file fsexp
           }
         | Atom (_, A "->") :: _
         | List _ :: _ | [] ->
@@ -384,16 +393,16 @@ module Lib_dep = struct
       loop String.Set.empty String.Set.empty l
     | sexp -> of_sexp_error sexp "(<library-name> <code>) expected"
 
-  let t = function
+  let t = Sexp.Of_sexp.make (function
     | Atom (loc, A s) | Quoted_string (loc, s) ->
       Direct (loc, s)
     | List (loc, Atom (_, A "select") :: m :: Atom (_, A "from") :: libs) ->
-      Select { result_fn = file m
+      Select { result_fn = parse file m
              ; choices   = List.map libs ~f:choice
              ; loc
              }
     | sexp ->
-      of_sexp_error sexp "<library> or (select <module> from <libraries...>) expected"
+      of_sexp_error sexp "<library> or (select <module> from <libraries...>) expected")
 
   let to_lib_names = function
     | Direct (_, s) -> [s]
@@ -415,8 +424,8 @@ module Lib_deps = struct
     | Optional
     | Forbidden
 
-  let t sexp =
-    let t = list Lib_dep.t sexp in
+  let t = Sexp.Of_sexp.make (fun sexp ->
+    let t = parse (list Lib_dep.t) sexp in
     let add kind name acc =
       match String.Map.find acc name with
       | None -> String.Map.add acc name kind
@@ -444,7 +453,7 @@ module Lib_deps = struct
             let acc = String.Set.fold c.Lib_dep.required ~init:acc ~f:(add Optional) in
             String.Set.fold c.forbidden ~init:acc ~f:(add Forbidden)))
       : kind String.Map.t);
-    t
+    t)
 
   let of_pps pps =
     List.map pps ~f:(fun pp -> Lib_dep.of_pp (Loc.none, pp))
@@ -623,7 +632,7 @@ module Mode_conf = struct
   module Set = struct
     include Set.Make(T)
 
-    let t sexp = of_list (list t sexp)
+    let t = Sexp.Of_sexp.Parser.map ~f:of_list (list t)
 
     let default = of_list [Byte; Best]
 
@@ -702,7 +711,7 @@ module Library = struct
        field      "self_build_stubs_archive" (option string) ~default:None >>= fun self_build_stubs_archive ->
        field_b    "no_dynlink"                                             >>= fun no_dynlink               ->
        Sub_system_info.record_parser () >>= fun sub_systems ->
-       field "ppx.driver" ignore ~default:() >>= fun () ->
+       field "ppx.driver" discard ~default:() >>= fun () ->
        return
          { name
          ; public
@@ -747,14 +756,13 @@ module Install_conf = struct
     ; dst : string option
     }
 
-  let file sexp =
-    match sexp with
+  let file = Sexp.Of_sexp.make (function
     | Atom (_, A src) -> { src; dst = None }
     | List (_, [Atom (_, A src); Atom (_, A "as"); Atom (_, A dst)]) ->
       { src; dst = Some dst }
-    | _ ->
+    | sexp ->
       of_sexp_error sexp
-        "invalid format, <name> or (<name> as <install-as>) expected"
+        "invalid format, <name> or (<name> as <install-as>) expected")
 
   type t =
     { section : Install.Section.t
@@ -822,12 +830,12 @@ module Executables = struct
     let simple =
       Sexp.Of_sexp.enum simple_representations
 
-    let t sexp =
+    let t = Sexp.Of_sexp.make (fun sexp ->
       match sexp with
       | List _ ->
-        let mode, kind = pair Mode_conf.t Binary_kind.t sexp in
+        let mode, kind = parse (pair Mode_conf.t Binary_kind.t) sexp in
         { mode; kind }
-      | _ -> simple sexp
+      | _ -> parse simple sexp)
 
     let simple_sexp_of_t link_mode =
       let is_ok (_, candidate) =
@@ -847,19 +855,19 @@ module Executables = struct
     module Set = struct
       include Set.Make(T)
 
-      let t sexp : t =
-        match list t sexp with
-        | [] -> of_sexp_error sexp "No linking mode defined"
-        | l ->
-          let t = of_list l in
-          if (mem t native_exe           && mem t exe          ) ||
-             (mem t native_object        && mem t object_      ) ||
-             (mem t native_shared_object && mem t shared_object) then
-            of_sexp_error sexp
-              "It is not allowed use both native and best \
-               for the same binary kind."
-          else
-            t
+      let t =
+        Parser.map_validate (list t) ~f:(function
+          | [] -> Parser.error "No linking mode defined"
+          | l ->
+            let t = of_list l in
+            if (mem t native_exe           && mem t exe          ) ||
+               (mem t native_object        && mem t object_      ) ||
+               (mem t native_shared_object && mem t shared_object) then
+              Parser.error
+                "It is not allowed use both native and best \
+                 for the same binary kind."
+            else
+              Ok t)
 
       let default =
         of_list
@@ -894,7 +902,8 @@ module Executables = struct
     field "modes" Link_mode.Set.t ~default:Link_mode.Set.default
     >>= fun modes ->
     map_validate
-      (field "inline_tests" (fun _ -> true) ~default:false ~short:(This true))
+      (field "inline_tests" (Parser.return true)
+         ~default:false ~short:(This true))
       ~f:(function
         | false -> Ok ()
         | true  ->
@@ -944,7 +953,7 @@ module Executables = struct
     in
     match to_install with
     | [] ->
-      (field_o "package" Sexp.Ast.loc >>= function
+      (field_o "package" loc >>= function
        | None -> return (t, None)
        | Some loc ->
          Loc.warn loc
@@ -955,10 +964,10 @@ module Executables = struct
       Pkg.field project >>= fun package ->
       return (t, Some { Install_conf. section = Bin; files; package })
 
-  let public_name sexp =
-    match string sexp with
-    | "-" -> None
-    | s   -> Some s
+  let public_name =
+    Parser.map string ~f:(function
+      | "-" -> None
+      | s   -> Some s)
 
   let multi ~syntax project =
     record
@@ -1018,63 +1027,64 @@ module Rule = struct
     ; loc      : Loc.t
     }
 
-  let v1 sexp =
+  let v1 = Sexp.Of_sexp.make (fun sexp ->
     let loc = Sexp.Ast.loc sexp in
     match sexp with
     | List (loc, (Atom _ :: _)) ->
       { targets  = Infer
       ; deps     = []
-      ; action   = (loc, Action.Unexpanded.t sexp)
+      ; action   = (loc, parse Action.Unexpanded.t sexp)
       ; mode     = Standard
       ; locks    = []
       ; loc      = loc
       }
     | _ ->
-      record
-        (field "targets" (list file_in_current_dir)    >>= fun targets ->
-         field "deps"    (list Dep_conf.t) ~default:[] >>= fun deps ->
-         field "action"  (located Action.Unexpanded.t) >>= fun action ->
-         field "locks"   (list String_with_vars.t) ~default:[] >>= fun locks ->
-         map_validate
-           (field_b "fallback" >>= fun fallback ->
-            field_o "mode" Mode.t >>= fun mode ->
-            return (fallback, mode))
-           ~f:(function
-             | true, Some _ ->
-               Error "Cannot use both (fallback) and (mode ...) at the \
-                      same time.\n\
-                      (fallback) is the same as (mode fallback), \
-                      please use the latter in new code."
-             | false, Some mode -> Ok mode
-             | true, None -> Ok Fallback
-             | false, None -> Ok Standard)
-         >>= fun mode ->
-         return { targets = Static targets
-                ; deps
-                ; action
-                ; mode
-                ; locks
-                ; loc
-                })
-        sexp
+      parse (
+        record
+          (field "targets" (list file_in_current_dir)    >>= fun targets ->
+           field "deps"    (list Dep_conf.t) ~default:[] >>= fun deps ->
+           field "action"  (located Action.Unexpanded.t) >>= fun action ->
+           field "locks"   (list String_with_vars.t) ~default:[] >>= fun locks ->
+           map_validate
+             (field_b "fallback" >>= fun fallback ->
+              field_o "mode" Mode.t >>= fun mode ->
+              return (fallback, mode))
+             ~f:(function
+               | true, Some _ ->
+                 Error "Cannot use both (fallback) and (mode ...) at the \
+                        same time.\n\
+                        (fallback) is the same as (mode fallback), \
+                        please use the latter in new code."
+               | false, Some mode -> Ok mode
+               | true, None -> Ok Fallback
+               | false, None -> Ok Standard)
+           >>= fun mode ->
+           return { targets = Static targets
+                  ; deps
+                  ; action
+                  ; mode
+                  ; locks
+                  ; loc
+                  }))
+        sexp)
 
   type lex_or_yacc =
     { modules : string list
     ; mode    : Mode.t
     }
 
-  let ocamllex_v1 sexp =
+  let ocamllex_v1 = Sexp.Of_sexp.make (fun sexp ->
     match sexp with
     | List (_, List (_, _) :: _) ->
-      record
-        (field "modules" (list string) >>= fun modules ->
-         Mode.field >>= fun mode ->
-         return { modules; mode })
-        sexp
+      parse (
+        record
+          (field "modules" (list string) >>= fun modules ->
+           Mode.field >>= fun mode ->
+           return { modules; mode })) sexp
     | _ ->
-      { modules = list string sexp
+      { modules = parse (list string) sexp
       ; mode    = Standard
-      }
+      })
 
   let ocamlyacc_v1 = ocamllex_v1
 
@@ -1152,12 +1162,12 @@ module Alias_conf = struct
     ; package : Package.t option
     }
 
-  let alias_name sexp =
-    let s = string sexp in
-    if Filename.basename s <> s then
-      of_sexp_errorf sexp "%S is not a valid alias name" s
-    else
-      s
+  let alias_name =
+    Parser.map_validate string ~f:(fun s ->
+      if Filename.basename s <> s then
+        Parser.errorf "%S is not a valid alias name" s
+      else
+        Ok s)
 
   let v1 project =
     record
@@ -1224,17 +1234,17 @@ module Env = struct
        field_oslu "ocamlopt_flags" >>= fun ocamlopt_flags ->
        return { flags; ocamlc_flags; ocamlopt_flags })
 
-  let rule = function
+  let rule = Sexp.Of_sexp.make (function
     | List (loc, Atom (_, A pat) :: fields) ->
       let pat =
         match pat with
         | "_" -> Any
         | s   -> Profile s
       in
-      (pat, config (List (loc, fields)))
+      (pat, parse config (List (loc, fields)))
     | sexp ->
       of_sexp_error sexp
-        "S-expression of the form (<profile> <fields>) expected"
+        "S-expression of the form (<profile> <fields>) expected")
 end
 
 type Stanza.t +=
@@ -1329,7 +1339,7 @@ module Stanzas = struct
   exception Include_loop of Path.t * (Loc.t * Path.t) list
 
   let rec parse stanza_parser ~current_file ~include_stack sexps =
-    List.concat_map sexps ~f:stanza_parser
+    List.concat_map sexps ~f:(Sexp.Of_sexp.parse stanza_parser)
     |> List.concat_map ~f:(function
       | Include (loc, fn) ->
         let include_stack = (loc, current_file) :: include_stack in

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -137,12 +137,6 @@ module Sub_system_info : sig
   type t = ..
   type sub_system = t = ..
 
-  type 'a parser =
-    { short : (Loc.t -> 'a) option (** Value when the sub-system has
-                                       no argument *)
-    ; parse : 'a Sexp.Of_sexp.t    (** Parse the argument *)
-    }
-
   (** What the user must provide in order to define the parsing part
       of a sub-system. *)
   module type S = sig
@@ -155,7 +149,7 @@ module Sub_system_info : sig
     (** Location of the S-expression passed to [of_sexp] or [short]. *)
     val loc : t -> Loc.t
 
-    val parsers : t parser Syntax.Versioned_parser.t
+    val parsers : t Sexp.Of_sexp.t Syntax.Versioned_parser.t
   end
 
   module Register(M : S) : sig end

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -73,7 +73,7 @@ module Dict = struct
       ; native = List.mem Native ~set:l
       }
 
-    let t = Sexp.Of_sexp.(Parser.map (list t) ~f:of_list)
+    let t = Sexp.Of_sexp.(map (list t) ~f:of_list)
 
     let is_empty t = not (t.byte || t.native)
 

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -73,7 +73,7 @@ module Dict = struct
       ; native = List.mem Native ~set:l
       }
 
-    let t sexp = of_list (Sexp.Of_sexp.list t sexp)
+    let t = Sexp.Of_sexp.(Parser.map (list t) ~f:of_list)
 
     let is_empty t = not (t.byte || t.native)
 

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -40,7 +40,9 @@ let parse_general sexp ~f =
   in
   of_sexp sexp
 
-let t = Sexp.Of_sexp.make (fun sexp ->
+let t =
+  let open Sexp.Of_sexp in
+  raw >>| fun sexp ->
   let ast =
     parse_general sexp ~f:(function
       | Atom (loc, A s) | Quoted_string (loc, s) -> (loc, s)
@@ -48,7 +50,7 @@ let t = Sexp.Of_sexp.make (fun sexp ->
   in
   { ast
   ; loc = Some (Sexp.Ast.loc sexp)
-  })
+  }
 
 let is_standard t =
   match (t.ast : ast_expanded) with
@@ -171,7 +173,9 @@ let standard =
 module Unexpanded = struct
   type ast = (Sexp.Ast.t, Ast.unexpanded) Ast.t
   type t = ast generic
-  let t = Sexp.Of_sexp.make (fun sexp ->
+  let t =
+    let open Sexp.Of_sexp in
+    raw >>| fun sexp ->
     let rec map (t : (Sexp.Ast.t, Ast.expanded) Ast.t) =
       let open Ast in
       match t with
@@ -189,7 +193,7 @@ module Unexpanded = struct
     in
     { ast = map (parse_general sexp ~f:(fun x -> x))
     ; loc = Some (Sexp.Ast.loc sexp)
-    })
+    }
 
   let sexp_of_t t =
     let open Ast in

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -56,7 +56,7 @@ module Unexpanded : sig
   include Sexp.Sexpable with type t := t
   val standard : t
 
-  val field : ?default:t -> string -> t Sexp.Of_sexp.record_parser
+  val field : ?default:t -> string -> t Sexp.Of_sexp.fields_parser
 
   val has_special_forms : t -> bool
 

--- a/src/package.ml
+++ b/src/package.ml
@@ -13,7 +13,7 @@ module Name = struct
 
   let pp fmt t = Format.pp_print_string fmt (to_string t)
 
-  let t = Sexp.Of_sexp.(Parser.map ~f:of_string string)
+  let t = Sexp.Of_sexp.(map string ~f:of_string)
 end
 
 

--- a/src/package.ml
+++ b/src/package.ml
@@ -12,6 +12,8 @@ module Name = struct
   let opam_fn (t : t) = to_string t ^ ".opam"
 
   let pp fmt t = Format.pp_print_string fmt (to_string t)
+
+  let t = Sexp.Of_sexp.(Parser.map ~f:of_string string)
 end
 
 

--- a/src/package.mli
+++ b/src/package.mli
@@ -12,6 +12,8 @@ module Name : sig
   val pp : Format.formatter -> t -> unit
 
   include Interned.S with type t := t
+
+  val t : t Sexp.Of_sexp.t
 end
 
 type t =

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -34,10 +34,9 @@ module Driver = struct
 
       open Sexp.Of_sexp
 
-      let short = None
       let parse =
         record
-          (list_loc >>= fun loc ->
+          (loc >>= fun loc ->
            Ordered_set_lang.Unexpanded.field "flags"      >>= fun      flags ->
            Ordered_set_lang.Unexpanded.field "lint_flags" >>= fun lint_flags ->
            field "main" string >>= fun main ->
@@ -53,12 +52,7 @@ module Driver = struct
 
       let parsers =
         Syntax.Versioned_parser.make
-          [ (1, 0),
-            { Jbuild.Sub_system_info.
-              short
-            ; parse
-            }
-          ]
+          [ (1, 0), parse ]
     end
 
     (* The [lib] field is lazy so that we don't need to fill it for

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -188,7 +188,7 @@ module Jbuild_driver = struct
   let make name info : (Pp.t * Driver.t) Lazy.t = lazy (
     let info =
       Sexp.parse_string ~mode:Single ~fname:"<internal>" info
-      |> Driver.Info.parse
+      |> Sexp.Of_sexp.parse Driver.Info.parse
     in
     (Pp.of_string name,
      { info

--- a/src/stanza.ml
+++ b/src/stanza.ml
@@ -3,5 +3,5 @@ open Stdune
 type t = ..
 
 module Parser = struct
-  type nonrec t = string * t list Sexp.Of_sexp.cstr_parser
+  type nonrec t = string * t list Sexp.Of_sexp.t
 end

--- a/src/stanza.mli
+++ b/src/stanza.mli
@@ -9,5 +9,5 @@ module Parser : sig
 
       Each stanza in a configuration file might produce several values
       of type [t], hence the [t list] here. *)
-  type nonrec t = string * t list Sexp.Of_sexp.cstr_parser
+  type nonrec t = string * t list Sexp.Of_sexp.t
 end

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -72,7 +72,7 @@ end = struct
   let sexp_of_t t = Sexp.To_sexp.string (to_string t)
   let t = Sexp.Of_sexp.plain_string (fun ~loc t ->
     if Filename.is_relative t then
-      Sexp.Of_sexp.of_sexp_errorf_loc loc "Absolute path expected"
+      Sexp.Of_sexp.of_sexp_errorf loc "Absolute path expected"
     else
       of_string t)
 

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -70,11 +70,12 @@ end = struct
     make t
 
   let sexp_of_t t = Sexp.To_sexp.string (to_string t)
-  let t sexp =
-    let t = Sexp.Of_sexp.string sexp in
-    if Filename.is_relative t then
-      Sexp.Of_sexp.of_sexp_error sexp "Absolute path expected";
-    of_string t
+  let t = Sexp.Of_sexp.(
+    Parser.map_validate string ~f:(fun t ->
+      if Filename.is_relative t then
+        Parser.error "Absolute path expected"
+      else
+        Ok (of_string t)))
 
 (*
   let rec cd_dot_dot t =
@@ -276,9 +277,9 @@ end = struct
     | _ ->
       relative root s ?error_loc
 
-  let t sexp =
-    of_string (Sexp.Of_sexp.string sexp)
-      ~error_loc:(Sexp.Ast.loc sexp)
+  let t = Sexp.Of_sexp.(
+    Parser.map (located string) ~f:(fun (error_loc, s) ->
+      of_string s ~error_loc))
 
   let rec mkdir_p t =
     if is_root t then
@@ -587,18 +588,20 @@ let of_string ?error_loc s =
     else
       make_local_path (Local.of_string s ?error_loc)
 
-let t = function
-  (* the first 2 cases are necessary for old build dirs *)
-  | Sexp.Ast.Atom (_, A s)
-  | Quoted_string (_, s) -> of_string s
-  | s ->
-    let open Sexp.Of_sexp in
-    sum
-      [ "In_build_dir"  , next Local.t    >>| in_build_dir
-      ; "In_source_tree", next Local.t    >>| in_source_tree
-      ; "External"      , next External.t >>| external_
-      ]
-      s
+let t =
+  Sexp.Of_sexp.make (function
+    (* the first 2 cases are necessary for old build dirs *)
+    | Sexp.Ast.Atom (_, A s)
+    | Quoted_string (_, s) -> of_string s
+    | s ->
+      let open Sexp.Of_sexp in
+      parse (
+        sum
+          [ "In_build_dir"  , next Local.t    >>| in_build_dir
+          ; "In_source_tree", next Local.t    >>| in_source_tree
+          ; "External"      , next External.t >>| external_
+          ])
+        s)
 
 let sexp_of_t t =
   let constr f x y = Sexp.To_sexp.(pair string f) (x, y) in

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -2,6 +2,8 @@ type ('a, 'error) t = ('a, 'error) Caml.result =
   | Ok    of 'a
   | Error of 'error
 
+let ok x = Ok x
+
 let is_ok = function
   | Ok    _ -> true
   | Error _ -> false

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -31,6 +31,9 @@ let map_error x ~f =
   | Ok _ as res -> res
   | Error x -> Error (f x)
 
+let errorf fmt =
+  Printf.ksprintf (fun x -> Error x) fmt
+
 module O = struct
   let ( >>= ) t f = bind t ~f
   let ( >>| ) t f = map  t ~f

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -4,6 +4,8 @@ type ('a, 'error) t = ('a, 'error) Caml.result =
   | Ok    of 'a
   | Error of 'error
 
+val ok : 'a -> ('a, _) t
+
 val is_ok    : _ t -> bool
 val is_error : _ t -> bool
 

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -28,5 +28,8 @@ val concat_map
   -> f:('a -> ('b list, 'error) t)
   -> ('b list, 'error) t
 
+(** Produce [Error <message>] *)
+val errorf : ('a, unit, string, (_, string) t) format4 -> 'a
+
 (** For compatibility with some other code *)
 type ('a, 'error) result = ('a, 'error) t

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -72,111 +72,12 @@ module Of_sexp = struct
 
   exception Of_sexp of Loc.t * string * hint option
 
-  type 'a t = ast -> 'a
-
-  let make f = f
-
-  let parse f a = f a
-
-  module Parser = struct
-    let fail fmt =
-      Printf.ksprintf (fun m ast -> raise (Exn.Loc_error (Ast.loc ast, m))) fmt
-    let map t ~f ast = f (t ast)
-    let return a _ = a
-
-    module O = struct
-      let (>>|) t f = map t ~f
-      let (>>=) t f ast = f (t ast) ast
-    end
-
-    type error = string * hint option
-
-    let error ?hint str = Result.Error (str, hint)
-    let errorf ?hint fmt = Printf.ksprintf (error ?hint) fmt
-
-    let map_validate t ~f ast =
-      match f (t ast) with
-      | Result.Ok b -> b
-      | Error (msg, hint) -> raise (Of_sexp (Ast.loc ast, msg, hint))
-  end
-
-  let fix f =
-    let rec p = lazy (f r)
-    and r ast = (Lazy.force p) ast in
-    r
-
-  let located f sexp =
-    (Ast.loc sexp, f sexp)
-
-  let loc = Ast.loc
-
-  let of_sexp_error ?hint sexp str = raise (Of_sexp (Ast.loc sexp, str, hint))
-  let of_sexp_errorf ?hint sexp fmt = Printf.ksprintf (of_sexp_error ?hint sexp) fmt
-
-  let sexp_error ?hint str sexp = of_sexp_error ?hint sexp str
-
-  let of_sexp_errorf_loc ?hint loc fmt =
-    Printf.ksprintf (fun s -> raise (Of_sexp (loc, s, hint))) fmt
-
-  let raw x = x
-
-  let unit = function
-    | List (_, []) -> ()
-    | sexp -> of_sexp_error sexp "() expected"
-
-  let discard (_ : ast) = ()
-
-  let string = function
-    | Atom (_, A s) -> s
-    | Quoted_string (_, s) -> s
-    | List _ as sexp -> of_sexp_error sexp "Atom or quoted string expected"
-
-  let int sexp = match sexp with
-    | Atom (_, A s) -> (try int_of_string s
-                        with _ -> of_sexp_error sexp "Integer expected")
-    | _ -> of_sexp_error sexp "Integer expected"
-
-  let float sexp = match sexp with
-    | Atom (_, A s) -> (try float_of_string s
-                        with _ -> of_sexp_error sexp "Float expected")
-    | _ -> of_sexp_error sexp "Float expected"
-
-  let bool = function
-    | Atom (_, A "true") -> true
-    | Atom (_, A "false") -> false
-    | sexp -> of_sexp_error sexp "'true' or 'false' expected"
-
-  let pair fa fb = function
-    | List (_, [a; b]) -> (fa a, fb b)
-    | sexp -> of_sexp_error sexp "S-expression of the form (_ _) expected"
-
-  let triple fa fb fc = function
-    | List (_, [a; b; c]) -> (fa a, fb b, fc c)
-    | sexp -> of_sexp_error sexp "S-expression of the form (_ _ _) expected"
-
-  let list f = function
-    | (Atom _ | Quoted_string _) as sexp -> of_sexp_error sexp "List expected"
-    | List (_, l) -> List.map l ~f
-
-  let array f sexp = Array.of_list (list f sexp)
-
-  let option f = function
-    | List (_, []) -> None
-    | List (_, [x]) -> Some (f x)
-    | sexp -> of_sexp_error sexp "S-expression of the form () or (_) expected"
-
-  let string_set sexp = String.Set.of_list (list string sexp)
-  let string_map f sexp =
-    match String.Map.of_list (list (pair string f) sexp) with
-    | Result.Ok x -> x
-    | Error (key, _v1, _v2) ->
-      of_sexp_error sexp (Printf.sprintf "key %S present multiple times" key)
-
-  let string_hashtbl f sexp =
-    let map = string_map f sexp in
-    let tbl = Hashtbl.create (String.Map.cardinal map + 32) in
-    String.Map.iteri map ~f:(Hashtbl.add tbl);
-    tbl
+  let of_sexp_error sexp ?hint msg =
+    raise (Of_sexp (Ast.loc sexp, msg, hint))
+  let of_sexp_errorf sexp ?hint fmt =
+    Printf.ksprintf (fun msg -> of_sexp_error sexp ?hint msg) fmt
+  let of_sexp_errorf_loc loc ?hint fmt =
+    Printf.ksprintf (fun msg -> raise (Of_sexp (loc, msg, hint))) fmt
 
   type unparsed_field =
     { values : Ast.t list
@@ -195,56 +96,286 @@ module Of_sexp = struct
 
   module Name_map = Map.Make(Name)
 
-  (* Either:
+  type values = Ast.t list
+  type fields =
+    { unparsed : unparsed_field Name_map.t
+    ; known    : string list
+    }
 
-     - [Sum (<list location>, <constructor name>, <elements>)]
-     - [Record (<list location>, <unparsed fields>, <known field names>)]
-  *)
-  type 'kind list_parser_state =
-    | Cstr
-      : Loc.t * string * Ast.t list -> [`Cstr] list_parser_state
-    | Record
-      : Loc.t * unparsed_field Name_map.t * string list
-      -> [`Record] list_parser_state
+  (* The two arguments are the location of the whole list as well as
+     the first atom when either parsing a constructor or a field. *)
+  type 'kind context =
+    | Values : Loc.t * string option -> values context
+    | Fields : Loc.t * string option -> fields context
 
-  type ('a, 'kind) list_parser
-    = 'kind list_parser_state -> 'a * 'kind list_parser_state
+  type ('a, 'kind) parser =  'kind context -> 'kind -> 'a * 'kind
 
-  type 'a   cstr_parser = ('a, [`Cstr  ]) list_parser
-  type 'a record_parser = ('a, [`Record]) list_parser
+  type 'a t             = ('a, values) parser
+  type 'a fields_parser = ('a, fields) parser
 
-  let return x state = (x, state)
-  let (>>=) m f state =
-    let x, state = m state in
-    f x state
-  let (>>|) m f state =
-    let x, state = m state in
+  let return x _ctx state = (x, state)
+  let (>>=) t f ctx state =
+    let x, state = t ctx state in
+    f x ctx state
+  let (>>|) t f ctx state =
+    let x, state = t ctx state in
     (f x, state)
+  let (>>>) a b ctx state =
+    let (), state = a ctx state in
+    b ctx state
+  let map t ~f = t >>| f
 
-  let get_loc : type k. k list_parser_state -> Loc.t = function
-    | Cstr   (loc, _, _) -> loc
-    | Record (loc, _, _) -> loc
+  let loc : type k. k context -> k -> Loc.t * k = fun ctx state ->
+    match ctx with
+    | Values (loc, _) -> (loc, state)
+    | Fields (loc, _) -> (loc, state)
 
-  let list_loc state = (get_loc state, state)
+  let eos : type k. k context -> k -> bool * k = fun ctx state ->
+    match ctx with
+    | Values _ -> (state = [], state)
+    | Fields _ -> (Name_map.is_empty state.unparsed, state)
 
-  let consume name (Record (loc, unparsed, known)) =
-    Record (loc, Name_map.remove unparsed name, name :: known)
+  let repeat : 'a t -> 'a list t =
+    let rec loop t acc ctx l =
+      match l with
+      | [] -> (List.rev acc, [])
+      | _ ->
+        let x, l = t ctx l in
+        loop t (x :: acc) ctx l
+    in
+    fun t ctx state -> loop t [] ctx state
 
-  let add_known name (Record (loc, unparsed, known)) =
-    (Record (loc, unparsed, name :: known))
+  let result : type a k. k context -> a * k -> a =
+    fun ctx (v, state) ->
+      match ctx with
+      | Values (_, cstr) -> begin
+          match state with
+          | [] -> v
+          | sexp :: _ ->
+            match cstr with
+            | None ->
+              of_sexp_errorf sexp "This value is unused"
+            | Some s ->
+              of_sexp_errorf sexp "Too many argument for %s" s
+        end
+      | Fields _ -> begin
+          match Name_map.choose state.unparsed with
+          | None -> v
+          | Some (name, { entry; _ }) ->
+            let name_sexp =
+              match entry with
+              | List (_, s :: _) -> s
+              | _ -> assert false
+            in
+            of_sexp_errorf ~hint:{ on = name; candidates = state.known }
+              name_sexp "Unknown field %s" name
+        end
 
-  let map_validate parse ~f state1 =
-    let x, state2 = parse state1 in
+  let parse t sexp =
+    let ctx = Values (Ast.loc sexp, None) in
+    result ctx (t ctx [sexp])
+
+  let end_of_list (Values (loc, cstr)) =
+    match cstr with
+    | None ->
+      let loc = { loc with start = loc.stop } in
+      of_sexp_errorf_loc loc "Premature end of list"
+    | Some s ->
+      of_sexp_errorf_loc loc "Not enough arguments for %s" s
+  [@@inline never]
+
+  let next f ctx sexps =
+    match sexps with
+    | [] -> end_of_list ctx
+    | sexp :: sexps -> (f sexp, sexps)
+  [@@inline always]
+
+  let peek t ctx sexps =
+    let x, _ = t ctx sexps in
+    (x, sexps)
+  [@@inline always]
+
+  let junk = next ignore
+
+  let plain_string f =
+    next (function
+      | Atom (loc, A s) | Quoted_string (loc, s) -> f ~loc s
+      | List _ as sexp -> of_sexp_error sexp "Atom or quoted string expected")
+
+  let enter t =
+    next (function
+      | List (loc, l) ->
+        let ctx = Values (loc, None) in
+        result ctx (t ctx l)
+      | sexp ->
+        of_sexp_error sexp "List expected")
+
+  let fix f =
+    let rec p = lazy (f r)
+    and r ast = (Lazy.force p) ast in
+    r
+
+  let located t ctx state1 =
+    let x, state2 = t ctx state1 in
+    match state1 with
+    | sexp :: rest when rest == state2 -> (* common case *)
+      ((Ast.loc sexp, x), state2)
+    | [] ->
+      let (Values (loc, _)) = ctx in
+      (({ loc with start = loc.stop }, x), state2)
+    | sexp :: rest ->
+      let loc = Ast.loc sexp in
+      let rec search last l =
+        if l == state2 then
+          (({ loc with stop = (Ast.loc last).stop }, x), state2)
+        else
+          match l with
+          | [] ->
+            let (Values (loc, _)) = ctx in
+            (({ (Ast.loc sexp) with stop = loc.stop }, x), state2)
+          | sexp :: rest ->
+            search sexp rest
+      in
+      search sexp rest
+
+  let of_sexp_error ?hint sexp str = raise (Of_sexp (Ast.loc sexp, str, hint))
+  let of_sexp_errorf ?hint sexp fmt =
+    Printf.ksprintf (of_sexp_error ?hint sexp) fmt
+
+  let of_sexp_errorf_loc ?hint loc fmt =
+    Printf.ksprintf (fun s -> raise (Of_sexp (loc, s, hint))) fmt
+
+  let raw = next (fun x -> x)
+
+  let unit =
+    next
+      (function
+        | List (_, []) -> ()
+        | sexp -> of_sexp_error sexp "() expected")
+
+  let basic desc f =
+    next (function
+      | List (loc, _) | Quoted_string (loc, _) ->
+        of_sexp_errorf_loc loc "%s expected" desc
+      | Atom (loc, s)  ->
+        match f (Atom.to_string s) with
+        | Error () ->
+          of_sexp_errorf_loc loc "%s expected" desc
+        | Ok x -> x)
+
+  let string = plain_string (fun ~loc:_ x -> x)
+  let int =
+    basic "Integer" (fun s ->
+      match int_of_string s with
+      | x -> Ok x
+      | exception _ -> Error ())
+
+  let float =
+    basic "Float" (fun s ->
+      match float_of_string s with
+      | x -> Ok x
+      | exception _ -> Error ())
+
+  let pair a b =
+    enter
+      (a >>= fun a ->
+       b >>= fun b ->
+       return (a, b))
+
+  let triple a b c =
+    enter
+      (a >>= fun a ->
+       b >>= fun b ->
+       c >>= fun c ->
+       return (a, b, c))
+
+  let list t = enter (repeat t)
+
+  let array t = list t >>| Array.of_list
+
+  let option t =
+    enter
+      (eos >>= function
+       | true -> return None
+       | false -> t >>| Option.some)
+
+  let string_set = list string >>| String.Set.of_list
+  let string_map t =
+    list (pair string t) >>= fun bindings ->
+    match String.Map.of_list bindings with
+    | Ok x -> return x
+    | Error (key, _v1, _v2) ->
+      loc >>= fun loc ->
+      of_sexp_errorf_loc loc "key %s present multiple times" key
+
+  let string_hashtbl t =
+    string_map t >>| fun map ->
+    let tbl = Hashtbl.create (String.Map.cardinal map + 32) in
+    String.Map.iteri map ~f:(Hashtbl.add tbl);
+    tbl
+
+
+  let find_cstr cstrs loc name ctx values =
+    match List.assoc cstrs name with
+    | Some t ->
+      result ctx (t ctx values)
+    | None ->
+      of_sexp_errorf_loc loc
+        ~hint:{ on         = name
+              ; candidates = List.map cstrs ~f:fst
+              }
+        "Unknown constructor %s" name
+
+  let sum cstrs =
+    next (fun sexp ->
+      match sexp with
+      | Atom (loc, A s) ->
+        find_cstr cstrs loc s (Values (loc, Some s)) []
+      | Quoted_string _ ->
+        of_sexp_error sexp "Atom expected"
+      | List (_, []) ->
+        of_sexp_error sexp "Non-empty list expected"
+      | List (loc, name :: args) ->
+        match name with
+        | Quoted_string _ | List _ -> of_sexp_error name "Atom expected"
+        | Atom (s_loc, A s) ->
+          find_cstr cstrs s_loc s (Values (loc, Some s)) args)
+
+  let enum cstrs =
+    next (fun sexp ->
+      match sexp with
+      | Quoted_string _ | List _ -> of_sexp_error sexp "Atom expected"
+      | Atom (_, A s) ->
+        match List.assoc cstrs s with
+        | Some value -> value
+        | None ->
+          of_sexp_errorf sexp
+            ~hint:{ on         = s
+                  ; candidates = List.map cstrs ~f:fst
+                  }
+            "Unknown value %s" s)
+
+  let bool = enum [ ("true", true); ("false", false) ]
+
+  let consume name state =
+    { unparsed = Name_map.remove state.unparsed name
+    ; known    = name :: state.known
+    }
+
+  let add_known name state =
+    { state with known = name :: state.known }
+
+  let map_validate t ~f ctx state1 =
+    let x, state2 = t ctx state1 in
     match f x with
-    | Result.Ok x -> x, state2
+    | Result.Ok x -> (x, state2)
     | Error msg ->
-      let (Record (_, unparsed1, _)) = state1 in
-      let (Record (_, unparsed2, _)) = state2 in
       let parsed =
-        Name_map.merge unparsed1 unparsed2 ~f:(fun _key before after ->
-          match before, after with
-          | Some _, None -> before
-          | _ -> None)
+        Name_map.merge state1.unparsed state2.unparsed
+          ~f:(fun _key before after ->
+            match before, after with
+            | Some _, None -> before
+            | _ -> None)
       in
       let loc =
         match
@@ -253,31 +384,18 @@ module Of_sexp = struct
           |> List.sort ~compare:(fun a b ->
             Int.compare a.Loc.start.pos_cnum b.start.pos_cnum)
         with
-        | [] -> get_loc state1
+        | [] ->
+          let (Fields (loc, _)) = ctx in
+          loc
         | first :: l ->
           let last = List.fold_left l ~init:first ~f:(fun _ x -> x) in
           { first with stop = last.stop }
       in
       of_sexp_errorf_loc loc "%s" msg
 
-  module Short_syntax = struct
-    type 'a t =
-      | Not_allowed
-      | This    of 'a
-      | Located of (Loc.t -> 'a)
-
-    let parse t entry name =
-      match t with
-      | Not_allowed -> of_sexp_errorf entry "field %s needs a value" name
-      | This    x -> x
-      | Located f -> f (Ast.loc entry)
-  end
-
-  let too_many_values name field =
-    of_sexp_errorf_loc (Ast.loc field.entry) "too many values for field %s" name
-
-  let field_missing state name =
-    of_sexp_errorf_loc (get_loc state) "field %s missing" name
+  let field_missing (Fields (loc, _)) name =
+    of_sexp_errorf_loc loc "field %s missing" name
+  [@@inline never]
 
   let rec multiple_occurrences ~name ~last ~prev =
     match prev.prev with
@@ -288,58 +406,53 @@ module Of_sexp = struct
       of_sexp_errorf last.entry "Field %S is present too many times" name
   [@@inline never]
 
-  let find_single (Record (_, unparsed, _)) name =
-    let res = Name_map.find unparsed name in
+  let find_single state name =
+    let res = Name_map.find state.unparsed name in
     (match res with
      | Some ({ prev = Some prev; _ } as last) ->
        multiple_occurrences ~name ~last ~prev
      | _ -> ());
     res
 
-  let field name ?(short=Short_syntax.Not_allowed)
-        ?default value_of_sexp state =
+  let field name ?default t ctx state =
     match find_single state name with
-    | Some { values = [value]; _ } ->
-      (value_of_sexp value, consume name state)
-    | Some { values = []; entry; _ } ->
-      (Short_syntax.parse short entry name,
-       consume name state)
-    | Some f ->
-      too_many_values name f
+    | Some { values; entry; _ } ->
+      let ctx = Values (Ast.loc entry, Some name) in
+      let x = result ctx (t ctx values) in
+      (x, consume name state)
     | None ->
       match default with
       | Some v -> (v, add_known name state)
-      | None -> field_missing state name
+      | None -> field_missing ctx name
 
-  let field_o name ?(short=Short_syntax.Not_allowed) value_of_sexp state =
+  let field_o name t _ctx state =
     match find_single state name with
-    | Some { values = [value]; _ } ->
-      (Some (value_of_sexp value), consume name state)
-    | Some { values = []; entry; _ } ->
-      (Some (Short_syntax.parse short entry name),
-       consume name state)
-    | Some f ->
-      too_many_values name f
-    | None -> (None, add_known name state)
+    | Some { values; entry; _ } ->
+      let ctx = Values (Ast.loc entry, Some name) in
+      let x = result ctx (t ctx values) in
+      (Some x, consume name state)
+    | None ->
+      (None, add_known name state)
 
-  let field_b name = field name bool ~default:false ~short:(This true)
+  let field_b name =
+    field name ~default:false
+      (eos >>= function
+       | true -> return true
+       | _ -> bool)
 
-  let dup_field name ?(short=Short_syntax.Not_allowed) value_of_sexp state =
+  let multi_field name t _ctx state =
     let rec loop acc field =
       match field with
       | None -> acc
-      | Some { values = [value]; prev; _ } ->
-        loop (value_of_sexp value :: acc) prev
-      | Some { values = []; entry; prev } ->
-        loop (Short_syntax.parse short entry name :: acc) prev
-      | Some f ->
-        too_many_values name f
+      | Some { values; prev; entry } ->
+        let ctx = Values (Ast.loc entry, Some name) in
+        let x = result ctx (t ctx values) in
+        loop (x :: acc) prev
     in
-    let (Record (_, unparsed, _)) = state in
-    let res = loop [] (Name_map.find unparsed name) in
+    let res = loop [] (Name_map.find state.unparsed name) in
     (res, consume name state)
 
-  let parse_fields m loc sexps =
+  let fields t (Values (loc, cstr)) sexps =
     let unparsed =
       List.fold_left sexps ~init:Name_map.empty ~f:(fun acc sexp ->
         match sexp with
@@ -358,99 +471,11 @@ module Of_sexp = struct
           of_sexp_error sexp
             "S-expression of the form (<name> <values>...) expected")
     in
-    let v, (Record (_, unparsed, known)) = m (Record (loc, unparsed, [])) in
-    match Name_map.choose unparsed with
-    | None -> v
-    | Some (name, { entry; _ }) ->
-      let name_sexp =
-        match entry with
-        | List (_, s :: _) -> s
-        | _ -> assert false
-      in
-      of_sexp_errorf ~hint:({ on = name ; candidates = known})
-        name_sexp "Unknown field %s" name
+    let ctx = Fields (loc, cstr) in
+    let x = result ctx (t ctx { unparsed; known = [] }) in
+    (x, [])
 
-  let record m sexp =
-    match sexp with
-    | Atom _ | Quoted_string _ -> of_sexp_error sexp "List expected"
-    | List (loc, sexps) -> parse_fields m loc sexps
-
-  let next t (Cstr (loc, cstr, sexps)) =
-    match sexps with
-    | [] -> of_sexp_errorf_loc loc "Not enough arguments for %s" cstr
-    | sexp :: sexps ->
-      let v = t sexp in
-      (v, Cstr (loc, cstr, sexps))
-
-  let rest t (Cstr (loc, cstr, sexps)) =
-    (List.map sexps ~f:t,
-     Cstr (loc, cstr, []))
-
-  let rest_as_record m (Cstr (loc, cstr, sexps)) =
-    let v = parse_fields m loc sexps in
-    (v, Cstr (loc, cstr, []))
-
-  let sum_result (v, Cstr (loc, cstr, sexps)) =
-    match sexps with
-    | [] -> v
-    | _ :: _ -> of_sexp_errorf_loc loc "Too many arguments for %s" cstr
-
-  let find_cstr cstrs loc name state =
-    match List.assoc cstrs name with
-    | Some m -> sum_result (m state)
-    | None ->
-      of_sexp_errorf_loc loc
-        ~hint:{ on         = name
-              ; candidates = List.map cstrs ~f:fst
-              }
-        "Unknown constructor %s" name
-
-  let sum cstrs sexp =
-    match sexp with
-    | Atom (loc, A s) ->
-      find_cstr cstrs loc s (Cstr (loc, s, []))
-    | Quoted_string _ -> of_sexp_error sexp "Atom expected"
-    | List (_, []) -> of_sexp_error sexp "non-empty list expected"
-    | List (loc, name :: args) ->
-      match name with
-      | Quoted_string _ | List _ -> of_sexp_error name "Atom expected"
-      | Atom (s_loc, A s) ->
-        find_cstr cstrs s_loc s (Cstr (loc, s, args))
-
-  let field_multi name ?default m state =
-    match find_single state name with
-    | Some { values; entry; _ } ->
-      (sum_result (m (Cstr (Ast.loc entry, name, values))),
-       consume name state)
-    | None ->
-      match default with
-      | Some v -> (v, add_known name state)
-      | None -> field_missing state name
-
-  let dup_field_multi name m state =
-    let rec loop acc field =
-      match field with
-      | None -> acc
-      | Some { values; entry; prev } ->
-        let x = sum_result (m (Cstr (Ast.loc entry, name, values))) in
-        loop (x :: acc) prev
-    in
-    let (Record (_, unparsed, _)) = state in
-    let res = loop [] (Name_map.find unparsed name) in
-    (res, consume name state)
-
-  let enum cstrs sexp =
-    match sexp with
-    | Quoted_string _ | List _ -> of_sexp_error sexp "Atom expected"
-    | Atom (_, A s) ->
-      match List.assoc cstrs s with
-      | Some value -> value
-      | None ->
-        of_sexp_errorf sexp
-          ~hint:{ on         = s
-                ; candidates = List.map cstrs ~f:fst
-                }
-          "Unknown value %s" s
+  let record t = enter (fields t)
 end
 
 module type Sexpable = sig

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -91,12 +91,12 @@ module Of_sexp = struct
 
     type error = string * hint option
 
-    let error ?hint str = Error (str, hint)
+    let error ?hint str = Result.Error (str, hint)
     let errorf ?hint fmt = Printf.ksprintf (error ?hint) fmt
 
     let map_validate t ~f ast =
       match f (t ast) with
-      | Ok b -> b
+      | Result.Ok b -> b
       | Error (msg, hint) -> raise (Of_sexp (Ast.loc ast, msg, hint))
   end
 

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -146,9 +146,16 @@ module Of_sexp : sig
 
   val fix : ('a t -> 'a t) -> 'a t
 
-  val of_sexp_error  : ?hint:hint -> Ast.t -> string -> _
-  val of_sexp_errorf : ?hint:hint -> Ast.t -> ('a, unit, string, 'b) format4 -> 'a
-  val of_sexp_errorf_loc : ?hint:hint -> Loc.t -> ('a, unit, string, 'b) format4 -> 'a
+  val of_sexp_error
+    :  ?hint:hint
+    -> Loc.t
+    -> string
+    -> _
+  val of_sexp_errorf
+    :  ?hint:hint
+    -> Loc.t
+    -> ('a, unit, string, 'b) format4
+    -> 'a
 
   val located : 'a t -> (Loc.t * 'a) t
 

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -87,7 +87,7 @@ module Of_sexp : sig
 
     val error : ?hint:hint -> string -> (_, error) Result.t
     val errorf
-      : ?hint:hint -> ('b, unit, string, (_, error) result) format4 -> 'b
+      : ?hint:hint -> ('b, unit, string, (_, error) Result.t) format4 -> 'b
     val map_validate : 'a t -> f:('a -> ('b, error) Result.t) -> 'b t
   end
 

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -65,12 +65,41 @@ module Of_sexp : sig
 
   exception Of_sexp of Loc.t * string * hint option
 
-  include Combinators with type 'a t = Ast.t -> 'a
+  include Combinators
 
+  val parse : 'a t -> ast -> 'a
+
+  val make : (ast -> 'a) -> 'a t
+
+  val discard : unit t
+
+  module Parser : sig
+    val fail : ('a, unit, string, string, string, 'b t) format6 -> 'a
+    val map : 'a t -> f:('a -> 'b) -> 'b t
+    val return : 'a -> 'a t
+
+    module O : sig
+      val (>>|) : 'a t -> ('a -> 'b)   -> 'b t
+      val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+    end
+
+    type error
+
+    val error : ?hint:hint -> string -> (_, error) Result.t
+    val errorf
+      : ?hint:hint -> ('b, unit, string, (_, error) result) format4 -> 'b
+    val map_validate : 'a t -> f:('a -> ('b, error) Result.t) -> 'b t
+  end
+
+  val fix : ('a t -> 'a t) -> 'a t
+
+  val sexp_error : ?hint:hint -> string -> _ t
   val of_sexp_error  : ?hint:hint -> Ast.t -> string -> _
   val of_sexp_errorf : ?hint:hint -> Ast.t -> ('a, unit, string, 'b) format4 -> 'a
 
   val located : 'a t -> (Loc.t * 'a) t
+
+  val loc : Loc.t t
 
   val raw : ast t
 

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -59,11 +59,12 @@ let rec of_tokens : Token.t list -> item list = function
 
 let items_of_string s = of_tokens (Token.tokenise s)
 
-let t : Sexp.Of_sexp.ast -> t = function
-  | Atom(loc, A s) -> { items = items_of_string s;  loc;  quoted = false }
-  | Quoted_string (loc, s) ->
-    { items = items_of_string s;  loc;  quoted = true }
-  | List _ as sexp -> Sexp.Of_sexp.of_sexp_error sexp "Atom expected"
+let t =
+  Sexp.Of_sexp.make (function
+    | Atom(loc, A s) -> { items = items_of_string s;  loc;  quoted = false }
+    | Quoted_string (loc, s) ->
+      { items = items_of_string s;  loc;  quoted = true }
+    | List _ as sexp -> Sexp.Of_sexp.of_sexp_error sexp "Atom expected")
 
 let loc t = t.loc
 

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -60,11 +60,13 @@ let rec of_tokens : Token.t list -> item list = function
 let items_of_string s = of_tokens (Token.tokenise s)
 
 let t =
-  Sexp.Of_sexp.make (function
-    | Atom(loc, A s) -> { items = items_of_string s;  loc;  quoted = false }
-    | Quoted_string (loc, s) ->
-      { items = items_of_string s;  loc;  quoted = true }
-    | List _ as sexp -> Sexp.Of_sexp.of_sexp_error sexp "Atom expected")
+  let open Sexp.Of_sexp in
+  raw >>| fun sexp ->
+  match sexp with
+  | Atom(loc, A s) -> { items = items_of_string s;  loc;  quoted = false }
+  | Quoted_string (loc, s) ->
+    { items = items_of_string s;  loc;  quoted = true }
+  | List _ as sexp -> of_sexp_error sexp "Atom or quoted string expected"
 
 let loc t = t.loc
 

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -66,7 +66,7 @@ let t =
   | Atom(loc, A s) -> { items = items_of_string s;  loc;  quoted = false }
   | Quoted_string (loc, s) ->
     { items = items_of_string s;  loc;  quoted = true }
-  | List _ as sexp -> of_sexp_error sexp "Atom or quoted string expected"
+  | List (loc, _) -> of_sexp_error loc "Atom or quoted string expected"
 
 let loc t = t.loc
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -17,7 +17,7 @@ module Version = struct
           Loc.fail loc "Atom of the form NNN.NNN expected"
       end
     | sexp ->
-      of_sexp_error sexp "Atom expected"
+      of_sexp_error (Sexp.Ast.loc sexp) "Atom expected"
 
   let can_read ~parser_version:(pa, pb) ~data_version:(da, db) =
     pa = da && db <= pb

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -7,7 +7,7 @@ module Version = struct
 
   let sexp_of_t t = Sexp.unsafe_atom_of_string (to_string t)
 
-  let t : t Sexp.Of_sexp.t = function
+  let t : t Sexp.Of_sexp.t = Sexp.Of_sexp.make (function
     | Atom (loc, A s) -> begin
         try
           Scanf.sscanf s "%u.%u" (fun a b -> (a, b))
@@ -15,7 +15,7 @@ module Version = struct
           Loc.fail loc "atom of the form NNN.NNN expected"
       end
     | sexp ->
-      Sexp.Of_sexp.of_sexp_error sexp "atom expected"
+      Sexp.Of_sexp.of_sexp_error sexp "atom expected")
 
   let can_read ~parser_version:(pa, pb) ~data_version:(da, db) =
     pa = da && db <= pb

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -7,15 +7,17 @@ module Version = struct
 
   let sexp_of_t t = Sexp.unsafe_atom_of_string (to_string t)
 
-  let t : t Sexp.Of_sexp.t = Sexp.Of_sexp.make (function
+  let t : t Sexp.Of_sexp.t =
+    let open Sexp.Of_sexp in
+    raw >>| function
     | Atom (loc, A s) -> begin
         try
           Scanf.sscanf s "%u.%u" (fun a b -> (a, b))
         with _ ->
-          Loc.fail loc "atom of the form NNN.NNN expected"
+          Loc.fail loc "Atom of the form NNN.NNN expected"
       end
     | sexp ->
-      Sexp.Of_sexp.of_sexp_error sexp "atom expected")
+      of_sexp_error sexp "Atom expected"
 
   let can_read ~parser_version:(pa, pb) ~data_version:(da, db) =
     pa = da && db <= pb

--- a/src/vfile_kind.ml
+++ b/src/vfile_kind.ml
@@ -66,7 +66,7 @@ module Make
 struct
   module Of_sexp = struct
     include F(Sexp.Of_sexp)
-    let t _ sexp = t sexp
+    let t _ sexp = Sexp.Of_sexp.parse t sexp
   end
   module To_sexp = struct
     include F(Sexp.To_sexp)

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -155,14 +155,17 @@ let t ?x ?profile:cmdline_profile sexps =
          name = "install" ||
          String.contains name '/' ||
          String.contains name '\\' then
-        of_sexp_errorf sexp "%S is not allowed as a build context name" name;
+        of_sexp_errorf (Sexp.Ast.loc sexp)
+          "%S is not allowed as a build context name" name;
       if String.Set.mem !defined_names name then
-        of_sexp_errorf sexp "second definition of build context %S" name;
+        of_sexp_errorf (Sexp.Ast.loc sexp)
+          "second definition of build context %S" name;
       defined_names := String.Set.union !defined_names
                          (String.Set.of_list (Context.all_names ctx));
       match ctx, t.merlin_context with
       | Opam { merlin = true; _ }, Some _ ->
-        of_sexp_errorf sexp "you can only have one context for merlin"
+        of_sexp_errorf (Sexp.Ast.loc sexp)
+          "you can only have one context for merlin"
       | Opam { merlin = true; _ }, None ->
         { merlin_context = Some name; contexts = ctx :: t.contexts }
       | _ ->

--- a/test/unit-tests/jbuild.mlt
+++ b/test/unit-tests/jbuild.mlt
@@ -1,3 +1,4 @@
+(* -*- tuareg -*- *)
 open Dune;;
 open Stdune;;
 
@@ -7,7 +8,7 @@ open Stdune;;
 
 (* Jbuild.Executables.Link_mode.t *)
 let test s =
-  Jbuild.Executables.Link_mode.t
+  Sexp.Of_sexp.parse Jbuild.Executables.Link_mode.t
     (Sexp.parse_string ~fname:"" ~mode:Sexp.Parser.Mode.Single s)
 [%%expect{|
 val test : string -> Dune.Jbuild.Executables.Link_mode.t = <fun>

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -24,18 +24,18 @@ val sexp : Usexp.Ast.t = ((foo 1) (foo 2))
 |}]
 
 let of_sexp = record (field "foo" int)
-let x = of_sexp sexp
+let x = parse of_sexp sexp
 [%%expect{|
-val of_sexp : int Stdune.Sexp.Of_sexp.t = <fun>
+val of_sexp : int Stdune.Sexp.Of_sexp.t = <abstr>
 Exception:
 Stdune__Sexp.Of_sexp.Of_sexp (<abstr>,
  "Field \"foo\" is present too many times", None).
 |}]
 
 let of_sexp = record (dup_field "foo" int)
-let x = of_sexp sexp
+let x = parse of_sexp sexp
 [%%expect{|
-val of_sexp : int list Stdune.Sexp.Of_sexp.t = <fun>
+val of_sexp : int list Stdune.Sexp.Of_sexp.t = <abstr>
 val x : int list = [1; 2]
 |}]
 

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -32,7 +32,7 @@ Stdune__Sexp.Of_sexp.Of_sexp (<abstr>,
  "Field \"foo\" is present too many times", None).
 |}]
 
-let of_sexp = record (dup_field "foo" int)
+let of_sexp = record (multi_field "foo" int)
 let x = parse of_sexp sexp
 [%%expect{|
 val of_sexp : int list Stdune.Sexp.Of_sexp.t = <abstr>


### PR DESCRIPTION
@diml the organization decisions made here are a bit questionable because we now have 2 monads co-existing in the same module. Error handling is still a bit messy as well. I welcome some suggestions here.

I've also left some uses of `Of_sexp.make` around. This is no ideal, but probably not urgent to fix as there are more important issues.