### PR TITLE
[WIP] Use Lib in installation

### DIFF
--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -147,6 +147,7 @@ module Gen(P : Params) = struct
         Module.Name.Map.values modules
       in
       let archives = Lib.archives lib' in
+      let foreign_archives = Lib.foreign_archives lib' in
       List.concat
         [ List.concat_map modules ~f:(fun m ->
             List.concat
@@ -159,8 +160,7 @@ module Gen(P : Params) = struct
                   | Some f -> Some f.path)
               ])
         ; if_ byte (Mode.Dict.get archives Mode.Byte)
-        ; if_ (Library.has_stubs lib)
-            [ Library.stubs_archive ~dir lib ~ext_lib:ctx.ext_lib ]
+        ; if_ byte (Mode.Dict.get foreign_archives Mode.Byte)
         ; if_ native
             (let files =
                (Library.archive ~dir lib ~ext:ctx.ext_lib)

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -117,6 +117,7 @@ module Gen(P : Params) = struct
 
   let lib_install_files ~dir_contents ~dir ~sub_dir ~name ~scope ~dir_kind
         (lib : Library.t) =
+    let lib' = Lib.DB.find_exn (Scope.libs scope) (Library.best_name lib) in
     let obj_dir = Utils.library_object_directory ~dir lib.name in
     let make_entry section ?dst fn =
       Install.Entry.make section fn
@@ -168,7 +169,7 @@ module Gen(P : Params) = struct
                ; Library.archive ~dir lib ~ext:ctx.ext_lib
                ]
              in
-             if ctx.natdynlink_supported && lib.dynlink then
+             if ctx.natdynlink_supported && Lib.dynlink lib' then
                files @ [ Library.archive ~dir lib ~ext:".cmxs" ]
              else
                files)
@@ -178,7 +179,7 @@ module Gen(P : Params) = struct
         ]
     in
     let dlls  =
-      if_ (byte && Library.has_stubs lib && lib.dynlink)
+      if_ (byte && Library.has_stubs lib && Lib.dynlink lib')
         [Library.dll ~dir lib ~ext_dll:ctx.ext_dll]
     in
     let execs =

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -140,7 +140,7 @@ module Gen(P : Params) = struct
       let modules =
         let { Dir_contents.Library_modules.modules; alias_module; _ } =
           Dir_contents.modules_of_library dir_contents
-            ~name:(Library.best_name lib)
+            ~name:(Lib.name lib')
         in
         let modules =
           match alias_module with

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -131,10 +131,7 @@ module Gen(P : Params) = struct
           | None -> dst
           | Some dir -> sprintf "%s/%s" dir dst)
     in
-    let { Mode.Dict.byte; native } =
-      Mode_conf.Set.eval lib.modes
-        ~has_native:(Option.is_some ctx.ocamlopt)
-    in
+    let { Mode.Dict.byte; native } = Lib.modes lib' in
     let if_ cond l = if cond then l else [] in
     let files =
       let modules =

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -116,7 +116,7 @@ module Gen(P : Params) = struct
            Build.write_file_dyn meta)))
 
   let lib_install_files ~dir_contents ~dir ~sub_dir ~name ~scope ~dir_kind
-        (lib : Library.t) =
+        (lib : Lib.t) =
     let lib' = Lib.DB.find_exn (Scope.libs scope) (Library.best_name lib) in
     let obj_dir = Utils.library_object_directory ~dir lib.name in
     let make_entry section ?dst fn =
@@ -181,10 +181,7 @@ module Gen(P : Params) = struct
         ; Lib.headers lib'
         ]
     in
