### PR TITLE
Move ocamldep output files to the object directory

### DIFF
--- a/src/exe.ml
+++ b/src/exe.ml
@@ -171,12 +171,11 @@ let link_exe
 let build_and_link_many
       ~programs
       ~linkages
-      ?already_used
       ?link_flags
       ?(js_of_ocaml=Jbuild.Js_of_ocaml.default)
       cctx
   =
-  let dep_graphs = Ocamldep.rules cctx ?already_used in
+  let dep_graphs = Ocamldep.rules cctx in
 
   (* CR-someday jdimino: this should probably say [~dynlink:false] *)
   Module_compilation.build_modules cctx ~js_of_ocaml ~dep_graphs;

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -39,7 +39,6 @@ end
 val build_and_link
   :  program:Program.t
   -> linkages:Linkage.t list
-  -> ?already_used:Module.Name.Set.t
   -> ?link_flags:(unit, string list) Build.t
   -> ?js_of_ocaml:Jbuild.Js_of_ocaml.t
   -> Compilation_context.t
@@ -48,7 +47,6 @@ val build_and_link
 val build_and_link_many
   :  programs:Program.t list
   -> linkages:Linkage.t list
-  -> ?already_used:Module.Name.Set.t
   -> ?link_flags:(unit, string list) Build.t
   -> ?js_of_ocaml:Jbuild.Js_of_ocaml.t
   -> Compilation_context.t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -580,11 +580,9 @@ module Gen(P : Install_rules.Params) = struct
         ~preprocessing:pp
     in
 
-    let already_used =
-      Modules_partitioner.acknowledge modules_partitioner cctx
-        ~loc:lib.buildable.loc ~modules:source_modules
-    in
-    let dep_graphs = Ocamldep.rules cctx ~already_used in
+    Modules_partitioner.acknowledge modules_partitioner cctx
+      ~loc:lib.buildable.loc ~modules:source_modules;
+    let dep_graphs = Ocamldep.rules cctx in
 
     Option.iter alias_module ~f:(fun m ->
       let file =
@@ -887,14 +885,11 @@ module Gen(P : Install_rules.Params) = struct
         ~requires
         ~preprocessing:pp
     in
-    let already_used =
-      Modules_partitioner.acknowledge modules_partitioner cctx
-        ~loc:exes.buildable.loc ~modules
-    in
+    Modules_partitioner.acknowledge modules_partitioner cctx
+      ~loc:exes.buildable.loc ~modules;
 
     Exe.build_and_link_many cctx
       ~programs
-      ~already_used
       ~linkages
       ~link_flags
       ~js_of_ocaml:exes.buildable.js_of_ocaml;

--- a/src/modules_partitioner.ml
+++ b/src/modules_partitioner.ml
@@ -11,12 +11,6 @@ let create ~dir_kind =
   }
 
 let acknowledge t part ~loc ~modules =
-  let already_used =
-    Module.Name.Map.merge modules t.used ~f:(fun _name x l ->
-      Option.some_if (Option.is_some x && Option.is_some l) ())
-    |> Module.Name.Map.keys
-    |> Module.Name.Set.of_list
-  in
   t.used <-
     Module.Name.Map.merge modules t.used ~f:(fun _name x y ->
       match x with
@@ -25,8 +19,7 @@ let acknowledge t part ~loc ~modules =
         Some (part,
               loc :: match y with
               | None -> []
-              | Some (_, l) -> l));
-  already_used
+              | Some (_, l) -> l))
 
 let find t name = Option.map (Module.Name.Map.find t.used name) ~f:fst
 

--- a/src/modules_partitioner.mli
+++ b/src/modules_partitioner.mli
@@ -7,17 +7,13 @@ type 'a t
 val create : dir_kind:File_tree.Dune_file.Kind.t -> 'a t
 
 (** [acknowledge t partition ~loc ~modules] registers the fact that [modules]
-    are associated with [loc].
-
-    Returns the set of modules that are already used at another
-    location.
-*)
+    are associated with [loc]. *)
 val acknowledge
   :  'a t
   -> 'a
   -> loc:Loc.t
   -> modules:Module.t Module.Name.Map.t
-  -> Module.Name.Set.t
+  -> unit
 
 (** Find which partition a module is part of *)
 val find : 'a t -> Module.Name.t -> 'a option

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -120,7 +120,7 @@ let parse_deps cctx ~file ~unit lines =
       | None -> deps
       | Some m -> m :: deps
 
