### PR TITLE
Support DESTDIR variable

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -550,7 +550,7 @@ let install_uninstall ~what =
     and prefix_from_command_line =
       Arg.(value
            & opt (some string) None
-           & info ["destdir"; "prefix"]
+           & info ["prefix"]
                ~docv:"PREFIX"
                ~doc:"Directory where files are copied. For instance binaries \
                      are copied into $(i,\\$prefix/bin), library files into \
@@ -567,6 +567,15 @@ let install_uninstall ~what =
                      is specified the default is $(i,\\$prefix/lib), otherwise \
                      it is the output of $(b,ocamlfind printconf destdir)"
           )
+    and destdir =
+      Arg.(value
+           & opt (some string) None
+           & info ["destdir"]
+               ~env:(env_var "DESTDIR")
+               ~docv:"PATH"
+               ~doc:"When passed, this directory is prepended to all \
+                     installed paths."
+          )
     and dry_run =
       Arg.(value
            & flag
@@ -577,7 +586,6 @@ let install_uninstall ~what =
       Arg.(value & pos_all package_name [] name_)
     in
     Common.set_common common ~targets:[];
-    let destdir = Sys.getenv_opt "DESTDIR" in
     let log = Log.create common in
     Scheduler.go ~log ~common
       (Main.setup ~log common >>= fun setup ->

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -50,6 +50,7 @@ module External : sig
   val extension : t -> string
   val is_suffix : t -> suffix:string -> bool
   val split_extension : t -> t * string
+  val as_local : t -> string
 end = struct
   include Interned.No_interning(struct
       let initial_size = 512
@@ -123,6 +124,10 @@ end = struct
 
   let cwd () = make (Sys.getcwd ())
   let initial_cwd = cwd ()
+
+  let as_local t =
+    let s = to_string t in
+    "." ^ s
 end
 
 module Local : sig
@@ -959,3 +964,8 @@ module L = struct
   (* TODO more efficient implementation *)
   let relative t = List.fold_left ~init:t ~f:relative
 end
+
+let local_part = function
+  | External e -> Local.of_string (External.as_local e)
+  | In_source_tree l -> l
+  | In_build_dir l -> l

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -175,3 +175,10 @@ end
 module L : sig
   val relative : t -> string list -> t
 end
+
+(** Return the "local part" of a path.
+    For local paths (in build directory or source tree),
+    this returns the path itself.
+    For external paths, it returns a path that is relative to the current
+    directory. For example, the local part of [/a/b] is [./a/b]. *)
+val local_part : t -> Local.t

--- a/test/blackbox-tests/test-cases/install-libdir/run.t
+++ b/test/blackbox-tests/test-cases/install-libdir/run.t
@@ -186,3 +186,84 @@ in libdir:
   Removing (if it exists) OPAM_VAR_PREFIX/bin/exec
   Removing directory (if empty) OPAM_VAR_PREFIX/bin
   Removing directory (if empty) /LIBDIR/foo
+
+The DESTDIR var is supported. When set, it is prepended to the prefix.
+This is the case when the prefix is implicit:
+
+  $ DESTDIR=DESTDIR dune install --dry-run 2>&1 | sed "s#$(opam config var prefix)#/OPAM_VAR_PREFIX#"
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/META
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo$ext_lib
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cma
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmi
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmt
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmx
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxa
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxs
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.dune
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.ml
+  Installing DESTDIR/OPAM_VAR_PREFIX/lib/foo/opam
+  Installing DESTDIR/OPAM_VAR_PREFIX/bin/exec
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/META to DESTDIR/OPAM_VAR_PREFIX/lib/foo/META (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo$ext_lib (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.cma to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cma (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmi (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmt (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmx (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxa (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxs (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.dune to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.dune (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/foo.ml to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.ml (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
+  Copying _build/install/default/lib/foo/opam to DESTDIR/OPAM_VAR_PREFIX/lib/foo/opam (executable: false)
+  Creating directory DESTDIR/OPAM_VAR_PREFIX/bin
+  Copying _build/install/default/bin/exec to DESTDIR/OPAM_VAR_PREFIX/bin/exec (executable: true)
+
+But also when the prefix is explicit:
+
+  $ DESTDIR=DESTDIR dune install --prefix prefix --dry-run
+  Installing DESTDIR/prefix/lib/foo/META
+  Installing DESTDIR/prefix/lib/foo/foo$ext_lib
+  Installing DESTDIR/prefix/lib/foo/foo.cma
+  Installing DESTDIR/prefix/lib/foo/foo.cmi
+  Installing DESTDIR/prefix/lib/foo/foo.cmt
+  Installing DESTDIR/prefix/lib/foo/foo.cmx
+  Installing DESTDIR/prefix/lib/foo/foo.cmxa
+  Installing DESTDIR/prefix/lib/foo/foo.cmxs
+  Installing DESTDIR/prefix/lib/foo/foo.dune
+  Installing DESTDIR/prefix/lib/foo/foo.ml
+  Installing DESTDIR/prefix/lib/foo/opam
+  Installing DESTDIR/prefix/bin/exec
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/META to DESTDIR/prefix/lib/foo/META (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/prefix/lib/foo/foo$ext_lib (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cma to DESTDIR/prefix/lib/foo/foo.cma (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/prefix/lib/foo/foo.cmi (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/prefix/lib/foo/foo.cmt (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/prefix/lib/foo/foo.cmx (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/prefix/lib/foo/foo.cmxa (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/prefix/lib/foo/foo.cmxs (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.dune to DESTDIR/prefix/lib/foo/foo.dune (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.ml to DESTDIR/prefix/lib/foo/foo.ml (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/opam to DESTDIR/prefix/lib/foo/opam (executable: false)
+  Creating directory DESTDIR/prefix/bin
+  Copying _build/install/default/bin/exec to DESTDIR/prefix/bin/exec (executable: true)

--- a/test/blackbox-tests/test-cases/install-libdir/run.t
+++ b/test/blackbox-tests/test-cases/install-libdir/run.t
@@ -267,3 +267,43 @@ But also when the prefix is explicit:
   Copying _build/install/default/lib/foo/opam to DESTDIR/prefix/lib/foo/opam (executable: false)
   Creating directory DESTDIR/prefix/bin
   Copying _build/install/default/bin/exec to DESTDIR/prefix/bin/exec (executable: true)
+
+DESTDIR can also be passed as a command line flag.
+
+  $ dune install --destdir DESTDIR --prefix prefix --dry-run
+  Installing DESTDIR/prefix/lib/foo/META
+  Installing DESTDIR/prefix/lib/foo/foo$ext_lib
+  Installing DESTDIR/prefix/lib/foo/foo.cma
+  Installing DESTDIR/prefix/lib/foo/foo.cmi
+  Installing DESTDIR/prefix/lib/foo/foo.cmt
+  Installing DESTDIR/prefix/lib/foo/foo.cmx
+  Installing DESTDIR/prefix/lib/foo/foo.cmxa
+  Installing DESTDIR/prefix/lib/foo/foo.cmxs
+  Installing DESTDIR/prefix/lib/foo/foo.dune
+  Installing DESTDIR/prefix/lib/foo/foo.ml
+  Installing DESTDIR/prefix/lib/foo/opam
+  Installing DESTDIR/prefix/bin/exec
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/META to DESTDIR/prefix/lib/foo/META (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/prefix/lib/foo/foo$ext_lib (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cma to DESTDIR/prefix/lib/foo/foo.cma (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/prefix/lib/foo/foo.cmi (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/prefix/lib/foo/foo.cmt (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/prefix/lib/foo/foo.cmx (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/prefix/lib/foo/foo.cmxa (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/prefix/lib/foo/foo.cmxs (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.dune to DESTDIR/prefix/lib/foo/foo.dune (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/foo.ml to DESTDIR/prefix/lib/foo/foo.ml (executable: false)
+  Creating directory DESTDIR/prefix/lib/foo
+  Copying _build/install/default/lib/foo/opam to DESTDIR/prefix/lib/foo/opam (executable: false)
+  Creating directory DESTDIR/prefix/bin
+  Copying _build/install/default/bin/exec to DESTDIR/prefix/bin/exec (executable: true)

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -10,11 +10,17 @@ let e = Path.of_filename_relative_to_initial_cwd;;
 
 #install_printer Path.pp_debug;;
 
+let pp_path_local fmt l =
+  Format.pp_print_string fmt (Path.Local.to_string l);;
+
+#install_printer pp_path_local;;
+
 Path.(let p = relative root "foo" in descendant p ~of_:p)
 [%%expect{|
 - : unit = ()
 val r : string -> Path.t = <fun>
 val e : string -> Path.t = <fun>
+val pp_path_local : Format.formatter -> Path.Local.t -> unit = <fun>
 - : Path.t option = Some (In_source_tree ".")
 |}]
 
@@ -126,7 +132,7 @@ Path.(descendant (relative build_dir "foo") ~of_:root)
 
 Path.(descendant (relative build_dir "foo") ~of_:(absolute "/foo/bar"))
 [%%expect{|
-File "test/unit-tests/path.mlt", line 127, characters 50-58:
+File "test/unit-tests/path.mlt", line 133, characters 50-58:
 Error: Unbound value absolute
 |}]
 
@@ -147,7 +153,7 @@ Path.(descendant (relative build_dir "foo/bar") ~of_:(relative build_dir "foo"))
 
 Path.(descendant (absolute "/foo/bar") ~of_:(absolute "/foo"))
 [%%expect{|
-File "test/unit-tests/path.mlt", line 148, characters 18-26:
+File "test/unit-tests/path.mlt", line 154, characters 18-26:
 Error: Unbound value absolute
 |}]
 
@@ -352,4 +358,19 @@ Path.relative Path.root "_build"
 Path.relative (r "foo") "../_build"
 [%%expect{|
 - : Path.t = (In_build_dir ".")
+|}]
+
+Path.local_part (Path.of_string "/c/d")
+[%%expect{|
+- : Path.Local.t = c/d
+|}]
+
+Path.local_part (Path.insert_after_build_dir_exn Path.build_dir "c/d")
+[%%expect{|
+- : Path.Local.t = c/d
+|}]
+
+Path.local_part (r "c/d")
+[%%expect{|
+- : Path.Local.t = c/d
 |}]


### PR DESCRIPTION
See <https://www.gnu.org/prep/standards/html_node/DESTDIR.html>. This variable, when present, is prepended to all installed paths.

In addition, this fixes the `--destdir` argument, which was used as synonym for `--prefix`. See the individual commit messages.

cc @bobot