### PR TITLE
Subsystem versioned

### DIFF
--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -40,7 +40,7 @@ module Gen(P : Install_params) = struct
     SC.add_rule sctx
       (Build.arr (fun () ->
          let lang = Option.value_exn (Lib.defined_using_lang lib) in
-         Format.asprintf "%a@." (Sexp.pp Dune)
+         Format.asprintf "%a@." (Sexp.pp lang)
            (Lib.Sub_system.dump_config lib |> Installed_dune_file.gen ~lang))
        >>> Build.write_file_dyn
              (lib_dune_file ~dir:(Lib.src_dir lib) ~name:(Lib.name lib)))

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -39,8 +39,9 @@ module Gen(P : Install_params) = struct
   let gen_lib_dune_file lib =
     SC.add_rule sctx
       (Build.arr (fun () ->
+         let lang = Option.value_exn (Lib.defined_using_lang lib) in
          Format.asprintf "%a@." (Sexp.pp Dune)
-           (Lib.Sub_system.dump_config lib |> Installed_dune_file.gen))
+           (Lib.Sub_system.dump_config lib |> Installed_dune_file.gen ~lang))
        >>> Build.write_file_dyn
              (lib_dune_file ~dir:(Lib.src_dir lib) ~name:(Lib.name lib)))
 

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -39,9 +39,11 @@ module Gen(P : Install_params) = struct
   let gen_lib_dune_file lib =
     SC.add_rule sctx
       (Build.arr (fun () ->
-         let lang = Option.value_exn (Lib.defined_using_lang lib) in
-         Format.asprintf "%a@." (Sexp.pp lang)
-           (Lib.Sub_system.dump_config lib |> Installed_dune_file.gen ~lang))
+         let dune_version = Option.value_exn (Lib.dune_version lib) in
+         Format.asprintf "%a@."
+           (Sexp.pp (Stanza.File_kind.of_syntax dune_version))
+           (Lib.Sub_system.dump_config lib
+            |> Installed_dune_file.gen ~dune_version))
        >>> Build.write_file_dyn
              (lib_dune_file ~dir:(Lib.src_dir lib) ~name:(Lib.name lib)))
 

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -66,7 +66,7 @@ let load fname =
       (Univ_map.singleton (Syntax.key Stanza.syntax) syntax)
       (Io.Sexp.load ~lexer ~mode:Single fname))
 
-let gen ~(lang : File_tree.Dune_file.Kind.t) confs =
+let gen ~(dune_version : Syntax.Version.t) confs =
   let sexps =
     Sub_system_name.Map.to_list confs
     |> List.map ~f:(fun (name, (ver, conf)) ->
@@ -79,8 +79,11 @@ let gen ~(lang : File_tree.Dune_file.Kind.t) confs =
   Sexp.List
     [ Sexp.unsafe_atom_of_string "dune"
     ; Sexp.unsafe_atom_of_string
-        (match lang with
-         | Jbuild -> "1"
-         | Dune -> "2")
+        (match dune_version with
+         | (0, 0) -> "1"
+         | (1, 0) -> "2"
+         | _ ->
+           Exn.code_error "Cannot generate dune with unknown version"
+             ["dune_version", Syntax.Version.sexp_of_t dune_version])
     ; List sexps
     ]

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -4,7 +4,7 @@ let parse_sub_systems ~parsing_context sexps =
   List.filter_map sexps ~f:(fun sexp ->
     let name, ver, data =
       Sexp.Of_sexp.(parse (triple string (located Syntax.Version.t) raw)
-                      Univ_map.empty) sexp
+                      parsing_context) sexp
     in
     match Sub_system_name.get name with
     | None ->

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -63,15 +63,13 @@ let load fname =
       | _ ->
         Loc.fail (Sexp.Loc.of_lexbuf lexbuf) "%s" bad_dune_file
     in
-    match version with
-    | "1" ->
-      Sexp.Of_sexp.parse of_sexp Univ_map.empty
-        (Io.Sexp.load ~lexer:Sexp.Lexer.jbuild_token ~mode:Single fname)
-    | "2" ->
-      Sexp.Of_sexp.parse of_sexp Univ_map.empty
-        (Io.Sexp.load ~lexer:Sexp.Lexer.token ~mode:Single fname)
-    | _ ->
-      Loc.fail version_loc "unknown version %S" version)
+    let lexer =
+      match version with
+      | "1" -> Sexp.Lexer.jbuild_token
+      | "2" -> Sexp.Lexer.token
+      | _   -> Loc.fail version_loc "unknown version %S" version
+    in
+    Sexp.Of_sexp.parse of_sexp Univ_map.empty lexer ~mode:Single fname
 
 let gen confs =
   let sexps =

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -61,10 +61,7 @@ let load fname =
       | [Lparen; Atom (A "dune"); Atom s] ->
         (Sexp.Loc.of_lexbuf lexbuf, Sexp.Atom.to_string s)
       | _ ->
