### PR TITLE
Run ocamlformat from build context root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,9 @@ unreleased
 
 - Support the `.cc` extension fro C++ sources (#2195, fixes #83, @rgrinberg)
 
+- Run `ocamlformat` relative to the context root. This improves the locations of
+  errors. (#2196, fixes #1370, @rgrinberg)
+
 1.9.3 (06/05/2019)
 ------------------
 

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -61,7 +61,8 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
           ; Target output
           ]
         in
-        Some (Lazy.force ocamlformat_deps >>> Build.run ~dir exe args)
+        Some (Lazy.force ocamlformat_deps
+              >>> Build.run ~dir:(Super_context.build_dir sctx) exe args)
       else
         None
     in

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -77,7 +77,7 @@ And fixable files can be promoted:
   Promoting _build/default/enabled/.formatted/ocaml_file.ml to enabled/ocaml_file.ml.
   Promoting _build/default/enabled/.formatted/reason_file.re to enabled/reason_file.re.
   $ cat enabled/ocaml_file.ml
-  Sys.argv: ../../install/default/bin/ocamlformat --impl ocaml_file.ml --name ../../../enabled/ocaml_file.ml -o .formatted/ocaml_file.ml
+  Sys.argv: ../install/default/bin/ocamlformat --impl enabled/ocaml_file.ml --name ../../enabled/ocaml_file.ml -o enabled/.formatted/ocaml_file.ml
   ocamlformat output
   $ cat enabled/reason_file.re
   Sys.argv: ../../install/default/bin/refmt reason_file.re


### PR DESCRIPTION
This will output errors relative to the correct directory.

@jordwalke Should a similar change be done to `refmt`?