### PR TITLE
Add virtual kind in module

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -163,10 +163,7 @@ let build_modules_map (d : _ Dir_with_dune.t) ~modules =
           Obj_dir.make_local ~dir:d.ctx_dir (snd lib.name)
             ~has_private_modules:(Option.is_some lib.private_modules)
         in
-        let { Modules_field_evaluator.
-              all_modules = modules
-            ; virtual_modules
-            } =
+        let modules =
           Modules_field_evaluator.eval ~modules
             ~obj_dir
             ~buildable:lib.buildable
@@ -194,18 +191,14 @@ let build_modules_map (d : _ Dir_with_dune.t) ~modules =
             )
         in
         Left ( lib
-             , Lib_modules.make lib ~obj_dir modules ~virtual_modules
-                 ~main_module_name ~wrapped
+             , Lib_modules.make lib ~obj_dir modules ~main_module_name ~wrapped
              )
       | Executables exes
       | Tests { exes; _} ->
         let obj_dir =
           Obj_dir.make_exe ~dir:d.ctx_dir (List.hd exes.names |> snd)
         in
-        let { Modules_field_evaluator.
-              all_modules = modules
-            ; virtual_modules = _
-            } =
+        let modules =
           Modules_field_evaluator.eval ~modules
             ~obj_dir
             ~buildable:exes.buildable

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -181,6 +181,7 @@ include Sub_system.Register_end_point(
              ~impl:{ path   = Path.relative inline_test_dir main_module_filename
                    ; syntax = OCaml
                    }
+             ~kind:Impl
              ~visibility:Public
              ~obj_name:name
              ~obj_dir)

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -26,7 +26,6 @@ val make
   :  Dune_file.Library.t
   -> obj_dir:Obj_dir.t
   -> Module.Name_map.t
-  -> virtual_modules:Module.Name_map.t
   -> main_module_name:Module.Name.t option
   -> wrapped:Wrapped.t
   -> t

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -41,7 +41,7 @@ let libraries_link ~name ~loc ~mode cctx libs =
     SC.add_rule ~dir sctx (Build.write_file ml s);
     let impl = Module.File.make OCaml ml in
     let name = Module.Name.of_string basename in
-    let module_ = Module.make ~impl name ~visibility:Public ~obj_dir in
+    let module_ = Module.make ~impl name ~visibility:Public ~obj_dir ~kind:Impl in
     let cctx = Compilation_context.(
       create
         ~super_context:sctx

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -208,6 +208,7 @@ module Run (P : PARAMS) : sig end = struct
       Module.make
         name
         ~visibility:Public
+        ~kind:Impl
         ~impl:{ path = mock_ml base; syntax = OCaml }
         ~obj_dir:(Compilation_context.obj_dir cctx)
     in

--- a/src/module.mli
+++ b/src/module.mli
@@ -58,6 +58,12 @@ module Visibility : sig
   include Dune_lang.Conv with type t := t
 end
 
+module Kind : sig
+  type t = Intf_only | Virtual | Impl
+
+  include Dune_lang.Conv with type t := t
+end
+
 type t
 
 (** [obj_name] Object name. It is different from [name] for wrapped modules. *)
@@ -67,6 +73,7 @@ val make
   -> ?obj_name:string
   -> visibility:Visibility.t
   -> obj_dir:Obj_dir.t
+  -> kind:Kind.t
   -> Name.t
   -> t
 
@@ -147,9 +154,11 @@ end with type module_ := t
 
 val is_public : t -> bool
 val is_private : t -> bool
+val is_virtual : t -> bool
 
 val set_private : t -> t
-val set_obj_dir : obj_dir:Obj_dir.t -> t -> t
+val set_obj_dir : t -> obj_dir:Obj_dir.t -> t
+val set_virtual : t -> t
 
 val remove_files : t -> t
 
@@ -179,4 +188,5 @@ module Source : sig
 
   val src_dir : t -> Path.t option
 
+  val name : t -> Name.t
 end

--- a/src/modules_field_evaluator.mli
+++ b/src/modules_field_evaluator.mli
@@ -1,14 +1,7 @@
-open! Stdune
-
-type t = private
-  { all_modules : Module.Name_map.t
-  ; virtual_modules : Module.Name_map.t
-  }
-
 val eval
   :  modules:(Module.Source.t Module.Name.Map.t)
   -> obj_dir:Obj_dir.t
   -> buildable:Dune_file.Buildable.t
   -> virtual_modules:Ordered_set_lang.t option
   -> private_modules:Ordered_set_lang.t
-  -> t
+  -> Module.Name_map.t

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -95,6 +95,7 @@ let setup sctx ~dir =
                ; syntax = Module.Syntax.OCaml
                }
          ~obj_name:exe_name
+         ~kind:Impl
          ~obj_dir)
   in
   let loc = Loc.in_dir dir in

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -329,6 +329,10 @@ Include variants and implementation information in dune-package
    (modules
     (alias_module (name Vlib) (obj_name vlib) (visibility public) (impl))
     (main_module_name Vlib)
-    (modules ((name Vmod) (obj_name vlib__Vmod) (visibility public) (intf)))
-    (virtual_modules Vmod)
+    (modules
+     ((name Vmod)
+      (obj_name vlib__Vmod)
+      (visibility public)
+      (kind virtual)
+      (intf)))
     (wrapped true)))


### PR DESCRIPTION
  - remove encoding, decoding duplication
  - remove threading of `virtual_modules` information
  - simplifies moving `obj_dir` to module