### PR TITLE
Tweak Map/Hashtable interfaces

### DIFF
--- a/src/alias.ml
+++ b/src/alias.ml
@@ -83,7 +83,7 @@ let standard_aliases = Hashtbl.create 7
 let is_standard name = Hashtbl.mem standard_aliases name
 
 let make_standard name =
-  Hashtbl.add standard_aliases name ();
+  Hashtbl.add_exn standard_aliases name ();
   make name
 
 let default     = make_standard "default"

--- a/src/artifacts.ml
+++ b/src/artifacts.ml
@@ -31,7 +31,7 @@ module Bin = struct
         ~f:(fun acc fb ->
           let path = File_binding.Expanded.dst_path fb
                        ~dir:(Utils.local_bin dir) in
-          String.Map.add acc (Path.Build.basename path) path)
+          String.Map.set acc (Path.Build.basename path) path)
     in
     { t with local_bins }
 
@@ -46,7 +46,7 @@ module Bin = struct
           else
             name
         in
-        String.Map.add acc key path)
+        String.Map.set acc key path)
     in
     { context
     ; local_bins

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -486,7 +486,7 @@ let get_dir_triage t ~dir =
 let add_spec_exn t fn rule =
   match Path.Build.Table.find t.files fn with
   | None ->
-    Path.Build.Table.add t.files fn rule
+    Path.Build.Table.set t.files fn rule
   | Some _ ->
     Code_error.raise
       "add_spec_exn called on the same file twice. \
@@ -778,7 +778,7 @@ end = struct
             match File_tree.find_dir t.file_tree src_dir with
             | None -> aliases
             | Some dir ->
-              String.Map.add aliases "default"
+              String.Map.set aliases "default"
                 { deps = Path.Set.empty
                 ; dyn_deps =
                     (Alias0.dep_rec_internal ~name:"install" ~dir ~ctx_dir
@@ -1820,7 +1820,7 @@ end = struct
             ; context = rule.context
             ; action
             } in
-          rules := Internal_rule.Id.Map.add !rules rule.id rule;
+          rules := Internal_rule.Id.Map.set !rules rule.id rule;
           if recursive then
             Dep.Set.parallel_iter_files deps ~f:proc_rule ~eval_pred
           else
@@ -1838,7 +1838,7 @@ end = struct
         Internal_rule.Id.Map.fold !rules ~init:Path.Build.Map.empty
           ~f:(fun (r : Rule.t) acc ->
             Path.Build.Set.fold r.targets ~init:acc ~f:(fun fn acc ->
-              Path.Build.Map.add acc fn r)) in
+              Path.Build.Map.set acc fn r)) in
       match
         Rule.Id.Top_closure.top_closure
           (rules_for_files rules goal)

--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -51,7 +51,7 @@ let load_sources ~dune_version ~dir ~files =
     | Recognized (obj, kind) ->
       let path = Path.Build.relative dir fn in
       C.Kind.Dict.update acc kind ~f:(fun v ->
-        String.Map.add v obj (C.Source.make ~kind ~path)
+        String.Map.set v obj (C.Source.make ~kind ~path)
       ))
 
 let make (d : _ Dir_with_dune.t)

--- a/src/context.ml
+++ b/src/context.ml
@@ -152,7 +152,7 @@ let opam_config_var ~env ~cache var =
       >>| function
       | Ok s ->
         let s = String.trim s in
-        Hashtbl.add cache var s;
+        Hashtbl.set cache var s;
         Some s
       | Error _ -> None
 
@@ -211,7 +211,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
   let opam_var_cache = Hashtbl.create 128 in
   (match kind with
    | Opam { root = Some root; _ } ->
-     Hashtbl.add opam_var_cache "root" root
+     Hashtbl.set opam_var_cache "root" root
    | _ -> ());
   let prog_not_found_in_path prog =
     Utils.program_not_found prog ~context:name ~loc:None

--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -71,7 +71,7 @@ let wrapped_compat ~modules ~wrapped_compat =
           in
           (* TODO this is wrong. The dependencies should be on the lib interface
              whenever it exists *)
