### PR TITLE
Set default target from Common.t

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -44,6 +44,15 @@ type t =
   ; promote_install_files : bool
   }
 
+let workspace_file t = t.workspace_file
+let x t = t.x
+let profile t = t.profile
+let capture_outputs t = t.capture_outputs
+let root t = t.root
+let config t = t.config
+let only_packages t = t.only_packages
+let watch t = t.watch
+
 let prefix_target common s = common.target_prefix ^ s
 
 let set_dirs c =

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -52,6 +52,7 @@ let root t = t.root
 let config t = t.config
 let only_packages t = t.only_packages
 let watch t = t.watch
+let default_target t = t.default_target
 
 let prefix_target common s = common.target_prefix ^ s
 

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -1,31 +1,13 @@
-type t =
-  { debug_dep_path        : bool
-  ; debug_findlib         : bool
-  ; debug_backtraces      : bool
-  ; profile               : string option
-  ; workspace_file        : Arg.Path.t option
-  ; root                  : Workspace_root.t
-  ; target_prefix         : string
-  ; only_packages         : Dune.Package.Name.Set.t option
-  ; capture_outputs       : bool
-  ; x                     : string option
-  ; diff_command          : string option
-  ; auto_promote          : bool
-  ; force                 : bool
-  ; ignore_promoted_rules : bool
-  ; build_dir             : string
-  ; no_print_directory    : bool
-  ; store_orig_src_dir    : bool
-  ; (* Original arguments for the external-lib-deps hint *)
-    orig_args             : string list
-  ; config                : Dune.Config.t
-  ; default_target        : string
-  (* For build & runtest only *)
-  ; watch : bool
-  ; stats_trace_file : string option
-  ; always_show_command_line : bool
-  ; promote_install_files : bool
-  }
+type t
+
+val workspace_file : t -> Arg.Path.t option
+val x : t -> string option
+val profile : t -> string option
+val capture_outputs : t -> bool
+val root : t -> Workspace_root.t
+val config : t -> Dune.Config.t
+val only_packages : t -> Dune.Package.Name.Set.t option
+val watch : t -> bool
 
 val prefix_target : t -> string -> string
 

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -8,6 +8,7 @@ val root : t -> Workspace_root.t
 val config : t -> Dune.Config.t
 val only_packages : t -> Dune.Package.Name.Set.t option
 val watch : t -> bool
+val default_target : t -> string
 
 val prefix_target : t -> string -> string
 

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -35,28 +35,30 @@ module Main = struct
   include Dune.Main
 
   let scan_workspace ~log (common : Common.t) =
-    scan_workspace
-      ~log
-      ?workspace_file:(Option.map ~f:Arg.Path.path common.workspace_file)
-      ?x:common.x
-      ?profile:common.profile
-      ~capture_outputs:common.capture_outputs
-      ~ancestor_vcs:common.root.ancestor_vcs
-      ()
+    let workspace_file =
+      Common.workspace_file common
+      |> Option.map ~f:Arg.Path.path
+    in
+    let x = Common.x common in
+    let profile = Common.profile common in
+    let capture_outputs = Common.capture_outputs common in
+    let ancestor_vcs = (Common.root common).ancestor_vcs in
+    scan_workspace ~log ?workspace_file ?x ?profile ~capture_outputs
+      ~ancestor_vcs ()
 
-  let setup ~log ?external_lib_deps_mode (common : Common.t) =
+  let setup ~log ?external_lib_deps_mode common =
     let open Fiber.O in
+    let only_packages = Common.only_packages common in
     scan_workspace ~log common
-    >>= init_build_system
-          ?external_lib_deps_mode
-          ?only_packages:common.only_packages
+    >>= init_build_system ?external_lib_deps_mode ?only_packages
 end
 
 module Log = struct
   include Stdune.Log
 
-  let create (common : Common.t) =
-    Log.create ~display:common.config.display ()
+  let create common =
+    let display = (Common.config common).display in
+    Log.create ~display ()
 end
 
 module Scheduler = struct
@@ -64,23 +66,26 @@ module Scheduler = struct
   open Fiber.O
 
   let go ?log ~(common : Common.t) f =
+    let config = Common.config common in
     let f () =
-      Main.set_concurrency ?log common.config >>= f
+      Main.set_concurrency ?log config >>= f
     in
-    Scheduler.go ?log ~config:common.config f
+    Scheduler.go ?log ~config f
 
   let poll ?log ~(common : Common.t) ~once ~finally () =
+    let config = Common.config common in
     let once () =
-      let* () = Main.set_concurrency ?log common.config in
+      let* () = Main.set_concurrency ?log config in
       once ()
     in
-    Scheduler.poll ?log ~config:common.config ~once ~finally ()
+    Scheduler.poll ?log ~config ~once ~finally ()
 end
 
 let restore_cwd_and_execve (common : Common.t) prog argv env =
   let prog =
     if Filename.is_relative prog then
-      Filename.concat common.root.dir prog
+      let root = Common.root common in
+      Filename.concat root.dir prog
     else
       prog
   in

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -14,7 +14,8 @@ let term =
              ~doc:"List libraries that are not available and explain why")
   in
   Common.set_common common ~targets:[];
-  let env = Import.Main.setup_env ~capture_outputs:common.capture_outputs in
+  let capture_outputs = Common.capture_outputs common in
+  let env = Import.Main.setup_env ~capture_outputs in
   Scheduler.go ~log:(Log.create common) ~common (fun () ->
     let open Fiber.O in
     let* ctxs = Context.create ~env (Workspace.default ()) in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -25,10 +25,14 @@ let build_targets =
     ]
   in
   let name_ = Arg.info [] ~docv:"TARGET" in
-  let default_target = "@@default" in
   let term =
     let+ common = Common.term
-    and+ targets = Arg.(value & pos_all string [default_target] name_)
+    and+ targets = Arg.(value & pos_all string [] name_)
+    in
+    let targets =
+      match targets with
+      | [] -> [Common.default_target common]
+      | _ :: _ -> targets
     in
     Common.set_common common ~targets;
     let log = Log.create common in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -7,7 +7,7 @@ let run_build_command ~log ~common ~targets =
     let* setup = Main.setup ~log common in
     do_build setup (targets setup)
   in
-  if common.watch then begin
+  if Common.watch common then begin
     let once () =
       Cached_digest.invalidate_cached_timestamps ();
       once ()

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -120,7 +120,8 @@ let resolve_targets_mixed ~log common (setup : Dune.Main.build_system)
       List.map user_targets ~f:(function
         | String s -> resolve_target common ~setup s
         | Path p -> resolve_path p ~setup) in
-    if common.config.display = Verbose then begin
+    let config = Common.config common in
+    if config.display = Verbose then begin
       Log.info log "Actual targets:";
       List.concat_map targets ~f:(function
         | Ok targets -> targets


### PR DESCRIPTION
Previously, we would just ignore this value and hence `-p` would set to `@install` only because the default target was `@install`.