### PR TITLE
Add Build.Alias

### DIFF
--- a/src/alias.ml
+++ b/src/alias.ml
@@ -1,0 +1,99 @@
+open! Stdune
+open Import
+
+module T : sig
+  type t = private
+    { dir : Path.t
+    ; name : string
+    }
+  val make : string -> dir:Path.t -> t
+  val of_user_written_path : loc:Loc.t -> Path.t -> t
+end = struct
+  type t =
+    { dir : Path.t
+    ; name : string
+    }
+
+  let make name ~dir =
+    if not (Path.is_in_build_dir dir) || String.contains name '/' then
+      Exn.code_error "Alias0.make: Invalid alias"
+        [ "name", Sexp.Encoder.string name
+        ; "dir", Path.to_sexp dir
+        ];
+    { dir; name }
+
+  let of_user_written_path ~loc path =
+    if not (Path.is_in_build_dir path) then
+      Errors.fail loc "Invalid alias!\n\
+                       Tried to reference path outside build dir: %S"
+        (Path.to_string_maybe_quoted path);
+    { dir = Path.parent_exn path
+    ; name = Path.basename path
+    }
+end
+include T
+
+let compare x y =
+  match String.compare x.name y.name with
+  | Lt | Gt as x -> x
+  | Eq -> Path.compare x.dir y.dir
+
+let equal x y = compare x y = Eq
+
+let hash { dir ; name } =
+  Hashtbl.hash (Path.hash dir, String.hash name)
+
+let pp fmt t = Path.pp fmt (Path.relative t.dir t.name)
+
+let to_dyn { dir ; name } =
+  let open Dyn in
+  Record
+    [ "dir", Path.to_dyn dir
+    ; "name", String name
+    ]
+
+let to_sexp t = Dyn.to_sexp (to_dyn t)
+
+let suffix = "-" ^ String.make 32 '0'
+
+let name t = t.name
+let dir  t = t.dir
+
+let fully_qualified_name t = Path.relative t.dir t.name
+
+let stamp_file t =
+  Path.relative (Path.insert_after_build_dir_exn t.dir ".aliases")
+    (t.name ^ suffix)
+
+let find_dir_specified_on_command_line ~dir ~file_tree =
+  match File_tree.find_dir file_tree dir with
+  | None ->
+    die "From the command line:\n\
+         @{<error>Error@}: Don't know about directory %s!"
+      (Path.to_string_maybe_quoted dir)
+  | Some dir -> dir
+
+let standard_aliases = Hashtbl.create 7
+
+let is_standard name = Hashtbl.mem standard_aliases name
+
+let make_standard name =
+  Hashtbl.add standard_aliases name ();
+  make name
+
+let default     = make_standard "default"
+let runtest     = make_standard "runtest"
+let install     = make_standard "install"
+let doc         = make_standard "doc"
+let private_doc = make_standard "doc-private"
+let lint        = make_standard "lint"
+let all         = make_standard "all"
+let check       = make_standard "check"
+let fmt         = make_standard "fmt"
+
+let encode { dir ; name } =
+  let open Dune_lang.Encoder in
+  record
+    [ "dir", Path_dune_lang.encode dir
+    ; "name", string name
+    ]

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -1,0 +1,53 @@
+open Stdune
+
+type t
+
+val equal : t -> t -> bool
+
+val hash : t -> int
+
+val compare : t -> t -> Ordering.t
+
+val make : string -> dir:Path.t -> t
+
+(** The following always holds:
+
+    {[
+      make (name t) ~dir:(dir t) = t
+    ]}
+*)
+val name : t -> string
+val dir : t -> Path.t
+
+val to_dyn : t -> Dyn.t
+
+val to_sexp : t -> Sexp.t
+
+val encode : t Dune_lang.Encoder.t
+
+val pp : t Fmt.t
+
+val of_user_written_path : loc:Loc.t -> Path.t -> t
+
+val fully_qualified_name : t -> Path.t
+
+val default     : dir:Path.t -> t
+val runtest     : dir:Path.t -> t
+val install     : dir:Path.t -> t
+val doc         : dir:Path.t -> t
+val private_doc : dir:Path.t -> t
+val lint        : dir:Path.t -> t
+val all         : dir:Path.t -> t
+val check       : dir:Path.t -> t
+val fmt         : dir:Path.t -> t
+
+(** Return the underlying stamp file *)
+val stamp_file : t -> Path.t
+
+val find_dir_specified_on_command_line
+  :  dir:Path.t
+  -> file_tree:File_tree.t
+  -> File_tree.Dir.t
+
+val is_standard : string -> bool
+val suffix : string

--- a/src/build.ml
+++ b/src/build.ml
@@ -31,6 +31,7 @@ module Repr = struct
     | Lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
     | Env_var : string -> ('a, 'a) t
     | Universe : ('a, 'a) t
