### PR TITLE
Remove dune subst form bootstrap

### DIFF
--- a/dune.opam
+++ b/dune.opam
@@ -41,6 +41,5 @@ build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
   ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
-  ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]
 ]

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -2,6 +2,5 @@ build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
   ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
-  ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]
 ]


### PR DESCRIPTION
It's no longer necessary as the build info library fills the information
in.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>