### PR TITLE
Consistent signature for Path.{parent,parent_exn}

### DIFF
--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -130,9 +130,6 @@ val append_relative : t -> Relative.t -> t
 val append_local : t -> Local.t -> t
 val append_source : t -> Source.t -> t
 
-val parent : t -> t option
-val parent_exn : t -> t
-
 val extend_basename : t -> suffix:string -> t
 
 (** Extract the build context from a path. For instance, representing paths as strings:

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -43,4 +43,5 @@ module type S = sig
 
   val is_root : t -> bool
   val parent_exn : t -> t
+  val parent : t -> t option
 end


### PR DESCRIPTION
One could argue that for relative paths, the parent should never fail but give that we often use `parent` in conjunction with recursion, I think it's a bit safer to always have the user check.