### PR TITLE
Refactor Lib.Error

### DIFF
--- a/src/lib.mli
+++ b/src/lib.mli
@@ -120,25 +120,25 @@ module Error : sig
 
   module Conflict : sig
     (** When two libraries in a transitive closure conflict *)
-    type nonrec t =
-      { lib1 : t * Dep_path.Entry.t list
-      ; lib2 : t * Dep_path.Entry.t list
+    type t =
+      { lib1 : Lib_info.t * Dep_path.Entry.t list
+      ; lib2 : Lib_info.t * Dep_path.Entry.t list
       }
   end
 
   module Overlap : sig
     (** A conflict that doesn't prevent compilation, but that we still
         consider as an error to avoid surprises. *)
-    type nonrec t =
-      { in_workspace : t
-      ; installed    : t * Dep_path.Entry.t list
+    type t =
+      { in_workspace : Lib_info.t
+      ; installed    : Lib_info.t * Dep_path.Entry.t list
       }
   end
 
   module Private_deps_not_allowed : sig
-    type nonrec t =
-      { private_dep : t
-      ; pd_loc      : Loc.t
+    type t =
+      { private_dep : Lib_info.t
+      ; loc         : Loc.t
       }
   end
 

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -60,6 +60,7 @@ end
 
 type t =
   { loc              : Loc.t
+  ; name             : Lib_name.t
   ; kind             : Dune_file.Library.Kind.t
   ; status           : Status.t
   ; src_dir          : Path.t
@@ -163,6 +164,7 @@ let of_library_stanza ~dir ~ext_lib ~ext_obj (conf : Dune_file.Library.t) =
   in
   let main_module_name = Dune_file.Library.main_module_name conf in
   { loc = conf.buildable.loc
+  ; name = Dune_file.Library.best_name conf
   ; kind     = conf.kind
   ; src_dir  = dir
   ; obj_dir
@@ -197,6 +199,7 @@ let of_findlib_package pkg =
     | Some fn -> Installed_dune_file.load fn
   in
   { loc              = loc
+  ; name             = Findlib.Package.name pkg
   ; kind             = Normal
   ; src_dir          = P.dir pkg
   ; obj_dir          = P.dir pkg

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -40,6 +40,7 @@ end
 
 type t = private
   { loc              : Loc.t
+  ; name             : Lib_name.t
   ; kind             : Dune_file.Library.Kind.t
   ; status           : Status.t
   ; src_dir          : Path.t


### PR DESCRIPTION
Use Lib_info.t everywhere instead of t or Lib_name.t + Lib_info.t. In particular, this avoids the need to duplicate the types and to split the module in two.
