### PR TITLE
quickstart.rst: old configurator -> dune.configurator

### DIFF
--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -201,12 +201,11 @@ Then create a ``config`` subdirectory and write this ``dune`` file:
 
     (executable
      (name discover)
-     (libraries base stdio configurator))
+     (libraries dune.configurator))
 
 as well as this ``discover.ml`` file:
 
 .. code:: ocaml
-
 
     module C = Configurator.V1
 


### PR DESCRIPTION
As pointed out by @samoht and @emillon, the quickstart was still using the old configurator
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>