### PR TITLE
Path.Kind cleanup

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -49,7 +49,7 @@ let set_dirs c =
   if c.root.dir <> Filename.current_dir_name then
     Sys.chdir c.root.dir;
   Path.set_root (Path.External.cwd ());
-  Path.Build.set_build_dir (Path.Kind.of_string c.build_dir)
+  Path.Build.set_build_dir (Path.Build.Kind.of_string c.build_dir)
 
 let set_common_other c ~targets =
   Clflags.debug_dep_path := c.debug_dep_path;

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -69,7 +69,7 @@ let term =
       }
     in
     Path.set_root (Path.External.cwd ());
-    Path.Build.set_build_dir (Path.Kind.of_string Common.default_build_dir);
+    Path.Build.set_build_dir (Path.Build.Kind.of_string Common.default_build_dir);
     Dune.Scheduler.go ~config Watermarks.subst
 
 let command = term, info

--- a/src/dep_path.ml
+++ b/src/dep_path.ml
@@ -10,8 +10,8 @@ module Entry = struct
     | Loc of Loc.t
 
   let to_string = function
-    | Path p -> Utils.describe_target p
-    | Alias p -> "alias " ^ Utils.describe_target p
+    | Path p -> Utils.describe_path p
+    | Alias p -> "alias " ^ Utils.describe_path p
     | Library (path, lib_name) ->
       Format.asprintf "library %a in %s" Lib_name.pp_quoted lib_name
         (Path.to_string_maybe_quoted path)

--- a/src/main.ml
+++ b/src/main.ml
@@ -162,7 +162,7 @@ let set_concurrency ?log (config : Config.t) =
 let bootstrap () =
   Colors.setup_err_formatter_colors ();
   Path.set_root Path.External.initial_cwd;
-  Path.Build.set_build_dir (Path.Kind.of_string "_boot");
+  Path.Build.set_build_dir (Path.Build.Kind.of_string "_boot");
   let main () =
     let anon s = raise (Arg.Bad (Printf.sprintf "don't know what to do with %s\n" s)) in
     let subst () =

--- a/src/path_dune_lang.ml
+++ b/src/path_dune_lang.ml
@@ -4,22 +4,19 @@ open Path
 type t = Path.t
 
 let encode p =
-  let arg =
-    match Internal.raw_kind p with
-    | Kind.External l -> External.to_string l
-    | Kind.Local    l -> Local.to_string l
+  let make constr arg =
+    Dune_lang.List [
+      Dune_lang.atom constr
+    ; Dune_lang.atom_or_quoted_string arg
+    ]
   in
-  let make constr =
-    Dune_lang.List [ Dune_lang.atom constr
-               ; Dune_lang.atom_or_quoted_string arg
-               ]
-  in
-  if is_in_build_dir p then
-    make "In_build_dir"
-  else if is_in_source_tree p then
-    make "In_source_tree"
-  else
-    make "External"
+  match p with
+  | In_build_dir p ->
+    make "In_build_dir" (Path.Build.to_string p)
+  | In_source_tree p ->
+    make "In_source_tree" (Path.Source.to_string p)
+  | External p ->
+    make "External" (Path.External.to_string p)
 
 let decode =
   let open Dune_lang.Decoder in

--- a/src/process.ml
+++ b/src/process.ml
@@ -195,9 +195,9 @@ module Fancy = struct
         | [] -> List.rev targets_acc, String.Set.(to_list (of_list ctxs_acc))
         | path :: rest ->
           let add_ctx ctx acc = if ctx = "default" then acc else ctx :: acc in
-          match Utils.analyse_target (Path.build path) with
+          match Utils.analyse_target path with
           | Other path ->
-            split_paths (Path.to_string path :: targets_acc) ctxs_acc rest
+            split_paths (Path.Build.to_string path :: targets_acc) ctxs_acc rest
           | Regular (ctx, filename) ->
             split_paths (Path.Source.to_string filename :: targets_acc)
               (add_ctx ctx ctxs_acc) rest
@@ -209,7 +209,9 @@ module Fancy = struct
               (add_ctx ctx ctxs_acc) rest
       in
       let targets = Path.Build.Set.to_list targets in
-      let target_names, contexts = split_paths [] [] targets in
+      let target_names, contexts =
+        split_paths [] [] targets
+      in
       let target_names_grouped_by_prefix =
         List.map target_names ~f:Filename.split_extension_after_dot
         |> String.Map.of_list_multi

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -652,6 +652,8 @@ module Build = struct
           |> Source0.of_string )
     end
 
+  let extract_first_component = extract_build_context
+
   let extract_build_context_dir t =
     let t_str = Local.to_string t in
     begin match String.lsplit2 t_str ~on:'/' with

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -544,7 +544,7 @@ module Relative_to_source_root : sig
 end = struct
 
   open Local
