### PR TITLE
Fix compatibility between meta templates and dune-package

### DIFF
--- a/src/dune_package.mli
+++ b/src/dune_package.mli
@@ -71,9 +71,15 @@ type 'sub_system t =
   ; dir          : Path.t
   }
 
-val gen
-  :  dune_version:Syntax.Version.t
-  -> (Syntax.Version.t * Dune_lang.t list) t
-  -> Dune_lang.t list
+module Or_meta : sig
+  type nonrec 'sub_system t =
+    | Use_meta
+    | Dune_package of 'sub_system t
 
-val load : Path_dune_lang.t -> Sub_system_info.t t
+  val encode
+    :  dune_version:Syntax.Version.t
+    -> (Syntax.Version.t * Dune_lang.t list) t
+    -> Dune_lang.t list
+
+  val load : Path_dune_lang.t -> Sub_system_info.t t
+end

--- a/src/local_package.mli
+++ b/src/local_package.mli
@@ -32,3 +32,7 @@ val install_paths : t -> Install.Section.Paths.t
 val libs : t -> Lib.Set.t
 
 val package : t -> Package.t
+
+val virtual_lib : t -> Lib.t option
+
+val meta_template : t -> Path.t

--- a/src/stdune/set.ml
+++ b/src/stdune/set.ml
@@ -44,6 +44,18 @@ module Make(Elt : Comparable.S) : S with type elt = Elt.t = struct
   let max_elt = max_elt_opt
   let choose = choose_opt
   let split x t = split t x
+
+  exception Found of elt
+  let find t ~f =
+    match
+      iter t ~f:(fun e ->
+        if f e then
+          raise_notrace (Found e)
+        else
+          ())
+    with
+    | () -> None
+    | exception (Found e) -> Some e
 end
 
 let to_sexp to_list f t =

--- a/src/stdune/set_intf.ml
+++ b/src/stdune/set_intf.ml
@@ -28,4 +28,5 @@ module type S = sig
   val split          : t -> elt -> t * bool * t
   val of_list        : elt list -> t
   val to_list        : t -> elt list
+  val find           : t -> f:(elt -> bool) -> elt option
 end


### PR DESCRIPTION
When a template exists with a virtual library, we error out. As that combination
is not possible.

When a meta template is present, we emit a special dune package file that
ignores it.
