### PR TITLE
Inherit modes for libraries

### DIFF
--- a/src/dune/compilation_context.ml
+++ b/src/dune/compilation_context.ml
@@ -57,6 +57,7 @@ type t =
   ; sandbox : Sandbox_config.t
   ; package : Package.t option
   ; vimpl : Vimpl.t option
+  ; modes : Mode.Dict.Set.t
   }
 
 let super_context t = t.super_context
@@ -97,12 +98,14 @@ let package t = t.package
 
 let vimpl t = t.vimpl
 
+let modes t = t.modes
+
 let context t = Super_context.context t.super_context
 
 let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
     ~requires_compile ~requires_link ?(preprocessing = Preprocessing.dummy)
     ?(no_keep_locs = false) ~opaque ?stdlib ~js_of_ocaml ~dynlink ~package
-    ?vimpl () =
+    ?vimpl ?modes () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link
@@ -117,6 +120,7 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
        ocaml_modules/ocamlgraph/src/.graph.objs/byte/graph__Pack.cmi: *)
     Sandbox_config.no_sandboxing
   in
+  let modes = Option.value ~default:Mode.Dict.Set.all modes in
   { super_context
   ; scope
   ; expander
@@ -135,6 +139,7 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
   ; sandbox
   ; package
   ; vimpl
+  ; modes
   }
 
 let for_alias_module t =

--- a/src/dune/compilation_context.mli
+++ b/src/dune/compilation_context.mli
@@ -28,6 +28,7 @@ val create :
   -> dynlink:bool
   -> package:Package.t option
   -> ?vimpl:Vimpl.t
+  -> ?modes:Mode.Dict.Set.t
   -> unit
   -> t
 
@@ -73,5 +74,7 @@ val sandbox : t -> Sandbox_config.t
 val package : t -> Package.t option
 
 val vimpl : t -> Vimpl.t option
+
+val modes : t -> Mode.Dict.Set.t
 
 val for_wrapped_compat : t -> t

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -174,12 +174,26 @@ module Mode_conf : sig
 
   val to_dyn : t -> Dyn.t
 
+  module Kind : sig
+    type t =
+      | Inherited
+      | Requested of Loc.t
+  end
+
+  module Map : sig
+    type nonrec 'a t =
+      { byte : 'a
+      ; native : 'a
+      ; best : 'a
+      }
+  end
+
   module Set : sig
-    include Set.S with type elt = t
+    type nonrec t = Kind.t option Map.t
 
     val decode : t Dune_lang.Decoder.t
 
-    (** Both Byte and Native *)
+    (** Byte inherited, Best is requested *)
     val default : t
 
     val eval : t -> has_native:bool -> Mode.Dict.Set.t

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -135,12 +135,13 @@ let ocamlmklib (lib : Library.t) ~sctx ~dir ~expander ~o_files ~sandbox ~custom
        ; Hidden_targets targets
        ])
 
-let build_self_stubs lib ~sctx ~expander ~dir ~o_files =
+let build_self_stubs lib ~cctx ~expander ~dir ~o_files =
+  let sctx = Compilation_context.super_context cctx in
   let ctx = Super_context.context sctx in
-  let { Lib_config.ext_lib; ext_dll; has_native; _ } = ctx.lib_config in
+  let { Lib_config.ext_lib; ext_dll; _ } = ctx.lib_config in
   let static = Library.stubs_archive lib ~dir ~ext_lib in
   let dynamic = Library.dll lib ~dir ~ext_dll in
-  let modes = Mode_conf.Set.eval lib.modes ~has_native in
+  let modes = Compilation_context.modes cctx in
   let ocamlmklib = ocamlmklib lib ~sctx ~expander ~dir ~o_files in
   if
     modes.native && modes.byte
@@ -159,8 +160,9 @@ let build_self_stubs lib ~sctx ~expander ~dir ~o_files =
       ~targets:[ dynamic ]
   )
 
-let build_stubs lib ~sctx ~dir ~expander ~requires ~dir_contents
+let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents
     ~vlib_stubs_o_files =
+  let sctx = Compilation_context.super_context cctx in
   let lib_o_files =
     if Library.has_stubs lib then
       let c_sources =
@@ -176,7 +178,7 @@ let build_stubs lib ~sctx ~dir ~expander ~requires ~dir_contents
   Check_rules.add_files sctx ~dir lib_o_files;
   match vlib_stubs_o_files @ lib_o_files with
   | [] -> ()
