### PR TITLE
dune-project: allow single-item list elements in package depends

### DIFF
--- a/src/package.ml
+++ b/src/package.ml
@@ -152,10 +152,13 @@ module Dependency = struct
     let open Dune_lang.Decoder in
     let constrained =
       let+ name = Name.decode
-      and+ expr = Constraint.decode
+      and+ expr =
+        peek >>= function
+        | None -> return None
+        | Some _ -> Constraint.decode >>| fun v -> Some v
       in
       { name
-      ; constraint_ = Some expr
+      ; constraint_ = expr
       }
     in
     if_list

--- a/test/blackbox-tests/test-cases/dune-project-meta/test-fields-with-tmpl/dune-project
+++ b/test/blackbox-tests/test-cases/dune-project-meta/test-fields-with-tmpl/dune-project
@@ -51,7 +51,7 @@ JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."))
   (github (= :version))
   (cohttp (>= 0.99.0))
   (cohttp-lwt-unix (>= 0.99.0))
-  stringext
+  (stringext)
   (lambda-term (>= 2.0))
   (cmdliner (>= 0.9.8))
   base-unix)


### PR DESCRIPTION
Previously, a dune-project opam depends would throw an "end of list"
error if specified as a single element list

```
(package <...> (depends (foo)))        # fails
(package <...> (depends foo))          # works
(package <...> (depends (foo >= 1)))   # works
```

This commit allows the single item list form as well, which is
convenient when editing lots of constraints, and also avoids the
bad error message.

