### PR TITLE
Remove Path.append

### DIFF
--- a/bin/target.ml
+++ b/bin/target.ml
@@ -87,7 +87,8 @@ let resolve_path path ~(setup : Dune.Main.build_system) =
      | None ->
        match
          List.filter_map setup.workspace.contexts ~f:(fun ctx ->
-           let path = Path.append (Path.build ctx.Context.build_dir) path in
+           let path =
+             Path.append_source (Path.build ctx.Context.build_dir) src in
            if Build_system.is_target path then
              Some (File path)
            else

--- a/src/install.ml
+++ b/src/install.ml
@@ -311,7 +311,9 @@ module Entry = struct
   let add_install_prefix t ~paths ~prefix =
     let opam_will_install_in_this_dir = Section.Paths.get paths t.section in
     let i_want_to_install_the_file_as =
-      Path.append prefix (relative_installed_path t ~paths)
+      relative_installed_path t ~paths
+      |> Path.as_in_source_tree_exn
+      |> Path.append_source prefix
     in
     let dst =
       Path.reach i_want_to_install_the_file_as

--- a/src/install_rules.ml
+++ b/src/install_rules.ml
@@ -439,8 +439,11 @@ let symlink_installed_artifacts_to_build_install
   let install_dir = Config.local_install_dir ~context:ctx.name in
   List.map entries ~f:(fun (loc, entry) ->
     let dst =
-      Path.append (Path.build install_dir)
-        (Install.Entry.relative_installed_path entry ~paths:install_paths)
+      let relative =
+        Install.Entry.relative_installed_path entry ~paths:install_paths
+        |> Path.as_in_source_tree_exn
+      in
+      Path.append_source (Path.build install_dir) relative
       |> Path.as_in_build_dir_exn
     in
     let loc =

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -914,16 +914,6 @@ let append_local a b =
 let append_local = append_local
 let append_source = append_local
 
-let append a b =
-  match b with
-  | In_build_dir _ | External _ ->
-    Code_error.raise "Path.append called with directory that's \
-                    not in the source tree"
-      [ "a", to_dyn a
-      ; "b", to_dyn b
-      ]
-  | In_source_tree b -> append_local a b
-
 let basename t =
   match kind t with
   | In_source_dir t -> Local.basename t
@@ -963,6 +953,14 @@ let as_in_source_tree = function
   | In_source_tree s -> Some s
   | In_build_dir _
   | External _ -> None
+
+let as_in_source_tree_exn t =
+  match as_in_source_tree t with
+  | Some t -> t
+  | None ->
+    Code_error.raise
+      "[as_in_source_tree_exn] called on something not in source tree"
+      ["t", to_dyn t]
 
 let as_in_build_dir = function
   | In_build_dir b -> Some b

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -191,7 +191,6 @@ val reach_for_running : ?from:t -> t -> string
 val descendant : t -> of_:t -> t option
 val is_descendant : t -> of_:t -> bool
 
-val append : t -> t -> t
 val append_local : t -> Local.t -> t
 val append_source : t -> Source.t -> t
 
@@ -243,6 +242,7 @@ val is_in_build_dir : t -> bool
 (** [is_in_build_dir t = is_managed t && not (is_in_build_dir t)] *)
 val is_in_source_tree : t -> bool
 val as_in_source_tree : t -> Source.t option
+val as_in_source_tree_exn : t -> Source.t
 val as_in_build_dir : t -> Build.t option
 val as_in_build_dir_exn : t -> Build.t
 

--- a/test/expect-tests/stdune/path_tests.ml
+++ b/test/expect-tests/stdune/path_tests.ml
@@ -51,8 +51,8 @@ let insert_after_build_dir_exn p s =
   |> Path.to_dyn
   |> print_dyn
 
-let append x y =
-  Path.append x y
+let append_source x y =
+  Path.append_source x y
   |> Path.to_dyn
   |> print_dyn
 
@@ -106,110 +106,110 @@ let%expect_test _ =
   |}]
 
 let%expect_test _ =