-          Module.Obj_map.add acc compat (Build.return [wrapped]))
+          Module.Obj_map.set acc compat (Build.return [wrapped]))
   }
 
 module Ml_kind = struct

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -127,7 +127,7 @@ let build_mlds_map (d : _ Dir_with_dune.t) ~files =
   let mlds = Memo.lazy_ (fun () -> (
       String.Set.fold files ~init:String.Map.empty ~f:(fun fn acc ->
         match String.lsplit2 fn ~on:'.' with
-        | Some (s, "mld") -> String.Map.add acc s fn
+        | Some (s, "mld") -> String.Map.set acc s fn
         | _ -> acc)))
   in
   List.filter_map d.data ~f:(function
@@ -171,7 +171,7 @@ let build_coq_modules_map (d : _ Dir_with_dune.t) ~dir ~modules =
     | Coq.T coq ->
       let modules = Coq_module.Eval.eval coq.modules
         ~parse:(Coq_module.parse ~dir) ~standard:modules in
-      Lib_name.Map.add map (Dune_file.Coq.best_name coq) modules
+      Lib_name.Map.set map (Dune_file.Coq.best_name coq) modules
     | _ -> map)
 
 module rec Load : sig

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -448,7 +448,7 @@ module Preprocess_map = struct
   let pps t =
     Per_module.fold t ~init:Lib_name.Map.empty ~f:(fun pp acc ->
       List.fold_left (Preprocess.pps pp) ~init:acc ~f:(fun acc (loc, pp) ->
-        Lib_name.Map.add acc pp loc))
+        Lib_name.Map.set acc pp loc))
     |> Lib_name.Map.foldi ~init:[] ~f:(fun pp loc acc -> (loc, pp) :: acc)
 end
 
@@ -576,7 +576,7 @@ module Lib_deps = struct
     in
     let add kind name acc =
       match Lib_name.Map.find acc name with
-      | None -> Lib_name.Map.add acc name kind
+      | None -> Lib_name.Map.set acc name kind
       | Some kind' ->
         match kind, kind' with
         | Required, Required ->

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -1043,7 +1043,7 @@ module Decoder = struct
         | List (_, name_sexp :: values) -> begin
             match name_sexp with
             | Atom (_, A name) ->
-              Name.Map.add acc name
+              Name.Map.set acc name
                 { Fields.Unparsed.
                   values
                 ; entry = sexp

--- a/src/dune_project.ml
+++ b/src/dune_project.ml
@@ -349,7 +349,7 @@ module Extension = struct
         [ "name", Dyn.Encoder.string name ];
     let key = Univ_map.Key.create ~name arg_to_dyn in
     let ext = { syntax; stanzas; experimental; key } in
-    Hashtbl.add extensions name (Extension ext);
+    Hashtbl.add_exn extensions name (Extension ext);
     key
 
   let register_simple ?experimental syntax stanzas =

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -181,14 +181,14 @@ module Resolved_forms = struct
     }
 
   let add_lib_dep acc lib kind =
-    acc.lib_deps <- Lib_name.Map.add acc.lib_deps lib kind
+    acc.lib_deps <- Lib_name.Map.set acc.lib_deps lib kind
 
   let add_fail acc fail =
     acc.failures <- fail :: acc.failures;
     None
 
   let add_ddep acc ~key dep =
-    acc.ddeps <- String.Map.add acc.ddeps key dep;
+    acc.ddeps <- String.Map.set acc.ddeps key dep;
     None
 end
 

--- a/src/file_tree.ml
+++ b/src/file_tree.ml
@@ -309,7 +309,7 @@ let load ?(warn_when_seeing_jbuild_file=true) path ~ancestor_vcs =
                 dirs_visited
               else
                 match File.Map.find dirs_visited file with
-                | None -> File.Map.add dirs_visited file path
+                | None -> File.Map.set dirs_visited file path
                 | Some first_path ->
                   die "Path %s has already been scanned. \
                        Cannot scan it again through symlink %s"
@@ -319,7 +319,7 @@ let load ?(warn_when_seeing_jbuild_file=true) path ~ancestor_vcs =
             match
               walk path ~dirs_visited ~project ~data_only ~vcs
             with
-            | Ok dir -> String.Map.add acc fn dir
+            | Ok dir -> String.Map.set acc fn dir
             | Error _ -> acc)
       in
       { Dir. files; sub_dirs; dune_file })

--- a/src/findlib.ml
+++ b/src/findlib.ml
@@ -375,7 +375,7 @@ end = struct
       let dir, res =
         parse_package db ~meta_file ~name:full_name ~parent_dir:dir ~vars
       in
-      Hashtbl.add db.packages full_name res;
+      Hashtbl.set db.packages full_name res;
       List.iter meta.subs ~f:(fun (meta : Meta.Simplified.t) ->
         let full_name =
           match meta.name with
@@ -420,12 +420,12 @@ let find_and_acknowledge_package t ~fq_name =
   in
   match loop t.paths with
   | None ->
-    Hashtbl.add t.packages root_name (Error Not_found)
+    Hashtbl.set t.packages root_name (Error Not_found)
   | Some (Findlib findlib_package) ->
     Meta_source.parse_and_acknowledge findlib_package t
   | Some (Dune pkg) ->
     List.iter pkg.libs ~f:(fun lib ->
-      Hashtbl.add t.packages (Dune_package.Lib.name lib) (Ok lib))
+      Hashtbl.set t.packages (Dune_package.Lib.name lib) (Ok lib))
 
 let find t name =
   match Hashtbl.find t.packages name with
