### PR TITLE
Replace jbuilder with dune when printing context

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -531,7 +531,7 @@ module Unexpanded = struct
           let loc = String_with_vars.loc fn in
           Loc.fail loc
             "This directory cannot be evaluated statically.\n\
-             This is not allowed by jbuilder"
+             This is not allowed by dune"
       end
     | Setenv (var, value, t) ->
       Setenv (E.string ~dir ~f var, E.string ~dir ~f value,

--- a/src/gen_meta.ml
+++ b/src/gen_meta.ml
@@ -84,7 +84,7 @@ let gen_lib pub_name lib ~version =
     ; if String.Set.is_empty ppx_rt_deps then
         []
       else
-        [ Comment "This is what jbuilder uses to find out the runtime \
+        [ Comment "This is what dune uses to find out the runtime \
                    dependencies of"
         ; Comment "a preprocessor"
         ; ppx_runtime_deps ppx_rt_deps

--- a/src/main.ml
+++ b/src/main.ml
@@ -78,7 +78,7 @@ let setup ?(log=Log.no_log)
   >>= fun contexts ->
   let contexts = List.concat contexts in
   List.iter contexts ~f:(fun (ctx : Context.t) ->
-    Log.infof log "@[<1>Jbuilder context:@,%a@]@." (Sexp.pp Dune)
+    Log.infof log "@[<1>Dune context:@,%a@]@." (Sexp.pp Dune)
       (Context.sexp_of_t ctx));
   let rule_done  = ref 0 in
   let rule_total = ref 0 in

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -120,7 +120,7 @@ let dot_merlin sctx ~dir ~scope ~dir_kind ({ requires; flags; _ } as t) =
        want to declare a dependency on the contents of the .merlin
        file.
 
-       Currently jbuilder doesn't support declaring a dependency only
+       Currently dune doesn't support declaring a dependency only
        on the existence of a file, so we have to use this trick. *)
     SC.add_rule sctx
       (Build.path merlin_file


### PR DESCRIPTION
```
$ dune utop --verbose
# Workspace root: /tmp/dune-demo
Running[0]: /usr/bin/nproc > /tmp/dune62799b.output
# # Workspace root: /tmp/dune-demo
# Auto-detected concurrency: 8
Running[1]: /home/louis/.opam/4.05.0/bin/ocamlc.opt -config > /tmp/dunedacebc.output
# # # Workspace root: /tmp/dune-demo
# # Auto-detected concurrency: 8
# Jbuilder context:
```

The last line used to contain `Jbuilder`. It is replaced by `Dune`.

There are some other occurrences, but I'm not sure that have to be replaced.

```
src/action.ml-532-          Loc.fail loc
src/action.ml-533-            "This directory cannot be evaluated statically.\n\
src/action.ml:534:             This is not allowed by jbuilder"
```

```
src/gen_meta.ml:87:        [ Comment "This is what jbuilder uses to find out the runtime \
src/gen_meta.ml-88-                   dependencies of"
src/gen_meta.ml-89-        ; Comment "a preprocessor"
```

```
src/merlin.ml:123:       Currently jbuilder doesn't support declaring a dependency only
src/merlin.ml-124-       on the existence of a file, so we have to use this trick. *)
```

Signed-off-by: Louis Roché <louis@louisroche.net>