### PR TITLE
Introduce Lib_name.t and Lib_name.Local.t types

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -582,7 +582,10 @@ let installed_libraries =
        let ctx = List.hd ctxs in
        let findlib = ctx.findlib in
        if na then begin
-         let pkgs = Findlib.all_unavailable_packages findlib in
+         let pkgs =
+           Findlib.all_unavailable_packages findlib
+           |> List.map ~f:(fun (l, e) -> (Lib_name.to_string l, e))
+         in
          let longest = String.longest_map pkgs ~f:fst in
          let ppf = Format.std_formatter in
          List.iter pkgs ~f:(fun (n, r) ->
@@ -592,13 +595,15 @@ let installed_libraries =
          Fiber.return ()
        end else begin
          let pkgs = Findlib.all_packages findlib in
-         let max_len = String.longest_map pkgs ~f:Findlib.Package.name in
+         let max_len = String.longest_map pkgs ~f:(fun n ->
+           Findlib.Package.name n
+           |> Lib_name.to_string) in
          List.iter pkgs ~f:(fun pkg ->
            let ver =
              Option.value (Findlib.Package.version pkg) ~default:"n/a"
            in
            Printf.printf "%-*s (version: %s)\n" max_len
-             (Findlib.Package.name pkg) ver);
+             (Lib_name.to_string (Findlib.Package.name pkg)) ver);
          Fiber.return ()
        end)
   in
@@ -829,11 +834,11 @@ let clean =
   (term, Term.info "clean" ~doc ~man)
 
 let format_external_libs libs =
-  String.Map.to_list libs
+  Lib_name.Map.to_list libs
   |> List.map ~f:(fun (name, kind) ->
     match (kind : Lib_deps_info.Kind.t) with
-    | Optional -> sprintf "- %s (optional)" name
-    | Required -> sprintf "- %s" name)
+    | Optional -> sprintf "- %s (optional)" (Lib_name.to_string name)
+    | Required -> sprintf "- %s" (Lib_name.to_string name))
   |> String.concat ~sep:"\n"
 
 let external_lib_deps =
@@ -876,20 +881,20 @@ let external_lib_deps =
                   | Some x -> x)
              in
              let externals =
-               String.Map.filteri lib_deps ~f:(fun name _ ->
-                 not (String.Set.mem internals name))
+               Lib_name.Map.filteri lib_deps ~f:(fun name _ ->
+                 not (Lib_name.Set.mem internals name))
              in
              if only_missing then begin
                let context =
                  List.find_exn setup.contexts ~f:(fun c -> c.name = context_name)
                in
                let missing =
-                 String.Map.filteri externals ~f:(fun name _ ->
+                 Lib_name.Map.filteri externals ~f:(fun name _ ->
                    not (Findlib.available context.findlib name))
                in
-               if String.Map.is_empty missing then
+               if Lib_name.Map.is_empty missing then
                  acc
-               else if String.Map.for_alli missing
+               else if Lib_name.Map.for_alli missing
                          ~f:(fun _ kind -> kind = Lib_deps_info.Kind.Optional)
                then begin
                  Format.eprintf
@@ -907,13 +912,14 @@ let external_lib_deps =
                     Hint: try: opam install %s@."
                    context_name
                    (format_external_libs missing)
-                   (String.Map.to_list missing
+                   (Lib_name.Map.to_list missing
                     |> List.filter_map ~f:(fun (name, kind) ->
                       match (kind : Lib_deps_info.Kind.t) with
                       | Optional -> None
-                      | Required -> Some (Findlib.root_package_name name))
-                    |> String.Set.of_list
-                    |> String.Set.to_list
+                      | Required -> Some (Lib_name.package_name name))
+                    |> Package.Name.Set.of_list
+                    |> Package.Name.Set.to_list
+                    |> List.map ~f:Package.Name.to_string
                     |> String.concat ~sep:" ");
                  true
                end

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -582,14 +582,12 @@ let installed_libraries =
        let ctx = List.hd ctxs in
        let findlib = ctx.findlib in
        if na then begin
-         let pkgs =
-           Findlib.all_unavailable_packages findlib
-           |> List.map ~f:(fun (l, e) -> (Lib_name.to_string l, e))
-         in
-         let longest = String.longest_map pkgs ~f:fst in
+         let pkgs = Findlib.all_unavailable_packages findlib in
+         let longest =
+           String.longest_map pkgs ~f:(fun (n, _) -> Lib_name.to_string n) in
          let ppf = Format.std_formatter in
          List.iter pkgs ~f:(fun (n, r) ->
-           Format.fprintf ppf "%-*s -> %a@\n" longest n
+           Format.fprintf ppf "%-*s -> %a@\n" longest (Lib_name.to_string n)
              Findlib.Unavailable_reason.pp r);
          Format.pp_print_flush ppf ();
          Fiber.return ()

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -75,20 +75,18 @@ let file_of_lib t ~loc ~lib ~file =
   match Lib.DB.find t.public_libs lib with
   | Error reason ->
     Error { fail = fun () ->
-      Lib.not_available ~loc reason "Public library %S" lib  }
+      Lib.not_available ~loc reason "Public library %a" Lib_name.pp_quoted lib }
   | Ok lib ->
     if Lib.is_local lib then begin
-      match String.split (Lib.name lib) ~on:'.' with
-      | [] -> assert false
-      | package :: rest ->
-        let lib_install_dir =
-          Config.local_install_lib_dir ~context:t.context.name ~package
-        in
-        let lib_install_dir =
-          match rest with
-          | [] -> lib_install_dir
-          | _  -> Path.relative lib_install_dir (String.concat rest ~sep:"/")
-        in
-        Ok (Path.relative lib_install_dir file)
+      let (package, rest) = Lib_name.split (Lib.name lib) in
+      let lib_install_dir =
+        Config.local_install_lib_dir ~context:t.context.name ~package
+      in
+      let lib_install_dir =
+        match rest with
+        | [] -> lib_install_dir
+        | _  -> Path.relative lib_install_dir (String.concat rest ~sep:"/")
+      in
+      Ok (Path.relative lib_install_dir file)
     end else
       Ok (Path.relative (Lib.src_dir lib) file)

--- a/src/artifacts.mli
+++ b/src/artifacts.mli
@@ -26,6 +26,6 @@ val binary
 val file_of_lib
   :  t
   -> loc:Loc.t
-  -> lib:string
+  -> lib:Lib_name.t
   -> file:string
   -> (Path.t, fail) result

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -156,7 +156,7 @@ let lib_deps =
       | Catch (t, _) -> loop t acc
       | Lazy_no_targets t -> loop (Lazy.force t) acc
   in
