### PR TITLE
Fix #1729

### DIFF
--- a/src/arg_spec.ml
+++ b/src/arg_spec.ml
@@ -1,19 +1,23 @@
 open! Stdune
 open Import
 
-type 'a t =
-  | A        of string
-  | As       of string list
-  | S        of 'a t list
-  | Concat   of string * 'a t list
-  | Dep      of Path.t
-  | Deps     of Path.t list
-  | Target   of Path.t
-  | Path     of Path.t
-  | Paths    of Path.t list
-  | Hidden_deps    of Path.t list
-  | Hidden_targets of Path.t list
-  | Dyn      of ('a -> Nothing.t t)
+type static = Static
+type dynamic = Dynamic
+
+type ('a, _) t =
+  | A        : string -> ('a, _) t
+  | As       : string list -> ('a, _) t
+  | S        : ('a, 'b) t list -> ('a, 'b) t
+  | Concat   : string * ('a, 'b) t list  -> ('a, 'b) t
+  | Dep      : Path.t -> ('a, _) t
+  | Deps     : Path.t list -> ('a, _) t
+  | Target   : Path.t -> ('a, dynamic) t
+  | Path     : Path.t -> ('a, _) t
+  | Paths    : Path.t list -> ('a, _) t
+  | Hidden_deps    : Path.t list -> ('a, _) t
+  | Hidden_targets : Path.t list -> ('a, dynamic) t
+  | Dyn      : ('a -> (Nothing.t, static) t) -> ('a, dynamic) t
+  | Fail     : fail -> ('a, _) t
 
 let rec add_deps ts set =
   List.fold_left ts ~init:set ~f:(fun set t ->
@@ -37,7 +41,7 @@ let rec add_targets ts acc =
 let expand ~dir ts x =
   let dyn_deps = ref Path.Set.empty in
   let add_dep path = dyn_deps := Path.Set.add !dyn_deps path in
-  let rec loop_dyn : Nothing.t t -> string list = function
+  let rec loop_dyn : (Nothing.t, static) t -> string list = function
     | A s  -> [s]
     | As l -> l
     | Dep fn ->
@@ -52,11 +56,10 @@ let expand ~dir ts x =
       List.map fns ~f:(Path.reach ~from:dir)
     | S ts -> List.concat_map ts ~f:loop_dyn
     | Concat (sep, ts) -> [String.concat ~sep (loop_dyn (S ts))]
-    | Target _ | Hidden_targets _ -> die "Target not allowed under Dyn"
-    | Dyn _ -> assert false
     | Hidden_deps l ->
       dyn_deps := Path.Set.union !dyn_deps (Path.Set.of_list l);
       []
+    | Fail f -> f.fail ()
   in
   let rec loop = function
     | A s  -> [s]
@@ -67,6 +70,7 @@ let expand ~dir ts x =
     | Concat (sep, ts) -> [String.concat ~sep (loop (S ts))]
     | Target fn -> [Path.reach fn ~from:dir]
     | Dyn f -> loop_dyn (f x)
+    | Fail f -> f.fail ()
     | Hidden_deps _ | Hidden_targets _ -> []
   in
   let l = List.concat_map ts ~f:loop in
@@ -81,9 +85,9 @@ let quote_args =
 
 let of_result = function
   | Ok x -> x
-  | Error e -> Dyn (fun _ -> raise e)
+  | Error e -> Fail {fail = fun _ -> raise e}
 
 let of_result_map res ~f =
   match res with
   | Ok    x -> f x
-  | Error e -> Dyn (fun _ -> raise e)
+  | Error e -> Fail {fail = fun _ -> raise e}

--- a/src/build.mli
+++ b/src/build.mli
@@ -150,7 +150,7 @@ val run
   :  dir:Path.t
   -> ?stdout_to:Path.t
   -> Action.Prog.t
-  -> 'a Arg_spec.t list
+  -> ('a, Arg_spec.dynamic) Arg_spec.t list
   -> ('a, Action.t) t
 
 val action

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -4,11 +4,12 @@ open Import
 module SC = Super_context
 
 module Includes = struct
-  type t = string list Arg_spec.t Cm_kind.Dict.t
+  type t = (string list, Arg_spec.dynamic) Arg_spec.t Cm_kind.Dict.t
 
   let make sctx ~opaque ~requires : _ Cm_kind.Dict.t =
     match requires with
-    | Error exn -> Cm_kind.Dict.make_all (Arg_spec.Dyn (fun _ -> raise exn))
+    | Error exn ->
+      Cm_kind.Dict.make_all (Arg_spec.Fail {fail = fun () -> raise exn})
     | Ok libs ->
       let iflags =
         Lib.L.include_flags libs ~stdlib_dir:(SC.context sctx).stdlib_dir

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -47,7 +47,7 @@ val alias_module         : t -> Module.t option
 val lib_interface_module : t -> Module.t option
 val flags                : t -> Ocaml_flags.t
 val requires             : t -> Lib.t list Or_exn.t
-val includes             : t -> string list Arg_spec.t Cm_kind.Dict.t
+val includes             : t -> (string list, Arg_spec.dynamic) Arg_spec.t Cm_kind.Dict.t
 val preprocessing        : t -> Preprocessing.t
 val no_keep_locs         : t -> bool
 val opaque               : t -> bool

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -116,12 +116,12 @@ module Run (P : PARAMS) : sig end = struct
      that are neither dependencies nor targets.
      [Hidden_targets] is for targets that are *not* command line arguments.  *)
 
-  type args =
-    string list Arg_spec.t list
+  type 'a args =
+    (string list, 'a) Arg_spec.t list
 
   (* [menhir args] generates a Menhir command line (a build action). *)
 
-  let menhir (args : args) : (string list, Action.t) Build.t =
+  let menhir (args : 'a args) : (string list, Action.t) Build.t =
     Build.run ~dir menhir_binary args
 
   let rule : (unit, Action.t) Build.t -> unit =


### PR DESCRIPTION
We are likely doing `Dyn (fun _ -> Dyn ...)` via one of the `Arg_spec.of_result` calls. This PR cleans things up by:

* Allowing to error out inside of Dyn using an explicit constructor. Actually, things were like this before, but @diml for some reason got rid of this constructor. I can't recall what the reasoning was.

* Add a phantom parameter so that we don't mix constructors incorrectly. It's not possible to nest Dyn, and it's not possible to add targets via Dyn. We can enforce that statically. This can feel a bit heavy weight, so I can remove this if there's too much objection.

Note: It's very likely that this error is present in 1.6, but it's not so easy to reproduce. I'm thinking we should just add it to the CHANGELOG regardless.