### PR TITLE
Odoc memoization part #2

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -101,6 +101,9 @@ type t =
   ; which_cache             : (string, Path.t option) Hashtbl.t
   }
 
+let equal x y = String.equal x.name y.name
+let hash t = String.hash t.name
+
 let to_sexp t =
   let open Sexp.Encoder in
   let path = Path.to_sexp in

--- a/src/context.mli
+++ b/src/context.mli
@@ -129,6 +129,9 @@ type t =
   ; which_cache             : (string, Path.t option) Hashtbl.t
   }
 
+val equal : t -> t -> bool
+val hash : t -> int
+
 val to_sexp : t -> Sexp.t
 
 (** Compare the context names *)

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -21,6 +21,10 @@ end
 module Syntax : sig
   type t = Jbuild | Dune
 
+  val hash : t -> int
+
+  val equal : t -> t -> bool
+
   val of_basename : string -> t option
 end
 

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -1,5 +1,9 @@
 type t = Jbuild | Dune
 
+let equal = (=)
+
+let hash = Hashtbl.hash
+
 let of_basename = function
   | "jbuild" -> Some Jbuild
   | "dune" -> Some Dune

--- a/src/dune_lang/syntax.mli
+++ b/src/dune_lang/syntax.mli
@@ -1,3 +1,7 @@
 type t = Jbuild | Dune
 
+val equal : t -> t -> bool
+
+val hash : t -> int
+
 val of_basename : string -> t option

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -169,6 +169,9 @@ type t =
   ; allow_approx_merlin : bool
   }
 
+let equal = (==)
+let hash = Hashtbl.hash
+
 let packages t = t.packages
 let version t = t.version
 let name t = t.name

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -47,6 +47,9 @@ val root : t -> Path.Local.t
 val stanza_parser : t -> Stanza.t list Dune_lang.Decoder.t
 val allow_approx_merlin : t -> bool
 
+val equal : t -> t -> bool
+val hash : t -> int
+
 (** Return the path of the project file. *)
 val file : t -> Path.t
 

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -201,7 +201,7 @@ module Gen(P : Install_rules.Params) = struct
     (match components with
      | ".js"  :: rest -> Js_of_ocaml_rules.setup_separate_compilation_rules
                            sctx rest
-     | "_doc" :: rest -> Lib_rules.Odoc.gen_rules rest ~dir
+     | "_doc" :: rest -> Odoc.gen_rules sctx rest ~dir
      | ".ppx"  :: rest -> Preprocessing.gen_rules sctx rest
      | comps ->
        begin match List.last comps with
@@ -245,7 +245,7 @@ module Gen(P : Install_rules.Params) = struct
 
   let init () =
     Install_rules.init ();
-    Lib_rules.Odoc.init ()
+    Odoc.init sctx
 end
 
 module type Gen = sig

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -10,8 +10,6 @@ module Mode_conf = Dune_file.Mode_conf
 module SC = Super_context
 
 module Gen (P : Install_rules.Params) = struct
-  module Odoc = Odoc.Gen(P)
-
   let sctx = P.sctx
   let ctx = SC.context sctx
 
@@ -504,7 +502,7 @@ module Gen (P : Install_rules.Params) = struct
         ~vlib_dep_graphs ~expander
     );
 
-    Odoc.setup_library_odoc_rules lib ~requires:requires_compile
+    Odoc.setup_library_odoc_rules sctx lib ~requires:requires_compile
       ~modules ~dep_graphs ~scope;
 
     let flags =

--- a/src/lib_rules.mli
+++ b/src/lib_rules.mli
@@ -2,12 +2,6 @@ open! Stdune
 open Dune_file
 
 module Gen (S : sig val sctx : Super_context.t end) : sig
-
-  module Odoc : sig
-    val init : unit -> unit
-    val gen_rules : dir:Path.t -> string list -> unit
-  end
-
   val rules
     : Library.t
     -> dir_contents:Dir_contents.t

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -41,7 +41,8 @@ let add_stanzas t ~sctx =
            }
          | _ -> t)
 
