### PR TITLE
Add module kind for implementations of virtual modules

### DIFF
--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -204,7 +204,7 @@ let install_rules ~sctx ~dir s =
   | { Dune_file.Coq. public = Some { package; _ } ; _ } ->
     let scope = SC.find_scope_by_dir sctx dir in
     let dir_contents =
-      Dir_contents.get_without_rules sctx ~dir
+      Dir_contents.get sctx ~dir
     in
     let name = Dune_file.Coq.best_name s in
     (* This is the usual root for now, Coq + Dune will change it! *)

--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -64,7 +64,7 @@ end
 
 let make_top_closed_implementations ~name ~f ts modules =
   Build.memoize name (
-    let filter_out_intf_only = List.filter ~f:Module.has_impl in
+    let filter_out_intf_only = List.filter ~f:(Module.has ~ml_kind:Impl) in
     f ts (filter_out_intf_only modules)
     >>^ filter_out_intf_only)
 
@@ -114,8 +114,9 @@ module Ml_kind = struct
     | None, Some d -> Some d
     | Some (mv, _), Some (mi, i) ->
       if Module.obj_name mv = Module.obj_name mi
-      && Module.intf_only mv
-      && Module.impl_only mi then
+      && Module.kind mv = Virtual
+      && Module.kind mi = Impl (* TODO more precise once we have right kind *)
+      then
         match ml_kind with
         | Impl -> Some (mi, i)
         | Intf -> None

--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -115,7 +115,7 @@ module Ml_kind = struct
     | Some (mv, _), Some (mi, i) ->
       if Module.obj_name mv = Module.obj_name mi
       && Module.kind mv = Virtual
-      && Module.kind mi = Impl (* TODO more precise once we have right kind *)
+      && Module.kind mi = Impl_vmodule
       then
         match ml_kind with
         | Impl -> Some (mi, i)

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -33,6 +33,7 @@ module Modules = struct
             Modules_field_evaluator.eval ~modules
               ~buildable:lib.buildable
               ~virtual_modules:lib.virtual_modules
+              ~existing_virtual_modules:Module.Name.Set.empty
               ~private_modules:(
                 Option.value ~default:Ordered_set_lang.standard
                   lib.private_modules)
@@ -74,6 +75,7 @@ module Modules = struct
               ~buildable:exes.buildable
               ~virtual_modules:None
               ~private_modules:Ordered_set_lang.standard
+              ~existing_virtual_modules:Module.Name.Set.empty
           in
           Right (exes, modules)
         | _ -> Skip)

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -21,8 +21,217 @@ module Modules = struct
     ; executables = String.Map.empty
     ; rev_map = Module.Name.Map.empty
     }
+end
 
