### PR TITLE
Allow variables in pps flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@ unreleased
   to produce targets that are present in the source tree. This has
   been a warning for long enough (#2068, @diml)
 
+- Allow %{...} variables in pps flags (#2076, @mlasson review by @diml and
+  @aalekseyev).
+
 - Add more opam metadata and use it to generate corrections to the .opam files
   in the source. This allows the user to partially specify opam metadata in the
   the dune-project file. (#2017, @avsm, @jonludlam)

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -7,7 +7,7 @@ module Preprocess : sig
   type pps =
     { loc   : Loc.t
     ; pps   : (Loc.t * Lib_name.t) list
-    ; flags : string list
+    ; flags : String_with_vars.t list
     ; staged : bool
     }
 

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -41,6 +41,8 @@ module Template : sig
     ; loc: Loc.t
     }
 
+  val compare_no_loc: t -> t -> Ordering.t
+
   val string_of_var : var -> string
 
   val to_string : t -> syntax:File_syntax.t -> string

--- a/src/dune_lang/template.ml
+++ b/src/dune_lang/template.ml
@@ -2,6 +2,36 @@ open! Stdune
 
 include Types.Template
 
+let compare_var_syntax x y =
+  match x, y with
+  | Percent, Percent
+  | Dollar_brace, Dollar_brace
+  | Dollar_paren, Dollar_paren -> Ordering.Eq
+  | Percent, (Dollar_brace | Dollar_paren) -> Ordering.Lt
+  | (Dollar_brace | Dollar_paren), Percent -> Ordering.Gt
+  | Dollar_brace, Dollar_paren -> Ordering.Lt
+  | Dollar_paren, Dollar_brace -> Ordering.Gt
+
+let compare_var_no_loc v1 v2 =
+   match String.compare v1.name v2.name with
+   | Ordering.Lt | Gt as a -> a
+   | Eq ->
+       match Option.compare String.compare v1.payload v2.payload with
+       | Ordering.Lt | Gt as a -> a
+       | Eq -> compare_var_syntax v1.syntax v2.syntax
+
+let compare_part p1 p2 =
+   match p1, p2 with
+   | Text s1, Text s2 -> String.compare s1 s2
+   | Var v1, Var v2 -> compare_var_no_loc v1 v2
+   | Text _, Var _ -> Ordering.Lt
+   | Var _, Text _ -> Ordering.Gt
+
+let compare_no_loc t1 t2 =
+  match List.compare ~compare:compare_part t1.parts t2.parts with
+  | Ordering.Lt | Gt as a -> a
+  | Eq -> Bool.compare t1.quoted t2.quoted
+
 let var_enclosers = function
   | Percent      -> "%{", "}"
   | Dollar_brace -> "${", "}"

--- a/src/dune_lang/template.mli
+++ b/src/dune_lang/template.mli
@@ -23,6 +23,7 @@ type t = Types.Template.t =
   }
 
 val to_string : t -> syntax:File_syntax.t -> string
+val compare_no_loc : t -> t -> Ordering.t
 val string_of_var : var -> string
 
 val pp : File_syntax.t -> Format.formatter -> t -> unit

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -38,7 +38,7 @@ module Preprocess = struct
     | Pps { loc ; pps = pps1; flags = flags1; staged = s1 },
       Pps { loc = _; pps = pps2; flags = flags2; staged = s2 } ->
       if Bool.(<>) s1 s2
-      || List.compare flags1 flags2 ~compare:String.compare <> Eq
+      || List.compare flags1 flags2 ~compare:String_with_vars.compare_no_loc <> Eq
       || List.compare pps1 pps2 ~compare:(fun (_, x) (_, y) ->
         Lib_name.compare x y) <> Eq
       then
@@ -130,6 +130,7 @@ let pp_flags sctx ~expander ~dir_kind { preprocess; libname; _ } =
     match Preprocessing.get_ppx_driver sctx ~scope ~dir_kind pps with
     | Error _ -> None
     | Ok exe ->
