### PR TITLE
Make artifact access go through Obj_dir.t

### DIFF
--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -28,14 +28,9 @@ module Modules = struct
       List.filter_partition_map d.data ~f:(fun stanza ->
         match (stanza : Stanza.t) with
         | Library lib ->
-          let obj_dir =
-            Obj_dir.make_lib ~dir:d.ctx_dir
-              (snd lib.name)
-              ~has_private_modules:(Option.is_some lib.private_modules)
-          in
+          let src_dir = d.ctx_dir in
           let modules =
             Modules_field_evaluator.eval ~modules
-              ~obj_dir
               ~buildable:lib.buildable
               ~virtual_modules:lib.virtual_modules
               ~private_modules:(
@@ -67,20 +62,15 @@ module Modules = struct
                   (main_module_name, Option.value_exn wrapped)
               )
           in
-          let obj_dir = Obj_dir.of_local obj_dir in
           Left ( lib
-               , Lib_modules.make lib ~obj_dir modules ~main_module_name
+               , let src_dir = Path.build src_dir in
+                 Lib_modules.make lib ~src_dir modules ~main_module_name
                    ~wrapped
                )
         | Executables exes
         | Tests { exes; _} ->
-          let obj_dir =
-            let name = snd (List.hd exes.names) in
-            Obj_dir.make_exe ~dir:d.ctx_dir ~name
-          in
           let modules =
             Modules_field_evaluator.eval ~modules
-              ~obj_dir
               ~buildable:exes.buildable
               ~virtual_modules:None
               ~private_modules:Ordered_set_lang.standard

--- a/src/dune_package.ml
+++ b/src/dune_package.ml
@@ -168,9 +168,10 @@ module Lib = struct
                                              (located Lib_name.decode))
       and+ sub_systems = Sub_system_info.record_parser ()
       and+ orig_src_dir = field_o "orig_src_dir" path
-      and+ modules = field_o "modules" (Lib_modules.decode
-                                          ~implements:(Option.is_some
-                                                         implements) ~obj_dir)
+      and+ modules =
+        let src_dir = Obj_dir.dir obj_dir in
+        field_o "modules" (
+          Lib_modules.decode ~implements:(Option.is_some implements) ~src_dir)
       and+ special_builtin_support =
         field_o "special_builtin_support"
           (Syntax.since Stanza.syntax (1, 10) >>>

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -134,16 +134,11 @@ let link_exe
   let exe = exe_path_from_name cctx ~name ~linkage in
   let compiler = Option.value_exn (Context.compiler ctx mode) in
   let kind = Mode.cm_kind mode in
-  let artifacts ~ext modules =
-    List.map modules ~f:(fun m ->
-      let path = Obj_dir.Module.obj_file obj_dir m ~kind ~ext in
-      Path.build path)
-  in
   let modules_and_cm_files =
     Build.memoize "cm files"
       (top_sorted_modules >>^ fun modules ->
        (modules,
-        artifacts modules ~ext:(Cm_kind.ext kind)))
+        Obj_dir.Module.L.cm_files obj_dir modules ~kind))
   in
   let register_native_objs_deps build =
     match mode with
@@ -151,7 +146,7 @@ let link_exe
     | Native ->
       build >>>
       Build.dyn_paths (Build.arr (fun (modules, _) ->
-        artifacts modules ~ext:ctx.ext_obj))
+        Obj_dir.Module.L.o_files obj_dir modules ~ext_obj:ctx.ext_obj))
   in
   (* The rule *)
   SC.add_rule sctx ~loc ~dir

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -127,6 +127,7 @@ let link_exe
   let sctx     = CC.super_context cctx in
   let ctx      = SC.context       sctx in
   let dir      = CC.dir           cctx in
+  let obj_dir  = CC.obj_dir cctx in
   let requires = CC.requires_link cctx in
   let expander = CC.expander      cctx in
   let mode = linkage.mode in
