### PR TITLE
Adopt new parsing/string conversion convention for Path

### DIFF
--- a/src/path_dune_lang.ml
+++ b/src/path_dune_lang.ml
@@ -28,7 +28,7 @@ let decode =
       if Filename.is_relative t then
         Dune_lang.Decoder.of_sexp_errorf loc "Absolute path expected"
       else
-        Path.of_string ~error_loc:loc t
+        Path.parse_string_exn ~loc t
     )
   in
   sum

--- a/src/stdune/loc.ml
+++ b/src/stdune/loc.ml
@@ -1,12 +1,5 @@
 include Loc0
 
-let none_pos p : Lexing.position =
-  { pos_fname = p
-  ; pos_lnum  = 1
-  ; pos_cnum  = 0
-  ; pos_bol   = 0
-  }
-
 let in_file p =
   let pos = none_pos (Path.to_string p) in
   { start = pos
@@ -14,12 +7,6 @@ let in_file p =
   }
 
 let in_dir = in_file
-
-let none =
-  let pos = none_pos "<none>" in
-  { start = pos
-  ; stop = pos
-  }
 
 let drop_position (t : t) =
   let pos = none_pos t.start.pos_fname in

--- a/src/stdune/loc0.ml
+++ b/src/stdune/loc0.ml
@@ -9,3 +9,16 @@ let print ppf { start; stop } =
   Format.fprintf ppf
     "@{<loc>File \"%s\", line %d, characters %d-%d:@}@\n"
     start.pos_fname start.pos_lnum start_c stop_c
+
+let none_pos p : Lexing.position =
+  { pos_fname = p
+  ; pos_lnum  = 1
+  ; pos_cnum  = 0
+  ; pos_bol   = 0
+  }
+
+let none =
+  let pos = none_pos "<none>" in
+  { start = pos
+  ; stop = pos
+  }

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -6,7 +6,6 @@ module Relative : sig
       relative to. *)
   val root : t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
@@ -21,7 +20,6 @@ module Local : sig
   include Path_intf.S
   val root : t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
@@ -36,7 +34,6 @@ module Source : sig
   include Path_intf.S
   val root : t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
@@ -63,7 +60,6 @@ module Build : sig
 
   val append_local : t -> Local.t -> t
 
-  val of_string : ?error_loc:Loc0.t -> string -> t
   module L : sig
     val relative : ?error_loc:Loc0.t -> t -> string list -> t
   end
@@ -100,8 +96,6 @@ include Path_intf.S
 val hash : t -> int
 
 module Table : Hashtbl.S with type key = t
-
-val of_string : ?error_loc:Loc0.t -> string -> t
 
 (** [to_string_maybe_quoted t] is [maybe_quoted (to_string t)] *)
 val to_string_maybe_quoted : t -> string

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -5,6 +5,7 @@ module type S = sig
 
   val to_string : t -> string
   val of_string : string -> t
+  val parse_string_exn : loc:Loc0.t -> string -> t
 
   val pp : Format.formatter -> t -> unit
 

--- a/test/blackbox-tests/test-cases/custom-build-dir/run.t
+++ b/test/blackbox-tests/test-cases/custom-build-dir/run.t
@@ -22,7 +22,7 @@
 Maybe this case should be supported?
 
   $ cd project && dune build foo --build-dir ../build
-  Path outside the workspace: ../build from .
+  Error: path outside the workspace: ../build from .
   [1]
 
 Test with build directory being an absolute path


### PR DESCRIPTION
* Path.of_string is for when we're sure the conversion cannot fail
* Path.parse_string_exn is for parsing user input

A parsing function that returns a Result.t wasn't necessary here as we don't really use this function in dune itself.

By the way, we still haven't decided about the convention for `Path.relative` and `Path.relative_exn`. We have the same situation, in some cases we are sure it's not going to fail and in others we are using user input and would like to return a `Result.t` to be handled by the caller.