### PR TITLE
Extend the test for external-lib-deps

### DIFF
--- a/test/blackbox-tests/test-cases/external-lib-deps/dune
+++ b/test/blackbox-tests/test-cases/external-lib-deps/dune
@@ -2,3 +2,7 @@
  (name foo)
  (libraries a b c)
  (preprocess (pps d e f)))
+
+(rule
+ (with-stdout-to file.ml
+  (echo %{lib-available:optional})))

--- a/test/blackbox-tests/test-cases/external-lib-deps/run.t
+++ b/test/blackbox-tests/test-cases/external-lib-deps/run.t
@@ -1,4 +1,4 @@
-Expected: a b c d e f
+Expected: a, b, c, d, e, f (required) and optional (optional)
 
   $ dune external-lib-deps @all
   These are the external library dependencies in the default context:
@@ -8,3 +8,4 @@ Expected: a b c d e f
   - d
   - e
   - f
+  - optional (optional)


### PR DESCRIPTION
This is a case that we rely on for the Jane Street public release.