### PR TITLE
Catapult improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@ unreleased
 
 - Add `--trace-file` option to trace dune internals (#1639, fix #1180, @emillon)
 
+- Remove `--stats` and track fd usage in `--trace-file` (#1667, @emillon)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -26,8 +26,7 @@ type t =
   ; default_target        : string
   (* For build & runtest only *)
   ; watch : bool
-  ; stats : bool
-  ; catapult_trace_file : string option
+  ; stats_trace_file : string option
   }
 
 let prefix_target common s = common.target_prefix ^ s
@@ -53,8 +52,7 @@ let set_common_other c ~targets =
       ; c.orig_args
       ; targets
       ];
-  if c.stats then Stats.enable ();
-  Option.iter ~f:Stats.enable_catapult c.catapult_trace_file
+  Option.iter ~f:Stats.enable c.stats_trace_file
 
 let set_common c ~targets =
   set_dirs c;
@@ -329,13 +327,7 @@ let term =
          & info ["diff-command"] ~docs
              ~doc:"Shell command to use to diff files.
                    Use - to disable printing the diff.")
-  and stats =
-    Arg.(value
-         & flag
-         & info ["stats"] ~docs
-             ~doc:{|Record and print statistics about Dune resource usage.
-                   |})
-  and catapult_trace_file =
+  and stats_trace_file =
     Arg.(value
          & opt (some string) None
          & info ["trace-file"] ~docs ~docv:"FILE"
@@ -394,8 +386,7 @@ let term =
   ; build_dir
   ; default_target
   ; watch
-  ; stats
-  ; catapult_trace_file
+  ; stats_trace_file
   }
 
 let term =

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -22,8 +22,7 @@ type t =
   ; default_target        : string
   (* For build & runtest only *)
   ; watch : bool
-  ; stats : bool
-  ; catapult_trace_file : string option
+  ; stats_trace_file : string option
   }
 
 val prefix_target : t -> string -> string

--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -37,7 +37,6 @@ let dirs =
   ; "src/dag"                , Some "Dag"
   ; "src/memo"               , Some "Memo"
   ; "src/ocaml-config"       , Some "Ocaml_config"
-  ; "src/catapult"           , Some "Catapult"
   ; "vendor/boot"            , None
   ; "src/dune_lang"              , Some "Dune_lang"
   ; "src"                    , None

--- a/src/catapult/catapult.mli
+++ b/src/catapult/catapult.mli
@@ -29,3 +29,9 @@ val on_process_start : t -> program:string -> args:string list -> event
 
 (** Capture the current time and output a complete event. *)
 val on_process_end : t -> event -> unit
+
+(** Emit a counter event. This is measuring the value of an integer variable. *)
+val emit_counter : t -> string -> int -> unit
+
+(** Emit counter events for GC stats. *)
+val emit_gc_counters : t -> unit

--- a/src/catapult/catapult.mli
+++ b/src/catapult/catapult.mli
@@ -5,10 +5,10 @@
     It is basically an output channel. *)
 type t
 
-(** Create a new reporter.
-    Initially, the reporter is in a disabled state where events are ignored and
-    no trace file is written. *)
-val make : unit -> t
+(** Create a reporter: open a trace file and further events will be logged into
+    it. It is necessary to call [close] on the reporter to make the file valid.
+*)
+val make : string -> t
 
 (** Return a fake reporter that reads time in a reference and writes JSON
     objects to a buffer. *)
@@ -16,10 +16,6 @@ val fake : float ref -> Buffer.t -> t
 
 (** Output trailing data to make the underlying file valid JSON, and close it. *)
 val close : t -> unit
-
-(** Enable tracing: open a trace file and further events will be logged into it.
-    It is necessary to call [close] on the reporter to make the file valid. *)
-val enable : t -> string -> unit
 
 type event
 

--- a/src/process.ml
+++ b/src/process.ml
@@ -246,12 +246,6 @@ let cmdline_approximate_length prog args =
   List.fold_left args ~init:(String.length prog) ~f:(fun acc arg ->
     acc + String.length arg)
 
-let with_process ~program ~args fiber =
-  let event = Catapult.on_process_start Stats.catapult ~program ~args in
-  fiber >>| fun result ->
-  Catapult.on_process_end Stats.catapult event;
-  result
-
 let run_internal ?dir ?(stdout_to=Output.stdout) ?(stderr_to=Output.stderr)
       ~env ~purpose fail_mode prog args =
   Scheduler.wait_for_available_job ()
@@ -325,7 +319,7 @@ let run_internal ?dir ?(stdout_to=Output.stdout) ?(stderr_to=Output.stderr)
   in
   Output.release stdout_to;
   Output.release stderr_to;
-  with_process ~program:prog_str ~args (Scheduler.wait_for_process pid)
+  Stats.with_process ~program:prog_str ~args (Scheduler.wait_for_process pid)
   >>| fun exit_status ->
   Option.iter response_file ~f:Path.unlink;
   let output =

--- a/src/stats.boot.ml
+++ b/src/stats.boot.ml
@@ -1,7 +1,5 @@
-let enable () = ()
+let enable _path = ()
 
 let record () = ()
-
-let enable_catapult _path = ()
 
 let with_process ~program:_ ~args:_ fiber = fiber

--- a/src/stats.boot.ml
+++ b/src/stats.boot.ml
@@ -1,0 +1,7 @@
+let enable () = ()
+
+let record () = ()
+
+let enable_catapult _path = ()
+
+let with_process ~program:_ ~args:_ fiber = fiber

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -51,7 +51,10 @@ let observed_max =
   { fds = Unknown
   }
 
+let catapult = Catapult.make ()
+
 let record () =
