### PR TITLE
Make deprecation warning non-fatal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ unreleased
 
 - Add support for `.cxx` extension for C++ stubs (#1831, @rgrinberg)
 
+- Remove the deprecation warning non fatal in dev profile (#1850, fix #1843,
+  @rgrinberg)
+
 1.7.1 (13/02/2019)
 ------------------
 

--- a/src/ocaml_flags.ml
+++ b/src/ocaml_flags.ml
@@ -9,7 +9,8 @@ let dev_mode_warnings =
   "@a" ^
   String.concat ~sep:""
     (List.map ~f:(sprintf "-%d")
-       [ 4
+       [ 3
+       ; 4
        ; 29
        ; 40
        ; 41

--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -7,11 +7,11 @@ This captures the commands that are being run:
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
   {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-modules","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-3-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-3-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-3-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
 
 As well as data about the garbage collector:

--- a/test/blackbox-tests/test-cases/wrapped-transition/run.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition/run.t
@@ -1,10 +1,6 @@
   $ dune build 2>&1 | grep -v ocamlc
-  File "fooexe.ml", line 3, characters 0-7:
-  Error (warning 3): deprecated: module Bar
-  Will be removed past 2020-20-20. Use Mylib.Bar instead.
-  File "fooexe.ml", line 4, characters 0-7:
-  Error (warning 3): deprecated: module Foo
-  Will be removed past 2020-20-20. Use Mylib.Foo instead.
-  File "fooexe.ml", line 7, characters 11-22:
-  Error (warning 3): deprecated: module Intf_only
-  Will be removed past 2020-20-20. Use Mylib.Intf_only instead.
+        fooexe alias default
+  bar
+  foo
+  bar
+  foo


### PR DESCRIPTION
Based on user experience, this is the more widely used default. This is not a breaking change, so we might as well just do it ASAP.

One thing, I'm wondering is if we should make this dafault project-version dependent. That is, set this to non fatal for >= 1.8 only. I'm not yet sure how hard that would be.

cc @NathanReb and @avsm