### PR TITLE
Modular Jsoo settings [WIP]

### DIFF
--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -5,10 +5,30 @@ module Stanza = struct
 
   let field_oslu name = Ordered_set_lang.Unexpanded.field name
 
+  module Jsoo_compilation = struct
+    type t =
+      | Separate
+      | Classic
+
+    let default ~profile =
+      match profile with
+      | "dev" -> Separate
+      | _     -> Classic
+
+    let t =
+      Syntax.since Stanza.syntax (1, 1) >>= fun () ->
+      enum
+        [ "separate", Separate
+        ; "classic", Classic
+        ]
+  end
+
   type config =
     { flags          : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags   : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags : Ordered_set_lang.Unexpanded.t
+
+    ; jsoo_compilation : Jsoo_compilation.t option
     }
 
   type pattern =
@@ -24,8 +44,13 @@ module Stanza = struct
     let%map flags = field_oslu "flags"
     and ocamlc_flags = field_oslu "ocamlc_flags"
     and ocamlopt_flags = field_oslu "ocamlopt_flags"
+    and jsoo_compilation = field_o "jsoo_compilation" Jsoo_compilation.t
     in
-    { flags; ocamlc_flags; ocamlopt_flags }
+    { flags
+    ; ocamlc_flags
+    ; ocamlopt_flags
+    ; jsoo_compilation
+    }
 
   let rule =
     enter

--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -5,30 +5,11 @@ module Stanza = struct
 
   let field_oslu name = Ordered_set_lang.Unexpanded.field name
 
-  module Jsoo_compilation = struct
-    type t =
-      | Separate
-      | Classic
-
-    let default ~profile =
-      match profile with
-      | "dev" -> Separate
-      | _     -> Classic
-
-    let t =
-      Syntax.since Stanza.syntax (1, 1) >>= fun () ->
-      enum
-        [ "separate", Separate
-        ; "classic", Classic
-        ]
-  end
-
   type config =
     { flags          : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags   : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags : Ordered_set_lang.Unexpanded.t
-
-    ; jsoo_compilation : Jsoo_compilation.t option
+    ; jsoo           : Jsoo_stanza.Env.t
     }
 
   type pattern =
@@ -41,15 +22,15 @@ module Stanza = struct
     }
 
   let config =
-    let%map flags = field_oslu "flags"
-    and ocamlc_flags = field_oslu "ocamlc_flags"
+    let%map flags      = field_oslu "flags"
+    and ocamlc_flags   = field_oslu "ocamlc_flags"
     and ocamlopt_flags = field_oslu "ocamlopt_flags"
-    and jsoo_compilation = field_o "jsoo_compilation" Jsoo_compilation.t
+    and jsoo           = Jsoo_stanza.Env.field
     in
     { flags
     ; ocamlc_flags
     ; ocamlopt_flags
-    ; jsoo_compilation
+    ; jsoo
     }
 
   let rule =

--- a/src/dune_env.mli
+++ b/src/dune_env.mli
@@ -3,10 +3,20 @@ open Import
 type stanza = Stanza.t = ..
 
 module Stanza : sig
+  module Jsoo_compilation : sig
+    type t =
+      | Separate
+      | Classic
+
+    val default : profile:string -> t
+  end
+
   type config =
     { flags          : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags   : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags : Ordered_set_lang.Unexpanded.t
+
+    ; jsoo_compilation : Jsoo_compilation.t option
     }
 
   type pattern =

--- a/src/dune_env.mli
+++ b/src/dune_env.mli
@@ -3,20 +3,11 @@ open Import
 type stanza = Stanza.t = ..
 
 module Stanza : sig
