### PR TITLE
Remove ocamlobjinfo from bootstrap

### DIFF
--- a/src/ocamlobjinfo.boot.ml
+++ b/src/ocamlobjinfo.boot.ml
@@ -1,0 +1,5 @@
+type t = Module.Name.Set.t Ml_kind.Dict.t
+
+let to_dyn _ = assert false
+let rules ~dir:_ ~ctx:_ ~unit:_ = assert false
+let parse _ = assert false


### PR DESCRIPTION
This module is not necessary for bootstrapping