### PR TITLE
Pforms fixes

### DIFF
--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -203,7 +203,7 @@ include Sub_system.Register_end_point(
         let target = Path.relative inline_test_dir main_module_filename in
         let source_modules = Module.Name.Map.values source_modules in
         let files ml_kind =
-          Pform.Values (Value.L.paths (
+          Pform.Var.Values (Value.L.paths (
             List.filter_map source_modules ~f:(fun m ->
               Module.file m ~dir ml_kind)))
         in

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -60,8 +60,8 @@ module Map = struct
       ; "<", deleted_in Var.First_dep ~version:(1, 0)
                ~repl:"Use a named dependency instead:\
                       \n\
-                      \n\  (deps (:x <dep>) ...)\
-                      \n\   ... %{x} ..."
+                      \n  (deps (:x <dep>) ...)\
+                      \n   ... %{x} ..."
       ; "@", renamed_in ~version:(1, 0) ~new_name:"targets"
       ; "^", renamed_in ~version:(1, 0) ~new_name:"deps"
       ; "SCOPE_ROOT", renamed_in ~version:(1, 0) ~new_name:"project_root"

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -1,30 +1,38 @@
 open Stdune
 
-type t =
-  (* Variables *)
-  | Values of Value.t list
-  | Project_root
-  | First_dep
-  | Deps
-  | Targets
-  | Named_local
+module Var : sig
+  type t =
+    | Values of Value.t list
+    | Project_root
+    | First_dep
+    | Deps
+    | Targets
+    | Named_local
+end
 
-  (* Macros *)
-  | Exe
-  | Dep
-  | Bin
-  | Lib
-  | Libexec
-  | Lib_available
-  | Version
-  | Read
-  | Read_strings
-  | Read_lines
-  | Path_no_dep
-  | Ocaml_config
+module Macro : sig
+  type t =
+    | Exe
+    | Dep
+    | Bin
+    | Lib
+    | Libexec
+    | Lib_available
+    | Version
+    | Read
+    | Read_strings
+    | Read_lines
+    | Path_no_dep
+    | Ocaml_config
+end
+
+module Expansion : sig
+  type t =
+    | Var   of Var.t
+    | Macro of Macro.t * string
+end
 
 module Map : sig
-  type pform
   type t
 
   val create : context:Context.t -> cxx_flags:string list -> t
@@ -34,9 +42,9 @@ module Map : sig
   (** Map with all named values as [Named_local] *)
   val of_bindings : _ Jbuild.Bindings.t -> t
 
-  val singleton : string -> pform -> t
+  val singleton : string -> Var.t -> t
 
-  val of_list_exn : (string * pform) list -> t
+  val of_list_exn : (string * Var.t) list -> t
 
   val input_file : Path.t -> t
 
@@ -44,7 +52,7 @@ module Map : sig
     :  t
     -> syntax_version:Syntax.Version.t
     -> pform:String_with_vars.Var.t
-    -> pform option
+    -> Expansion.t option
 
   val empty : t
-end with type pform := t
+end

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -195,32 +195,18 @@ module Var = struct
 
   let loc (t : t) = t.loc
 
-  type kind =
-    | Var of string
-    | Macro of string * string
-
-  let destruct { loc = _ ; name; payload; syntax = _ } =
-    match payload with
-    | None -> Var name
-    | Some p -> Macro (name, p)
-
   let name { name; _ } = name
 
   let full_name t =
-    match destruct t with
-    | Var s -> s
-    | Macro (k, v) -> k ^ ":" ^ v
+    match t.payload with
+    | None -> t.name
+    | Some v -> t.name ^ ":" ^ v
 
   let payload t = t.payload
 
   let to_string = string_of_var
 
-  let pp fmt t = Format.pp_print_string fmt (to_string t)
-
   let sexp_of_t t = Sexp.atom (to_string t)
-
-  let with_payload t ~payload =
-    { t with payload }
 
   let with_name t ~name =
     { t with name }

--- a/src/string_with_vars.mli
+++ b/src/string_with_vars.mli
@@ -49,8 +49,6 @@ end
 module Var : sig
   type t
 
-  val pp : t Fmt.t
-
   val sexp_of_t : t -> Sexp.t
 
   val name : t -> string
@@ -58,15 +56,7 @@ module Var : sig
   val full_name : t -> string
   val payload : t -> string option
 
-  type kind =
-    | Var of string
-    | Macro of string * string
-
-  val destruct : t -> kind
-
   val with_name : t -> name:string -> t
-
-  val with_payload : t -> payload:string option -> t
 
   val is_macro : t -> bool
 

--- a/test/blackbox-tests/test-cases/dep-vars/dune
+++ b/test/blackbox-tests/test-cases/dep-vars/dune
@@ -1,5 +1,11 @@
+(alias
+ (name runtest)
+ (deps (:foo a b) (:baz foo (alias x)) a b c)
+ (action (echo "foo = %{foo}\nbaz = %{baz}\n")))
 
-(rule
- (deps (:foo a b) (:baz foo (alias test)) a b c)
- (targets bar)
- (action (with-stdout-to bar (echo "foo"))))
+(rule (with-stdout-to a (echo "")))
+(rule (with-stdout-to b (echo "")))
+(rule (with-stdout-to c (echo "")))
+(rule (with-stdout-to foo (echo "")))
+
+(alias (name x))

--- a/test/blackbox-tests/test-cases/dep-vars/jbuild/jbuild
+++ b/test/blackbox-tests/test-cases/dep-vars/jbuild/jbuild
@@ -1,0 +1,8 @@
+(alias
+ ((name runtest)
+  (deps ((alias x) foo (alias x)))
+  (action (echo "< = ${<}\n"))))
+
+(alias ((name x)))
+
+(rule (with-stdout-to foo (echo "")))

--- a/test/blackbox-tests/test-cases/dep-vars/run.t
+++ b/test/blackbox-tests/test-cases/dep-vars/run.t
@@ -1,3 +1,6 @@
 Dependencies are allowed :patterns
 
-  $ dune build
+  $ dune runtest
+  < = foo
+  foo = a b
+  baz = foo

--- a/test/blackbox-tests/test-cases/shadow-bindings/dune
+++ b/test/blackbox-tests/test-cases/shadow-bindings/dune
@@ -3,3 +3,13 @@
  (name runtest)
  (deps (:root foo))
  (action (echo %{root})))
+
+(alias
+ (name   runtest)
+ (deps   (:read x))
+ (action (progn
+          (echo %{read})
+          (echo %{read:y}))))
+
+(rule (with-stdout-to x (echo "a\n")))
+(rule (with-stdout-to y (echo "b\n")))

--- a/test/blackbox-tests/test-cases/shadow-bindings/run.t
+++ b/test/blackbox-tests/test-cases/shadow-bindings/run.t
@@ -1,4 +1,14 @@
 Bindings introduced by user dependencies should shadow existing bindings
 
   $ dune runtest
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+  ("Local named variable not present in named deps"
+   (pform "\%{read:y}")
+   (deps_written_by_user ((:read (In_build_dir default/x)))))
+  Backtrace:
+  Raised at file "src/dep_path.ml" (inlined), line 45, characters 24-55
+  Called from file "src/build_system.ml", line 89, characters 6-48
+  Called from file "src/fiber/fiber.ml", line 243, characters 6-18
   foo
+  [1]

--- a/test/blackbox-tests/test-cases/shadow-bindings/run.t
+++ b/test/blackbox-tests/test-cases/shadow-bindings/run.t
@@ -1,14 +1,5 @@
 Bindings introduced by user dependencies should shadow existing bindings
 
   $ dune runtest
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-  ("Local named variable not present in named deps"
-   (pform "\%{read:y}")
-   (deps_written_by_user ((:read (In_build_dir default/x)))))
-  Backtrace:
-  Raised at file "src/dep_path.ml" (inlined), line 45, characters 24-55
-  Called from file "src/build_system.ml", line 89, characters 6-48
-  Called from file "src/fiber/fiber.ml", line 243, characters 6-18
+  xb
   foo
-  [1]


### PR DESCRIPTION
I went a bit too far with merging the maps for variables and macros and as a result expansion doesn't work well when the user define a variable with the same name as a macro. This PR fixes this by splitting the maps for variables and macros inside `Pform.Map.t`. It does a couple of other simplification/cleanups as well.