-let stanzas_to_consider_for_install stanzas ~external_lib_deps_mode =
+let stanzas_to_consider_for_install
+      (stanzas : Stanza.t list Dir_with_dune.t list) ~external_lib_deps_mode =
   if not external_lib_deps_mode then
     List.concat_map stanzas
       ~f:(fun ({ Dir_with_dune.ctx_dir =  _; data = stanzas
@@ -62,11 +63,6 @@ let stanzas_to_consider_for_install stanzas ~external_lib_deps_mode =
       ~f:(fun d ->
         List.map d.data ~f:(fun stanza ->
           { d with data = stanza}))
-
-let make_mlds sctx =
-  List.concat_map ~f:(fun (doc :  _ Dir_with_dune.t) ->
-    let dir_contents = Dir_contents.get sctx ~dir:doc.ctx_dir in
-    Dir_contents.mlds dir_contents doc.data)
 
 let of_sctx (sctx : Super_context.t) =
   let ctx = Super_context.context sctx in
@@ -121,7 +117,7 @@ let of_sctx (sctx : Super_context.t) =
         (Package.Name.Map.find stanzas_per_package pkg.name
          |> Option.value ~default:[])
     in
-    { t with mlds = lazy (make_mlds sctx t.docs) }
+    { t with mlds = lazy (Packages.mlds sctx pkg.name) }
   )
 
 let odig_files t = t.odig_files

--- a/src/odoc.boot.ml
+++ b/src/odoc.boot.ml
@@ -1,10 +1,6 @@
+let setup_library_odoc_rules _ _ ~scope:_ ~modules:_ ~requires:_
+      ~dep_graphs:_ = ()
 
-module Gen (S : sig val sctx : Super_context.t end) = struct
+let init _ = ()
 
-  let setup_library_odoc_rules _ ~scope:_ ~modules:_ ~requires:_
-        ~dep_graphs:_ = ()
-
-  let init () = ()
-
-  let gen_rules ~dir:_ _ = ()
-end
+let gen_rules _ ~dir:_ _ = ()

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -33,218 +33,222 @@ type odoc =
   ; source: source
   }
 
-module Gen (S : sig val sctx : SC.t end) = struct
-  open S
+let add_rule sctx =
+  Super_context.add_rule sctx ~dir:(Super_context.build_dir sctx)
 
-  let context = SC.context sctx
-  let stanzas = SC.stanzas sctx
+module Paths = struct
+  let root (context : Context.t) =
+    context.Context.build_dir ++ "_doc"
 
-  let add_rule = Super_context.add_rule sctx ~dir:(Super_context.build_dir sctx)
+  let odocs ctx m =
+    root ctx ++ (
+      match m with
+      | Lib lib -> sprintf "_odoc/lib/%s" (lib_unique_name lib)
+      | Pkg pkg -> sprintf "_odoc/pkg/%s" (Package.Name.to_string pkg)
+    )
 
-  module Paths = struct
-    let root = context.Context.build_dir ++ "_doc"
+  let html_root ctx = root ctx ++ "_html"
 
-    let odocs m =
-      root ++ (
-        match m with
-        | Lib lib -> sprintf "_odoc/lib/%s" (lib_unique_name lib)
-        | Pkg pkg -> sprintf "_odoc/pkg/%s" (Package.Name.to_string pkg)
-      )
+  let html ctx m =
+    html_root ctx ++ (
+      match m with
+      | Pkg pkg -> Package.Name.to_string pkg
+      | Lib lib -> pkg_or_lnu lib
+    )
 
-    let html_root = root ++ "_html"
+  let gen_mld_dir ctx pkg =
+    root ctx ++ "_mlds" ++ (Package.Name.to_string pkg)
 
-    let html m =
-      html_root ++ (
-        match m with
-        | Pkg pkg -> Package.Name.to_string pkg
-        | Lib lib -> pkg_or_lnu lib
-      )
+  let css_file ctx = html_root ctx ++ "odoc.css"
+  let highlight_pack_js ctx = html_root ctx ++ "highlight.pack.js"
 
-    let gen_mld_dir pkg =
-      root ++ "_mlds" ++ (Package.Name.to_string pkg)
-  end
+  let toplevel_index ctx = html_root ctx ++ "index.html"
+end
 
-  module Dep = struct
-    let html_alias m =
-      Build_system.Alias.doc ~dir:(Paths.html m)
+module Dep = struct
+  let html_alias ctx m =
+    Build_system.Alias.doc ~dir:(Paths.html ctx m)
 
-    let alias = Build_system.Alias.make ".odoc-all"
+  let alias = Build_system.Alias.make ".odoc-all"
 
-    let deps requires =
-      Build.of_result_map requires ~f:(fun libs ->
-        Build.path_set (
-          List.fold_left libs ~init:Path.Set.empty ~f:(fun acc (lib : Lib.t) ->
-            if Lib.is_local lib then
-              let dir = Paths.odocs (Lib lib) in
-              Path.Set.add acc (Build_system.Alias.stamp_file (alias ~dir))
-            else
-              acc)))
+  let deps ctx requires =
+    Build.of_result_map requires ~f:(fun libs ->
+      Build.path_set (
+        List.fold_left libs ~init:Path.Set.empty ~f:(fun acc (lib : Lib.t) ->
+          if Lib.is_local lib then
+            let dir = Paths.odocs ctx (Lib lib) in
+            Path.Set.add acc (Build_system.Alias.stamp_file (alias ~dir))
+          else
+            acc)))
 
-    let alias m = alias ~dir:(Paths.odocs m)
+  let alias ctx m = alias ~dir:(Paths.odocs ctx m)
 
-    (* let static_deps t lib = Build_system.Alias.dep (alias t lib) *)
+  (* let static_deps t lib = Build_system.Alias.dep (alias t lib) *)
 
-    let setup_deps m files = Build_system.Alias.add_deps (alias m) files
-  end
+  let setup_deps ctx m files = Build_system.Alias.add_deps (alias ctx m) files
+end
 
-  let odoc = lazy (
-    SC.resolve_program sctx ~dir:(Super_context.build_dir sctx) "odoc"
-      ~loc:None ~hint:"try: opam install odoc")
-  let odoc_ext = ".odoc"
+let odoc_ext = ".odoc"
 
-  module Mld : sig
-    type t
+module Mld : sig
+  type t
 
-    val create : Path.t -> t
+  val create : Path.t -> t
 
-    val odoc_file : doc_dir:Path.t -> t -> Path.t
-    val odoc_input : t -> Path.t
+  val odoc_file : doc_dir:Path.t -> t -> Path.t
+  val odoc_input : t -> Path.t
 
-  end = struct
-    type t = Path.t
+end = struct
+  type t = Path.t
 
-    let create p = p
+  let create p = p
 
-    let odoc_file ~doc_dir t =
-      let t = Filename.chop_extension (Path.basename t) in
-      Path.relative doc_dir (sprintf "page-%s%s" t odoc_ext)
+  let odoc_file ~doc_dir t =
+    let t = Filename.chop_extension (Path.basename t) in
+    Path.relative doc_dir (sprintf "page-%s%s" t odoc_ext)
 
-    let odoc_input t = t
-  end
+  let odoc_input t = t
+end
 
-  let module_deps (m : Module.t) ~doc_dir ~(dep_graphs:Dep_graph.Ml_kind.t) =
-    (if Module.has_intf m then
-       Dep_graph.deps_of dep_graphs.intf m
-     else
-       (* When a module has no .mli, use the dependencies for the .ml *)
-       Dep_graph.deps_of dep_graphs.impl m)
-    >>^ List.map ~f:(Module.odoc_file ~doc_dir)
-    |> Build.dyn_paths
+let odoc sctx =
+  SC.resolve_program sctx ~dir:(Super_context.build_dir sctx) "odoc"
+    ~loc:None ~hint:"try: opam install odoc"
 
-  let compile_module (m : Module.t) ~includes:(file_deps, iflags)
-        ~dep_graphs ~doc_dir ~pkg_or_lnu =
-    let odoc_file = Module.odoc_file m ~doc_dir in
-    add_rule
-      (file_deps
-       >>>
-       module_deps m ~doc_dir ~dep_graphs
-       >>>
-       Build.run ~dir:doc_dir (Lazy.force odoc)
-         [ A "compile"
-         ; A "-I"; Path doc_dir
-         ; iflags
-         ; As ["--pkg"; pkg_or_lnu]
-         ; A "-o"; Target odoc_file
-         ; Dep (Module.cmti_file m)
-         ]);
-    (m, odoc_file)
+let module_deps (m : Module.t) ~doc_dir ~(dep_graphs:Dep_graph.Ml_kind.t) =
+  (if Module.has_intf m then
+     Dep_graph.deps_of dep_graphs.intf m
+   else
+     (* When a module has no .mli, use the dependencies for the .ml *)
+     Dep_graph.deps_of dep_graphs.impl m)
+  >>^ List.map ~f:(Module.odoc_file ~doc_dir)
+  |> Build.dyn_paths
 
-  let compile_mld (m : Mld.t) ~includes ~doc_dir ~pkg =
-    let odoc_file = Mld.odoc_file m ~doc_dir in
-    add_rule
-      (includes
-       >>>
-       Build.run ~dir:doc_dir (Lazy.force odoc)
-         [ A "compile"
-         ; Dyn Fn.id
-         ; As ["--pkg"; Package.Name.to_string pkg]
-         ; A "-o"; Target odoc_file
-         ; Dep (Mld.odoc_input m)
-         ]);
-    odoc_file
+let compile_module sctx (m : Module.t) ~includes:(file_deps, iflags)
+      ~dep_graphs ~doc_dir ~pkg_or_lnu =
+  let odoc_file = Module.odoc_file m ~doc_dir in
+  add_rule sctx
+    (file_deps
+     >>>
+     module_deps m ~doc_dir ~dep_graphs
+     >>>
+     Build.run ~dir:doc_dir (odoc sctx)
+       [ A "compile"
+       ; A "-I"; Path doc_dir
+       ; iflags
+       ; As ["--pkg"; pkg_or_lnu]
+       ; A "-o"; Target odoc_file
+       ; Dep (Module.cmti_file m)
+       ]);
+  (m, odoc_file)
 
-  let odoc_include_flags requires =
-    Arg_spec.of_result_map requires ~f:(fun libs ->
-      let paths =
-        libs |> List.fold_left ~f:(fun paths lib ->
-          if Lib.is_local lib then (
-            Path.Set.add paths (Paths.odocs (Lib lib))
-          ) else (
-            paths
-          )
-        ) ~init:Path.Set.empty in
-      Arg_spec.S (List.concat_map (Path.Set.to_list paths)
-                    ~f:(fun dir -> [Arg_spec.A "-I"; Path dir])))
+let compile_mld sctx (m : Mld.t) ~includes ~doc_dir ~pkg =
+  let odoc_file = Mld.odoc_file m ~doc_dir in
+  add_rule sctx
+    (includes
+     >>>
+     Build.run ~dir:doc_dir (odoc sctx)
+       [ A "compile"
+       ; Dyn Fn.id
+       ; As ["--pkg"; Package.Name.to_string pkg]
+       ; A "-o"; Target odoc_file
+       ; Dep (Mld.odoc_input m)
+       ]);
+  odoc_file
 
-  let setup_html (odoc_file : odoc) ~requires =
-    let deps = Dep.deps requires in
-    let to_remove, dune_keep =
-      match odoc_file.source with
-      | Mld -> odoc_file.html_file, []
-      | Module ->
-        let dune_keep =
-          Build.create_file (odoc_file.html_dir ++ Config.dune_keep_fname) in
-        odoc_file.html_dir, [dune_keep]
-    in
-    add_rule
-      (deps
-       >>>
-       Build.progn (
-         Build.remove_tree to_remove
-         :: Build.mkdir odoc_file.html_dir
-         :: Build.run ~dir:Paths.html_root
-              (Lazy.force odoc)
-              [ A "html"
-              ; odoc_include_flags requires
-              ; A "-o"; Path Paths.html_root
-              ; Dep odoc_file.odoc_input
-              ; Hidden_targets [odoc_file.html_file]
-              ]
-         :: dune_keep))
+let odoc_include_flags ctx requires =
+  Arg_spec.of_result_map requires ~f:(fun libs ->
+    let paths =
+      libs |> List.fold_left ~f:(fun paths lib ->
+        if Lib.is_local lib then (
+          Path.Set.add paths (Paths.odocs ctx (Lib lib))
+        ) else (
+          paths
+        )
+      ) ~init:Path.Set.empty in
+    Arg_spec.S (List.concat_map (Path.Set.to_list paths)
+                  ~f:(fun dir -> [Arg_spec.A "-I"; Path dir])))
 
-  let css_file = Paths.html_root ++ "odoc.css"
-  let highlight_pack_js = Paths.html_root ++ "highlight.pack.js"
+let setup_html sctx (odoc_file : odoc) ~requires =
+  let ctx = Super_context.context sctx in
+  let deps = Dep.deps ctx requires in
+  let to_remove, dune_keep =
+    match odoc_file.source with
+    | Mld -> odoc_file.html_file, []
+    | Module ->
+      let dune_keep =
+        Build.create_file (odoc_file.html_dir ++ Config.dune_keep_fname) in
+      odoc_file.html_dir, [dune_keep]
+  in
+  add_rule sctx
+    (deps
+     >>>
+     Build.progn (
+       Build.remove_tree to_remove
+       :: Build.mkdir odoc_file.html_dir
+       :: Build.run ~dir:(Paths.html_root ctx)
+            (odoc sctx)
+            [ A "html"
+            ; odoc_include_flags ctx requires
+            ; A "-o"; Path (Paths.html_root ctx)
+            ; Dep odoc_file.odoc_input
+            ; Hidden_targets [odoc_file.html_file]
+            ]
+       :: dune_keep))
 
-  let toplevel_index = Paths.html_root ++ "index.html"
+let setup_library_odoc_rules sctx (library : Library.t) ~scope ~modules
+      ~requires ~(dep_graphs:Dep_graph.Ml_kind.t) =
+  let lib =
+    Option.value_exn (Lib.DB.find_even_when_hidden (Scope.libs scope)
+                        (Library.best_name library)) in
+  (* Using the proper package name doesn't actually work since odoc assumes
+     that a package contains only 1 library *)
+  let pkg_or_lnu = pkg_or_lnu lib in
+  let ctx = Super_context.context sctx in
+  let doc_dir = Paths.odocs ctx (Lib lib) in
+  let odoc_include_flags = odoc_include_flags ctx requires in
+  let includes = (Dep.deps ctx requires, odoc_include_flags) in
+  let modules_and_odoc_files =
+    List.map (Module.Name.Map.values modules) ~f:(
+      compile_module sctx ~includes ~dep_graphs
+        ~doc_dir ~pkg_or_lnu)
+  in
+  Dep.setup_deps ctx (Lib lib)
+    (List.map modules_and_odoc_files ~f:snd
+     |> Path.Set.of_list)
 
-  let setup_library_odoc_rules (library : Library.t) ~scope ~modules
-        ~requires ~(dep_graphs:Dep_graph.Ml_kind.t) =
-    let lib =
-      Option.value_exn (Lib.DB.find_even_when_hidden (Scope.libs scope)
-                          (Library.best_name library)) in
-    (* Using the proper package name doesn't actually work since odoc assumes
-       that a package contains only 1 library *)
-    let pkg_or_lnu = pkg_or_lnu lib in
-    let doc_dir = Paths.odocs (Lib lib) in
-    let includes = (Dep.deps requires, odoc_include_flags requires) in
-    let modules_and_odoc_files =
-      List.map (Module.Name.Map.values modules) ~f:(
-        compile_module ~includes ~dep_graphs
-          ~doc_dir ~pkg_or_lnu)
-    in
-    Dep.setup_deps (Lib lib) (List.map modules_and_odoc_files ~f:snd
-                              |> Path.Set.of_list)
+let setup_css_rule sctx =
+  let ctx = Super_context.context sctx in
+  add_rule sctx
+    (Build.run
+       ~dir:ctx.build_dir
+       (odoc sctx)
+       [ A "support-files"; A "-o"; Path (Paths.html_root ctx)
+       ; Hidden_targets [ Paths.css_file ctx
+                        ; Paths.highlight_pack_js ctx
+                        ]
+       ])
 
-  let setup_css_rule () =
-    add_rule
-      (Build.run
-         ~dir:context.build_dir
-         (Lazy.force odoc)
-         [ A "support-files"; A "-o"; Path Paths.html_root
-         ; Hidden_targets [css_file; highlight_pack_js]
-         ])
+let sp = Printf.sprintf
 
-  let sp = Printf.sprintf
-
-  let setup_toplevel_index_rule () =
-    let list_items =
-      Super_context.packages sctx
-      |> Package.Name.Map.to_list
-      |> List.filter_map ~f:(fun (name, pkg) ->
-        let name = Package.Name.to_string name in
-        let link = sp {|<a href="%s/index.html">%s</a>|} name name in
-        let version_suffix =
-          match pkg.Package.version_from_opam_file with
-          | None ->
-            ""
-          | Some v ->
-            sp {| <span class="version">%s</span>|} v
-        in
-        Some (sp "<li>%s%s</li>" link version_suffix))
-    in
-    let list_items = String.concat ~sep:"\n      " list_items in
-    let html = sp
-{|<!DOCTYPE html>
+let setup_toplevel_index_rule sctx =
+  let list_items =
+    Super_context.packages sctx
+    |> Package.Name.Map.to_list
+    |> List.filter_map ~f:(fun (name, pkg) ->
+      let name = Package.Name.to_string name in
+      let link = sp {|<a href="%s/index.html">%s</a>|} name name in
+      let version_suffix =
+        match pkg.Package.version_from_opam_file with
+        | None ->
+          ""
+        | Some v ->
+          sp {| <span class="version">%s</span>|} v
+      in
+      Some (sp "<li>%s%s</li>" link version_suffix))
+  in
+  let list_items = String.concat ~sep:"\n      " list_items in
+  let html = sp
+               {|<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>index</title>
@@ -263,329 +267,345 @@ module Gen (S : sig val sctx : SC.t end) = struct
     </main>
   </body>
 </html>|} list_items
-    in
-    add_rule (Build.write_file toplevel_index html)
+  in
+  let ctx = Super_context.context sctx in
+  add_rule sctx (Build.write_file (Paths.toplevel_index ctx) html)
 
-  let libs_of_pkg ~pkg =
-    match Package.Name.Map.find (SC.libs_by_package sctx) pkg with
-    | None -> Lib.Set.empty
-    | Some (_, libs) -> libs
+let libs_of_pkg sctx ~pkg =
+  match Package.Name.Map.find (SC.libs_by_package sctx) pkg with
+  | None -> Lib.Set.empty
+  | Some (_, libs) -> libs
 
-  let load_all_odoc_rules_pkg ~pkg =
-    let pkg_libs = libs_of_pkg ~pkg in
-    Build_system.load_dir ~dir:(Paths.odocs (Pkg pkg));
-    Lib.Set.iter pkg_libs ~f:(fun lib ->
-      Build_system.load_dir ~dir:(Paths.odocs (Lib lib)));
-    pkg_libs
+let load_all_odoc_rules_pkg sctx ~pkg =
+  let pkg_libs = libs_of_pkg sctx ~pkg in
+  let ctx = Super_context.context sctx in
+  Build_system.load_dir ~dir:(Paths.odocs ctx (Pkg pkg));
+  Lib.Set.iter pkg_libs ~f:(fun lib ->
+    Build_system.load_dir ~dir:(Paths.odocs ctx (Lib lib)));
+  pkg_libs
 
-  let create_odoc ~target odoc_input =
-    let html_base = Paths.html target in
-    match target with
-    | Lib _ ->
-      let html_dir =
-        html_base ++ (
-          Path.basename odoc_input
-          |> Filename.chop_extension
-          |> Stdune.String.capitalize
-        ) in
-      { odoc_input
-      ; html_dir
-      ; html_file = html_dir ++ "index.html"
-      ; source = Module
-      }
-    | Pkg _ ->
-      { odoc_input
-      ; html_dir = html_base
-      ; html_file = html_base ++ sprintf "%s.html" (
-          Path.basename odoc_input
-          |> Filename.chop_extension
-          |> String.drop_prefix ~prefix:"page-"
-          |> Option.value_exn
-        )
-      ; source = Mld
-      }
-
-  let static_html = [ css_file; highlight_pack_js; toplevel_index ]
-
-  let odocs =
-    let odoc_glob =
-      Re.compile (Re.seq [Re.(rep1 any) ; Re.str ".odoc" ; Re.eos]) in
-    fun target ->
-      let dir = Paths.odocs target in
-      Build_system.eval_glob ~dir odoc_glob
-      |> List.map ~f:(fun d -> create_odoc (Path.relative dir d) ~target)
-
-  let setup_lib_html_rules =
-    let loaded = ref Lib.Set.empty in
-    fun lib ~requires ->
-      if not (Lib.Set.mem !loaded lib) then begin
-        loaded := Lib.Set.add !loaded lib;
-        let odocs = odocs (Lib lib) in
-        List.iter odocs ~f:(setup_html ~requires);
-        let html_files = List.map ~f:(fun o -> o.html_file) odocs in
-        Build_system.Alias.add_deps (Dep.html_alias (Lib lib))
-          (Path.Set.of_list (List.rev_append static_html html_files));
-      end
-
-  let setup_pkg_html_rules_def =
-    let module Input = struct
-      type t = Package.Name.t * Lib.t list
-
-      let equal (p1, l1) (p2, l2) =
-        Package.Name.equal p1 p2
-        && List.equal Lib.equal l1 l2
-
-      let hash (p, ls) =
-        Hashtbl.hash (Package.Name.hash p, List.hash Lib.hash ls)
-
-      let to_sexp (package, libs) =
-        let open Dyn in
-        Tuple
-          [ Package.Name.to_dyn package
-          ; List (List.map ~f:Lib.to_dyn libs)
-          ]
-        |> Dyn.to_sexp
-    end
-    in
-    Memo.create "setup-package-html-rules"
-      ~output:(Allow_cutoff (module Unit))
-      ~doc:"setup odoc package html rules"
-      ~input:(module Input)
-      ~visibility:Hidden
-      Sync
-      None
-
-  let () =
-    let setup_pkg_html_rules (pkg, libs) =
-      let requires = Lib.closure libs ~linking:false in
-      List.iter libs ~f:(setup_lib_html_rules ~requires);
-      let pkg_odocs = odocs (Pkg pkg) in
-      List.iter pkg_odocs ~f:(setup_html ~requires);
-      let odocs =
-        List.concat (
-          pkg_odocs
-          :: (List.map libs ~f:(fun lib -> odocs (Lib lib)))
-        ) in
-      let html_files = List.map ~f:(fun o -> o.html_file) odocs in
-      Build_system.Alias.add_deps (Dep.html_alias (Pkg pkg))
-        (Path.Set.of_list (List.rev_append static_html html_files))
-    in
-    Memo.set_impl setup_pkg_html_rules_def setup_pkg_html_rules
-
-
-  let setup_pkg_html_rules ~pkg ~libs =
-    Memo.exec setup_pkg_html_rules_def (pkg, libs)
-
-  let gen_rules ~dir:_ rest =
-    match rest with
-    | ["_html"] ->
-      setup_css_rule ();
-      setup_toplevel_index_rule ()
-    | "_mlds" :: _pkg :: _
-    | "_odoc" :: "pkg" :: _pkg :: _ ->
-      () (* rules were already setup lazily in gen_rules *)
-    | "_odoc" :: "lib" :: lib :: _ ->
-      let lib, lib_db = SC.Scope_key.of_string sctx lib in
-      let lib = Lib_name.of_string_exn ~loc:None lib in
-      begin match Lib.DB.find lib_db lib with
-      | Error _ -> ()
-      | Ok lib  -> Build_system.load_dir ~dir:(Lib.src_dir lib)
-      end
-    | "_html" :: lib_unique_name_or_pkg :: _ ->
-      (* TODO we can be a better with the error handling in the case where
-         lib_unique_name_or_pkg is neither a valid pkg or lnu *)
-      let lib, lib_db = SC.Scope_key.of_string sctx lib_unique_name_or_pkg in
-      let lib = Lib_name.of_string_exn ~loc:None lib in
-      let setup_pkg_html_rules pkg =
-        setup_pkg_html_rules ~pkg ~libs:(
-          Lib.Set.to_list (load_all_odoc_rules_pkg ~pkg)) in
-      begin match Lib.DB.find lib_db lib with
-      | Error _ -> ()
-      | Ok lib ->
-        begin match Lib.package lib with
-        | None ->
-          setup_lib_html_rules lib ~requires:(Lib.closure ~linking:false [lib])
-        | Some pkg ->
-          setup_pkg_html_rules pkg
-        end
-      end;
-      Option.iter
-        (Package.Name.Map.find (SC.packages sctx)
-           (Package.Name.of_string lib_unique_name_or_pkg))
-        ~f:(fun pkg -> setup_pkg_html_rules pkg.name)
-    | _ -> ()
-
-  let setup_package_aliases (pkg : Package.t) =
-    let alias =
-      Build_system.Alias.doc ~dir:(
-        Path.append context.build_dir pkg.Package.path
+let create_odoc ctx ~target odoc_input =
+  let html_base = Paths.html ctx target in
+  match target with
+  | Lib _ ->
+    let html_dir =
+      html_base ++ (
+        Path.basename odoc_input
+        |> Filename.chop_extension
+        |> Stdune.String.capitalize
       ) in
-    Build_system.Alias.add_deps alias (
-      Dep.html_alias (Pkg pkg.name)
-      :: (libs_of_pkg ~pkg:pkg.name
-          |> Lib.Set.to_list
-          |> List.map ~f:(fun lib -> Dep.html_alias (Lib lib)))
-      |> List.map ~f:Build_system.Alias.stamp_file
-      |> Path.Set.of_list
-    )
-
-  let entry_modules_by_lib lib =
-    Dir_contents.get sctx ~dir:(Lib.src_dir lib)
-    |> Dir_contents.modules_of_library ~name:(Lib.name lib)
-    |> Lib_modules.entry_modules
-
-  let entry_modules ~pkg =
-    libs_of_pkg ~pkg
-    |> Lib.Set.to_list
-    |> List.filter_map ~f:(fun l ->
-      if Lib.is_local l then (
-        Some (l, entry_modules_by_lib l)
-      ) else (
-        None
-      ))
-    |> Lib.Map.of_list_exn
-
-  let default_index ~pkg entry_modules =
-    let b = Buffer.create 512 in
-    Printf.bprintf b "{0 %s index}\n"
-      (Package.Name.to_string pkg);
-    Lib.Map.to_list entry_modules
-    |> List.sort ~compare:(fun (x, _) (y, _) ->
-      Lib_name.compare (Lib.name x) (Lib.name y))
-    |> List.iter ~f:(fun (lib, modules) ->
-      Printf.bprintf b "{1 Library %s}\n" (Lib_name.to_string (Lib.name lib));
-      Buffer.add_string b (
-        match modules with
-        | [ x ] ->
-          sprintf
-            "The entry point of this library is the module:\n{!module-%s}.\n"
-            (Module.Name.to_string (Module.name x))
-        | _ ->
-          sprintf
-            "This library exposes the following toplevel modules:\n\
-             {!modules:%s}\n"
-            (modules
-             |> List.sort ~compare:(fun x y ->
-               Module.Name.compare (Module.name x) (Module.name y))
-             |> List.map ~f:(fun m -> Module.Name.to_string (Module.name m))
-             |> String.concat ~sep:" ")
-      );
-    );
-    Buffer.contents b
-
-  let check_mlds_no_dupes ~pkg ~mlds =
-    match
-      List.map mlds ~f:(fun mld ->
-        (Filename.chop_extension (Path.basename mld), mld))
-      |> String.Map.of_list
-    with
-    | Ok m -> m
-    | Error (_, p1, p2) ->
-      die "Package %s has two mld's with the same basename %s, %s"
-        (Package.Name.to_string pkg)
-        (Path.to_string_maybe_quoted p1)
-        (Path.to_string_maybe_quoted p2)
-
-  let setup_package_odoc_rules_def =
-    let module Input = struct
-      type t = Package.Name.t * Path.t list
-
-      let hash (p, ps) =
-        Hashtbl.hash (Package.Name.hash p, List.hash Path.hash ps)
-
-      let equal (x1, y1) (x2, y2) =
-        Package.Name.equal x1 x2 && List.equal Path.equal y1 y2
-
-      let to_sexp (name, paths) =
-        Dyn.Tuple
-          [ Package.Name.to_dyn name
-          ; Dyn.List (List.map ~f:Path.to_dyn paths)
-          ]
-        |> Dyn.to_sexp
-    end
-    in
-    Memo.create "setup-package-odoc-rules"
-      ~output:(Allow_cutoff (module Unit))
-      ~doc:"setup odoc package rules"
-      ~input:(module Input)
-      ~visibility:Hidden
-      Sync
-      None
-
-  let () =
-    let setup_package_odoc_rules (pkg, mlds) =
-      let mlds = check_mlds_no_dupes ~pkg ~mlds in
-      let mlds =
-        if String.Map.mem mlds "index" then
-          mlds
-        else
-          let entry_modules = entry_modules ~pkg in
-          let gen_mld = Paths.gen_mld_dir pkg ++ "index.mld" in
-          add_rule (Build.write_file gen_mld (default_index ~pkg entry_modules));
-          String.Map.add mlds "index" gen_mld in
-      let odocs = List.map (String.Map.values mlds) ~f:(fun mld ->
-        compile_mld
-          (Mld.create mld)
-          ~pkg
-          ~doc_dir:(Paths.odocs (Pkg pkg))
-          ~includes:(Build.arr (fun _ -> Arg_spec.As []))
-      ) in
-      Dep.setup_deps (Pkg pkg) (Path.Set.of_list odocs)
-    in
-    Memo.set_impl setup_package_odoc_rules_def setup_package_odoc_rules
-
-  let setup_package_odoc_rules ~pkg ~mlds =
-    Memo.exec setup_package_odoc_rules_def (pkg, mlds)
-
-  let init () =
-    let mlds_by_package =
-      let map = lazy (
-        stanzas
-        |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
-          List.filter_map w.data ~f:(function
-            | Documentation d ->
-              let dc = Dir_contents.get sctx ~dir:w.ctx_dir in
-              let mlds = Dir_contents.mlds dc d in
-              Some (d.package.name, mlds)
-            | _ ->
-              None
-          ))
-        |> Package.Name.Map.of_list_reduce ~f:List.rev_append
-      ) in
-      fun (p : Package.t) ->
-        Option.value (Package.Name.Map.find (Lazy.force map) p.name) ~default:[]
-    in
-    SC.packages sctx
-    |> Package.Name.Map.iter ~f:(fun (pkg : Package.t) ->
-      List.iter [ Paths.odocs (Pkg pkg.name)
-                ; Paths.gen_mld_dir pkg.name ]
-        ~f:(fun dir ->
-          Build_system.on_load_dir ~dir ~f:(fun () ->
-            setup_package_odoc_rules ~pkg:pkg.name ~mlds:(mlds_by_package pkg)
-          ));
-      (* setup @doc to build the correct html for the package *)
-      setup_package_aliases pkg;
-    );
-    Build_system.Alias.add_deps
-      (Build_system.Alias.private_doc ~dir:context.build_dir)
-      (stanzas
-       |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
-         List.filter_map w.data ~f:(function
-           | Dune_file.Library (l : Dune_file.Library.t) ->
-             begin match l.public with
-             | Some _ -> None
-             | None ->
-               let scope = SC.find_scope_by_dir sctx w.ctx_dir in
-               Some (Option.value_exn (
-                 Lib.DB.find_even_when_hidden (Scope.libs scope)
-                   (Library.best_name l))
-               )
-             end
-           | _ -> None
-         ))
-       |> List.map ~f:(fun (lib : Lib.t) ->
-         Build_system.Alias.stamp_file (Dep.html_alias (Lib lib)))
-       |> Path.Set.of_list
+    { odoc_input
+    ; html_dir
+    ; html_file = html_dir ++ "index.html"
+    ; source = Module
+    }
+  | Pkg _ ->
+    { odoc_input
+    ; html_dir = html_base
+    ; html_file = html_base ++ sprintf "%s.html" (
+        Path.basename odoc_input
+        |> Filename.chop_extension
+        |> String.drop_prefix ~prefix:"page-"
+        |> Option.value_exn
       )
+    ; source = Mld
+    }
 
-end
+let static_html ctx =
+  let open Paths in
+  [ css_file ctx
+  ; highlight_pack_js ctx
+  ; toplevel_index ctx
+  ]
+
+let odocs =
+  let odoc_glob =
+    Re.compile (Re.seq [Re.(rep1 any) ; Re.str ".odoc" ; Re.eos]) in
+  fun ctx target ->
+    let dir = Paths.odocs ctx target in
+    Build_system.eval_glob ~dir odoc_glob
+    |> List.map ~f:(fun d -> create_odoc ctx (Path.relative dir d) ~target)
+
+let setup_lib_html_rules =
+  let loaded = ref Lib.Set.empty in
+  fun sctx lib ~requires ->
+    if not (Lib.Set.mem !loaded lib) then begin
+      loaded := Lib.Set.add !loaded lib;
+      let ctx = Super_context.context sctx in
+      let odocs = odocs ctx (Lib lib) in
+      List.iter odocs ~f:(setup_html sctx ~requires);
+      let html_files = List.map ~f:(fun o -> o.html_file) odocs in
+      let static_html = static_html ctx in
+      Build_system.Alias.add_deps (Dep.html_alias ctx (Lib lib))
+        (Path.Set.of_list (List.rev_append static_html html_files));
+    end
+
+let setup_pkg_html_rules_def =
+  let module Input = struct
+    type t = Super_context.t * Package.Name.t * Lib.t list
+
+    let equal (_, p1, l1) (_, p2, l2) =
+      Package.Name.equal p1 p2
+      && List.equal Lib.equal l1 l2
+
+    let hash (_, p, ls) =
+      Hashtbl.hash (Package.Name.hash p, List.hash Lib.hash ls)
+
+    let to_sexp (_, package, libs) =
+      let open Dyn in
+      Tuple
+        [ Package.Name.to_dyn package
+        ; List (List.map ~f:Lib.to_dyn libs)
+        ]
+      |> Dyn.to_sexp
+  end
+  in
+  Memo.create "setup-package-html-rules"
+    ~output:(Allow_cutoff (module Unit))
+    ~doc:"setup odoc package html rules"
+    ~input:(module Input)
+    ~visibility:Hidden
+    Sync
+    None
+
+let () =
+  let setup_pkg_html_rules (sctx, pkg, libs) =
+    let requires = Lib.closure libs ~linking:false in
+    let ctx = Super_context.context sctx in
+    List.iter libs ~f:(setup_lib_html_rules sctx ~requires);
+    let pkg_odocs = odocs ctx (Pkg pkg) in
+    List.iter pkg_odocs ~f:(setup_html sctx ~requires);
+    let odocs =
+      List.concat (
+        pkg_odocs
+        :: (List.map libs ~f:(fun lib -> odocs ctx (Lib lib)))
+      ) in
+    let html_files = List.map ~f:(fun o -> o.html_file) odocs in
+    let static_html = static_html ctx in
+    Build_system.Alias.add_deps (Dep.html_alias ctx (Pkg pkg))
+      (Path.Set.of_list (List.rev_append static_html html_files))
+  in
+  Memo.set_impl setup_pkg_html_rules_def setup_pkg_html_rules
+
+
+let setup_pkg_html_rules sctx ~pkg ~libs =
+  Memo.exec setup_pkg_html_rules_def (sctx, pkg, libs)
+
+let gen_rules sctx ~dir:_ rest =
+  match rest with
+  | ["_html"] ->
+    setup_css_rule sctx;
+    setup_toplevel_index_rule sctx
+  | "_mlds" :: _pkg :: _
+  | "_odoc" :: "pkg" :: _pkg :: _ ->
+    () (* rules were already setup lazily in gen_rules *)
+  | "_odoc" :: "lib" :: lib :: _ ->
+    let lib, lib_db = SC.Scope_key.of_string sctx lib in
+    let lib = Lib_name.of_string_exn ~loc:None lib in
+    begin match Lib.DB.find lib_db lib with
+    | Error _ -> ()
+    | Ok lib  -> Build_system.load_dir ~dir:(Lib.src_dir lib)
+    end
+  | "_html" :: lib_unique_name_or_pkg :: _ ->
+    (* TODO we can be a better with the error handling in the case where
+       lib_unique_name_or_pkg is neither a valid pkg or lnu *)
+    let lib, lib_db = SC.Scope_key.of_string sctx lib_unique_name_or_pkg in
+    let lib = Lib_name.of_string_exn ~loc:None lib in
+    let setup_pkg_html_rules pkg =
+      setup_pkg_html_rules sctx ~pkg ~libs:(
+        Lib.Set.to_list (load_all_odoc_rules_pkg sctx ~pkg)) in
+    begin match Lib.DB.find lib_db lib with
+    | Error _ -> ()
+    | Ok lib ->
+      begin match Lib.package lib with
+      | None ->
+        setup_lib_html_rules sctx
+          lib ~requires:(Lib.closure ~linking:false [lib])
+      | Some pkg ->
+        setup_pkg_html_rules pkg
+      end
+    end;
+    Option.iter
+      (Package.Name.Map.find (SC.packages sctx)
+         (Package.Name.of_string lib_unique_name_or_pkg))
+      ~f:(fun pkg -> setup_pkg_html_rules pkg.name)
+  | _ -> ()
+
+let setup_package_aliases sctx (pkg : Package.t) =
+  let ctx = Super_context.context sctx in
+  let alias =
+    Build_system.Alias.doc ~dir:(
+      Path.append ctx.build_dir pkg.Package.path
+    ) in
+  Build_system.Alias.add_deps alias (
+    Dep.html_alias ctx (Pkg pkg.name)
+    :: (libs_of_pkg sctx ~pkg:pkg.name
+        |> Lib.Set.to_list
+        |> List.map ~f:(fun lib -> Dep.html_alias ctx (Lib lib)))
+    |> List.map ~f:Build_system.Alias.stamp_file
+    |> Path.Set.of_list
+  )
+
+let entry_modules_by_lib sctx lib =
+  Dir_contents.get sctx ~dir:(Lib.src_dir lib)
+  |> Dir_contents.modules_of_library ~name:(Lib.name lib)
+  |> Lib_modules.entry_modules
+
+let entry_modules sctx ~pkg =
+  libs_of_pkg sctx ~pkg
+  |> Lib.Set.to_list
+  |> List.filter_map ~f:(fun l ->
+    if Lib.is_local l then (
+      Some (l, entry_modules_by_lib sctx l)
+    ) else (
+      None
+    ))
+  |> Lib.Map.of_list_exn
+
+let default_index ~pkg entry_modules =
+  let b = Buffer.create 512 in
+  Printf.bprintf b "{0 %s index}\n"
+    (Package.Name.to_string pkg);
+  Lib.Map.to_list entry_modules
+  |> List.sort ~compare:(fun (x, _) (y, _) ->
+    Lib_name.compare (Lib.name x) (Lib.name y))
+  |> List.iter ~f:(fun (lib, modules) ->
+    Printf.bprintf b "{1 Library %s}\n" (Lib_name.to_string (Lib.name lib));
+    Buffer.add_string b (
+      match modules with
+      | [ x ] ->
+        sprintf
+          "The entry point of this library is the module:\n{!module-%s}.\n"
+          (Module.Name.to_string (Module.name x))
+      | _ ->
+        sprintf
+          "This library exposes the following toplevel modules:\n\
+           {!modules:%s}\n"
+          (modules
+           |> List.sort ~compare:(fun x y ->
+             Module.Name.compare (Module.name x) (Module.name y))
+           |> List.map ~f:(fun m -> Module.Name.to_string (Module.name m))
+           |> String.concat ~sep:" ")
+    );
+  );
+  Buffer.contents b
+
+let check_mlds_no_dupes ~pkg ~mlds =
+  match
+    List.map mlds ~f:(fun mld ->
+      (Filename.chop_extension (Path.basename mld), mld))
+    |> String.Map.of_list
+  with
+  | Ok m -> m
+  | Error (_, p1, p2) ->
+    die "Package %s has two mld's with the same basename %s, %s"
+      (Package.Name.to_string pkg)
+      (Path.to_string_maybe_quoted p1)
+      (Path.to_string_maybe_quoted p2)
+
+let setup_package_odoc_rules_def =
+  let module Input = struct
+    type t = Super_context.t * Package.Name.t * Path.t list
+
+    let hash (_, p, ps) =
+      Hashtbl.hash (Package.Name.hash p, List.hash Path.hash ps)
+
+    let equal (_, x1, y1) (_, x2, y2) =
+      Package.Name.equal x1 x2 && List.equal Path.equal y1 y2
+
+    let to_sexp (_, name, paths) =
+      Dyn.Tuple
+        [ Package.Name.to_dyn name
+        ; Dyn.List (List.map ~f:Path.to_dyn paths)
+        ]
+      |> Dyn.to_sexp
+  end
+  in
+  Memo.create "setup-package-odoc-rules"
+    ~output:(Allow_cutoff (module Unit))
+    ~doc:"setup odoc package rules"
+    ~input:(module Input)
+    ~visibility:Hidden
+    Sync
+    None
+
+let () =
+  let setup_package_odoc_rules (sctx, pkg, mlds) =
+    let mlds = check_mlds_no_dupes ~pkg ~mlds in
+    let ctx = Super_context.context sctx in
+    let mlds =
+      if String.Map.mem mlds "index" then
+        mlds
+      else
+        let entry_modules = entry_modules ~pkg in
+        let gen_mld = Paths.gen_mld_dir ctx pkg ++ "index.mld" in
+        let entry_modules = entry_modules sctx in
+        add_rule sctx
+          (Build.write_file gen_mld (default_index ~pkg entry_modules));
+        String.Map.add mlds "index" gen_mld in
+    let odocs = List.map (String.Map.values mlds) ~f:(fun mld ->
+      compile_mld sctx
+        (Mld.create mld)
+        ~pkg
+        ~doc_dir:(Paths.odocs ctx (Pkg pkg))
+        ~includes:(Build.arr (fun _ -> Arg_spec.As []))
+    ) in
+    Dep.setup_deps ctx (Pkg pkg) (Path.Set.of_list odocs)
+  in
+  Memo.set_impl setup_package_odoc_rules_def setup_package_odoc_rules
+
+let setup_package_odoc_rules sctx ~pkg ~mlds =
+  Memo.exec setup_package_odoc_rules_def (sctx, pkg, mlds)
+
+let init sctx =
+  let stanzas = SC.stanzas sctx in
+  let mlds_by_package =
+    let map = lazy (
+      stanzas
+      |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
+        List.filter_map w.data ~f:(function
+          | Documentation d ->
+            let dc = Dir_contents.get sctx ~dir:w.ctx_dir in
+            let mlds = Dir_contents.mlds dc d in
+            Some (d.package.name, mlds)
+          | _ ->
+            None
+        ))
+      |> Package.Name.Map.of_list_reduce ~f:List.rev_append
+    ) in
+    fun (p : Package.t) ->
+      Option.value (Package.Name.Map.find (Lazy.force map) p.name) ~default:[]
+  in
+  let ctx = Super_context.context sctx in
+  SC.packages sctx
+  |> Package.Name.Map.iter ~f:(fun (pkg : Package.t) ->
+    List.iter [ Paths.odocs ctx (Pkg pkg.name)
+              ; Paths.gen_mld_dir ctx pkg.name ]
+      ~f:(fun dir ->
+        Build_system.on_load_dir ~dir ~f:(fun () ->
+          setup_package_odoc_rules sctx ~pkg:pkg.name ~mlds:(mlds_by_package pkg)
+        ));
+    (* setup @doc to build the correct html for the package *)
+    setup_package_aliases sctx pkg;
+  );
+  Build_system.Alias.add_deps
+    (Build_system.Alias.private_doc ~dir:ctx.build_dir)
+    (stanzas
+     |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
+       List.filter_map w.data ~f:(function
+         | Dune_file.Library (l : Dune_file.Library.t) ->
+           begin match l.public with
+           | Some _ -> None
+           | None ->
+             let scope = SC.find_scope_by_dir sctx w.ctx_dir in
+             Some (Option.value_exn (
+               Lib.DB.find_even_when_hidden (Scope.libs scope)
+                 (Library.best_name l))
+             )
+           end
+         | _ -> None
+       ))
+     |> List.map ~f:(fun (lib : Lib.t) ->
+       Build_system.Alias.stamp_file (Dep.html_alias ctx (Lib lib)))
+     |> Path.Set.of_list
+    )

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -4,17 +4,15 @@ open! Stdune
 open Import
 open Dune_file
 
