### PR TITLE
Convert `Process`, `Scheduler` and `Console` to the new error reporting API and restore coloring

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -222,20 +222,14 @@ let install_uninstall ~what =
                 with
                 | [] -> (package, entries)
                 | missing_files ->
-                  let pp =
-                    let open Pp in
-                    List.map missing_files ~f:(fun p ->
-                      concat
-                        [ verbatim "- "
-                        ; verbatim (Path.Build.to_string_maybe_quoted p)
-                        ]
-                    )
-                    |> concat ~sep:newline
-                  in
-                  die "The following files which are listed in %s cannot be \
-                       installed because they do not exist:@.%a@."
-                    (Path.to_string_maybe_quoted install_file)
-                    (fun fmt () -> Pp.pp fmt pp) ())
+                  User_error.raise
+                    [ Pp.textf
+                        "The following files which are listed in %s \
+                         cannot be installed because they do not exist:"
+                        (Path.to_string_maybe_quoted install_file)
+                    ; Pp.enumerate missing_files ~f:(fun p ->
+                        Pp.verbatim (Path.Build.to_string_maybe_quoted p))
+                    ])
           in
           (context, entries_per_package))
       in

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -39,7 +39,7 @@ let print_rule_makefile ppf (rule : Build_system.Rule.t) =
     (fun ppf ->
        Path.Set.iter (Dep.Set.paths rule.deps ~eval_pred) ~f:(fun dep ->
          Format.fprintf ppf "@ %s" (Path.to_string dep)))
-    Pp.pp
+    Pp.render_ignore_tags
     (Action_to_sh.pp action)
 
 let print_rule_sexp ppf (rule : Build_system.Rule.t) =

--- a/src/colors.ml
+++ b/src/colors.ml
@@ -33,10 +33,11 @@ module Style = struct
     | _         -> None
 end
 
-let styles_of_tag s =
+let mark_open_tag s =
   match Style.of_string s with
-  | None -> []
-  | Some style -> Style.to_styles style
+  | Some style -> Ansi_color.Style.escape_sequence (Style.to_styles style)
+  | None ->
+    if s <> "" && s.[0] = '\027' then s else ""
 
 let setup_err_formatter_colors () =
   let open Format in
@@ -46,8 +47,7 @@ let setup_err_formatter_colors () =
       pp_set_mark_tags ppf true;
       pp_set_formatter_tag_functions ppf
         { funcs with
-          mark_close_tag = (fun _   -> Ansi_color.Style.escape_sequence [])
-        ; mark_open_tag  = (fun tag -> Ansi_color.Style.escape_sequence
-                                         (styles_of_tag tag))
+          mark_close_tag = (fun _ -> Ansi_color.Style.escape_sequence [])
+        ; mark_open_tag
         } [@warning "-3"])
   end

--- a/src/colors.ml
+++ b/src/colors.ml
@@ -1,20 +1,6 @@
 open! Stdune
 open Import
 
-type styles = Ansi_color.Style.t list
-
-let apply_string styles str =
-  sprintf "%s%s%s"
-    (Ansi_color.Style.escape_sequence styles)
-    str
-    (Ansi_color.Style.escape_sequence [])
-
-let strip_colors_for_stderr s =
-  if Lazy.force Ansi_color.stderr_supports_color then
-    s
-  else
-    Ansi_color.strip s
-
 (* We redirect the output of all commands, so by default the various
    tools will disable colors. Since we support colors in the output of
    commands, we force it via specific environment variables if stderr
@@ -65,9 +51,3 @@ let setup_err_formatter_colors () =
                                          (styles_of_tag tag))
         } [@warning "-3"])
   end
-
-let output_filename : styles = [Bold; Fg Green]
-
-let command_success : styles = [Bold; Fg Green]
-
-let command_error : styles = [Bold; Fg Red]

--- a/src/colors.ml
+++ b/src/colors.ml
@@ -9,24 +9,6 @@ let apply_string styles str =
     str
     (Ansi_color.Style.escape_sequence [])
 
-let colorize =
-  let color_combos =
-    let open Ansi_color.Color in
-    [| Blue,          Bright_green
-     ; Red,           Bright_yellow
-     ; Yellow,        Blue
-     ; Magenta,       Bright_cyan
-     ; Bright_green,  Blue
-     ; Bright_yellow, Red
-     ; Blue,          Yellow
-     ; Bright_cyan,   Magenta
-    |]
-  in
-  fun ~key str ->
-    let hash = Hashtbl.hash key in
-    let fore, back = color_combos.(hash mod (Array.length color_combos)) in
-    apply_string [Fg fore; Bg back] str
-
 let strip_colors_for_stderr s =
   if Lazy.force Ansi_color.stderr_supports_color then
     s

--- a/src/colors.mli
+++ b/src/colors.mli
@@ -4,18 +4,5 @@ open! Stdune
     print colors *)
 val setup_env_for_colors : Env.t -> Env.t
 
-(** Strip colors in [not (Lazy.force Ansi_color.stderr_supports_colors)] *)
-val strip_colors_for_stderr : string -> string
-
 (** Enable the interpretation of color tags for [Format.err_formatter] *)
 val setup_err_formatter_colors : unit -> unit
-
-type styles
-
-val output_filename : styles
-
-val command_success : styles
-
-val command_error : styles
-
-val apply_string : styles -> string -> string

--- a/src/colors.mli
+++ b/src/colors.mli
@@ -1,7 +1,5 @@
 open! Stdune
 
-val colorize : key:string -> string -> string
-
 (** [Env.initial] extended with variables to force a few tools to
     print colors *)
 val setup_env_for_colors : Env.t -> Env.t

--- a/src/console.ml
+++ b/src/console.ml
@@ -48,6 +48,13 @@ module T = struct
     show_status_line s;
     flush stderr
 
+  let print_user_message t ?config ?margin msg =
+    let s = t.status_line in
+    hide_status_line s;
+    User_message.prerr ?config ?margin msg;
+    show_status_line s;
+    flush stderr
+
   let hide_status_line t =
     hide_status_line t.status_line;
     flush stderr
@@ -81,3 +88,7 @@ let print msg =
   match !t_var with
   | None -> Printf.eprintf "%s%!" msg
   | Some t -> T.print t msg
+let print_user_message ?config ?margin msg =
+  match !t_var with
+  | None -> User_message.prerr ?config ?margin msg
+  | Some t -> T.print_user_message t ?config ?margin msg

--- a/src/console.ml
+++ b/src/console.ml
@@ -39,9 +39,7 @@ module T = struct
           Pp.map_tags status_line ~f:User_message.Print_config.default
         in
         let status_line_len =
-          String.length
-            (Format.asprintf "%a" Pp.pp
-               (Pp.map_tags status_line ~f:ignore))
+          String.length (Format.asprintf "%a" Pp.render_ignore_tags status_line)
         in
         hide_status_line t;
         show_status_line status_line;
@@ -56,9 +54,9 @@ module T = struct
     show_status_line t.status_line;
     flush stderr
 
-  let print_user_message t ?config ?margin msg =
+  let print_user_message t ?config msg =
     hide_status_line t;
-    User_message.prerr ?config ?margin msg;
+    User_message.prerr ?config msg;
     show_status_line t.status_line;
     flush stderr
 
@@ -95,7 +93,7 @@ let print msg =
   match !t_var with
   | None -> Printf.eprintf "%s%!" msg
   | Some t -> T.print t msg
-let print_user_message ?config ?margin msg =
+let print_user_message ?config msg =
   match !t_var with
-  | None -> User_message.prerr ?config ?margin msg
-  | Some t -> T.print_user_message t ?config ?margin msg
+  | None -> User_message.prerr ?config msg
+  | Some t -> T.print_user_message t ?config msg

--- a/src/console.mli
+++ b/src/console.mli
@@ -4,7 +4,6 @@ val print : string -> unit
 
 val print_user_message
   :  ?config:User_message.Print_config.t
-  -> ?margin:int
   -> User_message.t
   -> unit
 

--- a/src/console.mli
+++ b/src/console.mli
@@ -9,7 +9,7 @@ val print_user_message
   -> unit
 
 type status_line_config =
