### PR TITLE
Split Env_node

### DIFF
--- a/src/env_node.ml
+++ b/src/env_node.ml
@@ -1,0 +1,44 @@
+open Import
+
+type t =
+  { dir                 : Path.t
+  ; inherit_from        : t Lazy.t option
+  ; scope               : Scope.t
+  ; config              : Dune_env.Stanza.t
+  ; mutable ocaml_flags : Ocaml_flags.t option
+  }
+
+let make ~dir ~inherit_from ~scope ~config =
+  { dir
+  ; inherit_from
+  ; scope
+  ; config
+  ; ocaml_flags = None
+  }
+
+let rec ocaml_flags node ~profile ~eval =
+  match node.ocaml_flags with
+  | Some x -> x
+  | None ->
+    let default =
+      match node.inherit_from with
+      | None -> Ocaml_flags.default ~profile
+      | Some (lazy node) -> ocaml_flags node ~profile ~eval
+    in
+    let flags =
+      match List.find_map node.config.rules ~f:(fun (pat, cfg) ->
+        match (pat : Dune_env.Stanza.pattern), profile with
+        | Any, _ -> Some cfg
+        | Profile a, b -> Option.some_if (a = b) cfg)
+      with
+      | None -> default
+      | Some cfg ->
+        Ocaml_flags.make
+          ~flags:cfg.flags
+          ~ocamlc_flags:cfg.ocamlc_flags
+          ~ocamlopt_flags:cfg.ocamlopt_flags
+          ~default
+          ~eval:(eval ~scope:node.scope ~dir:node.dir)
+    in
+    node.ocaml_flags <- Some flags;
+    flags

--- a/src/env_node.mli
+++ b/src/env_node.mli
@@ -1,0 +1,19 @@
+open Import
+
+type t
+
+val make :
+  dir:Path.t ->
+  inherit_from:t Lazy.t option ->
+  scope:Scope.t ->
+  config:Dune_env.Stanza.t ->
+  t
+
+val ocaml_flags :
+  t ->
+  profile:string ->
+  eval:(scope:Scope.t ->
+        dir:Path.t ->
+        Ordered_set_lang.Unexpanded.t ->
+        standard:(unit, string list) Build.t -> (unit, string list) Build.t) ->
+  Ocaml_flags.t


### PR DESCRIPTION
This moves Env_node out of Super_context. The dependency is broken by passing `eval` - the signature is a bit large but this moves this simplifies `Super_context`.