### PR TITLE
Convert Fmt.t instances to Dyn

### DIFF
--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -26,8 +26,8 @@ let term =
         String.longest_map pkgs ~f:(fun (n, _) -> Lib_name.to_string n) in
       let ppf = Format.std_formatter in
       List.iter pkgs ~f:(fun (n, r) ->
-        Format.fprintf ppf "%-*s -> %a@\n" longest (Lib_name.to_string n)
-          Findlib.Unavailable_reason.pp r);
+        Format.fprintf ppf "%-*s -> %s@\n" longest (Lib_name.to_string n)
+          (Findlib.Unavailable_reason.to_string r));
       Format.pp_print_flush ppf ();
       Fiber.return ()
     end else begin

--- a/src/findlib.mli
+++ b/src/findlib.mli
@@ -26,7 +26,8 @@ module Unavailable_reason : sig
         'exist_if' clause *)
     | Hidden of Sub_system_info.t Dune_package.Lib.t
 
-  val pp : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val to_dyn : t -> Dyn.t
 end
 
 (** Lookup a package in the given database *)
@@ -54,7 +55,7 @@ val dummy_package
 module Config : sig
   type t
 
-  val pp : t Fmt.t
+  val to_dyn : t -> Dyn.t
 
   val load : Path.t -> toolchain:string -> context:string -> t
   val get : t -> string -> string option

--- a/test/unit-tests/tests.mlt
+++ b/test/unit-tests/tests.mlt
@@ -83,7 +83,10 @@ val meta : Simplified.t =
   }
 |}]
 
-#install_printer Findlib.Config.pp;;
+let config_printer fmt d = Dyn.pp fmt (Findlib.Config.to_dyn d);;
+[%%ignore]
+
+#install_printer config_printer;;
 
 let conf =
   Findlib.Config.load (Path.in_source "test/unit-tests/toolchain")
@@ -91,18 +94,14 @@ let conf =
 
 [%%expect{|
 val conf : Findlib.Config.t =
-  { vars =
-     [ (FOO_BAR, { set_rules =
-                    [ { preds_required = [ "tlc"; "env" ]
-                      ; preds_forbidden = []
-                      ; value = "my variable"
-                      }
-                    ]
-                 ; add_rules = []
-                 })
-     ]
-  ; preds = [ "tlc" ]
-  }
+  {vars =
+     map {"FOO_BAR" :
+          {set_rules =
+             [{preds_required = set {6; 7};
+                preds_forbidden = set {};
+                value = "my variable"}];
+            add_rules = []}};
+    preds = set {6}}
 |}]
 
 let env_pp fmt env = Dyn.pp fmt (Env.to_dyn env);;


### PR DESCRIPTION
@diml One thing I'm wondering about is how to make your `Pp` module usable with the toplevel. It seems like we'll still need to write `Format` printers for the toplevel, but it's quite tedious to have to do that. Is there a way to somehow have formatters be derived automatically for `Dyn.t` converters?