### PR TITLE
More precise action arguments

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -43,6 +43,7 @@ end
 module type Ast = Action_intf.Ast
   with type program = Prog.t
   with type path    = Path.t
+  with type target  = Path.Build.t
   with type string  = String.t
 module rec Ast : Ast = Ast
 
@@ -52,19 +53,22 @@ module String_with_sexp = struct
   let encode = Dune_lang.Encoder.string
 end
 
-include Action_ast.Make(Prog)(Dpath)(String_with_sexp)(Ast)
+include Action_ast.Make(Prog)(Dpath)(Dpath.Build)(String_with_sexp)(Ast)
 type program = Prog.t
 type path = Path.t
+type target = Path.Build.t
 type string = String.t
 
 module For_shell = struct
   module type Ast = Action_intf.Ast
     with type program = string
     with type path    = string
+    with type target  = string
     with type string  = string
   module rec Ast : Ast = Ast
 
   include Action_ast.Make
+      (String_with_sexp)
       (String_with_sexp)
       (String_with_sexp)
       (String_with_sexp)
@@ -74,23 +78,24 @@ end
 module Relativise = Action_mapper.Make(Ast)(For_shell.Ast)
 
 let for_shell t =
-  let rec loop t ~dir ~f_program ~f_string ~f_path =
+  let rec loop t ~dir ~f_program ~f_string ~f_path ~f_target =
     match t with
     | Symlink (src, dst) ->
       let src =
-        match Path.parent dst with
+        match Path.Build.parent dst with
         | None -> Path.to_string src
-        | Some from -> Path.reach ~from src
+        | Some from -> Path.reach ~from:(Path.build from) src
       in
-      let dst = Path.reach ~from:dir dst in
+      let dst = Path.reach ~from:dir (Path.build dst) in
       For_shell.Symlink (src, dst)
     | t ->
-      Relativise.map_one_step loop t ~dir ~f_program ~f_string ~f_path
+      Relativise.map_one_step loop t ~dir ~f_program ~f_string ~f_path ~f_target
   in
   loop t
     ~dir:Path.root
     ~f_string:(fun ~dir:_ x -> x)
     ~f_path:(fun ~dir x -> Path.reach x ~from:dir)
+    ~f_target:(fun ~dir x -> Path.reach (Path.build x) ~from:dir)
     ~f_program:(fun ~dir x ->
       match x with
       | Ok p -> Path.reach p ~from:dir
@@ -112,6 +117,7 @@ module Unresolved = struct
   module type Uast = Action_intf.Ast
     with type program = Program.t
     with type path    = Path.t
+    with type target  = Path.Build.t
     with type string  = String.t
   module rec Uast : Uast = Uast
   include Uast
@@ -122,6 +128,7 @@ module Unresolved = struct
     map t
       ~dir:Path.root
       ~f_path:(fun ~dir:_ x -> x)
+      ~f_target:(fun ~dir:_ x -> x)
       ~f_string:(fun ~dir:_ x -> x)
       ~f_program:(fun ~dir:_ -> function
         | This p -> Ok p
@@ -169,13 +176,16 @@ let symlink_managed_paths sandboxed deps ~eval_pred =
     Path.Set.fold (Dep.Set.paths deps ~eval_pred)
       ~init:[]
       ~f:(fun path acc ->
-        if Path.is_managed path then
-          Symlink (path, sandboxed path)::acc
-        else
-          acc
-      )
+        match Path.as_in_build_dir path with
+        | None -> acc
+        | Some p -> Symlink (path, sandboxed p) :: acc)
   in
   Progn steps
+
+let maybe_sandbox_path f p =
+  match Path.as_in_build_dir p with
+  | None -> p
+  | Some p -> Path.build (f p)
 
 let sandbox t ~sandboxed ~deps ~targets ~eval_pred : t =
   Progn
@@ -183,9 +193,10 @@ let sandbox t ~sandboxed ~deps ~targets ~eval_pred : t =
     ; map t
         ~dir:Path.root
         ~f_string:(fun ~dir:_ x -> x)
-        ~f_path:(fun ~dir:_ p -> sandboxed p)
-        ~f_program:(fun ~dir:_ x -> Result.map x ~f:sandboxed)
+        ~f_path:(fun ~dir:_ p -> maybe_sandbox_path sandboxed p)
+        ~f_target:(fun ~dir:_ -> sandboxed)
+        ~f_program:(fun ~dir:_ ->
+          Result.map ~f:(maybe_sandbox_path sandboxed))
     ; Progn (List.filter_map targets ~f:(fun path ->
-        let path = Path.build path in
         Some (Rename (sandboxed path, path))))
     ]

--- a/src/action.ml
+++ b/src/action.ml
@@ -51,6 +51,8 @@ module String_with_sexp = struct
   type t = string
   let decode = Dune_lang.Decoder.string
   let encode = Dune_lang.Encoder.string
+  let is_dev_null s =
+    Path.equal (Path.of_string s) Config.dev_null
 end
 
 include Action_ast.Make(Prog)(Dpath)(Dpath.Build)(String_with_sexp)(Ast)

--- a/src/action.ml
+++ b/src/action.ml
@@ -173,11 +173,12 @@ let chdirs =
 
 let symlink_managed_paths sandboxed deps ~eval_pred =
   let steps =
