### PR TITLE
Make Loc.in_* functions take Path.t directly

### DIFF
--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -61,7 +61,7 @@ let rule_loc ~file_tree ~loc ~dir =
       | Some file -> File_tree.Dune_file.path file
       | None      -> Path.relative dir "_unknown_"
     in
-    Loc.in_file (Path.to_string file)
+    Loc.in_file file
 
 module Internal_rule = struct
   module Id = struct

--- a/src/context.ml
+++ b/src/context.ml
@@ -329,7 +329,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
              %s"
           (Path.to_string ocamlc) msg
       | Error (Makefile_config file, msg) ->
-        Errors.fail (Loc.in_file (Path.to_string file)) "%s" msg
+        Errors.fail (Loc.in_file file) "%s" msg
     in
     Fiber.fork_and_join
       findlib_paths

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -251,7 +251,7 @@ let build_modules_map (d : _ Dir_with_dune.t) ~modules =
               Option.some_if (n = name) b.loc)
             |> List.sort ~compare
           in
-          Errors.fail (Loc.in_file (List.hd locs).start.pos_fname)
+          Errors.fail (Loc.drop_position (List.hd locs))
             "Module %a is used in several stanzas:@\n\
              @[<v>%a@]@\n\
              @[%a@]"
@@ -276,7 +276,7 @@ let build_modules_map (d : _ Dir_with_dune.t) ~modules =
             List.sort ~compare
               (b.Buildable.loc :: List.map rest ~f:(fun b -> b.Buildable.loc))
           in
-          Errors.warn (Loc.in_file b.loc.start.pos_fname)
+          Errors.warn (Loc.drop_position b.loc)
             "Module %a is used in several stanzas:@\n\
              @[<v>%a@]@\n\
              @[%a@]@\n\
@@ -394,12 +394,11 @@ let rec get sctx ~dir =
               let modules = modules_of_files ~dir ~files in
               Module.Name.Map.union acc modules ~f:(fun name x y ->
                 Errors.fail (Loc.in_file
-                            (Path.to_string
                                (match File_tree.Dir.dune_file ft_dir with
                                 | None ->
                                   Path.relative (File_tree.Dir.path ft_dir)
                                     "_unknown_"
-                                | Some d -> File_tree.Dune_file.path d)))
+                                | Some d -> File_tree.Dune_file.path d))
                   "Module %a appears in several directories:\
                    @\n- %a\
                    @\n- %a"

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -208,7 +208,8 @@ module Parser = struct
         | Many -> sexps
         | Many_as_one ->
           match sexps with
-          | [] -> List (Loc.in_file lexbuf.lex_curr_p.pos_fname, [])
+          | [] -> List (Loc.in_file
+                          (Path.of_string lexbuf.lex_curr_p.pos_fname), [])
           | x :: l ->
             let last = List.fold_left l ~init:x ~f:(fun _ x -> x) in
             let loc = { (Ast.loc x) with stop = (Ast.loc last).stop } in

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -448,7 +448,7 @@ let default_name ~dir ~packages =
     match Name.named name with
     | Some x -> x
     | None ->
-      Errors.fail (Loc.in_file (Path.to_string (Package.opam_file pkg)))
+      Errors.fail (Loc.in_file (Package.opam_file pkg))
         "%S is not a valid opam package name."
         name
 

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -146,7 +146,7 @@ module Package = struct
     ; vars      : Vars.t
     }
 
