### PR TITLE
Complete handling of syntax versioning

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -626,7 +626,8 @@ module Promotion = struct
   let load_db () =
     if Path.exists db_file then
       Sexp.Of_sexp.(
-        parse (list File.t) (Io.Sexp.load db_file ~mode:Many_as_one))
+        parse (list File.t) Univ_map.empty
+          (Io.Sexp.load db_file ~mode:Many_as_one))
     else
       []
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -19,7 +19,7 @@ module Promoted_to_delete = struct
   let load () =
     if Path.exists fn then
       Io.Sexp.load fn ~mode:Many
-      |> List.map ~f:(Sexp.Of_sexp.parse Path.t)
+      |> List.map ~f:(Sexp.Of_sexp.parse Path.t Univ_map.empty)
     else
       []
 
@@ -1220,7 +1220,8 @@ let update_universe t =
   Utils.Cached_digest.remove universe_file;
   let n =
     if Path.exists universe_file then
-      Sexp.Of_sexp.(parse int) (Io.Sexp.load ~mode:Single universe_file) + 1
+      Sexp.Of_sexp.(parse int) Univ_map.empty
+        (Io.Sexp.load ~mode:Single universe_file) + 1
     else
       0
   in

--- a/src/config.ml
+++ b/src/config.ml
@@ -115,7 +115,7 @@ let user_config_file =
     "dune/config"
 
 let load_config_file p =
-  (Sexp.Of_sexp.parse t) (Io.Sexp.load p ~mode:Many_as_one)
+  (Sexp.Of_sexp.parse t Univ_map.empty) (Io.Sexp.load p ~mode:Many_as_one)
 
 let load_user_config_file () =
   if Path.exists user_config_file then

--- a/src/context.ml
+++ b/src/context.ml
@@ -425,7 +425,7 @@ let create_for_opam ?root ~env ~targets ~profile ~switch ~name
     >>= fun s ->
     let vars =
       Usexp.parse_string ~fname:"<opam output>" ~mode:Single s
-      |> Sexp.Of_sexp.(parse (list (pair string string)))
+      |> Sexp.Of_sexp.(parse (list (pair string string)) Univ_map.empty)
       |> Env.Map.of_list_multi
       |> Env.Map.mapi ~f:(fun var values ->
         match List.rev values with

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -112,19 +112,17 @@ end = struct
 end
 
 type t =
-  { kind                  : Kind.t
-  ; name                  : Name.t
-  ; root                  : Path.Local.t
-  ; version               : string option
-  ; packages              : Package.t Package.Name.Map.t
-  ; mutable stanza_parser : Stanza.t list Sexp.Of_sexp.t
-  ; mutable project_file  : Path.t option
+  { kind                 : Kind.t
+  ; name                 : Name.t
+  ; root                 : Path.Local.t
+  ; version              : string option
+  ; packages             : Package.t Package.Name.Map.t
+  ; stanza_parser        : Stanza.t list Sexp.Of_sexp.t
+  ; mutable project_file : Path.t option
   }
 
-type project = t
-
 module Lang = struct
-  type t = Syntax.Version.t * (project -> Stanza.Parser.t list)
+  type t = Syntax.Version.t * Stanza.Parser.t list
 
   let make ver f = (ver, f)
 
@@ -161,9 +159,7 @@ module Lang = struct
 end
 
 module Extension = struct
-  type maker = project -> Stanza.Parser.t list Sexp.Of_sexp.t
-
-  type t = Syntax.Version.t * maker
+  type t = Syntax.Version.t * Stanza.Parser.t list Sexp.Of_sexp.t
 
   let make ver f = (ver, f)
 
@@ -184,6 +180,15 @@ module Extension = struct
       Syntax.Versioned_parser.find_exn versions ~loc:ver_loc ~data_version:ver
 end
 
+let key = Univ_map.Key.create ()
+let set t = Sexp.Of_sexp.set key t
+let get_exn () =
+  let open Sexp.Of_sexp in
+  get key >>| function
+  | Some t -> t
+  | None ->
+    Exn.code_error "Current project is unset" []
+
 let filename = "dune-project"
 
 let get_local_path p =
@@ -191,23 +196,15 @@ let get_local_path p =
   | External _ -> assert false
   | Local    p -> p
 
-let fake_stanza_parser =
-  let open Sexp.Of_sexp in
-  return () >>| fun _ -> assert false
-
-let anonymous = lazy(
-  let t =
-    { kind          = Dune
-    ; name          = Name.anonymous_root
-    ; packages      = Package.Name.Map.empty
-    ; root          = get_local_path Path.root
-    ; version       = None
-    ; stanza_parser = fake_stanza_parser
-    ; project_file  = None
-    }
-  in
-  t.stanza_parser <- Sexp.Of_sexp.sum (snd (Lang.latest "dune") t);
-  t)
+let anonymous = lazy (
+  { kind          = Dune
+  ; name          = Name.anonymous_root
+  ; packages      = Package.Name.Map.empty
+  ; root          = get_local_path Path.root
+  ; version       = None
+  ; stanza_parser = Sexp.Of_sexp.sum (snd (Lang.latest "dune"))
+  ; project_file  = None
+  })
 
 let default_name ~dir ~packages =
   match Package.Name.Map.choose packages with
@@ -237,21 +234,11 @@ let parse ~dir ~lang_stanzas ~packages ~file =
   record
     (name ~dir ~packages >>= fun name ->
      field_o "version" string >>= fun version ->
-     let t =
-       { kind = Dune
-       ; name
-       ; root = get_local_path dir
-       ; version
-       ; packages
-       ; stanza_parser = fake_stanza_parser
-       ; project_file  = Some file
-       }
-     in
      multi_field "using"
        (loc >>= fun loc ->
         located string >>= fun name ->
         located Syntax.Version.t >>= fun ver ->
-        Extension.lookup name ver t >>= fun stanzas ->
+        Extension.lookup name ver >>= fun stanzas ->
         return (snd name, (loc, stanzas)))
      >>= fun extensions ->
      let extensions_stanzas =
@@ -261,8 +248,15 @@ let parse ~dir ~lang_stanzas ~packages ~file =
        | Ok _ ->
          List.concat_map extensions ~f:(fun (_, (_, x)) -> x)
      in
-     t.stanza_parser <- Sexp.Of_sexp.sum (lang_stanzas t @ extensions_stanzas);
-     return t)
+     return
+       { kind = Dune
+       ; name
+       ; root = get_local_path dir
+       ; version
+       ; packages
+       ; stanza_parser = Sexp.Of_sexp.sum (lang_stanzas @ extensions_stanzas)
+       ; project_file  = Some file
+       })
 
 let load_dune_project ~dir packages =
   let fname = Path.relative dir filename in
@@ -273,18 +267,14 @@ let load_dune_project ~dir packages =
       Univ_map.empty sexp)
 
 let make_jbuilder_project ~dir packages =