-let deps_of cctx ~ml_kind ~already_used unit =
+let deps_of cctx ~ml_kind unit =
   let sctx = CC.super_context cctx in
   let dir  = CC.dir           cctx in
   if is_alias_module cctx unit then
@@ -129,61 +129,56 @@ let deps_of cctx ~ml_kind ~already_used unit =
     match Module.file ~dir unit ml_kind with
     | None -> Build.return []
     | Some file ->
-      let all_deps_path file =
-        Path.extend_basename file ~suffix:".all-deps"
+      let file_in_obj_dir ~suffix file =
+        let base = Path.basename file in
+        Path.relative (Compilation_context.obj_dir cctx) (base ^ suffix)
       in
+      let all_deps_path file = file_in_obj_dir file ~suffix:".all-deps" in
       let context = SC.context sctx in
       let all_deps_file = all_deps_path file in
-      let ocamldep_output = Path.extend_basename file ~suffix:".d" in
-      if not (Module.Name.Set.mem already_used unit.name) then
-        begin
-          SC.add_rule sctx
-            ( Build.run ~context (Ok context.ocamldep)
-                [A "-modules"; Ml_kind.flag ml_kind; Dep file]
-                ~stdout_to:ocamldep_output
-            );
-          let build_paths dependencies =
-            let dependency_file_path m =
-              let path =
-                if is_alias_module cctx m then
-                  None
-                else
-                  match Module.file ~dir m Ml_kind.Intf with
-                  | Some _ as x -> x
-                  | None -> Module.file ~dir m Ml_kind.Impl
-              in
-              Option.map path ~f:all_deps_path
-            in
-            List.filter_map dependencies ~f:dependency_file_path
+      let ocamldep_output = file_in_obj_dir file ~suffix:".d" in
+      SC.add_rule sctx
+        ( Build.run ~context (Ok context.ocamldep)
+            [A "-modules"; Ml_kind.flag ml_kind; Dep file]
+            ~stdout_to:ocamldep_output
+        );
+      let build_paths dependencies =
+        let dependency_file_path m =
+          let path =
+            if is_alias_module cctx m then
+              None
+            else
+              match Module.file ~dir m Ml_kind.Intf with
+              | Some _ as x -> x
+              | None -> Module.file ~dir m Ml_kind.Impl
           in
-          SC.add_rule sctx
-            ( Build.lines_of ocamldep_output
-              >>^ parse_deps cctx ~file ~unit
-              >>^ (fun modules ->
-                (build_paths modules,
-                 List.map modules ~f:(fun m ->
-                   Module.Name.to_string (Module.name m))
-                ))
-              >>> Build.merge_files_dyn ~target:all_deps_file)
-        end;
+          Option.map path ~f:all_deps_path
+        in
+        List.filter_map dependencies ~f:dependency_file_path
+      in
+      SC.add_rule sctx
+        ( Build.lines_of ocamldep_output
+          >>^ parse_deps cctx ~file ~unit
+          >>^ (fun modules ->
+            (build_paths modules,
+             List.map modules ~f:(fun m ->
+               Module.Name.to_string (Module.name m))
+            ))
+          >>> Build.merge_files_dyn ~target:all_deps_file);
       Build.memoize (Path.to_string all_deps_file)
         ( Build.lines_of all_deps_file
           >>^ parse_module_names ~unit ~modules:(CC.modules cctx))
 
-let rules_generic ?(already_used=Module.Name.Set.empty) cctx ~modules =
+let rules_generic cctx ~modules =
   Ml_kind.Dict.of_func
     (fun ~ml_kind ->
-      let per_module =
-        Module.Name.Map.map modules
-          ~f:(deps_of cctx ~already_used ~ml_kind)
-      in
+      let per_module = Module.Name.Map.map modules ~f:(deps_of cctx ~ml_kind) in
       { Dep_graph.
         dir = CC.dir cctx
       ; per_module
       })
 
-let rules ?already_used cctx =
-  rules_generic ?already_used cctx ~modules:(CC.modules cctx)
+let rules cctx = rules_generic cctx ~modules:(CC.modules cctx)
 
 let rules_for_auxiliary_module cctx (m : Module.t) =
   rules_generic cctx ~modules:(Module.Name.Map.singleton m.name m)

