### PR TITLE
Port more functions to use Path.Build.t

### DIFF
--- a/src/c.ml
+++ b/src/c.ml
@@ -111,7 +111,7 @@ module Sources = struct
 
   let objects (t : t) ~dir ~ext_obj =
     String.Map.keys t
-    |> List.map ~f:(fun c -> Path.relative dir (c ^ ext_obj))
+    |> List.map ~f:(fun c -> Path.Build.relative dir (c ^ ext_obj))
 
   let split_by_kind t =
     let (c, cxx) =

--- a/src/c.mli
+++ b/src/c.mli
@@ -61,7 +61,7 @@ end
 module Sources : sig
   type t = (Loc.t * Source.t) String.Map.t
 
-  val objects : t -> dir:Path.t -> ext_obj:string -> Path.t list
+  val objects : t -> dir:Path.Build.t -> ext_obj:string -> Path.Build.t list
 
   val split_by_kind : t -> t Kind.Dict.t
 end

--- a/src/coq_module.ml
+++ b/src/coq_module.ml
@@ -32,8 +32,8 @@ let source x = x.source
 let prefix x = x.prefix
 let name x = x.name
 let obj_file ~obj_dir ~ext x =
-  let vo_dir = List.fold_left x.prefix ~init:obj_dir ~f:Path.relative in
-  Path.relative vo_dir (x.name ^ ext)
+  let vo_dir = List.fold_left x.prefix ~init:obj_dir ~f:Path.Build.relative in
+  Path.Build.relative vo_dir (x.name ^ ext)
 let pp fmt x =
   let open Format in
   let pp_sep fmt () = pp_print_string fmt "." in

--- a/src/coq_module.mli
+++ b/src/coq_module.mli
@@ -32,7 +32,7 @@ val make
 val source : t -> Path.Build.t
 val prefix : t -> string list
 val name : t -> string
-val obj_file : obj_dir:Path.t -> ext:string -> t -> Path.t
+val obj_file : obj_dir:Path.Build.t -> ext:string -> t -> Path.Build.t
 val pp : t Fmt.t
 
 (** Parses a form "a.b.c" to a module *)

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1081,16 +1081,16 @@ module Library = struct
     in
     name ^ "_stubs"
 
-  let stubs t ~dir = Path.relative dir (stubs_name t)
+  let stubs t ~dir = Path.Build.relative dir (stubs_name t)
 
   let stubs_archive t ~dir ~ext_lib =
-    Path.relative dir (sprintf "lib%s%s" (stubs_name t) ext_lib)
+    Path.Build.relative dir (sprintf "lib%s%s" (stubs_name t) ext_lib)
 
   let dll t ~dir ~ext_dll =
-    Path.relative dir (sprintf "dll%s%s" (stubs_name t) ext_dll)
+    Path.Build.relative dir (sprintf "dll%s%s" (stubs_name t) ext_dll)
 
   let archive t ~dir ~ext =
-    Path.relative dir (Lib_name.Local.to_string (snd t.name) ^ ext)
+    Path.Build.relative dir (Lib_name.Local.to_string (snd t.name) ^ ext)
 
   let best_name t =
     match t.public with

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -240,10 +240,10 @@ module Library : sig
 
   val has_stubs : t -> bool
   val stubs_name : t -> string
-  val stubs : t -> dir:Path.t -> Path.t
-  val stubs_archive : t -> dir:Path.t -> ext_lib:string -> Path.t
-  val dll : t -> dir:Path.t -> ext_dll:string -> Path.t
-  val archive : t -> dir:Path.t -> ext:string -> Path.t
+  val stubs : t -> dir:Path.Build.t -> Path.Build.t
+  val stubs_archive : t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
+  val dll : t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
+  val archive : t -> dir:Path.Build.t -> ext:string -> Path.Build.t
   val best_name : t -> Lib_name.t
   val is_virtual : t -> bool
   val is_impl : t -> bool

--- a/src/env_node.ml
+++ b/src/env_node.ml
@@ -112,8 +112,7 @@ let rec ocaml_flags t ~profile ~expander =
       match find_config t ~profile with
       | None -> default
       | Some cfg ->
-        let dir = Path.build t.dir in
-        let expander = Expander.set_dir expander ~dir in
+        let expander = Expander.set_dir expander ~dir:t.dir in
         Ocaml_flags.make
           ~spec:cfg.flags
           ~default
@@ -135,8 +134,7 @@ let rec c_flags t ~profile ~expander ~default_context_flags =
       match find_config t ~profile with
       | None -> default
       | Some cfg ->
-        let dir = Path.build t.dir in
-        let expander = Expander.set_dir expander ~dir in
+        let expander = Expander.set_dir expander ~dir:t.dir in
         C.Kind.Dict.mapi cfg.c_flags ~f:(fun ~kind f ->
           let default = C.Kind.Dict.get default kind in
           Expander.expand_and_eval_set expander f ~standard:default)

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -130,7 +130,7 @@ let link_exe
   let requires = CC.requires_link cctx in
   let expander = CC.expander      cctx in
   let mode = linkage.mode in
-  let exe = Path.build (exe_path_from_name cctx ~name ~linkage) in
+  let exe = exe_path_from_name cctx ~name ~linkage in
   let compiler = Option.value_exn (Context.compiler ctx mode) in
   let kind = Mode.cm_kind mode in
   let artifacts ~ext modules =
@@ -151,7 +151,7 @@ let link_exe
         artifacts modules ~ext:ctx.ext_obj))
   in
   (* The rule *)