-        Loc.fail
-          { start = Lexing.lexeme_start_p lexbuf
-          ; stop = Lexing.lexeme_end_p lexbuf
-          } "%s" bad_dune_file
+        Loc.fail (Sexp.Loc.of_lexbuf lexbuf) "%s" bad_dune_file
     in
     match version with
     | "1" ->

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -63,13 +63,15 @@ let load fname =
       | _ ->
         Loc.fail (Sexp.Loc.of_lexbuf lexbuf) "%s" bad_dune_file
     in
-    let lexer =
+    let (lexer, syntax) =
       match version with
-      | "1" -> Sexp.Lexer.jbuild_token
-      | "2" -> Sexp.Lexer.token
+      | "1" -> (Sexp.Lexer.jbuild_token, (0, 0))
+      | "2" -> (Sexp.Lexer.token, (1, 0))
       | _   -> Loc.fail version_loc "unknown version %S" version
     in
-    Sexp.Of_sexp.parse of_sexp Univ_map.empty lexer ~mode:Single fname
+    Sexp.Of_sexp.parse of_sexp
+      (Univ_map.singleton (Syntax.key Stanza.syntax) syntax)
+      (Io.Sexp.load ~lexer ~mode:Single fname))
 
 let gen confs =
   let sexps =

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -43,20 +43,18 @@ let of_sexp =
 let load fname =
   Io.with_lexbuf_from_file fname ~f:(fun lexbuf ->
     let (version_loc, version) =
-      let bad_dune_file = "Unable to read (dune x.y ..) line file" in
       let rec loop = function
         | [_; _; _] as a -> List.rev a
         | acc ->
           begin match (Sexp.Lexer.token lexbuf : Sexp.Lexer.Token.t) with
-          | Eof ->
-            Loc.fail (Loc.in_file (Path.to_string fname)) "%s" bad_dune_file
+          | Eof -> List.rev acc
           | t -> loop (t :: acc)
           end
       in
       let loc = Sexp.Loc.of_lexbuf lexbuf in
       match loop [] with
       | [Lparen; Atom (A "dune"); Atom s] -> (loc, Sexp.Atom.to_string s)
-      | _ -> Loc.fail loc "%s" bad_dune_file
+      | _ -> Loc.fail loc "Unable to read (dune x.y ..) line file"
     in
     let (lexer, syntax) =
       match version with

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -57,11 +57,10 @@ let load fname =
           | t -> loop (t :: acc)
           end
       in
+      let loc = Sexp.Loc.of_lexbuf lexbuf in
       match loop [] with
-      | [Lparen; Atom (A "dune"); Atom s] ->
-        (Sexp.Loc.of_lexbuf lexbuf, Sexp.Atom.to_string s)
-      | _ ->
-        Loc.fail (Sexp.Loc.of_lexbuf lexbuf) "%s" bad_dune_file
+      | [Lparen; Atom (A "dune"); Atom s] -> (loc, Sexp.Atom.to_string s)
+      | _ -> Loc.fail loc "%s" bad_dune_file
     in
     let (lexer, syntax) =
       match version with

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -27,10 +27,10 @@ let of_sexp =
   let open Sexp.Of_sexp in
   let version =
     plain_string (fun ~loc -> function
-      | "1" -> ()
-      | _ ->
+      | "1" | "2" -> ()
+      | v ->
         of_sexp_errorf loc
-          "Unsupported version, only version 1 is supported")
+          "Unsupported version %S, only version 1 is supported" v)
   in
   sum
     [ "dune",
@@ -68,7 +68,7 @@ let load fname =
       (Univ_map.singleton (Syntax.key Stanza.syntax) syntax)
       (Io.Sexp.load ~lexer ~mode:Single fname))
 