-    Path.Set.fold (Dep.Set.paths deps ~eval_pred)
-      ~init:[]
+    Path.Set.fold (Dep.Set.paths deps ~eval_pred) ~init:[]
       ~f:(fun path acc ->
         match Path.as_in_build_dir path with
-        | None -> acc
+        | None ->
+          assert (not (Path.is_in_source_tree path));
+          acc
         | Some p -> Symlink (path, sandboxed p) :: acc)
   in
   Progn steps

--- a/src/action.mli
+++ b/src/action.mli
@@ -14,13 +14,13 @@ module Prog : sig
       ; loc     : Loc.t option
       }
 
-      val create
-        :  ?hint:string
-        -> context:string
-        -> program:string
-        -> loc:Loc.t option
-        -> unit
-        -> t
+    val create
+      :  ?hint:string
+      -> context:string
+      -> program:string
+      -> loc:Loc.t option
+      -> unit
+      -> t
 
     val raise : t -> _
   end

--- a/src/action.mli
+++ b/src/action.mli
@@ -31,11 +31,13 @@ end
 include Action_intf.Ast
   with type program = Prog.t
   with type path    = Path.t
+  with type target  = Path.Build.t
   with type string  = string
 
 include Action_intf.Helpers
   with type program := Prog.t
   with type path    := Path.t
+  with type target  := Path.Build.t
   with type string  := string
   with type t       := t
 
@@ -45,6 +47,7 @@ module For_shell : sig
   include Action_intf.Ast
     with type program := string
     with type path    := string
+    with type target  := string
     with type string  := string
 
   val encode : t Dune_lang.Encoder.t
@@ -71,6 +74,7 @@ module Unresolved : sig
   include Action_intf.Ast
     with type program := Program.t
     with type path    := Path.t
+    with type target  := Path.Build.t
     with type string  := string
 
   val resolve : t -> f:(Loc.t option -> string -> Path.t) -> action
@@ -79,7 +83,7 @@ end with type action := t
 (** Return a sandboxed version of an action *)
 val sandbox
   :  t
-  -> sandboxed:(Path.t -> Path.t)
+  -> sandboxed:(Path.Build.t -> Path.Build.t)
   -> deps:Dep.Set.t
   -> targets:Path.Build.t list
   -> eval_pred:Dep.eval_pred

--- a/src/action_ast.ml
+++ b/src/action_ast.ml
@@ -16,16 +16,20 @@ end
 module Make
     (Program : Dune_lang.Conv)
     (Path    : Dune_lang.Conv)
+    (Target    : Dune_lang.Conv)
     (String  : Dune_lang.Conv)
     (Ast : Action_intf.Ast
      with type program := Program.t
      with type path    := Path.t
+     with type target  := Target.t
      with type string  := String.t) =
 struct
   include Ast
 
   let decode =
