### PR TITLE
Better Code_error reporting

### DIFF
--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -1424,7 +1424,7 @@ end = struct
   let build_file =
     Memo.exec build_file_memo
 
-  let execute_rule_memo = 
+  let execute_rule_memo =
     Memo.create
       "execute-rule"
       ~output:(Allow_cutoff (module Unit))

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -98,11 +98,11 @@ end
     version of [f]. The result of [f] for a given input is cached, so that the
     second time [exec t x] is called, the previous result is re-used if
     possible.
-    
+
     [exec t x] tracks what calls to other memoized function [f x] performs. When
     the result of such dependent call changes, [exec t x] will automatically
     recompute [f x].
-    
+
     Running the computation may raise [Memo.Cycle_error.E] if a cycle is
     detected.
 

--- a/src/stdune/dyn.mli
+++ b/src/stdune/dyn.mli
@@ -50,4 +50,6 @@ val opaque : t
 
 val to_sexp : t Sexp.Encoder.t
 
+val to_string : t -> string
+
 type dyn = t

--- a/src/stdune/dyn0.ml
+++ b/src/stdune/dyn0.ml
@@ -1,4 +1,7 @@
 module Array = Dune_caml.ArrayLabels
+module List = Dune_caml.ListLabels
+
+module String = Dune_caml.StringLabels
 
 type t =
   | Opaque
@@ -19,96 +22,135 @@ type t =
   | Map of (t * t) list
   | Set of t list
 
-let rec pp = function
-  | Opaque -> Pp.verbatim "<opaque>"
-  | Unit -> Pp.verbatim "()"
-  | Int i -> Pp.verbatim (string_of_int i)
-  | Bool b -> Pp.verbatim (string_of_bool b)
-  | String s -> Pp.verbatim s
-  | Bytes b -> Pp.verbatim (Bytes.to_string b)
-  | Char c -> Pp.char c
-  | Float f -> Pp.verbatim (string_of_float f)
-  | Sexp s -> pp_sexp s
-  | Option None -> pp (Variant ("None", []))
-  | Option (Some x) -> pp (Variant ("Some", [x]))
-  | List x ->
-    Pp.box
-      (Pp.concat
-         [ Pp.char '['
-         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) x ~f:pp
-         ; Pp.char ']'
-         ])
-  | Array a ->
-    Pp.box
-      (Pp.concat
-         [ Pp.verbatim "[|"
-         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) (Array.to_list a) ~f:pp
-         ; Pp.verbatim "|]"
-         ])
-  | Set xs ->
-    Pp.box
-      (Pp.concat
-         [ Pp.verbatim "set {"
-         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:pp
-         ; Pp.verbatim "}"
-         ])
-  | Map xs ->
-    Pp.box
-      (Pp.concat
-         [ Pp.verbatim "map {"
-         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:(fun (k, v) ->
-             Pp.box
-               (Pp.concat
-                  [ pp k
-                  ; Pp.space
-                  ; Pp.verbatim ":"
-                  ; Pp.space
-                  ; pp v
-                  ])
-           )
-         ; Pp.verbatim "}"
-         ])
-  | Tuple x ->
-    Pp.box
-      (Pp.concat
-         [ Pp.char '('
-         ; Pp.concat_map ~sep:(Pp.seq (Pp.char ',') Pp.space) x ~f:pp
-         ; Pp.char ')'
-         ])
-  | Record fields ->
-    Pp.vbox ~indent:2
-      (Pp.concat
-         [ Pp.char '{'
-         ; Pp.concat_map ~sep:(Pp.char ';') fields ~f:(fun (f, v) ->
-             Pp.concat
-               [ Pp.verbatim f
-               ; Pp.space
-               ; Pp.char '='
-               ; Pp.space
-               ; Pp.box ~indent:2 (pp v)
-               ]
-           )
-         ; Pp.char '}'
-         ])
-  | Variant (v, []) -> Pp.verbatim v
-  | Variant (v, xs) ->
-    Pp.hvbox ~indent:2
-      (Pp.concat
-         [ Pp.verbatim v
-         ; Pp.space
-         ; Pp.concat_map ~sep:(Pp.char ',') xs ~f:pp
-         ])
+  let unsnoc l = match List.rev l with
+    | last :: before_last -> Some (List.rev before_last, last)
+    | [] -> None
 
