### PR TITLE
Tweak error message when failing to parse dune/jbuild files

### DIFF
--- a/src/dune_lang/dune_lexer.mll
+++ b/src/dune_lang/dune_lexer.mll
@@ -24,8 +24,7 @@ module Template = struct
     lexbuf.lex_start_p <- start;
     match parts with
     | [] | [Text ""] ->
-      error lexbuf "Internal error in the S-expression parser, \
-                    please report upstream."
+      invalid_dune_or_jbuild lexbuf
     | [Text s] ->
       Token.Atom (Atom.of_string s)
     | _ ->

--- a/src/dune_lang/jbuild_lexer.mll
+++ b/src/dune_lang/jbuild_lexer.mll
@@ -79,9 +79,7 @@ and atom acc start = parse
     { atom (if acc = "" then s else acc ^ s) start lexbuf
     }
   | ""
-    { if acc = "" then
-        error lexbuf "Internal error in the S-expression parser, \
-                      please report upstream.";
+    { if acc = "" then invalid_dune_or_jbuild lexbuf;
       lexbuf.lex_start_p <- start;
       Token.Atom (Atom.of_string acc)
     }

--- a/src/dune_lang/lexer_shared.ml
+++ b/src/dune_lang/lexer_shared.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 module Token = struct
   module Comment = struct
     type t =
@@ -35,6 +37,11 @@ let error ?(delta=0) lexbuf message =
            ; stop  = Lexing.lexeme_end_p   lexbuf
            ; message
            })
+
+let invalid_dune_or_jbuild lexbuf =
+  let start = Lexing.lexeme_start_p lexbuf in
+  let fname = Filename.basename start.pos_fname in
+  error lexbuf (sprintf "Invalid %s file" fname)
 
 let escaped_buf = Buffer.create 256
 

--- a/src/dune_lang/lexer_shared.mli
+++ b/src/dune_lang/lexer_shared.mli
@@ -28,6 +28,8 @@ end
 
 val error : ?delta:int -> Lexing.lexbuf -> string -> 'a
 
+val invalid_dune_or_jbuild : Lexing.lexbuf -> 'a
+
 val escaped_buf : Buffer.t
 
 exception Error of Error.t


### PR DESCRIPTION
be a little less pessimistic that our parser is wrong. It's probably an invalid
file.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>