### PR TITLE
excludes should include local opam (2.0.0) switches

### DIFF
--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -115,6 +115,7 @@ end = struct
   let command =
     lazy (
       let excludes = [ {|/_build|}
+                     ; {|/_opam|}
                      ; {|/\..+|}
                      ; {|~$|}
                      ; {|/#[^#]*#$|}


### PR DESCRIPTION
... otherwise `dune build -w` produces infinite

```
 inotifywait (internal) (exit 1) 
/usr/bin/inotifywait -r . --exclude \.#|_build|\.hg|\.git|~$|/#[^#]*#$|\.install$ -e close_write -e delete -q > /dev/null
Failed to watch .; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
Had errors.
Had errors.                      
 inotifywait (internal) (exit 1) 
/usr/bin/inotifywait -r . --exclude \.#|_build|\.hg|\.git|~$|/#[^#]*#$|\.install$ -e close_write -e delete -q > /dev/null
Failed to watch .; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
Had errors.
Had errors.                      
 inotifywait (internal) (exit 1) 
/usr/bin/inotifywait -r . --exclude \.#|_build|\.hg|\.git|~$|/#[^#]*#$|\.install$ -e close_write -e delete -q > /dev/null
Failed to watch .; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
Had errors.
Had errors.                      
 inotifywait (internal) (exit 1) 
/usr/bin/inotifywait -r . --exclude \.#|_build|\.hg|\.git|~$|/#[^#]*#$|\.install$ -e close_write -e delete -q > /dev/null
Failed to watch .; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
Had errors.
Had errors.                      
Waiting for filesystem changes...^C
```