### PR TITLE
Use Path.Build.t in some places

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -56,7 +56,10 @@ let term =
   let targets = lazy (
     (match prog_where with
      | `Search p ->
-       [Path.relative (Config.local_install_bin_dir ~context:context.name) p]
+       [Path.Build.relative
+          (Config.local_install_bin_dir ~context:context.name) p
+       |> Path.build
+       ]
      | `This_rel p when Sys.win32 ->
        [p; Path.extend_basename p ~suffix:Bin.exe]
      | `This_rel p ->
@@ -81,7 +84,9 @@ let term =
     end;
     match prog_where with
     | `Search prog ->
-      let path = Config.local_install_bin_dir ~context:context.name :: context.path in
+      let path =
+        Path.build (Config.local_install_bin_dir ~context:context.name)
+        :: context.path in
       Bin.which prog ~path
     | `This_rel prog
     | `This_abs prog ->

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -8,7 +8,7 @@ module Bin = struct
     (* Mapping from executable names to their actual path in the
        workspace. The keys are the executable names without the .exe,
        even on Windows. *)
-    local_bins : Path.t String.Map.t;
+    local_bins : Path.Build.t String.Map.t;
   }
 
   let binary t ?hint ~loc name =
@@ -16,7 +16,7 @@ module Bin = struct
       Ok (Path.of_filename_relative_to_initial_cwd name)
     else
       match String.Map.find t.local_bins name with
-      | Some path -> Ok path
+      | Some path -> Ok (Path.build path)
       | None ->
         match Context.which t.context name with
         | Some p -> Ok p
@@ -31,14 +31,14 @@ module Bin = struct
         ~f:(fun acc fb ->
           let path = File_binding.Expanded.dst_path fb
                        ~dir:(Utils.local_bin dir) in
-          String.Map.add acc (Path.basename path) path)
+          String.Map.add acc (Path.Build.basename path) path)
     in
     { t with local_bins }
 
   let create ~(context : Context.t) ~local_bins =
     let local_bins =
