### PR TITLE
Move back .pp files to the source directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,6 @@ next
   passing in `--root` in conjunction with `--workspace` or `--config` would not
   work correctly (#997, @rgrinberg)
 
-- Change the location of preprocessed files inside the build directory
-  (#1004, @diml)
-
 - Fix parsing of `%{lib:name:file}` forms (#1022, fixes #1019, @diml)
 
 1.0.0 (10/07/2018)

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -164,7 +164,7 @@ module Gen(P : Install_rules.Params) = struct
     (* Preprocess before adding the alias module as it doesn't need
        preprocessing *)
     let pp =
-      Preprocessing.make sctx ~dir ~obj_dir ~dep_kind ~scope
+      Preprocessing.make sctx ~dir ~dep_kind ~scope
         ~preprocess:lib.buildable.preprocess
         ~preprocessor_deps:
           (SC.Deps.interpret sctx ~scope ~dir
@@ -437,7 +437,7 @@ module Gen(P : Install_rules.Params) = struct
         ~scope ~dir
     in
     let pp =
-      Preprocessing.make sctx ~dir ~obj_dir ~dep_kind:Required
+      Preprocessing.make sctx ~dir ~dep_kind:Required
         ~scope
         ~preprocess:exes.buildable.preprocess
         ~preprocessor_deps

--- a/src/preprocessing.mli
+++ b/src/preprocessing.mli
@@ -10,7 +10,6 @@ val dummy : t
 val make
   :  Super_context.t
   -> dir:Path.t
-  -> obj_dir:Path.t
   -> dep_kind:Build.lib_dep_kind
   -> lint:Jbuild.Preprocess_map.t
   -> preprocess:Jbuild.Preprocess_map.t

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -140,6 +140,7 @@ val rm_rf : t -> unit
 val mkdir_p : t -> unit
 
 val extension : t -> string
+val split_extension : t -> t * string
 
 val pp : Format.formatter -> t -> unit
 val pp_debug : Format.formatter -> t -> unit

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -41,7 +41,7 @@ Same, but with error pointing to .ppx
 Test the argument syntax
 
   $ dune build test_ppx_args.cma
-           ppx .test_ppx_args.objs/test_ppx_args.pp.ml
+           ppx test_ppx_args.pp.ml
   .ppx/driver_print_args@foo/ppx.exe
   -arg1
   -arg2
@@ -50,9 +50,9 @@ Test the argument syntax
   --cookie
   library-name="test_ppx_args"
   -o
-  .test_ppx_args.objs/test_ppx_args.pp.ml
+  test_ppx_args.pp.ml
   --impl
   test_ppx_args.ml
   Error: Rule failed to generate the following targets:
-  - .test_ppx_args.objs/test_ppx_args.pp.ml
+  - test_ppx_args.pp.ml
   [1]

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -2,17 +2,17 @@
         ocamlc lib/stubs$ext_obj
     ocamlmklib lib/dllx_stubs$ext_dll,lib/libx_stubs$ext_lib
       ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
-           ppx lib/.x.objs/x.pp.ml
+           ppx lib/x.pp.ml
       ocamldep lib/.x.objs/x.pp.ml.d
         ocamlc lib/.x.objs/x__.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__.{cmx,o}
-           ppx lib/.x.objs/y.pp.ml
+           ppx lib/y.pp.ml
       ocamldep lib/.x.objs/y.pp.ml.d
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
-           ppx bin/.technologic.eobjs/technologic.pp.ml
+           ppx bin/technologic.pp.ml
       ocamldep bin/.technologic.eobjs/technologic.pp.ml.d
-           ppx bin/.technologic.eobjs/z.pp.ml
+           ppx bin/z.pp.ml
       ocamldep bin/.technologic.eobjs/z.pp.ml.d
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml lib/.x.objs/x__Y.cmo.js

--- a/test/blackbox-tests/test-cases/ppx-rewriter/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter/run.t
@@ -4,7 +4,7 @@
       ocamlopt ppx/.fooppx.objs/fooppx.{cmx,o}
       ocamlopt ppx/fooppx.{a,cmxa}
       ocamlopt .ppx/jbuild/fooppx/ppx.exe
-           ppx .w_omp_driver.eobjs/w_omp_driver.pp.ml
+           ppx w_omp_driver.pp.ml
       ocamldep .w_omp_driver.eobjs/w_omp_driver.pp.ml.d
         ocamlc .w_omp_driver.eobjs/w_omp_driver.{cmi,cmo,cmt}
       ocamlopt .w_omp_driver.eobjs/w_omp_driver.{cmx,o}

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -15,7 +15,7 @@ On the other hand, public libraries may have private preprocessors
       ocamlopt .ppx_internal.objs/ppx_internal.{cmx,o}
       ocamlopt ppx_internal.{a,cmxa}
       ocamlopt .ppx/jbuild/ppx_internal@mylib/ppx.exe
-           ppx .mylib.objs/mylib.pp.ml
+           ppx mylib.pp.ml
       ocamldep .mylib.objs/mylib.pp.ml.d
         ocamlc .mylib.objs/mylib.{cmi,cmo,cmt}
       ocamlopt .mylib.objs/mylib.{cmx,o}
@@ -33,7 +33,7 @@ Unless they introduce private runtime dependencies:
       ocamlopt .private_ppx.objs/private_ppx.{cmx,o}
       ocamlopt private_ppx.{a,cmxa}
       ocamlopt .ppx/jbuild/private_ppx@mylib/ppx.exe
-           ppx .mylib.objs/mylib.pp.ml
+           ppx mylib.pp.ml
       ocamldep .mylib.objs/mylib.pp.ml.d
   [1]
 

--- a/test/blackbox-tests/test-cases/reason/run.t
+++ b/test/blackbox-tests/test-cases/reason/run.t
@@ -1,54 +1,54 @@
   $ dune build @runtest @install-file --display short
-         refmt .rlib.objs/bar.ast.re
-      ocamldep .rlib.objs/bar.ast.re.d
+         refmt bar.re.ml
+      ocamldep .rlib.objs/bar.re.ml.d
       ocamldep pp/.reasononlypp.eobjs/reasononlypp.ml.d
         ocamlc pp/.reasononlypp.eobjs/reasononlypp.{cmi,cmo,cmt}
       ocamlopt pp/.reasononlypp.eobjs/reasononlypp.{cmx,o}
       ocamlopt pp/reasononlypp.exe
-  reasononlypp .rlib.objs/cppome.pp.re
-         refmt .rlib.objs/cppome.pp.ast.re
-      ocamldep .rlib.objs/cppome.pp.ast.re.d
+  reasononlypp cppome.pp.re
+         refmt cppome.pp.re.ml
+      ocamldep .rlib.objs/cppome.pp.re.ml.d
       ocamldep ppx/.reasonppx.objs/reasonppx.ml.d
         ocamlc ppx/.reasonppx.objs/reasonppx.{cmi,cmo,cmt}
       ocamlopt ppx/.reasonppx.objs/reasonppx.{cmx,o}
       ocamlopt ppx/reasonppx.{a,cmxa}
       ocamlopt .ppx/jbuild/reasonppx@rlib/ppx.exe
-           ppx .rlib.objs/foo.pp.ml
+           ppx foo.pp.ml
       ocamldep .rlib.objs/foo.pp.ml.d
-         refmt .rlib.objs/hello.ast.re
-           ppx .rlib.objs/hello.ast.pp.re
-      ocamldep .rlib.objs/hello.ast.pp.re.d
-         refmt .rlib.objs/pped.ast.re
-      ocamldep .rlib.objs/pped.ast.re.d
+         refmt hello.re.ml
+           ppx hello.re.pp.ml
+      ocamldep .rlib.objs/hello.re.pp.ml.d
+         refmt pped.re.ml
+      ocamldep .rlib.objs/pped.re.ml.d
         ocamlc .rlib.objs/rlib.{cmi,cmo,cmt}
       ocamlopt .rlib.objs/rlib.{cmx,o}
       ocamldep .rlib.objs/bar.mli.d
         ocamlc .rlib.objs/rlib__Bar.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Bar.{cmx,o}
-         refmt .rlib.objs/foo.ast.rei
-           ppx .rlib.objs/foo.ast.pp.rei
-      ocamldep .rlib.objs/foo.ast.pp.rei.d
+         refmt foo.re.mli
+           ppx foo.re.pp.mli
+      ocamldep .rlib.objs/foo.re.pp.mli.d
         ocamlc .rlib.objs/rlib__Foo.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Foo.{cmx,o}
-         refmt .rlib.objs/hello.ast.rei
-           ppx .rlib.objs/hello.ast.pp.rei
-      ocamldep .rlib.objs/hello.ast.pp.rei.d
+         refmt hello.re.mli
+           ppx hello.re.pp.mli
+      ocamldep .rlib.objs/hello.re.pp.mli.d
         ocamlc .rlib.objs/rlib__Hello.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Hello.{cmx,o}
-         refmt .rlib.objs/pped.ast.rei
-      ocamldep .rlib.objs/pped.ast.rei.d
+         refmt pped.re.mli
+      ocamldep .rlib.objs/pped.re.mli.d
         ocamlc .rlib.objs/rlib__Pped.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Pped.{cmx,o}
-  reasononlypp .rlib.objs/cppome.pp.rei
-         refmt .rlib.objs/cppome.pp.ast.rei
-      ocamldep .rlib.objs/cppome.pp.ast.rei.d
+  reasononlypp cppome.pp.rei
+         refmt cppome.pp.re.mli
+      ocamldep .rlib.objs/cppome.pp.re.mli.d
         ocamlc .rlib.objs/rlib__Cppome.{cmi,cmti}
       ocamlopt .rlib.objs/rlib__Cppome.{cmx,o}
       ocamlopt rlib.{a,cmxa}
       ocamlopt rlib.cmxs
-  reasononlypp .rbin.eobjs/rbin.pp.re
-         refmt .rbin.eobjs/rbin.pp.ast.re
-      ocamldep .rbin.eobjs/rbin.pp.ast.re.d
+  reasononlypp rbin.pp.re
+         refmt rbin.pp.re.ml
+      ocamldep .rbin.eobjs/rbin.pp.re.ml.d
         ocamlc .rbin.eobjs/rbin.{cmi,cmo,cmt}
       ocamlopt .rbin.eobjs/rbin.{cmx,o}
       ocamlopt rbin.exe

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -11,7 +11,7 @@
         ocamlc a/kernel/a_kernel.cma
       ocamlopt .ppx/jbuild/a.kernel/ppx.exe
       ocamlopt .ppx/jbuild/a/ppx.exe
-           ppx b/.b.objs/b.pp.ml
+           ppx b/b.pp.ml
       ocamldep b/.b.objs/b.pp.ml.d
         ocamlc b/.b.objs/b.{cmi,cmo,cmt}
       ocamlopt b/.b.objs/b.{cmx,o}


### PR DESCRIPTION
I have been getting weird errors from the compiler because of this change and it turns out it is not necessary to support multi-directory libraries.