### PR TITLE
Refactor jsoo rules to use Compilation_context.t

### DIFF
--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -63,6 +63,8 @@ let includes             t = t.includes
 let preprocessing        t = t.preprocessing
 let no_keep_locs         t = t.no_keep_locs
 
+let context              t = Super_context.context t.super_context
+
 let create ~super_context ~scope ~dir ?(dir_kind=File_tree.Dune_file.Kind.Dune)
       ?(obj_dir=dir) ~modules ?alias_module ?lib_interface_module ~flags
       ~requires ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false) () =

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -32,6 +32,7 @@ val create
 val for_alias_module : t -> t
 
 val super_context        : t -> Super_context.t
+val context              : t -> Context.t
 val scope                : t -> Scope.t
 val dir                  : t -> Path.t
 val dir_kind             : t -> File_tree.Dune_file.Kind.t

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -6,7 +6,7 @@ open Import
 
     A compilation context contains all the necessary information to
     preprocess and compile OCaml source files. Exactly one compilation
-    context is associated to each library, executable and executbales
+    context is associated to each library, executable and executables
     stanza.
 *)
 type t

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -157,7 +157,7 @@ let link_exe
        ]);
   if linkage.ext = ".bc" then
     let rules =
-      Js_of_ocaml_rules.build_exe sctx ~dir ~js_of_ocaml ~src:exe ~requires
+      Js_of_ocaml_rules.build_exe cctx ~js_of_ocaml ~src:exe
     in
     let cm_and_flags =
       Build.fanout

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -342,7 +342,7 @@ module Gen(P : Install_rules.Params) = struct
     SC.add_rules sctx (
       let src = Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Mode.Byte) in
       let target = Path.extend_basename src ~suffix:".js" in
-      Js_of_ocaml_rules.build_cm sctx ~scope ~dir
+      Js_of_ocaml_rules.build_cm cctx
         ~js_of_ocaml:lib.buildable.js_of_ocaml ~src ~target);
 
     if ctx.natdynlink_supported then

--- a/src/js_of_ocaml_rules.boot.ml
+++ b/src/js_of_ocaml_rules.boot.ml
@@ -1,7 +1,7 @@
 
-let build_cm _ ~scope:_ ~dir:_ ~js_of_ocaml:_ ~src:_ ~target:_ = []
+let build_cm _ ~js_of_ocaml:_ ~src:_ ~target:_ = []
 
-let build_exe _ ~dir:_ ~js_of_ocaml:_ ~src:_ ~requires:_ = []
+let build_exe _ ~js_of_ocaml:_ ~src:_ = []
 
 let setup_separate_compilation_rules _ _ = ()
 

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -32,10 +32,10 @@ let runtime_file ~sctx fname =
         "js_of_ocaml-compiler")
   | Ok f -> Arg_spec.Dep f
 
-let js_of_ocaml_rule ~sctx ~dir ~flags ~spec ~target =
+let js_of_ocaml_rule sctx ~dir ~flags ~spec ~target =
   let jsoo = SC.resolve_program sctx ~hint:install_jsoo_hint "js_of_ocaml" in
   let runtime = runtime_file ~sctx "runtime.js" in
-  Build.run ~context:(SC.context sctx) ~dir
+  Build.run ~context:(Super_context.context sctx) ~dir
     jsoo
     [ Arg_spec.Dyn flags
     ; Arg_spec.A "-o"; Target target
@@ -43,36 +43,42 @@ let js_of_ocaml_rule ~sctx ~dir ~flags ~spec ~target =
     ; spec
     ]
 
-let standalone_runtime_rule ~sctx ~dir ~javascript_files ~target ~requires =
+let standalone_runtime_rule cc ~javascript_files ~target =
   let spec =
     Arg_spec.S
