### PR TITLE
Fix the build on 4.02 by emulating -no-keep-locs

### DIFF
--- a/doc/jbuild.rst
+++ b/doc/jbuild.rst
@@ -183,6 +183,9 @@ modules you want.
 - ``(allow_overlapping_dependencies)`` allows external dependencies to
   overlap with libraries that are present in the workspace
 
+- ``(no_keep_locs)`` undocumented, it is a necessary hack until this
+  is implemented: https://github.com/ocaml/dune/issues/921
+
 Note that when binding C libraries, Jbuilder doesn't provide special support for
 tools such as ``pkg-config``, however it integrates easily with configurator_ by
 using ``(c_flags (:include ...))`` and ``(c_library_flags (:include ...))``.

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -46,6 +46,7 @@ type t =
   ; requires             : Lib.t list Or_exn.t
   ; includes             : Includes.t
   ; preprocessing        : Preprocessing.t
+  ; no_keep_locs         : bool
   }
 
 let super_context        t = t.super_context
@@ -60,10 +61,11 @@ let flags                t = t.flags
 let requires             t = t.requires
 let includes             t = t.includes
 let preprocessing        t = t.preprocessing
+let no_keep_locs         t = t.no_keep_locs
 
 let create ~super_context ~scope ~dir ?(dir_kind=File_tree.Dune_file.Kind.Dune)
       ?(obj_dir=dir) ~modules ?alias_module ?lib_interface_module ~flags
-      ~requires ?(preprocessing=Preprocessing.dummy) () =
+      ~requires ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false) () =
   { super_context
   ; scope
   ; dir
@@ -76,6 +78,7 @@ let create ~super_context ~scope ~dir ?(dir_kind=File_tree.Dune_file.Kind.Dune)
   ; requires
   ; includes = Includes.make super_context ~requires
   ; preprocessing
+  ; no_keep_locs
   }
 
 let for_alias_module t =

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -24,6 +24,7 @@ val create
   -> flags                 : Ocaml_flags.t
   -> requires              : Lib.t list Or_exn.t
   -> ?preprocessing        : Preprocessing.t
+  -> ?no_keep_locs         : bool
   -> unit
   -> t
 
@@ -42,3 +43,4 @@ val flags                : t -> Ocaml_flags.t
 val requires             : t -> Lib.t list Or_exn.t
 val includes             : t -> string list Arg_spec.t Cm_kind.Dict.t
 val preprocessing        : t -> Preprocessing.t
+val no_keep_locs         : t -> bool

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -578,6 +578,7 @@ module Gen(P : Install_rules.Params) = struct
         ~flags
         ~requires
         ~preprocessing:pp
+        ~no_keep_locs:lib.no_keep_locs
     in
 
     Modules_partitioner.acknowledge modules_partitioner cctx

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -731,6 +731,7 @@ module Library = struct
     ; dynlink                  : bool
     ; project                  : Dune_project.t
     ; sub_systems              : Sub_system_info.t Sub_system_name.Map.t
+    ; no_keep_locs             : bool
     }
 
   let t =
@@ -759,6 +760,7 @@ module Library = struct
        field_b    "optional"                                               >>= fun optional                 ->
        field      "self_build_stubs_archive" (option string) ~default:None >>= fun self_build_stubs_archive ->
        field_b    "no_dynlink"                                             >>= fun no_dynlink               ->
+       field_b "no_keep_locs" >>= fun no_keep_locs ->
        Sub_system_info.record_parser () >>= fun sub_systems ->
        Dune_project.get_exn () >>= fun project ->
        return
@@ -783,6 +785,7 @@ module Library = struct
          ; dynlink = not no_dynlink
          ; project
          ; sub_systems
+         ; no_keep_locs
          })
 
   let has_stubs t =

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -205,6 +205,7 @@ module Library : sig
     ; dynlink                  : bool
     ; project                  : Dune_project.t
     ; sub_systems              : Sub_system_info.t Sub_system_name.Map.t
+    ; no_keep_locs             : bool
     }
 
   val has_stubs : t -> bool

--- a/src/which_program/dune
+++ b/src/which_program/dune
@@ -3,12 +3,8 @@
  (public_name dune.which-program)
  (synopsis    "[Internal] Standard library of Dune")
  (wrapped     false)
- (flags       (:standard (:include no-keep-locs)))
+ (no_keep_locs)
  (modules_without_implementation which_program))
 
 ; To avoid issues on Windows and OSX
 (rule (with-stdout-to which_program_dummy.ml (echo "")))
-
-(rule
- (with-stdout-to no-keep-locs
-  (run %{OCAML} %{path:gen-no-keep-locs} %{ocaml_version})))

--- a/src/which_program/dune-impl/dune
+++ b/src/which_program/dune-impl/dune
@@ -2,6 +2,6 @@
  (name        which_program_dune)
  (public_name dune.which-program.dune)
  (wrapped     false)
- (flags       (:standard (:include ../no-keep-locs))))
+ (no_keep_locs))
 
-(rule (copy# ../which_program.mli which_program.mli))
+(rule (copy ../which_program.mli which_program.mli))

--- a/src/which_program/gen-no-keep-locs
+++ b/src/which_program/gen-no-keep-locs
@@ -1,8 +1,0 @@
-(* -*- tuared -*- *)
-
-let () =
-  let ver = Scanf.sscanf Sys.argv.(1) "%u.%u" (fun a b -> a, b) in
-  if ver >= (4, 03) then
-    print_endline "(-no-keep-locs)"
-  else
-    print_endline "()"

--- a/src/which_program/jbuilder-impl/dune
+++ b/src/which_program/jbuilder-impl/dune
@@ -2,6 +2,6 @@
  (name        which_program_jbuilder)
  (public_name dune.which-program.jbuilder)
  (wrapped     false)
- (flags       (:standard (:include ../no-keep-locs))))
+ (no_keep_locs))
 
-(rule (copy# ../which_program.mli which_program.mli))
+(rule (copy ../which_program.mli which_program.mli))


### PR DESCRIPTION
The build on OCaml 4.02 is broken since #920. The issue is that `-no-keep-locs` is not supported in 4.02. To fix the issue this PR adds a field `(no_keep_locs)` to library stanzas which emulates the behavior of `-no-keep-locs` in 4.02.