-  let t =
-    { kind = Jbuilder
-    ; name = default_name ~dir ~packages
-    ; root = get_local_path dir
-    ; version = None
-    ; packages
-    ; stanza_parser = fake_stanza_parser
-    ; project_file = None
-    }
-  in
-  t.stanza_parser <- Sexp.Of_sexp.sum (snd (Lang.latest "dune") t);
-  t
+  { kind = Jbuilder
+  ; name = default_name ~dir ~packages
+  ; root = get_local_path dir
+  ; version = None
+  ; packages
+  ; stanza_parser = Sexp.Of_sexp.sum (snd (Lang.latest "dune"))
+  ; project_file = None
+  }
 
 let load ~dir ~files =
   let packages =
@@ -344,4 +334,3 @@ let append_to_project_file t str =
       output_string oc s;
       let len = String.length s in
       if len > 0 && s.[len - 1] <> '\n' then output_char oc '\n'))
-

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -143,7 +143,7 @@ module Lang = struct
         } = first_line
     in
     let ver =
-      Sexp.Of_sexp.parse Syntax.Version.t
+      Sexp.Of_sexp.parse Syntax.Version.t Univ_map.empty
         (Atom (ver_loc, Sexp.Atom.of_string ver)) in
     match Hashtbl.find langs name with
     | None ->
@@ -269,7 +269,8 @@ let load_dune_project ~dir packages =
   Io.with_lexbuf_from_file fname ~f:(fun lb ->
     let lang_stanzas = Lang.parse (Dune_lexer.first_line lb) in
     let sexp = Sexp.Parser.parse lb ~mode:Many_as_one in
-    Sexp.Of_sexp.parse (parse ~dir ~lang_stanzas ~packages ~file:fname) sexp)
+    Sexp.Of_sexp.parse (parse ~dir ~lang_stanzas ~packages ~file:fname)
+      Univ_map.empty sexp)
 
 let make_jbuilder_project ~dir packages =
   let t =

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -31,18 +31,16 @@ end
 
 (* CR-soon diml: make this abstract *)
 type t = private
-  { kind                  : Kind.t
-  ; name                  : Name.t
-  ; root                  : Path.Local.t
-  ; version               : string option
-  ; packages              : Package.t Package.Name.Map.t
-  ; mutable stanza_parser : Stanza.t list Sexp.Of_sexp.t
-  ; mutable project_file  : Path.t option
+  { kind                 : Kind.t
+  ; name                 : Name.t
+  ; root                 : Path.Local.t
+  ; version              : string option
+  ; packages             : Package.t Package.Name.Map.t
+  ; stanza_parser        : Stanza.t list Sexp.Of_sexp.t
+  ; mutable project_file : Path.t option
   }
 
 module Lang : sig
-  type project = t
-
   (** One version of a language *)
   type t
 
@@ -53,10 +51,7 @@ module Lang : sig
 
       as the first line of their [dune-project] file. [stanza_parsers]
       defines what stanzas the user can write in [dune] files. *)
