### PR TITLE
Add ocamlobjinfo parser

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -14,7 +14,7 @@
  (preprocess  (action
                (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))
 
-(ocamllex meta_lexer glob_lexer dune_lexer)
+(ocamllex meta_lexer glob_lexer dune_lexer ocamlobjinfo)
 
 (rule
  (targets setup.ml)

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -113,6 +113,8 @@ end
 
 open O
 
+let map t ~f = t >>| f
+
 let both a b =
   a >>= fun x ->
   b >>= fun y ->

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -30,6 +30,8 @@ module O : sig
   val (>>|) : 'a t -> ('a -> 'b) -> 'b t
 end
 
+val map : 'a t -> f:('a -> 'b) -> 'b t
+
 (** {1 Forking execution} *)
 
 module Future : sig

--- a/src/ml_kind.ml
+++ b/src/ml_kind.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 type t = Impl | Intf
 
 let all = [Impl; Intf]
@@ -34,4 +36,10 @@ module Dict = struct
   let make_both x = { impl = x; intf = x }
 
   let map t ~f = { impl = f t.impl; intf = f t.intf }
+
+  let pp f fmt { impl; intf } =
+    Fmt.record fmt
+      [ "impl", Fmt.const f impl
+      ; "intf", Fmt.const f intf
+      ]
 end

--- a/src/ml_kind.mli
+++ b/src/ml_kind.mli
@@ -22,6 +22,8 @@ module Dict : sig
     ; intf : 'a
     }
 
+  val pp : 'a Fmt.t -> 'a t Fmt.t
+
   val get : 'a t -> kind -> 'a
 
   val of_func : (ml_kind:kind -> 'a) -> 'a t

--- a/src/module.ml
+++ b/src/module.ml
@@ -24,7 +24,9 @@ module Name = struct
   let pp = Format.pp_print_string
   let pp_quote fmt x = Format.fprintf fmt "%S" x
 
-  module Set = String.Set
+  module Set = struct
+    include String.Set
+  end
   module Map = String.Map
   module Top_closure = Top_closure.String
   module Infix = Comparable.Operators(T)

--- a/src/module.mli
+++ b/src/module.mli
@@ -18,7 +18,11 @@ module Name : sig
   val pp : Format.formatter -> t -> unit
   val pp_quote : Format.formatter -> t -> unit
 
-  module Set : Set.S with type elt = t
+  module Set : sig
+    include Set.S with type elt = t
+    val pp : t Fmt.t
+  end
+
   module Map : Map.S with type key = t
 
   module Top_closure : Top_closure.S with type key := t

--- a/src/ocamlobjinfo.mli
+++ b/src/ocamlobjinfo.mli
@@ -2,4 +2,5 @@ open Stdune
 
 type t = Module.Name.Set.t Ml_kind.Dict.t
 
+val pp : t Fmt.t
 val load : ocamlobjinfo:Path.t -> unit:Path.t -> t Fiber.t

--- a/src/ocamlobjinfo.mli
+++ b/src/ocamlobjinfo.mli
@@ -1,0 +1,5 @@
+open Stdune
+
+type t = Module.Name.Set.t Ml_kind.Dict.t
+
+val load : ocamlobjinfo:Path.t -> unit:Path.t -> t Fiber.t

--- a/src/ocamlobjinfo.mli
+++ b/src/ocamlobjinfo.mli
@@ -1,6 +1,11 @@
+(** Parse ocamlobjinfo output *)
 open Stdune
 
 type t = Module.Name.Set.t Ml_kind.Dict.t
 
 val pp : t Fmt.t
+
 val load : ocamlobjinfo:Path.t -> unit:Path.t -> t Fiber.t
+
+(** For testing only *)
+val parse : string -> t

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -20,8 +20,8 @@ let add_impl (t : t) i =
 
 let newline = '\r'? '\n'
 let ws = [' ' '\t']+
-let hash = ['0'-'9' 'a'-'z']+
-let name = ['A'-'Z'] ['a'-'z' '0'-'9' '_']*
+let hash = ['0'-'9' 'a'-'z' '-']+
+let name = ['A'-'Z'] ['A'-'Z' 'a'-'z' '0'-'9' '_']*
 
 rule ocamlobjinfo acc = parse
   | "Interfaces imported:" newline { intfs acc lexbuf }
@@ -37,6 +37,8 @@ and impls acc = parse
   | _ | eof { acc }
 
 {
+let parse s = ocamlobjinfo empty (Lexing.from_string s)
+
 let load ~ocamlobjinfo:bin ~unit =
   ["-no-approx"; "-no-code"; Path.to_absolute_filename unit]
   |> Process.run_capture ~env:Env.empty Process.Strict bin

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -3,6 +3,9 @@ open Stdune
 
 type t = Module.Name.Set.t Ml_kind.Dict.t
 
+let pp =
+  Ml_kind.Dict.pp Module.Name.Set.pp
+
 let empty =
   { Ml_kind.Dict.
     intf = Module.Name.Set.empty

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -1,0 +1,41 @@
+{
+open Stdune
+
+type t = Module.Name.Set.t Ml_kind.Dict.t
+
+let empty =
+  { Ml_kind.Dict.
+    intf = Module.Name.Set.empty
+  ; impl = Module.Name.Set.empty
+  }
+
+let add_intf (t : t) i =
+  { t with intf = Module.Name.Set.add t.intf (Module.Name.of_string i) }
+let add_impl (t : t) i =
+  { t with impl = Module.Name.Set.add t.impl (Module.Name.of_string i) }
+}
+
+let newline = '\r'? '\n'
+let ws = [' ' '\t']+
+let hash = ['0'-'9' 'a'-'z']+
+let name = ['A'-'Z'] ['a'-'z' '0'-'9' '_']*
+
+rule ocamlobjinfo acc = parse
+  | "Interfaces imported:" newline { intfs acc lexbuf }
+  | "Implementations imported:" newline { impls acc lexbuf }
+  | _ { ocamlobjinfo acc lexbuf }
+  | eof { acc }
+and intfs acc = parse
+  | ws hash ws (name as name) newline { intfs (add_intf acc name) lexbuf }
+  | "Implementations imported:" newline { impls acc lexbuf }
+  | _ | eof { acc }
+and impls acc = parse
+  | ws hash ws (name as name) newline { impls (add_impl acc name) lexbuf }
+  | _ | eof { acc }
+
+{
+let load ~ocamlobjinfo:bin ~unit =
+  ["-no-approx"; "-no-code"; Path.to_absolute_filename unit]
+  |> Process.run_capture ~env:Env.empty Process.Strict bin
+  |> Fiber.map ~f:(fun s -> ocamlobjinfo empty (Lexing.from_string s))
+}

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -224,7 +224,14 @@ let maybe_quoted s =
   else
     Printf.sprintf {|"%s"|} escaped
 
-module Set = Set.Make(T)
+module Set = struct
+  include Set.Make(T)
+  let pp fmt t =
+    Format.fprintf fmt "Set (@[%a@])"
+      (Format.pp_print_list Format.pp_print_string
+         ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ "))
+      (to_list t)
+end
 
 module Map = struct
   include Map.Make(T)

--- a/src/stdune/string.mli
+++ b/src/stdune/string.mli
@@ -60,7 +60,11 @@ val enumerate_and : string list -> string
 (** Produces: "x, y or z" *)
 val enumerate_or  : string list -> string
 
-module Set : Set.S with type elt = t
+module Set : sig
+  include Set.S with type elt = t
+
+  val pp : Format.formatter -> t -> unit
+end
 module Map : sig
   include Map.S with type key = t
 

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -108,3 +108,13 @@
           (progn
            (run %{exe:expect_test.exe} %{t})
            (diff? %{t} %{t}.corrected)))))
+
+(alias
+ (name runtest)
+ (deps (:t ocamlobjinfo.mlt)
+  (glob_files %{project_root}/src/.dune.objs/*.cmi)
+  (glob_files %{project_root}/src/stdune/.stdune.objs/*.cmi))
+ (action (chdir %{project_root}
+          (progn
+           (run %{exe:expect_test.exe} %{t})
+           (diff? %{t} %{t}.corrected)))))

--- a/test/unit-tests/expect_test.mll
+++ b/test/unit-tests/expect_test.mll
@@ -4,6 +4,8 @@ open StdLabels
 type kind = Ignore | Expect
 }
 
+let newline = eof | '\r'? '\n'
+
 rule code txt start = parse
   | "[%%ignore]\n" {
     let pos = start.Lexing.pos_cnum in
@@ -37,7 +39,7 @@ rule code txt start = parse
   }
 
 and expectation txt = parse
-  | "|}]\n" {
+  | "|}]" newline {
       Lexing.new_line lexbuf;
       code txt lexbuf.lex_curr_p lexbuf
     }

--- a/test/unit-tests/ocamlobjinfo.mlt
+++ b/test/unit-tests/ocamlobjinfo.mlt
@@ -1,0 +1,98 @@
+(* -*- tuareg -*- *)
+open Dune;;
+open! Stdune;;
+
+#install_printer Ocamlobjinfo.pp;;
+
+let fixture = {ocamlobjinfo|
+File _build/install/default/lib/dune/_stdune/stdune__Env.cmx
+Name: Stdune__Env
+CRC of implementation: b678d7aae434ca3158721e3a37a15776
+Globals defined:
+        Stdune__Env
+Interfaces imported:
+        053326e853ce10e1fadf8d891f08f891        Unix
+        596c497318b5c3057b47b9d6747ef5d1        Uchar
+        3fe6d98e0634486be22d9de07aa0709a        Sys
+        6339e2b71e8c583a81e808954faf6818        StringLabels
+        953d4ea121ff79e9719730997e04436d        Stdune__String
+        744ae4e7c80910dd9302bf207d11274f        Stdune__Sexp_intf
+        3a8d88a2c7628492ca76328610a53b04        Stdune__Sexp
+        788120b20799b5148dc44c2effd9db08        Stdune__Set_intf
+        764302df6c51161e13ccc4553710003d        Stdune__Set
+        7577d25061f730d87e8e0ab574216d9c        Stdune__Result
+        4d34756156087d6e6530be0d3275bde4        Stdune__Path
+        e8eebf0307152a528b7d97ebdf37d1dc        Stdune__Ordering
+        1fb9ae8c1fb73c55a857f02869cfbeab        Stdune__Map_intf
+        96daa1ecff8c9bc6c5aadf39201c2f0d        Stdune__Map
+        5b332ee2108ade34f2abc1448318c5a0        Stdune__Loc
+        721c54b94b8c3b89fffc8587041c241a        Stdune__List
+        0c6e26bc5bc285a87ab7304ee5f3bf0a        Stdune__Hashtbl_intf
+        8df5a38cb2f28d4cf23f6cd8a6c4c923        Stdune__Hashtbl
+        0ff241a400cabb742a8d681c7132c350        Stdune__Hashable
+        b438dbe8d4c60ca1bb06d04c7bc95652        Stdune__Exn
+        a1b4f657ccceb16196f104a53a0e199a        Stdune__Env
+        7643682d2d95acbcf8834a351a1e2779        Stdune__Either
+        826226f09894dc48694a431d13b9e541        Stdune__Comparable
+        69861cabc5a73becd98269ce298eaa59        Stdune__Bin
+        cbf0ce887ccceaff96f4a22a8f057799        Stdune__Array
+        37cf8dd4fc4be5636ff9f78604107f8b        Stdune__
+        28a12def19edf36c317c30fafcc03d6d        Set
+        e5dfd0ca6436c8abad976fc9e914999a        Printf
+        1b461321ebcc8e419f24eb531c5ac7ac        Printexc
+        9b04ecdc97e5102c1d342892ef7ad9a2        Pervasives
+        db5fc31b815ab3040d5a9940a91712c4        MoreLabels
+        8b8de381501aa7862270c15619322ee7        Map
+        f4e829075d9d0bb7de979cfc49c2600b        ListLabels
+        0971650cdf1fa8e506e733e9a5da2628        Lexing
+        0a88e320f172d3413ba0d5e0f9c70ccd        Hashtbl
+        1a17539924469551f027475153d4d3b5        Format
+        a4afff2bf4082efda68a6a65cf31f8e2        Dune_caml__Result_compat
+        de733b926f4af640c957c8129aba4139        Dune_caml__Result
+        ba19641102c1711bdb2476bb8b8dbe32        Dune_caml__
+        7b10d1bd2d88af9c1da841149c988d94        Dune_caml
+        cd4856c93f21942683ce190142e88396        Complex
+        79ae8c0eb753af6b441fe05456c7970b        CamlinternalFormatBasics
+        4ff98b0650eef9c38ee9c9930e0c3e9b        CamlinternalBigarray
+        9c9b3639d23d7746c571cdf04646eb29        Buffer
+        c4974e11dd7c941c002b826edc727de8        ArrayLabels
+Implementations imported:
+        e28bcdad48b0cb1739e47106149016cb        Unix
+        3c11d6a8ae012d6541b58cecff4809d5        Sys
+        --------------------------------        Stdune__String
+        --------------------------------        Stdune__Sexp
+        --------------------------------        Stdune__Set
+        --------------------------------        Stdune__Map
+        --------------------------------        Stdune__List
+        --------------------------------        Stdune__Exn
+        --------------------------------        Stdune__Bin
+        --------------------------------        Stdune__Array
+        a3cdcb16ec3b460d51a685302e993c0b        Printf
+Clambda approximation:
+  _
+Currying functions: 3 2
+Apply functions: 3 2
+Send functions:
+Force link: no
+|ocamlobjinfo}
+
+[%%ignore]
+
+Ocamlobjinfo.parse fixture;;
+[%%expect{|
+- : Ocamlobjinfo.t =
+{ impl =
+   Set (Printf Stdune__Array Stdune__Bin Stdune__Exn Stdune__List Stdune__Map
+        Stdune__Set Stdune__Sexp Stdune__String Sys Unix)
+; intf =
+   Set (ArrayLabels Buffer CamlinternalBigarray CamlinternalFormatBasics
+        Complex Dune_caml Dune_caml__ Dune_caml__Result
+        Dune_caml__Result_compat Format Hashtbl Lexing ListLabels Map
+        MoreLabels Pervasives Printexc Printf Set Stdune__ Stdune__Array
+        Stdune__Bin Stdune__Comparable Stdune__Either Stdune__Env Stdune__Exn
+        Stdune__Hashable Stdune__Hashtbl Stdune__Hashtbl_intf Stdune__List
+        Stdune__Loc Stdune__Map Stdune__Map_intf Stdune__Ordering
+        Stdune__Path Stdune__Result Stdune__Set Stdune__Set_intf Stdune__Sexp
+        Stdune__Sexp_intf Stdune__String StringLabels Sys Uchar Unix)
+}
+|}]


### PR DESCRIPTION
This will be useful to avoid installing all-deps files, but I expect that it will have other uses in the future as well. For example, to discover unused library dependencies.

I'll push some tests in this PR as well.