### PR TITLE
Remove dune_result from dune's deps

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,6 @@
  (name        dune)
  (libraries   unix
               stdune
-              dune_result
               fiber
               incremental_cycles
               dag


### PR DESCRIPTION
It uses stdune which includes this dependency

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>