### PR TITLE
Raise when the same memoized function name is used twice

### DIFF
--- a/src/dir_status.ml
+++ b/src/dir_status.ml
@@ -107,7 +107,7 @@ module DB = struct
           Memo.create
             "get-dir-status"
             ~input:(module Path)
-            ~visibility:(Public Path_dune_lang.decode)
+            ~visibility:Hidden
             ~output:(Simple (module T))
             ~doc:"Get a directory status."
             Sync

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -95,11 +95,16 @@ module Spec = struct
 
   let by_name = Function_name.Table.create ~default_value:None
 
-  let register t =
-    Function_name.Table.set by_name ~key:t.name ~data:(Some (T t))
-
   let find name =
     Function_name.Table.get by_name name
+
+  let register t =
+    match find t.name with
+    | Some _ ->
+      Exn.code_error "[Spec.register] called twice on the same function" []
+    | None ->
+      Function_name.Table.set by_name ~key:t.name ~data:(Some (T t))
+
 end
 
 module Id = Id.Make()

--- a/src/stdune/interned.ml
+++ b/src/stdune/interned.ml
@@ -75,6 +75,7 @@ module Make(R : Settings)()
     let set t ~key ~data =
       if key >= Array.length t.data then resize t;
       t.data.(key) <- data
+
   end
 
   let names = Table.create ~default_value:""

--- a/test/unit-tests/memoize.mlt
+++ b/test/unit-tests/memoize.mlt
@@ -228,7 +228,12 @@ let sync_fib =
     else
       mfib (x - 1) + mfib (x - 2)
   in
-  let fn = sync_int_fn_create "fib" ~output:(Allow_cutoff (module Int)) (Some compfib) ~doc:"" in
+  let fn =
+    sync_int_fn_create
+      "sync-fib"
+      ~output:(Allow_cutoff (module Int))
+      (Some compfib) ~doc:""
+  in
   Fdecl.set mfib fn;
   fn;;
 [%%ignore]


### PR DESCRIPTION
Raise when the same memoized function name is used twice.