### PR TITLE
More conversions to dyn

### DIFF
--- a/src/context.mli
+++ b/src/context.mli
@@ -133,6 +133,7 @@ val equal : t -> t -> bool
 val hash : t -> int
 
 val to_sexp : t -> Sexp.t
+val to_dyn : t -> Dyn.t
 
 (** Compare the context names *)
 val compare : t -> t -> Ordering.t

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -108,7 +108,7 @@ module Dir = struct
     Record
       [ "files", String.Set.to_dyn files
       ; "sub_dirs", String.Map.to_dyn to_dyn sub_dirs
-      ; "dune_file", Dyn.option (fun _ -> Dyn.opaque) dune_file
+      ; "dune_file", Dyn.Encoder.(option opaque dune_file)
       ; "project", Dyn.opaque
       ]
 

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -17,15 +17,17 @@ module Value = struct
     | Words         of string list
     | Prog_and_args of Prog_and_args.t
 
-  let to_sexp : t -> Sexp.t =
-    let open Sexp.Encoder in
+  let to_dyn : t -> Dyn.t =
+    let open Dyn.Encoder in
     function
-    | Bool   x -> bool x
-    | Int    x -> int x
-    | String x -> string x
+    | Bool   x -> Bool x
+    | Int    x -> Int x
+    | String x -> String x
     | Words  x -> (list string) x
     | Prog_and_args { prog; args } ->
       (list string) (prog :: args)
+
+  let to_sexp t = Dyn.to_sexp (to_dyn t)
 
   let to_string = function
     | Bool   x -> string_of_bool x
@@ -188,14 +190,14 @@ let to_list t : (string * Value.t) list =
   ; "windows_unicode"          , Bool          t.windows_unicode
   ]
 
-let to_sexp t =
-  let open Sexp in
-  List
+let to_dyn t =
+  let open Dyn in
+  Record
     (to_list t
      |> List.map ~f:(fun (k, v) ->
-       List [ Atom k
-            ; Value.to_sexp v
-            ]))
+       k, Value.to_dyn v))
+
+let to_sexp t = Dyn.to_sexp (to_dyn t)
 
 module Origin = struct
   type t =

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -8,6 +8,7 @@ open! Stdune
     contents of [Makefile.config]. *)
 type t
 
+val to_dyn : t Dyn.Encoder.t
 val to_sexp : t Sexp.Encoder.t
 
 module Prog_and_args : sig

--- a/src/stdune/dyn.mli
+++ b/src/stdune/dyn.mli
@@ -6,6 +6,7 @@ type t = Dyn0.t =
   | Bytes of bytes
   | Char of char
   | Float of float
+  | Sexp of Sexp0.t
   | Option of t option
   | List of t list
   | Array of t array
@@ -15,10 +16,35 @@ type t = Dyn0.t =
   | Map of (t * t) list
   | Set of t list
 
