### PR TITLE
bump latest version to 2.0

### DIFF
--- a/src/stanza.ml
+++ b/src/stanza.ml
@@ -6,11 +6,12 @@ module Parser = struct
   type nonrec t = string * t list Dune_lang.Decoder.t
 end
 
-let latest_version = (1, 11)
+let latest_version = (2, 0)
 
 let syntax =
   Syntax.create ~name:"dune" ~desc:"the dune language"
     [ (0, 0) (* Jbuild syntax *)
+    ; (1, 11)
     ; latest_version
     ]
 

--- a/test/blackbox-tests/test-cases/allow_approximate_merlin/run.t
+++ b/test/blackbox-tests/test-cases/allow_approximate_merlin/run.t
@@ -17,7 +17,7 @@ For lang >= 1.9, a warning is printed:
 
 Indeed, adding this will suppress the warning:
 
-  $ echo '(lang dune 1.9)\n(allow_approximate_merlin)' > dune-project
+  $ printf '(lang dune 1.9)\n(allow_approximate_merlin)\n' > dune-project
   $ dune build @check
 
 However, the warning is not emitted if it is not fixable (#2399).

--- a/test/blackbox-tests/test-cases/dune-init/run.t
+++ b/test/blackbox-tests/test-cases/dune-init/run.t
@@ -10,7 +10,7 @@ Can build the public library
 
   $ cd _test_lib_dir && touch test_lib.opam && dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   | (name test_lib)
   $ cat ./_test_lib_dir/dune
   (library
@@ -61,7 +61,7 @@ Can build an executable
 
   $ cd _test_bin_dir && touch test_bin.opam && dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   | (name test_bin)
 
 Can run the created executable
@@ -141,7 +141,7 @@ Can build the combo project
 
   $ cd _test_lib_exe_dir && touch test_bin.opam && dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   | (name test_bin)
 
 Can run the combo project
@@ -174,7 +174,7 @@ Can build the multiple library project
 
   $ cd _test_lib && touch test_lib1.opam && dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   | (name test_lib1)
 
 Clan up the multiple library project
@@ -301,7 +301,7 @@ Can init and build a new executable project
 
   $ cd test_exec_proj && dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   | (name test_exec_proj)
   $ rm -rf ./test_exec_proj
 
@@ -322,7 +322,7 @@ Can init and build a new library project
 
   $ cd test_lib_proj && dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   | (name test_lib_proj)
 Can init and build a project using Esy
 

--- a/test/blackbox-tests/test-cases/dune-package/run.t
+++ b/test/blackbox-tests/test-cases/dune-package/run.t
@@ -1,6 +1,6 @@
   $ dune build
   $ cat _build/install/default/lib/a/dune-package
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name a)
   (library
    (name a)

--- a/test/blackbox-tests/test-cases/dune-project-edition/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-edition/run.t
@@ -4,9 +4,9 @@
   $ echo '(alias (name runtest) (action (progn)))' >  src/dune
   $ dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   $ cat dune-project
-  (lang dune 1.11)
+  (lang dune 2.0)
 
 Test that using menhir automatically update the dune-project file
 
@@ -14,5 +14,5 @@ Test that using menhir automatically update the dune-project file
   $ dune build
   Info: Appending this line to dune-project: (using menhir 2.0)
   $ cat dune-project
-  (lang dune 1.11)
+  (lang dune 2.0)
   (using menhir 2.0)

--- a/test/blackbox-tests/test-cases/github1529/run.t
+++ b/test/blackbox-tests/test-cases/github1529/run.t
@@ -3,5 +3,5 @@ file is present.
 
   $ dune build
   Info: Creating file dune-project with this contents:
-  | (lang dune 1.11)
+  | (lang dune 2.0)
   Info: Appending this line to dune-project: (using menhir 2.0)

--- a/test/blackbox-tests/test-cases/github1549/run.t
+++ b/test/blackbox-tests/test-cases/github1549/run.t
@@ -4,7 +4,7 @@ Reproduction case for #1549: too many parentheses in installed .dune files
   Entering directory 'backend'
 
   $ cat backend/_build/install/default/lib/dune_inline_tests/dune-package
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name dune_inline_tests)
   (library
    (name dune_inline_tests)

--- a/test/blackbox-tests/test-cases/inline_tests/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/run.t
@@ -38,7 +38,7 @@ The expected behavior for the following three tests is to output nothing: the te
   backend_mbc1
 
   $ dune runtest dune-file
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name foo)
   (library
    (name foo)

--- a/test/blackbox-tests/test-cases/ocamldep-multi-stanzas/run.t
+++ b/test/blackbox-tests/test-cases/ocamldep-multi-stanzas/run.t
@@ -16,10 +16,21 @@
   library, executable, and executables stanzas in this jbuild file. Note that
   each module cannot appear in more than one "modules" field - it must belong
   to a single library or executable.
-  Error: Multiple rules generated for _build/default/lib.cmo:
-  - <internal location>
-  - <internal location>
-  [1]
+  Entering directory 'jbuild'
+        ocamlc .test.eobjs/byte/dune__exe.{cmi,cmo,cmt}
+      ocamlopt .test.eobjs/native/dune__exe.{cmx,o}
+      ocamldep .lib.objs/lib.ml.d
+        ocamlc .lib.objs/byte/lib.{cmi,cmo,cmt}
+      ocamlopt .lib.objs/native/lib.{cmx,o}
+      ocamlopt lib.{a,cmxa}
+      ocamldep .test.eobjs/lib.ml.d
+        ocamlc .test.eobjs/byte/dune__exe__Lib.{cmi,cmo,cmt}
+      ocamlopt .test.eobjs/native/dune__exe__Lib.{cmx,o}
+      ocamldep .test.eobjs/test.ml.d
+        ocamlc .test.eobjs/byte/dune__exe__Test.{cmi,cmo,cmt}
+      ocamlopt .test.eobjs/native/dune__exe__Test.{cmx,o}
+      ocamlopt test.exe
+  foo bar
 
   $ dune build src/a.cma --debug-dep --display short --root jbuild
   Entering directory 'jbuild'

--- a/test/blackbox-tests/test-cases/variants-external-declaration/run.t
+++ b/test/blackbox-tests/test-cases/variants-external-declaration/run.t
@@ -6,7 +6,7 @@ declared in the virtual library definition.
   $ dune build -p vlibfoo-ext
 
   $ cat _build/install/default/lib/vlibfoo-ext/dune-package
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name vlibfoo-ext)
   (library
    (name vlibfoo-ext)

--- a/test/blackbox-tests/test-cases/variants-only-package/run.t
+++ b/test/blackbox-tests/test-cases/variants-only-package/run.t
@@ -4,7 +4,7 @@ known_implementations implementations when using -p
   $ cd project && dune build -p vlibfoo
 
   $ cat project/_build/install/default/lib/vlibfoo/dune-package
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name vlibfoo)
   (library
    (name vlibfoo)

--- a/test/blackbox-tests/test-cases/variants/run.t
+++ b/test/blackbox-tests/test-cases/variants/run.t
@@ -41,7 +41,7 @@ Check that variant data is installed in the dune package file.
   $ dune build --root dune-package
   Entering directory 'dune-package'
   $ cat  dune-package/_build/install/default/lib/a/dune-package
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name a)
   (library
    (name a)
@@ -66,7 +66,7 @@ Check that variant data is installed in the dune package file.
       (impl))
      (wrapped true))))
   $ cat  dune-package/_build/install/default/lib/b/dune-package
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name b)
   (library
    (name b)

--- a/test/blackbox-tests/test-cases/vlib-default-impl/run.t
+++ b/test/blackbox-tests/test-cases/vlib-default-impl/run.t
@@ -34,7 +34,7 @@ Check that default implementation data is installed in the dune package file.
   $ dune build --root dune-package
   Entering directory 'dune-package'
   $ cat dune-package/_build/install/default/lib/a/dune-package
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name a)
   (library
    (name a)

--- a/test/blackbox-tests/test-cases/vlib/run.t
+++ b/test/blackbox-tests/test-cases/vlib/run.t
@@ -319,7 +319,7 @@ Implement external virtual libraries with private modules
 Include variants and implementation information in dune-package
   $ dune build --root dune-package-info
   Entering directory 'dune-package-info'
-  (lang dune 1.11)
+  (lang dune 2.0)
   (name foo)
   (library
    (name foo.impl)


### PR DESCRIPTION
I need this to add a dune language feature (sandboxing spec).
To be clear, for this purpose I'm equally happy with 1.12 so if somebody thinks I should call it that (even if that version will never be released) I'm happy to do so.

The diff in test/blackbox-tests/test-cases/ocamldep-multi-stanzas/run.t seems strange, but it's to do with jbuild files, so it's probably OK.