### PR TITLE
Add a variable %{target}

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,11 @@
 
 - Set version in `META` and `dune-package` files to the one read from
   the vcs when no other version is available (#2224, @diml)
+  
+- Add a variable %{target} to be used in situations where the context
+  requires at most one word, so %{targets} can be confusing. Stdout
+  redirections and "-o" arguments of various tools are the main
+  use case.  (#????, @aalekseyev)
 
 - Fix dependency graph of wrapped_compat modules. Previously, the dependency on
   the user written entry module was omitted. (#2305, @rgrinberg)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,9 +54,10 @@
   the vcs when no other version is available (#2224, @diml)
   
 - Add a variable %{target} to be used in situations where the context
-  requires at most one word, so %{targets} can be confusing. Stdout
-  redirections and "-o" arguments of various tools are the main
-  use case.  (#????, @aalekseyev)
+  requires at most one word, so %{targets} can be confusing; stdout
+  redirections and "-o" arguments of various tools are the main use
+  case; also, introduce a separate field [target] that must be used
+  instead of [targets] in those situations.  (#2341, @aalekseyev)
 
 - Fix dependency graph of wrapped_compat modules. Previously, the dependency on
   the user written entry module was omitted. (#2305, @rgrinberg)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,11 +53,11 @@
 - Set version in `META` and `dune-package` files to the one read from
   the vcs when no other version is available (#2224, @diml)
   
-- Add a variable %{target} to be used in situations where the context
-  requires at most one word, so %{targets} can be confusing; stdout
+- Add a variable `%{target}` to be used in situations where the context
+  requires at most one word, so `%{targets}` can be confusing; stdout
   redirections and "-o" arguments of various tools are the main use
-  case; also, introduce a separate field [target] that must be used
-  instead of [targets] in those situations.  (#2341, @aalekseyev)
+  case; also, introduce a separate field `target` that must be used
+  instead of `targets` in those situations.  (#2341, @aalekseyev)
 
 - Fix dependency graph of wrapped_compat modules. Previously, the dependency on
   the user written entry module was omitted. (#2305, @rgrinberg)

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -20,9 +20,9 @@ Stanzas
      (libraries base lwt))
 
     (rule
-     (targets foo.ml)
-     (deps    generator/gen.exe)
-     (action  (run %{deps} -o %{targets})))
+     (target foo.ml)
+     (deps   generator/gen.exe)
+     (action (run %{deps} -o %{target})))
 
 The following sections describe the available stanzas and their meaning.
 
@@ -419,12 +419,14 @@ The syntax is as follows:
 .. code:: scheme
 
     (rule
-     (targets <filenames>)
+     (target[s] <filenames>)
      (action  <action>)
      <optional-fields>)
 
-``<filenames>`` is a list of file names. Note that currently dune only
-support user rules with targets in the current directory.
+``<filenames>`` is a list of file names (if defined with ``targets``)
+or exactly one file name (if defined with ``target``). Note that
+currently dune only supports user rules with targets in the current
+directory.
 
 ``<action>`` is the action to run to produce the targets from the dependencies.
 See the `User actions`_ section for more details.
@@ -509,9 +511,9 @@ For instance:
 .. code:: scheme
 
     (rule
-     (targets b)
-     (deps    a)
-     (action  (copy %{deps} %{targets})))
+     (target b)
+     (deps   a)
+     (action (copy %{deps} %{target})))
 
 In this example it is obvious by inspecting the action what the
 dependencies and targets are. When this is the case you can use the
@@ -545,10 +547,10 @@ ocamllex
 .. code:: scheme
 
     (rule
-     (targets <name>.ml)
-     (deps    <name>.mll)
-     (action  (chdir %{workspace_root}
-               (run %{bin:ocamllex} -q -o %{targets} %{deps}))))
+     (target <name>.ml)
+     (deps   <name>.mll)
+     (action (chdir %{workspace_root}
+              (run %{bin:ocamllex} -q -o %{target} %{deps}))))
 
 To use a different rule mode, use the long form:
 
@@ -1076,6 +1078,7 @@ Dune supports the following variables:
 
 In addition, ``(action ...)`` fields support the following special variables:
 
+- ``target`` expands to the one target
 - ``targets`` expands to the list of target
 - ``deps`` expands to the list of dependencies
 - ``^`` expands to the list of dependencies, separated by spaces
@@ -1173,9 +1176,9 @@ Here is another example:
 .. code:: scheme
 
     (rule
-     (targets foo.exe)
-     (deps    foo.c)
-     (action  (run %{cc} -o %{targets} %{deps} -lfoolib)))
+     (target foo.exe)
+     (deps   foo.c)
+     (action (run %{cc} -o %{target} %{deps} -lfoolib)))
 
 
 Library dependencies
@@ -1284,10 +1287,10 @@ you had setup a rule for every file of the form:
    .. code:: scheme
 
        (rule
-        (targets file.pp.ml)
-        (deps    file.ml)
-        (action  (with-stdout-to %{targets}
-                  (chdir %{workspace_root} <action>))))
+        (target file.pp.ml)
+        (deps   file.ml)
+        (action (with-stdout-to %{target}
+                 (chdir %{workspace_root} <action>))))
 
 The equivalent of a ``-pp <command>`` option passed to the OCaml compiler is
 ``(system "<command> %{input-file}")``.
@@ -1403,7 +1406,7 @@ Named Dependencies
 
 dune allows a user to organize dependency lists by naming them. The user is
 allowed to assign a group of dependencies a name that can later be referred to
-in actions (like the ``%{deps}`` and ``%{targets}`` built in variables).
+in actions (like the ``%{deps}``, ``%{target}`` and ``%{targets}`` built in variables).
 
 One instance where this is useful is for naming globs. Here's an
 example of an imaginary bundle command:
@@ -1411,14 +1414,14 @@ example of an imaginary bundle command:
 .. code:: scheme
 
    (rule
-    (targets archive.tar)
+    (target archive.tar)
     (deps
      index.html
      (:css (glob_files *.css))
      (:js foo.js bar.js)
      (:img (glob_files *.png) (glob_files *.jpg)))
     (action
-     (run %{bin:bundle} index.html -css %{css} -js %{js} -img %{img} -o %{targets})))
+     (run %{bin:bundle} index.html -css %{css} -js %{js} -img %{img} -o %{target})))
 
 Note that such named dependency list can also include unnamed
 dependencies (like ``index.html`` in the example above). Also, such
@@ -1577,9 +1580,9 @@ To understand why this is important, let's consider this dune file living in
 ::
 
     (rule
-     (targets blah.ml)
-     (deps    blah.mll)
-     (action  (run ocamllex -o %{targets} %{deps})))
+     (target blah.ml)
+     (deps   blah.mll)
+     (action (run ocamllex -o %{target} %{deps})))
 
 Here the command that will be executed is:
 
@@ -1601,9 +1604,9 @@ of your project. What you should write instead is:
 ::
 
     (rule
-     (targets blah.ml)
-     (deps    blah.mll)
-     (action  (chdir %{workspace_root} (run ocamllex -o %{targets} %{deps}))))
+     (target blah.ml)
+     (deps   blah.mll)
+     (action (chdir %{workspace_root} (run ocamllex -o %{target} %{deps}))))
 
 Locks
 -----

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1932,7 +1932,11 @@ module Rule = struct
     List.map modules ~f:(fun name ->
       let src = name ^ ".mll" in
       let dst = name ^ ".ml" in
-      { targets = Static { targets = [S.make_text loc dst]; multiplicity = One }
+      { targets =
+          (* CR-someday aalekseyev: want to use [multiplicity = One] here, but
+             can't because this is might get parsed with old dune syntax where
+             [multiplicity = One] is not supported. *)
+          Static { targets = [S.make_text loc dst]; multiplicity = Multiple }
       ; deps    = Bindings.singleton (Dep_conf.File (S.virt_text __POS__ src))
       ; action  =
           (loc,

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1659,16 +1659,10 @@ module Rule = struct
       Static { targets; multiplicity = Multiple }
 
     let decode_one_static =
-      let+ syntax_version = Syntax.get_exn Stanza.syntax
+      let+ () = Syntax.since Stanza.syntax (1, 11)
       and+ target = String_with_vars.decode
       in
-      if syntax_version < (1, 11) then
-        Syntax.Error.since (String_with_vars.loc target)
-          Stanza.syntax
-          (1, 11)
-          ~what:"[target] field"
-      else
-        Static { targets = [target]; multiplicity = One }
+      Static { targets = [target]; multiplicity = One }
 
     let fields_parser =
       fields_mutually_exclusive

--- a/src/dune_file.ml
+++ b/src/dune_file.ml
@@ -1632,9 +1632,17 @@ end
 
 module Rule = struct
   module Targets = struct
+
+    module Multiplicity = struct
+      type t = One | Multiple
+    end
+
+    type static =
+      { targets : String_with_vars.t list; multiplicity : Multiplicity.t }
+
     type t =
       (* List of files in the current directory *)
-      | Static of String_with_vars.t list
+      | Static of static
       | Infer
 
     let decode_static =
@@ -1648,7 +1656,26 @@ module Rule = struct
               Stanza.syntax
               (1, 3)
               ~what:"Using variables in the targets field");
-      Static targets
+      Static { targets; multiplicity = Multiple }
+
+    let decode_one_static =
+      let+ syntax_version = Syntax.get_exn Stanza.syntax
+      and+ target = String_with_vars.decode
+      in
+      if syntax_version < (1, 11) then
+        Syntax.Error.since (String_with_vars.loc target)
+          Stanza.syntax
+          (1, 11)
+          ~what:"[target] field"
+      else
+        Static { targets = [target]; multiplicity = One }
+
+    let fields_parser =
+      fields_mutually_exclusive
+        [ "targets", decode_static
+        ; "target", decode_one_static
+        ]
+
   end
 
 
@@ -1761,6 +1788,7 @@ module Rule = struct
       ; "diff"                        , Action
       ; "diff?"                       , Action
       ; "targets"                     , Field
+      ; "target"                      , Field
       ; "deps"                        , Field
       ; "action"                      , Field
       ; "locks"                       , Field
@@ -1782,7 +1810,7 @@ module Rule = struct
   let long_form =
     let+ loc = loc
     and+ action = field "action" (located Action_dune_lang.decode)
-    and+ targets = field "targets" Targets.decode_static
+    and+ targets = Targets.fields_parser
     and+ deps =
       field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty
     and+ locks = field "locks" (list String_with_vars.decode) ~default:[]
@@ -1904,7 +1932,7 @@ module Rule = struct
     List.map modules ~f:(fun name ->
       let src = name ^ ".mll" in
       let dst = name ^ ".ml" in
-      { targets = Static [S.make_text loc dst]
+      { targets = Static { targets = [S.make_text loc dst]; multiplicity = One }
       ; deps    = Bindings.singleton (Dep_conf.File (S.virt_text __POS__ src))
       ; action  =
           (loc,
@@ -1926,7 +1954,10 @@ module Rule = struct
     let module S = String_with_vars in
     List.map modules ~f:(fun name ->
       let src = name ^ ".mly" in
-      { targets = Static (List.map ~f:(S.make_text loc) [name ^ ".ml"; name ^ ".mli"])
+      { targets = Static {
+          targets = List.map ~f:(S.make_text loc) [name ^ ".ml"; name ^ ".mli"];
+          multiplicity = Multiple;
+        }
       ; deps    = Bindings.singleton (Dep_conf.File (S.virt_text __POS__ src))
       ; action  =
           (loc,

--- a/src/dune_file.mli
+++ b/src/dune_file.mli
@@ -332,8 +332,16 @@ end
 
 module Rule : sig
   module Targets : sig
+
+    module Multiplicity : sig
+      type t = One | Multiple
+    end
+
+    type static =
+      { targets : String_with_vars.t list; multiplicity : Multiplicity.t }
+
     type t =
-      | Static of String_with_vars.t list
+      | Static of static
       | Infer
   end
 

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -1041,52 +1041,54 @@ module Decoder = struct
       | Values (loc, cstr, _) -> (Values (loc, cstr), state)
       | Fields (loc, cstr, _) -> (Fields (loc, cstr), state)
 
-  let ( let* ) = ( >>= )
-  let ( let+ ) = ( >>| )
-  let ( and+ ) a b ctx state =
-    let a, state = a ctx state in
-    let b, state = b ctx state in
-    ((a, b), state)
-
-  let traverse f l ctx state =
+  let traverse l ~f ctx state =
     Tuple.T2.swap (
       List.fold_map ~init:state l ~f:(fun state x ->
         Tuple.T2.swap (f x ctx state)
       ))
 
-let fields_missing_need_exactly_one loc names =
-  User_error.raise ~loc [
-    Pp.textf "fields %s are all missing (exactly one is needed)"
-      (String.concat ~sep:", " names)
-  ]
-[@@inline never]
+  let all = traverse ~f:(fun x -> x)
 
-let fields_mutual_exclusion_violation loc names =
-  User_error.raise ~loc [
-    Pp.textf "fields %s are mutually exclusive"
-      (String.concat ~sep:", " names)
-  ]
-[@@inline never]
+  let fields_missing_need_exactly_one loc names =
+    User_error.raise ~loc [
+      Pp.textf "fields %s are all missing (exactly one is needed)"
+        (String.concat ~sep:", " names)
+    ]
+  [@@inline never]
 
-let fields_mutually_exclusive
-      ?on_dup fields ((Fields (loc, _, _) : _ context) as ctx) state =
-  let res, state =
-    traverse (fun (name, parser) ->
-      field_o name ?on_dup parser
-      >>| fun res -> (name, res)
-    ) fields ctx state
-  in
-  match
-    List.filter_map res
-      ~f:(function (name, Some x) -> Some(name, x) | (_, None) -> None) with
-  | [] ->
-    let names = List.map fields ~f:fst in
-    fields_missing_need_exactly_one loc names
-  | [ (_name, res) ] ->
-    res, state
-  | (_ :: _ :: _ as results) ->
-    let names = List.map ~f:fst results in
-    fields_mutual_exclusion_violation loc names
+  let fields_mutual_exclusion_violation loc names =
+    User_error.raise ~loc [
+      Pp.textf "fields %s are mutually exclusive"
+        (String.concat ~sep:", " names)
+    ]
+  [@@inline never]
+
+  let fields_mutually_exclusive
+        ?on_dup fields ((Fields (loc, _, _) : _ context) as ctx) state =
+    let res, state =
+      traverse ~f:(fun (name, parser) ->
+        field_o name ?on_dup parser
+        >>| fun res -> (name, res)
+      ) fields ctx state
+    in
+    match
+      List.filter_map res
+        ~f:(function (name, Some x) -> Some(name, x) | (_, None) -> None) with
+    | [] ->
+      let names = List.map fields ~f:fst in
+      fields_missing_need_exactly_one loc names
+    | [ (_name, res) ] ->
+      res, state
+    | (_ :: _ :: _ as results) ->
+      let names = List.map ~f:fst results in
+      fields_mutual_exclusion_violation loc names
+
+  let ( let* ) = ( >>= )
+  let ( let+ ) = ( >>| )
+  let ( and+ ) a b ctx state =
+               let a, state = a ctx state in
+               let b, state = b ctx state in
+               ((a, b), state)
 
 end
 

--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -1055,13 +1055,17 @@ module Decoder = struct
       ))
 
 let fields_missing_need_exactly_one loc names =
-  of_sexp_errorf loc "fields %s are all missing (exactly one is needed)"
-    (String.concat ~sep:", " names)
+  User_error.raise ~loc [
+    Pp.textf "fields %s are all missing (exactly one is needed)"
+      (String.concat ~sep:", " names)
+  ]
 [@@inline never]
 
 let fields_mutual_exclusion_violation loc names =
-  of_sexp_errorf loc "fields %s are mutually-exclusive"
-    (String.concat ~sep:", " names)
+  User_error.raise ~loc [
+    Pp.textf "fields %s are mutually exclusive"
+      (String.concat ~sep:", " names)
+  ]
 [@@inline never]
 
 let fields_mutually_exclusive

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -295,6 +295,8 @@ module Decoder : sig
   val (>>>) : (unit, 'k) parser -> ('a, 'k) parser -> ('a, 'k) parser
   val map : ('a, 'k) parser -> f:('a -> 'b) -> ('b, 'k) parser
   val try_ : ('a, 'k) parser -> (exn -> ('a, 'k) parser) -> ('a, 'k) parser
+  val traverse : 'a list -> f:('a -> ('b, 'k) parser) -> ('b list, 'k) parser
+  val all : ('a, 'k) parser list -> ('a list, 'k) parser
 
   (** Access to the context *)
   val get : 'a Univ_map.Key.t -> ('a option, _) parser

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -427,6 +427,11 @@ module Decoder : sig
     -> 'a t
     -> 'a option fields_parser
 
+  val fields_mutually_exclusive
+    : ?on_dup:(Univ_map.t -> string -> Ast.t list -> unit)
+    -> (string * 'a t) list
+    -> 'a fields_parser
+
   val field_b
     :  ?check:(unit t)
     -> ?on_dup:(Univ_map.t -> string -> Ast.t list -> unit)

--- a/src/expander.mli
+++ b/src/expander.mli
@@ -83,8 +83,15 @@ module Resolved_forms : sig
 end
 
 module Targets : sig
+
+  type static =
+    {
+      targets : Path.t list;
+      multiplicity : Dune_file.Rule.Targets.Multiplicity.t;
+    }
+
   type t =
-    | Static of Path.t list
+    | Static of static
     | Infer
     | Forbidden of string (** context *)
 end

--- a/src/pform.ml
+++ b/src/pform.ml
@@ -8,6 +8,7 @@ module Var = struct
     | First_dep
     | Deps
     | Targets
+    | Target
     | Named_local
     | Cc
     | Cxx
@@ -20,6 +21,7 @@ module Var = struct
     | First_dep -> string "First_dep"
     | Deps -> string "Deps"
     | Targets -> string "Targets"
+    | Target -> string "Target"
     | Named_local -> string "Named_local"
     | Cc -> string "cc"
     | Cxx -> string "cxx"
@@ -110,6 +112,7 @@ module Map = struct
   let static_vars =
     String.Map.of_list_exn
       [ "targets", since ~version:(1, 0) Var.Targets
+      ; "target", since ~version:(1,11) Var.Target
       ; "deps", since ~version:(1, 0) Var.Deps
       ; "project_root", since ~version:(1, 0) Var.Project_root
 

--- a/src/pform.mli
+++ b/src/pform.mli
@@ -7,6 +7,7 @@ module Var : sig
     | First_dep
     | Deps
     | Targets
+    | Target
     | Named_local
     | Cc
     | Cxx

--- a/src/simple_rules.ml
+++ b/src/simple_rules.ml
@@ -20,7 +20,7 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
     let targets : Expander.Targets.t =
       match rule.targets with
       | Infer -> Infer
-      | Static fns ->
+      | Static { targets = fns; multiplicity = _ } ->
         let f fn =
           let not_in_dir ~error_loc s =
             User_error.raise ~loc:error_loc
@@ -40,14 +40,14 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
             | Path p ->
               if Option.compare Path.compare
                    (Path.parent p) (Some (Path.build dir))
-                   <> Eq
+                 <> Eq
               then
                 not_in_dir ~error_loc (Path.to_string p);
               p
             | Dir p ->
               not_in_dir ~error_loc (Path.to_string p))
         in
-        Static (List.concat_map ~f fns)
+        Expander.Targets.Static (List.concat_map ~f fns)
     in
     let bindings = dep_bindings ~extra_bindings rule.deps in
     let expander = Expander.add_bindings expander ~bindings in

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -161,3 +161,15 @@ let rec equal eq xs ys =
 let hash f xs = Dune_caml.Hashtbl.hash (map ~f xs)
 
 let cons xs x = x :: xs
+
+(* copy&paste from [base] *)
+let fold_map t ~init ~f =
+  let acc = ref init in
+  let result =
+    map t ~f:(fun x ->
+      let new_acc, y = f !acc x in
+      acc := new_acc;
+      y)
+  in
+  !acc, result
+;;

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -62,3 +62,6 @@ val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 val hash : ('a -> int) -> 'a list -> int
 
 val cons : 'a t -> 'a -> 'a t
+
+val fold_map : 'a list -> init:'b -> f:('b -> 'a -> 'b * 'c) -> 'b * 'c list
+

--- a/src/stdune/tuple.ml
+++ b/src/stdune/tuple.ml
@@ -9,4 +9,6 @@ module T2 = struct
     match f a1 a2 with
     | Ordering.Lt | Gt  as x -> x
     | Eq -> g b1 b2
+
+  let swap (x, y) = (y, x)
 end

--- a/src/stdune/tuple.mli
+++ b/src/stdune/tuple.mli
@@ -16,4 +16,6 @@ module T2 : sig
     -> ('a, 'b) t
     -> ('a, 'b) t
     -> Ordering.t
+
+  val swap : ('a * 'b) -> ('b * 'a)
 end

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -681,8 +681,10 @@ module Action = struct
     let { U.Infer.Outcome. deps; targets } =
       match targets_written_by_user with
       | Infer -> U.Infer.partial t ~all_targets:true
-      | Static targets_written_by_user ->
-        let targets_written_by_user = Path.Set.of_list targets_written_by_user in
+      | Static { targets = targets_written_by_user; multiplicity = _ } ->
+        let targets_written_by_user =
+          Path.Set.of_list targets_written_by_user
+        in
         let { U.Infer.Outcome. deps; targets } =
           U.Infer.partial t ~all_targets:false
         in

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1031,6 +1031,14 @@
     (diff? run.t run.t.corrected)))))
 
 (alias
+ (name multiple-targets)
+ (deps (package dune) (source_tree test-cases/multiple-targets))
+ (action
+  (chdir
+   test-cases/multiple-targets
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name name-field-validation)
  (deps (package dune) (source_tree test-cases/name-field-validation))
  (action
@@ -1710,6 +1718,7 @@
   (alias missing-loc-run)
   (alias multi-dir)
   (alias multiple-private-libs)
+  (alias multiple-targets)
   (alias name-field-validation)
   (alias no-installable-mode)
   (alias no-name-field)
@@ -1890,6 +1899,7 @@
   (alias misc)
   (alias missing-loc-run)
   (alias multi-dir)
+  (alias multiple-targets)
   (alias name-field-validation)
   (alias no-installable-mode)
   (alias no-name-field)

--- a/test/blackbox-tests/test-cases/multiple-targets/run.t
+++ b/test/blackbox-tests/test-cases/multiple-targets/run.t
@@ -53,3 +53,44 @@ to get a better error message:
   Error: There is more than one target. %{target} requires there to be one
   unambiguous target.
   [1]
+
+^ Expected error message
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (targets a)
+  >   (target a)
+  >   (action (bash "echo hola > %{target}")))
+  > EOF
+
+  $ dune build a
+  File "dune", line 1, characters 0-75:
+  1 | (rule
+  2 |   (targets a)
+  3 |   (target a)
+  4 |   (action (bash "echo hola > %{target}")))
+  Error: fields targets, target are mutually-exclusive
+  [1]
+
+^ Specifying both [targets] and [target] is not allowed
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (targets a)
+  >   (action (bash "echo hola > %{target}")))
+  > EOF
+
+  $ dune build a
+
+^ You can use [target] even though you specified [targets]
+^ CR aalekseyev: It seems that people want to disallow this.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (target a)
+  >   (action (bash "echo hola > %{targets}")))
+  > EOF
+
+  $ dune build a
+
+^ You can use [targets] even though you specified [target]

--- a/test/blackbox-tests/test-cases/multiple-targets/run.t
+++ b/test/blackbox-tests/test-cases/multiple-targets/run.t
@@ -50,8 +50,8 @@ to get a better error message:
   File "dune", line 3, characters 31-38:
   3 |   (action (bash "echo hola > %{target}")))
                                      ^^^^^^^
-  Error: There is more than one target. %{target} requires there to be one
-  unambiguous target.
+  Error: You can only use the variable %{target} if you defined the list of
+  targets using a field [target] (not [targets])
   [1]
 
 ^ Expected error message
@@ -69,7 +69,7 @@ to get a better error message:
   2 |   (targets a)
   3 |   (target a)
   4 |   (action (bash "echo hola > %{target}")))
-  Error: fields targets, target are mutually-exclusive
+  Error: fields targets, target are mutually exclusive
   [1]
 
 ^ Specifying both [targets] and [target] is not allowed
@@ -81,9 +81,15 @@ to get a better error message:
   > EOF
 
   $ dune build a
+  File "dune", line 3, characters 31-38:
+  3 |   (action (bash "echo hola > %{target}")))
+                                     ^^^^^^^
+  Error: You can only use the variable %{target} if you defined the list of
+  targets using a field [target] (not [targets])
+  [1]
 
-^ You can use [target] even though you specified [targets]
-^ CR aalekseyev: It seems that people want to disallow this.
+^ You can't use the variable %{target} if you specified targets with
+the field [targets]
 
   $ cat > dune <<EOF
   > (rule

--- a/test/blackbox-tests/test-cases/multiple-targets/run.t
+++ b/test/blackbox-tests/test-cases/multiple-targets/run.t
@@ -51,7 +51,7 @@ to get a better error message:
   3 |   (action (bash "echo hola > %{target}")))
                                      ^^^^^^^
   Error: You can only use the variable %{target} if you defined the list of
-  targets using a field [target] (not [targets])
+  targets using the field [target] (not [targets])
   [1]
 
 ^ Expected error message
@@ -85,11 +85,10 @@ to get a better error message:
   3 |   (action (bash "echo hola > %{target}")))
                                      ^^^^^^^
   Error: You can only use the variable %{target} if you defined the list of
-  targets using a field [target] (not [targets])
+  targets using the field [target] (not [targets])
   [1]
 
-^ You can't use the variable %{target} if you specified targets with
-the field [targets]
+^ Expected error
 
   $ cat > dune <<EOF
   > (rule
@@ -98,5 +97,11 @@ the field [targets]
   > EOF
 
   $ dune build a
+  File "dune", line 3, characters 31-39:
+  3 |   (action (bash "echo hola > %{targets}")))
+                                     ^^^^^^^^
+  Error: You can only use the variable %{targets} if you defined the list of
+  targets using the field [targets] (not [target])
+  [1]
 
-^ You can use [targets] even though you specified [target]
+^ Expected error

--- a/test/blackbox-tests/test-cases/multiple-targets/run.t
+++ b/test/blackbox-tests/test-cases/multiple-targets/run.t
@@ -1,0 +1,55 @@
+
+  $ cat > dune-project <<EOF
+  > (lang dune 1.11)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (targets a b)
+  >   (action (with-stdout-to %{targets} (echo "hola"))))
+  > 
+  > EOF
+
+  $ dune build a
+  File "dune", line 3, characters 28-36:
+  3 |   (action (with-stdout-to %{targets} (echo "hola"))))
+                                  ^^^^^^^^
+  Error: Variable %{targets} expands to 2 values, however a single value is
+  expected here. Please quote this atom.
+  [1]
+
+# CR-someday aalekseyev: the suggestion above is nonsense!
+# quoting the atom will achieve nothing.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (targets a b)
+  >   (action (bash "echo hola > %{targets}")))
+  > EOF
+
+  $ dune build a
+  File "dune", line 1, characters 0-65:
+  1 | (rule
+  2 |   (targets a b)
+  3 |   (action (bash "echo hola > %{targets}")))
+  Error: Rule failed to generate the following targets:
+  - b
+  [1]
+
+^ the echo command may succeed, but what it does is total nonsense
+Therefore the user is encouraged to write singular [target] where it makes sense
+to get a better error message:
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (targets a b)
+  >   (action (bash "echo hola > %{target}")))
+  > EOF
+
+  $ dune build a
+  File "dune", line 3, characters 31-38:
+  3 |   (action (bash "echo hola > %{target}")))
+                                     ^^^^^^^
+  Error: There is more than one target. %{target} requires there to be one
+  unambiguous target.
+  [1]


### PR DESCRIPTION
Add a variable %{target} which expands to the one target where unambiguous.

This is to make command lines like these more obviously do what you want and not something crazy:

cmd > %{targets}
tool.exe -o %{targets}

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>