--- a/src/ocamldep.mli
+++ b/src/ocamldep.mli
@@ -20,14 +20,9 @@ module Dep_graphs : sig
   val dummy : Module.t -> t
 end
 
-(** Generate ocamldep rules for all the modules in the context.
-
-    [already_used] represents the modules that are used by another
-    stanzas in the same directory. No [.d] rule will be generated for
-    such modules. *)
+(** Generate ocamldep rules for all the modules in the context. *)
 val rules
-  :  ?already_used:Module.Name.Set.t
-  -> Compilation_context.t
+  :  Compilation_context.t
   -> Dep_graphs.t
 
 (** Compute the dependencies of an auxiliary module. *)

--- a/test/blackbox-tests/test-cases/byte-code-only/run.t
+++ b/test/blackbox-tests/test-cases/byte-code-only/run.t
@@ -1,8 +1,8 @@
   $ env ORIG_PATH="$PATH" PATH="$PWD/ocaml-bin:$PATH" jbuilder build --display short
-      ocamldep bin/toto.ml.d
+      ocamldep bin/.toto.eobjs/toto.ml.d
         ocamlc bin/.toto.eobjs/toto.{cmi,cmo,cmt}
         ocamlc bin/toto.exe
-      ocamldep src/foo.ml.d
+      ocamldep src/.foo.objs/foo.ml.d
         ocamlc src/.foo.objs/foo.{cmi,cmo,cmt}
         ocamlc src/foo.cma
 

--- a/test/blackbox-tests/test-cases/c-stubs/run.t
+++ b/test/blackbox-tests/test-cases/c-stubs/run.t
@@ -1,9 +1,9 @@
   $ dune exec ./qnativerun/run.exe --display short
-      ocamldep qnativerun/run.ml.d
+      ocamldep qnativerun/.run.eobjs/run.ml.d
         ocamlc q/q_stub$ext_obj
     ocamlmklib q/dllq_stubs$ext_dll,q/libq_stubs$ext_lib
-      ocamldep q/q.ml.d
-      ocamldep q/q.mli.d
+      ocamldep q/.q.objs/q.ml.d
+      ocamldep q/.q.objs/q.mli.d
         ocamlc q/.q.objs/q.{cmi,cmti}
       ocamlopt q/.q.objs/q.{cmx,o}
       ocamlopt q/q.{a,cmxa}

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -1,8 +1,8 @@
   $ dune build test.exe .merlin --display short --debug-dependency-path
       ocamllex lexers/lexer1.ml
-      ocamldep lexer1.ml.d
-      ocamldep test.ml.d
-      ocamldep dummy.ml.d
+      ocamldep .test.eobjs/lexer1.ml.d
+      ocamldep .test.eobjs/test.ml.d
+      ocamldep .foo.objs/dummy.ml.d
         ocamlc .foo.objs/dummy.{cmi,cmo,cmt}
       ocamlopt .foo.objs/dummy.{cmx,o}
       ocamlopt foo.{a,cmxa}

--- a/test/blackbox-tests/test-cases/cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation/run.t
@@ -1,12 +1,12 @@
   $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf jbuilder build --display short -x foo file @install
-      ocamldep bin/blah.ml.d [default.foo]
-      ocamldep lib/p.ml.d [default.foo]
+      ocamldep bin/.blah.eobjs/blah.ml.d [default.foo]
+      ocamldep lib/.p.objs/p.ml.d [default.foo]
         ocamlc lib/.p.objs/p.{cmi,cmo,cmt} [default.foo]
       ocamlopt lib/.p.objs/p.{cmx,o} [default.foo]
       ocamlopt lib/p.{a,cmxa} [default.foo]
       ocamlopt lib/p.cmxs [default.foo]
-      ocamldep bin/blah.ml.d
-      ocamldep lib/p.ml.d
+      ocamldep bin/.blah.eobjs/blah.ml.d
+      ocamldep lib/.p.objs/p.ml.d
         ocamlc lib/.p.objs/p.{cmi,cmo,cmt}
       ocamlopt lib/.p.objs/p.{cmx,o}
       ocamlopt lib/p.{a,cmxa}

