### PR TITLE
Introduce Lib.Local.t

### DIFF
--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -25,20 +25,23 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
           in
           let libs =
             Local_package.libs pkg
-            |> Lib.Set.to_list
+            |> Lib.Local.Set.to_list
             |> List.map ~f:(fun lib ->
-              let name = Lib.name lib in
               let dir_contents =
-                Dir_contents.get_without_rules sctx ~dir:(
-                  Path.as_in_build_dir_exn (Lib.src_dir lib)) in
-              let lib_modules =
-                Dir_contents.modules_of_library dir_contents ~name in
+                let dir = Lib.Local.src_dir lib in
+                Dir_contents.get_without_rules sctx ~dir
+              in
+              let obj_dir = Lib.Local.obj_dir lib in
+              let lib = Lib.Local.to_lib lib in
+              let name = Lib.name lib in
               let foreign_objects =
-                let dir = Obj_dir.obj_dir (Lib.obj_dir lib) in
+                let dir = Obj_dir.Local.obj_dir obj_dir in
                 Dir_contents.c_sources_of_library dir_contents ~name
-                |> C.Sources.objects ~dir:(Path.as_in_build_dir_exn dir)
-                     ~ext_obj:ctx.ext_obj
+                |> C.Sources.objects ~dir ~ext_obj:ctx.ext_obj
                 |> List.map ~f:Path.build
+              in
+              let lib_modules =
+                Dir_contents.modules_of_library dir_contents ~name
               in
               Lib.to_dune_lib lib ~dir:(Path.build (lib_root lib)) ~lib_modules
                 ~foreign_objects)
