### PR TITLE
Add Dep.alias dependency

### DIFF
--- a/src/alias.ml
+++ b/src/alias.ml
@@ -1,0 +1,99 @@
+open! Stdune
+open Import
+
+module T : sig
+  type t = private
+    { dir : Path.t
+    ; name : string
+    }
+  val make : string -> dir:Path.t -> t
+  val of_user_written_path : loc:Loc.t -> Path.t -> t
+end = struct
+  type t =
+    { dir : Path.t
+    ; name : string
+    }
+
+  let make name ~dir =
+    if not (Path.is_in_build_dir dir) || String.contains name '/' then
+      Exn.code_error "Alias0.make: Invalid alias"
+        [ "name", Sexp.Encoder.string name
+        ; "dir", Path.to_sexp dir
+        ];
+    { dir; name }
+
+  let of_user_written_path ~loc path =
+    if not (Path.is_in_build_dir path) then
+      Errors.fail loc "Invalid alias!\n\
+                       Tried to reference path outside build dir: %S"
+        (Path.to_string_maybe_quoted path);
+    { dir = Path.parent_exn path
+    ; name = Path.basename path
+    }
+end
+include T
+
+let compare x y =
+  match String.compare x.name y.name with
+  | Lt | Gt as x -> x
+  | Eq -> Path.compare x.dir y.dir
+
+let equal x y = compare x y = Eq
+
+let hash { dir ; name } =
+  Hashtbl.hash (Path.hash dir, String.hash name)
+
+let pp fmt t = Path.pp fmt (Path.relative t.dir t.name)
+
+let to_dyn { dir ; name } =
+  let open Dyn in
+  Record
+    [ "dir", Path.to_dyn dir
+    ; "name", String name
+    ]
+
+let to_sexp t = Dyn.to_sexp (to_dyn t)
+
+let suffix = "-" ^ String.make 32 '0'
+
+let name t = t.name
+let dir  t = t.dir
+
+let fully_qualified_name t = Path.relative t.dir t.name
+
+let stamp_file t =
+  Path.relative (Path.insert_after_build_dir_exn t.dir ".aliases")
+    (t.name ^ suffix)
+
+let find_dir_specified_on_command_line ~dir ~file_tree =
+  match File_tree.find_dir file_tree dir with
+  | None ->
+    die "From the command line:\n\
+         @{<error>Error@}: Don't know about directory %s!"
+      (Path.to_string_maybe_quoted dir)
+  | Some dir -> dir
+
+let standard_aliases = Hashtbl.create 7
+
+let is_standard name = Hashtbl.mem standard_aliases name
+
+let make_standard name =
+  Hashtbl.add standard_aliases name ();
+  make name
+
+let default     = make_standard "default"
+let runtest     = make_standard "runtest"
+let install     = make_standard "install"
+let doc         = make_standard "doc"
+let private_doc = make_standard "doc-private"
+let lint        = make_standard "lint"
+let all         = make_standard "all"
+let check       = make_standard "check"
+let fmt         = make_standard "fmt"
+
+let encode { dir ; name } =
+  let open Dune_lang.Encoder in
+  record
+    [ "dir", Path_dune_lang.encode dir
+    ; "name", string name
+    ]

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -1,0 +1,53 @@
+open Stdune
+
+type t
+
+val equal : t -> t -> bool
+
+val hash : t -> int
+
+val compare : t -> t -> Ordering.t
+
+val make : string -> dir:Path.t -> t
+
+(** The following always holds:
+
+    {[
+      make (name t) ~dir:(dir t) = t
+    ]}
+*)
+val name : t -> string
+val dir : t -> Path.t
+
+val to_dyn : t -> Dyn.t
+
+val to_sexp : t -> Sexp.t
+
+val encode : t Dune_lang.Encoder.t
+
+val pp : t Fmt.t
+
+val of_user_written_path : loc:Loc.t -> Path.t -> t
+
+val fully_qualified_name : t -> Path.t
+
+val default     : dir:Path.t -> t
+val runtest     : dir:Path.t -> t
+val install     : dir:Path.t -> t
+val doc         : dir:Path.t -> t
+val private_doc : dir:Path.t -> t
+val lint        : dir:Path.t -> t
+val all         : dir:Path.t -> t
+val check       : dir:Path.t -> t
+val fmt         : dir:Path.t -> t
+
+(** Return the underlying stamp file *)
+val stamp_file : t -> Path.t
+
+val find_dir_specified_on_command_line
+  :  dir:Path.t
+  -> file_tree:File_tree.t
+  -> File_tree.Dir.t
+
+val is_standard : string -> bool
+val suffix : string

--- a/src/build.ml
+++ b/src/build.ml
@@ -110,6 +110,7 @@ let rec all = function
 
 let lazy_no_targets t = Lazy_no_targets t
 
+let deps d = Deps d
 let dep d = Deps (Dep.Set.singleton d)
 let path p = Deps (Dep.Set.singleton (Dep.file p))
 let paths ps = Deps (Dep.Set.of_files ps)
