### PR TITLE
WIP: support (lang dune unstable)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -56,6 +56,7 @@ type common =
     orig_args             : string list
   ; config                : Config.t
   ; default_target        : string
+  ; unstable_lang         : bool
   }
 
 let prefix_target common s = common.target_prefix ^ s
@@ -110,6 +111,8 @@ module Main = struct
   include Dune.Main
 
   let setup ~log ?external_lib_deps_mode common =
+    if common.unstable_lang then
+      Syntax.enable_unstable Stanza.syntax;
     setup
       ~log
       ?workspace_file:(Option.map ~f:Arg.Path.path common.workspace_file)
@@ -497,6 +500,11 @@ let common =
          & opt (some string) None
          & info ["diff-command"] ~docs
              ~doc:"Shell command to use to diff files")
+  and unstable_lang =
+    Arg.(value
+         & flag
+         & info ["unstable"]
+             ~doc:"Enable unstable features from the dune language")
   in
   let build_dir = Option.value ~default:"_build" build_dir in
   let root, to_cwd =
@@ -555,6 +563,7 @@ let common =
   ; config
   ; build_dir
   ; default_target
+  ; unstable_lang
   }
 
 let installed_libraries =

--- a/src/action.ml
+++ b/src/action.ml
@@ -122,7 +122,7 @@ struct
            in
            Diff { optional = true; file1; file2; mode })
         ; "cmp",
-          (let%map () = Syntax.since Stanza.syntax (1, 0)
+          (let%map () = Syntax.since Stanza.syntax (Stable (1, 0))
            and file1 = path
            and file2 = path
            in

--- a/src/config.ml
+++ b/src/config.ml
@@ -134,7 +134,7 @@ let load_config_file p =
       match Dune_lexer.maybe_first_line lb with
       | None ->
         parse (enter t)
-          (Univ_map.singleton (Syntax.key syntax) (0, 0))
+          (Univ_map.singleton (Syntax.key syntax) (Stable (0, 0)))
           (Io.Sexp.load p ~mode:Many_as_one ~lexer:Sexp.Lexer.jbuild_token)
       | Some first_line ->
         parse_contents lb first_line ~f:(fun _lang -> t))

--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -37,7 +37,7 @@ module Stanza = struct
        (pat, configs))
 
   let t =
-    let%map () = Syntax.since Stanza.syntax (1, 0)
+    let%map () = Syntax.since Stanza.syntax (Stable (1, 0))
     and loc = loc
     and rules = repeat rule
     in

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -83,7 +83,7 @@ module Backend = struct
       let open Sexp.To_sexp in
       let lib x = string (Lib.name x) in
       let f x = string (Lib.name x.lib) in
