### PR TITLE
User context in S-expression parsers

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -626,7 +626,8 @@ module Promotion = struct
   let load_db () =
     if Path.exists db_file then
       Sexp.Of_sexp.(
-        parse (list File.t) (Io.Sexp.load db_file ~mode:Many_as_one))
+        parse (list File.t) Univ_map.empty
+          (Io.Sexp.load db_file ~mode:Many_as_one))
     else
       []
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -19,7 +19,7 @@ module Promoted_to_delete = struct
   let load () =
     if Path.exists fn then
       Io.Sexp.load fn ~mode:Many
-      |> List.map ~f:(Sexp.Of_sexp.parse Path.t)
+      |> List.map ~f:(Sexp.Of_sexp.parse Path.t Univ_map.empty)
     else
       []
 
@@ -1220,7 +1220,8 @@ let update_universe t =
   Utils.Cached_digest.remove universe_file;
   let n =
     if Path.exists universe_file then
-      Sexp.Of_sexp.(parse int) (Io.Sexp.load ~mode:Single universe_file) + 1
+      Sexp.Of_sexp.(parse int) Univ_map.empty
+        (Io.Sexp.load ~mode:Single universe_file) + 1
     else
       0
   in

--- a/src/config.ml
+++ b/src/config.ml
@@ -115,7 +115,7 @@ let user_config_file =
     "dune/config"
 
 let load_config_file p =
-  (Sexp.Of_sexp.parse t) (Io.Sexp.load p ~mode:Many_as_one)
+  (Sexp.Of_sexp.parse t Univ_map.empty) (Io.Sexp.load p ~mode:Many_as_one)
 
 let load_user_config_file () =
   if Path.exists user_config_file then

--- a/src/context.ml
+++ b/src/context.ml
@@ -425,7 +425,7 @@ let create_for_opam ?root ~env ~targets ~profile ~switch ~name
     >>= fun s ->
     let vars =
       Usexp.parse_string ~fname:"<opam output>" ~mode:Single s
