### PR TITLE
Use Path.Build.t in Obj_dir and Utop

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -29,7 +29,8 @@ module Modules = struct
         match (stanza : Stanza.t) with
         | Library lib ->
           let obj_dir =
-            Obj_dir.make_lib ~dir:d.ctx_dir (snd lib.name)
+            Obj_dir.make_lib ~dir:(Path.as_in_build_dir_exn d.ctx_dir)
+              (snd lib.name)
               ~has_private_modules:(Option.is_some lib.private_modules)
           in
           let modules =
@@ -72,7 +73,8 @@ module Modules = struct
         | Executables exes
         | Tests { exes; _} ->
           let obj_dir =
-            Obj_dir.make_exe ~dir:d.ctx_dir ~name:(snd (List.hd exes.names))
+            Obj_dir.make_exe ~dir:(Path.as_in_build_dir_exn d.ctx_dir)
+              ~name:(snd (List.hd exes.names))
           in
           let modules =
             Modules_field_evaluator.eval ~modules

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -247,7 +247,7 @@ module Library : sig
   val best_name : t -> Lib_name.t
   val is_virtual : t -> bool
   val is_impl : t -> bool
-  val obj_dir : dir:Path.t -> t -> Obj_dir.t
+  val obj_dir : dir:Path.Build.t -> t -> Obj_dir.t
 
   module Main_module_name : sig
     type t = Module.Name.t option Inherited.t

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -8,7 +8,8 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       (exes : Dune_file.Executables.t) =
   (* Use "eobjs" rather than "objs" to avoid a potential conflict
      with a library of the same name *)
-  let obj_dir = Obj_dir.make_exe ~dir ~name:(snd (List.hd exes.names)) in
+  let obj_dir = Obj_dir.make_exe ~dir:(Path.as_in_build_dir_exn dir)
+                  ~name:(snd (List.hd exes.names)) in
   Check_rules.add_obj_dir sctx ~obj_dir;
   let modules =
     Dir_contents.modules_of_executables dir_contents

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -76,7 +76,8 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
       let dir = ctx_dir in
       match stanza with
       | Toplevel toplevel ->
-        Toplevel_rules.setup ~sctx ~dir ~toplevel;
+        Toplevel_rules.setup ~sctx
+          ~dir:(Path.as_in_build_dir_exn dir) ~toplevel;
         For_stanza.empty_none
       | Library lib ->
         let cctx, merlin =

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -171,7 +171,8 @@ include Sub_system.Register_end_point(
       let inline_test_dir = Path.relative dir ("." ^ inline_test_name) in
 
       let obj_dir =
-        Obj_dir.make_exe ~dir:inline_test_dir ~name:inline_test_name in
+        Obj_dir.make_exe ~dir:(Path.as_in_build_dir_exn inline_test_dir)
+          ~name:inline_test_name in
 
       let name = "run" in
       let main_module_filename = name ^ ".ml" in

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -98,7 +98,7 @@ let of_library_stanza ~dir
       (conf : Dune_file.Library.t) =
   let (_loc, lib_name) = conf.name in
   let obj_dir =
-    Obj_dir.make_lib ~dir
+    Obj_dir.make_lib ~dir:(Path.as_in_build_dir_exn dir)
       ~has_private_modules:(conf.private_modules <> None) lib_name in
   let gen_archive_file ~dir ext =
     Path.relative dir (Lib_name.Local.to_string lib_name ^ ext) in

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -413,11 +413,12 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let lib_modules =
       Dir_contents.modules_of_library dir_contents ~name:(Library.best_name lib)
     in
-    let obj_dir = Library.obj_dir ~dir lib in
+    let obj_dir = Library.obj_dir ~dir:(Path.as_in_build_dir_exn dir) lib in
     Check_rules.add_obj_dir sctx ~obj_dir;
     let source_modules = Lib_modules.modules lib_modules in
     let vimpl =
-      Virtual_rules.impl sctx ~lib ~dir ~scope ~modules:source_modules in
+      Virtual_rules.impl sctx ~lib ~dir:(Path.as_in_build_dir_exn dir)
+        ~scope ~modules:source_modules in
     Option.iter vimpl ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir);
     (* Preprocess before adding the alias module as it doesn't need
        preprocessing *)

--- a/src/module.ml
+++ b/src/module.ml
@@ -262,7 +262,7 @@ let odoc_file t ~doc_dir =
     | Public -> doc_dir
     | Private -> Utils.library_private_dir ~obj_dir:doc_dir
   in
-  Path.relative base (t.obj_name ^ ".odoc")
+  Path.Build.relative base (t.obj_name ^ ".odoc")
 
 let cmti_file t =
   match t.intf with

--- a/src/module.mli
+++ b/src/module.mli
@@ -101,7 +101,7 @@ val src_dir : t -> Path.t option
 val cm_file_unsafe : t -> ?ext:string -> Cm_kind.t -> Path.t
 val cm_public_file_unsafe : t -> ?ext:string -> Cm_kind.t -> Path.t
 
-val odoc_file : t -> doc_dir:Path.t -> Path.t
+val odoc_file : t -> doc_dir:Path.Build.t -> Path.Build.t
 
 (** Either the .cmti, or .cmt if the module has no interface *)
 val cmti_file : t -> Path.t

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -27,12 +27,12 @@ val to_sexp: t -> Sexp.t
 val all_obj_dirs : t -> mode:Mode.t -> Path.t list
 
 val make_lib
-  :  dir:Path.t
+  :  dir:Path.Build.t
   -> has_private_modules:bool
   -> Lib_name.Local.t
   -> t
 
