### PR TITLE
Fix spelling typos

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -73,7 +73,7 @@ the test.
 An example `run.t` file:
 
 ```
-A description of the test. The command running the tests is preceeded by
+A description of the test. The command running the tests is preceded by
 two spaces and a $. The expected output of the command is also indented by
 two spaces and is right below the command (note the absence of a $)
 

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -24,7 +24,7 @@ let man =
             supported and the version is obtained from the output of:|})
   ; `Pre {|  \$ git describe --always --dirty|}
   ; `P {|$(b,dune subst) substitutes the variables that topkg substitutes with
-          the defatult configuration:|}
+          the default configuration:|}
   ; var "NAME" "the name of the project (from the dune-project file)"
   ; var "VERSION" "output of $(b,git describe --always --dirty)"
   ; var "VERSION_NUM" ("same as $(b," ^ literal_version ^

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -41,7 +41,7 @@ source files. They have to be ``.c`` and ``.cpp``. If you have source
 files that that do not follow this extension and you want to build
 them with Dune, you need to rename them first. Alternatively, you can
 use the :ref:`foreign build sandboxing <foreign-sandboxing>` method
-described bellow.
+described below.
 
 Header files
 ------------
@@ -83,7 +83,7 @@ To do that, follow the following procedure:
   - depend on this directory recursively via :ref:`source_tree <source_tree>`
   - invoke the external build system
   - copy the C archive files (``.a``, ``.so``, ...) in main library
-    directory with a specific names (see bellow)
+    directory with a specific names (see below)
 - *attach* the C archive files to an OCaml library via the
   :ref:`self_build_stubs_archive <self_build_stubs_archive>` field
 

--- a/editor-integration/emacs/dune-flymake.el
+++ b/editor-integration/emacs/dune-flymake.el
@@ -53,7 +53,7 @@ characters \\([0-9]+\\)-\\([0-9]+\\): +\\([^\n]*\\)$"
 
 (defun dune-flymake-create-lint-script ()
   "Create the lint script if it does not exist.
-This is nedded as long as https://github.com/ocaml/dune/issues/241
+This is needed as long as https://github.com/ocaml/dune/issues/241
 is not fixed."
   (unless (file-exists-p dune-flymake-program)
     (let ((dir (file-name-directory dune-program))

--- a/plugin/jbuild_plugin.mli
+++ b/plugin/jbuild_plugin.mli
@@ -4,7 +4,7 @@ module V1 : sig
   (** Current build context *)
   val context : string
 
-  (** OCaml version for the current buid context. It might not be the
+  (** OCaml version for the current build context. It might not be the
       same as [Sys.ocaml_version] *)
   val ocaml_version : string
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -1218,9 +1218,9 @@ let evaluate_rule (rule : Internal_rule.t) =
   let action_deps = Dep.Set.union static_action_deps dynamic_action_deps in
   (action, action_deps)
 
-(* Same as the function just bellow, but with less opportunity for
+(* Same as the function just below, but with less opportunity for
    parallelism. We keep this dead code here for documentation purposes
-   as it is eaiser to read the one bellow. The reader only has to
+   as it is easier to read the one below. The reader only has to
    check that both function do the same thing. *)
 let _evaluate_rule_and_wait_for_dependencies rule =
   evaluate_rule rule

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -187,7 +187,7 @@ module Library : sig
       { modules_before_stdlib : Module.Name.Set.t
       (** Modules that the Stdlib module depend on. *)
       ; exit_module : Module.Name.t option
-      (** Modules that's implicitely added by the compiler at the
+      (** Modules that's implicitly added by the compiler at the
           end when linking an executable *)
       ; internal_modules : Glob.t
       (** Module names that are hardcoded in the compiler and so

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -82,7 +82,7 @@ val pp_quoted : Format.formatter -> t -> unit
     must have been prepared with [prepare_formatter]. *)
 val pp_split_strings : Format.formatter -> t -> unit
 
-(** Prepare a formatter for [pp_split_strings]. Additionaly the
+(** Prepare a formatter for [pp_split_strings]. Additionally the
     formatter escape newlines when the tags "makefile-action" or
     "makefile-stuff" are active. *)
 val prepare_formatter : Format.formatter -> unit
@@ -355,7 +355,7 @@ module Decoder : sig
     -> ('a list * 'b option) t
 
   (** What is currently being parsed. The second argument is the atom
-      at the beginnig of the list when inside a [sum ...] or [field
+      at the beginning of the list when inside a [sum ...] or [field
       ...]. *)
   type kind =
     | Values of Loc.t * string option

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -2,7 +2,7 @@
     It has two modes of expansion:
 
     1. Static. In this mode it will only expand variables that do not introduce
-       dependncies
+       dependencies
 
     2. Dynamic. In this mode, the expander will record dependencies that are
        introduced by forms it has failed to expand. Later, these dependenceis

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -16,7 +16,7 @@ module Execution_context : sig
     val run_list : 'a t list -> 'a -> unit
   end
 
-  (* Execute a function returning a fiber, passing any raised excetion
+  (* Execute a function returning a fiber, passing any raised exception
      to the current execution context. [apply] is guaranteed to not
      raise. *)
   val apply : ('a -> 'b t) -> 'a -> 'b t

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -577,7 +577,7 @@ end = struct
               begin match Map.find acc vlib with
               | None ->
                 (* we've already traversed the virtual library because
-                   it must have occured earlier in the closure *)
+                   it must have occurred earlier in the closure *)
                 assert false
               | Some (No_impl _) ->
                 loop (Map.add acc vlib (Impl (lib, stack))) libs

--- a/src/report_error.ml
+++ b/src/report_error.ml
@@ -90,7 +90,7 @@ let exn_printer exn =
   in
   make_printer ~backtrace:true pp
 
-(* Firt return value is [true] if the backtrace was printed *)
+(* First return value is [true] if the backtrace was printed *)
 let report_with_backtrace exn =
   match find_printer exn with
   | Some p -> p

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -319,7 +319,7 @@ let upgrade_opam_file todo fn =
     let ofs =
       List.fold_left substs ~init:0 ~f:(fun ofs (start, stop, repl) ->
         if not (ofs <= start && start <= stop) then
-          Exn.code_error "Invalid text subsitution"
+          Exn.code_error "Invalid text substitution"
             [ "ofs", Sexp.Encoder.int ofs
             ; "start", Sexp.Encoder.int start
             ; "stop", Sexp.Encoder.int stop

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -73,7 +73,7 @@ Test the argument syntax
   - test_ppx_args.pp.ml
   [1]
 
-Test that going throught the -ppx option of the compiler works
+Test that going through the -ppx option of the compiler works
 
   $ dune build --root driver-tests test_ppx_staged.cma
   Entering directory 'driver-tests'

--- a/test/blackbox-tests/test-cases/env-dune-file/run.t
+++ b/test/blackbox-tests/test-cases/env-dune-file/run.t
@@ -3,13 +3,13 @@ env vars set in env should be visible to all subdirs
   Entering directory 'env-subdir'
   PASS
 
-env vars intepreted in various fields, such as flags
+env vars interpreted in various fields, such as flags
   $ dune build --force --root flag-field
   Entering directory 'flag-field'
   var visible from dune: -principal         foo alias default
   DUNE_FOO: -principal
 
-global vars are overriden
+global vars are overridden
   $ DUNE_FOO=blarg dune build --force --root flag-field
   Entering directory 'flag-field'
   var visible from dune: -principal         foo alias default

--- a/test/blackbox-tests/test-cases/pkg-config-quoting/run.t
+++ b/test/blackbox-tests/test-cases/pkg-config-quoting/run.t
@@ -1,4 +1,4 @@
-These tests show how various pkg-config invocations get qouted:
+These tests show how various pkg-config invocations get quoted:
   $ dune build 2>&1 | awk '/run:.*bin\/pkg-config/{a=1}/stderr/{a=0}a'
   run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config --print-errors gtk+-quartz-3.0
   -> process exited with code 0

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -161,7 +161,7 @@ Executable that tries to use two implementations for the same virtual lib
   This cannot work.-> required by executable foo in dune:2
   [1]
 
-Install files for implemenations and virtual libs have all the artifacts:
+Install files for implementations and virtual libs have all the artifacts:
   $ dune build --root install-file
   Entering directory 'install-file'
   lib: [

--- a/test/dune
+++ b/test/dune
@@ -80,7 +80,7 @@ Printf.fprintf (open_out Sys.argv.(2)) \"%g\n%!\" (Sys.time ())
 
 ;; Control the list of public libraries
 ;;
-;; This test is to make sure we don't accidently publicize internal
+;; This test is to make sure we don't accidentally publicize internal
 ;; libraries for which we are not ready to commit to a stable API
 
 (rule

--- a/vendor/cmdliner/src/cmdliner.mli
+++ b/vendor/cmdliner/src/cmdliner.mli
@@ -1014,14 +1014,14 @@ markup language.
    mandatory only in markup directives. Escaping ( is only here for
    your symmetric pleasure. Any other sequence of characters starting
    with a \ is an illegal character sequence.}
-{- Refering to unknown markup directives or variables will generate
+{- Referring to unknown markup directives or variables will generate
    errors on standard error during documentation generation.}}
 
 {2:manual Manual}
 
 Man page sections for a term are printed in the order specified by the
-term manual as given to {!Term.info}. Unless specified explicitely in
-the term's manual the following sections are automaticaly created and
+term manual as given to {!Term.info}. Unless specified explicitly in
+the term's manual the following sections are automatically created and
 populated for you:
 
 {ul
@@ -1051,7 +1051,7 @@ If the created section is:
 {- {{!Manpage.standard_sections}standard}, it
     is inserted at the right place in the order specified
     {{!Manpage.standard_sections}here}, but after a possible non-standard
-    section explicitely specified by the term since the latter get the
+    section explicitly specified by the term since the latter get the
     order number of the last previously specified standard section
     or the order of {!Manpage.s_synopsis} if there is no such section.}
 {-  non-standard, it is inserted before the {!Manpage.s_commands}


### PR DESCRIPTION
Note:
Typos found with https://github.com/codespell-project/codespell