### PR TITLE
Virtual library implementation fixes related to private modules

### DIFF
--- a/src/ml_kind.ml
+++ b/src/ml_kind.ml
@@ -10,6 +10,8 @@ let suffix = choose "" "i"
 
 let to_string = choose "impl" "intf"
 
+let pp fmt t = Format.pp_print_string fmt (to_string t)
+
 let flag t = choose (Arg_spec.A "-impl") (A "-intf") t
 
 let ppx_driver_flag t = choose (Arg_spec.A "--impl") (A "--intf") t

--- a/src/ml_kind.mli
+++ b/src/ml_kind.mli
@@ -1,6 +1,10 @@
+open Stdune
+
 type t = Impl | Intf
 
 val all : t list
+
+val pp : t Fmt.t
 
 (** "" or "i" *)
 val suffix : t -> string

--- a/src/module.mli
+++ b/src/module.mli
@@ -99,6 +99,8 @@ val set_pp : t -> (unit, string list) Build.t option -> t
 
 val to_sexp : t Sexp.Encoder.t
 
+val pp : t Fmt.t
+
 val wrapped_compat : t -> t
 
 module Name_map : sig

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -136,6 +136,12 @@ module Dep_graphs = struct
     }
 end
 
+let is_alias_module cctx (m : Module.t) =
+  let open Module.Name.Infix in
+  match CC.alias_module cctx with
+  | None -> false
+  | Some alias -> Module.name alias = Module.name m
+
 let parse_module_names ~(unit : Module.t) ~modules ~modules_of_vlib words =
   let open Module.Name.Infix in
   List.filter_map words ~f:(fun m ->
@@ -146,12 +152,6 @@ let parse_module_names ~(unit : Module.t) ~modules ~modules_of_vlib words =
       match Module.Name.Map.find modules m with
       | Some _ as m -> m
       | None -> Module.Name.Map.find modules_of_vlib m)
-
-let is_alias_module cctx (m : Module.t) =
-  let open Module.Name.Infix in
-  match CC.alias_module cctx with
-  | None -> false
-  | Some alias -> Module.name alias = Module.name m
 
 let parse_deps cctx ~file ~unit lines =
   let dir                  = CC.dir                  cctx in

--- a/src/virtual_rules.mli
+++ b/src/virtual_rules.mli
@@ -8,7 +8,7 @@ module Implementation : sig
     -> Ocamldep.Dep_graphs.t
     -> Ocamldep.Dep_graph.t Ml_kind.Dict.t
 
-  val modules_of_vlib : t -> Module.Name_map.t
+  val vlib_modules : t -> Lib_modules.t
 end
 
 module Gen (S : sig val sctx : Super_context.t end) : sig

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/dune
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/dune
@@ -1,0 +1,7 @@
+(executable
+ (name test)
+ (libraries foo_impl))
+
+(alias
+ (name default)
+ (action (run ./test.exe)))

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/bar.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/bar.ml
@@ -1,1 +1,3 @@
-let run () = print_endline "implementing bar"
+let run () =
+  Priv.run ();
+  print_endline "implementing bar"

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/baz.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/baz.ml
@@ -1,1 +1,0 @@
-(* this module isn't allowed as it introduces a new interface *)

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/dune
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/dune
@@ -1,4 +1,4 @@
 (library
  (name foo_impl)
- (private_modules baz)
+ (private_modules priv)
  (implements foo))

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/priv.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/priv.ml
@@ -1,0 +1,1 @@
+let run () = print_endline "Private module Baz"

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/priv.mli
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/impl/priv.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit

--- a/test/blackbox-tests/test-cases/variants/impl-private-modules/test.ml
+++ b/test/blackbox-tests/test-cases/variants/impl-private-modules/test.ml
@@ -1,0 +1,1 @@
+let () = Foo.Bar.run ()

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -130,6 +130,22 @@ Implementations cannot introduce new modules to the library's interface
 They can only introduce private modules:
   $ dune build --root impl-private-modules
   Entering directory 'impl-private-modules'
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+  (Ocamldep.Dep_graph.deps_of
+   (dir (In_build_dir default/vlib/.foo.objs))
+   (modules (Bar))
+   (module Priv))
+  Backtrace:
+  Raised at file "src/dep_path.ml", line 46, characters 24-55
+  Called from file "src/fiber/fiber.ml", line 243, characters 6-18
+  
+  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
+  the little-death that brings total obliteration.  I will fully express
+  my cases.  Execution will pass over me and through me.  And when it
+  has gone past, I will unwind the stack along its path.  Where the
+  cases are handled there will be nothing.  Only I will remain.
+  [1]
 
 Virtual library with a single module
   $ dune build --root variants-simple

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -190,10 +190,10 @@ Install files for implemenations and virtual libs have all the artifacts:
     "_build/install/default/lib/impl/vlib__Foo.cmi" {"vlib__Foo.cmi"}
     "_build/install/default/lib/impl/vlib__Foo.cmt" {"vlib__Foo.cmt"}
     "_build/install/default/lib/impl/vlib__Foo.cmx" {"vlib__Foo.cmx"}
-    "_build/install/default/lib/impl/vlib_impl__.cmi" {"vlib_impl__.cmi"}
-    "_build/install/default/lib/impl/vlib_impl__.cmt" {"vlib_impl__.cmt"}
-    "_build/install/default/lib/impl/vlib_impl__.cmx" {"vlib_impl__.cmx"}
-    "_build/install/default/lib/impl/vlib_impl__.ml" {"vlib_impl__.ml"}
+    "_build/install/default/lib/impl/vlib__impl__.cmi" {"vlib__impl__.cmi"}
+    "_build/install/default/lib/impl/vlib__impl__.cmt" {"vlib__impl__.cmt"}
+    "_build/install/default/lib/impl/vlib__impl__.cmx" {"vlib__impl__.cmx"}
+    "_build/install/default/lib/impl/vlib__impl__.ml" {"vlib__impl__.ml"}
   ]
 
 Implementations may refer to virtual library's modules

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -130,22 +130,9 @@ Implementations cannot introduce new modules to the library's interface
 They can only introduce private modules:
   $ dune build --root impl-private-modules
   Entering directory 'impl-private-modules'
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-  (Ocamldep.Dep_graph.deps_of
-   (dir (In_build_dir default/vlib/.foo.objs))
-   (modules (Bar))
-   (module Priv))
-  Backtrace:
-  Raised at file "src/dep_path.ml", line 46, characters 24-55
-  Called from file "src/fiber/fiber.ml", line 243, characters 6-18
-  
-  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
-  the little-death that brings total obliteration.  I will fully express
-  my cases.  Execution will pass over me and through me.  And when it
-  has gone past, I will unwind the stack along its path.  Where the
-  cases are handled there will be nothing.  Only I will remain.
-  [1]
+          test alias default
+  Private module Baz
+  implementing bar
 
 Virtual library with a single module
   $ dune build --root variants-simple
