### PR TITLE
Use merlin's -pp support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,9 @@ unreleased
 - Add `toplevel` stanza. This stanza is used to define toplevels with libraries
   already preloaded. (#1713, @rgrinberg)
 
+- Generate `.merlin` files that account for normal preprocessors defined using a
+  subset of the `action` language. (#1768, @rgrinberg)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -14,9 +14,6 @@ type t =
              result option String_with_vars.expander
   }
 
-type var_expander =
-  (Value.t list, Pform.Expansion.t) result option String_with_vars.expander
-
 let scope t = t.scope
 let dir t = t.dir
 let bindings t = t.bindings

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -41,9 +41,6 @@ val add_bindings : t -> bindings:Pform.Map.t -> t
 
 val extend_env : t -> env:Env.t -> t
 
-type var_expander =
-  (Value.t list, Pform.Expansion.t) result option String_with_vars.expander
-
 val expand
   :  t
   -> mode:'a String_with_vars.Mode.t

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -151,7 +151,7 @@ module Gen(P : Install_rules.Params) = struct
         List.map (Dir_contents.dirs dir_contents) ~f:(fun dc ->
           Path.drop_optional_build_context (Dir_contents.dir dc))
       in
-      Merlin.add_rules sctx ~dir:ctx_dir ~more_src_dirs ~scope ~dir_kind
+      Merlin.add_rules sctx ~dir:ctx_dir ~more_src_dirs ~expander ~dir_kind
         (Merlin.add_source_dir m src_dir));
     List.iter stanzas ~f:(fun stanza ->
       match (stanza : Stanza.t) with

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -24,7 +24,7 @@ val add_rules
   : Super_context.t
   -> dir:Path.t
   -> more_src_dirs:Path.t list
-  -> scope:Scope.t
+  -> expander:Expander.t
   -> dir_kind:Dune_lang.Syntax.t
   -> t
   -> unit

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -97,6 +97,14 @@ let rec last = function
   | [x] -> Some x
   | _::xs -> last xs
 
+let destruct_last =
+  let rec loop acc = function
+    | [] -> None
+    | [x] -> Some (rev acc, x)
+    | x :: xs -> loop (x :: acc) xs
+  in
+  fun xs -> loop [] xs
+
 let sort t ~compare =
   sort t ~cmp:(fun a b -> Ordering.to_int (compare a b))
 

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -37,6 +37,7 @@ val find_exn : 'a t -> f:('a -> bool     ) -> 'a
 val find_map : 'a t -> f:('a -> 'b option) -> 'b option
 
 val last : 'a t -> 'a option
+val destruct_last : 'a t -> ('a list * 'a) option
 
 val        sort : 'a t -> compare:('a -> 'a -> Ordering.t) -> 'a t
 val stable_sort : 'a t -> compare:('a -> 'a -> Ordering.t) -> 'a t

--- a/test/blackbox-tests/test-cases/merlin-tests/exe/dune
+++ b/test/blackbox-tests/test-cases/merlin-tests/exe/dune
@@ -1,3 +1,4 @@
 (executable
  (name x)
+ (preprocess (action (run ./foo-bar %{input-file})))
  (libraries foo))

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -16,6 +16,7 @@
   S $LIB_PREFIX/lib/ocaml
   S .
   S ../lib
+  FLG -pp '$PP/_build/default/exe/foo-bar'
   FLG -w -40
   # Processing lib/.merlin
   EXCLUDE_QUERY_DIR

--- a/test/blackbox-tests/test-cases/merlin-tests/sanitize-dot-merlin/sanitize_dot_merlin.ml
+++ b/test/blackbox-tests/test-cases/merlin-tests/sanitize-dot-merlin/sanitize_dot_merlin.ml
@@ -3,10 +3,12 @@ open Printf
 let process_line =
   let path_re = Str.regexp {|^\([SB]\) /.+/lib/\(.+\)$|} in
   let ppx_re = Str.regexp {|^FLG -ppx '/.+/\.ppx/\(.+\)$|} in
+  let pp_re = Str.regexp {|^FLG -pp '/.+/merlin-tests/\(.+\)$|} in
   fun line ->
     line
     |> Str.replace_first path_re {|\1 $LIB_PREFIX/lib/\2|}
     |> Str.global_replace ppx_re {|FLG -ppx '$PPX/\1|}
+    |> Str.global_replace pp_re {|FLG -pp '$PP/\1|}
 
 let () =
   let files = ref [] in


### PR DESCRIPTION
Fix #1694. In particular, I'm following diml's suggestion of only converting a subset of actions to a `-pp` argument.

The main issue with this PR is that it requires an unreleased version of merlin. Shall we just wait for merlin to be released and require users to upgrade it, or do some version checking in dune? (cc @trefis on this one)