-module Gen (S : sig val sctx : Super_context.t end) : sig
+val setup_library_odoc_rules
+  :  Super_context.t
+  -> Library.t
+  -> scope:Scope.t
+  -> modules:Module.t Module.Name.Map.t
+  -> requires:Lib.t list Or_exn.t
+  -> dep_graphs:Dep_graph.Ml_kind.t
+  -> unit
 
-  val setup_library_odoc_rules
-    :  Library.t
-    -> scope:Scope.t
-    -> modules:Module.t Module.Name.Map.t
-    -> requires:Lib.t list Or_exn.t
-    -> dep_graphs:Dep_graph.Ml_kind.t
-    -> unit
+val init : Super_context.t -> unit
 
-  val init : unit -> unit
-
-  val gen_rules : dir:Path.t -> string list -> unit
-end
+val gen_rules : Super_context.t -> dir:Path.t -> string list -> unit

--- a/src/packages.ml
+++ b/src/packages.ml
@@ -1,0 +1,44 @@
+open! Stdune
+open Import
+open Dune_file
+
+let mlds_by_package_def =
+  let module Output = struct
+    type t = Path.t list Package.Name.Map.t
+
+    let equal = Package.Name.Map.equal ~equal:(List.equal Path.equal)
+
+    let to_sexp _ = Sexp.Encoder.string "opaque"
+  end
+  in
+  Memo.create "mlds by package"
+    ~doc:"mlds by package"
+    ~input:(module Super_context)
+    ~output:(Allow_cutoff (module Output))
+    ~visibility:Hidden
+    Sync
+    None
+
+let () =
+  let mlds_by_package sctx =
+    let stanzas = Super_context.stanzas sctx in
+    stanzas
+    |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
+      List.filter_map w.data ~f:(function
+        | Documentation d ->
+          let dc = Dir_contents.get sctx ~dir:w.ctx_dir in
+          let mlds = Dir_contents.mlds dc d in
+          Some (d.package.name, mlds)
+        | _ ->
+          None
+      ))
+    |> Package.Name.Map.of_list_reduce ~f:List.rev_append
+  in
+  Memo.set_impl mlds_by_package_def mlds_by_package
+
+let mlds_by_package = Memo.exec mlds_by_package_def
+
+(* TODO memoize this so that we can cutoff at the package *)
+let mlds sctx pkg =
+  Package.Name.Map.find (mlds_by_package sctx) pkg
+  |> Option.value ~default:[]

