### PR TITLE
Highlight error locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ next
 - Fix error message when the source directory of `copy_files` does not exist.
   (#1120, fix #1099, @emillon)
 
+- Highlight error locations in error messages (#1121, @emillon)
+
 1.1.1 (08/08/2018)
 ------------------
 

--- a/src/loc.ml
+++ b/src/loc.ml
@@ -61,12 +61,35 @@ let of_pos (fname, lnum, cnum, enum) =
   ; stop  = { pos with pos_cnum = enum }
   }
 
-let print ppf { start; stop } =
+let file_line path n =
+  Io.with_file_in ~binary:false path
+    ~f:(fun ic ->
+      for _ = 1 to n - 1 do
+        ignore (input_line ic)
+      done;
+      input_line ic
+    )
+
+let print ppf loc =
+  let { start; stop } = loc in
   let start_c = start.pos_cnum - start.pos_bol in
   let stop_c  = stop.pos_cnum  - start.pos_bol in
+  let pp_file_excerpt pp () =
+    let whole_file = start_c = 0 && stop_c = 0 in
+    if not whole_file then
+      let path = Path.of_string start.pos_fname in
+      if Path.exists path then
+        let line = file_line path start.pos_lnum in
+        if stop_c <= String.length line then
+          let len = stop_c - start_c in
+          Format.fprintf pp "%s\n%*s\n" line
+            stop_c
+            (String.make len '^')
+  in
   Format.fprintf ppf
-    "@{<loc>File \"%s\", line %d, characters %d-%d:@}@\n"
+    "@{<loc>File \"%s\", line %d, characters %d-%d:@}@\n%a"
     start.pos_fname start.pos_lnum start_c stop_c
+    pp_file_excerpt ()
 
 let warn t fmt =
   Errors.kerrf ~f:print_to_console

--- a/test/blackbox-tests/test-cases/bad-alias-error/run.t
+++ b/test/blackbox-tests/test-cases/bad-alias-error/run.t
@@ -1,11 +1,15 @@
   $ dune runtest --root absolute-path
   Entering directory 'absolute-path'
   File "jbuild", line 3, characters 16-24:
+    (deps ((alias /foo/bar)))))
+                  ^^^^^^^^
   Error: Invalid alias!
   Tried to reference path outside build dir: "/foo/bar"
   [1]
   $ dune runtest --root outside-workspace
   Entering directory 'outside-workspace'
   File "jbuild", line 4, characters 16-39:
+    (deps ((alias ${ROOT}/../../../foobar)))))
+                  ^^^^^^^^^^^^^^^^^^^^^^^
   Error: path outside the workspace: ./../../../foobar from default
   [1]

--- a/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
+++ b/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
@@ -6,6 +6,8 @@ All builtin variables are lower cased in Dune:
   $ dune runtest --root dune-upper
   Entering directory 'dune-upper'
   File "dune", line 3, characters 41-46:
+   (action (with-stdout-to %{null} (echo %{MAKE}))))
+                                           ^^^^^
   Error: %{MAKE} was renamed to '%{make}' in the 1.0 version of the dune language
   [1]
 

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -2,6 +2,8 @@ No ppx driver found
 
   $ dune build foo1.cma
   File "dune", line 6, characters 13-18:
+   (preprocess (pps)))
+               ^^^^^
   Error: You must specify at least one ppx rewriter.
   [1]
 
@@ -9,6 +11,8 @@ Too many drivers
 
   $ dune build foo2.cma
   File "dune", line 13, characters 13-28:
+   (preprocess (pps ppx1 ppx2)))
+               ^^^^^^^^^^^^^^^
   Error: Too many incompatible ppx drivers were found: foo.driver2 and
   foo.driver1.
   [1]
@@ -17,6 +21,8 @@ Not compatible with Dune
 
   $ dune build foo3.cma
   File "dune", line 20, characters 13-28:
+   (preprocess (pps ppx_other)))
+               ^^^^^^^^^^^^^^^
   Error: No ppx driver were found. It seems that ppx_other is not compatible
   with Dune. Examples of ppx rewriters that are compatible with Dune are ones
   using ocaml-migrate-parsetree, ppxlib or ppx_driver.

