### PR TITLE
Setup code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+* @diml @rgrinberg @emillon
+
+src/menhir.* @fpottier
+
+src/odoc.* @rginberg
+
+src/configurator/* @rgrinberg
+
+src/js_of_ocaml* @hhugo


### PR DESCRIPTION
This PR adds a `.github/CODEOWNERS` file so that we get automatically added as reviewers for new pull requests.