### PR TITLE
Always display the line number in file excerpts

### DIFF
--- a/test/blackbox-tests/test-cases/bad-alias-error/run.t
+++ b/test/blackbox-tests/test-cases/bad-alias-error/run.t
@@ -1,15 +1,15 @@
   $ dune runtest --root absolute-path
   Entering directory 'absolute-path'
   File "jbuild", line 3, characters 16-24:
-    (deps ((alias /foo/bar)))))
-                  ^^^^^^^^
+  3 |   (deps ((alias /foo/bar)))))
+                      ^^^^^^^^
   Error: Invalid alias!
   Tried to reference path outside build dir: "/foo/bar"
   [1]
   $ dune runtest --root outside-workspace
   Entering directory 'outside-workspace'
   File "jbuild", line 4, characters 16-39:
-    (deps ((alias ${ROOT}/../../../foobar)))))
-                  ^^^^^^^^^^^^^^^^^^^^^^^
+  4 |   (deps ((alias ${ROOT}/../../../foobar)))))
+                      ^^^^^^^^^^^^^^^^^^^^^^^
   Error: path outside the workspace: ./../../../foobar from default
   [1]

--- a/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
+++ b/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
@@ -6,8 +6,8 @@ All builtin variables are lower cased in Dune:
   $ dune runtest --root dune-upper
   Entering directory 'dune-upper'
   File "dune", line 3, characters 41-46:
-   (action (with-stdout-to %{null} (echo %{MAKE}))))
-                                           ^^^^^
+  3 |  (action (with-stdout-to %{null} (echo %{MAKE}))))
+                                               ^^^^^
   Error: %{MAKE} was renamed to '%{make}' in the 1.0 version of the dune language
   [1]
 

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -2,8 +2,8 @@ No ppx driver found
 
   $ dune build foo1.cma
   File "dune", line 6, characters 13-18:
-   (preprocess (pps)))
-               ^^^^^
+  6 |  (preprocess (pps)))
+                   ^^^^^
   Error: You must specify at least one ppx rewriter.
   [1]
 
@@ -11,8 +11,8 @@ Too many drivers
 
   $ dune build foo2.cma
   File "dune", line 13, characters 13-28:
-   (preprocess (pps ppx1 ppx2)))
-               ^^^^^^^^^^^^^^^
+  13 |  (preprocess (pps ppx1 ppx2)))
+                    ^^^^^^^^^^^^^^^
   Error: Too many incompatible ppx drivers were found: foo.driver2 and
   foo.driver1.
   [1]
@@ -21,8 +21,8 @@ Not compatible with Dune
 
   $ dune build foo3.cma
   File "dune", line 20, characters 13-28:
-   (preprocess (pps ppx_other)))
-               ^^^^^^^^^^^^^^^
+  20 |  (preprocess (pps ppx_other)))
+                    ^^^^^^^^^^^^^^^
   Error: No ppx driver were found. It seems that ppx_other is not compatible
   with Dune. Examples of ppx rewriters that are compatible with Dune are ones
   using ocaml-migrate-parsetree, ppxlib or ppx_driver.

--- a/test/blackbox-tests/test-cases/dup-fields/run.t
+++ b/test/blackbox-tests/test-cases/dup-fields/run.t
@@ -5,8 +5,8 @@ Duplicating a field in a dune file is an error:
 
   $ dune build --root dune
   File "dune", line 4, characters 1-20:
-   (action (echo bar)))
-   ^^^^^^^^^^^^^^^^^^^
+  4 |  (action (echo bar)))
+       ^^^^^^^^^^^^^^^^^^^
   Error: Field "action" is present too many times
   [1]
 
@@ -17,8 +17,8 @@ For backward compatibility, it is only a warning in jbuild files:
 
   $ dune build --root jbuild
   File "jbuild", line 4, characters 2-21:
-    (action (echo bar))))
-    ^^^^^^^^^^^^^^^^^^^
+  4 |   (action (echo bar))))
+        ^^^^^^^^^^^^^^^^^^^
   Warning: Field "action" is present several times, previous occurrences are ignored.
   Entering directory 'jbuild'
   bar

