### PR TITLE
Wrong key for for top closure

### DIFF
--- a/src/module.ml
+++ b/src/module.ml
@@ -314,7 +314,7 @@ module Obj_map = struct
 
   let top_closure t =
     Top_closure.String.top_closure
-      ~key:real_unit_name
+      ~key:obj_name
       ~deps:(find_exn t)
 end
 


### PR DESCRIPTION
It should be the object name rather module name. In module.ml, name =
string, so the two types were confused.

@diml perhaps it makes sense to introduce `Moudle_name.t`? I could write an internal interface for `Module.Name` inside module.ml, but it would really be just copy pasted from the mli.