-      |> Sexp.Of_sexp.(parse (list (pair string string)))
+      |> Sexp.Of_sexp.(parse (list (pair string string)) Univ_map.empty)
       |> Env.Map.of_list_multi
       |> Env.Map.mapi ~f:(fun var values ->
         match List.rev values with

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -112,19 +112,17 @@ end = struct
 end
 
 type t =
-  { kind                  : Kind.t
-  ; name                  : Name.t
-  ; root                  : Path.Local.t
-  ; version               : string option
-  ; packages              : Package.t Package.Name.Map.t
-  ; mutable stanza_parser : Stanza.t list Sexp.Of_sexp.t
-  ; mutable project_file  : Path.t option
+  { kind                 : Kind.t
+  ; name                 : Name.t
+  ; root                 : Path.Local.t
+  ; version              : string option
+  ; packages             : Package.t Package.Name.Map.t
+  ; stanza_parser        : Stanza.t list Sexp.Of_sexp.t
+  ; mutable project_file : Path.t option
   }
 
-type project = t
-
 module Lang = struct
-  type t = Syntax.Version.t * (project -> Stanza.Parser.t list)
+  type t = Syntax.Version.t * Stanza.Parser.t list
 
   let make ver f = (ver, f)
 
@@ -161,9 +159,7 @@ module Lang = struct
 end
 
 module Extension = struct
-  type maker = project -> Stanza.Parser.t list Sexp.Of_sexp.t
-
-  type t = Syntax.Version.t * maker
+  type t = Syntax.Version.t * Stanza.Parser.t list Sexp.Of_sexp.t
 
   let make ver f = (ver, f)
 
@@ -184,6 +180,15 @@ module Extension = struct
       Syntax.Versioned_parser.find_exn versions ~loc:ver_loc ~data_version:ver
 end
 
+let key = Univ_map.Key.create ()
+let set t = Sexp.Of_sexp.set key t
+let get_exn () =
+  let open Sexp.Of_sexp in
+  get key >>| function
+  | Some t -> t
+  | None ->
+    Exn.code_error "Current project is unset" []
+
 let filename = "dune-project"
 
 let get_local_path p =
@@ -191,23 +196,15 @@ let get_local_path p =
   | External _ -> assert false
   | Local    p -> p
 
-let fake_stanza_parser =
-  let open Sexp.Of_sexp in
-  return () >>| fun _ -> assert false
-
-let anonymous = lazy(
-  let t =
-    { kind          = Dune
-    ; name          = Name.anonymous_root
-    ; packages      = Package.Name.Map.empty
-    ; root          = get_local_path Path.root
-    ; version       = None
-    ; stanza_parser = fake_stanza_parser
-    ; project_file  = None
-    }
-  in
-  t.stanza_parser <- Sexp.Of_sexp.sum (snd (Lang.latest "dune") t);
-  t)
+let anonymous = lazy (
+  { kind          = Dune
+  ; name          = Name.anonymous_root
+  ; packages      = Package.Name.Map.empty
+  ; root          = get_local_path Path.root
+  ; version       = None
+  ; stanza_parser = Sexp.Of_sexp.sum (snd (Lang.latest "dune"))
+  ; project_file  = None
+  })
 
 let default_name ~dir ~packages =
   match Package.Name.Map.choose packages with
@@ -237,21 +234,11 @@ let parse ~dir ~lang_stanzas ~packages ~file =
   record
     (name ~dir ~packages >>= fun name ->
      field_o "version" string >>= fun version ->
-     let t =
-       { kind = Dune
-       ; name
-       ; root = get_local_path dir
-       ; version
-       ; packages
-       ; stanza_parser = fake_stanza_parser
-       ; project_file  = Some file
-       }
-     in
      multi_field "using"
        (loc >>= fun loc ->
         located string >>= fun name ->
         located Syntax.Version.t >>= fun ver ->
-        Extension.lookup name ver t >>= fun stanzas ->
+        Extension.lookup name ver >>= fun stanzas ->
         return (snd name, (loc, stanzas)))
      >>= fun extensions ->
      let extensions_stanzas =
@@ -261,8 +248,15 @@ let parse ~dir ~lang_stanzas ~packages ~file =
        | Ok _ ->
          List.concat_map extensions ~f:(fun (_, (_, x)) -> x)
      in
-     t.stanza_parser <- Sexp.Of_sexp.sum (lang_stanzas t @ extensions_stanzas);
-     return t)
+     return
+       { kind = Dune
+       ; name
+       ; root = get_local_path dir
+       ; version
+       ; packages
+       ; stanza_parser = Sexp.Of_sexp.sum (lang_stanzas @ extensions_stanzas)
+       ; project_file  = Some file
+       })
 
 let load_dune_project ~dir packages =
   let fname = Path.relative dir filename in
@@ -273,18 +267,14 @@ let load_dune_project ~dir packages =
       Univ_map.empty sexp)
 
 let make_jbuilder_project ~dir packages =
-  let t =
-    { kind = Jbuilder
-    ; name = default_name ~dir ~packages
-    ; root = get_local_path dir
-    ; version = None
-    ; packages
-    ; stanza_parser = fake_stanza_parser
-    ; project_file = None
-    }
-  in
-  t.stanza_parser <- Sexp.Of_sexp.sum (snd (Lang.latest "dune") t);
-  t
+  { kind = Jbuilder
+  ; name = default_name ~dir ~packages
+  ; root = get_local_path dir
+  ; version = None
+  ; packages
+  ; stanza_parser = Sexp.Of_sexp.sum (snd (Lang.latest "dune"))
+  ; project_file = None
+  }
 
 let load ~dir ~files =
   let packages =
@@ -344,4 +334,3 @@ let append_to_project_file t str =
       output_string oc s;
       let len = String.length s in
       if len > 0 && s.[len - 1] <> '\n' then output_char oc '\n'))
-

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -143,7 +143,7 @@ module Lang = struct
         } = first_line
     in
     let ver =
