### PR TITLE
Libraries without archives

### DIFF
--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -19,7 +19,7 @@ let term =
   Scheduler.go ~common (fun () ->
     Dune.Upgrader.upgrade
       (Dune.File_tree.load Path.Source.root ~warn_when_seeing_jbuild_file:false
-         ~ancestor_vcs:None)
+        ~ancestor_vcs:None)
     |> Fiber.return)
 
 let command = (term, info)

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -229,7 +229,15 @@ module Package = struct
     let archives = archives t in
     let obj_dir = Obj_dir.make_external_no_private ~dir:t.dir in
     let modes : Mode.Dict.Set.t =
-      Mode.Dict.map ~f:(fun x -> not (List.is_empty x)) archives
+      (* libraries without archives are compatible with all modes. mainly a
+        hack for compiler-libs which doesn't have any archives *)
+      let discovered =
+        Mode.Dict.map ~f:(fun x -> not (List.is_empty x)) archives
+      in
+      if Mode.Dict.Set.is_empty discovered then
+        Mode.Dict.Set.all
+      else
+        discovered
     in
     Dune_package.Lib.make ~orig_src_dir:None ~loc ~kind:Normal ~name:(name t)
       ~synopsis:(description t) ~archives ~plugins:(plugins t)

--- a/src/dune/upgrader.ml
+++ b/src/dune/upgrader.ml
@@ -388,9 +388,9 @@ let upgrade ft =
     let { original_file; new_file; extra_files_to_delete; contents } = x in
     log "Upgrading %s to %s...\n"
       ( List.map
-          (extra_files_to_delete @ [ original_file ])
+        (extra_files_to_delete @ [ original_file ])
           ~f:Path.Source.to_string_maybe_quoted
-        |> String.enumerate_and )
+      |> String.enumerate_and )
       (Path.Source.to_string_maybe_quoted new_file);
     List.iter (original_file :: extra_files_to_delete) ~f:(fun p ->
       Path.unlink (Path.source p));


### PR DESCRIPTION
Findlib defined libraries without an archive field will now have both `native` and `bytes` modes. On its own, it doesn't do anything but pave the way for reviving inheriting the modes is working correctly.