### PR TITLE
Better name detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ next
   `(c_names ...)` or `(cxx_names ...)` simultaneously.
   (#1375, fix #1306, @nojb)
 
+- Improve name detection for packages when the prefix isn't an actual package
+  (#1361, fix #1360, @rgrinberg)
+
 1.3.0 (23/09/2018)
 ------------------
 

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -185,6 +185,19 @@ let longest_map l ~f =
 
 let longest l = longest_map l ~f:(fun x -> x)
 
+let longest_prefix = function
+  | [] -> ""
+  | [x] -> x
+  | x :: xs ->
+    let rec loop len i =
+      if i < len && List.for_all xs ~f:(fun s -> s.[i] = x.[i]) then
+        loop len (i + 1)
+      else
+        i
+    in
+    let len =
+      List.fold_left ~init:(length x) ~f:(fun acc x -> min acc (length x)) xs in
+    sub ~pos:0 x ~len:(loop len 0)
 
 let exists =
   let rec loop s i len f =

--- a/src/stdune/string.mli
+++ b/src/stdune/string.mli
@@ -45,6 +45,8 @@ val escape_double_quote : t -> t
 val longest : string list -> int
 val longest_map : 'a list -> f:('a -> string) -> int
 
+val longest_prefix : t list -> t
+
 val exists : t -> f:(char -> bool) -> bool
 val for_all : t -> f:(char -> bool) -> bool
 

--- a/src/watermarks.ml
+++ b/src/watermarks.ml
@@ -202,19 +202,19 @@ let get_name ~files ?name () =
         with
         | Some name -> name
         | None ->
-          let shortest =
-            match package_names with
-            | [] -> assert false
-            | first :: rest ->
-              List.fold_left rest ~init:first ~f:(fun acc s ->
-                if String.length s < String.length acc then
-                  s
-                else
-                  acc)
+          let name =
+            let prefix = String.longest_prefix package_names in
+            if prefix = "" then
+              None
+            else
+              match String.drop_suffix prefix ~suffix:"-" with
+              | None ->
+                Option.some_if (List.mem ~set:package_names prefix) prefix
+              | Some _ as p -> p
           in
-          if List.for_all package_names ~f:(String.is_prefix ~prefix:shortest) then
-            shortest
-          else
+          match name with
+          | Some name -> name
+          | None ->
             die "@{<error>Error@}: cannot determine name automatically.\n\
                  You must pass a [--name] command line argument."
   in

--- a/src/watermarks.ml
+++ b/src/watermarks.ml
@@ -207,10 +207,13 @@ let get_name ~files ?name () =
             if prefix = "" then
               None
             else
-              match String.drop_suffix prefix ~suffix:"-" with
-              | None ->
+              match String.drop_suffix prefix ~suffix:"-"
+                  , String.drop_suffix prefix ~suffix:"_" with
+              | Some _, Some _ -> assert false
+              | None, None ->
                 Option.some_if (List.mem ~set:package_names prefix) prefix
-              | Some _ as p -> p
+              | (Some _ as p), None
+              | None, (Some _ as p) -> p
           in
           match name with
           | Some name -> name

--- a/test/unit-tests/string.mlt
+++ b/test/unit-tests/string.mlt
@@ -79,3 +79,8 @@ String.split_n "" 10;;
 [%%expect{|
 - : string * string = ("", "")
 |}]
+
+String.longest_prefix ["food"; "foo"; "foo-bar"]
+[%%expect{|
+- : string = "foo"
+|}]


### PR DESCRIPTION
The old name detection is confusing and also incorrectly detects situations where the prefix is unintended. This new scheme is more resilient and understands that many packages have a `-` as a separator.

Fix #1360 