### PR TITLE
[WIP] response file support

### DIFF
--- a/src/arg_spec.ml
+++ b/src/arg_spec.ml
@@ -87,3 +87,43 @@ let of_result_map res ~f =
   match res with
   | Ok    x -> f x
   | Error e -> Dyn (fun _ -> raise e)
+
+module Simple = struct
+  type t =
+    | A     of string
+    | As    of string list
+    | S     of t list
+    | Dep   of Path.t
+    | Deps  of Path.t list
+    | Path  of Path.t
+    | Paths of Path.t list
+
+  let deps =
+    let rec loop acc t =
+      match t with
+      | A _ | As _ | Path _ | Paths _ -> acc
+      | S l -> List.fold_left l ~init:acc ~f:loop
+      | Dep fn -> Path.Set.add acc fn
+      | Deps fns -> Path.Set.union acc (Path.Set.of_list fns)
+    in
+    fun t -> loop Path.Set.empty t
+
+  let expand t ~dir =
+    let rec loop = function
+      | A s -> [s]
+      | As l -> l
+      | (Dep fn | Path fn) -> [Path.reach fn ~from:dir]
+      | (Deps fns | Paths fns) -> List.map fns ~f:(Path.reach ~from:dir)
+      | S ts -> List.concat_map ts ~f:loop
+    in
+    loop t
+end
+
+let rec of_simple : Simple.t -> _ t = function
+  | A x -> A x
+  | As x -> As x
+  | S l -> S (List.map l ~f:of_simple)
+  | Dep x -> Dep x
+  | Deps x -> Deps x
+  | Path x -> Path x
+  | Paths x -> Paths x

--- a/src/arg_spec.mli
+++ b/src/arg_spec.mli
@@ -53,3 +53,20 @@ val quote_args : string -> string list -> _ t
 
 val of_result : 'a t Or_exn.t -> 'a t
 val of_result_map : 'a Or_exn.t -> f:('a -> 'b t) -> 'b t
+
+(** Serializable subset of [t] *)
+module Simple : sig
+  type t =
+    | A     of string
+    | As    of string list
+    | S     of t list
+    | Dep   of Path.t
+    | Deps  of Path.t list
+    | Path  of Path.t
+    | Paths of Path.t list
+
+  val deps : t -> Path.Set.t
+  val expand : t -> dir:Path.t -> string list
+end
+
+val of_simple : Simple.t -> 'a t

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -6,12 +6,17 @@ module SC = Super_context
 module Includes = struct
   type t = string list Arg_spec.t Cm_kind.Dict.t
 
-  let make sctx ~opaque ~requires : _ Cm_kind.Dict.t =
+  let make sctx ~dir ~opaque ~requires : _ Cm_kind.Dict.t =
     match requires with
     | Error exn -> Cm_kind.Dict.make_all (Arg_spec.Dyn (fun _ -> raise exn))
     | Ok libs ->
       let iflags =
         Lib.L.include_flags libs ~stdlib_dir:(SC.context sctx).stdlib_dir
+        |> Response_file.process_ocaml_call
+             sctx
+             ~key:"include-flags"
+             ~exec_dir:dir
+             ~response_file_dir:dir
       in
       let cmi_includes =
         Arg_spec.S [ iflags
@@ -92,7 +97,7 @@ let create ~super_context ~scope ~dir ?(dir_kind=File_tree.Dune_file.Kind.Dune)
   ; lib_interface_module
   ; flags
   ; requires
-  ; includes = Includes.make super_context ~opaque ~requires
+  ; includes = Includes.make super_context ~opaque ~requires ~dir
   ; preprocessing
   ; no_keep_locs
   ; opaque

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -140,7 +140,14 @@ let link_exe
         artifacts modules ~ext:ctx.ext_obj))
   in
   let arg_spec_for_requires =
-    Result.map requires ~f:(Link_time_code_gen.libraries_link ~name ~mode cctx)
+    Result.map requires
+      ~f:(fun libs ->
+        Link_time_code_gen.libraries_link ~name ~mode cctx libs
+        |> Response_file.process_ocaml_call
+             sctx
+             ~exec_dir:dir
+             ~response_file_dir:dir
+             ~key:("link-flags-" ^ Path.basename exe))
   in
   (* The rule *)
   SC.add_rule sctx

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -416,9 +416,9 @@ module L = struct
   type nonrec t = t list
 
   let to_iflags dirs =
-    Arg_spec.S
+    Arg_spec.Simple.S
       (Path.Set.fold dirs ~init:[] ~f:(fun dir acc ->
-         Arg_spec.Path dir :: A "-I" :: acc)
+         Arg_spec.Simple.Path dir :: A "-I" :: acc)
        |> List.rev)
 
   let include_paths ts ~stdlib_dir =
@@ -442,10 +442,10 @@ module L = struct
     to_iflags (c_include_paths ts ~stdlib_dir)
 
   let link_flags ts ~mode ~stdlib_dir =