-      Path.Set.fold local_bins ~init:String.Map.empty ~f:(fun path acc ->
-        let name = Filename.basename (Path.to_string path) in
+      Path.Build.Set.fold local_bins ~init:String.Map.empty ~f:(fun path acc ->
+        let name = Path.Build.basename path in
         let key =
           if Sys.win32 then
             Option.value ~default:name

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -76,9 +76,9 @@ module Public_libs = struct
         let lib_install_dir =
           match rest with
           | [] -> lib_install_dir
-          | _  -> Path.relative lib_install_dir (String.concat rest ~sep:"/")
+          | _  -> Path.Build.relative lib_install_dir (String.concat rest ~sep:"/")
         in
-        Ok (Path.relative lib_install_dir file)
+        Ok (Path.build (Path.Build.relative lib_install_dir file))
       end else
         Ok (Path.relative (Lib.src_dir lib) file)
 

--- a/src/artifacts.mli
+++ b/src/artifacts.mli
@@ -16,11 +16,11 @@ module Bin : sig
 
   val add_binaries
     :  t
-    -> dir:Path.t
+    -> dir:Path.Build.t
     -> File_binding.Expanded.t list
     -> t
 
-  val create : context:Context.t -> local_bins:Path.Set.t -> t
+  val create : context:Context.t -> local_bins:Path.Build.Set.t -> t
 end
 
 module Public_libs : sig
@@ -47,5 +47,5 @@ type t = {
 val create
   :  Context.t
   -> public_libs:Lib.DB.t
-  -> local_bins:Path.Set.t
+  -> local_bins:Path.Build.Set.t
   -> t

--- a/src/config.ml
+++ b/src/config.ml
@@ -2,18 +2,18 @@ open! Stdune
 open! Import
 
 let local_install_dir =
-  let dir = Path.relative Path.build_dir "install" in
-  fun ~context -> Path.relative dir context
+  let dir = Path.Build.relative Path.Build.root "install" in
+  fun ~context -> Path.Build.relative dir context
 
 let local_install_bin_dir ~context =
-  Path.relative (local_install_dir ~context) "bin"
+  Path.Build.relative (local_install_dir ~context) "bin"
 
 let local_install_man_dir ~context =
-  Path.relative (local_install_dir ~context) "bin"
+  Path.Build.relative (local_install_dir ~context) "bin"
 
 let local_install_lib_dir ~context ~package =
-  Path.relative
-    (Path.relative (local_install_dir ~context) "lib")
+  Path.Build.relative
+    (Path.Build.relative (local_install_dir ~context) "lib")
     (Package.Name.to_string package)
 
 let dev_null =

--- a/src/config.mli
+++ b/src/config.mli
@@ -3,11 +3,14 @@
 open! Import
 
 (** Local installation directory *)
-val local_install_dir : context:string -> Path.t
+val local_install_dir : context:string -> Path.Build.t
 
-val local_install_bin_dir : context:string -> Path.t
-val local_install_man_dir : context:string -> Path.t
-val local_install_lib_dir : context:string -> package:Package.Name.t -> Path.t
+val local_install_bin_dir : context:string -> Path.Build.t
+val local_install_man_dir : context:string -> Path.Build.t
+val local_install_lib_dir
+  :  context:string
+  -> package:Package.Name.t
+  -> Path.Build.t
 
 val dev_null : Path.t
 

--- a/src/context.ml
+++ b/src/context.ml
@@ -379,20 +379,21 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       in
       let vars =
         let local_lib_path =
-          (Path.relative
+          Path.Build.relative
              (Config.local_install_dir ~context:name)
-             "lib")
+             "lib"
+          |> Path.build
         in
         [ extend_var "CAML_LD_LIBRARY_PATH"
-            (Path.relative
-               (Config.local_install_dir ~context:name)
-               "lib/stublibs")
+            (Path.build (Path.Build.relative
+                           (Config.local_install_dir ~context:name)
+                           "lib/stublibs"))
         ; extend_var "OCAMLPATH" ~path_sep:ocamlpath_sep
             local_lib_path
         ; extend_var "OCAMLFIND_IGNORE_DUPS_IN" ~path_sep:ocamlpath_sep
             local_lib_path
         ; extend_var "MANPATH"
-            (Config.local_install_man_dir ~context:name)
+            (Path.build (Config.local_install_man_dir ~context:name))
         ; "DUNE_CONFIGURATOR", (Path.to_string ocamlc)
         ]
       in
@@ -401,7 +402,8 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
         match host with
         | None ->
           let _key, path =
-            extend_var "PATH" (Config.local_install_bin_dir ~context:name) in
+            Path.build (Config.local_install_bin_dir ~context:name)
+            |> extend_var "PATH" in
           Some path
         | Some host ->
           Env.get host.env "PATH"

--- a/src/env_node.ml
+++ b/src/env_node.ml
@@ -71,7 +71,13 @@ let rec external_ t ~profile ~default =
     in
     let env =
       if have_binaries then
-        Env.cons_path env ~dir:(Utils.local_bin t.dir)
+        let dir =
+          Path.as_in_build_dir t.dir
+          |> Option.value_exn
+          |> Utils.local_bin
+          |> Path.build
+        in
+        Env.cons_path env ~dir
       else
         env
     in
@@ -88,8 +94,9 @@ let rec bin_artifacts t ~profile ~default ~expander =
       | Some (lazy t) -> bin_artifacts t ~default ~profile ~expander
     in
     let bin_artifacts =
+      let dir = Path.as_in_build_dir t.dir |> Option.value_exn in
       local_binaries t ~profile ~expander
-      |> Artifacts.Bin.add_binaries default ~dir:t.dir
+      |> Artifacts.Bin.add_binaries default ~dir
     in
     t.bin_artifacts <- Some bin_artifacts;
     bin_artifacts

--- a/src/env_node.ml
+++ b/src/env_node.ml
@@ -1,7 +1,7 @@
 open Stdune
 
 type t =
-  { dir                   : Path.t
+  { dir                   : Path.Build.t
   ; inherit_from          : t Lazy.t option
   ; scope                 : Scope.t
   ; config                : Dune_env.Stanza.t option
@@ -43,11 +43,12 @@ let rec local_binaries t ~profile ~expander =
       match find_config t ~profile with
       | None -> default
       | Some cfg ->
+        let dir = Path.build t.dir in
         default @
         List.map cfg.binaries
-          ~f:(File_binding.Unexpanded.expand ~dir:t.dir ~f:(fun template ->
+          ~f:(File_binding.Unexpanded.expand ~dir ~f:(fun template ->
             Expander.expand expander ~mode:Single ~template
-            |> Value.to_string ~dir:t.dir))
+            |> Value.to_string ~dir))
     in
     t.local_binaries <- Some local_binaries;
     local_binaries
@@ -72,9 +73,7 @@ let rec external_ t ~profile ~default =
     let env =
       if have_binaries then
         let dir =
-          Path.as_in_build_dir t.dir
-          |> Option.value_exn
-          |> Utils.local_bin
+          Utils.local_bin t.dir
           |> Path.build
         in
         Env.cons_path env ~dir
@@ -94,9 +93,8 @@ let rec bin_artifacts t ~profile ~default ~expander =
       | Some (lazy t) -> bin_artifacts t ~default ~profile ~expander
     in
     let bin_artifacts =
-      let dir = Path.as_in_build_dir t.dir |> Option.value_exn in
       local_binaries t ~profile ~expander
-      |> Artifacts.Bin.add_binaries default ~dir
+      |> Artifacts.Bin.add_binaries default ~dir:t.dir
     in
     t.bin_artifacts <- Some bin_artifacts;
     bin_artifacts
@@ -114,7 +112,8 @@ let rec ocaml_flags t ~profile ~expander =
       match find_config t ~profile with
       | None -> default
       | Some cfg ->
-        let expander = Expander.set_dir expander ~dir:t.dir in
+        let dir = Path.build t.dir in
+        let expander = Expander.set_dir expander ~dir in
         Ocaml_flags.make
           ~spec:cfg.flags
           ~default
@@ -136,7 +135,8 @@ let rec c_flags t ~profile ~expander ~default_context_flags =
       match find_config t ~profile with
       | None -> default
       | Some cfg ->
-        let expander = Expander.set_dir expander ~dir:t.dir in
+        let dir = Path.build t.dir in
+        let expander = Expander.set_dir expander ~dir in
         C.Kind.Dict.mapi cfg.c_flags ~f:(fun ~kind f ->
           let default = C.Kind.Dict.get default kind in
           Expander.expand_and_eval_set expander f ~standard:default)

--- a/src/env_node.mli
+++ b/src/env_node.mli
@@ -6,7 +6,7 @@ open Stdune
 type t
 
 val make
-  :  dir:Path.t
+  :  dir:Path.Build.t
   -> inherit_from:t Lazy.t option
   -> scope:Scope.t
   -> config:Dune_env.Stanza.t option

--- a/src/file_binding.ml
+++ b/src/file_binding.ml
@@ -23,7 +23,7 @@ module Expanded = struct
       |> Option.value ~default:basename
 
   let dst_path t ~dir =
-    Path.relative dir (dst_basename t)
+    Path.Build.relative dir (dst_basename t)
 end
 
 module Unexpanded = struct

--- a/src/file_binding.mli
+++ b/src/file_binding.mli
@@ -8,7 +8,7 @@ module Expanded : sig
 
   val src_loc : t -> Loc.t
 
-  val dst_path : t -> dir:Path.t -> Path.t
+  val dst_path : t -> dir:Path.Build.t -> Path.Build.t
   val src_path : t -> Path.t
 end
 

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -234,7 +234,11 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
          |> List.iter ~f:(fun t ->
            let loc = File_binding.Expanded.src_loc t in
            let src = File_binding.Expanded.src_path t in
-           let dst = File_binding.Expanded.dst_path t ~dir in
+           let dst =
+             let dir = Path.as_in_build_dir dir |> Option.value_exn in
+             File_binding.Expanded.dst_path t ~dir
+             |> Path.build
+           in
            Super_context.add_rule sctx ~loc ~dir (Build.symlink ~src ~dst))
        | _ ->
          match

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -11,7 +11,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
   let meta_template = Local_package.meta_template pkg in
   let name = Local_package.name pkg in
   let dune_version = Syntax.greatest_supported_version Stanza.syntax in
-  Build.if_file_exists meta_template
+  Build.if_file_exists (Path.build meta_template)
     ~then_:(Build.return Dune_package.Or_meta.Use_meta)
     ~else_:(
       version >>^ (fun version ->
@@ -55,7 +55,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
          (Fmt.list ~pp_sep:Fmt.nl
             (Dune_lang.pp (Stanza.File_kind.of_syntax dune_version))))
   >>>
-  Build.write_file_dyn dune_package_file
+  Build.write_file_dyn (Path.build dune_package_file)
   |> Super_context.add_rule sctx ~dir:ctx.build_dir
 
 type version_method =
@@ -68,7 +68,7 @@ let pkg_version ~path ~(pkg : Package.t) =
     | candidate :: rest ->
       match candidate with
       | File fn ->
-        let p = Path.relative path fn in
+        let p = Path.Build.relative path fn |> Path.build in
         Build.if_file_exists p
           ~then_:(Build.lines_of p
                   >>^ function
@@ -95,7 +95,7 @@ let init_meta sctx ~dir =
     let path = Local_package.build_dir pkg in
     let pkg_name = Local_package.name pkg in
     let meta = Local_package.meta_file pkg in
-    let meta_template = Local_package.meta_template pkg in
+    let meta_template = Path.build (Local_package.meta_template pkg) in
     let version =
       let pkg = Local_package.package pkg in
       let get = pkg_version ~pkg ~path in
@@ -148,7 +148,7 @@ let init_meta sctx ~dir =
          Format.pp_print_flush ppf ();
          Buffer.contents buf)
        >>>
-       Build.write_file_dyn meta))
+       Build.write_file_dyn (Path.build meta)))
 
 let lib_ppxs sctx ~(lib : Dune_file.Library.t) ~scope ~dir_kind =
   match lib.kind with
@@ -290,17 +290,18 @@ let install_file sctx (package : Local_package.t) entries =
   let meta = Local_package.meta_file package in
   let dune_package = Local_package.dune_package_file package in
   let package_name = Local_package.name package in
-  let pkg_build_dir = Local_package.build_dir package in
+  let pkg_build_dir = Path.build (Local_package.build_dir package) in
   let install_paths = Local_package.install_paths package in
   let entries =
     let docs =
       Local_package.odig_files package
-      |> List.map ~f:(fun doc -> (None, Install.Entry.make Doc doc))
+      |> List.map ~f:(fun doc -> (None, Install.Entry.make Doc (Path.build doc)))
     in
     local_install_rules sctx ~package:package_name ~install_paths (
-      (None, Install.Entry.make Lib opam ~dst:"opam")
-      :: (None, Install.Entry.make Lib meta ~dst:"META")
-      :: (None, Install.Entry.make Lib dune_package ~dst:"dune-package")
+      (None, Install.Entry.make Lib (Path.build opam) ~dst:"opam")
+      :: (None, Install.Entry.make Lib (Path.build meta) ~dst:"META")
+      :: (None, Install.Entry.make Lib (Path.build dune_package)
+                  ~dst:"dune-package")
       :: docs)
     |> List.rev_append entries
   in
@@ -411,7 +412,7 @@ let init_install_files (ctx : Context.t) (package : Local_package.t) =
       Utils.install_file ~package:(Local_package.name package)
         ~findlib_toolchain:ctx.findlib_toolchain
     in
-    let path = Local_package.build_dir package in
+    let path = Path.build (Local_package.build_dir package) in
     let install_alias = Alias.install ~dir:path in
     let install_file = Path.relative path install_fn in
     Build_system.Alias.add_deps install_alias (Path.Set.singleton install_file)

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -21,7 +21,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
           in
           let lib_root lib =
             let (_, subdir) = Lib_name.split (Lib.name lib) in
-            Path.L.relative pkg_root subdir
+            Path.Build.L.relative pkg_root subdir
           in
           let libs =
             Local_package.libs pkg
@@ -37,7 +37,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
                 Dir_contents.c_sources_of_library dir_contents ~name
                 |> C.Sources.objects ~dir ~ext_obj:ctx.ext_obj
               in
-              Lib.to_dune_lib lib ~dir:(lib_root lib) ~lib_modules
+              Lib.to_dune_lib lib ~dir:(Path.build (lib_root lib)) ~lib_modules
                 ~foreign_objects)
           in
           Dune_package.Or_meta.Dune_package
@@ -45,7 +45,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
               version
             ; name
             ; libs
-            ; dir = pkg_root
+            ; dir = Path.build pkg_root
             }
         in
         dune_package))
