### PR TITLE
Remove ?ext arg from the Module.cm_file family of functions

### DIFF
--- a/src/module.ml
+++ b/src/module.ml
@@ -269,25 +269,25 @@ let obj_name t = t.obj_name
 
 let cm_source t kind = file t (Cm_kind.source kind)
 
-let cm_file_unsafe t ?ext kind =
-  let ext = Option.value ext ~default:(Cm_kind.ext kind) in
+let cm_file_unsafe t kind =
+  let ext = Cm_kind.ext kind in
   obj_file t ~kind ~ext
 
-let cm_file t ?ext (kind : Cm_kind.t) =
+let cm_file t (kind : Cm_kind.t) =
   match kind with
   | (Cmx | Cmo) when not (has_impl t) -> None
-  | _ -> Some (cm_file_unsafe t ?ext kind)
+  | _ -> Some (cm_file_unsafe t kind)
 
-let cm_public_file_unsafe t ?ext kind =
-  let ext = Option.value ext ~default:(Cm_kind.ext kind) in
+let cm_public_file_unsafe t kind =
+  let ext = Cm_kind.ext kind in
   let base = Obj_dir.cm_public_dir t.obj_dir kind in
   Path.relative base (t.obj_name ^ ext)
 
-let cm_public_file t ?ext (kind : Cm_kind.t) =
+let cm_public_file t (kind : Cm_kind.t) =
   match kind with
   | (Cmx | Cmo) when not (has_impl t) -> None
   |  Cmi when is_private t -> None
-  | _ -> Some (cm_public_file_unsafe t ?ext kind)
+  | _ -> Some (cm_public_file_unsafe t kind)
 
 let cmt_file t (kind : Ml_kind.t) =
   match kind with

--- a/src/module.mli
+++ b/src/module.mli
@@ -113,8 +113,8 @@ val pp_flags : t -> (unit, string list) Build.t option
 
 val file            : t -> Ml_kind.t -> Path.t option
 val cm_source       : t -> Cm_kind.t -> Path.t option
-val cm_file         : t -> ?ext:string -> Cm_kind.t -> Path.t option
-val cm_public_file  : t -> ?ext:string -> Cm_kind.t -> Path.t option
+val cm_file         : t -> Cm_kind.t -> Path.t option
+val cm_public_file  : t -> Cm_kind.t -> Path.t option
 val cmt_file        : t -> Ml_kind.t -> Path.t option
 
 val obj_file : t -> kind:Cm_kind.t -> ext:string -> Path.t
@@ -123,10 +123,9 @@ val obj_name : t -> string
 
 (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx]
     and the module has no implementation.
-    If present [ext] replace the extension of the kind
  *)
-val cm_file_unsafe : t -> ?ext:string -> Cm_kind.t -> Path.t
-val cm_public_file_unsafe : t -> ?ext:string -> Cm_kind.t -> Path.t
+val cm_file_unsafe : t -> Cm_kind.t -> Path.t
+val cm_public_file_unsafe : t -> Cm_kind.t -> Path.t
 
 val odoc_file : t -> doc_dir:Path.Build.t -> Path.Build.t
 


### PR DESCRIPTION
The ?ext is only set for .o files. This isn't strong enough justification to
keep this argument around.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>