### PR TITLE
Add a Vcs module to deal with git and hg

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -49,6 +49,7 @@ module Main = struct
       ?profile:common.profile
       ~ignore_promoted_rules:common.ignore_promoted_rules
       ~capture_outputs:common.capture_outputs
+      ~ancestor_vcs:common.root.ancestor_vcs
       ()
 
   let setup ~log ?external_lib_deps_mode (common : Common.t) =

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -17,6 +17,7 @@ let term =
   Common.set_common common ~targets:[];
   Scheduler.go ~common (fun () ->
     Dune.Upgrader.upgrade (Dune.File_tree.load Path.Source.root
-                             ~warn_when_seeing_jbuild_file:false))
+                             ~warn_when_seeing_jbuild_file:false
+                             ~ancestor_vcs:None))
 
 let command = term, info

--- a/bin/workspace_root.mli
+++ b/bin/workspace_root.mli
@@ -13,6 +13,8 @@ type t =
   { dir : string
   ; to_cwd : string list (** How to reach the cwd from the root *)
   ; kind : Kind.t
+  ; (** Closest VCS in directories strictly above the root *)
+    ancestor_vcs : Dune.Vcs.t option
   }
 
 val create : specified_by_user:string option -> t

--- a/src/dune_load.ml
+++ b/src/dune_load.ml
@@ -239,8 +239,8 @@ let interpret ~dir ~project ~ignore_promoted_rules
   | Ocaml_script file ->
     Script { dir; project; file; kind = dune_file.kind }
 
-let load ?(ignore_promoted_rules=false) () =
-  let ftree = File_tree.load Path.Source.root in
+let load ?(ignore_promoted_rules=false) ~ancestor_vcs () =
+  let ftree = File_tree.load Path.Source.root ~ancestor_vcs in
   let projects =
     File_tree.fold ftree ~traverse_ignored_dirs:false ~init:[]
       ~f:(fun dir acc ->

--- a/src/dune_load.mli
+++ b/src/dune_load.mli
@@ -27,5 +27,6 @@ type conf = private
 
 val load
   :  ?ignore_promoted_rules:bool
+  -> ancestor_vcs:Vcs.t option
   -> unit
   -> conf

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -42,6 +42,8 @@ module Dir : sig
      or [jbuild-ignore] file in one of its ancestor directories. *)
   val ignored : t -> bool
 
+  val vcs : t -> Vcs.t option
+
   val fold
     :  t
     -> traverse_ignored_dirs:bool
@@ -65,7 +67,11 @@ end
     compatibility. *)
 type t
 
