### PR TITLE
Split executable & test rules out of Gen_rules

### DIFF
--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -1,0 +1,125 @@
+open Import
+open! No_io
+open Build.O
+module SC = Super_context
+
+let executables_rules ~sctx ~dir ~dir_kind
+      ~dir_contents ~scope ~compile_info
+      (exes : Dune_file.Executables.t) =
+  (* Use "eobjs" rather than "objs" to avoid a potential conflict
+     with a library of the same name *)
+  let obj_dir =
+    Utils.executable_object_directory ~dir (List.hd exes.names |> snd)
+  in
+  let requires = Lib.Compile.requires compile_info in
+  let modules =
+    Dir_contents.modules_of_executables dir_contents
+      ~first_exe:(snd (List.hd exes.names))
+  in
+
+  let preprocessor_deps =
+    SC.Deps.interpret sctx exes.buildable.preprocessor_deps
+      ~scope ~dir
+  in
+  let pp =
+    Preprocessing.make sctx ~dir ~dep_kind:Required
+      ~scope
+      ~preprocess:exes.buildable.preprocess
+      ~preprocessor_deps
+      ~lint:exes.buildable.lint
+      ~lib_name:None
+      ~dir_kind
+  in
+  let modules =
+    Module.Name.Map.map modules ~f:(fun m ->
+      Preprocessing.pp_module_as pp (Module.name m) m)
+  in
+
+  let programs =
+    List.map exes.names ~f:(fun (loc, name) ->
+      let mod_name = Module.Name.of_string name in
+      match Module.Name.Map.find modules mod_name with
+      | Some m ->
+        if not (Module.has_impl m) then
+          Errors.fail loc "Module %a has no implementation."
+            Module.Name.pp mod_name
+        else
+          { Exe.Program.name; main_module_name = mod_name ; loc }
+      | None -> Errors.fail loc "Module %a doesn't exist."
+                  Module.Name.pp mod_name)
+  in
+
+  let linkages =
+    let module L = Dune_file.Executables.Link_mode in
+    let ctx = SC.context sctx in
+    let l =
+      let has_native = Option.is_some ctx.ocamlopt in
+      List.filter_map (L.Set.to_list exes.modes) ~f:(fun (mode : L.t) ->
+        match has_native, mode.mode with
+        | false, Native ->
+          None
+        | _ ->
+          Some (Exe.Linkage.of_user_config ctx mode))
+    in
+    (* If bytecode was requested but not native or best version,
+       add custom linking *)
+    if L.Set.mem exes.modes L.byte         &&
+       not (L.Set.mem exes.modes L.native) &&
+       not (L.Set.mem exes.modes L.exe) then
+      Exe.Linkage.custom :: l
+    else
+      l
+  in
+
+  let flags = SC.ocaml_flags sctx ~scope ~dir exes.buildable in
+  let link_deps =
+    SC.Deps.interpret sctx ~scope ~dir exes.link_deps
+  in
+  let link_flags =
+    link_deps >>^ ignore >>>
+    SC.expand_and_eval_set sctx exes.link_flags
+      ~scope
+      ~dir
+      ~standard:(Build.return [])
+  in
+
+  let cctx =
+    Compilation_context.create ()
+      ~super_context:sctx
+      ~scope
+      ~dir
+      ~dir_kind
+      ~obj_dir
+      ~modules
+      ~flags
+      ~requires
+      ~preprocessing:pp
+      ~opaque:(SC.opaque sctx)
+  in
+
+  Exe.build_and_link_many cctx
+    ~programs
+    ~linkages
+    ~link_flags
+    ~js_of_ocaml:exes.buildable.js_of_ocaml;
+
+  (cctx,
+   Merlin.make ()
+     ~requires:(Lib.Compile.requires compile_info)
+     ~flags:(Ocaml_flags.common flags)
+     ~preprocess:(Dune_file.Buildable.single_preprocess exes.buildable)
+     ~objs_dirs:(Path.Set.singleton obj_dir))
+
+let rules ~sctx ~dir ~dir_contents ~scope ~dir_kind
+      (exes : Dune_file.Executables.t) =
+  let compile_info =
+    Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
+      exes.buildable.libraries
+      ~pps:(Dune_file.Preprocess_map.pps exes.buildable.preprocess)
+      ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
+  in
+  SC.Libs.gen_select_rules sctx compile_info ~dir;
+  SC.Libs.with_lib_deps sctx compile_info ~dir
+    ~f:(fun () ->
+      executables_rules exes ~sctx ~dir
+        ~dir_contents ~scope ~compile_info ~dir_kind)

