### PR TITLE
Make Log.t a global variable

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -69,6 +69,8 @@ let set_dirs c =
   Path.Build.set_build_dir (Path.Build.Kind.of_string c.build_dir)
 
 let set_common_other c ~targets =
+  Console.init c.config.display;
+  Log.init ();
   Clflags.debug_dep_path := c.debug_dep_path;
   Clflags.debug_findlib := c.debug_findlib;
   Clflags.debug_backtraces := c.debug_backtraces;

--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -30,12 +30,11 @@ let term =
              ~doc:"Use $(docv) as the input to the function.")
      in
      Common.set_common common ~targets:[];
-     let log = Log.create common in
      let action =
-       Scheduler.go ~log ~common (fun () ->
+       Scheduler.go ~common (fun () ->
            let open Fiber.O in
            let* _setup =
-             Import.Main.setup ~log common ~external_lib_deps_mode:true
+             Import.Main.setup common ~external_lib_deps_mode:true
            in
            match (fn, inp) with
            | "list", None ->

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -39,10 +39,7 @@ let term =
       & info [ "no-build" ] ~doc:"don't rebuild target before executing")
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
   Common.set_common common ~targets:[ Arg.Dep.file prog ];
-  let log = Log.create common in
-  let setup =
-    Scheduler.go ~log ~common (fun () -> Import.Main.setup ~log common)
-  in
+  let setup = Scheduler.go ~common (fun () -> Import.Main.setup common) in
   let context = Import.Main.find_context_exn setup.workspace ~name:context in
   let prog_where =
     match Filename.analyze_program_name prog with
@@ -72,7 +69,7 @@ let term =
         | `This_abs _ ->
             [] )
       |> List.map ~f:(fun p -> Target.Path p)
-      |> Target.resolve_targets_mixed ~log common setup
+      |> Target.resolve_targets_mixed common setup
       |> List.concat_map ~f:(function Ok targets -> targets | Error _ -> []) )
   in
   let real_prog =
@@ -81,7 +78,7 @@ let term =
       | [] ->
           ()
       | targets ->
-          Scheduler.go ~log ~common (fun () -> do_build setup targets);
+          Scheduler.go ~common (fun () -> do_build setup targets);
           Hooks.End_of_build.run () );
     match prog_where with
     | `Search prog ->

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -134,14 +134,11 @@ let term =
     Arg.(value & flag & info [ "sexp" ] ~doc:{|Produce a s-expression output|})
   in
   Common.set_common common ~targets:[];
-  let log = Log.create common in
   let setup, lib_deps =
-    Scheduler.go ~log ~common (fun () ->
+    Scheduler.go ~common (fun () ->
         let open Fiber.O in
-        let* setup =
-          Import.Main.setup ~log common ~external_lib_deps_mode:true
-        in
-        let targets = Target.resolve_targets_exn ~log common setup targets in
+        let* setup = Import.Main.setup common ~external_lib_deps_mode:true in
+        let targets = Target.resolve_targets_exn common setup targets in
         let request = Target.request setup targets in
         let+ deps = Build_system.all_lib_deps ~request in
         (setup, deps))

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -31,7 +31,7 @@ include Common.Let_syntax
 module Main = struct
   include Dune.Main
 
-  let scan_workspace ~log (common : Common.t) =
+  let scan_workspace (common : Common.t) =
     let workspace_file =
       Common.workspace_file common |> Option.map ~f:Arg.Path.path
     in
@@ -39,42 +39,34 @@ module Main = struct
     let profile = Common.profile common in
     let capture_outputs = Common.capture_outputs common in
     let ancestor_vcs = (Common.root common).ancestor_vcs in
-    scan_workspace ~log ?workspace_file ?x ?profile ~capture_outputs
-      ~ancestor_vcs ()
+    scan_workspace ?workspace_file ?x ?profile ~capture_outputs ~ancestor_vcs
+      ()
 
-  let setup ~log ?external_lib_deps_mode common =
+  let setup ?external_lib_deps_mode common =
     let open Fiber.O in
     let only_packages = Common.only_packages common in
-    scan_workspace ~log common
+    scan_workspace common
     >>= init_build_system
           ~sandboxing_preference:(Common.config common).sandboxing_preference
           ?external_lib_deps_mode ?only_packages
-end
-
-module Log = struct
-  include Stdune.Log
-
-  let create common =
-    let display = (Common.config common).display in
-    Log.create ~display ()
 end
 
 module Scheduler = struct
   include Dune.Scheduler
   open Fiber.O
 
-  let go ?log ~(common : Common.t) f =
+  let go ~(common : Common.t) f =
     let config = Common.config common in
-    let f () = Main.set_concurrency ?log config >>= f in
-    Scheduler.go ?log ~config f
+    let f () = Main.set_concurrency config >>= f in
+    Scheduler.go ~config f
 
-  let poll ?log ~(common : Common.t) ~once ~finally () =
+  let poll ~(common : Common.t) ~once ~finally () =
     let config = Common.config common in
     let once () =
-      let* () = Main.set_concurrency ?log config in
+      let* () = Main.set_concurrency config in
       once ()
     in
-    Scheduler.poll ?log ~config ~once ~finally ()
+    Scheduler.poll ~config ~once ~finally ()
 end
 
 let restore_cwd_and_execve (common : Common.t) prog argv env =

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -286,10 +286,9 @@ let install_uninstall ~what =
                all defined contexts.")
     in
     Common.set_common common ~targets:[];
-    let log = Log.create common in
-    Scheduler.go ~log ~common (fun () ->
+    Scheduler.go ~common (fun () ->
         let open Fiber.O in
-        let* workspace = Import.Main.scan_workspace ~log common in
+        let* workspace = Import.Main.scan_workspace common in
         let contexts =
           match context with
           | None ->

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -16,7 +16,7 @@ let term =
   Common.set_common common ~targets:[];
   let capture_outputs = Common.capture_outputs common in
   let env = Import.Main.setup_env ~capture_outputs in
-  Scheduler.go ~log:(Log.create common) ~common (fun () ->
+  Scheduler.go ~common (fun () ->
       let open Fiber.O in
       let* ctxs = Context.create ~env (Workspace.default ()) in
       let ctx = List.hd ctxs in

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -116,12 +116,9 @@ let term =
   let out = Option.map ~f:Path.of_string out in
   let targets = List.map ~f:Arg.Dep.file targets in
   Common.set_common common ~targets;
-  let log = Log.create common in
-  Scheduler.go ~log ~common (fun () ->
+  Scheduler.go ~common (fun () ->
       let open Fiber.O in
-      let* setup =
-        Import.Main.setup ~log common ~external_lib_deps_mode:true
-      in
+      let* setup = Import.Main.setup common ~external_lib_deps_mode:true in
       let request =
         match targets with
         | [] ->
@@ -130,7 +127,7 @@ let term =
                    Path.build p :: acc)
             |> Build.paths
         | _ ->
-            Target.resolve_targets_exn ~log common setup targets
+            Target.resolve_targets_exn common setup targets
             |> Target.request setup
       in
       let* rules = Build_system.evaluate_rules ~request ~recursive in

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -26,10 +26,9 @@ let term =
   let+ common = Common.term
   and+ dir = Arg.(value & pos 0 dir "" & info [] ~docv:"PATH") in
   Common.set_common common ~targets:[];
-  let log = Log.create common in
-  Scheduler.go ~log ~common (fun () ->
+  Scheduler.go ~common (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup ~log common in
+      let* setup = Import.Main.setup common in
       let dir = Path.of_string dir in
       let checked = Util.check_path setup.workspace.contexts dir in
       let request =

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -68,6 +68,8 @@ let term =
   in
   Path.set_root (Path.External.cwd ());
   Path.Build.set_build_dir (Path.Build.Kind.of_string Common.default_build_dir);
+  Console.init config.display;
+  Log.init_disabled ();
   Dune.Scheduler.go ~config Watermarks.subst
 
 let command = (term, info)

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -27,12 +27,12 @@ let request (setup : Dune.Main.build_system) targets =
             Build_system.Alias.dep_multi_contexts )
             ~dir ~name ~file_tree:setup.workspace.conf.file_tree ~contexts)
 
-let log_targets ~log targets =
+let log_targets targets =
   List.iter targets ~f:(function
     | File path ->
-        Log.info log @@ "- " ^ Path.to_string path
+        Log.info @@ "- " ^ Path.to_string path
     | Alias a ->
-        Log.info log (Alias.to_log_string a));
+        Log.info (Alias.to_log_string a));
   flush stdout
 
 let target_hint (_setup : Dune.Main.build_system) path =
@@ -149,7 +149,7 @@ let resolve_target common ~setup = function
   | dep ->
       Error (dep, [])
 
-let resolve_targets_mixed ~log common setup user_targets =
+let resolve_targets_mixed common setup user_targets =
   match user_targets with
   | [] ->
       []
@@ -165,22 +165,22 @@ let resolve_targets_mixed ~log common setup user_targets =
       in
       let config = Common.config common in
       if config.display = Verbose then (
-        Log.info log "Actual targets:";
+        Log.info "Actual targets:";
         List.concat_map targets ~f:(function
           | Ok targets ->
               targets
           | Error _ ->
               [])
-        |> log_targets ~log
+        |> log_targets
       );
       targets
 
-let resolve_targets ~log common (setup : Dune.Main.build_system) user_targets =
+let resolve_targets common (setup : Dune.Main.build_system) user_targets =
   List.map ~f:(fun dep -> Dep dep) user_targets
-  |> resolve_targets_mixed ~log common setup
+  |> resolve_targets_mixed common setup
 
-let resolve_targets_exn ~log common setup user_targets =
-  resolve_targets ~log common setup user_targets
+let resolve_targets_exn common setup user_targets =
+  resolve_targets common setup user_targets
   |> List.concat_map ~f:(function
        | Error (dep, hints) ->
            User_error.raise

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -17,11 +17,10 @@ type resolve_input =
   | Dep of Arg.Dep.t
 
 val resolve_targets_mixed :
-     log:Log.t
-  -> Common.t
+     Common.t
   -> Dune.Main.build_system
   -> resolve_input list
   -> (t list, Arg.Dep.t * User_message.Style.t Pp.t list) result list
 
 val resolve_targets_exn :
-  log:Log.t -> Common.t -> Dune.Main.build_system -> Arg.Dep.t list -> t list
+  Common.t -> Dune.Main.build_system -> Arg.Dep.t list -> t list

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -26,11 +26,10 @@ let term =
       [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];
   let utop_target = Arg.Dep.file (Filename.concat dir Utop.utop_exe) in
   Common.set_common_other common ~targets:[ utop_target ];
-  let log = Log.create common in
   let context, utop_path =
-    Scheduler.go ~log ~common (fun () ->
+    Scheduler.go ~common (fun () ->
         let open Fiber.O in
-        let* setup = Import.Main.setup ~log common in
+        let* setup = Import.Main.setup common in
         let context =
           Import.Main.find_context_exn setup.workspace ~name:ctx_name
         in

--- a/src/dune/main.ml
+++ b/src/dune/main.ml
@@ -186,6 +186,10 @@ let bootstrap () =
     let anon s =
       raise (Arg.Bad (Printf.sprintf "don't know what to do with %s\n" s))
     in
+    let init (config : Config.t) =
+      Console.init config.display;
+      Log.init ()
+    in
     let subst () =
       let config : Config.t =
         { display = Quiet
@@ -194,6 +198,7 @@ let bootstrap () =
         ; sandboxing_preference = []
         }
       in
+      init config;
       Scheduler.go ~config Watermarks.subst;
       exit 0
     in
@@ -245,8 +250,7 @@ let bootstrap () =
       Config.adapt_display config
         ~output_is_a_tty:(Lazy.force Ansi_color.stderr_supports_color)
     in
-    Console.init config.display;
-    Log.init ();
+    init config;
     Scheduler.go ~config (fun () ->
         let* () = set_concurrency config in
         let* workspace =

--- a/src/dune/main.mli
+++ b/src/dune/main.mli
@@ -18,8 +18,7 @@ val package_install_file :
 
 (** Scan the source tree and discover the overall layout of the workspace. *)
 val scan_workspace :
-     ?log:Log.t
-  -> ?workspace:Workspace.t
+     ?workspace:Workspace.t
   -> ?workspace_file:Path.t
   -> ?x:string
   -> ?capture_outputs:bool
@@ -42,7 +41,7 @@ val find_context_exn : workspace -> name:string -> Context.t
 val setup_env : capture_outputs:bool -> Env.t
 
 (** Set the concurrency level according to the user configuration *)
-val set_concurrency : ?log:Log.t -> Config.t -> unit Fiber.t
+val set_concurrency : Config.t -> unit Fiber.t
 
 (**/**)
 

--- a/src/dune/process.ml
+++ b/src/dune/process.ml
@@ -587,7 +587,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
         Temp.destroy fn;
         s
   in
-  Log.command (Scheduler.log scheduler) ~command_line ~output ~exit_status;
+  Log.command ~command_line ~output ~exit_status;
   let exit_status : Exit_status.t =
     match exit_status with
     | WEXITED n when code_is_ok ok_codes n ->

--- a/src/dune/scheduler.mli
+++ b/src/dune/scheduler.mli
@@ -3,15 +3,14 @@
 open! Stdune
 
 (** [go ?log ?config fiber] runs the fiber until it terminates. *)
-val go : ?log:Log.t -> ?config:Config.t -> (unit -> 'a Fiber.t) -> 'a
+val go : ?config:Config.t -> (unit -> 'a Fiber.t) -> 'a
 
 (** Runs [once] in a loop, executing [finally] after every iteration, even if
     Fiber.Never was encountered.
 
     If any source files change in the middle of iteration, it gets canceled. *)
 val poll :
-     ?log:Log.t
-  -> ?config:Config.t
+     ?config:Config.t
   -> once:(unit -> unit Fiber.t)
   -> finally:(unit -> unit)
   -> unit
@@ -42,9 +41,6 @@ type t
 (** Wait until fewer than [!Clflags.concurrency] external processes are running
     and return the scheduler information. *)
 val wait_for_available_job : unit -> t Fiber.t
-
-(** Logger *)
-val log : t -> Log.t
 
 (** Execute the given callback with current directory temporarily changed *)
 val with_chdir : t -> dir:Path.t -> f:(unit -> 'a) -> 'a

--- a/src/stdune/log.mli
+++ b/src/stdune/log.mli
@@ -1,20 +1,20 @@
 (** Log file *)
 
-type t
+(** Initialise the log file *)
+val init : ?path:Path.t -> unit -> unit
 
-val no_log : t
+(** Initialise this module with a disabled logger, i.e. swallowing error
+    messages. *)
+val init_disabled : unit -> unit
 
-val create : ?display:Console.Display.t -> ?path:Path.t -> unit -> t
+(** Print an informative message in the log *)
+val info : string -> unit
 
-(** Print an information message in the log *)
-val info : t -> string -> unit
-
-val infof : t -> ('a, Format.formatter, unit, unit) format4 -> 'a
+val infof : ('a, Format.formatter, unit, unit) format4 -> 'a
 
 (** Print an executed command in the log *)
 val command :
-     t
-  -> command_line:string
+     command_line:string
   -> output:string
   -> exit_status:Unix.process_status
   -> unit

--- a/test/expect-tests/common/dune_tests_common.ml
+++ b/test/expect-tests/common/dune_tests_common.ml
@@ -9,6 +9,8 @@ let init =
     lazy
       ( Printexc.record_backtrace false;
         Path.set_root (Path.External.cwd ());
-        Path.Build.set_build_dir (Path.Build.Kind.of_string "_build") )
+        Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");
+        Console.init Quiet;
+        Log.init () )
   in
   fun () -> Lazy.force init


### PR DESCRIPTION
There is only one log file so there is no point allowing multiple `Log.t` values. Additionally, this change makes it easier to log things at random places.