### PR TITLE
Remove compat symlinks for jbuild files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
 
 - Enable `(explicit_js_mode)` by default. (#1941, @nojb)
 
+- Stop symlinking object files to main directory for stanzas defined `jbuild`
+  files (#2440, @rgrinerg)
+
 1.11.0 (23/07/2019)
 -------------------
 

--- a/src/module_compilation.ml
+++ b/src/module_compilation.ml
@@ -105,21 +105,6 @@ let build_cm cctx ~dep_graphs ~precompiled_cmi ~cm_kind (m : Module.t) =
             Option.value_exn (Obj_dir.Module.cmt_file obj_dir m ~ml_kind) in
           (fn :: other_targets, A "-bin-annot")
       in
-      if CC.dir_kind cctx = Jbuild then begin
-        (* Symlink the object files in the original directory for
-           backward compatibility *)
-        let old_dst =
-          (Module.obj_name m) ^ (Cm_kind.ext cm_kind)
-          |> Path.Build.relative dir
-        in
-        SC.add_rule sctx ~dir
-          (Build.symlink ~src:(Path.build dst) ~dst:old_dst);
-        List.iter other_targets ~f:(fun in_obj_dir ->
-          let in_dir = Path.Build.relative dir
-                         (Path.Build.basename in_obj_dir) in
-          SC.add_rule sctx ~dir
-            (Build.symlink ~src:(Path.build in_obj_dir) ~dst:in_dir))
-      end;
       let opaque_arg =
         let intf_only = cm_kind = Cmi && not (Module.has m ~ml_kind:Impl) in
         if opaque

--- a/test/blackbox-tests/test-cases/ocamldep-multi-stanzas/run.t
+++ b/test/blackbox-tests/test-cases/ocamldep-multi-stanzas/run.t
@@ -16,10 +16,19 @@
   library, executable, and executables stanzas in this jbuild file. Note that
   each module cannot appear in more than one "modules" field - it must belong
   to a single library or executable.
-  Error: Multiple rules generated for _build/default/lib.cmo:
-  - <internal location>
-  - <internal location>
-  [1]
+  Entering directory 'jbuild'
+      ocamldep .lib.objs/lib.ml.d
+        ocamlc .lib.objs/byte/lib.{cmi,cmo,cmt}
+      ocamlopt .lib.objs/native/lib.{cmx,o}
+      ocamlopt lib.{a,cmxa}
+      ocamldep .test.eobjs/lib.ml.d
+      ocamldep .test.eobjs/test.ml.d
+        ocamlc .test.eobjs/byte/lib.{cmi,cmo,cmt}
+        ocamlc .test.eobjs/byte/test.{cmi,cmo,cmt}
+      ocamlopt .test.eobjs/native/lib.{cmx,o}
+      ocamlopt .test.eobjs/native/test.{cmx,o}
+      ocamlopt test.exe
+  foo bar
 
   $ dune build src/a.cma --debug-dep --display short --root jbuild
   Entering directory 'jbuild'


### PR DESCRIPTION
This was a compatibility hack for jbuild files that is no longer
necessary in dune 2.0.

This should be one of the more benign breaking changes. (cc @avsm)