--- a/src/exe_rules.mli
+++ b/src/exe_rules.mli
@@ -1,0 +1,8 @@
+val rules :
+  sctx:Super_context.t ->
+  dir:Stdune.Path.t ->
+  dir_contents:Dir_contents.t ->
+  scope:Scope.t ->
+  dir_kind:Dune_lang.syntax ->
+  Dune_file.Executables.t ->
+  Compilation_context.t * Merlin.t

--- a/src/test_rules.ml
+++ b/src/test_rules.ml
@@ -1,0 +1,63 @@
+open Import
+open! No_io
+
+let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~dir_contents ~dir_kind =
+  let test_kind (loc, name) =
+    let files = Dir_contents.text_files dir_contents in
+    let expected_basename = name ^ ".expected" in
+    if String.Set.mem files expected_basename then
+      `Expect
+        { Action.Unexpanded.Diff.
+          file1 = String_with_vars.make_text loc expected_basename
+        ; file2 = String_with_vars.make_text loc (name ^ ".output")
+        ; optional = false
+        ; mode = Text
+        }
+    else
+      `Regular
+  in
+  List.iter t.exes.names ~f:(fun (loc, s) ->
+    let test_var_name = "test" in
+    let run_action =
+      match t.action with
+      | Some a -> a
+      | None -> Action.Unexpanded.Run (
+        String_with_vars.make_var loc test_var_name, [])
+    in
+    let extra_bindings =
+      let test_exe = s ^ ".exe" in
+      let test_exe_path =
+        Super_context.Action.map_exe sctx (Path.relative dir test_exe) in
+      Pform.Map.singleton test_var_name (Values [Path test_exe_path]) in
+    let add_alias ~loc ~action ~locks =
+      let alias =
+        { Dune_file.Alias_conf.
+          name = "runtest"
+        ; locks
+        ; package = t.package
+        ; deps = t.deps
+        ; action = Some (loc, action)
+        ; enabled_if = t.enabled_if
+        ; loc
+        }
+      in
+      Simple_rules.alias sctx ~extra_bindings ~dir ~scope alias
+    in
+    match test_kind (loc, s) with
+    | `Regular ->
+      add_alias ~loc ~action:run_action ~locks:[]
+    | `Expect diff ->
+      let rule =
+        { Dune_file.Rule.
+          targets = Infer
+        ; deps = Dune_file.Bindings.empty
+        ; action =
+            (loc, Action.Unexpanded.Redirect (Stdout, diff.file2, run_action))
+        ; mode = Standard
+        ; locks = t.locks
+        ; loc
+        } in
+      add_alias ~loc ~action:(Diff diff) ~locks:t.locks;
+      ignore (Simple_rules.user_rule sctx rule ~extra_bindings ~dir ~scope
+              : Path.t list));
+  Exe_rules.rules t.exes ~sctx ~dir ~scope ~dir_kind ~dir_contents

--- a/src/test_rules.mli
+++ b/src/test_rules.mli
@@ -1,0 +1,7 @@
+val rules :
+  Dune_file.Tests.t ->
+  sctx:Super_context.t ->
+  dir:Stdune.Path.t ->
+  scope:Scope.t ->
+  dir_contents:Dir_contents.t ->
+  dir_kind:Dune_lang.syntax -> Compilation_context.t * Merlin.t


### PR DESCRIPTION
`Gen_rules` is a bit difficult to navigate. My plan is to extract the different parts into different files and ultimately replace then `Gen` functor by plain functions. Does that sound like a good plan to you?