### PR TITLE
[odoc] do not create .odoc rules for alias module

### DIFF
--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -495,7 +495,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     );
 
     Odoc.setup_library_odoc_rules sctx lib ~obj_dir ~requires:requires_compile
-      ~modules ~dep_graphs ~scope;
+      ~modules:(Lib_modules.modules lib_modules) ~dep_graphs ~scope;
 
     let flags =
       match alias_module with


### PR DESCRIPTION
This module is generated and should not be visible to the user, hence
there's no need to extract docs from it.

I believe the previous code only compiled it by accident, since the modules variable included the modules for compilation