### PR TITLE
Simplify Result code with Combinators

### DIFF
--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -65,10 +65,10 @@ module Backend = struct
       { info
       ; lib
       ; runner_libraries =
-          Result.all (List.map info.runner_libraries ~f:resolve)
+          Result.List.all (List.map info.runner_libraries ~f:resolve)
       ; extends =
           let open Result.O in
-          Result.all
+          Result.List.all
             (List.map info.extends
                ~f:(fun ((loc, name) as x) ->
                  resolve x >>= fun lib ->
@@ -182,12 +182,12 @@ include Sub_system.Register_end_point(
 
       let runner_libs =
         let open Result.O in
-        Result.concat_map backends
+        Result.List.concat_map backends
           ~f:(fun (backend : Backend.t) -> backend.runner_libraries)
         >>= fun libs ->
         Lib.DB.find_many (Scope.libs scope) [lib.name]
         >>= fun lib ->
-        Result.all
+        Result.List.all
           (List.map info.libraries
              ~f:(Lib.DB.resolve (Scope.libs scope)))
         >>= fun more_libs ->

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -814,16 +814,26 @@ and resolve_user_deps db deps ~allow_private_deps ~pps ~stack =
         closure_with_overlap_checks None pps ~stack
       in
       let deps =
+        let rec check_runtime_deps acc pps = function
+          | [] -> loop acc pps
+          | lib :: ppx_rts ->
+            check_private_deps lib ~loc ~allow_private_deps >>= fun rt ->
+            check_runtime_deps (rt :: acc) pps ppx_rts
+        and loop acc = function
+          | [] -> Ok acc
+          | pp :: pps ->
+            pp.ppx_runtime_deps >>= fun rt_deps ->
+            check_runtime_deps acc pps rt_deps
+        in
         deps >>= fun deps ->
-        pps >>= Result.List.concat_map ~f:(fun pp -> pp.ppx_runtime_deps)
-        >>| List.rev_append deps
-        >>= Result.List.map ~f:(check_private_deps ~loc ~allow_private_deps)
+        pps  >>= fun pps  ->
+        loop deps pps
       in
       (deps, pps)
   in
   (deps, pps, resolved_selects)
 
-and closure_with_overlap_checks db ts ~stack =
+  and closure_with_overlap_checks db ts ~stack =
   let visited = ref String.Map.empty in
   let res = ref [] in
   let orig_stack = stack in

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -815,7 +815,7 @@ and resolve_user_deps db deps ~allow_private_deps ~pps ~stack =
       in
       let deps =
         deps >>= fun deps ->
-        pps >>= Result.concat_map ~f:(fun pp -> pp.ppx_runtime_deps)
+        pps >>= Result.List.concat_map ~f:(fun pp -> pp.ppx_runtime_deps)
         >>| List.rev_append deps
         >>= Result.List.map ~f:(check_private_deps ~loc ~allow_private_deps)
       in
@@ -859,10 +859,10 @@ and closure_with_overlap_checks db ts ~stack =
       >>= fun () ->
       Dep_stack.push stack (to_id t) >>= fun stack ->
       t.requires >>= fun deps ->
-      Result.iter deps ~f:(loop ~stack) >>| fun () ->
+      Result.List.iter deps ~f:(loop ~stack) >>| fun () ->
       res := t :: !res
   in
-  Result.iter ts ~f:(loop ~stack) >>| fun () ->
+  Result.List.iter ts ~f:(loop ~stack) >>| fun () ->
   List.rev !res
 
 let closure_with_overlap_checks db l =

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -575,7 +575,7 @@ module Dep_stack = struct
          }
 end
 
-let check_private_deps ~(lib : lib) ~loc ~allow_private_deps =
+let check_private_deps lib ~loc ~allow_private_deps =
   if (not allow_private_deps) && Status.is_private lib.info.status then
     Result.Error (Error (
       Private_deps_not_allowed { private_dep = lib ; pd_loc = loc }))
@@ -689,7 +689,7 @@ and resolve_dep db name ~allow_private_deps ~loc ~stack : t Or_exn.t =
   match find_internal db name ~stack with
   | St_initializing id ->
     Error (Dep_stack.dependency_cycle stack id)
-  | St_found lib -> check_private_deps ~lib ~loc ~allow_private_deps
+  | St_found lib -> check_private_deps lib ~loc ~allow_private_deps
   | St_not_found ->
     Error (Error (Library_not_available { loc; name; reason = Not_found }))
   | St_hidden (_, hidden) ->
@@ -819,20 +819,12 @@ and resolve_user_deps db deps ~allow_private_deps ~pps ~stack =
         closure_with_overlap_checks None pps ~stack
       in
       let deps =
-        let rec check_runtime_deps acc pps = function
-          | [] -> loop acc pps
-          | lib :: ppx_rts ->
-            check_private_deps ~lib ~loc ~allow_private_deps >>= fun rt ->
-            check_runtime_deps (rt :: acc) pps ppx_rts
-        and loop acc = function
-          | [] -> Ok acc
-          | pp :: pps ->
-            pp.ppx_runtime_deps >>= fun rt_deps ->
-            check_runtime_deps acc pps rt_deps
-        in
-        deps >>= fun deps ->
-        pps  >>= fun pps  ->
-        loop deps pps
+        (deps >>= fun deps ->
+         pps >>= Result.concat_map ~f:(fun pp -> pp.ppx_runtime_deps)
+         >>| fun pp_deps -> List.rev_append deps pp_deps)
+        >>= fun deps ->
+        List.map deps ~f:(check_private_deps ~loc ~allow_private_deps)
+        |> Result.all
       in
       (deps, pps)
   in

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -874,16 +874,10 @@ and closure_with_overlap_checks db ts ~stack =
       >>= fun () ->
       Dep_stack.push stack (to_id t) >>= fun stack ->
       t.requires >>= fun deps ->
-      iter deps ~stack >>| fun () ->
+      Result.iter deps ~f:(loop ~stack) >>| fun () ->
       res := t :: !res
-  and iter ts ~stack =
-    match ts with
-    | [] -> Ok ()
-    | t :: ts ->
-      loop t ~stack >>= fun () ->
-      iter ts ~stack
   in
-  iter ts ~stack >>| fun () ->
+  Result.iter ts ~f:(loop ~stack) >>| fun () ->
   List.rev !res
 
 let closure_with_overlap_checks db l =

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -85,7 +85,7 @@ module Driver = struct
       ; lib = lazy lib
       ; replaces =
           let open Result.O in
-          Result.all
+          Result.List.all
             (List.map info.replaces
                ~f:(fun ((loc, name) as x) ->
                  resolve x >>= fun lib ->

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -67,3 +67,14 @@ let rec iter t ~f =
     iter xs ~f
 
 type ('a, 'error) result = ('a, 'error) t
+
+module List = struct
+  let map t ~f =
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | x :: xs ->
+        f x >>= fun x ->
+        loop (x :: acc) xs
+    in
+    loop [] t
+end

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -59,4 +59,11 @@ let concat_map =
   in
   fun l ~f -> loop f [] l
 
+let rec iter t ~f =
+  match t with
+  | [] -> Ok ()
+  | x :: xs ->
+    f x >>= fun () ->
+    iter xs ~f
+
 type ('a, 'error) result = ('a, 'error) t

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -41,31 +41,6 @@ end
 
 open O
 
-let all =
-  let rec loop acc = function
-    | [] -> Ok (List.rev acc)
-    | t :: l ->
-      t >>= fun x ->
-      loop (x :: acc) l
-  in
-  fun l -> loop [] l
-
-let concat_map =
-  let rec loop f acc = function
-    | [] -> Ok (List.rev acc)
-    | x :: l ->
-      f x >>= fun y ->
-      loop f (List.rev_append y acc) l
-  in
-  fun l ~f -> loop f [] l
-
-let rec iter t ~f =
-  match t with
-  | [] -> Ok ()
-  | x :: xs ->
-    f x >>= fun () ->
-    iter xs ~f
-
 type ('a, 'error) result = ('a, 'error) t
 
 module List = struct
@@ -77,4 +52,29 @@ module List = struct
         loop (x :: acc) xs
     in
     loop [] t
+
+  let all =
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | t :: l ->
+        t >>= fun x ->
+        loop (x :: acc) l
+    in
+    fun l -> loop [] l
+
+  let concat_map =
+    let rec loop f acc = function
+      | [] -> Ok (List.rev acc)
+      | x :: l ->
+        f x >>= fun y ->
+        loop f (List.rev_append y acc) l
+    in
+    fun l ~f -> loop f [] l
+
+  let rec iter t ~f =
+    match t with
+    | [] -> Ok ()
+    | x :: xs ->
+      f x >>= fun () ->
+      iter xs ~f
 end

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -35,3 +35,7 @@ val errorf : ('a, unit, string, (_, string) t) format4 -> 'a
 
 (** For compatibility with some other code *)
 type ('a, 'error) result = ('a, 'error) t
+
+module List : sig
+  val map : 'a list -> f:('a -> ('b, 'e) t) -> ('b list, 'e) t
+end

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -23,6 +23,8 @@ val map_error : ('a, 'error1) t -> f:('error1 -> 'error2) -> ('a, 'error2) t
 
 val all : ('a, 'error) t list -> ('a list, 'error) t
 
+val iter : 'a list -> f:('a -> (unit, 'error) t) -> (unit, 'error) t
+
 val concat_map
   :  'a list
   -> f:('a -> ('b list, 'error) t)

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -21,15 +21,6 @@ val bind : ('a, 'error) t -> f:('a -> ('b, 'error) t) -> ('b, 'error) t
 
 val map_error : ('a, 'error1) t -> f:('error1 -> 'error2) -> ('a, 'error2) t
 
-val all : ('a, 'error) t list -> ('a list, 'error) t
-
-val iter : 'a list -> f:('a -> (unit, 'error) t) -> (unit, 'error) t
-
-val concat_map
-  :  'a list
-  -> f:('a -> ('b list, 'error) t)
-  -> ('b list, 'error) t
-
 (** Produce [Error <message>] *)
 val errorf : ('a, unit, string, (_, string) t) format4 -> 'a
 
@@ -38,4 +29,13 @@ type ('a, 'error) result = ('a, 'error) t
 
 module List : sig
   val map : 'a list -> f:('a -> ('b, 'e) t) -> ('b list, 'e) t
+
+  val all : ('a, 'error) t list -> ('a list, 'error) t
+
+  val iter : 'a list -> f:('a -> (unit, 'error) t) -> (unit, 'error) t
+
+  val concat_map
+    :  'a list
+    -> f:('a -> ('b list, 'error) t)
+    -> ('b list, 'error) t
 end

--- a/src/sub_system.ml
+++ b/src/sub_system.ml
@@ -107,7 +107,7 @@ module Register_backend(M : Backend) = struct
     let open Result.O in
     written_by_user_or_scan ~written_by_user ~to_scan
     >>= fun backends ->
-    wrap (Result.concat_map backends ~f:replaces)
+    wrap (Result.List.concat_map backends ~f:replaces)
     >>= fun replaced_backends ->
     match
       Set.diff (Set.of_list backends) (Set.of_list replaced_backends)
@@ -131,7 +131,7 @@ module Register_end_point(M : End_point) = struct
       (match M.Info.backends info with
        | None -> Ok None
        | Some l ->
-         Result.all (List.map l ~f:(M.Backend.resolve (Scope.libs c.scope)))
+         Result.List.all (List.map l ~f:(M.Backend.resolve (Scope.libs c.scope)))
          >>| Option.some)
       >>= fun written_by_user ->
       M.Backend.Selection_error.or_exn ~loc:(M.Info.loc info)


### PR DESCRIPTION
I realize that some of the old code was written with performance in mind, but `Result.List.map` should be efficient. I can revert the bits that look slow however.