### PR TITLE
Fix double quoting of pkg-config when package contains a space

### DIFF
--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -152,8 +152,8 @@ module Process = struct
   let command_line prog args =
     String.concat ~sep:" " (List.map (prog :: args) ~f:quote_if_needed)
 
-(* [cmd] which cannot be quoted (such as [t.c_compiler] which contains
-   some flags) followed by additional arguments. *)
+  (* [cmd] which cannot be quoted (such as [t.c_compiler] which contains
+     some flags) followed by additional arguments. *)
   let command_args cmd args =
     String.concat ~sep:" " (cmd :: List.map args ~f:quote_if_needed)
 
@@ -510,8 +510,6 @@ module Pkg_config = struct
     }
 
   let query t ~package =
-    let package = quote_if_needed package in
-    let pkg_config = quote_if_needed t.pkg_config in
     let c = t.configurator in
     let dir = c.dest_dir in
     let env =
@@ -529,10 +527,10 @@ module Pkg_config = struct
         end
       | _ -> []
     in
-    if Process.run_ok c ~dir ~env pkg_config [package] then
+    if Process.run_ok c ~dir ~env t.pkg_config [package] then
       let run what =
-        match String.trim
-                (Process.run_capture_exn c ~dir ~env pkg_config [what; package])
+        match String.trim (Process.run_capture_exn c ~dir ~env
+                             t.pkg_config [what; package])
         with
         | "" -> []
         | s  -> String.split s ~on:' '

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -79,16 +79,19 @@ module Pkg_config : sig
   type configurator = t
   type t
 
-  (** Returns [None] if pkg-config is not installed *)
   val get : configurator -> t option
+  (** Search pkg-config in the PATH.  Returns [None] if pkg-config is
+     not found. *)
 
   type package_conf =
     { libs   : string list
     ; cflags : string list
     }
 
-  (** Returns [None] if [package] is not available *)
   val query : t -> package:string -> package_conf option
+  (** [query t ~package] query pkg-config for the [package].  The
+     package may contain a version constraint.  For example
+     "gtk+-3.0 >= 3.18".  Returns [None] if [package] is not available  *)
 end with type configurator := t
 
 module Flags : sig


### PR DESCRIPTION
Example: Pkg_config.query p ~package:"gtk+-3.0 >= 3.10"

Fixes https://github.com/ocaml/dune/issues/1833


I have tested the fix.