### PR TITLE
Explicit js mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,8 +15,7 @@
   is done to prevent the accidental collision with library dependencies of the
   executable. (#2364, fixes #2292, @rgrinberg)
 
-- New compilation mode `js` for libraries and modules in order to explicitly
-  enable Javascript targets. (#1941, @nojb)
+- Enable `(explicit_js_mode)` by default. (#1941, @nojb)
 
 1.11.0 (unreleased)
 -------------------
@@ -110,6 +109,10 @@
 - Add a new `inline_tests` field in the env stanza to control inline_tests
   framework with a variable (#2313, @mlasson, original idea by @diml, review
   by @rgrinberg).
+
+- New binary kind `js` for executables in order to explicitly enable Javascript
+  targets, and a switch `(explicit_js_mode)` to require this mode in order to
+  declare JS targets corresponding to executables. (#1941, @nojb)
 
 1.10.0 (04/06/2019)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
   is done to prevent the accidental collision with library dependencies of the
   executable. (#2364, fixes #2292, @rgrinberg)
 
+- New compilation mode `js` for libraries and modules in order to explicitly
+  enable Javascript targets. (#1941, @nojb)
+
 1.11.0 (unreleased)
 -------------------
 

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -268,6 +268,24 @@ Starting from dune 2.0, dune mangles compilation units of executables by
 default. However, this can still be turned off using ``(wrapped_executables
 false)``
 
+Explicit JS mode
+================
+
+By default, Javascript targets are defined for every bytecode executable that
+dune knows about. This is not very precise and does not interact well with the
+``@all`` alias (eg, the ``@all`` alias will try to build JS targets
+corresponding to every `test` stanza). In order to better control the
+compilation of JS targets, this behaviour can be turned off by using
+``(explicit_js_mode)`` in the ``dune-project`` file.
+
+When explicit JS mode is enabled, an explicit `js` mode needs to be added to the
+``(modes ...)`` field of executables in order to trigger JS
+compilation. Explicit JS targets declared like this will be attached to the
+``@all`` alias.
+
+Starting from dune 2.0 this new behaviour will be the default and JS compilation
+of binaries will need to be explicitly declared.
+
 .. _dialects-main:
 
 Dialects

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -268,13 +268,15 @@ Starting from dune 2.0, dune mangles compilation units of executables by
 default. However, this can still be turned off using ``(wrapped_executables
 false)``
 
+.. _explicit-js-mode:
+
 Explicit JS mode
 ================
 
 By default, Javascript targets are defined for every bytecode executable that
 dune knows about. This is not very precise and does not interact well with the
 ``@all`` alias (eg, the ``@all`` alias will try to build JS targets
-corresponding to every `test` stanza). In order to better control the
+corresponding to every ``test`` stanza). In order to better control the
 compilation of JS targets, this behaviour can be turned off by using
 ``(explicit_js_mode)`` in the ``dune-project`` file.
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -342,7 +342,7 @@ compilation is not available.
   loaded into an application. This mode can be used to write a plugin
   in OCaml for a non-OCaml application.
 - ``js`` for producing Javascript from bytecode executables, see
-  `Explicit JS mode`_.
+  :ref:`explicit-js-mode`.
 
 For instance the following ``executables`` stanza will produce byte
 code executables and native shared objects:

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -341,6 +341,8 @@ compilation is not available.
 - ``shared_object`` for producing object files that can be dynamically
   loaded into an application. This mode can be used to write a plugin
   in OCaml for a non-OCaml application.
+- ``js`` for producing Javascript from bytecode executables, see
+  `Explicit JS mode`_.
 
 For instance the following ``executables`` stanza will produce byte
 code executables and native shared objects:
@@ -359,6 +361,7 @@ Additionally, you can use the following short-hands:
 - ``shared_object`` for ``(best shared_object)``
 - ``byte`` for ``(byte exe)``
 - ``native`` for ``(native exe)``
+- ``js`` for ``(byte js)``
 
 For instance the following ``modes`` fields are all equivalent:
 
@@ -381,6 +384,7 @@ native/best      object        .exe%{ext_obj}
 byte             shared_object .bc%{ext_dll}
 native/best      shared_object %{ext_dll}
 byte             c             .bc.c
+byte             js            .bc.js
 ================ ============= =================
 
 Where ``%{ext_obj}`` and ``%{ext_dll}`` are the extensions for object

--- a/dune-project
+++ b/dune-project
@@ -4,6 +4,7 @@
 (implicit_transitive_deps false)
 (generate_opam_files true)
 (wrapped_executables true)
+(explicit_js_mode)
 
 (license MIT)
 (maintainers "Jane Street Group, LLC <opensource@janestreet.com>")

--- a/src/binary_kind.ml
+++ b/src/binary_kind.ml
@@ -5,6 +5,7 @@ type t =
   | Exe
   | Object
   | Shared_object
+  | Js
 
 let decode =
   let open Dune_lang.Decoder in
@@ -13,6 +14,7 @@ let decode =
     ; "exe"           , return Exe
     ; "object"        , return Object
     ; "shared_object" , return Shared_object
+    ; "js"            , Syntax.since Stanza.syntax (1, 11) >>> return Js
     ]
 
 let to_string = function
@@ -20,6 +22,7 @@ let to_string = function
   | Exe -> "exe"
   | Object -> "object"
   | Shared_object -> "shared_object"
+  | Js -> "js"
 
 let to_dyn t =
   let open Dyn.Encoder in
@@ -28,4 +31,4 @@ let to_dyn t =
 let encode t =
   Dune_lang.unsafe_atom_of_string (to_string t)
 
-let all = [C; Exe; Object; Shared_object]
+let all = [C; Exe; Object; Shared_object; Js]

--- a/src/binary_kind.mli
+++ b/src/binary_kind.mli
@@ -7,6 +7,7 @@ type t =
   | Exe
   | Object
   | Shared_object
+  | Js
 
 include Dune_lang.Conv with type t := t
 

--- a/src/cinaps.ml
+++ b/src/cinaps.ml
@@ -130,9 +130,12 @@ let gen_rules sctx t ~dir ~scope ~dir_kind =
       ~dynlink:false
       ~package:None
   in
+  let linkages =
+    [Exe.Linkage.Js.NonJs (Exe.Linkage.native_or_custom (Super_context.context sctx))]
+  in
   Exe.build_and_link cctx
     ~program:{ name; main_module_name; loc }
-    ~linkages:[Exe.Linkage.native_or_custom (Super_context.context sctx)]
+    ~linkages
     ~promote:None;
 
   Super_context.add_alias_action sctx ~dir ~loc:(Some loc) ~stamp:"cinaps"

--- a/src/cinaps.ml
+++ b/src/cinaps.ml
@@ -132,7 +132,7 @@ let gen_rules sctx t ~dir ~scope ~dir_kind =
       ~package:None
   in
   let linkages =
-    [Exe.Linkage.Js.NonJs (Exe.Linkage.native_or_custom (Super_context.context sctx))]
+    [Exe.Linkage.Js.Non_js (Exe.Linkage.native_or_custom (Super_context.context sctx))]
   in
   Exe.build_and_link cctx
     ~program:{ name; main_module_name; loc }

--- a/src/cinaps.ml
+++ b/src/cinaps.ml
@@ -127,6 +127,7 @@ let gen_rules sctx t ~dir ~scope ~dir_kind =
       ~requires_compile:(Lib.Compile.direct_requires compile_info)
       ~requires_link:(Lib.Compile.requires_link compile_info)
       ~flags:(Ocaml_flags.of_list ["-w"; "-24"])
+      ~js_of_ocaml:None
       ~dynlink:false
       ~package:None
   in

--- a/src/cinaps.ml
+++ b/src/cinaps.ml
@@ -131,12 +131,9 @@ let gen_rules sctx t ~dir ~scope ~dir_kind =
       ~dynlink:false
       ~package:None
   in
-  let linkages =
-    [Exe.Linkage.Js.Non_js (Exe.Linkage.native_or_custom (Super_context.context sctx))]
-  in
   Exe.build_and_link cctx
     ~program:{ name; main_module_name; loc }
-    ~linkages
+    ~linkages:[Exe.Linkage.native_or_custom (Super_context.context sctx)]
     ~promote:None;
 
   Super_context.add_alias_action sctx ~dir ~loc:(Some loc) ~stamp:"cinaps"

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -91,7 +91,7 @@ let create ~super_context ~scope ~expander ~obj_dir
       ?(dir_kind=Dune_lang.File_syntax.Dune)
       ~modules ~flags ~requires_compile ~requires_link
       ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
-      ~opaque ?stdlib ?js_of_ocaml ~dynlink ?sandbox ~package ?vimpl () =
+      ~opaque ?stdlib ~js_of_ocaml ~dynlink ?sandbox ~package ?vimpl () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -27,7 +27,7 @@ val create
   -> ?no_keep_locs         : bool
   -> opaque                : bool
   -> ?stdlib               : Dune_file.Library.Stdlib.t
-  -> ?js_of_ocaml          : Dune_file.Js_of_ocaml.t
+  -> js_of_ocaml           : Dune_file.Js_of_ocaml.t option
   -> dynlink               : bool
   -> ?sandbox              : bool
   -> package               : Package.t option

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1545,11 +1545,12 @@ module Executables = struct
 
     let decode =
       if_list
-        ~then_:(enter
-                  (let+ mode = Mode_conf.decode
-                   and+ kind = Binary_kind.decode
-                   and+ loc = loc in
-                   {mode; kind; loc}))
+        ~then_:
+          (enter
+             (let+ mode = Mode_conf.decode
+              and+ kind = Binary_kind.decode
+              and+ loc = loc in
+              {mode; kind; loc}))
         ~else_:simple
 
     let simple_encode link_mode =

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -800,7 +800,6 @@ module Mode_conf = struct
       | Byte
       | Native
       | Best
-      | Js
     let compare (a : t) b = compare a b
     let to_dyn _ = Dyn.opaque
   end
@@ -811,14 +810,12 @@ module Mode_conf = struct
       [ "byte"  , Byte
       ; "native", Native
       ; "best"  , Best
-      ; "js"    , Js
       ]
 
   let to_string = function
     | Byte -> "byte"
     | Native -> "native"
     | Best -> "best"
-    | Js -> "js"
 
   let to_dyn t =
     let open Dyn.Encoder in
@@ -837,7 +834,7 @@ module Mode_conf = struct
 
     let eval t ~has_native =
       let has_best = mem t Best in
-      let byte = mem t Byte || mem t Js || (has_best && (not has_native)) in
+      let byte = mem t Byte || (has_best && (not has_native)) in
       let native = has_native && (mem t Native || has_best) in
       { Mode.Dict.byte; native }
   end
@@ -1529,7 +1526,7 @@ module Executables = struct
 
     let byte   = byte_exe
     let native = native_exe
-    let js     = make Js Exe
+    let js     = make Byte Js
 
     let installable_modes =
       [exe; native; byte]
@@ -1547,27 +1544,12 @@ module Executables = struct
       Dune_lang.Decoder.enum simple_representations
 
     let decode =
-      let then_ =
-        let non_js_mode =
-          let f (loc, mode) =
-            match mode with
-            | Mode_conf.Js ->
-              User_error.raise ~loc
-                [ Pp.text "It is not allowed to specify a binary kind when \
-                           using js mode."
-                ]
-            | mode -> mode
-          in
-          map ~f (located Mode_conf.decode)
-        in
-        enter
-          (let+ mode = non_js_mode
-           and+ kind = Binary_kind.decode
-           and+ loc = loc in
-           {mode; kind; loc})
-      in
       if_list
-        ~then_
+        ~then_:(enter
+                  (let+ mode = Mode_conf.decode
+                   and+ kind = Binary_kind.decode
+                   and+ loc = loc in
+                   {mode; kind; loc}))
         ~else_:simple
 
     let simple_encode link_mode =
@@ -1685,7 +1667,6 @@ module Executables = struct
             match mode.mode with
             | Native | Best -> ".exe"
             | Byte -> ".bc"
-            | Js -> ".bc.js"
           in
           Names.install_conf names ~ext
       in

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -837,7 +837,7 @@ module Mode_conf = struct
 
     let eval t ~has_native =
       let has_best = mem t Best in
-      let byte = mem t Byte || (has_best && (not has_native)) in
+      let byte = mem t Byte || mem t Js || (has_best && (not has_native)) in
       let native = has_native && (mem t Native || has_best) in
       { Mode.Dict.byte; native }
   end

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -167,7 +167,6 @@ module Mode_conf : sig
     | Byte
     | Native
     | Best (** [Native] if available and [Byte] if not *)
-    | Js
 
   val decode : t Dune_lang.Decoder.t
   val compare : t -> t -> Ordering.t

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -333,6 +333,7 @@ module Executables : sig
     val shared_object : t
     val byte          : t
     val native        : t
+    val byte_exe      : t
 
     val compare : t -> t -> Ordering.t
 

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -334,6 +334,7 @@ module Executables : sig
     val byte          : t
     val native        : t
     val byte_exe      : t
+    val js            : t
 
     val compare : t -> t -> Ordering.t
 

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -167,6 +167,7 @@ module Mode_conf : sig
     | Byte
     | Native
     | Best (** [Native] if available and [Byte] if not *)
+    | Js
 
   val decode : t Dune_lang.Decoder.t
   val compare : t -> t -> Ordering.t

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -233,6 +233,7 @@ let implicit_transitive_deps t = t.implicit_transitive_deps
 let allow_approx_merlin t = t.allow_approx_merlin
 let generate_opam_files t = t.generate_opam_files
 let dialects t = t.dialects
+let explicit_js_mode t = t.explicit_js_mode
 
 let to_dyn
       { name ; root ; version ; source; license; authors

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -533,6 +533,9 @@ let implicit_transitive_deps_default ~(lang : Lang.Instance.t) =
 let wrapped_executables_default ~(lang : Lang.Instance.t) =
   lang.version >= (2, 0)
 
+let explicit_js_mode_default ~(lang : Lang.Instance.t) =
+  lang.version >= (2, 0)
+
 let anonymous = lazy (
   let lang = get_dune_lang () in
   let name = Name.anonymous_root in
@@ -548,6 +551,7 @@ let anonymous = lazy (
   in
   let implicit_transitive_deps = implicit_transitive_deps_default ~lang in
   let wrapped_executables = wrapped_executables_default ~lang in
+  let explicit_js_mode = explicit_js_mode_default ~lang in
   let root = Path.Source.root in
   let file_key = File_key.make ~root ~name in
   { name
@@ -572,7 +576,7 @@ let anonymous = lazy (
   ; generate_opam_files = false
   ; file_key
   ; dialects = Dialect.DB.builtin
-  ; explicit_js_mode = false
+  ; explicit_js_mode
   })
 
 let default_name ~dir ~packages =

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -209,6 +209,7 @@ type t =
   ; generate_opam_files : bool
   ; file_key : File_key.t
   ; dialects        : Dialect.DB.t
+  ; explicit_js_mode : bool
   }
 
 let equal = (==)
@@ -240,7 +241,7 @@ let to_dyn
       ; extension_args = _; stanza_parser = _ ; packages
       ; implicit_transitive_deps ; wrapped_executables ; dune_version
       ; allow_approx_merlin ; generate_opam_files
-      ; file_key ; dialects } =
+      ; file_key ; dialects ; explicit_js_mode } =
   let open Dyn.Encoder in
   record
     [ "name", Name.to_dyn name
@@ -265,6 +266,7 @@ let to_dyn
     ; "generate_opam_files", bool generate_opam_files
     ; "file_key", string file_key
     ; "dialects", Dialect.DB.to_dyn dialects
+    ; "explicit_js_mode", bool explicit_js_mode
     ]
 
 let find_extension_args t key =
@@ -569,6 +571,7 @@ let anonymous = lazy (
   ; generate_opam_files = false
   ; file_key
   ; dialects = Dialect.DB.builtin
+  ; explicit_js_mode = false
   })
 
 let default_name ~dir ~packages =
@@ -636,6 +639,8 @@ let parse ~dir ~lang ~opam_packages ~file =
                                   ~check:(Syntax.since Stanza.syntax (1, 10))
      and+ dialects = multi_field "dialect"
                        (Syntax.since Stanza.syntax (1, 11) >>> located Dialect.decode)
+     and+ explicit_js_mode =
+       field_b "explicit_js_mode" ~check:(Syntax.since Stanza.syntax (1, 11))
      in
      let homepage =
        match homepage, source with
@@ -750,6 +755,7 @@ let parse ~dir ~lang ~opam_packages ~file =
      ; allow_approx_merlin
      ; generate_opam_files
      ; dialects
+     ; explicit_js_mode
      })
 
 let load_dune_project ~dir opam_packages =
@@ -798,6 +804,7 @@ let make_jbuilder_project ~dir opam_packages =
   ; generate_opam_files = false
   ; wrapped_executables = false
   ; dialects
+  ; explicit_js_mode = false
   }
 
 let load ~dir ~files =

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -83,6 +83,7 @@ val stanza_parser : t -> Stanza.t list Dune_lang.Decoder.t
 val allow_approx_merlin : t -> bool
 val generate_opam_files : t -> bool
 val dialects : t -> Dialect.DB.t
