### PR TITLE
Remove the .cma.js target in the lib dir

### DIFF
--- a/src/lib.ml
+++ b/src/lib.ml
@@ -176,6 +176,7 @@ let synopsis     t = t.info.synopsis
 let archives     t = t.info.archives
 let plugins      t = t.info.plugins
 let jsoo_runtime t = t.info.jsoo_runtime
+let jsoo_archive t = t.info.jsoo_archive
 let unique_id    t = t.unique_id
 
 let virtual_     t = t.info.virtual_

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -28,6 +28,7 @@ val kind         : t -> Dune_file.Library.Kind.t
 val archives     : t -> Path.t list Mode.Dict.t
 val plugins      : t -> Path.t list Mode.Dict.t
 val jsoo_runtime : t -> Path.t list
+val jsoo_archive : t -> Path.t option
 
 val foreign_objects : t -> Path.t list
 

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -53,6 +53,7 @@ type t = private
   ; foreign_objects  : Path.t list
   ; foreign_archives : Path.t list Mode.Dict.t (** [.a/.lib/...] files *)
   ; jsoo_runtime     : Path.t list
+  ; jsoo_archive     : Path.t option
   ; requires         : Deps.t
   ; ppx_runtime_deps : (Loc.t * Lib_name.t) list
   ; pps              : (Loc.t * Lib_name.t) list

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -485,8 +485,11 @@ module Gen (P : Install_rules.Params) = struct
       (* Build *.cma.js *)
       SC.add_rules sctx (
         let src =
-          Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Mode.Byte) in
-        let target = Path.extend_basename src ~suffix:".js" in
+          Library.archive lib ~dir
+            ~ext:(Mode.compiled_lib_ext Mode.Byte) in
+        let target =
+          Path.relative obj_dir (Path.basename src)
+          |> Path.extend_basename ~suffix:".js" in
         Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target);
 
       if Dynlink_supported.By_the_os.get ctx.natdynlink_supported then

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -170,13 +170,9 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
   Option.iter js_of_ocaml ~f:(fun js_of_ocaml ->
     (* Build *.cmo.js *)
     let sctx     = CC.super_context cctx in
-    let dir      = CC.dir           cctx in
     let obj_dir  = CC.obj_dir       cctx in
     let src = Module.cm_file_unsafe m ~obj_dir Cm_kind.Cmo in
-    let target =
-      Path.extend_basename (Module.cm_file_unsafe m ~obj_dir:dir Cm_kind.Cmo)
-        ~suffix:".js"
-    in
+    let target = Path.extend_basename src ~suffix:".js" in
     SC.add_rules sctx
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
 

--- a/test/blackbox-tests/test-cases/glob-deps/run.t
+++ b/test/blackbox-tests/test-cases/glob-deps/run.t
@@ -1,2 +1,2 @@
   $ dune build @glob
-  foo/dune foo/foo$ext_lib foo/foo.cma foo/foo.cma.js foo/foo.cmo.js foo/foo.cmxa foo/foo.cmxs foo/foo.ml
+  foo/dune foo/foo$ext_lib foo/foo.cma foo/foo.cmxa foo/foo.cmxs foo/foo.ml

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -1,4 +1,4 @@
-  $ dune build --display short bin/technologic.bc.js @install lib/x.cma.js lib/x__Y.cmo.js bin/z.cmo.js
+  $ dune build --display short bin/technologic.bc.js @install
         ocamlc lib/stubs$ext_obj
     ocamlmklib lib/dllx_stubs$ext_dll,lib/libx_stubs$ext_lib
       ocamlopt .ppx/js_of_ocaml-ppx/ppx.exe
@@ -15,7 +15,6 @@
            ppx bin/z.pp.ml
       ocamldep bin/.technologic.eobjs/z.pp.ml.d
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
-   js_of_ocaml lib/.x.objs/x__Y.cmo.js
         ocamlc lib/.x.objs/x.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x.{cmx,o}
       ocamlopt lib/x.{a,cmxa}
@@ -23,11 +22,11 @@
    js_of_ocaml .js/stdlib/stdlib.cma.js
    js_of_ocaml bin/technologic.bc.runtime.js
         ocamlc lib/x.cma
-   js_of_ocaml lib/x.cma.js
+   js_of_ocaml lib/.x.objs/x.cma.js
         ocamlc bin/.technologic.eobjs/z.{cmi,cmo,cmt}
-   js_of_ocaml bin/.technologic.eobjs/z.cmo.js
         ocamlc bin/.technologic.eobjs/technologic.{cmi,cmo,cmt}
    js_of_ocaml bin/.technologic.eobjs/technologic.cmo.js
+   js_of_ocaml bin/.technologic.eobjs/z.cmo.js
      jsoo_link bin/technologic.bc.js
   $ $NODE ./_build/default/bin/technologic.bc.js
   buy it


### PR DESCRIPTION
And remove the unnecessary aliasing for js files.

I think the `Lib.jsoo_archive` function improves things as it's how we handle other jsoo archives. Perhaps we should consider moving the in_build_dir path hack to `Lib_info.of_findlib_package` as well. It would make more sense sense as `Lib.t` has all the paths resolved for the user as well.