-  val make
-    :  Syntax.Version.t
-    -> (project -> Stanza.Parser.t list)
-    -> t
+  val make : Syntax.Version.t -> Stanza.Parser.t list -> t
 
   val version : t -> Syntax.Version.t
 
@@ -65,11 +60,9 @@ module Lang : sig
 
   (** Latest version of the following language *)
   val latest : string -> t
-end with type project := t
+end
 
 module Extension : sig
-  type project = t
-
   (** One version of an extension *)
   type t
 
@@ -80,14 +73,11 @@ module Extension : sig
 
       in their [dune-project] file. [parser] is used to describe
       what [<args>] might be.  *)
-  val make
-    :  Syntax.Version.t
-    -> (project -> Stanza.Parser.t list Sexp.Of_sexp.t)
-    -> t
+  val make : Syntax.Version.t -> Stanza.Parser.t list Sexp.Of_sexp.t -> t
 
   (** Register all the supported versions of an extension *)
   val register : string -> t list -> unit
-end with type project := t
+end
 
 (** Load a project description from the following directory. [files]
     is the set of files in this directory. *)
@@ -105,3 +95,7 @@ val ensure_project_file_exists : t -> unit
 
 (** Append the following text to the project file *)
 val append_to_project_file : t -> string -> unit
+
+(** Set the project we are currently parsing dune files for *)
+val set : t -> ('a, 'k) Sexp.Of_sexp.parser -> ('a, 'k) Sexp.Of_sexp.parser
+val get_exn : unit -> (t, 'k) Sexp.Of_sexp.parser

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -41,42 +41,25 @@ type t = private
   }
 
 module Lang : sig
-  (** One version of a language *)
-  type t
-
-  (** [make version stanzas_parser] defines one version of a
-      language. Users will select this language by writing:
+  (** [register id stanzas_parser] register a new language. Users will
+      select this language by writing:
 
       {[ (lang <name> <version>) ]}
 
       as the first line of their [dune-project] file. [stanza_parsers]
       defines what stanzas the user can write in [dune] files. *)
-  val make : Syntax.Version.t -> Stanza.Parser.t list -> t
-
-  val version : t -> Syntax.Version.t
-
-  (** Register all the supported versions of a language *)
-  val register : string -> t list -> unit
-
-  (** Latest version of the following language *)
-  val latest : string -> t
+  val register : Syntax.t -> Stanza.Parser.t list -> unit
 end
 
 module Extension : sig
-  (** One version of an extension *)
-  type t
-
-  (** [make version parser] defines one version of an extension. Users will
+  (** [register id parser] registers a new extension. Users will
       enable this extension by writing:
 
       {[ (using <name> <version> <args>) ]}
 
       in their [dune-project] file. [parser] is used to describe
-      what [<args>] might be.  *)
-  val make : Syntax.Version.t -> Stanza.Parser.t list Sexp.Of_sexp.t -> t
-
-  (** Register all the supported versions of an extension *)
-  val register : string -> t list -> unit
+      what [<args>] might be. *)
+  val register : Syntax.t -> Stanza.Parser.t list Sexp.Of_sexp.t -> unit
 end
 
 (** Load a project description from the following directory. [files]

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -60,7 +60,7 @@ module Dune_file = struct
         List.partition_map sexps ~f:(fun sexp ->
           match (sexp : Sexp.Ast.t) with
           | List (_, (Atom (_, A "ignored_subdirs") :: _)) ->
-            Left (Sexp.Of_sexp.parse stanza sexp)
+            Left (Sexp.Of_sexp.parse stanza Univ_map.empty sexp)
           | _ -> Right sexp)
       in
       let ignored_subdirs =

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -22,6 +22,14 @@ module Backend = struct
 
       let loc t = t.loc
 
+      (* The syntax of the driver sub-system is part of the main dune
+         syntax, so we simply don't create a new one.
+
+         If we wanted to make the ppx system an extension, then we
+         would create a new one.
+      *)
+      let syntax = Jbuild.syntax
+
       open Sexp.Of_sexp
 
       let parse =
@@ -41,11 +49,6 @@ module Backend = struct
              ; generate_runner
              ; extends
              })
-
-      let parsers =
-        Syntax.Versioned_parser.make
-          [ (1, 0), parse
-          ]
     end
 
     type t =
@@ -125,6 +128,8 @@ include Sub_system.Register_end_point(
       let loc      t = t.loc
       let backends t = Option.map t.backend ~f:(fun x -> [x])
 
+      let syntax = Jbuild.syntax
+
       open Sexp.Of_sexp
 
       let parse =
@@ -145,11 +150,6 @@ include Sub_system.Register_end_point(
                ; backend
                ; libraries
                })
