### PR TITLE
Make install tests less verbose

### DIFF
--- a/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
+++ b/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
@@ -1,33 +1,4 @@
-  $ dune runtest --display short
-      ocamldep .bar.eobjs/bar.ml.d
-      ocamldep .foo.objs/foo.ml.d
-      ocamldep .foo.objs/foo.mli.d
-        ocamlc .foo.objs/foo.{cmi,cmti}
-      ocamlopt .foo.objs/foo.{cmx,o}
-      ocamlopt foo.{a,cmxa}
-      ocamlopt foo.cmxs
-      ocamldep .foo_byte.objs/foo_byte.ml.d
-        ocamlc .foo_byte.objs/foo_byte.{cmi,cmo,cmt}
-        ocamlc foo_byte.cma
-      ocamldep ppx-new/.foo_ppx_rewriter_dune.objs/foo_ppx_rewriter_dune.ml.d
-        ocamlc ppx-new/.foo_ppx_rewriter_dune.objs/foo_ppx_rewriter_dune.{cmi,cmo,cmt}
-      ocamlopt ppx-new/.foo_ppx_rewriter_dune.objs/foo_ppx_rewriter_dune.{cmx,o}
-      ocamlopt ppx-new/foo_ppx_rewriter_dune.{a,cmxa}
-      ocamlopt ppx-new/foo_ppx_rewriter_dune.cmxs
-      ocamldep ppx-old/.foo_ppx_rewriter_jbuild.objs/foo_ppx_rewriter_jbuild.ml.d
-        ocamlc ppx-old/.foo_ppx_rewriter_jbuild.objs/foo_ppx_rewriter_jbuild.{cmi,cmo,cmt}
-      ocamlopt ppx-old/.foo_ppx_rewriter_jbuild.objs/foo_ppx_rewriter_jbuild.{cmx,o}
-      ocamlopt ppx-old/foo_ppx_rewriter_jbuild.{a,cmxa}
-      ocamlopt ppx-old/foo_ppx_rewriter_jbuild.cmxs
-        ocamlc .foo.objs/foo.{cmo,cmt}
-        ocamlc foo.cma
-        ocamlc .bar.eobjs/bar.{cmi,cmo,cmt}
-      ocamlopt .bar.eobjs/bar.{cmx,o}
-      ocamlopt bar.exe
-        ocamlc ppx-new/foo_ppx_rewriter_dune.cma
-      ocamlopt .ppx/foo.ppx_rewriter_dune/ppx.exe
-        ocamlc ppx-old/foo_ppx_rewriter_jbuild.cma
-      ocamlopt .ppx/jbuild/foo.ppx_rewriter_jbuild/ppx.exe
+  $ dune runtest
   lib: [
     "_build/install/default/lib/foo/META" {"META"}
     "_build/install/default/lib/foo/opam" {"opam"}


### PR DESCRIPTION
--display short isn't useful for many tests.