### PR TITLE
[stdune] Support for OCaml 4.08 `List.t` type.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ next
 - Allow targets to be directories, which Dune will treat opaquely
   (#1547, @jordwalke)
 
+- Support for OCaml 4.08: `List.t` is now provided by OCaml (#1561 @ejgallego)
 
 1.5.1 (7/11/2018)
 -----------------

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -1,6 +1,6 @@
-type 'a t = 'a list
-
 include ListLabels
+
+type 'a t = 'a list
 
 let map ~f t = rev (rev_map ~f t)
 

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -1,6 +1,9 @@
-type 'a t = 'a list
-
 include module type of struct include ListLabels end
+
+(* ocaml/ocaml#1892 "Allow shadowing of items coming from an include"
+   helps making this work in 4.08, as OCaml now includes a `List.t`
+   type. *)
+type 'a t = 'a list
 
 val is_empty : _ t -> bool
 


### PR DESCRIPTION
We piggyback on ocaml/ocaml#1892 "Allow shadowing of items coming from
an include" to support OCaml 4.08 and avoid a conflict with OCaml's
new `List.t`.

Thanks to @diml for pointing this out.

Note the comment from @diml regarding `Stdune.List`:

> Ideally, we shouldn't use include and manually import the function we use in dune. That would make the code more robust against upstream changes.

This is left to future work.
