### PR TITLE
Adapt the behavior of dune subst for dune projects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,7 +114,7 @@ next
 
 - Remove `path-no-dep:file` (#948, @emillon)
 
-- Adapt the behavior of `dune subst` for dune projects (#..., @diml)
+- Adapt the behavior of `dune subst` for dune projects (#960, @diml)
 
 1.0+beta20 (10/04/2018)
 -----------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,6 +114,8 @@ next
 
 - Remove `path-no-dep:file` (#948, @emillon)
 
+- Adapt the behavior of `dune subst` for dune projects (#..., @diml)
+
 1.0+beta20 (10/04/2018)
 -----------------------
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -462,30 +462,32 @@ must be prefixed by the shortest one.
 Watermarking
 ============
 
-One of the feature topkg provides is watermarking; it replaces various strings
-of the form ``%%ID%%`` in all files of your project before creating a release
-tarball or when the package is pinned by the user using opam.
+One of the feature dune-release provides is watermarking; it replaces
+various strings of the form ``%%ID%%`` in all files of your project
+before creating a release tarball or when the package is pinned by the
+user using opam.
 
 This is especially interesting for the ``VERSION`` watermark, which gets
 replaced by the version obtained from the vcs. For instance if you are using
-git, topkg invokes this command to find out the version:
+git, dune-release invokes this command to find out the version:
 
 .. code:: bash
 
     $ git describe --always --dirty
     1.0+beta9-79-g29e9b37
 
-Projects using dune usually only need topkg for creating and publishing
-releases. However they might still want to substitute the watermarks when the
-package is pinned by the user. To help with this, dune provides the ``subst``
-sub-command.
+Projects using dune usually only need dune-release for creating and
+publishing releases. However they might still want to substitute the
+watermarks when the package is pinned by the user. To help with this,
+dune provides the ``subst`` sub-command.
 
 dune subst
 ==========
 
-``dune subst`` performs the same substitution ``topkg`` does with the default
-configuration. i.e. calling ``dune subst`` at the root of your project will
-rewrite in place all the files in your project.
+``dune subst`` performs the same substitution ``dune-release`` does
+with the default configuration. i.e. calling ``dune subst`` at the
+root of your project will rewrite in place all the files in your
+project.
 
 More precisely, it replaces all the following watermarks in source files:
 
@@ -503,18 +505,15 @@ More precisely, it replaces all the following watermarks in source files:
 - ``PKG_LICENSE``, contents of the ``license`` field from the opam file
 - ``PKG_REPO``, contents of the ``repo`` field from the opam file
 
-Note that if your project contains several packages, ``NAME`` will be replaced
-by the shorted package name as long as it is a prefix of all the package names.
-If your package names don't follow this rule, you need to specify the name
-explicitly via the ``-n`` flag:
+The name of the project is obtained by reading the ``dune-project``
+file in the directory where ``dune subst`` is called. The
+``dune-project`` file must exist and contain a valid ``(name ...)``
+field.
 
-.. code:: bash
-
-    $ dune subst -n myproject
-
-Finally, note that dune doesn't allow you to customize the list of substituted
-watermarks. If you which to do so, you need to configure topkg and use it
-instead of ``dune subst``.
+Note that ``dune subst`` is meant to be called from the opam file and
+in particular behaves a bit different to other ``dune`` commands. In
+particular it doesn't try to detect the root of the workspace and must
+be called from the root of the project.
 
 Custom Build Directory
 ======================

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -386,6 +386,13 @@ let make_jbuilder_project ~dir packages =
   ; project_file = { file = Path.relative dir filename; exists = false }
   }
 
+let read_name file =
+  load file ~f:(fun _lang ->
+    fields
+      (field_o "name" string >>= fun name ->
+       junk_everything >>= fun () ->
+       return name))
+
 let load ~dir ~files =
   let packages =
     String.Set.fold files ~init:[] ~f:(fun fn acc ->
@@ -399,7 +406,8 @@ let load ~dir ~files =
         in
         let name = Package.Name.of_string pkg in
         (name,
-         { Package. name
+         { Package.
+           name
          ; path = dir
          ; version_from_opam_file
          }) :: acc

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -70,6 +70,9 @@ end
     is the set of files in this directory. *)
 val load : dir:Path.t -> files:String.Set.t -> t option
 
+(** Read the [name] file from a dune-project file *)
+val read_name : Path.t -> string option
+
 (** "dune-project" *)
 val filename : string
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -199,7 +199,12 @@ let bootstrap () =
   let main () =
     let anon s = raise (Arg.Bad (Printf.sprintf "don't know what to do with %s\n" s)) in
     let subst () =
-      Scheduler.go (Watermarks.subst () ~name:"dune");
+      let config : Config.t =
+        { display     = Quiet
+        ; concurrency = Fixed 1
+        }
+      in
+      Scheduler.go ~config (Watermarks.subst ());
       exit 0
     in
     let display = ref None in

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -245,6 +245,11 @@ module Of_sexp = struct
 
   let junk = next ignore
 
+  let junk_everything : type k. (unit, k) parser = fun ctx state ->
+    match ctx with
+    | Values _ -> ((), [])
+    | Fields _ -> ((), { state with unparsed = Name_map.empty })
+
   let plain_string f =
     next (function
       | Atom (loc, A s) | Quoted_string (loc, s) -> f ~loc s

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -163,6 +163,9 @@ module Of_sexp : sig
   (** Consume and ignore the next element of the input *)
   val junk : unit t
 
+  (** Ignore all the rest of the input *)
+  val junk_everything : (unit, _) parser
+
   (** [plain_string f] expects the next element of the input to be a
       plain string, i.e. either an atom or a quoted string, but not a
       template nor a list. *)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -572,6 +572,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name subst)
+ (deps (package dune) (source_tree test-cases/subst))
+ (action
+  (chdir
+   test-cases/subst
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name syntax-versioning)
  (deps (package dune) (source_tree test-cases/syntax-versioning))
  (action
@@ -688,6 +696,7 @@
   (alias scope-bug)
   (alias scope-ppx-bug)
   (alias select)
+  (alias subst)
   (alias syntax-versioning)
   (alias tests-stanza)
   (alias use-meta)
@@ -756,6 +765,7 @@
   (alias scope-bug)
   (alias scope-ppx-bug)
   (alias select)
+  (alias subst)
   (alias syntax-versioning)
   (alias tests-stanza)
   (alias use-meta)

--- a/test/blackbox-tests/test-cases/output-obj/run.t
+++ b/test/blackbox-tests/test-cases/output-obj/run.t
@@ -13,10 +13,10 @@
 
   $ dune build @runtest
        dynamic alias runtest
-  OK: ./dynamic.exe ./test$ext_dll
+  OK: ./dynamic.exe ./test.bc.so
         static alias runtest
   OK: ./static.bc
         static alias runtest
   OK: ./static.exe
        dynamic alias runtest
-  OK: ./dynamic.exe ./test.bc.so
+  OK: ./dynamic.exe ./test$ext_dll

--- a/test/blackbox-tests/test-cases/subst/dune-project
+++ b/test/blackbox-tests/test-cases/subst/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name foo)

--- a/test/blackbox-tests/test-cases/subst/file.ml
+++ b/test/blackbox-tests/test-cases/subst/file.ml
@@ -1,3 +1,0 @@
-let name = "%%NAME%%"
-let authors = "%%PKG_AUTHORS%%"
-let version = "%%VERSION%%"

--- a/test/blackbox-tests/test-cases/subst/file.ml
+++ b/test/blackbox-tests/test-cases/subst/file.ml
@@ -1,0 +1,3 @@
+let name = "%%NAME%%"
+let authors = "%%PKG_AUTHORS%%"
+let version = "%%VERSION%%"

--- a/test/blackbox-tests/test-cases/subst/file.ml.in
+++ b/test/blackbox-tests/test-cases/subst/file.ml.in
@@ -1,0 +1,3 @@
+let name = "%_%NAME%_%"
+let authors = "%_%PKG_AUTHORS%_%"
+let version = "%_%VERSION%_%"

--- a/test/blackbox-tests/test-cases/subst/foo.opam
+++ b/test/blackbox-tests/test-cases/subst/foo.opam
@@ -1,0 +1,1 @@
+authors: [ "John Doe <john@doe.com>" ]

--- a/test/blackbox-tests/test-cases/subst/run.t
+++ b/test/blackbox-tests/test-cases/subst/run.t
@@ -1,0 +1,13 @@
+  $ git init &> /dev/null
+  $ git add . &> /dev/null
+  $ git commit -am _ &> /dev/null
+  $ git tag -a 1.0 -m 1.0
+  $ dune subst
+  $ cat file.ml
+  let name = "foo"
+  let authors = "John Doe <john@doe.com>"
+  let version = "1.0"
+
+To avoid the issue exposed in ../action-modifying-a-dependency:
+
+  $ git reset --hard &> /dev/null

--- a/test/blackbox-tests/test-cases/subst/run.t
+++ b/test/blackbox-tests/test-cases/subst/run.t
@@ -1,3 +1,4 @@
+  $ sed 's/%_%/%%/g' file.ml.in > file.ml
   $ git init &> /dev/null
   $ git add . &> /dev/null
   $ git commit -am _ &> /dev/null
@@ -7,7 +8,3 @@
   let name = "foo"
   let authors = "John Doe <john@doe.com>"
   let version = "1.0"
-
-To avoid the issue exposed in ../action-modifying-a-dependency:
-
-  $ git reset --hard &> /dev/null

--- a/test/blackbox-tests/test-cases/subst/run.t
+++ b/test/blackbox-tests/test-cases/subst/run.t
@@ -1,7 +1,7 @@
   $ sed 's/%_%/%%/g' file.ml.in > file.ml
-  $ git init &> /dev/null
-  $ git add . &> /dev/null
-  $ git commit -am _ &> /dev/null
+  $ git init --quiet
+  $ git add .
+  $ git commit -am _ --quiet
   $ git tag -a 1.0 -m 1.0
   $ dune subst
   $ cat file.ml


### PR DESCRIPTION
Projects are better defined with dune, so we don't need the automatic project name detection jbuilder was doing and can simply read the dune-project file. Additionally, since `dune subst` is only meant to be called from opam files, this PR simplify this command a bit so that it doesn't looks up the root of the workspace. This fix #954 which was due to users often forgetting to pass `"-p" name` to the `dune subst` invocation.