### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.{ml,mli}]
+max_line_length = 80


### PR DESCRIPTION
Set maximum line length to 80 columns.

Follow up on #2113 

The list of editor extensions is available at https://editorconfig.org/#download
For emacs it is https://github.com/editorconfig/editorconfig-emacs.

`whitespace` mode might need a custom config so that is uses `fill-column`:

```elisp
(setq whitespace-line-column nil)
```