### PR TITLE
Switch odoc dir to object directory

### DIFF
--- a/src/module.ml
+++ b/src/module.ml
@@ -240,14 +240,6 @@ let file t ~(ml_kind : Ml_kind.t) =
 
 let obj_name t = t.obj_name
 
-let odoc_file t ~doc_dir =
-  let base =
-    match t.visibility with
-    | Public -> doc_dir
-    | Private -> Utils.library_private_dir ~obj_dir:doc_dir
-  in
-  Path.Build.relative base (t.obj_name ^ ".odoc")
-
 let iter t ~f =
   Ml_kind.Dict.iteri t.source.files
     ~f:(fun kind -> Option.iter ~f:(f kind))

--- a/src/module.mli
+++ b/src/module.mli
@@ -99,8 +99,6 @@ val file            : t -> ml_kind:Ml_kind.t -> Path.t option
 
 val obj_name : t -> string
 
-val odoc_file : t -> doc_dir:Path.Build.t -> Path.Build.t
-
 val iter : t -> f:(Ml_kind.t -> File.t -> unit) -> unit
 
 val has : t -> ml_kind:Ml_kind.t -> bool

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -1,6 +1,25 @@
 open! Stdune
 open Import
 
+module Paths = struct
+  let library_object_directory ~dir name =
+    Path.Build.relative dir ("." ^ Lib_name.Local.to_string name ^ ".objs")
+
+  let library_native_dir ~obj_dir =
+    Path.Build.relative obj_dir "native"
+
+  let library_byte_dir ~obj_dir =
+    Path.Build.relative obj_dir "byte"
+
+  let library_public_cmi_dir ~obj_dir =
+    Path.Build.relative obj_dir "public_cmi"
+
+  (* Use "eobjs" rather than "objs" to avoid a potential conflict with a
+     library of the same name *)
+  let executable_object_directory ~dir name =
+    Path.Build.relative dir ("." ^ name ^ ".eobjs")
+end
+
 module External = struct
   type t =
     { public_dir : Path.t
@@ -129,24 +148,24 @@ module Local = struct
     |> Path.Build.Set.to_list
 
   let make_lib ~dir ~has_private_modules lib_name =
-    let obj_dir = Utils.library_object_directory ~dir lib_name in
+    let obj_dir = Paths.library_object_directory ~dir lib_name in
     let public_cmi_dir =
       Option.some_if
         has_private_modules
-        (Utils.library_public_cmi_dir ~obj_dir)
+        (Paths.library_public_cmi_dir ~obj_dir)
     in
     make ~dir
       ~obj_dir
-      ~native_dir:(Utils.library_native_dir ~obj_dir)
-      ~byte_dir:(Utils.library_byte_dir ~obj_dir)
+      ~native_dir:(Paths.library_native_dir ~obj_dir)
+      ~byte_dir:(Paths.library_byte_dir ~obj_dir)
       ~public_cmi_dir
 
   let make_exe ~dir ~name =
-    let obj_dir = Utils.executable_object_directory ~dir name in
+    let obj_dir = Paths.executable_object_directory ~dir name in
     make ~dir
       ~obj_dir
-      ~native_dir:(Utils.library_native_dir ~obj_dir)
-      ~byte_dir:(Utils.library_byte_dir ~obj_dir)
+      ~native_dir:(Paths.library_native_dir ~obj_dir)
+      ~byte_dir:(Paths.library_byte_dir ~obj_dir)
       ~public_cmi_dir:None
 
   let cm_dir t cm_kind _ =

--- a/src/obj_dir.ml
+++ b/src/obj_dir.ml
@@ -86,6 +86,7 @@ module External = struct
   let native_dir t = t.public_dir
   let dir t = t.public_dir
   let obj_dir t = t.public_dir
+  let odoc_dir t = t.public_dir
 
   let all_obj_dirs t ~mode:_ =
     [t.public_dir]
@@ -136,6 +137,7 @@ module Local = struct
   let obj_dir t = t.obj_dir
   let byte_dir t = t.byte_dir
   let native_dir t = t.native_dir
+  let odoc_dir t = t.byte_dir
 
   let all_obj_dirs t ~(mode : Mode.t) =
     let dirs = [t.byte_dir; public_cmi_dir t] in
@@ -266,6 +268,9 @@ let cm_public_dir t cm_kind =
     ~l:(fun l -> Local.cm_public_dir l cm_kind)
     ~e:(fun e -> External.cm_public_dir e cm_kind)
 
+let odoc_dir t =
+  get_path t ~l:Local.odoc_dir ~e:External.odoc_dir
+
 let need_dedicated_public_dir (t : Path.Build.t t) =
   match t with
   | Local t -> Local.need_dedicated_public_dir t
@@ -342,6 +347,10 @@ module Module = struct
       | Some _ -> Intf
     ) in
     obj_file t m ~kind:Cmi ~ext
