### PR TITLE
Refactor Dune_file.Stanzas.parser and clean up Dune_init stanza conflict detection

### DIFF
--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -444,15 +444,26 @@ module Stanzas : sig
 
   type syntax = OCaml | Plain
 
+  (** [of_ast ~kind project ast] is the list of [Stanza.t]s derived from
+      decoding the [ast] according to the syntax given by [kind] in the context
+      of the [project] *)
+  val of_ast
+    :  kind:Dune_lang.Syntax.t
+    -> Dune_project.t
+    -> Dune_lang.Ast.t
+    -> Stanza.t list
+
   (** [parse ~file ~kind project stanza_exprs] is a list of [Stanza.t]s derived
-      from decoding the [stanza_exprs] from [Dune_lang.Ast.t]s to [Stanza.t]s
-      and combining those with the stanzas parsed from the supplied dune [file].
+      from decoding the [stanza_exprs] from [Dune_lang.Ast.t]s to [Stanza.t]s.
+
+      [file] is used to check for illegal recursive file inclusions and to
+      anchor file includes given as relative paths.
 
       The stanzas are parsed in the context of the dune [project].
 
-      The syntax [kind] determines whether the expected syntax is either the
-      depreciated jbuilder syntax or the version of dune syntax specified in the
-      [project]. *)
+      The syntax [kind] determines whether the expected syntax is the
+      depreciated jbuilder syntax or the version of dune syntax specified by the
+      current [project]. *)
   val parse
     :  file:Path.t
     -> kind:Dune_lang.Syntax.t

--- a/test/blackbox-tests/test-cases/dune-init/run.t
+++ b/test/blackbox-tests/test-cases/dune-init/run.t
@@ -161,13 +161,12 @@ Adding libraries in a single directory
 
 Can add multiple libraries in the same directory
 
-  $ dune init lib test_lib1 ./_test_lib --public
+  $ dune init lib test_lib1 ./_test_lib
   Success: initialized library component named test_lib1
   $ dune init lib test_lib2 ./_test_lib --libs test_lib1
   Success: initialized library component named test_lib2
   $ cat ./_test_lib/dune
   (library
-   (public_name test_lib1)
    (name test_lib1))
   
   (library
@@ -262,7 +261,7 @@ Adding fields to existing stanzas
 # TODO(shonfeder)
 Adding fields to existing stanzas is currently not supported
 
-  $ dune init exe test_bin ./_test_bin --libs test_lib1 --public
+  $ dune init exe test_bin ./_test_bin --libs test_lib1
   Success: initialized executable component named test_bin
   $ dune init exe test_bin ./_test_bin --libs test_lib2
   Updating existing stanzas is not yet supported.
@@ -272,10 +271,9 @@ Adding fields to existing stanzas is currently not supported
   (executable (name main) (libraries test_lib2))
   
   Pre-existing stanza:
-  (executable (public_name test_bin) (name main) (libraries test_lib1))
+  (executable (name main) (libraries test_lib1))
   [1]
   $ cat ./_test_bin/dune
   (executable
-   (public_name test_bin)
    (name main)
    (libraries test_lib1))


### PR DESCRIPTION
Fulfills @rgrinberg's request at https://github.com/ocaml/dune/pull/1448#issuecomment-472710046.

The new auxiliary function and light refactor in e24ef68 follows lines discussed with @diml in  #1972