### PR TITLE
Add package-level mlds to odoc include path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+unreleased
+----------
+
+- Fix invocation of odoc to add previously missing include paths, impacting
+  mld files that are not in directories containing libraries (#2016, fixes
+  #2007, @jonludlam)
+
 1.9.0 (09/04/2019)
 ------------------
 

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -76,7 +76,9 @@ module Dep = struct
       Build.deps (
         let init =
           match pkg with
-          | Some p -> Dep.Set.singleton (Dep.alias (alias ~dir:(Paths.odocs ctx (Pkg p))))
+          | Some p ->
+            Dep.Set.singleton
+              (Dep.alias (alias ~dir:(Paths.odocs ctx (Pkg p))))
           | None -> Dep.Set.empty
         in
         List.fold_left libs ~init ~f:(fun acc (lib : Lib.t) ->

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -993,6 +993,14 @@
     (diff? run.t run.t.corrected)))))
 
 (alias
+ (name odoc-package-mld-link)
+ (deps (package dune) (source_tree test-cases/odoc-package-mld-link))
+ (action
+  (chdir
+   test-cases/odoc-package-mld-link
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name odoc-unique-mlds)
  (deps (package dune) (source_tree test-cases/odoc-unique-mlds))
  (action
@@ -1498,6 +1506,7 @@
   (alias ocamldep-multi-stanzas)
   (alias ocamllex-jbuild)
   (alias odoc)
+  (alias odoc-package-mld-link)
   (alias odoc-unique-mlds)
   (alias old-dune-subsystem)
   (alias optional)
@@ -1653,6 +1662,7 @@
   (alias ocaml-syntax)
   (alias ocamldep-multi-stanzas)
   (alias ocamllex-jbuild)
+  (alias odoc-package-mld-link)
   (alias old-dune-subsystem)
   (alias optional)
   (alias output-obj)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -998,7 +998,9 @@
  (action
   (chdir
    test-cases/odoc-package-mld-link
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
+    (diff? run.t run.t.corrected)))))
 
 (alias
  (name odoc-unique-mlds)
@@ -1662,7 +1664,6 @@
   (alias ocaml-syntax)
   (alias ocamldep-multi-stanzas)
   (alias ocamllex-jbuild)
-  (alias odoc-package-mld-link)
   (alias old-dune-subsystem)
   (alias optional)
   (alias output-obj)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -128,6 +128,7 @@ let exclusions =
   ; make "coq" ~external_deps:true ~coq:true
   ; make "github25" ~env:("OCAMLPATH", Dune_lang.atom "./findlib-packages")
   ; odoc "odoc"
+  ; odoc "odoc-package-mld-link"
   ; odoc "odoc-unique-mlds"
   ; odoc "github717-odoc-index"
   ; odoc "multiple-private-libs"

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/dune
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/dune
@@ -1,0 +1,1 @@
+(documentation)

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/dune-project
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.5)
+(name ocaml-labs)

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/index.mld
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/index.mld
@@ -1,0 +1,4 @@
+{0 Big title}
+
+Let's test a link to {{!page-otherpage}Other page} and see if it works.
+

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/odoc_page_link_bug.opam
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/odoc_page_link_bug.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+name: "odoc_page_link_bug"
+version: "0.0.1"
+synopsis: "Odoc page link bug"
+license: "MIT"
+depends: [
+
+	"dune" {build}
+]

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/odoc_page_link_bug.opam
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/odoc_page_link_bug.opam
@@ -1,9 +1,0 @@
-opam-version: "2.0"
-name: "odoc_page_link_bug"
-version: "0.0.1"
-synopsis: "Odoc page link bug"
-license: "MIT"
-depends: [
-
-	"dune" {build}
-]

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/otherpage.mld
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/otherpage.mld
@@ -1,0 +1,4 @@
+{0 The other page}
+
+This is the other page.  Congratulations!
+

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/run.t
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/run.t
@@ -3,7 +3,7 @@ no library associated with the project
 
 This test case is based on code provided by @vphantom, ocaml/dune#2007
 
-  $ dune build @doc
+  $ dune build _doc/_html/odoc_page_link_bug/index.html
 
   $ grep -r xref-unresolved _build/default/_doc/_html/odoc_page_link_bug/index.html
   [1]

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/run.t
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/run.t
@@ -1,0 +1,9 @@
+Make sure that links between mld files are resolved even when there is
+no library associated with the project
+
+This test case is based on code provided by @vphantom, ocaml/dune#2007
+
+  $ dune build @doc
+
+  $ grep -r xref-unresolved _build/default/_doc/_html/odoc_page_link_bug/index.html
+

--- a/test/blackbox-tests/test-cases/odoc-package-mld-link/run.t
+++ b/test/blackbox-tests/test-cases/odoc-package-mld-link/run.t
@@ -6,4 +6,5 @@ This test case is based on code provided by @vphantom, ocaml/dune#2007
   $ dune build @doc
 
   $ grep -r xref-unresolved _build/default/_doc/_html/odoc_page_link_bug/index.html
+  [1]
 

--- a/test/blackbox-tests/test-cases/odoc-unique-mlds/run.t
+++ b/test/blackbox-tests/test-cases/odoc-unique-mlds/run.t
@@ -3,11 +3,11 @@ Duplicate mld's in the same scope
   Entering directory 'same-scope'
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
         ocamlc lib1/.root_lib1.objs/byte/root_lib1.{cmi,cmo,cmt}
+          odoc _doc/_odoc/pkg/root/page-index.odoc
           odoc _doc/_odoc/lib/root.lib1/root_lib1.odoc
         ocamlc lib2/.root_lib2.objs/byte/root_lib2.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/root.lib2/root_lib2.odoc
           odoc _doc/_html/root/Root_lib2/.dune-keep,_doc/_html/root/Root_lib2/index.html
-          odoc _doc/_odoc/pkg/root/page-index.odoc
           odoc _doc/_html/root/index.html
           odoc _doc/_html/root/Root_lib1/.dune-keep,_doc/_html/root/Root_lib1/index.html
 
@@ -17,12 +17,12 @@ Duplicate mld's in different scope
   Entering directory 'diff-scope'
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
         ocamlc scope1/.scope1.objs/byte/scope1.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/scope1/scope1.odoc
-          odoc _doc/_html/scope1/Scope1/.dune-keep,_doc/_html/scope1/Scope1/index.html
           odoc _doc/_odoc/pkg/scope1/page-index.odoc
+          odoc _doc/_odoc/lib/scope1/scope1.odoc
           odoc _doc/_html/scope1/index.html
         ocamlc scope2/.scope2.objs/byte/scope2.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/scope2/scope2.odoc
-          odoc _doc/_html/scope2/Scope2/.dune-keep,_doc/_html/scope2/Scope2/index.html
           odoc _doc/_odoc/pkg/scope2/page-index.odoc
+          odoc _doc/_odoc/lib/scope2/scope2.odoc
           odoc _doc/_html/scope2/index.html
+          odoc _doc/_html/scope1/Scope1/.dune-keep,_doc/_html/scope1/Scope1/index.html
+          odoc _doc/_html/scope2/Scope2/.dune-keep,_doc/_html/scope2/Scope2/index.html

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -1,13 +1,13 @@
   $ dune build @doc --display short
       ocamldep .bar.objs/bar.ml.d
         ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/bar/bar.odoc
-          odoc _doc/_html/bar/Bar/.dune-keep,_doc/_html/bar/Bar/index.html
           odoc _doc/_odoc/pkg/bar/page-index.odoc
+          odoc _doc/_odoc/lib/bar/bar.odoc
           odoc _doc/_html/bar/index.html
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
       ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
+          odoc _doc/_odoc/pkg/foo/page-index.odoc
           odoc _doc/_odoc/lib/foo/foo.odoc
       ocamldep .foo.objs/foo2.ml.d
         ocamlc .foo.objs/byte/foo2.{cmi,cmo,cmt}
@@ -19,9 +19,9 @@
         ocamlc .foo_byte.objs/byte/foo_byte.{cmi,cmo,cmt}
           odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
           odoc _doc/_html/foo/Foo2/.dune-keep,_doc/_html/foo/Foo2/index.html
-          odoc _doc/_odoc/pkg/foo/page-index.odoc
-          odoc _doc/_html/foo/index.html
+          odoc _doc/_html/bar/Bar/.dune-keep,_doc/_html/bar/Bar/index.html
           odoc _doc/_html/foo/Foo_byte/.dune-keep,_doc/_html/foo/Foo_byte/index.html
+          odoc _doc/_html/foo/index.html
           odoc _doc/_html/foo/Foo/.dune-keep,_doc/_html/foo/Foo/index.html
   $ dune runtest --display short
   <!DOCTYPE html>


### PR DESCRIPTION
This ensures links to/from docs that exist outside of a library are correctly resolved.