### PR TITLE
Compilation context params

### DIFF
--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -63,6 +63,7 @@ type t =
   ; stdlib               : Dune_file.Library.Stdlib.t option
   ; js_of_ocaml          : Dune_file.Js_of_ocaml.t option
   ; dynlink              : bool
+  ; sandbox              : bool option
   ; vimpl                : Vimpl.t option
   }
 
@@ -85,6 +86,7 @@ let opaque               t = t.opaque
 let stdlib               t = t.stdlib
 let js_of_ocaml          t = t.js_of_ocaml
 let dynlink              t = t.dynlink
+let sandbox              t = t.sandbox
 let vimpl                t = t.vimpl
 
 let context              t = Super_context.context t.super_context
@@ -95,7 +97,7 @@ let create ~super_context ~scope ~expander ~obj_dir
       ~modules ?alias_module ?lib_interface_module ~flags
       ~requires_compile ~requires_link
       ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
-      ~opaque ?stdlib ?js_of_ocaml ?(dynlink=false) () =
+      ~opaque ?stdlib ?js_of_ocaml ?(dynlink=false) ?sandbox () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link
@@ -121,10 +123,18 @@ let create ~super_context ~scope ~expander ~obj_dir
   ; js_of_ocaml
   ; vimpl
   ; dynlink
+  ; sandbox
   }
 
 let for_alias_module t =
   let flags = Ocaml_flags.default ~profile:(SC.profile t.super_context) in
+  let sandbox =
+    let ctx = Super_context.context t.super_context in
+    (* If the compiler reads the cmi for module alias even with [-w -49
+    -no-alias-deps], we must sandbox the build of the alias module since the
+    modules it references are built after. *)
+    Ocaml_version.always_reads_alias_cmi ctx.version
+  in
   { t with
     flags =
       Ocaml_flags.append_common flags
@@ -132,6 +142,7 @@ let for_alias_module t =
   ; includes     = Includes.empty
   ; alias_module = None
   ; stdlib       = None
+  ; sandbox      = Some sandbox
   }
 
 let for_wrapped_compat t modules =

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -62,6 +62,7 @@ type t =
   ; opaque               : bool
   ; stdlib               : Dune_file.Library.Stdlib.t option
   ; js_of_ocaml          : Dune_file.Js_of_ocaml.t option
+  ; dynlink              : bool
   ; vimpl                : Vimpl.t option
   }
 
@@ -83,6 +84,7 @@ let no_keep_locs         t = t.no_keep_locs
 let opaque               t = t.opaque
 let stdlib               t = t.stdlib
 let js_of_ocaml          t = t.js_of_ocaml
+let dynlink              t = t.dynlink
 let vimpl                t = t.vimpl
 
 let context              t = Super_context.context t.super_context
@@ -93,7 +95,7 @@ let create ~super_context ~scope ~expander ~obj_dir
       ~modules ?alias_module ?lib_interface_module ~flags
       ~requires_compile ~requires_link
       ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
-      ~opaque ?stdlib ?js_of_ocaml () =
+      ~opaque ?stdlib ?js_of_ocaml ?(dynlink=false) () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link
@@ -118,6 +120,7 @@ let create ~super_context ~scope ~expander ~obj_dir
   ; stdlib
   ; js_of_ocaml
   ; vimpl
+  ; dynlink
   }
 
 let for_alias_module t =

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -31,6 +31,7 @@ val create
   -> opaque                : bool
   -> ?stdlib               : Dune_file.Library.Stdlib.t
   -> ?js_of_ocaml          : Dune_file.Js_of_ocaml.t
+  -> ?dynlink              : bool
   -> unit
   -> t
 
@@ -56,6 +57,7 @@ val no_keep_locs         : t -> bool
 val opaque               : t -> bool
 val stdlib               : t -> Dune_file.Library.Stdlib.t option
 val js_of_ocaml          : t -> Dune_file.Js_of_ocaml.t option
