### PR TITLE
Correctly keep track of install subdirectories to keep

### DIFF
--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -20,9 +20,19 @@ val init
 
 val reset : unit -> unit
 
-type extra_sub_directories_to_keep =
-  | All
-  | These of String.Set.t
+module Subdir_set : sig
+  type t =
+    | All
+    | These of String.Set.t
+
+  val empty : t
+
+  val union : t -> t -> t
+
+  val mem : t -> string -> bool
+end
+
+type extra_sub_directories_to_keep = Subdir_set.t
 
 module Context_or_install : sig
   type t =

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -529,11 +529,11 @@ let scheme_per_ctx_memo =
        Scheme.evaluate ~union:Rules.Dir_rules.union scheme))
 
 let gen_rules sctx ~dir =
-  let rules =
+  let rules, subdirs =
     Scheme.Evaluated.get_rules (Memo.exec scheme_per_ctx_memo sctx) ~dir
-    |> Option.value ~default:Rules.Dir_rules.empty
   in
-  Rules.produce_dir ~dir rules
+  Rules.produce_dir ~dir (Option.value ~default:Rules.Dir_rules.empty rules);
+  Build_system.Subdir_set.These subdirs
 
 let packages =
   let f sctx =

--- a/src/install_rules.mli
+++ b/src/install_rules.mli
@@ -1,6 +1,7 @@
 open Stdune
 
-val gen_rules : Super_context.t -> (dir:Path.Build.t -> unit)
+val gen_rules :
+  Super_context.t -> (dir:Path.Build.t -> Build_system.Subdir_set.t)
 
 val init_meta : Super_context.t -> dir:Path.Build.t -> unit
 

--- a/src/scheme.ml
+++ b/src/scheme.ml
@@ -98,7 +98,8 @@ module Evaluated = struct
   let get_rules t ~dir =
     let dir = Path.explode dir in
     let t = List.fold_left dir ~init:t ~f:descend in
-    Memo.Lazy.force t.rules_here
+    (Memo.Lazy.force t.rules_here,
+     String.Set.of_list (String.Map.keys t.by_child))
 end
 
 let evaluate ~union_rules =

--- a/src/scheme.mli
+++ b/src/scheme.mli
@@ -33,7 +33,9 @@ type 'rules t =
 module Evaluated : sig
   type 'a t
 
-  val get_rules : 'a t -> dir:Path.Build.t -> 'a option
+  (** returns the rules and the set of child directories that could have
+      rules defined in this scheme *)
+  val get_rules : 'a t -> dir:Path.Build.t -> ('a option * String.Set.t)
 end
 
 (** [Evaluated.t] shares the work of scheme evaluation between multiple

--- a/test/blackbox-tests/test-cases/github2228/run.t
+++ b/test/blackbox-tests/test-cases/github2228/run.t
@@ -26,11 +26,13 @@
   Installing installed/lib/foobar/foobar.cmxs
   Installing installed/lib/foobar/foobar.mli
   Installing installed/lib/foobar/impl/foobar.cmi
-  Error: exception Sys_error("_build/install/default/lib/foobar/impl/foobar.cmi: No such file or directory")
-  Backtrace:
-  
-  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
-  the little-death that brings total obliteration.  I will fully express
-  my cases.  Execution will pass over me and through me.  And when it
-  has gone past, I will unwind the stack along its path.  Where the
-  cases are handled there will be nothing.  Only I will remain.
+  Installing installed/lib/foobar/impl/foobar.cmt
+  Installing installed/lib/foobar/impl/foobar.cmti
+  Installing installed/lib/foobar/impl/foobar.cmx
+  Installing installed/lib/foobar/impl/foobar.ml
+  Installing installed/lib/foobar/impl/foobar.mli
+  Installing installed/lib/foobar/impl/foobar_impl$ext_lib
+  Installing installed/lib/foobar/impl/foobar_impl.cma
+  Installing installed/lib/foobar/impl/foobar_impl.cmxa
+  Installing installed/lib/foobar/impl/foobar_impl.cmxs
+  Installing installed/lib/foobar/opam

--- a/test/unit-tests/scheme.mlt
+++ b/test/unit-tests/scheme.mlt
@@ -80,7 +80,7 @@ module Scheme = struct
   let evaluate = evaluate ~union:Directory_rules.union
 
   let get_rules t ~dir =
-    Option.value (Evaluated.get_rules t ~dir)
+    Option.value (fst (Evaluated.get_rules t ~dir))
       ~default:Directory_rules.empty
 end
 


### PR DESCRIPTION
This is a fix for #2228.

The problem is that stale artifact deletion doesn't know that the install directories should be kept.

This PR makes us correctly track that.

I'm working on a follow-up change that makes build system more robust to such problems.
As it stands, I have low confidence that the fix is complete.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>