-  { message   : string option
+  { message   : User_message.Style.t Pp.t option
   ; show_jobs : bool
   }
 

--- a/src/console.mli
+++ b/src/console.mli
@@ -2,6 +2,11 @@ open! Stdune
 
 val print : string -> unit
 
+val print_user_message
+  :  ?config:User_message.Print_config.t
+  -> ?margin:int
+  -> User_message.t
+  -> unit
 
 type status_line_config =
   { message   : string option

--- a/src/main.ml
+++ b/src/main.ml
@@ -86,7 +86,8 @@ let init_build_system ?only_packages ?external_lib_deps_mode w =
   let rule_total = ref 0 in
   let gen_status_line () =
     { Console.
-      message = Some (sprintf "Done: %u/%u" !rule_done !rule_total)
+      message = Some (Pp.verbatim
+                        (sprintf "Done: %u/%u" !rule_done !rule_total))
     ; show_jobs = true
     }
   in

--- a/src/process.ml
+++ b/src/process.ml
@@ -177,15 +177,15 @@ module Fancy = struct
     end
 
   let color_combos =
-    let open Ansi_color.Color in
-    [| Blue,          Bright_green
-     ; Red,           Bright_yellow
-     ; Yellow,        Blue
-     ; Magenta,       Bright_cyan
-     ; Bright_green,  Blue
-     ; Bright_yellow, Red
-     ; Blue,          Yellow
-     ; Bright_cyan,   Magenta
+    let open Ansi_color.Style in
+    [| [ fg_blue;          bg_bright_green ]
+     ; [ fg_red;           bg_bright_yellow ]
+     ; [ fg_yellow;        bg_blue ]
+     ; [ fg_magenta;       bg_bright_cyan ]
+     ; [ fg_bright_green;  bg_blue ]
+     ; [ fg_bright_yellow; bg_red ]
+     ; [ fg_blue;          bg_yellow ]
+     ; [ fg_bright_cyan;   bg_magenta ]
     |]
 
   let colorize_prog s =
@@ -196,8 +196,8 @@ module Fancy = struct
       let before, prog, after = split_prog s in
       let styles =
         let hash = Hashtbl.hash prog in
-        let fore, back = color_combos.(hash mod (Array.length color_combos)) in
-        User_message.Style.Ansi_styles [Fg fore; Bg back]
+        let styles = color_combos.(hash mod (Array.length color_combos)) in
+        User_message.Style.Ansi_styles styles
       in
       Pp.seq
         (Pp.verbatim before)
@@ -210,7 +210,8 @@ module Fancy = struct
     | "-o" :: fn :: rest ->
       Pp.verbatim "-o"
       :: Pp.tag (Pp.verbatim (quote_for_shell fn))
-           ~tag:(User_message.Style.Ansi_styles [Bold; Fg Green])
+           ~tag:(User_message.Style.Ansi_styles
+                   Ansi_color.Style.[bold; fg_green])
       :: colorize_args rest
     | x :: rest -> Pp.verbatim (quote_for_shell x) :: colorize_args rest
 

--- a/src/process.ml
+++ b/src/process.ml
@@ -343,7 +343,7 @@ module Exit_status = struct
         Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Command") ++
         Pp.space ++ pp_id id ++
         Pp.space ++ Pp.text msg ++ Pp.char ':'
-        :: Pp.tag ~tag:User_message.Style.Prompt (Pp.char '$') ++ Pp.space ++
+        :: Pp.tag ~tag:User_message.Style.Prompt (Pp.char '$') ++ Pp.char ' ' ++
            command_line
         :: Option.to_list output)
 
@@ -436,7 +436,7 @@ let run_internal ?dir ?(stdout_to=Output.stdout) ?(stderr_to=Output.stderr)
       Console.print_user_message
         (User_message.make
            [ Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Running") ++
-             pp_id id ++ Pp.char ':' ++ Pp.space ++
+             pp_id id ++ Pp.verbatim ": " ++
              cmdline
            ]);
       cmdline

--- a/src/process.ml
+++ b/src/process.ml
@@ -114,6 +114,37 @@ module Temp = struct
     tmp_files := Path.Set.remove !tmp_files fn
 end
 
+let command_line_enclosers ~dir ~(stdout_to:Output.t) ~(stderr_to:Output.t) =
+  let quote fn = quote_for_shell (Path.to_string fn) in
+  let prefix, suffix =
+    match dir with
+    | None -> "", ""
+    | Some dir -> sprintf "(cd %s && " (quote dir), ")"
+  in
+  let suffix =
+    match stdout_to.kind, stderr_to.kind with
+    | File fn1, File fn2 when Path.equal fn1 fn2 ->
+      " &> " ^ quote fn1
+    | _ ->
+      let suffix =
+        match stdout_to.kind with
+        | Terminal -> suffix
+        | File fn -> suffix ^ " > " ^ quote fn
+      in
+      match stderr_to.kind with
+      | Terminal -> suffix
+      | File fn -> suffix ^ " 2> " ^ quote fn
+  in
+  (prefix, suffix)
+
+let command_line ~prog ~args ~dir ~stdout_to ~stderr_to =
+  let s =
+    List.map (prog :: args) ~f:quote_for_shell
+    |> String.concat ~sep:" "
+  in
+  let prefix, suffix = command_line_enclosers ~dir ~stdout_to ~stderr_to in
+  prefix ^ s ^ suffix
+
 module Fancy = struct
   let split_prog s =
     let len = String.length s in
@@ -145,102 +176,108 @@ module Fancy = struct
       before, prog, after
     end
 
+  let color_combos =
+    let open Ansi_color.Color in
+    [| Blue,          Bright_green
+     ; Red,           Bright_yellow
+     ; Yellow,        Blue
+     ; Magenta,       Bright_cyan
+     ; Bright_green,  Blue
+     ; Bright_yellow, Red
+     ; Blue,          Yellow
+     ; Bright_cyan,   Magenta
+    |]
+
   let colorize_prog s =
     let len = String.length s in
     if len = 0 then
-      s
+      Pp.verbatim s
     else
       let before, prog, after = split_prog s in
-      before ^ Colors.colorize ~key:prog prog ^ after
+      let styles =
+        let hash = Hashtbl.hash prog in
+        let fore, back = color_combos.(hash mod (Array.length color_combos)) in
+        User_message.Style.Ansi_styles [Fg fore; Bg back]
+      in
+      Pp.seq
+        (Pp.verbatim before)
+        (Pp.seq
+           (Pp.tag (Pp.verbatim prog) ~tag:styles)
+           (Pp.verbatim after))
 
   let rec colorize_args = function
     | [] -> []
     | "-o" :: fn :: rest ->
-      "-o" :: Colors.(apply_string output_filename) fn :: colorize_args rest
-    | x :: rest -> x :: colorize_args rest
+      Pp.verbatim "-o"
+      :: Pp.tag (Pp.verbatim (quote_for_shell fn))
+           ~tag:(User_message.Style.Ansi_styles [Bold; Fg Green])
+      :: colorize_args rest
+    | x :: rest -> Pp.verbatim (quote_for_shell x) :: colorize_args rest
 
-  let command_line ~prog ~args ~dir
-        ~(stdout_to:Output.t) ~(stderr_to:Output.t) =
-    let prog = Path.reach_for_running ?from:dir prog in
-    let quote = quote_for_shell in
-    let prog = colorize_prog (quote prog) in
-    let s =
-      String.concat (prog :: colorize_args (List.map args ~f:quote)) ~sep:" "
+  let command_line ~prog ~args ~dir ~stdout_to ~stderr_to =
+    let open Pp.O in
+    let prog = colorize_prog (quote_for_shell prog) in
+    let pp =
+      Pp.concat ~sep:(Pp.char ' ') (prog :: colorize_args args)
     in
-    let s =
-      match dir with
-      | None -> s
-      | Some dir -> sprintf "(cd %s && %s)" (Path.to_string dir) s
-    in
-    match stdout_to.kind, stderr_to.kind with
-    | File fn1, File fn2 when Path.equal fn1 fn2 ->
-      sprintf "%s &> %s" s (Path.to_string fn1)
-    | _ ->
-      let s =
-        match stdout_to.kind with
-        | Terminal -> s
-        | File fn ->
-          sprintf "%s > %s" s (Path.to_string fn)
-      in
-      match stderr_to.kind with
-      | Terminal -> s
-      | File fn ->
-        sprintf "%s 2> %s" s (Path.to_string fn)
+    let prefix, suffix = command_line_enclosers ~dir ~stdout_to ~stderr_to in
+    Pp.verbatim prefix ++ pp ++ Pp.verbatim suffix
 
-  let pp_purpose ppf = function
-    | Internal_job ->
-      Format.fprintf ppf "(internal)"
+  let pp_purpose = function
+    | Internal_job -> Pp.verbatim "(internal)"
     | Build_job targets ->
       let rec split_paths targets_acc ctxs_acc = function
-        | [] -> List.rev targets_acc, String.Set.(to_list (of_list ctxs_acc))
+        | [] -> List.rev targets_acc, String.Set.to_list ctxs_acc
         | path :: rest ->
-          let add_ctx ctx acc = if ctx = "default" then acc else ctx :: acc in
+          let add_ctx ctx acc =
+            match ctx with
+            | "default" -> acc
+            | _ -> String.Set.add acc ctx
+          in
           match Dpath.analyse_target path with
           | Other path ->
-            split_paths (Path.Build.to_string path :: targets_acc) ctxs_acc rest
+            split_paths
+              (Path.Build.to_string path :: targets_acc)
+              ctxs_acc rest
           | Regular (ctx, filename) ->
-            split_paths (Path.Source.to_string filename :: targets_acc)
+            split_paths
+              (Path.Source.to_string filename :: targets_acc)
               (add_ctx ctx ctxs_acc) rest
           | Alias (ctx, name) ->
-            split_paths (("alias " ^ Path.Source.to_string name) :: targets_acc)
+            split_paths
+              (("alias " ^ Path.Source.to_string name) :: targets_acc)
               (add_ctx ctx ctxs_acc) rest
           | Install (ctx, name) ->
-            split_paths (("install " ^ Path.Source.to_string name) :: targets_acc)
+            split_paths
+              (("install " ^ Path.Source.to_string name) :: targets_acc)
               (add_ctx ctx ctxs_acc) rest
       in
       let targets = Path.Build.Set.to_list targets in
       let target_names, contexts =
-        split_paths [] [] targets
+        split_paths [] String.Set.empty targets
       in
-      let target_names_grouped_by_prefix =
+      let targets =
         List.map target_names ~f:Filename.split_extension_after_dot
         |> String.Map.of_list_multi
         |> String.Map.to_list
+        |> List.map ~f:(fun (prefix, suffixes) ->
+          match suffixes with
+          | [] -> assert false
+          | [suffix] -> prefix ^ suffix
+          | _ ->
+            sprintf "%s{%s}" prefix (String.concat ~sep:"," suffixes))
+        |> String.concat ~sep:","
       in
-      let pp_comma ppf () = Format.fprintf ppf "," in
-      let pp_group ppf (prefix, suffixes) =
-        match suffixes with
-        | [] -> assert false
-        | [suffix] -> Format.fprintf ppf "%s%s" prefix suffix
-        | _ ->
-          Format.fprintf ppf "%s{%a}"
-            prefix
-            (Format.pp_print_list ~pp_sep:pp_comma Format.pp_print_string)
-            suffixes
-      in
-      let pp_contexts ppf = function
-        | [] -> ()
-        | ctxs ->
-          Format.fprintf ppf " @{<details>[%a]@}"
-            (Format.pp_print_list ~pp_sep:pp_comma
-               (fun ppf s -> Format.fprintf ppf "%s" s))
-            ctxs
-      in
-      Format.fprintf ppf "%a%a"
-        (Format.pp_print_list ~pp_sep:pp_comma pp_group)
-        target_names_grouped_by_prefix
-        pp_contexts
-        contexts;
+      let pp = Pp.verbatim targets in
+      match contexts with
+      | [] -> pp
+      | l ->
+        let open Pp.O in
+        pp ++ Pp.char ' ' ++
+        Pp.tag ~tag:User_message.Style.Details
+          (Pp.char '[' ++
+           Pp.concat_map l ~sep:(Pp.char ',') ~f:Pp.verbatim ++
+           Pp.char ']')
 end
 
 let gen_id =
@@ -250,6 +287,125 @@ let gen_id =
 let cmdline_approximate_length prog args =
   List.fold_left args ~init:(String.length prog) ~f:(fun acc arg ->
     acc + String.length arg)
+
+let pp_id id =
+  let open Pp.O in
+  Pp.char '[' ++
+  Pp.tag ~tag:User_message.Style.Id (Pp.textf "%d" id) ++
+  Pp.char ']'
+
+module Exit_status = struct
+  type error =
+    | Failed of int
+    | Signaled of string
+
+  type t = (int, error) result
+
+  let parse_output = function
+    | "" -> None
+    | s -> Some (Pp.map_tags (Ansi_color.parse s)
+                   ~f:(fun styles -> User_message.Style.Ansi_styles styles))
+
+  (* In this module, we don't need the "Error: " prefix given that it
+     is already included in the error message from the command. *)
+  let fail paragraphs =
+    raise (User_error.E (User_message.make paragraphs))
+
+  let handle_verbose t ~id ~output ~command_line =
+    let open Pp.O in
+    let output = parse_output output in
+    match t with
+    | Ok n ->
+      Option.iter output ~f:(fun output ->
+        Console.print_user_message
+          (User_message.make
+             [ Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Output") ++
+               pp_id id ++ Pp.char ':'
+             ; output
+             ]));
+      if n <> 0 then
+        User_warning.emit
+          [ Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Command") ++
+            Pp.space ++ pp_id id ++
+            Pp.textf " exited with code %d, but I'm ignoring it, hope \
+                      that's OK." n
+          ];
+      n
+    | Error err ->
+      let msg =
+        match err with
+        | Failed n ->
+          sprintf "exited with code %d" n
+        | Signaled signame ->
+          sprintf "got signal %s" signame
+      in
+      fail (
+        Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Command") ++
+        Pp.space ++ pp_id id ++
+        Pp.space ++ Pp.text msg ++ Pp.char ':'
+        :: Pp.tag ~tag:User_message.Style.Prompt (Pp.char '$') ++ Pp.space ++
+           command_line
+        :: Option.to_list output)
+
+  (* Check if the command output starts with a location, ignoring ansi
+     escape sequences *)
+  let outputs_starts_with_location =
+    let rec loop s pos len prefix =
+      match prefix with
+      | [] -> true
+      | c :: rest ->
+        pos < len &&
+        match s.[pos] with
+        | '\027' -> begin
+            match String.index_from s pos 'm' with
+            | exception Not_found -> false
+            | pos -> loop s (pos + 1) len prefix
+          end
+        | c' -> c = c' && loop s (pos + 1) len rest
+    in
+    fun output -> loop output 0 (String.length output) ['F'; 'i'; 'l'; 'e'; ' ']
+
+  let handle_non_verbose t ~display ~purpose ~output ~prog ~command_line =
+    let open Pp.O in
+    let show_command =
+      Config.show_full_command_on_error () ||
+      not (outputs_starts_with_location output)
+    in
+    let output = parse_output output in
+    let _, progname, _ = Fancy.split_prog prog in
+    let progname_and_purpose tag =
+      let progname = sprintf "%12s" progname in
+      Pp.tag ~tag (Pp.verbatim progname) ++
+      Pp.char ' ' ++ Fancy.pp_purpose purpose
+    in
+    match t with
+    | Ok n ->
+      if Option.is_some output ||
+         (display = Config.Display.Short && purpose <> Internal_job) then
+        Console.print_user_message (
+          User_message.make (
+            if show_command then
+              progname_and_purpose Ok :: Option.to_list output
+            else
+              Option.to_list output));
+      n
+    | Error err ->
+      let msg =
+        match err with
+        | Failed n ->
+          if show_command then
+            sprintf "(exit %d)" n
+          else
+            fail (Option.to_list output)
+        | Signaled signame ->
+          sprintf "(got signal %s)" signame
+      in
+      fail (
+        progname_and_purpose Error ++ Pp.char ' ' ++
+        Pp.tag ~tag:User_message.Style.Error (Pp.verbatim msg)
+        :: Pp.tag ~tag:User_message.Style.Details (Pp.verbatim command_line)
+        :: Option.to_list output)
+end
 
 let run_internal ?dir ?(stdout_to=Output.stdout) ?(stderr_to=Output.stderr)
       ~env ~purpose fail_mode prog args =
@@ -266,11 +422,26 @@ let run_internal ?dir ?(stdout_to=Output.stdout) ?(stderr_to=Output.stderr)
   in
   let id = gen_id () in
   let ok_codes = accepted_codes fail_mode in
-  let command_line = Fancy.command_line ~prog ~args ~dir ~stdout_to ~stderr_to in
-  if display = Verbose then
-    Format.eprintf "@{<kwd>Running@}[@{<id>%d@}]: %s@." id
-      (Colors.strip_colors_for_stderr command_line);
   let prog_str = Path.reach_for_running ?from:dir prog in
+  let command_line =
+    command_line ~prog:prog_str ~args ~dir ~stdout_to ~stderr_to
+  in
+  let fancy_command_line =
+    match display with
+    | Verbose ->
+      let open Pp.O in
+      let cmdline =
+        Fancy.command_line ~prog:prog_str ~args ~dir ~stdout_to ~stderr_to
+      in
+      Console.print_user_message
+        (User_message.make
+           [ Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Running") ++
+             pp_id id ++ Pp.char ':' ++ Pp.space ++
+             cmdline
+           ]);
+      cmdline
+    | _ -> Pp.nop
+  in
   let args, response_file =
     if Sys.win32 && cmdline_approximate_length prog_str args >= 1024 then
       match Response_file.get ~prog with
@@ -333,68 +504,24 @@ let run_internal ?dir ?(stdout_to=Output.stdout) ?(stderr_to=Output.stderr)
     | Some fn ->
       let s = Io.read_file fn in
       Temp.destroy fn;
-      let len = String.length s in
-      if len > 0 && s.[len - 1] <> '\n' then
-        s ^ "\n"
-      else
-        s
+      s
   in
   Log.command (Scheduler.log scheduler) ~command_line ~output ~exit_status;
-  let _, progname, _ = Fancy.split_prog prog_str in
-  let print fmt = Errors.kerrf ~f:Console.print fmt in
-  let show_command =
-    Config.show_full_command_on_error ()
-    || (not (String.is_prefix output ~prefix:"File "))
+  let exit_status : Exit_status.t =
+    match exit_status with
+    | WEXITED n when code_is_ok ok_codes n -> Ok n
+    | WEXITED n -> Error (Failed n)
+    | WSIGNALED n -> Error (Signaled (Utils.signal_name n))
+    | WSTOPPED _ -> assert false
   in
-  match exit_status with
-  | WEXITED n when code_is_ok ok_codes n ->
-    if display = Verbose then begin
-      if output <> "" then
-        print "@{<kwd>Output@}[@{<id>%d@}]:\n%s" id output;
-      if n <> 0 then
-        print
-          "@{<warning>Warning@}: Command [@{<id>%d@}] exited with code %d, \
-           but I'm ignoring it, hope that's OK.\n" id n
-    end else if output <> "" ||
-                (display = Short && purpose <> Internal_job) then begin
-      let pad = String.make (max 0 (12 - String.length progname)) ' ' in
-      if show_command then
-        print "%s@{<ok>%s@} %a\n%s" pad progname Fancy.pp_purpose purpose output
-      else
-        print "%s" output
-    end;
-    n
-  | WEXITED n ->
-    if display = Verbose then
-      die "\n@{<kwd>Command@} [@{<id>%d@}] exited with code %d:\n\
-           @{<prompt>$@} %s\n%s"
-        id n
-        (Colors.strip_colors_for_stderr command_line)
-        (Colors.strip_colors_for_stderr output)
-    else if show_command then
-      die "@{<error>%12s@} %a @{<error>(exit %d)@}\n\
-           @{<details>%s@}\n\
-           %s"
-        progname Fancy.pp_purpose purpose n
-        (Ansi_color.strip command_line)
-        output
-    else
-      die "%s" output
-  | WSIGNALED n ->
-    if display = Verbose then
-      die "\n@{<kwd>Command@} [@{<id>%d@}] got signal %s:\n\
-           @{<prompt>$@} %s\n%s"
-        id (Utils.signal_name n)
-        (Colors.strip_colors_for_stderr command_line)
-        (Colors.strip_colors_for_stderr output)
-    else
-      die "@{<error>%12s@} %a @{<error>(got signal %s)@}\n\
-           @{<details>%s@}\n\
-           %s"
-        progname Fancy.pp_purpose purpose (Utils.signal_name n)
-        (Ansi_color.strip command_line)
-        output
-  | WSTOPPED _ -> assert false
+  match display, exit_status, output with
+  | (Quiet | Progress), Ok n, "" -> n (* Optimisation for the common case *)
+  | Verbose, _, _ ->
+    Exit_status.handle_verbose exit_status ~id ~command_line:fancy_command_line
+      ~output
+  | _ ->
+    Exit_status.handle_non_verbose exit_status ~prog:prog_str ~command_line
+      ~output ~purpose ~display
 
 let run ?dir ?stdout_to ?stderr_to ~env ?(purpose=Internal_job) fail_mode
       prog args =

--- a/src/report_error.ml
+++ b/src/report_error.ml
@@ -35,8 +35,7 @@ let rec get_printer = function
          | hint :: _ ->
            Some (Format.asprintf "%a" Pp.pp (Pp.map_tags hint ~f:ignore)))
     ; pp = fun ppf ->
-        Format.fprintf ppf "%a@."
-          Pp.pp
+        Pp.pp ppf
           (User_message.pp { msg with loc = None; hints = [] }
            |> Pp.map_tags ~f:ignore)
     }

