### PR TITLE
Check user-written input of implementations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 1.11.0 (unreleased)
 -------------------
 
+- Check that selected implementations (either by variants or default
+  implementations) are indeed implementations. (#2328, @TheLortex, review by ?)
+
 - Don't reserve the `Ppx` toplevel module name for ppx rewriters (#2242, @diml)
 
 - Redesign of the library variant feature according to the #2134 proposal. The

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1491,6 +1491,16 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name variants-wrong-external-declaration)
+ (deps
+  (package dune)
+  (source_tree test-cases/variants-wrong-external-declaration))
+ (action
+  (chdir
+   test-cases/variants-wrong-external-declaration
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name vlib)
  (deps (package dune) (source_tree test-cases/vlib))
  (action
@@ -1504,6 +1514,14 @@
  (action
   (chdir
    test-cases/vlib-default-impl
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
+ (name vlib-wrong-default-impl)
+ (deps (package dune) (source_tree test-cases/vlib-wrong-default-impl))
+ (action
+  (chdir
+   test-cases/vlib-wrong-default-impl
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
@@ -1721,8 +1739,10 @@
   (alias variants-external-declaration-conflict)
   (alias variants-multi-project)
   (alias variants-only-package)
+  (alias variants-wrong-external-declaration)
   (alias vlib)
   (alias vlib-default-impl)
+  (alias vlib-wrong-default-impl)
   (alias windows-diff)
   (alias workspaces)
   (alias wrapped-false-main-module-name)
@@ -1885,8 +1905,10 @@
   (alias variants-external-declaration-conflict)
   (alias variants-multi-project)
   (alias variants-only-package)
+  (alias variants-wrong-external-declaration)
   (alias vlib)
   (alias vlib-default-impl)
+  (alias vlib-wrong-default-impl)
   (alias windows-diff)
   (alias workspaces)
   (alias wrapped-false-main-module-name)

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/exe/dune
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/exe/dune
@@ -1,0 +1,4 @@
+(executable
+ (name exe)
+ (libraries vlibfoo-ext)
+ (variants somevariant))

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/exe/dune-project
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/exe/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.10)
+(using library_variants 0.1)

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/exe/exe.ml
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/exe/exe.ml
@@ -1,0 +1,1 @@
+let () = Vlibfoo.implme ()

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj1/dune
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj1/dune
@@ -1,0 +1,10 @@
+(library
+ (name vlibfoo)
+ (public_name vlibfoo-ext)
+ (virtual_modules vlibfoo)
+)
+
+(external_variant
+  (virtual_library vlibfoo)
+  (variant somevariant)
+  (implementation not-an-implementation))

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj1/dune-project
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj1/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.10)
+(using library_variants 0.2)

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj1/vlibfoo.mli
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj1/vlibfoo.mli
@@ -1,0 +1,1 @@
+val implme : unit -> unit

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj2/bar.ml
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj2/bar.ml
@@ -1,0 +1,1 @@
+let implme () = print_endline "foobar"

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj2/dune
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj2/dune
@@ -1,0 +1,4 @@
+(library
+ (name not_an_implementation)
+ (public_name not-an-implementation)
+)

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj2/dune-project
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/prj2/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.10)
+(using library_variants 0.1)

--- a/test/blackbox-tests/test-cases/variants-wrong-external-declaration/run.t
+++ b/test/blackbox-tests/test-cases/variants-wrong-external-declaration/run.t
@@ -1,0 +1,7 @@
+External declaration of an implementation, when the given library is not an
+implementation, should fail.
+
+  $ dune build exe/exe.exe
+  Error: "not-an-implementation" is not an implementation of "vlibfoo-ext".
+  -> required by executable exe in exe/dune:2
+  [1]

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/dune-project
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.10)
+(using library_variants 0.1)

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/exe/dune
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/exe/dune
@@ -1,0 +1,9 @@
+(executable
+ (name exe)
+ (libraries vlibfoo)
+)
+
+(alias
+ (name default)
+ (action
+  (run ./exe.exe)))

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/exe/exe.ml
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/exe/exe.ml
@@ -1,0 +1,1 @@
+let () = Vlibfoo.implme ()

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/implfoo/bar.ml
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/implfoo/bar.ml
@@ -1,0 +1,1 @@
+let implme () = ()

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/implfoo/dune
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/implfoo/dune
@@ -1,0 +1,3 @@
+(library
+ (name not_an_implem)
+)

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/run.t
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/run.t
@@ -1,0 +1,7 @@
+Check that dune makes a proper error if the default implementation of a virtual
+library is not actually an implementation of the virtual library.
+
+  $ dune build @default
+  Error: "not_an_implem" is not an implementation of "vlibfoo".
+  -> required by executable exe in exe/dune:2
+  [1]

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/vlibfoo/dune
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/vlibfoo/dune
@@ -1,0 +1,5 @@
+(library
+ (name vlibfoo)
+ (virtual_modules vlibfoo)
+ (default_implementation not_an_implem)
+)

--- a/test/blackbox-tests/test-cases/vlib-wrong-default-impl/vlibfoo/vlibfoo.mli
+++ b/test/blackbox-tests/test-cases/vlib-wrong-default-impl/vlibfoo/vlibfoo.mli
@@ -1,0 +1,1 @@
+val implme : unit -> unit


### PR DESCRIPTION
The user can use the `default_implementation ...` option or use the `external_variant` stanza but no check was done to make sure the resolved library is indeed an implementation of the virtual library. 

This is related to https://github.com/ocaml/dune/issues/2323