### PR TITLE
Lib info direct access

### DIFF
--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -80,7 +80,8 @@ module Public_libs = struct
         in
         Ok (Path.build (Path.Build.relative lib_install_dir file))
       end else
-        Ok (Path.relative (Lib.src_dir lib) file)
+        let info = Lib.info lib in
+        Ok (Path.relative info.src_dir file)
 
 end
 

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -92,10 +92,11 @@ let exe_rule cc ~javascript_files ~src ~target ~flags =
   js_of_ocaml_rule sctx ~dir ~spec ~target ~flags
 
 let jsoo_archives ~ctx lib =
-  match Lib.jsoo_archive lib with
+  let info = Lib.info lib in
+  match info.jsoo_archive with
   | Some a -> [a]
   | None ->
-    List.map (Lib.archives lib).byte ~f:(fun archive ->
+    List.map info.archives.byte ~f:(fun archive ->
       in_build_dir ~ctx
         [ Lib_name.to_string (Lib.name lib)
         ; Path.basename archive ^ ".js"
@@ -152,7 +153,8 @@ let setup_separate_compilation_rules sctx components =
       match Lib.DB.find (SC.installed_libs sctx) pkg with
       | Error _ -> ()
       | Ok pkg ->
-        let archives = (Lib.archives pkg).byte in
+        let info = Lib.info pkg in
+        let archives = info.archives.byte in
         let archives =
           (* Special case for the stdlib because it is not referenced
              in the META *)
@@ -162,7 +164,7 @@ let setup_separate_compilation_rules sctx components =
         in
         List.iter archives ~f:(fun fn ->
           let name = Path.basename fn in
-          let src = Path.relative (Lib.src_dir pkg) name in
+          let src = Path.relative info.src_dir name in
           let lib_name = Lib_name.to_string (Lib.name pkg) in
           let target =
             in_build_dir ~ctx [lib_name ; sprintf "%s.js" name]

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -255,35 +255,15 @@ let not_available ~loc reason fmt =
 (* Generals *)
 
 let name t = t.name
+let info t = t.info
 
-let kind         t = t.info.kind
-let synopsis     t = t.info.synopsis
-let archives     t = t.info.archives
-let plugins      t = t.info.plugins
-let jsoo_runtime t = t.info.jsoo_runtime
-let jsoo_archive t = t.info.jsoo_archive
 let unique_id    t = t.unique_id
-let modes        t = t.info.modes
-
-let virtual_     t = t.info.virtual_
 
 let is_impl      t = Option.is_some t.implements
 
-let src_dir t = t.info.src_dir
-let orig_src_dir t = Option.value ~default:t.info.src_dir t.info.orig_src_dir
 let obj_dir t = t.info.obj_dir
 
 let is_local t = Path.is_managed (Obj_dir.byte_dir t.info.obj_dir)
-
-let public_cmi_dir t = Obj_dir.public_cmi_dir t.info.obj_dir
-
-let native_dir t = Obj_dir.native_dir t.info.obj_dir
-
-let status t = t.info.status
-
-let foreign_objects t = t.info.foreign_objects
-
-let special_builtin_support t = t.info.special_builtin_support
 
 let main_module_name t =
   match t.info.main_module_name with
@@ -330,8 +310,10 @@ module L = struct
   let include_paths ts ~stdlib_dir =
     let dirs =
       List.fold_left ts ~init:Path.Set.empty ~f:(fun acc t ->
+        let public_cmi_dir = Obj_dir.public_cmi_dir t.info.obj_dir in
+        let native_dir = Obj_dir.native_dir t.info.obj_dir in
         List.fold_left ~f:Path.Set.add ~init:acc
-          [public_cmi_dir t ; native_dir t])
+          [public_cmi_dir ; native_dir])
     in
     Path.Set.remove dirs stdlib_dir
 

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -12,41 +12,20 @@ val to_dyn : t -> Dyn.t
     present or the [name] if not. *)
 val name : t -> Lib_name.t
 
-(* CR-someday diml: this should be [Path.t list], since some libraries
-   have multiple source directories because of [copy_files]. *)
-(** Directory where the source files for the library are located. *)
-val src_dir : t -> Path.t
-val orig_src_dir : t -> Path.t
-
 (** Directory where the object files for the library are located. *)
 val obj_dir : t -> Path.t Obj_dir.t
-val public_cmi_dir : t -> Path.t
 
 (** Same as [Path.is_managed (obj_dir t)] *)
 val is_local : t -> bool
 
-val synopsis     : t -> string option
-val kind         : t -> Lib_kind.t
-val archives     : t -> Path.t list Mode.Dict.t
-val plugins      : t -> Path.t list Mode.Dict.t
-val jsoo_runtime : t -> Path.t list
-val jsoo_archive : t -> Path.t option
-val modes        : t -> Mode.Dict.Set.t
-
-val foreign_objects : t -> Path.t list Lib_info.Source.t
+val info : t -> Lib_info.t
 
 val main_module_name : t -> Module.Name.t option Or_exn.t
 val wrapped : t -> Wrapped.t option Or_exn.t
 
-val virtual_ : t -> Lib_modules.t Lib_info.Source.t option
-
 (** [is_impl lib] returns [true] if the library is an implementation
     of a virtual library *)
 val is_impl : t -> bool
-
-
-val special_builtin_support
-  : t -> Dune_file.Library.Special_builtin_support.t option
 
 (** A unique integer identifier. It is only unique for the duration of
     the process *)
@@ -60,8 +39,6 @@ val unique_id : t -> Id.t
 module Set : Set.S with type elt = t
 
 module Map : Map.S with type key = t
-
-val status : t -> Lib_info.Status.t
 
 val package : t -> Package.Name.t option
 

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -267,3 +267,5 @@ let of_dune_lib dp =
   ; wrapped
   ; special_builtin_support = Lib.special_builtin_support dp
   }
+
+let orig_src_dir t = Option.value ~default:t.src_dir t.orig_src_dir

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -84,3 +84,8 @@ val user_written_deps : t -> Dune_file.Lib_deps.t
 val of_dune_lib
   :  Sub_system_info.t Dune_package.Lib.t
   -> t
+
+(* CR-someday diml: this should be [Path.t list], since some libraries
+   have multiple source directories because of [copy_files]. *)
+(** Directory where the source files for the library are located. *)
+val orig_src_dir : t -> Path.t

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -45,7 +45,9 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
 let findlib_init_code ~preds ~libs =
   let public_libs =
     List.filter
-      ~f:(fun lib -> not (Lib_info.Status.is_private (Lib.status lib)))
+      ~f:(fun lib ->
+        let info = Lib.info lib in
+        not (Lib_info.Status.is_private info.status))
       libs
   in
   Format.asprintf "%t@." (fun ppf ->
@@ -98,7 +100,8 @@ let handle_special_libs cctx =
           | Lib.Lib_and_module.Module _ ->
             x :: insert l
           | Lib lib ->
-            match Lib.special_builtin_support lib with
+            let info = Lib.info lib in
+            match info.special_builtin_support with
             | Some Findlib_dynload ->
               let obj_dir = Obj_dir.of_local obj_dir in
               x :: Module (obj_dir, module_) :: l

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -141,7 +141,8 @@ module Of_sctx = struct
         let virtual_lib = lazy (
           Lib.Local.Set.find libs ~f:(fun l ->
             let l = Lib.Local.to_lib l in
-            Option.is_some (Lib.virtual_ l))
+            let info = Lib.info l in
+            Option.is_some info.virtual_)
         ) in
         let t =
           add_stanzas

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -238,11 +238,11 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
             (Path.set_of_source_paths t.source_dirs)
           , t.objs_dirs)
             ~f:(fun (lib : Lib.t) (src_dirs, obj_dirs) ->
-              ( Path.Set.add src_dirs (
-                  Lib.orig_src_dir lib
-                  |> Path.drop_optional_build_context)
-                ,
-                Path.Set.add obj_dirs (Lib.public_cmi_dir lib)
+              let info = Lib.info lib in
+              let orig_src_dir = Lib_info.orig_src_dir info in
+              ( Path.Set.add src_dirs (Path.drop_optional_build_context orig_src_dir)
+              , let public_cmi_dir = Obj_dir.public_cmi_dir (Lib.obj_dir lib) in
+                Path.Set.add obj_dirs public_cmi_dir
               ))
         in
         let src_dirs =

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -9,7 +9,7 @@ let (++) = Path.Build.relative
 
 let lib_unique_name lib =
   let name = Lib.name lib in
-  match Lib.status lib with
+  match (Lib.info lib).status with
   | Installed -> assert false
   | Public _  -> Lib_name.to_string name
   | Private scope_name ->
@@ -626,7 +626,8 @@ let gen_rules sctx ~dir:_ rest =
     |> Result.iter ~f:(fun lib ->
       (* TODO instead of this hack, call memoized function that generates the
          rules for this library *)
-      Build_system.load_dir ~dir:(Lib.src_dir lib))
+      let dir = (Lib.info lib).src_dir in
+      Build_system.load_dir ~dir)
   | "_html" :: lib_unique_name_or_pkg :: _ ->
     (* TODO we can be a better with the error handling in the case where
        lib_unique_name_or_pkg is neither a valid pkg or lnu *)

