### PR TITLE
Remove all invalid_arg from codebase

### DIFF
--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -62,7 +62,7 @@ type t =
 
 val atom : string -> t
 (** [atom s] convert the string [s] to an Atom.
-    @raise Invalid_argument if [s] does not satisfy [Atom.is_valid s]. *)
+    @raise Exn.Code_error if [s] does not satisfy [Atom.is_valid s]. *)
 
 val atom_or_quoted_string : string -> t
 

--- a/src/dune_lang/template.ml
+++ b/src/dune_lang/template.ml
@@ -27,7 +27,8 @@ end = struct
   (* TODO use the loc for the error *)
   let check_valid_unquoted s ~syntax ~loc:_ =
     if not (Atom.is_valid (Atom.of_string s) syntax) then
-      Printf.ksprintf invalid_arg "Invalid text %S in unquoted template" s
+      Exn.code_error "Invalid text in unquoted template"
+        ["s", Sexp.Encoder.string s]
 
   let to_string { parts; quoted; loc } ~syntax =
     Buffer.clear buf;

--- a/src/install.ml
+++ b/src/install.ml
@@ -150,7 +150,7 @@ module Section = struct
       | Doc          -> t.doc
       | Stublibs     -> t.stublibs
       | Man          -> t.man
-      | Misc         -> invalid_arg"Install.Paths.get"
+      | Misc         -> Exn.code_error "Install.Paths.get" []
 
     let man_subdir p =
       match Filename.split_extension_after_dot p with

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -626,7 +626,7 @@ let peek_exn t inp = Option.value_exn (peek t inp)
 
 let set_impl t f =
   match t.fdecl with
-  | None -> invalid_arg "Memo.set_impl"
+  | None -> Exn.code_error "Memo.set_impl" []
   | Some fdecl -> Fdecl.set fdecl f
 
 let get_deps t inp =

--- a/src/stdune/caml/dune_caml.ml
+++ b/src/stdune/caml/dune_caml.ml
@@ -8,7 +8,8 @@ module Result   = Dune_result.Result
 module Hashtbl  = MoreLabels.Hashtbl
 module Lexing   = Lexing
 module Digest   = Digest
-module StringLabels   = StringLabels
+module StringLabels = StringLabels
+module ListLabels   = ListLabels
 
 type ('a, 'error) result = ('a, 'error) Result.t =
   | Ok    of 'a

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -1,3 +1,5 @@
+module List = Dune_caml.ListLabels
+module String = Dune_caml.StringLabels
 type t = exn
 
 exception Code_error of Sexp.t
@@ -37,7 +39,6 @@ let code_error message vars =
              Sexp.List [Atom name; value])))
   |> raise
 
-module String = Dune_caml.StringLabels
 let pp_uncaught ~backtrace fmt exn =
   let s =
     Printf.sprintf "%s\n%s" (Printexc.to_string exn) backtrace

--- a/src/stdune/fdecl.ml
+++ b/src/stdune/fdecl.ml
@@ -9,9 +9,9 @@ let create () = { state = Unset }
 let set t x =
   match t.state with
   | Unset -> t.state <- Set x
-  | Set _ -> invalid_arg "Fdecl.set: already set"
+  | Set _ -> Exn.code_error "Fdecl.set: already set" []
 
 let get t =
   match t.state with
-  | Unset -> invalid_arg "Fdecl.get: not set"
+  | Unset -> Exn.code_error "Fdecl.get: not set" []
   | Set x -> x

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -90,7 +90,7 @@ let rec find l ~f =
 let find_exn l ~f =
   match find l ~f with
   | Some x -> x
-  | None -> invalid_arg "List.find_exn"
+  | None -> Exn.code_error "List.find_exn" []
 
 let rec last = function
   | [] -> None

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -111,7 +111,7 @@ module Make(Key : Comparable.S) : S with type key = Key.t = struct
   let of_list_exn l =
     match of_list l with
     | Ok    x -> x
-    | Error _ -> invalid_arg "Map.of_list_exn"
+    | Error _ -> Exn.code_error "Map.of_list_exn" []
 
   let of_list_reduce l ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->

--- a/src/stdune/option.ml
+++ b/src/stdune/option.ml
@@ -37,7 +37,7 @@ let value t ~default =
 
 let value_exn = function
   | Some x -> x
-  | None -> invalid_arg "Option.value_exn"
+  | None -> Exn.code_error "Option.value_exn" []
 
 let some x = Some x
 

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -113,7 +113,11 @@ let lsplit2 s ~on =
 let lsplit2_exn s ~on =
   match lsplit2 s ~on with
   | Some s -> s
-  | None -> invalid_arg "lsplit2_exn"
+  | None ->
+    Exn.code_error "lsplit2_exn"
+      [ "s", Sexp.Encoder.string s
+      ; "on", Sexp.Encoder.char on
+      ]
 
 let rsplit2 s ~on =
   match rindex s on with

--- a/src/stdune/string_split.ml
+++ b/src/stdune/string_split.ml
@@ -1,3 +1,4 @@
+module List = Dune_caml.ListLabels
 module String = Dune_caml.StringLabels
 open String
 

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -55,7 +55,7 @@ let parse s =
           |> List.map ~f:Dune_lang.Ast.remove_locs)
     with
     | Dune_lang.Parse_error e -> Error (Dune_lang.Parse_error.message e)
-    | Invalid_argument e -> Error e
+    | e -> Error (Printexc.to_string e)
   in
   let jbuild = f ~lexer:Dune_lang.Lexer.jbuild_token in
   let dune   = f ~lexer:Dune_lang.Lexer.token        in
@@ -334,12 +334,18 @@ test Dune (a "toto")
 
 test Dune (t [Text "x%{"])
 [%%expect{|
-Exception: Invalid_argument "Invalid text \"x%{\" in unquoted template".
+Exception:
+Code_error
+ (List
+   [Atom "Invalid text in unquoted template"; List [Atom "s"; Atom "x%{"]]).
 |}]
 
 test Dune (t [Text "x%"; Text "{"])
 [%%expect{|
-Exception: Invalid_argument "Invalid text \"x%{\" in unquoted template".
+Exception:
+Code_error
+ (List
+   [Atom "Invalid text in unquoted template"; List [Atom "s"; Atom "x%{"]]).
 |}]
 
 (* This round trip failure is expected *)


### PR DESCRIPTION
Exn.code_error should be used everywhere

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>