-  let loc  t = Loc.in_dir (Path.to_string t.meta_file)
+  let loc  t = Loc.in_dir t.meta_file
   let name t = t.name
 
   let preds = Ps.of_list [P.ppx_driver; P.mt; P.mt_posix]

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -119,7 +119,7 @@ module Gen(P : Params) = struct
             match Local_package.virtual_lib pkg with
             | Some lib ->
               Build.fail { fail = fun () ->
-                Errors.fail (Loc.in_file (Path.to_string meta_template))
+                Errors.fail (Loc.in_file meta_template)
                   "Package %a defines virtual library %a and has a META \
                    template. This is not allowed."
                   Package.Name.pp (Local_package.name pkg)

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -212,7 +212,7 @@ module Driver = struct
     match loc with
     | User_file (loc, _) -> Error (Errors.exnf loc "%a" Fmt.text msg)
     | Dot_ppx (path, pps) ->
-      Error (Errors.exnf (Loc.in_file (Path.to_string path)) "%a" Fmt.text
+      Error (Errors.exnf (Loc.in_file path) "%a" Fmt.text
                (sprintf
                   "Failed to create on-demand ppx rewriter for %s; %s"
                   (String.enumerate_and (List.map pps ~f:Lib_name.to_string))
@@ -531,8 +531,7 @@ let setup_reason_rules sctx (m : Module.t) =
           | ".rei" -> ".re.mli"
           | _     ->
             Errors.fail
-              (Loc.in_file
-                 (Path.to_string (Path.drop_build_context_exn f.path)))
+              (Loc.in_file (Path.drop_build_context_exn f.path))
               "Unknown file extension for reason source file: %S"
               ext
         in

--- a/src/print_diff.ml
+++ b/src/print_diff.ml
@@ -10,11 +10,12 @@ let print ?(skip_trailing_cr=Sys.win32) path1 path2 =
       Path.extract_build_context_dir path2
     with
     | Some (dir1, f1), Some (dir2, f2) when Path.equal dir1 dir2 ->
-      (dir1, Path.to_string f1, Path.to_string f2)
+      (dir1, f1, f2)
     | _ ->
-      (Path.root, Path.to_string path1, Path.to_string path2)
+      (Path.root, path1, path2)
   in
   let loc = Loc.in_file file1 in
+  let (file1, file2) = Path.(to_string file1, to_string file2) in
   let fallback () =
     die "%aFiles %s and %s differ." Errors.print loc
       (Path.to_string_maybe_quoted path1)

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -4,7 +4,7 @@ exception Code_error of Sexp.t
 
 exception Fatal_error of string
 
-exception Loc_error of Loc.t * string
+exception Loc_error of Loc0.t * string
 
 external raise         : exn -> _ = "%raise"
 external raise_notrace : exn -> _ = "%raise_notrace"

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -7,17 +7,17 @@ exception Code_error of Sexp.t
 
 (* CR-soon diml:
    - Rename to [User_error]
-   - change the [string] argument to [Loc.t option * string] and get rid of
+   - change the [string] argument to [Loc0.t option * string] and get rid of
    [Loc.Error]. The two are a bit confusing
    - change [string] to [Colors.Style.t Lib_name.t]
 *)
 (** A fatal error, that should be reported to the user in a nice way *)
 exception Fatal_error of string
 
-exception Loc_error of Loc.t * string
+exception Loc_error of Loc0.t * string
 
 val fatalf
-  :  ?loc:Loc.t
+  :  ?loc:Loc0.t
   -> ('a, unit, string, string, string, 'b) format6
   -> 'a
 

--- a/src/stdune/loc.ml
+++ b/src/stdune/loc.ml
@@ -1,23 +1,31 @@
-type t =
-  { start : Lexing.position
-  ; stop  : Lexing.position
+include Loc0
+
+let none_pos p : Lexing.position =
+  { pos_fname = p
+  ; pos_lnum  = 1
+  ; pos_cnum  = 0
+  ; pos_bol   = 0
   }
 
-let in_file fn =
-  let pos : Lexing.position =
-    { pos_fname = fn
-    ; pos_lnum  = 1
-    ; pos_cnum  = 0
-    ; pos_bol   = 0
-    }
-  in
+let in_file p =
+  let pos = none_pos (Path.to_string p) in
   { start = pos
   ; stop = pos
   }
 
 let in_dir = in_file
 
-let none = in_file "<none>"
+let none =
+  let pos = none_pos "<none>" in
+  { start = pos
+  ; stop = pos
+  }
+
+let drop_position (t : t) =
+  let pos = none_pos t.start.pos_fname in
+  { start = pos
+  ; stop = pos
+  }
 
 let of_lexbuf lexbuf : t =
   { start = Lexing.lexeme_start_p lexbuf

--- a/src/stdune/loc.mli
+++ b/src/stdune/loc.mli
@@ -1,13 +1,12 @@
-type t =
-  { start : Lexing.position
-  ; stop  : Lexing.position
-  }
+include module type of struct include Loc0 end
 
-val in_file : string -> t
+val in_file : Path.t -> t
 
-val in_dir : string -> t
+val in_dir : Path.t -> t
 
 val none : t
+
+val drop_position : t -> t
 
 val of_lexbuf : Lexing.lexbuf -> t
 

--- a/src/stdune/loc0.ml
+++ b/src/stdune/loc0.ml
@@ -1,0 +1,4 @@
+type t =
+  { start : Lexing.position
+  ; stop  : Lexing.position
+  }

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -140,9 +140,9 @@ module Local : sig
   val compare : t -> t -> Ordering.t
   val compare_val : t -> t -> Ordering.t
   val equal : t -> t -> bool
-  val of_string : ?error_loc:Loc.t -> string -> t
+  val of_string : ?error_loc:Loc0.t -> string -> t
   val to_string : t -> string
-  val relative : ?error_loc:Loc.t -> t -> string -> t
+  val relative : ?error_loc:Loc0.t -> t -> string -> t
   val append : t -> t -> t
   val parent : t -> t
   val mkdir_p : t -> unit
@@ -157,7 +157,7 @@ module Local : sig
   val pp : Format.formatter -> t -> unit
 
   module L : sig
-    val relative : ?error_loc:Loc.t -> t -> string list -> t
+    val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
   module Set : Set.S with type elt = t
 

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -8,7 +8,7 @@ module Local : sig
   val to_string : t -> string
   val pp : Format.formatter -> t -> unit
   module L : sig
-    val relative : ?error_loc:Loc.t -> t -> string list -> t
+    val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
 end
 
@@ -55,7 +55,7 @@ end
 module Map : Map.S with type key = t
 module Table : Hashtbl.S with type key = t
 
-val of_string : ?error_loc:Loc.t -> string -> t
+val of_string : ?error_loc:Loc0.t -> string -> t
 val to_string : t -> string
 
 (** [to_string_maybe_quoted t] is [maybe_quoted (to_string t)] *)
@@ -68,7 +68,7 @@ val is_root : t -> bool
 
 val is_managed : t -> bool
 
-val relative : ?error_loc:Loc.t -> t -> string -> t
+val relative : ?error_loc:Loc0.t -> t -> string -> t
 
 (** Create an external path. If the argument is relative, assume it is relative
     to the initial directory dune was launched in. *)

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -95,7 +95,7 @@ let setup sctx ~dir =
                }
          ~obj_name:exe_name)
   in
-  let loc = Loc.in_dir (Path.to_string dir) in
+  let loc = Loc.in_dir dir in
   let requires =
     let open Result.O in
     (loc, Lib_name.of_string_exn ~loc:(Some loc) "utop")


### PR DESCRIPTION
To unbreak recursion, we introduce a Loc0, internal module.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>