### PR TITLE
Fix #1107

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ next
 - Fix duplicate profile argument in suggested command when an external library
   is missing (#1109, #1106, @emillon)
 
+- Fix #1107. `-opaque` wasn't correctly being added to modules without
+  an interface. (#1108, fix #1107, @rgrinberg)
+
 1.1.0 (06/08/2018)
 ------------------
 

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -88,7 +88,9 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs ~cm_kind (m : Module.t) =
           SC.add_rule sctx (Build.symlink ~src:in_obj_dir ~dst:in_dir))
       end;
       let opaque_arg =
-        if opaque && cm_kind = Cmi then
+        let intf_only = cm_kind = Cmi && not (Module.has_impl m) in
+        if opaque
+        || (intf_only && Ocaml_version.supports_opaque_for_mli ctx.version) then
           Arg_spec.A "-opaque"
         else
           As []


### PR DESCRIPTION
-opaque should be passed for mli only modules or for all modules when opaque
 mode is on

This is overdoing the opaque mode a bit. As we don't really need to pass it when creating cmo/cmx files for which the cmi exists, but it seems like it doesn't do any harm.