### PR TITLE
Setup utop rules recursively for every directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@ next
 
 - Exit gracefully when a signal is received (#1366, @diml)
 
+- Load all defined libraries recursively into utop (#1384, fix #1344,
+  @rgrinberg)
+
 1.3.0 (23/09/2018)
 ------------------
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -220,11 +220,11 @@ with locally defined libraries loaded.
 
    $ dune utop <dir> -- <args>
 
-Where ``<dir>`` is a directory containing a ``dune`` file defining all the
-libraries that will be loaded (using the ``library`` stanza). ``<args>`` will be
-passed as arguments to the utop command itself. For example, ``dune utop lib --
--implicit-bindings`` will start ``utop`` with the libraries defined in ``lib``
-and implicit bindings for toplevel expressions.
+Where ``<dir>`` is a directory under which dune will search (recursively) for
+all libraries that will be loaded. ``<args>`` will be passed as arguments to the
+utop command itself. For example, ``dune utop lib -- -implicit-bindings`` will
+start ``utop`` with the libraries defined in ``lib`` and implicit bindings for
+toplevel expressions.
 
 Requirements & Limitations
 --------------------------

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -87,10 +87,6 @@ module Gen(P : Install_rules.Params) = struct
       in
       Merlin.add_rules sctx ~dir:ctx_dir ~more_src_dirs ~scope ~dir_kind
         (Merlin.add_source_dir m src_dir));
-    Utop.setup sctx ~dir:ctx_dir ~scope ~libs:(
-      List.filter_map stanzas ~f:(function
-        | Library lib -> Some lib
-        | _ -> None));
     List.iter stanzas ~f:(fun stanza ->
       match (stanza : Stanza.t) with
       | Menhir.T m when SC.eval_blang sctx m.enabled_if ~dir:ctx_dir ~scope ->
@@ -141,7 +137,10 @@ module Gen(P : Install_rules.Params) = struct
        | None ->
          (* We get here when [dir] is a generated directory, such as
             [.utop] or [.foo.objs]. *)
-         if components <> [] then SC.load_dir sctx ~dir:(Path.parent_exn dir)
+         if Utop.is_utop_dir dir then
+           Utop.setup sctx ~dir:(Path.parent_exn dir)
+         else if components <> [] then
+           SC.load_dir sctx ~dir:(Path.parent_exn dir)
        | Some _ ->
          (* This interprets "rule" and "copy_files" stanzas. *)
          let dir_contents = Dir_contents.get sctx ~dir in

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -38,7 +38,9 @@ let add_module_rules sctx ~dir lib_requires =
   in
   Super_context.add_rule sctx utop_ml
 
-let utop_exe_dir ~dir = Path.relative dir ".utop"
+let utop_dir_basename = ".utop"
+
+let utop_exe_dir ~dir = Path.relative dir utop_dir_basename
 
 let utop_exe dir =
   Path.relative (utop_exe_dir ~dir) exe_name
@@ -48,10 +50,7 @@ let utop_exe dir =
      generating a utop for a library with C stubs. *)
   |> Path.extend_basename ~suffix:(Mode.exe_ext Mode.Native)
 
-let is_utop_dir dir =
-  match Path.parent dir with
-  | None -> false
-  | Some dir' -> Path.equal dir (utop_exe_dir ~dir:dir')
+let is_utop_dir dir = Path.basename dir = utop_dir_basename
 
 let libs_under_dir sctx ~dir =
   Super_context.stanzas sctx

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -6,9 +6,6 @@ val utop_exe : Path.t -> Path.t
 (** Return the path of the utop bytecode binary inside a directory where
     some libraries are defined. *)
 
-val setup
-  : Super_context.t
-  -> dir:Path.t
-  -> libs:Dune_file.Library.t list
-  -> scope:Scope.t
-  -> unit
+val is_utop_dir : Path.t -> bool
+
+val setup : Super_context.t -> dir:Path.t -> unit

--- a/test/blackbox-tests/test-cases/utop-default/run.t
+++ b/test/blackbox-tests/test-cases/utop-default/run.t
@@ -5,12 +5,14 @@ By default, dune utop tries to make a toplevel for the current directory:
   
   # 
 
-If there is no library there, it displays an error message:
 
-  $ dune utop --root nothing-in-root
+Utop will load libs recursively:
+
+  $ echo 'exit 0;;' | dune utop --root nothing-in-root | grep -v 'version'
   Entering directory 'nothing-in-root'
-  No library is defined in .
-  [1]
+  
+  # 
+
 
 The message where the library path does not exist is different:
 


### PR DESCRIPTION
The current PR seems to work but there a few issues:

* ~~Somehow this makes the current utop tests get stuck. Infinite loop somewhere?~~ actually, one of the new tests simply forgot exit utop after launching it.

* The experience with multiple opam packages is not very good. If we pick a directory above an opam file for `$ dune utop <dir>` all the private libs will be invisible. I don't think this can be helped, but I think that it will confuse users.

* The code is quite inefficient, but is only run when doing `$ dune utop` so it's probably ok.