-  
+
   let rec mkdir_p t =
     if is_root t then
       ()
@@ -675,9 +675,11 @@ module Build = struct
         [ "t", to_dyn t
         ]
 
+  (* CR-someday rgrinberg:
+     I think we should just move this function to the alias module. *)
   let is_alias_stamp_file s =
-    String.is_prefix (Local.to_string s) ~prefix:".aliases/"  
-  
+    String.is_prefix (Local.to_string s) ~prefix:".aliases/"
+
   let (build_dir_kind, build_dir_prefix, set_build_dir) =
     let build_dir = ref None in
     let build_dir_prefix = ref None in
@@ -852,7 +854,7 @@ let of_filename_relative_to_initial_cwd fn =
     else
       External.of_string fn
   )
-                    
+
 let to_absolute_filename t =
   Kind.to_absolute_filename (kind t)
 

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1243,13 +1243,6 @@ let build s = in_build_dir s
 
 module Table = Hashtbl.Make(T)
 
-module Internal = struct
-  let raw_kind = function
-    | In_build_dir l -> Kind.Local l
-    | In_source_tree l -> Local l
-    | External l -> External l
-end
-
 module L = struct
   (* TODO more efficient implementation *)
   let relative t = List.fold_left ~init:t ~f:relative

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -585,53 +585,41 @@ let (abs_root, set_root) =
   in
   (abs_root, set_root)
 
-
 module Kind = struct
   type t =
     | External of External.t
-    | Local    of Local.t
+    | In_source_dir of Local.t
 
   let to_absolute_filename t =
     match t with
     | External s -> External.to_string s
-    | Local l ->
+    | In_source_dir l ->
       External.to_string
         (External.relative (Lazy.force abs_root)
            (Local.to_string l))
 
   let to_string = function
-    | Local t -> Local.to_string t
+    | In_source_dir t -> Local.to_string t
     | External t -> External.to_string t
 
   let to_dyn t = Dyn.String (to_string t)
 
   let of_string s =
     if Filename.is_relative s then
-      Local (Local.of_string s)
+      In_source_dir (Local.of_string s)
     else
       External (External.of_string s)
 
-  let _ =
-    let root = Local Local.root in
-    assert (of_string ""  = root);
-    assert (of_string "." = root)
-
-  let _relative ?error_loc t fn =
-    match t with
-    | Local t -> Local (Local.relative ?error_loc t fn)
-    | External t -> External (External.relative t fn)
-
   let mkdir_p = function
-    | Local t -> Relative_to_source_root.mkdir_p t
+    | In_source_dir t -> Relative_to_source_root.mkdir_p t
     | External t -> External.mkdir_p t
 
   let append_local x y =
     match x with
-    | Local x -> Local (Local.append x y)
+    | In_source_dir x -> In_source_dir (Local.append x y)
     | External x -> External (External.relative x (Local.to_string y))
 
 end
-
 
 module Build = struct
   include Local
@@ -688,8 +676,8 @@ module Build = struct
         ]
 
   let is_alias_stamp_file s =
-    String.is_prefix (Local.to_string s) ~prefix:".aliases/"
-
+    String.is_prefix (Local.to_string s) ~prefix:".aliases/"  
+  
   let (build_dir_kind, build_dir_prefix, set_build_dir) =
     let build_dir = ref None in
     let build_dir_prefix = ref None in
