### PR TITLE
Clean up Scope DB creation

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -666,3 +666,10 @@ let cc_g (ctx : t) =
 let name t = t.name
 
 let has_native t = Option.is_some t.ocamlopt
+
+let lib_config t =
+  { Lib_config.
+    has_native = has_native t
+  ; ext_obj = t.ext_obj
+  ; ext_lib = t.ext_lib
+  }

--- a/src/context.mli
+++ b/src/context.mli
@@ -159,3 +159,5 @@ val cc_g : t -> string list
 val name : t -> string
 
 val has_native : t -> bool
+
+val lib_config : t -> Lib_config.t

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1278,17 +1278,15 @@ module DB = struct
       (virtual_lib, Variant.Map.of_list_exn [content]))
     |> Lib_name.Map.of_list_reduce ~f:Variant.Map.Multi.rev_union
 
-  let create_from_library_stanzas ?parent ~has_native ~ext_lib ~ext_obj
-        stanzas =
+  let create_from_library_stanzas ?parent ~lib_config stanzas =
     let variant_map =
       List.map stanzas ~f:(fun (dir, (conf : Dune_file.Library.t)) ->
-        Lib_info.of_library_stanza ~dir ~has_native ~ext_lib ~ext_obj conf)
+        Lib_info.of_library_stanza ~dir ~lib_config conf)
       |> create_variant_map
     in
     let map =
       List.concat_map stanzas ~f:(fun (dir, (conf : Dune_file.Library.t)) ->
-        let info =
-          Lib_info.of_library_stanza ~dir ~has_native ~ext_lib ~ext_obj conf in
+        let info = Lib_info.of_library_stanza ~dir ~lib_config conf in
         match conf.public with
         | None ->
           [Dune_file.Library.best_name conf, Resolve_result.Found info]

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -252,9 +252,7 @@ module DB : sig
   (** Create a database from a list of library stanzas *)
   val create_from_library_stanzas
     :  ?parent:t
-    -> has_native:bool
-    -> ext_lib:string
-    -> ext_obj:string
+    -> lib_config:Lib_config.t
     -> (Path.t * Dune_file.Library.t) list
     -> t
 

--- a/src/lib_config.ml
+++ b/src/lib_config.ml
@@ -1,0 +1,7 @@
+open! Stdune
+
+type t =
+  { has_native : bool
+  ; ext_lib : string
+  ; ext_obj : string
+  }

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -84,7 +84,8 @@ let user_written_deps t =
     ~init:(Deps.to_lib_deps t.requires)
     ~f:(fun acc s -> Dune_file.Lib_dep.Direct s :: acc)
 
-let of_library_stanza ~dir ~has_native ~ext_lib ~ext_obj
+let of_library_stanza ~dir
+      ~lib_config:{ Lib_config.has_native; ext_lib; ext_obj}
       (conf : Dune_file.Library.t) =
   let (_loc, lib_name) = conf.name in
   let obj_dir =

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -62,9 +62,7 @@ type t = private
 
 val of_library_stanza
   :  dir:Path.t
-  -> has_native:bool
-  -> ext_lib:string
-  -> ext_obj:string
+  -> lib_config:Lib_config.t
   -> Dune_file.Library.t
   -> t
 

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -75,8 +75,7 @@ module DB = struct
       Lib.DB.find_implementations scope.db virt
       |> Variant.Map.Multi.rev_union acc)
 
-  let create ~projects ~context ~installed_libs ~has_native ~ext_lib ~ext_obj
-        internal_libs =
+  let create ~projects ~context ~installed_libs ~lib_config internal_libs =
     let projects_by_name =
       List.map projects ~f:(fun (project : Dune_project.t) ->
         (Dune_project.name project, project))
@@ -139,8 +138,8 @@ module DB = struct
           let project = Option.value_exn project in
           let libs = Option.value libs ~default:[] in
           let db =
-            Lib.DB.create_from_library_stanzas libs ~has_native
-              ~parent:public_libs ~ext_lib ~ext_obj
+            Lib.DB.create_from_library_stanzas libs
+              ~parent:public_libs ~lib_config
           in
           let root =
             Path.append_local build_context_dir (Dune_project.root project) in

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -69,7 +69,42 @@ module DB = struct
       Lib.DB.find_implementations scope.db virt
       |> Variant.Map.Multi.rev_union acc)
 