--- a/test/blackbox-tests/test-cases/dup-fields/run.t
+++ b/test/blackbox-tests/test-cases/dup-fields/run.t
@@ -5,6 +5,8 @@ Duplicating a field in a dune file is an error:
 
   $ dune build --root dune
   File "dune", line 4, characters 1-20:
+   (action (echo bar)))
+   ^^^^^^^^^^^^^^^^^^^
   Error: Field "action" is present too many times
   [1]
 
@@ -15,6 +17,8 @@ For backward compatibility, it is only a warning in jbuild files:
 
   $ dune build --root jbuild
   File "jbuild", line 4, characters 2-21:
+    (action (echo bar))))
+    ^^^^^^^^^^^^^^^^^^^
   Warning: Field "action" is present several times, previous occurrences are ignored.
   Entering directory 'jbuild'
   bar

--- a/test/blackbox-tests/test-cases/exclude-missing-module/run.t
+++ b/test/blackbox-tests/test-cases/exclude-missing-module/run.t
@@ -1,3 +1,5 @@
   $ dune build --display short
   File "dune", line 3, characters 22-26:
+   (modules :standard \ fake))
+                        ^^^^
   Warning: Module Fake is excluded but it doesn't exist.

--- a/test/blackbox-tests/test-cases/exec-missing/run.t
+++ b/test/blackbox-tests/test-cases/exec-missing/run.t
@@ -2,6 +2,8 @@ When using dune exec, the external-lib-deps command refers to the executable:
 
   $ dune exec ./x.exe
   File "dune", line 3, characters 12-26:
+   (libraries does-not-exist))
+              ^^^^^^^^^^^^^^
   Error: Library "does-not-exist" not found.
   Hint: try: dune external-lib-deps --missing ./x.exe
   [1]

--- a/test/blackbox-tests/test-cases/fallback-dune/run.t
+++ b/test/blackbox-tests/test-cases/fallback-dune/run.t
@@ -2,6 +2,8 @@ fallback isn't allowed in dune
 
   $ dune build --root dune1
   File "dune", line 2, characters 1-11:
+   (fallback)
+   ^^^^^^^^^^
   Error: 'fallback' was renamed to '(mode fallback)' in the 1.0 version of the dune language
   [1]
 
@@ -9,6 +11,8 @@ fallback isn't allowed in dune
 
   $ dune build --root dune2
   File "dune", line 2, characters 1-17:
+   (fallback false)
+   ^^^^^^^^^^^^^^^^
   Error: 'fallback' was renamed to '(mode fallback)' in the 1.0 version of the dune language
   [1]
 

--- a/test/blackbox-tests/test-cases/findlib-error/run.t
+++ b/test/blackbox-tests/test-cases/findlib-error/run.t
@@ -3,6 +3,8 @@ We are dropping support for findlib in dune
   $ dune build --root in-dune target.txt
   Entering directory 'in-dune'
   File "dune", line 2, characters 25-37:
+  (write-file target.txt %{findlib:pkg})
+                           ^^^^^^^^^^^^
   Error: %{findlib:..} was renamed to '%{lib:..}' in the 1.0 version of the dune language
   [1]
 
@@ -11,5 +13,7 @@ But it must still be available in jbuild files
   $ dune build --root in-jbuild target.txt
   Entering directory 'in-jbuild'
   File "jbuild", line 4, characters 23-42:
+  (write-file target.txt ${findlib:pkg:file})
+                         ^^^^^^^^^^^^^^^^^^^
   Error: Public library "pkg" not found
   [1]

--- a/test/blackbox-tests/test-cases/findlib/run.t
+++ b/test/blackbox-tests/test-cases/findlib/run.t
@@ -8,6 +8,8 @@ Reproduction case for #484. The error should point to src/jbuild
 
   $ dune build @install
   File "src/dune", line 4, characters 14-15:
+   (libraries   a b c))
+                ^
   Error: Library "a" not found.
   Hint: try: dune external-lib-deps --missing @install
   [1]