-  module Jsoo_compilation : sig
-    type t =
-      | Separate
-      | Classic
-
-    val default : profile:string -> t
-  end
-
   type config =
     { flags          : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags   : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags : Ordered_set_lang.Unexpanded.t
-
-    ; jsoo_compilation : Jsoo_compilation.t option
+    ; jsoo           : Jsoo_stanza.Env.t
     }
 
   type pattern =

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -164,7 +164,7 @@ let link_exe
         (modules_and_cm_files >>^ snd)
         (SC.expand_and_eval_set sctx ~scope:(CC.scope cctx) ~dir
            js_of_ocaml.flags
-           ~standard:(Build.return (Js_of_ocaml_rules.standard sctx)))
+           ~standard:(Build.return (Js_of_ocaml_rules.standard sctx ~dir)))
     in
     SC.add_rules sctx (List.map rules ~f:(fun r -> cm_and_flags >>> r))
 

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -40,7 +40,7 @@ val build_and_link
   :  program:Program.t
   -> linkages:Linkage.t list
   -> ?link_flags:(unit, string list) Build.t
-  -> ?js_of_ocaml:Jbuild.Js_of_ocaml.t
+  -> ?js_of_ocaml:_ Jsoo_stanza.Flags.t
   -> Compilation_context.t
   -> unit
 
@@ -48,7 +48,7 @@ val build_and_link_many
   :  programs:Program.t list
   -> linkages:Linkage.t list
   -> ?link_flags:(unit, string list) Build.t
-  -> ?js_of_ocaml:Jbuild.Js_of_ocaml.t
+  -> ?jsoo_build:Jsoo_stanza.In_buildable.t
   -> Compilation_context.t
   -> unit
 
@@ -60,6 +60,6 @@ val link_exe
   -> linkage:Linkage.t
   -> top_sorted_modules:(unit, Module.t list) Build.t
   -> ?link_flags:(unit, string list) Build.t
-  -> ?js_of_ocaml:Jbuild.Js_of_ocaml.t
+  -> ?jsoo_build:Jsoo_stanza.In_buildable.t
   -> Compilation_context.t
   -> unit

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -433,25 +433,6 @@ end
 
 let field_oslu name = Ordered_set_lang.Unexpanded.field name
 
-module Js_of_ocaml = struct
-
-  type t =
-    { flags            : Ordered_set_lang.Unexpanded.t
-    ; javascript_files : string list
-    }
-
-  let t =
-    record
-      (let%map flags = field_oslu "flags"
-       and javascript_files = field "javascript_files" (list string) ~default:[]
-       in
-       { flags; javascript_files })
-
-  let default =
-    { flags = Ordered_set_lang.Unexpanded.standard
-    ; javascript_files = [] }
-end
-
 module Lib_dep = struct
   type choice =
     { required  : String.Set.t
@@ -592,7 +573,7 @@ module Buildable = struct
     ; flags                    : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags             : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags           : Ordered_set_lang.Unexpanded.t
-    ; js_of_ocaml              : Js_of_ocaml.t
+    ; js_of_ocaml              : Jsoo_stanza.In_buildable.t
     ; allow_overlapping_dependencies : bool
     }
 
@@ -612,8 +593,7 @@ module Buildable = struct
     and flags = field_oslu "flags"
     and ocamlc_flags = field_oslu "ocamlc_flags"
     and ocamlopt_flags = field_oslu "ocamlopt_flags"
-    and js_of_ocaml =
-      field "js_of_ocaml" Js_of_ocaml.t ~default:Js_of_ocaml.default
+    and js_of_ocaml = Jsoo_stanza.In_buildable.field
     and allow_overlapping_dependencies =
       field_b "allow_overlapping_dependencies"
     in

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -45,15 +45,6 @@ module Lint : sig
 end
 
 
-module Js_of_ocaml : sig
-  type t =
-    { flags            : Ordered_set_lang.Unexpanded.t
-    ; javascript_files : string list
-    }
-
-  val default : t
-end
-
 module Lib_dep : sig
   type choice =
     { required  : String.Set.t
@@ -127,7 +118,7 @@ module Buildable : sig
     ; flags                    : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags             : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags           : Ordered_set_lang.Unexpanded.t
-    ; js_of_ocaml              : Js_of_ocaml.t
+    ; js_of_ocaml              : Jsoo_stanza.In_buildable.t
     ; allow_overlapping_dependencies : bool
     }
 

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -4,14 +4,19 @@ open Build.O
 
 module SC = Super_context
 
-let dev_mode sctx = SC.profile sctx = "dev"
+let jsoo_compilation = SC.Env.jsoo_compilation
 
