### PR TITLE
Add test to attempt to reproduce 1541

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -628,6 +628,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name github1541)
+ (deps (package dune) (source_tree test-cases/github1541))
+ (action
+  (chdir
+   test-cases/github1541
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name github1549)
  (deps (package dune) (source_tree test-cases/github1549))
  (action
@@ -1741,6 +1749,7 @@
   (alias github1395)
   (alias github1426)
   (alias github1529)
+  (alias github1541)
   (alias github1549)
   (alias github1560)
   (alias github1616)
@@ -1938,6 +1947,7 @@
   (alias github1395)
   (alias github1426)
   (alias github1529)
+  (alias github1541)
   (alias github1549)
   (alias github1560)
   (alias github1616)

--- a/test/blackbox-tests/test-cases/github1541/run.t
+++ b/test/blackbox-tests/test-cases/github1541/run.t
@@ -1,0 +1,25 @@
+This demonstrates error messages whennever a pform isn't expanded
+
+  $ echo '(lang dune 2.0)' > dune-project
+
+for libraries:
+
+  $ echo '(rule (with-stdout-to dummy1 (echo "%{lib:fakelib:bar.ml}")))' > dune
+  $ dune build ./dummy1
+  File "dune", line 1, characters 38-57:
+  1 | (rule (with-stdout-to dummy1 (echo "%{lib:fakelib:bar.ml}")))
+                                            ^^^^^^^^^^^^^^^^^^^
+  Error: Library "fakelib" not found.
+  Hint: try: dune external-lib-deps --missing ./dummy1
+  [1]
+
+for binaries:
+
+  $ echo '(rule (with-stdout-to dummy2 (echo "%{bin:fakebin}")))' > dune
+  $ dune build ./dummy2
+  File "dune", line 1, characters 38-50:
+  1 | (rule (with-stdout-to dummy2 (echo "%{bin:fakebin}")))
+                                            ^^^^^^^^^^^^
+  Error: Program fakebin not found in the tree or in PATH
+   (context: default)
+  [1]


### PR DESCRIPTION
This test shows the errors that we get when we try to expand a percent
form from a missing library or binary.

cc @ejgallego and @jorisio I will close #1541 as it seems it was fixed sometime.