### PR TITLE
Do not use Local_package in Opam_create

### DIFF
--- a/src/opam_create.ml
+++ b/src/opam_create.ml
@@ -146,9 +146,10 @@ let opam_template sctx ~pkg =
 
 let add_rule sctx ~project ~pkg =
   let open Build.O in
-  let opam_path = Local_package.opam_file pkg in
+  let build_dir = Super_context.build_dir sctx in
+  let opam_path = Path.Build.append_source build_dir (Package.opam_file pkg) in
   let opam_rule =
-    (match opam_template sctx ~pkg:(Local_package.package pkg) with
+    (match opam_template sctx ~pkg with
      | Some p -> Build.contents (Path.build p)
      | None -> Build.return "")
     >>>
@@ -160,8 +161,7 @@ let add_rule sctx ~project ~pkg =
       in
       let existing_vars_template = Opam_file.existing_variables opamfile in
       let generated_fields =
-        let package = Local_package.package pkg in
-        opam_fields project package
+        opam_fields project pkg
         |> List.filter ~f:(fun (v, _) ->
           not (String.Set.mem existing_vars_template v))
         |> Opam_file.Create.of_bindings ~file:opam_path
@@ -173,7 +173,7 @@ let add_rule sctx ~project ~pkg =
         template)
     >>> Build.write_file_dyn opam_path
   in
-  let dir = Local_package.build_dir pkg in
+  let dir = Path.Build.append_source build_dir pkg.path in
   let mode =
     Dune_file.Rule.Mode.Promote
       { lifetime = Unlimited
@@ -198,10 +198,9 @@ let add_rules sctx ~dir =
     |> Scope.project
   in
   if Dune_project.generate_opam_files project then begin
-    Local_package.defined_in sctx ~dir
-    |> List.iter ~f:(fun pkg ->
-      let package = Local_package.package pkg in
-      match package.kind with
+    Dune_project.packages project
+    |> Package.Name.Map.iter ~f:(fun (pkg : Package.t) ->
+      match pkg.kind with
       | Dune _ -> add_rule sctx ~project ~pkg
       | Opam -> ())
   end

--- a/src/package.mli
+++ b/src/package.mli
@@ -89,7 +89,6 @@ type t =
 val decode : dir:Path.Source.t -> t Dune_lang.Decoder.t
 
 val opam_file : t -> Path.Source.t
-
 val meta_file : t -> Path.Source.t
 
 val to_dyn : t -> Dyn.t


### PR DESCRIPTION
This PR removes `Local_package` from `Opam_create`. To replace it, all we need is a simple function that gives us all the packages defined in a directory.