### PR TITLE
Remove virtual rules from bootstrap

### DIFF
--- a/src/virtual_rules.boot.ml
+++ b/src/virtual_rules.boot.ml
@@ -1,0 +1,2 @@
+let setup_copy_rules_for_impl ~sctx:_ ~dir:_ _ = ()
+let impl _ ~lib:_ ~scope:_ = None


### PR DESCRIPTION
These aren't necessary as dune doesn't use virtual libraries anymore