-  SC.add_rule sctx ~loc ~dir:(Path.build dir)
+  SC.add_rule sctx ~loc ~dir
     (let cm_files    = register_native_objs_deps modules_and_cm_files >>^ snd in
      let ocaml_flags = Ocaml_flags.get (CC.flags cctx) mode
      in
@@ -160,7 +160,7 @@ let link_exe
        (Command.run ~dir:(Path.build ctx.build_dir)
           (Ok compiler)
           [ Command.Args.dyn ocaml_flags
-          ; A "-o"; Target exe
+          ; A "-o"; Target (Path.build exe)
           ; As linkage.flags
           ; Command.Args.dyn link_flags
           ; Command.of_result_map link_time_code_gen
@@ -181,7 +181,7 @@ let link_exe
       Js_of_ocaml_rules.build_exe cctx ~js_of_ocaml ~src:exe ~cm
         ~flags:(Command.Args.dyn flags)
     in
-    SC.add_rules ~dir:(Path.build dir) sctx rules
+    SC.add_rules ~dir sctx rules
 
 let build_and_link_many
       ~programs

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -9,7 +9,6 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
   (* Use "eobjs" rather than "objs" to avoid a potential conflict
      with a library of the same name *)
   let obj_dir = Obj_dir.make_exe ~dir ~name:(snd (List.hd exes.names)) in
-  let dir = Path.build dir in
   Check_rules.add_obj_dir sctx ~obj_dir;
   let modules =
     Dir_contents.modules_of_executables dir_contents
@@ -70,11 +69,8 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       l
   in
 
-  let flags =
-    SC.ocaml_flags sctx ~dir:(Path.as_in_build_dir_exn dir) exes.buildable in
-  let link_deps =
-    SC.Deps.interpret sctx ~expander exes.link_deps
-  in
+  let flags = SC.ocaml_flags sctx ~dir exes.buildable in
+  let link_deps = SC.Deps.interpret sctx ~expander exes.link_deps in
   let link_flags =
     link_deps >>^ ignore >>>
     Expander.expand_and_eval_set expander exes.link_flags

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -1,7 +1,7 @@
 open Stdune
 
 type t =
-  { dir : Path.t
+  { dir : Path.Build.t
   ; hidden_env : Env.Var.Set.t
   ; env : Env.t
   ; lib_artifacts : Artifacts.Public_libs.t
@@ -111,7 +111,7 @@ let make ~scope ~(context : Context.t) ~lib_artifacts
       | expansion -> Some (Error expansion))
   in
   let ocaml_config = lazy (make_ocaml_config context.ocaml_config) in
-  let dir = Path.build context.build_dir in
+  let dir = context.build_dir in
   let bindings = Pform.Map.create ~context in
   let env = context.env in
   let c_compiler = context.c_compiler in
@@ -128,16 +128,16 @@ let make ~scope ~(context : Context.t) ~lib_artifacts
   }
 
 let expand t ~mode ~template =
-  String_with_vars.expand ~dir:t.dir ~mode template
+  String_with_vars.expand ~dir:(Path.build t.dir) ~mode template
     ~f:(expand_var_exn t)
 
 let expand_path t sw =
   expand t ~mode:Single ~template:sw
-  |> Value.to_path ~error_loc:(String_with_vars.loc sw) ~dir:t.dir
+  |> Value.to_path ~error_loc:(String_with_vars.loc sw) ~dir:(Path.build t.dir)
 
 let expand_str t sw =
   expand t ~mode:Single ~template:sw
-  |> Value.to_string ~dir:t.dir
+  |> Value.to_string ~dir:(Path.build t.dir)
 
 type reduced_var_result =
   | Unknown
@@ -233,11 +233,12 @@ let resolve_binary t ~loc ~prog =
     Error {Import. fail = fun () -> Action.Prog.Not_found.raise e }
 
 let expand_and_record acc ~map_exe ~dep_kind ~scope
-      ~expansion_kind ~dir ~pform t expansion
-      ~(cc : dir:Path.t -> (unit, Value.t list) Build.t C.Kind.Dict.t) =
+      ~expansion_kind ~(dir : Path.Build.t) ~pform t expansion
+      ~(cc : dir:Path.Build.t -> (unit, Value.t list) Build.t C.Kind.Dict.t) =
   let key = String_with_vars.Var.full_name pform in
   let loc = String_with_vars.Var.loc pform in
-  let relative = Path.relative ~error_loc:loc in
+  let relative d s =
+    Path.build (Path.Build.relative ~error_loc:loc d s) in
   let add_ddep =
     match expansion_kind with
     | Static -> fun _ ->
@@ -346,7 +347,7 @@ let expand_and_record acc ~map_exe ~dep_kind ~scope
         }
     end
 
-let expand_and_record_deps acc ~dir ~read_package ~dep_kind
+let expand_and_record_deps acc ~(dir : Path.Build.t) ~read_package ~dep_kind
       ~targets_written_by_user ~map_exe ~expand_var ~cc
       t pform syntax_version =
   let res =
@@ -400,7 +401,8 @@ let expand_no_ddeps acc ~dir ~dep_kind ~map_exe ~expand_var
   Option.map res ~f:Result.ok
 
 let gen_with_record_deps ~expand t resolved_forms ~dep_kind ~map_exe
-      ~(c_flags : dir:Path.t -> (unit, string list) Build.t C.Kind.Dict.t) =
+      ~(c_flags : dir:Path.Build.t
+        -> (unit, string list) Build.t C.Kind.Dict.t) =
   let cc ~dir = cc_of_c_flags t (c_flags ~dir) in
   let expand_var =
     expand
@@ -487,7 +489,7 @@ let add_ddeps_and_bindings t ~dynamic_expansions ~deps_written_by_user =
 
 let expand_and_eval_set t set ~standard =
   let open Build.O in
-  let dir = dir t in
+  let dir = Path.build (dir t) in
   let parse ~loc:_ s = s in
   let standard =
     if Ordered_set_lang.Unexpanded.has_special_forms set then
@@ -521,4 +523,4 @@ let expand_and_eval_set t set ~standard =
 
 let eval_blang t = function
   | Blang.Const x -> x (* common case *)
-  | blang -> Blang.eval blang ~dir:t.dir ~f:(expand_var_exn t)
+  | blang -> Blang.eval blang ~dir:(Path.build t.dir) ~f:(expand_var_exn t)

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -13,7 +13,7 @@ type t
 
 val bindings : t -> Pform.Map.t
 val scope : t -> Scope.t
-val dir : t -> Path.t
+val dir : t -> Path.Build.t
 
 val make
   :  scope:Scope.t
@@ -26,7 +26,7 @@ val set_env : t -> var:string -> value:string -> t
 
 val hide_env : t -> var:string -> t
 
-val set_dir : t -> dir:Path.t -> t
+val set_dir : t -> dir:Path.Build.t -> t
 
 val set_scope : t -> scope:Scope.t -> t
 
@@ -96,7 +96,7 @@ val with_record_deps
   -> targets_written_by_user:Targets.t
   -> dep_kind:Lib_deps_info.Kind.t
   -> map_exe:(Path.t -> Path.t)
-  -> c_flags:(dir:Path.t -> (unit, string list) Build.t C.Kind.Dict.t)
+  -> c_flags:(dir:Path.Build.t -> (unit, string list) Build.t C.Kind.Dict.t)
   -> t
 
 val with_record_no_ddeps
@@ -104,7 +104,7 @@ val with_record_no_ddeps
   -> Resolved_forms.t
   -> dep_kind:Lib_deps_info.Kind.t
   -> map_exe:(Path.t -> Path.t)
-  -> c_flags:(dir:Path.t -> (unit, string list) Build.t C.Kind.Dict.t)
+  -> c_flags:(dir:Path.Build.t -> (unit, string list) Build.t C.Kind.Dict.t)
   -> t
 
 val add_ddeps_and_bindings

--- a/src/format_rules.mli
+++ b/src/format_rules.mli
@@ -3,10 +3,10 @@ open Import
 (** Setup automatic format rules for the given dir.
     If tools like ocamlformat are not available in $PATH, just display an error
     message when the alias is built. *)
-val gen_rules : dir:Path.t -> unit
+val gen_rules : dir:Path.Build.t -> unit
 
 val gen_rules_output
   :  Super_context.t
   -> Dune_file.Auto_format.t
-  -> output_dir:Path.t
+  -> output_dir:Path.Build.t
   -> unit

--- a/src/js_of_ocaml_rules.mli
+++ b/src/js_of_ocaml_rules.mli
@@ -7,14 +7,14 @@ open Dune_file
 val build_cm
   :  Compilation_context.t
   -> js_of_ocaml:Js_of_ocaml.t
-  -> src:Path.t
-  -> target:Path.t
+  -> src:Path.Build.t
+  -> target:Path.Build.t
   -> (unit, Action.t) Build.t list
 
 val build_exe
   :  Compilation_context.t
   -> js_of_ocaml:Js_of_ocaml.t
-  -> src:Path.t
+  -> src:Path.Build.t
   -> cm:Path.t list Build.s
   -> flags:Command.Args.dynamic Command.Args.t
   -> Action.t Build.s list

--- a/src/lib_archives.ml
+++ b/src/lib_archives.ml
@@ -44,9 +44,10 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
              files @ [ Library.archive ~dir lib ~ext:".cmxs" ]
            else
              files)
-      ; List.map lib.buildable.js_of_ocaml.javascript_files ~f:(Path.relative dir)
+      ; List.map lib.buildable.js_of_ocaml.javascript_files
+          ~f:(Path.Build.relative dir)
       ; List.map lib.install_c_headers ~f:(fun fn ->
-          Path.relative dir (fn ^ ".h"))
+          Path.Build.relative dir (fn ^ ".h"))
       ]
   in
   let dlls  =
