### PR TITLE
Run `dune build @install` before `dune install` in Makefile

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -13,8 +13,9 @@ To get the development version bootstrapped and installed, run the following
 while in the project's root directory:
 
 ```sh
-$ make          # create the dune.exe file and bootstrap the dune build
-$ make install  # install the newly built dune
+$ make                # create the dune.exe file and bootstrap the dune build
+$ make build-install  # build dune in preparation for installation
+$ make install        # install the newly built dune in to your environment
 ```
 
 Note that we don't include all of the sources in boot.ml. We skip a

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ release: boot.exe
 boot.exe: bootstrap.ml
 	ocaml bootstrap.ml
 
+build-install:
+	$(BIN) build @install
+
 install:
 	$(BIN) install $(INSTALL_ARGS) dune
 


### PR DESCRIPTION
Signed-off-by: Shon Feder <shon.feder@gmail.com>

Without this change, I am getting the following on `HEAD`:

```
$ make install
./_build_bootstrap/default/bin/main_dune.exe install   dune
The following <package>.install are missing:
- _build/default/dune.install
You need to run: dune build @install
make: *** [install] Error 1
```

when trying to install following the instructions in [HACKING.md](https://github.com/ocaml/dune/blob/master/HACKING.md).