--- a/test/blackbox-tests/test-cases/exec-cmd/run.t
+++ b/test/blackbox-tests/test-cases/exec-cmd/run.t
@@ -3,7 +3,7 @@
   Error: Program "./foo.exe" isn't built yet you need to buid it first or remove the --no-build option.
   [1]
   $ dune exec ./foo.exe --display short
-      ocamldep foo.ml.d
+      ocamldep .foo.eobjs/foo.ml.d
         ocamlc .foo.eobjs/foo.{cmi,cmo,cmt}
       ocamlopt .foo.eobjs/foo.{cmx,o}
       ocamlopt foo.exe
@@ -17,7 +17,7 @@
   Error: Program "dunetestbar" isn't built yet you need to buid it first or remove the --no-build option.
   [1]
   $ dune exec dunetestbar --display short
-      ocamldep bar.ml.d
+      ocamldep .bar.eobjs/bar.ml.d
         ocamlc .bar.eobjs/bar.{cmi,cmo,cmt}
       ocamlopt .bar.eobjs/bar.{cmx,o}
       ocamlopt bar.exe

--- a/test/blackbox-tests/test-cases/force-test/run.t
+++ b/test/blackbox-tests/test-cases/force-test/run.t
@@ -1,6 +1,6 @@
   $ dune clean --display short
   $ dune runtest --display short
-      ocamldep f.ml.d
+      ocamldep .f.eobjs/f.ml.d
         ocamlc .f.eobjs/f.{cmi,cmo,cmt}
       ocamlopt .f.eobjs/f.{cmx,o}
       ocamlopt f.exe

--- a/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
+++ b/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
@@ -1,20 +1,20 @@
   $ dune runtest --display short
-      ocamldep bar.ml.d
-      ocamldep foo.ml.d
-      ocamldep foo.mli.d
+      ocamldep .bar.eobjs/bar.ml.d
+      ocamldep .foo.objs/foo.ml.d
+      ocamldep .foo.objs/foo.mli.d
         ocamlc .foo.objs/foo.{cmi,cmti}
       ocamlopt .foo.objs/foo.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs
-      ocamldep foo_byte.ml.d
+      ocamldep .foo_byte.objs/foo_byte.ml.d
         ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
         ocamlc foo_byte.cma
-      ocamldep ppx-new/foo_ppx_rewriter_dune.ml.d
+      ocamldep ppx-new/.foo_ppx_rewriter_dune.objs/foo_ppx_rewriter_dune.ml.d
         ocamlc ppx-new/.foo_ppx_rewriter_dune.objs/foo_ppx_rewriter_dune.{cmi,cmo,cmt}
       ocamlopt ppx-new/.foo_ppx_rewriter_dune.objs/foo_ppx_rewriter_dune.{cmx,o}
       ocamlopt ppx-new/foo_ppx_rewriter_dune.{a,cmxa}
       ocamlopt ppx-new/foo_ppx_rewriter_dune.cmxs
-      ocamldep ppx-old/foo_ppx_rewriter_jbuild.ml.d
+      ocamldep ppx-old/.foo_ppx_rewriter_jbuild.objs/foo_ppx_rewriter_jbuild.ml.d
         ocamlc ppx-old/.foo_ppx_rewriter_jbuild.objs/foo_ppx_rewriter_jbuild.{cmi,cmo,cmt}
       ocamlopt ppx-old/.foo_ppx_rewriter_jbuild.objs/foo_ppx_rewriter_jbuild.{cmx,o}
       ocamlopt ppx-old/foo_ppx_rewriter_jbuild.{a,cmxa}

--- a/test/blackbox-tests/test-cases/github25/run.t
+++ b/test/blackbox-tests/test-cases/github25/run.t
@@ -14,11 +14,11 @@ We need ocamlfind to run this test
         ocamlc root/hello.cma
 
   $ dune build @install --display short --only pas-de-bol 2>&1 | sed 's/[^ "]*findlib-packages/.../'
-      ocamldep root/a.ml.d
+      ocamldep root/.pas_de_bol.objs/a.ml.d
   File ".../plop/META", line 1, characters 0-0:
   Error: Library "une-lib-qui-nexiste-pas" not found.
   -> required by library "plop.ca-marche-pas" in .../plop
   Hint: try: dune external-lib-deps --missing --only-packages pas-de-bol @install
