### PR TITLE
Fix staged_pps to work with reason

### DIFF
--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -647,7 +647,7 @@ let make sctx ~dir ~dep_kind ~lint ~preprocess
         (fun m ~lint ->
            let ast = setup_reason_rules sctx m in
            if lint then lint_module ~ast ~source:m;
-           Module.set_pp m pp)
+           Module.set_pp ast pp)
       end)
 
 let pp_modules t ?(lint=true) modules =


### PR DESCRIPTION
Hi, I was using the staged_pps feature of dune and noticed that it would try to parse Reason files as OCaml only when doing so. This change fixed the problem for me. :balloon: 