### PR TITLE
Dune & Jbuild validation for atoms

### DIFF
--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -149,8 +149,7 @@ module Lang = struct
     in
     let ver =
       Sexp.Of_sexp.parse Syntax.Version.t Univ_map.empty
-        (Atom (ver_loc, Sexp.Atom.of_string ver))
-    in
+        (Atom (ver_loc, Sexp.Atom.of_string_exn Sexp.Atom.Dune ver)) in
     match Hashtbl.find langs name with
     | None ->
       Loc.fail name_loc "Unknown language %S.%s" name

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -149,7 +149,7 @@ module Lang = struct
     in
     let ver =
       Sexp.Of_sexp.parse Syntax.Version.t Univ_map.empty
-        (Atom (ver_loc, Sexp.Atom.of_string_exn Sexp.Atom.Dune ver)) in
+        (Atom (ver_loc, Sexp.Atom.of_string ver)) in
     match Hashtbl.find langs name with
     | None ->
       Loc.fail name_loc "Unknown language %S.%s" name

--- a/src/loc.ml
+++ b/src/loc.ml
@@ -11,8 +11,7 @@ let int n = Usexp.Atom (Usexp.Atom.of_int n)
 let string = Usexp.atom_or_quoted_string
 let record l =
   let open Usexp in
-  List (List.map l ~f:(fun (n, v) ->
-    List [Atom(Atom.of_string_exn Atom.Dune n); v]))
+  List (List.map l ~f:(fun (n, v) -> List [Atom(Atom.of_string n); v]))
 
 let sexp_of_position_no_file (p : Lexing.position) =
   record

--- a/src/loc.ml
+++ b/src/loc.ml
@@ -11,7 +11,8 @@ let int n = Usexp.Atom (Usexp.Atom.of_int n)
 let string = Usexp.atom_or_quoted_string
 let record l =
   let open Usexp in
-  List (List.map l ~f:(fun (n, v) -> List [Atom(Atom.of_string n); v]))
+  List (List.map l ~f:(fun (n, v) ->
+    List [Atom(Atom.of_string_exn Atom.Dune n); v]))
 
 let sexp_of_position_no_file (p : Lexing.position) =
   record

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -34,8 +34,7 @@ module To_sexp = struct
   let string_set set = list atom (String.Set.to_list set)
   let string_map f map = list (pair atom f) (String.Map.to_list map)
   let record l =
-    List (List.map l ~f:(fun (n, v) ->
-      List [Atom(Atom.of_string_exn Usexp.Atom.Dune n); v]))
+    List (List.map l ~f:(fun (n, v) -> List [Atom(Atom.of_string n); v]))
   let string_hashtbl f h =
     string_map f
       (Hashtbl.foldi h ~init:String.Map.empty ~f:(fun key data acc ->
@@ -55,7 +54,7 @@ module To_sexp = struct
 
   let record_fields (l : field list) =
     List (List.filter_map l ~f:(fun (k, v) ->
-      Option.map v ~f:(fun v -> List[Atom (Atom.of_string_exn Atom.Dune k); v])))
+      Option.map v ~f:(fun v -> List[Atom (Atom.of_string k); v])))
 
   let unknown _ = unsafe_atom_of_string "<unknown>"
 end

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -296,13 +296,13 @@ module Of_sexp = struct
   let string = plain_string (fun ~loc:_ x -> x)
   let int =
     basic "Integer" (fun s ->
-      match int_of_string (s Atom.Dune) with
+      match int_of_string s with
       | x -> Ok x
       | exception _ -> Result.Error ())
 
   let float =
     basic "Float" (fun s ->
-      match float_of_string (s Atom.Dune) with
+      match float_of_string s with
       | x -> Ok x
       | exception _ -> Result.Error ())
 

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -299,13 +299,13 @@ module Of_sexp = struct
     basic "Integer" (fun s ->
       match int_of_string (s Atom.Dune) with
       | x -> Ok x
-      | exception _ -> Error ())
+      | exception _ -> Result.Error ())
 
   let float =
     basic "Float" (fun s ->
       match float_of_string (s Atom.Dune) with
       | x -> Ok x
-      | exception _ -> Error ())
+      | exception _ -> Result.Error ())
 
   let pair a b =
     enter
@@ -334,7 +334,7 @@ module Of_sexp = struct
   let string_map t =
     list (pair string t) >>= fun bindings ->
     match String.Map.of_list bindings with
-    | Ok x -> return x
+    | Result.Ok x -> return x
     | Error (key, _v1, _v2) ->
       loc >>= fun loc ->
       of_sexp_errorf loc "key %s present multiple times" key

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -34,7 +34,8 @@ module To_sexp = struct
   let string_set set = list atom (String.Set.to_list set)
   let string_map f map = list (pair atom f) (String.Map.to_list map)
   let record l =
