### PR TITLE
Move pp files to obj dir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ next
   passing in `--root` in conjunction with `--workspace` or `--config` would not
   work correctly (#997, @rgrinberg)
 
+- Change the location of preprocessed files inside the build directory
+  (#1004, @diml)
+
 1.0.0 (10/07/2018)
 ------------------
 

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -548,7 +548,7 @@ module Gen(P : Install_rules.Params) = struct
     (* Preprocess before adding the alias module as it doesn't need
        preprocessing *)
     let pp =
-      Preprocessing.make sctx ~dir ~dep_kind ~scope
+      Preprocessing.make sctx ~dir ~obj_dir ~dep_kind ~scope
         ~preprocess:lib.buildable.preprocess
         ~preprocessor_deps:
           (SC.Deps.interpret sctx ~scope ~dir
@@ -805,6 +805,11 @@ module Gen(P : Install_rules.Params) = struct
   let executables_rules ~dir ~all_modules ~dir_kind
         ~modules_partitioner ~scope ~compile_info
         (exes : Executables.t) =
+    (* Use "eobjs" rather than "objs" to avoid a potential conflict
+       with a library of the same name *)
+    let obj_dir =
+      Utils.executable_object_directory ~dir (List.hd exes.names |> snd)
+    in
     let requires = Lib.Compile.requires compile_info in
     let modules =
       parse_modules ~all_modules ~buildable:exes.buildable
@@ -815,7 +820,7 @@ module Gen(P : Install_rules.Params) = struct
         ~scope ~dir
     in
     let pp =
-      Preprocessing.make sctx ~dir ~dep_kind:Required
+      Preprocessing.make sctx ~dir ~obj_dir ~dep_kind:Required
         ~scope
         ~preprocess:exes.buildable.preprocess
         ~preprocessor_deps
@@ -872,12 +877,6 @@ module Gen(P : Install_rules.Params) = struct
         ~scope
         ~dir
         ~standard:(Build.return [])
-    in
-
-    (* Use "eobjs" rather than "objs" to avoid a potential conflict
-       with a library of the same name *)
-    let obj_dir =
-      Utils.executable_object_directory ~dir (List.hd programs).name
     in
 
     let cctx =

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -197,6 +197,7 @@ module Gen(P : Install_rules.Params) = struct
          ~bindings:(Pform.Map.of_bindings rule.deps)
          ~dep_kind:Required
          ~targets
+         ~targets_dir:dir
          ~scope)
 
   let copy_files_rules (def: Copy_files.t) ~src_dir ~dir ~scope =
@@ -955,6 +956,7 @@ module Gen(P : Install_rules.Params) = struct
            ~dep_kind:Required
            ~bindings:(Pform.Map.of_bindings alias_conf.deps)
            ~targets:Alias
+           ~targets_dir:dir
            ~scope)
 
   let tests_rules (t : Tests.t) ~dir ~scope ~all_modules ~modules_partitioner

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -173,7 +173,7 @@ include Sub_system.Register_end_point(
       let modules =
         Module.Name.Map.singleton main_module_name
           (Module.make main_module_name
-             ~impl:{ name   = main_module_filename
+             ~impl:{ path   = Path.relative inline_test_dir main_module_filename
                    ; syntax = OCaml
                    }
              ~obj_name:name)
@@ -205,7 +205,7 @@ include Sub_system.Register_end_point(
         let files ml_kind =
           Pform.Var.Values (Value.L.paths (
             List.filter_map source_modules ~f:(fun m ->
-              Module.file m ~dir ml_kind)))
+              Module.file m ml_kind)))
         in
         let bindings =
           Pform.Map.of_list_exn
@@ -273,8 +273,8 @@ include Sub_system.Register_end_point(
               (A.run (Ok exe) flags ::
                (Module.Name.Map.values source_modules
                 |> List.concat_map ~f:(fun m ->
-                  [ Module.file m ~dir Impl
-                  ; Module.file m ~dir Intf
+                  [ Module.file m Impl
+                  ; Module.file m Intf
                   ])
                 |> List.filter_map ~f:(fun x -> x)
                 |> List.map ~f:(fun fn ->

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -220,7 +220,11 @@ include Sub_system.Register_end_point(
              Option.map backend.info.generate_runner ~f:(fun (loc, action) ->
                SC.Action.run sctx action ~loc
                  ~bindings
-                 ~dir ~dep_kind:Required ~targets:Alias ~scope)))
+                 ~dir
+                 ~dep_kind:Required
+                 ~targets:Alias
+                 ~targets_dir:dir
+                 ~scope)))
         >>^ (fun actions ->
           Action.with_stdout_to target
             (Action.progn actions))

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -164,7 +164,7 @@ module Gen(P : Install_params) = struct
               ; List.filter_map Ml_kind.all ~f:(Module.cmt_file m ~obj_dir)
               ; List.filter_map [m.intf;m.impl] ~f:(function
                   | None -> None
-                  | Some f -> Some (Path.relative dir f.name))
+                  | Some f -> Some f.path)
               ])
         ; if_ byte [ lib_archive ~dir lib ~ext:".cma" ]
         ; if_ (Library.has_stubs lib) [ stubs_archive ~dir lib ]