@@ -54,6 +55,8 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
          Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries)
       [Library.dll ~dir lib ~ext_dll:ctx.ext_dll]
   in
+  let files = List.map ~f:Path.build files in
+  let dlls = List.map ~f:Path.build dlls in
   { files
   ; dlls
   }

--- a/src/lib_archives.mli
+++ b/src/lib_archives.mli
@@ -4,7 +4,7 @@ type t
 
 val make
   :  ctx:Context.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> dir_contents:Dir_contents.t
   -> Dune_file.Library.t
   -> t

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -62,15 +62,17 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       let ocaml_flags = Ocaml_flags.get flags mode in
       let cclibs = Expander.expand_and_eval_set expander lib.c_library_flags
                      ~standard:(Build.return []) in
-      let library_flags = Expander.expand_and_eval_set expander lib.library_flags
-                            ~standard:(Build.return []) in
+      let library_flags =
+        Expander.expand_and_eval_set expander lib.library_flags
+          ~standard:(Build.return []) in
       SC.add_rule ~dir sctx ~loc:lib.buildable.loc
         (Build.S.seq obj_deps
            (Command.run (Ok compiler) ~dir:(Path.build ctx.build_dir)
               [ Command.Args.dyn ocaml_flags
-              ; A "-a"; A "-o"; Target target
+              ; A "-a"; A "-o"; Target (Path.build target)
               ; As stubs_flags
-              ; Dyn (Build.S.map cclibs ~f:(fun x -> Command.quote_args "-cclib" (map_cclibs x)))
+              ; Dyn (Build.S.map cclibs
+                       ~f:(fun x -> Command.quote_args "-cclib" (map_cclibs x)))
               ; Command.Args.dyn library_flags
               ; As (match lib.kind with
                   | Normal -> []
@@ -79,7 +81,8 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
               ; Hidden_targets
                   (match mode with
                    | Byte -> []
-                   | Native -> [Library.archive lib ~dir ~ext:ctx.ext_lib])
+                   | Native ->
+                     [Path.build (Library.archive lib ~dir ~ext:ctx.ext_lib)])
               ])))
 
   (* If the compiler reads the cmi for module alias even with
@@ -149,7 +152,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       let source_path = Option.value_exn (Module.file m Impl) in
       Build.return contents
       >>> Build.write_file_dyn source_path
-      |> SC.add_rule sctx ~dir:(Path.build (Compilation_context.dir cctx))
+      |> SC.add_rule sctx ~dir:(Compilation_context.dir cctx)
     );
     let dep_graphs =
       Dep_graph.Ml_kind.wrapped_compat ~modules ~wrapped_compat
