### PR TITLE
Support interrupting and restarting builds on file changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ next
 - Allow `dune.configurator` and `base` to be used together (#1291, fix
   #1167, @diml)
 
+- Support interrupting and restarting builds on file changes (#1246,
+  @kodek16)
+
 1.2.1 (17/09/2018)
 ------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -54,7 +54,7 @@ module Scheduler = struct
     in
     Scheduler.go ?log ~config:common.config fiber
 
-  let poll ?log ~common ~once ~finally () =
+  let poll ?log ~(common : Common.t) ~once ~finally () =
     let once () =
       Main.set_concurrency ?log common.config
       >>= fun () ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -60,12 +60,7 @@ module Scheduler = struct
       >>= fun () ->
       once ()
     in
-    Scheduler.poll
-      ?log
-      ~config:common.config
-      ~once
-      ~finally
-      ()
+    Scheduler.poll ?log ~config:common.config ~once ~finally ()
 end
 
 let do_build (setup : Main.setup) targets =

--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -438,7 +438,7 @@ let cleanup ~keep_ml_file =
 
 let () =
   let n =
-    try exec "%s -g -w -40 -o boot.exe unix.cma %s"
+    try exec "%s -g -w -40 -o boot.exe unix.cma threads.cma -I +threads %s"
           (Filename.quote compiler) generated_file
     with e -> cleanup ~keep_ml_file:true; raise e
   in

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -827,10 +827,13 @@ let rec compile_rule t ?(copy_source=false) pre_rule =
     end >>| fun () ->
     begin
       match mode with
-      | Standard | Fallback | Not_a_rule_stanza | Ignore_source_files -> ()
+      | Standard | Fallback | Not_a_rule_stanza | Ignore_source_files ->
+        Path.Set.iter targets ~f:(fun path ->
+          Option.iter (Path.drop_build_context path) ~f:Scheduler.don't_ignore_for_watch)
       | Promote | Promote_but_delete_on_clean ->
         Path.Set.iter targets ~f:(fun path ->
           let in_source_tree = Option.value_exn (Path.drop_build_context path) in
+          Scheduler.ignore_for_watch in_source_tree;
           if not (Path.exists in_source_tree) ||
              (Utils.Cached_digest.file path <>
               Utils.Cached_digest.file in_source_tree) then begin

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -827,9 +827,7 @@ let rec compile_rule t ?(copy_source=false) pre_rule =
     end >>| fun () ->
     begin
       match mode with
-      | Standard | Fallback | Not_a_rule_stanza | Ignore_source_files ->
-        Path.Set.iter targets ~f:(fun path ->
-          Option.iter (Path.drop_build_context path) ~f:Scheduler.don't_ignore_for_watch)
+      | Standard | Fallback | Not_a_rule_stanza | Ignore_source_files -> ()
       | Promote | Promote_but_delete_on_clean ->
         Path.Set.iter targets ~f:(fun path ->
           let in_source_tree = Option.value_exn (Path.drop_build_context path) in

--- a/src/dune
+++ b/src/dune
@@ -5,6 +5,7 @@
               fiber
               xdg
               dune_re
+              threads
               opam_file_format
               dsexp
               ocaml_config

--- a/src/hooks.ml
+++ b/src/hooks.ml
@@ -1,6 +1,12 @@
 open Stdune
 
-module End_of_build = struct
+module type S = sig
+  val always : (unit -> unit) -> unit
+  val once : (unit -> unit) -> unit
+  val run : unit -> unit
+end
+
+module Hooks_manager = struct
   let persistent_hooks = ref []
 
   let one_off_hooks = ref []
@@ -17,4 +23,16 @@ module End_of_build = struct
     one_off_hooks := []
 end
 
+module End_of_build = struct
+  include Hooks_manager
+end
+
+module End_of_build_not_canceled = struct
+  include Hooks_manager
+
+  let clear () =
+    one_off_hooks := []
+end
+
 let () = at_exit End_of_build.run
+let () = at_exit End_of_build_not_canceled.run

--- a/src/hooks.mli
+++ b/src/hooks.mli
@@ -1,21 +1,27 @@
 (** This module deals with management of hooks that run
     after specific events (e.g. end of build). *)
 
-module End_of_build : sig
-  (** Register a hook called at the end of every build.
-
-      For watch mode, this means that once registered, the hook
-      will be called after every iteration. *)
+module type S = sig
+  (** Register a hook called every time the event occurs. *)
   val always : (unit -> unit) -> unit
 
-  (** Register a hook called at the end of current build only.
-
-      For watch mode, this means that after current iteration
-      is over, the hook will be called and deregistered
-      automatically. *)
+  (** Register a hook that will only be called once when the next event occurs. *)
   val once : (unit -> unit) -> unit
 
-
-  (** Signalize end of build and run all registered hooks. *)
+  (** Signalize the event and run all registered hooks. *)
   val run : unit -> unit
+end
+
+(** Every time a build ends, which includes every iteration in watch mode,
+    including cancellation of build because of file changes. *)
+module End_of_build : S
+
+(** Same as End_of_build, but not signalized if build was canceled in
+    watch mode. *)
+module End_of_build_not_canceled : sig
+  include S
+
+  (** Signalize that current build was canceled and hooks registered with [once]
+      should be removed. *)
+  val clear : unit -> unit
 end

--- a/src/promotion.ml
+++ b/src/promotion.ml
@@ -54,8 +54,6 @@ let group_by_targets db =
   (* Sort the list of possible sources for deterministic behavior *)
   |> Path.Map.map ~f:(List.sort ~compare:Path.compare)
 
-let were_files_promoted = ref false
-
 type files_to_promote =
   | All
   | These of Path.t list * (Path.t -> unit)
@@ -86,7 +84,6 @@ let do_promote db files_to_promote =
       List.iter dirs_to_clear_from_cache ~f:(fun dir ->
         Utils.Cached_digest.remove (Path.append dir dst));
       File.promote { src; dst };
-      were_files_promoted := true;
       List.iter others ~f:(fun path ->
         Format.eprintf " -> ignored %s.@."
           (Path.to_string_maybe_quoted path))
@@ -114,7 +111,6 @@ let do_promote db files_to_promote =
       List.map srcs ~f:(fun src -> { File.src; dst }))
 
 let finalize () =
-  were_files_promoted := false;
   let db =
     if !Clflags.auto_promote then
       do_promote !File.db All
@@ -122,9 +118,6 @@ let finalize () =
       !File.db
   in
   dump_db db
-
-let were_files_promoted () =
-  !were_files_promoted
 
 let promote_files_registered_in_last_run files_to_promote =
   let db = load_db () in

--- a/src/promotion.mli
+++ b/src/promotion.mli
@@ -14,9 +14,6 @@ end
     dump the list of registered files to [_build/.to-promote]. *)
 val finalize : unit -> unit
 
-(** Returns true if any files were promoted the last time [finalize] ran. *)
-val were_files_promoted : unit -> bool
-
 (** Describe what files should be promoted. The second argument of
     [These] is a function that is called on files that cannot be
     promoted. *)

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -165,13 +165,17 @@ end = struct
       wait_unix
 
   let rec wait_to_chan chan =
-    Mutex.lock i_count_mtx;
     if !i_count = 0 then
       Condition.wait i_count_cv i_count_mtx;
-    i_count := !i_count - 1;
     Mutex.unlock i_count_mtx;
     let pid, status = wait () in
     Event.(sync (send chan (pid, status)));
+    Mutex.lock i_count_mtx;
+    i_count := !i_count - 1;
+    wait_to_chan chan
+
+  let wait_to_chan chan =
+    Mutex.lock i_count_mtx;
     wait_to_chan chan
 
   let count () = Hashtbl.length all

--- a/src/scheduler.mli
+++ b/src/scheduler.mli
@@ -17,21 +17,18 @@ val go
   -> 'a Fiber.t
   -> 'a
 
-(** Runs a fiber loop that looks like this (if cache_init is true, as default):
-              /------------------\
-              v                  |
-    init --> once --> finally  --/
+(** Runs [once] in a loop, executing [finally] after every iteration,
+    even if Fiber.Never was encountered.
 
-    If cache_init is false, every iteration reexecutes init instead of
-    saving it.
+    If any source files change in the middle of iteration, it gets
+    canceled, and [canceled] is called instead of [finally].
 *)
 val poll
   :  ?log:Log.t
   -> ?config:Config.t
-  -> ?cache_init:bool
-  -> init:(unit -> unit Fiber.t)
   -> once:(unit -> unit Fiber.t)
-  -> finally:(unit -> unit Fiber.t)
+  -> finally:(unit -> unit)
+  -> canceled:(unit -> unit)
   -> unit
   -> 'a
 

--- a/src/scheduler.mli
+++ b/src/scheduler.mli
@@ -40,6 +40,18 @@ val set_status_line_generator : (unit -> status_line_config) -> unit Fiber.t
 
 val set_concurrency : int -> unit Fiber.t
 
+(** Make the scheduler ignore changes to a certain file in watch mode.
+
+    This is used with promoted files that are copied back to the source tree
+    after generation *)
+val ignore_for_watch : Path.t -> unit
+
+(** Make the scheduler keep track of changes to a certain file in watch mode.
+
+    If a target was promoted before, and has a different mode now, this function
+    allows us to stop ignoring it *)
+val don't_ignore_for_watch : Path.t -> unit
+
 (** Scheduler information *)
 type t
 

--- a/src/scheduler.mli
+++ b/src/scheduler.mli
@@ -40,17 +40,11 @@ val set_status_line_generator : (unit -> status_line_config) -> unit Fiber.t
 
 val set_concurrency : int -> unit Fiber.t
 
-(** Make the scheduler ignore changes to a certain file in watch mode.
+(** Make the scheduler ignore next change to a certain file in watch mode.
 
     This is used with promoted files that are copied back to the source tree
     after generation *)
 val ignore_for_watch : Path.t -> unit
-
-(** Make the scheduler keep track of changes to a certain file in watch mode.
-
-    If a target was promoted before, and has a different mode now, this function
-    allows us to stop ignoring it *)
-val don't_ignore_for_watch : Path.t -> unit
 
 (** Scheduler information *)
 type t

--- a/src/scheduler.mli
+++ b/src/scheduler.mli
@@ -24,8 +24,6 @@ val go
 
     If cache_init is false, every iteration reexecutes init instead of
     saving it.
-
-    [~watch] should return after the first change to any of the project files.
 *)
 val poll
   :  ?log:Log.t
@@ -34,7 +32,6 @@ val poll
   -> init:(unit -> unit Fiber.t)
   -> once:(unit -> unit Fiber.t)
   -> finally:(unit -> unit Fiber.t)
-  -> watch:(unit -> unit Fiber.t)
   -> unit
   -> 'a
 


### PR DESCRIPTION
Instead of spawning a new inotifywait/fswatch process after every build, reuse one process, using pipes to read its output.

This allows to interrupt a build iteration in the middle, and restart it from the beginning, instead of ignoring file changes as is done now.