--- a/test/blackbox-tests/test-cases/exclude-missing-module/run.t
+++ b/test/blackbox-tests/test-cases/exclude-missing-module/run.t
@@ -1,5 +1,5 @@
   $ dune build --display short
   File "dune", line 3, characters 22-26:
-   (modules :standard \ fake))
-                        ^^^^
+  3 |  (modules :standard \ fake))
+                            ^^^^
   Warning: Module Fake is excluded but it doesn't exist.

--- a/test/blackbox-tests/test-cases/exec-missing/run.t
+++ b/test/blackbox-tests/test-cases/exec-missing/run.t
@@ -2,8 +2,8 @@ When using dune exec, the external-lib-deps command refers to the executable:
 
   $ dune exec ./x.exe
   File "dune", line 3, characters 12-26:
-   (libraries does-not-exist))
-              ^^^^^^^^^^^^^^
+  3 |  (libraries does-not-exist))
+                  ^^^^^^^^^^^^^^
   Error: Library "does-not-exist" not found.
   Hint: try: dune external-lib-deps --missing ./x.exe
   [1]

--- a/test/blackbox-tests/test-cases/fallback-dune/run.t
+++ b/test/blackbox-tests/test-cases/fallback-dune/run.t
@@ -2,8 +2,8 @@ fallback isn't allowed in dune
 
   $ dune build --root dune1
   File "dune", line 2, characters 1-11:
-   (fallback)
-   ^^^^^^^^^^
+  2 |  (fallback)
+       ^^^^^^^^^^
   Error: 'fallback' was renamed to '(mode fallback)' in the 1.0 version of the dune language
   [1]
 
@@ -11,8 +11,8 @@ fallback isn't allowed in dune
 
   $ dune build --root dune2
   File "dune", line 2, characters 1-17:
-   (fallback false)
-   ^^^^^^^^^^^^^^^^
+  2 |  (fallback false)
+       ^^^^^^^^^^^^^^^^
   Error: 'fallback' was renamed to '(mode fallback)' in the 1.0 version of the dune language
   [1]
 

--- a/test/blackbox-tests/test-cases/findlib-error/run.t
+++ b/test/blackbox-tests/test-cases/findlib-error/run.t
@@ -3,8 +3,8 @@ We are dropping support for findlib in dune
   $ dune build --root in-dune target.txt
   Entering directory 'in-dune'
   File "dune", line 2, characters 25-37:
-  (write-file target.txt %{findlib:pkg})
-                           ^^^^^^^^^^^^
+  2 | (write-file target.txt %{findlib:pkg})
+                               ^^^^^^^^^^^^
   Error: %{findlib:..} was renamed to '%{lib:..}' in the 1.0 version of the dune language
   [1]
 
@@ -13,7 +13,7 @@ But it must still be available in jbuild files
   $ dune build --root in-jbuild target.txt
   Entering directory 'in-jbuild'
   File "jbuild", line 4, characters 23-42:
-  (write-file target.txt ${findlib:pkg:file})
-                         ^^^^^^^^^^^^^^^^^^^
+  4 | (write-file target.txt ${findlib:pkg:file})
+                             ^^^^^^^^^^^^^^^^^^^
   Error: Public library "pkg" not found
   [1]

--- a/test/blackbox-tests/test-cases/findlib/run.t
+++ b/test/blackbox-tests/test-cases/findlib/run.t
@@ -8,8 +8,8 @@ Reproduction case for #484. The error should point to src/jbuild
 
   $ dune build @install
   File "src/dune", line 4, characters 14-15:
-   (libraries   a b c))
-                ^
+  4 |  (libraries   a b c))
+                    ^
   Error: Library "a" not found.
   Hint: try: dune external-lib-deps --missing @install
   [1]
@@ -18,8 +18,8 @@ When passing --dev, the profile should be displayed only once (#1106):
 
   $ jbuilder build --dev @install
   File "src/dune", line 4, characters 14-15:
-   (libraries   a b c))
-                ^
+  4 |  (libraries   a b c))
+                    ^
   Error: Library "a" not found.
   Hint: try: dune external-lib-deps --missing --profile dev @install
   [1]
@@ -28,8 +28,8 @@ With dune and an explicit profile, it is the same:
 
   $ dune build --profile dev @install
   File "src/dune", line 4, characters 14-15:
