### PR TITLE
Add a generic action

### DIFF
--- a/src/action.mli
+++ b/src/action.mli
@@ -1,6 +1,16 @@
 open! Stdune
 open! Import
 
+module Generic : sig
+  type t
+
+  val create : f:(unit -> unit Fiber.t) -> id:Dune_lang.t Lazy.t -> t
+
+  val encode : t -> Dune_lang.t
+
+  val run : t -> unit Fiber.t
+end
+
 module Outputs : module type of struct include Action_intf.Outputs end
 module Diff_mode : module type of struct include Action_intf.Diff_mode end
 
@@ -11,6 +21,7 @@ module Make_mapper (Src : Action_intf.Ast) (Dst : Action_intf.Ast) : sig
     -> f_program:(dir:Src.path -> Src.program -> Dst.program)
     -> f_string:(dir:Src.path -> Src.string -> Dst.string)
     -> f_path:(dir:Src.path -> Src.path -> Dst.path)
+    -> f_gen:(Src.generic -> Dst.generic)
     -> Dst.t
 end
 
@@ -35,11 +46,13 @@ include Action_intf.Ast
   with type program = Prog.t
   with type path    = Path.t
   with type string  = string
+  with type generic = Generic.t
 
 include Action_intf.Helpers
   with type program := Prog.t
   with type path    := Path.t
   with type string  := string
+  with type generic := Generic.t
   with type t       := t
 
 val decode : t Dune_lang.Decoder.t
@@ -49,6 +62,7 @@ module For_shell : sig
     with type program := string
     with type path    := string
     with type string  := string
+    with type generic := Dune_lang.t
 
   val encode : t Dune_lang.Encoder.t
 end

--- a/src/action_ast.ml
+++ b/src/action_ast.ml
@@ -18,10 +18,12 @@ module Make
     (Program : Dune_lang.Conv)
     (Path    : Dune_lang.Conv)
     (String  : Dune_lang.Conv)
+    (Generic : sig type t end)
     (Ast : Action_intf.Ast
      with type program := Program.t
      with type path    := Path.t
-     with type string  := String.t) =
+     with type string  := String.t
+     with type generic := Generic.t) =
 struct
   include Ast
 
@@ -180,6 +182,7 @@ struct
         ; List (List.map ~f:string extras)
         ; path target
         ]
+    | Generic _ -> assert false
 
   let run prog args = Run (prog, args)
   let chdir path t = Chdir (path, t)
@@ -205,4 +208,5 @@ struct
   let digest_files files = Digest_files files
   let diff ?(optional=false) ?(mode=Diff_mode.Text) file1 file2 =
     Diff { optional; file1; file2; mode }
+  let generic g = Generic g
 end

--- a/src/action_dune_lang.ml
+++ b/src/action_dune_lang.ml
@@ -3,13 +3,15 @@ open! Stdune
 type program = String_with_vars.t
 type string = String_with_vars.t
 type path = String_with_vars.t
+type generic = Nothing.t
 
 module type Uast = Action_intf.Ast
   with type program = String_with_vars.t
   with type path    = String_with_vars.t
   with type string  = String_with_vars.t
+  with type generic = Nothing.t
 module rec Uast : Uast = Uast
-include Action_ast.Make(String_with_vars)(String_with_vars)(String_with_vars)(Uast)
+include Action_ast.Make(String_with_vars)(String_with_vars)(String_with_vars)(Nothing)(Uast)
 
 module Mapper = Action.Make_mapper(Uast)(Uast)
 
@@ -17,6 +19,7 @@ let upgrade_to_dune =
   let id ~dir:_ p = p in
   let dir = String_with_vars.make_text Loc.none "" in
   Mapper.map ~dir ~f_program:id ~f_path:id
+    ~f_gen:Fn.id
     ~f_string:(fun ~dir:_ sw ->
       String_with_vars.upgrade_to_dune sw ~allow_first_dep_var:false)
 

--- a/src/action_dune_lang.mli
+++ b/src/action_dune_lang.mli
@@ -5,7 +5,8 @@ open Stdune
 include Action_intf.Ast
   with type program := String_with_vars.t and
   type string := String_with_vars.t and
-  type path := String_with_vars.t
+  type path := String_with_vars.t and
+  type generic := Nothing.t
 
 include Dune_lang.Conv with type t := t
 
