### PR TITLE
Ppx expect

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -14,6 +14,7 @@ opam_install_test_deps () {
          ocamlfind \
          utop \
          ppxlib \
+         ppx_expect \
          $ODOC \
          menhir \
          ocaml-migrate-parsetree \

--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -58,7 +58,8 @@ let term =
   | `Error msg ->
     `Error (true, msg)
   | `Result res ->
-    Format.printf "%a\n%!" Dyn.pp res;
+    Ansi_color.print (Dyn.pp res);
+    print_newline ();
     `Ok ()
   | `List ->
     let fns = Memo.registered_functions () in

--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -1663,12 +1663,9 @@ let process_memcycle exn =
   in
   match List.last cycle with
   | None ->
-    let frames : string list =
-      Memo.Cycle_error.get exn
-      |> List.map ~f:(Format.asprintf "%a" Memo.Stack_frame.pp)
-    in
+    let frames = Memo.Cycle_error.get exn in
     Code_error.raise "dependency cycle that does not involve any files"
-      ["frames", Dyn.Encoder.(list string) frames]
+      ["frames", Dyn.Encoder.(list Memo.Stack_frame.to_dyn) frames]
   | Some last ->
     let first = List.hd cycle in
     let cycle = if last = first then cycle else last :: cycle in

--- a/src/coq_rules.ml
+++ b/src/coq_rules.ml
@@ -66,7 +66,7 @@ let setup_rule ~expander ~dir ~cc ~source_rule ~coq_flags ~file_flags
 
   if coq_debug
   then Format.eprintf "gen_rule coq_module: %a@\n%!"
-         Dyn.pp (Coq_module.to_dyn coq_module);
+         Pp.render_ignore_tags (Dyn.pp (Coq_module.to_dyn coq_module));
 
   let obj_dir = dir in
   let source    = Coq_module.source coq_module in

--- a/src/dep.ml
+++ b/src/dep.ml
@@ -56,13 +56,6 @@ module T = struct
       in
       [var, value]
 
-  let pp fmt = function
-    | Env e -> Format.fprintf fmt "Env %S" e
-    | Alias a -> Format.fprintf fmt "Alias %a" Alias.pp a
-    | File f -> Format.fprintf fmt "File %a" Path.pp f
-    | Glob g -> Format.fprintf fmt "Glob %a" File_selector.pp g
-    | Universe -> Format.fprintf fmt "Universe"
-
   let encode t =
     let open Dune_lang.Encoder in
     match t with
@@ -92,9 +85,6 @@ module Set = struct
 
   let trace t ~env ~eval_pred =
     List.concat_map (to_list t) ~f:(trace ~env ~eval_pred)
-
-  let pp fmt (t : t) =
-    Format.fprintf fmt "Deps %a" (Fmt.list pp) (to_list t)
 
   let add_paths t paths =
     Path.Set.fold paths ~init:t ~f:(fun p set -> add set (File p))

--- a/src/dep.mli
+++ b/src/dep.mli
@@ -15,8 +15,6 @@ val alias : Alias.t -> t
 
 val compare : t -> t -> Ordering.t
 
-val pp : t Fmt.t
-
 type eval_pred = File_selector.t -> Path.Set.t
 
 module Trace : sig
@@ -49,8 +47,6 @@ module Set : sig
     -> f:(Path.t -> unit Fiber.t)
     -> eval_pred:eval_pred
     -> unit Fiber.t
-
-  val pp : t Fmt.t
 
   val dirs : t -> Path.Set.t
 end

--- a/src/file_selector.ml
+++ b/src/file_selector.ml
@@ -21,8 +21,6 @@ let to_dyn { dir ; predicate } =
     ; "predicate", Predicate.to_dyn predicate
     ]
 
-let pp fmt t = Dyn.pp fmt (to_dyn t)
-
 let encode { dir; predicate } =
   let open Dune_lang.Encoder in
   record

--- a/src/file_selector.mli
+++ b/src/file_selector.mli
@@ -15,8 +15,6 @@ val hash : t -> int
 
 val compare : t -> t -> Ordering.t
 
-val pp : t Fmt.t
-
 val encode : t Dune_lang.Encoder.t
 
 val to_dyn : t -> Dyn.t

--- a/src/main.ml
+++ b/src/main.ml
@@ -65,8 +65,8 @@ let scan_workspace ?(log=Log.no_log)
 
   let+ contexts = Context.create ~env workspace in
   List.iter contexts ~f:(fun (ctx : Context.t) ->
-    Log.infof log "@[<1>Dune context:@,%a@]@." Dyn.pp
-      (Context.to_dyn ctx));
+    Log.infof log "@[<1>Dune context:@,%a@]@." Pp.render_ignore_tags
+      (Dyn.pp (Context.to_dyn ctx)));
   { contexts
   ; conf
   ; env

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -374,11 +374,6 @@ module Stack_frame0 = struct
   let compare (T a) (T b) = Id.compare a.id b.id
 
   let to_dyn t = Dyn.Tuple [String (name t); input t]
-
-  let pp ppf t =
-    Format.fprintf ppf "%s %a"
-      (name t)
-      Dyn.pp (input t)
 end
 
 module To_open = struct
@@ -428,16 +423,16 @@ module Call_stack = struct
 
 end
 
-let pp_stack ppf () =
+let pp_stack () =
+  let open Pp.O in
   let stack = Call_stack.get_call_stack () in
-  Format.fprintf ppf "Memoized function stack:@\n";
-  Format.pp_print_list ~pp_sep:Fmt.nl
-    (fun ppf t -> Format.fprintf ppf "  %a" Stack_frame.pp t)
-    ppf
-    stack
+  Pp.vbox
+    (Pp.box (Pp.text "Memoized function stack:") ++ Pp.cut ++
+     Pp.chain stack ~f:(fun frame ->
+       Dyn.pp (Stack_frame.to_dyn frame)))
 
 let dump_stack () =
-  Format.eprintf "%a" pp_stack ()
+  Format.eprintf "%a" Pp.render_ignore_tags (pp_stack ())
 
 let add_rev_dep dep_node =
   match Call_stack.get_call_stack_tip () with

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -20,7 +20,6 @@ module Stack_frame : sig
 
   type t
 
-  val pp : Format.formatter -> t -> unit
   val to_dyn : t -> Dyn.t
 
   val equal : t -> t -> bool
@@ -149,7 +148,7 @@ val get_deps : ('i, _, _) t -> 'i -> (string * Dyn.t) list option
     debugging purposes. *)
 val dump_stack : unit -> unit
 
-val pp_stack : Format.formatter -> unit -> unit
+val pp_stack : unit -> _ Pp.t
 
 (** Get the memoized call stack during the execution of a memoized function. *)
 val get_call_stack : unit -> Stack_frame.t list

--- a/src/ocamlobjinfo.mli
+++ b/src/ocamlobjinfo.mli
@@ -4,7 +4,6 @@ open Stdune
 type t = Module.Name.Set.t Ml_kind.Dict.t
 
 val to_dyn : t -> Dyn.t
-val pp : t Fmt.t
 
 val rules
   :  dir:Path.Build.t

--- a/src/ocamlobjinfo.mll
+++ b/src/ocamlobjinfo.mll
@@ -4,7 +4,6 @@ open Stdune
 type t = Module.Name.Set.t Ml_kind.Dict.t
 
 let to_dyn = Ml_kind.Dict.to_dyn Module.Name.Set.to_dyn
-let pp fmt t = Dyn.pp fmt (to_dyn t)
 
 let empty =
   { Ml_kind.Dict.

--- a/src/package.ml
+++ b/src/package.ml
@@ -277,8 +277,6 @@ let to_dyn { name; path; version ; synopsis ; description
         Dyn.Tuple [String v; Version_source.to_dyn s]))
     ]
 
-let pp fmt t = Dyn.pp fmt (to_dyn t)
-
 let opam_file t = Path.Source.relative t.path (Name.opam_fn t.name)
 
 let meta_file t = Path.Source.relative t.path (Name.meta_fn t.name)

--- a/src/package.mli
+++ b/src/package.mli
@@ -88,8 +88,6 @@ type t =
 
 val decode : dir:Path.Source.t -> t Dune_lang.Decoder.t
 
-val pp : Format.formatter -> t -> unit
-
 val opam_file : t -> Path.Source.t
 
 val meta_file : t -> Path.Source.t

--- a/src/predicate.ml
+++ b/src/predicate.ml
@@ -27,5 +27,3 @@ let contramap t ~f ~map_id =
   { f = (fun s -> t.f (f s))
   ; id = lazy (map_id (Lazy.force t.id))
   }
-
-let pp fmt t = Dyn.pp fmt (to_dyn t)

--- a/src/predicate.mli
+++ b/src/predicate.mli
@@ -26,5 +26,3 @@ val test : 'a t -> 'a -> bool
 (** the user of this function must take care not to break the uniqueness of the
     underlying representation *)
 val contramap : 'a t -> f:('b -> 'a) -> map_id:(Dyn.t -> Dyn.t) -> 'b t
-
-val pp : _ t Fmt.t

--- a/src/report_error.ml
+++ b/src/report_error.ml
@@ -54,7 +54,7 @@ let rec get_printer = function
       Format.fprintf ppf "@{<error>Internal error, please report upstream \
                           including the contents of _build/log.@}\n\
                           Description:%a\n"
-        Dyn.pp (Code_error.to_dyn t)
+        Pp.render_ignore_tags (Dyn.pp (Code_error.to_dyn t))
     in
     make_printer ~backtrace:true pp
   | Unix.Unix_error (err, func, fname) ->

--- a/src/stdune/dyn.ml
+++ b/src/stdune/dyn.ml
@@ -140,9 +140,7 @@ let rec pp = function
          ; Pp.concat_map ~sep:(Pp.char ',') xs ~f:pp
          ])
 
-let pp fmt t = Pp.render_ignore_tags fmt (pp t)
-
-let to_string t = Format.asprintf "%a" pp t
+let to_string t = Format.asprintf "%a" Pp.render_ignore_tags (pp t)
 
 module Encoder = struct
 

--- a/src/stdune/dyn.mli
+++ b/src/stdune/dyn.mli
@@ -41,7 +41,7 @@ module Encoder : sig
   val constr : string -> dyn list -> dyn
 end with type dyn := t
 
-val pp : Format.formatter -> t -> unit
+val pp : t -> _ Pp.t
 
 val opaque : t
 

--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -1,0 +1,14 @@
+(library
+ (name dune_unit_tests)
+ (inline_tests
+  (deps
+   (source_tree ../unit-tests/findlib-db)
+   (source_tree ../unit-tests/toolchain.d)))
+ (libraries stdune dune wp_dune
+            ;; This is because of the (implicit_transitive_deps false)
+            ;; in dune-project
+            ppx_expect.config
+            ppx_expect.common
+            base
+            ppx_inline_test.config)
+ (preprocess (pps ppx_expect)))

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -26,18 +26,6 @@
 
 (alias
  (name runtest)
- (deps (:t tests.mlt)
-  (glob_files %{project_root}/src/.dune.objs/byte/*.cmi)
-  (glob_files %{project_root}/src/stdune/.stdune.objs/byte/*.cmi)
-  (source_tree toolchain.d)
-  (source_tree findlib-db))
- (action (chdir %{project_root}
-          (progn
-           (run %{exe:expect_test.exe} %{t})
-           (diff? %{t} %{t}.corrected)))))
-
-(alias
- (name runtest)
  (deps (:t filename.mlt)
   (glob_files %{project_root}/src/.dune.objs/byte/*.cmi)
   (glob_files %{project_root}/src/stdune/.stdune.objs/byte/*.cmi))

--- a/test/unit-tests/dune_file.mlt
+++ b/test/unit-tests/dune_file.mlt
@@ -5,9 +5,10 @@ open! Stdune;;
 #warnings "-40";;
 
 let sexp_pp ppf x = Pp.render_ignore_tags ppf (Dune_lang.pp Dune x);;
-let mode_conf_pp fmt x = Dyn.pp fmt (Dune_file.Mode_conf.to_dyn x);;
-let binary_kind_pp fmt x = Dyn.pp fmt (Binary_kind.to_dyn x);;
-let link_mode_pp fmt x = Dyn.pp fmt (Dune_file.Executables.Link_mode.to_dyn x);;
+let print_dyn fmt dyn = Format.fprintf fmt "%a" Pp.render_ignore_tags (Dyn.pp dyn);;
+let mode_conf_pp fmt x = print_dyn fmt (Dune_file.Mode_conf.to_dyn x);;
+let binary_kind_pp fmt x = print_dyn fmt (Binary_kind.to_dyn x);;
+let link_mode_pp fmt x = print_dyn fmt (Dune_file.Executables.Link_mode.to_dyn x);;
 #install_printer mode_conf_pp;;
 #install_printer binary_kind_pp;;
 #install_printer link_mode_pp;;

--- a/test/unit-tests/ocamlobjinfo.mlt
+++ b/test/unit-tests/ocamlobjinfo.mlt
@@ -2,7 +2,13 @@
 open Dune;;
 open! Stdune;;
 
-#install_printer Ocamlobjinfo.pp;;
+let pp ppf ooi =
+  Format.fprintf ppf "%a" Pp.render_ignore_tags
+    (Ocamlobjinfo.to_dyn ooi |> Dyn.pp)
+;;
+#install_printer pp;;
+
+[%%ignore]
 
 let fixture = {ocamlobjinfo|
 File _build/install/default/lib/dune/_stdune/stdune__Env.cmx


### PR DESCRIPTION
This PR converts one of the unit test to ppx_expect.

PROS:
- we can use merlin in the test code \o/
- the dune file is much simpler
- we have more control over the structure of the code, i.e. we don't have to do everything at the toplevel
- we don't need to install printers and put `[%%ignore]` statements

CONS:
- we have to print things manually rather than rely on the toplevel

As a I needed a few Pp.t returning functions, I converted a few Format users to Pp. I also just deleted a bunch of `X.pp` functions that were unused