+val explicit_js_mode : t -> bool
 
 val equal : t -> t -> bool
 val hash : t -> int

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -24,7 +24,7 @@ module Linkage = struct
     type linkage = t
     type t =
       | Js
-      | NonJs of linkage
+      | Non_js of linkage
   end
 
   let byte =
@@ -124,7 +124,7 @@ module Linkage = struct
   let of_user_config (ctx : Context.t) (m : Dune_file.Executables.Link_mode.t) =
     match m.mode with
     | Js -> Js.Js
-    | _ -> NonJs (of_user_config ctx m)
+    | _ -> Non_js (of_user_config ctx m)
 end
 
 let exe_path_from_name cctx ~name ~(linkage : Linkage.t) =
@@ -231,7 +231,7 @@ let build_and_link_many
       match linkage with
       | Linkage.Js.Js ->
         link_js ~name ~cm_files ~promote cctx
-      | NonJs linkage ->
+      | Non_js linkage ->
         link_exe cctx
           ~loc
           ~name

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -186,13 +186,14 @@ let link_exe
           ; Dyn (Build.S.map top_sorted_cms ~f:(fun x -> Command.Args.Deps x))
           ]))
 
-let link_js ~src ~cm_files ~promote cctx =
+let link_js ~name ~cm_files ~promote cctx =
   let sctx     = CC.super_context cctx in
   let expander = CC.expander cctx in
   let js_of_ocaml =
     CC.js_of_ocaml cctx
     |> Option.value ~default:Dune_file.Js_of_ocaml.default
   in
