### PR TITLE
Remove stdlib_dir for various flag functions

### DIFF
--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -6,14 +6,12 @@ module SC = Super_context
 module Includes = struct
   type t = Command.Args.dynamic Command.Args.t Cm_kind.Dict.t
 
-  let make sctx ~opaque ~requires : _ Cm_kind.Dict.t =
+  let make ~opaque ~requires : _ Cm_kind.Dict.t =
     match requires with
     | Error exn ->
       Cm_kind.Dict.make_all (Command.Args.Fail {fail = fun () -> raise exn})
     | Ok libs ->
-      let iflags =
-        Lib.L.include_flags libs ~stdlib_dir:(SC.context sctx).stdlib_dir
-      in
+      let iflags = Lib.L.include_flags libs in
       let cmi_includes =
         Command.Args.S [ iflags
                        ; Hidden_deps (Lib_file_deps.deps libs ~groups:[Cmi])
@@ -117,7 +115,7 @@ let create ~super_context ~scope ~expander ~obj_dir
   ; flags
   ; requires_compile
   ; requires_link
-  ; includes = Includes.make super_context ~opaque ~requires:requires_compile
+  ; includes = Includes.make ~opaque ~requires:requires_compile
   ; preprocessing
   ; no_keep_locs
   ; opaque

--- a/src/context.ml
+++ b/src/context.ml
@@ -436,6 +436,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; ext_dll = Ocaml_config.ext_dll ocfg
       ; natdynlink_supported =
           Dynlink_supported.By_the_os.of_bool natdynlink_supported
+      ; stdlib_dir
       }
     in
     let t =

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -175,7 +175,6 @@ let link_exe
               ~f:(fun { Link_time_code_gen.to_link; force_linkall } ->
                 S [ As (if force_linkall then ["-linkall"] else [])
                   ; Lib.Lib_and_module.L.link_flags to_link ~mode
-                      ~stdlib_dir:ctx.stdlib_dir
                   ])
           ; Dyn (Build.S.map top_sorted_cms ~f:(fun x -> Command.Args.Deps x))
           ]));

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -54,18 +54,17 @@ module L : sig
 
   val to_iflags : Path.Set.t -> 'a Command.Args.t
 
-  val include_paths : t -> stdlib_dir:Path.t -> Path.Set.t
-  val include_flags : t -> stdlib_dir:Path.t -> _ Command.Args.t
+  val include_paths : t -> Path.Set.t
+  val include_flags : t -> _ Command.Args.t
 
-  val c_include_flags : t -> stdlib_dir:Path.t -> _ Command.Args.t
+  val c_include_flags : t -> _ Command.Args.t
 
-  val link_flags : t -> mode:Mode.t -> stdlib_dir:Path.t -> _ Command.Args.t
+  val link_flags : t -> mode:Mode.t -> _ Command.Args.t
 
   val compile_and_link_flags
     :  compile:t
     -> link:t
     -> mode:Mode.t
-    -> stdlib_dir:Path.t
     -> _ Command.Args.t
 
   (** All the library archive files (.a, .cmxa, _stubs.a, ...)  that
@@ -93,7 +92,7 @@ module Lib_and_module : sig
   module L : sig
     type nonrec t = t list
     val of_libs : lib list -> t
-    val link_flags : t -> mode:Mode.t -> stdlib_dir:Path.t -> _ Command.Args.t
+    val link_flags : t -> mode:Mode.t -> _ Command.Args.t
   end
 end with type lib := t
 
@@ -158,6 +157,7 @@ module DB : sig
   *)
   val create
     :  ?parent:t
+    -> stdlib_dir:Path.t
     -> resolve:(Lib_name.t -> Resolve_result.t)
     -> all:(unit -> Lib_name.t list)
     -> unit
@@ -173,6 +173,7 @@ module DB : sig
 
   val create_from_findlib
     :  ?external_lib_deps_mode:bool
+    -> stdlib_dir:Path.t
     -> Findlib.t
     -> t
 

--- a/src/lib_config.ml
+++ b/src/lib_config.ml
@@ -10,6 +10,7 @@ type t =
   ; model : string
   ; natdynlink_supported    : Dynlink_supported.By_the_os.t
   ; ext_dll                 : string
