### PR TITLE
Add macros %{ocaml_flags:...} and %{link_flags:...}

### DIFF
--- a/src/expander.ml
+++ b/src/expander.ml
@@ -347,15 +347,10 @@ let expand_and_record acc ~map_exe ~dep_kind ~scope
             "Package %S doesn't exist in the current project." s
         }
     end
-  | Macro (Ocaml_flags, mode) ->
-    begin match Mode.of_string mode with
-    | Some mode ->
-      add_ddep (Ocaml_flags.get ocaml_flags mode >>^ Value.L.strings)
-    | None ->
-      Resolved_forms.add_fail acc { fail = fun () ->
-        Errors.fail loc "Unrecognized mode %S." mode
-      }
-    end
+  | Var Ocamlc_flags ->
+    add_ddep (Ocaml_flags.get ocaml_flags Mode.Byte >>^ Value.L.strings)
+  | Var Ocamlopt_flags ->
+    add_ddep (Ocaml_flags.get ocaml_flags Mode.Native >>^ Value.L.strings)
 
 let expand_and_record_deps acc ~dir ~read_package ~dep_kind
       ~targets_written_by_user ~map_exe ~expand_var ~ocaml_flags

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -84,6 +84,7 @@ val with_record_deps
   -> dep_kind:Lib_deps_info.Kind.t
   -> targets_written_by_user:targets
   -> map_exe:(Path.t -> Path.t)
+  -> ocaml_flags:Ocaml_flags.t
   -> t
 
 val with_record_no_ddeps
@@ -91,6 +92,7 @@ val with_record_no_ddeps
   -> Resolved_forms.t
   -> dep_kind:Lib_deps_info.Kind.t
   -> map_exe:(Path.t -> Path.t)
+  -> ocaml_flags:Ocaml_flags.t
   -> t
 
 val add_ddeps_and_bindings

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -56,6 +56,7 @@ module L : sig
   val include_paths : t -> stdlib_dir:Path.t -> Path.Set.t
   val include_flags : t -> stdlib_dir:Path.t -> _ Arg_spec.t
 
+  val c_include_paths : t -> stdlib_dir:Path.t -> Path.Set.t
   val c_include_flags : t -> stdlib_dir:Path.t -> _ Arg_spec.t
 
   val link_flags : t -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -3,6 +3,11 @@ open! Import
 
 type t = Byte | Native
 
+let of_string = function
+  | "byte" -> Some Byte
+  | "native" -> Some Native
+  | _ -> None
+
 let all = [Byte; Native]
 
 let decode =

--- a/src/mode.mli
+++ b/src/mode.mli
@@ -2,6 +2,8 @@ open! Import
 
 type t = Byte | Native
 
+val of_string : string -> t option
+
 val decode : t Dune_lang.Decoder.t
 
 val all : t list

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -40,6 +40,7 @@ module Macro = struct
     | Ocaml_config
     | Env
     | Link_flags
+    | Ocaml_flags
 
   let to_sexp =
     let open Sexp.Encoder in
@@ -58,6 +59,7 @@ module Macro = struct
     | Ocaml_config -> string "Ocaml_config"
     | Env -> string "Env"
     | Link_flags -> string "Link_flags"
+    | Ocaml_flags -> string "Ocaml_flags"
 
   let pp_debug fmt t =
     Sexp.pp fmt (to_sexp t)
@@ -156,6 +158,7 @@ module Map = struct
       ; "env", since ~version:(1, 4) Macro.Env
 
       ; "link_flags", macro Link_flags
+      ; "ocaml_flags", macro Ocaml_flags
       ]
 
   let create ~(context : Context.t) ~cxx_flags =

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -39,6 +39,7 @@ module Macro = struct
     | Path_no_dep
     | Ocaml_config
     | Env
+    | Link_flags
 
   let to_sexp =
     let open Sexp.Encoder in
@@ -56,6 +57,7 @@ module Macro = struct
     | Path_no_dep -> string "Path_no_dep"
     | Ocaml_config -> string "Ocaml_config"
     | Env -> string "Env"
+    | Link_flags -> string "Link_flags"
 
   let pp_debug fmt t =
     Sexp.pp fmt (to_sexp t)
@@ -152,6 +154,8 @@ module Map = struct
       ; "path-no-dep", deleted_in ~version:(1, 0) Macro.Path_no_dep
       ; "ocaml-config", macro Ocaml_config
       ; "env", since ~version:(1, 4) Macro.Env
+
+      ; "link_flags", macro Link_flags
       ]
 
   let create ~(context : Context.t) ~cxx_flags =

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -9,6 +9,8 @@ module Var = struct
     | Deps
     | Targets
     | Named_local
+    | Ocamlopt_flags
+    | Ocamlc_flags
 
   let to_sexp =
     let open Sexp.Encoder in
@@ -19,6 +21,8 @@ module Var = struct
     | Deps -> string "Deps"
     | Targets -> string "Targets"
     | Named_local -> string "Named_local"
