### PR TITLE
[lang] Preliminary Coq support, core part with recursively qualified modules.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -94,7 +94,7 @@ case "$TARGET" in
       fi
       opam list
       opam pin add dune . --no-action
-      opam install ocamlfind utop ppxlib $ODOC ocaml-migrate-parsetree js_of_ocaml-ppx js_of_ocaml-compiler
+      opam install ocamlfind utop ppxlib $ODOC ocaml-migrate-parsetree js_of_ocaml-ppx js_of_ocaml-compiler coq
       echo -en "travis_fold:end:opam.deps\r"
     fi
     echo -en "travis_fold:end:dune.boot\r"
@@ -102,6 +102,7 @@ case "$TARGET" in
       cat $RUNTEST_NO_DEPS;
       _boot/install/default/bin/dune runtest && \
       _boot/install/default/bin/dune build @test/blackbox-tests/runtest-js && \
+      _boot/install/default/bin/dune build @test/blackbox-tests/runtest-coq && \
       ! _boot/install/default/bin/dune build @test/fail-with-background-jobs-running
       RESULT=$?
       if [ $UPDATE_OPAM -eq 0 ] ; then

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ unreleased
 - Add experimental `$ dune init` command. This command is used to create or
   update project boilerplate. (#1448, fixes #159, @shonfeder)
 
+- Experimental Coq support (1466, @ejgallego)
+
 1.8.2 (10/03/2019)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ test:
 test-js:
 	$(BIN) build @runtest-js
 
+test-coq:
+	$(BIN) build @runtest-coq
+
 test-all:
-	$(BIN) build @runtest @runtest-js
+	$(BIN) build @runtest @runtest-js @runtest-coq
 
 check:
 	$(BIN) build @check

--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -1,0 +1,63 @@
+.. _coq-main:
+
+******
+Coq
+******
+
+Dune is also able to build Coq developments. A Coq project is a mix of
+Coq ``.v`` files and (optionally) OCaml libraries linking to the Coq
+API (in which case we say the project is a *Coq plugin*). To enable
+Coq support in a dune project, the language version should be selected
+in the ``dune-project`` file. For example:
+
+.. code:: scheme
+
+    (using coq 0.1)
+
+This will enable support for the ``coqlib`` stanza in the current project. If the
+language version is absent, dune will automatically add this line with the
+latest Coq version to the project file once a ``(coqlib ...)`` stanza is used anywhere.
+
+
+Basic Usage
+===========
+
+The basic form for defining Coq libraries is very similar to the OCaml form:
+
+.. code:: scheme
+
+    (coqlib
+     (name <module_prefix>)
+     (synopsis <text>)
+     (modules <ordered_set_lang>)
+     (flags <coq_flags>))
+
+The stanza will build all `.v` files on the given directory.
+The semantics of fields is:
+- ``<module_prefix>>`` will be used as the default Coq library prefix
+  ``-R``
+- the ``modules`` field does allow to constraint the set of modules
+  included in the library, similarly to its OCaml counterpart
+- ``<coq_flags>`` will be passed to ``coqc``.
+
+Library Composition and Handling
+===================
+
+The ``coqlib`` stanza does not yet support composition of Coq
+libraries. In the 0.1 version of the language, libraries are located
+using Coq's built-in library management, thus Coq will always resort
+to the installed version of a particular library.
+
+This will be fixed in the future.
+
+Recursive modules
+===================
+
+Adding:
+
+.. code:: scheme
+    (include_subdirs qualified)
+
+to the ``dune`` file will make Dune to consider all the modules in the
+current directory and sub-directories, qualified in the current Coq
+style.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,6 +24,7 @@ Welcome to dune's documentation!
    jsoo
    variants
    formatting
+   coq
    faq
    known-issues
    migration

--- a/src/coq_module.ml
+++ b/src/coq_module.ml
@@ -1,0 +1,60 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(*     Written by: Emilio Jesús Gallego Arias  *)
+
+open! Stdune
+
+module Name = struct
+
+  type t = string
+
+  let make x = x
+  let compare = String.compare
+  let pp = Fmt.text
+
+end
+
+(* We keep prefix and name separated as the handling of
+  `From Foo Require Bar.` may benefit from it. *)
+type t =
+  { source: Path.t
+  ; prefix : string list
+  ; name : string
+  }
+
+let make ~source ~prefix ~name =
+  { source
+  ; prefix
+  ; name
+  }
+
+let source x = x.source
+let prefix x = x.prefix
+let name x = x.name
+let obj_file ~obj_dir ~ext x =
+  let vo_dir = List.fold_left x.prefix ~init:obj_dir ~f:Path.relative in
+  Path.relative vo_dir (x.name ^ ext)
+let pp fmt x =
+  let open Format in
+  let pp_sep fmt () = pp_print_string fmt "." in
+  fprintf fmt "{ prefix = %a; name = %s; source = %a }"
+    (pp_print_list ~pp_sep pp_print_string) x.prefix x.name Path.pp x.source
+
+let parse ~dir ~loc s =
+  let clist = List.rev @@ String.split s ~on:'.' in
+  match clist with
+  | [] ->
+    Errors.fail loc "invalid coq module"
+  | name :: prefix ->
+    let prefix = List.rev prefix in
+    let source = List.fold_left prefix ~init:dir ~f:Path.relative in
+    let source = Path.relative source (name ^ ".v") in
+    make ~name ~source ~prefix
+
+module Value = struct
+  type nonrec t = t
+  type key = string
+  let key x = String.concat ~sep:"." (x.prefix @ [x.name])
+end
+
+module Eval = Ordered_set_lang.Make(String)(Value)

--- a/src/coq_module.mli
+++ b/src/coq_module.mli
@@ -1,0 +1,40 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(*     Written by: Emilio Jesús Gallego Arias  *)
+
+open! Stdune
+
+module Name : sig
+
+  type t
+
+  val make : string -> t
+  val compare : t -> t -> Ordering.t
+
+  val pp : t Fmt.t
+
+end
+
+type t
+
+(** A Coq module [a.b.foo] defined in file [a/b/foo.v] *)
+val make
+  :  source:Path.t
+  (** file = .v source file; module name has to be the same so far *)
+  -> prefix:string list
+  (** Library-local qualified prefix *)
+  -> name:Name.t
+  (** Name of the module *)
+  -> t
+
+(** Coq does enforce some invariants wrt module vs file names *)
+
+val source : t -> Path.t
+val prefix : t -> string list
+val name : t -> string
+val obj_file : obj_dir:Path.t -> ext:string -> t -> Path.t
+val pp : t Fmt.t
+
+(** Parses a form "a.b.c" to a module *)
+val parse : dir:Path.t -> loc:Loc.t -> string -> t
+module Eval : Ordered_set_lang.S with type value := t

--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -1,0 +1,113 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(*     Written by: Emilio Jesús Gallego Arias  *)
+
+open! Stdune
+open Build.O
+module SC = Super_context
+
+let coq_debug = false
+
+type coq_context =
+  { coqdep : Action.program
+  ; coqc   : Action.program
+  ; coqpp  : Action.program
+  }
+
+let parse_coqdep ~coq_module (lines : string list) =
+  if coq_debug then Format.eprintf "Parsing coqdep @\n%!";
+  let source = Coq_module.source coq_module in
+  let invalid p =
+    Errors.die "coqdep returned invalid output for %s / [phase: %s]"
+      (Path.to_string source) p in
+  let line =
+    match lines with
+    | [] | _ :: _ :: _ :: _ -> invalid "line"
+    | [line] -> line
+    | [l1;_l2] ->
+      (* .vo is produced before .vio, this is fragile tho *)
+      l1
+  in
+  match String.lsplit2 line ~on:':' with
+  | None -> invalid "split"
+  | Some (basename,deps) ->
+    let ff = List.hd @@ String.extract_blank_separated_words basename in
+    let depname, _ = Filename.split_extension ff in
+    let modname =
+      Coq_module.(String.concat ~sep:"/" (prefix coq_module @ [name coq_module])) in
+    if coq_debug
+    then Format.eprintf "depname / modname: %s / %s@\n%!" depname modname;
+    if depname <> modname then invalid "basename";
+    let deps = String.extract_blank_separated_words deps in
+    if coq_debug
+    then Format.eprintf "deps for %a: %a@\n%!" Path.pp source Fmt.(list text) deps;
+    deps
+
+let setup_rule ~expander ~dir ~cc ~source_rule ~name ~cflags coq_module =
+
+  if coq_debug
+  then Format.eprintf "gen_rule coq_module: %a@\n%!" Coq_module.pp coq_module;
+  let obj_dir = dir in
+  let source    = Coq_module.source coq_module in
+  let stdout_to = Coq_module.obj_file ~obj_dir ~ext:".v.d" coq_module in
+  let object_to = Coq_module.obj_file ~obj_dir ~ext:".vo"  coq_module in
+
+  let iflags = Arg_spec.As ["-R"; "."; name] in
+  let cd_arg = Arg_spec.[ iflags; Dep source ] in
+
+  (* coqdep needs the full source to be present :( *)
+  let coqdep_rule =
+    source_rule >>>
+    Build.run ~dir ~stdout_to cc.coqdep cd_arg
+  in
+
+  (* Process coqdep and generate rules *)
+  let deps_of = Build.dyn_paths (
+    Build.lines_of stdout_to >>^
+    parse_coqdep ~coq_module >>^
+    List.map ~f:(Path.relative dir)
+  ) in
+  let cc_arg = Arg_spec.[
+    iflags;
+    Dep source;
+    Hidden_targets [object_to] ]
+  in
+  [coqdep_rule;
+   deps_of >>>
+   Expander.expand_and_eval_set expander cflags ~standard:(Build.return []) >>>
+   Build.run ~dir cc.coqc (Dyn (fun flags -> As flags) :: cc_arg)
+  ]
+
+(* TODO: remove; rgrinberg points out:
+   - resolve program is actually cached,
+   - better just to ask for values that we actually use.
+ *)
+let create_ccoq sctx ~dir =
+  let rr prg =
+    SC.resolve_program ~dir sctx prg ~loc:None ~hint:"try: opam install coq" in
+  { coqdep = rr "coqdep"
+  ; coqc   = rr "coqc"
+  ; coqpp  = rr "coqpp"
+  }
+
+let setup_rules ~sctx ~dir ~dir_contents (s : Dune_file.Coq.t) =
+
+  if coq_debug then begin
+    let scope = SC.find_scope_by_dir sctx dir in
+    Format.eprintf "[gen_rules] @[dir: %a@\nscope: %a@]@\n%!"
+      Path.pp dir Path.pp (Scope.root scope)
+  end;
+
+  let cc = create_ccoq sctx ~dir in
+  let name = snd s.name in
+  let coq_modules = Dir_contents.coq_modules_of_library dir_contents ~name in
+
+  (* coqdep requires all the files to be in the tree to produce correct
+     dependencies *)
+  let source_rule = Build.paths (List.map ~f:Coq_module.source coq_modules) in
+  let cflags = s.Dune_file.Coq.flags in
+  let expander = SC.expander sctx ~dir in
+  let coq_rules =
+    List.concat_map
+      ~f:(setup_rule ~expander ~dir ~cc ~source_rule ~name ~cflags) coq_modules in
+  coq_rules

--- a/src/coq_rules.mli
+++ b/src/coq_rules.mli
@@ -1,0 +1,14 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(*     Written by: Emilio Jesús Gallego Arias  *)
+
+(* Build rules for Coq's .v -> .vo files       *)
+
+open! Stdune
+
+val setup_rules
+  :  sctx:Super_context.t
+  -> dir:Path.t
+  -> dir_contents:Dir_contents.t
+  -> Dune_file.Coq.t
+  -> (unit, Action.t) Build.t list

--- a/src/dir_contents.mli
+++ b/src/dir_contents.mli
@@ -34,6 +34,9 @@ val lookup_module : t -> Module.Name.t -> Dune_file.Buildable.t option
 (** All mld files attached to this documentation stanza *)
 val mlds : t -> Dune_file.Documentation.t -> Path.t list
 
+(** Coq modules of library [name] is the Coq library name.  *)
+val coq_modules_of_library : t -> name:string -> Coq_module.t list
+
 type get_result =
   | Standalone_or_root of t
   | Group_part of Path.t

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1819,6 +1819,60 @@ module Menhir = struct
        })
 end
 
+module Coq = struct
+
+  type t =
+    (* ; public     : Public_lib.t option *\) *)
+    { name       : Loc.t * string
+    (* TODO: validate name *)
+    ; synopsis   : string option
+    ; modules    : Ordered_set_lang.t
+    ; flags      : Ordered_set_lang.Unexpanded.t
+    ; libraries  : Lib_dep.t list
+    (** ocaml libraries *)
+    ; loc        : Loc.t
+    ; enabled_if : Blang.t
+    }
+
+  let syntax =
+    Syntax.create
+      ~name:"coq"
+      ~desc:"the coq extension (experimental)"
+      [ 0, 1 ]
+
+  let decode =
+    record
+      (* let_map name = field_o "name" Lib_name.Local.decode_loc
+       * and public = Public_lib.public_name_field *)
+      (let+ name = field "name" (located string)
+       and+ loc = loc
+       and+ synopsis = field_o "synopsis" string
+       and+ flags = field_oslu "flags"
+       and+ modules = modules_field "modules"
+       and+ libraries = field "libraries" Lib_deps.decode ~default:[]
+       and+ enabled_if = enabled_if
+       in
+       (* { name
+        * ; public *)
+       { name
+       ; synopsis
+       ; modules
+       ; flags
+       ; libraries
+       ; loc
+       ; enabled_if
+       })
+
+  type Stanza.t += T of t
+
+  let () =
+    Dune_project.Extension.register_simple
+      syntax
+      (return [ "coqlib", decode >>| fun x -> [T x] ])
+
+end
+
+
 module Alias_conf = struct
   type t =
     { name    : string

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -356,6 +356,23 @@ module Menhir : sig
   type Stanza.t += T of t
 end
 
+module Coq : sig
+
+  type t =
+    (* ; public     : Public_lib.t option *\) *)
+    { name       : Loc.t * string
+    ; synopsis   : string option
+    ; modules    : Ordered_set_lang.t
+    ; flags      : Ordered_set_lang.Unexpanded.t
+    ; libraries  : Lib_dep.t list
+    (** ocaml libraries *)
+    ; loc        : Loc.t
+    ; enabled_if : Blang.t
+    }
+
+  type Stanza.t += T of t
+end
+
 module Alias_conf : sig
   type t =
     { name    : string

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -183,6 +183,11 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
         | Some cctx ->
           Menhir_rules.gen_rules cctx m ~dir:ctx_dir
         end
+      | Coq.T m when Expander.eval_blang expander m.enabled_if ->
+        (* Format.eprintf "[coq] gen_rules called @\n%!"; *)
+        let dir = ctx_dir in
+        let coq_rules = Coq_rules.setup_rules ~sctx ~dir ~dir_contents m in
+        SC.add_rules ~dir:ctx_dir sctx coq_rules
       | _ -> ());
     let dyn_deps =
       let pred =

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -96,6 +96,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name coq)
+ (deps (package dune) (source_tree test-cases/coq))
+ (action
+  (chdir
+   test-cases/coq
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name cross-compilation)
  (deps (package dune) (source_tree test-cases/cross-compilation))
  (action
@@ -1666,3 +1674,5 @@
 (alias (name runtest-disabled) (deps (alias envs-and-contexts)))
 
 (alias (name runtest-js) (deps (alias js_of_ocaml)))
+
+(alias (name runtest-coq) (deps (alias coq)))

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -61,10 +61,11 @@ module Test = struct
     ; skip_platforms : Platform.t list
     ; enabled        : bool
     ; js             : bool
+    ; coq            : bool
     ; external_deps  : bool
     }
 
-  let make ?env ?skip_ocaml ?(skip_platforms=[]) ?(enabled=true) ?(js=false)
+  let make ?env ?skip_ocaml ?(skip_platforms=[]) ?(enabled=true) ?(js=false) ?(coq=false)
         ?(external_deps=false) name =
     { name
     ; env
@@ -73,6 +74,7 @@ module Test = struct
     ; external_deps
     ; enabled
     ; js
+    ; coq
     }
 
   let pp_sexp fmt t =
@@ -123,6 +125,7 @@ let exclusions =
   let odoc = make ~external_deps:true ~skip_ocaml:"4.02.3" in
   [ make "js_of_ocaml" ~external_deps:true ~js:true
       ~env:("NODE", Sexp.parse "%{bin:node}")
+  ; make "coq" ~external_deps:true ~coq:true
   ; make "github25" ~env:("OCAMLPATH", Dune_lang.atom "./findlib-packages")
   ; odoc "odoc"
   ; odoc "odoc-unique-mlds"
@@ -179,13 +182,14 @@ let pp_group fmt (name, tests) =
 
 let () =
   let tests = Lazy.force all_tests in
-  (* The runtest target has a "specoial" definition. It includes all tests
-     except for js and disabled tests *)
+  (* The runtest target has a "special" definition. It includes all
+     tests except for js, coq, and disabled tests *)
   tests |> List.iter ~f:(fun t -> Format.printf "%a@.@." Test.pp_sexp t);
-  [ "runtest", (fun (t : Test.t) -> not t.js && t.enabled)
+  [ "runtest", (fun (t : Test.t) -> not t.js && not t.coq && t.enabled)
   ; "runtest-no-deps", (fun (t : Test.t) -> not t.external_deps && t.enabled)
   ; "runtest-disabled", (fun (t : Test.t) -> not t.enabled)
-  ; "runtest-js", (fun (t : Test.t) -> t.js && t.enabled) ]
+  ; "runtest-js", (fun (t : Test.t) -> t.js && t.enabled)
+  ; "runtest-coq", (fun (t : Test.t) -> t.coq && t.enabled) ]
   |> List.map ~f:(fun (name, predicate) ->
     (name, List.filter tests ~f:predicate))
   |> Format.pp_print_list

--- a/test/blackbox-tests/test-cases/coq/base/bar.v
+++ b/test/blackbox-tests/test-cases/coq/base/bar.v
@@ -1,0 +1,3 @@
+From basic Require Import foo.
+
+Definition mynum (i : mynat) := 3.

--- a/test/blackbox-tests/test-cases/coq/base/dune
+++ b/test/blackbox-tests/test-cases/coq/base/dune
@@ -1,0 +1,5 @@
+(coqlib
+ (name basic)
+ ; (public_name dune.test.basic)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/base/dune-project
+++ b/test/blackbox-tests/test-cases/coq/base/dune-project
@@ -1,0 +1,3 @@
+(lang dune 1.8)
+
+(using coq 0.1)

--- a/test/blackbox-tests/test-cases/coq/base/foo.v
+++ b/test/blackbox-tests/test-cases/coq/base/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/rec_module/a/bar.v
+++ b/test/blackbox-tests/test-cases/coq/rec_module/a/bar.v
@@ -1,0 +1,5 @@
+From rec_module Require Import b.foo.
+From rec_module Require Import c.ooo.
+From rec_module Require c.d.bar.
+
+Definition mynum (i : mynat) := 3 + ooo_nat + c.d.bar.bar_nat.

--- a/test/blackbox-tests/test-cases/coq/rec_module/b/foo.v
+++ b/test/blackbox-tests/test-cases/coq/rec_module/b/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/rec_module/c/d/bar.v
+++ b/test/blackbox-tests/test-cases/coq/rec_module/c/d/bar.v
@@ -1,0 +1,1 @@
+Definition bar_nat : nat := 4.

--- a/test/blackbox-tests/test-cases/coq/rec_module/c/ooo.v
+++ b/test/blackbox-tests/test-cases/coq/rec_module/c/ooo.v
@@ -1,0 +1,1 @@
+Definition ooo_nat : nat := 10.

--- a/test/blackbox-tests/test-cases/coq/rec_module/dune
+++ b/test/blackbox-tests/test-cases/coq/rec_module/dune
@@ -1,0 +1,7 @@
+(coqlib
+ (name rec_module)
+ ; (public_name dune.test.basic)
+ (modules :standard)
+ (synopsis "Test Coq library"))
+
+(include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/coq/rec_module/dune-project
+++ b/test/blackbox-tests/test-cases/coq/rec_module/dune-project
@@ -1,0 +1,3 @@
+(lang dune 1.8)
+
+(using coq 0.1)

--- a/test/blackbox-tests/test-cases/coq/run.t
+++ b/test/blackbox-tests/test-cases/coq/run.t
@@ -1,0 +1,9 @@
+  $ dune build --root base --display short --debug-dependency-path @all
+  Entering directory 'base'
+        coqdep bar.v.d
+        coqdep foo.v.d
+          coqc foo.vo
+          coqc bar.vo
+
+  $ dune build --root rec_module --display short --debug-dependency-path @all
+  Entering directory 'rec_module'


### PR DESCRIPTION
Dear Dune devs, this is a reworked partial version of #1555 , which only includes the very basic handling of Coq modules and rules.

We piggyback on the `local` support for dir traversal when `(include_subdirs qualified)` is enabled to build qualified Coq modules.

I have tested this on a few developments that use recursive modules and so far it works well :)

Below is the commit message:

------

This commit adds experimental Coq support to Dune. See Dune issue 1446
for more details.

The patch adds a new stanza `(coqlib ...)` enabled by adding
`(using coq 0.1)` to `dune-project`. The stanza looks like:

```lisp
(coqlib
 (name Ltac2)               ; Determines the `-R` flag
 (synopsis "Ltac 2 Plugin") ;
 (modules core Lib.mod)
 (flags -warn -no-cbv))     ; Flags for `coqc`
```

The functionality of the mode is basic, but it should suffice to
replace and extend most uses of `coq_makefile`.

The main remaining issue is the definition of on Coq libraries. Local
support for Coq libraries should suffice in the short-term. That is to
say, `(coqlib ....)` will only see libraries in the same scope, and
rely on Coq's default rules for the rest.

However, this doesn't seem straightforward. In particular, we may have
to re-implement `Lib.DB` which is not trivial.

Upcoming commits will add:

- support for depending on ML libraries;
- generation of `(install ...)` rules;

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>