### PR TITLE
Modify Build/Command to use Path.Build.t for targets

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -25,7 +25,7 @@ let info = Term.info "rules" ~doc ~man
 let print_rule_makefile ppf (rule : Build_system.Rule.t) =
   let action =
     Action.For_shell.Progn
-      [ Mkdir (Path.to_string rule.dir)
+      [ Mkdir (Path.to_string (Path.build rule.dir))
       ; Action.for_shell rule.action
       ]
   in

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -54,8 +54,7 @@ let print_rule_sexp ppf (rule : Build_system.Rule.t) =
       List.concat
         [ [ "deps"   , Dep.Set.encode rule.deps
           ; "targets", paths (Path.Build.Set.to_list rule.targets
-                              |> List.map ~f:Path.build
-                              |> Path.Set.of_list) ]
+                              |> Path.set_of_build_paths_list) ]
         ; (match rule.context with
            | None -> []
            | Some c -> ["context",

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -40,14 +40,14 @@ let log_targets ~log targets =
 let target_hint (_setup : Dune.Main.build_system) path =
   assert (Path.is_managed path);
   let sub_dir = Option.value ~default:path (Path.parent path) in
-  let candidates = Path.Set.to_list (Build_system.all_targets ()) in
+  let candidates = Path.Build.Set.to_list (Build_system.all_targets ()) in
   let candidates =
     if Path.is_in_build_dir path then
-      candidates
+      List.map ~f:Path.build candidates
     else
       List.map candidates ~f:(fun path ->
-        match Path.extract_build_context path with
-        | None -> path
+        match Path.Build.extract_build_context path with
+        | None -> Path.build path
         | Some (_, path) -> Path.source path)
   in
   let candidates =

--- a/src/action.ml
+++ b/src/action.ml
@@ -225,8 +225,6 @@ let sandbox t ~sandboxed ~deps ~targets ~eval_pred : t =
         ~f_path:(fun ~dir:_ p -> sandboxed p)
         ~f_program:(fun ~dir:_ x -> Result.map x ~f:sandboxed)
     ; Progn (List.filter_map targets ~f:(fun path ->
-        if Path.is_managed path then
-          Some (Rename (sandboxed path, path))
-        else
-          None))
+        let path = Path.build path in
+        Some (Rename (sandboxed path, path))))
     ]

--- a/src/action.mli
+++ b/src/action.mli
@@ -91,6 +91,6 @@ val sandbox
   :  t
   -> sandboxed:(Path.t -> Path.t)
   -> deps:Dep.Set.t
-  -> targets:Path.t list
+  -> targets:Path.Build.t list
   -> eval_pred:Dep.eval_pred
   -> t

--- a/src/action_exec.mli
+++ b/src/action_exec.mli
@@ -1,7 +1,7 @@
 open! Stdune
 
 val exec
-  :  targets:Path.Set.t
+  :  targets:Path.Build.Set.t
   -> context:Context.t option
   -> env:Env.t option
   -> Action.t

--- a/src/build.ml
+++ b/src/build.ml
@@ -3,7 +3,7 @@ open Import
 
 type ('a, 'b) t =
   | Arr : ('a -> 'b) -> ('a, 'b) t
-  | Targets : Path.Set.t -> ('a, 'a) t
+  | Targets : Path.Build.Set.t -> ('a, 'a) t
   | Compose : ('a, 'b) t * ('b, 'c) t -> ('a, 'c) t
   | First : ('a, 'b) t -> ('a * 'c, 'b * 'c) t
   | Second : ('a, 'b) t -> ('c * 'a, 'c * 'b) t
@@ -101,9 +101,7 @@ let dyn_path_set t = Dyn_paths t
 let paths_for_rule ps = Paths_for_rule ps
 let env_var s = Deps (Dep.Set.singleton (Dep.env s))
 let alias a = dep (Dep.alias a)
-let declare_targets a =
-  Targets (Path.Build.Set.fold a ~init:Path.Set.empty ~f:(fun p acc ->
-    Path.Set.add acc (Path.build p)))
+let declare_targets a = Targets a
 
 let catch t ~on_error = Catch (t, on_error)
 
@@ -149,7 +147,7 @@ let fail ?targets x =
   match targets with
   | None -> Fail x
   | Some l ->
-    Targets (Path.set_of_build_paths_list l)
+    Targets (Path.Build.Set.of_list l)
     >>> Fail x
 
 let of_result ?targets = function
@@ -170,7 +168,7 @@ let source_tree ~dir ~file_tree =
   path_set paths >>^ fun _ -> paths
 
 let action ?dir ~targets action =
-  Targets (Path.set_of_build_paths_list targets)
+  Targets (Path.Build.Set.of_list targets)
   >>^ fun _ ->
   match dir with
   | None -> action
@@ -178,9 +176,9 @@ let action ?dir ~targets action =
 
 let action_dyn ?dir ~targets () =
   match dir with