--- a/src/module.ml
+++ b/src/module.ml
@@ -28,23 +28,6 @@ module File = struct
     { name : string
     ; syntax : Syntax.t
     }
-
-  let to_ocaml t =
-    match t.syntax with
-    | OCaml -> Exn.code_error "to_ocaml: can only convert reason Files"
-                 ["t.name", Sexp.To_sexp.string t.name]
-    | Reason ->
-      { syntax = OCaml
-      ; name =
-          let base, ext = Filename.split_extension t.name in
-          base ^ ".re" ^
-          (match Filename.extension t.name with
-           | ".re" -> ".ml"
-           | ".rei" -> ".mli"
-           | _ -> Exn.code_error "to_ocaml: unrecognized extension"
-                    [ "name", Sexp.To_sexp.string t.name
-                    ; "ext", Sexp.To_sexp.string ext ])
-      }
 end
 
 type t =

--- a/src/module.ml
+++ b/src/module.ml
@@ -25,9 +25,11 @@ end
 
 module File = struct
   type t =
-    { name : string
+    { path   : Path.t
     ; syntax : Syntax.t
     }
+
+  let make syntax path = { syntax; path }
 end
 
 type t =
@@ -55,7 +57,7 @@ let make ?impl ?intf ?obj_name name =
     match obj_name with
     | Some s -> s
     | None ->
-      let fn = file.name in
+      let fn = Path.basename file.path in
       match String.index fn '.' with
       | None   -> fn
       | Some i -> String.sub fn ~pos:0 ~len:i
@@ -70,17 +72,17 @@ let real_unit_name t = Name.of_string (Filename.basename t.obj_name)
 
 let has_impl t = Option.is_some t.impl
 
-let file t ~dir (kind : Ml_kind.t) =
+let file t (kind : Ml_kind.t) =
   let file =
     match kind with
     | Impl -> t.impl
     | Intf -> t.intf
   in
-  Option.map file ~f:(fun f -> Path.relative dir f.name)
+  Option.map file ~f:(fun f -> f.path)
 
 let obj_file t ~obj_dir ~ext = Path.relative obj_dir (t.obj_name ^ ext)
 
-let cm_source t ~dir kind = file t ~dir (Cm_kind.source kind)
+let cm_source t kind = file t (Cm_kind.source kind)
 
 let cm_file_unsafe t ~obj_dir kind =
   obj_file t ~obj_dir ~ext:(Cm_kind.ext kind)

--- a/src/module.mli
+++ b/src/module.mli
@@ -25,9 +25,11 @@ end
 
 module File : sig
   type t =
-    { name : string
-    ; syntax: Syntax.t
+    { path   : Path.t
+    ; syntax : Syntax.t
     }
+
+  val make : Syntax.t -> Path.t -> t
 end
 
 (** Representation of a module. It is guaranteed that at least one of
@@ -54,8 +56,8 @@ val name : t -> Name.t
 (** Real unit name once wrapped. This is always a valid module name. *)
 val real_unit_name : t -> Name.t
 
-val file      : t -> dir:    Path.t -> Ml_kind.t -> Path.t option
-val cm_source : t -> dir:    Path.t -> Cm_kind.t -> Path.t option
+val file      : t -> Ml_kind.t -> Path.t option
+val cm_source : t -> Cm_kind.t -> Path.t option
 val cm_file   : t -> obj_dir:Path.t -> Cm_kind.t -> Path.t option
 val cmt_file  : t -> obj_dir:Path.t -> Ml_kind.t -> Path.t option
 

--- a/src/module.mli
+++ b/src/module.mli
@@ -28,8 +28,6 @@ module File : sig
     { name : string
     ; syntax: Syntax.t
     }
-
-  val to_ocaml : t -> t
 end
 
 (** Representation of a module. It is guaranteed that at least one of

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -36,7 +36,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs ~cm_kind (m : Module.t) =
   let obj_dir  = CC.obj_dir       cctx in
   let ctx      = SC.context       sctx in
   Option.iter (Mode.of_cm_kind cm_kind |> Context.compiler ctx) ~f:(fun compiler ->
-    Option.iter (Module.cm_source ~dir m cm_kind) ~f:(fun src ->
+    Option.iter (Module.cm_source m cm_kind) ~f:(fun src ->
       let ml_kind = Cm_kind.source cm_kind in
       let dst = Module.cm_file_unsafe m ~obj_dir cm_kind in
       let extra_args, extra_deps, other_targets =
@@ -149,10 +149,9 @@ let build_modules ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx =
 
 let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   let sctx     = CC.super_context cctx in
-  let dir      = CC.dir           cctx in
   let obj_dir  = CC.obj_dir       cctx in
   let ctx      = SC.context       sctx in
-  let src = Option.value_exn (Module.file ~dir m Impl) in
+  let src = Option.value_exn (Module.file m Impl) in
   let dep_graph = Ml_kind.Dict.get dep_graphs Impl in
   let cm_deps =
     Build.dyn_paths

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -122,11 +122,10 @@ let parse_deps cctx ~file ~unit lines =
 
 let deps_of cctx ~ml_kind unit =
   let sctx = CC.super_context cctx in
-  let dir  = CC.dir           cctx in
   if is_alias_module cctx unit then
     Build.return []
   else
-    match Module.file ~dir unit ml_kind with
+    match Module.file unit ml_kind with
     | None -> Build.return []
     | Some file ->
       let file_in_obj_dir ~suffix file =
@@ -148,9 +147,9 @@ let deps_of cctx ~ml_kind unit =
             if is_alias_module cctx m then
               None
             else
-              match Module.file ~dir m Ml_kind.Intf with
+              match Module.file m Ml_kind.Intf with
               | Some _ as x -> x
-              | None -> Module.file ~dir m Ml_kind.Impl
+              | None -> Module.file m Ml_kind.Impl
           in
           Option.map path ~f:all_deps_path
         in

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -470,6 +470,7 @@ let lint_module sctx ~dir ~dep_kind ~lint ~lib_name ~scope ~dir_kind =
                         ~dep_kind
                         ~bindings
                         ~targets:(Static [])
+                        ~targets_dir:dir
                         ~scope)))
         | Pps { loc; pps; flags } ->
           let args : _ Arg_spec.t =

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -422,7 +422,12 @@ let setup_reason_rules sctx ~dir (m : Module.t) =
     match f.syntax with
     | OCaml  -> f
     | Reason ->
-      let ml = Module.File.to_ocaml f in
+      let ml =
+        { Module.File.
+          syntax = OCaml
+        ; name   = f.name ^ ".ast"
+        }
+      in
       SC.add_rule sctx (rule f.name ml.name);
       ml)
 

--- a/src/preprocessing.mli
+++ b/src/preprocessing.mli
@@ -10,6 +10,7 @@ val dummy : t
 val make
   :  Super_context.t
   -> dir:Path.t
+  -> obj_dir:Path.t
   -> dep_kind:Build.lib_dep_kind
   -> lint:Jbuild.Preprocess_map.t
   -> preprocess:Jbuild.Preprocess_map.t

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -903,7 +903,7 @@ let compare x y =
 
 let extension t = Filename.extension (to_string t)
 
-let pp ppf t = Format.pp_print_string ppf (to_string t)
+let pp ppf t = Format.pp_print_string ppf (to_string_maybe_quoted t)
 
 let pp_debug ppf = function
   | In_source_tree s ->

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -772,8 +772,8 @@ module Action = struct
             Exn.code_error "Unexpected variable in step2"
               ["var", String_with_vars.Var.sexp_of_t pform]))
 
-  let run sctx ~loc ~bindings t ~dir ~dep_kind
-        ~targets:targets_written_by_user ~scope
+  let run sctx ~loc ~bindings ~dir ~dep_kind
+        ~targets:targets_written_by_user ~scope ?(targets_dir=dir) t
     : (Path.t Bindings.t, Action.t) Build.t =
     let bindings = Pform.Map.superpose sctx.pforms bindings in
     let map_exe = map_exe sctx in
@@ -824,7 +824,7 @@ module Action = struct
     in
     let targets = Path.Set.to_list targets in
     List.iter targets ~f:(fun target ->
-      if Path.parent_exn target <> dir then
+      if Path.parent_exn target <> targets_dir then
         Loc.fail loc
           "This action has targets in a different directory than the current \
            one, this is not allowed by dune at the moment:\n%s"

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -773,7 +773,7 @@ module Action = struct
               ["var", String_with_vars.Var.sexp_of_t pform]))
 
   let run sctx ~loc ~bindings ~dir ~dep_kind
