### PR TITLE
Record number of evaluated rules in the trace file

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1365,6 +1365,7 @@ end = struct
     in
     start_rule t rule;
     let* action, deps = evaluate_rule_and_wait_for_dependencies rule in
+    Stats.new_evaluated_rule ();
     Fs.mkdir_p dir;
     let targets_as_list = Path.Build.Set.to_list targets in
     let head_target = List.hd targets_as_list in

--- a/src/dune/build_system.mli
+++ b/src/dune/build_system.mli
@@ -7,16 +7,11 @@ open! Import
 
 (** {2 Creation} *)
 
-type hook =
-  | Rule_started
-  | Rule_completed
-
 (** Initializes the build system. This must be called first. *)
 val init :
      contexts:Context.t list
   -> ?memory:Dune_manager.Client.t
   -> file_tree:File_tree.t
-  -> hook:(hook -> unit)
   -> sandboxing_preference:Sandbox_mode.t list
   -> unit
 

--- a/src/dune/file_tree.ml
+++ b/src/dune/file_tree.ml
@@ -196,12 +196,13 @@ let readdir path =
 let load path ~ancestor_vcs ~recognize_jbuilder_projects =
   let open Result.O in
   let nb_path_visited = ref 0 in
+  Console.Status_line.set (fun () ->
+      Some
+        (Pp.verbatim (Printf.sprintf "Scanned %i directories" !nb_path_visited)));
   let rec walk path ~dirs_visited ~project:parent_project ~vcs
       ~(dir_status : Sub_dirs.Status.t) { dirs; files } =
     incr nb_path_visited;
-    if !nb_path_visited mod 100 = 0 then
-      Console.update_status_line
-        (Pp.verbatim (Printf.sprintf "Scanned %i directories" !nb_path_visited));
+    if !nb_path_visited mod 100 = 0 then Console.Status_line.refresh ();
     let project =
       if dir_status = Data_only then
         parent_project
@@ -319,7 +320,7 @@ let load path ~ancestor_vcs ~recognize_jbuilder_projects =
       ~dirs_visited:(File.Map.singleton (File.of_source_path path) path)
       ~dir_status:Normal ~project ~vcs:ancestor_vcs x
   in
-  Console.clear_status_line ();
+  Console.Status_line.set (Fn.const None);
   match walk with
   | Ok dir -> dir
   | Error m ->

--- a/src/dune/hooks.ml
+++ b/src/dune/hooks.ml
@@ -8,7 +8,7 @@ module type S = sig
   val run : unit -> unit
 end
 
-module Hooks_manager = struct
+module Make () = struct
   let persistent_hooks = ref []
 
   let one_off_hooks = ref []
@@ -18,13 +18,14 @@ module Hooks_manager = struct
   let once hook = one_off_hooks := hook :: !one_off_hooks
 
   let run () =
-    List.iter !one_off_hooks ~f:(fun f -> f ());
-    List.iter !persistent_hooks ~f:(fun f -> f ());
-    one_off_hooks := []
+    let l = !one_off_hooks in
+    one_off_hooks := [];
+    List.iter l ~f:(fun f -> f ());
+    List.iter !persistent_hooks ~f:(fun f -> f ())
 end
 
 module End_of_build = struct
-  include Hooks_manager
+  include Make ()
 end
 
 let () = at_exit End_of_build.run

--- a/src/dune/hooks.mli
+++ b/src/dune/hooks.mli
@@ -12,6 +12,8 @@ module type S = sig
   val run : unit -> unit
 end
 
+module Make () : S
+
 (** Every time a build ends, which includes every iteration in watch mode,
     including cancellation of build because of file changes. *)
 module End_of_build : S

--- a/src/dune/main.ml
+++ b/src/dune/main.ml
@@ -82,25 +82,11 @@ let init_build_system ?only_packages ?external_lib_deps_mode
                    ~candidates:
                      ( Package.Name.Map.keys w.conf.packages
                      |> List.map ~f:Package.Name.to_string ))));
-  let rule_done = ref 0 in
-  let rule_total = ref 0 in
-  let gen_status_line () =
-    { Scheduler.message =
-        Some (Pp.verbatim (sprintf "Done: %u/%u" !rule_done !rule_total))
-    ; show_jobs = true
-    }
-  in
-  let hook (hook : Build_system.hook) =
-    match hook with
-    | Rule_started -> incr rule_total
-    | Rule_completed -> incr rule_done
-  in
   Build_system.reset ();
   Build_system.init ~sandboxing_preference ~contexts:w.contexts
