### PR TITLE
modules_without_implementation suggestion uses old (pre-dune) syntax

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -91,11 +91,12 @@ end = struct
              \nThis will become an error in the future."
             (let tag = Sexp.unsafe_atom_of_string
                          "modules_without_implementation" in
-             Sexp.to_string ~syntax:Dune
-               (List [ tag
-                     ; Sexp.To_sexp.(list string)
-                         (uncapitalized should_be_listed)
-                     ]))
+             let modules =
+               should_be_listed
+               |> uncapitalized
+               |> List.map ~f:Sexp.To_sexp.string
+             in
+             Sexp.to_string ~syntax:Dune (List (tag :: modules)))
         | Some loc ->
           let list_modules l =
             uncapitalized l


### PR DESCRIPTION
Modules that only have `.mli` files will produce the following warning:
```
Warning: Some modules don't have an implementation.
You need to add the following field to this stanza:
  (modules_without_implementation (a b))
```

The syntax is wrong, this patch changes the last line to:
```
  (modules_without_implementation a b)
```