### PR TITLE
Specifies the object directory in module

### DIFF
--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -7,10 +7,13 @@ let dev_files p =
   | ".cmi" -> true
   | _ -> false
 
-let add_obj_dir sctx ~dir ~obj_dir =
+let add_obj_dir sctx ~obj_dir =
   if (Super_context.context sctx).merlin then
-    Super_context.add_alias_deps
-      sctx
-      (Build_system.Alias.check ~dir)
-      ~dyn_deps:(Build.paths_matching ~loc:Loc.none ~dir:obj_dir dev_files)
-      Path.Set.empty
+    let f dir =
+      Super_context.add_alias_deps
+        sctx
+        (Build_system.Alias.check ~dir:obj_dir.Obj_dir.dir)
+        ~dyn_deps:(Build.paths_matching ~loc:Loc.none ~dir dev_files)
+        Path.Set.empty
+    in
+    List.iter ~f (Obj_dir.all_objs_dir obj_dir)

--- a/src/check_rules.mli
+++ b/src/check_rules.mli
@@ -1,3 +1,1 @@
-open Stdune
-
-val add_obj_dir : Super_context.t -> dir:Path.t -> obj_dir:Path.t -> unit
+val add_obj_dir : Super_context.t -> obj_dir:Obj_dir.t -> unit

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -48,10 +48,8 @@ type t =
   { super_context        : Super_context.t
   ; scope                : Scope.t
   ; expander             : Expander.t
-  ; dir                  : Path.t
+  ; obj_dir              : Obj_dir.t
   ; dir_kind             : Dune_lang.Syntax.t
-  ; obj_dir              : Path.t
-  ; private_obj_dir      : Path.t option
   ; modules              : Module.t Module.Name.Map.t
   ; alias_module         : Module.t option
   ; lib_interface_module : Module.t option
@@ -68,10 +66,9 @@ type t =
 let super_context        t = t.super_context
 let scope                t = t.scope
 let expander             t = t.expander
-let dir                  t = t.dir
+let dir                  t = t.obj_dir.dir
 let dir_kind             t = t.dir_kind
 let obj_dir              t = t.obj_dir
-let private_obj_dir      t = t.private_obj_dir
 let modules              t = t.modules
 let alias_module         t = t.alias_module
 let lib_interface_module t = t.lib_interface_module
@@ -86,19 +83,17 @@ let vimpl                t = t.vimpl
 
 let context              t = Super_context.context t.super_context
 
-let create ~super_context ~scope ~expander ~dir ?private_obj_dir
+let create ~super_context ~scope ~expander ~obj_dir
       ?vimpl
       ?(dir_kind=Dune_lang.Syntax.Dune)
-      ?(obj_dir=dir) ~modules ?alias_module ?lib_interface_module ~flags
+      ~modules ?alias_module ?lib_interface_module ~flags
       ~requires ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
       ~opaque ?stdlib () =
   { super_context
   ; scope
   ; expander
-  ; dir
-  ; dir_kind
   ; obj_dir
-  ; private_obj_dir
+  ; dir_kind
   ; modules
   ; alias_module
   ; lib_interface_module

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -17,11 +17,9 @@ val create
   :  super_context         : Super_context.t
   -> scope                 : Scope.t
   -> expander              : Expander.t
-  -> dir                   : Path.t
-  -> ?private_obj_dir      : Path.t
+  -> obj_dir               : Obj_dir.t
   -> ?vimpl                : Vimpl.t
   -> ?dir_kind             : Dune_lang.Syntax.t
-  -> ?obj_dir              : Path.t
   -> modules               : Module.t Module.Name.Map.t
   -> ?alias_module         : Module.t
   -> ?lib_interface_module : Module.t
@@ -43,8 +41,7 @@ val context              : t -> Context.t
 val scope                : t -> Scope.t
 val dir                  : t -> Path.t
 val dir_kind             : t -> Dune_lang.Syntax.t
-val obj_dir              : t -> Path.t
-val private_obj_dir      : t -> Path.t option
+val obj_dir              : t -> Obj_dir.t
 val modules              : t -> Module.t Module.Name.Map.t
 val alias_module         : t -> Module.t option
 val lib_interface_module : t -> Module.t option

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -986,6 +986,11 @@ module Library = struct
   let is_virtual t = Option.is_some t.virtual_modules
   let is_impl t = Option.is_some t.implements
 
+  let obj_dir ~dir t =
+    Obj_dir.make_local ~dir
+      ~has_private_modules:(t.private_modules <> None)
+      (snd t.name)
+
   module Main_module_name = struct
     type t = Module.Name.t option Inherited.t
   end

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -228,6 +228,7 @@ module Library : sig
   val best_name : t -> Lib_name.t
   val is_virtual : t -> bool
   val is_impl : t -> bool
+  val obj_dir : dir:Path.t -> t -> Obj_dir.t
 
   module Main_module_name : sig
     type t = Module.Name.t option Inherited.t

--- a/src/dune_package.ml
+++ b/src/dune_package.ml
@@ -112,9 +112,10 @@ module Lib = struct
     record (
       field_o "main_module_name" Module.Name.decode >>= fun main_module_name ->
       field_o "implements" (located Lib_name.decode) >>= fun implements ->
+      field "name" Lib_name.decode >>= fun name ->
+      let dir = Path.append_local base (dir_of_name name) in
       let%map synopsis = field_o "synopsis" string
       and loc = loc
-      and name = field "name" Lib_name.decode
       and modes = field_l "modes" Mode.decode
       and kind = field "kind" Lib_kind.decode
       and archives = mode_paths "archives"
@@ -127,7 +128,7 @@ module Lib = struct
       and virtual_ = field_b "virtual"
       and sub_systems = Sub_system_info.record_parser ()
       and modules = field_o "modules" (Lib_modules.decode
-                         ~implements:(Option.is_some implements) ~dir:base)
+                         ~implements:(Option.is_some implements) ~dir)
       in
       let modes = Mode.Dict.Set.of_list modes in
       { kind
@@ -146,7 +147,7 @@ module Lib = struct
       ; main_module_name
       ; virtual_
       ; version = None
-      ; dir = Path.append_local base (dir_of_name name)
+      ; dir
       ; modules
       ; modes
       }

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -124,14 +124,13 @@ let link_exe
   let sctx     = CC.super_context cctx in
   let ctx      = SC.context       sctx in
   let dir      = CC.dir           cctx in
-  let obj_dir  = CC.obj_dir       cctx in
   let requires = CC.requires      cctx in
   let expander = CC.expander      cctx in
   let mode = linkage.mode in
   let exe = Path.relative dir (name ^ linkage.ext) in
   let compiler = Option.value_exn (Context.compiler ctx mode) in
   let artifacts ~ext modules =
-    List.map modules ~f:(Module.obj_file ~obj_dir ~ext)
+    List.map modules ~f:(Module.obj_file ~ext)
   in
   let modules_and_cm_files =
     Build.memoize "cm files"

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -8,10 +8,9 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       (exes : Dune_file.Executables.t) =
   (* Use "eobjs" rather than "objs" to avoid a potential conflict
      with a library of the same name *)
-  let obj_dir =
-    Utils.executable_object_directory ~dir (List.hd exes.names |> snd)
+  let obj_dir = Obj_dir.make_exe ~dir (List.hd exes.names |> snd)
   in
-  Check_rules.add_obj_dir sctx ~dir ~obj_dir;
+  Check_rules.add_obj_dir sctx ~obj_dir;
   let requires = Lib.Compile.requires compile_info in
   let modules =
     Dir_contents.modules_of_executables dir_contents
@@ -87,9 +86,8 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       ~super_context:sctx
       ~expander
       ~scope
-      ~dir
-      ~dir_kind
       ~obj_dir
+      ~dir_kind
       ~modules
       ~flags
       ~requires
@@ -108,7 +106,8 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
      ~requires:(Lib.Compile.requires compile_info)
      ~flags:(Ocaml_flags.common flags)
      ~preprocess:(Dune_file.Buildable.single_preprocess exes.buildable)
-     ~objs_dirs:(Path.Set.singleton obj_dir))
+     (* only public_dir? *)
+     ~objs_dirs:(Path.Set.singleton obj_dir.Obj_dir.public_dir))
 
 let rules ~sctx ~dir ~dir_contents ~scope ~expander ~dir_kind
       (exes : Dune_file.Executables.t) =

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -164,10 +164,13 @@ include Sub_system.Register_end_point(
 
       let loc = lib.buildable.loc in
 
-      let inline_test_dir =
-        Path.relative dir (sprintf ".%s.inline-tests"
-                             (Lib_name.Local.to_string (snd lib.name)))
+      let inline_test_name =
+        sprintf "%s.inline-tests" (Lib_name.Local.to_string (snd lib.name))
       in
+
+      let inline_test_dir = Path.relative dir ("."^inline_test_name) in
+
+      let obj_dir = Obj_dir.make_exe ~dir:inline_test_dir inline_test_name in
 
       let name = "run" in
       let main_module_filename = name ^ ".ml" in
@@ -179,7 +182,8 @@ include Sub_system.Register_end_point(
                    ; syntax = OCaml
                    }
              ~visibility:Public
-             ~obj_name:name)
+             ~obj_name:name
+             ~obj_dir)
       in
 
       let bindings =
