### PR TITLE
Memoize load dir

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -117,7 +117,7 @@ let term =
     let request =
       match targets with
       | [] ->
-        Build.paths (Build_system.all_targets ())
+        Build.paths (Path.Set.to_list (Build_system.all_targets ()))
       | _  ->
         Target.resolve_targets_exn ~log common setup targets
         |> Target.request setup

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -40,7 +40,7 @@ let log_targets ~log targets =
 let target_hint (_setup : Dune.Main.build_system) path =
   assert (Path.is_managed path);
   let sub_dir = Option.value ~default:path (Path.parent path) in
-  let candidates = Build_system.all_targets () in
+  let candidates = Path.Set.to_list (Build_system.all_targets ()) in
   let candidates =
     if Path.is_in_build_dir path then
       candidates

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -143,7 +143,7 @@ val all_lib_deps
   -> Lib_deps_info.t Path.Source.Map.t String.Map.t Fiber.t
 
 (** List of all buildable targets *)
-val all_targets : unit -> Path.t list
+val all_targets : unit -> Path.Set.t
 
 (** Return the set of files that were created in the source tree and
     needs to be deleted *)

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -119,8 +119,8 @@ module Dir = struct
   let vcs t = t.vcs
 
   let file_paths t =
-    Path.Source.Set.of_list
-      (List.map (String.Set.to_list (files t)) ~f:(Path.Source.relative t.path))
+    Path.Source.Set.of_listing
+      ~dir:t.path ~filenames:(String.Set.to_list (files t))
 
   let sub_dir_names t =
     String.Map.foldi (sub_dirs t) ~init:String.Set.empty

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -122,6 +122,14 @@ val create
   -> 'f option
   -> ('i, 'o, 'f) t
 
+val create_hidden
+  :  string
+  -> doc:string
+  -> input:(module Input with type t = 'i)
+  -> ('i, 'o, 'f) Function_type.t
+  -> 'f option
+  -> ('i, 'o, 'f) t
+
 (** Set the implementation of a memoized function whose implementation was omitted
     when calling [create]. *)
 val set_impl : (_, _, 'f) t -> 'f -> unit

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -2,6 +2,9 @@ open !Stdune
 
 type ('input, 'output, 'fdecl) t
 
+val on_already_reported :
+  (Exn_with_backtrace.t -> Nothing.t) -> unit
+
 module Sync : sig
   type nonrec ('i, 'o) t = ('i, 'o, 'i -> 'o) t
 end

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -234,9 +234,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
       >>^ (fun (flags, pp) ->
         let (src_dirs, obj_dirs) =
           Lib.Set.fold requires ~init:(
-            (Path.Source.Set.to_list t.source_dirs
-             |> List.map ~f:Path.source
-             |> Path.Set.of_list)
+            (Path.set_of_source_paths t.source_dirs)
           , t.objs_dirs)
             ~f:(fun (lib : Lib.t) (src_dirs, obj_dirs) ->
               ( Path.Set.add src_dirs (

--- a/src/stdune/nothing.ml
+++ b/src/stdune/nothing.ml
@@ -1,1 +1,4 @@
 type t = (int, string) Type_eq.t
+
+let unreachable_code (t : t) = match t with
+  | _ -> .

--- a/src/stdune/nothing.ml
+++ b/src/stdune/nothing.ml
@@ -1,4 +1,19 @@
 type t = (int, string) Type_eq.t
 
-let unreachable_code (t : t) = match t with
-  | _ -> .
+(* The purpose of [dummy] is to get the definition of [unreachable_code]
+   that OCaml 4.02 would accept without having to write "assert false".
+
+   The problem is that 4.02 doesn't have refutation branches, so we turn the
+   "nullary" pattern-match into an equivalent one with one branch. *)
+type ('a, 'b, 'c) dummy =
+  | No of 'c
+  | Eq : ('a, 'a, 'c) dummy
+
+let _f x = No x
+
+let to_dummy : type a b . (a, b) Type_eq.t -> (a, b, 'c) dummy =
+  fun Type_eq.T -> Eq
+
+let unreachable_code (t : t) =
+  match to_dummy t with
+  | No c -> c

--- a/src/stdune/nothing.mli
+++ b/src/stdune/nothing.mli
@@ -1,3 +1,5 @@
 (** Inhabited type *)
 
 type t = (int, string) Type_eq.t
+
+val unreachable_code : t -> 'a

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -246,3 +246,8 @@ end
 val local_part : t -> Relative.t
 
 val stat : t -> Unix.stats
+
+(* it would be nice to call this [Set.of_source_paths], but it's annoying
+   to change the [Set] signature because then we don't comply with [Path_intf.S]
+*)
+val set_of_source_paths : Source.Set.t -> Set.t

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -31,6 +31,7 @@ module type S = sig
   module Set : sig
     include Set.S with type elt = t
     val to_sexp : t Sexp.Encoder.t
+    val of_listing : dir:elt -> filenames:string list -> t
   end
 
   module Map :  Map.S with type key = t

--- a/test/blackbox-tests/test-cases/github2061/run.t
+++ b/test/blackbox-tests/test-cases/github2061/run.t
@@ -47,7 +47,7 @@ Dune >= 1.10
   $ echo '(lang dune 1.10)' > dune-project
   $ dune build a
   Multiple rules generated for _build/default/a:
-  - dune:1
   - file present in source tree
+  - dune:1
   Hint: rm -f a
   [1]


### PR DESCRIPTION
This converts more of the rule generation to purely functional style and memoizes the `load_dir` function.

The only remaining purpose of the `Build_system.files` field is stale directory deletion.