### PR TITLE
Pass rules between dirs without relying on side effect

### DIFF
--- a/src/rules.ml
+++ b/src/rules.ml
@@ -85,6 +85,8 @@ module Dir_rules = struct
 
   let is_subset t ~of_ =
     Id.Map.is_subset t ~of_ ~f:(fun _ ~of_:_ -> true)
+
+  let is_empty = Id.Map.is_empty
 end
 
 module T = struct

--- a/src/rules.mli
+++ b/src/rules.mli
@@ -95,6 +95,7 @@ end
 
 val implicit_output : t Memo.Implicit_output.t
 
+val empty : t
 val union : t -> t -> t
 
 val produce_dir : dir:Path.Build.t -> Dir_rules.t -> unit

--- a/src/rules.mli
+++ b/src/rules.mli
@@ -36,6 +36,9 @@ module Dir_rules : sig
   val consume : t -> ready
 
   val is_subset : t -> of_:t -> bool
+
+  val is_empty : t -> bool
+
 end
 
 (** A value of type [t] holds a set of rules for multiple directories *)


### PR DESCRIPTION
- Now directories can only pick up rules created in other directories by explicit call to `load_dir` and not by accident
- Build_system.prefix_rules is now done locally, without mutating a global ref
- Get rid of rule collector, replacing it with a simple flag for now (not stored in the table), but the plan is to get rid of that too when we replace the table with memoized function