### PR TITLE
Capture the package name in Dune_file.Executables.t

### DIFF
--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -286,6 +286,7 @@ module Executables : sig
     ; modes      : Link_mode.Set.t
     ; buildable  : Buildable.t
     ; variants   : (Loc.t * Variant.Set.t) option
+    ; package    : Package.t option
     }
 end
 

--- a/test/blackbox-tests/test-cases/too-many-parens/b/dune
+++ b/test/blackbox-tests/test-cases/too-many-parens/b/dune
@@ -1,4 +1,3 @@
 (executable
  (name hello)
- (public_name hello)
  (libraries (lib)))

--- a/test/blackbox-tests/test-cases/too-many-parens/run.t
+++ b/test/blackbox-tests/test-cases/too-many-parens/run.t
@@ -16,8 +16,8 @@ are readable.
 
   $ dune build --root b
   Entering directory 'b'
-  File "dune", line 4, characters 12-17:
-  4 |  (libraries (lib)))
+  File "dune", line 3, characters 12-17:
+  3 |  (libraries (lib)))
                   ^^^^^
   Error: 'select' expected
   Hint: dune files require fewer parentheses than jbuild files.


### PR DESCRIPTION
This is another small feature required for #1930. The parser now captures the package name in executable stanzas.