### PR TITLE
Change the Pp.*box API to not take lists

### DIFF
--- a/src/action_to_sh.ml
+++ b/src/action_to_sh.ml
@@ -96,15 +96,17 @@ let quote s = Pp.verbatim (quote_for_shell s)
 let rec pp = function
   | Run (prog, args) ->
     Pp.hovbox ~indent:2
-      (quote prog
-       :: List.concat_map args ~f:(fun arg ->
-         [Pp.space; quote arg]))
+      (Pp.concat
+         (quote prog
+          :: List.concat_map args ~f:(fun arg ->
+            [Pp.space; quote arg])))
   | Chdir dir ->
     Pp.hovbox ~indent:2
-      [ Pp.verbatim "cd"
-      ; Pp.space
-      ; quote dir
-      ]
+      (Pp.concat
+         [ Pp.verbatim "cd"
+         ; Pp.space
+         ; quote dir
+         ])
   | Setenv (k, v) ->
     Pp.concat [Pp.verbatim k; Pp.verbatim "="; quote v]
   | Sh s ->
@@ -115,29 +117,32 @@ let rec pp = function
       | [x] -> pp x
       | l ->
         Pp.box
-          [ Pp.hvbox ~indent:2
-              [ Pp.char '{'
-              ; Pp.space
-              ; Pp.hvbox [Pp.concat_map l ~sep:Pp.space
-                            ~f:(fun x -> Pp.seq (pp x) (Pp.char ';'))]
-              ]
-          ; Pp.space
-          ; Pp.char '}'
-          ]
+          (Pp.concat
+             [ Pp.hvbox ~indent:2
+                 (Pp.concat
+                    [ Pp.char '{'
+                    ; Pp.space
+                    ; Pp.hvbox (Pp.concat_map l ~sep:Pp.space
+                                  ~f:(fun x -> Pp.seq (pp x) (Pp.char ';')))
+                    ])
+             ; Pp.space
+             ; Pp.char '}'
+             ])
     in
     Pp.hovbox ~indent:2
-      [ body
-      ; Pp.space
-      ; Pp.verbatim (match outputs with
-          | Stdout -> ">"
-          | Stderr -> "2>"
-          | Outputs -> "&>")
-      ; Pp.space
-      ; quote
-          (match dest with
-           | Dev_null -> "/dev/null"
-           | File fn -> fn)
-      ]
+      (Pp.concat
+         [ body
+         ; Pp.space
+         ; Pp.verbatim (match outputs with
+             | Stdout -> ">"
+             | Stderr -> "2>"
+             | Outputs -> "&>")
+         ; Pp.space
+         ; quote
+             (match dest with
+              | Dev_null -> "/dev/null"
+              | File fn -> fn)
+         ])
 
 let rec pp_seq = function
   | [] -> Pp.verbatim "true"

--- a/src/stdune/dyn0.ml
+++ b/src/stdune/dyn0.ml
@@ -31,73 +31,82 @@ let rec pp = function
   | Option (Some x) -> pp (Variant ("Some", [x]))
   | List x ->
     Pp.box
-      [ Pp.char '['
-      ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) x ~f:pp
-      ; Pp.char ']'
-      ]
+      (Pp.concat
+         [ Pp.char '['
+         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) x ~f:pp
+         ; Pp.char ']'
+         ])
   | Array a ->
     Pp.box
-      [ Pp.verbatim "[|"
-      ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) (Array.to_list a) ~f:pp
-      ; Pp.verbatim "|]"
-      ]
+      (Pp.concat
+         [ Pp.verbatim "[|"
+         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) (Array.to_list a) ~f:pp
+         ; Pp.verbatim "|]"
+         ])
   | Set xs ->
     Pp.box
-      [ Pp.verbatim "set {"
-      ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:pp
-      ; Pp.verbatim "}"
-      ]
+      (Pp.concat
+         [ Pp.verbatim "set {"
+         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:pp
+         ; Pp.verbatim "}"
+         ])
   | Map xs ->
     Pp.box
-      [ Pp.verbatim "map {"
-      ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:(fun (k, v) ->
-          Pp.box
-            [ pp k
-            ; Pp.space
-            ; Pp.verbatim ":"
-            ; Pp.space
-            ; pp v
-            ]
-        )
-      ; Pp.verbatim "}"
-      ]
+      (Pp.concat
+         [ Pp.verbatim "map {"
+         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:(fun (k, v) ->
+             Pp.box
+               (Pp.concat
+                  [ pp k
+                  ; Pp.space
+                  ; Pp.verbatim ":"
+                  ; Pp.space
+                  ; pp v
+                  ])
+           )
+         ; Pp.verbatim "}"
+         ])
   | Tuple x ->
     Pp.box