@@ -134,7 +135,9 @@ let link_exe
   let compiler = Option.value_exn (Context.compiler ctx mode) in
   let kind = Mode.cm_kind mode in
   let artifacts ~ext modules =
-    List.map modules ~f:(Module.obj_file ~kind ~ext)
+    List.map modules ~f:(fun m ->
+      let path = Obj_dir.Module.obj_file obj_dir m ~kind ~ext in
+      Path.build path)
   in
   let modules_and_cm_files =
     Build.memoize "cm files"

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -178,7 +178,6 @@ include Sub_system.Register_end_point(
       let main_module_filename = name ^ ".ml" in
       let main_module_name = Module.Name.of_string name in
       let modules =
-        let obj_dir = Obj_dir.of_local obj_dir in
         Module.Name.Map.singleton main_module_name
           (Module.make main_module_name
              ~impl:{ path =
@@ -188,8 +187,7 @@ include Sub_system.Register_end_point(
                    }
              ~kind:Impl
              ~visibility:Public
-             ~obj_name:name
-             ~obj_dir)
+             ~obj_name:name)
       in
 
       let bindings =

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -239,7 +239,7 @@ let lib_install_files sctx ~dir_contents ~dir ~sub_dir:lib_subdir
     in
     let virtual_library = Library.is_virtual lib in
     List.concat_map installable_modules ~f:(fun m ->
-      let cm_file_unsafe = Obj_dir.Module.cm_file_unsafe obj_dir m in
+      let cm_file_unsafe kind = Obj_dir.Module.cm_file_unsafe obj_dir m ~kind in
       let cmi_file =
         ( Module.visibility m
         , cm_file_unsafe Cmi

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -195,6 +195,7 @@ let lib_ppxs sctx ~(lib : Dune_file.Library.t) ~scope ~dir_kind =
 let lib_install_files sctx ~dir_contents ~dir ~sub_dir:lib_subdir
       ~scope ~dir_kind (lib : Library.t) =
   let loc = lib.buildable.loc in
+  let obj_dir = Dune_file.Library.obj_dir lib ~dir in
   let make_entry section ?sub_dir ?dst fn =
     ( Some loc
     , Install.Entry.make section fn
@@ -238,23 +239,24 @@ let lib_install_files sctx ~dir_contents ~dir ~sub_dir:lib_subdir
     in
     let virtual_library = Library.is_virtual lib in
     List.concat_map installable_modules ~f:(fun m ->
+      let cm_file_unsafe = Obj_dir.Module.cm_file_unsafe obj_dir m in
       let cmi_file =
         ( Module.visibility m
-        , Path.as_in_build_dir_exn (Module.cm_file_unsafe m Cmi)
+        , cm_file_unsafe Cmi
         )
       in
       let other_cm_files =
         [ if_ (native && Module.has_impl m)
-            [ Module.cm_file_unsafe m Cmx ]
+            [ cm_file_unsafe Cmx ]
         ; if_ (byte && Module.has_impl m && virtual_library)
-            [ Module.cm_file_unsafe m Cmo ]
+            [ cm_file_unsafe Cmo ]
         ; if_ (native && Module.has_impl m && virtual_library)
-            [ Module.obj_file m ~kind:Cmx ~ext:ctx.ext_obj ]
-        ; List.filter_map Ml_kind.all ~f:(Module.cmt_file m)
+            [ Obj_dir.Module.obj_file obj_dir m ~kind:Cmx ~ext:ctx.ext_obj ]
+        ; List.filter_map Ml_kind.all ~f:(Obj_dir.Module.cmt_file obj_dir m)
         ]
         |> List.concat
         |> List.map ~f:(fun f ->
-          (Visibility.Public, Path.as_in_build_dir_exn f))
+          (Visibility.Public, f))
       in
       cmi_file :: other_cm_files
     )

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -416,7 +416,8 @@ module Lib_and_module = struct
            | Lib t ->
              Command.Args.Deps (Mode.Dict.get t.info.archives mode)
            | Module (obj_dir, m) ->
-             Dep (Obj_dir.Module.cm_file_unsafe obj_dir m (Mode.cm_kind mode))
+             Dep (Obj_dir.Module.cm_file_unsafe obj_dir m
+                    ~kind:(Mode.cm_kind mode))
          ))
 
     let of_libs l = List.map l ~f:(fun x -> Lib x)

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -112,7 +112,7 @@ module Lib_and_module : sig
   type lib = t
   type t =
     | Lib of lib
-    | Module of Module.t
+    | Module of Path.t Obj_dir.t * Module.t
 
   module L : sig
     type nonrec t = t list

--- a/src/lib_modules.mli
+++ b/src/lib_modules.mli
@@ -40,17 +40,13 @@ val public_modules : t -> Module.Name_map.t
 
 val make
   :  Dune_file.Library.t
-  -> obj_dir:Path.t Obj_dir.t
+  -> src_dir:Path.t
   -> Module.Name_map.t
   -> main_module_name:Module.Name.t option
   -> wrapped:Wrapped.t
   -> t
 
 val set_modules : t -> Module.Name_map.t -> t
-
-(** [version_installed t ~install_dir] converts [t] to a version that represents
-    a library installed [install_dir]*)
-val version_installed : t -> install_dir:Path.t Obj_dir.t -> t
 
 (** Return all modules that need to be compiled. Includes the alias module if it
     exists. This does not include the compatibility modules which are compiled
@@ -63,7 +59,7 @@ val for_alias : t -> Module.Name_map.t
 val encode : t -> Dune_lang.t list
 
 val decode
-  : implements:bool -> obj_dir:Path.t Obj_dir.t -> t Dune_lang.Decoder.t
+  : implements:bool -> src_dir:Path.t -> t Dune_lang.Decoder.t
 
 val is_wrapped : t -> bool
 
@@ -72,3 +68,5 @@ val wrapped : t -> Wrapped.t
 (** Returns true if the collection of modules represented here needs an alias
     module. I.e. it's wrapped and has more than one module. *)
 val needs_alias_module : t -> bool
+
+val version_installed : t -> install_dir:Path.t -> t

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -45,22 +45,17 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         else
           Fn.id
       in
-      let artifacts ~ext modules =
-        List.map modules ~f:(fun m ->
-          let obj = Obj_dir.Module.obj_file obj_dir m ~kind ~ext in
-          Path.build obj)
-      in
+      let cm_files = Obj_dir.Module.L.cm_files obj_dir ~kind in
       let obj_deps =
-        Build.paths (artifacts modules ~ext:(Cm_kind.ext kind))
-      in
-      let obj_deps =
+        let obj_deps = Build.paths (cm_files modules) in
         match mode with
         | Byte   -> obj_deps
         | Native ->
           obj_deps >>>
-          Build.paths (artifacts modules ~ext:ctx.ext_obj)
+          Build.paths (
+            Obj_dir.Module.L.o_files obj_dir modules ~ext_obj:ctx.ext_obj)
       in
-      let cm_files = top_sorted_modules >>^artifacts ~ext:(Cm_kind.ext kind) in
+      let cm_files = top_sorted_modules >>^ cm_files in
       let ocaml_flags = Ocaml_flags.get flags mode in
       let cclibs = Expander.expand_and_eval_set expander lib.c_library_flags
                      ~standard:(Build.return []) in

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -212,7 +212,6 @@ module Run (P : PARAMS) : sig end = struct
         ~visibility:Public
         ~kind:Impl
         ~impl:{ path = Path.build (mock_ml base); syntax = OCaml }
-        ~obj_dir:(Obj_dir.of_local (Compilation_context.obj_dir cctx))
     in
 
     (* The following incantation allows the mock [.ml] file to be preprocessed

--- a/src/module.mli
+++ b/src/module.mli
@@ -86,7 +86,6 @@ val make
   -> ?intf:File.t
   -> ?obj_name:string
   -> visibility:Visibility.t
-  -> obj_dir:Path.t Obj_dir.t
   -> kind:Kind.t
   -> Name.t
   -> t
@@ -95,7 +94,6 @@ val make
 val of_source
   :  ?obj_name:string
   -> visibility:Visibility.t
-  -> obj_dir:Path.t Obj_dir.t
   -> kind:Kind.t
   -> Source.t
   -> t
@@ -107,30 +105,15 @@ val real_unit_name : t -> Name.t
 
 val intf : t -> File.t option
 val impl : t -> File.t option
-val obj_dir : t -> Path.t Obj_dir.t
 
 val pp_flags : t -> (unit, string list) Build.t option
 
 val file            : t -> Ml_kind.t -> Path.t option
 val cm_source       : t -> Cm_kind.t -> Path.t option
-val cm_file         : t -> Cm_kind.t -> Path.t option
-val cm_public_file  : t -> Cm_kind.t -> Path.t option
-val cmt_file        : t -> Ml_kind.t -> Path.t option
-
-val obj_file : t -> kind:Cm_kind.t -> ext:string -> Path.t
 
 val obj_name : t -> string
 
-(** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx]
-    and the module has no implementation.
- *)
-val cm_file_unsafe : t -> Cm_kind.t -> Path.t
-val cm_public_file_unsafe : t -> Cm_kind.t -> Path.t
-
 val odoc_file : t -> doc_dir:Path.Build.t -> Path.Build.t
-
-(** Either the .cmti, or .cmt if the module has no interface *)
-val cmti_file : t -> Path.t
 
 val iter : t -> f:(Ml_kind.t -> File.t -> unit) -> unit
 
@@ -181,7 +164,6 @@ val is_private : t -> bool
 val is_virtual : t -> bool
 
 val set_private : t -> t
-val set_obj_dir : t -> obj_dir:Path.t Obj_dir.t -> t
 val set_virtual : t -> t
 
 val sources : t -> Path.t list
@@ -190,10 +172,12 @@ val visibility : t -> Visibility.t
 
 val encode : t -> Dune_lang.t list
 
-val decode : obj_dir:Path.t Obj_dir.t -> t Dune_lang.Decoder.t
+val decode : src_dir:Path.t -> t Dune_lang.Decoder.t
 
 (** [pped m] return [m] but with the preprocessed source paths paths *)
 val pped : t -> t
 
 (** [ml_source m] returns [m] but with the OCaml syntax source paths *)
 val ml_source : t -> t
+
+val set_src_dir : t -> src_dir:Path.t -> t

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -33,16 +33,15 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
   |> Option.iter ~f:(fun compiler ->
     Option.iter (Module.cm_source m cm_kind) ~f:(fun src ->
       let ml_kind = Cm_kind.source cm_kind in
-      let dst = Path.as_in_build_dir_exn (Module.cm_file_unsafe m cm_kind) in
+      let dst = Obj_dir.Module.cm_file_unsafe obj_dir m cm_kind in
       let copy_interface () =
         (* symlink the .cmi into the public interface directory *)
         if not (Module.is_private m)
         && (Obj_dir.need_dedicated_public_dir obj_dir) then
           SC.add_rule sctx ~sandbox:false ~dir
             (Build.symlink
-               ~src:(Module.cm_file_unsafe m Cmi)
-               ~dst:(Path.as_in_build_dir_exn
-                       (Module.cm_public_file_unsafe m Cmi))
+               ~src:(Path.build (Obj_dir.Module.cm_file_unsafe obj_dir m Cmi))
+               ~dst:(Obj_dir.Module.cm_public_file_unsafe obj_dir m Cmi)
             )
       in
       let extra_args, extra_deps, other_targets =
@@ -54,11 +53,11 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
            conditions. *)
         | Cmo, None, false ->
           copy_interface ();
-          [], [], [Path.as_in_build_dir_exn (Module.cm_file_unsafe m Cmi)]
+          [], [], [Obj_dir.Module.cm_file_unsafe obj_dir m Cmi]
         | Cmo, None, true
         | (Cmo | Cmx), _, _ ->
           force_read_cmi src,
-          [Module.cm_file_unsafe m Cmi],
+          [Path.build (Obj_dir.Module.cm_file_unsafe obj_dir m Cmi)],
           []
         | Cmi, _, _ ->
           copy_interface ();
@@ -66,9 +65,8 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
       in
       let other_targets =
         match cm_kind with
-        | Cmx ->
-          Path.as_in_build_dir_exn
-            (Module.obj_file m ~kind:Cmx ~ext:ctx.ext_obj) :: other_targets
+        | Cmx -> (Obj_dir.Module.obj_file obj_dir m ~kind:Cmx ~ext:ctx.ext_obj)
+                 :: other_targets
         | Cmi | Cmo -> other_targets
       in
       let dep_graph = Ml_kind.Dict.get dep_graphs ml_kind in
@@ -78,9 +76,10 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
           (Dep_graph.deps_of dep_graph m >>^ fun deps ->
            List.concat_map deps
              ~f:(fun m ->
-               let deps = [Module.cm_file_unsafe m Cmi] in
+               let deps = [Path.build (Obj_dir.Module.cm_file_unsafe obj_dir m Cmi)] in
                if Module.has_impl m && cm_kind = Cmx && not opaque then
-                 Module.cm_file_unsafe m Cmx :: deps
+                 let cmx = Obj_dir.Module.cm_file_unsafe obj_dir m Cmx in
+                 Path.build cmx :: deps
                else
                  deps))
       in
@@ -89,8 +88,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
         | Cmx -> (other_targets, Command.Args.S [])
         | Cmi | Cmo ->
           let fn =
-            Path.as_in_build_dir_exn (Option.value_exn
-                                        (Module.cmt_file m ml_kind)) in
+            Option.value_exn (Obj_dir.Module.cmt_file obj_dir m ml_kind) in
           (fn :: other_targets, A "-bin-annot")
       in
       if CC.dir_kind cctx = Jbuild then begin
@@ -186,7 +184,8 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
     (* Build *.cmo.js *)
     let sctx     = CC.super_context cctx in
     let dir      = CC.dir           cctx in
-    let src = Path.as_in_build_dir_exn (Module.cm_file_unsafe m Cm_kind.Cmo) in
+    let obj_dir = CC.obj_dir cctx in
+    let src = Obj_dir.Module.cm_file_unsafe obj_dir m Cm_kind.Cmo in
     let target = Path.Build.extend_basename src ~suffix:".js" in
     SC.add_rules sctx ~dir
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
@@ -210,7 +209,7 @@ let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
     Build.dyn_paths
       (Dep_graph.deps_of dep_graph m >>^ fun deps ->
        List.concat_map deps
-         ~f:(fun m -> [Module.cm_file_unsafe m Cmi]))
+         ~f:(fun m -> [Path.build (Obj_dir.Module.cm_file_unsafe obj_dir m Cmi)]))
   in
   let ocaml_flags = Ocaml_flags.get_for_cm (CC.flags cctx) ~cm_kind:Cmo
   in

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -173,7 +173,6 @@ let check_invalid_module_listing ~(buildable : Buildable.t) ~intf_only
     errors.spurious_modules_virtual
 
 let eval ~modules:(all_modules : Module.Source.t Module.Name.Map.t)
-      ~obj_dir
       ~buildable:(conf : Buildable.t) ~virtual_modules
       ~private_modules =
   (* fake modules are modules that doesn't exists but it doesn't
@@ -211,7 +210,6 @@ let eval ~modules:(all_modules : Module.Source.t Module.Name.Map.t)
   check_invalid_module_listing ~buildable:conf ~intf_only
     ~modules ~virtual_modules ~private_modules;
   let all_modules =
-    let obj_dir = Obj_dir.of_local obj_dir in
     Module.Name.Map.map modules ~f:(fun (_, m) ->
       let name = Module.Source.name m in
       let visibility =
@@ -228,9 +226,6 @@ let eval ~modules:(all_modules : Module.Source.t Module.Name.Map.t)
         else
           Intf_only
       in
-      Module.of_source m
-        ~kind
-        ~visibility
-        ~obj_dir)
+      Module.of_source m ~kind ~visibility)
   in
   all_modules

--- a/src/modules_field_evaluator.mli
+++ b/src/modules_field_evaluator.mli
@@ -1,8 +1,7 @@
-open Stdune
+open! Stdune
 
 val eval
   :  modules:(Module.Source.t Module.Name.Map.t)
-  -> obj_dir:Path.Build.t Obj_dir.t
   -> buildable:Dune_file.Buildable.t
   -> virtual_modules:Ordered_set_lang.t option
   -> private_modules:Ordered_set_lang.t

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -87,3 +87,22 @@ val as_local_exn : Path.t t -> Path.Build.t t
 val need_dedicated_public_dir : Path.Build.t t -> bool
 
 val to_local : Path.t t -> Path.Build.t t option
+
+module Module : sig
+  (** The functions in this this module gives the paths to the various
+      object files produced from the compilation of a module (.cmi
+      files, .cmx files, .o files, ...) *)
+
+  val cm_file        : 'path t -> Module.t -> Cm_kind.t -> 'path option
+  val cm_public_file : 'path t -> Module.t -> Cm_kind.t -> 'path option
+  val cmt_file       : 'path t -> Module.t -> Ml_kind.t -> 'path option
+  val obj_file       : 'path t -> Module.t -> kind:Cm_kind.t -> ext:string -> 'path
+
+  (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx] and the
+      module has no implementation.*)
+  val cm_file_unsafe : 'path t -> Module.t -> Cm_kind.t -> 'path
+  val cm_public_file_unsafe : 'path t -> Module.t -> Cm_kind.t -> 'path
+
+  (** Either the .cmti, or .cmt if the module has no interface *)
+  val cmti_file : 'path t -> Module.t -> 'path
+end

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -93,16 +93,21 @@ module Module : sig
       object files produced from the compilation of a module (.cmi
       files, .cmx files, .o files, ...) *)
 
-  val cm_file        : 'path t -> Module.t -> Cm_kind.t -> 'path option
-  val cm_public_file : 'path t -> Module.t -> Cm_kind.t -> 'path option
+  val cm_file        : 'path t -> Module.t -> kind:Cm_kind.t -> 'path option
+  val cm_public_file : 'path t -> Module.t -> kind:Cm_kind.t -> 'path option
   val cmt_file       : 'path t -> Module.t -> Ml_kind.t -> 'path option
   val obj_file       : 'path t -> Module.t -> kind:Cm_kind.t -> ext:string -> 'path
 
   (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx] and the
       module has no implementation.*)
