### PR TITLE
wrapped-transition tests work on 4.06

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1205,7 +1205,7 @@
   (chdir
    test-cases/wrapped-transition
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.07.0 -test run.t)
+    (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -143,7 +143,7 @@ let exclusions =
   (* The next test is disabled as it relies on configured opam
      swtiches and it's hard to get that working properly *)
   ; make "envs-and-contexts" ~external_deps:true ~enabled:false
-  ; make "wrapped-transition" ~skip_ocaml:"<4.07.0"
+  ; make "wrapped-transition" ~skip_ocaml:"<4.06.0"
   ]
 
 let all_tests = lazy (


### PR DESCRIPTION
@bobot i've tested this on 4.06 and it seems to work.