-    let dlls  =
-      if_ (byte && Library.has_stubs lib && Lib.dynlink lib')
-        [Library.dll ~dir lib ~ext_dll:ctx.ext_dll]
-    in
+    let dlls = if_ byte (Option.to_list (Lib.dll lib')) in
     let execs =
       match lib.kind with
       | Normal | Ppx_deriver -> []

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -170,7 +170,7 @@ module Gen(P : Params) = struct
                files @ (Mode.Dict.get (Lib.plugins lib') Native)
              else
                files)
-        ; List.map lib.buildable.js_of_ocaml.javascript_files ~f:(Path.relative dir)
+        ; Lib.jsoo_runtime lib'
         ; List.map lib.install_c_headers ~f:(fun fn ->
             Path.relative dir (fn ^ ".h"))
         ]

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -171,8 +171,7 @@ module Gen(P : Params) = struct
              else
                files)
         ; Lib.jsoo_runtime lib'
-        ; List.map lib.install_c_headers ~f:(fun fn ->
-            Path.relative dir (fn ^ ".h"))
+        ; Lib.headers lib'
         ]
     in
     let dlls  =

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -67,6 +67,7 @@ module Info = struct
     ; sub_systems      : Dune_file.Sub_system_info.t Sub_system_name.Map.t
     ; dynlink          : bool
     ; modes            : Mode.Dict.Set.t
+    ; headers          : Path.t list
     }
 
   let user_written_deps t =
@@ -120,6 +121,8 @@ module Info = struct
     ; dune_version = Some conf.dune_version
     ; dynlink = conf.dynlink
     ; modes = Dune_file.Mode_conf.Set.eval ~has_native conf.modes
+    ; headers = List.map conf.install_c_headers ~f:(fun fn ->
+      Path.relative dir (fn ^ ".h"))
     }
 
   let of_findlib_package pkg =
@@ -152,6 +155,7 @@ module Info = struct
     ; dune_version = None
     ; dynlink = true
     ; modes = Mode.Dict.Set.empty
+    ; headers = []
     }
 end
 
@@ -345,6 +349,7 @@ let dune_version t = t.info.dune_version
 
 let dynlink t = t.info.dynlink
 let modes t = t.info.modes
+let headers t = t.info.headers
 
 let src_dir t = t.info.src_dir
 let obj_dir t = t.info.obj_dir

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -358,6 +358,8 @@ let is_local t = Path.is_managed t.info.obj_dir
 
 let status t = t.info.status
 
+let foreign_archives t = t.info.foreign_archives
+
 let package t =
   match t.info.status with
   | Installed ->

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -65,6 +65,7 @@ module Info = struct
     ; virtual_deps     : (Loc.t * string) list
     ; dune_version : Syntax.Version.t option
     ; sub_systems      : Dune_file.Sub_system_info.t Sub_system_name.Map.t
+    ; dynlink          : bool
     }
 
   let user_written_deps t =
@@ -116,6 +117,7 @@ module Info = struct
     ; pps = Dune_file.Preprocess_map.pps conf.buildable.preprocess
     ; sub_systems = conf.sub_systems
     ; dune_version = Some conf.dune_version
+    ; dynlink = conf.dynlink
     }
 
   let of_findlib_package pkg =
@@ -146,6 +148,7 @@ module Info = struct
       foreign_archives = Mode.Dict.make_both []
     ; sub_systems      = sub_systems
     ; dune_version = None
+    ; dynlink = true
     }
 end
 
@@ -336,6 +339,8 @@ let jsoo_runtime t = t.info.jsoo_runtime
 let unique_id    t = t.unique_id
 
 let dune_version t = t.info.dune_version
+
+let dynlink t = t.info.dynlink
 
 let src_dir t = t.info.src_dir
 let obj_dir t = t.info.obj_dir
@@ -1011,6 +1016,15 @@ module DB = struct
         |> List.map ~f:Findlib.Package.name)
 
   let find = find
+
+  let find_exn t name =
+    match find t name with
+    | Ok lib -> lib
+    | Error reason ->
+      raise (Error (Library_not_available { reason
+                                          ; loc = Loc.none
+                                          ; name }))
+
   let find_even_when_hidden = find_even_when_hidden
 
   let resolve t (loc, name) =

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -31,6 +31,7 @@ val modes : t -> Mode.Dict.Set.t
 val headers : t -> Path.t list
 
 val foreign_archives : t -> Path.t list Mode.Dict.t
