### PR TITLE
Transitive no longer depend on module name

### DIFF
--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -326,19 +326,21 @@ module Module = struct
 
   module Dep = struct
     type t =
-      | Immediate
-      | Transitive
+      | Immediate of Module.File.t
+      | Transitive of Module.t * Ml_kind.t
 
-    let ext = function
-      | Immediate -> ".d"
-      | Transitive -> ".all-deps"
+    let basename = function
+      | Immediate f -> Path.basename (Module.File.path f) ^ ".d"
+      | Transitive (m, ml_kind) ->
+        sprintf "%s.%s.all-deps"
+          (Module.obj_name m)
+          (Ml_kind.choose ml_kind ~intf:"intf" ~impl:"impl")
   end
 
-  let dep t file ~kind =
+  let dep t dep =
     let dir = obj_dir t in
-    let name = Path.basename (Module.File.path file) in
-    let ext = Dep.ext kind in
-    Path.Build.relative dir (name ^ ext)
+    let name = Dep.basename dep in
+    Path.Build.relative dir name
 
   module L = struct
     let o_files t modules ~ext_obj =

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -110,9 +110,9 @@ module Module : sig
 
   module Dep : sig
     type t =
-      | Immediate
-      | Transitive
+      | Immediate of Module.File.t
+      | Transitive of Module.t * Ml_kind.t
   end
 
-  val dep : Path.Build.t t -> Module.File.t -> kind:Dep.t -> Path.Build.t
+  val dep : Path.Build.t t -> Dep.t -> Path.Build.t
 end

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -77,11 +77,10 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
         if Module.visibility m = Public && Module.kind m <> Alias then
           List.iter [Intf; Impl] ~f:(fun ml_kind ->
             Module.source m ~ml_kind
-            |> Option.iter ~f:(fun f ->
-              let kind = Obj_dir.Module.Dep.Transitive in
-              let src =
-                Path.build (Obj_dir.Module.dep vlib_obj_dir f ~kind) in
-              let dst = Obj_dir.Module.dep impl_obj_dir f ~kind in
+            |> Option.iter ~f:(fun _ ->
+              let dep = Obj_dir.Module.Dep.Transitive (m, ml_kind) in
+              let src = Path.build (Obj_dir.Module.dep vlib_obj_dir dep) in
+              let dst = Obj_dir.Module.dep impl_obj_dir dep in
               copy_to_obj_dir ~src ~dst)
           );
     | None ->
@@ -92,7 +91,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
         List.iter [Intf; Impl] ~f:(fun ml_kind ->
           let dep_graph = Ml_kind.Dict.get vlib_dep_graph ml_kind in
           let deps = Dep_graph.deps_of dep_graph m in
-          Module.source m ~ml_kind |> Option.iter ~f:(fun source ->
+          Module.source m ~ml_kind |> Option.iter ~f:(fun _ ->
             let open Build.O in
             deps >>^ (fun modules ->
               modules
@@ -100,7 +99,7 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
               |> String.concat ~sep:"\n")
             >>>
             Build.write_file_dyn
-              (Obj_dir.Module.dep impl_obj_dir source ~kind:Transitive)
+              (Obj_dir.Module.dep impl_obj_dir (Transitive (m, ml_kind)))
             |> add_rule))
   in
   let vlib_modules = Vimpl.vlib_modules vimpl in


### PR DESCRIPTION
When we get such deps from external modules, we don't really know the
original filename. This is a more consistent assumption if deps are
obtained from ocamlobjinfo or ocamldeps.