### PR TITLE
Move ocamldep artifacts to Obj_dir

### DIFF
--- a/src/module.ml
+++ b/src/module.ml
@@ -86,6 +86,8 @@ module File = struct
     ; syntax : Syntax.t
     }
 
+  let path t = t.path
+
   let set_src_dir t ~src_dir =
     let path = Path.relative src_dir (Path.basename t.path) in
     { t with path }
@@ -254,13 +256,14 @@ let is_public t = Visibility.is_public t.visibility
 let is_private t = Visibility.is_private t.visibility
 let is_virtual t = Kind.is_virtual t.kind
 
+let source t (kind : Ml_kind.t) =
+  match kind with
+  | Impl -> t.source.impl
+  | Intf -> t.source.intf
+
 let file t (kind : Ml_kind.t) =
-  let file =
-    match kind with
-    | Impl -> t.source.impl
-    | Intf -> t.source.intf
-  in
-  Option.map file ~f:(fun f -> f.path)
+  source t kind
+  |> Option.map ~f:File.path
 
 let obj_name t = t.obj_name
 

--- a/src/module.mli
+++ b/src/module.mli
@@ -49,6 +49,8 @@ module File : sig
     ; syntax : Syntax.t
     }
 
+  val path : t -> Path.t
+
   val make : Syntax.t -> Path.t -> t
 end
 
@@ -105,6 +107,8 @@ val real_unit_name : t -> Name.t
 
 val intf : t -> File.t option
 val impl : t -> File.t option
+
+val source : t -> Ml_kind.t -> File.t option
 
 val pp_flags : t -> (unit, string list) Build.t option
 

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -345,6 +345,21 @@ module Module = struct
     ) in
     obj_file t m ~kind:Cmi ~ext
 
+  module Dep = struct
+    type t =
+      | Immediate
+      | Transitive
+
+    let ext = function
+      | Immediate -> ".d"
+      | Transitive -> ".all-deps"
+  end
+
+  let dep t file ~kind =
+    let dir = obj_dir t in
+    let name = Path.basename (Module.File.path file) in
+    let ext = Dep.ext kind in
+    Path.Build.relative dir (name ^ ext)
 
   module L = struct
     let o_files t modules ~ext_obj =

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -110,4 +110,12 @@ module Module : sig
     val o_files : 'path t -> Module.t list -> ext_obj:string -> Path.t list
     val cm_files : 'path t -> Module.t list -> kind:Cm_kind.t -> Path.t list
   end
+
+  module Dep : sig
+    type t =
+      | Immediate
+      | Transitive
+  end
+
+  val dep : Path.Build.t t -> Module.File.t -> kind:Dep.t -> Path.Build.t
 end

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -73,24 +73,21 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     end
   in
   let copy_all_deps =
-    let all_deps ~obj_dir f =
-      Path.Build.relative obj_dir (Path.basename f ^ ".all-deps") in
-    if Lib.is_local vlib then
+    match Lib.Local.of_lib vlib with
+    | Some vlib ->
+      let vlib_obj_dir = Lib.Local.obj_dir vlib in
       fun m ->
         if Module.is_public m then
           List.iter [Intf; Impl] ~f:(fun kind ->
-            Module.file m kind
+            Module.source m kind
             |> Option.iter ~f:(fun f ->
-              copy_to_obj_dir
-                ~src:(Path.build
-                        (all_deps
-                           ~obj_dir:
-                           (Path.as_in_build_dir_exn
-                              (Obj_dir.obj_dir vlib_obj_dir)) f))
-                ~dst:(all_deps
-                        ~obj_dir:(Obj_dir.obj_dir impl_obj_dir) f))
+              let kind = Obj_dir.Module.Dep.Transitive in
+              let src =
+                Path.build (Obj_dir.Module.dep vlib_obj_dir f ~kind) in
+              let dst = Obj_dir.Module.dep impl_obj_dir f ~kind in
+              copy_to_obj_dir ~src ~dst)
           );
-    else
+    | None ->
       (* we only need to copy the .all-deps files for local libraries. for
          remote libraries, we just use ocamlobjinfo *)
       let vlib_dep_graph = Vimpl.vlib_dep_graph vimpl in
@@ -98,7 +95,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
         List.iter [Intf; Impl] ~f:(fun kind ->
           let dep_graph = Ml_kind.Dict.get vlib_dep_graph kind in
           let deps = Dep_graph.deps_of dep_graph m in
-          Module.file m kind |> Option.iter ~f:(fun f ->
+          Module.source m kind |> Option.iter ~f:(fun source ->
             let open Build.O in
             deps >>^ (fun modules ->
               modules
@@ -106,7 +103,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
               |> String.concat ~sep:"\n")
             >>>
             Build.write_file_dyn
-              (all_deps ~obj_dir:(Obj_dir.obj_dir impl_obj_dir) f)
+              (Obj_dir.Module.dep impl_obj_dir source ~kind:Transitive)
             |> add_rule))
   in
   Option.iter (Lib_modules.alias_module vlib_modules) ~f:copy_objs;


### PR DESCRIPTION
This is consistent with the other artifacts. The virtual library rules
need to know where these files are, so they can no longer stay private
to ocamldep.