### PR TITLE
Introduce vlib implementation module

### DIFF
--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -62,7 +62,7 @@ type t =
   ; no_keep_locs         : bool
   ; opaque               : bool
   ; stdlib               : Dune_file.Library.Stdlib.t option
-  ; modules_of_vlib      : Module.Name_map.t
+  ; vimpl                : Vimpl.t option
   }
 
 let super_context        t = t.super_context
@@ -82,12 +82,12 @@ let preprocessing        t = t.preprocessing
 let no_keep_locs         t = t.no_keep_locs
 let opaque               t = t.opaque
 let stdlib               t = t.stdlib
-let modules_of_vlib      t = t.modules_of_vlib
+let vimpl                t = t.vimpl
 
 let context              t = Super_context.context t.super_context
 
 let create ~super_context ~scope ~expander ~dir ?private_obj_dir
-      ?(modules_of_vlib=Module.Name.Map.empty)
+      ?vimpl
       ?(dir_kind=Dune_lang.Syntax.Dune)
       ?(obj_dir=dir) ~modules ?alias_module ?lib_interface_module ~flags
       ~requires ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
@@ -109,7 +109,7 @@ let create ~super_context ~scope ~expander ~dir ?private_obj_dir
   ; no_keep_locs
   ; opaque
   ; stdlib
-  ; modules_of_vlib
+  ; vimpl
   }
 
 let for_alias_module t =

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -19,7 +19,7 @@ val create
   -> expander              : Expander.t
   -> dir                   : Path.t
   -> ?private_obj_dir      : Path.t
-  -> ?modules_of_vlib      : Module.Name_map.t
+  -> ?vimpl                : Vimpl.t
   -> ?dir_kind             : Dune_lang.Syntax.t
   -> ?obj_dir              : Path.t
   -> modules               : Module.t Module.Name.Map.t
@@ -56,8 +56,7 @@ val no_keep_locs         : t -> bool
 val opaque               : t -> bool
 val stdlib               : t -> Dune_file.Library.Stdlib.t option
 
-(** Modules of the virtual library. Non-empty only for implementations of
-    virtual libs *)
-val modules_of_vlib      : t -> Module.Name_map.t
+(** Information for implementation of virtual libraries. *)
+val vimpl                : t -> Vimpl.t option
 
 val for_wrapped_compat : t -> Module.t Module.Name.Map.t -> t