+  let src = exe_path_from_name cctx ~name ~linkage:Linkage.byte in
   let flags =
     (Expander.expand_and_eval_set expander
        js_of_ocaml.flags
@@ -229,8 +230,7 @@ let build_and_link_many
     List.iter linkages ~f:(fun linkage ->
       match linkage with
       | Linkage.Js.Js ->
-        let exe = exe_path_from_name cctx ~name ~linkage:Linkage.byte in
-        link_js ~src:exe ~cm_files ~promote cctx
+        link_js ~name ~cm_files ~promote cctx
       | NonJs linkage ->
         link_exe cctx
           ~loc

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -63,13 +63,13 @@ module Linkage = struct
   let of_user_config (ctx : Context.t) (m : Dune_file.Executables.Link_mode.t) =
     let wanted_mode : Mode.t =
       match m.mode with
-      | Byte -> Byte
+      | Byte   -> Byte
       | Native -> Native
       | Best   -> Native
     in
     let real_mode : Mode.t =
       match m.mode with
-      | Byte -> Byte
+      | Byte   -> Byte
       | Native -> Native
       | Best   -> if Option.is_some ctx.ocamlopt then Native else Byte
     in
@@ -207,9 +207,10 @@ let build_and_link_many
       ?link_flags
       cctx
   =
-  let modules = CC.modules cctx in
+  let modules = Compilation_context.modules cctx in
   let dep_graphs = Dep_rules.rules cctx ~modules in
   Module_compilation.build_all cctx ~dep_graphs;
+
   let link_time_code_gen = Link_time_code_gen.handle_special_libs cctx in
   List.iter programs ~f:(fun { Program.name; main_module_name ; loc } ->
     let cm_files =

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -12,13 +12,6 @@ end
 module Linkage : sig
   type t
 
-  module Js : sig
-    type linkage
-    type t =
-      | Js
-      | Non_js of linkage
-  end with type linkage := t
-
   (** Byte compilation, exetension [.bc] *)
   val byte : t
 
@@ -31,6 +24,9 @@ module Linkage : sig
   (** [native] if supported, [custom] if not *)
   val native_or_custom : Context.t -> t
 
+  (** Javascript compilation, extension [.bc.js] *)
+  val js : t
+
   val make
     :  mode:Mode.t
     -> ext:string
@@ -38,7 +34,7 @@ module Linkage : sig
     -> unit
     -> t
 
-  val of_user_config : Context.t -> Dune_file.Executables.Link_mode.t -> Js.t
+  val of_user_config : Context.t -> Dune_file.Executables.Link_mode.t -> t
 end
 
 (** {1 High-level functions} *)
@@ -47,7 +43,7 @@ end
 
 val build_and_link
   :  program:Program.t
-  -> linkages:Linkage.Js.t list
+  -> linkages:Linkage.t list
   -> promote:Dune_file.Promote.t option
   -> ?link_flags:(unit, string list) Build.t
   -> Compilation_context.t
@@ -55,7 +51,7 @@ val build_and_link
 
 val build_and_link_many
   :  programs:Program.t list
-  -> linkages:Linkage.Js.t list
+  -> linkages:Linkage.t list
   -> promote:Dune_file.Promote.t option
   -> ?link_flags:(unit, string list) Build.t
   -> Compilation_context.t

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -10,30 +10,35 @@ module Program : sig
 end
 
 module Linkage : sig
-  type 'mode t
+  type t
 
-  val map : 'm1 t -> f:('m1 -> 'm2) -> 'm2 t
+  module Js : sig
+    type linkage
+    type t =
+      | Js
+      | NonJs of linkage
+  end with type linkage := t
 
   (** Byte compilation, exetension [.bc] *)
-  val byte : Mode.Js.t t
+  val byte : t
 
   (** Native compilation, extension [.exe] *)
-  val native : Mode.Js.t t
+  val native : t
 
   (** Byte compilation, link with [-custom], extension [.exe] *)
-  val custom : Mode.Js.t t
+  val custom : t
 
   (** [native] if supported, [custom] if not *)
-  val native_or_custom : Context.t -> Mode.Js.t t
+  val native_or_custom : Context.t -> t
 
   val make
-    :  mode:'mode
+    :  mode:Mode.t
     -> ext:string
     -> ?flags:string list
     -> unit
-    -> 'mode t
+    -> t
 
-  val of_user_config : Context.t -> Dune_file.Executables.Link_mode.t -> Mode.Js.t t
+  val of_user_config : Context.t -> Dune_file.Executables.Link_mode.t -> Js.t
 end
 
 (** {1 High-level functions} *)
@@ -42,7 +47,7 @@ end
 
 val build_and_link
   :  program:Program.t
-  -> linkages:Mode.Js.t Linkage.t list
+  -> linkages:Linkage.Js.t list
   -> promote:Dune_file.Promote.t option
   -> ?link_flags:(unit, string list) Build.t
   -> Compilation_context.t
@@ -50,7 +55,7 @@ val build_and_link
 
 val build_and_link_many
   :  programs:Program.t list
-  -> linkages:Mode.Js.t Linkage.t list
+  -> linkages:Linkage.Js.t list
   -> promote:Dune_file.Promote.t option
   -> ?link_flags:(unit, string list) Build.t
   -> Compilation_context.t
@@ -59,5 +64,5 @@ val build_and_link_many
 val exe_path
   :  Compilation_context.t
   -> program:Program.t
-  -> linkage:Mode.t Linkage.t
+  -> linkage:Linkage.t
   -> Path.Build.t

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -10,28 +10,30 @@ module Program : sig
 end
 
 module Linkage : sig
-  type t
+  type 'mode t
+
+  val map : 'm1 t -> f:('m1 -> 'm2) -> 'm2 t
 
   (** Byte compilation, exetension [.bc] *)
-  val byte : t
+  val byte : Mode.Js.t t
 
   (** Native compilation, extension [.exe] *)
-  val native : t
+  val native : Mode.Js.t t
 
   (** Byte compilation, link with [-custom], extension [.exe] *)
-  val custom : t
+  val custom : Mode.Js.t t
 
   (** [native] if supported, [custom] if not *)
-  val native_or_custom : Context.t -> t
+  val native_or_custom : Context.t -> Mode.Js.t t
 
   val make
-    :  mode:Mode.t
+    :  mode:'mode
     -> ext:string
     -> ?flags:string list
     -> unit
-    -> t
+    -> 'mode t
 
-  val of_user_config : Context.t -> Dune_file.Executables.Link_mode.t -> t
+  val of_user_config : Context.t -> Dune_file.Executables.Link_mode.t -> Mode.Js.t t
 end
 
 (** {1 High-level functions} *)
@@ -40,7 +42,7 @@ end
 
 val build_and_link
   :  program:Program.t
-  -> linkages:Linkage.t list
+  -> linkages:Mode.Js.t Linkage.t list
   -> promote:Dune_file.Promote.t option
   -> ?link_flags:(unit, string list) Build.t
   -> Compilation_context.t
@@ -48,7 +50,7 @@ val build_and_link
 
 val build_and_link_many
   :  programs:Program.t list
-  -> linkages:Linkage.t list
+  -> linkages:Mode.Js.t Linkage.t list
   -> promote:Dune_file.Promote.t option
   -> ?link_flags:(unit, string list) Build.t
   -> Compilation_context.t
@@ -57,5 +59,5 @@ val build_and_link_many
 val exe_path
   :  Compilation_context.t
   -> program:Program.t
-  -> linkage:Linkage.t
+  -> linkage:Mode.t Linkage.t
   -> Path.Build.t

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -16,7 +16,7 @@ module Linkage : sig
     type linkage
     type t =
       | Js
-      | NonJs of linkage
+      | Non_js of linkage
   end with type linkage := t
 
   (** Byte compilation, exetension [.bc] *)

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -58,7 +58,14 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     let ctx = SC.context sctx in
     let l =
       let has_native = Option.is_some ctx.ocamlopt in
-      List.filter_map (L.Set.to_list exes.modes) ~f:(fun (mode : L.t) ->
+      let modes =
+        let f = function {L.mode = Js; _} -> true | _ -> false in
+        if L.Set.exists exes.modes ~f then
+          L.Set.add exes.modes L.byte_exe
+        else
+          exes.modes
+      in
+      List.filter_map (L.Set.to_list modes) ~f:(fun (mode : L.t) ->
         match has_native, mode.mode with
         | false, Native ->
           None
@@ -70,7 +77,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     if L.Set.mem exes.modes L.byte         &&
        not (L.Set.mem exes.modes L.native) &&
        not (L.Set.mem exes.modes L.exe) then
-      Exe.Linkage.custom :: l
+      Exe.Linkage.Js.NonJs Exe.Linkage.custom :: l
     else
       l
   in

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -53,12 +53,13 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
           ])
   in
 
+  let explicit_js_mode = Dune_project.explicit_js_mode (Scope.project scope) in
+
   let linkages =
     let module L = Dune_file.Executables.Link_mode in
     let ctx = SC.context sctx in
     let l =
       let has_native = Option.is_some ctx.ocamlopt in
-      let explicit_js_mode = Dune_project.explicit_js_mode (Scope.project scope) in
       let modes =
         let f = function {L.mode = Js; _} -> true | _ -> false in
         if L.Set.exists exes.modes ~f then
@@ -98,7 +99,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     let requires_link = Lib.Compile.requires_link compile_info in
     let js_of_ocaml =
       let js_of_ocaml = exes.buildable.js_of_ocaml in
-      if Dune_project.explicit_js_mode (Scope.project scope) then
+      if explicit_js_mode then
         Option.some_if (List.mem ~set:linkages Exe.Linkage.Js.Js) js_of_ocaml
       else
         Some js_of_ocaml

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -61,7 +61,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     let l =
       let has_native = Option.is_some ctx.ocamlopt in
       let modes =
-        let f = function {L.mode = Js; _} -> true | _ -> false in
+        let f = function {L.kind = Js; _} -> true | _ -> false in
         if L.Set.exists exes.modes ~f then
           L.Set.add exes.modes L.byte_exe
         else if not explicit_js_mode && L.Set.mem exes.modes L.byte_exe then
@@ -81,7 +81,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     if L.Set.mem exes.modes L.byte         &&
        not (L.Set.mem exes.modes L.native) &&
        not (L.Set.mem exes.modes L.exe) then
-      Exe.Linkage.Js.Non_js Exe.Linkage.custom :: l
+      Exe.Linkage.custom :: l
     else
       l
   in
@@ -100,7 +100,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     let js_of_ocaml =
       let js_of_ocaml = exes.buildable.js_of_ocaml in
       if explicit_js_mode then
-        Option.some_if (List.mem ~set:linkages Exe.Linkage.Js.Js) js_of_ocaml
+        Option.some_if (List.mem ~set:linkages Exe.Linkage.js) js_of_ocaml
       else
         Some js_of_ocaml
     in

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -96,6 +96,13 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
   let cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info in
     let requires_link = Lib.Compile.requires_link compile_info in
+    let js_of_ocaml =
+      let js_of_ocaml = exes.buildable.js_of_ocaml in
+      if Dune_project.explicit_js_mode (Scope.project scope) then
+        Option.some_if (List.mem ~set:linkages Exe.Linkage.Js.Js) js_of_ocaml
+      else
+        Some js_of_ocaml
+    in
     let dynlink =
       Dune_file.Executables.Link_mode.Set.exists exes.modes ~f:(fun mode ->
         match mode.kind with
@@ -113,7 +120,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       ~requires_link
       ~requires_compile
       ~preprocessing:pp
-      ~js_of_ocaml:exes.buildable.js_of_ocaml
+      ~js_of_ocaml
       ~opaque:(SC.opaque sctx)
       ~dynlink
       ~package:exes.package

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -58,10 +58,13 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     let ctx = SC.context sctx in
     let l =
       let has_native = Option.is_some ctx.ocamlopt in
+      let explicit_js_mode = Dune_project.explicit_js_mode (Scope.project scope) in
       let modes =
         let f = function {L.mode = Js; _} -> true | _ -> false in
         if L.Set.exists exes.modes ~f then
           L.Set.add exes.modes L.byte_exe
+        else if not explicit_js_mode && L.Set.mem exes.modes L.byte_exe then
+          L.Set.add exes.modes L.js
         else
           exes.modes
       in

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -80,7 +80,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     if L.Set.mem exes.modes L.byte         &&
        not (L.Set.mem exes.modes L.native) &&
        not (L.Set.mem exes.modes L.exe) then
-      Exe.Linkage.Js.NonJs Exe.Linkage.custom :: l
+      Exe.Linkage.Js.Non_js Exe.Linkage.custom :: l
     else
       l
   in

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -225,9 +225,15 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
         List.iter js_targets ~f:(fun js_target ->
           assert (Path.Build.equal (Path.Build.parent_exn js_target)
                     ctx_dir));
-        Predicate.create ~id ~f:(fun basename ->
-          not (List.exists js_targets ~f:(fun js_target ->
-            String.equal (Path.Build.basename js_target) basename)))
+        let f =
+          if Dune_project.explicit_js_mode (Scope.project scope) then
+            fun _ -> true
+          else
+            fun basename ->
+              not (List.exists js_targets ~f:(fun js_target ->
+                String.equal (Path.Build.basename js_target) basename))
+        in
+        Predicate.create ~id ~f
       in
       File_selector.create ~dir:(Path.build ctx_dir) pred
       |> Build.paths_matching ~loc:Loc.none

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -216,6 +216,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
         |> SC.add_rules ~dir:ctx_dir sctx
       | _ -> ());
     let dyn_deps =
+      (* DUNE2: no need to filter out js targets anymore *)
       let pred =
         let id = lazy (
           let open Dyn.Encoder in

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -311,7 +311,7 @@ include Sub_system.Register_end_point(
         )
       in
       let linkages =
-        List.map ~f:(fun linkage -> Exe.Linkage.Js.NonJs linkage) linkages in
+        List.map ~f:(fun linkage -> Exe.Linkage.Js.Non_js linkage) linkages in
       Exe.build_and_link cctx
         ~program:{ name; main_module_name = Module.name main_module ; loc }
         ~linkages

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -292,7 +292,7 @@ include Sub_system.Register_end_point(
           ~requires_compile:runner_libs
           ~requires_link:(lazy runner_libs)
           ~flags:(Ocaml_flags.of_list ["-w"; "-24"; "-g"])
-          ~js_of_ocaml:lib.buildable.js_of_ocaml
+          ~js_of_ocaml:None
           ~dynlink:false
           ~package:(Option.map lib.public ~f:(fun p -> p.package));
       in

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -302,12 +302,12 @@ include Sub_system.Register_end_point(
           then Mode_conf.Set.add info.modes Byte
           else info.modes
         in
-        List.filter_map (Mode_conf.Set.to_list modes) ~f:(fun (mode : Mode_conf.t) ->
+        List.map (Mode_conf.Set.to_list modes) ~f:(fun (mode : Mode_conf.t) ->
           match mode with
-          | Native -> Some Exe.Linkage.native
-          | Best -> Some (Exe.Linkage.native_or_custom (Super_context.context sctx))
-          | Byte -> Some Exe.Linkage.byte
-          | Javascript -> None
+          | Native -> Exe.Linkage.native
+          | Best -> Exe.Linkage.native_or_custom (Super_context.context sctx)
+          | Byte -> Exe.Linkage.byte
+          | Javascript -> Exe.Linkage.js
         )
       in
       Exe.build_and_link cctx

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -292,7 +292,7 @@ include Sub_system.Register_end_point(
           ~requires_compile:runner_libs
           ~requires_link:(lazy runner_libs)
           ~flags:(Ocaml_flags.of_list ["-w"; "-24"; "-g"])
-          ~js_of_ocaml:None
+          ~js_of_ocaml:(Some lib.buildable.js_of_ocaml)
           ~dynlink:false
           ~package:(Option.map lib.public ~f:(fun p -> p.package));
       in

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -310,8 +310,6 @@ include Sub_system.Register_end_point(
           | Javascript -> None
         )
       in
-      let linkages =
-        List.map ~f:(fun linkage -> Exe.Linkage.Js.Non_js linkage) linkages in
       Exe.build_and_link cctx
         ~program:{ name; main_module_name = Module.name main_module ; loc }
         ~linkages

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -310,6 +310,8 @@ include Sub_system.Register_end_point(
           | Javascript -> None
         )
       in
+      let linkages =
+        List.map ~f:(fun linkage -> Exe.Linkage.Js.NonJs linkage) linkages in
       Exe.build_and_link cctx
         ~program:{ name; main_module_name = Module.name main_module ; loc }
         ~linkages

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -361,6 +361,13 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let cctx =
       let requires_compile = Lib.Compile.direct_requires compile_info in
       let requires_link    = Lib.Compile.requires_link compile_info in
+      let js_of_ocaml =
+        let js_of_ocaml = lib.buildable.js_of_ocaml in
+        if Dune_project.explicit_js_mode (Scope.project scope) then
+          Option.some_if (Mode_conf.Set.mem lib.modes Js) js_of_ocaml
+        else
+          Some js_of_ocaml
+      in
       let dynlink =
         Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries in
       Compilation_context.create ()
@@ -376,7 +383,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         ~preprocessing:pp
         ~no_keep_locs:lib.no_keep_locs
         ~opaque
-        ~js_of_ocaml:lib.buildable.js_of_ocaml
+        ~js_of_ocaml
         ~dynlink
         ?stdlib:lib.stdlib
         ~package:(Option.map lib.public ~f:(fun p -> p.package))

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -279,6 +279,10 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let obj_dir = Compilation_context.obj_dir cctx in
     let flags = Compilation_context.flags cctx in
     let modules = Compilation_context.modules cctx in
+    let explicit_js_mode =
+      Dune_project.explicit_js_mode
+        (Scope.project (Compilation_context.scope cctx))
+    in
     let js_of_ocaml = lib.buildable.js_of_ocaml in
     let { Lib_config. ext_obj; has_native; natdynlink_supported; _ } =
       ctx.lib_config in
@@ -304,7 +308,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
      Mode.Dict.Set.iter modes ~f:(fun mode ->
        build_lib lib ~expander ~flags ~dir ~mode ~cm_files));
     (* Build *.cma.js *)
-    if modes.byte then
+    if (explicit_js_mode && Mode_conf.Set.mem lib.modes Js) || modes.byte then
       SC.add_rules sctx ~dir (
         let src =
           Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Mode.Byte) in

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -308,7 +308,9 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
      Mode.Dict.Set.iter modes ~f:(fun mode ->
        build_lib lib ~expander ~flags ~dir ~mode ~cm_files));
     (* Build *.cma.js *)
-    if (explicit_js_mode && Mode_conf.Set.mem lib.modes Js) || modes.byte then
+    if (explicit_js_mode && Mode_conf.Set.mem lib.modes Js) ||
+       (not explicit_js_mode && modes.byte)
+    then
       SC.add_rules sctx ~dir (
         let src =
           Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Mode.Byte) in

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -55,6 +55,7 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name:basename
       ~requires_link:(lazy requires)
       ~flags:Ocaml_flags.empty
       ~opaque
+      ~js_of_ocaml:None
       ~dynlink:(Compilation_context.dynlink cctx)
       ~package:(Compilation_context.package cctx)
       ()

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -135,3 +135,13 @@ module Dict = struct
       )
   end
 end
+
+module Js = struct
+  type mode_ = t
+  type t =
+    | Js
+    | Mode of mode_
+  let to_mode = function
+    | Js -> Byte
+    | Mode m -> m
+end

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -135,13 +135,3 @@ module Dict = struct
       )
   end
 end
-
-module Js = struct
-  type mode_ = t
-  type t =
-    | Js
-    | Mode of mode_
-  let to_mode = function
-    | Js -> Byte
-    | Mode m -> m
-end

--- a/src/mode.mli
+++ b/src/mode.mli
@@ -64,11 +64,3 @@ module Dict : sig
     val iter : t -> f:(mode -> unit) -> unit
   end
 end with type mode := t
-
-module Js : sig
-  type mode_ = t
-  type t =
-    | Js
-    | Mode of mode_
-  val to_mode : t -> mode_
-end with type mode_ := t

--- a/src/mode.mli
+++ b/src/mode.mli
@@ -64,3 +64,11 @@ module Dict : sig
     val iter : t -> f:(mode -> unit) -> unit
   end
 end with type mode := t
+
+module Js : sig
+  type mode_ = t
+  type t =
+    | Js
+    | Mode of mode_
+  val to_mode : t -> mode_
+end with type mode_ := t

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -94,7 +94,7 @@ let setup_rules t =
   let sctx = Compilation_context.super_context t.cctx in
   Exe.build_and_link t.cctx
     ~program
-    ~linkages:[Exe.Linkage.Js.Non_js linkage]
+    ~linkages:[linkage]
     ~link_flags:(Build.return ["-linkall"; "-warn-error"; "-31"])
     ~promote:None;
   let src = Exe.exe_path t.cctx ~program ~linkage in

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -144,6 +144,7 @@ module Stanza = struct
         ~requires_compile
         ~requires_link
         ~flags
+        ~js_of_ocaml:None
         ~dynlink:false
         ~package:None
     in

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -97,7 +97,10 @@ let setup_rules t =
     ~linkages:[linkage]
     ~link_flags:(Build.return ["-linkall"; "-warn-error"; "-31"])
     ~promote:None;
-  let src = Exe.exe_path t.cctx ~program ~linkage in
+  let src =
+    Exe.exe_path t.cctx ~program
+      ~linkage:(Exe.Linkage.map ~f:Mode.Js.to_mode linkage)
+  in
   let dir = Source.stanza_dir t.source in
   let dst = Path.Build.relative dir (Path.Build.basename src) in
   Super_context.add_rule sctx ~dir ~loc:t.source.loc

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -94,13 +94,10 @@ let setup_rules t =
   let sctx = Compilation_context.super_context t.cctx in
   Exe.build_and_link t.cctx
     ~program
-    ~linkages:[linkage]
+    ~linkages:[Exe.Linkage.Js.NonJs linkage]
     ~link_flags:(Build.return ["-linkall"; "-warn-error"; "-31"])
     ~promote:None;
-  let src =
-    Exe.exe_path t.cctx ~program
-      ~linkage:(Exe.Linkage.map ~f:Mode.Js.to_mode linkage)
-  in
+  let src = Exe.exe_path t.cctx ~program ~linkage in
   let dir = Source.stanza_dir t.source in
   let dst = Path.Build.relative dir (Path.Build.basename src) in
   Super_context.add_rule sctx ~dir ~loc:t.source.loc

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -94,7 +94,7 @@ let setup_rules t =
   let sctx = Compilation_context.super_context t.cctx in
   Exe.build_and_link t.cctx
     ~program
-    ~linkages:[Exe.Linkage.Js.NonJs linkage]
+    ~linkages:[Exe.Linkage.Js.Non_js linkage]
     ~link_flags:(Build.return ["-linkall"; "-warn-error"; "-31"])
     ~promote:None;
   let src = Exe.exe_path t.cctx ~program ~linkage in

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -91,6 +91,7 @@ let setup sctx ~dir =
       ~requires_link:(lazy requires)
       ~requires_compile:requires
       ~flags
+      ~js_of_ocaml:None
       ~dynlink:false
       ~package:None
   in

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1904,7 +1904,6 @@
   (alias exe-name-mangle)
   (alias exec-cmd)
   (alias exec-missing)
-  (alias explicit_js_mode)
   (alias external-lib-deps)
   (alias extra-lang-line)
   (alias fallback-dune)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -468,6 +468,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name explicit_js_mode)
+ (deps (package dune) (source_tree test-cases/explicit_js_mode))
+ (action
+  (chdir
+   test-cases/explicit_js_mode
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name external-lib-deps)
  (deps (package dune) (source_tree test-cases/external-lib-deps))
  (action
@@ -1698,6 +1706,7 @@
   (alias exe-name-mangle)
   (alias exec-cmd)
   (alias exec-missing)
+  (alias explicit_js_mode)
   (alias external-lib-deps)
   (alias extra-lang-line)
   (alias fallback-dune)
@@ -1896,6 +1905,7 @@
   (alias exe-name-mangle)
   (alias exec-cmd)
   (alias exec-missing)
+  (alias explicit_js_mode)
   (alias external-lib-deps)
   (alias extra-lang-line)
   (alias fallback-dune)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1706,7 +1706,6 @@
   (alias exe-name-mangle)
   (alias exec-cmd)
   (alias exec-missing)
-  (alias explicit_js_mode)
   (alias external-lib-deps)
   (alias extra-lang-line)
   (alias fallback-dune)
@@ -2029,6 +2028,6 @@
  (name runtest-disabled)
  (deps (alias cinaps) (alias envs-and-contexts)))
 
-(alias (name runtest-js) (deps (alias js_of_ocaml)))
+(alias (name runtest-js) (deps (alias explicit_js_mode) (alias js_of_ocaml)))
 
 (alias (name runtest-coq) (deps (alias coq)))

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -165,6 +165,7 @@ let exclusions =
   ; make "env" ~skip_ocaml:"<4.06.0"
   ; make "env-cflags" ~skip_ocaml:"<4.06.0"
   ; make "wrapped-transition" ~skip_ocaml:"<4.06.0"
+  ; make "explicit_js_mode" ~js:true
   ]
 
 let all_tests = lazy (

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -165,7 +165,7 @@ let exclusions =
   ; make "env" ~skip_ocaml:"<4.06.0"
   ; make "env-cflags" ~skip_ocaml:"<4.06.0"
   ; make "wrapped-transition" ~skip_ocaml:"<4.06.0"
-  ; make "explicit_js_mode" ~js:true
+  ; make "explicit_js_mode" ~external_deps:true ~js:true
   ]
 
 let all_tests = lazy (

--- a/test/blackbox-tests/test-cases/explicit_js_mode/dune
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/dune
@@ -15,3 +15,7 @@
  (name bar)
  (modules d)
  (modes js))
+
+(test
+ (name e)
+ (modules e))

--- a/test/blackbox-tests/test-cases/explicit_js_mode/dune
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/dune
@@ -6,3 +6,12 @@
  (name b)
  (modes js)
  (modules b))
+
+(library
+ (name foo)
+ (modules c))
+
+(library
+ (name bar)
+ (modules d)
+ (modes js))

--- a/test/blackbox-tests/test-cases/explicit_js_mode/dune
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/dune
@@ -1,0 +1,8 @@
+(executable
+ (name a)
+ (modules a))
+
+(executable
+ (name b)
+ (modes js)
+ (modules b))

--- a/test/blackbox-tests/test-cases/explicit_js_mode/dune
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/dune
@@ -11,11 +11,12 @@
  (name foo)
  (modules c))
 
-(library
- (name bar)
- (modules d)
- (modes js))
-
 (test
+ (name d)
+ (modules d))
+
+(executable
  (name e)
- (modules e))
+ (modules e)
+ (modes js)
+ (libraries foo))

