### PR TITLE
Install private cmi's

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -29,7 +29,7 @@ module Modules = struct
         match (stanza : Stanza.t) with
         | Library lib ->
           let obj_dir =
-            Obj_dir.make_local ~dir:d.ctx_dir (snd lib.name)
+            Obj_dir.make_lib ~dir:d.ctx_dir (snd lib.name)
               ~has_private_modules:(Option.is_some lib.private_modules)
           in
           let modules =

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1059,7 +1059,7 @@ module Library = struct
   let is_impl t = Option.is_some t.implements
 
   let obj_dir ~dir t =
-    Obj_dir.make_local ~dir
+    Obj_dir.make_lib ~dir
       ~has_private_modules:(t.private_modules <> None)
       (snd t.name)
 

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -1080,6 +1080,7 @@ module Decoder = struct
       | Values (loc, cstr, _) -> (Values (loc, cstr), state)
       | Fields (loc, cstr, _) -> (Fields (loc, cstr), state)
 
+  let ( let* ) = ( >>= )
   let ( let+ ) = ( >>| )
   let ( and+ ) a b ctx state =
     let a, state = a ctx state in

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -487,6 +487,7 @@ module Decoder : sig
 
   val leftover_fields : Ast.t list fields_parser
 
+  val ( let* ) : ('a, 'k) parser -> ('a -> ('b, 'k) parser) -> ('b, 'k) parser
   val ( let+ ) : ('a, 'k) parser -> ('a -> 'b) -> ('b, 'k) parser
   val ( and+ ) : ('a, 'k) parser -> ('b, 'k) parser -> ('a * 'b, 'k) parser
 end

--- a/src/dune_package.ml
+++ b/src/dune_package.ml
@@ -135,6 +135,7 @@ module Lib = struct
       >>= fun default_implementation ->
       field "name" Lib_name.decode >>= fun name ->
       let dir = Path.append_local base (dir_of_name name) in
+      let obj_dir = Obj_dir.make_external ~dir in
       let+ synopsis = field_o "synopsis" string
       and+ loc = loc
       and+ modes = field_l "modes" Mode.decode
@@ -150,7 +151,7 @@ module Lib = struct
       and+ sub_systems = Sub_system_info.record_parser ()
       and+ orig_src_dir = field_o "orig_src_dir" path
       and+ modules = field_o "modules" (Lib_modules.decode
-                         ~implements:(Option.is_some implements) ~dir)
+                         ~implements:(Option.is_some implements) ~obj_dir)
       in
       let modes = Mode.Dict.Set.of_list modes in
       { kind

--- a/src/dune_package.ml
+++ b/src/dune_package.ml
@@ -7,7 +7,7 @@ module Lib = struct
   type 'sub_system t =
     { loc              : Loc.t
     ; name             : Lib_name.t
-    ; dir              : Path.t
+    ; obj_dir          : Obj_dir.t
     ; orig_src_dir     : Path.t option
     ; kind             : Lib_kind.t
     ; synopsis         : string option
@@ -33,7 +33,8 @@ module Lib = struct
         ~foreign_archives ~jsoo_runtime ~main_module_name ~sub_systems
         ~requires ~ppx_runtime_deps ~implements ~variant
         ~default_implementation ~virtual_ ~modules ~modes
-        ~version ~orig_src_dir ~dir =
+        ~version ~orig_src_dir ~obj_dir =
+    let dir = Obj_dir.dir obj_dir in
     let map_path p =
       if Path.is_managed p then
         Path.relative dir (Path.basename p)
@@ -59,14 +60,15 @@ module Lib = struct
     ; variant
     ; default_implementation
     ; version
-    ; dir
     ; orig_src_dir
     ; virtual_
     ; modules
     ; modes
+    ; obj_dir
     }
 
-  let dir t = t.dir
+  let obj_dir t = t.obj_dir
+  let dir t = Obj_dir.dir t.obj_dir
   let orig_src_dir t = t.orig_src_dir
 
   let set_subsystems t sub_systems =
@@ -81,7 +83,7 @@ module Lib = struct
         ; foreign_objects ; foreign_archives ; jsoo_runtime ; requires
         ; ppx_runtime_deps ; sub_systems ; virtual_
         ; implements ; variant ; default_implementation
-        ; main_module_name ; version = _; dir = _; orig_src_dir
+        ; main_module_name ; version = _; obj_dir ; orig_src_dir
         ; modules ; modes
         } =
     let open Dune_lang.Encoder in
@@ -110,6 +112,7 @@ module Lib = struct
         (no_loc Lib_name.encode) default_implementation
     ; field_o "main_module_name" Module.Name.encode main_module_name
     ; field_l "modes" sexp (Mode.Dict.Set.encode modes)
+    ; field_l "obj_dir" sexp (Obj_dir.encode obj_dir)
     ; field_l "modules" sexp
         (match modules with
          | None -> []
@@ -128,14 +131,19 @@ module Lib = struct
       field ~default:Mode.Dict.List.empty
         name (Mode.Dict.List.decode path) in
     record (
-      field_o "main_module_name" Module.Name.decode >>= fun main_module_name ->
-      field_o "implements" (located Lib_name.decode) >>= fun implements ->
-      field_o "variant" Variant.decode >>= fun variant ->
-      field_o "default_implementation" (located Lib_name.decode)
-      >>= fun default_implementation ->
-      field "name" Lib_name.decode >>= fun name ->
+      let* main_module_name = field_o "main_module_name" Module.Name.decode in
+      let* implements = field_o "implements" (located Lib_name.decode) in
+      let* variant = field_o "variant" Variant.decode in
+      let* default_implementation =
+        field_o "default_implementation" (located Lib_name.decode) in
+      let* name = field "name" Lib_name.decode in
       let dir = Path.append_local base (dir_of_name name) in
-      let obj_dir = Obj_dir.make_external ~dir in
+      let* obj_dir = field_o "obj_dir" (Obj_dir.decode ~dir) in
+      let obj_dir =
+        match obj_dir with
+        | None -> Obj_dir.make_external ~dir
+        | Some obj_dir -> obj_dir
+      in
       let+ synopsis = field_o "synopsis" string
       and+ loc = loc
       and+ modes = field_l "modes" Mode.decode
@@ -172,8 +180,8 @@ module Lib = struct
       ; main_module_name
       ; virtual_
       ; version = None
-      ; dir
       ; orig_src_dir
+      ; obj_dir
       ; modules
       ; modes
       }

--- a/src/dune_package.ml
+++ b/src/dune_package.ml
@@ -141,7 +141,7 @@ module Lib = struct
       let* obj_dir = field_o "obj_dir" (Obj_dir.decode ~dir) in
       let obj_dir =
         match obj_dir with
-        | None -> Obj_dir.make_external ~dir
+        | None -> Obj_dir.make_external_no_private ~dir
         | Some obj_dir -> obj_dir
       in
       let+ synopsis = field_o "synopsis" string

--- a/src/dune_package.mli
+++ b/src/dune_package.mli
@@ -5,6 +5,7 @@ module Lib : sig
 
   val dir : _ t -> Path.t
   val orig_src_dir : _ t -> Path.t option
+  val obj_dir : _ t -> Obj_dir.t
   val requires : _ t -> (Loc.t * Lib_name.t) list
   val name : _ t -> Lib_name.t
   val version : _ t -> string option
@@ -55,7 +56,7 @@ module Lib : sig
     -> modes:Mode.Dict.Set.t
     -> version:string option
     -> orig_src_dir:Path.t option
-    -> dir:Path.t
+    -> obj_dir:Obj_dir.t
     -> 'a t
 
   val set_subsystems : 'a t -> 'b Sub_system_name.Map.t -> 'b t

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -134,7 +134,7 @@ let link_exe
   let compiler = Option.value_exn (Context.compiler ctx mode) in
   let kind = Mode.cm_kind mode in
   let artifacts ~ext modules =
-    List.map modules ~f:(Module.obj_file ~mode ~ext)
+    List.map modules ~f:(Module.obj_file ~kind ~ext)
   in
   let modules_and_cm_files =
     Build.memoize "cm files"

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -212,7 +212,7 @@ module Package = struct
       | Some p -> Installed_dune_file.load p
     in
     let archives = archives t in
-    let obj_dir = Obj_dir.make_external ~dir:t.dir in
+    let obj_dir = Obj_dir.make_external_no_private ~dir:t.dir in
     let modes : Mode.Dict.Set.t =
       Mode.Dict.map ~f:(fun x -> not (List.is_empty x)) archives in
     Dune_package.Lib.make

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -212,6 +212,7 @@ module Package = struct
       | Some p -> Installed_dune_file.load p
     in
     let archives = archives t in
+    let obj_dir = Obj_dir.make_external ~dir:t.dir in
     let modes : Mode.Dict.Set.t =
       Mode.Dict.map ~f:(fun x -> not (List.is_empty x)) archives in
     Dune_package.Lib.make
@@ -236,7 +237,7 @@ module Package = struct
       ~main_module_name:None (* XXX remove *)
       ~version:(version t)
       ~modes
-      ~dir:t.dir
+      ~obj_dir
 
   let parse db ~meta_file ~name ~parent_dir ~vars =
     let pkg_dir = Vars.get vars "directory" Ps.empty in

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -235,7 +235,7 @@ let lib_install_files sctx ~dir_contents ~dir ~sub_dir ~scope ~dir_kind
         ; if_ (byte && Module.has_impl m && virtual_library)
             [ Module.cm_file_unsafe m Cmo ]
         ; if_ (native && Module.has_impl m && virtual_library)
-            [ Module.obj_file m ~mode:Native ~ext:ctx.ext_obj ]
+            [ Module.obj_file m ~kind:Cmx ~ext:ctx.ext_obj ]
         ; List.filter_map Ml_kind.all ~f:(Module.cmt_file m)
         ])
   in

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1604,7 +1604,7 @@ let () =
 let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects ~dir =
   let add_loc = List.map ~f:(fun x -> (info.loc, x.name)) in
   let virtual_ = Option.is_some info.virtual_ in
