### PR TITLE
use physical equality for Super_context

### DIFF
--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -39,7 +39,7 @@ let build_dir t = t.context.build_dir
 let profile t = t.context.profile
 let external_lib_deps_mode t = t.external_lib_deps_mode
 
-let equal x y = Context.equal x.context y.context
+let equal = ((==) : t -> t -> bool)
 let hash t = Context.hash t.context
 let to_sexp t = Context.to_sexp t.context
 


### PR DESCRIPTION
I'm not sure why we ended up using `Context.equal`, but there are many fields in `Super_context` and it's unclear that none of them may change from run to run without the `Context` changing.

It's much easier to think about if we use physical equality instead.