+val dll : t -> Path.t option
 
 val dune_version : t -> Syntax.Version.t option
 
@@ -116,11 +117,13 @@ module Info : sig
     ; dynlink          : bool
     ; modes            : Mode.Dict.Set.t
     ; headers          : Path.t list
+    ; dll              : Path.t option
     }
 
   val of_library_stanza
     : dir:Path.t
     -> ext_lib:string
+    -> ext_dll:string
     -> has_native:bool
     -> Dune_file.Library.t
     -> t
@@ -273,6 +276,7 @@ module DB : sig
   val create_from_library_stanzas
     :  ?parent:t
     -> ext_lib:string
+    -> ext_dll:string
     -> has_native:bool
     -> (Path.t * Dune_file.Library.t) list
     -> t

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -26,6 +26,8 @@ val archives     : t -> Path.t list Mode.Dict.t
 val plugins      : t -> Path.t list Mode.Dict.t
 val jsoo_runtime : t -> Path.t list
 
+val dynlink : t -> bool
+
 val dune_version : t -> Syntax.Version.t option
 
 (** A unique integer identifier. It is only unique for the duration of
@@ -107,6 +109,7 @@ module Info : sig
     ; virtual_deps     : (Loc.t * string) list
     ; dune_version : Syntax.Version.t option
     ; sub_systems      : Dune_file.Sub_system_info.t Sub_system_name.Map.t
+    ; dynlink : bool
     }
 
   val of_library_stanza
@@ -272,6 +275,7 @@ module DB : sig
     -> t
 
   val find : t -> string -> (lib, Error.Library_not_available.Reason.t) result
+  val find_exn : t -> string -> lib
   val find_many
     :  t
     -> string list

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -28,6 +28,7 @@ val jsoo_runtime : t -> Path.t list
 
 val dynlink : t -> bool
 val modes : t -> Mode.Dict.Set.t
+val headers : t -> Path.t list
 
 val dune_version : t -> Syntax.Version.t option
 
@@ -110,8 +111,9 @@ module Info : sig
     ; virtual_deps     : (Loc.t * string) list
     ; dune_version : Syntax.Version.t option
     ; sub_systems      : Dune_file.Sub_system_info.t Sub_system_name.Map.t
-    ; dynlink : bool
-    ; modes : Mode.Dict.Set.t
+    ; dynlink          : bool
+    ; modes            : Mode.Dict.Set.t
+    ; headers          : Path.t list
     }
 
   val of_library_stanza

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -27,6 +27,7 @@ val plugins      : t -> Path.t list Mode.Dict.t
 val jsoo_runtime : t -> Path.t list
 
 val dynlink : t -> bool
+val modes : t -> Mode.Dict.Set.t
 
 val dune_version : t -> Syntax.Version.t option
 
@@ -110,11 +111,13 @@ module Info : sig
     ; dune_version : Syntax.Version.t option
     ; sub_systems      : Dune_file.Sub_system_info.t Sub_system_name.Map.t
     ; dynlink : bool
+    ; modes : Mode.Dict.Set.t
     }
 
   val of_library_stanza
     : dir:Path.t
     -> ext_lib:string
+    -> has_native:bool
     -> Dune_file.Library.t
     -> t
 
@@ -266,6 +269,7 @@ module DB : sig
   val create_from_library_stanzas
     :  ?parent:t
     -> ext_lib:string
+    -> has_native:bool
     -> (Path.t * Dune_file.Library.t) list
     -> t
 

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -30,6 +30,8 @@ val dynlink : t -> bool
 val modes : t -> Mode.Dict.Set.t
 val headers : t -> Path.t list
 
+val foreign_archives : t -> Path.t list Mode.Dict.t
+
 val dune_version : t -> Syntax.Version.t option
 
 (** A unique integer identifier. It is only unique for the duration of

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -62,6 +62,11 @@ module Dict = struct
       ; native = true
       }
 
+    let empty =
+      { byte = false
+      ; native = true
+      }
+
     let to_list t =
       let l = [] in
       let l = if t.native then Native :: l else l in

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -35,6 +35,11 @@ module Dict = struct
     ; native : 'a
     }
 
