### PR TITLE
Add [%%ignore] to expect tests

### DIFF
--- a/test/unit-tests/action.mlt
+++ b/test/unit-tests/action.mlt
@@ -12,11 +12,7 @@ let infer (a : Action.t) =
   let x = Action.Infer.infer a in
   (List.map (Path.Set.to_list x.deps) ~f:Path.to_string,
    List.map (Path.Set.to_list x.targets) ~f:Path.to_string)
-[%%expect{|
-- : unit = ()
-val p : ?error_loc:Stdune__Loc.t -> string -> Path.t = <fun>
-val infer : Action.t -> string list * string list = <fun>
-|}]
+[%%ignore]
 
 infer (Copy (p "a", p "b"));;
 [%%expect{|


### PR DESCRIPTION
This is used to ignore some output generated by the toplevel. Useful when the
output isn't useful for the tests and not deterministic.

@ejgallego this should fix another failure for you