### PR TITLE
Add the new error reporting api

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -400,7 +400,7 @@ let term =
   in
   let config =
     Config.adapt_display config
-      ~output_is_a_tty:(Lazy.force Colors.stderr_supports_colors)
+      ~output_is_a_tty:(Lazy.force Ansi_color.stderr_supports_color)
   in
   { debug_dep_path
   ; debug_findlib

--- a/src/action_exec.ml
+++ b/src/action_exec.ml
@@ -112,7 +112,7 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to =
       if Path.is_in_build_dir path then
         Path.mkdir_p path
       else
-        Exn.code_error "Action_exec.exec: mkdir on non build dir"
+        Errors.code_error "Action_exec.exec: mkdir on non build dir"
           ["path", Path.to_sexp path]
     end;
     Fiber.return ()

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -16,7 +16,7 @@ end = struct
 
   let make name ~dir =
     if String.contains name '/' then
-      Exn.code_error "Alias0.make: Invalid alias"
+      Errors.code_error "Alias0.make: Invalid alias"
         [ "name", Sexp.Encoder.string name
         ; "dir", Path.Build.to_sexp dir
         ];

--- a/src/build.ml
+++ b/src/build.ml
@@ -45,7 +45,7 @@ let get_if_file_exists_exn state =
   match !state with
   | Decided (_, t) -> t
   | Undecided _ ->
-    Exn.code_error "Build.get_if_file_exists_exn: got undecided" []
+    Errors.code_error "Build.get_if_file_exists_exn: got undecided" []
 
 let arr f = Arr f
 let return x = Arr (fun _ -> x)
@@ -227,7 +227,7 @@ let merge_files_dyn ~target =
 (* Analysis *)
 
 let no_targets_allowed () =
-  Exn.code_error "No targets allowed under a [Build.lazy_no_targets] \
+  Errors.code_error "No targets allowed under a [Build.lazy_no_targets] \
                   or [Build.if_file_exists]" []
 [@@inline never]
 
@@ -325,7 +325,7 @@ let targets =
       | If_file_exists (_, state) -> begin
           match !state with
           | Decided (v, _) ->
-            Exn.code_error "Build_interpret.targets got decided if_file_exists"
+            Errors.code_error "Build_interpret.targets got decided if_file_exists"
               ["exists", Sexp.Encoder.bool v]
           | Undecided (a, b) ->
             let a = loop a Path.Build.Set.empty in
@@ -333,7 +333,7 @@ let targets =
             if Path.Build.Set.is_empty a && Path.Build.Set.is_empty b then
               acc
             else begin
-              Exn.code_error "Build_interpret.targets: cannot have targets \
+              Errors.code_error "Build_interpret.targets: cannot have targets \
                               under a [if_file_exists]"
                 [ "targets-a", Path.Build.Set.to_sexp a
                 ; "targets-b", Path.Build.Set.to_sexp b

--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -11,7 +11,7 @@ let for_lib t ~dir ~name =
   match Lib_name.Map.find t.libraries name with
   | Some m -> m
   | None ->
-    Exn.code_error "C_sources.for_lib"
+    Errors.code_error "C_sources.for_lib"
       [ "name", Lib_name.to_sexp name
       ; "dir", Path.to_sexp dir
       ; "available", Sexp.Encoder.(list Lib_name.to_sexp)

--- a/src/colors.mli
+++ b/src/colors.mli
@@ -2,13 +2,11 @@ open! Stdune
 
 val colorize : key:string -> string -> string
 
-val stderr_supports_colors : bool Lazy.t
-
 (** [Env.initial] extended with variables to force a few tools to
     print colors *)
 val setup_env_for_colors : Env.t -> Env.t
 
-(** Strip colors in [not (Lazy.force stderr_supports_colors)] *)
+(** Strip colors in [not (Lazy.force Ansi_color.stderr_supports_colors)] *)
 val strip_colors_for_stderr : string -> string
 
 (** Enable the interpretation of color tags for [Format.err_formatter] *)
@@ -23,19 +21,3 @@ val command_success : styles
 val command_error : styles
 
 val apply_string : styles -> string -> string
-
-module Style : sig
-  type t =
-    | Loc
-    | Error
-    | Warning
-    | Kwd
-    | Id
-    | Prompt
-    | Details
-    | Ok
-    | Debug
-end
-
-module Render : Pp.Renderer.S
-  with type Tag.t = Style.t

--- a/src/context.ml
+++ b/src/context.ml
@@ -358,7 +358,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
          OCAMLPARAM, use the latter.
          If 'color' is not supported, we just don't force colors with 4.02. *)
       if !Clflags.capture_outputs
-      && Lazy.force Colors.stderr_supports_colors
+      && Lazy.force Ansi_color.stderr_supports_color
       && Ocaml_version.supports_color_in_ocamlparam version
       && not (Ocaml_version.supports_ocaml_color version) then
         let value =

--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -14,7 +14,7 @@ let deps_of t (m : Module.t) =
   match Module.Name.Map.find t.per_module name with
   | Some (_, x) -> x
   | None ->
-    Exn.code_error "Ocamldep.Dep_graph.deps_of"
+    Errors.code_error "Ocamldep.Dep_graph.deps_of"
       [ "dir", Path.Build.to_sexp t.dir
       ; "modules", Sexp.Encoder.(list Module.Name.to_sexp)
                      (Module.Name.Map.keys t.per_module)
@@ -88,7 +88,7 @@ let wrapped_compat ~modules ~wrapped_compat =
       match d, m with
       | None, None -> assert false
       | Some wrapped_compat, None ->
-        Exn.code_error "deprecated module needs counterpart"
+        Errors.code_error "deprecated module needs counterpart"
           [ "deprecated", Module.to_sexp wrapped_compat
           ]
       | None, Some _ -> None
@@ -123,7 +123,7 @@ module Ml_kind = struct
         Some (mi, i)
       else
         let open Sexp.Encoder in
-        Exn.code_error "merge_impl: unexpected dep graph"
+        Errors.code_error "merge_impl: unexpected dep graph"
           [ "ml_kind", string (Ml_kind.to_string ml_kind)
           ; "mv", Module.to_sexp mv
           ; "mi", Module.to_sexp mi

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -210,7 +210,7 @@ let modules_of_library t ~name =
   match Lib_name.Map.find map name with
   | Some m -> m
   | None ->
-    Exn.code_error "Dir_contents.modules_of_library"
+    Errors.code_error "Dir_contents.modules_of_library"
       [ "name", Lib_name.to_sexp name
       ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
       ]
@@ -220,7 +220,7 @@ let modules_of_executables t ~first_exe =
   match String.Map.find map first_exe with
   | Some m -> m
   | None ->
-    Exn.code_error "Dir_contents.modules_of_executables"
+    Errors.code_error "Dir_contents.modules_of_executables"
       [ "first_exe", Sexp.Encoder.string first_exe
       ; "available", Sexp.Encoder.(list string) (String.Map.keys map)
       ]
@@ -239,7 +239,7 @@ let mlds t (doc : Documentation.t) =
   with
   | Some x -> x
   | None ->
-    Exn.code_error "Dir_contents.mlds"
+    Errors.code_error "Dir_contents.mlds"
       [ "doc", Loc.to_sexp doc.loc
       ; "available", Sexp.Encoder.(list Loc.to_sexp)
                        (List.map map ~f:(fun (d, _) -> d.Documentation.loc))
@@ -250,7 +250,7 @@ let coq_modules_of_library t ~name =
   match Lib_name.Map.find map name with
   | Some x -> x
   | None ->
-    Exn.code_error "Dir_contents.coq_modules_of_library"
+    Errors.code_error "Dir_contents.coq_modules_of_library"
       [ "name", Lib_name.to_sexp name
       ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
       ]

--- a/src/dune_lang/atom.ml
+++ b/src/dune_lang/atom.ml
@@ -48,11 +48,11 @@ let print ((A atom) as t) syntax =
   else
     match syntax with
     | Jbuild ->
-      Exn.code_error "atom cannot be printed in jbuild syntax"
-        ["atom", Sexp.Atom atom]
+      Code_error.raise "atom cannot be printed in jbuild syntax"
+        ["atom", String atom]
     | Dune ->
-      Exn.code_error "atom cannot be printed in dune syntax"
-        ["atom", Sexp.Atom atom]
+      Code_error.raise "atom cannot be printed in dune syntax"
+        ["atom", String atom]
 
 let of_int i = of_string (string_of_int i)
 let of_float x = of_string (string_of_float x)

--- a/src/dune_lang/template.ml
+++ b/src/dune_lang/template.ml
@@ -57,8 +57,8 @@ end = struct
   (* TODO use the loc for the error *)
   let check_valid_unquoted s ~syntax ~loc:_ =
     if not (Atom.is_valid (Atom.of_string s) syntax) then
-      Exn.code_error "Invalid text in unquoted template"
-        ["s", Sexp.Encoder.string s]
+      Code_error.raise "Invalid text in unquoted template"
+        ["s", String s]
 
   let to_string { parts; quoted; loc } ~syntax =
     Buffer.clear buf;

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -345,7 +345,7 @@ module Extension = struct
   let register ?(experimental=false) syntax stanzas arg_to_sexp =
     let name = Syntax.name syntax in
     if Hashtbl.mem extensions name then
-      Exn.code_error "Dune_project.Extension.register: already registered"
+      Errors.code_error "Dune_project.Extension.register: already registered"
         [ "name", Sexp.Encoder.string name ];
     let key = Univ_map.Key.create ~name arg_to_sexp in
     let ext = { syntax; stanzas; experimental; key } in
@@ -510,7 +510,7 @@ let get_exn () =
   get key >>| function
   | Some t -> t
   | None ->
-    Exn.code_error "Current project is unset" []
+    Errors.code_error "Current project is unset" []
 
 let filename = "dune-project"
 

--- a/src/errors.ml
+++ b/src/errors.ml
@@ -1,5 +1,26 @@
 open! Stdune
 
+exception Fatal_error of string
+
+exception Loc_error of Loc.t * string
+
+let () =
+  Printexc.register_printer (function
+    | Loc_error (loc, s) -> Some (Format.asprintf "%a%s" Loc.print loc s)
+    | _ -> None)
+
+let fatalf ?loc fmt =
+  Format.ksprintf (fun s ->
+    match loc with
+    | None -> raise (Fatal_error s)
+    | Some loc -> raise (Loc_error (loc, s))
+  ) fmt
+
+let code_error message vars =
+  List.map vars ~f:(fun (v, sexp) ->
+    (v, Dyn.Sexp sexp))
+  |> Code_error.raise message
+
 exception Already_reported
 
 let max_lines_to_print_in_full = 10
@@ -18,17 +39,17 @@ let kerrf fmt ~f =
     err_ppf fmt
 
 let die fmt =
-  kerrf fmt ~f:(fun s -> raise (Exn.Fatal_error s))
+  kerrf fmt ~f:(fun s -> raise (Fatal_error s))
 
 let exnf t fmt =
   Format.pp_open_box err_ppf 0;
   Format.pp_print_as err_ppf 7 ""; (* "Error: " *)
-  kerrf (fmt^^ "@]") ~f:(fun s -> Exn.Loc_error (t, s))
+  kerrf (fmt^^ "@]") ~f:(fun s -> Loc_error (t, s))
 
 let fail t fmt =
   Format.pp_print_as err_ppf 7 ""; (* "Error: " *)
   kerrf fmt ~f:(fun s ->
-    raise (Exn.Loc_error (t, s)))
+    raise (Loc_error (t, s)))
 
 let fail_lex lb fmt =
   fail (Loc.of_lexbuf lb) fmt

--- a/src/errors.mli
+++ b/src/errors.mli
@@ -4,6 +4,24 @@ open Stdune
 (* CR-soon diml: stop including this in [Import] *)
 (** This module is included in [Import] *)
 
+(* CR-soon diml:
+   - Rename to [User_error]
+   - change the [string] argument to [Loc0.t option * string] and get rid of
+   [Loc.Error]. The two are a bit confusing
+   - change [string] to [Colors.Style.t Lib_name.t]
+*)
+(** A fatal error, that should be reported to the user in a nice way *)
+exception Fatal_error of string
+
+exception Loc_error of Loc.t * string
+
+val fatalf
+  :  ?loc:Loc.t
+  -> ('a, unit, string, string, string, 'b) format6
+  -> 'a
+
+val code_error : string -> (string * Sexp.t) list -> _
+
 (* CR-soon diml: we won't need this once we can generate rules dynamically *)
 (** Raised for errors that have already been reported to the user and shouldn't be
     reported again. This might happen when trying to build a dependency that has already

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -439,7 +439,7 @@ let expand_special_vars ~deps_written_by_user ~var pform =
   | Pform.Expansion.Var Named_local ->
     begin match Bindings.find deps_written_by_user key with
     | None ->
-      Exn.code_error "Local named variable not present in named deps"
+      Errors.code_error "Local named variable not present in named deps"
         [ "pform", String_with_vars.Var.to_sexp var
         ; "deps_written_by_user",
           Bindings.to_sexp Path.to_sexp deps_written_by_user
@@ -464,7 +464,7 @@ let expand_special_vars ~deps_written_by_user ~var pform =
       [Value.String ""]
     end
   | _ ->
-    Exn.code_error "Unexpected variable in step2"
+    Errors.code_error "Unexpected variable in step2"
       ["var", String_with_vars.Var.to_sexp var]
 
 let expand_ddeps_and_bindings ~(dynamic_expansions : Value.t list String.Map.t)

--- a/src/install.ml
+++ b/src/install.ml
@@ -218,7 +218,7 @@ module Section = struct
       | Doc          -> t.doc
       | Stublibs     -> t.stublibs
       | Man          -> t.man
-      | Misc         -> Exn.code_error "Install.Paths.get" []
+      | Misc         -> Errors.code_error "Install.Paths.get" []
 
     let install_path t section p =
       Path.relative (get t section) (Dst.to_string p)

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -572,7 +572,7 @@ let already_in_table (info : Lib_info.t) name x =
       List [Sexp.Atom "Hidden";
             Path.to_sexp path; Sexp.Atom reason]
   in
-  Exn.code_error
+  Errors.code_error
     "Lib_db.DB: resolver returned name that's already in the table"
     [ "name"            , Lib_name.to_sexp name
     ; "returned_lib"    , to_sexp (info.src_dir, name)
@@ -1497,7 +1497,7 @@ module DB = struct
   let get_compile_info t ?(allow_overlaps=false) name =
     match find_even_when_hidden t name with
     | None ->
-      Exn.code_error "Lib.DB.get_compile_info got library that doesn't exist"
+      Errors.code_error "Lib.DB.get_compile_info got library that doesn't exist"
         [ "name", Lib_name.to_sexp name ]
     | Some lib ->
       let t = Option.some_if (not allow_overlaps) t in
@@ -1798,8 +1798,8 @@ end = struct
   let of_lib_exn t =
     match of_lib t with
     | Some l -> l
-    | None -> Exn.code_error "Lib.Local.of_lib_exn"
-                ["l", Dyn.to_sexp (to_dyn t)]
+    | None -> Code_error.raise "Lib.Local.of_lib_exn"
+                ["l", to_dyn t]
 
   let obj_dir t = Obj_dir.as_local_exn t.info.obj_dir
 

--- a/src/lib_config.ml
+++ b/src/lib_config.ml
@@ -23,5 +23,5 @@ let get_for_enabled_if t ~var =
   match List.assoc var_map var with
   | Some f -> f t
   | None ->
-    Exn.code_error "Lib_config.get_for_enabled_if: var not allowed"
+    Errors.code_error "Lib_config.get_for_enabled_if: var not allowed"
       ["var", Sexp.Encoder.string var]

--- a/src/main.ml
+++ b/src/main.ml
@@ -24,7 +24,7 @@ let package_install_file w pkg =
 
 let setup_env ~capture_outputs =
   let env =
-    if capture_outputs || not (Lazy.force Colors.stderr_supports_colors) then
+    if capture_outputs || not (Lazy.force Ansi_color.stderr_supports_color) then
       Env.initial
     else
       Colors.setup_env_for_colors Env.initial
@@ -216,7 +216,7 @@ let bootstrap () =
     in
     let config =
       Config.adapt_display config
-        ~output_is_a_tty:(Lazy.force Colors.stderr_supports_colors)
+        ~output_is_a_tty:(Lazy.force Ansi_color.stderr_supports_color)
     in
     let log = Log.create ~display:config.display () in
     Scheduler.go ~log ~config

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -79,18 +79,18 @@ let produce' ~union opt v =
 let produce (type o) (type_ : o t) (value : o) =
   match Fiber.Var.get current_handler with
   | None ->
-    Exn.code_error
+    Code_error.raise
       "Implicit_output.produce called without any handler in dynamic scope"
-      ["type", Sexp.Atom (Witness.get_name type_)]
+      ["type", String (Witness.get_name type_)]
   | Some (module H : Handler) ->
     match Witness.same type_ H.type_ with
     | Some Type_eq.T ->
       produce' ~union:(Witness.get_union type_) H.so_far value
     | None ->
-      Exn.code_error
+      Code_error.raise
         "Implicit_output.produce called with a handler for a different output"
-        [ "type_handled", Sexp.Atom (Witness.get_name H.type_)
-        ; "type_produced", Sexp.Atom (Witness.get_name type_)
+        [ "type_handled", String (Witness.get_name H.type_)
+        ; "type_produced", String (Witness.get_name type_)
         ]
 
 let produce_opt t v = match v with

--- a/src/module.ml
+++ b/src/module.ml
@@ -153,7 +153,7 @@ module Source = struct
   let make ?impl ?intf name =
     begin match impl, intf with
     | None, None ->
-      Exn.code_error "Module.Source.make called with no files"
+      Errors.code_error "Module.Source.make called with no files"
         [ "name", Sexp.Encoder.string name
         ; "impl", Sexp.Encoder.(option unknown) impl
         ; "intf", Sexp.Encoder.(option unknown) intf
@@ -211,7 +211,7 @@ let of_source ?obj_name ~visibility ~obj_dir ~(kind : Kind.t)
   | Impl, None, _
   | Intf_only, Some _, _ ->
     let open Sexp.Encoder in
-    Exn.code_error "Module.make: invalid kind, impl, intf combination"
+    Errors.code_error "Module.make: invalid kind, impl, intf combination"
       [ "name", Name.to_sexp source.name
       ; "kind", Kind.to_sexp kind
       ; "intf", (option File.to_sexp) source.intf
@@ -425,7 +425,7 @@ module Obj_map = struct
         match find t m with
         | Some m -> m
         | None ->
-          Exn.code_error "top_closure: unable to find key"
+          Errors.code_error "top_closure: unable to find key"
             [ "m", to_sexp m
             ; "t", (Sexp.Encoder.list to_sexp) (keys t)
             ])

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -31,7 +31,7 @@ module External = struct
     match cm_kind, visibility, t.private_dir with
     | Cmi, Private, Some p -> p
     | Cmi, Private, None ->
-      Exn.code_error "External.cm_dir"
+      Errors.code_error "External.cm_dir"
         [ "t", Dyn.to_sexp (to_dyn t)
         ]
     | Cmi, Public, _
@@ -176,12 +176,12 @@ let of_local
 
 let encode = function
   | Local_as_path obj_dir ->
-    Exn.code_error "Obj_dir.encode: local obj_dir cannot be encoded"
-      [ "obj_dir", Dyn.to_sexp (Local.to_dyn obj_dir)
+    Code_error.raise "Obj_dir.encode: local obj_dir cannot be encoded"
+      [ "obj_dir", Local.to_dyn obj_dir
       ]
   | Local obj_dir ->
-    Exn.code_error "Obj_dir.encode: local obj_dir cannot be encoded"
-      [ "obj_dir", Dyn.to_sexp (Local.to_dyn obj_dir)
+    Code_error.raise "Obj_dir.encode: local obj_dir cannot be encoded"
+      [ "obj_dir", Local.to_dyn obj_dir
       ]
   | External e -> External.encode e
 
@@ -273,7 +273,7 @@ let as_local_exn (t : Path.t t) =
   match t with
   | Local _ -> assert false
   | Local_as_path e -> Local e
-  | External _ -> Exn.code_error "Obj_dir.as_local_exn: external dir" []
+  | External _ -> Code_error.raise "Obj_dir.as_local_exn: external dir" []
 
 let make_exe ~dir ~name = Local (Local.make_exe ~dir ~name)
 

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -387,7 +387,7 @@ module Unexpanded = struct
           match Path.Map.find files_contents path with
           | Some x -> x
           | None ->
-            Exn.code_error
+            Errors.code_error
               "Ordered_set_lang.Unexpanded.expand"
               [ "included-file", Path.to_sexp path
               ; "files", Sexp.Encoder.(list Path.to_sexp)

--- a/src/package.ml
+++ b/src/package.ml
@@ -177,7 +177,7 @@ module Dependency = struct
     | Or (c :: cs) ->
       Logop (nopos, `Or, opam_constraint c, opam_constraint (And cs))
     | And []
-    | Or [] -> Exn.code_error "opam_constraint" []
+    | Or [] -> Errors.code_error "opam_constraint" []
 
   let opam_depend : t -> OpamParserTypes.value =
     let nopos = Opam_file.nopos in

--- a/src/print_diff.ml
+++ b/src/print_diff.ml
@@ -60,7 +60,7 @@ let print ?(skip_trailing_cr=Sys.win32) path1 path2 =
           Process.run ~dir ~env:Env.initial Strict prog
             [ "-keep-whitespace"
             ; "-location-style"; "omake"
-            ; if Lazy.force Colors.stderr_supports_colors then
+            ; if Lazy.force Ansi_color.stderr_supports_color then
                 "-unrefined"
               else
                 "-ascii"

--- a/src/rule.ml
+++ b/src/rule.ml
@@ -37,7 +37,7 @@ let make ?(sandbox=false) ?(mode=Dune_file.Rule.Mode.Standard)
     | None -> begin
         match info with
         | From_dune_file loc -> Errors.fail loc "Rule has no targets specified"
-        | _ -> Exn.code_error "Build_interpret.Rule.make: no targets" []
+        | _ -> Errors.code_error "Build_interpret.Rule.make: no targets" []
       end
     | Some x ->
       let dir = Path.Build.parent_exn x in
@@ -46,7 +46,7 @@ let make ?(sandbox=false) ?(mode=Dune_file.Rule.Mode.Standard)
       then begin
         match info with
         | Internal | Source_file_copy ->
-          Exn.code_error "rule has targets in different directories"
+          Errors.code_error "rule has targets in different directories"
             [ "targets", Path.Build.Set.to_sexp targets
             ]
         | From_dune_file loc ->

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -677,7 +677,7 @@ end = struct
              let* pump_events_result = pump_events t in
              Fiber.return (pump_events_result, user_action_result)) with
     | exception Fiber.Never ->
-      Exn.code_error "[Scheduler.pump_events] got stuck somehow" []
+      Errors.code_error "[Scheduler.pump_events] got stuck somehow" []
     | exception exn ->
       Error (Exn (exn, (Printexc.get_raw_backtrace ())))
     | (a, b) ->
@@ -721,7 +721,7 @@ let go ?log ?config f =
   | Error Never ->
     raise Fiber.Never
   | Error Files_changed ->
-    Exn.code_error
+    Errors.code_error
       "Scheduler.go: files changed even though we're running without filesystem watcher"
       []
 

--- a/src/scheme.ml
+++ b/src/scheme.ml
@@ -112,7 +112,7 @@ let evaluate ~union_rules =
         not (Dir_set.is_subset paths ~of_:env)
         && not (Dir_set.is_subset (Dir_set.negate paths) ~of_:env)
       then
-        Exn.code_error
+        Errors.code_error
           "inner [Approximate] specifies a set such that neither it, \
            nor its negation, are a subset of directories specified by \
            the outer [Approximate]."
@@ -131,7 +131,7 @@ let evaluate ~union_rules =
       (match violations with
        | [] -> ()
        | _ :: _ ->
-         Exn.code_error
+         Errors.code_error
            "Scheme attempted to generate rules in a directory it promised not \
             to touch"
            [ "directories", (Sexp.Encoder.list Path.to_sexp) violations ]);

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -24,7 +24,7 @@ module DB = struct
   let find_by_dir t dir =
     let rec loop d =
       if Path.Build.is_root d then
-        Exn.code_error "Scope.DB.find_by_dir got an invalid path"
+        Errors.code_error "Scope.DB.find_by_dir got an invalid path"
           [ "dir"    , Path.Build.to_sexp dir
           ; "context", Sexp.Encoder.string t.context
           ];
@@ -34,7 +34,7 @@ module DB = struct
         begin match Path.Build.parent d with
         | Some d -> loop d
         | None ->
-          Exn.code_error "find_by_dir: invalid directory"
+          Errors.code_error "find_by_dir: invalid directory"
             [ "d", Path.Build.to_sexp d
             ; "dir", Path.Build.to_sexp dir
             ]
@@ -47,7 +47,7 @@ module DB = struct
     | Some x -> x
     | None ->
       let dune_project_sexp p = Dyn.to_sexp (Dune_project.Name.to_dyn p) in
-      Exn.code_error "Scope.DB.find_by_name"
+      Errors.code_error "Scope.DB.find_by_name"
         [ "name"   , dune_project_sexp name
         ; "context", Sexp.Encoder.string t.context
         ; "names",
@@ -108,7 +108,7 @@ module DB = struct
             (Dune_project.name project, Dune_project.root project)
           |> Dyn.to_sexp
         in
-        Exn.code_error "Scope.DB.create got two projects with the same name"
+        Errors.code_error "Scope.DB.create got two projects with the same name"
           [ "project1", to_sexp project1
           ; "project2", to_sexp project2
           ]

--- a/src/stdune/ansi_color.mli
+++ b/src/stdune/ansi_color.mli
@@ -37,3 +37,13 @@ module Render : Pp.Renderer.S
 
 (** Filter out escape sequences in a string *)
 val strip : string -> string
+
+(** Print to [stdout] (not thread safe) *)
+val print : ?margin:int -> Style.t list Pp.t -> unit
+
+(** Print to [stderr] (not thread safe) *)
+val prerr : ?margin:int -> Style.t list Pp.t -> unit
+
+(** Whether [stdout]/[stderr] support colors *)
+val stdout_supports_color : bool Lazy.t
+val stderr_supports_color : bool Lazy.t

--- a/src/stdune/code_error.ml
+++ b/src/stdune/code_error.ml
@@ -20,4 +20,3 @@ let () =
   Printexc.register_printer (function
     | E t -> Some (Dyn.to_string (to_dyn t))
     | _ -> None)
-

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -48,8 +48,8 @@ let of_unix arr =
   |> List.map ~f:(fun s ->
     match String.lsplit2 s ~on:'=' with
     | None ->
-      Exn.code_error "Env.of_unix: entry without '=' found in the environ"
-        ["var", Sexp.Encoder.string s]
+      Code_error.raise "Env.of_unix: entry without '=' found in the environ"
+        ["var", String s]
     | Some (k, v) -> (k, v))
   |> Map.of_list_multi
   |> Map.map ~f:(function

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -3,25 +3,9 @@ module String = Dune_caml.StringLabels
 module Dyn = Dyn0
 type t = exn
 
-exception Fatal_error of string
-
-exception Loc_error of Loc0.t * string
-
 external raise         : exn -> _ = "%raise"
 external raise_notrace : exn -> _ = "%raise_notrace"
 external reraise       : exn -> _ = "%reraise"
-
-let () =
-  Printexc.register_printer (function
-    | Loc_error (loc, s) -> Some (Format.asprintf "%a%s" Loc0.print loc s)
-    | _ -> None)
-
-let fatalf ?loc fmt =
-  Format.ksprintf (fun s ->
-    match loc with
-    | None -> raise (Fatal_error s)
-    | Some loc -> raise (Loc_error (loc, s))
-  ) fmt
 
 let protectx x ~f ~finally =
   match f x with
@@ -29,11 +13,6 @@ let protectx x ~f ~finally =
   | exception e -> finally x; raise e
 
 let protect ~f ~finally = protectx () ~f ~finally
-
-let code_error message vars =
-  List.map vars ~f:(fun (v, sexp) ->
-    (v, Dyn0.Sexp sexp))
-  |> Code_error.raise message
 
 let pp_uncaught ~backtrace fmt exn =
   let s =

--- a/src/stdune/exn.mli
+++ b/src/stdune/exn.mli
@@ -1,24 +1,5 @@
 (** Exceptions *)
 
-
-(* CR-soon diml:
-   - Rename to [User_error]
-   - change the [string] argument to [Loc0.t option * string] and get rid of
-   [Loc.Error]. The two are a bit confusing
-   - change [string] to [Colors.Style.t Lib_name.t]
-*)
-(** A fatal error, that should be reported to the user in a nice way *)
-exception Fatal_error of string
-
-exception Loc_error of Loc0.t * string
-
-val fatalf
-  :  ?loc:Loc0.t
-  -> ('a, unit, string, string, string, 'b) format6
-  -> 'a
-
-val code_error : string -> (string * Sexp0.t) list -> _
-
 type t = exn
 
 external raise         : exn -> _ = "%raise"

--- a/src/stdune/fdecl.ml
+++ b/src/stdune/fdecl.ml
@@ -9,9 +9,9 @@ let create () = { state = Unset }
 let set t x =
   match t.state with
   | Unset -> t.state <- Set x
-  | Set _ -> Exn.code_error "Fdecl.set: already set" []
+  | Set _ -> Code_error.raise "Fdecl.set: already set" []
 
 let get t =
   match t.state with
-  | Unset -> Exn.code_error "Fdecl.get: not set" []
+  | Unset -> Code_error.raise "Fdecl.get: not set" []
   | Set x -> x

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -57,7 +57,7 @@ module Make(H : Hashable.S) = struct
     match of_list l with
     | Result.Ok h -> h
     | Error (_, _, _) ->
-      Exn.code_error "Hashtbl.of_list_exn duplicate keys" []
+      Code_error.raise "Hashtbl.of_list_exn duplicate keys" []
 end
 
 open MoreLabels.Hashtbl

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -90,7 +90,7 @@ let rec find l ~f =
 let find_exn l ~f =
   match find l ~f with
   | Some x -> x
-  | None -> Exn.code_error "List.find_exn" []
+  | None -> Code_error.raise "List.find_exn" []
 
 let rec last = function
   | [] -> None

--- a/src/stdune/loc.ml
+++ b/src/stdune/loc.ml
@@ -106,7 +106,7 @@ let pp_file_excerpt ~context_lines ~max_lines_to_print_in_full
       Result.try_with (fun () -> Io.String_path.file_line file line_num) in
     if stop_c <= String.length line then begin
       let len = stop_c - start_c in
-      Format.fprintf pp "%a%*s\n"
+      Format.fprintf pp "%a%*s@."
         (pp_line padding_width) (line_num_str, line)
         (stop_c + padding_width + 3)
         (String.make len '^');

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -111,12 +111,12 @@ module Make(Key : Comparable.S) : S with type key = Key.t = struct
   let of_list_map_exn t ~f =
     match of_list_map t ~f with
     | Ok x -> x
-    | Error _ -> Exn.code_error "Map.of_list_map_exn" []
+    | Error _ -> Code_error.raise "Map.of_list_map_exn" []
 
   let of_list_exn l =
     match of_list l with
     | Ok    x -> x
-    | Error _ -> Exn.code_error "Map.of_list_exn" []
+    | Error _ -> Code_error.raise "Map.of_list_exn" []
 
   let of_list_reduce l ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->

--- a/src/stdune/option.ml
+++ b/src/stdune/option.ml
@@ -37,7 +37,7 @@ let value t ~default =
 
 let value_exn = function
   | Some x -> x
-  | None -> Exn.code_error "Option.value_exn" []
+  | None -> Code_error.raise "Option.value_exn" []
 
 let some x = Some x
 

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -17,6 +17,19 @@ type +'a t =
   | Text of string
   | Tag of 'a * 'a t
 
+let rec map_tags t ~f =
+  match t with
+  | Nop -> Nop
+  | Seq (a, b) -> Seq (map_tags a ~f, map_tags b ~f)
+  | Concat (sep, l) -> Concat (map_tags sep ~f, List.map l ~f:(map_tags ~f))
+  | Box (indent, t) -> Box (indent, map_tags t ~f)
+  | Vbox (indent, t) -> Vbox (indent, map_tags t ~f)
+  | Hbox t -> Hbox (map_tags t ~f)
+  | Hvbox (indent, t) -> Hvbox (indent, map_tags t ~f)
+  | Hovbox (indent, t) -> Hovbox (indent, map_tags t ~f)
+  | Verbatim _ | Char _ | Break _ | Newline | Text _ as t -> t
+  | Tag (tag, t) -> Tag (f tag, map_tags t ~f)
+
 module type Tag = sig
   type t
   module Handler : sig
@@ -186,3 +199,8 @@ let text s = Text s
 let textf fmt = Printf.ksprintf text fmt
 
 let tag t ~tag = Tag (tag, t)
+
+let enumerate l ~f =
+  vbox (concat ~sep:cut (List.map l ~f:(fun x ->
+    box ~indent:2
+      (seq (verbatim "- ") (f x)))))

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -53,6 +53,9 @@ val break : nspaces:int -> shift:int -> _ t
 (** Force a newline to be printed *)
 val newline : _ t
 
+(** Convert tags in a documents *)
+val map_tags : 'a t -> f:('a -> 'b) -> 'b t
+
 (** {1 Boxes} *)
 
 (** Boxes are the basic components to control the layout of the text.
@@ -78,6 +81,19 @@ val hvbox : ?indent:int -> 'a t -> 'a t
 
 (** Try to put as much as possible on each line. *)
 val hovbox : ?indent:int -> 'a t -> 'a t
+
+(** {1 Common convenience functions} *)
+
+(** [enumerate l ~f] produces an enumeration of the form:
+
+    {v
+       - item1
+       - item2
+       - item3
+       ...
+    v}
+*)
+val enumerate : 'a list -> f:('a -> 'b t) -> 'b t
 
 (** {1 Rendering} *)
 

--- a/src/stdune/set.ml
+++ b/src/stdune/set.ml
@@ -69,7 +69,7 @@ module Make(Elt : Comparable.S) : S with type elt = Elt.t = struct
     match choose t with
     | Some e -> e
     | None ->
-      Exn.code_error "Set.choose_exn" []
+      Code_error.raise "Set.choose_exn" []
 end
 
 let to_sexp to_list f t =

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -46,6 +46,9 @@ module Float      = Float
 module Tuple      = Tuple
 module Poly       = Poly
 module Code_error = Code_error
+module User_error = User_error
+module User_message = User_message
+module User_warning = User_warning
 
 external reraise : exn -> _ = "%reraise"
 

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -115,9 +115,9 @@ let lsplit2_exn s ~on =
   match lsplit2 s ~on with
   | Some s -> s
   | None ->
-    Exn.code_error "lsplit2_exn"
-      [ "s", Sexp.Encoder.string s
-      ; "on", Sexp.Encoder.char on
+    Code_error.raise "lsplit2_exn"
+      [ "s", String s
+      ; "on", Char on
       ]
 
 let rsplit2 s ~on =

--- a/src/stdune/user_error.ml
+++ b/src/stdune/user_error.ml
@@ -1,0 +1,18 @@
+exception E of User_message.t
+
+let prefix =
+  Pp.seq
+    (Pp.tag (Pp.verbatim "Error") ~tag:User_message.Style.Error)
+    (Pp.char ':')
+
+let make ?loc ?hints paragraphs =
+  User_message.make ?loc ?hints paragraphs ~prefix
+
+let raise ?loc ?hints paragraphs =
+  raise (E (make ?loc ?hints paragraphs))
+
+let () =
+  Printexc.register_printer (function
+    | E t -> Some (Format.asprintf "%a@?" Pp.pp
+                     (User_message.pp t |> Pp.map_tags ~f:ignore))
+    | _ -> None)

--- a/src/stdune/user_error.mli
+++ b/src/stdune/user_error.mli
@@ -1,0 +1,24 @@
+(** Error meant for humans *)
+
+(** User errors are errors that users need to fix themselves in order
+    to make progress. Since these errors are read by users, they should
+    be simple to understand for people who are not familiar with the
+    dune codebase.
+*)
+exception E of User_message.t
+
+(** Raise a user error.  The arguments are interpreted in the same way
+    as [User_message.make]. The first paragraph is prefixed with
+    "Error:".  *)
+val raise
+  :  ?loc:Loc0.t
+  -> ?hints:User_message.Style.t Pp.t list
+  -> User_message.Style.t Pp.t list
+  -> _
+
+(** Create a user error. *)
+val make
+  :  ?loc:Loc0.t
+  -> ?hints:User_message.Style.t Pp.t list
+  -> User_message.Style.t Pp.t list
+  -> User_message.t

--- a/src/stdune/user_message.ml
+++ b/src/stdune/user_message.ml
@@ -1,0 +1,116 @@
+module Style = struct
+  type t =
+    | Loc
+    | Error
+    | Warning
+    | Kwd
+    | Id
+    | Prompt
+    | Details
+    | Ok
+    | Debug
+end
+
+module Print_config = struct
+  type t = Style.t -> Ansi_color.Style.t list
+
+  let default : t = function
+    | Loc     -> [Bold]
+    | Error   -> [Bold; Fg Red]
+    | Warning -> [Bold; Fg Magenta]
+    | Kwd     -> [Bold; Fg Blue]
+    | Id      -> [Bold; Fg Yellow]
+    | Prompt  -> [Bold; Fg Green]
+    | Details -> [Dim; Fg White]
+    | Ok      -> [Dim; Fg Green]
+    | Debug   -> [Underlined; Fg Bright_cyan]
+end
+
+type t =
+  { loc : Loc0.t option
+  ; paragraphs : Style.t Pp.t list
+  ; hints : Style.t Pp.t list
+  }
+
+let make ?loc ?prefix ?(hints=[]) paragraphs =
+  let paragraphs =
+    match prefix, paragraphs with
+    | None, l -> l
+    | Some p, [] -> [p]
+    | Some p, x :: l ->
+      Pp.concat ~sep:Pp.space [p; x] :: l
+  in
+  { loc; hints; paragraphs }
+
+let pp { loc; paragraphs; hints } =
+  let paragraphs =
+    match hints with
+    | [] -> paragraphs
+    | _ ->
+      List.append
+        paragraphs
+        (List.map hints ~f:(fun hint ->
+           Pp.concat ~sep:Pp.space [Pp.verbatim "Hint:"; hint]))
+  in
+  let paragraphs = List.map paragraphs ~f:Pp.box in
+  let paragraphs =
+    match loc with
+    | None -> paragraphs
+    | Some { Loc0.start; stop } ->
+      let start_c = start.pos_cnum - start.pos_bol in
+      let stop_c  = stop.pos_cnum  - start.pos_bol in
+      Pp.tag ~tag:Style.Loc
+        (Pp.textf "File %S, line %d, characters %d-%d:"
+           start.pos_fname start.pos_lnum start_c stop_c)
+      :: paragraphs
+  in
+  Pp.vbox (Pp.concat paragraphs ~sep:Pp.cut)
+
+let print ?(config=Print_config.default) ?margin t =
+  Ansi_color.print ?margin (Pp.map_tags (pp t) ~f:config)
+
+let prerr ?(config=Print_config.default) ?margin t =
+  Ansi_color.prerr ?margin (Pp.map_tags (pp t) ~f:config)
+
+(* As found here http://rosettacode.org/wiki/Levenshtein_distance#OCaml *)
+let levenshtein_distance s t =
+  let m = String.length s
+  and n = String.length t in
+  (* for all i and j, d.(i).(j) will hold the Levenshtein distance between
+     the first i characters of s and the first j characters of t *)
+  let d = Array.make_matrix ~dimx:(m+1) ~dimy:(n+1) 0 in
+
+  for i = 0 to m do
+    (* the distance of any first string to an empty second string *)
+    d.(i).(0) <- i
+  done;
+  for j = 0 to n do
+    (* the distance of any second string to an empty first string *)
+    d.(0).(j) <- j
+  done;
+
+  for j = 1 to n do
+    for i = 1 to m do
+
+      if s.[i-1] = t.[j-1] then
+        d.(i).(j) <- d.(i-1).(j-1)  (* no operation required *)
+      else
+        d.(i).(j) <- min
+                       (d.(i-1).(j) + 1) (* a deletion *)
+                       (min
+                          (d.(i).(j-1) + 1) (* an insertion *)
+                          (d.(i-1).(j-1) + 1) (* a substitution *)
+                       )
+    done;
+  done;
+
+  d.(m).(n)
+
+let did_you_mean s ~candidates =
+  let candidates =
+    List.filter candidates ~f:(fun candidate ->
+      levenshtein_distance s candidate < 3)
+  in
+  match candidates with
+  | [] -> []
+  | l -> [Pp.textf "did you mean %s?" (String.enumerate_or l)]

--- a/src/stdune/user_message.mli
+++ b/src/stdune/user_message.mli
@@ -1,0 +1,70 @@
+(** A message for the user *)
+
+(** User messages are styled document that can be printed to the
+    console or in the log file. *)
+
+(** Symbolic styles that can be used inside messages. These styles are
+    later converted to actual concrete styles depending on the output
+    device.  For instance, when printed to the terminal they are
+    converted to ansi terminal styles ([Ansi_color.Style.t list]
+    values). *)
+module Style : sig
+  type t =
+    | Loc
+    | Error
+    | Warning
+    | Kwd
+    | Id
+    | Prompt
+    | Details
+    | Ok
+    | Debug
+end
+
+(** A user message.contents composed of an optional file location and
+    a list of paragraphs.
+
+    The various paragraphs will be printed one after the other and
+    will all start at the beginning of a line. They are all wrapped
+    inside a [Pp.box].
+
+    When hints are provided, they are printed as last paragraphs and
+    prefixed with "Hint:".  Hints should give indication to the user
+    for how to fix the issue.
+*)
+type t =
+  { loc : Loc0.t option
+  ; paragraphs : Style.t Pp.t list
+  ; hints : Style.t Pp.t list
+  }
+
+val pp : t -> Style.t Pp.t
+
+module Print_config : sig
+  (** Associate ANSI terminal styles to symbolic styles *)
+  type t = Style.t -> Ansi_color.Style.t list
+
+  (** The default configuration *)
+  val default : t
+end
+
+(** Construct a user message from a list of paragraphs.
+
+    The first paragraph is prefixed with [prefix] inside the
+    box. [prefix] should not end with a space as a space is
+    automatically inserted by [make] if necessary. *)
+val make
+  :  ?loc:Loc0.t
+  -> ?prefix:Style.t Pp.t
+  -> ?hints:Style.t Pp.t list
+  -> Style.t Pp.t list
+  -> t
+
+(** Print to [stdout] (not thread safe) *)
+val print : ?config:Print_config.t -> ?margin:int -> t -> unit
+
+(** Print to [stderr] (not thread safe) *)
+val prerr : ?config:Print_config.t -> ?margin:int -> t -> unit
+
+(** Produces a "Did you mean ...?" hint *)
+val did_you_mean : string -> candidates:string list -> Style.t Pp.t list

--- a/src/stdune/user_warning.ml
+++ b/src/stdune/user_warning.ml
@@ -1,0 +1,11 @@
+let reporter = ref (fun msg -> User_message.prerr msg)
+
+let set_reporter f = reporter := f
+
+let emit ~loc ?hints paragraphs =
+  !reporter
+    (User_message.make paragraphs ~loc ?hints
+       ~prefix:(Pp.seq
+                  (Pp.tag (Pp.verbatim "Warning")
+                     ~tag:User_message.Style.Warning)
+                  (Pp.char ':')))

--- a/src/stdune/user_warning.mli
+++ b/src/stdune/user_warning.mli
@@ -1,0 +1,17 @@
+(** Non-fatal user errors *)
+
+(** Warnings are user errors that cannot be proper errors for backward
+    compatibility reasons *)
+
+(** Emit a user warning. The arguments are interpreted in a similar
+    fashion to {!User_error.raise} except that the first paragraph is
+    prefixed with "Warning: " rather than "Error: ". *)
+val emit
+  :  loc:Loc0.t
+  -> ?hints:User_message.Style.t Pp.t list
+  -> User_message.Style.t Pp.t list
+  -> unit
+
+(** Set the warning reporter. The default one is
+    [User_message.prerr]. *)
+val set_reporter : (User_message.t -> unit) -> unit

--- a/src/string_with_vars.ml
+++ b/src/string_with_vars.ml
@@ -120,7 +120,7 @@ let decode =
   let jbuild =
     raw >>| function
     | Template _ as t ->
-      Exn.code_error "Unexpected dune template from a jbuild file"
+      Errors.code_error "Unexpected dune template from a jbuild file"
         [ "t", Dune_lang.to_sexp (Dune_lang.Ast.remove_locs t)
         ]
     | Atom(loc, A s) -> Jbuild.parse s ~loc ~quoted:false

--- a/src/sub_system_info.ml
+++ b/src/sub_system_info.ml
@@ -24,7 +24,7 @@ module Register(M : S) : sig end = struct
   let () =
     match Sub_system_name.Table.get all name with
     | Some _ ->
-      Exn.code_error "Sub_system_info.register: already registered"
+      Errors.code_error "Sub_system_info.register: already registered"
         [ "name", Sexp.Encoder.string (Sub_system_name.to_string name) ];
     | None ->
       Sub_system_name.Table.set all ~key:name ~data:(Some (module M : S));

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -128,7 +128,7 @@ end = struct
       try
         get t ~dir ~scope
       with Exit ->
-        Exn.code_error "Super_context.Env.get called on invalid directory"
+        Errors.code_error "Super_context.Env.get called on invalid directory"
           [ "dir", Path.Build.to_sexp dir ]
 
   let external_ t  ~dir =

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -64,7 +64,7 @@ module Supported_versions = struct
     with
     | Ok x -> x
     | Error _ ->
-      Exn.code_error
+      Errors.code_error
         "Syntax.create"
         [ "versions", Sexp.Encoder.list Version.to_sexp l ]
 
@@ -160,7 +160,7 @@ let get_exn t =
   | Some x -> return x
   | None ->
     let+ context = get_all in
-    Exn.code_error "Syntax identifier is unset"
+    Errors.code_error "Syntax identifier is unset"
       [ "name", Sexp.Encoder.string t.name
       ; "supported_versions", Supported_versions.to_sexp t.supported_versions
       ; "context", Univ_map.to_sexp context

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -320,7 +320,7 @@ let upgrade_opam_file todo fn =
     let ofs =
       List.fold_left substs ~init:0 ~f:(fun ofs (start, stop, repl) ->
         if not (ofs <= start && start <= stop) then
-          Exn.code_error "Invalid text subsitution"
+          Errors.code_error "Invalid text subsitution"
             [ "ofs", Sexp.Encoder.int ofs
             ; "start", Sexp.Encoder.int start
             ; "stop", Sexp.Encoder.int stop

--- a/src/versioned_file.ml
+++ b/src/versioned_file.ml
@@ -43,7 +43,7 @@ module Make(Data : sig type t end) = struct
     let register syntax data =
       let name = Syntax.name syntax in
       if Hashtbl.mem langs name then
-        Exn.code_error "Versioned_file.Lang.register: already registered"
+        Errors.code_error "Versioned_file.Lang.register: already registered"
           [ "name", Sexp.Encoder.string name ];
       Hashtbl.add langs name { syntax; data }
 

--- a/test/blackbox-tests/test-cases/custom-build-dir/run.t
+++ b/test/blackbox-tests/test-cases/custom-build-dir/run.t
@@ -8,12 +8,14 @@
 
   $ dune build foo --build-dir .
   Error: Invalid build directory: .
-  The build directory must be an absolute path or a sub-directory of the root of the workspace.
+  The build directory must be an absolute path or a sub-directory of the root
+  of the workspace.
   [1]
 
   $ dune build foo --build-dir src/foo
   Error: Invalid build directory: src/foo
-  The build directory must be an absolute path or a sub-directory of the root of the workspace.
+  The build directory must be an absolute path or a sub-directory of the root
+  of the workspace.
   [1]
 
   $ mkdir project

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -15,8 +15,8 @@ variants results in an appropriate error message.
   File "dune", line 4, characters 11-14:
   4 |  (variants a b))
                  ^^^
-  Error: Multiple solutions for the implementation
-  of vlib  with variants [ "a"; "b" ]
+  Error: Multiple solutions for the implementation of vlib 
+  with variants [ "a"; "b" ]
   -> lib_b ("b")
   -> lib2_a ("a")
   -> required by executable bar in dune:2

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -195,6 +195,15 @@
            (diff? %{t} %{t}.corrected)))))
 
 (alias
+ (name runtest)
+ (deps (:t pp.mlt)
+  (glob_files %{project_root}/src/stdune/.stdune.objs/byte/*.cmi))
+ (action (chdir %{project_root}
+          (progn
+           (run %{exe:expect_test.exe} %{t})
+           (diff? %{t} %{t}.corrected)))))
+
+(alias
  (name runtestscheme)
  (deps (:t scheme.mlt)
   (glob_files %{project_root}/src/.dune.objs/byte/*.cmi)

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -226,8 +226,8 @@ Exception:
 E
  {message = "Path.insert_after_build_dir_exn";
   data =
-   [("path", Sexp (List [Atom "In_source_tree"; Atom "."]));
-    ("insert", Sexp (Atom "foobar"))]}.
+   [("path", Variant ("In_source_tree", [String "."]));
+    ("insert", String "foobar")]}.
 |}]
 
 Path.insert_after_build_dir_exn Path.build_dir "foobar"
@@ -251,8 +251,8 @@ Exception:
 E
  {message = "Path.append called with directory that's not in the source tree";
   data =
-   [("a", Sexp (List [Atom "In_build_dir"; Atom "."]));
-    ("b", Sexp (List [Atom "In_build_dir"; Atom "foo"]))]}.
+   [("a", Variant ("In_build_dir", [String "."]));
+    ("b", Variant ("In_build_dir", [String "foo"]))]}.
 |}]
 
 Path.append Path.root (Path.relative Path.build_dir "foo")
@@ -261,8 +261,8 @@ Exception:
 E
  {message = "Path.append called with directory that's not in the source tree";
   data =
-   [("a", Sexp (List [Atom "In_source_tree"; Atom "."]));
-    ("b", Sexp (List [Atom "In_build_dir"; Atom "foo"]))]}.
+   [("a", Variant ("In_source_tree", [String "."]));
+    ("b", Variant ("In_build_dir", [String "foo"]))]}.
 |}]
 
 Path.append Path.root (Path.relative Path.root "foo")
@@ -281,8 +281,8 @@ Exception:
 E
  {message = "Path.append called with directory that's not in the source tree";
   data =
-   [("a", Sexp (List [Atom "External"; Atom "/root"]));
-    ("b", Sexp (List [Atom "In_build_dir"; Atom "foo"]))]}.
+   [("a", Variant ("External", [String "/root"]));
+    ("b", Variant ("In_build_dir", [String "foo"]))]}.
 |}]
 
 Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")
@@ -291,7 +291,7 @@ Exception:
 E
  {message = "Path.rm_rf called on external dir";
   data =
-   [("t", Sexp (List [Atom "External"; Atom "/does/not/exist/foo/bar/baz"]))]}.
+   [("t", Variant ("External", [String "/does/not/exist/foo/bar/baz"]))]}.
 |}]
 
 Path.drop_build_context (Path.relative Path.build_dir "foo/bar")

--- a/test/unit-tests/pp.mlt
+++ b/test/unit-tests/pp.mlt
@@ -1,0 +1,41 @@
+(* -*- tuareg -*- *)
+open! Stdune;;
+
+#warnings "-40";;
+
+let pp pp =
+  Format.printf "%a@." Pp.pp pp
+;;
+
+[%%ignore]
+
+let enum_x_and_y =
+  Pp.enumerate
+      [ Array.make 50 "x"
+      ; Array.make 50 "y"
+      ]
+      ~f:(fun a -> Pp.concat_map (Array.to_list a) ~sep:Pp.space ~f:Pp.verbatim)
+[%%ignore]
+
+pp enum_x_and_y
+[%%expect{|
+- x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
+  x x x x x x x x x x x x
+- y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y
+  y y y y y y y y y y y y
+- : unit = ()
+|}]
+
+pp (Pp.enumerate
+      [ Pp.enumerate [ "abc"; "def" ] ~f:Pp.text
+      ; enum_x_and_y
+      ] ~f:Fn.id)
+[%%expect{|
+- - abc
+  - def
+- - x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
+    x x x x x x x x x x x x x
+  - y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y y
+    y y y y y y y y y y y y y
+- : unit = ()
+|}]

--- a/test/unit-tests/scheme.mlt
+++ b/test/unit-tests/scheme.mlt
@@ -116,11 +116,11 @@ let print_rules scheme ~dir =
   in
   if not ((res1 : string list) = res2)
   then
-    Exn.code_error
+    Code_error.raise
       "Naive [collect_rules_simple] gives result inconsistent with [Scheme.evaluate]"
       [
-        "res1", Sexp.List (List.map res1 ~f:(fun s -> Sexp.Atom s));
-        "res2", Sexp.List (List.map res2 ~f:(fun s -> Sexp.Atom s));
+        "res1", Dyn.Encoder.(list string) res1;
+        "res2", Dyn.Encoder.(list string) res2;
       ]
   else
     (

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -339,7 +339,7 @@ test Dune (t [Text "x%{"])
 Exception:
 E
  {message = "Invalid text in unquoted template";
-  data = [("s", Sexp (Atom "x%{"))]}.
+  data = [("s", String "x%{")]}.
 |}]
 
 test Dune (t [Text "x%"; Text "{"])
@@ -347,7 +347,7 @@ test Dune (t [Text "x%"; Text "{"])
 Exception:
 E
  {message = "Invalid text in unquoted template";
-  data = [("s", Sexp (Atom "x%{"))]}.
+  data = [("s", String "x%{")]}.
 |}]
 
 (* This round trip failure is expected *)


### PR DESCRIPTION
This PR implements the new error reporting API described in #2190 and moves the old functions to the `Errors` module in the `dune` library. This means that stdune and all the libraries that come before `dune` have been updated to use the new API. In addition to what is described in #2190, I introduced a module `User_message` to represent all messages displayed to the user: error messages, warnings and informative messages. I also added an API for printing these on the terminal.

At the moment, `Report_error` was very roughly updated to handle the new exception. ~which explains why in one of the backbox test a spurious empty line is inserted. This will be sorted once more of the code has been ported to the `Pp` API. I intend to do this next.~ EDIT: I found why the empty line was inserted and fixed the issue.