--- a/src/report_error.ml
+++ b/src/report_error.ml
@@ -15,6 +15,15 @@ let make_printer ?(backtrace=false) ?hint ?loc pp =
   ; backtrace
   }
 
+let rec tag_handler ppf (style : User_message.Style.t) pp =
+  Format.pp_open_tag ppf
+    (User_message.Print_config.default style
+     |> Ansi_color.Style.escape_sequence) [@warning "-3"];
+  Pp.render ppf pp ~tag_handler;
+  Format.pp_close_tag ppf () [@warning "-3"]
+
+let render ppf pp = Pp.render ppf pp ~tag_handler
+
 let rec get_printer = function
   | Stanza.Decoder.Parens_no_longer_necessary (loc, exn) ->
     let hint =
@@ -33,11 +42,10 @@ let rec get_printer = function
         (match msg.hints with
          | [] -> None
          | hint :: _ ->
-           Some (Format.asprintf "%a" Pp.pp (Pp.map_tags hint ~f:ignore)))
+           Some (Format.asprintf "%a" Pp.render_ignore_tags hint))
     ; pp = fun ppf ->
-        Pp.pp ppf
-          (User_message.pp { msg with loc = None; hints = [] }
-           |> Pp.map_tags ~f:ignore)
+        render ppf
+          (User_message.pp { msg with loc = None; hints = [] })
     }
   | Dune_lang.Decoder.Decoder (loc, msg, hint') ->
     let pp ppf = Format.fprintf ppf "@{<error>Error@}: %s%s\n" msg
@@ -152,7 +160,7 @@ let report { Exn_with_backtrace. exn; backtrace } =
               drop dependency_path
       in
       if dependency_path <> [] then
-        Format.fprintf ppf "%a@\n" Pp.pp
+        Format.fprintf ppf "%a@\n" render
           (Dep_path.Entries.pp (List.rev dependency_path));
       Option.iter p.hint ~f:(fun s -> Format.fprintf ppf "Hint: %s\n" s);
       Format.pp_print_flush ppf ();

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -696,7 +696,10 @@ end = struct
      | Error Files_changed ->
        set_status_line_generator
          (fun () ->
-            { message = Some "Had errors, killing current build..."
+            { message =
+                Some (Pp.seq (Pp.tag ~tag:User_message.Style.Error
+                                (Pp.verbatim "Had errors"))
+                        (Pp.verbatim ", killing current build..."))
             ; show_jobs = false
             })
      | _ -> ());
@@ -742,7 +745,8 @@ let poll ?log ?config ~once ~finally () =
     let old_generator = Console.get_status_line_generator () in
     set_status_line_generator
       (fun () ->
-         { message = Some (msg ^ ", waiting for filesystem changes...")
+         { message = Some (Pp.seq msg
+                             (Pp.verbatim ", waiting for filesystem changes..."))
          ; show_jobs = false
          });
     let res = block_waiting_for_changes () in
@@ -754,11 +758,15 @@ let poll ?log ?config ~once ~finally () =
     finally ();
     match res with
     | Ok () ->
-      wait (Colors.apply_string Colors.command_success "Success") |> after_wait
+      wait (Pp.tag ~tag:User_message.Style.Success
+              (Pp.verbatim "Success"))
+      |> after_wait
     | Error Got_signal ->
       (Already_reported, None)
     | Error Never ->
-      wait (Colors.apply_string Colors.command_error "Had errors") |> after_wait
+      wait (Pp.tag ~tag:User_message.Style.Error
+              (Pp.verbatim "Had errors"))
+      |> after_wait
     | Error Files_changed ->
       loop ()
     | Error (Exn (exn, bt)) -> (exn, Some bt)

--- a/src/stdune/ansi_color.ml
+++ b/src/stdune/ansi_color.ml
@@ -1,179 +1,52 @@
-module Color = struct
-  type t =
-    | Default
-    | Black
-    | Red
-    | Green
-    | Yellow
-    | Blue
-    | Magenta
-    | Cyan
-    | White
-    | Bright_black
-    | Bright_red
-    | Bright_green
-    | Bright_yellow
-    | Bright_blue
-    | Bright_magenta
-    | Bright_cyan
-    | Bright_white
-
-  let fg_code = function
-    | Black          -> "30"
-    | Red            -> "31"
-    | Green          -> "32"
-    | Yellow         -> "33"
-    | Blue           -> "34"
-    | Magenta        -> "35"
-    | Cyan           -> "36"
-    | White          -> "37"
-    | Default        -> "39"
-    | Bright_black   -> "90"
-    | Bright_red     -> "91"
-    | Bright_green   -> "92"
-    | Bright_yellow  -> "93"
-    | Bright_blue    -> "94"
-    | Bright_magenta -> "95"
-    | Bright_cyan    -> "96"
-    | Bright_white   -> "97"
-
-  let bg_code = function
-    | Black          -> "40"
-    | Red            -> "41"
-    | Green          -> "42"
-    | Yellow         -> "43"
-    | Blue           -> "44"
-    | Magenta        -> "45"
-    | Cyan           -> "46"
-    | White          -> "47"
-    | Default        -> "49"
-    | Bright_black   -> "100"
-    | Bright_red     -> "101"
-    | Bright_green   -> "102"
-    | Bright_yellow  -> "103"
-    | Bright_blue    -> "104"
-    | Bright_magenta -> "105"
-    | Bright_cyan    -> "106"
-    | Bright_white   -> "107"
-end
-
 module Style = struct
-  type t =
-    | Fg of Color.t
-    | Bg of Color.t
-    | Bold
-    | Dim
-    | Underlined
+  type t = string
 
-  let code = function
-    | Bold       -> "1"
-    | Dim        -> "2"
-    | Underlined -> "4"
-    | Fg c       -> Color.fg_code c
-    | Bg c       -> Color.bg_code c
+  let fg_black          = "30"
+  let fg_red            = "31"
+  let fg_green          = "32"
+  let fg_yellow         = "33"
+  let fg_blue           = "34"
+  let fg_magenta        = "35"
+  let fg_cyan           = "36"
+  let fg_white          = "37"
+  let fg_default        = "39"
+  let fg_bright_black   = "90"
+  let fg_bright_red     = "91"
+  let fg_bright_green   = "92"
+  let fg_bright_yellow  = "93"
+  let fg_bright_blue    = "94"
+  let fg_bright_magenta = "95"
+  let fg_bright_cyan    = "96"
+  let fg_bright_white   = "97"
+
+  let bg_black          = "40"
+  let bg_red            = "41"
+  let bg_green          = "42"
+  let bg_yellow         = "43"
+  let bg_blue           = "44"
+  let bg_magenta        = "45"
+  let bg_cyan           = "46"
+  let bg_white          = "47"
+  let bg_default        = "49"
+  let bg_bright_black   = "100"
+  let bg_bright_red     = "101"
+  let bg_bright_green   = "102"
+  let bg_bright_yellow  = "103"
+  let bg_bright_blue    = "104"
+  let bg_bright_magenta = "105"
+  let bg_bright_cyan    = "106"
+  let bg_bright_white   = "107"
+
+  let bold       = "1"
+  let dim        = "2"
+  let underlined = "4"
 
   let escape_sequence l =
-    let codes = "0" :: List.map l ~f:code in
-    Printf.sprintf "\027[%sm" (String.concat codes ~sep:";")
+    let l = "0" :: l in
+    Printf.sprintf "\027[%sm" (String.concat l ~sep:";")
 
-  let of_code = function
-    | 1 -> Some Bold
-    | 2 -> Some Dim
-    | 4 -> Some Underlined
-    | 30 -> Some (Fg Black)
-    | 31 -> Some (Fg Red)
-    | 32 -> Some (Fg Green)
-    | 33 -> Some (Fg Yellow)
-    | 34 -> Some (Fg Blue)
-    | 35 -> Some (Fg Magenta)
-    | 36 -> Some (Fg Cyan)
-    | 37 -> Some (Fg White)
-    | 39 -> Some (Fg Default)
-    | 90 -> Some (Fg Bright_black)
-    | 91 -> Some (Fg Bright_red)
-    | 92 -> Some (Fg Bright_green)
-    | 93 -> Some (Fg Bright_yellow)
-    | 94 -> Some (Fg Bright_blue)
-    | 95 -> Some (Fg Bright_magenta)
-    | 96 -> Some (Fg Bright_cyan)
-    | 97 -> Some (Fg Bright_white)
-    | 40 -> Some (Bg Black)
-    | 41 -> Some (Bg Red)
-    | 42 -> Some (Bg Green)
-    | 43 -> Some (Bg Yellow)
-    | 44 -> Some (Bg Blue)
-    | 45 -> Some (Bg Magenta)
-    | 46 -> Some (Bg Cyan)
-    | 47 -> Some (Bg White)
-    | 49 -> Some (Bg Default)
-    | 100 -> Some (Bg Bright_black)
-    | 101 -> Some (Bg Bright_red)
-    | 102 -> Some (Bg Bright_green)
-    | 103 -> Some (Bg Bright_yellow)
-    | 104 -> Some (Bg Bright_blue)
-    | 105 -> Some (Bg Bright_magenta)
-    | 106 -> Some (Bg Bright_cyan)
-    | 107 -> Some (Bg Bright_white)
-    | _ -> None
-end
-
-module Styles = struct
-  type t =
-    { fg         : Color.t
-    ; bg         : Color.t
-    ; bold       : bool
-    ; dim        : bool
-    ; underlined : bool
-    }
-
-  let default =
-    { fg         = Default
-    ; bg         = Default
-    ; bold       = true
-    ; dim        = true
-    ; underlined = true
-    }
-
-  let apply t (style : Style.t) =
-    match style with
-    | Fg c       -> { t with fg         = c    }
-    | Bg c       -> { t with bg         = c    }
-    | Bold       -> { t with bold       = true }
-    | Dim        -> { t with dim        = true }
-    | Underlined -> { t with underlined = true }
-
-  let escape_sequence t =
-    let open Style in
-    let l = [] in
-    let l =
-      match t.fg with
-      | Default -> l
-      | c       -> Fg c :: l
-    in
-    let l =
-      match t.bg with
-      | Default -> l
-      | c       -> Bg c :: l
-    in
-    let l =
-      if t.bold then
-        Bold :: l
-      else
-        l
-    in
-    let l =
-      if t.bold then
-        Dim :: l
-      else
-        l
-    in
-    let l =
-      if t.underlined then
-        Underlined :: l
-      else
-        l
-    in
-    Style.escape_sequence l
+  let escape_sequence_no_reset l =
+    Printf.sprintf "\027[%sm" (String.concat l ~sep:";")
 end
 
 let term_supports_color = lazy (
@@ -188,54 +61,26 @@ let stdout_supports_color = lazy (
 let stderr_supports_color = lazy (
   Lazy.force term_supports_color && Unix.isatty Unix.stderr)
 
-module Render = struct
-  include Pp.Renderer.Make(struct
-    type t = Style.t list
+let rec tag_handler current_styles ppf styles pp =
+  Format.pp_print_as ppf 0 (Style.escape_sequence_no_reset styles);
+  Pp.render ppf pp ~tag_handler:(tag_handler (current_styles @ styles));
+  Format.pp_print_as ppf 0 (Style.escape_sequence current_styles)
 
-    module Handler = struct
-      type t = Styles.t * string
-
-      let init = (Styles.default, "")
-
-      let handle (t, seq) styles =
-        let t' = List.fold_left styles ~init:t ~f:Styles.apply in
-        if t <> t' then
-          let seq' = Styles.escape_sequence t' in
-          (seq',
-           (t', seq'),
-           seq)
-        else
-          ("", (t, seq), "")
-    end
-  end)
-
-  let channel_strip_colors oc =
-    let output = Staged.unstage (Pp.Render.channel oc) in
-    Staged.stage (fun ?margin ?tag_handler:_ pp ->
-      output ?margin (Pp.map_tags pp ~f:ignore))
-end
+let make_printer supports_color ppf =
+  let f = lazy (
+    if Lazy.force supports_color then begin
+      Pp.render ppf ~tag_handler:(tag_handler [])
+    end else
+      Pp.render_ignore_tags ppf)
+  in
+  Staged.stage (fun pp ->
+    Lazy.force f pp;
+    Format.pp_print_flush ppf ())
 
 let print =
-  let f = lazy (
-    Staged.unstage (
-      (if Lazy.force stdout_supports_color then
-         Render.channel
-       else
-         Render.channel_strip_colors)
-        stdout))
-  in
-  fun ?margin pp -> Lazy.force f ?margin ?tag_handler:None pp
-
+  Staged.unstage (make_printer stdout_supports_color Format.std_formatter)
 let prerr =
-  let f = lazy (
-    Staged.unstage (
-      (if Lazy.force stderr_supports_color then
-         Render.channel
-       else
-         Render.channel_strip_colors)
-        stderr))
-  in
-  fun ?margin pp -> Lazy.force f ?margin ?tag_handler:None pp
+  Staged.unstage (make_printer stderr_supports_color Format.err_formatter)
 
 let strip str =
   let len = String.length str in
@@ -279,13 +124,9 @@ let parse_line str styles =
           String.sub str ~pos:(seq_start + 1) ~len:(seq_end - seq_start - 1)
           |> String.split ~on:';'
           |> List.fold_left ~init:(List.rev styles) ~f:(fun styles s ->
-            match int_of_string s with
-            | exception _ -> styles
-            | 0 -> []
-            | n ->
-              match Style.of_code n with
-              | None -> styles
-              | Some style -> style :: styles)
+            match s with
+            | "0" -> styles
+            | _ -> s :: styles)
           |> List.rev
         in
         loop styles (seq_end + 1) acc

--- a/src/stdune/ansi_color.mli
+++ b/src/stdune/ansi_color.mli
@@ -1,45 +1,56 @@
-module Color : sig
-  type t =
-    | Default
-    | Black
-    | Red
-    | Green
-    | Yellow
-    | Blue
-    | Magenta
-    | Cyan
-    | White
-    | Bright_black
-    | Bright_red
-    | Bright_green
-    | Bright_yellow
-    | Bright_blue
-    | Bright_magenta
-    | Bright_cyan
-    | Bright_white
-end
-
 module Style : sig
-  type t =
-    | Fg of Color.t
-    | Bg of Color.t
-    | Bold
-    | Dim
-    | Underlined
+  type t
+
+  val fg_default : t
+  val fg_black : t
+  val fg_red : t
+  val fg_green : t
+  val fg_yellow : t
+  val fg_blue : t
+  val fg_magenta : t
+  val fg_cyan : t
+  val fg_white : t
+  val fg_bright_black : t
+  val fg_bright_red : t
+  val fg_bright_green : t
+  val fg_bright_yellow : t
+  val fg_bright_blue : t
+  val fg_bright_magenta : t
+  val fg_bright_cyan : t
+  val fg_bright_white : t
+
+  val bg_default : t
+  val bg_black : t
+  val bg_red : t
+  val bg_green : t
+  val bg_yellow : t
+  val bg_blue : t
+  val bg_magenta : t
+  val bg_cyan : t
+  val bg_white : t
+  val bg_bright_black : t
+  val bg_bright_red : t
+  val bg_bright_green : t
+  val bg_bright_yellow : t
+  val bg_bright_blue : t
+  val bg_bright_magenta : t
+  val bg_bright_cyan : t
+  val bg_bright_white : t
+
+  val bold : t
+  val dim : t
+  val underlined : t
 
   (** Ansi escape sequence that set the terminal style to exactly
       these styles *)
   val escape_sequence : t list -> string
 end
 
-module Render : Pp.Renderer.S
-  with type Tag.t = Style.t list
+(** Print to [Format.std_formatter] *)
+val print : Style.t list Pp.t -> unit
 
-(** Print to [stdout] (not thread safe) *)
-val print : ?margin:int -> Style.t list Pp.t -> unit
-
-(** Print to [stderr] (not thread safe) *)
-val prerr : ?margin:int -> Style.t list Pp.t -> unit
+(** Print to [Format.err_formatter] *)
+val prerr : Style.t list Pp.t -> unit
 
 (** Whether [stdout]/[stderr] support colors *)
 val stdout_supports_color : bool Lazy.t

--- a/src/stdune/ansi_color.mli
+++ b/src/stdune/ansi_color.mli
@@ -35,9 +35,6 @@ end
 module Render : Pp.Renderer.S
   with type Tag.t = Style.t list
 
-(** Filter out escape sequences in a string *)
-val strip : string -> string
-
 (** Print to [stdout] (not thread safe) *)
 val print : ?margin:int -> Style.t list Pp.t -> unit
 
@@ -47,3 +44,9 @@ val prerr : ?margin:int -> Style.t list Pp.t -> unit
 (** Whether [stdout]/[stderr] support colors *)
 val stdout_supports_color : bool Lazy.t
 val stderr_supports_color : bool Lazy.t
+
+(** Filter out escape sequences in a string *)
+val strip : string -> string
+
+(** Parse a string containing ANSI escape sequences *)
+val parse : string -> Style.t list Pp.t

--- a/src/stdune/dyn0.ml
+++ b/src/stdune/dyn0.ml
@@ -152,6 +152,6 @@ type t =
            ; Pp.char ')'
            ])
 
-let pp fmt t = Pp.pp fmt (pp t)
+let pp fmt t = Pp.render_ignore_tags fmt (pp t)
 
 let to_string t = Format.asprintf "%a" pp t

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -48,145 +48,52 @@ let rec filter_map_tags t ~f =
     | None -> t
     | Some tag -> Tag (tag, t)
 
-module type Tag = sig
-  type t
-  module Handler : sig
-    type tag = t
-    type t
-    val init : t
-    val handle : t -> tag -> string * t * string
-  end with type tag := t
+module Render = struct
+  open Format
+
+  let rec render ppf t ~tag_handler =
+    match t with
+    | Nop -> ()
+    | Seq (a, b) -> render ppf ~tag_handler a; render ppf ~tag_handler b
+    | Concat (_, []) -> ()
+    | Concat (sep, x :: l) ->
+      render ppf ~tag_handler x;
+      List.iter l ~f:(fun x ->
+        render ppf ~tag_handler sep;
+        render ppf ~tag_handler x)
+    | Box (indent, t) ->
+      pp_open_box ppf indent;
+      render ppf ~tag_handler t;
+      pp_close_box ppf ()
+    | Vbox (indent, t) ->
+      pp_open_vbox ppf indent;
+      render ppf ~tag_handler t;
+      pp_close_box ppf ()
+    | Hbox t ->
+      pp_open_hbox ppf ();
+      render ppf ~tag_handler t;
+      pp_close_box ppf ()
+    | Hvbox (indent, t) ->
+      pp_open_hvbox ppf indent;
+      render ppf ~tag_handler t;
+      pp_close_box ppf ()
+    | Hovbox (indent, t) ->
+      pp_open_hovbox ppf indent;
+      render ppf ~tag_handler t;
+      pp_close_box ppf ()
+    | Verbatim x -> pp_print_string ppf x
+    | Char   x -> pp_print_char ppf x
+    | Break (nspaces, shift) -> pp_print_break ppf nspaces shift
+    | Newline -> pp_force_newline ppf ()
+    | Text s -> pp_print_text ppf s
+    | Tag (tag, t) -> tag_handler ppf tag t
 end
 
-module Renderer = struct
-  module type S = sig
-    module Tag : Tag
+let render = Render.render
 
-    val string
-      :  unit
-      -> (?margin:int -> ?tag_handler:Tag.Handler.t -> Tag.t t -> string)
-           Staged.t
-    val channel
-      :  out_channel
-      -> (?margin:int -> ?tag_handler:Tag.Handler.t -> Tag.t t -> unit)
-           Staged.t
-  end
-
-  module Make(Tag : Tag) = struct
-    open Format
-
-    module Tag = Tag
-
-    (* The format interface only support string for tags, so we embed
-       then as follow:
-
-       - length of opening string on 16 bits
-       - opening string
-       - closing string
-    *)
-    external get16 : string -> int -> int         = "%caml_string_get16"
-    external set16 : bytes  -> int -> int -> unit = "%caml_string_set16"
-
-    let embed_tag ~opening ~closing =
-      let opening_len = String.length opening  in
-      let closing_len = String.length closing in
-      assert (opening_len <= 0xffff);
-      let buf = Bytes.create (2 + opening_len + closing_len) in
-      set16 buf 0 opening_len;
-      Bytes.blit_string ~src:opening ~src_pos:0 ~dst:buf ~dst_pos:2   ~len:opening_len;
-      Bytes.blit_string ~src:closing ~src_pos:0 ~dst:buf ~dst_pos:(2 + opening_len) ~len:closing_len;
-      Bytes.unsafe_to_string buf
-
-    let extract_opening_tag s =
-      let open_len = get16 s 0 in
-      String.sub s ~pos:2 ~len:open_len
-
-    let extract_closing_tag s =
-      let pos = 2 + get16 s 0 in
-      String.sub s ~pos ~len:(String.length s - pos)
-
-    let rec pp th ppf t =
-      match t with
-      | Nop -> ()
-      | Seq (a, b) -> pp th ppf a; pp th ppf b
-      | Concat (_, []) -> ()
-      | Concat (sep, x :: l) ->
-        pp th ppf x;
-        List.iter l ~f:(fun x ->
-          pp th ppf sep;
-          pp th ppf x)
-      | Box (indent, t) ->
-        pp_open_box ppf indent;
-        pp th ppf t;
-        pp_close_box ppf ()
-      | Vbox (indent, t) ->
-        pp_open_vbox ppf indent;
-        pp th ppf t;
-        pp_close_box ppf ()
-      | Hbox t ->
-        pp_open_hbox ppf ();
-        pp th ppf t;
-        pp_close_box ppf ()
-      | Hvbox (indent, t) ->
-        pp_open_hvbox ppf indent;
-        pp th ppf t;
-        pp_close_box ppf ()
-      | Hovbox (indent, t) ->
-        pp_open_hovbox ppf indent;
-        pp th ppf t;
-        pp_close_box ppf ()
-      | Verbatim x -> pp_print_string ppf x
-      | Char   x -> pp_print_char ppf x
-      | Break (nspaces, shift) -> pp_print_break ppf nspaces shift
-      | Newline -> pp_force_newline ppf ()
-      | Text s -> pp_print_text ppf s
-      | Tag (tag, t) ->
-        let opening, th, closing = Tag.Handler.handle th tag in
-        pp_open_tag ppf (embed_tag ~opening ~closing) [@warning "-3"];
-        pp th ppf t;
-        pp_close_tag ppf () [@warning "-3"]
-
-    let setup ppf =
-      let funcs = pp_get_formatter_tag_functions ppf () [@warning "-3"] in
-      pp_set_mark_tags ppf true;
-      pp_set_formatter_tag_functions ppf
-        { funcs with
-          mark_open_tag  = extract_opening_tag
-        ; mark_close_tag = extract_closing_tag
-        } [@warning "-3"]
-
-    let string () =
-      let buf = Buffer.create 1024 in
-      let ppf = formatter_of_buffer buf in
-      setup ppf;
-      Staged.stage (fun ?(margin=80) ?(tag_handler=Tag.Handler.init) t ->
-        pp_set_margin ppf margin;
-        pp tag_handler ppf t;
-        pp_print_flush ppf ();
-        let s = Buffer.contents buf in
-        Buffer.clear buf;
-        s)
-
-    let channel oc =
-      let ppf = formatter_of_out_channel oc in
-      setup ppf;
-      Staged.stage (fun ?(margin=80) ?(tag_handler=Tag.Handler.init) t ->
-        pp_set_margin ppf margin;
-        pp tag_handler ppf t;
-        pp_print_flush ppf ())
-  end
-end
-
-module Render = Renderer.Make(struct
-    type t = unit
-    module Handler = struct
-      type t   = unit
-      let init = ()
-      let handle () () = "", (), ""
-    end
-  end)
-
-let pp ppf t = Render.pp () ppf t
+let rec render_ignore_tags ppf t =
+  render ppf t ~tag_handler:(fun ppf _tag t ->
+    render_ignore_tags ppf t)
 
 let nop = Nop
 let seq a b = Seq (a, b)

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -117,44 +117,14 @@ end
 
 (** {1 Rendering} *)
 
-module type Tag = sig
-  type t
+(** Render a document to a classic formatter *)
+val render
+  :  Format.formatter
+  -> 'a t
+  -> tag_handler:(Format.formatter -> 'a -> 'a t -> unit)
+  -> unit
 
-  module Handler : sig
-    type tag = t
-    type t
-
-    (** Initial tag handler *)
-    val init : t
-
-    (** Handle a tag: return the string that enables the tag, the
-        handler while the tag is active and the string to disable the
-        tag. *)
-    val handle : t -> tag -> string * t * string
-  end with type tag := t
-end
-
-module Renderer : sig
-  module type S = sig
-    module Tag : Tag
-
-    val string
-      :  unit
-      -> (?margin:int -> ?tag_handler:Tag.Handler.t -> Tag.t t -> string)
-           Staged.t
-    val channel
-      :  out_channel
-      -> (?margin:int -> ?tag_handler:Tag.Handler.t -> Tag.t t -> unit)
-           Staged.t
-  end
-
-  module Make(Tag : Tag) : S with module Tag = Tag
-end
-
-(** A simple renderer that doesn't take tags *)
-module Render : Renderer.S
-    with type Tag.t         = unit
-    with type Tag.Handler.t = unit
-
-(** Render to a formatter *)
-val pp : Format.formatter -> unit t -> unit
+val render_ignore_tags
+  :  Format.formatter
+  -> 'a t
+  -> unit

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -55,6 +55,7 @@ val newline : _ t
 
 (** Convert tags in a documents *)
 val map_tags : 'a t -> f:('a -> 'b) -> 'b t
+val filter_map_tags : 'a t -> f:('a -> 'b option) -> 'b t
 
 (** {1 Boxes} *)
 
@@ -106,6 +107,13 @@ val enumerate : 'a list -> f:('a -> 'b t) -> 'b t
     v}
 *)
 val chain : 'a list -> f:('a -> 'b t) -> 'b t