+val dynlink              : t -> bool
 
 (** Information for implementation of virtual libraries. *)
 val vimpl                : t -> Vimpl.t option

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -32,6 +32,7 @@ val create
   -> ?stdlib               : Dune_file.Library.Stdlib.t
   -> ?js_of_ocaml          : Dune_file.Js_of_ocaml.t
   -> ?dynlink              : bool
+  -> ?sandbox              : bool
   -> unit
   -> t
 
@@ -58,6 +59,7 @@ val opaque               : t -> bool
 val stdlib               : t -> Dune_file.Library.Stdlib.t option
 val js_of_ocaml          : t -> Dune_file.Js_of_ocaml.t option
 val dynlink              : t -> bool
+val sandbox              : t -> bool option
 
 (** Information for implementation of virtual libraries. *)
 val vimpl                : t -> Vimpl.t option

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -82,7 +82,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
   let alias_module_build_sandbox =
     Ocaml_version.always_reads_alias_cmi ctx.version
 
-  let build_alias_module ~loc ~alias_module ~lib_modules ~dir ~cctx ~dynlink =
+  let build_alias_module ~loc ~alias_module ~lib_modules ~dir ~cctx =
     let vimpl = Compilation_context.vimpl cctx in
     let file = Option.value_exn (Module.file alias_module ~ml_kind:Impl) in
     let alias_file () =
@@ -107,12 +107,10 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     );
     let cctx = Compilation_context.for_alias_module cctx in
     Module_compilation.build_module cctx alias_module
-      ~dynlink
       ~sandbox:alias_module_build_sandbox
       ~dep_graphs:(Dep_graph.Ml_kind.dummy alias_module)
 
-  let build_wrapped_compat_modules (lib : Library.t) cctx
-        ~dynlink ~lib_modules =
+  let build_wrapped_compat_modules (lib : Library.t) cctx ~lib_modules =
     let wrapped_compat = Lib_modules.wrapped_compat lib_modules in
     let modules = Lib_modules.modules lib_modules in
     let wrapped = Lib_modules.wrapped lib_modules in
@@ -144,7 +142,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       Dep_graph.Ml_kind.wrapped_compat ~modules ~wrapped_compat
     in
     let cctx = Compilation_context.for_wrapped_compat cctx wrapped_compat in
-    Module_compilation.build_modules cctx ~dynlink ~dep_graphs
+    Module_compilation.build_modules cctx ~dep_graphs
 
   let build_c_file (lib : Library.t) ~dir ~expander ~includes (loc, src, dst) =
     let c_flags = (SC.c_flags sctx ~dir ~expander ~flags:lib.c_flags).c in
@@ -428,6 +426,8 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let cctx =
       let requires_compile = Lib.Compile.direct_requires compile_info in
       let requires_link    = Lib.Compile.requires_link compile_info in
+      let dynlink =
+        Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries in
       Compilation_context.create ()
         ~super_context:sctx
         ~expander
@@ -445,16 +445,13 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         ~no_keep_locs:lib.no_keep_locs
         ~opaque
         ~js_of_ocaml:lib.buildable.js_of_ocaml
+        ~dynlink
         ?stdlib:lib.stdlib
     in
 
     let requires_compile = Compilation_context.requires_compile cctx in
 
-    let dynlink =
-      Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries
-    in
-
-    build_wrapped_compat_modules lib cctx ~dynlink ~lib_modules;
+    build_wrapped_compat_modules lib cctx ~lib_modules;
 
     let (vlib_dep_graphs, dep_graphs) =
       let dep_graphs = Ocamldep.rules cctx in
@@ -468,13 +465,13 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         )
     in
 
-    Module_compilation.build_modules cctx ~dynlink ~dep_graphs;
+    Module_compilation.build_modules cctx ~dep_graphs;
 
     if Option.is_none lib.stdlib then begin
       Lib_modules.alias_module lib_modules
       |> Option.iter ~f:(fun alias_module ->
         let loc = lib.buildable.loc in
-        build_alias_module ~loc ~alias_module ~dir ~lib_modules ~cctx ~dynlink)
+        build_alias_module ~loc ~alias_module ~dir ~lib_modules ~cctx)
     end;
 
     let expander = Super_context.expander sctx ~dir in

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -76,12 +76,6 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
                      [Library.archive lib ~dir ~ext:ext_lib])
               ])))
 