+module Encoder : sig
+  type dyn
+
+  type 'a t = 'a -> dyn
+
+  val unit       : unit                      t
+  val char       : char                      t
+  val string     : string                    t
+  val int        : int                       t
+  val float      : float                     t
+  val bool       : bool                      t
+  val pair       : 'a t -> 'b t -> ('a * 'b) t
+  val triple     : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
+  val list       : 'a t -> 'a list           t
+  val array      : 'a t -> 'a array          t
+  val option     : 'a t -> 'a option         t
+
+  val via_sexp : ('a -> Sexp0.t) -> 'a t
+
+  val record : (string * dyn) list -> dyn
+
+  val unknown : _ t
+  val opaque : _ t
+
+  val constr : string -> dyn list -> dyn
+end with type dyn := t
+
 val pp : Format.formatter -> t -> unit
 
 val opaque : t
 
 val to_sexp : t Sexp.Encoder.t
-
-val option : ('a -> t) -> 'a option -> t

--- a/src/stdune/dyn0.ml
+++ b/src/stdune/dyn0.ml
@@ -6,6 +6,7 @@ type t =
   | Bytes of bytes
   | Char of char
   | Float of float
+  | Sexp of Sexp0.t
   | Option of t option
   | List of t list
   | Array of t array

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -12,6 +12,7 @@ module Var = struct
   include T
 end
 
+let map_to_dyn = Map.to_dyn
 module Map = Map.Make(Var)
 
 type t =
@@ -69,9 +70,12 @@ let extend t ~vars =
 let extend_env x y =
   extend x ~vars:y.vars
 
+let to_dyn t =
+  let open Dyn.Encoder in
+  map_to_dyn Map.to_list string string t.vars
+
 let to_sexp t =
-  let open Sexp.Encoder in
-  (list (pair string string)) (Map.to_list t.vars)
+  Dyn.to_sexp (to_dyn t)
 
 let diff x y =
   Map.merge x.vars y.vars ~f:(fun _k vx vy ->

--- a/src/stdune/env.mli
+++ b/src/stdune/env.mli
@@ -34,6 +34,8 @@ val update : t -> var:string -> f:(string option -> string option) -> t
 
 val to_sexp : t -> Sexp.t
 
+val to_dyn : t -> Dyn.t
+
 val of_string_map : string String.Map.t -> t
 
 val iter : t -> f:(string -> string -> unit) -> unit

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -92,13 +92,16 @@ let iter t ~f = iter ~f t
 
 let keys t = foldi t ~init:[] ~f:(fun key _ acc -> key :: acc)
 
-let to_sexp (type key) f g t =
+let to_dyn (type key) f g t =
   let module M =
     Map.Make(struct
       type t = key
       let compare a b = Ordering.of_int (compare a b)
     end)
   in
-  Map.to_sexp M.to_list f g
+  Map.to_dyn M.to_list f g
     (foldi t ~init:M.empty ~f:(fun key data acc ->
        M.add acc key data))
+
+let to_sexp f g t =
+  Dyn.to_sexp (to_dyn (Dyn.Encoder.via_sexp f) (Dyn.Encoder.via_sexp g) t)

--- a/src/stdune/hashtbl.mli
+++ b/src/stdune/hashtbl.mli
@@ -32,3 +32,4 @@ val mem : ('a, _) t -> 'a -> bool
 val keys : ('a, _) t -> 'a list
 
 val to_sexp : ('a -> Sexp.t) -> ('b -> Sexp.t) -> ('a, 'b) t -> Sexp.t
+val to_dyn : ('a -> Dyn.t) -> ('b -> Dyn.t) -> ('a, 'b) t -> Dyn.t

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -146,5 +146,8 @@ module Make(Key : Comparable.S) : S with type key = Key.t = struct
     union a b ~f:(fun _ _ y -> Some y)
 end
 
+let to_dyn to_list f g t =
+  Dyn.Map (List.map ~f:(fun (k, v) -> (f k, g v)) (to_list t))
+
 let to_sexp to_list f g t =
-  Sexp.Encoder.(list (pair f g)) (to_list t)
+  Dyn.to_sexp (to_dyn to_list (Dyn.Encoder.via_sexp f) (Dyn.Encoder.via_sexp g) t)

--- a/src/stdune/map.mli
+++ b/src/stdune/map.mli
@@ -7,3 +7,9 @@ val to_sexp
   -> 'b Sexp.Encoder.t
   -> 'c Sexp.Encoder.t
   -> 'a Sexp.Encoder.t
+
+val to_dyn
+  :  ('a -> ('b * 'c) list)
+  -> ('b -> Dyn0.t)
+  -> ('c -> Dyn0.t)
+  -> ('a -> Dyn0.t)

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -1,4 +1,4 @@
-module String = String0
+module String = Dune_caml.StringLabels
 
 type +'a t =
   | Nop
@@ -77,7 +77,7 @@ module Renderer = struct
 
     let extract_closing_tag s =
       let pos = 2 + get16 s 0 in
-      String.drop s pos
+      String.sub s ~pos ~len:(String.length s - pos)
 
     let rec pp th ppf t =
       match t with

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -12,6 +12,7 @@ type +'a t =
   | String of string
   | Char of char
   | Float of float
+  | Sexp of Sexp0.t
   | List : 'b t * ('a -> 'b t) * 'a list -> 'b t
   | Space
   | Cut
@@ -106,6 +107,7 @@ module Renderer = struct
       | String x -> pp_print_string ppf x
       | Char   x -> pp_print_char ppf x
       | Float  x -> pp_print_float ppf x
+      | Sexp x -> Sexp1.pp ppf x
       | List (sep, f, l) ->
         pp_print_list (fun ppf x -> pp th ppf (f x)) ppf l
           ~pp_sep:(fun ppf () -> pp th ppf sep)
@@ -175,6 +177,7 @@ let int x = Int x
 let string x = String x
 let char x = Char x
 let float x = Float x
+let sexp s = Sexp s
 let list ?(sep=Cut) l ~f = List (sep, f, l)
 
 let space = Space

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -1,3 +1,5 @@
+module String = String0
+
 type +'a t =
   | Nop
   | Seq of 'a t * 'a t

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -60,6 +60,7 @@ val int    : int    -> _ t
 val string : string -> _ t
 val char   : char   -> _ t
 val float  : float  -> _ t
+val sexp  : Sexp0.t  -> _ t
 val list   : ?sep:'b t -> 'a list -> f:('a -> 'b t) -> 'b t
 
 val space   : _ t

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -2,7 +2,7 @@ module Array = ArrayLabels
 module List = ListLabels
 module String = StringLabels
 
-type t =
+type t = Sexp0.t =
   | Atom of string
   | List of t list
 
@@ -44,22 +44,7 @@ let rec to_string = function
       (List.map ~f:to_string l
        |> String.concat ~sep:" ")
 
-let rec pp ppf = function
-  | Atom s ->
-    Format.pp_print_string ppf (Escape.quote_if_needed s)
-  | List [] ->
-    Format.pp_print_string ppf "()"
-  | List (first :: rest) ->
-    Format.pp_open_box ppf 1;
-    Format.pp_print_string ppf "(";
-    Format.pp_open_hvbox ppf 0;
-    pp ppf first;
-    List.iter rest ~f:(fun sexp ->
-      Format.pp_print_space ppf ();
-      pp ppf sexp);
-    Format.pp_close_box ppf ();
-    Format.pp_print_string ppf ")";
-    Format.pp_close_box ppf ()
+let pp = Sexp1.pp
 
 let hash = Dune_caml.Hashtbl.hash
 

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -1,4 +1,4 @@
-type t =
+type t = Sexp0.t =
   | Atom of string
   | List of t list
 

--- a/src/stdune/sexp0.ml
+++ b/src/stdune/sexp0.ml
@@ -1,0 +1,3 @@
+type t =
+  | Atom of string
+  | List of t list

--- a/src/stdune/sexp1.ml
+++ b/src/stdune/sexp1.ml
@@ -1,0 +1,20 @@
+include Sexp0
+
+module List = ListLabels
+
+let rec pp ppf = function
+  | Atom s ->
+    Format.pp_print_string ppf (Escape.quote_if_needed s)
+  | List [] ->
+    Format.pp_print_string ppf "()"
+  | List (first :: rest) ->
+    Format.pp_open_box ppf 1;
+    Format.pp_print_string ppf "(";
+    Format.pp_open_hvbox ppf 0;
+    pp ppf first;
+    List.iter rest ~f:(fun sexp ->
+      Format.pp_print_space ppf ();
+      pp ppf sexp);
+    Format.pp_close_box ppf ();
+    Format.pp_print_string ppf ")";
+    Format.pp_close_box ppf ()

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -264,7 +264,9 @@ let concat ~sep = function
 let take s len =
   sub s ~pos:0 ~len:(min (length s) len)
 
-let drop = String0.drop
+let drop s n =
+  let len = length s in
+  sub s ~pos:(min n len) ~len:(max (len - n) 0)
 
 let split_n s n =
   let len = length s in

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -264,9 +264,7 @@ let concat ~sep = function
 let take s len =
   sub s ~pos:0 ~len:(min (length s) len)
 
-let drop s n =
-  let len = length s in
-  sub s ~pos:(min n len) ~len:(max (len - n) 0)
+let drop = String0.drop
 
 let split_n s n =
   let len = length s in

--- a/src/stdune/string0.ml
+++ b/src/stdune/string0.ml
@@ -1,0 +1,7 @@
+module String = Dune_caml.String
+
+include StringLabels
+
+let drop s n =
+  let len = length s in
+  sub s ~pos:(min n len) ~len:(max (len - n) 0)

--- a/src/stdune/string0.ml
+++ b/src/stdune/string0.ml
@@ -1,7 +1,0 @@
-module String = Dune_caml.String
-
-include StringLabels
-
-let drop s n =
-  let len = length s in
-  sub s ~pos:(min n len) ~len:(max (len - n) 0)

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -41,6 +41,7 @@ let external_lib_deps_mode t = t.external_lib_deps_mode
 
 let equal = ((==) : t -> t -> bool)
 let hash t = Context.hash t.context
+let to_dyn t = Context.to_dyn t.context
 let to_sexp t = Context.to_sexp t.context
 
 let host t = Option.value t.host ~default:t

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -14,6 +14,7 @@ type t
 val equal : t -> t -> bool
 val hash : t -> int
 
+val to_dyn : t -> Dyn.t
 val to_sexp : t -> Sexp.t
 
 val create


### PR DESCRIPTION
- Add a few conversion to `Dyn.t`
- Add a constructor `Dyn.Sexp` for cases where obtaining a `Dyn.t` is otherwise not easy.
- Introduce `Dyn.Encoder` module similar to `Sexp.Encoder`, both because it's useful and to make it even easier to migrate from Sexp to Dyn.