--- a/test/blackbox-tests/test-cases/explicit_js_mode/dune-project
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.11)
+(explicit_js_mode)

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -1,0 +1,14 @@
+Check that .bc.js rule is generated only if js mode is used.
+
+  $ dune build --display short a.bc.js
+  Error: Don't know how to build a.bc.js
+  Hint: did you mean b.bc.js?
+  [1]
+
+  $ dune build --display short b.bc.js
+   js_of_ocaml b.bc.runtime.js
+      ocamldep .b.eobjs/b.ml.d
+        ocamlc .b.eobjs/byte/b.{cmi,cmo,cmt}
+   js_of_ocaml .b.eobjs/byte/b.cmo.js
+   js_of_ocaml .js/stdlib/stdlib.cma.js
+     jsoo_link b.bc.js

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -13,6 +13,12 @@ Check that .bc.js rule is generated only if js mode is used.
    js_of_ocaml .js/stdlib/stdlib.cma.js
      jsoo_link b.bc.js
 
+We also check that .cmo.js rules are not generated if not specified.
+
+  $ dune build --display short _build/default/.a.eobjs/byte/a.cmo.js
+  Error: Don't know how to build _build/default/.a.eobjs/byte/a.cmo.js
+  [1]
+
 Same for libraries.
 
   $ dune build --display short _build/default/.foo.objs/foo.cma.js

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -2,7 +2,7 @@ Check that .bc.js rule is generated only if js mode is used.
 
   $ dune build --display short a.bc.js
   Error: Don't know how to build a.bc.js
