### PR TITLE
[WIP] Expand variables in `install` stanzas

### DIFF
--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -216,8 +216,8 @@ end
 
 module Install_conf : sig
   type file =
-    { src : string
-    ; dst : string option
+    { src : String_with_vars.t
+    ; dst : String_with_vars.t option
     }
 
   type t =


### PR DESCRIPTION
# Overview 
This PR reflects my work towards fixing issue #690.

NOTE: I will file another PR (or perhaps repurpose this one), with a squashed + signed-off commit when the work is done. This is just for documentation + discussion on progress.

## Progress

- [ ] Switch `Install_conf.file` to use `String_with_vars.t` 
- [ ] Fix parser(s) for `Install_conf.file` 
- [ ] Eliminate instances of `String_with_vars.t` into OCaml strings using `String_with_vars.expand`

## Questions

1. Which variables can / cannot be supported in `install` stanzas?
2. Where should variables be expanded? Eagerly? Lazily?
3. When generating a literal `String_with_vars.t` from a string, is `String_with_vars.virt_text` the correct way? Is using a dummy position appropriate? Since we know this is a literal, we don't expect to ever use the position (e.g. in an error message).