### PR TITLE
Make Module.Source.t a part of Module.t

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -503,8 +503,8 @@ let get0_impl (sctx, dir) : result0 =
                  @\n- %a\
                  @\n- %a"
                 Module.Name.pp_quote name
-                (Fmt.optional Path.pp) (Module.Source.src_dir x)
-                (Fmt.optional Path.pp) (Module.Source.src_dir y)))
+                Path.pp (Module.Source.src_dir x)
+                Path.pp (Module.Source.src_dir y)))
       in
       Modules.make d ~modules)
     in

--- a/src/module.mli
+++ b/src/module.mli
@@ -58,6 +58,26 @@ module Kind : sig
   include Dune_lang.Conv with type t := t
 end
 
+(* Only the source of a module, not yet associated to a library *)
+module Source : sig
+  type t
+
+  val name : t -> Name.t
+  val impl : t -> File.t option
+  val intf : t -> File.t option
+
+  val make
+    :  ?impl:File.t
+    -> ?intf:File.t
+    -> Name.t
+    -> t
+
+  val has_impl: t -> bool
+
+  val src_dir : t -> Path.t
+end
+
+
 type t
 
 (** [obj_name] Object name. It is different from [name] for wrapped modules. *)
@@ -69,6 +89,15 @@ val make
   -> obj_dir:Obj_dir.t
   -> kind:Kind.t
   -> Name.t
+  -> t
+
+(** [obj_name] Object name. It is different from [name] for wrapped modules. *)
+val of_source
+  :  ?obj_name:string
+  -> visibility:Visibility.t
+  -> obj_dir:Obj_dir.t
+  -> kind:Kind.t
+  -> Source.t
   -> t
 
 val name : t -> Name.t
@@ -91,8 +120,6 @@ val cmt_file        : t -> Ml_kind.t -> Path.t option
 val obj_file : t -> kind:Cm_kind.t -> ext:string -> Path.t
 
 val obj_name : t -> string
-
-val src_dir : t -> Path.t option
 
 (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx]
     and the module has no implementation.
@@ -158,8 +185,6 @@ val set_private : t -> t
 val set_obj_dir : t -> obj_dir:Obj_dir.t -> t
 val set_virtual : t -> t
 
-val remove_files : t -> t
-
 val sources : t -> Path.t list
 
 val visibility : t -> Visibility.t
@@ -167,27 +192,6 @@ val visibility : t -> Visibility.t
 val encode : t -> Dune_lang.t list
 
 val decode : obj_dir:Obj_dir.t -> t Dune_lang.Decoder.t
-
-(* Only the source of a module, not yet associated to a library *)
-module Source : sig
-  type t = private
-    { name : Name.t
-    ; impl : File.t option
-    ; intf : File.t option
-    }
-
-  val make
-    :  ?impl:File.t
-    -> ?intf:File.t
-    -> Name.t
-    -> t
-
-  val has_impl: t -> bool
-
-  val src_dir : t -> Path.t option
-
-  val name : t -> Name.t
-end
 
 (** [pped m] return [m] but with the preprocessed source paths paths *)
 val pped : t -> t

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -10,7 +10,7 @@ let eval =
 
     let key = function
       | Error s -> s
-      | Ok m -> m.Module.Source.name
+      | Ok m -> Module.Source.name m
   end in
   let module Eval = Ordered_set_lang.Make_loc(Module.Name)(Value) in
   let parse ~all_modules ~fake_modules ~loc s =
@@ -227,7 +227,7 @@ let eval ~modules:(all_modules : Module.Source.t Module.Name.Map.t)
         else
           Intf_only
       in
-      Module.make ?impl:m.impl ?intf:m.intf m.name
+      Module.of_source m
         ~kind
         ~visibility
         ~obj_dir)


### PR DESCRIPTION
Previously, they would just duplicate the fields name, intf, and impl.