### PR TITLE
configurator: allow sizeof in C symbols import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@ unreleased
   rules that require files outside the build/source directory. (#1708, fixes
   #848, @rgrinberg)
 
+- Let `Configurator` handle `sizeof` (in addition to negative numbers).
+  (#1726, fixes #1723, @Chris00)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -340,16 +340,18 @@ module C_define = struct
     Option.iter prelude ~f:(pr "%s");
     if has_type Type.Int then (
       pr {|
-#define D0(x) ('0'+(x/1         )%%10)
-#define D1(x) ('0'+(x/10        )%%10), D0(x)
-#define D2(x) ('0'+(x/100       )%%10), D1(x)
-#define D3(x) ('0'+(x/1000      )%%10), D2(x)
-#define D4(x) ('0'+(x/10000     )%%10), D3(x)
-#define D5(x) ('0'+(x/100000    )%%10), D4(x)
-#define D6(x) ('0'+(x/1000000   )%%10), D5(x)
-#define D7(x) ('0'+(x/10000000  )%%10), D6(x)
-#define D8(x) ('0'+(x/100000000 )%%10), D7(x)
-#define D9(x) ('0'+(x/1000000000)%%10), D8(x)
+#define DUNE_ABS(x) ((x >= 0)? x: -(x))
+#define D0(x) ('0'+(DUNE_ABS(x)/1         )%%10)
+#define D1(x) ('0'+(DUNE_ABS(x)/10        )%%10), D0(x)
+#define D2(x) ('0'+(DUNE_ABS(x)/100       )%%10), D1(x)
+#define D3(x) ('0'+(DUNE_ABS(x)/1000      )%%10), D2(x)
+#define D4(x) ('0'+(DUNE_ABS(x)/10000     )%%10), D3(x)
+#define D5(x) ('0'+(DUNE_ABS(x)/100000    )%%10), D4(x)
+#define D6(x) ('0'+(DUNE_ABS(x)/1000000   )%%10), D5(x)
+#define D7(x) ('0'+(DUNE_ABS(x)/10000000  )%%10), D6(x)
+#define D8(x) ('0'+(DUNE_ABS(x)/100000000 )%%10), D7(x)
+#define D9(x) ('0'+(DUNE_ABS(x)/1000000000)%%10), D8(x)
+#define DUNE_SIGN(x) ((x >= 0)? '+': '-')
 |}
     );
     List.iteri vars ~f:(fun i (name, t) ->
@@ -366,14 +368,11 @@ module C_define = struct
         pr {|
 const char s%i[] = {
   'B', 'E', 'G', 'I', 'N', '-', %s'-',
-#if %s >= 0
+  DUNE_SIGN((%s)),
   D9((%s)),
-#else
-  '-', D9((- %s)),
-#endif
   '-', 'E', 'N', 'D'
 };
-|} i c_arr_i name name name
+|} i c_arr_i name name
       | String ->
         pr {|const char *s%i = "BEGIN-%i-" %s "-END";|} i i name;
       | Switch ->

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -341,16 +341,16 @@ module C_define = struct
     if has_type Type.Int then (
       pr {|
 #define DUNE_ABS(x) ((x >= 0)? x: -(x))
-#define D0(x) ('0'+(DUNE_ABS(x)/1         )%%10)
-#define D1(x) ('0'+(DUNE_ABS(x)/10        )%%10), D0(x)
-#define D2(x) ('0'+(DUNE_ABS(x)/100       )%%10), D1(x)
-#define D3(x) ('0'+(DUNE_ABS(x)/1000      )%%10), D2(x)
-#define D4(x) ('0'+(DUNE_ABS(x)/10000     )%%10), D3(x)
-#define D5(x) ('0'+(DUNE_ABS(x)/100000    )%%10), D4(x)
-#define D6(x) ('0'+(DUNE_ABS(x)/1000000   )%%10), D5(x)
-#define D7(x) ('0'+(DUNE_ABS(x)/10000000  )%%10), D6(x)
-#define D8(x) ('0'+(DUNE_ABS(x)/100000000 )%%10), D7(x)
-#define D9(x) ('0'+(DUNE_ABS(x)/1000000000)%%10), D8(x)
+#define DUNE_D0(x) ('0'+(DUNE_ABS(x)/1         )%%10)
+#define DUNE_D1(x) ('0'+(DUNE_ABS(x)/10        )%%10), DUNE_D0(x)
+#define DUNE_D2(x) ('0'+(DUNE_ABS(x)/100       )%%10), DUNE_D1(x)
+#define DUNE_D3(x) ('0'+(DUNE_ABS(x)/1000      )%%10), DUNE_D2(x)
+#define DUNE_D4(x) ('0'+(DUNE_ABS(x)/10000     )%%10), DUNE_D3(x)
+#define DUNE_D5(x) ('0'+(DUNE_ABS(x)/100000    )%%10), DUNE_D4(x)
+#define DUNE_D6(x) ('0'+(DUNE_ABS(x)/1000000   )%%10), DUNE_D5(x)
+#define DUNE_D7(x) ('0'+(DUNE_ABS(x)/10000000  )%%10), DUNE_D6(x)
+#define DUNE_D8(x) ('0'+(DUNE_ABS(x)/100000000 )%%10), DUNE_D7(x)
+#define DUNE_D9(x) ('0'+(DUNE_ABS(x)/1000000000)%%10), DUNE_D8(x)
 #define DUNE_SIGN(x) ((x >= 0)? '+': '-')
 |}
     );
@@ -369,7 +369,7 @@ module C_define = struct
 const char s%i[] = {
   'B', 'E', 'G', 'I', 'N', '-', %s'-',
   DUNE_SIGN((%s)),
-  D9((%s)),
+  DUNE_D9((%s)),
   '-', 'E', 'N', 'D'
 };
 |} i c_arr_i name name

--- a/test/blackbox-tests/test-cases/configurator/import-define/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/import-define/run.ml
@@ -4,11 +4,14 @@ let () =
   let module C_define = Configurator.C_define in
   Configurator.main ~name:"c_test" (fun t ->
     C_define.import t
-      ~prelude:{|#define CONFIGURATOR_TESTING "foobar"|}
+      ~prelude:"#define CONFIGURATOR_TESTING \"foobar\"\n\
+                #define CONFIGURATOR_NEG_INT -127\n"
       ~includes:["caml/config.h"]
       [ "CAML_CONFIG_H", C_define.Type.Switch
       ; "Page_log", C_define.Type.Int
       ; "CONFIGURATOR_TESTING", C_define.Type.String
+      ; "CONFIGURATOR_NEG_INT", C_define.Type.Int
+      ; "sizeof(char)", C_define.Type.Int
       ]
     |> List.iter (fun (n, v) ->
       Printf.printf "%s=%s\n"

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -12,3 +12,5 @@ Importing #define's from code is successful
   CAML_CONFIG_H=true
   Page_log=12
   CONFIGURATOR_TESTING=foobar
+  CONFIGURATOR_NEG_INT=-127
+  sizeof(char)=1


### PR DESCRIPTION
This is an alternative proposal to https://github.com/ocaml/dune/pull/1723 — with tests.   Count on the CI to show it works with all targeted compilers.