@@ -178,9 +165,36 @@ Executable that tries to use two implementations for the same virtual lib
 Install files for implemenations and virtual libs have all the artifacts:
   $ dune build --root install-file
   Entering directory 'install-file'
-  No rule found for impl/.impl.objs/vlib.cmt
-  No rule found for impl/vlib.ml-gen
-  [1]
+  lib: [
+    "_build/install/default/lib/vlib/META" {"META"}
+    "_build/install/default/lib/vlib/foo.mli" {"foo.mli"}
+    "_build/install/default/lib/vlib/opam" {"opam"}
+    "_build/install/default/lib/vlib/vlib.cmi" {"vlib.cmi"}
+    "_build/install/default/lib/vlib/vlib.cmt" {"vlib.cmt"}
+    "_build/install/default/lib/vlib/vlib.cmx" {"vlib.cmx"}
+    "_build/install/default/lib/vlib/vlib.dune" {"vlib.dune"}
+    "_build/install/default/lib/vlib/vlib.ml" {"vlib.ml"}
+    "_build/install/default/lib/vlib/vlib$ext_obj" {"vlib$ext_obj"}
+    "_build/install/default/lib/vlib/vlib__Foo.cmi" {"vlib__Foo.cmi"}
+    "_build/install/default/lib/vlib/vlib__Foo.cmti" {"vlib__Foo.cmti"}
+  ]
+  lib: [
+    "_build/install/default/lib/impl/META" {"META"}
+    "_build/install/default/lib/impl/foo.ml" {"foo.ml"}
+    "_build/install/default/lib/impl/impl$ext_lib" {"impl$ext_lib"}
+    "_build/install/default/lib/impl/impl.cma" {"impl.cma"}
+    "_build/install/default/lib/impl/impl.cmxa" {"impl.cmxa"}
+    "_build/install/default/lib/impl/impl.cmxs" {"impl.cmxs"}
+    "_build/install/default/lib/impl/impl.dune" {"impl.dune"}
+    "_build/install/default/lib/impl/opam" {"opam"}
+    "_build/install/default/lib/impl/vlib__Foo.cmi" {"vlib__Foo.cmi"}
+    "_build/install/default/lib/impl/vlib__Foo.cmt" {"vlib__Foo.cmt"}
+    "_build/install/default/lib/impl/vlib__Foo.cmx" {"vlib__Foo.cmx"}
+    "_build/install/default/lib/impl/vlib_impl__.cmi" {"vlib_impl__.cmi"}
+    "_build/install/default/lib/impl/vlib_impl__.cmt" {"vlib_impl__.cmt"}
+    "_build/install/default/lib/impl/vlib_impl__.cmx" {"vlib_impl__.cmx"}
+    "_build/install/default/lib/impl/vlib_impl__.ml" {"vlib_impl__.ml"}
+  ]
 
 Implementations may refer to virtual library's modules
   $ dune build --root impl-using-vlib-modules


### PR DESCRIPTION
Implementations of virtual libraries need an alias module that includes modules from the implementation and virtual library. On the way, I also fix two unrelated issues:

* The dependency graph was wrong in the presence of private module mli's
* The .install file wasn't being generated as some incorrect copy rules were setup.