### PR TITLE
Add support for wrapped code gen modules

### DIFF
--- a/otherlibs/build-info/src/dune
+++ b/otherlibs/build-info/src/dune
@@ -1,7 +1,6 @@
 (library
  (name build_info)
  (public_name dune-build-info)
- (wrapped false)
  (modules_without_implementation build_info_data)
  (special_builtin_support
   (build_info

--- a/src/link_time_code_gen.ml
+++ b/src/link_time_code_gen.ml
@@ -8,16 +8,28 @@ type t =
   ; force_linkall : bool
   }
 
-let generate_and_compile_module cctx ~precompiled_cmi ~name:basename ~code
-      ~requires =
+let generate_and_compile_module cctx ~precompiled_cmi ~name:basename
+      ~lib ~code ~requires =
   let open Build.O in
   let sctx       = CC.super_context cctx in
   let obj_dir    = CC.obj_dir       cctx in
   let dir        = CC.dir           cctx in
   let name = Module.Name.of_string basename in
+  let wrapped = Result.ok_exn (Lib.wrapped lib) in
   let module_ =
     let src_dir = Path.build (Obj_dir.obj_dir obj_dir) in
-    Module.generated ~src_dir name
+    let gen_module = Module.generated ~src_dir name in
+    match wrapped with
+    | None -> gen_module
+    | Some (Yes_with_transition _) -> assert false
+    | Some (Simple false) -> gen_module
+    | Some (Simple true) ->
+      let main_module_name =
+        Lib.main_module_name lib
+        |> Result.ok_exn
+        |> Option.value_exn
+      in
+      Module.with_wrapper gen_module ~main_module_name
   in
   SC.add_rule ~dir sctx (
     let ml =
@@ -200,6 +212,7 @@ let handle_special_libs cctx =
             generate_and_compile_module
               cctx
               ~name:data_module
+              ~lib
               ~code:(Build.arr (fun () ->
                 build_info_code cctx ~libs:all_libs ~api_version))
               ~requires:(Ok [lib])
@@ -230,6 +243,7 @@ let handle_special_libs cctx =
           let module_ =
             generate_and_compile_module
               cctx
+              ~lib
               ~name:"findlib_initl"
               ~code:(Build.arr (fun () ->
                 findlib_init_code ~preds:Findlib.Package.preds ~libs:all_libs))


### PR DESCRIPTION
This allows us to wrap the build info library and maintain some encapsulation of the generated modules.

The way this is currently done is a bit hackish, let's wait for #2305 to be merged to fix this.