### PR TITLE
Simplify the --force tests

### DIFF
--- a/test/blackbox-tests/test-cases/force-test/run.t
+++ b/test/blackbox-tests/test-cases/force-test/run.t
@@ -1,4 +1,3 @@
-  $ dune clean --display short
   $ dune runtest --display short
       ocamldep .f.eobjs/f.ml.d
         ocamlc .f.eobjs/f.{cmi,cmo,cmt}
@@ -6,7 +5,7 @@
       ocamlopt f.exe
              f alias runtest
   Foo Bar
-  $ dune runtest --display short
+  $ dune runtest
   $ dune runtest --force --display short
              f alias runtest
   Foo Bar


### PR DESCRIPTION
There's no need to clean in the beginning or rely on --display short to check if
something is rebuilt

@ejgallego could you check if this fixes the `force-test` test for you? You can run it individually with `$ dune build @force-test` btw.