-    let path = Path.decode and string = String.decode in
+    let path = Path.decode in
+    let string = String.decode in
+    let target = Target.decode in
     Dune_lang.Decoder.fix (fun t ->
       sum
         [ "run",
@@ -45,17 +49,17 @@ struct
            in
            Setenv (k, v, t))
         ; "with-stdout-to",
-          (let+ fn = path
+          (let+ fn = target
            and+ t = t
            in
            Redirect (Stdout, fn, t))
         ; "with-stderr-to",
-          (let+ fn = path
+          (let+ fn = target
            and+ t = t
            in
            Redirect (Stderr, fn, t))
         ; "with-outputs-to",
-          (let+ fn = path
+          (let+ fn = target
            and+ t = t
            in
            Redirect (Outputs, fn, t))
@@ -76,17 +80,17 @@ struct
           (path >>| fun x -> Cat x)
         ; "copy",
           (let+ src = path
-           and+ dst = path
+           and+ dst = target
            in
            Copy (src, dst))
         ; "copy#",
           (let+ src = path
-           and+ dst = path
+           and+ dst = target
            in
            Copy_and_add_line_directive (src, dst))
         ; "copy-and-add-line-directive",
           (let+ src = path
-           and+ dst = path
+           and+ dst = target
            in
            Copy_and_add_line_directive (src, dst))
         ; "system",
@@ -94,7 +98,7 @@ struct
         ; "bash",
           (string >>| fun cmd -> Bash cmd)
         ; "write-file",
-          (let+ fn = path
+          (let+ fn = target
            and+ s = string
            in
            Write_file (fn, s))
@@ -114,6 +118,7 @@ struct
     let program = Program.encode in
     let string = String.encode in
     let path = Path.encode in
+    let target = Target.encode in
     function
     | Run (a, xs) ->
       List (atom "run" :: program a :: List.map xs ~f:string)
@@ -121,7 +126,7 @@ struct
     | Setenv (k, v, r) -> List [atom "setenv" ; string k ; string v ; encode r]
     | Redirect (outputs, fn, r) ->
       List [ atom (sprintf "with-%s-to" (Outputs.to_string outputs))
-           ; path fn
+           ; target fn
            ; encode r
            ]
     | Ignore (outputs, r) ->
@@ -133,16 +138,16 @@ struct
       List (atom "echo" :: List.map xs ~f:string)
     | Cat x -> List [atom "cat"; path x]
     | Copy (x, y) ->
-      List [atom "copy"; path x; path y]
+      List [atom "copy"; path x; target y]
     | Symlink (x, y) ->
-      List [atom "symlink"; path x; path y]
+      List [atom "symlink"; path x; target y]
     | Copy_and_add_line_directive (x, y) ->
-      List [atom "copy#"; path x; path y]
+      List [atom "copy#"; path x; target y]
     | System x -> List [atom "system"; string x]
     | Bash   x -> List [atom "bash"; string x]
-    | Write_file (x, y) -> List [atom "write-file"; path x; string y]
-    | Rename (x, y) -> List [atom "rename"; path x; path y]
-    | Remove_tree x -> List [atom "remove-tree"; path x]
+    | Write_file (x, y) -> List [atom "write-file"; target x; string y]
+    | Rename (x, y) -> List [atom "rename"; target x; target y]
+    | Remove_tree x -> List [atom "remove-tree"; target x]
     | Mkdir x       -> List [atom "mkdir"; path x]
     | Digest_files paths -> List [atom "digest-files";
                                   List (List.map paths ~f:path)]
@@ -153,12 +158,12 @@ struct
       List [atom "diff"; path file1; path file2]
     | Diff { optional = true; file1; file2; mode = _ } ->
       List [atom "diff?"; path file1; path file2]
-    | Merge_files_into (srcs, extras, target) ->
+    | Merge_files_into (srcs, extras, into) ->
       List
         [ atom "merge-files-into"
         ; List (List.map ~f:path srcs)
         ; List (List.map ~f:string extras)
-        ; path target
+        ; target into
         ]
 
   let run prog args = Run (prog, args)

--- a/src/action_dune_lang.ml
+++ b/src/action_dune_lang.ml
@@ -5,13 +5,19 @@ type string = String_with_vars.t
 type path = String_with_vars.t
 type target = String_with_vars.t
 
+module String_with_vars = struct
+  include String_with_vars
+  let is_dev_null = String_with_vars.is_var ~name:"null"
+end
+
 module type Uast = Action_intf.Ast
   with type program = String_with_vars.t
   with type path    = String_with_vars.t
   with type target  = String_with_vars.t
   with type string  = String_with_vars.t
 module rec Uast : Uast = Uast
-include Action_ast.Make(String_with_vars)(String_with_vars)(String_with_vars)(String_with_vars)(Uast)
+include Action_ast.Make(String_with_vars)(String_with_vars)(String_with_vars)
+    (String_with_vars)(Uast)
 
 module Mapper = Action_mapper.Make(Uast)(Uast)
 

--- a/src/action_dune_lang.ml
+++ b/src/action_dune_lang.ml
@@ -3,20 +3,22 @@ open! Stdune
 type program = String_with_vars.t
 type string = String_with_vars.t
 type path = String_with_vars.t
+type target = String_with_vars.t
 
 module type Uast = Action_intf.Ast
   with type program = String_with_vars.t
   with type path    = String_with_vars.t
+  with type target  = String_with_vars.t
   with type string  = String_with_vars.t
 module rec Uast : Uast = Uast
-include Action_ast.Make(String_with_vars)(String_with_vars)(String_with_vars)(Uast)
+include Action_ast.Make(String_with_vars)(String_with_vars)(String_with_vars)(String_with_vars)(Uast)
 
 module Mapper = Action_mapper.Make(Uast)(Uast)
 
 let upgrade_to_dune =
   let id ~dir:_ p = p in
   let dir = String_with_vars.make_text Loc.none "" in
-  Mapper.map ~dir ~f_program:id ~f_path:id
+  Mapper.map ~dir ~f_program:id ~f_path:id ~f_target:id
     ~f_string:(fun ~dir:_ sw ->
       String_with_vars.upgrade_to_dune sw ~allow_first_dep_var:false)
 
@@ -26,8 +28,9 @@ let remove_locs =
   let dir = String_with_vars.make_text Loc.none "" in
   let f_program ~dir:_ = String_with_vars.remove_locs in
   let f_path ~dir:_ = String_with_vars.remove_locs in
+  let f_target ~dir:_ = String_with_vars.remove_locs in
   let f_string ~dir:_ = String_with_vars.remove_locs in
-  Mapper.map ~dir ~f_program ~f_path ~f_string
+  Mapper.map ~dir ~f_program ~f_path ~f_target ~f_string
 
 let compare_no_locs t1 t2 = compare (remove_locs t1) (remove_locs t2)
 

--- a/src/action_dune_lang.mli
+++ b/src/action_dune_lang.mli
@@ -1,21 +1,23 @@
 open Stdune
 
 (* This module is to be used in Dune_file. It should not introduce any
-    dependencies unless they're already dependencies of Dune_file *)
+   dependencies unless they're already dependencies of Dune_file *)
 include Action_intf.Ast
-  with type program := String_with_vars.t and
-  type string := String_with_vars.t and
-  type path := String_with_vars.t
+  with type program := String_with_vars.t
+   and type string := String_with_vars.t
+   and type path := String_with_vars.t
+   and type target := String_with_vars.t
 
 include Dune_lang.Conv with type t := t
 
 val encode_and_upgrade : t Dune_lang.Encoder.t
 
 include Action_intf.Helpers
-  with type t := t and
-  type program = String_with_vars.t and
-  type string = String_with_vars.t and
-  type path = String_with_vars.t
+  with type t := t
+   and type program = String_with_vars.t
+   and type string = String_with_vars.t
+   and type path = String_with_vars.t
+   and type target = String_with_vars.t
 
 val compare_no_locs : t -> t -> Ordering.t
 

--- a/src/action_intf.ml
+++ b/src/action_intf.ml
@@ -10,57 +10,61 @@ end
 module type Ast = sig
   type program
   type path
+  type target
   type string
 
   type t =
     | Run            of program * string list
     | Chdir          of path * t
     | Setenv         of string * string * t
-    | Redirect       of Outputs.t * path * t
+    (* It's not possible to use a build path here since jbuild supports
+       redirecting to /dev/null. In dune files this is replaced with %{null} *)
+    | Redirect       of Outputs.t * target * t
     | Ignore         of Outputs.t * t
     | Progn          of t list
     | Echo           of string list
     | Cat            of path
-    | Copy           of path * path
-    | Symlink        of path * path
-    | Copy_and_add_line_directive of path * path
+    | Copy           of path * target
+    | Symlink        of path * target
+    | Copy_and_add_line_directive of path * target
     | System         of string
     | Bash           of string
-    | Write_file     of path * string
-    | Rename         of path * path
-    | Remove_tree    of path
+    | Write_file     of target * string
+    | Rename         of target * target
+    | Remove_tree    of target
     | Mkdir          of path
     | Digest_files   of path list
     | Diff           of path Diff.t
-    | Merge_files_into of path list * string list * path
+    | Merge_files_into of path list * string list * target
 end
 
 module type Helpers = sig
   type program
   type path
+  type target
   type string
   type t
 
   val run : program -> string list -> t
   val chdir : path -> t -> t
   val setenv : string -> string -> t -> t
-  val with_stdout_to : path -> t -> t
-  val with_stderr_to : path -> t -> t
-  val with_outputs_to : path -> t -> t
+  val with_stdout_to : target -> t -> t
+  val with_stderr_to : target -> t -> t
+  val with_outputs_to : target -> t -> t
   val ignore_stdout : t -> t
   val ignore_stderr : t -> t
   val ignore_outputs : t -> t
   val progn : t list -> t
   val echo : string list -> t
   val cat : path -> t
-  val copy : path -> path -> t
-  val symlink : path -> path -> t
-  val copy_and_add_line_directive : path -> path -> t
+  val copy : path -> target -> t
+  val symlink : path -> target -> t
+  val copy_and_add_line_directive : path -> target -> t
   val system : string -> t
   val bash : string -> t
-  val write_file : path -> string -> t
-  val rename : path -> path -> t
-  val remove_tree : path -> t
+  val write_file : target -> string -> t
+  val rename : target -> target -> t
+  val remove_tree : target -> t
   val mkdir : path -> t
   val digest_files : path list -> t
   val diff : ?optional:bool -> ?mode:Diff.Mode.t -> path -> path -> t

--- a/src/action_mapper.ml
+++ b/src/action_mapper.ml
@@ -5,38 +5,40 @@ module Make
     (Dst : Action_intf.Ast)
 = struct
   type map
-    =  Src.t
+    = Src.t
     -> dir:Src.path
     -> f_program:(dir:Src.path -> Src.program -> Dst.program)
     -> f_string:(dir:Src.path -> Src.string -> Dst.string)
     -> f_path:(dir:Src.path -> Src.path -> Dst.path)
+    -> f_target:(dir:Src.path -> Src.target -> Dst.target)
     -> Dst.t
 
-  let map_one_step f (t : Src.t) ~dir ~f_program ~f_string ~f_path : Dst.t =
+  let map_one_step f (t : Src.t) ~dir ~f_program ~f_string ~f_path ~f_target : Dst.t =
+    let f t ~dir = f t ~dir ~f_program ~f_string ~f_path ~f_target in
     match t with
     | Run (prog, args) ->
       Run (f_program ~dir prog, List.map args ~f:(f_string ~dir))
     | Chdir (fn, t) ->
-      Chdir (f_path ~dir fn, f t ~dir:fn ~f_program ~f_string ~f_path)
+      Chdir (f_path ~dir fn, f t ~dir:fn)
     | Setenv (var, value, t) ->
-      Setenv (f_string ~dir var, f_string ~dir value, f t ~dir ~f_program ~f_string ~f_path)
+      Setenv (f_string ~dir var, f_string ~dir value, f t ~dir)
     | Redirect (outputs, fn, t) ->
-      Redirect (outputs, f_path ~dir fn, f t ~dir ~f_program ~f_string ~f_path)
+      Redirect (outputs, f_target ~dir fn, f t ~dir)
     | Ignore (outputs, t) ->
-      Ignore (outputs, f t ~dir ~f_program ~f_string ~f_path)
-    | Progn l -> Progn (List.map l ~f:(fun t -> f t ~dir ~f_program ~f_string ~f_path))
+      Ignore (outputs, f t ~dir)
+    | Progn l -> Progn (List.map l ~f:(fun t -> f t ~dir))
     | Echo xs -> Echo (List.map xs ~f:(f_string ~dir))
     | Cat x -> Cat (f_path ~dir x)
-    | Copy (x, y) -> Copy (f_path ~dir x, f_path ~dir y)
+    | Copy (x, y) -> Copy (f_path ~dir x, f_target ~dir y)
     | Symlink (x, y) ->
-      Symlink (f_path ~dir x, f_path ~dir y)
+      Symlink (f_path ~dir x, f_target ~dir y)
     | Copy_and_add_line_directive (x, y) ->
-      Copy_and_add_line_directive (f_path ~dir x, f_path ~dir y)
+      Copy_and_add_line_directive (f_path ~dir x, f_target ~dir y)
     | System x -> System (f_string ~dir x)
     | Bash x -> Bash (f_string ~dir x)
-    | Write_file (x, y) -> Write_file (f_path ~dir x, f_string ~dir y)
-    | Rename (x, y) -> Rename (f_path ~dir x, f_path ~dir y)
-    | Remove_tree x -> Remove_tree (f_path ~dir x)
+    | Write_file (x, y) -> Write_file (f_target ~dir x, f_string ~dir y)
+    | Rename (x, y) -> Rename (f_target ~dir x, f_target ~dir y)
+    | Remove_tree x -> Remove_tree (f_target ~dir x)
     | Mkdir x -> Mkdir (f_path ~dir x)
     | Digest_files x -> Digest_files (List.map x ~f:(f_path ~dir))
     | Diff ({ file1; file2 ; _ } as diff) ->
@@ -48,8 +50,8 @@ module Make
       Merge_files_into
         (List.map sources ~f:(f_path ~dir),
          List.map extras ~f:(f_string ~dir),
-         f_path ~dir target)
+         f_target ~dir target)
 
-  let rec map t ~dir ~f_program ~f_string ~f_path =
-    map_one_step map t ~dir ~f_program ~f_string ~f_path
+  let rec map t ~dir ~f_program ~f_string ~f_path ~f_target =
+    map_one_step map t ~dir ~f_program ~f_string ~f_path ~f_target
 end

--- a/src/action_mapper.mli
+++ b/src/action_mapper.mli
@@ -2,12 +2,14 @@
 
 module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) : sig
   type map
-    =  Src.t
+    = Src.t
     -> dir:Src.path
     -> f_program:(dir:Src.path -> Src.program -> Dst.program)
     -> f_string:(dir:Src.path -> Src.string -> Dst.string)
     -> f_path:(dir:Src.path -> Src.path -> Dst.path)
+    -> f_target:(dir:Src.path -> Src.target -> Dst.target)
     -> Dst.t
+
   val map_one_step : map -> map
   val map : map
 end

--- a/src/action_unexpanded.ml
+++ b/src/action_unexpanded.ml
@@ -35,7 +35,7 @@ let as_in_build_dir ~loc p =
   | None ->
     User_error.raise ?loc
       [ Pp.textf
-          "target %s cannot be in build dir"
+          "target %s is outside the build directory. This is not allowed."
           (Path.to_string_maybe_quoted p)
       ]
 

--- a/src/action_unexpanded.mli
+++ b/src/action_unexpanded.mli
@@ -29,7 +29,7 @@ module Infer : sig
   module Outcome : sig
     type t =
       { deps    : Path.Set.t
-      ; targets : Path.Set.t
+      ; targets : Path.Build.Set.t
       }
   end
 

--- a/src/build.ml
+++ b/src/build.ml
@@ -183,31 +183,30 @@ let action_dyn ?dir ~targets () =
     Action.Chdir (dir, action)
 
 let write_file fn s =
-  action ~targets:[fn] (Write_file ((Path.build fn), s))
+  action ~targets:[fn] (Write_file (fn, s))
 
 let write_file_dyn fn =
   Targets (Path.Build.Set.singleton fn)
   >>^ fun s ->
-  Action.Write_file (Path.build fn, s)
+  Action.Write_file (fn, s)
 
 let copy ~src ~dst =
   path src >>>
-  action ~targets:[dst] (Copy (src, Path.build dst))
+  action ~targets:[dst] (Copy (src, dst))
 
 let copy_and_add_line_directive ~src ~dst =
   path src >>>
   action ~targets:[dst]
-    (Copy_and_add_line_directive (src, Path.build dst))
+    (Copy_and_add_line_directive (src, dst))
 
 let symlink ~src ~dst =
   path src >>>
-  action ~targets:[dst] (Symlink (src, Path.build dst))
+  action ~targets:[dst] (Symlink (src, dst))
 
 let create_file fn =
-  action ~targets:[fn] (Redirect (Stdout, Path.build fn, Progn []))
+  action ~targets:[fn] (Redirect (Stdout, fn, Progn []))
 
 let remove_tree dir =
-  let dir = Path.build dir in
   arr (fun _ -> Action.Remove_tree dir)
 
 let mkdir dir =
@@ -221,7 +220,7 @@ let progn ts =
 let merge_files_dyn ~target =
   dyn_paths (arr fst)
   >>^ (fun (sources, extras) ->
-    Action.Merge_files_into (sources, extras, Path.build target))
+    Action.Merge_files_into (sources, extras, target))
   >>> action_dyn ~targets:[target] ()
 
 (* Analysis *)

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -9,6 +9,7 @@ let () = Hooks.End_of_build.always Memo.reset
 module Fs : sig
   val mkdir_p : Path.Build.t -> unit
   val mkdir_p_or_check_exists : loc:Loc.t option -> Path.t -> unit
+  val assert_exists : loc:Loc.t option -> Path.t -> unit
 end = struct
   let mkdir_p_def =
     Memo.create
@@ -841,7 +842,7 @@ end = struct
                  Build.dyn_path_set (Build.arr Fn.id)
                  >>^ (fun dyn_deps ->
                    let deps = Path.Set.union deps dyn_deps in
-                   Action.with_stdout_to (Path.build path)
+                   Action.with_stdout_to path
                      (Action.digest_files (Path.Set.to_list deps)))
                  >>>
                  Build.action_dyn () ~targets:[path])
@@ -1480,12 +1481,16 @@ end = struct
             action
           | Some sandbox_dir ->
             Path.rm_rf (Path.build sandbox_dir);
-            let sandboxed path = Path.sandbox_managed_paths ~sandbox_dir path in
+            let sandboxed path : Path.Build.t =
+              Path.Build.append_local sandbox_dir
+                (Path.Build.local path)
+            in
             Dep.Set.dirs deps
             |> Path.Set.iter ~f:(fun p ->
-              sandboxed p
-              |> Fs.mkdir_p_or_check_exists ~loc);
-            Fs.mkdir_p_or_check_exists ~loc (sandboxed (Path.build dir));
+              match Path.as_in_build_dir p with
+               | None -> Fs.assert_exists ~loc p
+               | Some p -> Fs.mkdir_p (sandboxed p));
+            Fs.mkdir_p (sandboxed dir);
             Action.sandbox action
               ~sandboxed
               ~deps

--- a/src/command.ml
+++ b/src/command.ml
@@ -100,7 +100,7 @@ let run ~dir ?stdout_to prog args =
       let action =
         match stdout_to with
         | None      -> action
-        | Some path -> Redirect (Stdout, Path.build path, action)
+        | Some path -> Redirect (Stdout, path, action)
       in
       Action.Chdir (dir, action)
     )