+  let map t ~f =
+    { byte = f t.byte
+    ; native = f t.native
+    }
+
   let get t = function
     | Byte   -> t.byte
     | Native -> t.native

--- a/src/mode.mli
+++ b/src/mode.mli
@@ -24,6 +24,8 @@ module Dict : sig
     ; native : 'a
     }
 
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+
   val get : 'a t -> mode -> 'a
 
   val of_func : (mode:mode -> 'a) -> 'a t

--- a/src/mode.mli
+++ b/src/mode.mli
@@ -37,6 +37,7 @@ module Dict : sig
     type nonrec t = bool t
     val t : t Sexp.Of_sexp.t
     val all : t
+    val empty : t
     val is_empty : t -> bool
     val to_list : t -> mode list
     val of_list : mode list -> t

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -50,7 +50,8 @@ module DB = struct
             (Project_name_map.keys t.by_name)
         ]
 
-  let create ~projects ~context ~installed_libs ~ext_lib ~has_native internal_libs =
+  let create ~projects ~context ~installed_libs ~ext_lib ~ext_dll
+        ~has_native internal_libs =
     let projects_by_name =
       List.map projects ~f:(fun (project : Dune_project.t) ->
         (project.name, project))
@@ -120,7 +121,7 @@ module DB = struct
           let libs = Option.value libs ~default:[] in
           let db =
             Lib.DB.create_from_library_stanzas libs ~parent:public_libs
-              ~ext_lib ~has_native
+              ~ext_lib ~ext_dll ~has_native
           in
           let root = Path.append_local build_context_dir project.root in
           Some { project; db; root })

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -50,7 +50,7 @@ module DB = struct
             (Project_name_map.keys t.by_name)
         ]
 
-  let create ~projects ~context ~installed_libs ~ext_lib internal_libs =
+  let create ~projects ~context ~installed_libs ~ext_lib ~has_native internal_libs =
     let projects_by_name =
       List.map projects ~f:(fun (project : Dune_project.t) ->
         (project.name, project))
@@ -119,7 +119,8 @@ module DB = struct
           let project = Option.value_exn project in
           let libs = Option.value libs ~default:[] in
           let db =
-            Lib.DB.create_from_library_stanzas libs ~parent:public_libs ~ext_lib
+            Lib.DB.create_from_library_stanzas libs ~parent:public_libs
+              ~ext_lib ~has_native
           in
           let root = Path.append_local build_context_dir project.root in
           Some { project; db; root })

--- a/src/scope.mli
+++ b/src/scope.mli
@@ -26,6 +26,7 @@ module DB : sig
     -> context:string
     -> installed_libs:Lib.DB.t
     -> ext_lib:string
+    -> ext_dll:string
     -> has_native:bool
     -> (Path.t * Dune_file.Library.t) list
     -> t * Lib.DB.t

--- a/src/scope.mli
+++ b/src/scope.mli
@@ -26,6 +26,7 @@ module DB : sig
     -> context:string
     -> installed_libs:Lib.DB.t
     -> ext_lib:string
+    -> has_native:bool
     -> (Path.t * Dune_file.Library.t) list
     -> t * Lib.DB.t
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -509,6 +509,7 @@ let create
   in
   let scopes, public_libs =
     Scope.DB.create
+      ~has_native:(Option.is_some context.ocamlopt)
       ~projects
       ~context:context.name
       ~installed_libs

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -514,6 +514,7 @@ let create
       ~context:context.name
       ~installed_libs
       ~ext_lib:context.ext_lib
+      ~ext_dll:context.ext_dll
       internal_libs
   in
   let stanzas =


### PR DESCRIPTION
I've tried refactoring the installation rules to use Lib.t instead of Library. The advantages of this being there's only one access path for the artifacts of a library. Unfortunately, it seems like the new code isn't nearly as compact as before.

I still think it would be really nice to have a single code path for accessing archives in the install and library rules, but something is missing to make it usable. Suggestions would be welcome.