### PR TITLE
Add a wrapper tag for odoc index pages.

### DIFF
--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -249,12 +249,14 @@ module Gen (S : sig val sctx : SC.t end) = struct
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   </head>
   <body>
-    <div class="by-name">
-    <h2>OCaml package documentation</h2>
-    <ol>
-    %s
-    </ol>
-    </div>
+    <main class="content">
+      <div class="by-name">
+      <h2>OCaml package documentation</h2>
+      <ol>
+      %s
+      </ol>
+      </div>
+    </main>
   </body>
 </html>|} list_items
     in

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -238,7 +238,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
         in
         Some (sp "<li>%s%s</li>" link version_suffix))
     in
-    let list_items = String.concat ~sep:"\n    " list_items in
+    let list_items = String.concat ~sep:"\n      " list_items in
     let html = sp
 {|<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -30,13 +30,15 @@
       <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     </head>
     <body>
-      <div class="by-name">
-      <h2>OCaml package documentation</h2>
-      <ol>
-      <li><a href="bar/index.html">bar</a></li>
-      <li><a href="foo/index.html">foo</a></li>
-      </ol>
-      </div>
+      <main class="content">
+        <div class="by-name">
+        <h2>OCaml package documentation</h2>
+        <ol>
+        <li><a href="bar/index.html">bar</a></li>
+        <li><a href="foo/index.html">foo</a></li>
+        </ol>
+        </div>
+      </main>
     </body>
   </html>
 


### PR DESCRIPTION
The new odoc theme uses a content wrapper element to position the main content and the sidebar. This PR updates the index page produced by dune to render output consistent with odoc with regards to sizing/padding.