### PR TITLE
Use stable set of warnings

### DIFF
--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -9,6 +9,10 @@ module Version = struct
       match Int.compare major_a major_b with
       | (Gt | Lt) as ne -> ne
       | Eq -> Int.compare minor_a minor_b
+
+    let to_dyn t =
+      let open Dyn.Encoder in
+      pair int int t
   end
 
   include T
@@ -20,10 +24,6 @@ module Version = struct
   let to_string (a, b) = sprintf "%u.%u" a b
 
   let pp fmt t = Format.fprintf fmt "%s" (to_string t)
-
-  let to_dyn t =
-    let open Dyn.Encoder in
-    pair int int t
 
   let hash = Hashtbl.hash
 

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -50,7 +50,7 @@ Make sure pp flag is correct and variables are expanded
   B ../_build/default/pp-with-expand/.foobar.eobjs/byte
   S .
   FLG -pp '$PP/_build/default/pp/pp.exe -nothing'
-  FLG -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs
+  FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs
 
 We want future-syntax to either be applied, or not, depending on OCaml version.
 Adding the `echo` with expected output to the set of lines is a way of achieving that.
@@ -60,7 +60,7 @@ Adding the `echo` with expected output to the set of lines is a way of achieving
   B ../_build/default/future-syntax/.pp_future_syntax.eobjs/byte
   EXCLUDE_QUERY_DIR
   FLG -pp '$BIN/ocaml-syntax-shims'
-  FLG -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs
+  FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs
   S .
   sanitize_dot_merlin alias print-merlins-future-syntax
 

--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -7,11 +7,11 @@ This captures the commands that are being run:
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
   {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-modules","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamldep.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlc.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-nodynlink","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-nodynlink","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
-  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@a-4-29-40-41-42-44-45-48-58-59-60-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]}
+  {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "b", "ts": ..., "args": ["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]}
   {"cat": "process", "name": "ocamlopt.opt", "id": ..., "pid": ..., "ph": "e", "ts": ...}
 
 As well as data about the garbage collector:


### PR DESCRIPTION
This prevents new version of OCaml breaking the dev build. New warnings
should be introduced in a dune version aware way.