--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -1,0 +1,141 @@
+open! Stdune
+open Import
+open Build.O
+
+type t =
+  { dir        : Path.t
+  ; per_module : (Module.t * (unit, Module.t list) Build.t) Module.Name.Map.t
+  }
+
+let make ~dir ~per_module = { dir ; per_module }
+
+let deps_of t (m : Module.t) =
+  let name = Module.name m in
+  match Module.Name.Map.find t.per_module name with
+  | Some (_, x) -> x
+  | None ->
+    Exn.code_error "Ocamldep.Dep_graph.deps_of"
+      [ "dir", Path.to_sexp t.dir
+      ; "modules", Sexp.Encoder.(list Module.Name.to_sexp)
+                     (Module.Name.Map.keys t.per_module)
+      ; "module", Module.Name.to_sexp name
+      ]
+
+let pp_cycle fmt cycle =
+  (Fmt.list ~pp_sep:Fmt.nl (Fmt.prefix (Fmt.string "-> ") Module.Name.pp))
+    fmt (List.map cycle ~f:Module.name)
+
+let top_closed t modules =
+  Module.Name.Map.to_list t.per_module
+  |> List.map ~f:(fun (unit, (_module, deps)) ->
+    deps >>^ fun deps -> (unit, deps))
+  |> Build.all
+  >>^ fun per_module ->
+  let per_module = Module.Name.Map.of_list_exn per_module in
+  match
+    Module.Name.Top_closure.top_closure modules
+      ~key:Module.name
+      ~deps:(fun m ->
+        Module.name m
+        |> Module.Name.Map.find per_module
+        |> Option.value_exn)
+  with
+  | Ok modules -> modules
+  | Error cycle ->
+    die "dependency cycle between modules in %s:\n   %a"
+      (Path.to_string t.dir)
+      pp_cycle cycle
+
+module Multi = struct
+  let top_closed_multi (ts : t list) modules =
+    List.concat_map ts ~f:(fun t ->
+      Module.Name.Map.to_list t.per_module
+      |> List.map ~f:(fun (_name, (unit, deps)) ->
+        deps >>^ fun deps -> (unit, deps)))
+    |> Build.all >>^ fun per_module ->
+    let per_obj =
+      Module.Obj_map.of_list_reduce per_module ~f:List.rev_append in
+    match Module.Obj_map.top_closure per_obj modules with
+    | Ok modules -> modules
+    | Error cycle ->
+      die "dependency cycle between modules\n   %a"
+        pp_cycle cycle
+end
+
+let make_top_closed_implementations ~name ~f ts modules =
+  Build.memoize name (
+    let filter_out_intf_only = List.filter ~f:Module.has_impl in
+    f ts (filter_out_intf_only modules)
+    >>^ filter_out_intf_only)
+
+let top_closed_multi_implementations =
+  make_top_closed_implementations
+    ~name:"top sorted multi implementations" ~f:Multi.top_closed_multi
+
+let top_closed_implementations =
+  make_top_closed_implementations
+    ~name:"top sorted implementations" ~f:top_closed
+
+let dummy (m : Module.t) =
+  { dir = Path.root
+  ; per_module =
+      Module.Name.Map.singleton (Module.name m) (m, (Build.return []))
+  }
+
+let wrapped_compat ~modules ~wrapped_compat =
+  { dir = Path.root
+  ; per_module = Module.Name.Map.merge wrapped_compat modules ~f:(fun _ d m ->
+      match d, m with
+      | None, None -> assert false
+      | Some wrapped_compat, None ->
+        Exn.code_error "deprecated module needs counterpart"
+          [ "deprecated", Module.to_sexp wrapped_compat
+          ]
+      | None, Some _ -> None
+      | Some _, Some m -> Some (m, (Build.return [m]))
+    )
+  }
+
+module Ml_kind = struct
+  type nonrec t = t Ml_kind.Dict.t
+
+  let dummy m =
+    Ml_kind.Dict.make_both (dummy m)
+
+  let wrapped_compat =
+    let w = wrapped_compat in
+    fun ~modules ~wrapped_compat ->
+      Ml_kind.Dict.make_both (w ~modules ~wrapped_compat)
+
+  let merge_impl ~(ml_kind : Ml_kind.t) _ vlib impl =
+    match vlib, impl with
+    | None, None -> assert false
+    | Some _, None -> None (* we don't care about internal vlib deps *)
+    | None, Some d -> Some d
+    | Some (mv, _), Some (mi, i) ->
+      if Module.obj_name mv = Module.obj_name mi
+      && Module.intf_only mv
+      && Module.impl_only mi then
+        match ml_kind with
+        | Impl -> Some (mi, i)
+        | Intf -> None
+      else if Module.is_private mv || Module.is_private mi then
+        Some (mi, i)
+      else
+        let open Sexp.Encoder in
+        Exn.code_error "merge_impl: unexpected dep graph"
+          [ "ml_kind", string (Ml_kind.to_string ml_kind)
+          ; "mv", Module.to_sexp mv
+          ; "mi", Module.to_sexp mi
+          ]
+
+  let merge_for_impl ~(vlib : t) ~(impl : t) =
+    Ml_kind.Dict.of_func (fun ~ml_kind ->
+      let impl = Ml_kind.Dict.get impl ml_kind in
+      { impl with
+        per_module =
+          Module.Name.Map.merge ~f:(merge_impl ~ml_kind)
+            (Ml_kind.Dict.get vlib ml_kind).per_module
+            impl.per_module
+      })
+end

--- a/src/dep_graph.mli
+++ b/src/dep_graph.mli
@@ -1,0 +1,39 @@
+(** Represent dependency graphs between OCaml modules *)
+
+open Stdune
+
+type t
+
+val make
+  :  dir:Path.t
+  -> per_module:(Module.t * (unit, Module.t list) Build.t) Module.Name.Map.t
+  -> t
+
+val deps_of
+  :  t
+  -> Module.t
+  -> (unit, Module.t list) Build.t
+
+val top_closed_implementations
+  :  t
+  -> Module.t list
+  -> (unit, Module.t list) Build.t
+
+val top_closed_multi_implementations
+  :  t list
+  -> Module.t list
+  -> (unit, Module.t list) Build.t
+
+
+module Ml_kind : sig
+  type nonrec t = t Ml_kind.Dict.t
+
+  val dummy : Module.t -> t
+
+  val wrapped_compat
+    :  modules:Module.t Module.Name.Map.t
+    -> wrapped_compat:Module.t Module.Name.Map.t
+    -> t
+
+  val merge_for_impl : vlib:t -> impl:t -> t
+end

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -198,7 +198,7 @@ let build_and_link_many
     let top_sorted_modules =
       let main = Option.value_exn
                    (Module.Name.Map.find (CC.modules cctx) main_module_name) in
-      Ocamldep.Dep_graph.top_closed_implementations dep_graphs.impl
+      Dep_graph.top_closed_implementations dep_graphs.impl
         [main]
     in
     let arg_spec_for_requires =

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -17,8 +17,6 @@ module Gen (P : Install_rules.Params) = struct
 
   let opaque = SC.opaque sctx
 
-  module Virtual = Virtual_rules.Gen(P)
-
   (* Library stuff *)
 
   let msvc_hack_cclibs =
@@ -428,8 +426,8 @@ module Gen (P : Install_rules.Params) = struct
     if Lib_modules.has_private_modules lib_modules then
       Check_rules.add_obj_dir sctx ~dir ~obj_dir:private_obj_dir;
     let source_modules = Lib_modules.modules lib_modules in
-    let vimpl = Virtual.impl ~lib ~scope ~modules:source_modules in
-    Option.iter vimpl ~f:(Virtual.setup_copy_rules_for_impl ~dir);
+    let vimpl = Virtual_rules.impl sctx ~lib ~scope ~modules:source_modules in
+    Option.iter vimpl ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir);
     (* Preprocess before adding the alias module as it doesn't need
        preprocessing *)
     let pp =

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -58,7 +58,7 @@ let libraries_link ~name ~loc ~mode cctx libs =
         ())
     in
     Module_compilation.build_module
