### PR TITLE
Remove the build tag from dune in the documentation

### DIFF
--- a/doc/opam.rst
+++ b/doc/opam.rst
@@ -90,7 +90,7 @@ Here's a complete example of a dune file with opam metadata specification:
     (description "A longer description")
     (depends
      (alcotest :with-test)
-     (dune (and :build (> 1.5)))
+     (dune (> 1.5))
      (foo (and :dev (> 1.5) (< 2.0)))
      (uri (>= 1.9.0))
      (uri (< 2.0.0))


### PR DESCRIPTION
Since ocaml/opam-repository#14266 it is a policy to not have dune marked as a build dependency but the dune documentation still has an example with dune marked as a build dependency.