+
+  let odoc t m =
+    let basename = Module.obj_name m ^ ".odoc" in
+    relative t (odoc_dir t) basename
 
   module Dep = struct
     type t =

--- a/src/obj_dir.mli
+++ b/src/obj_dir.mli
@@ -50,6 +50,8 @@ val all_cmis: 'path t -> 'path list
 (** The public compiled cmi file directory *)
 val public_cmi_dir: 'path t -> 'path
 
+val odoc_dir : 'path t -> 'path
+
 val all_obj_dirs : 'path t -> mode:Mode.t -> 'path list
 
 (** Create the object directory for a library *)
@@ -102,6 +104,8 @@ module Module : sig
 
   (** Either the .cmti, or .cmt if the module has no interface *)
   val cmti_file : 'path t -> Module.t -> 'path
+
+  val odoc : 'path t -> Module.t -> 'path
 
   module L : sig
     val o_files : 'path t -> Module.t list -> ext_obj:string -> Path.t list

--- a/src/odoc.ml
+++ b/src/odoc.ml
@@ -49,7 +49,7 @@ let pkg_or_lnu lib =
   | None -> lib_unique_name lib
 
 type target =
-  | Lib of Lib.t
+  | Lib of Lib.Local.t
   | Pkg of Package.Name.t
 
 type source = Module | Mld
@@ -68,12 +68,13 @@ module Paths = struct
   let root (context : Context.t) =
     Path.Build.relative context.Context.build_dir "_doc"
 
-  let odocs ctx m =
-    root ctx ++ (
-      match m with
-      | Lib lib -> sprintf "_odoc/lib/%s" (lib_unique_name lib)
-      | Pkg pkg -> sprintf "_odoc/pkg/%s" (Package.Name.to_string pkg)
-    )
+  let odocs ctx = function
+    | Lib lib ->
+      let obj_dir = Lib.Local.obj_dir lib in
+      Obj_dir.odoc_dir obj_dir
+    | Pkg pkg ->
+      root ctx
+      ++ (sprintf "_odoc/pkg/%s" (Package.Name.to_string pkg))
 
   let html_root ctx = root ctx ++ "_html"
 
@@ -81,7 +82,7 @@ module Paths = struct
     html_root ctx ++ (
       match m with
       | Pkg pkg -> Package.Name.to_string pkg
-      | Lib lib -> pkg_or_lnu lib
+      | Lib lib -> pkg_or_lnu (Lib.Local.to_lib lib)
     )
 
   let gen_mld_dir ctx pkg =
@@ -110,12 +111,12 @@ module Dep = struct
           | None -> Dep.Set.empty
         in
         List.fold_left libs ~init ~f:(fun acc (lib : Lib.t) ->
-          if Lib.is_local lib then
+          match Lib.Local.of_lib lib with
+          | None -> acc
+          | Some lib ->
             let dir = Paths.odocs ctx (Lib lib) in
             let alias = alias ~dir in
-            Dep.Set.add acc (Dep.alias alias)
-          else
-            acc)))
+            Dep.Set.add acc (Dep.alias alias))))
 
   let alias ctx m = alias ~dir:(Paths.odocs ctx m)
 
@@ -151,24 +152,25 @@ let odoc sctx =
     ~dir:(Super_context.build_dir sctx) "odoc"
     ~loc:None ~hint:"try: opam install odoc"
 
