### PR TITLE
Add pform for accessing public cmi's of a library

### DIFF
--- a/src/pform.ml
+++ b/src/pform.ml
@@ -36,6 +36,7 @@ module Macro = struct
     | Lib
     | Libexec
     | Lib_available
+    | Lib_intf
     | Version
     | Read
     | Read_strings
@@ -53,6 +54,7 @@ module Macro = struct
     | Lib -> string "Lib"
     | Libexec -> string "Libexec"
     | Lib_available -> string "Lib_available"
+    | Lib_intf -> string "Lib_intf"
     | Version -> string "Version"
     | Read -> string "Read"
     | Read_strings -> string "Read_strings"
@@ -143,6 +145,7 @@ module Map = struct
       ; "lib", macro Lib
       ; "libexec", macro Libexec
       ; "lib-available", macro Lib_available
+      ; "intf", since ~version:(1, 8) Macro.Lib_intf
       ; "version", macro Version
       ; "read", macro Read
       ; "read-lines", macro Read_lines

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -20,6 +20,7 @@ module Macro : sig
     | Lib
     | Libexec
     | Lib_available
+    | Lib_intf
     | Version
     | Read
     | Read_strings

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -951,6 +951,8 @@ let split_extension t =
     let t, ext = Local.split_extension t in
     (in_source_tree t, ext)
 
+let test_extension t ~ext = extension t = ext
+
 let pp ppf t = Format.pp_print_string ppf (to_string_maybe_quoted t)
 
 let pp_in_source ppf t =

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -159,6 +159,8 @@ val mkdir_p : t -> unit
 val extension : t -> string
 val split_extension : t -> t * string
 
+val test_extension : t -> ext:string -> bool
+
 val pp : Format.formatter -> t -> unit
 val pp_in_source : Format.formatter -> t -> unit
 val pp_debug : Format.formatter -> t -> unit

--- a/src/value.ml
+++ b/src/value.ml
@@ -59,4 +59,6 @@ module L = struct
   let paths = List.map ~f:(fun x -> Path x)
 
   let dirs = List.map ~f:(fun x -> Dir x)
+
+  let of_paths_set set = paths (Path.Set.to_list set)
 end

--- a/src/value.mli
+++ b/src/value.mli
@@ -33,4 +33,6 @@ module L : sig
   val concat : t list -> dir:Path.t -> string
 
   val to_strings : t list -> dir:Path.t -> string list
+
+  val of_paths_set : Path.Set.t -> t list
 end


### PR DESCRIPTION
This PR introduces a simple form to depend on the public cmi's of libraries. It looks as follows:

```
%{intf:<lib name>:public}
```

The `public` suffix is necessary to plan for expanding the syntax for `%{intf:<lib name>:private}` etc.

Now, I would have preferred a name like: `%{lib:<lib_name>:intf:public}` but this does not seem backwards compatible.

Uunfortunately, this PR doesn't cover all use cases yet. It seems like we'd like to be able to access cmi's by:

* By selecting individual modules. I propose to add a form like `%{module:intf:Foo.Bar}`. This form intentionally omits having to specify the library name, because i think that this feature could be generalized to be able to directly build these paths in the command line (like in https://github.com/ocaml/dune/issues/1642).  We could add a lib based form as well that disambiguates as well of course.

* Selecting modules in a directory. This is something that merlin team might need. It would be nice to confirm that first however.

This pform is not perfect, but it should already be enough to replace the hard coded build paths in dune's tests for example.