-      ocamldep root/b.ml.d
+      ocamldep root/.pas_de_bol.objs/b.ml.d
         ocamlc root/.pas_de_bol.objs/pas_de_bol.{cmi,cmo,cmt}
       ocamlopt root/.pas_de_bol.objs/pas_de_bol.{cmx,o}

--- a/test/blackbox-tests/test-cases/github534/run.t
+++ b/test/blackbox-tests/test-cases/github534/run.t
@@ -1,6 +1,6 @@
   $ dune exec ./main.exe --display short
           echo main.ml
-      ocamldep main.ml.d
+      ocamldep .main.eobjs/main.ml.d
         ocamlc .main.eobjs/main.{cmi,cmo,cmt}
       ocamlopt .main.eobjs/main.{cmx,o}
       ocamlopt main.exe

--- a/test/blackbox-tests/test-cases/github568/run.t
+++ b/test/blackbox-tests/test-cases/github568/run.t
@@ -1,6 +1,6 @@
   $ dune runtest --display short -p lib1 --debug-dependency-path
-      ocamldep test1.ml.d
-      ocamldep lib1.ml.d
+      ocamldep .test1.eobjs/test1.ml.d
+      ocamldep .lib1.objs/lib1.ml.d
         ocamlc .lib1.objs/lib1.{cmi,cmo,cmt}
       ocamlopt .lib1.objs/lib1.{cmx,o}
       ocamlopt lib1.{a,cmxa}

--- a/test/blackbox-tests/test-cases/installable-dup-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/installable-dup-private-libs/run.t
@@ -1,10 +1,10 @@
   $ dune build @install --display short
-      ocamldep a1/a.ml.d
+      ocamldep a1/.a.objs/a.ml.d
         ocamlc a1/.a.objs/a.{cmi,cmo,cmt}
       ocamlopt a1/.a.objs/a.{cmx,o}
       ocamlopt a1/a.{a,cmxa}
       ocamlopt a1/a.cmxs
-      ocamldep a2/a.ml.d
+      ocamldep a2/.a.objs/a.ml.d
         ocamlc a2/.a.objs/a.{cmi,cmo,cmt}
       ocamlopt a2/.a.objs/a.{cmx,o}
       ocamlopt a2/a.{a,cmxa}

--- a/test/blackbox-tests/test-cases/intf-only/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/run.t
@@ -2,11 +2,11 @@ Successes:
 
   $ dune build --display short --root foo --debug-dep
   Entering directory 'foo'
-      ocamldep test/bar.ml.d
-      ocamldep foo.ml.d
+      ocamldep test/.bar.objs/bar.ml.d
+      ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/foo__.{cmi,cmo,cmt}
       ocamlopt .foo.objs/foo__.{cmx,o}
-      ocamldep intf.mli.d
+      ocamldep .foo.objs/intf.mli.d
         ocamlc .foo.objs/foo__Intf.{cmi,cmti}
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
         ocamlc test/.bar.objs/bar.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -3,17 +3,17 @@
     ocamlmklib lib/dllx_stubs$ext_dll,lib/libx_stubs$ext_lib
       ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
            ppx lib/x.pp.ml
-      ocamldep lib/x.pp.ml.d
+      ocamldep lib/.x.objs/x.pp.ml.d
         ocamlc lib/.x.objs/x__.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__.{cmx,o}
            ppx lib/y.pp.ml
-      ocamldep lib/y.pp.ml.d
+      ocamldep lib/.x.objs/y.pp.ml.d
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
            ppx bin/technologic.pp.ml
-      ocamldep bin/technologic.pp.ml.d
+      ocamldep bin/.technologic.eobjs/technologic.pp.ml.d
            ppx bin/z.pp.ml
-      ocamldep bin/z.pp.ml.d
+      ocamldep bin/.technologic.eobjs/z.pp.ml.d
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml lib/.x.objs/x__Y.cmo.js
         ocamlc lib/.x.objs/x.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/link-deps/run.t
+++ b/test/blackbox-tests/test-cases/link-deps/run.t
@@ -4,7 +4,7 @@ In particular, these can depend on the result of the compilation (like a .cmo
 file) and be created just before linking.
 
   $ dune build --display short link_deps.exe
-      ocamldep link_deps.ml.d
+      ocamldep .link_deps.eobjs/link_deps.ml.d
         ocamlc .link_deps.eobjs/link_deps.{cmi,cmo,cmt}
   link
       ocamlopt .link_deps.eobjs/link_deps.{cmx,o}

