### PR TITLE
Do not use opam-installer to copy files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,8 @@ next
 
 - Add `%{profile}` variable. (#938, @rgrinberg)
 
+- Do not require opam-installer anymore (#941, @diml)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1067,11 +1067,8 @@ let print_unix_error f =
   try
     f ()
   with Unix.Unix_error (e, _, _) ->
-    Format.fprintf err_ppf "@{<error>Error@}: %s@."
-      (Unix.error_message e);
-    let s = Buffer.contents err_buf in
-    Buffer.clear err_buf;
-    Printf.eprintf "%s%!" s
+    Format.eprintf "@{<error>Error@}: %s@."
+      (Unix.error_message e)
 
 let install_uninstall ~what =
   let doc =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1053,16 +1053,6 @@ let rules =
                  & Arg.info [] ~docv:"TARGET"))
   , Term.info "rules" ~doc ~man)
 
-let opam_installer () =
-  match Bin.which "opam-installer" with
-  | None ->
-    die "\
-Sorry, you need the opam-installer tool to be able to install or
-uninstall packages.
-
-I couldn't find the opam-installer binary :-("
-  | Some fn -> fn
-
 let get_prefix context ~from_command_line =
   match from_command_line with
   | Some p -> Fiber.return (Path.of_string p)
@@ -1073,6 +1063,16 @@ let get_libdir context ~libdir_from_command_line =
   | Some p -> Fiber.return (Some (Path.of_string p))
   | None -> Context.install_ocaml_libdir context
 
+let print_unix_error f =
+  try
+    f ()
+  with Unix.Unix_error (e, _, _) ->
+    Format.fprintf err_ppf "@{<error>Error@}: %s@."
+      (Unix.error_message e);
+    let s = Buffer.contents err_buf in
+    Buffer.clear err_buf;
+    Printf.eprintf "%s%!" s
+
 let install_uninstall ~what =
   let doc =
     sprintf "%s packages using opam-installer." (String.capitalize what)
@@ -1080,7 +1080,6 @@ let install_uninstall ~what =
   let name_ = Arg.info [] ~docv:"PACKAGE" in
   let go common prefix_from_command_line libdir_from_command_line pkgs =
     set_common common ~targets:[];
-    let opam_installer = opam_installer () in
     let log = Log.create common in
     Scheduler.go ~log ~common
       (Main.setup ~log common >>= fun setup ->
@@ -1095,7 +1094,7 @@ let install_uninstall ~what =
            List.map setup.contexts ~f:(fun ctx ->
              let fn = Path.append ctx.Context.build_dir fn in
              if Path.exists fn then
-               Left (ctx, fn)
+               Left (ctx, (pkg, fn))
              else
                Right fn))
          |> List.partition_map ~f:(fun x -> x)
