### PR TITLE
Do not load dune files when not necessary

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -43,7 +43,7 @@ let term =
   let log = Log.create common in
   let setup =
     Scheduler.go ~log ~common (fun () -> Import.Main.setup ~log common) in
-  let context = Import.Main.find_context_exn setup ~name:context in
+  let context = Import.Main.find_context_exn setup.workspace ~name:context in
   let prog_where =
     match Filename.analyze_program_name prog with
     | Absolute ->

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -42,7 +42,8 @@ let run ~lib_deps ~by_dir ~setup ~only_missing ~sexp =
           die "@{<error>Error@}: --only-missing cannot be used with \
                --unstable-by-dir or --sexp";
         let context =
-          List.find_exn setup.contexts ~f:(fun c -> c.name = context_name)
+          List.find_exn setup.workspace.contexts
+            ~f:(fun c -> c.name = context_name)
         in
         let missing =
           Lib_name.Map.filteri externals ~f:(fun name _ ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -62,11 +62,11 @@ let runtest =
         | dir when dir.[String.length dir - 1] = '/' -> sprintf "@%sruntest" dir
         | dir -> sprintf "@%s/runtest" dir));
     let log = Log.create common in
-    let targets (setup : Main.setup) =
+    let targets (setup : Main.build_system) =
       List.map dirs ~f:(fun dir ->
         let dir = Path.(relative root) (Common.prefix_target common dir) in
         Target.Alias (Alias.in_dir ~name:"runtest" ~recursive:true
-                        ~contexts:setup.contexts dir))
+                        ~contexts:setup.workspace.contexts dir))
     in
     run_build_command ~log ~common ~targets
   in

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -27,7 +27,7 @@ let term =
   Scheduler.go ~log ~common (fun () ->
     Import.Main.setup ~log common >>= fun setup ->
     let dir = Path.of_string dir in
-    Util.check_path setup.contexts dir;
+    Util.check_path setup.workspace.contexts dir;
     let request =
       Build.all (
         match Path.extract_build_context dir with

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -16,7 +16,7 @@ type resolve_input =
   | Path of Path.t
   | String of string
 
-let request (setup : Dune.Main.setup) targets =
+let request (setup : Dune.Main.build_system) targets =
   let open Build.O in
   List.fold_left targets ~init:(Build.return ()) ~f:(fun acc target ->
     acc >>>
@@ -28,7 +28,7 @@ let request (setup : Dune.Main.setup) targets =
          Build_system.Alias.dep_rec_multi_contexts
        else
          Build_system.Alias.dep_multi_contexts)
-        ~dir ~name ~file_tree:setup.file_tree ~contexts)
+        ~dir ~name ~file_tree:setup.workspace.conf.file_tree ~contexts)
 
 let log_targets ~log targets =
   List.iter targets ~f:(function
@@ -37,7 +37,7 @@ let log_targets ~log targets =
     | Alias a -> Log.info log (Alias.to_log_string a));
   flush stdout
 
-let target_hint (setup : Dune.Main.setup) path =
+let target_hint (setup : Dune.Main.build_system) path =
   assert (Path.is_managed path);
   let sub_dir = Option.value ~default:path (Path.parent path) in
   let candidates = Build_system.all_targets setup.build_system in
@@ -62,14 +62,14 @@ let target_hint (setup : Dune.Main.setup) path =
   let candidates = String.Set.of_list candidates |> String.Set.to_list in
   hint (Path.to_string path) candidates
 
-let resolve_path path ~(setup : Dune.Main.setup) =
-  Util.check_path setup.contexts path;
+let resolve_path path ~(setup : Dune.Main.build_system) =
+  Util.check_path setup.workspace.contexts path;
   let can't_build path =
     Error (path, target_hint setup path);
   in
-  if Dune.File_tree.dir_exists setup.file_tree path then
+  if Dune.File_tree.dir_exists setup.workspace.conf.file_tree path then
     Ok [ Alias (Alias.in_dir ~name:"default" ~recursive:true
-                  ~contexts:setup.contexts path) ]
+                  ~contexts:setup.workspace.contexts path) ]
   else if not (Path.is_managed path) then
     Ok [File path]
   else if Path.is_in_build_dir path then begin
@@ -79,7 +79,7 @@ let resolve_path path ~(setup : Dune.Main.setup) =
       can't_build path
   end else
     match
