### PR TITLE
Fix the documentation of env_var.

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1284,7 +1284,7 @@ syntax:
 - ``(package <pkg>)`` depend on all files installed by ``<package>``, as well
   as on the transitive package dependencies of ``<package>``. This can be used
   to test a command against the files that will be installed
-- ``(env <var>)``: depend on the value of the environment variable ``<var>``.
+- ``(env_var <var>)``: depend on the value of the environment variable ``<var>``.
   If this variable becomes set, becomes unset, or changes value, the target
   will be rebuilt.
 


### PR DESCRIPTION
This feature was introduced in #1186 but it seems that the documentation that was introduced at the same time was incorrect.