--- a/test/blackbox-tests/test-cases/menhir/run.t
+++ b/test/blackbox-tests/test-cases/menhir/run.t
@@ -1,15 +1,15 @@
   $ dune build src/test.exe --display short --debug-dependency-path
       ocamllex src/lexer1.ml
-      ocamldep src/lexer1.ml.d
+      ocamldep src/.test.eobjs/lexer1.ml.d
       ocamllex src/lexer2.ml
-      ocamldep src/lexer2.ml.d
-      ocamldep src/test.ml.d
+      ocamldep src/.test.eobjs/lexer2.ml.d
+      ocamldep src/.test.eobjs/test.ml.d
         menhir src/test_base.{ml,mli}
-      ocamldep src/test_base.ml.d
+      ocamldep src/.test.eobjs/test_base.ml.d
         menhir src/test_menhir1.{ml,mli}
-      ocamldep src/test_menhir1.ml.d
-      ocamldep src/test_base.mli.d
-      ocamldep src/test_menhir1.mli.d
+      ocamldep src/.test.eobjs/test_menhir1.ml.d
+      ocamldep src/.test.eobjs/test_base.mli.d
+      ocamldep src/.test.eobjs/test_menhir1.mli.d
         ocamlc src/.test.eobjs/test_menhir1.{cmi,cmti}
         ocamlc src/.test.eobjs/lexer1.{cmi,cmo,cmt}
         ocamlc src/.test.eobjs/test_base.{cmi,cmti}

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -1,5 +1,5 @@
   $ dune build @print-merlins --display short
-      ocamldep sanitize-dot-merlin/sanitize_dot_merlin.ml.d
+      ocamldep sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/sanitize_dot_merlin.ml.d
         ocamlc sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/sanitize_dot_merlin.{cmi,cmo,cmt}
       ocamlopt sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/sanitize_dot_merlin.{cmx,o}
       ocamlopt sanitize-dot-merlin/sanitize_dot_merlin.exe

--- a/test/blackbox-tests/test-cases/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/multiple-private-libs/run.t
@@ -2,11 +2,11 @@ This test checks that there is no clash when two private libraries have the same
 
   $ dune build --display short @doc-private
           odoc _doc/_html/odoc.css
-      ocamldep a/test.ml.d
+      ocamldep a/.test.objs/test.ml.d
         ocamlc a/.test.objs/test.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/test@a/test.odoc
           odoc _doc/_html/test@a/Test/.jbuilder-keep,_doc/_html/test@a/Test/index.html
-      ocamldep b/test.ml.d
+      ocamldep b/.test.objs/test.ml.d
         ocamlc b/.test.objs/test.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/test@b/test.odoc
           odoc _doc/_html/test@b/Test/.jbuilder-keep,_doc/_html/test@b/Test/index.html

--- a/test/blackbox-tests/test-cases/no-installable-mode/run.t
+++ b/test/blackbox-tests/test-cases/no-installable-mode/run.t
@@ -14,7 +14,7 @@ However, it is possible to build a private one explicitly.
 
   $ dune build --root=private --display=short myprivatelib.so
   Entering directory 'private'
-      ocamldep myprivatelib.ml.d
+      ocamldep .myprivatelib.eobjs/myprivatelib.ml.d
         ocamlc .myprivatelib.eobjs/myprivatelib.{cmi,cmo,cmt}
       ocamlopt .myprivatelib.eobjs/myprivatelib.{cmx,o}
       ocamlopt myprivatelib$ext_dll

--- a/test/blackbox-tests/test-cases/ocamldep-multi-stanzas/run.t
+++ b/test/blackbox-tests/test-cases/ocamldep-multi-stanzas/run.t
@@ -25,7 +25,7 @@
   each module cannot appear in more than one "modules" field - it must belong
   to a single library or executable.
   This warning will become an error in the future.
-      ocamldep src/x.ml.d
+      ocamldep src/.a.objs/x.ml.d
         ocamlc src/.a.objs/a.{cmi,cmo,cmt}
         ocamlc src/.a.objs/a__X.{cmi,cmo,cmt}
         ocamlc src/a.cma

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -1,18 +1,18 @@
   $ dune build @doc --display short
