### PR TITLE
Compute Console Command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@ unreleased
 - Get the correct environment node for multi project workspaces (#1648,
   @rgrinberg)
 
+- Add `dune compute` to call internal memoized functions (#1528,
+  @rudihorn, @diml)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -72,15 +72,6 @@
  (files   dune-installed-libraries.1))
 
 (rule
- (with-stdout-to dune-list-functions.1
-  (run dune list-functions --help=groff)))
-
-(install
- (section man)
- (package dune)
- (files   dune-list-functions.1))
-
-(rule
  (with-stdout-to dune-printenv.1
   (run dune printenv --help=groff)))
 

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -18,6 +18,15 @@
  (files   dune-clean.1))
 
 (rule
+ (with-stdout-to dune-compute.1
+  (run dune compute --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-compute.1))
+
+(rule
  (with-stdout-to dune-exec.1
   (run dune exec --help=groff)))
 
@@ -61,6 +70,15 @@
  (section man)
  (package dune)
  (files   dune-installed-libraries.1))
+
+(rule
+ (with-stdout-to dune-list-functions.1
+  (run dune list-functions --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-list-functions.1))
 
 (rule
  (with-stdout-to dune-printenv.1

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -89,6 +89,11 @@ module Internal_rule = struct
 
   let loc ~file_tree ~dir t  = rule_loc ~file_tree ~dir ~loc:t.loc
 
+  let decode : t Dune_lang.Decoder.t =
+    let open Dune_lang.Decoder in
+    loc >>= fun loc ->
+    Errors.fail loc "<not-implemented>"
+
   let to_sexp t : Sexp.t =
     Sexp.Encoder.record
       [ "id", Id.to_sexp t.id
@@ -382,7 +387,10 @@ module Action_and_deps = struct
 end
 
 module Rule_fn = Memo.Make(Internal_rule)
-module Path_fn = Memo.Make(Path)
+module Path_fn = Memo.Make(struct
+    include Path
+    let decode = Path_dune_lang.decode
+  end)
 
 type t =
   { (* File specification by targets *)
@@ -1354,15 +1362,18 @@ let create ~contexts ~file_tree ~hook =
   in
   Fdecl.set t.prepare_rule_def
     (Rule_fn.create "prepare-rule" (module Action_and_deps) (prepare_rule t)
+       ~doc:"Evaluate the build arrow part of a rule."
      |> Rule_fn.exec);
   Fdecl.set t.build_rule_def
-    (Rule_fn.create "build-rule" (module Action_and_deps) (build_rule t));
+    (Rule_fn.create "build-rule" (module Action_and_deps) (build_rule t)
+       ~doc:"Execute a rule.");
   Fdecl.set t.build_rule_internal_def
     (Rule_fn.create "build-rule-internal" (module Unit)
-       (build_rule_internal t)
+       (build_rule_internal t) ~doc:"-"
      |> Rule_fn.exec);
   Fdecl.set t.build_file_def
-    (Path_fn.create "build-file" (module Unit) (build_file t));
+    (Path_fn.create "build-file" (module Unit) (build_file t)
+       ~doc:"Build a file.");
   Hooks.End_of_build.once (fun () -> finalize t);
   t
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -89,11 +89,6 @@ module Internal_rule = struct
 
   let loc ~file_tree ~dir t  = rule_loc ~file_tree ~dir ~loc:t.loc
 
-  let decode : t Dune_lang.Decoder.t =
-    let open Dune_lang.Decoder in
-    loc >>= fun loc ->
-    Errors.fail loc "<not-implemented>"
-
   let to_sexp t : Sexp.t =
     Sexp.Encoder.record
       [ "id", Id.to_sexp t.id
@@ -386,11 +381,8 @@ module Action_and_deps = struct
       ]
 end
 
-module Rule_fn = Memo.Make(Internal_rule)
-module Path_fn = Memo.Make(struct
-    include Path
-    let decode = Path_dune_lang.decode
-  end)
+module Rule_fn = Memo.Make_hidden(Internal_rule)
+module Path_fn = Memo.Make(Path)(Path_dune_lang)
 
 type t =
   { (* File specification by targets *)

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,4 +1,4 @@
 (library
  (name memo)
- (libraries stdune dag fiber)
+ (libraries stdune dune_lang dag fiber)
  (synopsis "Function memoizer"))

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -69,3 +69,6 @@ end
 
 (** Return the list of registered functions *)
 val registered_functions : unit -> Function_info.t list
+
+(** Lookup function's info *)
+val function_info : string -> Function_info.t

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -28,9 +28,10 @@ end
 val reset : unit -> unit
 
 module type S = Memo_intf.S with type stack_frame := Stack_frame.t
-module type Data = Memo_intf.Data
+module type Input = Memo_intf.Input
+module type Output = Memo_intf.Output
 
-module Make(Input : Data) : S with type input := Input.t
+module Make(Input : Input) : S with type input := Input.t
 
 (** Print the memoized call stack during execution. This is useful for debugging purposes.
     Example code:
@@ -45,3 +46,16 @@ val dump_stack : 'a -> 'a Fiber.t
 
 (** Get the memoized call stack during the execution of a memoized function. *)
 val get_call_stack : Stack_frame.t list Fiber.t
+
+(** Call a memoized function by name *)
+val call : string -> Dune_lang.Ast.t -> Sexp.t Fiber.t
+
+module Function_info : sig
+  type t =
+    { name : string
+    ; doc  : string
+    }
+end
+
+(** Return the list of registered functions *)
+val registered_functions : unit -> Function_info.t list

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -30,10 +30,20 @@ val reset : unit -> unit
 module type S = Memo_intf.S with type stack_frame := Stack_frame.t
 module type Input = Memo_intf.Input
 module type Output = Memo_intf.Output
+module type Decoder = Memo_intf.Decoder
 
-module Make(Input : Input) : S with type input := Input.t
+module Make(Input : Input)(Decoder : Decoder with type t := Input.t)
+  : S with type input := Input.t
 
-(** Print the memoized call stack during execution. This is useful for debugging purposes.
+(** Same as [Make] except that registered functions won't be available
+    through [dune compute]. In particular, it is not necessary to
+    provide a decoder for the input. *)
+module Make_hidden(Input : Input)
+  : S with type input := Input.t
+
+(** Print the memoized call stack during execution. This is useful for
+    debugging purposes.
+
     Example code:
 
     {[

--- a/src/memo/memo_intf.ml
+++ b/src/memo/memo_intf.ml
@@ -7,6 +7,13 @@ module type Data = sig
   val to_sexp : t -> Sexp.t
 end
 
+module type Input = sig
+  include Data
+  val decode : t Dune_lang.Decoder.t
+end
+
+module type Output = Data
+
 module type S = sig
   type input
 
@@ -27,7 +34,8 @@ module type S = sig
   val create
     :  string
     -> ?allow_cutoff:bool
-    -> (module Data with type t = 'a)
+    -> doc:string
+    -> (module Output with type t = 'a)
     -> (input -> 'a Fiber.t)
     -> 'a t
 

--- a/src/memo/memo_intf.ml
+++ b/src/memo/memo_intf.ml
@@ -7,12 +7,13 @@ module type Data = sig
   val to_sexp : t -> Sexp.t
 end
 
-module type Input = sig
-  include Data
+module type Input = Data
+module type Output = Data
+
+module type Decoder = sig
+  type t
   val decode : t Dune_lang.Decoder.t
 end
-
-module type Output = Data
 
 module type S = sig
   type input

--- a/src/stdune/interned.ml
+++ b/src/stdune/interned.ml
@@ -5,6 +5,7 @@ module type S = sig
   val pp: t Fmt.t
   val make : string -> t
   val get : string -> t option
+  val all : unit -> t list
   module Set : sig
     include Set.S with type elt = t
     val make : string list -> t
@@ -89,6 +90,8 @@ module Make(R : Settings)()
 
   let to_string t = Table.get names t
 
+  let all () = List.init !next ~f:(fun t -> t)
+
   module T = struct
     type nonrec t = int
 
@@ -122,6 +125,7 @@ module No_interning(R : Settings)() = struct
   let to_string s = s
   let pp fmt s = Format.fprintf fmt "%S" (to_string s)
   let get s = Some s
+  let all () = assert false
 
   module Set = struct
     include String.Set

--- a/src/stdune/interned.mli
+++ b/src/stdune/interned.mli
@@ -12,6 +12,9 @@ module type S = sig
       registered with [make] previously. *)
   val get : string -> t option
 
+  (** Return the list of all existing [t]s. *)
+  val all : unit -> t list
+
   module Set : sig
     include Set.S with type elt = t
 

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -127,3 +127,12 @@ let rec nth t i =
   | _ :: xs, i -> nth xs (i - 1)
 
 let physically_equal = Pervasives.(==)
+
+let init =
+  let rec loop acc i n f =
+    if i = n then
+      rev acc
+    else
+      loop (f i :: acc) (i + 1) n f
+  in
+  fun n ~f -> loop [] 0 n f

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -50,3 +50,5 @@ val singleton : 'a -> 'a t
 val nth : 'a t -> int -> 'a option
 
 val physically_equal : 'a t -> 'a t -> bool
+
+val init : int -> f:(int -> 'a) -> 'a list

--- a/test/unit-tests/expect_test.mll
+++ b/test/unit-tests/expect_test.mll
@@ -118,6 +118,11 @@ let main () =
           in
           ignore (Toploop.execute_phrase true ppf phr : bool)
         with exn ->
+          let ppf =
+            match kind with
+            | Expect -> ppf
+            | Ignore -> Format.err_formatter
+          in
           Location.report_exception ppf exn
       );
       begin match kind with

--- a/test/unit-tests/memoize.mlt
+++ b/test/unit-tests/memoize.mlt
@@ -5,12 +5,10 @@ open Stdune;;
 open Fiber.O;;
 open Memo;;
 
-module String_fn = Memo.Make(struct
-    include String
+module String_fn = Memo.Make(String)(struct
     let decode = Dune_lang.Decoder.string
   end)
-module Int_fn = Memo.Make(struct
-    include Int
+module Int_fn = Memo.Make(Int)(struct
     let decode = Dune_lang.Decoder.int
   end)
 [%%ignore]
@@ -32,8 +30,8 @@ let run = run_string
 let compdep x = Fiber.return (x ^ x);;
 
 (* our two dependencies are called some and another *)
-let mcompdep1 = String_fn.create "some" (module String) compdep;;
-let mcompdep2 = String_fn.create "another" (module String) compdep;;
+let mcompdep1 = String_fn.create "some" (module String) compdep ~doc:"";;
+let mcompdep2 = String_fn.create "another" (module String) compdep ~doc:"";;
 
 (* compute the dependencies once so they are present in the
    global hash table *)
@@ -55,7 +53,7 @@ let comp x =
   String_fn.exec mcompdep2 >>=
   (fun a -> counter := !counter + 1; String.sub a 0 (String.length a |> min 3) |> Fiber.return);;
 
-let mcomp = String_fn.create "test" (module String) comp;;
+let mcomp = String_fn.create "test" (module String) comp ~doc:"";;
 
 [%%ignore]
 
@@ -128,7 +126,7 @@ let mcompcycle =
           else
             failwith "cycle"
         ) in
-  let fn = Int_fn.create "cycle" (module String) compcycle in
+  let fn = Int_fn.create "cycle" (module String) compcycle ~doc:"" in
   Fdecl.set mcompcycle fn;
   fn;;
 
@@ -172,7 +170,7 @@ let mfib =
       >>= (fun r1 ->
         mfib (x - 2)
         >>| fun r2 -> r1 + r2) in
-  let fn = Int_fn.create "fib" (module Int) compfib in
+  let fn = Int_fn.create "fib" (module Int) compfib ~doc:"" in
   Fdecl.set mfib fn;
   fn;;
 

--- a/test/unit-tests/memoize.mlt
+++ b/test/unit-tests/memoize.mlt
@@ -5,8 +5,14 @@ open Stdune;;
 open Fiber.O;;
 open Memo;;
 
-module String_fn = Memo.Make(String)
-module Int_fn = Memo.Make(Int)
+module String_fn = Memo.Make(struct
+    include String
+    let decode = Dune_lang.Decoder.string
+  end)
+module Int_fn = Memo.Make(struct
+    include Int
+    let decode = Dune_lang.Decoder.int
+  end)
 [%%ignore]
 
 (* to run a computation *)


### PR DESCRIPTION
This is to be merged in after #1489. It adds a console command called `compute`, which allows individual registered memoized functions to be run for debugging purposes.

For example, to call the load directory function on the "src" directory run `dune compute load-dir src`.