### PR TITLE
Windows - Response Files: Turn off response files for ocamlmklib

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -470,7 +470,9 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       set t.ocamlc;
       Option.iter t.ocamlopt ~f:set;
       set t.ocamldep;
-      set t.ocamlmklib
+      if Ocaml_version.ocamlmklib_supports_response_file version then begin
+        set t.ocamlmklib;
+      end;
     end;
     Fiber.return t
   in

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -20,3 +20,6 @@ let supports_ocaml_color version =
 
 let supports_response_file version =
   version >= (4, 05, 0)
+
+let ocamlmklib_supports_response_file version =
+  version >= (4, 08, 0)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -21,3 +21,6 @@ val supports_ocaml_color : t -> bool
 
 (** Does this this support [-args0]? *)
 val supports_response_file : t -> bool
+
+(** Does ocamlmklib support [-args0]? *)
+val ocamlmklib_supports_response_file : t -> bool


### PR DESCRIPTION
__Issue:__ Testing the latest master, I saw error messages building `lwt@4.1.0`:
```
Unknown option -args0
Don't know what to do with C:\Users\bryph\AppData\Roaming\npm\node_modules\esy\node_modules\esy-bash\.cygwin\tmp\responsefilea40798.data
Usage: ocamlmklib [options] <.cmo|.cma|.cmx|.cmxa|.ml|.mli|.o|.a|.obj|.lib|.dll|.dylib files>
```
[Full error log](https://github.com/ocaml/dune/files/2381385/log.txt)

__Fix:__ It turns out that `ocamlmklib` does not support response files at this time, so we should remove it from the whitelist of commands to consider for response files.

cc @diml - please let me know if I should add tests or tweak anything. Thank you!
