### PR TITLE
Store all contexts in a global reference

### DIFF
--- a/src/context.ml
+++ b/src/context.ml
@@ -673,3 +673,26 @@ let lib_config t =
   ; ext_obj = t.ext_obj
   ; ext_lib = t.ext_lib
   }
+
+let db = Fdecl.create ()
+
+let set contexts =
+  List.map contexts ~f:(fun context -> (context.build_dir, context))
+  |> Path.Map.of_list_exn
+  |> Fdecl.set db
+
+let get ~dir:init_dir =
+  let contexts = Fdecl.get db in
+  let rec find dir =
+    match Path.Map.find contexts dir with
+    | Some c -> c
+    | None ->
+      match Path.parent dir with
+      | None ->
+        Exn.code_error "context not defined for this dir"
+          [ "init_dir", Path.to_sexp init_dir
+          ]
+      | Some p -> find p
+  in
+  find init_dir
+

--- a/src/context.mli
+++ b/src/context.mli
@@ -161,3 +161,7 @@ val name : t -> string
 val has_native : t -> bool
 
 val lib_config : t -> Lib_config.t
+
+val set : t list -> unit
+
+val get : dir:Path.t -> t

--- a/src/env_node.mli
+++ b/src/env_node.mli
@@ -15,26 +15,23 @@ val make
 
 val scope : t -> Scope.t
 
-val external_ : t -> profile:string -> default:Env.t -> Env.t
+val external_ : t -> default:Env.t -> Env.t
 
-val ocaml_flags : t -> profile:string -> expander:Expander.t -> Ocaml_flags.t
+val ocaml_flags : t -> expander:Expander.t -> Ocaml_flags.t
 
 val c_flags
   : t
-  -> profile:string
   -> expander:Expander.t
   -> default_context_flags:string list C.Kind.Dict.t
   -> (unit, string list) Build.t C.Kind.Dict.t
 
 val local_binaries
   :  t
-  -> profile:string
   -> expander:Expander.t
   -> File_binding.Expanded.t list
 
 val artifacts
   :  t
-  -> profile:string
   -> default:Artifacts.t
   -> expander:Expander.t
   -> Artifacts.t

--- a/src/main.ml
+++ b/src/main.ml
@@ -71,6 +71,7 @@ let scan_workspace ?(log=Log.no_log)
   }
 
 let init_build_system ?only_packages ?external_lib_deps_mode w =
+  Context.set w.contexts;
   Option.iter only_packages ~f:(fun set ->
     Package.Name.Set.iter set ~f:(fun pkg ->
       if not (Package.Name.Map.mem w.conf.packages pkg) then

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -111,7 +111,7 @@ end = struct
           [ "dir", Path.to_sexp dir ]
 
   let external_ t  ~dir =
-    Env_node.external_ (get t ~dir) ~profile:(profile t) ~default:t.context.env
+    Env_node.external_ (get t ~dir) ~default:t.context.env
 
   let expander_for_artifacts t ~dir =
     let node = get t ~dir in
@@ -123,11 +123,11 @@ end = struct
   let local_binaries t ~dir =
     let node = get t ~dir in
     let expander = expander_for_artifacts t ~dir in
-    Env_node.local_binaries node ~profile:(profile t) ~expander
+    Env_node.local_binaries node ~expander
 
   let artifacts t ~dir =
     let expander = expander_for_artifacts t ~dir in
-    Env_node.artifacts (get t ~dir) ~profile:(profile t) ~default:t.artifacts
+    Env_node.artifacts (get t ~dir) ~default:t.artifacts
       ~expander
 
   let artifacts_host t ~dir =
@@ -145,8 +145,7 @@ end = struct
     Expander.set_artifacts expander ~artifacts ~artifacts_host
 
   let ocaml_flags t ~dir =
-    Env_node.ocaml_flags (get t ~dir)
-      ~profile:(profile t) ~expander:(expander t ~dir)
+    Env_node.ocaml_flags (get t ~dir) ~expander:(expander t ~dir)
 
   let default_context_flags (ctx : Context.t) =
     let c = ctx.ocamlc_cflags in
@@ -158,7 +157,7 @@ end = struct
   let c_flags t ~dir =
     let default_context_flags = default_context_flags t.context in
     Env_node.c_flags (get t ~dir)
-      ~profile:(profile t) ~expander:(expander t ~dir)
+      ~expander:(expander t ~dir)
       ~default_context_flags
 end
 


### PR DESCRIPTION
This allows us to access the profile based on the current build directory
without any extra definition. With this, we are able to get rid of the ~profile
argument to all the Env_node functions.

This is just an experiment more than anything, but I think this pattern lets us simplify a bunch of the code. I never liked how error prone the `Env_node` functions were with respect to the `~profile` argument. For example, if you call any of the `Env_node.foo` functions twice with a different profile, you will get an incorrect result.