-    List (List.map l ~f:(fun (n, v) -> List [Atom(Atom.of_string n); v]))
+    List (List.map l ~f:(fun (n, v) ->
+      List [Atom(Atom.of_string_exn Usexp.Atom.Dune n); v]))
   let string_hashtbl f h =
     string_map f
       (Hashtbl.foldi h ~init:String.Map.empty ~f:(fun key data acc ->
@@ -54,7 +55,7 @@ module To_sexp = struct
 
   let record_fields (l : field list) =
     List (List.filter_map l ~f:(fun (k, v) ->
-      Option.map v ~f:(fun v -> List[Atom (Atom.of_string k); v])))
+      Option.map v ~f:(fun v -> List[Atom (Atom.of_string_exn Atom.Dune k); v])))
 
   let unknown _ = unsafe_atom_of_string "<unknown>"
 end
@@ -296,13 +297,13 @@ module Of_sexp = struct
   let string = plain_string (fun ~loc:_ x -> x)
   let int =
     basic "Integer" (fun s ->
-      match int_of_string s with
+      match int_of_string (s Atom.Dune) with
       | x -> Ok x
       | exception _ -> Error ())
 
   let float =
     basic "Float" (fun s ->
-      match float_of_string s with
+      match float_of_string (s Atom.Dune) with
       | x -> Ok x
       | exception _ -> Error ())
 

--- a/src/usexp/atom.ml
+++ b/src/usexp/atom.ml
@@ -1,0 +1,55 @@
+type t = A of string [@@unboxed]
+
+let invalid_argf fmt = Printf.ksprintf invalid_arg fmt
+
+type syntax = Jbuild | Dune
+
+let string_of_syntax = function
+  | Jbuild -> "jbuild"
+  | Dune -> "dune"
+
+let (is_valid_jbuild, is_valid_dune) =
+  let rec jbuild s i len =
+    i = len ||
+    match String.unsafe_get s i with
+    | '"' | '(' | ')' | ';' | '\000'..'\032' | '\127'..'\255' -> false
+    | _ -> jbuild s (i + 1) len
+  in
+  let rec dune s i len =
+    i = len ||
+    match String.unsafe_get s i with
+    | '%' | '"' | '(' | ')' | ';' | '\000'..'\032' | '\127'..'\255' -> false
+    | _ -> dune s (i + 1) len
+  in
+  let make looper s =
+    let len = String.length s in
+    len > 0 && looper s 0 len
+  in
+  (make jbuild, make dune)
+
+let of_string syn s =
+  match syn with
+  | Jbuild when is_valid_jbuild s -> Some (A s)
+  | Dune when is_valid_dune s -> Some (A s)
+  | _ -> None
+
+let of_string_exn syn s =
+  match of_string syn s with
+  | Some s -> s
+  | None ->
+    invalid_argf "'%s' is not a valid %s atom" s (string_of_syntax syn)
+
+let to_string (A t) syntax =
+  match syntax with
+  | Jbuild -> t
+  | Dune ->
+    if is_valid_dune t then
+      t
+    else
+      invalid_argf "Jbuild atom '%s' is not a valid dune atom" t
+
+let of_int i = of_string_exn Dune (string_of_int i)
+let of_float x = of_string_exn Dune (string_of_float x)
+let of_bool x = of_string_exn Dune (string_of_bool x)
+let of_int64 i = of_string_exn Dune (Int64.to_string i)
+let of_digest d = of_string_exn Dune (Digest.to_hex d)

--- a/src/usexp/atom.ml
+++ b/src/usexp/atom.ml
@@ -31,18 +31,17 @@ let is_valid_jbuild str =
 let of_string s = A s
 let to_string (A s) = s
 
-let print (A t) syntax =
-  match syntax with
-  | Jbuild ->
-    if is_valid_jbuild t then
-      t
-    else
-      invalid_argf "Dune atom '%s' cannot be printed" t
-  | Dune ->
-    if is_valid_dune t then
-      t
-    else
-      invalid_argf "Jbuild atom '%s' cannot be printed" t
+let is_valid (A t) = function
+  | Jbuild -> is_valid_jbuild t
+  | Dune   -> is_valid_dune t
+
+let print ((A s) as t) syntax =
+  if is_valid t syntax then
+    s
+  else
+    match syntax with
+    | Jbuild -> invalid_argf "atom '%s' cannot be printed in jbuild syntax" s
+    | Dune -> invalid_argf "atom '%s' cannot be in dune syntax" s
 
 let of_int i = of_string (string_of_int i)
 let of_float x = of_string (string_of_float x)

