### PR TITLE
[dir_contents] Allow qualified traversal of directories.

### DIFF
--- a/src/dir_status.ml
+++ b/src/dir_status.ml
@@ -15,6 +15,7 @@ module T = struct
        generated ones. *)
 
     | Group_root of File_tree.Dir.t
+                    * Include_subdirs.qualification
                     * Stanza.t list Dir_with_dune.t
     (* Directory with [(include_subdirs x)] where [x] is not [no] *)
 
@@ -105,8 +106,8 @@ module DB = struct
                { stanzas = None; group_root })
       | Some d ->
         match get_include_subdirs d.data with
-        | Some Unqualified ->
-          Group_root (ft_dir, d)
+        | Some (Include mode) ->
+          Group_root (ft_dir, mode, d)
         | Some No ->
           Standalone (Some (ft_dir, Some d))
         | None ->

--- a/src/dir_status.mli
+++ b/src/dir_status.mli
@@ -13,6 +13,7 @@ type t =
      generated ones. *)
 
   | Group_root of File_tree.Dir.t
+                  * Dune_file.Include_subdirs.qualification
                   * Stanza.t list Dir_with_dune.t
   (* Directory with [(include_subdirs x)] where [x] is not [no] *)
 

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1960,13 +1960,17 @@ module Documentation = struct
 end
 
 module Include_subdirs = struct
-  type t = No | Unqualified
 
-  let decode =
-    enum
+  type qualification = Unqualified | Qualified
+  type t = No | Include of qualification
+
+  let decode ~enable_qualified =
+    let opts_list =
       [ "no", No
-      ; "unqualified", Unqualified
-      ]
+      ; "unqualified", Include Unqualified
+      ] @ if enable_qualified then ["qualified", Include Qualified] else []
+    in
+    enum opts_list
 end
 
 type Stanza.t +=
@@ -2053,7 +2057,7 @@ module Stanzas = struct
        [Dune_env.T x])
     ; "include_subdirs",
       (let+ () = Syntax.since Stanza.syntax (1, 1)
-       and+ t = Include_subdirs.decode
+       and+ t = Include_subdirs.decode ~enable_qualified:false
        and+ loc = loc in
        [Include_subdirs (loc, t)])
     ; "toplevel",

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -405,7 +405,8 @@ module Toplevel : sig
 end
 
 module Include_subdirs : sig
-  type t = No | Unqualified
+  type qualification = Unqualified | Qualified
+  type t = No | Include of qualification
 end
 
 type Stanza.t +=


### PR DESCRIPTION
This is a cherry-pick of the directory traversal parts from the Dune
PR (#1968) plus a modification to enable the `qualified` mode inside `(include_subdirs ...)`

I was uncomfortable with the misnaming done there, so this PR enables
the `(include_subdirs qualified)` syntax and provides a `local` part
to the traversal so clients [such as the Coq mode] can use it.

Note that this does introduce a bit of overhead in the tree traversal,
especially in deep trees, it should be possible to optimize if we deem
it necessary.