### PR TITLE
Local path polymorphic over its root

### DIFF
--- a/src/dir_set.ml
+++ b/src/dir_set.ml
@@ -1,14 +1,16 @@
 open! Stdune
 
-type t =
+type t0 =
   | Empty
   | Universal
   | Nontrivial of nontrivial
 and nontrivial = {
   default : bool;
   here : bool;
-  exceptions : t String.Map.t;
+  exceptions : t0 String.Map.t;
 }
+
+type _ t = t0
 
 let here = function
   | Empty -> false
@@ -110,7 +112,7 @@ let rec mem t dir =
       | None -> default
       | Some t -> mem t rest
 
-let mem t dir = mem t (Path.Build.explode dir)
+let mem t dir = mem t (Path.Local_gen.explode dir)
 
 let descend t child =
   match t with
@@ -133,7 +135,7 @@ let of_subtree_gen =
         ~default:false
         ~exceptions:(String.Map.singleton component (loop subtree rest))
   in
-  fun subtree path -> loop subtree (Path.Build.explode path)
+  fun subtree path -> loop subtree (Path.Local_gen.explode path)
 
 let just_the_root =
   Nontrivial
@@ -168,3 +170,5 @@ let rec to_sexp t = match t with
          | false -> []
          | true -> [("*", Sexp.Atom "Universal")]))
       |> List.map ~f:(fun (k, v) -> Sexp.List [Sexp.Atom k; v]))
+
+let forget_root t = t

--- a/src/dir_set.mli
+++ b/src/dir_set.mli
@@ -4,20 +4,20 @@ open! Stdune
 
 (** Type of potentially infinite sets of directories. Not all sets can
     be represented, only ones that can be efficiently inspected. *)
-type t
+type 'w t
 
 (** [mem t p] is [true] if and only if [p] is in [t] *)
-val mem : t -> Path.Build.t -> bool
+val mem : 'w t -> 'w Path.Local_gen.t -> bool
 
 (** [here t] is the same as [mem t Path.Build.root] but more
     efficient. *)
-val here : t -> bool
+val here : 'w t -> bool
 
 (** The empty set *)
-val empty : t
+val empty : 'w t
 
 (** The set of all possible directories *)
-val universal : t
+val universal : 'w t
 
 (** [trivial b] is such that for all path [p]:
 
@@ -27,15 +27,15 @@ val universal : t
 
     i.e. [trivial false] is [empty] and [trivial true] is [universal].
 *)
-val trivial : bool -> t
+val trivial : bool -> 'w t
 
