### PR TITLE
Simplify handling of incompatible options

### DIFF
--- a/test/blackbox-tests/test-cases/github25/run.t
+++ b/test/blackbox-tests/test-cases/github25/run.t
@@ -21,6 +21,6 @@ We need ocamlfind to run this test
   Error: Library "une-lib-qui-nexiste-pas" not found.
   -> required by library "plop.ca-marche-pas" in
      .../plop
-  Hint: try: dune external-lib-deps --missing --display short --only pas-de-bol
+  Hint: try: dune external-lib-deps --missing --only pas-de-bol --display short
     @install
       ocamldep root/.pas_de_bol.objs/b.ml.d

--- a/test/blackbox-tests/test-cases/misc/run.t
+++ b/test/blackbox-tests/test-cases/misc/run.t
@@ -10,3 +10,30 @@ Testing multiline commands in cram tests:
   > EOF
   Multiline
   Text
+
+Test that incompatible options are properly reported
+----------------------------------------------------
+
+  $ dune build --verbose --display quiet
+  dune: Cannot use --verbose and --display simultaneously
+  Usage: dune build [OPTION]... [TARGET]...
+  Try `dune build --help' or `dune --help' for more information.
+  [1]
+
+  $ dune build -p toto --root .
+  dune: Cannot use --root and -p simultaneously
+  Usage: dune build [OPTION]... [TARGET]...
+  Try `dune build --help' or `dune --help' for more information.
+  [1]
+
+  $ dune build --for-release-of-packages toto --root .
+  dune: Cannot use --root and --for-release-of-packages simultaneously
+  Usage: dune build [OPTION]... [TARGET]...
+  Try `dune build --help' or `dune --help' for more information.
+  [1]
+
+  $ dune build --no-config --config x
+  dune: Cannot use --config and --no-config simultaneously
+  Usage: dune build [OPTION]... [TARGET]...
+  Try `dune build --help' or `dune --help' for more information.
+  [1]


### PR DESCRIPTION
This PR introduces a function `one_of` that makes use the of `Term.with_used_args` to easily implement incompatible options with cmdliner:

```ocaml
val one_of : 'a Term.t -> 'a Term.t -> 'a Term.t
```

We have several sets of options that are incompatible in the CLI and this PR simplify their definitions. In addition, the error message now reports the exact names of the incompatible options rather than always their long forms.