### PR TITLE
Add polymorphic Obj_dir.t operations

### DIFF
--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -16,10 +16,10 @@ let dev_files =
 let add_obj_dir sctx ~obj_dir =
   if (Super_context.context sctx).merlin then
     let dir_glob =
-      let dir = Path.build (Obj_dir.Local.byte_dir obj_dir) in
+      let dir = Path.build (Obj_dir.byte_dir obj_dir) in
       File_selector.create ~dir dev_files in
     let dyn_deps = Build.paths_matching ~loc:(Loc.of_pos __POS__) dir_glob in
     Rules.Produce.Alias.add_deps
-      (Alias.check ~dir:(Obj_dir.Local.dir obj_dir))
+      (Alias.check ~dir:(Obj_dir.dir obj_dir))
       ~dyn_deps
       Path.Set.empty

--- a/src/check_rules.mli
+++ b/src/check_rules.mli
@@ -1,1 +1,3 @@
-val add_obj_dir : Super_context.t -> obj_dir:Obj_dir.Local.t -> unit
+open Stdune
+
+val add_obj_dir : Super_context.t -> obj_dir:Path.Build.t Obj_dir.t -> unit

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -48,7 +48,7 @@ type t =
   { super_context        : Super_context.t
   ; scope                : Scope.t
   ; expander             : Expander.t
-  ; obj_dir              : Obj_dir.Local.t
+  ; obj_dir              : Path.Build.t Obj_dir.t
   ; dir_kind             : Dune_lang.File_syntax.t
   ; modules              : Module.t Module.Name.Map.t
   ; alias_module         : Module.t option
@@ -67,7 +67,7 @@ type t =
 let super_context        t = t.super_context
 let scope                t = t.scope
 let expander             t = t.expander
-let dir                  t = Obj_dir.Local.dir t.obj_dir
+let dir                  t = Obj_dir.dir t.obj_dir
 let dir_kind             t = t.dir_kind
 let obj_dir              t = t.obj_dir
 let modules              t = t.modules

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -17,7 +17,7 @@ val create
   :  super_context         : Super_context.t
   -> scope                 : Scope.t
   -> expander              : Expander.t
-  -> obj_dir               : Obj_dir.Local.t
+  -> obj_dir               : Path.Build.t Obj_dir.t
   -> ?vimpl                : Vimpl.t
   -> ?dir_kind             : Dune_lang.File_syntax.t
   -> modules               : Module.t Module.Name.Map.t
@@ -42,7 +42,7 @@ val context              : t -> Context.t
 val scope                : t -> Scope.t
 val dir                  : t -> Path.Build.t
 val dir_kind             : t -> Dune_lang.File_syntax.t
-val obj_dir              : t -> Obj_dir.Local.t
+val obj_dir              : t -> Path.Build.t Obj_dir.t
 val modules              : t -> Module.t Module.Name.Map.t
 val alias_module         : t -> Module.t option
 val lib_interface_module : t -> Module.t option

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -29,7 +29,7 @@ module Modules = struct
         match (stanza : Stanza.t) with
         | Library lib ->
           let obj_dir =
-            Obj_dir.Local.make_lib ~dir:d.ctx_dir
+            Obj_dir.make_lib ~dir:d.ctx_dir
               (snd lib.name)
               ~has_private_modules:(Option.is_some lib.private_modules)
           in
@@ -76,7 +76,7 @@ module Modules = struct
         | Tests { exes; _} ->
           let obj_dir =
             let name = snd (List.hd exes.names) in
-            Obj_dir.Local.make_exe ~dir:d.ctx_dir ~name
+            Obj_dir.make_exe ~dir:d.ctx_dir ~name
           in
           let modules =
             Modules_field_evaluator.eval ~modules

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1172,7 +1172,7 @@ module Library = struct
   let is_impl t = Option.is_some t.implements
 
   let obj_dir ~dir t =
-    Obj_dir.Local.make_lib ~dir
+    Obj_dir.make_lib ~dir
       ~has_private_modules:(t.private_modules <> None)
       (snd t.name)
 

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -268,7 +268,7 @@ module Library : sig
   val best_name : t -> Lib_name.t
   val is_virtual : t -> bool
   val is_impl : t -> bool
-  val obj_dir : dir:Path.Build.t -> t -> Obj_dir.Local.t
+  val obj_dir : dir:Path.Build.t -> t -> Path.Build.t Obj_dir.t
 
   module Main_module_name : sig
     type t = Module.Name.t option Inherited.t

--- a/src/dune_package.ml
+++ b/src/dune_package.ml
@@ -7,7 +7,7 @@ module Lib = struct
   type 'sub_system t =
     { loc              : Loc.t
     ; name             : Lib_name.t
-    ; obj_dir          : Obj_dir.t
+    ; obj_dir          : Path.t Obj_dir.t
     ; orig_src_dir     : Path.t option
     ; kind             : Lib_kind.t
     ; synopsis         : string option

--- a/src/dune_package.mli
+++ b/src/dune_package.mli
@@ -5,7 +5,7 @@ module Lib : sig
 
   val dir : _ t -> Path.t
   val orig_src_dir : _ t -> Path.t option
-  val obj_dir : _ t -> Obj_dir.t
+  val obj_dir : _ t -> Path.t Obj_dir.t
   val requires : _ t -> (Loc.t * Lib_name.t) list
   val name : _ t -> Lib_name.t
   val version : _ t -> string option
@@ -58,7 +58,7 @@ module Lib : sig
     -> modes:Mode.Dict.Set.t
     -> version:string option
     -> orig_src_dir:Path.t option
-    -> obj_dir:Obj_dir.t
+    -> obj_dir:Path.t Obj_dir.t
     -> special_builtin_support:
          Dune_file.Library.Special_builtin_support.t option
     -> 'a t

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -8,7 +8,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       (exes : Dune_file.Executables.t) =
   (* Use "eobjs" rather than "objs" to avoid a potential conflict
      with a library of the same name *)
-  let obj_dir = Obj_dir.Local.make_exe ~dir ~name:(snd (List.hd exes.names)) in
+  let obj_dir = Obj_dir.make_exe ~dir ~name:(snd (List.hd exes.names)) in
   Check_rules.add_obj_dir sctx ~obj_dir;
   let modules =
     Dir_contents.modules_of_executables dir_contents
@@ -104,7 +104,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
 
   (cctx,
    let objs_dirs =
-     Obj_dir.Local.public_cmi_dir obj_dir
+     Obj_dir.public_cmi_dir obj_dir
      |> Path.build
      |> Path.Set.singleton
    in

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -171,7 +171,7 @@ include Sub_system.Register_end_point(
       let inline_test_dir = Path.Build.relative dir ("." ^ inline_test_name) in
 
       let obj_dir =
-        Obj_dir.Local.make_exe ~dir:inline_test_dir
+        Obj_dir.make_exe ~dir:inline_test_dir
           ~name:inline_test_name in
 
       let name = "run" in

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -35,7 +35,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
               let lib = Lib.Local.to_lib lib in
               let name = Lib.name lib in
               let foreign_objects =
-                let dir = Obj_dir.Local.obj_dir obj_dir in
+                let dir = Obj_dir.obj_dir obj_dir in
                 Dir_contents.c_sources_of_library dir_contents ~name
                 |> C.Sources.objects ~dir ~ext_obj:ctx.ext_obj
                 |> List.map ~f:Path.build

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1724,7 +1724,11 @@ let to_dune_lib ({ name ; info ; _ } as lib) ~lib_modules ~foreign_objects
       ~dir =
   let add_loc = List.map ~f:(fun x -> (info.loc, x.name)) in
   let virtual_ = Option.is_some info.virtual_ in
-  let obj_dir = Obj_dir.convert_to_external ~dir (obj_dir lib) in
+  let obj_dir =
+    match Obj_dir.to_local (obj_dir lib) with
+    | None -> assert false
+    | Some obj_dir -> Obj_dir.convert_to_external ~dir obj_dir
+  in
   let lib_modules =
     Lib_modules.version_installed ~install_dir:obj_dir lib_modules in
   let orig_src_dir =

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1775,7 +1775,7 @@ module Local : sig
   val of_lib : lib -> t option
   val of_lib_exn : lib -> t
   val to_lib : t -> lib
-  val obj_dir : t -> Obj_dir.Local.t
+  val obj_dir : t -> Path.Build.t Obj_dir.t
   val src_dir : t -> Path.Build.t
   val to_dyn : t -> Dyn.t
   val equal : t -> t -> bool

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -19,7 +19,7 @@ val src_dir : t -> Path.t
 val orig_src_dir : t -> Path.t
 
 (** Directory where the object files for the library are located. *)
-val obj_dir : t -> Obj_dir.t
+val obj_dir : t -> Path.t Obj_dir.t
 val public_cmi_dir : t -> Path.t
 
 (** Same as [Path.is_managed (obj_dir t)] *)
@@ -379,7 +379,7 @@ module Local : sig
   val of_lib_exn : lib -> t
   val to_lib : t -> lib
 
-  val obj_dir : t -> Obj_dir.Local.t
+  val obj_dir : t -> Path.Build.t Obj_dir.t
   val src_dir : t -> Path.Build.t
 
   module Set : Stdune.Set.S with type elt = t

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -65,7 +65,7 @@ type t =
   ; status           : Status.t
   ; src_dir          : Path.t
   ; orig_src_dir     : Path.t option
-  ; obj_dir          : Obj_dir.t
+  ; obj_dir          : Path.t Obj_dir.t
   ; version          : string option
   ; synopsis         : string option
   ; archives         : Path.t list Mode.Dict.t

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -45,7 +45,7 @@ type t = private
   ; status           : Status.t
   ; src_dir          : Path.t
   ; orig_src_dir     : Path.t option
-  ; obj_dir          : Obj_dir.t
+  ; obj_dir          : Path.t Obj_dir.t
   ; version          : string option
   ; synopsis         : string option
   ; archives         : Path.t list Mode.Dict.t

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -40,7 +40,7 @@ val public_modules : t -> Module.Name_map.t
 
 val make
   :  Dune_file.Library.t
-  -> obj_dir:Obj_dir.t
+  -> obj_dir:Path.t Obj_dir.t
   -> Module.Name_map.t
   -> main_module_name:Module.Name.t option
   -> wrapped:Wrapped.t
@@ -50,7 +50,7 @@ val set_modules : t -> Module.Name_map.t -> t
 
 (** [version_installed t ~install_dir] converts [t] to a version that represents
     a library installed [install_dir]*)
-val version_installed : t -> install_dir:Obj_dir.t -> t
+val version_installed : t -> install_dir:Path.t Obj_dir.t -> t
 
 (** Return all modules that need to be compiled. Includes the alias module if it
     exists. This does not include the compatibility modules which are compiled
@@ -62,7 +62,8 @@ val for_alias : t -> Module.Name_map.t
 
 val encode : t -> Dune_lang.t list
 
-val decode : implements:bool -> obj_dir:Obj_dir.t -> t Dune_lang.Decoder.t
+val decode
+  : implements:bool -> obj_dir:Path.t Obj_dir.t -> t Dune_lang.Decoder.t
 
 val is_wrapped : t -> bool
 

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -398,7 +398,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
           Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext Mode.Byte) in
         let target =
           Path.Build.relative
-            (Obj_dir.Local.obj_dir obj_dir)
+            (Obj_dir.obj_dir obj_dir)
             (Path.Build.basename src)
           |> Path.Build.extend_basename ~suffix:".js" in
         Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target);

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -13,7 +13,7 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
   let obj_dir    = CC.obj_dir       cctx in
   let dir        = CC.dir           cctx in
   let ml = Path.Build.relative
-             (Obj_dir.Local.obj_dir obj_dir) (basename ^ ".ml") in
+             (Obj_dir.obj_dir obj_dir) (basename ^ ".ml") in
   SC.add_rule ~dir sctx (Build.write_file ml code);
   let impl = Module.File.make OCaml (Path.build ml) in
   let name = Module.Name.of_string basename in

--- a/src/module.ml
+++ b/src/module.ml
@@ -194,7 +194,7 @@ type t =
   ; obj_name   : string
   ; pp         : (unit, string list) Build.t option
   ; visibility : Visibility.t
-  ; obj_dir    : Obj_dir.t
+  ; obj_dir    : Path.t Obj_dir.t
   ; kind       : Kind.t
   }
 
@@ -337,7 +337,7 @@ let to_sexp { source = { name; impl; intf }
     ; "intf", (option File.to_sexp) intf
     ; "pp", (option string) (Option.map ~f:(fun _ -> "has pp") pp)
     ; "visibility", Visibility.to_sexp visibility
-    ; "obj_dir", Obj_dir.to_sexp obj_dir
+    ; "obj_dir", Dyn.to_sexp (Obj_dir.to_dyn obj_dir)
     ; "kind", Kind.to_sexp kind
     ]
 
@@ -349,7 +349,7 @@ let pp fmt { source = { name; impl; intf }
     ; "intf", Fmt.const (Fmt.optional File.pp) intf
     ; "obj_name", Fmt.const Format.pp_print_string obj_name
     ; "visibility", Fmt.const Visibility.pp visibility
-    ; "obj_dir", Fmt.const Obj_dir.pp obj_dir
+    ; "obj_dir", Fmt.const Dyn.pp (Obj_dir.to_dyn obj_dir)
     ; "kind", Fmt.const Kind.pp kind
     ]
 

--- a/src/module.mli
+++ b/src/module.mli
@@ -86,7 +86,7 @@ val make
   -> ?intf:File.t
   -> ?obj_name:string
   -> visibility:Visibility.t
-  -> obj_dir:Obj_dir.t
+  -> obj_dir:Path.t Obj_dir.t
   -> kind:Kind.t
   -> Name.t
   -> t
@@ -95,7 +95,7 @@ val make
 val of_source
   :  ?obj_name:string
   -> visibility:Visibility.t
-  -> obj_dir:Obj_dir.t
+  -> obj_dir:Path.t Obj_dir.t
   -> kind:Kind.t
   -> Source.t
   -> t
@@ -107,7 +107,7 @@ val real_unit_name : t -> Name.t
 
 val intf : t -> File.t option
 val impl : t -> File.t option
-val obj_dir : t -> Obj_dir.t
+val obj_dir : t -> Path.t Obj_dir.t
 
 val pp_flags : t -> (unit, string list) Build.t option
 
@@ -181,7 +181,7 @@ val is_private : t -> bool
 val is_virtual : t -> bool
 
 val set_private : t -> t
-val set_obj_dir : t -> obj_dir:Obj_dir.t -> t
+val set_obj_dir : t -> obj_dir:Path.t Obj_dir.t -> t
 val set_virtual : t -> t
 
 val sources : t -> Path.t list
@@ -190,7 +190,7 @@ val visibility : t -> Visibility.t
 
 val encode : t -> Dune_lang.t list
 
-val decode : obj_dir:Obj_dir.t -> t Dune_lang.Decoder.t
+val decode : obj_dir:Path.t Obj_dir.t -> t Dune_lang.Decoder.t
 
 (** [pped m] return [m] but with the preprocessed source paths paths *)
 val pped : t -> t

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -37,7 +37,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
       let copy_interface () =
         (* symlink the .cmi into the public interface directory *)
         if not (Module.is_private m)
-        && (Obj_dir.Local.need_dedicated_public_dir obj_dir) then
+        && (Obj_dir.need_dedicated_public_dir obj_dir) then
           SC.add_rule sctx ~sandbox:false ~dir
             (Build.symlink
                ~src:(Module.cm_file_unsafe m Cmi)
@@ -124,7 +124,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
         | true, Cmi, true ->
           (ctx.build_dir, Command.Args.As ["-no-keep-locs"])
         | true, Cmi, false ->
-          (Obj_dir.Local.byte_dir obj_dir, As [])
+          (Obj_dir.byte_dir obj_dir, As [])
         (* emulated -no-keep-locs *)
         | true, (Cmo | Cmx), _
         | false, _, _ ->
@@ -145,7 +145,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
               ; no_keep_locs
               ; cmt_args
               ; Command.Args.S (
-                  Obj_dir.Local.all_obj_dirs obj_dir ~mode
+                  Obj_dir.all_obj_dirs obj_dir ~mode
                   |> List.concat_map ~f:(fun p -> [ Command.Args.A "-I"
                                                   ; Path (Path.build p)])
                 )
@@ -219,7 +219,7 @@ let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
        (Build.S.map ~f:(fun act -> Action.with_stdout_to (Path.build output) act)
           (Command.run (Ok ctx.ocamlc) ~dir:(Path.build ctx.build_dir)
              [ Command.Args.dyn ocaml_flags
-             ; A "-I"; Path (Path.build (Obj_dir.Local.byte_dir obj_dir))
+             ; A "-I"; Path (Path.build (Obj_dir.byte_dir obj_dir))
              ; Cm_kind.Dict.get (CC.includes cctx) Cmo
              ; (match CC.alias_module cctx with
                 | None -> S []

--- a/src/modules_field_evaluator.mli
+++ b/src/modules_field_evaluator.mli
@@ -1,6 +1,8 @@
+open Stdune
+
 val eval
   :  modules:(Module.Source.t Module.Name.Map.t)
-  -> obj_dir:Obj_dir.Local.t
+  -> obj_dir:Path.Build.t Obj_dir.t
   -> buildable:Dune_file.Buildable.t
   -> virtual_modules:Ordered_set_lang.t option
   -> private_modules:Ordered_set_lang.t

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -239,20 +239,12 @@ let to_dyn (type path) (t : path t) =
   | Local_as_path e -> constr "Local_as_path" [Local.to_dyn e]
   | External e -> constr "External" [External.to_dyn e]
 
-let convert_to_external t ~dir =
+let convert_to_external (t : Path.Build.t t) ~dir =
   match t with
-  | Local_as_path e ->
-    let has_private_modules = Local.need_dedicated_public_dir e in
-    External (External.make ~dir ~has_private_modules)
   | Local e ->
     let has_private_modules = Local.need_dedicated_public_dir e in
     External (External.make ~dir ~has_private_modules)
-  | External obj_dir ->
-    Exn.code_error
-      "Obj_dir.convert_to_external: converting already external dir"
-      [ "dir", Path.to_sexp dir
-      ; "obj_dir", Dyn.to_sexp (External.to_dyn obj_dir)
-      ]
+  | _ -> assert false
 
 let all_cmis (type path) (t : path t) : path list =
   match t with
@@ -284,3 +276,9 @@ let as_local_exn (t : Path.t t) =
   | External _ -> Exn.code_error "Obj_dir.as_local_exn: external dir" []
 
 let make_exe ~dir ~name = Local (Local.make_exe ~dir ~name)
+
+let to_local (t : Path.t t) =
+  match t with
+  | Local _ -> assert false
+  | Local_as_path t -> Some (Local t)
+  | External _ -> None

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -74,6 +74,12 @@ module External = struct
 
   let all_cmis {public_dir; private_dir} =
     List.filter_opt [Some public_dir; private_dir]
+
+  let cm_public_dir t (cm_kind : Cm_kind.t) =
+    match cm_kind with
+    | Cmx -> native_dir t
+    | Cmo -> byte_dir t
+    | Cmi -> public_cmi_dir t
 end
 
 module Local = struct
@@ -148,15 +154,31 @@ module Local = struct
     match cm_kind with
     | Cm_kind.Cmx -> native_dir t
     | Cmo | Cmi -> byte_dir t
+
+  let cm_public_dir t (cm_kind : Cm_kind.t) =
+    match cm_kind with
+    | Cmx -> native_dir t
+    | Cmo -> byte_dir t
+    | Cmi -> public_cmi_dir t
 end
 
-type t =
-  | External of External.t
-  | Local of Local.t
+type _ t =
+  | External      : External.t -> Path.t t
+  | Local         : Local.t    -> Path.Build.t t
+  | Local_as_path : Local.t    -> Path.t t
 
-let of_local t = Local t
+let of_local
+  : Path.Build.t t -> Path.t t
+  = fun t ->
+    match t with
+    | Local t -> Local_as_path t
+    | _ -> assert false
 
 let encode = function
+  | Local_as_path obj_dir ->
+    Exn.code_error "Obj_dir.encode: local obj_dir cannot be encoded"
+      [ "obj_dir", Dyn.to_sexp (Local.to_dyn obj_dir)
+      ]
   | Local obj_dir ->
     Exn.code_error "Obj_dir.encode: local obj_dir cannot be encoded"
       [ "obj_dir", Dyn.to_sexp (Local.to_dyn obj_dir)
@@ -174,42 +196,54 @@ let make_lib ~dir ~has_private_modules lib_name =
 let make_external_no_private ~dir =
   External (External.make ~dir ~has_private_modules:false)
 
-let all_obj_dirs t ~mode =
+let all_obj_dirs (type path) (t : path t) ~mode : path list =
   match t with
   | External e -> External.all_obj_dirs e ~mode
-  | Local e -> Local.all_obj_dirs e ~mode |> List.map ~f:Path.build
+  | Local e -> Local.all_obj_dirs e ~mode
+  | Local_as_path e -> Local.all_obj_dirs e ~mode |> List.map ~f:Path.build
 
-let public_cmi_dir = function
+let public_cmi_dir (type path) (t : path t) : path =
+  match t with
   | External e -> External.public_cmi_dir e
-  | Local e -> Path.build (Local.public_cmi_dir e)
+  | Local e -> Local.public_cmi_dir e
+  | Local_as_path e -> Path.build (Local.public_cmi_dir e)
 
-let byte_dir = function
+let byte_dir (type path) (t : path t) : path =
+  match t with
   | External e -> External.byte_dir e
-  | Local e -> Path.build (Local.byte_dir e)
+  | Local e -> Local.byte_dir e
+  | Local_as_path e -> Path.build (Local.byte_dir e)
 
-let native_dir = function
+let native_dir (type path) (t : path t) : path =
+  match t with
   | External e -> External.native_dir e
-  | Local e -> Path.build (Local.native_dir e)
+  | Local e -> Local.native_dir e
+  | Local_as_path e -> Path.build (Local.native_dir e)
 
-let dir = function
+let dir (type path) (t : path t) : path =
+  match t with
   | External e -> External.dir e
-  | Local e -> Path.build (Local.dir e)
+  | Local e -> Local.dir e
+  | Local_as_path e -> Path.build (Local.dir e)
 
-let obj_dir = function
+let obj_dir (type path) (t : path t) : path =
+  match t with
   | External e -> External.obj_dir e
-  | Local e -> Path.build (Local.obj_dir e)
+  | Local e -> Local.obj_dir e
+  | Local_as_path e -> Path.build (Local.obj_dir e)
 
-let to_dyn =
+let to_dyn (type path) (t : path t) =
   let open Dyn.Encoder in
-  function
+  match t with
   | Local e -> constr "Local" [Local.to_dyn e]
+  | Local_as_path e -> constr "Local_as_path" [Local.to_dyn e]
   | External e -> constr "External" [External.to_dyn e]
-
-let to_sexp t = Dyn.to_sexp (to_dyn t)
-let pp fmt t = Dyn.pp fmt (to_dyn t)
 
 let convert_to_external t ~dir =
   match t with
+  | Local_as_path e ->
+    let has_private_modules = Local.need_dedicated_public_dir e in
+    External (External.make ~dir ~has_private_modules)
   | Local e ->
     let has_private_modules = Local.need_dedicated_public_dir e in
     External (External.make ~dir ~has_private_modules)
@@ -220,21 +254,33 @@ let convert_to_external t ~dir =
       ; "obj_dir", Dyn.to_sexp (External.to_dyn obj_dir)
       ]
 
-let all_cmis = function
-  | Local e -> [Path.build (Local.byte_dir e)]
+let all_cmis (type path) (t : path t) : path list =
+  match t with
+  | Local e -> [Local.byte_dir e]
+  | Local_as_path e -> [Path.build (Local.byte_dir e)]
   | External e -> External.all_cmis e
 
-let cm_dir t cm_kind visibility =
+let cm_dir (type path) (t : path t) cm_kind visibility : path =
   match t with
   | External e -> External.cm_dir e cm_kind visibility
-  | Local e -> Path.build (Local.cm_dir e cm_kind visibility)
+  | Local e -> Local.cm_dir e cm_kind visibility
+  | Local_as_path e -> Path.build (Local.cm_dir e cm_kind visibility)
 
-let cm_public_dir t (cm_kind : Cm_kind.t) =
-  match cm_kind with
-  | Cmx -> native_dir t
-  | Cmo -> byte_dir t
-  | Cmi -> public_cmi_dir t
+let cm_public_dir (type path) (t : path t) (cm_kind : Cm_kind.t) : path =
+  match t with
+  | External e -> External.cm_public_dir e cm_kind
+  | Local e -> Local.cm_public_dir e cm_kind
+  | Local_as_path e -> Path.build (Local.cm_public_dir e cm_kind)
 
-let as_local_exn = function
-  | Local e -> e
+let need_dedicated_public_dir (t : Path.Build.t t) =
+  match t with
+  | Local t -> Local.need_dedicated_public_dir t
+  | _ -> assert false
+
+let as_local_exn (t : Path.t t) =
+  match t with
+  | Local _ -> assert false
+  | Local_as_path e -> Local e
   | External _ -> Exn.code_error "Obj_dir.as_local_exn: external dir" []
+
+let make_exe ~dir ~name = Local (Local.make_exe ~dir ~name)

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -1,75 +1,49 @@
 open! Stdune
 
-(** Representation of the object directory for libraries that are local to the workspace *)
-module Local : sig
-  type t
+type 'path t
 
-  (** The source_root directory *)
-  val dir : t -> Path.Build.t
-
-  val make_exe: dir:Path.Build.t -> name:string -> t
-
-  val need_dedicated_public_dir : t -> bool
-
-  (** The directory for ocamldep files *)
-  val obj_dir : t -> Path.Build.t
-
-  (** The private compiled byte file directories, and all cmi *)
-  val byte_dir : t -> Path.Build.t
-
-  val all_obj_dirs : t -> mode:Mode.t -> Path.Build.t list
-
-  (** The public compiled cmi file directory *)
-  val public_cmi_dir: t -> Path.Build.t
-
-  val make_lib
-    :  dir:Path.Build.t
-    -> has_private_modules:bool
-    -> Lib_name.Local.t
-    -> t
-end
-
-type t
-
-val of_local : Local.t -> t
+val of_local : Path.Build.t t -> Path.t t
 
 (** The source_root directory *)
-val dir : t -> Path.t
+val dir : 'path t -> 'path
 
 (** The directory for ocamldep files *)
-val obj_dir : t -> Path.t
+val obj_dir : 'path t -> 'path
 
 (** The private compiled native file directory *)
-val native_dir : t -> Path.t
+val native_dir : 'path t -> 'path
 
 (** The private compiled byte file directories, and all cmi *)
-val byte_dir : t -> Path.t
+val byte_dir : 'path t -> 'path
 
-val all_cmis: t -> Path.t list
+val all_cmis: 'path t -> 'path list
 
 (** The public compiled cmi file directory *)
-val public_cmi_dir: t -> Path.t
+val public_cmi_dir: 'path t -> 'path
 
-val pp: t Fmt.t
-val to_sexp: t -> Sexp.t
-
-val all_obj_dirs : t -> mode:Mode.t -> Path.t list
+val all_obj_dirs : 'path t -> mode:Mode.t -> 'path list
 
 val make_lib
   :  dir:Path.Build.t
   -> has_private_modules:bool
   -> Lib_name.Local.t
-  -> t
+  -> Path.Build.t t
 
-val make_external_no_private : dir:Path.t -> t
+val make_external_no_private : dir:Path.t -> Path.t t
 
-val encode : t -> Dune_lang.t list
-val decode : dir:Path.t -> t Dune_lang.Decoder.t
+val encode : Path.t t -> Dune_lang.t list
+val decode : dir:Path.t -> Path.t t Dune_lang.Decoder.t
 
-val convert_to_external : t -> dir:Path.t -> t
+val convert_to_external : Path.t t -> dir:Path.t -> Path.t t
 
-val cm_dir : t -> Cm_kind.t -> Visibility.t -> Path.t
+val cm_dir : 'path t -> Cm_kind.t -> Visibility.t -> 'path
 
-val cm_public_dir : t -> Cm_kind.t -> Path.t
+val cm_public_dir : 'path t -> Cm_kind.t -> 'path
 
-val as_local_exn : t -> Local.t
+val to_dyn : _ t -> Dyn.t
+
+val make_exe: dir:Path.Build.t -> name:string -> Path.Build.t t
+
+val as_local_exn : Path.t t -> Path.Build.t t
+
+val need_dedicated_public_dir : Path.Build.t t -> bool

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -1,3 +1,32 @@
+(** Representation of the object directory for libraries *)
+
+(** Dune store the artifacts of a library or a set of executables in a
+    dedicated dot directory (name starting with a '.').
+
+    This is mainly for hygiene reasons. Since the compiler might look
+    at any artifact in an include directory, it is important that we
+    control precisely what it can see. This is important when a
+    directory contains several libraries and/or executables.
+
+    This also allows us to provide a different API for a given
+    library.  In particular, depending on the context we might choose
+    to expose or not the private modules.
+
+    In the rest of this API, "local" and "external" have their usual
+    Dune meaning: "local" is for libraries or executables that are
+    local to the current worksapce and "extenal" for libraries that are
+    part of the installed world.
+
+    For local libraries, the path are reported as [Path.Build.t]
+    values given that they are all inside the build directory.  For
+    external libraries the path are reported as [Path.t]
+    values. However, it is possible to get a view of the object
+    directory for a local library where the path are reported as
+    [Path.t] values with [of_local].  This is convenient in places
+    where we need to treat object directories of both local and
+    external library in the same way.
+*)
+
 open! Stdune
 
 type 'path t
@@ -23,12 +52,18 @@ val public_cmi_dir: 'path t -> 'path
 
 val all_obj_dirs : 'path t -> mode:Mode.t -> 'path list
 
+(** Create the object directory for a library *)
 val make_lib
   :  dir:Path.Build.t
   -> has_private_modules:bool
   -> Lib_name.Local.t
   -> Path.Build.t t
 
+(** Create the object directory for a set of executables. [name] is
+    name of one of the executable in set. It is included in the dot
+    subdirectory name. *)
+(** Create the object directory for an external library that has no
+   private directory for private modules *)
 val make_external_no_private : dir:Path.t -> Path.t t
 
 val encode : Path.t t -> Dune_lang.t list

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -69,7 +69,7 @@ val make_external_no_private : dir:Path.t -> Path.t t
 val encode : Path.t t -> Dune_lang.t list
 val decode : dir:Path.t -> Path.t t Dune_lang.Decoder.t
 
-val convert_to_external : Path.t t -> dir:Path.t -> Path.t t
+val convert_to_external : Path.Build.t t -> dir:Path.t -> Path.t t
 
 val cm_dir : 'path t -> Cm_kind.t -> Visibility.t -> 'path
 
@@ -85,3 +85,5 @@ val as_local_exn : Path.t t -> Path.Build.t t
     their own directory. Such a public cmi dir is only necessary if a library
     contains private modules *)
 val need_dedicated_public_dir : Path.Build.t t -> bool
+
+val to_local : Path.t t -> Path.Build.t t option

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -46,4 +46,7 @@ val make_exe: dir:Path.Build.t -> name:string -> Path.Build.t t
 
 val as_local_exn : Path.t t -> Path.Build.t t
 
+(** For local libraries with private modules, all public cmi's are symlinked to
+    their own directory. Such a public cmi dir is only necessary if a library
+    contains private modules *)
 val need_dedicated_public_dir : Path.Build.t t -> bool

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -106,7 +106,7 @@ let deps_of cctx ~ml_kind unit =
       let file_in_obj_dir ~suffix file =
         let base = Path.basename file in
         Path.Build.relative
-          (Obj_dir.Local.obj_dir (Compilation_context.obj_dir cctx))
+          (Obj_dir.obj_dir (Compilation_context.obj_dir cctx))
           (base ^ suffix)
       in
       let all_deps_path file = file_in_obj_dir file ~suffix:".all-deps" in

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -15,7 +15,7 @@ module Source = struct
   let source_path t = Path.Build.relative t.dir (main_module_filename t)
 
   let obj_dir { dir; name ; _ } =
-    Obj_dir.Local.make_exe ~dir ~name
+    Obj_dir.make_exe ~dir ~name
 
   let modules t =
     let obj_dir = Obj_dir.of_local (obj_dir t) in

--- a/src/toplevel.mli
+++ b/src/toplevel.mli
@@ -12,7 +12,7 @@ module Source : sig
 
   val loc : t -> Loc.t
   val modules : t -> Module.t Module.Name.Map.t
-  val obj_dir : t -> Obj_dir.Local.t
+  val obj_dir : t -> Path.Build.t Obj_dir.t
 end
 
 type t

--- a/src/vimpl.ml
+++ b/src/vimpl.ml
@@ -3,7 +3,7 @@ open! Stdune
 type t =
   { vlib                 : Lib.t
   ; impl                 : Dune_file.Library.t
-  ; obj_dir              : Obj_dir.Local.t
+  ; obj_dir              : Path.Build.t Obj_dir.t
   ; vlib_modules         : Lib_modules.t
   ; vlib_foreign_objects : Path.t list
   ; vlib_dep_graph       : Dep_graph.Ml_kind.t

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -53,7 +53,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     let dst = Module.set_obj_dir ~obj_dir:(Obj_dir.of_local impl_obj_dir) src in
     copy_obj_file ~src ~dst Cmi;
     if Module.is_public dst
-    && Obj_dir.Local.need_dedicated_public_dir impl_obj_dir
+    && Obj_dir.need_dedicated_public_dir impl_obj_dir
     then begin
       let src = Module.cm_public_file_unsafe src Cmi in
       let dst = Module.cm_public_file_unsafe dst Cmi in
@@ -87,7 +87,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
                            (Path.as_in_build_dir_exn
                               (Obj_dir.obj_dir vlib_obj_dir)) f))
                 ~dst:(all_deps
-                        ~obj_dir:(Obj_dir.Local.obj_dir impl_obj_dir) f))
+                        ~obj_dir:(Obj_dir.obj_dir impl_obj_dir) f))
           );
     else
       (* we only need to copy the .all-deps files for local libraries. for
@@ -105,7 +105,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
               |> String.concat ~sep:"\n")
             >>>
             Build.write_file_dyn
-              (all_deps ~obj_dir:(Obj_dir.Local.obj_dir impl_obj_dir) f)
+              (all_deps ~obj_dir:(Obj_dir.obj_dir impl_obj_dir) f)
             |> add_rule sctx))
   in
   Option.iter (Lib_modules.alias_module vlib_modules) ~f:copy_objs;
@@ -277,7 +277,7 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
           in
           let foreign_objects =
             let ext_obj = (Super_context.context sctx).ext_obj in
-            let dir = Obj_dir.Local.obj_dir (Lib.Local.obj_dir vlib) in
+            let dir = Obj_dir.obj_dir (Lib.Local.obj_dir vlib) in
             Dir_contents.c_sources_of_library dir_contents ~name
             |> C.Sources.objects ~ext_obj ~dir
             |> List.map ~f:Path.build


### PR DESCRIPTION
This PR parameterizes the `Obj_dir.t` by the type of paths that it returns. This allows us to use a single API for accessing Obj_dir.t values. But more importantly, it allows us to parameterize other code more easily - such as modules.

In particular, currently Module.t's contain two values that should be different between local modules and ones that were created by decoding dune-package files. To accommodate both kinds, we can do:

```
type 'path module =
  { name : Name.t
  ; source : 'path Source.t
  ; obj_dir : 'path Obj_dir.t
  ...
  }
```

So now we'll have a single set of functions for module and they will all return the right paths.

The motivation for this is that I've tried introducing local modules to get rid of the last few _exn's and simplify virtual library copying rules (currently the obj_dir's are being changed and it's not at all clear where this is happening). If there's a better way to do this, that would be great.