### PR TITLE
Add a "dune targets" command to list available targets

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -155,6 +155,7 @@ let all =
   ; Compute.command
   ; Upgrade.command
   ; Cache_daemon.command
+  ; Print_targets.command
   ]
 
 let default =

--- a/bin/print_targets.ml
+++ b/bin/print_targets.ml
@@ -1,0 +1,25 @@
+open! Stdune
+open Import
+
+let doc = "Print available targets"
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P {|$(b,dune targets) prints the available targets|}
+  ; `Blocks Common.help_secs
+  ]
+
+let info = Term.info "targets" ~doc ~man
+
+let term =
+  let+ common = Common.term in
+  Common.set_common common ~targets:[] ;
+  Scheduler.go ~common (fun () ->
+      let open Fiber.O in
+      let* setup = Import.Main.setup common in
+      let targets = Target.targets_of_path setup Path.root in
+      List.iter targets ~f:print_endline ;
+      Fiber.return ()
+    )
+
+let command = (term, info)

--- a/bin/print_targets.mli
+++ b/bin/print_targets.mli
@@ -1,0 +1,1 @@
+val command : unit Cmdliner.Term.t * Cmdliner.Term.info

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -32,7 +32,7 @@ let log_targets targets =
     | Alias a -> Log.info (Alias.to_log_string a));
   flush stdout
 
-let target_hint (_setup : Dune.Main.build_system) path =
+let targets_of_path (_setup : Dune.Main.build_system) path =
   assert (Path.is_managed path);
   let sub_dir = Option.value ~default:path (Path.parent path) in
   let candidates = Path.Build.Set.to_list (Build_system.all_targets ()) in
@@ -54,7 +54,10 @@ let target_hint (_setup : Dune.Main.build_system) path =
         else
           None)
   in
-  let candidates = String.Set.of_list candidates |> String.Set.to_list in
+  String.Set.of_list candidates |> String.Set.to_list
+
+let target_hint (setup : Dune.Main.build_system) path =
+  let candidates = targets_of_path setup path in
   User_message.did_you_mean (Path.to_string path) ~candidates
 
 let resolve_path path ~(setup : Dune.Main.build_system) =

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -24,3 +24,5 @@ val resolve_targets_mixed :
 
 val resolve_targets_exn :
   Common.t -> Dune.Main.build_system -> Arg.Dep.t list -> t list
+
+val targets_of_path : Dune.Main.build_system -> Path.t -> string list

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -144,6 +144,15 @@
  (files   dune-subst.1))
 
 (rule
+ (with-stdout-to dune-targets.1
+  (run dune targets --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-targets.1))
+
+(rule
  (with-stdout-to dune-uninstall.1
   (run dune uninstall --help=groff)))
 

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1557,6 +1557,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name targets)
+ (deps (package dune) (source_tree test-cases/targets))
+ (action
+  (chdir
+   test-cases/targets
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name targets-with-vars)
  (deps (package dune) (source_tree test-cases/targets-with-vars))
  (action
@@ -2034,6 +2042,7 @@
   (alias subst)
   (alias syntax-versioning)
   (alias target-dir-alias)
+  (alias targets)
   (alias targets-with-vars)
   (alias tests-stanza)
   (alias tests-stanza-action)
@@ -2234,6 +2243,7 @@
   (alias subst)
   (alias syntax-versioning)
   (alias target-dir-alias)
+  (alias targets)
   (alias targets-with-vars)
   (alias tests-stanza)
   (alias tests-stanza-action)

--- a/test/blackbox-tests/test-cases/targets/run.t
+++ b/test/blackbox-tests/test-cases/targets/run.t
@@ -1,0 +1,2 @@
+  $ dune targets
+  run.t


### PR DESCRIPTION
Add a new command `dune targets` as suggested in issue #265 

- ~the `DIRS` parameters of the command allows to filter the targets, if `DIRS=d1,d2`, only lists the targets in the following directories:~
  * ~_build/default/d1/*~
  * ~_build/default/d2/*~