### PR TITLE
Refactor interaction between compilation context and module compilation

### DIFF
--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -92,6 +92,8 @@ let wrapped_compat ~modules ~wrapped_compat =
           [ "deprecated", Module.to_dyn wrapped_compat
           ]
       | None, Some _ -> None
+      (* TODO this is wrong. The dependencies should be on the lib interface
+         whenever it exists *)
       | Some _, Some m -> Some (m, (Build.return [m]))
     )
   }

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -202,8 +202,9 @@ let build_and_link_many
   =
   let dep_graphs = Ocamldep.rules cctx in
 
-  (* CR-someday jdimino: this should probably say [~dynlink:false] *)
-  Module_compilation.build_modules cctx ~dep_graphs;
+  Compilation_context.modules cctx
+  |> Module.Name.Map.iter ~f:(
+    Module_compilation.build_module cctx ~dep_graphs);
 
   let link_time_code_gen = Link_time_code_gen.handle_special_libs cctx in
   List.iter programs ~f:(fun { Program.name; main_module_name ; loc } ->

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -196,14 +196,6 @@ let build_module ~dep_graphs cctx m =
     SC.add_rules sctx ~dir
       (Js_of_ocaml_rules.build_cm cctx ~js_of_ocaml ~src ~target))
 
-let build_modules ~dep_graphs cctx =
-  Module.Name.Map.iter
-    (match CC.alias_module cctx with
-     | None -> CC.modules cctx
-     | Some (m : Module.t) ->
-       Module.Name.Map.remove (CC.modules cctx) (Module.name m))
-    ~f:(build_module cctx ~dep_graphs)
-
 let ocamlc_i ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   let sctx     = CC.super_context cctx in
   let obj_dir  = CC.obj_dir       cctx in

--- a/src/module_compilation.mli
+++ b/src/module_compilation.mli
@@ -9,12 +9,6 @@ val build_module
   -> Module.t
   -> unit
 
-(** Setup rules to build all of the modules in the compilation context. *)
-val build_modules
-  :  dep_graphs:Dep_graph.Ml_kind.t
-  -> Compilation_context.t
-  -> unit
-
 val ocamlc_i
   :  ?flags:string list
   -> dep_graphs:Dep_graph.Ml_kind.t


### PR DESCRIPTION
The previous behavior was to get all the modules in the compilation context, but then to filter out the alias module. That is quite confusing and we might as well just pass the modules that we want to compile explicitly.