### PR TITLE
[rfc] vendor and expose Ocaml_version in configurator

### DIFF
--- a/src/configurator/ocaml_version.ml
+++ b/src/configurator/ocaml_version.ml
@@ -1,0 +1,253 @@
+(* Copyright (c) 2017 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+*)
+
+type t = { major: int; minor: int; patch: int option; extra: string option }
+let v ?patch ?extra major minor = { major; minor; patch; extra }
+
+let major { major; _ } = major
+let minor { minor; _ } = minor
+let patch { patch; _ } = patch
+let extra { extra; _ } = extra
+
+let to_string ?(sep='+') =
+  function
+  | {major;minor;patch=None;extra=None} -> Printf.sprintf "%d.%02d" major minor
+  | {major;minor;patch=Some patch;extra=None} -> Printf.sprintf "%d.%02d.%d" major minor patch
+  | {major;minor;patch=Some patch;extra=Some extra} -> Printf.sprintf "%d.%02d.%d%c%s" major minor patch sep extra
+  | {major;minor;patch=None;extra=Some extra} -> Printf.sprintf "%d.%02d%c%s" major minor sep extra
+
+let parse s =
+  try Scanf.sscanf s "%d.%d.%d+%s" (fun major minor patch extra -> v ~patch ~extra major minor)
+  with End_of_file | Scanf.Scan_failure _ -> begin
+      try Scanf.sscanf s "%d.%d+%s" (fun major minor extra -> v ~extra major minor)
+      with End_of_file | Scanf.Scan_failure _ -> begin
+          try Scanf.sscanf s "%d.%d.%d" (fun major minor patch -> v ~patch major minor)
+          with End_of_file | Scanf.Scan_failure _ -> begin
+              Scanf.sscanf s "%d.%d" (fun major minor -> v major minor)
+            end
+        end
+    end
+
+let of_string s =
+  try Ok (parse s) with
+  | _ -> Error (`Msg (Printf.sprintf "Unable to parse OCaml version '%s'" s))
+
+let of_string_exn s =
+  try parse s with
+  | _ -> raise (Invalid_argument (Printf.sprintf "Unable to parse OCaml version '%s'" s))
+
+let pp ppf v = Format.pp_print_string ppf (to_string v)
+
+let ( ++ ) x fn =
+  match x with
+  | 0 -> fn ()
+  | r -> r
+
+let compare {major; minor; patch; extra} a =
+  compare major a.major ++ fun () ->
+    compare minor a.minor ++ fun () ->
+      compare patch a.patch ++ fun () ->
+        compare extra a.extra
+
+let sys_version = of_string_exn Sys.ocaml_version
+
+let with_variant t extra = { t with extra }
+let without_variant t = { t with extra=None }
+let with_patch t patch = { t with patch }
+let without_patch t = { t with patch=None }
+let with_just_major_and_minor t = { t with patch=None; extra=None }
+
+module Releases = struct
+  let v4_00_0 = of_string_exn "4.00.0"
+  let v4_00_1 = of_string_exn "4.00.1"
+  let v4_00 = v4_00_1
+
+  let v4_01_0 = of_string_exn "4.01.0"
+  let v4_01 = v4_01_0
+
+  let v4_02_0 = of_string_exn "4.02.0"
+  let v4_02_1 = of_string_exn "4.02.1"
+  let v4_02_2 = of_string_exn "4.02.2"
+  let v4_02_3 = of_string_exn "4.02.3"
+  let v4_02 = v4_02_3
+
+  let v4_03_0 = of_string_exn "4.03.0"
+  let v4_03 = v4_03_0
+
+  let v4_04_0 = of_string_exn "4.04.0"
+  let v4_04_1 = of_string_exn "4.04.1"
+  let v4_04_2 = of_string_exn "4.04.2"
+  let v4_04 = v4_04_2
+
+  let v4_05_0 = of_string_exn "4.05.0"
+  let v4_05 = v4_05_0
+
+  let v4_06_0 = of_string_exn "4.06.0"
+  let v4_06_1 = of_string_exn "4.06.1"
+  let v4_06 = v4_06_1
+
+  let v4_07_0 = of_string_exn "4.07.0"
+  let v4_07_1 = of_string_exn "4.07.1"
+  let v4_07 = v4_07_1
+
+  let v4_08_0 = of_string_exn "4.08.0"
+  let v4_08 = v4_08_0
+
+  let v4_09_0 = of_string_exn "4.09.0"
+  let v4_09 = v4_09_0
+
+  let all_patches = [
+    v4_00_1; v4_01_0; v4_02_0; v4_02_1; v4_02_2;
+    v4_02_3; v4_03_0; v4_04_0; v4_04_1; v4_04_2;
+    v4_05_0; v4_06_0; v4_06_1; v4_07_0; v4_07_1;
+    v4_08_0; v4_09_0 ]
+
+  let all = [ v4_00; v4_01; v4_02; v4_03; v4_04;
+              v4_05; v4_06; v4_07; v4_08; v4_09 ]
+
+  let recent = [ v4_02; v4_03; v4_04; v4_05; v4_06; v4_07 ]
+
+  let latest = v4_07
+
+  let dev = [ v4_08; v4_09 ]
+
+  let is_dev t =
+    let t = with_just_major_and_minor t in
+    let dev = List.map with_just_major_and_minor dev in
+    List.mem t dev
+
+  let recent_with_dev = List.concat [recent; dev]
+
+end
+
+type arch = [`X86_64 | `Aarch64 | `Ppc64le | `Aarch32 ]
+let arches = [ `X86_64; `Aarch64; `Ppc64le; `Aarch32 ]
+
+let string_of_arch = function
+  | `Aarch64 -> "arm64"
+  | `Aarch32 -> "arm32v7"
+  | `X86_64 -> "amd64"
+  | `Ppc64le -> "ppc64le"
+
+let arch_of_string = function
+  | "arm64" | "aarch64" -> Ok `Aarch64
+  | "amd64" | "x86_64" -> Ok `X86_64
+  | "arm32" | "arm32v7" | "aarch32" -> Ok `Aarch32
+  | "ppc64le" -> Ok `Ppc64le
+  | arch -> Error (`Msg ("Unknown architecture " ^ arch))
+
+let arch_of_string_exn a =
+  match arch_of_string a with
+  | Ok a -> a
+  | Error (`Msg m) -> raise (Invalid_argument m)
+
+module Since = struct
+  let bytes = Releases.v4_03_0
+
+  let arch (a:arch) =
+    match a with
+    | `Aarch32 -> Releases.v4_06_0
+    | `Aarch64 -> Releases.v4_05_0
+    | `Ppc64le -> Releases.v4_06_0
+    | `X86_64 -> Releases.v4_00_0 (* TODO obviously earlier *)
+end
+
+module Has = struct
+
+  let bytes v =
+    match compare Since.bytes v with
+    |(-1) | 0 -> true
+    |_ -> false
+
+  let arch (a:arch) v =
+    match compare (Since.arch a) v with
+    |(-1) | 0 -> true
+    |_ -> false
+end
+
+module Configure_options = struct
+  type o = [ `Afl | `Flambda | `Default_unsafe_string | `Force_safe_string | `Frame_pointer ]
+
+  let to_description t = 
+    match t with
+    | `Afl -> "AFL (fuzzing) support"
+    | `Flambda -> "flambda inlining"
+    | `Default_unsafe_string -> "default to unsafe strings"
+    | `Force_safe_string -> "force safe string mode"
+    | `Frame_pointer -> "frame pointer"
+
+  let to_string t =
+    match t with
+    | `Afl -> "afl"
+    | `Flambda -> "flambda"
+    | `Default_unsafe_string -> "default-unsafe-string"
+    | `Force_safe_string -> "force-safe-string"
+    | `Frame_pointer -> "fp"
+
+  let to_configure_flag t =
+    match t with
+    | `Afl -> "-afl-instrument"
+    | `Flambda -> "-flambda"
+    | `Default_unsafe_string -> "-default-unsafe-string"
+    | `Force_safe_string -> "-force-safe-string"
+    | `Frame_pointer -> "-with-frame-pointer"
+
+end
+
+let compiler_variants arch {major; minor; _} =
+    match major,minor,arch with
+    | 4,9,`X86_64 -> [[]]
+    | 4,9,_ -> [[]]
+    | 4,8,`X86_64 -> [[]; [`Afl]; [`Flambda]; [`Frame_pointer]; [`Frame_pointer;`Flambda]; [`Default_unsafe_string]]
+    | 4,8,_ -> [[]; [`Afl]; [`Flambda];[`Default_unsafe_string]]
+    | 4,7,_ -> [[]; [`Afl]; [`Flambda]; [`Default_unsafe_string]; [`Force_safe_string]]
+    | 4,6,_ -> [[]; [`Afl]; [`Flambda]; [`Default_unsafe_string]; [`Force_safe_string]]
+    | 4,5,_ -> [[]; [`Afl]; [`Flambda]]
+    | 4,4,_ -> [[]; [`Flambda]]
+    | 4,3,_ -> [[]; [`Flambda]]
+    | _ -> [[]]
+
+module Sources = struct
+  let trunk = Releases.v4_08
+
+  let git_tag ({major; minor; patch; _ } as ov) =
+    match major, minor, patch with
+    | major, minor, _ when major = trunk.major && minor = trunk.minor -> "trunk"
+    | _ -> to_string (with_variant ov None)
+end
+
+module Opam = struct
+
+  module V2 = struct
+    let name t =
+      match t.extra with
+      | Some extra when Releases.is_dev t -> Printf.sprintf "ocaml-variants.%s+trunk+%s" (to_string (without_variant t)) extra
+      | Some _ -> "ocaml-variants." ^ (to_string t)
+      | None when Releases.is_dev t -> Printf.sprintf "ocaml-variants.%s+trunk" (to_string t)
+      | None -> "ocaml-base-compiler." ^ (to_string t)
+
+    let variant_switch t vs =
+      match vs with
+      | [] -> with_variant t None
+      | vs ->
+        let v = String.concat "+" (List.map Configure_options.to_string vs) in
+        with_variant t (Some v)
+
+    let switches arch t =
+      compiler_variants arch t |>
+      List.map (fun vs -> variant_switch t vs)
+  end
+end

