### PR TITLE
Make parsing context a type variable

### DIFF
--- a/src/binary_kind.mli
+++ b/src/binary_kind.mli
@@ -7,7 +7,7 @@ type t =
   | Object
   | Shared_object
 
-val t : t Sexp.Of_sexp.t
+val t : (t, _) Sexp.Of_sexp.t
 
 val sexp_of_t : t Sexp.To_sexp.t
 

--- a/src/config.mli
+++ b/src/config.mli
@@ -32,7 +32,7 @@ module Display : sig
     | Verbose  (** Display all commands fully     *)
     | Quiet    (** Only display errors            *)
 
-  val t : t Sexp.Of_sexp.t
+  val t : (t, _) Sexp.Of_sexp.t
   val all : (string * t) list
 end
 
@@ -58,7 +58,7 @@ include S with type 'a field = 'a
 
 module Partial : S with type 'a field := 'a option
 
-val t : t Sexp.Of_sexp.t
+val t : (t, _) Sexp.Of_sexp.t
 
 val merge : t -> Partial.t -> t
 

--- a/src/install.mli
+++ b/src/install.mli
@@ -19,7 +19,7 @@ module Section : sig
     | Man
     | Misc
 
-  val t : t Sexp.Of_sexp.t
+  val t : (t, _) Sexp.Of_sexp.t
 
   (** [true] iff the executable bit should be set for files installed
       in this location. *)

--- a/src/package.mli
+++ b/src/package.mli
@@ -13,7 +13,7 @@ module Name : sig
 
   include Interned.S with type t := t
 
-  val t : t Sexp.Of_sexp.t
+  val t : (t, _) Sexp.Of_sexp.t
 
   module Infix : Comparable.OPS with type t = t
 end

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -26,7 +26,7 @@ end
 
 type t
 
-val t : t Sexp.Of_sexp.t
+val t : (t, _) Sexp.Of_sexp.t
 val sexp_of_t : t Sexp.To_sexp.t
 
 val compare : t -> t -> Ordering.t

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -110,14 +110,14 @@ module Of_sexp = struct
      - the first atom when parsing a constructor or a field
      - the universal map holding the user context
   *)
-  type 'kind context =
-    | Values : Loc.t * string option * Univ_map.t -> values context
-    | Fields : Loc.t * string option * Univ_map.t -> fields context
+  type ('kind, 'ctx) context =
+    | Values : Loc.t * string option * 'ctx -> (values, 'ctx) context
+    | Fields : Loc.t * string option * 'ctx -> (fields, 'ctx) context
 
-  type ('a, 'kind) parser =  'kind context -> 'kind -> 'a * 'kind
+  type ('a, 'kind, 'ctx) parser =  ('kind, 'ctx) context -> 'kind -> 'a * 'kind
 
-  type 'a t             = ('a, values) parser
-  type 'a fields_parser = ('a, fields) parser
+  type ('a, 'ctx) t             = ('a, values, 'ctx) parser
+  type ('a, 'ctx) fields_parser = ('a, fields, 'ctx) parser
 
   let return x _ctx state = (x, state)
   let (>>=) t f ctx state =
@@ -137,7 +137,7 @@ module Of_sexp = struct
     with exn ->
       f exn ctx state
 