@@ -265,7 +265,7 @@ let local_install_rules sctx (entries : (Loc.t option * Install.Entry.t) list)
   let install_dir = Config.local_install_dir ~context:ctx.name in
   List.map entries ~f:(fun (loc, entry) ->
     let dst =
-      Path.append install_dir
+      Path.append (Path.build install_dir)
         (Install.Entry.relative_installed_path entry ~paths:install_paths)
     in
     let loc =

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -242,7 +242,8 @@ let local_packages_by_dir = Memo.exec local_packages_by_dir_def
 let defined_in sctx ~dir =
   let local_packages = of_sctx sctx in
   let by_build_dir = local_packages_by_dir local_packages in
-  Path.as_in_build_dir dir
-  |> Option.value_exn
-  |> Path.Build.Map.find by_build_dir
-  |> Option.value ~default:[]
+  match Path.as_in_build_dir dir with
+  | None -> []
+  | Some dir ->
+    Path.Build.Map.find by_build_dir dir
+    |> Option.value ~default:[]

--- a/src/local_package.mli
+++ b/src/local_package.mli
@@ -7,7 +7,7 @@ type t
 
 val to_sexp : t Sexp.Encoder.t
 
-val build_dir : t -> Path.t
+val build_dir : t -> Path.Build.t
 
 val lib_stanzas : t -> Dune_file.Library.t Dir_with_dune.t list
 
@@ -17,15 +17,15 @@ val installs
   : t
   -> File_binding.Expanded.t Dune_file.Install_conf.t Dir_with_dune.t list
 
-val odig_files : t -> Path.t list
+val odig_files : t -> Path.Build.t list
 
 val of_sctx : Super_context.t -> t Package.Name.Map.t
 
-val meta_file : t -> Path.t
+val meta_file : t -> Path.Build.t
 
-val opam_file : t -> Path.t
+val opam_file : t -> Path.Build.t
 
-val dune_package_file : t -> Path.t
+val dune_package_file : t -> Path.Build.t
 
 val name : t -> Package.Name.t
 
@@ -37,7 +37,7 @@ val package : t -> Package.t
 
 val virtual_lib : t -> Lib.t option
 
-val meta_template : t -> Path.t
+val meta_template : t -> Path.Build.t
 
 val defined_in : Super_context.t -> dir:Path.t -> t list
 

--- a/src/opam_create.ml
+++ b/src/opam_create.ml
@@ -37,10 +37,15 @@ let add_rules sctx ~dir ~project =
   Local_package.defined_in sctx ~dir
   |> List.iter ~f:(fun pkg ->
     let opam_path = Local_package.opam_file pkg in
-    let expected_path = Path.extend_basename opam_path ~suffix:".expected" in
+    let expected_path =
+      Path.Build.extend_basename opam_path ~suffix:".expected"
+      |> Path.build
+    in
+    let opam_path = Path.build opam_path in
     let expected_rule =
       Build.contents opam_path >>^ (fun contents ->
-        let opamfile = Opam_file.of_string ~path:opam_path contents in
+        let opamfile =
+          Opam_file.of_string ~path:opam_path contents in
         let package_name = Local_package.name pkg in
         let corrected =
           Opam_file.Mutator.apply (correct project package_name) opamfile in
@@ -58,7 +63,7 @@ let add_rules sctx ~dir ~project =
                   ; mode = Text
                   }
     in
-    let dir = Local_package.build_dir pkg in
+    let dir = Path.build (Local_package.build_dir pkg) in
     Super_context.add_rule sctx ~dir expected_rule;
     let aliases =
       [ Alias.install ~dir

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -471,6 +471,8 @@ end
 module Build = struct
   include Relative
   let append_source = append
+  let append_relative = append
+  let append_local = append
 end
 module Local = Relative
 module Source0 = Relative
@@ -816,6 +818,11 @@ let as_in_source_tree = function
   | In_build_dir _
   | External _ -> None
 
+let as_in_build_dir = function
+  | In_build_dir b -> Some b
+  | In_source_tree _
+  | External _ -> None
+
 let is_alias_stamp_file = function
   | In_build_dir s -> String.is_prefix (Local.to_string s) ~prefix:".aliases/"
   | In_source_tree _
@@ -1089,6 +1096,7 @@ end
 
 let in_source s = in_source_tree (Local.of_string s)
 let source s = in_source_tree s
+let build s = in_build_dir s
 
 let is_suffix p ~suffix =
   match p with

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -59,6 +59,10 @@ module Build : sig
 
   val append_source : t -> Source.t -> t
 
+  val append_relative : t -> Relative.t -> t
+
+  val append_local : t -> Local.t -> t
+
   val of_string : ?error_loc:Loc0.t -> string -> t
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
@@ -187,6 +191,7 @@ val is_in_build_dir : t -> bool
 (** [is_in_build_dir t = is_managed t && not (is_in_build_dir t)] *)
 val is_in_source_tree : t -> bool
 val as_in_source_tree : t -> Source.t option
+val as_in_build_dir : t -> Build.t option
 
 val is_alias_stamp_file : t -> bool
 
@@ -221,6 +226,7 @@ val ensure_build_dir_exists : unit -> unit
 val set_build_dir : Kind.t -> unit
 
 val source : Source.t -> t
+val build : Build.t -> t
 
 (** paths guaranteed to be in the source directory *)
 val in_source : string -> t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -114,6 +114,7 @@ end = struct
             | Some parent -> lazy (get t ~dir:parent ~scope)
         in
         let config = get_env_stanza t ~dir in
+        let dir = Path.as_in_build_dir dir |> Option.value_exn in
         Env_node.make ~dir ~scope ~config ~inherit_from:(Some inherit_from)
       in
       Hashtbl.add t.env dir node;
@@ -403,7 +404,7 @@ let create
   let default_env = lazy (
     let make ~inherit_from ~config =
       Env_node.make
-        ~dir:context.build_dir
+        ~dir:(Path.as_in_build_dir context.build_dir |> Option.value_exn)
         ~scope:(Scope.DB.find_by_dir scopes context.build_dir)
         ~inherit_from
         ~config

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -344,7 +344,7 @@ let get_installed_binaries stanzas ~(context : Context.t) =
         in
         let p = Path.Relative.of_string (Install.Dst.to_string p) in
         if Path.Relative.is_root (Path.Relative.parent_exn p) then
-          Path.Set.add acc (Path.append_relative install_dir p)
+          Path.Set.add acc (Path.append_relative (Path.build install_dir) p)
         else
           acc)
     | _ -> acc)

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -331,23 +331,24 @@ let get_installed_binaries stanzas ~(context : Context.t) =
     ) sw
     |> String_with_vars.Partial.map ~f:(Value.to_string ~dir)
   in
-  Dir_with_dune.deep_fold stanzas ~init:Path.Set.empty ~f:(fun d stanza acc ->
-    match (stanza : Stanza.t) with
-    | Dune_file.Install { section = Bin; files; _ } ->
-      List.fold_left files ~init:acc ~f:(fun acc fb ->
-        let p =
-          File_binding.Unexpanded.destination_relative_to_install_path
-            fb
-            ~section:Bin
-            ~expand:(expand_str ~dir:d.ctx_dir)
-            ~expand_partial:(expand_str_partial ~dir:d.ctx_dir)
-        in
-        let p = Path.Relative.of_string (Install.Dst.to_string p) in
-        if Path.Relative.is_root (Path.Relative.parent_exn p) then
-          Path.Set.add acc (Path.append_relative (Path.build install_dir) p)
-        else
-          acc)
-    | _ -> acc)
+  Dir_with_dune.deep_fold stanzas ~init:Path.Build.Set.empty
+    ~f:(fun d stanza acc ->
+      match (stanza : Stanza.t) with
+      | Dune_file.Install { section = Bin; files; _ } ->
+        List.fold_left files ~init:acc ~f:(fun acc fb ->
+          let p =
+            File_binding.Unexpanded.destination_relative_to_install_path
+              fb
+              ~section:Bin
+              ~expand:(expand_str ~dir:d.ctx_dir)
+              ~expand_partial:(expand_str_partial ~dir:d.ctx_dir)
+          in
+          let p = Path.Relative.of_string (Install.Dst.to_string p) in
+          if Path.Relative.is_root (Path.Relative.parent_exn p) then
+            Path.Build.Set.add acc (Path.Build.append_relative install_dir p)
+          else
+            acc)
+      | _ -> acc)
 
 let create
       ~(context:Context.t)

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -164,7 +164,7 @@ let line_directive ~filename:fn ~line_number =
   in
   sprintf "#%s %d %S\n" directive line_number fn
 
-let local_bin p = Path.relative p ".bin"
+let local_bin p = Path.Build.relative p ".bin"
 
 module type Persistent_desc = sig
   type t

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -66,7 +66,7 @@ val line_directive : filename:string -> line_number:int -> string
 
 (** [local_bin dir] The directory which contains the local binaries viewed by
     rules defined in [dir] *)
-val local_bin : Path.t -> Path.t
+val local_bin : Path.Build.t -> Path.Build.t
 
 module type Persistent_desc = sig
   type t


### PR DESCRIPTION
All the installation directories live in the build directory, therefore this is
what we should return.

This is only the beginning as this type can be used in quite a few more places.