### PR TITLE
Improvements to `diff?` semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,11 @@
   already end in .exe. Second, when resolving binary names, .opt variants are no
   longer chosen automatically. (#2543, @nojb)
 
+- Make `(diff? x y)` move the correction file (`y`) away from the build 
+  directory to promotion staging area.
+  This makes corrections work with sandboxing and in general reduces build 
+  directory pollution. (#2486, @aalekseyev, fixes #2482)
+
 1.11.0 (23/07/2019)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,9 @@
 - Get rid of ad-hoc rules for guessing the version. Dune now only
   relies on the version written in the `dune-project` file and no
   longer read `VERSION` or similar files (#2541, @diml)
+  
+- In `(diff? x y)` action, require `x` to exist and register a 
+  dependency on that file. (#2486, @aalekseyev)
 
 - On Windows, an .exe suffix is no longer added implicitly to binary names that
   already end in .exe. Second, when resolving binary names, .opt variants are no

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -622,9 +622,10 @@ The following constructions are available:
 - ``(diff <file1> <file2>)`` is similar to ``(run diff <file1>
   <file2>)`` but is better and allows promotion.  See `Diffing and
   promotion`_ for more details
-- ``(diff? <file1> <file2>)`` is the same as ``(diff <file1>
-  <file2>)`` except that it is ignored when ``<file1>`` or ``<file2>``
-  doesn't exists
+- ``(diff? <file1> <file2>)`` is similar to ``(diff <file1>
+  <file2>)`` except that ``<file2>`` should be produced by a part of the
+  same action rather than be a dependency, is optional and will
+  be consumed by ``diff?``.
 - ``(cmp <file1> <file2>)`` is similar to ``(run cmp <file1>
   <file2>)`` but allows promotion.  See `Diffing and promotion`_ for
   more details

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -141,31 +141,22 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to ~stdin_from =
         Digest.generic data
       in
       exec_echo stdout_to (Digest.to_string_raw s)
-  | Diff ({ optional = _; file1; file2; mode } as diff) ->
-      if Diff.eq_files diff then
-        Fiber.return ()
-      else
-        let is_copied_from_source_tree file =
-          match Path.extract_build_context_dir_maybe_sandboxed file with
-          | None ->
-              false
-          | Some (_, file) ->
-              Path.exists (Path.source file)
-        in
-        if
-          is_copied_from_source_tree file1
-          && not (is_copied_from_source_tree file2)
-        then
-          Promotion.File.register
-            { src =
-                snd
-                  (Path.Build.split_sandbox_root
-                     (Path.as_in_build_dir_exn file2))
-            ; dst =
-                snd
-                  (Option.value_exn
-                     (Path.extract_build_context_dir_maybe_sandboxed file1))
-            };
+  | Diff ({ optional; file1; file2; mode } as diff) ->
+    let remove_intermediate_file () =
+      if optional then
+        (try Path.unlink file2 with
+         | (Unix.Unix_error (ENOENT, _, _)) -> ())
+    in
+    if Diff.eq_files diff then
+      (remove_intermediate_file ();
+       Fiber.return ())
+    else begin
+      let is_copied_from_source_tree file =
+        match Path.extract_build_context_dir_maybe_sandboxed file with
+        | None -> false
+        | Some (_, file) -> Path.exists (Path.source file)
+      in
+      Fiber.finalize (fun () ->
         if mode = Binary then
           User_error.raise
             [ Pp.textf "Files %s and %s differ."
@@ -173,8 +164,32 @@ let rec exec t ~ectx ~dir ~env ~stdout_to ~stderr_to ~stdin_from =
                 (Path.to_string_maybe_quoted file2)
             ]
         else
-          Print_diff.print file1 file2
-            ~skip_trailing_cr:(mode = Text && Sys.win32)
+          Print_diff.print file1 file2 ~skip_trailing_cr:(mode = Text && Sys.win32))
+        ~finally:(fun () ->
+          (match optional with
+          | false ->
+            if is_copied_from_source_tree file1 &&
+               (not (is_copied_from_source_tree file2)) then begin
+              Promotion.File.register_dep
+                ~source_file:
+                  (snd (Option.value_exn (
+                     Path.extract_build_context_dir_maybe_sandboxed file1)))
+                ~correction_file:
+                  (Path.as_in_build_dir_exn file2)
+            end
+          | true ->
+            if is_copied_from_source_tree file1 then begin
+              Promotion.File.register_intermediate
+                ~source_file:
+                  (snd (Option.value_exn (
+                     Path.extract_build_context_dir_maybe_sandboxed file1)))
+                ~correction_file:
+                  (Path.as_in_build_dir_exn file2)
+            end else
+              remove_intermediate_file ());
+          Fiber.return ()
+        )
+    end
   | Merge_files_into (sources, extras, target) ->
       let lines =
         List.fold_left

--- a/src/dune/action_unexpanded.ml
+++ b/src/dune/action_unexpanded.ml
@@ -414,12 +414,9 @@ module Infer = struct
       | Digest_files l ->
           List.fold_left l ~init:acc ~f:( +< )
       | Diff { optional; file1; file2; mode = _ } ->
-          if optional then
-            acc
-          else
-            acc +< file1 +< file2
+        if optional then acc +< file1 else acc +< file1 +< file2
       | Merge_files_into (sources, _extras, target) ->
-          List.fold_left sources ~init:acc ~f:( +< ) +@+ target
+        List.fold_left sources ~init:acc ~f:( +< ) +@+ target
       | Echo _ | System _ | Bash _ | Remove_tree _ | Mkdir _ ->
           acc
 

--- a/src/dune/diff.ml
+++ b/src/dune/diff.ml
@@ -32,6 +32,6 @@ let decode_binary path =
   and+ file2 = path in
   { optional = false; file1; file2; mode = Binary }
 
-let eq_files { optional; mode; file1; file2 } =
-  (optional && not (Path.exists file1 && Path.exists file2))
+let eq_files { optional ; mode; file1; file2 } =
+  (optional && not (Path.exists file2))
   || Mode.compare_files mode file1 file2 = Eq

--- a/src/dune/print_diff.ml
+++ b/src/dune/print_diff.ml
@@ -18,8 +18,8 @@ let print ?(skip_trailing_cr = Sys.win32) path1 path2 =
   let fallback () =
     User_error.raise ~loc
       [ Pp.textf "Files %s and %s differ."
-          (Path.to_string_maybe_quoted path1)
-          (Path.to_string_maybe_quoted path2)
+          (Path.to_string_maybe_quoted (Path.drop_optional_sandbox_root path1))
+          (Path.to_string_maybe_quoted (Path.drop_optional_sandbox_root path2))
       ]
   in
   let normal_diff () =

--- a/src/dune/promotion.mli
+++ b/src/dune/promotion.mli
@@ -1,15 +1,30 @@
 open! Stdune
 
 module File : sig
-  type t =
-    { src : Path.Build.t
-    ; dst : Path.Source.t
-    }
+  type t
 
   val to_dyn : t -> Dyn.t
 
-  (** Register a file to promote *)
-  val register : t -> unit
+  (** Register an intermediate file to promote.
+      The build path may point to the sandbox and the file will be
+      moved to the staging area.
+  *)
+  val register_intermediate :
+    source_file:Path.Source.t ->
+    correction_file:Path.Build.t ->
+    unit
+
+  (** Register file to promote where the correction
+      file is a dependency of the current action (rather than an
+      intermediate file).
+      [correction_file] refers to a path in the build dir, not in the sandbox
+      (it can point to the sandbox, but the sandbox root will be stripped).
+  *)
+  val register_dep :
+    source_file:Path.Source.t ->
+    correction_file:Path.Build.t ->
+    unit
+
 end
 
 (** Promote all registered files if [!Clflags.auto_promote]. Otherwise dump the

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -816,7 +816,7 @@ module Build = struct
 end
 
 module T : sig
-  type t = private
+  type t =
     | External of External.t
     | In_source_tree of Local.t
     | In_build_dir of Local.t
@@ -1139,6 +1139,11 @@ let extract_build_context_dir_maybe_sandboxed = function
   | In_build_dir t ->
       Option.map (Build.extract_build_context_dir_maybe_sandboxed t)
         ~f:(fun (base, rest) -> (in_build_dir base, rest))
+
+let drop_optional_sandbox_root = function
+  | (In_source_tree _ | External _) as x -> x
+  | In_build_dir t -> match (Build.split_sandbox_root t) with
+    | _sandbox_root, t -> (In_build_dir t : t)
 
 let extract_build_context_dir_exn t =
   match extract_build_context_dir t with

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -249,6 +249,8 @@ val drop_optional_build_context : t -> t
 
 val drop_optional_build_context_maybe_sandboxed : t -> t
 
+val drop_optional_sandbox_root : t -> t
+
 (** Drop the "_build/blah" prefix if present, return [t] if it's a source file,
     otherwise fail. *)
 val drop_optional_build_context_src_exn : t -> Source.t

--- a/test/blackbox-tests/test-cases/corrections/run.t
+++ b/test/blackbox-tests/test-cases/corrections/run.t
@@ -44,3 +44,34 @@ When correction is no longer produced, dune no longer complains.
   $ echo new-contents > text-file
 
   $ dune build @correction1
+
+Dependency on the second argument of diff? is *not* automatically added.
+This is fine if we think of it as an intermediate file rather than dep.
+
+  $ cat > dune <<EOF
+  > (alias (name correction1)
+  >   (deps)
+  >   (action
+  >     (progn
+  >     (diff? text-file text-file-corrected)))
+  > )
+  > EOF
+
+  $ > text-file-corrected echo corrected-contents-1
+
+  $ dune build @correction1
+
+But dune looks at this file if it exists. This is clearly a bug.
+One fix is to not look at it, and flag its existence as an error.
+
+  $ dune build text-file-corrected
+  $ dune build @correction1
+
+  $ rm -r _build
+
+  $ dune build text-file-corrected
+  $ dune build @correction1
+  File "text-file", line 1, characters 0-0:
+  Error: Files _build/default/text-file and _build/default/text-file-corrected
+  differ.
+  [1]

--- a/test/blackbox-tests/test-cases/corrections/run.t
+++ b/test/blackbox-tests/test-cases/corrections/run.t
@@ -12,11 +12,8 @@ It's OK if there's no correction:
   > EOF
   $ dune build @no_correction
 
-# CR-someday aalekseyev:
-# Weird: if dependency is missing, dune fails to report a correction.
-# This is an idiom used in the wild,
-# and in fact the docs suggest that one should do something like this,
-# and you can't even specify optional targets at all.
+Dependency on the first argument of diff? is automatically added
+and dune correctly complains
 
   $ cat > dune <<EOF
   > (alias (name correction1)
@@ -27,15 +24,6 @@ It's OK if there's no correction:
   > )
   > EOF
 
-  $ dune build @correction1
-
-  $ dune build text-file
-  $ dune build @correction1
-
-The correction shines through once the source file is created in the build dir:
-
-  $ rm -r _build
-  $ dune build text-file
   $ dune build @correction1
   File "text-file", line 1, characters 0-0:
   Error: Files _build/default/text-file and _build/default/text-file-corrected

--- a/test/blackbox-tests/test-cases/corrections/run.t
+++ b/test/blackbox-tests/test-cases/corrections/run.t
@@ -65,14 +65,12 @@ Promotion should work when sandboxing is used:
 
   $ dune build @correction1 --sandbox copy
   File "text-file", line 1, characters 0-0:
-  Error: Files
-  _build/.sandbox/150b972ad59fdd3e13294c94880afcfd/default/text-file and
-  _build/.sandbox/150b972ad59fdd3e13294c94880afcfd/default/text-file-corrected
+  Error: Files _build/default/text-file and _build/default/text-file-corrected
   differ.
   [1]
 
   $ dune promote
-  Skipping promotion of _build/default/text-file-corrected to text-file as the file is missing.
+  Promoting _build/default/text-file-corrected to text-file.
 
 Dependency on the second argument of diff? is *not* automatically added.
 This is fine because we think of it as an intermediate file rather than dep.

--- a/test/blackbox-tests/test-cases/promote/dune
+++ b/test/blackbox-tests/test-cases/promote/dune
@@ -4,6 +4,8 @@
  (name blah)
  (action (diff x x.gen)))
 
+(rule (with-stdout-to x.gen.copy (cat x.gen)))
+
 (rule (with-stdout-to y.gen (echo "titi")))
 
 (alias

--- a/test/blackbox-tests/test-cases/promote/run.t
+++ b/test/blackbox-tests/test-cases/promote/run.t
@@ -19,6 +19,20 @@ General tests
   $ cat x
   toto
 
+The correction file stays on the filesystem even after promotion and
+can be depended on by other actions.
+
+  $ cat _build/default/x.gen
+  toto
+
+  $ printf titi > x
+  $ dune build --display short @blah x.gen.copy
+  File "x", line 1, characters 0-0:
+  Error: Files _build/default/x and _build/default/x.gen differ.
+  [1]
+  $ cat _build/default/x.gen.copy
+  toto
+
 Otherwise this test fails on OSX
   $ dune clean --display short
 


### PR DESCRIPTION
As proposed in #2482, this PR changes the semantics of `diff?` in two ways:

- the first argument becomes a required dependency
- the second argument is treated as an intermediate file and is consumed by `diff?`. It's moved to the `.promotion-staging` directory where `dune promote` can still find it.