@@ -1121,23 +1120,54 @@ let install_uninstall ~what =
        in
        Fiber.parallel_iter install_files_by_context
          ~f:(fun (context, install_files) ->
-           let install_files_set = Path.Set.of_list install_files in
            get_prefix context ~from_command_line:prefix_from_command_line
            >>= fun prefix ->
            get_libdir context ~libdir_from_command_line
-           >>= fun libdir ->
-           Fiber.parallel_iter install_files ~f:(fun path ->
-             let purpose = Process.Build_job install_files_set in
-             Process.run ~purpose ~env:setup.env Strict opam_installer
-               ([ sprintf "-%c" what.[0]
-                ; Path.to_string path
-                ; "--prefix"
-                ; Path.to_string prefix
-                ] @
-                match libdir with
-                | None -> []
-                | Some p -> [ "--libdir"; Path.to_string p ]
-               ))))
+           >>| fun libdir ->
+           List.iter install_files ~f:(fun (package, path) ->
+             let entries = Install.load_install_file path in
+             let paths =
+               Install.Section.Paths.make
+                 ~package
+                 ~destdir:prefix
+                 ?libdir
+                 ()
+             in
+             let files_deleted_in = ref Path.Set.empty in
+             List.iter entries ~f:(fun { Install.Entry. src; dst; section } ->
+               let src = src in
+               let dst = Option.value dst ~default:(Path.basename src) in
+               let dst =
+                 Path.relative (Install.Section.Paths.get paths section) dst
+               in
+               let dir = Path.parent_exn dst in
+               if what = "install" then begin
+                 Printf.eprintf "Installing %s as %s\n%!"
+                   (Path.to_string src)
+                   (Path.to_string_maybe_quoted dst);
+                 Path.mkdir_p dir;
+                 Io.copy_file () ~src ~dst
+                   ~chmod:(match section with
+                     | Libexec -> (fun x -> x lor 0o111)
+                     | _ -> (fun x -> x))
+               end else begin
+                 if Path.exists dst then begin
+                   Printf.eprintf "Deleting %s\n%!"
+                     (Path.to_string_maybe_quoted dst);
+                   print_unix_error (fun () -> Path.unlink dst)
+                 end;
+                 files_deleted_in := Path.Set.add !files_deleted_in dir;
+               end;
+               Path.Set.to_list !files_deleted_in
+               |> List.rev
+               |> List.iter ~f:(fun dir ->
+                 if Path.exists dir then
+                   match Path.readdir_unsorted dir with
+                   | [] ->
+                     Printf.eprintf "Deleting empty directory %s\n%!"
+                       (Path.to_string_maybe_quoted dst);
+                     print_unix_error (fun () -> Path.rmdir dir)
+                   | _  -> ())))))
   in
   ( Term.(const go
           $ common

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1142,8 +1142,7 @@ let install_uninstall ~what =
                in
                let dir = Path.parent_exn dst in
                if what = "install" then begin
-                 Printf.eprintf "Installing %s as %s\n%!"
-                   (Path.to_string src)
+                 Printf.eprintf "Installing %s\n%!"
                    (Path.to_string_maybe_quoted dst);
                  Path.mkdir_p dir;
                  Io.copy_file () ~src ~dst

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1160,6 +1160,8 @@ let install_uninstall ~what =
                  files_deleted_in := Path.Set.add !files_deleted_in dir;
                end;
                Path.Set.to_list !files_deleted_in
+               (* This [List.rev] is to ensure we process children
+                  directories before their parents *)
                |> List.rev
                |> List.iter ~f:(fun dir ->
                  if Path.exists dir then

--- a/src/action.ml
+++ b/src/action.ml
@@ -637,7 +637,7 @@ module Promotion = struct
       Format.eprintf "Promoting %s to %s.@."
         (Path.to_string_maybe_quoted src)
         (Path.to_string_maybe_quoted dst);
-      Io.copy_file ~src ~dst
+      Io.copy_file ~src ~dst ()
   end
 
   module P = Utils.Persistent(struct
@@ -785,11 +785,11 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to =
       Io.copy_channels ic oc);
     Fiber.return ()
   | Copy (src, dst) ->
-    Io.copy_file ~src ~dst;
+    Io.copy_file ~src ~dst ();
     Fiber.return ()
   | Symlink (src, dst) ->
     if Sys.win32 then
-      Io.copy_file ~src ~dst
+      Io.copy_file ~src ~dst ()
     else begin
       let src =
         match Path.parent dst with

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -826,7 +826,7 @@ let rec compile_rule t ?(copy_source=false) pre_rule =
               Utils.Cached_digest.file in_source_tree) then begin
             if mode = Promote_but_delete_on_clean then
               Promoted_to_delete.add in_source_tree;
-            Io.copy_file ~src:path ~dst:in_source_tree
+            Io.copy_file ~src:path ~dst:in_source_tree ()
           end)
     end;
     t.hook Rule_completed

--- a/src/install.ml
+++ b/src/install.ml
@@ -63,6 +63,20 @@ module Section = struct
       ; "misc"       , Misc
       ]
 
