### PR TITLE
Ocamlformat depends on all .ocamlformat files

### DIFF
--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -55,7 +55,9 @@ let gen_rules sctx (config : Dune_file.Auto_format.t) ~dir =
   let alias = Build_system.Alias.make "fmt" ~dir in
   let alias_formatted = Build_system.Alias.make "fmt" ~dir:output_dir in
   let resolve_program = Super_context.resolve_program sctx ~loc:(Some loc) in
-  let ocamlformat_deps = depend_on_files ~named:".ocamlformat" source_dir in
+  let ocamlformat_deps =
+    lazy (depend_on_files ~named:".ocamlformat" source_dir)
+  in
   let setup_formatting file =
     let open Build.O in
     let input_basename = Path.basename file in
@@ -75,7 +77,7 @@ let gen_rules sctx (config : Dune_file.Auto_format.t) ~dir =
           ; Target output
           ]
         in
-        Some (ocamlformat_deps >>> Build.run ~dir exe args)
+        Some (Lazy.force ocamlformat_deps >>> Build.run ~dir exe args)
       else
         None
     in

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -35,22 +35,21 @@ Configuration files are taken into account for this action:
 
   $ touch enabled/.ocamlformat
   $ dune build --display short @fmt
-  File "enabled/subdir/lib.ml", line 1, characters 0-0:
-  Files _build/default/enabled/subdir/lib.ml and _build/default/enabled/subdir/.formatted/lib.ml differ.
-  File "partial/a.ml", line 1, characters 0-0:
-  Files _build/default/partial/a.ml and _build/default/partial/.formatted/a.ml differ.
-         refmt enabled/.formatted/reason_file.re
   File "enabled/reason_file.re", line 1, characters 0-0:
   Files _build/default/enabled/reason_file.re and _build/default/enabled/.formatted/reason_file.re differ.
-         refmt enabled/.formatted/reason_file.rei
   File "enabled/reason_file.rei", line 1, characters 0-0:
   Files _build/default/enabled/reason_file.rei and _build/default/enabled/.formatted/reason_file.rei differ.
+  File "partial/a.ml", line 1, characters 0-0:
+  Files _build/default/partial/a.ml and _build/default/partial/.formatted/a.ml differ.
    ocamlformat enabled/.formatted/ocaml_file.mli
   File "enabled/ocaml_file.mli", line 1, characters 0-0:
   Files _build/default/enabled/ocaml_file.mli and _build/default/enabled/.formatted/ocaml_file.mli differ.
    ocamlformat enabled/.formatted/ocaml_file.ml
   File "enabled/ocaml_file.ml", line 1, characters 0-0:
   Files _build/default/enabled/ocaml_file.ml and _build/default/enabled/.formatted/ocaml_file.ml differ.
+   ocamlformat enabled/subdir/.formatted/lib.ml
+  File "enabled/subdir/lib.ml", line 1, characters 0-0:
+  Files _build/default/enabled/subdir/lib.ml and _build/default/enabled/subdir/.formatted/lib.ml differ.
   [1]
 
 And fixable files can be promoted:
@@ -64,3 +63,22 @@ And fixable files can be promoted:
   $ cat enabled/reason_file.re
   Sys.argv: ../../install/default/bin/refmt reason_file.re
   refmt output
+
+All .ocamlformat files are considered dependencies:
+
+  $ echo 'margin = 70' > .ocamlformat
+  $ dune build --display short @fmt
+  File "enabled/reason_file.rei", line 1, characters 0-0:
+  Files _build/default/enabled/reason_file.rei and _build/default/enabled/.formatted/reason_file.rei differ.
+         refmt enabled/.formatted/reason_file.re
+   ocamlformat enabled/.formatted/ocaml_file.mli
+  File "enabled/ocaml_file.mli", line 1, characters 0-0:
+  Files _build/default/enabled/ocaml_file.mli and _build/default/enabled/.formatted/ocaml_file.mli differ.
+   ocamlformat enabled/.formatted/ocaml_file.ml
+   ocamlformat enabled/subdir/.formatted/lib.ml
+  File "enabled/subdir/lib.ml", line 1, characters 0-0:
+  Files _build/default/enabled/subdir/lib.ml and _build/default/enabled/subdir/.formatted/lib.ml differ.
+   ocamlformat partial/.formatted/a.ml
+  File "partial/a.ml", line 1, characters 0-0:
+  Files _build/default/partial/a.ml and _build/default/partial/.formatted/a.ml differ.
+  [1]


### PR DESCRIPTION
More precisely, when invoked in a directory, it depends on all files named `.ocamlformat` in parent directories.

This change has two benefits:
- it makes ocamlformat dependency tracking correct (all dependencies are there);
- it makes refmt dependency tracking more precise (changing .ocamlformat used to trigger recompilations of reason source files).