@@ -698,7 +686,7 @@ module Build = struct
       | None ->
         (match new_build_dir with
          | External _ -> ()
-         | Local p ->
+         | In_source_dir p ->
            if Local.is_root p || Local.parent_exn p <> Local.root then
              User_error.raise
                [ Pp.textf "Invalid build directory: %s"
@@ -710,7 +698,7 @@ module Build = struct
         build_dir := Some new_build_dir;
         build_dir_prefix :=
           Some (match new_build_dir with
-            | Local    p -> Local.Prefix.make p
+            | In_source_dir p -> Local.Prefix.make p
             | External _ -> Local.Prefix.invalid)
       | Some build_dir ->
         Code_error.raise "set_build_dir: cannot set build_dir more than once"
@@ -733,12 +721,14 @@ module Build = struct
 
   let to_string p =
     match Lazy.force build_dir_kind with
-    | Local    b -> Local.to_string (Local.append b p)
+    | In_source_dir b -> Local.to_string (Local.append b p)
     | External b ->
       if Local.is_root p then
         External.to_string b
       else
         Filename.concat (External.to_string b) (Local.to_string p)
+
+  module Kind = Kind
 end
 
 module T : sig
@@ -793,7 +783,7 @@ module Map = Map.Make(T)
 
 let kind = function
   | In_build_dir p -> Kind.append_local (Lazy.force Build.build_dir_kind) p
-  | In_source_tree s -> Kind.Local s
+  | In_source_tree s -> Kind.In_source_dir s
   | External s -> Kind.External s
 
 let is_managed = function
@@ -862,8 +852,9 @@ let of_filename_relative_to_initial_cwd fn =
     else
       External.of_string fn
   )
-
-let to_absolute_filename t = Kind.to_absolute_filename (kind t)
+                    
+let to_absolute_filename t =
+  Kind.to_absolute_filename (kind t)
 
 let external_of_local x ~root =
   External.to_string (External.relative root (Local.to_string x))
@@ -878,18 +869,18 @@ let reach t ~from =
   | In_build_dir   t, In_build_dir   from -> Local.reach t ~from
   | In_source_tree t, In_build_dir from -> begin
       match Lazy.force Build.build_dir_kind with
-      | Local    b -> Local.reach t ~from:(Local.append b from)
+      | In_source_dir b -> Local.reach t ~from:(Local.append b from)
       | External _ -> external_of_in_source_tree t
     end
   | In_build_dir t, In_source_tree from -> begin
       match Lazy.force Build.build_dir_kind with
-      | Local    b -> Local.reach (Local.append b t) ~from
+      | In_source_dir b -> Local.reach (Local.append b t) ~from
       | External b -> external_of_local t ~root:b
     end
   | In_source_tree t, External _ -> external_of_in_source_tree t
   | In_build_dir t, External _ ->
     match Lazy.force Build.build_dir_kind with
-    | Local    b -> external_of_in_source_tree (Local.append b t)
+    | In_source_dir b -> external_of_in_source_tree (Local.append b t)
     | External b -> external_of_local t ~root:b
 
 let reach_for_running ?(from=root) t =
@@ -933,7 +924,7 @@ let append a b =
 
 let basename t =
   match kind t with
-  | Local t -> Local.basename t
+  | In_source_dir t -> Local.basename t
   | External t -> External.basename t
 
 let parent = function
@@ -1050,7 +1041,7 @@ let sandbox_managed_paths =
 
 let split_first_component t =
   match kind t, is_root t with
-  | Local t, false ->
+  | In_source_dir t, false ->
     let t = Local.to_string t in
     begin match String.lsplit2 t ~on:'/' with
     | None -> Some (t, root)
@@ -1065,8 +1056,8 @@ let split_first_component t =
 
 let explode t =
   match kind t with
-  | Local p when Local.is_root p -> Some []
-  | Local s -> Some (String.split (Local.to_string s) ~on:'/')
+  | In_source_dir p when Local.is_root p -> Some []
+  | In_source_dir s -> Some (String.split (Local.to_string s) ~on:'/')
   | External _ -> None
 
 let explode_exn t =
@@ -1126,7 +1117,7 @@ let build_dir_exists () = is_directory build_dir
 
 let ensure_build_dir_exists () =
   match kind build_dir with
-  | Local p -> Relative_to_source_root.mkdir_p p
+  | In_source_dir p -> Relative_to_source_root.mkdir_p p
   | External p ->
     let p = External.to_string p in
     try

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -96,7 +96,7 @@ module Build : sig
   val extract_build_context_dir : t -> (t * Source.t) option
   val extract_build_context_dir_exn : t -> (t * Source.t)
 
-  (** This function does the same as [extract_build_context], but gas a
+  (** This function does the same as [extract_build_context], but has a
       "righter" type.  *)
   val extract_first_component : t -> (string * Local.t) option
 
@@ -109,7 +109,7 @@ module Build : sig
 
     val of_string : string -> t
   end
-  
+
   (** set the build directory. Can only be called once and must be done before
       paths are converted to strings elsewhere. *)
   val set_build_dir : Kind.t -> unit

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -64,14 +64,6 @@ module External : sig
   val mkdir_p : t -> unit
 end
 
-module Kind : sig
-  type t = private
-    | External of External.t
-    | Local    of Local.t
-
-  val of_string : string -> t
-end
-
 module Build : sig
   type w
 
@@ -110,6 +102,14 @@ module Build : sig
 
   val is_alias_stamp_file : t -> bool
 
+  module Kind : sig
+    type t = private
+      | External of External.t
+      | In_source_dir of Local.t
+
+    val of_string : string -> t
+  end
+  
   (** set the build directory. Can only be called once and must be done before
       paths are converted to strings elsewhere. *)
   val set_build_dir : Kind.t -> unit
@@ -126,8 +126,6 @@ val hash : t -> int
 
 (** [to_string_maybe_quoted t] is [maybe_quoted (to_string t)] *)
 val to_string_maybe_quoted : t -> string
-
-val kind : t -> Kind.t
 
 val root : t
 val is_root : t -> bool

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -109,8 +109,12 @@ module Build : sig
   val set_build_dir : Kind.t -> unit
 end
 
-(** In the outside world *)
-include Path_intf.S
+type t = private
+  | External of External.t
+  | In_source_tree of Source.t
+  | In_build_dir of Build.t
+
+include Path_intf.S with type t := t
 
 val hash : t -> int
 
@@ -238,11 +242,6 @@ val of_local : Local.t -> t
 (** Set the workspace root. Can only be called once and the path must be
     absolute *)
 val set_root : External.t -> unit
-
-(** Internal use only *)
-module Internal : sig
-  val raw_kind : t -> Kind.t
-end
 
 module L : sig
   val relative : t -> string list -> t

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -97,10 +97,16 @@ module Build : sig
   val drop_build_context     : t -> Source.t option
   val drop_build_context_exn : t -> Source.t
 
+  (** [Source.t] here is a lie in some cases: consider when the context name
+      happens to be ["install"] or [".alias"]. *)
   val extract_build_context  : t -> (string * Source.t) option
   val extract_build_context_exn  : t -> (string * Source.t)
   val extract_build_context_dir : t -> (t * Source.t) option
   val extract_build_context_dir_exn : t -> (t * Source.t)
+
+  (** This function does the same as [extract_build_context], but gas a
+      "righter" type.  *)
+  val extract_first_component : t -> (string * Local.t) option
 
   val is_alias_stamp_file : t -> bool
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -701,7 +701,7 @@ module Action = struct
           "This action has targets in a different directory than the current \
            one, this is not allowed by dune at the moment:\n%s"
           (List.map targets ~f:(fun target ->
-             sprintf "- %s" (Utils.describe_target (Path.build target)))
+             sprintf "- %s" (Utils.describe_path (Path.build target)))
            |> String.concat ~sep:"\n"));
     let build =
       Build.record_lib_deps (Expander.Resolved_forms.lib_deps forms)

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -13,7 +13,8 @@ val bash_exn : needed_to:string -> Path.t
 val signal_name : int -> string
 
 (** Nice description of a target *)