-      Sexp.Of_sexp.parse Syntax.Version.t
+      Sexp.Of_sexp.parse Syntax.Version.t Univ_map.empty
         (Atom (ver_loc, Sexp.Atom.of_string ver)) in
     match Hashtbl.find langs name with
     | None ->
@@ -269,7 +269,8 @@ let load_dune_project ~dir packages =
   Io.with_lexbuf_from_file fname ~f:(fun lb ->
     let lang_stanzas = Lang.parse (Dune_lexer.first_line lb) in
     let sexp = Sexp.Parser.parse lb ~mode:Many_as_one in
-    Sexp.Of_sexp.parse (parse ~dir ~lang_stanzas ~packages ~file:fname) sexp)
+    Sexp.Of_sexp.parse (parse ~dir ~lang_stanzas ~packages ~file:fname)
+      Univ_map.empty sexp)
 
 let make_jbuilder_project ~dir packages =
   let t =

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -31,18 +31,16 @@ end
 
 (* CR-soon diml: make this abstract *)
 type t = private
-  { kind                  : Kind.t
-  ; name                  : Name.t
-  ; root                  : Path.Local.t
-  ; version               : string option
-  ; packages              : Package.t Package.Name.Map.t
-  ; mutable stanza_parser : Stanza.t list Sexp.Of_sexp.t
-  ; mutable project_file  : Path.t option
+  { kind                 : Kind.t
+  ; name                 : Name.t
+  ; root                 : Path.Local.t
+  ; version              : string option
+  ; packages             : Package.t Package.Name.Map.t
+  ; stanza_parser        : Stanza.t list Sexp.Of_sexp.t
+  ; mutable project_file : Path.t option
   }
 
 module Lang : sig
-  type project = t
-
   (** One version of a language *)
   type t
 
@@ -53,10 +51,7 @@ module Lang : sig
 
       as the first line of their [dune-project] file. [stanza_parsers]
       defines what stanzas the user can write in [dune] files. *)
-  val make
-    :  Syntax.Version.t
-    -> (project -> Stanza.Parser.t list)
-    -> t
+  val make : Syntax.Version.t -> Stanza.Parser.t list -> t
 
   val version : t -> Syntax.Version.t
 
@@ -65,11 +60,9 @@ module Lang : sig
 
   (** Latest version of the following language *)
   val latest : string -> t
-end with type project := t
+end
 
 module Extension : sig
-  type project = t
-
   (** One version of an extension *)
   type t
 
@@ -80,14 +73,11 @@ module Extension : sig
 
       in their [dune-project] file. [parser] is used to describe
       what [<args>] might be.  *)
-  val make
-    :  Syntax.Version.t
-    -> (project -> Stanza.Parser.t list Sexp.Of_sexp.t)
-    -> t
+  val make : Syntax.Version.t -> Stanza.Parser.t list Sexp.Of_sexp.t -> t
 
   (** Register all the supported versions of an extension *)
   val register : string -> t list -> unit
-end with type project := t
+end
 
 (** Load a project description from the following directory. [files]
     is the set of files in this directory. *)
@@ -105,3 +95,7 @@ val ensure_project_file_exists : t -> unit
 
 (** Append the following text to the project file *)
 val append_to_project_file : t -> string -> unit
+
+(** Set the project we are currently parsing dune files for *)
+val set : t -> ('a, 'k) Sexp.Of_sexp.parser -> ('a, 'k) Sexp.Of_sexp.parser
+val get_exn : unit -> (t, 'k) Sexp.Of_sexp.parser

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -60,7 +60,7 @@ module Dune_file = struct
         List.partition_map sexps ~f:(fun sexp ->
           match (sexp : Sexp.Ast.t) with
           | List (_, (Atom (_, A "ignored_subdirs") :: _)) ->
-            Left (Sexp.Of_sexp.parse stanza sexp)
+            Left (Sexp.Of_sexp.parse stanza Univ_map.empty sexp)
           | _ -> Right sexp)
       in
       let ignored_subdirs =

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -3,7 +3,8 @@ open Import
 let parse_sub_systems sexps =
   List.filter_map sexps ~f:(fun sexp ->
     let name, ver, data =
-      Sexp.Of_sexp.(parse (triple string (located Syntax.Version.t) raw)) sexp
+      Sexp.Of_sexp.(parse (triple string (located Syntax.Version.t) raw)
+                      Univ_map.empty) sexp
     in
     match Sub_system_name.get name with
     | None ->
@@ -24,7 +25,7 @@ let parse_sub_systems sexps =
       Syntax.Versioned_parser.find_exn M.parsers ~loc:vloc
         ~data_version:ver
     in
-    M.T (Sexp.Of_sexp.parse parser data))
+    M.T (Sexp.Of_sexp.parse parser Univ_map.empty data))
 
 let of_sexp =
   let open Sexp.Of_sexp in