@@ -114,6 +117,7 @@ let init_meta sctx ~dir =
         ~then_:(
           match Local_package.virtual_lib pkg with
           | Some lib ->
+            let lib = Lib.Local.to_lib lib in
             Build.fail { fail = fun () ->
               Errors.fail (Loc.in_file meta_template)
                 "Package %a defines virtual library %a and has a META \
@@ -130,7 +134,8 @@ let init_meta sctx ~dir =
       Gen_meta.gen
         ~package:(Package.Name.to_string pkg_name)
         ~version
-        (Lib.Set.to_list libs)
+        (Lib.Local.Set.to_list libs
+         |> List.map ~f:Lib.Local.to_lib)
     in
     let ctx = Super_context.context sctx in
     Super_context.add_rule sctx ~dir:ctx.build_dir

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1771,7 +1771,7 @@ let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects
     ~special_builtin_support:info.special_builtin_support
 
 module Local : sig
-  type t
+  type t = private lib
   val of_lib : lib -> t option
   val of_lib_exn : lib -> t
   val to_lib : t -> lib
@@ -1784,9 +1784,6 @@ module Local : sig
   module Set : Stdune.Set.S with type elt = t
   module Map : Stdune.Map.S with type key = t
 
-  module L : sig
-    val to_lib : t list -> lib list
-  end
 end = struct
   type nonrec t = t
 
@@ -1810,8 +1807,4 @@ end = struct
   let to_dyn = to_dyn
   let equal = equal
   let hash = hash
-
-  module L = struct
-    let to_lib x = x
-  end
 end

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1769,3 +1769,49 @@ let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects
     ~main_module_name:(Result.ok_exn (main_module_name lib))
     ~sub_systems:(Sub_system.dump_config lib)
     ~special_builtin_support:info.special_builtin_support
+
+module Local : sig
+  type t
+  val of_lib : lib -> t option
+  val of_lib_exn : lib -> t
+  val to_lib : t -> lib
+  val obj_dir : t -> Obj_dir.Local.t
+  val src_dir : t -> Path.Build.t
+  val to_dyn : t -> Dyn.t
+  val equal : t -> t -> bool
+  val hash : t -> int
+
+  module Set : Stdune.Set.S with type elt = t
+  module Map : Stdune.Map.S with type key = t
+
+  module L : sig
+    val to_lib : t list -> lib list
+  end
+end = struct
+  type nonrec t = t
+
+  let to_lib t = t
+
+  let of_lib (t : lib) = Option.some_if (is_local t) t
+
+  let of_lib_exn t =
+    match of_lib t with
+    | Some l -> l
+    | None -> Exn.code_error "Lib.Local.of_lib_exn"
+                ["l", Dyn.to_sexp (to_dyn t)]
+
+  let obj_dir t = Obj_dir.as_local_exn t.info.obj_dir
+
+  let src_dir t = Path.as_in_build_dir_exn t.info.src_dir
+
+  module Set = Set
+  module Map = Map
+
+  let to_dyn = to_dyn
+  let equal = equal
+  let hash = hash
+
+  module L = struct
+    let to_lib x = x
+  end
+end

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -368,8 +368,8 @@ val to_dune_lib
   -> (Syntax.Version.t * Dune_lang.t list) Dune_package.Lib.t
 
 module Local : sig
-  type t
   type lib
+  type t = private lib
 
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool
@@ -385,7 +385,4 @@ module Local : sig
   module Set : Stdune.Set.S with type elt = t
   module Map : Stdune.Map.S with type key = t
 
-  module L : sig
-    val to_lib : t list -> lib list
-  end
 end with type lib := t

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -366,3 +366,26 @@ val to_dune_lib
   -> foreign_objects:Path.t list
   -> dir:Path.t
   -> (Syntax.Version.t * Dune_lang.t list) Dune_package.Lib.t
+
+module Local : sig
+  type t
+  type lib
+
+  val to_dyn : t -> Dyn.t
+  val equal : t -> t -> bool
+  val hash : t -> int
+
+  val of_lib : lib -> t option
+  val of_lib_exn : lib -> t
+  val to_lib : t -> lib
+
+  val obj_dir : t -> Obj_dir.Local.t
+  val src_dir : t -> Path.Build.t
+
+  module Set : Stdune.Set.S with type elt = t
+  module Map : Stdune.Map.S with type key = t
+
+  module L : sig
+    val to_lib : t list -> lib list
+  end
+end with type lib := t

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -10,8 +10,8 @@ type t =
   ; mlds : Path.Build.t list Lazy.t
   ; coqlibs : Dune_file.Coq.t Dir_with_dune.t list
   ; pkg : Package.t
-  ; libs : Lib.Set.t
-  ; virtual_lib : Lib.t option Lazy.t
+  ; libs : Lib.Local.Set.t
+  ; virtual_lib : Lib.Local.t option Lazy.t
   }
 
 let to_dyn t = Package.to_dyn t.pkg
@@ -125,7 +125,7 @@ module Of_sctx = struct
         fun (pkg : Package.t) ->
           match Package.Name.Map.find libs pkg.name with
           | Some (_, libs) -> libs
-          | None -> Lib.Set.empty
+          | None -> Lib.Local.Set.empty
       in
       Super_context.packages sctx
       |> Package.Name.Map.map ~f:(fun (pkg : Package.t) ->
@@ -140,7 +140,9 @@ module Of_sctx = struct
         in
         let libs = libs_of pkg in
         let virtual_lib = lazy (
-          Lib.Set.find libs ~f:(fun l -> Option.is_some (Lib.virtual_ l))
+          Lib.Local.Set.find libs ~f:(fun l ->
+            let l = Lib.Local.to_lib l in
+            Option.is_some (Lib.virtual_ l))
         ) in
         let t =
           add_stanzas

--- a/src/local_package.mli
+++ b/src/local_package.mli
@@ -33,11 +33,11 @@ val name : t -> Package.Name.t
 
 val install_paths : t -> Install.Section.Paths.t
 
-val libs : t -> Lib.Set.t
+val libs : t -> Lib.Local.Set.t
 
 val package : t -> Package.t
 
-val virtual_lib : t -> Lib.t option
+val virtual_lib : t -> Lib.Local.t option
 
 val meta_template : t -> Path.Build.t
 

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -234,3 +234,7 @@ let cm_public_dir t (cm_kind : Cm_kind.t) =
   | Cmx -> native_dir t
   | Cmo -> byte_dir t
   | Cmi -> public_cmi_dir t
+
+let as_local_exn = function
+  | Local e -> e
+  | External _ -> Exn.code_error "Obj_dir.as_local_exn: external dir" []

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -71,3 +71,5 @@ val convert_to_external : t -> dir:Path.t -> t
 val cm_dir : t -> Cm_kind.t -> Visibility.t -> Path.t
 
 val cm_public_dir : t -> Cm_kind.t -> Path.t
+
+val as_local_exn : t -> Local.t

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -289,17 +289,19 @@ let setup_toplevel_index_rule sctx =
 
 let libs_of_pkg sctx ~pkg =
   match Package.Name.Map.find (SC.libs_by_package sctx) pkg with
-  | None -> Lib.Set.empty
+  | None -> Lib.Local.Set.empty
   | Some (_, libs) ->
     (* Filter out all implementations of virtual libraries *)
-    Lib.Set.filter ~f:(fun lib ->
-      not (Lib.is_impl lib)) libs
+    Lib.Local.Set.filter libs ~f:(fun lib ->
+      let lib = Lib.Local.to_lib lib in
+      not (Lib.is_impl lib))
 
 let load_all_odoc_rules_pkg sctx ~pkg =
   let pkg_libs = libs_of_pkg sctx ~pkg in
   let ctx = Super_context.context sctx in
   Build_system.load_dir ~dir:(Path.build (Paths.odocs ctx (Pkg pkg)));
-  Lib.Set.iter pkg_libs ~f:(fun lib ->
+  Lib.Local.Set.iter pkg_libs ~f:(fun lib ->
+    let lib = Lib.Local.to_lib lib in
     Build_system.load_dir ~dir:(Path.build (Paths.odocs ctx (Lib lib))));
   pkg_libs
 
@@ -392,25 +394,25 @@ let setup_lib_html_rules sctx lib ~requires =
 
 let setup_pkg_html_rules_def =
   let module Input = struct
-    type t = Super_context.t * Package.Name.t * Lib.t list
+    type t = Super_context.t * Package.Name.t * Lib.Local.t list
 
     let equal (s1, p1, l1) (s2, p2, l2) =
       Package.Name.equal p1 p2
-      && List.equal Lib.equal l1 l2
+      && List.equal Lib.Local.equal l1 l2
       && Super_context.equal s1 s2
 
     let hash (sctx, p, ls) =
       Hashtbl.hash
         ( Super_context.hash sctx
         , Package.Name.hash p
-        , List.hash Lib.hash ls
+        , List.hash Lib.Local.hash ls
         )
 
     let to_sexp (_, package, libs) =
       let open Dyn in
       Tuple
         [ Package.Name.to_dyn package
-        ; List (List.map ~f:Lib.to_dyn libs)
+        ; List (List.map ~f:Lib.Local.to_dyn libs)
         ]
       |> Dyn.to_sexp
   end
@@ -423,6 +425,7 @@ let setup_pkg_html_rules_def =
     ~visibility:Hidden
     Sync
     (fun (sctx, pkg, libs) ->
+       let libs = Lib.Local.L.to_lib libs in
        let requires = Lib.closure libs ~linking:false in
        let ctx = Super_context.context sctx in
        List.iter libs ~f:(setup_lib_html_rules sctx ~requires);
@@ -450,37 +453,37 @@ let setup_package_aliases sctx (pkg : Package.t) =
   Rules.Produce.Alias.add_deps alias (
     Dep.html_alias ctx (Pkg pkg.name)
     :: (libs_of_pkg sctx ~pkg:pkg.name
-        |> Lib.Set.to_list
-        |> List.map ~f:(fun lib -> Dep.html_alias ctx (Lib lib)))
+        |> Lib.Local.Set.to_list
+        |> List.map ~f:(fun lib ->
+          let lib = Lib.Local.to_lib lib in
+          Dep.html_alias ctx (Lib lib)))
     |> List.map ~f:(fun f -> Path.build (Alias.stamp_file f))
     |> Path.Set.of_list
   )
 
 let entry_modules_by_lib sctx lib =
-  Dir_contents.get_without_rules sctx
-    ~dir:(Path.as_in_build_dir_exn (Lib.src_dir lib))
-  |> Dir_contents.modules_of_library ~name:(Lib.name lib)
+  let dir = Lib.Local.src_dir lib in
+  let name = Lib.name (Lib.Local.to_lib lib) in
+  Dir_contents.get_without_rules sctx ~dir
+  |> Dir_contents.modules_of_library ~name
   |> Lib_modules.entry_modules
 
 let entry_modules sctx ~pkg =
   libs_of_pkg sctx ~pkg
-  |> Lib.Set.to_list
-  |> List.filter_map ~f:(fun l ->
-    if Lib.is_local l then (
-      Some (l, entry_modules_by_lib sctx l)
-    ) else (
-      None
-    ))
-  |> Lib.Map.of_list_exn
+  |> Lib.Local.Set.to_list
+  |> Lib.Local.Map.of_list_map_exn ~f:(fun l ->
+    (l, entry_modules_by_lib sctx l))
 
 let default_index ~pkg entry_modules =
   let b = Buffer.create 512 in
   Printf.bprintf b "{0 %s index}\n"
     (Package.Name.to_string pkg);
-  Lib.Map.to_list entry_modules
+  Lib.Local.Map.to_list entry_modules
   |> List.sort ~compare:(fun (x, _) (y, _) ->
-    Lib_name.compare (Lib.name x) (Lib.name y))
+    let name lib = Lib.name (Lib.Local.to_lib lib) in
+    Lib_name.compare (name x) (name y))
   |> List.iter ~f:(fun (lib, modules) ->
+    let lib = Lib.Local.to_lib lib in
     Printf.bprintf b "{1 Library %s}\n" (Lib_name.to_string (Lib.name lib));
     Buffer.add_string b (
       match modules with
@@ -633,7 +636,7 @@ let gen_rules sctx ~dir:_ rest =
     let lib = Lib_name.of_string_exn ~loc:None lib in
     let setup_pkg_html_rules pkg =
       setup_pkg_html_rules sctx ~pkg ~libs:(
-        Lib.Set.to_list (load_all_odoc_rules_pkg sctx ~pkg)) in
+        Lib.Local.Set.to_list (load_all_odoc_rules_pkg sctx ~pkg)) in
     Lib.DB.find lib_db lib
     |> Result.iter ~f:(fun lib ->
       match Lib.package lib with

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -425,7 +425,7 @@ let setup_pkg_html_rules_def =
     ~visibility:Hidden
     Sync
     (fun (sctx, pkg, libs) ->
-       let libs = Lib.Local.L.to_lib libs in
+       let libs = (libs :> Lib.t list) in
        let requires = Lib.closure libs ~linking:false in
        let ctx = Super_context.context sctx in
        List.iter libs ~f:(setup_lib_html_rules sctx ~requires);

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -424,7 +424,7 @@ let setup_pkg_html_rules_def =
     ~input:(module Input)
     ~visibility:Hidden
     Sync
-    (fun (sctx, pkg, libs) ->
+    (fun (sctx, pkg, (libs : Lib.Local.t list)) ->
        let libs = (libs :> Lib.t list) in
        let requires = Lib.closure libs ~linking:false in
        let ctx = Super_context.context sctx in

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -32,7 +32,7 @@ type t =
   ; expander                         : Expander.t
   ; chdir                            : (Action.t, Action.t) Build.t
   ; host                             : t option
-  ; libs_by_package : (Package.t * Lib.Set.t) Package.Name.Map.t
+  ; libs_by_package : (Package.t * Lib.Local.Set.t) Package.Name.Map.t
   ; env_context                      : Env_context.t
   ; dir_status_db                    : Dir_status.DB.t
   ; external_lib_deps_mode           : bool
@@ -492,13 +492,15 @@ let create
   ; libs_by_package =
       Lib.DB.all public_libs
       |> Lib.Set.to_list
-      |> List.map ~f:(fun lib ->
-        (Option.value_exn (Lib.package lib), lib))
+      |> List.filter_map ~f:(fun lib ->
+        Lib.Local.of_lib lib
+        |> Option.map ~f:(fun local ->
+          (Option.value_exn (Lib.package lib), local)))
       |> Package.Name.Map.of_list_multi
       |> Package.Name.Map.merge packages ~f:(fun _name pkg libs ->
         let pkg  = Option.value_exn pkg          in
         let libs = Option.value libs ~default:[] in
-        Some (pkg, Lib.Set.of_list libs))
+        Some (pkg, Lib.Local.Set.of_list libs))
   ; env_context
   ; default_env
   ; external_lib_deps_mode

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -31,7 +31,7 @@ val context   : t -> Context.t
 val stanzas   : t -> Stanzas.t Dir_with_dune.t list
 val stanzas_in : t -> dir:Path.Build.t -> Stanzas.t Dir_with_dune.t option
 val packages  : t -> Package.t Package.Name.Map.t
-val libs_by_package : t -> (Package.t * Lib.Set.t) Package.Name.Map.t
+val libs_by_package : t -> (Package.t * Lib.Local.Set.t) Package.Name.Map.t
 val file_tree : t -> File_tree.t
 val artifacts : t -> Artifacts.t
 val build_dir : t -> Path.Build.t

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -260,9 +260,11 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         | External lib_modules, External fa -> (lib_modules, fa)
         | Local, Local ->
           let name = Lib.name vlib in
+          let vlib = Lib.Local.of_lib_exn vlib in
           let dir_contents =
-            Dir_contents.get_without_rules sctx ~dir:(
-              Path.as_in_build_dir_exn (Lib.src_dir vlib)) in
+            let dir = Lib.Local.src_dir vlib in
+            Dir_contents.get_without_rules sctx ~dir
+          in
           let modules =
             let pp_spec =
               Pp_spec.make lib.buildable.preprocess
@@ -275,9 +277,9 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
           in
           let foreign_objects =
             let ext_obj = (Super_context.context sctx).ext_obj in
-            let dir = Obj_dir.obj_dir (Lib.obj_dir vlib) in
+            let dir = Obj_dir.Local.obj_dir (Lib.Local.obj_dir vlib) in
             Dir_contents.c_sources_of_library dir_contents ~name
-            |> C.Sources.objects ~ext_obj ~dir:(Path.as_in_build_dir_exn dir)
+            |> C.Sources.objects ~ext_obj ~dir
             |> List.map ~f:Path.build
           in
           (modules, foreign_objects)


### PR DESCRIPTION
This type allows us to access to local versions of some artifacts without _exn. Unfortunately, we need to push some of the _exn calls into `Lib.Local` itself, but this still seems like an improvement. `Lib.Local.of_lib_exn` can also be eliminated with a little more effort.