-and pp_sexp = function
-  | Sexp0.Atom s -> Pp.verbatim (Escape.quote_if_needed s)
-  | List [] -> Pp.verbatim "()"
-  | List l ->
-    Pp.box ~indent:1
-      (Pp.concat
-         [ Pp.char '('
-         ; Pp.hvbox (Pp.concat_map l ~sep:Pp.space ~f:pp_sexp)
-         ; Pp.char ')'
-         ])
+  let string_in_ocaml_syntax str =
+    let is_space = function
+      | ' ' ->
+        (* don't need to handle tabs because those are already escaped *)
+        true
+      | _ -> false
+    in
+    let escape_protect_first_space s =
+      let first_char =
+        if String.length s > 0 && is_space s.[0]
+        then "\\"
+        else
+          " "
+      in
+      first_char ^  String.escaped s
+    in
+    (* CR-someday aalekseyev: should use the method from
+       [Dune_lang.prepare_formatter] so that the formatter can fit multiple
+       lines on one line. *)
+    match String_split.split ~on:'\n' str with
+    | [] -> assert false
+    | first :: rest -> match unsnoc rest with
+      | None -> Pp.verbatim (Printf.sprintf "%S" first)
+      | Some (middle, last) ->
+        Pp.vbox (
+          Pp.concat ~sep:Pp.newline (
+            List.map ~f:Pp.verbatim (
+              ("\"" ^ (String.escaped first) ^ "\\n\\") ::
+              List.map middle ~f:(fun s ->
+                (escape_protect_first_space s) ^ "\\n\\"
+              ) @
+              [ escape_protect_first_space last ^ "\"" ]
+            )))
+
+  let rec pp = function
+    | Opaque -> Pp.verbatim "<opaque>"
+    | Unit -> Pp.verbatim "()"
+    | Int i -> Pp.verbatim (string_of_int i)
+    | Bool b -> Pp.verbatim (string_of_bool b)
+    | String s -> string_in_ocaml_syntax s
+    | Bytes b -> string_in_ocaml_syntax (Bytes.to_string b)
+    | Char c -> Pp.char c
+    | Float f -> Pp.verbatim (string_of_float f)
+    | Sexp s -> pp_sexp s
+    | Option None -> pp (Variant ("None", []))
+    | Option (Some x) -> pp (Variant ("Some", [x]))
+    | List x ->
+      Pp.box
+        (Pp.concat
+           [ Pp.char '['
+           ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) x ~f:pp
+           ; Pp.char ']'
+           ])
+    | Array a ->
+      Pp.box
+        (Pp.concat
+           [ Pp.verbatim "[|"
+           ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) (Array.to_list a) ~f:pp
+           ; Pp.verbatim "|]"
+           ])
+    | Set xs ->
+      Pp.box
+        (Pp.concat
+           [ Pp.verbatim "set {"
+           ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:pp
+           ; Pp.verbatim "}"
+           ])
+    | Map xs ->
+      Pp.box
+        (Pp.concat
+           [ Pp.verbatim "map {"
+           ; Pp.concat_map ~sep:(Pp.seq (Pp.char ';') Pp.space) xs ~f:(fun (k, v) ->
+               Pp.box
+                 (Pp.concat
+                    [ pp k
+                    ; Pp.space
+                    ; Pp.verbatim ":"
+                    ; Pp.space
+                    ; pp v
+                    ])
+             )
+           ; Pp.verbatim "}"
+           ])
+    | Tuple x ->
+      Pp.box
+        (Pp.concat
+           [ Pp.char '('
+           ; Pp.concat_map ~sep:(Pp.seq (Pp.char ',') Pp.space) x ~f:pp
+           ; Pp.char ')'
+           ])
+    | Record fields ->
+      Pp.vbox ~indent:2
+        (Pp.concat
+           [ Pp.char '{'
+           ; Pp.concat_map  fields
+               ~sep:(Pp.seq (Pp.char ';') Pp.space)
+               ~f:(fun (f, v) ->
+                 Pp.box ~indent:2 (Pp.concat
+                                     [ Pp.verbatim f
+                                     ; Pp.space
+                                     ; Pp.char '='
+                                     ; Pp.space
+                                     ; pp v
+                                     ])
+               )
+           ; Pp.char '}'
+           ])
+    | Variant (v, []) -> Pp.verbatim v
+    | Variant (v, xs) ->
+      Pp.hvbox ~indent:2
+        (Pp.concat
+           [ Pp.verbatim v
+           ; Pp.space
+           ; Pp.concat_map ~sep:(Pp.char ',') xs ~f:pp
+           ])
+  and pp_sexp = function
+    | Sexp0.Atom s -> Pp.verbatim (Escape.quote_if_needed s)
+    | List [] -> Pp.verbatim "()"
+    | List l ->
+      Pp.box ~indent:1
+        (Pp.concat
+           [ Pp.char '('
+           ; Pp.hvbox (Pp.concat_map l ~sep:Pp.space ~f:pp_sexp)
+           ; Pp.char ')'
+           ])
 
 let pp fmt t = Pp.pp fmt (pp t)
 

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -133,17 +133,6 @@ let index s ch =
   | i -> Some i
   | exception Not_found -> None
 
