### PR TITLE
Add Obj_dir.Local to public API

### DIFF
--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -16,10 +16,10 @@ let dev_files =
 let add_obj_dir sctx ~obj_dir =
   if (Super_context.context sctx).merlin then
     let dir_glob =
-      let dir = Obj_dir.byte_dir obj_dir in
+      let dir = Path.build (Obj_dir.Local.byte_dir obj_dir) in
       File_selector.create ~dir dev_files in
     let dyn_deps = Build.paths_matching ~loc:(Loc.of_pos __POS__) dir_glob in
     Rules.Produce.Alias.add_deps
-      (Alias.check ~dir:(Path.as_in_build_dir_exn (Obj_dir.dir obj_dir)))
+      (Alias.check ~dir:(Obj_dir.Local.dir obj_dir))
       ~dyn_deps
       Path.Set.empty

--- a/src/check_rules.mli
+++ b/src/check_rules.mli
@@ -1,1 +1,1 @@
-val add_obj_dir : Super_context.t -> obj_dir:Obj_dir.t -> unit
+val add_obj_dir : Super_context.t -> obj_dir:Obj_dir.Local.t -> unit

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -48,7 +48,7 @@ type t =
   { super_context        : Super_context.t
   ; scope                : Scope.t
   ; expander             : Expander.t
-  ; obj_dir              : Obj_dir.t
+  ; obj_dir              : Obj_dir.Local.t
   ; dir_kind             : Dune_lang.File_syntax.t
   ; modules              : Module.t Module.Name.Map.t
   ; alias_module         : Module.t option
@@ -67,7 +67,7 @@ type t =
 let super_context        t = t.super_context
 let scope                t = t.scope
 let expander             t = t.expander
-let dir                  t = Path.as_in_build_dir_exn (Obj_dir.dir t.obj_dir)
+let dir                  t = Obj_dir.Local.dir t.obj_dir
 let dir_kind             t = t.dir_kind
 let obj_dir              t = t.obj_dir
 let modules              t = t.modules

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -17,7 +17,7 @@ val create
   :  super_context         : Super_context.t
   -> scope                 : Scope.t
   -> expander              : Expander.t
-  -> obj_dir               : Obj_dir.t
+  -> obj_dir               : Obj_dir.Local.t
   -> ?vimpl                : Vimpl.t
   -> ?dir_kind             : Dune_lang.File_syntax.t
   -> modules               : Module.t Module.Name.Map.t
@@ -42,7 +42,7 @@ val context              : t -> Context.t
 val scope                : t -> Scope.t
 val dir                  : t -> Path.Build.t
 val dir_kind             : t -> Dune_lang.File_syntax.t
-val obj_dir              : t -> Obj_dir.t
+val obj_dir              : t -> Obj_dir.Local.t
 val modules              : t -> Module.t Module.Name.Map.t
 val alias_module         : t -> Module.t option
 val lib_interface_module : t -> Module.t option

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -29,7 +29,7 @@ module Modules = struct
         match (stanza : Stanza.t) with
         | Library lib ->
           let obj_dir =
-            Obj_dir.make_lib ~dir:d.ctx_dir
+            Obj_dir.Local.make_lib ~dir:d.ctx_dir
               (snd lib.name)
               ~has_private_modules:(Option.is_some lib.private_modules)
           in
@@ -67,13 +67,16 @@ module Modules = struct
                   (main_module_name, Option.value_exn wrapped)
               )
           in
+          let obj_dir = Obj_dir.of_local obj_dir in
           Left ( lib
-               , Lib_modules.make lib ~obj_dir modules ~main_module_name ~wrapped
+               , Lib_modules.make lib ~obj_dir modules ~main_module_name
+                   ~wrapped
                )
         | Executables exes
         | Tests { exes; _} ->
           let obj_dir =