--- a/src/usexp/atom.ml
+++ b/src/usexp/atom.ml
@@ -12,8 +12,12 @@ let (is_valid_jbuild, is_valid_dune) =
   let rec jbuild s i len =
     i = len ||
     match String.unsafe_get s i with
+    | '#' -> disallow_next '|' s (i + 1) len
+    | '|' -> disallow_next '#' s (i + 1) len
     | '"' | '(' | ')' | ';' | '\000'..'\032' | '\127'..'\255' -> false
     | _ -> jbuild s (i + 1) len
+  and disallow_next c s i len =
+    i = len || String.unsafe_get s i <> c && jbuild s i len
   in
   let rec dune s i len =
     i = len ||

--- a/src/usexp/atom.ml
+++ b/src/usexp/atom.ml
@@ -29,8 +29,9 @@ let is_valid_jbuild str =
   not (loop (len - 1))
 
 let of_string s = A s
+let to_string (A s) = s
 
-let to_string (A t) syntax =
+let print (A t) syntax =
   match syntax with
   | Jbuild ->
     if is_valid_jbuild t then

--- a/src/usexp/atom.ml
+++ b/src/usexp/atom.ml
@@ -4,10 +4,6 @@ let invalid_argf fmt = Printf.ksprintf invalid_arg fmt
 
 type syntax = Jbuild | Dune
 
-let string_of_syntax = function
-  | Jbuild -> "jbuild"
-  | Dune -> "dune"
-
 let (is_valid_jbuild, is_valid_dune) =
   let rec jbuild s i len =
     i = len ||
@@ -31,29 +27,23 @@ let (is_valid_jbuild, is_valid_dune) =
   in
   (make jbuild, make dune)
 
-let of_string syn s =
-  match syn with
-  | Jbuild when is_valid_jbuild s -> Some (A s)
-  | Dune when is_valid_dune s -> Some (A s)
-  | _ -> None
-
-let of_string_exn syn s =
-  match of_string syn s with
-  | Some s -> s
-  | None ->
-    invalid_argf "'%s' is not a valid %s atom" s (string_of_syntax syn)
+let of_string s = A s
 
 let to_string (A t) syntax =
   match syntax with
-  | Jbuild -> t
+  | Jbuild ->
+    if is_valid_jbuild t then
+      t
+    else
+      invalid_argf "Dune atom '%s' cannot be printed" t
   | Dune ->
     if is_valid_dune t then
       t
     else
-      invalid_argf "Jbuild atom '%s' is not a valid dune atom" t
+      invalid_argf "Jbuild atom '%s' cannot be printed" t
 
-let of_int i = of_string_exn Dune (string_of_int i)
-let of_float x = of_string_exn Dune (string_of_float x)
-let of_bool x = of_string_exn Dune (string_of_bool x)
-let of_int64 i = of_string_exn Dune (Int64.to_string i)
-let of_digest d = of_string_exn Dune (Digest.to_hex d)
+let of_int i = of_string (string_of_int i)
+let of_float x = of_string (string_of_float x)
+let of_bool x = of_string (string_of_bool x)
+let of_digest d = of_string (Digest.to_hex d)
+let of_int64 i = of_string (Int64.to_string i)

--- a/src/usexp/atom.mli
+++ b/src/usexp/atom.mli
@@ -5,8 +5,9 @@ type syntax = Jbuild | Dune
 val is_valid_dune : string -> bool
 
 val of_string : string -> t
+val to_string : t -> string
 
-val to_string : t -> syntax -> string
+val print : t -> syntax -> string
 
 val of_int : int -> t
 val of_float : float -> t

--- a/src/usexp/atom.mli
+++ b/src/usexp/atom.mli
@@ -3,6 +3,7 @@ type t = private A of string [@@unboxed]
 type syntax = Jbuild | Dune
 
 val is_valid_dune : string -> bool
+val is_valid : t -> syntax -> bool
 
 val of_string : string -> t
 val to_string : t -> string

--- a/src/usexp/atom.mli
+++ b/src/usexp/atom.mli
@@ -1,0 +1,15 @@
+type t = private A of string [@@unboxed]
+
+type syntax = Jbuild | Dune
+
+val of_string : syntax -> string -> t option
+
+val of_string_exn : syntax -> string -> t
+
+val to_string : t -> syntax -> string
+
+val of_int : int -> t
+val of_float : float -> t
+val of_bool : bool -> t
+val of_int64 : Int64.t -> t
+val of_digest : Digest.t -> t

