### PR TITLE
Simplify Link_time_code_gen even more

### DIFF
--- a/src/lib.ml
+++ b/src/lib.ml
@@ -390,23 +390,28 @@ module L = struct
 end
 
 module Lib_and_module = struct
-  type nonrec t =
-    | Lib of t
+  type t =
+    | Lib of lib
     | Module of Module.t
 
-  let link_flags ts ~mode ~stdlib_dir =
-    let libs = List.filter_map ts ~f:(function
-      | Lib lib -> Some lib
-      | Module _ -> None) in
-    Arg_spec.S
-      (L.c_include_flags libs ~stdlib_dir ::
-       List.map ts ~f:(function
-         | Lib t ->
-           Arg_spec.Deps (Mode.Dict.get t.info.archives mode)
-         | Module m ->
-           Dep (Module.cm_file_unsafe m (Mode.cm_kind mode))
-       ))
+  module L = struct
+    type nonrec t = t list
 
+    let link_flags ts ~mode ~stdlib_dir =
+      let libs = List.filter_map ts ~f:(function
+        | Lib lib -> Some lib
+        | Module _ -> None) in
+      Arg_spec.S
+        (L.c_include_flags libs ~stdlib_dir ::
+         List.map ts ~f:(function
+           | Lib t ->
+             Arg_spec.Deps (Mode.Dict.get t.info.archives mode)
+           | Module m ->
+             Dep (Module.cm_file_unsafe m (Mode.cm_kind mode))
+         ))
+
+    let of_libs l = List.map l ~f:(fun x -> Lib x)
+  end
 end
 
 (* Sub-systems *)

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -98,13 +98,17 @@ end with type lib := t
 
 (** Operation on list of libraries and modules *)
 module Lib_and_module : sig
-  type nonrec t =
-    | Lib of t
+  type lib = t
+  type t =
+    | Lib of lib
     | Module of Module.t
 
-  val link_flags : t list -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
-
-end
+  module L : sig
+    type nonrec t = t list
+    val of_libs : lib list -> t
+    val link_flags : t -> mode:Mode.t -> stdlib_dir:Path.t -> _ Arg_spec.t
+  end
+end with type lib := t
 
 (** {1 Errors} *)
 

--- a/src/link_time_code_gen.mli
+++ b/src/link_time_code_gen.mli
@@ -2,5 +2,10 @@
 
 open Stdune
 
-(** Insert link time generated code for findlib_dynload in the list *)
-val libraries_link : Compilation_context.t -> (Mode.t -> _ Arg_spec.t) Staged.t
+type t =
+  { to_link : Lib.Lib_and_module.t list
+  ; force_linkall : bool
+  }
+
+(** Generate link time code for special libraries such as [findlib.dynload] *)
+val handle_special_libs : Compilation_context.t -> t Or_exn.t

--- a/test/blackbox-tests/test-cases/findlib-dynload/run.t
+++ b/test/blackbox-tests/test-cases/findlib-dynload/run.t
@@ -62,3 +62,17 @@
   $ dune exe mytool c_thread
   m: init
   c_thread: registering
+
+  $ cat _build/default/.main.eobjs/findlib_initl.ml
+  Findlib.record_package Findlib.Record_core "mytool";;
+  Findlib.record_package Findlib.Record_core "findlib.internal";;
+  Findlib.record_package Findlib.Record_core "findlib";;
+  Findlib.record_package Findlib.Record_core "dynlink";;
+  Findlib.record_package Findlib.Record_core "findlib.dynload";;
+  Findlib.record_package Findlib.Record_core "unix";;
+  Findlib.record_package Findlib.Record_core "threads.posix";;
+  Findlib.record_package Findlib.Record_core "threads";;
+  let preds = [ "ppx_driver"; "mt"; "mt_posix" ] in
+  let preds = (if Dynlink.is_native then "native" else "byte") :: preds in
+  Findlib.record_package_predicates preds;;
+  


### PR DESCRIPTION
By generating the same file in all modes and using `Dynlink.is_native` instead.
