### PR TITLE
Fix 1395 by not including build output

### DIFF
--- a/test/blackbox-tests/test-cases/github1395/run.t
+++ b/test/blackbox-tests/test-cases/github1395/run.t
@@ -1,11 +1,1 @@
-  $ dune build --display=short ./main.exe
-      ocamldep .main.eobjs/main.ml.d
-      ocamldep .bar.objs/bar.ml.d
-        ocamlc .bar.objs/bar.{cmi,cmo,cmt}
-      ocamlopt .bar.objs/bar.{cmx,o}
-      ocamlopt bar.{a,cmxa}
-           gcc foo$ext_obj
-            ar libfoo_stubs$ext_lib
-        ocamlc .main.eobjs/main.{cmi,cmo,cmt}
-      ocamlopt .main.eobjs/main.{cmx,o}
-      ocamlopt main.exe
+  $ dune exec ./main.exe


### PR DESCRIPTION
This output contains some platform specific stuff (CC in this case)

Having an analogous fix for output-obj would be nice.