### PR TITLE
In dune utop, stop selecting all local implementations 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@
 1.11.0 (unreleased)
 -------------------
 
+- Don't select all local implementations in `dune utop`. Instead, let the
+  default implementation selection do its job. (#2327, fixes #2323, @TheLortex,
+  review by @rgrinberg)
+
 - Don't reserve the `Ppx` toplevel module name for ppx rewriters (#2242, @diml)
 
 - Redesign of the library variant feature according to the #2134 proposal. The

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1449,6 +1449,14 @@
     (diff? run.t run.t.corrected)))))
 
 (alias
+ (name utop-default-implementation)
+ (deps (package dune) (source_tree test-cases/utop-default-implementation))
+ (action
+  (chdir
+   test-cases/utop-default-implementation
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name variants)
  (deps (package dune) (source_tree test-cases/variants))
  (action
@@ -1716,6 +1724,7 @@
   (alias use-meta)
   (alias utop)
   (alias utop-default)
+  (alias utop-default-implementation)
   (alias variants)
   (alias variants-external-declaration)
   (alias variants-external-declaration-conflict)
@@ -1880,6 +1889,7 @@
   (alias transitive-deps-mode)
   (alias unreadable-src)
   (alias upgrader)
+  (alias utop-default-implementation)
   (alias variants)
   (alias variants-external-declaration)
   (alias variants-external-declaration-conflict)

--- a/test/blackbox-tests/test-cases/utop-default-implementation/dune-project
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.7)
+(using library_variants 0.1)

--- a/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl-2/dune
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl-2/dune
@@ -1,0 +1,3 @@
+(library
+ (name forutop_impl_2)
+ (implements forutop))

--- a/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl-2/forutop.ml
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl-2/forutop.ml
@@ -1,0 +1,1 @@
+let run () = print_endline "shouldn't be selected"

--- a/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl/dune
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl/dune
@@ -1,0 +1,3 @@
+(library
+ (name forutop_impl)
+ (implements forutop))

--- a/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl/forutop.ml
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/forutop-impl/forutop.ml
@@ -1,0 +1,1 @@
+let run () = print_endline "selected by default impl"

--- a/test/blackbox-tests/test-cases/utop-default-implementation/forutop/dune
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/forutop/dune
@@ -1,0 +1,4 @@
+(library
+ (name forutop)
+ (virtual_modules forutop)
+ (default_implementation forutop_impl))

--- a/test/blackbox-tests/test-cases/utop-default-implementation/forutop/forutop.mli
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/forutop/forutop.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit

--- a/test/blackbox-tests/test-cases/utop-default-implementation/init_forutop.ml
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/init_forutop.ml
@@ -1,0 +1,1 @@
+Forutop.run ();;

--- a/test/blackbox-tests/test-cases/utop-default-implementation/run.t
+++ b/test/blackbox-tests/test-cases/utop-default-implementation/run.t
@@ -1,0 +1,2 @@
+  $ dune utop . init_forutop.ml
+  selected by default impl


### PR DESCRIPTION
This fixes https://github.com/ocaml/dune/issues/2323 by letting the virtual library algorithm choose an implementation.