### PR TITLE
Make `dune upgrade` upgrade the opam files as well

### DIFF
--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -16,6 +16,7 @@ let term =
   let%map common = Common.term in
   Common.set_common common ~targets:[];
   Scheduler.go ~common (fun () ->
-    Dune.Upgrader.upgrade (Dune.File_tree.load Path.root))
+    Dune.Upgrader.upgrade (Dune.File_tree.load Path.root
+                             ~warn_when_seeing_jbuild_file:false))
 
 let command = term, info

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -198,6 +198,12 @@ include Versioned_file.Make(struct
     type t = Stanza.Parser.t list
   end)
 
+let default_dune_language_version =
+  ref (Syntax.greatest_supported_version Stanza.syntax)
+
+let get_dune_lang () =
+  { (Lang.get_exn "dune" ) with version = !default_dune_language_version }
+
 type created_or_already_exist = Created | Already_exist
 
 module Project_file_edit = struct
@@ -210,7 +216,7 @@ module Project_file_edit = struct
     if t.exists then
       Already_exist
     else begin
-      let ver = (Lang.get_exn "dune").version in
+      let ver = !default_dune_language_version in
       let lines =
         [sprintf "(lang dune %s)" (Syntax.Version.to_string ver)]
       in
@@ -442,7 +448,7 @@ let get_local_path p =
   | Local    p -> p
 
 let anonymous = lazy (
-  let lang = Lang.get_exn "dune" in
+  let lang = get_dune_lang () in
   let name = Name.anonymous_root in
   let project_file =
     { Project_file.
@@ -538,7 +544,7 @@ let load_dune_project ~dir packages =
   load file ~f:(fun lang -> parse ~dir ~lang ~packages ~file)
 
 let make_jbuilder_project ~dir packages =
-  let lang = Lang.get_exn "dune" in
+  let lang = get_dune_lang () in
   let name = default_name ~dir ~packages in
   let project_file =
     { Project_file.

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -108,6 +108,11 @@ val ensure_project_file_exists : t -> created_or_already_exist
 (** Append the following text to the project file *)
 val append_to_project_file : t -> string -> created_or_already_exist
 
+(** Default language version to use for projects that don't have a
+    [dune-project] file. The default value is the latest version of the
+    dune language. *)
+val default_dune_language_version : Syntax.Version.t ref
+
 (** Set the project we are currently parsing dune files for *)
 val set : t -> ('a, 'k) Dune_lang.Decoder.parser -> ('a, 'k) Dune_lang.Decoder.parser
 val get_exn : unit -> (t, 'k) Dune_lang.Decoder.parser

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -134,7 +134,7 @@ let is_temp_file fn =
   || String.is_suffix fn ~suffix:".swp"
   || String.is_suffix fn ~suffix:"~"
 
-let load path =
+let load ?(warn_when_seeing_jbuild_file=true) path =
   let rec walk path ~dirs_visited ~project ~data_only : Dir.t =
     let contents = lazy (
       let files, unfiltered_sub_dirs =
@@ -181,7 +181,7 @@ let load path =
               if fn = "dune" then
                 ignore (Dune_project.ensure_project_file_exists project
                         : Dune_project.created_or_already_exist)
-              else
+              else if warn_when_seeing_jbuild_file then
                 Errors.warn (Loc.in_file file)
                   "jbuild files are deprecated, please convert this file to \
                    a dune file instead.\n\

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -62,7 +62,7 @@ end
     compatibility. *)
 type t
 
-val load : Path.t -> t
+val load : ?warn_when_seeing_jbuild_file:bool -> Path.t -> t
 
 (** Passing [~traverse_ignored_dirs:true] to this functions causes the
     whole source tree to be deeply scanned, including ignored

--- a/src/opam_file.ml
+++ b/src/opam_file.ml
@@ -20,3 +20,48 @@ let get_field t name =
       | Variable (_, var, value) when name = var ->
         Some value
       | _ -> None)
+
+let absolutify_positions ~file_contents t =
+  let open OpamParserTypes in
+  let bols = ref [] in
+  String.iteri file_contents ~f:(fun i ch ->
+    if ch = '\n' then bols := (i + 1) :: !bols);
+  let bols = Array.of_list (List.rev !bols) in
+  let map_pos (fname, line, col) =
+    (fname, line, bols.(line - 1) + col)
+  in
+  let rec map_value = function
+    | Bool (pos, x) ->
+      Bool (map_pos pos, x)
+    | Int (pos, x) ->
+      Int (map_pos pos, x)
+    | String (pos, x) ->
+      String (map_pos pos, x)
+    | Relop (pos, x, y, z) ->
+      Relop (map_pos pos, x, map_value y, map_value z)
+    | Prefix_relop (pos, x, y) ->
+      Prefix_relop (map_pos pos, x, map_value y)
+    | Logop (pos, x, y, z) ->
+      Logop (map_pos pos, x, map_value y, map_value z)
+    | Pfxop (pos, x, y) ->
+      Pfxop (map_pos pos, x, map_value y)
+    | Ident (pos, x) ->
+      Ident (map_pos pos, x)
+    | List (pos, x) ->
+      List (map_pos pos, List.map x ~f:map_value)
+    | Group (pos, x) ->
+      Group (map_pos pos, List.map x ~f:map_value)
+    | Option (pos, x, y) ->
+      Option (map_pos pos, map_value x, List.map y ~f:map_value)
+    | Env_binding (pos, x, y, z) ->
+      Env_binding (map_pos pos, map_value x, y, map_value z)
+  in
+  let rec map_section s =
+    { s with section_items = List.map s.section_items ~f:map_item }
+  and map_item = function
+    | Section (pos, s) -> Section (map_pos pos, map_section s)
+    | Variable (pos, s, v) -> Variable (map_pos pos, s, map_value v)
+  in
+  { file_contents = List.map t.file_contents ~f:map_item
+  ; file_name = t.file_name
+  }

--- a/src/opam_file.mli
+++ b/src/opam_file.mli
@@ -13,6 +13,9 @@ val load : Path.t -> t
 (** Extracts a field *)
 val get_field : t -> string -> value option
 
+(** Parse the contents of an opam file *)
+val parse : Lexing.lexbuf -> t
+
 (** Replace all [pos] value by a triplet [(fname, line,
     absolute_offset)] *)
 val absolutify_positions : file_contents:string -> opamfile -> opamfile

--- a/src/opam_file.mli
+++ b/src/opam_file.mli
@@ -12,3 +12,7 @@ val load : Path.t -> t
 
 (** Extracts a field *)
 val get_field : t -> string -> value option
+
+(** Replace all [pos] value by a triplet [(fname, line,
+    absolute_offset)] *)
+val absolutify_positions : file_contents:string -> opamfile -> opamfile

--- a/src/upgrader.boot.ml
+++ b/src/upgrader.boot.ml
@@ -1,0 +1,1 @@
+let upgrade _ = Fiber.return ()

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1159,6 +1159,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name upgrader)
+ (deps (package dune) (source_tree test-cases/upgrader))
+ (action
+  (chdir
+   test-cases/upgrader
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name use-meta)
  (deps (package dune) (source_tree test-cases/use-meta))
  (action
@@ -1367,6 +1375,7 @@
   (alias toplevel-stanza)
   (alias trace-file)
   (alias transitive-deps-mode)
+  (alias upgrader)
   (alias use-meta)
   (alias utop)
   (alias utop-default)
@@ -1507,6 +1516,7 @@
   (alias toplevel-stanza)
   (alias trace-file)
   (alias transitive-deps-mode)
+  (alias upgrader)
   (alias use-meta)
   (alias utop-default)
   (alias variants)

--- a/test/blackbox-tests/test-cases/upgrader/foo.opam
+++ b/test/blackbox-tests/test-cases/upgrader/foo.opam
@@ -1,0 +1,7 @@
+build: [
+  ["jbuilder" "subst" "-p" name]
+  ["jbuilder" "build"]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta42"}
+]

--- a/test/blackbox-tests/test-cases/upgrader/jbuild
+++ b/test/blackbox-tests/test-cases/upgrader/jbuild
@@ -1,0 +1,6 @@
+(rule
+ ((deps (x y z))
+  (targets (z))
+  (action (with-stdout-to z (run echo ${<})))))
+
+(rule (copy x y))

--- a/test/blackbox-tests/test-cases/upgrader/run.t
+++ b/test/blackbox-tests/test-cases/upgrader/run.t
@@ -1,0 +1,31 @@
+  $ dune upgrade
+  Info: creating file dune-project with this contents:
+  | (lang dune 1.0)
+  | (name foo)
+  
+  Upgrading foo.opam...
+  Upgrading jbuild to dune...
+
+  $ cat dune
+  (rule
+   (deps
+    (:< x)
+    y
+    z)
+   (targets z)
+   (action
+    (with-stdout-to
+     z
+     (run echo %{<}))))
+  
+  (rule
+   (copy x y))
+
+  $ cat foo.opam
+  build: [
+    ["dune" "subst"]
+    ["dune" "build" "-p" name "-j" jobs]
+  ]
+  depends: [
+    "dune" {build & >= "1.0"}
+  ]


### PR DESCRIPTION
`dune upgrade` now upgrades the opam files:

- it replaces `"jbuilder" ...` by `"dune" ...`
- it changes the contraints to `{build & >= "1.17"}` (or whatever the current version of dune is)

This PR contains a test.