--- a/src/sub_system.ml
+++ b/src/sub_system.ml
@@ -60,9 +60,10 @@ module Register_backend(M : Backend) = struct
           (String.concat ~sep:"\n"
              (List.map backends ~f:(fun t ->
                 let lib = M.lib t in
+                let info = Lib.info lib in
                 sprintf "- %S in %s"
                   (Lib_name.to_string (Lib.name lib))
-                  (Path.to_string_maybe_quoted (Lib.src_dir lib)))))
+                  (Path.to_string_maybe_quoted info.src_dir))))
       | No_backend_found ->
         Errors.exnf loc "No %s found." (M.desc ~plural:false)
       | Other exn ->

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -42,7 +42,8 @@ let libs_under_dir sctx ~db ~dir =
              | Some lib ->
                (* still need to make sure that it's not coming from an external
                   source *)
-               if Path.is_descendant ~of_:(Path.build dir) (Lib.src_dir lib) then
+               let info = Lib.info lib in
+               if Path.is_descendant ~of_:(Path.build dir) info.src_dir then
                  lib :: acc
                else
                  acc (* external lib with a name matching our private name *)

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -250,8 +250,9 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         "Cannot implement %a as that library isn't available"
         Lib_name.pp implements
     | Ok vlib ->
+      let info = Lib.info vlib in
       let virtual_ =
-        match Lib.virtual_ vlib with
+        match info.virtual_ with
         | None ->
           Errors.fail lib.buildable.loc
             "Library %a isn't virtual and cannot be implemented"
@@ -259,7 +260,7 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         | Some v -> v
       in
       let (vlib_modules, vlib_foreign_objects) =
-        match virtual_, Lib.foreign_objects vlib with
+        match virtual_, info.foreign_objects with
         | External _, Local
         | Local, External _ -> assert false
         | External lib_modules, External fa -> (lib_modules, fa)
@@ -304,7 +305,7 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         | External _ ->
           let impl_obj_dir = Dune_file.Library.obj_dir ~dir lib in
           let impl_cm_kind =
-            let { Mode.Dict. byte; native = _ } = Lib.modes vlib in
+            let { Mode.Dict. byte; native = _ } = (Lib.info vlib).modes in
             Mode.cm_kind (if byte then Byte else Native)
           in
           external_dep_graph sctx ~impl_cm_kind ~impl_obj_dir ~vlib_modules


### PR DESCRIPTION
We should have done this refactoring when Lib_info was introduced, but there were other things to do. Most of these fields aren't accessed so often. We might as well just use Lib_info.t directly.