### PR TITLE
Distinguish between local and relative and remove locs from Path

### DIFF
--- a/bench/file_tree_cache.ml
+++ b/bench/file_tree_cache.ml
@@ -9,9 +9,9 @@ let setup = lazy (
   let tmp = Path.External.of_string (Filename.get_temp_dir_name ()) in
   Path.External.mkdir_p (Path.External.relative tmp deep_path);
   Path.set_root tmp;
-  Path.set_build_dir (Path.Kind.of_string "_build");
+  Path.set_build_dir (Path.Kind.of_string_exn "_build");
   let ft = (Dune_load.load ~ancestor_vcs:None ()).file_tree in
-  let path = Path.Source.of_string deep_path in
+  let path = Path.Source.of_string_exn deep_path in
   at_exit (fun () -> Sys.remove "./dune-project");
   (ft, path))
 

--- a/bench/scheduler_bench.ml
+++ b/bench/scheduler_bench.ml
@@ -5,7 +5,7 @@ open Dune
 
 let setup = lazy (
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string "_build"))
+  Path.set_build_dir (Path.Kind.of_string_exn "_build"))
 
 let prog =
   Option.value_exn (Bin.which ~path:(Env.path Env.initial) "true")
@@ -22,4 +22,4 @@ let l = List.init 100 ~f:ignore
 let%bench_fun "many" [@indexed jobs = [1; 2; 4; 8]] =
   Lazy.force setup;
   fun () ->
-  go ~jobs (fun () -> Fiber.parallel_iter l ~f:run)
+    go ~jobs (fun () -> Fiber.parallel_iter l ~f:run)

--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -30,7 +30,7 @@ let in_dir ~name ~recursive ~contexts dir =
   | In_install_dir _ ->
     die "Invalid alias: %s.\n\
          There are no aliases in %s."
-      (Path.to_string_maybe_quoted Path.(relative build_dir "install"))
+      (Path.to_string_maybe_quoted Path.(relative_exn build_dir "install"))
       (Path.to_string_maybe_quoted dir)
   | In_build_dir (ctx, dir) ->
     { dir
@@ -51,7 +51,7 @@ let of_string common s ~contexts =
         (1, true)
     in
     let s = String.drop s pos in
-    let path = Path.relative Path.root (Common.prefix_target common s) in
+    let path = Path.relative_exn Path.root (Common.prefix_target common s) in
     if Path.is_root path then
       die "@@ on the command line must be followed by a valid alias name"
     else

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -11,7 +11,7 @@ module Let_syntax = struct
   let ( let+ ) t f =
     Term.(const f $ t)
   let ( and+ ) a b =
-    Term.(const (fun x y -> x, y) $ a $ b)
+               Term.(const (fun x y -> x, y) $ a $ b)
 end
 open Let_syntax
 
@@ -48,7 +48,7 @@ let set_dirs c =
   if c.root.dir <> Filename.current_dir_name then
     Sys.chdir c.root.dir;
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string c.build_dir)
+  Path.set_build_dir (Path.Kind.of_string_exn c.build_dir)
 
 let set_common_other c ~targets =
   Clflags.debug_dep_path := c.debug_dep_path;

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -39,7 +39,7 @@ val set_common : t -> targets:string list -> unit
 val set_common_other : t -> targets:string list -> unit
 
 (** [set_dirs common] sets the workspace root and build directories, and makes
- the root the current working directory *)
+    the root the current working directory *)
 val set_dirs : t -> unit
 
 val help_secs
@@ -58,7 +58,7 @@ val default_build_dir : string
 module Let_syntax : sig
   val ( let+ ) : 'a Cmdliner.Term.t -> ('a -> 'b) -> 'b Cmdliner.Term.t
   val ( and+ )
-   :  'a Cmdliner.Term.t
-   -> 'b Cmdliner.Term.t
-   -> ('a * 'b) Cmdliner.Term.t
+:  'a Cmdliner.Term.t
+-> 'b Cmdliner.Term.t
+-> ('a * 'b) Cmdliner.Term.t
 end

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -9,7 +9,7 @@ let man =
   ; `P {|$(b,dune exec -- COMMAND) should behave in the same way as if you
           do:|}
   ; `Pre "  \\$ dune install\n\
-          \  \\$ COMMAND"
+         \  \\$ COMMAND"
   ; `P {|In particular if you run $(b,dune exec ocaml), you will have
           access to the libraries defined in the workspace using your usual
           directives ($(b,#require) for instance)|}
@@ -47,16 +47,16 @@ let term =
   let prog_where =
     match Filename.analyze_program_name prog with
     | Absolute ->
-      `This_abs (Path.of_string prog)
+      `This_abs (Path.of_string_exn prog)
     | In_path ->
       `Search prog
     | Relative_to_current_dir ->
       let prog = Common.prefix_target common prog in
-      `This_rel (Path.relative context.build_dir prog) in
+      `This_rel (Path.relative_exn context.build_dir prog) in
   let targets = lazy (
     (match prog_where with
      | `Search p ->
-       [Path.relative (Config.local_install_bin_dir ~context:context.name) p]
+       [Path.relative_exn (Config.local_install_bin_dir ~context:context.name) p]
      | `This_rel p when Sys.win32 ->
        [p; Path.extend_basename p ~suffix:Bin.exe]
      | `This_rel p ->

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -6,7 +6,7 @@ let interpret_destdir ~destdir path =
   | None ->
     path
   | Some prefix ->
-    Path.append_relative
+    Path.append_local
       (Path.of_string_exn prefix)
       (Path.local_part path)
 

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -7,22 +7,22 @@ let interpret_destdir ~destdir path =
     path
   | Some prefix ->
     Path.append_relative
-      (Path.of_string prefix)
+      (Path.of_string_exn prefix)
       (Path.local_part path)
 
 let get_dirs context ~prefix_from_command_line ~libdir_from_command_line =
   match prefix_from_command_line with
   | Some p ->
-    let prefix = Path.of_string p in
+    let prefix = Path.of_string_exn p in
     let dir = Option.value ~default:"lib" libdir_from_command_line in
-    Fiber.return (prefix, Some (Path.relative prefix dir))
+    Fiber.return (prefix, Some (Path.relative_exn prefix dir))
   | None ->
     let open Fiber.O in
     let* prefix = Context.install_prefix context in
     let libdir =
       match libdir_from_command_line with
       | None -> Context.install_ocaml_libdir context
-      | Some l -> Fiber.return (Some (Path.relative prefix l))
+      | Some l -> Fiber.return (Some (Path.relative_exn prefix l))
     in
     let+ libdir = libdir in
     (prefix, libdir)
@@ -88,8 +88,8 @@ module File_ops_real : FILE_OPERATIONS = struct
     let chmod =
       if executable then
         set_executable_bits
-     else
-       clear_executable_bits
+      else
+        clear_executable_bits
     in
     Io.copy_file ~src ~dst ~chmod ()
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -63,7 +63,7 @@ let runtest =
     let log = Log.create common in
     let targets (setup : Main.build_system) =
       List.map dirs ~f:(fun dir ->
-        let dir = Path.(relative root) (Common.prefix_target common dir) in
+        let dir = Path.(relative_exn root) (Common.prefix_target common dir) in
         Target.Alias (Alias.in_dir ~name:"runtest" ~recursive:true
                         ~contexts:setup.workspace.contexts dir))
     in
@@ -114,7 +114,7 @@ let promote =
        | _ ->
          let files =
            List.map files
-             ~f:(fun fn -> Path.Source.of_string (Common.prefix_target common fn))
+             ~f:(fun fn -> Path.Source.of_string_exn (Common.prefix_target common fn))
          in
          let on_missing fn =
            Format.eprintf "@{<warning>Warning@}: Nothing to promote for %a.@."

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -107,7 +107,7 @@ let term =
          & pos_all string []
          & Arg.info [] ~docv:"TARGET")
   in
-  let out = Option.map ~f:Path.of_string out in
+  let out = Option.map ~f:Path.of_string_exn out in
   Common.set_common common ~targets;
   let log = Log.create common in
   Scheduler.go ~log ~common (fun () ->

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -34,7 +34,7 @@ let term =
   Scheduler.go ~log ~common (fun () ->
     let open Fiber.O in
     let* setup = Import.Main.setup ~log common in
-    let dir = Path.of_string dir in
+    let dir = Path.of_string_exn dir in
     let checked = Util.check_path setup.workspace.contexts dir in
     let request =
       Build.all (

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -69,7 +69,7 @@ let term =
       }
     in
     Path.set_root (Path.External.cwd ());
-    Path.set_build_dir (Path.Kind.of_string Common.default_build_dir);
+    Path.set_build_dir (Path.Kind.of_string_exn Common.default_build_dir);
     Dune.Scheduler.go ~config Watermarks.subst
 
 let command = term, info

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -111,7 +111,7 @@ let resolve_target common ~(setup : Dune.Main.build_system) s =
   match Alias.of_string common s ~contexts:setup.workspace.contexts with
   | Some a -> Ok [Alias a]
   | None ->
-    let path = Path.relative Path.root (Common.prefix_target common s) in
+    let path = Path.relative_exn Path.root (Common.prefix_target common s) in
     resolve_path path ~setup
 
 let resolve_targets_mixed ~log common (setup : Dune.Main.build_system)

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -45,6 +45,6 @@ let check_path contexts =
             match Path.Source.split_first_component src with
             | None -> internal path
             | Some (ctx, src) ->
-              In_install_dir (context_exn ctx, Path.Source.of_relative src)
+              In_install_dir (context_exn ctx, Path.Source.of_local src)
           )
           else (In_build_dir (context_exn name, src))

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -11,7 +11,7 @@ let man =
   ; `Blocks Common.help_secs
   ]
 
- let info = Term.info "utop" ~doc ~man
+let info = Term.info "utop" ~doc ~man
 
 let term =
   let+ common = Common.term
@@ -22,7 +22,7 @@ let term =
   in
   Common.set_dirs common;
   if not (Path.is_directory
-            (Path.of_string (Common.prefix_target common dir))) then
+            (Path.of_string_exn (Common.prefix_target common dir))) then
     die "cannot find directory: %s" (String.maybe_quoted dir);
   let utop_target = Filename.concat dir Utop.utop_exe in
   Common.set_common_other common ~targets:[utop_target];

--- a/bin/workspace_root.ml
+++ b/bin/workspace_root.ml
@@ -71,7 +71,7 @@ let find () =
           match Vcs.Kind.of_dir_contents files with
           | Some kind ->
             { candidate with
-              ancestor_vcs = Some { kind; root = Path.of_string dir }
+              ancestor_vcs = Some { kind; root = Path.of_string_exn dir }
             }
           | None -> candidate
       in

--- a/example/sample-projects/with-configure-step/real_configure.ml
+++ b/example/sample-projects/with-configure-step/real_configure.ml
@@ -1,5 +1,5 @@
 #use "config_common.ml"
-#use "config"
+     #use "config"
 
 let with_blah =
   match enable_blah with

--- a/src/action.ml
+++ b/src/action.ml
@@ -145,7 +145,7 @@ module Unresolved = struct
 
     let of_string ~dir ~loc s =
       if String.contains s '/' then
-        This (Path.relative dir s)
+        This (Path.relative_exn dir s)
       else
         Search (loc, s)
   end

--- a/src/action_dune_lang.mli
+++ b/src/action_dune_lang.mli
@@ -1,7 +1,7 @@
 open Stdune
 
 (* This module is to be used in Dune_file. It should not introduce any
-    dependencies unless they're already dependencies of Dune_file *)
+   dependencies unless they're already dependencies of Dune_file *)
 include Action_intf.Ast
   with type program := String_with_vars.t and
   type string := String_with_vars.t and

--- a/src/action_exec.ml
+++ b/src/action_exec.ml
@@ -19,8 +19,8 @@ let exec_run ~ectx ~dir ~env ~stdout_to ~stderr_to prog args =
         die "Context %s has a host %s.@.It's not possible to execute binary %a \
              in it.@.@.This is a bug and should be reported upstream."
           target.name host.name Path.pp prog in
-    invalid_prefix (Path.relative Path.build_dir target.name);
-    invalid_prefix (Path.relative Path.build_dir ("install/" ^ target.name));
+    invalid_prefix (Path.relative_exn Path.build_dir target.name);
+    invalid_prefix (Path.relative_exn Path.build_dir ("install/" ^ target.name));
   end;
   Process.run Strict ~dir ~env
     ~stdout_to ~stderr_to

--- a/src/action_to_sh.ml
+++ b/src/action_to_sh.ml
@@ -119,7 +119,7 @@ let rec pp = function
               [ Pp.char '{'
               ; Pp.space
               ; Pp.hvbox [Pp.list l ~f:(fun x -> Pp.seq (pp x) (Pp.char ';'))
-                             ~sep:Pp.space]
+                            ~sep:Pp.space]
               ]
           ; Pp.space
           ; Pp.char '}'

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -43,7 +43,7 @@ let equal x y = compare x y = Eq
 let hash { dir ; name } =
   Hashtbl.hash (Path.hash dir, String.hash name)
 
-let pp fmt t = Path.pp fmt (Path.relative t.dir t.name)
+let pp fmt t = Path.pp fmt (Path.relative_exn t.dir t.name)
 
 let to_dyn { dir ; name } =
   let open Dyn in
@@ -59,10 +59,10 @@ let suffix = "-" ^ String.make 32 '0'
 let name t = t.name
 let dir  t = t.dir
 
-let fully_qualified_name t = Path.relative t.dir t.name
+let fully_qualified_name t = Path.relative_exn t.dir t.name
 
 let stamp_file t =
-  Path.relative (Path.insert_after_build_dir_exn t.dir ".aliases")
+  Path.relative_exn (Path.insert_after_build_dir_exn t.dir ".aliases")
     (t.name ^ suffix)
 
 let find_dir_specified_on_command_line ~dir ~file_tree =

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -76,11 +76,11 @@ module Public_libs = struct
         let lib_install_dir =
           match rest with
           | [] -> lib_install_dir
-          | _  -> Path.relative lib_install_dir (String.concat rest ~sep:"/")
+          | _  -> Path.relative_exn lib_install_dir (String.concat rest ~sep:"/")
         in
-        Ok (Path.relative lib_install_dir file)
+        Ok (Path.relative_exn lib_install_dir file)
       end else
-        Ok (Path.relative (Lib.src_dir lib) file)
+        Ok (Path.relative_exn (Lib.src_dir lib) file)
 
 end
 

--- a/src/build.ml
+++ b/src/build.ml
@@ -263,43 +263,43 @@ let no_targets_allowed () =
 let static_deps t ~all_targets =
   let rec loop : type a b. (a, b) t -> Static_deps.t -> bool -> Static_deps.t
     = fun t acc targets_allowed ->
