### PR TITLE
RFC: add enabled_if to library stanza

### DIFF
--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -979,6 +979,7 @@ module Library = struct
     ; implements               : (Loc.t * Lib_name.t) option
     ; private_modules          : Ordered_set_lang.t option
     ; stdlib                   : Stdlib.t option
+    ; enabled_if               : Blang.t
     }
 
   let decode =
@@ -1027,6 +1028,7 @@ module Library = struct
            >>= fun () -> Ordered_set_lang.decode)
        and stdlib =
          field_o "stdlib" (Syntax.since Stdlib.syntax (0, 1) >>> Stdlib.decode)
+       and enabled_if = enabled_if (* COMBAK This will set it for 1.4, not 1.5 *)
        in
        let name =
          let open Syntax.Version.Infix in
@@ -1116,6 +1118,7 @@ module Library = struct
        ; implements
        ; private_modules
        ; stdlib
+       ; enabled_if
        })
 
   let has_stubs t =

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -280,6 +280,7 @@ module Library : sig
     ; implements               : (Loc.t * Lib_name.t) option
     ; private_modules          : Ordered_set_lang.t option
     ; stdlib                   : Stdlib.t option
+    ; enabled_if               : Blang.t
     }
 
   val has_stubs : t -> bool


### PR DESCRIPTION
This is a (very) hacked addition of `enabled_if` to `library` stanzas. This finally allows me to add `(enabled_if      (= %{ocaml-config:os_type} "Win32"))` and so be able to enable opam's Win32 stubs library from within Dune, rather than by having `configure` symlink `src/stubs/dune-win32` to `src/stubs/dune` only on Windows builds.

This implementation is obviously rubbish, but I seek comments on what parts of the mechanism should be altered (and what could be broken y allowing this which I haven't spotted in my machete type-driven style of hacking...):

 - I've made no effort (yet) to mark this as a 1.5/1.6 feature - it's erroneously piggy-backing on a 1.4 feature
 - I've produced a different version of `Super_context.eval_blang` which only depends on the specific parts of the sctx need to do the evaluation. In particular, this means you can use `eval_blang_no_scope` _before_ the super context has been created.
 - In the brief look I had, I couldn't decide whether needing a scope (e.g. for the project root) didn't make sense at this stage and so should be rejected or whether more refactoring was required on setting up the scopes DB. For now, `expand_var_no_scope` is a crude copy of `expand_var` where the case requiring the scope raises instead.

The rest is a fairly obvious moving of code in `Super_context.create` to filter the stanzas list as early as possible.

Feedback on the general direction welcome and I'll tidy this up properly and extend it to `executable`.

It works, at least in the opam context I just tried it in. In particular, the library opam-core.stubs is only defined at all on Windows - this is detected in opam-core itself which has a `select` on the presence of that library.
