### PR TITLE
Add --disable-promotion option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,10 @@
 
 - Remove git integration from `$ dune upgrade` (#2565, @rgrinberg)
 
+- Add a `--disable-promotion` to disable all modification to the source
+  directory. There's also a corresponding `DUNE_DISABLE_PROMOTION` environment
+  variable. (#2588, fix #2568, @rgrinberg)
+
 1.11.3 (23/08/2019)
 -------------------
 

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1659,14 +1659,12 @@ let package_deps pkg files =
       (* if this file isn't in the build dir, it doesnt belong to any packages
         and it doesn't have dependencies that do *)
       acc
-    | Some fn -> (
+    | Some fn ->
       let pkgs = Fdecl.get t.packages fn in
-      if Package.Name.Set.is_empty pkgs then
-        loop_deps fn acc
-      else if Package.Name.Set.mem pkgs pkg then
+      if Package.Name.Set.is_empty pkgs || Package.Name.Set.mem pkgs pkg then
         loop_deps fn acc
       else
-        Package.Name.Set.union acc pkgs)
+        Package.Name.Set.union acc pkgs
   and loop_deps fn acc =
     match Path.Build.Table.find t.files fn with
     | None -> acc

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1465,12 +1465,11 @@ end = struct
         Fiber.return ()
     in
     let+ () =
-      match mode with
-      | Standard
-       |Fallback
-       |Ignore_source_files ->
+      match (mode, !Clflags.promote) with
+      | (Standard | Fallback | Ignore_source_files), _
+       |Promote _, Some Never ->
         Fiber.return ()
-      | Promote { lifetime; into; only } ->
+      | Promote { lifetime; into; only }, (Some Automatically | None) ->
         Fiber.sequential_iter targets_as_list ~f:(fun path ->
           let consider_for_promotion =
             match only with

--- a/src/dune/clflags.ml
+++ b/src/dune/clflags.ml
@@ -1,3 +1,9 @@
+module Promote = struct
+  type t =
+    | Automatically
+    | Never
+end
+
 let debug_findlib = ref false
 
 let debug_dep_path = ref false
@@ -10,7 +16,7 @@ let debug_backtraces = ref false
 
 let diff_command = ref None
 
-let auto_promote = ref false
+let promote = ref None
 
 let force = ref false
 

--- a/src/dune/clflags.mli
+++ b/src/dune/clflags.mli
@@ -18,8 +18,14 @@ val debug_backtraces : bool ref
 (** Command to use to diff things *)
 val diff_command : string option ref
 
-(** Automatically promote files *)
-val auto_promote : bool ref
+module Promote : sig
+  type t =
+    | Automatically
+    | Never
+end
+
+(** explicit promotion mode is set *)
+val promote : Promote.t option ref
 
 (** Force re-running actions associated to aliases *)
 val force : bool ref

--- a/src/dune/promotion.ml
+++ b/src/dune/promotion.ml
@@ -148,9 +148,10 @@ let do_promote db files_to_promote =
 
 let finalize () =
   let db =
-    if !Clflags.auto_promote then
-      do_promote !File.db All
-    else
+    match !Clflags.promote with
+    | Some Automatically -> do_promote !File.db All
+    | Some Never
+     |None ->
       !File.db
   in
   dump_db db

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -232,6 +232,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name disable-promotion)
+ (deps (package dune) (source_tree test-cases/disable-promotion))
+ (action
+  (chdir
+   test-cases/disable-promotion
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name double-echo)
  (deps (package dune) (source_tree test-cases/double-echo))
  (action
@@ -1742,6 +1750,7 @@
   (alias deps-conf-vars)
   (alias dialects)
   (alias dir-target-dep)
+  (alias disable-promotion)
   (alias double-echo)
   (alias dune-build-dir-exec-1101)
   (alias dune-init)
@@ -1946,6 +1955,7 @@
   (alias deps-conf-vars)
   (alias dialects)
   (alias dir-target-dep)
+  (alias disable-promotion)
   (alias double-echo)
   (alias dune-build-dir-exec-1101)
   (alias dune-init)

--- a/test/blackbox-tests/test-cases/disable-promotion/dune
+++ b/test/blackbox-tests/test-cases/disable-promotion/dune
@@ -1,0 +1,3 @@
+(library
+ (name foo)
+ (public_name foo))

--- a/test/blackbox-tests/test-cases/disable-promotion/dune-project
+++ b/test/blackbox-tests/test-cases/disable-promotion/dune-project
@@ -1,0 +1,4 @@
+(lang dune 1.11)
+
+(package
+ (name foo))

--- a/test/blackbox-tests/test-cases/disable-promotion/run.t
+++ b/test/blackbox-tests/test-cases/disable-promotion/run.t
@@ -1,0 +1,12 @@
+This tests shows how all promotion to the source dir may be disabled. This
+includes both .install and .merlin files
+
+  $ dune build --disable-promotion @all
+.merlin is absent
+  $ test -f .merlin && echo ".merlin exists"
+  [1]
+
+now we build without the option and see that it is present:
+  $ dune build @all
+  $ test -f .merlin && echo ".merlin exists"
+  .merlin exists


### PR DESCRIPTION
Add an option to disable all promotion. This option is enabled via `--disable-promotion` or `DUNE_PROMOTION_DISABLED` env var.

Fix #2568 