### PR TITLE
Odoc Memoization

### DIFF
--- a/src/lib.ml
+++ b/src/lib.ml
@@ -212,6 +212,8 @@ and resolve_result =
 
 type lib = t
 
+let to_dyn t = Lib_name.to_dyn t.name
+
 let not_available ~loc reason fmt =
   Errors.kerrf fmt ~f:(fun s ->
     Errors.fail loc "%s %a" s
@@ -274,6 +276,8 @@ let package t =
     None
 
 let to_id t : Id.t = t.unique_id
+
+let equal l1 l2 = Id.equal (to_id l1) (to_id l2)
 
 module Set = Set.Make(
 struct

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -126,6 +126,8 @@ module Id : sig
     ; name      : Lib_name.t
     }
 
+  val hash : t -> int
+
   val compare : t -> t -> Ordering.t
 
   include Comparable.OPS with type t := t
@@ -157,6 +159,8 @@ end = struct
       let n = !next in
       next := n + 1;
       n
+
+  let hash t = t.unique_id
 
   let make ~path ~name =
     { unique_id = gen_unique_id ()
@@ -278,6 +282,7 @@ let package t =
 let to_id t : Id.t = t.unique_id
 
 let equal l1 l2 = Id.equal (to_id l1) (to_id l2)
+let hash t = Id.hash (to_id t)
 
 module Set = Set.Make(
 struct

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -58,6 +58,7 @@ val status : t -> Lib_info.Status.t
 val package : t -> Package.Name.t option
 
 val equal : t -> t -> bool
+val hash : t -> int
 
 (** Operations on list of libraries *)
 module L : sig

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -6,6 +6,8 @@ open Import
 (** Representation of a library *)
 type t
 
+val to_dyn : t -> Dyn.t
+
 (** For libraries defined in the workspace, this is the [public_name] if
     present or the [name] if not. *)
 val name : t -> Lib_name.t
@@ -54,6 +56,8 @@ module Map : Map.S with type key = t
 val status : t -> Lib_info.Status.t
 
 val package : t -> Package.Name.t option
+
+val equal : t -> t -> bool
 
 (** Operations on list of libraries *)
 module L : sig

--- a/src/lib_name.ml
+++ b/src/lib_name.ml
@@ -94,6 +94,8 @@ let to_local = Local.of_string
 
 let to_sexp t = Sexp.Atom t
 
+let to_dyn t = Dyn.String t
+
 let to_string t = t
 
 let of_string_exn ~loc:_ s = s

--- a/src/lib_name.mli
+++ b/src/lib_name.mli
@@ -58,3 +58,5 @@ end
 val to_sexp : t Sexp.Encoder.t
 
 val nest : t -> t -> t
+
+val to_dyn : t -> Dyn.t

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -335,7 +335,8 @@ module Gen (S : sig val sctx : SC.t end) = struct
         Package.Name.equal p1 p2
         && List.equal Lib.equal l1 l2
 
-      let hash = Hashtbl.hash
+      let hash (p, ls) =
+        Hashtbl.hash (Package.Name.hash p, List.hash Lib.hash ls)
 
       let to_sexp (package, libs) =
         let open Dyn in
@@ -489,7 +490,8 @@ module Gen (S : sig val sctx : SC.t end) = struct
     let module Input = struct
       type t = Package.Name.t * Path.t list
 
-      let hash = Hashtbl.hash
+      let hash (p, ps) =
+        Hashtbl.hash (Package.Name.hash p, List.hash Path.hash ps)
 
       let equal (x1, y1) (x2, y2) =
         Package.Name.equal x1 x2 && List.equal Path.equal y1 y2

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -60,8 +60,8 @@ module Gen (S : sig val sctx : SC.t end) = struct
         | Lib lib -> pkg_or_lnu lib
       )
 
-    let gen_mld_dir (pkg : Package.t) =
-      root ++ "_mlds" ++ (Package.Name.to_string pkg.name)
+    let gen_mld_dir pkg =
+      root ++ "_mlds" ++ (Package.Name.to_string pkg)
   end
 
   module Dep = struct
@@ -404,8 +404,8 @@ module Gen (S : sig val sctx : SC.t end) = struct
     |> Dir_contents.modules_of_library ~name:(Lib.name lib)
     |> Lib_modules.entry_modules
 
-  let entry_modules ~(pkg : Package.t) =
-    libs_of_pkg ~pkg:pkg.name
+  let entry_modules ~pkg =
+    libs_of_pkg ~pkg
     |> Lib.Set.to_list
     |> List.filter_map ~f:(fun l ->
       if Lib.is_local l then (
@@ -415,10 +415,10 @@ module Gen (S : sig val sctx : SC.t end) = struct
       ))
     |> Lib.Map.of_list_exn
 
-  let default_index ~(pkg : Package.t) entry_modules =
+  let default_index ~pkg entry_modules =
     let b = Buffer.create 512 in
     Printf.bprintf b "{0 %s index}\n"
-      (Package.Name.to_string pkg.name);
+      (Package.Name.to_string pkg);
     Lib.Map.to_list entry_modules
     |> List.sort ~compare:(fun (x, _) (y, _) ->
       Lib_name.compare (Lib.name x) (Lib.name y))
@@ -452,28 +452,59 @@ module Gen (S : sig val sctx : SC.t end) = struct
     | Ok m -> m
     | Error (_, p1, p2) ->
       die "Package %s has two mld's with the same basename %s, %s"
-        (Package.Name.to_string pkg.Package.name)
+        (Package.Name.to_string pkg)
         (Path.to_string_maybe_quoted p1)
         (Path.to_string_maybe_quoted p2)
 
+  let setup_package_odoc_rules_def =
+    let module Input = struct
+      type t = Package.Name.t * Path.t list
+
+      let hash = Hashtbl.hash
+
+      let equal (x1, y1) (x2, y2) =
+        Package.Name.equal x1 x2 && List.equal Path.equal y1 y2
+
+      let to_sexp (name, paths) =
+        Dyn.Tuple
+          [ Package.Name.to_dyn name
+          ; Dyn.List (List.map ~f:Path.to_dyn paths)
+          ]
+        |> Dyn.to_sexp
+    end
+    in
+    Memo.create "setup-package-odoc-rules"
+      ~output:(Allow_cutoff (module Unit))
+      ~doc:"setup odoc package rules"
+      ~input:(module Input)
+      ~visibility:Hidden
+      Sync
+      None
+
+  let () =
+    let setup_package_odoc_rules (pkg, mlds) =
+      let mlds = check_mlds_no_dupes ~pkg ~mlds in
+      let mlds =
+        if String.Map.mem mlds "index" then
+          mlds
+        else
+          let entry_modules = entry_modules ~pkg in
+          let gen_mld = Paths.gen_mld_dir pkg ++ "index.mld" in
+          add_rule (Build.write_file gen_mld (default_index ~pkg entry_modules));
+          String.Map.add mlds "index" gen_mld in
+      let odocs = List.map (String.Map.values mlds) ~f:(fun mld ->
+        compile_mld
+          (Mld.create mld)
+          ~pkg
+          ~doc_dir:(Paths.odocs (Pkg pkg))
+          ~includes:(Build.arr (fun _ -> Arg_spec.As []))
+      ) in
+      Dep.setup_deps (Pkg pkg) (Path.Set.of_list odocs)
+    in
+    Memo.set_impl setup_package_odoc_rules_def setup_package_odoc_rules
+
   let setup_package_odoc_rules ~pkg ~mlds =
-    let mlds = check_mlds_no_dupes ~pkg ~mlds in
-    let mlds =
-      if String.Map.mem mlds "index" then
-        mlds
-      else
-        let entry_modules = entry_modules ~pkg in
-        let gen_mld = Paths.gen_mld_dir pkg ++ "index.mld" in
-        add_rule (Build.write_file gen_mld (default_index ~pkg entry_modules));
-        String.Map.add mlds "index" gen_mld in
-    let odocs = List.map (String.Map.values mlds) ~f:(fun mld ->
-      compile_mld
-        (Mld.create mld)
-        ~pkg:pkg.name
-        ~doc_dir:(Paths.odocs (Pkg pkg.name))
-        ~includes:(Build.arr (fun _ -> Arg_spec.As []))
-    ) in
-    Dep.setup_deps (Pkg pkg.name) (Path.Set.of_list odocs)
+    Memo.exec setup_package_odoc_rules_def (pkg, mlds)
 
   let init () =
     let mlds_by_package =
@@ -495,15 +526,12 @@ module Gen (S : sig val sctx : SC.t end) = struct
     in
     SC.packages sctx
     |> Package.Name.Map.iter ~f:(fun (pkg : Package.t) ->
-      let rules = lazy (
-        setup_package_odoc_rules
-          ~pkg
-          ~mlds:(mlds_by_package pkg)
-      ) in
       List.iter [ Paths.odocs (Pkg pkg.name)
-                ; Paths.gen_mld_dir pkg ]
+                ; Paths.gen_mld_dir pkg.name ]
         ~f:(fun dir ->
-          Build_system.on_load_dir ~dir ~f:(fun () -> Lazy.force rules));
+          Build_system.on_load_dir ~dir ~f:(fun () ->
+            setup_package_odoc_rules ~pkg:pkg.name ~mlds:(mlds_by_package pkg)
+          ));
       (* setup @doc to build the correct html for the package *)
       setup_package_aliases pkg;
     );

