### PR TITLE
Implement compound dependency rules for vlibs

### DIFF
--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -61,6 +61,7 @@ type t =
   ; dynlink              : bool
   ; sandbox              : bool option
   ; package              : Package.t option
+  ; vimpl                : Vimpl.t option
   }
 
 let super_context        t = t.super_context
@@ -82,6 +83,7 @@ let js_of_ocaml          t = t.js_of_ocaml
 let dynlink              t = t.dynlink
 let sandbox              t = t.sandbox
 let package              t = t.package
+let vimpl                t = t.vimpl
 
 let context              t = Super_context.context t.super_context
 
@@ -89,7 +91,7 @@ let create ~super_context ~scope ~expander ~obj_dir
       ?(dir_kind=Dune_lang.File_syntax.Dune)
       ~modules ~flags ~requires_compile ~requires_link
       ?(preprocessing=Preprocessing.dummy) ?(no_keep_locs=false)
-      ~opaque ?stdlib ?js_of_ocaml ~dynlink ?sandbox ~package () =
+      ~opaque ?stdlib ?js_of_ocaml ~dynlink ?sandbox ~package ?vimpl () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link
@@ -114,6 +116,7 @@ let create ~super_context ~scope ~expander ~obj_dir
   ; dynlink
   ; sandbox
   ; package
+  ; vimpl
   }
 
 let for_alias_module t =

--- a/src/compilation_context.mli
+++ b/src/compilation_context.mli
@@ -31,6 +31,7 @@ val create
   -> dynlink               : bool
   -> ?sandbox              : bool
   -> package               : Package.t option
+  -> ?vimpl                : Vimpl.t
   -> unit
   -> t
 
@@ -57,5 +58,6 @@ val js_of_ocaml          : t -> Dune_file.Js_of_ocaml.t option
 val dynlink              : t -> bool
 val sandbox              : t -> bool option
 val package              : t -> Package.t option
+val vimpl                : t -> Vimpl.t option
 
 val for_wrapped_compat : t -> t

--- a/src/dep_graph.ml
+++ b/src/dep_graph.ml
@@ -54,17 +54,4 @@ module Ml_kind = struct
 
   let dummy m =
     Ml_kind.Dict.make_both (dummy m)
-
-  let merge_impl ~(ml_kind : Ml_kind.t) _ vlib impl =
-    Some (Ml_kind.choose ml_kind ~impl ~intf:vlib)
-
-  let merge_for_impl ~(vlib : t) ~(impl : t) =
-    Ml_kind.Dict.of_func (fun ~ml_kind ->
-      let impl = Ml_kind.Dict.get impl ml_kind in
-      { impl with
-        per_module =
-          Module.Obj_map.union ~f:(merge_impl ~ml_kind)
-            (Ml_kind.Dict.get vlib ml_kind).per_module
-            impl.per_module
-      })
 end

--- a/src/dep_graph.mli
+++ b/src/dep_graph.mli
@@ -23,6 +23,4 @@ module Ml_kind : sig
   type nonrec t = t Ml_kind.Dict.t
 
   val dummy : Module.t -> t
-
-  val merge_for_impl : vlib:t -> impl:t -> t
 end