-  | None -> Targets (Path.set_of_build_paths_list targets)
+  | None -> Targets (Path.Build.Set.of_list targets)
   | Some dir ->
-    Targets (Path.set_of_build_paths_list targets)
+    Targets (Path.Build.Set.of_list targets)
     >>^ fun action ->
     Action.Chdir (dir, action)
 
@@ -188,10 +186,9 @@ let write_file fn s =
   action ~targets:[fn] (Write_file ((Path.build fn), s))
 
 let write_file_dyn fn =
-  let fn = Path.build fn in
-  Targets (Path.Set.singleton fn)
+  Targets (Path.Build.Set.singleton fn)
   >>^ fun s ->
-  Action.Write_file (fn, s)
+  Action.Write_file (Path.build fn, s)
 
 let copy ~src ~dst =
   path src >>>
@@ -306,47 +303,48 @@ let lib_deps =
   fun t -> loop t Lib_name.Map.empty
 
 let targets =
-  let rec loop : type a b. (a, b) t -> Path.Set.t -> Path.Set.t = fun t acc ->
-    match t with
-    | Arr _ -> acc
-    | Targets targets -> Path.Set.union targets acc
-    | Compose (a, b) -> loop a (loop b acc)
-    | First t -> loop t acc
-    | Second t -> loop t acc
-    | Split (a, b) -> loop a (loop b acc)
-    | Fanout (a, b) -> loop a (loop b acc)
-    | Paths_for_rule _ -> acc
-    | Paths_glob _ -> acc
-    | Deps _ -> acc
-    | Dyn_paths t -> loop t acc
-    | Dyn_deps t -> loop t acc
-    | Contents _ -> acc
-    | Lines_of _ -> acc
-    | Record_lib_deps _ -> acc
-    | Fail _ -> acc
-    | If_file_exists (_, state) -> begin
-        match !state with
-        | Decided (v, _) ->
-          Exn.code_error "Build_interpret.targets got decided if_file_exists"
-            ["exists", Sexp.Encoder.bool v]
-        | Undecided (a, b) ->
-          let a = loop a Path.Set.empty in
-          let b = loop b Path.Set.empty in
-          if Path.Set.is_empty a && Path.Set.is_empty b then
-            acc
-          else begin
-            Exn.code_error "Build_interpret.targets: cannot have targets \
-                            under a [if_file_exists]"
-              [ "targets-a", Path.Set.to_sexp a
-              ; "targets-b", Path.Set.to_sexp b
-              ]
-          end
-      end
-    | Memo m -> loop m.t acc
-    | Catch (t, _) -> loop t acc
-    | Lazy_no_targets _ -> acc
+  let rec loop : type a b. (a, b) t -> Path.Build.Set.t -> Path.Build.Set.t
+    = fun t acc ->
+      match t with
+      | Arr _ -> acc
+      | Targets targets -> Path.Build.Set.union targets acc
+      | Compose (a, b) -> loop a (loop b acc)
+      | First t -> loop t acc
+      | Second t -> loop t acc
+      | Split (a, b) -> loop a (loop b acc)
+      | Fanout (a, b) -> loop a (loop b acc)
+      | Paths_for_rule _ -> acc
+      | Paths_glob _ -> acc
+      | Deps _ -> acc
+      | Dyn_paths t -> loop t acc
+      | Dyn_deps t -> loop t acc
+      | Contents _ -> acc
+      | Lines_of _ -> acc
+      | Record_lib_deps _ -> acc
+      | Fail _ -> acc
+      | If_file_exists (_, state) -> begin
+          match !state with
+          | Decided (v, _) ->
+            Exn.code_error "Build_interpret.targets got decided if_file_exists"
+              ["exists", Sexp.Encoder.bool v]
+          | Undecided (a, b) ->
+            let a = loop a Path.Build.Set.empty in
+            let b = loop b Path.Build.Set.empty in
+            if Path.Build.Set.is_empty a && Path.Build.Set.is_empty b then
+              acc
+            else begin
+              Exn.code_error "Build_interpret.targets: cannot have targets \
+                              under a [if_file_exists]"
+                [ "targets-a", Path.Build.Set.to_sexp a
+                ; "targets-b", Path.Build.Set.to_sexp b
+                ]
+            end
+        end
+      | Memo m -> loop m.t acc
+      | Catch (t, _) -> loop t acc
+      | Lazy_no_targets _ -> acc
   in
-  fun t -> loop t Path.Set.empty
+  fun t -> loop t Path.Build.Set.empty
 
 (* Execution *)
 

--- a/src/build.mli
+++ b/src/build.mli
@@ -80,7 +80,7 @@ val env_var : string -> ('a, 'a) t
 val alias : Alias.t -> ('a, 'a) t
 
 (** Record a set of targets of the action produced by the build arrow. *)
-val declare_targets : Path.Set.t -> ('a, 'a) t
+val declare_targets : Path.Build.Set.t -> ('a, 'a) t
 
 (** Compute the set of source of all files present in the sub-tree
     starting at [dir] and record them as dependencies. *)