-  | o_files -> build_self_stubs lib ~sctx ~dir ~expander ~o_files
+  | o_files -> build_self_stubs lib ~cctx ~dir ~expander ~o_files
 
 let build_shared lib ~sctx ~dir ~flags =
   let ctx = Super_context.context sctx in
@@ -224,9 +226,7 @@ let setup_build_archives (lib : Dune_file.Library.t) ~cctx
   let js_of_ocaml = lib.buildable.js_of_ocaml in
   let sctx = Compilation_context.super_context cctx in
   let ctx = Compilation_context.context cctx in
-  let { Lib_config.ext_obj; has_native; natdynlink_supported; _ } =
-    ctx.lib_config
-  in
+  let { Lib_config.ext_obj; natdynlink_supported; _ } = ctx.lib_config in
   let impl_only = Modules.impl_only modules in
   Modules.exit_module modules
   |> Option.iter ~f:(fun m ->
@@ -245,7 +245,7 @@ let setup_build_archives (lib : Dune_file.Library.t) ~cctx
   let top_sorted_modules =
     Dep_graph.top_closed_implementations dep_graphs.impl impl_only
   in
-  let modes = Mode_conf.Set.eval lib.modes ~has_native in
+  let modes = Compilation_context.modes cctx in
   (let cm_files =
      Cm_files.make ~obj_dir ~ext_obj ~modules ~top_sorted_modules
    in
@@ -298,12 +298,16 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
   let dynlink =
     Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries
   in
+  let modes =
+    let { Lib_config.has_native ; _ } = ctx.lib_config in
+    Dune_file.Mode_conf.Set.eval lib.modes ~has_native
+  in
   Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
     ~modules ~flags ~requires_compile ~requires_link ~preprocessing:pp
     ~no_keep_locs:lib.no_keep_locs ~opaque
     ~js_of_ocaml:(Some lib.buildable.js_of_ocaml) ~dynlink ?stdlib:lib.stdlib
     ~package:(Option.map lib.public ~f:(fun p -> p.package))
-    ?vimpl
+    ?vimpl ~modes
 
 let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
     ~compile_info =
@@ -320,18 +324,18 @@ let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
   let dir = Compilation_context.dir cctx in
   let scope = Compilation_context.scope cctx in
   let requires_compile = Compilation_context.requires_compile cctx in
-  let expander = Compilation_context.expander cctx in
   let dep_graphs = Dep_rules.rules cctx ~modules in
   Option.iter vimpl ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir);
   Check_rules.add_obj_dir sctx ~obj_dir;
   gen_wrapped_compat_modules lib cctx;
   Module_compilation.build_all cctx ~dep_graphs;
+  let expander = Super_context.expander sctx ~dir in
   if not (Library.is_virtual lib) then
     setup_build_archives lib ~cctx ~dep_graphs ~expander;
   let () =
     let vlib_stubs_o_files = Vimpl.vlib_stubs_o_files vimpl in
     if Library.has_stubs lib || not (List.is_empty vlib_stubs_o_files) then
-      build_stubs lib ~sctx ~dir ~expander ~requires:requires_compile
+      build_stubs lib ~cctx ~dir ~expander ~requires:requires_compile
         ~dir_contents ~vlib_stubs_o_files
   in
   Odoc.setup_library_odoc_rules cctx lib ~dep_graphs;

--- a/src/dune/mode.ml
+++ b/src/dune/mode.ml
@@ -72,6 +72,10 @@ module Dict = struct
   module Set = struct
     type nonrec t = bool t
 
+    let to_dyn { byte; native } =
+      let open Dyn.Encoder in
+      record [ ("byte", bool byte); ("native", bool native) ]
+
     let all = { byte = true; native = true }
 
     let to_list t =

--- a/src/dune/mode.mli
+++ b/src/dune/mode.mli
@@ -68,6 +68,8 @@ module Dict : sig
   module Set : sig
     type nonrec t = bool t
 
+    val to_dyn : t -> Dyn.t
+
     val encode : t -> Dune_lang.t list
 
     val all : t


### PR DESCRIPTION
This PR makes it so that `(modes ..)` settings are inherited in dependencies. This is important when depending on libraries such as `compiler-libs.toplevel`, which only provide a bytecode archive.

Some questions:

* The hack for libraries without archives is quite ugly. Shall we make it specific to compiler-libs perhaps?

* Do we need this for executables as well? If so, I would make that a separate PR.