-
-      let parsers =
-        Syntax.Versioned_parser.make
-          [ (1, 0), parse
-          ]
     end
 
     let gen_rules c ~(info:Info.t) ~backends =

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -20,12 +20,11 @@ let parse_sub_systems sexps =
       Loc.fail loc "%S present twice" (Sub_system_name.to_string name))
   |> Sub_system_name.Map.mapi ~f:(fun name (_, version, data) ->
     let (module M) = Jbuild.Sub_system_info.get name in
-    let vloc, ver = version in
-    let parser =
-      Syntax.Versioned_parser.find_exn M.parsers ~loc:vloc
-        ~data_version:ver
+    Syntax.check_supported M.syntax version;
+    let parsing_context =
+      Univ_map.singleton (Syntax.key M.syntax) (snd version)
     in
-    M.T (Sexp.Of_sexp.parse parser Univ_map.empty data))
+    M.T (Sexp.Of_sexp.parse M.parse parsing_context data))
 
 let of_sexp =
   let open Sexp.Of_sexp in

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -3,7 +3,8 @@ open Import
 let parse_sub_systems sexps =
   List.filter_map sexps ~f:(fun sexp ->
     let name, ver, data =
-      Sexp.Of_sexp.(parse (triple string (located Syntax.Version.t) raw)) sexp
+      Sexp.Of_sexp.(parse (triple string (located Syntax.Version.t) raw)
+                      Univ_map.empty) sexp
     in
     match Sub_system_name.get name with
     | None ->
@@ -24,7 +25,7 @@ let parse_sub_systems sexps =
       Syntax.Versioned_parser.find_exn M.parsers ~loc:vloc
         ~data_version:ver
     in
-    M.T (Sexp.Of_sexp.parse parser data))
+    M.T (Sexp.Of_sexp.parse parser Univ_map.empty data))
 
 let of_sexp =
   let open Sexp.Of_sexp in
@@ -42,7 +43,8 @@ let of_sexp =
        parse_sub_systems l)
     ]
 
-let load fname = Sexp.Of_sexp.parse of_sexp (Io.Sexp.load ~mode:Single fname)
+let load fname =
+  Sexp.Of_sexp.parse of_sexp Univ_map.empty (Io.Sexp.load ~mode:Single fname)
 
 let gen confs =
   let sexps =

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -5,6 +5,12 @@ open Sexp.Of_sexp
    syntax for the various supported version of the specification.
 *)
 
+let syntax =
+  Syntax.create ~name:"dune"
+    [ (0, 0) (* Jbuild syntax *)
+    ; (1, 0)
+    ]
+
 (* Deprecated *)
 module Jbuild_version = struct
   type t =
@@ -575,9 +581,10 @@ module Sub_system_info = struct
   module type S = sig
     type t
     type sub_system += T of t
-    val name    : Sub_system_name.t
-    val loc     : t -> Loc.t
-    val parsers : t Sexp.Of_sexp.t Syntax.Versioned_parser.t
+    val name   : Sub_system_name.t
+    val loc    : t -> Loc.t
+    val syntax : Syntax.t
+    val parse  : t Sexp.Of_sexp.t
   end
 
   let all = Sub_system_name.Table.create ~default_value:None
@@ -587,8 +594,6 @@ module Sub_system_info = struct
 
   module Register(M : S) : sig end = struct
     open M
-
-    let parse = snd (Syntax.Versioned_parser.last M.parsers)
 
     let () =
       match Sub_system_name.Table.get all name with
@@ -1346,10 +1351,7 @@ module Stanzas = struct
     ]
 
   let () =
-    let open Dune_project.Lang in
-    register "dune"
-      [ make (1, 0) dune
-      ]
+    Dune_project.Lang.register syntax dune
 
   exception Include_loop of Path.t * (Loc.t * Path.t) list
 

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -1354,7 +1354,7 @@ module Stanzas = struct
   exception Include_loop of Path.t * (Loc.t * Path.t) list
 
   let rec parse stanza_parser ~current_file ~include_stack sexps =