-    match t with
-    | Arr _ -> acc
-    | Targets _ -> if not targets_allowed then no_targets_allowed (); acc
-    | Compose (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
-    | First t -> loop t acc targets_allowed
-    | Second t -> loop t acc targets_allowed
-    | Split (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
-    | Fanout (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
-    | Deps deps ->
-      Static_deps.add_action_deps acc deps
-    | Paths_for_rule fns ->
-      Static_deps.add_rule_paths acc fns
-    | Paths_glob g ->
-      Static_deps.add_action_dep acc (Dep.glob g)
-    | If_file_exists (p, state) -> begin
-        match !state with
-        | Decided (_, t) -> loop t acc false
-        | Undecided (then_, else_) ->
-          let dir = Path.parent_exn p in
-          let targets = all_targets ~dir in
-          if Path.Set.mem targets p then begin
-            state := Decided (true, then_);
-            loop then_ acc false
-          end else begin
-            state := Decided (false, else_);
-            loop else_ acc false
-          end
-      end
-    | Dyn_paths t -> loop t acc targets_allowed
-    | Dyn_deps t -> loop t acc targets_allowed
-    | Contents p -> Static_deps.add_rule_path acc p
-    | Lines_of p -> Static_deps.add_rule_path acc p
-    | Record_lib_deps _ -> acc
-    | Fail _ -> acc
-    | Memo m -> loop m.t acc targets_allowed
-    | Catch (t, _) -> loop t acc targets_allowed
-    | Lazy_no_targets t -> loop (Lazy.force t) acc false
+      match t with
+      | Arr _ -> acc
+      | Targets _ -> if not targets_allowed then no_targets_allowed (); acc
+      | Compose (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
+      | First t -> loop t acc targets_allowed
+      | Second t -> loop t acc targets_allowed
+      | Split (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
+      | Fanout (a, b) -> loop a (loop b acc targets_allowed) targets_allowed
+      | Deps deps ->
+        Static_deps.add_action_deps acc deps
+      | Paths_for_rule fns ->
+        Static_deps.add_rule_paths acc fns
+      | Paths_glob g ->
+        Static_deps.add_action_dep acc (Dep.glob g)
+      | If_file_exists (p, state) -> begin
+          match !state with
+          | Decided (_, t) -> loop t acc false
+          | Undecided (then_, else_) ->
+            let dir = Path.parent_exn p in
+            let targets = all_targets ~dir in
+            if Path.Set.mem targets p then begin
+              state := Decided (true, then_);
+              loop then_ acc false
+            end else begin
+              state := Decided (false, else_);
+              loop else_ acc false
+            end
+        end
+      | Dyn_paths t -> loop t acc targets_allowed
+      | Dyn_deps t -> loop t acc targets_allowed
+      | Contents p -> Static_deps.add_rule_path acc p
+      | Lines_of p -> Static_deps.add_rule_path acc p
+      | Record_lib_deps _ -> acc
+      | Fail _ -> acc
+      | Memo m -> loop m.t acc targets_allowed
+      | Catch (t, _) -> loop t acc targets_allowed
+      | Lazy_no_targets t -> loop (Lazy.force t) acc false
   in
   loop t Static_deps.empty true
 

--- a/src/c.ml
+++ b/src/c.ml
@@ -104,7 +104,7 @@ module Sources = struct
 
   let objects (t : t) ~dir ~ext_obj =
     String.Map.keys t
-    |> List.map ~f:(fun c -> Path.relative dir (c ^ ext_obj))
+    |> List.map ~f:(fun c -> Path.relative_exn dir (c ^ ext_obj))
 
   let split_by_kind t =
     let (c, cxx) =

--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -57,7 +57,7 @@ let load_sources ~dune_version ~dir ~files =
         fn (Filename.extension fn) Syntax.Version.pp version;
       acc
     | Recognized (obj, kind) ->
-      let path = Path.relative dir fn in
+      let path = Path.relative_exn dir fn in
       C.Kind.Dict.update acc kind ~f:(fun v ->
         String.Map.add v obj (C.Source.make ~kind ~path)
       ))

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -24,15 +24,15 @@ module Includes = struct
           [ iflags
           ; Hidden_deps
               (if opaque then
-                  List.map libs ~f:(fun lib ->
-                    (lib, if Lib.is_local lib then
-                       [Lib_file_deps.Group.Cmi]
-                     else
-                       [Cmi; Cmx]))
-                  |> Lib_file_deps.deps_with_exts
-                else
-                  Lib_file_deps.deps libs
-                    ~groups:[Lib_file_deps.Group.Cmi; Cmx])
+                 List.map libs ~f:(fun lib ->
+                   (lib, if Lib.is_local lib then
+                      [Lib_file_deps.Group.Cmi]
+                    else
+                      [Cmi; Cmx]))
+                 |> Lib_file_deps.deps_with_exts
+               else
+                 Lib_file_deps.deps libs
+                   ~groups:[Lib_file_deps.Group.Cmi; Cmx])
           ]
       in
       { cmi = cmi_includes

--- a/src/config.ml
+++ b/src/config.ml
@@ -2,18 +2,18 @@ open! Stdune
 open! Import
 
 let local_install_dir =
-  let dir = Path.relative Path.build_dir "install" in
-  fun ~context -> Path.relative dir context
+  let dir = Path.relative_exn Path.build_dir "install" in
+  fun ~context -> Path.relative_exn dir context
 
 let local_install_bin_dir ~context =
-  Path.relative (local_install_dir ~context) "bin"
+  Path.relative_exn (local_install_dir ~context) "bin"
 
 let local_install_man_dir ~context =
-  Path.relative (local_install_dir ~context) "bin"
+  Path.relative_exn (local_install_dir ~context) "bin"
 
 let local_install_lib_dir ~context ~package =
-  Path.relative
-    (Path.relative (local_install_dir ~context) "lib")
+  Path.relative_exn
+    (Path.relative_exn (local_install_dir ~context) "lib")
     (Package.Name.to_string package)
 
 let dev_null =
@@ -110,7 +110,7 @@ let decode =
 let decode = fields decode
 
 let user_config_file =
-  Path.relative (Path.of_filename_relative_to_initial_cwd Xdg.config_dir)
+  Path.relative_exn (Path.of_filename_relative_to_initial_cwd Xdg.config_dir)
     "dune/config"
 
 include Versioned_file.Make(struct type t = unit end)

--- a/src/config0.ml
+++ b/src/config0.ml
@@ -6,9 +6,9 @@ module Display = struct
     | Quiet
 
   let all =
-      [ "progress" , Progress
-      ; "verbose"  , Verbose
-      ; "short"    , Short
-      ; "quiet"    , Quiet
-      ]
+    [ "progress" , Progress
+    ; "verbose"  , Verbose
+    ; "short"    , Short
+    ; "quiet"    , Quiet
+    ]
 end

--- a/src/configurator/v1.ml
+++ b/src/configurator/v1.ml
@@ -375,8 +375,8 @@ let compile_c_prog t ?(c_flags=[]) code =
   let ok = Process.run_command_ok t ~dir
              (Process.command_args t.c_compiler (c_flags
                                                  @ [ "-I" ; t.stdlib_dir
-                                                     ; "-o" ; obj_fname
-                                                     ; "-c" ; c_fname
+                                                   ; "-o" ; obj_fname
+                                                   ; "-c" ; c_fname
                                                    ]))
   in
   if ok then

--- a/src/configurator/v1.mli
+++ b/src/configurator/v1.mli
@@ -15,8 +15,8 @@ val ocaml_config_var     : t -> string -> string option
 val ocaml_config_var_exn : t -> string -> string
 
 (** [c_test t ?c_flags ?link_flags c_code] try to compile and link the
-   C code given in [c_code]. Return whether compilation was
-   successful. *)
+    C code given in [c_code]. Return whether compilation was
+    successful. *)
 val c_test
   :  t
   -> ?c_flags:   string list (** default: [] *)
@@ -43,7 +43,7 @@ module C_define : sig
 
       {[
         # C.C_define.import c ~includes:"caml/config.h"
-                            ["ARCH_SIXTYFOUR", Switch];;
+          ["ARCH_SIXTYFOUR", Switch];;
         - (string * Configurator.C_define.Value.t) list =
         ["ARCH_SIXTYFOUR", Switch true]
       ]}
@@ -64,7 +64,7 @@ module C_define : sig
       {[
         #ifndef BLAH
         #define BLAH
-        ...
+          ...
         #endif
       ]}
 
@@ -83,7 +83,7 @@ module Pkg_config : sig
 
   val get : configurator -> t option
   (** Search pkg-config in the PATH.  Returns [None] if pkg-config is
-     not found. *)
+      not found. *)
 
   type package_conf =
     { libs   : string list
@@ -92,8 +92,8 @@ module Pkg_config : sig
 
   val query : t -> package:string -> package_conf option
   (** [query t ~package] query pkg-config for the [package].  The
-     package may contain a version constraint.  For example
-     "gtk+-3.0 >= 3.18".  Returns [None] if [package] is not available  *)
+      package may contain a version constraint.  For example
+      "gtk+-3.0 >= 3.18".  Returns [None] if [package] is not available  *)
 
   val query_expr : t
     -> package:string
@@ -105,10 +105,10 @@ module Pkg_config : sig
     -> package:string
     -> expr:string
     -> (package_conf, string) Result.t
-  (** [query_expr_err t ~package ~expr] query pkg-config for the
-     [package]. [expr] may contain a version constraint, for example
-     "gtk+-3.0 >= 3.18". [package] should be just the name of the
-     package. Returns [Error error_msg] if [package] is not available *)
+    (** [query_expr_err t ~package ~expr] query pkg-config for the
+        [package]. [expr] may contain a version constraint, for example
+        "gtk+-3.0 >= 3.18". [package] should be just the name of the
+        package. Returns [Error error_msg] if [package] is not available *)
 end with type configurator := t
 
 module Flags : sig
@@ -140,8 +140,8 @@ end
 
 val which : t -> string -> string option
 (** [which t prog] seek [prog] in the PATH and return the name
-   of the program prefixed with the first path where it is found.
-   Return [None] the the program is not found. *)
+    of the program prefixed with the first path where it is found.
+    Return [None] the the program is not found. *)
 
 
 (** Execute external programs. *)
@@ -152,27 +152,37 @@ module Process : sig
     ; stderr    : string
     }
 
-  val run : t -> ?dir:string -> ?env:string list ->
-            string -> string list -> result
+  val run
+    :  t
+    -> ?dir:string
+    -> ?env:string list
+    -> string
+    -> string list
+    -> result
   (** [run t prog args] runs [prog] with arguments [args] and returns
-     its exit status together with the content of stdout and stderr.
-     The action is logged.
+      its exit status together with the content of stdout and stderr.
+      The action is logged.
 
-     @param dir change to [dir] before running the command.
-     @param env specify additional environment variables as a list of
-     the form NAME=VALUE. *)
+      @param dir change to [dir] before running the command.
+      @param env specify additional environment variables as a list of
+      the form NAME=VALUE. *)
 
-  val run_capture_exn : t -> ?dir:string -> ?env:string list ->
-                        string -> string list -> string
+  val run_capture_exn
+    :  t
+    -> ?dir:string
+    -> ?env:string list
+    -> string
+    -> string list
+    -> string
   (** [run_capture_exn t prog args] same as [run t prog args] but
-     returns [stdout] and {!die} if the error code is nonzero or there
-     is some output on [stderr].  *)
+      returns [stdout] and {!die} if the error code is nonzero or there
+      is some output on [stderr].  *)
 
   val run_ok : t -> ?dir:string -> ?env:string list ->
-               string -> string list -> bool
+    string -> string list -> bool
   (** [run_ok t prog args] same as [run t prog args] but only cares
-     whether the execution terminated successfully (i.e., returned an
-     error code of [0]).  *)
+      whether the execution terminated successfully (i.e., returned an
+      error code of [0]).  *)
 end
 
 
@@ -184,5 +194,5 @@ val main
   -> unit
 
 (** Abort execution. If raised from within [main], the argument of
-   [die] is printed as [Error: <message>]. *)
+    [die] is printed as [Error: <message>]. *)
 val die : ('a, unit, string, 'b) format4 -> 'a

--- a/src/context.mli
+++ b/src/context.mli
@@ -3,8 +3,8 @@
 (** jbuild supports two different kind of contexts:
 
     - the default context, which correspond to the environment jbuild is run, i.e. it
-    takes [ocamlc] and other tools from the [PATH] and the ocamlfind configuration where
-    it can find it
+      takes [ocamlc] and other tools from the [PATH] and the ocamlfind configuration where
+      it can find it
 
     - opam switch contexts, where one opam switch correspond to one context
 

--- a/src/coq_module.ml
+++ b/src/coq_module.ml
@@ -15,7 +15,7 @@ module Name = struct
 end
 
 (* We keep prefix and name separated as the handling of
-  `From Foo Require Bar.` may benefit from it. *)
+   `From Foo Require Bar.` may benefit from it. *)
 type t =
   { source: Path.t
   ; prefix : string list
@@ -32,8 +32,8 @@ let source x = x.source
 let prefix x = x.prefix
 let name x = x.name
 let obj_file ~obj_dir ~ext x =
-  let vo_dir = List.fold_left x.prefix ~init:obj_dir ~f:Path.relative in
-  Path.relative vo_dir (x.name ^ ext)
+  let vo_dir = List.fold_left x.prefix ~init:obj_dir ~f:Path.relative_exn in
+  Path.relative_exn vo_dir (x.name ^ ext)
 let pp fmt x =
   let open Format in
   let pp_sep fmt () = pp_print_string fmt "." in
@@ -47,8 +47,8 @@ let parse ~dir ~loc s =
     Errors.fail loc "invalid coq module"
   | name :: prefix ->
     let prefix = List.rev prefix in
-    let source = List.fold_left prefix ~init:dir ~f:Path.relative in
-    let source = Path.relative source (name ^ ".v") in
+    let source = List.fold_left prefix ~init:dir ~f:Path.relative_exn in
+    let source = Path.relative_exn source (name ^ ".v") in
     make ~name ~source ~prefix
 
 module Value = struct

--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -81,7 +81,7 @@ let setup_rule ~expander ~dir ~cc ~source_rule ~coq_flags ~file_flags
   let deps_of = Build.dyn_paths (
     Build.lines_of stdout_to >>^
     parse_coqdep ~coq_module >>^
-    List.map ~f:(Path.relative dir)
+    List.map ~f:(Path.relative_exn dir)
   ) in
 
   let cc_arg = (Arg_spec.Hidden_targets [object_to]) :: file_flags in
@@ -96,7 +96,7 @@ let setup_rule ~expander ~dir ~cc ~source_rule ~coq_flags ~file_flags
 (* TODO: remove; rgrinberg points out:
    - resolve program is actually cached,
    - better just to ask for values that we actually use.
- *)
+*)
 let create_ccoq sctx ~dir =
   let rr prg =
     SC.resolve_program ~dir sctx prg ~loc:None ~hint:"try: opam install coq" in
@@ -177,7 +177,7 @@ let coq_plugins_install_rules ~scope ~package ~dst_dir (s : Dune_file.Coq.t) =
     then
       Mode.Dict.get (Lib.plugins lib) Mode.Native |>
       List.map ~f:(fun plugin_file ->
-        let dst = Path.(to_string (relative dst_dir (basename plugin_file))) in
+        let dst = Path.(to_string (relative_exn dst_dir (basename plugin_file))) in
         None, Install.(Entry.make Section.Lib_root ~dst plugin_file))
     else []
   in
@@ -192,10 +192,10 @@ let install_rules ~sctx ~dir s =
     let dir_contents = Dir_contents.get_without_rules sctx ~dir in
     let name = Dune_file.Coq.best_name s in
     (* This is the usual root for now, Coq + Dune will change it! *)
-    let coq_root = Path.of_string "coq/user-contrib" in
+    let coq_root = Path.of_string_exn "coq/user-contrib" in
     (* This must match the wrapper prefix for now to remain compatible *)
     let dst_suffix = coqlib_wrapper_name s in
-    let dst_dir = Path.relative coq_root dst_suffix in
+    let dst_dir = Path.relative_exn coq_root dst_suffix in
     Dir_contents.coq_modules_of_library dir_contents ~name
     |> List.map ~f:(fun (vfile : Coq_module.t) ->
       let vofile = Coq_module.obj_file ~obj_dir:dir ~ext:".vo" vfile in
@@ -209,8 +209,8 @@ let coqpp_rules ~sctx ~build_dir ~dir (s : Dune_file.Coqpp.t) =
   let cc = create_ccoq sctx ~dir in
 
   let mlg_rule m =
-    let source = Path.relative dir (m ^ ".mlg") in
-    let target = Path.relative dir (m ^ ".ml") in
+    let source = Path.relative_exn dir (m ^ ".mlg") in
+    let target = Path.relative_exn dir (m ^ ".ml") in
     let args = Arg_spec.[Dep source; Hidden_targets [target]] in
     Build.run ~dir:build_dir cc.coqpp args in
 

--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -32,7 +32,7 @@ module Stanza = struct
 
   let env_vars_field =
     field
-    "env-vars"
+      "env-vars"
       ~default:Env.empty
       (Syntax.since Stanza.syntax (1, 5) >>>
        located (list (pair string string)) >>| fun (loc, pairs) ->

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -116,7 +116,7 @@ module Pkg = struct
                   adding a <package>.opam file at the root of your project.\n\
                   To declare elements to be installed as part of package %S, \
                   add a %S file at the root of your project.\nn\
-                 Root of the project as discovered by dune: %s@"
+                  Root of the project as discovered by dune: %s@"
                  name_s (Package.Name.opam_fn name)
                  (Path.Source.to_string_maybe_quoted
                     (Dune_project.root project)))
@@ -370,7 +370,7 @@ module Per_module = struct
             let+ x =
               repeat
                 (let+ (pp, names) = pair a (list module_name) in
-                (names, pp))
+                 (names, pp))
             in
             of_mapping x ~default
             |> function
@@ -918,7 +918,7 @@ module Library = struct
          located (field "self_build_stubs_archive" (option string) ~default:None)
        and+ no_dynlink = field_b "no_dynlink"
        and+ no_keep_locs = field_b "no_keep_locs"
-                            ~check:(Syntax.deprecated_in Stanza.syntax (1, 7))
+                             ~check:(Syntax.deprecated_in Stanza.syntax (1, 7))
        and+ sub_systems =
          let* () = return () in
          Sub_system_info.record_parser ()
@@ -1059,16 +1059,16 @@ module Library = struct
     in
     name ^ "_stubs"
 
-  let stubs t ~dir = Path.relative dir (stubs_name t)
+  let stubs t ~dir = Path.relative_exn dir (stubs_name t)
 
   let stubs_archive t ~dir ~ext_lib =
