### PR TITLE
Remove global variable from dir_status

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -315,8 +315,7 @@ let build_mlds_map (d : _ Dir_with_dune.t) ~files =
 let cache = Hashtbl.create 32
 
 let clear_cache () =
-  Hashtbl.reset cache;
-  Dir_status.clear_cache ()
+  Hashtbl.reset cache
 
 let () = Hooks.End_of_build.always clear_cache
 
@@ -324,7 +323,8 @@ let rec get sctx ~dir =
   match Hashtbl.find cache dir with
   | Some t -> t
   | None ->
-    match Dir_status.get sctx ~dir with
+    let dir_status_db = Super_context.dir_status_db sctx in
+    match Dir_status.DB.get dir_status_db ~dir with
     | Standalone x ->
       let t =
         match x with
@@ -359,7 +359,8 @@ let rec get sctx ~dir =
     | Group_root (ft_dir, d) ->
       let rec walk ft_dir ~dir acc =
         match
-          Dir_status.get_assuming_parent_is_part_of_group sctx ft_dir ~dir
+          Dir_status.DB.get_assuming_parent_is_part_of_group dir_status_db
+            ft_dir ~dir
         with
         | Is_component_of_a_group_but_not_the_root d ->
           let files =

--- a/src/dir_status.ml
+++ b/src/dir_status.ml
@@ -20,8 +20,6 @@ let is_standalone = function
   | Standalone _ -> true
   | _ -> false
 
-let cache = Hashtbl.create 32
-
 let get_include_subdirs stanzas =
   List.fold_left stanzas ~init:None ~f:(fun acc stanza ->
     match stanza with
@@ -43,36 +41,77 @@ let check_no_module_consumer stanzas =
          Hint: add (include_subdirs no) to this file."
     | _ -> ())
 
-let rec get sctx ~dir =
-  match Hashtbl.find cache dir with
-  | Some t -> t
-  | None ->
-    let t =
-      match
-        Option.bind (Path.drop_build_context dir)
-          ~f:(File_tree.find_dir (Super_context.file_tree sctx))
-      with
-      | None -> begin
-          match Path.parent dir with
-          | None -> Standalone None
-          | Some dir ->
-            if is_standalone (get sctx ~dir) then
-              Standalone None
+module DB = struct
+  type nonrec t =
+    { cache : (Path.t, t) Hashtbl.t
+    ; file_tree : File_tree.t
+    ; stanzas_per_dir : Dune_file.Stanzas.t Dir_with_dune.t Path.Map.t
+    }
+
+  let make file_tree ~stanzas_per_dir =
+    { cache = Hashtbl.create 32
+    ; file_tree
+    ; stanzas_per_dir
+    }
+
+  let stanzas_in db ~dir =
+    Path.Map.find db.stanzas_per_dir dir
+
+  let rec get db ~dir =
+    match Hashtbl.find db.cache dir with
+    | Some t -> t
+    | None ->
+      let t =
+        match
+          Option.bind (Path.drop_build_context dir)
+            ~f:(File_tree.find_dir db.file_tree)
+        with
+        | None -> begin
+            match Path.parent dir with
+            | None -> Standalone None
+            | Some dir ->
+              if is_standalone (get db ~dir) then
+                Standalone None
+              else
+                Is_component_of_a_group_but_not_the_root None
+          end
+        | Some ft_dir ->
+          let project_root =
+            File_tree.Dir.project ft_dir
+            |> Dune_project.root
+            |> Path.of_local in
+          match stanzas_in db ~dir with
+          | None ->
+            if Path.equal dir project_root ||
+               is_standalone (get db ~dir:(Path.parent_exn dir)) then
+              Standalone (Some (ft_dir, None))
             else
               Is_component_of_a_group_but_not_the_root None
-        end
-      | Some ft_dir ->
-        let project_root =
-          File_tree.Dir.project ft_dir
-          |> Dune_project.root
-          |> Path.of_local in
-        match Super_context.stanzas_in sctx ~dir with
-        | None ->
-          if Path.equal dir project_root ||
-             is_standalone (get sctx ~dir:(Path.parent_exn dir)) then
-            Standalone (Some (ft_dir, None))
-          else
-            Is_component_of_a_group_but_not_the_root None
+          | Some d ->
+            match get_include_subdirs d.data with
+            | Some Unqualified ->
+              Group_root (ft_dir, d)
+            | Some No ->
+              Standalone (Some (ft_dir, Some d))
+            | None ->
+              if dir <> project_root &&
+                 not (is_standalone (get db ~dir:(Path.parent_exn dir)))
+              then begin
+                check_no_module_consumer d.data;
+                Is_component_of_a_group_but_not_the_root (Some d)
+              end else
+                Standalone (Some (ft_dir, Some d))
+      in
+      Hashtbl.add db.cache dir t;
+      t
+
+  let get_assuming_parent_is_part_of_group db ~dir ft_dir =
+    match Hashtbl.find db.cache (File_tree.Dir.path ft_dir) with
+    | Some t -> t
+    | None ->
+      let t =
+        match stanzas_in db ~dir with
+        | None -> Is_component_of_a_group_but_not_the_root None
         | Some d ->
           match get_include_subdirs d.data with
           | Some Unqualified ->