-    Arg_spec.S
+    Arg_spec.Simple.S
       (c_include_flags ts ~stdlib_dir ::
        List.map ts ~f:(fun t ->
-         Arg_spec.Deps (Mode.Dict.get t.info.archives mode)))
+         Arg_spec.Simple.Deps (Mode.Dict.get t.info.archives mode)))
 
   let compile_and_link_flags ~compile ~link ~mode ~stdlib_dir =
     let dirs =
@@ -453,10 +453,10 @@ module L = struct
         (  include_paths compile ~stdlib_dir)
         (c_include_paths link    ~stdlib_dir)
     in
-    Arg_spec.S
+    Arg_spec.Simple.S
       (to_iflags dirs ::
        List.map link ~f:(fun t ->
-         Arg_spec.Deps (Mode.Dict.get t.info.archives mode)))
+         Arg_spec.Simple.Deps (Mode.Dict.get t.info.archives mode)))
 
   let jsoo_runtime_files ts =
     List.concat_map ts ~f:(fun t -> t.info.jsoo_runtime)
@@ -485,12 +485,14 @@ module Lib_and_module = struct
     | Module of Module.t * Path.t (** obj_dir *)
 
   let link_flags ts ~mode ~stdlib_dir =
-    let libs = List.filter_map ts ~f:(function Lib lib -> Some lib | Module _ -> None) in
-    Arg_spec.S
+    let libs =
+      List.filter_map ts ~f:(function Lib lib -> Some lib | Module _ -> None)
+    in
+    Arg_spec.Simple.S
       (L.c_include_flags libs ~stdlib_dir ::
        List.map ts ~f:(function
          | Lib t ->
-           Arg_spec.Deps (Mode.Dict.get t.info.archives mode)
+           Arg_spec.Simple.Deps (Mode.Dict.get t.info.archives mode)
          | Module (m,obj_dir) ->
            Dep (Module.cm_file_unsafe m ~obj_dir (Mode.cm_kind mode))
        ))

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -55,18 +55,18 @@ module L : sig
   type nonrec t = t list
 
   val include_paths : t -> stdlib_dir:Path.t -> Path.Set.t
-  val include_flags : t -> stdlib_dir:Path.t -> _ Arg_spec.t
+  val include_flags : t -> stdlib_dir:Path.t -> Arg_spec.Simple.t
 
-  val c_include_flags : t -> stdlib_dir:Path.t -> _ Arg_spec.t
+  val c_include_flags : t -> stdlib_dir:Path.t -> Arg_spec.Simple.t
 
-  val link_flags : t -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
+  val link_flags : t -> mode:Mode.t -> stdlib_dir:Path.t -> Arg_spec.Simple.t
 
   val compile_and_link_flags
     :  compile:t
     -> link:t
     -> mode:Mode.t
     -> stdlib_dir:Path.t
-    -> _ Arg_spec.t
+    -> Arg_spec.Simple.t
 
   (** All the library archive files (.a, .cmxa, _stubs.a, ...)  that
       should be linked in when linking an executable. *)
@@ -83,8 +83,11 @@ module Lib_and_module : sig
     | Lib of t
     | Module of Module.t * Path.t (** obj_dir *)
 
-  val link_flags : t list -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
-
+  val link_flags
+    :  t list
+    -> mode:Mode.t
+    -> stdlib_dir:Path.t
+    -> Arg_spec.Simple.t
 end
 
 (** {1 Raw library descriptions} *)

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -241,6 +241,11 @@ module Gen (P : Install_rules.Params) = struct
           [ Hidden_deps h_files
           ; Arg_spec.of_result_map requires ~f:(fun libs ->
               S [ Lib.L.c_include_flags libs ~stdlib_dir:ctx.stdlib_dir
+                  |> Response_file.process_ocaml_call
+                       sctx
+                       ~exec_dir:dir
+                       ~response_file_dir:dir
+                       ~key:"c-include-flags"
                 ; Hidden_deps (SC.Libs.file_deps sctx libs ~ext:".h")
                 ])
           ]

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -59,6 +59,9 @@ let libraries_link ~name ~mode cctx libs =
       cctx
       module_;
     let lm = (of_libs before)@[Lib.Lib_and_module.Module (module_,obj_dir)]@(of_libs after) in
-    Arg_spec.S [A "-linkall"; Lib.Lib_and_module.link_flags lm ~mode ~stdlib_dir]
+    Arg_spec.Simple.S
+      [ A "-linkall"
+      ; Lib.Lib_and_module.link_flags lm ~mode ~stdlib_dir
+      ]
   | None ->
     Lib.L.link_flags libs ~mode ~stdlib_dir

--- a/src/link_time_code_gen.mli
+++ b/src/link_time_code_gen.mli
@@ -5,5 +5,5 @@ val libraries_link
   -> mode:Mode.t
   -> Compilation_context.t
   -> Lib.L.t
