### PR TITLE
printf in expect tests

### DIFF
--- a/src/stdune/in_expect_test.ml
+++ b/src/stdune/in_expect_test.ml
@@ -1,0 +1,8 @@
+let formatter = ref None
+
+let printf fmt =
+  match !formatter with
+  | None ->
+    failwith "Not running an expect test"
+  | Some formatter ->
+    Format.fprintf formatter fmt

--- a/src/stdune/in_expect_test.mli
+++ b/src/stdune/in_expect_test.mli
@@ -1,0 +1,5 @@
+(** A [printf] that's usable in expect tests. *)
+
+val formatter : Format.formatter option ref
+
+val printf : ('a, Format.formatter, unit) format -> 'a

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -44,6 +44,7 @@ module Fn         = Fn
 module Dyn        = Dyn
 module Float      = Float
 module Tuple      = Tuple
+module In_expect_test = In_expect_test
 
 external reraise : exn -> _ = "%reraise"
 

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -3,7 +3,7 @@
  (modules expect_test)
  (link_flags (-linkall))
  (modes byte)
- (libraries wp_dune unix dune compiler-libs.toplevel test_common dag))
+ (libraries stdune wp_dune unix dune compiler-libs.toplevel test_common dag))
 
 (ocamllex expect_test)
 

--- a/test/unit-tests/expect_test.mll
+++ b/test/unit-tests/expect_test.mll
@@ -123,6 +123,7 @@ let main () =
             | Expect | Error -> true
             | Ignore -> false
           in
+          Stdune.In_expect_test.formatter := Some ppf;
           ignore (Toploop.execute_phrase print_types_and_values ppf phr : bool)
         with exn ->
           let ppf =


### PR DESCRIPTION
After this PR if you use `Stdune.In_expect_test.printf "hello world\n"` in an expect test, that output will become a part of the expectation. (ideally we'd capture the normal printf, but that's trickier)

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>