-let separate_compilation_enabled = dev_mode
+let pretty sctx ~dir =
+  match jsoo_compilation sctx ~dir with
+  | Separate ->  ["--pretty"]
+  | Classic ->   []
 
-let pretty    sctx = if dev_mode sctx then ["--pretty"           ] else []
-let sourcemap sctx = if dev_mode sctx then ["--source-map-inline"] else []
+let sourcemap sctx ~dir =
+  match jsoo_compilation sctx ~dir with
+  | Separate ->  ["--source-map-inline"]
+  | Classic ->   []
 
-let standard sctx = pretty sctx @ sourcemap sctx
+let standard sctx ~dir = pretty sctx ~dir @ sourcemap sctx ~dir
 
 let install_jsoo_hint = "opam install js_of_ocaml-compiler"
 
@@ -97,18 +102,19 @@ let link_rule ~sctx ~dir ~runtime ~target ~requires =
     jsoo_link
     [ Arg_spec.A "-o"; Target target
     ; Arg_spec.Dep runtime
-    ; Arg_spec.As (sourcemap sctx)
+    ; Arg_spec.As (sourcemap sctx ~dir)
     ; Arg_spec.Dyn get_all
     ]
 
 let build_cm sctx ~scope ~dir ~(js_of_ocaml:Jbuild.Js_of_ocaml.t) ~src ~target =
-  if separate_compilation_enabled sctx
-  then
+  match jsoo_compilation sctx ~dir with
+  | Classic -> []
+  | Separate ->
     let itarget = Path.extend_basename src ~suffix:".js" in
     let spec = Arg_spec.Dep src in
     let flags =
       SC.expand_and_eval_set sctx ~scope ~dir js_of_ocaml.flags
-        ~standard:(Build.return (standard sctx))
+        ~standard:(Build.return (standard sctx ~dir))
     in
     [ flags
       >>>
@@ -118,40 +124,36 @@ let build_cm sctx ~scope ~dir ~(js_of_ocaml:Jbuild.Js_of_ocaml.t) ~src ~target =
          []
        else
          [Build.symlink ~src:itarget ~dst:target])
-  else []
 
 let setup_separate_compilation_rules sctx components =
-  if separate_compilation_enabled sctx
-  then
-    match components with
-    | [] | _ :: _ :: _ -> ()
-    | [pkg] ->
-      let ctx = SC.context sctx in
-      match Lib.DB.find (SC.installed_libs sctx) pkg with
-      | Error _ -> ()
-      | Ok pkg ->
-        let archives = (Lib.archives pkg).byte in
-        let archives =
-          (* Special case for the stdlib because it is not referenced
-             in the META *)
-          match Lib.name pkg with
-          | "stdlib" -> Path.relative ctx.stdlib_dir "stdlib.cma" :: archives
-          | _ -> archives
+  match components with
+  | [] | _ :: _ :: _ -> ()
+  | [pkg] ->
+    let ctx = SC.context sctx in
+    match Lib.DB.find (SC.installed_libs sctx) pkg with
+    | Error _ -> ()
+    | Ok pkg ->
+      let archives = (Lib.archives pkg).byte in
+      let archives =
+        (* Special case for the stdlib because it is not referenced
+           in the META *)
+        match Lib.name pkg with
+        | "stdlib" -> Path.relative ctx.stdlib_dir "stdlib.cma" :: archives
+        | _ -> archives
+      in
+      List.iter archives ~f:(fun fn ->
+        let name = Path.basename fn in
+        let src = Path.relative (Lib.src_dir pkg) name in
+        let target =
+          in_build_dir ~ctx [ Lib.name pkg; sprintf "%s.js" name]
         in
-        List.iter archives ~f:(fun fn ->
-          let name = Path.basename fn in
-          let src = Path.relative (Lib.src_dir pkg) name in
-          let target =
-            in_build_dir ~ctx [ Lib.name pkg; sprintf "%s.js" name]
-          in
-          let dir = in_build_dir ~ctx [ Lib.name pkg ] in
-          let spec = Arg_spec.Dep src in
-          SC.add_rule sctx
-            (Build.return (standard sctx)
-             >>>
-             js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags ->
-               As flags) ~spec ~target)
-        )
+        let dir = in_build_dir ~ctx [ Lib.name pkg ] in
+        let spec = Arg_spec.Dep src in
+        SC.add_rule sctx
+          (Build.return (standard sctx ~dir)
+           >>>
+           js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags ->
+             As flags) ~spec ~target))
 
 let build_exe sctx ~dir ~js_of_ocaml ~src ~requires =
   let {Jbuild.Js_of_ocaml.javascript_files; _} = js_of_ocaml in
