### PR TITLE
Relax restriction on project names being unique

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,9 @@
   not distinguished in the names of binding operators (`let@` was the
   same as `let&`) (#2376, @aalekseyev, @diml)
 
+- Workspaces with non unique project names are now supported. (#2377, fix #2325,
+  @rgrinberg)
+
 1.10.0 (04/06/2019)
 -------------------
 

--- a/src/dune_project.mli
+++ b/src/dune_project.mli
@@ -52,7 +52,21 @@ end
 
 type t
 
+module File_key : sig
+  (** File_key encodes the project in a unique way to be used as part of file
+      path. *)
+  type t
+
+  val to_string : t -> string
+
+  val of_string : string -> t
+
+  module Map : Map.S with type key = t
+end
+
 val to_dyn : t -> Dyn.t
+
+val file_key : t -> File_key.t
 
 val packages : t -> Package.t Package.Name.Map.t
 val version : t -> string option

--- a/src/lib_info.ml
+++ b/src/lib_info.ml
@@ -4,14 +4,15 @@ module Status = struct
   type t =
     | Installed
     | Public  of Dune_project.Name.t * Package.t
-    | Private of Dune_project.Name.t
+    | Private of Dune_project.t
 
   let pp ppf t =
     Format.pp_print_string ppf
       (match t with
        | Installed -> "installed"
        | Public _ -> "public"
-       | Private name ->
+       | Private project ->
+         let name = Dune_project.name project in
          sprintf "private (%s)" (Dune_project.Name.to_string_hum name))
 
   let is_private = function
@@ -20,7 +21,8 @@ module Status = struct
 
   let project_name = function
     | Installed -> None
-    | Public (name, _) | Private name -> Some name
+    | Private project -> Some (Dune_project.name project)
+    | Public (name, _)  -> Some name
 end
 
 
@@ -151,7 +153,7 @@ let of_library_stanza ~dir
   in
   let status =
     match conf.public with
-    | None   -> Status.Private (Dune_project.name conf.project)
+    | None   -> Status.Private conf.project
     | Some p -> Public (Dune_project.name conf.project, p.package)
   in
   let virtual_library = Dune_file.Library.is_virtual conf in

--- a/src/lib_info.mli
+++ b/src/lib_info.mli
@@ -13,7 +13,7 @@ module Status : sig
   type t =
     | Installed
     | Public  of Dune_project.Name.t * Package.t
-    | Private of Dune_project.Name.t
+    | Private of Dune_project.t
 
   val pp : t Fmt.t
 

--- a/src/preprocessing.ml
+++ b/src/preprocessing.ml
@@ -10,77 +10,86 @@ module Key : sig
   (* This module implements a bi-directional function between
      [encoded] and [decoded] *)
   type encoded = Digest.t
-  type decoded =
-    { pps   : Lib_name.t list
-    ; scope : Dune_project.Name.t option
-    }
+  module Decoded : sig
+    type t = private
+      { pps   : Lib_name.t list
+      ; project : Dune_project.t option
+      }
 
-  val of_libs : dir_kind:Dune_lang.File_syntax.t -> Lib.t list -> decoded
+    val of_libs : dir_kind:Dune_lang.File_syntax.t -> Lib.t list -> t
+  end
 
   (* [decode y] fails if there hasn't been a previous call to [encode]
      such that [encode x = y]. *)
-  val encode : decoded -> encoded
-  val decode : encoded -> decoded
+  val encode : Decoded.t -> encoded
+  val decode : encoded -> Decoded.t
 end = struct
   type encoded = Digest.t
-  type decoded =
-    { pps   : Lib_name.t list
-    ; scope : Dune_project.Name.t option
-    }
+  module Decoded = struct
+    type t =
+      { pps   : Lib_name.t list
+      ; project : Dune_project.t option
+      }
 
-  let reverse_table : (encoded, decoded) Hashtbl.t = Hashtbl.create 128
+    let equal x y =
+      List.equal Lib_name.equal x.pps y.pps
+      && Option.equal Dune_project.equal x.project y.project
 
-  let of_libs ~dir_kind libs =
-    let pps =
-      (let compare a b = Lib_name.compare (Lib.name a) (Lib.name b) in
-       match (dir_kind : Dune_lang.File_syntax.t) with
-       | Dune -> List.sort libs ~compare
-       | Jbuild ->
-         match List.rev libs with
-         | last :: others -> List.sort others ~compare @ [last]
-         | [] -> [])
-      |> List.map ~f:Lib.name
-    in
-    let scope =
-      List.fold_left libs ~init:None ~f:(fun acc lib ->
-        let scope_for_key =
-          let info = Lib.info lib in
-          let status = Lib_info.status info in
-          match status with
-          | Private scope_name   -> Some scope_name
-          | Public _ | Installed -> None
-        in
-        let open Dune_project.Name.Infix in
-        match acc, scope_for_key with
-        | Some a, Some b -> assert (a = b); acc
-        | Some _, None   -> acc
-        | None  , Some _ -> scope_for_key
-        | None  , None   -> None)
-    in
-    { pps; scope }
+    let to_string { pps; project } =
+      let s = String.enumerate_and (List.map pps ~f:Lib_name.to_string) in
+      match project with
+      | None -> s
+      | Some project ->
+        let name = Dune_project.name project in
+        sprintf "%s (in project: %s)" s
+          (Dune_project.Name.to_string_hum name)
 
-  let encode x =
-    let y = Digest.generic x in
+    let of_libs ~dir_kind libs =
+      let pps =
+        (let compare a b = Lib_name.compare (Lib.name a) (Lib.name b) in
+         match (dir_kind : Dune_lang.File_syntax.t) with
+         | Dune -> List.sort libs ~compare
+         | Jbuild ->
+           match List.rev libs with
+           | last :: others -> List.sort others ~compare @ [last]
+           | [] -> [])
+        |> List.map ~f:Lib.name
+      in
+      let project =
+        List.fold_left libs ~init:None ~f:(fun acc lib ->
+          let scope_for_key =
+            let info = Lib.info lib in
+            let status = Lib_info.status info in
+            match status with
+            | Private scope_name   -> Some scope_name
+            | Public _ | Installed -> None
+          in
+          match acc, scope_for_key with
+          | Some a, Some b -> assert (Dune_project.equal a b); acc
+          | Some _, None   -> acc
+          | None  , Some _ -> scope_for_key
+          | None  , None   -> None)
+      in
+      { pps; project }
+  end
+
+  let reverse_table : (encoded, Decoded.t) Hashtbl.t =
+    Hashtbl.create 128
+
+  let encode ({ Decoded. pps; project } as x) =
+    let y = Digest.generic (pps, Option.map ~f:Dune_project.file_key project) in
     match Hashtbl.find reverse_table y with
     | None ->
       Hashtbl.set reverse_table y x;
       y
     | Some x' ->
-      if x = x' then
+      if Decoded.equal x x' then
         y
       else begin
-        let to_string { pps; scope } =
-          let s = String.enumerate_and (List.map pps ~f:Lib_name.to_string) in
-          match scope with
-          | None -> s
-          | Some scope ->
-            sprintf "%s (in project: %s)" s
-              (Dune_project.Name.to_string_hum scope)
-        in
         User_error.raise
           [ Pp.textf "Hash collision between set of ppx drivers:"
-          ; Pp.textf "- cache : %s" (to_string x')
-          ; Pp.textf "- fetch : %s" (to_string x)
+          ; Pp.textf "- cache : %s" (Decoded.to_string x')
+          ; Pp.textf "- fetch : %s" (Decoded.to_string x)
           ]
       end
 
@@ -432,16 +441,47 @@ let get_rules sctx key ~dir_kind =
     let names, lib_db =
       match Digest.from_hex key with
       | key ->
-        let { Key.pps; scope } = Key.decode key in
+        let { Key.Decoded.pps; project } = Key.decode key in
         let lib_db =
-          match scope with
+          match project with
           | None -> SC.public_libs sctx
-          | Some name -> Scope.libs (SC.find_scope_by_name sctx name)
+          | Some project -> Scope.libs (SC.find_scope_by_project sctx project)
         in
         (pps, lib_db)
       | exception _ ->
         (* Still support the old scheme for backward compatibility *)
-        let (key, lib_db) = SC.Scope_key.of_string sctx key in
+
+        (* DUNE2 get rid of this crud *)
+        let module Scope_key = struct
+          let of_string sctx key =
+            match String.rsplit2 key ~on:'@' with
+            | None ->
+              (key, Super_context.public_libs sctx)
+            | Some (key, scope) ->
+              let scope =
+                let name = Dune_project.Name.of_encoded_string scope in
+                match Super_context.find_scope_by_name sctx name with
+                | [x] -> x
+                | [] -> assert false
+                | p1 :: p2 :: _ ->
+                  let file p =
+                    Scope.project p
+                    |> Dune_project.file
+                    |> Path.Source.to_string
+                    |> Pp.textf "- %s"
+                  in
+                  User_error.raise
+                    [ Pp.textf "jbuild projects must have unique names. \
+                               The project %s is defined in:"
+                        (Dune_project.Name.to_string_hum name)
+                    ; file p1
+                    ; file p2
+                    ]
+                    in
+              (key, Scope.libs scope)
+        end in
+
+        let (key, lib_db) = Scope_key.of_string sctx key in
         let names =
           match key with
           | "+none+" -> []
@@ -469,7 +509,8 @@ let gen_rules sctx components =
   | _ -> ()
 
 let ppx_driver_exe sctx libs ~dir_kind =
-  let key = Digest.to_string (Key.of_libs ~dir_kind libs |> Key.encode) in
+  let key =
+    Digest.to_string (Key.Decoded.of_libs ~dir_kind libs |> Key.encode) in
   ppx_exe sctx ~key ~dir_kind
 
 module Compat_ppx_exe_kind = struct

--- a/src/scope.mli
+++ b/src/scope.mli
@@ -30,6 +30,7 @@ module DB : sig
     -> Dune_file.External_variant.t list
     -> t * Lib.DB.t
 
-  val find_by_dir  : t -> Path.Build.t        -> scope
-  val find_by_name : t -> Dune_project.Name.t -> scope
+  val find_by_dir     : t -> Path.Build.t        -> scope
+  val find_by_name    : t -> Dune_project.Name.t -> scope list
+  val find_by_project : t -> Dune_project.t      -> scope
 end with type scope := t

--- a/src/super_context.mli
+++ b/src/super_context.mli
@@ -67,7 +67,9 @@ val local_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list
 val dump_env : t -> dir:Path.Build.t -> (unit, Dune_lang.t list) Build.t
 
 val find_scope_by_dir  : t -> Path.Build.t        -> Scope.t
-val find_scope_by_name : t -> Dune_project.Name.t -> Scope.t
+val find_scope_by_name : t -> Dune_project.Name.t -> Scope.t list
+val find_scope_by_project : t -> Dune_project.t -> Scope.t
+val find_project_by_key : t -> Dune_project.File_key.t -> Dune_project.t
 
 (** Tells whether the given source directory is marked as vendored *)
 val dir_is_vendored : t -> Path.Source.t -> bool
@@ -192,12 +194,6 @@ module Pkg_version : sig
     -> (unit, string option) Build.t
 
   val read : t -> Package.t -> (unit, string option) Build.t
-end
-
-module Scope_key : sig
-  val of_string : t -> string -> string * Lib.DB.t
-
-  val to_string : string -> Dune_project.Name.t -> string
 end
 
 val opaque : t -> bool

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -65,7 +65,7 @@ Test the argument syntax
   $ dune build --root driver-tests test_ppx_args.cma
   Entering directory 'driver-tests'
            ppx test_ppx_args.pp.ml
-  .ppx/fb8f5a35329c41c0aef8d783a2c365db/ppx.exe
+  .ppx/031272d0b003c307d6a59ce4a911dd3b/ppx.exe
   -arg1
   -arg2
   -arg3=Oreo

--- a/test/blackbox-tests/test-cases/duplicate-project-names/run.t
+++ b/test/blackbox-tests/test-cases/duplicate-project-names/run.t
@@ -1,5 +1,2 @@
 Duplicate project names are currently not allowed:
   $ dune build @all
-  File "b/dune-project", line 1, characters 0-0:
-  Error: Project foo is already defined in a/dune-project
-  [1]

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -34,7 +34,7 @@
   S $LIB_PREFIX/lib/ocaml
   S .
   S subdir
-  FLG -ppx '$PPX/fcfe04ecb8bb41c1143a3b9acec18678/ppx.exe --as-ppx --cookie '\''library-name="foo"'\'''
+  FLG -ppx '$PPX/7e13e649a7f0a21347eded34e394c6e8/ppx.exe --as-ppx --cookie '\''library-name="foo"'\'''
   FLG -open Foo -w -40 -open Bar -w -40
 
 Make sure a ppx directive is generated

--- a/test/blackbox-tests/test-cases/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/multiple-private-libs/run.t
@@ -2,11 +2,11 @@ This test checks that there is no clash when two private libraries have the same
 
   $ dune build --display short @doc-private
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
-      ocamldep a/.test.objs/test.ml.d
-        ocamlc a/.test.objs/byte/test.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/test@a/test.odoc
-          odoc _doc/_html/test@a/Test/.dune-keep,_doc/_html/test@a/Test/index.html
       ocamldep b/.test.objs/test.ml.d
         ocamlc b/.test.objs/byte/test.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/test@b/test.odoc
-          odoc _doc/_html/test@b/Test/.dune-keep,_doc/_html/test@b/Test/index.html
+          odoc _doc/_odoc/lib/test@4f4e394aec41/test.odoc
+          odoc _doc/_html/test@4f4e394aec41/Test/.dune-keep,_doc/_html/test@4f4e394aec41/Test/index.html
+      ocamldep a/.test.objs/test.ml.d
+        ocamlc a/.test.objs/byte/test.{cmi,cmo,cmt}
+          odoc _doc/_odoc/lib/test@574d7a9dbf61/test.odoc
+          odoc _doc/_html/test@574d7a9dbf61/Test/.dune-keep,_doc/_html/test@574d7a9dbf61/Test/index.html

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -17,7 +17,7 @@ On the other hand, public libraries may have private preprocessors
         ocamlc .ppx_internal.objs/byte/ppx_internal.{cmi,cmo,cmt}
       ocamlopt .ppx_internal.objs/native/ppx_internal.{cmx,o}
       ocamlopt ppx_internal.{a,cmxa}
-      ocamlopt .ppx/a55edf08f347158c59e28648f66f5be3/ppx.exe
+      ocamlopt .ppx/56104176c8a6db31b669b5ba60470694/ppx.exe
            ppx mylib.pp.ml
       ocamldep .mylib.objs/mylib.pp.ml.d
         ocamlc .mylib.objs/byte/mylib.{cmi,cmo,cmt}
@@ -38,7 +38,7 @@ Unless they introduce private runtime dependencies:
         ocamlc .private_ppx.objs/byte/private_ppx.{cmi,cmo,cmt}
       ocamlopt .private_ppx.objs/native/private_ppx.{cmx,o}
       ocamlopt private_ppx.{a,cmxa}
-      ocamlopt .ppx/3e9c40969655ac7a27e8982841adf043/ppx.exe
+      ocamlopt .ppx/6100aaab21a64480982f84e67ccfce18/ppx.exe
            ppx mylib.pp.ml
       ocamldep .mylib.objs/mylib.pp.ml.d
   [1]


### PR DESCRIPTION
Project names no longer need to be unique, but they are still selected
randomly for compat ppx and odoc.

@diml I'm not entirely sure how to get rid of the last 2 use cases for project names. We still need to encode the scope in a unique way, but that's harder with non unique project names. Perhaps we need to some sort of digest based approach where we keep track of the reverse map? Similar to how you've handled the ppx map.