### PR TITLE
Do not allow new public modules in implementations

### DIFF
--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -40,19 +40,18 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       end)
 
   let module_list ms =
-    List.map ms ~f:Module.Name.to_string
+    List.map ms ~f:(fun m -> sprintf "- %s" (Module.Name.to_string m))
     |> String.concat ~sep:"\n"
 
   let check_module_fields ~(lib : Dune_file.Library.t) ~virtual_modules
         ~modules ~implements =
     let new_public_modules =
-      Module.Name.Map.fold modules ~init:[] ~f:(fun m acc ->
+      Module.Name.Map.foldi modules ~init:[] ~f:(fun name m acc ->
         if Module.is_public m
-        && not (Module.Name.Map.mem virtual_modules (Module.name m)) then
-          (Module.name m) :: acc
+        && not (Module.Name.Map.mem virtual_modules name) then
+          name :: acc
         else
-          acc
-      )
+          acc)
     in
     if new_public_modules <> [] then begin
       Errors.fail lib.buildable.loc

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -39,8 +39,28 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
           List.iter [Cm_kind.ext Cmx; ctx.ext_obj] ~f:copy_obj_file
       end)
 
-  let check_virtual_modules_field ~(lib : Dune_file.Library.t) ~virtual_modules
+  let module_list ms =
+    List.map ms ~f:Module.Name.to_string
+    |> String.concat ~sep:"\n"
+
+  let check_module_fields ~(lib : Dune_file.Library.t) ~virtual_modules
         ~modules ~implements =
+    let new_public_modules =
+      Module.Name.Map.fold modules ~init:[] ~f:(fun m acc ->
+        if Module.is_public m
+        && not (Module.Name.Map.mem virtual_modules (Module.name m)) then
+          (Module.name m) :: acc
+        else
+          acc
+      )
+    in
+    if new_public_modules <> [] then begin
+      Errors.fail lib.buildable.loc
+        "The following modules aren't part of the virtual library's interface:\
+         \n%s\n\
+         They must be marked as private using the (private_modules ..) field"
+        (module_list new_public_modules)
+    end;
     let (missing_modules, impl_modules_with_intf, private_virtual_modules) =
       Module.Name.Map.foldi virtual_modules ~init:([], [], [])
         ~f:(fun m _ (mms, ims, pvms) ->
@@ -60,10 +80,6 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
                 Module.name m :: pvms
             in
             (mms, ims, pvms))
-    in
-    let module_list ms =
-      List.map ms ~f:Module.Name.to_string
-      |> String.concat ~sep:"\n"
     in
     if private_virtual_modules <> [] then begin
       (* The loc here will never be none as we've some private modules *)
@@ -114,7 +130,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
             , Lib_modules.virtual_modules lib_modules
             )
         in
-        check_virtual_modules_field ~lib ~virtual_modules ~modules ~implements;
+        check_module_fields ~lib ~virtual_modules ~modules ~implements;
         { Implementation.
           impl = lib
         ; vlib

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/dune-project
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.2)
+(using in_development_do_not_use_variants 0.1)

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/bar.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/bar.ml
@@ -1,0 +1,1 @@
+let run () = print_endline "implementing bar"

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/baz.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/baz.ml
@@ -1,0 +1,1 @@
+(* this module isn't allowed as it introduces a new interface *)

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/dune
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/dune
@@ -1,0 +1,4 @@
+(library
+ (name foo_impl)
+ (private_modules baz)
+ (implements foo))

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/vlib/bar.mli
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/vlib/bar.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/vlib/dune
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/vlib/dune
@@ -1,0 +1,3 @@
+(library
+ (name foo)
+ (virtual_modules bar))

--- a/test/blackbox-tests/test-cases/variants/impl-public-modules/dune-project
+++ b/test/blackbox-tests/test-cases/variants/impl-public-modules/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.2)
+(using in_development_do_not_use_variants 0.1)

--- a/test/blackbox-tests/test-cases/variants/impl-public-modules/impl/bar.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-public-modules/impl/bar.ml
@@ -1,0 +1,1 @@
+let run () = print_endline "implementing bar"

--- a/test/blackbox-tests/test-cases/variants/impl-public-modules/impl/baz.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-public-modules/impl/baz.ml
@@ -1,0 +1,1 @@
+(* this module isn't allowed as it introduces a new interface *)

--- a/test/blackbox-tests/test-cases/variants/impl-public-modules/impl/dune
+++ b/test/blackbox-tests/test-cases/variants/impl-public-modules/impl/dune
@@ -1,0 +1,3 @@
+(library
+ (name foo_impl)
+ (implements foo))

--- a/test/blackbox-tests/test-cases/variants/impl-public-modules/vlib/bar.mli
+++ b/test/blackbox-tests/test-cases/variants/impl-public-modules/vlib/bar.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit

--- a/test/blackbox-tests/test-cases/variants/impl-public-modules/vlib/dune
+++ b/test/blackbox-tests/test-cases/variants/impl-public-modules/vlib/dune
@@ -1,0 +1,3 @@
+(library
+ (name foo)
+ (virtual_modules bar))

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -123,7 +123,7 @@ Implementations cannot introduce new modules to the library's interface
   2 |  (name foo_impl)
   3 |  (implements foo))
   Error: The following modules aren't part of the virtual library's interface:
-  Baz
+  - Baz
   They must be marked as private using the (private_modules ..) field
   [1]
 

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -118,6 +118,14 @@ virtual libraries may not implement their virtual modules
 Implementations cannot introduce new modules to the library's interface
   $ dune build --root impl-public-modules
   Entering directory 'impl-public-modules'
+  File "impl/dune", line 1, characters 0-44:
+  1 | (library
+  2 |  (name foo_impl)
+  3 |  (implements foo))
+  Error: The following modules aren't part of the virtual library's interface:
+  Baz
+  They must be marked as private using the (private_modules ..) field
+  [1]
 
 They can only introduce private modules:
   $ dune build --root impl-private-modules

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -114,3 +114,11 @@ virtual libraries may not implement their virtual modules
   
   This will become an error in the future.
   -------------------------
+
+Implementations cannot introduce new modules to the library's interface
+  $ dune build --root impl-public-modules
+  Entering directory 'impl-public-modules'
+
+They can only introduce private modules:
+  $ dune build --root impl-private-modules
+  Entering directory 'impl-private-modules'


### PR DESCRIPTION
As discussed, the implementations shouldn't introduce anything that might change the existing alias module.