### PR TITLE
Remove environment from digest or internal rules

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1382,7 +1382,7 @@ end = struct
     let rule_digest =
       let env =
         match (env, context) with
-        | None, None -> Env.initial
+        | None, None -> Env.empty
         | Some e, _ -> e
         | None, Some c -> c.env
       in


### PR DESCRIPTION
I'm submitting this PR to discuss our initial decision to incorporate the initial environment for dune's own rules. These internal rules should not really be affected the environment in any way.  The only thing they should depend on is the dune executable.