### PR TITLE
Future proof build info

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -129,9 +129,10 @@ let build_info =
       | None -> "n/a"
       | Some v -> B.Version.to_string v
     in
-    pr "version: %s" (ver_string B.version);
+    pr "version: %s" (ver_string (B.version ()));
     let libs =
-      List.map B.statically_linked_libraries ~f:(fun lib ->
+      B.All_statically_linked_libraries.to_list ()
+      |> List.map ~f:(fun lib ->
         B.Statically_linked_library.name lib,
         ver_string (B.Statically_linked_library.version lib))
       |> List.sort ~compare

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -131,7 +131,7 @@ let build_info =
     in
     pr "version: %s" (ver_string (B.version ()));
     let libs =
-      B.All_statically_linked_libraries.to_list ()
+      B.Statically_linked_libraries.to_list ()
       |> List.map ~f:(fun lib ->
         B.Statically_linked_library.name lib,
         ver_string (B.Statically_linked_library.version lib))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -154,7 +154,7 @@ let default =
   in
   (term,
    Term.info "dune" ~doc
-     ~version:(match Build_info.V1.version with
+     ~version:(match Build_info.V1.version () with
        | None -> "n/a"
        | Some v -> Build_info.V1.Version.to_string v)
      ~man:

--- a/otherlibs/build-info/src/build_info.ml
+++ b/otherlibs/build-info/src/build_info.ml
@@ -11,7 +11,7 @@ module V1 = struct
     let version = snd
   end
 
-  module All_statically_linked_libraries = struct
+  module Statically_linked_libraries = struct
     let to_list () = Build_info_data.statically_linked_libraries
 
     let find ~name =

--- a/otherlibs/build-info/src/build_info.ml
+++ b/otherlibs/build-info/src/build_info.ml
@@ -5,11 +5,20 @@ module V1 = struct
     let to_string x = x
   end
 
-  include Build_info_data
-
   module Statically_linked_library = struct
     type t = string * string option
     let name = fst
     let version = snd
   end
+
+  module All_statically_linked_libraries = struct
+    let to_list () = Build_info_data.statically_linked_libraries
+
+    let find ~name =
+      match List.assoc name (to_list ()) with
+      | exception Not_found -> None
+      | version -> Some (name, version)
+  end
+
+  let version () = Build_info_data.version
 end

--- a/otherlibs/build-info/src/build_info.mli
+++ b/otherlibs/build-info/src/build_info.mli
@@ -11,7 +11,7 @@ module V1 : sig
   (** The version at which the current executable was built. The
       version is [None] during development, it is only [Some _] once
       the executable is installed or promoted to the source tree. *)
-  val version : Version.t option
+  val version : unit -> Version.t option
 
   module Statically_linked_library : sig
     type t
@@ -24,6 +24,11 @@ module V1 : sig
     val version : t -> Version.t option
   end
 
-  (** All the libraries that where statically linked in *)
-  val statically_linked_libraries : Statically_linked_library.t list
+  module All_statically_linked_libraries : sig
+    (** All the libraries that where statically linked in *)
+
+    val to_list : unit -> Statically_linked_library.t list
+
+    val find : name:string -> Statically_linked_library.t option
+  end
 end

--- a/otherlibs/build-info/src/build_info.mli
+++ b/otherlibs/build-info/src/build_info.mli
@@ -24,7 +24,7 @@ module V1 : sig
     val version : t -> Version.t option
   end
 
-  module All_statically_linked_libraries : sig
+  module Statically_linked_libraries : sig
     (** All the libraries that where statically linked in *)
 
     val to_list : unit -> Statically_linked_library.t list

--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -37,13 +37,13 @@ Test embedding of build information
   >   | Some v -> B.Version.to_string v
   >   | None -> "n/a"
   > let () =
-  >   pr "%s" (get_version B.version);
+  >   pr "%s" (get_version (B.version ()));
   >   let process_lib lib =
   >     let name = B.Statically_linked_library.name lib in
   >     let version = B.Statically_linked_library.version lib in
   >     pr "lib %s: %s" name (get_version version)
   >   in
-  >   List.iter process_lib B.statically_linked_libraries
+  >   List.iter process_lib (B.All_statically_linked_libraries.to_list ())
   > EOF
 
   $ dune build

--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -43,7 +43,7 @@ Test embedding of build information
   >     let version = B.Statically_linked_library.version lib in
   >     pr "lib %s: %s" name (get_version version)
   >   in
-  >   List.iter process_lib (B.All_statically_linked_libraries.to_list ())
+  >   List.iter process_lib (B.Statically_linked_libraries.to_list ())
   > EOF
 
   $ dune build


### PR DESCRIPTION
By not exposing naked values. This allows us to implement laziness or
some sort of transparent loading down the road.

Add a find primitive for statically linked libraries. We could easily
make this common look up faster down the road.

Some other things to consider:

* Implement comparison for versions
* Add a folding primitive for all statically linked libraries. This is useful if we ever change the representation of loaded libs to be a map for example.