### PR TITLE
Refactor creating Merlin.t

### DIFF
--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -117,19 +117,11 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
     ~link_flags
     ~promote:exes.promote;
 
-  let flags =
-    match Modules.alias_module modules with
-    | None -> Ocaml_flags.common flags
-    | Some m ->
-      Ocaml_flags.prepend_common
-        ["-open"; Module.Name.to_string (Module.name m)] flags
-      |> Ocaml_flags.common
-  in
-
   (cctx,
    Merlin.make ()
      ~requires:requires_compile
      ~flags
+     ~modules
      ~preprocess:(Dune_file.Buildable.single_preprocess exes.buildable)
      ~obj_dir)
 

--- a/src/exe_rules.ml
+++ b/src/exe_rules.ml
@@ -127,17 +127,11 @@ let executables_rules ~sctx ~dir ~dir_kind ~expander
   in
 
   (cctx,
-   let objs_dirs =
-     Obj_dir.public_cmi_dir obj_dir
-     |> Path.build
-     |> Path.Set.singleton
-   in
    Merlin.make ()
      ~requires:requires_compile
      ~flags
      ~preprocess:(Dune_file.Buildable.single_preprocess exes.buildable)
-     (* only public_dir? *)
-     ~objs_dirs)
+     ~obj_dir)
 
 let rules ~sctx ~dir ~dir_contents ~scope ~expander ~dir_kind
       (exes : Dune_file.Executables.t) =

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -348,7 +348,6 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       Modules.map_user_written modules ~f:(Preprocessing.pp_module pp)
     in
     let modules = Vimpl.impl_modules vimpl modules in
-    let alias_module = Modules.alias_module modules in
 
     let cctx =
       let requires_compile = Lib.Compile.direct_requires compile_info in
@@ -402,15 +401,6 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     Odoc.setup_library_odoc_rules sctx lib ~obj_dir ~requires:requires_compile
       ~modules ~dep_graphs ~scope;
 
-    let flags =
-      match alias_module with
-      | None -> Ocaml_flags.common flags
-      | Some m ->
-        Ocaml_flags.prepend_common
-          ["-open"; Module.Name.to_string (Module.name m)] flags
-        |> Ocaml_flags.common
-    in
-
     Sub_system.gen_rules
       { super_context = sctx
       ; dir
@@ -420,13 +410,14 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       ; compile_info
       };
 
-    (cctx,
-     Merlin.make ()
-       ~requires:requires_compile
-       ~flags
-       ~preprocess:(Buildable.single_preprocess lib.buildable)
-       ~libname:(snd lib.name)
-       ~obj_dir
+    ( cctx
+    , Merlin.make ()
+        ~requires:requires_compile
+        ~flags
+        ~modules
+        ~preprocess:(Buildable.single_preprocess lib.buildable)
+        ~libname:(snd lib.name)
+        ~obj_dir
     )
 
   let rules (lib : Library.t) ~dir_contents ~dir ~expander ~scope

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -421,17 +421,12 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
       };
 
     (cctx,
-     let objs_dirs =
-       Obj_dir.of_local obj_dir
-       |> Obj_dir.all_cmis
-       |> Path.Set.of_list
-     in
      Merlin.make ()
        ~requires:requires_compile
        ~flags
        ~preprocess:(Buildable.single_preprocess lib.buildable)
        ~libname:(snd lib.name)
-       ~objs_dirs
+       ~obj_dir
     )
 
   let rules (lib : Library.t) ~dir_contents ~dir ~expander ~scope

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -110,13 +110,18 @@ let make
       ?(preprocess=Dune_file.Preprocess.No_preprocessing)
       ?libname
       ?(source_dirs=Path.Source.Set.empty)
-      ?(objs_dirs=Path.Set.empty)
+      ~obj_dir
       () =
   (* Merlin shouldn't cause the build to fail, so we just ignore errors *)
   let requires =
     match requires with
     | Ok    l -> Lib.Set.of_list l
     | Error _ -> Lib.Set.empty
+  in
+  let objs_dirs =
+    Obj_dir.byte_dir obj_dir
+    |> Path.build
+    |> Path.Set.singleton
   in
   { requires
   ; flags      = Build.catch flags    ~on_error:(fun _ -> [])

--- a/src/merlin.ml
+++ b/src/merlin.ml
@@ -106,10 +106,11 @@ type t =
 
 let make
       ?(requires=Ok [])
-      ?(flags=Build.return [])
+      ~flags
       ?(preprocess=Dune_file.Preprocess.No_preprocessing)
       ?libname
       ?(source_dirs=Path.Source.Set.empty)
+      ~modules
       ~obj_dir
       () =
   (* Merlin shouldn't cause the build to fail, so we just ignore errors *)
@@ -122,6 +123,14 @@ let make
     Obj_dir.byte_dir obj_dir
     |> Path.build
     |> Path.Set.singleton
+  in
+  let flags =
+    match Modules.alias_module modules with
+    | None -> Ocaml_flags.common flags
+    | Some m ->
+      Ocaml_flags.prepend_common
+        ["-open"; Module.Name.to_string (Module.name m)] flags
+      |> Ocaml_flags.common
   in
   { requires
   ; flags      = Build.catch flags    ~on_error:(fun _ -> [])

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -7,10 +7,11 @@ type t
 
 val make
   :  ?requires:Lib.t list Or_exn.t
-  -> ?flags:(unit, string list) Build.t
+  -> flags:Ocaml_flags.t
   -> ?preprocess:Dune_file.Preprocess.t
   -> ?libname:Lib_name.Local.t
   -> ?source_dirs: Path.Source.Set.t
+  -> modules:Modules.t
   -> obj_dir:Path.Build.t Obj_dir.t
   -> unit
   -> t

--- a/src/merlin.mli
+++ b/src/merlin.mli
@@ -11,7 +11,7 @@ val make
   -> ?preprocess:Dune_file.Preprocess.t
   -> ?libname:Lib_name.Local.t
   -> ?source_dirs: Path.Source.Set.t
-  -> ?objs_dirs:Path.Set.t
+  -> obj_dir:Path.Build.t Obj_dir.t
   -> unit
   -> t
 


### PR DESCRIPTION
Since we introduced wrapped mode for executables, the same logic for flags is duplicated for libraries and executables. This PR moves this logic to `Merlin.make`. I also take the chance to clean up the object directory handling.