@@ -238,7 +242,7 @@ include Sub_system.Register_end_point(
           ~super_context:sctx
           ~expander
           ~scope
-          ~dir:inline_test_dir
+          ~obj_dir
           ~modules
           ~opaque:false
           ~requires:runner_libs

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -218,8 +218,6 @@ module Gen(P : Params) = struct
     in
     let module_files =
       let if_ cond l = if cond then l else [] in
-      let (_loc, lib_name_local) = lib.name in
-      let obj_dir = Utils.library_object_directory ~dir lib_name_local in
       let { Mode.Dict.byte ; native } =
         Dune_file.Mode_conf.Set.eval lib.modes
           ~has_native:(Option.is_some ctx.ocamlopt)
@@ -228,14 +226,14 @@ module Gen(P : Params) = struct
       List.concat_map installable_modules ~f:(fun m ->
         List.concat
           [ if_ (Module.is_public m)
-              [ Module.cm_file_unsafe m ~obj_dir Cmi ]
+              [ Module.cm_file_unsafe m Cmi ]
           ; if_ (native && Module.has_impl m)
-              [ Module.cm_file_unsafe m ~obj_dir Cmx ]
+              [ Module.cm_file_unsafe m Cmx ]
           ; if_ (byte && Module.has_impl m && virtual_library)
-              [ Module.cm_file_unsafe m ~obj_dir Cmo ]
+              [ Module.cm_file_unsafe m Cmo ]
           ; if_ (native && Module.has_impl m && virtual_library)
-              [ Module.obj_file m ~obj_dir ~ext:ctx.ext_obj ]
-          ; List.filter_map Ml_kind.all ~f:(Module.cmt_file m ~obj_dir)
+              [ Module.obj_file m ~ext:ctx.ext_obj ]
+          ; List.filter_map Ml_kind.all ~f:(Module.cmt_file m)
           ])
     in
     let archives = Lib_archives.make ~ctx ~dir lib in

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -16,9 +16,7 @@ val name : t -> Lib_name.t
 val src_dir : t -> Path.t
 
 (** Directory where the object files for the library are located. *)
-val obj_dir : t -> Path.t
-
-val private_obj_dir : t -> Path.t option
+val obj_dir : t -> Obj_dir.t
 
 (** Same as [Path.is_managed (obj_dir t)] *)
 val is_local : t -> bool
@@ -81,7 +79,7 @@ end
 module Lib_and_module : sig
   type nonrec t =
     | Lib of t
-    | Module of Module.t * Path.t (** obj_dir *)
+    | Module of Module.t
 
   val link_flags : t list -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
 

--- a/src/lib_file_deps.ml
+++ b/src/lib_file_deps.ml
@@ -26,7 +26,7 @@ module L = struct
         (lib_files_alias ~dir:(Lib.src_dir lib) ~name:(Lib.name lib) ~exts)
     else
       Build_system.stamp_file_for_files_of (Super_context.build_system t)
-        ~dir:(Lib.obj_dir lib) ~ext:(string_of_exts exts)
+        ~dir:(Lib.obj_dir lib).public_dir ~ext:(string_of_exts exts)
 
   let file_deps_with_exts t lib_exts =
     List.rev_map lib_exts ~f:(fun (lib, exts) -> file_deps_of_lib t lib ~exts)

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -33,8 +33,7 @@ type t = private
   ; kind             : Lib_kind.t
   ; status           : Status.t
   ; src_dir          : Path.t
-  ; obj_dir          : Path.t
-  ; private_obj_dir  : Path.t option
+  ; obj_dir          : Obj_dir.t
   ; version          : string option
   ; synopsis         : string option
   ; archives         : Path.t list Mode.Dict.t

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -24,7 +24,7 @@ val public_modules : t -> Module.Name_map.t
 
 val make
   :  Dune_file.Library.t
-  -> dir:Path.t
+  -> obj_dir:Obj_dir.t
   -> Module.Name_map.t
   -> virtual_modules:Module.Name_map.t
   -> main_module_name:Module.Name.t option
@@ -32,6 +32,8 @@ val make
   -> t
 
 val set_modules : t -> Module.Name_map.t -> t
+
+val version_installed : t -> install_dir:Path.t -> t
 
 val for_compilation : t -> Module.Name_map.t
 

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -209,6 +209,7 @@ module Run (P : PARAMS) : sig end = struct
         name
         ~visibility:Public
         ~impl:{ path = mock_ml base; syntax = OCaml }
+        ~obj_dir:(Compilation_context.obj_dir cctx)
     in
 
     (* The following incantation allows the mock [.ml] file to be preprocessed

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -144,7 +144,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~scope ~dir_kind
                   Lib.src_dir lib
                   |> Path.drop_optional_build_context)
               ,
-              Path.Set.add obj_dirs (Lib.obj_dir lib)
+              Path.Set.add obj_dirs (Lib.obj_dir lib).public_dir
             ))
         in
         let src_dirs =

