### PR TITLE
Run refmt from the context's root dir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+* Run `refmt` from the context's root directory. This improves error messages in
+  case of syntax errors. (#2223, @rgrinberg)
+
 1.10.0 (30/05/2019)
 -------------------
 

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -67,19 +67,18 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
     in
 
     let formatter =
-      let dir = Path.build dir in
       let input = Path.build input in
       match Path.Source.basename file, Path.Source.extension file with
       | _, ".ml" -> ocaml Impl
       | _, ".mli" -> ocaml Intf
       | _, ".re"
       | _, ".rei" when Dune_file.Auto_format.includes config Reason ->
-        let exe = resolve_program "refmt" in
-        let args = [Command.Args.Dep input] in
-        Some (Command.run ~dir ~stdout_to:output exe args)
+        let refmt = Refmt.get sctx ~loc:(Some loc) ~dir in
+        Some (Refmt.format refmt ~input ~output)
       | "dune", _ when Dune_file.Auto_format.includes config Dune ->
         let exe = resolve_program "dune" in
         let args = [Command.Args.A "format-dune-file"; Dep input] in
+        let dir = Path.build dir in
         Some (Command.run ~dir ~stdout_to:output exe args)
       | _ -> None
     in

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -566,18 +566,8 @@ let workspace_root_var = String_with_vars.virt_var __POS__ "workspace_root"
    a new module with only OCaml sources *)
 let setup_reason_rules sctx (m : Module.t) =
   let ctx = SC.context sctx in
-  let refmt =
-    SC.resolve_program sctx ~loc:None
-      ~dir:ctx.build_dir
-      "refmt" ~hint:"try: opam install reason" in
-  let rule src target =
-    Command.run ~dir:(Path.build ctx.build_dir) refmt
-      [ A "--print"
-      ; A "binary"
-      ; Dep src
-      ]
-      ~stdout_to:target
-  in
+  let refmt = Refmt.get sctx ~loc:None ~dir:ctx.build_dir in
+  let rule input output = Refmt.to_ocaml_ast refmt ~input ~output in
   let ml = Module.ml_source m in
   Module.iter m ~f:(fun kind f ->
     match f.syntax with

--- a/src/refmt.ml
+++ b/src/refmt.ml
@@ -1,0 +1,24 @@
+open Stdune
+
+type t =
+  { path : Action.program
+  ; run_dir : Path.Build.t
+  }
+
+let get sctx ~loc ~dir =
+  { path = Super_context.resolve_program ~dir sctx ~loc "refmt"
+             ~hint:"try: opam install reason"
+  ; run_dir = Super_context.build_dir sctx
+  }
+
+let run ?stdout_to t = Command.run ?stdout_to ~dir:(Path.build t.run_dir) t.path
+
+let format t ~input ~output =
+  run t ~stdout_to:output [Command.Args.Dep input]
+
+let to_ocaml_ast t ~input ~output =
+  run t ~stdout_to:output
+    [ Command.Args.A "--print"
+    ; A "binary"
+    ; Dep input
+    ]

--- a/src/refmt.mli
+++ b/src/refmt.mli
@@ -1,0 +1,11 @@
+(** refmt is the binary that is used to convert reason syntax to OCaml and
+    reformat reason source *)
+open Stdune
+
+type t
+
+val get : Super_context.t -> loc:Loc.t option -> dir:Path.Build.t -> t
+
+val format : t -> input:Path.t -> output:Path.Build.t -> Action.t Build.s
+
+val to_ocaml_ast : t -> input:Path.t -> output:Path.Build.t -> Action.t Build.s

--- a/src/stdune/bin.mli
+++ b/src/stdune/bin.mli
@@ -16,8 +16,8 @@ val exe : string
 (** Look for a program in the PATH *)
 val which : path:Path.t list -> string -> Path.t option
 
-(** Return the .opt version of a tool if available. If the tool is not available at all in
-    the given directory, returns [None]. *)
+(** Return the .opt version of a tool if available. If the tool is not available
+    at all in the given directory, returns [None]. *)
 val best_prog : Path.t -> string -> Path.t option
 
 (** "make" program *)

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -80,7 +80,7 @@ And fixable files can be promoted:
   Sys.argv: ../install/default/bin/ocamlformat --impl enabled/ocaml_file.ml --name ../../enabled/ocaml_file.ml -o enabled/.formatted/ocaml_file.ml
   ocamlformat output
   $ cat enabled/reason_file.re
-  Sys.argv: ../../install/default/bin/refmt reason_file.re
+  Sys.argv: ../install/default/bin/refmt enabled/reason_file.re
   refmt output
   $ cat enabled/dune
   (library


### PR DESCRIPTION
This is consistent with how we convert reason sources to OCaml ast. To keep
formatting and compilation consistent, we introduce a Refmt module that handles
these details in one place.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>