### PR TITLE
Error when stub names are relative paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,13 +24,16 @@
   would be allowed for unwrapped libraries (#2442, @rgrinberg)
 
 - mli only modules must now be explicitly declared. This was previously a
-  warning that is now an error. (#2442, @rgrinberg)
+  warning and is now an error. (#2442, @rgrinberg)
 
 - Modules filtered out from the module list via the Ordered Set Language must
   now be actual modules. (#2442, @rgrinberg)
 
 - Actions which introduce targets where new targets are forbidden (e.g.
   preprocessing) are now an error instead of a warning. (#2442, @rgrinberg)
+
+- Stub names are no longer allowed relative paths. This was previously a warning
+  and is now an error (#2443, @rgrinberg).
 
 1.11.0 (23/07/2019)
 -------------------

--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -68,10 +68,11 @@ let make (d : _ Dir_with_dune.t)
               let s = validate ~loc s in
               let s' = Filename.basename s in
               if s' <> s then begin
-                (* DUNE2: make this an error *)
-                User_warning.emit ~loc
-                  [ Pp.text "relative part of stub are no longer \
-                             necessary and are ignored."
+                User_error.raise ~loc
+                  [ Pp.text
+                      "relative part of stub is not necessary and should be \
+                       removed. To include sources in subdirectories, \
+                       use the include_subdirs stanza"
                   ]
               end;
               s'

--- a/test/blackbox-tests/test-cases/github734/run.t
+++ b/test/blackbox-tests/test-cases/github734/run.t
@@ -2,9 +2,6 @@
   File "src/dune", line 4, characters 10-17:
   4 |  (c_names stubs/x))
                 ^^^^^^^
-  Warning: relative part of stub are no longer necessary and are ignored.
-  File "src/dune", line 4, characters 10-17:
-  4 |  (c_names stubs/x))
-                ^^^^^^^
-  Error: x does not exist as a C source. x.c must be present
+  Error: relative part of stub is not necessary and should be removed. To
+  include sources in subdirectories, use the include_subdirs stanza
   [1]

--- a/test/blackbox-tests/test-cases/multi-dir/run.t
+++ b/test/blackbox-tests/test-cases/multi-dir/run.t
@@ -22,9 +22,9 @@ Test with C stubs in sub-directories
   File "dune", line 9, characters 16-25:
   9 |  (c_names stub1 sub/stub2))
                       ^^^^^^^^^
-  Warning: relative part of stub are no longer necessary and are ignored.
-          main alias runtest
-  Hello, world!
+  Error: relative part of stub is not necessary and should be removed. To
+  include sources in subdirectories, use the include_subdirs stanza
+  [1]
 
 Test some error cases
 ---------------------


### PR DESCRIPTION
Previously, these would be ignored with a warning.