-  val cm_file_unsafe : 'path t -> Module.t -> Cm_kind.t -> 'path
-  val cm_public_file_unsafe : 'path t -> Module.t -> Cm_kind.t -> 'path
+  val cm_file_unsafe : 'path t -> Module.t -> kind:Cm_kind.t -> 'path
+  val cm_public_file_unsafe : 'path t -> Module.t -> kind:Cm_kind.t -> 'path
 
   (** Either the .cmti, or .cmt if the module has no interface *)
   val cmti_file : 'path t -> Module.t -> 'path
+
+  module L : sig
+    val o_files : 'path t -> Module.t list -> ext_obj:string -> Path.t list
+    val cm_files : 'path t -> Module.t list -> kind:Cm_kind.t -> Path.t list
+  end
 end

--- a/src/odoc.boot.ml
+++ b/src/odoc.boot.ml
@@ -1,4 +1,4 @@
-let setup_library_odoc_rules _ _ ~scope:_ ~modules:_ ~requires:_
+let setup_library_odoc_rules _ _ ~obj_dir:_ ~scope:_ ~modules:_ ~requires:_
       ~dep_graphs:_ = ()
 
 let init _ = ()

--- a/src/odoc.mli
+++ b/src/odoc.mli
@@ -7,6 +7,7 @@ open Dune_file
 val setup_library_odoc_rules
   :  Super_context.t
   -> Library.t
