### PR TITLE
Configurator: support both negative numbers and expressions in C imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@ unreleased
   rules that require files outside the build/source directory. (#1708, fixes
   #848, @rgrinberg)
 
+- Configurator: fix regression when using C expressions (#1731, fixes #1720,
+  @emillon)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -366,14 +366,10 @@ module C_define = struct
         pr {|
 const char s%i[] = {
   'B', 'E', 'G', 'I', 'N', '-', %s'-',
-#if %s >= 0
   D9((%s)),
-#else
-  '-', D9((- %s)),
-#endif
   '-', 'E', 'N', 'D'
 };
-|} i c_arr_i name name name
+|} i c_arr_i name
       | String ->
         pr {|const char *s%i = "BEGIN-%i-" %s "-END";|} i i name;
       | Switch ->

--- a/test/blackbox-tests/test-cases/configurator/import-define/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/import-define/run.ml
@@ -4,11 +4,17 @@ let () =
   let module C_define = Configurator.C_define in
   Configurator.main ~name:"c_test" (fun t ->
     C_define.import t
-      ~prelude:{|#define CONFIGURATOR_TESTING "foobar"|}
+      ~prelude:{|
+        #define CONFIGURATOR_TESTING "foobar"
+        #define NEGATIVE_INT (0-345)
+        #define ZERO (763-763*1)
+      |}
       ~includes:["caml/config.h"]
       [ "CAML_CONFIG_H", C_define.Type.Switch
       ; "Page_log", C_define.Type.Int
       ; "CONFIGURATOR_TESTING", C_define.Type.String
+      ; "NEGATIVE_INT", C_define.Type.Int
+      ; "ZERO", C_define.Type.Int
       ]
     |> List.iter (fun (n, v) ->
       Printf.printf "%s=%s\n"

--- a/test/blackbox-tests/test-cases/configurator/import-define/run.ml
+++ b/test/blackbox-tests/test-cases/configurator/import-define/run.ml
@@ -15,6 +15,7 @@ let () =
       ; "CONFIGURATOR_TESTING", C_define.Type.String
       ; "NEGATIVE_INT", C_define.Type.Int
       ; "ZERO", C_define.Type.Int
+      ; "sizeof(char)", C_define.Type.Int
       ]
     |> List.iter (fun (n, v) ->
       Printf.printf "%s=%s\n"

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -14,3 +14,4 @@ Importing #define's from code is successful
   CONFIGURATOR_TESTING=foobar
   NEGATIVE_INT=-345
   ZERO=0
+  sizeof(char)=1

--- a/test/blackbox-tests/test-cases/configurator/run.t
+++ b/test/blackbox-tests/test-cases/configurator/run.t
@@ -12,3 +12,5 @@ Importing #define's from code is successful
   CAML_CONFIG_H=true
   Page_log=12
   CONFIGURATOR_TESTING=foobar
+  NEGATIVE_INT=-345
+  ZERO=0


### PR DESCRIPTION
Rather than using the preprocessor to determine the sign of a value, we store both `x` and `-x`. One of them has an all-digit representation.

For example, `1234` is stored as `"0000001234000000/.-,"` and `-5678` is stored as `"000000+*)(0000005678"`.

We might be able to do better if we could encode the sign and absolute value in the preprocessor, but it seems tricky to do so in a portable way.

(cc @Chris00 @avsm)