### PR TITLE
Fix preprocessing action in src/dune

### DIFF
--- a/src/configurator/dune
+++ b/src/configurator/dune
@@ -4,5 +4,4 @@
  (name        configurator)
  (public_name dune.configurator)
  (libraries   stdune ocaml_config dsexp)
- (flags       (:standard -safe-string (:include flags/flags.sexp)))
- (preprocess  no_preprocessing))
+ (flags       (:standard -safe-string (:include flags/flags.sexp))))

--- a/src/dune
+++ b/src/dune
@@ -10,7 +10,8 @@
               ocaml_config
               which_program)
  (synopsis    "Internal Dune library, do not use!")
- (preprocess  (action (run src/let-syntax/pp.exe %{input-file}))))
+ (preprocess  (action
+               (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))
 
 (ocamllex meta_lexer glob_lexer dune_lexer)
 


### PR DESCRIPTION
So that dune itself can be vendored. Also remove useless `preprocess` field in `src/configurator/dune`.

/cc @avsm