### PR TITLE
Add bench for file_tree cache

### DIFF
--- a/bench/file_tree_cache.ml
+++ b/bench/file_tree_cache.ml
@@ -5,15 +5,18 @@ open Dune
 
 let deep_path = "a1/a2/a3/a4/a5/a6/a7/a8/a9/10"
 
-let (ft, path) =
+let setup = lazy (
   let tmp = Path.External.of_string (Filename.get_temp_dir_name ()) in
   Path.External.mkdir_p (Path.External.relative tmp deep_path);
   Path.set_root tmp;
   Path.set_build_dir (Path.Kind.of_string "_build");
   let ft = (Dune_load.load ()).file_tree in
   let path = Path.of_string deep_path in
-  (ft, path)
+  at_exit (fun () -> Sys.remove "./dune-project");
+  (ft, path))
 
-let%bench "File_tree.find_dir" =
-  ignore (Sys.opaque_identity (File_tree.find_dir ft path)
-          : File_tree.Dir.t option)
+let%bench_fun "File_tree.find_dir" =
+  let (ft, path) = Lazy.force setup in
+  fun () ->
+    ignore (Sys.opaque_identity (File_tree.find_dir ft path)
+            : File_tree.Dir.t option)

--- a/bench/file_tree_cache.ml
+++ b/bench/file_tree_cache.ml
@@ -1,0 +1,19 @@
+(* Benchmark File_tree.t's internal cache *)
+
+open Stdune
+open Dune
+
+let deep_path = "a1/a2/a3/a4/a5/a6/a7/a8/a9/10"
+
+let (ft, path) =
+  let tmp = Path.External.of_string (Filename.get_temp_dir_name ()) in
+  Path.External.mkdir_p (Path.External.relative tmp deep_path);
+  Path.set_root tmp;
+  Path.set_build_dir (Path.Kind.of_string "_build");
+  let ft = (Dune_load.load ()).file_tree in
+  let path = Path.of_string deep_path in
+  (ft, path)
+
+let%bench "File_tree.find_dir" =
+  ignore (Sys.opaque_identity (File_tree.find_dir ft path)
+          : File_tree.Dir.t option)

--- a/bench/scheduler_bench.ml
+++ b/bench/scheduler_bench.ml
@@ -3,20 +3,23 @@
 open Stdune
 open Dune
 
-let () =
+let setup = lazy (
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string "_build")
+  Path.set_build_dir (Path.Kind.of_string "_build"))
 
 let prog =
   Option.value_exn (Bin.which ~path:(Env.path Env.initial) "true")
+
 let run () = Process.run ~env:Env.initial Strict prog []
 
 let go ~jobs fiber =
   Scheduler.go fiber ~config:{ Config.default with concurrency = Fixed jobs }
 
-let%bench "single" = go (run ()) ~jobs:1
+let%bench_fun "single" = Lazy.force setup; fun () -> go (run ()) ~jobs:1
 
 let l = List.init ~len:100 ~f:ignore
 
-let%bench "many" [@indexed jobs = [1; 2; 4; 8]] =
+let%bench_fun "many" [@indexed jobs = [1; 2; 4; 8]] =
+  Lazy.force setup;
+  fun () ->
   go ~jobs (Fiber.parallel_iter l ~f:run)

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -15,6 +15,10 @@ module External : sig
   val initial_cwd : t
 
   val cwd : unit -> t
+
+  val relative : t -> string -> t
+
+  val mkdir_p : t -> unit
 end
 
 module Kind : sig
@@ -163,7 +167,7 @@ val in_source : string -> t
 
 val of_local : Local.t -> t
 
-(** Set the workspace root. Can onyl be called once and the path must be
+(** Set the workspace root. Can only be called once and the path must be
     absolute *)
 val set_root : External.t -> unit
 


### PR DESCRIPTION
To run this benchmark, the scheduler benchmark must be commented. Should we include this in a separate benchmark executable perhaps?