-    Path.relative dir (sprintf "lib%s%s" (stubs_name t) ext_lib)
+    Path.relative_exn dir (sprintf "lib%s%s" (stubs_name t) ext_lib)
 
   let dll t ~dir ~ext_dll =
-    Path.relative dir (sprintf "dll%s%s" (stubs_name t) ext_dll)
+    Path.relative_exn dir (sprintf "dll%s%s" (stubs_name t) ext_dll)
 
   let archive t ~dir ~ext =
-    Path.relative dir (Lib_name.Local.to_string (snd t.name) ^ ext)
+    Path.relative_exn dir (Lib_name.Local.to_string (snd t.name) ^ ext)
 
   let best_name t =
     match t.public with
@@ -1414,7 +1414,7 @@ module Executables = struct
   let common =
     let+ buildable = Buildable.decode
     and+ (_ : bool) = field "link_executables" ~default:true
-                       (Syntax.deleted_in Stanza.syntax (1, 0) >>> bool)
+                        (Syntax.deleted_in Stanza.syntax (1, 0) >>> bool)
     and+ link_deps = field "link_deps" (list Dep_conf.decode) ~default:[]
     and+ link_flags = field_oslu "link_flags"
     and+ modes = field "modes" Link_mode.Set.decode ~default:Link_mode.Set.default
@@ -2007,7 +2007,7 @@ module Tests = struct
        and+ package = field_o "package" Pkg.decode
        and+ locks = field "locks" (list String_with_vars.decode) ~default:[]
        and+ modes = field "modes" Executables.Link_mode.Set.decode
-                     ~default:Executables.Link_mode.Set.default
+                      ~default:Executables.Link_mode.Set.default
        and+ deps =
          field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty
        and+ enabled_if = enabled_if
@@ -2242,7 +2242,7 @@ module Stanzas = struct
       | Include (loc, fn) ->
         let include_stack = (loc, current_file) :: include_stack in
         let dir = Path.Source.parent_exn current_file in
-        let current_file = Path.Source.relative dir fn in
+        let current_file = Path.Source.relative_exn dir fn in
         if not (Path.exists (Path.source current_file)) then
           Errors.fail loc "File %s doesn't exist."
             (Path.Source.to_string_maybe_quoted current_file);

--- a/src/dune_init.ml
+++ b/src/dune_init.ml
@@ -50,7 +50,7 @@ module File = struct
 
   let full_path = function
     | Dune {path; name; _} | Text {path; name; _} ->
-       Path.relative path name
+      Path.relative_exn path name
 
   (** Inspection and manipulation of stanzas in a file *)
   module Stanza = struct
@@ -122,7 +122,7 @@ module File = struct
 
   let load_dune_file ~path =
     let name = "dune" in
-    let full_path = Path.relative path name in
+    let full_path = Path.relative_exn path name in
     let content =
       if not (Path.exists full_path) then
         []
@@ -136,7 +136,7 @@ module File = struct
     Dune {path; name; content}
 
   let write_dune_file (dune_file : dune) =
-    let path = Path.relative dune_file.path dune_file.name in
+    let path = Path.relative_exn dune_file.path dune_file.name in
     Format_dune_lang.write_file ~path dune_file.content
 
   let write f =
@@ -166,7 +166,7 @@ module Init_context = struct
     let dir =
       match path with
       | None -> Path.root
-      | Some p -> Path.of_string p
+      | Some p -> Path.of_string_exn p
     in
     File.create_dir dir;
     { dir; project }
@@ -325,9 +325,9 @@ module Component = struct
     | Ok _ -> ()
     | Error path ->
       Errors.kerrf ~f:print_to_console
-         "@{<warning>Warning@}: file @{<kwd>%a@} was not created \
-          because it already exists\n"
-         Path.pp path
+        "@{<warning>Warning@}: file @{<kwd>%a@} was not created \
+         because it already exists\n"
+        Path.pp path
 
   let create target =
     File.create_dir target.dir;

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -124,8 +124,8 @@ module Cst : sig
       | Legacy
       (** Legacy for jbuild files: either block comments or sexp
           comments. The programmer is responsible for fetching the
-         comment contents using the location. *)
-    end
+          comment contents using the location. *)
+  end
 
   type t =
     | Atom of Loc.t * Atom.t

--- a/src/dune_lang/template.ml
+++ b/src/dune_lang/template.ml
@@ -13,19 +13,19 @@ let compare_var_syntax x y =
   | Dollar_paren, Dollar_brace -> Ordering.Gt
 
 let compare_var_no_loc v1 v2 =
-   match String.compare v1.name v2.name with
-   | Ordering.Lt | Gt as a -> a
-   | Eq ->
-       match Option.compare String.compare v1.payload v2.payload with
-       | Ordering.Lt | Gt as a -> a
-       | Eq -> compare_var_syntax v1.syntax v2.syntax
+  match String.compare v1.name v2.name with
+  | Ordering.Lt | Gt as a -> a
+  | Eq ->
+    match Option.compare String.compare v1.payload v2.payload with
+    | Ordering.Lt | Gt as a -> a
+    | Eq -> compare_var_syntax v1.syntax v2.syntax
 
 let compare_part p1 p2 =
-   match p1, p2 with
-   | Text s1, Text s2 -> String.compare s1 s2
-   | Var v1, Var v2 -> compare_var_no_loc v1 v2
-   | Text _, Var _ -> Ordering.Lt
-   | Var _, Text _ -> Ordering.Gt
+  match p1, p2 with
+  | Text s1, Text s2 -> String.compare s1 s2
+  | Var v1, Var v2 -> compare_var_no_loc v1 v2
+  | Text _, Var _ -> Ordering.Lt
+  | Var _, Text _ -> Ordering.Gt
 
 let compare_no_loc t1 t2 =
   match List.compare ~compare:compare_part t1.parts t2.parts with

--- a/src/dune_load.ml
+++ b/src/dune_load.ml
@@ -45,7 +45,7 @@ module Dune_files = struct
     ; ignore_promoted_rules : bool
     }
 
-  let generated_dune_files_dir = Path.relative Path.build_dir ".dune"
+  let generated_dune_files_dir = Path.relative_exn Path.build_dir ".dune"
 
   let ensure_parent_dir_exists path =
     if Path.is_in_build_dir path then
@@ -171,7 +171,7 @@ end
     in
     Fiber.parallel_map dynamic ~f:(fun { dir; file; project; kind } ->
       let generated_dune_file =
-        Path.append_source (Path.relative generated_dune_files_dir context.name) file
+        Path.append_source (Path.relative_exn generated_dune_files_dir context.name) file
       in
       let wrapper = Path.extend_basename generated_dune_file ~suffix:".ml" in
       ensure_parent_dir_exists generated_dune_file;

--- a/src/dune_package.ml
+++ b/src/dune_package.ml
@@ -40,7 +40,7 @@ module Lib = struct
     let dir = Obj_dir.dir obj_dir in
     let map_path p =
       if Path.is_managed p then
-        Path.relative dir (Path.basename p)
+        Path.relative_exn dir (Path.basename p)
       else
         p
     in
@@ -80,7 +80,7 @@ module Lib = struct
 
   let dir_of_name name =
     let (_, components) = Lib_name.split name in
-    Path.Local.L.relative Path.Local.root components
+    Path.Local.L.relative_exn Path.Local.root components
 
   let encode ~package_root
         { loc = _ ; kind ; synopsis ; name ; archives ; plugins
@@ -166,10 +166,10 @@ module Lib = struct
       and+ orig_src_dir = field_o "orig_src_dir" path
       and+ modules = field_o "modules" (Lib_modules.decode
                                           ~implements:(Option.is_some implements) ~obj_dir)
-       and+ special_builtin_support =
-         field_o "special_builtin_support"
-           (Syntax.since Stanza.syntax (1, 10) >>>
-            Dune_file.Library.Special_builtin_support.decode)
+      and+ special_builtin_support =
+        field_o "special_builtin_support"
+          (Syntax.since Stanza.syntax (1, 10) >>>
+           Dune_file.Library.Special_builtin_support.decode)
       in
       let modes = Mode.Dict.Set.of_list modes in
       { kind

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -113,7 +113,7 @@ end = struct
       | "." -> anonymous_root
       | _ when s.[0] = '.' ->
         let p =
-          Path.of_string
+          Path.of_string_exn
             (String.split s ~on:'.'
              |> List.tl
              |> String.concat ~sep:"/")
@@ -736,7 +736,7 @@ let anonymous = lazy (
   let name = Name.anonymous_root in
   let project_file =
     { Project_file.
-      file = Path.Source.relative Path.Source.root filename
+      file = Path.Source.relative_exn Path.Source.root filename
     ; exists = false
     ; project_name = name
     }
@@ -858,7 +858,7 @@ let parse ~dir ~lang ~packages ~file =
      })
 
 let load_dune_project ~dir packages =
-  let file = Path.Source.relative dir filename in
+  let file = Path.Source.relative_exn dir filename in
   load (Path.source file) ~f:(fun lang -> parse ~dir ~lang ~packages ~file)
 
 let make_jbuilder_project ~dir packages =
@@ -866,7 +866,7 @@ let make_jbuilder_project ~dir packages =
   let name = default_name ~dir:(Path.source dir) ~packages in
   let project_file =
     { Project_file.
-      file = Path.Source.relative dir filename
+      file = Path.Source.relative_exn dir filename
     ; exists = false
     ; project_name = name
     }
@@ -907,7 +907,7 @@ let load ~dir ~files =
         let version =
           let open Option.O in
           let* opam =
-            let opam_file = Path.Source.relative dir fn in
+            let opam_file = Path.Source.relative_exn dir fn in
             match Opam_file.load (Path.source opam_file) with
             | s -> Some s
             | exception exn ->

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -112,7 +112,7 @@ module Linkage = struct
 end
 
 let exe_path_from_name cctx ~name ~(linkage : Linkage.t) =
-  Path.relative (CC.dir cctx) (name ^ linkage.ext)
+  Path.relative_exn (CC.dir cctx) (name ^ linkage.ext)
 
 let link_exe
       ~loc

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -236,7 +236,11 @@ let expand_and_record acc ~map_exe ~dep_kind ~scope
       ~(cc : dir:Path.t -> (unit, Value.t list) Build.t C.Kind.Dict.t) =
   let key = String_with_vars.Var.full_name pform in
   let loc = String_with_vars.Var.loc pform in
-  let relative = Path.relative ~error_loc:loc in
+  let relative t s =
+    match Path.relative t s with
+    | Ok s -> s
+    | Error e -> Errors.fail loc "%s" e
+  in
   let add_ddep =
     match expansion_kind with
     | Static -> fun _ ->

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -2,11 +2,11 @@
     It has two modes of expansion:
 
     1. Static. In this mode it will only expand variables that do not introduce
-       dependncies
+    dependncies
 
     2. Dynamic. In this mode, the expander will record dependencies that are
-       introduced by forms it has failed to expand. Later, these dependenceis
-       can be filled for a full expansion.*)
+    introduced by forms it has failed to expand. Later, these dependenceis
+    can be filled for a full expansion.*)
 open Stdune
 
 type t

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -98,7 +98,7 @@ val map_all_unit : 'a list -> f:('a -> unit t) -> unit t
         fork f >>= fun a ->
         fork g >>= fun b ->
         both (Future.wait a) (Future.wait b)
-      ]}
+    ]}
 *)
 val fork_and_join : (unit -> 'a t) -> (unit -> 'b t) -> ('a * 'b) t
 
@@ -177,7 +177,7 @@ module Var : sig
       {[
         set v x (get_exn v >>| fun y -> x = y)
       ]}
- *)
+  *)
   val set : 'a t -> 'a -> (unit -> 'b fiber) -> 'b fiber
   val set_sync : 'a t -> 'a -> (unit -> 'b) -> 'b
 

--- a/src/file_binding.ml
+++ b/src/file_binding.ml
@@ -6,7 +6,7 @@ type ('src, 'dst) t =
   }
 
 module Expanded = struct
-  type nonrec t = (Loc.t * Path.t, Loc.t * Path.Relative.t) t
+  type nonrec t = (Loc.t * Path.t, Loc.t * Path.Local.t) t
 
   let src t = snd t.src
   let dst t = Option.map ~f:snd t.dst
@@ -21,10 +21,10 @@ module Expanded = struct
       let basename = Path.basename src in
       String.drop_suffix basename ~suffix:".exe"
       |> Option.value ~default:basename
-      |> Path.Relative.of_string_exn
+      |> Path.Local.of_string_exn
 
   let dst_path t ~dir =
-    Path.append_relative dir (dst_basename t)
+    Path.append_local dir (dst_basename t)
 end
 
 module Unexpanded = struct
@@ -54,7 +54,7 @@ module Unexpanded = struct
     ; dst =
         let f sw =
           let (loc, p) = f sw in
-          (loc, Path.Relative.of_string_exn p)
+          (loc, Path.Local.of_string_exn p)
         in
         Option.map ~f t.dst
     }

--- a/src/file_binding.ml
+++ b/src/file_binding.ml
@@ -6,7 +6,7 @@ type ('src, 'dst) t =
   }
 
 module Expanded = struct
-  type nonrec t = (Loc.t * Path.t, Loc.t * Path.Local.t) t
+  type nonrec t = (Loc.t * Path.t, Loc.t * Path.Relative.t) t
 
   let src t = snd t.src
   let dst t = Option.map ~f:snd t.dst
@@ -21,10 +21,10 @@ module Expanded = struct
       let basename = Path.basename src in
       String.drop_suffix basename ~suffix:".exe"
       |> Option.value ~default:basename
-      |> Path.Local.of_string
+      |> Path.Relative.of_string
 
   let dst_path t ~dir =
-    Path.append_local dir (dst_basename t)
+    Path.append_relative dir (dst_basename t)
 end
 
 module Unexpanded = struct
@@ -54,7 +54,7 @@ module Unexpanded = struct
     ; dst =
         let f sw =
           let (loc, p) = f sw in
-          (loc, Path.Local.of_string p)
+          (loc, Path.Relative.of_string p)
         in
         Option.map ~f t.dst
     }

--- a/src/file_binding.ml
+++ b/src/file_binding.ml
@@ -21,7 +21,7 @@ module Expanded = struct
       let basename = Path.basename src in
       String.drop_suffix basename ~suffix:".exe"
       |> Option.value ~default:basename
-      |> Path.Relative.of_string
+      |> Path.Relative.of_string_exn
 
   let dst_path t ~dir =
     Path.append_relative dir (dst_basename t)
@@ -35,7 +35,7 @@ module Unexpanded = struct
     ; dst = Some (String_with_vars.make_text locd dst)
     }
 
-  let expand_src t ~dir ~f = Path.relative dir (f t.src)
+  let expand_src t ~dir ~f = Path.relative_exn dir (f t.src)
 
   let destination_relative_to_install_path t ~section ~expand ~expand_partial =
     let dst = Option.map ~f:expand t.dst in
@@ -48,13 +48,13 @@ module Unexpanded = struct
     let f sw = (String_with_vars.loc sw, f sw) in
     let src =
       let (loc, expanded) = f t.src in
-      (loc, Path.relative dir expanded)
+      (loc, Path.relative_exn dir expanded)
     in
     { src
     ; dst =
         let f sw =
           let (loc, p) = f sw in
-          (loc, Path.Relative.of_string p)
+          (loc, Path.Relative.of_string_exn p)
         in
         Option.map ~f t.dst
     }

--- a/src/file_binding.mli
+++ b/src/file_binding.mli
@@ -4,7 +4,7 @@ module Expanded : sig
   type t
 
   val src : t -> Path.t
-  val dst : t -> Path.Local.t option
+  val dst : t -> Path.Relative.t option
 
   val src_loc : t -> Loc.t
 

--- a/src/file_binding.mli
+++ b/src/file_binding.mli
@@ -4,7 +4,7 @@ module Expanded : sig
   type t
 
   val src : t -> Path.t
-  val dst : t -> Path.Relative.t option
+  val dst : t -> Path.Local.t option
 
   val src_loc : t -> Loc.t
 

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -39,7 +39,7 @@ module Dir : sig
   val sub_dir_names : t -> String.Set.t
 
   (** Whether this directory is ignored by an [ignored_subdirs] stanza
-     or [jbuild-ignore] file in one of its ancestor directories. *)
+      or [jbuild-ignore] file in one of its ancestor directories. *)
   val ignored : t -> bool
 
   val vcs : t -> Vcs.t option

--- a/src/format_dune_lang.ml
+++ b/src/format_dune_lang.ml
@@ -43,8 +43,8 @@ let pp_simple fmt t =
 let print_wrapped_list fmt =
   Format.fprintf fmt "(@[<hov 1>%a@])"
     (Fmt.list
-      ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")
-      pp_simple
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")
+       pp_simple
     )
 
 let pp_comment_line fmt l =

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -24,7 +24,7 @@ let rec subdirs_until_root dir =
 
 let depend_on_files ~named dir =
   subdirs_until_root dir
