### PR TITLE
Install all-deps files for virtual libraries

### DIFF
--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -191,10 +191,8 @@ module Gen(P : Params) = struct
               [ Module.obj_file m ~obj_dir ~ext:ctx.ext_obj ]
           ; if_ (virtual_library && Module.is_public m
                  && not (Lib_modules.is_alias_module lib_modules m))
-              (List.filter_map [Ml_kind.Intf; Impl] ~f:(fun kind ->
-                 Module.file m kind
-                 |> Option.map ~f:(fun f ->
-                   Path.relative obj_dir (Path.basename f ^ ".all-deps"))))
+              (List.filter_map [Ml_kind.Intf; Impl]
+                 ~f:(Module.all_deps m ~obj_dir))
           ; List.filter_map Ml_kind.all ~f:(Module.cmt_file m ~obj_dir)
           ])
     in

--- a/src/lib_modules.ml
+++ b/src/lib_modules.ml
@@ -145,6 +145,11 @@ module Alias_module = struct
     }
 end
 
+let is_alias_module t m =
+  match t.alias_module with
+  | None -> false
+  | Some m' -> Module.Name.equal (Module.name m') (Module.name m)
+
 let alias t =
   match t.alias_module, t.main_module_name with
   | None, None -> None

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -9,6 +9,8 @@ module Alias_module : sig
     }
 end
 
+val is_alias_module : t -> Module.t -> bool
+
 val alias : t -> Alias_module.t option
 
 val alias_module : t -> Module.t option

--- a/src/module.ml
+++ b/src/module.ml
@@ -29,6 +29,8 @@ module Name = struct
   module Top_closure = Top_closure.String
   module Infix = Comparable.Operators(T)
 
+  let equal = Infix.(=)
+
   let of_local_lib_name s =
     of_string (Lib_name.Local.to_string s)
 end

--- a/src/module.ml
+++ b/src/module.ml
@@ -171,6 +171,10 @@ let cmt_file t ~obj_dir (kind : Ml_kind.t) =
   | Impl -> Option.map t.impl ~f:(fun _ -> obj_file t ~obj_dir ~ext:".cmt" )
   | Intf -> Option.map t.intf ~f:(fun _ -> obj_file t ~obj_dir ~ext:".cmti")
 
+let all_deps t ~obj_dir (kind : Ml_kind.t) =
+  Option.map (file t kind) ~f:(fun f ->
+    Path.relative obj_dir (Path.basename f ^ ".all-deps"))
+
 let odoc_file t ~doc_dir = obj_file t ~obj_dir:doc_dir~ext:".odoc"
 
 let cmti_file t ~obj_dir =

--- a/src/module.mli
+++ b/src/module.mli
@@ -15,6 +15,8 @@ module Name : sig
 
   val uncapitalize : t -> string
 
+  val equal : t -> t -> bool
+
   val pp : Format.formatter -> t -> unit
   val pp_quote : Format.formatter -> t -> unit
 

--- a/src/module.mli
+++ b/src/module.mli
@@ -72,6 +72,7 @@ val file      : t -> Ml_kind.t -> Path.t option
 val cm_source : t -> Cm_kind.t -> Path.t option
 val cm_file   : t -> obj_dir:Path.t -> Cm_kind.t -> Path.t option
 val cmt_file  : t -> obj_dir:Path.t -> Ml_kind.t -> Path.t option
+val all_deps  : t -> obj_dir:Path.t -> Ml_kind.t -> Path.t option
 
 val obj_file : t -> obj_dir:Path.t -> ext:string -> Path.t
 

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -313,15 +313,9 @@ let rules_for_auxiliary_module cctx (m : Module.t) =
 
 let graph_of_remote_lib ~obj_dir ~modules =
   let deps_of unit ~ml_kind =
-    match Module.file unit ml_kind with
+    match Module.all_deps unit ~obj_dir ml_kind with
     | None -> Build.return []
-    | Some file ->
-      let file_in_obj_dir ~suffix file =
-        let base = Path.basename file in
-        Path.relative obj_dir (base ^ suffix)
-      in
-      let all_deps_path file = file_in_obj_dir file ~suffix:".all-deps" in
-      let all_deps_file = all_deps_path file in
+    | Some all_deps_file ->
       Build.memoize (Path.to_string all_deps_file)
         (Build.lines_of all_deps_file
          >>^ parse_module_names ~unit ~modules

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -51,10 +51,8 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       copy_obj_file m (Cm_kind.ext Cmi);
       if Module.is_public m then
         List.iter [Intf; Impl] ~f:(fun kind ->
-          Module.file m kind
-          |> Option.iter ~f:(fun f ->
-            Path.relative obj_dir (Path.basename f ^ ".all-deps")
-            |> copy_to_obj_dir ~obj_dir:(target_obj_dir m))
+          Module.all_deps m ~obj_dir kind
+          |> Option.iter ~f:(copy_to_obj_dir ~obj_dir:(target_obj_dir m))
         );
       if Module.has_impl m then begin
         if modes.byte then

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -168,6 +168,7 @@ Install files for implemenations and virtual libs have all the artifacts:
   lib: [
     "_build/install/default/lib/vlib/META" {"META"}
     "_build/install/default/lib/vlib/foo.mli" {"foo.mli"}
+    "_build/install/default/lib/vlib/foo.mli.all-deps" {"foo.mli.all-deps"}
     "_build/install/default/lib/vlib/opam" {"opam"}
     "_build/install/default/lib/vlib/vlib.cmi" {"vlib.cmi"}
     "_build/install/default/lib/vlib/vlib.cmt" {"vlib.cmt"}


### PR DESCRIPTION
These are necessary to rebuild the compilation graph for implementations. It's probably not necessary to go via the file to do this, but it does keep the code simpler as we don't know have to keep a separate code path for local and external virtual libraries. Once we get rid of all the copying, I'm thinking that this will go away as well.