### PR TITLE
Catapult: use async events

### DIFF
--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -2,12 +2,17 @@
 
 This captures the commands that are being run:
 
-  $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/ [0-9]+/ .../g'
-  {"name": "ocamlc.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_uninterruptible", "args": ["-config"]}
-  {"name": "ocamldep.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_runnable", "args": ["-modules","-impl","prog.ml"]}
-  {"name": "ocamlc.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_uninterruptible", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmo","-c","-impl","prog.ml"]}
-  {"name": "ocamlopt.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_running", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmx","-c","-impl","prog.ml"]}
-  {"name": "ocamlopt.opt", "pid": ..., "tid": ..., "ph": "X", "dur": ..., "ts": ..., "color": "thread_state_running", "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/prog.cmx"]}
+  $ <trace.json grep '"[be]"' | cut -c 2- | sed -E 's/ [0-9]+/ .../g'
+  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-config"]}
+  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
+  {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-modules","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
+  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmo","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/prog.cmx","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/prog.cmx"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
 
 As well as data about the garbage collector:
 

--- a/test/unit-tests/catapult.mlt
+++ b/test/unit-tests/catapult.mlt
@@ -40,29 +40,10 @@ let buffer_lines () =
 buffer_lines ();;
 [%%expect{|
 - : string list =
-["[{\"name\": \"program\", \"pid\": 0, \"tid\": 0, \"ph\": \"X\", \"dur\": 20000000, \"ts\": 30000000, \"color\": \"generic_work\", \"args\": [\"arg1\",\"arg2\"]}";
+["[{\"cat\": \"process\", \"name\": \"program\", \"id\": 0, \"pid\": 0, \"ph\": \"b\", \"ts\": 10000000, \"args\": [\"arg1\",\"arg2\"]}";
+ ",{\"cat\": \"process\", \"name\": \"program\", \"id\": 0, \"pid\": 0, \"ph\": \"e\", \"ts\": 30000000}";
  ",{\"name\": \"live_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
  ",{\"name\": \"free_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
  ",{\"name\": \"stack_size\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
  "]"; ""]
-|}]
-
-let get_program_line program =
-  Buffer.clear buf;
-  let e = Catapult.on_process_start c ~program ~args:[] in
-  Catapult.on_process_end c e;
-  List.hd (buffer_lines ())
-;;
-[%%ignore]
-
-(* opt compilers and non-opt have the same color *)
-get_program_line "ocamlc.opt";;
-[%%expect{|
-- : string =
-",{\"name\": \"ocamlc.opt\", \"pid\": 0, \"tid\": 0, \"ph\": \"X\", \"dur\": 0, \"ts\": 30000000, \"color\": \"thread_state_uninterruptible\", \"args\": []}"
-|}]
-get_program_line "ocamlc";;
-[%%expect{|
-- : string =
-",{\"name\": \"ocamlc\", \"pid\": 0, \"tid\": 0, \"ph\": \"X\", \"dur\": 0, \"ts\": 30000000, \"color\": \"thread_state_uninterruptible\", \"args\": []}"
 |}]


### PR DESCRIPTION
Instead of computing the duration and emitting a single event, this outputs one event when the process starts and one when the process ends. They are linked by an auto-incremented id.

Bonus parts:
- we can get rid of the color generation code
- it looks nicer

Before:

![before](https://user-images.githubusercontent.com/496345/50030349-be9f1580-fff4-11e8-9f0e-a966c576ab89.png)

After:

![after](https://user-images.githubusercontent.com/496345/50030436-c3fc6000-fff4-11e8-9645-ae7066ff4a2f.png)