### PR TITLE
Fix getting node for directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ unreleased
   one from [this paper](https://doi.org/10.1145/2756553) (#1489,
   @rudihorn)
 
+- Get the correct environment node for multi project workspaces (#1648,
+  @rgrinberg)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -112,3 +112,5 @@ val get_exn : unit -> (t, 'k) Dune_lang.Decoder.parser
 val find_extension_args : t -> 'a Extension.t -> 'a option
 
 val set_parsing_context : t -> 'a Dune_lang.Decoder.t -> 'a Dune_lang.Decoder.t
+
+val pp : t Fmt.t

--- a/src/env_node.mli
+++ b/src/env_node.mli
@@ -9,7 +9,7 @@ val make
   :  dir:Path.t
   -> inherit_from:t Lazy.t option
   -> scope:Scope.t
-  -> config:Dune_env.Stanza.t
+  -> config:Dune_env.Stanza.t option
   -> env:Env.t option
   -> t
 

--- a/src/file_bindings.ml
+++ b/src/file_bindings.ml
@@ -68,3 +68,11 @@ module Unexpanded = struct
 end
 
 let is_empty xs = List.is_empty xs
+
+let pp f =
+  Fmt.ocaml_list
+    (fun fmt { src; dst } ->
+       Fmt.record fmt
+         [ "src", Fmt.const f src
+         ; "dst", Fmt.const (Fmt.optional f) dst
+         ])

--- a/src/file_bindings.mli
+++ b/src/file_bindings.mli
@@ -22,3 +22,5 @@ module Unexpanded : sig
 end
 
 val is_empty : _ t -> bool
+
+val pp : 'a Fmt.t -> 'a t Fmt.t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -199,7 +199,7 @@ module Gen(P : Install_rules.Params) = struct
        begin match List.last comps with
        | Some ".bin" ->
          let src_dir = Path.parent_exn dir in
-         Super_context.local_binaries sctx ~dir
+         Super_context.local_binaries sctx ~dir:src_dir
          |> List.iter ~f:(fun t ->
            let src = File_bindings.src_path t ~dir:src_dir in
            let dst = File_bindings.dst_path t ~dir in

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -96,11 +96,9 @@ end = struct
             | None -> raise_notrace Exit
             | Some parent -> lazy (get t ~dir:parent ~scope)
         in
-        match get_env_stanza t ~dir with
-        | None -> Lazy.force inherit_from
-        | Some config ->
-          Env_node.make ~dir ~scope ~config ~inherit_from:(Some inherit_from)
-            ~env:None
+        let config = get_env_stanza t ~dir in
+        Env_node.make ~dir ~scope ~config ~inherit_from:(Some inherit_from)
+          ~env:None
       in
       Hashtbl.add t.env dir node;
       node
@@ -314,13 +312,14 @@ let create
     in
     match context.env_nodes with
     | { context = None; workspace = None } ->
-      make ~config:{ loc = Loc.none; rules = [] } ~inherit_from:None
-    | { context = Some config; workspace = None }
-    | { context = None; workspace = Some config } ->
+      make ~config:(Some { loc = Loc.none; rules = [] }) ~inherit_from:None
+    | { context = Some _ as config; workspace = None }
+    | { context = None; workspace = Some _ as config } ->
       make ~config ~inherit_from:None
-    | { context = Some context ; workspace = Some workspace } ->
+    | { context = Some _ as context ; workspace = Some _ as workspace } ->
       make ~config:context
-        ~inherit_from:(Some (lazy (make ~inherit_from:None ~config:workspace)))
+        ~inherit_from:(Some (lazy (make ~inherit_from:None
+                                     ~config:workspace)))
   ) in
   let expander =
     let artifacts_host =

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -53,8 +53,8 @@ val ocaml_flags
   -> Buildable.t
   -> Ocaml_flags.t
 
-(** Binaries that are symlinked in local .bin directories. [dir]
-    should point to such a [.bin] directory, such as [foo/bar/.bin]. *)
+(** Binaries that are symlinked in the associated .bin directory of [dir]. This
+    associated directory is [Path.relative dir ".bin"] *)
 val local_binaries : t -> dir:Path.t -> string File_bindings.t
 
 (** Dump a directory environment in a readable form *)

--- a/test/blackbox-tests/test-cases/embed-jbuild/run.t
+++ b/test/blackbox-tests/test-cases/embed-jbuild/run.t
@@ -10,15 +10,5 @@ Now lets try with a jbuild project in the subdirectory:
 Now lets try it from the current directory:
 
   $ dune build a-dune-proj/version.ml --root=.
-  File "a-dune-proj/dune", line 5, characters 29-49:
-  5 |     (echo "let version = \"%{version:a-dune-proj}\""))))
-                                   ^^^^^^^^^^^^^^^^^^^^
-  Error: Package "a-dune-proj" doesn't exist in the current project.
-  [1]
   $ dune build a-jbuild-proj/version.ml --root=.
