### PR TITLE
Fix #979

### DIFF
--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -790,12 +790,7 @@ let rec compile_rule t ?(copy_source=false) pre_rule =
           match sandbox_dir with
           | Some sandbox_dir ->
             Path.rm_rf sandbox_dir;
-            let sandboxed path =
-              if Path.is_managed path then
-                Path.append sandbox_dir path
-              else
-                path
-            in
+            let sandboxed path = Path.sandbox_managed_paths ~sandbox_dir path in
             make_local_parent_dirs t all_deps ~map_path:sandboxed;
             make_local_parent_dirs t targets  ~map_path:sandboxed;
             Action.sandbox action

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -667,13 +667,14 @@ let append_local a b =
   | External a -> external_ (External.relative a (Local.to_string b))
 
 let append a b =
-  match kind b with
-  | External _ ->
-    Exn.code_error "Path.append called with non-local second path"
+  match b with
+  | In_build_dir _ | External _ ->
+    Exn.code_error "Path.append called with directory that's \
+                    not in the source tree"
       [ "a", sexp_of_t a
       ; "b", sexp_of_t b
       ]
-  | Local b -> append_local a b
+  | In_source_tree b -> append_local a b
 
 let basename t =
   match kind t with

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -764,6 +764,15 @@ let drop_optional_build_context t =
   | None -> t
   | Some (_, t) -> t
 
+let local_src   = Local.of_string "src"
+let local_build = Local.of_string "build"
+
+let sandbox_managed_paths ~sandbox_dir t =
+  match t with
+  | External _ -> t
+  | In_source_tree p -> append_local sandbox_dir (Local.append local_src   p)
+  | In_build_dir   p -> append_local sandbox_dir (Local.append local_build p)
+
 let split_first_component t =
   match kind t, is_root t with
   | Local t, false ->

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -103,6 +103,10 @@ val drop_build_context_exn : t -> t
 (** Drop the "_build/blah" prefix if present, return [t] otherwise *)
 val drop_optional_build_context : t -> t
 
+(** Transform managed paths so that they are descedant of
+    [sandbox_dir]. *)
+val sandbox_managed_paths : sandbox_dir:t -> t -> t
+
 val explode : t -> string list option
 val explode_exn : t -> string list
 

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -243,12 +243,24 @@ Path.append Path.build_dir (Path.relative Path.root "foo")
 
 Path.append Path.build_dir (Path.relative Path.build_dir "foo")
 [%%expect{|
-- : Path.t = (In_build_dir "_build/foo")
+Exception:
+Code_error
+ (List
+   [Quoted_string
+     "Path.append called with directory that's not in the source tree";
+    List [Atom (A "a"); List [Atom (A "In_build_dir"); Atom (A ".")]];
+    List [Atom (A "b"); List [Atom (A "In_build_dir"); Atom (A "foo")]]]).
 |}]
 
 Path.append Path.root (Path.relative Path.build_dir "foo")
 [%%expect{|
-- : Path.t = (In_source_tree "_build/foo")
+Exception:
+Code_error
+ (List
+   [Quoted_string
+     "Path.append called with directory that's not in the source tree";
+    List [Atom (A "a"); List [Atom (A "In_source_tree"); Atom (A ".")]];
+    List [Atom (A "b"); List [Atom (A "In_build_dir"); Atom (A "foo")]]]).
 |}]
 
 Path.append Path.root (Path.relative Path.root "foo")
@@ -263,7 +275,13 @@ Path.append (Path.of_string "/root") (Path.relative Path.root "foo")
 
 Path.append (Path.of_string "/root") (Path.relative Path.build_dir "foo")
 [%%expect{|
-- : Path.t = (External "/root/_build/foo")
+Exception:
+Code_error
+ (List
+   [Quoted_string
+     "Path.append called with directory that's not in the source tree";
+    List [Atom (A "a"); List [Atom (A "External"); Atom (A "/root")]];
+    List [Atom (A "b"); List [Atom (A "In_build_dir"); Atom (A "foo")]]]).
 |}]
 
 Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")


### PR DESCRIPTION
Add a function `Path.sandbox_managed_paths` to properly sandbox managed paths. One difference with before is that we add an extra `src` or `build` prefix inside the sandbox directory, this is to ensure there is no clash when the build directory is set explicitly.

This PR also changes `Path.append` to forbid `Path.append _ (In_build_dir _)` as discussed on slack.