-      ~dep_graphs:(Ocamldep.Dep_graphs.dummy module_)
+      ~dep_graphs:(Dep_graph.Ml_kind.dummy module_)
       cctx
       module_;
     let lm = (of_libs before)@[Lib.Lib_and_module.Module (module_,obj_dir)]@(of_libs after) in

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -11,7 +11,7 @@ val build_module
   :  ?sandbox:bool
   -> ?js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> ?dynlink:bool
-  -> dep_graphs:Ocamldep.Dep_graphs.t
+  -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> Module.t
   -> unit
@@ -21,14 +21,14 @@ val build_modules
   :  ?sandbox:bool
   -> ?js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> ?dynlink:bool
-  -> dep_graphs:Ocamldep.Dep_graphs.t
+  -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> unit
 
 val ocamlc_i
   :  ?sandbox:bool
   -> ?flags:string list
-  -> dep_graphs:Ocamldep.Dep_graphs.t
+  -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> Module.t
   -> output:Path.t

--- a/src/ocamldep.mli
+++ b/src/ocamldep.mli
@@ -2,49 +2,17 @@
 
 open Stdune
 
-module Dep_graph : sig
-  type t
-
-  val deps_of
-    :  t
-    -> Module.t
-    -> (unit, Module.t list) Build.t
-
-  val top_closed_implementations
-    :  t
-    -> Module.t list
-    -> (unit, Module.t list) Build.t
-
-  val top_closed_multi_implementations
-    :  t list
-    -> Module.t list
-    -> (unit, Module.t list) Build.t
-end
-
-module Dep_graphs : sig
-  type t = Dep_graph.t Ml_kind.Dict.t
-
-  val dummy : Module.t -> t
-
-  val wrapped_compat
-    :  modules:Module.t Module.Name.Map.t
-    -> wrapped_compat:Module.t Module.Name.Map.t
-    -> t
-
-  val merge_for_impl : vlib:t -> impl:t -> t
-end
-
 (** Generate ocamldep rules for all the modules in the context. *)