-            Obj_dir.make_exe ~dir:d.ctx_dir ~name:(snd (List.hd exes.names))
+            let name = snd (List.hd exes.names) in
+            Obj_dir.Local.make_exe ~dir:d.ctx_dir ~name
           in
           let modules =
             Modules_field_evaluator.eval ~modules

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1144,7 +1144,7 @@ module Library = struct
   let is_impl t = Option.is_some t.implements
 
   let obj_dir ~dir t =
-    Obj_dir.make_lib ~dir
+    Obj_dir.Local.make_lib ~dir
       ~has_private_modules:(t.private_modules <> None)
       (snd t.name)
 

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -258,7 +258,7 @@ module Library : sig
   val best_name : t -> Lib_name.t
   val is_virtual : t -> bool
   val is_impl : t -> bool
-  val obj_dir : dir:Path.Build.t -> t -> Obj_dir.t
+  val obj_dir : dir:Path.Build.t -> t -> Obj_dir.Local.t
 
   module Main_module_name : sig
     type t = Module.Name.t option Inherited.t

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -8,7 +8,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       (exes : Dune_file.Executables.t) =
   (* Use "eobjs" rather than "objs" to avoid a potential conflict
      with a library of the same name *)
-  let obj_dir = Obj_dir.make_exe ~dir ~name:(snd (List.hd exes.names)) in
+  let obj_dir = Obj_dir.Local.make_exe ~dir ~name:(snd (List.hd exes.names)) in
   Check_rules.add_obj_dir sctx ~obj_dir;
   let modules =
     Dir_contents.modules_of_executables dir_contents
@@ -103,12 +103,17 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     ~js_of_ocaml:exes.buildable.js_of_ocaml;
 
   (cctx,
+   let objs_dirs =
+     Obj_dir.Local.public_cmi_dir obj_dir
+     |> Path.build
+     |> Path.Set.singleton
+   in
    Merlin.make ()
      ~requires:requires_compile
      ~flags:(Ocaml_flags.common flags)
      ~preprocess:(Dune_file.Buildable.single_preprocess exes.buildable)
      (* only public_dir? *)
-     ~objs_dirs:(Path.Set.singleton (Obj_dir.public_cmi_dir obj_dir)))
+     ~objs_dirs)
 
 let rules ~sctx ~dir ~dir_contents ~scope ~expander ~dir_kind
       (exes : Dune_file.Executables.t) =

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -171,13 +171,14 @@ include Sub_system.Register_end_point(
       let inline_test_dir = Path.Build.relative dir ("." ^ inline_test_name) in
 
       let obj_dir =
-        Obj_dir.make_exe ~dir:inline_test_dir
+        Obj_dir.Local.make_exe ~dir:inline_test_dir
           ~name:inline_test_name in
 
       let name = "run" in
       let main_module_filename = name ^ ".ml" in
       let main_module_name = Module.Name.of_string name in
       let modules =
+        let obj_dir = Obj_dir.of_local obj_dir in
         Module.Name.Map.singleton main_module_name
           (Module.make main_module_name
              ~impl:{ path =

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -98,8 +98,9 @@ let of_library_stanza ~dir
       (conf : Dune_file.Library.t) =
   let (_loc, lib_name) = conf.name in
   let obj_dir =
-    Obj_dir.make_lib ~dir
-      ~has_private_modules:(conf.private_modules <> None) lib_name in
+    Dune_file.Library.obj_dir ~dir conf
+    |> Obj_dir.of_local
+  in
   let gen_archive_file ~dir ext =
     Path.relative dir (Lib_name.Local.to_string lib_name ^ ext) in
   let archive_file = gen_archive_file ~dir:(Path.build dir) in

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -398,7 +398,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
           Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Mode.Byte) in
         let target =
           Path.Build.relative
-            (Path.as_in_build_dir_exn (Obj_dir.obj_dir obj_dir))
+            (Obj_dir.Local.obj_dir obj_dir)
             (Path.Build.basename src)
           |> Path.Build.extend_basename ~suffix:".js" in
         Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target);
@@ -525,9 +525,12 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       ; compile_info
       };
 