+
+(** {1 Operators} *)
+
+module O : sig
+  (** Same as [seq] *)
+  val ( ++ ) : 'a t -> 'a t -> 'a t
+end
 
 (** {1 Rendering} *)
 

--- a/src/stdune/user_error.ml
+++ b/src/stdune/user_error.ml
@@ -13,6 +13,6 @@ let raise ?loc ?hints paragraphs =
 
 let () =
   Printexc.register_printer (function
-    | E t -> Some (Format.asprintf "%a@?" Pp.pp
-                     (User_message.pp t |> Pp.map_tags ~f:ignore))
+    | E t -> Some (Format.asprintf "%a@?" Pp.render_ignore_tags
+                     (User_message.pp t))
     | _ -> None)

--- a/src/stdune/user_message.ml
+++ b/src/stdune/user_message.ml
@@ -16,17 +16,19 @@ end
 module Print_config = struct
   type t = Style.t -> Ansi_color.Style.t list
 
-  let default : t = function
-    | Loc     -> [Bold]
-    | Error   -> [Bold; Fg Red]
-    | Warning -> [Bold; Fg Magenta]
-    | Kwd     -> [Bold; Fg Blue]
-    | Id      -> [Bold; Fg Yellow]
-    | Prompt  -> [Bold; Fg Green]
-    | Details -> [Dim; Fg White]
-    | Ok      -> [Dim; Fg Green]
-    | Debug   -> [Underlined; Fg Bright_cyan]
-    | Success -> [Bold; Fg Green]
+  open Ansi_color.Style
+
+  let default : Style.t -> _ = function
+    | Loc     -> [bold]
+    | Error   -> [bold; fg_red]
+    | Warning -> [bold; fg_magenta]
+    | Kwd     -> [bold; fg_blue]
+    | Id      -> [bold; fg_yellow]
+    | Prompt  -> [bold; fg_green]
+    | Details -> [dim; fg_white]
+    | Ok      -> [dim; fg_green]
+    | Debug   -> [underlined; fg_bright_cyan]
+    | Success -> [bold; fg_green]
     | Ansi_styles l -> l
 end
 