-    ~file_tree:w.conf.file_tree ~hook ?memory;
+    ~file_tree:w.conf.file_tree ?memory;
   Option.iter memory ~f:(fun memory ->
       Hooks.End_of_build.once (fun () -> Dune_manager.Client.teardown memory));
-  Scheduler.set_status_line_generator gen_status_line;
   let+ scontexts =
     Gen_rules.gen w.conf ~contexts:w.contexts ?only_packages
       ?external_lib_deps_mode

--- a/src/dune/scheduler.mli
+++ b/src/dune/scheduler.mli
@@ -19,14 +19,6 @@ val poll :
 (** Wait for the following process to terminate *)
 val wait_for_process : int -> Unix.process_status Fiber.t
 
-type status_line_config =
-  { message : User_message.Style.t Pp.t option
-  ; show_jobs : bool
-  }
-
-(** Set the status line generator for the current scheduler *)
-val set_status_line_generator : (unit -> status_line_config) -> unit
-
 val set_concurrency : int -> unit
 
 (** Make the scheduler ignore next change to a certain file in watch mode.
@@ -34,6 +26,9 @@ val set_concurrency : int -> unit
     This is used with promoted files that are copied back to the source tree
     after generation *)
 val ignore_for_watch : Path.t -> unit
+
+(** Number of jobs currently running in the background *)
+val running_jobs_count : unit -> int
 
 (** Scheduler information *)
 type t

--- a/src/dune/stats.boot.ml
+++ b/src/dune/stats.boot.ml
@@ -3,3 +3,5 @@ let enable _path = ()
 let record () = ()
 
 let with_process ~program:_ ~args:_ fiber = fiber
+
+let new_evaluated_rule () = ()

--- a/src/dune/stats.ml
+++ b/src/dune/stats.ml
@@ -32,11 +32,18 @@ module Fd_count = struct
     | files -> This (Array.length files - 1 (* -1 for the dirfd *))
 end
 
+let evaluated_rules = ref 0
+
+let new_evaluated_rule () = incr evaluated_rules
+
+let () = Hooks.End_of_build.always (fun () -> evaluated_rules := 0)
+
 let catapult = ref None
 
 let record () =
   Option.iter !catapult ~f:(fun reporter ->
       Catapult.emit_gc_counters reporter;
+      Catapult.emit_counter reporter "evaluated-rules" !evaluated_rules;
       match Fd_count.get () with
       | This fds -> Catapult.emit_counter reporter "fds" fds
       | Unknown -> ())

--- a/src/dune/stats.mli
+++ b/src/dune/stats.mli
@@ -9,3 +9,7 @@ val record : unit -> unit
 (** Collect data about a subprocess *)
 val with_process :
   program:string -> args:string list -> 'a Fiber.t -> 'a Fiber.t
+
+(** Called by the build system when a new rule is fully evaluated and ready to
+  fire *)
+val new_evaluated_rule : unit -> unit

--- a/src/stdune/console.mli
+++ b/src/stdune/console.mli
@@ -18,16 +18,22 @@ val print_user_message :
 
 val init : Display.t -> unit
 
+val reset_terminal : unit -> unit
+
 (** / *)
 
 (** Everything below this line requires [init] to have been called earlier. *)
 
-(** Update the status line if the display is in progress mode. *)
-val update_status_line : User_message.Style.t Pp.t -> unit
+module Status_line : sig
+  (** Function that produces the current status line *)
+  type t = unit -> User_message.Style.t Pp.t option
 
-(** Clear the status line *)
-val clear_status_line : unit -> unit
+  (** Change the status line if the display is in progress mode. *)
+  val set : t -> unit
 
-val reset_terminal : unit -> unit
+  val set_temporarily : t -> (unit -> 'a) -> 'a
+
+  val refresh : unit -> unit
+end
 
 val display : unit -> Display.t

--- a/test/blackbox-tests/test-cases/trace-file/run.t
+++ b/test/blackbox-tests/test-cases/trace-file/run.t
@@ -18,6 +18,7 @@ As well as data about the garbage collector:
 
   $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/ [0-9]+/ .../g' | sort -u
   {"name": "compactions", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
+  {"name": "evaluated-rules", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
   {"name": "fds", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
   {"name": "free_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
   {"name": "heap_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}


### PR DESCRIPTION
This PR adds a a new option `--debug-rule-batches` that causes Dune to display the number of rules that become ready to fire at once. If this number is high, we can expect to be able to efficiently prefetch things for the shared artifact cache. So far it seems that this number is high right from the start, which is good.