@@ -436,7 +436,7 @@ let find t name =
     | Some x -> x
     | None ->
       let res = Error Unavailable_reason.Not_found in
-      Hashtbl.add t.packages name res;
+      Hashtbl.set t.packages name res;
       res
 
 let available t name = Result.is_ok (find t name)

--- a/src/gen_rules.ml
+++ b/src/gen_rules.ml
@@ -358,7 +358,7 @@ let gen ~contexts
   in
   let sctxs = Hashtbl.create 4 in
   List.iter contexts ~f:(fun c ->
-    Hashtbl.add sctxs c.Context.name (Fiber.Ivar.create ()));
+    Hashtbl.add_exn sctxs c.Context.name (Fiber.Ivar.create ()));
   let make_sctx (context : Context.t) : _ Fiber.t =
     let host () =
       match context.for_host with

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -124,7 +124,7 @@ let build_info_code cctx ~libs ~api_version =
       | Some var -> var
       | None ->
         let  var = gen_placeholder_var () in
-        placeholders := Path.Source.Map.add !placeholders p var;
+        placeholders := Path.Source.Map.set !placeholders p var;
         var
   in
   let version_of_package (p : Package.t) =

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -628,7 +628,7 @@ module Exec_sync = struct
         }
       in
       dep_node.dag_node <- lazy dag_node;
-      Table.add t.cache inp dep_node;
+      Table.set t.cache inp dep_node;
       add_rev_dep dag_node;
       compute t run inp dep_node
     | Some dep_node ->
@@ -708,7 +708,7 @@ module Exec_async = struct
         }
       in
       dep_node.dag_node <- lazy dag_node;
-      Table.add t.cache inp dep_node;
+      Table.set t.cache inp dep_node;
       add_rev_dep dag_node;
       compute t inp ivar dep_node
     | Some dep_node ->

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -220,7 +220,7 @@ let rec simplify t =
           | Set -> { rules with set_rules = rule :: rules.set_rules }
           | Add -> { rules with add_rules = rule :: rules.add_rules }
         in
-        { pkg with vars = String.Map.add pkg.vars rule.var rules })
+        { pkg with vars = String.Map.set pkg.vars rule.var rules })
 
 let parse_entries lb = Parse.entries lb 0 []
 

--- a/src/module.ml
+++ b/src/module.ml
@@ -446,5 +446,5 @@ module Name_map = struct
   let by_obj =
     Name.Map.fold ~init:Name.Map.empty ~f:(fun m acc ->
       let obj = real_unit_name m in
-      Name.Map.add acc obj m)
+      Name.Map.add_exn acc obj m)
 end

--- a/src/module.ml
+++ b/src/module.ml
@@ -438,7 +438,7 @@ module Name_map = struct
     |> Name.Map.of_list_exn
 
   let add t module_ =
-    Name.Map.add t (name module_) module_
+    Name.Map.set t (name module_) module_
 
   let pp fmt t =
     Fmt.ocaml_list Name.pp fmt (Name.Map.keys t)

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -36,7 +36,7 @@ let eval =
     match Module.Name.Map.find all_modules name with
     | Some m -> Ok m
     | None ->
-      fake_modules := Module.Name.Map.add !fake_modules name loc;
+      fake_modules := Module.Name.Map.set !fake_modules name loc;
       Error name
   in
   fun ~loc ~fake_modules ~all_modules ~standard osl ->
@@ -78,7 +78,7 @@ let find_errors ~modules ~intf_only ~virtual_modules ~private_modules
       ~init:(Module.Name.Map.map modules ~f:snd)
       ~f:(fun acc map ->
         Module.Name.Map.foldi map ~init:acc ~f:(fun name (_loc, m) acc ->
-          Module.Name.Map.add acc name m))
+          Module.Name.Map.set acc name m))
   in
   let errors =
     Module.Name.Map.foldi all ~init:[] ~f:(fun module_name module_ acc ->

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -156,7 +156,7 @@ let rules_generic cctx ~modules =
        let per_module =
          Module.Name.Map.fold modules ~init:Module.Obj_map.empty
            ~f:(fun m acc ->
-             Module.Obj_map.add acc m (deps_of cctx ~ml_kind m))
+             Module.Obj_map.set acc m (deps_of cctx ~ml_kind m))
        in
        Dep_graph.make ~dir:(CC.dir cctx) ~per_module)
 
