### PR TITLE
Fix generation of -pp in .merlin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,8 @@ unreleased
 - Don't build documentation for implementations of virtual libraries (#2141,
   fixes #2138, @jonludlam)
 
+- Fix generation of the `-pp` flag in .merlin (#2142, @rgrinberg)
+
 1.9.3 (06/05/2019)
 ------------------
 

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -325,6 +325,12 @@ module Preprocess = struct
          Future_syntax loc)
       ]
 
+  let loc = function
+    | No_preprocessing -> None
+    | Action (loc, _)
+    | Pps { loc; _ }
+    | Future_syntax loc -> Some loc
+
   let pps = function
     | Pps { pps; _ } -> pps
     | _ -> []

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -24,6 +24,8 @@ module Preprocess : sig
       | Pps    of pps
   end
 
+  val loc : t -> Loc.t option
+
   val remove_future_syntax : t -> Ocaml_version.t -> Without_future_syntax.t
 end
 

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -521,30 +521,3 @@ let expand_and_eval_set t set ~standard =
 let eval_blang t = function
   | Blang.Const x -> x (* common case *)
   | blang -> Blang.eval blang ~dir:t.dir ~f:(expand_var_exn t)
-
-module Option = struct
-  exception Not_found
-
-  let expand_var_exn t var syn =
-    t.expand_var t var syn
-    |> Option.map ~f:(function
-      | Ok s -> s
-      | Error _ -> raise_notrace Not_found)
-
-  let expand t ~mode ~template =
-    match
-      String_with_vars.expand ~dir:t.dir ~mode template
-        ~f:(expand_var_exn t)
-    with
-    | exception Not_found -> None
-    | s -> Some s
-
-  let expand_path t sw =
-    expand t ~mode:Single ~template:sw
-    |> Option.map ~f:(
-      Value.to_path ~error_loc:(String_with_vars.loc sw) ~dir:t.dir)
-
-  let expand_str t sw =
-    expand t ~mode:Single ~template:sw
-    |> Option.map ~f:(Value.to_string ~dir:t.dir)
-end

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -64,11 +64,6 @@ val expand_with_reduced_var_set
   :  context:Context.t
   -> reduced_var_result String_with_vars.expander
 
-module Option : sig
-  val expand_path : t -> String_with_vars.t -> Path.t option
-  val expand_str : t -> String_with_vars.t -> string option
-end
-
 module Resolved_forms : sig
   type t
 

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -162,7 +162,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
 
   let build_c_file (lib : Library.t) ~dir ~expander ~includes (loc, src, dst) =
     let src = C.Source.path src in
-    let c_flags = (SC.c_flags sctx ~dir ~expander ~lib).c in
+    let c_flags = (SC.c_flags sctx ~dir ~expander ~flags:lib.c_flags).c in
     SC.add_rule sctx ~loc ~dir
       (c_flags
        >>>
@@ -188,7 +188,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       else
         [A "-o"; Target dst]
     in
-    let cxx_flags = (SC.c_flags sctx ~dir ~expander ~lib).cxx in
+    let cxx_flags = (SC.c_flags sctx ~dir ~expander ~flags:lib.c_flags).cxx in
     SC.add_rule sctx ~loc ~dir
       (cxx_flags
        >>>

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -591,8 +591,10 @@ let promote_correction fn build ~suffix =
            (Path.extend_basename fn ~suffix))
     ]
 
+let chdir action = Action_unexpanded.Chdir (workspace_root_var, action)
+
 let action_for_pp sctx ~dep_kind ~loc ~expander ~action ~src ~target =
-  let action = Action_unexpanded.Chdir (workspace_root_var, action) in
+  let action = chdir action in
   let bindings = Pform.Map.input_file src in
   let expander = Expander.add_bindings expander ~bindings in
   let targets = Expander.Targets.Forbidden "preprocessing actions" in

--- a/src/preprocessing.mli
+++ b/src/preprocessing.mli
@@ -66,3 +66,5 @@ val get_compat_ppx_exe
   -> Path.t
 
 val gen_rules : Super_context.t -> string list -> unit
+
+val chdir : Action_unexpanded.t -> Action_unexpanded.t

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -271,10 +271,9 @@ let ocaml_flags t ~dir (x : Dune_file.Buildable.t) =
     ~default:(Env.ocaml_flags t ~dir)
     ~eval:(Expander.expand_and_eval_set expander)
 
-let c_flags t ~dir ~expander ~(lib : Dune_file.Library.t) =
+let c_flags t ~dir ~expander ~flags =
   let t = t.env_context in
   let ccg = Context.cc_g t.context in