@@ -71,11 +73,11 @@ let pp { loc; paragraphs; hints } =
   Pp.vbox (Pp.concat_map paragraphs ~sep:Pp.nop
              ~f:(fun pp -> Pp.seq pp Pp.cut))
 
-let print ?(config=Print_config.default) ?margin t =
-  Ansi_color.print ?margin (Pp.map_tags (pp t) ~f:config)
+let print ?(config=Print_config.default) t =
+  Ansi_color.print (Pp.map_tags (pp t) ~f:config)
 
-let prerr ?(config=Print_config.default) ?margin t =
-  Ansi_color.prerr ?margin (Pp.map_tags (pp t) ~f:config)
+let prerr ?(config=Print_config.default) t =
+  Ansi_color.prerr (Pp.map_tags (pp t) ~f:config)
 
 (* As found here http://rosettacode.org/wiki/Levenshtein_distance#OCaml *)
 let levenshtein_distance s t =

--- a/src/stdune/user_message.ml
+++ b/src/stdune/user_message.ml
@@ -9,6 +9,7 @@ module Style = struct
     | Details
     | Ok
     | Debug
+    | Success
     | Ansi_styles of Ansi_color.Style.t list
 end
 
@@ -25,6 +26,7 @@ module Print_config = struct
     | Details -> [Dim; Fg White]
     | Ok      -> [Dim; Fg Green]
     | Debug   -> [Underlined; Fg Bright_cyan]
+    | Success -> [Bold; Fg Green]
     | Ansi_styles l -> l
 end
 

--- a/src/stdune/user_message.ml
+++ b/src/stdune/user_message.ml
@@ -9,6 +9,7 @@ module Style = struct
     | Details
     | Ok
     | Debug
+    | Ansi_styles of Ansi_color.Style.t list
 end
 
 module Print_config = struct
@@ -24,6 +25,7 @@ module Print_config = struct
     | Details -> [Dim; Fg White]
     | Ok      -> [Dim; Fg Green]
     | Debug   -> [Underlined; Fg Bright_cyan]
+    | Ansi_styles l -> l
 end
 
 type t =
@@ -64,7 +66,8 @@ let pp { loc; paragraphs; hints } =
            start.pos_fname start.pos_lnum start_c stop_c)
       :: paragraphs
   in
