### PR TITLE
Source_tree cannot be used for paths outside the context

### DIFF
--- a/src/build.ml
+++ b/src/build.ml
@@ -159,11 +159,7 @@ let memoize name t =
   Memo { name; t; state = Unevaluated }
 
 let source_tree ~dir ~file_tree =
-  let prefix_with, dir =
-    match Path.extract_build_context_dir dir with
-    | None -> (Path.root, Option.value_exn (Path.as_in_source_tree dir))
-    | Some (ctx_dir, src_dir) -> (ctx_dir, src_dir)
-  in
+  let (prefix_with, dir) = Path.extract_build_context_dir_exn dir in
   let paths = File_tree.files_recursively_in file_tree dir ~prefix_with in
   path_set paths >>^ fun _ -> paths
 

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -360,7 +360,7 @@ let file_exists t path =
 
 let dir_exists t path = Option.is_some (find_dir t path)
 
-let files_recursively_in t ?(prefix_with=Path.root) path =
+let files_recursively_in t ~prefix_with path =
   match find_dir t path with
   | None -> Path.Set.empty
   | Some dir ->

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -95,7 +95,11 @@ val dir_exists : t -> Path.Source.t -> bool
 (** [true] iff the path is a file *)
 val file_exists : t -> Path.Source.t -> bool
 
-val files_recursively_in : t -> ?prefix_with:Path.t -> Path.Source.t -> Path.Set.t
+val files_recursively_in
+  :  t
+  -> prefix_with:Path.t
+  -> Path.Source.t
+  -> Path.Set.t
 
 (** Load a [jbuild-ignore] file *)
 val load_jbuild_ignore : Path.t -> String.Set.t


### PR DESCRIPTION
The form `(source_tree <path>)` only makes sense for paths that exist in the source tree. Hence when we interpret this dependency, we can assume that all paths are going to come a directory belonging to a build context. This is because the corresponding source files have been copied.

This PR changes the evaluation of `source_tree` to make use of this fact and not consider directories that come from outside a context's build dir.