+  let should_set_executable_bit = function
+    | Lib        -> false
+    | Libexec    -> true
+    | Bin        -> true
+    | Sbin       -> true
+    | Toplevel   -> false
+    | Share      -> false
+    | Share_root -> false
+    | Etc        -> false
+    | Doc        -> false
+    | Stublibs   -> true
+    | Man        -> false
+    | Misc       -> false
+
   module Paths = struct
     type t =
       { lib         : Path.t

--- a/src/install.mli
+++ b/src/install.mli
@@ -36,3 +36,5 @@ end
 
 val files : Entry.t list -> Path.Set.t
 val gen_install_file : Entry.t list -> string
+
+val load_install_file : Path.t -> Entry.t list

--- a/src/install.mli
+++ b/src/install.mli
@@ -19,6 +19,10 @@ module Section : sig
 
   val t : t Sexp.Of_sexp.t
 
+  (** [true] iff the executable bit should be set for files installed
+      in this location. *)
+  val should_set_executable_bit : t -> bool
+
   module Paths : sig
     type section = t
 

--- a/src/install.mli
+++ b/src/install.mli
@@ -18,6 +18,33 @@ module Section : sig
     | Misc
 
   val t : t Sexp.Of_sexp.t
+
+  module Paths : sig
+    type section = t
+
+    type t =
+      { lib         : Path.t
+      ; libexec     : Path.t
+      ; bin         : Path.t
+      ; sbin        : Path.t
+      ; toplevel    : Path.t
+      ; share       : Path.t
+      ; share_root  : Path.t
+      ; etc         : Path.t
+      ; doc         : Path.t
+      ; stublibs    : Path.t
+      ; man         : Path.t
+      }
+
+    val make
+      :  package:Package.Name.t
+      -> destdir:Path.t
+      -> ?libdir:Path.t
+      -> unit
+      -> t
+
+    val get : t -> section -> Path.t
+  end with type section := t
 end
 
 module Entry : sig
@@ -30,8 +57,8 @@ module Entry : sig
   val make : Section.t -> ?dst:string -> Path.t -> t
   val set_src : t -> Path.t -> t
 
-  val relative_installed_path : t -> package:Package.Name.t -> Path.t
-  val add_install_prefix : t -> package:Package.Name.t -> prefix:Path.t -> t
+  val relative_installed_path : t -> paths:Section.Paths.t -> Path.t
+  val add_install_prefix : t -> paths:Section.Paths.t -> prefix:Path.t -> t
 end
 
 val files : Entry.t list -> Path.Set.t

--- a/src/stdune/io.ml
+++ b/src/stdune/io.ml
@@ -66,9 +66,9 @@ let copy_channels =
   in
   loop
 
-let copy_file ~src ~dst =
+let copy_file ?(chmod=fun x -> x) ~src ~dst () =
   with_file_in src ~f:(fun ic ->
-    let perm = (Unix.fstat (Unix.descr_of_in_channel ic)).st_perm in
+    let perm = (Unix.fstat (Unix.descr_of_in_channel ic)).st_perm |> chmod in
     Exn.protectx (P.open_out_gen
                     [Open_wronly; Open_creat; Open_trunc; Open_binary]
                     perm

--- a/src/stdune/io.mli
+++ b/src/stdune/io.mli
@@ -23,7 +23,7 @@ val write_lines : Path.t -> string list -> unit
 
 val copy_channels : in_channel -> out_channel -> unit
 
-val copy_file : src:Path.t -> dst:Path.t -> unit
+val copy_file : ?chmod:(int -> int) -> src:Path.t -> dst:Path.t -> unit -> unit
 
 val read_all : in_channel -> string
 

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -874,9 +874,7 @@ let rm_rf =
     | _ -> loop fn
 
 let mkdir_p = function
-  | External s ->
-    Exn.code_error "Path.mkdir_p cannot create external path"
-      ["s", External.sexp_of_t s]
+  | External s -> External.mkdir_p s
   | In_source_tree s ->
     Exn.code_error "Path.mkdir_p cannot dir in source"
       ["s", Local.sexp_of_t s]

--- a/vendor/boot/opamParserTypes.ml
+++ b/vendor/boot/opamParserTypes.ml
@@ -1,13 +1,54 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2012-2015 OCamlPro                                        *)
+(*    Copyright 2012 INRIA                                                *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+type relop = [ `Eq | `Neq | `Geq | `Gt | `Leq | `Lt ]
+type logop = [ `And | `Or ]
+type pfxop = [ `Not ]
+
+type file_name = string
+
+(** Source file positions: filename, line, column *)
+type pos = file_name * int * int
+
+type env_update_op = Eq | PlusEq | EqPlus | ColonEq | EqColon | EqPlusEq
+
+(** Base values *)
 type value =
-  | String of unit * string
-  | List of unit * value list
-  | Other
+  | Bool of pos * bool
+  | Int of pos * int
+  | String of pos * string
+  | Relop of pos * relop * value * value
+  | Prefix_relop of pos * relop * value
+  | Logop of pos * logop * value * value
+  | Pfxop of pos * pfxop * value
+  | Ident of pos * string
+  | List of pos * value list
+  | Group of pos * value list
+  | Option of pos * value * value list
+  | Env_binding of pos * value * env_update_op * value
 
-type opamfile_item =
-  | Variable of unit * string * value
-  | Other
+(** An opamfile section *)
+type opamfile_section = {
+  section_kind  : string;
+  section_name  : string option;
+  section_items : opamfile_item list;
+}
 
-type opamfile =
-  { file_contents : opamfile_item list
-  ; file_name     : string
-  }
+(** An opamfile is composed of sections and variable definitions *)
+and opamfile_item =
+  | Section of pos * opamfile_section
+  | Variable of pos * string * value
+
+(** A file is a list of items and the filename *)
+type opamfile = {
+  file_contents: opamfile_item list;
+  file_name    : file_name;
+}


### PR DESCRIPTION
opam is currently not mandatory to use dune, however one still needs the external `opam-installer` binary in order to run `dune install` or `dune uninstall`. This is annoying, especially since this tool is quite simple.

In order to make dune more self-contained, this PR reimplements `dune install` and `dune uninstall` without calling out to `opam-installer`.