-  (* If the compiler reads the cmi for module alias even with
-     [-w -49 -no-alias-deps], we must sandbox the build of the
-     alias module since the modules it references are built after. *)
-  let alias_module_build_sandbox =
-    Ocaml_version.always_reads_alias_cmi ctx.version
-
   let build_alias_module ~loc ~alias_module ~lib_modules ~dir ~cctx =
     let vimpl = Compilation_context.vimpl cctx in
     let file = Option.value_exn (Module.file alias_module ~ml_kind:Impl) in
@@ -107,7 +101,6 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     );
     let cctx = Compilation_context.for_alias_module cctx in
     Module_compilation.build_module cctx alias_module
-      ~sandbox:alias_module_build_sandbox
       ~dep_graphs:(Dep_graph.Ml_kind.dummy alias_module)
 
   let build_wrapped_compat_modules (lib : Library.t) cctx ~lib_modules =

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -20,8 +20,7 @@ let force_read_cmi source_file =
 (* Build the cm* if the corresponding source is present, in the case of cmi if
    the mli is not present it is added as additional target to the .cmo
    generation *)
-let build_cm cctx ?sandbox ~dep_graphs
-      ~cm_kind (m : Module.t) =
+let build_cm cctx ~dep_graphs ~cm_kind (m : Module.t) =
   let sctx     = CC.super_context cctx in
   let dir      = CC.dir           cctx in
   let obj_dir  = CC.obj_dir       cctx in
@@ -30,6 +29,7 @@ let build_cm cctx ?sandbox ~dep_graphs
   let vimpl    = CC.vimpl cctx in
   let mode     = Mode.of_cm_kind cm_kind in
   let dynlink  = CC.dynlink cctx in
+  let sandbox  = CC.sandbox cctx in
   Context.compiler ctx mode
   |> Option.iter ~f:(fun compiler ->
     let ml_kind = Cm_kind.source cm_kind in
@@ -182,9 +182,9 @@ let build_cm cctx ?sandbox ~dep_graphs
               ; Hidden_targets other_targets
               ]))))
 
-let build_module ?sandbox ~dep_graphs cctx m =
+let build_module ~dep_graphs cctx m =
   List.iter Cm_kind.all ~f:(fun cm_kind ->
-    build_cm cctx m ?sandbox ~dep_graphs ~cm_kind);
+    build_cm cctx m ~dep_graphs ~cm_kind);
   Compilation_context.js_of_ocaml cctx
   |> Option.iter ~f:(fun js_of_ocaml ->
     (* Build *.cmo.js *)
@@ -196,21 +196,22 @@ let build_module ?sandbox ~dep_graphs cctx m =
     SC.add_rules sctx ~dir
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
 
-let build_modules ?sandbox ~dep_graphs cctx =
+let build_modules ~dep_graphs cctx =
   Module.Name.Map.iter
     (match CC.alias_module cctx with
      | None -> CC.modules cctx
      | Some (m : Module.t) ->
        Module.Name.Map.remove (CC.modules cctx) (Module.name m))
-    ~f:(build_module cctx ?sandbox ~dep_graphs)
+    ~f:(build_module cctx ~dep_graphs)
 
-let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
+let ocamlc_i ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   let sctx     = CC.super_context cctx in
   let obj_dir  = CC.obj_dir       cctx in
   let dir      = CC.dir           cctx in
   let ctx      = SC.context       sctx in
   let src = Option.value_exn (Module.file m ~ml_kind:Impl) in
   let dep_graph = Ml_kind.Dict.get dep_graphs Impl in
+  let sandbox = Compilation_context.sandbox cctx in
   let cm_deps =
     Build.dyn_paths
       (Dep_graph.deps_of dep_graph m >>^ fun deps ->

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -20,7 +20,7 @@ let force_read_cmi source_file =
 (* Build the cm* if the corresponding source is present, in the case of cmi if
    the mli is not present it is added as additional target to the .cmo
    generation *)
-let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
+let build_cm cctx ?sandbox ~dep_graphs
       ~cm_kind (m : Module.t) =
   let sctx     = CC.super_context cctx in
   let dir      = CC.dir           cctx in
@@ -29,6 +29,7 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
   let stdlib   = CC.stdlib        cctx in
   let vimpl    = CC.vimpl cctx in
   let mode     = Mode.of_cm_kind cm_kind in
+  let dynlink  = CC.dynlink cctx in
   Context.compiler ctx mode
   |> Option.iter ~f:(fun compiler ->
     let ml_kind = Cm_kind.source cm_kind in
@@ -181,9 +182,9 @@ let build_cm cctx ?sandbox ?(dynlink=true) ~dep_graphs
               ; Hidden_targets other_targets
               ]))))
 
