### PR TITLE
Move jsoo options to Compilation_context

### DIFF
--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -61,6 +61,7 @@ type t =
   ; no_keep_locs         : bool
   ; opaque               : bool
   ; stdlib               : Dune_file.Library.Stdlib.t option
+  ; js_of_ocaml          : Dune_file.Js_of_ocaml.t option
   ; vimpl                : Vimpl.t option
   }
 
@@ -81,6 +82,7 @@ let preprocessing        t = t.preprocessing
 let no_keep_locs         t = t.no_keep_locs
 let opaque               t = t.opaque
 let stdlib               t = t.stdlib
+let js_of_ocaml          t = t.js_of_ocaml
 let vimpl                t = t.vimpl
 
 let context              t = Super_context.context t.super_context
@@ -91,7 +93,7 @@ let create ~super_context ~scope ~expander ~obj_dir
       ~modules ?alias_module ?lib_interface_module ~flags
       ~requires_compile ~requires_link
       ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
-      ~opaque ?stdlib () =
+      ~opaque ?stdlib ?js_of_ocaml () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link
@@ -114,6 +116,7 @@ let create ~super_context ~scope ~expander ~obj_dir
   ; no_keep_locs
   ; opaque
   ; stdlib
+  ; js_of_ocaml
   ; vimpl
   }
 

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -30,6 +30,7 @@ val create
   -> ?no_keep_locs         : bool
   -> opaque                : bool
   -> ?stdlib               : Dune_file.Library.Stdlib.t
+  -> ?js_of_ocaml          : Dune_file.Js_of_ocaml.t
   -> unit
   -> t
 
@@ -54,6 +55,7 @@ val preprocessing        : t -> Preprocessing.t
 val no_keep_locs         : t -> bool
 val opaque               : t -> bool
 val stdlib               : t -> Dune_file.Library.Stdlib.t option
+val js_of_ocaml          : t -> Dune_file.Js_of_ocaml.t option
 
 (** Information for implementation of virtual libraries. *)
 val vimpl                : t -> Vimpl.t option

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -121,7 +121,6 @@ let link_exe
       ~top_sorted_modules
       ~link_time_code_gen
       ?(link_flags=Build.arr (fun _ -> []))
-      ?(js_of_ocaml=Dune_file.Js_of_ocaml.default)
       cctx
   =
   let sctx     = CC.super_context cctx in
@@ -134,6 +133,10 @@ let link_exe
   let exe = exe_path_from_name cctx ~name ~linkage in
   let compiler = Option.value_exn (Context.compiler ctx mode) in
   let kind = Mode.cm_kind mode in
+  let js_of_ocaml =
+    CC.js_of_ocaml cctx
+    |> Option.value ~default:Dune_file.Js_of_ocaml.default
+  in
   let cm_files =
     let modules = CC.modules cctx in
     Cm_files.make_exe ~obj_dir ~modules ~top_sorted_modules
@@ -195,13 +198,12 @@ let build_and_link_many
       ~programs
       ~linkages
       ?link_flags
-      ?(js_of_ocaml=Dune_file.Js_of_ocaml.default)
       cctx
   =
   let dep_graphs = Ocamldep.rules cctx in
 
   (* CR-someday jdimino: this should probably say [~dynlink:false] *)
-  Module_compilation.build_modules cctx ~js_of_ocaml ~dep_graphs;
+  Module_compilation.build_modules cctx ~dep_graphs;
 
   let link_time_code_gen = Link_time_code_gen.handle_special_libs cctx in
   List.iter programs ~f:(fun { Program.name; main_module_name ; loc } ->
@@ -217,7 +219,6 @@ let build_and_link_many
         ~name
         ~linkage
         ~top_sorted_modules
-        ~js_of_ocaml
         ~link_time_code_gen
         ?link_flags))
 

--- a/src/exe.mli
+++ b/src/exe.mli
@@ -42,7 +42,6 @@ val build_and_link
   :  program:Program.t
   -> linkages:Linkage.t list
   -> ?link_flags:(unit, string list) Build.t
-  -> ?js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> Compilation_context.t
   -> unit
 
@@ -50,7 +49,6 @@ val build_and_link_many
   :  programs:Program.t list
   -> linkages:Linkage.t list
   -> ?link_flags:(unit, string list) Build.t
-  -> ?js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> Compilation_context.t
   -> unit
 

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -91,6 +91,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       ~requires_link
       ~requires_compile
       ~preprocessing:pp
+      ~js_of_ocaml:exes.buildable.js_of_ocaml
       ~opaque:(SC.opaque sctx)
   in
 
@@ -99,8 +100,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
   Exe.build_and_link_many cctx
     ~programs
     ~linkages
-    ~link_flags
-    ~js_of_ocaml:exes.buildable.js_of_ocaml;
+    ~link_flags;
 
   (cctx,
    let objs_dirs =

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -178,10 +178,11 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
               ; Hidden_targets other_targets
               ]))))
 
-let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
+let build_module ?sandbox ?dynlink ~dep_graphs cctx m =
   List.iter Cm_kind.all ~f:(fun cm_kind ->
     build_cm cctx m ?sandbox ?dynlink ~dep_graphs ~cm_kind);
-  Option.iter js_of_ocaml ~f:(fun js_of_ocaml ->
+  Compilation_context.js_of_ocaml cctx
+  |> Option.iter ~f:(fun js_of_ocaml ->
     (* Build *.cmo.js *)
     let sctx     = CC.super_context cctx in
     let dir      = CC.dir           cctx in
@@ -191,13 +192,13 @@ let build_module ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx m =
     SC.add_rules sctx ~dir
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
 
-let build_modules ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs cctx =
+let build_modules ?sandbox ?dynlink ~dep_graphs cctx =
   Module.Name.Map.iter
     (match CC.alias_module cctx with
      | None -> CC.modules cctx
      | Some (m : Module.t) ->
        Module.Name.Map.remove (CC.modules cctx) (Module.name m))
-    ~f:(build_module cctx ?sandbox ?js_of_ocaml ?dynlink ~dep_graphs)
+    ~f:(build_module cctx ?sandbox ?dynlink ~dep_graphs)
 
 let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   let sctx     = CC.super_context cctx in

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -9,7 +9,6 @@ open Import
  *)
 val build_module
   :  ?sandbox:bool
-  -> ?js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> ?dynlink:bool
   -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
@@ -19,7 +18,6 @@ val build_module
 (** Setup rules to build all of the modules in the compilation context. *)
 val build_modules
   :  ?sandbox:bool
-  -> ?js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> ?dynlink:bool
   -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t


### PR DESCRIPTION
Those were always passed manually along with the compilation context.
Doing it via the compilation context reduces the boilerplate.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>