### PR TITLE
Add module Lib_deps_info

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -816,7 +816,7 @@ let clean =
 let format_external_libs libs =
   String.Map.to_list libs
   |> List.map ~f:(fun (name, kind) ->
-    match (kind : Build.lib_dep_kind) with
+    match (kind : Lib_deps_info.Kind.t) with
     | Optional -> sprintf "- %s (optional)" name
     | Required -> sprintf "- %s" name)
   |> String.concat ~sep:"\n"
@@ -875,7 +875,7 @@ let external_lib_deps =
                if String.Map.is_empty missing then
                  acc
                else if String.Map.for_alli missing
-                         ~f:(fun _ kind -> kind = Build.Optional)
+                         ~f:(fun _ kind -> kind = Lib_deps_info.Kind.Optional)
                then begin
                  Format.eprintf
                    "@{<error>Error@}: The following libraries are missing \
@@ -894,7 +894,7 @@ let external_lib_deps =
                    (format_external_libs missing)
                    (String.Map.to_list missing
                     |> List.filter_map ~f:(fun (name, kind) ->
-                      match (kind : Build.lib_dep_kind) with
+                      match (kind : Lib_deps_info.Kind.t) with
                       | Optional -> None
                       | Required -> Some (Findlib.root_package_name name))
                     |> String.Set.of_list

--- a/src/build.mli
+++ b/src/build.mli
@@ -168,18 +168,7 @@ val mkdir : Path.t -> (_, Action.t) t
 (** Merge a list of actions *)
 val progn : ('a, Action.t) t list -> ('a, Action.t) t
 
-type lib_dep_kind =
-  | Optional
-  | Required
-
-val record_lib_deps
-  :  kind:lib_dep_kind
-  -> Jbuild.Lib_dep.t list
-  -> ('a, 'a) t
-
-type lib_deps = lib_dep_kind String.Map.t
-
-val record_lib_deps_simple : lib_deps -> ('a, 'a) t
+val record_lib_deps : Lib_deps_info.t -> ('a, 'a) t
 
 (**/**)
 
@@ -202,7 +191,7 @@ module Repr : sig
     | Lines_of : Path.t -> ('a, string list) t
     | Vpath : 'a Vspec.t -> (unit, 'a) t
     | Dyn_paths : ('a, Path.Set.t) t -> ('a, 'a) t
-    | Record_lib_deps : lib_deps -> ('a, 'a) t
+    | Record_lib_deps : Lib_deps_info.t -> ('a, 'a) t
     | Fail : fail -> (_, _) t
     | Memo : 'a memo -> (unit, 'a) t
     | Catch : ('a, 'b) t * (exn -> 'b) -> ('a, 'b) t
@@ -232,8 +221,6 @@ module Repr : sig
 end
 
 val repr : ('a, 'b) t -> ('a, 'b) Repr.t
-
-val merge_lib_deps : lib_deps -> lib_deps -> lib_deps
 
 (**/**)
 val paths_for_rule : Path.Set.t -> ('a, 'a) t

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -129,7 +129,7 @@ let static_deps t ~all_targets ~file_tree =
     true
 
 let lib_deps =
-  let rec loop : type a b. (a, b) t -> Build.lib_deps -> Build.lib_deps
+  let rec loop : type a b. (a, b) t -> Lib_deps_info.t -> Lib_deps_info.t
     = fun t acc ->
       match t with
       | Arr _ -> acc
@@ -147,7 +147,7 @@ let lib_deps =
       | Dyn_paths t -> loop t acc
       | Contents _ -> acc
       | Lines_of _ -> acc
-      | Record_lib_deps deps -> Build.merge_lib_deps deps acc
+      | Record_lib_deps deps -> Lib_deps_info.merge deps acc
       | Fail _ -> acc
       | If_file_exists (_, state) ->
         loop (get_if_file_exists_exn state) acc

--- a/src/build_interpret.mli
+++ b/src/build_interpret.mli
@@ -48,7 +48,7 @@ val static_deps
 
 val lib_deps
   :  (_, _) Build.t
-  -> Build.lib_deps
+  -> Lib_deps_info.t
 
 val targets
   :  (_, _) Build.t

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -1336,7 +1336,7 @@ let all_lib_deps t ~request =
         let deps =
           match Path.Map.find acc rule.dir with
           | None -> deps
-          | Some deps' -> Build.merge_lib_deps deps deps'
+          | Some deps' -> Lib_deps_info.merge deps deps'
         in
         Path.Map.add acc rule.dir deps)
 
@@ -1355,7 +1355,7 @@ let all_lib_deps_by_context t ~request =
   |> String.Map.filteri ~f:(fun ctx _ -> String.Map.mem t.contexts ctx)
   |> String.Map.map ~f:(function
     | [] -> String.Map.empty
-    | x :: l -> List.fold_left l ~init:x ~f:Build.merge_lib_deps)
+    | x :: l -> List.fold_left l ~init:x ~f:Lib_deps_info.merge)
 
 module Rule = struct
   module Id = Internal_rule.Id

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -200,14 +200,14 @@ val is_target : t -> Path.t -> bool
 val all_lib_deps
   :  t
   -> request:(unit, unit) Build.t
