### PR TITLE
Sandboxing tests osx

### DIFF
--- a/src/build_system.ml
+++ b/src/build_system.ml
@@ -1408,7 +1408,19 @@ end = struct
     let prev_trace = Trace.get (Path.build head_target) in
     let sandbox_mode =
       match Action.is_useful_to_sandbox action with
-      | Clearly_not -> Sandbox_mode.none
+      | Clearly_not ->
+        let config = (Dep.Set.sandbox_config deps) in
+        if Sandbox_config.mem config Sandbox_mode.none
+        then
+          Sandbox_mode.none
+        else
+          User_error.raise
+            ~loc:(rule_loc ~file_tree:t.file_tree ~info ~dir)
+            [
+              Pp.text
+                "Rule dependencies are configured to require sandboxing, but the rule has \
+                 no actions that could potentially require sandboxing."
+            ]
       | Maybe ->
         select_sandbox_mode
           ~loc:(rule_loc ~file_tree:t.file_tree ~info ~dir)

--- a/test/blackbox-tests/test-cases/sandboxing/run.t
+++ b/test/blackbox-tests/test-cases/sandboxing/run.t
@@ -77,23 +77,9 @@ If rule fails to generate targets, we give a good error message, even with sandb
   $ true > dune
   $ echo '(rule (target t) (deps (sandbox always)) (action (echo ":")))' >> dune
   $ dune build t
-  File "src/dep.ml", line 68, characters 6-12: Assertion failed
-  Backtrace:
-  Raised at file "src/dep.ml", line 68, characters 6-53
-  Called from file "list.ml", line 99, characters 22-25
-  Called from file "src/stdune/list.ml" (inlined), line 5, characters 19-33
-  Called from file "src/stdune/list.ml", line 39, characters 29-39
-  Called from file "src/dep.ml", line 125, characters 6-74
-  Called from file "src/build_system.ml", line 1426, characters 10-58
-  Called from file "src/fiber/fiber.ml", line 112, characters 7-12
-  Re-raised at file "src/stdune/exn.ml", line 39, characters 38-65
-  Called from file "src/fiber/fiber.ml", line 82, characters 8-15
-  Re-raised at file "src/stdune/exn.ml", line 39, characters 38-65
-  Called from file "src/fiber/fiber.ml", line 82, characters 8-15
-  
-  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
-  the little-death that brings total obliteration.  I will fully express
-  my cases.  Execution will pass over me and through me.  And when it
-  has gone past, I will unwind the stack along its path.  Where the
-  cases are handled there will be nothing.  Only I will remain.
+  File "dune", line 1, characters 0-61:
+  1 | (rule (target t) (deps (sandbox always)) (action (echo ":")))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Rule dependencies are configured to require sandboxing, but the rule
+  has no actions that could potentially require sandboxing.
   [1]

--- a/test/blackbox-tests/test-cases/sandboxing/run.t
+++ b/test/blackbox-tests/test-cases/sandboxing/run.t
@@ -54,23 +54,23 @@ When we don't pass [preserve_file_kind], the rules can observe the file kind cha
   $ rm -rf _build
   $ echo text-file > text-file
   $ true > dune
-  $ echo '(rule (target t) (deps text-file) (action (bash "find text-file -printf '%y' > t")))' >> dune
+  $ echo '(rule (deps text-file) (target t) (action (with-stdout-to %{target} (run file -h text-file))))' >> dune
 
   $ dune build t --sandbox symlink
-  $ cat _build/default/t
-  l
+  $ cat _build/default/t | grep -Eo 'link|ASCII'
+  link
 
   $ dune build t --sandbox none
-  $ cat _build/default/t
-  f
+  $ cat _build/default/t | grep -Eo 'link|ASCII'
+  ASCII
 
 When we pass [preserve_file_kind], the file type seen by the rule is preserved:
 
   $ true > dune