--- a/src/stdune/comparable.ml
+++ b/src/stdune/comparable.ml
@@ -5,6 +5,7 @@ end
 
 module type OPS = sig
   type t
+  val equal : t -> t -> bool
   val (=) : t -> t -> bool
   val (>=) : t -> t -> bool
   val (>) : t -> t -> bool
@@ -19,6 +20,8 @@ module Operators (X : S) = struct
     match X.compare a b with
     | Eq -> true
     | Gt | Lt -> false
+
+  let equal = (=)
 
   let (>=) a b =
     match X.compare a b with

--- a/src/stdune/comparable.mli
+++ b/src/stdune/comparable.mli
@@ -5,6 +5,7 @@ end
 
 module type OPS = sig
   type t
+  val equal : t -> t -> bool
   val (=) : t -> t -> bool
   val (>=) : t -> t -> bool
   val (>) : t -> t -> bool

--- a/src/stdune/interned.ml
+++ b/src/stdune/interned.ml
@@ -1,5 +1,6 @@
 module type S = sig
   type t
+  val hash : t -> int
   val equal : t -> t -> bool
   val compare : t -> t -> Ordering.t
   val to_dyn : t -> Dyn.t
@@ -90,6 +91,7 @@ module Make(R : Settings)() = struct
   let get s = Hashtbl.find ids s
 
   let to_string t = Table.get names t
