### PR TITLE
Do not rely on cat output in tests

### DIFF
--- a/test/blackbox-tests/test-cases/dune-project-edition/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-edition/run.t
@@ -1,6 +1,5 @@
-  $ cat dune-project
-  cat: dune-project: No such file or directory
-  [1]
+  $ [ -e dune-project ] || echo File does not exist
+  File does not exist
   $ mkdir src
   $ echo '(alias (name runtest) (action (progn)))' >  src/dune
   $ dune build


### PR DESCRIPTION
The error messages of `cat` can change a bit, for example if a different locale is set. This uses a shell test instead.