-  |> List.concat_map ~f:(fun dir -> List.map named ~f:(Path.relative dir))
+  |> List.concat_map ~f:(fun dir -> List.map named ~f:(Path.relative_exn dir))
   |> Build.paths_existing
 
 let formatted = ".formatted"
@@ -43,8 +43,8 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
   let setup_formatting file =
     let open Build.O in
     let input_basename = Path.Source.basename file in
-    let input = Path.relative dir input_basename in
-    let output = Path.relative output_dir input_basename in
+    let input = Path.relative_exn dir input_basename in
+    let output = Path.relative_exn output_dir input_basename in
 
     let ocaml kind =
       if Dune_file.Auto_format.includes config Ocaml then
@@ -89,7 +89,7 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
   Build_system.Alias.add_deps alias_formatted Path.Set.empty
 
 let gen_rules ~dir =
-  let output_dir = Path.relative dir formatted in
+  let output_dir = Path.relative_exn dir formatted in
   let alias = Alias.fmt ~dir in
   let alias_formatted = Alias.fmt ~dir:output_dir in
   Alias.stamp_file alias_formatted

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -88,13 +88,13 @@ module Backend = struct
       let f x = Lib_name.encode (Lib.name x.lib) in
       ((1, 0),
        record_fields @@
-         [ field_l "runner_libraries" lib (Result.ok_exn t.runner_libraries)
-         ; field_i "flags" Ordered_set_lang.Unexpanded.encode_and_upgrade
-             t.info.flags
-         ; field_o "generate_runner" Action_dune_lang.encode_and_upgrade
-             (Option.map t.info.generate_runner ~f:snd)
-         ; field_l "extends" f (Result.ok_exn t.extends)
-         ])
+       [ field_l "runner_libraries" lib (Result.ok_exn t.runner_libraries)
+       ; field_i "flags" Ordered_set_lang.Unexpanded.encode_and_upgrade
+           t.info.flags
+       ; field_o "generate_runner" Action_dune_lang.encode_and_upgrade
+           (Option.map t.info.generate_runner ~f:snd)
+       ; field_l "extends" f (Result.ok_exn t.extends)
+       ])
   end
   include M
   include Sub_system.Register_backend(M)
@@ -168,7 +168,7 @@ include Sub_system.Register_end_point(
         sprintf "%s.inline-tests" (Lib_name.Local.to_string (snd lib.name))
       in
 
-      let inline_test_dir = Path.relative dir ("." ^ inline_test_name) in
+      let inline_test_dir = Path.relative_exn dir ("." ^ inline_test_name) in
 
       let obj_dir =
         Obj_dir.make_exe ~dir:inline_test_dir ~name:inline_test_name in
@@ -179,7 +179,7 @@ include Sub_system.Register_end_point(
       let modules =
         Module.Name.Map.singleton main_module_name
           (Module.make main_module_name
-             ~impl:{ path   = Path.relative inline_test_dir main_module_filename
+             ~impl:{ path   = Path.relative_exn inline_test_dir main_module_filename
                    ; syntax = OCaml
                    }
              ~kind:Impl
@@ -213,7 +213,7 @@ include Sub_system.Register_end_point(
 
       (* Generate the runner file *)
       SC.add_rule sctx ~dir ~loc (
-        let target = Path.relative inline_test_dir main_module_filename in
+        let target = Path.relative_exn inline_test_dir main_module_filename in
         let source_modules = Module.Name.Map.values source_modules in
         let files ml_kind =
           Pform.Var.Values (Value.L.paths (
@@ -277,7 +277,7 @@ include Sub_system.Register_end_point(
         (Alias.runtest ~dir)
         ~stamp:("ppx-runner", name)
         (let module A = Action in
-         let exe = Path.relative inline_test_dir (name ^ ".exe") in
+         let exe = Path.relative_exn inline_test_dir (name ^ ".exe") in
          Build.path exe >>>
          Build.fanout
            (Super_context.Deps.interpret sctx info.deps ~expander)

--- a/src/install.ml
+++ b/src/install.ml
@@ -174,26 +174,26 @@ module Section = struct
       ; man          : Path.t
       }
 
-    let make ~package ~destdir ?(libdir=Path.relative destdir "lib") () =
+    let make ~package ~destdir ?(libdir=Path.relative_exn destdir "lib") () =
       let package = Package.Name.to_string package in
       let lib_root     = libdir                        in
       let libexec_root = libdir                        in
-      let share_root   = Path.relative destdir "share" in
-      let etc_root     = Path.relative destdir "etc"   in
-      let doc_root     = Path.relative destdir "doc"   in
+      let share_root   = Path.relative_exn destdir "share" in
+      let etc_root     = Path.relative_exn destdir "etc"   in
+      let doc_root     = Path.relative_exn destdir "doc"   in
       { lib_root
       ; libexec_root
       ; share_root
-      ; bin          = Path.relative destdir "bin"
-      ; sbin         = Path.relative destdir "sbin"
-      ; man          = Path.relative destdir "man"
-      ; toplevel     = Path.relative libdir  "toplevel"
-      ; stublibs     = Path.relative libdir  "stublibs"
-      ; lib          = Path.relative lib_root     package
-      ; libexec      = Path.relative libexec_root package
-      ; share        = Path.relative share_root   package
-      ; etc          = Path.relative etc_root     package
-      ; doc          = Path.relative doc_root     package
+      ; bin          = Path.relative_exn destdir "bin"
+      ; sbin         = Path.relative_exn destdir "sbin"
+      ; man          = Path.relative_exn destdir "man"
+      ; toplevel     = Path.relative_exn libdir  "toplevel"
+      ; stublibs     = Path.relative_exn libdir  "stublibs"
+      ; lib          = Path.relative_exn lib_root     package
+      ; libexec      = Path.relative_exn libexec_root package
+      ; share        = Path.relative_exn share_root   package
+      ; etc          = Path.relative_exn etc_root     package
+      ; doc          = Path.relative_exn doc_root     package
       }
 
     let get t section =
@@ -214,7 +214,7 @@ module Section = struct
       | Misc         -> Exn.code_error "Install.Paths.get" []
 
     let install_path t section p =
-      Path.relative (get t section) (Dst.to_string p)
+      Path.relative_exn (get t section) (Dst.to_string p)
 
   end
 end
@@ -374,11 +374,11 @@ let load_install_file path =
             | List (_, l) ->
               List.map l ~f:(function
                 | String (_, src) ->
-                  let src = Path.of_string src in
+                  let src = Path.of_string_exn src in
                   Entry.of_install_file ~src ~dst:None ~section
                 | Option (_, String (_, src),
                           [String (_, dst)]) ->
-                  let src = Path.of_string src in
+                  let src = Path.of_string_exn src in
                   Entry.of_install_file ~src ~dst:(Some dst) ~section
                 | v ->
                   fail (pos_of_opam_value v)

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -68,7 +68,7 @@ let pkg_version ~path ~(pkg : Package.t) =
     | candidate :: rest ->
       match candidate with
       | File fn ->
-        let p = Path.relative path fn in
+        let p = Path.relative_exn path fn in
         Build.if_file_exists p
           ~then_:(Build.lines_of p
                   >>^ function
@@ -305,7 +305,7 @@ let install_file sctx (package : Local_package.t) entries =
     |> List.rev_append entries
   in
   let fn =
-    Path.relative pkg_build_dir
+    Path.relative_exn pkg_build_dir
       (Utils.install_file ~package:package_name
          ~findlib_toolchain:ctx.findlib_toolchain)
   in
@@ -334,7 +334,7 @@ let install_file sctx (package : Local_package.t) entries =
          match ctx.findlib_toolchain with
          | None -> entries
          | Some toolchain ->
-           let prefix = Path.of_string (toolchain ^ "-sysroot") in
+           let prefix = Path.of_string_exn (toolchain ^ "-sysroot") in
            List.map entries
              ~f:(Install.Entry.add_install_prefix
                    ~paths:install_paths ~prefix)
@@ -414,7 +414,7 @@ let init_install_files (ctx : Context.t) (package : Local_package.t) =
     in
     let path = Local_package.build_dir package in
     let install_alias = Alias.install ~dir:path in
-    let install_file = Path.relative path install_fn in
+    let install_file = Path.relative_exn path install_fn in
     Build_system.Alias.add_deps install_alias (Path.Set.singleton install_file)
 
 let init sctx =

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -352,7 +352,7 @@ let get_install_entries package =
     List.map files ~f:(fun fb ->
       let loc = File_binding.Expanded.src_loc fb in
       let src = File_binding.Expanded.src fb in
-      let dst = Option.map ~f:Path.Local.to_string
+      let dst = Option.map ~f:Path.Relative.to_string
                   (File_binding.Expanded.dst fb) in
       ( Some loc
       , Install.Entry.make section src ?dst

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -352,7 +352,7 @@ let get_install_entries package =
     List.map files ~f:(fun fb ->
       let loc = File_binding.Expanded.src_loc fb in
       let src = File_binding.Expanded.src fb in
-      let dst = Option.map ~f:Path.Relative.to_string
+      let dst = Option.map ~f:Path.Local.to_string
                   (File_binding.Expanded.dst fb) in
       ( Some loc
       , Install.Entry.make section src ?dst

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -40,7 +40,7 @@ let runtime_file ~dir ~sctx file =
     in
     begin match jsoo ~dir sctx with
     | Ok path ->
-      let path = Path.relative (Path.parent_exn path) file in
+      let path = Path.relative_exn (Path.parent_exn path) file in
       Build.if_file_exists path ~then_:(Build.arr (fun _ -> path)) ~else_:fail
     | _ ->
       fail
@@ -65,7 +65,7 @@ let standalone_runtime_rule cc ~javascript_files ~target =
     Arg_spec.S
       [ Arg_spec.of_result_map
           (Compilation_context.requires_link cc) ~f:(fun libs ->
-          Arg_spec.Deps (Lib.L.jsoo_runtime_files libs))
+            Arg_spec.Deps (Lib.L.jsoo_runtime_files libs))
       ; Arg_spec.Deps javascript_files
       ]
   in
@@ -159,12 +159,12 @@ let setup_separate_compilation_rules sctx components =
           (* Special case for the stdlib because it is not referenced
              in the META *)
           match Lib_name.to_string (Lib.name pkg) with
-          | "stdlib" -> Path.relative ctx.stdlib_dir "stdlib.cma" :: archives
+          | "stdlib" -> Path.relative_exn ctx.stdlib_dir "stdlib.cma" :: archives
           | _ -> archives
         in
         List.iter archives ~f:(fun fn ->
           let name = Path.basename fn in
-          let src = Path.relative (Lib.src_dir pkg) name in
+          let src = Path.relative_exn (Lib.src_dir pkg) name in
           let lib_name = Lib_name.to_string (Lib.name pkg) in
           let target =
             in_build_dir ~ctx [lib_name ; sprintf "%s.js" name]
@@ -180,7 +180,7 @@ let setup_separate_compilation_rules sctx components =
 let build_exe cc ~js_of_ocaml ~src =
   let {Dune_file.Js_of_ocaml.javascript_files; _} = js_of_ocaml in
   let javascript_files =
-    List.map javascript_files ~f:(Path.relative (Compilation_context.dir cc)) in
+    List.map javascript_files ~f:(Path.relative_exn (Compilation_context.dir cc)) in
   let mk_target ext = Path.extend_basename src ~suffix:ext in
   let target = mk_target ".js" in
   let standalone_runtime = mk_target ".runtime.js" in

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1678,7 +1678,7 @@ let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects ~dir 
       | None ->
         match Path.drop_build_context info.src_dir with
         | None -> info.src_dir
-        | Some src_dir -> Path.(of_string (to_absolute_filename (Path.source src_dir)))
+        | Some src_dir -> Path.(of_string_exn (to_absolute_filename (Path.source src_dir)))
     )
     else None
   in

--- a/src/lib_archives.ml
+++ b/src/lib_archives.ml
@@ -44,9 +44,9 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
              files @ [ Library.archive ~dir lib ~ext:".cmxs" ]
            else
              files)
-      ; List.map lib.buildable.js_of_ocaml.javascript_files ~f:(Path.relative dir)
+      ; List.map lib.buildable.js_of_ocaml.javascript_files ~f:(Path.relative_exn dir)
       ; List.map lib.install_c_headers ~f:(fun fn ->
-          Path.relative dir (fn ^ ".h"))
+          Path.relative_exn dir (fn ^ ".h"))
       ]
   in
   let dlls  =

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -93,14 +93,14 @@ let of_library_stanza ~dir
     Obj_dir.make_lib ~dir
       ~has_private_modules:(conf.private_modules <> None) lib_name in
   let gen_archive_file ~dir ext =
-    Path.relative dir (Lib_name.Local.to_string lib_name ^ ext) in
+    Path.relative_exn dir (Lib_name.Local.to_string lib_name ^ ext) in
   let archive_file = gen_archive_file ~dir in
   let archive_files ~f_ext =
     Mode.Dict.of_func (fun ~mode -> [archive_file (f_ext mode)])
   in
   let jsoo_runtime =
     List.map conf.buildable.js_of_ocaml.javascript_files
-      ~f:(Path.relative dir)
+      ~f:(Path.relative_exn dir)
   in
   let status =
     match conf.public with
@@ -116,16 +116,16 @@ let of_library_stanza ~dir
         []
     in
     { Mode.Dict.
-       byte   = stubs
-     ; native =
-         Path.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib)
-         :: stubs
-     }
+      byte   = stubs
+    ; native =
+        Path.relative_exn dir (Lib_name.Local.to_string lib_name ^ ext_lib)
+        :: stubs
+    }
   in
   let foreign_archives =
     match conf.stdlib with
     | Some { exit_module = Some m; _ } ->
-      let obj_name = Path.relative dir (Module.Name.uncapitalize m) in
+      let obj_name = Path.relative_exn dir (Module.Name.uncapitalize m) in
       { Mode.Dict.
         byte =
           Path.extend_basename obj_name ~suffix:(Cm_kind.ext Cmo) ::

--- a/src/lib_modules.ml
+++ b/src/lib_modules.ml
@@ -42,7 +42,7 @@ let make_alias_module ~obj_dir ~implements ~lib_name ~stdlib
          ~visibility:Public
          ~kind:Impl
          ~impl:(Module.File.make OCaml
-                  (Path.relative dir (sprintf "%s.ml-gen" alias_prefix)))
+                  (Path.relative_exn dir (sprintf "%s.ml-gen" alias_prefix)))
          ~obj_name:alias_prefix
          ~obj_dir)
   else if Module.Name.Map.cardinal modules = 1 &&
@@ -59,7 +59,7 @@ let make_alias_module ~obj_dir ~implements ~lib_name ~stdlib
          ~visibility:Public
          ~kind:Impl
          ~impl:(Module.File.make OCaml
-                  (Path.relative dir (sprintf "%s__.ml-gen" alias_prefix)))
+                  (Path.relative_exn dir (sprintf "%s__.ml-gen" alias_prefix)))
          ~obj_name:(alias_prefix ^ "__")
          ~obj_dir)
   else
@@ -68,7 +68,7 @@ let make_alias_module ~obj_dir ~implements ~lib_name ~stdlib
          ~visibility:Public
          ~kind:Impl
          ~impl:(Module.File.make OCaml
-                  (Path.relative dir (alias_prefix ^ ".ml-gen")))
+                  (Path.relative_exn dir (alias_prefix ^ ".ml-gen")))
          ~obj_name:alias_prefix
          ~obj_dir)
 

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -16,7 +16,7 @@ val modules : t -> Module.Name_map.t
 val wrapped_compat : t -> Module.Name_map.t
 
 (** Returns the main module name if it exists. It exist for libraries with
-   [(wrapped true)] or one module libraries. *)
+    [(wrapped true)] or one module libraries. *)
 val main_module_name : t -> Module.Name.t option
 
 (** Returns only the virtual modules in the library *)

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -109,7 +109,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       |> List.map ~f:(fun (m : Module.t) ->
         let name = Module.Name.to_string (Module.name m) in
         sprintf "(** @canonical %s.%s *)\n\
-                module %s = %s\n"
+                 module %s = %s\n"
           (Module.Name.to_string main_module_name)
           name
           name
@@ -132,9 +132,9 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let modules = Lib_modules.modules lib_modules in
     let wrapped = Lib_modules.wrapped lib_modules in
     let transition_message = lazy (
-        match (wrapped : Wrapped.t) with
-        | Simple _ -> assert false
-        | Yes_with_transition r -> r)
+      match (wrapped : Wrapped.t) with
+      | Simple _ -> assert false
+      | Yes_with_transition r -> r)
     in
     Module.Name.Map.iteri wrapped_compat ~f:(fun name m ->
       let main_module_name =
@@ -260,7 +260,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         String.Set.fold (Dir_contents.text_files dc) ~init:acc
           ~f:(fun fn acc ->
             if String.is_suffix fn ~suffix:".h" then
-              Path.relative (Dir_contents.dir dc) fn :: acc
+              Path.relative_exn (Dir_contents.dir dc) fn :: acc
             else
               acc))
     in
@@ -278,7 +278,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let build_x_files build_x files =
       String.Map.to_list files
       |> List.map ~f:(fun (obj, (loc, src)) ->
-        let dst = Path.relative dir (obj ^ ctx.ext_obj) in
+        let dst = Path.relative_exn dir (obj ^ ctx.ext_obj) in
         build_x lib ~dir ~expander ~includes (loc, src, dst)
       )
     in
@@ -351,7 +351,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
             ; Cmx, ctx.ext_obj ]
             |> List.iter ~f:(fun (kind, ext) ->
               let src = Module.obj_file m ~kind ~ext in
-              let dst = Path.relative dir ((Module.obj_name m) ^ ext) in
+              let dst = Path.relative_exn dir ((Module.obj_name m) ^ ext) in
               SC.add_rule sctx ~dir (Build.copy ~src ~dst));
             Module.Name.Map.remove modules name
         end
@@ -393,12 +393,12 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
           Library.archive lib ~dir
             ~ext:(Mode.compiled_lib_ext Mode.Byte) in
         let target =
-          Path.relative (Obj_dir.obj_dir obj_dir) (Path.basename src)
+          Path.relative_exn (Obj_dir.obj_dir obj_dir) (Path.basename src)
           |> Path.extend_basename ~suffix:".js" in
         Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target);
     if Dynlink_supported.By_the_os.get ctx.natdynlink_supported
     && modes.native then
-        build_shared lib ~dir ~flags ~ctx
+      build_shared lib ~dir ~flags ~ctx
 
   let library_rules (lib : Library.t) ~dir_contents ~dir ~expander ~scope
         ~compile_info ~dir_kind =

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -12,7 +12,7 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
   let sctx       = CC.super_context cctx in
   let obj_dir    = CC.obj_dir       cctx in
   let dir        = CC.dir           cctx in
-  let ml = Path.relative (Obj_dir.obj_dir obj_dir) (basename ^ ".ml") in
+  let ml = Path.relative_exn (Obj_dir.obj_dir obj_dir) (basename ^ ".ml") in
   SC.add_rule ~dir sctx (Build.write_file ml code);
   let impl = Module.File.make OCaml ml in
   let name = Module.Name.of_string basename in

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -134,7 +134,7 @@ module Of_sctx = struct
           let files = Super_context.source_files sctx ~src_path:Path.Source.root in
           String.Set.fold files ~init:[] ~f:(fun fn acc ->
             if is_odig_doc_file fn then
-              Path.relative ctx.build_dir fn :: acc
+              Path.relative_exn ctx.build_dir fn :: acc
             else
               acc)
         in
@@ -185,7 +185,7 @@ let meta_file t = Path.append_source t.ctx_build_dir (Package.meta_file t.pkg)
 let build_dir t = Path.append_source t.ctx_build_dir t.pkg.path
 let name t = t.pkg.name
 let dune_package_file t =
-  Path.relative (build_dir t)
+  Path.relative_exn (build_dir t)
     (Package.Name.to_string (name t) ^ ".dune-package")
 
 let coqlibs t = t.coqlibs

--- a/src/log.ml
+++ b/src/log.ml
@@ -14,7 +14,7 @@ let no_log = None
 
 let create ?(display=Config.default.display) () =
   Path.ensure_build_dir_exists ();
-  let oc = Io.open_out (Path.relative Path.build_dir "log") in
+  let oc = Io.open_out (Path.relative_exn Path.build_dir "log") in
   Printf.fprintf oc "# %s\n# OCAMLPARAM: %s\n%!"
     (String.concat (List.map (Array.to_list Sys.argv) ~f:quote_for_shell) ~sep:" ")
     (match Env.get Env.initial "OCAMLPARAM" with

--- a/src/main.ml
+++ b/src/main.ml
@@ -19,7 +19,7 @@ let package_install_file w pkg =
   match Package.Name.Map.find w.conf.packages pkg with
   | None -> Error ()
   | Some p ->
-    Ok (Path.Source.relative p.path
+    Ok (Path.Source.relative_exn p.path
           (Utils.install_file ~package:p.name ~findlib_toolchain:None))
 
 let setup_env ~capture_outputs =
@@ -55,7 +55,7 @@ let scan_workspace ?(log=Log.no_log)
         Workspace.load ?x ?profile p
       | None ->
         match
-          let p = Path.of_string Workspace.filename in
+          let p = Path.of_string_exn Workspace.filename in
           Option.some_if (Path.exists p) p
         with
         | Some p -> Workspace.load ?x ?profile p
@@ -162,7 +162,7 @@ let set_concurrency ?log (config : Config.t) =
 let bootstrap () =
   Colors.setup_err_formatter_colors ();
   Path.set_root Path.External.initial_cwd;
-  Path.set_build_dir (Path.Kind.of_string "_boot");
+  Path.set_build_dir (Path.Kind.of_string_exn "_boot");
   let main () =
     let anon s = raise (Arg.Bad (Printf.sprintf "don't know what to do with %s\n" s)) in
     let subst () =
@@ -223,14 +223,14 @@ let bootstrap () =
       (fun () ->
          let* () = set_concurrency config in
          let* workspace =
-          scan_workspace ~log ~workspace:(Workspace.default ?profile:!profile ())
-            ?profile:!profile ~ancestor_vcs:None
-            ()
+           scan_workspace ~log ~workspace:(Workspace.default ?profile:!profile ())
+             ?profile:!profile ~ancestor_vcs:None
+             ()
          in
          let* _ = init_build_system workspace in
          Build_system.do_build
            ~request:(Build.path (
-             Path.relative Path.build_dir "default/dune.install")))
+             Path.relative_exn Path.build_dir "default/dune.install")))
   in
   try
     main ()

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -33,10 +33,10 @@ end = struct
 
   let create (type a) (module I : Implicit_output with type t = a) =
     ((module struct
-       type nonrec a = a
-       type _ w += W : a w
-       include I
-     end) : a t)
+      type nonrec a = a
+      type _ w += W : a w
+      include I
+    end) : a t)
   ;;
 
   let get (type a) (module T : T with type a = a) =

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -447,8 +447,8 @@ let create (type i) (type o) (type f)
         Some f, (fun x -> Fdecl.get f x)
       in
       ((match typ with
-       | Function_type.Sync -> decl_and_get ()
-       | Function_type.Async -> decl_and_get ()) : f Fdecl.t option * f)
+         | Function_type.Sync -> decl_and_get ()
+         | Function_type.Async -> decl_and_get ()) : f Fdecl.t option * f)
     | Some f ->
       None, f
   in
