### PR TITLE
Parser cleanups

### DIFF
--- a/test/blackbox-tests/test-cases/github1560/run.t
+++ b/test/blackbox-tests/test-cases/github1560/run.t
@@ -21,4 +21,4 @@ Testing in presence of an `ignored_subdirs` stanza:
   File "dune", line 1, characters 17-23:
   1 | (ignored_subdirs (blah))
                        ^^^^^^
-  Warning: ignored_subdirs is deprecated in 1.6.Use subdirs to specify visibile directories or data_only_dirs for ignoring only dune files.
+  Warning: ignored_subdirs is deprecated in 1.6. Use dirs to specify visible directories or data_only_dirs for ignoring only dune files.


### PR DESCRIPTION
Mainly a re-organization by giving the various types their own values. We should be able to move some of their helper functions to these modules.