### PR TITLE
Add documentation field to dune-project

### DIFF
--- a/doc/opam.rst
+++ b/doc/opam.rst
@@ -19,7 +19,8 @@ Dune is able to use metadata specified in the ``dune-project`` file to generate
 Dune uses the following global fields to set the metadata for all packages
 defined in the project:
 
-- ``(license <name>)`` - Specifies the license of the project, ideally as an identifier from the `SPDX License List <https://spdx.org/licenses/>`__
+- ``(license <name>)`` - Specifies the license of the project, ideally as an
+  identifier from the `SPDX License List <https://spdx.org/licenses/>`__
 
 - ``(authors <authors>)`` - A list of authors
 
@@ -28,9 +29,12 @@ defined in the project:
 - ``(source <source>)`` - where the source is specified two ways:
   ``(github <user/repo>)`` or ``(uri <uri>)``
 
-- ``(bug_reports <url>)`` - Where to report bugs. This defaults to the GitHub issue tracker if the source is specified as a GitHub repository
+- ``(bug_reports <url>)`` - Where to report bugs. This defaults to the GitHub
+  issue tracker if the source is specified as a GitHub repository
 
 - ``(homepage <url>)`` - The homepage of the project
+
+- ``(documentation <url>)`` - Where the documentation is hosted
 
 Package specific information is specified in the ``(package <package>)`` stanza.
 It contains the following fields:

--- a/dune-project
+++ b/dune-project
@@ -8,6 +8,7 @@
 (maintainers "Jane Street Group, LLC <opensource@janestreet.com>")
 (authors "Jane Street Group, LLC <opensource@janestreet.com>")
 (source (github ocaml/dune))
+(documentation "https://dune.readthedocs.io/")
 
 (package
  (name dune)

--- a/dune.opam
+++ b/dune.opam
@@ -3,6 +3,7 @@ maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 bug-reports: "https://github.com/ocaml/dune/issues"
 homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
 license: "MIT"
 dev-repo: "git+https://github.com/ocaml/dune.git"
 synopsis: "Fast, portable and opinionated build system"

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -178,6 +178,7 @@ type t =
   ; authors         : string list
   ; homepage        : string option
   ; bug_reports     : string option
+  ; documentation   : string option
   ; maintainers     : string list
   ; packages        : Package.t Package.Name.Map.t
   ; stanza_parser   : Stanza.t list Dune_lang.Decoder.t
@@ -198,6 +199,7 @@ let version t = t.version
 let source t = t.source
 let license t = t.license
 let homepage t = t.homepage
+let documentation t = t.documentation
 let bug_reports t = t.bug_reports
 let maintainers t = t.maintainers
 let authors t = t.authors
@@ -211,7 +213,7 @@ let generate_opam_files t = t.generate_opam_files
 
 let to_dyn
       { name ; root ; version ; source; license; authors
-      ; homepage ; project_file ; parsing_context = _
+      ; homepage ; documentation ; project_file ; parsing_context = _
       ; bug_reports ; maintainers
       ; extension_args = _; stanza_parser = _ ; packages
       ; implicit_transitive_deps ; dune_version
@@ -224,6 +226,7 @@ let to_dyn
     ; "source", (option Source_kind.to_dyn) source
     ; "license", (option string) license
     ; "homepage", (option string) homepage
+    ; "documentation", (option string) documentation
     ; "bug_reports", (option string) bug_reports
     ; "maintainers", (list string) maintainers
     ; "authors", (list string) authors
@@ -474,7 +477,7 @@ let interpret_lang_and_extensions ~(lang : Lang.Instance.t)
 let key =
   Univ_map.Key.create ~name:"dune-project"
     (fun { name; root; version; project_file; source
-         ; license; authors; homepage ; bug_reports ; maintainers
+         ; license; authors; homepage; documentation ; bug_reports ; maintainers
          ; stanza_parser = _; packages = _ ; extension_args = _
          ; parsing_context ; implicit_transitive_deps ; dune_version
          ; allow_approx_merlin ; generate_opam_files } ->
@@ -487,6 +490,7 @@ let key =
         ; "source", Dyn.to_sexp (Dyn.Encoder.(option Source_kind.to_dyn) source)
         ; "version", (option string) version
         ; "homepage", (option string) homepage
+        ; "documentation", (option string) documentation
         ; "bug_reports", (option string) bug_reports
         ; "maintainers", (list string) maintainers
         ; "project_file", Dyn.to_sexp (Project_file.to_dyn project_file)
@@ -527,6 +531,7 @@ let anonymous = lazy (
   ; license       = None
   ; homepage      = None
   ; bug_reports   = None
+  ; documentation = None
   ; maintainers   = []
   ; authors       = []
   ; version       = None
@@ -573,6 +578,8 @@ let parse ~dir ~lang ~opam_packages ~file =
      and+ license = field_o "license"
                       (Syntax.since Stanza.syntax (1, 9) >>> string)
      and+ homepage = field_o "homepage"
+                       (Syntax.since Stanza.syntax (1, 10) >>> string)
+     and+ documentation = field_o "documentation"
                        (Syntax.since Stanza.syntax (1, 10) >>> string)
      and+ bug_reports = field_o "bug_reports"
                           (Syntax.since Stanza.syntax (1, 10) >>> string)
@@ -680,6 +687,7 @@ in your project.")
      ; license
      ; authors
      ; homepage
+     ; documentation
      ; bug_reports
      ; maintainers
      ; packages
@@ -720,6 +728,7 @@ let make_jbuilder_project ~dir opam_packages =
   ; license = None
   ; homepage = None
   ; bug_reports = None
+  ; documentation = None
   ; maintainers = []
   ; authors = []
   ; packages

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -61,6 +61,7 @@ val source: t -> Source_kind.t option
 val license : t -> string option
 val maintainers : t -> string list
 val bug_reports : t -> string option
+val documentation : t -> string option
 val homepage : t -> string option
 val authors : t -> string list
 val stanza_parser : t -> Stanza.t list Dune_lang.Decoder.t

--- a/src/opam_create.ml
+++ b/src/opam_create.ml
@@ -56,6 +56,7 @@ let opam_fields project (package : Package.t) =
   let optional_fields =
     [ "bug-reports", Dune_project.bug_reports project
     ; "homepage", Dune_project.homepage project
+    ; "doc", Dune_project.documentation project
     ; "license", Dune_project.license project
     ; "version", Dune_project.version project
     ; "dev-repo",


### PR DESCRIPTION
This field is analogous to opam's doc field.

All this discussion about linting made me double check what the linter says about dune's opam file. Looks like it's useful after all :)

I'm undecided if we should call the field `doc` or `documentation`.