### PR TITLE
Make Dep_graph keyed by obj_name

### DIFF
--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -110,18 +110,14 @@ module Ml_kind = struct
       Ml_kind.Dict.make_both (w ~modules ~wrapped_compat)
 
   let merge_impl ~(ml_kind : Ml_kind.t) _ vlib impl =
-    match vlib, impl with
-    | None, None -> assert false
-    | Some _, None -> None (* we don't care about internal vlib deps *)
-    | None, Some d -> Some d
-    | Some vlib , Some impl -> Some (Ml_kind.choose ml_kind ~impl ~intf:vlib)
+    Some (Ml_kind.choose ml_kind ~impl ~intf:vlib)
 
   let merge_for_impl ~(vlib : t) ~(impl : t) =
     Ml_kind.Dict.of_func (fun ~ml_kind ->
       let impl = Ml_kind.Dict.get impl ml_kind in
       { impl with
         per_module =
-          Module.Obj_map.merge ~f:(merge_impl ~ml_kind)
+          Module.Obj_map.union ~f:(merge_impl ~ml_kind)
             (Ml_kind.Dict.get vlib ml_kind).per_module
             impl.per_module
       })

--- a/src/dep_graph.mli
+++ b/src/dep_graph.mli
@@ -19,12 +19,6 @@ val top_closed_implementations
   -> Module.t list
   -> (unit, Module.t list) Build.t
 
-val top_closed_multi_implementations
-  :  t list
-  -> Module.t list
-  -> (unit, Module.t list) Build.t
-
-
 module Ml_kind : sig
   type nonrec t = t Ml_kind.Dict.t
 

--- a/src/dep_graph.mli
+++ b/src/dep_graph.mli
@@ -6,7 +6,7 @@ type t
 
 val make
   :  dir:Path.Build.t
-  -> per_module:(Module.t * (unit, Module.t list) Build.t) Module.Obj_map.t
+  -> per_module:((unit, Module.t list) Build.t) Module.Obj_map.t
   -> t
 
 val deps_of

--- a/src/dep_graph.mli
+++ b/src/dep_graph.mli
@@ -6,7 +6,7 @@ type t
 
 val make
   :  dir:Path.Build.t
-  -> per_module:(Module.t * (unit, Module.t list) Build.t) Module.Name.Map.t
+  -> per_module:(Module.t * (unit, Module.t list) Build.t) Module.Obj_map.t
   -> t
 
 val deps_of

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -154,7 +154,9 @@ let rules_generic cctx ~modules =
   Ml_kind.Dict.of_func
     (fun ~ml_kind ->
        let per_module =
-         Module.Name.Map.map modules ~f:(fun m -> (m, deps_of cctx ~ml_kind m))
+         Module.Name.Map.fold modules ~init:Module.Obj_map.empty
+           ~f:(fun m acc ->
+             Module.Obj_map.add acc m (m, deps_of cctx ~ml_kind m))
        in
        Dep_graph.make ~dir:(CC.dir cctx) ~per_module)
 
@@ -176,5 +178,8 @@ let graph_of_remote_lib ~obj_dir ~modules =
   let dir = Obj_dir.dir obj_dir in
   Ml_kind.Dict.of_func (fun ~ml_kind ->
     let per_module =
-      Module.Name.Map.map modules ~f:(fun m -> (m, deps_of ~ml_kind m)) in
+      Module.Name.Map.fold modules ~init:Module.Obj_map.empty
+        ~f:(fun m acc ->
+          Module.Obj_map.add acc m (m, deps_of ~ml_kind m))
+    in
     Dep_graph.make ~dir ~per_module)

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -156,7 +156,7 @@ let rules_generic cctx ~modules =
        let per_module =
          Module.Name.Map.fold modules ~init:Module.Obj_map.empty
            ~f:(fun m acc ->
-             Module.Obj_map.add acc m (m, deps_of cctx ~ml_kind m))
+             Module.Obj_map.add acc m (deps_of cctx ~ml_kind m))
        in
        Dep_graph.make ~dir:(CC.dir cctx) ~per_module)
 
@@ -180,6 +180,6 @@ let graph_of_remote_lib ~obj_dir ~modules =
     let per_module =
       Module.Name.Map.fold modules ~init:Module.Obj_map.empty
         ~f:(fun m acc ->
-          Module.Obj_map.add acc m (m, deps_of ~ml_kind m))
+          Module.Obj_map.add acc m (deps_of ~ml_kind m))
     in
     Dep_graph.make ~dir ~per_module)

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -175,7 +175,7 @@ let external_dep_graph sctx ~impl_cm_kind ~impl_obj_dir ~vlib_modules =
               Build.memoize "ocamlobjinfo" @@
               read >>^ deps_from_objinfo ~for_module:m
           in
-          Module.Obj_map.add acc m (m, deps))))
+          Module.Obj_map.add acc m deps)))
 
 let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope =
   Option.map lib.implements ~f:begin fun (loc, implements) ->


### PR DESCRIPTION
Now the dependency graph can be reliably represented for entire libraries -- there's no longer a need for a separate graph compatibility modules and implementations of virtual libraries

It also future proofs us for when we introduce qualified subdirs. The dependency graph will be able to contain all dependencies for such libraries as well.

Also, this makes the merging of impl and vlib dep graphs quite trivial. See the 3rd commit for how simple it looks.