### PR TITLE
Break the dependency between build and context

### DIFF
--- a/src/build.ml
+++ b/src/build.ml
@@ -195,7 +195,7 @@ let prog_and_args ?(dir=Path.root) prog args =
     >>>
     arr fst))
 
-let run ~context ?(dir=context.Context.build_dir) ?stdout_to prog args =
+let run ~dir ?stdout_to prog args =
   let targets = Arg_spec.add_targets args (Option.to_list stdout_to) in
   prog_and_args ~dir prog args
   >>>

--- a/src/build.mli
+++ b/src/build.mli
@@ -138,8 +138,7 @@ val of_result_map
 val memoize : string -> (unit, 'a) t -> (unit, 'a) t
 
 val run
-  :  context:Context.t
-  -> ?dir:Path.t (* default: [context.build_dir] *)
+  :  dir:Path.t
   -> ?stdout_to:Path.t
   -> Action.Prog.t
   -> 'a Arg_spec.t list

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -159,7 +159,7 @@ let link_exe
      Build.of_result_map requires ~f:(fun libs ->
        Build.paths (Lib.L.archive_files libs ~mode))
      >>>
-     Build.run ~context:ctx
+     Build.run ~dir:ctx.build_dir
        (Ok compiler)
        [ Dyn (fun (_, flags,_) -> As flags)
        ; A "-o"; Target exe

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -37,7 +37,7 @@ let js_of_ocaml_rule sctx ~dir ~flags ~spec ~target =
   let jsoo =
     SC.resolve_program sctx ~loc:None ~hint:install_jsoo_hint "js_of_ocaml" in
   let runtime = runtime_file ~sctx "runtime.js" in
-  Build.run ~context:(Super_context.context sctx) ~dir
+  Build.run ~dir
     jsoo
     [ Arg_spec.Dyn flags
     ; Arg_spec.A "-o"; Target target
@@ -105,7 +105,7 @@ let link_rule cc ~runtime ~target =
   in
   let jsoo_link =
     SC.resolve_program sctx ~loc:None ~hint:install_jsoo_hint "jsoo_link" in
-  Build.run ~context:ctx ~dir:(Compilation_context.dir cc)
+  Build.run ~dir:(Compilation_context.dir cc)
     jsoo_link
     [ Arg_spec.A "-o"; Target target
     ; Arg_spec.Dep runtime

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -76,7 +76,7 @@ module Gen (P : Install_rules.Params) = struct
            (SC.expand_and_eval_set sctx ~scope ~dir lib.library_flags
               ~standard:(Build.return []))
          >>>
-         Build.run ~context:ctx (Ok compiler)
+         Build.run (Ok compiler) ~dir:ctx.build_dir
            [ Dyn (fun (_, _, flags, _) -> As flags)
            ; A "-a"; A "-o"; Target target
            ; As stubs_flags
@@ -166,7 +166,7 @@ module Gen (P : Install_rules.Params) = struct
       (SC.expand_and_eval_set sctx ~scope ~dir lib.c_flags
          ~standard:(Build.return (Context.cc_g ctx))
        >>>
-       Build.run ~context:ctx
+       Build.run
          (* We have to execute the rule in the library directory as
             the .o is produced in the current directory *)
          ~dir:(Path.parent_exn src)
@@ -191,7 +191,7 @@ module Gen (P : Install_rules.Params) = struct
       (SC.expand_and_eval_set sctx ~scope ~dir lib.cxx_flags
          ~standard:(Build.return (Context.cc_g ctx))
        >>>
-       Build.run ~context:ctx
+       Build.run
          (* We have to execute the rule in the library directory as
             the .o is produced in the current directory *)
          ~dir:(Path.parent_exn src)
@@ -212,7 +212,7 @@ module Gen (P : Install_rules.Params) = struct
       (SC.expand_and_eval_set sctx ~scope ~dir
          lib.c_library_flags ~standard:(Build.return [])
        >>>
-       Build.run ~context:ctx
+       Build.run ~dir:ctx.build_dir
          (Ok ctx.ocamlmklib)
          [ As (Utils.g ())
          ; if custom then A "-custom" else As []
@@ -312,7 +312,7 @@ module Gen (P : Install_rules.Params) = struct
         >>>
         Ocaml_flags.get flags Native
         >>>
-        Build.run ~context:ctx
+        Build.run ~dir:ctx.build_dir
           (Ok ocamlopt)
           [ Dyn (fun flags -> As flags)
           ; A "-shared"; A "-linkall"

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -45,9 +45,6 @@ module Run (P : PARAMS) = struct
 
   open P
 
-  let context =
-    SC.context sctx
-
   (* If [m] is a (short) module name, such as "myparser", then [source dir m]
      is the corresponding source file, and [targets dir m] is the list of
      targets that Menhir must build. *)
@@ -79,7 +76,7 @@ module Run (P : PARAMS) = struct
     string list Arg_spec.t list
 
   let menhir (args : args) =
-    flags >>> Build.run menhir_binary ~dir ~context args
+    flags >>> Build.run menhir_binary ~dir args
 
   let rule : (unit, Action.t) Build.t -> unit =
     SC.add_rule sctx ~mode:stanza.mode ~loc:stanza.loc

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -126,7 +126,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
          other_cm_files >>>
          flags
          >>>
-         Build.run ~dir ~context:ctx (Ok compiler)
+         Build.run ~dir (Ok compiler)
            [ Dyn (fun flags -> As flags)
            ; no_keep_locs
            ; cmt_args
@@ -203,7 +203,7 @@ let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   SC.add_rule sctx ?sandbox
     (cm_deps >>>
      Ocaml_flags.get_for_cm (CC.flags cctx) ~cm_kind:Cmo >>>
-     Build.run ~context:ctx (Ok ctx.ocamlc)
+     Build.run (Ok ctx.ocamlc) ~dir:ctx.build_dir
        [ Dyn (fun ocaml_flags -> As ocaml_flags)
        ; A "-I"; Path obj_dir
        ; Cm_kind.Dict.get (CC.includes cctx) Cmo

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -216,7 +216,7 @@ let deps_of cctx ~ml_kind unit =
         (let flags =
            Option.value (Module.pp_flags unit) ~default:(Build.return []) in
          flags >>>
-         Build.run ~context (Ok context.ocamldep)
+         Build.run (Ok context.ocamldep) ~dir:context.build_dir
            [ A "-modules"
            ; Dyn (fun flags -> As flags)
            ; Ml_kind.flag ml_kind

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -125,7 +125,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
        >>>
        module_deps m ~doc_dir ~dep_graphs
        >>>
-       Build.run ~context ~dir:doc_dir odoc
+       Build.run ~dir:doc_dir odoc
          [ A "compile"
          ; A "-I"; Path doc_dir
          ; iflags
@@ -140,7 +140,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
     SC.add_rule sctx
       (includes
        >>>
-       Build.run ~context ~dir:doc_dir odoc
+       Build.run ~dir:doc_dir odoc
          [ A "compile"
          ; Dyn (fun x -> x)
          ; As ["--pkg"; Package.Name.to_string pkg]
@@ -178,7 +178,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
        Build.progn (
          Build.remove_tree to_remove
          :: Build.mkdir odoc_file.html_dir
-         :: Build.run ~context ~dir:Paths.html_root
+         :: Build.run ~dir:Paths.html_root
               odoc
               [ A "html"
               ; odoc_include_flags requires
@@ -213,7 +213,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
 
   let setup_css_rule () =
     SC.add_rule sctx
-      (Build.run ~context
+      (Build.run
          ~dir:context.build_dir
          odoc
          [ A "css"; A "-o"; Path Paths.html_root

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -301,7 +301,7 @@ let build_ppx_driver sctx ~lib_db ~dep_kind ~target ~dir_kind pps =
      Build.of_result_map driver_and_libs ~f:(fun (_, libs) ->
        Build.paths (Lib.L.archive_files libs ~mode))
      >>>
-     Build.run ~context:ctx (Ok compiler)
+     Build.run (Ok compiler) ~dir:ctx.build_dir
        [ A "-o" ; Target target
        ; Arg_spec.of_result
            (Result.map driver_and_libs ~f:(fun (_driver, libs) ->
@@ -416,7 +416,7 @@ let setup_reason_rules sctx (m : Module.t) =
   let refmt =
     SC.resolve_program sctx ~loc:None "refmt" ~hint:"try: opam install reason" in
   let rule src target =
-    Build.run ~context:ctx refmt
+    Build.run ~dir:ctx.build_dir refmt
       [ A "--print"
       ; A "binary"
       ; Dep src
@@ -517,7 +517,7 @@ let lint_module sctx ~dir ~dep_kind ~lint ~lib_name ~scope ~dir_kind =
                     (Option.value_exn (Module.file source kind))
                     (Build.of_result_map driver_and_flags ~f:(fun (exe, flags) ->
                        flags >>>
-                       Build.run ~context:(SC.context sctx)
+                       Build.run ~dir:(SC.context sctx).build_dir
                          (Ok exe)
                          [ args
                          ; Ml_kind.ppx_driver_flag kind
@@ -611,7 +611,7 @@ let make sctx ~dir ~dep_kind ~lint ~preprocess
                      ~f:(fun (exe, flags) ->
                        flags
                        >>>
-                       Build.run ~context:(SC.context sctx)
+                       Build.run ~dir:(SC.context sctx).build_dir
                          (Ok exe)
                          [ args
                          ; A "-o"; Target dst


### PR DESCRIPTION
Explained why this is necessary in slack