### PR TITLE
Test for implementing external library should use public lib

### DIFF
--- a/test/blackbox-tests/test-cases/variants/implements-external/vlib/dune
+++ b/test/blackbox-tests/test-cases/variants/implements-external/vlib/dune
@@ -1,3 +1,3 @@
 (library
- (name vlib)
+ (public_name vlib)
  (virtual_modules foo))


### PR DESCRIPTION
I just noticed that this library should have been public because this test fails on the dune-package branch.

Findlib is aggressive here in interpreting an empty META file as a library being present. dune-package is more conservative and will treat this library as simply being absent.