### PR TITLE
Set ppx.exe to be built for the compiling host.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   the cost of building unnecessary artifacts in some cases. Some of these extra
   artifacts can fail to built, so this is a breaking change. (#2268, @rgrinberg)
 
+- Build `ppx.exe` as compiling host binary. (#2286, fixes #2252, @toots, review
+  by @rgrinberg and @diml)
+
 1.11.0 (unreleased)
 -------------------
 

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -472,6 +472,7 @@ end
 
 let get_compat_ppx_exe sctx ~name ~kind =
   let name = Lib_name.to_string name in
+  let sctx = SC.host sctx in
   match (kind : Compat_ppx_exe_kind.t) with
   | Dune ->
     ppx_exe sctx ~key:name ~dir_kind:Dune


### PR DESCRIPTION
 Fixes: #2252