-val rules : Compilation_context.t -> Dep_graphs.t
+val rules : Compilation_context.t -> Dep_graph.Ml_kind.t
 
 (** Compute the dependencies of an auxiliary module. *)
 val rules_for_auxiliary_module
   :  Compilation_context.t
   -> Module.t
-  -> Dep_graphs.t
+  -> Dep_graph.Ml_kind.t
 
 (** Get the dep graph for an already defined library *)
 val graph_of_remote_lib
   :  obj_dir:Path.t
   -> modules:Module.t Module.Name.Map.t
-  -> Dep_graph.t Ml_kind.Dict.t
+  -> Dep_graph.Ml_kind.t

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -112,12 +112,12 @@ module Gen (S : sig val sctx : SC.t end) = struct
     let odoc_input t = t
   end
 
-  let module_deps (m : Module.t) ~doc_dir ~(dep_graphs:Ocamldep.Dep_graphs.t) =
+  let module_deps (m : Module.t) ~doc_dir ~(dep_graphs:Dep_graph.Ml_kind.t) =
     (if Module.has_intf m then
-       Ocamldep.Dep_graph.deps_of dep_graphs.intf m
+       Dep_graph.deps_of dep_graphs.intf m
      else
        (* When a module has no .mli, use the dependencies for the .ml *)
-       Ocamldep.Dep_graph.deps_of dep_graphs.impl m)
+       Dep_graph.deps_of dep_graphs.impl m)
     >>^ List.map ~f:(Module.odoc_file ~doc_dir)
     |> Build.dyn_paths
 
@@ -198,7 +198,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
   let toplevel_index = Paths.html_root ++ "index.html"
 
   let setup_library_odoc_rules (library : Library.t) ~scope ~modules
-        ~requires ~(dep_graphs:Ocamldep.Dep_graph.t Ml_kind.Dict.t) =
+        ~requires ~(dep_graphs:Dep_graph.Ml_kind.t) =
     let lib =
       Option.value_exn (Lib.DB.find_even_when_hidden (Scope.libs scope)
                           (Library.best_name library)) in

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -11,7 +11,7 @@ module Gen (S : sig val sctx : Super_context.t end) : sig
     -> scope:Scope.t
     -> modules:Module.t Module.Name.Map.t
     -> requires:Lib.t list Or_exn.t
-    -> dep_graphs:Ocamldep.Dep_graphs.t
+    -> dep_graphs:Dep_graph.Ml_kind.t
     -> unit
 
   val init : unit -> unit

--- a/src/vimpl.ml
+++ b/src/vimpl.ml
@@ -1,0 +1,63 @@
+open! Stdune
+
+type t =
+  { vlib            : Lib.t
+  ; impl            : Dune_file.Library.t
+  ; vlib_modules    : Lib_modules.t
+  ; vlib_dep_graph  : Dep_graph.Ml_kind.t
+  }
+
+let vlib_modules t = t.vlib_modules
+
+let vlib_dep_graph t = t.vlib_dep_graph
+
+let add_vlib_modules t modules =
+  match t with
+  | None -> modules
+  | Some t ->
+    Module.Name.Map.superpose (Lib_modules.modules t.vlib_modules) modules
+
+let is_public_vlib_module t m =
+  match t with
+  | None -> false
+  | Some { vlib_modules ; _ } ->
+    let modules = Lib_modules.modules vlib_modules in
+    begin match Module.Name.Map.find modules (Module.name m) with
+    | None -> false
+    | Some m -> Module.is_public m
+    end
+
+let impl_only = function
+  | None -> []
+  | Some t ->
+    t.vlib_modules |> Lib_modules.modules |> Module.Name_map.impl_only
+
+let aliased_modules t modules =
+  match t with
+  | None -> modules
+  | Some t ->
+    let vlib_modules = Lib_modules.modules t.vlib_modules in
+    Module.Name.Map.merge modules vlib_modules ~f:(fun _ impl vlib ->
+      match impl, vlib with
+      | None, None -> assert false
+      | Some _, (None | Some _) -> impl
+      | _, Some vlib -> Option.some_if (Module.is_public vlib) vlib)
+
+let find_module t m =
+  match t with
+  | None -> None
+  | Some t ->
+    Module.name m
+    |> Module.Name.Map.find (Lib_modules.modules t.vlib_modules)
+
+let vlib_stubs_o_files = function
+  | None -> []
+  | Some t -> Lib.foreign_objects t.vlib
+
+let for_file_deps t modules =
+  match t with
+  | None -> modules
+  | Some t ->
+    Lib_modules.for_compilation t.vlib_modules
+    |> Module.Name.Map.values
+    |> List.rev_append modules