-      [ Pp.char '('
-      ; Pp.concat_map ~sep:(Pp.seq (Pp.char ',') Pp.space) x ~f:pp
-      ; Pp.char ')'
-      ]
+      (Pp.concat
+         [ Pp.char '('
+         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ',') Pp.space) x ~f:pp
+         ; Pp.char ')'
+         ])
   | Record fields ->
     Pp.vbox ~indent:2
-      [ Pp.char '{'
-      ; Pp.concat_map ~sep:(Pp.char ';') fields ~f:(fun (f, v) ->
-          Pp.concat
-            [ Pp.verbatim f
-            ; Pp.space
-            ; Pp.char '='
-            ; Pp.space
-            ; Pp.box ~indent:2 [pp v]
-            ]
-        )
-      ; Pp.char '}'
-      ]
+      (Pp.concat
+         [ Pp.char '{'
+         ; Pp.concat_map ~sep:(Pp.char ';') fields ~f:(fun (f, v) ->
+             Pp.concat
+               [ Pp.verbatim f
+               ; Pp.space
+               ; Pp.char '='
+               ; Pp.space
+               ; Pp.box ~indent:2 (pp v)
+               ]
+           )
+         ; Pp.char '}'
+         ])
   | Variant (v, []) -> Pp.verbatim v
   | Variant (v, xs) ->
     Pp.hvbox ~indent:2
-      [ Pp.verbatim v
-      ; Pp.space
-      ; Pp.concat_map ~sep:(Pp.char ',') xs ~f:pp
-      ]
+      (Pp.concat
+         [ Pp.verbatim v
+         ; Pp.space
+         ; Pp.concat_map ~sep:(Pp.char ',') xs ~f:pp
+         ])
 
 and pp_sexp = function
   | Sexp0.Atom s -> Pp.verbatim (Escape.quote_if_needed s)
   | List [] -> Pp.verbatim "()"
   | List l ->
     Pp.box ~indent:1
-      [ Pp.char '('
-      ; Pp.hvbox [ Pp.concat_map l ~sep:Pp.space ~f:pp_sexp ]
-      ; Pp.char ')'
-      ]
+      (Pp.concat
+         [ Pp.char '('
+         ; Pp.hvbox (Pp.concat_map l ~sep:Pp.space ~f:pp_sexp)
+         ; Pp.char ')'
+         ])
 
 let pp fmt t = Pp.pp fmt (pp t)
 

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -168,11 +168,11 @@ let concat_map ?(sep=Nop) l ~f =
   | [] -> Nop
   | [x] -> f x
   | l -> Concat (sep, List.map l ~f)
-let box ?(indent=0) l = Box (indent, concat l)
-let vbox ?(indent=0) l = Vbox (indent, concat l)
-let hbox l = Hbox (concat l)
-let hvbox ?(indent=0) l = Hvbox (indent, concat l)
-let hovbox ?(indent=0) l = Hovbox (indent, concat l)
+let box ?(indent=0) t = Box (indent, t)
+let vbox ?(indent=0) t = Vbox (indent, t)
+let hbox t = Hbox t
+let hvbox ?(indent=0) t = Hvbox (indent, t)
+let hovbox ?(indent=0) t = Hovbox (indent, t)
 
 let verbatim x = Verbatim x
 let char x = Char x

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -59,28 +59,25 @@ val newline : _ t
     Break hints such as [space] and [cut] may cause the line to be
     broken, depending on the splitting rules.  Whenever a line is
     split, the rest of the material printed in the box is indented with
-    [indent].
-
-    All functions take a list as argument for convenience.  Elements
-    are printed one by one. *)
+    [indent]. *)
 
 (** Try to put as much as possible on each line.  Additionally, a
     break hint always break the line if the breaking would reduce the
     indentation level ([break] with negative [shift] value). *)
-val box : ?indent:int -> 'a t list -> 'a t
+val box : ?indent:int -> 'a t -> 'a t
 
 (** Always break the line when encountering a break hint. *)
-val vbox : ?indent:int -> 'a t list -> 'a t
+val vbox : ?indent:int -> 'a t -> 'a t
 
 (** Print everything on one line, no matter what *)
-val hbox : 'a t list -> 'a t
+val hbox : 'a t -> 'a t
 
 (** If possible, print everything on one line. Otherwise, behave as a
     [vbox] *)
-val hvbox : ?indent:int -> 'a t list -> 'a t
+val hvbox : ?indent:int -> 'a t -> 'a t
 
 (** Try to put as much as possible on each line. *)
-val hovbox : ?indent:int -> 'a t list -> 'a t
+val hovbox : ?indent:int -> 'a t -> 'a t
 
 (** {1 Rendering} *)
 


### PR DESCRIPTION
I originally thought it was a good idea, but as I'm converting error messages to the new API, I realise that it's not that great and it makes things more confusing than anything else. In particular, one could think that the element of the list are separated by cuts, which is not the case.
