### PR TITLE
Make the "dynlink" argument of Compilation_context.create required

### DIFF
--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -97,7 +97,7 @@ let create ~super_context ~scope ~expander ~obj_dir
       ~modules ?alias_module ?lib_interface_module ~flags
       ~requires_compile ~requires_link
       ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
-      ~opaque ?stdlib ?js_of_ocaml ?(dynlink=false) ?sandbox () =
+      ~opaque ?stdlib ?js_of_ocaml ~dynlink ?sandbox () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -31,7 +31,7 @@ val create
   -> opaque                : bool
   -> ?stdlib               : Dune_file.Library.Stdlib.t
   -> ?js_of_ocaml          : Dune_file.Js_of_ocaml.t
-  -> ?dynlink              : bool
+  -> dynlink               : bool
   -> ?sandbox              : bool
   -> unit
   -> t

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -80,6 +80,12 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
   let cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info in
     let requires_link = Lib.Compile.requires_link compile_info in
+    let dynlink =
+      Dune_file.Executables.Link_mode.Set.exists exes.modes ~f:(fun mode ->
+        match mode.kind with
+        | Shared_object -> true
+        | _ -> false)
+    in
     Compilation_context.create ()
       ~super_context:sctx
       ~expander
@@ -93,6 +99,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
       ~preprocessing:pp
       ~js_of_ocaml:exes.buildable.js_of_ocaml
       ~opaque:(SC.opaque sctx)
+      ~dynlink
   in
 
   let requires_compile = Compilation_context.requires_compile cctx in

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -287,7 +287,8 @@ include Sub_system.Register_end_point(
           ~requires_compile:runner_libs
           ~requires_link:(lazy runner_libs)
           ~flags:(Ocaml_flags.of_list ["-w"; "-24"; "-g"])
-          ~js_of_ocaml:lib.buildable.js_of_ocaml;
+          ~js_of_ocaml:lib.buildable.js_of_ocaml
+          ~dynlink:false;
       in
       let linkages =
         let modes =

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -40,6 +40,7 @@ let generate_and_compile_module cctx ~name:basename ~code ~requires =
       ~requires_link:(lazy requires)
       ~flags:Ocaml_flags.empty
       ~opaque
+      ~dynlink:(Compilation_context.dynlink cctx)
       ()
   in
   Module_compilation.build_module

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -145,6 +145,7 @@ module Stanza = struct
         ~flags:(Ocaml_flags.append_common
                   (Ocaml_flags.default ~profile:(Super_context.profile sctx))
                   ["-w"; "-24"])
+        ~dynlink:false
     in
     let resolved = make ~cctx ~source in
     setup_rules resolved

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -81,6 +81,7 @@ let setup sctx ~dir =
       ~flags:(Ocaml_flags.append_common
                 (Ocaml_flags.default ~profile:(Super_context.profile sctx))
                 ["-w"; "-24"])
+      ~dynlink:false
   in
   let toplevel = Toplevel.make ~cctx ~source in
   Toplevel.setup_rules toplevel

--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -9,7 +9,7 @@ This captures the commands that are being run:
   {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-66-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-66-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-66-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-nodynlink","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-66-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}


### PR DESCRIPTION
#2297 accidentally changed the `dynlink` status for executables to `false`, breaking the production of shared objects. This PR makes this parameter explicit to lower the chances of getting it wrong in the future. For executables, it sets it to `true` only if the user requested building a shared object.