@@ -158,48 +161,47 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     Module_compilation.build_modules cctx ~js_of_ocaml ~dynlink ~dep_graphs
 
   let build_c_file (lib : Library.t) ~dir ~expander ~includes (loc, src, dst) =
-    let c_flags = (SC.c_flags sctx ~dir:(Path.as_in_build_dir_exn dir)
-                     ~expander ~flags:lib.c_flags).c in
+    let c_flags = (SC.c_flags sctx ~dir ~expander ~flags:lib.c_flags).c in
     SC.add_rule sctx ~loc ~dir
       (
         let src = Path.build (C.Source.path src) in
         Command.run
           (* We have to execute the rule in the library directory as
              the .o is produced in the current directory *)
-          ~dir
+          ~dir:(Path.build dir)
           (Ok ctx.ocamlc)
           [ A "-g"
           ; includes
-          ; Dyn (Build.S.map c_flags ~f:(fun x -> Command.quote_args "-ccopt" x))
-          ; A "-o"; Target dst
+          ; Dyn (
+              Build.S.map c_flags ~f:(fun x -> Command.quote_args "-ccopt" x))
+          ; A "-o"; Target (Path.build dst)
           ; Dep src
           ]);
     dst
 
-  let build_cxx_file (lib : Library.t) ~dir ~expander ~includes (loc, src, dst) =
+  let build_cxx_file
+        (lib : Library.t) ~dir ~expander ~includes (loc, src, dst) =
     let output_param =
+      let dst = Path.build dst in
       if ctx.ccomp_type = "msvc" then
         [Command.Args.Concat ("", [A "/Fo"; Target dst])]
       else
         [A "-o"; Target dst]
     in
-    let cxx_flags = (SC.c_flags sctx ~dir:(Path.as_in_build_dir_exn dir)
-                       ~expander ~flags:lib.c_flags).cxx in
-    SC.add_rule sctx ~loc ~dir
-      (
-        let src = Path.build (C.Source.path src) in
-        Command.run
-          (* We have to execute the rule in the library directory as
-             the .o is produced in the current directory *)
-          ~dir
-          (SC.resolve_program ~loc:None ~dir:(Path.as_in_build_dir_exn dir)
-             sctx ctx.c_compiler)
-          ([ Command.Args.S [A "-I"; Path ctx.stdlib_dir]
-           ; includes
-           ; Command.Args.dyn cxx_flags
-           ] @ output_param @
-           [ A "-c"; Dep src
-           ]));
+    let cxx_flags = (SC.c_flags sctx ~dir ~expander ~flags:lib.c_flags).cxx in
+    SC.add_rule sctx ~loc ~dir (
+      let src = Path.build (C.Source.path src) in
+      Command.run
+        (* We have to execute the rule in the library directory as
+           the .o is produced in the current directory *)
+        ~dir:(Path.build dir)
+        (SC.resolve_program ~loc:None ~dir sctx ctx.c_compiler)
+        ([ Command.Args.S [A "-I"; Path ctx.stdlib_dir]
+         ; includes
+         ; Command.Args.dyn cxx_flags
+         ] @ output_param @
+         [ A "-c"; Dep src
+         ]));
     dst
 
   let ocamlmklib (lib : Library.t) ~dir ~expander ~o_files ~sandbox ~custom
@@ -214,7 +216,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
          [ A "-g"
          ; if custom then A "-custom" else As []
          ; A "-o"
-         ; Path (Library.stubs lib ~dir)
+         ; Path (Path.build (Library.stubs lib ~dir))
          ; Deps o_files
          ; Dyn (Build.S.map cclibs_args ~f:(fun cclibs ->
              (* https://github.com/ocaml/dune/issues/119 *)
@@ -224,7 +226,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
              else
                As cclibs
            ))
-         ; Hidden_targets targets
+         ; Hidden_targets (List.map ~f:Path.build targets)
          ])
 
   let build_self_stubs lib ~expander ~dir ~o_files =
