### PR TITLE
Ocamlfind toolchain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@ next
 - Unblock signals in processes started by dune (#1461, fixes #1451,
   @diml)
 
+- Respect `OCAMLFIND_TOOLCHAIN` and add a `toolchain` option to contexts in the
+  workspace file. (#1449, fix #1413, @rgrinberg)
+
 1.4.0 (10/10/2018)
 ------------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -83,9 +83,10 @@ let installed_libraries =
       (Context.create ~env
          { merlin_context = Some "default"
          ; contexts = [Default { loc = Loc.of_pos __POS__
-                               ; targets = [Native]
-                               ; profile = Config.default_build_profile
-                               ; env     = None
+                               ; targets   = [Native]
+                               ; profile   = Config.default_build_profile
+                               ; env       = None
+                               ; toolchain = None
                                }]
          ; env = None
          }

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -468,6 +468,8 @@ context or can be the description of an opam switch, as follows:
   higher precedence than the toplevel ``env`` stanza in the workspace file. This
   field the same options as the :ref:`dune-env` stanza.
 
+- ``(toolchain <findlib_coolchain>)`` set findlib toolchain for the context.
+
 Both ``(default ...)`` and ``(opam ...)`` accept a ``targets`` field in order to
 setup cross compilation. See :ref:`advanced-cross-compilation` for more
 information.

--- a/src/context.ml
+++ b/src/context.ml
@@ -175,7 +175,7 @@ module Build_environment_kind = struct
           | None -> Unknown
 end
 
-let ocamlfind_printconf_path ~env ~ocamlfind ?toolchain () =
+let ocamlfind_printconf_path ~env ~ocamlfind ~toolchain =
   let args =
     let args = ["printconf"; "path"] in
     match toolchain with
@@ -187,7 +187,7 @@ let ocamlfind_printconf_path ~env ~ocamlfind ?toolchain () =
   List.map l ~f:Path.of_filename_relative_to_initial_cwd
 
 let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
-      ~profile () =
+      ~profile =
   let opam_var_cache = Hashtbl.create 128 in
   (match kind with
    | Opam { root = Some root; _ } ->
@@ -215,7 +215,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     >>| Path.of_filename_relative_to_initial_cwd)
   in
 
-  let create_one ~name ~implicit ?findlib_toolchain ?host ~merlin () =
+  let create_one ~name ~implicit ~findlib_toolchain ~host ~merlin =
     (match findlib_toolchain with
      | None -> Fiber.return None
      | Some toolchain ->
@@ -281,7 +281,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       match Build_environment_kind.query ~kind ~findlib_toolchain ~env with
       | Cross_compilation_using_findlib_toolchain toolchain ->
         let ocamlfind = which_exn "ocamlfind" in
-        ocamlfind_printconf_path ~env ~ocamlfind ~toolchain ()
+        ocamlfind_printconf_path ~env ~ocamlfind ~toolchain:(Some toolchain)
 
       | Hardcoded_path l ->
         Fiber.return
@@ -302,7 +302,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       | Unknown ->
         match which "ocamlfind" with
         | Some ocamlfind ->
-          ocamlfind_printconf_path ~env ~ocamlfind ()
+          ocamlfind_printconf_path ~env ~ocamlfind ~toolchain:None
 
         | None ->
           Fiber.return
@@ -483,22 +483,24 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
   in
 
   let implicit = not (List.mem ~set:targets Workspace.Context.Target.Native) in
-  create_one () ~implicit ~name ~merlin >>= fun native ->
+  create_one ~host:None ~findlib_toolchain:None ~implicit ~name ~merlin
+  >>= fun native ->
   Fiber.parallel_map targets ~f:(function
     | Native -> Fiber.return None
     | Named findlib_toolchain ->
       let name = sprintf "%s.%s" name findlib_toolchain in
-      create_one () ~implicit:false ~name ~findlib_toolchain ~host:native
-        ~merlin:false
+      create_one ~implicit:false ~name ~host:(Some native) ~merlin:false
+        ~findlib_toolchain:(Some findlib_toolchain)
       >>| fun x -> Some x)
   >>| fun others ->
   native :: List.filter_map others ~f:(fun x -> x)
 
-let opam_config_var t var = opam_config_var ~env:t.env ~cache:t.opam_var_cache var
+let opam_config_var t var =
+  opam_config_var ~env:t.env ~cache:t.opam_var_cache var
 
-let default ?(merlin=true) ~env_nodes ~env ~targets () =
+let default ~merlin ~env_nodes ~env ~targets =
   create ~kind:Default ~path:Bin.path ~env ~env_nodes ~name:"default"
-    ~merlin ~targets ()
+    ~merlin ~targets
 
 let opam_version =
   let res = ref None in
@@ -520,7 +522,7 @@ let opam_version =
       Fiber.Future.wait future
 
 let create_for_opam ~root ~env ~env_nodes ~targets ~profile
-      ~switch ~name ~merlin () =
+      ~switch ~name ~merlin =
   let opam =
     match Lazy.force opam with
     | None -> Utils.program_not_found "opam" ~loc:None
@@ -566,7 +568,7 @@ let create_for_opam ~root ~env ~env_nodes ~targets ~profile
   in
   let env = Env.extend env ~vars in
   create ~kind:(Opam { root; switch }) ~profile ~targets ~path ~env ~env_nodes
-    ~name ~merlin ()
+    ~name ~merlin
 
 let create ~env (workspace : Workspace.t) =
   let env_nodes context =
@@ -581,11 +583,11 @@ let create ~env (workspace : Workspace.t) =
       let merlin =
         workspace.merlin_context = Some (Workspace.Context.name def)
       in
-      default ~env ~env_nodes:(env_nodes env_node) ~profile ~targets ~merlin ()
+      default ~env ~env_nodes:(env_nodes env_node) ~profile ~targets ~merlin
     | Opam { base = { targets; profile; env = env_node; loc = _ }
            ; name; switch; root; merlin } ->
       create_for_opam ~root ~env_nodes:(env_nodes env_node) ~env ~profile
-        ~switch ~name ~merlin ~targets ())
+        ~switch ~name ~merlin ~targets)
   >>| List.concat
 
 let which t s = which ~cache:t.which_cache ~path:t.path s

--- a/src/stanza.ml
+++ b/src/stanza.ml
@@ -9,7 +9,7 @@ end
 let syntax =
   Syntax.create ~name:"dune" ~desc:"the dune language"
     [ (0, 0) (* Jbuild syntax *)
-    ; (1, 4)
+    ; (1, 5)
     ]
 
 module File_kind = struct

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -47,22 +47,26 @@ module Context = struct
 
   module Common = struct
     type t =
-      { loc     : Loc.t
-      ; profile : string
-      ; targets : Target.t list
-      ; env     : Dune_env.Stanza.t option
+      { loc       : Loc.t
+      ; profile   : string
+      ; targets   : Target.t list
+      ; env       : Dune_env.Stanza.t option
+      ; toolchain : string option
       }
 
     let t ~profile =
       let%map env = env_field
       and targets = field "targets" (list Target.t) ~default:[Target.Native]
       and profile = field "profile" string ~default:profile
+      and toolchain =
+        field_o "toolchain" (Syntax.since syntax (1, 5) >>= fun () -> string)
       and loc = loc
       in
       { targets
       ; profile
       ; loc
       ; env
+      ; toolchain
       }
   end
 
@@ -147,6 +151,7 @@ module Context = struct
       ; profile = Option.value profile
                     ~default:Config.default_build_profile
       ; env = None
+      ; toolchain = None
       }
 end
 

--- a/src/workspace.mli
+++ b/src/workspace.mli
@@ -11,10 +11,11 @@ module Context : sig
   end
   module Common : sig
     type t =
-      { loc     : Loc.t
-      ; profile : string
-      ; targets : Target.t list
-      ; env     : Dune_env.Stanza.t option
+      { loc       : Loc.t
+      ; profile   : string
+      ; targets   : Target.t list
+      ; env       : Dune_env.Stanza.t option
+      ; toolchain : string option
       }
   end
   module Opam : sig

--- a/test/blackbox-tests/test-cases/dune-project-edition/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-edition/run.t
@@ -3,9 +3,9 @@
   $ mkdir src
   $ echo '(alias (name runtest) (action (progn)))' >  src/dune
   $ dune build
-  Info: creating file dune-project with this contents: (lang dune 1.4)
+  Info: creating file dune-project with this contents: (lang dune 1.5)
   $ cat dune-project
-  (lang dune 1.4)
+  (lang dune 1.5)
 
 Test that using menhir automatically update the dune-project file
 
@@ -13,5 +13,5 @@ Test that using menhir automatically update the dune-project file
   $ dune build
   Info: appending this line to dune-project: (using menhir 2.0)
   $ cat dune-project
-  (lang dune 1.4)
+  (lang dune 1.5)
   (using menhir 2.0)


### PR DESCRIPTION
Should address the toolchain problems encountered in #1413 by respecting the OCAMLFIND_TOOLCHAIN variable for the default context. Since dune reimplements ocamlfind, this behavior seems to be desirable.

I'm also thinking of we should toolchain selection via the workspace file. It's a natural place to configure to put such configuration and this way wouldn't be limited to just the default context.