### PR TITLE
[coq] Deprecate public_name field in favor of package.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
   performance when a target has a large number of dependencies (#2959,
   @ejgallego, @aalekseyev, @Armael)
 
+- [coq] Add `(boot)` option to `(coq.theories)` to enable bootstrap of
+  Coq's stdlib (#3096, @ejgallego)
+
+- [coq] Deprecate `public_name` field in favour of `package` (#2087, @ejgallego)
+
 2.2.0 (06/02/2020)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1506,32 +1506,54 @@ This will enable support for the ``coq.theory`` stanza in the current project. I
 language version is absent, dune will automatically add this line with the
 latest Coq version to the project file once a ``(coq.theory ...)`` stanza is used anywhere.
 
+The only version supported is ``0.1`` and it doesn't provide any kind
+of guarantees with respect to stability, however, as implementation of
+features progresses, we hope to bump ``0.1`` to ``1.0`` soon. The 1.0
+version will commit to a stable set of functionality; features marked
+``1.0`` below are expected to reach 1.0 unchanged.
+
 The basic form for defining Coq libraries is very similar to the OCaml form:
 
 .. code:: scheme
 
     (coq.theory
      (name <module_prefix>)
-     (public_name <package.lib_name>)
+     (package <package>)
      (synopsis <text>)
      (modules <ordered_set_lang>)
      (libraries <ocaml_libraries>)
      (flags <coq_flags>))
 
-The stanza will build all `.v` files on the given directory. The semantics of fields is:
+The stanza will build all ``.v`` files on the given directory. The semantics of fields is:
 
-- ``<module_prefix>`` will be used as the default Coq library prefix ``-R``,
+- ``<module_prefix>`` is a dot-separated list of valid Coq module
+  names and determines the module scope under which the theory is
+  compiled [``-R`` option]. For example, if ``<module_prefix>`` is
+  ``foo.Bar``, the theory modules will be named as
+  ``foo.Bar.module1``, ``foo.Bar.module2``, etc... Note that modules
+  in the same theory don't see the ``foo.Bar`` prefix, in the same
+  way that OCaml ``wrapped`` libraries do. For compatibility reasons,
+  the 1.0 version of the Coq language installs a theory named
+  ``foo.Bar`` under ``foo/Bar``. Also note that Coq supports composing
+  a module path from different theories, thus you can name a theory
+  ``foo.Bar`` and a second one ``foo.Baz`` and things will work
+  properly,
 - the ``modules`` field enables constraining the set of modules
-  included in the library, similarly to its OCaml counterpart,
-- ``public_name`` will make Dune generate install rules for the `.vo`
-  files; files will be installed in
-  ``lib/coq/user-contrib/<module_prefix>``, as customary in the
-  make-based Coq package eco-system. For compatibility, we also install the `.cmxs`
-  files appearing in `<ocaml-libraries>` under the `user-contrib` prefix.
-- ``<coq_flags>`` will be passed to ``coqc``,
-- the path to install locations of ``<ocaml_libraries>`` will be passed to
-  ``coqdep`` and ``coqc`` using Coq's ``-I`` flag; this allows a Coq
-  library to depend on an ML plugin.
+  included in the theory, similarly to its OCaml counterpart. Modules
+  are specified in Coq notation, that is to say ``A/b.v`` is written
+  ``A.b`` in this field,
+- if ``package``is present, Dune will generate install rules for the
+  ``.vo`` files on the theory. ``pkg_name`` must be a valid package
+  name. Note that the 1.0 version of the language uses the Coq legacy
+  install setup, where all packages share a common root namespace and
+  install directory, ``lib/coq/user-contrib/<module_prefix>``, as
+  customary in the make-based Coq package ecosystem. For
+  compatibility, we also install under the ``user-contrib`` prefix the
+  ``.cmxs`` files appearing in ``<ocaml_libraries>``,
+- ``<coq_flags>`` will be passed to ``coqc`` as command-line options,
+- the path to installed locations of ``<ocaml_libraries>`` will be passed to
+  ``coqdep`` and ``coqc`` using Coq's ``-I`` flag; this allows for a Coq
+  theory to depend on a ML plugin,
 
 Recursive qualification of modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/dune/coq_lib_name.ml
+++ b/src/dune/coq_lib_name.ml
@@ -1,0 +1,29 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(* (c) INRIA 2020                              *)
+(*     Written by: Emilio Jesús Gallego Arias  *)
+
+open! Stdune
+(* Coq Directoy Path *)
+type t = string list
+
+let to_string x = String.concat ~sep:"." x
+let wrapper x = to_string x
+
+let decode : (Loc.t * t) Dune_lang.Decoder.t =
+  Dune_lang.Decoder.plain_string (fun ~loc s ->
+    (loc, String.split ~on:'.' s))
+
+let encode : t Dune_lang.Encoder.t =
+  fun lib -> Dune_lang.Encoder.string (to_string lib)
+
+(* let pp x = Pp.text (to_string x) *)
+let to_dyn = Dyn.Encoder.(list string)
+
+module Rep = struct
+  type nonrec t = t
+  let compare = List.compare ~compare:String.compare
+  let to_dyn = to_dyn
+end
+
+module Map = Map.Make(Rep)

--- a/src/dune/coq_lib_name.mli
+++ b/src/dune/coq_lib_name.mli
@@ -1,0 +1,22 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(*     Written by: Emilio Jesús Gallego Arias  *)
+
+open! Stdune
+
+(* This is in its own file due to dependency issues *)
+
+(** A Coq library name is a dot-separated list of Coq module
+    identifiers. *)
+type t
+
+val wrapper : t -> string
+
+val encode : t Dune_lang.Encoder.t
+val decode : (Loc.t * t) Dune_lang.Decoder.t
+
+(* to be removed in favor of encode / decode *)
+(* val _pp : t -> Pp.t *)
+val to_dyn : t -> Dyn.t
+
+module Map : Map.S with type key = t

--- a/src/dune/coq_rules.ml
+++ b/src/dune/coq_rules.ml
@@ -190,16 +190,16 @@ let setup_ml_deps ~lib_db libs =
   (ml_iflags, Build.paths_existing mlpack)
 
 let coqlib_wrapper_name (s : Dune_file.Coq.t) =
-  Lib_name.Local.to_string (snd s.name)
+  Coq_lib_name.wrapper (snd s.name)
 
 let setup_rules ~sctx ~dir ~dir_contents (s : Dune_file.Coq.t) =
   let scope = SC.find_scope_by_dir sctx dir in
-  let cc = create_ccoq sctx ~dir in
   let expander = SC.expander sctx ~dir in
   if coq_debug then
     Format.eprintf "[gen_rules] @[dir: %a@\nscope: %a@]@\n%!" Path.Build.pp dir
       Path.Build.pp (Scope.root scope);
-  let name = Dune_file.Coq.best_name s in
+  let cc = create_ccoq sctx ~dir in
+  let name = snd s.name in
   let coq_modules = Dir_contents.coq_modules_of_library dir_contents ~name in
   (* coqdep requires all the files to be in the tree to produce correct
      dependencies *)
@@ -247,11 +247,11 @@ let coq_plugins_install_rules ~scope ~package ~dst_dir (s : Dune_file.Coq.t) =
 
 let install_rules ~sctx ~dir s =
   match s with
-  | { Dune_file.Coq.public = None; _ } -> []
-  | { Dune_file.Coq.public = Some { package; _ }; _ } ->
+  | { Dune_file.Coq.package = None; _ } -> []
+  | { Dune_file.Coq.package = Some package; _ } ->
     let scope = SC.find_scope_by_dir sctx dir in
     let dir_contents = Dir_contents.get sctx ~dir in
-    let name = Dune_file.Coq.best_name s in
+    let name = snd s.name in
     (* This is the usual root for now, Coq + Dune will change it! *)
     let coq_root = Path.Local.of_string "coq/user-contrib" in
     (* This must match the wrapper prefix for now to remain compatible *)

--- a/src/dune/dir_contents.mli
+++ b/src/dune/dir_contents.mli
@@ -49,7 +49,7 @@ val artifacts : t -> Dir_artifacts.t
 val mlds : t -> Dune_file.Documentation.t -> Path.Build.t list
 
 (** Coq modules of library [name] is the Coq library name. *)
-val coq_modules_of_library : t -> name:Lib_name.t -> Coq_module.t list
+val coq_modules_of_library : t -> name:Coq_lib_name.t -> Coq_module.t list
 
 (** Get the directory contents of the given directory. *)
 val get : Super_context.t -> dir:Path.Build.t -> t

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -351,8 +351,8 @@ end
 
 module Coq : sig
   type t =
-    { name : Loc.t * Lib_name.Local.t
-    ; public : Public_lib.t option
+    { name : Loc.t * Coq_lib_name.t
+    ; package : Package.t option
     ; synopsis : string option
     ; modules : Ordered_set_lang.t
     ; flags : Ordered_set_lang.Unexpanded.t
@@ -361,8 +361,6 @@ module Coq : sig
     ; loc : Loc.t
     ; enabled_if : Blang.t
     }
-
-  val best_name : t -> Lib_name.t
 
   type Stanza.t += T of t
 end

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -156,7 +156,7 @@ end = struct
             ~variants:exes.variants ~optional:exes.optional
         in
         Result.is_ok (Lib.Compile.direct_requires compile_info)
-      | Dune_file.Coq.T d -> Option.is_some d.public
+      | Dune_file.Coq.T d -> Option.is_some d.package
       | _ -> false )
       stanza
 

--- a/test/blackbox-tests/test-cases/coq/base/dune
+++ b/test/blackbox-tests/test-cases/coq/base/dune
@@ -1,6 +1,6 @@
 (coq.theory
  (name basic)
- (public_name base.basic)
+ (package base)
  (modules :standard)
  (synopsis "Test Coq library"))
 

--- a/test/blackbox-tests/test-cases/coq/ml_lib/theories/dune
+++ b/test/blackbox-tests/test-cases/coq/ml_lib/theories/dune
@@ -1,6 +1,6 @@
 (coq.theory
  (name Plugin)
- (public_name ml_lib.Plugin)
+ (package ml_lib)
  (synopsis "Test Plugin")
  (libraries ml_lib.ml_plugin_b)
  (modules :standard))

--- a/test/blackbox-tests/test-cases/coq/rec_module/dune
+++ b/test/blackbox-tests/test-cases/coq/rec_module/dune
@@ -1,6 +1,6 @@
 (coq.theory
  (name rec_module)
- (public_name rec.module)
+ (package rec)
  (modules :standard)
  (synopsis "Test Coq library"))
 


### PR DESCRIPTION
In the current model, Coq theory names can be of the form `A.b.C`,
which does mean that modules do live under that module prefix.

This poses a problem for handling `public_name` in a sensible way if
we want to allow globally-installed theories to satisfy local
dependencies.

Imagine the following theory declaration:

```lisp
(coq.theory
 (name mow)
 (theories foo.bar))
```

How should we satisfy `foo.bar`? Indeed, there is an ambiguity, does
it mean, "theory `bar` in package `foo`" or "theory `bar.foo`" in the
current package.

In particular, we could have a local stanza of the following form:

```
(coq.theory
 (name bar)
 (public_name foo.bar))
```

but then it would not be stable under vendoring, as this library would
be installed in `user-contrib/bar`. And moreover, it is ambiguous
with:
```
(coq.theory
 (name foo.bar))
```

One solution is to forbid the use of `public_name` and prefer
`package` instead. This way, libraries live under a global namespace
and the problem is solved.

However, this is not very satisfying, and the problem in future
versions of the language would still remain. Thus I am not very
convinced by this solution; suggestions are welcome.

This is a pre-requisite for #2053