### PR TITLE
Do not reuse memo name for assert_exists.

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -22,7 +22,7 @@ end = struct
   let mkdir_p = Memo.exec mkdir_p_def
 
   let assert_exists_def =
-    Memo.create "mkdir_p" ~doc:"mkdir_p"
+    Memo.create "assert_path_exists" ~doc:"Path.exists"
       ~input:(module Path)
       ~output:(Simple (module Bool))
       ~visibility:Hidden Sync Path.exists


### PR DESCRIPTION
Looks like a copy-paste error from the above mkdir_p function.

Signed-off-by: Jakub Staron <jstaron@janestreet.com>