--- a/src/configurator/ocaml_version.mli
+++ b/src/configurator/ocaml_version.mli
@@ -1,0 +1,345 @@
+(* Copyright (c) 2017-2018 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+*)
+
+(** Manipulate, parse and generate OCaml version strings.
+
+    These are of the form [major.minor.patch+extra], where the
+    [patch] and [extra] fields are optional.  *)
+
+type t
+(** Type of an OCaml version string *)
+
+val v : ?patch:int -> ?extra:string -> int -> int -> t
+(** [v ?patch ?extra major minor] will construct an OCaml
+    version string with the appropriate parameters.  The
+    [patch] and [extra] indicators are optional, but it is
+    conventional to include a [patch] value of 0 for most
+    recent OCaml releases. *)
+
+(** {2 Parsers and serializers} *)
+
+val to_string : ?sep:char -> t -> string
+(** [to_string ?sep t] will convert the version [t] into
+    a human-readable representation.  The [sep] will default
+    to [+] which is the normal representation of extra
+    version strings, but can be changed to another character
+    by supplying [sep].  One such usecase is to generate
+    Docker container tags from OCaml version strings, where
+    only dashes and alphanumeric characters are allowed. *)
+
+val of_string : string -> (t, [> `Msg of string ]) result
+(** [of_string t] will parse the version string in [t].
+    The return value is compatible with the {!Result}
+    combinators defined in the [rresult] library. *)
+
+val of_string_exn : string -> t
+(** [of_string_exn t] behaves as {!of_string} but raises
+    [Invalid_argument] if the string cannot be parsed. *)
+
+val compare : t -> t -> int
+(** [compare a b] is the comparison function for two OCaml
+    version strings. Returns [-1] if [a<b], [0] if they are
+    equal and [1] if [a>b]. Comparison is done using integer
+    comparison for the major, minor and patch versions, and
+    lexical comparison for any extra version strings present. *)
+
+val pp : Format.formatter -> t -> unit
+(** [pp fmt t] will output a human-readable version string of
+    [t] to the [fmt] formatter. *)
+
+(** {2 Architecture Support }
+    These definitions cover the CPU architectures that OCaml
+    runs and is supported on. *)
+
+type arch = [ `X86_64 | `Aarch64 | `Aarch32 | `Ppc64le ]
+(** Type of CPU architectures.
+    TODO: This is currently an incomplete list, and lists just
+    those used by the opam test systems. Contributions welcome
+    to complete it. *)
+
+val arches : arch list
+(** [arches] is an enumeration of all of the possible {!arch} values. *)
+
+val string_of_arch : arch -> string
+(** [string_of_arch arch] will convert [arch] into a human-readable
+    CPU architecture string.  The result will follow the
+    {{:https://golang.org/doc/install/source#environment}GOARCH}
+    convention used by Golang. *)
+
+val arch_of_string : string -> (arch, [> `Msg of string ]) result
+(** [arch_of_string t] will parse the architecture string in [t].
+    The return value is compatible with the {!Result}
+    combinators defined in the [rresult] library. This function
+    is liberal and will attempt to understand variants of the
+    same architecture.  For example, both [aarch64] and [arm64]
+    are parsed into {!`Aarch64}. *)
+
+val arch_of_string_exn: string -> arch
+(** [arch_of_string_exn t] is the same as {!arch_of_string},
+    except that it raises [Invalid_argument] in case of error. *)
+
+(** {2 Accessors} *)
+
+val major : t -> int
+(** [major t] will return the major version number of an OCaml
+    release.  For example, [of_string "4.03.0" |> major] will
+    return [4]. *)
+
+val minor : t -> int
+(** [minor t] will return the minor version number of an OCaml
+    release.  For example, [of_string "4.03.0" |> minor] will
+    return [3]. *)
+
+val patch : t -> int option
+(** [patch t] will return the patch version number of an OCaml
+    release.  For example, [of_string "4.03.0" |> minor] will
+    return [Some 0]. *)
+
+val extra : t -> string option
+(** [extra t] will return the additional information string of
+    an OCaml release.
+    For example, [of_string "4.03.0+flambda" |> extra] will
+    return [Some "flambda"]. *)
+
+val with_variant : t -> string option -> t
+(** [with_variant t extra] will return a fresh value with
+    the extra version information in [t] to
+    [extra], and remove it if [None] is supplied. *)
+
+val without_variant : t -> t
+(** [without_variant t] is {!with_variant} [t None]. It removes
+    any extra version information from the version string [t]. *)
+
+val with_patch : t -> int option -> t
+(** [with_patch t patch] will return a fresh value with
+    the patch number in [t] to [patch], and remove it if [None]
+    is supplied. *)
+
+val without_patch : t -> t
+(** [without_patch t] is as {!with_patch} [t None]. It removes
+    the least significant number from the version string.
+    This is useful for the Docker OCaml containers, which are
+    all named without a patch number and compiled using the
+    latest patch release (e.g. [4.06] instead of [4.06.1]). *)
+
+val with_just_major_and_minor : t -> t
+(** [with_just_major_and_minor t] strips out any patch and
+    extra version information to return the X.Y form of the
+    OCaml release. For example, [4.08.0+trunk+flambda] will
+    return the version representing [4.08]. *)
+
+(** {2 Constants } *)
+
+val sys_version : t
+(** [sys_version] is the version of OCaml that this library is
+    currently compiled with, which will be the same as
+    {!Sys.ocaml_version}. *)
+
+(** Values representing official releases of OCaml. *)
+module Releases : sig
+
+  val v4_00_1 : t
+  (** Version 4.00.1 *)
+
+  val v4_00 : t
+  (** Latest release in the 4.00.x series *)
+
+  val v4_01_0 : t
+  (** Version 4.01.0 *)
+
+  val v4_01 : t
+  (** Latest release in the 4.01.x series *)
+
+  val v4_02_0 : t
+  (** Version 4.02.0 *)
+
+  val v4_02_1 : t
+  (** Version 4.02.1 *)
+
+  val v4_02_2 : t
+  (** Version 4.02.2 *)
+
+  val v4_02_3 : t
+  (** Version 4.02.3 *)
+
+  val v4_02 : t
+  (** Latest release in the 4.02.x series *)
+
+  val v4_03_0 : t
+  (** Version 4.03.0 *)
+
+  val v4_03 : t
+  (** Latest release in the 4.03.x series *)
+
+  val v4_04_0 : t
+  (** Version 4.04.0 *)
+
+  val v4_04_1 : t
+  (** Version 4.04.1 *)
+
+  val v4_04_2 : t
+  (** Version 4.04.2 *)
+
+  val v4_04 : t
+  (** Latest release in the 4.04.x series *)
+
+  val v4_05_0 : t
+  (** Version 4.05.0 *)
+
+  val v4_05 : t
+  (** Latest release in the 4.05.x series *)
+
+  val v4_06_0 : t
+  (** Version 4.06.0 *)
+
+  val v4_06_1 : t
+  (** Version 4.06.1 *)
+
+  val v4_06 : t
+  (** Latest release in the 4.06.x series *)
+
+  val v4_07_0 : t
+  (** Version 4.07.0 *)
+
+  val v4_07_1 : t
+  (** Version 4.07.1 *)
+
+  val v4_07 : t
+  (** Latest release in the 4.07.x series *)
+
+  val v4_08_0 : t
+  (** Versior 4.08.0 *)
+
+  val v4_08 : t
+  (** Latest release in the 4.08.x series *)
+
+  val v4_09_0 : t
+  (** Version 4.09.0 *)
+
+  val v4_09 : t
+  (** Latest release in the 4.09.x series *)
+
+  val all_patches : t list
+  (** [all_patches] is an enumeration of all OCaml releases, including every patch release.
+      To get the major and minor releases with the latest patch version, use {!all} instead. *)
+
+  val all : t list
+  (** [all] is an enumeration of all the OCaml releases, with the latest patch versions in
+      each major and minor release. *)
+
+  val dev : t list
+  (** Enumeration of the latest development OCaml releases.
+      This is usually just one, but may include two active dev
+      versions if a release branch has just been cut. *)
+
+  val latest: t
+  (** [latest] is the most recent stable release of OCaml. *)
+
+  val recent : t list
+  (** [recent] is the last five releases of OCaml, with each at the latest patch level.
+      This is the set that is most reliably tested in the opam package repository. *)
+
+  val recent_with_dev : t list
+  (** [recent_with_dev] are the last four stable releases of OCaml and the latest
+      development branches. *)
+
+  val is_dev : t -> bool
+  (** [is_dev t] will return true if the release [t] represents a development
+      release instead of a stable archive. *)
+end
+
+(** Values relating to the source code and version control of OCaml *)
+module Sources : sig
+
+  val trunk : t
+  (** [trunk] is the version of the development head of the OCaml git repository. *)
+
+  val git_tag : t -> string
+  (* [git_tag v] returns the Git tag or branch that corresponds to the release
+     [v] of OCaml.  If [v] does not have a patch releases, then it will be a branch
+     that points to the relevant release branch. *)
+end
+
+(** {2 Feature Selection} *)
+
+(** Determine which release a feature or architecture first appeared in. *)
+module Since : sig
+
+  val bytes: t
+  (** [bytes] is the release that the {!Bytes} module first appeared in. *)
+
+  val arch : arch -> t 
+  (** [arch a] will return the first release of OCaml that the architecture
+      was reasonably stably supported on. *)
+end
+
+(** Test whether a release has a given feature. *)
+module Has : sig
+
+  val bytes : t -> bool
+  (** [bytes t] will return {!true} if that release has a {!bytes} type.
+      Note that opam provides a [bytes] compatibility package for older releases. *)
+
+  val arch : arch -> t -> bool
+  (** [arch a t] will return {!true} if architecture [a] is supported on release [t]. *)
+end
+
+(** Configuration parameters that affect the behaviour of OCaml at compiler-build-time. *)
+module Configure_options : sig
+
+  type o =
+    [ `Afl
+    | `Default_unsafe_string
+    | `Flambda
+    | `Force_safe_string
+    | `Frame_pointer ]
+  (** Configuration options available at compiler build time. *)
+
+  val to_string : o -> string
+  (** [to_string o] returns a compact representation of {!o} suitable for use in opam version strings. *)
+
+  val to_description : o -> string
+  (** [to_description o] returns a human-readable representation of {!o}. *)
+
+  val to_configure_flag : o -> string
+  (** [to_configure_flag o] returns a string that can be passed to OCaml's [configure] script to activate that feature. *)
+end
+
+val compiler_variants : arch -> t -> Configure_options.o list list
+(** [compiler_variants v] returns a list of configuration options that are available and useful
+    for version [v] of the compiler. *)
+
+(** Opam compiler switches.
+    These are available from the public {{:https://github.com/ocaml/opam-repository}opam-repository}. *)
+module Opam : sig
+
+  (** Opam 2.0 functions *)
+  module V2 : sig
+    val name : t -> string
+    (** [package t] returns the opam2 package for that compiler version. *)
+
+    val variant_switch : t -> Configure_options.o list -> t
+    (** [variant_switch t cs] returns an OCaml version [t] whose
+        variant version field reflects the configuration options in [cs] *)
+
+    val switches : arch -> t -> t list
+    (** [switches arch t] returns the list of opam switches that
+        are available for that compiler and architecture combination.
+        For example, an x86_64 one would yield a list that includes
+        flambda and the flambda-with-frame-pointer combinations. *)
+
+  end
+end

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -4,6 +4,7 @@ open! Stdune
    initialized *)
 module Path = struct end
 module Io = Io.String_path
+module Ocaml_version = Ocaml_version
 
 let sprintf = Printf.sprintf
 let eprintf = Printf.eprintf
@@ -217,6 +218,10 @@ let ocaml_config_var t var = String.Map.find t.ocamlc_config var
 let ocaml_config_var_exn t var =
   get_ocaml_config_var_exn t.ocamlc_config var
     ~ocamlc_config_cmd:t.ocamlc_config_cmd
+
+let ocaml_version t =
+  ocaml_config_var_exn t "version" |>
+  Ocaml_version.of_string_exn
 
 let create ?dest_dir ?ocamlc ?(log=ignore) name =
   let dest_dir =

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -12,6 +12,14 @@ val create
 val ocaml_config_var     : t -> string -> string option
 val ocaml_config_var_exn : t -> string -> string
 
+module Ocaml_version : sig
+  type t
+  val pp : Format.formatter -> t -> unit
+  val compare : t -> t -> int
+end
+
+val ocaml_version : t -> Ocaml_version.t
+
 (** [c_test t ?c_flags ?link_flags c_code] try to compile and link the
    C code given in [c_code]. Return whether compilation was
    successful. *)


### PR DESCRIPTION
This allows for easy OCaml version detection and comparison without having to deal with raw strings directly.  The library is a vendored version of the standalone [ocaml-version](https://github.com/avsm/ocaml-version) that we use for all the container generation in the ocaml.org infrastructure.

The PR isn't complete as I wanted to check the best way to integrate it into Configurator and expose the full interface.  The full interface has lots of convenience functions (like variables for known releases, so you can do `Ocaml_version.(compare v Releases.v4_08)` and so on.  