### PR TITLE
[upgrader] do not use git for untracked files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,6 +115,8 @@
 - `c_flags`, `c_names` and `cxx_names` are now supported in `executable`
   and `executables` stanzas. (#2562, @nojb)
 
+- Remove git integration from `$ dune upgrade` (#2565, @rgrinberg)
+
 1.11.0 (23/07/2019)
 -------------------
 

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -19,6 +19,7 @@ let term =
   Scheduler.go ~common (fun () ->
     Dune.Upgrader.upgrade
       (Dune.File_tree.load Path.Source.root ~warn_when_seeing_jbuild_file:false
-        ~ancestor_vcs:None))
+         ~ancestor_vcs:None)
+    |> Fiber.return)
 
 let command = (term, info)

--- a/src/dune/upgrader.boot.ml
+++ b/src/dune/upgrader.boot.ml
@@ -1,1 +1,1 @@
-let upgrade _ = Fiber.return ()
+let upgrade _ = ()

--- a/src/dune/upgrader.ml
+++ b/src/dune/upgrader.ml
@@ -1,6 +1,5 @@
 open! Stdune
 open Import
-open Fiber.O
 
 (* Return a mapping [Path.t -> Dune_lang.Ast.t list] containing [path] and all
   the files in includes, recursiverly *)
@@ -376,92 +375,23 @@ let upgrade_dir todo dir =
         upgrade_file todo fn sexps comments
           ~look_for_jbuild_ignore:(Path.Source.equal fn path)))
 
-let lookup_git_repo ft fn =
-  match File_tree.Dir.vcs (File_tree.nearest_dir ft fn) with
-  | Some { kind = Git; root } -> Some root
-  | _ -> None
-
-type git_file =
-  | Tracked of Path.t
-  | Untracked
-
-let git_file_tracked =
-  let ls_files_per_dir = Table.create (module Path.Source) 16 in
-  fun ft fn ~git ->
-    match lookup_git_repo ft fn with
-    | None -> Fiber.return Untracked
-    | Some dir ->
-      let dir = Path.as_in_source_tree_exn dir in
-      let+ files =
-        match Table.find ls_files_per_dir dir with
-        | Some files -> Fiber.return files
-        | None ->
-          let+ files =
-            let dir = Path.source dir in
-            Process.run_capture_lines Strict ~dir ~env:Env.initial
-              (Lazy.force git) [ "ls-files" ]
-          in
-          let files =
-            List.map files ~f:(fun file -> Path.Source.relative dir file)
-            |> Path.Source.Set.of_list
-          in
-          Table.add_exn ls_files_per_dir dir files;
-          files
-      in
-      if Path.Source.Set.mem files fn then
-        Tracked (Path.source dir)
-      else
-        Untracked
-
 let upgrade ft =
   Dune_project.default_dune_language_version := (1, 0);
   let todo = { to_rename_and_edit = []; to_add = []; to_edit = [] } in
   File_tree.fold ft ~traverse:Sub_dirs.Status.Set.normal_only ~init:()
     ~f:(fun dir () -> upgrade_dir todo dir);
-  let git =
-    lazy
-      ( match Bin.which ~path:(Env.path Env.initial) "git" with
-      | Some x -> x
-      | None -> Utils.program_not_found "git" ~loc:None )
-  in
   let log fmt = Printf.ksprintf Console.print fmt in
-  let* () =
-    Fiber.sequential_iter todo.to_add ~f:(fun fn ->
-      let* status = git_file_tracked ft fn ~git in
-      match status with
-      | Untracked -> Fiber.return ()
-      | Tracked dir ->
-        Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
-          [ "add"; Path.reach (Path.source fn) ~from:dir ])
-  in
   List.iter todo.to_edit ~f:(fun (fn, s) ->
     log "Upgrading %s...\n" (Path.Source.to_string_maybe_quoted fn);
     Io.write_file (Path.source fn) s ~binary:true);
-  Fiber.sequential_iter todo.to_rename_and_edit ~f:(fun x ->
+  List.iter todo.to_rename_and_edit ~f:(fun x ->
     let { original_file; new_file; extra_files_to_delete; contents } = x in
     log "Upgrading %s to %s...\n"
       ( List.map
-        (extra_files_to_delete @ [ original_file ])
+          (extra_files_to_delete @ [ original_file ])
           ~f:Path.Source.to_string_maybe_quoted
-      |> String.enumerate_and )
+        |> String.enumerate_and )
       (Path.Source.to_string_maybe_quoted new_file);
-    (let* status = git_file_tracked ft original_file ~git in
-     match status with
-     | Untracked ->
-       List.iter (original_file :: extra_files_to_delete) ~f:(fun p ->
-         Path.unlink (Path.source p));
-       Fiber.return ()
-     | Tracked dir ->
-       Fiber.sequential_iter extra_files_to_delete ~f:(fun fn ->
-         let fn = Path.source fn in
-         Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
-           [ "rm"; Path.reach fn ~from:dir ])
-       >>>
-       let original_file = Path.source original_file in
-       let new_file = Path.source new_file in
-       Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
-         [ "mv"
-         ; Path.reach original_file ~from:dir
-         ; Path.reach new_file ~from:dir
-         ])
-    >>| fun () -> Io.write_file (Path.source new_file) contents ~binary:true)
+    List.iter (original_file :: extra_files_to_delete) ~f:(fun p ->
+      Path.unlink (Path.source p));
+    Io.write_file (Path.source new_file) contents ~binary:true)

