### PR TITLE
Fix detecting odig files for installation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,10 @@ unreleased
 - Run `ocamlformat` relative to the context root. This improves the locations of
   errors. (#2196, fixes #1370, @rgrinberg)
 
+- Fix detection of `README`, `LICENSE`, `CHANGE`, and `HISTORY` files. These
+  would be undetected whenever the project was nested in another workspace.
+  (#2194, @rgrinberg)
+
 1.9.3 (06/05/2019)
 ------------------
 

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -132,11 +132,11 @@ module Of_sctx = struct
       Super_context.packages sctx
       |> Package.Name.Map.map ~f:(fun (pkg : Package.t) ->
         let odig_files =
-          let files =
-            Super_context.source_files sctx ~src_path:Path.Source.root in
+          let files = Super_context.source_files sctx ~src_path:pkg.path in
+          let pkg_dir = Path.Build.append_source ctx_build_dir pkg.path in
           String.Set.fold files ~init:[] ~f:(fun fn acc ->
             if is_odig_doc_file fn then
-              Path.Build.relative ctx_build_dir fn :: acc
+              Path.Build.relative pkg_dir fn :: acc
             else
               acc)
         in

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1047,6 +1047,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name odig-files-workspace)
+ (deps (package dune) (source_tree test-cases/odig-files-workspace))
+ (action
+  (chdir
+   test-cases/odig-files-workspace
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name odoc)
  (deps (package dune) (source_tree test-cases/odoc))
  (action
@@ -1595,6 +1603,7 @@
   (alias ocaml-syntax)
   (alias ocamldep-multi-stanzas)
   (alias ocamllex-jbuild)
+  (alias odig-files-workspace)
   (alias odoc)
   (alias odoc-package-mld-link)
   (alias odoc-unique-mlds)
@@ -1762,6 +1771,7 @@
   (alias ocaml-syntax)
   (alias ocamldep-multi-stanzas)
   (alias ocamllex-jbuild)
+  (alias odig-files-workspace)
   (alias old-dune-subsystem)
   (alias optional)
   (alias output-obj)

--- a/test/blackbox-tests/test-cases/odig-files-workspace/project/dune-project
+++ b/test/blackbox-tests/test-cases/odig-files-workspace/project/dune-project
@@ -1,0 +1,4 @@
+(lang dune 1.10)
+
+(package
+ (name foobar))

--- a/test/blackbox-tests/test-cases/odig-files-workspace/run.t
+++ b/test/blackbox-tests/test-cases/odig-files-workspace/run.t
@@ -5,3 +5,6 @@ Odig files should be detected relative to the package directory
     "_build/install/default/lib/foobar/META"
     "_build/install/default/lib/foobar/dune-package"
   ]
+  doc: [
+    "_build/install/default/doc/foobar/LICENSE"
+  ]

--- a/test/blackbox-tests/test-cases/odig-files-workspace/run.t
+++ b/test/blackbox-tests/test-cases/odig-files-workspace/run.t
@@ -1,0 +1,7 @@
+Odig files should be detected relative to the package directory
+  $ dune build @install --root .
+  $ cat project/foobar.install
+  lib: [
+    "_build/install/default/lib/foobar/META"
+    "_build/install/default/lib/foobar/dune-package"
+  ]


### PR DESCRIPTION
These files are relative to the project rather than the context. Otherwise, they
will not be included in the .install file in composed builds.

I will add a test if this is fix is indeed what we want.