### PR TITLE
Improve error message when dune subst fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ unreleased
   this is used in merlin to promote menhir generated files in a
   directory that depends on the version of the compiler (#1890, @diml)
 
+- Improve error message when `dune subst` fails (#1898, fix #1897, @rgrinberg)
+
 1.7.3 (unreleased)
 ------------------
 

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -576,7 +576,7 @@ let make_jbuilder_project ~dir packages =
 let read_name file =
   load file ~f:(fun _lang ->
     fields
-      (let%map name = field_o "name" string
+      (let%map name = field_o "name" (located string)
        and () = junk_everything
        in
        name))

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -91,7 +91,7 @@ end
 val load : dir:Path.t -> files:String.Set.t -> t option
 
 (** Read the [name] file from a dune-project file *)
-val read_name : Path.t -> string option
+val read_name : Path.t -> (Loc.t * string) option
 
 (** "dune-project" *)
 val filename : string

--- a/src/stdune/loc.ml
+++ b/src/stdune/loc.ml
@@ -78,6 +78,8 @@ let of_pos (fname, lnum, cnum, enum) =
   ; stop  = { pos with pos_cnum = enum }
   }
 
+let is_none = equal none
+
 let to_file_colon_line t =
   Printf.sprintf "%s:%d" t.start.pos_fname t.start.pos_lnum
 

--- a/src/stdune/loc.mli
+++ b/src/stdune/loc.mli
@@ -6,6 +6,8 @@ val in_dir : Path.t -> t
 
 val none : t
 
+val is_none : t -> bool
+
 val drop_position : t -> t
 
 val of_lexbuf : Lexing.lexbuf -> t


### PR DESCRIPTION
If the project name doesn't match the opam fail, we improve the error message to
point to the project name.