### PR TITLE
Make Path.Build.to_string equivalent to Path.to_string

### DIFF
--- a/bench/dune_bench/file_tree_cache.ml
+++ b/bench/dune_bench/file_tree_cache.ml
@@ -9,7 +9,7 @@ let setup = lazy (
   let tmp = Path.External.of_string (Filename.get_temp_dir_name ()) in
   Path.External.mkdir_p (Path.External.relative tmp deep_path);
   Path.set_root tmp;
-  Path.set_build_dir (Path.Kind.of_string "_build");
+  Path.Build.set_build_dir (Path.Kind.of_string "_build");
   let ft = (Dune_load.load ~ancestor_vcs:None ()).file_tree in
   let path = Path.Source.of_string deep_path in
   at_exit (fun () -> Sys.remove "./dune-project");

--- a/bench/dune_bench/scheduler_bench.ml
+++ b/bench/dune_bench/scheduler_bench.ml
@@ -5,7 +5,7 @@ open Dune
 
 let setup = lazy (
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string "_build"))
+  Path.Build.set_build_dir (Path.Kind.of_string "_build"))
 
 let prog =
   Option.value_exn (Bin.which ~path:(Env.path Env.initial) "true")

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -49,7 +49,7 @@ let set_dirs c =
   if c.root.dir <> Filename.current_dir_name then
     Sys.chdir c.root.dir;
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string c.build_dir)
+  Path.Build.set_build_dir (Path.Kind.of_string c.build_dir)
 
 let set_common_other c ~targets =
   Clflags.debug_dep_path := c.debug_dep_path;

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -69,7 +69,7 @@ let term =
       }
     in
     Path.set_root (Path.External.cwd ());
-    Path.set_build_dir (Path.Kind.of_string Common.default_build_dir);
+    Path.Build.set_build_dir (Path.Kind.of_string Common.default_build_dir);
     Dune.Scheduler.go ~config Watermarks.subst
 
 let command = term, info

--- a/src/main.ml
+++ b/src/main.ml
@@ -162,7 +162,7 @@ let set_concurrency ?log (config : Config.t) =
 let bootstrap () =
   Colors.setup_err_formatter_colors ();
   Path.set_root Path.External.initial_cwd;
-  Path.set_build_dir (Path.Kind.of_string "_boot");
+  Path.Build.set_build_dir (Path.Kind.of_string "_boot");
   let main () =
     let anon s = raise (Arg.Bad (Printf.sprintf "don't know what to do with %s\n" s)) in
     let subst () =

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -50,6 +50,26 @@ module Source : sig
   val to_local : t -> Local.t
 end
 
+module External : sig
+  include Path_intf.S
+
+  val initial_cwd : t
+
+  val cwd : unit -> t
+
+  val relative : t -> string -> t
+
+  val mkdir_p : t -> unit
+end
+
+module Kind : sig
+  type t = private
+    | External of External.t
+    | Local    of Local.t
+
+  val of_string : string -> t
+end
+
 module Build : sig
   include Path_intf.S
   val root : t
@@ -74,29 +94,13 @@ module Build : sig
   val extract_build_context  : t -> (string * Source.t) option
 
   val is_alias_stamp_file : t -> bool
+
+  (** set the build directory. Can only be called once and must be done before
+      paths are converted to strings elsewhere. *)
+  val set_build_dir : Kind.t -> unit
 end
 
 (** In the outside world *)
-module External : sig
-  include Path_intf.S
-
-  val initial_cwd : t
-
-  val cwd : unit -> t
-
-  val relative : t -> string -> t
-
-  val mkdir_p : t -> unit
-end
-
-module Kind : sig
-  type t = private
-    | External of External.t
-    | Local    of Local.t
-
-  val of_string : string -> t
-end
-
 include Path_intf.S
 
 val hash : t -> int
@@ -216,10 +220,6 @@ val pp_debug : Format.formatter -> t -> unit
 val build_dir_exists : unit -> bool
 
 val ensure_build_dir_exists : unit -> unit
-
-(** set the build directory. Can only be called once and must be done before
-    paths are converted to strings elsewhere. *)
-val set_build_dir : Kind.t -> unit
 
 val source : Source.t -> t
 val build : Build.t -> t

--- a/test/unit-tests/action.mlt
+++ b/test/unit-tests/action.mlt
@@ -5,7 +5,7 @@
 open Stdune;;
 open Dune;;
 open Action_unexpanded.Infer.Outcome;;
-Stdune.Path.set_build_dir (Path.Kind.of_string "_build");;
+Stdune.Path.Build.set_build_dir (Path.Kind.of_string "_build");;
 
 let p = Path.of_string;;
 let infer (a : Action.t) =

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -1,7 +1,7 @@
 (* -*- tuareg -*- *)
 open! Stdune;;
 Path.set_root (Path.External.cwd ());
-Path.set_build_dir (Path.Kind.of_string "_build");
+Path.Build.set_build_dir (Path.Kind.of_string "_build");
 
 Printexc.record_backtrace false;;
 

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -7,7 +7,7 @@ open Import
 
 let () =
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string "_build")
+  Path.Build.set_build_dir (Path.Kind.of_string "_build")
 ;;
 
 let print_pkg ppf pkg =

--- a/test/unit-tests/vcs.mlt
+++ b/test/unit-tests/vcs.mlt
@@ -8,7 +8,7 @@ let printf = Printf.printf;;
 
 let () =
   Path.set_root (Path.External.cwd ());
-  Path.set_build_dir (Path.Kind.of_string "_build")
+  Path.Build.set_build_dir (Path.Kind.of_string "_build")
 ;;
 
 let temp_dir = Path.of_string "vcs-tests";;


### PR DESCRIPTION
Also move some build related functions to Path.Build

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>