### PR TITLE
Add --no-print-directory command line argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,9 @@ unreleased
 
 - Add `--trace-file` option to trace dune internals (#1639, fix #1180, @emillon)
 
+- Add `--no-print-directory` (borrowed from GNU make) to suppress
+  `Entering directory` messages. (#1668, @dra27)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -20,6 +20,7 @@ type t =
   ; force                 : bool
   ; ignore_promoted_rules : bool
   ; build_dir             : string
+  ; no_print_directory    : bool
   ; (* Original arguments for the external-lib-deps hint *)
     orig_args             : string list
   ; config                : Config.t
@@ -47,6 +48,7 @@ let set_common_other c ~targets =
   Clflags.auto_promote := c.auto_promote;
   Clflags.force := c.force;
   Clflags.watch := c.watch;
+  Clflags.no_print_directory := c.no_print_directory;
   Clflags.external_lib_deps_hint :=
     List.concat
       [ ["dune"; "external-lib-deps"; "--missing"]
@@ -341,6 +343,11 @@ let term =
          & info ["trace-file"] ~docs ~docv:"FILE"
              ~doc:"Output trace data in catapult format
                    (compatible with chrome://tracing)")
+  and no_print_directory =
+    Arg.(value
+         & flag
+         & info ["no-print-directory"] ~docs
+             ~doc:"Suppress \"Entering directory\" messages")
   in
   let build_dir = Option.value ~default:"_build" build_dir in
   let root, to_cwd =
@@ -392,6 +399,7 @@ let term =
   ; x
   ; config
   ; build_dir
+  ; no_print_directory
   ; default_target
   ; watch
   ; stats

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -16,6 +16,7 @@ type t =
   ; force                 : bool
   ; ignore_promoted_rules : bool
   ; build_dir             : string
+  ; no_print_directory    : bool
   ; (* Original arguments for the external-lib-deps hint *)
     orig_args             : string list
   ; config                : Config.t

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -48,6 +48,9 @@ to setup the configuration of the workspace unless the ``--workspace``
 command line option is used. See the section `Workspace
 configuration`_ for the syntax of this file.
 
+The ``Entering directory`` message can be suppressed with the
+``--no-print-directory`` command line option (as in GNU make).
+
 Current directory
 -----------------
 

--- a/src/clflags.ml
+++ b/src/clflags.ml
@@ -7,3 +7,4 @@ let diff_command = ref None
 let auto_promote = ref false
 let force = ref false
 let watch = ref false
+let no_print_directory = ref false

--- a/src/clflags.mli
+++ b/src/clflags.mli
@@ -26,3 +26,6 @@ val force : bool ref
 
 (** Instead of terminating build after completion, watch for changes *)
 val watch : bool ref
+
+(** Do not print "Entering directory" messages *)
+val no_print_directory : bool ref

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -642,7 +642,7 @@ let prepare ?(log=Log.no_log) ?(config=Config.default)
   Signal_watcher.init ();
   Process_watcher.init ();
   let cwd = Sys.getcwd () in
-  if cwd <> initial_cwd then
+  if cwd <> initial_cwd && not !Clflags.no_print_directory then
     Printf.eprintf "Entering directory '%s'\n%!"
       (if Config.inside_dune then
          let descendant_simple p ~of_ =


### PR DESCRIPTION
Suppresses the `Entering directory` message, as in GNU make.