-  let create ~projects ~context ~installed_libs ~lib_config internal_libs =
+  let public_libs t ~installed_libs internal_libs =
+    let public_libs =
+      List.filter_map internal_libs
+        ~f:(fun (_dir, (lib : Dune_file.Library.t)) ->
+          Option.map lib.public ~f:(fun p ->
+            (Dune_file.Public_lib.name p, lib.project)))
+      |> Lib_name.Map.of_list
+      |> function
+      | Ok x -> x
+      | Error (name, _, _) ->
+        match
+          List.filter_map internal_libs ~f:(fun (_dir, lib) ->
+            Option.bind lib.public ~f:(fun p ->
+              Option.some_if (name = Dune_file.Public_lib.name p)
+                lib.buildable.loc))
+        with
+        | [] | [_] -> assert false
+        | loc1 :: loc2 :: _ ->
+          die "Public library %a is defined twice:\n\
+               - %s\n\
+               - %s"
+            Lib_name.pp_quoted name
+            (Loc.to_file_colon_line loc1)
+            (Loc.to_file_colon_line loc2)
+    in
+    let resolve = resolve t public_libs in
+    let find_implementations = find_implementations t public_libs in
+    Lib.DB.create ()
+      ~parent:installed_libs
+      ~resolve
+      ~find_implementations
+      ~all:(fun () -> Lib_name.Map.keys public_libs)
+
+  let sccopes_by_name ~context ~projects ~lib_config ~public_libs
+        internal_libs =
+    let build_context_dir = Path.relative Path.build_dir context in
     let projects_by_name =
       List.map projects ~f:(fun (project : Dune_project.t) ->
         (Dune_project.name project, project))
@@ -91,52 +126,21 @@ module DB = struct
         (Dune_project.name lib.project, (dir, lib)))
       |> Dune_project.Name.Map.of_list_multi
     in
+    Dune_project.Name.Map.merge projects_by_name libs_by_project_name
+      ~f:(fun _name project libs ->
+        let project = Option.value_exn project in
+        let libs = Option.value libs ~default:[] in
+        let db = Lib.DB.create_from_library_stanzas libs
+                   ~parent:public_libs ~lib_config in
+        let root =
+          Path.append_local build_context_dir (Dune_project.root project) in
+        Some { project; db; root })
+
+  let create ~projects ~context ~installed_libs ~lib_config internal_libs =
     let t = Fdecl.create () in
-    let public_libs =
-      let public_libs =
-        List.filter_map internal_libs ~f:(fun (_dir, lib) ->
-          Option.map lib.public ~f:(fun p ->
-            (Dune_file.Public_lib.name p, lib.project)))
-        |> Lib_name.Map.of_list
-        |> function
-        | Ok x -> x
-        | Error (name, _, _) ->
-          match
-            List.filter_map internal_libs ~f:(fun (_dir, lib) ->
-              Option.bind lib.public ~f:(fun p ->
-                Option.some_if (name = Dune_file.Public_lib.name p)
-                  lib.buildable.loc))
-          with
-          | [] | [_] -> assert false
-          | loc1 :: loc2 :: _ ->
-            die "Public library %a is defined twice:\n\
-                 - %s\n\
-                 - %s"
-              Lib_name.pp_quoted name
-              (Loc.to_file_colon_line loc1)
-              (Loc.to_file_colon_line loc2)
-      in
-      let resolve = resolve t public_libs in
-      let find_implementations = find_implementations t public_libs in
-      Lib.DB.create ()
-        ~parent:installed_libs
-        ~resolve
-        ~find_implementations
-        ~all:(fun () -> Lib_name.Map.keys public_libs)
-    in
+    let public_libs = public_libs t ~installed_libs internal_libs in
     let by_name =
-      let build_context_dir = Path.relative Path.build_dir context in
-      Dune_project.Name.Map.merge projects_by_name libs_by_project_name
-        ~f:(fun _name project libs ->
-          let project = Option.value_exn project in
-          let libs = Option.value libs ~default:[] in
-          let db =
-            Lib.DB.create_from_library_stanzas libs
-              ~parent:public_libs ~lib_config
-          in
-          let root =
-            Path.append_local build_context_dir (Dune_project.root project) in
-          Some { project; db; root })
+      sccopes_by_name ~context ~projects ~lib_config ~public_libs internal_libs
     in
     let by_dir = Hashtbl.create 1024 in
     Dune_project.Name.Map.iter by_name ~f:(fun scope ->

--- a/src/scope.mli
+++ b/src/scope.mli
@@ -25,9 +25,7 @@ module DB : sig
     :  projects:Dune_project.t list
     -> context:string
     -> installed_libs:Lib.DB.t
-    -> has_native:bool
-    -> ext_lib:string
-    -> ext_obj:string
+    -> lib_config:Lib_config.t
     -> (Path.t * Dune_file.Library.t) list
     -> t * Lib.DB.t
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -297,13 +297,12 @@ let create
           | _ -> None))
   in
   let scopes, public_libs =
+    let lib_config = Context.lib_config context in
     Scope.DB.create
       ~projects
       ~context:context.name
       ~installed_libs
-      ~has_native:(Context.has_native context)
-      ~ext_lib:context.ext_lib
-      ~ext_obj:context.ext_obj
+      ~lib_config
       internal_libs
   in
   let stanzas =


### PR DESCRIPTION
The creation is basically done in 2 parts, so I split it into 2 functions. I also get rid of the mutability which is more clearly handled with a forward declaration. Lib_config.t is introduced to stop passing the same parameters everywhere.