### PR TITLE
Remove on_load_dir in Format_rules and in general

### DIFF
--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -74,10 +74,6 @@ val targets_of : dir:Path.t -> Path.Set.t
 (** Load the rules for this directory. *)
 val load_dir : dir:Path.t -> unit
 
-(** [on_load_dir ~dir ~f] remembers to run [f] when loading the rules
-    for [dir]. *)
-val on_load_dir : dir:Path.t -> f:(unit -> unit) -> unit
-
 (** Stamp file that depends on all files of [dir] with extension [ext]. *)
 val stamp_file_for_files_of : dir:Path.t -> ext:string -> Path.t
 

--- a/src/format_rules.mli
+++ b/src/format_rules.mli
@@ -3,8 +3,10 @@ open Import
 (** Setup automatic format rules for the given dir.
     If tools like ocamlformat are not available in $PATH, just display an error
     message when the alias is built. *)
-val gen_rules:
-  Super_context.t
+val gen_rules : dir:Path.t -> unit
+
+val gen_rules_output
+  :  Super_context.t
   -> Dune_file.Auto_format.t
-  -> dir:Path.t
+  -> output_dir:Path.t
   -> unit


### PR DESCRIPTION
Just split the rule generation into two functions. The code isn't very clean yet, I just wanted to show this as a POC. I did not add any memoization because I don't really see what needs to be memoized. Fetching the format config per directory perhaps?

I can clean this code up if the reviewers are happy with this direction.