### PR TITLE
Remove the option in Dune_env.Stanza.t option

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -810,8 +810,8 @@ Fields supported in ``<settings>`` are:
 
 - ``(env-vars (<var1> <val1>) .. (<varN> <valN>))``. This will add the
   corresponding variables to the environment in which the build commands are
-  executed, and under which ``dune exec`` runs. At the moment, this mechanism is
-  only supported in ``dune-workspace`` files.
+  executed, and under which ``dune exec`` runs.
+
 
 - ``(binaries <filepath> (<filepath> as <name>))``. This will make the binary at
   ``<filepath>`` as ``<name>``. If the ``<name>`` isn't provided, then it will

--- a/src/context.ml
+++ b/src/context.ml
@@ -23,23 +23,14 @@ end
 
 module Env_nodes = struct
   type t =
-    { context: Dune_env.Stanza.t option
-    ; workspace: Dune_env.Stanza.t option
+    { context: Dune_env.Stanza.t
+    ; workspace: Dune_env.Stanza.t
     }
 
   let extra_env ~profile env_nodes =
-    let make_env l =
-      let open Option.O in
-      Option.value
-        ~default:Env.empty
-        (let* stanza = l in
-         let+ env = Dune_env.Stanza.find stanza ~profile
-         in
-         env.env_vars)
-    in
     Env.extend_env
-      (make_env env_nodes.context)
-      (make_env env_nodes.workspace)
+      (Dune_env.Stanza.find env_nodes.context ~profile).env_vars
+      (Dune_env.Stanza.find env_nodes.workspace ~profile).env_vars
 end
 
 type t =

--- a/src/context.mli
+++ b/src/context.mli
@@ -33,8 +33,8 @@ end
 
 module Env_nodes : sig
   type t =
-    { context: Dune_env.Stanza.t option
-    ; workspace: Dune_env.Stanza.t option
+    { context: Dune_env.Stanza.t
+    ; workspace: Dune_env.Stanza.t
     }
 end
 

--- a/src/dune_env.ml
+++ b/src/dune_env.ml
@@ -41,6 +41,14 @@ module Stanza = struct
     ; inline_tests   : Inline_tests.t option
     }
 
+  let empty_config = {
+    flags = Ocaml_flags.Spec.standard
+  ; c_flags =  C.Kind.Dict.make_both Ordered_set_lang.Unexpanded.standard
+  ; env_vars = Env.empty
+  ; binaries = []
+  ; inline_tests = None
+  }
+
   type pattern =
     | Profile of string
     | Any
@@ -100,7 +108,10 @@ module Stanza = struct
     in
     { loc; rules }
 
+  let empty = { loc = Loc.none; rules = [] }
+
   let find t ~profile =
+    Option.value ~default:empty_config @@
     List.find_map t.rules ~f:(fun (pat, cfg) ->
       match pat with
       | Any -> Some cfg

--- a/src/dune_env.mli
+++ b/src/dune_env.mli
@@ -36,7 +36,9 @@ module Stanza : sig
 
   val decode : t Dune_lang.Decoder.t
 
-  val find : t -> profile:string -> config option
+  val empty : t
+
+  val find : t -> profile:string -> config
 end
 
 type stanza +=

--- a/src/env_node.mli
+++ b/src/env_node.mli
@@ -9,7 +9,7 @@ val make
   :  dir:Path.Build.t
   -> inherit_from:t Lazy.t option
   -> scope:Scope.t
-  -> config:Dune_env.Stanza.t option
+  -> config:Dune_env.Stanza.t
   -> t
 
 val scope : t -> Scope.t

--- a/src/ocaml_flags.ml
+++ b/src/ocaml_flags.ml
@@ -78,6 +78,11 @@ type 'a t' =
 module Spec = struct
   type t = Ordered_set_lang.Unexpanded.t t'
 
+  let standard = {
+    common = Ordered_set_lang.Unexpanded.standard
+  ; specific = Mode.Dict.make_both Ordered_set_lang.Unexpanded.standard
+  }
+
   let decode =
     let open Dune_lang.Decoder in
     let field_oslu = Ordered_set_lang.Unexpanded.field in

--- a/src/ocaml_flags.mli
+++ b/src/ocaml_flags.mli
@@ -7,6 +7,7 @@ type t
 module Spec : sig
   type t
   val decode : t Dune_lang.Decoder.fields_parser
+  val standard : t
 end
 
 val make

--- a/src/super_context.ml
+++ b/src/super_context.ml
@@ -103,6 +103,7 @@ end = struct
   include Env_context
 
   let get_env_stanza t ~dir =
+    Option.value ~default:Dune_env.Stanza.empty @@
     let open Option.O in
     let* stanza = Path.Build.Map.find t.stanzas_per_dir dir in
     List.find_map stanza.data ~f:(function
@@ -460,16 +461,9 @@ let create
         ~inherit_from
         ~config
     in
-    match context.env_nodes with
-    | { context = None; workspace = None } ->
-      make ~config:(Some { loc = Loc.none; rules = [] }) ~inherit_from:None
-    | { context = Some _ as config; workspace = None }
-    | { context = None; workspace = Some _ as config } ->
-      make ~config ~inherit_from:None
-    | { context = Some _ as context ; workspace = Some _ as workspace } ->
-      make ~config:context
-        ~inherit_from:(Some (lazy (make ~inherit_from:None
-                                     ~config:workspace)))
+    make ~config:context.env_nodes.context
+      ~inherit_from:(Some (lazy (make ~inherit_from:None
+                                   ~config:context.env_nodes.workspace)))
   )
   in
   let artifacts =

--- a/src/workspace.ml
+++ b/src/workspace.ml
@@ -6,7 +6,7 @@ open Dune_lang.Decoder
 let syntax = Stanza.syntax
 
 let env_field =
-  field_o "env"
+  field "env" ~default:Dune_env.Stanza.empty
     (Syntax.since syntax (1, 1) >>>
      Dune_env.Stanza.decode)
 
@@ -50,7 +50,7 @@ module Context = struct
       { loc          : Loc.t
       ; profile      : string
       ; targets      : Target.t list
-      ; env          : Dune_env.Stanza.t option
+      ; env          : Dune_env.Stanza.t
       ; toolchain    : string option
       ; name         : string
       ; host_context : string option
@@ -182,7 +182,7 @@ module Context = struct
                     ~default:Config.default_build_profile
       ; name = "default"
       ; host_context = None
-      ; env = None
+      ; env = Dune_env.Stanza.empty
       ; toolchain = None
       ; paths = []
       }
@@ -191,7 +191,7 @@ end
 type t =
   { merlin_context : string option
   ; contexts       : Context.t list
-  ; env            : Dune_env.Stanza.t option
+  ; env            : Dune_env.Stanza.t
   }
 
 include Versioned_file.Make(struct type t = unit end)
@@ -289,7 +289,7 @@ let t ?x ?profile () = fields (t ?x ?profile ())
 let default ?x ?profile () =
   { merlin_context = Some "default"
   ; contexts = [Context.default ?x ?profile ()]
-  ; env = None
+  ; env = Dune_env.Stanza.empty
   }
 
 let load ?x ?profile p =

--- a/src/workspace.mli
+++ b/src/workspace.mli
@@ -14,7 +14,7 @@ module Context : sig
       { loc          : Loc.t
       ; profile      : string
       ; targets      : Target.t list
-      ; env          : Dune_env.Stanza.t option
+      ; env          : Dune_env.Stanza.t
       ; toolchain    : string option
       ; name         : string
       ; host_context : string option
@@ -40,7 +40,7 @@ module Context : sig
 
   val name : t -> string
 
-  val env : t -> Dune_env.Stanza.t option
+  val env : t -> Dune_env.Stanza.t
 
   val host_context : t -> string option
 end
@@ -51,7 +51,7 @@ end
 type t = private
   { merlin_context : string option
   ; contexts       : Context.t list
-  ; env            : Dune_env.Stanza.t option
+  ; env            : Dune_env.Stanza.t
   }
 
 val load : ?x:string -> ?profile:string -> Path.t -> t


### PR DESCRIPTION
Since it is already a list, it simplifies some part and remove one negligible optimization, which allowed to not create `env_node` of empty `env`.

The documentation for `env-vars` is updated.