### PR TITLE
Fix opam build instructions in usage.rst

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -237,7 +237,10 @@ follows:
 
 ::
 
-    build: [["dune" "build" "-p" name "-j" jobs]]
+    build: [
+      ["dune" "subst"] {pinned}
+      ["dune" "build" "-p" name "-j" jobs]
+    ]
 
 ``-p pkg`` is a shorthand for ``--root . --only-packages pkg --profile
 release --default-target @install``. ``-p`` is the short version of


### PR DESCRIPTION
They should include dune subst when pinning as well

cc @Drup