-let module_deps (m : Module.t) ~doc_dir ~(dep_graphs:Dep_graph.Ml_kind.t) =
+let module_deps (m : Module.t) ~obj_dir
+      ~(dep_graphs:Dep_graph.Ml_kind.t) =
   (if Module.has m ~ml_kind:Intf then
      Dep_graph.deps_of dep_graphs.intf m
    else
      (* When a module has no .mli, use the dependencies for the .ml *)
      Dep_graph.deps_of dep_graphs.impl m)
-  >>^ List.map ~f:(fun m -> Path.build (Module.odoc_file ~doc_dir m))
+  >>^ List.map ~f:(fun m -> Path.build (Obj_dir.Module.odoc obj_dir m))
   |> Build.dyn_paths
 
 let compile_module sctx ~obj_dir (m : Module.t) ~includes:(file_deps, iflags)
-      ~dep_graphs ~doc_dir ~pkg_or_lnu =
-  let odoc_file = Module.odoc_file m ~doc_dir in
+      ~dep_graphs ~pkg_or_lnu =
+  let odoc_file = Obj_dir.Module.odoc obj_dir m in
   add_rule sctx
     (file_deps
      >>>
-     module_deps m ~doc_dir ~dep_graphs
+     module_deps m ~obj_dir ~dep_graphs
      >>>
-     let doc_dir = Path.build doc_dir in
+     let doc_dir = Path.build (Obj_dir.odoc_dir obj_dir) in
      Command.run ~dir:doc_dir (odoc sctx)
        [ A "compile"
        ; A "-I"; Path doc_dir
@@ -195,11 +197,10 @@ let odoc_include_flags ctx pkg requires =
   Command.of_result_map requires ~f:(fun libs ->
     let paths =
       libs |> List.fold_left ~f:(fun paths lib ->
-        if Lib.is_local lib then (
+        match Lib.Local.of_lib lib with
+        | None -> paths
+        | Some lib ->
           Path.Set.add paths (Path.build (Paths.odocs ctx (Lib lib)))
-        ) else (
-          paths
-        )
       ) ~init:Path.Set.empty in
     let paths =
       match pkg with
@@ -239,25 +240,26 @@ let setup_html sctx (odoc_file : odoc) ~pkg ~requires =
 let setup_library_odoc_rules sctx (library : Library.t) ~obj_dir ~scope ~modules
       ~requires ~(dep_graphs:Dep_graph.Ml_kind.t) =
   let lib =
-    Option.value_exn (Lib.DB.find_even_when_hidden (Scope.libs scope)
-                        (Library.best_name library)) in
+    Library.best_name library
+    |> Lib.DB.find_even_when_hidden (Scope.libs scope)
+    |> Option.value_exn
+  in
+  let local_lib = Lib.Local.of_lib_exn lib in
   (* Using the proper package name doesn't actually work since odoc assumes
      that a package contains only 1 library *)
   let pkg_or_lnu = pkg_or_lnu lib in
   let ctx = Super_context.context sctx in
-  let doc_dir = Paths.odocs ctx (Lib lib) in
   let odoc_include_flags = odoc_include_flags ctx (Lib.package lib) requires in
   let includes =
     (Dep.deps ctx (Lib.package lib) requires, odoc_include_flags) in
   let modules_and_odoc_files =
     Modules.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
       let compiled =
-        compile_module sctx ~includes ~dep_graphs ~obj_dir
-          ~doc_dir ~pkg_or_lnu m
+        compile_module sctx ~includes ~dep_graphs ~obj_dir ~pkg_or_lnu m
       in
       compiled :: acc)
   in
-  Dep.setup_deps ctx (Lib lib)
+  Dep.setup_deps ctx (Lib local_lib)
     (List.map modules_and_odoc_files ~f:(fun (_, p) -> Path.build p)
      |> Path.Set.of_list)
 
@@ -332,7 +334,6 @@ let load_all_odoc_rules_pkg sctx ~pkg =
   let ctx = Super_context.context sctx in
   Build_system.load_dir ~dir:(Path.build (Paths.odocs ctx (Pkg pkg)));
   Lib.Local.Set.iter pkg_libs ~f:(fun lib ->
-    let lib = Lib.Local.to_lib lib in
     Build_system.load_dir ~dir:(Path.build (Paths.odocs ctx (Lib lib))));
   pkg_libs
 
@@ -385,17 +386,17 @@ let odocs =
 let setup_lib_html_rules_def =
   let module Input = struct
     module Super_context = Super_context.As_memo_key
-    type t = Super_context.t * Lib.t * Lib.t list Or_exn.t
+    type t = Super_context.t * Lib.Local.t * Lib.t list Or_exn.t
 
     let equal (sc1, l1, r1) (sc2, l2, r2) =
       Super_context.equal sc1 sc2
-      && Lib.equal l1 l2
+      && Lib.Local.equal l1 l2
       && Or_exn.equal (List.equal Lib.equal) r1 r2
 
     let hash (sc, l, r) =
       Hashtbl.hash
         ( Super_context.hash sc
-        , Lib.hash l
+        , Lib.Local.hash l
         , Or_exn.hash (List.hash Lib.hash) r
         )
 
@@ -405,7 +406,7 @@ let setup_lib_html_rules_def =
   let f (sctx, lib, requires) =
     let ctx = Super_context.context sctx in
     let odocs = odocs ctx (Lib lib) in
-    let pkg = Lib.package lib in
+    let pkg = Lib.package (Lib.Local.to_lib lib) in
     List.iter odocs ~f:(setup_html sctx ~pkg ~requires);
     let html_files = List.map ~f:(fun o -> Path.build o.html_file) odocs in
     let static_html = List.map ~f:Path.build (static_html ctx) in
@@ -459,8 +460,9 @@ let setup_pkg_html_rules_def =
     ~visibility:Hidden
     Sync
     (fun (sctx, pkg, (libs : Lib.Local.t list)) ->
-       let libs = (libs :> Lib.t list) in
-       let requires = Lib.closure libs ~linking:false in
+       let requires =
+         let libs = (libs :> Lib.t list) in
+         Lib.closure libs ~linking:false in
        let ctx = Super_context.context sctx in
        List.iter libs ~f:(setup_lib_html_rules sctx ~requires);
        let pkg_odocs = odocs ctx (Pkg pkg) in
@@ -489,7 +491,6 @@ let setup_package_aliases sctx (pkg : Package.t) =
     :: (libs_of_pkg sctx ~pkg:pkg.name
         |> Lib.Local.Set.to_list
         |> List.map ~f:(fun lib ->
-          let lib = Lib.Local.to_lib lib in
           Dep.html_alias ctx (Lib lib)))
     |> List.map ~f:(fun f -> Path.build (Alias.stamp_file f))
     |> Path.Set.of_list
@@ -632,14 +633,15 @@ let init sctx =
            | Some _ -> None
            | None ->
              let scope = SC.find_scope_by_dir sctx w.ctx_dir in
-             Some (Option.value_exn (
-               Lib.DB.find_even_when_hidden (Scope.libs scope)
-                 (Library.best_name l))
-             )
+             Library.best_name l
+             |> Lib.DB.find_even_when_hidden (Scope.libs scope)
+             |> Option.value_exn
+             |> Lib.Local.of_lib_exn
+             |> Option.some
            end
          | _ -> None
        ))
-     |> List.map ~f:(fun (lib : Lib.t) ->
+     |> List.map ~f:(fun (lib : Lib.Local.t) ->
        Lib lib
        |> Dep.html_alias ctx
        |> Alias.stamp_file
@@ -677,11 +679,16 @@ let gen_rules sctx ~dir:_ rest =
       setup_pkg_html_rules sctx ~pkg ~libs:(
         Lib.Local.Set.to_list (load_all_odoc_rules_pkg sctx ~pkg)) in
     (* diml: why isn't [None] some kind of error here? *)
-    Option.iter (Lib.DB.find lib_db lib) ~f:(fun lib ->
-      match Lib.package lib with
+    let lib =
+      let open Option.O in
+      let* lib = Lib.DB.find lib_db lib in
+      Lib.Local.of_lib lib
+    in
+    Option.iter lib ~f:(fun lib ->
+      match Lib.package (Lib.Local.to_lib lib) with
       | None ->
         setup_lib_html_rules sctx
-          lib ~requires:(Lib.closure ~linking:false [lib])
+          lib ~requires:(Lib.closure ~linking:false [Lib.Local.to_lib lib])
       | Some pkg ->
         setup_pkg_html_rules pkg);
     Option.iter

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -29,25 +29,8 @@ let bash_exn =
             needed_to
         ]
 
-let library_object_directory ~dir name =
-  Path.Build.relative dir ("." ^ Lib_name.Local.to_string name ^ ".objs")
-
-let library_native_dir ~obj_dir =
-  Path.Build.relative obj_dir "native"
-
-let library_byte_dir ~obj_dir =
-  Path.Build.relative obj_dir "byte"
-
-let library_public_cmi_dir ~obj_dir =
-  Path.Build.relative obj_dir "public_cmi"
-
 let library_private_dir ~obj_dir =
   Path.Build.relative obj_dir "private"
-
-(* Use "eobjs" rather than "objs" to avoid a potential conflict with a
-   library of the same name *)
-let executable_object_directory ~dir name =
-  Path.Build.relative dir ("." ^ name ^ ".eobjs")
 
 let not_found fmt ?loc ?context ?hint x =
   User_error.raise ?loc

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -29,9 +29,6 @@ let bash_exn =
             needed_to
         ]
 
-let library_private_dir ~obj_dir =
-  Path.Build.relative obj_dir "private"
-
 let not_found fmt ?loc ?context ?hint x =
   User_error.raise ?loc
     (Pp.textf fmt (String.maybe_quoted x)

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -9,27 +9,7 @@ val system_shell_exn : needed_to:string -> Path.t * string
 (** Same as [system_shell_exn] but for bash *)
 val bash_exn : needed_to:string -> Path.t
 
-(** Return the directory where the object files for the given
-    library should be stored. *)
-val library_object_directory
-  :  dir:Path.Build.t
-  -> Lib_name.Local.t
-  -> Path.Build.t
-
-(** cmx, .a *)
-val library_native_dir     : obj_dir:Path.Build.t -> Path.Build.t
-
-(** cmo, cmi, cmt, cmti *)
-val library_byte_dir       : obj_dir:Path.Build.t -> Path.Build.t
-val library_public_cmi_dir : obj_dir:Path.Build.t -> Path.Build.t
 val library_private_dir    : obj_dir:Path.Build.t -> Path.Build.t
-
-(** Return the directory where the object files for the given
-    executable should be stored. *)
-val executable_object_directory
-  :  dir:Path.Build.t
-  -> string
-  -> Path.Build.t
 
 (** Raise an error about a program not found in the PATH or in the tree *)
 val program_not_found

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -9,8 +9,6 @@ val system_shell_exn : needed_to:string -> Path.t * string
 (** Same as [system_shell_exn] but for bash *)
 val bash_exn : needed_to:string -> Path.t
 
-val library_private_dir    : obj_dir:Path.Build.t -> Path.Build.t
-
 (** Raise an error about a program not found in the PATH or in the tree *)
 val program_not_found
   :  ?context:string

--- a/test/blackbox-tests/test-cases/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/multiple-private-libs/run.t
@@ -4,9 +4,9 @@ This test checks that there is no clash when two private libraries have the same
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
       ocamldep b/.test.objs/test.ml.d
         ocamlc b/.test.objs/byte/test.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/test@4f4e394aec41/test.odoc
+          odoc b/.test.objs/byte/test.odoc
           odoc _doc/_html/test@4f4e394aec41/Test/.dune-keep,_doc/_html/test@4f4e394aec41/Test/index.html
       ocamldep a/.test.objs/test.ml.d
         ocamlc a/.test.objs/byte/test.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/test@574d7a9dbf61/test.odoc
+          odoc a/.test.objs/byte/test.odoc
           odoc _doc/_html/test@574d7a9dbf61/Test/.dune-keep,_doc/_html/test@574d7a9dbf61/Test/index.html

--- a/test/blackbox-tests/test-cases/odoc-unique-mlds/run.t
+++ b/test/blackbox-tests/test-cases/odoc-unique-mlds/run.t
@@ -4,9 +4,9 @@ Duplicate mld's in the same scope
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
         ocamlc lib1/.root_lib1.objs/byte/root_lib1.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/root/page-index.odoc
-          odoc _doc/_odoc/lib/root.lib1/root_lib1.odoc
+          odoc lib1/.root_lib1.objs/byte/root_lib1.odoc
         ocamlc lib2/.root_lib2.objs/byte/root_lib2.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/root.lib2/root_lib2.odoc
+          odoc lib2/.root_lib2.objs/byte/root_lib2.odoc
           odoc _doc/_html/root/Root_lib2/.dune-keep,_doc/_html/root/Root_lib2/index.html
           odoc _doc/_html/root/index.html
           odoc _doc/_html/root/Root_lib1/.dune-keep,_doc/_html/root/Root_lib1/index.html
@@ -18,11 +18,11 @@ Duplicate mld's in different scope
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
         ocamlc scope1/.scope1.objs/byte/scope1.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/scope1/page-index.odoc
-          odoc _doc/_odoc/lib/scope1/scope1.odoc
+          odoc scope1/.scope1.objs/byte/scope1.odoc
           odoc _doc/_html/scope1/index.html
         ocamlc scope2/.scope2.objs/byte/scope2.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/scope2/page-index.odoc
-          odoc _doc/_odoc/lib/scope2/scope2.odoc
+          odoc scope2/.scope2.objs/byte/scope2.odoc
           odoc _doc/_html/scope2/index.html
           odoc _doc/_html/scope1/Scope1/.dune-keep,_doc/_html/scope1/Scope1/index.html
           odoc _doc/_html/scope2/Scope2/.dune-keep,_doc/_html/scope2/Scope2/index.html

--- a/test/blackbox-tests/test-cases/odoc/run.t
+++ b/test/blackbox-tests/test-cases/odoc/run.t
@@ -2,24 +2,25 @@
       ocamldep .bar.objs/bar.ml.d
         ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/bar/page-index.odoc
-          odoc _doc/_odoc/lib/bar/bar.odoc
+          odoc .bar.objs/byte/bar.odoc
           odoc _doc/_html/bar/index.html
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
       ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/foo/page-index.odoc
-          odoc _doc/_odoc/lib/foo/foo.odoc
+          odoc .foo.objs/byte/foo.odoc
       ocamldep .foo.objs/foo2.ml.d
         ocamlc .foo.objs/byte/foo2.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/foo/foo2.odoc
+          odoc .foo.objs/byte/foo2.odoc
       ocamldep .foo.objs/foo3.ml.d
         ocamlc .foo.objs/byte/foo3.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/foo/private/foo3.odoc
+          odoc .foo.objs/byte/foo3.odoc
       ocamldep .foo_byte.objs/foo_byte.ml.d
         ocamlc .foo_byte.objs/byte/foo_byte.{cmi,cmo,cmt}
-          odoc _doc/_odoc/lib/foo.byte/foo_byte.odoc
+          odoc .foo_byte.objs/byte/foo_byte.odoc
           odoc _doc/_html/foo/Foo2/.dune-keep,_doc/_html/foo/Foo2/index.html
           odoc _doc/_html/bar/Bar/.dune-keep,_doc/_html/bar/Bar/index.html
+          odoc _doc/_html/foo/Foo3/.dune-keep,_doc/_html/foo/Foo3/index.html
           odoc _doc/_html/foo/Foo_byte/.dune-keep,_doc/_html/foo/Foo_byte/index.html
           odoc _doc/_html/foo/index.html
           odoc _doc/_html/foo/Foo/.dune-keep,_doc/_html/foo/Foo/index.html


### PR DESCRIPTION
A parallel odoc directory structure isn't necessary anymore.

By the way, this also moves the .odoc files for private modules to the same directory as other modules. I believe this is consistent with @trefis suggestion that dune should not be hiding anything from odoc.