-let gen confs =
+let gen ~(lang : File_tree.Dune_file.Kind.t) confs =
   let sexps =
     Sub_system_name.Map.to_list confs
     |> List.map ~f:(fun (name, (ver, conf)) ->
@@ -80,6 +80,9 @@ let gen confs =
   in
   Sexp.List
     [ Sexp.unsafe_atom_of_string "dune"
-    ; Sexp.unsafe_atom_of_string "1"
+    ; Sexp.unsafe_atom_of_string
+        (match lang with
+         | Jbuild -> "1"
+         | Dune -> "2")
     ; List sexps
     ]

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -99,8 +99,8 @@ let gen ~(dune_version : Syntax.Version.t) confs =
     ; Sexp.unsafe_atom_of_string
         (match dune_version with
          | (0, 0) -> "1"
-         | (1, 0) -> "2"
-         | _ ->
+         | (x, _) when x >= 1 -> "2"
+         | (_, _) ->
            Exn.code_error "Cannot generate dune with unknown version"
              ["dune_version", Syntax.Version.sexp_of_t dune_version])
     ; List sexps

--- a/src/installed_dune_file.mli
+++ b/src/installed_dune_file.mli
@@ -3,4 +3,7 @@
 open Stdune
 
 val load : Path.t -> Jbuild.Sub_system_info.t Sub_system_name.Map.t
-val gen : (Syntax.Version.t * Sexp.t) Sub_system_name.Map.t -> Sexp.t
+val gen
+  : lang:File_tree.Dune_file.Kind.t
+  -> (Syntax.Version.t * Sexp.t) Sub_system_name.Map.t
+  -> Sexp.t

--- a/src/installed_dune_file.mli
+++ b/src/installed_dune_file.mli
@@ -4,6 +4,6 @@ open Stdune
 
 val load : Path.t -> Jbuild.Sub_system_info.t Sub_system_name.Map.t
 val gen
-  : lang:File_tree.Dune_file.Kind.t
+  : dune_version:Syntax.Version.t
   -> (Syntax.Version.t * Sexp.t) Sub_system_name.Map.t
   -> Sexp.t

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -732,6 +732,7 @@ module Library = struct
     ; project                  : Dune_project.t
     ; sub_systems              : Sub_system_info.t Sub_system_name.Map.t
     ; no_keep_locs             : bool
+    ; dune_version             : Syntax.Version.t
     }
 
   let t =
@@ -763,6 +764,7 @@ module Library = struct
        field_b "no_keep_locs" >>= fun no_keep_locs ->
        Sub_system_info.record_parser () >>= fun sub_systems ->
        Dune_project.get_exn () >>= fun project ->
+       Syntax.get_exn Stanza.syntax >>= fun dune_version ->
        return
          { name
          ; public
@@ -786,6 +788,7 @@ module Library = struct
          ; project
          ; sub_systems
          ; no_keep_locs
+         ; dune_version
          })
 
   let has_stubs t =

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -206,6 +206,7 @@ module Library : sig
     ; project                  : Dune_project.t
     ; sub_systems              : Sub_system_info.t Sub_system_name.Map.t
     ; no_keep_locs             : bool
+    ; dune_version             : Syntax.Version.t
     }
 
   val has_stubs : t -> bool

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -508,9 +508,7 @@ module Sub_system = struct
   let dump_config lib =
     Sub_system_name.Map.filter_map lib.sub_systems ~f:(fun (lazy inst) ->
       let (Sub_system0.Instance.T ((module M), t)) = inst in
-      match M.to_sexp with
-      | None -> None
-      | Some f -> Some (f t))
+      Option.map ~f:(fun f -> f t) M.to_sexp)
 end
 
 (* +-----------------------------------------------------------------+

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -63,7 +63,7 @@ module Info = struct
     ; pps              : (Loc.t * Jbuild.Pp.t) list
     ; optional         : bool
     ; virtual_deps     : (Loc.t * string) list
-    ; defined_using_lang : File_tree.Dune_file.Kind.t option
+    ; dune_version : Syntax.Version.t option
     ; sub_systems      : Jbuild.Sub_system_info.t Sub_system_name.Map.t
     }
 
@@ -115,11 +115,7 @@ module Info = struct
     ; ppx_runtime_deps = conf.ppx_runtime_libraries
     ; pps = Jbuild.Preprocess_map.pps conf.buildable.preprocess
     ; sub_systems = conf.sub_systems
