### PR TITLE
Add a default alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,13 @@ next
 
 - Version `dune-workspace` and `~/.config/dune/config` files (#..., @diml)
 
+- Add the ability to build an alias non-recursively from the command
+  line by writing `@@alias` (#926, @diml)
+
+- Add a special `default` alias that defaults to `(alias_rec install)`
+  when not defined by the user and make `@@default` be the default
+  target (#926, @diml)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -531,6 +531,8 @@ menhir
 A ``menhir`` stanza is available to support the menhir_ parser generator. See
 the :ref:`menhir-main` section for details.
 
+.. _alias-stanza:
+
 alias
 -----
 

--- a/doc/terminology.rst
+++ b/doc/terminology.rst
@@ -50,6 +50,9 @@ Terminology
    alias in all children directories recursively. Jbuilder defines the
    following standard aliases:
 
+   -  ``default`` which is the alias build by default when no targets
+      are specified on the command line. See :ref:`default-alias` for
+      details
    -  ``runtest`` which runs user defined tests
    -  ``install`` which depends on everything that should be installed
    -  ``doc``     which depends on the generated HTML

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -121,6 +121,13 @@ So for instance:
    the ``foo`` build context
 -  ``jbuilder build @runtest`` will run the tests for all build contexts
 
+You can also build an alias non-recursively by using ``@@`` instead of
+``@``. For instance to run tests only from the current directory:
+
+.. code::
+
+   dune build @@runtest
+
 Finding external libraries
 ==========================
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -68,8 +68,9 @@ directory as this is normally the case.
 Interpretation of targets
 =========================
 
-This section describes how ``jbuilder`` interprets the targets given on
-the command line.
+This section describes how ``dune`` interprets the targets given on
+the command line. When no targets are specified, ``dune`` builds the
+``default`` alias, see :ref:`default-alias` for more details.
 
 Resolution
 ----------
@@ -127,6 +128,31 @@ You can also build an alias non-recursively by using ``@@`` instead of
 .. code::
 
    dune build @@runtest
+
+.. _default-alias:
+
+Default alias
+-------------
+
+When no targets are given to ``dune build``, it builds the special
+``default`` alias. Effectively ``dune build`` is equivalent to:
+
+.. code::
+
+   dune build @@default
+
+When a directory doesn't explicitly define what the ``default`` alias
+means via an :ref:`alias-stanza` stanza, the following implicit
+definition is assumed:
+
+.. code::
+
+   (alias
+    (name default)
+    (deps (alias_rec install)))
+
+Which means that by default ``dune build`` will build everything that
+is installable.
 
 Finding external libraries
 ==========================
@@ -214,7 +240,7 @@ follows:
     build: [["dune" "build" "-p" name "-j" jobs]]
 
 ``-p pkg`` is a shorthand for ``--root . --only-packages pkg --profile
-release``. ``-p`` is the short version of
+release --default-target @install``. ``-p`` is the short version of
 ``--for-release-of-packages``.
 
 This has the following effects:
@@ -224,6 +250,7 @@ This has the following effects:
 -  it sets the root to prevent jbuilder from looking it up
 -  it sets the build profile to ``release``
 -  it uses whatever concurrency option opam provides
+-  it sets the default target to ``@install`` rather than ``@@default``
 
 Note that ``name`` and ``jobs`` are variables expanded by opam. ``name``
 expands to the package name and ``jobs`` to the number of jobs available

--- a/src/build.ml
+++ b/src/build.ml
@@ -37,6 +37,7 @@ module Repr = struct
     | Fail : fail -> (_, _) t
     | Memo : 'a memo -> (unit, 'a) t
     | Catch : ('a, 'b) t * (exn -> 'b) -> ('a, 'b) t
+    | Lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
 
   and 'a memo =
     { name          : string
@@ -131,6 +132,8 @@ let rec all = function
     t &&& all ts
     >>>
     arr (fun (x, y) -> x :: y)
+
+let lazy_no_targets t = Lazy_no_targets t
 
 let path p = Paths (Path.Set.singleton p)
 let paths ps = Paths (Path.Set.of_list ps)

--- a/src/build.mli
+++ b/src/build.mli
@@ -34,6 +34,10 @@ val fanout4 : ('a, 'b) t -> ('a, 'c) t -> ('a, 'd) t -> ('a, 'e) t -> ('a, 'b * 
 
 val all : ('a, 'b) t list -> ('a, 'b list) t
 
+(** Optimization to avoiding eagerly computing a [Build.t] value,
+    assume it contains no targets. *)
+val lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
+
 (* CR-someday diml: this API is not great, what about:
 
    {[
@@ -202,6 +206,7 @@ module Repr : sig
     | Fail : fail -> (_, _) t
     | Memo : 'a memo -> (unit, 'a) t
     | Catch : ('a, 'b) t * (exn -> 'b) -> ('a, 'b) t
+    | Lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
 
   and 'a memo =
     { name          : string

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -675,13 +675,22 @@ let no_rule_found =
     die "No rule found for %s" (Utils.describe_target fn)
   in
   fun t fn ->
-    match Path.extract_build_context fn with
-    | None -> fail fn
-    | Some (ctx, _) ->
+    match Utils.analyse_target fn with
+    | Other _ -> fail fn
+    | Regular (ctx, _) ->
       if String.Map.mem t.contexts ctx then
         fail fn
       else
         die "Trying to build %s but build context %s doesn't exist.%s"
+          (Path.to_string_maybe_quoted fn)
+          ctx
+          (hint ctx (String.Map.keys t.contexts))
+    | Alias (ctx, fn') ->
+      if String.Map.mem t.contexts ctx then
+        fail fn
+      else
+        let fn = Path.append (Path.relative Path.build_dir ctx) fn' in
+        die "Trying to build alias %s but build context %s doesn't exist.%s"
           (Path.to_string_maybe_quoted fn)
           ctx
           (hint ctx (String.Map.keys t.contexts))

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -129,6 +129,14 @@ module Alias : sig
   (** [dep t = Build.path (stamp_file t)] *)
   val dep : t -> ('a, 'a) Build.t
 
+  (** Implements [@@alias] on the command line *)
+  val dep_multi_contexts
+    :  dir:Path.t
+    -> name:string
+    -> file_tree:File_tree.t
+    -> contexts:string list
+    -> (unit, unit) Build.t
+
   (** Implements [(alias_rec ...)] in dependency specification *)
   val dep_rec
     :  t

--- a/test/blackbox-tests/test-cases/aliases/run.t
+++ b/test/blackbox-tests/test-cases/aliases/run.t
@@ -13,7 +13,7 @@
   running in src
   $ dune build --display short @plop
   From the command line:
-  Error: Alias plop is empty.
+  Error: Alias "plop" is empty.
   It is not defined in . or any of its descendants.
   [1]
   $ dune build --display short @truc/x


### PR DESCRIPTION
This PR adds a special `default` alias which become the new default target.

## Definition

When the `default` alias is not explictely defined in a directory, it is implicitely defined as follow:

```scheme
(alias
 (name default)
 (deps (alias_rec install)))
```

Otherwise the user definition is used.

## Default target

The default target is changed from building recursively the alias `install` to building the `default` only in the current directory. This allows to redefine what `dune build` in different directories.

In order to represent that, a new syntax is added to the command line: `@@x` means building alias `x` in the current directory. In the end `dune build` is equivalent to `dune build @@default`.

`dune build -p x` still means `dune build -p x @install`. This is done by adding a command line option `--default-target` and making `-p` imply `--default-target @install`.

## Future work

It'd be nice to allow to define what the default target means in any directory of a project. A nice way to do that would be to allow a `copy_in_subdirs` field to alias stanza that would cause the the alias stanza to be copied in all directories of the project, so that a user may write in the dune-project file:

```scheme
(alias
 ((name default)
  (copy_in_subdirs)
  (deps (alias_rec install) (alias_rec runtest))))
```

## Implementation details

`(alias_rec ...)` requires recursive throught the file tree. Since it is now uses for every single directory through the default alias, a bit of laziness was added to `Build.t`.