### PR TITLE
Generate sorted .install files

### DIFF
--- a/src/stdune/option.ml
+++ b/src/stdune/option.ml
@@ -59,3 +59,10 @@ let equal eq x y =
   | Some _, None -> false
   | None, Some _ -> false
   | Some sx, Some sy -> eq sx sy
+
+let compare cmp x y =
+  match x, y with
+  | None, None -> Ordering.Eq
+  | Some _, None -> Gt
+  | None, Some _ -> Lt
+  | Some x, Some y -> cmp x y

--- a/src/stdune/option.mli
+++ b/src/stdune/option.mli
@@ -28,3 +28,5 @@ val both : 'a t -> 'b t -> ('a * 'b) t
 val to_list : 'a t -> 'a list
 
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val compare : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t

--- a/test/blackbox-tests/test-cases/cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation/run.t
@@ -27,15 +27,15 @@
   lib: [
     "_build/install/default.foo/lib/p/META" {"../../foo-sysroot/lib/p/META"}
     "_build/install/default.foo/lib/p/opam" {"../../foo-sysroot/lib/p/opam"}
-    "_build/install/default.foo/lib/p/p.cmi" {"../../foo-sysroot/lib/p/p.cmi"}
-    "_build/install/default.foo/lib/p/p.cmx" {"../../foo-sysroot/lib/p/p.cmx"}
-    "_build/install/default.foo/lib/p/p.cmt" {"../../foo-sysroot/lib/p/p.cmt"}
-    "_build/install/default.foo/lib/p/p.ml" {"../../foo-sysroot/lib/p/p.ml"}
-    "_build/install/default.foo/lib/p/p.cma" {"../../foo-sysroot/lib/p/p.cma"}
-    "_build/install/default.foo/lib/p/p.cmxa" {"../../foo-sysroot/lib/p/p.cmxa"}
     "_build/install/default.foo/lib/p/p$ext_lib" {"../../foo-sysroot/lib/p/p$ext_lib"}
+    "_build/install/default.foo/lib/p/p.cma" {"../../foo-sysroot/lib/p/p.cma"}
+    "_build/install/default.foo/lib/p/p.cmi" {"../../foo-sysroot/lib/p/p.cmi"}
+    "_build/install/default.foo/lib/p/p.cmt" {"../../foo-sysroot/lib/p/p.cmt"}
+    "_build/install/default.foo/lib/p/p.cmx" {"../../foo-sysroot/lib/p/p.cmx"}
+    "_build/install/default.foo/lib/p/p.cmxa" {"../../foo-sysroot/lib/p/p.cmxa"}
     "_build/install/default.foo/lib/p/p.cmxs" {"../../foo-sysroot/lib/p/p.cmxs"}
     "_build/install/default.foo/lib/p/p.dune" {"../../foo-sysroot/lib/p/p.dune"}
+    "_build/install/default.foo/lib/p/p.ml" {"../../foo-sysroot/lib/p/p.ml"}
   ]
   bin: [
     "_build/install/default.foo/bin/blah" {"../foo-sysroot/bin/blah"}

--- a/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
+++ b/test/blackbox-tests/test-cases/gen-opam-install-file/run.t
@@ -1,48 +1,48 @@
   $ dune runtest
   lib: [
     "_build/install/default/lib/foo/META" {"META"}
-    "_build/install/default/lib/foo/opam" {"opam"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmi" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmi"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmx" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmx"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmt" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmt"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.ml" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.ml"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cma" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cma"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxa" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxa"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild$ext_lib" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild$ext_lib"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxs" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxs"}
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo.ppx_rewriter_jbuild.dune" {"ppx_rewriter_jbuild/foo.ppx_rewriter_jbuild.dune"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmi" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmi"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmx" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmx"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmt" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmt"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.ml" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.ml"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cma" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cma"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxa" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxa"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune$ext_lib" {"ppx_rewriter_dune/foo_ppx_rewriter_dune$ext_lib"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxs" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxs"}
-    "_build/install/default/lib/foo/ppx_rewriter_dune/foo.ppx_rewriter_dune.dune" {"ppx_rewriter_dune/foo.ppx_rewriter_dune.dune"}
-    "_build/install/default/lib/foo/foo.cmi" {"foo.cmi"}
-    "_build/install/default/lib/foo/foo.cmx" {"foo.cmx"}
-    "_build/install/default/lib/foo/foo.cmt" {"foo.cmt"}
-    "_build/install/default/lib/foo/foo.cmti" {"foo.cmti"}
-    "_build/install/default/lib/foo/foo.mli" {"foo.mli"}
-    "_build/install/default/lib/foo/foo.ml" {"foo.ml"}
-    "_build/install/default/lib/foo/foo.cma" {"foo.cma"}
-    "_build/install/default/lib/foo/libfoo_stubs$ext_lib" {"libfoo_stubs$ext_lib"}
-    "_build/install/default/lib/foo/foo.cmxa" {"foo.cmxa"}
-    "_build/install/default/lib/foo/foo$ext_lib" {"foo$ext_lib"}
-    "_build/install/default/lib/foo/foo.cmxs" {"foo.cmxs"}
-    "_build/install/default/lib/foo/foo.js" {"foo.js"}
-    "_build/install/default/lib/foo/cfoo.h" {"cfoo.h"}
-    "_build/install/default/lib/foo/foo.dune" {"foo.dune"}
+    "_build/install/default/lib/foo/byte/foo.byte.dune" {"byte/foo.byte.dune"}
+    "_build/install/default/lib/foo/byte/foo_byte.cma" {"byte/foo_byte.cma"}
     "_build/install/default/lib/foo/byte/foo_byte.cmi" {"byte/foo_byte.cmi"}
     "_build/install/default/lib/foo/byte/foo_byte.cmt" {"byte/foo_byte.cmt"}
     "_build/install/default/lib/foo/byte/foo_byte.ml" {"byte/foo_byte.ml"}
-    "_build/install/default/lib/foo/byte/foo_byte.cma" {"byte/foo_byte.cma"}
-    "_build/install/default/lib/foo/byte/foo.byte.dune" {"byte/foo.byte.dune"}
+    "_build/install/default/lib/foo/cfoo.h" {"cfoo.h"}
+    "_build/install/default/lib/foo/foo$ext_lib" {"foo$ext_lib"}
+    "_build/install/default/lib/foo/foo.cma" {"foo.cma"}
+    "_build/install/default/lib/foo/foo.cmi" {"foo.cmi"}
+    "_build/install/default/lib/foo/foo.cmt" {"foo.cmt"}
+    "_build/install/default/lib/foo/foo.cmti" {"foo.cmti"}
+    "_build/install/default/lib/foo/foo.cmx" {"foo.cmx"}
+    "_build/install/default/lib/foo/foo.cmxa" {"foo.cmxa"}
+    "_build/install/default/lib/foo/foo.cmxs" {"foo.cmxs"}
+    "_build/install/default/lib/foo/foo.dune" {"foo.dune"}
+    "_build/install/default/lib/foo/foo.js" {"foo.js"}
+    "_build/install/default/lib/foo/foo.ml" {"foo.ml"}
+    "_build/install/default/lib/foo/foo.mli" {"foo.mli"}
+    "_build/install/default/lib/foo/libfoo_stubs$ext_lib" {"libfoo_stubs$ext_lib"}
+    "_build/install/default/lib/foo/opam" {"opam"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo.ppx_rewriter_dune.dune" {"ppx_rewriter_dune/foo.ppx_rewriter_dune.dune"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune$ext_lib" {"ppx_rewriter_dune/foo_ppx_rewriter_dune$ext_lib"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cma" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cma"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmi" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmi"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmt" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmt"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmx" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmx"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxa" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxa"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxs" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.cmxs"}
+    "_build/install/default/lib/foo/ppx_rewriter_dune/foo_ppx_rewriter_dune.ml" {"ppx_rewriter_dune/foo_ppx_rewriter_dune.ml"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo.ppx_rewriter_jbuild.dune" {"ppx_rewriter_jbuild/foo.ppx_rewriter_jbuild.dune"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild$ext_lib" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild$ext_lib"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cma" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cma"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmi" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmi"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmt" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmt"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmx" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmx"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxa" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxa"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxs" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.cmxs"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.ml" {"ppx_rewriter_jbuild/foo_ppx_rewriter_jbuild.ml"}
   ]
   libexec: [
-    "_build/install/default/lib/foo/ppx_rewriter_jbuild/ppx.exe" {"ppx_rewriter_jbuild/ppx.exe"}
     "_build/install/default/lib/foo/ppx_rewriter_dune/ppx.exe" {"ppx_rewriter_dune/ppx.exe"}
+    "_build/install/default/lib/foo/ppx_rewriter_jbuild/ppx.exe" {"ppx_rewriter_jbuild/ppx.exe"}
   ]
   bin: [
     "_build/install/default/bin/bar" {"bar"}

--- a/test/blackbox-tests/test-cases/reason/run.t
+++ b/test/blackbox-tests/test-cases/reason/run.t
@@ -65,44 +65,44 @@
         ocamlc rlib.cma
   lib: [
     "_build/install/default/lib/rlib/META" {"META"}
-    "_build/install/default/lib/rlib/opam" {"opam"}
-    "_build/install/default/lib/rlib/rlib__Bar.cmi" {"rlib__Bar.cmi"}
-    "_build/install/default/lib/rlib/rlib__Bar.cmx" {"rlib__Bar.cmx"}
-    "_build/install/default/lib/rlib/rlib__Bar.cmt" {"rlib__Bar.cmt"}
-    "_build/install/default/lib/rlib/rlib__Bar.cmti" {"rlib__Bar.cmti"}
     "_build/install/default/lib/rlib/bar.mli" {"bar.mli"}
     "_build/install/default/lib/rlib/bar.re" {"bar.re"}
-    "_build/install/default/lib/rlib/rlib__Cppome.cmi" {"rlib__Cppome.cmi"}
-    "_build/install/default/lib/rlib/rlib__Cppome.cmx" {"rlib__Cppome.cmx"}
-    "_build/install/default/lib/rlib/rlib__Cppome.cmt" {"rlib__Cppome.cmt"}
-    "_build/install/default/lib/rlib/rlib__Cppome.cmti" {"rlib__Cppome.cmti"}
-    "_build/install/default/lib/rlib/cppome.rei" {"cppome.rei"}
     "_build/install/default/lib/rlib/cppome.re" {"cppome.re"}
-    "_build/install/default/lib/rlib/rlib__Foo.cmi" {"rlib__Foo.cmi"}
-    "_build/install/default/lib/rlib/rlib__Foo.cmx" {"rlib__Foo.cmx"}
-    "_build/install/default/lib/rlib/rlib__Foo.cmt" {"rlib__Foo.cmt"}
-    "_build/install/default/lib/rlib/rlib__Foo.cmti" {"rlib__Foo.cmti"}
-    "_build/install/default/lib/rlib/foo.rei" {"foo.rei"}
+    "_build/install/default/lib/rlib/cppome.rei" {"cppome.rei"}
     "_build/install/default/lib/rlib/foo.ml" {"foo.ml"}
-    "_build/install/default/lib/rlib/rlib__Hello.cmi" {"rlib__Hello.cmi"}
-    "_build/install/default/lib/rlib/rlib__Hello.cmx" {"rlib__Hello.cmx"}
-    "_build/install/default/lib/rlib/rlib__Hello.cmt" {"rlib__Hello.cmt"}
-    "_build/install/default/lib/rlib/rlib__Hello.cmti" {"rlib__Hello.cmti"}
-    "_build/install/default/lib/rlib/hello.rei" {"hello.rei"}
+    "_build/install/default/lib/rlib/foo.rei" {"foo.rei"}
     "_build/install/default/lib/rlib/hello.re" {"hello.re"}
-    "_build/install/default/lib/rlib/rlib__Pped.cmi" {"rlib__Pped.cmi"}
-    "_build/install/default/lib/rlib/rlib__Pped.cmx" {"rlib__Pped.cmx"}
-    "_build/install/default/lib/rlib/rlib__Pped.cmt" {"rlib__Pped.cmt"}
-    "_build/install/default/lib/rlib/rlib__Pped.cmti" {"rlib__Pped.cmti"}
-    "_build/install/default/lib/rlib/pped.rei" {"pped.rei"}
+    "_build/install/default/lib/rlib/hello.rei" {"hello.rei"}
+    "_build/install/default/lib/rlib/opam" {"opam"}
     "_build/install/default/lib/rlib/pped.re" {"pped.re"}
-    "_build/install/default/lib/rlib/rlib.cmi" {"rlib.cmi"}
-    "_build/install/default/lib/rlib/rlib.cmx" {"rlib.cmx"}
-    "_build/install/default/lib/rlib/rlib.cmt" {"rlib.cmt"}
-    "_build/install/default/lib/rlib/rlib.ml-gen" {"rlib.ml-gen"}
-    "_build/install/default/lib/rlib/rlib.cma" {"rlib.cma"}
-    "_build/install/default/lib/rlib/rlib.cmxa" {"rlib.cmxa"}
+    "_build/install/default/lib/rlib/pped.rei" {"pped.rei"}
     "_build/install/default/lib/rlib/rlib$ext_lib" {"rlib$ext_lib"}
+    "_build/install/default/lib/rlib/rlib.cma" {"rlib.cma"}
+    "_build/install/default/lib/rlib/rlib.cmi" {"rlib.cmi"}
+    "_build/install/default/lib/rlib/rlib.cmt" {"rlib.cmt"}
+    "_build/install/default/lib/rlib/rlib.cmx" {"rlib.cmx"}
+    "_build/install/default/lib/rlib/rlib.cmxa" {"rlib.cmxa"}
     "_build/install/default/lib/rlib/rlib.cmxs" {"rlib.cmxs"}
     "_build/install/default/lib/rlib/rlib.dune" {"rlib.dune"}
+    "_build/install/default/lib/rlib/rlib.ml-gen" {"rlib.ml-gen"}
+    "_build/install/default/lib/rlib/rlib__Bar.cmi" {"rlib__Bar.cmi"}
+    "_build/install/default/lib/rlib/rlib__Bar.cmt" {"rlib__Bar.cmt"}
+    "_build/install/default/lib/rlib/rlib__Bar.cmti" {"rlib__Bar.cmti"}
+    "_build/install/default/lib/rlib/rlib__Bar.cmx" {"rlib__Bar.cmx"}
+    "_build/install/default/lib/rlib/rlib__Cppome.cmi" {"rlib__Cppome.cmi"}
+    "_build/install/default/lib/rlib/rlib__Cppome.cmt" {"rlib__Cppome.cmt"}
+    "_build/install/default/lib/rlib/rlib__Cppome.cmti" {"rlib__Cppome.cmti"}
+    "_build/install/default/lib/rlib/rlib__Cppome.cmx" {"rlib__Cppome.cmx"}
+    "_build/install/default/lib/rlib/rlib__Foo.cmi" {"rlib__Foo.cmi"}
+    "_build/install/default/lib/rlib/rlib__Foo.cmt" {"rlib__Foo.cmt"}
+    "_build/install/default/lib/rlib/rlib__Foo.cmti" {"rlib__Foo.cmti"}
+    "_build/install/default/lib/rlib/rlib__Foo.cmx" {"rlib__Foo.cmx"}
+    "_build/install/default/lib/rlib/rlib__Hello.cmi" {"rlib__Hello.cmi"}
+    "_build/install/default/lib/rlib/rlib__Hello.cmt" {"rlib__Hello.cmt"}
+    "_build/install/default/lib/rlib/rlib__Hello.cmti" {"rlib__Hello.cmti"}
+    "_build/install/default/lib/rlib/rlib__Hello.cmx" {"rlib__Hello.cmx"}
+    "_build/install/default/lib/rlib/rlib__Pped.cmi" {"rlib__Pped.cmi"}
+    "_build/install/default/lib/rlib/rlib__Pped.cmt" {"rlib__Pped.cmt"}
+    "_build/install/default/lib/rlib/rlib__Pped.cmti" {"rlib__Pped.cmti"}
+    "_build/install/default/lib/rlib/rlib__Pped.cmx" {"rlib__Pped.cmx"}
   ]


### PR DESCRIPTION
An upcoming diff ends up accidentally changing the order of artifacts. It would be better if this order was deterministic and independent of how we generate the list of entries.