@@ -274,15 +276,17 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let build_x_files build_x files =
       String.Map.to_list files
       |> List.map ~f:(fun (obj, (loc, src)) ->
-        let dst = Path.relative dir (obj ^ ctx.ext_obj) in
+        let dst = Path.Build.relative dir (obj ^ ctx.ext_obj) in
         build_x lib ~dir ~expander ~includes (loc, src, dst)
       )
     in
     let { C.Kind.Dict. c; cxx } = C.Sources.split_by_kind c_sources in
     build_x_files build_c_file c
     @ build_x_files build_cxx_file cxx
+    |> List.map ~f:Path.build
 
-  let build_stubs lib ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_files =
+  let build_stubs lib ~dir ~expander ~requires ~dir_contents
+        ~vlib_stubs_o_files =
     let lib_o_files =
       if Library.has_stubs lib then
         let c_sources = Dir_contents.c_sources_of_library
@@ -297,23 +301,31 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
 
   let build_shared lib ~dir ~flags ~(ctx : Context.t) =
     Option.iter ctx.ocamlopt ~f:(fun ocamlopt ->
-      let src = Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Native) in
-      let dst = Library.archive lib ~dir ~ext:".cmxs" in
+      let src =
+        let ext = Mode.compiled_lib_ext Native in
+        Path.build (Library.archive lib ~dir ~ext)
+      in
+      let dst =
+        let ext = Mode.plugin_ext Native in
+        Path.build (Library.archive lib ~dir ~ext)
+      in
       let build =
-        Build.S.seq (Build.dyn_paths (Build.arr (fun () ->
-          [Library.archive lib ~dir ~ext:ctx.ext_lib])))
+        Build.S.seq (Build.dyn_paths (Build.arr (fun () -> [
+            Path.build (Library.archive lib ~dir ~ext:ctx.ext_lib)
+          ])))
           (Command.run ~dir:(Path.build ctx.build_dir)
              (Ok ocamlopt)
              [ Command.Args.dyn (Ocaml_flags.get flags Native)
              ; A "-shared"; A "-linkall"
-             ; A "-I"; Path dir
+             ; A "-I"; Path (Path.build dir)
              ; A "-o"; Target dst
              ; Dep src
              ])
       in
       let build =
         if Library.has_stubs lib then
-          Build.path (Library.stubs_archive ~dir lib ~ext_lib:ctx.ext_lib)
+          Build.path (Path.build (Library.stubs_archive ~dir lib
+                                    ~ext_lib:ctx.ext_lib))
           >>>
           build
         else
@@ -325,7 +337,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         ~wrapped_compat ~cctx ~(dep_graphs : Dep_graph.Ml_kind.t)
         ~expander
         ~vlib_dep_graphs =
-    let dir = Path.build (Compilation_context.dir cctx) in
+    let dir = Compilation_context.dir cctx in
     let obj_dir = Compilation_context.obj_dir cctx in
     let flags = Compilation_context.flags cctx in
     let modules = Compilation_context.modules cctx in
@@ -344,7 +356,9 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
             ; Cmx, ctx.ext_obj ]
             |> List.iter ~f:(fun (kind, ext) ->
               let src = Module.obj_file m ~kind ~ext in
-              let dst = Path.relative dir ((Module.obj_name m) ^ ext) in
+              let dst =
+                Path.build (Path.Build.relative dir
+                              ((Module.obj_name m) ^ ext)) in
               SC.add_rule sctx ~dir (Build.copy ~src ~dst));
             Module.Name.Map.remove modules name
         end
@@ -383,11 +397,12 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     if modes.byte then
       SC.add_rules sctx ~dir (
         let src =
-          Library.archive lib ~dir
-            ~ext:(Mode.compiled_lib_ext Mode.Byte) in
+          Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Mode.Byte) in
         let target =
-          Path.relative (Obj_dir.obj_dir obj_dir) (Path.basename src)
-          |> Path.extend_basename ~suffix:".js" in
+          Path.Build.relative
+            (Path.as_in_build_dir_exn (Obj_dir.obj_dir obj_dir))
+            (Path.Build.basename src)
+          |> Path.Build.extend_basename ~suffix:".js" in
         Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target);
     if Dynlink_supported.By_the_os.get ctx.natdynlink_supported
     && modes.native then
@@ -398,17 +413,15 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let dep_kind =
       if lib.optional then Lib_deps_info.Kind.Optional else Required
     in
-    let flags =
-      SC.ocaml_flags sctx ~dir:(Path.as_in_build_dir_exn dir) lib.buildable in
+    let flags = SC.ocaml_flags sctx ~dir lib.buildable in
     let lib_modules =
       Dir_contents.modules_of_library dir_contents ~name:(Library.best_name lib)
     in
-    let obj_dir = Library.obj_dir ~dir:(Path.as_in_build_dir_exn dir) lib in
+    let obj_dir = Library.obj_dir ~dir lib in
     Check_rules.add_obj_dir sctx ~obj_dir;
     let source_modules = Lib_modules.modules lib_modules in
     let vimpl =
-      Virtual_rules.impl sctx ~lib ~dir:(Path.as_in_build_dir_exn dir)
-        ~scope ~modules:source_modules in
+      Virtual_rules.impl sctx ~lib ~dir ~scope ~modules:source_modules in
     Option.iter vimpl ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir);
     (* Preprocess before adding the alias module as it doesn't need
        preprocessing *)
@@ -480,8 +493,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     && Lib_modules.needs_alias_module lib_modules then
       build_alias_module ~dir ~lib_modules ~cctx ~dynlink ~js_of_ocaml;
 
