### PR TITLE
-no-approx is not supported in 4.02

### DIFF
--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -37,3 +37,6 @@ let stdlib_includes_bigarray version =
 
 let stdlib_includes_seq version =
   version >= (4, 07, 0)
+
+let supports_no_approx version =
+  version >= (4, 02, 0)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -38,3 +38,5 @@ val stdlib_includes_bigarray : t -> bool
 
 (** Whether the standard library includes the [Seq] module *)
 val stdlib_includes_seq : t -> bool
+
+val supports_no_approx : t -> bool

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -57,11 +57,20 @@ let rules ~dir ~(ctx : Context.t) ~unit =
         })
     | Some bin -> Ok bin
   in
+  let no_approx =
+    if Ocaml_version.supports_no_approx ctx.version then
+      [Arg_spec.A "-no-approx"]
+    else
+      []
+  in
   ( Build.run ~dir bin
-      [ A "-no-approx"
-      ; A "-no-code"
-      ; Dep unit
-      ] ~stdout_to:output
+      (List.concat
+         [ no_approx
+         ; [ A "-no-code"
+           ; Dep unit
+           ]
+         ])
+      ~stdout_to:output
   , Build.contents output >>^ parse
   )
 }


### PR DESCRIPTION
However, it can safely be omitted

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>