### PR TITLE
[configurator] Return pkg-config error to clients of new query API.

### DIFF
--- a/src/configurator/dune
+++ b/src/configurator/dune
@@ -3,5 +3,5 @@
 (library
  (name        configurator)
  (public_name dune.configurator)
- (libraries   stdune ocaml_config dune_lang)
+ (libraries   stdune ocaml_config dune_lang dune_caml dune._result)
  (flags       (:standard -safe-string (:include flags/flags.sexp))))

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -1,3 +1,5 @@
+open! Dune_result
+
 type t
 
 val create
@@ -93,7 +95,20 @@ module Pkg_config : sig
      package may contain a version constraint.  For example
      "gtk+-3.0 >= 3.18".  Returns [None] if [package] is not available  *)
 
-  val query_expr : t -> package:string -> expr:string -> package_conf option
+  val query_expr : t
+    -> package:string
+    -> expr:string
+    -> package_conf option
+  [@@ocaml.deprecated "please use [query_expr_err]"]
+
+  val query_expr_err : t
+    -> package:string
+    -> expr:string
+    -> (package_conf, string) Result.t
+  (** [query_expr_err t ~package ~expr] query pkg-config for the
+     [package]. [expr] may contain a version constraint, for example
+     "gtk+-3.0 >= 3.18". [package] should be just the name of the
+     package. Returns [Error error_msg] if [package] is not available *)
 end with type configurator := t
 
 module Flags : sig

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -36,6 +36,10 @@ let map_error x ~f =
   | Ok _ as res -> res
   | Error x -> Error (f x)
 
+let to_option = function
+  | Ok p -> Some p
+  | Error _ -> None
+
 let errorf fmt =
   Printf.ksprintf (fun x -> Error x) fmt
 

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -23,6 +23,8 @@ val bind : ('a, 'error) t -> f:('a -> ('b, 'error) t) -> ('b, 'error) t
 
 val map_error : ('a, 'error1) t -> f:('error1 -> 'error2) -> ('a, 'error2) t
 
+val to_option : ('a, 'error) t -> 'a option
+
 (** Produce [Error <message>] *)
 val errorf : ('a, unit, string, (_, string) t) format4 -> 'a
 

--- a/test/blackbox-tests/test-cases/pkg-config-quoting/pkg_config.ml
+++ b/test/blackbox-tests/test-cases/pkg-config-quoting/pkg_config.ml
@@ -1,4 +1,8 @@
+(* We'd like to use String.equal but that's OCaml >= 4.03 *)
+let not_flag x = not ("--print-errors" = x)
+
 let () =
   let args = List.tl (Array.to_list Sys.argv) in
+  let args = List.filter not_flag args in
   Format.printf "%a@."
     (Format.pp_print_list Format.pp_print_string) args

--- a/test/blackbox-tests/test-cases/pkg-config-quoting/run.t
+++ b/test/blackbox-tests/test-cases/pkg-config-quoting/run.t
@@ -1,6 +1,6 @@
 These tests show how various pkg-config invocations get qouted:
   $ dune build 2>&1 | awk '/run:.*bin\/pkg-config/{a=1}/stderr/{a=0}a'
-  run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config gtk+-quartz-3.0
+  run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config --print-errors gtk+-quartz-3.0
   -> process exited with code 0
   -> stdout:
    | gtk+-quartz-3.0
@@ -14,7 +14,7 @@ These tests show how various pkg-config invocations get qouted:
   -> stdout:
    | --libs
    | gtk+-quartz-3.0
-  run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config 'gtk+-quartz-3.0 >= 3.18'
+  run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config --print-errors 'gtk+-quartz-3.0 >= 3.18'
   -> process exited with code 0
   -> stdout:
    | gtk+-quartz-3.0 >= 3.18
@@ -28,7 +28,7 @@ These tests show how various pkg-config invocations get qouted:
   -> stdout:
    | --libs
    | gtk+-quartz-3.0 >= 3.18
-  run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config 'gtksourceview-3.0 >= 3.18'
+  run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config --print-errors 'gtksourceview-3.0 >= 3.18'
   -> process exited with code 0
   -> stdout:
    | gtksourceview-3.0 >= 3.18


### PR DESCRIPTION
It is very convenient for configuration tools to be able to provide a
better error message to the user when pkg-config fails.

This was suggested by @garrigue.

We take advantage of the newly [undocumented] API in 1.7.2 to modify
its return type, but this could be a problem. If so, we will have to
introduce yet another function if we want this functionality.