--- a/src/packages.mli
+++ b/src/packages.mli
@@ -1,0 +1,6 @@
+(** Collect functions keyed by a package *)
+(* TODO : for now these take the super context, but eventually this should be
+   more fine grained *)
+open Stdune
+
+val mlds : Super_context.t -> Package.Name.t -> Path.t list

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -63,3 +63,6 @@ include
   end) : (sig
      val raise_with_backtrace: exn -> Printexc.raw_backtrace -> _
    end))
+
+let equal = (=)
+let hash = Dune_caml.Hashtbl.hash

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -35,3 +35,7 @@ val protectx : 'a -> f:('a -> 'b) -> finally:('a -> unit) -> 'b
 val pp_uncaught : backtrace:string -> Format.formatter -> t -> unit
 
 val raise_with_backtrace: exn -> Printexc.raw_backtrace -> _
+
+val equal : t -> t -> bool
+
+val hash : t -> int

--- a/src/stdune/or_exn.ml
+++ b/src/stdune/or_exn.ml
@@ -1,1 +1,4 @@
 type 'a t = ('a, exn) Result.t
+
+let equal eq x y = Result.equal eq Exn.equal x y
+let hash h = Result.hash h Exn.hash

--- a/src/stdune/or_exn.mli
+++ b/src/stdune/or_exn.mli
@@ -1,3 +1,7 @@
 (** Either a value or an exception *)
 
 type 'a t = ('a, exn) Result.t
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val hash : ('a -> int) -> 'a t -> int

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -97,3 +97,20 @@ module List = struct
       f init x >>= fun init ->
       fold_left xs ~f ~init
 end
+
+let hash h1 h2 t =
+  Dune_caml.Hashtbl.hash (
+    match t with
+    | Ok s -> h1 s
+    | Error e -> h2 e)
+
+let equal e1 e2 x y =
+  match x, y with
+  | Ok x, Ok y -> e1 x y
+  | Error x, Error y -> e2 x y
+  | _, _ -> false
+
+let iter t ~f =
+  match t with
+  | Error _ -> ()
+  | Ok s -> f s

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -13,6 +13,15 @@ val ok_exn : ('a, exn) t -> 'a
 
 val try_with : (unit -> 'a) -> ('a, exn) t
 
+val equal
+  :  ('a -> 'a -> bool)
+  -> ('b -> 'b -> bool)
+  -> ('a, 'b) t
+  -> ('a, 'b) t
+  -> bool
+
+val hash : ('a -> int) -> ('b -> int) -> ('a, 'b) t -> int
+
 module O : sig
   val ( >>| ) : ('a, 'error) t -> ('a -> 'b) -> ('b, 'error) t
   val ( >>= ) : ('a, 'error) t -> ('a -> ('b, 'error) t) -> ('b, 'error) t
@@ -30,6 +39,8 @@ val to_option : ('a, 'error) t -> 'a option
 
 (** Produce [Error <message>] *)
 val errorf : ('a, unit, string, (_, string) t) format4 -> 'a
+
+val iter : ('a, _) t -> f:('a -> unit) -> unit
 
 (** For compatibility with some other code *)
 type ('a, 'error) result = ('a, 'error) t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -39,6 +39,10 @@ let build_dir t = t.context.build_dir
 let profile t = t.context.profile
 let external_lib_deps_mode t = t.external_lib_deps_mode
 
+let equal x y = Context.equal x.context y.context
+let hash t = Context.hash t.context
+let to_sexp t = Context.to_sexp t.context
+
 let host t = Option.value t.host ~default:t
 
 let internal_lib_names t =

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -11,6 +11,11 @@ open Dune_file
 
 type t
 
+val equal : t -> t -> bool
+val hash : t -> int
+
+val to_sexp : t -> Sexp.t
+
 val create
   :  context:Context.t
   -> ?host:t

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -15,11 +15,15 @@ module Version = struct
 
   module Infix = Comparable.Operators(T)
 
+  let equal = Infix.equal
+
   let to_string (a, b) = sprintf "%u.%u" a b
 
   let pp fmt t = Format.fprintf fmt "%s" (to_string t)
 
   let to_sexp t = Sexp.Atom (to_string t)
+
+  let hash = Hashtbl.hash
 
   let encode t = Dune_lang.Encoder.string (to_string t)
 

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -12,6 +12,10 @@ module Version : sig
 
   include Dune_lang.Conv with type t := t
 
+  val hash : t -> int
+
+  val equal : t -> t -> bool
+
   val to_sexp : t Sexp.Encoder.t
 
   val to_string : t -> string


### PR DESCRIPTION
So far, I've mechanically removed the functor. The memoized functions now include & ignore a `Super_context.t` argument. This works for now but later we'll need to fix this properly.