### PR TITLE
Fix closure calculation for dep graphs

### DIFF
--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -32,13 +32,7 @@ let top_closed t modules =
   |> Build.all
   >>^ fun per_module ->
   let per_module = Module.Obj_map.of_list_exn per_module in
-  match
-    Module.Name.Top_closure.top_closure modules
-      ~key:Module.name
-      ~deps:(fun m ->
-        Module.Obj_map.find per_module m
-        |> Option.value_exn)
-  with
+  match Module.Obj_map.top_closure per_module modules with
   | Ok modules -> modules
   | Error cycle ->
     die "dependency cycle between modules in %s:\n   %a"

--- a/src/module.ml
+++ b/src/module.ml
@@ -39,7 +39,6 @@ module Name = struct
     let to_dyn t = Dyn.Set (List.map ~f:(fun s -> Dyn.String s) (to_list t))
   end
   module Map = String.Map
-  module Top_closure = Top_closure.String
   module Infix = Comparator.Operators(T)
 
   let of_local_lib_name s =
@@ -315,7 +314,7 @@ module Obj_map = struct
 
   let top_closure t =
     Top_closure.String.top_closure
-      ~key:(fun m -> m.obj_name)
+      ~key:real_unit_name
       ~deps:(find_exn t)
 end
 

--- a/src/module.mli
+++ b/src/module.mli
@@ -27,10 +27,6 @@ module Name : sig
 
   module Map : Map.S with type key = t
 
-  module Top_closure : Top_closure.S
-    with type key := t
-     and type 'a monad := 'a Monad.Id.t
-
   module Infix : Comparator.OPS with type t = t
 
   val of_local_lib_name : Lib_name.Local.t -> t


### PR DESCRIPTION
Previously, we'd be using the module name to lookup the compilation
unit. However, the obj_map is keyed by the real units or "object names".