--- a/src/vimpl.mli
+++ b/src/vimpl.mli
@@ -1,0 +1,29 @@
+(** Extra information required to generate rules for virtual library
+    implementations *)
+
+open Stdune
+
+type t =
+  { vlib            : Lib.t
+  ; impl            : Dune_file.Library.t
+  ; vlib_modules    : Lib_modules.t
+  ; vlib_dep_graph  : Dep_graph.Ml_kind.t
+  }
+
+val vlib_dep_graph : t -> Dep_graph.Ml_kind.t
+
+val vlib_modules : t -> Lib_modules.t
+
+val is_public_vlib_module : t option -> Module.t -> bool
+
+val add_vlib_modules : t option -> Module.Name_map.t -> Module.Name_map.t
+
+val impl_only : t option -> Module.t list
+
+val aliased_modules : t option -> Module.Name_map.t -> Module.Name_map.t
+
+val find_module : t option -> Module.t -> Module.t option
+
+val vlib_stubs_o_files : t option -> Path.t list
+
+val for_file_deps : t option -> Module.t list -> Module.t list

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -1,162 +1,158 @@
 open Import
 open! No_io
 
-module Gen (P : sig val sctx : Super_context.t end) = struct
-  open P
-  let ctx = Super_context.context sctx
-
-  let setup_copy_rules_for_impl ~dir
-        ({ Vimpl.vlib ; impl ; vlib_modules ; vlib_dep_graph = _ }) =
-    let lib_name = snd impl.name in
-    let target_obj_dir =
-      let obj_dir = Utils.library_object_directory ~dir lib_name in
-      let private_obj_dir = Utils.library_private_obj_dir ~obj_dir in
-      fun m ->
-        if Module.is_public m then
-          obj_dir
-        else
-          private_obj_dir
-    in
-    let copy_to_obj_dir ~obj_dir file =
-      let dst = Path.relative obj_dir (Path.basename file) in
-      Super_context.add_rule ~dir ~loc:(Loc.of_pos __POS__)
-        sctx (Build.symlink ~src:file ~dst)
-    in
-    let obj_dir = Lib.obj_dir vlib in
-    let modes =
-      Dune_file.Mode_conf.Set.eval impl.modes
-        ~has_native:(Option.is_some ctx.ocamlopt) in
-    let copy_obj_file m ext =
-      let source = Module.obj_file m ~obj_dir ~ext in
-      copy_to_obj_dir ~obj_dir:(target_obj_dir m) source in
-    let copy_module m =
-      copy_obj_file m (Cm_kind.ext Cmi);
+let setup_copy_rules_for_impl ~sctx ~dir
+      ({ Vimpl.vlib ; impl ; vlib_modules ; vlib_dep_graph = _ }) =
+  let ctx = Super_context.context sctx in
+  let lib_name = snd impl.name in
+  let target_obj_dir =
+    let obj_dir = Utils.library_object_directory ~dir lib_name in
+    let private_obj_dir = Utils.library_private_obj_dir ~obj_dir in
+    fun m ->
       if Module.is_public m then