@@ -121,6 +122,7 @@ let dyn_path_set t = Dyn_paths t
 let dyn_deps t = Dyn_deps t
 let paths_for_rule ps = Paths_for_rule ps
 let env_var s = Deps (Dep.Set.singleton (Dep.env s))
+let alias a = dep (Dep.alias a)
 
 let catch t ~on_error = Catch (t, on_error)
 

--- a/src/build.mli
+++ b/src/build.mli
@@ -60,6 +60,7 @@ val lazy_no_targets : ('a, 'b) t Lazy.t -> ('a, 'b) t
 val path  : Path.t -> ('a, 'a) t
 
 val dep : Dep.t -> ('a, 'a) t
+val deps : Dep.Set.t -> ('a, 'a) t
 
 val paths : Path.t list -> ('a, 'a) t
 val path_set : Path.Set.t -> ('a, 'a) t
@@ -71,6 +72,8 @@ val paths_matching : loc:Loc.t -> File_selector.t -> ('a, Path.Set.t) t
 (** [env_var v] records [v] as an environment variable that is read by the
     action produced by the build arrow. *)
 val env_var : string -> ('a, 'a) t
+
+val alias : Alias.t -> ('a, 'a) t
 
 (** Compute the set of source of all files present in the sub-tree
     starting at [dir] and record them as dependencies. *)

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -89,41 +89,11 @@ val package_deps
 (** {2 Aliases} *)
 
 module Alias : sig
-  type t
-
-  val pp : t Fmt.t
-
-  val make : string -> dir:Path.t -> t
-
-  val of_user_written_path : loc:Loc.t -> Path.t -> t
-
-  (** The following always holds:
-
-      {[
-        make (name t) ~dir:(dir t) = t
-      ]}
-  *)
-  val name : t -> string
-  val dir  : t -> Path.t
-
-  val fully_qualified_name : t -> Path.t
-
-  val default     : dir:Path.t -> t
-  val runtest     : dir:Path.t -> t
-  val install     : dir:Path.t -> t
-  val doc         : dir:Path.t -> t
-  val private_doc : dir:Path.t -> t
-  val lint        : dir:Path.t -> t
-  val all         : dir:Path.t -> t
-  val check       : dir:Path.t -> t
-  val fmt         : dir:Path.t -> t
+  type t = Alias.t
 
   (** Alias for all the files in [_build/install] that belong to this
       package *)
   val package_install : context:Context.t -> pkg:Package.Name.t -> t
-
-  (** Return the underlying stamp file *)
-  val stamp_file : t -> Path.t
 
   (** [dep t = Build.path (stamp_file t)] *)
   val dep : t -> ('a, 'a) Build.t

--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -19,6 +19,6 @@ let add_obj_dir sctx ~obj_dir =
       File_selector.create ~dir dev_files in
     let dyn_deps = Build.paths_matching ~loc:(Loc.of_pos __POS__) dir_glob in
     Build_system.Alias.add_deps
-      (Build_system.Alias.check ~dir:(Obj_dir.dir obj_dir))
+      (Alias.check ~dir:(Obj_dir.dir obj_dir))
       ~dyn_deps
       Path.Set.empty

--- a/src/dep.mli
+++ b/src/dep.mli
@@ -3,6 +3,7 @@ open Stdune
 type t = private
   | Env of Env.Var.t
   | File of Path.t
+  | Alias of Alias.t
   | Glob of File_selector.t
   | Universe
 
@@ -10,6 +11,7 @@ val file : Path.t -> t
 val env : Env.Var.t -> t
 val universe : t
 val glob : File_selector.t -> t
+val alias : Alias.t -> t
 
 val compare : t -> t -> Ordering.t
 

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -48,7 +48,7 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
   let loc = Dune_file.Auto_format.loc config in
   let dir = Path.parent_exn output_dir in
   let source_dir = Path.drop_build_context_exn dir in
-  let alias_formatted = Build_system.Alias.fmt ~dir:output_dir in
+  let alias_formatted = Alias.fmt ~dir:output_dir in
   let resolve_program =
     Super_context.resolve_program ~dir sctx ~loc:(Some loc) in
   let ocamlformat_deps = lazy (
@@ -104,8 +104,8 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
 
 let gen_rules ~dir =
   let output_dir = Path.relative dir formatted in
-  let alias = Build_system.Alias.fmt ~dir in
-  let alias_formatted = Build_system.Alias.fmt ~dir:output_dir in
-  Build_system.Alias.stamp_file alias_formatted
+  let alias = Alias.fmt ~dir in
+  let alias_formatted = Alias.fmt ~dir:output_dir in
+  Alias.stamp_file alias_formatted
   |> Path.Set.singleton
   |> Build_system.Alias.add_deps alias

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -46,7 +46,6 @@ module For_stanza = struct
 end
 
 module Gen(P : sig val sctx : Super_context.t end) = struct
-  module Alias = Build_system.Alias
   module CC = Compilation_context
   module SC = Super_context
   (* We need to instantiate Install_rules earlier to avoid issues whenever
@@ -132,8 +131,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
           let src_expanded = Expander.expand_str expander src in
           Path.relative ctx_dir src_expanded)
         |> Path.Set.of_list
-        |> Build_system.Alias.add_deps
-             (Build_system.Alias.all ~dir:ctx_dir);
+        |> Build_system.Alias.add_deps (Alias.all ~dir:ctx_dir);
         For_stanza.empty_none
       | _ ->
         For_stanza.empty_none
@@ -203,7 +201,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
     in
     Build_system.Alias.add_deps
       ~dyn_deps
-      (Build_system.Alias.all ~dir:ctx_dir) Path.Set.empty;
+      (Alias.all ~dir:ctx_dir) Path.Set.empty;
     cctxs
 
   let gen_rules dir_contents cctxs ~dir : (Loc.t * Compilation_context.t) list =

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -274,7 +274,7 @@ include Sub_system.Register_end_point(
 
       SC.add_alias_action sctx ~dir
         ~loc:(Some info.loc)
-        (Build_system.Alias.runtest ~dir)
+        (Alias.runtest ~dir)
         ~stamp:("ppx-runner", name)
         (let module A = Action in
          let exe = Path.relative inline_test_dir (name ^ ".exe") in

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -5,8 +5,6 @@ open! No_io
 
 module Library = Dune_file.Library
 
-module Alias = Build_system.Alias
-
 let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
   let ctx = Super_context.context sctx in
   let dune_package_file = Local_package.dune_package_file pkg in
@@ -304,7 +302,7 @@ let install_file sctx (package : Local_package.t) entries =
   in
   let files = Install.files entries in
   Build_system.Alias.add_deps
-    (Alias.package_install ~context:ctx ~pkg:package_name)
+    (Build_system.Alias.package_install ~context:ctx ~pkg:package_name)
     files
     ~dyn_deps:
       (Build_system.package_deps package_name files
@@ -312,7 +310,7 @@ let install_file sctx (package : Local_package.t) entries =
        Package.Name.Set.to_list packages
        |> List.map ~f:(fun pkg ->
          Build_system.Alias.package_install ~context:ctx ~pkg
-         |> Build_system.Alias.stamp_file)
+         |> Alias.stamp_file)
        |> Path.Set.of_list);
   Super_context.add_rule sctx ~dir:pkg_build_dir
     ~mode:(if promote_install_file ctx then

--- a/src/lib_file_deps.ml
+++ b/src/lib_file_deps.ml
@@ -1,6 +1,5 @@
 open Stdune
 open Dune_file
-open Build_system
 
 module Group = struct
   type t =
@@ -82,8 +81,7 @@ let setup_file_deps =
 let deps_of_lib (lib : Lib.t) ~groups =
   if Lib.is_local lib then
     Group.L.alias groups ~dir:(Lib.src_dir lib) ~name:(Lib.name lib)
-    |> Alias.stamp_file
-    |> Dep.file
+    |> Dep.alias
     |> Dep.Set.singleton
   else
     (* suppose that all the files of an external lib are at the same place *)

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -184,7 +184,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
        >>>
        Build.create_file (Path.relative dir ".merlin-exists"));
     Path.Set.singleton merlin_file
-    |> Build_system.Alias.add_deps (Build_system.Alias.check ~dir);
+    |> Build_system.Alias.add_deps (Alias.check ~dir);
     SC.add_rule sctx ~dir ~mode:(Promote (Until_clean, None)) (
       flags
       >>^ (fun flags ->

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -562,7 +562,7 @@ let action_for_pp sctx ~dep_kind ~loc ~expander ~action ~src ~target =
 
 let lint_module sctx ~dir ~expander ~dep_kind ~lint ~lib_name ~scope ~dir_kind =
   Staged.stage (
-    let alias = Build_system.Alias.lint ~dir in
+    let alias = Alias.lint ~dir in
     let add_alias fn build =
       SC.add_alias_action sctx alias build ~dir
         ~stamp:("lint", lib_name, fn)

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -103,7 +103,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
     file_dst)
 
 let add_alias sctx ~dir ~name ~stamp ~loc ?(locks=[]) build =
-  let alias = Build_system.Alias.make name ~dir in
+  let alias = Alias.make name ~dir in
   SC.add_alias_action sctx alias ~dir ~loc ~locks ~stamp build
 
 let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -6,15 +6,15 @@
           odoc _doc/_odoc/pkg/bar/page-index.odoc
           odoc _doc/_html/bar/index.html
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
-      ocamldep .foo_byte.objs/foo_byte.ml.d
-        ocamlc .foo_byte.objs/byte/foo_byte.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
       ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo.odoc
       ocamldep .foo.objs/foo2.ml.d
         ocamlc .foo.objs/byte/foo2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo/foo2.odoc
+      ocamldep .foo_byte.objs/foo_byte.ml.d
+        ocamlc .foo_byte.objs/byte/foo_byte.{cmi,cmo,cmt}
+          odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
           odoc _doc/_html/foo/Foo2/.dune-keep,_doc/_html/foo/Foo2/index.html
           odoc _doc/_odoc/pkg/foo/page-index.odoc
           odoc _doc/_html/foo/index.html


### PR DESCRIPTION
This is the first step to treat aliases a bit more abstractly. There are still uses of `Alias.stamp_file`. To replace those, we will need to simplify the mechanism to add deps to aliases.