### PR TITLE
Fix unreadable source dirs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ unreleased
 - Install .cmi files of private modules in a `.private` directory (#1983, fix
   #1973 @rgrinberg)
 
-- Fix dune subst attempting to sunbstitute on directories. (#2000, fix #1997,
+- Fix `dune subst` attempting to substitute on directories. (#2000, fix #1997,
   @rgrinberg)
 
 - Do not list private modules in the generated index. (#2009, fix #2008,
@@ -33,6 +33,9 @@ unreleased
 
 - Do not crash if unable to read a directory when traversing to find root
   (#2024, @rgrinberg)
+
+- Do not exit dune if some source directories are unreadable. Instead, warn the
+  user that such directories need to be ignored (#2004, fix #310, @rgrinberg)
 
 1.8.2 (10/03/2019)
 ------------------

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -69,3 +69,5 @@ include
 
 let equal = (=)
 let hash = Dune_caml.Hashtbl.hash
+
+let to_dyn exn = Dyn0.String (Printexc.to_string exn)

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -41,3 +41,5 @@ val raise_with_backtrace: exn -> Printexc.raw_backtrace -> _
 val equal : t -> t -> bool
 
 val hash : t -> int
+
+val to_dyn : t -> Dyn0.t

--- a/src/stdune/or_exn.ml
+++ b/src/stdune/or_exn.ml
@@ -2,3 +2,5 @@ type 'a t = ('a, exn) Result.t
 
 let equal eq x y = Result.equal eq Exn.equal x y
 let hash h = Result.hash h Exn.hash
+
+let to_dyn f = Result.to_dyn f Exn.to_dyn

--- a/src/stdune/or_exn.mli
+++ b/src/stdune/or_exn.mli
@@ -5,3 +5,5 @@ type 'a t = ('a, exn) Result.t
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
 val hash : ('a -> int) -> 'a t -> int
+
+val to_dyn : ('a -> Dyn.t) -> 'a t Dyn.Encoder.t

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1042,3 +1042,5 @@ let local_part = function
   | External e -> Local.of_string (External.as_local e)
   | In_source_tree l -> l
   | In_build_dir l -> l
+
+let stat t = Unix.stat (to_string t)

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -203,3 +203,5 @@ end
     For external paths, it returns a path that is relative to the current
     directory. For example, the local part of [/a/b] is [./a/b]. *)
 val local_part : t -> Local.t
+
+val stat : t -> Unix.stats

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -130,3 +130,7 @@ module Option = struct
     | None -> Ok ()
     | Some x -> x >>= f
 end
+
+let to_dyn ok err = function
+  | Ok e -> Dyn.Encoder.constr "Ok" [ok e]
+  | Error e -> Dyn.Encoder.constr "Error" [err e]

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -38,6 +38,11 @@ val map_error : ('a, 'error1) t -> f:('error1 -> 'error2) -> ('a, 'error2) t
 
 val to_option : ('a, 'error) t -> 'a option
 
+val to_dyn
+  : 'a Dyn.Encoder.t
+  -> 'error Dyn.Encoder.t
+  -> ('a, 'error) t Dyn.Encoder.t
+
 (** Produce [Error <message>] *)
 val errorf : ('a, unit, string, (_, string) t) format4 -> 'a
 

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1269,6 +1269,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name unreadable-src)
+ (deps (package dune) (source_tree test-cases/unreadable-src))
+ (action
+  (chdir
+   test-cases/unreadable-src
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name upgrader)
  (deps (package dune) (source_tree test-cases/upgrader))
  (action
@@ -1515,6 +1523,7 @@
   (alias toplevel-stanza)
   (alias trace-file)
   (alias transitive-deps-mode)
+  (alias unreadable-src)
   (alias upgrader)
   (alias use-meta)
   (alias utop)
@@ -1662,6 +1671,7 @@
   (alias toplevel-stanza)
   (alias trace-file)
   (alias transitive-deps-mode)
+  (alias unreadable-src)
   (alias upgrader)
   (alias variants)
   (alias vlib)

--- a/test/blackbox-tests/test-cases/unreadable-src/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-src/run.t
@@ -1,0 +1,10 @@
+  $ mkdir foo && chmod -r foo
+  $ dune build
+  File "<none>", line 1, characters 0-0:
+  Warning: Unable to read directory foo. Ignoring.
+  Remove this message by ignoring by adding:
+  (dirs \ foo)
+  to the dune file: dune
+  Reason: foo: Permission denied
+  
+  $ chmod +r foo && rm -rf foo


### PR DESCRIPTION
This PR makes it so that unreadable directories are treated as empty. Any time an unreadable dir is encountered, we report this as a warning.

One thing that would have been nicer would be to completely exclude them from the contents, but that breaks laziness a bit. Because we have to try reading the dir before adding it to the map.