### PR TITLE
Allow to substitute in env vars

### DIFF
--- a/src/context.mli
+++ b/src/context.mli
@@ -32,7 +32,7 @@ module Kind : sig
 end
 
 module Env_nodes : sig
-  type t =
+  type t = private
     { context: Dune_env.Stanza.t option
     ; workspace: Dune_env.Stanza.t option
     }

--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -11,7 +11,7 @@ module Stanza = struct
     { flags          : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags   : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags : Ordered_set_lang.Unexpanded.t
-    ; env_vars       : Env.t
+    ; env_vars       : String_with_vars.t String.Map.t
     ; binaries       : File_bindings.Unexpanded.t
     }
 
@@ -27,11 +27,12 @@ module Stanza = struct
   let env_vars_field =
     field
     "env-vars"
-      ~default:Env.empty
+      ~default:String.Map.empty
       (Syntax.since Stanza.syntax (1, 5) >>>
-       located (list (pair string string)) >>| fun (loc, pairs) ->
-       match Env.Map.of_list pairs with
-       | Ok vars -> Env.extend Env.empty ~vars
+       located (list (pair string String_with_vars.decode))
+       >>| fun (loc, pairs) ->
+       match String.Map.of_list pairs with
+       | Ok vars -> vars
        | Error (k, _, _) ->
          Errors.fail loc "Variable %s is specified several times" k)
 

--- a/src/dune_env.mli
+++ b/src/dune_env.mli
@@ -7,7 +7,7 @@ module Stanza : sig
     { flags          : Ordered_set_lang.Unexpanded.t
     ; ocamlc_flags   : Ordered_set_lang.Unexpanded.t
     ; ocamlopt_flags : Ordered_set_lang.Unexpanded.t
-    ; env_vars       : Env.t
+    ; env_vars       : String_with_vars.t String.Map.t
     ; binaries       : File_bindings.Unexpanded.t
     }
 

--- a/src/env_node.mli
+++ b/src/env_node.mli
@@ -15,7 +15,12 @@ val make
 
 val scope : t -> Scope.t
 
-val external_ : t -> profile:string -> default:Env.t -> Env.t
+val external_
+  :  t
+  -> profile:string
+  -> default:Env.t
+  -> expander:(dir:Path.t -> Expander.t)
+  -> Env.t
 
 val ocaml_flags : t -> profile:string -> expander:Expander.t -> Ocaml_flags.t
 


### PR DESCRIPTION
The idea is that when expanding the environment variables in the current node, we should still have access to all the variables already loaded in the parent directories.

This isn't working yet. We need a way to know when to stop when iterating through the parent directories. Unfortunately, the root build directory does not have a valid `Env_node` and hence we don't have a clean way to stop the recursion.
 
cc @nojb who has looked into having this feature