@@ -159,10 +161,11 @@ let build_exe sctx ~dir ~js_of_ocaml ~src ~requires =
   let mk_target ext = Path.extend_basename src ~suffix:ext in
   let target = mk_target ".js" in
   let standalone_runtime = mk_target ".runtime.js" in
-  if separate_compilation_enabled sctx then
+  match jsoo_compilation sctx ~dir with
+  | Separate ->
     [ link_rule ~sctx ~dir ~runtime:standalone_runtime ~target ~requires
     ; standalone_runtime_rule ~sctx ~dir ~javascript_files
         ~target:standalone_runtime ~requires
     ]
-  else
+  | Classic ->
     [ exe_rule ~sctx ~dir ~javascript_files ~src ~target ~requires ]

--- a/src/js_of_ocaml_rules.mli
+++ b/src/js_of_ocaml_rules.mli
@@ -25,4 +25,4 @@ val setup_separate_compilation_rules
   -> string list
   -> unit
 
-val standard : Super_context.t -> string list
+val standard : Super_context.t -> dir:Path.t -> string list

--- a/src/js_of_ocaml_rules.mli
+++ b/src/js_of_ocaml_rules.mli
@@ -1,13 +1,12 @@
 (** Generate rules for js_of_ocaml *)
 
 open Import
-open Jbuild
 
 val build_cm
   :  Super_context.t
-  -> scope:Scope.t
   -> dir:Path.t
-  -> js_of_ocaml:Js_of_ocaml.t
+  -> scope:Scope.t
+  -> build:Jbuild.Buildable.t
   -> src:Path.t
   -> target:Path.t
   -> (unit, Action.t) Build.t list
@@ -15,7 +14,7 @@ val build_cm
 val build_exe
   :  Super_context.t
   -> dir:Path.t
-  -> js_of_ocaml:Js_of_ocaml.t
+  -> jsoo_build:Jsoo_stanza.In_buildable.t
   -> src:Path.t
   -> requires:Lib.t list Or_exn.t
   -> (Path.t list * string list, Action.t) Build.t list
@@ -24,5 +23,3 @@ val setup_separate_compilation_rules
   :  Super_context.t
   -> string list
   -> unit
-
-val standard : Super_context.t -> dir:Path.t -> string list

--- a/src/jsoo_stanza.ml
+++ b/src/jsoo_stanza.ml
@@ -1,0 +1,111 @@
+open Stdune
+open Sexp.Of_sexp
+
+let field_oslu name = Ordered_set_lang.Unexpanded.field name
+
+module Flags = struct
+  type 'flag t =
+    { compile : 'flag
+    ; link    : 'flag
+    }
+
+  let fields =
+    let%map compile = field_oslu "flags"
+    and link = field_oslu "link_flags" (* TODO (1, 1) only *)
+    in
+    { compile
+    ; link
+    }
+
+  let empty =
+    { compile = []
+    ; link = []
+    }
+
+  let default ~profile =
+    if profile = "dev" then
+      { compile = ["--pretty"; "--source-map-inline"]
+      ; link    = ["--source-map-inline"]
+      }
+    else
+      empty
+
+  let map { compile; link } ~f =
+    { compile = f compile
+    ; link    = f link
+    }
+
+  let default_user_written =
+    { compile = Ordered_set_lang.Unexpanded.standard
+    ; link = Ordered_set_lang.Unexpanded.standard
+    }
+
+  type user_written = Ordered_set_lang.Unexpanded.t t
+end
+
+module In_buildable = struct
+  type t =
+    { flags            : Flags.user_written
+    ; javascript_files : string list
+    }
+
+  let t =
+    record
+      (let%map flags = Flags.fields
+       and javascript_files = field "javascript_files" (list string) ~default:[]
+       in
+       { flags
+       ; javascript_files
+       })
+
+  let flags t = t.flags
+
+  let default =
+    { flags = Flags.default_user_written
+    ; javascript_files = []
+    }
+
+  let field = field "js_of_ocaml" t ~default
+end
+
+module Compilation = struct
+  type t =
+    | Separate
+    | Classic
+
+  let default ~profile =
+    if profile = "dev" then
+      Separate
+    else
+      Classic
+
+  let t =
+    Syntax.since Stanza.syntax (1, 1) >>= fun () ->
+    enum
+      [ "separate", Separate
+      ; "classic", Classic
+      ]
+end
+
+module Env = struct
+  type t =
+    { flags       : Flags.user_written
+    ; compilation : Compilation.t option
+    }
+
+  let default =
+    { flags = Flags.default_user_written
+    ; compilation = None
+    }
+
+  let t =
+    record
+      (let%map flags = Flags.fields
+       and compilation = field_o "compilation" Compilation.t
+       in
+       { flags
+       ; compilation
+       })
+
+  let field = field "jsoo" t ~default
+end

