### PR TITLE
Remove a few more custom exceptions

### DIFF
--- a/src/dune_lang/dune_lang.ml
+++ b/src/dune_lang/dune_lang.ml
@@ -235,23 +235,11 @@ module Cst = struct
     List.rev !tokens
 end
 
-module Parse_error = struct
-  include Lexer.Error
-
-  let loc t : Loc.t = { start = t.start; stop = t.stop }
-  let message t = t.message
-end
-exception Parse_error = Lexer.Error
-
 module Lexer = Lexer
 
 module Parser = struct
   let error (loc : Loc.t) message =
-    raise (Parse_error
-             { start = loc.start
-             ; stop  = loc.stop
-             ; message
-             })
+    User_error.raise ~loc [ Pp.text message ]
 
   module Mode = struct
     type 'a t =

--- a/src/dune_lang/dune_lang.mli
+++ b/src/dune_lang/dune_lang.mli
@@ -155,16 +155,6 @@ end with type sexp := t
     based on their location. *)
 val insert_comments : Cst.t list -> (Loc.t * Cst.Comment.t) list -> Cst.t list
 
-module Parse_error : sig
-  type t
-
-  val loc     : t -> Loc.t
-  val message : t -> string
-end
-
-(** Exception raised in case of a parsing error *)
-exception Parse_error of Parse_error.t
-
 module Lexer : sig
   module Token : sig
 

--- a/src/dune_lang/lexer.ml
+++ b/src/dune_lang/lexer.ml
@@ -1,5 +1,4 @@
 module Token = Lexer_shared.Token
-module Error = Lexer_shared.Error
 
 type t = Lexer_shared.t
 
@@ -9,5 +8,3 @@ let jbuild_token = Jbuild_lexer.token
 let of_syntax = function
   | File_syntax.Dune -> token
   | Jbuild -> jbuild_token
-
-exception Error = Lexer_shared.Error

--- a/src/dune_lang/lexer.mli
+++ b/src/dune_lang/lexer.mli
@@ -6,13 +6,3 @@ val token : t
 val jbuild_token : t
 
 val of_syntax : File_syntax.t -> t
-
-module Error : sig
-  type t =
-    { start   : Lexing.position
-    ; stop    : Lexing.position
-    ; message : string
-    }
-end
-
-exception Error of Error.t

--- a/src/dune_lang/lexer_shared.ml
+++ b/src/dune_lang/lexer_shared.ml
@@ -20,23 +20,14 @@ end
 
 type t = with_comments:bool -> Lexing.lexbuf -> Token.t
 
-module Error = struct
-  type t =
-    { start   : Lexing.position
-    ; stop    : Lexing.position
-    ; message : string
-    }
-end
-
-exception Error of Error.t
-
 let error ?(delta=0) lexbuf message =
-  let start = Lexing.lexeme_start_p lexbuf in
-  raise
-    (Error { start = { start with pos_cnum = start.pos_cnum + delta }
-           ; stop  = Lexing.lexeme_end_p   lexbuf
-           ; message
-           })
+   let start = Lexing.lexeme_start_p lexbuf in
+   let loc : Loc.t =
+     { start = { start with pos_cnum = start.pos_cnum + delta }
+     ; stop  = Lexing.lexeme_end_p   lexbuf
+     }
+   in
+  User_error.raise ~loc [ Pp.text message ]
 
 let invalid_dune_or_jbuild lexbuf =
   let start = Lexing.lexeme_start_p lexbuf in

--- a/src/dune_lang/lexer_shared.mli
+++ b/src/dune_lang/lexer_shared.mli
@@ -18,21 +18,11 @@ end
 
 type t = with_comments:bool -> Lexing.lexbuf -> Token.t
 
-module Error : sig
-  type t =
-    { start   : Lexing.position
-    ; stop    : Lexing.position
-    ; message : string
-    }
-end
-
 val error : ?delta:int -> Lexing.lexbuf -> string -> 'a
 
 val invalid_dune_or_jbuild : Lexing.lexbuf -> 'a
 
 val escaped_buf : Buffer.t
-
-exception Error of Error.t
 
 type escape_sequence =
   | Newline

--- a/src/format_dune_lang.ml
+++ b/src/format_dune_lang.ml
@@ -129,11 +129,6 @@ let write_file ~path sexps =
 
 let format_file ~input =
   match parse_file input with
