### PR TITLE
Compile dune in `_build_bootstrap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bootstrap.cmo
 bootstrap.exe
 Makefile.dev
 src/setup.ml
+/_build_bootstrap

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -133,9 +133,9 @@ case "$TARGET" in
     ./boot.exe
     echo -en "travis_fold:end:dune.boot\r"
     if [ $WITH_OPAM -eq 1 ] ; then
-      _build/install/default/bin/dune runtest && \
-      _build/install/default/bin/dune build @test/blackbox-tests/runtest-js && \
-      ! _build/install/default/bin/dune build @test/fail-with-background-jobs-running
+      _build_bootstrap/install/default/bin/dune runtest && \
+      _build_bootstrap/install/default/bin/dune build @test/blackbox-tests/runtest-js && \
+      ! _build_bootstrap/install/default/bin/dune build @test/fail-with-background-jobs-running
       RESULT=$?
       if [ $UPDATE_OPAM -eq 0 ] ; then
         rm -rf ~/.opam

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX_ARG := $(if $(PREFIX),--prefix $(PREFIX),)
 LIBDIR_ARG := $(if $(LIBDIR),--libdir $(LIBDIR),)
 INSTALL_ARGS := $(PREFIX_ARG) $(LIBDIR_ARG)
-BIN := ./_build/default/bin/main_dune.exe
+BIN := ./_build_bootstrap/default/bin/main_dune.exe
 
 -include Makefile.dev
 
@@ -45,6 +45,7 @@ all-supported-ocaml-versions:
 clean:
 	rm -f ./boot.exe $(wildcard ./bootstrap.cmi ./bootstrap.cmo ./bootstrap.exe)
 	$(BIN) clean
+	rm -rf _build_bootstrap
 
 distclean: clean
 	rm -f src/setup.ml

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you do not have `make`, you can do the following:
 ```sh
 $ ocaml bootstrap.ml
 $ ./boot.exe
-$ ./_build/default/bin/main_dune.exe install dune
+$ ./_build_bootstrap/default/bin/main_dune.exe install dune
 ```
 
 Support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,11 @@ build_script:
   - cd "%APPVEYOR_BUILD_FOLDER%"
   - ocaml bootstrap.ml
   - boot.exe
-  - copy _build\install\default\bin\dune.exe dune.exe
+  - copy _build_bootstrap\install\default\bin\dune.exe dune.exe
   - dune.exe build @test\blackbox-tests\windows-diff
 
 artifacts:
   - path: _build/log
     name: build-log
+  - path: _build_bootstrap/log
+    name: build_bootstrap-log

--- a/src/main.ml
+++ b/src/main.ml
@@ -160,7 +160,7 @@ let set_concurrency ?log (config : Config.t) =
 let bootstrap () =
   Colors.setup_err_formatter_colors ();
   Path.set_root Path.External.initial_cwd;
-  Path.set_build_dir (Path.Kind.of_string "_build");
+  Path.set_build_dir (Path.Kind.of_string "_build_bootstrap");
   let main () =
     let anon s = raise (Arg.Bad (Printf.sprintf "don't know what to do with %s\n" s)) in
     let subst () =


### PR DESCRIPTION
During development if one modifies the rules that compiles dune, `make` and `make test` are removing the work done by the other. So for a more efficient workflow, this commit separate them in two build directories.