### PR TITLE
Flush the output in ocaml-syntax-shims

### DIFF
--- a/src/ocaml-syntax-shims/pp.real.ml
+++ b/src/ocaml-syntax-shims/pp.real.ml
@@ -220,7 +220,8 @@ let process_file fn ~magic ~parse ~print ~map ~mk_ext =
     set_binary_mode_out stdout true;
     output_string stdout magic;
     output_value stdout fn;
-    output_value stdout ast
+    output_value stdout ast;
+    flush stdout
   end else
     Format.printf "%a@?" print ast
 


### PR DESCRIPTION
On my machine, `make test` segfaults with master. Flushing the output when dumping the AST in `ocaml-syntax-shims` fixes the issue. Not sure why that makes dune segfault though, or why we didn't observe this before