@@ -15,6 +16,7 @@ include Action_intf.Helpers
   with type t := t and
   type program = String_with_vars.t and
   type string = String_with_vars.t and
-  type path = String_with_vars.t
+  type path = String_with_vars.t and
+  type generic = Nothing.t
 
 val compare_no_locs : t -> t -> Ordering.t

--- a/src/action_exec.ml
+++ b/src/action_exec.ml
@@ -32,6 +32,7 @@ let exec_echo stdout_to str =
 
 let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to =
   match (t : Action.t) with
+  | Generic g -> Action.Generic.run g
   | Run (Error e, _) ->
     Action.Prog.Not_found.raise e
   | Run (Ok prog, args) ->

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -18,6 +18,7 @@ module type Ast = sig
   type program
   type path
   type string
+  type generic
 
   module Diff : sig
     type file = { src : path; dst : path }
@@ -51,6 +52,7 @@ module type Ast = sig
     | Digest_files   of path list
     | Diff           of Diff.t
     | Merge_files_into of path list * string list * path
+    | Generic        of generic
 end
 
 module type Helpers = sig
@@ -58,6 +60,7 @@ module type Helpers = sig
   type path
   type string
   type t
+  type generic
 
   val run : program -> string list -> t
   val chdir : path -> t -> t
@@ -82,4 +85,5 @@ module type Helpers = sig
   val mkdir : path -> t
   val digest_files : path list -> t
   val diff : ?optional:bool -> ?mode:Diff_mode.t -> path -> path -> t
+  val generic : generic -> t
 end

--- a/src/action_to_sh.ml
+++ b/src/action_to_sh.ml
@@ -29,6 +29,7 @@ let mkdir p = Run ("mkdir", ["-p"; p])
 let simplify act =
   let rec loop (act : Action.For_shell.t) acc =
     match act with
+    | Generic _ -> assert false
     | Run (prog, args) ->
       Run (prog, args) :: acc
     | Chdir (p, act) ->

--- a/src/action_unexpanded.ml
+++ b/src/action_unexpanded.ml
@@ -163,6 +163,9 @@ module E = struct
   let prog_and_args = expand ~mode:Many ~map:Partial.E.prog_and_args_of_values
 end
 
+include (struct
+  (* Generic _ is not possible, but we cannot refute it in 4.02 *)
+[@@@warning "-56"]
 let rec partial_expand t ~map_exe ~expander : Partial.t =
   match t with
   | Run (prog, args) ->
@@ -251,7 +254,8 @@ let rec partial_expand t ~map_exe ~expander : Partial.t =
       (List.map sources ~f:(E.path ~expander),
        List.map extras ~f:(E.string ~expander),
        E.path ~expander target)
-  | Generic _ -> .
+  | Generic _ -> assert false
+end)
 
 module Infer = struct
   module Outcome = struct

--- a/src/action_unexpanded.ml
+++ b/src/action_unexpanded.ml
@@ -16,6 +16,7 @@ let remove_locs =
       ~f_program:(fun ~dir:_ -> String_with_vars.remove_locs)
       ~f_path:(fun ~dir:_ -> String_with_vars.remove_locs)
       ~f_string:(fun ~dir:_ -> String_with_vars.remove_locs)
+      ~f_gen:Fn.id
 
 let check_mkdir loc path =
   if not (Path.is_managed path) then
@@ -140,6 +141,7 @@ module Partial = struct
         (List.map ~f:(E.path ~expander) sources,
          List.map ~f:(E.string ~expander) extras,
          E.path ~expander target)
+    | Generic _ -> assert false
 end
 
 module E = struct
@@ -249,6 +251,7 @@ let rec partial_expand t ~map_exe ~expander : Partial.t =
       (List.map sources ~f:(E.path ~expander),
        List.map extras ~f:(E.string ~expander),
        E.path ~expander target)
+  | Generic _ -> .
 
 module Infer = struct
   module Outcome = struct
@@ -317,6 +320,7 @@ module Infer = struct
       | System _
       | Bash _
       | Remove_tree _
+      | Generic _
       | Mkdir _ -> acc
 
     let infer t =


### PR DESCRIPTION
This allows one to turn any OCaml thunk into an action to be executed during the build.

As discussed privately, we need a manually written id parameter. But this makes it much easier to run functions such as `Dep.Set.trace` in the build itself.