### PR TITLE
Port Super_context.t to use Path.Build.t

### DIFF
--- a/src/coq_rules.boot.ml
+++ b/src/coq_rules.boot.ml
@@ -1,5 +1,5 @@
 module Dir_contents = Dir_contents (* hack for bootstrappign + ocamldep*)
 
-let setup_rules ~sctx:_ ~build_dir:_ ~dir:_ ~dir_contents:_ _ = []
+let setup_rules ~sctx:_ ~dir:_ ~dir_contents:_ _ = []
 let install_rules ~sctx:_ ~dir:_ _ = []
 let coqpp_rules ~sctx:_ ~build_dir:_ ~dir:_ _ = []

--- a/src/coq_rules.mli
+++ b/src/coq_rules.mli
@@ -8,7 +8,6 @@ open! Stdune
 
 val setup_rules
   :  sctx:Super_context.t
-  -> build_dir:Path.t
   -> dir:Path.t
   -> dir_contents:Dir_contents.t
   -> Dune_file.Coq.t

--- a/src/install_rules.mli
+++ b/src/install_rules.mli
@@ -2,6 +2,6 @@ open Stdune
 
 val gen_rules : Super_context.t -> (dir:Path.Build.t -> unit)
 
-val init_meta : Super_context.t -> dir:Path.t -> unit
+val init_meta : Super_context.t -> dir:Path.Build.t -> unit
 
 val packages : Super_context.t -> Package.Name.Set.t Path.Map.t

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -240,8 +240,5 @@ let local_packages_by_dir = Memo.exec local_packages_by_dir_def
 let defined_in sctx ~dir =
   let local_packages = of_sctx sctx in
   let by_build_dir = local_packages_by_dir local_packages in
-  match Path.as_in_build_dir dir with
-  | None -> []
-  | Some dir ->
-    Path.Build.Map.find by_build_dir dir
-    |> Option.value ~default:[]
+  Path.Build.Map.find by_build_dir dir
+  |> Option.value ~default:[]

--- a/src/local_package.mli
+++ b/src/local_package.mli
@@ -41,6 +41,6 @@ val virtual_lib : t -> Lib.t option
 
 val meta_template : t -> Path.Build.t
 
-val defined_in : Super_context.t -> dir:Path.t -> t list
+val defined_in : Super_context.t -> dir:Path.Build.t -> t list
 
 val coqlibs : t -> Dune_file.Coq.t Dir_with_dune.t list

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -585,7 +585,8 @@ let init sctx =
            begin match l.public with
            | Some _ -> None
            | None ->
-             let scope = SC.find_scope_by_dir sctx w.ctx_dir in
+             let scope =
+               SC.find_scope_by_dir sctx (Path.as_in_build_dir_exn w.ctx_dir) in
              Some (Option.value_exn (
                Lib.DB.find_even_when_hidden (Scope.libs scope)
                  (Library.best_name l))

--- a/src/opam_create.ml
+++ b/src/opam_create.ml
@@ -145,8 +145,8 @@ let add_rule sctx ~project ~pkg =
 
 let add_rules sctx ~dir =
   let project =
-    let scope = Super_context.find_scope_by_dir sctx dir in
-    Scope.project scope
+    Super_context.find_scope_by_dir sctx dir
+    |> Scope.project
   in
   if Dune_project.generate_opam_files project then begin
     Local_package.defined_in sctx ~dir

--- a/src/opam_create.mli
+++ b/src/opam_create.mli
@@ -1,3 +1,3 @@
 open Stdune
 
-val add_rules : Super_context.t -> dir:Path.t -> unit
+val add_rules : Super_context.t -> dir:Path.Build.t -> unit

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -76,8 +76,7 @@ let internal_lib_names t =
 let public_libs    t = t.public_libs
 let installed_libs t = t.installed_libs
 
-let find_scope_by_dir t dir  =
-  Scope.DB.find_by_dir  t.scopes (Path.as_in_build_dir_exn dir)
+let find_scope_by_dir t dir = Scope.DB.find_by_dir t.scopes dir
 let find_scope_by_name t name = Scope.DB.find_by_name t.scopes name
 
 module External_env = Env

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -70,7 +70,7 @@ val local_binaries : t -> dir:Path.t -> File_binding.Expanded.t list
 (** Dump a directory environment in a readable form *)
 val dump_env : t -> dir:Path.t -> (unit, Dune_lang.t list) Build.t
 
-val find_scope_by_dir  : t -> Path.t              -> Scope.t
+val find_scope_by_dir  : t -> Path.Build.t        -> Scope.t
 val find_scope_by_name : t -> Dune_project.Name.t -> Scope.t
 
 val add_rule

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -118,7 +118,8 @@ module Stanza = struct
   let setup ~sctx ~dir ~(toplevel : Dune_file.Toplevel.t) =
     let source = Source.of_stanza ~dir ~toplevel in
     let expander = Super_context.expander sctx ~dir in
-    let scope = Super_context.find_scope_by_dir sctx dir in
+    let scope =
+      Super_context.find_scope_by_dir sctx (Path.as_in_build_dir_exn dir) in
     let compile_info =
       let compiler_libs =
         Lib_name.of_string_exn ~loc:(Some source.loc) "compiler-libs.toplevel"

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -52,7 +52,8 @@ let libs_under_dir sctx ~db ~dir =
 
 let setup sctx ~dir =
   let expander = Super_context.expander sctx ~dir in
-  let scope = Super_context.find_scope_by_dir sctx dir in
+  let scope =
+    Super_context.find_scope_by_dir sctx (Path.as_in_build_dir_exn dir) in
   let db = Scope.libs scope in
   let libs = libs_under_dir sctx ~db ~dir in
   let source = source ~dir in


### PR DESCRIPTION
Additionally, we port Opam_create's rule as well as it now becomes easy to do
so.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>