+    | Ocamlopt_flags -> string "Ocamlopt_flags"
+    | Ocamlc_flags -> string "Ocamlc_flags"
 
   let pp_debug fmt t =
     Sexp.pp fmt (to_sexp t)
@@ -40,7 +44,6 @@ module Macro = struct
     | Ocaml_config
     | Env
     | Link_flags
-    | Ocaml_flags
 
   let to_sexp =
     let open Sexp.Encoder in
@@ -59,7 +62,6 @@ module Macro = struct
     | Ocaml_config -> string "Ocaml_config"
     | Env -> string "Env"
     | Link_flags -> string "Link_flags"
-    | Ocaml_flags -> string "Ocaml_flags"
 
   let pp_debug fmt t =
     Sexp.pp fmt (to_sexp t)
@@ -133,6 +135,8 @@ module Map = struct
       ; "@", renamed_in ~version:(1, 0) ~new_name:"targets"
       ; "^", renamed_in ~version:(1, 0) ~new_name:"deps"
       ; "SCOPE_ROOT", renamed_in ~version:(1, 0) ~new_name:"project_root"
+      ; "ocamlopt_flags", since ~version:(1, 7) Var.Ocamlopt_flags
+      ; "ocamlc_flags", since ~version:(1, 7) Var.Ocamlc_flags
       ]
 
   let macros =
@@ -158,7 +162,6 @@ module Map = struct
       ; "env", since ~version:(1, 4) Macro.Env
 
       ; "link_flags", macro Link_flags
-      ; "ocaml_flags", macro Ocaml_flags
       ]
 
   let create ~(context : Context.t) ~cxx_flags =

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -8,6 +8,8 @@ module Var : sig
     | Deps
     | Targets
     | Named_local
+    | Ocamlopt_flags
+    | Ocamlc_flags
 end
 
 module Macro : sig
@@ -26,7 +28,6 @@ module Macro : sig
     | Ocaml_config
     | Env
     | Link_flags
-    | Ocaml_flags
 end
 
 module Expansion : sig

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -26,6 +26,7 @@ module Macro : sig
     | Ocaml_config
     | Env
     | Link_flags
+    | Ocaml_flags
 end
 
 module Expansion : sig

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -25,6 +25,7 @@ module Macro : sig
     | Path_no_dep
     | Ocaml_config
     | Env
+    | Link_flags
 end
 
 module Expansion : sig

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -217,13 +217,13 @@ module Pkg_version = struct
     Build.vpath spec
 end
 
-let partial_expand sctx ~dep_kind ~targets_written_by_user ~map_exe
+let partial_expand sctx ~dir ~dep_kind ~targets_written_by_user ~map_exe
       ~expander t =
   let acc = Expander.Resolved_forms.empty () in
   let read_package = Pkg_version.read sctx in
   let expander =
-    Expander.with_record_deps expander  acc ~dep_kind ~targets_written_by_user
-      ~map_exe ~read_package in
+    Expander.with_record_deps expander acc ~dep_kind ~targets_written_by_user
+      ~map_exe ~read_package ~ocaml_flags:(Env.ocaml_flags sctx ~dir) in
   let partial = Action_unexpanded.partial_expand t ~expander ~map_exe in
   (partial, acc)
 
@@ -455,7 +455,7 @@ module Deps = struct
     let forms = Expander.Resolved_forms.empty () in
     let expander =
       Expander.with_record_no_ddeps expander forms
-        ~dep_kind:Optional ~map_exe:(fun x -> x)
+        ~dep_kind:Optional ~map_exe:(fun x -> x) ~ocaml_flags:Ocaml_flags.empty
     in
     let deps =
       List.map l ~f:(f t expander)
@@ -523,7 +523,7 @@ module Action = struct
            This will become an error in the future.";
     end;
     let t, forms =
-      partial_expand sctx ~expander ~dep_kind
+      partial_expand sctx ~dir ~expander ~dep_kind
         ~targets_written_by_user ~map_exe t
     in
     let { U.Infer.Outcome. deps; targets } =


### PR DESCRIPTION
This PR adds two macros that help writing explicit rules in some cases where the extra flexibility is needed. The first one,

- `%{ocaml_flags:mode}` gives the ocaml flags as computed by `dune` in the current directory.

- `%{link_flags:mode:libs}` produces the list of arguments needed to link an executable with `libs` (comma separated list of lib names).

(`mode` is either `byte` or `native`)

As mentioned, these are not for the casual user, but it gives an escape hatch when needed.

In my use case, I need to create `cmxs` and `exe`'s sharing a large number of modules (plugins) in a way that doesn't lend itself to a stratification by libraries and where copying modules around is too inefficient and just not convenient. With these variables I can define a "big" library that includes all plugins in order to set up the compilation of individual modules and can define explicit rules for the linking commands producing the individual `cmxs`'s and `exe`'s in a way "compatible" with `dune`.

It is not beautiful, but it is a fairly specialized need and I don't see an easy way to express this in `dune`'s current model.

Opinions?