### PR TITLE
Configurator: Export additional existing functions 

### DIFF
--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -118,7 +118,7 @@ module Find_in_path = struct
     | None -> prog_not_found prog
     | Some fn -> fn
 
-  let find prog =
+  let which prog =
     List.find_map (get_path ()) ~f:(fun dir ->
       let fn = dir ^/ prog ^ exe in
       Option.some_if (Sys.file_exists fn) fn)
@@ -470,9 +470,9 @@ const char *s%i = "BEGIN-%i-false-END";
     Sys.rename tmp_fname fname
 end
 
-let find_in_path t prog =
-  logf t "find_in_path: %s" prog;
-  let x = Find_in_path.find prog in
+let which t prog =
+  logf t "which: %s" prog;
+  let x = Find_in_path.which prog in
   logf t "-> %s"
     (match x with
      | None -> "not found"
@@ -486,7 +486,7 @@ module Pkg_config = struct
     }
 
   let get c =
-    Option.map (find_in_path c "pkg-config") ~f:(fun pkg_config ->
+    Option.map (which c "pkg-config") ~f:(fun pkg_config ->
       { pkg_config; configurator = c })
 
   type package_conf =
@@ -502,7 +502,7 @@ module Pkg_config = struct
     let env =
       match ocaml_config_var c "system" with
       | Some "macosx" -> begin
-          match find_in_path c "brew" with
+          match which c "brew" with
           | Some brew ->
             let prefix =
               String.trim (run_capture_exn c ~dir (command_line brew ["--prefix"]))

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -118,6 +118,11 @@ module Flags : sig
       Any blank words are filtered out of the results. *)
 end
 
+val find_in_path : t -> string -> string option
+(** [find_in_path t prog] seek [prog] in the PATH and return the name
+   of the program prefixed with the first path where it is found.
+   Return [None] the the program is not found. *)
+
 (** Typical entry point for configurator programs *)
 val main
   :  ?args:(Arg.key * Arg.spec * Arg.doc) list

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -7,12 +7,14 @@ val create
   -> string (** name, such as library name *)
   -> t
 
-(** Return the value associated to a variable in the output of [ocamlc -config] *)
+(** Return the value associated to a variable in the output of
+    [ocamlc -config] *)
 val ocaml_config_var     : t -> string -> string option
 val ocaml_config_var_exn : t -> string -> string
 
-(** [c_test t ?c_flags ?link_flags c_code] try to compile and link the C code given in
-    [c_code]. Return whether compilation was successful. *)
+(** [c_test t ?c_flags ?link_flags c_code] try to compile and link the
+   C code given in [c_code]. Return whether compilation was
+   successful. *)
 val c_test
   :  t
   -> ?c_flags:   string list (** default: [] *)
@@ -38,8 +40,10 @@ module C_define : sig
   (** Import some #define from the given header files. For instance:
 
       {[
-        # C.C_define.import c ~includes:"caml/config.h" ["ARCH_SIXTYFOUR", Switch];;
-        - (string * Configurator.C_define.Value.t) list = ["ARCH_SIXTYFOUR", Switch true]
+        # C.C_define.import c ~includes:"caml/config.h"
+                            ["ARCH_SIXTYFOUR", Switch];;
+        - (string * Configurator.C_define.Value.t) list =
+        ["ARCH_SIXTYFOUR", Switch true]
       ]}
   *)
   val import
@@ -52,8 +56,8 @@ module C_define : sig
     -> (string * Type.t ) list
     -> (string * Value.t) list
 
-  (** Generate a C header file containing the following #define. [protection_var] is used
-      to enclose the file with:
+  (** Generate a C header file containing the following
+      #define. [protection_var] is used to enclose the file with:
 
       {[
         #ifndef BLAH
@@ -121,6 +125,6 @@ val main
   -> (t -> unit)
   -> unit
 
-(** Abort execution. If raised from within [main], the argument of [die] is printed as
-    [Error: <message>]. *)
+(** Abort execution. If raised from within [main], the argument of
+   [die] is printed as [Error: <message>]. *)
 val die : ('a, unit, string, 'b) format4 -> 'a

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -118,8 +118,8 @@ module Flags : sig
       Any blank words are filtered out of the results. *)
 end
 
-val find_in_path : t -> string -> string option
-(** [find_in_path t prog] seek [prog] in the PATH and return the name
+val which : t -> string -> string option
+(** [which t prog] seek [prog] in the PATH and return the name
    of the program prefixed with the first path where it is found.
    Return [None] the the program is not found. *)
 


### PR DESCRIPTION
These functions are useful to, say, locate a FORTRAN compiler and querying it to locate where `libgfortran` resides (when needed).