### PR TITLE
Move directory deletion outside the inner loop in `dune uninstall`

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -210,44 +210,46 @@ let install_uninstall ~what =
         CMap.of_list_multi install_files |> CMap.to_list
       in
       let (module Ops) = file_operations ~dry_run in
-      Fiber.parallel_iter install_files_by_context
-        ~f:(fun (context, install_files) ->
-          let+ (prefix, libdir) =
-            get_dirs context ~prefix_from_command_line ~libdir_from_command_line
-          in
-          List.iter install_files ~f:(fun (package, path) ->
-            let entries = Install.load_install_file path in
-            let paths =
-              Install.Section.Paths.make
-                ~package
-                ~destdir:prefix
-                ?libdir
-                ()
+      let files_deleted_in = ref Path.Set.empty in
+      let+ () =
+        Fiber.map_all_unit install_files_by_context
+          ~f:(fun (context, install_files) ->
+            let+ (prefix, libdir) =
+              get_dirs context ~prefix_from_command_line ~libdir_from_command_line
             in
-            let files_deleted_in = ref Path.Set.empty in
-            List.iter entries ~f:(fun entry ->
-              let dst =
-                Install.Entry.relative_installed_path entry ~paths
-                |> interpret_destdir ~destdir
+            List.iter install_files ~f:(fun (package, path) ->
+              let entries = Install.load_install_file path in
+              let paths =
+                Install.Section.Paths.make
+                  ~package
+                  ~destdir:prefix
+                  ?libdir
+                  ()
               in
-              let dir = Path.parent_exn dst in
-              if what = "install" then begin
-                Printf.eprintf "Installing %s\n%!"
-                  (Path.to_string_maybe_quoted dst);
-                Ops.mkdir_p dir;
-                let executable =
-                  Install.Section.should_set_executable_bit entry.section
+              List.iter entries ~f:(fun entry ->
+                let dst =
+                  Install.Entry.relative_installed_path entry ~paths
+                  |> interpret_destdir ~destdir
                 in
-                Ops.copy_file ~src:(Path.build entry.src) ~dst ~executable
-              end else begin
-                Ops.remove_if_exists dst;
-                files_deleted_in := Path.Set.add !files_deleted_in dir;
-              end;
-              Path.Set.to_list !files_deleted_in
-              (* This [List.rev] is to ensure we process children
-                 directories before their parents *)
-              |> List.rev
-              |> List.iter ~f:Ops.remove_dir_if_empty))))
+                let dir = Path.parent_exn dst in
+                if what = "install" then begin
+                  Printf.eprintf "Installing %s\n%!"
+                    (Path.to_string_maybe_quoted dst);
+                  Ops.mkdir_p dir;
+                  let executable =
+                    Install.Section.should_set_executable_bit entry.section
+                  in
+                  Ops.copy_file ~src:(Path.build entry.src) ~dst ~executable
+                end else begin
+                  Ops.remove_if_exists dst;
+                  files_deleted_in := Path.Set.add !files_deleted_in dir;
+                end)))
+      in
+      Path.Set.to_list !files_deleted_in
+      (* This [List.rev] is to ensure we process children
+         directories before their parents *)
+      |> List.rev
+      |> List.iter ~f:Ops.remove_dir_if_empty)
   in
   (term, Cmdliner.Term.info what ~doc ~man:Common.help_secs)
 

--- a/test/blackbox-tests/test-cases/install-dry-run/run.t
+++ b/test/blackbox-tests/test-cases/install-dry-run/run.t
@@ -36,24 +36,14 @@
 
   $ dune uninstall --dry-run 2>&1 | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Removing (if it exists) OPAM_PREFIX/lib/mylib/META
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/dune-package
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib$ext_lib
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cma
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmi
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmt
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmx
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmxa
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmxs
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.ml
-  Removing directory (if empty) OPAM_PREFIX/lib/mylib
   Removing (if it exists) OPAM_PREFIX/lib/mylib/opam
   Removing directory (if empty) OPAM_PREFIX/lib/mylib

--- a/test/blackbox-tests/test-cases/install-libdir/run.t
+++ b/test/blackbox-tests/test-cases/install-libdir/run.t
@@ -117,39 +117,19 @@ destdir`:
   Creating directory OPAM_VAR_PREFIX/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to OPAM_VAR_PREFIX/man/man3/another-man-page.3 (executable: false)
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/META
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/dune-package
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo$ext_lib
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cma
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmi
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmt
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmx
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmxa
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmxs
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.ml
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/opam
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/bin/exec
-  Removing directory (if empty) OPAM_VAR_PREFIX/bin
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
-  Removing directory (if empty) OPAM_VAR_PREFIX/man
-  Removing directory (if empty) OPAM_VAR_PREFIX/bin
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/man/man1/a-man-page.1
-  Removing directory (if empty) OPAM_VAR_PREFIX/man/man1
-  Removing directory (if empty) OPAM_VAR_PREFIX/man
-  Removing directory (if empty) OPAM_VAR_PREFIX/bin
-  Removing directory (if empty) /OCAMLFIND_DESTDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/man/man3/another-man-page.3
   Removing directory (if empty) OPAM_VAR_PREFIX/man/man3
   Removing directory (if empty) OPAM_VAR_PREFIX/man/man1
@@ -207,39 +187,19 @@ in libdir:
   Creating directory OPAM_VAR_PREFIX/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to OPAM_VAR_PREFIX/man/man3/another-man-page.3 (executable: false)
   Removing (if it exists) /LIBDIR/foo/META
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/dune-package
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo$ext_lib
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cma
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmi
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmt
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmx
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmxa
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.cmxs
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/foo.ml
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) /LIBDIR/foo/opam
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/bin/exec
-  Removing directory (if empty) OPAM_VAR_PREFIX/bin
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
-  Removing directory (if empty) OPAM_VAR_PREFIX/man
-  Removing directory (if empty) OPAM_VAR_PREFIX/bin
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/man/man1/a-man-page.1
-  Removing directory (if empty) OPAM_VAR_PREFIX/man/man1
-  Removing directory (if empty) OPAM_VAR_PREFIX/man
-  Removing directory (if empty) OPAM_VAR_PREFIX/bin
-  Removing directory (if empty) /LIBDIR/foo
   Removing (if it exists) OPAM_VAR_PREFIX/man/man3/another-man-page.3
   Removing directory (if empty) OPAM_VAR_PREFIX/man/man3
   Removing directory (if empty) OPAM_VAR_PREFIX/man/man1


### PR DESCRIPTION
When uninstalling a package, the old code was checking every single directory that we deleted files in so far after delete every single file.

Now we just do it once at the end.