-    let objs_dirs = Path.Set.of_list (Obj_dir.all_cmis obj_dir) in
-
     (cctx,
+     let objs_dirs =
+       Obj_dir.of_local obj_dir
+       |> Obj_dir.all_cmis
+       |> Path.Set.of_list
+     in
      Merlin.make ()
        ~requires:requires_compile
        ~flags

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -12,11 +12,13 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
   let sctx       = CC.super_context cctx in
   let obj_dir    = CC.obj_dir       cctx in
   let dir        = CC.dir           cctx in
-  let ml = Path.relative (Obj_dir.obj_dir obj_dir) (basename ^ ".ml") in
-  SC.add_rule ~dir sctx (Build.write_file (Path.as_in_build_dir_exn ml) code);
-  let impl = Module.File.make OCaml ml in
+  let ml = Path.Build.relative
+             (Obj_dir.Local.obj_dir obj_dir) (basename ^ ".ml") in
+  SC.add_rule ~dir sctx (Build.write_file ml code);
+  let impl = Module.File.make OCaml (Path.build ml) in
   let name = Module.Name.of_string basename in
   let module_ =
+    let obj_dir = Obj_dir.of_local obj_dir in
     Module.make ~impl name ~visibility:Public ~obj_dir ~kind:Impl
   in
   let opaque =

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -212,7 +212,7 @@ module Run (P : PARAMS) : sig end = struct
         ~visibility:Public
         ~kind:Impl
         ~impl:{ path = Path.build (mock_ml base); syntax = OCaml }
-        ~obj_dir:(Compilation_context.obj_dir cctx)
+        ~obj_dir:(Obj_dir.of_local (Compilation_context.obj_dir cctx))
     in
 
     (* The following incantation allows the mock [.ml] file to be preprocessed

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -37,7 +37,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
       let copy_interface () =
         (* symlink the .cmi into the public interface directory *)
         if not (Module.is_private m)
-        && (Obj_dir.need_dedicated_public_dir obj_dir) then
+        && (Obj_dir.Local.need_dedicated_public_dir obj_dir) then
           SC.add_rule sctx ~sandbox:false ~dir
             (Build.symlink
                ~src:(Module.cm_file_unsafe m Cmi)
@@ -124,7 +124,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
         | true, Cmi, true ->
           (ctx.build_dir, Command.Args.As ["-no-keep-locs"])
         | true, Cmi, false ->
-          (Path.as_in_build_dir_exn (Obj_dir.byte_dir obj_dir), As [])
+          (Obj_dir.Local.byte_dir obj_dir, As [])
         (* emulated -no-keep-locs *)
         | true, (Cmo | Cmx), _
         | false, _, _ ->
@@ -145,8 +145,9 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
               ; no_keep_locs
               ; cmt_args
               ; Command.Args.S (
-                  Obj_dir.all_obj_dirs obj_dir ~mode
-                  |> List.concat_map ~f:(fun p -> [Command.Args.A "-I"; Path p])
+                  Obj_dir.Local.all_obj_dirs obj_dir ~mode
+                  |> List.concat_map ~f:(fun p -> [ Command.Args.A "-I"
+                                                  ; Path (Path.build p)])
                 )
               ; Cm_kind.Dict.get (CC.includes cctx) cm_kind
               ; As extra_args
@@ -218,7 +219,7 @@ let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
        (Build.S.map ~f:(fun act -> Action.with_stdout_to (Path.build output) act)
           (Command.run (Ok ctx.ocamlc) ~dir:(Path.build ctx.build_dir)
              [ Command.Args.dyn ocaml_flags
-             ; A "-I"; Path (Obj_dir.byte_dir obj_dir)
+             ; A "-I"; Path (Path.build (Obj_dir.Local.byte_dir obj_dir))
              ; Cm_kind.Dict.get (CC.includes cctx) Cmo
              ; (match CC.alias_module cctx with
                 | None -> S []

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -211,6 +211,7 @@ let eval ~modules:(all_modules : Module.Source.t Module.Name.Map.t)
   check_invalid_module_listing ~buildable:conf ~intf_only
     ~modules ~virtual_modules ~private_modules;
   let all_modules =
+    let obj_dir = Obj_dir.of_local obj_dir in
     Module.Name.Map.map modules ~f:(fun (_, m) ->
       let name = Module.Source.name m in
       let visibility =

--- a/src/modules_field_evaluator.mli
+++ b/src/modules_field_evaluator.mli
@@ -1,6 +1,6 @@
 val eval
   :  modules:(Module.Source.t Module.Name.Map.t)
-  -> obj_dir:Obj_dir.t
+  -> obj_dir:Obj_dir.Local.t
   -> buildable:Dune_file.Buildable.t
   -> virtual_modules:Ordered_set_lang.t option
   -> private_modules:Ordered_set_lang.t

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -18,8 +18,6 @@ module External = struct
     ; private_dir
     }
 
-  let need_dedicated_public_dir t = Option.is_some t.private_dir
-
   let public_cmi_dir t = t.public_dir
 
   let to_dyn { public_dir; private_dir } =
@@ -156,9 +154,7 @@ type t =
   | External of External.t
   | Local of Local.t
 
-let need_dedicated_public_dir = function
-  | External e -> External.need_dedicated_public_dir e
-  | Local e -> Local.need_dedicated_public_dir e
+let of_local t = Local t
 
 let encode = function
   | Local obj_dir ->
@@ -172,7 +168,6 @@ let decode ~dir =
   let+ external_ = External.decode ~dir in
   External external_
 
-let make_exe ~dir ~name = Local (Local.make_exe ~dir ~name)
 let make_lib ~dir ~has_private_modules lib_name =
   Local (Local.make_lib ~dir ~has_private_modules lib_name)
 

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -1,6 +1,37 @@
 open! Stdune
 
+(** Representation of the object directory for libraries that are local to the workspace *)
+module Local : sig
+  type t
+
+  (** The source_root directory *)
+  val dir : t -> Path.Build.t
+
+  val make_exe: dir:Path.Build.t -> name:string -> t
+
+  val need_dedicated_public_dir : t -> bool
+
+  (** The directory for ocamldep files *)
+  val obj_dir : t -> Path.Build.t
+
+  (** The private compiled byte file directories, and all cmi *)
+  val byte_dir : t -> Path.Build.t
+
+  val all_obj_dirs : t -> mode:Mode.t -> Path.Build.t list
+
+  (** The public compiled cmi file directory *)
+  val public_cmi_dir: t -> Path.Build.t
+
+  val make_lib
+    :  dir:Path.Build.t
+    -> has_private_modules:bool
+    -> Lib_name.Local.t
+    -> t
+end
+
 type t
+
+val of_local : Local.t -> t
 
 (** The source_root directory *)
 val dir : t -> Path.t
@@ -19,8 +50,6 @@ val all_cmis: t -> Path.t list
 (** The public compiled cmi file directory *)
 val public_cmi_dir: t -> Path.t
 
-val need_dedicated_public_dir : t -> bool
-
 val pp: t Fmt.t
 val to_sexp: t -> Sexp.t
 
@@ -31,8 +60,6 @@ val make_lib
   -> has_private_modules:bool
   -> Lib_name.Local.t
   -> t
-
-val make_exe: dir:Path.Build.t -> name:string -> t
 
 val make_external_no_private : dir:Path.t -> t
 

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -105,10 +105,9 @@ let deps_of cctx ~ml_kind unit =
       let dir = Compilation_context.dir cctx in
       let file_in_obj_dir ~suffix file =
         let base = Path.basename file in
-        Path.relative
-          (Obj_dir.obj_dir (Compilation_context.obj_dir cctx))
+        Path.Build.relative
+          (Obj_dir.Local.obj_dir (Compilation_context.obj_dir cctx))
           (base ^ suffix)
-        |> Path.as_in_build_dir_exn
       in
       let all_deps_path file = file_in_obj_dir file ~suffix:".all-deps" in
       let context = SC.context sctx in

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -15,10 +15,10 @@ module Source = struct
   let source_path t = Path.Build.relative t.dir (main_module_filename t)
 
   let obj_dir { dir; name ; _ } =
-    Obj_dir.make_exe ~dir ~name
+    Obj_dir.Local.make_exe ~dir ~name
 
   let modules t =
-    let obj_dir = obj_dir t in
+    let obj_dir = Obj_dir.of_local (obj_dir t) in
     let main_module_name = main_module_name t in
     Module.Name.Map.singleton
       main_module_name

--- a/src/toplevel.mli
+++ b/src/toplevel.mli
@@ -12,7 +12,7 @@ module Source : sig
 
   val loc : t -> Loc.t
   val modules : t -> Module.t Module.Name.Map.t
-  val obj_dir : t -> Obj_dir.t
+  val obj_dir : t -> Obj_dir.Local.t
 end
 
 type t

--- a/src/vimpl.ml
+++ b/src/vimpl.ml
@@ -3,7 +3,7 @@ open! Stdune
 type t =
   { vlib                 : Lib.t
   ; impl                 : Dune_file.Library.t
-  ; obj_dir              : Obj_dir.t
+  ; obj_dir              : Obj_dir.Local.t
   ; vlib_modules         : Lib_modules.t
   ; vlib_foreign_objects : Path.t list
   ; vlib_dep_graph       : Dep_graph.Ml_kind.t
@@ -15,7 +15,7 @@ let impl t = t.impl
 let vlib_dep_graph t = t.vlib_dep_graph
 
 let from_vlib_to_impl_module t m =
-  Module.set_obj_dir ~obj_dir:t.obj_dir m
+  Module.set_obj_dir ~obj_dir:(Obj_dir.of_local t.obj_dir) m
 
 let make ~vlib ~impl ~dir ~vlib_modules ~vlib_foreign_objects ~vlib_dep_graph =
   { impl

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -50,9 +50,10 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     let dst = Module.cm_file_unsafe dst ?ext kind in
     copy_to_obj_dir ~src ~dst:(Path.as_in_build_dir_exn dst) in
   let copy_objs src =
-    let dst = Module.set_obj_dir ~obj_dir:impl_obj_dir src in
+    let dst = Module.set_obj_dir ~obj_dir:(Obj_dir.of_local impl_obj_dir) src in
     copy_obj_file ~src ~dst Cmi;
-    if Module.is_public dst && Obj_dir.need_dedicated_public_dir impl_obj_dir
+    if Module.is_public dst
+    && Obj_dir.Local.need_dedicated_public_dir impl_obj_dir
     then begin
       let src = Module.cm_public_file_unsafe src Cmi in
       let dst = Module.cm_public_file_unsafe dst Cmi in
@@ -82,8 +83,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
                            (Path.as_in_build_dir_exn
                               (Obj_dir.obj_dir vlib_obj_dir)) f))
                 ~dst:(all_deps
-                        ~obj_dir:(Path.as_in_build_dir_exn
-                                    (Obj_dir.obj_dir impl_obj_dir)) f))
+                        ~obj_dir:(Obj_dir.Local.obj_dir impl_obj_dir) f))
           );
     else
       (* we only need to copy the .all-deps files for local libraries. for
@@ -101,8 +101,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
               |> String.concat ~sep:"\n")
             >>>
             Build.write_file_dyn
-              (all_deps ~obj_dir:(Path.as_in_build_dir_exn
-                                    (Obj_dir.obj_dir impl_obj_dir)) f)
+              (all_deps ~obj_dir:(Obj_dir.Local.obj_dir impl_obj_dir) f)
             |> add_rule sctx))
   in
   Option.iter (Lib_modules.alias_module vlib_modules) ~f:copy_objs;


### PR DESCRIPTION
This is a representation of the object directory where we know all the paths are
build paths. It allows us to remove a bunch of _exn calls to conver those paths
to build paths.