### PR TITLE
Allow $PKG_CONFIG_PATH to have effect on macOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,10 @@ unreleased
 
 - unstable-fmt: ignore files using OCaml syntax (#1784, @emillon)
 
+- Make configurator append paths to `$PKG_CONFIG_PATH` on macOS. Previously it
+  was prepending paths and thus `$PKG_CONFIG_PATH` set by users could have been
+  overriden by homebrew installed libraries (#1785, @andreypopp)
+
 1.6.2 (05/12/2018)
 ------------------
 

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -507,7 +507,7 @@ module Pkg_config = struct
             let prefix =
               String.trim (run_capture_exn c ~dir (command_line brew ["--prefix"]))
             in
-            sprintf "env PKG_CONFIG_PATH=%s/opt/%s/lib/pkgconfig:$PKG_CONFIG_PATH "
+            sprintf "env PKG_CONFIG_PATH=$PKG_CONFIG_PATH:%s/opt/%s/lib/pkgconfig "
               (quote prefix) package
           | None ->
             ""


### PR DESCRIPTION
Previously brew's `$PKG_CONFIG_PATH` took precedence over `$PKG_CONFIG_PATH`, this commit changes so that already set `$PKG_CONFIG_PATH` have effect over brew's path.

We are seeing that with esy dune prefers globally installed libraries on macOS b/c of how dune overrides `$PKG_CONFIG_PATH`. This fixes that.