### PR TITLE
configurator: add an unsigned int type for C symbol imports

### DIFF
--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -25,6 +25,7 @@ module C_define : sig
     type t =
       | Switch (** defined/undefined *)
       | Int
+      | Uint
       | String
   end
 


### PR DESCRIPTION
The current `C_define.Type.Int` supports signed integers since
the fix in #1344. This fix meant that some C expressions cannot
be evaluated such as `sizeof(expr)` since those are not valid
in cpp.

This changeset adds a new `Uint` type switch that is expressly
for the purpose of evaluating unsigned C integers only. This
allows for constructs such as `sizeof(expr)`.

This changeset lets the Ctypes library completely use Configurator
for all of its compile-time tests (ocamllabs/ocaml-ctypes#574)

fixes #1720

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>