### PR TITLE
Fix documentation rst errors

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -32,6 +32,8 @@ jbuild_version
 Deprecated. This stanza is no longer used and will be removed in the
 future.
 
+.. _library:
+
 library
 -------
 
@@ -314,7 +316,7 @@ compilation is not available.
 
 ``<binary-kind>`` is one of:
 
-= ``c`` for producing OCaml bytecode embedded in a C file
+- ``c`` for producing OCaml bytecode embedded in a C file
 - ``exe`` for normal executables
 - ``object`` for producing static object files that can be manually
   linked into C applications
@@ -609,6 +611,8 @@ from the opam file using a ``build-test`` field, then all your ``runtest`` alias
 stanzas should have a ``(package ...)`` field in order to partition the set of
 tests.
 
+.. _install:
+
 install
 -------
 
@@ -802,7 +806,7 @@ Fields supported in ``<settings>`` are:
   be inferred from the basename of ``<filepath>`` by dropping the ``.exe``
   suffix if it exists.
 
-.. dune-subdirs:
+.. _dune-subdirs:
 
 subdirs (since 1.6)
 -------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -41,7 +41,7 @@ However, the dune-release_ project is specifically designed for releasing dune
 projects to opam. We recommend using tool for publishing dune packages.
 
 Where can I find some examples of projects using dune?
-=====================================================
+======================================================
 
 The dune-universe_ repository contains a snapshot of the latest versions of all
 opam packages depending on dune. It is therefore a useful reference to

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -74,16 +74,18 @@ build. Note that this method can be used to build other things, not
 just C libraries.
 
 To do that, follow the following procedure:
+
 - put all the foreign code in a sub-directory
 - tell Dune not to interpret configuration files in this directory via
   an :ref:`ignored_subdirs <dune-ignored_subdirs>` stanza
 - write a custom rule that:
-  + depend on this directory recursively via :ref:`source_tree`
-  + invoke the external build system
-  + copy the C archive files (``.a``, ``.so``, ...) in main library
+
+  - depend on this directory recursively via :ref:`source_tree <source_tree>`
+  - invoke the external build system
+  - copy the C archive files (``.a``, ``.so``, ...) in main library
     directory with a specific names (see bellow)
 - *attach* the C archive files to an OCaml library via the
-  :ref:`self_build_stubs_archive` field
+  :ref:`self_build_stubs_archive <self_build_stubs_archive>` field
 
 For instance, let's assume that you want to build a C library
 ``libfoo`` using ``libfoo``'s own build system and attach it to an


### PR DESCRIPTION
 - Add missing labels for `library` and `install`
 - Add missing `_` for `dune-subdirs` label
 - Extend underline for one of the headers
 - Add required duplication of link target when the label isn't a
   section header
 - Fix list markers to consistently use `-` and have the right amount
   of whitespace surrounding them

Signed-off-by: Brendan Long <self@brendanlong.com>