### PR TITLE
Fix compilation in --dev mode with 4.08

### DIFF
--- a/src/colors.ml
+++ b/src/colors.ml
@@ -74,14 +74,14 @@ let setup_err_formatter_colors () =
   let open Format in
   if Lazy.force Ansi_color.stderr_supports_color then begin
     List.iter [err_formatter; err_ppf] ~f:(fun ppf ->
-      let funcs = pp_get_formatter_tag_functions ppf () in
+      let funcs = pp_get_formatter_tag_functions ppf () [@warning "-3"] in
       pp_set_mark_tags ppf true;
       pp_set_formatter_tag_functions ppf
         { funcs with
           mark_close_tag = (fun _   -> Ansi_color.Style.escape_sequence [])
         ; mark_open_tag  = (fun tag -> Ansi_color.Style.escape_sequence
                                          (styles_of_tag tag))
-        })
+        } [@warning "-3"])
   end
 
 let output_filename : styles = [Bold; Fg Green]

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -102,7 +102,7 @@ let prepare_formatter ppf =
   let state = ref [] in
   Format.pp_set_mark_tags ppf true;
   let ofuncs = Format.pp_get_formatter_out_functions ppf () in
-  let tfuncs = Format.pp_get_formatter_tag_functions ppf () in
+  let tfuncs = Format.pp_get_formatter_tag_functions ppf () [@warning "-3"] in
   Format.pp_set_formatter_tag_functions ppf
     { tfuncs with
       mark_open_tag  = (function
@@ -113,7 +113,7 @@ let prepare_formatter ppf =
     ; mark_close_tag = (function
         | "atom" | "makefile-action" | "makefile-stuff" -> state := List.tl !state; ""
         | s -> tfuncs.mark_close_tag s)
-    };
+    } [@warning "-3"];
   Format.pp_set_formatter_out_functions ppf
     { ofuncs with
       out_newline = (fun () ->

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -59,9 +59,6 @@ val make_lib
   -> Lib_name.Local.t
   -> Path.Build.t t
 
-(** Create the object directory for a set of executables. [name] is
-    name of one of the executable in set. It is included in the dot
-    subdirectory name. *)
 (** Create the object directory for an external library that has no
    private directory for private modules *)
 val make_external_no_private : dir:Path.t -> Path.t t

--- a/src/ocaml_flags.ml
+++ b/src/ocaml_flags.ml
@@ -20,6 +20,7 @@ let dev_mode_warnings =
        ; 58
        ; 59
        ; 60
+       ; 66
        ])
 
 let default_warnings =

--- a/src/scheme.mli
+++ b/src/scheme.mli
@@ -3,12 +3,13 @@
 open! Stdune
 
 type 'rules t =
-  (** [Empty] is a scheme that has no rules *)
   | Empty
+  (** [Empty] is a scheme that has no rules *)
 
-  (** [Union (a, b)] produces all the rules produced by a and b *)
   | Union of 'rules t * 'rules t
+  (** [Union (a, b)] produces all the rules produced by a and b *)
 
+  | Approximation of Path.Build.w Dir_set.t * 'rules t
   (** [Approximation (dirs, x)] produces the same rules as [x] in [dirs] and
       produces no rules outside of [dirs].
 
@@ -16,19 +17,18 @@ type 'rules t =
       This error is not always going to be detected, especially if it's hidden
       by an occurrence of [Thunk]. If the error is undetected, the violating
       rules are just silently ignored. *)
-  | Approximation of Path.Build.w Dir_set.t * 'rules t
 
+  | Finite of 'rules Path.Build.Map.t
   (** [Finite rules] just produces a fixed set of rules known in advance.
       The keys in the map are the directory paths. *)
-  | Finite of 'rules Path.Build.Map.t
 
