### PR TITLE
Formalise special builtin support for findlib.dynload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,13 @@ unreleased
 - Fix crash when calculating library dependency closure (#2090, fixes #2085,
   @rgrinberg)
 
+- Clean up the special support for `findlib.dynload`. Before, Dune
+  would simply match on the library name. Now, we only match on the
+  findlib package name when the library doesn't come from
+  Dune. Someone writing a library called `findlib.dynload` with Dune
+  would have to add `(special_builton_support findlib_dynload)` to
+  trigger the special behavior. (#2115, @diml)
+
 1.9.1 (11/04/2019)
 ------------------
 

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -193,6 +193,16 @@ module Library : sig
       }
   end
 
+  module Special_builtin_support : sig
+    type t =
+      | Findlib_dynload
+
+    val compare : t -> t -> Ordering.t
+    include Dune_lang.Conv with type t := t
+
+    module Map : Map.S with type key := t
+  end
+
   type t =
     { name                     : (Loc.t * Lib_name.Local.t)
     ; public                   : Public_lib.t option
@@ -222,6 +232,7 @@ module Library : sig
     ; default_implementation   : (Loc.t * Lib_name.t) option
     ; private_modules          : Ordered_set_lang.t option
     ; stdlib                   : Stdlib.t option
+    ; special_builtin_support  : Special_builtin_support.t option
     }
 
   val has_stubs : t -> bool

--- a/src/dune_package.mli
+++ b/src/dune_package.mli
@@ -25,6 +25,8 @@ module Lib : sig
   val implements : _ t -> (Loc.t * Lib_name.t) option
   val variant : _ t -> Variant.t option
   val default_implementation : _ t -> (Loc.t * Lib_name.t) option
+  val special_builtin_support
+    : _ t -> Dune_file.Library.Special_builtin_support.t option
 
   val dir_of_name : Lib_name.t -> Path.Local.t
 
@@ -57,6 +59,8 @@ module Lib : sig
     -> version:string option
     -> orig_src_dir:Path.t option
     -> obj_dir:Obj_dir.t
+    -> special_builtin_support:
+         Dune_file.Library.Special_builtin_support.t option
     -> 'a t
 
   val set_subsystems : 'a t -> 'b Sub_system_name.Map.t -> 'b t

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -238,6 +238,12 @@ module Package = struct
       ~version:(version t)
       ~modes
       ~obj_dir
+      ~special_builtin_support:(
+        (* findlib has been around for much longer than dune, so it is
+           acceptable to have a special case in dune for findlib. *)
+        match Lib_name.to_string t.name with
+        | "findlib.dynload" -> Some Findlib_dynload
+        | _ -> None)
 
   let parse db ~meta_file ~name ~parent_dir ~vars =
     let pkg_dir = Vars.get vars "directory" Ps.empty in

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -282,6 +282,8 @@ let status t = t.info.status
 
 let foreign_objects t = t.info.foreign_objects
 
+let special_builtin_support t = t.info.special_builtin_support
+
 let main_module_name t =
   match t.info.main_module_name with
   | This mmn -> Ok mmn
@@ -387,6 +389,13 @@ module L = struct
     Id.Top_closure.top_closure l
       ~key:(fun t -> unique_id (key t))
       ~deps
+
+  let special_builtin_support l =
+    let module M = Dune_file.Library.Special_builtin_support.Map in
+    List.fold_left l ~init:M.empty ~f:(fun acc lib ->
+      match lib.info.special_builtin_support with
+      | None -> acc
+      | Some x -> M.add acc x lib)
 end
 
 module Lib_and_module = struct
@@ -1701,5 +1710,4 @@ let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects ~dir 
     ~modules:(Some lib_modules)
     ~main_module_name:(Result.ok_exn (main_module_name lib))
     ~sub_systems:(Sub_system.dump_config lib)
-
-
+    ~special_builtin_support:info.special_builtin_support

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -40,6 +40,9 @@ val wrapped : t -> Wrapped.t option Or_exn.t
 
 val virtual_ : t -> Lib_modules.t Lib_info.Source.t option
 
+val special_builtin_support
+  : t -> Dune_file.Library.Special_builtin_support.t option
+
 (** A unique integer identifier. It is only unique for the duration of
     the process *)
 module Id : sig
@@ -94,6 +97,9 @@ module L : sig
     -> key:('a -> lib)
     -> deps:('a -> 'a list)
     -> ('a list, 'a list) Result.t
+
+  val special_builtin_support
+    : t -> lib Dune_file.Library.Special_builtin_support.Map.t
 end with type lib := t
 
 (** Operation on list of libraries and modules *)

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -77,6 +77,7 @@ type t =
   ; wrapped          : Wrapped.t Dune_file.Library.Inherited.t option
   ; main_module_name : Dune_file.Library.Main_module_name.t
   ; modes            : Mode.Dict.Set.t
+  ; special_builtin_support : Dune_file.Library.Special_builtin_support.t option
   }
 
 let user_written_deps t =
@@ -182,6 +183,7 @@ let of_library_stanza ~dir
   ; main_module_name
   ; modes
   ; wrapped = Some conf.wrapped
+  ; special_builtin_support = conf.special_builtin_support
   }
 
 let of_dune_lib dp =
@@ -227,4 +229,5 @@ let of_dune_lib dp =
   ; default_implementation = Lib.default_implementation dp
   ; modes = Lib.modes dp
   ; wrapped
+  ; special_builtin_support = Lib.special_builtin_support dp
   }

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -58,6 +58,7 @@ type t = private
   ; wrapped          : Wrapped.t Dune_file.Library.Inherited.t option
   ; main_module_name : Dune_file.Library.Main_module_name.t
   ; modes            : Mode.Dict.Set.t
+  ; special_builtin_support : Dune_file.Library.Special_builtin_support.t option
   }
 
 val of_library_stanza


### PR DESCRIPTION
So that we can extend it to other libraries in the future without more hard-coding. After this patch, the matching on the name `findlib.dynload` is now done only when looking at the META file. So if someone was defining a `findlib.dynload` library via dune, it wouldn't get special treatment unless explicitly marked with `(special_builtin_support findlib_dynload)`, which is cleaner as well.