--- a/src/jsoo_stanza.mli
+++ b/src/jsoo_stanza.mli
@@ -1,0 +1,46 @@
+open Stdune
+
+module Flags : sig
+  type 'flag t =
+    { compile : 'flag
+    ; link    : 'flag
+    }
+
+  val empty : string list t
+
+  val default : profile:string -> string list t
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  type user_written = Ordered_set_lang.Unexpanded.t t
+end
+
+module In_buildable : sig
+  type t =
+    { flags            : Flags.user_written
+    ; javascript_files : string list
+    }
+
+  val field : t Sexp.Of_sexp.fields_parser
+
+  val flags : t -> Flags.user_written
+
+  val default : t
+end
+
+module Compilation : sig
+  type t =
+    | Separate
+    | Classic
+
+  val default : profile:string -> t
+end
+
+module Env : sig
+  type t =
+    { flags       : Flags.user_written
+    ; compilation : Compilation.t option
+    }
+
+  val field : t Sexp.Of_sexp.fields_parser
+end

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -129,7 +129,6 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
   Option.iter js_of_ocaml ~f:(fun js_of_ocaml ->
     (* Build *.cmo.js *)
     let sctx     = CC.super_context cctx in
-    let scope    = CC.scope         cctx in
     let dir      = CC.dir           cctx in
     let obj_dir  = CC.obj_dir       cctx in
     let src = Module.cm_file_unsafe m ~obj_dir Cm_kind.Cmo in
@@ -138,7 +137,7 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
         ~suffix:".js"
     in
     SC.add_rules sctx
-      (Js_of_ocaml_rules.build_cm sctx ~scope ~dir ~js_of_ocaml ~src ~target))
+      (Js_of_ocaml_rules.build_cm sctx ~dir ~scope ~build ~src ~target))
 
 let build_modules ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx =
   Module.Name.Map.iter

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -5,7 +5,7 @@ open Import
 (** Setup rules to build a single module. *)
 val build_module
   :  ?sandbox:bool
-  -> ?js_of_ocaml:Jbuild.Js_of_ocaml.t
+  -> ?js_of_ocaml:(unit, string list) Build.t Jsoo_stanza.Flags.t
   -> ?dynlink:bool
   -> dep_graphs:Ocamldep.Dep_graphs.t
   -> Compilation_context.t
@@ -15,7 +15,7 @@ val build_module
 (** Setup rules to build all of the modules in the compilation context. *)
 val build_modules
   :  ?sandbox:bool
-  -> ?js_of_ocaml:Jbuild.Js_of_ocaml.t
+  -> ?js_of_ocaml:(unit, string list) Build.t Jsoo_stanza.Flags.t
   -> ?dynlink:bool
   -> dep_graphs:Ocamldep.Dep_graphs.t
   -> Compilation_context.t