-        ~targets:targets_written_by_user ~scope ?(targets_dir=dir) t
+        ~targets:targets_written_by_user ~targets_dir ~scope t
     : (Path.t Bindings.t, Action.t) Build.t =
     let bindings = Pform.Map.superpose sctx.pforms bindings in
     let map_exe = map_exe sctx in
@@ -798,23 +798,6 @@ module Action = struct
         let { Action.Infer.Outcome. deps; targets } =
           Action.Infer.partial t ~all_targets:false
         in
-        (* CR-someday jdimino: should this be an error or not?
-
-           It's likely that what we get here is what the user thinks
-           of as temporary files, even though they might conflict with
-           actual targets. We need to tell dune about such things,
-           so that it can report better errors.
-
-           {[
-             let missing = Path.Set.diff targets targets_written_by_user in
-             if not (Path.Set.is_empty missing) then
-               Loc.warn (Loc.in_file (Utils.jbuild_name_in ~dir))
-                 "Missing targets in user action:\n%s"
-                 (List.map (Path.Set.elements missing) ~f:(fun target ->
-                    sprintf "- %s" (Utils.describe_target target))
-                  |> String.concat ~sep:"\n");
-           ]}
-        *)
         { deps; targets = Path.Set.union targets targets_written_by_user }
       | Alias ->
         let { Action.Infer.Outcome. deps; targets = _ } =

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -240,11 +240,12 @@ module Action : sig
     :  t
     -> loc:Loc.t
     -> bindings:Pform.Map.t
