### PR TITLE
[coq] Support depending on non-packed legacy plugins.

### DIFF
--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -67,6 +67,5 @@ Limitations
 - composition and scoping of Coq libraries is still not possible. For now, libraries are located using Coq's built-in library management,
 - .v always depend on the native version of a plugin,
 - a ``foo.mlpack`` file must the present for locally defined plugins to work, this is a limitation of coqdep,
-- Coq plugins are installed into their regular OCaml library path.
-
+- Coq plugins are installed into their regular OCaml library path, this means Coq < 8.11 won't properly detect them.
 

--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -118,8 +118,11 @@ let setup_ml_deps ~scope ~loc libs =
    * will omit the cmxs deps *)
   let ml_pack_files lib =
     let plugins = Mode.Dict.get (Lib.plugins lib) Mode.Native in
-    let to_mlpack file = Path.set_extension file ~ext:".mlpack" in
-    List.map plugins ~f:to_mlpack
+    let to_mlpack file =
+      Path.([ set_extension file ~ext:".mlpack"
+            ; set_extension file ~ext:".mllib"
+            ]) in
+    List.concat_map plugins ~f:to_mlpack
   in
 
   (* Pair of include flags and paths to mlpack *)


### PR DESCRIPTION
Using non-"packed" plugins is deprecated in Coq upstream, however
there are still too many of them using declaring an `.mllib` and it is
not reasonable to ask them to migrate for old Coq versions such as
8.8, which we support.

We thus add support for detecting an `.mllib` file if around.