### PR TITLE
Use let%map in jbuild.ml

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,8 @@
               usexp
               ocaml_config
               which_program)
- (synopsis    "Internal Dune library, do not use!"))
+ (synopsis    "Internal Dune library, do not use!")
+ (preprocess  (action (run src/let-syntax/pp.exe %{input-file}))))
 
 (ocamllex meta_lexer glob_lexer dune_lexer)
 


### PR DESCRIPTION
This PR switches jbuild.ml to the let%map syntax and start using more applicative constructs rather than monadic ones. The result is that the parsing is often more clearly separated from the processing code.