--- a/src/dpath.ml
+++ b/src/dpath.ml
@@ -113,3 +113,15 @@ module Local = struct
     in
     Path.relative ~error_loc dir path
 end
+
+module Build = struct
+  type t = Path.Build.t
+  let encode p =
+    let str = Path.reach ~from:Path.build_dir (Path.build p) in
+    Dune_lang.atom_or_quoted_string str
+
+  let decode =
+    let open Dune_lang.Decoder in
+    let+ base = string in
+    Path.Build.(relative root) base
+end

--- a/src/dpath.ml
+++ b/src/dpath.ml
@@ -124,4 +124,6 @@ module Build = struct
     let open Dune_lang.Decoder in
     let+ base = string in
     Path.Build.(relative root) base
+
+  let is_dev_null = Fn.const false
 end

--- a/src/dpath.mli
+++ b/src/dpath.mli
@@ -27,4 +27,7 @@ module Local : sig
   val decode : dir:Path.t -> Path.t Dune_lang.Decoder.t
 end
 
-module Build : Dune_lang.Conv with type t = Path.Build.t
+module Build : sig
+  include Dune_lang.Conv with type t = Path.Build.t
+  val is_dev_null : t -> bool
+end

--- a/src/dpath.mli
+++ b/src/dpath.mli
@@ -26,3 +26,5 @@ module Local : sig
 
   val decode : dir:Path.t -> Path.t Dune_lang.Decoder.t
 end
