### PR TITLE
unstable-fmt: ignore files in OCaml syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,8 @@ unreleased
   stanza. It was previously causing intermediate *mock* files to be
   promoted (#1783, fixes #1781, @diml)
 
+- unstable-fmt: ignore files using OCaml syntax (#1784, @emillon)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -361,10 +361,6 @@ let parse_string ~fname ~mode ?lexer str =
   let lb = lexbuf_from_string ~fname str in
   Parser.parse ~mode ?lexer lb
 
-let parse_cst_string ~fname ?lexer str =
-  let lb = lexbuf_from_string ~fname str in
-  Parser.parse_cst ?lexer lb
-
 type dune_lang = t
 
 module Encoder = struct

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -206,12 +206,6 @@ val parse_string
   -> string
   -> 'a
 
-val parse_cst_string
-  :  fname:string
-  -> ?lexer:Lexer.t
-  -> string
-  -> Cst.t list
-
 module Encoder : sig
   type sexp = t
   include Sexp_intf.Combinators with type 'a t = 'a -> t

--- a/test/blackbox-tests/test-cases/fmt/ocaml-syntax.dune
+++ b/test/blackbox-tests/test-cases/fmt/ocaml-syntax.dune
@@ -1,0 +1,7 @@
+(* -*- tuareg -*- *)
+
+let () = Jbuild_plugin.V1.send {|
+(alias
+ (name runtest)
+ (action (echo "ocaml syntax")))
+|}

--- a/test/blackbox-tests/test-cases/fmt/run.t
+++ b/test/blackbox-tests/test-cases/fmt/run.t
@@ -164,3 +164,14 @@ When a comment is at the end of a list, the ")" is on a own line.
    ; final unattached
    ; multiline
    )
+
+Files in OCaml syntax are ignored with a warning.
+
+  $ dune unstable-fmt < ocaml-syntax.dune
+  File "", line 1, characters 0-20:
+  Warning: OCaml syntax is not supported, skipping.
+  $ dune unstable-fmt ocaml-syntax.dune
+  File "$TESTCASE_ROOT/ocaml-syntax.dune", line 1, characters 0-20:
+  1 | (* -*- tuareg -*- *)
+      ^^^^^^^^^^^^^^^^^^^^
+  Warning: OCaml syntax is not supported, skipping.


### PR DESCRIPTION
When this is detected, it displays a warning and does nothing.