@@ -490,7 +490,7 @@ let create (type i) (type o) (type f)
   }
 
 module Exec_sync = struct
-    let compute t inp dep_node =
+  let compute t inp dep_node =
     (* define the function to update / double check intermediate result *)
     (* set context of computation then run it *)
     let res = Call_stack.push_sync_frame (T dep_node) (fun () -> match t.spec.f with
@@ -755,12 +755,12 @@ module With_implicit_output = struct
     | Function_type.Sync ->
       let memo =
         (create
-             name
-             ~doc ~input ~visibility
-             ~output
-             Sync
-             (Some (fun i ->
-                Implicit_output.collect_sync implicit_output (fun () -> impl i))))
+           name
+           ~doc ~input ~visibility
+           ~output
+           Sync
+           (Some (fun i ->
+              Implicit_output.collect_sync implicit_output (fun () -> impl i))))
       in
       ((fun input ->
          let (res, output) = exec memo input in
@@ -770,12 +770,12 @@ module With_implicit_output = struct
     | Function_type.Async ->
       let memo =
         (create
-             name
-             ~doc ~input ~visibility
-             ~output
-             Async
-             (Some (fun i ->
-                Implicit_output.collect_async implicit_output (fun () -> impl i))))
+           name
+           ~doc ~input ~visibility
+           ~output
+           Async
+           (Some (fun i ->
+              Implicit_output.collect_async implicit_output (fun () -> impl i))))
       in
       ((fun input ->
          Fiber.map
@@ -783,7 +783,7 @@ module With_implicit_output = struct
            ~f:(fun (res, output) ->
              Implicit_output.produce_opt implicit_output output;
              res)
-      ) : f)
+       ) : f)
   ;;
 
   let exec t = t

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -76,11 +76,11 @@ module Run (P : PARAMS) : sig end = struct
      that Menhir must build. *)
 
   let source m =
-    Path.relative dir (m ^ ".mly")
+    Path.relative_exn dir (m ^ ".mly")
 
   let targets m ~cmly =
     let base = [m ^ ".ml"; m ^ ".mli"] in
-    List.map ~f:(Path.relative dir) (
+    List.map ~f:(Path.relative_exn dir) (
       if cmly then
         (m ^ ".cmly") :: base
       else
@@ -100,10 +100,10 @@ module Run (P : PARAMS) : sig end = struct
     m ^ "__mock"
 
   let mock_ml m : Path.t =
-    Path.relative dir (mock m ^ ".ml.mock")
+    Path.relative_exn dir (mock m ^ ".ml.mock")
 
   let inferred_mli m : Path.t =
-    Path.relative dir (mock m ^ ".mli.inferred")
+    Path.relative_exn dir (mock m ^ ".mli.inferred")
 
   (* ------------------------------------------------------------------------ *)
 
@@ -199,7 +199,7 @@ module Run (P : PARAMS) : sig end = struct
       menhir
         [ Dyn (fun flags -> As flags)
         ; Deps (sources stanza.modules)
-        ; A "--base" ; Path (Path.relative dir base)
+        ; A "--base" ; Path (Path.relative_exn dir base)
         ; A "--infer-write-query"; Target (mock_ml base)
         ]
     );
@@ -242,7 +242,7 @@ module Run (P : PARAMS) : sig end = struct
       menhir
         [ Dyn (fun flags -> As flags)
         ; Deps (sources stanza.modules)
-        ; A "--base" ; Path (Path.relative dir base)
+        ; A "--base" ; Path (Path.relative_exn dir base)
         ; A "--infer-read-reply"; Dep (inferred_mli base)
         ; Hidden_targets (targets base ~cmly)
         ]
@@ -261,7 +261,7 @@ module Run (P : PARAMS) : sig end = struct
       menhir
         [ Dyn (fun flags -> As flags)
         ; Deps (sources stanza.modules)
-        ; A "--base" ; Path (Path.relative dir base)
+        ; A "--base" ; Path (Path.relative_exn dir base)
         ; Hidden_targets (targets base ~cmly)
         ]
     )

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -9,8 +9,8 @@ let warn_dropped_pp loc ~allow_approx_merlin ~reason =
   if not allow_approx_merlin then
     Errors.warn loc
       ".merlin generated is inaccurate. %s.\n\
-        Split the stanzas into different directories or silence this warning \
-        by adding (allow_approximate_merlin) to your dune-project."
+       Split the stanzas into different directories or silence this warning \
+       by adding (allow_approximate_merlin) to your dune-project."
       reason
 
 module Preprocess = struct
@@ -127,20 +127,20 @@ let pp_flags sctx ~expander ~dir_kind { preprocess; libname; _ } =
           (Super_context.context sctx).version
   with
   | Pps { loc = _; pps; flags; staged = _ } -> begin
-    match Preprocessing.get_ppx_driver sctx ~scope ~dir_kind pps with
-    | Error _ -> None
-    | Ok exe ->
-      let flags = List.map ~f:(Expander.expand_str expander) flags in
-      (Path.to_absolute_filename exe
-       :: "--as-ppx"
-       :: Preprocessing.cookie_library_name libname
-       @ flags)
-      |> List.map ~f:quote_for_merlin
-      |> String.concat ~sep:" "
-      |> Filename.quote
-      |> sprintf "FLG -ppx %s"
-      |> Option.some
-  end
+      match Preprocessing.get_ppx_driver sctx ~scope ~dir_kind pps with
+      | Error _ -> None
+      | Ok exe ->
+        let flags = List.map ~f:(Expander.expand_str expander) flags in
+        (Path.to_absolute_filename exe
+         :: "--as-ppx"
+         :: Preprocessing.cookie_library_name libname
+         @ flags)
+        |> List.map ~f:quote_for_merlin
+        |> String.concat ~sep:" "
+        |> Filename.quote
+        |> sprintf "FLG -ppx %s"
+        |> Option.some
+    end
   | Action (_, (action : Action_dune_lang.t)) ->
     begin match action with
     | Run (exe, args) ->
@@ -173,7 +173,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
   match Path.drop_build_context dir with
   | None -> ()
   | Some remaindir ->
-    let merlin_file = Path.relative dir ".merlin" in
+    let merlin_file = Path.relative_exn dir ".merlin" in
     (* We make the compilation of .ml/.mli files depend on the
        existence of .merlin so that they are always generated, however
        the command themselves don't read the merlin file, so we don't
@@ -185,7 +185,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
     SC.add_rule sctx ~dir
       (Build.path merlin_file
        >>>
-       Build.create_file (Path.relative dir ".merlin-exists"));
+       Build.create_file (Path.relative_exn dir ".merlin-exists"));
     Path.Set.singleton merlin_file
     |> Build_system.Alias.add_deps (Alias.check ~dir);
     SC.add_rule sctx ~dir

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -239,7 +239,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   let unix = simple "unix" [] ~dir:"+" in
   let bigarray =
     if Ocaml_version.stdlib_includes_bigarray ocaml_version &&
-       not (Path.exists (Path.relative stdlib_dir "bigarray.cma")) then
+       not (Path.exists (Path.relative_exn stdlib_dir "bigarray.cma")) then
       dummy "bigarray"
     else
       simple "bigarray" ["unix"] ~dir:"+"
@@ -293,7 +293,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
     (* We do not rely on an "exists_if" ocamlfind variable,
        because it would produce an error message mentioning
        a "hidden" package (which could be confusing). *)
-    if Path.exists (Path.relative stdlib_dir "nums.cma") then
+    if Path.exists (Path.relative_exn stdlib_dir "nums.cma") then
       num :: base
     else
       base
@@ -333,9 +333,9 @@ let pp_quoted_value var =
   match var with
   | "archive" | "plugin" | "requires"
   | "ppx_runtime_deps" | "linkopts" | "jsoo_runtime" ->
-     pp_print_text
+    pp_print_text
   | _ ->
-     pp_print_string
+    pp_print_string
 
 let rec pp ppf entries =
   Format.fprintf ppf "@[<v>%a@]" (pp_list pp_entry) entries

--- a/src/module.ml
+++ b/src/module.ml
@@ -225,7 +225,7 @@ let file t (kind : Ml_kind.t) =
 
 let obj_file t ~kind ~ext =
   let base = Obj_dir.cm_dir t.obj_dir kind t.visibility in
-  Path.relative base (t.obj_name ^ ext)
+  Path.relative_exn base (t.obj_name ^ ext)
 
 let obj_name t = t.obj_name
 
@@ -243,7 +243,7 @@ let cm_file t ?ext (kind : Cm_kind.t) =
 let cm_public_file_unsafe t ?ext kind =
   let ext = Option.value ext ~default:(Cm_kind.ext kind) in
   let base = Obj_dir.cm_public_dir t.obj_dir kind in
-  Path.relative base (t.obj_name ^ ext)
+  Path.relative_exn base (t.obj_name ^ ext)
 
 let cm_public_file t ?ext (kind : Cm_kind.t) =
   match kind with
@@ -262,7 +262,7 @@ let odoc_file t ~doc_dir =
     | Public -> doc_dir
     | Private -> Utils.library_private_dir ~obj_dir:doc_dir
   in
-  Path.relative base (t.obj_name ^ ".odoc")
+  Path.relative_exn base (t.obj_name ^ ".odoc")
 
 let cmti_file t =
   match t.intf with
@@ -441,7 +441,7 @@ let decode ~obj_dir =
     let file exists ml_kind =
       if exists then
         let basename = Name.basename name ~ml_kind ~syntax:OCaml in
-        Some (File.make Syntax.OCaml (Path.relative dir basename))
+        Some (File.make Syntax.OCaml (Path.relative_exn dir basename))
       else
         None
     in
@@ -485,11 +485,11 @@ module Source = struct
   let name t = t.name
 
   let src_dir t =
-  match t.intf, t.impl with
-  | None, None -> None
-  | Some x, Some _
-  | Some x, None
-  | None, Some x -> Some (Path.parent_exn x.path)
+    match t.intf, t.impl with
+    | None, None -> None
+    | Some x, Some _
+    | Some x, None
+    | None, Some x -> Some (Path.parent_exn x.path)
 
 end
 

