### PR TITLE
Control+C handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 unreleased
 ----------
 
+- Clean up watch mode polling loop: improves signal handling and error handling
+during polling (#1912, fix #1907, fix #1671, @aalekseyev)
+
+- Change status messages during polling to be one-line, so that the messages are 
+correctly erased by ^K. (#1912, @aalekseyev)
+
 - Add support for `.cxx` extension for C++ stubs (#1831, @rgrinberg)
 
 - Add `DUNE_WORKSPACE` variable. This variable is equivalent to setting

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -472,14 +472,16 @@ let run t =
   let result = ref None in
   EC.apply (fun () -> t) () (fun x -> result := Some x);
   let rec loop () =
-    match !result with
-    | Some x -> x
-    | None ->
-      match List.rev !suspended with
-      | [] -> raise Never
-      | to_run ->
-        suspended := [];
-        K.run_list to_run ();
-        loop ()
+    match List.rev !suspended with
+    | [] ->
+      (match !result with
+       | None -> raise Never
+       | Some x -> x)
+    | to_run ->
+      suspended := [];
+      K.run_list to_run ();
+      loop ()
   in
   loop ()
+
+

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -281,9 +281,9 @@ end with type 'a fiber := 'a t
 (** Wait for one iteration of the scheduler *)
 val yield : unit -> unit t
 
-(** [run t] runs a fiber until it yield a result. If it becomes clear
-    that the execution of the fiber will never terminate, raise
-    [Never]. *)
+(** [run t] runs a fiber until it (and all the fibers it forked) terminate.
+    Returns the result if it's determined in the end, otherwise
+    raises [Never].  *)
 val run : 'a t -> 'a
 
 exception Never

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -661,7 +661,7 @@ end = struct
           Fiber.return Files_changed
         | Signal signal ->
           got_signal t signal;
-          Fiber.return (Got_signal : pump_events_result)
+          Fiber.return Got_signal
       end
     end
 

--- a/src/scheduler.mli
+++ b/src/scheduler.mli
@@ -2,9 +2,7 @@
 
 open! Stdune
 
-(** [go ?log ?config ?gen_status_line fiber] runs the following fiber until it
-    terminates. [gen_status_line] is used to print a status line when [config.display =
-    Progress]. *)
+(** [go ?log ?config fiber] runs the fiber until it terminates. *)
 val go
   :  ?log:Log.t
   -> ?config:Config.t


### PR DESCRIPTION
This PR deals with problematic behavior of dune when it's interrupted with Ctrl+C while running a build in polling mode.
Before this PR, dune would just fail with "assert false" and keep watching, among other weird behaviors.

After this PR, killing with Ctrl+C should just terminate dune quickly.