### PR TITLE
Warn instead of failing on opam files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ unreleased
 - Do not list private modules in the generated index. (#2009, fix #2008,
   @rgrinberg)
 
+- Warn instead of failing if an opam file fails to parse. This opam file can
+  still be used to define scope. (#2023, @rgrinberg)
+
 1.8.2 (10/03/2019)
 ------------------
 

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -52,7 +52,10 @@ let pp_uncaught ~backtrace fmt exn =
      | @{<error>Internal error@}: Uncaught exception.\n\
      %s\n\
      \\%s@."
-    line s line;
+    line s line
+
+let pp fmt exn =
+  Format.pp_print_string fmt (Printexc.to_string exn)
 
 include
   ((struct

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -34,6 +34,8 @@ val protectx : 'a -> f:('a -> 'b) -> finally:('a -> unit) -> 'b
 
 val pp_uncaught : backtrace:string -> Format.formatter -> t -> unit
 
+val pp : Format.formatter -> t -> unit
+
 val raise_with_backtrace: exn -> Printexc.raw_backtrace -> _
 
 val equal : t -> t -> bool


### PR DESCRIPTION
The contents of these files doesn't really matter so we should simply ignore
them if we fail to read them.

I'm planning on making a similar change to dune-project reading. But in that case, it's probably only safe to continue when encountering Unix errors. 