-      ocamldep bar.ml.d
+      ocamldep .bar.objs/bar.ml.d
         ocamlc .bar.objs/bar.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/bar/bar.odoc
           odoc _doc/_html/bar/Bar/.jbuilder-keep,_doc/_html/bar/Bar/index.html
           odoc _doc/_odoc/pkg/bar/page-index.odoc
           odoc _doc/_html/bar/index.html
           odoc _doc/_html/odoc.css
-      ocamldep foo_byte.ml.d
+      ocamldep .foo_byte.objs/foo_byte.ml.d
         ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
-      ocamldep foo.ml.d
+      ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo.odoc
-      ocamldep foo2.ml.d
+      ocamldep .foo.objs/foo2.ml.d
         ocamlc .foo.objs/foo2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo2.odoc
           odoc _doc/_html/foo/Foo/.jbuilder-keep,_doc/_html/foo/Foo/index.html

--- a/test/blackbox-tests/test-cases/output-obj/run.t
+++ b/test/blackbox-tests/test-cases/output-obj/run.t
@@ -1,5 +1,5 @@
   $ dune build --display short @all
-      ocamldep test.ml.d
+      ocamldep .test.eobjs/test.ml.d
         ocamlc .test.eobjs/test.{cmi,cmo,cmt}
         ocamlc test.bc.o
            gcc static.bc

--- a/test/blackbox-tests/test-cases/package-dep/run.t
+++ b/test/blackbox-tests/test-cases/package-dep/run.t
@@ -1,6 +1,6 @@
   $ dune runtest --display short
-      ocamldep bar.ml.d
-      ocamldep foo.ml.d
+      ocamldep .bar.objs/bar.ml.d
+      ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
         ocamlc .bar.objs/bar.{cmi,cmo,cmt}
         ocamlc bar.cma

--- a/test/blackbox-tests/test-cases/ppx-rewriter/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter/run.t
@@ -1,18 +1,18 @@
   $ dune build ./w_omp_driver.exe --display short
-      ocamldep ppx/fooppx.ml.d
+      ocamldep ppx/.fooppx.objs/fooppx.ml.d
         ocamlc ppx/.fooppx.objs/fooppx.{cmi,cmo,cmt}
       ocamlopt ppx/.fooppx.objs/fooppx.{cmx,o}
       ocamlopt ppx/fooppx.{a,cmxa}
       ocamlopt .ppx/jbuild/fooppx/ppx.exe
            ppx w_omp_driver.pp.ml
-      ocamldep w_omp_driver.pp.ml.d
+      ocamldep .w_omp_driver.eobjs/w_omp_driver.pp.ml.d
         ocamlc .w_omp_driver.eobjs/w_omp_driver.{cmi,cmo,cmt}
       ocamlopt .w_omp_driver.eobjs/w_omp_driver.{cmx,o}
       ocamlopt w_omp_driver.exe
   $ dune build ./w_ppx_driver.exe --display short
       ocamlopt .ppx/jbuild/ppx_driver.runner/ppx.exe
            ppx w_ppx_driver.pp.ml
-      ocamldep w_ppx_driver.pp.ml.d
+      ocamldep .w_ppx_driver.eobjs/w_ppx_driver.pp.ml.d
         ocamlc .w_ppx_driver.eobjs/w_ppx_driver.{cmi,cmo,cmt}
       ocamlopt .w_ppx_driver.eobjs/w_ppx_driver.{cmx,o}
       ocamlopt w_ppx_driver.exe

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -5,7 +5,7 @@ public libraries may not have private dependencies
   File "dune", line 8, characters 12-22:
   Error: Library "privatelib" is private, it cannot be a dependency of a public library.
   You need to give "privatelib" a public name.
-      ocamldep publiclib.ml.d
+      ocamldep .publiclib.objs/publiclib.ml.d
   [1]
 
 On the other hand, public libraries may have private preprocessors
@@ -16,7 +16,7 @@ On the other hand, public libraries may have private preprocessors
       ocamlopt ppx_internal.{a,cmxa}
       ocamlopt .ppx/jbuild/ppx_internal@mylib/ppx.exe
            ppx mylib.pp.ml
-      ocamldep mylib.pp.ml.d
+      ocamldep .mylib.objs/mylib.pp.ml.d
         ocamlc .mylib.objs/mylib.{cmi,cmo,cmt}
       ocamlopt .mylib.objs/mylib.{cmx,o}
       ocamlopt mylib.{a,cmxa}