-    let expander =
-      Super_context.expander sctx ~dir:(Path.as_in_build_dir_exn dir) in
+    let expander = Super_context.expander sctx ~dir in
 
     let vlib_stubs_o_files = Vimpl.vlib_stubs_o_files vimpl in
     if Library.has_stubs lib || not (List.is_empty vlib_stubs_o_files) then
@@ -533,7 +545,6 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         ~allow_overlaps:lib.buildable.allow_overlapping_dependencies
     in
     let f () =
-      let dir = Path.build dir in
       library_rules lib ~dir_contents ~dir ~scope ~expander ~compile_info
         ~dir_kind
     in

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -13,7 +13,7 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
   let obj_dir    = CC.obj_dir       cctx in
   let dir        = CC.dir           cctx in
   let ml = Path.relative (Obj_dir.obj_dir obj_dir) (basename ^ ".ml") in
-  SC.add_rule ~dir:(Path.build dir) sctx (Build.write_file ml code);
+  SC.add_rule ~dir sctx (Build.write_file ml code);
   let impl = Module.File.make OCaml ml in
   let name = Module.Name.of_string basename in
   let module_ =

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -129,7 +129,7 @@ module Run (P : PARAMS) : sig end = struct
     Command.run ~dir:(Path.build build_dir) menhir_binary args
 
   let rule ?(mode=stanza.mode) :Action.t Build.s -> unit =
-    SC.add_rule sctx ~dir:(Path.build dir) ~mode ~loc:stanza.loc
+    SC.add_rule sctx ~dir ~mode ~loc:stanza.loc
 
   let expand_flags flags =
     Expander.expand_and_eval_set expander

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -217,7 +217,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
 
        Currently dune doesn't support declaring a dependency only
        on the existence of a file, so we have to use this trick. *)