+  let hash t = String.hash (to_string t)
   let to_dyn t = Dyn.String (to_string t)
 
   let all () = List.init !next ~f:(fun t -> t)
@@ -125,6 +127,7 @@ module No_interning(R : Settings)() = struct
   type t = string
 
   let compare = String.compare
+  let hash = String.hash
   let equal = String.equal
   let make s = s
   let to_string s = s

--- a/src/stdune/interned.mli
+++ b/src/stdune/interned.mli
@@ -2,7 +2,9 @@
 
 module type S = sig
   type t
+  val equal : t -> t -> bool
   val compare : t -> t -> Ordering.t
+  val to_dyn : t -> Dyn.t
   val to_string : t -> string
   val pp : t Fmt.t
 

--- a/src/stdune/interned.mli
+++ b/src/stdune/interned.mli
@@ -2,6 +2,7 @@
 
 module type S = sig
   type t
+  val hash : t -> int
   val equal : t -> t -> bool
   val compare : t -> t -> Ordering.t
   val to_dyn : t -> Dyn.t

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -154,3 +154,5 @@ let rec equal eq xs ys =
   | [], [] -> true
   | x :: xs, y :: ys -> eq x y && equal eq xs ys
   | _, _ -> false
+
+let hash f xs = Dune_caml.Hashtbl.hash (map ~f xs)

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -148,3 +148,9 @@ let init =
 let hd_opt = function
   | [] -> None
   | x :: _ -> Some x
+
+let rec equal eq xs ys =
+  match xs, ys with
+  | [], [] -> true
+  | x :: xs, y :: ys -> eq x y && equal eq xs ys
+  | _, _ -> false

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -55,3 +55,5 @@ val physically_equal : 'a t -> 'a t -> bool
 val init : int -> f:(int -> 'a) -> 'a list
 
 val hd_opt : 'a t -> 'a option
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -57,3 +57,5 @@ val init : int -> f:(int -> 'a) -> 'a list
 val hd_opt : 'a t -> 'a option
 
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val hash : ('a -> int) -> 'a list -> int


### PR DESCRIPTION
I've memoized a couple of functions in odoc that were previously memoized "manually" using a hash table.

I've refrained removing the on_load_dir yet, because I'm a little concerned with the use of a functor in this module. Should we be removing this functor as it's bloating the scope accessible to the memoized functions.