### PR TITLE
Use source paths in bootstrap

### DIFF
--- a/src/bootstrap.boot.ml
+++ b/src/bootstrap.boot.ml
@@ -1,6 +1,6 @@
 open Stdune
 
 let data_only_path p =
-  match Path.to_string p with
+  match Path.Source.to_string p with
   | "test" | "example" -> true
   | _ -> false

--- a/src/bootstrap.mli
+++ b/src/bootstrap.mli
@@ -4,4 +4,4 @@ open Stdune
 
 (** Treat the following path as if it was declared as a data only path
     in a [dune] file. *)
-val data_only_path : Path.t -> bool
+val data_only_path : Path.Source.t -> bool

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -290,7 +290,7 @@ let load ?(warn_when_seeing_jbuild_file=true) path ~ancestor_vcs =
         dirs
         |> List.fold_left ~init:String.Map.empty ~f:(fun acc (fn, path, file) ->
           let status =
-            if Bootstrap.data_only_path (Path.source path) then
+            if Bootstrap.data_only_path path then
               Sub_dirs.Status.Ignored
             else
               Sub_dirs.status sub_dirs ~dir:fn


### PR DESCRIPTION
Data only paths must only exist in the source

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>