@@ -180,6 +180,6 @@ let graph_of_remote_lib ~obj_dir ~modules =
     let per_module =
       Module.Name.Map.fold modules ~init:Module.Obj_map.empty
         ~f:(fun m acc ->
-          Module.Obj_map.add acc m (deps_of ~ml_kind m))
+          Module.Obj_map.set acc m (deps_of ~ml_kind m))
     in
     Dep_graph.make ~dir ~per_module)

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -570,7 +570,7 @@ let setup_package_odoc_rules_def =
            add_rule sctx
              (Build.write_file gen_mld
                 (default_index ~pkg entry_modules));
-           String.Map.add mlds "index" gen_mld in
+           String.Map.set mlds "index" gen_mld in
        let odocs = List.map (String.Map.values mlds) ~f:(fun mld ->
          compile_mld sctx
            (Mld.create mld)

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -283,7 +283,7 @@ module Map = struct
         Bindings.fold bindings ~init:String.Map.empty ~f:(fun x acc ->
           match x with
           | Unnamed _ -> acc
-          | Named (s, _) -> String.Map.add acc s (No_info Var.Named_local))
+          | Named (s, _) -> String.Map.set acc s (No_info Var.Named_local))
     ; macros = String.Map.empty
     }
 

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -63,7 +63,7 @@ end = struct
     let y = Digest.string (Marshal.to_string x []) in
     match Hashtbl.find reverse_table y with
     | None ->
-      Hashtbl.add reverse_table y x;
+      Hashtbl.set reverse_table y x;
       y
     | Some x' ->
       if x = x' then

--- a/src/response_file.ml
+++ b/src/response_file.ml
@@ -10,4 +10,4 @@ let get ~prog =
   Option.value (Hashtbl.find registry prog) ~default:Not_supported
 
 let set ~prog t =
-  Hashtbl.add registry prog t
+  Hashtbl.set registry prog t

--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -356,7 +356,7 @@ end = struct
     let add job =
       match Hashtbl.find table job.pid with
       | None ->
-        Hashtbl.add table job.pid (Running job);
+        Hashtbl.set table job.pid (Running job);
         incr running_count;
         if !running_count = 1 then Condition.signal something_is_running_cv
       | Some (Zombie status) ->
@@ -368,7 +368,7 @@ end = struct
     let remove ~pid status =
       match Hashtbl.find table pid with
       | None ->
-        Hashtbl.add table pid (Zombie status)
+        Hashtbl.set table pid (Zombie status)
       | Some (Running job) ->
         decr running_count;
         Hashtbl.remove table pid;

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -60,7 +60,7 @@ let of_unix arr =
 let initial = make (of_unix (Unix.environment ()))
 
 let add t ~var ~value =
-  make (Map.add t.vars var value)
+  make (Map.set t.vars var value)
 
 let remove t ~var =
   make (Map.remove t.vars var)
@@ -86,7 +86,7 @@ let update t ~var ~f =
   make (Map.update t.vars var ~f)
 
 let of_string_map m =
-  make (String.Map.foldi ~init:Map.empty ~f:(fun k v acc -> Map.add acc k v) m)
+  make (String.Map.foldi ~init:Map.empty ~f:(fun k v acc -> Map.set acc k v) m)
 
 let iter t =
   Map.iteri t.vars

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -63,6 +63,11 @@ module Make(H : Hashable.S) = struct
     match find t key with
     | None -> set t key data
     | Some _ -> Code_error.raise "Hastbl.add_exn: key already exists" []
+
+  let add t key data =
+    match find t key with
+    | None -> set t key data; Ok ()
+    | Some p -> Result.Error p
 end
 
 open MoreLabels.Hashtbl
@@ -93,6 +98,11 @@ let add_exn t key data =
   match find t key with
   | None -> set t key data
   | Some _ -> Code_error.raise "Hastbl.add_exn: key already exists" []
+
+let add t key data =
+  match find t key with
+  | None -> set t key data; Ok ()
+  | Some p -> Error p
 
 let foldi t ~init ~f = fold  t ~init ~f:(fun ~key ~data acc -> f key data acc)
 let fold  t ~init ~f = foldi t ~init ~f:(fun _ x -> f x)

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -66,7 +66,7 @@ module Make(H : Hashable.S) = struct
 
   let add t key data =
     match find t key with
-    | None -> set t key data; Ok ()
+    | None -> set t key data; Result.Ok ()
     | Some p -> Result.Error p
 end
 
@@ -101,7 +101,7 @@ let add_exn t key data =
 
 let add t key data =
   match find t key with