-        List.iter [Intf; Impl] ~f:(fun kind ->
-          Module.file m kind
-          |> Option.iter ~f:(fun f ->
-            Path.relative obj_dir (Path.basename f ^ ".all-deps")
-            |> copy_to_obj_dir ~obj_dir:(target_obj_dir m))
-        );
-      if Module.has_impl m then begin
-        if modes.byte then
-          copy_obj_file m (Cm_kind.ext Cmo);
-        if modes.native then
-          List.iter [Cm_kind.ext Cmx; ctx.ext_obj] ~f:(copy_obj_file m)
-      end
-    in
-    let copy_alias_module m =
-      copy_obj_file m (Cm_kind.ext Cmi);
+        obj_dir
+      else
+        private_obj_dir
+  in
+  let copy_to_obj_dir ~obj_dir file =
+    let dst = Path.relative obj_dir (Path.basename file) in
+    Super_context.add_rule ~dir ~loc:(Loc.of_pos __POS__)
+      sctx (Build.symlink ~src:file ~dst)
+  in
+  let obj_dir = Lib.obj_dir vlib in
+  let modes =
+    Dune_file.Mode_conf.Set.eval impl.modes
+      ~has_native:(Option.is_some ctx.ocamlopt) in
+  let copy_obj_file m ext =
+    let source = Module.obj_file m ~obj_dir ~ext in
+    copy_to_obj_dir ~obj_dir:(target_obj_dir m) source in
+  let copy_module m =
+    copy_obj_file m (Cm_kind.ext Cmi);
+    if Module.is_public m then
       List.iter [Intf; Impl] ~f:(fun kind ->
         Module.file m kind
-        |> Option.iter ~f:(copy_to_obj_dir ~obj_dir:(target_obj_dir m))
+        |> Option.iter ~f:(fun f ->
+          Path.relative obj_dir (Path.basename f ^ ".all-deps")
+          |> copy_to_obj_dir ~obj_dir:(target_obj_dir m))
       );
+    if Module.has_impl m then begin
       if modes.byte then
         copy_obj_file m (Cm_kind.ext Cmo);
       if modes.native then
         List.iter [Cm_kind.ext Cmx; ctx.ext_obj] ~f:(copy_obj_file m)
-    in
-    Option.iter (Lib_modules.alias_module vlib_modules) ~f:copy_alias_module;
-    Module.Name.Map.iter (Lib_modules.modules vlib_modules) ~f:copy_module
+    end
+  in
+  let copy_alias_module m =
+    copy_obj_file m (Cm_kind.ext Cmi);
+    List.iter [Intf; Impl] ~f:(fun kind ->
+      Module.file m kind
+      |> Option.iter ~f:(copy_to_obj_dir ~obj_dir:(target_obj_dir m))
+    );
+    if modes.byte then
+      copy_obj_file m (Cm_kind.ext Cmo);
+    if modes.native then
+      List.iter [Cm_kind.ext Cmx; ctx.ext_obj] ~f:(copy_obj_file m)
+  in
+  Option.iter (Lib_modules.alias_module vlib_modules) ~f:copy_alias_module;
+  Module.Name.Map.iter (Lib_modules.modules vlib_modules) ~f:copy_module
 
-  let module_list ms =
-    List.map ms ~f:(fun m -> sprintf "- %s" (Module.Name.to_string m))
-    |> String.concat ~sep:"\n"
+let module_list ms =
+  List.map ms ~f:(fun m -> sprintf "- %s" (Module.Name.to_string m))
+  |> String.concat ~sep:"\n"
 