-    SC.add_rule sctx ~dir:(Path.build dir)
+    SC.add_rule sctx ~dir
       (Build.path (Path.build merlin_file)
        >>>
        Build.create_file (Path.build
@@ -225,7 +225,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
     Path.Set.singleton (Path.build merlin_file)
     |> Rules.Produce.Alias.add_deps (Alias.check ~dir:(Path.build dir));
     let pp_flags = pp_flags sctx ~expander ~dir_kind t in
-    SC.add_rule sctx ~dir:(Path.build dir)
+    SC.add_rule sctx ~dir
       ~mode:(Promote
                { lifetime = Until_clean
                ; into = None

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -38,7 +38,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
         (* symlink the .cmi into the public interface directory *)
         if not (Module.is_private m)
         && (Obj_dir.need_dedicated_public_dir obj_dir) then
-          SC.add_rule sctx ~sandbox:false ~dir:(Path.build dir)
+          SC.add_rule sctx ~sandbox:false ~dir
             (Build.symlink
                ~src:(Module.cm_file_unsafe m Cmi)
                ~dst:(Module.cm_public_file_unsafe m Cmi)
@@ -96,11 +96,11 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
           |> Path.Build.relative dir
           |> Path.build
         in
-        let dir = Path.build dir in
         SC.add_rule sctx ~dir (Build.symlink ~src:dst ~dst:old_dst);
         List.iter other_targets ~f:(fun in_obj_dir ->
-          let in_dir = Path.relative dir (Path.basename in_obj_dir) in
-          SC.add_rule sctx ~dir (Build.symlink ~src:in_obj_dir ~dst:in_dir))
+          let in_dir = Path.Build.relative dir (Path.basename in_obj_dir) in
+          SC.add_rule sctx ~dir
+            (Build.symlink ~src:in_obj_dir ~dst:(Path.build in_dir)))
       end;
       let opaque_arg =
         let intf_only = cm_kind = Cmi && not (Module.has_impl m) in
@@ -116,12 +116,13 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
             , Ocaml_version.supports_no_keep_locs ctx.version
         with
         | true, Cmi, true ->
-          (Path.build ctx.build_dir, Command.Args.As ["-no-keep-locs"])
+          (ctx.build_dir, Command.Args.As ["-no-keep-locs"])
         | true, Cmi, false ->
-          (Obj_dir.byte_dir obj_dir, As []) (* emulated -no-keep-locs *)
+          (Path.as_in_build_dir_exn (Obj_dir.byte_dir obj_dir), As [])
+        (* emulated -no-keep-locs *)
         | true, (Cmo | Cmx), _
         | false, _, _ ->
-          (Path.build ctx.build_dir, As [])
+          (ctx.build_dir, As [])
       in
       let flags =
         let flags = Ocaml_flags.get_for_cm (CC.flags cctx) ~cm_kind in
@@ -133,7 +134,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
       in
       SC.add_rule sctx ?sandbox ~dir
         (Build.S.seqs [Build.paths extra_deps; other_cm_files]
-           (Command.run ~dir (Ok compiler)
+           (Command.run ~dir:(Path.build dir) (Ok compiler)
               [ Command.Args.dyn flags
               ; no_keep_locs
               ; cmt_args
@@ -178,9 +179,9 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
     (* Build *.cmo.js *)
     let sctx     = CC.super_context cctx in
     let dir      = CC.dir           cctx in
-    let src = Module.cm_file_unsafe m Cm_kind.Cmo in
-    let target = Path.extend_basename src ~suffix:".js" in
-    SC.add_rules sctx ~dir:(Path.build dir)
+    let src = Path.as_in_build_dir_exn (Module.cm_file_unsafe m Cm_kind.Cmo) in
+    let target = Path.Build.extend_basename src ~suffix:".js" in
+    SC.add_rules sctx ~dir
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
 
 let build_modules ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx =
@@ -206,7 +207,7 @@ let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   in
   let ocaml_flags = Ocaml_flags.get_for_cm (CC.flags cctx) ~cm_kind:Cmo
   in
-  SC.add_rule sctx ?sandbox ~dir:(Path.build dir)
+  SC.add_rule sctx ?sandbox ~dir
     (Build.S.seq cm_deps
        (Build.S.map ~f:(fun act -> Action.with_stdout_to output act)
           (Command.run (Ok ctx.ocamlc) ~dir:(Path.build ctx.build_dir)

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -102,7 +102,7 @@ let deps_of cctx ~ml_kind unit =
     match Module.file unit ml_kind with
     | None -> Build.return []
     | Some file ->
-      let dir = Path.build (Compilation_context.dir cctx) in
+      let dir = Compilation_context.dir cctx in
       let file_in_obj_dir ~suffix file =
         let base = Path.basename file in
         Path.relative

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -34,7 +34,7 @@ type odoc =
   }
 
 let add_rule sctx =
-  Super_context.add_rule sctx ~dir:(Path.build (Super_context.build_dir sctx))
+  Super_context.add_rule sctx ~dir:(Super_context.build_dir sctx)
 
 module Paths = struct
   let root (context : Context.t) =

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -15,4 +15,4 @@ val setup_library_odoc_rules
 
 val init : Super_context.t -> unit
 
-val gen_rules : Super_context.t -> dir:Path.t -> string list -> unit
+val gen_rules : Super_context.t -> dir:Path.Build.t -> string list -> unit

--- a/src/opam_create.ml
+++ b/src/opam_create.ml
@@ -124,7 +124,7 @@ let add_rule sctx ~project ~pkg =
         template)
     >>> Build.write_file_dyn opam_path
   in
-  let dir = Path.build (Local_package.build_dir pkg) in
+  let dir = Local_package.build_dir pkg in
   let mode =
     Dune_file.Rule.Mode.Promote
       { lifetime = Unlimited
@@ -134,6 +134,7 @@ let add_rule sctx ~project ~pkg =
   in
   Super_context.add_rule sctx ~mode ~dir opam_rule;
   let aliases =
+    let dir = Path.build dir in
     [ Alias.install ~dir
     ; Alias.runtest ~dir
     ; Alias.check ~dir (* check doesn't pick up the promote target? *)

--- a/src/preprocessing.mli
+++ b/src/preprocessing.mli
@@ -10,7 +10,7 @@ val dummy : t
 
 val make
   :  Super_context.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> expander:Expander.t
   -> dep_kind:Lib_deps_info.Kind.t
   -> lint:Dune_file.Preprocess_map.t

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -37,7 +37,10 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
                 not_in_dir ~error_loc s;
               Path.relative ~error_loc (Path.build dir) s
             | Path p ->
-              if Path.parent p <> Some (Path.build dir) then
+              if Option.compare Path.compare
+                   (Path.parent p) (Some (Path.build dir))
+                   <> Eq
+              then
                 not_in_dir ~error_loc (Path.to_string p);
               p
             | Dir p ->

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -16,7 +16,6 @@ let dep_bindings ~extra_bindings deps =
   | None -> base
 
 let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
-  let dir = Path.build dir in
   if Expander.eval_blang expander rule.enabled_if then begin
     let targets : Expander.Targets.t =
       match rule.targets with
@@ -36,9 +35,9 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
             | String s ->
               if Filename.dirname s <> Filename.current_dir_name then
                 not_in_dir ~error_loc s;
-              Path.relative ~error_loc dir s
+              Path.relative ~error_loc (Path.build dir) s
             | Path p ->
-              if Path.parent p <> Some dir then
+              if Path.parent p <> Some (Path.build dir) then
                 not_in_dir ~error_loc (Path.to_string p);
               p
             | Dir p ->
@@ -64,7 +63,6 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
     Path.Set.empty
 
 let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
-  let dir = Path.build dir in
   let loc = String_with_vars.loc def.glob in
   let glob_in_src =
     let src_glob = Expander.expand_str expander def.glob in
@@ -97,7 +95,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
       (File_selector.create ~dir:(Path.build src_in_build) pred) in
   Path.Set.map files ~f:(fun file_src ->
     let basename = Path.basename file_src in
-    let file_dst = Path.relative dir basename in
+    let file_dst = Path.build (Path.Build.relative dir basename) in
     SC.add_rule sctx ~loc ~dir
       ((if def.add_line_directive
         then Build.copy_and_add_line_directive
@@ -107,7 +105,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
     file_dst)
 
 let add_alias sctx ~dir ~name ~stamp ~loc ?(locks=[]) build =
-  let alias = Alias.make name ~dir in
+  let alias = Alias.make name ~dir:(Path.build dir) in
   SC.add_alias_action sctx alias ~dir ~loc ~locks ~stamp build
 
 let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
@@ -123,7 +121,7 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
   let loc = Some alias_conf.loc in
   if Expander.eval_blang expander alias_conf.enabled_if then
     add_alias sctx
-      ~dir:(Path.build dir)
+      ~dir
       ~loc
       ~name:alias_conf.name
       ~stamp
@@ -142,11 +140,11 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
            ~expander
            ~dep_kind:Required
            ~targets:(Forbidden "aliases")
-           ~targets_dir:(Path.build dir))
+           ~targets_dir:dir)
   else
     add_alias sctx
       ~loc
-      ~dir:(Path.build dir)
+      ~dir
       ~name:alias_conf.name
       ~stamp
       (Build.return (Action.Progn []))

--- a/src/sub_system_intf.ml
+++ b/src/sub_system_intf.ml
@@ -84,7 +84,7 @@ end
 module Library_compilation_context = struct
   type t =
     { super_context  : Super_context.t
-    ; dir            : Path.t
+    ; dir            : Path.Build.t
     ; stanza         : Dune_file.Library.t
     ; scope          : Scope.t
     ; source_modules : Module.t Module.Name.Map.t

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -79,7 +79,7 @@ val add_rule
   -> ?mode:Dune_file.Rule.Mode.t
   -> ?locks:Path.t list
   -> ?loc:Loc.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> (unit, Action.t) Build.t
   -> unit
 val add_rule_get_targets
@@ -88,19 +88,19 @@ val add_rule_get_targets
   -> ?mode:Dune_file.Rule.Mode.t
   -> ?locks:Path.t list
   -> ?loc:Loc.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> (unit, Action.t) Build.t
   -> Path.Set.t
 val add_rules
   :  t
   -> ?sandbox:bool
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> (unit, Action.t) Build.t list
   -> unit
 val add_alias_action
   :  t
   -> Build_system.Alias.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> loc:Loc.t option
   -> ?locks:Path.t list
   -> stamp:_
@@ -178,7 +178,7 @@ module Action : sig
     -> expander:Expander.t
     -> dep_kind:Lib_deps_info.Kind.t
     -> targets:Expander.Targets.t
-    -> targets_dir:Path.t
+    -> targets_dir:Path.Build.t
     -> Action_unexpanded.t
     -> (Path.t Bindings.t, Action.t) Build.t
 

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -96,7 +96,7 @@ let setup_module_rules t =
         Buffer.contents b))
     >>> Build.write_file_dyn (Path.build path)
   in
-  Super_context.add_rule sctx ~dir:(Path.build dir) main_ml
+  Super_context.add_rule sctx ~dir main_ml
 
 let setup_rules t =
   let linkage = Exe.Linkage.custom in
@@ -109,7 +109,7 @@ let setup_rules t =
   let src = Exe.exe_path t.cctx ~program ~linkage in
   let dir = Source.stanza_dir t.source in
   let dst = Path.Build.relative dir (Path.Build.basename src) in
-  Super_context.add_rule sctx ~dir:(Path.build dir) ~loc:t.source.loc
+  Super_context.add_rule sctx ~dir ~loc:t.source.loc
     (Build.symlink ~src:(Path.build src) ~dst:(Path.build dst));
   setup_module_rules t
 

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -20,7 +20,7 @@ let source ~dir =
     ~main:"UTop_main.main ();"
     ~name:exe_name
 
-let is_utop_dir dir = Path.basename dir = utop_dir_basename
+let is_utop_dir dir = Path.Build.basename dir = utop_dir_basename
 
 let libs_under_dir sctx ~db ~dir =
   (let open Option.O in
@@ -52,15 +52,11 @@ let libs_under_dir sctx ~db ~dir =
   |> Option.value ~default:[]
 
 let setup sctx ~dir =
-  let (expander, scope) =
-    let dir = Path.as_in_build_dir_exn dir in
-    let expander = Super_context.expander sctx ~dir in
-    let scope = Super_context.find_scope_by_dir sctx dir in
-    (expander, scope)
-  in
+  let expander = Super_context.expander sctx ~dir in
+  let scope = Super_context.find_scope_by_dir sctx dir in
   let db = Scope.libs scope in
-  let libs = libs_under_dir sctx ~db ~dir in
-  let source = source ~dir:(Path.as_in_build_dir_exn dir) in
+  let libs = libs_under_dir sctx ~db ~dir:(Path.build dir) in
+  let source = source ~dir in
   let obj_dir = Toplevel.Source.obj_dir source in
   let loc = Toplevel.Source.loc source in
   let modules = Toplevel.Source.modules source in

--- a/src/utop.mli
+++ b/src/utop.mli
@@ -6,6 +6,6 @@ val utop_exe : string
 (** Return the name of the utop target inside a directory where some
     libraries are defined. *)
 
-val is_utop_dir : Path.t -> bool
+val is_utop_dir : Path.Build.t -> bool
 
-val setup : Super_context.t -> dir:Path.t -> unit
+val setup : Super_context.t -> dir:Path.Build.t -> unit

--- a/src/virtual_rules.mli
+++ b/src/virtual_rules.mli
@@ -2,7 +2,7 @@ open Stdune
 
 val setup_copy_rules_for_impl
   :  sctx:Super_context.t
-  -> dir:Path.t
+  -> dir:Path.Build.t
   -> Vimpl.t
   -> unit
 


### PR DESCRIPTION
List of public functions modified:

* C.Sources.objects
* Coq_module.obj_file
* Format_rules.gen_rules
* Format_rules.gen_rules_output
* Preprocessing.make
* Super_context.add_rule
* Super_context.add_rule_get_targets
* Super_context.add_rules
* Super_context.add_alias_action
* Super_context.Action.run
* Virtual_rules.setup_copy_rules_for_impl
* Utop.setup
* Utop.is_utop_dir
* Odoc.gen_rules
* Js_of_ocaml_rules.build_cm
* Js_of_ocaml_rules.build_exe
* Lib_archives.make
* Expander.dir
* Expander.set_dir
* Expander.c_flags
* Dune_file.Library.stubs
* Dune_file.Library.stubs_archive
* Dune_file.Library.dll
* Dune_file.Library.archive


I believe I can start porting Action, Build