+  Catapult.emit_gc_counters catapult;
   if !enabled then begin
     let fds = Fd_count.get () in
     observed_max.fds <- Fd_count.max fds observed_max.fds
@@ -66,8 +69,6 @@ let dump () =
 let enable () =
   enabled := true;
   at_exit dump
-
-let catapult = Catapult.make ()
 
 let enable_catapult path =
   Catapult.enable catapult path;

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -72,3 +72,10 @@ let catapult = Catapult.make ()
 let enable_catapult path =
   Catapult.enable catapult path;
   at_exit (fun () -> Catapult.close catapult)
+
+let with_process ~program ~args fiber =
+  let open Fiber.O in
+  let event = Catapult.on_process_start catapult ~program ~args in
+  fiber >>| fun result ->
+  Catapult.on_process_end catapult event;
+  result

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -1,7 +1,5 @@
 open Stdune
 
-let enabled = ref false
-
 module Fd_count = struct
   type t = Unknown | This of int
 
@@ -30,47 +28,20 @@ module Fd_count = struct
       | value -> value
       end
     | files -> This (Array.length files - 1 (* -1 for the dirfd *))
-
-  let map2 ~f a b =
-    match a, b with
-    | Unknown, x | x, Unknown -> x
-    | This a, This b -> This (f a b)
-
-  let max = map2 ~f:max
-
-  let to_string = function
-    | Unknown -> "unknown"
-    | This n -> string_of_int n
 end
-
-type t =
-  { mutable fds : Fd_count.t
-  }
-
-let observed_max =
-  { fds = Unknown
-  }
 
 let catapult = ref None
 
 let record () =
-  Option.iter !catapult ~f:Catapult.emit_gc_counters;
-  if !enabled then begin
-    let fds = Fd_count.get () in
-    observed_max.fds <- Fd_count.max fds observed_max.fds
-  end
+  Option.iter !catapult ~f:(fun reporter ->
+    Catapult.emit_gc_counters reporter;
+    match Fd_count.get () with
+    | This fds ->
+      Catapult.emit_counter reporter "fds" fds
+    | Unknown -> ()
+  )
 
-let dump () =
-  let pr fmt = Printf.eprintf (fmt ^^ "\n") in
-  pr "Stats:";
-  pr "max opened fds: %s" (Fd_count.to_string observed_max.fds);
-  flush stderr
-
-let enable () =
-  enabled := true;
-  at_exit dump
-
-let enable_catapult path =
+let enable path =
   let reporter = Catapult.make path in
   catapult := Some reporter;
   at_exit (fun () -> Catapult.close reporter)

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -6,6 +6,6 @@ val enable : unit -> unit
 (** If stats recording is enabled, collect stats now *)
 val record : unit -> unit
 
-val catapult : Catapult.t
-
 val enable_catapult : string -> unit
+
+val with_process : program:string -> args:string list -> 'a Fiber.t -> 'a Fiber.t

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -1,11 +1,10 @@
 (** Collect stats during the execution of dune *)
 
 (** Enable stats recording *)
-val enable : unit -> unit
+val enable : string -> unit
 
 (** If stats recording is enabled, collect stats now *)
 val record : unit -> unit
 
-val enable_catapult : string -> unit
-
+(** Collect data about a subprocess *)
 val with_process : program:string -> args:string list -> 'a Fiber.t -> 'a Fiber.t

--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -2,16 +2,16 @@
 
 This captures the commands that are being run:
 
-  $ <trace.json grep '"X"' | sed -E 's/ [0-9]+/ .../g'
-  [{"name": "ocamlc.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_uninterruptible", "args": ["-config"]}
-  ,{"name": "ocamldep.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_runnable", "args": ["-modules","-impl","prog.ml"]}
-  ,{"name": "ocamlc.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_uninterruptible", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmo","-c","-impl","prog.ml"]}
-  ,{"name": "ocamlopt.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_running", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmx","-c","-impl","prog.ml"]}
-  ,{"name": "ocamlopt.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_running", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/prog.cmx"]}
+  $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/ [0-9]+/ .../g'
+  {"name": "ocamlc.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_uninterruptible", "args": ["-config"]}
+  {"name": "ocamldep.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_runnable", "args": ["-modules","-impl","prog.ml"]}
+  {"name": "ocamlc.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_uninterruptible", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmo","-c","-impl","prog.ml"]}
+  {"name": "ocamlopt.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_running", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmx","-c","-impl","prog.ml"]}
+  {"name": "ocamlopt.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_running", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/prog.cmx"]}
 
 As well as data about the garbage collector:
 
-  $ <trace.json grep '"C"' | sed -E 's/ [0-9]+/ .../g' | sort -u
-  ,{"name": "free_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  ,{"name": "live_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  ,{"name": "stack_size", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
+  $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/ [0-9]+/ .../g' | sort -u
+  {"name": "free_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
+  {"name": "live_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
+  {"name": "stack_size", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}

--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -12,6 +12,7 @@ This captures the commands that are being run:
 As well as data about the garbage collector:
 
   $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/ [0-9]+/ .../g' | sort -u
+  {"name": "fds", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
   {"name": "free_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
   {"name": "live_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
   {"name": "stack_size", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}

--- a/test/unit-tests/catapult.mlt
+++ b/test/unit-tests/catapult.mlt
@@ -26,6 +26,9 @@ time := 30.;;
 Catapult.on_process_end c e;;
 [%%ignore]
 
+Catapult.emit_gc_counters c;;
+[%%ignore]
+
 Catapult.close c;;
 [%%ignore]
 


### PR DESCRIPTION
- let `Stats` be responsible for enabling/disabling
- cut this part off when bootstrapping
- use catapult for fd tracking