### PR TITLE
Update doc and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ $ make release
 $ make install
 ```
 
-Note however that `make install` requires the `opam-installer`
-tool. Running simply `make` will build dune using the development
+Running simply `make` will build dune using the development
 settings.
 
 If you do not have `make`, you can do the following:

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -838,7 +838,7 @@ let clear_executable_bits x = x land (lnot 0o111)
 
 let install_uninstall ~what =
   let doc =
-    sprintf "%s packages using opam-installer." (String.capitalize what)
+    sprintf "%s packages." (String.capitalize what)
   in
   let name_ = Arg.info [] ~docv:"PACKAGE" in
   let term =

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -299,10 +299,6 @@ workspace. With a specific list of packages, it will only install these
 packages. If several build contexts are configured, the installation will be
 performed for all of them.
 
-Note that ``dune install`` is a thin wrapper around the ``opam-installer`` tool,
-so you will need to install this tool in order to be able to use ``dune
-install``.
-
 Destination
 -----------
 


### PR DESCRIPTION
Reflect the fact that dune install doesn't need opam-installer anymore.

Signed-off-by: Hongchang Wu <wuhc85@gmail.com>