### PR TITLE
Fix building exe

### DIFF
--- a/src/build.ml
+++ b/src/build.ml
@@ -422,6 +422,8 @@ let exec ~(eval_pred : Dep.eval_pred) (t : ('a, 'b) t) (x : 'a)
   let result = exec dyn_deps t x in
   (result, !dyn_deps)
 
+let ignore x = x >>^ ignore
+
 module S = struct
   open O
   module O = struct

--- a/src/build.mli
+++ b/src/build.mli
@@ -210,6 +210,8 @@ val merge_files_dyn
   :  target:Path.Build.t
   -> (Path.t list * string list, Action.t) t
 
+val ignore : ('a, 'b) t -> ('a, unit) t
+
 (* A module with standard combinators for applicative and selective functors, as
 well as equivalents of the functions from the arrow-based API. *)
 module S : sig

--- a/src/cm_files.ml
+++ b/src/cm_files.ml
@@ -22,17 +22,25 @@ let make_lib ~obj_dir ~modules ~top_sorted_modules ~ext_obj =
   ; ext_obj
   }
 
-let unsorted_objects_and_cms t ~mode =
+let objects_and_cms t ~mode modules =
   let kind = Mode.cm_kind mode in
-  let cm_files = Obj_dir.Module.L.cm_files t.obj_dir t.modules ~kind in
+  let cm_files = Obj_dir.Module.L.cm_files t.obj_dir modules ~kind in
   match mode with
   | Byte -> cm_files
   | Native ->
-    Obj_dir.Module.L.o_files t.obj_dir t.modules ~ext_obj:t.ext_obj
+    Obj_dir.Module.L.o_files t.obj_dir modules ~ext_obj:t.ext_obj
     |> List.rev_append cm_files
+
+let unsorted_objects_and_cms t ~mode =
+  objects_and_cms t ~mode t.modules
 
 let top_sorted_cms t ~mode =
   let kind = Mode.cm_kind mode in
   let open Build.O in
   t.top_sorted_modules
   >>^ Obj_dir.Module.L.cm_files t.obj_dir ~kind
+
+let top_sorted_objects_and_cms t ~mode =
+  let open Build.O in
+  t.top_sorted_modules
+  >>^ objects_and_cms t ~mode

--- a/src/cm_files.mli
+++ b/src/cm_files.mli
@@ -23,3 +23,6 @@ val make_lib
 val unsorted_objects_and_cms : t -> mode:Mode.t -> Path.t list
 
 val top_sorted_cms : t -> mode:Mode.t -> (unit, Path.t list) Build.t
+
+val top_sorted_objects_and_cms
+  : t -> mode:Mode.t -> (unit, Path.t list) Build.t

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -150,14 +150,14 @@ let link_exe
          let project = Scope.project scope in
          Dune_project.dune_version project
        in
-       if dune_version >= (2, 0) then
-         Cm_files.unsorted_objects_and_cms cm_files ~mode
-         |> Build.paths
-         >>^ ignore
-       else
-         Cm_files.top_sorted_objects_and_cms cm_files ~mode
-         |> Build.dyn_paths
-         >>^ ignore
+       Build.ignore (
+         if dune_version >= (2, 0) then
+           Cm_files.unsorted_objects_and_cms cm_files ~mode
+           |> Build.paths
+         else
+           Cm_files.top_sorted_objects_and_cms cm_files ~mode
+           |> Build.dyn_paths
+       )
      in
      prefix
      >>>

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -132,7 +132,6 @@ let link_exe
   let mode = linkage.mode in
   let exe = exe_path_from_name cctx ~name ~linkage in
   let compiler = Option.value_exn (Context.compiler ctx mode) in
-  let kind = Mode.cm_kind mode in
   let js_of_ocaml =
     CC.js_of_ocaml cctx
     |> Option.value ~default:Dune_file.Js_of_ocaml.default
@@ -142,15 +141,9 @@ let link_exe
     Cm_files.make_exe ~obj_dir ~modules ~top_sorted_modules
       ~ext_obj:ctx.lib_config.ext_obj
   in
-  let modules_and_cm_files =
-    Build.memoize "cm files"
-      (top_sorted_modules >>^ fun modules ->
-       (modules,
-        Obj_dir.Module.L.cm_files obj_dir modules ~kind))
-  in
+  let top_sorted_cms = Cm_files.top_sorted_cms cm_files ~mode in
   SC.add_rule sctx ~loc ~dir
     (let ocaml_flags = Ocaml_flags.get (CC.flags cctx) mode in
-     let top_sorted_cms = Cm_files.top_sorted_cms cm_files ~mode in
      let prefix =
        let dune_version =
          let scope = CC.scope cctx in
@@ -162,7 +155,9 @@ let link_exe
          |> Build.paths
          >>^ ignore
        else
-         Build.return ()
+         Cm_files.top_sorted_objects_and_cms cm_files ~mode
+         |> Build.dyn_paths
+         >>^ ignore
      in
      prefix
      >>>
@@ -183,14 +178,13 @@ let link_exe
           ; Dyn (Build.S.map top_sorted_cms ~f:(fun x -> Command.Args.Deps x))
           ]));
   if linkage.ext = ".bc" then
-    let cm = modules_and_cm_files >>^ snd in
     let flags =
       (Expander.expand_and_eval_set expander
          js_of_ocaml.flags
          ~standard:(Build.return (Js_of_ocaml_rules.standard sctx))) in
     let rules =
-      Js_of_ocaml_rules.build_exe cctx ~js_of_ocaml ~src:exe ~cm
-        ~flags:(Command.Args.dyn flags)
+      Js_of_ocaml_rules.build_exe cctx ~js_of_ocaml ~src:exe
+        ~cm:top_sorted_cms ~flags:(Command.Args.dyn flags)
     in
     SC.add_rules ~dir sctx rules
 

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -72,7 +72,7 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
   let flags = SC.ocaml_flags sctx ~dir exes.buildable in
   let link_deps = SC.Deps.interpret sctx ~expander exes.link_deps in
   let link_flags =
-    link_deps >>^ ignore >>>
+    link_deps |> Build.ignore >>>
     Expander.expand_and_eval_set expander exes.link_flags
       ~standard:(Build.return [])
   in

--- a/test/blackbox-tests/test-cases/github660/run.t
+++ b/test/blackbox-tests/test-cases/github660/run.t
@@ -10,6 +10,8 @@ When there are explicit interfaces, modules must be rebuilt.
   $ echo 'let _x = 1' >> explicit-interfaces/lib_sub.ml
   $ dune runtest --root explicit-interfaces
   Entering directory 'explicit-interfaces'
+          main alias runtest
+  hello
 
 When there are no interfaces, the situation is the same, but it is not possible
 to rely on these.


### PR DESCRIPTION
The desired behavior for dune 2.0:

* Ask for all .cmx/.o files statically
* Only use topsorted .cmx files for linking

For < 2.0

* Topsort modules
* Ask for the topsorted subsets of .cmx/.o files dynamically
* Only use topsorted .cmx for linkig