### PR TITLE
Remove manual globs in favor of the stamps of function

### DIFF
--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -855,7 +855,7 @@ and load_dir_and_get_targets t ~dir =
       | Loading ->
         die "recursive dependency between directories:\n    %s"
           (String.concat ~sep:"\n--> "
-             (List.map t.load_dir_stack ~f:Utils.describe_target))
+             (List.map (dir :: t.load_dir_stack) ~f:Utils.describe_target))
       | Pending { lazy_generators } ->
         collector.stage <- Loading;
         lazy_generators

--- a/src/lib_file_deps.ml
+++ b/src/lib_file_deps.ml
@@ -1,6 +1,4 @@
 open Stdune
-open Dune_file
-open Build_system
 
 module Group = struct
   type t =
@@ -12,68 +10,22 @@ module Group = struct
     | Cmi -> ".cmi"
     | Cmx -> ".cmx"
     | Header -> ".h"
-
-  let of_cm_kind = function
-    | Cm_kind.Cmx -> Cmx
-    | Cmi -> Cmi
-    | Cmo -> Exn.code_error "Lib_file_deps.Group.of_cm_kind: Cmo" []
-
-  module L = struct
-    let to_string l =
-      List.map l ~f:to_string
-      |> List.sort ~compare:String.compare
-      |> String.concat  ~sep:"-and-"
-
-    let alias t ~dir ~name =
-      sprintf "lib-%s%s-all" (Lib_name.to_string name) (to_string t)
-      |> Alias.make ~dir
-
-    let setup_alias t ~dir ~lib ~files =
-      Build_system.Alias.add_deps
-        (alias t ~dir ~name:(Library.best_name lib))
-        files
-
-    let setup_file_deps_group_alias t ~dir ~lib =
-      setup_alias t ~dir ~lib ~files:(
-        List.map t ~f:(fun t ->
-          Alias.stamp_file (alias [t] ~dir ~name:(Library.best_name lib)))
-        |> Path.Set.of_list
-      )
-  end
 end
 
-let setup_file_deps =
-  let cm_kinds = [Cm_kind.Cmx; Cmi] in
-  let groups = List.map ~f:Group.of_cm_kind cm_kinds in
-  fun ~dir ~lib ~modules ->
-    let add_cms ~cm_kind =
-      List.fold_left ~f:(fun acc m ->
-        match Module.cm_public_file m cm_kind with
-        | None -> acc
-        | Some fn -> Path.Set.add acc fn)
-    in
-    List.iter cm_kinds ~f:(fun cm_kind ->
-      let files = add_cms ~cm_kind ~init:Path.Set.empty modules in
-      let groups = [Group.of_cm_kind cm_kind] in
-      Group.L.setup_alias groups ~dir ~lib ~files);
-    Group.L.setup_file_deps_group_alias groups ~dir ~lib;
-    Group.L.setup_alias [Header] ~dir ~lib ~files:(
-      List.map lib.install_c_headers ~f:(fun header ->
-        Path.relative dir (header ^ ".h"))
-      |> Path.Set.of_list)
-
 let file_deps_of_lib (lib : Lib.t) ~groups =
-  if Lib.is_local lib then
-    Alias.stamp_file
-      (Group.L.alias groups ~dir:(Lib.src_dir lib) ~name:(Lib.name lib))
-  else
-    (* suppose that all the files of an external lib are at the same place *)
-    Build_system.stamp_file_for_files_of
-      ~dir:(Obj_dir.public_cmi_dir (Lib.obj_dir lib))
-      ~ext:(Group.L.to_string groups)
+  let obj_dir = Lib.obj_dir lib in
+  List.map groups ~f:(fun (group : Group.t) ->
+    let dir =
+      match group with
+      | Cmi -> Obj_dir.all_cmis_dir obj_dir
+      | Cmx -> Obj_dir.native_dir obj_dir
+      | Header -> Obj_dir.obj_dir obj_dir
+    in
+    let ext = Group.to_string group in
+    Build_system.stamp_file_for_files_of ~dir ~ext)
 
 let file_deps_with_exts =
-  List.rev_map ~f:(fun (lib, groups) -> file_deps_of_lib lib ~groups)
+  List.concat_map ~f:(fun (lib, groups) -> file_deps_of_lib lib ~groups)
 
 let file_deps libs ~groups =
-  List.rev_map libs ~f:(file_deps_of_lib ~groups)
+  List.concat_map libs ~f:(file_deps_of_lib ~groups)

--- a/src/lib_file_deps.mli
+++ b/src/lib_file_deps.mli
@@ -17,10 +17,3 @@ val file_deps
 val file_deps_with_exts
   :  (Lib.t * Group.t list) list
   -> Path.t list
-
-(** Setup alias dependencies for library artifacts grouped by extensions *)
-val setup_file_deps
-  :  dir:Path.t
-  -> lib:Dune_file.Library.t
-  -> modules:Module.t list
-  -> unit

--- a/src/lib_modules.ml
+++ b/src/lib_modules.ml
@@ -200,13 +200,6 @@ let has_private_modules t =
 let public_modules t =
   Module.Name.Map.filter ~f:Module.is_public t.modules
 
-let have_artifacts t =
-  let base =
-    Module.Name.Map.superpose t.modules t.wrapped_compat in
-  match t.alias_module with
-  | None -> base
-  | Some alias_module -> Module.Name_map.add base alias_module
-
 let encode
       { modules
       ; alias_module

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -36,8 +36,6 @@ val version_installed : t -> install_dir:Path.t -> t
 
 val for_compilation : t -> Module.Name_map.t
 
-val have_artifacts : t -> Module.Name_map.t
-
 val for_alias : t -> Module.Name_map.t
 
 val encode : t -> Dune_lang.t list

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -493,11 +493,6 @@ module Gen (P : Install_rules.Params) = struct
       build_stubs lib ~dir ~expander ~requires:requires_compile
         ~dir_contents ~vlib_stubs_o_files;
 
-    Lib_file_deps.setup_file_deps ~lib ~dir
-      ~modules:(Lib_modules.have_artifacts lib_modules
-                |> Module.Name.Map.values
-                |> Vimpl.for_file_deps vimpl);
-
     if not (Library.is_virtual lib) then (
       let wrapped_compat = Lib_modules.wrapped_compat lib_modules in
       setup_build_archives lib ~wrapped_compat ~cctx ~dep_graphs

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -17,6 +17,7 @@ let public_cmi_dir t =
 let dir t = t.dir
 let obj_dir t = t.obj_dir
 let byte_dir t = t.byte_dir
+let all_cmis_dir = byte_dir
 let native_dir t = t.native_dir
 
 let all_obj_dirs t ~(mode : Mode.t) =

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -14,6 +14,9 @@ val native_dir : t -> Path.t
 (** The private compiled byte file directory, and all cmi *)
 val byte_dir : t -> Path.t
 
+(** Alias for [byte_dir] that describes the intention better *)
+val all_cmis_dir:  t -> Path.t
+
 (** The public compiled cmi file directory *)
 val public_cmi_dir: t -> Path.t
 


### PR DESCRIPTION
This PR revives #1622 by following @diml's advice of using `Build_system.stamp_for_files_of`. This is a good intermediate step until we have full glob support

Unfortunately, this creates a circular dependency between the directory loading functions:

```
Recursive dependency between directories:
    bin
--> bin/.main.objs
--> bin/.main.objs/byte
--> bin
```

I'm not able to understand what is the cause of this circularity. So if anyone has an idea, that would be helpful.