-   (libraries   a b c))
-                ^
+  4 |  (libraries   a b c))
+                    ^
   Error: Library "a" not found.
   Hint: try: dune external-lib-deps --missing --profile dev @install
   [1]

--- a/test/blackbox-tests/test-cases/github1099/run.t
+++ b/test/blackbox-tests/test-cases/github1099/run.t
@@ -3,8 +3,8 @@ If the source directory does not exist, an error message is printed:
   $ dune build --root no-dir demo.exe
   Entering directory 'no-dir'
   File "dune", line 1, characters 13-23:
-  (copy_files# "no_dir/*")
-               ^^^^^^^^^^
+  1 | (copy_files# "no_dir/*")
+                   ^^^^^^^^^^
   Error: cannot find directory: no_dir
   [1]
 
@@ -13,7 +13,7 @@ This works also is a file exists with the same name:
   $ dune build --root file-with-same-name demo.exe
   Entering directory 'file-with-same-name'
   File "dune", line 1, characters 13-23:
-  (copy_files# "no_dir/*")
-               ^^^^^^^^^^
+  1 | (copy_files# "no_dir/*")
+                   ^^^^^^^^^^
   Error: cannot find directory: no_dir
   [1]

--- a/test/blackbox-tests/test-cases/github644/run.t
+++ b/test/blackbox-tests/test-cases/github644/run.t
@@ -1,7 +1,7 @@
   $ dune runtest
   File "jbuild", line 4, characters 20-42:
-    (preprocess (pps (ppx_that_doesn't_exist)))))
-                      ^^^^^^^^^^^^^^^^^^^^^^
+  4 |   (preprocess (pps (ppx_that_doesn't_exist)))))
+                          ^^^^^^^^^^^^^^^^^^^^^^
   Error: Library "ppx_that_doesn't_exist" not found.
   Hint: try: dune external-lib-deps --missing @runtest
   [1]

--- a/test/blackbox-tests/test-cases/github734/run.t
+++ b/test/blackbox-tests/test-cases/github734/run.t
@@ -1,6 +1,6 @@
   $ jbuilder build @foo
   File "src/dune", line 4, characters 10-17:
-   (c_names stubs/x))
-            ^^^^^^^
+  4 |  (c_names stubs/x))
+                ^^^^^^^
   Error: File src/stubs/x.c is not part of the current directory group. This is not allowed.
   [1]

--- a/test/blackbox-tests/test-cases/github761/run.t
+++ b/test/blackbox-tests/test-cases/github761/run.t
@@ -1,6 +1,6 @@
   $ jbuilder build @bar
   File "dune", line 2, characters 7-14:
-   (name foo/bar)
-         ^^^^^^^
+  2 |  (name foo/bar)
+             ^^^^^^^
   Error: "foo/bar" is not a valid alias name
   [1]

--- a/test/blackbox-tests/test-cases/github784/run.t
+++ b/test/blackbox-tests/test-cases/github784/run.t
@@ -1,6 +1,6 @@
   $ dune build
   File "dune", line 1, characters 0-28:
-  (rule (run %{bin:echo} foo))
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  1 | (rule (run %{bin:echo} foo))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Rule has no targets specified
   [1]

--- a/test/blackbox-tests/test-cases/github992/run.t
+++ b/test/blackbox-tests/test-cases/github992/run.t
@@ -17,13 +17,13 @@ argument of "package".
 
   $ cd package-without-pub-name && dune build -p foo
   File "dune", line 3, characters 1-14:
-   (package foo))
-   ^^^^^^^^^^^^^
+  3 |  (package foo))
+       ^^^^^^^^^^^^^
   Error: This field is useless without a (public_name ...) field.
   [1]
 
   $ cd package-without-pub-name-jbuild && dune build -p foo
   File "jbuild", line 3, characters 2-15:
-    (package foo)))
-    ^^^^^^^^^^^^^
+  3 |   (package foo)))
+        ^^^^^^^^^^^^^
   Warning: This field is useless without a (public_name ...) field.

--- a/test/blackbox-tests/test-cases/include-loop/run.t
+++ b/test/blackbox-tests/test-cases/include-loop/run.t
@@ -1,7 +1,7 @@
   $ dune build --display short
   File "dune", line 1, characters 0-15:
-  (include a.inc)
-  ^^^^^^^^^^^^^^^
+  1 | (include a.inc)
+      ^^^^^^^^^^^^^^^
   Error: Recursive inclusion of jbuild files detected:
   File a.inc is included from c.inc:1
   --> included from b.inc:1

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -6,15 +6,15 @@
 
   $ dune runtest missing-backend
   File "missing-backend/dune", line 3, characters 1-15:
-   (inline_tests))
-   ^^^^^^^^^^^^^^
+  3 |  (inline_tests))
+       ^^^^^^^^^^^^^^
   Error: No inline tests backend found.
   [1]
 
   $ dune runtest too-many-backends
   File "too-many-backends/dune", line 17, characters 1-15:
-   (inline_tests)
-   ^^^^^^^^^^^^^^
+  17 |  (inline_tests)
+        ^^^^^^^^^^^^^^
   Error: Too many independent inline tests backends found:
   - "backend_tmb1" in _build/default/too-many-backends
   - "backend_tmb2" in _build/default/too-many-backends

--- a/test/blackbox-tests/test-cases/intf-only/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/run.t
@@ -37,8 +37,8 @@ Errors:
   $ dune build --display short --root b foo.cma
   Entering directory 'b'
   File "dune", line 3, characters 33-34:
-   (modules_without_implementation x))
-                                   ^
+  3 |  (modules_without_implementation x))
+                                       ^
   Warning: The following modules must be listed here as they don't have an implementation:
   - y
   This will become an error in the future.
@@ -47,14 +47,14 @@ Errors:
   $ dune build --display short --root c foo.cma
   Entering directory 'c'
   File "dune", line 3, characters 33-34:
-   (modules_without_implementation x))
-                                   ^
+  3 |  (modules_without_implementation x))
+                                       ^
   Error: Module X doesn't exist.
   [1]
   $ dune build --display short --root d foo.cma
   Entering directory 'd'
   File "dune", line 3, characters 33-34:
-   (modules_without_implementation x))
-                                   ^
+  3 |  (modules_without_implementation x))
+                                       ^
   Error: Module X has an implementation, it cannot be listed here
   [1]

--- a/test/blackbox-tests/test-cases/macro-expand-error/run.t
+++ b/test/blackbox-tests/test-cases/macro-expand-error/run.t
@@ -3,7 +3,7 @@ inappropariate place:
 
   $ dune build
   File "dune", line 1, characters 14-21:
