### PR TITLE
Add automatic glob handling to Arg_spec

### DIFF
--- a/src/arg_spec.mli
+++ b/src/arg_spec.mli
@@ -29,6 +29,12 @@ open! Import
     where the command is executed. For instance [Path (Path.of_string
     "src/foo.ml")] will translate to "../src/foo.ml" if the command is
     started from the "test" directory.  *)
+
+type glob =
+  { dir : Path.t
+  ; exts : string list
+  }
+
 type 'a t =
   | A        of string
   | As       of string list
@@ -39,14 +45,20 @@ type 'a t =
   | Target   of Path.t
   | Path     of Path.t
   | Paths    of Path.t list
+  | Hidden_glob_deps of glob list
   | Hidden_deps    of Path.t list
   | Hidden_targets of Path.t list
   (** Register dependencies but produce no argument *)
   | Dyn      of ('a -> Nothing.t t)
 
-val add_deps    : _ t list -> Path.Set.t -> Path.Set.t
+val add_deps    : _ t list -> Path.Set.t -> Path.Set.t * glob list
 val add_targets : _ t list -> Path.t list -> Path.t list
-val expand      : dir:Path.t -> 'a t list -> 'a -> string list * Path.Set.t
+
+val expand
+  :  dir:Path.t
+  -> 'a t list
+  -> 'a
+  -> string list * Path.Set.t * glob list
 
 (** [quote_args quote args] is [As \[quote; arg1; quote; arg2; ...\]] *)
 val quote_args : string -> string list -> _ t

--- a/src/build.mli
+++ b/src/build.mli
@@ -227,8 +227,12 @@ module Repr : sig
     | Decided   of bool * ('a, 'b) t
 
   and glob_state =
-    | G_unevaluated of Loc.t * Path.t * (Path.t -> bool)
+    | G_unevaluated of Loc.t * Path.t * (Path.t -> bool) * dir_missing
     | G_evaluated   of Path.Set.t
+
+  and dir_missing =
+    | Warn
+    | Ignore
 
   val get_if_file_exists_exn : ('a, 'b) if_file_exists_state ref -> ('a, 'b) t
   val get_glob_result_exn : glob_state ref -> Path.Set.t

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -68,20 +68,21 @@ let static_deps t ~all_targets ~file_tree =
         match !state with
         | G_evaluated l ->
           Static_deps.add_action_paths acc l
-        | G_unevaluated (loc, dir, f) ->
+        | G_unevaluated (loc, dir, f, dir_missing) ->
           let targets = all_targets ~dir in
           let result = Path.Set.filter targets ~f in
           if Path.Set.is_empty result then begin
-            match inspect_path file_tree dir with
-            | None ->
+            match inspect_path file_tree dir, dir_missing with
+            | None, Warn ->
               Errors.warn loc "Directory %s doesn't exist."
                 (Path.to_string_maybe_quoted
                    (Path.drop_optional_build_context dir))
-            | Some Reg ->
+            | Some Reg, _ ->
               Errors.warn loc "%s is not a directory."
                 (Path.to_string_maybe_quoted
                    (Path.drop_optional_build_context dir))
-            | Some Dir ->
+            | None, Ignore -> ()
+            | Some Dir, _ ->
               (* diml: we should probably warn in this case as well *)
               ()
           end;

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -15,23 +15,21 @@ module Includes = struct
       in
       let cmi_includes =
         Arg_spec.S [ iflags
-                   ; Hidden_deps
-                       (Lib_file_deps.L.file_deps sctx libs ~exts:[".cmi"])
+                   ; Hidden_glob_deps (Lib_file_deps.L.cmi libs)
                    ]
       in
       let cmx_includes =
         Arg_spec.S
           [ iflags
-          ; Hidden_deps
+          ; Hidden_glob_deps
               ( if opaque then
                   List.map libs ~f:(fun lib ->
-                    (lib, if Lib.is_local lib then
-                       [".cmi"]
-                     else
-                       [".cmi"; ".cmx"]))
-                  |> Lib_file_deps.L.file_deps_with_exts sctx
+                    if Lib.is_local lib then
+                      Lib_file_deps.cmi lib
+                    else
+                      Lib_file_deps.cmi_and_cmx lib)
                 else
-                  Lib_file_deps.L.file_deps sctx libs ~exts:[".cmi"; ".cmx"]
+                  Lib_file_deps.L.cmi_and_cmx libs
               )
           ]
       in

--- a/src/lib_file_deps.mli
+++ b/src/lib_file_deps.mli
@@ -1,31 +1,22 @@
-open Stdune
+open! Stdune
+
+val cmi : Lib.t -> Arg_spec.glob
+val cmi_and_cmx : Lib.t -> Arg_spec.glob
 
 module L : sig
-
   (** [file_deps t libs ~ext] returns a list of path dependencies for all the
       files with extension [ext] of libraries [libs]. *)
-  val file_deps : Super_context.t -> Lib.L.t -> exts:string list -> Path.t list
+  val file_deps
+    :  Lib.L.t
+    -> exts:string list
+    -> Arg_spec.glob list
 
   val file_deps_with_exts
-    :  Super_context.t
-    -> (Lib.t * string list) list
-    -> Path.t list
+    : (Lib.t * string list) list
+    -> Arg_spec.glob list
+
+  val headers : Lib.t list -> Arg_spec.glob list
+
+  val cmi         : Lib.L.t -> Arg_spec.glob list
+  val cmi_and_cmx : Lib.L.t -> Arg_spec.glob list
 end
-
-(** Setup the alias that depends on all files with a given extension for a
-    library *)
-val setup_file_deps_alias
-  :  Super_context.t
-  -> dir:Path.t
-  -> exts:string list
-  -> Dune_file.Library.t
-  -> Path.Set.t
-  -> unit
-
-(** Setup an alias that depend on all files with the given extensions.*)
-val setup_file_deps_group_alias
-  :  Super_context.t
-  -> dir:Path.t
-  -> exts:string list
-  -> Dune_file.Library.t
-  -> unit

--- a/src/vimpl.ml
+++ b/src/vimpl.ml
@@ -61,11 +61,3 @@ let find_module t m =
 let vlib_stubs_o_files = function
   | None -> []
   | Some t -> Lib.foreign_objects t.vlib
-
-let for_file_deps t modules =
-  match t with
-  | None -> modules
-  | Some t ->
-    Lib_modules.for_compilation t.vlib_modules
-    |> Module.Name.Map.values
-    |> List.rev_append modules

--- a/src/vimpl.mli
+++ b/src/vimpl.mli
@@ -31,5 +31,3 @@ val aliased_modules : t option -> Module.Name_map.t -> Module.Name_map.t
 val find_module : t option -> Module.t -> Module.t option
 
 val vlib_stubs_o_files : t option -> Path.t list
-
-val for_file_deps : t option -> Module.t list -> Module.t list


### PR DESCRIPTION
Hidden_glob_deps now allows users to add file globs as dependencies. After this,
it's no longer required to manually keep track of alias files for globs.

We discussed this change on Thursday, so I thought I'd give it a go. It does seem to simplify some things, but I'm not yet sure if we should support dynamically produced globs (`Hidden_glob_deps` produced under `Dyn`). This will be a bit tricky to implement as well. We'll need to evaluate `Arg_spec.expand` outside of the arrow, save w/e exception it raised and then re-raise it using `Build.arr` or `Build.fail`.