### PR TITLE
Watch mode: display red/green status in colors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ unreleased
   different preprocessing specifications. This warning can now be disabled with
   `allow_approx_merlin` (#1947, fix #1946, @rgrinberg)
 
+- Watch mode: display "Success" in green and "Had errors" in red (#1956,
+  @emillon)
+
 1.8.2 (10/03/2019)
 ------------------
 

--- a/src/colors.ml
+++ b/src/colors.ml
@@ -114,6 +114,10 @@ let setup_err_formatter_colors () =
 
 let output_filename : styles = [Bold; Fg Green]
 
+let command_success : styles = [Bold; Fg Green]
+
+let command_error : styles = [Bold; Fg Red]
+
 module Render = Pp.Renderer.Make(struct
     type t = Style.t
 

--- a/src/colors.mli
+++ b/src/colors.mli
@@ -18,6 +18,10 @@ type styles
 
 val output_filename : styles
 
+val command_success : styles
+
+val command_error : styles
+
 val apply_string : styles -> string -> string
 
 module Style : sig

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -754,11 +754,11 @@ let poll ?log ?config ~once ~finally () =
     finally ();
     match res with
     | Ok () ->
-      wait "Success" |> after_wait
+      wait (Colors.apply_string Colors.command_success "Success") |> after_wait
     | Error Got_signal ->
       (Already_reported, None)
     | Error Never ->
-      wait "Had errors" |> after_wait
+      wait (Colors.apply_string Colors.command_error "Had errors") |> after_wait
     | Error Files_changed ->
       loop ()
     | Error (Exn (exn, bt)) -> (exn, Some bt)


### PR DESCRIPTION
When the screen is crowded, it can be a bit tricky to determine if that last command succeeded or not.

This displays "Success" in green and "Had errors" in red, making this a bit faster to understand.

I'm not too sure about the colors API - let me know if this would be better using `Colors.Render` (it seems that some refactoring would be necessary to use a formatter there).