### PR TITLE
Memoization function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,13 @@ unreleased
   opened by Dune (#1635, #1643, fixes #1633, @jonludlam, @rgrinberg,
   @diml)
 
+- Reimplement the core of Dune using a new generic memoization system
+  (#1489, @rudihorn, @diml)
+
+- Replace the broken cycle detection algorithm by a state of the art
+  one from [this paper](https://doi.org/10.1145/2756553) (#1489,
+  @rudihorn)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -34,6 +34,8 @@ let dirs =
   ; "src/stdune"             , Some "Stdune"
   ; "src/fiber"              , Some "Fiber"
   ; "src/xdg"                , Some "Xdg"
+  ; "src/dag"                , Some "Dag"
+  ; "src/memo"               , Some "Memo"
   ; "src/ocaml-config"       , Some "Ocaml_config"
   ; "vendor/boot"            , None
   ; "src/dune_lang"              , Some "Dune_lang"

--- a/example/sample-projects/hello_world/run.t
+++ b/example/sample-projects/hello_world/run.t
@@ -2,15 +2,15 @@
       ocamldep bin/.main.eobjs/main.ml.d
       ocamldep lib/.hello_world.objs/hello_world.ml.d
         ocamlc lib/.hello_world.objs/hello_world.{cmi,cmo,cmt}
+        ocamlc lib/hello_world.cma
+      ocamldep test/.test.eobjs/test.ml.d
       ocamlopt lib/.hello_world.objs/hello_world.{cmx,o}
       ocamlopt lib/hello_world.{a,cmxa}
-      ocamlopt lib/hello_world.cmxs
-      ocamldep test/.test.eobjs/test.ml.d
         ocamlc test/.test.eobjs/test.{cmi,cmo,cmt}
       ocamlopt test/.test.eobjs/test.{cmx,o}
       ocamlopt test/test.exe
           test test/test.output
-        ocamlc lib/hello_world.cma
+      ocamlopt lib/hello_world.cmxs
         ocamlc bin/.main.eobjs/main.{cmi,cmo,cmt}
       ocamlopt bin/.main.eobjs/main.{cmx,o}
       ocamlopt bin/main.exe

--- a/example/sample-projects/with-configure-step/run.t
+++ b/example/sample-projects/with-configure-step/run.t
@@ -3,7 +3,7 @@
       ocamldep src/.plop.eobjs/config.ml.d
       ocamldep src/.plop.eobjs/plop.ml.d
         ocamlc src/.plop.eobjs/config.{cmi,cmo,cmt}
-      ocamlopt src/.plop.eobjs/config.{cmx,o}
         ocamlc src/.plop.eobjs/plop.{cmi,cmo,cmt}
       ocamlopt src/.plop.eobjs/plop.{cmx,o}
+      ocamlopt src/.plop.eobjs/config.{cmx,o}
       ocamlopt src/plop.exe

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -212,7 +212,7 @@ val is_target : t -> Path.t -> bool
 val all_lib_deps
   :  t
   -> request:(unit, unit) Build.t
-  -> Lib_deps_info.t Path.Map.t String.Map.t
+  -> Lib_deps_info.t Path.Map.t String.Map.t Fiber.t
 
 (** List of all buildable targets *)
 val all_targets : t -> Path.t list

--- a/src/dag/dag.ml
+++ b/src/dag/dag.ml
@@ -1,0 +1,149 @@
+open! Stdune
+
+include Dag_intf
+
+module Make(Value : Value) : S with type value := Value.t = struct
+  type t = {
+    mutable num : int;
+    mutable index : int;
+    mutable arcs : int;
+  }
+
+  type node_info = {
+    id : int;
+    mutable index : int;
+    mutable level : int;
+    mutable deps : node list;
+    mutable rev_deps : node list;
+  }
+
+  and node =
+    { data : Value.t
+    ; info : node_info
+    }
+
+  exception Cycle of node list
+
+  let create () = {
+    num = 0;
+    index = 0;
+    arcs = 0;
+  }
+
+  let gen_index (dag : t) =
+    dag.index <- dag.index - 1;
+    dag.index
+
+  let create_node_info dag =
+    dag.num <- dag.num + 1;
+    {
+      id = dag.num;
+      index = gen_index dag;
+      level = 1;
+      deps = [];
+      rev_deps = [];
+    }
+
+  let delta dag =
+    let n = dag.num in
+    let m = dag.arcs in
+    min (float m ** (1.0 /. 2.0)) (float n ** (2.0 /. 3.0)) |> int_of_float
+
+  let add dag v w =
+    let delta = delta dag in
+
+    dag.arcs <- dag.arcs + 1;
+
+    let marked_ids = ref Int.Set.empty in
+    let arcs = ref 0 in
+    let f = ref [] in
+    let b = ref [] in
+
+    let rec bvisit y acc =
+      marked_ids := Int.Set.union !marked_ids (Int.Set.singleton y.info.id);
+      if List.exists y.info.rev_deps ~f:(fun x -> btraverse x y (x :: acc)) |> not then begin
+        b := List.append !b [y];
+        false end
+      else
+        true
+    and btraverse x _y acc =
+      if x.info.id = w.info.id then raise (Cycle acc);
+      arcs := !arcs + 1;
+      if !arcs >= delta then begin
+        w.info.level <- v.info.level + 1;
+        w.info.rev_deps <- [];
+        b := [];
+        true
+      end else begin
+        if Int.Set.mem !marked_ids x.info.id then
+          false
+        else
+          bvisit x acc
+      end in
+
+    let rec reconstruct_b_path  y acc x =
+      if x.info.id = y.info.id then
+        Some (acc)
+      else
+        List.find_map ~f:(reconstruct_b_path y (x :: acc)) x.info.rev_deps in
+
+    let rec fvisit x acc =
+      List.iter x.info.deps ~f:(fun y -> ftraverse x y (y :: acc));
+      f := x :: !f
+    and ftraverse x y acc =
+      if y.info.id = v.info.id || List.exists ~f:(fun n -> n.info.id = y.info.id) !b then begin
+        let path = reconstruct_b_path y [] v |> Option.value_exn in
+        Cycle (List.append path acc) |> raise
+      end;
+      if y.info.level < w.info.level then begin
+        y.info.level <- w.info.level;
+        y.info.rev_deps <- [];
+        fvisit y acc
+      end;
+      if y.info.level = w.info.level then
+        y.info.rev_deps <- x :: y.info.rev_deps in
+
+    (* step 1: test order *)
+    if (v.info.level < w.info.level || (v.info.level = w.info.level && v.info.index < w.info.index)) |> not then
+      begin
+        (* step 2 *)
+        let step2res = bvisit v [v; w] in
+
+        let acc = [w; v] in
+        (* step 3 *)
+        if step2res then
+          fvisit w acc
+        else if w.info.level <> v.info.level then begin
+          w.info.level <- v.info.level;
+          w.info.rev_deps <- [];
+          fvisit w acc
+        end;
+
+        (* step 4 *)
+        let l = List.rev (List.append !b !f) in
+        List.iter ~f:(fun x -> x.info.index <- gen_index dag) l
+      end;
+
+    (* step 5 *)
+    v.info.deps <- w :: v.info.deps;
+    if v.info.level = w.info.level then
+      w.info.rev_deps <- v :: w.info.rev_deps
+
+  let children node = node.info.deps
+
+  let rec pp_depth depth pp_value fmt n =
+    if depth >= 20 then
+      Format.fprintf fmt "..."
+    else
+      Format.fprintf fmt "(%d: k=%d, i=%d) (%a) [@[%a@]]"
+        n.info.id n.info.level n.info.index pp_value n.data
+        (pp_depth (depth + 1) pp_value
+         |> Fmt.list ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@, "))
+        n.info.deps
+
+  let pp_node pp_value fmt n =
+    pp_depth 0 pp_value fmt n
+
+  let is_child v w =
+    v.info.deps |> List.exists ~f:(fun c -> c.info.id = w.info.id)
+end

--- a/src/dag/dag.mli
+++ b/src/dag/dag.mli
@@ -1,0 +1,15 @@
+(** Detection of cycles in dynamic dags *)
+
+open! Stdune
+
+(** Based on the work by:
+
+    Michael A. Bender, Jeremy T. Fineman, Seth Gilbert, and Robert
+    E. Tarjan. 2015. A New Approach to Incremental Cycle Detection and
+    Related Problems. ACM Trans. Algorithms 12, 2, Article 14 (December
+    2015), 22 pages. DOI: https://doi.org/10.1145/2756553 *)
+
+module type Value = Dag_intf.Value
+module type S = Dag_intf.S
+
+module Make(Value : Value) : S with type value := Value.t

--- a/src/dag/dag_intf.ml
+++ b/src/dag/dag_intf.ml
@@ -1,0 +1,52 @@
+(** Detection of cycles in dynamic dags *)
+
+open! Stdune
+
+module type Value = sig
+  type t
+end
+
+module type S = sig
+  (** A DAG (Directed Acyclic Graph). *)
+  type t
+
+  (** Info about a node in the DAG. *)
+  type node_info
+
+  (** Type of values attached to nodes. *)
+  type value
+
+  type node =
+    { data : value
+    ; info : node_info
+    }
+
+  (** A cycle has been found while adding an arc. *)
+  exception Cycle of node list
+
+  (** [create ()] creates a directed acyclic graph. *)
+  val create : unit -> t
+
+  (** [create_node_info dag v] creates new node info that belongs to [dag]. *)
+  val create_node_info : t -> node_info
+
+  (** [add dag v w] creates an arc going from [v] to [w].
+      @raise Cycle if creating the arc would create a cycle. *)
+  val add : t -> node -> node -> unit
+
+  (** [children v] returns all nodes [w] for which an arc going from [v]
+      to [w] exists. *)
+  val children : node -> node list
+
+  (** Pretty print a node. *)
+  val pp_node : value Fmt.t -> node Fmt.t
+
+  (** This returns the \Delta value of the given dag. This is a
+      maximum bound on the number of nodes to search and is useful for
+      debugging. *)
+  val delta : t -> int
+
+  (** [is_child v w] returns a boolean indicating if an arc going from
+      [v] to [w] exists. *)
+  val is_child : node -> node -> bool
+end

--- a/src/dag/dune
+++ b/src/dag/dune
@@ -1,0 +1,4 @@
+(library
+ (name dag)
+ (libraries stdune)
+ (synopsis "Directed Acyclic Graph library"))

--- a/src/dep_path.ml
+++ b/src/dep_path.ml
@@ -49,6 +49,14 @@ let unwrap_exn = function
   | E (exn, entries) -> (exn, Some entries)
   | exn -> (exn, None)
 
+let map ~f = function
+  | E (exn, entries) -> begin
+      match f exn with
+      | E (exn, entries') -> E (exn, entries' @ entries)
+      | exn -> E (exn, entries)
+    end
+  | exn -> f exn
+
 let () =
   Printexc.register_printer (function
     | E (exn, _) -> Some (Printexc.to_string exn)

--- a/src/dep_path.mli
+++ b/src/dep_path.mli
@@ -29,3 +29,6 @@ val prepend_exn : exn -> Entry.t -> exn
 
 (** Extract a wrapped exception *)
 val unwrap_exn : exn -> exn * Entry.t list option
+
+(** Apply [f] to the underlying exception. *)
+val map : f:(exn -> exn) -> exn -> exn

--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,8 @@
  (libraries   unix
               stdune
               fiber
+              dag
+              memo
               xdg
               dune_re
               threads

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -120,6 +120,26 @@ val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
 *)
 val parallel_iter : 'a list -> f:('a -> unit t) -> unit t
 
+(** {1 Execute once fibers} *)
+
+module Once : sig
+  type 'a fiber = 'a t
+  type 'a t
+
+  val create : (unit -> 'a fiber) -> 'a t
+
+  (** [get t] returns the value of [t]. If [get] was never called
+      before on this [t], it is executed at this point, otherwise
+      returns a fiber that waits for the fiber from the first call to
+      [get t] to terminate. *)
+  val get : 'a t -> 'a fiber
+
+  (** [peek t] returns [Some v] if [get t] has already been called and
+      has yielded a value [v]. *)
+  val peek : 'a t -> 'a option
+  val peek_exn : 'a t -> 'a
+end with type 'a fiber := 'a t
+
 (** {1 Local storage} *)
 
 (** Variables local to a fiber *)

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,0 +1,4 @@
+(library
+ (name memo)
+ (libraries stdune dag fiber)
+ (synopsis "Function memoizer"))

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1,0 +1,338 @@
+open !Stdune
+open Fiber.O
+
+module type Data = Memo_intf.Data
+
+module Function_name = Interned.Make(struct
+    let initial_size = 1024
+    let resize_policy = Interned.Greedy
+    let order = Interned.Fast
+  end) ()
+
+module Spec = struct
+  type _ witness = ..
+
+  type ('a, 'b) t =
+    { name : Function_name.t
+    ; allow_cutoff : bool
+    ; input : (module Data with type t = 'a)
+    ; output : (module Data with type t = 'b)
+    ; witness : 'a witness
+    }
+end
+
+module Id = Id.Make()
+
+module Run : sig
+  (** Represent a run of the system *)
+  type t
+
+  (** Return the current run *)
+  val current : unit -> t
+
+  (** Whether this run is the current one *)
+  val is_current : t -> bool
+
+  (** End the current run and start a new one *)
+  val restart : unit -> unit
+end = struct
+  type t = bool ref
+
+  let current = ref (ref true)
+
+  let restart () =
+    !current := false;
+    current := ref true
+
+  let current () = !current
+  let is_current t = !t
+end
+
+let reset = Run.restart
+
+module M = struct
+  module Generic_dag = Dag
+
+  module rec Cached_value : sig
+    type 'a t =
+      { data : 'a
+      ; (* When was the value computed *)
+        mutable calculated_at : Run.t
+      ; deps : Last_dep.t list
+      }
+  end = Cached_value
+
+  and State : sig
+    type 'a t =
+      | Running of Run.t * 'a Fiber.Ivar.t
+      | Done of 'a Cached_value.t
+  end = State
+
+  and Dep_node : sig
+    type ('a, 'b) t = {
+      spec : ('a, 'b) Spec.t;
+      input : 'a;
+      id : Id.t;
+      mutable dag_node : Dag.node Lazy.t;
+      mutable state : 'b State.t;
+    }
+
+    type packed = T : (_, _) t -> packed [@@unboxed]
+  end = Dep_node
+
+  and Last_dep : sig
+    type t = T : ('a, 'b) Dep_node.t * 'b -> t
+  end = Last_dep
+
+  and Dag : Generic_dag.S with type value := Dep_node.packed
+    = Generic_dag.Make(struct type t = Dep_node.packed end)
+end
+
+module State = M.State
+module Dep_node = M.Dep_node
+module Last_dep = M.Last_dep
+module Dag = M.Dag
+
+module Cached_value = struct
+  include M.Cached_value
+
+  let create x ~deps =
+    { deps
+    ; data = x
+    ; calculated_at = Run.current ()
+    }
+
+  let dep_changed (type a) (node : (_, a) Dep_node.t) prev_output curr_output =
+    if node.spec.allow_cutoff then
+      let (module Output : Data with type t = a) = node.spec.output in
+      not (Output.equal prev_output curr_output)
+    else
+      true
+
+  (* Check if a cached value is up to date. If yes, return it *)
+  let rec get : type a. a t -> a option Fiber.t = fun t ->
+    if Run.is_current t.calculated_at then
+      Fiber.return (Some t.data)
+    else begin
+      let rec deps_changed acc = function
+        | [] ->
+          Fiber.parallel_map acc ~f:(fun x -> x) >>| List.exists ~f:(fun x -> x)
+        | Last_dep.T (node, prev_output) :: deps ->
+          match node.state with
+          | Running (run, ivar) ->
+            if not (Run.is_current run) then
+              Fiber.return true
+            else
+              let changed =
+                Fiber.Ivar.read ivar >>| fun curr_output ->
+                dep_changed node prev_output curr_output
+              in
+              deps_changed (changed :: acc) deps
+          | Done t' ->
+            if Run.is_current t'.calculated_at then begin
+              (* handle common case separately to avoid feeding more
+                 fibers to [parallel_map] *)
+              if dep_changed node prev_output t'.data then
+                Fiber.return true
+              else
+                deps_changed acc deps
+            end else
+              let changed =
+                get t' >>| function
+                | None -> true
+                | Some curr_output ->
+                  dep_changed node prev_output curr_output
+              in
+              deps_changed (changed :: acc) deps
+      in
+      deps_changed [] t.deps >>| function
+      | true -> None
+      | false ->
+        t.calculated_at <- Run.current ();
+        Some t.data
+    end
+end
+
+let ser_input (type a) (node : (a, _) Dep_node.t) =
+  let (module Input : Data with type t = a) = node.spec.input in
+  Input.to_sexp node.input
+
+let dag_node (dep_node : _ Dep_node.t) = Lazy.force dep_node.dag_node
+
+module Stack_frame = struct
+  open Dep_node
+
+  type t = packed
+
+  let name (T t) = Function_name.to_string t.spec.name
+  let input (T t) = ser_input t
+
+  let equal (T a) (T b) = Id.equal a.id b.id
+  let compare (T a) (T b) = Id.compare a.id b.id
+end
+
+module Cycle_error = struct
+  type t =
+    { cycle : Stack_frame.t list
+    ; stack : Stack_frame.t list
+    }
+
+  exception E of t
+
+  let get t = t.cycle
+  let stack t = t.stack
+end
+
+module type S = Memo_intf.S with type stack_frame := Stack_frame.t
+
+let global_dep_dag = Dag.create ()
+
+(* fiber context variable keys *)
+let call_stack_key = Fiber.Var.create ()
+let get_call_stack =
+  Fiber.Var.get call_stack_key (* get call stack *)
+  >>| Option.value ~default:[] (* default call stack is empty *)
+
+let push_stack_frame frame f =
+  get_call_stack >>= fun stack ->
+  Fiber.Var.set call_stack_key (frame :: stack) f
+
+let dump_stack v =
+  get_call_stack
+  >>|
+  (Printf.printf "Memoized function stack:\n";
+   List.iter ~f:(
+     fun st -> Printf.printf "   %s %s\n"
+                 (Stack_frame.name st)
+                 (Stack_frame.input st |> Sexp.to_string)
+   )
+  )
+  >>| (fun _ -> v)
+
+module Make(Input : Data) : S with type input := Input.t = struct
+  module Table = Hashtbl.Make(Input)
+
+  type 'a t =
+    { spec  : (Input.t, 'a) Spec.t
+    ; cache : (Input.t, 'a) Dep_node.t Table.t
+    ; f     : Input.t -> 'a Fiber.t
+    }
+
+  type _ Spec.witness += W : Input.t Spec.witness
+
+  let add_rev_dep dep_node =
+    get_call_stack >>| function
+    | [] -> ()
+    | (Dep_node.T rev_dep) :: _ as stack ->
+      (* if the caller doesn't already contain this as a dependent *)
+      let rev_dep = dag_node rev_dep in
+      try
+        if Dag.is_child rev_dep dep_node |> not then
+          Dag.add global_dep_dag rev_dep dep_node
+      with Dag.Cycle cycle ->
+        Cycle_error.E {
+          stack = stack;
+          cycle = List.map cycle ~f:(fun node -> node.Dag.data)
+        } |> raise
+
+  let get_deps t inp =
+    match Table.find t.cache inp with
+    | None | Some { state = Running _; _ } -> None
+    | Some { state = Done cv; _ } ->
+      Some (List.map cv.deps ~f:(fun (Last_dep.T (n,_u)) ->
+        (Function_name.to_string n.spec.name, ser_input n)))
+
+  let create name ?(allow_cutoff=true) output f =
+    let name = Function_name.make name in
+    { cache = Table.create 1024
+    ; spec = { name; input = (module Input); output; allow_cutoff; witness = W }
+    ; f
+    }
+
+  let compute t inp ivar dep_node =
+    (* define the function to update / double check intermediate result *)
+    (* set context of computation then run it *)
+    push_stack_frame (T dep_node) (t.f inp) >>= fun res ->
+    (* update the output cache with the correct value *)
+    let deps =
+      Dag.children (dag_node dep_node)
+      |> List.map ~f:(fun { Dag.data = Dep_node.T node; _ } ->
+        match node.state with
+        | Running _ -> assert false
+        | Done res ->
+          Last_dep.T (node, res.data)
+      )
+    in
+    dep_node.state <- Done (Cached_value.create res ~deps);
+    (* fill the ivar for any waiting threads *)
+    Fiber.Ivar.fill ivar res >>= fun () ->
+    Fiber.return res
+
+  (* the computation that force computes the fiber *)
+  let recompute t inp (dep_node : _ Dep_node.t) =
+    (* create an ivar so other threads can wait for the computation to
+       finish *)
+    let ivar : 'b Fiber.Ivar.t = Fiber.Ivar.create () in
+    dep_node.state <- Running (Run.current (), ivar);
+    compute t inp ivar dep_node
+
+  let exec t inp =
+    match Table.find t.cache inp with
+    | None ->
+      let ivar = Fiber.Ivar.create () in
+      let dep_node : _ Dep_node.t =
+        { id = Id.gen ()
+        ; input = inp
+        ; spec = t.spec
+        ; dag_node = lazy (assert false)
+        ; state = Running (Run.current (), ivar)
+        }
+      in
+      let dag_node : Dag.node =
+        { info = Dag.create_node_info global_dep_dag
+        ; data = Dep_node.T dep_node
+        }
+      in
+      dep_node.dag_node <- lazy dag_node;
+      Table.add t.cache inp dep_node;
+      add_rev_dep dag_node >>= fun () ->
+      compute t inp ivar dep_node
+    | Some dep_node ->
+      add_rev_dep (dag_node dep_node) >>= fun () ->
+      match dep_node.state with
+      | Running (run, fut) ->
+        if Run.is_current run then
+          Fiber.Ivar.read fut
+        else
+          recompute t inp dep_node
+      | Done cv ->
+        Cached_value.get cv >>= function
+        | Some v -> Fiber.return v
+        | None -> recompute t inp dep_node
+
+  let peek t inp =
+    (* This doesn't add a reverse dependency, which is wrong, see
+       https://github.com/ocaml/dune/issues/1583 for details.  *)
+    match Table.find t.cache inp with
+    | None -> None
+    | Some dep_node ->
+      match dep_node.state with
+      | Running _ -> None
+      | Done cv ->
+        if Run.is_current cv.calculated_at then
+          Some cv.data
+        else
+          None
+
+  let peek_exn t inp = Option.value_exn (peek t inp)
+
+  module Stack_frame = struct
+    let input (Dep_node.T dep_node) : Input.t option =
+      match dep_node.spec.witness with
+      | W -> Some dep_node.input
+      | _ -> None
+
+    let instance_of (Dep_node.T dep_node) ~of_ =
+      dep_node.spec.name = of_.spec.name
+  end
+end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -1,0 +1,47 @@
+open !Stdune
+
+(** A stack frame within a computation. *)
+module Stack_frame : sig
+  type t
+
+  val equal : t -> t -> bool
+  val compare : t -> t -> Ordering.t
+
+  val name : t -> string
+  val input : t -> Sexp.t
+end
+
+module Cycle_error : sig
+  type t
+
+  exception E of t
+
+  (** Get the list of stack frames in this cycle. *)
+  val get : t -> Stack_frame.t list
+
+  (** Return the stack leading to the node which raised the cycle. *)
+  val stack : t -> Stack_frame.t list
+end
+
+(** Restart the system. Cached values with a [Current_run] lifetime
+    are forgotten, pending computations are cancelled. *)
+val reset : unit -> unit
+
+module type S = Memo_intf.S with type stack_frame := Stack_frame.t
+module type Data = Memo_intf.Data
+
+module Make(Input : Data) : S with type input := Input.t
+
+(** Print the memoized call stack during execution. This is useful for debugging purposes.
+    Example code:
+
+    {[
+      some_fiber_computation
+      >>= dump_stack
+      >>= some_more_computation
+    ]}
+*)
+val dump_stack : 'a -> 'a Fiber.t
+
+(** Get the memoized call stack during the execution of a memoized function. *)
+val get_call_stack : Stack_frame.t list Fiber.t

--- a/src/memo/memo_intf.ml
+++ b/src/memo/memo_intf.ml
@@ -1,0 +1,53 @@
+open Stdune
+
+module type Data = sig
+  type t
+  val equal : t -> t -> bool
+  val hash : t -> int
+  val to_sexp : t -> Sexp.t
+end
+
+module type S = sig
+  type input
+
+  (** Type of memoized functions *)
+  type 'a t
+
+  (** [create name ?lifetime ouput_spec f] creates a memoized version
+      of [f]. The result of [f] for a given input is cached, so that
+      the second time [exec t x] is called, the previous result is
+      re-used if possible.
+
+      [exec t x] tracks what calls to other memoized function [f x]
+      performs. When the result of such dependent call changes, [exec t
+      x] will automatically recomputes [f x].
+
+      Running the computation may raise [Memo.Cycle_error.E] if a cycle is
+      detected.  *)
+  val create
+    :  string
+    -> ?allow_cutoff:bool
+    -> (module Data with type t = 'a)
+    -> (input -> 'a Fiber.t)
+    -> 'a t
+
+  (** Execute a memoized function *)
+  val exec : 'a t -> input -> 'a Fiber.t
+
+  (** Check whether we already have a value for the given call *)
+  val peek : 'a t -> input -> 'a option
+  val peek_exn : 'a t -> input -> 'a
+
+  (** After running a memoization function with a given name and
+      input, it is possibly to query which dependencies that function
+      used during execution by calling [get_deps] with the name and
+      input used during execution. *)
+  val get_deps : _ t -> input -> (string * Sexp.t) list option
+
+  type stack_frame
+
+  module Stack_frame : sig
+    val instance_of : stack_frame -> of_:_ t -> bool
+    val input : stack_frame -> input option
+  end
+end

--- a/src/module.mli
+++ b/src/module.mli
@@ -25,7 +25,9 @@ module Name : sig
 
   module Map : Map.S with type key = t
 
-  module Top_closure : Top_closure.S with type key := t
+  module Top_closure : Top_closure.S
+    with type key := t
+     and type 'a monad := 'a Monad.Id.t
 
   module Infix : Comparable.OPS with type t = t
 

--- a/src/static_deps.mli
+++ b/src/static_deps.mli
@@ -1,7 +1,11 @@
 open! Import
 
-(** A simple wrapper around [Deps.t], where some dependencies are recorded as
-    "rule deps" and other as "action deps". *)
+(** A simple wrapper around [Deps.t], where some dependencies are
+    recorded as "rule deps" and other as "action deps". Action
+    Dependencies are dependencies the external commands are expected to
+    access while rule dependencies are dependencies needed in order to
+    compute the action to execute and its dependencies *)
+
 type t
 
 (** {1} Constructors *)
@@ -29,5 +33,5 @@ val rule_deps : t -> Deps.t
 (** Return the action deps. *)
 val action_deps : t -> Deps.t
 
-(** Return the paths deps, both for the rule deps and the action deps . *)
+(** Return the paths deps, both for the rule deps and the action deps. *)
 val paths : t -> Path.Set.t

--- a/src/stdune/bin.mli
+++ b/src/stdune/bin.mli
@@ -1,4 +1,4 @@
-(** OCaml binaries *)
+(** Binaries from the PATH *)
 
 (** Character used to separate entries in [PATH] and similar
     environment variables *)
@@ -7,6 +7,7 @@ val path_sep : char
 (** Parse a [PATH] like variable *)
 val parse_path : ?sep:char -> string -> Path.t list
 
+(** Add an entry to the contents of a [PATH] variable. *)
 val cons_path : Path.t -> _PATH:string option -> string
 
 (** Extension to append to executable filenames *)

--- a/src/stdune/fdecl.ml
+++ b/src/stdune/fdecl.ml
@@ -1,0 +1,17 @@
+type 'a state =
+  | Unset
+  | Set of 'a
+
+type 'a t = { mutable state : 'a state }
+
+let create () = { state = Unset }
+
+let set t x =
+  match t.state with
+  | Unset -> t.state <- Set x
+  | Set _ -> invalid_arg "Fdecl.set: already set"
+
+let get t =
+  match t.state with
+  | Unset -> invalid_arg "Fdecl.get: not set"
+  | Set x -> x

--- a/src/stdune/fdecl.mli
+++ b/src/stdune/fdecl.mli
@@ -1,0 +1,14 @@
+(** Forward declarations *)
+
+type 'a t
+
+(** [create ()] creates a forward declaration. *)
+val create : unit -> 'a t
+
+(** [set t x] set's the value that is returned by [get t] to [x].
+    Raise if [set] was already called *)
+val set : 'a t -> 'a -> unit
+
+(** [get t] returns the [x] if [set comp x] was called.
+    Raise if [set] has not been called yet. *)
+val get : 'a t -> 'a

--- a/src/stdune/id.ml
+++ b/src/stdune/id.ml
@@ -1,0 +1,35 @@
+module type S = sig
+  type t
+
+  module Set : Set.S with type elt = t
+
+  val gen : unit -> t
+  val peek : unit -> t
+  val to_int : t -> int
+  val compare : t -> t -> Ordering.t
+  val equal : t -> t -> bool
+  val hash : t -> int
+  val to_sexp : t -> Sexp.t
+end
+
+module Make () : S = struct
+  module Set = Int.Set
+
+  type t = int
+
+  let next = ref 0
+
+  let gen () =
+    let v = !next in
+    next := v + 1;
+    v
+
+  let peek () = !next
+
+  let to_int x = x
+
+  let compare = Int.compare
+  let equal = Int.equal
+  let hash (t : t) = t
+  let to_sexp = Sexp.Encoder.int
+end

--- a/src/stdune/id.mli
+++ b/src/stdune/id.mli
@@ -1,0 +1,25 @@
+module type S = sig
+  type t
+
+  module Set : Set_intf.S with type elt = t
+
+  (** Generate a new id. *)
+  val gen : unit -> t
+
+  (** Get the next id that would be generated, without actually
+      generating it. *)
+  val peek : unit -> t
+
+  (** Convert the id to an integer. *)
+  val to_int : t -> int
+
+  (** Compare two ids. *)
+  val compare : t -> t -> Ordering.t
+
+  val equal : t -> t -> bool
+  val hash : t -> int
+  val to_sexp : t -> Sexp.t
+end
+
+(** A functor to create a new ID generator module. *)
+module Make () : S

--- a/src/stdune/int.ml
+++ b/src/stdune/int.ml
@@ -15,6 +15,10 @@ include T
 module Set = Set.Make(T)
 module Map = Map.Make(T)
 
+let equal (a : t) b = a = b
+
+let hash (t : t) = t
+
 let of_string_exn s =
   match int_of_string s with
   | exception Failure _ ->

--- a/src/stdune/int.mli
+++ b/src/stdune/int.mli
@@ -1,5 +1,7 @@
 type t = int
 val compare : t -> t -> Ordering.t
+val equal : t -> t -> bool
+val hash : t -> int
 val to_sexp : t -> Sexp.t
 
 module Set : Set.S with type elt = t

--- a/src/stdune/monad.ml
+++ b/src/stdune/monad.ml
@@ -1,0 +1,11 @@
+module type S = sig
+  type 'a t
+  val return : 'a -> 'a t
+  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+end
+
+module Id = struct
+  type 'a t = 'a
+  let return x = x
+  let ( >>= ) x f = f x
+end

--- a/src/stdune/monad.mli
+++ b/src/stdune/monad.mli
@@ -1,0 +1,9 @@
+(** Monad signatures *)
+
+module type S = sig
+  type 'a t
+  val return : 'a -> 'a t
+  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+end
+
+module Id : S with type 'a t = 'a

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -565,6 +565,8 @@ end
 
 include T
 
+let hash (t : t) = Hashtbl.hash t
+
 let build_dir = in_build_dir Local.root
 
 let is_root = function

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -44,6 +44,8 @@ val compare : t -> t -> Ordering.t
 
 val equal : t -> t -> bool
 
+val hash : t -> int
+
 module Set : sig
   include Set.S with type elt = t
   val to_sexp : t Sexp.Encoder.t

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -7,6 +7,7 @@ module Exn        = Exn
 module Filename   = Filename
 module Hashtbl    = Hashtbl
 module Int        = Int
+module Id         = Id
 module Io         = Io
 module List       = List
 module Map        = Map
@@ -33,6 +34,9 @@ module Type_eq    = Type_eq
 module Nothing    = Nothing
 module Bin        = Bin
 module Digest     = Digest
+module Fdecl      = Fdecl
+module Unit       = Unit
+module Monad      = Monad
 
 external reraise : exn -> _ = "%reraise"
 

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -21,6 +21,10 @@ module T = struct
   let hash (s : t) = Hashtbl.hash s
 end
 
+let equal : string -> string -> bool = (=)
+let hash = Hashtbl.hash
+let to_sexp = Sexp.Encoder.string
+
 let capitalize   = capitalize_ascii
 let uncapitalize = uncapitalize_ascii
 let uppercase    = uppercase_ascii

--- a/src/stdune/string.mli
+++ b/src/stdune/string.mli
@@ -3,6 +3,8 @@ include module type of struct include StringLabels end with type t := t
 
 val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
+val hash : t -> int
+val to_sexp : t -> Sexp.t
 
 val break : t -> pos:int -> t * t
 

--- a/src/stdune/unit.ml
+++ b/src/stdune/unit.ml
@@ -1,0 +1,5 @@
+type t = unit
+let equal () () = true
+let compare () () = Ordering.Eq
+let hash () = 0
+let to_sexp () = Sexp.List []

--- a/src/stdune/unit.mli
+++ b/src/stdune/unit.mli
@@ -1,0 +1,5 @@
+type t = unit
+val equal : t -> t -> bool
+val compare : t -> t -> Ordering.t
+val hash : t -> int
+val to_sexp : t -> Sexp.t

--- a/src/top_closure.mli
+++ b/src/top_closure.mli
@@ -10,16 +10,20 @@ end
 
 module type S = sig
   type key
+  type 'a monad
 
   (** Returns [Error cycle] in case the graph is not a DAG *)
   val top_closure
     :  key:('a -> key)
-    -> deps:('a -> 'a list)
+    -> deps:('a -> 'a list monad)
     -> 'a list
-    -> ('a list, 'a list) result
+    -> ('a list, 'a list) result monad
 end
 
-module Int    : S with type key := int
-module String : S with type key := string
+module Int    : S with type key := int and type 'a monad := 'a Monad.Id.t
+module String : S with type key := string and type 'a monad := 'a Monad.Id.t
 
-module Make(Keys : Keys) : S with type key := Keys.elt
+module Make(Keys : Keys)(Monad : Monad.S) : S
+  with type key := Keys.elt
+   and type 'a monad := 'a Monad.t
+[@@inlined always]

--- a/test/blackbox-tests/test-cases/all-alias/run.t
+++ b/test/blackbox-tests/test-cases/all-alias/run.t
@@ -14,10 +14,10 @@
   Entering directory 'private-lib'
       ocamldep .bar.objs/bar.ml.d
         ocamlc .bar.objs/bar.{cmi,cmo,cmt}
+        ocamlc bar.cma
       ocamlopt .bar.objs/bar.{cmx,o}
       ocamlopt bar.{a,cmxa}
       ocamlopt bar.cmxs
-        ocamlc bar.cma
 
 @all builds custom install stanzas
 

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -10,9 +10,9 @@
         ocamlc bar$ext_obj
     ocamlmklib dllfoo_stubs$ext_dll,libfoo_stubs$ext_lib
         ocamlc .test.eobjs/lexer1.{cmi,cmo,cmt}
-      ocamlopt .test.eobjs/lexer1.{cmx,o}
         ocamlc .test.eobjs/test.{cmi,cmo,cmt}
       ocamlopt .test.eobjs/test.{cmx,o}
+      ocamlopt .test.eobjs/lexer1.{cmx,o}
       ocamlopt test.exe
   $ dune build --root test1 @bar-source --display short
   Entering directory 'test1'

--- a/test/blackbox-tests/test-cases/cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation/run.t
@@ -2,23 +2,23 @@
       ocamldep bin/.blah.eobjs/blah.ml.d [default.foo]
       ocamldep lib/.p.objs/p.ml.d [default.foo]
         ocamlc lib/.p.objs/p.{cmi,cmo,cmt} [default.foo]
-      ocamlopt lib/.p.objs/p.{cmx,o} [default.foo]
-      ocamlopt lib/p.{a,cmxa} [default.foo]
-      ocamlopt lib/p.cmxs [default.foo]
+        ocamlc lib/p.cma [default.foo]
       ocamldep bin/.blah.eobjs/blah.ml.d
       ocamldep lib/.p.objs/p.ml.d
         ocamlc lib/.p.objs/p.{cmi,cmo,cmt}
       ocamlopt lib/.p.objs/p.{cmx,o}
       ocamlopt lib/p.{a,cmxa}
-        ocamlc lib/p.cma [default.foo]
-        ocamlc bin/.blah.eobjs/blah.{cmi,cmo,cmt} [default.foo]
-      ocamlopt bin/.blah.eobjs/blah.{cmx,o} [default.foo]
-      ocamlopt bin/blah.exe [default.foo]
         ocamlc bin/.blah.eobjs/blah.{cmi,cmo,cmt}
       ocamlopt bin/.blah.eobjs/blah.{cmx,o}
       ocamlopt bin/blah.exe
-          blah file [default.foo]
           blah file
+      ocamlopt lib/.p.objs/p.{cmx,o} [default.foo]
+      ocamlopt lib/p.{a,cmxa} [default.foo]
+      ocamlopt lib/p.cmxs [default.foo]
+          blah file [default.foo]
+        ocamlc bin/.blah.eobjs/blah.{cmi,cmo,cmt} [default.foo]
+      ocamlopt bin/.blah.eobjs/blah.{cmx,o} [default.foo]
+      ocamlopt bin/blah.exe [default.foo]
   $ cat _build/default.foo/file
   42
   $ ls *.install

--- a/test/blackbox-tests/test-cases/default-targets/run.t
+++ b/test/blackbox-tests/test-cases/default-targets/run.t
@@ -9,9 +9,9 @@ Generates targets when modes is set for binaries:
 Generate targets when modes are set for libraries
 
   $ dune build --root libs --display short @all 2>&1 | grep 'cma\|cmxa\|cmxs'
-      ocamlopt byteandnative.{a,cmxa}
-      ocamlopt byteandnative.cmxs
+        ocamlc byteandnative.cma
         ocamlc byteonly.cma
       ocamlopt nativeonly.{a,cmxa}
       ocamlopt nativeonly.cmxs
-        ocamlc byteandnative.cma
+      ocamlopt byteandnative.{a,cmxa}
+      ocamlopt byteandnative.cmxs

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -149,18 +149,18 @@ Test using installed drivers
   $ dune build --display short --root jbuild-driver @all
   Entering directory 'jbuild-driver'
         ocamlc .testdriver.objs/testdriver.{cmi,cmo,cmt}
+        ocamlc testdriver.cma
       ocamlopt .testdriver.objs/testdriver.{cmx,o}
       ocamlopt testdriver.{a,cmxa}
+      ocamlopt testdriver.cmxs
       ocamlopt .ppx/jbuild/631757a4a4789e0bd29628f7a73480f7/ppx.exe
            ppx test_ppx_args.pp.ml
       ocamldep .test_ppx_args.objs/test_ppx_args.pp.ml.d
         ocamlc .test_ppx_args.objs/test_ppx_args.{cmi,cmo,cmt}
+        ocamlc test_ppx_args.cma
       ocamlopt .test_ppx_args.objs/test_ppx_args.{cmx,o}
       ocamlopt test_ppx_args.{a,cmxa}
       ocamlopt test_ppx_args.cmxs
-        ocamlc testdriver.cma
-      ocamlopt testdriver.cmxs
-        ocamlc test_ppx_args.cma
 
   $ dune build --display short --root jbuild-driver @install
   Entering directory 'jbuild-driver'

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -5,30 +5,30 @@ Formatting can be checked using the @fmt target:
   $ dune build --display short @fmt
       ocamldep fake-tools/.ocamlformat.eobjs/ocamlformat.ml.d
       ocamldep fake-tools/.ocamlformat.eobjs/refmt.ml.d
-        ocamlc fake-tools/.ocamlformat.eobjs/refmt.{cmi,cmo,cmt}
-      ocamlopt fake-tools/.ocamlformat.eobjs/refmt.{cmx,o}
-      ocamlopt fake-tools/refmt.exe
-         refmt enabled/.formatted/reason_file.re
-  File "enabled/reason_file.re", line 1, characters 0-0:
-  Files _build/default/enabled/reason_file.re and _build/default/enabled/.formatted/reason_file.re differ.
         ocamlc fake-tools/.ocamlformat.eobjs/ocamlformat.{cmi,cmo,cmt}
       ocamlopt fake-tools/.ocamlformat.eobjs/ocamlformat.{cmx,o}
       ocamlopt fake-tools/ocamlformat.exe
-   ocamlformat enabled/.formatted/ocaml_file.mli
-  File "enabled/ocaml_file.mli", line 1, characters 0-0:
-  Files _build/default/enabled/ocaml_file.mli and _build/default/enabled/.formatted/ocaml_file.mli differ.
-         refmt enabled/.formatted/reason_file.rei
-  File "enabled/reason_file.rei", line 1, characters 0-0:
-  Files _build/default/enabled/reason_file.rei and _build/default/enabled/.formatted/reason_file.rei differ.
    ocamlformat enabled/.formatted/ocaml_file.ml
   File "enabled/ocaml_file.ml", line 1, characters 0-0:
   Files _build/default/enabled/ocaml_file.ml and _build/default/enabled/.formatted/ocaml_file.ml differ.
+        ocamlc fake-tools/.ocamlformat.eobjs/refmt.{cmi,cmo,cmt}
+      ocamlopt fake-tools/.ocamlformat.eobjs/refmt.{cmx,o}
+      ocamlopt fake-tools/refmt.exe
+         refmt enabled/.formatted/reason_file.rei
+  File "enabled/reason_file.rei", line 1, characters 0-0:
+  Files _build/default/enabled/reason_file.rei and _build/default/enabled/.formatted/reason_file.rei differ.
    ocamlformat enabled/subdir/.formatted/lib.ml
   File "enabled/subdir/lib.ml", line 1, characters 0-0:
   Files _build/default/enabled/subdir/lib.ml and _build/default/enabled/subdir/.formatted/lib.ml differ.
    ocamlformat partial/.formatted/a.ml
   File "partial/a.ml", line 1, characters 0-0:
   Files _build/default/partial/a.ml and _build/default/partial/.formatted/a.ml differ.
+   ocamlformat enabled/.formatted/ocaml_file.mli
+  File "enabled/ocaml_file.mli", line 1, characters 0-0:
+  Files _build/default/enabled/ocaml_file.mli and _build/default/enabled/.formatted/ocaml_file.mli differ.
+         refmt enabled/.formatted/reason_file.re
+  File "enabled/reason_file.re", line 1, characters 0-0:
+  Files _build/default/enabled/reason_file.re and _build/default/enabled/.formatted/reason_file.re differ.
   [1]
 
 Configuration files are taken into account for this action:

--- a/test/blackbox-tests/test-cases/github25/run.t
+++ b/test/blackbox-tests/test-cases/github25/run.t
@@ -8,10 +8,10 @@ We need ocamlfind to run this test
 
   $ dune build @install --display short --only hello
         ocamlc root/.hello.objs/hello.{cmi,cmo,cmt}
+        ocamlc root/hello.cma
       ocamlopt root/.hello.objs/hello.{cmx,o}
       ocamlopt root/hello.{a,cmxa}
       ocamlopt root/hello.cmxs
-        ocamlc root/hello.cma
 
   $ dune build @install --display short --only pas-de-bol 2>&1 | sed 's/[^ "]*findlib-packages/.../'
       ocamldep root/.pas_de_bol.objs/a.ml.d

--- a/test/blackbox-tests/test-cases/installable-dup-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/installable-dup-private-libs/run.t
@@ -1,13 +1,13 @@
   $ dune build @install --display short
       ocamldep a1/.a.objs/a.ml.d
         ocamlc a1/.a.objs/a.{cmi,cmo,cmt}
+        ocamlc a1/a.cma
+      ocamldep a2/.a.objs/a.ml.d
+        ocamlc a2/.a.objs/a.{cmi,cmo,cmt}
+        ocamlc a2/a.cma
       ocamlopt a1/.a.objs/a.{cmx,o}
       ocamlopt a1/a.{a,cmxa}
       ocamlopt a1/a.cmxs
-      ocamldep a2/.a.objs/a.ml.d
-        ocamlc a2/.a.objs/a.{cmi,cmo,cmt}
       ocamlopt a2/.a.objs/a.{cmx,o}
       ocamlopt a2/a.{a,cmxa}
       ocamlopt a2/a.cmxs
-        ocamlc a1/a.cma
-        ocamlc a2/a.cma

--- a/test/blackbox-tests/test-cases/intf-only/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/run.t
@@ -9,15 +9,15 @@ Successes:
       ocamldep .foo.objs/intf.mli.d
         ocamlc .foo.objs/foo__Intf.{cmi,cmti}
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
-        ocamlc test/.bar.objs/bar.{cmi,cmo,cmt}
-      ocamlopt test/.bar.objs/bar.{cmx,o}
-      ocamlopt test/bar.{a,cmxa}
-      ocamlopt test/bar.cmxs
+        ocamlc foo.cma
       ocamlopt .foo.objs/foo.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs
-        ocamlc foo.cma
+        ocamlc test/.bar.objs/bar.{cmi,cmo,cmt}
         ocamlc test/bar.cma
+      ocamlopt test/.bar.objs/bar.{cmx,o}
+      ocamlopt test/bar.{a,cmxa}
+      ocamlopt test/bar.cmxs
 
 Errors:
 

--- a/test/blackbox-tests/test-cases/js_of_ocaml/run.t
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/run.t
@@ -2,30 +2,30 @@
         ocamlc lib/stubs$ext_obj
     ocamlmklib lib/dllx_stubs$ext_dll,lib/libx_stubs$ext_lib
       ocamlopt .ppx/3edf09989a28fce237f8b735bd39446a/ppx.exe
-           ppx lib/x.pp.ml
-      ocamldep lib/.x.objs/x.pp.ml.d
-        ocamlc lib/.x.objs/x__.{cmi,cmo,cmt}
-      ocamlopt lib/.x.objs/x__.{cmx,o}
            ppx lib/y.pp.ml
       ocamldep lib/.x.objs/y.pp.ml.d
+        ocamlc lib/.x.objs/x__.{cmi,cmo,cmt}
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
            ppx bin/technologic.pp.ml
       ocamldep bin/.technologic.eobjs/technologic.pp.ml.d
            ppx bin/z.pp.ml
       ocamldep bin/.technologic.eobjs/z.pp.ml.d
-   js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
-        ocamlc lib/.x.objs/x.{cmi,cmo,cmt}
-      ocamlopt lib/.x.objs/x.{cmx,o}
-      ocamlopt lib/x.{a,cmxa}
-      ocamlopt lib/x.cmxs
-   js_of_ocaml .js/stdlib/stdlib.cma.js
    js_of_ocaml bin/technologic.bc.runtime.js
+   js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
+           ppx lib/x.pp.ml
+      ocamldep lib/.x.objs/x.pp.ml.d
+        ocamlc lib/.x.objs/x.{cmi,cmo,cmt}
         ocamlc lib/x.cma
    js_of_ocaml lib/.x.objs/x.cma.js
+      ocamlopt lib/.x.objs/x__.{cmx,o}
+   js_of_ocaml .js/stdlib/stdlib.cma.js
         ocamlc bin/.technologic.eobjs/z.{cmi,cmo,cmt}
         ocamlc bin/.technologic.eobjs/technologic.{cmi,cmo,cmt}
    js_of_ocaml bin/.technologic.eobjs/technologic.cmo.js
+      ocamlopt lib/.x.objs/x.{cmx,o}
+      ocamlopt lib/x.{a,cmxa}
+      ocamlopt lib/x.cmxs
    js_of_ocaml bin/.technologic.eobjs/z.cmo.js
      jsoo_link bin/technologic.bc.js
   $ $NODE ./_build/default/bin/technologic.bc.js
@@ -38,15 +38,15 @@
         ocamlc lib/.x.objs/x__Y.{cmi,cmo,cmt}
         ocamlc lib/.x.objs/x.{cmi,cmo,cmt}
         ocamlc lib/x.cma
+        ocamlc bin/.technologic.eobjs/z.{cmi,cmo,cmt}
+        ocamlc bin/.technologic.eobjs/technologic.{cmi,cmo,cmt}
+        ocamlc bin/technologic.bc
+   js_of_ocaml bin/technologic.bc.js
       ocamlopt lib/.x.objs/x__.{cmx,o}
       ocamlopt lib/.x.objs/x__Y.{cmx,o}
       ocamlopt lib/.x.objs/x.{cmx,o}
       ocamlopt lib/x.{a,cmxa}
       ocamlopt lib/x.cmxs
-        ocamlc bin/.technologic.eobjs/z.{cmi,cmo,cmt}
-        ocamlc bin/.technologic.eobjs/technologic.{cmi,cmo,cmt}
-        ocamlc bin/technologic.bc
-   js_of_ocaml bin/technologic.bc.js
   $ $NODE ./_build/default/bin/technologic.bc.js
   buy it
   use it

--- a/test/blackbox-tests/test-cases/loop/run.t
+++ b/test/blackbox-tests/test-cases/loop/run.t
@@ -23,6 +23,7 @@ does show a cycle.
       _build/default/result2
   --> _build/default/input
   --> _build/default/result2
+  -> required by result2
   -> required by input
   -> required by result1
   [1]

--- a/test/blackbox-tests/test-cases/menhir/run.t
+++ b/test/blackbox-tests/test-cases/menhir/run.t
@@ -6,21 +6,21 @@
       ocamldep src/.test.eobjs/lexer2.ml.d
       ocamldep src/.test.eobjs/test.ml.d
         menhir src/test_base.{ml,mli}
-      ocamldep src/.test.eobjs/test_base.ml.d
-        menhir src/test_menhir1.{ml,mli}
-      ocamldep src/.test.eobjs/test_menhir1.ml.d
       ocamldep src/.test.eobjs/test_base.mli.d
+        menhir src/test_menhir1.{ml,mli}
       ocamldep src/.test.eobjs/test_menhir1.mli.d
+      ocamldep src/.test.eobjs/test_base.ml.d
+      ocamldep src/.test.eobjs/test_menhir1.ml.d
         ocamlc src/.test.eobjs/test_menhir1.{cmi,cmti}
+      ocamlopt src/.test.eobjs/test_menhir1.{cmx,o}
+        ocamlc src/.test.eobjs/test_base.{cmi,cmti}
+      ocamlopt src/.test.eobjs/test_base.{cmx,o}
         ocamlc src/.test.eobjs/lexer1.{cmi,cmo,cmt}
       ocamlopt src/.test.eobjs/lexer1.{cmx,o}
-        ocamlc src/.test.eobjs/test_base.{cmi,cmti}
         ocamlc src/.test.eobjs/lexer2.{cmi,cmo,cmt}
-      ocamlopt src/.test.eobjs/lexer2.{cmx,o}
-      ocamlopt src/.test.eobjs/test_menhir1.{cmx,o}
-      ocamlopt src/.test.eobjs/test_base.{cmx,o}
         ocamlc src/.test.eobjs/test.{cmi,cmo,cmt}
       ocamlopt src/.test.eobjs/test.{cmx,o}
+      ocamlopt src/.test.eobjs/lexer2.{cmx,o}
       ocamlopt src/test.exe
 
   $ dune build --root cmly test.exe --display short --debug-dependency-path
@@ -29,14 +29,14 @@
       ocamldep .test.eobjs/lexer1.ml.d
       ocamldep .test.eobjs/test.ml.d
         menhir test_menhir1.{cmly,ml,mli}
-      ocamldep .test.eobjs/test_menhir1.ml.d
       ocamldep .test.eobjs/test_menhir1.mli.d
+      ocamldep .test.eobjs/test_menhir1.ml.d
         ocamlc .test.eobjs/test_menhir1.{cmi,cmti}
-        ocamlc .test.eobjs/lexer1.{cmi,cmo,cmt}
-      ocamlopt .test.eobjs/lexer1.{cmx,o}
       ocamlopt .test.eobjs/test_menhir1.{cmx,o}
+        ocamlc .test.eobjs/lexer1.{cmi,cmo,cmt}
         ocamlc .test.eobjs/test.{cmi,cmo,cmt}
       ocamlopt .test.eobjs/test.{cmx,o}
+      ocamlopt .test.eobjs/lexer1.{cmx,o}
       ocamlopt test.exe
 
   $ dune build --root general-2.0 src/test.exe --display short --debug-dependency-path
@@ -50,22 +50,22 @@
       ocamldep src/.test.eobjs/test_base__mock.ml.mock.d
         ocamlc src/test_base__mock.mli.inferred
         menhir src/test_base.{ml,mli}
-      ocamldep src/.test.eobjs/test_base.ml.d
+      ocamldep src/.test.eobjs/test_base.mli.d
         menhir src/test_menhir1__mock.ml.mock
       ocamldep src/.test.eobjs/test_menhir1__mock.ml.mock.d
         ocamlc src/test_menhir1__mock.mli.inferred
         menhir src/test_menhir1.{ml,mli}
-      ocamldep src/.test.eobjs/test_menhir1.ml.d
-      ocamldep src/.test.eobjs/test_base.mli.d
       ocamldep src/.test.eobjs/test_menhir1.mli.d
+      ocamldep src/.test.eobjs/test_base.ml.d
+      ocamldep src/.test.eobjs/test_menhir1.ml.d
         ocamlc src/.test.eobjs/test_menhir1.{cmi,cmti}
+      ocamlopt src/.test.eobjs/test_menhir1.{cmx,o}
+        ocamlc src/.test.eobjs/test_base.{cmi,cmti}
+      ocamlopt src/.test.eobjs/test_base.{cmx,o}
         ocamlc src/.test.eobjs/lexer1.{cmi,cmo,cmt}
       ocamlopt src/.test.eobjs/lexer1.{cmx,o}
-        ocamlc src/.test.eobjs/test_base.{cmi,cmti}
         ocamlc src/.test.eobjs/lexer2.{cmi,cmo,cmt}
-      ocamlopt src/.test.eobjs/lexer2.{cmx,o}
-      ocamlopt src/.test.eobjs/test_menhir1.{cmx,o}
-      ocamlopt src/.test.eobjs/test_base.{cmx,o}
         ocamlc src/.test.eobjs/test.{cmi,cmo,cmt}
       ocamlopt src/.test.eobjs/test.{cmx,o}
+      ocamlopt src/.test.eobjs/lexer2.{cmx,o}
       ocamlopt src/test.exe

--- a/test/blackbox-tests/test-cases/multi-dir/run.t
+++ b/test/blackbox-tests/test-cases/multi-dir/run.t
@@ -62,8 +62,8 @@ Test for (include_subdir unqualified) with (preprocess (action ...))
           main sub/foo.pp.ml
       ocamldep .foo.objs/foo.pp.ml.d
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
+        ocamlc foo.cma
+        ocamlc main.bc
       ocamlopt .foo.objs/foo.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs
-        ocamlc main.bc
-        ocamlc foo.cma

--- a/test/blackbox-tests/test-cases/odoc-unique-mlds/run.t
+++ b/test/blackbox-tests/test-cases/odoc-unique-mlds/run.t
@@ -6,10 +6,10 @@ Duplicate mld's in the same scope
           odoc _doc/_odoc/lib/root.lib1/root_lib1.odoc
         ocamlc lib2/.root_lib2.objs/root_lib2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/root.lib2/root_lib2.odoc
-          odoc _doc/_html/root/Root_lib1/.dune-keep,_doc/_html/root/Root_lib1/index.html
+          odoc _doc/_html/root/Root_lib2/.dune-keep,_doc/_html/root/Root_lib2/index.html
           odoc _doc/_odoc/pkg/root/page-index.odoc
           odoc _doc/_html/root/index.html
-          odoc _doc/_html/root/Root_lib2/.dune-keep,_doc/_html/root/Root_lib2/index.html
+          odoc _doc/_html/root/Root_lib1/.dune-keep,_doc/_html/root/Root_lib1/index.html
 
 Duplicate mld's in different scope
   $ rm -rf diff-scope/_build

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -15,11 +15,11 @@
       ocamldep .foo.objs/foo2.ml.d
         ocamlc .foo.objs/foo2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo2.odoc
-          odoc _doc/_html/foo/Foo/.dune-keep,_doc/_html/foo/Foo/index.html
+          odoc _doc/_html/foo/Foo2/.dune-keep,_doc/_html/foo/Foo2/index.html
           odoc _doc/_odoc/pkg/foo/page-index.odoc
           odoc _doc/_html/foo/index.html
           odoc _doc/_html/foo/Foo_byte/.dune-keep,_doc/_html/foo/Foo_byte/index.html
-          odoc _doc/_html/foo/Foo2/.dune-keep,_doc/_html/foo/Foo2/index.html
+          odoc _doc/_html/foo/Foo/.dune-keep,_doc/_html/foo/Foo/index.html
   $ dune runtest --display short
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">

--- a/test/blackbox-tests/test-cases/package-dep/run.t
+++ b/test/blackbox-tests/test-cases/package-dep/run.t
@@ -3,10 +3,10 @@
       ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/foo.{cmi,cmo,cmt}
         ocamlc .bar.objs/bar.{cmi,cmo,cmt}
+        ocamlc bar.cma
       ocamlopt .bar.objs/bar.{cmx,o}
       ocamlopt bar.{a,cmxa}
       ocamlopt bar.cmxs
-        ocamlc bar.cma
       ocamlopt .foo.objs/foo.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -20,10 +20,10 @@ On the other hand, public libraries may have private preprocessors
            ppx mylib.pp.ml
       ocamldep .mylib.objs/mylib.pp.ml.d
         ocamlc .mylib.objs/mylib.{cmi,cmo,cmt}
+        ocamlc mylib.cma
       ocamlopt .mylib.objs/mylib.{cmx,o}
       ocamlopt mylib.{a,cmxa}
       ocamlopt mylib.cmxs
-        ocamlc mylib.cma
 
 Unless they introduce private runtime dependencies:
   $ dune build --display short --root private-runtime-deps

--- a/test/blackbox-tests/test-cases/reporting-of-cycles/dune
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles/dune
@@ -18,3 +18,15 @@
 (rule (copy x3 x4))
 
 (rule (with-stdout-to x3-x2-dyn-dep (system "printf x2")))
+
+(alias
+  (name complex-repro-case)
+  (deps cd1 cd3))
+
+(rule (copy cd2 cd1))
+(rule (copy cd4 cd3))
+(rule (copy %{read:dcd3} cd2))
+(rule (copy %{read:dcd1} cd4))
+
+(rule (with-stdout-to dcd3 (system "printf cd3")))
+(rule (with-stdout-to dcd1 (system "printf cd1")))

--- a/test/blackbox-tests/test-cases/reporting-of-cycles/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles/run.t
@@ -24,3 +24,12 @@ the second run of dune.
   --> _build/default/x3
   --> _build/default/x2
   [1]
+
+  $ dune build @complex-repro-case
+  Dependency cycle between the following files:
+      _build/default/cd1
+  --> _build/default/cd4
+  --> _build/default/cd3
+  --> _build/default/cd2
+  --> _build/default/cd1
+  [1]

--- a/test/blackbox-tests/test-cases/scope-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-bug/run.t
@@ -4,21 +4,21 @@
       ocamldep blib/.blib.objs/blib.ml.d
       ocamldep blib/sub/.sub.objs/sub.ml.d
         ocamlc blib/sub/.sub.objs/sub.{cmi,cmo,cmt}
-        ocamlc blib/.blib.objs/blib.{cmi,cmo,cmt}
-      ocamlopt blib/.blib.objs/blib.{cmx,o}
-      ocamlopt blib/blib.{a,cmxa}
-      ocamlopt blib/blib.cmxs
+        ocamlc blib/sub/sub.cma
         ocamlc alib/.alib.objs/alib__.{cmi,cmo,cmt}
       ocamlopt alib/.alib.objs/alib__.{cmx,o}
       ocamlopt blib/sub/.sub.objs/sub.{cmx,o}
       ocamlopt blib/sub/sub.{a,cmxa}
       ocamlopt blib/sub/sub.cmxs
-        ocamlc blib/sub/sub.cma
+        ocamlc blib/.blib.objs/blib.{cmi,cmo,cmt}
         ocamlc blib/blib.cma
+      ocamlopt blib/.blib.objs/blib.{cmx,o}
+      ocamlopt blib/blib.{a,cmxa}
+      ocamlopt blib/blib.cmxs
         ocamlc alib/.alib.objs/alib.{cmi,cmo,cmt}
       ocamlopt alib/.alib.objs/alib.{cmx,o}
         ocamlc alib/.alib.objs/alib__Main.{cmi,cmo,cmt}
+        ocamlc alib/alib.cma
       ocamlopt alib/.alib.objs/alib__Main.{cmx,o}
       ocamlopt alib/alib.{a,cmxa}
       ocamlopt alib/alib.cmxs
-        ocamlc alib/alib.cma

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -1,21 +1,21 @@
   $ dune build --display short @install --debug-dep
         ocamlc a/ppx/.a.objs/a.{cmi,cmo,cmt}
+        ocamlc a/ppx/a.cma
+        ocamlc a/kernel/.a_kernel.objs/a_kernel.{cmi,cmo,cmt}
+        ocamlc a/kernel/a_kernel.cma
       ocamlopt a/ppx/.a.objs/a.{cmx,o}
       ocamlopt a/ppx/a.{a,cmxa}
       ocamlopt a/ppx/a.cmxs
-        ocamlc a/kernel/.a_kernel.objs/a_kernel.{cmi,cmo,cmt}
       ocamlopt a/kernel/.a_kernel.objs/a_kernel.{cmx,o}
       ocamlopt a/kernel/a_kernel.{a,cmxa}
-      ocamlopt a/kernel/a_kernel.cmxs
-        ocamlc a/ppx/a.cma
-        ocamlc a/kernel/a_kernel.cma
       ocamlopt .ppx/jbuild/a.kernel/ppx.exe
       ocamlopt .ppx/jbuild/a/ppx.exe
       ocamlopt .ppx/jbuild/631b31a68eb10e1850cf7721d41e5b84/ppx.exe
            ppx b/b.pp.ml
       ocamldep b/.b.objs/b.pp.ml.d
         ocamlc b/.b.objs/b.{cmi,cmo,cmt}
+        ocamlc b/b.cma
+      ocamlopt a/kernel/a_kernel.cmxs
       ocamlopt b/.b.objs/b.{cmx,o}
       ocamlopt b/b.{a,cmxa}
       ocamlopt b/b.cmxs
-        ocamlc b/b.cma

--- a/test/blackbox-tests/test-cases/select/run.t
+++ b/test/blackbox-tests/test-cases/select/run.t
@@ -9,9 +9,9 @@
         ocamlc .main.eobjs/bar.{cmi,cmo,cmt}
       ocamlopt .main.eobjs/bar.{cmx,o}
         ocamlc .main.eobjs/foo.{cmi,cmo,cmt}
-      ocamlopt .main.eobjs/foo.{cmx,o}
         ocamlc .main.eobjs/main.{cmi,cmo,cmt}
       ocamlopt .main.eobjs/main.{cmx,o}
+      ocamlopt .main.eobjs/foo.{cmx,o}
       ocamlopt main.exe
           main alias runtest
   bar has unix

--- a/test/blackbox-tests/test-cases/tests-stanza/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/run.t
@@ -12,10 +12,6 @@
       ocamldep .expect_test.eobjs/expect_test.ml.d
       ocamldep .expect_test.eobjs/regular_test.ml.d
       ocamldep .expect_test.eobjs/regular_test2.ml.d
-        ocamlc .expect_test.eobjs/expect_test.{cmi,cmo,cmt}
-      ocamlopt .expect_test.eobjs/expect_test.{cmx,o}
-      ocamlopt expect_test.exe
-   expect_test expect_test.output
         ocamlc .expect_test.eobjs/regular_test2.{cmi,cmo,cmt}
       ocamlopt .expect_test.eobjs/regular_test2.{cmx,o}
       ocamlopt regular_test2.exe
@@ -26,6 +22,10 @@
       ocamlopt regular_test.exe
   regular_test alias runtest
   regular test
+        ocamlc .expect_test.eobjs/expect_test.{cmi,cmo,cmt}
+      ocamlopt .expect_test.eobjs/expect_test.{cmx,o}
+      ocamlopt expect_test.exe
+   expect_test expect_test.output
   $ dune runtest --root generated --display short
   Entering directory 'generated'
       ocamldep .generated.eobjs/generated.ml.d

--- a/test/unit-tests/dag.mlt
+++ b/test/unit-tests/dag.mlt
@@ -1,0 +1,114 @@
+(* -*- tuareg -*- *)
+
+open Stdune;;
+
+type mynode = {
+  name : string;
+}
+
+module Dag = struct
+  include Dag.Make(struct
+      type t = mynode
+    end)
+
+  let node dag data =
+    { info = create_node_info dag; data }
+end
+[%%expect{|
+type mynode = { name : string; }
+module Dag :
+  sig
+    type t
+    type node_info
+    type node = { data : mynode; info : node_info; }
+    exception Cycle of node list
+    val create : unit -> t
+    val create_node_info : t -> node_info
+    val add : t -> node -> node -> unit
+    val children : node -> node list
+    val pp_node : mynode Fmt.t -> node Fmt.t
+    val delta : t -> int
+    val is_child : node -> node -> bool
+    val node : t -> mynode -> node
+  end
+|}]
+
+open Dag
+
+let dag = Dag.create ();;
+
+let node = Dag.node dag { name = "root" };;
+let node11 = Dag.node dag { name = "child 1 1" };;
+let node12 = Dag.node dag { name = "child 1 2" };;
+let node21 = Dag.node dag { name = "child 2 1" };;
+let node31 = Dag.node dag { name = "child 3 1" };;
+
+Dag.add dag node node11;;
+Dag.add dag node node12;;
+Dag.add dag node12 node21;;
+Dag.add dag node21 node31;;
+
+let pp_mynode fmt n =
+  Format.fprintf fmt "%s" n.name;;
+let dag_pp_mynode = (Dag.pp_node pp_mynode);;
+
+#install_printer dag_pp_mynode;;
+
+node;;
+
+let node41 = Dag.node dag { name = "child 4 1" };;
+
+Dag.add dag node31 node41;;
+
+node;;
+Dag.delta dag;;
+
+let name node = node.data.name in
+try
+  Dag.add dag node41 node;
+  None
+with
+  | Dag.Cycle cycle ->
+    let cycle = List.map cycle ~f:name in
+    Some cycle;;
+node;;
+
+(* node;; *)
+
+[%%expect{|
+val dag : t = <abstr>
+val node : node = {data = {name = "root"}; info = <abstr>}
+val node11 : node = {data = {name = "child 1 1"}; info = <abstr>}
+val node12 : node = {data = {name = "child 1 2"}; info = <abstr>}
+val node21 : node = {data = {name = "child 2 1"}; info = <abstr>}
+val node31 : node = {data = {name = "child 3 1"}; info = <abstr>}
+- : unit = ()
+- : unit = ()
+- : unit = ()
+- : unit = ()
+val pp_mynode : Format.formatter -> mynode -> unit = <fun>
+val dag_pp_mynode : node Fmt.t = <fun>
+- : node =
+(1: k=1, i=-6) (root) [(3: k=1, i=-3) (child 1 2) [(4: k=2, i=-9) (child 2 1) [
+                                                   (5: k=2, i=-8) (child 3 1) [
+                                                   ]]];
+                        (2: k=1, i=-2) (child 1 1) []]
+val node41 : node = (6: k=1, i=-10) (child 4 1) []
+- : unit = ()
+- : node =
+(1: k=1, i=-6) (root) [(3: k=1, i=-3) (child 1 2) [(4: k=2, i=-13) (child 2 1) [
+                                                   (5: k=2, i=-12) (child 3 1) [
+                                                   (6: k=2, i=-11) (child 4 1) [
+                                                   ]]]];
+                        (2: k=1, i=-2) (child 1 1) []]
+- : int = 2
+- : string list option =
+Some
+ ["child 4 1"; "child 3 1"; "child 2 1"; "child 1 2"; "root"; "child 4 1"]
+- : node =
+(1: k=3, i=-6) (root) [(3: k=3, i=-3) (child 1 2) [(4: k=3, i=-13) (child 2 1) [
+                                                   (5: k=3, i=-12) (child 3 1) [
+                                                   (6: k=2, i=-11) (child 4 1) [
+                                                   ]]]];
+                        (2: k=1, i=-2) (child 1 1) []]
+|}]

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -3,7 +3,7 @@
  (modules expect_test)
  (link_flags (-linkall))
  (modes byte)
- (libraries which_program_dune unix dune compiler-libs.toplevel test_common))
+ (libraries which_program_dune unix dune compiler-libs.toplevel test_common dag))
 
 (ocamllex expect_test)
 
@@ -56,12 +56,12 @@
   (glob_files %{project_root}/src/stdune/.stdune.objs/*.cmi))
  (action (chdir %{project_root}
           (progn
-           (run %{exe:expect_test.exe} %{t})
+           (run %{exe:expect_test.exe} %{t}) 
            (diff? %{t} %{t}.corrected)))))
 
 (alias
  (name runtest)
- (deps (:t action.mlt)
+ (deps (:t action.mlt) 
   (glob_files %{project_root}/src/.dune.objs/*.cmi)
   (glob_files %{project_root}/src/stdune/.stdune.objs/*.cmi))
  (action (chdir %{project_root}
@@ -118,3 +118,32 @@
           (progn
            (run %{exe:expect_test.exe} %{t})
            (diff? %{t} %{t}.corrected)))))
+
+(alias
+ (name runtestmem)
+ (deps (:t memoize.mlt)
+  (glob_files %{project_root}/src/.dune.objs/*.cmi)
+  (glob_files %{project_root}/src/stdune/.stdune.objs/*.cmi)
+  (glob_files %{project_root}/src/memo/.memo.objs/*.cmi)
+  (glob_files %{project_root}/src/fiber/.fiber.objs/*.cmi))
+ (action (chdir %{project_root}
+          (progn
+           (run %{exe:expect_test.exe} %{t})
+           (diff? %{t} %{t}.corrected)))))
+(alias
+ (name runtest)
+ (deps (alias runtestmem)))
+
+(alias
+ (name runtestdag)
+ (deps (:t dag.mlt)
+  (glob_files %{project_root}/src/stdune/.stdune.objs/*.cmi)
+  (glob_files %{project_root}/src/dag/.dag.objs/*.cmi))
+ (action (chdir %{project_root}
+          (progn
+           (run %{exe:expect_test.exe} %{t})
+           (diff? %{t} %{t}.corrected)))))
+
+(alias
+ (name runtest)
+ (deps (alias runtestdag)))

--- a/test/unit-tests/expect_test.mll
+++ b/test/unit-tests/expect_test.mll
@@ -92,6 +92,8 @@ let main () =
       [ "src/dune_lang/.dune_lang.objs"
       ; "src/stdune/.stdune.objs"
       ; "src/fiber/.fiber.objs"
+      ; "src/dag/.dag.objs"
+      ; "src/memo/.memo.objs"
       ; "src/.dune.objs"
       ]
       ~f:Topdirs.dir_directory;

--- a/test/unit-tests/memoize.mlt
+++ b/test/unit-tests/memoize.mlt
@@ -1,0 +1,236 @@
+(* -*- tuareg -*- *)
+
+open Dune;;
+open Stdune;;
+open Fiber.O;;
+open Memo;;
+
+module String_fn = Memo.Make(String)
+module Int_fn = Memo.Make(Int)
+[%%expect{|
+module String_fn :
+  sig
+    type 'a t = 'a Memo.Make(Stdune.String).t
+    val create :
+      string ->
+      ?allow_cutoff:bool ->
+      (module Memo__.Memo_intf.Data with type t = 'a) ->
+      (string -> 'a Fiber.t) -> 'a t
+    val exec : 'a t -> string -> 'a Fiber.t
+    val peek : 'a t -> string -> 'a option
+    val peek_exn : 'a t -> string -> 'a
+    val get_deps : 'a t -> string -> (string * Sexp.t) list option
+    module Stack_frame :
+      sig
+        val instance_of : Stack_frame.t -> of_:'a t -> bool
+        val input : Stack_frame.t -> string option
+      end
+  end
+module Int_fn :
+  sig
+    type 'a t = 'a Memo.Make(Stdune.Int).t
+    val create :
+      string ->
+      ?allow_cutoff:bool ->
+      (module Memo__.Memo_intf.Data with type t = 'a) ->
+      (int -> 'a Fiber.t) -> 'a t
+    val exec : 'a t -> int -> 'a Fiber.t
+    val peek : 'a t -> int -> 'a option
+    val peek_exn : 'a t -> int -> 'a
+    val get_deps : 'a t -> int -> (string * Sexp.t) list option
+    module Stack_frame :
+      sig
+        val instance_of : Stack_frame.t -> of_:'a t -> bool
+        val input : Stack_frame.t -> int option
+      end
+  end
+|}]
+
+(* to run a computation *)
+let run exec f v =
+  let exn = ref None in
+  try
+    Fiber.run
+      (Fiber.with_error_handler (fun () -> exec f v)
+         ~on_error:(fun e -> exn := Some e))
+  with Fiber.Never ->
+    raise (Option.value ~default:Fiber.Never !exn);;
+let run_int f v = run Int_fn.exec f v
+let run_string f v = run String_fn.exec f v
+let run = run_string
+
+(* the trivial dependencies are simply the identity function *)
+let compdep x = Fiber.return (x ^ x);;
+
+(* our two dependencies are called some and another *)
+let mcompdep1 = String_fn.create "some" (module String) compdep;;
+let mcompdep2 = String_fn.create "another" (module String) compdep;;
+
+(* compute the dependencies once so they are present in the
+   global hash table *)
+run mcompdep1 "a";;
+run mcompdep2 "a";;
+
+[%%expect{|
+val run : ('a -> 'b -> 'c Fiber.t) -> 'a -> 'b -> 'c = <fun>
+val run_int : 'a Int_fn.t -> int -> 'a = <fun>
+val run_string : 'a String_fn.t -> string -> 'a = <fun>
+val run : 'a String_fn.t -> string -> 'a = <fun>
+val compdep : string -> string Fiber.t = <fun>
+val mcompdep1 : string String_fn.t = <abstr>
+val mcompdep2 : string String_fn.t = <abstr>
+- : string = "aa"
+- : string = "aa"
+|}]
+
+(* define a counter so we can track how often our computation
+   has been run *)
+let counter = ref 0;;
+
+(* our computation increases the counter, adds the two
+   dependencies, "some" and "another" and works by multiplying
+   the input by two *)
+let comp x =
+  Fiber.return x >>=
+  String_fn.exec mcompdep1 >>=
+  String_fn.exec mcompdep2 >>=
+  (fun a -> counter := !counter + 1; String.sub a 0 (String.length a |> min 3) |> Fiber.return);;
+
+let mcomp = String_fn.create "test" (module String) comp;;
+
+[%%expect{|
+val counter : int ref = {contents = 0}
+val comp : string -> string Fiber.t = <fun>
+val mcomp : string String_fn.t = <abstr>
+|}]
+
+(* running it the first time should increase the counter,
+   running it again should not, but should still return the
+   same result *)
+!counter;;
+run mcomp "a";;
+!counter;;
+run mcomp "a";;
+!counter;;
+
+[%%expect{|
+- : int = 0
+- : string = "aaa"
+- : int = 1
+- : string = "aaa"
+- : int = 1
+|}]
+
+String_fn.get_deps mcomp "a";;
+
+[%%expect{|
+- : (string * Sexp.t) list option =
+Some [("another", Atom "aa"); ("some", Atom "a")]
+|}]
+
+(* running it on a new input should cause it to recompute
+   the first time it is run *)
+run mcomp "hello";;
+!counter;;
+run mcomp "hello";;
+!counter;;
+
+[%%expect{|
+- : string = "hel"
+- : int = 2
+- : string = "hel"
+- : int = 2
+|}]
+
+(* updating the first dependency should require recomputation of mcomp 7 *)
+run mcompdep1 "testtest";;
+run mcomp "hello";;
+!counter;;
+run mcomp "hello";;
+!counter;;
+
+[%%expect{|
+- : string = "testtesttesttest"
+- : string = "hel"
+- : int = 2
+- : string = "hel"
+- : int = 2
+|}]
+
+let stack = ref [];;
+let dump_stack v =
+  get_call_stack >>| (fun s -> stack := s; v);;
+
+let mcompcycle =
+  let mcompcycle = Fdecl.create () in
+  let compcycle x =
+    Fiber.return x
+    >>= dump_stack
+    >>= (fun x ->
+          counter := !counter + 1;
+          if !counter < 20 then
+            ((x + 1) mod 3) |> Int_fn.exec (Fdecl.get mcompcycle)
+          else
+            failwith "cycle"
+        ) in
+  let fn = Int_fn.create "cycle" (module String) compcycle in
+  Fdecl.set mcompcycle fn;
+  fn;;
+
+[%%expect{|
+val stack : '_weak1 list ref = {contents = []}
+val dump_stack : 'a -> 'a Fiber.t = <fun>
+val mcompcycle : string Int_fn.t = <abstr>
+|}]
+
+counter := 0;
+try
+ run_int mcompcycle 5 |> ignore;
+ None
+with
+ | Cycle_error.E err ->
+   let cycle =
+     Cycle_error.get err
+     |> List.filter_map ~f:Int_fn.Stack_frame.input
+   in
+   Some cycle;;
+!counter;;
+!stack |> List.map ~f:(fun st -> Stack_frame.name st, Stack_frame.input st);;
+
+[%%expect{|
+- : int list option = Some [2; 1; 0; 2]
+- : int = 4
+- : (string * Sexp.t) list =
+[("cycle", Atom "2"); ("cycle", Atom "1"); ("cycle", Atom "0");
+ ("cycle", Atom "5")]
+|}]
+
+let mfib =
+  let mfib = Fdecl.create () in
+  let compfib x =
+    let mfib = Int_fn.exec (Fdecl.get mfib) in
+    counter := !counter + 1;
+    if x <= 1 then
+      Fiber.return x
+    else
+      mfib (x - 1)
+      >>= (fun r1 ->
+        mfib (x - 2)
+        >>| fun r2 -> r1 + r2) in
+  let fn = Int_fn.create "fib" (module Int) compfib in
+  Fdecl.set mfib fn;
+  fn;;
+
+counter := 0;
+run_int mfib 2000;;
+!counter;;
+run_int mfib 1800;;
+!counter;;
+
+[%%expect{|
+val mfib : int Int_fn.t = <abstr>
+- : int = 2406280077793834213
+- : int = 2001
+- : int = 3080005411477819488
+- : int = 2001
+|}]


### PR DESCRIPTION
This is referencing the computation model specified in #1280. The goal has been to implement a memoization function which takes a computation of the form `'a -> 'b Fiber.t` and returns a computation `'a -> 'b Fiber.t` which additionally performs:
* Dependency tracking
* Output caching with early cut-off
* Cycle detection

Currently the memoization function has been implemented and is able to perform these three functions. An example of how to use the memoization functions is shown in `test/unit-tests/memoize.mlt`. Below is an example of how one could use the system to implement a Fibonacci sequence which is automatically cached between computations.

```
let mfib = 
  let mfib = CRef.deferred () in
  let compfib x =
    let mfib = CRef.get mfib in
    counter := !counter + 1;
    if x <= 1 then
      Fiber.return x
    else
      mfib (x - 1)
      >>= (fun r1 ->
        mfib (x - 2)
        >>| fun r2 -> r1 + r2) in
  memoization iimemcached "fib" int_input_spec int_output_spec compfib |> CRef.set mfib;
  CRef.get mfib;;
```

There has been a little bit of progress to change `build_system.ml` so that the actual build process is a little more abstracted to make it easier to drop in the `memoization` function and remove the current caching etc. This bit is still a little bit of a mess however, and in essence it just breaks existing caching (for now). 

Feedback welcome.