### PR TITLE
[RFC] Add cmxs linkage for executables

### DIFF
--- a/src/binary_kind.ml
+++ b/src/binary_kind.ml
@@ -5,6 +5,7 @@ type t =
   | Exe
   | Object
   | Shared_object
+  | Plugin
 
 let decode =
   let open Dune_lang.Decoder in
@@ -13,6 +14,7 @@ let decode =
     ; "exe"           , return Exe
     ; "object"        , return Object
     ; "shared_object" , return Shared_object
+    ; "plugin"        , return Plugin
     ]
 
 let to_string = function
@@ -20,6 +22,7 @@ let to_string = function
   | Exe -> "exe"
   | Object -> "object"
   | Shared_object -> "shared_object"
+  | Plugin -> "plugin"
 
 let pp fmt t =
   Format.pp_print_string fmt (to_string t)
@@ -27,4 +30,4 @@ let pp fmt t =
 let encode t =
   Dune_lang.unsafe_atom_of_string (to_string t)
 
-let all = [C; Exe; Object; Shared_object]
+let all = [C; Exe; Object; Shared_object; Plugin]

--- a/src/binary_kind.mli
+++ b/src/binary_kind.mli
@@ -7,6 +7,7 @@ type t =
   | Exe
   | Object
   | Shared_object
+  | Plugin
 
 include Dune_lang.Conv with type t := t
 

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1138,6 +1138,7 @@ module Executables = struct
     let native_exe           = make Native Exe
     let native_object        = make Native Object
     let native_shared_object = make Native Shared_object
+    let native_plugin        = make Native Plugin
 
     let byte   = byte_exe
     let native = native_exe
@@ -1149,6 +1150,7 @@ module Executables = struct
       [ "exe"           , exe
       ; "object"        , object_
       ; "shared_object" , shared_object
+      ; "cmxs"          , native_plugin
       ; "byte"          , byte
       ; "native"        , native
       ]

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -38,6 +38,12 @@ module Linkage = struct
     ; flags = ["-custom"]
     }
 
+  let plugin =
+    { mode  = Native
+    ; ext   = ".cmxs"
+    ; flags = []
+    }
+
   let native_or_custom (context : Context.t) =
     match context.ocamlopt with
     | None   -> custom
@@ -77,6 +83,8 @@ module Linkage = struct
       | Native , Object        -> ".exe" ^ ctx.ext_obj
       | Byte   , Shared_object -> ".bc"  ^ ctx.ext_dll
       | Native , Shared_object ->          ctx.ext_dll
+      | Native , Plugin        -> ".cmxs"
+      | Byte   , Plugin        -> Errors.fail m.loc "Plugin generation only supported native-code!"
     in
     let flags =
       match m.kind with
@@ -95,7 +103,7 @@ module Linkage = struct
           else
             so_flags_unix
         in
-        match real_mode with
+        begin match real_mode with
         | Native ->
           (* The compiler doesn't pass these flags in native mode. This
              looks like a bug in the compiler. *)
@@ -104,6 +112,9 @@ module Linkage = struct
           @ so_flags
         | Byte ->
           so_flags
+        end
+      | Plugin ->
+        ["-shared"]
     in
     { ext
     ; mode = real_mode

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -21,6 +21,9 @@ module Linkage : sig
   (** Byte compilation, link with [-custom], extension [.exe] *)
   val custom : t
 
+  (** Native compilation, extension [.cmxs] *)
+  val plugin : t
+
   (** [native] if supported, [custom] if not *)
   val native_or_custom : Context.t -> t
 


### PR DESCRIPTION
This PR introduces a new linking mode for executables allowing to link them as `.cmxs` archives.  Concretely,

```
(executable
 (name foo)
 (libraries bar)
 (modes cmxs)
 (modules foo))
```

will define a target `foo.cmxs` linking together `bar.cmxa` and `foo.cmx`.

Opinions appreciated (it has not seen much testing but it seems to work in simple cases). If there is agreement I will flesh out the patch (tests, doc, support for bytecode?)