-let split s ~on =
-  let rec loop i j =
-    if j = length s then
-      [sub s ~pos:i ~len:(j - i)]
-    else if s.[j] = on then
-      sub s ~pos:i ~len:(j - i) :: loop (j + 1) (j + 1)
-    else
-      loop i (j + 1)
-  in
-  loop 0 0
-
 include String_split
 
 let escape_only c s =

--- a/src/stdune/string.mli
+++ b/src/stdune/string.mli
@@ -54,7 +54,12 @@ val exists : t -> f:(char -> bool) -> bool
 val for_all : t -> f:(char -> bool) -> bool
 
 (** [maybe_quoted s] is [s] if [s] doesn't need escaping according to OCaml
-    lexing conventions and [sprintf "%S" s] otherwise. *)
+    lexing conventions and [sprintf "%S" s] otherwise.
+
+    (* CR-someday aalekseyev: this function is not great: barely anything
+    "needs escaping according to OCaml lexing conventions", so the condition
+    for whether to add the quote characters ends up being quite arbitrary. *)
+*)
 val maybe_quoted : t -> t
 
 (** Produces: "x, y and z" *)

--- a/src/stdune/string_split.ml
+++ b/src/stdune/string_split.ml
@@ -2,6 +2,17 @@ module List = Dune_caml.ListLabels
 module String = Dune_caml.StringLabels
 open String
 
+let split s ~on =
+  let rec loop i j =
+    if j = length s then
+      [sub s ~pos:i ~len:(j - i)]
+    else if s.[j] = on then
+      sub s ~pos:i ~len:(j - i) :: loop (j + 1) (j + 1)
+    else
+      loop i (j + 1)
+  in
+  loop 0 0
+
 let split_lines s =
   let rec loop ~last_is_cr ~acc i j =
     if j = length s then (

--- a/src/stdune/string_split.mli
+++ b/src/stdune/string_split.mli
@@ -1,1 +1,2 @@
+val split : string -> on:char -> string list
 val split_lines : string -> string list


### PR DESCRIPTION
Improve the reporting of `Code_error` errors that happen in memoized functions.

We make them additionally report the memo call stack and, where easy, show correct interleaving of Memo stack frames and OCaml stack frames.  (which doesn't seem easy for async call frames)

An example is below. The interesting new bits is the interleaving between:

- \"src/build_system.ml\", line 1120
- "load-dir", "default/enabled/no-source-code/.formatted"
- \"src/build_system.ml\", line 1197
- "load-dir", In_build_dir ".aliases/default/enabled/no-source-code/.formatted"

And then the entire `outer_call_stack` is newly-reported.

```
  Error: exception {exn =
     ("Generated rules in a directory not allowed by the parent",
     {dir = "default/enabled/no-source-code/.formatted";
       rules = [Alias {name = "fmt"}]});
    backtrace =
      [{ocaml =
          "Raised at file \"src/stdune/code_error.ml\", line 11, characters 2-29\n\
           Called from file \"src/build_system.ml\", line 1120, characters 11-200\n\
           Called from file \"src/stdune/exn.ml\", line 11, characters 8-11\n\
           Re-raised at file \"src/stdune/exn.ml\", line 13, characters 30-37\n\
           Called from file \"src/stdune/exn.ml\", line 11, characters 8-11\n\
           Re-raised at file \"src/stdune/exn.ml\", line 13, characters 30-37\n\
           Called from file \"src/memo/memo.ml\", line 561, characters 12-118\n\
           ";
         memo =
           ("load-dir",
           In_build_dir "default/enabled/no-source-code/.formatted")};
      {ocaml =
         "Raised at file \"src/memo/memo.ml\", line 573, characters 10-368\n\
          Called from file \"src/memo/memo.ml\", line 585, characters 11-188\n\
          Called from file \"src/build_system.ml\", line 1197, characters 13-44\n\
          Called from file \"src/stdune/exn.ml\", line 11, characters 8-11\n\
          Re-raised at file \"src/stdune/exn.ml\", line 13, characters 30-37\n\
          Called from file \"src/stdune/exn.ml\", line 11, characters 8-11\n\
          Re-raised at file \"src/stdune/exn.ml\", line 13, characters 30-37\n\
          Called from file \"src/memo/memo.ml\", line 561, characters 12-118\n\
          ";
        memo =
          ("load-dir",
          In_build_dir ".aliases/default/enabled/no-source-code/.formatted")}];
    outer_call_stack =
      [("build-file",
       In_build_dir
         ".aliases/default/enabled/no-source-code/.formatted/fmt-00000000000000000000000000000000");
      ("execute-rule", {id = 65;
                         loc = None});
      ("build-file",
      In_build_dir
        ".aliases/default/enabled/no-source-code/fmt-00000000000000000000000000000000")]}
```