### PR TITLE
Implicit outputs

### DIFF
--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -37,8 +37,8 @@ type extra_sub_directories_to_keep =
     It is expected that [f] only generate rules whose targets are
     descendant of [dir]. *)
 val set_rule_generators
-  :  (dir:Path.t -> string list -> extra_sub_directories_to_keep) String.Map.t
-  -> unit
+  :  (dir:Path.t -> string list -> extra_sub_directories_to_keep)
+       String.Map.t -> unit
 
 (** All other functions in this section must be called inside the rule generator
     callback. *)
@@ -231,3 +231,9 @@ val evaluate_rules
   :  recursive:bool
   -> request:(unit, unit) Build.t
   -> Rule.t list Fiber.t
+
+type rule_collection_implicit_output
+val rule_collection_implicit_output :
+  rule_collection_implicit_output Memo.Implicit_output.t
+
+val handle_add_rule_effects : (unit -> 'a) -> 'a

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -330,6 +330,12 @@ module Var = struct
   let set var x f k =
     EC.set_vars (Univ_map.add (EC.vars ()) var x) f () k
 
+  let unset_sync var f =
+    EC.set_vars_sync (Univ_map.remove (EC.vars ()) var) f ()
+
+  let unset var f k =
+    EC.set_vars (Univ_map.remove (EC.vars ()) var) f () k
+
   let create () =
     create ~name:"var" (fun _ -> Sexp.Encoder.string "var")
 end

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -181,6 +181,9 @@ module Var : sig
   val set : 'a t -> 'a -> (unit -> 'b fiber) -> 'b fiber
   val set_sync : 'a t -> 'a -> (unit -> 'b) -> 'b
 
+  val unset : 'a t -> (unit -> 'b fiber) -> 'b fiber
+  val unset_sync : 'a t -> (unit -> 'b) -> 'b
+
 end with type 'a fiber := 'a t
 
 (** {1 Error handling} *)

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -258,7 +258,8 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
 
   let init () =
     Install_rules.init sctx;
-    Odoc.init sctx
+    Build_system.handle_add_rule_effects (fun () ->
+      Odoc.init sctx)
 end
 
 module type Gen = sig
@@ -332,3 +333,4 @@ let gen ~contexts
     (String.Map.map map ~f:(fun (module M : Gen) -> M.gen_rules));
   String.Map.iter map ~f:(fun (module M : Gen) -> M.init ());
   String.Map.map map ~f:(fun (module M : Gen) -> M.sctx)
+

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -408,10 +408,13 @@ let init sctx =
   let packages = Local_package.of_sctx sctx in
   let ctx = Super_context.context sctx in
   let artifacts_per_package =
-    Package.Name.Map.map packages ~f:(init_binary_artifacts sctx) in
-  Package.Name.Map.iter packages ~f:(fun pkg ->
-    Local_package.name pkg
-    |> Package.Name.Map.find artifacts_per_package
-    |> Option.value_exn
-    |> init_install sctx pkg;
-    init_install_files ctx pkg)
+    Build_system.handle_add_rule_effects (fun () ->
+      Package.Name.Map.map packages ~f:(init_binary_artifacts sctx))
+  in
+  Build_system.handle_add_rule_effects (fun () ->
+    Package.Name.Map.iter packages ~f:(fun pkg ->
+      Local_package.name pkg
+      |> Package.Name.Map.find artifacts_per_package
+      |> Option.value_exn
+      |> init_install sctx pkg;
+      init_install_files ctx pkg))

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -33,10 +33,10 @@ end = struct
 
   let create (type a) (module I : Implicit_output with type t = a) =
     ((module struct
-      type nonrec a = a
-      type _ w += W : a w
-      include I
-    end) : a t)
+       type nonrec a = a
+       type _ w += W : a w
+       include I
+     end) : a t)
   ;;
 
   let get (type a) (module T : T with type a = a) =
@@ -100,10 +100,9 @@ let produce_opt t v = match v with
 let collect_async (type o) (type_ : o t) f =
   let output = ref None in
   Fiber.map