@@ -42,7 +43,8 @@ let of_sexp =
        parse_sub_systems l)
     ]
 
-let load fname = Sexp.Of_sexp.parse of_sexp (Io.Sexp.load ~mode:Single fname)
+let load fname =
+  Sexp.Of_sexp.parse of_sexp Univ_map.empty (Io.Sexp.load ~mode:Single fname)
 
 let gen confs =
   let sexps =

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -1354,7 +1354,7 @@ module Stanzas = struct
   exception Include_loop of Path.t * (Loc.t * Path.t) list
 
   let rec parse stanza_parser ~current_file ~include_stack sexps =
-    List.concat_map sexps ~f:(Sexp.Of_sexp.parse stanza_parser)
+    List.concat_map sexps ~f:(Sexp.Of_sexp.parse stanza_parser Univ_map.empty)
     |> List.concat_map ~f:(function
       | Include (loc, fn) ->
         let include_stack = (loc, current_file) :: include_stack in

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -2,13 +2,6 @@
 
 open Import
 
-module Jbuild_version : sig
-  type t = V1
-  val t : t Sexp.Of_sexp.t
-
-  val latest_stable : t
-end
-
 (** Ppx preprocessors  *)
 module Pp : sig
   type t = private string

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -181,7 +181,7 @@ module Unexpanded = struct
       match t with
       | Element x -> Element x
       | Union [Special (_, "include"); Element fn] ->
-        Include (Sexp.Of_sexp.parse String_with_vars.t fn)
+        Include (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty fn)
       | Union [Special (loc, "include"); _]
       | Special (loc, "include") ->
         Loc.fail loc "(:include expects a single element (do you need to quote the filename?)"
@@ -246,7 +246,8 @@ module Unexpanded = struct
       let open Ast in
       match t with
       | Element s ->
-        Element (Sexp.Ast.loc s, f (Sexp.Of_sexp.parse String_with_vars.t s))
+        Element (Sexp.Ast.loc s,
+                 f (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty s))
       | Special (l, s) -> Special (l, s)
       | Include fn ->
         let sexp =
@@ -262,7 +263,8 @@ module Unexpanded = struct
               ]
         in
         parse_general sexp ~f:(fun sexp ->
-          (Sexp.Ast.loc sexp, f (Sexp.Of_sexp.parse String_with_vars.t sexp)))
+          (Sexp.Ast.loc sexp,
+           f (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty sexp)))
       | Union l -> Union (List.map l ~f:expand)
       | Diff (l, r) ->
         Diff (expand l, expand r)

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -182,7 +182,7 @@ module Jbuild_driver = struct
   let make name info : (Pp.t * Driver.t) Lazy.t = lazy (
     let info =
       Sexp.parse_string ~mode:Single ~fname:"<internal>" info
-      |> Sexp.Of_sexp.parse Driver.Info.parse
+      |> Sexp.Of_sexp.parse Driver.Info.parse Univ_map.empty
     in
     (Pp.of_string name,
      { info

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -94,14 +94,21 @@ module Of_sexp : sig
   type 'a t             = ('a, values) parser
   type 'a fields_parser = ('a, fields) parser
 
-  (** Parse a S-expression using the following parser *)
-  val parse : 'a t -> ast -> 'a
+  (** [parse parser context sexp] parse a S-expression using the
+      following parser. The input consist of a single
+      S-expression. [context] allows to pass extra informations such as
+      versions to individual parsers. *)
+  val parse : 'a t -> Univ_map.t -> ast -> 'a
 
   val return : 'a -> ('a, _) parser
   val (>>=) : ('a, 'k) parser -> ('a -> ('b, 'k) parser) -> ('b, 'k) parser
   val (>>|) : ('a, 'k) parser -> ('a -> 'b) -> ('b, 'k) parser
   val (>>>) : (unit, 'k) parser -> ('a, 'k) parser -> ('a, 'k) parser
   val map : ('a, 'k) parser -> f:('a -> 'b) -> ('b, 'k) parser
+
+  (** Access to the context *)
+  val get : 'a Univ_map.Key.t -> ('a option, _) parser
+  val set : 'a Univ_map.Key.t -> 'a -> ('b, 'k) parser -> ('b, 'k) parser
 
   (** Return the location of the list currently being parsed. *)
   val loc : (Loc.t, _) parser

--- a/src/vfile_kind.ml
+++ b/src/vfile_kind.ml
@@ -66,7 +66,7 @@ module Make
 struct
   module Of_sexp = struct
     include F(Sexp.Of_sexp)
-    let t _ sexp = Sexp.Of_sexp.parse t sexp
+    let t _ sexp = Sexp.Of_sexp.parse t Univ_map.empty sexp
   end
   module To_sexp = struct
     include F(Sexp.To_sexp)

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -111,7 +111,7 @@ let t ?x ?profile:cmdline_profile sexps =
   let defined_names = ref String.Set.empty in
   let profiles, contexts =
     List.partition_map sexps ~f:(fun sexp ->
-      match Sexp.Of_sexp.parse item_of_sexp sexp with
+      match Sexp.Of_sexp.parse item_of_sexp Univ_map.empty sexp with
       | Profile (loc, p) -> Left (loc, p)
       | Context c -> Right c)
   in
@@ -130,7 +130,7 @@ let t ?x ?profile:cmdline_profile sexps =
       }
     in
     List.fold_left contexts ~init ~f:(fun t sexp ->
-      let ctx = Sexp.Of_sexp.parse (Context.t ~profile) sexp in
+      let ctx = Sexp.Of_sexp.parse (Context.t ~profile) Univ_map.empty sexp in
       let ctx =
         match x with
         | None -> ctx

--- a/test/unit-tests/jbuild.mlt
+++ b/test/unit-tests/jbuild.mlt
@@ -8,7 +8,7 @@ open Stdune;;
 
 (* Jbuild.Executables.Link_mode.t *)
 let test s =
-  Sexp.Of_sexp.parse Jbuild.Executables.Link_mode.t
+  Sexp.Of_sexp.parse Jbuild.Executables.Link_mode.t Univ_map.empty
     (Sexp.parse_string ~fname:"" ~mode:Sexp.Parser.Mode.Single s)
 [%%expect{|
 val test : string -> Dune.Jbuild.Executables.Link_mode.t = <fun>

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -24,7 +24,7 @@ val sexp : Usexp.Ast.t = ((foo 1) (foo 2))
 |}]
 
 let of_sexp = record (field "foo" int)
-let x = parse of_sexp sexp
+let x = parse of_sexp Univ_map.empty sexp
 [%%expect{|
 val of_sexp : int Stdune.Sexp.Of_sexp.t = <abstr>
 Exception:
@@ -33,7 +33,7 @@ Stdune__Sexp.Of_sexp.Of_sexp (<abstr>,
 |}]
 
 let of_sexp = record (multi_field "foo" int)
-let x = parse of_sexp sexp
+let x = parse of_sexp Univ_map.empty sexp
 [%%expect{|
 val of_sexp : int list Stdune.Sexp.Of_sexp.t = <abstr>
 val x : int list = [1; 2]


### PR DESCRIPTION
This PRs adds a user context that is passed around to S-expression parsers. It also changes the code so that the `Dune_project.t` value is passed through this context. In particular, this allows to make the `stanza_parser` field immutable.