### PR TITLE
Move .cmt & .cmti exts to Ml_kind

### DIFF
--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -1,17 +1,19 @@
 open Stdune
 
 let dev_files =
+  let exts =
+    [ Ml_kind.cmt_ext Impl
+    ; Ml_kind.cmt_ext Intf
+    ; Cm_kind.ext Cmi
+    ]
+  in
   let id = lazy (
     let open Dyn.Encoder in
-    constr "dev_files"
-      [string ".cmt"; string ".cmti"; string (Cm_kind.ext Cmi)]
+    constr "dev_files" (List.map ~f:string exts)
   ) in
-  let cmi = Cm_kind.ext Cmi in
   Predicate.create ~id ~f:(fun p ->
-    match Filename.extension p with
-    | ".cmt"
-    | ".cmti" -> true
-    | ext -> ext = cmi)
+    let ext = Filename.extension p in
+    List.mem ext ~set:exts)
 
 let add_obj_dir sctx ~obj_dir =
   if (Super_context.context sctx).merlin then

--- a/src/ml_kind.ml
+++ b/src/ml_kind.ml
@@ -21,6 +21,10 @@ let flag t = choose ~impl:(Command.Args.A "-impl") ~intf:(A "-intf") t
 
 let ppx_driver_flag t = choose ~impl:(Command.Args.A "--impl") ~intf:(A "--intf") t
 
+let cmt_ext = function
+  | Impl -> ".cmt"
+  | Intf -> ".cmti"
+
 module Dict = struct
   type 'a t =
     { impl : 'a

--- a/src/ml_kind.mli
+++ b/src/ml_kind.mli
@@ -18,6 +18,8 @@ val to_dyn : t -> Dyn.t
 val flag : t -> _ Command.Args.t
 val ppx_driver_flag : t -> _ Command.Args.t
 
+val cmt_ext : t -> string
+
 module Dict : sig
   type kind = t
 

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -302,7 +302,8 @@ module Module = struct
     let obj_name = Module.obj_name m in
     relative t base (obj_name ^ ext)
 
-  let cm_public_file (type path) (t : path t) m ~(kind : Cm_kind.t) : path option =
+  let cm_public_file (type path) (t : path t) m ~(kind : Cm_kind.t)
+    : path option =
     let is_private = Module.visibility m = Private in
     let has_impl = Module.has m ~ml_kind:Impl in
     match kind with
@@ -310,18 +311,13 @@ module Module = struct
     |  Cmi when is_private -> None
     | _ -> Some (cm_public_file_unsafe t m ~kind)
 
-  let cmt_ext (kind : Ml_kind.t) =
-    match kind with
-    | Impl -> ".cmt"
-    | Intf -> ".cmti"
-
   let cmt_file t m ~(ml_kind : Ml_kind.t) =
     let file = Module.file m ~ml_kind in
-    let ext = cmt_ext ml_kind in
+    let ext = Ml_kind.cmt_ext ml_kind in
     Option.map file ~f:(fun _ -> obj_file t m ~kind:Cmi ~ext)
 
   let cmti_file t m =
-    let ext = cmt_ext (
+    let ext = Ml_kind.cmt_ext (
       match Module.file m ~ml_kind:Intf with
       | None -> Impl
       | Some _ -> Intf


### PR DESCRIPTION
Previously they were spread across Obj_dir and Check_rules