### PR TITLE
Split parsing of module names and reading them

### DIFF
--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -20,12 +20,7 @@ let parse_module_names ~(unit : Module.t) ~modules words =
     else
       Module.Name.Map.find modules m)
 
-let parse_deps cctx ~file ~unit lines =
-  let dir                  = CC.dir                  cctx in
-  let alias_module         = CC.alias_module         cctx in
-  let lib_interface_module = CC.lib_interface_module cctx in
-  let modules              = CC.modules              cctx in
-  let vimpl                = CC.vimpl                cctx in
+let parse_deps_exn ~file lines =
   let invalid () =
     die "ocamldep returned unexpected output for %s:\n\
          %s"
@@ -41,56 +36,63 @@ let parse_deps cctx ~file ~unit lines =
     | Some (basename, deps) ->
       let basename = Filename.basename basename in
       if basename <> Path.basename file then invalid ();
-      let deps =
-        let modules = Vimpl.add_vlib_modules vimpl modules in
-        String.extract_blank_separated_words deps
-        |> parse_module_names ~unit ~modules
-      in
-      let stdlib = CC.stdlib cctx in
-      let deps =
-        match stdlib, CC.lib_interface_module cctx with
-        | Some { modules_before_stdlib; _ }, Some m
-          when Module.name unit = Module.name m ->
-          (* See comment in [Dune_file.Stdlib]. *)
-          List.filter deps ~f:(fun m ->
-            Module.Name.Set.mem modules_before_stdlib (Module.name m))
-        | _ -> deps
-      in
-      if Option.is_none stdlib then
-        Option.iter lib_interface_module ~f:(fun (m : Module.t) ->
-          let m = Module.name m in
-          let open Module.Name.Infix in
-          if Module.name unit <> m
-          && not (is_alias_module cctx unit)
-          && List.exists deps ~f:(fun x -> Module.name x = m) then
-            die "Module %a in directory %s depends on %a.\n\
-                 This doesn't make sense to me.\n\
-                 \n\
-                 %a is the main module of the library and is \
-                 the only module exposed \n\
-                 outside of the library. Consequently, it should \
-                 be the one depending \n\
-                 on all the other modules in the library."
-              Module.Name.pp (Module.name unit) (Path.to_string dir)
-              Module.Name.pp m
-              Module.Name.pp m);
-      match stdlib with
-      | None -> begin
-          match alias_module with
-          | None -> deps
-          | Some m -> m :: deps
-        end
-      | Some { modules_before_stdlib; _ } ->
-        if Module.Name.Set.mem modules_before_stdlib (Module.name unit) then
+      String.extract_blank_separated_words deps
+
+let interpret_deps cctx ~unit deps =
+  let dir                  = CC.dir                  cctx in
+  let alias_module         = CC.alias_module         cctx in
+  let lib_interface_module = CC.lib_interface_module cctx in
+  let modules              = CC.modules              cctx in
+  let vimpl                = CC.vimpl                cctx in
+  let deps =
+    let modules = Vimpl.add_vlib_modules vimpl modules in
+    parse_module_names ~unit ~modules deps
+  in
+  let stdlib = CC.stdlib cctx in
+  let deps =
+    match stdlib, CC.lib_interface_module cctx with
+    | Some { modules_before_stdlib; _ }, Some m
+      when Module.name unit = Module.name m ->
+      (* See comment in [Dune_file.Stdlib]. *)
+      List.filter deps ~f:(fun m ->
+        Module.Name.Set.mem modules_before_stdlib (Module.name m))
+    | _ -> deps
+  in
+  if Option.is_none stdlib then
+    Option.iter lib_interface_module ~f:(fun (m : Module.t) ->
+      let m = Module.name m in
+      let open Module.Name.Infix in
+      if Module.name unit <> m
+      && not (is_alias_module cctx unit)
+      && List.exists deps ~f:(fun x -> Module.name x = m) then
+        die "Module %a in directory %s depends on %a.\n\
+             This doesn't make sense to me.\n\
+             \n\
+             %a is the main module of the library and is \
+             the only module exposed \n\
+             outside of the library. Consequently, it should \
+             be the one depending \n\
+             on all the other modules in the library."
+          Module.Name.pp (Module.name unit) (Path.to_string dir)
+          Module.Name.pp m
+          Module.Name.pp m);
+  match stdlib with
+  | None -> begin
+      match alias_module with
+      | None -> deps
+      | Some m -> m :: deps
+    end
+  | Some { modules_before_stdlib; _ } ->
+    if Module.Name.Set.mem modules_before_stdlib (Module.name unit) then
+      deps
+    else
+      match CC.lib_interface_module cctx with
+      | None -> deps
+      | Some m ->
+        if Module.name unit = Module.name m then
           deps
         else
-          match CC.lib_interface_module cctx with
-          | None -> deps
-          | Some m ->
-            if Module.name unit = Module.name m then
-              deps
-            else
-              m :: deps
+          m :: deps
 
 let deps_of cctx ~ml_kind unit =
   let sctx = CC.super_context cctx in
@@ -150,7 +152,8 @@ let deps_of cctx ~ml_kind unit =
       in
       SC.add_rule sctx ~dir
         ( Build.lines_of ocamldep_output
-          >>^ parse_deps cctx ~file ~unit
+          >>^ parse_deps_exn ~file
+          >>^ interpret_deps cctx ~unit
           >>^ (fun modules ->
             (build_paths modules,
              List.map modules ~f:(fun m ->


### PR DESCRIPTION
The old function was already doing many things at once. This simplifies things at least a little bit.