-val is_empty : t -> bool
-val is_universal : t -> bool
+val is_empty : 'w t -> bool
+val is_universal : 'w t -> bool
 
 (** [descend t comp] is the set [t'] such that for all path [p], [p]
     is in [t'] iff [comp/p] is in [t]. [comp] must be a path component,
     i.e. without directory separator characters. *)
-val descend : t -> string -> t
+val descend : 'w t -> string -> Path.Local.w t
 
 (** [exceptions t] is the set of all bindings of the form [(comp,
     t']] such that:
@@ -46,26 +46,28 @@ val descend : t -> string -> t
     Sets of directories for which [exceptions t] is not finite cannot be
     represented by this module.
 *)
-val exceptions : t -> t String.Map.t
+val exceptions : 'w t -> Path.Local.w t String.Map.t
 
 (** Default membership value for paths that are neither empty nor part
     of the exceptions. I.e. for all non-empty path [p] whose first
     component is not in [exceptions t], [mem t p = default t]. *)
-val default : t -> bool
+val default : 'w t -> bool
 
 (** [singleton p] is the set containing only [p] *)
-val singleton : Path.Build.t -> t
+val singleton : 'w Path.Local_gen.t -> 'w t
 
 (** [subtree p] is the set of all directories that are descendant of
     [p]. *)
-val subtree : Path.Build.t -> t
+val subtree : 'w Path.Local_gen.t -> 'w t
 
-val is_subset : t -> of_:t -> bool
-val union : t -> t -> t
-val union_all : t list -> t
-val inter : t -> t -> t
-val inter_all : t list -> t
-val diff : t -> t -> t
-val negate : t -> t
+val is_subset : 'w t -> of_:'w t -> bool
+val union : 'w t -> 'w t -> 'w t
+val union_all : 'w t list -> 'w t
+val inter : 'w t -> 'w t -> 'w t
+val inter_all : 'w t list -> 'w t
+val diff : 'w t -> 'w t -> 'w t
+val negate : 'w t -> 'w t
 
-val to_sexp : t -> Sexp.t
+val to_sexp : 'w t -> Sexp.t
+
+val forget_root : 'w t -> Path.Local.w t

--- a/src/scheme.mli
+++ b/src/scheme.mli
@@ -16,7 +16,7 @@ type 'rules t =
       This error is not always going to be detected, especially if it's hidden
       by an occurrence of [Thunk]. If the error is undetected, the violating
       rules are just silently ignored. *)
-  | Approximation of Dir_set.t * 'rules t
+  | Approximation of Path.Build.w Dir_set.t * 'rules t
 
   (** [Finite rules] just produces a fixed set of rules known in advance.
       The keys in the map are the directory paths. *)

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -206,12 +206,12 @@ module Local_gen : sig
 
   val basename : 'w t -> string
   val extend_basename : 'w t -> suffix:string -> 'w t
-  val is_suffix : 'w t -> suffix:string -> bool
 
   module Fix_root (Root : sig type w end) : sig
     module Set : sig
       include Set.S with type elt = Root.w t
       val to_sexp : t Sexp.Encoder.t
+      val to_dyn : t Dyn.Encoder.t
       val of_listing : dir:elt -> filenames:string list -> t
     end
 
@@ -303,11 +303,6 @@ end = struct
       match String.rindex_from t (String.length t - 1) '/' with
       | exception Not_found -> Some root
       | i -> Some (make (String.take t i))
-
-  let parent_exn t =
-    match parent t with
-    | None -> Code_error.raise "Path.Local.parent called on the root" []
-    | Some t -> t
 
   let basename t =
     if is_root t then
@@ -612,6 +607,8 @@ module Relative_to_source_root : sig
   val mkdir_p : Local.t -> unit
 end = struct
 
+  open Local
+  
   let rec mkdir_p t =
     if is_root t then
       ()

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -173,64 +173,11 @@ end = struct
   module Map = T.Map
 end
 
-module Unspecified = struct
-  type w
-end
+module Unspecified = Path_intf.Unspecified
 
 module Local_gen : sig
 
-  type 'w t
-
-  val hash : 'w t -> int
-
-  (* it's not clear that these should be polymorphic over 'w, maybe they should
-     additionally ask for an object that fixes 'w *)
-  val to_string : 'w t -> string
-  val of_string : string -> 'w t
-  val parse_string_exn : loc:Loc0.t -> string -> 'w t
-
-  val pp : Format.formatter -> 'w t -> unit
-
-  (** a directory is smaller than its descendants *)
-  val compare : 'w t -> 'w t -> Ordering.t
-
-  val to_dyn : 'w t -> Dyn.t
-  val to_sexp : 'w t -> Sexp.t
-
-  val extension : 'w t -> string
-
-  (** [set_extension path ~ext] replaces extension of [path] by [ext] *)
-  val set_extension : 'w t -> ext:string -> 'w t
-
-  val split_extension : 'w t -> 'w t * string
-
-  val basename : 'w t -> string
-  val extend_basename : 'w t -> suffix:string -> 'w t
-
-  module Fix_root (Root : sig type w end) : sig
-    module Set : sig
-      include Set.S with type elt = Root.w t
-      val to_sexp : t Sexp.Encoder.t
-      val to_dyn : t Dyn.Encoder.t
-      val of_listing : dir:elt -> filenames:string list -> t
-    end
-
-    module Map :  Map.S with type key = Root.w t
-
-    module Table : Hashtbl.S with type key = Root.w t
-  end
-
-  val relative : ?error_loc:Loc0.t -> 'w t -> string -> 'w t
-
-  val to_string_maybe_quoted : 'w t -> string
-
-  val is_root : 'w t -> bool
-  val parent_exn : 'w t -> 'w t
-  val parent : 'w t -> 'w t option
-
-  val root : 'w t
-
-  val explode : 'w t -> string list
+  include Path_intf.Local_gen
 
   module Prefix : sig
     type 'w local = 'w t
@@ -242,17 +189,6 @@ module Local_gen : sig
     (* for all local path p, drop (invalid p = None) *)
     val invalid : 'w t
   end with type 'w local := 'w t
-
-  module L : sig
-    val relative : ?error_loc:Loc0.t -> 'w t -> string list -> 'w t
-  end
-
-  val append : 'w t -> Unspecified.w t -> 'w t
-  val descendant : 'w t -> of_:'w t -> Unspecified.w t option
-  val is_descendant : 'w t -> of_:'w t -> bool
-  val reach : 'w t -> from:'w t -> string
-
-  val split_first_component : 'w t -> (string * Unspecified.w t) option
 
 end = struct
   (* either "." for root, or a '/' separated list of components

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -1,9 +1,76 @@
+(** Relative path relative to the root tracked by the type system.
+
+    Represented as: either the root, or a '/' separated list of components
+    other that ".", ".."  and not containing a '/'. *)
+module Local_gen : sig
+
+  type 'w t
+
+  val hash : 'w t -> int
+
+  (* it's not clear that these should be polymorphic over 'w, maybe they should
+     additionally ask for an object that fixes 'w *)
+  val to_string : 'w t -> string
+  val of_string : string -> 'w t
+  val parse_string_exn : loc:Loc0.t -> string -> 'w t
+
+  val pp : Format.formatter -> 'w t -> unit
+
+  (** a directory is smaller than its descendants *)
+  val compare : 'w t -> 'w t -> Ordering.t
+
+  val to_dyn : 'w t -> Dyn.t
+  val to_sexp : 'w t -> Sexp.t
+
+  val extension : 'w t -> string
+
+  (** [set_extension path ~ext] replaces extension of [path] by [ext] *)
+  val set_extension : 'w t -> ext:string -> 'w t
+
+  val split_extension : 'w t -> 'w t * string
+
+  val basename : 'w t -> string
+  val extend_basename : 'w t -> suffix:string -> 'w t
+  val is_suffix : 'w t -> suffix:string -> bool
+
+  module Fix_root (Root : sig type w end) : sig
+    module Set : sig
+      include Set.S with type elt = Root.w t
+      val to_sexp : t Sexp.Encoder.t
+      val of_listing : dir:elt -> filenames:string list -> t
+    end
+
+    module Map :  Map.S with type key = Root.w t
+
+    module Table : Hashtbl.S with type key = Root.w t
+  end
+
+  val relative : ?error_loc:Loc0.t -> 'w t -> string -> 'w t
+
+  val to_string_maybe_quoted : 'w t -> string
+
+  val is_descendant : 'w t -> of_:'w t -> bool
+
+  val is_root : 'w t -> bool
+  val parent_exn : 'w t -> 'w t
+  val parent : 'w t -> 'w t option
+
+  val explode : 'w t -> string list
+
+end
+
+module Unspecified : sig
+  type w
+end
+
 (** Relative path with unspecified root.
 
     Either root, or a '/' separated list of components
     other that ".", ".."  and not containing a '/'. *)
 module Local : sig
-  include Path_intf.S
+  type w = Unspecified.w
+  type t = w Local_gen.t
+  include Path_intf.S with type t := t
   val root : t
 
   module L : sig
@@ -17,7 +84,11 @@ end
 
 (** In the source section of the current workspace. *)
 module Source : sig
-  include Path_intf.S
+  type w
+
+  type t = w Local_gen.t
+
+  include Path_intf.S with type t := t
   val root : t
 
   module L : sig
@@ -57,7 +128,11 @@ module Kind : sig
 end
 
 module Build : sig
-  include Path_intf.S
+  type w
+
+  type t = w Local_gen.t
+
+  include Path_intf.S with type t := t
   val root : t
 
   val append_source : t -> Source.t -> t

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -2,65 +2,10 @@
 
     Represented as: either the root, or a '/' separated list of components
     other that ".", ".."  and not containing a '/'. *)
-module Local_gen : sig
-
-  type 'w t
-
-  val hash : 'w t -> int
-
-  (* it's not clear that these should be polymorphic over 'w, maybe they should
-     additionally ask for an object that fixes 'w *)
-  val to_string : 'w t -> string
-  val of_string : string -> 'w t
-  val parse_string_exn : loc:Loc0.t -> string -> 'w t
-
-  val pp : Format.formatter -> 'w t -> unit
-
-  (** a directory is smaller than its descendants *)
-  val compare : 'w t -> 'w t -> Ordering.t
-
-  val to_dyn : 'w t -> Dyn.t
-  val to_sexp : 'w t -> Sexp.t
-
-  val extension : 'w t -> string
-
-  (** [set_extension path ~ext] replaces extension of [path] by [ext] *)
-  val set_extension : 'w t -> ext:string -> 'w t
-
-  val split_extension : 'w t -> 'w t * string
-
-  val basename : 'w t -> string
-  val extend_basename : 'w t -> suffix:string -> 'w t
-
-  module Fix_root (Root : sig type w end) : sig
-    module Set : sig
-      include Set.S with type elt = Root.w t
-      val to_sexp : t Sexp.Encoder.t
-      val to_dyn : t Dyn.Encoder.t
-      val of_listing : dir:elt -> filenames:string list -> t
-    end
-
-    module Map :  Map.S with type key = Root.w t
-
-    module Table : Hashtbl.S with type key = Root.w t
-  end
-
-  val relative : ?error_loc:Loc0.t -> 'w t -> string -> 'w t
-
-  val to_string_maybe_quoted : 'w t -> string
-
-  val is_descendant : 'w t -> of_:'w t -> bool
-
-  val is_root : 'w t -> bool
-  val parent_exn : 'w t -> 'w t
-  val parent : 'w t -> 'w t option
-
-  val explode : 'w t -> string list
-
-end
+module Local_gen : Path_intf.Local_gen
 
 module Unspecified : sig
-  type w
+  type w = Path_intf.Unspecified.w
 end
 
 (** Relative path with unspecified root.

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -31,12 +31,12 @@ module Local_gen : sig
 
   val basename : 'w t -> string
   val extend_basename : 'w t -> suffix:string -> 'w t
-  val is_suffix : 'w t -> suffix:string -> bool
 
   module Fix_root (Root : sig type w end) : sig
     module Set : sig
       include Set.S with type elt = Root.w t
       val to_sexp : t Sexp.Encoder.t
+      val to_dyn : t Dyn.Encoder.t
       val of_listing : dir:elt -> filenames:string list -> t
     end
 

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -48,3 +48,83 @@ module type S = sig
   val parent_exn : t -> t
   val parent : t -> t option
 end
+
+(** [Unspecified.w] is a type-level placeholder of an unspecified path.
+    (see [Local_gen] for how it's used) *)
+module Unspecified = struct
+  type w
+end
+
+(** ['w Local_gen.t] is the type of local paths that live under ['w].
+    If [x : w Local_gen.t] and [w] is a type-level witness corresponding to a
+    (real or hypothetical) filesystem location [base], then we think of [x] as
+    referring to the location [to_string base ^/ to_string x].
+*)
+module type Local_gen = sig
+
+  type 'w t
+
+  val hash : 'w t -> int
+
+  (* it's not clear that these should be polymorphic over 'w, maybe they should
+     additionally ask for an object that fixes 'w *)
+  val to_string : 'w t -> string
+  val of_string : string -> 'w t
+  val parse_string_exn : loc:Loc0.t -> string -> 'w t
+
+  val pp : Format.formatter -> 'w t -> unit
+
+  (** a directory is smaller than its descendants *)
+  val compare : 'w t -> 'w t -> Ordering.t
+
+  val to_dyn : 'w t -> Dyn.t
+  val to_sexp : 'w t -> Sexp.t
+
+  val extension : 'w t -> string
+
+  (** [set_extension path ~ext] replaces extension of [path] by [ext] *)
+  val set_extension : 'w t -> ext:string -> 'w t
+
+  val split_extension : 'w t -> 'w t * string
+
+  val basename : 'w t -> string
+  val extend_basename : 'w t -> suffix:string -> 'w t
+
+  module Fix_root (Root : sig type w end) : sig
+    module Set : sig
+      include Set.S with type elt = Root.w t
+      val to_sexp : t Sexp.Encoder.t
+      val to_dyn : t Dyn.Encoder.t
+      val of_listing : dir:elt -> filenames:string list -> t
+    end
+
+    module Map :  Map.S with type key = Root.w t
+
+    module Table : Hashtbl.S with type key = Root.w t
+  end
+
+  val relative : ?error_loc:Loc0.t -> 'w t -> string -> 'w t
+
+  val to_string_maybe_quoted : 'w t -> string
+
+  val is_descendant : 'w t -> of_:'w t -> bool
+
+  val is_root : 'w t -> bool
+
+  val parent_exn : 'w t -> 'w t
+  val parent : 'w t -> 'w t option
+
+  val explode : 'w t -> string list
+
+  val root : 'w t
+  
+  val append : 'w t -> Unspecified.w t -> 'w t
+  val descendant : 'w t -> of_:'w t -> Unspecified.w t option
+  val reach : 'w t -> from:'w t -> string
+
+  val split_first_component : 'w t -> (string * Unspecified.w t) option
+
+  module L : sig
+    val relative : ?error_loc:Loc0.t -> 'w t -> string list -> 'w t
+  end
+end


### PR DESCRIPTION
We've previously thrown around an idea of making the type of paths polymorphic over a type variable that represents the root, so that the three types of paths (Local, Build, Source) are the same type and you can write code polymorphic over them.

This PR implements this idea and makes use of that to make the type of Dir_set more precise: the thing about Dir_set is that `descend` function returns a Dir_set that's no longer rooted where the original Dir_set was rooted, so it also benefits from the same type variable.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>