-  -> Build.lib_deps Path.Map.t
+  -> Lib_deps_info.t Path.Map.t
 
 (** Return all the library dependencies required to build this
    request, by context name *)
 val all_lib_deps_by_context
   :  t
   -> request:(unit, unit) Build.t
-  -> Build.lib_deps String.Map.t
+  -> Lib_deps_info.t String.Map.t
 
 (** List of all buildable targets *)
 val all_targets : t -> Path.t list

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -154,7 +154,9 @@ module Gen(P : Install_rules.Params) = struct
         ~compile_info ~dir_kind =
     let obj_dir = Utils.library_object_directory ~dir lib.name in
     let requires = Lib.Compile.requires compile_info in
-    let dep_kind = if lib.optional then Build.Optional else Required in
+    let dep_kind =
+      if lib.optional then Lib_deps_info.Kind.Optional else Required
+    in
     let flags = SC.ocaml_flags sctx ~scope ~dir lib.buildable in
     let { Dir_contents.Library_modules.
           modules; main_module_name; alias_module } =

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -617,6 +617,16 @@ module Lib_deps = struct
 
   let of_pps pps =
     List.map pps ~f:(fun pp -> Lib_dep.of_pp (Loc.none, pp))
+
+
+  let info t ~kind =
+    List.concat_map t ~f:(function
+       | Lib_dep.Direct (_, s) -> [(s, kind)]
+       | Select { choices; _ } ->
+         List.concat_map choices ~f:(fun c ->
+           String.Set.to_list c.Lib_dep.required
+           |> List.map ~f:(fun d -> (d, Lib_deps_info.Kind.Optional))))
+     |> String.Map.of_list_reduce ~f:Lib_deps_info.Kind.merge
 end
 
 module Buildable = struct

--- a/src/jbuild.mli
+++ b/src/jbuild.mli
@@ -79,6 +79,7 @@ end
 module Lib_deps : sig
   type t = Lib_dep.t list
   val of_pps : Pp.t list -> t
+  val info : t -> kind:Lib_deps_info.Kind.t -> Lib_deps_info.t
 end
 
 module Bindings : sig

--- a/src/lib_deps_info.ml
+++ b/src/lib_deps_info.ml
@@ -1,0 +1,21 @@
+open Import
+
+module Kind = struct
+  type t =
+    | Optional
+    | Required
+
+  let merge a b =
+    match a, b with
+    | Optional, Optional -> Optional
+    | _ -> Required
+end
+
+type t = Kind.t String.Map.t
+
+let merge a b =
+  String.Map.merge a b ~f:(fun _ a b ->
+    match a, b with
+    | None, None -> None
+    | x, None | None, x -> x
+    | Some a, Some b -> Some (Kind.merge a b))

--- a/src/lib_deps_info.mli
+++ b/src/lib_deps_info.mli
@@ -1,0 +1,18 @@
+(** Tracking of library dependencies *)
+
+(** This module implements tracking of external library dependencies,
+    for [dune external-lib-deps] *)
+
+open Import
+
+module Kind : sig
+  type t =
+    | Optional
+    | Required
+
+  val merge : t -> t -> t
+end
+
+type t = Kind.t String.Map.t
+
+val merge : t -> t -> t

--- a/src/main.mli
+++ b/src/main.mli
@@ -30,7 +30,7 @@ val external_lib_deps
   : ?log:Log.t
   -> packages:Package.Name.t list
   -> unit
-  -> Build.lib_deps Path.Map.t
+  -> Lib_deps_info.t Path.Map.t
 
 val find_context_exn : setup -> name:string -> Context.t
 

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -286,7 +286,8 @@ let build_ppx_driver sctx ~lib_db ~dep_kind ~target ~dir_kind pps =
      >>>
      Build.write_file_dyn ml);
   SC.add_rule sctx
-    (Build.record_lib_deps ~kind:dep_kind (Lib_deps.of_pps pps)
+    (Build.record_lib_deps
+       (Lib_deps.info ~kind:dep_kind (Lib_deps.of_pps pps))
      >>>
      Build.of_result_map driver_and_libs ~f:(fun (_, libs) ->
        Build.paths (Lib.L.archive_files libs ~mode ~ext_lib:ctx.ext_lib))

--- a/src/preprocessing.mli
+++ b/src/preprocessing.mli
@@ -10,7 +10,7 @@ val dummy : t
 val make
   :  Super_context.t
   -> dir:Path.t
-  -> dep_kind:Build.lib_dep_kind
+  -> dep_kind:Lib_deps_info.Kind.t
   -> lint:Jbuild.Preprocess_map.t
   -> preprocess:Jbuild.Preprocess_map.t
   -> preprocessor_deps:(unit, Path.t list) Build.t

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -250,7 +250,7 @@ module Action : sig
     -> loc:Loc.t
     -> bindings:Pform.Map.t
     -> dir:Path.t
-    -> dep_kind:Build.lib_dep_kind
+    -> dep_kind:Lib_deps_info.Kind.t
     -> targets:targets
     -> targets_dir:Path.t
     -> scope:Scope.t


### PR DESCRIPTION
This is just some refactoring in preparation for another PR. The `Build.lib_deps` type and its associated functions are moved to their own module.