-    ; defined_using_lang =
-        Some
-          (match conf.project.kind with
-           | Dune -> Dune
-           | Jbuilder -> Jbuild)
+    ; dune_version = Some conf.dune_version
     }
 
   let of_findlib_package pkg =
@@ -149,7 +145,7 @@ module Info = struct
     ; (* We don't know how these are named for external libraries *)
       foreign_archives = Mode.Dict.make_both []
     ; sub_systems      = sub_systems
-    ; defined_using_lang = None
+    ; dune_version = None
     }
 end
 
@@ -244,7 +240,7 @@ type t =
   ; resolved_selects  : Resolved_select.t list
   ; optional          : bool
   ; user_written_deps : Jbuild.Lib_deps.t
-  ; defined_using_lang : File_tree.Dune_file.Kind.t option
+  ; dune_version : Syntax.Version.t option
   ; (* This is mutable to avoid this error:
 
        {[
@@ -351,7 +347,7 @@ let plugins      t = t.plugins
 let jsoo_runtime t = t.jsoo_runtime
 let unique_id    t = t.unique_id
 
-let defined_using_lang t = t.defined_using_lang
+let dune_version t = t.dune_version
 
 let src_dir t = t.src_dir
 let obj_dir t = t.obj_dir
@@ -672,7 +668,7 @@ let rec instantiate db name (info : Info.t) ~stack ~hidden =
     ; optional          = info.optional
     ; user_written_deps = Info.user_written_deps info
     ; sub_systems       = Sub_system_name.Map.empty
-    ; defined_using_lang = info.defined_using_lang
+    ; dune_version = info.dune_version
     }
   in
   t.sub_systems <-

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -63,6 +63,7 @@ module Info = struct
     ; pps              : (Loc.t * Jbuild.Pp.t) list
     ; optional         : bool
     ; virtual_deps     : (Loc.t * string) list
+    ; defined_using_lang : File_tree.Dune_file.Kind.t option
     ; sub_systems      : Jbuild.Sub_system_info.t Sub_system_name.Map.t
     }
 
@@ -114,6 +115,11 @@ module Info = struct
     ; ppx_runtime_deps = conf.ppx_runtime_libraries
     ; pps = Jbuild.Preprocess_map.pps conf.buildable.preprocess
     ; sub_systems = conf.sub_systems
+    ; defined_using_lang =
+        Some
+          (match conf.project.kind with
+           | Dune -> Dune
+           | Jbuilder -> Jbuild)
     }
 
   let of_findlib_package pkg =
@@ -143,6 +149,7 @@ module Info = struct
     ; (* We don't know how these are named for external libraries *)
       foreign_archives = Mode.Dict.make_both []
     ; sub_systems      = sub_systems
+    ; defined_using_lang = None
     }
 end
 
@@ -237,6 +244,7 @@ type t =
   ; resolved_selects  : Resolved_select.t list
   ; optional          : bool
   ; user_written_deps : Jbuild.Lib_deps.t
+  ; defined_using_lang : File_tree.Dune_file.Kind.t option
   ; (* This is mutable to avoid this error:
 
        {[
@@ -342,6 +350,8 @@ let archives     t = t.archives
 let plugins      t = t.plugins
 let jsoo_runtime t = t.jsoo_runtime
 let unique_id    t = t.unique_id
+
+let defined_using_lang t = t.defined_using_lang
 
 let src_dir t = t.src_dir
 let obj_dir t = t.obj_dir
@@ -662,6 +672,7 @@ let rec instantiate db name (info : Info.t) ~stack ~hidden =
     ; optional          = info.optional
     ; user_written_deps = Info.user_written_deps info
     ; sub_systems       = Sub_system_name.Map.empty
+    ; defined_using_lang = info.defined_using_lang
     }
   in
   t.sub_systems <-

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -26,7 +26,7 @@ val archives     : t -> Path.t list Mode.Dict.t
 val plugins      : t -> Path.t list Mode.Dict.t
 val jsoo_runtime : t -> Path.t list
 
-val defined_using_lang : t -> File_tree.Dune_file.Kind.t option
+val dune_version : t -> Syntax.Version.t option
 
 (** A unique integer identifier. It is only unique for the duration of
     the process *)
@@ -105,7 +105,7 @@ module Info : sig
     ; pps              : (Loc.t * Jbuild.Pp.t) list
     ; optional         : bool
     ; virtual_deps     : (Loc.t * string) list
-    ; defined_using_lang : File_tree.Dune_file.Kind.t option
+    ; dune_version : Syntax.Version.t option
     ; sub_systems      : Jbuild.Sub_system_info.t Sub_system_name.Map.t
     }
 

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -26,6 +26,8 @@ val archives     : t -> Path.t list Mode.Dict.t
 val plugins      : t -> Path.t list Mode.Dict.t
 val jsoo_runtime : t -> Path.t list
 
+val defined_using_lang : t -> File_tree.Dune_file.Kind.t option
+
 (** A unique integer identifier. It is only unique for the duration of
     the process *)
 val unique_id : t -> int
@@ -103,6 +105,7 @@ module Info : sig
     ; pps              : (Loc.t * Jbuild.Pp.t) list
     ; optional         : bool
     ; virtual_deps     : (Loc.t * string) list
+    ; defined_using_lang : File_tree.Dune_file.Kind.t option
     ; sub_systems      : Jbuild.Sub_system_info.t Sub_system_name.Map.t
     }
 

