### PR TITLE
Library artifact refactoring (#2277

### DIFF
--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -78,7 +78,8 @@ module Public_libs = struct
       Path.build (Path.Build.relative lib_install_dir file)
     end else
       let info = Lib.info lib in
-      Path.relative info.src_dir file
+      let src_dir = Lib_info.src_dir info in
+      Path.relative src_dir file
 end
 
 type t = {

--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -14,7 +14,8 @@ module Util = struct
   let include_paths ts =
     List.fold_left ts ~init:Path.Set.empty ~f:(fun acc t ->
       let info = Lib.info t in
-      Path.Set.add acc info.src_dir)
+      let src_dir = Lib_info.src_dir info in
+      Path.Set.add acc src_dir)
 
   let include_flags ts = include_paths ts |> Lib.L.to_iflags
 
@@ -121,7 +122,8 @@ let setup_ml_deps ~lib_db libs =
   let ml_pack_files lib =
     let plugins =
       let info = Lib.info lib in
-      Mode.Dict.get info.plugins Mode.Native
+      let plugins = Lib_info.plugins info in
+      Mode.Dict.get plugins Mode.Native
     in
     let to_mlpack file =
       [ Path.set_extension file ~ext:".mlpack"
@@ -183,7 +185,8 @@ let coq_plugins_install_rules ~scope ~package ~dst_dir (s : Dune_file.Coq.t) =
          (Lib.package lib) (Some (package.Package.name))
     then
       let info = Lib.info lib in
-      Mode.Dict.get info.plugins Mode.Native
+      let plugins = Lib_info.plugins info in
+      Mode.Dict.get plugins Mode.Native
       |> List.map ~f:(fun plugin_file ->
         let plugin_file = Path.as_in_build_dir_exn plugin_file in
         let plugin_file_basename = Path.Build.basename plugin_file in

--- a/src/gen_meta.ml
+++ b/src/gen_meta.ml
@@ -50,8 +50,8 @@ let plugin preds  s = rule "plugin"    preds Set s
 
 let archives ?(preds=[]) lib =
   let info = Lib.info lib in
-  let archives = info.archives in
-  let plugins  = info.plugins in
+  let archives = Lib_info.archives info in
+  let plugins  = Lib_info.plugins info in
   let make ps =
     String.concat ~sep:" " (List.map ps ~f:Path.basename)
   in
@@ -63,8 +63,10 @@ let archives ?(preds=[]) lib =
 
 let gen_lib pub_name lib ~version =
   let info = Lib.info lib in
+  let synopsis = Lib_info.synopsis info in
+  let kind = Lib_info.kind info in
   let desc =
-    match info.synopsis with
+    match synopsis with
     | Some s -> s
     | None ->
       (* CR-someday jdimino: wut? this looks old *)
@@ -76,7 +78,7 @@ let gen_lib pub_name lib ~version =
       | _ -> ""
   in
   let preds =
-    match info.kind with
+    match kind with
     | Normal -> []
     | Ppx_rewriter _ | Ppx_deriver _ -> [Pos "ppx_driver"]
   in
@@ -96,7 +98,7 @@ let gen_lib pub_name lib ~version =
         ; Comment "a preprocessor"
         ; ppx_runtime_deps ppx_rt_deps
         ]
-    ; (match info.kind with
+    ; (match kind with
        | Normal -> []
        | Ppx_rewriter _ | Ppx_deriver _ ->
          (* Deprecated ppx method support *)
@@ -108,7 +110,7 @@ let gen_lib pub_name lib ~version =
              ; requires ~preds:[no_ppx_driver]
                  (Lib.Meta.ppx_runtime_deps_for_deprecated_method lib)
              ]
-           ; match info.kind with
+           ; match kind with
            | Normal -> assert false
            | Ppx_rewriter _ ->
              [ rule "ppx" [no_ppx_driver; no_custom_ppx]
@@ -121,7 +123,7 @@ let gen_lib pub_name lib ~version =
              ]
            ]
       )
-    ; (match info.jsoo_runtime with
+    ; (match Lib_info.jsoo_runtime info with
        | [] -> []
        | l  ->
          let root = Pub_name.root pub_name in

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -28,7 +28,8 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
             |> Lib.Local.Set.to_list
             |> List.map ~f:(fun lib ->
               let dir_contents =
-                let dir = Lib.Local.src_dir lib in
+                let info = Lib.Local.info lib in
+                let dir = Lib_info.src_dir info in
                 Dir_contents.get_without_rules sctx ~dir
               in
               let obj_dir = Lib.Local.obj_dir lib in

--- a/src/js_of_ocaml_rules.ml
+++ b/src/js_of_ocaml_rules.ml
@@ -93,10 +93,12 @@ let exe_rule cc ~javascript_files ~src ~target ~flags =
 
 let jsoo_archives ~ctx lib =
   let info = Lib.info lib in
-  match info.jsoo_archive with
+  let jsoo_archive = Lib_info.jsoo_archive info in
+  match jsoo_archive with
   | Some a -> [a]
   | None ->
-    List.map info.archives.byte ~f:(fun archive ->
+    let archives = Lib_info.archives info in
+    List.map archives.byte ~f:(fun archive ->
       in_build_dir ~ctx
         [ Lib_name.to_string (Lib.name lib)
         ; Path.basename archive ^ ".js"
@@ -154,7 +156,7 @@ let setup_separate_compilation_rules sctx components =
       | None -> ()
       | Some pkg ->
         let info = Lib.info pkg in
-        let archives = info.archives.byte in
+        let archives = (Lib_info.archives info).byte in
         let archives =
           (* Special case for the stdlib because it is not referenced
              in the META *)
@@ -164,7 +166,8 @@ let setup_separate_compilation_rules sctx components =
         in
         List.iter archives ~f:(fun fn ->
           let name = Path.basename fn in
-          let src = Path.relative info.src_dir name in
+          let src_dir = Lib_info.src_dir info in
+          let src = Path.relative src_dir name in
           let lib_name = Lib_name.to_string (Lib.name pkg) in
           let target =
             in_build_dir ~ctx [lib_name ; sprintf "%s.js" name]

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1456,14 +1456,15 @@ module DB = struct
               | Some variants_public ->
                 List.rev_append variants_private variants_public
         in
-        let variants =
+        let known_implementations =
           match Variant.Map.of_list variants with
           | Ok x -> x
           | Error (variant, x, y) ->
             error_two_impl_for_variant (snd conf.name) variant x y
         in
         let info =
-          Lib_info.of_library_stanza ~dir ~lib_config variants conf
+          Lib_info.of_library_stanza ~dir ~lib_config
+            ~known_implementations conf
           |> Lib_info.of_local
         in
         match conf.public with

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1464,7 +1464,7 @@ module DB = struct
         in
         let info =
           Lib_info.of_library_stanza ~dir ~lib_config variants conf
-          |> Lib_info.to_external
+          |> Lib_info.of_local
         in
         match conf.public with
         | None ->

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -274,8 +274,8 @@ module Local : sig
   val of_lib_exn : lib -> t
   val to_lib : t -> lib
 
+  val info    : t -> Lib_info.local
   val obj_dir : t -> Path.Build.t Obj_dir.t
-  val src_dir : t -> Path.Build.t
 
   module Set : Stdune.Set.S with type elt = t
   module Map : Stdune.Map.S with type key = t

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -18,7 +18,7 @@ val obj_dir : t -> Path.t Obj_dir.t
 (** Same as [Path.is_managed (obj_dir t)] *)
 val is_local : t -> bool
 
-val info : t -> Lib_info.t
+val info : t -> Path.t Lib_info.t
 
 val main_module_name : t -> Module.Name.t option Or_exn.t
 val wrapped : t -> Wrapped.t option Or_exn.t
@@ -144,8 +144,8 @@ module DB : sig
   module Resolve_result : sig
     type nonrec t =
       | Not_found
-      | Found    of Lib_info.t
-      | Hidden   of Lib_info.t * string
+      | Found    of Lib_info.external_
+      | Hidden   of Lib_info.external_ * string
       | Redirect of t option * Lib_name.t
   end
 

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -320,5 +320,5 @@ let map t ~f_path ~f_obj_dir =
   ; jsoo_archive = Option.map ~f t.jsoo_archive
   }
 
-let to_external = map ~f_path:Path.build ~f_obj_dir:Obj_dir.of_local
+let of_local = map ~f_path:Path.build ~f_obj_dir:Obj_dir.of_local
 let as_local_exn = map ~f_path:Path.as_in_build_dir_exn ~f_obj_dir:Obj_dir.as_local_exn

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -97,6 +97,37 @@ type 'path t =
   ; special_builtin_support : Dune_file.Library.Special_builtin_support.t option
   }
 
+let name t = t.name
+let version t = t.version
+let loc t = t.loc
+let requires t = t.requires
+let pps t = t.pps
+let ppx_runtime_deps t = t.ppx_runtime_deps
+let sub_systems t = t.sub_systems
+let modes t =t.modes
+let archives t = t.archives
+let foreign_archives t = t.foreign_archives
+let foreign_objects t = t.foreign_objects
+let plugins t = t.plugins
+let src_dir t = t.src_dir
+let variant t = t.variant
+let enabled t = t.enabled
+let status t = t.status
+let kind t = t.kind
+let default_implementation t = t.default_implementation
+let known_implementations t = t.known_implementations
+let obj_dir t = t.obj_dir
+let virtual_ t = t.virtual_
+let implements t = t.implements
+let synopsis t = t.synopsis
+let wrapped t = t.wrapped
+let special_builtin_support t = t.special_builtin_support
+let jsoo_runtime t = t.jsoo_runtime
+let jsoo_archive t = t.jsoo_archive
+let main_module_name t = t.main_module_name
+let orig_src_dir t = t.orig_src_dir
+let best_src_dir t = Option.value ~default:t.src_dir t.orig_src_dir
+
 let user_written_deps t =
   List.fold_left (t.virtual_deps @ t.ppx_runtime_deps)
     ~init:(Deps.to_lib_deps t.requires)
@@ -270,19 +301,17 @@ let of_dune_lib dp =
   ; special_builtin_support = Lib.special_builtin_support dp
   }
 
-let orig_src_dir t = Option.value ~default:t.src_dir t.orig_src_dir
-
 type external_ = Path.t t
 type local = Path.Build.t t
 
-let to_external t =
-  let f = Path.build in
+let map t ~f_path ~f_obj_dir =
+  let f = f_path in
   let list = List.map ~f in
   let mode_list = Mode.Dict.map ~f:list in
   { t with
-    src_dir = Path.build t.src_dir
+    src_dir = f t.src_dir
   ; orig_src_dir = Option.map ~f t.orig_src_dir
-  ; obj_dir = Obj_dir.of_local t.obj_dir
+  ; obj_dir = f_obj_dir t.obj_dir
   ; archives = mode_list t.archives
   ; plugins = mode_list t.plugins
   ; foreign_objects = Source.map ~f:(List.map ~f) t.foreign_objects
@@ -290,3 +319,6 @@ let to_external t =
   ; jsoo_runtime = List.map ~f t.jsoo_runtime
   ; jsoo_archive = Option.map ~f t.jsoo_archive
   }
+
+let to_external = map ~f_path:Path.build ~f_obj_dir:Obj_dir.of_local
+let as_local_exn = map ~f_path:Path.as_in_build_dir_exn ~f_obj_dir:Obj_dir.as_local_exn

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -136,8 +136,7 @@ let user_written_deps t =
 let of_library_stanza ~dir
       ~lib_config:({ Lib_config.has_native; ext_lib; ext_obj; _ }
                    as lib_config)
-      (known_implementations : (Loc.t * Lib_name.t) Variant.Map.t)
-      (conf : Dune_file.Library.t) =
+      ~known_implementations (conf : Dune_file.Library.t) =
   let (_loc, lib_name) = conf.name in
   let obj_dir = Dune_file.Library.obj_dir ~dir conf in
   let gen_archive_file ~dir ext =

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -70,8 +70,6 @@ val enabled : _ t -> Enabled_status.t
 val orig_src_dir : 'path t -> 'path option
 val version : _ t -> string option
 
-(* CR-someday diml: this should be [Path.t list], since some libraries
-   have multiple source directories because of [copy_files]. *)
 (** Directory where the source files for the library are located. Returns
     the original src dir when it exists *)
 val best_src_dir : 'path t -> 'path

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -38,39 +38,43 @@ module Enabled_status : sig
     | Disabled_because_of_enabled_if
 end
 
-type 'path t = private
-  { loc              : Loc.t
-  ; name             : Lib_name.t
-  ; kind             : Lib_kind.t
-  ; status           : Status.t
-  ; src_dir          : 'path
-  ; orig_src_dir     : 'path option
-  ; obj_dir          : 'path Obj_dir.t
-  ; version          : string option
-  ; synopsis         : string option
-  ; archives         : 'path list Mode.Dict.t
-  ; plugins          : 'path list Mode.Dict.t
-  ; foreign_objects  : 'path list Source.t
-  ; foreign_archives : 'path list Mode.Dict.t (** [.a/.lib/...] files *)
-  ; jsoo_runtime     : 'path list
-  ; jsoo_archive     : 'path option
-  ; requires         : Deps.t
-  ; ppx_runtime_deps : (Loc.t * Lib_name.t) list
-  ; pps              : (Loc.t * Lib_name.t) list
-  ; enabled          : Enabled_status.t
-  ; virtual_deps     : (Loc.t * Lib_name.t) list
-  ; dune_version     : Syntax.Version.t option
-  ; sub_systems      : Sub_system_info.t Sub_system_name.Map.t
-  ; virtual_         : Lib_modules.t Source.t option
-  ; implements       : (Loc.t * Lib_name.t) option
-  ; variant          : Variant.t option
-  ; known_implementations : (Loc.t * Lib_name.t) Variant.Map.t
-  ; default_implementation  : (Loc.t * Lib_name.t) option
-  ; wrapped          : Wrapped.t Dune_file.Library.Inherited.t option
-  ; main_module_name : Dune_file.Library.Main_module_name.t
-  ; modes            : Mode.Dict.Set.t
-  ; special_builtin_support : Dune_file.Library.Special_builtin_support.t option
-  }
+type 'path t
+
+val name : _ t -> Lib_name.t
+val loc : _ t -> Loc.t
+val archives : 'path t -> 'path list Mode.Dict.t
+val foreign_archives : 'path t -> 'path list Mode.Dict.t
+val foreign_objects : 'path t -> 'path list Source.t
+val plugins : 'path t -> 'path list Mode.Dict.t
+val src_dir : 'path t -> 'path
+val status : _ t -> Status.t
+val variant : _ t -> Variant.t option
+val default_implementation : _ t -> (Loc.t * Lib_name.t) option
+val kind : _ t -> Lib_kind.t
+val synopsis : _ t -> string option
+val jsoo_runtime : 'path t -> 'path list
+val jsoo_archive : 'path t -> 'path option
+val obj_dir : 'path t -> 'path Obj_dir.t
+val virtual_ : _ t -> Lib_modules.t Source.t option
+val main_module_name : _ t -> Dune_file.Library.Main_module_name.t
+val wrapped : _ t -> Wrapped.t Dune_file.Library.Inherited.t option
+val special_builtin_support : _ t -> Dune_file.Library.Special_builtin_support.t option
+val modes : _ t -> Mode.Dict.Set.t
+val implements : _ t -> (Loc.t * Lib_name.t) option
+val known_implementations : _ t -> (Loc.t * Lib_name.t) Variant.Map.t
+val requires : _ t -> Deps.t
+val ppx_runtime_deps : _ t -> (Loc.t * Lib_name.t) list
+val pps : _ t -> (Loc.t * Lib_name.t) list
+val sub_systems : _ t -> Sub_system_info.t Sub_system_name.Map.t
+val enabled : _ t -> Enabled_status.t
+val orig_src_dir : 'path t -> 'path option
+val version : _ t -> string option
+
+(* CR-someday diml: this should be [Path.t list], since some libraries
+   have multiple source directories because of [copy_files]. *)
+(** Directory where the source files for the library are located. Returns
+    the original src dir when it exists *)
+val best_src_dir : 'path t -> 'path
 
 type external_ = Path.t t
 type local = Path.Build.t t
@@ -90,7 +94,4 @@ val of_dune_lib
 
 val to_external : local -> external_
 
-(* CR-someday diml: this should be [Path.t list], since some libraries
-   have multiple source directories because of [copy_files]. *)
-(** Directory where the source files for the library are located. *)
-val orig_src_dir : 'path t -> 'path
+val as_local_exn : external_ -> local

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -87,7 +87,7 @@ type local = Path.Build.t t
 val of_library_stanza
   :  dir:Path.Build.t
   -> lib_config:Lib_config.t
-  -> (Loc.t * Lib_name.t) Variant.Map.t
+  -> known_implementations:(Loc.t * Lib_name.t) Variant.Map.t
   -> Dune_file.Library.t
   -> local
 

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -97,6 +97,6 @@ val of_dune_lib
   :  Sub_system_info.t Dune_package.Lib.t
   -> external_
 
-val to_external : local -> external_
+val of_local : local -> external_
 
 val as_local_exn : external_ -> local

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -38,22 +38,22 @@ module Enabled_status : sig
     | Disabled_because_of_enabled_if
 end
 
-type t = private
+type 'path t = private
   { loc              : Loc.t
   ; name             : Lib_name.t
   ; kind             : Lib_kind.t
   ; status           : Status.t
-  ; src_dir          : Path.t
-  ; orig_src_dir     : Path.t option
-  ; obj_dir          : Path.t Obj_dir.t
+  ; src_dir          : 'path
+  ; orig_src_dir     : 'path option
+  ; obj_dir          : 'path Obj_dir.t
   ; version          : string option
   ; synopsis         : string option
-  ; archives         : Path.t list Mode.Dict.t
-  ; plugins          : Path.t list Mode.Dict.t
-  ; foreign_objects  : Path.t list Source.t
-  ; foreign_archives : Path.t list Mode.Dict.t (** [.a/.lib/...] files *)
-  ; jsoo_runtime     : Path.t list
-  ; jsoo_archive     : Path.t option
+  ; archives         : 'path list Mode.Dict.t
+  ; plugins          : 'path list Mode.Dict.t
+  ; foreign_objects  : 'path list Source.t
+  ; foreign_archives : 'path list Mode.Dict.t (** [.a/.lib/...] files *)
+  ; jsoo_runtime     : 'path list
+  ; jsoo_archive     : 'path option
   ; requires         : Deps.t
   ; ppx_runtime_deps : (Loc.t * Lib_name.t) list
   ; pps              : (Loc.t * Lib_name.t) list
@@ -72,20 +72,25 @@ type t = private
   ; special_builtin_support : Dune_file.Library.Special_builtin_support.t option
   }
 
+type external_ = Path.t t
+type local = Path.Build.t t
+
 val of_library_stanza
   :  dir:Path.Build.t
   -> lib_config:Lib_config.t
   -> (Loc.t * Lib_name.t) Variant.Map.t
   -> Dune_file.Library.t
-  -> t
+  -> local
 
-val user_written_deps : t -> Dune_file.Lib_deps.t
+val user_written_deps : _ t -> Dune_file.Lib_deps.t
 
 val of_dune_lib
   :  Sub_system_info.t Dune_package.Lib.t
-  -> t
+  -> external_
+
+val to_external : local -> external_
 
 (* CR-someday diml: this should be [Path.t list], since some libraries
    have multiple source directories because of [copy_files]. *)
 (** Directory where the source files for the library are located. *)
-val orig_src_dir : t -> Path.t
+val orig_src_dir : 'path t -> 'path

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -1,4 +1,11 @@
-(** {1 Raw library descriptions} *)
+(** Raw library descriptions *)
+
+(** This module regroup all information about a library. We call such
+    descriptions "raw" as the names, such as the names of dependencies
+    are plain unresolved library names.
+
+    The [Lib] module takes care of resolving library names to actual
+    libraries. *)
 
 open Stdune
 

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -53,7 +53,8 @@ let findlib_init_code ~preds ~libs =
     List.filter
       ~f:(fun lib ->
         let info = Lib.info lib in
-        not (Lib_info.Status.is_private info.status))
+        let status = Lib_info.status info in
+        not (Lib_info.Status.is_private status))
       libs
   in
   Format.asprintf "%t@." (fun ppf ->
@@ -112,7 +113,8 @@ let handle_special_libs cctx =
             x :: insert l
           | Lib lib ->
             let info = Lib.info lib in
-            match info.special_builtin_support with
+            let special_builtin_support = Lib_info.special_builtin_support info in
+            match special_builtin_support with
             | Some Findlib_dynload ->
               let obj_dir = Obj_dir.of_local obj_dir in
               x :: Module (obj_dir, module_) :: l

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -142,7 +142,8 @@ module Of_sctx = struct
           Lib.Local.Set.find libs ~f:(fun l ->
             let l = Lib.Local.to_lib l in
             let info = Lib.info l in
-            Option.is_some info.virtual_)
+            let virtual_ = Lib_info.virtual_ info in
+            Option.is_some virtual_)
         ) in
         let t =
           add_stanzas

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -239,8 +239,8 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ~dir_kind
           , t.objs_dirs)
             ~f:(fun (lib : Lib.t) (src_dirs, obj_dirs) ->
               let info = Lib.info lib in
-              let orig_src_dir = Lib_info.orig_src_dir info in
-              ( Path.Set.add src_dirs (Path.drop_optional_build_context orig_src_dir)
+              let best_src_dir = Lib_info.best_src_dir info in
+              ( Path.Set.add src_dirs (Path.drop_optional_build_context best_src_dir)
               , let public_cmi_dir = Obj_dir.public_cmi_dir (Lib.obj_dir lib) in
                 Path.Set.add obj_dirs public_cmi_dir
               ))

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -9,7 +9,9 @@ let (++) = Path.Build.relative
 
 let lib_unique_name lib =
   let name = Lib.name lib in
-  match (Lib.info lib).status with
+  let info = Lib.info lib in
+  let status = Lib_info.status info in
+  match status with
   | Installed -> assert false
   | Public _  -> Lib_name.to_string name
   | Private scope_name ->
@@ -465,7 +467,8 @@ let setup_package_aliases sctx (pkg : Package.t) =
   )
 
 let entry_modules_by_lib sctx lib =
-  let dir = Lib.Local.src_dir lib in
+  let info = Lib.Local.info lib in
+  let dir = Lib_info.src_dir info in
   let name = Lib.name (Lib.Local.to_lib lib) in
   Dir_contents.get_without_rules sctx ~dir
   |> Dir_contents.modules_of_library ~name
@@ -633,7 +636,8 @@ let gen_rules sctx ~dir:_ rest =
     Option.iter (Lib.DB.find lib_db lib) ~f:(fun lib ->
       (* TODO instead of this hack, call memoized function that
          generates the rules for this library *)
-      let dir = (Lib.info lib).src_dir in
+      let info = Lib.info lib in
+      let dir = Lib_info.src_dir info in
       Build_system.load_dir ~dir)
   | "_html" :: lib_unique_name_or_pkg :: _ ->
     (* TODO we can be a better with the error handling in the case where

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -45,7 +45,8 @@ end = struct
       List.fold_left libs ~init:None ~f:(fun acc lib ->
         let scope_for_key =
           let info = Lib.info lib in
-          match info.status with
+          let status = Lib_info.status info in
+          match status with
           | Private scope_name   -> Some scope_name
           | Public _ | Installed -> None
         in
@@ -503,7 +504,8 @@ let get_cookies ~loc ~expander ~lib_name libs =
     Ok (
       List.concat_map libs ~f:(fun t ->
         let info = Lib.info t in
-        match info.kind with
+        let kind = Lib_info.kind info in
+        match kind with
         | Normal -> []
         | Ppx_rewriter {cookies}
         | Ppx_deriver {cookies} ->

--- a/src/sub_system.ml
+++ b/src/sub_system.ml
@@ -61,9 +61,10 @@ module Register_backend(M : Backend) = struct
              (List.map backends ~f:(fun t ->
                 let lib = M.lib t in
                 let info = Lib.info lib in
+                let src_dir = Lib_info.src_dir info in
                 sprintf "- %S in %s"
                   (Lib_name.to_string (Lib.name lib))
-                  (Path.to_string_maybe_quoted info.src_dir))))
+                  (Path.to_string_maybe_quoted src_dir))))
       | No_backend_found ->
         Errors.exnf loc "No %s found." (M.desc ~plural:false)
       | Other exn ->

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -43,7 +43,8 @@ let libs_under_dir sctx ~db ~dir =
                (* still need to make sure that it's not coming from an external
                   source *)
                let info = Lib.info lib in
-               if Path.is_descendant ~of_:(Path.build dir) info.src_dir then
+               let src_dir = Lib_info.src_dir info in
+               if Path.is_descendant ~of_:(Path.build dir) src_dir then
                  lib :: acc
                else
                  acc (* external lib with a name matching our private name *)

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -247,7 +247,8 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
     | Some vlib ->
       let info = Lib.info vlib in
       let virtual_ =
-        match info.virtual_ with
+        let virtual_ = Lib_info.virtual_ info in
+        match virtual_ with
         | None ->
           Errors.fail lib.buildable.loc
             "Library %a isn't virtual and cannot be implemented"
@@ -255,7 +256,8 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         | Some v -> v
       in
       let (vlib_modules, vlib_foreign_objects) =
-        match virtual_, info.foreign_objects with
+        let foreign_objects = Lib_info.foreign_objects info in
+        match virtual_, foreign_objects with
         | External _, Local
         | Local, External _ -> assert false
         | External lib_modules, External fa -> (lib_modules, fa)
@@ -263,7 +265,8 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
           let name = Lib.name vlib in
           let vlib = Lib.Local.of_lib_exn vlib in
           let dir_contents =
-            let dir = Lib.Local.src_dir vlib in
+            let info = Lib.Local.info vlib in
+            let dir = Lib_info.src_dir info in
             Dir_contents.get_without_rules sctx ~dir
           in
           let modules =
@@ -299,7 +302,7 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope ~modules =
         | External _ ->
           let impl_obj_dir = Dune_file.Library.obj_dir ~dir lib in
           let impl_cm_kind =
-            let { Mode.Dict. byte; native = _ } = (Lib.info vlib).modes in
+            let { Mode.Dict. byte; native = _ } = Lib_info.modes info in
             Mode.cm_kind (if byte then Byte else Native)
           in
           external_dep_graph sctx ~impl_cm_kind ~impl_obj_dir ~vlib_modules


### PR DESCRIPTION
This PR plans to accomplish:

- [x] Index Lib_info.t by the type of paths

- [x] Make Lib_info.t abstract

- [ ] Move the following to Lib_info.t:

```ocaml
  val stubs : t -> dir:Path.Build.t -> Path.Build.t
  val stubs_archive : t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
  val dll : t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
  val archive : t -> dir:Path.Build.t -> ext:string -> Path.Build.t
```

After this change, library artifacts will be consumed the same way everywhere.

- [ ] Get rid of `Lib_archives` and move its function to `Lib_info.t`