### PR TITLE
Doc: fix typo in stage names

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -240,7 +240,7 @@ language: The syntax is as a list of the following elements:
 
    op := '=' | '<' | '>' | '<>' | '>=' | '<='
 
-   stage := :with_test | :build | :dev
+   stage := :with-test | :build | :dev
 
    constr := (<op> <version>)
 


### PR DESCRIPTION
Stage names are passed as is, so `with-test` should be used.