-  $ echo '(rule (target t) (deps text-file (sandbox preserve_file_kind)) (action (bash "find text-file -printf '%y' > t")))' >> dune
+  $ echo '(rule (target t) (deps text-file (sandbox preserve_file_kind)) (action (with-stdout-to %{target} (run file -h text-file))))' >> dune
   $ dune build t --sandbox symlink
-  $ cat _build/default/t
-  f
+  $ cat _build/default/t | grep -Eo 'link|ASCII'
+  ASCII
 
 If rule fails to generate targets, we give a good error message, even with sandboxing:
 

--- a/test/blackbox-tests/test-cases/sandboxing/run.t
+++ b/test/blackbox-tests/test-cases/sandboxing/run.t
@@ -75,11 +75,25 @@ When we pass [preserve_file_kind], the file type seen by the rule is preserved:
 If rule fails to generate targets, we give a good error message, even with sandboxing:
 
   $ true > dune
-  $ echo '(rule (target t) (deps (sandbox always)) (action (bash ":")))' >> dune
+  $ echo '(rule (target t) (deps (sandbox always)) (action (echo ":")))' >> dune
   $ dune build t
-  File "dune", line 1, characters 0-61:
-  1 | (rule (target t) (deps (sandbox always)) (action (bash ":")))
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Rule failed to generate the following targets:
-  - t
+  File "src/dep.ml", line 68, characters 6-12: Assertion failed
+  Backtrace:
+  Raised at file "src/dep.ml", line 68, characters 6-53
+  Called from file "list.ml", line 99, characters 22-25
+  Called from file "src/stdune/list.ml" (inlined), line 5, characters 19-33
+  Called from file "src/stdune/list.ml", line 39, characters 29-39
+  Called from file "src/dep.ml", line 125, characters 6-74
+  Called from file "src/build_system.ml", line 1426, characters 10-58
+  Called from file "src/fiber/fiber.ml", line 112, characters 7-12
+  Re-raised at file "src/stdune/exn.ml", line 39, characters 38-65
+  Called from file "src/fiber/fiber.ml", line 82, characters 8-15
+  Re-raised at file "src/stdune/exn.ml", line 39, characters 38-65
+  Called from file "src/fiber/fiber.ml", line 82, characters 8-15
+  
+  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
+  the little-death that brings total obliteration.  I will fully express
+  my cases.  Execution will pass over me and through me.  And when it
+  has gone past, I will unwind the stack along its path.  Where the
+  cases are handled there will be nothing.  Only I will remain.
   [1]

--- a/test/blackbox-tests/test-cases/sandboxing/run.t
+++ b/test/blackbox-tests/test-cases/sandboxing/run.t
@@ -75,11 +75,24 @@ When we pass [preserve_file_kind], the file type seen by the rule is preserved:
 If rule fails to generate targets, we give a good error message, even with sandboxing:
 
   $ true > dune
-  $ echo '(rule (target t) (deps (sandbox always)) (action (echo ":")))' >> dune
+  $ echo '(rule (target t) (deps (sandbox always)) (action (run true)))' >> dune
   $ dune build t
   File "dune", line 1, characters 0-61:
-  1 | (rule (target t) (deps (sandbox always)) (action (echo ":")))
+  1 | (rule (target t) (deps (sandbox always)) (action (run true)))
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Rule failed to generate the following targets:
+  - t
+  [1]
+
+If rule is configured to require sandboxing, but clearly needs none,
+we give an error message:
+
+  $ true > dune
+  $ echo '(rule (target t) (deps (sandbox always)) (action (echo "")))' >> dune
+  $ dune build t
+  File "dune", line 1, characters 0-60:
+  1 | (rule (target t) (deps (sandbox always)) (action (echo "")))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Rule dependencies are configured to require sandboxing, but the rule
   has no actions that could potentially require sandboxing.
   [1]


### PR DESCRIPTION
* The first commit ports the tests to OSX (hopefully)
* The second commit reproduces an assertion failure in the sandboxing code.

@aalekseyev let's try to avoid using bash in the tests as much as possible :)