### PR TITLE
change ownership of src/merlin.*

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@ src/menhir.* @fpottier
 
 src/odoc.* @rginberg @antron
 
-src/merlin.* @trefis
+src/merlin.* @aalekseyev
 
 src/configurator/* @rgrinberg
 


### PR DESCRIPTION
trefis doesn't want to own it because it generates a lot of notifications

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>