-val make_exe: dir:Path.t -> name:string -> t
+val make_exe: dir:Path.Build.t -> name:string -> t
 
 val make_external_no_private : dir:Path.t -> t
 

--- a/src/toplevel.mli
+++ b/src/toplevel.mli
@@ -4,7 +4,7 @@ module Source : sig
   type t
 
   val make
-    :  dir:Path.t
+    :  dir:Path.Build.t
     -> loc:Loc.t
     -> main:string
     -> name:string
@@ -24,7 +24,7 @@ val make : cctx:Compilation_context.t -> source:Source.t -> t
 module Stanza : sig
   val setup
     :  sctx:Super_context.t
-    -> dir:Path.t
+    -> dir:Path.Build.t
     -> toplevel:Dune_file.Toplevel.t
     -> unit
 end

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -117,24 +117,24 @@ let describe_target fn =
     Path.to_string_maybe_quoted fn
 
 let library_object_directory ~dir name =
-  Path.relative dir ("." ^ Lib_name.Local.to_string name ^ ".objs")
+  Path.Build.relative dir ("." ^ Lib_name.Local.to_string name ^ ".objs")
 
 let library_native_dir ~obj_dir =
-  Path.relative obj_dir "native"
+  Path.Build.relative obj_dir "native"
 
 let library_byte_dir ~obj_dir =
-  Path.relative obj_dir "byte"
+  Path.Build.relative obj_dir "byte"
 
 let library_public_cmi_dir ~obj_dir =
-  Path.relative obj_dir "public_cmi"
+  Path.Build.relative obj_dir "public_cmi"
 
 let library_private_dir ~obj_dir =
-  Path.relative obj_dir "private"
+  Path.Build.relative obj_dir "private"
 
 (* Use "eobjs" rather than "objs" to avoid a potential conflict with a
    library of the same name *)
 let executable_object_directory ~dir name =
-  Path.relative dir ("." ^ name ^ ".eobjs")
+  Path.Build.relative dir ("." ^ name ^ ".eobjs")
 
 let program_not_found ?context ?hint ~loc prog =
   Errors.fail_opt loc

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -18,24 +18,24 @@ val describe_target : Path.t -> string
 (** Return the directory where the object files for the given
     library should be stored. *)
 val library_object_directory
-  :  dir:Path.t
+  :  dir:Path.Build.t
   -> Lib_name.Local.t
-  -> Path.t
+  -> Path.Build.t
 
 (** cmx, .a *)
-val library_native_dir     : obj_dir:Path.t -> Path.t
+val library_native_dir     : obj_dir:Path.Build.t -> Path.Build.t
 
 (** cmo, cmi, cmt, cmti *)
-val library_byte_dir       : obj_dir:Path.t -> Path.t
-val library_public_cmi_dir : obj_dir:Path.t -> Path.t
-val library_private_dir    : obj_dir:Path.t -> Path.t
+val library_byte_dir       : obj_dir:Path.Build.t -> Path.Build.t
+val library_public_cmi_dir : obj_dir:Path.Build.t -> Path.Build.t
+val library_private_dir    : obj_dir:Path.Build.t -> Path.Build.t
 
 (** Return the directory where the object files for the given
     executable should be stored. *)
 val executable_object_directory
-  :  dir:Path.t
+  :  dir:Path.Build.t
   -> string
-  -> Path.t
+  -> Path.Build.t
 
 type target_kind =
   | Regular of string (* build context *) * Path.Source.t

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -15,8 +15,8 @@ let utop_exe =
 
 let source ~dir =
   Toplevel.Source.make
-    ~dir:(Path.relative dir utop_dir_basename)
-    ~loc:(Loc.in_dir dir)
+    ~dir:(Path.Build.relative dir utop_dir_basename)
+    ~loc:(Loc.in_dir (Path.build dir))
     ~main:"UTop_main.main ();"
     ~name:exe_name
 
@@ -61,7 +61,7 @@ let setup sctx ~dir =
   in
   let db = Scope.libs scope in
   let libs = libs_under_dir sctx ~db ~dir in
-  let source = source ~dir in
+  let source = source ~dir:(Path.as_in_build_dir_exn dir) in
   let obj_dir = Toplevel.Source.obj_dir source in
   let loc = Toplevel.Source.loc source in
   let modules = Toplevel.Source.modules source in

--- a/src/vimpl.mli
+++ b/src/vimpl.mli
@@ -8,7 +8,7 @@ type t
 val make
   :  vlib:Lib.t
   -> impl:Dune_file.Library.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> vlib_modules:Lib_modules.t
   -> vlib_foreign_objects:Path.t list
   -> vlib_dep_graph:Dep_graph.Ml_kind.t

--- a/src/virtual_rules.mli
+++ b/src/virtual_rules.mli
@@ -8,7 +8,7 @@ val setup_copy_rules_for_impl
 
 val impl
   :  Super_context.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> lib:Dune_file.Library.t
   -> scope:Scope.t
   -> modules:Module.Name_map.t


### PR DESCRIPTION
This is likely to have a small conflict with PR #2192. I'll clean it up once either one of the PR's is merged.

The list of public functions updated:
* Dune_file.obj_dir
* Module.odoc_file
* Obj_dir.make_lib
* Obj_dir.make_exe
* Toplevel.Source.make
* Utils.library_object_directory
* Utils.library_native_dir
* Utils.library_public_cmi_dir
* Utils.library_private_dir
* Vimpl.make
* Virtual_rules.impl