### PR TITLE
Use Unix.opendir to list directories

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -104,10 +104,13 @@ module File_ops_real : FILE_OPERATIONS = struct
   let remove_dir_if_empty dir =
     if Path.exists dir then
       match Path.readdir_unsorted dir with
-      | [] ->
-          Printf.eprintf "Deleting empty directory %s\n%!"
+      | Ok [] ->
+        Printf.eprintf "Deleting empty directory %s\n%!"
           (Path.to_string_maybe_quoted dir);
         print_unix_error (fun () -> Path.rmdir dir)
+      | Error e ->
+        Format.eprintf "@{<error>Error@}: %s@."
+          (Unix.error_message e)
       | _  -> ()
 
   let mkdir_p = Path.mkdir_p

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -170,7 +170,7 @@ type readdir =
 
 let readdir path =
   match Path.readdir_unsorted path with
-  | exception (Sys_error msg) ->
+  | Error unix_error ->
     Errors.warn Loc.none
       "Unable to read directory %s. Ignoring.@.\
        Remove this message by ignoring by adding:@.\
@@ -180,9 +180,9 @@ let readdir path =
       (Path.to_string_maybe_quoted path)
       (Path.basename path)
       (Path.to_string_maybe_quoted (Path.relative (Path.parent_exn path) "dune"))
-      msg;
-    Error msg
-  | unsorted_contents ->
+      (Unix.error_message unix_error);
+    Error unix_error
+  | Ok unsorted_contents ->
     let files, dirs =
       List.filter_partition_map unsorted_contents ~f:(fun fn ->
         let path = Path.relative path fn in
@@ -307,7 +307,7 @@ let load ?(warn_when_seeing_jbuild_file=true) path =
   | Ok dir -> dir
   | Error m ->
     die "Unable to load source %s.@.Reason:%s@."
-      (Path.to_string_maybe_quoted path) m
+      (Path.to_string_maybe_quoted path) (Unix.error_message m)
 
 let fold = Dir.fold
 

--- a/src/promotion.ml
+++ b/src/promotion.ml
@@ -70,7 +70,8 @@ let do_promote db files_to_promote =
   let potential_build_contexts =
     match Path.readdir_unsorted Path.build_dir with
     | exception _ -> []
-    | files ->
+    | Error _ -> []
+    | Ok files ->
       List.filter_map files ~f:(fun fn ->
         if fn = "" || fn.[0] = '.' || fn = "install" then
           None

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -134,7 +134,7 @@ val split_first_component : t -> (string * t) option
 val insert_after_build_dir_exn : t -> string -> t
 
 val exists : t -> bool
-val readdir_unsorted : t -> string list
+val readdir_unsorted : t -> (string list, Unix.error) Result.t
 val is_directory : t -> bool
 val is_file : t -> bool
 val rmdir : t -> unit

--- a/test/blackbox-tests/test-cases/unreadable-src/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-src/run.t
@@ -5,6 +5,6 @@
   Remove this message by ignoring by adding:
   (dirs \ foo)
   to the dune file: dune
-  Reason: foo: Permission denied
+  Reason: Permission denied
   
   $ chmod +r foo && rm -rf foo


### PR DESCRIPTION
This allows us to accurately detect errors unlike Sys.readdir.