### PR TITLE
Simplify Ordered_set_language

### DIFF
--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -53,7 +53,7 @@ let make (d : _ Dir_with_dune.t)
       | Library lib ->
         let eval (kind : C.Kind.t) (c_sources : C.Source.t String.Map.t)
               validate osl =
-          Ordered_set_lang.String.eval_unordered_loc osl
+          Ordered_set_lang.Unordered_string.eval_loc osl
             ~key:(fun x -> x)
             ~parse:(fun ~loc s ->
               let s = validate ~loc s in

--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -27,15 +27,7 @@ let c_name, cxx_name =
   , make "C++"
   )
 
-module Eval = struct
-  module Value = struct
-    type t = string
-    type key = string
-    let key s = s
-  end
-
-  include Ordered_set_lang.Make_loc(String)(Value)
-end
+module Eval = Ordered_set_lang.Make(String)
 
 let load_sources ~dune_version ~dir ~files =
   let init = C.Kind.Dict.make_both String.Map.empty in
@@ -63,7 +55,8 @@ let make (d : _ Dir_with_dune.t)
       | Library lib ->
         let eval (kind : C.Kind.t) (c_sources : C.Source.t String.Map.t)
               validate osl =
-          Eval.eval_unordered osl
+          Eval.eval_unordered_loc osl
+            ~key:(fun x -> x)
             ~parse:(fun ~loc s ->
               let s = validate ~loc s in
               let s' = Filename.basename s in

--- a/src/c_sources.ml
+++ b/src/c_sources.ml
@@ -27,8 +27,6 @@ let c_name, cxx_name =
   , make "C++"
   )
 
