### PR TITLE
Extract predicates for compiler versions

### DIFF
--- a/src/context.mli
+++ b/src/context.mli
@@ -90,7 +90,7 @@ type t =
 
   ; ocaml_config            : Ocaml_config.t
   ; version_string          : string
-  ; version                 : int * int * int
+  ; version                 : Ocaml_version.t
   ; stdlib_dir              : Path.t
   ; ccomp_type              : string
   ; c_compiler              : string

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -17,7 +17,8 @@ module Gen(P : Install_rules.Params) = struct
   let sctx = P.sctx
   let ctx = SC.context sctx
 
-  let opaque = ctx.profile = "dev" && ctx.version >= (4, 03, 0)
+  let opaque =
+    ctx.profile = "dev" && Ocaml_version.supports_opaque_for_mli ctx.version
 
   (* +-----------------------------------------------------------------+
      | Library stuff                                                   |
@@ -143,10 +144,11 @@ module Gen(P : Install_rules.Params) = struct
           ]));
     dst
 
-  (* In 4.02, the compiler reads the cmi for module alias even with
-     [-w -49 -no-alias-deps], so we must sandbox the build of the
+  (* If the compiler reads the cmi for module alias even with
+     [-w -49 -no-alias-deps], we must sandbox the build of the
      alias module since the modules it references are built after. *)
-  let alias_module_build_sandbox = ctx.version < (4, 03, 0)
+  let alias_module_build_sandbox =
+    Ocaml_version.always_reads_alias_cmi ctx.version
 
   let library_rules (lib : Library.t) ~dir_contents ~dir ~scope
         ~compile_info ~dir_kind =

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -95,10 +95,10 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs ~cm_kind (m : Module.t) =
       in
       let dir, no_keep_locs =
         if CC.no_keep_locs cctx && cm_kind = Cmi then begin
-          if ctx.version < (4, 03, 0) then
-            (obj_dir, Arg_spec.As [])
+          if Ocaml_version.supports_no_keep_locs ctx.version then
+            (ctx.build_dir, Arg_spec.As ["-no-keep-locs"])
           else
-            (ctx.build_dir, As ["-no-keep-locs"])
+            (obj_dir, As [])
         end else
           (ctx.build_dir, As [])
       in

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -1,0 +1,19 @@
+type t = int * int * int
+
+let of_ocaml_config ocfg =
+  Ocaml_config.version ocfg
+
+let supports_no_keep_locs version =
+  version >= (4, 03, 0)
+
+let supports_opaque_for_mli version =
+  version >= (4, 03, 0)
+
+let always_reads_alias_cmi version =
+  version < (4, 03, 0)
+
+let supports_color_in_ocamlparam version =
+  version >= (4, 03, 0)
+
+let supports_ocaml_color version =
+  version >= (4, 05, 0)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -1,0 +1,20 @@
+(** Version numbers for ocamlc and ocamlopt *)
+type t
+
+val of_ocaml_config : Ocaml_config.t -> t
+
+(** Does this support [-no-keep-locs]? *)
+val supports_no_keep_locs : t -> bool
+
+(** Does this support [-opaque] for [.mli] files? *)
+val supports_opaque_for_mli : t -> bool
+
+(** Does it read the [.cmi] file of module alias
+    even when [-no-alias-deps] is passed? *)
+val always_reads_alias_cmi : t -> bool
+
+(** Does this support ['color'] in [OCAMLPARAM]? *)
+val supports_color_in_ocamlparam : t -> bool
+
+(** Does this support [OCAML_COLOR]? *)
+val supports_ocaml_color : t -> bool


### PR DESCRIPTION
Instead of comparing on the version numbers, add some predicates in `Context` that describe the compiler behavior.

(as discussed in #1079)