--- a/src/dep_rules.ml
+++ b/src/dep_rules.ml
@@ -1,0 +1,116 @@
+open! Import
+open Build.O
+
+let transitive_deps_contents modules =
+  List.map modules ~f:(fun m -> Module.Name.to_string (Module.name m))
+  |> String.concat ~sep:"\n"
+
+let ooi_deps cctx ~vlib_obj_map ~(ml_kind : Ml_kind.t) (m : Module.t) =
+  let cm_kind =
+    match ml_kind with
+    | Intf -> Cm_kind.Cmi
+    | Impl ->
+      Compilation_context.vimpl cctx
+      |> Option.value_exn
+      |> Vimpl.impl_cm_kind
+  in
+  let sctx = Compilation_context.super_context cctx in
+  let dir = Compilation_context.dir cctx in
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let (write, read) =
+    let ctx = Super_context.context sctx in
+    let unit =
+      Obj_dir.Module.cm_file_unsafe obj_dir m ~kind:cm_kind
+      |> Path.build
+    in
+    Ocamlobjinfo.rules ~dir ~ctx ~unit
+  in
+  let add_rule = Super_context.add_rule sctx ~dir in
+  add_rule write;
+  let read =
+    Build.memoize "ocamlobjinfo" (
+      read >>^ fun (ooi : Ocamlobjinfo.t) ->
+      Module.Name.Set.to_list ooi.intf
+      |> List.filter_map ~f:(fun dep ->
+        if Module.real_unit_name m = dep then
+          None
+        else
+          Module.Name.Map.find vlib_obj_map dep)
+    ) in
+  add_rule (
+    let target = Obj_dir.Module.dep obj_dir (Transitive (m, ml_kind)) in
+    read
+    >>^ transitive_deps_contents
+    >>> Build.write_file_dyn target);
+  read
+
+let deps_of_module cctx ~ml_kind m =
+  match Module.kind m with
+  | Wrapped_compat ->
+    let modules = Compilation_context.modules cctx in
+    begin match Modules.lib_interface modules with
+    | Some m -> m
+    | None -> Modules.compat_for_exn modules m
+    end
+    |> List.singleton
+    |> Build.return
+  | _ -> Ocamldep.deps_of ~cctx ~ml_kind m
+
+let deps_of_vlib_module cctx ~ml_kind m =
+  let vimpl = Option.value_exn (Compilation_context.vimpl cctx) in
+  let vlib = Vimpl.vlib vimpl in
+  match Lib.Local.of_lib vlib with
+  | None ->
+    let vlib_obj_map = Vimpl.vlib_obj_map vimpl in
+    ooi_deps cctx ~vlib_obj_map ~ml_kind m
+  | Some lib ->
+    let modules = Vimpl.vlib_modules vimpl in
+    let info = Lib.Local.info lib in
+    let vlib_obj_dir = Lib_info.obj_dir info in
+    let dir = Compilation_context.dir cctx in
+    let src =
+      Obj_dir.Module.dep vlib_obj_dir (Transitive (m, ml_kind))
+      |> Path.build
+    in
+    let dst =
+      let obj_dir = Compilation_context.obj_dir cctx in
+      Obj_dir.Module.dep obj_dir (Transitive (m, ml_kind))
+    in
+    let sctx = Compilation_context.super_context cctx in
+    Super_context.add_rule sctx ~dir (Build.symlink ~src ~dst);
+    Ocamldep.read_deps_of ~obj_dir:vlib_obj_dir ~modules ~ml_kind m
+
+let rec deps_of cctx ~ml_kind (m : Modules.Sourced_module.t) =
+  let is_alias =
+    match m with
+    | Imported_from_vlib m
+    | Normal m -> Module.kind m = Alias
+    | Impl_of_virtual_module _ -> false
+  in
+  if is_alias then
+    Build.return []
+  else
+    let skip_if_source_absent f m =
+      if Module.has m ~ml_kind then
+        f m
+      else
+        Build.return []
+    in
+    match m with
+    | Imported_from_vlib m ->
+      skip_if_source_absent (deps_of_vlib_module cctx ~ml_kind) m
+    | Normal m ->
+      skip_if_source_absent (deps_of_module cctx ~ml_kind) m
+    | Impl_of_virtual_module impl_or_vlib ->
+      let m = Ml_kind.Dict.get impl_or_vlib ml_kind in
+      begin match ml_kind with
+      | Intf -> deps_of cctx ~ml_kind (Imported_from_vlib m)
+      | Impl -> deps_of cctx ~ml_kind (Normal m)
+      end
+
+let rules cctx ~modules =
+  let dir = Compilation_context.dir cctx in
+  Ml_kind.Dict.of_func (fun ~ml_kind ->
+    let per_module =
+      Modules.obj_map modules ~f:(deps_of cctx ~ml_kind) in
+    Dep_graph.make ~dir ~per_module)