-  fun t -> loop (Build.repr t) String.Map.empty
+  fun t -> loop (Build.repr t) Lib_name.Map.empty
 
 let targets =
   let rec loop : type a b. (a, b) t -> Target.t list -> Target.t list = fun t acc ->

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -1332,7 +1332,7 @@ let all_lib_deps t ~request =
   List.fold_left (rules_for_targets t targets) ~init:Path.Map.empty
     ~f:(fun acc rule ->
       let deps = Internal_rule.lib_deps rule in
-      if String.Map.is_empty deps then
+      if Lib_name.Map.is_empty deps then
         acc
       else
         let deps =
@@ -1347,7 +1347,7 @@ let all_lib_deps_by_context t ~request =
   let rules = rules_for_targets t targets in
   List.fold_left rules ~init:[] ~f:(fun acc rule ->
     let deps = Internal_rule.lib_deps rule in
-    if String.Map.is_empty deps then
+    if Lib_name.Map.is_empty deps then
       acc
     else
       match Path.extract_build_context rule.dir with
@@ -1356,7 +1356,7 @@ let all_lib_deps_by_context t ~request =
   |> String.Map.of_list_multi
   |> String.Map.filteri ~f:(fun ctx _ -> String.Map.mem t.contexts ctx)
   |> String.Map.map ~f:(function
-    | [] -> String.Map.empty
+    | [] -> Lib_name.Map.empty
     | x :: l -> List.fold_left l ~init:x ~f:Lib_deps_info.merge)
 
 module Rule = struct

--- a/src/config.ml
+++ b/src/config.ml
@@ -14,7 +14,7 @@ let local_install_man_dir ~context =
 let local_install_lib_dir ~context ~package =
   Path.relative
     (Path.relative (local_install_dir ~context) "lib")
-    package
+    (Package.Name.to_string package)
 
 let dev_null =
   Path.of_filename_relative_to_initial_cwd

--- a/src/config.mli
+++ b/src/config.mli
@@ -7,7 +7,7 @@ val local_install_dir : context:string -> Path.t
 
 val local_install_bin_dir : context:string -> Path.t
 val local_install_man_dir : context:string -> Path.t
-val local_install_lib_dir : context:string -> package:string -> Path.t
+val local_install_lib_dir : context:string -> package:Package.Name.t -> Path.t
 
 val dev_null : Path.t
 

--- a/src/dep_path.ml
+++ b/src/dep_path.ml
@@ -4,19 +4,20 @@ module Entry = struct
   type t =
     | Path of Path.t
     | Alias of Path.t
-    | Library of Path.t * string
-    | Preprocess of string list
+    | Library of Path.t * Lib_name.t
+    | Preprocess of Lib_name.t list
     | Loc of Loc.t
 
   let to_string = function
     | Path p -> Utils.describe_target p
     | Alias p -> "alias " ^ Utils.describe_target p
     | Library (path, lib_name) ->
-      sprintf "library %S in %s" lib_name (Path.to_string_maybe_quoted path)
+      Format.asprintf "library %a in %s" Lib_name.pp_quoted lib_name
+        (Path.to_string_maybe_quoted path)
     | Preprocess l ->
       Sexp.to_string
         (List [ Atom "pps"
-              ; Sexp.To_sexp.(list string) l])
+              ; Sexp.To_sexp.(list Lib_name.to_sexp) l])
     | Loc loc ->
       Loc.to_file_colon_line loc
 

--- a/src/dep_path.mli
+++ b/src/dep_path.mli
@@ -6,8 +6,8 @@ module Entry : sig
   type t =
     | Path of Path.t
     | Alias of Path.t
-    | Library of Path.t * string
-    | Preprocess of string list
+    | Library of Path.t * Lib_name.t
+    | Preprocess of Lib_name.t list
     | Loc of Loc.t
 
   val to_string : t -> string

--- a/src/dir_contents.mli
+++ b/src/dir_contents.mli
@@ -29,7 +29,7 @@ module Executables_modules : sig
 end
 
 (** Modules attached to a library. [name] is the library best name. *)
-val modules_of_library : t -> name:string -> Library_modules.t
+val modules_of_library : t -> name:Lib_name.t -> Library_modules.t
 
 (** Modules attached to a set of executables. *)
 val modules_of_executables : t -> first_exe:string -> Executables_modules.t

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -5,9 +5,11 @@ open Import
 
 (** Ppx preprocessors  *)
 module Pp : sig
-  type t = private string
+  type t = private Lib_name.t
   val of_string : string -> t
   val to_string : t -> string
+
+  val to_lib_name : t -> Lib_name.t
   val compare : t -> t -> Ordering.t
 end
 
@@ -58,8 +60,8 @@ end
 
 module Lib_dep : sig
   type choice =
-    { required  : String.Set.t
-    ; forbidden : String.Set.t
+    { required  : Lib_name.Set.t
+    ; forbidden : Lib_name.Set.t
     ; file      : string
     }
 
@@ -70,11 +72,11 @@ module Lib_dep : sig
     }
 
   type t =
-    | Direct of (Loc.t * string)
+    | Direct of (Loc.t * Lib_name.t)
     | Select of select
 
-  val to_lib_names : t -> string list
-  val direct : Loc.t * string -> t
+  val to_lib_names : t -> Lib_name.t list
+  val direct : Loc.t * Lib_name.t -> t
   val of_pp : Loc.t * Pp.t -> t
 end
 
@@ -146,13 +148,13 @@ end
 
 module Public_lib : sig
   type t =
-    { name    : Loc.t * string (** Full public name *)
+    { name    : Loc.t * Lib_name.t (** Full public name *)
     ; package : Package.t      (** Package it is part of *)
     ; sub_dir : string option  (** Subdirectory inside the installation
                                    directory *)
     }
 
-  val name : t -> string
+  val name : t -> Lib_name.t
 end
 
 module Sub_system_info : sig
@@ -215,11 +217,11 @@ module Library : sig
   end
 
   type t =
-    { name                     : string
+    { name                     : Lib_name.Local.t
     ; public                   : Public_lib.t option
     ; synopsis                 : string option
     ; install_c_headers        : string list
-    ; ppx_runtime_libraries    : (Loc.t * string) list
+    ; ppx_runtime_libraries    : (Loc.t * Lib_name.t) list
     ; modes                    : Mode_conf.Set.t
     ; kind                     : Kind.t
     ; c_flags                  : Ordered_set_lang.Unexpanded.t
@@ -229,7 +231,7 @@ module Library : sig
     ; library_flags            : Ordered_set_lang.Unexpanded.t
     ; c_library_flags          : Ordered_set_lang.Unexpanded.t
     ; self_build_stubs_archive : string option
-    ; virtual_deps             : (Loc.t * string) list
+    ; virtual_deps             : (Loc.t * Lib_name.t) list
     ; wrapped                  : bool
     ; optional                 : bool
     ; buildable                : Buildable.t
@@ -244,7 +246,7 @@ module Library : sig
   val stubs_archive : t -> dir:Path.t -> ext_lib:string -> Path.t
   val dll : t -> dir:Path.t -> ext_dll:string -> Path.t
   val archive : t -> dir:Path.t -> ext:string -> Path.t
-  val best_name : t -> string
+  val best_name : t -> Lib_name.t
 end
 
 module Install_conf : sig

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -6,7 +6,7 @@ open Import
 (** Ppx preprocessors  *)
 module Pp : sig
   type t = private Lib_name.t
-  val of_string : string -> t
+  val of_string : loc:Loc.t option -> string -> t
   val to_string : t -> string
 
   val to_lib_name : t -> Lib_name.t

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -164,10 +164,10 @@ module Package = struct
   let jsoo_runtime     t = get_paths      t      "jsoo_runtime"     Ps.empty
   let requires         t =
     Vars.get_words t.vars "requires"         preds
-    |> List.map ~f:Lib_name.of_string_exn
+    |> List.map ~f:(Lib_name.of_string_exn ~loc:None)
   let ppx_runtime_deps t =
     Vars.get_words t.vars "ppx_runtime_deps" preds
-    |> List.map ~f:Lib_name.of_string_exn
+    |> List.map ~f:(Lib_name.of_string_exn ~loc:None)
 
   let archives t = make_archives t "archive" preds
   let plugins t =
@@ -347,7 +347,7 @@ let root_packages t =
       |> Array.to_list
       |> List.filter_map ~f:(fun name ->
         if Path.exists (Path.relative dir (name ^ "/META")) then
-          Some (Lib_name.of_string_exn name)
+          Some (Lib_name.of_string_exn ~loc:None name)
         else
           None))
     |> Lib_name.Set.of_list

--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -14,23 +14,20 @@ val create
 (** The search path for this DB *)
 val path : t -> Path.t list
 
-(** [root_package_name "foo.*"] is "foo" *)
-val root_package_name : string -> string
-
 module Package : sig
   (** Representation of a findlib package *)
   type t
 
   val meta_file        : t -> Path.t
-  val name             : t -> string
+  val name             : t -> Lib_name.t
   val dir              : t -> Path.t
   val version          : t -> string option
   val description      : t -> string option
   val archives         : t -> Path.t list Mode.Dict.t
   val plugins          : t -> Path.t list Mode.Dict.t
   val jsoo_runtime     : t -> Path.t list
-  val requires         : t -> string list
-  val ppx_runtime_deps : t -> string list
+  val requires         : t -> Lib_name.t list
+  val ppx_runtime_deps : t -> Lib_name.t list
   val dune_file        : t -> Path.t option
 end
 
@@ -46,18 +43,18 @@ module Unavailable_reason : sig
 end
 
 (** Lookup a package in the given database *)
-val find : t -> string -> (Package.t, Unavailable_reason.t) result
+val find : t -> Lib_name.t -> (Package.t, Unavailable_reason.t) result
 
-val available : t -> string -> bool
+val available : t -> Lib_name.t -> bool
 
 (** List all the packages available in this Database *)
 val all_packages  : t -> Package.t list
 
 (** List all the packages that are not available in this database *)
-val all_unavailable_packages : t -> (string * Unavailable_reason.t) list
+val all_unavailable_packages : t -> (Lib_name.t * Unavailable_reason.t) list
 
 (** A dummy package. This is used to implement [external-lib-deps] *)
-val dummy_package : t -> name:string -> Package.t
+val dummy_package : t -> name:Lib_name.t -> Package.t
 
 module Config : sig
   type t

--- a/src/gen_meta.ml
+++ b/src/gen_meta.ml
@@ -166,7 +166,7 @@ let gen ~package ~version libs =
                   entries = directory name :: pkg.entries
                 })
     in
