### PR TITLE
Improved error reporting api (WIP)

### DIFF
--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -18,7 +18,7 @@ let in_dir ~name ~recursive ~contexts dir =
   let checked = Util.check_path contexts dir in
   match checked with
   | External _ ->
-    die "@@ on the command line must be followed by a relative path"
+    User_error.raise [ Pp.textf "@@ on the command line must be followed by a relative path" ]
   | In_source_dir dir ->
     { dir
     ; recursive
@@ -26,10 +26,12 @@ let in_dir ~name ~recursive ~contexts dir =
     ; contexts
     }
   | In_install_dir _ ->
-    die "Invalid alias: %s.\n\
-         There are no aliases in %s."
-      (Path.to_string_maybe_quoted Path.(relative build_dir "install"))
-      (Path.to_string_maybe_quoted dir)
+    User_error.raise
+      [ Pp.textf "Invalid alias: %s."
+          (Path.to_string_maybe_quoted Path.(relative build_dir "install"))
+      ; Pp.textf "There are no aliases in %s."
+          (Path.to_string_maybe_quoted dir)
+      ]
   | In_build_dir (ctx, dir) ->
     { dir
     ; recursive
@@ -51,7 +53,10 @@ let of_string common s ~contexts =
     let s = String.drop s pos in
     let path = Path.relative Path.root (Common.prefix_target common s) in
     if Path.is_root path then
-      die "@@ on the command line must be followed by a valid alias name"
+      User_error.raise
+        [ Pp.textf
+            "@ on the command line must be followed by a valid alias name"
+        ]
     else
       let dir = Path.parent_exn path in
       let name = Path.basename path in

--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -1,7 +1,5 @@
 open Stdune
 
-let die = Dune.Import.die
-
 type t =
   { name : string
   ; recursive : bool

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -102,11 +102,13 @@ let term =
   | None, true ->
     begin match Lazy.force targets with
     | [] ->
-      die "@{<Error>Error@}: Program %S not found!" prog
+      User_error.raise
+        [ Pp.textf "Program %S not found!" prog ]
     | _::_ ->
-      die "@{<Error>Error@}: Program %S isn't built yet \
-           you need to build it first or remove the \
-           --no-build option." prog
+      User_error.raise
+        [ Pp.textf "Program %S isn't built yet. You need to build it \
+                    first or remove the --no-build option." prog
+        ]
     end
   | None, false ->
     die "@{<Error>Error@}: Program %S not found!" prog

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -111,7 +111,7 @@ let term =
         ]
     end
   | None, false ->
-    die "@{<Error>Error@}: Program %S not found!" prog
+    User_error.raise [ Pp.textf "Program %S not found!" prog ]
   | Some real_prog, _ ->
     let real_prog = Path.to_string real_prog     in
     let argv      = prog :: args in

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -34,9 +34,6 @@ module Workspace      = Dune.Workspace
 
 include Common.Let_syntax
 
-let die = Dune.Import.die
-let hint = Dune.Import.hint
-
 module Main = struct
 
   include Dune.Main

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -8,8 +8,9 @@ let validate_component_options kind ~unsupported_options =
   let report_invalid_option = function
     | _, false -> ()  (* The option wasn't supplied *)
     | option_name, true ->
-      die "The %s component does not support the %s option"
-        (Kind.to_string kind) option_name
+      User_error.raise
+        [ Pp.textf "The %s component does not support the %s option"
+            (Kind.to_string kind) option_name ]
   in
   List.iter ~f:report_invalid_option unsupported_options
 

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -49,9 +49,11 @@ let term =
               Path.Build.append_source (Super_context.build_dir sctx) dir in
             dump sctx ~dir)
         | External _ ->
-          die "Environment is not defined for external paths"
+          User_error.raise
+            [ Pp.text "Environment is not defined for external paths" ]
         | In_install_dir _ ->
-          die "Environment is not defined in install dirs"
+          User_error.raise
+            [ Pp.text "Environment is not defined in install dirs" ]
       )
     in
     Build_system.do_build ~request

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -60,7 +60,7 @@ let target_hint (_setup : Dune.Main.build_system) path =
         None)
   in
   let candidates = String.Set.of_list candidates |> String.Set.to_list in
-  hint (Path.to_string path) candidates
+  User_message.did_you_mean path candidates
 
 let resolve_path path ~(setup : Dune.Main.build_system) =
   let checked = Util.check_path setup.workspace.contexts path in
@@ -139,7 +139,10 @@ let resolve_targets ~log common (setup : Dune.Main.build_system) user_targets =
 let resolve_targets_exn ~log common setup user_targets =
   resolve_targets ~log common setup user_targets
   |> List.concat_map ~f:(function
-    | Error (path, hint) ->
-      die "Don't know how to build %a%s" Path.pp path hint
+    | Error (path, hints) ->
+      User_error.raise
+        [ Pp.textf "Don't know how to build %s"
+            (Path.to_string_maybe_quoted path) ]
+        ~hints
     | Ok targets ->
       targets)

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -19,17 +19,21 @@ let check_path contexts =
   in
   fun path ->
     let internal path =
-      die "This path is internal to dune: %s"
-        (Path.to_string_maybe_quoted path)
+      User_error.raise
+        [ Pp.textf "This path is internal to dune: %s"
+            (Path.to_string_maybe_quoted path) ]
     in
     let context_exn ctx =
       match String.Map.find contexts ctx with
       | Some context -> context
       | None ->
-        die "%s refers to unknown build context: %s%s"
-          (Path.to_string_maybe_quoted path)
-          ctx
-          (hint ctx (String.Map.keys contexts))
+        User_error.raise
+          [ Pp.textf "%s refers to unknown build context: %s"
+              (Path.to_string_maybe_quoted path)
+              ctx
+          ]
+          ~hints:(User_message.did_you_mean ctx
+                    ~candidates:(String.Map.keys contexts))
     in
     match Path.kind path with
     | External e -> External e

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -23,7 +23,8 @@ let term =
   Common.set_dirs common;
   if not (Path.is_directory
             (Path.of_string (Common.prefix_target common dir))) then
-    die "cannot find directory: %s" (String.maybe_quoted dir);
+    User_error.raise
+      [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];
   let utop_target = Filename.concat dir Utop.utop_exe in
   Common.set_common_other common ~targets:[utop_target];
   let log = Log.create common in
@@ -42,7 +43,8 @@ let term =
       let target =
         match Target.resolve_target common ~setup utop_target with
         | Error _ ->
-          die "no library is defined in %s" (String.maybe_quoted dir)
+          User_error.raise
+            [ Pp.textf "no library is defined in %s" (String.maybe_quoted dir) ]
         | Ok [File target] -> target
         | Ok _ -> assert false
       in

--- a/src/action_dune_lang.ml
+++ b/src/action_dune_lang.ml
@@ -37,6 +37,9 @@ let decode =
     ~then_:decode
     ~else_:
       (loc >>| fun loc ->
-       of_sexp_errorf
-         loc
-         "if you meant for this to be executed with bash, write (bash \"...\") instead")
+       User_error.raise
+         ~loc
+         [ Pp.textf
+             "if you meant for this to be executed with bash, write \
+              (bash \"...\") instead"
+         ])

--- a/src/action_exec.ml
+++ b/src/action_exec.ml
@@ -16,9 +16,15 @@ let exec_run ~ectx ~dir ~env ~stdout_to ~stderr_to prog args =
       match Path.descendant prog ~of_:prefix with
       | None -> ()
       | Some _ ->
-        die "Context %s has a host %s.@.It's not possible to execute binary %a \
-             in it.@.@.This is a bug and should be reported upstream."
-          target.name host.name Path.pp prog in
+        User_error.raise
+          [ Pp.textf "Context %s has a host %s."
+              target.name host.name
+          ; Pp.textf "It's not possible to execute binary %s in it."
+              (Path.to_string_maybe_quoted prog)
+          ; Pp.nop
+          ; Pp.text "This is a bug and should be reported upstream."
+          ]
+    in
     invalid_prefix (Path.relative Path.build_dir target.name);
     invalid_prefix (Path.relative Path.build_dir ("install/" ^ target.name));
   end;
@@ -143,9 +149,11 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to =
           }
       end;
       if mode = Binary then
-        die "@{<error>Error@}: Files %s and %s differ."
-          (Path.to_string_maybe_quoted file1)
-          (Path.to_string_maybe_quoted file2)
+        User_error.raise
+          [ Pp.textf "Files %s and %s differ."
+              (Path.to_string_maybe_quoted file1)
+              (Path.to_string_maybe_quoted file2)
+          ]
       else
         Print_diff.print file1 file2
           ~skip_trailing_cr:(mode = Text && Sys.win32)

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -75,9 +75,11 @@ let stamp_file t =
 let find_dir_specified_on_command_line ~dir ~file_tree =
   match File_tree.find_dir file_tree dir with
   | None ->
-    die "From the command line:\n\
-         @{<error>Error@}: Don't know about directory %s!"
-      (Path.Source.to_string_maybe_quoted dir)
+    User_error.raise
+      [ Pp.textf "Don't know about directory %s (specified on the \
+                  command line)!"
+          (Path.Source.to_string_maybe_quoted dir)
+      ]
   | Some dir -> dir
 
 let standard_aliases = Hashtbl.create 7

--- a/src/bindings.ml
+++ b/src/bindings.ml
@@ -57,8 +57,9 @@ let dune elem =
           if not (String.Set.mem vars name) then
             String.Set.add vars name
           else
-            of_sexp_errorf loc "Variable %s is defined for the second time."
-              name
+            User_error.raise ~loc
+              [ Pp.textf "Variable %s is defined for the second time."
+                  name ]
         in
         loop vars (Named (name, values) :: acc) l
     in