--- a/src/module.mli
+++ b/src/module.mli
@@ -97,7 +97,7 @@ val src_dir : t -> Path.t option
 (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx]
     and the module has no implementation.
     If present [ext] replace the extension of the kind
- *)
+*)
 val cm_file_unsafe : t -> ?ext:string -> Cm_kind.t -> Path.t
 val cm_public_file_unsafe : t -> ?ext:string -> Cm_kind.t -> Path.t
 

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -91,10 +91,11 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
       if CC.dir_kind cctx = Jbuild then begin
         (* Symlink the object files in the original directory for
            backward compatibility *)
-        let old_dst = Path.relative dir ((Module.obj_name m) ^ (Cm_kind.ext cm_kind)) in
+        let old_dst =
+          Path.relative_exn dir ((Module.obj_name m) ^ (Cm_kind.ext cm_kind)) in
         SC.add_rule sctx ~dir (Build.symlink ~src:dst ~dst:old_dst);
         List.iter other_targets ~f:(fun in_obj_dir ->
-          let in_dir = Path.relative dir (Path.basename in_obj_dir) in
+          let in_dir = Path.relative_exn dir (Path.basename in_obj_dir) in
           SC.add_rule sctx ~dir (Build.symlink ~src:in_obj_dir ~dst:in_dir))
       end;
       let opaque_arg =

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -6,7 +6,7 @@ open Import
 
     @param dynlink if false disables the possibility to dynamically
     link. The module can't be in a .cmxs or .so (default true).
- *)
+*)
 val build_module
   :  ?sandbox:bool
   -> ?js_of_ocaml:Dune_file.Js_of_ocaml.t

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -10,7 +10,7 @@ module External = struct
   let make ~dir ~has_private_modules =
     let private_dir =
       if has_private_modules then
-        Some (Path.relative dir ".private")
+        Some (Path.relative_exn dir ".private")
       else
         None
     in
@@ -60,7 +60,7 @@ module External = struct
       let+ private_dir = field_o "private_dir" string
       in
       let public_dir = dir in
-      let private_dir = Option.map ~f:(Path.relative dir) private_dir in
+      let private_dir = Option.map ~f:(Path.relative_exn dir) private_dir in
       { public_dir
       ; private_dir
       }

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -406,7 +406,7 @@ let make vars =
     in
 
     let file =
-      Path.relative (Path.of_string standard_library) "Makefile.config"
+      Path.relative_exn (Path.of_string_exn standard_library) "Makefile.config"
     in
     let vars = Vars.load_makefile_config file in
     let module Getters =

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -105,7 +105,7 @@ let deps_of cctx ~ml_kind unit =
       let dir = Compilation_context.dir cctx in
       let file_in_obj_dir ~suffix file =
         let base = Path.basename file in
-        Path.relative
+        Path.relative_exn
           (Obj_dir.obj_dir (Compilation_context.obj_dir cctx))
           (base ^ suffix)
       in
@@ -184,7 +184,7 @@ let graph_of_remote_lib ~obj_dir ~modules =
     | Some file ->
       let file_in_obj_dir ~suffix file =
         let base = Path.basename file in
-        Path.relative obj_dir (base ^ suffix)
+        Path.relative_exn obj_dir (base ^ suffix)
       in
       let all_deps_path file = file_in_obj_dir file ~suffix:".all-deps" in
       let all_deps_file = all_deps_path file in

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -42,7 +42,7 @@ let parse s = ocamlobjinfo empty (Lexing.from_string s)
 let rules ~dir ~(ctx : Context.t) ~unit =
   let open Build.O in
   let output =
-    Path.relative dir (Path.basename unit)
+    Path.relative_exn dir (Path.basename unit)
     |> Path.extend_basename ~suffix:".ooi-deps"
   in
   let bin =

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -5,7 +5,7 @@ open Build.O
 
 module SC = Super_context
 
-let (++) = Path.relative
+let (++) = Path.relative_exn
 
 let lib_unique_name lib =
   let name = Lib.name lib in
@@ -113,7 +113,7 @@ end = struct
 
   let odoc_file ~doc_dir t =
     let t = Filename.chop_extension (Path.basename t) in
-    Path.relative doc_dir (sprintf "page-%s%s" t odoc_ext)
+    Path.relative_exn doc_dir (sprintf "page-%s%s" t odoc_ext)
 
   let odoc_input t = t
 end

--- a/src/opam_file.ml
+++ b/src/opam_file.ml
@@ -108,9 +108,9 @@ module Mutator = struct
   let remap x f =
     List.filter_map ~f:(function
       | Variable (_, v, y) when v = x -> begin
-        match f (Some y) with
-        | Some y' -> Some (Variable (nopos, v, y'))
-        | None -> None
+          match f (Some y) with
+          | Some y' -> Some (Variable (nopos, v, y'))
+          | None -> None
         end
       | z -> Some z)
 

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -264,11 +264,11 @@ module Unexpanded = struct
   let map t ~f : t =
     let rec map_ast : ast -> ast =
       let open Ast in function
-      | Element sw -> Element (f sw)
-      | Include sw -> Include (f sw)
-      | Union xs -> Union (List.map ~f:map_ast xs)
-      | Diff (x, y) -> Diff (map_ast x, map_ast y)
-      | Standard as t -> t
+        | Element sw -> Element (f sw)
+        | Include sw -> Include (f sw)
+        | Union xs -> Union (List.map ~f:map_ast xs)
+        | Diff (x, y) -> Diff (map_ast x, map_ast y)
+        | Standard as t -> t
     in
     { t with ast = map_ast t.ast }
 

--- a/src/package.ml
+++ b/src/package.ml
@@ -64,6 +64,6 @@ let to_dyn { name; path; version } =
 
 let pp fmt t = Dyn.pp fmt (to_dyn t)
 
-let opam_file t = Path.Source.relative t.path (Name.opam_fn t.name)
+let opam_file t = Path.Source.relative_exn t.path (Name.opam_fn t.name)
 
-let meta_file t = Path.Source.relative t.path (Name.meta_fn t.name)
+let meta_file t = Path.Source.relative_exn t.path (Name.meta_fn t.name)

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -161,7 +161,7 @@ module Map = struct
   let create ~(context : Context.t) =
     let ocamlopt =
       match context.ocamlopt with
-      | None -> Path.relative context.ocaml_bin "ocamlopt"
+      | None -> Path.relative_exn context.ocaml_bin "ocamlopt"
       | Some p -> p
     in
     let string s = values [Value.String s] in

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -187,13 +187,13 @@ module Driver = struct
       let f x = Lib_name.encode (Lib.name (Lazy.force x.lib)) in
       ((1, 0),
        record_fields @@
-         [ field_i "flags" Ordered_set_lang.Unexpanded.encode_and_upgrade
-             t.info.flags
-         ; field_i "lint_flags" Ordered_set_lang.Unexpanded.encode_and_upgrade
-             t.info.lint_flags
-         ; field "main" string t.info.main
-         ; field_l "replaces" f (Result.ok_exn t.replaces)
-         ])
+       [ field_i "flags" Ordered_set_lang.Unexpanded.encode_and_upgrade
+           t.info.flags
+       ; field_i "lint_flags" Ordered_set_lang.Unexpanded.encode_and_upgrade
+           t.info.lint_flags
+       ; field "main" string t.info.main
+       ; field_l "replaces" f (Result.ok_exn t.replaces)
+       ])
   end
   include M
   include Sub_system.Register_backend(M)
@@ -335,9 +335,9 @@ end
 let ppx_exe sctx ~key ~dir_kind =
   match (dir_kind : Dune_lang.File_syntax.t) with
   | Dune ->
-    Path.relative (SC.build_dir sctx) (".ppx/" ^ key ^ "/ppx.exe")
+    Path.relative_exn (SC.build_dir sctx) (".ppx/" ^ key ^ "/ppx.exe")
   | Jbuild ->
-    Path.relative (SC.build_dir sctx) (".ppx/jbuild/" ^ key ^ "/ppx.exe")
+    Path.relative_exn (SC.build_dir sctx) (".ppx/jbuild/" ^ key ^ "/ppx.exe")
 
 let build_ppx_driver sctx ~dep_kind ~target ~dir_kind ~pps ~pp_names =
   let ctx = SC.context sctx in
@@ -378,7 +378,7 @@ let build_ppx_driver sctx ~dep_kind ~target ~dir_kind ~pps ~pp_names =
        match jbuild_driver with
        | None ->
          let+ driver =
-          Driver.select pps ~loc:(Dot_ppx (target, pp_names))
+           Driver.select pps ~loc:(Dot_ppx (target, pp_names))
          in
          (driver, pps)
        | Some driver ->
@@ -386,7 +386,7 @@ let build_ppx_driver sctx ~dep_kind ~target ~dir_kind ~pps ~pp_names =
   in
   (* CR-someday diml: what we should do is build the .cmx/.cmo once
      and for all at the point where the driver is defined. *)
-  let ml = Path.relative (Path.parent_exn target) "ppx.ml" in
+  let ml = Path.relative_exn (Path.parent_exn target) "ppx.ml" in
   let add_rule = SC.add_rule sctx ~dir:(Super_context.build_dir sctx) in
   add_rule
     (Build.of_result_map driver_and_libs ~f:(fun (driver, _) ->

--- a/src/process.ml
+++ b/src/process.ml
@@ -105,7 +105,7 @@ module Temp = struct
       Path.Set.iter fns ~f:Path.unlink_no_err)
 
   let create prefix suffix =
-    let fn = Path.of_string (Filename.temp_file prefix suffix) in
+    let fn = Path.of_string_exn (Filename.temp_file prefix suffix) in
     tmp_files := Path.Set.add !tmp_files fn;
     fn
 

--- a/src/promotion.ml
+++ b/src/promotion.ml
@@ -43,7 +43,7 @@ module P = Utils.Persistent(struct
     let version = 1
   end)
 
-let db_file = Path.relative Path.build_dir ".to-promote"
+let db_file = Path.relative_exn Path.build_dir ".to-promote"
 
 let dump_db db =
   if Path.build_dir_exists () then begin
@@ -76,7 +76,7 @@ let do_promote db files_to_promote =
         if fn = "" || fn.[0] = '.' || fn = "install" then
           None
         else
-          let path = Path.(relative build_dir) fn in
+          let path = Path.(relative_exn build_dir) fn in
           Option.some_if (Path.is_directory path) path)
   in
   let dirs_to_clear_from_cache = Path.root :: potential_build_contexts in

--- a/src/report_error.ml
+++ b/src/report_error.ml
@@ -48,10 +48,10 @@ let builtin_printer = function
     Some (make_printer pp)
   | Stdune.Exn.Code_error sexp ->
     let pp = fun ppf ->
-          Format.fprintf ppf "@{<error>Internal error, please report upstream \
-                              including the contents of _build/log.@}\n\
-                              Description:%a\n"
-            Sexp.pp sexp
+      Format.fprintf ppf "@{<error>Internal error, please report upstream \
+                          including the contents of _build/log.@}\n\
+                          Description:%a\n"
+        Sexp.pp sexp
     in
     Some (make_printer ~backtrace:true pp)
   | Unix.Unix_error (err, func, fname) ->

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -281,7 +281,7 @@ end = struct
         }
       in
       while true do
-        let lines = List.map (read_lines buffer pipe) ~f:Path.of_string in
+        let lines = List.map (read_lines buffer pipe) ~f:Path.of_string_exn in
         Mutex.lock event_mtx;
         files_changed := List.rev_append lines !files_changed;
         Condition.signal event_cv;
@@ -298,10 +298,10 @@ end = struct
        It works as follow:
 
        - when the first event is received, send it to the main thread
-       immediately so that we get a fast response time
+         immediately so that we get a fast response time
 
        - after the first event is received, buffer subsequent events
-       for [buffering_time]
+         for [buffering_time]
     *)
     let rec buffer_thread () =
       Mutex.lock event_mtx;

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -103,7 +103,7 @@ module DB = struct
 
   let sccopes_by_name ~context ~projects ~lib_config ~public_libs
         internal_libs =
-    let build_context_dir = Path.relative Path.build_dir context in
+    let build_context_dir = Path.relative_exn Path.build_dir context in
     let projects_by_name =
       List.map projects ~f:(fun (project : Dune_project.t) ->
         (Dune_project.name project, project))

--- a/src/stanza.mli
+++ b/src/stanza.mli
@@ -27,7 +27,7 @@ end
 val file_kind : unit -> (File_kind.t, _) Dune_lang.Decoder.parser
 
 (** Overlay for [Dune_lang.Decoder] where lists and records don't require
-   an extra level of parentheses in Dune files.
+    an extra level of parentheses in Dune files.
 
     Additionally, [field_xxx] functions only warn about duplicated
     fields in jbuild files, for backward compatibility. *)
@@ -66,7 +66,7 @@ module Decoder : sig
       If the syntax version is strictly less than `(1, 0)`, use `jbuild`.
       Otherwise use `dune`. *)
   val switch_file_kind :
-   jbuild:('a, 'b) parser ->
-   dune:('a, 'b) parser ->
-   ('a, 'b) parser
+    jbuild:('a, 'b) parser ->
+    dune:('a, 'b) parser ->
+    ('a, 'b) parser
 end

--- a/src/stdune/bin.ml
+++ b/src/stdune/bin.ml
@@ -25,11 +25,11 @@ let exists fn =
   | _ -> true
 
 let best_prog dir prog =
-  let fn = Path.relative dir (prog ^ ".opt" ^ exe) in
+  let fn = Path.relative_exn dir (prog ^ ".opt" ^ exe) in
   if exists fn then
     Some fn
   else
-    let fn = Path.relative dir (prog ^ exe) in
+    let fn = Path.relative_exn dir (prog ^ exe) in
     if exists fn then
       Some fn
     else

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -8,7 +8,7 @@ exception Code_error of Sexp.t
 (* CR-soon diml:
    - Rename to [User_error]
    - change the [string] argument to [Loc0.t option * string] and get rid of
-   [Loc.Error]. The two are a bit confusing
+     [Loc.Error]. The two are a bit confusing
    - change [string] to [Colors.Style.t Lib_name.t]
 *)
 (** A fatal error, that should be reported to the user in a nice way *)

--- a/src/stdune/io.ml
+++ b/src/stdune/io.ml
@@ -8,7 +8,7 @@ let input_lines =
     match input_line ic with
     | exception End_of_file -> List.rev acc
     | line ->
-       loop ic (line :: acc)
+      loop ic (line :: acc)
   in
   fun ic -> loop ic []
 

--- a/src/stdune/loc.ml
+++ b/src/stdune/loc.ml
@@ -69,11 +69,11 @@ let equal_position
       ; pos_bol = b_a; pos_cnum = c_a }
       { Lexing.pos_fname = f_b; pos_lnum = l_b
       ; pos_bol = b_b; pos_cnum = c_b }
-      =
-      f_a = f_b
-      && l_a = l_b
-      && b_a = b_b
-      && c_a = c_b
+  =
+  f_a = f_b
+  && l_a = l_b
+  && b_a = b_b
+  && c_a = c_b
 
 let equal
       { start = start_a ; stop = stop_a }

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -156,7 +156,7 @@ end = struct
 
 end
 
-module Relative : sig
+module Local : sig
   include Path_intf.S
 
   val root : t
@@ -484,10 +484,10 @@ end = struct
 end
 
 module Build = struct
-  include Relative
+  include Local
   let append_source = append
 end
-module Local = Relative
+module Relative = Local
 module Source0 = Relative
 
 let (abs_root, set_root) =

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -6,12 +6,16 @@ module Relative : sig
       relative to. *)
   val root : t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
+  val of_string : string -> (t, string) Result.t
+  val of_string_exn : string -> t
+
   module L : sig
-    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+    val relative : t -> string list -> (t, string) Result.t
+    val relative_exn : t -> string list -> t
   end
 
-  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val relative : t -> string -> (t, string) Result.t
+  val relative_exn : t -> string -> t
   val split_first_component : t -> (string * t) option
   val explode : t -> string list
 end
@@ -21,12 +25,16 @@ module Local : sig
   include Path_intf.S
   val root : t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
+  val of_string : string -> (t, string) Result.t
+  val of_string_exn : string -> t
+
   module L : sig
-    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+    val relative : t -> string list -> (t, string) Result.t
+    val relative_exn : t -> string list -> t
   end
 
-  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val relative : t -> string -> (t, string) Result.t
+  val relative_exn : t -> string -> t
   val split_first_component : t -> (string * Relative.t) option
   val explode : t -> string list
 end
@@ -36,13 +44,15 @@ module Source : sig
   include Path_intf.S
   val root : t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
+  val of_string : string -> (t, string) Result.t
+  val of_string_exn : string -> t
   module L : sig
