### PR TITLE
Add emacs dir locals el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,7 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+(
+ (tuareg-mode (whitespace-line-column . 80))
+ (tuareg-mode (fill-column . 80))
+ )


### PR DESCRIPTION
Add .dir-locals.el with some dune-specific emacs settings, 
at the moment just `whitespace-line-column` and  `fill-column`.

Sadly, `whitespace-mode` seems to not pick this up immediately and you need to restart `whitespace-mode` for this setting to apply properly. I'm still looking for workarounds, but having this file seems better than not having it.