-  -> _ Arg_spec.t
+  -> Arg_spec.Simple.t
 (** Insert link time generated code for findlib_dynload in the list *)

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -17,3 +17,6 @@ let supports_color_in_ocamlparam version =
 
 let supports_ocaml_color version =
   version >= (4, 05, 0)
+
+let supports_response_file version =
+  version >= (4, 05, 0)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -18,3 +18,6 @@ val supports_color_in_ocamlparam : t -> bool
 
 (** Does this support [OCAML_COLOR]? *)
 val supports_ocaml_color : t -> bool
+
+(** Does this this support [-args0]? *)
+val supports_response_file : t -> bool

--- a/src/response_file.ml
+++ b/src/response_file.ml
@@ -1,0 +1,54 @@
+open Import
+
+(* After seeing this number of paths, switch to a response file *)
+let max_paths = 4
+
+let too_long spec =
+  let add n len =
+    let n = n + len in
+    if n >= max_paths then raise_notrace Exit;
+    n
+  in
+  let rec loop acc (spec : Arg_spec.Simple.t) =
+    match spec with
+    | A _ | As _ -> acc
+    | Path _ | Dep _ -> add acc 1
+    | Paths l | Deps l -> add acc (List.length l)
+    | S l -> List.fold_left l ~init:acc ~f:loop
+  in
+  try
+    ignore (loop 0 spec : int);
+    false
+  with Exit ->
+    true
+
+let process sctx ~key ~exec_dir ~response_file_dir ~arg_name
+      ~dump_response_file spec =
+  match arg_name with
+  | None -> Arg_spec.of_simple spec
+  | Some arg ->
+    if not (Sys.win32 && too_long spec) then
+      Arg_spec.of_simple spec
+    else begin
+      let contents =
+        dump_response_file (Arg_spec.Simple.expand spec ~dir:exec_dir)
+      in
+      let file =
+        Path.relative response_file_dir ("." ^ key ^ ".response-file")
+      in
+      Super_context.add_rule sctx (Build.write_file file contents);
+      Arg_spec.S
+        [ A arg
+        ; Dep file
+        ; Hidden_deps (Arg_spec.Simple.deps spec |> Path.Set.to_list)
+        ]
+    end
+
+let process_ocaml_call sctx ~key ~exec_dir ~response_file_dir spec =
+  process sctx ~key ~exec_dir ~response_file_dir spec
+    ~arg_name:(Option.some_if
+                 (Ocaml_version.supports_response_file
+                    (Super_context.context sctx).version)
+                 "-args0")
+    ~dump_response_file:(fun l ->
+      String.concat (List.map l ~f:(fun s -> s ^ "\x00")) ~sep:"")

--- a/src/response_file.mli
+++ b/src/response_file.mli
@@ -1,0 +1,39 @@
+(** Automatically create response files *)
+
+open Import
+
+(** If the list of arguments is too long and [arg_name] is [Some a],
+    setup a rule to dump it to a response file [x] and return:
+
+    {[
+      S [A a_name; Dep x]
+    ]}
+
+    otherwise, return the argument specification unmodified. [key] is
+    just any string that is used to choose a unique response file name,
+    in case several response files are needed in the same directory.
+
+    [dump_response_file] is used to create the contents of the response
+    file from a list of strings.
+
+    [exec_dir] must be the directory where the final command will be executed.
+    [response_file_dir] is the directory where the command will be executed.
+*)
+val process
+  :  Super_context.t
+  -> key:string
+  -> exec_dir:Path.t
+  -> response_file_dir:Path.t
+  -> arg_name:string option
+  -> dump_response_file:(string list -> string)
+  -> Arg_spec.Simple.t
+  -> _ Arg_spec.t
+
+(** Same [process] but specialized to calls to the OCaml compiler. *)
+val process_ocaml_call
+  :  Super_context.t
+  -> key:string
+  -> exec_dir:Path.t
+  -> response_file_dir:Path.t
+  -> Arg_spec.Simple.t
+  -> _ Arg_spec.t


### PR DESCRIPTION
This PR adds support for passing arguments to the OCaml compiler via a response file when the list of arguments is too long. This is to bypass the low command line length limit of Windows.

## Remaining problems

Response files are not a generic feature and every application must support it. For instance we can only uses this feature for the OCaml compiler. If we want to use it for C compilers as well, then Dune will have to learn about the various C compilers and how they take responsefiles.

## Implementation

The current implementation works by adding a function that automatically convert long argument lists into `-args0 <file>` and setting up a rule to dump the original arguments in `<file>` at the same time. This is done at rule generation time.

Another alternative is to do it at process execution time: when describing the execution of a command, we could specify that this command supports passing arguments through a response file, and a temporary response file would be generated.

With the first approach, more work is shared: the arguments are serialized once and for all for all modules of a library rather than for every module. On the other hand, the response file will appear in the log, possibly hiding valuable information in CI build logs.