--- a/src/build.ml
+++ b/src/build.ml
@@ -403,7 +403,9 @@ let exec ~(eval_pred : Dep.eval_pred) (t : ('a, 'b) t) (x : 'a)
         dyn_deps := Dep.Set.union !dyn_deps deps;
         x
       | Evaluating ->
-        die "Dependency cycle evaluating memoized build arrow %s" m.name
+        User_error.raise
+          [ Pp.textf "Dependency cycle evaluating memoized build arrow \
+                      %s" m.name ]
       | Unevaluated ->
         m.state <- Evaluating;
         let dyn_deps' = ref Dep.Set.empty in

--- a/src/colors.ml
+++ b/src/colors.ml
@@ -117,13 +117,3 @@ let output_filename : styles = [Bold; Fg Green]
 let command_success : styles = [Bold; Fg Green]
 
 let command_error : styles = [Bold; Fg Red]
-
-module Render = Pp.Renderer.Make(struct
-    type t = Style.t
-
-    module Handler = struct
-      include Ansi_color.Render.Tag.Handler
-
-      let handle t style = handle t (Style.to_styles style)
-    end
-  end)

--- a/src/colors.mli
+++ b/src/colors.mli
@@ -23,19 +23,3 @@ val command_success : styles
 val command_error : styles
 
 val apply_string : styles -> string -> string
-
-module Style : sig
-  type t =
-    | Loc
-    | Error
-    | Warning
-    | Kwd
-    | Id
-    | Prompt
-    | Details
-    | Ok
-    | Debug
-end
-
-module Render : Pp.Renderer.S
-  with type Tag.t = Style.t

--- a/src/config.ml
+++ b/src/config.ml
@@ -67,7 +67,7 @@ module Concurrency = struct
   let decode =
     plain_string (fun ~loc s ->
       match of_string s with
-      | Error m -> of_sexp_errorf loc "%s" m
+      | Error m -> User_error.raise ~loc [ Pp.text m ]
       | Ok s -> s)
 
   let to_string = function

--- a/src/context.ml
+++ b/src/context.ml
@@ -265,8 +265,11 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     in
     let dir = Path.parent_exn ocamlc in
     let ocaml_tool_not_found prog =
-      die "ocamlc found in %s, but %s/%s doesn't exist (context: %s)"
-        (Path.to_string dir) (Path.to_string dir) prog name
+      User_error.raise
+        [ Pp.textf "ocamlc found in %s, but %s/%s doesn't exist \
+                    (context: %s)"
+            (Path.to_string dir) (Path.to_string dir) prog name
+        ]
     in
     let get_ocaml_tool prog =
       match get_tool_using_findlib_config prog with
@@ -334,11 +337,14 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     let ocaml_config_ok_exn = function
       | Ok x -> x
       | Error (Ocaml_config.Origin.Ocamlc_config, msg) ->
-        die "Failed to parse the output of '%s -config':@\n\
-             %s"
-          (Path.to_string ocamlc) msg
+        User_error.raise
+          [ Pp.textf "Failed to parse the output of '%s -config':"
+              (Path.to_string ocamlc)
+          ; Pp.text msg
+          ]
       | Error (Makefile_config file, msg) ->
-        Errors.fail (Loc.in_file file) "%s" msg
+        User_error.raise ~loc:(Loc.in_file file)
+          [ Pp.text msg ]
     in
     let* (findlib_paths, ocfg) =
       Fiber.fork_and_join
@@ -547,9 +553,12 @@ let opam_version =
           try
             Scanf.sscanf version "%d.%d.%d" (fun a b c -> a, b, c)
           with _ ->
-            die "@{<error>Error@}: `%a config --version' \
-                 returned invalid output:\n%s"
-              Path.pp opam version)
+            User_error.raise
+              [ Pp.textf "`%a config --version' returned invalid \
+                          output:"
+                  (Path.to_string_maybe_quoted opam)
+              ; Pp.verbatim version
+              ])
       in
       res := Some future;
       Fiber.Future.wait future

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -318,13 +318,12 @@ let modules_of_files ~dir ~files =
     | Ok x -> x
     | Error (name, f1, f2) ->
       let src_dir = Path.drop_build_context_exn dir in
-      die "Too many files for module %a in %a:\
-           \n- %a\
-           \n- %a"
-        Module.Name.pp name
-        Path.Source.pp src_dir
-        Path.pp f1.path
-        Path.pp f2.path
+      User_error.raise
+        [ Pp.textf "Too many files for module %a in %a:"
+            (Pp.verbatin (Module.Name.pp name))
+        ; Pp.textf "- %s" (Path.to_string_maybe_quoted f1.path)
+        ; Pp.textf "- %s" (Path.to_string_maybe_quoted f2.path)
+        ]
   in
   let impls = parse_one_set impl_files in
   let intfs = parse_one_set intf_files in

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1064,9 +1064,12 @@ module Library = struct
              | None ->
                self_build_stubs_archive
              | Some name ->
-               of_sexp_errorf loc
-                 "A library cannot use (self_build_stubs_archive ...) \
-                  and (%s ...) simultaneously." name
+               user_error ~loc
+                 [ Pp.textf
+                     "A library cannot use (self_build_stubs_archive \
+                      ...) and (%s ...) simultaneously."
+                     name
+                 ]
            in
            Blang.fold_vars enabled_if ~init:() ~f:(fun var () ->
              match String_with_vars.Var.name var,

--- a/src/dune_init.ml
+++ b/src/dune_init.ml
@@ -107,18 +107,18 @@ module File = struct
         match find_conflicting project stanzas f.content with
         | None -> Dune {f with content = f.content @ stanzas}
         | Some (a, b) ->
-          die "Updating existing stanzas is not yet supported.@\n\
+          User_error.raise [ Pp.textf "Updating existing stanzas is not yet supported.@\n\
                A preexisting dune stanza conflicts with a generated stanza:\
                @\n@\nGenerated stanza:@.%a@.@.Pre-existing stanza:@.%a"
-            pp a pp b
+            pp a pp b ]
   end (* Stanza *)
 
   let create_dir path =
     try Path.mkdir_p path with
     | Unix.Unix_error (EACCES, _, _) ->
-      die "A project directory cannot be created or accessed: \
+      User_error.raise [ Pp.textf "A project directory cannot be created or accessed: \
            Lacking permissions needed to create directory %a"
-        Path.pp path
+        Path.pp path ]
 
   let load_dune_file ~path =
     let name = "dune" in
@@ -130,8 +130,8 @@ module File = struct
         match Format_dune_lang.parse_file (Some full_path) with
         | Format_dune_lang.Sexps content -> content
         | Format_dune_lang.OCaml_syntax _ ->
-          die "Cannot load dune file %a because it uses OCaml syntax"
-            Path.pp full_path
+          User_error.raise [ Pp.textf "Cannot load dune file %a because it uses OCaml syntax"
+            Path.pp full_path ]
     in
     Dune {path; name; content}
 
@@ -348,8 +348,8 @@ let validate_component_name name =
   match Lib_name.Local.of_string name with
   | Ok _ -> ()
   | _    ->
-    die "A component named '%s' cannot be created because it is an %s"
-      name Lib_name.Local.invalid_message
+    User_error.raise [ Pp.textf "A component named '%s' cannot be created because it is an %s"
+      name Lib_name.Local.invalid_message ]
 
 let print_completion kind name =
   Errors.kerrf ~f:print_to_console

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -943,11 +943,10 @@ module Decoder = struct
         match List.assoc cstrs s with
         | Some value -> value
         | None ->
-          of_sexp_errorf loc
-            ~hint:{ on         = s
-                  ; candidates = List.map cstrs ~f:fst
-                  }
-            "Unknown value %s" s)
+          User_error.raise ~loc
+            [ Pp.textf "Unknown value %s" s ]
+            ~hints:(User_message.did_you_mean s
+                      ~candidates:(List.map cstrs ~f:fst)))
 
   let bool = enum [ ("true", true); ("false", false) ]
 

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -764,7 +764,7 @@ module Decoder = struct
     next (function
       | Atom (loc, A s) | Quoted_string (loc, s) -> f ~loc s
       | Template { loc ; _ } | List (loc, _) ->
-        User_error.raise ~loc [ Pp.text "Atom or quoted string expected" ]
+        User_error.raise ~loc [ Pp.text "Atom or quoted string expected" ])
 
   let enter t =
     next_with_user_context (fun uc sexp ->

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -407,23 +407,6 @@ module Decoder : sig
 
   val fix : ('a t -> 'a t) -> 'a t
 
-  val of_sexp_error
-    :  ?hint:hint
-    -> Loc.t
-    -> string
-    -> _
-  val of_sexp_errorf
-    :  ?hint:hint
-    -> Loc.t
-    -> ('a, unit, string, 'b) format4
-    -> 'a
-
-  val no_templates
-    : ?hint:hint
-    -> Loc.t
-    -> ('a, unit, string, 'b) format4
-    -> 'a
-
   val located : ('a, 'k) parser -> (Loc.t * 'a, 'k) parser
 
   val enum : (string * 'a) list -> 'a t

--- a/src/dune_load.ml
+++ b/src/dune_load.ml
@@ -209,9 +209,9 @@ end
         Process.run Strict ~dir:(Path.source dir)
           ~env:context.env context.ocaml args in
       if not (Path.exists (Path.build generated_dune_file)) then
-        die "@{<error>Error:@} %s failed to produce a valid dune_file file.\n\
+        User_error.raise [ Pp.textf "@{<error>Error:@} %s failed to produce a valid dune_file file.\n\
              Did you forgot to call [Jbuild_plugin.V*.send]?"
-          (Path.Source.to_string file);
+          (Path.Source.to_string file) ];
       Fiber.return
         (Dune_lang.Io.load (Path.build generated_dune_file) ~mode:Many
            ~lexer:(Dune_lang.Lexer.of_syntax kind)
@@ -264,10 +264,10 @@ let load ?(ignore_promoted_rules=false) ~ancestor_vcs () =
           | None, Some _ -> b
           | Some _, None -> a
           | Some a, Some b ->
-            die "Too many opam files for package %S:\n- %s\n- %s"
+            User_error.raise [ Pp.textf "Too many opam files for package %S:\n- %s\n- %s"
               (Package.Name.to_string name)
               (Path.Source.to_string_maybe_quoted (Package.opam_file a))
-              (Path.Source.to_string_maybe_quoted (Package.opam_file b))))
+              (Path.Source.to_string_maybe_quoted (Package.opam_file b)) ]))
   in
 
   let rec walk dir dune_files =

