### PR TITLE
Remove sexp everywhere

### DIFF
--- a/src/action_exec.ml
+++ b/src/action_exec.ml
@@ -112,8 +112,8 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to =
       if Path.is_in_build_dir path then
         Path.mkdir_p path
       else
-        Errors.code_error "Action_exec.exec: mkdir on non build dir"
-          ["path", Path.to_sexp path]
+        Code_error.raise "Action_exec.exec: mkdir on non build dir"
+          ["path", Path.to_dyn path]
     end;
     Fiber.return ()
   | Digest_files paths ->

--- a/src/alias.ml
+++ b/src/alias.ml
@@ -16,9 +16,9 @@ end = struct
 
   let make name ~dir =
     if String.contains name '/' then
-      Errors.code_error "Alias0.make: Invalid alias"
-        [ "name", Sexp.Encoder.string name
-        ; "dir", Path.Build.to_sexp dir
+      Code_error.raise "Alias0.make: Invalid alias"
+        [ "name", Dyn.Encoder.string name
+        ; "dir", Path.Build.to_dyn dir
         ];
     { dir; name }
 
@@ -53,8 +53,6 @@ let to_dyn { dir ; name } =
     [ "dir", Path.Build.to_dyn dir
     ; "name", String name
     ]
-
-let to_sexp t = Dyn.to_sexp (to_dyn t)
 
 let suffix = "-" ^ String.make 32 '0'
 

--- a/src/alias.mli
+++ b/src/alias.mli
@@ -21,8 +21,6 @@ val dir : t -> Path.Build.t
 
 val to_dyn : t -> Dyn.t
 
-val to_sexp : t -> Sexp.t
-
 val encode : t Dune_lang.Encoder.t
 
 val pp : t Fmt.t

--- a/src/bindings.ml
+++ b/src/bindings.ml
@@ -28,12 +28,13 @@ let empty = []
 
 let singleton x = [Unnamed x]
 
-let to_sexp sexp_of_a bindings =
-  Sexp.List (
+let to_dyn dyn_of_a bindings =
+  let open Dyn.Encoder in
+  Dyn.List (
     List.map bindings ~f:(function
-      | Unnamed a -> sexp_of_a a
+      | Unnamed a -> dyn_of_a a
       | Named (name, bindings) ->
-        Sexp.List (Sexp.Encoder.string (":" ^ name) :: List.map ~f:sexp_of_a bindings))
+        Dyn.List (string (":" ^ name) :: List.map ~f:dyn_of_a bindings))
   )
 
 let jbuild elem =

--- a/src/bindings.mli
+++ b/src/bindings.mli
@@ -21,7 +21,7 @@ val to_list : 'a t -> 'a list
 
 val singleton : 'a -> 'a t
 
-val to_sexp : 'a Sexp.Encoder.t -> 'a t Sexp.Encoder.t
+val to_dyn : 'a Dyn.Encoder.t -> 'a t Dyn.Encoder.t
 
 val decode : 'a Dune_lang.Decoder.t -> 'a t Dune_lang.Decoder.t
 

--- a/src/blang.ml
+++ b/src/blang.ml
@@ -58,14 +58,14 @@ let rec to_dyn =
   let open Dyn.Encoder in
   function
   | Const b -> constr "Const" [bool b]
-  | Expr e -> constr "Expr" [via_sexp String_with_vars.to_sexp e]
+  | Expr e -> constr "Expr" [String_with_vars.to_dyn e]
   | And t -> constr "And" (List.map ~f:to_dyn t)
   | Or t -> constr "Or" (List.map ~f:to_dyn t)
   | Compare (o, s1, s2) ->
     constr "Compare"
       [ Op.to_dyn o
-      ; via_sexp String_with_vars.to_sexp s1
-      ; via_sexp String_with_vars.to_sexp s2
+      ; String_with_vars.to_dyn s1
+      ; String_with_vars.to_dyn s2
       ]
 
 let ops =

--- a/src/build.ml
+++ b/src/build.ml
@@ -45,7 +45,7 @@ let get_if_file_exists_exn state =
   match !state with
   | Decided (_, t) -> t
   | Undecided _ ->
-    Errors.code_error "Build.get_if_file_exists_exn: got undecided" []
+    Code_error.raise "Build.get_if_file_exists_exn: got undecided" []
 
 let arr f = Arr f
 let return x = Arr (fun _ -> x)
@@ -227,7 +227,7 @@ let merge_files_dyn ~target =
 (* Analysis *)
 
 let no_targets_allowed () =
-  Errors.code_error "No targets allowed under a [Build.lazy_no_targets] \
+  Code_error.raise "No targets allowed under a [Build.lazy_no_targets] \
                   or [Build.if_file_exists]" []
 [@@inline never]
 
@@ -325,18 +325,19 @@ let targets =
       | If_file_exists (_, state) -> begin
           match !state with
           | Decided (v, _) ->
-            Errors.code_error "Build_interpret.targets got decided if_file_exists"
-              ["exists", Sexp.Encoder.bool v]
+            Code_error.raise "Build_interpret.targets got decided if_file_exists"
+              ["exists", Dyn.Encoder.bool v]
           | Undecided (a, b) ->
             let a = loop a Path.Build.Set.empty in
             let b = loop b Path.Build.Set.empty in
             if Path.Build.Set.is_empty a && Path.Build.Set.is_empty b then
               acc
             else begin
-              Errors.code_error "Build_interpret.targets: cannot have targets \
-                              under a [if_file_exists]"
-                [ "targets-a", Path.Build.Set.to_sexp a
-                ; "targets-b", Path.Build.Set.to_sexp b
+              Code_error.raise
+                "Build_interpret.targets: cannot have targets \
+                 under a [if_file_exists]"
+                [ "targets-a", Path.Build.Set.to_dyn a
+                ; "targets-b", Path.Build.Set.to_dyn b
                 ]
             end
         end

--- a/src/build_system.mli
+++ b/src/build_system.mli
@@ -42,7 +42,6 @@ module Context_or_install : sig
     | Context of string
 
   val to_dyn : t -> Dyn.t
-  val to_sexp : t -> Sexp.t
 end
 
 (** Set the rule generators callback. There must be one callback per

--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -7,16 +7,7 @@ type t =
   { libraries : C.Sources.t Lib_name.Map.t
   }
 
-let for_lib t ~dir ~name =
-  match Lib_name.Map.find t.libraries name with
-  | Some m -> m
-  | None ->
-    Errors.code_error "C_sources.for_lib"
-      [ "name", Lib_name.to_sexp name
-      ; "dir", Path.to_sexp dir
-      ; "available", Sexp.Encoder.(list Lib_name.to_sexp)
-                       (Lib_name.Map.keys t.libraries)
-      ]
+let for_lib t ~name = Lib_name.Map.find_exn t.libraries name
 
 let empty =
   { libraries = Lib_name.Map.empty

--- a/src/c_sources.mli
+++ b/src/c_sources.mli
@@ -6,7 +6,7 @@ type t
 
 val empty : t
 
-val for_lib : t -> dir:Path.t -> name:Lib_name.t -> C.Sources.t
+val for_lib : t -> name:Lib_name.t -> C.Sources.t
 
 (** [load_sources dir ~files] will load the C sources in [dir] into a two double
     map. The first level will is keyed by C vs. C++ sources. The second level is

--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -2,7 +2,7 @@ open Stdune
 
 let dev_files =
   let id = lazy (
-    let open Sexp.Encoder in
+    let open Dyn.Encoder in
     constr "dev_files"
       [string ".cmt"; string ".cmti"; string (Cm_kind.ext Cmi)]
   ) in

--- a/src/cm_kind.ml
+++ b/src/cm_kind.ml
@@ -40,9 +40,9 @@ module Dict = struct
     }
 end
 
-let to_sexp =
-  let open Sexp.Encoder in
+let to_dyn =
+  let open Dyn.Encoder in
   function
-  | Cmi -> string "cmi"
-  | Cmo -> string "cmo"
-  | Cmx -> string "cmx"
+  | Cmi -> constr "cmi" []
+  | Cmo -> constr "cmo" []
+  | Cmx -> constr "cmx" []

--- a/src/cm_kind.mli
+++ b/src/cm_kind.mli
@@ -7,7 +7,7 @@ val pp : t Fmt.t
 val ext : t -> string
 val source : t -> Ml_kind.t
 
-val to_sexp : t Sexp.Encoder.t
+val to_dyn : t -> Dyn.t
 
 module Dict : sig
   type cm_kind = t

--- a/src/context.ml
+++ b/src/context.ml
@@ -136,8 +136,6 @@ let to_dyn t : Dyn.t =
 
 let to_dyn_concise t : Dyn.t = String t.name
 
-let to_sexp t = Dyn.to_sexp (to_dyn t)
-
 let compare a b = compare a.name b.name
 
 let opam = lazy (Bin.which ~path:(Env.path Env.initial) "opam")

--- a/src/context.mli
+++ b/src/context.mli
@@ -128,7 +128,6 @@ type t =
 val equal : t -> t -> bool
 val hash : t -> int
 
-val to_sexp : t -> Sexp.t
 val to_dyn : t -> Dyn.t
 val to_dyn_concise : t -> Dyn.t
 

--- a/src/dep_path.ml
+++ b/src/dep_path.ml
@@ -27,9 +27,9 @@ module Entry = struct
         (Loc.to_file_colon_line loc)
     | Preprocess l ->
       Pp.textf "%s"
-        (Sexp.to_string
-           (List [ Atom "pps"
-                 ; Sexp.Encoder.(list Lib_name.to_sexp) l ]))
+        (Dyn.to_string
+           (List [ String "pps"
+                 ; Dyn.Encoder.(list Lib_name.to_dyn) l ]))
     | Loc loc ->
       Pp.text (Loc.to_file_colon_line loc)
 end

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -56,27 +56,14 @@ let text_files t = t.text_files
 
 let modules_of_library t ~name =
   let map = (Memo.Lazy.force t.modules).libraries in
-  match Lib_name.Map.find map name with
-  | Some m -> m
-  | None ->
-    Errors.code_error "Dir_contents.modules_of_library"
-      [ "name", Lib_name.to_sexp name
-      ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
-      ]
+  Lib_name.Map.find_exn map name
 
 let modules_of_executables t ~first_exe =
   let map = (Memo.Lazy.force t.modules).executables in
-  match String.Map.find map first_exe with
-  | Some m -> m
-  | None ->
-    Errors.code_error "Dir_contents.modules_of_executables"
-      [ "first_exe", Sexp.Encoder.string first_exe
-      ; "available", Sexp.Encoder.(list string) (String.Map.keys map)
-      ]
+  String.Map.find_exn map first_exe
 
 let c_sources_of_library t ~name =
-  C_sources.for_lib (Memo.Lazy.force t.c_sources)
-    ~dir:(Path.build t.dir) ~name
+  C_sources.for_lib (Memo.Lazy.force t.c_sources) ~name
 
 let lookup_module t name =
   Module.Name.Map.find (Memo.Lazy.force t.modules).rev_map name
@@ -89,21 +76,15 @@ let mlds t (doc : Documentation.t) =
   with
   | Some x -> x
   | None ->
-    Errors.code_error "Dir_contents.mlds"
-      [ "doc", Loc.to_sexp doc.loc
-      ; "available", Sexp.Encoder.(list Loc.to_sexp)
+    Code_error.raise "Dir_contents.mlds"
+      [ "doc", Loc.to_dyn doc.loc
+      ; "available", Dyn.Encoder.(list Loc.to_dyn)
                        (List.map map ~f:(fun (d, _) -> d.Documentation.loc))
       ]
 
 let coq_modules_of_library t ~name =
   let map = Memo.Lazy.force t.coq_modules in
-  match Lib_name.Map.find map name with
-  | Some x -> x
-  | None ->
-    Errors.code_error "Dir_contents.coq_modules_of_library"
-      [ "name", Lib_name.to_sexp name
-      ; "available", Sexp.Encoder.(list Lib_name.to_sexp) (Lib_name.Map.keys map)
-      ]
+  Lib_name.Map.find_exn map name
 
 let modules_of_files ~dir ~files =
   let dir = Path.build dir in

--- a/src/dir_set.ml
+++ b/src/dir_set.ml
@@ -159,22 +159,22 @@ let rec is_subset t ~of_ =
     (not x.default || y.default) &&
     String.Map.is_subset x.exceptions ~of_:y.exceptions ~f:is_subset
 
-let rec to_sexp t = match t with
-  | Empty -> Sexp.Atom "Empty"
-  | Universal -> Sexp.Atom "Universal"
+let rec to_dyn =
+  let open Dyn.Encoder in
+  function
+  | Empty -> constr "Empty" []
+  | Universal -> constr "Universal" []
   | Nontrivial { here; default; exceptions } ->
-    Sexp.List (
-      (
-        (match here with | true -> [ ".", Sexp.Atom "true" ] | false -> []) @
-        (String.Map.to_list exceptions
-         |> List.map ~f:(fun (s, t) ->
-           s, to_sexp t)) @
-        (match default with
-         | false -> []
-         | true -> [("*", Sexp.Atom "Universal")]))
-      |> List.map ~f:(fun (k, v) -> Sexp.List [Sexp.Atom k; v]))
-
-let to_dyn t : Dyn.t = Sexp (to_sexp t)
+    let open Dyn in
+    List ((
+      (match here with | true -> [ ".", String "true" ] | false -> []) @
+      (String.Map.to_list exceptions
+       |> List.map ~f:(fun (s, t) ->
+         s, to_dyn t)) @
+      (match default with
+       | false -> []
+       | true -> [("*", String "Universal")]))
+      |> List.map ~f:(fun (k, v) -> List [String k; v]))
 
 let forget_root t = t
 

--- a/src/dir_set.mli
+++ b/src/dir_set.mli
@@ -74,7 +74,6 @@ val inter_all : 'w t list -> 'w t
 val diff : 'w t -> 'w t -> 'w t
 val negate : 'w t -> 'w t
 
-val to_sexp : 'w t -> Sexp.t
 val to_dyn : 'w t -> Dyn.t
 
 val forget_root : 'w t -> Path.Unspecified.w t

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -116,7 +116,7 @@ module Dep_conf : sig
   val remove_locs : t -> t
 
   include Dune_lang.Conv with type t := t
-  val to_sexp : t Sexp.Encoder.t
+  val to_dyn : t Dyn.Encoder.t
 end
 
 module Auto_format : sig

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -1094,15 +1094,14 @@ module type Conv = sig
   val encode : t Encoder.t
 end
 
-let rec to_sexp = function
-  | Atom (A a) -> Sexp.Atom a
-  | List s -> List (List.map s ~f:to_sexp)
-  | Quoted_string s -> Sexp.Atom s
+let rec to_dyn =
+  let open Dyn.Encoder in
+  function
+  | Atom (A a) -> string a
+  | List s -> List (List.map s ~f:to_dyn)
+  | Quoted_string s -> string s
   | Template t ->
-    List
-      [ Atom "template"
-      ; Atom (Template.to_string ~syntax:Dune t)
-      ]
+    constr "template" [string (Template.to_string ~syntax:Dune t)]
 
 module Io = struct
   let load ?lexer path ~mode =

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -490,7 +490,7 @@ module type Conv = sig
   val encode : t Encoder.t
 end
 
-val to_sexp : t Sexp.Encoder.t
+val to_dyn : t Dyn.Encoder.t
 
 module Io : sig
   val load : ?lexer:Lexer.t -> Path.t -> mode:'a Parser.Mode.t -> 'a

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -100,7 +100,7 @@ module Extension : sig
     :  ?experimental:bool
     -> Syntax.t
     -> ('a * Stanza.Parser.t list) Dune_lang.Decoder.t
-    -> ('a -> Sexp.t)
+    -> ('a -> Dyn.t)
     -> 'a t
 
   (** A simple version where the arguments are not used through

--- a/src/errors.ml
+++ b/src/errors.ml
@@ -16,11 +16,6 @@ let fatalf ?loc fmt =
     | Some loc -> raise (Loc_error (loc, s))
   ) fmt
 
-let code_error message vars =
-  List.map vars ~f:(fun (v, sexp) ->
-    (v, Dyn.Sexp sexp))
-  |> Code_error.raise message
-
 exception Already_reported
 
 let max_lines_to_print_in_full = 10

--- a/src/errors.mli
+++ b/src/errors.mli
@@ -20,8 +20,6 @@ val fatalf
   -> ('a, unit, string, string, string, 'b) format6
   -> 'a
 
-val code_error : string -> (string * Sexp.t) list -> _
-
 (* CR-soon diml: we won't need this once we can generate rules dynamically *)
 (** Raised for errors that have already been reported to the user and shouldn't be
     reported again. This might happen when trying to build a dependency that has already

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -439,10 +439,10 @@ let expand_special_vars ~deps_written_by_user ~var pform =
   | Pform.Expansion.Var Named_local ->
     begin match Bindings.find deps_written_by_user key with
     | None ->
-      Errors.code_error "Local named variable not present in named deps"
-        [ "pform", String_with_vars.Var.to_sexp var
+      Code_error.raise "Local named variable not present in named deps"
+        [ "pform", String_with_vars.Var.to_dyn var
         ; "deps_written_by_user",
-          Bindings.to_sexp Path.to_sexp deps_written_by_user
+          Bindings.to_dyn Path.to_dyn deps_written_by_user
         ]
     | Some x -> Value.L.paths x
     end
@@ -464,8 +464,8 @@ let expand_special_vars ~deps_written_by_user ~var pform =
       [Value.String ""]
     end
   | _ ->
-    Errors.code_error "Unexpected variable in step2"
-      ["var", String_with_vars.Var.to_sexp var]
+    Code_error.raise "Unexpected variable in step2"
+      ["var", String_with_vars.Var.to_dyn var]
 
 let expand_ddeps_and_bindings ~(dynamic_expansions : Value.t list String.Map.t)
       ~(deps_written_by_user : Path.t Bindings.t) ~expand_var

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -331,7 +331,7 @@ module Var = struct
     EC.set_vars (Univ_map.remove (EC.vars ()) var) f () k
 
   let create () =
-    create ~name:"var" (fun _ -> Sexp.Encoder.string "var")
+    create ~name:"var" (fun _ -> Dyn.Encoder.string "var")
 end
 
 let with_error_handler f ~on_error k =

--- a/src/file_selector.ml
+++ b/src/file_selector.ml
@@ -34,6 +34,4 @@ let equal x y = compare x y = Eq
 let hash { dir; predicate} =
   Tuple.T2.hash Path.hash Predicate.hash (dir, predicate)
 
-let to_sexp t = Dyn.to_sexp (to_dyn t)
-
 let test t path = Predicate.test t.predicate (Path.basename path)

--- a/src/file_selector.mli
+++ b/src/file_selector.mli
@@ -17,10 +17,8 @@ val compare : t -> t -> Ordering.t
 
 val pp : t Fmt.t
 
-val to_dyn : t -> Dyn.t
-
 val encode : t Dune_lang.Encoder.t
 
-val to_sexp : t -> Sexp.t
+val to_dyn : t -> Dyn.t
 
 val test : t -> Path.t -> bool

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -160,8 +160,6 @@ module Dir = struct
       ; "contents", dyn_of_contents contents
       ; "vcs", Dyn.Encoder.option Vcs.to_dyn vcs
       ]
-
-  let to_sexp t = Dyn.to_sexp (to_dyn t)
 end
 
 type t = Dir.t

--- a/src/file_tree.mli
+++ b/src/file_tree.mli
@@ -58,7 +58,6 @@ module Dir : sig
   val project : t -> Dune_project.t
 
   val to_dyn : t -> Dyn.t
-  val to_sexp : t -> Sexp.t
 end
 
 (** A [t] value represent a view of the source tree. It is lazily

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -211,8 +211,9 @@ module Gen(P : sig val sctx : Super_context.t end) = struct
     let dyn_deps =
       let pred =
         let id = lazy (
-          let open Sexp.Encoder in
-          constr "exclude" (List.map ~f:Path.Build.to_sexp js_targets)
+          let open Dyn.Encoder in
+          constr "exclude" (List.map ~f:(fun p ->
+            Path.Build.to_dyn p) js_targets)
         ) in
         List.iter js_targets ~f:(fun js_target ->
           assert (Path.Build.equal (Path.Build.parent_exn js_target)

--- a/src/glob.ml
+++ b/src/glob.ml
@@ -10,7 +10,7 @@ let equal x y = String.equal x.repr y.repr
 
 let hash t = String.hash t.repr
 
-let to_sexp t = Sexp.Encoder.string t.repr
+let to_dyn t = Dyn.Encoder.string t.repr
 
 let of_string repr =
   Glob_lexer.parse_string repr
@@ -40,5 +40,8 @@ let empty =
   }
 
 let to_pred t =
-  let id = lazy (Sexp.List [Atom "Glob"; Atom t.repr]) in
+  let id = lazy (
+    let open Dyn.Encoder in
+    constr "Glob" [string t.repr])
+  in
   Predicate.create ~id ~f:(test t)

--- a/src/glob.mli
+++ b/src/glob.mli
@@ -6,7 +6,7 @@ val equal : t -> t -> bool
 
 val hash : t -> int
 
-val to_sexp : t Sexp.Encoder.t
+val to_dyn : t Dyn.Encoder.t
 
 val decode : t Stanza.Decoder.t
 

--- a/src/install.ml
+++ b/src/install.ml
@@ -219,7 +219,7 @@ module Section = struct
       | Doc          -> t.doc
       | Stublibs     -> t.stublibs
       | Man          -> t.man
-      | Misc         -> Errors.code_error "Install.Paths.get" []
+      | Misc         -> Code_error.raise "Install.Paths.get" []
 
     let install_path t section p =
       Path.relative (get t section) (Dst.to_string p)

--- a/src/lib_config.ml
+++ b/src/lib_config.ml
@@ -25,5 +25,5 @@ let get_for_enabled_if t ~var =
   match List.assoc var_map var with
   | Some f -> f t
   | None ->
-    Errors.code_error "Lib_config.get_for_enabled_if: var not allowed"
-      ["var", Sexp.Encoder.string var]
+    Code_error.raise "Lib_config.get_for_enabled_if: var not allowed"
+      ["var", Dyn.Encoder.string var]

--- a/src/lib_file_deps.ml
+++ b/src/lib_file_deps.ml
@@ -24,8 +24,8 @@ module Group = struct
       let ext = ext g in
       (* we cannot use globs because of bootstrapping. *)
       let id = lazy (
-        let open Sexp.Encoder in
-        constr "Lib_file_deps" [Atom ext]
+        let open Dyn.Encoder in
+        constr "Lib_file_deps" [string ext]
       ) in
       let pred = Predicate.create ~id ~f:(fun p ->
         String.equal (Filename.extension p) ext)

--- a/src/lib_name.ml
+++ b/src/lib_name.ml
@@ -50,8 +50,6 @@ module Local = struct
 
   let encode = Dune_lang.Encoder.string
 
-  let to_sexp = Sexp.Encoder.string
-
   let pp_quoted fmt t = Format.fprintf fmt "%S" t
   let pp fmt t = Format.fprintf fmt "%s" t
 
@@ -91,8 +89,6 @@ let pp = Format.pp_print_string
 let pp_quoted fmt t = Format.fprintf fmt "%S" t
 
 let to_local = Local.of_string
-
-let to_sexp t = Sexp.Atom t
 
 let to_dyn t = Dyn.String t
 

--- a/src/lib_name.mli
+++ b/src/lib_name.mli
@@ -19,8 +19,6 @@ module Local : sig
   val decode_loc : (Loc.t * result) Dune_lang.Decoder.t
   val validate : (Loc.t * result) -> wrapped:bool option -> t
 
-  val to_sexp : t Sexp.Encoder.t
-
   val of_string_exn : string -> t
 
   val of_string : string -> result
@@ -56,8 +54,6 @@ module Set : sig
   include Set.S with type elt = t
   val to_string_list : t -> string list
 end
-
-val to_sexp : t Sexp.Encoder.t
 
 val nest : t -> t -> t
 

--- a/src/local_package.ml
+++ b/src/local_package.ml
@@ -16,8 +16,6 @@ type t =
 
 let to_dyn t = Package.to_dyn t.pkg
 
-let to_sexp t = Dyn.to_sexp (to_dyn t)
-
 let hash t =
   Hashtbl.hash
     ( List.hash Path.Build.hash t.odig_files

--- a/src/local_package.mli
+++ b/src/local_package.mli
@@ -7,7 +7,7 @@ type t
 
 val hash : t -> int
 
-val to_sexp : t Sexp.Encoder.t
+val to_dyn : t Dyn.Encoder.t
 
 val build_dir : t -> Path.Build.t
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -64,8 +64,8 @@ let scan_workspace ?(log=Log.no_log)
 
   let+ contexts = Context.create ~env workspace in
   List.iter contexts ~f:(fun (ctx : Context.t) ->
-    Log.infof log "@[<1>Dune context:@,%a@]@." Sexp.pp
-      (Context.to_sexp ctx));
+    Log.infof log "@[<1>Dune context:@,%a@]@." Dyn.pp
+      (Context.to_dyn ctx));
   { contexts
   ; conf
   ; env

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -31,9 +31,8 @@ module External = struct
     match cm_kind, visibility, t.private_dir with
     | Cmi, Private, Some p -> p
     | Cmi, Private, None ->
-      Errors.code_error "External.cm_dir"
-        [ "t", Dyn.to_sexp (to_dyn t)
-        ]
+      Code_error.raise "External.cm_dir"
+        [ "t", to_dyn t]
     | Cmi, Public, _
     | (Cmo | Cmx), _, _ -> t.public_dir
 

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -27,8 +27,6 @@ module Value = struct
     | Prog_and_args { prog; args } ->
       (list string) (prog :: args)
 
-  let to_sexp t = Dyn.to_sexp (to_dyn t)
-
   let to_string = function
     | Bool   x -> string_of_bool x
     | Int    x -> string_of_int x
@@ -196,8 +194,6 @@ let to_dyn t =
     (to_list t
      |> List.map ~f:(fun (k, v) ->
        k, Value.to_dyn v))
-
-let to_sexp t = Dyn.to_sexp (to_dyn t)
 
 module Origin = struct
   type t =

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -9,7 +9,6 @@ open! Stdune
 type t
 
 val to_dyn : t Dyn.Encoder.t
-val to_sexp : t Sexp.Encoder.t
 
 module Prog_and_args : sig
   type t =
@@ -108,7 +107,7 @@ module Value : sig
 
   val to_string : t -> string
 
-  val to_sexp : t Sexp.Encoder.t
+  val to_dyn : t Dyn.Encoder.t
 end
 
 val to_list : t -> (string * Value.t) list

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -384,15 +384,7 @@ module Unexpanded = struct
                 "An unquoted templated expanded to more than one value. \
                  A file path is expected in this position."
           in
-          match Path.Map.find files_contents path with
-          | Some x -> x
-          | None ->
-            Errors.code_error
-              "Ordered_set_lang.Unexpanded.expand"
-              [ "included-file", Path.to_sexp path
-              ; "files", Sexp.Encoder.(list Path.to_sexp)
-                           (Path.Map.keys files_contents)
-              ]
+          Path.Map.find_exn files_contents path
         in
         let open Stanza.Decoder in
         parse

--- a/src/package.ml
+++ b/src/package.ml
@@ -23,7 +23,7 @@ module Name = struct
 
   let encode t = Dune_lang.Encoder.(string (to_string t))
 
-  let to_sexp t = Sexp.Encoder.string (to_string t)
+  let to_dyn t = Dyn.Encoder.string (to_string t)
 
   module Infix = Comparator.Operators(T)
 end
@@ -177,7 +177,7 @@ module Dependency = struct
     | Or (c :: cs) ->
       Logop (nopos, `Or, opam_constraint c, opam_constraint (And cs))
     | And []
-    | Or [] -> Errors.code_error "opam_constraint" []
+    | Or [] -> Code_error.raise "opam_constraint" []
 
   let opam_depend : t -> OpamParserTypes.value =
     let nopos = Opam_file.nopos in

--- a/src/package.mli
+++ b/src/package.mli
@@ -17,7 +17,7 @@ module Name : sig
 
   module Infix : Comparator.OPS with type t = t
 
-  val to_sexp : t -> Sexp.t
+  val to_dyn : t -> Dyn.t
 end
 
 module Version_source : sig

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -34,7 +34,7 @@ module Expansion : sig
     | Var   of Var.t
     | Macro of Macro.t * string
 
-  val to_sexp : t -> Sexp.t
+  val to_dyn : t -> Dyn.t
 end
 
 module Map : sig
@@ -61,5 +61,5 @@ module Map : sig
 
   val to_stamp : t -> stamp
 
-  val pp_debug : t Fmt.t
+  val to_dyn : t -> Dyn.t
 end

--- a/src/predicate.ml
+++ b/src/predicate.ml
@@ -1,21 +1,18 @@
 open Stdune
 
 type 'a t =
-  { id : Sexp.t Lazy.t
+  { id : Dyn.t Lazy.t
   ; f : 'a -> bool
   }
 
-let compare x y = Sexp.compare (Lazy.force x.id) (Lazy.force y.id)
+let compare x y = Dyn.compare (Lazy.force x.id) (Lazy.force y.id)
 let equal x y = compare x y = Ordering.Eq
-let hash t = Sexp.hash (Lazy.force t.id)
-
-let to_sexp t = Sexp.Encoder.constr "Predicate" [Lazy.force t.id]
+let hash t = Dyn.hash (Lazy.force t.id)
 
 let to_dyn t =
   let open Dyn in
   Record
-    [ "id", Sexp.to_dyn (Lazy.force t.id)
-    ]
+    ["id", Lazy.force t.id]
 
 let encode _ = Dune_lang.Encoder.string "predicate <opaque>"
 

--- a/src/predicate.mli
+++ b/src/predicate.mli
@@ -12,8 +12,6 @@ val compare : 'a t -> 'a t -> Ordering.t
 
 val hash : _ t -> int
 
-val to_sexp : _ t Sexp.Encoder.t
-
 val encode : _ t Dune_lang.Encoder.t
 
 val to_dyn : _ t -> Dyn.t
@@ -21,12 +19,12 @@ val to_dyn : _ t -> Dyn.t
 (**[create id ~f] creates a predicate defined by [f] identified uniquely with
    [id]. [id] is used to safely compare predicates for equality for
    memoization *)
-val create : id:Sexp.t Lazy.t -> f:('a -> bool) -> 'a t
+val create : id:Dyn.t Lazy.t -> f:('a -> bool) -> 'a t
 
 val test : 'a t -> 'a -> bool
 
 (** the user of this function must take care not to break the uniqueness of the
     underlying representation *)
-val contramap : 'a t -> f:('b -> 'a) -> map_id:(Sexp.t -> Sexp.t) -> 'b t
+val contramap : 'a t -> f:('b -> 'a) -> map_id:(Dyn.t -> Dyn.t) -> 'b t
 
 val pp : _ t Fmt.t

--- a/src/predicate_lang.ml
+++ b/src/predicate_lang.ml
@@ -69,20 +69,20 @@ module Ast = struct
     | Dune -> many union [] kind
     | Jbuild -> one kind
 
-  let rec to_sexp f =
-    let open Sexp.Encoder in
+  let rec to_dyn f =
+    let open Dyn.Encoder in
     function
     | Element a -> f a
-    | Compl a -> constr "compl" [to_sexp f a]
+    | Compl a -> constr "compl" [to_dyn f a]
     | Standard -> string ":standard"
-    | Union xs -> constr "or" (List.map ~f:(to_sexp f) xs)
-    | Inter xs -> constr "and" (List.map ~f:(to_sexp f) xs)
+    | Union xs -> constr "or" (List.map ~f:(to_dyn f) xs)
+    | Inter xs -> constr "and" (List.map ~f:(to_dyn f) xs)
 end
 
 type t = (string -> bool) Ast.t
 
-let pp ppf t =
-  Sexp.pp ppf (Ast.to_sexp (fun _ -> Sexp.Encoder.string "opaque") t)
+let to_dyn t =
+  Ast.to_dyn (fun _ -> Dyn.Encoder.string "opaque") t
 
 let decode : t Dune_lang.Decoder.t =
   let open Stanza.Decoder in

--- a/src/predicate_lang.mli
+++ b/src/predicate_lang.mli
@@ -5,7 +5,7 @@ open! Stdune
 
 type t
 
-val pp : t Fmt.t
+val to_dyn : t -> Dyn.t
 
 val decode : t Stanza.Decoder.t
 

--- a/src/promotion.ml
+++ b/src/promotion.ml
@@ -6,12 +6,11 @@ module File = struct
     ; dst : Path.Source.t
     }
 
-  (* XXX these sexp converters will be useful for the dump command *)
-  let _to_sexp { src; dst } =
-    Sexp.List
-      [ Path.Build.to_sexp src
-      ; Sexp.Atom "as"
-      ; Path.Source.to_sexp dst
+  let to_dyn { src; dst } =
+    let open Dyn.Encoder in
+    record
+      [ "src", Path.Build.to_dyn src
+      ; "dst", Path.Source.to_dyn dst
       ]
 
   let db : t list ref = ref []

--- a/src/promotion.mli
+++ b/src/promotion.mli
@@ -6,6 +6,8 @@ module File : sig
     ; dst : Path.Source.t
     }
 
+  val to_dyn : t -> Dyn.t
+
   (** Register a file to promote *)
   val register : t -> unit
 end

--- a/src/rule.ml
+++ b/src/rule.ml
@@ -37,7 +37,7 @@ let make ?(sandbox=false) ?(mode=Dune_file.Rule.Mode.Standard)
     | None -> begin
         match info with
         | From_dune_file loc -> Errors.fail loc "Rule has no targets specified"
-        | _ -> Errors.code_error "Build_interpret.Rule.make: no targets" []
+        | _ -> Code_error.raise "Build_interpret.Rule.make: no targets" []
       end
     | Some x ->
       let dir = Path.Build.parent_exn x in
@@ -46,8 +46,8 @@ let make ?(sandbox=false) ?(mode=Dune_file.Rule.Mode.Standard)
       then begin
         match info with
         | Internal | Source_file_copy ->
-          Errors.code_error "rule has targets in different directories"
-            [ "targets", Path.Build.Set.to_sexp targets
+          Code_error.raise "rule has targets in different directories"
+            [ "targets", Path.Build.Set.to_dyn targets
             ]
         | From_dune_file loc ->
           Errors.fail loc

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -678,7 +678,7 @@ end = struct
              let* pump_events_result = pump_events t in
              Fiber.return (pump_events_result, user_action_result)) with
     | exception Fiber.Never ->
-      Errors.code_error "[Scheduler.pump_events] got stuck somehow" []
+      Code_error.raise "[Scheduler.pump_events] got stuck somehow" []
     | exception exn ->
       Error (Exn (exn, (Printexc.get_raw_backtrace ())))
     | (a, b) ->
@@ -725,7 +725,7 @@ let go ?log ?config f =
   | Error Never ->
     raise Fiber.Never
   | Error Files_changed ->
-    Errors.code_error
+    Code_error.raise
       "Scheduler.go: files changed even though we're running without filesystem watcher"
       []
 

--- a/src/scheme.ml
+++ b/src/scheme.ml
@@ -129,13 +129,13 @@ let evaluate ~union_rules =
         not (Dir_set.is_subset paths ~of_:env)
         && not (Dir_set.is_subset (Dir_set.negate paths) ~of_:env)
       then
-        Errors.code_error
+        Code_error.raise
           "inner [Approximate] specifies a set such that neither it, \
            nor its negation, are a subset of directories specified by \
            the outer [Approximate]."
           [
-            "inner", (Dir_set.to_sexp paths);
-            "outer", (Dir_set.to_sexp env);
+            "inner", (Dir_set.to_dyn paths);
+            "outer", (Dir_set.to_dyn env);
           ]
       else
         let paths = Dir_set.inter paths env in
@@ -148,10 +148,10 @@ let evaluate ~union_rules =
       (match violations with
        | [] -> ()
        | _ :: _ ->
-         Errors.code_error
+         Code_error.raise
            "Scheme attempted to generate rules in a directory it promised not \
             to touch"
-           [ "directories", (Sexp.Encoder.list Path.Build.to_sexp) violations ]);
+           [ "directories", (Dyn.Encoder.list Path.Build.to_dyn) violations ]);
       Evaluated.finite ~union_rules rules
     | Thunk f -> loop ~env (f ())
   in

--- a/src/stdune/bool.ml
+++ b/src/stdune/bool.ml
@@ -15,5 +15,3 @@ let to_string = string_of_bool
 let of_string s = Option.try_with (fun () -> bool_of_string s)
 
 let to_dyn t = Dyn0.Bool t
-
-let to_sexp t = Sexp0.Atom (to_string t)

--- a/src/stdune/bool.mli
+++ b/src/stdune/bool.mli
@@ -9,5 +9,3 @@ val to_string : t -> string
 val of_string : string -> t option
 
 val to_dyn : t -> Dyn0.t
-
-val to_sexp : t -> Sexp0.t

--- a/src/stdune/dyn.ml
+++ b/src/stdune/dyn.ml
@@ -42,8 +42,6 @@ module Encoder = struct
   let array f = fun a -> Array (Array.map ~f a)
   let option f = fun x -> Option (Option.map ~f x)
 
-  let via_sexp f = fun x -> Sexp (f x)
-
   let record r = Record r
 
   let unknown _ = String "<unknown>"
@@ -56,3 +54,6 @@ end
 let opaque = String "<opaque>"
 
 type dyn = t
+
+let hash = Dune_caml.Hashtbl.hash
+let compare x y = Ordering.of_int (compare x y)

--- a/src/stdune/dyn.mli
+++ b/src/stdune/dyn.mli
@@ -34,8 +34,6 @@ module Encoder : sig
   val array      : 'a t -> 'a array          t
   val option     : 'a t -> 'a option         t
 
-  val via_sexp : ('a -> Sexp0.t) -> 'a t
-
   val record : (string * dyn) list -> dyn
 
   val unknown : _ t
@@ -48,7 +46,11 @@ val pp : Format.formatter -> t -> unit
 
 val opaque : t
 
-val to_sexp : t Sexp.Encoder.t
+val compare : t -> t -> Ordering.t
+
+val to_sexp : t -> Sexp0.t
+
+val hash : t -> int
 
 val to_string : t -> string
 

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -75,9 +75,6 @@ let to_dyn t =
   let open Dyn.Encoder in
   Map.to_dyn string t.vars
 
-let to_sexp t =
-  Dyn.to_sexp (to_dyn t)
-
 let diff x y =
   Map.merge x.vars y.vars ~f:(fun _k vx vy ->
     match vy with
@@ -93,8 +90,6 @@ let of_string_map m =
 
 let iter t =
   Map.iteri t.vars
-
-let pp fmt t = Sexp.pp fmt (to_sexp t)
 
 let cons_path t ~dir =
   make (Map.update t.vars "PATH"

--- a/src/stdune/env.mli
+++ b/src/stdune/env.mli
@@ -32,15 +32,11 @@ val diff : t -> t -> t
 
 val update : t -> var:string -> f:(string option -> string option) -> t
 
-val to_sexp : t -> Sexp.t
-
 val to_dyn : t -> Dyn.t
 
 val of_string_map : string String.Map.t -> t
 
 val iter : t -> f:(string -> string -> unit) -> unit
-
-val pp : Format.formatter -> t -> unit
 
 val cons_path : t -> dir:Path.t -> t
 

--- a/src/stdune/exn_with_backtrace.ml
+++ b/src/stdune/exn_with_backtrace.ml
@@ -24,8 +24,9 @@ let map { exn; backtrace } ~f =
 
 let map_and_reraise t ~f = reraise (map ~f t)
 
-let to_sexp { exn; backtrace } =
-  Sexp.List [
-    Atom (Printexc.to_string exn);
-    Atom (Printexc.raw_backtrace_to_string backtrace)
-  ]
+let to_dyn { exn; backtrace } =
+  let open Dyn.Encoder in
+  record
+    [ "exn", string (Printexc.to_string exn)
+    ; "backtrace", string (Printexc.raw_backtrace_to_string backtrace)
+    ]

--- a/src/stdune/exn_with_backtrace.mli
+++ b/src/stdune/exn_with_backtrace.mli
@@ -20,4 +20,4 @@ val map : t -> f:(exn -> exn) -> t
 
 val map_and_reraise  : t -> f:(exn -> exn) -> 'a
 
-val to_sexp : t -> Sexp.t
+val to_dyn : t -> Dyn.t

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -104,6 +104,3 @@ let to_dyn (type key) f g t =
     foldi t ~init:M.empty ~f:(fun key data acc -> M.add acc key data)
   in
   M.to_dyn g m
-
-let to_sexp f g t =
-  Dyn.to_sexp (to_dyn (Dyn.Encoder.via_sexp f) (Dyn.Encoder.via_sexp g) t)

--- a/src/stdune/hashtbl.mli
+++ b/src/stdune/hashtbl.mli
@@ -31,5 +31,4 @@ val mem : ('a, _) t -> 'a -> bool
 
 val keys : ('a, _) t -> 'a list
 
-val to_sexp : ('a -> Sexp.t) -> ('b -> Sexp.t) -> ('a, 'b) t -> Sexp.t
-val to_dyn : ('a -> Dyn.t) -> ('b -> Dyn.t) -> ('a, 'b) t -> Dyn.t
+val to_dyn : ('a -> Dyn0.t) -> ('b -> Dyn0.t) -> ('a, 'b) t -> Dyn0.t

--- a/src/stdune/id.ml
+++ b/src/stdune/id.ml
@@ -12,7 +12,6 @@ module type S = sig
   val equal : t -> t -> bool
   val hash : t -> int
   val to_dyn : t -> Dyn.t
-  val to_sexp : t -> Sexp.t
 end
 
 module Make () : S = struct
@@ -35,6 +34,5 @@ module Make () : S = struct
   let compare = Int.compare
   let equal = Int.equal
   let hash (t : t) = t
-  let to_sexp = Sexp.Encoder.int
   let to_dyn t = Dyn.Int t
 end

--- a/src/stdune/id.mli
+++ b/src/stdune/id.mli
@@ -21,7 +21,6 @@ module type S = sig
   val equal : t -> t -> bool
   val hash : t -> int
   val to_dyn : t -> Dyn.t
-  val to_sexp : t -> Sexp.t
 end
 
 (** A functor to create a new ID generator module. *)

--- a/src/stdune/int.ml
+++ b/src/stdune/int.ml
@@ -7,7 +7,6 @@ module T = struct
       Eq
     else
       Gt
-  let to_sexp = Sexp.Encoder.int
   let to_dyn x = Dyn0.Int x
 end
 

--- a/src/stdune/int.mli
+++ b/src/stdune/int.mli
@@ -2,7 +2,6 @@ type t = int
 val compare : t -> t -> Ordering.t
 val equal : t -> t -> bool
 val hash : t -> int
-val to_sexp : t -> Sexp.t
 val to_dyn : t -> Dyn0.t
 
 module Set : Set.S with type elt = t

--- a/src/stdune/interned.ml
+++ b/src/stdune/interned.ml
@@ -12,7 +12,6 @@ module type S = sig
   module Set : sig
     include Set.S with type elt = t
 
-    val to_sexp : t -> Sexp.t
     val to_dyn : t -> Dyn.t
 
     val make : string list -> t
@@ -122,8 +121,6 @@ module Make(R : Settings)() = struct
   module Set = struct
     include O.Set
 
-    let to_sexp t = Sexp.Encoder.(list String.to_sexp) (List.map ~f:to_string (to_list t))
-
     let make l =
       List.fold_left l ~init:empty ~f:(fun acc s -> add acc (make s))
 
@@ -151,7 +148,6 @@ module No_interning(R : Settings)() = struct
     include String.Set
     let make = of_list
     let pp fmt t = Fmt.ocaml_list Format.pp_print_string fmt (to_list t)
-    let to_sexp t = Sexp.Encoder.(list String.to_sexp) (to_list t)
   end
   module Map = String.Map
 

--- a/src/stdune/interned.mli
+++ b/src/stdune/interned.mli
@@ -21,7 +21,6 @@ module type S = sig
   module Set : sig
     include Set.S with type elt = t
 
-    val to_sexp : t -> Sexp.t
     val to_dyn : t -> Dyn.t
 
     val make : string list -> t

--- a/src/stdune/loc.ml
+++ b/src/stdune/loc.ml
@@ -19,28 +19,12 @@ let of_lexbuf lexbuf : t =
   ; stop  = Lexing.lexeme_end_p   lexbuf
   }
 
-let sexp_of_position_no_file (p : Lexing.position) =
-  let open Sexp.Encoder in
-  record
-    [ "pos_lnum", int p.pos_lnum
-    ; "pos_bol", int p.pos_bol
-    ; "pos_cnum", int p.pos_cnum
-    ]
-
 let dyn_of_position_no_file (p : Lexing.position) =
   let open Dyn in
   Record
     [ "pos_lnum", Int p.pos_lnum
     ; "pos_bol", Int p.pos_bol
     ; "pos_cnum", Int p.pos_cnum
-    ]
-
-let to_sexp t =
-  let open Sexp.Encoder in
-  record (* TODO handle when pos_fname differs *)
-    [ "pos_fname", string t.start.pos_fname
-    ; "start", sexp_of_position_no_file t.start
-    ; "stop", sexp_of_position_no_file t.stop
     ]
 
 let to_dyn t =

--- a/src/stdune/loc.mli
+++ b/src/stdune/loc.mli
@@ -12,11 +12,9 @@ val drop_position : t -> t
 
 val of_lexbuf : Lexing.lexbuf -> t
 
-val to_sexp : t -> Sexp.t
-
 val to_dyn : t -> Dyn.t
 
-val sexp_of_position_no_file : Lexing.position -> Sexp.t
+val dyn_of_position_no_file : Lexing.position -> Dyn.t
 
 val equal : t -> t -> bool
 

--- a/src/stdune/map_intf.ml
+++ b/src/stdune/map_intf.ml
@@ -1,6 +1,6 @@
 module type Key = sig
   include Comparator.S
-  val to_dyn : t -> Dyn.t
+  val to_dyn : t -> Dyn0.t
 end
 
 module type S = sig

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -74,7 +74,6 @@ end = struct
       User_error.raise ~loc [ Pp.textf "path %s is not absolute" t ];
     make t
 
-  let to_sexp t = Sexp.Encoder.string (to_string t)
   let to_dyn t = Dyn.String (to_string t)
 
 (*
@@ -250,7 +249,6 @@ end = struct
       | None -> t
       | Some i -> String.sub t ~pos:(i + 1) ~len:(len - i - 1)
 
-  let to_sexp t = Sexp.Encoder.string (to_string t)
   let to_dyn t = Dyn.String (to_string t)
 
   module L = struct
@@ -842,12 +840,12 @@ let parse_string_exn ~loc s =
 
 let of_string s = parse_string_exn ~loc:Loc0.none s
 
-let to_sexp t =
-  let constr f x y = Sexp.Encoder.(pair string f) (x, y) in
-  match t with
-  | In_build_dir s -> constr Local.to_sexp "In_build_dir" s
-  | In_source_tree s -> constr Local.to_sexp "In_source_tree" s
-  | External s -> constr External.to_sexp "External" s
+let to_dyn =
+  let open Dyn.Encoder in
+  function
+  | In_build_dir s -> constr "In_build_dir" [Local.to_dyn s]
+  | In_source_tree s -> constr "In_source_tree" [Local.to_dyn s]
+  | External s -> constr "External" [External.to_dyn s]
 
 let of_filename_relative_to_initial_cwd fn =
   external_ (
@@ -1229,7 +1227,6 @@ let pp_debug ppf = function
 module O = Comparable.Make(T)
 module Set = struct
   include O.Set
-  let to_sexp t = Sexp.Encoder.(list to_sexp) (to_list t)
   let of_listing ~dir ~filenames =
     of_list (List.map filenames ~f:(fun f -> relative dir f))
 end

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -15,7 +15,6 @@ module type S = sig
   include Comparator.OPS with type t := t
 
   val to_dyn : t -> Dyn.t
-  val to_sexp : t -> Sexp.t
 
   val extension : t -> string
 
@@ -29,7 +28,6 @@ module type S = sig
 
   module Set : sig
     include Set.S with type elt = t
-    val to_sexp : t Sexp.Encoder.t
     val to_dyn : t Dyn.Encoder.t
     val of_listing : dir:elt -> filenames:string list -> t
   end
@@ -78,7 +76,6 @@ module type Local_gen = sig
   val compare : 'w t -> 'w t -> Ordering.t
 
   val to_dyn : 'w t -> Dyn.t
-  val to_sexp : 'w t -> Sexp.t
 
   val extension : 'w t -> string
 
@@ -93,7 +90,6 @@ module type Local_gen = sig
   module Fix_root (Root : sig type w end) : sig
     module Set : sig
       include Set.S with type elt = Root.w t
-      val to_sexp : t Sexp.Encoder.t
       val to_dyn : t Dyn.Encoder.t
       val of_listing : dir:elt -> filenames:string list -> t
     end

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -43,7 +43,6 @@ let to_dyn = T.to_dyn
 
 let equal : string -> string -> bool = (=)
 let hash = Hashtbl.hash
-let to_sexp = Sexp.Encoder.string
 
 let capitalize   = capitalize_ascii
 let uncapitalize = uncapitalize_ascii

--- a/src/stdune/string.mli
+++ b/src/stdune/string.mli
@@ -4,7 +4,6 @@ include module type of struct include StringLabels end with type t := t
 val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 val hash : t -> int
-val to_sexp : t -> Sexp.t
 val to_dyn : t -> Dyn.t
 
 val break : t -> pos:int -> t * t

--- a/src/stdune/unit.ml
+++ b/src/stdune/unit.ml
@@ -2,5 +2,4 @@ type t = unit
 let equal () () = true
 let compare () () = Ordering.Eq
 let hash () = 0
-let to_sexp () = Sexp.List []
 let to_dyn () = Dyn.Unit

--- a/src/stdune/unit.mli
+++ b/src/stdune/unit.mli
@@ -2,5 +2,4 @@ type t = unit
 val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 val hash : t -> int
-val to_sexp : t -> Sexp.t
 val to_dyn : t -> Dyn0.t

--- a/src/stdune/univ_map.mli
+++ b/src/stdune/univ_map.mli
@@ -7,7 +7,7 @@ type t
 
 module Key : sig
   type 'a t
-  val create : name:string -> ('a -> Sexp.t) -> 'a t
+  val create : name:string -> ('a -> Dyn.t) -> 'a t
 end
 
 val empty    : t
@@ -23,4 +23,4 @@ val singleton : 'a Key.t -> 'a -> t
     in [b]. *)
 val superpose : t -> t -> t
 
-val to_sexp : t -> Sexp.t
+val to_dyn : t -> Dyn.t

--- a/src/string_with_vars.mli
+++ b/src/string_with_vars.mli
@@ -16,7 +16,7 @@ val loc : t -> Loc.t
 
 val syntax_version : t -> Syntax.Version.t
 
-val to_sexp : t Sexp.Encoder.t
+val to_dyn : t Dyn.Encoder.t
 
 include Dune_lang.Conv with type t := t
 
@@ -46,7 +46,7 @@ end
 module Var : sig
   type t
 
-  val to_sexp : t -> Sexp.t
+  val to_dyn : t -> Dyn.t
 
   val name : t -> string
   val loc : t -> Loc.t
@@ -69,7 +69,7 @@ module Partial : sig
     | Expanded of 'a
     | Unexpanded of t
 
-  val to_sexp : ('a -> Sexp.t) -> 'a t -> Sexp.t
+  val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 

--- a/src/sub_system_info.ml
+++ b/src/sub_system_info.ml
@@ -24,8 +24,8 @@ module Register(M : S) : sig end = struct
   let () =
     match Sub_system_name.Table.get all name with
     | Some _ ->
-      Errors.code_error "Sub_system_info.register: already registered"
-        [ "name", Sexp.Encoder.string (Sub_system_name.to_string name) ];
+      Code_error.raise "Sub_system_info.register: already registered"
+        [ "name", Dyn.Encoder.string (Sub_system_name.to_string name) ];
     | None ->
       Sub_system_name.Table.set all ~key:name ~data:(Some (module M : S));
       let p = !record_parser in

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -58,7 +58,6 @@ let hash t = Context.hash t.context
 let to_dyn_concise t =
   Context.to_dyn_concise t.context
 let to_dyn t = Context.to_dyn t.context
-let to_sexp t = Context.to_sexp t.context
 
 let host t = Option.value t.host ~default:t
 
@@ -130,8 +129,8 @@ end = struct
       try
         get t ~dir ~scope
       with Exit ->
-        Errors.code_error "Super_context.Env.get called on invalid directory"
-          [ "dir", Path.Build.to_sexp dir ]
+        Code_error.raise "Super_context.Env.get called on invalid directory"
+          [ "dir", Path.Build.to_dyn dir ]
 
   let external_ t  ~dir =
     Env_node.external_ (get t ~dir) ~profile:t.profile ~default:t.context_env

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -12,7 +12,6 @@ open Dune_file
 type t
 
 val to_dyn : t -> Dyn.t
-val to_sexp : t -> Sexp.t
 
 val create
   :  context:Context.t

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -14,8 +14,6 @@ module Version : sig
 
   val pp : t Fmt.t
 
-  val to_sexp : t Sexp.Encoder.t
-
   val to_dyn : t Dyn.Encoder.t
 
   val hash : t -> int

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -320,11 +320,11 @@ let upgrade_opam_file todo fn =
     let ofs =
       List.fold_left substs ~init:0 ~f:(fun ofs (start, stop, repl) ->
         if not (ofs <= start && start <= stop) then
-          Errors.code_error "Invalid text subsitution"
-            [ "ofs", Sexp.Encoder.int ofs
-            ; "start", Sexp.Encoder.int start
-            ; "stop", Sexp.Encoder.int stop
-            ; "repl", Sexp.Encoder.string repl
+          Code_error.raise "Invalid text subsitution"
+            [ "ofs", Dyn.Encoder.int ofs
+            ; "start", Dyn.Encoder.int start
+            ; "stop", Dyn.Encoder.int stop
+            ; "repl", Dyn.Encoder.string repl
             ];
         Buffer.add_substring buf s ofs (start - ofs);
         Buffer.add_string buf repl;

--- a/src/value.ml
+++ b/src/value.ml
@@ -6,12 +6,12 @@ type t =
   | Dir of Path.t
   | Path of Path.t
 
-let to_sexp =
-  let open Sexp.Encoder in
+let to_dyn =
+  let open Dyn.Encoder in
   function
-  | String s -> (pair string string) ("string", s)
-  | Path p -> (pair string Path.to_sexp) ("path", p)
-  | Dir p -> (pair string Path.to_sexp) ("dir", p)
+  | String s -> constr "string" [string s]
+  | Path p -> constr "path" [Path.to_dyn p]
+  | Dir p -> constr "dir" [Path.to_dyn p]
 
 let string_of_path ~dir p = Path.reach ~from:dir p
 

--- a/src/value.mli
+++ b/src/value.mli
@@ -5,7 +5,7 @@ type t =
   | Dir of Path.t
   | Path of Path.t
 
-val to_sexp : t Sexp.Encoder.t
+val to_dyn : t -> Dyn.t
 
 val to_string : t -> dir:Path.t -> string
 

--- a/src/versioned_file.ml
+++ b/src/versioned_file.ml
@@ -43,8 +43,8 @@ module Make(Data : sig type t end) = struct
     let register syntax data =
       let name = Syntax.name syntax in
       if Hashtbl.mem langs name then
-        Errors.code_error "Versioned_file.Lang.register: already registered"
-          [ "name", Sexp.Encoder.string name ];
+        Code_error.raise "Versioned_file.Lang.register: already registered"
+          [ "name", Dyn.Encoder.string name ];
       Hashtbl.add langs name { syntax; data }
 
     let parse first_line : Instance.t =

--- a/src/visibility.ml
+++ b/src/visibility.ml
@@ -8,7 +8,6 @@ let to_string = function
 
 let pp fmt t = Format.pp_print_string fmt (to_string t)
 
-let to_sexp t = Sexp.Encoder.string (to_string t)
 let to_dyn t = Dyn.Encoder.string (to_string t)
 
 let encode =

--- a/src/visibility.mli
+++ b/src/visibility.mli
@@ -7,7 +7,6 @@ include Dune_lang.Conv with type t := t
 val is_public : t -> bool
 val is_private : t -> bool
 
-val to_sexp : t -> Sexp.t
 val to_dyn : t -> Dyn.t
 
 val pp : t Fmt.t

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -105,7 +105,7 @@ val conf : Findlib.Config.t =
   }
 |}]
 
-let env_pp fmt env = Sexp.pp fmt (Env.to_sexp env);;
+let env_pp fmt env = Dyn.pp fmt (Env.to_dyn env);;
 #install_printer env_pp;;
 
 [%%expect{|
@@ -115,5 +115,5 @@ val env_pp : Format.formatter -> Env.t -> unit = <fun>
 let env = Findlib.Config.env conf
 
 [%%expect{|
-val env : Env.t = ((FOO_BAR "my variable"))
+val env : Env.t = map {"FOO_BAR" : "my variable"}
 |}]


### PR DESCRIPTION
As discussed before, Dyn is now used instead.

I cannot remove Sexp completely because it's uses as a serialization mechanism for `$ dune external-lib-deps --sexp`. I believe this is only used internally by janestreet, so @diml will have to take care of this when he's back.