+  | Thunk of (unit -> 'rules t)
   (** [Thunk f] is a "lazy" collection of rules. This is normally used with
       [Approximation (dirs, Thunk f)] such that the work of [f] can be delayed
       (or avoided entirely) until (or unless) the rules for [dirs] become
       necessary.
 
       The thunk will be called at most once per [evaluate]. *)
-  | Thunk of (unit -> 'rules t)
 
 module Evaluated : sig
   type 'a t

--- a/src/stdune/io.ml
+++ b/src/stdune/io.ml
@@ -1,4 +1,4 @@
-module P = Pervasives
+module P = Pervasives [@warning "-3"]
 
 let close_in  = close_in
 let close_out = close_out

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -137,7 +137,7 @@ let rec nth t i =
   | x :: _, 0 -> Some x
   | _ :: xs, i -> nth xs (i - 1)
 
-let physically_equal = Pervasives.(==)
+let physically_equal = Pervasives.(==) [@warning "-3"]
 
 let init =
   let rec loop acc i n f =

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -124,18 +124,18 @@ module Renderer = struct
       | Text s -> pp_print_text ppf s
       | Tag (tag, t) ->
         let opening, th, closing = Tag.Handler.handle th tag in
-        pp_open_tag ppf (embed_tag ~opening ~closing);
+        pp_open_tag ppf (embed_tag ~opening ~closing) [@warning "-3"];
         pp th ppf t;
-        pp_close_tag ppf ()
+        pp_close_tag ppf () [@warning "-3"]
 
     let setup ppf =
-      let funcs = pp_get_formatter_tag_functions ppf () in
+      let funcs = pp_get_formatter_tag_functions ppf () [@warning "-3"] in
       pp_set_mark_tags ppf true;
       pp_set_formatter_tag_functions ppf
         { funcs with
           mark_open_tag  = extract_opening_tag
         ; mark_close_tag = extract_closing_tag
-        }
+        } [@warning "-3"]
 
     let string () =
       let buf = Buffer.create 1024 in

--- a/src/stdune/result/result.ml
+++ b/src/stdune/result/result.ml
@@ -1,7 +1,7 @@
 include struct
   [@@@warning "-33"]
   open Result_compat
-  open Pervasives
+  open Pervasives [@@warning "-3"]
 
   type ('a, 'error) t = ('a, 'error) result =
     | Ok    of 'a

--- a/src/stdune/result/result.mli
+++ b/src/stdune/result/result.mli
@@ -3,7 +3,7 @@ include sig
   (* This open is unused with OCaml >= 4.03 since the stdlib defines a
      result type *)
   open Result_compat
-  open Pervasives
+  open Pervasives [@@warning "-3"]
 
   (** The result type.
 

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -63,7 +63,7 @@ let rec pp ppf = function
 
 let hash = Dune_caml.Hashtbl.hash
 
-let string_equal (x : string) (y : string) = Pervasives.(=) x y
+let string_equal (x : string) (y : string) = (=) x y
 
 let rec equal x y =
   match x, y with

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -50,6 +50,11 @@ module User_error = User_error
 module User_message = User_message
 module User_warning = User_warning
 
+(* Pervasives is deprecated in 4.08 in favor of Stdlib, however we are
+   currently compatible with OCaml >= 4.02 so for now we simply
+   disable the deprecation warning. *)
+module Pervasives = Pervasives [@@warning "-3"]
+
 external reraise : exn -> _ = "%reraise"
 
 let compare a b = Ordering.of_int (compare a b)


### PR DESCRIPTION
A few things that we use are deprecated in 4.08:

- `Pervasives`
- the `tag` functions of the `Format`  module

Since we are currently keeping compatibility with OCaml >= 4.02, i simply disabled warning 3 for these. I also disabled the new warning 66 in dev mode, since it is causing a lot of code in Dune, and I expect in many projects to break. This warning is for unused `open!`, which we often use to keep `open Stdune` or similar even when they are not used.

BTW, testing 4.08 in the CI is going to be annoying as a lot of compiler messages changed in 4.08. I.e. the captured output will be different between < 4.08 and >= 4.08 :(