--- a/src/dune/upgrader.ml
+++ b/src/dune/upgrader.ml
@@ -381,6 +381,38 @@ let lookup_git_repo ft fn =
   | Some { kind = Git; root } -> Some root
   | _ -> None
 
+type git_file =
+  | Tracked of Path.t
+  | Untracked
+
+let git_file_tracked =
+  let ls_files_per_dir = Table.create (module Path.Source) 16 in
+  fun ft fn ~git ->
+    match lookup_git_repo ft fn with
+    | None -> Fiber.return Untracked
+    | Some dir ->
+      let dir = Path.as_in_source_tree_exn dir in
+      let+ files =
+        match Table.find ls_files_per_dir dir with
+        | Some files -> Fiber.return files
+        | None ->
+          let+ files =
+            let dir = Path.source dir in
+            Process.run_capture_lines Strict ~dir ~env:Env.initial
+              (Lazy.force git) [ "ls-files" ]
+          in
+          let files =
+            List.map files ~f:(fun file -> Path.Source.relative dir file)
+            |> Path.Source.Set.of_list
+          in
+          Table.add_exn ls_files_per_dir dir files;
+          files
+      in
+      if Path.Source.Set.mem files fn then
+        Tracked (Path.source dir)
+      else
+        Untracked
+
 let upgrade ft =
   Dune_project.default_dune_language_version := (1, 0);
   let todo = { to_rename_and_edit = []; to_add = []; to_edit = [] } in
@@ -395,11 +427,12 @@ let upgrade ft =
   let log fmt = Printf.ksprintf Console.print fmt in
   let* () =
     Fiber.sequential_iter todo.to_add ~f:(fun fn ->
-      match lookup_git_repo ft fn with
-      | Some dir ->
+      let* status = git_file_tracked ft fn ~git in
+      match status with
+      | Untracked -> Fiber.return ()
+      | Tracked dir ->
         Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
-          [ "add"; Path.reach (Path.source fn) ~from:dir ]
-      | None -> Fiber.return ())
+          [ "add"; Path.reach (Path.source fn) ~from:dir ])
   in
   List.iter todo.to_edit ~f:(fun (fn, s) ->
     log "Upgrading %s...\n" (Path.Source.to_string_maybe_quoted fn);
@@ -412,22 +445,23 @@ let upgrade ft =
           ~f:Path.Source.to_string_maybe_quoted
       |> String.enumerate_and )
       (Path.Source.to_string_maybe_quoted new_file);
-    ( match lookup_git_repo ft original_file with
-    | Some dir ->
-      Fiber.sequential_iter extra_files_to_delete ~f:(fun fn ->
-        let fn = Path.source fn in
-        Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
-          [ "rm"; Path.reach fn ~from:dir ])
-      >>>
-      let original_file = Path.source original_file in
-      let new_file = Path.source new_file in
-      Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
-        [ "mv"
-        ; Path.reach original_file ~from:dir
-        ; Path.reach new_file ~from:dir
-        ]
-    | None ->
-      List.iter (original_file :: extra_files_to_delete) ~f:(fun p ->
-        Path.unlink (Path.source p));
-      Fiber.return () )
+    (let* status = git_file_tracked ft original_file ~git in
+     match status with
+     | Untracked ->
+       List.iter (original_file :: extra_files_to_delete) ~f:(fun p ->
+         Path.unlink (Path.source p));
+       Fiber.return ()
+     | Tracked dir ->
+       Fiber.sequential_iter extra_files_to_delete ~f:(fun fn ->
+         let fn = Path.source fn in
+         Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
+           [ "rm"; Path.reach fn ~from:dir ])
+       >>>
+       let original_file = Path.source original_file in
+       let new_file = Path.source new_file in
+       Process.run Strict ~dir ~env:Env.initial (Lazy.force git)
+         [ "mv"
+         ; Path.reach original_file ~from:dir
+         ; Path.reach new_file ~from:dir
+         ])
     >>| fun () -> Io.write_file (Path.source new_file) contents ~binary:true)

--- a/src/dune/upgrader.mli
+++ b/src/dune/upgrader.mli
@@ -1,4 +1,4 @@
 (** Upgrade projects from jbuilder to Dune *)
 
 (** Upgrade all projects in this file tree *)
-val upgrade : File_tree.t -> unit Fiber.t
+val upgrade : File_tree.t -> unit


### PR DESCRIPTION
We make sure that a file is tracked by git before doing git operations to it.
This makes $ dune upgrade work better for vendored dirs.

@avsm does this sound like a good fix for #2232 