### PR TITLE
Fix generating .merlin with -pp

### DIFF
--- a/src/expander.ml
+++ b/src/expander.ml
@@ -468,3 +468,30 @@ let expand_and_eval_set t set ~standard =
 let eval_blang t = function
   | Blang.Const x -> x (* common case *)
   | blang -> Blang.eval blang ~dir:t.dir ~f:(expand_var_exn t)
+
+module Option = struct
+  exception Not_found
+
+  let expand_var_exn t var syn =
+    t.expand_var t var syn
+    |> Option.map ~f:(function
+      | Ok s -> s
+      | Error _ -> raise_notrace Not_found)
+
+  let expand t ~mode ~template =
+    match
+      String_with_vars.expand ~dir:t.dir ~mode template
+        ~f:(expand_var_exn t)
+    with
+    | exception Not_found -> None
+    | s -> Some s
+
+  let expand_path t sw =
+    expand t ~mode:Single ~template:sw
+    |> Option.map ~f:(
+      Value.to_path ~error_loc:(String_with_vars.loc sw) ~dir:t.dir)
+
+  let expand_str t sw =
+    expand t ~mode:Single ~template:sw
+    |> Option.map ~f:(Value.to_string ~dir:t.dir)
+end

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -53,6 +53,11 @@ val expand_str : t -> String_with_vars.t -> string
 
 val artifacts_host : t -> Artifacts.t
 
+module Option : sig
+  val expand_path : t -> String_with_vars.t -> Path.t option
+  val expand_str : t -> String_with_vars.t -> string option
+end
+
 module Resolved_forms : sig
   type t
 

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -114,8 +114,10 @@ let pp_flags sctx ~expander ~dir_kind { preprocess; libname; _ } =
         else
           None)
       >>= fun args ->
-      let args = List.map ~f:(Expander.expand_str expander) args in
-      let exe = Expander.expand_path expander exe in
+      Expander.Option.expand_path expander exe >>= fun exe ->
+      List.map ~f:(Expander.Option.expand_str expander) args
+      |> Option.List.all
+      >>= fun args ->
       (Path.to_absolute_filename exe :: args)
       |> List.map ~f:quote_for_shell
       |> String.concat ~sep:" "

--- a/src/stdune/option.ml
+++ b/src/stdune/option.ml
@@ -76,3 +76,13 @@ let try_with f =
   match f () with
   | exception _ -> None
   | s -> Some s
+
+module List = struct
+  let all =
+    let rec loop acc = function
+      | [] -> Some (List.rev acc)
+      | None :: _ -> None
+      | Some x :: xs -> loop (x :: acc) xs
+    in
+    fun xs -> loop [] xs
+end

--- a/src/stdune/option.mli
+++ b/src/stdune/option.mli
@@ -34,3 +34,7 @@ val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 val compare : ('a -> 'a -> Ordering.t) -> 'a t -> 'a t -> Ordering.t
 
 val try_with : (unit -> 'a) -> 'a option
+
+module List : sig
+  val all : 'a option list -> 'a list option
+end


### PR DESCRIPTION
Previously, it would fail if some vars failed to expand.

I could have used partial expansion to implement this, but we really don't care about the partial results.

Also, this bug really shows that we need support for arbitrary actions. As it's a shame that omp won't have merlin support for example.