--- a/src/ocaml_flags.mli
+++ b/src/ocaml_flags.mli
@@ -8,6 +8,7 @@ val make
   :  flags          : Ordered_set_lang.Unexpanded.t
   -> ocamlc_flags   : Ordered_set_lang.Unexpanded.t
   -> ocamlopt_flags : Ordered_set_lang.Unexpanded.t
+  -> jsoo           : Jsoo_stanza.Flags.user_written
   -> default:t
   -> eval:(Ordered_set_lang.Unexpanded.t
            -> standard:(unit, string list) Build.t
@@ -29,3 +30,5 @@ val prepend_common : string list -> t -> t
 val common : t -> (unit, string list) Build.t
 
 val dump : t -> (unit, Sexp.t list) Build.t
+
+val jsoo : t -> (unit, string list) Build.t Jsoo_stanza.Flags.t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -415,7 +415,7 @@ module Env : sig
   val ocaml_flags : t -> dir:Path.t -> Ocaml_flags.t
   val get : t -> dir:Path.t -> Env_node.t
 
-  val jsoo_compilation : t -> dir:Path.t -> Dune_env.Stanza.Jsoo_compilation.t
+  val jsoo_compilation : t -> dir:Path.t -> Jsoo_stanza.Compilation.t
 end = struct
   open Env_node
 
@@ -460,6 +460,7 @@ end = struct
               ~flags:cfg.flags
               ~ocamlc_flags:cfg.ocamlc_flags
               ~ocamlopt_flags:cfg.ocamlopt_flags
+              ~jsoo:cfg.jsoo.flags
               ~default
               ~eval:(expand_and_eval_set t ~scope:node.scope ~dir:node.dir
                        ?bindings:None)
@@ -479,13 +480,12 @@ end = struct
       | None ->
         begin match node.inherit_from with
         | None ->
-          Dune_env.Stanza.Jsoo_compilation.default ~profile:(profile t)
+          Jsoo_stanza.Compilation.default ~profile:(profile t)
         | Some (lazy node) -> loop t node
         end
       | Some cfg ->
-        begin match cfg.jsoo_compilation with
-        | None ->
-          Dune_env.Stanza.Jsoo_compilation.default ~profile:(profile t)
+        begin match cfg.jsoo.compilation with
+        | None -> Jsoo_stanza.Compilation.default ~profile:(profile t)
         | Some jc -> jc
         end
     in
@@ -498,6 +498,7 @@ let ocaml_flags t ~dir ~scope (x : Buildable.t) =
     ~flags:x.flags
     ~ocamlc_flags:x.ocamlc_flags
     ~ocamlopt_flags:x.ocamlopt_flags
+    ~jsoo:x.js_of_ocaml.flags
     ~default:(Env.ocaml_flags t ~dir)
     ~eval:(expand_and_eval_set t ~scope ~dir ?bindings:None)
 

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -259,3 +259,7 @@ module Scope_key : sig
 
   val to_string : string -> Dune_project.Name.t -> string
 end
+
+module Env : sig
+  val jsoo_compilation : t -> dir:Path.t -> Dune_env.Stanza.Jsoo_compilation.t
+end

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -261,5 +261,7 @@ module Scope_key : sig
 end
 
 module Env : sig
-  val jsoo_compilation : t -> dir:Path.t -> Dune_env.Stanza.Jsoo_compilation.t
+  val jsoo_compilation : t -> dir:Path.t -> Jsoo_stanza.Compilation.t
+
+  val ocaml_flags : t -> dir:Path.t -> Ocaml_flags.t
 end


### PR DESCRIPTION
WIP to address #970 

I've added the basic functionality that `--dev` enabled via the single `jsoo_compilation` field. However, the old mode is a bit more involved than just separate compilation and also involved some flag switching. The flags thing I think is best handled the same way we handle `ocaml_flags`. So either include the profile dependant jsoo flags in `Ocaml_flags.t` or make something similar.

I'm also taking suggestions for naming. What I think would be ideal if we had a field for env that looked like this:

```
(js_of_ocaml
 (compilation separate|classic)
 (flags <osl>))
```

Btw: `js_of_ocaml` is kind of a mouthful, I'd be in favor of deprecating it and adopting `jsoo` instead in the dune lang.