@@ -130,15 +130,15 @@ val file_exists_opt : Path.t -> ('a, 'b) t -> ('a, 'b option) t
 
 (** Always fail when executed. We pass a function rather than an
     exception to get a proper backtrace *)
-val fail : ?targets:Path.t list -> fail -> (_, _) t
+val fail : ?targets:Path.Build.t list -> fail -> (_, _) t
 
 val of_result
-  :  ?targets:Path.t list
+  :  ?targets:Path.Build.t list
   -> ('a, 'b) t Or_exn.t
   -> ('a, 'b) t
 
 val of_result_map
-  : ?targets:Path.t list
+  : ?targets:Path.Build.t list
   -> 'a Or_exn.t
   -> f:('a -> ('b, 'c) t)
   -> ('b, 'c) t
@@ -149,28 +149,31 @@ val memoize : string -> (unit, 'a) t -> (unit, 'a) t
 
 val action
   :  ?dir:Path.t
-  -> targets:Path.t list
+  -> targets:Path.Build.t list
   -> Action.t
   -> (_, Action.t) t
 
 val action_dyn
   :  ?dir:Path.t
-  -> targets:Path.t list
+  -> targets:Path.Build.t list
   -> unit
   -> (Action.t, Action.t) t
 
 (** Create a file with the given contents. *)
-val write_file : Path.t -> string -> (unit, Action.t) t
-val write_file_dyn : Path.t -> (string, Action.t) t
+val write_file : Path.Build.t -> string -> (unit, Action.t) t
+val write_file_dyn : Path.Build.t -> (string, Action.t) t
 
-val copy : src:Path.t -> dst:Path.t -> (unit, Action.t) t
-val copy_and_add_line_directive : src:Path.t -> dst:Path.t -> (unit, Action.t) t
+val copy : src:Path.t -> dst:Path.Build.t -> (unit, Action.t) t
+val copy_and_add_line_directive
+  :  src:Path.t
+  -> dst:Path.Build.t
+  -> (unit, Action.t) t
 
-val symlink : src:Path.t -> dst:Path.t -> (unit, Action.t) t
+val symlink : src:Path.t -> dst:Path.Build.t -> (unit, Action.t) t
 
-val create_file : Path.t -> (_, Action.t) t
-val remove_tree : Path.t -> (_, Action.t) t
-val mkdir : Path.t -> (_, Action.t) t
+val create_file : Path.Build.t -> (_, Action.t) t
+val remove_tree : Path.Build.t -> (_, Action.t) t
+val mkdir : Path.Build.t -> (_, Action.t) t
 
 (** Merge a list of actions *)
 val progn : ('a, Action.t) t list -> ('a, Action.t) t
@@ -203,7 +206,9 @@ val exec : eval_pred:Dep.eval_pred -> ('a, 'b) t -> 'a -> 'b * Dep.Set.t
 (**/**)
 val paths_for_rule : Path.Set.t -> ('a, 'a) t
 
-val merge_files_dyn : target:Path.t -> (Path.t list * string list, Action.t) t
+val merge_files_dyn
+  :  target:Path.Build.t
+  -> (Path.t list * string list, Action.t) t
 
 (* A module with standard combinators for applicative and selective functors, as
 well as equivalents of the functions from the arrow-based API. *)

--- a/src/build.mli
+++ b/src/build.mli
@@ -195,7 +195,7 @@ val lib_deps
 
 val targets
   :  (_, _) t
-  -> Path.Set.t
+  -> Path.Build.Set.t
 
 (** {1 Execution} *)
 

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -163,7 +163,7 @@ module Rule : sig
 
   type t =
     { id      : Id.t
-    ; dir     : Path.t
+    ; dir     : Path.Build.t
     ; deps    : Dep.Set.t
     ; targets : Path.Set.t
     ; context : Context.t option

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -143,7 +143,7 @@ val all_lib_deps
   -> Lib_deps_info.t Path.Source.Map.t String.Map.t Fiber.t
 
 (** List of all buildable targets *)
-val all_targets : unit -> Path.Set.t
+val all_targets : unit -> Path.Build.Set.t
 
 (** Return the set of files that were created in the source tree and
     needs to be deleted *)
@@ -165,7 +165,7 @@ module Rule : sig
     { id      : Id.t
     ; dir     : Path.Build.t
     ; deps    : Dep.Set.t
-    ; targets : Path.Set.t
+    ; targets : Path.Build.Set.t
     ; context : Context.t option
     ; action  : Action.t
     }

--- a/src/command.mli
+++ b/src/command.mli
@@ -41,11 +41,11 @@ module Args : sig
     | Concat   : string * 'a t list  -> 'a t
     | Dep      : Path.t -> _ t
     | Deps     : Path.t list -> _ t
-    | Target   : Path.t -> dynamic t
+    | Target   : Path.Build.t -> dynamic t
     | Path     : Path.t -> _ t
     | Paths    : Path.t list -> _ t
     | Hidden_deps    : Dep.Set.t -> _ t
-    | Hidden_targets : Path.t list -> dynamic t
+    | Hidden_targets : Path.Build.t list -> dynamic t
     | Dyn      : static t Build.s -> dynamic t
     | Fail     : fail -> _ t
 
@@ -57,7 +57,7 @@ end
 can use the constructor [S] to concatenate lists instead. *)
 val run
   :  dir:Path.t
-  -> ?stdout_to:Path.t
+  -> ?stdout_to:Path.Build.t
   -> Action.Prog.t
   -> Args.dynamic Args.t list
   -> Action.t Build.s

--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -64,10 +64,8 @@ let setup_rule ~expander ~dir ~cc ~source_rule ~coq_flags ~file_flags
 
   let obj_dir = dir in
   let source    = Coq_module.source coq_module in
-  let stdout_to =
-    Path.build (Coq_module.obj_file ~obj_dir ~ext:".v.d" coq_module) in
-  let object_to =
-    Path.build (Coq_module.obj_file ~obj_dir ~ext:".vo" coq_module) in
+  let stdout_to = Coq_module.obj_file ~obj_dir ~ext:".v.d" coq_module in
+  let object_to = Coq_module.obj_file ~obj_dir ~ext:".vo" coq_module in
   let dir = Path.build dir in
 
   let file_flags = file_flags @ [Command.Args.Dep (Path.build source)] in
@@ -85,7 +83,7 @@ let setup_rule ~expander ~dir ~cc ~source_rule ~coq_flags ~file_flags
   (* Process coqdep and generate rules *)
 
   let deps_of : unit Build.s = Build.dyn_paths (
-    Build.S.map (Build.lines_of stdout_to)
+    Build.S.map (Build.lines_of (Path.build stdout_to))
       ~f:(fun x -> List.map ~f:(Path.relative dir) (parse_coqdep ~coq_module x))
   ) in
 
@@ -223,7 +221,7 @@ let coqpp_rules ~sctx ~build_dir ~dir (s : Dune_file.Coqpp.t) =
 
   let mlg_rule m =
     let source = Path.build (Path.Build.relative dir (m ^ ".mlg")) in
-    let target = Path.build (Path.Build.relative dir (m ^ ".ml")) in
+    let target = Path.Build.relative dir (m ^ ".ml") in
     let args = [Command.Args.Dep source; Hidden_targets [target]] in
     Command.run ~dir:(Path.build build_dir) cc.coqpp args in
 

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -273,8 +273,8 @@ let load_text_files sctx ft_dir
         Menhir_rules.targets menhir
       | Rule rule ->
         Simple_rules.user_rule sctx rule ~dir ~expander
-        |> Path.Set.to_list
-        |> List.map ~f:Path.basename
+        |> Path.Build.Set.to_list
+        |> List.map ~f:Path.Build.basename
       | Copy_files def ->
         Simple_rules.copy_files sctx def ~src_dir ~dir ~expander
         |> Path.Set.to_list

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -160,7 +160,7 @@ let link_exe
        (Command.run ~dir:(Path.build ctx.build_dir)
           (Ok compiler)
           [ Command.Args.dyn ocaml_flags
-          ; A "-o"; Target (Path.build exe)
+          ; A "-o"; Target exe
           ; As linkage.flags
           ; Command.Args.dyn link_flags
           ; Command.of_result_map link_time_code_gen

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -55,7 +55,7 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
           ; A "--name"
           ; Path (Path.source file)
           ; A "-o"
-          ; Target (Path.build output)
+          ; Target output
           ]
         in
         Some (
@@ -68,7 +68,6 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
 
     let formatter =
       let dir = Path.build dir in
-      let output = Path.build output in
       let input = Path.build input in
       match Path.Source.basename file, Path.Source.extension file with
       | _, ".ml" -> ocaml Impl

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -186,7 +186,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
              hides a library *)
           let targets =
             List.map (Menhir_rules.targets m)
-              ~f:(Path.relative (Path.build ctx_dir))
+              ~f:(Path.Build.relative ctx_dir)
           in
           SC.add_rule sctx ~dir:ctx_dir
             (Build.fail ~targets
@@ -252,10 +252,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
          |> List.iter ~f:(fun t ->
            let loc = File_binding.Expanded.src_loc t in
            let src = File_binding.Expanded.src_path t in
-           let dst =
-             File_binding.Expanded.dst_path t ~dir
-             |> Path.build
-           in
+           let dst = File_binding.Expanded.dst_path t ~dir in
            Super_context.add_rule sctx ~loc ~dir (Build.symlink ~src ~dst))
        | _ ->
          match

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -244,7 +244,7 @@ include Sub_system.Register_end_point(
           Action.with_stdout_to (Path.build target)
             (Action.progn actions))
         >>>
-        Build.action_dyn ~targets:[Path.build target] ());
+        Build.action_dyn ~targets:[target] ());
 
       let cctx =
         Compilation_context.create ()

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -58,7 +58,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
          (Fmt.list ~pp_sep:Fmt.nl
             (Dune_lang.pp (Stanza.File_kind.of_syntax dune_version))))
   >>>
-  Build.write_file_dyn (Path.build dune_package_file)
+  Build.write_file_dyn  dune_package_file
   |> Super_context.add_rule sctx ~dir:ctx.build_dir
 
 type version_method =
@@ -151,7 +151,7 @@ let init_meta sctx ~dir =
          Format.pp_print_flush ppf ();
          Buffer.contents buf)
        >>>
-       Build.write_file_dyn (Path.build meta)))
+       Build.write_file_dyn meta))
 
 let lib_ppxs sctx ~(lib : Dune_file.Library.t) ~scope ~dir_kind =
   match lib.kind with
@@ -272,6 +272,7 @@ let symlink_installed_artifacts_to_build_install
     let dst =
       Path.append (Path.build install_dir)
         (Install.Entry.relative_installed_path entry ~paths:install_paths)
+      |> Path.as_in_build_dir_exn
     in
     let loc =
       match loc with
@@ -280,7 +281,7 @@ let symlink_installed_artifacts_to_build_install
     in
     Super_context.add_rule sctx ~loc ~dir:ctx.build_dir
       (Build.symlink ~src:entry.src ~dst);
-    Install.Entry.set_src entry dst)
+    Install.Entry.set_src entry (Path.build dst))
 
 let promote_install_file (ctx : Context.t) =
   not ctx.implicit &&
@@ -443,7 +444,7 @@ let install_rules sctx package =
        in
        Install.gen_install_file entries)
      >>>
-     Build.write_file_dyn (Path.build install_file))
+     Build.write_file_dyn install_file)
 
 let install_alias (ctx : Context.t) (package : Local_package.t) =
   if not ctx.implicit then

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -53,12 +53,11 @@ let runtime_file ~dir ~sctx file =
 
 let js_of_ocaml_rule sctx ~dir ~flags ~spec ~target =
   let jsoo = jsoo ~dir sctx in
-  let runtime_dep = runtime_file ~dir ~sctx "runtime.js"
-  in
+  let runtime_dep = runtime_file ~dir ~sctx "runtime.js" in
   Command.run ~dir:(Path.build dir)
     jsoo
     [ flags
-    ; A "-o"; Target (Path.build target)
+    ; A "-o"; Target target
     ; A "--no-runtime"
     ; Dyn (Build.S.map runtime_dep ~f:(fun x -> Command.Args.Dep x))
     ; spec
@@ -122,7 +121,7 @@ let link_rule cc ~runtime ~target cm =
   let jsoo_link = jsoo_link ~dir sctx in
   Command.run ~dir:(Path.build dir)
     jsoo_link
-    [ A "-o"; Target (Path.build target)
+    [ A "-o"; Target target
     ; Dep (Path.build runtime)
     ; As (sourcemap sctx)
     ; Dyn get_all

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -13,7 +13,7 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
   let obj_dir    = CC.obj_dir       cctx in
   let dir        = CC.dir           cctx in
   let ml = Path.relative (Obj_dir.obj_dir obj_dir) (basename ^ ".ml") in
-  SC.add_rule ~dir sctx (Build.write_file ml code);
+  SC.add_rule ~dir sctx (Build.write_file (Path.as_in_build_dir_exn ml) code);
   let impl = Module.File.make OCaml ml in
   let name = Module.Name.of_string basename in
   let module_ =

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -80,7 +80,7 @@ module Run (P : PARAMS) : sig end = struct
 
   let targets m ~cmly =
     let base = [m ^ ".ml"; m ^ ".mli"] in
-    List.map ~f:(Path.relative (Path.build dir)) (
+    List.map ~f:(Path.Build.relative dir) (
       if cmly then
         (m ^ ".cmly") :: base
       else
@@ -99,11 +99,11 @@ module Run (P : PARAMS) : sig end = struct
   let mock m =
     m ^ "__mock"
 
-  let mock_ml m : Path.t =
-    Path.relative (Path.build dir) (mock m ^ ".ml.mock")
+  let mock_ml m : Path.Build.t =
+    Path.Build.relative dir (mock m ^ ".ml.mock")
 
-  let inferred_mli m : Path.t =
-    Path.relative (Path.build dir) (mock m ^ ".mli.inferred")
+  let inferred_mli m : Path.Build.t =
+    Path.Build.relative dir (mock m ^ ".mli.inferred")
 
   (* ------------------------------------------------------------------------ *)
 
@@ -211,7 +211,7 @@ module Run (P : PARAMS) : sig end = struct
         name
         ~visibility:Public
         ~kind:Impl
-        ~impl:{ path = mock_ml base; syntax = OCaml }
+        ~impl:{ path = Path.build (mock_ml base); syntax = OCaml }
         ~obj_dir:(Compilation_context.obj_dir cctx)
     in
 
@@ -239,7 +239,7 @@ module Run (P : PARAMS) : sig end = struct
         [ Command.Args.dyn expanded_flags
         ; Deps (sources stanza.modules)
         ; A "--base" ; Path (Path.relative (Path.build dir) base)
-        ; A "--infer-read-reply"; Dep (inferred_mli base)
+        ; A "--infer-read-reply"; Dep (Path.build (inferred_mli base))
         ; Hidden_targets (targets base ~cmly)
         ]
     )

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -220,8 +220,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
     SC.add_rule sctx ~dir
       (Build.path (Path.build merlin_file)
        >>>
-       Build.create_file (Path.build
-                            (Path.Build.relative dir ".merlin-exists")));
+       Build.create_file (Path.Build.relative dir ".merlin-exists"));
     Path.Set.singleton (Path.build merlin_file)
     |> Rules.Produce.Alias.add_deps (Alias.check ~dir:(Path.build dir));
     let pp_flags = pp_flags sctx ~expander ~dir_kind t in
@@ -256,7 +255,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
           ~src_dirs
           ~obj_dirs)
       >>>
-      Build.write_file_dyn (Path.build merlin_file)))
+      Build.write_file_dyn merlin_file))
 
 let merge_two ~allow_approx_merlin a b =
   { requires = Lib.Set.union a.requires b.requires

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -31,5 +31,5 @@ val ocamlc_i
   -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> Module.t
-  -> output:Path.t
+  -> output:Path.Build.t
   -> unit

--- a/src/ocamlobjinfo.mli
+++ b/src/ocamlobjinfo.mli
@@ -6,7 +6,7 @@ type t = Module.Name.Set.t Ml_kind.Dict.t
 val pp : t Fmt.t
 
 val rules
-  :  dir:Path.t
+  :  dir:Path.Build.t
   -> ctx:Context.t
   -> unit:Path.t
   -> Action.t Build.s * t Build.s

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -42,8 +42,8 @@ let parse s = ocamlobjinfo empty (Lexing.from_string s)
 let rules ~dir ~(ctx : Context.t) ~unit =
   let open Build.O in
   let output =
-    Path.relative dir (Path.basename unit)
-    |> Path.extend_basename ~suffix:".ooi-deps"
+    Path.Build.relative dir (Path.basename unit)
+    |> Path.Build.extend_basename ~suffix:".ooi-deps"
   in
   let bin =
     match ctx.ocamlobjinfo with
@@ -66,13 +66,13 @@ let rules ~dir ~(ctx : Context.t) ~unit =
     else
       []
   in
-  ( Command.run ~dir bin
+  ( Command.run ~dir:(Path.build dir) bin
       (List.concat
          [ no_approx
          ; no_code
          ; [ Dep unit ]
          ])
       ~stdout_to:output
-  , Build.contents output >>^ parse
+  , Build.contents (Path.build output) >>^ parse
   )
 }

--- a/src/opam_create.ml
+++ b/src/opam_create.ml
@@ -101,13 +101,14 @@ let opam_template sctx ~pkg =
 
 let add_rule sctx ~project ~pkg =
   let open Build.O in
-  let opam_path = Path.build (Local_package.opam_file pkg) in
+  let opam_path = Local_package.opam_file pkg in
   let opam_rule =
     (match opam_template sctx ~pkg:(Local_package.package pkg) with
      | Some p -> Build.contents (Path.build p)
      | None -> Build.return "")
     >>>
     Build.arr (fun template ->
+      let opam_path = Path.build opam_path in
       let opamfile = Opam_file.of_string ~path:opam_path template in
       let existing_vars_template = Opam_file.existing_variables opamfile in
       let generated_fields =
@@ -140,7 +141,7 @@ let add_rule sctx ~project ~pkg =
     ; Alias.check ~dir (* check doesn't pick up the promote target? *)
     ]
   in
-  let deps = Path.Set.singleton opam_path in
+  let deps = Path.Set.singleton (Path.build opam_path) in
   List.iter aliases ~f:(fun alias ->
     Rules.Produce.Alias.add_deps alias deps)
 

--- a/src/process.ml
+++ b/src/process.ml
@@ -94,7 +94,7 @@ end
 
 type purpose =
   | Internal_job
-  | Build_job of Path.Set.t
+  | Build_job of Path.Build.Set.t
 
 module Temp = struct
   let tmp_files = ref Path.Set.empty
@@ -195,7 +195,7 @@ module Fancy = struct
         | [] -> List.rev targets_acc, String.Set.(to_list (of_list ctxs_acc))
         | path :: rest ->
           let add_ctx ctx acc = if ctx = "default" then acc else ctx :: acc in
-          match Utils.analyse_target path with
+          match Utils.analyse_target (Path.build path) with
           | Other path ->
             split_paths (Path.to_string path :: targets_acc) ctxs_acc rest
           | Regular (ctx, filename) ->
@@ -208,7 +208,7 @@ module Fancy = struct
             split_paths (("install " ^ Path.Source.to_string name) :: targets_acc)
               (add_ctx ctx ctxs_acc) rest
       in
-      let targets = Path.Set.to_list targets in
+      let targets = Path.Build.Set.to_list targets in
       let target_names, contexts = split_paths [] [] targets in
       let target_names_grouped_by_prefix =
         List.map target_names ~f:Filename.split_extension_after_dot

--- a/src/process.mli
+++ b/src/process.mli
@@ -40,7 +40,7 @@ end
 (** Why a Fiber.t was run *)
 type purpose =
   | Internal_job
-  | Build_job of Path.Set.t
+  | Build_job of Path.Build.Set.t
 
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its termination *)
 val run

--- a/src/rule.ml
+++ b/src/rule.ml
@@ -21,7 +21,7 @@ type t =
   { context  : Context.t option
   ; env      : Env.t option
   ; build    : (unit, Action.t) Build.t
-  ; targets  : Path.Set.t
+  ; targets  : Path.Build.Set.t
   ; sandbox  : bool
   ; mode     : Dune_file.Rule.Mode.t
   ; locks    : Path.t list
@@ -33,30 +33,31 @@ let make ?(sandbox=false) ?(mode=Dune_file.Rule.Mode.Standard)
       ~context ~env ?(locks=[]) ?(info=Info.Internal) build =
   let targets = Build.targets build in
   let dir =
-    match Path.Set.choose targets with
+    match Path.Build.Set.choose targets with
     | None -> begin
         match info with
         | From_dune_file loc -> Errors.fail loc "Rule has no targets specified"
         | _ -> Exn.code_error "Build_interpret.Rule.make: no targets" []
       end
     | Some x ->
-      let dir = Path.parent_exn x in
-      if Path.Set.exists targets ~f:(fun path -> Path.parent_exn path <> dir)
+      let dir = Path.Build.parent_exn x in
+      if Path.Build.Set.exists targets ~f:(fun path ->
+        Path.Build.(<>) (Path.Build.parent_exn path) dir)
       then begin
         match info with
         | Internal | Source_file_copy ->
           Exn.code_error "rule has targets in different directories"
-            [ "targets", Path.Set.to_sexp targets
+            [ "targets", Path.Build.Set.to_sexp targets
             ]
         | From_dune_file loc ->
           Errors.fail loc
             "Rule has targets in different directories.\nTargets:\n%s"
             (String.concat ~sep:"\n"
-               (Path.Set.to_list targets |> List.map ~f:(fun p ->
+               (Path.Build.Set.to_list targets |> List.map ~f:(fun p ->
                   sprintf "- %s"
-                    (Path.to_string_maybe_quoted p))))
+                    (Path.to_string_maybe_quoted (Path.build p)))))
       end;
-      Path.as_in_build_dir_exn dir
+      dir
   in
   { context
   ; env

--- a/src/rule.ml
+++ b/src/rule.ml
@@ -26,7 +26,7 @@ type t =
   ; mode     : Dune_file.Rule.Mode.t
   ; locks    : Path.t list
   ; info     : Info.t
-  ; dir      : Path.t
+  ; dir      : Path.Build.t
   }
 
 let make ?(sandbox=false) ?(mode=Dune_file.Rule.Mode.Standard)
@@ -56,7 +56,7 @@ let make ?(sandbox=false) ?(mode=Dune_file.Rule.Mode.Standard)
                   sprintf "- %s"
                     (Path.to_string_maybe_quoted p))))
       end;
-      dir
+      Path.as_in_build_dir_exn dir
   in
   { context
   ; env

--- a/src/rule.mli
+++ b/src/rule.mli
@@ -24,7 +24,7 @@ type t =
   ; locks    : Path.t list
   ; info     : Info.t
   ; (** Directory where all the targets are produced *)
-    dir      : Path.t
+    dir      : Path.Build.t
   }
 
 val make

--- a/src/rule.mli
+++ b/src/rule.mli
@@ -18,7 +18,7 @@ type t =
   { context  : Context.t option
   ; env      : Env.t option
   ; build    : (unit, Action.t) Build.t
-  ; targets  : Path.Set.t
+  ; targets  : Path.Build.Set.t
   ; sandbox  : bool
   ; mode     : Dune_file.Rule.Mode.t
   ; locks    : Path.t list

--- a/src/rules.ml
+++ b/src/rules.ml
@@ -106,7 +106,6 @@ include T
 
 let singleton_rule (rule : Rule.t) =
   let dir = rule.dir in
-  let dir = Path.as_in_build_dir_exn dir in
   Path.Build.Map.singleton dir (Dir_rules.singleton (Rule rule))
 
 let implicit_output = Memo.Implicit_output.add(module T)

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -98,14 +98,14 @@ let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
       (File_selector.create ~dir:(Path.build src_in_build) pred) in
   Path.Set.map files ~f:(fun file_src ->
     let basename = Path.basename file_src in
-    let file_dst = Path.build (Path.Build.relative dir basename) in
+    let file_dst = Path.Build.relative dir basename in
     SC.add_rule sctx ~loc ~dir
       ((if def.add_line_directive
         then Build.copy_and_add_line_directive
         else Build.copy)
          ~src:file_src
          ~dst:file_dst);
-    file_dst)
+    Path.build file_dst)
 
 let add_alias sctx ~dir ~name ~stamp ~loc ?(locks=[]) build =
   let alias = Alias.make name ~dir:(Path.build dir) in

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -63,7 +63,7 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
          ~targets
          ~targets_dir:dir)
   end else
-    Path.Set.empty
+    Path.Build.Set.empty
 
 let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
   let loc = String_with_vars.loc def.glob in

--- a/src/simple_rules.mli
+++ b/src/simple_rules.mli
@@ -11,7 +11,7 @@ val user_rule
   -> dir:Path.Build.t
   -> expander:Expander.t
   -> Rule.t
-  -> Path.Set.t
+  -> Path.Build.Set.t
 
 (** Interpret a [(copy_files ...)] stanza and return the targets it produces. *)
 val copy_files

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -548,6 +548,9 @@ module Build = struct
       Exn.code_error "Path.Build.drop_build_context_exn"
         [ "t", to_sexp t
         ]
+
+  let is_alias_stamp_file s =
+    String.is_prefix (Local.to_string s) ~prefix:".aliases/"
 end
 
 let (abs_root, set_root) =
@@ -902,11 +905,6 @@ let as_in_build_dir_exn t = match t with
       "[as_in_build_dir_exn] called on something not in build dir"
       ["t", to_sexp t]
   | In_build_dir p -> p
-
-let is_alias_stamp_file = function
-  | In_build_dir s -> String.is_prefix (Local.to_string s) ~prefix:".aliases/"
-  | In_source_tree _
-  | External _ -> false
 
 let extract_build_context = function
   | In_source_tree _

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -72,6 +72,8 @@ module Build : sig
   val drop_build_context_exn : t -> Source.t
 
   val extract_build_context  : t -> (string * Source.t) option
+
+  val is_alias_stamp_file : t -> bool
 end
 
 (** In the outside world *)
@@ -188,8 +190,6 @@ val is_in_source_tree : t -> bool
 val as_in_source_tree : t -> Source.t option
 val as_in_build_dir : t -> Build.t option
 val as_in_build_dir_exn : t -> Build.t
-
-val is_alias_stamp_file : t -> bool
 
 (** [is_strict_descendant_of_build_dir t = is_in_build_dir t && t <>
     build_dir] *)

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -70,6 +70,8 @@ module Build : sig
 
   val drop_build_context     : t -> Source.t option
   val drop_build_context_exn : t -> Source.t
+
+  val extract_build_context  : t -> (string * Source.t) option
 end
 
 (** In the outside world *)

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -90,7 +90,7 @@ val add_rule_get_targets
   -> ?loc:Loc.t
   -> dir:Path.Build.t
   -> (unit, Action.t) Build.t
-  -> Path.Set.t
+  -> Path.Build.Set.t
 val add_rules
   :  t
   -> ?sandbox:bool

--- a/src/test_rules.ml
+++ b/src/test_rules.ml
@@ -62,5 +62,5 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents
         } in
       add_alias ~loc ~action:(Diff diff) ~locks:t.locks;
       ignore (Simple_rules.user_rule sctx rule ~extra_bindings ~dir ~expander
-              : Path.Set.t));
+              : Path.Build.Set.t));
   Exe_rules.rules t.exes ~sctx ~dir ~scope ~expander ~dir_kind ~dir_contents

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -94,7 +94,7 @@ let setup_module_rules t =
         Source.pp_ml fmt t.source ~include_dirs;
         Format.pp_print_flush fmt ();
         Buffer.contents b))
-    >>> Build.write_file_dyn (Path.build path)
+    >>> Build.write_file_dyn path
   in
   Super_context.add_rule sctx ~dir main_ml
 
@@ -110,7 +110,7 @@ let setup_rules t =
   let dir = Source.stanza_dir t.source in
   let dst = Path.Build.relative dir (Path.Build.basename src) in
   Super_context.add_rule sctx ~dir ~loc:t.source.loc
-    (Build.symlink ~src:(Path.build src) ~dst:(Path.build dst));
+    (Build.symlink ~src:(Path.build src) ~dst);
   setup_module_rules t
 
 module Stanza = struct


### PR DESCRIPTION
* Build.declare_targets
* Build.fail
* Build.of_result
* Build.of_result_map
* Build.action
* Build.action_dyn
* Build.write_file
* Build.write_file_dyn
* Build.copy
* Build.copy_and_add_line_directive
* Build.symlink
* Build.create_tree
* Build.remove_tree
* Build.mkdir
* Build.merge_files_dyn
* Command.Target
* Command.Hidden_target
* Command.run
* Module_compilation.ocamlc_i
* Ocamlobjinfo.rules

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>