### PR TITLE
meta built-ins: fix bigarray entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ next
 - Install generated OCaml files with a `.ml` rather than a `.ml-gen` extension
   (#1425, fix #1414, @rgrinberg)
 
+- Allow to use the `bigarray` library in >= 4.07 without ocamlfind and without
+  installing the corresponding `otherlib`. (#1455, @nojb)
+
 1.4.0 (10/10/2018)
 ------------------
 

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -237,7 +237,12 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   in
   let str = simple "str" [] ~dir:"+" in
   let unix = simple "unix" [] ~dir:"+" in
-  let bigarray = simple "bigarray" ["unix"] ~dir:"+" in
+  let bigarray =
+    if Ocaml_version.stdlib_includes_bigarray ocaml_version then
+      dummy "bigarray"
+    else
+      simple "bigarray" ["unix"] ~dir:"+"
+  in
   let dynlink = simple "dynlink" [] ~dir:"+" in
   let bytes = dummy "bytes" in
   let result = dummy "result" in

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -238,7 +238,8 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   let str = simple "str" [] ~dir:"+" in
   let unix = simple "unix" [] ~dir:"+" in
   let bigarray =
-    if Ocaml_version.stdlib_includes_bigarray ocaml_version then
+    if Ocaml_version.stdlib_includes_bigarray ocaml_version &&
+       not (Path.exists (Path.relative stdlib_dir "bigarray.cma")) then
       dummy "bigarray"
     else
       simple "bigarray" ["unix"] ~dir:"+"

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -31,3 +31,6 @@ let pervasives_includes_result version =
 
 let stdlib_includes_uchar version =
   version >= (4, 03, 0)
+
+let stdlib_includes_bigarray version =
+  version >= (4, 07, 0)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -32,3 +32,6 @@ val pervasives_includes_result : t -> bool
 
 (** Whether the standard library includes the [Uchar] module *)
 val stdlib_includes_uchar : t -> bool
+
+(** Whether the standard library includes the [Bigarray] module *)
+val stdlib_includes_bigarray : t -> bool


### PR DESCRIPTION
This makes it so that `Bigarray` can be used, post-4.07, without installing the `bigarray` library.