### PR TITLE
Add missing link flags to c_test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,12 @@
 next
 ----
 
-- Enrich the `dune` Emacs mode with syntax highlighting and
-  indentation.  New file `dune-flymake` to provide a hook
-  `dune-flymake-dune-mode-hook` to enable linting of dune files.
+- Enrich the `dune` Emacs mode with syntax highlighting and indentation. New
+  file `dune-flymake` to provide a hook `dune-flymake-dune-mode-hook` to enable
+  linting of dune files.
+
+- Pass `link_flags` to `cc` when compiling with `Configurator.V1.c_test` (#1274,
+  @rgrinberg)
 
 1.2.0 (14/09/2018)
 ------------------

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -278,6 +278,7 @@ let compile_and_link_c_prog t ?(c_flags=[]) ?(link_flags=[]) code =
              ; "-o" ; exe_fname
              ; c_fname
              ]
+           ; link_flags
            ])
   in
   if ok then Ok () else Error ()


### PR DESCRIPTION
I fear that this will require 1.2.1. This regression has been present for a while, but now I need this function in ocaml-ssl.