-    List.concat_map sexps ~f:(Sexp.Of_sexp.parse stanza_parser)
+    List.concat_map sexps ~f:(Sexp.Of_sexp.parse stanza_parser Univ_map.empty)
     |> List.concat_map ~f:(function
       | Include (loc, fn) ->
         let include_stack = (loc, current_file) :: include_stack in

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -2,13 +2,6 @@
 
 open Import
 
-module Jbuild_version : sig
-  type t = V1
-  val t : t Sexp.Of_sexp.t
-
-  val latest_stable : t
-end
-
 (** Ppx preprocessors  *)
 module Pp : sig
   type t = private string

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -2,6 +2,11 @@
 
 open Import
 
+(** Syntax identifier for the Dune language. [(0, X)] correspond to
+    the Jbuild language while versions from [(1, 0)] correspond to the
+    Dune one. *)
+val syntax : Syntax.t
+
 (** Ppx preprocessors  *)
 module Pp : sig
   type t = private string
@@ -139,10 +144,14 @@ module Sub_system_info : sig
     (** Name of the sub-system *)
     val name : Sub_system_name.t
 
-    (** Location of the S-expression passed to [of_sexp] or [short]. *)
+    (** Location of the parameters in the jbuild/dune file. *)
     val loc : t -> Loc.t
 
-    val parsers : t Sexp.Of_sexp.t Syntax.Versioned_parser.t
+    (** Syntax for jbuild/dune files *)
+    val syntax : Syntax.t
+
+    (** Parse parameters written by the user in jbuid/dune files *)
+    val parse : t Sexp.Of_sexp.t
   end
 
   module Register(M : S) : sig end

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -181,7 +181,7 @@ module Unexpanded = struct
       match t with
       | Element x -> Element x
       | Union [Special (_, "include"); Element fn] ->
-        Include (Sexp.Of_sexp.parse String_with_vars.t fn)
+        Include (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty fn)
       | Union [Special (loc, "include"); _]
       | Special (loc, "include") ->
         Loc.fail loc "(:include expects a single element (do you need to quote the filename?)"
@@ -246,7 +246,8 @@ module Unexpanded = struct
       let open Ast in
       match t with
       | Element s ->
-        Element (Sexp.Ast.loc s, f (Sexp.Of_sexp.parse String_with_vars.t s))
+        Element (Sexp.Ast.loc s,
+                 f (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty s))
       | Special (l, s) -> Special (l, s)
       | Include fn ->
         let sexp =
@@ -262,7 +263,8 @@ module Unexpanded = struct
               ]
         in
         parse_general sexp ~f:(fun sexp ->
-          (Sexp.Ast.loc sexp, f (Sexp.Of_sexp.parse String_with_vars.t sexp)))
+          (Sexp.Ast.loc sexp,
+           f (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty sexp)))
       | Union l -> Union (List.map l ~f:expand)
       | Diff (l, r) ->
         Diff (expand l, expand r)

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -32,6 +32,14 @@ module Driver = struct
 
       let loc t = t.loc
 
+      (* The syntax of the driver sub-system is part of the main dune
+         syntax, so we simply don't create a new one.
+
+         If we wanted to make the ppx system an extension, then we
+         would create a new one.
+      *)
+      let syntax = Jbuild.syntax
+
       open Sexp.Of_sexp
 
       let parse =
@@ -49,10 +57,6 @@ module Driver = struct
              ; main
              ; replaces
              })