@@ -34,13 +34,13 @@ Unless they introduce private runtime dependencies:
       ocamlopt private_ppx.{a,cmxa}
       ocamlopt .ppx/jbuild/private_ppx@mylib/ppx.exe
            ppx mylib.pp.ml
-      ocamldep mylib.pp.ml.d
+      ocamldep .mylib.objs/mylib.pp.ml.d
   [1]
 
 However, public binaries may accept private dependencies
   $ dune build --display short --root exes
   Entering directory 'exes'
-      ocamldep publicbin.ml.d
+      ocamldep .publicbin.eobjs/publicbin.ml.d
         ocamlc .publicbin.eobjs/publicbin.{cmi,cmo,cmt}
       ocamlopt .publicbin.eobjs/publicbin.{cmx,o}
       ocamlopt publicbin.exe

--- a/test/blackbox-tests/test-cases/scope-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-bug/run.t
@@ -1,8 +1,8 @@
   $ dune build --display short @install
-      ocamldep alib/alib.ml.d
-      ocamldep alib/main.ml.d
-      ocamldep blib/blib.ml.d
-      ocamldep blib/sub/sub.ml.d
+      ocamldep alib/.alib.objs/alib.ml.d
+      ocamldep alib/.alib.objs/main.ml.d
+      ocamldep blib/.blib.objs/blib.ml.d
+      ocamldep blib/sub/.sub.objs/sub.ml.d
         ocamlc blib/sub/.sub.objs/sub.{cmi,cmo,cmt}
         ocamlc blib/.blib.objs/blib.{cmi,cmo,cmt}
         ocamlc blib/blib.cma

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -12,7 +12,7 @@
       ocamlopt .ppx/jbuild/a.kernel/ppx.exe
       ocamlopt .ppx/jbuild/a/ppx.exe
            ppx b/b.pp.ml
-      ocamldep b/b.pp.ml.d
+      ocamldep b/.b.objs/b.pp.ml.d
         ocamlc b/.b.objs/b.{cmi,cmo,cmt}
       ocamlopt b/.b.objs/b.{cmx,o}
       ocamlopt b/b.{a,cmxa}

--- a/test/blackbox-tests/test-cases/select/run.t
+++ b/test/blackbox-tests/test-cases/select/run.t
@@ -1,11 +1,11 @@
   $ dune runtest --display short
-      ocamldep bar.ml.d
-      ocamldep bar_no_unix.ml.d
-      ocamldep bar_unix.ml.d
-      ocamldep foo.ml.d
-      ocamldep foo_fake.ml.d
-      ocamldep foo_no_fake.ml.d
-      ocamldep main.ml.d
+      ocamldep .main.eobjs/bar.ml.d
+      ocamldep .main.eobjs/bar_no_unix.ml.d
+      ocamldep .main.eobjs/bar_unix.ml.d
+      ocamldep .main.eobjs/foo.ml.d
+      ocamldep .main.eobjs/foo_fake.ml.d
+      ocamldep .main.eobjs/foo_no_fake.ml.d
+      ocamldep .main.eobjs/main.ml.d
         ocamlc .main.eobjs/bar.{cmi,cmo,cmt}
       ocamlopt .main.eobjs/bar.{cmx,o}
         ocamlc .main.eobjs/foo.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/utop/run.t
+++ b/test/blackbox-tests/test-cases/utop/run.t
@@ -1,6 +1,6 @@
   $ dune utop --display short forutop -- init_forutop.ml
       ocamldep forutop/.utop/utop.ml.d
-      ocamldep forutop/forutop.ml.d
+      ocamldep forutop/.forutop.objs/forutop.ml.d
         ocamlc forutop/.forutop.objs/forutop.{cmi,cmo,cmt}
         ocamlc forutop/forutop.cma
         ocamlc forutop/.utop/utop.{cmi,cmo,cmt}


### PR DESCRIPTION
We were talking with @trefis eariler about some limitation of `copy_files` and it occurred to me that if we generated the various .d, .pp files in the object directory we could safely and easily support multi-directories library without having to use `copy_files`.

This PR moves the .d files to the object directory. A nice side-effect is that we can get rid of the `already_used` set, which simplifies a bit the code.