-  | exception Dune_lang.Parse_error e ->
-    Printf.eprintf
-      "Parse error: %s\n"
-      (Dune_lang.Parse_error.message e);
-    exit 1
   | OCaml_syntax loc ->
     begin
       match input with

--- a/src/lib_name.ml
+++ b/src/lib_name.ml
@@ -1,7 +1,5 @@
 open Stdune
 
-exception Invalid_lib_name of string
-
 let encode = Dune_lang.Encoder.string
 let decode = Dune_lang.Decoder.string
 
@@ -43,7 +41,9 @@ module Local = struct
     match of_string s with
     | Ok s -> s
     | Warn _
-    | Invalid -> raise (Invalid_lib_name s)
+    | Invalid ->
+      Code_error.raise "Lib_name.Local.of_string_exn got invalid name"
+        [ "name", String s ]
 
   let decode_loc =
     Dune_lang.Decoder.plain_string (fun ~loc s -> (loc, of_string s))

--- a/src/report_error.ml
+++ b/src/report_error.ml
@@ -49,11 +49,6 @@ let rec get_printer = function
         render ppf
           (User_message.pp { msg with loc = None; hints = [] })
     }
-  | Dune_lang.Parse_error e ->
-    let loc = Dune_lang.Parse_error.loc     e in
-    let msg = Dune_lang.Parse_error.message e in
-    let pp ppf = Format.fprintf ppf "@{<error>Error@}: %s\n" msg in
-    make_printer ~loc pp
   | Code_error.E t ->
     let pp = fun ppf ->
       Format.fprintf ppf "@{<error>Internal error, please report upstream \

--- a/test/blackbox-tests/test-cases/format-dune-file/run.t
+++ b/test/blackbox-tests/test-cases/format-dune-file/run.t
@@ -35,7 +35,8 @@ It is possible to pass a file name:
 Parse errors are displayed:
 
   $ echo '(' | dune format-dune-file
-  Parse error: unclosed parenthesis at end of input
+  File "", line 2, characters 0-0:
+  Error: unclosed parenthesis at end of input
   [1]
 
 When a list is indented, there is no extra space at the end.
@@ -162,5 +163,6 @@ Files in OCaml syntax are copied verbatim (but error when passed in stdin).
 Non 0 error code:
 
   $ echo "(" | dune format ; echo $?
-  Parse error: unclosed parenthesis at end of input
+  File "", line 2, characters 0-0:
+  Error: unclosed parenthesis at end of input
   1

--- a/test/unit-tests/sexp.mlt
+++ b/test/unit-tests/sexp.mlt
@@ -54,13 +54,22 @@ type 'res parse_result =
   | Same of ('res, string) result
   | Different of 'res parse_result_diff
 
+let string_of_user_error (msg : User_message.t) =
+  Format.asprintf "%a"
+    Pp.render_ignore_tags
+    (User_message.pp { msg with loc = None })
+  |> String.drop_prefix ~prefix:"Error: "
+  |> Option.value_exn
+  |> String.trim
+
 let parse s =
   let f ~lexer =
     try
       Ok (Dune_lang.parse_string ~fname:"" ~mode:Many ~lexer s
           |> List.map ~f:Dune_lang.Ast.remove_locs)
     with
-    | Dune_lang.Parse_error e -> Error (Dune_lang.Parse_error.message e)
+    | User_error.E msg ->
+      Error (string_of_user_error msg)
     | e -> Error (Printexc.to_string e)
   in
   let jbuild = f ~lexer:Dune_lang.Lexer.jbuild_token in
@@ -77,6 +86,7 @@ type 'res parse_result_diff = {
 type 'res parse_result =
     Same of ('res, string) Stdune.result
   | Different of 'res parse_result_diff
+val string_of_user_error : User_message.t -> string = <fun>
 val parse : string -> Dune_lang.t list parse_result = <fun>
 |}]
 
@@ -311,8 +321,8 @@ let test syntax sexp =
        Round_trip_success
      else
        Did_not_round_trip sexp'
-   | exception (Dune_lang.Parse_error e) ->
-     Did_not_parse_back (Dune_lang.Parse_error.message e))
+   | exception (User_error.E msg) ->
+     Did_not_parse_back (string_of_user_error msg))
 ;;
 #install_printer print_sexp
 


### PR DESCRIPTION
- `Dune_lang.Parse_error`, it was only caught by `Report_error` so we can use `User_error.raise` instead
- `Lib_name.Invalid_lib_name`: it was never caught, turned into a `Code_error.raise` instead