-  | None -> set t key data; Ok ()
+  | None -> set t key data; Result.Ok ()
   | Some p -> Error p
 
 let foldi t ~init ~f = fold  t ~init ~f:(fun ~key ~data acc -> f key data acc)

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -26,14 +26,14 @@ module Make(H : Hashable.S) = struct
   include struct
     let find = find_opt
     let find_exn t key = Option.value_exn (find_opt t key)
-    let add t key data = add t ~key ~data
+    let set t key data = add t ~key ~data
 
     let find_or_add t key ~f =
       match find t key with
       | Some x -> x
       | None ->
         let x = f key in
-        add t key x;
+        set t key x;
         x
 
     let foldi t ~init ~f =
@@ -47,7 +47,7 @@ module Make(H : Hashable.S) = struct
       | [] -> Result.Ok h
       | (k, v) :: xs ->
         begin match find h k with
-        | None -> add h k v; loop xs
+        | None -> set h k v; loop xs
         | Some v' -> Error (k, v', v)
         end
     in
@@ -58,6 +58,11 @@ module Make(H : Hashable.S) = struct
     | Result.Ok h -> h
     | Error (_, _, _) ->
       Code_error.raise "Hashtbl.of_list_exn duplicate keys" []
+
+  let add_exn t key data =
+    match find t key with
+    | None -> set t key data
+    | Some _ -> Code_error.raise "Hastbl.add_exn: key already exists" []
 end
 
 open MoreLabels.Hashtbl
@@ -66,7 +71,6 @@ type nonrec ('a, 'b) t = ('a, 'b) t
 
 let hash = hash
 let create = create
-let add = add
 let replace = replace
 let length = length
 let remove = remove
@@ -75,15 +79,20 @@ let reset = reset
 
 let find = find_opt
 
-let add t key data = add t ~key ~data
+let set t key data = add t ~key ~data
 
 let find_or_add t key ~f =
   match find t key with
   | Some x -> x
   | None ->
     let x = f key in
-    add t key x;
+    set t key x;
     x
+
+let add_exn t key data =
+  match find t key with
+  | None -> set t key data
+  | Some _ -> Code_error.raise "Hastbl.add_exn: key already exists" []
 
 let foldi t ~init ~f = fold  t ~init ~f:(fun ~key ~data acc -> f key data acc)
 let fold  t ~init ~f = foldi t ~init ~f:(fun _ x -> f x)
@@ -101,6 +110,6 @@ let to_dyn (type key) f g t =
     end)
   in
   let m =
-    foldi t ~init:M.empty ~f:(fun key data acc -> M.add acc key data)
+    foldi t ~init:M.empty ~f:(fun key data acc -> M.set acc key data)
   in
   M.to_dyn g m

--- a/src/stdune/hashtbl.mli
+++ b/src/stdune/hashtbl.mli
@@ -18,7 +18,8 @@ val iter : ('a, 'b) t -> f:(key:'a -> data:'b -> unit) -> unit
 
 val replace : ('a, 'b) t -> key:'a -> data:'b -> unit
 
-val add : ('a, 'b) t -> 'a -> 'b -> unit
+val add_exn : ('a, 'b) t -> 'a -> 'b -> unit
+val set : ('a, 'b) t -> 'a -> 'b -> unit
 
 val find : ('a, 'b) t -> 'a -> 'b option
 val find_exn : ('a, 'b) t -> 'a -> 'b

--- a/src/stdune/hashtbl.mli
+++ b/src/stdune/hashtbl.mli
@@ -18,6 +18,8 @@ val iter : ('a, 'b) t -> f:(key:'a -> data:'b -> unit) -> unit
 
 val replace : ('a, 'b) t -> key:'a -> data:'b -> unit
 
