### PR TITLE
Add Deps constructor to Build.t

### DIFF
--- a/src/build.mli
+++ b/src/build.mli
@@ -59,7 +59,7 @@ val lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
     build arrow. *)
 val path  : Path.t -> ('a, 'a) t
 
-val universe : ('a, 'a) t
+val dep : Dep.t -> ('a, 'a) t
 
 val paths : Path.t list -> ('a, 'a) t
 val path_set : Path.Set.t -> ('a, 'a) t
@@ -193,7 +193,6 @@ module Repr : sig
     | Second : ('a, 'b) t -> ('c * 'a, 'c * 'b) t
     | Split : ('a, 'b) t * ('c, 'd) t -> ('a * 'c, 'b * 'd) t
     | Fanout : ('a, 'b) t * ('a, 'c) t -> ('a, 'b * 'c) t
-    | Paths : Path.Set.t -> ('a, 'a) t
     | Paths_for_rule : Path.Set.t -> ('a, 'a) t
     | Paths_glob : Path.t * Path.t Predicate.t -> ('a, Path.Set.t) t
     | If_file_exists : Path.t * ('a, 'b) if_file_exists_state ref -> ('a, 'b) t
@@ -207,8 +206,7 @@ module Repr : sig
     | Memo : 'a memo -> (unit, 'a) t
     | Catch : ('a, 'b) t * (exn -> 'b) -> ('a, 'b) t
     | Lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
-    | Env_var : string -> ('a, 'a) t
-    | Universe : ('a, 'a) t
+    | Deps : Dep.Set.t -> ('a, 'a) t
 
   and 'a memo =
     { name          : string

--- a/src/build_interpret.ml
+++ b/src/build_interpret.ml
@@ -35,8 +35,8 @@ let static_deps t ~all_targets =
     | Second t -> loop t acc targets_allowed
     | Split (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
     | Fanout (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
-    | Paths fns ->
-      Static_deps.add_action_paths acc fns
+    | Deps deps ->
+      Static_deps.add_action_deps acc deps
     | Paths_for_rule fns ->
       Static_deps.add_rule_paths acc fns
     | Paths_glob (dir, pred) ->
@@ -66,9 +66,6 @@ let static_deps t ~all_targets =
     | Memo m -> loop m.t acc targets_allowed
     | Catch (t, _) -> loop t acc targets_allowed
     | Lazy_no_targets t -> loop (Lazy.force t) acc false
-    | Env_var var ->
-      Static_deps.add_action_env_var acc var
-    | Universe -> Static_deps.add_action_dep acc Dep.universe
   in
   loop (Build.repr t) Static_deps.empty true
 
@@ -84,10 +81,10 @@ let lib_deps =
       | Second t -> loop t acc
       | Split (a, b) -> loop a (loop b acc)
       | Fanout (a, b) -> loop a (loop b acc)
-      | Paths _ -> acc
       | Paths_for_rule _ -> acc
       | Vpath _ -> acc
       | Paths_glob _ -> acc
+      | Deps _ -> acc
       | Dyn_paths t -> loop t acc
       | Dyn_deps t -> loop t acc
       | Contents _ -> acc
@@ -99,8 +96,6 @@ let lib_deps =
       | Memo m -> loop m.t acc
       | Catch (t, _) -> loop t acc
       | Lazy_no_targets t -> loop (Lazy.force t) acc
-      | Universe -> acc
-      | Env_var _ -> acc
   in
   fun t -> loop (Build.repr t) Lib_name.Map.empty
 
@@ -116,10 +111,10 @@ let targets =
     | Second t -> loop t acc
     | Split (a, b) -> loop a (loop b acc)
     | Fanout (a, b) -> loop a (loop b acc)
-    | Paths _ -> acc
     | Paths_for_rule _ -> acc
     | Vpath _ -> acc
     | Paths_glob _ -> acc
+    | Deps _ -> acc
     | Dyn_paths t -> loop t acc
     | Dyn_deps t -> loop t acc
     | Contents _ -> acc
@@ -145,8 +140,6 @@ let targets =
     | Memo m -> loop m.t acc
     | Catch (t, _) -> loop t acc
     | Lazy_no_targets _ -> acc
-    | Universe -> acc
-    | Env_var _ -> acc
   in
   fun t -> loop (Build.repr t) []
 

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -542,7 +542,7 @@ module Build_exec = struct
         let a = exec dyn_deps a x in
         let b = exec dyn_deps b x in
         (a, b)
-      | Paths _ -> x
+      | Deps _ -> x
       | Paths_for_rule _ -> x
       | Paths_glob (dir, pred) -> eval_pred ~dir pred
       | Contents p -> Io.read_file p
@@ -570,8 +570,6 @@ module Build_exec = struct
         end
       | Lazy_no_targets t ->
         exec dyn_deps (Lazy.force t) x
-      | Env_var _ ->
-        x
       | Memo m ->
         begin match m.state with
         | Evaluated (x, deps) ->
@@ -591,7 +589,6 @@ module Build_exec = struct
             m.state <- Unevaluated;
             reraise exn
         end
-      | Universe -> x
     in
     let dyn_deps = ref Dep.Set.empty in
     let result = exec dyn_deps (Build.repr t) x in

--- a/src/dep.ml
+++ b/src/dep.ml
@@ -77,6 +77,9 @@ module Set = struct
 
   let of_files = List.fold_left ~init:empty ~f:(fun acc f -> add acc (file f))
 
+  let of_files_set =
+    Path.Set.fold ~init:empty ~f:(fun f acc -> add acc (file f))
+
   let trace t ~env ~eval_pred =
     List.concat_map (to_list t) ~f:(trace ~env ~eval_pred)
 

--- a/src/dep.mli
+++ b/src/dep.mli
@@ -24,6 +24,8 @@ module Set : sig
 
   val of_files : Path.t list -> t
 
+  val of_files_set : Path.Set.t -> t
+
   val paths :  t -> eval_pred:eval_pred -> Path.Set.t
 
   val encode : t -> Dune_lang.t

--- a/src/static_deps.ml
+++ b/src/static_deps.ml
@@ -35,6 +35,11 @@ let add_action_dep t dep =
     action_deps = Dep.Set.add t.action_deps dep
   }
 
+let add_action_deps t deps =
+  { t with
+    action_deps = Dep.Set.union t.action_deps deps
+  }
+
 let add_action_paths t fns =
   { t with
     action_deps = Dep.Set.add_paths t.action_deps fns

--- a/src/static_deps.mli
+++ b/src/static_deps.mli
@@ -30,6 +30,9 @@ val add_action_env_var : t -> string -> t
 (** Add a dependency to action deps. *)
 val add_action_dep : t -> Dep.t -> t
 
+(** Add dependencies to action deps. *)
+val add_action_deps : t -> Dep.Set.t -> t
+
 (** {1} Deconstructors *)
 
 (** Return the rule deps. *)

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -487,7 +487,7 @@ module Deps = struct
       Alias.dep (Alias.package_install ~context:t.context ~pkg)
       >>^ fun () -> []
     | Universe ->
-      Build.universe
+      Build.dep Dep.universe
       >>^ fun () -> []
     | Env_var var_sw ->
       let var = Expander.expand_str expander var_sw in


### PR DESCRIPTION
This allows us to introduce dependency primitives without having to change
[Build.t]. Note that Globs are not included since they require a different index
in the GADT.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>