### PR TITLE
Never raise when printing errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,9 @@ unreleased
   some cases. The fix is to systematically use `-short-paths` when
   calling `ocamlc -i` (#1743, fix #1504, @diml)
 
+- Never raise when printing located errors. The code that would print the
+  location excerpts was prone to raising. (#1744, fix #1736, @rgrinberg)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -70,20 +70,8 @@ end = struct
     | None ->
       (* We can't let the exception leak at this point, so we just
          dump the error on stderr and exit *)
-      let bt = Printexc.get_backtrace () in
-      let s =
-        Printf.sprintf "%s\n%s" (Printexc.to_string exn) bt
-        |> String.split_lines
-        |> List.map ~f:(Printf.sprintf "| %s")
-        |> String.concat ~sep:"\n"
-      in
-      let line = String.make 71 '-' in
-      Format.eprintf
-        "/%s\n\
-         | @{<error>Internal error@}: Uncaught exception.\n\
-         %s\n\
-         \\%s@."
-        line s line;
+      let backtrace = Printexc.get_backtrace () in
+      Format.eprintf "%a@.%!" (Exn.pp_uncaught ~backtrace) exn;
       sys_exit 42
     | Some { ctx; run } ->
       current := ctx;

--- a/src/stdune/caml/dune_caml.ml
+++ b/src/stdune/caml/dune_caml.ml
@@ -8,6 +8,7 @@ module Result   = Result
 module Hashtbl  = MoreLabels.Hashtbl
 module Lexing   = Lexing
 module Digest   = Digest
+module StringLabels   = StringLabels
 
 type ('a, 'error) result = ('a, 'error) Result.t =
   | Ok    of 'a

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -37,6 +37,22 @@ let code_error message vars =
              Sexp.List [Atom name; value])))
   |> raise
 
+module String = Dune_caml.StringLabels
+let pp_uncaught ~backtrace fmt exn =
+  let s =
+    Printf.sprintf "%s\n%s" (Printexc.to_string exn) backtrace
+    |> String_split.split_lines
+    |> ListLabels.map ~f:(Printf.sprintf "| %s")
+    |> String.concat ~sep:"\n"
+  in
+  let line = String.make 71 '-' in
+  Format.fprintf fmt
+    "/%s\n\
+     | @{<error>Internal error@}: Uncaught exception.\n\
+     %s\n\
+     \\%s@."
+    line s line;
+
 include
   ((struct
     [@@@warning "-32-3"]

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -32,4 +32,6 @@ external reraise       : exn -> _ = "%reraise"
 val protect : f:(unit -> 'a) -> finally:(unit -> unit) -> 'a
 val protectx : 'a -> f:('a -> 'b) -> finally:('a -> unit) -> 'b
 
+val pp_uncaught : backtrace:string -> Format.formatter -> t -> unit
+
 val raise_with_backtrace: exn -> Printexc.raw_backtrace -> _

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -626,10 +626,10 @@ let of_string ?error_loc s =
   match s with
   | "" | "." -> in_source_tree Local.root
   | s  ->
-    if not (Filename.is_relative s) then
-      external_ (External.of_string s)
-    else
+    if Filename.is_relative s then
       make_local_path (Local.of_string s ?error_loc)
+    else
+      external_ (External.of_string s)
 
 let to_sexp t =
   let constr f x y = Sexp.Encoder.(pair string f) (x, y) in

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -16,6 +16,11 @@ let ok_exn = function
   | Ok    x -> x
   | Error e -> raise e
 
+let try_with f =
+  match f () with
+  | s -> Ok s
+  | exception e -> Error e
+
 let bind t ~f =
   match t with
   | Ok x -> f x

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -11,6 +11,8 @@ val is_error : _ t -> bool
 
 val ok_exn : ('a, exn) t -> 'a
 
+val try_with : (unit -> 'a) -> ('a, exn) t
+
 module O : sig
   val ( >>| ) : ('a, 'error) t -> ('a -> 'b) -> ('b, 'error) t
   val ( >>= ) : ('a, 'error) t -> ('a -> ('b, 'error) t) -> ('b, 'error) t

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -138,29 +138,7 @@ let split s ~on =
   in
   loop 0 0
 
-let split_lines s =
-  let rec loop ~last_is_cr ~acc i j =
-    if j = length s then (
-      let acc =
-        if j = i || (j = i + 1 && last_is_cr) then
-          acc
-        else
-          sub s ~pos:i ~len:(j - i) :: acc
-      in
-      List.rev acc
-    ) else
-      match s.[j] with
-      | '\r' -> loop ~last_is_cr:true ~acc i (j + 1)
-      | '\n' ->
-        let line =
-          let len = if last_is_cr then j - i - 1 else j - i in
-          sub s ~pos:i ~len
-        in
-        loop ~acc:(line :: acc) (j + 1) (j + 1) ~last_is_cr:false
-      | _ ->
-        loop ~acc i (j + 1) ~last_is_cr:false
-  in
-  loop ~acc:[] 0 0 ~last_is_cr:false
+include String_split
 
 let escape_double_quote s =
   let n = ref 0 in

--- a/src/stdune/string_split.ml
+++ b/src/stdune/string_split.ml
@@ -1,0 +1,26 @@
+module String = Dune_caml.StringLabels
+open String
+
+let split_lines s =
+  let rec loop ~last_is_cr ~acc i j =
+    if j = length s then (
+      let acc =
+        if j = i || (j = i + 1 && last_is_cr) then
+          acc
+        else
+          sub s ~pos:i ~len:(j - i) :: acc
+      in
+      List.rev acc
+    ) else
+      match s.[j] with
+      | '\r' -> loop ~last_is_cr:true ~acc i (j + 1)
+      | '\n' ->
+        let line =
+          let len = if last_is_cr then j - i - 1 else j - i in
+          sub s ~pos:i ~len
+        in
+        loop ~acc:(line :: acc) (j + 1) (j + 1) ~last_is_cr:false
+      | _ ->
+        loop ~acc i (j + 1) ~last_is_cr:false
+  in
+  loop ~acc:[] 0 0 ~last_is_cr:false

--- a/src/stdune/string_split.mli
+++ b/src/stdune/string_split.mli
@@ -1,0 +1,1 @@
+val split_lines : string -> string list


### PR DESCRIPTION
We shouldn't raise in exception handling code. We avoid raising exceptions
by wrapping calls with Result.try_with and avoiding the Path module.

Apologies for the annoying contortions required to factor out the uncaught exception printing code.

Fix #1736 (@avsm could you give this one a test run?)
