### PR TITLE
Ignore _esy in file watcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ next
 
 - Document virtual libraries (experimental) (#1580, @rgrinberg)
 
+- Exclude the local esy directory (`_esy`) from the list of watched
+  directories (#1578, @andreypopp)
+
 1.5.1 (7/11/2018)
 -----------------
 

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -188,6 +188,7 @@ end = struct
     lazy (
       let excludes = [ {|/_build|}
                      ; {|/_opam|}
+                     ; {|/_esy|}
                      ; {|/\..+|}
                      ; {|~$|}
                      ; {|/#[^#]*#$|}


### PR DESCRIPTION
Similarly to how dune ignores `_opam` dir this commit makes it ignore `_esy` dir. This is related to #1578.