-  let make (d : _ Dir_with_dune.t) ~virtual_modules_of_impl ~modules =
+type t =
+  { kind : kind
+  ; dir : Path.Build.t
+  ; text_files : String.Set.t
+  ; modules : Modules.t Memo.Lazy.t
+  ; c_sources : C_sources.t Memo.Lazy.t
+  ; mlds : (Dune_file.Documentation.t * Path.Build.t list) list Memo.Lazy.t
+  ; coq_modules : Coq_module.t list Lib_name.Map.t Memo.Lazy.t
+  }
+
+and kind =
+  | Standalone
+  | Group_root of t list
+  | Group_part
+
+type gen_rules_result =
+  | Standalone_or_root of t * t list
+  | Group_part of Path.Build.t
+
+let dir t = t.dir
+
+let dirs t =
+  match t.kind with
+  | Standalone -> [t]
+  | Group_root subs -> t :: subs
+  | Group_part ->
+    Code_error.raise "Dir_contents.dirs called on a group part"
+      [ "dir", Path.Build.to_dyn t.dir ]
+
+let text_files t = t.text_files
+
+let modules_of_library t ~name =
+  let map = (Memo.Lazy.force t.modules).libraries in
+  match Lib_name.Map.find map name with
+  | Some m -> m
+  | None ->
+    Errors.code_error "Dir_contents.modules_of_library"
+      [ "name", Lib_name.to_sexp name
+      ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
+      ]
+
+let modules_of_executables t ~first_exe =
+  let map = (Memo.Lazy.force t.modules).executables in
+  match String.Map.find map first_exe with
+  | Some m -> m
+  | None ->
+    Errors.code_error "Dir_contents.modules_of_executables"
+      [ "first_exe", Sexp.Encoder.string first_exe
+      ; "available", Sexp.Encoder.(list string) (String.Map.keys map)
+      ]
+
+let c_sources_of_library t ~name =
+  C_sources.for_lib (Memo.Lazy.force t.c_sources)
+    ~dir:(Path.build t.dir) ~name
+
+let lookup_module t name =
+  Module.Name.Map.find (Memo.Lazy.force t.modules).rev_map name
+
+let mlds t (doc : Documentation.t) =
+  let map = Memo.Lazy.force t.mlds in
+  match
+    List.find_map map ~f:(fun (doc', x) ->
+      Option.some_if (Loc.equal doc.loc doc'.loc) x)
+  with
+  | Some x -> x
+  | None ->
+    Errors.code_error "Dir_contents.mlds"
+      [ "doc", Loc.to_sexp doc.loc
+      ; "available", Sexp.Encoder.(list Loc.to_sexp)
+                       (List.map map ~f:(fun (d, _) -> d.Documentation.loc))
+      ]
+
+let coq_modules_of_library t ~name =
+  let map = Memo.Lazy.force t.coq_modules in
+  match Lib_name.Map.find map name with
+  | Some x -> x
+  | None ->
+    Errors.code_error "Dir_contents.coq_modules_of_library"
+      [ "name", Lib_name.to_sexp name
+      ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
+      ]
+
+let modules_of_files ~dir ~files =
+  let dir = Path.build dir in
+  let make_module syntax base fn =
+    (Module.Name.of_string base,
+     Module.File.make syntax (Path.relative dir fn))
+  in
+  let impl_files, intf_files =
+    String.Set.to_list files
+    |> List.filter_partition_map ~f:(fun fn ->
+      (* we aren't using Filename.extension because we want to handle
+         filenames such as foo.cppo.ml *)
+      match String.lsplit2 fn ~on:'.' with
+      | Some (s, "ml" ) -> Left  (make_module OCaml  s fn)
+      | Some (s, "re" ) -> Left  (make_module Reason s fn)
+      | Some (s, "mli") -> Right (make_module OCaml  s fn)
+      | Some (s, "rei") -> Right (make_module Reason s fn)
+      | _ -> Skip)
+  in
+  let parse_one_set (files : (Module.Name.t * Module.File.t) list)  =
+    match Module.Name.Map.of_list files with
+    | Ok x -> x
+    | Error (name, f1, f2) ->
+      let src_dir = Path.drop_build_context_exn dir in
+      die "Too many files for module %a in %a:\
+           \n- %a\
+           \n- %a"
+        Module.Name.pp name
+        Path.Source.pp src_dir
+        Path.pp f1.path
+        Path.pp f2.path
+  in
+  let impls = parse_one_set impl_files in
+  let intfs = parse_one_set intf_files in
+  Module.Name.Map.merge impls intfs ~f:(fun name impl intf ->
+    Some (Module.Source.make name ?impl ?intf))
+
+let build_mlds_map (d : _ Dir_with_dune.t) ~files =
+  let dir = d.ctx_dir in
+  let mlds = Memo.lazy_ (fun () -> (
+      String.Set.fold files ~init:String.Map.empty ~f:(fun fn acc ->
+        match String.lsplit2 fn ~on:'.' with
+        | Some (s, "mld") -> String.Map.add acc s fn
+        | _ -> acc)))
+  in
+  List.filter_map d.data ~f:(function
+    | Documentation doc ->
+      let mlds =
+        let mlds = Memo.Lazy.force mlds in
+        Ordered_set_lang.String.eval_unordered doc.mld_files
+          ~parse:(fun ~loc s ->
+            match String.Map.find mlds s with
+            | Some s ->
+              s
+            | None ->
+              Errors.fail loc "%s.mld doesn't exist in %s" s
+                (Path.to_string_maybe_quoted
+                   (Path.drop_optional_build_context (Path.build dir)))
+          )
+          ~standard:mlds
+      in
+      Some (doc, List.map (String.Map.values mlds) ~f:(Path.Build.relative dir))
+    | _ -> None)
+
+let coq_modules_of_files ~subdirs =
+  let filter_v_files (dir, local, files) =
+    (dir, local, String.Set.filter files ~f:(fun f -> Filename.check_suffix f ".v")) in
+  let subdirs = List.map subdirs ~f:filter_v_files in
+  let build_mod_dir (dir, prefix, files) =
+    String.Set.to_list files |> List.map ~f:(fun file ->
+      let name, _ = Filename.split_extension file in
+      let name = Coq_module.Name.make name in
+      Coq_module.make
+        ~source:(Path.Build.relative dir file)
+        ~prefix ~name) in
+  let modules = List.concat_map ~f:build_mod_dir subdirs in
+  modules
+
+(* TODO: Build reverse map and check duplicates, however, are duplicates harmful?
+ * In Coq all libs are "wrapped" so including a module twice is not so bad.
+ *)
+let build_coq_modules_map (d : _ Dir_with_dune.t) ~dir ~modules =
+  List.fold_left d.data ~init:Lib_name.Map.empty ~f:(fun map -> function
+    | Coq.T coq ->
+      let modules = Coq_module.Eval.eval coq.modules
+        ~parse:(Coq_module.parse ~dir) ~standard:modules in
+      Lib_name.Map.add map (Dune_file.Coq.best_name coq) modules
+    | _ -> map)
+
+module rec Load : sig
+  val get : Super_context.t -> dir:Path.Build.t -> t
+  val gen_rules : Super_context.t -> dir:Path.Build.t -> gen_rules_result
+end = struct
+  let virtual_modules_of_impl sctx impl
+    : Modules_field_evaluator.Implementation.t Or_exn.t =
+    match Lib.implements impl with
+    | None -> assert false
+    | Some vlib ->
+      let open Result.O in
+      let+ vlib = vlib in
+      let info = Lib.info vlib in
+      let lib_modules =
+        match Option.value_exn (Lib_info.virtual_ info) with
+        | External lib_modules -> lib_modules
+        | Local ->
+          let src_dir =
+            Lib_info.src_dir info
+            |> Path.as_in_build_dir_exn
+          in
+          let t = Load.get sctx ~dir:src_dir in
+          modules_of_library t ~name:(Lib.name vlib)
+      in
+      let existing_virtual_modules =
+        Lib_modules.virtual_modules lib_modules
+        |> Module.Name.Map.keys
+        |> Module.Name.Set.of_list
+      in
+      let allow_new_public_modules =
+        Lib_modules.wrapped lib_modules
+        |> Wrapped.to_bool
+        |> not
+      in
+      { Modules_field_evaluator.Implementation.
+        existing_virtual_modules
+      ; allow_new_public_modules
+      }
+
+  let make_modules sctx (d : _ Dir_with_dune.t) ~modules =
     let scope = d.scope in
     let libs, exes =
       List.filter_partition_map d.data ~f:(fun stanza ->
@@ -40,7 +249,7 @@ module Modules = struct
             match lib.implements, lib.virtual_modules with
             | Some _, None ->
               Implementation (
-                virtual_modules_of_impl (Lazy.force resolved)
+                virtual_modules_of_impl sctx (Lazy.force resolved)
                 |> Result.ok_exn)
             | None, Some virtual_modules ->
               Virtual { Modules_field_evaluator.Virtual.
@@ -177,474 +386,264 @@ module Modules = struct
                or executable.";
             b)
     in
-    { libraries; executables; rev_map }
-end
+    { Modules. libraries; executables; rev_map }
 
-type t =
-  { kind : kind
-  ; dir : Path.Build.t
-  ; text_files : String.Set.t
-  ; modules : Modules.t Memo.Lazy.t
-  ; c_sources : C_sources.t Memo.Lazy.t
-  ; mlds : (Dune_file.Documentation.t * Path.Build.t list) list Memo.Lazy.t
-  ; coq_modules : Coq_module.t list Lib_name.Map.t Memo.Lazy.t
+  (* As a side-effect, setup user rules and copy_files rules. *)
+  let load_text_files sctx ft_dir
+        { Dir_with_dune.
+          ctx_dir = dir
+        ; src_dir
+        ; scope = _
+        ; data = stanzas
+        ; kind = _
+        ; dune_version = _
+        } =
+    (* Interpret a few stanzas in order to determine the list of
+       files generated by the user. *)
+    let expander = Super_context.expander sctx ~dir in
+    let generated_files =
+      List.concat_map stanzas ~f:(fun stanza ->
+        match (stanza : Stanza.t) with
+        | Coqpp.T { modules; _ } ->
+          List.map modules ~f:(fun m -> m ^ ".ml")
+        | Menhir.T menhir ->
+          Menhir_rules.targets menhir
+        | Rule rule ->
+          Simple_rules.user_rule sctx rule ~dir ~expander
+          |> Path.Build.Set.to_list
+          |> List.map ~f:Path.Build.basename
+        | Copy_files def ->
+          Simple_rules.copy_files sctx def ~src_dir ~dir ~expander
+          |> Path.Set.to_list
+          |> List.map ~f:Path.basename
+        | Library { buildable; _ } | Executables { buildable; _ } ->
+          (* Manually add files generated by the (select ...)
+             dependencies *)
+          List.filter_map buildable.libraries ~f:(fun dep ->
+            match (dep : Dune_file.Lib_dep.t) with
+            | Direct _ -> None
+            | Select s -> Some s.result_fn)
+        | _ -> [])
+      |> String.Set.of_list
+    in
+    String.Set.union generated_files (File_tree.Dir.files ft_dir)
+
+
+  type result0_here = {
+    t : t;
+    (* [rules] includes rules for subdirectories too *)
+    rules : Rules.t option;
+    subdirs : t Path.Build.Map.t;
   }
 
-and kind =
-  | Standalone
-  | Group_root of t list
-  | Group_part
+  type result0 =
+    | See_above of Path.Build.t
+    | Here of result0_here
 
-let dir t = t.dir
+  module Key = struct
+    module Super_context = Super_context.As_memo_key
 
-let dirs t =
-  match t.kind with
-  | Standalone -> [t]
-  | Group_root subs -> t :: subs
-  | Group_part ->
-    Code_error.raise "Dir_contents.dirs called on a group part"
-      [ "dir", Path.Build.to_dyn t.dir ]
+    type t = Super_context.t * Path.Build.t
 
-let text_files t = t.text_files
+    let to_dyn (sctx, path) =
+      Dyn.Tuple [Super_context.to_dyn sctx; Path.Build.to_dyn path;]
 
-let modules_of_library t ~name =
-  let map = (Memo.Lazy.force t.modules).libraries in
-  match Lib_name.Map.find map name with
-  | Some m -> m
-  | None ->
-    Errors.code_error "Dir_contents.modules_of_library"
-      [ "name", Lib_name.to_sexp name
-      ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
-      ]
+    let equal = Tuple.T2.equal Super_context.equal Path.Build.equal
+    let hash = Tuple.T2.hash Super_context.hash Path.Build.hash
+  end
 
-let modules_of_executables t ~first_exe =
-  let map = (Memo.Lazy.force t.modules).executables in
-  match String.Map.find map first_exe with
-  | Some m -> m
-  | None ->
-    Errors.code_error "Dir_contents.modules_of_executables"
-      [ "first_exe", Sexp.Encoder.string first_exe
-      ; "available", Sexp.Encoder.(list string) (String.Map.keys map)
-      ]
+  let check_no_qualified loc qualif_mode =
+    if qualif_mode = Include_subdirs.Qualified then
+      Errors.fail loc "(include_subdirs qualified) is not supported yet"
 
-let c_sources_of_library t ~name =
-  C_sources.for_lib (Memo.Lazy.force t.c_sources)
-    ~dir:(Path.build t.dir) ~name
+  let check_no_unqualified loc qualif_mode =
+    if qualif_mode = Include_subdirs.Unqualified then
+      Errors.fail loc "(include_subdirs qualified) is not supported yet"
 
-let lookup_module t name =
-  Module.Name.Map.find (Memo.Lazy.force t.modules).rev_map name
-
-let mlds t (doc : Documentation.t) =
-  let map = Memo.Lazy.force t.mlds in
-  match
-    List.find_map map ~f:(fun (doc', x) ->
-      Option.some_if (Loc.equal doc.loc doc'.loc) x)
-  with
-  | Some x -> x
-  | None ->
-    Errors.code_error "Dir_contents.mlds"
-      [ "doc", Loc.to_sexp doc.loc
-      ; "available", Sexp.Encoder.(list Loc.to_sexp)
-                       (List.map map ~f:(fun (d, _) -> d.Documentation.loc))
-      ]
-
-let coq_modules_of_library t ~name =
-  let map = Memo.Lazy.force t.coq_modules in
-  match Lib_name.Map.find map name with
-  | Some x -> x
-  | None ->
-    Errors.code_error "Dir_contents.coq_modules_of_library"
-      [ "name", Lib_name.to_sexp name
-      ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
-      ]
-
-(* As a side-effect, setup user rules and copy_files rules. *)
-let load_text_files sctx ft_dir
-      { Dir_with_dune.
-        ctx_dir = dir
-      ; src_dir
-      ; scope = _
-      ; data = stanzas
-      ; kind = _
-      ; dune_version = _
-      } =
-  (* Interpret a few stanzas in order to determine the list of
-     files generated by the user. *)
-  let expander = Super_context.expander sctx ~dir in
-  let generated_files =
-    List.concat_map stanzas ~f:(fun stanza ->
-      match (stanza : Stanza.t) with
-      | Coqpp.T { modules; _ } ->
-        List.map modules ~f:(fun m -> m ^ ".ml")
-      | Menhir.T menhir ->
-        Menhir_rules.targets menhir
-      | Rule rule ->
-        Simple_rules.user_rule sctx rule ~dir ~expander
-        |> Path.Build.Set.to_list
-        |> List.map ~f:Path.Build.basename
-      | Copy_files def ->
-        Simple_rules.copy_files sctx def ~src_dir ~dir ~expander
-        |> Path.Set.to_list
-        |> List.map ~f:Path.basename
-      | Library { buildable; _ } | Executables { buildable; _ } ->
-        (* Manually add files generated by the (select ...)
-           dependencies *)
-        List.filter_map buildable.libraries ~f:(fun dep ->
-          match (dep : Dune_file.Lib_dep.t) with
-          | Direct _ -> None
-          | Select s -> Some s.result_fn)
-      | _ -> [])
-    |> String.Set.of_list
-  in
-  String.Set.union generated_files (File_tree.Dir.files ft_dir)
-
-let modules_of_files ~dir ~files =
-  let dir = Path.build dir in
-  let make_module syntax base fn =
-    (Module.Name.of_string base,
-     Module.File.make syntax (Path.relative dir fn))
-  in
-  let impl_files, intf_files =
-    String.Set.to_list files
-    |> List.filter_partition_map ~f:(fun fn ->
-      (* we aren't using Filename.extension because we want to handle
-         filenames such as foo.cppo.ml *)
-      match String.lsplit2 fn ~on:'.' with
-      | Some (s, "ml" ) -> Left  (make_module OCaml  s fn)
-      | Some (s, "re" ) -> Left  (make_module Reason s fn)
-      | Some (s, "mli") -> Right (make_module OCaml  s fn)
-      | Some (s, "rei") -> Right (make_module Reason s fn)
-      | _ -> Skip)
-  in
-  let parse_one_set (files : (Module.Name.t * Module.File.t) list)  =
-    match Module.Name.Map.of_list files with
-    | Ok x -> x
-    | Error (name, f1, f2) ->
-      let src_dir = Path.drop_build_context_exn dir in
-      die "Too many files for module %a in %a:\
-           \n- %a\
-           \n- %a"
-        Module.Name.pp name
-        Path.Source.pp src_dir
-        Path.pp f1.path
-        Path.pp f2.path
-  in
-  let impls = parse_one_set impl_files in
-  let intfs = parse_one_set intf_files in
-  Module.Name.Map.merge impls intfs ~f:(fun name impl intf ->
-    Some (Module.Source.make name ?impl ?intf))
-
-
-let build_mlds_map (d : _ Dir_with_dune.t) ~files =
-  let dir = d.ctx_dir in
-  let mlds = Memo.lazy_ (fun () -> (
-      String.Set.fold files ~init:String.Map.empty ~f:(fun fn acc ->
-        match String.lsplit2 fn ~on:'.' with
-        | Some (s, "mld") -> String.Map.add acc s fn
-        | _ -> acc)))
-  in
-  List.filter_map d.data ~f:(function
-    | Documentation doc ->
-      let mlds =
-        let mlds = Memo.Lazy.force mlds in
-        Ordered_set_lang.String.eval_unordered doc.mld_files
-          ~parse:(fun ~loc s ->
-            match String.Map.find mlds s with
-            | Some s ->
-              s
-            | None ->
-              Errors.fail loc "%s.mld doesn't exist in %s" s
-                (Path.to_string_maybe_quoted
-                   (Path.drop_optional_build_context (Path.build dir)))
-          )
-          ~standard:mlds
+  let get0_impl (sctx, dir) : result0 =
+    let dir_status_db = Super_context.dir_status_db sctx in
+    match Dir_status.DB.get dir_status_db ~dir with
+    | Standalone x ->
+      (match x with
+       | Some (ft_dir, Some d) ->
+         let files, rules =
+           Rules.collect_opt (fun () -> load_text_files sctx ft_dir d)
+         in
+         Here {
+           t = { kind = Standalone
+               ; dir
+               ; text_files = files
+               ; modules = Memo.lazy_ (fun () ->
+                   make_modules sctx d
+                     ~modules:(modules_of_files ~dir:d.ctx_dir ~files))
+               ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
+               ; c_sources = Memo.lazy_ (fun () ->
+                   let dune_version = d.dune_version in
+                   C_sources.make d
+                     ~c_sources:(
+                       C_sources.load_sources ~dune_version ~dir:d.ctx_dir ~files))
+               ; coq_modules = Memo.lazy_ (fun () ->
+                   build_coq_modules_map d ~dir:d.ctx_dir
+                     ~modules:(
+                       coq_modules_of_files ~subdirs:[dir,[],files]))
+               };
+           rules;
+           subdirs = Path.Build.Map.empty;
+         }
+       | Some (_, None)
+       | None ->
+         Here {
+           t = { kind = Standalone
+               ; dir
+               ; text_files = String.Set.empty
+               ; modules = Memo.Lazy.of_val Modules.empty
+               ; mlds = Memo.Lazy.of_val []
+               ; c_sources = Memo.Lazy.of_val C_sources.empty
+               ; coq_modules = Memo.Lazy.of_val Lib_name.Map.empty
+               };
+           rules = None;
+           subdirs = Path.Build.Map.empty;
+         })
+    | Is_component_of_a_group_but_not_the_root { group_root; _ } ->
+      See_above group_root
+    | Group_root (ft_dir, qualif_mode, d) ->
+      let rec walk ft_dir ~dir ~local acc =
+        match
+          Dir_status.DB.get dir_status_db ~dir
+        with
+        | Is_component_of_a_group_but_not_the_root { stanzas = d; group_root = _ } ->
+          let files =
+            match d with
+            | None -> File_tree.Dir.files ft_dir
+            | Some d -> load_text_files sctx ft_dir d
+          in
+          walk_children ft_dir ~dir ~local ((dir, List.rev local, files) :: acc)
+        | _ -> acc
+      and walk_children ft_dir ~dir ~local acc =
+        String.Map.foldi (File_tree.Dir.sub_dirs ft_dir) ~init:acc
+          ~f:(fun name ft_dir acc ->
+            let dir = Path.Build.relative dir name in
+            let local = if qualif_mode = Qualified then name :: local else local in
+            walk ft_dir ~dir ~local acc)
       in
-      Some (doc, List.map (String.Map.values mlds) ~f:(Path.Build.relative dir))
-    | _ -> None)
-
-let coq_modules_of_files ~subdirs =
-  let filter_v_files (dir, local, files) =
-    (dir, local, String.Set.filter files ~f:(fun f -> Filename.check_suffix f ".v")) in
-  let subdirs = List.map subdirs ~f:filter_v_files in
-  let build_mod_dir (dir, prefix, files) =
-    String.Set.to_list files |> List.map ~f:(fun file ->
-      let name, _ = Filename.split_extension file in
-      let name = Coq_module.Name.make name in
-      Coq_module.make
-        ~source:(Path.Build.relative dir file)
-        ~prefix ~name) in
-  let modules = List.concat_map ~f:build_mod_dir subdirs in
-  modules
-
-(* TODO: Build reverse map and check duplicates, however, are duplicates harmful?
- * In Coq all libs are "wrapped" so including a module twice is not so bad.
- *)
-let build_coq_modules_map (d : _ Dir_with_dune.t) ~dir ~modules =
-  List.fold_left d.data ~init:Lib_name.Map.empty ~f:(fun map -> function
-    | Coq.T coq ->
-      let modules = Coq_module.Eval.eval coq.modules
-        ~parse:(Coq_module.parse ~dir) ~standard:modules in
-      Lib_name.Map.add map (Dune_file.Coq.best_name coq) modules
-    | _ -> map)
-
-type result0_here = {
-  t : t;
-  (* [rules] includes rules for subdirectories too *)
-  rules : Rules.t option;
-  subdirs : t Path.Build.Map.t;
-}
-
-type result0 =
-  | See_above of Path.Build.t
-  | Here of result0_here
-
-let get_fdecl : (Super_context.t -> dir:Path.Build.t -> t) Fdecl.t =
-  Fdecl.create ()
-
-module Key = struct
-  module Super_context = Super_context.As_memo_key
-
-  type t = Super_context.t * Path.Build.t
-
-  let to_dyn (sctx, path) =
-    Dyn.Tuple [Super_context.to_dyn sctx; Path.Build.to_dyn path;]
-
-  let equal = Tuple.T2.equal Super_context.equal Path.Build.equal
-  let hash = Tuple.T2.hash Super_context.hash Path.Build.hash
-end
-
-let check_no_qualified loc qualif_mode =
-  if qualif_mode = Include_subdirs.Qualified then
-    Errors.fail loc "(include_subdirs qualified) is not supported yet"
-
-let check_no_unqualified loc qualif_mode =
-  if qualif_mode = Include_subdirs.Unqualified then
-    Errors.fail loc "(include_subdirs qualified) is not supported yet"
-
-let virtual_modules_of_impl ~sctx impl
-  : Modules_field_evaluator.Implementation.t Or_exn.t =
-  match Lib.implements impl with
-  | None -> assert false
-  | Some vlib ->
-    let open Result.O in
-    let+ vlib = vlib in
-    let info = Lib.info vlib in
-    let lib_modules =
-      match Option.value_exn (Lib_info.virtual_ info) with
-      | External lib_modules -> lib_modules
-      | Local ->
-        let src_dir =
-          Lib_info.src_dir info
-          |> Path.as_in_build_dir_exn
-        in
-        let t = Fdecl.get get_fdecl sctx ~dir:src_dir in
-        modules_of_library t ~name:(Lib.name vlib)
-    in
-    let existing_virtual_modules =
-      Lib_modules.virtual_modules lib_modules
-      |> Module.Name.Map.keys
-      |> Module.Name.Set.of_list
-    in
-    let allow_new_public_modules =
-      Lib_modules.wrapped lib_modules
-      |> Wrapped.to_bool
-      |> not
-    in
-    { Modules_field_evaluator.Implementation.
-      existing_virtual_modules
-    ; allow_new_public_modules
-    }
-
-let get0_impl (sctx, dir) : result0 =
-  let dir_status_db = Super_context.dir_status_db sctx in
-  match Dir_status.DB.get dir_status_db ~dir with
-  | Standalone x ->
-    (match x with
-     | Some (ft_dir, Some d) ->
-       let files, rules =
-         Rules.collect_opt (fun () -> load_text_files sctx ft_dir d)
-       in
-       Here {
-         t = { kind = Standalone
-             ; dir
-             ; text_files = files
-             ; modules = Memo.lazy_ (fun () ->
-                 Modules.make d
-                   ~virtual_modules_of_impl:(virtual_modules_of_impl ~sctx)
-                   ~modules:(modules_of_files ~dir:d.ctx_dir ~files))
-             ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
-             ; c_sources = Memo.lazy_ (fun () ->
-                 let dune_version = d.dune_version in
-                 C_sources.make d
-                   ~c_sources:(
-                     C_sources.load_sources ~dune_version ~dir:d.ctx_dir ~files))
-             ; coq_modules = Memo.lazy_ (fun () ->
-                 build_coq_modules_map d ~dir:d.ctx_dir
-                   ~modules:(
-                     coq_modules_of_files ~subdirs:[dir,[],files]))
-             };
-         rules;
-         subdirs = Path.Build.Map.empty;
-       }
-     | Some (_, None)
-     | None ->
-       Here {
-         t = { kind = Standalone
-             ; dir
-             ; text_files = String.Set.empty
-             ; modules = Memo.Lazy.of_val Modules.empty
-             ; mlds = Memo.Lazy.of_val []
-             ; c_sources = Memo.Lazy.of_val C_sources.empty
-             ; coq_modules = Memo.Lazy.of_val Lib_name.Map.empty
-             };
-         rules = None;
-         subdirs = Path.Build.Map.empty;
-       })
-  | Is_component_of_a_group_but_not_the_root { group_root; _ } ->
-    See_above group_root
-  | Group_root (ft_dir, qualif_mode, d) ->
-    let rec walk ft_dir ~dir ~local acc =
-      match
-        Dir_status.DB.get dir_status_db ~dir
-      with
-      | Is_component_of_a_group_but_not_the_root { stanzas = d; group_root = _ } ->
-        let files =
-          match d with
-          | None -> File_tree.Dir.files ft_dir
-          | Some d -> load_text_files sctx ft_dir d
-        in
-        walk_children ft_dir ~dir ~local ((dir, List.rev local, files) :: acc)
-      | _ -> acc
-    and walk_children ft_dir ~dir ~local acc =
-      String.Map.foldi (File_tree.Dir.sub_dirs ft_dir) ~init:acc
-        ~f:(fun name ft_dir acc ->
-          let dir = Path.Build.relative dir name in
-          let local = if qualif_mode = Qualified then name :: local else local in
-          walk ft_dir ~dir ~local acc)
-    in
-    let (files, (subdirs : (Path.Build.t * _ * _) list)), rules =
-      Rules.collect_opt (fun () ->
-        let files = load_text_files sctx ft_dir d in
-        let subdirs = walk_children ft_dir ~dir ~local:[] [] in
-        files, subdirs)
-    in
-    let modules = Memo.lazy_ (fun () ->
-      check_no_qualified Loc.none qualif_mode;
-      let modules =
-        List.fold_left ((dir, [], files) :: subdirs) ~init:Module.Name.Map.empty
-          ~f:(fun acc ((dir : Path.Build.t), _local, files) ->
-            let modules = modules_of_files ~dir ~files in
-            Module.Name.Map.union acc modules ~f:(fun name x y ->
-              Errors.fail (Loc.in_file
-                             (Path.source (match File_tree.Dir.dune_file ft_dir with
-                                | None ->
-                                  Path.Source.relative (File_tree.Dir.path ft_dir)
-                                    "_unknown_"
-                                | Some d -> File_tree.Dune_file.path d)))
-                "Module %a appears in several directories:\
-                 @\n- %a\
-                 @\n- %a"
-                Module.Name.pp_quote name
-                Path.pp (Module.Source.src_dir x)
-                Path.pp (Module.Source.src_dir y)))
+      let (files, (subdirs : (Path.Build.t * _ * _) list)), rules =
+        Rules.collect_opt (fun () ->
+          let files = load_text_files sctx ft_dir d in
+          let subdirs = walk_children ft_dir ~dir ~local:[] [] in
+          files, subdirs)
       in
-      Modules.make d
-        ~virtual_modules_of_impl:(virtual_modules_of_impl ~sctx)
-        ~modules)
-    in
-    let c_sources = Memo.lazy_ (fun () ->
-      check_no_qualified Loc.none qualif_mode;
-      let dune_version = d.dune_version in
-      let init = C.Kind.Dict.make_both String.Map.empty in
-      let c_sources =
-        List.fold_left ((dir, [], files) :: subdirs) ~init
-          ~f:(fun acc (dir, _local, files) ->
-            let sources = C_sources.load_sources ~dir ~dune_version ~files in
-            let f acc sources =
-              String.Map.union acc sources ~f:(fun name x y ->
+      let modules = Memo.lazy_ (fun () ->
+        check_no_qualified Loc.none qualif_mode;
+        let modules =
+          List.fold_left ((dir, [], files) :: subdirs) ~init:Module.Name.Map.empty
+            ~f:(fun acc ((dir : Path.Build.t), _local, files) ->
+              let modules = modules_of_files ~dir ~files in
+              Module.Name.Map.union acc modules ~f:(fun name x y ->
                 Errors.fail (Loc.in_file
                                (Path.source (match File_tree.Dir.dune_file ft_dir with
                                   | None ->
                                     Path.Source.relative (File_tree.Dir.path ft_dir)
                                       "_unknown_"
                                   | Some d -> File_tree.Dune_file.path d)))
-                  "%a file %s appears in several directories:\
+                  "Module %a appears in several directories:\
                    @\n- %a\
-                   @\n- %a\
-                   @\nThis is not allowed, please rename one of them."
-                  (C.Kind.pp) (C.Source.kind x)
-                  name
-                  Path.pp_in_source (Path.build (C.Source.src_dir x))
-                  Path.pp_in_source (Path.build (C.Source.src_dir y)))
-            in
-            C.Kind.Dict.merge acc sources ~f)
+                   @\n- %a"
+                  Module.Name.pp_quote name
+                  Path.pp (Module.Source.src_dir x)
+                  Path.pp (Module.Source.src_dir y)))
+        in
+        make_modules sctx d ~modules)
       in
-      C_sources.make d ~c_sources
-    ) in
-    let coq_modules = Memo.lazy_ (fun () ->
-      check_no_unqualified Loc.none qualif_mode;
-      build_coq_modules_map d ~dir:d.ctx_dir
-        ~modules:(coq_modules_of_files ~subdirs:((dir,[],files)::subdirs))) in
-    let subdirs =
-      List.map subdirs ~f:(fun (dir, _local, files) ->
-        { kind = Group_part
+      let c_sources = Memo.lazy_ (fun () ->
+        check_no_qualified Loc.none qualif_mode;
+        let dune_version = d.dune_version in
+        let init = C.Kind.Dict.make_both String.Map.empty in
+        let c_sources =
+          List.fold_left ((dir, [], files) :: subdirs) ~init
+            ~f:(fun acc (dir, _local, files) ->
+              let sources = C_sources.load_sources ~dir ~dune_version ~files in
+              let f acc sources =
+                String.Map.union acc sources ~f:(fun name x y ->
+                  Errors.fail (Loc.in_file
+                                 (Path.source (match File_tree.Dir.dune_file ft_dir with
+                                    | None ->
+                                      Path.Source.relative (File_tree.Dir.path ft_dir)
+                                        "_unknown_"
+                                    | Some d -> File_tree.Dune_file.path d)))
+                    "%a file %s appears in several directories:\
+                     @\n- %a\
+                     @\n- %a\
+                     @\nThis is not allowed, please rename one of them."
+                    (C.Kind.pp) (C.Source.kind x)
+                    name
+                    Path.pp_in_source (Path.build (C.Source.src_dir x))
+                    Path.pp_in_source (Path.build (C.Source.src_dir y)))
+              in
+              C.Kind.Dict.merge acc sources ~f)
+        in
+        C_sources.make d ~c_sources
+      ) in
+      let coq_modules = Memo.lazy_ (fun () ->
+        check_no_unqualified Loc.none qualif_mode;
+        build_coq_modules_map d ~dir:d.ctx_dir
+          ~modules:(coq_modules_of_files ~subdirs:((dir,[],files)::subdirs))) in
+      let subdirs =
+        List.map subdirs ~f:(fun (dir, _local, files) ->
+          { kind = Group_part
+          ; dir
+          ; text_files = files
+          ; modules
+          ; c_sources
+          ; mlds = Memo.lazy_ (fun () -> (build_mlds_map d ~files))
+          ; coq_modules
+          })
+      in
+      let t =
+        { kind = Group_root subdirs
         ; dir
         ; text_files = files
         ; modules
         ; c_sources
-        ; mlds = Memo.lazy_ (fun () -> (build_mlds_map d ~files))
+        ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
         ; coq_modules
-        })
-    in
-    let t =
-      { kind = Group_root subdirs
-      ; dir
-      ; text_files = files
-      ; modules
-      ; c_sources
-      ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
-      ; coq_modules
+        }
+      in
+      Here {
+        t;
+        rules;
+        subdirs = Path.Build.Map.of_list_map_exn subdirs ~f:(fun x -> x.dir, x)
       }
+
+  let memo0 =
+    let module Output = struct
+      type t = result0
+      let to_dyn _ = Dyn.Opaque
+    end
     in
-    Here {
-      t;
-      rules;
-      subdirs = Path.Build.Map.of_list_map_exn subdirs ~f:(fun x -> x.dir, x)
-    }
+    Memo.create
+      "dir-contents-get0"
+      ~input:(module Key)
+      ~output:(Simple (module Output))
+      ~doc:"dir contents"
+      ~visibility:Hidden
+      Sync
+      get0_impl
 
-let memo0 =
-  let module Output = struct
-    type t = result0
-    let to_dyn _ = Dyn.Opaque
-  end
-  in
-  Memo.create
-    "dir-contents-memo0"
-    ~input:(module Key)
-    ~output:(Simple (module Output))
-    ~doc:"dir contents"
-    ~visibility:Hidden
-    Sync
-    get0_impl
-
-let get sctx ~dir =
-  match Memo.exec memo0 (sctx, dir) with
-  | Here { t; rules = _; subdirs = _ } -> t
-  | See_above group_root ->
-    match Memo.exec memo0 (sctx, group_root) with
-    | See_above _ -> assert false
+  let get sctx ~dir =
+    match Memo.exec memo0 (sctx, dir) with
     | Here { t; rules = _; subdirs = _ } -> t
+    | See_above group_root ->
+      match Memo.exec memo0 (sctx, group_root) with
+      | See_above _ -> assert false
+      | Here { t; rules = _; subdirs = _ } -> t
 
-let () = Fdecl.set get_fdecl get
+  let gen_rules sctx ~dir =
+    match Memo.exec memo0 (sctx, dir) with
+    | See_above group_root ->
+      Group_part group_root
+    | Here { t; rules; subdirs } ->
+      Rules.produce_opt rules;
+      Standalone_or_root (t, Path.Build.Map.values subdirs)
+end
 
-type gen_rules_result =
-  | Standalone_or_root of t * t list
-  | Group_part of Path.Build.t
-
-let gen_rules sctx ~dir =
-  match Memo.exec memo0 (sctx, dir) with
-  | See_above group_root ->
-    Group_part group_root
-  | Here { t; rules; subdirs } ->
-    Rules.produce_opt rules;
-    Standalone_or_root (t, Path.Build.Map.values subdirs)
+include Load

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -38,7 +38,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       let mod_name = Module.Name.of_string name in
       match Module.Name.Map.find modules mod_name with
       | Some m ->
-        if not (Module.has_impl m) then
+        if not (Module.has m ~ml_kind:Impl) then
           Errors.fail loc "Module %a has no implementation."
             Module.Name.pp mod_name
         else

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -274,22 +274,15 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
                 Build_system.load_dir ~dir:(Path.parent_exn (Path.build dir)))
            | Some _ ->
              (* This interprets "rule" and "copy_files" stanzas. *)
-             let dir_contents = Dir_contents.get sctx ~dir in
-             match dir_contents with
+             match Dir_contents.gen_rules sctx ~dir with
              | Group_part root ->
                Build_system.load_dir ~dir:(Path.build root)
-             | Standalone_or_root dir_contents ->
-               match Dir_contents.kind dir_contents with
-               | Group_part _ -> assert false
-               | Standalone ->
-                 ignore (gen_rules dir_contents [] ~dir : _ list)
-               | Group_root subs ->
-                 let cctxs = gen_rules dir_contents [] ~dir in
-                 let subs = Memo.Lazy.force subs in
-                 List.iter subs ~f:(fun dc ->
-                   ignore (
-                     gen_rules dir_contents cctxs ~dir:(Dir_contents.dir dc)
-                     : _ list))
+             | Standalone_or_root (dir_contents, subs) ->
+               let cctxs = gen_rules dir_contents [] ~dir in
+               List.iter subs ~f:(fun dc ->
+                 ignore (
+                   gen_rules dir_contents cctxs ~dir:(Dir_contents.dir dc)
+                   : _ list))
          end;
          These (String.Set.of_list subdirs))
     in

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -244,15 +244,14 @@ include Sub_system.Register_end_point(
       (* Generate the runner file *)
       SC.add_rule sctx ~dir ~loc (
         let target =
-          Module.file main_module Impl
+          Module.file main_module ~ml_kind:Impl
           |> Option.value_exn
           |> Path.as_in_build_dir_exn
         in
         let source_modules = Module.Name.Map.values source_modules in
         let files ml_kind =
           Pform.Var.Values (Value.L.paths (
-            List.filter_map source_modules ~f:(fun m ->
-              Module.file m ml_kind)))
+            List.filter_map source_modules ~f:(Module.file ~ml_kind)))
         in
         let bindings =
           Pform.Map.of_list_exn

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -247,13 +247,15 @@ let lib_install_files sctx ~dir_contents ~dir ~sub_dir:lib_subdir
         )
       in
       let other_cm_files =
-        [ if_ (native && Module.has_impl m)
+        let has_impl = Module.has ~ml_kind:Impl m in
+        [ if_ (native && has_impl)
             [ cm_file_unsafe Cmx ]
-        ; if_ (byte && Module.has_impl m && virtual_library)
+        ; if_ (byte && has_impl && virtual_library)
             [ cm_file_unsafe Cmo ]
-        ; if_ (native && Module.has_impl m && virtual_library)
+        ; if_ (native && has_impl && virtual_library)
             [ Obj_dir.Module.obj_file obj_dir m ~kind:Cmx ~ext:ext_obj ]
-        ; List.filter_map Ml_kind.all ~f:(Obj_dir.Module.cmt_file obj_dir m)
+        ; List.filter_map Ml_kind.all ~f:(fun ml_kind ->
+            Obj_dir.Module.cmt_file obj_dir m ~ml_kind)
         ]
         |> List.concat
         |> List.map ~f:(fun f ->

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -30,7 +30,7 @@ let gen_dune_package sctx ~version ~(pkg : Local_package.t) =
               let dir_contents =
                 let info = Lib.Local.info lib in
                 let dir = Lib_info.src_dir info in
-                Dir_contents.get_without_rules sctx ~dir
+                Dir_contents.get sctx ~dir
               in
               let obj_dir = Lib.Local.obj_dir lib in
               let lib = Lib.Local.to_lib lib in
@@ -355,7 +355,7 @@ let install_entries sctx package =
                  ; dune_version = _
                  } ->
               let sub_dir = (Option.value_exn lib.public).sub_dir in
-              let dir_contents = Dir_contents.get_without_rules sctx ~dir in
+              let dir_contents = Dir_contents.get sctx ~dir in
               lib_install_files sctx ~dir ~sub_dir lib ~scope
                 ~dir_kind ~dir_contents)
   in

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -311,6 +311,7 @@ let to_dyn t = Lib_name.to_dyn t.name
 
 let name t = t.name
 let info t = t.info
+let implements t = t.implements
 
 let unique_id    t = t.unique_id
 

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -12,6 +12,8 @@ val to_dyn : t -> Dyn.t
     present or the [name] if not. *)
 val name : t -> Lib_name.t
 
+val implements : t -> t Or_exn.t option
+
 (** Directory where the object files for the library are located. *)
 val obj_dir : t -> Path.t Obj_dir.t
 

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -402,8 +402,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let obj_dir = Library.obj_dir ~dir lib in
     Check_rules.add_obj_dir sctx ~obj_dir;
     let source_modules = Lib_modules.modules lib_modules in
-    let vimpl =
-      Virtual_rules.impl sctx ~lib ~dir ~scope ~modules:source_modules in
+    let vimpl = Virtual_rules.impl sctx ~lib ~dir ~scope in
     Option.iter vimpl ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir);
     (* Preprocess before adding the alias module as it doesn't need
        preprocessing *)

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -84,7 +84,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
 
   let build_alias_module ~loc ~alias_module ~lib_modules ~dir ~cctx ~dynlink =
     let vimpl = Compilation_context.vimpl cctx in
-    let file = Option.value_exn (Module.impl alias_module) in
+    let file = Option.value_exn (Module.file alias_module ~ml_kind:Impl) in
     let alias_file () =
       let main_module_name =
         Option.value_exn (Lib_modules.main_module_name lib_modules)
@@ -103,7 +103,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     in
     SC.add_rule ~loc sctx ~dir (
       Build.arr alias_file
-      >>> Build.write_file_dyn (Path.as_in_build_dir_exn file.path)
+      >>> Build.write_file_dyn (Path.as_in_build_dir_exn file)
     );
     let cctx = Compilation_context.for_alias_module cctx in
     Module_compilation.build_module cctx alias_module
@@ -134,7 +134,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         sprintf {|[@@@deprecated "%s. Use %s instead."] include %s|}
           (Lazy.force transition_message) real_name hidden_name
       in
-      let source_path = Option.value_exn (Module.file m Impl) in
+      let source_path = Option.value_exn (Module.file m ~ml_kind:Impl) in
       let loc = lib.buildable.loc in
       Build.return contents
       >>> Build.write_file_dyn (Path.as_in_build_dir_exn source_path)

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -19,7 +19,7 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
   in
   SC.add_rule ~dir sctx (
     let ml =
-      Module.file module_ Impl
+      Module.file module_ ~ml_kind:Impl
       |> Option.value_exn
       |> Path.as_in_build_dir_exn
     in

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -207,11 +207,11 @@ module Run (P : PARAMS) : sig end = struct
     let name = Module.Name.of_string (mock base) in
 
     let mock_module : Module.t =
-      Module.make
-        name
-        ~visibility:Public
-        ~kind:Impl
-        ~impl:{ path = Path.build (mock_ml base); syntax = OCaml }
+      let source =
+        let impl = Module.File.make OCaml (Path.build (mock_ml base)) in
+        Module.Source.make ~impl name
+      in
+      Module.of_source ~visibility:Public ~kind:Impl source
     in
 
     (* The following incantation allows the mock [.ml] file to be preprocessed

--- a/src/ml_kind.ml
+++ b/src/ml_kind.ml
@@ -4,21 +4,22 @@ type t = Impl | Intf
 
 let all = [Impl; Intf]
 
-let choose impl intf = function
+let choose t ~impl ~intf =
+  match t with
   | Impl -> impl
   | Intf -> intf
 
-let suffix = choose "" "i"
+let suffix = choose ~impl:"" ~intf:"i"
 
-let to_string = choose "impl" "intf"
+let to_string = choose ~impl:"impl" ~intf:"intf"
 
 let to_dyn t = Dyn.String (to_string t)
 
 let pp fmt t = Format.pp_print_string fmt (to_string t)
 
-let flag t = choose (Command.Args.A "-impl") (A "-intf") t
+let flag t = choose ~impl:(Command.Args.A "-impl") ~intf:(A "-intf") t
 
-let ppx_driver_flag t = choose (Command.Args.A "--impl") (A "--intf") t
+let ppx_driver_flag t = choose ~impl:(Command.Args.A "--impl") ~intf:(A "--intf") t
 
 module Dict = struct
   type 'a t =

--- a/src/ml_kind.mli
+++ b/src/ml_kind.mli
@@ -4,6 +4,8 @@ type t = Impl | Intf
 
 val all : t list
 
+val choose : t -> impl:'a -> intf:'a -> 'a
+
 val pp : t Fmt.t
 
 (** "" or "i" *)

--- a/src/module.ml
+++ b/src/module.ml
@@ -199,6 +199,16 @@ let pp_flags t = t.pp
 
 let of_source ?obj_name ~visibility ~(kind : Kind.t)
       (source : Source.t) =
+  begin match kind, visibility with
+  | (Alias | Impl_vmodule | Virtual), Visibility.Public
+  | (Impl | Intf_only), _ -> ()
+  | _, _ ->
+    Code_error.raise "Module.of_source: invalid kind, visibility combination"
+      [ "name", Name.to_dyn source.name
+      ; "kind", Kind.to_dyn kind
+      ; "visibility", Visibility.to_dyn visibility
+      ]
+  end;
   begin match kind, source.files.impl, source.files.intf with
   | (Alias | Impl_vmodule | Impl), None, _
   | (Alias | Impl_vmodule), Some _, Some _

--- a/src/module.ml
+++ b/src/module.ml
@@ -167,7 +167,9 @@ module Source = struct
     ; files
     }
 
-  let has_impl t = Option.is_some t.files.impl
+  let has t ~ml_kind =
+    Ml_kind.Dict.get t.files ml_kind
+    |> Option.is_some
 
   let name t = t.name
 

--- a/src/module.ml
+++ b/src/module.ml
@@ -108,22 +108,18 @@ module Kind = struct
     | Virtual
     | Impl
     | Alias
+    | Impl_vmodule
 
   let to_string = function
     | Intf_only -> "intf_only"
     | Virtual -> "virtual"
     | Impl -> "impl"
     | Alias -> "alias"
+    | Impl_vmodule -> "impl_vmodule"
 
   let to_dyn t = Dyn.Encoder.string (to_string t)
 
-  let encode =
-    let open Dune_lang.Encoder in
-    function
-    | Intf_only -> string "intf_only"
-    | Virtual -> string "virtual"
-    | Impl -> string "impl"
-    | Alias -> string "alias"
+  let encode t = Dune_lang.Encoder.string (to_string t)
 
   let decode =
     let open Stanza.Decoder in
@@ -132,10 +128,12 @@ module Kind = struct
       ; "virtual", Virtual
       ; "impl", Impl
       ; "alias", Alias
+      ; "impl_vmodule", Impl_vmodule
       ]
 
   let has_impl = function
     | Alias
+    | Impl_vmodule
     | Impl -> true
     | Intf_only
     | Virtual -> false
@@ -348,7 +346,7 @@ let encode
     match kind with
     | Kind.Impl when has_impl -> None
     | Intf_only when not has_impl -> None
-    | Alias | Impl | Virtual | Intf_only -> Some kind
+    | Impl_vmodule | Alias | Impl | Virtual | Intf_only -> Some kind
   in
   record_fields
     [ field "name" Name.encode name

--- a/src/module.ml
+++ b/src/module.ml
@@ -200,9 +200,10 @@ let pp_flags t = t.pp
 let of_source ?obj_name ~visibility ~(kind : Kind.t)
       (source : Source.t) =
   begin match kind, source.files.impl, source.files.intf with
-  | Virtual, Some _, _
-  | Impl, None, _
-  | Intf_only, Some _, _ ->
+  | (Alias | Impl_vmodule | Impl), None, _
+  | (Alias | Impl_vmodule), Some _, Some _
+  | (Intf_only | Virtual), Some _, _
+  | (Intf_only | Virtual), _, None ->
     let open Dyn.Encoder in
     Code_error.raise "Module.make: invalid kind, impl, intf combination"
       [ "name", Name.to_dyn source.name

--- a/src/module.mli
+++ b/src/module.mli
@@ -57,7 +57,7 @@ module File : sig
 end
 
 module Kind : sig
-  type t = Intf_only | Virtual | Impl | Alias
+  type t = Intf_only | Virtual | Impl | Alias | Impl_vmodule
 
   include Dune_lang.Conv with type t := t
 end

--- a/src/module.mli
+++ b/src/module.mli
@@ -74,7 +74,7 @@ module Source : sig
     -> Name.t
     -> t
 
-  val has_impl: t -> bool
+  val has : t -> ml_kind:Ml_kind.t -> bool
 
   val src_dir : t -> Path.t
 end

--- a/src/module.mli
+++ b/src/module.mli
@@ -87,16 +87,6 @@ val kind : t -> Kind.t
 val to_dyn : t -> Dyn.t
 
 (** [obj_name] Object name. It is different from [name] for wrapped modules. *)
-val make
-  :  ?impl:File.t
-  -> ?intf:File.t
-  -> ?obj_name:string
-  -> visibility:Visibility.t
-  -> kind:Kind.t
-  -> Name.t
-  -> t
-
-(** [obj_name] Object name. It is different from [name] for wrapped modules. *)
 val of_source
   :  ?obj_name:string
   -> visibility:Visibility.t
@@ -109,15 +99,11 @@ val name : t -> Name.t
 (** Real unit name once wrapped. This is always a valid module name. *)
 val real_unit_name : t -> Name.t
 
-val intf : t -> File.t option
-val impl : t -> File.t option
-
-val source : t -> Ml_kind.t -> File.t option
+val source : t -> ml_kind:Ml_kind.t -> File.t option
 
 val pp_flags : t -> (unit, string list) Build.t option
 
-val file            : t -> Ml_kind.t -> Path.t option
-val cm_source       : t -> Cm_kind.t -> Path.t option
+val file            : t -> ml_kind:Ml_kind.t -> Path.t option
 
 val obj_name : t -> string
 
@@ -125,10 +111,7 @@ val odoc_file : t -> doc_dir:Path.Build.t -> Path.Build.t
 
 val iter : t -> f:(Ml_kind.t -> File.t -> unit) -> unit
 
-val has_impl : t -> bool
-val has_intf : t -> bool
-val impl_only : t -> bool
-val intf_only : t -> bool
+val has : t -> ml_kind:Ml_kind.t -> bool
 
 (** Prefix the object name with the library name. *)
 val with_wrapper : t -> main_module_name:Name.t -> t

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -39,9 +39,9 @@ let eval =
       fake_modules := Module.Name.Map.add !fake_modules name loc;
       Error name
   in
-  fun ~fake_modules ~all_modules ~standard osl ->
+  fun ~loc ~fake_modules ~all_modules ~standard osl ->
     let parse = parse ~fake_modules ~all_modules in
-    let standard = Module.Name.Map.map standard ~f:(fun m -> Ok m) in
+    let standard = Module.Name.Map.map standard ~f:(fun m -> loc, Ok m) in
     let modules = Eval.eval_unordered ~parse ~standard osl in
     Module.Name.Map.filter_map modules ~f:(fun (loc, m) ->
       match m with
@@ -254,7 +254,7 @@ let eval ~modules:(all_modules : Module.Source.t Module.Name.Map.t)
      matter because they are only removed from a set (for jbuild file
      compatibility) *)
   let fake_modules = ref Module.Name.Map.empty in
-  let eval = eval ~fake_modules ~all_modules in
+  let eval = eval ~loc:conf.loc ~fake_modules ~all_modules in
   let modules = eval ~standard:all_modules conf.modules in
   let intf_only =
     eval ~standard:Module.Name.Map.empty conf.modules_without_implementation

--- a/src/modules_field_evaluator.mli
+++ b/src/modules_field_evaluator.mli
@@ -1,9 +1,26 @@
 open! Stdune
 
+module Virtual : sig
+  type t =
+    { virtual_modules : Ordered_set_lang.t
+    }
+end
+
+module Implementation : sig
+  type t =
+    { existing_virtual_modules : Module.Name.Set.t
+    ; allow_new_public_modules : bool
+    }
+end
+
+type kind =
+  | Virtual of Virtual.t
+  | Implementation of Implementation.t
+  | Exe_or_normal_lib
+
 val eval
   :  modules:(Module.Source.t Module.Name.Map.t)
   -> buildable:Dune_file.Buildable.t
-  -> virtual_modules:Ordered_set_lang.t option
   -> private_modules:Ordered_set_lang.t
-  -> existing_virtual_modules:Module.Name.Set.t
+  -> kind:kind
   -> Module.Name_map.t

--- a/src/modules_field_evaluator.mli
+++ b/src/modules_field_evaluator.mli
@@ -5,4 +5,5 @@ val eval
   -> buildable:Dune_file.Buildable.t
   -> virtual_modules:Ordered_set_lang.t option
   -> private_modules:Ordered_set_lang.t
+  -> existing_virtual_modules:Module.Name.Set.t
   -> Module.Name_map.t

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -308,7 +308,7 @@ module Module = struct
     obj_file t m ~kind ~ext
 
   let cm_file t m ~(kind : Cm_kind.t) =
-    let has_impl = Module.has_impl m in
+    let has_impl = Module.has m ~ml_kind:Impl in
     match kind with
     | (Cmx | Cmo) when not has_impl -> None
     | _ -> Some (cm_file_unsafe t m ~kind)
@@ -321,7 +321,7 @@ module Module = struct
 
   let cm_public_file (type path) (t : path t) m ~(kind : Cm_kind.t) : path option =
     let is_private = Module.visibility m = Private in
-    let has_impl = Module.has_impl m in
+    let has_impl = Module.has m ~ml_kind:Impl in
     match kind with
     | (Cmx | Cmo) when not has_impl -> None
     |  Cmi when is_private -> None
@@ -332,14 +332,14 @@ module Module = struct
     | Impl -> ".cmt"
     | Intf -> ".cmti"
 
-  let cmt_file t m (kind : Ml_kind.t) =
-    let file = Module.file m kind in
-    let ext = cmt_ext kind in
+  let cmt_file t m ~(ml_kind : Ml_kind.t) =
+    let file = Module.file m ~ml_kind in
+    let ext = cmt_ext ml_kind in
     Option.map file ~f:(fun _ -> obj_file t m ~kind:Cmi ~ext)
 
   let cmti_file t m =
     let ext = cmt_ext (
-      match Module.file m Intf with
+      match Module.file m ~ml_kind:Intf with
       | None -> Impl
       | Some _ -> Intf
     ) in
@@ -364,7 +364,7 @@ module Module = struct
   module L = struct
     let o_files t modules ~ext_obj =
       List.filter_map modules ~f:(fun m ->
-        if Module.has_impl m then
+        if Module.has m ~ml_kind:Impl then
           Some (path_of_build t (obj_file t m ~kind:Cmx ~ext:ext_obj))
         else
           None)

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -92,7 +92,7 @@ module Module : sig
 
   val cm_file        : 'path t -> Module.t -> kind:Cm_kind.t -> 'path option
   val cm_public_file : 'path t -> Module.t -> kind:Cm_kind.t -> 'path option
-  val cmt_file       : 'path t -> Module.t -> Ml_kind.t -> 'path option
+  val cmt_file       : 'path t -> Module.t -> ml_kind:Ml_kind.t -> 'path option
   val obj_file       : 'path t -> Module.t -> kind:Cm_kind.t -> ext:string -> 'path
 
   (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx] and the

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -92,7 +92,7 @@ let deps_of cctx ~ml_kind unit =
   if Module.kind unit = Alias then
     Build.return []
   else
-    match Module.source unit ml_kind with
+    match Module.source unit ~ml_kind with
     | None -> Build.return []
     | Some source ->
       let obj_dir = Compilation_context.obj_dir cctx in
@@ -123,9 +123,9 @@ let deps_of cctx ~ml_kind unit =
             if Module.kind m = Alias then
               None
             else
-              match Module.source m Ml_kind.Intf with
+              match Module.source m ~ml_kind:Intf with
               | Some _ as x -> x
-              | None -> Module.source m Ml_kind.Impl
+              | None -> Module.source m ~ml_kind:Impl
           in
           let module_file_ =
             match source m with
@@ -165,7 +165,7 @@ let rules_for_auxiliary_module cctx (m : Module.t) =
 
 let graph_of_remote_lib ~obj_dir ~modules =
   let deps_of unit ~ml_kind =
-    match Module.source unit ml_kind with
+    match Module.source unit ~ml_kind with
     | None -> Build.return []
     | Some source ->
       let all_deps_file = Obj_dir.Module.dep obj_dir source ~kind:Transitive in

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -470,7 +470,7 @@ let entry_modules_by_lib sctx lib =
   let info = Lib.Local.info lib in
   let dir = Lib_info.src_dir info in
   let name = Lib.name (Lib.Local.to_lib lib) in
-  Dir_contents.get_without_rules sctx ~dir
+  Dir_contents.get sctx ~dir
   |> Dir_contents.modules_of_library ~name
   |> Lib_modules.entry_modules
 

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -126,7 +126,7 @@ let odoc sctx =
     ~loc:None ~hint:"try: opam install odoc"
 
 let module_deps (m : Module.t) ~doc_dir ~(dep_graphs:Dep_graph.Ml_kind.t) =
-  (if Module.has_intf m then
+  (if Module.has m ~ml_kind:Intf then
      Dep_graph.deps_of dep_graphs.intf m
    else
      (* When a module has no .mli, use the dependencies for the .ml *)

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -218,12 +218,12 @@ module Make_loc(Key : Key)(Value : Value with type key = Key.t) = struct
   let eval t ~parse ~standard =
     No_loc.eval t
       ~parse:(loc_parse parse)
-      ~standard:(List.map standard ~f:(fun x -> (Loc.none, x)))
+      ~standard
 
   let eval_unordered t ~parse ~standard =
     No_loc.eval_unordered t
       ~parse:(loc_parse parse)
-      ~standard:(Key.Map.map standard ~f:(fun x -> (Loc.none, x)))
+      ~standard
 end
 
 let standard =

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -53,14 +53,14 @@ module Make_loc (Key : Key)(Value : Value with type key = Key.t) : sig
   val eval
     :  t
     -> parse:(loc:Loc.t -> string -> Value.t)
-    -> standard:Value.t list
+    -> standard:(Loc.t * Value.t) list
     -> (Loc.t * Value.t) list
 
   (** Same as [eval] but the result is unordered *)
   val eval_unordered
     :  t
     -> parse:(loc:Loc.t -> string -> Value.t)
-    -> standard:Value.t Key.Map.t
+    -> standard:(Loc.t * Value.t) Key.Map.t
     -> (Loc.t * Value.t) Key.Map.t
 end
 

--- a/src/packages.ml
+++ b/src/packages.ml
@@ -22,7 +22,7 @@ let mlds_by_package_def =
        |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
          List.filter_map w.data ~f:(function
            | Documentation d ->
-             let dc = Dir_contents.get_without_rules sctx ~dir:w.ctx_dir in
+             let dc = Dir_contents.get sctx ~dir:w.ctx_dir in
              let mlds = Dir_contents.mlds dc d in
              Some (d.package.name, mlds)
            | _ ->

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -16,7 +16,7 @@ module Source = struct
     Module.generated ~src_dir main_module_name
 
   let source_path t =
-    Module.file (main_module t) Impl
+    Module.file (main_module t) ~ml_kind:Impl
     |> Option.value_exn
     |> Path.as_in_build_dir_exn
 

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -116,21 +116,6 @@ let module_list ms =
 
 let check_module_fields ~(lib : Dune_file.Library.t) ~virtual_modules
       ~modules ~implements =
-  let new_public_modules =
-    Module.Name.Map.foldi modules ~init:[] ~f:(fun name m acc ->
-      if Module.visibility m = Public
-      && not (Module.Name.Map.mem virtual_modules name) then
-        name :: acc
-      else
-        acc)
-  in
-  if new_public_modules <> [] then begin
-    Errors.fail lib.buildable.loc
-      "The following modules aren't part of the virtual library's interface:\
-       \n%s\n\
-       They must be marked as private using the (private_modules ..) field"
-      (module_list new_public_modules)
-  end;
   let (missing_modules, impl_modules_with_intf) =
     Module.Name.Map.foldi virtual_modules ~init:([], [])
       ~f:(fun m _ (mms, ims) ->

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -206,7 +206,7 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope =
           let dir_contents =
             let info = Lib.Local.info vlib in
             let dir = Lib_info.src_dir info in
-            Dir_contents.get_without_rules sctx ~dir
+            Dir_contents.get sctx ~dir
           in
           let modules =
             let pp_spec =

--- a/src/virtual_rules.mli
+++ b/src/virtual_rules.mli
@@ -11,5 +11,4 @@ val impl
   -> dir:Path.Build.t
   -> lib:Dune_file.Library.t
   -> scope:Scope.t
-  -> modules:Module.Name_map.t
   -> Vimpl.t option

--- a/test/blackbox-tests/test-cases/github1856/impl/dune
+++ b/test/blackbox-tests/test-cases/github1856/impl/dune
@@ -1,4 +1,4 @@
-(library 
+(library
  (name foo_impl)
  (public_name foo.impl)
  (implements foo)

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -61,7 +61,8 @@ Check that variant data is installed in the dune package file.
      (kind alias)
      (impl))
     (main_module_name B)
-    (modules ((name X) (obj_name b__X) (visibility public) (impl)))
+    (modules
+     ((name X) (obj_name b__X) (visibility public) (kind impl_vmodule) (impl)))
     (wrapped true)))
   $ cat  dune-package/_build/install/default/lib/b/dune-package
   (lang dune 1.11)

--- a/test/blackbox-tests/test-cases/vlib/run.t
+++ b/test/blackbox-tests/test-cases/vlib/run.t
@@ -116,13 +116,10 @@ virtual libraries may not implement their virtual modules
 Implementations cannot introduce new modules to the library's interface
   $ dune build --root impl-public-modules
   Entering directory 'impl-public-modules'
-  File "impl/dune", line 1, characters 0-44:
-  1 | (library
-  2 |  (name foo_impl)
-  3 |  (implements foo))
-  Error: The following modules aren't part of the virtual library's interface:
+  Error: Implementations of wrapped libraries cannot introduce new public modules.
+  The following modules:
   - Baz
-  They must be marked as private using the (private_modules ..) field
+   must all be marked as private using the (private_modules ..) field.
   [1]
 
 They can only introduce private modules:
@@ -234,13 +231,10 @@ Implementations may not provide a library interface module unless it is virtual.
 There should be an error message that clarifies this.
   $ dune build --root impl-lib-interface-module @all
   Entering directory 'impl-lib-interface-module'
-  File "impl/dune", line 1, characters 0-41:
-  1 | (library
-  2 |  (name impl)
-  3 |  (implements vlib))
-  Error: The following modules aren't part of the virtual library's interface:
+  Error: Implementations of wrapped libraries cannot introduce new public modules.
+  The following modules:
   - Vlib
-  They must be marked as private using the (private_modules ..) field
+   must all be marked as private using the (private_modules ..) field.
   [1]
 
 Test that implementing vlibs that aren't present is impossible

--- a/test/blackbox-tests/test-cases/vlib/run.t
+++ b/test/blackbox-tests/test-cases/vlib/run.t
@@ -116,6 +116,10 @@ virtual libraries may not implement their virtual modules
 Implementations cannot introduce new modules to the library's interface
   $ dune build --root impl-public-modules
   Entering directory 'impl-public-modules'
+  File "impl/dune", line 1, characters 0-44:
+  1 | (library
+  2 |  (name foo_impl)
+  3 |  (implements foo))
   Error: Implementations of wrapped libraries cannot introduce new public modules.
   The following modules:
   - Baz
@@ -231,6 +235,10 @@ Implementations may not provide a library interface module unless it is virtual.
 There should be an error message that clarifies this.
   $ dune build --root impl-lib-interface-module @all
   Entering directory 'impl-lib-interface-module'
+  File "impl/dune", line 1, characters 0-41:
+  1 | (library
+  2 |  (name impl)
+  3 |  (implements vlib))
   Error: Implementations of wrapped libraries cannot introduce new public modules.
   The following modules:
   - Vlib

--- a/test/blackbox-tests/test-cases/vlib/run.t
+++ b/test/blackbox-tests/test-cases/vlib/run.t
@@ -329,7 +329,12 @@ Include variants and implementation information in dune-package
      (kind alias)
      (impl))
     (main_module_name Vlib)
-    (modules ((name Vmod) (obj_name vlib__Vmod) (visibility public) (impl)))
+    (modules
+     ((name Vmod)
+      (obj_name vlib__Vmod)
+      (visibility public)
+      (kind impl_vmodule)
+      (impl)))
     (wrapped true)))
   (library
    (name foo.vlib)


### PR DESCRIPTION
- [x] Add a proper kind to Module.Kind
- [x] Use this kind when loading modules in Dir_contents
- [x] Cleanup modules_field_evaluator. The case for loading virtual libraries and having existing virtual modules are mutually exclusive
- [x] Move the module validation rules of virtual_rules to dir_contents.
- [x] Make sure wrapped implementations don't introduce new modules
- [x] Make sure unwrapped implementations are allowed to introduce new modules