+val add : ('a, 'b) t -> 'a -> 'b -> (unit, 'b) Result.t
+
 val add_exn : ('a, 'b) t -> 'a -> 'b -> unit
 val set : ('a, 'b) t -> 'a -> 'b -> unit
 

--- a/src/stdune/hashtbl_intf.ml
+++ b/src/stdune/hashtbl_intf.ml
@@ -4,6 +4,7 @@ module type S = sig
   val set : 'a t -> key -> 'a -> unit
 
   val add_exn : 'a t -> key -> 'a -> unit
+  val add : 'a t -> key -> 'a -> (unit, 'a) Result.t
 
   val find : 'a t -> key -> 'a option
   val find_exn : 'a t -> key -> 'a

--- a/src/stdune/hashtbl_intf.ml
+++ b/src/stdune/hashtbl_intf.ml
@@ -1,7 +1,9 @@
 module type S = sig
   include MoreLabels.Hashtbl.S
 
-  val add : 'a t -> key -> 'a -> unit
+  val set : 'a t -> key -> 'a -> unit
+
+  val add_exn : 'a t -> key -> 'a -> unit
 
   val find : 'a t -> key -> 'a option
   val find_exn : 'a t -> key -> 'a

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -42,13 +42,13 @@ module Make(Key : Key) : S with type key = Key.t = struct
   let find key t = find_opt t key
 
   let mem t k = mem k t
-  let add t k v = add ~key:k ~data:v t
+  let set t k v = add ~key:k ~data:v t
   let update t k ~f = update ~key:k ~f t
   let remove t k = remove k t
 
   let add_multi t key x =
     let l = Option.value (find t key) ~default:[] in
-    add t key (x :: l)
+    set t key (x :: l)
 
   let merge a b ~f = merge a b ~f
   let union a b ~f = union a b ~f
@@ -79,7 +79,7 @@ module Make(Key : Key) : S with type key = Key.t = struct
       | [] -> Result.Ok acc
       | (k, v) :: l ->
         match find acc k with
-        | None       -> loop (add acc k v) l
+        | None       -> loop (set acc k v) l
         | Some v_old -> Error (k, v_old, v)
     in
     fun l -> loop empty l
@@ -90,7 +90,7 @@ module Make(Key : Key) : S with type key = Key.t = struct
       | x :: l ->
         let k, v = f x in
         if not (mem acc k) then
-          loop f (add acc k v) l
+          loop f (set acc k v) l
         else
           Error k
     in
@@ -124,19 +124,19 @@ module Make(Key : Key) : S with type key = Key.t = struct
   let of_list_reduce l ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->
       match find acc key with
-      | None   -> add acc key data
-      | Some x -> add acc key (f x data))
+      | None   -> set acc key data
+      | Some x -> set acc key (f x data))
 
   let of_list_fold l ~init ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->
       let x = Option.value (find acc key) ~default:init in
-      add acc key (f x data))
+      set acc key (f x data))
 
   let of_list_reducei l ~f =
     List.fold_left l ~init:empty ~f:(fun acc (key, data) ->
       match find acc key with
-      | None   -> add acc key data
-      | Some x -> add acc key (f key x data))
+      | None   -> set acc key data
+      | Some x -> set acc key (f key x data))
 
   let of_list_multi l =
     List.fold_left (List.rev l) ~init:empty ~f:(fun acc (key, data) ->

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -44,6 +44,11 @@ module Make(Key : Key) : S with type key = Key.t = struct
   let mem t k = mem k t
   let set t k v = add ~key:k ~data:v t
   let update t k ~f = update ~key:k ~f t
+  let add_exn t key v = update t key ~f:(function
+    | None -> Some v
+    | Some _ ->
+      Code_error.raise "Map.add_exn: key already exists"
+        ["key", Key.to_dyn key])
   let remove t k = remove k t
 
   let add_multi t key x =

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -49,6 +49,17 @@ module Make(Key : Key) : S with type key = Key.t = struct
     | Some _ ->
       Code_error.raise "Map.add_exn: key already exists"
         ["key", Key.to_dyn key])
+
+  let add (type e) (t : e t) key v =
+    let module M = struct exception Found of e end in
+    try
+      Ok (
+        update t key ~f:(function
+          | None -> Some v
+          | Some e -> raise_notrace (M.Found e)))
+    with M.Found e ->
+      Error e
+
   let remove t k = remove k t
 
   let add_multi t key x =

--- a/src/stdune/map.ml
+++ b/src/stdune/map.ml
@@ -53,7 +53,7 @@ module Make(Key : Key) : S with type key = Key.t = struct
   let add (type e) (t : e t) key v =
     let module M = struct exception Found of e end in
     try
