### PR TITLE
[menhir] Call menhir from root build directory to improve error reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- [menhir] call menhir from context root build_dir (#2067, @ejgallego,
+  review by @diml, @rgrinberg)
+
 - [coq] Rename `(coqlib ...)` to `(coq.theory ...)`, support for
   `coqlib` will be dropped in the 1.0 version of the Coq language
   (#2055, @ejgallego)

--- a/src/coq_rules.boot.ml
+++ b/src/coq_rules.boot.ml
@@ -1,5 +1,5 @@
 module Dir_contents = Dir_contents (* hack for bootstrappign + ocamldep*)
 
-let setup_rules ~sctx:_ ~dir:_ ~dir_contents:_ _ = []
+let setup_rules ~sctx:_ ~build_dir:_ ~dir:_ ~dir_contents:_ _ = []
 let install_rules ~sctx:_ ~dir:_ _ = []
-let coqpp_rules ~sctx:_ ~dir:_ _ = []
+let coqpp_rules ~sctx:_ ~build_dir:_ ~dir:_ _ = []

--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -135,7 +135,7 @@ let setup_ml_deps ~lib_db libs =
 let coqlib_wrapper_name (s : Dune_file.Coq.t) =
   Lib_name.Local.to_string (snd s.name)
 
-let setup_rules ~sctx ~dir ~dir_contents (s : Dune_file.Coq.t) =
+let setup_rules ~sctx ~build_dir:_ ~dir ~dir_contents (s : Dune_file.Coq.t) =
 
   let scope = SC.find_scope_by_dir sctx dir in
 
@@ -203,16 +203,14 @@ let install_rules ~sctx ~dir s =
       None, Install.(Entry.make Section.Lib_root ~dst vofile))
     |> List.rev_append (coq_plugins_install_rules ~scope ~package ~dst_dir s)
 
-let coqpp_rules ~sctx ~dir (s : Dune_file.Coqpp.t) =
+let coqpp_rules ~sctx ~build_dir ~dir (s : Dune_file.Coqpp.t) =
 
-  let scope = SC.find_scope_by_dir sctx dir in
-  let base_dir = Scope.root scope in
   let cc = create_ccoq sctx ~dir in
 
   let mlg_rule m =
     let source = Path.relative dir (m ^ ".mlg") in
     let target = Path.relative dir (m ^ ".ml") in
     let args = Arg_spec.[Dep source; Hidden_targets [target]] in
-    Build.run ~dir:base_dir cc.coqpp args in
+    Build.run ~dir:build_dir cc.coqpp args in
 
   List.map ~f:mlg_rule s.modules

--- a/src/coq_rules.mli
+++ b/src/coq_rules.mli
@@ -8,6 +8,7 @@ open! Stdune
 
 val setup_rules
   :  sctx:Super_context.t
+  -> build_dir:Path.t
   -> dir:Path.t
   -> dir_contents:Dir_contents.t
   -> Dune_file.Coq.t
@@ -21,6 +22,7 @@ val install_rules
 
 val coqpp_rules
   :  sctx:Super_context.t
+  -> build_dir:Path.t
   -> dir:Path.t
   -> Dune_file.Coqpp.t
   -> (unit, Action.t) Build.t list

--- a/src/menhir.boot.ml
+++ b/src/menhir.boot.ml
@@ -1,4 +1,4 @@
-let gen_rules ~dir _ _ = ()
+let gen_rules ~build_dir:_ ~dir:_ _ _ = ()
 
 let targets _ = []
 

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -40,10 +40,9 @@ module type PARAMS = sig
      is of the form [_build/<context>/src], e.g., [_build/default/src]. *)
   val dir : Path.t
 
-  (* [root_dir] is the base directory of the context, usually where
-     the build is invoked from; we run menhir from this directoy to we
-     get correct error paths. *)
-  val root_dir : Path.t
+  (* [build_dir] is the base directory of the context; we run menhir
+     from this directoy to we get correct error paths. *)
+  val build_dir : Path.t
 
   (* [stanza] is the [(menhir ...)] stanza, as found in the [jbuild] file. *)
 
@@ -127,7 +126,7 @@ module Run (P : PARAMS) : sig end = struct
   (* [menhir args] generates a Menhir command line (a build action). *)
 
   let menhir (args : 'a args) : (string list, Action.t) Build.t =
-    Build.run ~dir:root_dir menhir_binary args
+    Build.run ~dir:build_dir menhir_binary args
 
   let rule ?(mode=stanza.mode) : (unit, Action.t) Build.t -> unit =
     SC.add_rule sctx ~dir ~mode ~loc:stanza.loc
@@ -322,12 +321,12 @@ let targets (stanza : Dune_file.Menhir.t) : string list =
 let module_names (stanza : Dune_file.Menhir.t) : Module.Name.t list =
   List.map (modules stanza) ~f:Module.Name.of_string
 
-let gen_rules ~dir cctx stanza =
+let gen_rules ~build_dir ~dir cctx stanza =
   let module R =
     Run (struct
       let cctx = cctx
       let dir = dir
-      let root_dir = Scope.root (Compilation_context.scope cctx)
+      let build_dir = build_dir
       let stanza = stanza
     end) in
   ()

--- a/src/menhir.mli
+++ b/src/menhir.mli
@@ -12,7 +12,8 @@ val module_names : Dune_file.Menhir.t -> Module.Name.t list
 
 (** Generate the rules for a [(menhir ...)] stanza. *)
 val gen_rules
-  :  dir:Path.t
+  :  build_dir:Path.t
+  -> dir:Path.t
   -> Compilation_context.t
   -> Dune_file.Menhir.t
   -> unit


### PR DESCRIPTION
This is a common problem in a few Dune tools: if a menhir file is
inside a sub-directory, the tool will be invoked from the subdir,
however the Dune call was likely from the top-level directory and the
error/warning messages won't be correct.

I am not sure this is the right way to address this problem, in
particular what will happen if Dune is called from some parallel
sub-directory. Suggestions welcome.