-      ((1, 0),
+      (Syntax.Version.Stable (1, 0),
        record_fields
          [ field "runner_libraries" (list lib)
              (Result.ok_exn t.runner_libraries)

--- a/src/jbuild.ml
+++ b/src/jbuild.ml
@@ -378,11 +378,11 @@ module Dep_conf = struct
         ; "universe"   , return Universe
         ; "files_recursively_in",
           (let%map () =
-             Syntax.renamed_in Stanza.syntax (1, 0) ~to_:"source_tree"
+             Syntax.renamed_in Stanza.syntax (Stable (1, 0)) ~to_:"source_tree"
            and x = sw in
            Source_tree x)
         ; "source_tree",
-          (let%map () = Syntax.since Stanza.syntax (1, 0)
+          (let%map () = Syntax.since Stanza.syntax (Stable (1, 0))
            and x = sw in
            Source_tree x)
         ]
@@ -438,7 +438,7 @@ module Preprocess = struct
          and pps, flags = Pps_and_flags.t in
          Pps { loc; pps; flags; staged = false })
       ; "staged_pps",
-        (let%map () = Syntax.since Stanza.syntax (1, 1)
+        (let%map () = Syntax.since Stanza.syntax (Stable (1, 1))
          and loc = loc
          and pps, flags = Pps_and_flags.t in
          Pps { loc; pps; flags; staged = true })
@@ -482,7 +482,7 @@ module Blang = struct
           ~else_:(String_with_vars.t >>| fun v -> Expr v)
       end
     in
-    let%map () = Syntax.since Stanza.syntax (1, 1)
+    let%map () = Syntax.since Stanza.syntax (Stable (1, 1))
     and t = t
     in
     t
@@ -958,7 +958,7 @@ module Library = struct
            Lib_name.validate n ~wrapped
            |> Lib_name.to_string
          | None, Some { name = (loc, name) ; _ }  ->
-           if dune_version >= (1, 1) then
+           if dune_version >= Stable (1, 1) then
              match Lib_name.of_string name with
              | Ok m -> Lib_name.to_string m
              | Warn _ | Invalid ->
@@ -973,7 +973,7 @@ module Library = struct
                                 1.1 of the dune language"
          | None, None ->
            of_sexp_error loc (
-             if dune_version >= (1, 1) then
+             if dune_version >= Stable (1, 1) then
                "supply at least least one of name or public_name fields"
              else
                "name field is missing"
@@ -1175,7 +1175,7 @@ module Executables = struct
   let common =
     let%map buildable = Buildable.t
     and (_ : bool) = field "link_executables" ~default:true
-                       (Syntax.deleted_in Stanza.syntax (1, 0) >>> bool)
+                       (Syntax.deleted_in Stanza.syntax (Stable (1, 0)) >>> bool)
     and link_deps = field "link_deps" (list Dep_conf.t) ~default:[]
     and link_flags = field_oslu "link_flags"
     and modes = field "modes" Link_mode.Set.t ~default:Link_mode.Set.default
@@ -1201,7 +1201,7 @@ module Executables = struct
         match names, public_names with
         | Some names, _ -> names
         | None, Some public_names ->
-          if dune_syntax >= (1, 1) then
+          if dune_syntax >= Stable (1, 1) then
             List.map public_names ~f:(fun (loc, p) ->
               match p with
               | None ->
@@ -1212,7 +1212,7 @@ module Executables = struct
               "%s field may not be omitted before dune version 1.1"
               (pluralize ~multi "name")
         | None, None ->
-          if dune_syntax >= (1, 1) then
+          if dune_syntax >= Stable (1, 1) then
             of_sexp_errorf loc "either the %s or the %s field must be present"
               (pluralize ~multi "name")
               (pluralize ~multi "public_name")
@@ -1425,7 +1425,7 @@ module Rule = struct
       map_validate
         (let%map fallback =
            field_b
-           ~check:(Syntax.renamed_in Stanza.syntax (1, 0)
+           ~check:(Syntax.renamed_in Stanza.syntax (Stable (1, 0))
                      ~to_:"(mode fallback)")
            "fallback"
          and mode = field_o "mode" Mode.t
@@ -1790,22 +1790,22 @@ module Stanzas = struct
       (let%map d = Documentation.t in
        [Documentation d])
     ; "jbuild_version",
-      (let%map () = Syntax.deleted_in Stanza.syntax (1, 0)
+      (let%map () = Syntax.deleted_in Stanza.syntax (Stable (1, 0))
        and _ = Jbuild_version.t in
        [])
     ; "tests",
-      (let%map () = Syntax.since Stanza.syntax (1, 0)
+      (let%map () = Syntax.since Stanza.syntax (Stable (1, 0))
        and t = Tests.multi in
        [Tests t])
     ; "test",
-      (let%map () = Syntax.since Stanza.syntax (1, 0)
+      (let%map () = Syntax.since Stanza.syntax (Stable (1, 0))
        and t = Tests.single in
        [Tests t])
     ; "env",
       (let%map x = Dune_env.Stanza.t in
        [Dune_env.T x])
     ; "include_subdirs",
-      (let%map () = Syntax.since Stanza.syntax (1, 1)
+      (let%map () = Syntax.since Stanza.syntax (Stable (1, 1))
        and t = Include_subdirs.t
        and loc = loc in
        [Include_subdirs (loc, t)])
@@ -1823,7 +1823,7 @@ module Stanzas = struct
          [Menhir.T { x with loc }])
       ]
     in
-    Syntax.set Stanza.syntax (0, 0) (sum stanzas)
+    Syntax.set Stanza.syntax (Stable (0, 0)) (sum stanzas)
 
   let () =
     Dune_project.Lang.register Stanza.syntax stanzas

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -292,8 +292,8 @@ module Unexpanded = struct
     in
     let syntax =
       match Univ_map.find t.context (Syntax.key Stanza.syntax) with
-      | Some (0, _)-> File_tree.Dune_file.Kind.Jbuild
-      | None | Some (_, _) -> Dune
+      | Some Stable (0, _)-> File_tree.Dune_file.Kind.Jbuild
+      | None | Some Stable (_, _) | Some Unstable -> Dune
     in
     (syntax, loop Path.Set.empty t.ast)
 

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -53,18 +53,18 @@ module Map = struct
 
   let static_vars =
     String.Map.of_list_exn
-      [ "targets", since ~version:(1, 0) Var.Targets
-      ; "deps", since ~version:(1, 0) Var.Deps
-      ; "project_root", since ~version:(1, 0) Var.Project_root
+      [ "targets", since ~version:(Stable (1, 0)) Var.Targets
+      ; "deps", since ~version:(Stable (1, 0)) Var.Deps
+      ; "project_root", since ~version:(Stable (1, 0)) Var.Project_root
 
-      ; "<", deleted_in Var.First_dep ~version:(1, 0)
+      ; "<", deleted_in Var.First_dep ~version:(Stable (1, 0))
                ~repl:"Use a named dependency instead:\
                       \n\
                       \n  (deps (:x <dep>) ...)\
                       \n   ... %{x} ..."
-      ; "@", renamed_in ~version:(1, 0) ~new_name:"targets"
-      ; "^", renamed_in ~version:(1, 0) ~new_name:"deps"
-      ; "SCOPE_ROOT", renamed_in ~version:(1, 0) ~new_name:"project_root"
+      ; "@", renamed_in ~version:(Stable (1, 0)) ~new_name:"targets"
+      ; "^", renamed_in ~version:(Stable (1, 0)) ~new_name:"deps"
+      ; "SCOPE_ROOT", renamed_in ~version:(Stable (1, 0)) ~new_name:"project_root"
       ]
 
   let macros =
@@ -80,12 +80,12 @@ module Map = struct
       ; "read-lines", macro Read_lines
       ; "read-strings", macro Read_strings
 
-      ; "dep", since ~version:(1, 0) Macro.Dep
+      ; "dep", since ~version:(Stable (1, 0)) Macro.Dep
 
-      ; "path", renamed_in ~version:(1, 0) ~new_name:"dep"
-      ; "findlib", renamed_in ~version:(1, 0) ~new_name:"lib"
+      ; "path", renamed_in ~version:(Stable (1, 0)) ~new_name:"dep"
+      ; "findlib", renamed_in ~version:(Stable (1, 0)) ~new_name:"lib"
 
-      ; "path-no-dep", deleted_in ~version:(1, 0) Macro.Path_no_dep
+      ; "path-no-dep", deleted_in ~version:(Stable (1, 0)) Macro.Path_no_dep
       ; "ocaml-config", macro Ocaml_config
       ]
 
@@ -120,7 +120,7 @@ module Map = struct
     in
     let uppercased =
       List.map lowercased ~f:(fun (k, _) ->
-        (String.uppercase k, renamed_in ~new_name:k ~version:(1, 0)))
+        (String.uppercase k, renamed_in ~new_name:k ~version:(Stable (1, 0))))
     in
     let other =
       [ "-verbose"       , values []
@@ -135,7 +135,7 @@ module Map = struct
       ; "ext_exe"        , string context.ext_exe
       ; "profile"        , string context.profile
       ; "workspace_root" , values [Value.Dir context.build_dir]
-      ; "ROOT"           , renamed_in ~version:(1, 0) ~new_name:"workspace_root"
+      ; "ROOT"           , renamed_in ~version:(Stable (1, 0)) ~new_name:"workspace_root"
       ]
     in
     { vars =
@@ -226,8 +226,8 @@ module Map = struct
     let value = Var.Values (Value.L.paths [path]) in
     { vars =
         String.Map.of_list_exn
-          [ "input-file", since ~version:(1, 0) value
-          ; "<", renamed_in ~new_name:"input-file" ~version:(1, 0)
+          [ "input-file", since ~version:(Stable (1, 0)) value
+          ; "<", renamed_in ~new_name:"input-file" ~version:(Stable (1, 0))
           ]
     ; macros = String.Map.empty
     }

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -49,7 +49,7 @@ module Driver = struct
            and flags = Ordered_set_lang.Unexpanded.field "flags"
            and as_ppx_flags =
              Ordered_set_lang.Unexpanded.field "flags"
-               ~check:(Syntax.since syntax (1, 1))
+               ~check:(Syntax.since syntax (Stable (1, 1)))
            and lint_flags = Ordered_set_lang.Unexpanded.field "lint_flags"
            and main = field "main" string
            and replaces = field "replaces" (list (located string)) ~default:[]
@@ -99,7 +99,7 @@ module Driver = struct
     let to_sexp t =
       let open Sexp.To_sexp in
       let f x = string (Lib.name (Lazy.force x.lib)) in
-      ((1, 0),
+      (Syntax.Version.Stable (1, 0),
        record
          [ "flags"            , Ordered_set_lang.Unexpanded.sexp_of_t
                                   t.info.flags
@@ -190,7 +190,7 @@ module Jbuild_driver = struct
   let make name info : (Pp.t * Driver.t) Lazy.t = lazy (
     let info =
       let parsing_context =
-        Univ_map.singleton (Syntax.key Stanza.syntax) (0, 0)
+        Univ_map.singleton (Syntax.key Stanza.syntax) (Stable (0, 0))
       in
       Sexp.parse_string ~mode:Single ~fname:"<internal>" info
         ~lexer:Sexp.Lexer.jbuild_token

--- a/src/stanza.ml
+++ b/src/stanza.ml
@@ -16,8 +16,9 @@ module File_kind = struct
   type t = Sexp.syntax = Jbuild | Dune
 
   let of_syntax = function
-    | (0, _) -> Jbuild
-    | (_, _) -> Dune
+    | Syntax.Version.Stable (0, _) -> Jbuild
+    | Syntax.Version.Stable (_, _) -> Dune
+    | Syntax.Version.Unstable -> Dune
 end
 
 let file_kind () =
@@ -86,7 +87,7 @@ module Of_sexp = struct
 
   let on_dup parsing_context name entries =
     match Univ_map.find parsing_context (Syntax.key syntax) with
-    | Some (0, _) ->
+    | Some Stable (0, _) ->
       let last = Option.value_exn (List.last entries) in
       Loc.warn (Sexp.Ast.loc last)
         "Field %S is present several times, previous occurrences are ignored."

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -13,7 +13,7 @@ let make_text ?(quoted=false) loc s =
       ; quoted
       ; loc
       }
-  ; syntax_version = (1, 0)
+  ; syntax_version = Stable (1, 0)
   }
 
 let literal ~quoted ~loc s =
@@ -123,7 +123,7 @@ let loc t = t.template.loc
 
 let syntax_version t = t.syntax_version
 
-let virt_syntax = (1, 0)
+let virt_syntax = Syntax.Version.Stable (1, 0)
 
 let virt ?(quoted=false) pos s =
   let template = Jbuild.parse ~quoted ~loc:(Loc.of_pos pos) s in

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -8,7 +8,9 @@ module Version : sig
       It is always assumed that a parser with version [(X, Y)] can
       read the output produced by a printer at version [(X, Z)] for any
       [Z <= Y]. *)
-  type t = int * int
+  type t =
+    | Stable of int * int
+    | Unstable
 
   include Sexp.Sexpable with type t := t
 
@@ -41,10 +43,12 @@ end
     syntax. [supported_version] is the list of the last minor version
     of each supported major version. [desc] is used to describe what
     this syntax represent in error messages. *)
-val create : name:string -> desc:string -> Version.t list -> t
+val create : name:string -> desc:string -> (int * int) list -> t
 
 (** Return the name of the syntax. *)
 val name : t -> string
+
+val enable_unstable : t -> unit
 
 (** Check that the given version is supported and raise otherwise. *)
 val check_supported : t -> Loc.t * Version.t -> unit

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -7,7 +7,7 @@ let syntax = Stanza.syntax
 
 let env_field =
   field_o "env"
-    (Syntax.since syntax (1, 1) >>= fun () ->
+    (Syntax.since syntax (Stable (1, 1)) >>= fun () ->
      Dune_env.Stanza.t)
 
 module Context = struct
@@ -228,7 +228,7 @@ let load ?x ?profile p =
     in
     parse
       (enter (t ?x ?profile ()))
-      (Univ_map.singleton (Syntax.key syntax) (0, 0))
+      (Univ_map.singleton (Syntax.key syntax) (Stable (0, 0)))
       sexp
 
 let default ?x ?profile () =

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -409,6 +409,14 @@
     (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
 (alias
+ (name lang-unstable)
+ (deps (package dune) (source_tree test-cases/lang-unstable))
+ (action
+  (chdir
+   test-cases/lang-unstable
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name lib-available)
  (deps (package dune) (source_tree test-cases/lib-available))
  (action
@@ -823,6 +831,7 @@
   (alias inline_tests)
   (alias installable-dup-private-libs)
   (alias intf-only)
+  (alias lang-unstable)
   (alias lib-available)
   (alias link-deps)
   (alias loop)
@@ -916,6 +925,7 @@
   (alias inline_tests)
   (alias installable-dup-private-libs)
   (alias intf-only)
+  (alias lang-unstable)
   (alias lib-available)
   (alias link-deps)
   (alias loop)

--- a/test/blackbox-tests/test-cases/lang-unstable/run.t
+++ b/test/blackbox-tests/test-cases/lang-unstable/run.t
@@ -1,0 +1,27 @@
+When (lang dune unstable) is present, unstable features are available.
+
+By default, this is not available:
+
+  $ dune printenv --root unstable
+  File "dune-project", line 1, characters 11-19:
+  Error: Version unstable of dune is not supported.
+  Supported versions:
+  - 0.0
+  - 1.0 to 1.1
+  [1]
+
+Passing --unstable unlocks this:
+
+  $ dune printenv --unstable --root unstable
+  Entering directory 'unstable'
+  (
+   (flags
+    (-w
+     @a-4-29-40-41-42-44-45-48-58-59-60-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs))
+   (ocamlc_flags (-g))
+   (ocamlopt_flags (-g))
+  )

--- a/test/blackbox-tests/test-cases/lang-unstable/unstable/dune-project
+++ b/test/blackbox-tests/test-cases/lang-unstable/unstable/dune-project
@@ -1,0 +1,1 @@
+(lang dune unstable)


### PR DESCRIPTION
As discussed before, we'd like a way to ship features that are only available if you know where to look, in order to try them without committing to an interface.

The idea is that if you set `(lang dune unstable)`, all language features are available, even those marked as unstable. To prevent users from relying on these, an explicit `--unstable` flag is necessary.

This PR is a way to discuss how this should work (error messages etc are not polished).

Here are some questions:

- how to gate this feature? is `--unstable` OK, or should we additionally forbid this when using the `release` profile (or is the profile check enough?)
- at the moment this relies on some global mutable state in `Stanza.t` which is... not great. could we move this `env` for example?
- it seems that only parts that use version numbers can benefit from this - for example installed dune files probably do not need this. Should we split stable version numbers and potentially unstable ones?
- since there are no unstable features for now, it's not possible to test the equivalent of `since` for unstable features. Should I add a temporary `(only_in_unstable)` syntax construct that is a no-op but requires the unstable language?
- at the moment `(1, 0)` is repeated in a lot of places in the code and this makes the diff a bit large to change the version API. That's probably acceptable, but there are ways to make this a bit more future proof: would `version_1_0` (etc) constants in `Syntax.Version` be useful? Or should we just pass the `(major, minor)` arguments to `since`? (it seems that `since` only makes sense for a stable version).

Let me know what you think.