-  (copy_files %{read:x}/*)
-                ^^^^^^^
+  1 | (copy_files %{read:x}/*)
+                    ^^^^^^^
   Error: %{read:..} isn't allowed in this position
   [1]

--- a/test/blackbox-tests/test-cases/misc/run.t
+++ b/test/blackbox-tests/test-cases/misc/run.t
@@ -1,7 +1,7 @@
   $ dune runtest --display short
   File "dune", line 44, characters 19-42:
-   (deps (glob_files dir-that-doesnt-exist/*)))
-                     ^^^^^^^^^^^^^^^^^^^^^^^
+  44 |  (deps (glob_files dir-that-doesnt-exist/*)))
+                          ^^^^^^^^^^^^^^^^^^^^^^^
   Warning: Directory dir-that-doesnt-exist doesn't exist.
           diff alias runtest
           diff alias runtest

--- a/test/blackbox-tests/test-cases/missing-loc-run/run.t
+++ b/test/blackbox-tests/test-cases/missing-loc-run/run.t
@@ -14,8 +14,8 @@ Path that needs to be searched:
   $ dune runtest --root search-path
   Entering directory 'search-path'
   File "dune", line 3, characters 14-32:
-   (action (run foo-does-not-exist)))
-                ^^^^^^^^^^^^^^^^^^
+  3 |  (action (run foo-does-not-exist)))
+                    ^^^^^^^^^^^^^^^^^^
   Error: Error: Program foo-does-not-exist not found in the tree or in PATH (context: default)
   [1]
 

--- a/test/blackbox-tests/test-cases/multi-dir/run.t
+++ b/test/blackbox-tests/test-cases/multi-dir/run.t
@@ -36,16 +36,16 @@ Test some error cases
   $ dune build --root error2
   Entering directory 'error2'
   File "dune", line 2, characters 0-29:
-  (include_subdirs unqualified)
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  2 | (include_subdirs unqualified)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: The 'include_subdirs' stanza cannot appear more than once
   [1]
 
   $ dune build --root error3
   Entering directory 'error3'
   File "src/gen/dune", line 1, characters 0-23:
-  (executable (name gen))
-  ^^^^^^^^^^^^^^^^^^^^^^^
+  1 | (executable (name gen))
+      ^^^^^^^^^^^^^^^^^^^^^^^
   Error: This stanza is not allowed in a sub-directory of directory with (include_subdirs unqualified).
   Hint: add (include_subdirs no) to this file.
   [1]

--- a/test/blackbox-tests/test-cases/name-field-validation/run.t
+++ b/test/blackbox-tests/test-cases/name-field-validation/run.t
@@ -1,7 +1,7 @@
   $ dune exec ./bar.exe
   File "dune", line 3, characters 7-14:
-   (name foo.bar)
-         ^^^^^^^
+  3 |  (name foo.bar)
+             ^^^^^^^
   Warning: invalid library name.
   Hint: library names must be non-empty and composed only of the following characters: 'A'..'Z',  'a'..'z', '_'  or '0'..'9'.
   This is temporary allowed for libraries with (wrapped false).

--- a/test/blackbox-tests/test-cases/no-name-field/run.t
+++ b/test/blackbox-tests/test-cases/no-name-field/run.t
@@ -5,8 +5,8 @@ the name field can be omitted for libraries when public_name is present
 this isn't possible for older syntax <= (1, 0)
   $ dune build --root no-name-lib-syntax-1-0
   File "dune", line 1, characters 22-25:
-  (library (public_name foo))
-                        ^^^
+  1 | (library (public_name foo))
+                            ^^^
   Error: name field cannot be omitted before version 1.1 of the dune language
   [1]
 
@@ -17,8 +17,8 @@ executable(s) stanza works the same way
 
   $ dune build --root no-name-exes-syntax-1-0
   File "dune", line 1, characters 0-36:
-  (executables (public_names foo bar))
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  1 | (executables (public_names foo bar))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: names field may not be omitted before dune version 1.1
   [1]
 
@@ -26,8 +26,8 @@ there's only a public name but it's invalid as a name
 
   $ dune build --root public-name-invalid-name
   File "dune", line 1, characters 22-28:
-  (library (public_name c.find))
-                        ^^^^^^
+  1 | (library (public_name c.find))
+                            ^^^^^^
   Error: invalid library name.
   Hint: library names must be non-empty and composed only of the following characters: 'A'..'Z',  'a'..'z', '_'  or '0'..'9'.
   Public library names don't have this restriction. You can either change this public name to be a valid library name or add a "name" field with a valid library name.
@@ -39,8 +39,8 @@ it's just a warning
   $ dune build --root public-name-invalid-wrapped-false
   Info: creating file dune-project with this contents: (lang dune 1.2)
   File "dune", line 3, characters 14-21:
-   (public_name foo.bar))
-                ^^^^^^^
+  3 |  (public_name foo.bar))
+                    ^^^^^^^
   Error: invalid library name.
   Hint: library names must be non-empty and composed only of the following characters: 'A'..'Z',  'a'..'z', '_'  or '0'..'9'.
   Public library names don't have this restriction. You can either change this public name to be a valid library name or add a "name" field with a valid library name.

--- a/test/blackbox-tests/test-cases/path-variables/run.t
+++ b/test/blackbox-tests/test-cases/path-variables/run.t
@@ -9,8 +9,8 @@ In expands to a file name, and registers this as a dependency.
   $ dune build --root dune @test-dep
   Entering directory 'dune'
   File "dune", line 13, characters 17-47:
-          (echo "%{path:file-that-does-not-exist}\n")
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  13 |         (echo "%{path:file-that-does-not-exist}\n")
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: %{path:..} was renamed to '%{dep:..}' in the 1.0 version of the dune language
   [1]
 
@@ -22,8 +22,8 @@ This form does not exist, but displays an hint:
   $ dune build --root dune-invalid @test-path-no-dep
   Entering directory 'dune-invalid'
   File "dune", line 7, characters 17-54:
-          (echo "%{path-no-dep:file-that-does-not-exist}\n")
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  7 |         (echo "%{path-no-dep:file-that-does-not-exist}\n")
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: %{path-no-dep:..} was deleted in version 1.0 of the dune language
   [1]
 
@@ -57,7 +57,7 @@ This form does not exist, but displays an hint:
   $ dune build --root jbuild-invalid @test-dep
   Entering directory 'jbuild-invalid'
   File "jbuild", line 5, characters 16-37:
-     (action (cat ${dep:generated-file}))))
-                  ^^^^^^^^^^^^^^^^^^^^^
+  5 |    (action (cat ${dep:generated-file}))))
+                      ^^^^^^^^^^^^^^^^^^^^^
   Error: ${dep:..} is only available since version 1.0 of the dune language
   [1]

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -3,8 +3,8 @@ public libraries may not have private dependencies
   $ dune build --display short --root private-dep
   Entering directory 'private-dep'
   File "dune", line 8, characters 12-22:
-   (libraries privatelib)
-              ^^^^^^^^^^
+  8 |  (libraries privatelib)
+                  ^^^^^^^^^^
   Error: Library "privatelib" is private, it cannot be a dependency of a public library.
   You need to give "privatelib" a public name.
       ocamldep .publiclib.objs/publiclib.ml.d
@@ -29,8 +29,8 @@ Unless they introduce private runtime dependencies:
   $ dune build --display short --root private-runtime-deps
   Entering directory 'private-runtime-deps'
   File "jbuild", line 16, characters 20-31:
-    (preprocess (pps (private_ppx)))
-                      ^^^^^^^^^^^
+  16 |   (preprocess (pps (private_ppx)))
+                           ^^^^^^^^^^^
   Error: Library "private_runtime_dep" is private, it cannot be a dependency of a public library.
   You need to give "private_runtime_dep" a public name.
         ocamlc .private_ppx.objs/private_ppx.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/quoting/run.t
+++ b/test/blackbox-tests/test-cases/quoting/run.t
@@ -4,8 +4,8 @@ that ${@} is not quoted and doesn't contain exactly 1 element
   $ dune build --root bad x
   Entering directory 'bad'
   File "dune", line 3, characters 27-35:
-   (action (with-stdout-to %{targets} (echo foo))))
-                             ^^^^^^^^
+  3 |  (action (with-stdout-to %{targets} (echo foo))))
+                                 ^^^^^^^^
   Error: Variable %{targets} expands to 2 values, however a single value is expected here. Please quote this atom.
   [1]
 
@@ -29,14 +29,14 @@ The targets should only be interpreted as a single path when quoted
 
   $ dune build @quoted --root filename-space
   File "dune", line 4, characters 17-18:
-   (action (echo %{read:foo bar.txt})))
-                   ^
+  4 |  (action (echo %{read:foo bar.txt})))
+                       ^
   Error: This character is not allowed inside %{...} forms
   [1]
 
   $ dune build @unquoted --root filename-space
   File "dune", line 4, characters 17-18:
-   (action (echo %{read:foo bar.txt})))
-                   ^
+  4 |  (action (echo %{read:foo bar.txt})))
+                       ^
   Error: This character is not allowed inside %{...} forms
   [1]

--- a/test/blackbox-tests/test-cases/several-packages/run.t
+++ b/test/blackbox-tests/test-cases/several-packages/run.t
@@ -19,8 +19,8 @@ displayed. This can happen for:
 
   $ dune build --root documentation
   File "dune", line 1, characters 0-15:
-  (documentation)
-  ^^^^^^^^^^^^^^^
+  1 | (documentation)
+      ^^^^^^^^^^^^^^^
   Error: I can't determine automatically which package this stanza is for.
   I have the choice between these ones:
   - pkg1 (because of pkg1.opam)

--- a/test/blackbox-tests/test-cases/syntax-versioning/run.t
+++ b/test/blackbox-tests/test-cases/syntax-versioning/run.t
@@ -1,8 +1,8 @@
   $ echo '(jbuild_version 1)' > dune
   $ dune build
   File "dune", line 1, characters 0-18:
-  (jbuild_version 1)
-  ^^^^^^^^^^^^^^^^^^
+  1 | (jbuild_version 1)
+      ^^^^^^^^^^^^^^^^^^
   Error: 'jbuild_version' was deleted in version 1.0 of the dune language
   [1]
   $ rm -f dune
@@ -14,8 +14,8 @@
   $ echo '(executable (name x) (link_executables false))' > dune
   $ dune build
   File "dune", line 1, characters 21-45:
-  (executable (name x) (link_executables false))
-                       ^^^^^^^^^^^^^^^^^^^^^^^^
+  1 | (executable (name x) (link_executables false))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^
   Error: 'link_executables' was deleted in version 1.0 of the dune language
   [1]
   $ rm -f dune
@@ -23,8 +23,8 @@
   $ echo '(alias (name x) (deps x) (action (run %{<})))' > dune
   $ dune build
   File "dune", line 1, characters 40-42:
-  (alias (name x) (deps x) (action (run %{<})))
-                                          ^^
+  1 | (alias (name x) (deps x) (action (run %{<})))
+                                              ^^
   Error: %{<} was deleted in version 1.0 of the dune language.
   Use a named dependency instead:
   

--- a/test/blackbox-tests/test-cases/too-many-parens/run.t
+++ b/test/blackbox-tests/test-cases/too-many-parens/run.t
@@ -15,8 +15,8 @@ are readable.
 
   $ dune build --root b
   File "dune", line 4, characters 12-17:
-   (libraries (lib)))
-              ^^^^^
+  4 |  (libraries (lib)))
+                  ^^^^^
   Error: 'select' expected
   Hint: dune files require less parentheses than jbuild files.
   If you just converted this file from a jbuild file, try removing these parentheses.
@@ -24,8 +24,8 @@ are readable.
 
   $ dune build --root c
   File "dune", line 3, characters 7-14:
-   (deps (x y z)))
-         ^^^^^^^
+  3 |  (deps (x y z)))
+             ^^^^^^^
   Error: Unknown constructor x
   Hint: dune files require less parentheses than jbuild files.
   If you just converted this file from a jbuild file, try removing these parentheses.
@@ -50,8 +50,8 @@ When the inner syntax is wrong, do not warn about the parens:
 
   $ dune build --root e
   File "dune", line 3, characters 7-15:
-   (deps (glob *)) ; this form doesn't exist
-         ^^^^^^^^
+  3 |  (deps (glob *)) ; this form doesn't exist
+             ^^^^^^^^
   Error: Unknown constructor glob
   Hint: dune files require less parentheses than jbuild files.
   If you just converted this file from a jbuild file, try removing these parentheses.

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -2,8 +2,8 @@ Variant feature is auto enabled when virtual_modules is used
 
   $ dune build --root variants-without-using
   File "dune", line 3, characters 1-25:
-   (virtual_modules foobar))
-   ^^^^^^^^^^^^^^^^^^^^^^^^
+  3 |  (virtual_modules foobar))
+       ^^^^^^^^^^^^^^^^^^^^^^^^
   Error: 'virtual_modules' is only available since version 0.1 of the experimental variants feature
   [1]
 

--- a/test/blackbox-tests/test-cases/workspaces/run.t
+++ b/test/blackbox-tests/test-cases/workspaces/run.t
@@ -2,8 +2,8 @@ jbuild still discovers workspaces as usual
 
   $ jbuilder build --root jbuilder-default-name
   File "jbuild-workspace", line 1, characters 10-24:
-  (context (does-not-exist))
-            ^^^^^^^^^^^^^^
+  1 | (context (does-not-exist))
+                ^^^^^^^^^^^^^^
   Error: Unknown constructor does-not-exist
   [1]
 
@@ -16,8 +16,8 @@ dune uses a versioned file. If the version is missing, then we get an error.
 
   $ dune build --root dune-no-version
   File "dune-workspace", line 1, characters 0-19:
-  (context (default))
-  ^^^^^^^^^^^^^^^^^^^
+  1 | (context (default))
+      ^^^^^^^^^^^^^^^^^^^
   Error: Invalid first line, expected: (lang <lang> <version>)
   [1]
 


### PR DESCRIPTION
As discussed in https://github.com/ocaml/dune/pull/1196#issuecomment-417611186, we can be more consistent when printing these messages.

cc @anuragsoni 