### PR TITLE
[WIP] Fix issue with modes and findlib.dynload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ next
 - Support interrupting and restarting builds on file changes (#1246,
   @kodek16)
 
+- Fix findlib-dynload support with byte mode only (#1295, @bobot)
+
 1.2.1 (17/09/2018)
 ------------------
 
@@ -25,7 +27,7 @@ next
 - Fix a bug causing `dune` to fail eagerly when an optional library
   isn't available (#1281, @diml)
 
-- ocamlmklib should use response files only if ocaml >= 4.08 (@1268, @bryphe)
+- ocamlmklib should use response files only if ocaml >= 4.08 (#1268, @bryphe)
 
 1.2.0 (14/09/2018)
 ------------------

--- a/test/blackbox-tests/test-cases/findlib-dynload/dune
+++ b/test/blackbox-tests/test-cases/findlib-dynload/dune
@@ -27,6 +27,7 @@
 
 
 (rule (copy main.ml main_with_a.ml))
+(rule (copy main.ml main_modes_byte.ml))
 
 (executable
   (name main_with_a)
@@ -36,6 +37,14 @@
   (libraries mytool findlib.dynload a threads)
  )
 
+(executable
+  (name main_modes_byte)
+  (modules main_modes_byte)
+  (public_name mytool_modes_byte)
+  (package mytool)
+  (libraries mytool findlib.dynload threads)
+  (modes byte)
+ )
 
 (executable
   (name main_auto)

--- a/test/blackbox-tests/test-cases/findlib-dynload/run.t
+++ b/test/blackbox-tests/test-cases/findlib-dynload/run.t
@@ -11,6 +11,10 @@
   m: init
   a: init
 
+  $ dune exec mytool_modes_byte a
+  m: init
+  a: init
+
   $ dune exec mytool mytool-plugin-b
   m: init
   a: init


### PR DESCRIPTION
There is a bad interaction between the use of the mode `byte` and `findlib.dynload` generation (cf diml/ppxfind#3 ). It is reproducible when adding mode `byte` to the current test of `findlib.dynload`.

Is the default mode not `byte native`, so why restricting cause a bug? What is the best way to generate only once a rule which is needed in different cases? That would allow to generate the ml file only once for any exectuable instead of once by modes, and I hope fix the bug.