@@ -16,6 +18,8 @@ When passing --dev, the profile should be displayed only once (#1106):
 
   $ jbuilder build --dev @install
   File "src/dune", line 4, characters 14-15:
+   (libraries   a b c))
+                ^
   Error: Library "a" not found.
   Hint: try: dune external-lib-deps --missing --profile dev @install
   [1]
@@ -24,6 +28,8 @@ With dune and an explicit profile, it is the same:
 
   $ dune build --profile dev @install
   File "src/dune", line 4, characters 14-15:
+   (libraries   a b c))
+                ^
   Error: Library "a" not found.
   Hint: try: dune external-lib-deps --missing --profile dev @install
   [1]

--- a/test/blackbox-tests/test-cases/github1099/run.t
+++ b/test/blackbox-tests/test-cases/github1099/run.t
@@ -3,6 +3,8 @@ If the source directory does not exist, an error message is printed:
   $ dune build --root no-dir demo.exe
   Entering directory 'no-dir'
   File "dune", line 1, characters 13-23:
+  (copy_files# "no_dir/*")
+               ^^^^^^^^^^
   Error: cannot find directory: no_dir
   [1]
 
@@ -11,5 +13,7 @@ This works also is a file exists with the same name:
   $ dune build --root file-with-same-name demo.exe
   Entering directory 'file-with-same-name'
   File "dune", line 1, characters 13-23:
+  (copy_files# "no_dir/*")
+               ^^^^^^^^^^
   Error: cannot find directory: no_dir
   [1]

--- a/test/blackbox-tests/test-cases/github644/run.t
+++ b/test/blackbox-tests/test-cases/github644/run.t
@@ -1,5 +1,7 @@
   $ dune runtest
   File "jbuild", line 4, characters 20-42:
+    (preprocess (pps (ppx_that_doesn't_exist)))))
+                      ^^^^^^^^^^^^^^^^^^^^^^
   Error: Library "ppx_that_doesn't_exist" not found.
   Hint: try: dune external-lib-deps --missing @runtest
   [1]

--- a/test/blackbox-tests/test-cases/github734/run.t
+++ b/test/blackbox-tests/test-cases/github734/run.t
@@ -1,4 +1,6 @@
   $ jbuilder build @foo
   File "src/dune", line 4, characters 10-17:
+   (c_names stubs/x))
+            ^^^^^^^
   Error: File src/stubs/x.c is not part of the current directory group. This is not allowed.
   [1]

--- a/test/blackbox-tests/test-cases/github761/run.t
+++ b/test/blackbox-tests/test-cases/github761/run.t
@@ -1,4 +1,6 @@
   $ jbuilder build @bar
   File "dune", line 2, characters 7-14:
+   (name foo/bar)
+         ^^^^^^^
   Error: "foo/bar" is not a valid alias name
   [1]

--- a/test/blackbox-tests/test-cases/github784/run.t
+++ b/test/blackbox-tests/test-cases/github784/run.t
@@ -1,4 +1,6 @@
   $ dune build
   File "dune", line 1, characters 0-28:
+  (rule (run %{bin:echo} foo))
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Rule has no targets specified
   [1]

--- a/test/blackbox-tests/test-cases/github992/run.t
+++ b/test/blackbox-tests/test-cases/github992/run.t
@@ -17,9 +17,13 @@ argument of "package".
 
   $ cd package-without-pub-name && dune build -p foo
   File "dune", line 3, characters 1-14:
+   (package foo))
+   ^^^^^^^^^^^^^
   Error: This field is useless without a (public_name ...) field.
   [1]
 
   $ cd package-without-pub-name-jbuild && dune build -p foo
   File "jbuild", line 3, characters 2-15:
+    (package foo)))
+    ^^^^^^^^^^^^^
   Warning: This field is useless without a (public_name ...) field.

--- a/test/blackbox-tests/test-cases/include-loop/run.t
+++ b/test/blackbox-tests/test-cases/include-loop/run.t
@@ -1,5 +1,7 @@
   $ dune build --display short
   File "dune", line 1, characters 0-15:
+  (include a.inc)
+  ^^^^^^^^^^^^^^^
   Error: Recursive inclusion of jbuild files detected:
   File a.inc is included from c.inc:1
   --> included from b.inc:1

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -6,11 +6,15 @@
 
   $ dune runtest missing-backend
   File "missing-backend/dune", line 3, characters 1-15:
+   (inline_tests))
+   ^^^^^^^^^^^^^^
   Error: No inline tests backend found.
   [1]
 
   $ dune runtest too-many-backends
   File "too-many-backends/dune", line 17, characters 1-15:
+   (inline_tests)
+   ^^^^^^^^^^^^^^
   Error: Too many independent inline tests backends found:
   - "backend_tmb1" in _build/default/too-many-backends
   - "backend_tmb2" in _build/default/too-many-backends

--- a/test/blackbox-tests/test-cases/intf-only/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/run.t
@@ -35,6 +35,8 @@ Errors:
   $ dune build --display short --root b foo.cma
   Entering directory 'b'
   File "dune", line 3, characters 33-34:
+   (modules_without_implementation x))
+                                   ^
   Warning: The following modules must be listed here as they don't have an implementation:
   - y
   This will become an error in the future.
@@ -43,10 +45,14 @@ Errors:
   $ dune build --display short --root c foo.cma
   Entering directory 'c'
   File "dune", line 3, characters 33-34:
+   (modules_without_implementation x))
+                                   ^
   Error: Module X doesn't exist.
   [1]
   $ dune build --display short --root d foo.cma
   Entering directory 'd'
   File "dune", line 3, characters 33-34:
+   (modules_without_implementation x))
+                                   ^
   Error: Module X has an implementation, it cannot be listed here
   [1]

--- a/test/blackbox-tests/test-cases/macro-expand-error/run.t
+++ b/test/blackbox-tests/test-cases/macro-expand-error/run.t
@@ -3,5 +3,7 @@ inappropariate place:
 
   $ dune build
   File "dune", line 1, characters 14-21:
+  (copy_files %{read:x}/*)
+                ^^^^^^^
   Error: %{read:..} isn't allowed in this position
   [1]

--- a/test/blackbox-tests/test-cases/misc/run.t
+++ b/test/blackbox-tests/test-cases/misc/run.t
@@ -1,5 +1,7 @@
   $ dune runtest --display short
   File "dune", line 44, characters 19-42:
+   (deps (glob_files dir-that-doesnt-exist/*)))
+                     ^^^^^^^^^^^^^^^^^^^^^^^
   Warning: Directory dir-that-doesnt-exist doesn't exist.
           diff alias runtest
           diff alias runtest

--- a/test/blackbox-tests/test-cases/missing-loc-run/run.t
+++ b/test/blackbox-tests/test-cases/missing-loc-run/run.t
@@ -11,6 +11,8 @@ Path that needs to be searched:
   $ dune runtest --root search-path
   Entering directory 'search-path'
   File "dune", line 3, characters 14-32:
+   (action (run foo-does-not-exist)))
+                ^^^^^^^^^^^^^^^^^^
   Error: Error: Program foo-does-not-exist not found in the tree or in PATH (context: default)
   [1]
 

--- a/test/blackbox-tests/test-cases/multi-dir/run.t
+++ b/test/blackbox-tests/test-cases/multi-dir/run.t
@@ -36,12 +36,16 @@ Test some error cases
   $ dune build --root error2
   Entering directory 'error2'
   File "dune", line 2, characters 0-29:
+  (include_subdirs unqualified)
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: The 'include_subdirs' stanza cannot appear more than once
   [1]
 
   $ dune build --root error3
   Entering directory 'error3'
   File "src/gen/dune", line 1, characters 0-23:
+  (executable (name gen))
+  ^^^^^^^^^^^^^^^^^^^^^^^
   Error: This stanza is not allowed in a sub-directory of directory with (include_subdirs unqualified).
   Hint: add (include_subdirs no) to this file.
   [1]

--- a/test/blackbox-tests/test-cases/name-field-validation/run.t
+++ b/test/blackbox-tests/test-cases/name-field-validation/run.t
@@ -1,5 +1,7 @@
   $ dune exec ./bar.exe
   File "dune", line 3, characters 7-14:
+   (name foo.bar)
+         ^^^^^^^
   Warning: invalid library name.
   Hint: library names must be non-empty and composed only of the following characters: 'A'..'Z',  'a'..'z', '_'  or '0'..'9'.
   This is temporary allowed for libraries with (wrapped false).

--- a/test/blackbox-tests/test-cases/no-name-field/run.t
+++ b/test/blackbox-tests/test-cases/no-name-field/run.t
@@ -5,6 +5,8 @@ the name field can be omitted for libraries when public_name is present
 this isn't possible for older syntax <= (1, 0)
   $ dune build --root no-name-lib-syntax-1-0
   File "dune", line 1, characters 22-25:
+  (library (public_name foo))
+                        ^^^
   Error: name field cannot be omitted before version 1.1 of the dune language
   [1]
 
@@ -15,6 +17,8 @@ executable(s) stanza works the same way
 
   $ dune build --root no-name-exes-syntax-1-0
   File "dune", line 1, characters 0-36:
+  (executables (public_names foo bar))
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: name field may not be omitted before dune version 1.1
   [1]
 
@@ -22,6 +26,8 @@ there's only a public name but it's invalid as a name
 
   $ dune build --root public-name-invalid-name
   File "dune", line 1, characters 22-28:
+  (library (public_name c.find))
+                        ^^^^^^
   Error: invalid library name.
   Hint: library names must be non-empty and composed only of the following characters: 'A'..'Z',  'a'..'z', '_'  or '0'..'9'.
   Public library names don't have this restriction. You can either change this public name to be a valid library name or add a "name" field with a valid library name.
@@ -33,6 +39,8 @@ it's just a warning
   $ dune build --root public-name-invalid-wrapped-false
   Info: creating file dune-project with this contents: (lang dune 1.1)
   File "dune", line 3, characters 14-21:
+   (public_name foo.bar))
+                ^^^^^^^
   Error: invalid library name.
   Hint: library names must be non-empty and composed only of the following characters: 'A'..'Z',  'a'..'z', '_'  or '0'..'9'.
   Public library names don't have this restriction. You can either change this public name to be a valid library name or add a "name" field with a valid library name.

--- a/test/blackbox-tests/test-cases/path-variables/run.t
+++ b/test/blackbox-tests/test-cases/path-variables/run.t
@@ -9,6 +9,8 @@ In expands to a file name, and registers this as a dependency.
   $ dune build --root dune @test-dep
   Entering directory 'dune'
   File "dune", line 13, characters 17-47:
+          (echo "%{path:file-that-does-not-exist}\n")
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: %{path:..} was renamed to '%{dep:..}' in the 1.0 version of the dune language
   [1]
 
@@ -20,6 +22,8 @@ This form does not exist, but displays an hint:
   $ dune build --root dune-invalid @test-path-no-dep
   Entering directory 'dune-invalid'
   File "dune", line 7, characters 17-54:
+          (echo "%{path-no-dep:file-that-does-not-exist}\n")
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: %{path-no-dep:..} was deleted in version 1.0 of the dune language
   [1]
 
@@ -53,5 +57,7 @@ This form does not exist, but displays an hint:
   $ dune build --root jbuild-invalid @test-dep
   Entering directory 'jbuild-invalid'
   File "jbuild", line 5, characters 16-37:
+     (action (cat ${dep:generated-file}))))
+                  ^^^^^^^^^^^^^^^^^^^^^
   Error: ${dep:..} is only available since version 1.0 of the dune language
   [1]

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -3,6 +3,8 @@ public libraries may not have private dependencies
   $ dune build --display short --root private-dep
   Entering directory 'private-dep'
   File "dune", line 8, characters 12-22:
+   (libraries privatelib)
+              ^^^^^^^^^^
   Error: Library "privatelib" is private, it cannot be a dependency of a public library.
   You need to give "privatelib" a public name.
       ocamldep .publiclib.objs/publiclib.ml.d
@@ -27,6 +29,8 @@ Unless they introduce private runtime dependencies:
   $ dune build --display short --root private-runtime-deps
   Entering directory 'private-runtime-deps'
   File "jbuild", line 16, characters 20-31:
+    (preprocess (pps (private_ppx)))
+                      ^^^^^^^^^^^
   Error: Library "private_runtime_dep" is private, it cannot be a dependency of a public library.
   You need to give "private_runtime_dep" a public name.
         ocamlc .private_ppx.objs/private_ppx.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/quoting/run.t
+++ b/test/blackbox-tests/test-cases/quoting/run.t
@@ -4,6 +4,8 @@ that ${@} is not quoted and doesn't contain exactly 1 element
   $ dune build --root bad x
   Entering directory 'bad'
   File "dune", line 3, characters 27-35:
+   (action (with-stdout-to %{targets} (echo foo))))
+                             ^^^^^^^^
   Error: Variable %{targets} expands to 2 values, however a single value is expected here. Please quote this atom.
   [1]
 
@@ -27,10 +29,14 @@ The targets should only be interpreted as a single path when quoted
 
   $ dune build @quoted --root filename-space
   File "dune", line 4, characters 17-18:
+   (action (echo %{read:foo bar.txt})))
+                   ^
   Error: This character is not allowed inside %{...} forms
   [1]
 
   $ dune build @unquoted --root filename-space
   File "dune", line 4, characters 17-18:
+   (action (echo %{read:foo bar.txt})))
+                   ^
   Error: This character is not allowed inside %{...} forms
   [1]

--- a/test/blackbox-tests/test-cases/syntax-versioning/run.t
+++ b/test/blackbox-tests/test-cases/syntax-versioning/run.t
@@ -1,6 +1,8 @@
   $ echo '(jbuild_version 1)' > dune
   $ dune build
   File "dune", line 1, characters 0-18:
+  (jbuild_version 1)
+  ^^^^^^^^^^^^^^^^^^
   Error: 'jbuild_version' was deleted in version 1.0 of the dune language
   [1]
   $ rm -f dune
@@ -12,6 +14,8 @@
   $ echo '(executable (name x) (link_executables false))' > dune
   $ dune build
   File "dune", line 1, characters 21-45:
+  (executable (name x) (link_executables false))
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
   Error: 'link_executables' was deleted in version 1.0 of the dune language
   [1]
   $ rm -f dune
@@ -19,6 +23,8 @@
   $ echo '(alias (name x) (deps x) (action (run %{<})))' > dune
   $ dune build
   File "dune", line 1, characters 40-42:
+  (alias (name x) (deps x) (action (run %{<})))
+                                          ^^
   Error: %{<} was deleted in version 1.0 of the dune language.
   Use a named dependency instead:
   

--- a/test/blackbox-tests/test-cases/too-many-parens/run.t
+++ b/test/blackbox-tests/test-cases/too-many-parens/run.t
@@ -8,10 +8,14 @@ are readable.
 
   $ dune build --root b
   File "dune", line 4, characters 12-17:
+   (libraries (lib)))
+              ^^^^^
   These parentheses are no longer necessary with dune, please remove them.
   [1]
 
   $ dune build --root c
   File "dune", line 3, characters 7-14:
+   (deps (x y z)))
+         ^^^^^^^
   These parentheses are no longer necessary with dune, please remove them.
   [1]

--- a/test/blackbox-tests/test-cases/workspaces/run.t
+++ b/test/blackbox-tests/test-cases/workspaces/run.t
@@ -2,6 +2,8 @@ jbuild still discovers workspaces as usual
 
   $ jbuilder build --root jbuilder-default-name
   File "jbuild-workspace", line 1, characters 10-24:
+  (context (does-not-exist))
+            ^^^^^^^^^^^^^^
   Error: Unknown constructor does-not-exist
   [1]
 
@@ -14,6 +16,8 @@ dune uses a versioned file. If the version is missing, then we get an error.
 
   $ dune build --root dune-no-version
   File "dune-workspace", line 1, characters 0-19:
+  (context (default))
+  ^^^^^^^^^^^^^^^^^^^
   Error: Invalid first line, expected: (lang <lang> <version>)
   [1]
 


### PR DESCRIPTION
This is a simple implementation of an error printer that highlights the error location with tildes, for example:

    File "dune", line 1, characters 14-21:
    (copy_files %{read:x}/*)
                  ~~~~~~~

The message is not displayed in some cases, like if the file does not exist, or if the location spans multiple lines.