### PR TITLE
Port Dep_graph to Path.Build.t

### DIFF
--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -3,7 +3,7 @@ open Import
 open Build.O
 
 type t =
-  { dir        : Path.t
+  { dir        : Path.Build.t
   ; per_module : (Module.t * (unit, Module.t list) Build.t) Module.Name.Map.t
   }
 
@@ -15,7 +15,7 @@ let deps_of t (m : Module.t) =
   | Some (_, x) -> x
   | None ->
     Exn.code_error "Ocamldep.Dep_graph.deps_of"
-      [ "dir", Path.to_sexp t.dir
+      [ "dir", Path.Build.to_sexp t.dir
       ; "modules", Sexp.Encoder.(list Module.Name.to_sexp)
                      (Module.Name.Map.keys t.per_module)
       ; "module", Module.Name.to_sexp name
@@ -43,7 +43,7 @@ let top_closed t modules =
   | Ok modules -> modules
   | Error cycle ->
     die "dependency cycle between modules in %s:\n   %a"
-      (Path.to_string t.dir)
+      (Path.Build.to_string t.dir)
       pp_cycle cycle
 
 module Multi = struct
@@ -77,13 +77,13 @@ let top_closed_implementations =
     ~name:"top sorted implementations" ~f:top_closed
 
 let dummy (m : Module.t) =
-  { dir = Path.root
+  { dir = Path.Build.root
   ; per_module =
       Module.Name.Map.singleton (Module.name m) (m, (Build.return []))
   }
 
 let wrapped_compat ~modules ~wrapped_compat =
-  { dir = Path.root
+  { dir = Path.Build.root
   ; per_module = Module.Name.Map.merge wrapped_compat modules ~f:(fun _ d m ->
       match d, m with
       | None, None -> assert false

--- a/src/dep_graph.mli
+++ b/src/dep_graph.mli
@@ -5,7 +5,7 @@ open Stdune
 type t
 
 val make
-  :  dir:Path.t
+  :  dir:Path.Build.t
   -> per_module:(Module.t * (unit, Module.t list) Build.t) Module.Name.Map.t
   -> t
 

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -170,7 +170,7 @@ let rules_generic cctx ~modules =
        let per_module =
          Module.Name.Map.map modules ~f:(fun m -> (m, deps_of cctx ~ml_kind m))
        in
-       Dep_graph.make ~dir:(Path.build (CC.dir cctx)) ~per_module)
+       Dep_graph.make ~dir:(CC.dir cctx) ~per_module)
 
 let rules cctx = rules_generic cctx ~modules:(CC.modules cctx)
 
@@ -182,14 +182,15 @@ let graph_of_remote_lib ~obj_dir ~modules =
     match Module.file unit ml_kind with
     | None -> Build.return []
     | Some file ->
+      let file = Path.as_in_build_dir_exn file in
       let file_in_obj_dir ~suffix file =
-        let base = Path.basename file in
-        Path.relative obj_dir (base ^ suffix)
+        let base = Path.Build.basename file in
+        Path.Build.relative obj_dir (base ^ suffix)
       in
       let all_deps_path file = file_in_obj_dir file ~suffix:".all-deps" in
       let all_deps_file = all_deps_path file in
-      Build.memoize (Path.to_string all_deps_file)
-        (Build.lines_of all_deps_file
+      Build.memoize (Path.Build.to_string all_deps_file)
+        (Build.lines_of (Path.build all_deps_file)
          >>^ parse_module_names ~unit ~modules)
   in
   Ml_kind.Dict.of_func (fun ~ml_kind ->

--- a/src/ocamldep.mli
+++ b/src/ocamldep.mli
@@ -13,6 +13,6 @@ val rules_for_auxiliary_module
 
 (** Get the dep graph for an already defined library *)
 val graph_of_remote_lib
-  :  obj_dir:Path.t
+  :  obj_dir:Path.Build.t
   -> modules:Module.t Module.Name.Map.t
   -> Dep_graph.Ml_kind.t

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -220,7 +220,7 @@ let external_dep_graph sctx ~impl_cm_kind ~vlib_obj_dir ~impl_obj_dir
               Module.Name.Map.find modules name
           end)
     in
-    Dep_graph.make ~dir:(Path.build impl_obj_dir)
+    Dep_graph.make ~dir:impl_obj_dir
       ~per_module:(Module.Name.Map.map modules ~f:(fun m ->
         let deps =
           if (ml_kind = Intf && not (Module.has_intf m))
@@ -288,8 +288,9 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         let modules = Lib_modules.modules vlib_modules in
         match virtual_ with
         | Local ->
-          Ocamldep.graph_of_remote_lib
-            ~obj_dir:(Obj_dir.obj_dir vlib_obj_dir) ~modules
+          let obj_dir =
+            Path.as_in_build_dir_exn (Obj_dir.obj_dir vlib_obj_dir) in
+          Ocamldep.graph_of_remote_lib ~obj_dir ~modules
         | External _ ->
           let impl_obj_dir =
             Utils.library_object_directory ~dir (snd lib.name) in


### PR DESCRIPTION
Use Path.Build.t in ocamldep/dep_graph wherever this makes sense. This changes
the following public changes:

* Dep_graph.make
* Ocamldep.graph_of_remote_lib

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>