### PR TITLE
Markup fixes

### DIFF
--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -61,12 +61,13 @@ Dynamic loading of packages
 ===========================
 
 Dune supports the ``findlib.dynload`` package from `findlib
-<http://projects.camlcity.org/projects/findlib.html>_` that allows to dynamically
-load packages and their dependencies (using OCaml Dynlink module).
-So adding the ability for an application to have plugins just requires
-to add ``findlib.dynload`` to the set of library dependencies:
+<http://projects.camlcity.org/projects/findlib.html>`_ that allows to
+dynamically load packages and their dependencies (using OCaml Dynlink module).
+So adding the ability for an application to have plugins just requires to add
+``findlib.dynload`` to the set of library dependencies:
 
 .. code:: scheme
+
     (library
       (name mytool)
       (public_name mytool)
@@ -88,6 +89,7 @@ only once. So trying to load a package statically linked does nothing.
 A plugin creator just need to link to your library:
 
 .. code:: scheme
+
     (library
       (name mytool_plugin_a)
       (public_name mytool-plugin-a)
@@ -99,6 +101,7 @@ By choosing some naming convention, for example all the plugins of
 load all the plugins installed for your tool by listing the existing packages:
 
 .. code:: ocaml
+
     let () = Findlib.init ()
     let () =
       let pkgs = Fl_package_base.list_packages () in

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -924,10 +924,9 @@ expanded by dune.
 
 Dune supports the following variables:
 
-- ``project_root`` is the root of the current project. It is typically
-   the toplevel directory of your project and as long as you have a
-   ``dune-project`` file there, ``project_root`` is independent of the
-   workspace configuration
+- ``project_root`` is the root of the current project. It is typically the
+  toplevel directory of your project and as long as you have a ``dune-project``
+  file there, ``project_root`` is independent of the workspace configuration
 - ``workspace_root`` is the root of the current workspace. Note that
   the value of ``workspace_root`` is not constant and depends on
   whether your project is vendored or not


### PR DESCRIPTION
Pretty easy to miss, but all the code examples were missing in the dynload section.