### PR TITLE
Make scopes use the build dir

### DIFF
--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -143,7 +143,7 @@ let setup_rules ~sctx ~build_dir:_ ~dir ~dir_contents (s : Dune_file.Coq.t) =
   if coq_debug then begin
     let scope = SC.find_scope_by_dir sctx dir in
     Format.eprintf "[gen_rules] @[dir: %a@\nscope: %a@]@\n%!"
-      Path.pp dir Path.pp (Scope.root scope)
+      Path.pp dir Path.Build.pp (Scope.root scope)
   end;
 
   let cc = create_ccoq sctx ~dir in

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -106,7 +106,8 @@ let make ~scope ~(context : Context.t) ~lib_artifacts
       | Macro (Ocaml_config, s) ->
         Some (Ok (expand_ocaml_config (Lazy.force ocaml_config) var s))
       | Macro (Env, s) -> Option.map ~f:Result.ok (expand_env t var s)
-      | Var Project_root -> Some (Ok [Value.Dir (Scope.root scope)])
+      | Var Project_root ->
+        Some (Ok [Value.Dir (Path.build (Scope.root scope))])
       | expansion -> Some (Error expansion))
   in
   let ocaml_config = lazy (make_ocaml_config context.ocaml_config) in

--- a/src/scope.mli
+++ b/src/scope.mli
@@ -6,7 +6,7 @@ open! Stdune
 
 type t
 
-val root : t -> Path.t
+val root : t -> Path.Build.t
 val name : t -> Dune_project.Name.t
 val project : t -> Dune_project.t
 
@@ -29,6 +29,6 @@ module DB : sig
     -> (Path.t * Dune_file.Library.t) list
     -> t * Lib.DB.t
 
-  val find_by_dir  : t -> Path.t              -> scope
+  val find_by_dir  : t -> Path.Build.t        -> scope
   val find_by_name : t -> Dune_project.Name.t -> scope
 end with type scope := t


### PR DESCRIPTION
Scopes are not defined for directories outside the build dir. There's a still major scope related function that needs to change `Super_context.find_scope_by_dir`, but it will make this PR quite a bit bigger.