### PR TITLE
Allow the `enabled_if` field in `library` stanzas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,9 @@ unreleased
 - Make `dune subst` add a `(version ...)` field to the `dune-project`
   file (#2148, @diml)
 
+- Add the `%{os_type}` variable, which is a short-hand for
+  `%{ocaml-config:os_type}` (#1764, @diml)
+
 1.9.3 (06/05/2019)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,9 @@ unreleased
 - Add the `%{os_type}` variable, which is a short-hand for
   `%{ocaml-config:os_type}` (#1764, @diml)
 
+- Allow `enabled_if` fields in `library` stanzas, restricted to the
+  `%{os_type}` variable (#1764, @diml)
+
 1.9.3 (06/05/2019)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1087,6 +1087,8 @@ Dune supports the following variables:
 - ``profile`` the profile selected via ``--profile``
 - ``context_name`` the name of the context (``default`` or defined in the
   workspace file)
+- ``os_type`` is the type of the OS the build is targetting. This is
+  the same as ``ocaml-config:os_type``
 
 In addition, ``(action ...)`` fields support the following special variables:
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -209,6 +209,14 @@ to use the :ref:`include_subdirs` stanza.
   we were waiting for proper support for virtual libraries. Do not use
   in new code, it will be deleted in dune 2.0
 
+- ``(enabled_if <blang expression>)`` allows to conditionally disable
+  a library. A disabled library cannot be built and will not be
+  installed. The condition is specified using the blang_, and the
+  field allows for the ``%{os_type}`` variable, which is expanded to
+  the type of OS being targeted by the current build. Its value is
+  the same as the value of the ``os_type`` parameter in the output of
+  ``ocamlc -config``
+
 Note that when binding C libraries, dune doesn't provide special support for
 tools such as ``pkg-config``, however it integrates easily with configurator_ by
 using ``(c_flags (:include ...))`` and ``(c_library_flags (:include ...))``.

--- a/src/blang.ml
+++ b/src/blang.ml
@@ -102,3 +102,17 @@ let decode =
   and+ decode = decode
   in
   decode
+
+let rec fold_vars t ~init ~f =
+  match t with
+  | Const _ -> init
+  | Expr sw -> String_with_vars.fold_vars sw ~init ~f
+  | And l | Or l -> fold_vars_list l ~init ~f
+  | Compare (_, x, y) ->
+    String_with_vars.fold_vars y ~f
+      ~init:(String_with_vars.fold_vars x ~f ~init)
+
+and fold_vars_list ts ~init ~f =
+  match ts with
+  | [] -> init
+  | t :: ts -> fold_vars_list ts ~f ~init:(fold_vars t ~init ~f)

--- a/src/blang.mli
+++ b/src/blang.mli
@@ -19,6 +19,8 @@ type t =
 
 val true_ : t
 
+val fold_vars : t -> init:'a -> f:(String_with_vars.Var.t -> 'a -> 'a) -> 'a
+
 val eval
   :  t
   -> dir:Path.t

--- a/src/context.ml
+++ b/src/context.ml
@@ -702,4 +702,5 @@ let lib_config t =
     has_native = has_native t
   ; ext_obj = t.ext_obj
   ; ext_lib = t.ext_lib
+  ; os_type = t.os_type
   }

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -235,6 +235,7 @@ module Library : sig
     ; private_modules          : Ordered_set_lang.t option
     ; stdlib                   : Stdlib.t option
     ; special_builtin_support  : Special_builtin_support.t option
+    ; enabled_if               : Blang.t
     }
 
   val has_stubs : t -> bool

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -891,12 +891,16 @@ let rec instantiate db name (info : Lib_info.t) ~stack ~hidden =
   let res =
     let hidden =
       match hidden with
-      | None ->
-        Option.some_if
-          (info.optional &&
-           not (Result.is_ok t.requires && Result.is_ok t.ppx_runtime_deps))
-          "optional with unavailable dependencies"
       | Some _ -> hidden
+      | None ->
+        match info.enabled with
+        | Normal -> None
+        | Optional ->
+          Option.some_if
+            (not (Result.is_ok t.requires && Result.is_ok t.ppx_runtime_deps))
+            "optional with unavailable dependencies"
+        | Disabled_because_of_enabled_if ->
+          Some "unsatisfied 'enabled_if'"
     in
     match hidden with
     | None -> St_found t
@@ -1265,7 +1269,9 @@ module Compile = struct
       make_lib_deps_info
         ~user_written_deps:(Lib_info.user_written_deps t.info)
         ~pps:t.info.pps
-        ~kind:(Lib_deps_info.Kind.of_optional t.info.optional)
+        ~kind:(match t.info.enabled with
+          | Normal -> Required
+          | _ -> Optional)
     in
     let requires_link = lazy (
       t.requires >>= closure_with_overlap_checks

--- a/src/lib_config.ml
+++ b/src/lib_config.ml
@@ -4,4 +4,5 @@ type t =
   { has_native : bool
   ; ext_lib : string
   ; ext_obj : string
+  ; os_type : string
   }

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -28,6 +28,13 @@ module Source : sig
     | External of 'a
 end
 
+module Enabled_status : sig
+  type t =
+    | Normal
+    | Optional
+    | Disabled_because_of_enabled_if
+end
+
 type t = private
   { loc              : Loc.t
   ; name             : Lib_name.t
@@ -47,7 +54,7 @@ type t = private
   ; requires         : Deps.t
   ; ppx_runtime_deps : (Loc.t * Lib_name.t) list
   ; pps              : (Loc.t * Lib_name.t) list
-  ; optional         : bool
+  ; enabled          : Enabled_status.t
   ; virtual_deps     : (Loc.t * Lib_name.t) list
   ; dune_version     : Syntax.Version.t option
   ; sub_systems      : Sub_system_info.t Sub_system_name.Map.t

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -208,6 +208,8 @@ module Map = struct
       ; "workspace_root" , values [Value.Dir context.build_dir]
       ; "context_name"   , string (Context.name context)
       ; "ROOT"           , renamed_in ~version:(1, 0) ~new_name:"workspace_root"
+      ; "os_type"        , since ~version:(1, 10)
+                             (Var.Values [String context.os_type])
       ]
     in
     { vars =

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -130,13 +130,14 @@ module DB = struct
       ~f:(fun _name project libs ->
         let project = Option.value_exn project in
         let libs = Option.value libs ~default:[] in
-        let db = Lib.DB.create_from_library_stanzas libs
-                   ~parent:public_libs ~lib_config in
+        let db = Lib.DB.create_from_library_stanzas libs ~parent:public_libs
+                   ~lib_config in
         let root =
           Path.append_source build_context_dir (Dune_project.root project) in
         Some { project; db; root })
 
-  let create ~projects ~context ~installed_libs ~lib_config internal_libs =
+  let create ~projects ~context ~installed_libs ~lib_config
+        internal_libs =
     let t = Fdecl.create () in
     let public_libs = public_libs t ~installed_libs internal_libs in
     let by_name =

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -253,6 +253,15 @@ let known_prefix =
     | Var v :: _ -> Partial (String.concat ~sep:"" (List.rev acc), v)
   in
   fun t -> go t.template.parts []
+let fold_vars =
+  let rec loop parts acc f =
+    match parts with
+    | [] -> acc
+    | Text _ :: parts -> loop parts acc f
+    | Var v :: parts -> loop parts (f v acc) f
+  in
+  fun t ~init ~f ->
+    loop t.template.parts init f
 
 type 'a expander = Var.t -> Syntax.Version.t -> 'a
 

--- a/src/string_with_vars.mli
+++ b/src/string_with_vars.mli
@@ -93,6 +93,7 @@ val known_prefix : t -> known_prefix
 val is_suffix : t -> suffix:string -> yes_no_unknown
 
 val is_prefix : t -> prefix:string -> yes_no_unknown
+val fold_vars : t -> init:'a -> f:(Var.t -> 'a -> 'a) -> 'a
 
 type 'a expander = Var.t -> Syntax.Version.t -> 'a
 

--- a/test/blackbox-tests/test-cases/enabled_if/dune
+++ b/test/blackbox-tests/test-cases/enabled_if/dune
@@ -21,3 +21,22 @@
           (echo "Building file b")
           (with-stdout-to b (progn))))
  (enabled_if true))
+
+(library
+ (name foo)
+ (modules)
+ (enabled_if false))
+
+(library
+ (name bar)
+ (modules)
+ (libraries foo))
+
+(library
+ (name baz)
+ (modules)
+ (libraries bar))
+
+(rule (with-stdout-to main.ml (echo "")))
+
+(executable (name main) (libraries baz))

--- a/test/blackbox-tests/test-cases/enabled_if/dune-project
+++ b/test/blackbox-tests/test-cases/enabled_if/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.4)
+(lang dune 1.10)

--- a/test/blackbox-tests/test-cases/enabled_if/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/run.t
@@ -16,3 +16,16 @@ This rule is disabled, trying to build a should fail:
 This one is enabled:
   $ dune build b
   Building file b
+
+Test the enabled_if field for libraries:
+
+  $ dune build main.exe
+  File "dune", line 33, characters 12-15:
+  33 |  (libraries foo))
+                   ^^^
+  Error: Library "foo" in _build/default is hidden (unsatisfied 'enabled_if').
+  Hint: try: dune external-lib-deps --missing main.exe
+  [1]
+
+Ideally, the above message should mention the dependency path between
+the requested target and the unsatisfied `enabled_if`.


### PR DESCRIPTION
This replaces #1445 (I exchanged this PR for an OCaml PR with @dra27). It implements the same thing, except that the interpretation of the `enabled_if` field is done a bit, producing better error messages when the user tries to use a library that is disabled.

Additionally, only the newly added `os_type` variable is allowed in this field. This is to avoid making the set of library names too dynamic. While it doesn't matter too much right now, I have a feeling that making 
 it too dynamic now might makes other things harder in the future.