+
+module Build : Dune_lang.Conv with type t = Path.Build.t

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -199,7 +199,7 @@ end
 module Targets = struct
   type static =
     {
-      targets : Path.t list;
+      targets : Path.Build.t list;
       multiplicity : Dune_file.Rule.Targets.Multiplicity.t;
     }
 
@@ -396,8 +396,11 @@ let expand_and_record_deps acc ~(dir : Path.Build.t) ~read_package ~dep_kind
         User_error.raise ~loc [
           Pp.textf  "You cannot use %s in %s."
             (String_with_vars.Var.describe pform) context ]
-      | Static { targets = l; multiplicity = declared_multiplicity } ->
-        let value = Value.L.dirs l (* XXX hack to signal no dep *) in
+      | Static { targets; multiplicity = declared_multiplicity } ->
+        let value =
+          List.map ~f:Path.build targets
+          |> Value.L.dirs (* XXX hack to signal no dep *)
+        in
         check_multiplicity
           ~pform ~declaration:declared_multiplicity ~use:multiplicity;
         Some value

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -86,7 +86,7 @@ module Targets : sig
 
   type static =
     {
-      targets : Path.t list;
+      targets : Path.Build.t list;
       multiplicity : Dune_file.Rule.Targets.Multiplicity.t;
     }
 