-  let check_module_fields ~(lib : Dune_file.Library.t) ~virtual_modules
-        ~modules ~implements =
-    let new_public_modules =
-      Module.Name.Map.foldi modules ~init:[] ~f:(fun name m acc ->
-        if Module.is_public m
-        && not (Module.Name.Map.mem virtual_modules name) then
-          name :: acc
-        else
-          acc)
-    in
-    if new_public_modules <> [] then begin
-      Errors.fail lib.buildable.loc
-        "The following modules aren't part of the virtual library's interface:\
-         \n%s\n\
-         They must be marked as private using the (private_modules ..) field"
-        (module_list new_public_modules)
-    end;
-    let (missing_modules, impl_modules_with_intf, private_virtual_modules) =
-      Module.Name.Map.foldi virtual_modules ~init:([], [], [])
-        ~f:(fun m _ (mms, ims, pvms) ->
-          match Module.Name.Map.find modules m with
-          | None -> (m :: mms, ims, pvms)
-          | Some m ->
-            let ims =
-              if Module.has_intf m then
-                Module.name m :: ims
-              else
-                ims
-            in
-            let pvms =
-              if Module.is_public m then
-                pvms
-              else
-                Module.name m :: pvms
-            in
-            (mms, ims, pvms))
-    in
-    if private_virtual_modules <> [] then begin
-      (* The loc here will never be none as we've some private modules *)
-      Errors.fail_opt (Option.bind lib.private_modules ~f:Ordered_set_lang.loc)
-        "These private modules cannot be private:\n%s"
-        (module_list private_virtual_modules)
-    end;
-    if missing_modules <> [] then begin
-      Errors.fail lib.buildable.loc
-        "Library %a cannot implement %a because the following \
-         modules lack an implementation:\n%s"
-        Lib_name.Local.pp (snd lib.name)
+let check_module_fields ~(lib : Dune_file.Library.t) ~virtual_modules
+      ~modules ~implements =
+  let new_public_modules =
+    Module.Name.Map.foldi modules ~init:[] ~f:(fun name m acc ->
+      if Module.is_public m
+      && not (Module.Name.Map.mem virtual_modules name) then
+        name :: acc
+      else
+        acc)
+  in
+  if new_public_modules <> [] then begin
+    Errors.fail lib.buildable.loc
+      "The following modules aren't part of the virtual library's interface:\
+       \n%s\n\
+       They must be marked as private using the (private_modules ..) field"
+      (module_list new_public_modules)
+  end;
+  let (missing_modules, impl_modules_with_intf, private_virtual_modules) =
+    Module.Name.Map.foldi virtual_modules ~init:([], [], [])
+      ~f:(fun m _ (mms, ims, pvms) ->
+        match Module.Name.Map.find modules m with
+        | None -> (m :: mms, ims, pvms)
+        | Some m ->
+          let ims =
+            if Module.has_intf m then
+              Module.name m :: ims
+            else
+              ims
+          in
+          let pvms =
+            if Module.is_public m then
+              pvms
+            else
+              Module.name m :: pvms
+          in
+          (mms, ims, pvms))
+  in
+  if private_virtual_modules <> [] then begin
+    (* The loc here will never be none as we've some private modules *)
+    Errors.fail_opt (Option.bind lib.private_modules ~f:Ordered_set_lang.loc)
+      "These private modules cannot be private:\n%s"
+      (module_list private_virtual_modules)
+  end;
+  if missing_modules <> [] then begin
+    Errors.fail lib.buildable.loc
+      "Library %a cannot implement %a because the following \
+       modules lack an implementation:\n%s"
+      Lib_name.Local.pp (snd lib.name)
+      Lib_name.pp implements
+      (module_list missing_modules)
+  end;
+  if impl_modules_with_intf <> [] then begin
+    Errors.fail lib.buildable.loc
+      "The following modules cannot have .mli files as they implement \
+       virtual modules:\n%s"
+      (module_list impl_modules_with_intf)
+  end
+
+let impl sctx ~(lib : Dune_file.Library.t) ~scope ~modules =
+  Option.map lib.implements ~f:begin fun (loc, implements) ->
+    match Lib.DB.find (Scope.libs scope) implements with
+    | Error _ ->
+      Errors.fail loc
+        "Cannot implement %a as that library isn't available"
         Lib_name.pp implements
-        (module_list missing_modules)
-    end;
-    if impl_modules_with_intf <> [] then begin
-      Errors.fail lib.buildable.loc
-        "The following modules cannot have .mli files as they implement \
-         virtual modules:\n%s"
-        (module_list impl_modules_with_intf)
-    end
-
-  let impl ~(lib : Dune_file.Library.t) ~scope ~modules =
-    Option.map lib.implements ~f:begin fun (loc, implements) ->
-      match Lib.DB.find (Scope.libs scope) implements with
-      | Error _ ->
-        Errors.fail loc
-          "Cannot implement %a as that library isn't available"
-          Lib_name.pp implements
-      | Ok vlib ->
-        let virtual_modules =
-          Option.map (Lib.virtual_ vlib) ~f:(fun (v : Lib_info.Virtual.t) ->
-            v.modules)
-        in
-        let vlib_modules =
-          match virtual_modules with
-          | None ->
-            Errors.fail lib.buildable.loc
-              "Library %a isn't virtual and cannot be implemented"
-              Lib_name.pp implements
-          | Some Unexpanded ->
-            let dir_contents =
-              Dir_contents.get sctx ~dir:(Lib.src_dir vlib) in
-            Dir_contents.modules_of_library dir_contents
-              ~name:(Lib.name vlib)
-        in
-        let virtual_modules = Lib_modules.virtual_modules vlib_modules in
-        check_module_fields ~lib ~virtual_modules ~modules ~implements;
-        let vlib_dep_graph =
-          let modules = Lib_modules.modules vlib_modules in
-          let obj_dir = Lib.obj_dir vlib in
-          Ocamldep.graph_of_remote_lib ~obj_dir ~modules
-        in
-        { Vimpl.
-          impl = lib
-        ; vlib
-        ; vlib_modules
-        ; vlib_dep_graph
-        }
-    end
-end
+    | Ok vlib ->
+      let virtual_modules =
+        Option.map (Lib.virtual_ vlib) ~f:(fun (v : Lib_info.Virtual.t) ->
+          v.modules)
+      in
+      let vlib_modules =
+        match virtual_modules with
+        | None ->
+          Errors.fail lib.buildable.loc
+            "Library %a isn't virtual and cannot be implemented"
+            Lib_name.pp implements
+        | Some Unexpanded ->
+          let dir_contents =
+            Dir_contents.get sctx ~dir:(Lib.src_dir vlib) in
+          Dir_contents.modules_of_library dir_contents
+            ~name:(Lib.name vlib)
+      in
+      let virtual_modules = Lib_modules.virtual_modules vlib_modules in
+      check_module_fields ~lib ~virtual_modules ~modules ~implements;
+      let vlib_dep_graph =
+        let modules = Lib_modules.modules vlib_modules in
+        let obj_dir = Lib.obj_dir vlib in
+        Ocamldep.graph_of_remote_lib ~obj_dir ~modules
+      in
+      { Vimpl.
+        impl = lib
+      ; vlib
+      ; vlib_modules
+      ; vlib_dep_graph
+      }
+  end

--- a/src/virtual_rules.mli
+++ b/src/virtual_rules.mli
@@ -1,14 +1,14 @@
 open Stdune
 
-module Gen (S : sig val sctx : Super_context.t end) : sig
-  val setup_copy_rules_for_impl
-    :  dir:Path.t
-    -> Vimpl.t
-    -> unit
+val setup_copy_rules_for_impl
+  :  sctx:Super_context.t
+  -> dir:Path.t
+  -> Vimpl.t
+  -> unit
 
-  val impl
-    :  lib:Dune_file.Library.t
-    -> scope:Scope.t
-    -> modules:Module.Name_map.t
-    -> Vimpl.t option
-end
+val impl
+  :  Super_context.t
+  -> lib:Dune_file.Library.t
+  -> scope:Scope.t
+  -> modules:Module.Name_map.t
+  -> Vimpl.t option

--- a/src/virtual_rules.mli
+++ b/src/virtual_rules.mli
@@ -1,24 +1,14 @@
 open Stdune
 
-module Implementation : sig
-  type t
-
-  val vlib_dep_graph : t -> Ocamldep.Dep_graphs.t
-
-  val vlib_modules : t -> Lib_modules.t
-end
-
 module Gen (S : sig val sctx : Super_context.t end) : sig
-  val vlib_stubs_o_files : Implementation.t -> Path.t list
-
   val setup_copy_rules_for_impl
     :  dir:Path.t
-    -> Implementation.t
+    -> Vimpl.t
     -> unit
 
   val impl
     :  lib:Dune_file.Library.t
     -> scope:Scope.t
     -> modules:Module.Name_map.t
-    -> Implementation.t option
+    -> Vimpl.t option
 end


### PR DESCRIPTION
In the old code, the fact that our virtual lib is local is assumed in too many places. I attempt to make this problem easier to address by introducing a `Vimpl` module that should encapsulate all that is necessary for transparently generating implementation rules; regardless of where/how the virtual lib lives.

Note that I had to split the ocamldep module to avoid cycles.