### PR TITLE
Add test to show that the env macro handle scoping of setenv

### DIFF
--- a/test/blackbox-tests/test-cases/env-var-expansion/correct/dune
+++ b/test/blackbox-tests/test-cases/env-var-expansion/correct/dune
@@ -4,8 +4,11 @@
 
 (alias
  (name echo2)
- (action (setenv DUNE_ENV_VAR false
-          (echo %{env:DUNE_ENV_VAR=true}))))
+ (action
+  (progn
+   (echo "previous env: %{env:DUNE_ENV_VAR=unset}\n")
+   (setenv DUNE_ENV_VAR false
+    (echo "new env:%{env:DUNE_ENV_VAR=unset}")))))
 
 (alias
  (name enabled)

--- a/test/blackbox-tests/test-cases/env-var-expansion/run.t
+++ b/test/blackbox-tests/test-cases/env-var-expansion/run.t
@@ -34,14 +34,21 @@ incrementality works properly, that (setenv ...) is taken into account, etc.
   Entering directory 'correct'
   true
 
+This test is broken because previous/new values should differ in these tests. In
+the dune file, the environment variable ends up being set locally, but this
+isn't reflected on a per action basis.
   $ dune build --root correct @echo2
   Entering directory 'correct'
-  true
+  previous env: unset
+  new env:unset
   $ DUNE_ENV_VAR=true dune build --root correct @echo2
   Entering directory 'correct'
+  previous env: true
+  new env:true
   $ DUNE_ENV_VAR=false dune build --root correct @echo2
   Entering directory 'correct'
-  false
+  previous env: false
+  new env:false
 
   $ dune build --root correct @enabled
   Entering directory 'correct'


### PR DESCRIPTION
The second run of alias echo2 should not be printing true twice for example

@trefis does this look intentional?