### PR TITLE
Add support for multiline commands in cram tests

### DIFF
--- a/test/blackbox-tests/test-cases/misc/run.t
+++ b/test/blackbox-tests/test-cases/misc/run.t
@@ -6,3 +6,11 @@
           diff alias runtest
           diff alias runtest
           diff alias runtest
+
+Testing multiline commands in cram tests:
+  $ cat <<EOF
+  > Multiline
+  > Text
+  > EOF
+  Multiline
+  Text


### PR DESCRIPTION
This should make some tests more readable. The syntax is:

```
  $ cat <<EOF
  > Multiline
  > Text
  > EOF
  Multiline
  Text
```