-val describe_target : Path.t -> string
+val describe_target : Path.Build.t -> string
+val describe_path : Path.t -> string
 
 (** Return the directory where the object files for the given
     library should be stored. *)
@@ -41,10 +42,16 @@ type target_kind =
   | Regular of string (* build context *) * Path.Source.t
   | Alias   of string (* build context *) * Path.Source.t
   | Install of string (* build context *) * Path.Source.t
-  | Other of Path.t
+  | Other of Path.Build.t
+
+type path_kind =
+  | Source of Path.Source.t
+  | External of Path.External.t
+  | Build of target_kind
 
 (** Return the name of an alias from its stamp file *)
-val analyse_target : Path.t -> target_kind
+val analyse_target : Path.Build.t -> target_kind
+val analyse_path : Path.t -> path_kind
 
 (** Raise an error about a program not found in the PATH or in the tree *)
 val program_not_found

--- a/test/unit-tests/action.mlt
+++ b/test/unit-tests/action.mlt
@@ -5,7 +5,7 @@
 open Stdune;;
 open Dune;;
 open Action_unexpanded.Infer.Outcome;;
-Stdune.Path.Build.set_build_dir (Path.Kind.of_string "_build");;
+Stdune.Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");;
 
 let p = Path.of_string;;
 let infer (a : Action.t) =

--- a/test/unit-tests/path.mlt
+++ b/test/unit-tests/path.mlt
@@ -1,7 +1,7 @@
 (* -*- tuareg -*- *)
 open! Stdune;;
 Path.set_root (Path.External.cwd ());
-Path.Build.set_build_dir (Path.Kind.of_string "_build");
+Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");
 
 Printexc.record_backtrace false;;
 

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -7,7 +7,7 @@ open Import
 
 let () =
   Path.set_root (Path.External.cwd ());
-  Path.Build.set_build_dir (Path.Kind.of_string "_build")
+  Path.Build.set_build_dir (Path.Build.Kind.of_string "_build")
 ;;
 
 let print_pkg ppf pkg =

--- a/test/unit-tests/vcs.mlt
+++ b/test/unit-tests/vcs.mlt
@@ -8,7 +8,7 @@ let printf = Printf.printf;;
 
 let () =
   Path.set_root (Path.External.cwd ());
-  Path.Build.set_build_dir (Path.Kind.of_string "_build")
+  Path.Build.set_build_dir (Path.Build.Kind.of_string "_build")
 ;;
 
 let temp_dir = Path.of_string "vcs-tests";;


### PR DESCRIPTION
Clean up various things that were matching on path kind.
Rewrite the two things that were actually using `Path.kind` or `Path.kind_raw` to match on path directly.
Rename Path.Kind -> Path.Build.Kind because it's only used to set the build directory root now.

And rename its constructor Local -> In_source_dir to remove the confusion between the Local module and this thing.