### PR TITLE
Tweak mkdir_p uses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ unreleased
 
 - Add a 'cookies' option to ppx_rewriter/deriver flags in library stanzas
   (#2106, @mlasson @diml). This allow to specify cookie requests from
-  variables expanded at each invocation of the preprocessor. 
+  variables expanded at each invocation of the preprocessor.
 
 - Add more opam metadata and use it to generate `.opam` files. In particular, a
   `package` field has been added to specify package specific information.

--- a/src/action_exec.ml
+++ b/src/action_exec.ml
@@ -108,7 +108,13 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to =
     Path.rm_rf path;
     Fiber.return ()
   | Mkdir path ->
-    Path.mkdir_p path;
+    begin
+      if Path.is_in_build_dir path then
+        Path.mkdir_p path
+      else
+        Exn.code_error "Action_exec.exec: mkdir on non build dir"
+          ["path", Path.to_sexp path]
+    end;
     Fiber.return ()
   | Digest_files paths ->
     let s =


### PR DESCRIPTION
If the directory that we're trying to create exists, then this is never an error.

We now forbid actions to create external or source dirs.

This should fix #2158 