### PR TITLE
[WIP] Make build_info_data module private

### DIFF
--- a/otherlibs/build-info/src/dune
+++ b/otherlibs/build-info/src/dune
@@ -3,6 +3,7 @@
  (public_name dune-build-info)
  (wrapped false)
  (modules_without_implementation build_info_data)
+ (private_modules build_info_data)
  (special_builtin_support
   (build_info
    (data_module build_info_data)


### PR DESCRIPTION
This module should not be used directly by the user

This doesn't actually work yet:

```
make test
./_boot/default/bin/main/main_dune.exe runtest
File "bin/main/.main_dune.eobjs/build_info_data.ml-gen", line 1:
Error: Could not find the .cmi file for interface
       bin/main/.main_dune.eobjs/build_info_data.ml-gen.
File "bin/main/.main_jbuilder.eobjs/build_info_data.ml-gen", line 1:
Error: Could not find the .cmi file for interface
       bin/main/.main_jbuilder.eobjs/build_info_data.ml-gen.
make: *** [test] Error 1
```