### PR TITLE
Don't use -no-code pre 4.04

### DIFF
--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -40,3 +40,6 @@ let stdlib_includes_seq version =
 
 let supports_no_approx version =
   version >= (4, 04, 0)
+
+let supports_no_code version =
+  version >= (4, 04, 0)

--- a/src/ocaml_version.ml
+++ b/src/ocaml_version.ml
@@ -38,8 +38,8 @@ let stdlib_includes_bigarray version =
 let stdlib_includes_seq version =
   version >= (4, 07, 0)
 
-let supports_no_approx version =
+let ooi_supports_no_approx version =
   version >= (4, 04, 0)
 
-let supports_no_code version =
+let ooi_supports_no_code version =
   version >= (4, 04, 0)

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -39,4 +39,8 @@ val stdlib_includes_bigarray : t -> bool
 (** Whether the standard library includes the [Seq] module *)
 val stdlib_includes_seq : t -> bool
 
+(** Whether ocamlobjinfo supports -no-approx*)
 val supports_no_approx : t -> bool
+
+(** Whether ocamlobjinfo supports -no-code*)
+val supports_no_code : t -> bool

--- a/src/ocaml_version.mli
+++ b/src/ocaml_version.mli
@@ -40,7 +40,7 @@ val stdlib_includes_bigarray : t -> bool
 val stdlib_includes_seq : t -> bool
 
 (** Whether ocamlobjinfo supports -no-approx*)
-val supports_no_approx : t -> bool
+val ooi_supports_no_approx : t -> bool
 
 (** Whether ocamlobjinfo supports -no-code*)
-val supports_no_code : t -> bool
+val ooi_supports_no_code : t -> bool

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -63,12 +63,17 @@ let rules ~dir ~(ctx : Context.t) ~unit =
     else
       []
   in
+  let no_code =
+    if Ocaml_version.supports_no_code ctx.version then
+      [Arg_spec.A "-no-code"]
+    else
+      []
+  in
   ( Build.run ~dir bin
       (List.concat
          [ no_approx
-         ; [ A "-no-code"
-           ; Dep unit
-           ]
+         ; no_code
+         ; [ Dep unit ]
          ])
       ~stdout_to:output
   , Build.contents output >>^ parse

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -58,13 +58,13 @@ let rules ~dir ~(ctx : Context.t) ~unit =
     | Some bin -> Ok bin
   in
   let no_approx =
-    if Ocaml_version.supports_no_approx ctx.version then
+    if Ocaml_version.ooi_supports_no_approx ctx.version then
       [Arg_spec.A "-no-approx"]
     else
       []
   in
   let no_code =
-    if Ocaml_version.supports_no_code ctx.version then
+    if Ocaml_version.ooi_supports_no_code ctx.version then
       [Arg_spec.A "-no-code"]
     else
       []


### PR DESCRIPTION
This option was introduced in 4.04 so we shouldn't be using it prematurely