-    { name = Some (Lib_name.of_string_exn name)
+    { name = Some (Lib_name.of_string_exn ~loc:None name)
     ; entries = entries @ subs
     }
   in

--- a/src/gen_meta.ml
+++ b/src/gen_meta.ml
@@ -8,6 +8,7 @@ module Pub_name = struct
     | Id  of string
 
   let parse s =
+    let s = Lib_name.to_string s in
     match String.split s ~on:'.' with
     | [] -> assert false
     | x :: l ->
@@ -32,7 +33,10 @@ module Pub_name = struct
   let to_string t = String.concat ~sep:"." (to_list t)
 end
 
-let string_of_deps deps = String.Set.to_list deps |> String.concat ~sep:" "
+let string_of_deps deps =
+  Lib_name.Set.to_list deps
+  |> List.map ~f:Lib_name.to_string
+  |> String.concat ~sep:" "
 
 let rule var predicates action value =
   Rule { var; predicates; action; value }
@@ -82,7 +86,7 @@ let gen_lib pub_name lib ~version =
       ; requires ~preds lib_deps
       ]
     ; archives ~preds lib
-    ; if String.Set.is_empty ppx_rt_deps then
+    ; if Lib_name.Set.is_empty ppx_rt_deps then
         []
       else
         [ Comment "This is what dune uses to find out the runtime \
@@ -163,7 +167,7 @@ let gen ~package ~version libs =
                   entries = directory name :: pkg.entries
                 })
     in