-let build_module ?sandbox ?dynlink ~dep_graphs cctx m =
+let build_module ?sandbox ~dep_graphs cctx m =
   List.iter Cm_kind.all ~f:(fun cm_kind ->
-    build_cm cctx m ?sandbox ?dynlink ~dep_graphs ~cm_kind);
+    build_cm cctx m ?sandbox ~dep_graphs ~cm_kind);
   Compilation_context.js_of_ocaml cctx
   |> Option.iter ~f:(fun js_of_ocaml ->
     (* Build *.cmo.js *)
@@ -195,13 +196,13 @@ let build_module ?sandbox ?dynlink ~dep_graphs cctx m =
     SC.add_rules sctx ~dir
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
 
-let build_modules ?sandbox ?dynlink ~dep_graphs cctx =
+let build_modules ?sandbox ~dep_graphs cctx =
   Module.Name.Map.iter
     (match CC.alias_module cctx with
      | None -> CC.modules cctx
      | Some (m : Module.t) ->
        Module.Name.Map.remove (CC.modules cctx) (Module.name m))
-    ~f:(build_module cctx ?sandbox ?dynlink ~dep_graphs)
+    ~f:(build_module cctx ?sandbox ~dep_graphs)
 
 let ocamlc_i ?sandbox ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   let sctx     = CC.super_context cctx in

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -2,14 +2,9 @@
 
 open Import
 
-(** Setup rules to build a single module.
-
-    @param dynlink if false disables the possibility to dynamically
-    link. The module can't be in a .cmxs or .so (default true).
- *)
+(** Setup rules to build a single module.*)
 val build_module
   :  ?sandbox:bool
-  -> ?dynlink:bool
   -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> Module.t
@@ -18,7 +13,6 @@ val build_module
 (** Setup rules to build all of the modules in the compilation context. *)
 val build_modules
   :  ?sandbox:bool
-  -> ?dynlink:bool
   -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> unit

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -4,22 +4,19 @@ open Import
 
 (** Setup rules to build a single module.*)
 val build_module
-  :  ?sandbox:bool
-  -> dep_graphs:Dep_graph.Ml_kind.t
+  :  dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> Module.t
   -> unit
 
 (** Setup rules to build all of the modules in the compilation context. *)
 val build_modules
-  :  ?sandbox:bool
-  -> dep_graphs:Dep_graph.Ml_kind.t
+  :  dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> unit
 
 val ocamlc_i
-  :  ?sandbox:bool
-  -> ?flags:string list
+  :  ?flags:string list
   -> dep_graphs:Dep_graph.Ml_kind.t
   -> Compilation_context.t
   -> Module.t


### PR DESCRIPTION
Passing `dynlink` & `sandbox` via the compilation context saves us passing around these variables. Also, since executables are going to have their own alias modules, we might as well handle it in a place shared between executables and libraries.