### PR TITLE
use DUNE_LIBDIR environent variable

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -259,6 +259,7 @@ let install_uninstall ~what =
       Arg.(value
            & opt (some string) None
            & info ["libdir"]
+               ~env:(env_var "DUNE_LIBDIR")
                ~docv:"PATH"
                ~doc:"Directory where library files are copied, relative to \
                      $(b,prefix) or absolute. If $(b,--prefix) \


### PR DESCRIPTION
This helps me solve the following problem when porting for OpenBSD:

The OCaml libdir on OpenBSD is ``/usr/local/lib/ocaml``.
When creating binary packages the installation is made into a "fake"
root, which results in a libdir like
``/usr/ports/pobj/dune-1.10.0/fake-amd64/usr/local/lib/ocaml``
which is constructed from ``PREFIX`` and ``DESTDIR``:
``${DESTDIR}/${TRUEPREFIX}/lib/ocaml``

Now, since the pre-dune era, we set ``OCAMLFIND_DESTDIR`` to
``/usr/local/lib/ocaml`` when building a port, but to
``/usr/ports/pobj/dune-1.10.0/fake-amd64/usr/local/lib/ocaml``
when (fake-)installing a port. This is not exactly how a ``DESTDIR`` is supposed to
work, but it did the job.

Now dune actually respects ``DESTDIR`` and will prepend it to
``OCAMLFIND_DESTDIR``, which will then result in
``/usr/ports/pobj/dune-1.10.0/fake-amd64/usr/ports/pobj/dune-1.10.0/fake-amd64/usr/local/lib/ocaml``
during (fake-)installation, which is obviously not what I want.

To solve this I currently need to special treat all ports using dune and
unset ``OCAMLFIND_DESTDIR`` for them.

For me it would be convenient if I could directly configure dune by
environment variables and bypass ocamlfind completely.

This commit accomplishes this only for ``dune install``. It would be nice if
dune would respect ``DUNE_LIBDIR`` for ``dune build``, too.

This may be related to #1707.

Here's GNU's definition of DESTDIR, LIBDIR, PREFIX and so on:
https://www.gnu.org/prep/standards/html_node/DESTDIR.html
https://www.gnu.org/prep/standards/html_node/Directory-Variables.html