### PR TITLE
Remove empty dep to @.formatted/fmt

### DIFF
--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -106,7 +106,6 @@ let gen_rules ~dir =
   let output_dir = Path.relative dir formatted in
   let alias = Build_system.Alias.fmt ~dir in
   let alias_formatted = Build_system.Alias.fmt ~dir:output_dir in
-  Build_system.Alias.add_deps alias_formatted Path.Set.empty;
   Build_system.Alias.stamp_file alias_formatted
   |> Path.Set.singleton
   |> Build_system.Alias.add_deps alias

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -42,25 +42,30 @@ Configuration files are taken into account for this action:
 
   $ touch enabled/.ocamlformat
   $ dune build --display short @fmt
+         refmt enabled/.formatted/reason_file.re
   File "enabled/reason_file.re", line 1, characters 0-0:
   Files _build/default/enabled/reason_file.re and _build/default/enabled/.formatted/reason_file.re differ.
+         refmt enabled/.formatted/reason_file.rei
   File "enabled/reason_file.rei", line 1, characters 0-0:
   Files _build/default/enabled/reason_file.rei and _build/default/enabled/.formatted/reason_file.rei differ.
-  File "enabled/dune", line 1, characters 0-0:
-  Files _build/default/enabled/dune and _build/default/enabled/.formatted/dune differ.
-  File "enabled/subdir/dune", line 1, characters 0-0:
-  Files _build/default/enabled/subdir/dune and _build/default/enabled/subdir/.formatted/dune differ.
-  File "partial/a.ml", line 1, characters 0-0:
-  Files _build/default/partial/a.ml and _build/default/partial/.formatted/a.ml differ.
    ocamlformat enabled/.formatted/ocaml_file.mli
   File "enabled/ocaml_file.mli", line 1, characters 0-0:
   Files _build/default/enabled/ocaml_file.mli and _build/default/enabled/.formatted/ocaml_file.mli differ.
    ocamlformat enabled/.formatted/ocaml_file.ml
   File "enabled/ocaml_file.ml", line 1, characters 0-0:
   Files _build/default/enabled/ocaml_file.ml and _build/default/enabled/.formatted/ocaml_file.ml differ.
+          dune enabled/.formatted/dune
+  File "enabled/dune", line 1, characters 0-0:
+  Files _build/default/enabled/dune and _build/default/enabled/.formatted/dune differ.
+          dune enabled/subdir/.formatted/dune
+  File "enabled/subdir/dune", line 1, characters 0-0:
+  Files _build/default/enabled/subdir/dune and _build/default/enabled/subdir/.formatted/dune differ.
    ocamlformat enabled/subdir/.formatted/lib.ml
   File "enabled/subdir/lib.ml", line 1, characters 0-0:
   Files _build/default/enabled/subdir/lib.ml and _build/default/enabled/subdir/.formatted/lib.ml differ.
+   ocamlformat partial/.formatted/a.ml
+  File "partial/a.ml", line 1, characters 0-0:
+  Files _build/default/partial/a.ml and _build/default/partial/.formatted/a.ml differ.
   [1]
 
 And fixable files can be promoted:
@@ -83,16 +88,18 @@ All .ocamlformat files are considered dependencies:
 
   $ echo 'margin = 70' > .ocamlformat
   $ dune build --display short @fmt
+         refmt enabled/.formatted/reason_file.re
+         refmt enabled/.formatted/reason_file.rei
   File "enabled/reason_file.rei", line 1, characters 0-0:
   Files _build/default/enabled/reason_file.rei and _build/default/enabled/.formatted/reason_file.rei differ.
-  File "enabled/subdir/dune", line 1, characters 0-0:
-  Files _build/default/enabled/subdir/dune and _build/default/enabled/subdir/.formatted/dune differ.
-         refmt enabled/.formatted/reason_file.re
    ocamlformat enabled/.formatted/ocaml_file.mli
   File "enabled/ocaml_file.mli", line 1, characters 0-0:
   Files _build/default/enabled/ocaml_file.mli and _build/default/enabled/.formatted/ocaml_file.mli differ.
    ocamlformat enabled/.formatted/ocaml_file.ml
           dune enabled/.formatted/dune
+          dune enabled/subdir/.formatted/dune
+  File "enabled/subdir/dune", line 1, characters 0-0:
+  Files _build/default/enabled/subdir/dune and _build/default/enabled/subdir/.formatted/dune differ.
    ocamlformat enabled/subdir/.formatted/lib.ml
   File "enabled/subdir/lib.ml", line 1, characters 0-0:
   Files _build/default/enabled/subdir/lib.ml and _build/default/enabled/subdir/.formatted/lib.ml differ.


### PR DESCRIPTION
This was causing some files that needed to be re-formatted not to show up as
such. [This comment](https://github.com/ocaml/dune/pull/1942#discussion_r267467311) explains why the current behavior isn't optimal.

Now I'm still not sure why exactly this line makes the difference. 

perhaps @diml knows?