### PR TITLE
Refactor ordered set lang

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -354,7 +354,7 @@ module Unexpanded = struct
 
   let t =
     let open Sexp.Of_sexp in
-    peek raw >>= function
+    peek_exn >>= function
     | Atom _ | Quoted_string _ as sexp ->
       of_sexp_errorf (Sexp.Ast.loc sexp)
         "if you meant for this to be executed with bash, write (bash \"...\") instead"
@@ -614,7 +614,7 @@ module Promotion = struct
 
     let t =
       let open Sexp.Of_sexp in
-      peek raw >>= function
+      peek_exn >>= function
       | List (_, [_; Atom (_, A "as"); _]) ->
         enter
           (Path.t >>= fun src ->

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -6,10 +6,10 @@ module Ast = struct
   type unexpanded = Unexpanded
   type ('a, _) t =
     | Element : 'a -> ('a, _) t
-    | Special : Loc.t * string -> ('a, _) t
+    | Standard : ('a, _) t
     | Union : ('a, 'b) t list -> ('a, 'b) t
     | Diff : ('a, 'b) t * ('a, 'b) t -> ('a, 'b) t
-    | Include : String_with_vars.t -> ('a, unexpanded) t
+    | Include : Univ_map.t * String_with_vars.t -> ('a, unexpanded) t
 end
 
 type 'ast generic =
@@ -21,40 +21,68 @@ type ast_expanded = (Loc.t * string, Ast.expanded) Ast.t
 type t = ast_expanded generic
 let loc t = t.loc
 
-let parse_general sexp ~f =
-  let rec of_sexp : Sexp.Ast.t -> _ = function
-    | Atom (loc, A "\\") -> Loc.fail loc "unexpected \\"
-    | (Atom (_, A "") | Quoted_string (_, _)) as t -> Ast.Element (f t)
-    | Atom (loc, A s) as t ->
-      if s.[0] = ':' then
-        Special (loc, String.sub s ~pos:1 ~len:(String.length s - 1))
-      else
-        Element (f t)
-    | List (_, sexps) -> of_sexps [] sexps
-  and of_sexps acc = function
-    | Atom (_, A "\\") :: sexps ->
-       Diff (Union (List.rev acc), of_sexps [] sexps)
-    | elt :: sexps ->
-      of_sexps (of_sexp elt :: acc) sexps
-    | [] -> Union (List.rev acc)
-  in
-  of_sexp sexp
+module Parse = struct
+  open Stanza.Of_sexp
+  open Ast
+
+  let generic ~inc ~elt =
+    let open Stanza.Of_sexp in
+    let rec one () =
+      peek_exn >>= function
+      | Atom (loc, A "\\") -> Loc.fail loc "unexpected \\"
+      | (Atom (_, A "") | Quoted_string (_, _)) ->
+        elt >>| fun x -> Element x
+      | Atom (loc, A s) -> begin
+          match s with
+          | ":standard" ->
+            junk >>> return Standard
+          | ":include" ->
+            Loc.fail loc
+              "Invalid use of :include, should be: (:include <filename>)"
+          | _ when s.[0] = ':' ->
+            Loc.fail loc "undefined symbol %s" s
+          | _ ->
+            elt >>| fun x -> Element x
+        end
+      | List (_, Atom (_, A ":include") :: _) -> inc
+      | List _ -> enter (many [])
+    and many acc =
+      peek >>= function
+      | None -> return (Union (List.rev acc))
+      | Some (Atom (_, A "\\")) ->
+        junk >>> many [] >>| fun to_remove ->
+        Diff (Union (List.rev acc), to_remove)
+      | Some _ ->
+        one () >>= fun x ->
+        many (x :: acc)
+    in
+    one ()
+
+  let with_include ~elt =
+    generic ~elt ~inc:(
+      sum [ ":include",
+            get_all >>= fun ctx ->
+            String_with_vars.t >>| fun s ->
+            Include (ctx, s)
+          ])
+
+  let without_include ~elt =
+    generic ~elt ~inc:(
+      enter
+        (loc >>= fun loc ->
+         Loc.fail loc "(:include ...) is not allowed here"))
+end
+
 
 let t =
-  let open Sexp.Of_sexp in
-  raw >>| fun sexp ->
-  let ast =
-    parse_general sexp ~f:(function
-      | Atom (loc, A s) | Quoted_string (loc, s) -> (loc, s)
-      | List _ -> assert false)
-  in
-  { ast
-  ; loc = Some (Sexp.Ast.loc sexp)
-  }
+  let open Stanza.Of_sexp in
+  located (Parse.without_include ~elt:(plain_string (fun ~loc s -> (loc, s))))
+  >>| fun (loc, ast) ->
+  { ast; loc = Some loc }
 
 let is_standard t =
   match (t.ast : ast_expanded) with
-  | Ast.Special (_, "standard") -> true
+  | Ast.Standard -> true
   | _ -> false
 
 module type Value = sig
@@ -96,18 +124,14 @@ module Make(Key : Key)(Value : Value with type key = Key.t) = struct
   end
 
   module Make(M : Named_values) = struct
-    let eval t ~parse ~special_values =
+    let eval t ~parse ~standard =
       let rec of_ast (t : ast_expanded) =
         let open Ast in
         match t with
         | Element (loc, s) ->
           let x = parse ~loc s in
           M.singleton x
-        | Special (loc, name) -> begin
-            match String.Map.find special_values name with
-            | Some x -> x
-            | None   -> Loc.fail loc "undefined symbol %s" name
-          end
+        | Standard -> standard
         | Union elts -> M.union (List.map elts ~f:of_ast)
         | Diff (left, right) ->
           let left  = of_ast left  in
@@ -154,71 +178,55 @@ module Make(Key : Key)(Value : Value with type key = Key.t) = struct
     if is_standard t then
       standard (* inline common case *)
     else
-      Ordered.eval t ~parse
-        ~special_values:(String.Map.singleton "standard" standard)
+      Ordered.eval t ~parse ~standard
 
   let eval_unordered t ~parse ~standard =
     if is_standard t then
       standard (* inline common case *)
     else
-      Unordered.eval t ~parse
-        ~special_values:(String.Map.singleton "standard" standard)
+      Unordered.eval t ~parse ~standard
 end
 
 let standard =
-  { ast = Ast.Special (Loc.none, "standard")
+  { ast = Ast.Standard
   ; loc = None
   }
 
 module Unexpanded = struct
-  type ast = (Sexp.Ast.t, Ast.unexpanded) Ast.t
+  type ast = (String_with_vars.t, Ast.unexpanded) Ast.t
   type t = ast generic
   let t =
-    let open Sexp.Of_sexp in
-    raw >>| fun sexp ->
-    let rec map (t : (Sexp.Ast.t, Ast.expanded) Ast.t) =
-      let open Ast in
-      match t with
-      | Element x -> Element x
-      | Union [Special (_, "include"); Element fn] ->
-        Include (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty fn)
-      | Union [Special (loc, "include"); _]
-      | Special (loc, "include") ->
-        Loc.fail loc "(:include expects a single element (do you need to quote the filename?)"
-      | Special (l, s) -> Special (l, s)
-      | Union l ->
-        Union (List.map l ~f:map)
-      | Diff (l, r) ->
-        Diff (map l, map r)
-    in
-    { ast = map (parse_general sexp ~f:(fun x -> x))
-    ; loc = Some (Sexp.Ast.loc sexp)
+    let open Stanza.Of_sexp in
+    located (Parse.with_include ~elt:String_with_vars.t)
+    >>| fun (loc, ast) ->
+    { ast
+    ; loc = Some loc
     }
 
   let sexp_of_t t =
     let open Ast in
     let rec loop : ast -> Sexp.t = function
-      | Element sexp -> Usexp.Ast.remove_locs sexp
-      | Special (_, s) -> Sexp.atom (":" ^ s)
+      | Element s -> String_with_vars.sexp_of_t s
+      | Standard -> Sexp.atom ":standard"
       | Union l -> List (List.map l ~f:loop)
       | Diff (a, b) -> List [loop a; Sexp.unsafe_atom_of_string "\\"; loop b]
-      | Include fn -> List [ Sexp.unsafe_atom_of_string ":include"
-                           ; String_with_vars.sexp_of_t fn
-                           ]
+      | Include (_, fn) ->
+        List [ Sexp.unsafe_atom_of_string ":include"
+             ; String_with_vars.sexp_of_t fn
+             ]
     in
     loop t.ast
 
   let standard = standard
 
-  let field ?(default=standard) name = Sexp.Of_sexp.field name t ~default
+  let field ?(default=standard) name = Stanza.Of_sexp.field name t ~default
 
   let files t ~f =
     let rec loop acc (t : ast) =
       let open Ast in
       match t with
-      | Element _
-      | Special _ -> acc
-      | Include fn ->
+      | Element _ | Standard -> acc
+      | Include (_, fn) ->
         String.Set.add acc (f fn)
       | Union l ->
         List.fold_left l ~init:acc ~f:loop
@@ -231,7 +239,7 @@ module Unexpanded = struct
     let rec loop (t : ast) =
       let open Ast in
       match t with
-      | Special _ | Include _ -> true
+      | Standard | Include _ -> true
       | Element _ -> false
       | Union l ->
         List.exists l ~f:loop
@@ -245,11 +253,9 @@ module Unexpanded = struct
     let rec expand (t : ast) : ast_expanded =
       let open Ast in
       match t with
-      | Element s ->
-        Element (Sexp.Ast.loc s,
-                 f (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty s))
-      | Special (l, s) -> Special (l, s)
-      | Include fn ->
+      | Element s -> Element (String_with_vars.loc s, f s)
+      | Standard -> Standard
+      | Include (ctx, fn) ->
         let sexp =
           let fn = f fn in
           match String.Map.find files_contents fn with
@@ -262,9 +268,13 @@ module Unexpanded = struct
                            (String.Map.keys files_contents)
               ]
         in
-        parse_general sexp ~f:(fun sexp ->
-          (Sexp.Ast.loc sexp,
-           f (Sexp.Of_sexp.parse String_with_vars.t Univ_map.empty sexp)))
+        let open Stanza.Of_sexp in
+        parse
+          (Parse.without_include
+             ~elt:(String_with_vars.t >>| fun s ->
+                   (String_with_vars.loc s, f s)))
+          ctx
+          sexp
       | Union l -> Union (List.map l ~f:expand)
       | Diff (l, r) ->
         Diff (expand l, expand r)

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -589,7 +589,7 @@ let of_string ?error_loc s =
 
 let t =
   Sexp.Of_sexp.(
-    peek raw >>= function
+    peek_exn >>= function
     | Atom _ | Quoted_string _ ->
       (* necessary for old build dirs *)
       plain_string (fun ~loc:_ s -> of_string s)

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -226,9 +226,16 @@ module Of_sexp = struct
     | sexp :: sexps -> (f (get_user_context ctx) sexp, sexps)
   [@@inline always]
 
-  let peek t ctx sexps =
-    let x, _ = t ctx sexps in
-    (x, sexps)
+  let peek _ctx sexps =
+    match sexps with
+    | [] -> (None, sexps)
+    | sexp :: _ -> (Some sexp, sexps)
+  [@@inline always]
+
+  let peek_exn ctx sexps =
+    match sexps with
+    | [] -> end_of_list ctx
+    | sexp :: _ -> (sexp, sexps)
   [@@inline always]
 
   let junk = next ignore

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -132,6 +132,7 @@ module Of_sexp = struct
     | Fields (_, _, uc) -> uc
 
   let get key ctx state = (Univ_map.find (get_user_context ctx) key, state)
+  let get_all ctx state = (get_user_context ctx, state)
 
   let set : type a b k. a Univ_map.Key.t -> a -> (b, k) parser -> (b, k) parser
     = fun key v t ctx state ->

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -152,8 +152,11 @@ module Of_sexp : sig
   (** Unparsed next element of the input *)
   val raw : ast t
 
-  (** Inspect the input without consuming it *)
-  val peek : 'a t -> 'a t
+  (** Inspect the next element of the input without consuming it *)
+  val peek : ast option t
+
+  (** Same as [peek] but fail if the end of input is reached *)
+  val peek_exn : ast t
 
   (** Consume and ignore the next element of the input *)
   val junk : unit t

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -109,6 +109,7 @@ module Of_sexp : sig
   (** Access to the context *)
   val get : 'a Univ_map.Key.t -> ('a option, _) parser
   val set : 'a Univ_map.Key.t -> 'a -> ('b, 'k) parser -> ('b, 'k) parser
+  val get_all : (Univ_map.t, _) parser
   val set_many : Univ_map.t -> ('a, 'k) parser -> ('a, 'k) parser
 
   (** Return the location of the list currently being parsed. *)

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -57,7 +57,7 @@ module Context = struct
 
   let t ~profile =
     Sexp.Of_sexp.(
-      peek raw >>= function
+      peek_exn >>= function
       | Atom _ | Quoted_string _ ->
         enum [ "default",
                Default { targets = [Native]


### PR DESCRIPTION
Following #915 I looked at reducing the number of parentheses required for `flags` fields. However the current `ordered_set_lang.ml` file was starting to be a bit complicated, so this feature only refactors it. In particular:

- I used the new S-expression parsing API
- I got rid of `Special` in favor of just `Standard`
- the argument of `Element` in `Unexpanded` is now simply `String_with_Vars.t` rather than `Sexp.Ast.t`
- The parsing of `(:include ...)` is now done directly in the generic parser if includes are allowed
- the parsing context is preserved for `(:include ...)`