### PR TITLE
Fix test 1395 on osx

### DIFF
--- a/test/blackbox-tests/test-cases/github1395/run.t
+++ b/test/blackbox-tests/test-cases/github1395/run.t
@@ -4,7 +4,7 @@
         ocamlc .bar.objs/bar.{cmi,cmo,cmt}
       ocamlopt .bar.objs/bar.{cmx,o}
       ocamlopt bar.{a,cmxa}
-           gcc foo$ext_obj
+            cc foo$ext_obj
             ar libfoo_stubs$ext_lib
         ocamlc .main.eobjs/main.{cmi,cmo,cmt}
       ocamlopt .main.eobjs/main.{cmx,o}


### PR DESCRIPTION
We really need to fix our blackbox tests on Windows.