### PR TITLE
Add more locations to rule creation

### DIFF
--- a/src/exe.ml
+++ b/src/exe.ml
@@ -112,6 +112,7 @@ module Linkage = struct
 end
 
 let link_exe
+      ~loc
       ~name
       ~(linkage:Linkage.t)
       ~top_sorted_modules
@@ -149,7 +150,7 @@ let link_exe
     Lazy.force (Mode.Dict.get arg_spec_for_requires mode)
   in
   (* The rule *)
-  SC.add_rule sctx
+  SC.add_rule sctx ~loc
     (Build.fanout3
        (register_native_objs_deps modules_and_cm_files >>^ snd)
        (Ocaml_flags.get (CC.flags cctx) mode)
@@ -206,6 +207,7 @@ let build_and_link_many
     in
     List.iter linkages ~f:(fun linkage ->
       link_exe cctx
+        ~loc
         ~name
         ~linkage
         ~top_sorted_modules

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -197,7 +197,7 @@ include Sub_system.Register_end_point(
       in
 
       (* Generate the runner file *)
-      SC.add_rule sctx (
+      SC.add_rule sctx ~loc (
         let target = Path.relative inline_test_dir main_module_filename in
         let source_modules = Module.Name.Map.values source_modules in
         let files ml_kind =

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -65,7 +65,7 @@ module Gen (P : Install_rules.Params) = struct
           obj_deps >>>
           Build.paths (artifacts modules ~ext:ctx.ext_obj)
       in
-      SC.add_rule sctx
+      SC.add_rule sctx ~loc:lib.buildable.loc
         (obj_deps
          >>>
          Build.fanout4
@@ -160,8 +160,8 @@ module Gen (P : Install_rules.Params) = struct
     let cctx = Compilation_context.for_wrapped_compat cctx wrapped_compat in
     Module_compilation.build_modules cctx ~js_of_ocaml ~dynlink ~dep_graphs
 
-  let build_c_file (lib : Library.t) ~scope ~dir ~includes (src, dst) =
-    SC.add_rule sctx
+  let build_c_file (lib : Library.t) ~scope ~dir ~includes (loc, src, dst) =
+    SC.add_rule sctx ~loc
       (SC.expand_and_eval_set sctx ~scope ~dir lib.c_flags
          ~standard:(Build.return (Context.cc_g ctx))
        >>>
@@ -178,7 +178,7 @@ module Gen (P : Install_rules.Params) = struct
          ]);
     dst
 
-  let build_cxx_file (lib : Library.t) ~scope ~dir ~includes (src, dst) =
+  let build_cxx_file (lib : Library.t) ~scope ~dir ~includes (loc, src, dst) =
     let open Arg_spec in
     let output_param =
       if ctx.ccomp_type = "msvc" then
@@ -186,7 +186,7 @@ module Gen (P : Install_rules.Params) = struct
       else
         [A "-o"; Target dst]
     in
-    SC.add_rule sctx
+    SC.add_rule sctx ~loc
       (SC.expand_and_eval_set sctx ~scope ~dir lib.cxx_flags
          ~standard:(Build.return (Context.cc_g ctx))
        >>>
@@ -207,6 +207,7 @@ module Gen (P : Install_rules.Params) = struct
   let ocamlmklib (lib : Library.t) ~dir ~scope ~o_files ~sandbox ~custom
         ~targets =
     SC.add_rule sctx ~sandbox
+      ~loc:lib.buildable.loc
       (SC.expand_and_eval_set sctx ~scope ~dir
          lib.c_library_flags ~standard:(Build.return [])
        >>>
@@ -272,7 +273,7 @@ module Gen (P : Install_rules.Params) = struct
            This is not allowed."
           Path.pp (Path.drop_optional_build_context p)
       ;
-      (p, Path.relative dir (fn ^ ctx.ext_obj))
+      (loc, p, Path.relative dir (fn ^ ctx.ext_obj))
     in
     let includes =
       Arg_spec.S

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -94,7 +94,7 @@ let copy_files sctx ~dir ~scope ~src_dir (def: Copy_files.t) =
   List.map files ~f:(fun basename ->
     let file_src = Path.relative src_in_build basename in
     let file_dst = Path.relative dir basename in
-    SC.add_rule sctx
+    SC.add_rule sctx ~loc
       ((if def.add_line_directive
         then Build.copy_and_add_line_directive
         else Build.copy)


### PR DESCRIPTION
This should avoid the interal location in a few more error messages when
duplicate rules are created.