### PR TITLE
Expect test framework: print exceptions raised by [@@ignore]d blocks

### DIFF
--- a/test/unit-tests/expect_test.mll
+++ b/test/unit-tests/expect_test.mll
@@ -107,7 +107,6 @@ let main () =
 
     let buf = Buffer.create (String.length file_contents + 1024) in
     let ppf = Format.formatter_of_buffer buf in
-    let null_ppf = Format.make_formatter (fun _ _ _ -> ()) (fun () -> ()) in
     List.iter chunks ~f:(fun (kind, pos, s) ->
       begin match kind with
       | Ignore -> Format.fprintf ppf "%s[%%%%ignore]@." s
@@ -119,12 +118,12 @@ let main () =
       let phrases = !Toploop.parse_use_file lexbuf in
       List.iter phrases ~f:(fun phr ->
         try
-          let ppf =
+          let print_types_and_values =
             match kind with
-            | Expect | Error -> ppf
-            | Ignore -> null_ppf
+            | Expect | Error -> true
+            | Ignore -> false
           in
-          ignore (Toploop.execute_phrase true ppf phr : bool)
+          ignore (Toploop.execute_phrase print_types_and_values ppf phr : bool)
         with exn ->
           let ppf =
             match kind with


### PR DESCRIPTION
Currently `[@@ignore]` blocks in `.mlt` files suppress raised exceptions just as well as they suppress the values themselves.
I think suppressing exceptions is probably unintentional: it's easy to end up with a block not doing any of its intended function with no error message whatsoever, which is confusing.

This PR makes us print the exceptions (and some of the other error messages), but not the values and types.