-  let obj_dir = Obj_dir.make_external ~dir in
+  let obj_dir = Obj_dir.convert_to_external ~dir (obj_dir lib) in
   let lib_modules =
     Lib_modules.version_installed ~install_dir:obj_dir lib_modules in
   let orig_src_dir =

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1604,8 +1604,9 @@ let () =
 let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects ~dir =
   let add_loc = List.map ~f:(fun x -> (info.loc, x.name)) in
   let virtual_ = Option.is_some info.virtual_ in
+  let obj_dir = Obj_dir.make_external ~dir in
   let lib_modules =
-    Lib_modules.version_installed ~install_dir:dir lib_modules in
+    Lib_modules.version_installed ~install_dir:obj_dir lib_modules in
   let orig_src_dir =
     if !Clflags.store_orig_src_dir
     then Some (
@@ -1624,7 +1625,7 @@ let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects ~dir 
     | Local -> foreign_objects
   in
   Dune_package.Lib.make
-    ~dir
+    ~obj_dir
     ~orig_src_dir
     ~name
     ~loc:info.loc

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -88,7 +88,7 @@ let of_library_stanza ~dir ~has_native ~ext_lib ~ext_obj
       (conf : Dune_file.Library.t) =
   let (_loc, lib_name) = conf.name in
   let obj_dir =
-    Obj_dir.make_local ~dir
+    Obj_dir.make_lib ~dir
       ~has_private_modules:(conf.private_modules <> None) lib_name in
   let gen_archive_file ~dir ext =
     Path.relative dir (Lib_name.Local.to_string lib_name ^ ext) in

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -196,7 +196,7 @@ let of_dune_lib dp =
     Lib.wrapped dp
     |> Option.map ~f:(fun w -> Dune_file.Library.Inherited.This w)
   in
-  let obj_dir = Obj_dir.make_external ~dir:src_dir in
+  let obj_dir = Lib.obj_dir dp in
   { loc = Lib.loc dp
   ; name = Lib.name dp
   ; kind = Lib.kind dp

--- a/src/lib_modules.ml
+++ b/src/lib_modules.ml
@@ -228,13 +228,13 @@ let encode
     ; field "wrapped" Wrapped.encode wrapped
     ]
 
-let decode ~implements ~dir =
+let decode ~implements ~obj_dir =
   let open Stanza.Decoder in
   fields (
-    let+ alias_module = field_o "alias_module" (Module.decode ~dir)
+    let+ alias_module = field_o "alias_module" (Module.decode ~obj_dir)
     and+ main_module_name = field_o "main_module_name" Module.Name.decode
     and+ modules =
-      field ~default:[] "modules" (list (enter (Module.decode ~dir)))
+      field ~default:[] "modules" (list (enter (Module.decode ~obj_dir)))
     and+ wrapped = field "wrapped" Wrapped.decode
     in
     let modules =

--- a/src/lib_modules.ml
+++ b/src/lib_modules.ml
@@ -160,9 +160,8 @@ let installable_modules t =
   | None -> modules
   | Some alias -> alias :: modules
 
-let version_installed t ~install_dir:(dir) =
-  let obj_dir = Obj_dir.make_external ~dir in
-  let set = Module.set_obj_dir ~obj_dir in
+let version_installed t ~install_dir =
+  let set = Module.set_obj_dir ~obj_dir:install_dir in
   { t with
     alias_module = Option.map ~f:set t.alias_module
   ; modules = Module.Name.Map.map ~f:set t.modules;

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -1,4 +1,4 @@
-open Stdune
+open! Stdune
 
 type t
 
@@ -32,7 +32,7 @@ val make
 
 val set_modules : t -> Module.Name_map.t -> t
 
-val version_installed : t -> install_dir:Path.t -> t
+val version_installed : t -> install_dir:Obj_dir.t -> t
 
 val for_compilation : t -> Module.Name_map.t
 

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -42,7 +42,7 @@ val for_alias : t -> Module.Name_map.t
 
 val encode : t -> Dune_lang.t list
 
-val decode : implements:bool -> dir:Path.t -> t Dune_lang.Decoder.t
+val decode : implements:bool -> obj_dir:Obj_dir.t -> t Dune_lang.Decoder.t
 
 val is_wrapped : t -> bool
 

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -46,7 +46,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
           Fn.id
       in
       let artifacts ~ext modules =
-        List.map modules ~f:(Module.obj_file ~mode ~ext)
+        List.map modules ~f:(Module.obj_file ~kind ~ext)
       in
       let obj_deps =
         Build.paths (artifacts modules ~ext:(Cm_kind.ext kind))
@@ -346,11 +346,11 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
           | Some m ->
             (* These files needs to be alongside stdlib.cma as the
                compiler implicitly adds this module. *)
-            [ Mode.Native, ".cmx"
-            ; Byte, ".cmo"
-            ; Native, ctx.ext_obj ]
-            |> List.iter ~f:(fun (mode, ext) ->
-              let src = Module.obj_file m ~mode ~ext in
+            [ Cm_kind.Cmx, ".cmx"
+            ; Cmo, ".cmo"
+            ; Cmx, ctx.ext_obj ]
+            |> List.iter ~f:(fun (kind, ext) ->
+              let src = Module.obj_file m ~kind ~ext in
               let dst = Path.relative dir ((Module.obj_name m) ^ ext) in
               SC.add_rule sctx ~dir (Build.copy ~src ~dst));
             Module.Name.Map.remove modules name
@@ -524,7 +524,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       ; compile_info
       };
 
-    let objs_dirs = Path.Set.singleton (Obj_dir.byte_dir obj_dir) in
+    let objs_dirs = Path.Set.of_list (Obj_dir.all_cmis obj_dir) in
 
     (cctx,
      Merlin.make ()

--- a/src/module.ml
+++ b/src/module.ml
@@ -446,7 +446,7 @@ let encode
        ; obj_name
        ; pp = _
        ; visibility
-       ; obj_dir
+       ; obj_dir = _
        ; kind
        } as t) =
   let open Dune_lang.Encoder in
@@ -465,11 +465,11 @@ let encode
     ; field_o "kind" Kind.encode kind
     ; field_b "impl" has_impl
     ; field_b "intf" (has_intf t)
-    ; field_i "obj_dir" Obj_dir.encode obj_dir
     ]
 
-let decode ~dir =
+let decode ~obj_dir =
   let open Dune_lang.Decoder in
+  let dir = Obj_dir.dir obj_dir in
   fields (
     let+ name = field "name" Name.decode
     and+ obj_name = field "obj_name" string
@@ -477,9 +477,6 @@ let decode ~dir =
     and+ kind = field_o "kind" Kind.decode
     and+ impl = field_b "impl"
     and+ intf = field_b "intf"
-    and+ obj_dir =
-      let default = Obj_dir.make_external ~dir in
-      field ~default "obj_dir" (Obj_dir.decode ~dir)
     in
     let file exists ml_kind =
       if exists then

--- a/src/module.mli
+++ b/src/module.mli
@@ -172,7 +172,7 @@ val visibility : t -> Visibility.t
 
 val encode : t -> Dune_lang.t list
 
-val decode : dir:Path.t -> t Dune_lang.Decoder.t
+val decode : obj_dir:Obj_dir.t -> t Dune_lang.Decoder.t
 
 (* Only the source of a module, not yet associated to a library *)
 module Source : sig

--- a/src/module.mli
+++ b/src/module.mli
@@ -52,12 +52,6 @@ module File : sig
   val make : Syntax.t -> Path.t -> t
 end
 
-module Visibility : sig
-  type t = Public | Private
-
-  include Dune_lang.Conv with type t := t
-end
-
 module Kind : sig
   type t = Intf_only | Virtual | Impl
 
@@ -94,7 +88,7 @@ val cm_file         : t -> ?ext:string -> Cm_kind.t -> Path.t option
 val cm_public_file  : t -> ?ext:string -> Cm_kind.t -> Path.t option
 val cmt_file        : t -> Ml_kind.t -> Path.t option
 
-val obj_file : t -> mode:Mode.t -> ext:string -> Path.t
+val obj_file : t -> kind:Cm_kind.t -> ext:string -> Path.t
 
 val obj_name : t -> string
 

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -65,7 +65,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
       in
       let other_targets =
         match cm_kind with
-        | Cmx -> Module.obj_file m ~mode:Native ~ext:ctx.ext_obj :: other_targets
+        | Cmx -> Module.obj_file m ~kind:Cmx ~ext:ctx.ext_obj :: other_targets
         | Cmi | Cmo -> other_targets
       in
       let dep_graph = Ml_kind.Dict.get dep_graphs ml_kind in

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -37,7 +37,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
       let copy_interface () =
         (* symlink the .cmi into the public interface directory *)
         if not (Module.is_private m)
-        && (Obj_dir.has_public_cmi_dir obj_dir) then
+        && (Obj_dir.need_dedicated_public_dir obj_dir) then
           SC.add_rule sctx ~sandbox:false ~dir
             (Build.symlink
                ~src:(Module.cm_file_unsafe m Cmi)

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -213,7 +213,7 @@ let eval ~modules:(all_modules : Module.Source.t Module.Name.Map.t)
       let name = Module.Source.name m in
       let visibility =
         if Module.Name.Map.mem private_modules name then
-          Module.Visibility.Private
+          Visibility.Private
         else
           Public
       in

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -18,7 +18,7 @@ module External = struct
     ; private_dir
     }
 
-  let has_public_cmi_dir t = Option.is_some t.private_dir
+  let need_dedicated_public_dir t = Option.is_some t.private_dir
 
   let public_cmi_dir t = t.public_dir
 
@@ -105,7 +105,7 @@ module Local = struct
     ; public_cmi_dir
     }
 
-  let has_public_cmi_dir t = Option.is_some t.public_cmi_dir
+  let need_dedicated_public_dir t = Option.is_some t.public_cmi_dir
 
   let public_cmi_dir t =
     Option.value ~default:t.byte_dir t.public_cmi_dir
@@ -156,9 +156,9 @@ type t =
   | External of External.t
   | Local of Local.t
 
-let has_public_cmi_dir = function
-  | External e -> External.has_public_cmi_dir e
-  | Local e -> Local.has_public_cmi_dir e
+let need_dedicated_public_dir = function
+  | External e -> External.need_dedicated_public_dir e
+  | Local e -> Local.need_dedicated_public_dir e
 
 let encode = function
   | Local obj_dir ->
@@ -216,7 +216,7 @@ let pp fmt t = Dyn.pp fmt (to_dyn t)
 let convert_to_external t ~dir =
   match t with
   | Local e ->
-    let has_private_modules = Local.has_public_cmi_dir e in
+    let has_private_modules = Local.need_dedicated_public_dir e in
     External (External.make ~dir ~has_private_modules)
   | External obj_dir ->
     Exn.code_error

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -133,7 +133,7 @@ let has_public_cmi_dir = function
 
 let encode = function
   | Local obj_dir ->
-    Exn.code_error "Obj_dir.encode: local paths cannot be encoded"
+    Exn.code_error "Obj_dir.encode: local obj_dir cannot be encoded"
       [ "obj_dir", Dyn.to_sexp (Local.to_dyn obj_dir)
       ]
   | External e -> External.encode e

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -1,127 +1,185 @@
 open! Stdune
 open Import
 
+module External = struct
+  type t =
+    { public_dir : Path.t
+    ; private_dir : Path.t option
+    }
+
+  let has_public_cmi_dir t = Option.is_some t.private_dir
+
+  let public_cmi_dir t = t.public_dir
+
+  let to_dyn { public_dir; private_dir } =
+    let open Dyn.Encoder in
+    record
+      [ "public_dir", Path.to_dyn public_dir
+      ; "private_dir", option Path.to_dyn private_dir
+      ]
+
+  let encode
+        { public_dir
+        ; private_dir
+        } =
+    let open Dune_lang.Encoder in
+    let extract d =
+      Path.descendant ~of_:public_dir d
+      |> Option.value_exn
+      |> Path.to_string
+    in
+    let private_dir = Option.map ~f:extract private_dir in
+    record_fields
+      [ field_o "private_dir" string private_dir
+      ]
+
+  let decode ~dir =
+    let open Dune_lang.Decoder in
+    fields (
+      let+ private_dir = field_o "private_dir" string
+      in
+      let public_dir = dir in
+      let private_dir = Option.map ~f:(Path.relative dir) private_dir in
+      { public_dir
+      ; private_dir
+      }
+    )
+
+  let byte_dir t = t.public_dir
+  let native_dir t = t.public_dir
+  let dir t = t.public_dir
+  let obj_dir t = t.public_dir
+
+  let all_obj_dirs t ~mode:_ =
+    [t.public_dir]
+end
+
+module Local = struct
+  type t =
+    { dir: Path.t
+    ; obj_dir: Path.t
+    ; native_dir: Path.t
+    ; byte_dir: Path.t
+    ; public_cmi_dir: Path.t option
+    }
+
+  let to_dyn { dir; obj_dir; native_dir; byte_dir; public_cmi_dir } =
+    let open Dyn.Encoder in
+    record
+      [ "dir", Path.to_dyn dir
+      ; "obj_dir", Path.to_dyn obj_dir
+      ; "native_dir", Path.to_dyn native_dir
+      ; "byte_dir", Path.to_dyn byte_dir
+      ; "public_cmi_dir", option Path.to_dyn public_cmi_dir
+      ]
+
+  let make ~dir ~obj_dir ~native_dir ~byte_dir ~public_cmi_dir =
+    { dir
+    ; obj_dir
+    ; native_dir
+    ; byte_dir
+    ; public_cmi_dir
+    }
+
+  let has_public_cmi_dir t = Option.is_some t.public_cmi_dir
+
+  let public_cmi_dir t =
+    Option.value ~default:t.byte_dir t.public_cmi_dir
+
+  let dir t = t.dir
+  let obj_dir t = t.obj_dir
+  let byte_dir t = t.byte_dir
+  let native_dir t = t.native_dir
+
+  let all_obj_dirs t ~(mode : Mode.t) =
+    let dirs = [t.byte_dir; public_cmi_dir t] in
+    let dirs =
+      match mode with
+      | Byte -> dirs
+      | Native -> t.native_dir :: dirs
+    in
+    Path.Set.of_list dirs
+    |> Path.Set.to_list
+
+  let make_lib ~dir ~has_private_modules lib_name =
+    let obj_dir = Utils.library_object_directory ~dir lib_name in
+    let public_cmi_dir =
+      Option.some_if
+        has_private_modules
+        (Utils.library_public_cmi_dir ~obj_dir)
+    in
+    make ~dir
+      ~obj_dir
+      ~native_dir:(Utils.library_native_dir ~obj_dir)
+      ~byte_dir:(Utils.library_byte_dir ~obj_dir)
+      ~public_cmi_dir
+
+  let make_exe ~dir ~name =
+    let obj_dir = Utils.executable_object_directory ~dir name in
+    make ~dir
+      ~obj_dir
+      ~native_dir:(Utils.library_native_dir ~obj_dir)
+      ~byte_dir:(Utils.library_byte_dir ~obj_dir)
+      ~public_cmi_dir:None
+end
+
 type t =
-  { dir: Path.t
-  ; obj_dir: Path.t
-  ; native_dir: Path.t
-  ; byte_dir: Path.t
-  ; public_cmi_dir: Path.t option
-  }
+  | External of External.t
+  | Local of Local.t
 
-let has_public_cmi_dir t = Option.is_some t.public_cmi_dir
+let has_public_cmi_dir = function
+  | External e -> External.has_public_cmi_dir e
+  | Local e -> Local.has_public_cmi_dir e
 
-let public_cmi_dir t =
-  Option.value ~default:t.byte_dir t.public_cmi_dir
-
-let dir t = t.dir
-let obj_dir t = t.obj_dir
-let byte_dir t = t.byte_dir
-let native_dir t = t.native_dir
-
-let all_obj_dirs t ~(mode : Mode.t) =
-  let dirs = [t.byte_dir; public_cmi_dir t] in
-  let dirs =
-    match mode with
-    | Byte -> dirs
-    | Native -> t.native_dir :: dirs
-  in
-  Path.Set.of_list dirs
-  |> Path.Set.to_list
-
-let make ~dir ~obj_dir ~native_dir ~byte_dir ~public_cmi_dir =
-  { dir
-  ; obj_dir
-  ; native_dir
-  ; byte_dir
-  ; public_cmi_dir
-  }
-
-let make_local ~dir ~has_private_modules lib_name =
-  let obj_dir = Utils.library_object_directory ~dir lib_name in
-  let public_cmi_dir =
-    Option.some_if
-      has_private_modules
-      (Utils.library_public_cmi_dir ~obj_dir)
-  in
-  make ~dir
-    ~obj_dir
-    ~native_dir:(Utils.library_native_dir ~obj_dir)
-    ~byte_dir:(Utils.library_byte_dir ~obj_dir)
-    ~public_cmi_dir
-
-let make_exe ~dir ~name =
-  let obj_dir = Utils.executable_object_directory ~dir name in
-  make ~dir
-    ~obj_dir
-    ~native_dir:(Utils.library_native_dir ~obj_dir)
-    ~byte_dir:(Utils.library_byte_dir ~obj_dir)
-    ~public_cmi_dir:None
-
-let make_external ~dir =
-  { dir
-  ; obj_dir = dir
-  ; native_dir = dir
-  ; byte_dir   = dir
-  ; public_cmi_dir = None
-  }
-
-let to_sexp { dir; obj_dir; native_dir; byte_dir; public_cmi_dir } =
-  let open Sexp.Encoder in
-  record
-    [ "dir", Path.to_sexp dir
-    ; "obj_dir", Path.to_sexp obj_dir
-    ; "native_dir", Path.to_sexp native_dir
-    ; "byte_dir", Path.to_sexp byte_dir
-    ; "public_cmi_dir", (option Path.to_sexp) public_cmi_dir
-    ]
-
-let pp fmt { dir; obj_dir; native_dir; byte_dir; public_cmi_dir } =
-  Fmt.record fmt
-    [ "dir", Fmt.const Path.pp dir
-    ; "obj_dir", Fmt.const Path.pp obj_dir
-    ; "native_dir", Fmt.const Path.pp native_dir
-    ; "byte_dir", Fmt.const Path.pp byte_dir
-    ; "public_cmi_dir", Fmt.const (Fmt.optional Path.pp) public_cmi_dir
-    ]
-
-
-let encode
-      { dir
-      ; obj_dir
-      ; native_dir
-      ; byte_dir
-      ; public_cmi_dir
-      } =
-  let open Dune_lang.Encoder in
-  let extract d =
-    Path.descendant ~of_:dir d
-    |> Option.value_exn
-    |> Path.to_string
-  in
-  let obj_dir = extract obj_dir in
-  let native_dir = extract native_dir in
-  let byte_dir = extract byte_dir in
-  let public_cmi_dir = Option.map ~f:extract public_cmi_dir in
-  record_fields
-    [ field "obj_dir" ~equal:String.equal ~default:"." string obj_dir
-    ; field "native_dir" ~equal:String.equal ~default:"." string native_dir
-    ; field "byte_dir" ~equal:String.equal ~default:"." string byte_dir
-    ; field_o "public_cmi_dir" string public_cmi_dir
-    ]
-
+let encode = function
+  | Local obj_dir ->
+    Exn.code_error "Obj_dir.encode: local paths cannot be encoded"
+      [ "obj_dir", Dyn.to_sexp (Local.to_dyn obj_dir)
+      ]
+  | External e -> External.encode e
 
 let decode ~dir =
   let open Dune_lang.Decoder in
-  fields (
-    let+ obj_dir = field ~default:"." "obj_dir" string
-    and+ native_dir = field ~default:"." "native_dir" string
-    and+ byte_dir = field ~default:"." "byte_dir" string
-    and+ public_cmi_dir = field_o "public_cmi_dir" string
-    in
-    make ~dir
-      ~obj_dir:(Path.relative dir obj_dir)
-      ~native_dir:(Path.relative dir native_dir)
-      ~byte_dir:(Path.relative dir byte_dir)
-      ~public_cmi_dir:(Option.map ~f:(Path.relative dir) public_cmi_dir)
-  )
+  let+ external_ = External.decode ~dir in
+  External external_
+
+let make_exe ~dir ~name = Local (Local.make_exe ~dir ~name)
+let make_lib ~dir ~has_private_modules lib_name =
+  Local (Local.make_lib ~dir ~has_private_modules lib_name)
+
+let make_external ~dir =
+  External { External.public_dir = dir; private_dir = None }
+
+let all_obj_dirs t ~mode =
+  match t with
+  | External e -> External.all_obj_dirs e ~mode
+  | Local e -> Local.all_obj_dirs e ~mode
+
+let public_cmi_dir = function
+  | External e -> External.public_cmi_dir e
+  | Local e -> Local.public_cmi_dir e
+
+let byte_dir = function
+  | External e -> External.byte_dir e
+  | Local e -> Local.byte_dir e
+
+let native_dir = function
+  | External e -> External.native_dir e
+  | Local e -> Local.native_dir e
+
+let dir = function
+  | External e -> External.dir e
+  | Local e -> Local.dir e
+
+let obj_dir = function
+  | External e -> External.obj_dir e
+  | Local e -> Local.obj_dir e
+
+let to_dyn =
+  let open Dyn.Encoder in
+  function
+  | Local e -> constr "Local" [Local.to_dyn e]
+  | External e -> constr "External" [External.to_dyn e]
+
+let to_sexp t = Dyn.to_sexp (to_dyn t)
+let pp fmt t = Dyn.pp fmt (to_dyn t)

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -24,7 +24,7 @@ val to_sexp: t -> Sexp.t
 
 val all_obj_dirs : t -> mode:Mode.t -> Path.t list
 
-val make_local
+val make_lib
   :  dir:Path.t
   -> has_private_modules:bool
   -> Lib_name.Local.t

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -19,7 +19,7 @@ val all_cmis: t -> Path.t list
 (** The public compiled cmi file directory *)
 val public_cmi_dir: t -> Path.t
 
-val has_public_cmi_dir : t -> bool
+val need_dedicated_public_dir : t -> bool
 
 val pp: t Fmt.t
 val to_sexp: t -> Sexp.t

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -32,7 +32,9 @@ val make_lib
 
 val make_exe: dir:Path.t -> name:string -> t
 
-val make_external: dir:Path.t -> t
+val make_external_no_private : dir:Path.t -> t
 
 val encode : t -> Dune_lang.t list
 val decode : dir:Path.t -> t Dune_lang.Decoder.t
+
+val convert_to_external : t -> dir:Path.t -> t

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -11,8 +11,10 @@ val obj_dir : t -> Path.t
 (** The private compiled native file directory *)
 val native_dir : t -> Path.t
 
-(** The private compiled byte file directory, and all cmi *)
+(** The private compiled byte file directories, and all cmi *)
 val byte_dir : t -> Path.t
+
+val all_cmis: t -> Path.t list
 
 (** The public compiled cmi file directory *)
 val public_cmi_dir: t -> Path.t
@@ -38,3 +40,7 @@ val encode : t -> Dune_lang.t list
 val decode : dir:Path.t -> t Dune_lang.Decoder.t
 
 val convert_to_external : t -> dir:Path.t -> t
+
+val cm_dir : t -> Cm_kind.t -> Visibility.t -> Path.t
+
+val cm_public_dir : t -> Cm_kind.t -> Path.t

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -51,7 +51,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
   let copy_objs src =
     let dst = Module.set_obj_dir ~obj_dir:impl_obj_dir src in
     copy_obj_file ~src ~dst Cmi;
-    if Module.is_public dst && Obj_dir.has_public_cmi_dir impl_obj_dir
+    if Module.is_public dst && Obj_dir.need_dedicated_public_dir impl_obj_dir
     then begin
       let src = Module.cm_public_file_unsafe src Cmi in
       let dst = Module.cm_public_file_unsafe dst Cmi in

--- a/src/visibility.ml
+++ b/src/visibility.ml
@@ -1,0 +1,31 @@
+open Stdune
+
+type t = Public | Private
+
+let to_string = function
+  | Public -> "public"
+  | Private -> "private"
+
+let pp fmt t = Format.pp_print_string fmt (to_string t)
+
+let to_sexp t = Sexp.Encoder.string (to_string t)
+
+let encode =
+  let open Dune_lang.Encoder in
+  function
+  | Public -> string "public"
+  | Private -> string "private"
+
+let decode =
+  let open Dune_lang.Decoder in
+  plain_string (fun ~loc -> function
+    | "public" -> Public
+    | "private" -> Private
+    | _ -> Errors.fail loc
+             "Not a valid visibility. Valid visibility is public or private")
+
+let is_public = function
+  | Public -> true
+  | Private -> false
+
+let is_private t = not (is_public t)

--- a/src/visibility.mli
+++ b/src/visibility.mli
@@ -1,0 +1,12 @@
+open! Stdune
+
+type t = Public | Private
+
+include Dune_lang.Conv with type t := t
+
+val is_public : t -> bool
+val is_private : t -> bool
+
+val to_sexp : t -> Sexp.t
+
+val pp : t Fmt.t

--- a/test/blackbox-tests/test-cases/dune-package/run.t
+++ b/test/blackbox-tests/test-cases/dune-package/run.t
@@ -23,6 +23,7 @@
    (foreign_archives (native b/c/c$ext_lib))
    (main_module_name C)
    (modes byte native)
+   (obj_dir (private_dir .private))
    (modules
     (alias_module (name C) (obj_name c) (visibility public) (impl))
     (main_module_name C)

--- a/test/blackbox-tests/test-cases/private-modules/run.t
+++ b/test/blackbox-tests/test-cases/private-modules/run.t
@@ -11,6 +11,8 @@
 
   $ dune build --root excluded-from-install-file | grep -i priv
   Entering directory 'excluded-from-install-file'
+    "_build/install/default/lib/lib/.private/lib__Priv.cmi" {".private/lib__Priv.cmi"}
+    "_build/install/default/lib/lib/.private/priv2.cmi" {".private/priv2.cmi"}
     "_build/install/default/lib/lib/foo/priv2.cmt" {"foo/priv2.cmt"}
     "_build/install/default/lib/lib/foo/priv2.cmx" {"foo/priv2.cmx"}
     "_build/install/default/lib/lib/foo/priv2.ml" {"foo/priv2.ml"}


### PR DESCRIPTION
Private cmi's are installed in a `.private` dir. They're also decoded back when reading dune-package files. This isn't used at the moment, but will be used once I fix the virtual library rules.