### PR TITLE
Forbid #require in dune files in OCaml syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,8 @@ next
   when not defined by the user and make `@@default` be the default
   target (#926, @diml)
 
+- Forbid `#require` in `dune` files in OCaml syntax (#938, @diml)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/plugin/jbuild_plugin.mli
+++ b/plugin/jbuild_plugin.mli
@@ -14,4 +14,7 @@ module V1 : sig
   (** [send s] send [s] to jbuilder. [s] should be the contents of a
       jbuild file following the specification described in the manual. *)
   val send : string -> unit
+
+  (** Execute a command and read it's output *)
+  val run_and_read_lines : string -> string list
 end


### PR DESCRIPTION
`#require` was restricted to `#require "unix"` a while ago as allowing files in OCaml syntax to load anything didn't seem right. We initially kept `"unix"` as some projects were using it, but we can now forbid `#require` entirely in `dune` files.

Forbidding `unix` improves portability.