### PR TITLE
Warning defaults now depend on version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,9 @@
 
 - Fix coloring of error messages from the compiler (@diml, #2384)
 
+- Add warning `66` to default set of warnings starting for dune projects with
+  language verison >= `1.11` (@rgrinberg, @diml, fixes #2299)
+
 1.10.0 (04/06/2019)
 -------------------
 

--- a/src/compilation_context.ml
+++ b/src/compilation_context.ml
@@ -120,7 +120,11 @@ let create ~super_context ~scope ~expander ~obj_dir
   }
 
 let for_alias_module t =
-  let flags = Ocaml_flags.default ~profile:(SC.profile t.super_context) in
+  let flags =
+    let project = Scope.project t.scope in
+    let dune_version = Dune_project.dune_version project in
+    Ocaml_flags.default ~profile:(SC.profile t.super_context) ~dune_version
+  in
   let sandbox =
     let ctx = Super_context.context t.super_context in
     (* If the compiler reads the cmi for module alias even with [-w -49

--- a/src/env_node.ml
+++ b/src/env_node.ml
@@ -104,7 +104,10 @@ let rec ocaml_flags t ~profile ~expander =
   | None ->
     let default =
       match t.inherit_from with
-      | None -> Ocaml_flags.default ~profile
+      | None ->
+        let project = Scope.project t.scope in
+        let dune_version = Dune_project.dune_version project in
+        Ocaml_flags.default ~profile ~dune_version
       | Some (lazy t) -> ocaml_flags t ~profile ~expander
     in
     let flags =

--- a/src/ocaml_flags.ml
+++ b/src/ocaml_flags.ml
@@ -5,23 +5,30 @@ open Build.O
 let default_ocamlc_flags   = ["-g"]
 let default_ocamlopt_flags = ["-g"]
 
-let dev_mode_warnings =
+let dev_mode_warnings ~dune_version =
+  let codes =
+    [ 4
+    ; 29
+    ; 40
+    ; 41
+    ; 42
+    ; 44
+    ; 45
+    ; 48
+    ; 58
+    ; 59
+    ; 60
+    ]
+  in
+  let codes =
+    if dune_version >= (1, 11) then
+      codes @ [66]
+    else
+      codes
+  in
   "@a" ^
   String.concat ~sep:""
-    (List.map ~f:(sprintf "-%d")
-       [ 4
-       ; 29
-       ; 40
-       ; 41
-       ; 42
-       ; 44
-       ; 45
-       ; 48
-       ; 58
-       ; 59
-       ; 60
-       ; 66
-       ])
+    (List.map ~f:(sprintf "-%d") codes)
 
 let default_warnings =
   "-40"
@@ -29,9 +36,9 @@ let default_warnings =
 let vendored_warnings =
   ["-w"; "-a"]
 
-let default_flags ~profile =
+let default_flags ~dune_version ~profile =
   if profile = "dev" then
-    [ "-w"; dev_mode_warnings ^ default_warnings
+    [ "-w"; dev_mode_warnings ~dune_version ^ default_warnings
     ; "-strict-sequence"
     ; "-strict-formats"
     ; "-short-paths"
@@ -72,8 +79,8 @@ let empty =
 let of_list l =
   { empty with common = Build.arr (fun () -> l) }
 
-let default ~profile =
-  { common = Build.return (default_flags ~profile)
+let default ~dune_version ~profile =
+  { common = Build.return (default_flags ~dune_version ~profile)
   ; specific =
       { byte   = Build.return default_ocamlc_flags
       ; native = Build.return default_ocamlopt_flags

--- a/src/ocaml_flags.mli
+++ b/src/ocaml_flags.mli
@@ -17,7 +17,7 @@ val make
            -> (unit, string list) Build.t)
   -> t
 
-val default : profile:string -> t
+val default : dune_version:Syntax.Version.t -> profile:string -> t
 
 val empty : t
 

--- a/src/toplevel.ml
+++ b/src/toplevel.ml
@@ -126,6 +126,13 @@ module Stanza = struct
     let requires_compile = Lib.Compile.direct_requires compile_info in
     let requires_link = Lib.Compile.requires_link compile_info in
     let obj_dir = Source.obj_dir source in
+    let flags =
+      let project = Scope.project scope in
+      let dune_version = Dune_project.dune_version project in
+      let profile = Super_context.profile sctx in
+      Ocaml_flags.append_common
+        (Ocaml_flags.default ~dune_version ~profile) ["-w"; "-24"]
+    in
     let cctx =
       Compilation_context.create ()
         ~super_context:sctx
@@ -136,9 +143,7 @@ module Stanza = struct
         ~opaque:false
         ~requires_compile
         ~requires_link
-        ~flags:(Ocaml_flags.append_common
-                  (Ocaml_flags.default ~profile:(Super_context.profile sctx))
-                  ["-w"; "-24"])
+        ~flags
         ~dynlink:false
         ~package:None
     in

--- a/src/utop.ml
+++ b/src/utop.ml
@@ -72,6 +72,14 @@ let setup sctx ~dir =
     |> Lib.DB.resolve db >>| (fun utop -> utop :: libs)
     >>= Lib.closure ~linking:true
   in
+  let flags =
+    let project = Scope.project scope in
+    let dune_version = Dune_project.dune_version project in
+    (Ocaml_flags.append_common
+       (Ocaml_flags.default ~dune_version
+          ~profile:(Super_context.profile sctx))
+       ["-w"; "-24"])
+  in
   let cctx =
     Compilation_context.create ()
       ~super_context:sctx
@@ -82,9 +90,7 @@ let setup sctx ~dir =
       ~opaque:false
       ~requires_link:(lazy requires)
       ~requires_compile:requires
-      ~flags:(Ocaml_flags.append_common
-                (Ocaml_flags.default ~profile:(Super_context.profile sctx))
-                ["-w"; "-24"])
+      ~flags
       ~dynlink:false
       ~package:None
   in

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -50,7 +50,7 @@ Make sure pp flag is correct and variables are expanded
   B ../_build/default/pp-with-expand/.foobar.eobjs/byte
   S .
   FLG -pp '$PP/_build/default/pp/pp.exe -nothing'
-  FLG -w @a-4-29-40-41-42-44-45-48-58-59-60-66-40 -strict-sequence -strict-formats -short-paths -keep-locs
+  FLG -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs
 
 We want future-syntax to either be applied, or not, depending on OCaml version.
 Adding the `echo` with expected output to the set of lines is a way of achieving that.
@@ -60,7 +60,7 @@ Adding the `echo` with expected output to the set of lines is a way of achieving
   B ../_build/default/future-syntax/.pp_future_syntax.eobjs/byte
   EXCLUDE_QUERY_DIR
   FLG -pp '$BIN/ocaml-syntax-shims'
-  FLG -w @a-4-29-40-41-42-44-45-48-58-59-60-66-40 -strict-sequence -strict-formats -short-paths -keep-locs
+  FLG -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs
   S .
   sanitize_dot_merlin alias print-merlins-future-syntax
 

--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -7,11 +7,11 @@ This captures the commands that are being run:
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
   {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-modules","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-66-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-66-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-nodynlink","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-nodynlink","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-66-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
 
 As well as data about the garbage collector:


### PR DESCRIPTION
To get the default set of warnings, we must pass the syntax version.

I do not mention this specifically in the change list, as we can just pretend it was always like this and this is the first time we're changing things.