--- a/src/module.mli
+++ b/src/module.mli
@@ -66,6 +66,7 @@ val make
   -> ?intf:File.t
   -> ?obj_name:string
   -> visibility:Visibility.t
+  -> obj_dir:Obj_dir.t
   -> Name.t
   -> t
 
@@ -76,28 +77,31 @@ val real_unit_name : t -> Name.t
 
 val intf : t -> File.t option
 val impl : t -> File.t option
+val obj_dir : t -> Obj_dir.t
 
 val pp_flags : t -> (unit, string list) Build.t option
 
 val file      : t -> Ml_kind.t -> Path.t option
 val cm_source : t -> Cm_kind.t -> Path.t option
-val cm_file   : t -> obj_dir:Path.t -> Cm_kind.t -> Path.t option
-val cmt_file  : t -> obj_dir:Path.t -> Ml_kind.t -> Path.t option
+val cm_file   : t -> Cm_kind.t -> Path.t option
+val cmt_file  : t -> Ml_kind.t -> Path.t option
 
-val obj_file : t -> obj_dir:Path.t -> ext:string -> Path.t
+val obj_file : t -> ext:string -> Path.t
 
 val obj_name : t -> string
 
 val src_dir : t -> Path.t option
 
 (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx]
-    and the module has no implementation. *)
-val cm_file_unsafe : t -> obj_dir:Path.t -> Cm_kind.t -> Path.t
+    and the module has no implementation.
+    If present [ext] replace the extension of the kind
+ *)
+val cm_file_unsafe : t -> ?ext:string -> Cm_kind.t -> Path.t
 
 val odoc_file : t -> doc_dir:Path.t -> Path.t
 
 (** Either the .cmti, or .cmt if the module has no interface *)