-  Hint: did you mean b.bc.js?
+  Hint: did you mean b.bc.js or e.bc.js?
   [1]
 
   $ dune build --display short b.bc.js
@@ -23,44 +23,36 @@ JS compilation of libraries is always available to avoid having to annotate
 every dependency of an executable.
 
   $ dune build --display short _build/default/.foo.objs/foo.cma.js
-  Error: Don't know how to build _build/default/.foo.objs/foo.cma.js
-  [1]
+        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
+      ocamldep .foo.objs/c.ml.d
+        ocamlc .foo.objs/byte/foo__C.{cmi,cmo,cmt}
+        ocamlc foo.cma
+   js_of_ocaml .foo.objs/foo.cma.js
 
 Check that js targets are attached to @all, but not for tests that do not
 specify js mode (#1940).
 
   $ dune clean
-  $ dune build --display short @@all | grep js_of_ocaml
-      ocamldep $ext_lib.eobjs/a.ml.d
-        ocamlc $ext_lib.eobjs/byte/a.{cmi,cmo,cmt}
-        ocamlc a.bc
-      ocamldep .b.eobjs/b.ml.d
-        ocamlc .b.eobjs/byte/b.{cmi,cmo,cmt}
-        ocamlc b.bc
+  $ dune build --display short @@all 2>&1 | grep js_of_ocaml
    js_of_ocaml b.bc.runtime.js
    js_of_ocaml .b.eobjs/byte/b.cmo.js
-        ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
-      ocamldep .bar.objs/d.ml.d
-        ocamlc .bar.objs/byte/bar__D.{cmi,cmo,cmt}
-        ocamlc bar.cma
-      ocamldep .e.eobjs/e.ml.d
-        ocamlc .e.eobjs/byte/e.{cmi,cmo,cmt}
-        ocamlc e.bc
-        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
-      ocamlopt .foo.objs/native/foo.{cmx,o}
-      ocamldep .foo.objs/c.ml.d
-        ocamlc .foo.objs/byte/foo__C.{cmi,cmo,cmt}
-        ocamlc foo.cma
-      ocamlopt $ext_lib.eobjs/native/a.{cmx,o}
-      ocamlopt a.exe
+   js_of_ocaml e.bc.runtime.js
+   js_of_ocaml .e.eobjs/byte/e.cmo.js
    js_of_ocaml .js/stdlib/stdlib.cma.js
-     jsoo_link b.bc.js
-      ocamlopt .e.eobjs/native/e.{cmx,o}
-      ocamlopt e.exe
-      ocamlopt .foo.objs/native/foo__C.{cmx,o}
-      ocamlopt foo.{a,cmxa}
-      ocamlopt foo.cmxs
+   js_of_ocaml .foo.objs/foo.cma.js
 
 Check that building a JS-enabled executable that depends on a library works.
 
+  $ dune clean
   $ dune build --display short e.bc.js
+   js_of_ocaml e.bc.runtime.js
+      ocamldep .e.eobjs/e.ml.d
+        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
+      ocamldep .foo.objs/c.ml.d
+        ocamlc .foo.objs/byte/foo__C.{cmi,cmo,cmt}
+        ocamlc foo.cma
+   js_of_ocaml .foo.objs/foo.cma.js
+   js_of_ocaml .js/stdlib/stdlib.cma.js
+        ocamlc .e.eobjs/byte/e.{cmi,cmo,cmt}
+   js_of_ocaml .e.eobjs/byte/e.cmo.js
+     jsoo_link e.bc.js

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -32,7 +32,8 @@ Same for libraries.
         ocamlc bar.cma
    js_of_ocaml .bar.objs/bar.cma.js
 
-Check that js targets are attached to @all
+Check that js targets are attached to @all, but not for tests that do not
+specify js mode (#1940).
 
   $ dune clean
   $ dune build --display short @all
@@ -48,6 +49,9 @@ Check that js targets are attached to @all
       ocamldep .bar.objs/d.ml.d
         ocamlc .bar.objs/byte/bar__D.{cmi,cmo,cmt}
         ocamlc bar.cma
+      ocamldep .e.eobjs/e.ml.d
+        ocamlc .e.eobjs/byte/e.{cmi,cmo,cmt}
+        ocamlc e.bc
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
       ocamlopt .foo.objs/native/foo.{cmx,o}
       ocamldep .foo.objs/c.ml.d
@@ -57,6 +61,8 @@ Check that js targets are attached to @all
       ocamlopt a.exe
    js_of_ocaml .js/stdlib/stdlib.cma.js
      jsoo_link b.bc.js
+      ocamlopt .e.eobjs/native/e.{cmx,o}
+      ocamlopt e.exe
       ocamlopt .foo.objs/native/foo__C.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -36,7 +36,7 @@ Check that js targets are attached to @all, but not for tests that do not
 specify js mode (#1940).
 
   $ dune clean
-  $ dune build --display short @all
+  $ dune build --display short @@all
       ocamldep $ext_lib.eobjs/a.ml.d
         ocamlc $ext_lib.eobjs/byte/a.{cmi,cmo,cmt}
         ocamlc a.bc
@@ -66,3 +66,20 @@ specify js mode (#1940).
       ocamlopt .foo.objs/native/foo__C.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs
+
+In the following test, the executable efoo has js mode enabled but it depends
+on the library foo that does not have it enabled. One can compile the bytecode
+executable:
+
+  $ dune build --display short sub/efoo.bc
+      ocamldep sub/.efoo.eobjs/efoo.ml.d
+        ocamlc sub/.efoo.eobjs/byte/efoo.{cmi,cmo,cmt}
+        ocamlc sub/efoo.bc
+
+But not the JS:
+
+  $ dune build --display short sub/efoo.bc.js
+   js_of_ocaml sub/efoo.bc.runtime.js
+  Error: No rule found for .foo.objs/foo.cma.js
+   js_of_ocaml sub/.efoo.eobjs/byte/efoo.cmo.js
+  [1]

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -19,24 +19,18 @@ We also check that .cmo.js rules are not generated if not specified.
   Error: Don't know how to build _build/default/.a.eobjs/byte/a.cmo.js
   [1]
 
-Same for libraries.
+JS compilation of libraries is always available to avoid having to annotate
+every dependency of an executable.
 
   $ dune build --display short _build/default/.foo.objs/foo.cma.js
   Error: Don't know how to build _build/default/.foo.objs/foo.cma.js
   [1]
 
-  $ dune build --display short _build/default/.bar.objs/bar.cma.js
-        ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
-      ocamldep .bar.objs/d.ml.d
-        ocamlc .bar.objs/byte/bar__D.{cmi,cmo,cmt}
-        ocamlc bar.cma
-   js_of_ocaml .bar.objs/bar.cma.js
-
 Check that js targets are attached to @all, but not for tests that do not
 specify js mode (#1940).
 
   $ dune clean
-  $ dune build --display short @@all
+  $ dune build --display short @@all | grep js_of_ocaml
       ocamldep $ext_lib.eobjs/a.ml.d
         ocamlc $ext_lib.eobjs/byte/a.{cmi,cmo,cmt}
         ocamlc a.bc
@@ -67,19 +61,6 @@ specify js mode (#1940).
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs
 
-In the following test, the executable efoo has js mode enabled but it depends
-on the library foo that does not have it enabled. One can compile the bytecode
-executable:
+Check that building a JS-enabled executable that depends on a library works.
 
-  $ dune build --display short sub/efoo.bc
-      ocamldep sub/.efoo.eobjs/efoo.ml.d
-        ocamlc sub/.efoo.eobjs/byte/efoo.{cmi,cmo,cmt}
-        ocamlc sub/efoo.bc
-
-But not the JS:
-
-  $ dune build --display short sub/efoo.bc.js
-   js_of_ocaml sub/efoo.bc.runtime.js
-  Error: No rule found for .foo.objs/foo.cma.js
-   js_of_ocaml sub/.efoo.eobjs/byte/efoo.cmo.js
-  [1]
+  $ dune build --display short e.bc.js

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -12,3 +12,16 @@ Check that .bc.js rule is generated only if js mode is used.
    js_of_ocaml .b.eobjs/byte/b.cmo.js
    js_of_ocaml .js/stdlib/stdlib.cma.js
      jsoo_link b.bc.js
+
+Same for libraries.
+
+  $ dune build --display short _build/default/.foo.objs/foo.cma.js
+  Error: Don't know how to build _build/default/.foo.objs/foo.cma.js
+  [1]
+
+  $ dune build --display short _build/default/.bar.objs/bar.cma.js
+        ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
+      ocamldep .bar.objs/d.ml.d
+        ocamlc .bar.objs/byte/bar__D.{cmi,cmo,cmt}
+        ocamlc bar.cma
+   js_of_ocaml .bar.objs/bar.cma.js

--- a/test/blackbox-tests/test-cases/explicit_js_mode/run.t
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/run.t
@@ -25,3 +25,32 @@ Same for libraries.
         ocamlc .bar.objs/byte/bar__D.{cmi,cmo,cmt}
         ocamlc bar.cma
    js_of_ocaml .bar.objs/bar.cma.js
+
+Check that js targets are attached to @all
+
+  $ dune clean
+  $ dune build --display short @all
+      ocamldep $ext_lib.eobjs/a.ml.d
+        ocamlc $ext_lib.eobjs/byte/a.{cmi,cmo,cmt}
+        ocamlc a.bc
+      ocamldep .b.eobjs/b.ml.d
+        ocamlc .b.eobjs/byte/b.{cmi,cmo,cmt}
+        ocamlc b.bc
+   js_of_ocaml b.bc.runtime.js
+   js_of_ocaml .b.eobjs/byte/b.cmo.js
+        ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
+      ocamldep .bar.objs/d.ml.d
+        ocamlc .bar.objs/byte/bar__D.{cmi,cmo,cmt}
+        ocamlc bar.cma
+        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
+      ocamlopt .foo.objs/native/foo.{cmx,o}
+      ocamldep .foo.objs/c.ml.d
+        ocamlc .foo.objs/byte/foo__C.{cmi,cmo,cmt}
+        ocamlc foo.cma
+      ocamlopt $ext_lib.eobjs/native/a.{cmx,o}
+      ocamlopt a.exe
+   js_of_ocaml .js/stdlib/stdlib.cma.js
+     jsoo_link b.bc.js
+      ocamlopt .foo.objs/native/foo__C.{cmx,o}
+      ocamlopt foo.{a,cmxa}
+      ocamlopt foo.cmxs

--- a/test/blackbox-tests/test-cases/explicit_js_mode/sub/dune
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/sub/dune
@@ -1,0 +1,5 @@
+(executable
+ (name efoo)
+ (modes js)
+ (libraries foo)
+ (modules efoo))

--- a/test/blackbox-tests/test-cases/explicit_js_mode/sub/dune
+++ b/test/blackbox-tests/test-cases/explicit_js_mode/sub/dune
@@ -1,5 +1,0 @@
-(executable
- (name efoo)
- (modes js)
- (libraries foo)
- (modules efoo))


### PR DESCRIPTION
Fixes #1675 and #1940 

This is a first try at having a `(explicit_js_mode)` as discussed in #1675.

From a user perspective, it works as follows: when activated, `.bc.js` targets are only set up if the `(executable ...)` stanza contains `js` or `(byte js)` in its `(modes ...)` field.

Suggestions welcome!