### PR TITLE
Filesystem timestamp precision problem

### DIFF
--- a/src/stdune/float.ml
+++ b/src/stdune/float.ml
@@ -1,3 +1,9 @@
 type t = float
 
 let to_string = string_of_float
+
+let compare x y = Ordering.of_int (compare x y)
+
+let max x y = match compare x y with
+  | Eq | Gt -> x
+  | Lt -> y

--- a/src/stdune/float.mli
+++ b/src/stdune/float.mli
@@ -1,3 +1,7 @@
 type t = float
 
 val to_string : t -> string
+
+val compare : t -> t -> Ordering.t
+
+val max : t -> t -> t

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -91,7 +91,23 @@ module Make(H : sig
       |> List.sort ~compare:(fun (k, _) (k', _) -> Dyn.compare k k')
     )
 
+  let filteri_inplace t ~f =
+    (* Surely there's a more performant way of writing this.
+       (e.g. using filter_map_inplace), but starting with a simple thing
+       for now, in part because [filter_map_inplace] is not available
+       in 4.02. *)
+    let to_delete =
+      ref []
+    in
+    iter t ~f:(fun ~key ~data -> match f ~key ~data with
+      | false -> to_delete := key :: !to_delete
+      | true -> ());
+    List.iter !to_delete ~f:(fun k ->
+      remove t k)
+
   let iter t ~f = iter t ~f:(fun ~key:_ ~data -> f data)
+
+
 end
 
 let hash = MoreLabels.Hashtbl.hash

--- a/src/stdune/hashtbl_intf.ml
+++ b/src/stdune/hashtbl_intf.ml
@@ -19,4 +19,6 @@ module type S = sig
   val keys : _ t -> key list
 
   val to_dyn : ('v -> Dyn.t) -> 'v t -> Dyn.t
+
+  val filteri_inplace : 'a t -> f:(key:key -> data:'a -> bool) -> unit
 end

--- a/src/stdune/table.ml
+++ b/src/stdune/table.ml
@@ -86,3 +86,6 @@ let remove (type input) (type output) ((module T) : (input, output) t) k =
 
 let iter (type input) (type output) ((module T) : (input, output) t) ~f =
   T.H.iter T.value ~f
+
+let filteri_inplace (type input) (type output) ((module T) : (input, output) t) ~f =
+  T.H.filteri_inplace T.value ~f

--- a/src/stdune/table.mli
+++ b/src/stdune/table.mli
@@ -49,3 +49,5 @@ val find_or_add : ('k, 'v) t -> 'k -> f:('k -> 'v) -> 'v
 val remove : ('k, _) t -> 'k -> unit
 
 val iter : (_, 'v) t -> f:('v -> unit) -> unit
+
+val filteri_inplace : ('a, 'b) t -> f:(key:'a -> data:'b -> bool) -> unit

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -874,6 +874,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name incremental-rebuilds)
+ (deps (package dune) (source_tree test-cases/incremental-rebuilds))
+ (action
+  (chdir
+   test-cases/incremental-rebuilds
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name inline_tests)
  (deps (package dune) (source_tree test-cases/inline_tests))
  (action
@@ -1747,6 +1755,7 @@
   (alias ignored_subdirs)
   (alias include-loop)
   (alias include-qualified)
+  (alias incremental-rebuilds)
   (alias inline_tests)
   (alias install-dry-run)
   (alias install-libdir)
@@ -1939,6 +1948,7 @@
   (alias ignored_subdirs)
   (alias include-loop)
   (alias include-qualified)
+  (alias incremental-rebuilds)
   (alias inline_tests)
   (alias install-multiple-contexts)
   (alias install-partial-package)

--- a/test/blackbox-tests/test-cases/incremental-rebuilds/run.t
+++ b/test/blackbox-tests/test-cases/incremental-rebuilds/run.t
@@ -1,0 +1,28 @@
+  $ echo '(lang dune 2.0)' > dune-project
+  $ echo '(rule (target b) (deps a) (action (progn (echo "running") (with-stdout-to b (cat a)))))' >> dune
+
+Basic incremental compilation test: we avoid re-running the
+action when the file is the same and we re-run it when the file changes.
+
+This test checks, among other things, that on the filesystems with poor
+timestamp precision we still correctly rebuild when the file changes,
+even if two modifications happen in the same time slot.
+
+  $ echo 1 > a
+  $ dune build b
+  running
+  $ cat _build/default/b
+  1
+  $ dune build b
+  $ cat _build/default/b
+  1
+  $ echo 2 > a
+  $ dune build b
+  running
+  $ cat _build/default/b
+  2
+  $ echo 3 > a
+  $ dune build b
+  running
+  $ cat _build/default/b
+  3


### PR DESCRIPTION
Dune uses filesystem timestamps to detect file modifications. 
Not all filesystems record precise timestamps though. If two modifications happen at the same timestamp, dune gets confused.

In particular, if the following happens:

- file is written to (at time t0)
- dune reads file, records its digest and timestamp
- file is written to again (still at time t0)

then we end up with a stale digest associated with the current timestamp.

There are three scenarios to consider where this matters:

1. The file is in a build directory and is modified only by dune.
2. The file is in a source directory and is modified by a script that runs sequentially with dune.
3. The file is in a source directory and is modified by a user in parallel with dune.

We saw no obvious fix that'd be good for all (1,2,3) while keeping performance good.
The current PR fixes (1) and (2), but not (3).

This PR also makes a separate improvement of using file size to detect modification. That should help a lot in all 3 cases.