-  let get_user_context : type k. k context -> Univ_map.t = function
+  let get_user_context : type k. (k, 'ctx) context -> 'ctx = function
     | Values (_, _, uc) -> uc
     | Fields (_, _, uc) -> uc
 

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -1,36 +1,8 @@
 include module type of struct include Usexp end with module Loc := Usexp.Loc
 
-module type Combinators = sig
-  type 'a t
-  val unit       : unit                      t
-
-  val string     : string                    t
-  (** Convert an [Atom] or a [Quoted_string] from/to a string. *)
-
-  val int        : int                       t
-  val float      : float                     t
-  val bool       : bool                      t
-  val pair       : 'a t -> 'b t -> ('a * 'b) t
-  val triple     : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
-  val list       : 'a t -> 'a list           t
-  val array      : 'a t -> 'a array          t
-  val option     : 'a t -> 'a option         t
-
-  val string_set : String.Set.t            t
-  (** [atom_set] is a conversion to/from a set of strings representing atoms. *)
-
-  val string_map : 'a t -> 'a String.Map.t   t
-  (** [atom_map conv]: given a conversion [conv] to/from ['a], returns
-     a conversion to/from a map where the keys are atoms and the
-     values are of type ['a]. *)
-
-  val string_hashtbl : 'a t -> (string, 'a) Hashtbl.t t
-  (** [atom_hashtbl conv] is similar to [atom_map] for hash tables. *)
-end
-
 module To_sexp : sig
   type sexp = t
-  include Combinators with type 'a t = 'a -> t
+  include Sexp_intf.Combinators.S with type 'a t = 'a -> t
 
   val record : (string * sexp) list -> sexp
 
@@ -87,73 +59,99 @@ module Of_sexp : sig
       It is possible to switch between the two mode at any time using
       the appropriate combinator. Some primitives can be used in both
       mode while some are specific to one mode.  *)
-  type ('a, 'kind) parser
+  type ('a, 'kind, 'ctx) parser
 
   type values
   type fields
 
-  type 'a t             = ('a, values) parser
-  type 'a fields_parser = ('a, fields) parser
+  type ('a, 'ctx) t             = ('a, values, 'ctx) parser
+  type ('a, 'ctx) fields_parser = ('a, fields, 'ctx) parser
 
   (** [parse parser context sexp] parse a S-expression using the
       following parser. The input consist of a single
       S-expression. [context] allows to pass extra information such as
       versions to individual parsers. *)
-  val parse : 'a t -> Univ_map.t -> ast -> 'a
+  val parse : ('a, 'ctx) t -> 'ctx -> ast -> 'a
 
-  val return : 'a -> ('a, _) parser
-  val (>>=) : ('a, 'k) parser -> ('a -> ('b, 'k) parser) -> ('b, 'k) parser
-  val (>>|) : ('a, 'k) parser -> ('a -> 'b) -> ('b, 'k) parser
-  val (>>>) : (unit, 'k) parser -> ('a, 'k) parser -> ('a, 'k) parser
-  val map : ('a, 'k) parser -> f:('a -> 'b) -> ('b, 'k) parser
-  val try_ : ('a, 'k) parser -> (exn -> ('a, 'k) parser) -> ('a, 'k) parser
+  val return : 'a -> ('a, _, _) parser
+
+  val (>>=)
+    :  ('a, 'k, 'ctx) parser
+    -> ('a -> ('b, 'k, 'ctx) parser)
+    -> ('b, 'k, 'ctx) parser
+
+  val (>>|) : ('a, 'k, 'ctx) parser -> ('a -> 'b) -> ('b, 'k, 'ctx) parser
+
+  val (>>>)
+    :  (unit, 'k, 'ctx) parser
+    -> ('a, 'k, 'ctx) parser
+    -> ('a, 'k, 'ctx) parser
+
+  val map : ('a, 'k, 'ctx) parser -> f:('a -> 'b) -> ('b, 'k, 'ctx) parser
+
+  val try_
+    :  ('a, 'k, 'ctx) parser
+    -> (exn -> ('a, 'k, 'ctx) parser)
+    -> ('a, 'k, 'ctx) parser
 
   (** Access to the context *)
-  val get : 'a Univ_map.Key.t -> ('a option, _) parser
-  val set : 'a Univ_map.Key.t -> 'a -> ('b, 'k) parser -> ('b, 'k) parser
-  val get_all : (Univ_map.t, _) parser
-  val set_many : Univ_map.t -> ('a, 'k) parser -> ('a, 'k) parser
+  val get : 'a Univ_map.Key.t -> ('a option, _, Univ_map.t) parser
+
+  val set
+    :  'a Univ_map.Key.t
+    -> 'a
+    -> ('b, 'k, Univ_map.t) parser
+    -> ('b, 'k, Univ_map.t) parser
+
+  val get_all : ('ctx, _, 'ctx) parser
+  val set_many
+    :  Univ_map.t
+    -> ('a, 'k, Univ_map.t) parser
+    -> ('a, 'k, Univ_map.t) parser
 
   (** Return the location of the list currently being parsed. *)
-  val loc : (Loc.t, _) parser
+  val loc : (Loc.t, _, _) parser
 
   (** End of sequence condition. Uses [then_] if there are no more
       S-expressions to parse, [else_] otherwise. *)
-  val if_eos : then_:('a, 'b) parser -> else_:('a, 'b) parser -> ('a, 'b) parser
+  val if_eos
+    :  then_:('a, 'b, 'ctx) parser
+    -> else_:('a, 'b, 'ctx) parser
+    -> ('a, 'b, 'ctx) parser
 
   (** If the next element of the sequence is a list, parse it with
       [then_], otherwise parse it with [else_]. *)
   val if_list
-    :  then_:'a t
-    -> else_:'a t
-    -> 'a t
+    :  then_:('a, 'ctx) t
+    -> else_:('a, 'ctx) t
+    -> ('a, 'ctx) t
 
   (** If the next element of the sequence is of the form [(:<name>
      ...)], use [then_] to parse [...]. Otherwise use [else_]. *)
   val if_paren_colon_form
-    :  then_:(Loc.t * string -> 'a) t
-    -> else_:'a t
-    -> 'a t
+    :  then_:(Loc.t * string -> 'a, 'ctx) t
+    -> else_:('a, 'ctx) t
+    -> ('a, 'ctx) t
 
   (** Expect the next element to be the following atom. *)
-  val keyword : string -> unit t
+  val keyword : string -> (unit, _) t
 
   (** {[match_keyword [(k1, t1); (k2, t2); ...] ~fallback]} inspects
      the next element of the input sequence. If it is an atom equal to
      one of [k1], [k2], ... then the corresponding parser is used to
      parse the rest of the sequence. Other [fallback] is used. *)
   val match_keyword
-    :  (string * 'a t) list
-    -> fallback:'a t
-    -> 'a t
+    :  (string * ('a, 'ctx) t) list
+    -> fallback:('a, 'ctx) t
+    -> ('a, 'ctx) t
 
   (** Use [before] to parse elements until the keyword is
       reached. Then use [after] to parse the rest. *)
   val until_keyword
     :  string
-    -> before:'a t
-    -> after:'b t
-    -> ('a list * 'b option) t
+    -> before:('a, 'ctx) t
+    -> after:('b, 'ctx) t
+    -> ('a list * 'b option, 'ctx) t
 
   (** What is currently being parsed. The second argument is the atom
       at the beginnig of the list when inside a [sum ...] or [field
@@ -161,52 +159,52 @@ module Of_sexp : sig
   type kind =
     | Values of Loc.t * string option
     | Fields of Loc.t * string option
-  val kind : (kind, _) parser
+  val kind : (kind, _, _) parser
 
   (** [repeat t] use [t] to consume all remaning elements of the input
       until the end of sequence is reached. *)
-  val repeat : 'a t -> 'a list t
+  val repeat : ('a, 'ctx) t -> ('a list, 'ctx) t
 
   (** Capture the rest of the input for later parsing *)
-  val capture : ('a t -> 'a) t
+  val capture : (('a, 'ctx) t -> 'a, 'ctx) t
 
   (** [enter t] expect the next element of the input to be a list and
       parse its contents with [t]. *)
-  val enter : 'a t -> 'a t
+  val enter : ('a, 'ctx) t -> ('a, 'ctx) t
 
   (** [fields fp] converts the rest of the current input to a list of
       fields and parse them with [fp]. This operation fails if one the
       S-expression in the input is not of the form [(<atom>
       <values>...)] *)
-  val fields : 'a fields_parser -> 'a t
+  val fields : ('a, 'ctx) fields_parser -> ('a, 'ctx) t
 
   (** [record fp = enter (fields fp)] *)
-  val record : 'a fields_parser -> 'a t
+  val record : ('a, 'ctx) fields_parser -> ('a, 'ctx) t
 
   (** Consume the next element of the input as a string, int, char, ... *)
-  include Combinators with type 'a t := 'a t
+  include Sexp_intf.Combinators.S2 with type ('a, 'ctx) t := ('a, 'ctx) t
 
   (** Unparsed next element of the input *)
-  val raw : ast t
+  val raw : (ast, _) t
 
   (** Inspect the next element of the input without consuming it *)
-  val peek : ast option t
+  val peek : (ast option, _) t
 
   (** Same as [peek] but fail if the end of input is reached *)
-  val peek_exn : ast t
+  val peek_exn : (ast, _) t
 
   (** Consume and ignore the next element of the input *)
-  val junk : unit t
+  val junk : (unit, _) t
 
   (** Ignore all the rest of the input *)
-  val junk_everything : (unit, _) parser
+  val junk_everything : (unit, _, _) parser
 
   (** [plain_string f] expects the next element of the input to be a
       plain string, i.e. either an atom or a quoted string, but not a
       template nor a list. *)
-  val plain_string : (loc:Loc.t -> string -> 'a) -> 'a t
+  val plain_string : (loc:Loc.t -> string -> 'a) -> ('a, _) t
 
-  val fix : ('a t -> 'a t) -> 'a t
+  val fix : (('a, 'ctx) t -> ('a, 'ctx) t) -> ('a, 'ctx) t
 
   val of_sexp_error
     :  ?hint:hint
@@ -225,22 +223,22 @@ module Of_sexp : sig
     -> ('a, unit, string, 'b) format4
     -> 'a
 
-  val located : ('a, 'k) parser -> (Loc.t * 'a, 'k) parser
+  val located : ('a, 'k, 'ctx) parser -> (Loc.t * 'a, 'k, 'ctx) parser
 
-  val enum : (string * 'a) list -> 'a t
+  val enum : (string * 'a) list -> ('a, _) t
 
   (** Parser that parse a S-expression of the form [(<atom> <s-exp1>
       <s-exp2> ...)] or [<atom>]. [<atom>] is looked up in the list and
       the remaining s-expressions are parsed using the corresponding
       list parser. *)
-  val sum : (string * 'a t) list -> 'a t
+  val sum : (string * ('a, 'ctx) t) list -> ('a, 'ctx) t
 
   (** Check the result of a list parser, and raise a properly located
       error in case of failure. *)
   val map_validate
-    :  'a fields_parser
+    :  ('a, 'ctx) fields_parser
     -> f:('a -> ('b, string) Result.t)
-    -> 'b fields_parser
+    -> ('b, 'ctx) fields_parser
 
   (** {3 Parsing record fields} *)
 
@@ -248,38 +246,43 @@ module Of_sexp : sig
     :  string
     -> ?default:'a
     -> ?on_dup:(Univ_map.t -> string -> Ast.t list -> unit)
-    -> 'a t
-    -> 'a fields_parser
+    -> ('a, 'ctx) t
+    -> ('a, 'ctx) fields_parser
+
   val field_o
     :  string
     -> ?on_dup:(Univ_map.t -> string -> Ast.t list -> unit)
-    -> 'a t
-    -> 'a option fields_parser
+    -> ('a, 'ctx) t
+    -> ('a option, 'ctx) fields_parser
 
   val field_b
-    :  ?check:(unit t)
+    :  ?check:((unit, 'ctx) t)
     -> ?on_dup:(Univ_map.t -> string -> Ast.t list -> unit)
     -> string
-    -> bool fields_parser
+    -> (bool, 'ctx) fields_parser
 
   (** A field that can appear multiple times *)
   val multi_field
     :  string
-    -> 'a t
-    -> 'a list fields_parser
+    -> ('a, 'ctx) t
+    -> ('a list, 'ctx) fields_parser
 
   (** Default value for [on_dup]. It fails with an appropriate error
       message. *)
   val field_present_too_many_times : Univ_map.t -> string -> Ast.t list -> _
 
   module Let_syntax : sig
-    val ( $ ) : ('a -> 'b, 'k) parser -> ('a, 'k) parser -> ('b, 'k) parser
-    val const : 'a -> ('a, _) parser
+    val ( $ )
+      :  ('a -> 'b, 'k, 'ctx) parser
+      -> ('a, 'k, 'ctx) parser
+      -> ('b, 'k, 'ctx) parser
+
+    val const : 'a -> ('a, _, _) parser
   end
 end
 
 module type Sexpable = sig
   type t
-  val t : t Of_sexp.t
+  val t : (t, _) Of_sexp.t
   val sexp_of_t : t To_sexp.t
 end

--- a/src/stdune/sexp_intf.ml
+++ b/src/stdune/sexp_intf.ml
@@ -1,0 +1,65 @@
+module Combinators = struct
+  module type S2 = sig
+    type ('a, 'ctx) t
+
+    val unit       : (unit, _) t
+
+    val string     : (string, _) t
+    (** Convert an [Atom] or a [Quoted_string] from/to a string. *)
+
+    val int        : (int, _) t
+    val float      : (float, _) t
+    val bool       : (bool, _) t
+    val pair       : ('a, 'ctx) t -> ('b, 'ctx) t -> ('a * 'b, 'ctx) t
+
+    val triple
+      :  ('a, 'ctx) t
+      -> ('b, 'ctx) t
+      -> ('c, 'ctx) t
+      -> ('a * 'b * 'c, 'ctx) t
+
+    val list       : ('a, 'ctx) t -> ('a list   , 'ctx) t
+    val array      : ('a, 'ctx) t -> ('a array  , 'ctx) t
+    val option     : ('a, 'ctx) t -> ('a option , 'ctx) t
+
+    val string_set : (String.Set.t, 'ctx) t
+    (** [atom_set] is a conversion to/from a set of strings representing
+        atoms. *)
+
+    val string_map : ('a, 'ctx) t -> ('a String.Map.t, 'ctx ) t
+    (** [atom_map conv]: given a conversion [conv] to/from ['a], returns
+        a conversion to/from a map where the keys are atoms and the
+        values are of type ['a]. *)
+
+    val string_hashtbl : ('a, 'ctx) t -> ((string, 'a) Hashtbl.t, 'ctx) t
+    (** [atom_hashtbl conv] is similar to [atom_map] for hash tables. *)
+  end
+
+  module type S = sig
+    type 'a t
+    val unit       : unit                      t
+
+    val string     : string                    t
+    (** Convert an [Atom] or a [Quoted_string] from/to a string. *)
+
+    val int        : int                       t
+    val float      : float                     t
+    val bool       : bool                      t
+    val pair       : 'a t -> 'b t -> ('a * 'b) t
+    val triple     : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
+    val list       : 'a t -> 'a list           t
+    val array      : 'a t -> 'a array          t
+    val option     : 'a t -> 'a option         t
+
+    val string_set : String.Set.t            t
+    (** [atom_set] is a conversion to/from a set of strings representing atoms. *)
+
+    val string_map : 'a t -> 'a String.Map.t   t
+    (** [atom_map conv]: given a conversion [conv] to/from ['a], returns
+        a conversion to/from a map where the keys are atoms and the
+        values are of type ['a]. *)
+
+    val string_hashtbl : 'a t -> (string, 'a) Hashtbl.t t
+    (** [atom_hashtbl conv] is similar to [atom_map] for hash tables. *)
+  end
+end


### PR DESCRIPTION
@diml this change seems to be harder than I thought. Now all the individual parsers that are defined aren't polymorphic in the parsing context unfortunately:

```
       In module Section:
       Values do not match:
         val t : (t, '_weak1) Import.Sexp.Of_sexp.t
       is not included in
         val t : (t, 'a) Stdune.Sexp.Of_sexp.t
```

I'm not sure how to fix this.