### PR TITLE
Build context variables

### DIFF
--- a/src/pform.ml
+++ b/src/pform.ml
@@ -138,6 +138,7 @@ module Map = struct
       ; "workspace_root" , values [Value.Dir context.build_dir]
       ; "ROOT"           , renamed_in ~version:(1, 0) ~new_name:"workspace_root"
       ; "name"           , since ~version:(1, 2) (Var.Values [Value.String context.name])
+      ; "build_dir"      , since ~version:(1, 2) (Var.Values [Value.String (Path.to_string context.build_dir)])
       ]
     in
     { vars =

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -137,6 +137,7 @@ module Map = struct
       ; "profile"        , string context.profile
       ; "workspace_root" , values [Value.Dir context.build_dir]
       ; "ROOT"           , renamed_in ~version:(1, 0) ~new_name:"workspace_root"
+      ; "name"           , since ~version:(1, 2) (Var.Values [Value.String context.name])
       ]
     in
     { vars =


### PR DESCRIPTION
This PR exposes the name of the build context as `%{name}` (so "default" usually) and also the actual build path within the workspace as `%{build_dir}` - this is the actual path (e.g. `_build/default`) as opposed to the relative path returned by `%{workspace_root}`.