### PR TITLE
Remove caching of scopes

### DIFF
--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -108,6 +108,11 @@ module Make(Key : Comparable.S) : S with type key = Key.t = struct
         | x :: y :: _ -> Error (k, x, y)
         | _ -> assert false
 
+  let of_list_map_exn t ~f =
+    match of_list_map t ~f with
+    | Ok x -> x
+    | Error _ -> Exn.code_error "Map.of_list_map_exn" []
+
   let of_list_exn l =
     match of_list l with
     | Ok    x -> x

--- a/src/stdune/map_intf.ml
+++ b/src/stdune/map_intf.ml
@@ -58,6 +58,10 @@ module type S = sig
     :  'a list
     -> f:('a -> key * 'b)
     -> ('b t, key * 'a * 'a) Result.t
+  val of_list_map_exn
+    :  'a list
+    -> f:('a -> key * 'b)
+    -> 'b t
   val of_list_exn : (key * 'a) list -> 'a t
 
   val of_list_multi  : (key * 'a) list -> 'a list t


### PR DESCRIPTION
This is similar to the case of the caching that was present in `File_tree.t`. I've benchmarked this change on the ocaml platform, and if it has an impact, it's infact negative as this PR seems to offer a small but measurable speed up. And in fact, the map lookup introduced here could be even faster if we had some sort of a trie based map of paths.

I'm aware that there's some duplication introduced between this PR and #2043. I will address it once both PR's are merged.