### PR TITLE
Remove merlin from bootstrap

### DIFF
--- a/src/merlin.boot.ml
+++ b/src/merlin.boot.ml
@@ -1,0 +1,16 @@
+open Stdune
+open Build.O
+
+type t = unit
+
+let make ?requires:_ ?flags:_ ?preprocess:_
+      ?libname:_ ?source_dirs:_ ?objs_dirs () = ()
+
+let add_source_dir x _ = x
+
+let merge_all _ = None
+
+let merlin_exists = Build.arr (fun x -> x)
+
+let add_rules _ ~dir:_ ~more_src_dirs:_ ~expander:_
+      ~dir_kind:_ () = ()

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -163,9 +163,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
        Currently dune doesn't support declaring a dependency only
        on the existence of a file, so we have to use this trick. *)
     SC.add_rule sctx ~dir
-      (Build.path merlin_file
-       >>>
-       Build.create_file (Path.relative dir ".merlin-exists"));
+      (Build.path merlin_file >>> Merlin_exists.create ~dir);
     Path.Set.singleton merlin_file
     |> Build_system.Alias.add_deps (Build_system.Alias.check ~dir);
     SC.add_rule sctx ~dir ~mode:(Promote (Until_clean, None)) (

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -21,7 +21,7 @@ val merge_all : t list -> t option
 
 (** Add rules for generating the .merlin in a directory *)
 val add_rules
-  : Super_context.t
+  :  Super_context.t
   -> dir:Path.t
   -> more_src_dirs:Path.t list
   -> expander:Expander.t

--- a/src/merlin_exists.boot.ml
+++ b/src/merlin_exists.boot.ml
@@ -1,0 +1,4 @@
+open Stdune
+
+let dep ~dir:_ = Build.arr (fun x -> x)
+let create ~dir:_ = Build.arr (fun _ -> Action.Progn [])

--- a/src/merlin_exists.ml
+++ b/src/merlin_exists.ml
@@ -1,0 +1,5 @@
+open Stdune
+
+let path ~dir = Path.relative dir ".merlin-exists"
+let dep ~dir = Build.path (path ~dir)
+let create ~dir = Build.create_file (path ~dir)

--- a/src/merlin_exists.mli
+++ b/src/merlin_exists.mli
@@ -1,0 +1,5 @@
+(** Dependency handling for the .merlin-exists file *)
+open Stdune
+
+val dep : dir:Path.t -> ('a, 'a) Build.t
+val create : dir:Path.t -> ('a, Action.t) Build.t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -432,7 +432,7 @@ module Libs = struct
     in
     let prefix =
       if t.context.merlin then
-        Build.path (Path.relative dir ".merlin-exists")
+        Merlin_exists.dep ~dir
         >>>
         prefix
       else

--- a/src/test_rules.mli
+++ b/src/test_rules.mli
@@ -1,8 +1,11 @@
-val rules :
-  Dune_file.Tests.t ->
-  sctx:Super_context.t ->
-  dir:Stdune.Path.t ->
-  scope:Scope.t ->
-  expander:Expander.t ->
-  dir_contents:Dir_contents.t ->
-  dir_kind:Dune_lang.syntax -> Compilation_context.t * Merlin.t
+open Stdune
+
+val rules
+  :  Dune_file.Tests.t
+  -> sctx:Super_context.t
+  -> dir:Path.t
+  -> scope:Scope.t
+  -> expander:Expander.t
+  -> dir_contents:Dir_contents.t
+  -> dir_kind:Dune_lang.syntax
+  -> Compilation_context.t * Merlin.t


### PR DESCRIPTION
This PR does two things:

* Remove utop from bootstrap
* Remove merlin from bootstrap. To do this, we need an intermediate `Merlin_exists` module that will not add a `.merlin-exists` dependency.

The reason why i'm removing merlin from bootstrap isn't to cut build times, but to stop the bootstrap binary from overwriting the .merlin files generated by the real binary.