### PR TITLE
Remove the Ocamldep.generic functions

### DIFF
--- a/src/exe.ml
+++ b/src/exe.ml
@@ -194,10 +194,9 @@ let build_and_link_many
       ?link_flags
       cctx
   =
-  let dep_graphs = Ocamldep.rules cctx in
-
-  Compilation_context.modules cctx
-  |> Module.Name.Map.iter ~f:(
+  let modules = Compilation_context.modules cctx in
+  let dep_graphs = Ocamldep.rules cctx ~modules in
+  Module.Name.Map.iter modules ~f:(
     Module_compilation.build_module cctx ~dep_graphs);
 
   let link_time_code_gen =

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -440,7 +440,8 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     build_wrapped_compat_modules lib cctx ~lib_modules;
 
     let dep_graphs =
-      let dep_graphs = Ocamldep.rules cctx in
+      let modules = Compilation_context.modules cctx in
+      let dep_graphs = Ocamldep.rules cctx ~modules in
       match vimpl with
       | None -> dep_graphs
       | Some impl ->

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -225,8 +225,14 @@ module Run (P : PARAMS) : sig end = struct
         ~lint:false
     in
 
+    let dep_graphs =
+      let name = Module.name mock_module in
+      let modules = Module.Name.Map.singleton name mock_module in
+      Ocamldep.rules cctx ~modules
+    in
+
     Module_compilation.ocamlc_i
-      ~dep_graphs:(Ocamldep.rules_for_auxiliary_module cctx mock_module)
+      ~dep_graphs
       cctx
       mock_module
       ~output:(inferred_mli base);

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -150,7 +150,7 @@ let deps_of cctx ~ml_kind unit =
       Build.memoize (Path.to_string all_deps_file)
         (Build.lines_of all_deps_file >>^ parse_module_names ~unit)
 
-let rules_generic cctx ~modules =
+let rules cctx ~modules =
   Ml_kind.Dict.of_func
     (fun ~ml_kind ->
        let per_module =
@@ -159,11 +159,6 @@ let rules_generic cctx ~modules =
              Module.Obj_map.set acc m (deps_of cctx ~ml_kind m))
        in
        Dep_graph.make ~dir:(CC.dir cctx) ~per_module)
-
-let rules cctx = rules_generic cctx ~modules:(CC.modules cctx)
-
-let rules_for_auxiliary_module cctx (m : Module.t) =
-  rules_generic cctx ~modules:(Module.Name.Map.singleton (Module.name m) m)
 
 let graph_of_remote_lib ~obj_dir ~modules =
   let deps_of unit ~ml_kind =

--- a/src/ocamldep.mli
+++ b/src/ocamldep.mli
@@ -3,12 +3,9 @@
 open Stdune
 
 (** Generate ocamldep rules for all the modules in the context. *)
-val rules : Compilation_context.t -> Dep_graph.Ml_kind.t
-
-(** Compute the dependencies of an auxiliary module. *)
-val rules_for_auxiliary_module
+val rules
   :  Compilation_context.t
-  -> Module.t
+  -> modules:Module.Name_map.t
   -> Dep_graph.Ml_kind.t
 
 (** Get the dep graph for an already defined library *)


### PR DESCRIPTION
These helpers aren't so useful and in an upcoming PR we'll be taking the dep graph for all modules at once.