-    (
-      (Fiber.Var.set current_handler
-         (module struct type nonrec o = o let type_ = type_ let so_far = output end)
-         f))
+    (Fiber.Var.set current_handler
+       (module struct type nonrec o = o let type_ = type_ let so_far = output end)
+       f)
     ~f:(fun res -> res, !output)
 let collect_sync (type o) (type_ : o t) f =
   let output = ref None in

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -1,0 +1,123 @@
+open! Stdune
+
+module type Implicit_output = sig
+  type t
+
+  val name : string
+  val union : t -> t -> t
+end
+
+module Witness : sig
+  type 'a t
+
+  val create : (module Implicit_output with type t = 'a) -> 'a t
+  ;;
+
+  (*  val get : 'a t -> (module Implicit_output with type t = 'a) *)
+
+  val get_name : 'a t -> string
+  val get_union : 'a t -> 'a -> 'a -> 'a
+
+  val same : 'a t -> 'b t -> ('a, 'b) Type_eq.t option
+end = struct
+
+  type _ w = ..
+
+  module type T = sig
+    type a
+    type _ w += W : a w
+    include Implicit_output with type t = a
+  end
+
+  type 'a t = (module T with type a = 'a)
+
+  let create (type a) (module I : Implicit_output with type t = a) =
+    ((module struct
+      type nonrec a = a
+      type _ w += W : a w
+      include I
+    end) : a t)
+  ;;
+
+  let get (type a) (module T : T with type a = a) =
+    (module T : Implicit_output with type t = a)
+  ;;
+
+  let get_name (type a) t =
+    let module I = (val get t : Implicit_output with type t = a) in
+    I.name
+  ;;
+
+  let get_union (type a) t =
+    let module I = (val get t : Implicit_output with type t = a) in
+    I.union
+
+  let same (type a) (type b) ((module M1) : a t) ((module M2) : b t) =
+    match M1.W with
+    | M2.W -> Some (Type_eq.T : (a, b) Type_eq.t)
+    | _ -> None
+
+end
+
+type 'o t = 'o Witness.t
+
+module type Handler = sig
+  type o
+  val type_ : o t
+  val so_far : o option ref
+end
+
+type handler = (module Handler)
+
+let current_handler : handler Fiber.Var.t = Fiber.Var.create ()
+
+let produce' ~union opt v =
+  match !opt with
+  | None -> opt := Some v
+  | Some v0 -> opt := Some (union v0 v)
+
+let produce (type o) (type_ : o t) (value : o) =
+  match Fiber.Var.get current_handler with
+  | None ->
+    Exn.code_error
+      "Implicit_output.produce called without any handler in dynamic scope"
+      ["type", Sexp.Atom (Witness.get_name type_)]
+  | Some (module H : Handler) ->
+    match Witness.same type_ H.type_ with
+    | Some Type_eq.T ->
+      produce' ~union:(Witness.get_union type_) H.so_far value
+    | None ->
+      Exn.code_error
+        "Implicit_output.produce called with a handler for a different output"
+        [ "type_handled", Sexp.Atom (Witness.get_name H.type_)
+        ; "type_produced", Sexp.Atom (Witness.get_name type_)
+        ]
+
+let produce_opt t v = match v with
+  | None -> ()
+  | Some v -> produce t v
+
+let collect_async (type o) (type_ : o t) f =
+  let output = ref None in
+  Fiber.map
+    (
+      (Fiber.Var.set current_handler
+         (module struct type nonrec o = o let type_ = type_ let so_far = output end)
+         f))
+    ~f:(fun res -> res, !output)
+let collect_sync (type o) (type_ : o t) f =
+  let output = ref None in
+  let res =
+    Fiber.Var.set_sync current_handler
+      (module struct type nonrec o = o let type_ = type_ let so_far = output end)
+      f
+  in
+  (res, !output)
+
+let forbid_sync f =
+  Fiber.Var.unset_sync current_handler f
+let forbid_async f =
+  Fiber.Var.unset current_handler f
+
+let add (type a) (module T : Implicit_output with type t = a) =
+  Witness.create (module T)

