### PR TITLE
Ignore empty paths in Bin.parse_path

### DIFF
--- a/src/bin.ml
+++ b/src/bin.ml
@@ -7,7 +7,10 @@ let path_sep =
     ':'
 
 let parse_path ?(sep=path_sep) s =
-  List.map (String.split s ~on:sep) ~f:Path.of_filename_relative_to_initial_cwd
+  String.split s ~on:sep
+  |> List.filter_map ~f:(function
+    | "" -> None
+    | p -> Some (Path.of_filename_relative_to_initial_cwd p))
 
 let path =
   match Env.get Env.initial "PATH" with


### PR DESCRIPTION
The coq devs have confirmed that it can be repeated and trail https://github.com/coq/coq/pull/8692#issuecomment-428545026

We might as well strip empty paths from `PATH` as well as they can't be useful.