-val load : ?warn_when_seeing_jbuild_file:bool -> Path.Source.t -> t
+val load
+  :  ?warn_when_seeing_jbuild_file:bool
+  -> Path.Source.t
+  -> ancestor_vcs:Vcs.t option
+  -> t
 
 (** Passing [~traverse_ignored_dirs:true] to this functions causes the
     whole source tree to be deeply scanned, including ignored

--- a/src/main.ml
+++ b/src/main.ml
@@ -37,10 +37,11 @@ let scan_workspace ?(log=Log.no_log)
       ?ignore_promoted_rules
       ?(capture_outputs=true)
       ?profile
+      ~ancestor_vcs
       () =
   let env = setup_env ~capture_outputs in
   let conf =
-    Dune_load.load ?ignore_promoted_rules ()
+    Dune_load.load ?ignore_promoted_rules ~ancestor_vcs ()
   in
   let workspace =
     match workspace with
@@ -223,7 +224,7 @@ let bootstrap () =
          let* () = set_concurrency config in
          let* workspace =
           scan_workspace ~log ~workspace:(Workspace.default ?profile:!profile ())
-            ?profile:!profile
+            ?profile:!profile ~ancestor_vcs:None
             ()
          in
          let* _ = init_build_system workspace in

--- a/src/main.mli
+++ b/src/main.mli
@@ -24,6 +24,7 @@ val scan_workspace
   -> ?ignore_promoted_rules:bool
   -> ?capture_outputs:bool
   -> ?profile:string
+  -> ancestor_vcs:Vcs.t option
   -> unit
   -> workspace Fiber.t
 

--- a/src/vcs.ml
+++ b/src/vcs.ml
@@ -1,0 +1,98 @@
+open Import
+
+module Kind = struct
+  type t = Git | Hg
+
+  let of_dir_contents files =
+    if String.Set.mem files ".git" then
+      Some Git
+    else if String.Set.mem files ".hg" then
+      Some Hg
+    else
+      None
+
+  let to_dyn t =
+    Dyn.Variant
+      ((match t with
+         | Git -> "Git"
+         | Hg -> "Hg"),
+       [])
+end
+
+type t =
+  { root : Path.t
+  ; kind : Kind.t
+  }
+
+let to_dyn { root; kind } =
+  Dyn.Encoder.record
+    [ "root", Path.to_dyn root
+    ; "kind", Kind.to_dyn kind
+    ]
+
+let git, hg =
+  let get prog = lazy (
+    match Bin.which ~path:(Env.path Env.initial) prog with
+    | Some x -> x
+    | None -> Utils.program_not_found prog ~loc:None)
+  in
+  (get "git", get "hg")
+
+let git_describe =
+  Memo.create
+    "git-describe"
+    ~doc:"Run [git describe] in the following directory"
+    ~input:(module Path)
+    ~output:(Simple (module String))
+    ~visibility:(Public Path_dune_lang.decode)
+    Async
+    (Some (fun dir ->
+       let open Fiber.O in
+       let+ s =
+         Process.run_capture Strict (Lazy.force git)
+           ["describe"; "--always"; "--dirty"] ~env:Env.initial ~dir
+       in
+       String.trim s))
+
+let hg_describe =
+  let f dir =
+    let open Fiber.O in
+    let hg = Lazy.force hg in
+    let hg args = Process.run_capture Strict hg ~env:Env.initial ~dir args in
+    let* s =
+      hg [ "log"; "--rev"; "."; "-T"; "{latesttag} {latesttagdistance}" ]
+    in
+    let+ id =
+      hg [ "id"; "-i" ]
+    in
+    let s = String.trim s and id = String.trim id in
+    let id, dirty_suffix =
+      match String.drop_suffix id ~suffix:"+" with
+      | Some id -> id, "-dirty"
+      | None -> id, ""
+    in
+    let s =
+      let s, dist = Option.value_exn (String.rsplit2 s ~on:' ') in
+      match s with
+      | "null" -> id
+      | _ ->
+        match int_of_string dist with
+        | 1 -> s
+        | n -> sprintf "%s-%d-%s" s (n - 1) id
+        | exception _ -> sprintf "%s-%s-%s" s dist id
+    in
+    s ^ dirty_suffix
+  in
+  Memo.create
+    "hg-describe"
+    ~doc:"Do something similar to [git describe] with hg"
+    ~input:(module Path)
+    ~output:(Simple (module String))
+    ~visibility:(Public Path_dune_lang.decode)
+    Async
+    (Some f)
+
+let describe { root; kind } =
+  match kind with
+  | Git -> Memo.exec git_describe root
+  | Hg -> Memo.exec hg_describe root

--- a/src/vcs.mli
+++ b/src/vcs.mli
@@ -1,0 +1,23 @@
+(** VCS handling *)
+
+open Stdune
+
+module Kind : sig
+  type t = Git | Hg
+
+  val of_dir_contents : String.Set.t -> t option
+end
+
+type t =
+  { root : Path.t
+  ; kind : Kind.t
+  }
+
+val to_dyn : t -> Dyn.t
+
+(** Output of [git describe --dirty --always] or hg equivalent *)
+val describe : t -> string Fiber.t
+
+(** VCS commands *)
+val git : Path.t Lazy.t
+val hg : Path.t Lazy.t

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -182,3 +182,14 @@
           (progn
            (run %{exe:expect_test.exe} %{t})
            (diff? %{t} %{t}.corrected)))))
