### PR TITLE
4.07.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
     env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=0
     stage: Build
   - os: linux
+    env: OCAML_VERSION=4.07 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build
+  - os: linux
     env: OCAML_VERSION=4.05 OCAML_RELEASE=0 WITH_OPAM=1
     stage: Test
     addons:
@@ -47,4 +50,7 @@ matrix:
     stage: Build_macOS
   - os: osx
     env: OCAML_VERSION=4.06 OCAML_RELEASE=0 WITH_OPAM=0
+    stage: Build_macOS
+  - os: osx
+    env: OCAML_VERSION=4.07 OCAML_RELEASE=0 WITH_OPAM=0
     stage: Build_macOS

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -6,4 +6,5 @@
 (context (opam (switch 4.04.2)))
 (context (opam (switch 4.05.0)))
 (context (opam (switch 4.06.1)))
-(context (opam (switch 4.07.0+trunk)))
+(context (opam (switch 4.07.0)))
+(context (opam (switch 4.08.0+trunk)))


### PR DESCRIPTION
Review from either maintainer should be sufficient here.

Tests will run on 4.07.0 once all the external packages for tests be available