### PR TITLE
Fine grained path types

### DIFF
--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -5,7 +5,7 @@ let die = Dune.Import.die
 type t =
   { name : string
   ; recursive : bool
-  ; dir : Path.t
+  ; dir : Path.Source.t
   ; contexts : Dune.Context.t list
   }
 
@@ -13,14 +13,14 @@ let to_log_string { name ; recursive; dir ; contexts = _ } =
   sprintf "- %s alias %s%s/%s"
     (if recursive then "recursive " else "")
     (if recursive then "@@" else "@")
-    (Path.to_string_maybe_quoted dir)
+    (Path.Source.to_string_maybe_quoted dir)
     name
 
 let in_dir ~name ~recursive ~contexts dir =
   Util.check_path contexts dir;
   match Path.extract_build_context dir with
   | None ->
-    { dir
+    { dir = Option.value_exn (Path.as_in_source_tree dir)
     ; recursive
     ; name
     ; contexts

--- a/bin/alias.mli
+++ b/bin/alias.mli
@@ -3,7 +3,7 @@ open Stdune
 type t = private
   { name : string
   ; recursive : bool
-  ; dir : Path.t
+  ; dir : Path.Source.t
   ; contexts : Dune.Context.t list
   }
 

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -25,7 +25,7 @@ let run ~lib_deps ~by_dir ~setup ~only_missing ~sexp =
   String.Map.foldi lib_deps ~init:false
     ~f:(fun context_name lib_deps_by_dir acc ->
       let lib_deps =
-        Path.Map.values lib_deps_by_dir
+        Path.Source.Map.values lib_deps_by_dir
         |> List.fold_left ~init:Lib_name.Map.empty ~f:Lib_deps_info.merge
       in
       let internals =
@@ -84,13 +84,13 @@ let run ~lib_deps ~by_dir ~setup ~only_missing ~sexp =
           die "@{<error>Error@}: --sexp requires --unstable-by-dir";
         let lib_deps_by_dir =
           lib_deps_by_dir
-          |> Path.Map.map ~f:(Lib_name.Map.filteri ~f:is_external)
-          |> Path.Map.filter ~f:(fun m -> not (Lib_name.Map.is_empty m))
+          |> Path.Source.Map.map ~f:(Lib_name.Map.filteri ~f:is_external)
+          |> Path.Source.Map.filter ~f:(fun m -> not (Lib_name.Map.is_empty m))
         in
         let sexp =
           Map.to_sexp
-            Path.Map.to_list
-            (fun p -> Atom (Path.to_string p))
+            Path.Source.Map.to_list
+            (fun p -> Atom (Path.Source.to_string p))
             Lib_deps_info.to_sexp
             lib_deps_by_dir
         in

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -6,7 +6,7 @@ let interpret_destdir ~destdir path =
   | None ->
     path
   | Some prefix ->
-    Path.append_local
+    Path.append_relative
       (Path.of_string prefix)
       (Path.local_part path)
 

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -181,7 +181,7 @@ let install_uninstall ~what =
         List.concat_map pkgs ~f:(fun pkg ->
           let fn = resolve_package_install workspace pkg in
           List.map workspace.contexts ~f:(fun ctx ->
-            let fn = Path.append ctx.Context.build_dir fn in
+            let fn = Path.append_source ctx.Context.build_dir fn in
             if Path.exists fn then
               Left (ctx, (pkg, fn))
             else

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -114,11 +114,11 @@ let promote =
        | _ ->
          let files =
            List.map files
-             ~f:(fun fn -> Path.of_string (Common.prefix_target common fn))
+             ~f:(fun fn -> Path.Source.of_string (Common.prefix_target common fn))
          in
          let on_missing fn =
            Format.eprintf "@{<warning>Warning@}: Nothing to promote for %a.@."
-             Path.pp fn
+             Path.Source.pp fn
          in
          These (files, on_missing))
   in

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -35,20 +35,24 @@ let term =
     let open Fiber.O in
     let* setup = Import.Main.setup ~log common in
     let dir = Path.of_string dir in
-    Util.check_path setup.workspace.contexts dir;
+    let checked = Util.check_path setup.workspace.contexts dir in
     let request =
       Build.all (
-        match Path.extract_build_context dir with
-        | Some (ctx, _) ->
-          let sctx = String.Map.find_exn setup.scontexts ctx in
+        match checked with
+        | In_build_dir (ctx, _) ->
+          let sctx = String.Map.find_exn setup.scontexts ctx.name in
           [dump sctx ~dir]
-        | None ->
+        | In_source_dir dir ->
           String.Map.values setup.scontexts
           |> List.map ~f:(fun sctx ->
             let dir =
-              Path.append (Super_context.context sctx).build_dir dir
+              Path.append_source (Super_context.context sctx).build_dir dir
             in
             dump sctx ~dir)
+        | External _ ->
+          die "Environment is not defined for external paths"
+        | In_install_dir _ ->
+          die "Environment is not defined in install dirs"
       )
     in
     Build_system.do_build ~request

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -63,35 +63,49 @@ let target_hint (_setup : Dune.Main.build_system) path =
   hint (Path.to_string path) candidates
 
 let resolve_path path ~(setup : Dune.Main.build_system) =
-  Util.check_path setup.workspace.contexts path;
+  let checked = Util.check_path setup.workspace.contexts path in
   let can't_build path =
     Error (path, target_hint setup path);
   in
-  if not (Path.is_managed path) then
-    Ok [File path]
-  else
-  let src_path =
-    Path.drop_optional_build_context_src_exn path
-  in
-  if Dune.File_tree.dir_exists setup.workspace.conf.file_tree src_path then
-    Ok [ Alias (Alias.in_dir ~name:"default" ~recursive:true
-                  ~contexts:setup.workspace.contexts path) ]
-  else if Path.is_in_build_dir path then begin
-    if Build_system.is_target path then
-      Ok [File path]
+  let as_source_dir src =
+    if Dune.File_tree.dir_exists setup.workspace.conf.file_tree src then
+      Some [ Alias (Alias.in_dir ~name:"default" ~recursive:true
+                      ~contexts:setup.workspace.contexts path) ]
     else
-      can't_build path
-  end else
-    match
-      List.filter_map setup.workspace.contexts ~f:(fun ctx ->
-        let path = Path.append ctx.Context.build_dir path in
-        if Build_system.is_target path then
-          Some (File path)
-        else
-          None)
-    with
-    | [] -> can't_build path
-    | l  -> Ok l
+      None
+  in
+  let build () =
+    begin
+      if Build_system.is_target path then
+        Ok [File path]
+      else
+        can't_build path
+    end
+  in
+  match checked with
+  | External _ ->
+    Ok [File path]
+  | In_source_dir src ->
+    (match as_source_dir src with
+     | Some res -> Ok res
+     | None ->
+       match
+         List.filter_map setup.workspace.contexts ~f:(fun ctx ->
+           let path = Path.append ctx.Context.build_dir path in
+           if Build_system.is_target path then
+             Some (File path)
+           else
+             None)
+       with
+       | [] -> can't_build path
+       | l  -> Ok l)
+  | In_build_dir (_ctx, src) ->
+    (match as_source_dir src with
+     | Some res -> Ok res
+     | None ->
+       build ())
+  | In_install_dir _ ->
+    build ()
 
 let resolve_target common ~(setup : Dune.Main.build_system) s =
   match Alias.of_string common s ~contexts:setup.workspace.contexts with

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -16,7 +16,7 @@ let term =
   let+ common = Common.term in
   Common.set_common common ~targets:[];
   Scheduler.go ~common (fun () ->
-    Dune.Upgrader.upgrade (Dune.File_tree.load Path.root
+    Dune.Upgrader.upgrade (Dune.File_tree.load Path.Source.root
                              ~warn_when_seeing_jbuild_file:false))
 
 let command = term, info

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -8,25 +8,47 @@ let die = Dune.Import.die
 let hint = Dune.Import.hint
 let warn = Dune.Errors.warn
 
+type checked =
+  | In_build_dir of (Context.t * Path.Source.t)
+  | In_install_dir of (Context.t * Path.Source.t)
+  | In_source_dir of Path.Source.t
+  | External of Path.External.t
+
 let check_path contexts =
   let contexts =
-    String.Set.of_list (List.map contexts ~f:(fun c -> c.Context.name))
+    String.Map.of_list_exn (List.map contexts ~f:(fun c -> c.Context.name, c))
   in
   fun path ->
     let internal path =
       die "This path is internal to dune: %s"
         (Path.to_string_maybe_quoted path)
     in
-    if Path.is_in_build_dir path then
-      match Path.extract_build_context path with
-      | None -> internal path
-      | Some (name, _) ->
-        if name = "" || name.[0] = '.' then internal path;
-        if not (name = "install" || String.Set.mem contexts name) then
-          die "%s refers to unknown build context: %s%s"
-            (Path.to_string_maybe_quoted path)
-            name
-            (hint name (String.Set.to_list contexts))
+    let context_exn ctx =
+      match String.Map.find contexts ctx with
+      | Some context -> context
+      | None ->
+        die "%s refers to unknown build context: %s%s"
+          (Path.to_string_maybe_quoted path)
+          ctx
+          (hint ctx (String.Map.keys contexts))
+    in
+    match Path.kind path with
+    | External e -> External e
+    | Local _ ->
+      match Path.as_in_source_tree path with
+      | Some src -> In_source_dir src
+      | None ->
+        match Path.extract_build_context path with
+        | None -> internal path
+        | Some (name, src) ->
+          if name = "" || name.[0] = '.' then internal path;
+          if name = "install" then (
+            match Path.Source.split_first_component src with
+            | None -> internal path
+            | Some (ctx, src) ->
+              In_install_dir (context_exn ctx, Path.Source.of_relative src)
+          )
+          else (In_build_dir (context_exn name, src))
 
 let find_root () =
   let cwd = Sys.getcwd () in

--- a/bin/util.mli
+++ b/bin/util.mli
@@ -1,6 +1,12 @@
 open Stdune
 open Dune
 
-val check_path : Context.t list -> Path.t -> unit
+type checked =
+  | In_build_dir of (Context.t * Path.Source.t)
+  | In_install_dir of (Context.t * Path.Source.t)
+  | In_source_dir of Path.Source.t
+  | External of Path.External.t
+
+val check_path : Context.t list -> Path.t -> checked
 
 val find_root : unit -> string * string list

--- a/src/action_exec.ml
+++ b/src/action_exec.ml
@@ -133,7 +133,7 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to =
       let is_copied_from_source_tree file =
         match Path.drop_build_context file with
         | None -> false
-        | Some file -> Path.exists file
+        | Some file -> Path.exists (Path.source file)
       in
       if is_copied_from_source_tree file1 &&
          not (is_copied_from_source_tree file2) then begin

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -70,7 +70,7 @@ let find_dir_specified_on_command_line ~dir ~file_tree =
   | None ->
     die "From the command line:\n\
          @{<error>Error@}: Don't know about directory %s!"
-      (Path.to_string_maybe_quoted dir)
+      (Path.Source.to_string_maybe_quoted dir)
   | Some dir -> dir
 
 let standard_aliases = Hashtbl.create 7

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -45,7 +45,7 @@ val fmt         : dir:Path.t -> t
 val stamp_file : t -> Path.t
 
 val find_dir_specified_on_command_line
-  :  dir:Path.t
+  :  dir:Path.Source.t
   -> file_tree:File_tree.t
   -> File_tree.Dir.t
 

--- a/src/build.ml
+++ b/src/build.ml
@@ -161,7 +161,7 @@ let memoize name t =
 let source_tree ~dir ~file_tree =
   let prefix_with, dir =
     match Path.extract_build_context_dir dir with
-    | None -> (Path.root, dir)
+    | None -> (Path.root, Option.value_exn (Path.as_in_source_tree dir))
     | Some (ctx_dir, src_dir) -> (ctx_dir, src_dir)
   in
   let paths = File_tree.files_recursively_in file_tree dir ~prefix_with in

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -100,7 +100,7 @@ module Alias : sig
 
   (** Implements [@@alias] on the command line *)
   val dep_multi_contexts
-    :  dir:Path.t
+    :  dir:Path.Source.t
     -> name:string
     -> file_tree:File_tree.t
     -> contexts:string list
@@ -115,7 +115,7 @@ module Alias : sig
 
   (** Implements [@alias] on the command line *)
   val dep_rec_multi_contexts
-    :  dir:Path.t
+    :  dir:Path.Source.t
     -> name:string
     -> file_tree:File_tree.t
     -> contexts:string list
@@ -164,7 +164,7 @@ val is_target : Path.t -> bool
     needed to build this request, by context name *)
 val all_lib_deps
   :  request:(unit, unit) Build.t
-  -> Lib_deps_info.t Path.Map.t String.Map.t Fiber.t
+  -> Lib_deps_info.t Path.Source.Map.t String.Map.t Fiber.t
 
 (** List of all buildable targets *)
 val all_targets : unit -> Path.t list

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -316,7 +316,7 @@ let modules_of_files ~dir ~files =
            \n- %a\
            \n- %a"
         Module.Name.pp name
-        Path.pp src_dir
+        Path.Source.pp src_dir
         Path.pp f1.path
         Path.pp f2.path
   in
@@ -491,11 +491,11 @@ let get0_impl (sctx, dir) : result0 =
             let modules = modules_of_files ~dir ~files in
             Module.Name.Map.union acc modules ~f:(fun name x y ->
               Errors.fail (Loc.in_file
-                             (match File_tree.Dir.dune_file ft_dir with
+                             (Path.source (match File_tree.Dir.dune_file ft_dir with
                               | None ->
-                                Path.relative (File_tree.Dir.path ft_dir)
+                                Path.Source.relative (File_tree.Dir.path ft_dir)
                                   "_unknown_"
-                              | Some d -> File_tree.Dune_file.path d))
+                              | Some d -> File_tree.Dune_file.path d)))
                 "Module %a appears in several directories:\
                  @\n- %a\
                  @\n- %a"
@@ -516,11 +516,11 @@ let get0_impl (sctx, dir) : result0 =
             let f acc sources =
               String.Map.union acc sources ~f:(fun name x y ->
                 Errors.fail (Loc.in_file
-                               (match File_tree.Dir.dune_file ft_dir with
+                               (Path.source (match File_tree.Dir.dune_file ft_dir with
                                 | None ->
-                                  Path.relative (File_tree.Dir.path ft_dir)
+                                  Path.Source.relative (File_tree.Dir.path ft_dir)
                                     "_unknown_"
-                                | Some d -> File_tree.Dune_file.path d))
+                                | Some d -> File_tree.Dune_file.path d)))
                   "%a file %s appears in several directories:\
                    @\n- %a\
                    @\n- %a\

--- a/src/dir_status.ml
+++ b/src/dir_status.ml
@@ -92,7 +92,7 @@ module DB = struct
       let project_root =
         File_tree.Dir.project ft_dir
         |> Dune_project.root
-        |> Path.of_local in
+        |> Path.source in
       match stanzas_in db ~dir with
       | None ->
         if Path.equal dir project_root  then

--- a/src/dir_with_dune.ml
+++ b/src/dir_with_dune.ml
@@ -1,7 +1,7 @@
 open Stdune
 
 type 'data t =
-  { src_dir         : Path.t
+  { src_dir         : Path.Source.t
   ; ctx_dir         : Path.t
   ; data            : 'data
   ; scope           : Scope.t

--- a/src/dir_with_dune.mli
+++ b/src/dir_with_dune.mli
@@ -2,7 +2,7 @@ open Stdune
 
 (** A directory with a [dune] file *)
 type 'data t =
-  { src_dir         : Path.t
+  { src_dir         : Path.Source.t
   ; ctx_dir         : Path.t  (** [_build/context-name/src_dir] *)
   ; data            : 'data
   ; scope           : Scope.t

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -66,7 +66,7 @@ module Pkg = struct
       (List.map packages ~f:(fun pkg ->
          sprintf "- %-*s (because of %s)" longest_pkg
            (Package.Name.to_string pkg.Package.name)
-           (Path.to_string (Package.opam_file pkg))))
+           (Path.Source.to_string (Package.opam_file pkg))))
 
   let default (project : Dune_project.t) stanza =
     match Package.Name.Map.values (Dune_project.packages project) with
@@ -102,8 +102,8 @@ module Pkg = struct
                   add a %S file at the root of your project.\nn\
                  Root of the project as discovered by dune: %s@"
                  name_s (Package.Name.opam_fn name)
-                 (Path.to_string_maybe_quoted
-                    (Dune_project.in_source_root project)))
+                 (Path.Source.to_string_maybe_quoted
+                    (Dune_project.root project)))
       else
         Error (sprintf
                  "The current scope doesn't define package %S.\n\

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -2218,7 +2218,7 @@ module Stanzas = struct
     let parser = parser ~kind project in
     parse parser sexp
 
-  exception Include_loop of Path.t * (Loc.t * Path.t) list
+  exception Include_loop of Path.Source.t * (Loc.t * Path.Source.t) list
 
   let rec parse_file_includes ~stanza_parser ~lexer ~current_file
             ~include_stack sexps =
@@ -2226,15 +2226,15 @@ module Stanzas = struct
     |> List.concat_map ~f:(function
       | Include (loc, fn) ->
         let include_stack = (loc, current_file) :: include_stack in
-        let dir = Path.parent_exn current_file in
-        let current_file = Path.relative dir fn in
-        if not (Path.exists current_file) then
+        let dir = Path.Source.parent_exn current_file in
+        let current_file = Path.Source.relative dir fn in
+        if not (Path.exists (Path.source current_file)) then
           Errors.fail loc "File %s doesn't exist."
-            (Path.to_string_maybe_quoted current_file);
+            (Path.Source.to_string_maybe_quoted current_file);
         if List.exists include_stack
-             ~f:(fun (_, f) -> Path.equal f current_file) then
+             ~f:(fun (_, f) -> Path.Source.equal f current_file) then
           raise (Include_loop (current_file, include_stack));
-        let sexps = Dune_lang.Io.load ~lexer current_file ~mode:Many in
+        let sexps = Dune_lang.Io.load ~lexer (Path.source current_file) ~mode:Many in
         parse_file_includes ~stanza_parser ~lexer
           ~current_file ~include_stack sexps
       | stanza -> [stanza])
@@ -2252,13 +2252,13 @@ module Stanzas = struct
         let loc = fst (Option.value (List.last rest) ~default:last) in
         let line_loc (loc, file) =
           sprintf "%s:%d"
-            (Path.to_string_maybe_quoted file)
+            (Path.Source.to_string_maybe_quoted file)
             loc.Loc.start.pos_lnum
         in
         Errors.fail loc
           "Recursive inclusion of jbuild files detected:\n\
            File %s is included from %s%s"
-          (Path.to_string_maybe_quoted file)
+          (Path.Source.to_string_maybe_quoted file)
           (line_loc last)
           (String.concat ~sep:""
              (List.map rest ~f:(fun x ->

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -480,7 +480,7 @@ module Stanzas : sig
       depreciated jbuilder syntax or the version of dune syntax specified by the
       current [project]. *)
   val parse
-    :  file:Path.t
+    :  file:Path.Source.t
     -> kind:Dune_lang.Syntax.t
     -> Dune_project.t
     -> Dune_lang.Ast.t list

--- a/src/dune_init.ml
+++ b/src/dune_init.ml
@@ -157,7 +157,7 @@ module Init_context = struct
 
   let make path =
     let project =
-      match Dune_project.load ~dir:Path.root ~files:String.Set.empty with
+      match Dune_project.load ~dir:Path.Source.root ~files:String.Set.empty with
       | Some p -> p
       | None   -> Lazy.force Dune_project.anonymous
     in

--- a/src/dune_load.ml
+++ b/src/dune_load.ml
@@ -4,7 +4,7 @@ open Dune_file
 
 module Dune_file = struct
   type t =
-    { dir     : Path.t
+    { dir     : Path.Source.t
     ; project : Dune_project.t
     ; stanzas : Stanzas.t
     ; kind    : Dune_lang.Syntax.t
@@ -30,8 +30,8 @@ end
 
 module Dune_files = struct
   type script =
-    { dir     : Path.t
-    ; file    : Path.t
+    { dir     : Path.Source.t
+    ; file    : Path.Source.t
     ; project : Dune_project.t
     ; kind    : Dune_lang.Syntax.t
     }
@@ -171,12 +171,13 @@ end
     in
     Fiber.parallel_map dynamic ~f:(fun { dir; file; project; kind } ->
       let generated_dune_file =
-        Path.append (Path.relative generated_dune_files_dir context.name) file
+        Path.append_source (Path.relative generated_dune_files_dir context.name) file
       in
       let wrapper = Path.extend_basename generated_dune_file ~suffix:".ml" in
       ensure_parent_dir_exists generated_dune_file;
       let requires =
-        create_plugin_wrapper context ~exec_dir:dir ~plugin:file ~wrapper
+        create_plugin_wrapper context
+          ~exec_dir:(Path.source dir) ~plugin:(Path.source file) ~wrapper
           ~target:generated_dune_file ~kind
       in
       let context = Option.value context.for_host ~default:context in
@@ -202,11 +203,11 @@ end
          ]}
       *)
       let* () =
-        Process.run Strict ~dir ~env:context.env context.ocaml args in
+        Process.run Strict ~dir:(Path.source dir) ~env:context.env context.ocaml args in
       if not (Path.exists generated_dune_file) then
         die "@{<error>Error:@} %s failed to produce a valid dune_file file.\n\
              Did you forgot to call [Jbuild_plugin.V*.send]?"
-          (Path.to_string file);
+          (Path.Source.to_string file);
       Fiber.return
         (Dune_lang.Io.load generated_dune_file ~mode:Many
            ~lexer:(Dune_lang.Lexer.of_syntax kind)
@@ -239,14 +240,16 @@ let interpret ~dir ~project ~ignore_promoted_rules
     Script { dir; project; file; kind = dune_file.kind }
 
 let load ?(ignore_promoted_rules=false) () =
-  let ftree = File_tree.load Path.root in
+  let ftree = File_tree.load Path.Source.root in
   let projects =
     File_tree.fold ftree ~traverse_ignored_dirs:false ~init:[]
       ~f:(fun dir acc ->
         let p = File_tree.Dir.project dir in
-        match Path.kind (File_tree.Dir.path dir) with
-        | Local d when Path.Local.equal d (Dune_project.root p) -> p :: acc
-        | _ -> acc)
+        if Path.Local.equal
+             (Path.Source.to_local (File_tree.Dir.path dir))
+             (Dune_project.root p)
+        then p :: acc
+        else acc)
   in
   let packages =
     List.fold_left projects ~init:Package.Name.Map.empty

--- a/src/dune_load.ml
+++ b/src/dune_load.ml
@@ -245,8 +245,8 @@ let load ?(ignore_promoted_rules=false) () =
     File_tree.fold ftree ~traverse_ignored_dirs:false ~init:[]
       ~f:(fun dir acc ->
         let p = File_tree.Dir.project dir in
-        if Path.Local.equal
-             (Path.Source.to_local (File_tree.Dir.path dir))
+        if Path.Source.equal
+             (File_tree.Dir.path dir)
              (Dune_project.root p)
         then p :: acc
         else acc)
@@ -262,8 +262,8 @@ let load ?(ignore_promoted_rules=false) () =
           | Some a, Some b ->
             die "Too many opam files for package %S:\n- %s\n- %s"
               (Package.Name.to_string name)
-              (Path.to_string_maybe_quoted (Package.opam_file a))
-              (Path.to_string_maybe_quoted (Package.opam_file b))))
+              (Path.Source.to_string_maybe_quoted (Package.opam_file a))
+              (Path.Source.to_string_maybe_quoted (Package.opam_file b))))
   in
 
   let rec walk dir dune_files =

--- a/src/dune_load.mli
+++ b/src/dune_load.mli
@@ -2,7 +2,7 @@ open! Stdune
 
 module Dune_file : sig
   type t =
-    { dir     : Path.t
+    { dir     : Path.Source.t
     ; project : Dune_project.t
     ; stanzas : Dune_file.Stanzas.t
     ; kind    : Dune_lang.Syntax.t

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -43,7 +43,7 @@ type t
 val packages : t -> Package.t Package.Name.Map.t
 val version : t -> string option
 val name : t -> Name.t
-val root : t -> Path.Local.t
+val root : t -> Path.Source.t
 val stanza_parser : t -> Stanza.t list Dune_lang.Decoder.t
 val allow_approx_merlin : t -> bool
 
@@ -51,7 +51,7 @@ val equal : t -> t -> bool
 val hash : t -> int
 
 (** Return the path of the project file. *)
-val file : t -> Path.t
+val file : t -> Path.Source.t
 
 module Lang : sig
   (** [register id stanzas_parser] register a new language. Users will
@@ -92,7 +92,7 @@ end
 
 (** Load a project description from the following directory. [files]
     is the set of files in this directory. *)
-val load : dir:Path.t -> files:String.Set.t -> t option
+val load : dir:Path.Source.t -> files:String.Set.t -> t option
 
 (** Read the [name] file from a dune-project file *)
 val read_name : Path.t -> (Loc.t * string) option
@@ -135,5 +135,3 @@ val implicit_transitive_deps : t -> bool
 val dune_version : t -> Syntax.Version.t
 
 val pp : t Fmt.t
-
-val in_source_root : t -> Path.t

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -116,7 +116,8 @@ module Dir = struct
   let project t = t.project
 
   let file_paths t =
-    Path.Set.of_string_set (files t) ~f:(Path.relative t.path)
+    Path.Set.of_list
+      (List.map (String.Set.to_list (files t)) ~f:(Path.relative t.path))
 
   let sub_dir_names t =
     String.Map.foldi (sub_dirs t) ~init:String.Set.empty
@@ -327,7 +328,8 @@ let files_of t path =
   match find_dir t path with
   | None -> Path.Set.empty
   | Some dir ->
-    Path.Set.of_string_set (Dir.files dir) ~f:(Path.relative path)
+    Path.Set.of_list (
+      List.map (String.Set.to_list (Dir.files dir)) ~f:(Path.relative path))
 
 let file_exists t path fn =
   match find_dir t path with

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -220,7 +220,7 @@ let load ?(warn_when_seeing_jbuild_file=true) path =
       if data_only then
         parent_project
       else
-        Option.value (Dune_project.load ~dir:(Path.source path) ~files)
+        Option.value (Dune_project.load ~dir:path ~files)
           ~default:parent_project
     in
     let contents = lazy (

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -9,7 +9,7 @@ module Dune_file : sig
         they have been parsed, in order to release the memory as soon
         as we don't need them. *)
     type t =
-      { path          : Path.t
+      { path          : Path.Source.t
       ; mutable sexps : Dune_lang.Ast.t list
       }
   end
@@ -17,7 +17,7 @@ module Dune_file : sig
   module Contents : sig
     type t = private
       | Plain of Plain.t
-      | Ocaml_script of Path.t
+      | Ocaml_script of Path.Source.t
   end
 
   type t = private
@@ -25,17 +25,17 @@ module Dune_file : sig
     ; kind     : Dune_lang.Syntax.t
     }
 
-  val path : t -> Path.t
+  val path : t -> Path.Source.t
 end
 
 module Dir : sig
   type t
 
-  val path     : t -> Path.t
+  val path     : t -> Path.Source.t
   val files    : t -> String.Set.t
-  val file_paths    : t -> Path.Set.t
+  val file_paths    : t -> Path.Source.Set.t
   val sub_dirs : t -> t String.Map.t
-  val sub_dir_paths : t -> Path.Set.t
+  val sub_dir_paths : t -> Path.Source.Set.t
   val sub_dir_names : t -> String.Set.t
 
   (** Whether this directory is ignored by an [ignored_subdirs] stanza
@@ -65,7 +65,7 @@ end
     compatibility. *)
 type t
 
-val load : ?warn_when_seeing_jbuild_file:bool -> Path.t -> t
+val load : ?warn_when_seeing_jbuild_file:bool -> Path.Source.t -> t
 
 (** Passing [~traverse_ignored_dirs:true] to this functions causes the
     whole source tree to be deeply scanned, including ignored
@@ -79,20 +79,20 @@ val fold
 
 val root : t -> Dir.t
 
-val find_dir : t -> Path.t -> Dir.t option
+val find_dir : t -> Path.Source.t -> Dir.t option
 
-val files_of : t -> Path.t -> Path.Set.t
+val files_of : t -> Path.Source.t -> Path.Source.Set.t
 
 (** [true] iff the path is either a directory or a file *)
-val exists : t -> Path.t -> bool
+val exists : t -> Path.Source.t -> bool
 
 (** [true] iff the path is a directory *)
-val dir_exists : t -> Path.t -> bool
+val dir_exists : t -> Path.Source.t -> bool
 
 (** [true] iff the path is a file *)
-val file_exists : t -> Path.t -> string -> bool
+val file_exists : t -> Path.Source.t -> string -> bool
 
-val files_recursively_in : t -> ?prefix_with:Path.t -> Path.t -> Path.Set.t
+val files_recursively_in : t -> ?prefix_with:Path.t -> Path.Source.t -> Path.Set.t
 
 (** Load a [jbuild-ignore] file *)
 val load_jbuild_ignore : Path.t -> String.Set.t

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -38,11 +38,11 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
   let resolve_program =
     Super_context.resolve_program ~dir sctx ~loc:(Some loc) in
   let ocamlformat_deps = lazy (
-    depend_on_files ~named:[".ocamlformat"; ".ocamlformat-ignore"] source_dir
+    depend_on_files ~named:[".ocamlformat"; ".ocamlformat-ignore"] (Path.source source_dir)
   ) in
   let setup_formatting file =
     let open Build.O in
-    let input_basename = Path.basename file in
+    let input_basename = Path.Source.basename file in
     let input = Path.relative dir input_basename in
     let output = Path.relative output_dir input_basename in
 
@@ -54,7 +54,7 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
           [ A (flag_of_kind kind)
           ; Dep input
           ; A "--name"
-          ; Path file
+          ; Path (Path.source file)
           ; A "-o"
           ; Target output
           ]
@@ -65,7 +65,7 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
     in
 
     let formatter =
-      match Path.basename file, Path.extension file with
+      match Path.Source.basename file, Path.Source.extension file with
       | _, ".ml" -> ocaml Impl
       | _, ".mli" -> ocaml Intf
       | _, ".re"
@@ -85,7 +85,7 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
       add_diff sctx loc alias_formatted ~dir ~input ~output)
   in
   File_tree.files_of (Super_context.file_tree sctx) source_dir
-  |> Path.Set.iter ~f:setup_formatting;
+  |> Path.Source.Set.iter ~f:setup_formatting;
   Build_system.Alias.add_deps alias_formatted Path.Set.empty
 
 let gen_rules ~dir =

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -118,9 +118,9 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
         let source_dirs =
           let loc = String_with_vars.loc glob in
           let src_glob = Expander.expand_str expander glob in
-          Path.relative src_dir src_glob ~error_loc:loc
-          |> Path.parent_exn
-          |> Path.Set.singleton
+          Path.Source.relative src_dir src_glob ~error_loc:loc
+          |> Path.Source.parent_exn
+          |> Path.Source.Set.singleton
         in
         { For_stanza.
           merlin = Some (Merlin.make ~source_dirs ())
@@ -153,7 +153,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
       ~f:(fun m ->
         let more_src_dirs =
           List.map (Dir_contents.dirs dir_contents) ~f:(fun dc ->
-            Path.drop_optional_build_context (Dir_contents.dir dc))
+            Path.drop_optional_build_context_src_exn (Dir_contents.dir dc))
         in
         Merlin.add_rules sctx ~dir:ctx_dir ~more_src_dirs ~expander ~dir_kind
           (Merlin.add_source_dir m src_dir));

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -59,7 +59,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
   |> Super_context.add_rule sctx ~dir:ctx.build_dir
 
 let version_from_dune_project sctx ~(pkg : Package.t) =
-  let dir = Path.append (Super_context.build_dir sctx) pkg.path in
+  let dir = Path.append_source (Super_context.build_dir sctx) pkg.path in
   let project = Scope.project (Super_context.find_scope_by_dir sctx dir) in
   Dune_project.version project
 

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1617,7 +1617,7 @@ let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects ~dir 
       | None ->
         match Path.drop_build_context info.src_dir with
         | None -> info.src_dir
-        | Some src_dir -> Path.(of_string (to_absolute_filename src_dir))
+        | Some src_dir -> Path.(of_string (to_absolute_filename (Path.source src_dir)))
     )
     else None
   in

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -180,9 +180,9 @@ let lib_stanzas t = t.lib_stanzas
 let mlds t = Lazy.force t.mlds
 
 let package t = t.pkg
-let opam_file t = Path.append t.ctx_build_dir (Package.opam_file t.pkg)
-let meta_file t = Path.append t.ctx_build_dir (Package.meta_file t.pkg)
-let build_dir t = Path.append t.ctx_build_dir t.pkg.path
+let opam_file t = Path.append_source t.ctx_build_dir (Package.opam_file t.pkg)
+let meta_file t = Path.append_source t.ctx_build_dir (Package.meta_file t.pkg)
+let build_dir t = Path.append_source t.ctx_build_dir t.pkg.path
 let name t = t.pkg.name
 let dune_package_file t =
   Path.relative (build_dir t)

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -131,7 +131,7 @@ module Of_sctx = struct
       Super_context.packages sctx
       |> Package.Name.Map.map ~f:(fun (pkg : Package.t) ->
         let odig_files =
-          let files = Super_context.source_files sctx ~src_path:Path.root in
+          let files = Super_context.source_files sctx ~src_path:Path.Source.root in
           String.Set.fold files ~init:[] ~f:(fun fn acc ->
             if is_odig_doc_file fn then
               Path.relative ctx.build_dir fn :: acc

--- a/src/main.ml
+++ b/src/main.ml
@@ -19,7 +19,7 @@ let package_install_file w pkg =
   match Package.Name.Map.find w.conf.packages pkg with
   | None -> Error ()
   | Some p ->
-    Ok (Path.relative p.path
+    Ok (Path.Source.relative p.path
           (Utils.install_file ~package:p.name ~findlib_toolchain:None))
 
 let setup_env ~capture_outputs =

--- a/src/main.mli
+++ b/src/main.mli
@@ -13,7 +13,7 @@ type build_system =
   }
 
 (* Returns [Error ()] if [pkg] is unknown *)
-val package_install_file : workspace -> Package.Name.t -> (Path.t, unit) result
+val package_install_file : workspace -> Package.Name.t -> (Path.Source.t, unit) result
 
 (** Scan the source tree and discover the overall layout of the workspace. *)
 val scan_workspace

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -10,12 +10,12 @@ val make
   -> ?flags:(unit, string list) Build.t
   -> ?preprocess:Dune_file.Preprocess.t
   -> ?libname:Lib_name.Local.t
-  -> ?source_dirs: Path.Set.t
+  -> ?source_dirs: Path.Source.Set.t
   -> ?objs_dirs:Path.Set.t
   -> unit
   -> t
 
-val add_source_dir : t -> Path.t -> t
+val add_source_dir : t -> Path.Source.t -> t
 
 val merge_all : allow_approx_merlin:bool -> t list -> t option
 
@@ -23,7 +23,7 @@ val merge_all : allow_approx_merlin:bool -> t list -> t option
 val add_rules
   : Super_context.t
   -> dir:Path.t
-  -> more_src_dirs:Path.t list
+  -> more_src_dirs:Path.Source.t list
   -> expander:Expander.t
   -> dir_kind:Dune_lang.Syntax.t
   -> t

--- a/src/module.ml
+++ b/src/module.ml
@@ -517,7 +517,7 @@ let ml_source =
           | ".rei" -> ".re.mli"
           | _     ->
             Errors.fail
-              (Loc.in_file (Path.drop_build_context_exn f.path))
+              (Loc.in_file (Path.source (Path.drop_build_context_exn f.path)))
               "Unknown file extension for reason source file: %S"
               ext
         in

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -438,7 +438,7 @@ let setup_pkg_html_rules sctx ~pkg ~libs =
 let setup_package_aliases sctx (pkg : Package.t) =
   let ctx = Super_context.context sctx in
   let alias =
-    let dir = Path.append ctx.build_dir pkg.Package.path in
+    let dir = Path.append_source ctx.build_dir pkg.Package.path in
     Alias.doc ~dir
   in
   Build_system.Alias.add_deps alias (

--- a/src/package.ml
+++ b/src/package.ml
@@ -29,14 +29,14 @@ end
 
 type t =
   { name                   : Name.t
-  ; path                   : Path.t
+  ; path                   : Path.Source.t
   ; version_from_opam_file : string option
   }
 
 let hash { name; path; version_from_opam_file } =
   Hashtbl.hash
     ( Name.hash name
-    , Path.hash path
+    , Path.Source.hash path
     , Option.hash String.hash version_from_opam_file
     )
 
@@ -44,13 +44,13 @@ let to_dyn { name; path; version_from_opam_file } =
   let open Dyn in
   Record
     [ "name", Name.to_dyn name
-    ; "path", Path.to_dyn path
+    ; "path", Path.Source.to_dyn path
     ; "version_from_opam_file"
     , Option (Option.map ~f:(fun s -> String s) version_from_opam_file)
     ]
 
 let pp fmt t = Dyn.pp fmt (to_dyn t)
 
-let opam_file t = Path.relative t.path (Name.opam_fn t.name)
+let opam_file t = Path.Source.relative t.path (Name.opam_fn t.name)
 
-let meta_file t = Path.relative t.path (Name.meta_fn t.name)
+let meta_file t = Path.Source.relative t.path (Name.meta_fn t.name)

--- a/src/package.mli
+++ b/src/package.mli
@@ -20,15 +20,15 @@ end
 
 type t =
   { name                   : Name.t
-  ; path                   : Path.t
+  ; path                   : Path.Source.t
   ; version_from_opam_file : string option
   }
 
 val pp : Format.formatter -> t -> unit
 
-val opam_file : t -> Path.t
+val opam_file : t -> Path.Source.t
 
-val meta_file : t -> Path.t
+val meta_file : t -> Path.Source.t
 
 val to_dyn : t -> Dyn.t
 

--- a/src/print_diff.ml
+++ b/src/print_diff.ml
@@ -10,7 +10,7 @@ let print ?(skip_trailing_cr=Sys.win32) path1 path2 =
       Path.extract_build_context_dir path2
     with
     | Some (dir1, f1), Some (dir2, f2) when Path.equal dir1 dir2 ->
-      (dir1, f1, f2)
+      (dir1, Path.source f1, Path.source f2)
     | _ ->
       (Path.root, path1, path2)
   in

--- a/src/process.ml
+++ b/src/process.ml
@@ -199,10 +199,10 @@ module Fancy = struct
           | Other path ->
             split_paths (Path.to_string path :: targets_acc) ctxs_acc rest
           | Regular (ctx, filename) ->
-            split_paths (Path.to_string filename :: targets_acc)
+            split_paths (Path.Source.to_string filename :: targets_acc)
               (add_ctx ctx ctxs_acc) rest
           | Alias (ctx, name) ->
-            split_paths (("alias " ^ Path.to_string name) :: targets_acc)
+            split_paths (("alias " ^ Path.Source.to_string name) :: targets_acc)
               (add_ctx ctx ctxs_acc) rest
       in
       let targets = Path.Set.to_list targets in

--- a/src/promotion.mli
+++ b/src/promotion.mli
@@ -3,7 +3,7 @@ open! Stdune
 module File : sig
   type t =
     { src : Path.t
-    ; dst : Path.t
+    ; dst : Path.Source.t
     }
 
   (** Register a file to promote *)
@@ -19,6 +19,6 @@ val finalize : unit -> unit
     promoted. *)
 type files_to_promote =
   | All
-  | These of Path.t list * (Path.t -> unit)
+  | These of Path.Source.t list * (Path.Source.t -> unit)
 
 val promote_files_registered_in_last_run : files_to_promote -> unit

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -111,7 +111,7 @@ module DB = struct
       | Ok x -> x
       | Error (_name, project1, project2) ->
         let to_sexp (project : Dune_project.t) =
-          Sexp.Encoder.(pair Dune_project.Name.to_sexp Path.Local.to_sexp)
+          Sexp.Encoder.(pair Dune_project.Name.to_sexp Path.Source.to_sexp)
             (Dune_project.name project, Dune_project.root project)
         in
         Exn.code_error "Scope.DB.create got two projects with the same name"
@@ -131,7 +131,7 @@ module DB = struct
         let db = Lib.DB.create_from_library_stanzas libs
                    ~parent:public_libs ~lib_config in
         let root =
-          Path.append_local build_context_dir (Dune_project.root project) in
+          Path.append_source build_context_dir (Dune_project.root project) in
         Some { project; db; root })
 
   let create ~projects ~context ~installed_libs ~lib_config internal_libs =

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -66,18 +66,18 @@ let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
   let loc = String_with_vars.loc def.glob in
   let glob_in_src =
     let src_glob = Expander.expand_str expander def.glob in
-    Path.relative src_dir src_glob ~error_loc:loc
+    Path.Source.relative src_dir src_glob ~error_loc:loc
   in
   let since = (1, 3) in
   if def.syntax_version < since
-  && not (Path.is_descendant glob_in_src ~of_:src_dir) then
+  && not (Path.Source.is_descendant glob_in_src ~of_:src_dir) then
     Syntax.Error.since loc Stanza.syntax since
       ~what:(sprintf "%s is not a sub-directory of %s. This"
-               (Path.to_string_maybe_quoted glob_in_src)
-               (Path.to_string_maybe_quoted src_dir));
-  let src_in_src = Path.parent_exn glob_in_src in
+               (Path.Source.to_string_maybe_quoted glob_in_src)
+               (Path.Source.to_string_maybe_quoted src_dir));
+  let src_in_src = Path.Source.parent_exn glob_in_src in
   let pred =
-    Path.basename glob_in_src
+    Path.Source.basename glob_in_src
     |> Glob.of_string_exn (String_with_vars.loc def.glob)
     |> Glob.to_pred
   in
@@ -86,9 +86,9 @@ let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
     Errors.fail
       loc
       "cannot find directory: %a"
-      Path.pp src_in_src;
+      Path.Source.pp src_in_src;
   (* add rules *)
-  let src_in_build = Path.append (SC.context sctx).build_dir src_in_src in
+  let src_in_build = Path.append_source (SC.context sctx).build_dir src_in_src in
   let files =
     Build_system.eval_pred (File_selector.create ~dir:src_in_build pred) in
   Path.Set.map files ~f:(fun file_src ->

--- a/src/simple_rules.mli
+++ b/src/simple_rules.mli
@@ -18,7 +18,7 @@ val copy_files
   :  Super_context.t
   -> dir:Path.t
   -> expander:Expander.t
-  -> src_dir:Path.t
+  -> src_dir:Path.Source.t
   -> Copy_files.t
   -> Path.Set.t
 

--- a/src/stdune/interned.ml
+++ b/src/stdune/interned.ml
@@ -11,6 +11,9 @@ module type S = sig
   val all : unit -> t list
   module Set : sig
     include Set.S with type elt = t
+
+    val to_sexp : t -> Sexp.t
+
     val make : string list -> t
 
     val pp : t Fmt.t
@@ -115,6 +118,8 @@ module Make(R : Settings)() = struct
   module Set = struct
     include Set.Make(T)
 
+    let to_sexp t = Sexp.Encoder.(list String.to_sexp) (List.map ~f:to_string (to_list t))
+
     let make l =
       List.fold_left l ~init:empty ~f:(fun acc s -> add acc (make s))
 
@@ -142,6 +147,7 @@ module No_interning(R : Settings)() = struct
     include String.Set
     let make = of_list
     let pp fmt t = Fmt.ocaml_list Format.pp_print_string fmt (to_list t)
+    let to_sexp t = Sexp.Encoder.(list String.to_sexp) (to_list t)
   end
   module Map = String.Map
 

--- a/src/stdune/interned.mli
+++ b/src/stdune/interned.mli
@@ -21,6 +21,8 @@ module type S = sig
   module Set : sig
     include Set.S with type elt = t
 
+    val to_sexp : t -> Sexp.t
+
     val make : string list -> t
 
     val pp : t Fmt.t

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -151,7 +151,6 @@ module Relative : sig
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
-  module Set : Set.S with type elt = t
 
   module Prefix : sig
     type local = t
@@ -1019,10 +1018,6 @@ let pp_debug ppf = function
 module Set = struct
   include Set.Make(T)
   let to_sexp t = Sexp.Encoder.(list to_sexp) (to_list t)
-  let of_string_set ss ~f =
-    String.Set.to_list ss
-    |> List.map ~f
-    |> of_list
 end
 
 let in_source s = in_source_tree (Local.of_string s)

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -68,12 +68,6 @@ include Path_intf.S
 
 val hash : t -> int
 
-module Set : sig
-  include Set.S with type elt = t
-  val to_sexp : t Sexp.Encoder.t
-  val of_string_set : String.Set.t -> f:(string -> elt) -> t
-end
-
 module Map : Map.S with type key = t
 module Table : Hashtbl.S with type key = t
 

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -10,29 +10,13 @@ module Relative : sig
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
+
+  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val split_first_component : t -> (string * t) option
+  val explode : t -> string list
 end
 
 (** In the current workspace (anything under the current project root) *)
-module Source : sig
-  include Path_intf.S
-  val root : t
-
-  val of_string : ?error_loc:Loc0.t -> string -> t
-  module L : sig
-    val relative : ?error_loc:Loc0.t -> t -> string list -> t
-  end
-end
-
-module Build : sig
-  include Path_intf.S
-  val root : t
-
-  val of_string : ?error_loc:Loc0.t -> string -> t
-  module L : sig
-    val relative : ?error_loc:Loc0.t -> t -> string list -> t
-  end
-end
-
 module Local : sig
   include Path_intf.S
   val root : t
@@ -41,6 +25,49 @@ module Local : sig
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
+
+  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val split_first_component : t -> (string * Relative.t) option
+  val explode : t -> string list
+end
+
+(** In the source section of the current workspace. *)
+module Source : sig
+  include Path_intf.S
+  val root : t
+
+  val of_string : ?error_loc:Loc0.t -> string -> t
+  module L : sig
+    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+  end
+
+  val of_relative : Relative.t -> t
+  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val split_first_component : t -> (string * Relative.t) option
+  val explode : t -> string list
+
+  (** [Source.t] does not statically forbid overlap with build directory,
+      even though having such paths is almost always an error. *)
+  val is_in_build_dir : t -> bool
+
+  val to_local : t -> Local.t
+end
+
+module Build : sig
+  include Path_intf.S
+  val root : t
+
+  val append_source : t -> Source.t -> t
+
+  val of_string : ?error_loc:Loc0.t -> string -> t
+  module L : sig
+    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+  end
+
+  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val split_first_component : t -> (string * Relative.t) option
+  val explode : t -> string list
+
 end
 
 (** In the outside world *)
@@ -68,7 +95,6 @@ include Path_intf.S
 
 val hash : t -> int
 
-module Map : Map.S with type key = t
 module Table : Hashtbl.S with type key = t
 
 val of_string : ?error_loc:Loc0.t -> string -> t
@@ -104,6 +130,7 @@ val is_descendant : t -> of_:t -> bool
 val append : t -> t -> t
 val append_relative : t -> Relative.t -> t
 val append_local : t -> Local.t -> t
+val append_source : t -> Source.t -> t
 
 val parent : t -> t option
 val parent_exn : t -> t
@@ -115,9 +142,14 @@ val extend_basename : t -> suffix:string -> t
     {[
       extract_build_context "_build/blah/foo/bar" = Some ("blah", "foo/bar")
     ]}
+
+    It doesn't work correctly (doesn't return a sensible source path) for build
+    directories that are not build contexts, e.g. "_build/install" and "_build/.aliases".
 *)
-val extract_build_context     : t -> (string * t) option
-val extract_build_context_exn : t -> (string * t)
+val extract_build_context     : t -> (string * Source.t) option
+val extract_build_context_exn : t -> (string * Source.t)
+
+val extract_build_dir_first_component     : t -> (string * Relative.t) option
 
 (** Same as [extract_build_context] but return the build context as a path:
 
@@ -125,15 +157,19 @@ val extract_build_context_exn : t -> (string * t)
       extract_build_context "_build/blah/foo/bar" = Some ("_build/blah", "foo/bar")
     ]}
 *)
-val extract_build_context_dir     : t -> (t * t) option
-val extract_build_context_dir_exn : t -> (t * t)
+val extract_build_context_dir     : t -> (t * Source.t) option
+val extract_build_context_dir_exn : t -> (t * Source.t)
 
 (** Drop the "_build/blah" prefix *)
-val drop_build_context : t -> t option
-val drop_build_context_exn : t -> t
+val drop_build_context : t -> Source.t option
+val drop_build_context_exn : t -> Source.t
 
 (** Drop the "_build/blah" prefix if present, return [t] otherwise *)
 val drop_optional_build_context : t -> t
+
+(** Drop the "_build/blah" prefix if present, return [t] if it's a source file,
+    otherwise fail. *)
+val drop_optional_build_context_src_exn : t -> Source.t
 
 (** Transform managed paths so that they are descedant of
     [sandbox_dir]. *)
@@ -150,6 +186,7 @@ val is_in_build_dir : t -> bool
 
 (** [is_in_build_dir t = is_managed t && not (is_in_build_dir t)] *)
 val is_in_source_tree : t -> bool
+val as_in_source_tree : t -> Source.t option
 
 val is_alias_stamp_file : t -> bool
 
@@ -182,6 +219,8 @@ val ensure_build_dir_exists : unit -> unit
 (** set the build directory. Can only be called once and must be done before
     paths are converted to strings elsewhere. *)
 val set_build_dir : Kind.t -> unit
+
+val source : Source.t -> t
 
 (** paths guaranteed to be in the source directory *)
 val in_source : string -> t

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -1,4 +1,38 @@
+(** Relative path with unspecified root *)
+module Relative : sig
+  include Path_intf.S
+
+  (** [root] refers to empty relative path, so whatever the path is interpreted
+      relative to. *)
+  val root : t
+
+  val of_string : ?error_loc:Loc0.t -> string -> t
+  module L : sig
+    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+  end
+end
+
 (** In the current workspace (anything under the current project root) *)
+module Source : sig
+  include Path_intf.S
+  val root : t
+
+  val of_string : ?error_loc:Loc0.t -> string -> t
+  module L : sig
+    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+  end
+end
+
+module Build : sig
+  include Path_intf.S
+  val root : t
+
+  val of_string : ?error_loc:Loc0.t -> string -> t
+  module L : sig
+    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+  end
+end
+
 module Local : sig
   include Path_intf.S
   val root : t
@@ -74,6 +108,7 @@ val descendant : t -> of_:t -> t option
 val is_descendant : t -> of_:t -> bool
 
 val append : t -> t -> t
+val append_relative : t -> Relative.t -> t
 val append_local : t -> Local.t -> t
 
 val parent : t -> t option
@@ -177,6 +212,6 @@ end
     this returns the path itself.
     For external paths, it returns a path that is relative to the current
     directory. For example, the local part of [/a/b] is [./a/b]. *)
-val local_part : t -> Local.t
+val local_part : t -> Relative.t
 
 val stat : t -> Unix.stats

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -1,6 +1,8 @@
 module type S = sig
   type t
 
+  val hash : t -> int
+
   val to_string : t -> string
   val of_string : string -> t
 

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -24,4 +24,10 @@ module type S = sig
   val basename : t -> string
   val extend_basename : t -> suffix:string -> t
   val is_suffix : t -> suffix:string -> bool
+
+  module Set : sig
+    include Set.S with type elt = t
+    val to_sexp : t Sexp.Encoder.t
+  end
+
 end

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -30,4 +30,14 @@ module type S = sig
     val to_sexp : t Sexp.Encoder.t
   end
 
+  module Map :  Map.S with type key = t
+
+  val relative : ?error_loc:Loc0.t -> t -> string -> t
+
+  val to_string_maybe_quoted : t -> string
+
+  val is_descendant : t -> of_:t -> bool
+
+  val is_root : t -> bool
+  val parent_exn : t -> t
 end

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -134,7 +134,7 @@ end = struct
     | None -> artifacts t ~dir
     | Some host ->
       let dir =
-        Path.append host.context.build_dir (Path.drop_build_context_exn dir) in
+        Path.append_source host.context.build_dir (Path.drop_build_context_exn dir) in
       artifacts host ~dir
 
   let expander t ~dir =
@@ -289,7 +289,7 @@ let create
   let internal_libs =
     List.concat_map stanzas
       ~f:(fun { Dune_load.Dune_file. dir; stanzas; project = _ ; kind = _ } ->
-        let ctx_dir = Path.append context.build_dir dir in
+        let ctx_dir = Path.append_source context.build_dir dir in
         List.filter_map stanzas ~f:(fun stanza ->
           match (stanza : Stanza.t) with
           | Dune_file.Library lib -> Some (ctx_dir, lib)
@@ -307,7 +307,7 @@ let create
   let stanzas =
     List.map stanzas
       ~f:(fun { Dune_load.Dune_file. dir; project; stanzas; kind } ->
-        let ctx_dir = Path.append context.build_dir dir in
+        let ctx_dir = Path.append_source context.build_dir dir in
         let dune_version = Dune_project.dune_version project in
         { Dir_with_dune.
           src_dir = dir
@@ -528,7 +528,7 @@ module Action = struct
       fun exe ->
         match Path.extract_build_context_dir exe with
         | Some (dir, exe) when Path.equal dir sctx.context.build_dir ->
-          Path.append host.context.build_dir exe
+          Path.append_source host.context.build_dir exe
         | _ -> exe
 
   let run sctx ~loc ~expander ~dep_kind ~targets:targets_written_by_user

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -199,7 +199,7 @@ module Pkg_version = struct
   open Build.O
 
   let file sctx (p : Package.t) =
-    Path.relative (Path.append sctx.context.build_dir p.path)
+    Path.relative (Path.append_source sctx.context.build_dir p.path)
       (sprintf "%s.version.sexp" (Package.Name.to_string p.name))
 
   let read_file fn =

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -107,7 +107,7 @@ val add_alias_action
   -> (unit, Action.t) Build.t
   -> unit
 
-val source_files : t -> src_path:Path.t -> String.Set.t
+val source_files : t -> src_path:Path.Source.t -> String.Set.t
 
 (** [prog_spec t ?hint name] resolve a program. [name] is looked up in the
     workspace, if it is not found in the tree is is looked up in the PATH. If it

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -45,8 +45,8 @@ type rename_and_edit =
 
 type todo =
   { mutable to_rename_and_edit : rename_and_edit list
-  ; mutable to_add : Path.t list
-  ; mutable to_edit : (Path.t * string) list
+  ; mutable to_add : Path.Source.t list
+  ; mutable to_edit : (Path.Source.t * string) list
   }
 
 let rename_basename base =
@@ -249,10 +249,10 @@ let rec end_offset_of_opam_value : OpamParserTypes.value -> int =
 
 let upgrade_opam_file todo fn =
   let open OpamParserTypes in
-  let s = Io.read_file fn ~binary:true in
+  let s = Io.read_file (Path.source fn) ~binary:true in
   let lb = Lexing.from_string s in
   lb.lex_curr_p <-
-    { pos_fname = Path.to_string fn
+    { pos_fname = Path.Source.to_string fn
     ; pos_lnum  = 1
     ; pos_bol   = 0
     ; pos_cnum  = 0
@@ -337,15 +337,15 @@ let upgrade_opam_file todo fn =
 
 let upgrade_dir todo dir =
   let project = File_tree.Dir.project dir in
-  let project_root = Path.of_local (Dune_project.root project) in
-  if project_root = Path.source (File_tree.Dir.path dir) then begin
+  let project_root = Dune_project.root project in
+  if project_root = File_tree.Dir.path dir then begin
     (match Dune_project.ensure_project_file_exists project with
      | Already_exist -> ()
      | Created ->
        todo.to_add <- Dune_project.file project :: todo.to_add);
     Package.Name.Map.iter (Dune_project.packages project) ~f:(fun pkg ->
       let fn = Package.opam_file pkg in
-      if Path.exists fn then upgrade_opam_file todo fn)
+      if Path.exists (Path.source fn) then upgrade_opam_file todo fn)
   end;
   Option.iter (File_tree.Dir.dune_file dir) ~f:(fun dune_file ->
     match dune_file.kind, dune_file.contents with
@@ -395,17 +395,17 @@ let upgrade ft =
     Printf.ksprintf print_to_console fmt
   in
   let* () =
-  Fiber.map_all_unit todo.to_add ~f:(fun fn ->
-    match has_git (Path.parent_exn fn) with
-    | Some dir ->
-      Process.run Strict ~dir ~env:Env.initial
-        (Lazy.force git)
-        ["add"; Path.reach fn ~from:dir]
-    | None -> Fiber.return ())
+    Fiber.map_all_unit todo.to_add ~f:(fun fn ->
+      match has_git (Path.source (Path.Source.parent_exn fn)) with
+      | Some dir ->
+        Process.run Strict ~dir ~env:Env.initial
+          (Lazy.force git)
+          ["add"; Path.reach (Path.source fn) ~from:dir]
+      | None -> Fiber.return ())
   in
   List.iter todo.to_edit ~f:(fun (fn, s) ->
-    log "Upgrading %s...\n" (Path.to_string_maybe_quoted fn);
-    Io.write_file fn s ~binary:true);
+    log "Upgrading %s...\n" (Path.Source.to_string_maybe_quoted fn);
+    Io.write_file (Path.source fn) s ~binary:true);
   Fiber.map_all_unit todo.to_rename_and_edit ~f:(fun x ->
     let { original_file
         ; new_file

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -338,7 +338,7 @@ let upgrade_opam_file todo fn =
 let upgrade_dir todo dir =
   let project = File_tree.Dir.project dir in
   let project_root = Path.of_local (Dune_project.root project) in
-  if project_root = File_tree.Dir.path dir then begin
+  if project_root = Path.source (File_tree.Dir.path dir) then begin
     (match Dune_project.ensure_project_file_exists project with
      | Already_exist -> ()
      | Created ->
@@ -351,14 +351,14 @@ let upgrade_dir todo dir =
     match dune_file.kind, dune_file.contents with
     | Dune, _ -> ()
     | Jbuild, Ocaml_script fn ->
-      Errors.warn (Loc.in_file fn)
+      Errors.warn (Loc.in_file (Path.source fn))
         "Cannot upgrade this jbuild file as it is using the OCaml syntax.\n\
          You need to upgrade it manually."
     | Jbuild, Plain { path; sexps = _ } ->
-      let files = scan_included_files path in
+      let files = scan_included_files (Path.source path) in
       Path.Map.iteri files ~f:(fun fn (sexps, comments) ->
         upgrade_file todo fn sexps comments
-          ~look_for_jbuild_ignore:(fn = path)))
+          ~look_for_jbuild_ignore:(fn = Path.source path)))
 
 let upgrade ft =
   Dune_project.default_dune_language_version := (1, 0);

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -66,30 +66,32 @@ let signal_name =
     | Some s -> s
 
 type target_kind =
-  | Regular of string * Path.t
-  | Alias   of string * Path.t
+  | Regular of string * Path.Source.t
+  | Alias   of string * Path.Source.t
   | Other of Path.t
 
 let analyse_target (fn as original_fn) =
-  match Path.extract_build_context fn with
+  match Path.extract_build_dir_first_component fn with
   | Some (".aliases", sub) -> begin
-      match Path.split_first_component sub with
+      match Path.Relative.split_first_component sub with
       | None -> Other fn
       | Some (ctx, fn) ->
-        if Path.is_root fn then
+        if Path.Relative.is_root fn then
           Other original_fn
         else
           let basename =
-            match String.rsplit2 (Path.basename fn) ~on:'-' with
+            match String.rsplit2 (Path.Relative.basename fn) ~on:'-' with
             | None -> assert false
             | Some (name, digest) ->
               assert (String.length digest = 32);
               name
           in
-          Alias (ctx, Path.relative (Path.parent_exn fn) basename)
+          Alias (ctx,
+                 Path.Source.of_relative
+                   (Path.Relative.relative (Path.Relative.parent_exn fn) basename))
     end
   | Some ("install", _) -> Other fn
-  | Some (ctx, sub) -> Regular (ctx, sub)
+  | Some (ctx, sub) -> Regular (ctx, Path.Source.of_relative sub)
   | None ->
     Other fn
 
@@ -100,9 +102,9 @@ let describe_target fn =
   in
   match analyse_target fn with
   | Alias (ctx, p) ->
-    sprintf "alias %s%s" (Path.to_string_maybe_quoted p) (ctx_suffix ctx)
+    sprintf "alias %s%s" (Path.Source.to_string_maybe_quoted p) (ctx_suffix ctx)
   | Regular (ctx, fn) ->
-    sprintf "%s%s" (Path.to_string_maybe_quoted fn) (ctx_suffix ctx)
+    sprintf "%s%s" (Path.Source.to_string_maybe_quoted fn) (ctx_suffix ctx)
   | Other fn ->
     Path.to_string_maybe_quoted fn
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -70,14 +70,14 @@ type target_kind =
   | Alias   of string * Path.t
   | Other of Path.t
 
-let analyse_target fn =
+let analyse_target (fn as original_fn) =
   match Path.extract_build_context fn with
   | Some (".aliases", sub) -> begin
       match Path.split_first_component sub with
       | None -> Other fn
       | Some (ctx, fn) ->
         if Path.is_root fn then
-          Other fn
+          Other original_fn
         else
           let basename =
             match String.rsplit2 (Path.basename fn) ~on:'-' with

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -38,8 +38,8 @@ val executable_object_directory
   -> Path.t
 
 type target_kind =
-  | Regular of string (* build context *) * Path.t
-  | Alias   of string (* build context *) * Path.t
+  | Regular of string (* build context *) * Path.Source.t
+  | Alias   of string (* build context *) * Path.Source.t
   | Other of Path.t
 
 (** Return the name of an alias from its stamp file *)

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -29,7 +29,7 @@ let libs_under_dir sctx ~db ~dir =
    File_tree.Dir.fold dir ~traverse_ignored_dirs:true
      ~init:[] ~f:(fun dir acc ->
        let dir =
-         Path.append (Super_context.build_dir sctx) (File_tree.Dir.path dir) in
+         Path.append_source (Super_context.build_dir sctx) (File_tree.Dir.path dir) in
        match Super_context.stanzas_in sctx ~dir with
        | None -> acc
        | Some (d : _ Dir_with_dune.t) ->

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -360,15 +360,15 @@ Path.relative (r "foo") "../_build"
 
 Path.local_part (Path.of_string "/c/d")
 [%%expect{|
-- : Path.Local.t = c/d
+- : Path.Relative.t = <abstr>
 |}]
 
 Path.local_part (Path.insert_after_build_dir_exn Path.build_dir "c/d")
 [%%expect{|
-- : Path.Local.t = c/d
+- : Path.Relative.t = <abstr>
 |}]
 
 Path.local_part (r "c/d")
 [%%expect{|
-- : Path.Local.t = c/d
+- : Path.Relative.t = <abstr>
 |}]

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -297,22 +297,22 @@ Code_error
 
 Path.drop_build_context (Path.relative Path.build_dir "foo/bar")
 [%%expect{|
-- : Path.t option = Some (In_source_tree "bar")
+- : Path.Source.t option = Some <abstr>
 |}]
 
 Path.drop_build_context (Path.of_string "foo/bar")
 [%%expect{|
-- : Path.t option = None
+- : Path.Source.t option = None
 |}]
 
 Path.drop_build_context (e "/foo/bar")
 [%%expect{|
-- : Path.t option = None
+- : Path.Source.t option = None
 |}]
 
 Path.drop_build_context Path.build_dir
 [%%expect{|
-- : Path.t option = None
+- : Path.Source.t option = None
 |}]
 
 Path.is_in_build_dir Path.build_dir


### PR DESCRIPTION
Introduce finer distinction between various Path types to make interfaces between various parts of Dune clearer.

In particular, introduce:
* `Path.Source.t`: paths in the source tree
* `Path.Build.t`: paths in the build directory
* `Path.Relative.t`: relative paths with no specific root

The idea is to use these to eliminate some of the common operations with implicit invariants, such as `Path.append`.

This PR also begins switching code to use `Path.Source.t` where appropriate as a first step.