### PR TITLE
Trim error messages in watch mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,12 @@ unreleased
 - Install the `future_syntax` preprocessor as `ocaml-syntax-shims.exe` (#2125,
   @rgrinberg)
 
+- Hide full command on errors and warnings in CI (detected using the `CI`
+  environment variable) and whenever the failed command outputs a location
+  (detected using the `File ` prefix heuristic). Add an
+  `--always-show-command-line` option to disable this behavior and always show
+  the full command.
+
 1.9.2 (02/05/2019)
 ------------------
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -40,6 +40,7 @@ type t =
   (* For build & runtest only *)
   ; watch : bool
   ; stats_trace_file : string option
+  ; always_show_command_line : bool
   }
 
 let prefix_target common s = common.target_prefix ^ s
@@ -67,6 +68,8 @@ let set_common_other c ~targets =
       ; c.orig_args
       ; targets
       ];
+  Clflags.always_show_command_line :=
+    c.always_show_command_line;
   Option.iter ~f:Dune.Stats.enable c.stats_trace_file
 
 let set_common c ~targets =
@@ -153,6 +156,11 @@ let term =
     | false , Some x -> `Ok (Some x)
     | true  , None   -> `Ok (Some Config.Display.Verbose)
     | true  , Some _ -> incompatible "--display" "--verbose"
+  and+ always_show_command_line =
+    let doc = "Always show the full command lines of programs executed by dune" in
+    Arg.(value
+         & flag
+         & info ["always-show-command-line"] ~docs ~doc)
   and+ no_buffer =
     Arg.(value
          & flag
@@ -416,6 +424,7 @@ let term =
   ; default_target
   ; watch
   ; stats_trace_file
+  ; always_show_command_line
   }
 
 let term =

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -23,6 +23,7 @@ type t =
   (* For build & runtest only *)
   ; watch : bool
   ; stats_trace_file : string option
+  ; always_show_command_line : bool
   }
 
 val prefix_target : t -> string -> string

--- a/src/clflags.ml
+++ b/src/clflags.ml
@@ -9,3 +9,4 @@ let force = ref false
 let watch = ref false
 let no_print_directory = ref false
 let store_orig_src_dir = ref false
+let always_show_command_line = ref false

--- a/src/clflags.mli
+++ b/src/clflags.mli
@@ -32,3 +32,6 @@ val no_print_directory : bool ref
 
 (** Store original source directory in dune-package metadata *)
 val store_orig_src_dir : bool ref
+
+(** Always show full command on error *)
+val always_show_command_line : bool ref

--- a/src/config.ml
+++ b/src/config.ml
@@ -24,6 +24,10 @@ let dune_keep_fname = ".dune-keep"
 
 let inside_emacs = Option.is_some (Env.get Env.initial "INSIDE_EMACS")
 let inside_dune  = Option.is_some (Env.get Env.initial "INSIDE_DUNE")
+let inside_ci = Option.is_some (Env.get Env.initial "CI")
+
+let show_full_command_on_error () =
+  inside_dune || inside_ci || !Clflags.always_show_command_line
 
 let default_build_profile =
   match Wp.t with

--- a/src/config.mli
+++ b/src/config.mli
@@ -21,8 +21,14 @@ val dune_keep_fname : string
 (** Are we running inside an emacs shell? *)
 val inside_emacs : bool
 
-(** Are we running insinde Dune? *)
+(** Are we running inside Dune? *)
 val inside_dune : bool
+
+(** Are we running in CI?. This checks the CI environment variable which is
+    supported by travis, gitlab.*)
+val inside_ci : bool
+
+val show_full_command_on_error : unit -> bool
 
 val default_build_profile : string
 


### PR DESCRIPTION
In watch mode, the error messages from the full compilation commands are quite noisy. I think the correct default here is to omit them, at least by default. I'm not sure what's the best way to turn this into a user configurable option as it doesn't really fit into our display hierarchy.