### PR TITLE
do not hard code cmo/cmx/cmi extensions everywhere

### DIFF
--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -3,14 +3,15 @@ open Stdune
 let dev_files =
   let id = lazy (
     let open Sexp.Encoder in
-    constr "dev_files" [string ".cmt"; string ".cmti"; string ".cmi"]
+    constr "dev_files"
+      [string ".cmt"; string ".cmti"; string (Cm_kind.ext Cmi)]
   ) in
+  let cmi = Cm_kind.ext Cmi in
   Predicate.create ~id ~f:(fun p ->
     match Filename.extension p with
     | ".cmt"
-    | ".cmti"
-    | ".cmi" -> true
-    | _ -> false)
+    | ".cmti" -> true
+    | ext -> ext = cmi)
 
 let add_obj_dir sctx ~obj_dir =
   if (Super_context.context sctx).merlin then

--- a/src/lib_file_deps.ml
+++ b/src/lib_file_deps.ml
@@ -8,9 +8,9 @@ module Group = struct
 
   let all = [Cmi; Cmx; Header]
 
-  let to_string = function
-    | Cmi -> ".cmi"
-    | Cmx -> ".cmx"
+  let ext = function
+    | Cmi -> Cm_kind.ext Cmi
+    | Cmx -> Cm_kind.ext Cmx
     | Header -> ".h"
 
   let obj_dir t obj_dir =
@@ -21,7 +21,7 @@ module Group = struct
 
   let to_predicate =
     let preds = List.map all ~f:(fun g ->
-      let ext = to_string g in
+      let ext = ext g in
       (* we cannot use globs because of bootstrapping. *)
       let id = lazy (
         let open Sexp.Encoder in

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -127,10 +127,10 @@ let of_library_stanza ~dir
       let obj_name = Path.relative dir (Module.Name.uncapitalize m) in
       { Mode.Dict.
         byte =
-          Path.extend_basename obj_name ~suffix:".cmo" ::
+          Path.extend_basename obj_name ~suffix:(Cm_kind.ext Cmo) ::
           foreign_archives.byte
       ; native =
-          Path.extend_basename obj_name ~suffix:".cmx" ::
+          Path.extend_basename obj_name ~suffix:(Cm_kind.ext Cmx) ::
           Path.extend_basename obj_name ~suffix:ext_obj ::
           foreign_archives.native
       }

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -346,8 +346,8 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
           | Some m ->
             (* These files needs to be alongside stdlib.cma as the
                compiler implicitly adds this module. *)
-            [ Cm_kind.Cmx, ".cmx"
-            ; Cmo, ".cmo"
+            [ Cm_kind.Cmx, (Cm_kind.ext Cmx)
+            ; Cmo, (Cm_kind.ext Cmo)
             ; Cmx, ctx.ext_obj ]
             |> List.iter ~f:(fun (kind, ext) ->
               let src = Module.obj_file m ~kind ~ext in

--- a/src/mode.ml
+++ b/src/mode.ml
@@ -26,7 +26,7 @@ let choose byte native = function
   | Byte   -> byte
   | Native -> native
 
-let compiled_unit_ext = choose ".cmo" ".cmx"
+let compiled_unit_ext = choose (Cm_kind.ext Cmo) (Cm_kind.ext Cmx)
 let compiled_lib_ext = choose ".cma" ".cmxa"
 let plugin_ext = choose ".cma" ".cmxs"
 


### PR DESCRIPTION
this makes it easier to experiment with alternative extensions such as for bucklescript