### PR TITLE
[RFC/WIP] Threadless scheduler

### DIFF
--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -439,7 +439,7 @@ let cleanup ~keep_ml_file =
 
 let () =
   let n =
-    try exec "%s -g -w -40 -o boot.exe unix.cma threads.cma -I +threads %s"
+    try exec "%s -g -w -40 -o boot.exe unix.cma %s"
           (Filename.quote compiler) generated_file
     with e -> cleanup ~keep_ml_file:true; raise e
   in

--- a/dune.opam
+++ b/dune.opam
@@ -8,7 +8,6 @@ license: "MIT"
 depends: [
   "ocaml" {>= "4.02"}
   "base-unix"
-  "base-threads"
 ]
 build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path

--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,6 @@
               memo
               xdg
               dune_re
-              threads.posix
               opam_file_format
               dune_lang
               ocaml_config

--- a/src/ev_select.ml
+++ b/src/ev_select.ml
@@ -1,0 +1,210 @@
+
+(* Signal handling via the self-pipe trick *)
+
+let nsig = 128
+
+type signal_handler_info =
+  | Signal_event_disabled
+  | Signal_event_enabled of {
+    pipe_rd : Unix.file_descr;
+    pipe_wr : Unix.file_descr;
+  }
+
+let signal_handlers = Array.make nsig Signal_event_disabled
+
+let get_sig_info s = signal_handlers.(-s-1)
+let set_sig_info s i = signal_handlers.(-s-1) <- i
+
+let make_sig_info () =
+  let pipe_rd, pipe_wr = Unix.pipe () in
+  Unix.set_close_on_exec pipe_rd;
+  Unix.set_nonblock pipe_rd;
+  Unix.set_close_on_exec pipe_wr;
+  Unix.set_nonblock pipe_wr;
+  (Signal_event_enabled { pipe_rd; pipe_wr })
+
+let byte = Bytes.make 1 '!'
+let handle_signal s =
+  match get_sig_info s with
+  | Signal_event_disabled ->
+     failwith "internal error: signal received when handler disabled"
+  | Signal_event_enabled { pipe_wr; _ } ->
+     match Unix.single_write pipe_wr byte 0 1 with
+     | 1 -> ()
+     | _ -> failwith "please return your operating system for a refund"
+     | exception (Unix.Unix_error ((EAGAIN|EWOULDBLOCK), _, _)) ->
+        (* this is OK *)
+        ()
+
+let check_valid_signal s =
+  if s = Sys.sigchld then
+    raise (Invalid_argument ("Signal events cannot be used for SIGCHLD"));
+  if s >= 0 || s < -nsig then
+    raise (Invalid_argument ("Unknown signal " ^ string_of_int s))
+
+let enable_signal_event s =
+  check_valid_signal s;
+  match get_sig_info s with
+  | Signal_event_enabled _ ->
+     raise (Invalid_argument ("Signal events already enabled for signal " ^ string_of_int s))
+  | Signal_event_disabled ->
+     set_sig_info s (make_sig_info ());
+     Sys.set_signal s (Sys.Signal_handle handle_signal)
+
+let disable_signal_event s =
+  check_valid_signal s;
+  match get_sig_info s with
+  | Signal_event_disabled ->
+     raise (Invalid_argument ("Signal events already disabled for signal " ^ string_of_int s))
+  | Signal_event_enabled { pipe_rd; pipe_wr } ->
+     Sys.set_signal s Sys.Signal_default;
+     Unix.close pipe_rd;
+     Unix.close pipe_wr;
+     set_sig_info s Signal_event_disabled
+
+(* Drains a pipe by reading until EWOULDBLOCK.
+   Returns true if the pipe was nonempty. *)
+let drain_pipe pipe_rd =
+  let buf = Bytes.create 1 in
+  let rec go status =
+    match Unix.read pipe_rd buf 0 1 with
+    | 1 -> go true
+    | _ -> failwith "uh oh"
+    | exception (Unix.Unix_error (EINTR, _, _)) -> go status
+    | exception (Unix.Unix_error ((EWOULDBLOCK|EAGAIN),_,_)) -> status in
+  go false
+
+let acknowledge_signal s =
+  match get_sig_info s with
+  | Signal_event_disabled ->
+     raise (Invalid_argument ("Signal " ^ string_of_int s ^ " does not have events enabled"))
+  | Signal_event_enabled { pipe_rd; _ } ->
+     if not (drain_pipe pipe_rd) then
+       raise (Invalid_argument ("Signal " ^ string_of_int s ^ " was not pending, so should not have been acknowledged"))
+
+
+
+(* Tracking of already-terminated processes *)
+
+let terminated_processes : (int, Unix.process_status) Hashtbl.t = Hashtbl.create 20
+
+let child_terminated pid =
+  if Hashtbl.mem terminated_processes pid then
+    true
+  else
+    match Unix.waitpid [Unix.WNOHANG] pid with
+    | 0, _ -> false
+    | _, status ->
+       Hashtbl.add terminated_processes pid status;
+       true
+
+let acknowledge_termination pid =
+  match Hashtbl.find terminated_processes pid with
+  | exception Not_found ->
+     raise (Invalid_argument ("Process " ^ string_of_int pid ^ " has not terminated, or has already been acknowledged"))
+  | status ->
+     Hashtbl.remove terminated_processes pid;
+     status
+
+
+(* select implementation *)
+
+type event =
+  | Ev_signal of int
+  | Ev_child_process of int
+  | Ev_read_fd of Unix.file_descr
+  | Ev_write_fd of Unix.file_descr
+  | Ev_urgent_fd of Unix.file_descr
+
+let rec map_app f xs tail =
+  match xs with
+  | [] -> tail
+  | x :: xs -> f x :: map_app f xs tail
+
+let rec retry_on_eintr f =
+  try f ()
+  with Unix.Unix_error (Unix.EINTR, _, _) -> retry_on_eintr f
+
+let select ?(timeout = (-1.0)) events =
+  let rec go timeout read write urgent sigs pids pids_terminated = function
+    | [] ->
+       let events =
+         let read, write, urgent =
+           retry_on_eintr (fun () -> Unix.select read write urgent timeout) in
+         let read_sig_fd, read_other =
+           List.partition (fun fd -> List.mem_assoc fd sigs) read in
+         (* This is O(n^2), but n is the number of active signal handlers
+            (which is never large) *)
+         let read_sigs =
+           List.map (fun fd -> List.assoc fd sigs) read_sig_fd in
+         let read_other, newly_terminated =
+           match pids with
+           | [] -> read_other, []
+           | _ ->
+              let sigchld_fd =
+                match get_sig_info Sys.sigchld with
+                | Signal_event_disabled -> assert false
+                | Signal_event_enabled { pipe_rd; _ } -> pipe_rd in
+              if not (List.mem sigchld_fd read_other) then
+                read_other, []
+              else
+                let read_other = List.filter (fun x -> x <> sigchld_fd) read_other in
+                let b = drain_pipe sigchld_fd in
+                assert b;
+                let terminated = List.filter child_terminated pids in
+                read_other, terminated in
+         map_app (fun x -> Ev_signal x) read_sigs
+         @@ map_app (fun x -> Ev_read_fd x) read_other
+         @@ map_app (fun x -> Ev_write_fd x) write
+         @@ map_app (fun x -> Ev_urgent_fd x) urgent
+         @@ map_app (fun x -> Ev_child_process x) newly_terminated
+         @@ map_app (fun x -> Ev_child_process x) pids_terminated [] in
+       begin match events with
+       | [] when timeout < 0. ->
+          (* This is possible if we got a spurious SIGCHLD:
+             i.e. a process terminated, but it wasn't one we're interested in *)
+          go timeout read write urgent sigs pids pids_terminated [] (* retry *)
+       | ev ->
+          (* BUG: spurious SIGCHLDs can make us return before the timer's expired *)
+          ev
+       end
+    | Ev_read_fd fd :: rest ->
+       go timeout (fd :: read) write urgent sigs pids pids_terminated rest
+    | Ev_write_fd fd :: rest ->
+       go timeout read (fd :: write) urgent sigs pids pids_terminated rest
+    | Ev_urgent_fd fd :: rest ->
+       go timeout read write (fd :: urgent) sigs pids pids_terminated rest
+    | Ev_signal s :: rest ->
+       check_valid_signal s;
+       begin match get_sig_info s with
+       | Signal_event_disabled ->
+          raise (Invalid_argument ("Signal " ^ string_of_int s ^ " must have events enabled before using select"))
+       | Signal_event_enabled { pipe_rd; _ } ->
+          go timeout (pipe_rd :: read) write urgent ((pipe_rd, s) :: sigs) pids pids_terminated rest
+       end
+    | Ev_child_process pid :: rest ->
+       if child_terminated pid then
+         (* This child has already terminated, so select should not block.
+            We still want to do the select, though, so that we report *all* of the
+            events that have occurred, not just this termination. So, we still do
+            a select, but the timeout is zero *)
+         go 0. read write urgent sigs pids (pid :: pids_terminated) rest
+       else
+         (* This child had not already terminated when we tested it, so
+            if it terminates after that point we'll see a SIGCHLD *)
+         let sigchld_rd =
+           match get_sig_info Sys.sigchld with
+           | Signal_event_disabled ->
+              (match make_sig_info () with
+              | Signal_event_disabled -> assert false
+              | Signal_event_enabled {pipe_rd; _} as si ->
+                 set_sig_info Sys.sigchld si;
+                 Sys.set_signal Sys.sigchld (Sys.Signal_handle handle_signal);
+                pipe_rd)
+           | Signal_event_enabled { pipe_rd; _ } -> pipe_rd in
+         go timeout (sigchld_rd :: read) write urgent sigs (pid :: pids) pids_terminated rest in
+  match events with
+  | [] when timeout < 0. ->
+     raise (Invalid_argument "Ev_select.select: nothing to wait for")
+  | events ->
+     go timeout [] [] [] [] [] [] events

--- a/src/ev_select.mli
+++ b/src/ev_select.mli
@@ -1,0 +1,18 @@
+(** Waiting for I/O readiness, process termination and signals *)
+
+type event =
+  | Ev_signal of int
+  | Ev_child_process of int
+  | Ev_read_fd of Unix.file_descr
+  | Ev_write_fd of Unix.file_descr
+  | Ev_urgent_fd of Unix.file_descr
+
+val select : ?timeout:float -> event list -> event list
+
+val enable_signal_event : int -> unit
+val disable_signal_event : int -> unit
+
+val acknowledge_signal : int -> unit
+val acknowledge_termination : int -> Unix.process_status
+
+

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -23,7 +23,7 @@ module Signal = struct
     | Quit -> Sys.sigquit
     | Term -> Sys.sigterm
 
-  let of_int =
+  let _of_int =
     List.map all ~f:(fun t -> to_int t, t)
     |> Int.Map.of_list_reduce ~f:(fun _ t -> t)
     |> Int.Map.find
@@ -31,140 +31,7 @@ module Signal = struct
   let name t = Utils.signal_name (to_int t)
 end
 
-module Thread = struct
-  include Thread
-
-  let block_signals = lazy (
-    let signos = List.map Signal.all ~f:Signal.to_int in
-    ignore (Unix.sigprocmask SIG_BLOCK signos : int list)
-  )
-
-  let create =
-    if Sys.win32 then
-      Thread.create
-    else
-      (* On unix, we make sure to block signals globally before
-         starting a thread so that only the signal watcher thread can
-         receive signals. *)
-      fun f x ->
-        Lazy.force block_signals;
-        Thread.create f x
-end
-
-(** The event queue *)
-module Event : sig
-  type t =
-    | Files_changed
-    | Job_completed of job * Unix.process_status
-    | Signal of Signal.t
-
-  (** Return the next event. File changes event are always flattened
-      and returned first. *)
-  val next : unit -> t
-
-  (** Ignore the ne next file change event about this file. *)
-  val ignore_next_file_change_event : Path.t -> unit
-
-  (** Register the fact that a job was started. *)
-  val register_job_started : unit -> unit
-
-  (** Number of jobs for which the status hasn't been reported yet .*)
-  val pending_jobs : unit -> int
-
-  (** Send an event to the main thread. *)
-  val send_files_changed : Path.t list -> unit
-  val send_job_completed : job -> Unix.process_status -> unit
-  val send_signal : Signal.t -> unit
-end = struct
-  type t =
-    | Files_changed
-    | Job_completed of job * Unix.process_status
-    | Signal of Signal.t
-
-  let jobs_completed = Queue.create ()
-  let files_changed = ref []
-  let signals = ref Signal.Set.empty
-  let mutex = Mutex.create ()
-  let cond = Condition.create ()
-
-  let ignored_files = String.Table.create 64
-  let pending_jobs = ref 0
-
-  let register_job_started () = incr pending_jobs
-
-  let ignore_next_file_change_event path =
-    assert (Path.is_in_source_tree path);
-    String.Table.replace
-      ignored_files
-      ~key:(Path.to_absolute_filename path)
-      ~data:()
-
-  let available () =
-    not (List.is_empty !files_changed
-         && Queue.is_empty jobs_completed
-         && Signal.Set.is_empty !signals)
-
-  let next () =
-    Stats.record ();
-    Mutex.lock mutex;
-    let rec loop () =
-      while not (available ()) do Condition.wait cond mutex done;
-      match Signal.Set.choose !signals with
-      | Some signal ->
-        signals := Signal.Set.remove !signals signal;
-        Signal signal
-      | None ->
-        match !files_changed with
-        | [] ->
-          let (job, status) = Queue.pop jobs_completed in
-          decr pending_jobs;
-          Job_completed (job, status)
-        | fns ->
-          files_changed := [];
-          let only_ignored_files =
-            List.fold_left fns ~init:true ~f:(fun acc fn ->
-              let fn = Path.to_absolute_filename fn in
-              if String.Table.mem ignored_files fn then begin
-                (* only use ignored record once *)
-                String.Table.remove ignored_files fn;
-                acc
-              end else
-                false)
-          in
-          if only_ignored_files then
-            loop ()
-          else
-            Files_changed
-    in
-    let ev = loop () in
-    Mutex.unlock mutex;
-    ev
-
-  let send_files_changed files =
-    Mutex.lock mutex;
-    let avail = available () in
-    files_changed := List.rev_append files !files_changed;
-    if not avail then Condition.signal cond;
-    Mutex.unlock mutex
-
-  let send_job_completed job status =
-    Mutex.lock mutex;
-    let avail = available () in
-    Queue.push (job, status) jobs_completed;
-    if not avail then Condition.signal cond;
-    Mutex.unlock mutex
-
-  let send_signal signal =
-    Mutex.lock mutex;
-    let avail = available () in
-    signals := Signal.Set.add !signals signal;
-    if not avail then Condition.signal cond;
-    Mutex.unlock mutex
-
-  let pending_jobs () = !pending_jobs
-end
-
-let ignore_for_watch = Event.ignore_next_file_change_event
+module Thread = struct end
 
 type status_line_config =
   { message   : string option
@@ -179,10 +46,28 @@ module File_watcher : sig
 
   (** Pid of the external file watcher process *)
   val pid : t -> int
-end = struct
-  type t = int
 
-  let pid t = t
+  (** Events the file watcher is interested in *)
+  val events : t -> Ev_select.event list
+
+  (** Reports the newly-changed file paths, given new events *)
+  val files_changed : t -> Ev_select.event list -> Path.t list
+end = struct
+  let buffer_capacity = 65536
+
+  type buffer =
+    { data : Bytes.t
+    ; mutable size : int
+    }
+
+  type t =
+    { watcher_pid : int
+    ; watcher_fd : Unix.file_descr
+    ; buffer : buffer
+    }
+
+  let pid { watcher_pid; _ } = watcher_pid
+  let events { watcher_fd; _ } = [ Ev_select.Ev_read_fd watcher_fd ]
 
   let command =
     lazy (
@@ -225,14 +110,6 @@ end = struct
            die "@{<error>Error@}: fswatch (or inotifywait) was not found. \
                 One of them needs to be installed for watch mode to work.\n"))
 
-  let buffering_time = 0.5 (* seconds *)
-  let buffer_capacity = 65536
-
-  type buffer =
-    { data : Bytes.t
-    ; mutable size : int
-    }
-
   let read_lines buffer fd =
     let len =
       Unix.read fd buffer.data buffer.size (buffer_capacity - buffer.size)
@@ -258,7 +135,13 @@ end = struct
       ~src:buffer.data ~src_pos:!line_start
       ~dst:buffer.data ~dst_pos:0
       ~len:buffer.size;
-    List.rev !lines
+    List.rev_map !lines ~f:Path.of_string
+
+  let files_changed { watcher_fd ; buffer ; _ } evs =
+    if List.mem (Ev_select.Ev_read_fd watcher_fd) ~set:evs then
+      read_lines buffer watcher_fd
+    else
+      []
 
   let spawn_external_watcher () =
     let prog, args = Lazy.force command in
@@ -275,9 +158,16 @@ end = struct
     (r, pid)
 
   let create () =
-    let files_changed = ref [] in
-    let event_mtx = Mutex.create () in
-    let event_cv = Condition.create () in
+    let watcher_fd, watcher_pid = spawn_external_watcher () in
+    let buffer =
+      { data = Bytes.create buffer_capacity
+      ; size = 0
+      } in
+    { watcher_fd; watcher_pid; buffer }
+
+(*
+
+FIXME
 
     let worker_thread pipe =
       let buffer =
@@ -286,7 +176,7 @@ end = struct
         }
       in
       while true do
-        let lines = List.map (read_lines buffer pipe) ~f:Path.of_string in
+        let lines = read_lines buffer pipe in
         Mutex.lock event_mtx;
         files_changed := List.rev_append lines !files_changed;
         Condition.signal event_cv;
@@ -308,6 +198,8 @@ end = struct
        - after the first event is received, buffer subsequent events
        for [buffering_time]
     *)
+    let buffering_time = 0.5 (* seconds *)
+
     let rec buffer_thread () =
       Mutex.lock event_mtx;
       while List.is_empty !files_changed do
@@ -321,137 +213,78 @@ end = struct
       buffer_thread ()
     in
 
-    let pipe, pid = spawn_external_watcher () in
-
     ignore (Thread.create worker_thread pipe : Thread.t);
     ignore (Thread.create buffer_thread () : Thread.t);
 
     pid
+
+*)
+
 end
 
 module Process_watcher : sig
-  (** Initialize the process watcher thread. *)
-  val init : unit -> unit
-
   (** Register a new running job. *)
-  val register_job : job -> unit
+  val watch_job : job -> unit
 
   (** Send the following signal to all running processes. *)
   val killall : int -> unit
-end = struct
-  let mutex = Mutex.create ()
-  let something_is_running_cv = Condition.create ()
 
+  (** Events the process watcher is interested in *)
+  val events : unit -> Ev_select.event list
+
+  (** Reports the newly-terminated processes, given new events *)
+  val processes_terminated : Ev_select.event list -> (job * Unix.process_status) list
+end = struct
   module Process_table : sig
     val add : job -> unit
-    val remove : pid:int -> Unix.process_status -> unit
-    val running_count : unit -> int
+    val remove : pid:int -> (job * Unix.process_status) option
     val iter : f:(job -> unit) -> unit
+    val map : f:(job -> 'a) -> 'a list
   end = struct
-    type process_state =
-      | Running of job
-      | Zombie of Unix.process_status
-
-    (* Invariant: [!running_count] is equal to the number of
-       [Running _] values in [table]. *)
     let table = Hashtbl.create 128
-    let running_count = ref 0
 
     let add job =
       match Hashtbl.find table job.pid with
       | None ->
-        Hashtbl.add table job.pid (Running job);
-        incr running_count;
-        if !running_count = 1 then Condition.signal something_is_running_cv
-      | Some (Zombie status) ->
-        Hashtbl.remove table job.pid;
-        Event.send_job_completed job status
-      | Some (Running _) ->
+        Hashtbl.add table job.pid job
+      | Some _ ->
         assert false
 
-    let remove ~pid status =
+    let remove ~pid =
       match Hashtbl.find table pid with
       | None ->
-        Hashtbl.add table pid (Zombie status)
-      | Some (Running job) ->
-        decr running_count;
+        None
+      | Some job ->
         Hashtbl.remove table pid;
-        Event.send_job_completed job status
-      | Some (Zombie _) ->
-        assert false
+        Some (job, Ev_select.acknowledge_termination pid)
 
     let iter ~f =
-      Hashtbl.iter table ~f:(fun ~key:_ ~data ->
-        match data with
-        | Running job -> f job
-        | Zombie _ -> ())
+      Hashtbl.iter table ~f:(fun ~key:_ ~data -> f data)
 
-    let running_count () = !running_count
+    let map ~f =
+      Hashtbl.fold table ~init:[] ~f:(fun data acc -> f data :: acc)
   end
 
-  let register_job job =
-    Event.register_job_started ();
-    Mutex.lock mutex;
-    Process_table.add job;
-    Mutex.unlock mutex
+  let watch_job job =
+    Process_table.add job
 
   let killall signal =
-    Mutex.lock mutex;
     Process_table.iter ~f:(fun job ->
       try
         Unix.kill job.pid signal
-      with Unix.Unix_error _ -> ());
-    Mutex.unlock mutex
+      with Unix.Unix_error _ -> ())
 
-  exception Finished of job * Unix.process_status
+  let events () =
+    Process_table.map ~f:(fun job ->
+      Ev_select.Ev_child_process job.pid)
 
-  let wait_nonblocking_win32 () =
-    try
-      Process_table.iter ~f:(fun job ->
-        let pid, status = Unix.waitpid [WNOHANG] job.pid in
-        if pid <> 0 then
-          raise_notrace (Finished (job, status)));
-      false
-    with Finished (job, status) ->
-      (* We need to do the [Unix.waitpid] and remove the process while
-         holding the lock, otherwise the pid might be reused in
-         between. *)
-      Process_table.remove ~pid:job.pid status;
-      true
-
-  let wait_win32 () =
-    while not (wait_nonblocking_win32 ()) do
-      Mutex.unlock mutex;
-      ignore (Unix.select [] [] [] 0.001);
-      Mutex.lock mutex
-    done
-
-  let wait_unix () =
-    Mutex.unlock mutex;
-    let pid, status = Unix.wait () in
-    Mutex.lock mutex;
-    Process_table.remove ~pid status
-
-  let wait =
-    if Sys.win32 then
-      wait_win32
-    else
-      wait_unix
-
-  let run () =
-    Mutex.lock mutex;
-    while true do
-      while Process_table.running_count () = 0 do
-        Condition.wait something_is_running_cv mutex
-      done;
-      wait ()
-    done
-
-  let init = lazy (ignore (Thread.create run () : Thread.t))
-
-  let init () = Lazy.force init
+  let processes_terminated events =
+    List.filter_map events ~f:(function
+      | Ev_select.Ev_child_process pid -> Process_table.remove ~pid
+      | _ -> None)
 end
 
+(*
 module Signal_watcher : sig
   val init : unit -> unit
 end = struct
@@ -508,6 +341,112 @@ end = struct
 
   let init () = Lazy.force init
 end
+*)
+
+(** The event queue *)
+module Event : sig
+  type t =
+    | Files_changed
+    | Job_completed of job * Unix.process_status
+    | Signal of Signal.t
+
+  (** Return the next event. File changes event are always flattened
+      and returned first. *)
+  val next : ?file_watcher:File_watcher.t -> unit -> t
+
+  (** Ignore the ne next file change event about this file. *)
+  val ignore_next_file_change_event : Path.t -> unit
+
+  (** Register a new job *)
+  val register_job : job -> unit
+
+  (** Number of jobs for which the status hasn't been reported yet .*)
+  val pending_jobs : unit -> int
+end = struct
+  type t =
+    | Files_changed
+    | Job_completed of job * Unix.process_status
+    | Signal of Signal.t
+
+  let jobs_completed = Queue.create ()
+  let files_changed = ref []
+  let signals = ref Signal.Set.empty
+
+  let ignored_files = String.Table.create 64
+  let pending_jobs = ref 0
+
+  let register_job job =
+    incr pending_jobs;
+    Process_watcher.watch_job job
+
+  let ignore_next_file_change_event path =
+    assert (Path.is_in_source_tree path);
+    String.Table.replace
+      ignored_files
+      ~key:(Path.to_absolute_filename path)
+      ~data:()
+
+  let await_more_events ?file_watcher () =
+    (* FIXME signals *)
+    let events =
+      Process_watcher.events ()
+      @ (match file_watcher with
+         | None -> []
+         | Some fw -> File_watcher.events fw) in
+    assert (events <> []);
+    let events = Ev_select.select events in
+    assert (events <> []);
+    List.iter (Process_watcher.processes_terminated events) ~f:(fun p ->
+        Queue.push p jobs_completed);
+    (* FIXME signals *)
+    (* FIXME file change debouncing *)
+    begin match file_watcher with
+    | None -> ()
+    | Some fw ->
+       let files = File_watcher.files_changed fw events in
+       files_changed := List.rev_append files !files_changed
+    end
+
+  let next ?file_watcher () =
+    Stats.record ();
+    let rec loop () =
+      match Signal.Set.choose !signals with
+      | Some signal ->
+        signals := Signal.Set.remove !signals signal;
+        Signal signal
+      | None ->
+        match !files_changed with
+        | [] ->
+          if Queue.is_empty jobs_completed then
+            (await_more_events ?file_watcher (); loop ())
+          else
+            let (job, status) = Queue.pop jobs_completed in
+            decr pending_jobs;
+            Job_completed (job, status)
+        | fns ->
+          files_changed := [];
+          let only_ignored_files =
+            List.fold_left fns ~init:true ~f:(fun acc fn ->
+              let fn = Path.to_absolute_filename fn in
+              if String.Table.mem ignored_files fn then begin
+                (* only use ignored record once *)
+                String.Table.remove ignored_files fn;
+                acc
+              end else
+                false)
+          in
+          if only_ignored_files then
+            loop ()
+          else
+            Files_changed
+    in
+    loop ()
+
+  let pending_jobs () = !pending_jobs
+end
+
+
+let ignore_for_watch = Event.ignore_next_file_change_event
 
 type t =
   { log                        : Log.t
@@ -585,7 +524,7 @@ let wait_for_available_job () =
 
 let wait_for_process pid =
   let ivar = Fiber.Ivar.create () in
-  Process_watcher.register_job { pid; ivar };
+  Event.register_job { pid; ivar };
   Fiber.Ivar.read ivar
 
 let rec restart_waiting_for_available_job t =
@@ -637,10 +576,6 @@ let prepare ?(log=Log.no_log) ?(config=Config.default)
       ?(gen_status_line=fun () -> { message = None; show_jobs = false }) () =
   Log.infof log "Workspace root: %s"
     (Path.to_absolute_filename Path.root |> String.maybe_quoted);
-  (* The signal watcher must be initialized first so that signals are
-     blocked in all threads. *)
-  Signal_watcher.init ();
-  Process_watcher.init ();
   let cwd = Sys.getcwd () in
   if cwd <> initial_cwd && not !Clflags.no_print_directory then
     Printf.eprintf "Entering directory '%s'\n%!"

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -16,7 +16,11 @@ module Signal = struct
       let compare = compare
     end)
 
-  let all = [Int; Quit; Term]
+  let all =
+    if Sys.win32 then
+      [Int]
+    else
+      [Int; Quit; Term]
 
   let to_int = function
     | Int -> Sys.sigint

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -322,9 +322,11 @@ end = struct
         if n = 3 then sys_exit 1
     done
 *)
-  let init () =
+  let init = lazy (
     List.iter Signal.all ~f:(fun s ->
-      Ev_select.enable_signal_event (Signal.to_int s))
+      Ev_select.enable_signal_event (Signal.to_int s)))
+
+  let init () = Lazy.force init
 
   let events () =
     List.map Signal.all ~f:(fun s ->


### PR DESCRIPTION
Dune doesn't build on multicore at the moment because (ironically enough) multicore doesn't support stock OCaml's systhreads (although it will eventually).

To fix this, I changed the scheduler to use `Unix.select` to handle process termination, signals and file changed notifications instead of using systhreads. Is this something the dune maintainers would be interested in having upstreamed?

In any case, there are a few more things this patch needs before it can be merged:

  - [ ] file watcher debouncing
  - [ ] windows support
  - [ ] docs for the new `Ev_select` interface
  - [ ] unit tests for the new `Ev_select` interface

(I'm happy to implement these, but I won't bother unless there's interest in merging this patch, so I'm asking for comments now)