### PR TITLE
Fix workspace lookup in conjunction with --root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+next
+----
+
+- Fix lookup of command line specified files when `--root` is given. Previously,
+  passing in `--root` in conjunction with `--workspace` or `--config` would not
+  work correctly (#997, @rgrinberg)
+
 1.0.0 (10/07/2018)
 ------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -185,13 +185,17 @@ let find_root () =
     in
     (dir, to_cwd)
 
-let package_name =
-  Arg.conv ((fun p -> Ok (Package.Name.of_string p)), Package.Name.pp)
+module Arg = struct
+  include Arg
 
-let path_arg =
-  Arg.conv ((fun p -> Ok (Path.of_filename_relative_to_initial_cwd p))
-           , Path.pp
-           )
+  let package_name =
+    Arg.conv ((fun p -> Ok (Package.Name.of_string p)), Package.Name.pp)
+
+  let path =
+    Arg.conv ((fun p -> Ok (Path.of_filename_relative_to_initial_cwd p))
+             , Path.pp
+             )
+end
 
 let common_footer =
   `Blocks
@@ -436,7 +440,7 @@ let common =
   in
   let workspace_file =
     Arg.(value
-         & opt (some path_arg) None
+         & opt (some path) None
          & info ["workspace"] ~docs ~docv:"FILE"
              ~doc:"Use this specific workspace file instead of looking it up.")
   in
@@ -473,7 +477,7 @@ let common =
     let config_file =
       let config_file =
         Arg.(value
-             & opt (some path_arg) None
+             & opt (some path) None
              & info ["config-file"] ~docs ~docv:"FILE"
                  ~doc:"Load this configuration file instead of the default one.")
       in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -29,6 +29,9 @@ module Arg = struct
   end
 
   let path = Path.conv
+
+  [@@@ocaml.warning "-32"]
+  let file = path
 end
 
 type common =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -84,7 +84,8 @@ module Main = struct
     setup
       ~log
       ?workspace_file:(
-        Option.map common.workspace_file ~f:Path.of_string)
+        Option.map common.workspace_file
+          ~f:Path.of_filename_relative_to_initial_cwd)
       ?only_packages:common.only_packages
       ?external_lib_deps_mode
       ?x:common.x

--- a/test/blackbox-tests/test-cases/workspaces/custom-workspace/dune-workspace.dev
+++ b/test/blackbox-tests/test-cases/workspaces/custom-workspace/dune-workspace.dev
@@ -1,3 +1,3 @@
 (lang dune 1.0)
 
-(context (does-not-exist))
+(context (default))

--- a/test/blackbox-tests/test-cases/workspaces/run.t
+++ b/test/blackbox-tests/test-cases/workspaces/run.t
@@ -25,7 +25,8 @@ analogously, jbuilder will ignore it
 specifying the workspace file is possible:
 
   $ dune build --root custom-workspace --workspace custom-workspace/dune-workspace.dev
-  Error: workspace file custom-workspace/dune-workspace.dev does not exist
+  File "/Users/rgrinberg/reps/dune/_build/default/test/blackbox-tests/test-cases/workspaces/custom-workspace/dune-workspace.dev", line 2, characters 10-24:
+  Error: Unknown constructor does-not-exist
   [1]
 
 Workspaces let you set custom profiles

--- a/test/blackbox-tests/test-cases/workspaces/run.t
+++ b/test/blackbox-tests/test-cases/workspaces/run.t
@@ -25,9 +25,7 @@ analogously, jbuilder will ignore it
 specifying the workspace file is possible:
 
   $ dune build --root custom-workspace --workspace custom-workspace/dune-workspace.dev
-  File "/Users/rgrinberg/reps/dune/_build/default/test/blackbox-tests/test-cases/workspaces/custom-workspace/dune-workspace.dev", line 2, characters 10-24:
-  Error: Unknown constructor does-not-exist
-  [1]
+  Entering directory 'custom-workspace'
 
 Workspaces let you set custom profiles
 


### PR DESCRIPTION
The workspace is specified to the initial CWD hence we must convert it a path
relative to it

Not sure if we should include this in 1.0 or not. But if this doesn't make it to 1.0 then it will need a CHANGELOG entry.