--- a/src/dep_rules.mli
+++ b/src/dep_rules.mli
@@ -1,0 +1,7 @@
+(** Get dependencies for a set of modules using either ocamldep or
+    ocamlobjinfo *)
+
+val rules
+  : Compilation_context.t
+  -> modules:Modules.t
+  -> Dep_graph.t Ml_kind.Dict.t

--- a/src/exe.ml
+++ b/src/exe.ml
@@ -199,7 +199,7 @@ let build_and_link_many
       cctx
   =
   let modules = Compilation_context.modules cctx in
-  let dep_graphs = Ocamldep.rules cctx ~modules in
+  let dep_graphs = Dep_rules.rules cctx ~modules in
   Module_compilation.build_all cctx ~dep_graphs;
 
   let link_time_code_gen = Link_time_code_gen.handle_special_libs cctx in

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -329,7 +329,7 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
     in
     let obj_dir = Library.obj_dir ~dir lib in
     Check_rules.add_obj_dir sctx ~obj_dir;
-    let vimpl = Virtual_rules.impl sctx ~lib ~dir ~scope in
+    let vimpl = Virtual_rules.impl sctx ~lib ~scope in
     Option.iter vimpl ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir);
     (* Preprocess before adding the alias module as it doesn't need
        preprocessing *)
@@ -371,19 +371,11 @@ module Gen (P : sig val sctx : Super_context.t end) = struct
         ~dynlink
         ?stdlib:lib.stdlib
         ~package:(Option.map lib.public ~f:(fun p -> p.package))
+        ?vimpl
     in
 
     let requires_compile = Compilation_context.requires_compile cctx in
-
-    let dep_graphs =
-      let modules = Compilation_context.modules cctx in
-      let dep_graphs = Ocamldep.rules cctx ~modules in
-      match vimpl with
-      | None -> dep_graphs
-      | Some impl ->
-        let vlib = Vimpl.vlib_dep_graph impl in
-        Dep_graph.Ml_kind.merge_for_impl ~vlib ~impl:dep_graphs
-    in
+    let dep_graphs = Dep_rules.rules cctx ~modules in
 
     gen_wrapped_compat_modules lib cctx;
     Module_compilation.build_all cctx ~dep_graphs;

--- a/src/menhir.ml
+++ b/src/menhir.ml
@@ -228,7 +228,7 @@ module Run (P : PARAMS) : sig end = struct
       in
       Modules.singleton_exe mock_module
     in
