### PR TITLE
Disable the build info tests

### DIFF
--- a/dune-build-info.opam
+++ b/dune-build-info.opam
@@ -19,6 +19,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "1.11"}
 ]
+dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
   ["dune" "subst"] {pinned}
   [
@@ -29,8 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dune-build-info.opam.template
+++ b/dune-build-info.opam.template
@@ -1,0 +1,13 @@
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]


### PR DESCRIPTION
These tests aren't tied to any package, and hence cannot be run
separately from dune.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>