--- a/src/inline_tests.ml
+++ b/src/inline_tests.ml
@@ -277,9 +277,7 @@ include Sub_system.Register_end_point(
                  ~dep_kind:Required
                  ~targets:(Forbidden "inline test generators")
                  ~targets_dir:dir)))
-        >>^ (fun actions ->
-          Action.with_stdout_to (Path.build target)
-            (Action.progn actions))
+        >>^ (fun actions -> Action.with_stdout_to target (Action.progn actions))
         >>>
         Build.action_dyn ~targets:[target] ());
 

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -212,7 +212,7 @@ let ocamlc_i ?(flags=[]) ~dep_graphs cctx (m : Module.t) ~output =
   let modules = Compilation_context.modules cctx in
   SC.add_rule sctx ?sandbox ~dir
     (Build.S.seq cm_deps
-       (Build.S.map ~f:(fun act -> Action.with_stdout_to (Path.build output) act)
+       (Build.S.map ~f:(Action.with_stdout_to output)
           (Command.run (Ok ctx.ocamlc) ~dir:(Path.build ctx.build_dir)
              [ Command.Args.dyn ocaml_flags
              ; A "-I"; Path (Path.build (Obj_dir.byte_dir obj_dir))

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -655,7 +655,7 @@ let action_for_pp sctx ~dep_kind ~loc ~expander ~action ~src ~target =
   >>^ fun action ->
   match target with
   | None -> action
-  | Some dst -> Action.with_stdout_to (Path.build dst) action
+  | Some dst -> Action.with_stdout_to dst action
 
 (* Generate rules for the dialect modules in [modules] and return a
    a new module with only OCaml sources *)

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -34,14 +34,14 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
             | String s ->
               if Filename.dirname s <> Filename.current_dir_name then
                 not_in_dir ~error_loc s;
-              Path.relative ~error_loc (Path.build dir) s
+              Path.Build.relative ~error_loc dir s
             | Path p ->
               if Option.compare Path.compare
                    (Path.parent p) (Some (Path.build dir))
                  <> Eq
               then
                 not_in_dir ~error_loc (Path.to_string p);
-              p
+              Path.as_in_build_dir_exn p
             | Dir p ->
               not_in_dir ~error_loc (Path.to_string p)
         in

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1028,19 +1028,6 @@ let drop_optional_build_context_src_exn t =
          "drop_optional_build_context_src_exn called on a build directory itself" [])
   | In_source_tree p -> p
 
-let local_src   = Local.of_string "src"
-let local_build = Local.of_string "build"
-
-let sandbox_managed_paths =
-  let append_local ~sandbox_dir local_x p =
-    in_build_dir (Build.append_local sandbox_dir (Local.append local_x p))
-  in
-  fun ~(sandbox_dir : Build.t) t ->
-    match t with
-    | External _ -> t
-    | In_source_tree p -> append_local ~sandbox_dir local_src p
-    | In_build_dir   p -> append_local ~sandbox_dir local_build p
-
 let split_first_component t =
   match kind t, is_root t with
   | In_source_dir t, false ->

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -231,10 +231,6 @@ val drop_optional_build_context : t -> t
     otherwise fail. *)
 val drop_optional_build_context_src_exn : t -> Source.t
 
-(** Transform managed paths so that they are descedant of
-    [sandbox_dir]. *)
-val sandbox_managed_paths : sandbox_dir:Build.t -> t -> t
-
 val explode : t -> string list option
 val explode_exn : t -> string list
 

--- a/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
+++ b/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
@@ -2,11 +2,6 @@ All builtin variables are lower cased in Dune:
 
   $ dune runtest --root dune-lower
   Entering directory 'dune-lower'
-  File "dune", line 3, characters 25-32:
-  3 |  (action (with-stdout-to %{null} (echo %{make}))))
-                               ^^^^^^^
-  Error: target /dev/null is outside the build directory. This is not allowed.
-  [1]
 
   $ dune runtest --root dune-upper
   Entering directory 'dune-upper'
@@ -25,11 +20,6 @@ jbuild files retain the the old names:
   Warning: jbuild files are deprecated, please convert this file to a dune file
   instead.
   Note: You can use "dune upgrade" to convert your project to dune.
-  File "jbuild", line 3, characters 26-33:
-  3 |   (action (with-stdout-to ${null} (echo ${MAKE})))))
-                                ^^^^^^^
-  Error: target /dev/null is outside the build directory. This is not allowed.
-  [1]
 
   $ dune runtest --root jbuilder-upper
   Entering directory 'jbuilder-upper'