-val cmti_file : t -> obj_dir:Path.t -> Path.t
+val cmti_file : t -> Path.t
 
 val iter : t -> f:(Ml_kind.t -> File.t -> unit) -> unit
 
@@ -145,6 +149,7 @@ val is_public : t -> bool
 val is_private : t -> bool
 
 val set_private : t -> t
+val set_obj_dir : obj_dir:Obj_dir.t -> t -> t
 
 val remove_files : t -> t
 
@@ -155,3 +160,23 @@ val visibility : t -> Visibility.t
 val encode : t -> Dune_lang.t list
 
 val decode : dir:Path.t -> t Dune_lang.Decoder.t
+
+(* Only the source of a module, not yet associated to a library *)
+module Source : sig
+  type t = private
+    { name : Name.t
+    ; impl : File.t option
+    ; intf : File.t option
+    }
+
+  val make
+    :  ?impl:File.t
+    -> ?intf:File.t
+    -> Name.t
+    -> t
+
+  val has_impl: t -> bool
+
+  val src_dir : t -> Path.t option
+
+end

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -6,20 +6,6 @@ open! No_io
 module CC = Compilation_context
 module SC = Super_context
 
-module Target : sig
-  type t
-  val cm : Module.t -> Cm_kind.t -> t
-  val obj : Module.t -> ext:string -> t
-  val cmt : Module.t -> Ml_kind.t -> t option
-  val file : Path.t -> t -> Path.t
-end = struct
-  type t = Path.t
-  let cm m cm_kind = Module.cm_file_unsafe m ~obj_dir:Path.root cm_kind
-  let obj m ~ext = Module.obj_file m ~obj_dir:Path.root ~ext
-  let cmt m ml_kind = Module.cmt_file m ~obj_dir:Path.root ml_kind
-  let file dir t = Path.append dir t
-end
-
 (* Arguments for the compiler to prevent it from being too clever.
 
    The compiler creates the cmi when it thinks a .ml file has no
@@ -38,14 +24,13 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
   let obj_dir  = CC.obj_dir       cctx in
   let ctx      = SC.context       sctx in
   let stdlib   = CC.stdlib        cctx in
-  let private_obj_dir = CC.private_obj_dir cctx in
   let vimpl    = CC.vimpl cctx in
   Mode.of_cm_kind cm_kind
   |> Context.compiler ctx
   |> Option.iter ~f:(fun compiler ->
     Option.iter (Module.cm_source m cm_kind) ~f:(fun src ->
       let ml_kind = Cm_kind.source cm_kind in
-      let dst = Module.cm_file_unsafe m ~obj_dir cm_kind in
+      let dst = Module.cm_file_unsafe m cm_kind in
       let extra_args, extra_deps, other_targets =
         match cm_kind, Module.intf m
               , Vimpl.is_public_vlib_module vimpl m with
@@ -53,17 +38,17 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
            .cmY and .cmi. We choose to use ocamlc to produce the cmi
            and to produce the cmx we have to wait to avoid race
            conditions. *)
-        | Cmo, None, false -> [], [], [Target.cm m Cmi]
+        | Cmo, None, false -> [], [], [Module.cm_file_unsafe m Cmi]
         | Cmo, None, true
         | (Cmo | Cmx), _, _ ->
           force_read_cmi src,
-          [Module.cm_file_unsafe m ~obj_dir Cmi],
+          [Module.cm_file_unsafe m Cmi],
           []
         | Cmi, _, _ -> [], [], []
       in
       let other_targets =
         match cm_kind with
-        | Cmx -> Target.obj m ~ext:ctx.ext_obj :: other_targets
+        | Cmx -> Module.obj_file m ~ext:ctx.ext_obj :: other_targets
         | Cmi | Cmo -> other_targets
       in
       let dep_graph = Ml_kind.Dict.get dep_graphs ml_kind in
@@ -73,9 +58,9 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
           (Dep_graph.deps_of dep_graph m >>^ fun deps ->
            List.concat_map deps
              ~f:(fun m ->
-               let deps = [Module.cm_file_unsafe m ~obj_dir Cmi] in
+               let deps = [Module.cm_file_unsafe m Cmi] in
                if Module.has_impl m && cm_kind = Cmx && not opaque then
-                 Module.cm_file_unsafe m ~obj_dir Cmx :: deps
+                 Module.cm_file_unsafe m Cmx :: deps
                else
                  deps))
       in
@@ -83,17 +68,16 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
         match cm_kind with
         | Cmx -> (other_targets, Arg_spec.S [])
         | Cmi | Cmo ->
-          let fn = Option.value_exn (Target.cmt m ml_kind) in
+          let fn = Option.value_exn (Module.cmt_file m ml_kind) in
           (fn :: other_targets, A "-bin-annot")
       in
-      let hidden_targets = List.map other_targets ~f:(Target.file obj_dir) in
-      if CC.dir_kind cctx = Jbuild && obj_dir <> dir then begin
+      if CC.dir_kind cctx = Jbuild && obj_dir.public_dir <> dir then begin
         (* Symlink the object files in the original directory for
            backward compatibility *)
-        let old_dst = Module.cm_file_unsafe m ~obj_dir:dir cm_kind in
+        let old_dst = Path.relative dir ((Module.obj_name m) ^ (Cm_kind.ext cm_kind)) in
         SC.add_rule sctx ~dir (Build.symlink ~src:dst ~dst:old_dst);
-        List.iter2 hidden_targets other_targets ~f:(fun in_obj_dir target ->
-          let in_dir = Target.file dir target in
+        List.iter other_targets ~f:(fun in_obj_dir ->
+          let in_dir = Path.relative dir (Path.basename in_obj_dir) in
           SC.add_rule sctx ~dir (Build.symlink ~src:in_obj_dir ~dst:in_dir))
       end;
       let opaque_arg =
@@ -109,7 +93,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
           if Ocaml_version.supports_no_keep_locs ctx.version then
             (ctx.build_dir, Arg_spec.As ["-no-keep-locs"])
           else
-            (obj_dir, As [])
+            (obj_dir.public_dir, As [])
         end else
           (ctx.build_dir, As [])
       in
@@ -130,8 +114,8 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
            [ Dyn (fun flags -> As flags)
            ; no_keep_locs
            ; cmt_args
-           ; A "-I"; Path obj_dir
-           ; (match private_obj_dir with
+           ; A "-I"; Path obj_dir.public_dir
+           ; (match obj_dir.private_dir with
               | None -> S []
               | Some private_obj_dir -> S [A "-I"; Path private_obj_dir])
            ; Cm_kind.Dict.get (CC.includes cctx) cm_kind
@@ -161,7 +145,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
                        :: flags)
            ; A "-o"; Target dst
            ; A "-c"; Ml_kind.flag ml_kind; Dep src
-           ; Hidden_targets hidden_targets
+           ; Hidden_targets other_targets
            ])))
 
 let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
