### PR TITLE
ocamllex does not need the list of modules to be in a list

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -509,7 +509,7 @@ To use a different rule mode, use the long form:
 ocamlyacc
 ---------
 
-``(ocamlyacc (<names>))`` is essentially a shorthand for:
+``(ocamlyacc <names>)`` is essentially a shorthand for:
 
 .. code:: scheme
 
@@ -524,7 +524,7 @@ To use a different rule mode, use the long form:
 .. code:: scheme
 
     (ocamlyacc
-      (modules (<names>))
+      (modules <names>)
       (mode    <mode>))
 
 menhir

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -488,7 +488,7 @@ stanza is rejected by dune:
 ocamllex
 --------
 
-``(ocamllex (<names>))`` is essentially a shorthand for:
+``(ocamllex <names>)`` is essentially a shorthand for:
 
 .. code:: scheme
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -503,7 +503,7 @@ To use a different rule mode, use the long form:
 .. code:: scheme
 
     (ocamllex
-      (modules (<names>))
+      (modules <names>)
       (mode    <mode>))
 
 ocamlyacc


### PR DESCRIPTION
Noticed this issue while finding another issue in #1056.

Also I assume the exact same is true for the `ocamlyacc` stanza, I'll happily also patch this in this PR if desired. Let me know.