### PR TITLE
Add Match_lang.t

### DIFF
--- a/src/dune/case_lang.ml
+++ b/src/dune/case_lang.ml
@@ -1,0 +1,39 @@
+open! Stdune
+
+module Ast = struct
+  type ('k, 'v) t =
+    { on : String_with_vars.t
+    ; clauses : ('k * 'v) list
+    }
+
+  let decode k v =
+    let open Dune_lang.Decoder in
+    enter
+      (let* loc, () = located (keyword "case") in
+       let* on = String_with_vars.decode in
+       let clause =
+         enter
+           (let* elt = k in
+            let* () = keyword "->" in
+            let+ v = v in
+            (elt, v))
+       in
+       let+ clauses = repeat clause in
+       ( match clauses with
+       | [] ->
+         User_error.raise ~loc
+           [ Pp.text "case expression must have at least one clause" ]
+       | _ :: _ -> () );
+       { on; clauses })
+end
+
+type 'a t = (Predicate_lang.Glob.t, 'a) Ast.t
+
+let decode f = Ast.decode Predicate_lang.Glob.decode f
+
+let eval (t : _ t) ~f =
+  let elem = f t.on in
+  List.find_map t.clauses ~f:(fun (keys, v) ->
+      Option.some_if
+        (Predicate_lang.Glob.exec keys ~standard:Predicate_lang.empty elem)
+        v)

--- a/src/dune/case_lang.mli
+++ b/src/dune/case_lang.mli
@@ -1,0 +1,11 @@
+(** The case language expresses conditional evaluation. The general form is:
+    [(case %{expr} (<pred> -> <outcome>))] where [<pred>] is described using
+    the predicate language: [Predicate_lang.t]. *)
+
+open! Stdune
+
+type 'a t
+
+val eval : 'a t -> f:(String_with_vars.t -> string) -> 'a option
+
+val decode : 'a Dune_lang.Decoder.t -> 'a t Dune_lang.Decoder.t


### PR DESCRIPTION
This is the WIP after the discussion in #1682. The idea is to implement the example given in:

```
(flags -w 1 (per_file
             (foo.ml -> -w 2)
             (bar.ml -> -w 3)))
```

Except that it would look like:

```
(flags
 -w 1
 (per_file
  (match
   (foo.ml -> -w 2)
   (bar.ml -> -w 3)))
```

The idea is that the generalized `match` will be useful in other contexts so I've made the element re-usable.

I'm trying to implement the above suggestion as being equivalent to:

```
(flags
 (per_file
  (match (* -> -w 1))
 (per_file
  (match
   (foo.ml -> -w 2)
   (bar.ml -> -w 3)))
```