@@ -170,9 +154,8 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
   Option.iter js_of_ocaml ~f:(fun js_of_ocaml ->
     (* Build *.cmo.js *)
     let sctx     = CC.super_context cctx in
-    let obj_dir  = CC.obj_dir       cctx in
     let dir      = CC.dir           cctx in
-    let src = Module.cm_file_unsafe m ~obj_dir Cm_kind.Cmo in
+    let src = Module.cm_file_unsafe m Cm_kind.Cmo in
     let target = Path.extend_basename src ~suffix:".js" in
     SC.add_rules sctx ~dir
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
@@ -196,14 +179,14 @@ let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
     Build.dyn_paths
       (Dep_graph.deps_of dep_graph m >>^ fun deps ->
        List.concat_map deps
-         ~f:(fun m -> [Module.cm_file_unsafe m ~obj_dir Cmi]))
+         ~f:(fun m -> [Module.cm_file_unsafe m Cmi]))
   in
   SC.add_rule sctx ?sandbox ~dir
     (cm_deps >>>
      Ocaml_flags.get_for_cm (CC.flags cctx) ~cm_kind:Cmo >>>
      Build.run (Ok ctx.ocamlc) ~dir:ctx.build_dir
        [ Dyn (fun ocaml_flags -> As ocaml_flags)
-       ; A "-I"; Path obj_dir
+       ; A "-I"; Path obj_dir.public_dir
        ; Cm_kind.Dict.get (CC.includes cctx) Cmo
        ; (match CC.alias_module cctx with
           | None -> S []

--- a/src/modules_field_evaluator.mli
+++ b/src/modules_field_evaluator.mli
@@ -1,10 +1,13 @@
+open! Stdune
+
 type t = private
   { all_modules : Module.Name_map.t
   ; virtual_modules : Module.Name_map.t
   }
 
 val eval
-  :  modules:Module.Name_map.t
+  :  modules:(Module.Source.t Module.Name.Map.t)
+  -> obj_dir:Obj_dir.t
   -> buildable:Dune_file.Buildable.t
   -> virtual_modules:Ordered_set_lang.t option
   -> private_modules:Ordered_set_lang.t

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -1,0 +1,83 @@
+open! Stdune
+open Import
+
+type t =
+  { dir: Path.t (** The source_root directory *)
+  ; public_dir: Path.t  (** The public compiled file directory *)
+  ; private_dir: Path.t option   (** The private compiled file directory *)
+  }
+
+let all_objs_dir t = (t.public_dir::(Option.to_list t.private_dir))
+
+let make ~dir ~public_dir ?private_dir () =
+  { dir
+  ; public_dir
+  ; private_dir
+  }
+
+
+let make_local ~dir ~has_private_modules lib_name =
+  let obj_dir = Utils.library_object_directory ~dir lib_name in
+  let private_dir =
+    Option.some_if
+      has_private_modules
+      (Utils.library_private_obj_dir ~obj_dir)
+  in
+  make ~dir ~public_dir:obj_dir ?private_dir ()
+
+let make_exe ~dir exe_name =
+  let obj_dir = Utils.executable_object_directory ~dir exe_name in
+  make ~dir ~public_dir:obj_dir ?private_dir:None ()
+
+let make_external ~dir =
+  { dir
+  ; public_dir = dir
+  ; private_dir = None
+  }
+
+let to_sexp { dir; public_dir; private_dir } =
+  let open Sexp.Encoder in
+  record
+    [ "dir", Path.to_sexp dir
+    ; "public_dir", Path.to_sexp public_dir
+    ; "private_dir", (option Path.to_sexp) private_dir
+    ]
+
+let pp fmt { dir; public_dir; private_dir } =
+  Fmt.record fmt
+    [ "dir", Fmt.const Path.pp dir
+    ; "public_dir", Fmt.const Path.pp public_dir
+    ; "private_dir", Fmt.const (Fmt.optional Path.pp) private_dir
+    ]
+
+
+let encode
+      { dir
+      ; public_dir
+      ; private_dir
+      } =
+  let open Dune_lang.Encoder in
+  let extract d =
+    Path.descendant ~of_:dir d
+    |> Option.value_exn
+    |> Path.to_string
+  in
+  let public_dir = extract public_dir in
+  let private_dir = Option.map ~f:extract private_dir in
+  record_fields
+    [ field "public_dir" ~equal:String.equal ~default:"." string public_dir
+    ; field_o "private_dir" string private_dir
+    ]
+
+
+let decode ~dir =
+  let open Dune_lang.Decoder in
+  fields (
+    let%map public_dir = field ~default:"." "public_dir" string
+    and private_dir = field_o "private_dir" string
+    in
+    make ~dir
+      ~public_dir:(Path.relative dir public_dir)
+      ?private_dir:(Option.map ~f:(Path.relative dir) private_dir)
+      ()
+  )

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -1,0 +1,30 @@
+open! Stdune
+
+type t = private
+  { dir: Path.t (** The main directory *)
+  ; public_dir: Path.t  (** The public compiled file directory *)
+  ; private_dir: Path.t option   (** The private compiled file directory *)
+  }
+
+val pp: t Fmt.t
+val to_sexp: t -> Sexp.t
+
+val all_objs_dir: t -> Path.t list
+
+val make_local:
+  dir: Path.t ->
+  has_private_modules:bool ->
+  Lib_name.Local.t ->
+  t
+
+val make_exe:
+  dir: Path.t ->
+  string ->
+  t
+
+val make_external:
+  dir: Path.t ->
+  t
+
+val encode : t -> Dune_lang.t list
+val decode : dir:Path.t -> t Dune_lang.Decoder.t

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -102,7 +102,7 @@ let deps_of cctx ~ml_kind unit =
     | Some file ->
       let file_in_obj_dir ~suffix file =
         let base = Path.basename file in
-        Path.relative (Compilation_context.obj_dir cctx) (base ^ suffix)
+        Path.relative (Compilation_context.obj_dir cctx).public_dir (base ^ suffix)
       in
       let all_deps_path file = file_in_obj_dir file ~suffix:".all-deps" in
       let context = SC.context sctx in

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -121,7 +121,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
     >>^ List.map ~f:(Module.odoc_file ~doc_dir)
     |> Build.dyn_paths
 
-  let compile_module (m : Module.t) ~obj_dir ~includes:(file_deps, iflags)
+  let compile_module (m : Module.t) ~includes:(file_deps, iflags)
         ~dep_graphs ~doc_dir ~pkg_or_lnu =
     let odoc_file = Module.odoc_file m ~doc_dir in
     add_rule
@@ -135,7 +135,7 @@ module Gen (S : sig val sctx : SC.t end) = struct
          ; iflags
          ; As ["--pkg"; pkg_or_lnu]
          ; A "-o"; Target odoc_file
-         ; Dep (Module.cmti_file m ~obj_dir)
+         ; Dep (Module.cmti_file m)
          ]);
     (m, odoc_file)
 
@@ -206,11 +206,10 @@ module Gen (S : sig val sctx : SC.t end) = struct
        that a package contains only 1 library *)
     let pkg_or_lnu = pkg_or_lnu lib in
     let doc_dir = Paths.odocs (Lib lib) in