+  -> obj_dir:Path.Build.t Obj_dir.t
   -> scope:Scope.t
   -> modules:Module.t Module.Name.Map.t
   -> requires:Lib.t list Or_exn.t

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -18,7 +18,6 @@ module Source = struct
     Obj_dir.make_exe ~dir ~name
 
   let modules t =
-    let obj_dir = Obj_dir.of_local (obj_dir t) in
     let main_module_name = main_module_name t in
     Module.Name.Map.singleton
       main_module_name
@@ -27,7 +26,6 @@ module Source = struct
          ~impl:{ path   = Path.build (source_path t)
                ; syntax = Module.Syntax.OCaml
                }
-         ~obj_dir
          ~kind:Module.Kind.Impl
          ~obj_name:t.name)
 

--- a/src/vimpl.ml
+++ b/src/vimpl.ml
@@ -15,7 +15,8 @@ let impl t = t.impl
 let vlib_dep_graph t = t.vlib_dep_graph
 
 let from_vlib_to_impl_module t m =
-  Module.set_obj_dir ~obj_dir:(Obj_dir.of_local t.obj_dir) m
+  let src_dir = Path.build (Obj_dir.dir t.obj_dir) in
+  Module.set_src_dir m ~src_dir
 
 let make ~vlib ~impl ~dir ~vlib_modules ~vlib_foreign_objects ~vlib_dep_graph =
   { impl

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -44,8 +44,8 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     Dune_file.Mode_conf.Set.eval impl.modes
       ~has_native:(Option.is_some ctx.ocamlopt) in
   let copy_obj_file m kind =
-    let src = Obj_dir.Module.cm_file_unsafe vlib_obj_dir m kind in
-    let dst = Obj_dir.Module.cm_file_unsafe impl_obj_dir m kind in
+    let src = Obj_dir.Module.cm_file_unsafe vlib_obj_dir m ~kind in
+    let dst = Obj_dir.Module.cm_file_unsafe impl_obj_dir m ~kind in
     copy_to_obj_dir ~src ~dst
   in
   let copy_objs src =
@@ -54,9 +54,9 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     && Obj_dir.need_dedicated_public_dir impl_obj_dir
     then begin
       let dst =
-        Obj_dir.Module.cm_public_file_unsafe impl_obj_dir src Cmi in
+        Obj_dir.Module.cm_public_file_unsafe impl_obj_dir src ~kind:Cmi in
       let src =
-        Obj_dir.Module.cm_public_file_unsafe vlib_obj_dir src Cmi in
+        Obj_dir.Module.cm_public_file_unsafe vlib_obj_dir src ~kind:Cmi in
       copy_to_obj_dir ~src ~dst
     end;
     if Module.has_impl src then begin
@@ -184,7 +184,7 @@ let external_dep_graph sctx ~impl_cm_kind ~impl_obj_dir ~vlib_modules =
     let ctx = Super_context.context sctx in
     fun m cm_kind ->
       let unit =
-        Obj_dir.Module.cm_file_unsafe impl_obj_dir m cm_kind
+        Obj_dir.Module.cm_file_unsafe impl_obj_dir m ~kind:cm_kind
         |> Path.build
       in
       Ocamlobjinfo.rules ~dir ~ctx ~unit


### PR DESCRIPTION
All cm files are now fetched through Obj_dir.Module instead of Module.
This means that we don't need an obj_dir in Module.t anymore.

As discussed in the email. I will update this description with those details later. 