### PR TITLE
Make OSL fields take standard as default

### DIFF
--- a/src/dune/ordered_set_lang.ml
+++ b/src/dune/ordered_set_lang.ml
@@ -212,7 +212,7 @@ let dune_kind t =
   | None | Some (_, _) ->
     Dune
 
-let field ?(default = standard) ?check name =
+let field ?check name =
   let decode =
     match check with
     | None ->
@@ -220,7 +220,7 @@ let field ?(default = standard) ?check name =
     | Some x ->
       Dune_lang.Decoder.( >>> ) x decode
   in
-  Dune_lang.Decoder.field name decode ~default
+  Dune_lang.Decoder.field name decode ~default:standard
 
 module Unexpanded = struct
   type ast = (String_with_vars.t, Ast.unexpanded) Ast.t
@@ -299,7 +299,7 @@ module Unexpanded = struct
     ; context = Univ_map.empty
     }
 
-  let field ?(default = standard) ?check name =
+  let field ?check name =
     let decode =
       match check with
       | None ->
@@ -307,7 +307,7 @@ module Unexpanded = struct
       | Some x ->
         Dune_lang.Decoder.( >>> ) x decode
     in
-    Dune_lang.Decoder.field name decode ~default
+    Dune_lang.Decoder.field name decode ~default:standard
 
   let files t ~f =
     let rec loop acc (ast : ast) =

--- a/src/dune/ordered_set_lang.mli
+++ b/src/dune/ordered_set_lang.mli
@@ -62,8 +62,7 @@ val standard : t
 val is_standard : t -> bool
 
 val field :
-     ?default:t
-  -> ?check:unit Dune_lang.Decoder.t
+     ?check:unit Dune_lang.Decoder.t
   -> string
   -> t Dune_lang.Decoder.fields_parser
 
@@ -83,8 +82,7 @@ module Unexpanded : sig
   val of_strings : pos:string * int * int * int -> string list -> t
 
   val field :
-       ?default:t
-    -> ?check:unit Dune_lang.Decoder.t
+       ?check:unit Dune_lang.Decoder.t
     -> string
     -> t Dune_lang.Decoder.fields_parser
 

--- a/src/dune/preprocessing.ml
+++ b/src/dune/preprocessing.ml
@@ -155,9 +155,6 @@ module Driver = struct
            and+ as_ppx_flags =
              Ordered_set_lang.Unexpanded.field "as_ppx_flags"
                ~check:(Syntax.since syntax (1, 2))
-               ~default:
-                 (Ordered_set_lang.Unexpanded.of_strings [ "--as-ppx" ]
-                   ~pos:__POS__)
            and+ lint_flags = Ordered_set_lang.Unexpanded.field "lint_flags"
            and+ main = field "main" string
            and+ replaces =
@@ -657,7 +654,8 @@ let make sctx ~dir ~expander ~dep_kind ~lint ~preprocess ~preprocessor_deps
               ( Build.path (Path.build exe)
               >>> preprocessor_deps >>^ ignore
               >>> Expander.expand_and_eval_set expander
-                driver.info.as_ppx_flags ~standard:(Build.return [])
+                driver.info.as_ppx_flags
+                  ~standard:(Build.return [ "--as-ppx" ])
               >>^ fun driver_flags ->
               let command =
                 List.map


### PR DESCRIPTION
This is more consistent with how OSL works everywhere. The only field
that didn't satisfy this was as_ppx_flags