### PR TITLE
Patch Dir_status to use Path.Build.t where possible

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -411,7 +411,7 @@ let check_no_unqualified loc qualif_mode =
 
 let get0_impl (sctx, dir) : result0 =
   let dir_status_db = Super_context.dir_status_db sctx in
-  match Dir_status.DB.get dir_status_db ~dir with
+  match Dir_status.DB.get dir_status_db ~dir:(Path.as_in_build_dir_exn dir) with
   | Standalone x ->
     (match x with
      | Some (ft_dir, Some d) ->
@@ -453,11 +453,11 @@ let get0_impl (sctx, dir) : result0 =
          subdirs = Path.Map.empty;
        })
   | Is_component_of_a_group_but_not_the_root { group_root; _ } ->
-    See_above group_root
+    See_above (Path.build group_root)
   | Group_root (ft_dir, qualif_mode, d) ->
     let rec walk ft_dir ~dir ~local acc =
       match
-        Dir_status.DB.get dir_status_db ~dir
+        Dir_status.DB.get dir_status_db ~dir:(Path.as_in_build_dir_exn dir)
       with
       | Is_component_of_a_group_but_not_the_root { stanzas = d; group_root = _ } ->
         let files =

--- a/src/dir_status.mli
+++ b/src/dir_status.mli
@@ -1,7 +1,7 @@
 open Stdune
 
 type is_component_of_a_group_but_not_the_root = {
-  group_root : Path.t;
+  group_root : Path.Build.t;
   stanzas : Stanza.t list Dir_with_dune.t option;
 }
 
@@ -29,6 +29,6 @@ module DB : sig
     -> stanzas_per_dir:Dune_file.Stanzas.t Dir_with_dune.t Path.Map.t
     -> t
 
-  val get : t -> dir:Path.t -> status
+  val get : t -> dir:Path.Build.t -> status
 
 end with type status := t

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -68,6 +68,8 @@ module Build : sig
   val split_first_component : t -> (string * Relative.t) option
   val explode : t -> string list
 
+  val drop_build_context     : t -> Source.t option
+  val drop_build_context_exn : t -> Source.t
 end
 
 (** In the outside world *)


### PR DESCRIPTION
Dir_status is only kept for build directories and we use the correct
path type to reflect that.

This PR also addresses a faulty like looking check for the project root. The
project root is a source path, and the dir whose status we're getting is a build
path. There was no way those would be equal, the build dir's context has to be
stripped first.