-    let dep_graphs = Ocamldep.rules cctx ~modules in
+    let dep_graphs = Dep_rules.rules cctx ~modules in
 
     Modules.iter_no_vlib modules ~f:(fun m ->
       Module_compilation.ocamlc_i

--- a/src/modules.mli
+++ b/src/modules.mli
@@ -61,7 +61,14 @@ val map_user_written : t -> f:(Module.t -> Module.t) -> t
 (** Returns all the compatibility modules. *)
 val wrapped_compat : t -> Module.Name_map.t
 
-val obj_map : t -> f:(Module.t -> 'a) -> 'a Module.Obj_map.t
+module Sourced_module : sig
+  type t =
+    | Normal of Module.t
+    | Imported_from_vlib of Module.t
+    | Impl_of_virtual_module of Module.t Ml_kind.Dict.t
+end
+
+val obj_map : t -> f:(Sourced_module.t -> 'a) -> 'a Module.Obj_map.t
 
 (** List of entry modules visible to users of the library. For wrapped
     libraries, this is always one module. For unwrapped libraries, this could be

--- a/src/ocamldep.ml
+++ b/src/ocamldep.ml
@@ -62,93 +62,61 @@ let interpret_deps cctx ~unit deps =
   | None -> deps
   | Some m -> m :: deps
 
-let deps_of cctx ~ml_kind unit =
-  let kind = Module.kind unit in
+let deps_of ~cctx ~ml_kind unit =
   let modules = Compilation_context.modules cctx in
-  match kind with
-  | Alias -> Build.return []
-  | Wrapped_compat ->
-    begin match Modules.lib_interface modules with
-    | Some m -> m
-    | None -> Modules.compat_for_exn modules unit
-    end
-    |> List.singleton
-    |> Build.return
-  | _ ->
-    let sctx = CC.super_context cctx in
-    begin match Module.source unit ~ml_kind with
-    | None -> Build.return []
-    | Some source ->
-      let obj_dir = Compilation_context.obj_dir cctx in
-      let dir = Compilation_context.dir cctx in
-      let dep = Obj_dir.Module.dep obj_dir in
-      let context = SC.context sctx in
-      let parse_module_names = parse_module_names ~modules in
-      let all_deps_file = dep (Transitive (unit, ml_kind)) in
-      let ocamldep_output = dep (Immediate source) in
-      SC.add_rule sctx ~dir
-        (let flags =
-           Option.value (Module.pp_flags unit) ~default:(Build.return []) in
-         Command.run (Ok context.ocamldep) ~dir:(Path.build context.build_dir)
-           [ A "-modules"
-           ; Command.Args.dyn flags
-           ; Ml_kind.flag ml_kind
-           ; Dep (Module.File.path source)
-           ]
-           ~stdout_to:ocamldep_output
-        );
-      let build_paths dependencies =
-        let dependency_file_path m =
-          let ml_kind m =
-            if Module.kind m = Alias then
-              None
-            else if Module.has m ~ml_kind:Intf then
-              Some Ml_kind.Intf
-            else
-              Some Impl
-          in
-          ml_kind m
-          |> Option.map ~f:(fun ml_kind ->
-            Path.build (dep (Transitive (m, ml_kind))))
-        in
-        List.filter_map dependencies ~f:dependency_file_path
+  let sctx = CC.super_context cctx in
+  let source = Option.value_exn (Module.source unit ~ml_kind) in
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let dir = Compilation_context.dir cctx in
+  let dep = Obj_dir.Module.dep obj_dir in
+  let context = SC.context sctx in
+  let parse_module_names = parse_module_names ~modules in
+  let all_deps_file = dep (Transitive (unit, ml_kind)) in
+  let ocamldep_output = dep (Immediate source) in
+  SC.add_rule sctx ~dir
+    (let flags =
+       Option.value (Module.pp_flags unit) ~default:(Build.return []) in
+     Command.run (Ok context.ocamldep) ~dir:(Path.build context.build_dir)
+       [ A "-modules"
+       ; Command.Args.dyn flags
+       ; Ml_kind.flag ml_kind
+       ; Dep (Module.File.path source)
+       ]
+       ~stdout_to:ocamldep_output
+    );
+  let build_paths dependencies =
+    let dependency_file_path m =
+      let ml_kind m =
+        if Module.kind m = Alias then
+          None
+        else if Module.has m ~ml_kind:Intf then
+          Some Ml_kind.Intf
+        else
+          Some Impl
       in
-      SC.add_rule sctx ~dir
-        ( Build.lines_of (Path.build ocamldep_output)
-          >>^ parse_deps_exn ~file:(Module.File.path source)
-          >>^ interpret_deps cctx ~unit
-          >>^ (fun modules ->
-            (build_paths modules,
-             List.map modules ~f:(fun m ->
-               Module.Name.to_string (Module.name m))
-            ))
-          >>> Build.merge_files_dyn ~target:all_deps_file);
-      let all_deps_file = Path.build all_deps_file in
-      Build.memoize (Path.to_string all_deps_file)
-        (Build.lines_of all_deps_file >>^ parse_module_names ~unit)
-    end
-
-let rules cctx ~modules =
-  let dir = CC.dir cctx in
-  Ml_kind.Dict.of_func (fun ~ml_kind ->
-    let per_module = Modules.obj_map modules ~f:(deps_of cctx ~ml_kind) in
-    Dep_graph.make ~dir ~per_module)
-
-let graph_of_remote_lib ~obj_dir ~modules =
-  let deps_of unit ~ml_kind =
-    if Module.kind unit = Alias then
-      Build.return []
-    else
-      match Module.source unit ~ml_kind with
-      | None -> Build.return []
-      | Some _ ->
-        let all_deps_file =
-          Obj_dir.Module.dep obj_dir (Transitive (unit, ml_kind)) in
-        Build.memoize (Path.Build.to_string all_deps_file)
-          (Build.lines_of (Path.build all_deps_file)
-           >>^ parse_module_names ~unit ~modules)
+      ml_kind m
+      |> Option.map ~f:(fun ml_kind ->
+        Path.build (dep (Transitive (m, ml_kind))))
+    in
+    List.filter_map dependencies ~f:dependency_file_path
   in
-  let dir = Obj_dir.dir obj_dir in
-  Ml_kind.Dict.of_func (fun ~ml_kind ->
-    let per_module = Modules.obj_map modules ~f:(deps_of ~ml_kind) in
-    Dep_graph.make ~dir ~per_module)
+  SC.add_rule sctx ~dir
+    ( Build.lines_of (Path.build ocamldep_output)
+      >>^ parse_deps_exn ~file:(Module.File.path source)
+      >>^ interpret_deps cctx ~unit
+      >>^ (fun modules ->
+        (build_paths modules,
+         List.map modules ~f:(fun m ->
+           Module.Name.to_string (Module.name m))
+        ))
+      >>> Build.merge_files_dyn ~target:all_deps_file);
+  let all_deps_file = Path.build all_deps_file in
+  Build.memoize (Path.to_string all_deps_file)
+    (Build.lines_of all_deps_file >>^ parse_module_names ~unit)
+
+let read_deps_of ~obj_dir ~modules ~ml_kind unit =
+  let all_deps_file =
+    Obj_dir.Module.dep obj_dir (Transitive (unit, ml_kind)) in
+  Build.memoize (Path.Build.to_string all_deps_file)
+    (Build.lines_of (Path.build all_deps_file)
+     >>^ parse_module_names ~unit ~modules)

--- a/src/ocamldep.mli
+++ b/src/ocamldep.mli
@@ -2,14 +2,15 @@
 
 open Stdune
 
-(** Generate ocamldep rules for all the modules in the context. *)
-val rules
-  :  Compilation_context.t
-  -> modules:Modules.t
-  -> Dep_graph.Ml_kind.t
+val deps_of
+  :  cctx:Compilation_context.t
+  -> ml_kind:Ml_kind.t
+  -> Module.t
+  -> (unit, Module.t list) Build.t
 
-(** Get the dep graph for an already defined library *)
-val graph_of_remote_lib
+val read_deps_of
   :  obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.t
-  -> Dep_graph.Ml_kind.t
+  -> ml_kind:Ml_kind.t
+  -> Module.t
+  -> (unit, Module.t list) Build.t

--- a/src/vimpl.ml
+++ b/src/vimpl.ml
@@ -5,26 +5,42 @@ type t =
   ; impl                 : Dune_file.Library.t
   ; vlib_modules         : Modules.t
   ; vlib_foreign_objects : Path.t list
-  ; vlib_dep_graph       : Dep_graph.Ml_kind.t
+  ; impl_cm_kind         : Cm_kind.t
+  ; vlib_obj_map         : Module.Name_map.t Lazy.t
   }
 
 let vlib_modules t = t.vlib_modules
 let vlib t = t.vlib
 let impl t = t.impl
-let vlib_dep_graph t = t.vlib_dep_graph
+let impl_cm_kind t = t.impl_cm_kind
 let impl_modules t m =
   match t with
   | None -> m
   | Some t -> Modules.impl ~vlib:t.vlib_modules m
 
-let make ~vlib ~impl ~vlib_modules ~vlib_foreign_objects ~vlib_dep_graph =
+let make ~vlib ~impl ~vlib_modules ~vlib_foreign_objects =
+  let impl_cm_kind =
+    let vlib_info = Lib.info vlib in
+    let { Mode.Dict. byte; native = _ } = Lib_info.modes vlib_info in
+    Mode.cm_kind (if byte then Byte else Native)
+  in
+  let vlib_obj_map = lazy (
+    Modules.obj_map vlib_modules ~f:(function
+      | Normal m -> m
+      | _ -> assert false)
+    |> Module.Obj_map.fold ~init:Module.Name.Map.empty ~f:(fun m acc ->
+      Module.Name.Map.add_exn acc (Module.real_unit_name m) m)
+  ) in
   { impl
+  ; impl_cm_kind
   ; vlib
   ; vlib_modules
-  ; vlib_dep_graph
   ; vlib_foreign_objects
+  ; vlib_obj_map
   }
 
 let vlib_stubs_o_files = function
   | None -> []
   | Some t -> t.vlib_foreign_objects
+
+let vlib_obj_map t = Lazy.force t.vlib_obj_map

--- a/src/vimpl.mli
+++ b/src/vimpl.mli
@@ -10,7 +10,6 @@ val make
   -> impl:Dune_file.Library.t
   -> vlib_modules:Modules.t
   -> vlib_foreign_objects:Path.t list
-  -> vlib_dep_graph:Dep_graph.Ml_kind.t
   -> t
 
 val impl : t -> Dune_file.Library.t
@@ -23,8 +22,10 @@ val impl_modules : t option -> Modules.t -> Modules.t
 
 val vlib : t -> Lib.t
 
-val vlib_dep_graph : t -> Dep_graph.Ml_kind.t
-
 (** Return the combined list of .o files for stubs consisting of .o files from
     the implementation and virtual library.*)
 val vlib_stubs_o_files : t option -> Path.t list
+
+val impl_cm_kind : t -> Cm_kind.t
+
+val vlib_obj_map : t -> Module.Name_map.t

--- a/src/virtual_rules.ml
+++ b/src/virtual_rules.ml
@@ -69,90 +69,11 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
       end
     end
   in
-  let copy_all_deps =
-    match Lib.Local.of_lib vlib with
-    | Some vlib ->
-      let vlib_obj_dir = Lib.Local.obj_dir vlib in
-      fun m ->
-        if Module.visibility m = Public && Module.kind m <> Alias then
-          List.iter [Intf; Impl] ~f:(fun ml_kind ->
-            Module.source m ~ml_kind
-            |> Option.iter ~f:(fun _ ->
-              let dep = Obj_dir.Module.Dep.Transitive (m, ml_kind) in
-              let src = Path.build (Obj_dir.Module.dep vlib_obj_dir dep) in
-              let dst = Obj_dir.Module.dep impl_obj_dir dep in
-              copy_to_obj_dir ~src ~dst)
-          );
-    | None ->
-      (* we only need to copy the .all-deps files for local libraries. for
-         remote libraries, we just use ocamlobjinfo *)
-      let vlib_dep_graph = Vimpl.vlib_dep_graph vimpl in
-      fun m ->
-        List.iter [Intf; Impl] ~f:(fun ml_kind ->
-          let dep_graph = Ml_kind.Dict.get vlib_dep_graph ml_kind in
-          let deps = Dep_graph.deps_of dep_graph m in
-          Module.source m ~ml_kind |> Option.iter ~f:(fun _ ->
-            let open Build.O in
-            deps >>^ (fun modules ->
-              modules
-              |> List.map ~f:(fun m -> Module.Name.to_string (Module.name m))
-              |> String.concat ~sep:"\n")
-            >>>
-            Build.write_file_dyn
-              (Obj_dir.Module.dep impl_obj_dir (Transitive (m, ml_kind)))
-            |> add_rule))
-  in
   let vlib_modules = Vimpl.vlib_modules vimpl in
   Modules.iter_no_vlib vlib_modules
-    ~f:(fun m -> copy_objs m; copy_all_deps m)
+    ~f:(fun m -> copy_objs m)
 
-
-let external_dep_graph sctx ~impl_cm_kind ~impl_obj_dir ~vlib_modules =
-  let dir = Obj_dir.dir impl_obj_dir in
-  let ocamlobjinfo =
-    let ctx = Super_context.context sctx in
-    fun m cm_kind ->
-      let unit =
-        Obj_dir.Module.cm_file_unsafe impl_obj_dir m ~kind:cm_kind
-        |> Path.build
-      in
-      Ocamlobjinfo.rules ~dir ~ctx ~unit
-  in
-  let vlib_obj_map =
-    Modules.fold_no_vlib vlib_modules ~init:Module.Name.Map.empty
-      ~f:(fun m acc ->
-        Module.Name.Map.add_exn acc (Module.real_unit_name m) m)
-  in
-  Ml_kind.Dict.of_func (fun ~ml_kind ->
-    let cm_kind =
-      match ml_kind with
-      | Impl -> impl_cm_kind
-      | Intf -> Cm_kind.Cmi
-    in
-    let deps_from_objinfo ~for_module (ocamlobjinfo : Ocamlobjinfo.t) =
-      Module.Name.Set.to_list ocamlobjinfo.intf
-      |> List.filter_map ~f:(fun dep ->
-        if Module.real_unit_name for_module = dep then
-          None (* no cycles *)
-        else
-          Module.Name.Map.find vlib_obj_map dep)
-    in
-    let per_module = Modules.obj_map vlib_modules ~f:(fun m ->
-      if Module.kind m = Alias
-      || (ml_kind = Intf && not (Module.has m ~ml_kind:Intf))
-      || (ml_kind = Impl && not (Module.has m ~ml_kind:Impl))
-      then
-        Build.return []
-      else
-        let (write, read) = ocamlobjinfo m cm_kind in
-        Super_context.add_rule sctx ~dir write;
-        let open Build.O in
-        Build.memoize "ocamlobjinfo" @@
-        read >>^ deps_from_objinfo ~for_module:m)
-    in
-    Dep_graph.make ~dir ~per_module)
-
-let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope =
+let impl sctx ~(lib : Dune_file.Library.t) ~scope =
   Option.map lib.implements ~f:begin fun (loc, implements) ->
     match Lib.DB.find (Scope.libs scope) implements with
     | None ->
@@ -203,22 +124,5 @@ let impl sctx ~dir ~(lib : Dune_file.Library.t) ~scope =
           in
           (modules, foreign_objects)
       in
-      let vlib_dep_graph =
-        match virtual_ with
-        | Local ->
-          let obj_dir =
-            Lib.Local.of_lib_exn vlib
-            |> Lib.Local.obj_dir
-          in
-          Ocamldep.graph_of_remote_lib ~obj_dir ~modules:vlib_modules
-        | External _ ->
-          let impl_obj_dir = Dune_file.Library.obj_dir ~dir lib in
-          let impl_cm_kind =
-            let { Mode.Dict. byte; native = _ } = Lib_info.modes info in
-            Mode.cm_kind (if byte then Byte else Native)
-          in
-          external_dep_graph sctx ~impl_cm_kind ~impl_obj_dir ~vlib_modules
-      in
-      Vimpl.make
-        ~impl:lib ~vlib ~vlib_modules ~vlib_dep_graph ~vlib_foreign_objects
+      Vimpl.make ~impl:lib ~vlib ~vlib_modules ~vlib_foreign_objects
   end

--- a/src/virtual_rules.mli
+++ b/src/virtual_rules.mli
@@ -8,7 +8,6 @@ val setup_copy_rules_for_impl
 
 val impl
   :  Super_context.t
-  -> dir:Path.Build.t
   -> lib:Dune_file.Library.t
   -> scope:Scope.t
   -> Vimpl.t option


### PR DESCRIPTION
Instead of taking vlib and impl dep graphs separately and then merging
them, we now have a higher level dependency procedure that is aware of
the special treatment implementations of virtual libraries need.