-    let obj_dir = Lib.obj_dir lib in
     let includes = (Dep.deps requires, odoc_include_flags requires) in
     let modules_and_odoc_files =
       List.map (Module.Name.Map.values modules) ~f:(
-        compile_module ~obj_dir ~includes ~dep_graphs
+        compile_module ~includes ~dep_graphs
           ~doc_dir ~pkg_or_lnu)
     in
     Dep.setup_deps (Lib lib) (List.map modules_and_odoc_files ~f:snd

--- a/src/stdune/option.ml
+++ b/src/stdune/option.ml
@@ -22,6 +22,11 @@ let iter t ~f =
   | None -> ()
   | Some x -> f x
 
+let forall t ~f =
+  match t with
+  | None -> true
+  | Some t -> f t
+
 let value t ~default =
   match t with
   | Some x -> x

--- a/src/stdune/option.mli
+++ b/src/stdune/option.mli
@@ -14,6 +14,8 @@ val bind : 'a t -> f:('a -> 'b t) -> 'b t
 
 val iter : 'a t -> f:('a -> unit) -> unit
 
+val forall: 'a t -> f:('a -> bool) -> bool
+
 val value : 'a t -> default:'a -> 'a
 val value_exn : 'a t -> 'a
 

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -83,6 +83,7 @@ let setup sctx ~dir =
   let expander = Super_context.expander sctx ~dir in
   let scope = Super_context.find_scope_by_dir sctx dir in
   let utop_exe_dir = utop_exe_dir ~dir in
