### PR TITLE
doc: only use "toplevel" in the OCaml sense

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1076,9 +1076,9 @@ expanded by dune.
 
 Dune supports the following variables:
 
-- ``project_root`` is the root of the current project. It is typically the
-  toplevel directory of your project and as long as you have a ``dune-project``
-  file there, ``project_root`` is independent of the workspace configuration
+- ``project_root`` is the root of the current project. It is typically the root
+  of your project and as long as you have a ``dune-project`` file there,
+  ``project_root`` is independent of the workspace configuration
 - ``workspace_root`` is the root of the current workspace. Note that
   the value of ``workspace_root`` is not constant and depends on
   whether your project is vendored or not

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -5,7 +5,7 @@ FAQ
 Why do many dune projects contain a Makefile?
 =============================================
 
-Many dune projects contain a toplevel `Makefile`. It is often only there for
+Many dune projects contain a root `Makefile`. It is often only there for
 convenience, for the following reasons:
 
 1. there are many different build systems out there, all with a different CLI.

--- a/doc/project-layout-specification.rst
+++ b/doc/project-layout-specification.rst
@@ -3,7 +3,7 @@ Project Layout and Metadata Specification
 *****************************************
 
 A typical dune project will have a ``dune-project`` and one or more
-``<package>.opam`` file at toplevel as well as ``dune`` files wherever
+``<package>.opam`` file at the root as well as ``dune`` files wherever
 interesting things are: libraries, executables, tests, documents to install,
 etc...
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -492,7 +492,7 @@ context or can be the description of an opam switch, as follows:
   ``--profile``
 
 - ``(env <env>)`` to set the environment for a particular context. This is of
-  higher precedence than the toplevel ``env`` stanza in the workspace file. This
+  higher precedence than the root ``env`` stanza in the workspace file. This
   field the same options as the :ref:`dune-env` stanza.
 
 - ``(toolchain <findlib_coolchain>)`` set findlib toolchain for the context.


### PR DESCRIPTION
Instead, rephrase using "repository root".

Closes #308