@@ -37,8 +27,3 @@ jbuild files retain the the old names:
   Warning: jbuild files are deprecated, please convert this file to a dune file
   instead.
   Note: You can use "dune upgrade" to convert your project to dune.
-  File "jbuild", line 3, characters 26-33:
-  3 |   (action (with-stdout-to ${null} (echo ${MAKE})))))
-                                ^^^^^^^
-  Error: target /dev/null is outside the build directory. This is not allowed.
-  [1]

--- a/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
+++ b/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
@@ -5,7 +5,7 @@ All builtin variables are lower cased in Dune:
   File "dune", line 3, characters 25-32:
   3 |  (action (with-stdout-to %{null} (echo %{make}))))
                                ^^^^^^^
-  Error: target /dev/null cannot be in build dir
+  Error: target /dev/null is outside the build directory. This is not allowed.
   [1]
 
   $ dune runtest --root dune-upper
@@ -28,7 +28,7 @@ jbuild files retain the the old names:
   File "jbuild", line 3, characters 26-33:
   3 |   (action (with-stdout-to ${null} (echo ${MAKE})))))
                                 ^^^^^^^
-  Error: target /dev/null cannot be in build dir
+  Error: target /dev/null is outside the build directory. This is not allowed.
   [1]
 
   $ dune runtest --root jbuilder-upper
@@ -40,5 +40,5 @@ jbuild files retain the the old names:
   File "jbuild", line 3, characters 26-33:
   3 |   (action (with-stdout-to ${null} (echo ${MAKE})))))
                                 ^^^^^^^
-  Error: target /dev/null cannot be in build dir
+  Error: target /dev/null is outside the build directory. This is not allowed.
   [1]

--- a/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
+++ b/test/blackbox-tests/test-cases/dune-jbuild-var-case/run.t
@@ -2,6 +2,11 @@ All builtin variables are lower cased in Dune:
 
   $ dune runtest --root dune-lower
   Entering directory 'dune-lower'
+  File "dune", line 3, characters 25-32:
+  3 |  (action (with-stdout-to %{null} (echo %{make}))))
+                               ^^^^^^^
+  Error: target /dev/null cannot be in build dir
+  [1]
 
   $ dune runtest --root dune-upper
   Entering directory 'dune-upper'
@@ -20,6 +25,11 @@ jbuild files retain the the old names:
   Warning: jbuild files are deprecated, please convert this file to a dune file
   instead.
   Note: You can use "dune upgrade" to convert your project to dune.
