### PR TITLE
Introduce explicit universe dependency

### DIFF
--- a/src/build.ml
+++ b/src/build.ml
@@ -30,6 +30,7 @@ module Repr = struct
     | Catch : ('a, 'b) t * (exn -> 'b) -> ('a, 'b) t
     | Lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
     | Env_var : string -> ('a, 'a) t
+    | Universe : ('a, 'a) t
 
   and 'a memo =
     { name          : string
@@ -122,7 +123,7 @@ let vpath vp = Vpath vp
 let dyn_paths t = Dyn_paths (t >>^ Path.Set.of_list)
 let dyn_path_set t = Dyn_paths t
 let paths_for_rule ps = Paths_for_rule ps
-
+let universe = Universe
 let env_var s = Env_var s
 
 let catch t ~on_error = Catch (t, on_error)

--- a/src/build.mli
+++ b/src/build.mli
@@ -59,6 +59,8 @@ val lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
     build arrow. *)
 val path  : Path.t -> ('a, 'a) t
 
+val universe : ('a, 'a) t
+
 val paths : Path.t list -> ('a, 'a) t
 val path_set : Path.Set.t -> ('a, 'a) t
 
@@ -210,6 +212,7 @@ module Repr : sig
     | Catch : ('a, 'b) t * (exn -> 'b) -> ('a, 'b) t
     | Lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
     | Env_var : string -> ('a, 'a) t
+    | Universe : ('a, 'a) t
 
   and 'a memo =
     { name          : string

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -114,6 +114,7 @@ let static_deps t ~all_targets ~file_tree =
     | Lazy_no_targets t -> loop (Lazy.force t) acc false
     | Env_var var ->
       Static_deps.add_action_env_var acc var
+    | Universe -> Static_deps.add_action_dep acc Dep.universe
   in
   loop (Build.repr t) Static_deps.empty true
 
@@ -143,6 +144,7 @@ let lib_deps =
       | Memo m -> loop m.t acc
       | Catch (t, _) -> loop t acc
       | Lazy_no_targets t -> loop (Lazy.force t) acc
+      | Universe -> acc
       | Env_var _ -> acc
   in
   fun t -> loop (Build.repr t) Lib_name.Map.empty
@@ -187,6 +189,7 @@ let targets =
     | Memo m -> loop m.t acc
     | Catch (t, _) -> loop t acc
     | Lazy_no_targets _ -> acc
+    | Universe -> acc
     | Env_var _ -> acc
   in
   fun t -> loop (Build.repr t) []

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -195,9 +195,6 @@ val do_build
 
 (** {2 Other queries} *)
 
-(** File for the [(universe)] dependency. *)
-val universe_file : Path.t
-
 val is_target : Path.t -> bool
 
 (** Return all the library dependencies (as written by the user)

--- a/src/dep.ml
+++ b/src/dep.ml
@@ -4,21 +4,28 @@ module T = struct
   type t =
     | Env of Env.Var.t
     | File of Path.t
+    | Universe
 
   let env e = Env e
   let file f = File f
+  let universe = Universe
 
   let compare x y =
     match x, y with
     | Env x, Env y -> Env.Var.compare x y
-    | Env _, File _ -> Ordering.Lt
+    | Env _, File _
+    | Env _, Universe -> Ordering.Lt
     | File x, File y -> Path.compare x y
     | File _, Env _ -> Ordering.Gt
+    | File _, Universe -> Ordering.Lt
+    | Universe, Universe -> Ordering.Eq
+    | Universe, (Env _ | File _) -> Gt
 
   let unset = lazy (Digest.string "unset")
 
   let trace t ~env =
     match t with
+    | Universe -> ("universe", Digest.string "universe")
     | File fn ->
       (Path.to_string fn, Utils.Cached_digest.file fn)
     | Env var ->
@@ -33,12 +40,14 @@ module T = struct
   let pp fmt = function
     | Env e -> Format.fprintf fmt "Env %S" e
     | File f -> Format.fprintf fmt "File %a" Path.pp f
+    | Universe -> Format.fprintf fmt "Universe"
 
   let encode t =
     let open Dune_lang.Encoder in
     match t with
     | Env e -> pair string string ("Env", e)
     | File f -> pair string Path_dune_lang.encode ("File", f)
+    | Universe -> string "Universe"
 end
 
 include T
@@ -46,7 +55,9 @@ include T
 module Set = struct
   include Set.Make(T)
 
-  let trace t ~env = List.map ~f:(trace ~env) (to_list t)
+  let has_universe t = mem t Universe
+
+  let trace t ~env = List.map (to_list t) ~f:(trace ~env)
 
   let pp fmt (t : t) =
     Format.fprintf fmt "Deps %a" (Fmt.list pp) (to_list t)
@@ -60,6 +71,7 @@ module Set = struct
     to_list t
     |> List.filter_map ~f:(function
       | File f -> Some f
+      | Universe
       | Env _ -> None)
 
   let paths t = Path.Set.of_list (file_list t)
@@ -70,5 +82,6 @@ module Set = struct
     fold t ~init:Path.Set.empty ~f:(fun f acc ->
       match f with
       | File f -> Path.Set.add acc (Path.parent_exn f)
+      | Universe
       | Env _ -> acc)
 end

--- a/src/dep.mli
+++ b/src/dep.mli
@@ -4,6 +4,7 @@ type t
 
 val file : Path.t -> t
 val env : Env.Var.t -> t
+val universe : t
 
 val compare : t -> t -> Ordering.t
 
@@ -12,11 +13,13 @@ val pp : t Fmt.t
 module Set : sig
   include Set.S with type elt = t
 
+  val has_universe : t -> bool
+
   val paths : t -> Path.Set.t
 
   val encode : t -> Dune_lang.t
 
-  val trace : t -> env:Env.t -> (string * Stdune.Digest.t) list
+  val trace : t -> env:Env.t -> (string * Digest.t) list
 
   val add_paths : t -> Path.Set.t -> t
 

--- a/src/static_deps.ml
+++ b/src/static_deps.ml
@@ -30,6 +30,11 @@ let add_rule_path t fn =
     rule_deps = Dep.Set.add t.rule_deps (Dep.file fn)
   }
 
+let add_action_dep t dep =
+  { t with
+    action_deps = Dep.Set.add t.action_deps dep
+  }
+
 let add_action_paths t fns =
   { t with
     action_deps = Dep.Set.add_paths t.action_deps fns

--- a/src/static_deps.mli
+++ b/src/static_deps.mli
@@ -27,6 +27,9 @@ val add_action_paths : t -> Path.Set.t -> t
 (** Add an environment variable as an action dep. *)
 val add_action_env_var : t -> string -> t
 
+(** Add a dependency to action deps. *)
+val add_action_dep : t -> Dep.t -> t
+
 (** {1} Deconstructors *)
 
 (** Return the rule deps. *)

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -482,7 +482,7 @@ module Deps = struct
       Alias.dep (Alias.package_install ~context:t.context ~pkg)
       >>^ fun () -> []
     | Universe ->
-      Build.path Build_system.universe_file
+      Build.universe
       >>^ fun () -> []
     | Env_var var_sw ->
       let var = Expander.expand_str expander var_sw in


### PR DESCRIPTION
Fix #1931

One thing that is now possible is to omit calculating the entire digest when the `Universe` dependency pops up. Unfortunately, we still need the digest for the sandbox dir. So we'd need an alternative mechanism for generating it.