-    -> Action.Unexpanded.t
     -> dir:Path.t
     -> dep_kind:Build.lib_dep_kind
     -> targets:targets
     -> scope:Scope.t
+    -> ?targets_dir:Path.t (* default: dir *)
+    -> Action.Unexpanded.t
     -> (Path.t Bindings.t, Action.t) Build.t
 end
 

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -243,8 +243,8 @@ module Action : sig
     -> dir:Path.t
     -> dep_kind:Build.lib_dep_kind
     -> targets:targets
+    -> targets_dir:Path.t
     -> scope:Scope.t
-    -> ?targets_dir:Path.t (* default: dir *)
     -> Action.Unexpanded.t
     -> (Path.t Bindings.t, Action.t) Build.t
 end

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -51,16 +51,16 @@ let setup sctx ~dir ~(libs : Library.t list) ~scope =
   match libs with
   | [] -> ()
   | _ :: _ ->
+    let utop_exe_dir = utop_exe_dir ~dir in
     let modules =
       Module.Name.Map.singleton
         main_module_name
         (Module.make main_module_name
-           ~impl:{ name = main_module_filename
+           ~impl:{ path   = Path.relative utop_exe_dir main_module_filename
                  ; syntax = Module.Syntax.OCaml
                  }
            ~obj_name:exe_name)
     in
-    let utop_exe_dir = utop_exe_dir ~dir in
     let requires =
       let open Result.O in
       Lib.DB.find_many (Scope.libs scope)

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -41,7 +41,7 @@ Same, but with error pointing to .ppx
 Test the argument syntax
 
   $ dune build test_ppx_args.cma
-           ppx .test_ppx_args.objs/test_ppx_args.ml.pp
+           ppx .test_ppx_args.objs/test_ppx_args.pp.ml
   .ppx/driver_print_args@foo/ppx.exe
   -arg1
   -arg2
@@ -50,9 +50,9 @@ Test the argument syntax
   --cookie
   library-name="test_ppx_args"
   -o
-  .test_ppx_args.objs/test_ppx_args.ml.pp
+  .test_ppx_args.objs/test_ppx_args.pp.ml
   --impl
   test_ppx_args.ml
   Error: Rule failed to generate the following targets:
-  - .test_ppx_args.objs/test_ppx_args.ml.pp
+  - .test_ppx_args.objs/test_ppx_args.pp.ml
   [1]

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -41,7 +41,7 @@ Same, but with error pointing to .ppx
 Test the argument syntax
 
   $ dune build test_ppx_args.cma
-           ppx test_ppx_args.pp.ml
+           ppx test_ppx_args.ml.pp
   .ppx/driver_print_args@foo/ppx.exe
   -arg1
   -arg2
@@ -50,9 +50,9 @@ Test the argument syntax
   --cookie
   library-name="test_ppx_args"
   -o
-  test_ppx_args.pp.ml
+  test_ppx_args.ml.pp
   --impl
   test_ppx_args.ml
   Error: Rule failed to generate the following targets:
-  - test_ppx_args.pp.ml
+  - test_ppx_args.ml.pp
   [1]

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -41,7 +41,7 @@ Same, but with error pointing to .ppx
 Test the argument syntax
 
   $ dune build test_ppx_args.cma
-           ppx test_ppx_args.ml.pp
+           ppx .test_ppx_args.objs/test_ppx_args.ml.pp
   .ppx/driver_print_args@foo/ppx.exe
   -arg1
   -arg2
@@ -50,9 +50,9 @@ Test the argument syntax
   --cookie
   library-name="test_ppx_args"
   -o
-  test_ppx_args.ml.pp
+  .test_ppx_args.objs/test_ppx_args.ml.pp
   --impl
   test_ppx_args.ml
   Error: Rule failed to generate the following targets:
-  - test_ppx_args.ml.pp
+  - .test_ppx_args.objs/test_ppx_args.ml.pp
   [1]

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -2,18 +2,18 @@
         ocamlc lib/stubs$ext_obj
     ocamlmklib lib/dllx_stubs$ext_dll,lib/libx_stubs$ext_lib
       ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
-           ppx lib/.x.objs/x.ml.pp
-      ocamldep lib/.x.objs/x.ml.pp.d
+           ppx lib/.x.objs/x.pp.ml
+      ocamldep lib/.x.objs/x.pp.ml.d
         ocamlc lib/.x.objs/x__.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__.{cmx,o}
-           ppx lib/.x.objs/y.ml.pp
-      ocamldep lib/.x.objs/y.ml.pp.d
+           ppx lib/.x.objs/y.pp.ml
+      ocamldep lib/.x.objs/y.pp.ml.d
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
-           ppx bin/.technologic.eobjs/technologic.ml.pp
-      ocamldep bin/.technologic.eobjs/technologic.ml.pp.d
-           ppx bin/.technologic.eobjs/z.ml.pp
-      ocamldep bin/.technologic.eobjs/z.ml.pp.d
+           ppx bin/.technologic.eobjs/technologic.pp.ml
+      ocamldep bin/.technologic.eobjs/technologic.pp.ml.d
+           ppx bin/.technologic.eobjs/z.pp.ml
+      ocamldep bin/.technologic.eobjs/z.pp.ml.d
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml lib/.x.objs/x__Y.cmo.js
         ocamlc lib/.x.objs/x.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -2,18 +2,18 @@
         ocamlc lib/stubs$ext_obj
     ocamlmklib lib/dllx_stubs$ext_dll,lib/libx_stubs$ext_lib
       ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
-           ppx lib/x.pp.ml
-      ocamldep lib/.x.objs/x.pp.ml.d
+           ppx lib/x.ml.pp
+      ocamldep lib/.x.objs/x.ml.pp.d
         ocamlc lib/.x.objs/x__.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__.{cmx,o}
-           ppx lib/y.pp.ml
-      ocamldep lib/.x.objs/y.pp.ml.d
+           ppx lib/y.ml.pp
+      ocamldep lib/.x.objs/y.ml.pp.d
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
-           ppx bin/technologic.pp.ml
-      ocamldep bin/.technologic.eobjs/technologic.pp.ml.d
-           ppx bin/z.pp.ml
-      ocamldep bin/.technologic.eobjs/z.pp.ml.d
+           ppx bin/technologic.ml.pp
+      ocamldep bin/.technologic.eobjs/technologic.ml.pp.d
+           ppx bin/z.ml.pp
+      ocamldep bin/.technologic.eobjs/z.ml.pp.d
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml lib/.x.objs/x__Y.cmo.js
         ocamlc lib/.x.objs/x.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -2,17 +2,17 @@
         ocamlc lib/stubs$ext_obj
     ocamlmklib lib/dllx_stubs$ext_dll,lib/libx_stubs$ext_lib
       ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
-           ppx lib/x.ml.pp
+           ppx lib/.x.objs/x.ml.pp
       ocamldep lib/.x.objs/x.ml.pp.d
         ocamlc lib/.x.objs/x__.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__.{cmx,o}
-           ppx lib/y.ml.pp
+           ppx lib/.x.objs/y.ml.pp
       ocamldep lib/.x.objs/y.ml.pp.d
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
-           ppx bin/technologic.ml.pp
+           ppx bin/.technologic.eobjs/technologic.ml.pp
       ocamldep bin/.technologic.eobjs/technologic.ml.pp.d
-           ppx bin/z.ml.pp
+           ppx bin/.technologic.eobjs/z.ml.pp
       ocamldep bin/.technologic.eobjs/z.ml.pp.d
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml lib/.x.objs/x__Y.cmo.js

--- a/test/blackbox-tests/test-cases/ppx-rewriter/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter/run.t
@@ -4,7 +4,7 @@
       ocamlopt ppx/.fooppx.objs/fooppx.{cmx,o}
       ocamlopt ppx/fooppx.{a,cmxa}
       ocamlopt .ppx/jbuild/fooppx/ppx.exe
-           ppx w_omp_driver.ml.pp
+           ppx .w_omp_driver.eobjs/w_omp_driver.ml.pp
       ocamldep .w_omp_driver.eobjs/w_omp_driver.ml.pp.d
         ocamlc .w_omp_driver.eobjs/w_omp_driver.{cmi,cmo,cmt}
       ocamlopt .w_omp_driver.eobjs/w_omp_driver.{cmx,o}

--- a/test/blackbox-tests/test-cases/ppx-rewriter/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter/run.t
@@ -4,8 +4,8 @@
       ocamlopt ppx/.fooppx.objs/fooppx.{cmx,o}
       ocamlopt ppx/fooppx.{a,cmxa}
       ocamlopt .ppx/jbuild/fooppx/ppx.exe
-           ppx w_omp_driver.pp.ml
-      ocamldep .w_omp_driver.eobjs/w_omp_driver.pp.ml.d
+           ppx w_omp_driver.ml.pp
+      ocamldep .w_omp_driver.eobjs/w_omp_driver.ml.pp.d
         ocamlc .w_omp_driver.eobjs/w_omp_driver.{cmi,cmo,cmt}
       ocamlopt .w_omp_driver.eobjs/w_omp_driver.{cmx,o}
       ocamlopt w_omp_driver.exe

--- a/test/blackbox-tests/test-cases/ppx-rewriter/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter/run.t
@@ -4,8 +4,8 @@
       ocamlopt ppx/.fooppx.objs/fooppx.{cmx,o}
       ocamlopt ppx/fooppx.{a,cmxa}
       ocamlopt .ppx/jbuild/fooppx/ppx.exe
-           ppx .w_omp_driver.eobjs/w_omp_driver.ml.pp
-      ocamldep .w_omp_driver.eobjs/w_omp_driver.ml.pp.d
+           ppx .w_omp_driver.eobjs/w_omp_driver.pp.ml
+      ocamldep .w_omp_driver.eobjs/w_omp_driver.pp.ml.d
         ocamlc .w_omp_driver.eobjs/w_omp_driver.{cmi,cmo,cmt}
       ocamlopt .w_omp_driver.eobjs/w_omp_driver.{cmx,o}
       ocamlopt w_omp_driver.exe

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -15,8 +15,8 @@ On the other hand, public libraries may have private preprocessors
       ocamlopt .ppx_internal.objs/ppx_internal.{cmx,o}
       ocamlopt ppx_internal.{a,cmxa}
       ocamlopt .ppx/jbuild/ppx_internal@mylib/ppx.exe
-           ppx mylib.pp.ml
-      ocamldep .mylib.objs/mylib.pp.ml.d
+           ppx mylib.ml.pp
+      ocamldep .mylib.objs/mylib.ml.pp.d
         ocamlc .mylib.objs/mylib.{cmi,cmo,cmt}
       ocamlopt .mylib.objs/mylib.{cmx,o}
       ocamlopt mylib.{a,cmxa}
@@ -33,8 +33,8 @@ Unless they introduce private runtime dependencies:
       ocamlopt .private_ppx.objs/private_ppx.{cmx,o}
       ocamlopt private_ppx.{a,cmxa}
       ocamlopt .ppx/jbuild/private_ppx@mylib/ppx.exe
-           ppx mylib.pp.ml
-      ocamldep .mylib.objs/mylib.pp.ml.d
+           ppx mylib.ml.pp
+      ocamldep .mylib.objs/mylib.ml.pp.d
   [1]
 
 However, public binaries may accept private dependencies

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -15,7 +15,7 @@ On the other hand, public libraries may have private preprocessors
       ocamlopt .ppx_internal.objs/ppx_internal.{cmx,o}
       ocamlopt ppx_internal.{a,cmxa}
       ocamlopt .ppx/jbuild/ppx_internal@mylib/ppx.exe
-           ppx mylib.ml.pp
+           ppx .mylib.objs/mylib.ml.pp
       ocamldep .mylib.objs/mylib.ml.pp.d
         ocamlc .mylib.objs/mylib.{cmi,cmo,cmt}
       ocamlopt .mylib.objs/mylib.{cmx,o}
@@ -33,7 +33,7 @@ Unless they introduce private runtime dependencies:
       ocamlopt .private_ppx.objs/private_ppx.{cmx,o}
       ocamlopt private_ppx.{a,cmxa}
       ocamlopt .ppx/jbuild/private_ppx@mylib/ppx.exe
-           ppx mylib.ml.pp
+           ppx .mylib.objs/mylib.ml.pp
       ocamldep .mylib.objs/mylib.ml.pp.d
   [1]
 

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -15,8 +15,8 @@ On the other hand, public libraries may have private preprocessors
       ocamlopt .ppx_internal.objs/ppx_internal.{cmx,o}
       ocamlopt ppx_internal.{a,cmxa}
       ocamlopt .ppx/jbuild/ppx_internal@mylib/ppx.exe
-           ppx .mylib.objs/mylib.ml.pp
-      ocamldep .mylib.objs/mylib.ml.pp.d
+           ppx .mylib.objs/mylib.pp.ml
+      ocamldep .mylib.objs/mylib.pp.ml.d
         ocamlc .mylib.objs/mylib.{cmi,cmo,cmt}
       ocamlopt .mylib.objs/mylib.{cmx,o}
       ocamlopt mylib.{a,cmxa}
@@ -33,8 +33,8 @@ Unless they introduce private runtime dependencies:
       ocamlopt .private_ppx.objs/private_ppx.{cmx,o}
       ocamlopt private_ppx.{a,cmxa}
       ocamlopt .ppx/jbuild/private_ppx@mylib/ppx.exe
-           ppx .mylib.objs/mylib.ml.pp
-      ocamldep .mylib.objs/mylib.ml.pp.d
+           ppx .mylib.objs/mylib.pp.ml
+      ocamldep .mylib.objs/mylib.pp.ml.d
   [1]
 
 However, public binaries may accept private dependencies

--- a/test/blackbox-tests/test-cases/reason/run.t
+++ b/test/blackbox-tests/test-cases/reason/run.t
@@ -1,54 +1,54 @@
   $ dune build @runtest @install-file --display short
-         refmt bar.re.ml
-      ocamldep .rlib.objs/bar.re.ml.d
+         refmt .rlib.objs/bar.ast.re
+      ocamldep .rlib.objs/bar.ast.re.d
       ocamldep pp/.reasononlypp.eobjs/reasononlypp.ml.d
         ocamlc pp/.reasononlypp.eobjs/reasononlypp.{cmi,cmo,cmt}
       ocamlopt pp/.reasononlypp.eobjs/reasononlypp.{cmx,o}
       ocamlopt pp/reasononlypp.exe
-  reasononlypp cppome.pp.re
-         refmt cppome.pp.re.ml
-      ocamldep .rlib.objs/cppome.pp.re.ml.d
+  reasononlypp .rlib.objs/cppome.pp.re
+         refmt .rlib.objs/cppome.pp.ast.re
+      ocamldep .rlib.objs/cppome.pp.ast.re.d
       ocamldep ppx/.reasonppx.objs/reasonppx.ml.d
         ocamlc ppx/.reasonppx.objs/reasonppx.{cmi,cmo,cmt}
       ocamlopt ppx/.reasonppx.objs/reasonppx.{cmx,o}
       ocamlopt ppx/reasonppx.{a,cmxa}
       ocamlopt .ppx/jbuild/reasonppx@rlib/ppx.exe
-           ppx foo.pp.ml
+           ppx .rlib.objs/foo.pp.ml
       ocamldep .rlib.objs/foo.pp.ml.d
-         refmt hello.re.ml
-           ppx hello.re.pp.ml
-      ocamldep .rlib.objs/hello.re.pp.ml.d
-         refmt pped.re.ml
-      ocamldep .rlib.objs/pped.re.ml.d
+         refmt .rlib.objs/hello.ast.re
+           ppx .rlib.objs/hello.ast.pp.re
+      ocamldep .rlib.objs/hello.ast.pp.re.d
+         refmt .rlib.objs/pped.ast.re
+      ocamldep .rlib.objs/pped.ast.re.d
         ocamlc .rlib.objs/rlib.{cmi,cmo,cmt}
       ocamlopt .rlib.objs/rlib.{cmx,o}
       ocamldep .rlib.objs/bar.mli.d
         ocamlc .rlib.objs/rlib__Bar.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Bar.{cmx,o}
-         refmt foo.re.mli
-           ppx foo.re.pp.mli
-      ocamldep .rlib.objs/foo.re.pp.mli.d
+         refmt .rlib.objs/foo.ast.rei
+           ppx .rlib.objs/foo.ast.pp.rei
+      ocamldep .rlib.objs/foo.ast.pp.rei.d
         ocamlc .rlib.objs/rlib__Foo.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Foo.{cmx,o}
-         refmt hello.re.mli
-           ppx hello.re.pp.mli
-      ocamldep .rlib.objs/hello.re.pp.mli.d
+         refmt .rlib.objs/hello.ast.rei
+           ppx .rlib.objs/hello.ast.pp.rei
+      ocamldep .rlib.objs/hello.ast.pp.rei.d
         ocamlc .rlib.objs/rlib__Hello.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Hello.{cmx,o}
-         refmt pped.re.mli
-      ocamldep .rlib.objs/pped.re.mli.d
+         refmt .rlib.objs/pped.ast.rei
+      ocamldep .rlib.objs/pped.ast.rei.d
         ocamlc .rlib.objs/rlib__Pped.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Pped.{cmx,o}
-  reasononlypp cppome.pp.rei
-         refmt cppome.pp.re.mli
-      ocamldep .rlib.objs/cppome.pp.re.mli.d
+  reasononlypp .rlib.objs/cppome.pp.rei
+         refmt .rlib.objs/cppome.pp.ast.rei
+      ocamldep .rlib.objs/cppome.pp.ast.rei.d
         ocamlc .rlib.objs/rlib__Cppome.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Cppome.{cmx,o}
       ocamlopt rlib.{a,cmxa}
       ocamlopt rlib.cmxs
-  reasononlypp rbin.pp.re
-         refmt rbin.pp.re.ml
-      ocamldep .rbin.eobjs/rbin.pp.re.ml.d
+  reasononlypp .rbin.eobjs/rbin.pp.re
+         refmt .rbin.eobjs/rbin.pp.ast.re
+      ocamldep .rbin.eobjs/rbin.pp.ast.re.d
         ocamlc .rbin.eobjs/rbin.{cmi,cmo,cmt}
       ocamlopt .rbin.eobjs/rbin.{cmx,o}
       ocamlopt rbin.exe

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -11,8 +11,8 @@
         ocamlc a/kernel/a_kernel.cma
       ocamlopt .ppx/jbuild/a.kernel/ppx.exe
       ocamlopt .ppx/jbuild/a/ppx.exe
-           ppx b/b.pp.ml
-      ocamldep b/.b.objs/b.pp.ml.d
+           ppx b/b.ml.pp
+      ocamldep b/.b.objs/b.ml.pp.d
         ocamlc b/.b.objs/b.{cmi,cmo,cmt}
       ocamlopt b/.b.objs/b.{cmx,o}
       ocamlopt b/b.{a,cmxa}

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -11,8 +11,8 @@
         ocamlc a/kernel/a_kernel.cma
       ocamlopt .ppx/jbuild/a.kernel/ppx.exe
       ocamlopt .ppx/jbuild/a/ppx.exe
-           ppx b/.b.objs/b.ml.pp
-      ocamldep b/.b.objs/b.ml.pp.d
+           ppx b/.b.objs/b.pp.ml
+      ocamldep b/.b.objs/b.pp.ml.d
         ocamlc b/.b.objs/b.{cmi,cmo,cmt}
       ocamlopt b/.b.objs/b.{cmx,o}
       ocamlopt b/b.{a,cmxa}

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -11,7 +11,7 @@
         ocamlc a/kernel/a_kernel.cma
       ocamlopt .ppx/jbuild/a.kernel/ppx.exe
       ocamlopt .ppx/jbuild/a/ppx.exe
-           ppx b/b.ml.pp
+           ppx b/.b.objs/b.ml.pp
       ocamldep b/.b.objs/b.ml.pp.d
         ocamlc b/.b.objs/b.{cmi,cmo,cmt}
       ocamlopt b/.b.objs/b.{cmx,o}


### PR DESCRIPTION
This PR moves all pre-processed files to the object directory. This is the last blocker to offer first class support for multi-directory libraries.

It changes the code as follow:

- systematically pass `-intf-suffix <extension-of-the-implementation-file>` when compiling implementation files. This forces the compiler to read the cmi file rather than create it. Normally the compiler checks that the .mli file is present, however now the implementation and interface files might no longer be in the same directory
- simplify the extension of ast files (ppx or reason). This is allowed by the previous point
- make the `name : string` field of `Module.File` be `path : Path.t` instead. This simplifies the code quite a bit
- put all the generated ast files in the object directory

I added a changelog entry for this. While we provide no stability guarantee on the naming of artifacts, some users might be looking inside the _build directory. So it seems good to document this change.