+  File "jbuild", line 3, characters 26-33:
+  3 |   (action (with-stdout-to ${null} (echo ${MAKE})))))
+                                ^^^^^^^
+  Error: target /dev/null cannot be in build dir
+  [1]
 
   $ dune runtest --root jbuilder-upper
   Entering directory 'jbuilder-upper'
@@ -27,3 +37,8 @@ jbuild files retain the the old names:
   Warning: jbuild files are deprecated, please convert this file to a dune file
   instead.
   Note: You can use "dune upgrade" to convert your project to dune.
+  File "jbuild", line 3, characters 26-33:
+  3 |   (action (with-stdout-to ${null} (echo ${MAKE})))))
+                                ^^^^^^^
+  Error: target /dev/null cannot be in build dir
+  [1]

--- a/test/blackbox-tests/test-cases/null-dep/run.t
+++ b/test/blackbox-tests/test-cases/null-dep/run.t
@@ -2,5 +2,5 @@
   File "dune", line 3, characters 25-32:
   3 |  (action (with-stdout-to %{null} (echo "hello world"))))
                                ^^^^^^^
-  Error: target /dev/null cannot be in build dir
+  Error: target /dev/null is outside the build directory. This is not allowed.
   [1]

--- a/test/blackbox-tests/test-cases/null-dep/run.t
+++ b/test/blackbox-tests/test-cases/null-dep/run.t
@@ -1,6 +1,1 @@
   $ dune runtest --debug-dependency-path
-  File "dune", line 3, characters 25-32:
-  3 |  (action (with-stdout-to %{null} (echo "hello world"))))
-                               ^^^^^^^
-  Error: target /dev/null is outside the build directory. This is not allowed.
-  [1]

--- a/test/blackbox-tests/test-cases/null-dep/run.t
+++ b/test/blackbox-tests/test-cases/null-dep/run.t
@@ -1,1 +1,6 @@
   $ dune runtest --debug-dependency-path
+  File "dune", line 3, characters 25-32:
+  3 |  (action (with-stdout-to %{null} (echo "hello world"))))
+                               ^^^^^^^
+  Error: target /dev/null cannot be in build dir
+  [1]

--- a/test/blackbox-tests/test-cases/rule-target-external/run.t
+++ b/test/blackbox-tests/test-cases/rule-target-external/run.t
@@ -1,7 +1,7 @@
 rules with targets outside the build dir are dot allowed
   $ dune build @all
-  File "dune", line 1, characters 6-53:
+  File "dune", line 1, characters 22-31:
   1 | (rule (with-stdout-to /abs/path (system "echo toto")))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: target /abs/path is outside the build directory. This is not allowed.
+                            ^^^^^^^^^
+  Error: target /abs/path cannot be in build dir
   [1]

--- a/test/blackbox-tests/test-cases/rule-target-external/run.t
+++ b/test/blackbox-tests/test-cases/rule-target-external/run.t
@@ -3,5 +3,5 @@ rules with targets outside the build dir are dot allowed
   File "dune", line 1, characters 22-31:
   1 | (rule (with-stdout-to /abs/path (system "echo toto")))
                             ^^^^^^^^^
-  Error: target /abs/path cannot be in build dir
+  Error: target /abs/path is outside the build directory. This is not allowed.
   [1]

--- a/test/unit-tests/action.mlt
+++ b/test/unit-tests/action.mlt
@@ -8,32 +8,34 @@ open Action_unexpanded.Infer.Outcome;;
 Stdune.Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");;
 
 let p = Path.of_string;;
+let b = Path.Build.of_string;;
+let pb x = Path.build (Path.Build.of_string x);;
 let infer (a : Action.t) =
   let x = Action_unexpanded.Infer.infer a in
   (List.map (Path.Set.to_list x.deps) ~f:Path.to_string,
-   List.map (Path.Set.to_list x.targets) ~f:Path.to_string)
+   List.map (Path.Build.Set.to_list x.targets) ~f:Path.Build.to_string)
 [%%ignore]
 
-infer (Copy (p "a", p "b"));;
+infer (Copy (p "a", b "b"));;
 [%%expect{|
-- : string list * string list = (["a"], ["b"])
+- : string list * string list = (["a"], ["_build/b"])
 |}]
 
 infer (Progn
-         [ Copy (p "a", p "b")
-         ; Copy (p "b", p "c")
+         [ Copy (p "a", b "b")
+         ; Copy (pb "b", b "c")
          ]);;
 [%%expect{|
-- : string list * string list = (["a"], ["b"; "c"])
+- : string list * string list = (["a"], ["_build/b"; "_build/c"])
 |}]
 
 (* CR-someday jdimino: ideally "b" should be treated as a non-buildable targets. As long
    as [rename] is not available in the DSL given to user, we don't need to care about this
    too much. *)
 infer (Progn
-         [ Copy (p "a", p "b")
-         ; Rename (p "b", p "c")
+         [ Copy (p "a", b "b")
+         ; Rename (b "b", b "c")
          ]);;
 [%%expect{|
-- : string list * string list = (["a"], ["b"; "c"])
+- : string list * string list = (["a"], ["_build/b"; "_build/c"])
 |}]


### PR DESCRIPTION
Use `target = Path.Build.t` for the arguments of actions that modify things. Only allowing to modify build paths is allowed

Simplify sandboxing. Source paths and external paths are never sandboxed, so just make the sandboxing work on build paths.