+  ; stdlib_dir              : Path.t
   }
 
 let var_map =

--- a/src/lib_config.mli
+++ b/src/lib_config.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 type t =
   { has_native : bool
   ; ext_lib : string
@@ -9,6 +11,7 @@ type t =
   ; (** Native dynlink *)
     natdynlink_supported    : Dynlink_supported.By_the_os.t
   ; ext_dll                 : string
+  ; stdlib_dir              : Path.t
   }
 
 val allowed_in_enabled_if : string list

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -241,7 +241,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     let includes =
       Command.Args.S [ Hidden_deps (Dep.Set.of_files h_files)
         ; Command.of_result_map requires ~f:(fun libs ->
-            S [ Lib.L.c_include_flags libs ~stdlib_dir:ctx.stdlib_dir
+            S [ Lib.L.c_include_flags libs
               ; Hidden_deps (
                   Lib_file_deps.deps libs
                     ~groups:[Lib_file_deps.Group.Header])

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -422,9 +422,7 @@ let build_ppx_driver sctx ~dep_kind ~target ~dir_kind ~pps ~pp_names =
           ; A "-w"; A "-24"
           ; Command.of_result
               (Result.map driver_and_libs ~f:(fun (_driver, libs) ->
-                 Lib.L.compile_and_link_flags ~mode ~stdlib_dir:ctx.stdlib_dir
-                   ~compile:libs
-                   ~link:libs))
+                 Lib.L.compile_and_link_flags ~mode ~compile:libs ~link:libs))
           ; Dep (Path.build ml)
           ]))
 

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -51,7 +51,7 @@ module DB = struct
       let scope = find_by_name (Fdecl.get t) (Dune_project.name project) in
       Redirect (Some scope.db, name)
 
-  let public_libs t ~installed_libs internal_libs =
+  let public_libs t ~stdlib_dir ~installed_libs internal_libs =
     let public_libs =
       List.filter_map internal_libs
         ~f:(fun (_dir, (lib : Dune_file.Library.t)) ->
@@ -78,6 +78,7 @@ module DB = struct
     in
     let resolve = resolve t public_libs in
     Lib.DB.create ()
+      ~stdlib_dir
       ~parent:installed_libs
       ~resolve
       ~all:(fun () -> Lib_name.Map.keys public_libs)
@@ -135,7 +136,9 @@ module DB = struct
   let create ~projects ~context ~installed_libs ~lib_config
         internal_libs variant_implementations =
     let t = Fdecl.create () in
-    let public_libs = public_libs t ~installed_libs internal_libs in
+    let public_libs =
+      public_libs t ~stdlib_dir:lib_config.Lib_config.stdlib_dir
+        ~installed_libs internal_libs in
     let by_name =
       sccopes_by_name ~context ~projects ~lib_config ~public_libs
         internal_libs variant_implementations

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -367,7 +367,9 @@ let create
       ~external_lib_deps_mode
   =
   let installed_libs =
-    Lib.DB.create_from_findlib context.findlib ~external_lib_deps_mode
+    let stdlib_dir = context.stdlib_dir in
+    Lib.DB.create_from_findlib context.findlib ~stdlib_dir
+      ~external_lib_deps_mode
   in
   let scopes, public_libs =
     let libs, external_variants =

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -81,11 +81,7 @@ let setup_module_rules t =
     let open Build.O in
     Build.of_result_map requires_compile ~f:(fun libs ->
       Build.arr (fun () ->
-        let include_dirs =
-          let ctx = Super_context.context sctx in
-          Path.Set.to_list
-            (Lib.L.include_paths libs ~stdlib_dir:ctx.stdlib_dir)
-        in
+        let include_dirs = Path.Set.to_list (Lib.L.include_paths libs) in
         let b = Buffer.create 64 in
         let fmt = Format.formatter_of_buffer b in
         Source.pp_ml fmt t.source ~include_dirs;


### PR DESCRIPTION
It's eaier to pass this parameter like other lib config values through
the database. The client code is now simplified and doesn't need to
carry contexts around.