### PR TITLE
Fix calculating top sorted order for implementations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,9 @@ unreleased
 - Fix generation of `.merlin` whenever there's more than one stanza with the
   same ppx preprocessing specification (#2209 ,fixes #2206, @rgrinberg)
 
+- Fix archive compilation of implementations of virtual libraries (#2172, fixes
+  #2166, @rgrinberg)
+
 1.9.3 (06/05/2019)
 ------------------
 

--- a/src/dep_graph.mli
+++ b/src/dep_graph.mli
@@ -19,8 +19,9 @@ val top_closed_implementations
   -> Module.t list
   -> (unit, Module.t list) Build.t
 
-val top_closed_multi_implementations
-  :  t list
+val top_closed_implementations_for_vlib_impl
+  :  vlib:t
+  -> impl:t
   -> Module.t list
   -> (unit, Module.t list) Build.t
 

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -378,10 +378,9 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         Dep_graph.top_closed_implementations dep_graphs.impl modules
         >>^ fun modules -> modules @ wrapped_compat
       | Some (vlib_dep_graphs : Dep_graph.Ml_kind.t) ->
-        Dep_graph.top_closed_multi_implementations
-          [ vlib_dep_graphs.impl
-          ; dep_graphs.impl
-          ]
+        Dep_graph.top_closed_implementations_for_vlib_impl
+          ~vlib:vlib_dep_graphs.impl
+          ~impl:dep_graphs.impl
           modules
     in
 


### PR DESCRIPTION
The bug is caused by the previous top sort using [Module.t] values from the
virtual library to construct the final top sorted list. That final list would
have some implementations missing. Those would be subsequently filtered out.

The new implementation is less generic but it explicitly merges the vlib and
impl dependencies correctly.

Fixes #2166

@jordwalke could you confirm the fix?