### PR TITLE
Compile stubs for @check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,8 @@
   presence of directories with only sub-directories and no files
   (#2514, fixes #2499, @diml)
 
+- Include building stubs in `@check` rules. (@rgrinberg, #2530)
+
 1.11.0 (23/07/2019)
 -------------------
 

--- a/src/check_rules.ml
+++ b/src/check_rules.ml
@@ -25,3 +25,9 @@ let add_obj_dir sctx ~obj_dir =
       (Alias.check ~dir:(Obj_dir.dir obj_dir))
       ~dyn_deps
       Path.Set.empty
+
+let add_files sctx ~dir files =
+  if (Super_context.context sctx).merlin then
+    let alias = Alias.check ~dir in
+    let files = Path.Set.of_list files in
+    Rules.Produce.Alias.add_deps alias files

--- a/src/check_rules.mli
+++ b/src/check_rules.mli
@@ -1,3 +1,9 @@
 open Stdune
 
 val add_obj_dir : Super_context.t -> obj_dir:Path.Build.t Obj_dir.t -> unit
+
+val add_files
+  : Super_context.t
+  -> dir:Path.Build.t
+  -> Path.t list
+  -> unit

--- a/src/lib_rules.ml
+++ b/src/lib_rules.ml
@@ -251,6 +251,7 @@ let build_stubs lib ~sctx ~dir ~expander ~requires ~dir_contents
     else
       []
   in
+  Check_rules.add_files sctx ~dir lib_o_files;
   match vlib_stubs_o_files @ lib_o_files with
   | [] -> ()
   | o_files -> build_self_stubs lib ~sctx ~dir ~expander ~o_files

--- a/test/blackbox-tests/test-cases/check-alias/lib/bar.c
+++ b/test/blackbox-tests/test-cases/check-alias/lib/bar.c
@@ -1,0 +1,3 @@
+int bla () {
+    return 0;
+}

--- a/test/blackbox-tests/test-cases/check-alias/lib/dune
+++ b/test/blackbox-tests/test-cases/check-alias/lib/dune
@@ -1,2 +1,3 @@
 (library
- (name foo))
+ (name foo)
+ (c_names bar))

--- a/test/blackbox-tests/test-cases/check-alias/run.t
+++ b/test/blackbox-tests/test-cases/check-alias/run.t
@@ -6,6 +6,7 @@
 
   $ dune build --root lib @check --display short && ls lib/.merlin
   Entering directory 'lib'
+        ocamlc bar$ext_obj
       ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
   lib/.merlin


### PR DESCRIPTION
Without this, errors in C/C++ sources would be ignored when building
@check

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>