### PR TITLE
Avoiding abbreviation

### DIFF
--- a/doc/jsoo.rst
+++ b/doc/jsoo.rst
@@ -3,8 +3,7 @@ js_of_ocaml
 ***********
 
 js_of_ocaml_ is a compiler from OCaml to JavaScript. The compiler works by
-translating OCaml bytecode to JS files. From here on, we'll abbreviate
-js_of_ocaml to jsoo. The compiler can be installed with opam:
+translating OCaml bytecode to JS files. The compiler can be installed with opam:
 
 .. code:: bash
 
@@ -13,7 +12,7 @@ js_of_ocaml to jsoo. The compiler can be installed with opam:
 Compiling to JS
 ===============
 
-Dune has full support building jsoo libraries and executables transparently.
+Dune has full support building js_of_ocaml libraries and executables transparently.
 There's no need to customize or enable anything to compile ocaml
 libraries/executables to JS.
 


### PR DESCRIPTION
The abbreviation jsoo only gets used once in the article after it is introduced. If abbreviation is the goal (as suggested), it's better to not introduce jsoo and write out js_of_ocaml instead.

By contributing, I certify the whole shebang of CONTRIBUTING.md (a) and (d), my real name is Sebastiaan Joosten (and sjc are my real initials), but this change is too small/trivial for credit.