-  let flags = lib.c_flags in
   let default = Env.c_flags t ~dir in
   C.Kind.Dict.mapi flags ~f:(fun ~kind flags ->
     let name = C.Kind.to_string kind in

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -60,7 +60,7 @@ val c_flags
   :  t
   -> dir:Path.t
   -> expander:Expander.t
-  -> lib:Library.t
+  -> flags:Ordered_set_lang.Unexpanded.t C.Kind.Dict.t
   -> (unit, string list) Build.t C.Kind.Dict.t
 
 (** Binaries that are symlinked in the associated .bin directory of [dir]. This
@@ -182,6 +182,8 @@ module Pkg_version : sig
     -> Package.t
     -> (unit, string option) Build.t
     -> (unit, string option) Build.t
+
+  val read : t -> Package.t -> (unit, string option) Build.t
 end
 
 module Scope_key : sig

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/replaces/dune-project
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/replaces/dune-project
@@ -1,1 +1,3 @@
-(lang dune 1.1)
+(lang dune 1.9)
+
+(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/external-lib-deps/dune-project
+++ b/test/blackbox-tests/test-cases/external-lib-deps/dune-project
@@ -1,2 +1,4 @@
-(lang dune 1.6)
+(lang dune 1.9)
 (name foo)
+
+(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/merlin-tests/dune
+++ b/test/blackbox-tests/test-cases/merlin-tests/dune
@@ -2,3 +2,8 @@
  (name print-merlins)
  (deps lib/.merlin exe/.merlin)
  (action (run ./sanitize-dot-merlin/sanitize_dot_merlin.exe %{deps})))
+
+(alias
+ (name print-merlins-pp)
+ (deps pp-with-expand/.merlin)
+ (action (run ./sanitize-dot-merlin/sanitize_dot_merlin.exe %{deps})))

--- a/test/blackbox-tests/test-cases/merlin-tests/exe/dune
+++ b/test/blackbox-tests/test-cases/merlin-tests/exe/dune
@@ -1,4 +1,4 @@
 (executable
  (name x)
- (preprocess (action (run ./foo-bar %{input-file})))
+ (preprocess (action (run pp/pp.exe %{input-file})))
  (libraries foo))

--- a/test/blackbox-tests/test-cases/merlin-tests/pp-with-expand/dune
+++ b/test/blackbox-tests/test-cases/merlin-tests/pp-with-expand/dune
@@ -1,0 +1,5 @@
+(rule (with-stdout-to dummy (echo "-nothing")))
+
+(executable
+ (name foobar)
+ (preprocess (action (run %{exe:../pp/pp.exe} %{read:dummy} %{input-file}))))

--- a/test/blackbox-tests/test-cases/merlin-tests/pp/dune
+++ b/test/blackbox-tests/test-cases/merlin-tests/pp/dune
@@ -1,0 +1,2 @@
+(executable
+ (name pp))

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -1,4 +1,8 @@
   $ dune build @print-merlins --display short --profile release
+      ocamldep pp/.pp.eobjs/pp.ml.d
+        ocamlc pp/.pp.eobjs/byte/pp.{cmi,cmo,cmt}
+      ocamlopt pp/.pp.eobjs/native/pp.{cmx,o}
+      ocamlopt pp/pp.exe
       ocamldep sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/sanitize_dot_merlin.ml.d
         ocamlc sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/byte/sanitize_dot_merlin.{cmi,cmo,cmt}
       ocamlopt sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/native/sanitize_dot_merlin.{cmx,o}
@@ -16,7 +20,7 @@
   S $LIB_PREFIX/lib/ocaml
   S .
   S ../lib
-  FLG -pp '$PP/_build/default/exe/foo-bar'
+  FLG -pp '$PP/_build/default/pp/pp.exe'
   FLG -w -40
   # Processing lib/.merlin
   EXCLUDE_QUERY_DIR
@@ -36,3 +40,14 @@ Make sure a ppx directive is generated
 
   $ grep -q ppx lib/.merlin
   [1]
+
+Make sure pp flag is correct and variables are expanded
+
+  $ dune build @print-merlins-pp
+  sanitize_dot_merlin alias print-merlins-pp
+  # Processing pp-with-expand/.merlin
+  EXCLUDE_QUERY_DIR
+  B ../_build/default/pp-with-expand/.foobar.eobjs/byte
+  S .
+  FLG -pp '$PP/_build/default/pp/pp.exe -nothing'
+  FLG -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs

--- a/test/blackbox-tests/test-cases/meta-gen/dune-project
+++ b/test/blackbox-tests/test-cases/meta-gen/dune-project
@@ -1,1 +1,3 @@
-(lang dune 1.0)
+(lang dune 1.9)
+
+(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/multi-dir/test4/dune-project
+++ b/test/blackbox-tests/test-cases/multi-dir/test4/dune-project
@@ -1,1 +1,3 @@
-(lang dune 1.1)
+(lang dune 1.9)
+
+(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/private-public-overlap/private-rewriter/dune-project
+++ b/test/blackbox-tests/test-cases/private-public-overlap/private-rewriter/dune-project
@@ -1,2 +1,4 @@
-(lang dune 1.7)
+(lang dune 1.9)
 (name mylib)
+
+(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/private-public-overlap/private-runtime-deps/dune-project
+++ b/test/blackbox-tests/test-cases/private-public-overlap/private-runtime-deps/dune-project
@@ -1,2 +1,4 @@
-(lang dune 1.7)
+(lang dune 1.9)
 (name mylib)
+
+(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/reason/dune-project
+++ b/test/blackbox-tests/test-cases/reason/dune-project
@@ -1,1 +1,3 @@
-(lang dune 1.0)
+(lang dune 1.9)
+
+(allow_approximate_merlin true)


### PR DESCRIPTION
First of all, we are going to be more strict and error out if we can't expand
any variables for the .merlin. If this happens, then it's really a bug that we
should catch.

The functions that swallow expansion errors are removed because they're too easy
to misuse.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>