### PR TITLE
Improve compatibility of Configurator.V1.write_flags

### DIFF
--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -487,7 +487,7 @@ end
 
 let write_flags fname s =
   let path = Path.in_source fname in
-  let sexp = Usexp.List(List.map ~f:Usexp.atom_or_quoted_string s) in
+  let sexp = Usexp.List (List.map s ~f:(fun s -> Usexp.Quoted_string s)) in
   Io.write_file path (Usexp.to_string sexp ~syntax:Dune)
 
 let main ?(args=[]) ~name f =


### PR DESCRIPTION
I haven't checked in detail but I'm pretty sure the following is true:

- take an arbitrary string `s`
- print `Quoted_string s` in dune syntax
- parse it either in dune or jbuilder syntax
- we obtain `Quoited_string s'` where `s = s'`

This is not true if we use `Atom (A s)` instead of `Quoted_string s`. With this in mind, this PR change the files produced by `Configurator.V1.write_flags` to make sure they produce only quoted strings.
