### PR TITLE
Enable dune to produce OCaml bytecode in a C file (Issue #1216)

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -308,6 +308,7 @@ compilation is not available.
 
 ``<binary-kind>`` is one of:
 
+= ``c`` for producing OCaml bytecode embedded in a C file
 - ``exe`` for normal executables
 - ``object`` for producing static object files that can be manually
   linked into C applications
@@ -326,6 +327,7 @@ code executables and native shared objects:
 
 Additionally, you can use the following short-hands:
 
+- ``c`` for ``(byte c)``
 - ``exe`` for ``(best exe)``
 - ``object`` for ``(best object)``
 - ``shared_object`` for ``(best shared_object)``
@@ -346,6 +348,7 @@ The extensions for the various linking modes are chosen as follows:
 ================ ============= =================
 compilation mode binary kind   extensions
 ---------------- ------------- -----------------
+byte             c             .bc.c
 byte             exe           .bc and .bc.js
 native/best      exe           .exe
 byte             object        .bc%{ext_obj}

--- a/src/binary_kind.ml
+++ b/src/binary_kind.ml
@@ -1,6 +1,7 @@
 open! Stdune
 
 type t =
+  | C
   | Exe
   | Object
   | Shared_object
@@ -8,12 +9,14 @@ type t =
 let dparse =
   let open Dsexp.Of_sexp in
   enum
-    [ "exe"           , Exe
+    [ "c"             , C
+    ; "exe"           , Exe
     ; "object"        , Object
     ; "shared_object" , Shared_object
     ]
 
 let to_string = function
+  | C -> "c"
   | Exe -> "exe"
   | Object -> "object"
   | Shared_object -> "shared_object"
@@ -24,4 +27,4 @@ let pp fmt t =
 let dgen t =
   Dsexp.unsafe_atom_of_string (to_string t)
 
-let all = [Exe; Object; Shared_object]
+let all = [C; Exe; Object; Shared_object]

--- a/src/binary_kind.mli
+++ b/src/binary_kind.mli
@@ -3,6 +3,7 @@
 open! Stdune
 
 type t =
+  | C
   | Exe
   | Object
   | Shared_object

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -67,6 +67,8 @@ module Linkage = struct
     in
     let ext =
       match wanted_mode, m.kind with
+      | Byte   , C             -> ".bc.c"
+      | Native , C             -> raise (Exn.Fatal_error "C file generation only supports bytecode!")
       | Byte   , Exe           -> ".bc"
       | Native , Exe           -> ".exe"
       | Byte   , Object        -> ".bc"  ^ ctx.ext_obj
@@ -76,6 +78,7 @@ module Linkage = struct
     in
     let flags =
       match m.kind with
+      | C -> o_flags
       | Exe ->
         begin
           match wanted_mode, real_mode with


### PR DESCRIPTION
This seems to work on the few examples I have to test.  Also:
```bash
$ make release
$ make test-all
```
passes.