-      Ok (
+      Result.Ok (
         update t key ~f:(function
           | None -> Some v
           | Some e -> raise_notrace (M.Found e)))
@@ -112,7 +112,7 @@ module Make(Key : Key) : S with type key = Key.t = struct
     in
     fun l ~f ->
       match loop f empty l with
-      | Ok _ as x -> x
+      | Result.Ok _ as x -> x
       | Error k ->
         match
           List.filter l ~f:(fun x ->
@@ -125,14 +125,14 @@ module Make(Key : Key) : S with type key = Key.t = struct
 
   let of_list_map_exn t ~f =
     match of_list_map t ~f with
-    | Ok x -> x
+    | Result.Ok x -> x
     | Error (key, _, _) ->
       Code_error.raise "Map.of_list_map_exn"
         ["key", Key.to_dyn key]
 
   let of_list_exn l =
     match of_list l with
-    | Ok    x -> x
+    | Result.Ok    x -> x
     | Error (key, _, _) ->
       Code_error.raise "Map.of_list_exn"
         ["key", Key.to_dyn key]

--- a/src/stdune/map_intf.ml
+++ b/src/stdune/map_intf.ml
@@ -9,7 +9,7 @@ module type S = sig
   val empty     : 'a t
   val is_empty  : 'a t -> bool
   val mem       : 'a t -> key -> bool
-  val add       : 'a t -> key -> 'a -> 'a t
+  val set       : 'a t -> key -> 'a -> 'a t
   val update    : 'a t -> key -> f:('a option -> 'a option) -> 'a t
   val singleton : key -> 'a -> 'a t
   val remove    : 'a t -> key -> 'a t

--- a/src/stdune/map_intf.ml
+++ b/src/stdune/map_intf.ml
@@ -10,6 +10,7 @@ module type S = sig
   val is_empty  : 'a t -> bool
   val mem       : 'a t -> key -> bool
   val set       : 'a t -> key -> 'a -> 'a t
+  val add       : 'a t -> key -> 'a -> ('a t, 'a) Result.t
   val add_exn   : 'a t -> key -> 'a -> 'a t
   val update    : 'a t -> key -> f:('a option -> 'a option) -> 'a t
   val singleton : key -> 'a -> 'a t

--- a/src/stdune/map_intf.ml
+++ b/src/stdune/map_intf.ml
@@ -10,6 +10,7 @@ module type S = sig
   val is_empty  : 'a t -> bool
   val mem       : 'a t -> key -> bool
   val set       : 'a t -> key -> 'a -> 'a t
+  val add_exn   : 'a t -> key -> 'a -> 'a t
   val update    : 'a t -> key -> f:('a option -> 'a option) -> 'a t
   val singleton : key -> 'a -> 'a t
   val remove    : 'a t -> key -> 'a t

--- a/src/stdune/result/result.ml
+++ b/src/stdune/result/result.ml
@@ -8,4 +8,6 @@ include struct
     | Error of 'error
 end
 
-type ('a, 'error) result = ('a, 'error) t
+type ('a, 'error) result = ('a, 'error) t =
+  | Ok of 'a
+  | Error of 'error

--- a/src/stdune/result/result.mli
+++ b/src/stdune/result/result.mli
@@ -14,4 +14,6 @@ include sig
     | Error of 'error
 end
 
-type ('a, 'error) result = ('a, 'error) t
+type ('a, 'error) result = ('a, 'error) t =
+  | Ok of 'a
+  | Error of 'error

--- a/src/stdune/set.ml
+++ b/src/stdune/set.ml
@@ -80,5 +80,5 @@ module Make(Key : Map_intf.Key)(M : Map_intf.S with type key = Key.t)
   let of_keys =
     M.foldi ~init:empty ~f:(fun k _ acc -> add acc k)
   let to_map =
-    fold ~init:M.empty ~f:(fun k acc -> M.add acc k ())
+    fold ~init:M.empty ~f:(fun k acc -> M.set acc k ())
 end

--- a/src/stdune/table.ml
+++ b/src/stdune/table.ml
@@ -23,8 +23,14 @@ let create (type key) (type value)
 let find (type input) (type output) ((module T) : (input, output) t) x =
   T.H.find T.value x
 
-let add (type input) (type output) ((module T) : (input, output) t) k v =
-  T.H.add T.value k v
+let set (type input) (type output) ((module T) : (input, output) t) k v =
+  T.H.set T.value k v
+
+let add_exn t k v =
+  match find t k with
+  | None -> set t k v
+  | Some _ ->
+    Code_error.raise "Table.add_exn: key already exists" []
 
 let clear (type input) (type output) ((module T) : (input, output) t) =
   T.H.clear T.value

--- a/src/stdune/table.ml
+++ b/src/stdune/table.ml
@@ -34,7 +34,7 @@ let add_exn t k v =
 
 let add t k v =
   match find t k with
-  | None -> set t k v; Ok ()
+  | None -> set t k v; Result.Ok ()
   | Some e -> Error e
 
 let clear (type input) (type output) ((module T) : (input, output) t) =

--- a/src/stdune/table.ml
+++ b/src/stdune/table.ml
@@ -32,5 +32,10 @@ let add_exn t k v =
   | Some _ ->
     Code_error.raise "Table.add_exn: key already exists" []
 
+let add t k v =
+  match find t k with
+  | None -> set t k v; Ok ()
+  | Some e -> Error e
+
 let clear (type input) (type output) ((module T) : (input, output) t) =
   T.H.clear T.value

--- a/src/stdune/table.mli
+++ b/src/stdune/table.mli
@@ -19,6 +19,8 @@ val create : (module Key with type t = 'k) -> int -> ('k, 'v) t
 
 val find : ('k, 'v) t -> 'k -> 'v option
 
-val add : ('k, 'v) t -> 'k -> 'v -> unit
+val set : ('k, 'v) t -> 'k -> 'v -> unit
+
+val add_exn : ('k, 'v) t -> 'k -> 'v -> unit
 
 val clear : ('k, 'v) t -> unit

--- a/src/stdune/table.mli
+++ b/src/stdune/table.mli
@@ -23,4 +23,6 @@ val set : ('k, 'v) t -> 'k -> 'v -> unit
 
 val add_exn : ('k, 'v) t -> 'k -> 'v -> unit
 
+val add : ('k, 'v) t -> 'k -> 'v -> (unit, 'v) Result.t
+
 val clear : ('k, 'v) t -> unit

--- a/src/stdune/univ_map.ml
+++ b/src/stdune/univ_map.ml
@@ -49,7 +49,7 @@ let is_empty = Int.Map.is_empty
 let add (type a) t (key : a Key.t) x =
   let (module M) = key in
   let data = Binding.T (key, x) in
-  Int.Map.add t M.id data
+  Int.Map.set t M.id data
 
 let mem t key = Int.Map.mem t (Key.id key)
 

--- a/src/sub_system_info.ml
+++ b/src/sub_system_info.ml
@@ -34,7 +34,7 @@ module Register(M : S) : sig end = struct
         field_o name_s parse >>= function
         | None   -> p acc
         | Some x ->
-          let acc = Sub_system_name.Map.add acc name (T x) in
+          let acc = Sub_system_name.Map.set acc name (T x) in
           p acc)
 end
 

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -117,7 +117,7 @@ end = struct
         let config = get_env_stanza t ~dir in
         Env_node.make ~dir ~scope ~config ~inherit_from:(Some inherit_from)
       in
-      Hashtbl.add t.env dir node;
+      Hashtbl.set t.env dir node;
       node
 
   let get t ~dir =
@@ -719,7 +719,7 @@ module Action = struct
       >>^ (fun (vals, deps_written_by_user) ->
         let dynamic_expansions =
           List.fold_left2 ddeps vals ~init:String.Map.empty
-            ~f:(fun acc (var, _) value -> String.Map.add acc var value)
+            ~f:(fun acc (var, _) value -> String.Map.set acc var value)
         in
         let unresolved =
           let expander =

--- a/src/upgrader.ml
+++ b/src/upgrader.ml
@@ -17,7 +17,7 @@ let scan_included_files path =
       in
       let comments = Dune_lang.Cst.extract_comments csts in
       let sexps = List.filter_map csts ~f:Dune_lang.Cst.abstract in
-      files := Path.Source.Map.add !files path (sexps, comments);
+      files := Path.Source.Map.set !files path (sexps, comments);
       List.iter sexps ~f:(function
         | Dune_lang.Ast.List
             (_,

--- a/src/versioned_file.ml
+++ b/src/versioned_file.ml
@@ -45,7 +45,7 @@ module Make(Data : sig type t end) = struct
       if Hashtbl.mem langs name then
         Code_error.raise "Versioned_file.Lang.register: already registered"
           [ "name", Dyn.Encoder.string name ];
-      Hashtbl.add langs name { syntax; data }
+      Hashtbl.add_exn langs name { syntax; data }
 
     let parse first_line : Instance.t =
       let { Dune_lexer.

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -152,7 +152,7 @@ let external_dep_graph sctx ~impl_cm_kind ~impl_obj_dir ~vlib_modules =
               Build.memoize "ocamlobjinfo" @@
               read >>^ deps_from_objinfo ~for_module:m
           in
-          Module.Obj_map.add acc m deps)))
+          Module.Obj_map.set acc m deps)))
 
 let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope =
   Option.map lib.implements ~f:begin fun (loc, implements) ->


### PR DESCRIPTION
As discussed on slack:

* The old `add` is now `set
* There's now a safe `add` called `add_exn`. It raises if we try to overwrite a key.

We should create an `add` as well, but I'm not sure of the type signature. Perhaps:

```ocaml
module Duplicate : sig
  type 'a t
  val make : 'a -> 'a t
  val get : 'a t -> 'a
end
val add : t -> key -> 'a -> (t, 'a Duplicate.t) Result.t
```

We can't use base because it uses polymorphic variants. And I'd like something that works with result. This makes it much more usable with the new syntax.