### PR TITLE
dune unstable-fmt: use boxes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- unstable-fmt: use boxes to wrap some lists (#1608, fix #1153, @emillon,
+  thanks to @rgrinberg)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/dune_fmt.ml
+++ b/src/dune_fmt.ml
@@ -68,22 +68,23 @@ and pp_sexp_list indent fmt sexps =
     begin
       Format.fprintf fmt "%a(" pp_indent indent;
       let first = ref true in
-      List.iter sexps ~f:(fun sexp ->
-        let indent =
-          if !first then
-            begin
-              first := false;
-              0
-            end
-          else
-            indent + 1
-        in
-        pp_sexp
-          indent
-          fmt
-          sexp;
-        Format.pp_print_string fmt "\n";
-      );
+      let pp_sep fmt () = Format.pp_print_char fmt '\n' in
+      Fmt.list
+        ~pp_sep
+        (fun fmt sexp ->
+          let indent =
+            if !first then
+              begin
+                first := false;
+                0
+              end
+            else
+              indent + 1
+          in
+          pp_sexp indent fmt sexp
+        )
+        fmt
+        sexps;
       Format.fprintf fmt "%a)" pp_indent indent;
     end
 

--- a/src/dune_fmt.ml
+++ b/src/dune_fmt.ml
@@ -85,7 +85,7 @@ and pp_sexp_list indent fmt sexps =
         )
         fmt
         sexps;
-      Format.fprintf fmt "%a)" pp_indent indent;
+      Format.pp_print_char fmt ')'
     end
 
 let pp_top_sexp fmt sexp =

--- a/test/blackbox-tests/test-cases/fmt/multi-line-strings
+++ b/test/blackbox-tests/test-cases/fmt/multi-line-strings
@@ -1,0 +1,10 @@
+(echo "\> multi
+      "\> line
+      "\> string
+)
+
+(echo "\
+multi
+line
+string
+")

--- a/test/blackbox-tests/test-cases/fmt/run.t
+++ b/test/blackbox-tests/test-cases/fmt/run.t
@@ -65,3 +65,17 @@ When a list is indented, there is no extra space at the end.
   (a
    (b
     (c d)))
+
+When there is a long list of atoms, quoted strings, templates and singletons,
+it gets wrapped.
+
+  $ echo '(library (name dune) (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang ocaml_config which_program) (synopsis "Internal Dune library, do not use!") (preprocess  (action (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))' | dune unstable-fmt
+  (library
+   (name dune)
+   (libraries unix stdune fiber xdg dune_re threads opam_file_format dune_lang
+     ocaml_config which_program)
+   (synopsis "Internal Dune library, do not use!")
+   (preprocess
+    (action
+     (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))
+

--- a/test/blackbox-tests/test-cases/fmt/run.t
+++ b/test/blackbox-tests/test-cases/fmt/run.t
@@ -79,3 +79,9 @@ it gets wrapped.
     (action
      (run %{project_root}/src/let-syntax/pp.exe %{input-file}))))
 
+In multi-line strings, newlines are escaped.
+
+  $ dune unstable-fmt < multi-line-strings
+  (echo "multi\nline\nstring\n")
+  
+  (echo "multi\nline\nstring\n")

--- a/test/blackbox-tests/test-cases/fmt/run.t
+++ b/test/blackbox-tests/test-cases/fmt/run.t
@@ -58,3 +58,10 @@ and files are not removed when there is an error:
   Parse error: unclosed parenthesis at end of input
   $ cat dune_temp
   (a
+
+When a list is indented, there is no extra space at the end.
+
+  $ echo ' (a (b (c d)))' | dune unstable-fmt
+  (a
+   (b
+    (c d) ))

--- a/test/blackbox-tests/test-cases/fmt/run.t
+++ b/test/blackbox-tests/test-cases/fmt/run.t
@@ -17,8 +17,7 @@ Other lists are displayed one element per line:
   $ echo '(a (b c d) e)' | dune unstable-fmt
   (a
    (b c d)
-   e
-  )
+   e)
 
 When there are several s-expressions, they are printed with an empty line
 between them:
@@ -39,8 +38,7 @@ A file can be fixed in place:
   $ dune unstable-fmt --inplace dune_temp
   $ cat dune_temp
   (a
-   (b c)
-  )
+   (b c))
 
 The --inplace flag requires a file name:
 

--- a/test/blackbox-tests/test-cases/fmt/run.t
+++ b/test/blackbox-tests/test-cases/fmt/run.t
@@ -64,4 +64,4 @@ When a list is indented, there is no extra space at the end.
   $ echo ' (a (b (c d)))' | dune unstable-fmt
   (a
    (b
-    (c d) ))
+    (c d)))

--- a/test/blackbox-tests/test-cases/js_of_ocaml/bin/technologic.ml
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/bin/technologic.ml
@@ -1,3 +1,4 @@
+module Js = Js_of_ocaml.Js
 
 let _ =
   print_endline X.buy_it;

--- a/test/blackbox-tests/test-cases/js_of_ocaml/lib/x.ml
+++ b/test/blackbox-tests/test-cases/js_of_ocaml/lib/x.ml
@@ -1,3 +1,5 @@
+module Js = Js_of_ocaml.Js
+
 let buy_it = "buy " ^ Y.it
-let print x = Js_of_ocaml.Js.to_string x##.name
+let print x = Js.to_string x##.name
 external external_print  : Js.js_string Js.t -> unit = "jsPrint"


### PR DESCRIPTION
We hacked this with @rgrinberg this morning. This uses format boxes for two things:
- dealing with indentation
- wrapping some lists automatically (lists of atoms/strings/templates/singletons)