-      List.filter_map setup.contexts ~f:(fun ctx ->
+      List.filter_map setup.workspace.contexts ~f:(fun ctx ->
         let path = Path.append ctx.Context.build_dir path in
         if Build_system.is_target setup.build_system path then
           Some (File path)
@@ -89,14 +89,15 @@ let resolve_path path ~(setup : Dune.Main.setup) =
     | [] -> can't_build path
     | l  -> Ok l
 
-let resolve_target common ~(setup : Dune.Main.setup) s =
-  match Alias.of_string common s ~contexts:setup.contexts with
+let resolve_target common ~(setup : Dune.Main.build_system) s =
+  match Alias.of_string common s ~contexts:setup.workspace.contexts with
   | Some a -> Ok [Alias a]
   | None ->
     let path = Path.relative Path.root (Common.prefix_target common s) in
     resolve_path path ~setup
 
-let resolve_targets_mixed ~log common (setup : Dune.Main.setup) user_targets =
+let resolve_targets_mixed ~log common (setup : Dune.Main.build_system)
+      user_targets =
   match user_targets with
   | [] -> []
   | _ ->
@@ -113,7 +114,7 @@ let resolve_targets_mixed ~log common (setup : Dune.Main.setup) user_targets =
     end;
     targets
 
-let resolve_targets ~log common (setup : Dune.Main.setup) user_targets =
+let resolve_targets ~log common (setup : Dune.Main.build_system) user_targets =
   List.map ~f:(fun s -> String s) user_targets
   |> resolve_targets_mixed ~log common setup
 

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -5,13 +5,13 @@ type t =
   | Alias     of Alias.t
 
 val request
-  :  Dune.Main.setup
+  :  Dune.Main.build_system
   -> t list
   -> (unit, unit) Dune.Build.t
 
 val resolve_target
   : Common.t
-  -> setup:Dune.Main.setup
+  -> setup:Dune.Main.build_system
   -> string
   -> (t list, Path.t * string) result
 
@@ -22,13 +22,13 @@ type resolve_input =
 val resolve_targets_mixed
   :  log:Dune.Log.t
   -> Common.t
-  -> Dune.Main.setup
+  -> Dune.Main.build_system
   -> resolve_input list
   -> (t list, Path.t * string) result list
 
 val resolve_targets_exn
   :  log:Dune.Log.t
   -> Common.t
-  -> Dune.Main.setup
+  -> Dune.Main.build_system
   -> string list
   -> t list

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -31,8 +31,14 @@ let term =
   let (context, utop_path) =
     Scheduler.go ~log ~common (fun () ->
       Import.Main.setup ~log common >>= fun setup ->
-      let context = Import.Main.find_context_exn setup ~name:ctx_name in
-      let setup = { setup with contexts = [context] } in
+      let context =
+        Import.Main.find_context_exn setup.workspace ~name:ctx_name
+      in
+      let setup =
+        { setup with
+          workspace = { setup.workspace with contexts = [context] }
+        }
+      in
       let target =
         match Target.resolve_target common ~setup utop_target with
         | Error _ ->

--- a/src/main.mli
+++ b/src/main.mli
@@ -1,34 +1,41 @@
 open! Stdune
 open! Import
 
-type setup =
-  { build_system : Build_system.t
-  ; contexts     : Context.t list
+type workspace =
+  { contexts : Context.t list
+  ; conf     : Dune_load.conf
+  ; env      : Env.t
+  }
+
+type build_system =
+  { workspace    : workspace
+  ; build_system : Build_system.t
   ; scontexts    : Super_context.t String.Map.t
-  ; packages     : Package.t Package.Name.Map.t
-  ; file_tree    : File_tree.t
-  ; env          : Env.t
   }
 
 (* Returns [Error ()] if [pkg] is unknown *)
-val package_install_file : setup -> Package.Name.t -> (Path.t, unit) result
+val package_install_file : workspace -> Package.Name.t -> (Path.t, unit) result
 
-(** Scan the source tree and discover everything that's needed in order to build
-    it. *)
-val setup
+(** Scan the source tree and discover the overall layout of the workspace. *)
+val scan_workspace
   :  ?log:Log.t
-  -> ?external_lib_deps_mode:bool
   -> ?workspace:Workspace.t
   -> ?workspace_file:Path.t
-  -> ?only_packages:Package.Name.Set.t
   -> ?x:string
   -> ?ignore_promoted_rules:bool
   -> ?capture_outputs:bool
   -> ?profile:string
   -> unit
-  -> setup Fiber.t
+  -> workspace Fiber.t
 
-val find_context_exn : setup -> name:string -> Context.t
+(** Load dune files and initializes the build system *)
+val init_build_system
+  :  ?only_packages:Package.Name.Set.t
+  -> ?external_lib_deps_mode:bool
+  -> workspace
+  -> build_system Fiber.t
+
+val find_context_exn : workspace -> name:string -> Context.t
 
 (** Setup the environment *)
 val setup_env : capture_outputs:bool -> Env.t


### PR DESCRIPTION
While working on #1757, I realised that for some commands such as `dune install` we load all the dune files, even though this is not necessary. This PR refactors a bit the `Main` module in `src` to avoid this.

Now instead of `Main.setup`, cli commands should use `Main.scan_workspace` if they don't need to access the build system or contents of dune files.