### PR TITLE
Fix generation of melrin with equal ppx pp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,9 @@ unreleased
   would be undetected whenever the project was nested in another workspace.
   (#2194, @rgrinberg)
 
+- Fix generation of `.merlin` whenever there's more than one stanza with the
+  same ppx preprocessing specification (#2209 ,fixes #2206, @rgrinberg)
+
 1.9.3 (06/05/2019)
 ------------------
 

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -4,24 +4,28 @@ open! Stdune
 open Import
 
 module Preprocess : sig
-  type pps =
-    { loc   : Loc.t
-    ; pps   : (Loc.t * Lib_name.t) list
-    ; flags : String_with_vars.t list
-    ; staged : bool
-    }
+  module Pps : sig
+    type t =
+      { loc   : Loc.t
+      ; pps   : (Loc.t * Lib_name.t) list
+      ; flags : String_with_vars.t list
+      ; staged : bool
+      }
+
+    val compare_no_locs : t -> t -> Ordering.t
+  end
 
   type t =
     | No_preprocessing
     | Action of Loc.t * Action_dune_lang.t
-    | Pps    of pps
+    | Pps    of Pps.t
     | Future_syntax of Loc.t
 
   module Without_future_syntax : sig
     type t =
       | No_preprocessing
       | Action of Loc.t * Action_dune_lang.t
-      | Pps    of pps
+      | Pps    of Pps.t
   end
 
   val loc : t -> Loc.t option

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -34,12 +34,12 @@
   S $LIB_PREFIX/lib/ocaml
   S .
   S subdir
+  FLG -ppx '$PPX/fcfe04ecb8bb41c1143a3b9acec18678/ppx.exe --as-ppx --cookie '\''library-name="foo"'\'''
   FLG -open Foo -w -40 -open Bar -w -40
 
 Make sure a ppx directive is generated
 
   $ grep -q ppx lib/.merlin
-  [1]
 
 Make sure pp flag is correct and variables are expanded
 


### PR DESCRIPTION
Previously, if the pps were all ppx and equivalent, then they would
be dropped.

Fix #2206