### PR TITLE
Fix make install/uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ boot.exe: bootstrap.ml
 	ocaml bootstrap.ml
 
 install:
-	$(BIN) install $(INSTALL_ARGS) dune
+	$(BIN) install $(INSTALL_ARGS) dune --build-dir _build_bootstrap
 
 uninstall:
-	$(BIN) uninstall $(INSTALL_ARGS) dune
+	$(BIN) uninstall $(INSTALL_ARGS) dune --build-dir _build_bootstrap
 
 reinstall: uninstall reinstall
 


### PR DESCRIPTION
Since the bootstrap build is now storing artifacts in `_build_bootstrap`, `make install/uninstall` need to copy the files from this same location.