-  File "a-jbuild-proj/jbuild", line 7, characters 10-54:
-  7 |     (echo "let version = \"${version:a-jbuild-proj}\"")))))
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Package "a-jbuild-proj" doesn't exist in the current project.
-  [1]
 

--- a/test/blackbox-tests/test-cases/env-bins/run.t
+++ b/test/blackbox-tests/test-cases/env-bins/run.t
@@ -1,23 +1,30 @@
 Basic test that we can use private binaries as public ones
   $ dune build --root private-bin-import
   Entering directory 'private-bin-import'
-          priv alias using-priv/runtest
-  Executing priv as priv
-  PATH:
-  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/default/using-priv/.bin
-  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/install/default/bin
-  	_build/install/default/bin
-  priv-renamed alias using-priv/runtest
-  Executing priv as priv-renamed
-  PATH:
-  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/default/using-priv/.bin
-  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/install/default/bin
-  	_build/install/default/bin
+  File "using-priv/dune", line 7, characters 0-79:
+   7 | (alias
+   8 |  (name runtest)
+   9 |  (action
+  10 |   (progn
+  11 |    (run priv)
+  12 |    (run priv-renamed))))
+  Error: No rule found for using-priv/.bin/priv
+  File "using-priv/dune", line 7, characters 0-79:
+   7 | (alias
+   8 |  (name runtest)
+   9 |  (action
+  10 |   (progn
+  11 |    (run priv)
+  12 |    (run priv-renamed))))
+  Error: No rule found for using-priv/.bin/priv-renamed
+  [1]
 
 Override public binary in env
   $ dune build --root override-bins
   Entering directory 'override-bins'
-           foo alias test/runtest
-  private binary
-           foo alias default
-  public binary
+  File "test/dune", line 5, characters 0-43:
+  5 | (alias
+  6 |  (name runtest)
+  7 |  (action (run foo)))
+  Error: No rule found for test/.bin/foo
+  [1]

--- a/test/blackbox-tests/test-cases/env-bins/run.t
+++ b/test/blackbox-tests/test-cases/env-bins/run.t
@@ -1,30 +1,23 @@
 Basic test that we can use private binaries as public ones
   $ dune build --root private-bin-import
   Entering directory 'private-bin-import'
-  File "using-priv/dune", line 7, characters 0-79:
-   7 | (alias
-   8 |  (name runtest)
-   9 |  (action
-  10 |   (progn
-  11 |    (run priv)
-  12 |    (run priv-renamed))))
-  Error: No rule found for using-priv/.bin/priv
-  File "using-priv/dune", line 7, characters 0-79:
-   7 | (alias
-   8 |  (name runtest)
-   9 |  (action
-  10 |   (progn
-  11 |    (run priv)
-  12 |    (run priv-renamed))))
-  Error: No rule found for using-priv/.bin/priv-renamed
-  [1]
+          priv alias using-priv/runtest
+  Executing priv as priv
+  PATH:
+  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/default/using-priv/.bin
+  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/install/default/bin
+  	_build/install/default/bin
+  priv-renamed alias using-priv/runtest
+  Executing priv as priv-renamed
+  PATH:
+  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/default/using-priv/.bin
+  	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/install/default/bin
+  	_build/install/default/bin
 
 Override public binary in env
   $ dune build --root override-bins
   Entering directory 'override-bins'
-  File "test/dune", line 5, characters 0-43:
-  5 | (alias
-  6 |  (name runtest)
-  7 |  (action (run foo)))
-  Error: No rule found for test/.bin/foo
-  [1]
+           foo alias test/runtest
+  private binary
+           foo alias default
+  public binary


### PR DESCRIPTION
Previously, we would just get the context node without updating the scope.