-  Pp.vbox (Pp.concat paragraphs ~sep:Pp.cut)
+  Pp.vbox (Pp.concat_map paragraphs ~sep:Pp.nop
+             ~f:(fun pp -> Pp.seq pp Pp.cut))
 
 let print ?(config=Print_config.default) ?margin t =
   Ansi_color.print ?margin (Pp.map_tags (pp t) ~f:config)

--- a/src/stdune/user_message.mli
+++ b/src/stdune/user_message.mli
@@ -19,6 +19,7 @@ module Style : sig
     | Details
     | Ok
     | Debug
+    | Success
     | Ansi_styles of Ansi_color.Style.t list
 end
 

--- a/src/stdune/user_message.mli
+++ b/src/stdune/user_message.mli
@@ -19,6 +19,7 @@ module Style : sig
     | Details
     | Ok
     | Debug
+    | Ansi_styles of Ansi_color.Style.t list
 end
 
 (** A user message.contents composed of an optional file location and

--- a/src/stdune/user_message.mli
+++ b/src/stdune/user_message.mli
@@ -63,10 +63,10 @@ val make
   -> t
 
 (** Print to [stdout] (not thread safe) *)
-val print : ?config:Print_config.t -> ?margin:int -> t -> unit
+val print : ?config:Print_config.t -> t -> unit
 
 (** Print to [stderr] (not thread safe) *)
-val prerr : ?config:Print_config.t -> ?margin:int -> t -> unit
+val prerr : ?config:Print_config.t -> t -> unit
 
 (** Produces a "Did you mean ...?" hint *)
 val did_you_mean : string -> candidates:string list -> Style.t Pp.t list

--- a/src/stdune/user_warning.ml
+++ b/src/stdune/user_warning.ml
@@ -2,9 +2,9 @@ let reporter = ref (fun msg -> User_message.prerr msg)
 
 let set_reporter f = reporter := f
 
-let emit ~loc ?hints paragraphs =
+let emit ?loc ?hints paragraphs =
   !reporter
-    (User_message.make paragraphs ~loc ?hints
+    (User_message.make paragraphs ?loc ?hints
        ~prefix:(Pp.seq
                   (Pp.tag (Pp.verbatim "Warning")
                      ~tag:User_message.Style.Warning)

--- a/src/stdune/user_warning.mli
+++ b/src/stdune/user_warning.mli
@@ -7,7 +7,7 @@
     fashion to {!User_error.raise} except that the first paragraph is
     prefixed with "Warning: " rather than "Error: ". *)
 val emit
-  :  loc:Loc0.t
+  :  ?loc:Loc0.t
   -> ?hints:User_message.Style.t Pp.t list
   -> User_message.Style.t Pp.t list
   -> unit

--- a/test/blackbox-tests/test-cases/install-partial-package/run.t
+++ b/test/blackbox-tests/test-cases/install-partial-package/run.t
@@ -4,6 +4,7 @@ are missing.
   $ dune build @install
   $ rm -rf _build/install/default/bin
   $ dune install
-  The following files which are listed in _build/default/foo.install cannot be installed because they do not exist:
+  Error: The following files which are listed in _build/default/foo.install
+  cannot be installed because they do not exist:
   - install/default/bin/foo
   [1]

--- a/test/unit-tests/pp.mlt
+++ b/test/unit-tests/pp.mlt
@@ -4,7 +4,7 @@ open! Stdune;;
 #warnings "-40";;
 
 let pp pp =
-  Format.printf "%a@." Pp.pp pp
+  Format.printf "%a@." Pp.render_ignore_tags pp
 ;;
 
 [%%ignore]


### PR DESCRIPTION
This PR converts a few more modules to the new error reporting API. `Process` was a bit more complicated since it embeds the output of sub-commands in error message. To deal with that, we now parse the ANSI escape sequence in the output of commands.

It also simplify the rendering API and restore coloring of error messages that use the new API.