@@ -80,36 +119,9 @@ let rec get sctx ~dir =
           | Some No ->
             Standalone (Some (ft_dir, Some d))
           | None ->
-            if dir <> project_root &&
-               not (is_standalone (get sctx ~dir:(Path.parent_exn dir)))
-            then begin
-              check_no_module_consumer d.data;
-              Is_component_of_a_group_but_not_the_root (Some d)
-            end else
-              Standalone (Some (ft_dir, Some d))
-    in
-    Hashtbl.add cache dir t;
-    t
-
-let get_assuming_parent_is_part_of_group sctx ~dir ft_dir =
-  match Hashtbl.find cache (File_tree.Dir.path ft_dir) with
-  | Some t -> t
-  | None ->
-    let t =
-      match Super_context.stanzas_in sctx ~dir with
-      | None -> Is_component_of_a_group_but_not_the_root None
-      | Some d ->
-        match get_include_subdirs d.data with
-        | Some Unqualified ->
-          Group_root (ft_dir, d)
-        | Some No ->
-          Standalone (Some (ft_dir, Some d))
-        | None ->
-          check_no_module_consumer d.data;
-          Is_component_of_a_group_but_not_the_root (Some d)
-    in
-    Hashtbl.add cache dir t;
-    t
-
-let clear_cache () =
-  Hashtbl.reset cache
+            check_no_module_consumer d.data;
+            Is_component_of_a_group_but_not_the_root (Some d)
+      in
+      Hashtbl.add db.cache dir t;
+      t
+end

--- a/src/dir_status.mli
+++ b/src/dir_status.mli
@@ -15,12 +15,20 @@ type t =
       Stanza.t list Dir_with_dune.t option
   (* Sub-directory of a [Group_root _] *)
 
-val get : Super_context.t -> dir:Path.t -> t
+module DB : sig
+  type t
+  type status
 
-val get_assuming_parent_is_part_of_group
-  :  Super_context.t
-  -> dir:Path.t
-  -> File_tree.Dir.t
-  -> t
+  val make
+    :  File_tree.t
+    -> stanzas_per_dir:Dune_file.Stanzas.t Dir_with_dune.t Path.Map.t
+    -> t
 
-val clear_cache : unit -> unit
+  val get : t -> dir:Path.t -> status
+
+  val get_assuming_parent_is_part_of_group
+    :  t
+    -> dir:Path.t
+    -> File_tree.Dir.t
+    -> status
+end with type status := t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -22,6 +22,7 @@ type t =
   ; host                             : t option
   ; libs_by_package : (Package.t * Lib.Set.t) Package.Name.Map.t
   ; env                              : (Path.t, Env_node.t) Hashtbl.t
+  ; dir_status_db                    : Dir_status.DB.t
   ; external_lib_deps_mode           : bool
   ; (* Env node that represent the environment configured for the
        workspace. It is used as default at the root of every project
@@ -334,6 +335,7 @@ let create
       ~artifacts_host
       ~cxx_flags
   in
+  let dir_status_db = Dir_status.DB.make file_tree ~stanzas_per_dir in
   { context
   ; expander
   ; host
@@ -364,6 +366,7 @@ let create
   ; env = Hashtbl.create 128
   ; default_env
   ; external_lib_deps_mode
+  ; dir_status_db
   }
 
 module Libs = struct
@@ -591,3 +594,5 @@ end
 let opaque t =
   t.context.profile = "dev"
   && Ocaml_version.supports_opaque_for_mli t.context.version
+
+let dir_status_db t = t.dir_status_db

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -195,3 +195,5 @@ end
 val opaque : t -> bool
 
 val expander : t -> dir:Path.t -> Expander.t
+
+val dir_status_db : t -> Dir_status.DB.t


### PR DESCRIPTION
Now we store the dir_status database per super context. Similarly, we could remove the global cache in Dir_contents as well if I manage to make #1566 work. 