### PR TITLE
Add a pkg_version independent of Super_context

### DIFF
--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -78,7 +78,9 @@ module Gen(P : Params) = struct
                 ; File "VERSION"
                 ]
           in
-          Super_context.Pkg_version.set sctx pkg get
+          let pkg_version = Super_context.pkg_version sctx in
+          Super_context.add_rule sctx (Pkg_version.rule pkg_version pkg get);
+          Pkg_version.read pkg_version pkg
         in
 
         let template =

--- a/src/pkg_version.ml
+++ b/src/pkg_version.ml
@@ -1,0 +1,27 @@
+open Stdune
+open Build.O
+
+type t =
+  { build_dir : Path.t
+  }
+
+let make ~build_dir =
+  { build_dir
+  }
+
+module V = Vfile_kind.Make(struct
+    type t = string option
+    let encode = Dune_lang.Encoder.(option string)
+    let name = "Pkg_version"
+  end)
+
+let spec { build_dir } (p : Package.t) =
+  let fn =
+    Path.relative (Path.append build_dir p.path)
+      (sprintf "%s.version.sexp" (Package.Name.to_string p.name))
+  in
+  Build.Vspec.T (fn, (module V))
+
+let read t p = Build.vpath (spec t p)
+
+let rule t p get = get >>> Build.store_vfile (spec t p)

--- a/src/pkg_version.mli
+++ b/src/pkg_version.mli
@@ -1,0 +1,13 @@
+open Stdune
+
+type t
+
+val make : build_dir:Path.t -> t
+
+val read : t -> Package.t -> (unit, string option) Build.t
+
+val rule
+  :  t
+  -> Package.t
+  -> (unit, string option) Build.t
+  -> (unit, Action.t) Build.t

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -55,6 +55,7 @@ val build_dir : t -> Path.t
 val profile   : t -> string
 val host : t -> t
 val build_system : t -> Build_system.t
+val pkg_version : t -> Pkg_version.t
 
 (** All public libraries of the workspace *)
 val public_libs : t -> Lib.DB.t
@@ -236,10 +237,6 @@ module Action : sig
     -> (Path.t Bindings.t, Action.t) Build.t
 
   val map_exe : t -> Path.t -> Path.t
-end
-
-module Pkg_version : sig
-  val set : t -> Package.t -> (unit, string option) Build.t -> (unit, string option) Build.t
 end
 
 module Scope_key : sig


### PR DESCRIPTION
This is required to split off all the expansions from the super context. It's
also good on its own as we are trying to shrink the Super_context module.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>