-is_descendant (r "foo") ~of_:(r "bar/");
-[%expect{|
+  is_descendant (r "foo") ~of_:(r "bar/");
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-is_descendant (r "foo/") ~of_:(r "bar");
-[%expect{|
+  is_descendant (r "foo/") ~of_:(r "bar");
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-is_descendant (r "glob/foo") ~of_:(r "glob");
-[%expect{|
+  is_descendant (r "glob/foo") ~of_:(r "glob");
+  [%expect{|
 true
 |}]
 
 let%expect_test _ =
-is_descendant (r "glob/foo") ~of_:(r "glob/");
-[%expect{|
+  is_descendant (r "glob/foo") ~of_:(r "glob/");
+  [%expect{|
 true
 |}]
 
 let%expect_test _ =
-is_descendant (e "/foo/bar") ~of_:(e "/foo");
-[%expect{|
+  is_descendant (e "/foo/bar") ~of_:(e "/foo");
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-is_descendant (e "/foo/bar") ~of_:(e "/foo/bar");
-[%expect{|
+  is_descendant (e "/foo/bar") ~of_:(e "/foo/bar");
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-is_descendant (e "/foo/bar") ~of_:(e "/foo/bar/");
-[%expect{|
+  is_descendant (e "/foo/bar") ~of_:(e "/foo/bar/");
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-is_descendant (e "/foo/bar/") ~of_:(e "/foo/bar");
-[%expect{|
+  is_descendant (e "/foo/bar/") ~of_:(e "/foo/bar");
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-is_descendant (e "/foo/bar") ~of_:(e "/");
-[%expect{|
+  is_descendant (e "/foo/bar") ~of_:(e "/");
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-descendant (r "foo") ~of_:(r "foo/");
-[%expect{|
+  descendant (r "foo") ~of_:(r "foo/");
+  [%expect{|
 Some In_source_tree "."
 |}]
 
 let%expect_test _ =
-descendant (r "foo/") ~of_:(r "foo");
-[%expect{|
+  descendant (r "foo/") ~of_:(r "foo");
+  [%expect{|
 Some In_source_tree "."
 |}]
 
 let%expect_test _ =
-descendant (r "foo/bar") ~of_:(r "foo");
-[%expect{|
+  descendant (r "foo/bar") ~of_:(r "foo");
+  [%expect{|
 Some In_source_tree "bar"
 |}]
 
 let%expect_test _ =
-descendant Path.root ~of_:(r "foo");
-[%expect{|
+  descendant Path.root ~of_:(r "foo");
+  [%expect{|
 None
 |}]
 
 let%expect_test _ =
-descendant Path.root ~of_:Path.root;
-[%expect{|
+  descendant Path.root ~of_:Path.root;
+  [%expect{|
 Some In_source_tree "."
 |}]
 
 let%expect_test _ =
-descendant (r "foo") ~of_:Path.root;
-[%expect{|
+  descendant (r "foo") ~of_:Path.root;
+  [%expect{|
 Some In_source_tree "foo"
 |}]
 
 let%expect_test _ =
-descendant (Path.relative build_dir "foo") ~of_:root;
-[%expect{|
+  descendant (Path.relative build_dir "foo") ~of_:root;
+  [%expect{|
 None
 |}]
 
 let%expect_test _ =
-descendant (Path.relative build_dir "foo") ~of_:(Path.of_string "/foo/bar");
-[%expect{|
+  descendant (Path.relative build_dir "foo") ~of_:(Path.of_string "/foo/bar");
+  [%expect{|
 None
 |}]
 
 let%expect_test _ =
-descendant (Path.relative build_dir "foo/bar") ~of_:build_dir;
-[%expect{|
+  descendant (Path.relative build_dir "foo/bar") ~of_:build_dir;
+  [%expect{|
 Some In_source_tree "foo/bar"
 |}]
 
@@ -221,61 +221,61 @@ Some In_source_tree "bar"
 |}]
 
 let%expect_test _ =
-descendant (Path.relative build_dir "foo/bar") ~of_:(Path.relative build_dir "foo");
-[%expect{|
+  descendant (Path.relative build_dir "foo/bar") ~of_:(Path.relative build_dir "foo");
+  [%expect{|
 Some In_source_tree "bar"
 |}]
 
 let%expect_test _ =
-descendant (Path.of_string "/foo/bar") ~of_:(Path.of_string "/foo");
-[%expect{|
+  descendant (Path.of_string "/foo/bar") ~of_:(Path.of_string "/foo");
+  [%expect{|
 None
 |}]
 
 let%expect_test _ = explode "a/b/c";
-[%expect{|
+  [%expect{|
 Some ["a"; "b"; "c"]
 |}]
 
 let%expect_test _ = explode "a/b";
-[%expect{|
+  [%expect{|
 Some ["a"; "b"]
 |}]
 
 let%expect_test _ = explode "a";
-[%expect{|
+  [%expect{|
 Some ["a"]
 |}]
 
 let%expect_test _ = explode "";
-[%expect{|
+  [%expect{|
 Some []
 |}]
 
 let%expect_test _ = reach "/foo/baz" ~from:"/foo/bar";
-[%expect{|
+  [%expect{|
 "/foo/baz"
 |}]
 
 let%expect_test _ = reach "/foo/bar" ~from:"baz";
-[%expect{|
+  [%expect{|
 "/foo/bar"
 |}]
 
 let%expect_test _ = reach "bar/foo" ~from:"bar/baz/y";
-[%expect{|
+  [%expect{|
 "../../foo"
 |}]
 
 let%expect_test _ =
-relative (Path.of_string "relative") "/absolute/path";
-[%expect{|
+  relative (Path.of_string "relative") "/absolute/path";
+  [%expect{|
 External "/absolute/path"
 |}]
 
 let%expect_test _ =
-relative (Path.of_string "/abs1") "/abs2";
-[%expect{|
+  relative (Path.of_string "/abs1") "/abs2";
+  [%expect{|
 External "/abs2"
 |}]
 
@@ -285,13 +285,13 @@ External "/abs1"
 |}]
 
 let%expect_test _ = relative root "/absolute/path";
-[%expect{|
+  [%expect{|
 External "/absolute/path"
 |}]
 
 let%expect_test _ =
-of_filename_relative_to_initial_cwd "/absolute/path";
-[%expect{|
+  of_filename_relative_to_initial_cwd "/absolute/path";
+  [%expect{|
 External "/absolute/path"
 |}]
 
@@ -299,71 +299,48 @@ let%expect_test _ =
   Path.is_managed (e "relative/path")
   |> Dyn.Encoder.bool
   |> print_dyn;
-[%expect{|
+  [%expect{|
 false
 |}]
 
 let%expect_test _ =
-insert_after_build_dir_exn Path.root "foobar";
-[%expect.unreachable]
+  insert_after_build_dir_exn Path.root "foobar";
+  [%expect.unreachable]
 [@@expect.uncaught_exn {|
   ( "(\"Path.insert_after_build_dir_exn\",\
    \n{path = In_source_tree \".\";\
    \n  insert = \"foobar\"})") |}]
 
 let%expect_test _ =
-insert_after_build_dir_exn Path.build_dir "foobar";
-[%expect{|
+  insert_after_build_dir_exn Path.build_dir "foobar";
+  [%expect{|
 In_build_dir "foobar"
 |}]
 
 let%expect_test _ =
-insert_after_build_dir_exn (Path.relative Path.build_dir "qux") "foobar";
-[%expect{|
+  insert_after_build_dir_exn (Path.relative Path.build_dir "qux") "foobar";
+  [%expect{|
 In_build_dir "foobar/qux"
 |}]
 
 let%expect_test _ =
-append Path.build_dir (Path.relative Path.root "foo");
-[%expect{|
+  append_source Path.build_dir (Path.Source.relative Path.Source.root "foo");
+  [%expect{|
 In_build_dir "foo"
 |}]
 
 let%expect_test _ =
-append Path.build_dir (Path.relative Path.build_dir "foo");
-[%expect.unreachable]
-[@@expect.uncaught_exn {|
-  ( "(\"Path.append called with directory that's not in the source tree\",\
-   \n{a = In_build_dir \".\";\
-   \n  b = In_build_dir \"foo\"})") |}]
-
-let%expect_test _ =
-append Path.root (Path.relative Path.build_dir "foo");
-[%expect.unreachable]
-[@@expect.uncaught_exn {|
-  ( "(\"Path.append called with directory that's not in the source tree\",\
-   \n{a = In_source_tree \".\";\
-   \n  b = In_build_dir \"foo\"})") |}]
-
-let%expect_test _ =
-append Path.root (Path.relative Path.root "foo");
-[%expect{|
+  append_source Path.root (Path.Source.relative Path.Source.root "foo");
+  [%expect{|
 In_source_tree "foo"
 |}]
 
 let%expect_test _ =
-append (Path.of_string "/root") (Path.relative Path.root "foo");
-[%expect{|
+  append_source (Path.of_string "/root")
+    (Path.Source.relative Path.Source.root "foo");
+  [%expect{|
 External "/root/foo"
 |}]
-
-let%expect_test _ =
-append (Path.of_string "/root") (Path.relative Path.build_dir "foo");
-[%expect.unreachable]
-[@@expect.uncaught_exn {|
-  ( "(\"Path.append called with directory that's not in the source tree\",\
-   \n{a = External \"/root\";\
-   \n  b = In_build_dir \"foo\"})") |}]
 
 let%expect_test _ =
   Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")
@@ -387,14 +364,14 @@ None
 |}]
 
 let%expect_test _ =
-drop_build_context (e "/foo/bar");
-[%expect{|
+  drop_build_context (e "/foo/bar");
+  [%expect{|
 None
 |}]
 
 let%expect_test _ =
-drop_build_context Path.build_dir;
-[%expect{|
+  drop_build_context Path.build_dir;
+  [%expect{|
 None
 |}]
 
@@ -424,7 +401,7 @@ let%expect_test _ =
 
 let%expect_test _ =
   reach_for_running (Path.relative build_dir "foo/baz")
-          ~from:(Path.relative build_dir "foo/bar/baz");
+    ~from:(Path.relative build_dir "foo/bar/baz");
   [%expect{|
 "../../baz"
 |}]
@@ -445,20 +422,20 @@ let%expect_test _ =
 
 let%expect_test _ =
   relative Path.root "_build";
-    [%expect{|
+  [%expect{|
 In_build_dir "."
 |}]
 
 let%expect_test _ =
   (* This is not right, but kind of annoying to fix :/ *)
   relative (r "foo") "../_build";
-    [%expect{|
+  [%expect{|
 In_build_dir "."
 |}]
 
 let%expect_test _ =
   local_part (Path.of_string "/c/d");
-    [%expect{|
+  [%expect{|
 "c/d"
 |}]
 


### PR DESCRIPTION
This function only works when the second argument is in the source, so
we should just use that function.