### PR TITLE
Fix glob dependencies on external directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ unreleased
 - Watch mode: display "Success" in green and "Had errors" in red (#1956,
   @emillon)
 
+- Fix glob dependencies on installed directories (#1965, @rgrinberg)
+
 1.8.2 (10/03/2019)
 ------------------
 

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -74,8 +74,8 @@ val targets_of : dir:Path.t -> Path.Set.t
 (** Load the rules for this directory. *)
 val load_dir : dir:Path.t -> unit
 
-(** Stamp file that depends on all files of [dir] with extension [ext]. *)
-val stamp_file_for_files_of : dir:Path.t -> ext:string -> Path.t
+(** Stamp files that depends on all files of [dir] with extensions [exts]. *)
+val stamp_files_for_files_of : dir:Path.t -> exts:string list -> Path.t list
 
 (** Sets the package this file is part of *)
 val set_package : Path.t -> Package.Name.t -> unit

--- a/src/lib_file_deps.ml
+++ b/src/lib_file_deps.ml
@@ -64,16 +64,16 @@ let setup_file_deps =
 
 let file_deps_of_lib (lib : Lib.t) ~groups =
   if Lib.is_local lib then
-    Alias.stamp_file
-      (Group.L.alias groups ~dir:(Lib.src_dir lib) ~name:(Lib.name lib))
+    [Alias.stamp_file
+       (Group.L.alias groups ~dir:(Lib.src_dir lib) ~name:(Lib.name lib))]
   else
     (* suppose that all the files of an external lib are at the same place *)
-    Build_system.stamp_file_for_files_of
+    Build_system.stamp_files_for_files_of
       ~dir:(Obj_dir.public_cmi_dir (Lib.obj_dir lib))
-      ~ext:(Group.L.to_string groups)
+      ~exts:(List.map ~f:Group.to_string groups)
 
 let file_deps_with_exts =
-  List.rev_map ~f:(fun (lib, groups) -> file_deps_of_lib lib ~groups)
+  List.concat_map ~f:(fun (lib, groups) -> file_deps_of_lib lib ~groups)
 
 let file_deps libs ~groups =
-  List.rev_map libs ~f:(file_deps_of_lib ~groups)
+  List.concat_map libs ~f:(file_deps_of_lib ~groups)


### PR DESCRIPTION
Previously, we'd pass multiple extensions as some dummy concatenated extension.
This is not correct and we should not flatten extensions this way.

I'm wondering if this is responsible for the issues that @copy observed when installing external packages and rebuilding.