--- a/src/usexp/atom.mli
+++ b/src/usexp/atom.mli
@@ -2,9 +2,9 @@ type t = private A of string [@@unboxed]
 
 type syntax = Jbuild | Dune
 
-val of_string : syntax -> string -> t option
+val is_valid_dune : string -> bool
 
-val of_string_exn : syntax -> string -> t
+val of_string : string -> t
 
 val to_string : t -> syntax -> string
 

--- a/src/usexp/lexer.mli
+++ b/src/usexp/lexer.mli
@@ -1,7 +1,3 @@
-module Atom : sig
-  type t = A of string [@@unboxed]
-end
-
 module Token : sig
   type t =
     | Atom          of Atom.t

--- a/src/usexp/lexer.mll
+++ b/src/usexp/lexer.mll
@@ -1,8 +1,4 @@
 {
-module Atom = struct
-  type t = A of string [@@unboxed]
-end
-
 module Token = struct
   type t =
     | Atom          of Atom.t
@@ -128,7 +124,7 @@ and jbuild_atom acc start = parse
         error lexbuf "Internal error in the S-expression parser, \
                       please report upstream.";
       lexbuf.lex_start_p <- start;
-      Token.Atom (A acc)
+      Token.Atom (Atom.of_string_exn Jbuild acc)
     }
 
 and quoted_string mode = parse
@@ -248,7 +244,7 @@ and token = parse
       Quoted_string s
     }
   | atom_char_dune+ as s
-    { Token.Atom (A s) }
+    { Token.Atom (Atom.of_string_exn Dune s) }
   | eof
     { Eof }
 

--- a/src/usexp/lexer.mll
+++ b/src/usexp/lexer.mll
@@ -77,7 +77,7 @@ let hexdigit  = ['0'-'9' 'a'-'f' 'A'-'F']
 let atom_char_jbuild =
   [^ ';' '(' ')' '"' ' ' '\t' '\r' '\n' '\012']
 let atom_char_dune =
-  [^ ';' '(' ')' '"' '\000'-'\032' '\127'-'\255']
+  [^ '%' ';' '(' ')' '"' '\000'-'\032' '\127'-'\255']
 
 (* rule for jbuild files *)
 rule jbuild_token = parse
@@ -124,7 +124,7 @@ and jbuild_atom acc start = parse
         error lexbuf "Internal error in the S-expression parser, \
                       please report upstream.";
       lexbuf.lex_start_p <- start;
-      Token.Atom (Atom.of_string_exn Jbuild acc)
+      Token.Atom (Atom.of_string acc)
     }
 
 and quoted_string mode = parse
@@ -244,7 +244,8 @@ and token = parse
       Quoted_string s
     }
   | atom_char_dune+ as s
-    { Token.Atom (Atom.of_string_exn Dune s) }
+    { Token.Atom (Atom.of_string s) }
+  | _ as c { error lexbuf (Printf.sprintf "Invalid atom character '%c'" c) }
   | eof
     { Eof }
 

--- a/src/usexp/usexp.ml
+++ b/src/usexp/usexp.ml
@@ -90,13 +90,13 @@ let quoted s =
   Bytes.unsafe_to_string s'
 
 let rec to_string = function
-  | Atom a -> Atom.to_string a Atom.Dune
+  | Atom a -> Atom.print a Atom.Dune
   | Quoted_string s -> quoted s
   | List l -> Printf.sprintf "(%s)" (List.map l ~f:to_string |> String.concat ~sep:" ")
 
 let rec pp ppf = function
   | Atom s ->
-    Format.pp_print_string ppf (Atom.to_string s Atom.Dune)
+    Format.pp_print_string ppf (Atom.print s Atom.Dune)
   | Quoted_string s ->
     Format.pp_print_string ppf (quoted s)
   | List [] ->
@@ -137,7 +137,7 @@ let pp_print_quoted_string ppf s =
     Format.pp_print_string ppf (quoted s)
 
 let rec pp_split_strings ppf = function
-  | Atom s -> Format.pp_print_string ppf (Atom.to_string s Atom.Dune)
+  | Atom s -> Format.pp_print_string ppf (Atom.print s Atom.Dune)
   | Quoted_string s -> pp_print_quoted_string ppf s
   | List [] ->
     Format.pp_print_string ppf "()"

--- a/src/usexp/usexp.ml
+++ b/src/usexp/usexp.ml
@@ -19,14 +19,15 @@ type t =
 
 type sexp = t
 
-let atom s = Atom (Atom.of_string_exn Dune s)
+let atom s = Atom (Atom.of_string s)
 
 let unsafe_atom_of_string s = atom s
 
 let atom_or_quoted_string s =
