### PR TITLE
Refactor var expansion

### DIFF
--- a/src/action.mli
+++ b/src/action.mli
@@ -83,7 +83,7 @@ module Unexpanded : sig
       :  t
       -> dir:Path.t
       -> map_exe:(Path.t -> Path.t)
-      -> f:(String_with_vars.Var.t -> Syntax.Version.t -> Value.t list option)
+      -> f:(Value.t list option String_with_vars.expander)
       -> Unresolved.t
   end
 
@@ -91,7 +91,7 @@ module Unexpanded : sig
     :  t
     -> dir:Path.t
     -> map_exe:(Path.t -> Path.t)
-    -> f:(String_with_vars.Var.t -> Syntax.Version.t -> Value.t list option)
+    -> f:(Value.t list option String_with_vars.expander)
     -> Partial.t
 end
 

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -11,9 +11,9 @@ module Ast = struct
     | Diff : ('a, 'b) t * ('a, 'b) t -> ('a, 'b) t
     | Include : String_with_vars.t -> ('a, unexpanded) t
 
-  let of_list = function
-    | [x]     -> Element x
-    | xs      -> Union (List.map ~f:(fun x -> Element x) xs)
+  let union = function
+    | [x] -> x
+    | xs  -> Union xs
 end
 
 type 'ast generic =
@@ -301,8 +301,8 @@ module Unexpanded = struct
     let context = t.context in
     let f_elems s =
       let loc = String_with_vars.loc s in
-      List.map ~f:(fun s -> (loc, Value.to_string ~dir s)) (f s)
-      |> Ast.of_list
+      Ast.union
+        (List.map (f s) ~f:(fun s -> Ast.Element (loc, Value.to_string ~dir s)))
     in
     let rec expand (t : ast) : ast_expanded =
       let open Ast in

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -315,8 +315,9 @@ module Unexpanded = struct
             match f fn with
             | [x] -> Value.to_path ~dir x
             | _ ->
-              Exn.code_error "Ordered_set_lang.Unexpanded.expand path"
-                ["fn", String_with_vars.sexp_of_t fn]
+              Loc.fail (String_with_vars.loc fn)
+                "An unquoted templated expanded to more than one value. \
+                 A file path is expected in this position."
           in
           match Path.Map.find files_contents path with
           | Some x -> x

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -65,16 +65,17 @@ module Unexpanded : sig
   (** List of files needed to expand this set *)
   val files
     : t
-    -> f:(String_with_vars.t -> string)
-    -> Sexp.syntax * String.Set.t
+    -> f:(String_with_vars.t -> Path.t)
+    -> Sexp.syntax * Path.Set.t
 
   (** Expand [t] using with the given file contents. [file_contents] is a map from
       filenames to their parsed contents. Every [(:include fn)] in [t] is replaced by
       [Map.find files_contents fn]. Every element is converted to a string using [f]. *)
   val expand
     :  t
-    -> files_contents:Sexp.Ast.t String.Map.t
-    -> f:(String_with_vars.t -> string)
+    -> dir:Path.t
+    -> files_contents:Sexp.Ast.t Path.Map.t
+    -> f:(String_with_vars.t -> Value.t list)
     -> expanded
 
   type position = Pos | Neg

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -187,7 +187,7 @@ module Map = struct
         Syntax.Error.deleted_in (String_with_vars.Var.loc pform)
           Stanza.syntax syntax_version ~what:(describe pform) ?repl
 
-  let expand t ~syntax_version ~pform =
+  let expand t pform syntax_version =
     match String_with_vars.Var.payload pform with
     | None ->
       Option.map (expand t.vars ~syntax_version ~pform) ~f:(fun x ->

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -48,11 +48,7 @@ module Map : sig
 
   val input_file : Path.t -> t
 
-  val expand
-    :  t
-    -> syntax_version:Syntax.Version.t
-    -> pform:String_with_vars.Var.t
-    -> Expansion.t option
+  val expand : t -> Expansion.t option String_with_vars.expander
 
   val empty : t
 end

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -158,7 +158,7 @@ let concat_rev = function
   | l -> String.concat (List.rev l) ~sep:""
 
 module Mode = struct
-  type 'a t =
+  type _ t =
     | Single : Value.t t
     | Many : Value.t list t
 

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -264,6 +264,8 @@ let partial_expand
       end
     | _ -> loop [] [] template.parts
 
+type 'a expander = Var.t -> Syntax.Version.t -> 'a
+
 let expand t ~mode ~dir ~f =
   match
     partial_expand t ~mode ~dir ~f:(fun var syntax_version ->

--- a/src/string_with_vars.mli
+++ b/src/string_with_vars.mli
@@ -64,16 +64,18 @@ module Var : sig
   val describe : t -> string
 end
 
+type 'a expander = Var.t -> Syntax.Version.t -> 'a
+
 val expand
   :  t
   -> mode:'a Mode.t
   -> dir:Path.t
-  -> f:(Var.t -> Syntax.Version.t -> Value.t list option)
+  -> f:(Value.t list option expander)
   -> 'a
 
 val partial_expand
   :  t
   -> mode:'a Mode.t
   -> dir:Path.t
-  -> f:(Var.t -> Syntax.Version.t -> Value.t list option)
+  -> f:(Value.t list option expander)
   -> 'a Partial.t

--- a/src/string_with_vars.mli
+++ b/src/string_with_vars.mli
@@ -35,7 +35,7 @@ val is_var : t -> name:string -> bool
 val text_only : t -> string option
 
 module Mode : sig
-  type 'a t =
+  type _ t =
     | Single : Value.t t
     | Many : Value.t list t
 end


### PR DESCRIPTION
This is a preparatory PR for making OSL allow forms such as `%{read:..}` work. There's no functional difference, but it does allow expanding values into OSL in a more consistent way. 