+  let obj_dir = Obj_dir.make_exe ~dir:utop_exe_dir main_module_filename in
   let db = Scope.libs scope in
   let libs = libs_under_dir sctx ~db ~dir in
   let modules =
@@ -93,7 +94,8 @@ let setup sctx ~dir =
          ~impl:{ path   = Path.relative utop_exe_dir main_module_filename
                ; syntax = Module.Syntax.OCaml
                }
-         ~obj_name:exe_name)
+         ~obj_name:exe_name
+         ~obj_dir)
   in
   let loc = Loc.in_dir (Path.to_string dir) in
   let requires =
@@ -107,7 +109,7 @@ let setup sctx ~dir =
       ~super_context:sctx
       ~expander
       ~scope
-      ~dir:utop_exe_dir
+      ~obj_dir
       ~modules
       ~opaque:false
       ~requires

--- a/src/vimpl.mli
+++ b/src/vimpl.mli
@@ -8,6 +8,7 @@ type t
 val make
   :  vlib:Lib.t
   -> impl:Dune_file.Library.t
+  -> dir:Path.t
   -> vlib_modules:Lib_modules.t
   -> vlib_dep_graph:Dep_graph.Ml_kind.t
   -> t

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -5,44 +5,47 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
   let ctx = Super_context.context sctx in
   let vlib = Vimpl.vlib vimpl in
   let impl = Vimpl.impl vimpl in
+  let impl_obj_dir = Dune_file.Library.obj_dir ~dir impl in
+  let vlib_obj_dir = Lib.obj_dir vlib in
   let vlib_modules = Vimpl.vlib_modules vimpl in
-  let lib_name = snd impl.name in
-  let target_obj_dir =
-    let obj_dir = Utils.library_object_directory ~dir lib_name in
-    let private_obj_dir = Utils.library_private_obj_dir ~obj_dir in
-    fun m ->
-      if Module.is_public m then
-        obj_dir
-      else
-        private_obj_dir
-  in
-  let copy_to_obj_dir ~obj_dir file =
-    let dst = Path.relative obj_dir (Path.basename file) in
+  let copy_to_obj_dir ~src ~dst =
     Super_context.add_rule ~dir ~loc:(Loc.of_pos __POS__)
-      sctx (Build.symlink ~src:file ~dst)
+      sctx (Build.symlink ~src ~dst)
   in
-  let obj_dir = Lib.obj_dir vlib in
   let modes =
     Dune_file.Mode_conf.Set.eval impl.modes
       ~has_native:(Option.is_some ctx.ocamlopt) in
-  let copy_obj_file m ext =
-    let source = Module.obj_file m ~obj_dir ~ext in
-    copy_to_obj_dir ~obj_dir:(target_obj_dir m) source in
-  let copy_objs m =
-    copy_obj_file m (Cm_kind.ext Cmi);
-    if Module.has_impl m then begin
+  let copy_obj_file ~src ~dst ?ext kind =
+    let src = Module.cm_file_unsafe src ?ext kind in
+    let dst = Module.cm_file_unsafe dst ?ext kind in
+    copy_to_obj_dir ~src ~dst in
+  let copy_objs src =
+    let dst = Module.set_obj_dir ~obj_dir:impl_obj_dir src in
+    copy_obj_file ~src ~dst Cmi;
+    if Module.has_impl src then begin
       if modes.byte then
-        copy_obj_file m (Cm_kind.ext Cmo);
+        copy_obj_file ~src ~dst Cmo;
       if modes.native then
