### PR TITLE
Adds a new 'inline-tests' setting in env stanza

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 - Do not put the `<package>.install` files in the source tree unless `-p` or
   `--promote-install-files` is passed on the command line (#2329, @diml)
 
+- Add a new `inline-tests` field in the env stanza to control inline-tests
+  framework with a variable (#2313, @mlasson review and original idea by @diml)
+
 - Change `implicit_transive_deps` to be false. Implicit transitive deps now must
   be manually enabled (#2306, @rgrinberg)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - Do not put the `<package>.install` files in the source tree unless `-p` or
   `--promote-install-files` is passed on the command line (#2329, @diml)
 
-- Add a new `inline-tests` field in the env stanza to control inline-tests
+- Add a new `inline_tests` field in the env stanza to control inline_tests
   framework with a variable (#2313, @mlasson review and original idea by @diml)
 
 - Change `implicit_transive_deps` to be false. Implicit transitive deps now must

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,6 @@
 - Do not put the `<package>.install` files in the source tree unless `-p` or
   `--promote-install-files` is passed on the command line (#2329, @diml)
 
-- Add a new `inline_tests` field in the env stanza to control inline_tests
-  framework with a variable (#2313, @mlasson review and original idea by @diml)
-
 - Change `implicit_transive_deps` to be false. Implicit transitive deps now must
   be manually enabled (#2306, @rgrinberg)
 
@@ -106,6 +103,10 @@
 
 - Do not warn about merlin files pre 1.9. This warning can only be disabled in
   1.9 (#2421, fixes #2399, @emillon)
+
+- Add a new `inline_tests` field in the env stanza to control inline_tests
+  framework with a variable (#2313, @mlasson, original idea by @diml, revinw
+  by @rgrinberg).
 
 1.10.0 (04/06/2019)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,7 +105,7 @@
   1.9 (#2421, fixes #2399, @emillon)
 
 - Add a new `inline_tests` field in the env stanza to control inline_tests
-  framework with a variable (#2313, @mlasson, original idea by @diml, revinw
+  framework with a variable (#2313, @mlasson, original idea by @diml, review
   by @rgrinberg).
 
 1.10.0 (04/06/2019)

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -814,8 +814,8 @@ Fields supported in ``<settings>`` are:
   be inferred from the basename of ``<filepath>`` by dropping the ``.exe``
   suffix if it exists.
 
-- ``(inline-tests <state>)`` where state is either ``enabled``, ``disabled`` or
-  ``ignored``. This field controls the value of the variable ``%{inline-tests}``
+- ``(inline_tests <state>)`` where state is either ``enabled``, ``disabled`` or
+  ``ignored``. This field controls the value of the variable ``%{inline_tests}``
   that is read by the inline test framework. The default value is ``disabled``
   for the ``release`` profile and ``enabled`` otherwise.
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -815,9 +815,10 @@ Fields supported in ``<settings>`` are:
   suffix if it exists.
 
 - ``(inline_tests <state>)`` where state is either ``enabled``, ``disabled`` or
-  ``ignored``. This field controls the value of the variable ``%{inline_tests}``
-  that is read by the inline test framework. The default value is ``disabled``
-  for the ``release`` profile and ``enabled`` otherwise.
+  ``ignored``. This field is available since Dune 1.11. It controls the value
+  of the variable ``%{inline_tests}`` that is read by the inline test framework.
+  The default value is ``disabled`` for the ``release`` profile and ``enabled``
+  otherwise.
 
 .. _dune-subdirs:
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -814,6 +814,11 @@ Fields supported in ``<settings>`` are:
   be inferred from the basename of ``<filepath>`` by dropping the ``.exe``
   suffix if it exists.
 
+- ``(inline-tests <state>)`` where state is either ``enabled``, ``disabled`` or
+  ``ignored``. This field controls the value of the variable ``%{inline-tests}``
+  that is read by the inline test framework. The default value is ``disabled``
+  for the ``release`` profile and ``enabled`` otherwise.
+
 .. _dune-subdirs:
 
 dirs (since 1.6)

--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -52,7 +52,7 @@ module Stanza = struct
 
   let inline_tests_field =
     field_o
-    "inline-tests"
+    "inline_tests"
       (Syntax.since Stanza.syntax (1, 11) >>>
       Inline_tests.decode)
 

--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -14,11 +14,31 @@ module Stanza = struct
     in
     C.Kind.Dict.make ~c ~cxx
 
+  module Inline_tests = struct
+    type t =
+      | Enabled
+      | Disabled
+      | Ignored
+
+    let decode =
+      enum
+        [ "enabled", Enabled
+        ; "disabled", Disabled
+        ; "ignored", Ignored ]
+
+    let to_string = function
+      | Enabled -> "enabled"
+      | Disabled -> "disabled"
+      | Ignored -> "ignored"
+
+  end
+
   type config =
     { flags          : Ocaml_flags.Spec.t
     ; c_flags        : Ordered_set_lang.Unexpanded.t C.Kind.Dict.t
     ; env_vars       : Env.t
     ; binaries       : File_binding.Unexpanded.t list
+    ; inline_tests   : Inline_tests.t option
     }
 
   type pattern =
@@ -29,6 +49,12 @@ module Stanza = struct
     { loc   : Loc.t
     ; rules : (pattern * config) list
     }
+
+  let inline_tests_field =
+    field_o
+    "inline-tests"
+      (Syntax.since Stanza.syntax (1, 11) >>>
+      Inline_tests.decode)
 
   let env_vars_field =
     field
@@ -49,11 +75,13 @@ module Stanza = struct
     and+ binaries = field ~default:[] "binaries"
                       (Syntax.since Stanza.syntax (1, 6)
                        >>> File_binding.Unexpanded.L.decode)
+    and+ inline_tests = inline_tests_field
     in
     { flags
     ; c_flags
     ; env_vars
     ; binaries
+    ; inline_tests
     }
 
   let rule =

--- a/src/dune_env.mli
+++ b/src/dune_env.mli
@@ -3,11 +3,22 @@ open! Stdune
 type stanza = Stanza.t = ..
 
 module Stanza : sig
+
+  module Inline_tests: sig
+    type t =
+      | Enabled
+      | Disabled
+      | Ignored
+    val decode: t Dune_lang.Decoder.t
+    val to_string: t -> string
+  end
+
   type config =
     { flags          : Ocaml_flags.Spec.t
     ; c_flags        : Ordered_set_lang.Unexpanded.t C.Kind.Dict.t
     ; env_vars       : Env.t
     ; binaries       : File_binding.Unexpanded.t list
+    ; inline_tests   : Inline_tests.t option
     }
 
   type pattern =

--- a/src/env_node.ml
+++ b/src/env_node.ml
@@ -125,17 +125,21 @@ let rec ocaml_flags t ~profile ~expander =
     t.ocaml_flags <- Some flags;
     flags
 
-let inline_tests t ~profile =
+let rec inline_tests t ~profile =
   match t.inline_tests with
   | Some x -> x
   | None ->
     let state : Dune_env.Stanza.Inline_tests.t =
       match find_config t ~profile with
       | None | Some {inline_tests = None; _} ->
-        if profile = "release" then
-          Disabled
-        else
-          Enabled
+        begin match t.inherit_from with
+        | None ->
+          if profile = "release" then
+            Disabled
+          else
+            Enabled
+        | Some (lazy t) -> inline_tests t ~profile
+        end
       | Some {inline_tests = Some s; _} -> s
     in
     t.inline_tests <- Some state;

--- a/src/env_node.mli
+++ b/src/env_node.mli
@@ -18,6 +18,8 @@ val external_ : t -> profile:string -> default:Env.t -> Env.t
 
 val ocaml_flags : t -> profile:string -> expander:Expander.t -> Ocaml_flags.t
 
+val inline_tests : t -> profile:string -> Dune_env.Stanza.Inline_tests.t
+
 val c_flags
   : t
   -> profile:string

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -186,7 +186,7 @@ end = struct
         inline_tests t ~dir
         |> Dune_env.Stanza.Inline_tests.to_string
       in
-      Pform.Map.singleton "inline-tests" (Values [String str])
+      Pform.Map.singleton "inline_tests" (Values [String str])
     in
     expander
     |> Expander.add_bindings ~bindings

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -153,6 +153,10 @@ end = struct
     in
     Env_node.local_binaries node ~profile:t.profile ~expander
 
+  let inline_tests ({profile; _} as t) ~dir =
+    let node = get t ~dir in
+    Env_node.inline_tests node ~profile
+
   let bin_artifacts t ~dir =
     let expander =
       expander_for_artifacts t ~context_expander:t.expander ~dir
@@ -177,7 +181,16 @@ end = struct
       expander_for_artifacts t ~context_expander:t.expander ~dir
     in
     let bin_artifacts_host = bin_artifacts_host t ~dir in
-    Expander.set_bin_artifacts expander ~bin_artifacts_host
+    let bindings =
+      let str =
+        inline_tests t ~dir
+        |> Dune_env.Stanza.Inline_tests.to_string
+      in
+      Pform.Map.singleton "inline-tests" (Values [String str])
+    in
+    expander
+    |> Expander.add_bindings ~bindings
+    |> Expander.set_bin_artifacts ~bin_artifacts_host
 
   let ocaml_flags t ~dir =
     Env_node.ocaml_flags (get t ~dir)

--- a/test/blackbox-tests/test-cases/inline_tests/dune-project
+++ b/test/blackbox-tests/test-cases/inline_tests/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.0)
+(lang dune 1.11)

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -6,6 +6,16 @@
 
   $ env -u OCAMLRUNPARAM dune runtest simple --profile release
 
+  $ env -u OCAMLRUNPARAM dune runtest simple --profile disable-inline-tests
+
+  $ env -u OCAMLRUNPARAM dune runtest simple --profile ignore-inline-tests
+
+  $ env -u OCAMLRUNPARAM dune runtest simple --profile enable-inline-tests
+           run alias simple/runtest (exit 2)
+  (cd _build/default/simple && .foo_simple.inline-tests/run.exe)
+  Fatal error: exception File "simple/.foo_simple.inline-tests/run.ml-gen", line 1, characters 40-46: Assertion failed
+  [1]
+
   $ dune runtest missing-backend
   File "missing-backend/dune", line 3, characters 1-15:
   3 |  (inline_tests))

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -1,8 +1,10 @@
   $ env -u OCAMLRUNPARAM dune runtest simple
            run alias simple/runtest (exit 2)
   (cd _build/default/simple && .foo_simple.inline-tests/run.exe)
-  Fatal error: exception File "simple/.foo_simple.inline-tests/run.ml-gen", line 1, characters 10-16: Assertion failed
+  Fatal error: exception File "simple/.foo_simple.inline-tests/run.ml-gen", line 1, characters 40-46: Assertion failed
   [1]
+
+  $ env -u OCAMLRUNPARAM dune runtest simple --profile release
 
   $ dune runtest missing-backend
   File "missing-backend/dune", line 3, characters 1-15:

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -4,6 +4,7 @@
   Fatal error: exception File "simple/.foo_simple.inline-tests/run.ml-gen", line 1, characters 40-46: Assertion failed
   [1]
 
+The expected behavior for the following three tests is to output nothing: the tests are disabled or ignored. 
   $ env -u OCAMLRUNPARAM dune runtest simple --profile release
 
   $ env -u OCAMLRUNPARAM dune runtest simple --profile disable-inline-tests

--- a/test/blackbox-tests/test-cases/inline_tests/simple/dune
+++ b/test/blackbox-tests/test-cases/inline_tests/simple/dune
@@ -8,3 +8,7 @@
 (library
  (name foo_simple)
  (inline_tests (backend backend_simple)))
+
+(env (ignore-inline-tests (inline_tests ignored))
+     (enable-inline-tests (inline_tests enabled))
+     (disable-inline-tests (inline_tests disabled)))

--- a/test/blackbox-tests/test-cases/inline_tests/simple/dune
+++ b/test/blackbox-tests/test-cases/inline_tests/simple/dune
@@ -2,7 +2,7 @@
  (name backend_simple)
  (modules ())
  (inline_tests.backend
-  (generate_runner (run sed "s/(\\*TEST:\\(.*\\)\\*)/let () = \\1;;/" %{impl-files})
+  (generate_runner (run sed "s/(\\*TEST:\\(.*\\)\\*)/let () = if \"%{inline-tests}\" = \"enabled\" then \\1;;/" %{impl-files})
   )))
 
 (library

--- a/test/blackbox-tests/test-cases/inline_tests/simple/dune
+++ b/test/blackbox-tests/test-cases/inline_tests/simple/dune
@@ -2,7 +2,7 @@
  (name backend_simple)
  (modules ())
  (inline_tests.backend
-  (generate_runner (run sed "s/(\\*TEST:\\(.*\\)\\*)/let () = if \"%{inline-tests}\" = \"enabled\" then \\1;;/" %{impl-files})
+  (generate_runner (run sed "s/(\\*TEST:\\(.*\\)\\*)/let () = if \"%{inline_tests}\" = \"enabled\" then \\1;;/" %{impl-files})
   )))
 
 (library


### PR DESCRIPTION
This PR propose to add new field "inline-tests" than can be used in the env stanza. 

For instance,
```
  (env
     (profile1 (inline-tests enabled))
     (profile2 (inline-tests disabled))
     (profile3 (inline-tests ignored))
  )
```

The only possible values are enabled/disabled/ignored evrything else is a sytanx error. 
Then we provide a new template variable %{inline-tests} that expands to "enabled"/"disabled"/"ignored" according to the current profile. The default value is "enabled" except if the profile is "release" in that case it is "disabled". 

# TODO

1. [x] : Add a paragraph in the manual to document the feature, 
2. [x] : Update CHANGES, 
3. [x] : Add a test. 
4. [x] : Rename "inline-tests" into "inline_tests" for consistency. 