-module Eval = Ordered_set_lang.Make(String)
-
 let load_sources ~dune_version ~dir ~files =
   let init = C.Kind.Dict.make_both String.Map.empty in
   String.Set.fold files ~init ~f:(fun fn acc ->
@@ -55,7 +53,7 @@ let make (d : _ Dir_with_dune.t)
       | Library lib ->
         let eval (kind : C.Kind.t) (c_sources : C.Source.t String.Map.t)
               validate osl =
-          Eval.eval_unordered_loc osl
+          Ordered_set_lang.String.eval_unordered_loc osl
             ~key:(fun x -> x)
             ~parse:(fun ~loc s ->
               let s = validate ~loc s in

--- a/src/context.ml
+++ b/src/context.ml
@@ -532,14 +532,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
   native :: List.filter_opt others
 
 let extend_paths t ~env =
-  let module Eval =
-    Ordered_set_lang.Make(String)
-      (struct
-        type t = string
-        type key = string
-        let key x = x
-      end)
-  in
+  let module Eval = Ordered_set_lang.Make(String) in
   let t =
     let f (var, t) =
       let parse ~loc:_ s = s in

--- a/src/context.ml
+++ b/src/context.ml
@@ -532,7 +532,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
   native :: List.filter_opt others
 
 let extend_paths t ~env =
-  let module Eval = Ordered_set_lang.Make(String) in
   let t =
     let f (var, t) =
       let parse ~loc:_ s = s in

--- a/src/context.ml
+++ b/src/context.ml
@@ -544,7 +544,7 @@ let extend_paths t ~env =
     let f (var, t) =
       let parse ~loc:_ s = s in
       let standard = Env.path env |> List.map ~f:Path.to_string in
-      var, Eval.eval t ~parse ~standard
+      var, Ordered_set_lang.eval t ~parse ~standard ~eq:String.equal
     in
     List.map ~f t
   in

--- a/src/coq_module.ml
+++ b/src/coq_module.ml
@@ -59,3 +59,9 @@ module Value = struct
 end
 
 module Eval = Ordered_set_lang.Make(String)(Value)
+
+let eval =
+  let eq_key x y = String.equal (Value.key x) (Value.key y) in
+  fun ~dir ~standard osl ->
+    Ordered_set_lang.eval ~parse:(parse ~dir)
+      ~standard ~eq:eq_key osl

--- a/src/coq_module.ml
+++ b/src/coq_module.ml
@@ -52,16 +52,9 @@ let parse ~dir ~loc s =
     let source = Path.Build.relative source (name ^ ".v") in
     make ~name ~source ~prefix
 
-module Value = struct
-  type nonrec t = t
-  type key = string
-  let key x = String.concat ~sep:"." (x.prefix @ [x.name])
-end
-
-module Eval = Ordered_set_lang.Make(String)(Value)
-
 let eval =
-  let eq_key x y = String.equal (Value.key x) (Value.key y) in
+  let key x = String.concat ~sep:"." (x.prefix @ [x.name]) in
+  let eq_key x y = String.equal (key x) (key y) in
   fun ~dir ~standard osl ->
     Ordered_set_lang.eval ~parse:(parse ~dir)
       ~standard ~eq:eq_key osl

--- a/src/coq_module.mli
+++ b/src/coq_module.mli
@@ -35,10 +35,6 @@ val name : t -> string
 val obj_file : obj_dir:Path.Build.t -> ext:string -> t -> Path.Build.t
 val to_dyn : t -> Dyn.t
 
-(** Parses a form "a.b.c" to a module *)
-val parse : dir:Path.Build.t -> loc:Loc.t -> string -> t
-module Eval : Ordered_set_lang.S with type value := t
-
 val eval
   :  dir:Path.Build.t
   -> standard:t list

--- a/src/coq_module.mli
+++ b/src/coq_module.mli
@@ -38,3 +38,9 @@ val to_dyn : t -> Dyn.t
 (** Parses a form "a.b.c" to a module *)
 val parse : dir:Path.Build.t -> loc:Loc.t -> string -> t
 module Eval : Ordered_set_lang.S with type value := t
+
+val eval
+  :  dir:Path.Build.t
+  -> standard:t list
+  -> Ordered_set_lang.t
+  -> t list

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -135,7 +135,8 @@ let build_mlds_map (d : _ Dir_with_dune.t) ~files =
     | Documentation doc ->
       let mlds =
         let mlds = Memo.Lazy.force mlds in
-        Ordered_set_lang.String.eval_unordered doc.mld_files ~key:(fun x -> x)
+        Ordered_set_lang.Unordered_string.eval doc.mld_files
+          ~key:(fun x -> x)
           ~parse:(fun ~loc s ->
             match String.Map.find mlds s with
             | Some s ->

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -172,8 +172,7 @@ let coq_modules_of_files ~subdirs =
 let build_coq_modules_map (d : _ Dir_with_dune.t) ~dir ~modules =
   List.fold_left d.data ~init:Lib_name.Map.empty ~f:(fun map -> function
     | Coq.T coq ->
-      let modules = Coq_module.Eval.eval coq.modules
-        ~parse:(Coq_module.parse ~dir) ~standard:modules in
+      let modules = Coq_module.eval coq.modules ~dir ~standard:modules in
       Lib_name.Map.set map (Dune_file.Coq.best_name coq) modules
     | _ -> map)
 

--- a/src/dir_contents.ml
+++ b/src/dir_contents.ml
@@ -135,7 +135,7 @@ let build_mlds_map (d : _ Dir_with_dune.t) ~files =
     | Documentation doc ->
       let mlds =
         let mlds = Memo.Lazy.force mlds in
-        Ordered_set_lang.String.eval_unordered doc.mld_files
+        Ordered_set_lang.String.eval_unordered doc.mld_files ~key:(fun x -> x)
           ~parse:(fun ~loc s ->
             match String.Map.find mlds s with
             | Some s ->

--- a/src/expander.ml
+++ b/src/expander.ml
@@ -558,7 +558,7 @@ let expand_and_eval_set t set ~standard =
         ~files_contents:Path.Map.empty ~f
     in
     standard >>^ fun standard ->
-    Ordered_set_lang.String.eval set ~standard ~parse
+    Ordered_set_lang.eval set ~standard ~parse ~eq:String.equal
   | paths ->
     List.map paths ~f:(fun f -> Build.read_sexp f syntax)
     |> Build.all
@@ -566,7 +566,7 @@ let expand_and_eval_set t set ~standard =
     >>^ fun (standard, sexps) ->
     let files_contents = List.combine paths sexps |> Path.Map.of_list_exn in
     Ordered_set_lang.Unexpanded.expand set ~dir ~files_contents ~f
-    |> Ordered_set_lang.String.eval ~standard ~parse
+    |> Ordered_set_lang.eval ~standard ~parse ~eq:String.equal
 
 let eval_blang t = function
   | Blang.Const x -> x (* common case *)

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -21,16 +21,11 @@ type kind =
   | Exe_or_normal_lib
 
 let eval =
-  let module Value = struct
-    type t = (Module.Source.t, Module_name.t) result
-
-    type key = Module_name.t
-
-    let key = function
-      | Error s -> s
-      | Ok m -> Module.Source.name m
-  end in
-  let module Eval = Ordered_set_lang.Make_loc(Module_name)(Value) in
+  let key = function
+    | Error s -> s
+    | Ok m -> Module.Source.name m
+  in
+  let module Eval = Ordered_set_lang.Make(Module_name) in
   let parse ~all_modules ~fake_modules ~loc s =
     let name = Module_name.of_string s in
     match Module_name.Map.find all_modules name with
@@ -42,7 +37,7 @@ let eval =
   fun ~loc ~fake_modules ~all_modules ~standard osl ->
     let parse = parse ~fake_modules ~all_modules in
     let standard = Module_name.Map.map standard ~f:(fun m -> loc, Ok m) in
-    let modules = Eval.eval_unordered ~parse ~standard osl in
+    let modules = Eval.eval_unordered_loc ~parse ~standard ~key osl in
     Module_name.Map.filter_map modules ~f:(fun (loc, m) ->
       match m with
       | Ok m -> Some (loc, m)

--- a/src/modules_field_evaluator.ml
+++ b/src/modules_field_evaluator.ml
@@ -25,7 +25,7 @@ let eval =
     | Error s -> s
     | Ok m -> Module.Source.name m
   in
-  let module Eval = Ordered_set_lang.Make(Module_name) in
+  let module Unordered = Ordered_set_lang.Unordered(Module_name) in
   let parse ~all_modules ~fake_modules ~loc s =
     let name = Module_name.of_string s in
     match Module_name.Map.find all_modules name with
@@ -37,7 +37,7 @@ let eval =
   fun ~loc ~fake_modules ~all_modules ~standard osl ->
     let parse = parse ~fake_modules ~all_modules in
     let standard = Module_name.Map.map standard ~f:(fun m -> loc, Ok m) in
-    let modules = Eval.eval_unordered_loc ~parse ~standard ~key osl in
+    let modules = Unordered.eval_loc ~parse ~standard ~key osl in
     Module_name.Map.filter_map modules ~f:(fun (loc, m) ->
       match m with
       | Ok m -> Some (loc, m)

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -116,14 +116,14 @@ end
 module type S = sig
   module Key : Key
 
-  val eval_unordered
+  val eval
     :  t
     -> parse:(loc:Loc.t -> string -> 'a)
     -> key:('a -> Key.t)
     -> standard:'a Key.Map.t
     -> 'a Key.Map.t
 
-  val eval_unordered_loc
+  val eval_loc
     :  t
     -> parse:(loc:Loc.t -> string -> 'a)
     -> key:('a -> Key.t)
@@ -181,10 +181,10 @@ end
 let eval t ~parse ~eq ~standard =
   Eval.ordered eq t ~parse ~standard
 
-module Make(Key : Key) = struct
+module Unordered(Key : Key) = struct
   module Key = Key
 
-  let eval_unordered t ~parse ~key ~standard =
+  let eval t ~parse ~key ~standard =
     let singleton = Key.Map.singleton in
     let empty = Key.Map.empty in
     let merge = Key.Map.merge in
@@ -192,8 +192,8 @@ module Make(Key : Key) = struct
 
   let loc_parse f ~loc s = (loc, f ~loc s)
 
-  let eval_unordered_loc t ~parse ~key ~standard =
-    eval_unordered t
+  let eval_loc t ~parse ~key ~standard =
+    eval t
       ~parse:(loc_parse parse) ~key:(fun (_, x) -> key x)
       ~standard
 end
@@ -377,4 +377,4 @@ module Unexpanded = struct
     { t with ast = expand t.ast }
 end
 
-module String = Make(String)
+module Unordered_string = Unordered(String)

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -132,13 +132,7 @@ module type S = sig
 end
 
 module Eval = struct
-  type ('k, 'map) t =
-    { singleton : 'k -> 'map
-    ; union : 'map list -> 'map
-    ; diff : 'map -> 'map -> 'map
-    }
-
-  let of_ast { diff ; singleton; union } t ~parse ~standard =
+  let of_ast ~diff ~singleton ~union t ~parse ~standard =
     let rec loop (t : ast_expanded) =
       match t with
       | Element (loc, s) ->
@@ -151,50 +145,50 @@ module Eval = struct
         let right = loop right in
         diff left right
     in
-    loop t.ast
+    if is_standard t then
+      standard
+    else
+      loop t.ast
 
-  let ordered (type a) (eq : a -> a -> bool) =
-    { singleton = List.singleton
-    ; union = (fun x -> List.flatten x)
-    ; diff = fun a b ->
-        List.filter a ~f:(fun x ->
-          List.for_all b ~f:(fun y ->
-            not (eq x y)))
-    }
+  let ordered eq =
+    let singleton = List.singleton in
+    let union = List.flatten in
+    let diff a b =
+      List.filter a ~f:(fun x ->
+        List.for_all b ~f:(fun y ->
+          not (eq x y)))
+    in
+    of_ast ~diff ~singleton ~union
+
+  let unordered ~singleton ~empty ~merge ~key =
+    let singleton x = singleton (key x) x in
+    let union =
+      List.fold_left ~init:empty ~f:(fun acc t ->
+        merge acc t ~f:(fun _name x y ->
+          match x, y with
+          | Some x, _ | _, Some x -> Some x
+          | _ -> None))
+    in
+    let diff a b =
+      merge a b ~f:(fun _name x y ->
+        match x, y with
+        | Some _, None -> x
+        | _ -> None)
+    in
+    of_ast ~diff ~singleton ~union
 end
 
 let eval t ~parse ~eq ~standard =
-  if is_standard t then
-    standard
-  else
-    let named_values = Eval.ordered eq in
-    Eval.of_ast named_values t ~parse ~standard
+  Eval.ordered eq t ~parse ~standard
 
 module Make(Key : Key) = struct
   module Key = Key
 
-  let unordered ~key =
-    { Eval.
-      singleton = (fun x -> Key.Map.singleton (key x) x)
-    ; union =
-        List.fold_left ~init:Key.Map.empty ~f:(fun acc t ->
-          Key.Map.merge acc t ~f:(fun _name x y ->
-            match x, y with
-            | Some x, _ | _, Some x -> Some x
-            | _ -> None))
-    ; diff =
-        Key.Map.merge ~f:(fun _name x y ->
-          match x, y with
-          | Some _, None -> x
-          | _ -> None)
-    }
-
   let eval_unordered t ~parse ~key ~standard =
-    if is_standard t then
-      standard (* inline common case *)
-    else
-      let eval = unordered ~key in
-      Eval.of_ast eval t ~parse ~standard
+    let singleton = Key.Map.singleton in
+    let empty = Key.Map.empty in
+    let merge = Key.Map.merge in
+    Eval.unordered ~singleton ~empty ~merge ~key t ~parse ~standard
 
   let loc_parse f ~loc s = (loc, f ~loc s)
 

--- a/src/ordered_set_lang.ml
+++ b/src/ordered_set_lang.ml
@@ -135,12 +135,12 @@ module Eval = struct
   let of_ast ~diff ~singleton ~union t ~parse ~standard =
     let rec loop (t : ast_expanded) =
       match t with
-      | Element (loc, s) ->
+      | Ast.Element (loc, s) ->
         let x = parse ~loc s in
         singleton x
-      | Standard -> standard
-      | Union elts -> union (List.map elts ~f:loop)
-      | Diff (left, right) ->
+      | Ast.Standard -> standard
+      | Ast.Union elts -> union (List.map elts ~f:loop)
+      | Ast.Diff (left, right) ->
         let left  = loop left  in
         let right = loop right in
         diff left right

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -29,12 +29,6 @@ module type S = sig
   type value
   type 'a map
 
-  val eval
-    :  t
-    -> parse:(loc:Loc.t -> string -> value)
-    -> standard:value list
-    -> value list
-
   (** Same as [eval] but the result is unordered *)
   val eval_unordered
     :  t
@@ -43,6 +37,13 @@ module type S = sig
     -> value map
 end
 
+val eval
+  : t
+  -> parse:(loc:Loc.t -> string -> 'a)
+  -> eq:('a -> 'a -> bool)
+  -> standard:'a list
+  -> 'a list
+
 module Make(Key : Key)(Value : Value with type key = Key.t)
   : S with type value = Value.t
        and type 'a map = 'a Key.Map.t
@@ -50,12 +51,6 @@ module Make(Key : Key)(Value : Value with type key = Key.t)
 (** same as [Make] but will retain the source location of the values in the
     evaluated results *)
 module Make_loc (Key : Key)(Value : Value with type key = Key.t) : sig
-  val eval
-    :  t
-    -> parse:(loc:Loc.t -> string -> Value.t)
-    -> standard:(Loc.t * Value.t) list
-    -> (Loc.t * Value.t) list
-
   (** Same as [eval] but the result is unordered *)
   val eval_unordered
     :  t
@@ -63,6 +58,13 @@ module Make_loc (Key : Key)(Value : Value with type key = Key.t) : sig
     -> standard:(Loc.t * Value.t) Key.Map.t
     -> (Loc.t * Value.t) Key.Map.t
 end
+
+val eval_loc
+    :  t
+    -> parse:(loc:Loc.t -> string -> 'a)
+    -> eq:('a -> 'a -> bool)
+    -> standard:(Loc.t * 'a) list
+    -> (Loc.t * 'a) list
 
 val standard : t
 val is_standard : t -> bool

--- a/src/ordered_set_lang.mli
+++ b/src/ordered_set_lang.mli
@@ -22,7 +22,7 @@ module type S = sig
   module Key : Key
 
   (** Same as [eval] but the result is unordered *)
-  val eval_unordered
+  val eval
     :  t
     -> parse:(loc:Loc.t -> string -> 'a)
     -> key:('a -> Key.t)
@@ -30,7 +30,7 @@ module type S = sig
     -> 'a Key.Map.t
 
   (** Same as [eval] but the result is unordered *)
-  val eval_unordered_loc
+  val eval_loc
     :  t
     -> parse:(loc:Loc.t -> string -> 'a)
     -> key:('a -> Key.t)
@@ -45,7 +45,7 @@ val eval
   -> standard:'a list
   -> 'a list
 
-module Make(Key : Key) : S with module Key := Key
+module Unordered(Key : Key) : S with module Key := Key
 
 val eval_loc
     :  t
@@ -111,4 +111,4 @@ module Unexpanded : sig
     -> 'a
 end with type expanded := t
 
-module String : S with module Key := String
+module Unordered_string : S with module Key := String


### PR DESCRIPTION
I removed all the functors for the unordered case since it's just passing one function. For the unordered case, there's still a functor because maps aren't polymorphic. However, the resulting modules are at least polymorphic in the values. Lastly, there's a couple of minor unrelated changes. No_loc is now unified under the same functor and the is_standard optimization is done in only one place.

This is a pre-requesite for `per_file`.