### PR TITLE
Do not generate extra targets for bytecode only libs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ unreleased
 - Delay opening redirected output files until executing commands (#1633,
   @jonludlam)
 
+- Do not generate targets for archive that don't match the `modes` field.
+  (#1632, fix #1617, @rgrinberg)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -392,20 +392,27 @@ module Gen (P : Install_rules.Params) = struct
           ]
           modules
     in
+
+    let modes =
+      Mode_conf.Set.eval lib.modes
+        ~has_native:(Option.is_some ctx.ocamlopt) in
     (let modules = modules @ wrapped_compat in
-     List.iter Mode.all ~f:(fun mode ->
+     Mode.Dict.Set.to_list modes
+     |> List.iter ~f:(fun mode ->
        build_lib lib ~expander ~flags ~dir ~obj_dir ~mode ~top_sorted_modules
          ~modules));
     (* Build *.cma.js *)
-    SC.add_rules sctx ~dir (
-      let src =
-        Library.archive lib ~dir
-          ~ext:(Mode.compiled_lib_ext Mode.Byte) in
-      let target =
-        Path.relative obj_dir (Path.basename src)
-        |> Path.extend_basename ~suffix:".js" in
-      Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target);
-    if Dynlink_supported.By_the_os.get ctx.natdynlink_supported then
+    if modes.byte then
+      SC.add_rules sctx ~dir (
+        let src =
+          Library.archive lib ~dir
+            ~ext:(Mode.compiled_lib_ext Mode.Byte) in
+        let target =
+          Path.relative obj_dir (Path.basename src)
+          |> Path.extend_basename ~suffix:".js" in
+        Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target);
+    if Dynlink_supported.By_the_os.get ctx.natdynlink_supported
+    && modes.native then
         build_shared lib ~dir ~flags ~ctx
 
   let library_rules (lib : Library.t) ~dir_contents ~dir ~expander ~scope


### PR DESCRIPTION
.cmxa, .cmxs, .a, targets shouldn't exist in bytecode only mode

Fix #1617 