--- a/src/errors.ml
+++ b/src/errors.ml
@@ -35,7 +35,7 @@ let fail_lex lb fmt =
 
 let fail_opt t fmt =
   match t with
-  | None -> die fmt
+  | None -> User_error.raise [ Pp.textf fmt ]
   | Some t -> fail t fmt
 
 let print ppf loc =

--- a/src/errors.mli
+++ b/src/errors.mli
@@ -10,10 +10,6 @@ open Stdune
     failed. *)
 exception Already_reported
 
-(* CR-soon diml: Rename to [user_errorf]. *)
-(** Raise a [Exn.Fatal_error] exception *)
-val die : ('a, Format.formatter, unit, 'b) format4 -> 'a
-
 (**/**)
 (* Referenced in Ansi_color and Report_error *)
 val err_buf : Buffer.t

--- a/src/file_binding.ml
+++ b/src/file_binding.ml
@@ -92,8 +92,8 @@ module Unexpanded = struct
            let* dst = decode in
            return { src; dst = Some dst })
       | sexp ->
-        of_sexp_error (Dune_lang.Ast.loc sexp)
-          "invalid format, <name> or (<name> as <install-as>) expected"
+        User_error.raise ~loc:(Dune_lang.Ast.loc sexp)
+          [ Pp.text "invalid format, <name> or (<name> as <install-as>) expected" ]
 
     let decode =
       let open Stanza.Decoder in list decode_file

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -271,9 +271,9 @@ let load ?(warn_when_seeing_jbuild_file=true) path ~ancestor_vcs =
               in
               (Some dune_file, sub_dirs)
             | _ ->
-              die "Directory %s has both a 'dune' and 'jbuild' file.\n\
+              User_error.raise [ Pp.textf "Directory %s has both a 'dune' and 'jbuild' file.\n\
                    This is not allowed"
-                (Path.Source.to_string_maybe_quoted path)
+                (Path.Source.to_string_maybe_quoted path) ]
           in
           let sub_dirs =
             if String.Set.mem files "jbuild-ignore" then
@@ -308,10 +308,10 @@ let load ?(warn_when_seeing_jbuild_file=true) path ~ancestor_vcs =
                 match File.Map.find dirs_visited file with
                 | None -> File.Map.add dirs_visited file path
                 | Some first_path ->
-                  die "Path %s has already been scanned. \
+                  User_error.raise [ Pp.textf "Path %s has already been scanned. \
                        Cannot scan it again through symlink %s"
                     (Path.Source.to_string_maybe_quoted first_path)
-                    (Path.Source.to_string_maybe_quoted path)
+                    (Path.Source.to_string_maybe_quoted path) ]
             in
             match
               walk path ~dirs_visited ~project ~data_only ~vcs
@@ -332,8 +332,8 @@ let load ?(warn_when_seeing_jbuild_file=true) path ~ancestor_vcs =
   with
   | Ok dir -> dir
   | Error m ->
-    die "Unable to load source %s.@.Reason:%s@."
-      (Path.Source.to_string_maybe_quoted path) (Unix.error_message m)
+    User_error.raise [ Pp.textf "Unable to load source %s.@.Reason:%s@."
+      (Path.Source.to_string_maybe_quoted path) (Unix.error_message m) ]
 
 let fold = Dir.fold
 

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -122,8 +122,8 @@ module Config = struct
     let path = Path.extend_basename path ~suffix:".d" in
     let conf_file = Path.relative path (toolchain ^ ".conf") in
     if not (Path.exists conf_file) then
-      die "@{<error>Error@}: ocamlfind toolchain %s isn't defined in %a \
-           (context: %s)" toolchain Path.pp path context;
+      User_error.raise [ Pp.textf "@{<error>Error@}: ocamlfind toolchain %s isn't defined in %a \
+           (context: %s)" toolchain Path.pp path context ];
     let vars = (Meta.load ~name:None conf_file).vars in
     { vars = String.Map.map vars ~f:Rules.of_meta_rules
     ; preds = Ps.make [toolchain]
@@ -447,10 +447,10 @@ let root_packages t =
       match Path.readdir_unsorted dir with
       | Error ENOENT -> []
       | Error unix_error ->
-        die
-          "Unable to read directory %s for findlib package@.Reason:%s@."
+        User_error.raise
+          [ Pp.textf "Unable to read directory %s for findlib package@.Reason:%s@."
           (Path.to_string_maybe_quoted dir)
-          (Unix.error_message unix_error)
+          (Unix.error_message unix_error) ]
       | Ok listing ->
         List.filter_map listing ~f:(fun name ->
           if Path.exists (Path.relative dir (name ^ "/META")) then

--- a/src/import.ml
+++ b/src/import.ml
@@ -52,20 +52,6 @@ let quote_for_shell s =
   else
     s
 
-let suggest_function : (string -> string list -> string list) ref = ref (fun _ _ -> [])
-
-let hint name candidates =
-  match !suggest_function name candidates with
-  | [] -> ""
-  | l ->
-    let rec mk_hint = function
-      | [a; b] -> sprintf "%s or %s" a b
-      | [a] -> a
-      | a :: l -> sprintf "%s, %s" a (mk_hint l)
-      | [] -> ""
-    in
-    sprintf "\nHint: did you mean %s?" (mk_hint l)
-
 (* Disable file operations to force to use the IO module *)
 let open_in      = `Use_Io
 let open_in_bin  = `Use_Io
@@ -81,3 +67,15 @@ module No_io = struct
 end
 
 let print_to_console = Console.print
+
+let pp_cycle cycle ~f =
+  Pp.vbox [
+    Pp.concat ~sep:Pp.cut (List.mapi l ~f:(fun i x ->
+      Pp.box ~indent:3
+        [ Pp.seq (if i = 0 then
+                    Pp.(seq space space)
+                  else
+                    Pp.verbatim "->")
+            (Pp.seq Pp.space (f x))
+        ]))
+  ]

--- a/src/import.ml
+++ b/src/import.ml
@@ -1,7 +1,6 @@
 open! Stdune
 
 include Stdune
-include Errors
 
 module Re = Dune_re
 
@@ -31,11 +30,6 @@ end
 
 let protect  = Exn.protect
 let protectx = Exn.protectx
-
-let warn fmt =
-  ksprintf (fun msg ->
-    prerr_endline ("Warning: jbuild: " ^ msg))
-    fmt
 
 type fail = { fail : 'a. unit -> 'a }
 
@@ -71,7 +65,6 @@ let hint name candidates =
       | [] -> ""
     in
     sprintf "\nHint: did you mean %s?" (mk_hint l)
-
 
 (* Disable file operations to force to use the IO module *)
 let open_in      = `Use_Io

--- a/src/installed_dune_file.ml
+++ b/src/installed_dune_file.ml
@@ -54,8 +54,8 @@ let of_sexp =
       | "1" -> (0, 0)
       | "2" -> (1, 0)
       | v ->
-        of_sexp_errorf loc
-          "Unsupported version %S, only version 1 is supported" v)
+        User_error.raise ~loc
+          [ Pp.textf "Unsupported version %S, only version 1 is supported" v ])
   in
   sum
     [ "dune",

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1381,12 +1381,12 @@ module DB = struct
         with
         | [] | [_] -> assert false
         | loc1 :: loc2 :: _ ->
-          die "Library %a is defined twice:\n\
+          User_error.raise [ Pp.textf "Library %a is defined twice:\n\
                - %s\n\
                - %s"
             Lib_name.pp_quoted name
             (Loc.to_file_colon_line loc1)
-            (Loc.to_file_colon_line loc2)
+            (Loc.to_file_colon_line loc2) ]
     in
     check_valid_implementations map;
     create () ?parent

--- a/src/main.ml
+++ b/src/main.ml
@@ -50,8 +50,8 @@ let scan_workspace ?(log=Log.no_log)
       match workspace_file with
       | Some p ->
         if not (Path.exists p) then
-          die "@{<error>Error@}: workspace file %s does not exist"
-            (Path.to_string_maybe_quoted p);
+          User_error.raise [ Pp.textf "@{<error>Error@}: workspace file %s does not exist"
+            (Path.to_string_maybe_quoted p) ];
         Workspace.load ?x ?profile p
       | None ->
         match
@@ -76,12 +76,12 @@ let init_build_system ?only_packages ?external_lib_deps_mode w =
     Package.Name.Set.iter set ~f:(fun pkg ->
       if not (Package.Name.Map.mem w.conf.packages pkg) then
         let pkg_name = Package.Name.to_string pkg in
-        die "@{<error>Error@}: I don't know about package %s \
+        User_error.raise [ Pp.textf "@{<error>Error@}: I don't know about package %s \
              (passed through --only-packages/--release)%s"
           pkg_name
           (hint pkg_name
              (Package.Name.Map.keys w.conf.packages
-              |> List.map ~f:Package.Name.to_string))));
+              |> List.map ~f:Package.Name.to_string)) ]));
   let rule_done  = ref 0 in
   let rule_total = ref 0 in
   let gen_status_line () =
@@ -245,4 +245,4 @@ let find_context_exn t ~name =
   match List.find t.contexts ~f:(fun c -> c.name = name) with
   | Some ctx -> ctx
   | None ->
-    die "@{<Error>Error@}: Context %S not found!@." name
+    User_error.raise [ Pp.textf "@{<Error>Error@}: Context %S not found!@." name ]

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -22,11 +22,11 @@ let parse_module_names ~(unit : Module.t) ~modules words =
 
 let parse_deps_exn ~file lines =
   let invalid () =
-    die "ocamldep returned unexpected output for %s:\n\
+    User_error.raise [ Pp.textf "ocamldep returned unexpected output for %s:\n\
          %s"
       (Path.to_string_maybe_quoted file)
       (String.concat ~sep:"\n"
-         (List.map lines ~f:(sprintf "> %s")))
+         (List.map lines ~f:(sprintf "> %s"))) ]
   in
   match lines with
   | [] | _ :: _ :: _ -> invalid ()
@@ -65,7 +65,7 @@ let interpret_deps cctx ~unit deps =
       if Module.name unit <> m
       && not (is_alias_module cctx unit)
       && List.exists deps ~f:(fun x -> Module.name x = m) then
-        die "Module %a in directory %s depends on %a.\n\
+        User_error.raise [ Pp.textf "Module %a in directory %s depends on %a.\n\
              This doesn't make sense to me.\n\
              \n\
              %a is the main module of the library and is \
@@ -75,7 +75,7 @@ let interpret_deps cctx ~unit deps =
              on all the other modules in the library."
           Module.Name.pp (Module.name unit) (Path.to_string (Path.build dir))
           Module.Name.pp m
-          Module.Name.pp m);
+          Module.Name.pp m ]);
   match stdlib with
   | None -> begin
       match alias_module with

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -510,10 +510,10 @@ let check_mlds_no_dupes ~pkg ~mlds =
   with
   | Ok m -> m
   | Error (_, p1, p2) ->
-    die "Package %s has two mld's with the same basename %s, %s"
+    User_error.raise [ Pp.textf "Package %s has two mld's with the same basename %s, %s"
       (Package.Name.to_string pkg)
       (Path.to_string_maybe_quoted (Path.build p1))
-      (Path.to_string_maybe_quoted (Path.build p2))
+      (Path.to_string_maybe_quoted (Path.build p2)) ]
 
 let setup_package_odoc_rules_def =
   let module Input = struct

--- a/src/package.ml
+++ b/src/package.ml
@@ -113,7 +113,7 @@ module Dependency = struct
           name, (let+ x = Var.decode in Uop (op, x)))
       in
       let ops =
-        ("!=", let+ loc = loc in of_sexp_error loc "Use <> instead of !=")
+        ("!=", let+ loc = loc in User_error.raise ~loc [ Pp.text "Use <> instead of !=" ])
         :: ops
       in
       fix begin fun t ->

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -80,7 +80,7 @@ end
 type 'a t =
   | No_info    of 'a
   | Since      of 'a * Syntax.Version.t
-  | Deleted_in of 'a * Syntax.Version.t * string option
+  | Deleted_in of 'a * Syntax.Version.t * unit Pp.t option
   | Renamed_in of Syntax.Version.t * string
 
 let values v                       = No_info (Var.Values v)
@@ -126,10 +126,14 @@ module Map = struct
       ; "project_root", since ~version:(1, 0) Var.Project_root
 
       ; "<", deleted_in Var.First_dep ~version:(1, 0)
-               ~repl:"Use a named dependency instead:\
-                      \n\
-                      \n  (deps (:x <dep>) ...)\
-                      \n   ... %{x} ..."
+               ~repl:
+                 (Pp.vbox
+                    [ Pp.text "Use a named dependency instead:"
+                    ; Pp.nop
+                    ; Pp.string "  (deps (:x <dep>) ...)"
+                    ; Pp.nop
+                    ; Pp.string "   ... %{x} ..."
+                    ])
       ; "@", renamed_in ~version:(1, 0) ~new_name:"targets"
       ; "^", renamed_in ~version:(1, 0) ~new_name:"deps"
       ; "SCOPE_ROOT", renamed_in ~version:(1, 0) ~new_name:"project_root"

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -75,19 +75,19 @@ end = struct
             sprintf "%s (in project: %s)" s
               (Dune_project.Name.to_string_hum scope)
         in
-        die "Hash collision between set of ppx drivers:\n\
+        User_error.raise [ Pp.textf "Hash collision between set of ppx drivers:\n\
              - cache : %s\n\
              - fetch : %s"
           (to_string x')
-          (to_string x)
+          (to_string x) ]
       end
 
   let decode y =
     match Hashtbl.find reverse_table y with
     | Some x -> x
     | None ->
-      die "I don't know what ppx rewriters set %s correspond to."
-        (Digest.to_string y)
+      User_error.raise [ Pp.textf "I don't know what ppx rewriters set %s correspond to."
+        (Digest.to_string y) ]
 end
 
 let pped_module m ~f =

--- a/src/print_diff.ml
+++ b/src/print_diff.ml
@@ -17,9 +17,9 @@ let print ?(skip_trailing_cr=Sys.win32) path1 path2 =
   let loc = Loc.in_file file1 in
   let (file1, file2) = Path.(to_string file1, to_string file2) in
   let fallback () =
-    die "%aFiles %s and %s differ." Errors.print loc
+    User_error.raise [ Pp.textf "%aFiles %s and %s differ." Errors.print loc
       (Path.to_string_maybe_quoted path1)
-      (Path.to_string_maybe_quoted path2)
+      (Path.to_string_maybe_quoted path2) ]
   in
   let normal_diff () =
     match Bin.which ~path:(Env.path Env.initial) "diff" with
@@ -44,11 +44,11 @@ let print ?(skip_trailing_cr=Sys.win32) path1 path2 =
       sprintf "%s %s %s" cmd (quote_for_shell file1) (quote_for_shell file2)
     in
     let* () = Process.run ~dir ~env:Env.initial Strict sh [arg; cmd] in
-    die "command reported no differences: %s"
+    User_error.raise [ Pp.textf "command reported no differences: %s"
       (if Path.is_root dir then
          cmd
        else
-         sprintf "cd %s && %s" (quote_for_shell (Path.to_string dir)) cmd)
+         sprintf "cd %s && %s" (quote_for_shell (Path.to_string dir)) cmd) ]
   | None ->
     if Config.inside_dune then
       fallback ()

--- a/src/process.ml
+++ b/src/process.ml
@@ -364,34 +364,34 @@ let run_internal ?dir ?(stdout_to=Output.stdout) ?(stderr_to=Output.stderr)
     n
   | WEXITED n ->
     if display = Verbose then
-      die "\n@{<kwd>Command@} [@{<id>%d@}] exited with code %d:\n\
+      User_error.raise [ Pp.textf "\n@{<kwd>Command@} [@{<id>%d@}] exited with code %d:\n\
            @{<prompt>$@} %s\n%s"
         id n
         (Colors.strip_colors_for_stderr command_line)
-        (Colors.strip_colors_for_stderr output)
+        (Colors.strip_colors_for_stderr output) ]
     else if show_command then
-      die "@{<error>%12s@} %a @{<error>(exit %d)@}\n\
+      User_error.raise [ Pp.textf "@{<error>%12s@} %a @{<error>(exit %d)@}\n\
            @{<details>%s@}\n\
            %s"
         progname Fancy.pp_purpose purpose n
         (Ansi_color.strip command_line)
-        output
+        output ]
     else
-      die "%s" output
+      User_error.raise [ Pp.textf "%s" output ]
   | WSIGNALED n ->
     if display = Verbose then
-      die "\n@{<kwd>Command@} [@{<id>%d@}] got signal %s:\n\
+      User_error.raise [ Pp.textf "\n@{<kwd>Command@} [@{<id>%d@}] got signal %s:\n\
            @{<prompt>$@} %s\n%s"
         id (Utils.signal_name n)
         (Colors.strip_colors_for_stderr command_line)
-        (Colors.strip_colors_for_stderr output)
+        (Colors.strip_colors_for_stderr output) ]
     else
-      die "@{<error>%12s@} %a @{<error>(got signal %s)@}\n\
+      User_error.raise [ Pp.textf "@{<error>%12s@} %a @{<error>(got signal %s)@}\n\
            @{<details>%s@}\n\
            %s"
         progname Fancy.pp_purpose purpose (Utils.signal_name n)
         (Ansi_color.strip command_line)
-        output
+        output ]
   | WSTOPPED _ -> assert false
 
 let run ?dir ?stdout_to ?stderr_to ~env ?(purpose=Internal_job) fail_mode
@@ -429,7 +429,7 @@ let run_capture_line ?dir ?stderr_to ~env ?(purpose=Internal_job) fail_mode
       in
       match l with
       | [] ->
-        die "command returned nothing: %s" cmdline
+        User_error.raise [ Pp.textf "command returned nothing: %s" cmdline ]
       | _ ->
-        die "command returned too many lines: %s\n%s"
-          cmdline (String.concat l ~sep:"\n"))
+        User_error.raise [ Pp.textf "command returned too many lines: %s\n%s"
+          cmdline (String.concat l ~sep:"\n") ])

--- a/src/report_error.ml
+++ b/src/report_error.ml
@@ -33,6 +33,17 @@ let builtin_printer = function
   | Exn.Loc_error (loc, msg) ->
     let pp ppf = Format.fprintf ppf "@{<error>Error@}: %s\n" msg in
     Some (make_printer ~loc pp)
+  | User_error.E { loc; paragraphs } ->
+    let error = Pp.text "Error:" in
+    let paragraphs =
+      match paragraphs with
+      | [] -> [ error ]
+      | x :: l -> Pp.box [error; Pp.space; x ] :: l
+    in
+    let pp ppf =
+      Pp.pp ppf (Pp.vbox [ Pp.many paragraphs ~sep:Pp.cut ])
+    in
+    Some (make_printer ?loc pp)
   | Dune_lang.Parse_error e ->
     let loc = Dune_lang.Parse_error.loc     e in
     let msg = Dune_lang.Parse_error.message e in

--- a/src/report_error.mli
+++ b/src/report_error.mli
@@ -11,21 +11,20 @@ open! Stdune
     We cache what is actually printed to the screen.  *)
 val report : Exn_with_backtrace.t -> unit
 
-type printer
+module Printer : sig
+  type t
 
-val make_printer :
-  ?backtrace:bool ->
-  ?hint:string ->
-  ?loc:Loc.t ->
-  (Format.formatter -> unit) ->
-  printer
+  (** If [backtrace] is [true], then any available backtrace will be
+      printed. *)
+  val make : ?backtrace:bool -> User_message.t -> t
 
-val set_loc : printer -> loc:Loc.t -> printer
+  (** Register an error printer. *)
+  val register : (exn -> t option) -> unit
 
-val set_hint : printer -> hint:string -> printer
+  (** Find an error printer *)
+  val find : exn -> t option
 
-(** Register an error printer. *)
-val register : (exn -> printer option) -> unit
+  val set_loc : t -> loc:Loc.t -> t
+  val add_hint : t -> hint:User_message.Style.t Pp.t -> t
+end
 
-(** Find an error printer *)
-val find_printer : exn -> printer option

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -217,8 +217,8 @@ end = struct
              "--event"; "Updated";
              "--event"; "Removed"] @ excludes
          | None ->
-           die "@{<error>Error@}: fswatch (or inotifywait) was not found. \
-                One of them needs to be installed for watch mode to work.\n"))
+           User_error.raise [ Pp.textf "@{<error>Error@}: fswatch (or inotifywait) was not found. \
+                One of them needs to be installed for watch mode to work.\n" ]))
 
   let buffering_time = 0.5 (* seconds *)
   let buffer_capacity = 65536

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -86,12 +86,12 @@ module DB = struct
         with
         | [] | [_] -> assert false
         | loc1 :: loc2 :: _ ->
-          die "Public library %a is defined twice:\n\
+          User_error.raise [ Pp.textf "Public library %a is defined twice:\n\
                - %s\n\
                - %s"
             Lib_name.pp_quoted name
             (Loc.to_file_colon_line loc1)
-            (Loc.to_file_colon_line loc2)
+            (Loc.to_file_colon_line loc2) ]
     in
     let resolve = resolve t public_libs in
     let find_implementations = find_implementations t public_libs in

--- a/src/stdune/ansi_color.ml
+++ b/src/stdune/ansi_color.ml
@@ -182,7 +182,7 @@ let print =
          Render.channel
        else
          Render.channel_strip_colors)
-        stdout)
+        stdout))
   in
   fun ?margin pp -> Lazy.force f pp ?margin
 
@@ -193,7 +193,7 @@ let prerr =
          Render.channel
        else
          Render.channel_strip_colors)
-        stderr)
+        stderr))
   in
   fun ?margin pp -> Lazy.force f pp ?margin
 

--- a/src/stdune/ansi_color.mli
+++ b/src/stdune/ansi_color.mli
@@ -37,3 +37,13 @@ module Render : Pp.Renderer.S
 
 (** Filter out escape sequences in a string *)
 val strip : string -> string
+
+(** Print to [stdout] (not thread safe) *)
+val print : ?margin:int -> Style.t list Pp.t -> unit
+
+(** Print to [stderr] (not thread safe) *)
+val prerr : ?margin:int -> Style.t list Pp.t -> unit
+
+(** Whether [stdout]/[stderr] support colors *)
+val stdout_supports_color : bool Lazy.t
+val stderr_supports_color : bool Lazy.t

--- a/src/stdune/code_error.ml
+++ b/src/stdune/code_error.ml
@@ -20,4 +20,3 @@ let () =
   Printexc.register_printer (function
     | E t -> Some (Dyn.to_string (to_dyn t))
     | _ -> None)
-

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -48,7 +48,7 @@ let of_unix arr =
   |> List.map ~f:(fun s ->
     match String.lsplit2 s ~on:'=' with
     | None ->
-      Code_error.raise "Env.of_unix: entry without '=' found in the environ"
+      Exn.code_error "Env.of_unix: entry without '=' found in the environ"
         ["var", Sexp.Encoder.string s]
     | Some (k, v) -> (k, v))
   |> Map.of_list_multi

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -48,7 +48,7 @@ let of_unix arr =
   |> List.map ~f:(fun s ->
     match String.lsplit2 s ~on:'=' with
     | None ->
-      Exn.code_error "Env.of_unix: entry without '=' found in the environ"
+      Code_error.raise "Env.of_unix: entry without '=' found in the environ"
         ["var", Sexp.Encoder.string s]
     | Some (k, v) -> (k, v))
   |> Map.of_list_multi

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -3,25 +3,9 @@ module String = Dune_caml.StringLabels
 module Dyn = Dyn0
 type t = exn
 
-exception Fatal_error of string
-
-exception Loc_error of Loc0.t * string
-
 external raise         : exn -> _ = "%raise"
 external raise_notrace : exn -> _ = "%raise_notrace"
 external reraise       : exn -> _ = "%reraise"
-
-let () =
-  Printexc.register_printer (function
-    | Loc_error (loc, s) -> Some (Format.asprintf "%a%s" Loc0.print loc s)
-    | _ -> None)
-
-let fatalf ?loc fmt =
-  Format.ksprintf (fun s ->
-    match loc with
-    | None -> raise (Fatal_error s)
-    | Some loc -> raise (Loc_error (loc, s))
-  ) fmt
 
 let protectx x ~f ~finally =
   match f x with

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -1,22 +1,5 @@
 (** Exceptions *)
 
-
-(* CR-soon diml:
-   - Rename to [User_error]
-   - change the [string] argument to [Loc0.t option * string] and get rid of
-   [Loc.Error]. The two are a bit confusing
-   - change [string] to [Colors.Style.t Lib_name.t]
-*)
-(** A fatal error, that should be reported to the user in a nice way *)
-exception Fatal_error of string
-
-exception Loc_error of Loc0.t * string
-
-val fatalf
-  :  ?loc:Loc0.t
-  -> ('a, unit, string, string, string, 'b) format6
-  -> 'a
-
 val code_error : string -> (string * Sexp0.t) list -> _
 
 type t = exn

--- a/src/stdune/fdecl.ml
+++ b/src/stdune/fdecl.ml
@@ -9,9 +9,9 @@ let create () = { state = Unset }
 let set t x =
   match t.state with
   | Unset -> t.state <- Set x
-  | Set _ -> Exn.code_error "Fdecl.set: already set" []
+  | Set _ -> Code_error.raise "Fdecl.set: already set" []
 
 let get t =
   match t.state with
-  | Unset -> Exn.code_error "Fdecl.get: not set" []
+  | Unset -> Code_error.raise "Fdecl.get: not set" []
   | Set x -> x

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -57,7 +57,7 @@ module Make(H : Hashable.S) = struct
     match of_list l with
     | Result.Ok h -> h
     | Error (_, _, _) ->
-      Exn.code_error "Hashtbl.of_list_exn duplicate keys" []
+      Code_error.raise "Hashtbl.of_list_exn duplicate keys" []
 end
 
 open MoreLabels.Hashtbl

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -90,7 +90,7 @@ let rec find l ~f =
 let find_exn l ~f =
   match find l ~f with
   | Some x -> x
-  | None -> Exn.code_error "List.find_exn" []
+  | None -> Code_error.raise "List.find_exn" []
 
 let rec last = function
   | [] -> None

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -111,12 +111,12 @@ module Make(Key : Comparable.S) : S with type key = Key.t = struct
   let of_list_map_exn t ~f =
     match of_list_map t ~f with
     | Ok x -> x
-    | Error _ -> Exn.code_error "Map.of_list_map_exn" []
+    | Error _ -> Code_error.raise "Map.of_list_map_exn" []
 
   let of_list_exn l =
     match of_list l with
     | Ok    x -> x
-    | Error _ -> Exn.code_error "Map.of_list_exn" []
+    | Error _ -> Code_error.raise "Map.of_list_exn" []
 
   let of_list_reduce l ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->

--- a/src/stdune/option.ml
+++ b/src/stdune/option.ml
@@ -37,7 +37,7 @@ let value t ~default =
 
 let value_exn = function
   | Some x -> x
-  | None -> Exn.code_error "Option.value_exn" []
+  | None -> Code_error.raise "Option.value_exn" []
 
 let some x = Some x
 

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -17,6 +17,19 @@ type +'a t =
   | Text of string
   | Tag of 'a * 'a t
 
+let rec map_tags t ~f =
+  match t with
+  | Nop -> Nop
+  | Seq (a, b) -> Seq (map_tags a ~f, map_tags b ~f)
+  | Concat (sep, l) -> Concat (map_tags sep ~f, List.map l ~f:(map_tags ~f))
+  | Box (indent, t) -> Box (indent, map_tags t ~f)
+  | Vbox (indent, t) -> Vbox (indent, map_tags t ~f)
+  | Hbox t -> Hbox (map_tags t ~f)
+  | Hvbox (indent, t) -> Hvbox (indent, map_tags t ~f)
+  | Hovbox (indent, t) -> Hovbox (indent, map_tags t ~f)
+  | Verbatim _ | Char _ | Break _ | Newline | Text _ -> t
+  | Tag (tag, t) -> Tag (f tag, map_tags t ~f)
+
 module type Tag = sig
   type t
   module Handler : sig

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -199,3 +199,9 @@ let text s = Text s
 let textf fmt = Printf.ksprintf text fmt
 
 let tag t ~tag = Tag (tag, t)
+
+let enumerate l ~f =
+  vbox [ concat ~sep:cut (List.map l ~f:(fun x ->
+    box ~indent:2
+      [ seq (char '-') (seq space (f x)) ])
+  ]

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -85,6 +85,19 @@ val hvbox : ?indent:int -> 'a t list -> 'a t
 (** Try to put as much as possible on each line. *)
 val hovbox : ?indent:int -> 'a t list -> 'a t
 
+(** {1 Common convenience functions} *)
+
+(** [enumerate l ~f] produces an enumeration of the form:
+
+    {v
+       - item1
+       - item2
+       - item3
+       ...
+    v}
+*)
+val enumerate : 'a list -> f:('a -> 'b t) -> 'b t
+
 (** {1 Rendering} *)
 
 module type Tag = sig

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -53,6 +53,9 @@ val break : nspaces:int -> shift:int -> _ t
 (** Force a newline to be printed *)
 val newline : _ t
 
+(** Convert tags in a documents *)
+val map_tag : 'a t -> f:('a -> 'b) -> 'b t
+
 (** {1 Boxes} *)
 
 (** Boxes are the basic components to control the layout of the text.

--- a/src/stdune/set.ml
+++ b/src/stdune/set.ml
@@ -69,7 +69,7 @@ module Make(Elt : Comparable.S) : S with type elt = Elt.t = struct
     match choose t with
     | Some e -> e
     | None ->
-      Exn.code_error "Set.choose_exn" []
+      Code_error.raise "Set.choose_exn" []
 end
 
 let to_sexp to_list f t =

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -46,6 +46,7 @@ module Float      = Float
 module Tuple      = Tuple
 module Poly       = Poly
 module Code_error = Code_error
+module User_error = User_error
 
 external reraise : exn -> _ = "%reraise"
 

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -47,6 +47,8 @@ module Tuple      = Tuple
 module Poly       = Poly
 module Code_error = Code_error
 module User_error = User_error
+module User_message = User_message
+module User_warning = User_warning
 
 external reraise : exn -> _ = "%reraise"
 

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -114,9 +114,9 @@ let lsplit2_exn s ~on =
   match lsplit2 s ~on with
   | Some s -> s
   | None ->
-    Exn.code_error "lsplit2_exn"
-      [ "s", Sexp.Encoder.string s
-      ; "on", Sexp.Encoder.char on
+    Code_error.raise "lsplit2_exn"
+      [ "s", String s
+      ; "on", Char on
       ]
 
 let rsplit2 s ~on =

--- a/src/stdune/user_error.ml
+++ b/src/stdune/user_error.ml
@@ -1,0 +1,87 @@
+module Style = struct
+  type t =
+    | Loc
+    | Error
+    | Warning
+    | Kwd
+    | Id
+    | Prompt
+    | Details
+    | Ok
+    | Debug
+end
+
+type t =
+  { loc : Loc.t option
+  ; paragraphs : Style.t Pp.t list
+  }
+
+exception E of t
+
+let raise ?loc paragraphs =
+  raise (E { loc; paragraphs })
+
+let pp { loc = _; paragraphs } =
+  let error = Pp.text "Error:" in
+  let paragraphs =
+    match paragraphs with
+    | [] -> [ error ]
+    | x :: l -> Pp.box [error; Pp.space; x ] :: l
+  in
+  Pp.vbox [ Pp.concat paragraphs ~sep:Pp.cut ]
+
+let () =
+  Printexc.register_printer (function
+    | E t -> Some (Format.asprintf "%a@?" Pp.pp (pp t |> Pp.map_tags ~f:ignore))
+    | _ -> None)
+
+module Ansi_output = struct
+  type config = (Style.t -> Ansi_color.Style.t list)
+
+  let default_config : config = function
+    | Loc     -> [Bold]
+    | Error   -> [Bold; Fg Red]
+    | Warning -> [Bold; Fg Magenta]
+    | Kwd     -> [Bold; Fg Blue]
+    | Id      -> [Bold; Fg Yellow]
+    | Prompt  -> [Bold; Fg Green]
+    | Details -> [Dim; Fg White]
+    | Ok      -> [Dim; Fg Green]
+    | Debug   -> [Underlined; Fg Bright_cyan]
+
+  module Tag_handler = struct
+    type t =
+      { config : config
+      ; ansi_handler : Ansi_color.Render.Tag.Handler.t
+      }
+
+    let init =
+      { config = default_config
+      ; ansi_handler = Ansi_color.Render.Tag.Handler.init
+      }
+
+    let handle { config; ansi_handler } style =
+      let before, ansi_handler, after =
+        Ansi_color.Render.Tag.Handler.handle ansi_handler (config style)
+      in
+      before, { config; ansi_handler }, after
+  end
+
+  module Render = Pp.Renderer.Make(struct
+      type t = Style.t
+      module Handler = Tag_handler
+    end)
+
+  let print_without_colors =
+
+  let create oc =
+    let renderer = lazy (Staged.unstage (Render.channel oc)) in
+    fun ?(config=default_config) ?margin pp ->
+      let tag_handler : Render.Tag.Handler.t =
+        { Render.Tag.Handler.init with config }
+      in
+      Lazy.force renderer ~tag_handler ?margin pp)
+
+  let print = create stdout
+  let prerr = create stderr
+end

--- a/src/stdune/user_error.ml
+++ b/src/stdune/user_error.ml
@@ -1,87 +1,18 @@
-module Style = struct
-  type t =
-    | Loc
-    | Error
-    | Warning
-    | Kwd
-    | Id
-    | Prompt
-    | Details
-    | Ok
-    | Debug
-end
+exception E of User_message.t
 
-type t =
-  { loc : Loc.t option
-  ; paragraphs : Style.t Pp.t list
-  }
+let prefix =
+  Pp.seq
+    (Pp.tag (Pp.verbatim "Error") ~tag:User_message.Style.Error)
+    (Pp.char ':')
 
-exception E of t
+let make ?loc ?hints paragraphs =
+  User_message.make ?loc ?hints paragraphs ~prefix
 
-let raise ?loc paragraphs =
-  raise (E { loc; paragraphs })
-
-let pp { loc = _; paragraphs } =
-  let error = Pp.text "Error:" in
-  let paragraphs =
-    match paragraphs with
-    | [] -> [ error ]
-    | x :: l -> Pp.box [error; Pp.space; x ] :: l
-  in
-  Pp.vbox [ Pp.concat paragraphs ~sep:Pp.cut ]
+let raise ?loc ?hints paragraphs =
+  raise (E (make ?loc ?hints paragraphs))
 
 let () =
   Printexc.register_printer (function
-    | E t -> Some (Format.asprintf "%a@?" Pp.pp (pp t |> Pp.map_tags ~f:ignore))
+    | E t -> Some (Format.asprintf "%a@?" Pp.pp
+                     (User_message.pp t |> Pp.map_tags ~f:ignore))
     | _ -> None)
-
-module Ansi_output = struct
-  type config = (Style.t -> Ansi_color.Style.t list)
-
-  let default_config : config = function
-    | Loc     -> [Bold]
-    | Error   -> [Bold; Fg Red]
-    | Warning -> [Bold; Fg Magenta]
-    | Kwd     -> [Bold; Fg Blue]
-    | Id      -> [Bold; Fg Yellow]
-    | Prompt  -> [Bold; Fg Green]
-    | Details -> [Dim; Fg White]
-    | Ok      -> [Dim; Fg Green]
-    | Debug   -> [Underlined; Fg Bright_cyan]
-
-  module Tag_handler = struct
-    type t =
-      { config : config
-      ; ansi_handler : Ansi_color.Render.Tag.Handler.t
-      }
-
-    let init =
-      { config = default_config
-      ; ansi_handler = Ansi_color.Render.Tag.Handler.init
-      }
-
-    let handle { config; ansi_handler } style =
-      let before, ansi_handler, after =
-        Ansi_color.Render.Tag.Handler.handle ansi_handler (config style)
-      in
-      before, { config; ansi_handler }, after
-  end
-
-  module Render = Pp.Renderer.Make(struct
-      type t = Style.t
-      module Handler = Tag_handler
-    end)
-
-  let print_without_colors =
-
-  let create oc =
-    let renderer = lazy (Staged.unstage (Render.channel oc)) in
-    fun ?(config=default_config) ?margin pp ->
-      let tag_handler : Render.Tag.Handler.t =
-        { Render.Tag.Handler.init with config }
-      in
-      Lazy.force renderer ~tag_handler ?margin pp)
-
-  let print = create stdout
-  let prerr = create stderr
-end

--- a/src/stdune/user_error.mli
+++ b/src/stdune/user_error.mli
@@ -1,5 +1,13 @@
 (** Error meant for humans *)
 
+(** User errors are errors that users need to fix themselves in order
+    to make progress. Since these errors are read by users, they should
+    be simple to understand for people who are not familiar with the
+    dune codebase.
+*)
+exception E of User_message.t
+
+(** Styles that can be used inside error messages *)
 module Style : sig
   type t =
     | Loc
@@ -13,30 +21,18 @@ module Style : sig
     | Debug
 end
 
-(** An error that is meant to be shown to the user. If a location is
-    provided, it will be included at the beginning of the error
-    message.
+(** Raise a user error.  The arguments are interpreted in the same way
+    as [User_message.make]. The first paragraph is prefixed with
+    "Error:".  *)
+val raise
+  :  ?loc:Loc.t
+  -> ?hints:Style.t Pp.t list
+  -> Style.t Pp.t list
+  -> _
 
-    The various paragraphs are printed one after the other and all
-    start at the beginning of a line. They are all wrapped inside a
-    [Pp.box] and the first paragraph is prefixed with "Error: ".  *)
-type t =
-  { loc : Loc.t option
-  ; paragraphs : Style.t Pp.t list
-  }
-
-exception E of t
-
-val raise : ?loc:Loc.t -> Style.t Pp.t list -> _
-
-val pp : t -> Style.t Pp.t
-
-module Ansi_output : sig
-  type config = (Style.t -> Ansi_color.Style.t list)
-
-  (** Print to [stdout] (not thread safe) *)
-  val print : ?config:config -> ?margin:int -> Style.t Pp.t -> unit
-
-  (** Print to [stderr] (not thread safe) *)
-  val prerr : ?config:config -> ?margin:int -> Style.t Pp.t -> unit
-end
+(** Create a user error. *)
+val make
+  :  ?loc:Loc.t
+  -> ?hints:Style.t Pp.t list
+  -> Style.t Pp.t list
+  -> User_message.t

--- a/src/stdune/user_error.mli
+++ b/src/stdune/user_error.mli
@@ -1,0 +1,42 @@
+(** Error meant for humans *)
+
+module Style : sig
+  type t =
+    | Loc
+    | Error
+    | Warning
+    | Kwd
+    | Id
+    | Prompt
+    | Details
+    | Ok
+    | Debug
+end
+
+(** An error that is meant to be shown to the user. If a location is
+    provided, it will be included at the beginning of the error
+    message.
+
+    The various paragraphs are printed one after the other and all
+    start at the beginning of a line. They are all wrapped inside a
+    [Pp.box] and the first paragraph is prefixed with "Error: ".  *)
+type t =
+  { loc : Loc.t option
+  ; paragraphs : Style.t Pp.t list
+  }
+
+exception E of t
+
+val raise : ?loc:Loc.t -> Style.t Pp.t list -> _
+
+val pp : t -> Style.t Pp.t
+
+module Ansi_output : sig
+  type config = (Style.t -> Ansi_color.Style.t list)
+
+  (** Print to [stdout] (not thread safe) *)
+  val print : ?config:config -> ?margin:int -> Style.t Pp.t -> unit
+
+  (** Print to [stderr] (not thread safe) *)
+  val prerr : ?config:config -> ?margin:int -> Style.t Pp.t -> unit
+end

--- a/src/stdune/user_message.ml
+++ b/src/stdune/user_message.ml
@@ -11,7 +11,7 @@ module Style = struct
     | Debug
 end
 
-module Print_config : sig
+module Print_config = struct
   type t = Style.t -> Ansi_color.Style.t list
 
   let default : t = function
@@ -73,7 +73,7 @@ let prerr ?(config=Print_config.default) ?margin t =
   Ansi_color.prerr ?margin (Pp.map_tags (pp t) ~f:config)
 
 (* As found here http://rosettacode.org/wiki/Levenshtein_distance#OCaml *)
-let levenshtein_distance s t let levenshtein_distance s t =
+let levenshtein_distance s t =
   let m = String.length s
   and n = String.length t in
   (* for all i and j, d.(i).(j) will hold the Levenshtein distance between

--- a/src/stdune/user_message.ml
+++ b/src/stdune/user_message.ml
@@ -1,0 +1,114 @@
+module Style = struct
+  type t =
+    | Loc
+    | Error
+    | Warning
+    | Keyword
+    | Id
+    | Prompt
+    | Details
+    | Ok
+    | Debug
+end
+
+module Print_config : sig
+  type t = Style.t -> Ansi_color.Style.t list
+
+  let default : t = function
+    | Loc     -> [Bold]
+    | Error   -> [Bold; Fg Red]
+    | Warning -> [Bold; Fg Magenta]
+    | Keyword -> [Bold; Fg Blue]
+    | Id      -> [Bold; Fg Yellow]
+    | Prompt  -> [Bold; Fg Green]
+    | Details -> [Dim; Fg White]
+    | Ok      -> [Dim; Fg Green]
+    | Debug   -> [Underlined; Fg Bright_cyan]
+end
+
+type t =
+  { loc : Loc.t option
+  ; paragraphs : Style.t Pp.t list
+  ; hints : Style.t Pp.t list
+  }
+
+let make ?loc ?(hints=[]) ?prefix paragraphs =
+  let paragraphs =
+    match prefix, paragraphs with
+    | None, l -> l
+    | Some p, [] -> [p]
+    | Some p, x :: l ->
+      Pp.concat ~sep:Pp.space [p; x] :: l
+  in
+  { loc; hints; paragraphs }
+
+let pp { loc; paragraphs; hints } =
+  let paragraphs =
+    match hints with
+    | [] -> paragraphs
+    | l ->
+      List.append
+        paragraphs
+        (List.map hints ~f:(fun hint ->
+           Pp.concat ~sep:Pp.space [Pp.verbatim "Hint:"; hint]))
+  in
+  let paragraphs = List.map paragraphs ~f:(fun x -> Pp.box [x]) in
+  let paragraphs =
+    match loc with
+    | None -> paragraphs
+    | Some { Loc.start; stop } ->
+      let start_c = start.pos_cnum - start.pos_bol in
+      let stop_c  = stop.pos_cnum  - start.pos_bol in
+      Pp.tag ~tag:User_message.Style.Loc
+        (Pp.textf "File %S, line %d, characters %d-%d:"
+           start.pos_fname start.pos_lnum start_c stop_c)
+      :: paragraphs
+  in
+  Pp.vbox [ Pp.concat paragraphs ~sep:Pp.cut ]
+
+let print ?(config=Print_config.default) ?margin t =
+  Ansi_color.print ?margin (Pp.map_tags (pp t) ~f:config)
+
+let prerr ?(config=Print_config.default) ?margin t =
+  Ansi_color.prerr ?margin (Pp.map_tags (pp t) ~f:config)
+
+(* As found here http://rosettacode.org/wiki/Levenshtein_distance#OCaml *)
+let levenshtein_distance s t let levenshtein_distance s t =
+  let m = String.length s
+  and n = String.length t in
+  (* for all i and j, d.(i).(j) will hold the Levenshtein distance between
+     the first i characters of s and the first j characters of t *)
+  let d = Array.make_matrix (m+1) (n+1) 0 in
+
+  for i = 0 to m do
+    (* the distance of any first string to an empty second string *)
+    d.(i).(0) <- i
+  done;
+  for j = 0 to n do
+    (* the distance of any second string to an empty first string *)
+    d.(0).(j) <- j
+  done;
+
+  for j = 1 to n do
+    for i = 1 to m do
+
+      if s.[i-1] = t.[j-1] then
+        d.(i).(j) <- d.(i-1).(j-1)  (* no operation required *)
+      else
+        d.(i).(j) <- minimum
+                       (d.(i-1).(j) + 1)   (* a deletion *)
+                       (d.(i).(j-1) + 1)   (* an insertion *)
+                       (d.(i-1).(j-1) + 1) (* a substitution *)
+    done;
+  done;
+
+  d.(m).(n)
+
+let did_you_mean s ~candidates =
+  let candidates =
+    List.filter candidates ~f:(fun candidate ->
+      levenshtein_distance s candidate < 3)
+  in
+  match candidates with
+  | [] -> []
+  | l -> [Pp.textf "did you mean %s?" (String.enumerate_or l)]

--- a/src/stdune/user_message.mli
+++ b/src/stdune/user_message.mli
@@ -1,0 +1,62 @@
+(** A message for the user *)
+
+(** User messages are styled document that can be printed to the
+    console or in the log file. *)
+
+(** Styles that can be used inside messages *)
+module Style : sig
+  type t =
+    | Loc
+    | Error
+    | Warning
+    | Kwd
+    | Id
+    | Prompt
+    | Details
+    | Ok
+    | Debug
+end
+
+(** A user message.contents composed of an optional file location and
+    a list of paragraphs.
+
+    The various paragraphs will be printed one after the other and
+    will all start at the beginning of a line. They are all wrapped
+    inside a [Pp.box].
+
+    When hints are provided, they are printed as last paragraphs and
+    prefixed with "Hint:".  Hints should give indication to the user
+    for how to fix the issue.
+*)
+type t =
+  { loc : Loc.t option
+  ; paragraphs : Style.t Pp.t list
+  ; hints : Style.t Pp.t list
+  ; backtrace : Printexc.raw_backtrace option
+  }
+
+val pp : t -> Style.t Pp.t
+
+module Print_config : sig
+  (** Associate ANSI terminal styles to abstract styles *)
+  type t = Style.t -> Ansi_color.Style.t list
+
+  (** The default configuration *)
+  val default : t
+end
+
+(** Construct a user message from a list of paragraphs.
+
+    The first paragraph is prefixed with [prefix] inside the
+    box. [prefix] should not end with a space as a space is
+    automatically inserted by [make] if necessary. *)
+val make : ?loc:Loc.t -> ?prefix:t -> ?hints:Style.t Pp.t list -> t list -> t
+
+(** Print to [stdout] (not thread safe) *)
+val print : ?config:Print_config.t -> ?margin:int -> t -> unit
+
+(** Print to [stderr] (not thread safe) *)
+val prerr : ?config:Print_config.t -> ?margin:int -> t -> unit
+
+(** Produces a "Did you mean ...?" hint *)
+val did_you_mean : string -> candidates:string list -> Style.t Pp.t list

--- a/src/stdune/user_warning.ml
+++ b/src/stdune/user_warning.ml
@@ -1,0 +1,11 @@
+let reporter = ref (fun msg -> User_message.prerr msg)
+
+let set_reporter f = reporter := f
+
+let emit ~loc ?hints paragraphs =
+  !reporter
+    (User_message.make paragraphs ~loc ?hints
+       ~prefix:(Pp.seq
+                  (Pp.tag (Pp.verbatim "Warning")
+                     ~tag:User_message.Style.Warning)
+                  (Pp.char ':')))

--- a/src/stdune/user_warning.mli
+++ b/src/stdune/user_warning.mli
@@ -8,8 +8,8 @@
     prefixed with "Warning: " rather than "Error: ". *)
 val emit
   :  loc:Loc.t
-  -> ?hints:Style.t Pp.t list
-  -> Style.t Pp.t list
+  -> ?hints:User_message.Style.t Pp.t list
+  -> User_message.Style.t Pp.t list
   -> _
 
 (** Set the warning reporter. The default one is

--- a/src/stdune/user_warning.mli
+++ b/src/stdune/user_warning.mli
@@ -1,0 +1,17 @@
+(** Non-fatal user errors *)
+
+(** Warnings are user errors that cannot be proper errors for backward
+    compatibility reasons *)
+
+(** Emit a user warning. The arguments are interpreted in a similar
+    fashion to {!User_error.raise} except that the first paragraph is
+    prefixed with "Warning: " rather than "Error: ". *)
+val emit
+  :  loc:Loc.t
+  -> ?hints:Style.t Pp.t list
+  -> Style.t Pp.t list
+  -> _
+
+(** Set the warning reporter. The default one is
+    [User_message.prerr]. *)
+val set_reporter : (User_message.t -> unit) -> unit

--- a/src/sub_dirs.ml
+++ b/src/sub_dirs.ml
@@ -61,7 +61,7 @@ let decode =
            | "" | "." | ".." -> true
            | _ -> false
         then
-          of_sexp_errorf loc "Invalid sub-directory name %S" dn
+          User_error.raise ~loc [ Pp.textf "Invalid sub-directory name %S" dn ]
         else
           dn)
       |> list

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -41,7 +41,7 @@ module Version = struct
           Errors.fail loc "Atom of the form NNN.NNN expected"
       end
     | sexp ->
-      of_sexp_error (Dune_lang.Ast.loc sexp) "Atom expected"
+      User_error.raise ~loc:(Dune_lang.Ast.loc sexp) [ Pp.text "Atom expected" ]
 
   let can_read
         ~parser_version:(parser_major, parser_minor)

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -95,18 +95,22 @@ end
 
 module Error = struct
   let since loc t ver ~what =
-    Errors.fail loc "%s" @@ Error_msg.since t ver ~what
+    user_error ~loc
+      [ Pp.text (Error_msg.since t ver ~what) ]
 
   let renamed_in loc t ver ~what ~to_ =
-    Errors.fail loc "%s was renamed to '%s' in the %s version of %s"
-      what to_ (Version.to_string ver) t.desc
+    user_error ~loc
+      [ Pp.textf "%s was renamed to '%s' in the %s version of %s"
+          what to_ (Version.to_string ver) t.desc
+      ]
 
   let deleted_in loc t ?repl ver ~what =
-    Errors.fail loc "%s was deleted in version %s of %s%s"
-      what (Version.to_string ver) t.desc
-      (match repl with
-       | None -> ""
-       | Some s -> ".\n" ^ s)
+    user_error ~loc
+      (Pp.textf "%s was deleted in version %s of %s"
+         what (Version.to_string ver) t.desc
+       :: match repl with
+       | None -> []
+       | Some s -> [Pp.text s])
 end
 
 module Warning = struct

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -136,27 +136,24 @@ let library_private_dir ~obj_dir =
 let executable_object_directory ~dir name =
   Path.Build.relative dir ("." ^ name ^ ".eobjs")
 
+let not_found fmt ?loc ?context ?hint x =
+  user_error ?loc
+    (Pp.many
+       (Pp.textf fmt (String.maybe_quoted x)
+        :: match context with
+        | None -> []
+        | Some name -> [Pp.textf " (context: %s)" name])
+     :: match hint with
+     | None -> []
+     | Some hint -> [Pp.textf "Hint: %s" hint])
+
 let program_not_found ?context ?hint ~loc prog =
-  Errors.fail_opt loc
-    "@{<error>Error@}: Program %s not found in the tree or in PATH%s%a"
-    (String.maybe_quoted prog)
-    (match context with
-     | None -> ""
-     | Some name -> sprintf " (context: %s)" name)
-    (fun fmt -> function
-       | None -> ()
-       | Some h -> Format.fprintf fmt "@ Hint: %s" h)
-    hint
+  not_found "Program %s not found in the tree or in PATH"
+    ?context ?hint ?loc prog
 
 let library_not_found ?context ?hint lib =
-  die "@{<error>Error@}: Library %s not found%s%a" (String.maybe_quoted lib)
-    (match context with
-     | None -> ""
-     | Some name -> sprintf " (context: %s)" name)
-    (fun fmt -> function
-       | None -> ()
-       | Some h -> Format.fprintf fmt "@ Hint: %s" h)
-    hint
+  not_found "Library %s not found"
+    ?context ?hint lib
 
 let install_file ~(package : Package.Name.t) ~findlib_toolchain =
   let package = Package.Name.to_string package in

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -13,9 +13,9 @@ let system_shell_exn =
     match Lazy.force bin with
     | Some path -> (path, arg)
     | None ->
-      die "I need %s to %s but I couldn't find it :(\n\
+      User_error.raise [ Pp.textf "I need %s to %s but I couldn't find it :(\n\
            Who doesn't have %s%s?!"
-        cmd needed_to cmd os
+        cmd needed_to cmd os ]
 
 let bash_exn =
   let bin = lazy (Bin.which ~path:(Env.path Env.initial) "bash") in
@@ -23,8 +23,8 @@ let bash_exn =
     match Lazy.force bin with
     | Some path -> path
     | None ->
-      die "I need bash to %s but I couldn't find it :("
-        needed_to
+      User_error.raise [ Pp.textf "I need bash to %s but I couldn't find it :("
+        needed_to ]
 
 let signal_name =
   let table =

--- a/src/watermarks.ml
+++ b/src/watermarks.ml
@@ -268,19 +268,19 @@ let get_name ~files ~(dune_project : Dune_project.t option) ?name () =
       | _ -> None)
   in
   if package_names = [] then
-    die "@{<error>Error@}: no <package>.opam files found.";
+    User_error.raise [ Pp.textf "@{<error>Error@}: no <package>.opam files found." ];
   let (loc, name) =
     match Wp.t with
     | Dune -> begin
         assert (Option.is_none name);
         match dune_project with
         | None ->
-          die "@{<error>Error@}: There is no dune-project file in the current \
+          User_error.raise [ Pp.textf "@{<error>Error@}: There is no dune-project file in the current \
                directory, please add one with a (name <name>) field in it.\n\
-               Hint: dune subst must be executed from the root of the project."
+               Hint: dune subst must be executed from the root of the project." ]
         | Some { name = None; _ } ->
-          die "@{<error>Error@}: The project name is not defined, please add \
-               a (name <name>) field to your dune-project file."
+          User_error.raise [ Pp.textf "@{<error>Error@}: The project name is not defined, please add \
+               a (name <name>) field to your dune-project file." ]
         | Some { name = Some n; _ } -> (n.loc_of_arg, n.arg)
       end
     | Jbuilder ->
@@ -306,12 +306,12 @@ let get_name ~files ~(dune_project : Dune_project.t option) ?name () =
           match name with
           | Some name -> (Loc.none, name)
           | None ->
-            die "@{<error>Error@}: cannot determine name automatically.\n\
-                 You must pass a [--name] command line argument."
+            User_error.raise [ Pp.textf "@{<error>Error@}: cannot determine name automatically.\n\
+                 You must pass a [--name] command line argument." ]
   in
   if not (List.mem name ~set:package_names) then begin
     if Loc.is_none loc then
-      die "@{<error>Error@}: file %s.opam doesn't exist." name
+      User_error.raise [ Pp.textf "@{<error>Error@}: file %s.opam doesn't exist." name ]
     else
       Errors.fail loc
         "file %s.opam doesn't exist. \

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -40,8 +40,8 @@ module Context = struct
            name = "install" ||
            String.contains name '/' ||
            String.contains name '\\' then
-          of_sexp_errorf loc
-            "%S is not allowed as a build context name" name;
+          User_error.raise ~loc
+            [ Pp.textf "%S is not allowed as a build context name" name ];
         name)
   end
 


### PR DESCRIPTION
The current error reporting API is a bit complex, we have too many functions to report user errors and many error messages are not cut properly and contains very long lines.

This PR proposes a new simpler API that makes it easier to construct well formatted error messages.

All error reporting functions are replaced by only two: `User_error.raise` and `Code_error.raise`. At this point, this PR only partially updates `Stdune` and a couple of call sites in src. I'd like to get some feedback on the new API before refactoring the whole code base.

## user errors

User errors are errors that users need to fix themselves in order to make progress. Since these errors are read by users, they should be simple to understand for people who are not familiar with the dune codebase.

```ocaml
val User_error.raise : ?loc:Loc.t -> Style.t Pp.t list -> _
```

This functions takes an optional location as well a list of paragraphs. Each paragraph starts on a new line and the first one is prefixed by `Error: `.

One noticeable point is the use of `Pp.t` rather `Format` format strings. I personally find it difficult to produce well formatted error messages using the `Format` or even `Fmt` API. In practice, grepping `test/blackbox-tests/test-cases` reveals that many error messages contain lines that are longer than 80 characters even though `Format` uses a margin of 80 characters by default, so I'm guessing that this is a general problem.

On the other hand, the `Pp` API makes it easier to construct arbitrarily complex messages programmatically that are well formatted.

The `Style.t` type indicate the that parts of the message might be styled with styles such as `Error`, `Details`, ...

## code errors

Code errors are errors that are due to programming errors and should be reported upstream. Since they are aimed at Dune developers, these don't need to be human readable and can leak internal details of the Dune codebase, such as the representation of internal data structures.

```
val Code_error.raise : string -> (string * Dyn.t) list -> _
```

The API is the same as before, except that we now use `Dyn.t` rather than `Sexp.t`.