### PR TITLE
Remove unused abbreviation "jsoo"

### DIFF
--- a/doc/jsoo.rst
+++ b/doc/jsoo.rst
@@ -3,8 +3,8 @@ js_of_ocaml
 ***********
 
 js_of_ocaml_ is a compiler from OCaml to JavaScript. The compiler works by
-translating OCaml bytecode to JS files. From here on, we'll abbreviate
-js_of_ocaml to jsoo. The compiler can be installed with opam:
+translating OCaml bytecode to JS files. The compiler can be installed with
+opam:
 
 .. code:: bash
 
@@ -13,7 +13,7 @@ js_of_ocaml to jsoo. The compiler can be installed with opam:
 Compiling to JS
 ===============
 
-Dune has full support building jsoo libraries and executables transparently.
+Dune has full support building js_of_ocaml libraries and executables transparently.
 There's no need to customize or enable anything to compile ocaml
 libraries/executables to JS.
 


### PR DESCRIPTION
There is currently no value in Introducing the "jsoo" abbreviation.

The term "jsoo" is used exactly once (excluding the sentence where the abbreviation is introduced), while "js_of_ocaml" is used 11 times. Moreover, at most places in the doc, "js_of_ocaml" can't be easily replaced with "jsoo", as it refers to either the command line tool, or to the dune configuration, where it is named js_of_ocaml and not jsoo.

So it makes more sense to just remove "jsoo", which shortens the documentation by a whole sentence and expands the one occurrence.