### PR TITLE
Rename and delete a few fiber functions

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -212,7 +212,7 @@ let install_uninstall ~what =
       let (module Ops) = file_operations ~dry_run in
       let files_deleted_in = ref Path.Set.empty in
       let+ () =
-        Fiber.map_all_unit install_files_by_context
+        Fiber.sequential_iter install_files_by_context
           ~f:(fun (context, install_files) ->
             let+ (prefix, libdir) =
               get_dirs context ~prefix_from_command_line ~libdir_from_command_line

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -214,19 +214,7 @@ let both a b =
   let* y = b in
   return (x, y)
 
-let all l =
-  let rec loop l acc =
-    match l with
-    | [] -> return (List.rev acc)
-    | t :: l ->
-      let* x = t in
-      loop l (x :: acc)
-  in
-  loop l []
-
-let all_unit l = List.fold_left l ~init:(return ()) ~f:(>>>)
-
-let map_all l ~f =
+let sequential_map l ~f =
   let rec loop l acc =
     match l with
     | [] -> return (List.rev acc)
@@ -236,7 +224,7 @@ let map_all l ~f =
   in
   loop l []
 
-let map_all_unit l ~f =
+let sequential_iter l ~f =
   let rec loop l =
     match l with
     | [] -> return ()

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -77,10 +77,8 @@ val nfork_map : 'a list -> f:('a -> 'b t) -> 'b Future.t list t
     parallelism. *)
 
 val both : 'a t -> 'b t -> ('a * 'b) t
-val all : 'a t list -> 'a list t
-val all_unit : unit t list -> unit t
-val map_all : 'a list -> f:('a -> 'b t) -> 'b list t
-val map_all_unit : 'a list -> f:('a -> unit t) -> unit t
+val sequential_map : 'a list -> f:('a -> 'b t) -> 'b list t
+val sequential_iter : 'a list -> f:('a -> unit t) -> unit t
 
 (** {1 Forking + joining} *)
 

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -385,7 +385,7 @@ let upgrade ft =
     Printf.ksprintf print_to_console fmt
   in
   let* () =
-    Fiber.map_all_unit todo.to_add ~f:(fun fn ->
+    Fiber.sequential_iter todo.to_add ~f:(fun fn ->
       match lookup_git_repo ft fn with
       | Some dir ->
         Process.run Strict ~dir ~env:Env.initial
@@ -396,7 +396,7 @@ let upgrade ft =
   List.iter todo.to_edit ~f:(fun (fn, s) ->
     log "Upgrading %s...\n" (Path.Source.to_string_maybe_quoted fn);
     Io.write_file (Path.source fn) s ~binary:true);
-  Fiber.map_all_unit todo.to_rename_and_edit ~f:(fun x ->
+  Fiber.sequential_iter todo.to_rename_and_edit ~f:(fun x ->
     let { original_file
         ; new_file
         ; extra_files_to_delete
@@ -409,7 +409,7 @@ let upgrade ft =
       (Path.Source.to_string_maybe_quoted new_file);
     (match lookup_git_repo ft original_file with
      | Some dir ->
-       Fiber.map_all_unit extra_files_to_delete ~f:(fun fn ->
+       Fiber.sequential_iter extra_files_to_delete ~f:(fun fn ->
          let fn = Path.source fn in
          Process.run Strict ~dir ~env:Env.initial
            (Lazy.force git)

--- a/test/unit-tests/vcs.mlt
+++ b/test/unit-tests/vcs.mlt
@@ -112,7 +112,7 @@ let run kind script =
   Path.mkdir_p temp_dir;
   let vcs = { Vcs.kind; root = temp_dir } in
   Scheduler.go (fun () ->
-    Fiber.map_all_unit script ~f:(run_action vcs))
+    Fiber.sequential_iter script ~f:(run_action vcs))
 ;;
 
 let script =


### PR DESCRIPTION
Some of the function names in the `Fiber` module were not great. This PR does the following renaming:

- `map_all` -> `sequential_map`
- `map_all_unit` -> `sequential_iter`

It also deletes the following unused functions:

- `all`
- `all_unit`