-    { name
+    { name = Some (Lib_name.of_string_exn name)
     ; entries = entries @ subs
     }
   in

--- a/src/gen_meta.ml
+++ b/src/gen_meta.ml
@@ -34,8 +34,7 @@ module Pub_name = struct
 end
 
 let string_of_deps deps =
-  Lib_name.Set.to_list deps
-  |> List.map ~f:Lib_name.to_string
+  Lib_name.Set.to_string_list deps
   |> String.concat ~sep:" "
 
 let rule var predicates action value =

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -188,7 +188,7 @@ include Sub_system.Register_end_point(
         Result.List.concat_map backends
           ~f:(fun (backend : Backend.t) -> backend.runner_libraries)
         >>= fun libs ->
-        Lib.DB.find_many (Scope.libs scope) [Lib_name.of_local lib.name]
+        Lib.DB.find_many (Scope.libs scope) [Dune_file.Library.best_name lib]
         >>= fun lib ->
         Result.List.all
           (List.map info.libraries

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -13,10 +13,10 @@ module Backend = struct
 
       type t =
         { loc              : Loc.t
-        ; runner_libraries : (Loc.t * string) list
+        ; runner_libraries : (Loc.t * Lib_name.t) list
         ; flags            : Ordered_set_lang.Unexpanded.t
         ; generate_runner  : (Loc.t * Action.Unexpanded.t) option
-        ; extends          : (Loc.t * string) list
+        ; extends          : (Loc.t * Lib_name.t) list
         }
 
       type Dune_file.Sub_system_info.t += T of t
@@ -36,10 +36,10 @@ module Backend = struct
       let parse =
         record
           (let%map loc = loc
-           and runner_libraries = field "runner_libraries" (list (located string)) ~default:[]
+           and runner_libraries = field "runner_libraries" (list (located Lib_name.dparse)) ~default:[]
            and flags = Ordered_set_lang.Unexpanded.field "flags"
            and generate_runner = field_o "generate_runner" (located Action.Unexpanded.dparse)
-           and extends = field "extends" (list (located string)) ~default:[]
+           and extends = field "extends" (list (located Lib_name.dparse)) ~default:[]
            in
            { loc
            ; runner_libraries
@@ -75,15 +75,16 @@ module Backend = struct
                  resolve x >>= fun lib ->
                  match get ~loc lib with
                  | None ->
-                   Error (Errors.exnf loc "%S is not an %s" name
+                   Error (Errors.exnf loc "%S is not an %s"
+                            (Lib_name.to_string name)
                             (desc ~plural:false))
                  | Some t -> Ok t))
       }
 
     let dgen t =
       let open Dsexp.To_sexp in
-      let lib x = string (Lib.name x) in
-      let f x = string (Lib.name x.lib) in
+      let lib x = Lib_name.dgen (Lib.name x) in
+      let f x = Lib_name.dgen (Lib.name x.lib) in
       ((1, 0),
        record_fields
          [ field "runner_libraries" (list lib)
@@ -109,8 +110,8 @@ include Sub_system.Register_end_point(
         { loc       : Loc.t
         ; deps      : Dep_conf.t list
         ; flags     : Ordered_set_lang.Unexpanded.t
-        ; backend   : (Loc.t * string) option
-        ; libraries : (Loc.t * string) list
+        ; backend   : (Loc.t * Lib_name.t) option
+        ; libraries : (Loc.t * Lib_name.t) list
         }
 
       type Dune_file.Sub_system_info.t += T of t
@@ -138,8 +139,8 @@ include Sub_system.Register_end_point(
                (let%map loc = loc
                 and deps = field "deps" (list Dep_conf.dparse) ~default:[]
                 and flags = Ordered_set_lang.Unexpanded.field "flags"
-                and backend = field_o "backend" (located string)
-                and libraries = field "libraries" (list (located string)) ~default:[]
+                and backend = field_o "backend" (located Lib_name.dparse)
+                and libraries = field "libraries" (list (located Lib_name.dparse)) ~default:[]
                 in
                 { loc
                 ; deps
@@ -161,7 +162,8 @@ include Sub_system.Register_end_point(
       in
 
       let inline_test_dir =
-        Path.relative dir (sprintf ".%s.inline-tests" lib.name)
+        Path.relative dir (sprintf ".%s.inline-tests"
+                             (Lib_name.Local.to_string lib.name))
       in
 
       let name = "run" in
@@ -178,7 +180,7 @@ include Sub_system.Register_end_point(
 
       let bindings =
         Pform.Map.singleton "library-name"
-          (Values [String lib.name])
+          (Values [String (Lib_name.Local.to_string lib.name)])
       in
 
       let runner_libs =
@@ -186,7 +188,7 @@ include Sub_system.Register_end_point(
         Result.List.concat_map backends
           ~f:(fun (backend : Backend.t) -> backend.runner_libraries)
         >>= fun libs ->
-        Lib.DB.find_many (Scope.libs scope) [lib.name]
+        Lib.DB.find_many (Scope.libs scope) [Lib_name.of_local lib.name]
         >>= fun lib ->
         Result.List.all
           (List.map info.libraries

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -203,7 +203,8 @@ module Gen(P : Params) = struct
             | [] -> None
             | l ->
               match Scope.name scope
-                  , List.mem ~set:l (Lib_name.of_string_exn "ppxlib") with
+                  , List.mem ~set:l (Lib_name.of_string_exn ~loc:None "ppxlib")
+              with
               | Named "ppxlib", _ | _, true ->
                 Some "ppxlib.runner"
               | _ ->

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -16,7 +16,7 @@ module Gen(P : Params) = struct
   let ctx = Super_context.context sctx
 
   let lib_dune_file ~dir ~name =
-    Path.relative dir (name ^ ".dune")
+    Path.relative dir ((Lib_name.to_string name) ^ ".dune")
 
   let gen_lib_dune_file lib =
     SC.add_rule sctx
@@ -115,7 +115,7 @@ module Gen(P : Params) = struct
            >>>
            Build.write_file_dyn meta)))
 
-  let lib_install_files ~dir_contents ~dir ~sub_dir ~name ~scope ~dir_kind
+  let lib_install_files ~dir_contents ~dir ~sub_dir ~(name : Lib_name.t) ~scope ~dir_kind
         (lib : Library.t) =
     let obj_dir = Utils.library_object_directory ~dir lib.name in
     let make_entry section ?dst fn =
@@ -195,13 +195,15 @@ module Gen(P : Params) = struct
               List.concat_map lib.buildable.libraries ~f:Lib_dep.to_lib_names
             in
             match
-              List.filter deps ~f:(function
+              List.filter deps ~f:(fun lib_name ->
+                match Lib_name.to_string lib_name with
                 | "ppx_driver" | "ppxlib" | "ppx_type_conv" -> true
                 | _ -> false)
             with
             | [] -> None
             | l ->
-              match Scope.name scope, List.mem ~set:l "ppxlib" with
+              match Scope.name scope
+                  , List.mem ~set:l (Lib_name.of_string_exn "ppxlib") with
               | Named "ppxlib", _ | _, true ->
                 Some "ppxlib.runner"
               | _ ->

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -20,11 +20,11 @@ let in_build_dir ~ctx =
   let init = Path.relative ctx.Context.build_dir ".js" in
   List.fold_left ~init ~f:Path.relative
 
-let runtime_file ~sctx fname =
+let runtime_file ~sctx file =
   match
     Artifacts.file_of_lib (SC.artifacts sctx)
       ~loc:Loc.none
-      ~lib:(Lib_name.of_string_exn "js_of_ocaml-compiler") ~file:fname
+      ~lib:(Lib_name.of_string_exn ~loc:None "js_of_ocaml-compiler") ~file
   with
   | Error _ ->
     Arg_spec.Dyn (fun _ ->
@@ -141,7 +141,7 @@ let setup_separate_compilation_rules sctx components =
     match components with
     | [] | _ :: _ :: _ -> ()
     | [pkg] ->
-      let pkg = Lib_name.of_string_exn pkg in
+      let pkg = Lib_name.of_string_exn ~loc:None pkg in
       let ctx = SC.context sctx in
       match Lib.DB.find (SC.installed_libs sctx) pkg with
       | Error _ -> ()

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -954,11 +954,11 @@ module DB = struct
         let info = Info.of_library_stanza ~dir ~ext_lib conf in
         match conf.public with
         | None ->
-          [Lib_name.of_local conf.name, Resolve_result.Found info]
+          [Dune_file.Library.best_name conf, Resolve_result.Found info]
         | Some p ->
           let name = Dune_file.Public_lib.name p in
           if name = Lib_name.of_local conf.name then
-            [(name, Found info)]
+            [name, Found info]
           else
             [ name                       , Found info
             ; Lib_name.of_local conf.name, Redirect (None, name)
@@ -1032,10 +1032,10 @@ module DB = struct
   let available t name = available_internal t name ~stack:Dep_stack.empty
 
   let get_compile_info t ?(allow_overlaps=false) name =
-    match find_even_when_hidden t (Lib_name.of_local name) with
+    match find_even_when_hidden t name with
     | None ->
       Exn.code_error "Lib.DB.get_compile_info got library that doesn't exist"
-        [ "name", Lib_name.Local.to_sexp name ]
+        [ "name", Lib_name.to_sexp name ]
     | Some lib ->
       let t = Option.some_if (not allow_overlaps) t in
       Compile.for_lib t lib

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -8,7 +8,7 @@ type t
 
 (** For libraries defined in the workspace, this is the [public_name] if
     present or the [name] if not. *)
-val name : t -> string
+val name : t -> Lib_name.t
 
 (* CR-someday diml: this should be [Path.t list], since some libraries
    have multiple source directories because of [copy_files]. *)
@@ -83,7 +83,7 @@ end
 module Info : sig
   module Deps : sig
     type t =
-      | Simple  of (Loc.t * string) list
+      | Simple  of (Loc.t * Lib_name.t) list
       | Complex of Dune_file.Lib_dep.t list
   end
 
@@ -102,10 +102,10 @@ module Info : sig
     ; foreign_archives : Path.t list Mode.Dict.t (** [.a/.lib/...] files *)
     ; jsoo_runtime     : Path.t list
     ; requires         : Deps.t
-    ; ppx_runtime_deps : (Loc.t * string) list
+    ; ppx_runtime_deps : (Loc.t * Lib_name.t) list
     ; pps              : (Loc.t * Dune_file.Pp.t) list
     ; optional         : bool
-    ; virtual_deps     : (Loc.t * string) list
+    ; virtual_deps     : (Loc.t * Lib_name.t) list
     ; dune_version : Syntax.Version.t option
     ; sub_systems      : Dune_file.Sub_system_info.t Sub_system_name.Map.t
     }
@@ -126,7 +126,7 @@ module Error : sig
     module Reason : sig
       module Hidden : sig
         type t =
-          { name   : string
+          { name   : Lib_name.t
           ; path   : Path.t
           ; reason : string
           }
@@ -142,7 +142,7 @@ module Error : sig
 
     type nonrec t =
       { loc    : Loc.t (** For names coming from Jbuild files *)
-      ; name   : string
+      ; name   : Lib_name.t
       ; reason : Reason.t
       }
   end
@@ -178,7 +178,7 @@ module Error : sig
   type t =
     | Library_not_available        of Library_not_available.t
     | No_solution_found_for_select of No_solution_found_for_select.t
-    | Dependency_cycle             of (Path.t * string) list
+    | Dependency_cycle             of (Path.t * Lib_name.t) list
     | Conflict                     of Conflict.t
     | Overlap                      of Overlap.t
     | Private_deps_not_allowed     of Private_deps_not_allowed.t
@@ -242,7 +242,7 @@ module DB : sig
       | Not_found
       | Found    of Info.t
       | Hidden   of Info.t * string
-      | Redirect of t option * string
+      | Redirect of t option * Lib_name.t
   end
 
   (** Create a new library database. [resolve] is used to resolve
@@ -255,8 +255,8 @@ module DB : sig
   *)
   val create
     :  ?parent:t
-    -> resolve:(string -> Resolve_result.t)
-    -> all:(unit -> string list)
+    -> resolve:(Lib_name.t -> Resolve_result.t)
+    -> all:(unit -> Lib_name.t list)
     -> unit
     -> t
 
@@ -272,21 +272,22 @@ module DB : sig
     -> Findlib.t
     -> t
 
-  val find : t -> string -> (lib, Error.Library_not_available.Reason.t) result
+  val find : t -> Lib_name.t -> (lib, Error.Library_not_available.Reason.t) result
   val find_many
     :  t
-    -> string list
+    -> Lib_name.t list
     -> lib list Or_exn.t
 
-  val find_even_when_hidden : t -> string -> lib option
+  val find_even_when_hidden : t -> Lib_name.t -> lib option
 
-  val available : t -> string -> bool
+  val available : t -> Lib_name.t -> bool
 
   (** Retrieve the compile information for the given library. Works
       for libraries that are optional and not available as well. *)
-  val get_compile_info : t -> ?allow_overlaps:bool -> string -> Compile.t
+  val get_compile_info
+    : t -> ?allow_overlaps:bool -> Lib_name.Local.t -> Compile.t
 
-  val resolve : t -> Loc.t * string -> lib Or_exn.t
+  val resolve : t -> Loc.t * Lib_name.t -> lib Or_exn.t
 
   (** Resolve libraries written by the user in a jbuild file. The
       resulting list of libraries is transitively closed and sorted by
@@ -327,7 +328,7 @@ module Sub_system : sig
     type t
     type sub_system += T of t
     val instantiate
-      :  resolve:(Loc.t * string -> lib Or_exn.t)
+      :  resolve:(Loc.t * Lib_name.t -> lib Or_exn.t)
       -> get:(loc:Loc.t -> lib -> t option)
       -> lib
       -> Info.t
@@ -346,7 +347,7 @@ end with type lib := t
 (** {1 Dependencies for META files} *)
 
 module Meta : sig
-  val requires                               : t -> String.Set.t
-  val ppx_runtime_deps                       : t -> String.Set.t
-  val ppx_runtime_deps_for_deprecated_method : t -> String.Set.t
+  val requires                               : t -> Lib_name.Set.t
+  val ppx_runtime_deps                       : t -> Lib_name.Set.t
+  val ppx_runtime_deps_for_deprecated_method : t -> Lib_name.Set.t
 end

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -284,8 +284,7 @@ module DB : sig
 
   (** Retrieve the compile information for the given library. Works
       for libraries that are optional and not available as well. *)
-  val get_compile_info
-    : t -> ?allow_overlaps:bool -> Lib_name.Local.t -> Compile.t
+  val get_compile_info : t -> ?allow_overlaps:bool -> Lib_name.t -> Compile.t
 
   val resolve : t -> Loc.t * Lib_name.t -> lib Or_exn.t
 

--- a/src/lib_deps_info.ml
+++ b/src/lib_deps_info.ml
@@ -11,10 +11,10 @@ module Kind = struct
     | _ -> Required
 end
 
-type t = Kind.t String.Map.t
+type t = Kind.t Lib_name.Map.t
 
 let merge a b =
-  String.Map.merge a b ~f:(fun _ a b ->
+  Lib_name.Map.merge a b ~f:(fun _ a b ->
     match a, b with
     | None, None -> None
     | x, None | None, x -> x

--- a/src/lib_deps_info.mli
+++ b/src/lib_deps_info.mli
@@ -13,6 +13,6 @@ module Kind : sig
   val merge : t -> t -> t
 end
 
-type t = Kind.t String.Map.t
+type t = Kind.t Lib_name.Map.t
 
 val merge : t -> t -> t

--- a/src/lib_name.ml
+++ b/src/lib_name.ml
@@ -94,7 +94,7 @@ let to_sexp t = Sexp.Atom t
 
 let to_string t = t
 
-let of_string_exn s = s
+let of_string_exn ~loc:_ s = s
 
 let of_local t = t
 

--- a/src/lib_name.ml
+++ b/src/lib_name.ml
@@ -101,7 +101,11 @@ let of_local t = t
 type t = string
 
 module Map = Map.Make(String)
-module Set = Set.Make(String)
+module Set = struct
+  include Set.Make(String)
+
+  let to_string_list = to_list
+end
 
 let root_lib t =
   match String.lsplit2 t ~on:'.' with
@@ -112,3 +116,9 @@ let package_name t =
   Package.Name.of_string (root_lib t)
 
 let nest x y = sprintf "%s.%s" x y
+
+module L = struct
+  let to_key = function
+    | [] -> "+none+"
+    | names  -> String.concat ~sep:"+" names
+end

--- a/src/lib_name.ml
+++ b/src/lib_name.ml
@@ -1,0 +1,114 @@
+open Stdune
+
+exception Invalid_lib_name of string
+
+let dgen = Dsexp.To_sexp.string
+let dparse = Dsexp.Of_sexp.string
+
+module Local = struct
+  type t = string
+
+  type result =
+    | Ok of t
+    | Warn of t
+    | Invalid
+
+  let valid_char = function
+    | 'A'..'Z' | 'a'..'z' | '_' | '0'..'9' -> true
+    | _ -> false
+
+  let of_string (name : string) =
+    match name with
+    | "" -> Invalid
+    | (s : string) ->
+      if s.[0] = '.' then
+        Invalid
+      else
+        let len = String.length s in
+        let rec loop warn i =
+          if i = len - 1 then
+            if warn then Warn s else Ok s
+          else
+            let c = String.unsafe_get s i in
+            if valid_char c then
+              loop warn (i + 1)
+            else if c = '.' then
+              loop true (i + 1)
+            else
+              Invalid
+        in
+        loop false 0
+
+  let of_string_exn s =
+    match of_string s with
+    | Ok s -> s
+    | Warn _
+    | Invalid -> raise (Invalid_lib_name s)
+
+  let dparse_loc =
+    Dsexp.Of_sexp.plain_string (fun ~loc s -> (loc, of_string s))
+
+  let dgen = Dsexp.To_sexp.string
+
+  let to_sexp = Sexp.To_sexp.string
+
+  let pp_quoted fmt t = Format.fprintf fmt "%S" t
+
+  let invalid_message =
+    "invalid library name.\n\
+     Hint: library names must be non-empty and composed only of \
+     the following characters: 'A'..'Z',  'a'..'z', '_'  or '0'..'9'"
+
+  let wrapped_message =
+    sprintf
+      "%s.\n\
+       This is temporary allowed for libraries with (wrapped false).\
+       \nIt will not be supported in the future. \
+       Please choose a valid name field."
+      invalid_message
+
+  let validate (loc, res) ~wrapped =
+    match res, wrapped with
+    | Ok s, _ -> s
+    | Warn _, true -> Errors.fail loc "%s" wrapped_message
+    | Warn s, false -> Errors.warn loc "%s" wrapped_message; s
+    | Invalid, _ -> Errors.fail loc "%s" invalid_message
+
+  let to_string s = s
+end
+
+let split t =
+  match String.split t ~on:'.' with
+  | [] -> assert false
+  | pkg :: rest -> (Package.Name.of_string pkg, rest)
+
+let pp = Format.pp_print_string
+
+let pp_quoted fmt t = Format.fprintf fmt "%S" t
+
+let compare = String.compare
+
+let to_local = Local.of_string
+
+let to_sexp t = Sexp.Atom t
+
+let to_string t = t
+
+let of_string_exn s = s
+
+let of_local t = t
+
+type t = string
+
+module Map = Map.Make(String)
+module Set = Set.Make(String)
+
+let root_lib t =
+  match String.lsplit2 t ~on:'.' with
+  | None -> t
+  | Some (p, _) -> p
+
+let package_name t =
+  Package.Name.of_string (root_lib t)
+
+let nest x y = sprintf "%s.%s" x y

--- a/src/lib_name.mli
+++ b/src/lib_name.mli
@@ -2,7 +2,7 @@ open Stdune
 
 type t
 
-val of_string_exn : string -> t
+val of_string_exn : loc:Loc.t option -> string -> t
 val to_string : t -> string
 
 include Dsexp.Sexpable with type t := t

--- a/src/lib_name.mli
+++ b/src/lib_name.mli
@@ -1,0 +1,56 @@
+open Stdune
+
+type t
+
+val of_string_exn : string -> t
+val to_string : t -> string
+
+include Dsexp.Sexpable with type t := t
+
+module Local : sig
+  type t
+
+  type result =
+    | Ok of t
+    | Warn of t
+    | Invalid
+
+  val dgen : t Dsexp.To_sexp.t
+  val dparse_loc : (Loc.t * result) Dsexp.Of_sexp.t
+  val validate : (Loc.t * result) -> wrapped:bool -> t
+
+  val to_sexp : t Sexp.To_sexp.t
+
+  val of_string_exn : string -> t
+
+  val of_string : string -> result
+
+  val to_string : t -> string
+
+  val invalid_message : string
+
+  val pp_quoted : t Fmt.t
+end
+
+val compare : t -> t -> Ordering.t
+
+val pp : t Fmt.t
+
+val pp_quoted : t Fmt.t
+
+val of_local : Local.t -> t
+
+val to_local : t -> Local.result
+
+val split : t -> Package.Name.t * string list
+
+val package_name : t -> Package.Name.t
+
+val root_lib : t -> t
+
+module Map : Map.S with type key = t
+module Set : Set.S with type elt = t
+
+val to_sexp : t Sexp.To_sexp.t
+
+val nest : t -> t -> t

--- a/src/lib_name.mli
+++ b/src/lib_name.mli
@@ -49,8 +49,15 @@ val package_name : t -> Package.Name.t
 val root_lib : t -> t
 
 module Map : Map.S with type key = t
-module Set : Set.S with type elt = t
+module Set : sig
+  include Set.S with type elt = t
+  val to_string_list : t -> string list
+end
 
 val to_sexp : t Sexp.To_sexp.t
 
 val nest : t -> t -> t
+
+module L : sig
+  val to_key : t list -> string
+end

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -422,7 +422,7 @@ module Gen (P : Install_rules.Params) = struct
   let rules (lib : Library.t) ~dir_contents ~dir ~scope
         ~dir_kind : Compilation_context.t * Merlin.t =
     let compile_info =
-      Lib.DB.get_compile_info (Scope.libs scope) lib.name
+      Lib.DB.get_compile_info (Scope.libs scope) (Library.best_name lib)
         ~allow_overlaps:lib.buildable.allow_overlapping_dependencies
     in
     SC.Libs.gen_select_rules sctx compile_info ~dir;

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -35,7 +35,7 @@ module Gen (P : Install_rules.Params) = struct
         if not (Library.has_stubs lib) then
           []
         else
-          let stubs_name = lib.name ^ "_stubs" in
+          let stubs_name = Lib_name.Local.to_string lib.name ^ "_stubs" in
           match mode with
           | Byte -> ["-dllib"; "-l" ^ stubs_name; "-cclib"; "-l" ^ stubs_name]
           | Native -> ["-cclib"; "-l" ^ stubs_name]
@@ -175,7 +175,8 @@ module Gen (P : Install_rules.Params) = struct
          [ As (Utils.g ())
          ; if custom then A "-custom" else As []
          ; A "-o"
-         ; Path (Path.relative dir (sprintf "%s_stubs" lib.name))
+         ; Path (Path.relative dir (sprintf "%s_stubs"
+                                      (Lib_name.Local.to_string lib.name)))
          ; Deps o_files
          ; Dyn (fun cclibs ->
              (* https://github.com/ocaml/dune/issues/119 *)

--- a/src/main.ml
+++ b/src/main.ml
@@ -133,8 +133,8 @@ let external_lib_deps ?log ~packages () =
      Path.Map.map
        (Build_system.all_lib_deps setup.build_system
           ~request:(Build.paths install_files))
-       ~f:(String.Map.filteri ~f:(fun name _ ->
-         not (String.Set.mem internals name))))
+       ~f:(Lib_name.Map.filteri ~f:(fun name _ ->
+         not (Lib_name.Set.mem internals name))))
 
 let ignored_during_bootstrap =
   Path.Set.of_list

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -70,7 +70,7 @@ type t =
   { requires   : Lib.Set.t
   ; flags      : (unit, string list) Build.t
   ; preprocess : Preprocess.t
-  ; libname    : string option
+  ; libname    : Lib_name.Local.t option
   ; source_dirs: Path.Set.t
   ; objs_dirs  : Path.Set.t
   }

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -9,7 +9,7 @@ val make
   :  ?requires:Lib.t list Or_exn.t
   -> ?flags:(unit, string list) Build.t
   -> ?preprocess:Dune_file.Preprocess.t
-  -> ?libname:string
+  -> ?libname:Lib_name.Local.t
   -> ?source_dirs: Path.Set.t
   -> ?objs_dirs:Path.Set.t
   -> unit

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -34,7 +34,7 @@ module Parse = struct
     | String s ->
       if String.contains s '.' then
         error lb "'.' not allowed in sub-package names";
-      Lib_name.of_string_exn s
+      Lib_name.of_string_exn ~loc:None s
     | _ -> error lb "package name expected"
 
   let string lb =
@@ -203,7 +203,7 @@ let builtins ~stdlib_dir =
       | None -> name
       | Some a -> a
     in
-    let name = Lib_name.of_string_exn name in
+    let name = Lib_name.of_string_exn ~loc:None name in
     let archives = archives archive_name in
     { name = Some name
     ; entries =
@@ -218,7 +218,7 @@ let builtins ~stdlib_dir =
     let sub name deps =
       Package (simple name deps ~archive_name:("ocaml" ^ name))
     in
-    { name = Some (Lib_name.of_string_exn "compiler-libs")
+    { name = Some (Lib_name.of_string_exn ~loc:None "compiler-libs")
     ; entries =
         [ requires []
         ; version
@@ -234,7 +234,7 @@ let builtins ~stdlib_dir =
   let unix = simple "unix" [] ~dir:"+" in
   let bigarray = simple "bigarray" ["unix"] ~dir:"+" in
   let threads =
-    { name = Some (Lib_name.of_string_exn "threads")
+    { name = Some (Lib_name.of_string_exn ~loc:None "threads")
     ; entries =
         [ version
         ; requires ~preds:[Pos "mt"; Pos "mt_vm"   ] ["threads.vm"]
@@ -249,7 +249,7 @@ let builtins ~stdlib_dir =
     }
   in
   let num =
-    { name = Some (Lib_name.of_string_exn "num")
+    { name = Some (Lib_name.of_string_exn ~loc:None "num")
     ; entries =
         [ requires ["num.core"]
         ; version

--- a/src/meta.mli
+++ b/src/meta.mli
@@ -4,7 +4,7 @@ open! Stdune
 open! Import
 
 type t =
-  { name    : string
+  { name    : Lib_name.t option
   ; entries : entry list
   }
 
@@ -35,7 +35,7 @@ module Simplified : sig
   end
 
   type t =
-    { name : string
+    { name : Lib_name.t option
     ; vars : Rules.t String.Map.t
     ; subs : t list
     }
@@ -43,10 +43,10 @@ module Simplified : sig
   val pp : Format.formatter -> t -> unit
 end
 
-val load : Path.t -> name:string -> Simplified.t
+val load : Path.t -> name:Lib_name.t option -> Simplified.t
 
 (** Builtin META files for libraries distributed with the compiler. For when ocamlfind is
     not installed. *)
-val builtins : stdlib_dir:Path.t -> Simplified.t String.Map.t
+val builtins : stdlib_dir:Path.t -> Simplified.t Lib_name.Map.t
 
 val pp : Format.formatter -> entry list -> unit

--- a/src/module.ml
+++ b/src/module.ml
@@ -122,7 +122,8 @@ let iter t ~f =
   Option.iter t.intf ~f:(f Ml_kind.Intf)
 
 let with_wrapper t ~libname =
-  { t with obj_name = sprintf "%s__%s" libname t.name }
+  { t with obj_name
+           = sprintf "%s__%s" (Lib_name.Local.to_string libname) t.name }
 
 let map_files t ~f =
   { t with

--- a/src/module.mli
+++ b/src/module.mli
@@ -87,7 +87,7 @@ val iter : t -> f:(Ml_kind.t -> File.t -> unit) -> unit
 val has_impl : t -> bool
 
 (** Prefix the object name with the library name. *)
-val with_wrapper : t -> libname:string -> t
+val with_wrapper : t -> libname:Lib_name.Local.t -> t
 
 val map_files : t -> f:(Ml_kind.t -> File.t -> File.t) -> t
 

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -351,7 +351,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
       () (* rules were already setup lazily in gen_rules *)
     | "_odoc" :: "lib" :: lib :: _ ->
       let lib, lib_db = SC.Scope_key.of_string sctx lib in
-      let lib = Lib_name.of_string_exn lib in
+      let lib = Lib_name.of_string_exn ~loc:None lib in
       begin match Lib.DB.find lib_db lib with
       | Error _ -> ()
       | Ok lib  -> SC.load_dir sctx ~dir:(Lib.src_dir lib)
@@ -360,7 +360,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
       (* TODO we can be a better with the error handling in the case where
          lib_unique_name_or_pkg is neither a valid pkg or lnu *)
       let lib, lib_db = SC.Scope_key.of_string sctx lib_unique_name_or_pkg in
-      let lib = Lib_name.of_string_exn lib in
+      let lib = Lib_name.of_string_exn ~loc:None lib in
       let setup_pkg_html_rules pkg =
         setup_pkg_html_rules ~pkg ~libs:(
           Lib.Set.to_list (load_all_odoc_rules_pkg ~pkg)) in

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -197,7 +197,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
         ~requires ~(dep_graphs:Ocamldep.Dep_graph.t Ml_kind.Dict.t) =
     let lib =
       Option.value_exn (Lib.DB.find_even_when_hidden (Scope.libs scope)
-                          (Lib_name.of_local library.name)) in
+                          (Library.best_name library)) in
     (* Using the proper package name doesn't actually work since odoc assumes
        that a package contains only 1 library *)
     let pkg_or_lnu = pkg_or_lnu lib in
@@ -517,7 +517,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
                let scope = SC.find_scope_by_dir sctx w.ctx_dir in
                Some (Option.value_exn (
                  Lib.DB.find_even_when_hidden (Scope.libs scope)
-                   (Lib_name.of_local l.name))
+                   (Library.best_name l))
                )
              end
            | _ -> None

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -356,13 +356,7 @@ let ppx_driver_exe sctx libs ~dir_kind =
       | None  , Some _ -> scope_for_key
       | None  , None   -> None)
   in
-  let key =
-    match names with
-    | [] -> "+none+"
-    | _  ->
-      List.map names ~f:Lib_name.to_string
-      |> String.concat ~sep:"+"
-  in
+  let key = Lib_name.L.to_key names in
   let key =
     match scope_for_key with
     | None            -> key

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -199,7 +199,7 @@ module Jbuild_driver = struct
         ~lexer:Dsexp.Lexer.jbuild_token
       |> Dsexp.Of_sexp.parse Driver.Info.parse parsing_context
     in
-    (Pp.of_string name,
+    (Pp.of_string ~loc:None name,
      { info
      ; lib = lazy (assert false)
      ; replaces = Ok []
@@ -221,9 +221,9 @@ module Jbuild_driver = struct
   |}
 
   let drivers =
-    [ Pp.of_string "ocaml-migrate-parsetree.driver-main" , omp
-    ; Pp.of_string "ppxlib.runner"                       , ppxlib
-    ; Pp.of_string "ppx_driver.runner"                   , ppx_driver
+    [ Pp.of_string ~loc:None "ocaml-migrate-parsetree.driver-main" , omp
+    ; Pp.of_string ~loc:None "ppxlib.runner"                       , ppxlib
+    ; Pp.of_string ~loc:None "ppx_driver.runner"                   , ppx_driver
     ]
 
   let get_driver pps =
@@ -323,7 +323,7 @@ let get_rules sctx key ~dir_kind =
     | [] -> []
     | driver :: rest -> List.sort rest ~compare:String.compare @ [driver]
   in
-  let pps = List.map names ~f:Dune_file.Pp.of_string in
+  let pps = List.map names ~f:(Dune_file.Pp.of_string ~loc:None) in
   build_ppx_driver sctx pps ~lib_db ~dep_kind:Required ~target:exe ~dir_kind
 
 let gen_rules sctx components =

--- a/src/preprocessing.mli
+++ b/src/preprocessing.mli
@@ -15,7 +15,7 @@ val make
   -> lint:Dune_file.Preprocess_map.t
   -> preprocess:Dune_file.Preprocess_map.t
   -> preprocessor_deps:(unit, Path.t list) Build.t
-  -> lib_name:string option
+  -> lib_name:Lib_name.Local.t option
   -> scope:Scope.t
   -> dir_kind:File_tree.Dune_file.Kind.t
   -> t
@@ -56,12 +56,12 @@ end
 (** Compatibility [ppx.exe] program for the findlib method. *)
 val get_compat_ppx_exe
   :  Super_context.t
-  -> name:string
+  -> name:Lib_name.t
   -> kind:Compat_ppx_exe_kind.t
   -> Path.t
 
 (** [cookie_library_name lib_name] is ["--cookie"; lib_name] if [lib_name] is not
     [None] *)
-val cookie_library_name : string option -> string list
+val cookie_library_name : Lib_name.Local.t option -> string list
 
 val gen_rules : Super_context.t -> string list -> unit

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -79,7 +79,7 @@ module DB = struct
         List.filter_map internal_libs ~f:(fun (_dir, lib) ->
           Option.map lib.public ~f:(fun p ->
             (Dune_file.Public_lib.name p, lib.project)))
-        |> String.Map.of_list
+        |> Lib_name.Map.of_list
         |> function
         | Ok x -> x
         | Error (name, _, _) ->
@@ -91,17 +91,17 @@ module DB = struct
           with
           | [] | [_] -> assert false
           | loc1 :: loc2 :: _ ->
-            die "Public library %S is defined twice:\n\
+            die "Public library %a is defined twice:\n\
                  - %s\n\
                  - %s"
-              name
+              Lib_name.pp_quoted name
               (Loc.to_file_colon_line loc1)
               (Loc.to_file_colon_line loc2)
       in
       Lib.DB.create ()
         ~parent:installed_libs
         ~resolve:(fun name ->
-          match String.Map.find public_libs name with
+          match Lib_name.Map.find public_libs name with
           | None -> Not_found
           | Some project ->
             let scope =
@@ -109,7 +109,7 @@ module DB = struct
                 (Project_name_map.find !by_name_cell (Dune_project.name project))
             in
             Redirect (Some scope.db, name))
-        ~all:(fun () -> String.Map.keys public_libs)
+        ~all:(fun () -> Lib_name.Map.keys public_libs)
     in
     let by_name =
       let build_context_dir = Path.relative Path.build_dir context in

--- a/src/stdune/fmt.ml
+++ b/src/stdune/fmt.ml
@@ -54,3 +54,7 @@ let record fmt = function
 
 let tuple ppfa ppfb fmt (a, b) =
   Format.fprintf fmt "@[<hv>(%a, %a)@]" ppfa a ppfb b
+
+let optional ppf fmt = function
+  | None -> Format.fprintf fmt "<None>"
+  | Some a -> ppf fmt a

--- a/src/stdune/fmt.mli
+++ b/src/stdune/fmt.mli
@@ -24,3 +24,5 @@ val record : (string * unit t) list t
 val tuple : 'a t -> 'b t -> ('a * 'b) t
 
 val nl : unit t
+
+val optional : 'a t -> 'a option t

--- a/src/sub_system.ml
+++ b/src/sub_system.ml
@@ -40,7 +40,8 @@ module Register_backend(M : Backend) = struct
     Lib.DB.resolve db (loc, name) >>= fun lib ->
     match get lib with
     | None ->
-      Error (Errors.exnf loc "%S is not %s %s" name M.desc_article
+      Error (Errors.exnf loc "%a is not %s %s" Lib_name.pp_quoted name
+               M.desc_article
                (M.desc ~plural:false))
     | Some t -> Ok t
 
@@ -60,7 +61,7 @@ module Register_backend(M : Backend) = struct
              (List.map backends ~f:(fun t ->
                 let lib = M.lib t in
                 sprintf "- %S in %s"
-                  (Lib.name lib)
+                  (Lib_name.to_string (Lib.name lib))
                   (Path.to_string_maybe_quoted (Lib.src_dir lib)))))
       | No_backend_found ->
         Errors.exnf loc "No %s found." (M.desc ~plural:false)

--- a/src/sub_system_intf.ml
+++ b/src/sub_system_intf.ml
@@ -12,7 +12,7 @@ module type S = sig
 
   (** Create an instance of the sub-system *)
   val instantiate
-    :  resolve:(Loc.t * string -> Lib.t Or_exn.t)
+    :  resolve:(Loc.t * Lib_name.t -> Lib.t Or_exn.t)
     -> get:(loc:Loc.t -> Lib.t -> t option)
     -> Lib.t
     -> Info.t
@@ -44,7 +44,7 @@ module type Registered_backend = sig
   val get : Lib.t -> t option
 
   (** Resolve a backend name *)
-  val resolve : Lib.DB.t -> Loc.t * string -> t Or_exn.t
+  val resolve : Lib.DB.t -> Loc.t * Lib_name.t -> t Or_exn.t
 
   module Selection_error : sig
     type nonrec t =
@@ -105,7 +105,7 @@ module type End_point = sig
     include Info
 
     (** Additional backends specified by the user at use-site *)
-    val backends : t -> (Loc.t * string) list option
+    val backends : t -> (Loc.t * Lib_name.t) list option
   end
 
   val gen_rules

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -541,7 +541,7 @@ let create
           let keep =
             match (stanza : Stanza.t) with
             | Library lib ->
-              Lib.DB.available (Scope.libs scope) (Lib_name.of_local lib.name)
+              Lib.DB.available (Scope.libs scope) (Library.best_name lib)
             | Documentation _
             | Install _   -> true
             | _           -> false

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -261,7 +261,7 @@ end = struct
     match String.lsplit2 s ~on:':' with
     | None ->
       Errors.fail loc "invalid %%{lib:...} form: %s" s
-    | Some (lib, f) -> (Lib_name.of_string_exn lib, f)
+    | Some (lib, f) -> (Lib_name.of_string_exn ~loc:(Some loc) lib, f)
 
   open Build.O
 
@@ -330,7 +330,7 @@ end = struct
               end
           end
         | Macro (Lib_available, s) -> begin
-            let lib = Lib_name.of_string_exn s in
+            let lib = Lib_name.of_string_exn ~loc:(Some loc) s in
             Resolved_forms.add_lib_dep acc lib Optional;
             Some (str_exp (string_of_bool (
               Lib.DB.available (Scope.libs scope) lib)))

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -63,7 +63,7 @@ val public_libs : t -> Lib.DB.t
 val installed_libs : t -> Lib.DB.t
 
 (** All non-public library names *)
-val internal_lib_names : t -> String.Set.t
+val internal_lib_names : t -> Lib_name.Set.t
 
 (** Compute the ocaml flags based on the directory environment and a
     buildable stanza *)

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -107,7 +107,7 @@ let describe_target fn =
     Path.to_string_maybe_quoted fn
 
 let library_object_directory ~dir name =
-  Path.relative dir ("." ^ name ^ ".objs")
+  Path.relative dir ("." ^ Lib_name.Local.to_string name ^ ".objs")
 
 (* Use "eobjs" rather than "objs" to avoid a potential conflict with a
    library of the same name *)

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -19,7 +19,7 @@ val describe_target : Path.t -> string
     library should be stored. *)
 val library_object_directory
   :  dir:Path.t
-  -> string
+  -> Lib_name.Local.t
   -> Path.t
 
 (** Return the directory where the object files for the given

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -65,7 +65,8 @@ let setup sctx ~dir ~(libs : Library.t list) ~scope =
     let requires =
       let open Result.O in
       Lib.DB.find_many (Scope.libs scope)
-        (Lib_name.of_string_exn "utop" :: List.map libs ~f:Library.best_name)
+        (Lib_name.of_string_exn ~loc:None "utop"
+         :: List.map libs ~f:Library.best_name)
       >>= Lib.closure
     in
     let cctx =

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -65,7 +65,9 @@ let setup sctx ~dir ~(libs : Library.t list) ~scope =
     let requires =
       let open Result.O in
       Lib.DB.find_many (Scope.libs scope)
-        ("utop" :: List.map libs ~f:(fun (lib : Library.t) -> lib.name))
+        (Lib_name.of_string_exn "utop"
+         :: List.map libs ~f:(fun (lib : Library.t) ->
+           Lib_name.of_local lib.name))
       >>= Lib.closure
     in
     let cctx =

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -65,9 +65,7 @@ let setup sctx ~dir ~(libs : Library.t list) ~scope =
     let requires =
       let open Result.O in
       Lib.DB.find_many (Scope.libs scope)
-        (Lib_name.of_string_exn "utop"
-         :: List.map libs ~f:(fun (lib : Library.t) ->
-           Lib_name.of_local lib.name))
+        (Lib_name.of_string_exn "utop" :: List.map libs ~f:Library.best_name)
       >>= Lib.closure
     in
     let cctx =

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -35,7 +35,7 @@ val findlib : Findlib.t = <abstr>
 |}]
 
 let pkg =
-  match Findlib.find findlib (Lib_name.of_string_exn "foo") with
+  match Findlib.find findlib (Lib_name.of_string_exn ~loc:None "foo") with
   | Ok x -> x
   | Error _ -> assert false;;
 
@@ -59,7 +59,7 @@ open Meta
 
 let meta =
   Path.in_source "test/unit-tests/findlib-db/foo/META"
-  |> Meta.load ~name:(Some (Lib_name.of_string_exn "foo"))
+  |> Meta.load ~name:(Some (Lib_name.of_string_exn ~loc:None "foo"))
 
 [%%expect{|
 val meta : Simplified.t =

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -11,9 +11,11 @@ let () =
 ;;
 
 let print_pkg ppf pkg =
-  Format.fprintf ppf "<package:%s>" (Findlib.Package.name pkg)
+  Format.fprintf ppf "<package:%s>"
+    (Lib_name.to_string (Findlib.Package.name pkg))
 ;;
 
+#install_printer Lib_name.pp_quoted;;
 #install_printer print_pkg;;
 #install_printer String.Map.pp;;
 
@@ -33,7 +35,7 @@ val findlib : Findlib.t = <abstr>
 |}]
 
 let pkg =
-  match Findlib.find findlib "foo" with
+  match Findlib.find findlib (Lib_name.of_string_exn "foo") with
   | Ok x -> x
   | Error _ -> assert false;;
 
@@ -45,7 +47,7 @@ val pkg : Findlib.Package.t = <package:foo>
 Findlib.Package.requires pkg;;
 
 [%%expect{|
-- : string list = ["baz"]
+- : Lib_name.t list = ["baz"]
 |}]
 
 (* +-----------------------------------------------------------------+
@@ -57,7 +59,7 @@ open Meta
 
 let meta =
   Path.in_source "test/unit-tests/findlib-db/foo/META"
-  |> Meta.load ~name:"foo"
+  |> Meta.load ~name:(Some (Lib_name.of_string_exn "foo"))
 
 [%%expect{|
 val meta : Simplified.t =


### PR DESCRIPTION
This is a refactoring that I wanted to do for a while now, but it's simply such a huge and tedious change. I finally managed to get it to a working state, and put up the result even though there are some rough edges. The benefit of this PR is that we now always know what kind of library names we're dealing with and expecting. It's no longer possible to introduce bugs by mixing up internal and external library names.

The rough edges of this PR are all the `of_string_exn` calls. Those should really raise on invalid library names, but currently don't to preserve backwards compat. I'm just a bit worried that a stricter `of_string_exn` will show some scary errors to users.

Another rough edge is the `Lib_name.of_local` function which doesn't really make sense. I'm thinking that would make more sense would be to allow `Lib.DB` to search things by private names rather than blindly converting local to public names.