+    | Alias : Alias.t -> ('a, 'a) t
 
   and 'a memo =
     { name          : string
@@ -124,6 +125,7 @@ let dyn_paths t = Dyn_paths (t >>^ Path.Set.of_list)
 let dyn_path_set t = Dyn_paths t
 let paths_for_rule ps = Paths_for_rule ps
 let universe = Universe
+let alias a = Alias a
 let env_var s = Env_var s
 
 let catch t ~on_error = Catch (t, on_error)

--- a/src/build.mli
+++ b/src/build.mli
@@ -61,6 +61,8 @@ val path  : Path.t -> ('a, 'a) t
 
 val universe : ('a, 'a) t
 
+val alias : Alias.t -> ('a, 'a) t
+
 val paths : Path.t list -> ('a, 'a) t
 val path_set : Path.Set.t -> ('a, 'a) t
 
@@ -213,6 +215,7 @@ module Repr : sig
     | Lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
     | Env_var : string -> ('a, 'a) t
     | Universe : ('a, 'a) t
+    | Alias : Alias.t -> ('a, 'a) t
 
   and 'a memo =
     { name          : string

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -115,6 +115,8 @@ let static_deps t ~all_targets ~file_tree =
     | Env_var var ->
       Static_deps.add_action_env_var acc var
     | Universe -> Static_deps.add_action_dep acc Dep.universe
+    | Alias a ->
+      Static_deps.add_action_dep acc (Dep.file (Alias.stamp_file a))
   in
   loop (Build.repr t) Static_deps.empty true
 
@@ -144,6 +146,7 @@ let lib_deps =
       | Memo m -> loop m.t acc
       | Catch (t, _) -> loop t acc
       | Lazy_no_targets t -> loop (Lazy.force t) acc
+      | Alias _ -> acc
       | Universe -> acc
       | Env_var _ -> acc
   in
@@ -189,6 +192,7 @@ let targets =
     | Memo m -> loop m.t acc
     | Catch (t, _) -> loop t acc
     | Lazy_no_targets _ -> acc
+    | Alias _ -> acc
     | Universe -> acc
     | Env_var _ -> acc
   in

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -96,7 +96,7 @@ val package_deps
 (** {2 Aliases} *)
 
 module Alias : sig
-  type t
+  type t = Alias.t
 
   val pp : t Fmt.t
 
@@ -131,9 +131,6 @@ module Alias : sig
 
   (** Return the underlying stamp file *)
   val stamp_file : t -> Path.t
-
-  (** [dep t = Build.path (stamp_file t)] *)
-  val dep : t -> ('a, 'a) Build.t
 
   (** Implements [@@alias] on the command line *)
   val dep_multi_contexts

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -104,6 +104,9 @@ let gen_rules sctx (config : Dune_file.Auto_format.t) ~dir =
     ~f:(fun () ->
       File_tree.files_of (Super_context.file_tree sctx) source_dir
       |> Path.Set.iter ~f:setup_formatting);
+  let dyn_deps =
+    let open Build.O in
+    Build.alias alias_formatted >>^ fun _ -> Path.Set.empty in
   Build_system.Alias.add_deps alias
-    (Path.Set.singleton (Build_system.Alias.stamp_file alias_formatted));
+    ~dyn_deps Path.Set.empty;
   Build_system.Alias.add_deps alias_formatted Path.Set.empty

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -73,13 +73,14 @@ module Dep = struct
 
   let deps ctx requires =
     Build.of_result_map requires ~f:(fun libs ->
-      Build.path_set (
-        List.fold_left libs ~init:Path.Set.empty ~f:(fun acc (lib : Lib.t) ->
-          if Lib.is_local lib then
-            let dir = Paths.odocs ctx (Lib lib) in
-            Path.Set.add acc (Build_system.Alias.stamp_file (alias ~dir))
-          else
-            acc)))
+      List.filter_map libs ~f:(fun lib ->
+        if Lib.is_local lib then
+          let dir = Paths.odocs ctx (Lib lib) in
+          Some (Build.alias (alias ~dir))
+        else
+          None)
+      |> Build.all)
+    >>^ fun _ -> ()
 
   let alias ctx m = alias ~dir:(Paths.odocs ctx m)
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -460,7 +460,7 @@ module Deps = struct
       Build.path path
       >>^ fun () -> [path]
     | Alias s ->
-      Alias.dep (make_alias expander s)
+      Build.alias (make_alias expander s)
       >>^ fun () -> []
     | Alias_rec s ->
       Alias.dep_rec ~loc:(String_with_vars.loc s) ~file_tree:t.file_tree
@@ -483,7 +483,7 @@ module Deps = struct
       >>^ Path.Set.to_list
     | Package p ->
       let pkg = Package.Name.of_string (Expander.expand_str expander p) in
-      Alias.dep (Alias.package_install ~context:t.context ~pkg)
+      Build.alias (Alias.package_install ~context:t.context ~pkg)
       >>^ fun () -> []
     | Universe ->
       Build.universe


### PR DESCRIPTION
Add an Alias dependency type that allows one to depend on aliases directly
without going through stamp file which will be removed in the future.

This PR requires us to introduce the `alias.ml` module (like we had before), to avoid circular dependencies.

The refactoring is not yet complete, but since it's a fairly large task I would like some feedback.

The next step is to introduce `Dep.Alias` constructor with the following arguments:

```
type Dep.t =
  ..
  | Alias of Alias.t (* eventually we can support recursive alias deps directly here *)
```

The Alias API has another quirk that I think might need addressing. Currently, file dependencies have a bit of a blessed status and one has to go through `?dyn_deps` to add other dependencies. This is annoying when one wants to add alias dependencies to another alias for example. I'm wondering, why can't we just add all deps via `Build.t` and use the same mechanism as we have elsewhere to separate static from dynamic deps?