--- a/src/memo/implicit_output.mli
+++ b/src/memo/implicit_output.mli
@@ -1,0 +1,24 @@
+(** Uses dynamic scope to collect implicit output produced by functions. *)
+
+type 'o t
+
+(** [produce] and [produce_opt] are used by effectful functions to produce output. *)
+val produce : 'o t -> 'o -> unit
+val produce_opt : 'o t -> 'o option -> unit
+
+(** [collect*] and [forbid*] take a potentially effectful function (one wich may produce
+    some implicit output) and turn it into a pure one (with explicit output if any) *)
+val collect_async : 'o t -> (unit -> 'a Fiber.t) -> ('a * 'o option) Fiber.t
+val collect_sync : 'o t -> (unit -> 'a) -> ('a * 'o option)
+val forbid_async : (unit -> 'a Fiber.t) -> 'a Fiber.t
+val forbid_sync : (unit -> 'a) -> 'a
+
+module type Implicit_output = sig
+  type t
+
+  val name : string
+  val union : t -> t -> t
+end
+
+(** Register a new type of implicit output. *)
+val add : (module Implicit_output with type t = 'o) -> 'o t

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -723,7 +723,7 @@ module With_implicit_output = struct
   type ('i, 'o, 'f) t = 'f
 
   let create
-        (type i o f)
+        (type i) (type o) (type f)
         (type io)
         name
         ~doc
@@ -781,3 +781,4 @@ module With_implicit_output = struct
   let exec t = t
 
 end
+module Implicit_output = Implicit_output

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -335,8 +335,6 @@ end
 
 let global_dep_dag = Dag.create ()
 
-(* call stack consists of two components: asynchronous call stack managed with a fiber
-   context variable and synchronous call stack on top of that managed with an explicit ref *)
 module Call_stack = struct
 
   (* fiber context variable keys *)

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -183,3 +183,5 @@ module With_implicit_output : sig
 
   val exec : (_, _, 'f) t -> 'f
 end
+
+module Implicit_output = Implicit_output

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -165,3 +165,21 @@ val registered_functions : unit -> Function_info.t list
 val function_info : string -> Function_info.t
 
 val lazy_ : (unit -> 'a) -> (unit -> 'a)
+
+module With_implicit_output : sig
+
+  type ('i, 'o, 'f) t
+
+  val create
+    :  string
+    -> doc:string
+    -> input:(module Input with type t = 'i)
+    -> visibility:'i Visibility.t
+    -> output:(module Output_simple with type t = 'o)
+    -> implicit_output:('io Implicit_output.t)
+    -> ('i, 'o, 'f) Function_type.t
+    -> 'f
+    -> ('i, 'o, 'f) t
+
+  val exec : (_, _, 'f) t -> 'f
+end

--- a/src/packages.ml
+++ b/src/packages.ml
@@ -6,37 +6,31 @@ let mlds_by_package_def =
   let module Output = struct
     type t = Path.t list Package.Name.Map.t
 
-    let equal = Package.Name.Map.equal ~equal:(List.equal Path.equal)
-
     let to_sexp _ = Sexp.Encoder.string "opaque"
   end
   in
-  Memo.create "mlds by package"
+  Memo.With_implicit_output.create "mlds by package"
+    ~implicit_output:Build_system.rule_collection_implicit_output
     ~doc:"mlds by package"
     ~input:(module Super_context)
-    ~output:(Allow_cutoff (module Output))
+    ~output:(module Output)
     ~visibility:Hidden
     Sync
-    None
+    (fun sctx ->
+       let stanzas = Super_context.stanzas sctx in
+       stanzas
+       |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
+         List.filter_map w.data ~f:(function
+           | Documentation d ->
+             let dc = Dir_contents.get sctx ~dir:w.ctx_dir in
+             let mlds = Dir_contents.mlds dc d in
+             Some (d.package.name, mlds)
+           | _ ->
+             None
+         ))
+       |> Package.Name.Map.of_list_reduce ~f:List.rev_append)
 
-let () =
-  let mlds_by_package sctx =
-    let stanzas = Super_context.stanzas sctx in
-    stanzas
-    |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
-      List.filter_map w.data ~f:(function
-        | Documentation d ->
-          let dc = Dir_contents.get sctx ~dir:w.ctx_dir in
-          let mlds = Dir_contents.mlds dc d in
-          Some (d.package.name, mlds)
-        | _ ->
-          None
-      ))
-    |> Package.Name.Map.of_list_reduce ~f:List.rev_append
-  in
-  Memo.set_impl mlds_by_package_def mlds_by_package
-
-let mlds_by_package = Memo.exec mlds_by_package_def
+let mlds_by_package = Memo.With_implicit_output.exec mlds_by_package_def
 
 (* TODO memoize this so that we can cutoff at the package *)
 let mlds sctx pkg =

--- a/src/stdune/appendable_list.ml
+++ b/src/stdune/appendable_list.ml
@@ -1,0 +1,10 @@
+
+type 'a t = 'a list -> 'a list
+
+let empty = fun k -> k
+
+let singleton x k = x :: k
+
+let to_list l = l []
+
+let (@) a b k = a (b k)

--- a/src/stdune/appendable_list.mli
+++ b/src/stdune/appendable_list.mli
@@ -1,0 +1,11 @@
+(** Appendable lists: concatenation takes O(1) time, conversion to a list takes O(n). *)
+
+type 'a t
+
+val empty : 'a t
+
+val singleton : 'a -> 'a t
+
+val (@) : 'a t -> 'a t -> 'a t
+
+val to_list : 'a t -> 'a list

--- a/src/stdune/exn_with_backtrace.ml
+++ b/src/stdune/exn_with_backtrace.ml
@@ -23,3 +23,9 @@ let map { exn; backtrace } ~f =
   { exn = f exn; backtrace }
 
 let map_and_reraise t ~f = reraise (map ~f t)
+
+let to_sexp { exn; backtrace } =
+  Sexp.List [
+    Atom (Printexc.to_string exn);
+    Atom (Printexc.raw_backtrace_to_string backtrace)
+  ]

--- a/src/stdune/exn_with_backtrace.mli
+++ b/src/stdune/exn_with_backtrace.mli
@@ -19,3 +19,5 @@ val pp_uncaught : Format.formatter -> t -> unit
 val map : t -> f:(exn -> exn) -> t
 
 val map_and_reraise  : t -> f:(exn -> exn) -> 'a
+
+val to_sexp : t -> Sexp.t

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -1,3 +1,4 @@
+module Appendable_list = Appendable_list
 module Ansi_color = Ansi_color
 module Array      = Array
 module Bytes      = Bytes


### PR DESCRIPTION
This PR introduces the concept of "implicit outputs".

This is a compatibility layer between the purely functional world of memoization and the side-effectful world of the rest of Dune. 

With implicit outputs, the rule generator can still be written in imperative style and call `add_rule`, while memoization will correctly treat this as a part of the output of the function.