-    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+    val relative : t -> string list -> (t, string) Result.t
   end
 
   val of_relative : Relative.t -> t
-  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val relative : t -> string -> (t, string) Result.t
+  val relative_exn : t -> string -> t
   val split_first_component : t -> (string * Relative.t) option
   val explode : t -> string list
 
@@ -59,12 +69,15 @@ module Build : sig
 
   val append_source : t -> Source.t -> t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
+  val of_string : string -> (t, string) Result.t
+  val of_string_exn : string -> t
   module L : sig
-    val relative : ?error_loc:Loc0.t -> t -> string list -> t
+    val relative : t -> string list -> (t, string) Result.t
   end
 
-  val relative : ?error_loc:Loc0.t -> t -> string -> t
+  val relative : t -> string -> (t, string) Result.t
+  val relative_exn : t -> string -> t
+
   val split_first_component : t -> (string * Relative.t) option
   val explode : t -> string list
 
@@ -88,7 +101,8 @@ module Kind : sig
     | External of External.t
     | Local    of Local.t
 
-  val of_string : string -> t
+  val of_string : string -> (t, string) Result.t
+  val of_string_exn : string -> t
 end
 
 include Path_intf.S
@@ -97,7 +111,8 @@ val hash : t -> int
 
 module Table : Hashtbl.S with type key = t
 
-val of_string : ?error_loc:Loc0.t -> string -> t
+val of_string : string -> (t, string) Result.t
+val of_string_exn : string -> t
 
 (** [to_string_maybe_quoted t] is [maybe_quoted (to_string t)] *)
 val to_string_maybe_quoted : t -> string
@@ -109,7 +124,8 @@ val is_root : t -> bool
 
 val is_managed : t -> bool
 
-val relative : ?error_loc:Loc0.t -> t -> string -> t
+val relative : t -> string -> (t, string) Result.t
+val relative_exn : t -> string -> t
 
 (** Create an external path. If the argument is relative, assume it is relative
     to the initial directory dune was launched in. *)

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -38,8 +38,6 @@ module type S = sig
 
   val to_string_maybe_quoted : t -> string
 
-  val is_descendant : t -> of_:t -> bool
-
   val is_root : t -> bool
   val parent_exn : t -> t
 end

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -41,8 +41,8 @@ end
 
 (** A simple renderer that doesn't take tags *)
 module Render : Renderer.S
-    with type Tag.t         = unit
-    with type Tag.Handler.t = unit
+  with type Tag.t         = unit
+  with type Tag.Handler.t = unit
 
 val pp : Format.formatter -> unit t -> unit
 

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -28,7 +28,7 @@ module O : sig
 
   val (let*) : ('a, 'error) t -> ('a -> ('b, 'error) t) -> ('b, 'error) t
   val (and+) : ('a, 'error) t -> ('b, 'error) t -> ('a * 'b, 'error) t
-  val (let+) : ('a, 'error) t -> ('a -> 'b) -> ('b, 'error) t
+val (let+) : ('a, 'error) t -> ('a -> 'b) -> ('b, 'error) t
 end
 
 val map  : ('a, 'error) t -> f:('a -> 'b) -> ('b, 'error) t

--- a/src/stdune/table.mli
+++ b/src/stdune/table.mli
@@ -1,14 +1,14 @@
 (** Hashtable with a simple polymorphic type, but without the polymorphic equality.
 
-   This module re-wraps the hashtable implementation provided by [Hashtbl.Make] under
-   a different interface: we just have a single type [('k, 'v) t], similar to a
-   polymorphic hashtable.
+    This module re-wraps the hashtable implementation provided by [Hashtbl.Make] under
+    a different interface: we just have a single type [('k, 'v) t], similar to a
+    polymorphic hashtable.
 
-   This means that if you want a hash table generic over the type of keys,
-   you don't have to put your type inside a functor.
+    This means that if you want a hash table generic over the type of keys,
+    you don't have to put your type inside a functor.
 
-   Unlike the polymorphich hashtable ([('k, 'v) Hashtbl.t]), this does not use polymorphic
-   hash and polymorphic equality, so this module does respect abstraction boundaries.
+    Unlike the polymorphich hashtable ([('k, 'v) Hashtbl.t]), this does not use polymorphic
+    hash and polymorphic equality, so this module does respect abstraction boundaries.
 *)
 
 type ('k, 'v) t

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -33,7 +33,7 @@ let make_var ?quoted loc ?payload name =
     ; name
     ; payload
     ; syntax = Percent
-  }
+    }
   in
   make ?quoted loc (Var var)
 
@@ -196,8 +196,8 @@ end
 
 let invalid_multivalue (v : var) x =
   Errors.fail v.loc "Variable %s expands to %d values, \
-                   however a single value is expected here. \
-                   Please quote this atom."
+                     however a single value is expected here. \
+                     Please quote this atom."
     (string_of_var v) (List.length x)
 
 module Var = struct
@@ -309,10 +309,10 @@ open Private
 
 let partial_expand
   : 'a.t
-  -> mode:'a Mode.t
-  -> dir:Path.t
-  -> f:Value.t list option expander
-  -> 'a Partial.t
+    -> mode:'a Mode.t
+    -> dir:Path.t
+    -> f:Value.t list option expander
+    -> 'a Partial.t
   = fun ({template; syntax_version} as t) ~mode ~dir ~f ->
     let commit_text acc_text acc =
       let s = concat_rev acc_text in

--- a/src/sub_system.ml
+++ b/src/sub_system.ml
@@ -129,10 +129,10 @@ module Register_end_point(M : End_point) = struct
       let* pps = Lib.Compile.pps c.compile_info in
       let* written_by_user =
         match M.Info.backends info with
-         | None -> Ok None
-         | Some l ->
-           Result.List.map l ~f:(M.Backend.resolve (Scope.libs c.scope))
-           >>| Option.some
+        | None -> Ok None
+        | Some l ->
+          Result.List.map l ~f:(M.Backend.resolve (Scope.libs c.scope))
+          >>| Option.some
       in
       M.Backend.Selection_error.or_exn ~loc:(M.Info.loc info)
         (M.Backend.select_extensible_backends

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -342,9 +342,9 @@ let get_installed_binaries stanzas ~(context : Context.t) =
             ~expand:(expand_str ~dir:d.ctx_dir)
             ~expand_partial:(expand_str_partial ~dir:d.ctx_dir)
         in
-        let p = Path.Relative.of_string_exn (Install.Dst.to_string p) in
-        if Path.Relative.is_root (Path.Relative.parent_exn p) then
-          Path.Set.add acc (Path.append_relative install_dir p)
+        let p = Path.Local.of_string_exn (Install.Dst.to_string p) in
+        if Path.Local.is_root (Path.Local.parent_exn p) then
+          Path.Set.add acc (Path.append_local install_dir p)
         else
           acc)
     | _ -> acc)

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -131,8 +131,8 @@ let name t = t.name
 let check_supported t (loc, ver) =
   if not (Supported_versions.is_supported t.supported_versions ver) then
     Errors.fail loc "Version %s of %s is not supported.\n\
-                  Supported versions:\n\
-                  %s"
+                     Supported versions:\n\
+                     %s"
       (Version.to_string ver) t.name
       (String.concat ~sep:"\n"
          (List.map (Supported_versions.supported_ranges t.supported_versions)

--- a/src/test_rules.ml
+++ b/src/test_rules.ml
@@ -28,7 +28,7 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents
     let extra_bindings =
       let test_exe = s ^ ".exe" in
       let test_exe_path =
-        Super_context.Action.map_exe sctx (Path.relative dir test_exe) in
+        Super_context.Action.map_exe sctx (Path.relative_exn dir test_exe) in
       Pform.Map.singleton test_var_name (Values [Path test_exe_path]) in
     let add_alias ~loc ~action ~locks =
       let alias =

--- a/src/top_closure.mli
+++ b/src/top_closure.mli
@@ -26,4 +26,4 @@ module String : S with type key := string and type 'a monad := 'a Monad.Id.t
 module Make(Keys : Keys)(Monad : Monad.S) : S
   with type key := Keys.elt
    and type 'a monad := 'a Monad.t
-[@@inlined always]
+   [@@inlined always]

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -12,7 +12,7 @@ module Source = struct
 
   let main_module_name t = Module.Name.of_string t.name
   let main_module_filename t = t.name ^ ".ml"
-  let source_path t = Path.relative t.dir (main_module_filename t)
+  let source_path t = Path.relative_exn t.dir (main_module_filename t)
 
   let obj_dir { dir; name ; _ } =
     Obj_dir.make_exe ~dir ~name
@@ -39,7 +39,7 @@ module Source = struct
     }
 
   let of_stanza ~dir ~(toplevel : Dune_file.Toplevel.t) =
-    { dir = Path.relative dir (toplevel_dir_prefix ^ toplevel.name)
+    { dir = Path.relative_exn dir (toplevel_dir_prefix ^ toplevel.name)
     ; name = toplevel.name
     ; loc = toplevel.loc
     ; main = "Topmain.main ()"
@@ -108,7 +108,7 @@ let setup_rules t =
     ~link_flags:(Build.return ["-linkall"; "-warn-error"; "-31"]);
   let src = Exe.exe_path t.cctx ~program ~linkage in
   let dir = Source.stanza_dir t.source in
-  let dst = Path.relative dir (Path.basename src) in
+  let dst = Path.relative_exn dir (Path.basename src) in
   Super_context.add_rule sctx ~dir ~loc:t.source.loc
     (Build.symlink ~src ~dst);
   setup_module_rules t

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -25,7 +25,7 @@ let scan_included_files path =
              ; (Atom (loc, A fn) | Quoted_string (loc, fn))
              ]) ->
           let dir = Path.parent_exn path in
-          let included_file = Path.relative dir fn in
+          let included_file = Path.relative_exn dir fn in
           if not (Path.exists included_file) then
             Errors.fail loc "File %s doesn't exist."
               (Path.to_string_maybe_quoted included_file);
@@ -192,7 +192,7 @@ let upgrade_file todo file sexps comments ~look_for_jbuild_ignore =
   let new_file =
     let base = Path.basename file in
     let new_base = rename_basename base in
-    Path.relative dir new_base
+    Path.relative_exn dir new_base
   in
   let sexps =
     List.filter sexps ~f:(function
@@ -202,7 +202,7 @@ let upgrade_file todo file sexps comments ~look_for_jbuild_ignore =
   let sexps = List.map sexps ~f:upgrade_stanza in
   let sexps, extra_files_to_delete =
     (* Port the jbuild-ignore file if necessary *)
-    let jbuild_ignore = Path.relative dir "jbuild-ignore" in
+    let jbuild_ignore = Path.relative_exn dir "jbuild-ignore" in
     if not (look_for_jbuild_ignore && Path.exists jbuild_ignore) then
       (sexps, [])
     else begin
@@ -380,7 +380,7 @@ let upgrade ft =
     match Hashtbl.find has_git_table path with
     | None ->
       let v =
-        if Path.is_directory (Path.relative path ".git") then
+        if Path.is_directory (Path.relative_exn path ".git") then
           Some path
         else
           match Path.parent path with

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -73,25 +73,25 @@ type target_kind =
 let analyse_target (fn as original_fn) =
   match Path.extract_build_dir_first_component fn with
   | Some (".aliases", sub) -> begin
-      match Path.Relative.split_first_component sub with
+      match Path.Local.split_first_component sub with
       | None -> Other fn
       | Some (ctx, fn) ->
-        if Path.Relative.is_root fn then
+        if Path.Local.is_root fn then
           Other original_fn
         else
           let basename =
-            match String.rsplit2 (Path.Relative.basename fn) ~on:'-' with
+            match String.rsplit2 (Path.Local.basename fn) ~on:'-' with
             | None -> assert false
             | Some (name, digest) ->
               assert (String.length digest = 32);
               name
           in
           Alias (ctx,
-                 Path.Source.of_relative
-                   (Path.Relative.relative_exn (Path.Relative.parent_exn fn) basename))
+                 Path.Source.of_local
+                   (Path.Local.relative_exn (Path.Local.parent_exn fn) basename))
     end
   | Some ("install", _) -> Other fn
-  | Some (ctx, sub) -> Regular (ctx, Path.Source.of_relative sub)
+  | Some (ctx, sub) -> Regular (ctx, Path.Source.of_local sub)
   | None ->
     Other fn
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -88,7 +88,7 @@ let analyse_target (fn as original_fn) =
           in
           Alias (ctx,
                  Path.Source.of_relative
-                   (Path.Relative.relative (Path.Relative.parent_exn fn) basename))
+                   (Path.Relative.relative_exn (Path.Relative.parent_exn fn) basename))
     end
   | Some ("install", _) -> Other fn
   | Some (ctx, sub) -> Regular (ctx, Path.Source.of_relative sub)
@@ -109,24 +109,24 @@ let describe_target fn =
     Path.to_string_maybe_quoted fn
 
 let library_object_directory ~dir name =
-  Path.relative dir ("." ^ Lib_name.Local.to_string name ^ ".objs")
+  Path.relative_exn dir ("." ^ Lib_name.Local.to_string name ^ ".objs")
 
 let library_native_dir ~obj_dir =
-  Path.relative obj_dir "native"
+  Path.relative_exn obj_dir "native"
 
 let library_byte_dir ~obj_dir =
-  Path.relative obj_dir "byte"
+  Path.relative_exn obj_dir "byte"
 
 let library_public_cmi_dir ~obj_dir =
-  Path.relative obj_dir "public_cmi"
+  Path.relative_exn obj_dir "public_cmi"
 
 let library_private_dir ~obj_dir =
-  Path.relative obj_dir "private"
+  Path.relative_exn obj_dir "private"
 
 (* Use "eobjs" rather than "objs" to avoid a potential conflict with a
    library of the same name *)
 let executable_object_directory ~dir name =
-  Path.relative dir ("." ^ name ^ ".eobjs")
+  Path.relative_exn dir ("." ^ name ^ ".eobjs")
 
 let program_not_found ?context ?hint ~loc prog =
   Errors.fail_opt loc
@@ -164,7 +164,7 @@ let line_directive ~filename:fn ~line_number =
   in
   sprintf "#%s %d %S\n" directive line_number fn
 
-let local_bin p = Path.relative p ".bin"
+let local_bin p = Path.relative_exn p ".bin"
 
 module type Persistent_desc = sig
   type t
@@ -209,7 +209,7 @@ module Cached_digest = struct
     ; table               : (Path.t, file) Hashtbl.t
     }
 
-  let db_file = Path.relative Path.build_dir ".digest-db"
+  let db_file = Path.relative_exn Path.build_dir ".digest-db"
 
   module P = Persistent(struct
       type nonrec t = t
@@ -268,7 +268,7 @@ module Cached_digest = struct
       ~data:{ digest
             ; timestamp = stat.st_mtime
             ; timestamp_checked = cache.checked_key
-      };
+            };
     digest
 
   let file fn =

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -15,7 +15,7 @@ let utop_exe =
 
 let source ~dir =
   Toplevel.Source.make
-    ~dir:(Path.relative dir utop_dir_basename)
+    ~dir:(Path.relative_exn dir utop_dir_basename)
     ~loc:(Loc.in_dir dir)
     ~main:"UTop_main.main ();"
     ~name:exe_name

--- a/src/value.ml
+++ b/src/value.ml
@@ -34,7 +34,11 @@ let compare_vals ~dir x y =
 
 let to_path ?error_loc t ~dir =
   match t with
-  | String s -> Path.relative ?error_loc dir s
+  | String s ->
+    begin match Path.relative dir s with
+    | Ok s -> s
+    | Error e -> Errors.fail_opt error_loc "%s" e
+    end
   | Dir p
   | Path p -> p
 

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -67,7 +67,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
   in
   let copy_all_deps =
     let all_deps ~obj_dir f =
-      Path.relative obj_dir (Path.basename f ^ ".all-deps") in
+      Path.relative_exn obj_dir (Path.basename f ^ ".all-deps") in
     if Lib.is_local vlib then
       fun m ->
         if Module.is_public m then