+
+(alias
+ (name runtest)
+ (deps (:t vcs.mlt)
+  (glob_files %{project_root}/src/.dune.objs/byte/*.cmi)
+  (glob_files %{project_root}/src/memo/.memo.objs/byte/*.cmi)
+  (glob_files %{project_root}/src/stdune/.stdune.objs/byte/*.cmi))
+ (action (chdir %{project_root}
+          (progn
+           (run %{exe:expect_test.exe} %{t})
+           (diff? %{t} %{t}.corrected)))))

--- a/test/unit-tests/vcs.mlt
+++ b/test/unit-tests/vcs.mlt
@@ -31,7 +31,8 @@ let run (vcs : Vcs.t) args =
       else
         Vcs.git, "hg",
         match args with
-        | ["tag"; s] -> ["tag"; "-a"; s; "-m"; s]
+        | ["tag"; s; "-u"; _] -> ["tag"; "-a"; s; "-m"; s]
+        | ["commit"; "-m"; msg; "-u"; _] -> ["commit"; "-m"; msg]
         | _ -> args
   in
   printf "$ %s\n" (List.map (prog_str :: args) ~f:Import.quote_for_shell
@@ -53,7 +54,11 @@ let run_action (vcs : Vcs.t) action =
   match action with
   | Init -> run vcs ["init"]
   | Add fn -> run vcs ["add"; fn]
-  | Commit -> run vcs ["commit"; "-m"; "commit message"]
+  | Commit -> begin
+      match vcs.kind with
+      | Git -> run vcs ["commit"; "-m"; "commit message"]
+      | Hg -> run vcs ["commit"; "-m"; "commit message"; "-u"; "toto"]
+    end
   | Write (fn, s) ->
     printf "$ echo %S > %s\n" s fn;
     Io.write_file (Path.relative temp_dir fn) s;
@@ -94,7 +99,7 @@ let run_action (vcs : Vcs.t) action =
   | Tag s ->
     match vcs.kind with
     | Git -> run vcs ["tag"; "-a"; s; "-m"; s]
-    | Hg -> run vcs ["tag"; s]
+    | Hg -> run vcs ["tag"; s; "-u"; "toto"]
 
 let run kind script =
   Path.rm_rf temp_dir;
@@ -180,7 +185,6 @@ $ git commit -m 'commit message'
 $ git describe [...]
 1.0-2-<commit-id>
 
-
 - : unit = ()
 |}]
 
@@ -190,7 +194,7 @@ run Hg script;;
 $ hg init
 $ echo "-" > a
 $ hg add a
-$ hg commit -m 'commit message'
+$ hg commit -m 'commit message' -u toto
 $ hg describe [...]
 <commit-id>
 
@@ -199,11 +203,11 @@ $ hg add b
 $ hg describe [...]
 <commit-id>-dirty
 
-$ hg commit -m 'commit message'
+$ hg commit -m 'commit message' -u toto
 $ hg describe [...]
 <commit-id>
 
-$ hg tag 1.0
+$ hg tag 1.0 -u toto
 $ hg describe [...]
 1.0
 
@@ -212,7 +216,7 @@ $ hg add c
 $ hg describe [...]
 1.0-dirty
 
-$ hg commit -m 'commit message'
+$ hg commit -m 'commit message' -u toto
 $ hg describe [...]
 1.0-1-<commit-id>
 
@@ -221,10 +225,9 @@ $ hg add d
 $ hg describe [...]
 1.0-1-<commit-id>-dirty
 
-$ hg commit -m 'commit message'
+$ hg commit -m 'commit message' -u toto
 $ hg describe [...]
 1.0-2-<commit-id>
-
 
 - : unit = ()
 |}]

--- a/test/unit-tests/vcs.mlt
+++ b/test/unit-tests/vcs.mlt
@@ -1,0 +1,230 @@
+open Stdune;;
+open Dune;;
+open Fiber.O;;
+
+#warnings "-40";;
+
+let printf = Printf.printf;;
+
+let () =
+  Path.set_root (Path.External.cwd ());
+  Path.set_build_dir (Path.Kind.of_string "_build")
+;;
+
+let temp_dir = Path.of_string "vcs-tests";;
+let () = at_exit (fun () -> Path.rm_rf temp_dir);;
+
+(* When hg is not available, we test with git twice indeed. This is
+   because many people don't have hg installed. *)
+let has_hg =
+  match Lazy.force Vcs.hg with
+  | (_ : Path.t) -> true
+  | exception _ -> false
+
+let run (vcs : Vcs.t) args =
+  let prog, prog_str, real_args =
+    match vcs.kind with
+    | Git -> Vcs.git, "git", args
+    | Hg ->
+      if has_hg then
+        Vcs.hg, "hg", args
+      else
+        Vcs.git, "hg",
+        match args with
+        | ["tag"; s] -> ["tag"; "-a"; s; "-m"; s]
+        | _ -> args
+  in
+  printf "$ %s\n" (List.map (prog_str :: args) ~f:Import.quote_for_shell
+               |> String.concat ~sep:" ");
+  Process.run Strict (Lazy.force prog) real_args
+    ~env:Env.initial ~dir:vcs.root
+    ~stdout_to:(Process.Output.file Config.dev_null)
+;;
+
+type action =
+  | Init
+  | Add of string
+  | Write of string * string
+  | Commit
+  | Tag of string
+  | Describe of string
+
+let run_action (vcs : Vcs.t) action =
+  match action with
+  | Init -> run vcs ["init"]
+  | Add fn -> run vcs ["add"; fn]
+  | Commit -> run vcs ["commit"; "-m"; "commit message"]
+  | Write (fn, s) ->
+    printf "$ echo %S > %s\n" s fn;
+    Io.write_file (Path.relative temp_dir fn) s;
+    Fiber.return ()
+  | Describe expected ->
+    printf "$ %s describe [...]\n"
+      (match vcs.kind with
+       | Git -> "git"
+       | Hg -> "hg");
+    Memo.reset ();
+    let vcs =
+      match vcs.kind with
+      | Hg when not has_hg -> { vcs with kind = Git }
+      | _ -> vcs
+    in
+    Vcs.describe vcs >>| fun s ->
+    let processed =
+      String.split s ~on:'-'
+      |> List.map ~f:(fun s ->
+        match s with
+        | "" | "dirty" -> s
+        | s when String.length s = 1 &&
+                 String.for_all s ~f:(function
+                   | '0'..'9' -> true
+                   | _ -> false) -> s
+        | _ when String.for_all s ~f:(function
+          | '0'..'9' | 'a'..'z' -> true
+          | _ -> false) ->
+          "<commit-id>"
+        | _ -> s)
+      |> String.concat ~sep:"-"
+    in
+    printf "%s\n" processed;
+    if processed <> expected then
+      printf "Expected: %s\n\
+              Original: %s\n" expected s;
+    printf "\n"
+  | Tag s ->
+    match vcs.kind with
+    | Git -> run vcs ["tag"; "-a"; s; "-m"; s]
+    | Hg -> run vcs ["tag"; s]
+
+let run kind script =
+  Path.rm_rf temp_dir;
+  Path.mkdir_p temp_dir;
+  let vcs = { Vcs.kind; root = temp_dir } in
+  Scheduler.go (fun () ->
+    Fiber.map_all_unit script ~f:(run_action vcs))
+;;
+
+let script =
+  [ Init
+  ; Write ("a", "-")
+  ; Add "a"
+  ; Commit
+  ; Describe "<commit-id>"
+
+  ; Write ("b", "-")
+  ; Add "b"
+  ; Describe "<commit-id>-dirty"
+
+  ; Commit
+  ; Describe "<commit-id>"
+
+  ; Tag "1.0"
+  ; Describe "1.0"
+
+  ; Write ("c", "-")
+  ; Add "c"
+  ; Describe "1.0-dirty"
+
+  ; Commit
+  ; Describe "1.0-1-<commit-id>"
+
+  ; Write ("d", "-")
+  ; Add "d"
+  ; Describe "1.0-1-<commit-id>-dirty"
+
+  ; Commit
+  ; Describe "1.0-2-<commit-id>"
+  ]
+;;
+
+[%%ignore]
+
+run Git script;;
+
+[%%expect{|
+$ git init
+$ echo "-" > a
+$ git add a
+$ git commit -m 'commit message'
+$ git describe [...]
+<commit-id>
+
+$ echo "-" > b
+$ git add b
+$ git describe [...]
+<commit-id>-dirty
+
+$ git commit -m 'commit message'
+$ git describe [...]
+<commit-id>
+
+$ git tag -a 1.0 -m 1.0
+$ git describe [...]
+1.0
+
+$ echo "-" > c
+$ git add c
+$ git describe [...]
+1.0-dirty
+
+$ git commit -m 'commit message'
+$ git describe [...]
+1.0-1-<commit-id>
+
+$ echo "-" > d
+$ git add d
+$ git describe [...]
+1.0-1-<commit-id>-dirty
+
+$ git commit -m 'commit message'
+$ git describe [...]
+1.0-2-<commit-id>
+
+
+- : unit = ()
+|}]
+
+run Hg script;;
+
+[%%expect{|
+$ hg init
+$ echo "-" > a
+$ hg add a
+$ hg commit -m 'commit message'
+$ hg describe [...]
+<commit-id>
+
+$ echo "-" > b
+$ hg add b
+$ hg describe [...]
+<commit-id>-dirty
+
+$ hg commit -m 'commit message'
+$ hg describe [...]
+<commit-id>
+
+$ hg tag 1.0
+$ hg describe [...]
+1.0
+
+$ echo "-" > c
+$ hg add c
+$ hg describe [...]
+1.0-dirty
+
+$ hg commit -m 'commit message'
+$ hg describe [...]
+1.0-1-<commit-id>
+
+$ echo "-" > d
+$ hg add d
+$ hg describe [...]
+1.0-1-<commit-id>-dirty
+
+$ hg commit -m 'commit message'
+$ hg describe [...]
+1.0-2-<commit-id>
+
+
+- : unit = ()
+|}]


### PR DESCRIPTION
In preparation for #1930. The module abstract and memoize `git describe ..` and a mercurial equivalent. This PR also add a test and attach vcs info to the file tree.