-
-      let parsers =
-        Syntax.Versioned_parser.make
-          [ (1, 0), parse ]
     end
 
     (* The [lib] field is lazy so that we don't need to fill it for

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -182,7 +182,7 @@ module Jbuild_driver = struct
   let make name info : (Pp.t * Driver.t) Lazy.t = lazy (
     let info =
       Sexp.parse_string ~mode:Single ~fname:"<internal>" info
-      |> Sexp.Of_sexp.parse Driver.Info.parse
+      |> Sexp.Of_sexp.parse Driver.Info.parse Univ_map.empty
     in
     (Pp.of_string name,
      { info

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -116,4 +116,7 @@ module Make(Key : Comparable.S) : S with type key = Key.t = struct
       | None      -> assert false
       | Some data -> f key data)
   let filter_map t ~f = filter_mapi t ~f:(fun _ x -> f x)
+
+  let superpose a b =
+    union a b ~f:(fun _ _ y -> Some y)
 end

--- a/src/stdune/map_intf.ml
+++ b/src/stdune/map_intf.ml
@@ -21,6 +21,10 @@ module type S = sig
     -> f:(key -> 'a -> 'a -> 'a option)
     -> 'a t
 
+  (** [superpose a b] is [b] augmented with bindings of [a] that are
+      not in [b]. *)
+  val superpose : 'a t -> 'a t -> 'a t
+
   val compare : 'a t -> 'a t -> compare:('a -> 'a -> Ordering.t) -> Ordering.t
   val equal   : 'a t -> 'a t -> equal:('a -> 'a -> bool) -> bool
 

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -141,6 +141,14 @@ module Of_sexp = struct
       | Fields (loc, cstr, uc) ->
         t (Fields (loc, cstr, Univ_map.add uc key v)) state
 
+  let set_many : type a k. Univ_map.t -> (a, k) parser -> (a, k) parser
+    = fun map t ctx state ->
+      match ctx with
+      | Values (loc, cstr, uc) ->
+        t (Values (loc, cstr, Univ_map.superpose uc map)) state
+      | Fields (loc, cstr, uc) ->
+        t (Fields (loc, cstr, Univ_map.superpose uc map)) state
+
   let loc : type k. k context -> k -> Loc.t * k = fun ctx state ->
     match ctx with
     | Values (loc, _, _) -> (loc, state)

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -508,6 +508,16 @@ module Of_sexp = struct
     (x, [])
 
   let record t = enter (fields t)
+
+  type kind =
+    | Values of Loc.t * string option
+    | Fields of Loc.t * string option
+
+  let kind : type k. k context -> k -> kind * k
+    = fun ctx state ->
+      match ctx with
+      | Values (loc, cstr, _) -> (Values (loc, cstr), state)
+      | Fields (loc, cstr, _) -> (Fields (loc, cstr), state)
 end
 
 module type Sexpable = sig

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -199,6 +199,12 @@ module Of_sexp = struct
     let ctx = Values (Ast.loc sexp, None, context) in
     result ctx (t ctx [sexp])
 
+  let capture ctx state =
+    let f t =
+      result ctx (t ctx state)
+    in
+    (f, [])
+
   let end_of_list (Values (loc, cstr, _)) =
     match cstr with
     | None ->

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -118,6 +118,14 @@ module Of_sexp : sig
       S-expressions to parse *)
   val eos : (bool, _) parser
 
+  (** What is currently being parsed. The second argument is the atom
+      at the beginnig of the list when inside a [sum ...] or [field
+      ...]. *)
+  type kind =
+    | Values of Loc.t * string option
+    | Fields of Loc.t * string option
+  val kind : (kind, _) parser
+
   (** [repeat t] use [t] to consume all remaning elements of the input
       until the end of sequence is reached. *)
   val repeat : 'a t -> 'a list t

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -122,6 +122,9 @@ module Of_sexp : sig
       until the end of sequence is reached. *)
   val repeat : 'a t -> 'a list t
 
+  (** Capture the rest of the input for later parsing *)
+  val capture : ('a t -> 'a) t
+
   (** [enter t] expect the next element of the input to be a list and
       parse its contents with [t]. *)
   val enter : 'a t -> 'a t

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -109,6 +109,7 @@ module Of_sexp : sig
   (** Access to the context *)
   val get : 'a Univ_map.Key.t -> ('a option, _) parser
   val set : 'a Univ_map.Key.t -> 'a -> ('b, 'k) parser -> ('b, 'k) parser
+  val set_many : Univ_map.t -> ('a, 'k) parser -> ('a, 'k) parser
 
   (** Return the location of the list currently being parsed. *)
   val loc : (Loc.t, _) parser

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -94,14 +94,21 @@ module Of_sexp : sig
   type 'a t             = ('a, values) parser
   type 'a fields_parser = ('a, fields) parser
 