-  match Atom.of_string Atom.Dune s with
-  | None -> Quoted_string s
-  | Some a -> Atom a
+  if Atom.is_valid_dune s then
+    Atom (Atom.of_string s)
+  else
+    Quoted_string s
 
 let quote_length s =
   let n = ref 0 in
@@ -221,9 +222,10 @@ module Ast = struct
     | List of Loc.t * t list
 
   let atom_or_quoted_string loc s =
-    match Atom.of_string Atom.Dune s with
-    | None -> Quoted_string (loc, s)
-    | Some a -> Atom (loc, a)
+    match atom_or_quoted_string s with
+    | Atom a -> Atom (loc, a)
+    | Quoted_string s -> Quoted_string (loc, s)
+    | List _ -> assert false
 
   let loc (Atom (loc, _) | Quoted_string (loc, _) | List (loc, _)) = loc
 

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -9,7 +9,7 @@ module Atom : sig
 
   type syntax = Jbuild | Dune
 
-  val is_valid_dune : string -> bool
+  val is_valid : t -> syntax -> bool
 
   val of_string : string -> t
   val to_string : t -> string

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -12,8 +12,7 @@ module Atom : sig
   val is_valid_dune : string -> bool
 
   val of_string : string -> t
-
-  val to_string : t -> syntax -> string
+  val to_string : t -> string
 
   val of_int : int -> t
   val of_float : float -> t

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -4,8 +4,6 @@
 
 module Atom : sig
   type t = private A of string [@@unboxed]
-  (** Acceptable atoms are composed of chars in the range ['!' .. '~'] excluding
-      [' ' '"' '(' ')' ';' '\\'], and must be nonempty. *)
 
   type syntax = Jbuild | Dune
 

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -7,20 +7,19 @@ module Atom : sig
   (** Acceptable atoms are composed of chars in the range ['!' .. '~'] excluding
       [' ' '"' '(' ')' ';' '\\'], and must be nonempty. *)
 
-  val is_valid : string -> bool
-  (** [is_valid s] checks that [s] respects the constraints to be an atom. *)
+  type syntax = Jbuild | Dune
 
- val of_string : string -> t
-  (** Convert a string to an atom.  If the string contains invalid
-     characters, raise [Invalid_argument]. *)
+ val of_string : syntax -> string -> t option
+
+ val of_string_exn : syntax -> string -> t
+
+  val to_string : t -> syntax -> string
 
   val of_int : int -> t
   val of_float : float -> t
   val of_bool : bool -> t
   val of_int64 : Int64.t -> t
   val of_digest : Digest.t -> t
-
-  val to_string : t -> string
 end
 
 module Loc : sig

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -9,9 +9,9 @@ module Atom : sig
 
   type syntax = Jbuild | Dune
 
- val of_string : syntax -> string -> t option
+  val is_valid_dune : string -> bool
 
- val of_string_exn : syntax -> string -> t
+  val of_string : string -> t
 
   val to_string : t -> syntax -> string
 

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -140,7 +140,7 @@ parse {|"$bar%foo%"|}
 
 parse {|\%{foo}|}
 [%%expect{|
-- : parse_result = Same (Ok [\%{foo}])
+Exception: Invalid_argument "'\\%{foo}' is not a valid dune atom".
 |}]
 
 parse {|\${foo}|}
@@ -150,15 +150,15 @@ parse {|\${foo}|}
 
 parse {|\$bar%foo%|}
 [%%expect{|
-- : parse_result = Same (Ok [\$bar%foo%])
+Exception: Invalid_argument "'\\$bar%foo%' is not a valid dune atom".
 |}]
 
 parse {|\$bar\%foo%|}
 [%%expect{|
-- : parse_result = Same (Ok [\$bar\%foo%])
+Exception: Invalid_argument "'\\$bar\\%foo%' is not a valid dune atom".
 |}]
 
 parse {|\$bar\%foo%{bar}|}
 [%%expect{|
-- : parse_result = Same (Ok [\$bar\%foo%{bar}])
+Exception: Invalid_argument "'\\$bar\\%foo%{bar}' is not a valid dune atom".
 |}]

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -2,9 +2,21 @@
 open Stdune;;
 open Sexp.Of_sexp;;
 
-let pp_sexp_ast ppf sexp =
-  Sexp.pp ppf (Sexp.Ast.remove_locs sexp)
+let pp_sexp_ast =
+  let rec subst_atoms ~f (s : Sexp.t) =
+    match s with
+    | Atom a -> f a
+    | Quoted_string _ -> s
+    | List xs -> List (List.map ~f:(subst_atoms ~f) xs)
+  in
+  fun ppf sexp ->
+    sexp
+    |> Sexp.Ast.remove_locs
+    |> subst_atoms ~f:(fun (A s) ->
+      List [(Sexp.atom "atom"); Sexp.atom_or_quoted_string s])
+    |> Sexp.pp ppf
 ;;
