### PR TITLE
Switch aliases module to use Path.Build.t

### DIFF
--- a/src/alias.ml
+++ b/src/alias.ml
@@ -3,52 +3,54 @@ open Import
 
 module T : sig
   type t = private
-    { dir : Path.t
+    { dir : Path.Build.t
     ; name : string
     }
-  val make : string -> dir:Path.t -> t
+  val make : string -> dir:Path.Build.t -> t
   val of_user_written_path : loc:Loc.t -> Path.t -> t
 end = struct
   type t =
-    { dir : Path.t
+    { dir : Path.Build.t
     ; name : string
     }
 
   let make name ~dir =
-    if not (Path.is_in_build_dir dir) || String.contains name '/' then
+    if String.contains name '/' then
       Exn.code_error "Alias0.make: Invalid alias"
         [ "name", Sexp.Encoder.string name
-        ; "dir", Path.to_sexp dir
+        ; "dir", Path.Build.to_sexp dir
         ];
     { dir; name }
 
   let of_user_written_path ~loc path =
-    if not (Path.is_in_build_dir path) then
+    match Path.as_in_build_dir path with
+    | Some path ->
+      { dir = Path.Build.parent_exn path
+      ; name = Path.Build.basename path
+      }
+    | None ->
       Errors.fail loc "Invalid alias!\n\
                        Tried to reference path outside build dir: %S"
         (Path.to_string_maybe_quoted path);
-    { dir = Path.parent_exn path
-    ; name = Path.basename path
-    }
 end
 include T
 
 let compare x y =
   match String.compare x.name y.name with
   | Lt | Gt as x -> x
-  | Eq -> Path.compare x.dir y.dir
+  | Eq -> Path.Build.compare x.dir y.dir
 
 let equal x y = compare x y = Eq
 
 let hash { dir ; name } =
-  Hashtbl.hash (Path.hash dir, String.hash name)
+  Hashtbl.hash (Path.Build.hash dir, String.hash name)
 
-let pp fmt t = Path.pp fmt (Path.relative t.dir t.name)
+let pp fmt t = Path.Build.pp fmt (Path.Build.relative t.dir t.name)
 
 let to_dyn { dir ; name } =
   let open Dyn in
   Record
-    [ "dir", Path.to_dyn dir
+    [ "dir", Path.Build.to_dyn dir
     ; "name", String name
     ]
 
@@ -59,10 +61,15 @@ let suffix = "-" ^ String.make 32 '0'
 let name t = t.name
 let dir  t = t.dir
 
-let fully_qualified_name t = Path.relative t.dir t.name
+let fully_qualified_name t = Path.Build.relative t.dir t.name
+
+(* Where we store stamp files for aliases *)
+let alias_dir = Path.Build.(relative root ".aliases")
 
 let stamp_file t =
-  Path.relative (Path.insert_after_build_dir_exn t.dir ".aliases")
+  let local = Path.Build.local t.dir in
+  Path.Build.relative
+    (Path.Build.append_local alias_dir local)
     (t.name ^ suffix)
 
 let find_dir_specified_on_command_line ~dir ~file_tree =
@@ -94,6 +101,6 @@ let fmt         = make_standard "fmt"
 let encode { dir ; name } =
   let open Dune_lang.Encoder in
   record
-    [ "dir", Path_dune_lang.encode dir
+    [ "dir", Path_dune_lang.encode (Path.build dir)
     ; "name", string name
     ]

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -8,7 +8,7 @@ val hash : t -> int
 
 val compare : t -> t -> Ordering.t
 
-val make : string -> dir:Path.t -> t
+val make : string -> dir:Path.Build.t -> t
 
 (** The following always holds:
 
@@ -17,7 +17,7 @@ val make : string -> dir:Path.t -> t
     ]}
 *)
 val name : t -> string
-val dir : t -> Path.t
+val dir : t -> Path.Build.t
 
 val to_dyn : t -> Dyn.t
 
@@ -29,20 +29,20 @@ val pp : t Fmt.t
 
 val of_user_written_path : loc:Loc.t -> Path.t -> t
 
-val fully_qualified_name : t -> Path.t
+val fully_qualified_name : t -> Path.Build.t
 
-val default     : dir:Path.t -> t
-val runtest     : dir:Path.t -> t
-val install     : dir:Path.t -> t
-val doc         : dir:Path.t -> t
-val private_doc : dir:Path.t -> t
-val lint        : dir:Path.t -> t
-val all         : dir:Path.t -> t
-val check       : dir:Path.t -> t
-val fmt         : dir:Path.t -> t
+val default     : dir:Path.Build.t -> t
+val runtest     : dir:Path.Build.t -> t
+val install     : dir:Path.Build.t -> t
+val doc         : dir:Path.Build.t -> t
+val private_doc : dir:Path.Build.t -> t
+val lint        : dir:Path.Build.t -> t
+val all         : dir:Path.Build.t -> t
+val check       : dir:Path.Build.t -> t
+val fmt         : dir:Path.Build.t -> t
 
 (** Return the underlying stamp file *)
-val stamp_file : t -> Path.t
+val stamp_file : t -> Path.Build.t
 
 val find_dir_specified_on_command_line
   :  dir:Path.Source.t
@@ -51,3 +51,5 @@ val find_dir_specified_on_command_line
 
 val is_standard : string -> bool
 val suffix : string
+
+val alias_dir : Path.Build.t

--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -20,6 +20,6 @@ let add_obj_dir sctx ~obj_dir =
       File_selector.create ~dir dev_files in
     let dyn_deps = Build.paths_matching ~loc:(Loc.of_pos __POS__) dir_glob in
     Rules.Produce.Alias.add_deps
-      (Alias.check ~dir:(Obj_dir.dir obj_dir))
+      (Alias.check ~dir:(Path.as_in_build_dir_exn (Obj_dir.dir obj_dir)))
       ~dyn_deps
       Path.Set.empty

--- a/src/dep.ml
+++ b/src/dep.ml
@@ -42,7 +42,7 @@ module T = struct
     match t with
     | Universe -> ["universe", Digest.string "universe"]
     | File fn -> [trace_file fn]
-    | Alias a -> [trace_file (Alias.stamp_file a)]
+    | Alias a -> [trace_file (Path.build (Alias.stamp_file a))]
     | Glob dir_glob ->
       eval_pred dir_glob
       |> Path.Set.to_list
@@ -99,7 +99,7 @@ module Set = struct
   let paths t ~eval_pred =
     fold t ~init:Path.Set.empty ~f:(fun d acc ->
       match d with
-      | Alias a -> Path.Set.add acc (Alias.stamp_file a)
+      | Alias a -> Path.Set.add acc (Path.build (Alias.stamp_file a))
       | File f -> Path.Set.add acc f
       | Glob g -> Path.Set.union acc (eval_pred g)
       | Universe
@@ -115,7 +115,7 @@ module Set = struct
   let dirs t =
     fold t ~init:Path.Set.empty ~f:(fun f acc ->
       match f with
-      | Alias a -> Path.Set.add acc (Alias.dir a)
+      | Alias a -> Path.Set.add acc (Path.build (Alias.dir a))
       | Glob g -> Path.Set.add acc (File_selector.dir g)
       | File f -> Path.Set.add acc (Path.parent_exn f)
       | Universe

--- a/src/format_rules.ml
+++ b/src/format_rules.ml
@@ -34,7 +34,7 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
   let loc = Dune_file.Auto_format.loc config in
   let dir = Path.Build.parent_exn output_dir in
   let source_dir = Path.Build.drop_build_context_exn dir in
-  let alias_formatted = Alias.fmt ~dir:(Path.build output_dir) in
+  let alias_formatted = Alias.fmt ~dir:output_dir in
   let resolve_program =
     Super_context.resolve_program ~dir sctx ~loc:(Some loc) in
   let ocamlformat_deps = lazy (
@@ -94,8 +94,9 @@ let gen_rules_output sctx (config : Dune_file.Auto_format.t) ~output_dir =
 
 let gen_rules ~dir =
   let output_dir = Path.Build.relative dir formatted in
-  let alias = Alias.fmt ~dir:(Path.build dir) in
-  let alias_formatted = Alias.fmt ~dir:(Path.build output_dir) in
+  let alias = Alias.fmt ~dir in
+  let alias_formatted = Alias.fmt ~dir:output_dir in
   Alias.stamp_file alias_formatted
+  |> Path.build
   |> Path.Set.singleton
   |> Rules.Produce.Alias.add_deps alias

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -141,7 +141,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
           File_binding.Unexpanded.expand_src ~dir:(Path.build ctx_dir)
             fb ~f:(Expander.expand_str expander))
         |> Path.Set.of_list
-        |> Rules.Produce.Alias.add_deps (Alias.all ~dir:(Path.build ctx_dir));
+        |> Rules.Produce.Alias.add_deps (Alias.all ~dir:ctx_dir);
         For_stanza.empty_none
       | _ ->
         For_stanza.empty_none
@@ -223,7 +223,7 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
     in
     Rules.Produce.Alias.add_deps
       ~dyn_deps
-      (Alias.all ~dir:(Path.build ctx_dir)) Path.Set.empty;
+      (Alias.all ~dir:ctx_dir) Path.Set.empty;
     cctxs
 
   let gen_rules dir_contents cctxs ~dir : (Loc.t * Compilation_context.t) list =

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -277,7 +277,7 @@ include Sub_system.Register_end_point(
 
       SC.add_alias_action sctx ~dir
         ~loc:(Some info.loc)
-        (Alias.runtest ~dir:(Path.build dir))
+        (Alias.runtest ~dir)
         ~stamp:("ppx-runner", name)
         (let module A = Action in
          let exe =

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -429,7 +429,8 @@ let install_rules sctx package =
          Package.Name.Set.to_list packages
          |> List.map ~f:(fun pkg ->
            Build_system.Alias.package_install ~context:ctx ~pkg
-           |> Alias.stamp_file)
+           |> Alias.stamp_file
+           |> Path.build)
          |> Path.Set.of_list)
   in
   Super_context.add_rule sctx ~dir:pkg_build_dir
@@ -460,9 +461,9 @@ let install_alias (ctx : Context.t) (package : Local_package.t) =
       Utils.install_file ~package:(Local_package.name package)
         ~findlib_toolchain:ctx.findlib_toolchain
     in
-    let path = Path.build (Local_package.build_dir package) in
+    let path = Local_package.build_dir package in
     let install_alias = Alias.install ~dir:path in
-    let install_file = Path.relative path install_fn in
+    let install_file = Path.relative (Path.build path) install_fn in
     Rules.Produce.Alias.add_deps install_alias (Path.Set.singleton install_file)
 
 module Scheme' =struct

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -222,7 +222,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
        >>>
        Build.create_file (Path.Build.relative dir ".merlin-exists"));
     Path.Set.singleton (Path.build merlin_file)
-    |> Rules.Produce.Alias.add_deps (Alias.check ~dir:(Path.build dir));
+    |> Rules.Produce.Alias.add_deps (Alias.check ~dir);
     let pp_flags = pp_flags sctx ~expander ~dir_kind t in
     SC.add_rule sctx ~dir
       ~mode:(Promote

--- a/src/opam_create.ml
+++ b/src/opam_create.ml
@@ -135,7 +135,6 @@ let add_rule sctx ~project ~pkg =
   in
   Super_context.add_rule sctx ~mode ~dir opam_rule;
   let aliases =
-    let dir = Path.build dir in
     [ Alias.install ~dir
     ; Alias.runtest ~dir
     ; Alias.check ~dir (* check doesn't pick up the promote target? *)

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -625,7 +625,7 @@ let action_for_pp sctx ~dep_kind ~loc ~expander ~action ~src ~target =
 
 let lint_module sctx ~dir ~expander ~dep_kind ~lint ~lib_name ~scope ~dir_kind =
   Staged.stage (
-    let alias = Alias.lint ~dir:(Path.build dir) in
+    let alias = Alias.lint ~dir in
     let add_alias fn build =
       SC.add_alias_action sctx alias build ~dir
         ~stamp:("lint", lib_name, fn)

--- a/src/rules.ml
+++ b/src/rules.ml
@@ -127,7 +127,6 @@ module Produce = struct
     let alias t spec =
       produce (
         let dir = Alias.dir t in
-        let dir = Path.as_in_build_dir_exn dir in
         let name = Alias.name t in
         Path.Build.Map.singleton dir (Dir_rules.singleton (Alias {
           name;

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -108,7 +108,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def: Copy_files.t) =
     Path.build file_dst)
 
 let add_alias sctx ~dir ~name ~stamp ~loc ?(locks=[]) build =
-  let alias = Alias.make name ~dir:(Path.build dir) in
+  let alias = Alias.make name ~dir in
   SC.add_alias_action sctx alias ~dir ~loc ~locks ~stamp build
 
 let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -595,6 +595,8 @@ module Build = struct
   let append_relative = append
   let append_local = append
 
+  let local t = t
+
   let extract_build_context t =
     let t = Relative.to_string t in
     begin match String.lsplit2 t ~on:'/' with
@@ -606,6 +608,30 @@ module Build = struct
         , after
           |> Source0.of_string )
     end
+
+  let extract_build_context_dir t =
+    let t_str = Local.to_string t in
+    begin match String.lsplit2 t_str ~on:'/' with
+    | None -> Some (t, Source0.root)
+    | Some (before, after) ->
+      Some
+        ( Local.of_string before
+        , after
+          |> Source0.of_string
+        )
+    end
+
+  let extract_build_context_dir_exn t =
+    match extract_build_context_dir t with
+    | Some t -> t
+    | None -> Exn.code_error "Path.Build.extract_build_context_dir_exn"
+                ["t", to_sexp t]
+
+  let extract_build_context_exn t =
+    match extract_build_context t with
+    | Some t -> t
+    | None -> Exn.code_error "Path.Build.extract_build_context_exn"
+                ["t", to_sexp t]
 
   let drop_build_context t = Option.map (extract_build_context t) ~f:snd
   let drop_build_context_exn t =

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -598,7 +598,7 @@ module Build = struct
   let local t = t
 
   let extract_build_context t =
-    let t = Relative.to_string t in
+    let t = Local.to_string t in
     begin match String.lsplit2 t ~on:'/' with
     | None ->
       Some (t, Source0.root)
@@ -950,21 +950,12 @@ let extract_build_context_exn t =
   | None -> Exn.code_error "Path.extract_build_context_exn"
               ["t", to_sexp t]
 
-
 let extract_build_context_dir = function
   | In_source_tree _
   | External _ -> None
   | In_build_dir t ->
-    let t_str = Local.to_string t in
-    begin match String.lsplit2 t_str ~on:'/' with
-    | None -> Some (in_build_dir t, Source0.root)
-    | Some (before, after) ->
-      Some
-        ( in_build_dir (Local.of_string before)
-        , after
-          |> Source0.of_string
-        )
-    end
+    Option.map (Build.extract_build_context_dir t)
+      ~f:(fun (base, rest) -> in_build_dir base, rest)
 
 let extract_build_context_dir_exn t =
   match extract_build_context_dir t with

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -88,10 +88,15 @@ module Build : sig
   val split_first_component : t -> (string * Relative.t) option
   val explode : t -> string list
 
+  val local : t -> Local.t
+
   val drop_build_context     : t -> Source.t option
   val drop_build_context_exn : t -> Source.t
 
   val extract_build_context  : t -> (string * Source.t) option
+  val extract_build_context_exn  : t -> (string * Source.t)
+  val extract_build_context_dir : t -> (t * Source.t) option
+  val extract_build_context_dir_exn : t -> (t * Source.t)
 
   val is_alias_stamp_file : t -> bool
 


### PR DESCRIPTION
Public functions modified:

* Alias.make
* Alias.dir
* Alias.fully_qualified_name
* Alias.{default,runtest,install,doc,private_doc,lint,all,check,fmt,default}
* Alias.stamp_file
* Alias.alias_dir (introduced to get rid of copying)