+      let flags = List.map ~f:(Expander.expand_str expander) flags in
       (Path.to_absolute_filename exe
        :: "--as-ppx"
        :: Preprocessing.cookie_library_name libname

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -584,6 +584,7 @@ let lint_module sctx ~dir ~expander ~dep_kind ~lint ~lib_name ~scope ~dir_kind =
           if staged then
             Errors.fail loc
               "Staged ppx rewriters cannot be used as linters.";
+          let flags = List.map ~f:(Expander.expand_str expander) flags in
           let args : _ Arg_spec.t =
             S [ As flags
               ; As (cookie_library_name lib_name)
@@ -659,6 +660,7 @@ let make sctx ~dir ~expander ~dep_kind ~lint ~preprocess
          if lint then lint_module ~ast ~source:m;
          ast)
     | Pps { loc; pps; flags; staged } ->
+      let flags = List.map ~f:(Expander.expand_str expander) flags in
       if not staged then begin
         let args : _ Arg_spec.t =
           S [ As flags

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -8,6 +8,11 @@ type t =
   ; syntax_version : Syntax.Version.t
   }
 
+let compare_no_loc t1 t2 =
+  match Syntax.Version.compare t1.syntax_version t2.syntax_version with
+  | Ordering.Lt | Gt as a -> a
+  | Eq -> Dune_lang.Template.compare_no_loc t1.template t2.template
+
 let make_syntax = (1, 0)
 
 let make ?(quoted=false) loc part =
@@ -307,6 +312,13 @@ let text_only t =
   match t.template.parts with
   | [Text s] -> Some s
   | _ -> None
+
+let known_prefix =
+  let rec go acc = function
+    | Text s :: rest -> go (s :: acc) rest
+    | _ -> String.concat ~sep:"" (List.rev acc)
+  in
+  fun t -> go [] t.template.parts
 
 let has_vars t = Option.is_none (text_only t)
 

--- a/src/string_with_vars.mli
+++ b/src/string_with_vars.mli
@@ -9,6 +9,8 @@ open Import
 type t
 (** A sequence of text and variables. *)
 
+val compare_no_loc: t -> t -> Ordering.t
+
 val loc : t -> Loc.t
 (** [loc t] returns the location of [t] — typically, in the jbuild file. *)
 
@@ -34,6 +36,8 @@ val has_vars : t -> bool
 
 (** If [t] contains no variable, returns the contents of [t]. *)
 val text_only : t -> string option
+
+val known_prefix : t -> string
 
 module Mode : sig
   type _ t =

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/driver-tests/dune
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/driver-tests/dune
@@ -82,7 +82,11 @@
 
 (rule (with-stdout-to test_ppx_staged.ml (echo "")))
 
+(env (_ (env-vars (FOO baz))))
+
 (library
  (name test_ppx_staged)
  (modules test_ppx_staged)
- (preprocess (staged_pps -arg1 driver_print_tool -arg2 -- -foo bar)))
+ (preprocess 
+  (staged_pps -arg1 driver_print_tool -arg2 -arg3=%{env:FOO=undefined} --
+    -foo bar %{env:FOO=undefined})))

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/driver-tests/dune-project
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/driver-tests/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.9)
+(lang dune 1.10)
 
 (allow_approximate_merlin)

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -79,10 +79,10 @@ Test that going throught the -ppx option of the compiler works
   Entering directory 'driver-tests'
       ocamldep .test_ppx_staged.objs/test_ppx_staged.ml.d
   tool name: ocamldep
-  args:--as-ppx -arg1 -arg2 -foo bar --cookie library-name="test_ppx_staged"
+  args:--as-ppx -arg1 -arg2 -arg3=baz -foo bar baz --cookie library-name="test_ppx_staged"
         ocamlc .test_ppx_staged.objs/byte/test_ppx_staged.{cmi,cmo,cmt}
   tool name: ocamlc
-  args:--as-ppx -arg1 -arg2 -foo bar --cookie library-name="test_ppx_staged"
+  args:--as-ppx -arg1 -arg2 -arg3=baz -foo bar baz --cookie library-name="test_ppx_staged"
 
 Test using installed drivers
 


### PR DESCRIPTION
This PR propose to add support for variables in the flags of the "pps" (and "pps_staged") kind of preprocessing. 

The use-case I have in mind would be to pass "%{profile}" to the preprocessor which would allow it to generate a different code depending on the profile. This would be useful for preprocessors that implement code instrumentation (eg. [bisect](https://github.com/aantron/bisect_ppx), or [landmarks](https://github.com/LexiFi/landmarks)): they could implement the "identity preprocessor" when profile is "release" (also they could use the profile name as a scoping mechanism).  

Here is an example: 
```
(executable
  (name test)
  (preprocess (pps landmarks.ppx -- --profile "%{profile}"))
)
```

I made this PR to experiment with a profile-based workflow for landmarks and maybe to see if others think it sounds like a good idea. So, do not hesitate to comment or to close the PR if it happens to be a bad idea. 







