### PR TITLE
Fix placeholders in dune subst documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ next
 - Use `-opaque` in the `dev` profile. This option trades off binary quality for
   compilation speed when compiling .cmx files. (#1079, fix #1058, @rgrinberg)
 
+- Fix placeholders in `dune subst` documentation (#1090, @emillon, thanks
+  @trefis for the bug report)
+
 1.0.1 (19/07/2018)
 ------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1279,6 +1279,10 @@ let exec =
   in
   (term, Term.info "exec" ~doc ~man)
 
+(** A string that is "%%VERSION%%" but not expanded by [dune subst] *)
+let literal_version =
+  "%%" ^ "VERSION%%"
+
 let subst =
   let doc =
     "Substitute watermarks in source files."
@@ -1294,17 +1298,17 @@ let subst =
     [ `S "DESCRIPTION"
     ; `P {|Substitute $(b,%%ID%%) strings in source files, in a similar fashion to
            what topkg does in the default configuration.|}
-    ; `P {|This command is only meant to be called when a user pins a package to
-           its development version. Especially it replaces $(b,%%VERSION%%) strings
-           by the version obtained from the vcs. Currently only git is supported and
-           the version is obtained from the output of:|}
+    ; `P ({|This command is only meant to be called when a user pins a package to
+            its development version. Especially it replaces $(b,|} ^ literal_version
+          ^{|) strings by the version obtained from the vcs. Currently only git is
+             supported and the version is obtained from the output of:|})
     ; `Pre {|  \$ git describe --always --dirty|}
     ; `P {|$(b,dune subst) substitutes the variables that topkg substitutes with
            the defatult configuration:|}
     ; var "NAME" "the name of the project (from the dune-project file)"
     ; var "VERSION" "output of $(b,git describe --always --dirty)"
-    ; var "VERSION_NUM" "same as $(b,%%VERSION%%) but with a potential leading \
-                         'v' or 'V' dropped"
+    ; var "VERSION_NUM" ("same as $(b," ^ literal_version ^
+                         ") but with a potential leading 'v' or 'V' dropped")
     ; var "VCS_COMMIT_ID" "commit hash from the vcs"
     ; opam "maintainer"
     ; opam "authors"


### PR DESCRIPTION
They were substituted, leading to confusing documentation.