### PR TITLE
Remove support for jbuild style flags

### DIFF
--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -131,11 +131,11 @@ let lines_of p = Lines_of p
 
 let strings p = lines_of p >>^ fun l -> List.map l ~f:Scanf.unescaped
 
-let read_sexp p syntax =
+let read_sexp p =
   contents p
   >>^ fun s ->
   Dune_lang.parse_string s
-    ~lexer:(Dune_lang.Lexer.of_syntax syntax)
+    ~lexer:Dune_lang.Lexer.token
     ~fname:(Path.to_string p) ~mode:Single
 
 let if_file_exists p ~then_ ~else_ =

--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -121,7 +121,7 @@ val lines_of : Path.t -> ('a, string list) t
 val strings : Path.t -> ('a, string list) t
 
 (** Load an S-expression from a file *)
-val read_sexp : Path.t -> Dune_lang.File_syntax.t -> (unit, Dune_lang.Ast.t) t
+val read_sexp : Path.t -> (unit, Dune_lang.Ast.t) t
 
 (** Evaluates to [true] if the file is present on the file system or is the
     target of a rule. *)

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -531,7 +531,7 @@ let expand_and_eval_set t set ~standard =
     else
       Build.return []
   in
-  let syntax, files =
+  let files =
     let f template =
       expand t ~mode:Single ~template
       |> Value.to_path ~error_loc:(String_with_vars.loc template) ~dir
@@ -549,7 +549,7 @@ let expand_and_eval_set t set ~standard =
       >>^ fun standard ->
       Ordered_set_lang.eval set ~standard ~parse ~eq:String.equal
   | paths ->
-      List.map paths ~f:(fun f -> Build.read_sexp f syntax)
+      List.map paths ~f:Build.read_sexp
       |> Build.all |> Build.fanout standard
       >>^ fun (standard, sexps) ->
       let files_contents = List.combine paths sexps |> Path.Map.of_list_exn in

--- a/src/dune/ordered_set_lang.ml
+++ b/src/dune/ordered_set_lang.ml
@@ -322,8 +322,7 @@ module Unexpanded = struct
       | Diff (l, r) ->
           loop (loop acc l) r
     in
-    let syntax = dune_kind t in
-    (syntax, loop Path.Set.empty t.ast)
+    loop Path.Set.empty t.ast
 
   let has_special_forms t =
     let rec loop (t : ast) =

--- a/src/dune/ordered_set_lang.mli
+++ b/src/dune/ordered_set_lang.mli
@@ -94,7 +94,7 @@ module Unexpanded : sig
   val files :
        t
     -> f:(String_with_vars.t -> Path.t)
-    -> Dune_lang.File_syntax.t * Path.Set.t
+    -> Path.Set.t
 
   (** Expand [t] using with the given file contents. [file_contents] is a map
       from filenames to their parsed contents. Every [(:include fn)] in [t] is


### PR DESCRIPTION
Previously, we'd parse :include files based on the syntax. This is no
longer necessary.