### PR TITLE
Do not promote install files by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   the cost of building unnecessary artifacts in some cases. Some of these extra
   artifacts can fail to built, so this is a breaking change. (#2268, @rgrinberg)
 
+- Do not put the `<package>.install` files in the source tree unless
+  `-p` or `--promote-install-files` is passed on the command line (#..., @diml)
+
 1.11.0 (unreleased)
 -------------------
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -229,11 +229,14 @@ module Options_implied_by_dash_p = struct
            & flag
            & info ["always-show-command-line"] ~docs ~doc)
     and+ promote_install_files =
-      let doc =
-        "Promote the generated <package>.install files to the source tree" in
-      Arg.(value
-           & flag
-           & info ["promote-install-files"] ~docs ~doc)
+      if Wp.dune2 then
+        let doc =
+          "Promote the generated <package>.install files to the source tree" in
+        Arg.(value
+             & flag
+             & info ["promote-install-files"] ~docs ~doc)
+      else
+        Term.const true
     in
     { root
     ; only_packages

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -41,6 +41,7 @@ type t =
   ; watch : bool
   ; stats_trace_file : string option
   ; always_show_command_line : bool
+  ; promote_install_files : bool
   }
 
 let prefix_target common s = common.target_prefix ^ s
@@ -62,6 +63,7 @@ let set_common_other c ~targets =
   Clflags.watch := c.watch;
   Clflags.no_print_directory := c.no_print_directory;
   Clflags.store_orig_src_dir := c.store_orig_src_dir;
+  Clflags.promote_install_files := c.promote_install_files;
   Clflags.external_lib_deps_hint :=
     List.concat
       [ ["dune"; "external-lib-deps"; "--missing"]
@@ -122,6 +124,7 @@ module Options_implied_by_dash_p = struct
     ; profile : string option
     ; default_target : string
     ; always_show_command_line : bool
+    ; promote_install_files : bool
     }
 
   let docs = copts_sect
@@ -225,6 +228,12 @@ module Options_implied_by_dash_p = struct
       Arg.(value
            & flag
            & info ["always-show-command-line"] ~docs ~doc)
+    and+ promote_install_files =
+      let doc =
+        "Promote the generated <package>.install files to the source tree" in
+      Arg.(value
+           & flag
+           & info ["promote-install-files"] ~docs ~doc)
     in
     { root
     ; only_packages
@@ -233,6 +242,7 @@ module Options_implied_by_dash_p = struct
     ; profile
     ; default_target
     ; always_show_command_line
+    ; promote_install_files
     }
 
   let for_release = "for-release-of-packages"
@@ -256,6 +266,7 @@ module Options_implied_by_dash_p = struct
     ; profile = Some "release"
     ; default_target = "@install"
     ; always_show_command_line = true
+    ; promote_install_files = true
     }
 
   let term = one_of options dash_p
@@ -356,6 +367,7 @@ let term =
        ; profile
        ; default_target
        ; always_show_command_line
+       ; promote_install_files
        } = Options_implied_by_dash_p.term
   and+ x =
     Arg.(value
@@ -443,6 +455,7 @@ let term =
   ; watch
   ; stats_trace_file
   ; always_show_command_line
+  ; promote_install_files
   }
 
 let term =

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -24,6 +24,7 @@ type t =
   ; watch : bool
   ; stats_trace_file : string option
   ; always_show_command_line : bool
+  ; promote_install_files : bool
   }
 
 val prefix_target : t -> string -> string

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -158,8 +158,8 @@ directory.  Although, some are sometimes copied to the source tree for
 the need of external tools. These includes:
 
 - ``.merlin`` files
-
-- ``<package>.install`` files
+- ``<package>.install`` files (when either ``-p`` or
+  ``--promote-install-files`` is passed on the command line)
 
 As a result, if you want to ask ``dune`` to produce a particular ``.exe``
 file you would have to type:

--- a/src/clflags.ml
+++ b/src/clflags.ml
@@ -10,3 +10,4 @@ let watch = ref false
 let no_print_directory = ref false
 let store_orig_src_dir = ref false
 let always_show_command_line = ref false
+let promote_install_files = ref false

--- a/src/clflags.mli
+++ b/src/clflags.mli
@@ -35,3 +35,6 @@ val store_orig_src_dir : bool ref
 
 (** Always show full command on error *)
 val always_show_command_line : bool ref
+
+(** Promote the generated [<package>.install] files to the source tree *)
+val promote_install_files : bool ref

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -303,6 +303,7 @@ let symlink_installed_artifacts_to_build_install
     Install.Entry.set_src entry dst)
 
 let promote_install_file (ctx : Context.t) =
+  !Clflags.promote_install_files &&
   not ctx.implicit &&
   match ctx.kind with
   | Default -> true

--- a/src/wp/dune-impl/wp.ml
+++ b/src/wp/dune-impl/wp.ml
@@ -1,2 +1,3 @@
 type t = Dune | Jbuilder
 let t = Dune
+let dune2 = false

--- a/src/wp/jbuilder-impl/wp.ml
+++ b/src/wp/jbuilder-impl/wp.ml
@@ -1,2 +1,3 @@
 type t = Dune | Jbuilder
 let t = Jbuilder
+let dune2 = false

--- a/src/wp/wp.boot.ml
+++ b/src/wp/wp.boot.ml
@@ -1,2 +1,3 @@
 type t = Dune | Jbuilder
 let t = Dune
+let dune2 = false

--- a/src/wp/wp.mli
+++ b/src/wp/wp.mli
@@ -3,3 +3,4 @@
 type t = Dune | Jbuilder
 
 val t : t
+val dune2 : bool


### PR DESCRIPTION
They are only useful for opam builds and they are annoying for development. This PR proposes to only promote them to the source tree when `--promote-install-files` is passed on the command line. `-p` implies `--promote-install-files`. This should go in Dune 2.0.0 only.