### PR TITLE
meta builtins: add support for bytes/result packages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@ next
 - Load all defined libraries recursively into utop (#1384, fix #1344,
   @rgrinberg)
 
+- Allow to use libraries `bytes`, `result` and `uchar` without `findlib`
+  installed (#1391, @nojb)
+
 1.3.0 (23/09/2018)
 ------------------
 

--- a/src/context.ml
+++ b/src/context.ml
@@ -418,7 +418,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; ocamlmklib = get_ocaml_tool_exn "ocamlmklib"
 
       ; env
-      ; findlib = Findlib.create ~stdlib_dir ~paths:findlib_paths
+      ; findlib = Findlib.create ~stdlib_dir ~paths:findlib_paths ~version
       ; findlib_toolchain
       ; arch_sixtyfour
 

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -364,10 +364,10 @@ let all_packages t =
     | Error _ -> acc)
   |> List.sort ~compare:(fun (a : Package.t) b -> Lib_name.compare a.name b.name)
 
-let create ~stdlib_dir ~paths =
+let create ~stdlib_dir ~paths ~version =
   { stdlib_dir
   ; paths
-  ; builtins = Meta.builtins ~stdlib_dir
+  ; builtins = Meta.builtins ~stdlib_dir ~version
   ; packages = Hashtbl.create 1024
   }
 

--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -9,6 +9,7 @@ type t
 val create
   :  stdlib_dir:Path.t
   -> paths:Path.t list
+  -> version:Ocaml_version.t
   -> t
 
 (** The search path for this DB *)

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -241,6 +241,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   let dynlink = simple "dynlink" [] ~dir:"+" in
   let bytes = dummy "bytes" in
   let result = dummy "result" in
+  let uchar = dummy "uchar" in
   let threads =
     { name = Some (Lib_name.of_string_exn ~loc:None "threads")
     ; entries =
@@ -272,6 +273,11 @@ let builtins ~stdlib_dir ~version:ocaml_version =
       if Ocaml_version.pervasives_includes_result ocaml_version then
         result :: base
       else base in
+    let base =
+      if Ocaml_version.stdlib_includes_uchar ocaml_version then
+        uchar :: base
+      else
+        base in
     (* We do not rely on an "exists_if" ocamlfind variable,
        because it would produce an error message mentioning
        a "hidden" package (which could be confusing). *)

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -195,7 +195,7 @@ let archives name =
   ; plugin  "native" (name ^ ".cmxs")
   ]
 
-let builtins ~stdlib_dir =
+let builtins ~stdlib_dir ~version:ocaml_version =
   let version = version "[distributed with Ocaml]" in
   let simple name ?dir ?archive_name deps =
     let archive_name =
@@ -212,6 +212,11 @@ let builtins ~stdlib_dir =
          match dir with
          | None -> archives
          | Some d -> directory d :: archives)
+    }
+  in
+  let dummy name =
+    { name = Some (Lib_name.of_string_exn ~loc:None name)
+    ; entries = [version]
     }
   in
   let compiler_libs =
@@ -234,6 +239,8 @@ let builtins ~stdlib_dir =
   let unix = simple "unix" [] ~dir:"+" in
   let bigarray = simple "bigarray" ["unix"] ~dir:"+" in
   let dynlink = simple "dynlink" [] ~dir:"+" in
+  let bytes = dummy "bytes" in
+  let result = dummy "result" in
   let threads =
     { name = Some (Lib_name.of_string_exn ~loc:None "threads")
     ; entries =
@@ -259,7 +266,12 @@ let builtins ~stdlib_dir =
     }
   in
   let libs =
-    let base = [compiler_libs; str; unix; bigarray; threads; dynlink] in
+    let base =
+      [compiler_libs; str; unix; bigarray; threads; dynlink; bytes] in
+    let base =
+      if Ocaml_version.pervasives_includes_result ocaml_version then
+        result :: base
+      else base in
     (* We do not rely on an "exists_if" ocamlfind variable,
        because it would produce an error message mentioning
        a "hidden" package (which could be confusing). *)

--- a/src/meta.mli
+++ b/src/meta.mli
@@ -47,6 +47,6 @@ val load : Path.t -> name:Lib_name.t option -> Simplified.t
 
 (** Builtin META files for libraries distributed with the compiler. For when ocamlfind is
     not installed. *)
-val builtins : stdlib_dir:Path.t -> Simplified.t Lib_name.Map.t
+val builtins : stdlib_dir:Path.t -> version:Ocaml_version.t -> Simplified.t Lib_name.Map.t
 
 val pp : Format.formatter -> entry list -> unit

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -1,5 +1,7 @@
 type t = int * int * int
 
+let make x = x
+
 let of_ocaml_config ocfg =
   Ocaml_config.version ocfg
 

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -23,3 +23,6 @@ let supports_response_file version =
 
 let ocamlmklib_supports_response_file version =
   version >= (4, 08, 0)
+
+let pervasives_includes_result version =
+  version >= (4, 03, 0)

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -26,3 +26,6 @@ let ocamlmklib_supports_response_file version =
 
 let pervasives_includes_result version =
   version >= (4, 03, 0)
+
+let stdlib_includes_uchar version =
+  version >= (4, 03, 0)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -27,3 +27,6 @@ val ocamlmklib_supports_response_file : t -> bool
 
 (** Whether [Pervasives] includes the [result] type *)
 val pervasives_includes_result : t -> bool
+
+(** Whether the standard library includes the [Uchar] module *)
+val stdlib_includes_uchar : t -> bool

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -1,6 +1,8 @@
 (** Version numbers for ocamlc and ocamlopt *)
 type t
 
+val make : int * int * int -> t
+
 val of_ocaml_config : Ocaml_config.t -> t
 
 (** Does this support [-no-keep-locs]? *)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -24,3 +24,6 @@ val supports_response_file : t -> bool
 
 (** Does ocamlmklib support [-args0]? *)
 val ocamlmklib_supports_response_file : t -> bool
+
+(** Whether [Pervasives] includes the [result] type *)
+val pervasives_includes_result : t -> bool

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -28,6 +28,7 @@ let findlib =
     Findlib.create
     ~stdlib_dir:cwd
     ~paths:[Path.relative cwd "test/unit-tests/findlib-db"]
+    ~version:(Ocaml_version.make (4, 02, 3))
 ;;
 
 [%%expect{|


### PR DESCRIPTION
This change allows to compile packages that depend on `bytes` and/or `result` libraries in the absence of `ocamlfind`.