### PR TITLE
Fix chdir handling

### DIFF
--- a/src/rule.ml
+++ b/src/rule.ml
@@ -10,6 +10,11 @@ module Info = struct
   let of_loc_opt = function
     | None -> Internal
     | Some loc -> From_dune_file loc
+
+  let loc = function
+    | From_dune_file loc -> Some loc
+    | Internal
+    | Source_file_copy -> None
 end
 
 type t =

--- a/src/rule.mli
+++ b/src/rule.mli
@@ -10,6 +10,8 @@ module Info : sig
     | Source_file_copy
 
   val of_loc_opt : Loc.t option -> t
+
+  val loc : t -> Loc.t option
 end
 
 type t =

--- a/src/stdune/bool.ml
+++ b/src/stdune/bool.ml
@@ -13,3 +13,7 @@ include Comparable.Operators(struct
 let to_string = string_of_bool
 
 let of_string s = Option.try_with (fun () -> bool_of_string s)
+
+let to_dyn t = Dyn0.Bool t
+
+let to_sexp t = Sexp0.Atom (to_string t)

--- a/src/stdune/bool.mli
+++ b/src/stdune/bool.mli
@@ -7,3 +7,7 @@ include Comparable.OPS with type t := t
 val to_string : t -> string
 
 val of_string : string -> t option
+
+val to_dyn : t -> Dyn0.t
+
+val to_sexp : t -> Sexp0.t

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -960,11 +960,15 @@ let drop_optional_build_context_src_exn t =
 let local_src   = Relative.of_string "src"
 let local_build = Relative.of_string "build"
 
-let sandbox_managed_paths ~sandbox_dir t =
-  match t with
-  | External _ -> t
-  | In_source_tree p -> append_relative sandbox_dir (Relative.append local_src   p)
-  | In_build_dir   p -> append_relative sandbox_dir (Relative.append local_build p)
+let sandbox_managed_paths =
+  let append_local ~sandbox_dir local_x p =
+    in_build_dir (Build.append_relative sandbox_dir (Relative.append local_x p))
+  in
+  fun ~(sandbox_dir : Build.t) t ->
+    match t with
+    | External _ -> t
+    | In_source_tree p -> append_local ~sandbox_dir local_src p
+    | In_build_dir   p -> append_local ~sandbox_dir local_build p
 
 let split_first_component t =
   match kind t, is_root t with

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -168,7 +168,7 @@ val drop_optional_build_context_src_exn : t -> Source.t
 
 (** Transform managed paths so that they are descedant of
     [sandbox_dir]. *)
-val sandbox_managed_paths : sandbox_dir:t -> t -> t
+val sandbox_managed_paths : sandbox_dir:Build.t -> t -> t
 
 val explode : t -> string list option
 val explode_exn : t -> string list


### PR DESCRIPTION
Never create directories outside the build dir, check for existence for all
other dirs.

I've tried to follow @diml's suggestion of just returning the build dirs in `Action.chdirs`, but I still don't see the point. We need to check for existence for the other dirs anyways. I think we could easily keep the old code where we return `Path.Set.t` and just call `Fs.mkdir_p_or_assert_exists` on everything.

There's still the issue of all the locs being absent. I'm not entirely sure this can be fixed but I will look into it.