-  (** Parse a S-expression using the following parser *)
-  val parse : 'a t -> ast -> 'a
+  (** [parse parser context sexp] parse a S-expression using the
+      following parser. The input consist of a single
+      S-expression. [context] allows to pass extra informations such as
+      versions to individual parsers. *)
+  val parse : 'a t -> Univ_map.t -> ast -> 'a
 
   val return : 'a -> ('a, _) parser
   val (>>=) : ('a, 'k) parser -> ('a -> ('b, 'k) parser) -> ('b, 'k) parser
   val (>>|) : ('a, 'k) parser -> ('a -> 'b) -> ('b, 'k) parser
   val (>>>) : (unit, 'k) parser -> ('a, 'k) parser -> ('a, 'k) parser
   val map : ('a, 'k) parser -> f:('a -> 'b) -> ('b, 'k) parser
+
+  (** Access to the context *)
+  val get : 'a Univ_map.Key.t -> ('a option, _) parser
+  val set : 'a Univ_map.Key.t -> 'a -> ('b, 'k) parser -> ('b, 'k) parser
 
   (** Return the location of the list currently being parsed. *)
   val loc : (Loc.t, _) parser

--- a/src/stdune/univ_map.ml
+++ b/src/stdune/univ_map.ml
@@ -72,3 +72,5 @@ let find_exn t key =
     Eq.cast eq v
 
 let singleton key v = Int.Map.singleton (Key.id key) (Binding.T (key, v))
+
+let superpose = Int.Map.superpose

--- a/src/stdune/univ_map.ml
+++ b/src/stdune/univ_map.ml
@@ -71,3 +71,4 @@ let find_exn t key =
     let eq = Key.eq key' key in
     Eq.cast eq v
 
+let singleton key v = Int.Map.singleton (Key.id key) (Binding.T (key, v))

--- a/src/stdune/univ_map.mli
+++ b/src/stdune/univ_map.mli
@@ -17,3 +17,4 @@ val add      : t -> 'a Key.t -> 'a -> t
 val remove   : t -> 'a Key.t -> t
 val find     : t -> 'a Key.t -> 'a option
 val find_exn : t -> 'a Key.t -> 'a
+val singleton : 'a Key.t -> 'a -> t

--- a/src/stdune/univ_map.mli
+++ b/src/stdune/univ_map.mli
@@ -18,3 +18,7 @@ val remove   : t -> 'a Key.t -> t
 val find     : t -> 'a Key.t -> 'a option
 val find_exn : t -> 'a Key.t -> 'a
 val singleton : 'a Key.t -> 'a -> t
+
+(** [superpose a b] is [b] augmented with bindings of [a] that are not
+    in [b]. *)
+val superpose : t -> t -> t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -1,5 +1,6 @@
+(** Management of syntaxes *)
+
 open Stdune
-(** Versioned syntaxes *)
 
 module Version : sig
   (** A syntax version.
@@ -11,20 +12,33 @@ module Version : sig
 
   include Sexp.Sexpable with type t := t
 
+  val to_string : t -> string
+
   (** Whether the parser can read the data or not *)
   val can_read : parser_version:t -> data_version:t -> bool
 end
 
-module Versioned_parser : sig
-  (** Versioned parser *)
-  type 'a t
+type t
 
-  (** Create a versionned parser. There must be exactly one parser per
-      major version. *)
-  val make : (Version.t * 'a) list -> 'a t
+(** [create ~name supported_versions] defines a new
+    syntax. [supported_version] is the list of the last minor version
+    of each supported major version. *)
+val create : name:string -> Version.t list -> t
 
-  val last : 'a t -> Version.t * 'a
+(** Return the name of the syntax. *)
+val name : t -> string
 
-  (** Find a parser that can parse data of this version *)
-  val find_exn : 'a t -> loc:Loc.t -> data_version:Version.t -> 'a
-end
+(** Check that the given version is supported and raise otherwise. *)
+val check_supported : t -> Loc.t * Version.t -> unit
+
+val greatest_supported_version : t -> Version.t
+
+val set
+  :  t
+  -> Version.t
+  -> ('a, 'k) Sexp.Of_sexp.parser
+  -> ('a, 'k) Sexp.Of_sexp.parser
+
+val get_exn : t -> (Version.t, 'k) Sexp.Of_sexp.parser
+
+val key : t -> Version.t Univ_map.Key.t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -20,10 +20,11 @@ end
 
 type t
 
-(** [create ~name supported_versions] defines a new
+(** [create ~name ~desc supported_versions] defines a new
     syntax. [supported_version] is the list of the last minor version
-    of each supported major version. *)
-val create : name:string -> Version.t list -> t
+    of each supported major version. [desc] is used to describe what
+    this syntax represent in error messages. *)
+val create : name:string -> desc:string -> Version.t list -> t
 
 (** Return the name of the syntax. *)
 val name : t -> string
@@ -32,6 +33,24 @@ val name : t -> string
 val check_supported : t -> Loc.t * Version.t -> unit
 
 val greatest_supported_version : t -> Version.t
+
+(** {1 S-expression parsing} *)
+
+(** {2 High-level functions} *)
+
+(** Indicate the field/constructor being parsed was deleted in the
+    given version *)
+val deleted_in : t -> Version.t -> (unit, _) Sexp.Of_sexp.parser
+
+(** Indicate the field/constructor being parsed was renamed in the
+    given version *)
+val renamed_in : t -> Version.t -> to_:string ->  (unit, _) Sexp.Of_sexp.parser
+
+(** Indicate the field/constructor being parsed was introduced in the
+    given version *)
+val since : t -> Version.t ->  (unit, _) Sexp.Of_sexp.parser
+
+(** {2 Low-level functions} *)
 
 val set
   :  t

--- a/src/vfile_kind.ml
+++ b/src/vfile_kind.ml
@@ -66,7 +66,7 @@ module Make
 struct
   module Of_sexp = struct
     include F(Sexp.Of_sexp)
-    let t _ sexp = Sexp.Of_sexp.parse t sexp
+    let t _ sexp = Sexp.Of_sexp.parse t Univ_map.empty sexp
   end
   module To_sexp = struct
     include F(Sexp.To_sexp)

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -111,7 +111,7 @@ let t ?x ?profile:cmdline_profile sexps =
   let defined_names = ref String.Set.empty in
   let profiles, contexts =
     List.partition_map sexps ~f:(fun sexp ->
-      match Sexp.Of_sexp.parse item_of_sexp sexp with
+      match Sexp.Of_sexp.parse item_of_sexp Univ_map.empty sexp with
       | Profile (loc, p) -> Left (loc, p)
       | Context c -> Right c)
   in
@@ -130,7 +130,7 @@ let t ?x ?profile:cmdline_profile sexps =
       }
     in
     List.fold_left contexts ~init ~f:(fun t sexp ->
-      let ctx = Sexp.Of_sexp.parse (Context.t ~profile) sexp in
+      let ctx = Sexp.Of_sexp.parse (Context.t ~profile) Univ_map.empty sexp in
       let ctx =
         match x with
         | None -> ctx

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -544,6 +544,14 @@
     (progn (run ${exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
 (alias
+ ((name syntax-versioning)
+  (deps ((package dune) (files_recursively_in test-cases/syntax-versioning)))
+  (action
+   (chdir
+    test-cases/syntax-versioning
+    (progn (run ${exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
+
+(alias
  ((name use-meta)
   (deps ((package dune) (files_recursively_in test-cases/use-meta)))
   (action
@@ -623,6 +631,7 @@
     (alias scope-bug)
     (alias scope-ppx-bug)
     (alias select)
+    (alias syntax-versioning)
     (alias use-meta)
     (alias utop)))))
 
@@ -682,6 +691,7 @@
     (alias scope-bug)
     (alias scope-ppx-bug)
     (alias select)
+    (alias syntax-versioning)
     (alias use-meta)))))
 
 (alias ((name runtest-disabled) (deps ((alias reason)))))

--- a/test/blackbox-tests/test-cases/syntax-versioning/run.t
+++ b/test/blackbox-tests/test-cases/syntax-versioning/run.t
@@ -1,0 +1,18 @@
+  $ echo '(jbuild_version 1)' > dune
+  $ dune build
+  Info: creating file dune-project with this contents: (lang dune 1.0)
+  File "dune", line 1, characters 0-18:
+  Error: 'jbuild_version' was deleted in version 1.0 of the dune language
+  [1]
+  $ rm -f dune
+
+  $ echo '(jbuild_version 1)' > jbuild
+  $ dune build
+  $ rm -f jbuild
+
+  $ echo '(executable ((name x) (link_executables false)))' > dune
+  $ dune build
+  File "dune", line 1, characters 22-46:
+  Error: 'link_executables' was deleted in version 1.0 of the dune language
+  [1]
+  $ rm -f dune

--- a/test/unit-tests/jbuild.mlt
+++ b/test/unit-tests/jbuild.mlt
@@ -8,7 +8,7 @@ open Stdune;;
 
 (* Jbuild.Executables.Link_mode.t *)
 let test s =
-  Sexp.Of_sexp.parse Jbuild.Executables.Link_mode.t
+  Sexp.Of_sexp.parse Jbuild.Executables.Link_mode.t Univ_map.empty
     (Sexp.parse_string ~fname:"" ~mode:Sexp.Parser.Mode.Single s)
 [%%expect{|
 val test : string -> Dune.Jbuild.Executables.Link_mode.t = <fun>

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -24,7 +24,7 @@ val sexp : Usexp.Ast.t = ((foo 1) (foo 2))
 |}]
 
 let of_sexp = record (field "foo" int)
-let x = parse of_sexp sexp
+let x = parse of_sexp Univ_map.empty sexp
 [%%expect{|
 val of_sexp : int Stdune.Sexp.Of_sexp.t = <abstr>
 Exception:
@@ -33,7 +33,7 @@ Stdune__Sexp.Of_sexp.Of_sexp (<abstr>,
 |}]
 
 let of_sexp = record (multi_field "foo" int)
-let x = parse of_sexp sexp
+let x = parse of_sexp Univ_map.empty sexp
 [%%expect{|
 val of_sexp : int list Stdune.Sexp.Of_sexp.t = <abstr>
 val x : int list = [1; 2]


### PR DESCRIPTION
This PRs refactors the way syntax versionning is handled. For every syntax (language, extension, sub-system) we must create a `Syntax.t` value that holds:

- the name and description of the syntax
- the supported versions

This `Syntax.t` value is attached:

- to languages registered via `Dune_project.Lang.register`
- to extensions registered via `Dune_project.Extension.register`
- to sub-systems

If the version of two components is managed by the same syntax, we can simply reuse the same `Syntax.t` value. For instance the versionning of `ppx.driver` or `inline_tests` fields is controlled by the version of the dune language, so they simply reuse the same syntax.

When parsing dune files, the version of each syntax in use is passed via the user context of S-expressions parser. The `Syntax` module contains high-level functions to declare that a field/constructor was deleted/renamed/... since a given version.

For the dune language, I used the convention that `0.x` means the jbuild syntax. So for instance we have:

```ocaml
    ; "jbuild_version",
      (Syntax.deleted_in syntax (1, 0) >>= fun () ->
       Jbuild_version.t >>| fun _ -> [])
```

and if the user tries to use `jbuild_version` in a `dune` file, they'll get an error saying that this constructor was deleted in version 1.0 of the dune language.