--- a/src/stanza.ml
+++ b/src/stanza.ml
@@ -16,7 +16,7 @@ module File_kind = struct
   type t = Sexp.syntax = Jbuild | Dune
 
   let of_syntax = function
-    | (0, 0) -> Jbuild
+    | (0, _) -> Jbuild
     | (_, _) -> Dune
 end
 

--- a/src/stanza.ml
+++ b/src/stanza.ml
@@ -13,7 +13,11 @@ let syntax =
     ]
 
 module File_kind = struct
-  type t = Jbuild | Dune
+  type t = Sexp.syntax = Jbuild | Dune
+
+  let of_syntax = function
+    | (0, 0) -> Jbuild
+    | (_, _) -> Dune
 end
 
 let file_kind () =

--- a/src/stanza.mli
+++ b/src/stanza.mli
@@ -18,7 +18,9 @@ end
 val syntax : Syntax.t
 
 module File_kind : sig
-  type t = Jbuild | Dune
+  type t = Sexp.syntax = Jbuild | Dune
+
+  val of_syntax : Syntax.Version.t -> t
 end
 
 (** Whether we are parsing a [jbuild] or [dune] file. *)

--- a/src/usexp/loc.ml
+++ b/src/usexp/loc.ml
@@ -16,3 +16,8 @@ let in_file fn =
   }
 
 let none = in_file "<none>"
+
+let of_lexbuf lexbuf : t =
+  { start = Lexing.lexeme_start_p lexbuf
+  ; stop  = Lexing.lexeme_end_p   lexbuf
+  }

--- a/src/usexp/loc.mli
+++ b/src/usexp/loc.mli
@@ -6,3 +6,5 @@ type t =
 val in_file : string -> t
 
 val none : t
+
+val of_lexbuf : Lexing.lexbuf -> t

--- a/src/usexp/usexp.mli
+++ b/src/usexp/usexp.mli
@@ -28,6 +28,8 @@ module Loc : sig
   val in_file : string -> t
 
   val none : t
+
+  val of_lexbuf : Lexing.lexbuf -> t
 end
 
 module Template : sig
@@ -112,7 +114,18 @@ end
 exception Parse_error of Parse_error.t
 
 module Lexer : sig
-  type t
+  module Token : sig
+    type t =
+      | Atom          of Atom.t
+      | Quoted_string of string
+      | Lparen
+      | Rparen
+      | Sexp_comment
+      | Eof
+      | Template of Template.t
+  end
+
+  type t = Lexing.lexbuf -> Token.t
 
   val token : t
   val jbuild_token : t

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -22,7 +22,7 @@
 
   $ dune runtest dune-file
   (dune
-   1
+   2
    ((inline_tests.backend
      1.0
      ((runner_libraries (str))


### PR DESCRIPTION
Fix #909 

This is still WIP because I should really be saving the syntax version rather than the Jbuild vs. Dune version in the Info files. But this PR is still useful for initial review.

One thing that I'm wondering about is we should still generate the per subsystem versions in syntax `(1, 0)`. Seems like jbuilder will not be able to load .dune files generated by dune anyway because of that initial 2.0 language.