-        List.iter [Cm_kind.ext Cmx; ctx.ext_obj] ~f:(copy_obj_file m)
+        List.iter [Cm_kind.ext Cmx; ctx.ext_obj]
+          ~f:(fun ext -> copy_obj_file ~src ~dst ~ext Cmx)
     end
   in
   let copy_all_deps =
     let all_deps ~obj_dir f =
       Path.relative obj_dir (Path.basename f ^ ".all-deps") in
+    if Lib.is_local vlib then
+      fun m ->
+        if Module.is_public m then
+          List.iter [Intf; Impl] ~f:(fun kind ->
+            Module.file m kind
+            |> Option.iter ~f:(fun f ->
+              copy_to_obj_dir
+                ~src:(all_deps ~obj_dir:vlib_obj_dir.public_dir f)
+                ~dst:(all_deps ~obj_dir:impl_obj_dir.public_dir f))
+          );
+    else
     (* we only need to copy the .all-deps files for local libraries. for remote
        libraries, we just use ocamlobjinfo *)
-    if not (Lib.is_local vlib) then
       let vlib_dep_graph = Vimpl.vlib_dep_graph vimpl in
       fun m ->
         List.iter [Intf; Impl] ~f:(fun kind ->
@@ -55,20 +58,13 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
               |> List.map ~f:(fun m -> Module.Name.to_string (Module.name m))
               |> String.concat ~sep:"\n")
             >>>
-            Build.write_file_dyn (all_deps ~obj_dir:(target_obj_dir m) f)
+            Build.write_file_dyn (all_deps ~obj_dir:impl_obj_dir.public_dir f)
             |> Super_context.add_rule sctx ~dir))
-    else
-      fun m ->
-        if Module.is_public m then
-          List.iter [Intf; Impl] ~f:(fun kind ->
-            Module.file m kind
-            |> Option.iter ~f:(fun f ->
-              copy_to_obj_dir (all_deps ~obj_dir f) ~obj_dir:(target_obj_dir m))
-          );
   in
   Option.iter (Lib_modules.alias_module vlib_modules) ~f:copy_objs;
   Module.Name.Map.iter (Lib_modules.modules vlib_modules)
     ~f:(fun m -> copy_objs m; copy_all_deps m)
+
 
 let module_list ms =
   List.map ms ~f:(fun m -> sprintf "- %s" (Module.Name.to_string m))
@@ -136,7 +132,8 @@ let external_dep_graph sctx ~impl_cm_kind ~vlib_obj_dir ~impl_obj_dir ~modules =
   let ocamlobjinfo =
     let ctx = Super_context.context sctx in
     fun m cm_kind ->
-      let unit = Module.cm_file_unsafe m ~obj_dir:vlib_obj_dir cm_kind in
+      let m = Module.set_obj_dir ~obj_dir:vlib_obj_dir m in
+      let unit = Module.cm_file_unsafe m cm_kind in
       Ocamlobjinfo.rules ~dir:impl_obj_dir ~ctx ~unit
   in
   Ml_kind.Dict.of_func (fun ~ml_kind ->
@@ -198,7 +195,7 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         let modules = Lib_modules.modules vlib_modules in
         match virtual_ with
         | Local ->
-          Ocamldep.graph_of_remote_lib ~obj_dir:vlib_obj_dir ~modules
+          Ocamldep.graph_of_remote_lib ~obj_dir:vlib_obj_dir.public_dir ~modules
         | External _ ->
           let impl_obj_dir =
             Utils.library_object_directory ~dir (snd lib.name) in
@@ -212,5 +209,5 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
           external_dep_graph sctx ~impl_cm_kind ~vlib_obj_dir ~impl_obj_dir
             ~modules
       in
-      Vimpl.make ~impl:lib ~vlib ~vlib_modules ~vlib_dep_graph
+      Vimpl.make ~dir ~impl:lib ~vlib ~vlib_modules ~vlib_dep_graph
   end

--- a/test/blackbox-tests/test-cases/utop/run.t
+++ b/test/blackbox-tests/test-cases/utop/run.t
@@ -1,8 +1,8 @@
   $ dune utop --display short forutop -- init_forutop.ml
-      ocamldep forutop/.utop/utop.ml.d
+      ocamldep forutop/.utop/.utop.ml.eobjs/utop.ml.d
       ocamldep forutop/.forutop.objs/forutop.ml.d
         ocamlc forutop/.forutop.objs/forutop.{cmi,cmo,cmt}
         ocamlc forutop/forutop.cma
-        ocamlc forutop/.utop/utop.{cmi,cmo,cmt}
+        ocamlc forutop/.utop/.utop.ml.eobjs/utop.{cmi,cmo,cmt}
         ocamlc forutop/.utop/utop.exe
   hello in utop


### PR DESCRIPTION
Big refactorisation that push the object directory inside Module.t
  - Adds Module.Source.t for module source not yet with object so with `obj_dir`
  - Remove the need to thread the `obj_dir` everywhere
  - Requires to convert the virtual modules to the implementation module
  - Require to convert local module to the installed module 
  - utop target has now the same layout than other executables
  - the serialization of Module.t is relative to main library directory