-      [ Arg_spec.of_result_map requires ~f:(fun libs ->
+      [ Arg_spec.of_result_map (Compilation_context.requires cc) ~f:(fun libs ->
           Arg_spec.Deps (Lib.L.jsoo_runtime_files libs))
       ; Arg_spec.Deps javascript_files
       ]
   in
   Build.arr (fun (cm_files, flags) -> (cm_files, "--runtime-only" :: flags))
   >>>
-  js_of_ocaml_rule ~sctx ~dir ~flags:(fun (_,flags) -> As flags) ~target ~spec
+  js_of_ocaml_rule
+    (Compilation_context.super_context cc)
+    ~dir:(Compilation_context.dir cc)
+    ~flags:(fun (_,flags) -> As flags) ~target ~spec
 
-let exe_rule ~sctx ~dir ~javascript_files ~src ~target ~requires =
+let exe_rule cc ~javascript_files ~src ~target =
+  let dir = Compilation_context.dir cc in
+  let sctx = Compilation_context.super_context cc in
   let spec =
     Arg_spec.S
-      [ Arg_spec.of_result_map requires ~f:(fun libs ->
-          Arg_spec.Deps (Lib.L.jsoo_runtime_files libs))
+      [ Arg_spec.of_result_map (Compilation_context.requires cc)
+          ~f:(fun libs -> Arg_spec.Deps (Lib.L.jsoo_runtime_files libs))
       ; Arg_spec.Deps javascript_files
       ; Arg_spec.Dep src
       ]
   in
-  js_of_ocaml_rule ~sctx ~dir ~flags:(fun (_,flags) -> As flags) ~spec ~target
+  js_of_ocaml_rule sctx ~dir ~flags:(fun (_,flags) -> As flags) ~spec ~target
 
 let jsoo_archives lib =
   List.map (Lib.archives lib).byte ~f:(Path.extend_basename ~suffix:".js")
 
-let link_rule ~sctx ~dir ~runtime ~target ~requires =
-  let ctx = SC.context sctx in
+let link_rule cc ~runtime ~target =
+  let sctx = Compilation_context.super_context cc in
+  let ctx = Compilation_context.context cc in
   let get_all (cm, _) =
-    Arg_spec.of_result_map requires ~f:(fun libs ->
+    Arg_spec.of_result_map (Compilation_context.requires cc) ~f:(fun libs ->
       let all_libs =
         List.concat_map libs ~f:(fun (lib : Lib.t) ->
           let jsoo_archives = jsoo_archives lib in
@@ -93,7 +99,7 @@ let link_rule ~sctx ~dir ~runtime ~target ~requires =
       Arg_spec.Deps (List.concat [all_libs;all_other_modules]))
   in
   let jsoo_link = SC.resolve_program sctx ~hint:install_jsoo_hint "jsoo_link" in
-  Build.run ~context:(SC.context sctx) ~dir
+  Build.run ~context:ctx ~dir:(Compilation_context.dir cc)
     jsoo_link
     [ Arg_spec.A "-o"; Target target
     ; Arg_spec.Dep runtime
@@ -101,19 +107,22 @@ let link_rule ~sctx ~dir ~runtime ~target ~requires =
     ; Arg_spec.Dyn get_all
     ]
 
-let build_cm sctx ~scope ~dir ~(js_of_ocaml:Jbuild.Js_of_ocaml.t) ~src ~target =
+let build_cm cc ~(js_of_ocaml:Jbuild.Js_of_ocaml.t) ~src ~target =
+  let sctx = Compilation_context.super_context cc in
+  let dir = Compilation_context.dir cc in
   if separate_compilation_enabled sctx
   then
     let itarget = Path.extend_basename src ~suffix:".js" in
     let spec = Arg_spec.Dep src in
     let flags =
+      let scope = Compilation_context.scope cc in
       SC.expand_and_eval_set sctx ~scope ~dir js_of_ocaml.flags
         ~standard:(Build.return (standard sctx))
     in
     [ flags
       >>>
-      js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags ->
-        As flags) ~spec ~target:itarget ]
+      js_of_ocaml_rule sctx ~dir ~flags:(fun flags -> As flags) ~spec ~target:itarget
+    ]
     @ (if target = itarget then
          []
        else
@@ -149,20 +158,19 @@ let setup_separate_compilation_rules sctx components =
           SC.add_rule sctx
             (Build.return (standard sctx)
              >>>
-             js_of_ocaml_rule ~sctx ~dir ~flags:(fun flags ->
-               As flags) ~spec ~target)
-        )
+             js_of_ocaml_rule sctx ~dir ~flags:(fun flags ->
+               As flags) ~spec ~target))
 
-let build_exe sctx ~dir ~js_of_ocaml ~src ~requires =
+let build_exe cc ~js_of_ocaml ~src =
   let {Jbuild.Js_of_ocaml.javascript_files; _} = js_of_ocaml in
-  let javascript_files = List.map javascript_files ~f:(Path.relative dir) in
+  let javascript_files =
+    List.map javascript_files ~f:(Path.relative (Compilation_context.dir cc)) in
   let mk_target ext = Path.extend_basename src ~suffix:ext in
   let target = mk_target ".js" in
   let standalone_runtime = mk_target ".runtime.js" in
-  if separate_compilation_enabled sctx then
-    [ link_rule ~sctx ~dir ~runtime:standalone_runtime ~target ~requires
-    ; standalone_runtime_rule ~sctx ~dir ~javascript_files
-        ~target:standalone_runtime ~requires
+  if separate_compilation_enabled (Compilation_context.super_context cc) then
+    [ link_rule cc ~runtime:standalone_runtime ~target
+    ; standalone_runtime_rule cc ~javascript_files ~target:standalone_runtime
     ]
   else
-    [ exe_rule ~sctx ~dir ~javascript_files ~src ~target ~requires ]
+    [ exe_rule cc ~javascript_files ~src ~target ]

--- a/src/js_of_ocaml_rules.mli
+++ b/src/js_of_ocaml_rules.mli
@@ -4,20 +4,16 @@ open Import
 open Jbuild
 
 val build_cm
-  :  Super_context.t
-  -> scope:Scope.t
-  -> dir:Path.t
+  :  Compilation_context.t
   -> js_of_ocaml:Js_of_ocaml.t
   -> src:Path.t
   -> target:Path.t
   -> (unit, Action.t) Build.t list
 
 val build_exe
-  :  Super_context.t
-  -> dir:Path.t
+  :  Compilation_context.t
   -> js_of_ocaml:Js_of_ocaml.t
   -> src:Path.t
-  -> requires:Lib.t list Or_exn.t
   -> (Path.t list * string list, Action.t) Build.t list
 
 val setup_separate_compilation_rules

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -129,7 +129,6 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
   Option.iter js_of_ocaml ~f:(fun js_of_ocaml ->
     (* Build *.cmo.js *)
     let sctx     = CC.super_context cctx in
-    let scope    = CC.scope         cctx in
     let dir      = CC.dir           cctx in
     let obj_dir  = CC.obj_dir       cctx in
     let src = Module.cm_file_unsafe m ~obj_dir Cm_kind.Cmo in
@@ -138,7 +137,7 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
         ~suffix:".js"
     in
     SC.add_rules sctx
-      (Js_of_ocaml_rules.build_cm sctx ~scope ~dir ~js_of_ocaml ~src ~target))
+      (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
 
 let build_modules ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx =
   Module.Name.Map.iter


### PR DESCRIPTION
This is how things are done in the menhir plugin for example. The jsoo rules are a bit older so haven't yet been refactored to use this type.

cc @hhugo 

PS: Should we consider making the jsoo rules a proper plugin eventually?