+
 #install_printer pp_sexp_ast;;
 [%%expect{|
 val pp_sexp_ast : Format.formatter -> Stdune.Sexp.Ast.t -> unit = <fun>
@@ -20,7 +32,7 @@ let sexp = Sexp.parse_string ~fname:"" ~mode:Single {|
  (foo 2))
 |}
 [%%expect{|
-val sexp : Usexp.Ast.t = ((foo 1) (foo 2))
+val sexp : Usexp.Ast.t = (((atom foo) (atom 1)) ((atom foo) (atom 2)))
 |}]
 
 let of_sexp = record (field "foo" int)
@@ -75,26 +87,34 @@ val parse : string -> parse_result = <fun>
 
 parse {| # ## x##y x||y a#b|c#d copy# |}
 [%%expect{|
-- : parse_result = Same (Ok [#; ##; x##y; x||y; a#b|c#d; copy#])
+- : parse_result =
+Same
+ (Ok
+   [(atom #); (atom ##); (atom x##y); (atom x||y); (atom a#b|c#d);
+    (atom copy#)])
 |}]
 
 
 parse {|x #| comment |# y|}
 [%%expect{|
 - : parse_result =
-Different {jbuild = Ok [x; y]; dune = Ok [x; #|; comment; |#; y]}
+Different
+ {jbuild = Ok [(atom x); (atom y)];
+  dune = Ok [(atom x); (atom #|); (atom comment); (atom |#); (atom y)]}
 |}]
 
 parse {|x#|y|}
 [%%expect{|
 - : parse_result =
-Different {jbuild = Error "jbuild_atoms cannot contain #|"; dune = Ok [x#|y]}
+Different
+ {jbuild = Error "jbuild_atoms cannot contain #|"; dune = Ok [(atom x#|y)]}
 |}]
 
 parse {|x|#y|}
 [%%expect{|
 - : parse_result =
-Different {jbuild = Error "jbuild_atoms cannot contain |#"; dune = Ok [x|#y]}
+Different
+ {jbuild = Error "jbuild_atoms cannot contain |#"; dune = Ok [(atom x|#y)]}
 |}]
 
 parse {|"\a"|}
@@ -139,28 +159,23 @@ parse {|"$bar%foo%"|}
 - : parse_result = Same (Ok ["$bar%foo%"])
 |}]
 
+parse {|\${foo}|}
+[%%expect{|
+- : parse_result = Same (Ok [(atom \${foo})])
+|}]
+
 parse {|\%{foo}|}
 [%%expect{|
 - : parse_result =
 Different
- {jbuild =
-   Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\%{foo}' cannot be in dune syntax")>];
-  dune = Error "Invalid atom character '%'"}
-|}]
-
-parse {|\${foo}|}
-[%%expect{|
-- : parse_result = Same (Ok [\${foo}])
+ {jbuild = Ok [(atom "\\%{foo}")]; dune = Error "Invalid atom character '%'"}
 |}]
 
 parse {|\$bar%foo%|}
 [%%expect{|
 - : parse_result =
 Different
- {jbuild =
-   Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\$bar%foo%' cannot be in dune syntax")>];
+ {jbuild = Ok [(atom "\\$bar%foo%")];
   dune = Error "Invalid atom character '%'"}
 |}]
 
@@ -168,9 +183,7 @@ parse {|\$bar\%foo%|}
 [%%expect{|
 - : parse_result =
 Different
- {jbuild =
-   Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\$bar\\%foo%' cannot be in dune syntax")>];
+ {jbuild = Ok [(atom "\\$bar\\%foo%")];
   dune = Error "Invalid atom character '%'"}
 |}]
 
@@ -178,8 +191,6 @@ parse {|\$bar\%foo%{bar}|}
 [%%expect{|
 - : parse_result =
 Different
- {jbuild =
-   Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\$bar\\%foo%{bar}' cannot be in dune syntax")>];
+ {jbuild = Ok [(atom "\\$bar\\%foo%{bar}")];
   dune = Error "Invalid atom character '%'"}
 |}]

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -145,7 +145,7 @@ parse {|\%{foo}|}
 Different
  {jbuild =
    Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\%{foo}' cannot be printed")>];
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\%{foo}' cannot be in dune syntax")>];
   dune = Error "Invalid atom character '%'"}
 |}]
 
@@ -160,7 +160,7 @@ parse {|\$bar%foo%|}
 Different
  {jbuild =
    Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\$bar%foo%' cannot be printed")>];
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\$bar%foo%' cannot be in dune syntax")>];
   dune = Error "Invalid atom character '%'"}
 |}]
 
@@ -170,7 +170,7 @@ parse {|\$bar\%foo%|}
 Different
  {jbuild =
    Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\$bar\\%foo%' cannot be printed")>];
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\$bar\\%foo%' cannot be in dune syntax")>];
   dune = Error "Invalid atom character '%'"}
 |}]
 
@@ -180,6 +180,6 @@ parse {|\$bar\%foo%{bar}|}
 Different
  {jbuild =
    Ok
-    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\$bar\\%foo%{bar}' cannot be printed")>];
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("atom '\\$bar\\%foo%{bar}' cannot be in dune syntax")>];
   dune = Error "Invalid atom character '%'"}
 |}]

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -52,8 +52,9 @@ let parse s =
   let f ~lexer =
     try
       Ok (Sexp.parse_string ~fname:"" ~mode:Many ~lexer s)
-    with Sexp.Parse_error e ->
-      Error (Sexp.Parse_error.message e)
+    with
+    | Sexp.Parse_error e -> Error (Sexp.Parse_error.message e)
+    | Invalid_argument e -> Error e
   in
   let jbuild = f ~lexer:Sexp.Lexer.jbuild_token in
   let dune   = f ~lexer:Sexp.Lexer.token        in
@@ -140,7 +141,12 @@ parse {|"$bar%foo%"|}
 
 parse {|\%{foo}|}
 [%%expect{|
-Exception: Invalid_argument "'\\%{foo}' is not a valid dune atom".
+- : parse_result =
+Different
+ {jbuild =
+   Ok
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\%{foo}' cannot be printed")>];
+  dune = Error "Invalid atom character '%'"}
 |}]
 
 parse {|\${foo}|}
@@ -150,15 +156,30 @@ parse {|\${foo}|}
 
 parse {|\$bar%foo%|}
 [%%expect{|
-Exception: Invalid_argument "'\\$bar%foo%' is not a valid dune atom".
+- : parse_result =
+Different
+ {jbuild =
+   Ok
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\$bar%foo%' cannot be printed")>];
+  dune = Error "Invalid atom character '%'"}
 |}]
 
 parse {|\$bar\%foo%|}
 [%%expect{|
-Exception: Invalid_argument "'\\$bar\\%foo%' is not a valid dune atom".
+- : parse_result =
+Different
+ {jbuild =
+   Ok
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\$bar\\%foo%' cannot be printed")>];
+  dune = Error "Invalid atom character '%'"}
 |}]
 
 parse {|\$bar\%foo%{bar}|}
 [%%expect{|
-Exception: Invalid_argument "'\\$bar\\%foo%{bar}' is not a valid dune atom".
+- : parse_result =
+Different
+ {jbuild =
+   Ok
+    [<printer pp_sexp_ast raised an exception: Invalid_argument("Jbuild atom '\\$bar\\%foo%{bar}' cannot be printed")>];
+  dune = Error "Invalid atom character '%'"}
 |}]

--- a/test/unit-tests/sexp_tests.ml
+++ b/test/unit-tests/sexp_tests.ml
@@ -23,13 +23,15 @@ let () =
         | Atom _ -> true
         | _      -> false
       in
-      if Usexp.Atom.is_valid s <> parser_recognizes_as_atom then begin
+      let valid_dune_atom =
+        Option.is_some (Usexp.Atom.of_string Dune s) in
+      if valid_dune_atom <> parser_recognizes_as_atom then begin
         Printf.eprintf
           "Usexp.Atom.is_valid error:\n\
            - s = %S\n\
            - Usexp.Atom.is_valid s = %B\n\
            - parser_recognizes_as_atom = %B\n"
-          s (Usexp.Atom.is_valid s) parser_recognizes_as_atom;
+          s valid_dune_atom parser_recognizes_as_atom;
         exit 1
       end;
       if printed_as_atom && not parser_recognizes_as_atom then begin

--- a/test/unit-tests/sexp_tests.ml
+++ b/test/unit-tests/sexp_tests.ml
@@ -4,43 +4,58 @@ let () = Printexc.record_backtrace true
 
 (* Test that all strings of length <= 3 such that [Usexp.Atom.is_valid
    s] are recignized as atoms by the parser *)
+
+let string_of_syntax (x : Usexp.Atom.syntax) =
+  match x with
+  | Dune -> "dune"
+  | Jbuild -> "jbuild"
+
 let () =
-  for len = 0 to 3 do
-    let s = Bytes.create len in
-    for i = 0 to 1 lsl (len * 8) - 1 do
-      if len > 0 then Bytes.set s 0 (Char.chr ( i        land 0xff));
-      if len > 1 then Bytes.set s 1 (Char.chr ((i lsr 4) land 0xff));
-      if len > 2 then Bytes.set s 2 (Char.chr ((i lsr 8) land 0xff));
-      let s = Bytes.unsafe_to_string s in
-      let parser_recognizes_as_atom =
-        match Usexp.parse_string ~fname:"" ~mode:Single s with
-        | exception _    -> false
-        | Atom (_, A s') -> s = s'
-        | _              -> false
-      in
-      let printed_as_atom =
-        match Usexp.atom_or_quoted_string s with
-        | Atom _ -> true
-        | _      -> false
-      in
-      let valid_dune_atom = Usexp.Atom.is_valid_dune s in
-      if valid_dune_atom <> parser_recognizes_as_atom then begin
-        Printf.eprintf
-          "Usexp.Atom.is_valid error:\n\
-           - s = %S\n\
-           - Usexp.Atom.is_valid s = %B\n\
-           - parser_recognizes_as_atom = %B\n"
-          s valid_dune_atom parser_recognizes_as_atom;
-        exit 1
-      end;
-      if printed_as_atom && not parser_recognizes_as_atom then begin
-        Printf.eprintf
-          "Usexp.Atom.atom_or_quoted_string error:\n\
-           - s = %S\n\
-           - printed_as_atom = %B\n\
-           - parser_recognizes_as_atom = %B\n"
-          s printed_as_atom parser_recognizes_as_atom;
-        exit 1
-      end
+  [ Usexp.Atom.Dune, Usexp.Lexer.token, (fun s -> Usexp.Atom.is_valid s Dune)
+  ; Jbuild, Usexp.Lexer.jbuild_token, (fun s -> Usexp.Atom.is_valid s Jbuild)
+  ]
+  |> List.iter ~f:(fun (syntax, lexer, validator) ->
+    for len = 0 to 3 do
+      let s = Bytes.create len in
+      for i = 0 to 1 lsl (len * 8) - 1 do
+        if len > 0 then Bytes.set s 0 (Char.chr ( i        land 0xff));
+        if len > 1 then Bytes.set s 1 (Char.chr ((i lsr 4) land 0xff));
+        if len > 2 then Bytes.set s 2 (Char.chr ((i lsr 8) land 0xff));
+        let s = Bytes.unsafe_to_string s in
+        let parser_recognizes_as_atom =
+          match Usexp.parse_string ~lexer ~fname:"" ~mode:Single s with
+          | exception _    -> false
+          | Atom (_, A s') -> s = s'
+          | _              -> false
+        in
+        let printed_as_atom =
+          match Usexp.atom_or_quoted_string s with
+          | Atom _ -> true
+          | _      -> false
+        in
+        let valid_dune_atom = validator (Usexp.Atom.of_string s) in
+        if valid_dune_atom <> parser_recognizes_as_atom then begin
+          Printf.eprintf
+            "Usexp.Atom.is_valid error:\n\
+             - syntax = %s\n\
+             - s = %S\n\
+             - Usexp.Atom.is_valid s = %B\n\
+             - parser_recognizes_as_atom = %B\n"
+            (string_of_syntax syntax) s valid_dune_atom
+            parser_recognizes_as_atom;
+          exit 1
+        end;
+        if printed_as_atom && not parser_recognizes_as_atom then begin
+          Printf.eprintf
+            "Usexp.Atom.atom_or_quoted_string error:\n\
+            - syntax = %s\n\
+             - s = %S\n\
+             - printed_as_atom = %B\n\
+             - parser_recognizes_as_atom = %B\n"
+            (string_of_syntax syntax) s printed_as_atom
+            parser_recognizes_as_atom;
+          exit 1
+        end
+      done
     done
-  done
+  )

--- a/test/unit-tests/sexp_tests.ml
+++ b/test/unit-tests/sexp_tests.ml
@@ -23,8 +23,7 @@ let () =
         | Atom _ -> true
         | _      -> false
       in
-      let valid_dune_atom =
-        Option.is_some (Usexp.Atom.of_string Dune s) in
+      let valid_dune_atom = Usexp.Atom.is_valid_dune s in
       if valid_dune_atom <> parser_recognizes_as_atom then begin
         Printf.eprintf
           "Usexp.Atom.is_valid error:\n\


### PR DESCRIPTION
Atoms can now be constructed and pretty printed with a syntax = Jbuild | Dune.
The syntax controls validation that will be used to make sure we are printing
something/reading valid

An issue here is that I'm hard coding the dune syntax in a couple of places where we should probably be flexible - like the sub systems file. But it seems to work.