### PR TITLE
Separate closure from resolution

### DIFF
--- a/src/lib.mli
+++ b/src/lib.mli
@@ -70,8 +70,6 @@ module L : sig
   val archive_files : t -> mode:Mode.t -> Path.t list
 
   val jsoo_runtime_files : t -> Path.t list
-
-  val remove_dups : t -> t
 end
 
 (** Operation on list of libraries and modules *)


### PR DESCRIPTION
@diml this is something that we've discussed in slack - that it would be nice to separate the closure from the resolution. The PR implements a proof of concept of this separation. Things are still a bit suspect:

* We need to calculate the ppx runtime deps for the META file properly. This would require to walk pp's and their deps and accumulate the runtime deps. It's quite similar to the closure, so we'd need a way to generalize the current code

* My closure function is still quite ugly. Though I'm sure I could refactor it into a usable state.

* Check for private deps has been moved to the closure. It doesn't seem like it makes a difference. The locs are a bit different for the errors, but it should be easy to fix.

This refactoring isn't entirely necessary, but one reason why I want is because it should simplify changing the transitive closure for variants. We never want the library resolution to fail because of the transitive closure not finding an implementation for some virtual library at the dependency position. On the other hand, every preprocessor virtual lib should have an implementation. I expect these invariants would be easier to maintain with a separate closure pass.