### PR TITLE
If a dune file uses OCaml syntax, use ocamlformat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,9 @@
 
 - Allow "." in `c_names` and `cxx_names` (#2036, fix #2033, @rgrinberg)
 
+- Format rules: if a dune file uses OCaml syntax, do not format it.
+  (#2014, fix #2012, @emillon)
+
 1.8.2 (10/03/2019)
 ------------------
 

--- a/src/format_dune_lang.ml
+++ b/src/format_dune_lang.ml
@@ -134,6 +134,14 @@ let format_file ~input =
       (Dune_lang.Parse_error.message e);
     exit 1
   | OCaml_syntax loc ->
-    Errors.warn loc "OCaml syntax is not supported, skipping."
+    begin
+      match input with
+      | Some path ->
+        Io.with_file_in path ~f:(fun ic ->
+          Io.copy_channels ic stdout
+        )
+      | None ->
+        Errors.fail loc "OCaml syntax is not supported."
+    end
   | Sexps sexps ->
     Format.printf "%a%!" pp_top_sexps sexps

--- a/test/blackbox-tests/test-cases/format-dune-file/run.t
+++ b/test/blackbox-tests/test-cases/format-dune-file/run.t
@@ -144,16 +144,20 @@ When a comment is at the end of a list, the ")" is on a own line.
    ; multiline
    )
 
-Files in OCaml syntax are ignored with a warning.
+Files in OCaml syntax are copied verbatim (but error when passed in stdin).
 
   $ dune format-dune-file < ocaml-syntax.dune
   File "", line 1, characters 0-20:
-  Warning: OCaml syntax is not supported, skipping.
+  Error: OCaml syntax is not supported.
+  [1]
   $ dune format-dune-file ocaml-syntax.dune
-  File "$TESTCASE_ROOT/ocaml-syntax.dune", line 1, characters 0-20:
-  1 | (* -*- tuareg -*- *)
-      ^^^^^^^^^^^^^^^^^^^^
-  Warning: OCaml syntax is not supported, skipping.
+  (* -*- tuareg -*- *)
+  
+  let () = Jbuild_plugin.V1.send {|
+  (alias
+   (name runtest)
+   (action (echo "ocaml syntax")))
+  |}
 
 Non 0 error code:
 

--- a/test/blackbox-tests/test-cases/formatting/enabled/dune-ocaml-syntax/dune
+++ b/test/blackbox-tests/test-cases/formatting/enabled/dune-ocaml-syntax/dune
@@ -1,0 +1,9 @@
+(* -*- tuareg -*- *)
+
+let
+() =
+Jbuild_plugin.V1.send {|
+(alias
+ (name runtest)
+ (action (echo "ocaml syntax")))
+|}

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -4,6 +4,7 @@ Formatting can be checked using the @fmt target:
   $ cp enabled/reason_file.re.orig enabled/reason_file.re
   $ cp enabled/dune.orig enabled/dune
   $ dune build --display short @fmt
+          dune enabled/dune-ocaml-syntax/.formatted/dune
       ocamldep fake-tools/.ocamlformat.eobjs/ocamlformat.ml.d
       ocamldep fake-tools/.ocamlformat.eobjs/refmt.ml.d
         ocamlc fake-tools/.ocamlformat.eobjs/byte/ocamlformat.{cmi,cmo,cmt}
@@ -42,6 +43,7 @@ Configuration files are taken into account for this action:
 
   $ touch enabled/.ocamlformat
   $ dune build --display short @fmt
+          dune enabled/dune-ocaml-syntax/.formatted/dune
          refmt enabled/.formatted/reason_file.re
   File "enabled/reason_file.re", line 1, characters 0-0:
   Files _build/default/enabled/reason_file.re and _build/default/enabled/.formatted/reason_file.re differ.
@@ -88,6 +90,7 @@ All .ocamlformat files are considered dependencies:
 
   $ echo 'margin = 70' > .ocamlformat
   $ dune build --display short @fmt
+          dune enabled/dune-ocaml-syntax/.formatted/dune
          refmt enabled/.formatted/reason_file.re
          refmt enabled/.formatted/reason_file.rei
   File "enabled/reason_file.rei", line 1, characters 0-0:


### PR DESCRIPTION
Closes #2012

I'm not sure what causes the difference in order.

Notes on this patch:
- this reads dune files during rule generation. This might be a problem. Alternatively, it might be possible to do that in the build action.
- enabling/disabling is defined by the formatter used, not on the file name. That is, `(only dune)` will not format dune files in ocaml syntax.