### PR TITLE
Cleanup findlib handling

### DIFF
--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -138,6 +138,30 @@ module Config = struct
     |> Env.of_string_map
 end
 
+module Unavailable_reason = struct
+  type t =
+    | Not_found
+    | Hidden of Sub_system_info.t Dune_package.Lib.t
+
+  let to_string = function
+    | Not_found  -> "not found"
+    | Hidden pkg ->
+      sprintf "in %s is hidden (unsatisfied 'exist_if')"
+        (Path.to_string_maybe_quoted (Dune_package.Lib.dir pkg))
+
+  let pp ppf t = Format.pp_print_string ppf (to_string t)
+end
+
+type t =
+  { stdlib_dir : Path.t
+  ; paths      : Path.t list
+  ; builtins   : Meta.Simplified.t Lib_name.Map.t
+  ; packages   : ( Lib_name.t
+                 , ( Sub_system_info.t Dune_package.Lib.t
+                   , Unavailable_reason.t) result
+                 ) Hashtbl.t
+  }
+
 module Package = struct
   type t =
     { meta_file : Path.t
@@ -211,31 +235,54 @@ module Package = struct
       ~version:(version t)
       ~modes
       ~dir:t.dir
+
+  let parse db ~meta_file ~name ~parent_dir ~vars =
+    let pkg_dir = Vars.get vars "directory" Ps.empty in
+    let dir =
+      match pkg_dir with
+      | None | Some "" -> parent_dir
+      | Some pkg_dir ->
+        if pkg_dir.[0] = '+' || pkg_dir.[0] = '^' then
+          Path.relative db.stdlib_dir (String.drop pkg_dir 1)
+        else if Filename.is_relative pkg_dir then
+          Path.relative parent_dir pkg_dir
+        else
+          Path.of_filename_relative_to_initial_cwd pkg_dir
+    in
+    let pkg =
+      { meta_file
+      ; name
+      ; dir
+      ; vars
+      }
+    in
+    let exists_if = Vars.get_words vars "exists_if" Ps.empty in
+    let exists =
+      match exists_if with
+      | _ :: _ ->
+        List.for_all exists_if ~f:(fun fn ->
+          Path.exists (Path.relative dir fn))
+      | [] ->
+        if not (Lib_name.Map.mem db.builtins (Lib_name.root_lib name)) then
+          true
+        else
+          (* The META files for installed packages are sometimes broken,
+             i.e. META files for libraries that were not installed by
+             the compiler are still present:
+
+             https://github.com/ocaml/dune/issues/563
+
+             To workaround this problem, for builtin packages we check
+             that at least one of the archive is present. *)
+          match archives pkg with
+          | { byte = []; native = [] } -> true
+          | { byte; native } -> List.exists (byte @ native) ~f:Path.exists
+    in
+    if exists then
+      Ok pkg
+    else
+      Error pkg
 end
-
-module Unavailable_reason = struct
-  type t =
-    | Not_found
-    | Hidden of Sub_system_info.t Dune_package.Lib.t
-
-  let to_string = function
-    | Not_found  -> "not found"
-    | Hidden pkg ->
-      sprintf "in %s is hidden (unsatisfied 'exist_if')"
-        (Path.to_string_maybe_quoted (Dune_package.Lib.dir pkg))
-
-  let pp ppf t = Format.pp_print_string ppf (to_string t)
-end
-
-type t =
-  { stdlib_dir : Path.t
-  ; paths      : Path.t list
-  ; builtins   : Meta.Simplified.t Lib_name.Map.t
-  ; packages   : ( Lib_name.t
-                 , ( Sub_system_info.t Dune_package.Lib.t
-                   , Unavailable_reason.t) result
-                 ) Hashtbl.t
-  }
 
 let paths t = t.paths
 
@@ -250,111 +297,105 @@ let dummy_package t ~name =
   in
   { Package.
     meta_file = Path.relative dir "META"
-  ; name      = name
-  ; dir       = dir
+  ; name
+  ; dir
   ; vars      = String.Map.empty
   }
   |> Package.to_dune
 
-(* Parse a single package from a META file *)
-let parse_package t ~meta_file ~name ~parent_dir ~vars =
-  let pkg_dir = Vars.get vars "directory" Ps.empty in
-  let dir =
-    match pkg_dir with
-    | None | Some "" -> parent_dir
-    | Some pkg_dir ->
-      if pkg_dir.[0] = '+' || pkg_dir.[0] = '^' then
-        Path.relative t.stdlib_dir (String.drop pkg_dir 1)
-      else if Filename.is_relative pkg_dir then
-        Path.relative parent_dir pkg_dir
-      else
-        Path.of_filename_relative_to_initial_cwd pkg_dir
-  in
-  let pkg =
-    { Package.
-      meta_file
-    ; name
-    ; dir
-    ; vars
+type db = t
+module Meta_source : sig
+  type t = private
+    { dir       : Path.t
+    ; meta_file : Path.t
+    ; meta      : Meta.Simplified.t
     }
-  in
-  let exists_if = Vars.get_words vars "exists_if" Ps.empty in
-  let exists =
-    match exists_if with
-    | _ :: _ ->
-      List.for_all exists_if ~f:(fun fn ->
-        Path.exists (Path.relative dir fn))
-    | [] ->
-      if not (Lib_name.Map.mem t.builtins (Lib_name.root_lib name)) then
-        true
-      else
-        (* The META files for installed packages are sometimes broken,
-           i.e. META files for libraries that were not installed by
-           the compiler are still present:
 
-           https://github.com/ocaml/dune/issues/563
+  val internal : db -> meta:Meta.Simplified.t -> t
 
-           To workaround this problem, for builtin packages we check
-           that at least one of the archive is present. *)
-        match Package.archives pkg with
-        | { byte = []; native = [] } -> true
-        | { byte; native } -> List.exists (byte @ native) ~f:Path.exists
-  in
-  let res =
-    let pkg = Package.to_dune pkg in
-    if exists then
-      Ok pkg
+  val parse_and_acknowledge : t -> db -> unit
+
+  val discover : dir:Path.t -> name:Lib_name.t -> t option
+end = struct
+  type t =
+    { dir       : Path.t
+    ; meta_file : Path.t
+    ; meta      : Meta.Simplified.t
+    }
+
+  let create ~dir ~meta_file ~name =
+    let meta = Meta.load meta_file ~name:(Some name) in
+    { dir
+    ; meta
+    ; meta_file
+    }
+
+  let internal db ~meta =
+    { dir = db.stdlib_dir
+    ; meta_file = Path.of_string "<internal>"
+    ; meta
+    }
+
+  let discover ~dir ~name =
+    let meta_file = Path.relative dir "META" in
+    if Path.exists meta_file then
+      Some (create ~dir ~meta_file ~name)
     else
-      Error (Unavailable_reason.Hidden pkg)
-  in
-  (dir, res)
+      (* Alternative layout *)
+      let open Option.O in
+      let* dir = Path.parent dir in
+      let meta_file = Path.relative dir ("META." ^ (Lib_name.to_string name)) in
+      if Path.exists meta_file then
+        Some (create ~dir ~meta_file ~name)
+      else
+        None
 
-(* Parse all the packages defined in a META file and add them to
-   [t.packages] *)
-let parse_and_acknowledge_meta t ~dir ~meta_file (meta : Meta.Simplified.t) =
-  let rec loop ~dir ~full_name (meta : Meta.Simplified.t) =
-    let vars = String.Map.map meta.vars ~f:Rules.of_meta_rules in
-    let dir, res =
-      parse_package t ~meta_file ~name:full_name ~parent_dir:dir ~vars
+  (* Parse a single package from a META file *)
+  let parse_package t ~meta_file ~name ~parent_dir ~vars =
+    match Package.parse t ~meta_file ~name ~parent_dir ~vars with
+    | Ok pkg ->
+      (pkg.dir, Ok (Package.to_dune pkg))
+    | Error pkg ->
+      (pkg.dir, Error (Unavailable_reason.Hidden (Package.to_dune pkg)))
+
+  (* Parse all the packages defined in a META file and add them to
+     [t.packages] *)
+  let parse_and_acknowledge { dir; meta_file; meta } db =
+    let rec loop ~dir ~full_name (meta : Meta.Simplified.t) =
+      let vars = String.Map.map meta.vars ~f:Rules.of_meta_rules in
+      let dir, res =
+        parse_package db ~meta_file ~name:full_name ~parent_dir:dir ~vars
+      in
+      Hashtbl.add db.packages full_name res;
+      List.iter meta.subs ~f:(fun (meta : Meta.Simplified.t) ->
+        let full_name =
+          match meta.name with
+          | None -> full_name
+          | Some name -> Lib_name.nest full_name name in
+        loop ~dir ~full_name meta)
     in
-    Hashtbl.add t.packages full_name res;
-    List.iter meta.subs ~f:(fun (meta : Meta.Simplified.t) ->
-      let full_name =
-        match meta.name with
-        | None -> full_name
-        | Some name -> Lib_name.nest full_name name in
-      loop ~dir ~full_name meta)
-  in
-  loop ~dir ~full_name:(Option.value_exn meta.name) meta
+    loop ~dir ~full_name:(Option.value_exn meta.name) meta
+end
 
-type findlib =
-  { dir       : Path.t
-  ; meta_file : Path.t
-  ; meta      : Meta.Simplified.t
-  }
+module Discovered_package = struct
+  type t =
+    | Dune of Sub_system_info.t Dune_package.t
+    | Findlib of Meta_source.t
+end
 
-type pkg =
-  | Dune of Sub_system_info.t Dune_package.t
-  | Findlib of findlib
-
-(* Search for a <package>/META file in the findlib search path, parse
-   it and add its contents to [t.packages] *)
-let find_and_acknowledge_meta t ~fq_name =
+(* Search for a <package>/{META,dune-package} file in the findlib search path,
+   parse it and add its contents to [t.packages] *)
+let find_and_acknowledge_package t ~fq_name =
   let root_name = Lib_name.root_lib fq_name in
-  let rec loop dirs : pkg option =
+  let rec loop dirs : Discovered_package.t option =
     match dirs with
     | [] ->
       Lib_name.Map.find t.builtins root_name
       |> Option.map ~f:(fun meta ->
-        Findlib
-          { dir = t.stdlib_dir
-          ; meta_file = Path.of_string "<internal>"
-          ; meta
-          })
+        Discovered_package.Findlib (Meta_source.internal t ~meta))
     | dir :: dirs ->
-      let sub_dir = Path.relative dir (Lib_name.to_string root_name) in
-      let dune = Path.relative sub_dir "dune-package" in
-      let meta_file = Path.relative sub_dir "META" in
+      let dir = Path.relative dir (Lib_name.to_string root_name) in
+      let dune = Path.relative dir "dune-package" in
       match
         (if Path.exists dune then
            Dune_package.Or_meta.load dune
@@ -363,24 +404,16 @@ let find_and_acknowledge_meta t ~fq_name =
       with
       | Dune_package p -> Some (Dune p)
       | Use_meta ->
-        if Path.exists meta_file then
-          let meta = Meta.load meta_file ~name:(Some root_name) in
-          Some (Findlib {dir = sub_dir; meta; meta_file})
-        else
-          (* Alternative layout *)
-          let meta_file =
-            Path.relative dir ("META." ^ (Lib_name.to_string root_name)) in
-          if Path.exists meta_file then
-            let meta = Meta.load meta_file ~name:(Some root_name) in
-            Some (Findlib {dir; meta_file; meta})
-          else
-            loop dirs
+        begin match Meta_source.discover ~dir ~name:root_name with
+        | None -> loop dirs
+        | Some meta_source -> Some (Findlib meta_source)
+        end
   in
   match loop t.paths with
   | None ->
     Hashtbl.add t.packages root_name (Error Not_found)
-  | Some (Findlib { meta ; meta_file ; dir }) ->
-    parse_and_acknowledge_meta t meta ~meta_file ~dir
+  | Some (Findlib findlib_package) ->
+    Meta_source.parse_and_acknowledge findlib_package t
   | Some (Dune pkg) ->
     List.iter pkg.libs ~f:(fun lib ->
       Hashtbl.add t.packages (Dune_package.Lib.name lib) (Ok lib))
@@ -389,7 +422,7 @@ let find t name =
   match Hashtbl.find t.packages name with
   | Some x -> x
   | None ->
-    find_and_acknowledge_meta t ~fq_name:name;
+    find_and_acknowledge_package t ~fq_name:name;
     match Hashtbl.find t.packages name with
     | Some x -> x
     | None ->
@@ -402,8 +435,7 @@ let available t name = Result.is_ok (find t name)
 let root_packages t =
   let pkgs =
     List.concat_map t.paths ~f:(fun dir ->
-      Sys.readdir (Path.to_string dir)
-      |> Array.to_list
+      Path.readdir_unsorted dir
       |> List.filter_map ~f:(fun name ->
         if Path.exists (Path.relative dir (name ^ "/META")) then
           Some (Lib_name.of_string_exn ~loc:None name)
@@ -411,12 +443,12 @@ let root_packages t =
           None))
     |> Lib_name.Set.of_list
   in
-  Lib_name.Set.union pkgs
-    (Lib_name.Set.of_list (Lib_name.Map.keys t.builtins))
+  let builtins = Lib_name.Set.of_list (Lib_name.Map.keys t.builtins) in
+  Lib_name.Set.union pkgs builtins
 
 let load_all_packages t =
   Lib_name.Set.iter (root_packages t) ~f:(fun pkg ->
-    find_and_acknowledge_meta t ~fq_name:pkg)
+    find_and_acknowledge_package t ~fq_name:pkg)
 
 let all_packages t =
   load_all_packages t;

--- a/src/stdune/dune
+++ b/src/stdune/dune
@@ -2,4 +2,5 @@
  (name stdune)
  (public_name dune._stdune)
  (synopsis "[Internal] Standard library of Dune")
+ (preprocess future_syntax)
  (libraries dune_caml dune_result unix))

--- a/src/stdune/option.ml
+++ b/src/stdune/option.ml
@@ -12,6 +12,8 @@ module O = struct
     match t with
     | None   -> None
     | Some a -> f a
+
+  let (let*) = (>>=)
 end
 
 let map  t ~f = O.(>>|) t f

--- a/src/stdune/option.mli
+++ b/src/stdune/option.mli
@@ -7,6 +7,8 @@ type 'a t = 'a option =
 module O : sig
   val (>>|) : 'a t -> ('a -> 'b  ) -> 'b t
   val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+
+  val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
 end
 
 val map  : 'a t -> f:('a -> 'b  ) -> 'b t


### PR DESCRIPTION
* Add a private Meta_source sub module that abstracts details such as META
  naming schemes. This makes a few helper functions private.

* Remove names specific to findlib. Some of these functions read dune-package
  files as well.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>