### PR TITLE
Add github info for generated docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -149,3 +149,11 @@ texinfo_documents = [
 import sphinx_rtd_theme
 
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+html_context = {
+    'display_github': True,
+    'github_user': 'ocaml',
+    'github_repo': 'dune',
+    'github_version': 'master',
+    'conf_py_path': '/doc/',
+}


### PR DESCRIPTION
This displays an "Edit on github" link even locally.

It probably fixes the online docs as well (#1350).