--- a/src/watermarks.ml
+++ b/src/watermarks.ml
@@ -245,16 +245,16 @@ let subst_git ?name () =
   let+ ((version, commit), files) =
     Fiber.fork_and_join
       (fun () ->
-        Fiber.fork_and_join
-          (fun () ->
+         Fiber.fork_and_join
+           (fun () ->
               Process.run_capture Strict git ["describe"; "--always"; "--dirty"]
                 ~env)
-          (fun () ->
+           (fun () ->
               Process.run_capture Strict git ["rev-parse"; rev]
                 ~env))
       (fun () ->
-        Process.run_capture_lines Strict git
-          ["ls-tree"; "-r"; "--name-only"; rev] ~env)
+         Process.run_capture_lines Strict git
+           ["ls-tree"; "-r"; "--name-only"; rev] ~env)
   in
   let version = String.trim version in
   let commit  = String.trim commit  in

--- a/src/xdg/xdg.ml
+++ b/src/xdg/xdg.ml
@@ -2,16 +2,16 @@ let home =
   try
     Sys.getenv "HOME"
   with Not_found ->
-    try
-      (Unix.getpwuid (Unix.getuid ())).Unix.pw_dir
-    with Unix.Unix_error _ | Not_found ->
-      if Sys.win32 then
-        try
-          Sys.getenv "AppData"
-        with Not_found ->
-          ""
-      else
+  try
+    (Unix.getpwuid (Unix.getuid ())).Unix.pw_dir
+  with Unix.Unix_error _ | Not_found ->
+    if Sys.win32 then
+      try
+        Sys.getenv "AppData"
+      with Not_found ->
         ""
+    else
+      ""
 
 let ( / ) = Filename.concat
 

--- a/test/blackbox-tests/test-cases/reason/pp/reasononlypp.ml
+++ b/test/blackbox-tests/test-cases/reason/pp/reasononlypp.ml
@@ -28,7 +28,7 @@ let () =
   if Filename.check_suffix fname ".re"
   || Filename.check_suffix fname ".rei" then (
     if !lint && (Filename.check_suffix fname ".pp.re"
-              || Filename.check_suffix fname ".pp.rei") then (
+                 || Filename.check_suffix fname ".pp.rei") then (
       Format.eprintf "reason linter doesn't accept preprocessed file %s" fname;
     );
     let ch = open_in fname in

--- a/test/blackbox-tests/test-cases/vlib/module-fields/test.ml
+++ b/test/blackbox-tests/test-cases/vlib/module-fields/test.ml
@@ -34,7 +34,7 @@ let chdir dir ~f =
   Sys.chdir old_dir
 
 let gen_test ~impl ~modules_without_implementation ~virtual_modules
-  ~private_modules =
+      ~private_modules =
   printf "impl: %b. modules_without_implementation: %b. \
           virtual_modules: %b. private_modules: %b\n%!"
     impl modules_without_implementation virtual_modules private_modules;

--- a/test/unit-tests/action.mlt
+++ b/test/unit-tests/action.mlt
@@ -5,9 +5,9 @@
 open Stdune;;
 open Dune;;
 open Action_unexpanded.Infer.Outcome;;
-Stdune.Path.set_build_dir (Path.Kind.of_string "_build");;
+Stdune.Path.set_build_dir (Path.Kind.of_string_exn "_build");;
 
-let p = Path.of_string;;
+let p = Path.of_string_exn;;
 let infer (a : Action.t) =
   let x = Action_unexpanded.Infer.infer a in
   (List.map (Path.Set.to_list x.deps) ~f:Path.to_string,

--- a/test/unit-tests/ocaml-config/gh637.ml
+++ b/test/unit-tests/ocaml-config/gh637.ml
@@ -3,7 +3,7 @@ open! Stdune
 let pwd = Sys.getcwd ()
 
 let valid_ocaml_config = Printf.sprintf
-{|version: 4.02.3
+                           {|version: 4.02.3
 standard_library_default: %s
 standard_library: %s
 standard_runtime: /usr/bin/ocamlrun
@@ -40,7 +40,7 @@ ast_impl_magic_number: Caml1999M016
 ast_intf_magic_number: Caml1999N015
 cmxs_magic_number: Caml2007D002
 cmt_magic_number: Caml2012T004|}
-pwd pwd
+                           pwd pwd
 
 let () =
   match

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -1,11 +1,11 @@
 (* -*- tuareg -*- *)
 open! Stdune;;
 Path.set_root (Path.External.cwd ());
-Path.set_build_dir (Path.Kind.of_string "_build");
+Path.set_build_dir (Path.Kind.of_string_exn "_build");
 
 Printexc.record_backtrace false;;
 
-let r = Path.(relative root);;
+let r = Path.(relative_exn root);;
 let e = Path.of_filename_relative_to_initial_cwd;;
 
 #install_printer Path.pp_debug;;
@@ -15,7 +15,7 @@ let pp_path_local fmt l =
 
 #install_printer pp_path_local;;
 
-Path.(let p = relative root "foo" in descendant p ~of_:p)
+Path.(let p = relative_exn root "foo" in descendant p ~of_:p)
 [%%expect{|
 - : unit = ()
 val r : string -> Path.t = <fun>
@@ -25,7 +25,7 @@ val pp_path_local : Format.formatter -> Path.Local.t -> unit = <fun>
 |}]
 
 (* different strings but same length *)
-Path.(descendant (relative root "foo") ~of_:(relative root "bar"))
+Path.(descendant (relative_exn root "foo") ~of_:(relative_exn root "bar"))
 [%%expect{|
 - : Path.t option = None
 |}]
@@ -125,87 +125,87 @@ Path.(descendant (r "foo") ~of_:Path.root)
 - : Path.t option = Some (In_source_tree "foo")
 |}]
 
-Path.(descendant (relative build_dir "foo") ~of_:root)
+Path.(descendant (relative_exn build_dir "foo") ~of_:root)
 [%%expect{|
 - : Path.t option = None
 |}]
 
-Path.(descendant (relative build_dir "foo") ~of_:(Path.of_string "/foo/bar"))
+Path.(descendant (relative_exn build_dir "foo") ~of_:(Path.of_string_exn "/foo/bar"))
 [%%expect{|
 - : Path.t option = None
 |}]
 
-Path.(descendant (relative build_dir "foo/bar") ~of_:build_dir)
+Path.(descendant (relative_exn build_dir "foo/bar") ~of_:build_dir)
 [%%expect{|
 - : Path.t option = Some (In_source_tree "foo/bar")
 |}]
 
-Path.(descendant (relative build_dir "foo/bar") ~of_:(relative build_dir "foo"))
+Path.(descendant (relative_exn build_dir "foo/bar") ~of_:(relative_exn build_dir "foo"))
 [%%expect{|
 - : Path.t option = Some (In_source_tree "bar")
 |}]
 
-Path.(descendant (relative build_dir "foo/bar") ~of_:(relative build_dir "foo"))
+Path.(descendant (relative_exn build_dir "foo/bar") ~of_:(relative_exn build_dir "foo"))
 [%%expect{|
 - : Path.t option = Some (In_source_tree "bar")
 |}]
 
-Path.(descendant (Path.of_string "/foo/bar") ~of_:(Path.of_string "/foo"))
+Path.(descendant (Path.of_string_exn "/foo/bar") ~of_:(Path.of_string_exn "/foo"))
 [%%expect{|
 - : Path.t option = None
 |}]
 
-Path.explode (Path.of_string "a/b/c");
+Path.explode (Path.of_string_exn "a/b/c");
 [%%expect{|
 - : string list option = Some ["a"; "b"; "c"]
 |}]
 
-Path.explode (Path.of_string "a/b");
+Path.explode (Path.of_string_exn "a/b");
 [%%expect{|
 - : string list option = Some ["a"; "b"]
 |}]
 
-Path.explode (Path.of_string "a");
+Path.explode (Path.of_string_exn "a");
 [%%expect{|
 - : string list option = Some ["a"]
 |}]
 
-Path.explode (Path.of_string "");
+Path.explode (Path.of_string_exn "");
 [%%expect{|
 - : string list option = Some []
 |}]
 
-Path.reach (Path.of_string "/foo/baz") ~from:(Path.of_string "/foo/bar");
+Path.reach (Path.of_string_exn "/foo/baz") ~from:(Path.of_string_exn "/foo/bar");
 [%%expect{|
 - : string = "/foo/baz"
 |}]
 
-Path.reach (Path.of_string "/foo/bar") ~from:(Path.of_string "baz")
+Path.reach (Path.of_string_exn "/foo/bar") ~from:(Path.of_string_exn "baz")
 [%%expect{|
 - : string = "/foo/bar"
 |}]
 
-Path.reach (Path.of_string "bar/foo") ~from:(Path.of_string "bar/baz/y")
+Path.reach (Path.of_string_exn "bar/foo") ~from:(Path.of_string_exn "bar/baz/y")
 [%%expect{|
 - : string = "../../foo"
 |}]
 
-Path.relative (Path.of_string "relative") "/absolute/path"
+Path.relative_exn (Path.of_string_exn "relative") "/absolute/path"
 [%%expect{|
 - : Path.t = (External "/absolute/path")
 |}]
 
-Path.relative (Path.of_string "/abs1") "/abs2"
+Path.relative_exn (Path.of_string_exn "/abs1") "/abs2"
 [%%expect{|
 - : Path.t = (External "/abs2")
 |}]
 
-Path.relative (Path.of_string "/abs1") ""
+Path.relative_exn (Path.of_string_exn "/abs1") ""
 [%%expect{|
 - : Path.t = (External "/abs1")
 |}]
 
-Path.relative Path.root "/absolute/path"
+Path.relative_exn Path.root "/absolute/path"
 [%%expect{|
 - : Path.t = (External "/absolute/path")
 |}]
@@ -235,17 +235,17 @@ Path.insert_after_build_dir_exn Path.build_dir "foobar"
 - : Path.t = (In_build_dir "foobar")
 |}]
 
-Path.insert_after_build_dir_exn (Path.relative Path.build_dir "qux") "foobar"
+Path.insert_after_build_dir_exn (Path.relative_exn Path.build_dir "qux") "foobar"
 [%%expect{|
 - : Path.t = (In_build_dir "foobar/qux")
 |}]
 
-Path.append Path.build_dir (Path.relative Path.root "foo")
+Path.append Path.build_dir (Path.relative_exn Path.root "foo")
 [%%expect{|
 - : Path.t = (In_build_dir "foo")
 |}]
 
-Path.append Path.build_dir (Path.relative Path.build_dir "foo")
+Path.append Path.build_dir (Path.relative_exn Path.build_dir "foo")
 [%%expect{|
 Exception:
 Code_error
@@ -255,7 +255,7 @@ Code_error
     List [Atom "b"; List [Atom "In_build_dir"; Atom "foo"]]]).
 |}]
 
-Path.append Path.root (Path.relative Path.build_dir "foo")
+Path.append Path.root (Path.relative_exn Path.build_dir "foo")
 [%%expect{|
 Exception:
 Code_error
@@ -265,17 +265,17 @@ Code_error
     List [Atom "b"; List [Atom "In_build_dir"; Atom "foo"]]]).
 |}]
 
-Path.append Path.root (Path.relative Path.root "foo")
+Path.append Path.root (Path.relative_exn Path.root "foo")
 [%%expect{|
 - : Path.t = (In_source_tree "foo")
 |}]
 
-Path.append (Path.of_string "/root") (Path.relative Path.root "foo")
+Path.append (Path.of_string_exn "/root") (Path.relative_exn Path.root "foo")
 [%%expect{|
 - : Path.t = (External "/root/foo")
 |}]
 
-Path.append (Path.of_string "/root") (Path.relative Path.build_dir "foo")
+Path.append (Path.of_string_exn "/root") (Path.relative_exn Path.build_dir "foo")
 [%%expect{|
 Exception:
 Code_error
@@ -285,7 +285,7 @@ Code_error
     List [Atom "b"; List [Atom "In_build_dir"; Atom "foo"]]]).
 |}]
 
-Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")
+Path.rm_rf (Path.of_string_exn "/does/not/exist/foo/bar/baz")
 [%%expect{|
 Exception:
 Code_error
@@ -295,12 +295,12 @@ Code_error
      [Atom "t"; List [Atom "External"; Atom "/does/not/exist/foo/bar/baz"]]]).
 |}]
 
-Path.drop_build_context (Path.relative Path.build_dir "foo/bar")
+Path.drop_build_context (Path.relative_exn Path.build_dir "foo/bar")
 [%%expect{|
 - : Path.Source.t option = Some <abstr>
 |}]
 
-Path.drop_build_context (Path.of_string "foo/bar")
+Path.drop_build_context (Path.of_string_exn "foo/bar")
 [%%expect{|
 - : Path.Source.t option = None
 |}]
@@ -330,35 +330,35 @@ Path.reach_for_running Path.build_dir ~from:Path.root
 - : string = "./_build"
 |}]
 
-Path.(reach_for_running (relative build_dir "foo/baz")
-        ~from:(relative build_dir "foo/bar/baz"))
+Path.(reach_for_running (relative_exn build_dir "foo/baz")
+        ~from:(relative_exn build_dir "foo/bar/baz"))
 [%%expect{|
 - : string = "../../baz"
 |}]
 
 Path.(reach_for_running (e "/fake/path")
-        ~from:(relative build_dir "foo/bar/baz"))
+        ~from:(relative_exn build_dir "foo/bar/baz"))
 [%%expect{|
 - : string = "/fake/path"
 |}]
 
-Path.(reach_for_running (relative root "foo") ~from:(Path.relative root "foo"))
+Path.(reach_for_running (relative_exn root "foo") ~from:(Path.relative_exn root "foo"))
 [%%expect{|
 - : string = "./."
 |}]
 
-Path.relative Path.root "_build"
+Path.relative_exn Path.root "_build"
 [%%expect{|
 - : Path.t = (In_build_dir ".")
 |}]
 
 (* This is not right, but kind of annoying to fix :/ *)
-Path.relative (r "foo") "../_build"
+Path.relative_exn (r "foo") "../_build"
 [%%expect{|
 - : Path.t = (In_build_dir ".")
 |}]
 
-Path.local_part (Path.of_string "/c/d")
+Path.local_part (Path.of_string_exn "/c/d")
 [%%expect{|
 - : Path.Relative.t = <abstr>
 |}]

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -360,15 +360,15 @@ Path.relative_exn (r "foo") "../_build"
 
 Path.local_part (Path.of_string_exn "/c/d")
 [%%expect{|
-- : Path.Relative.t = <abstr>
+- : Path.Local.t = c/d
 |}]
 
 Path.local_part (Path.insert_after_build_dir_exn Path.build_dir "c/d")
 [%%expect{|
-- : Path.Relative.t = <abstr>
+- : Path.Local.t = c/d
 |}]
 
 Path.local_part (r "c/d")
 [%%expect{|
-- : Path.Relative.t = <abstr>
+- : Path.Local.t = c/d
 |}]

--- a/test/unit-tests/sexp_tests.ml
+++ b/test/unit-tests/sexp_tests.ml
@@ -50,7 +50,7 @@ let () =
         if printed_as_atom && not parser_recognizes_as_atom then begin
           Printf.eprintf
             "Dune_lang.Atom.atom_or_quoted_string error:\n\
-            - syntax = %s\n\
+             - syntax = %s\n\
              - s = %S\n\
              - printed_as_atom = %B\n\
              - parser_recognizes_as_atom = %B\n"

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -7,7 +7,7 @@ open Import
 
 let () =
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string "_build")
+  Path.set_build_dir (Path.Kind.of_string_exn "_build")
 ;;
 
 let print_pkg ppf pkg =
@@ -27,7 +27,7 @@ let findlib =
   let cwd = Path.of_filename_relative_to_initial_cwd (Sys.getcwd ()) in
     Findlib.create
     ~stdlib_dir:cwd
-    ~paths:[Path.relative cwd "test/unit-tests/findlib-db"]
+    ~paths:[Path.relative_exn cwd "test/unit-tests/findlib-db"]
     ~version:(Ocaml_version.make (4, 02, 3))
 ;;
 

--- a/test/unit-tests/vcs.mlt
+++ b/test/unit-tests/vcs.mlt
@@ -8,10 +8,10 @@ let printf = Printf.printf;;
 
 let () =
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string "_build")
+  Path.set_build_dir (Path.Kind.of_string_exn "_build")
 ;;
 
-let temp_dir = Path.of_string "vcs-tests";;
+let temp_dir = Path.of_string_exn "vcs-tests";;
 let () = at_exit (fun () -> Path.rm_rf temp_dir);;
 
 (* When hg is not available, we test with git twice indeed. This is
@@ -61,7 +61,7 @@ let run_action (vcs : Vcs.t) action =
     end
   | Write (fn, s) ->
     printf "$ echo %S > %s\n" s fn;
-    Io.write_file (Path.relative temp_dir fn) s;
+    Io.write_file (Path.relative_exn temp_dir fn) s;
     Fiber.return ()
   | Describe expected ->
     printf "$ %s describe [...]\n"


### PR DESCRIPTION
## No more loc in Path

All loc handling is now done at the caller. Callers that want to handle errors may now pattern match on the result of `Path.of_string` or `Path.relative`. The rest can just keep using the `_exn` versions of these functions.

## Relative vs Local

* Relative.t - An unrestricted relative path

* Local.t - A relative path that may not go outside `Path.root`.

After this change, there are actually no uses of `Path.Relative.t` left. In all cases where I replaced it with `Local.t`, it was guaranteed that the path wouldn't go outside the `Path.root` so it was safe to do so.