### PR TITLE
[WIP] Tentative implementation for test schemes

### DIFF
--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -631,6 +631,17 @@ end
 
 let modules_field name = Ordered_set_lang.field name
 
+module Test_scheme = struct
+  let syntax =
+    Syntax.create ~name:"run_test_schemes"
+      ~desc:"test schemes"
+      [ (0, 1) ]
+
+  let () =
+    Dune_project.Extension.register_simple ~experimental:true syntax
+      (Dune_lang.Decoder.return [])
+end
+
 module Auto_format = struct
   let syntax =
     Syntax.create ~name:"fmt"
@@ -1820,16 +1831,9 @@ module Alias_conf = struct
     ; loc : Loc.t
     }
 
-  let alias_name =
-    plain_string (fun ~loc s ->
-      if Filename.basename s <> s then
-        of_sexp_errorf loc "%S is not a valid alias name" s
-      else
-        s)
-
   let decode =
     record
-      (let%map name = field "name" alias_name
+      (let%map name = field "name" Dune_project.Alias_name.decode
        and loc = loc
        and package = field_o "package" Pkg.decode
        and action = field_o "action" (located Action.Unexpanded.decode)

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -464,7 +464,8 @@ let parse ~dir ~lang ~packages ~file =
        in
        if not run_test_scheme_enabled then
          Errors.fail first_scheme_loc
-           "Run test schemes should be explicitly enabled."
+           "Run test schemes should be explicitly enabled by adding:\n\
+            (using run_test_schemes 0.1)"
      end;
      match
        String.Map.of_list

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -32,8 +32,21 @@ module Name : sig
   module Infix : Comparable.OPS with type t = t
 end
 
+module Alias_name : sig
+  val decode : string Stanza.Decoder.t
+end
+
 module Project_file : sig
   type t
+end
+
+module Scheme : sig
+  type t =
+    { dir_extension : string
+    ; file_extension : string
+    ; alias_name : string
+    ; action_template : Action.Unexpanded.t
+    }
 end
 
 type t
@@ -43,6 +56,7 @@ val version : t -> string option
 val name : t -> Name.t
 val root : t -> Path.Local.t
 val stanza_parser : t -> Stanza.t list Dune_lang.Decoder.t
+val schemes : t -> (Loc.t * Scheme.t) list
 
 module Lang : sig
   (** [register id stanzas_parser] register a new language. Users will

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -273,7 +273,6 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) path =
               ignored
               || String.Set.mem ignored_subdirs fn
               || Path.Set.mem extra_ignored_subtrees path
-              || scheme <> None
             in
             String.Map.add acc fn
               (walk path ~dirs_visited ~project ~ignored ~scheme))

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -259,6 +259,16 @@ let load ?(extra_ignored_subtrees=Path.Set.empty) path =
               ignored
               || String.Set.mem ignored_subdirs fn
               || Path.Set.mem extra_ignored_subtrees path
+              || List.exists
+                   (Dune_project.schemes project)
+                   ~f:(fun (_loc,
+                            { Dune_project.Scheme.
+                              dir_extension
+                            ; file_extension = _
+                            ; alias_name = _
+                            ; action_template = _
+                            }) ->
+                        Path.extension path = "." ^ dir_extension)
             in
             String.Map.add acc fn
               (walk path ~dirs_visited ~project ~ignored))

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -43,6 +43,7 @@ module Dir : sig
   val sub_dirs : t -> t String.Map.t
   val sub_dir_paths : t -> Path.Set.t
   val sub_dir_names : t -> String.Set.t
+  val scheme : t -> (Loc.t * Dune_project.Scheme.t) option
 
   (** Whether this directory is ignored by an [ignored_subdirs] stanza
      or [jbuild-ignore] file in one of its ancestor directories. *)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -933,6 +933,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name test-scheme)
+ (deps (package dune) (source_tree test-cases/test-scheme))
+ (action
+  (chdir
+   test-cases/test-scheme
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name tests-stanza)
  (deps (package dune) (source_tree test-cases/tests-stanza))
  (action
@@ -1135,6 +1143,7 @@
   (alias syntax-versioning)
   (alias target-dir-alias)
   (alias targets-with-vars)
+  (alias test-scheme)
   (alias tests-stanza)
   (alias tests-stanza-action)
   (alias too-many-parens)
@@ -1250,6 +1259,7 @@
   (alias syntax-versioning)
   (alias target-dir-alias)
   (alias targets-with-vars)
+  (alias test-scheme)
   (alias tests-stanza)
   (alias tests-stanza-action)
   (alias too-many-parens)

--- a/test/blackbox-tests/test-cases/test-scheme/also.testing/e.t
+++ b/test/blackbox-tests/test-cases/test-scheme/also.testing/e.t
@@ -1,0 +1,1 @@
+contents of e

--- a/test/blackbox-tests/test-cases/test-scheme/dune-project
+++ b/test/blackbox-tests/test-cases/test-scheme/dune-project
@@ -1,0 +1,15 @@
+(lang dune 1.0)
+
+(using run_test_schemes 0.1)
+
+(run_test_scheme
+ (dir_extension tests)
+ (extension t)
+ (alias testscheme)
+ (action (cat %{test})))
+
+(run_test_scheme
+ (dir_extension testing)
+ (extension t)
+ (alias testscheme)
+ (action (cat %{test})))

--- a/test/blackbox-tests/test-cases/test-scheme/other.tests/c.t
+++ b/test/blackbox-tests/test-cases/test-scheme/other.tests/c.t
@@ -1,0 +1,1 @@
+contents of c

--- a/test/blackbox-tests/test-cases/test-scheme/other.tests/d.t
+++ b/test/blackbox-tests/test-cases/test-scheme/other.tests/d.t
@@ -1,0 +1,1 @@
+contents of d

--- a/test/blackbox-tests/test-cases/test-scheme/run.t
+++ b/test/blackbox-tests/test-cases/test-scheme/run.t
@@ -1,0 +1,6 @@
+  $ dune build @testscheme | sort
+  contents of a
+  contents of b
+  contents of c
+  contents of d
+  contents of e

--- a/test/blackbox-tests/test-cases/test-scheme/some.tests/a.t
+++ b/test/blackbox-tests/test-cases/test-scheme/some.tests/a.t
@@ -1,0 +1,1 @@
+contents of a

--- a/test/blackbox-tests/test-cases/test-scheme/some.tests/b.t
+++ b/test/blackbox-tests/test-cases/test-scheme/some.tests/b.t
@@ -1,0 +1,1 @@
+contents of b


### PR DESCRIPTION
This PR is an attempt to implement the mechanism described [here](https://github.com/ocaml/dune/issues/622).

One can add test schemes from the `dune-project` file as follows:

```
(run_test_scheme
 (dir_extension tests)
 (extension t)
 (alias testscheme)
 (action (cat %{test})))
```

The previous stanza will add an action for each file whose
extension is `t` in a directory whose extension is `tests`;
the action will be added to the alias `testscheme`. In the
`action` sub-stanza, `%{test}` will be substituted with the
actual file name.

As the feature is experimental, it can currently be used
only if test schemes are explicitly enabled, through:

```
(using run_test_schemes 0.1)
```