### PR TITLE
Use correct environment in one place

### DIFF
--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -228,16 +228,17 @@ and exec_list ts ~ectx ~eenv =
     in
     exec_list rest ~ectx ~eenv
 
+let exec_env ~(context : Context.t option) ~env =
+  match (env, context) with
+  | None, None -> Env.initial
+  | Some e, _ -> e
+  | None, Some c -> c.env
+
 let exec ~targets ~context ~env t =
-  let env =
-    match ((context : Context.t option), env) with
-    | _, Some e -> e
-    | None, None -> Env.initial
-    | Some c, None -> c.env
-  in
+  let env = exec_env ~context ~env in
   let purpose = Process.Build_job targets in
-  let ectx = { purpose; context }
-  and eenv =
+  let ectx = { purpose; context } in
+  let eenv =
     { working_dir = Path.root
     ; env
     ; stdout_to = Process.Io.stdout

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -2,25 +2,50 @@ open! Stdune
 open Import
 open Fiber.O
 
-type exec_context =
-  { context : Context.t option
-  ; purpose : Process.purpose
-  }
+module Context = struct
+  module For_exec = struct
+    type t =
+      { working_dir : Path.t
+      ; env : Env.t
+      ; stdout_to : Process.Io.output Process.Io.t
+      ; stderr_to : Process.Io.output Process.Io.t
+      ; stdin_from : Process.Io.input Process.Io.t
+      }
+  end
 
-type exec_environment =
-  { working_dir : Path.t
-  ; env : Env.t
-  ; stdout_to : Process.Io.output Process.Io.t
-  ; stderr_to : Process.Io.output Process.Io.t
-  ; stdin_from : Process.Io.input Process.Io.t
-  }
+  type t =
+    { context : Context.t option
+    ; purpose : Process.purpose
+    ; env : Env.t
+    }
 
-let exec_run ~ectx ~eenv prog args =
+  let env t = t.env
+
+  let for_exec t =
+    { For_exec.working_dir = Path.root
+    ; env = t.env
+    ; stdout_to = Process.Io.stdout
+    ; stderr_to = Process.Io.stderr
+    ; stdin_from = Process.Io.stdin
+    }
+
+  let make ~targets ~(context : Context.t option) ~env =
+    let env =
+      match (env, context) with
+      | None, None -> Env.initial
+      | Some e, _ -> e
+      | None, Some c -> c.env
+    in
+    let purpose = Process.Build_job targets in
+    { purpose; context; env }
+end
+
+let exec_run ~(ectx : Context.t) ~(eenv : Context.For_exec.t) prog args =
   ( match ectx.context with
   | None
-   |Some { Context.for_host = None; _ } ->
+   |Some { for_host = None; _ } ->
     ()
-  | Some ({ Context.for_host = Some host; _ } as target) ->
+  | Some ({ for_host = Some host; _ } as target) ->
     let invalid_prefix prefix =
       match Path.descendant prog ~of_:prefix with
       | None -> ()
@@ -228,22 +253,6 @@ and exec_list ts ~ectx ~eenv =
     in
     exec_list rest ~ectx ~eenv
 
-let exec_env ~(context : Context.t option) ~env =
-  match (env, context) with
-  | None, None -> Env.initial
-  | Some e, _ -> e
-  | None, Some c -> c.env
-
-let exec ~targets ~context ~env t =
-  let env = exec_env ~context ~env in
-  let purpose = Process.Build_job targets in
-  let ectx = { purpose; context } in
-  let eenv =
-    { working_dir = Path.root
-    ; env
-    ; stdout_to = Process.Io.stdout
-    ; stderr_to = Process.Io.stderr
-    ; stdin_from = Process.Io.stdin
-    }
-  in
-  exec t ~ectx ~eenv
+let exec action (ectx : Context.t) =
+  let eenv = Context.for_exec ectx in
+  exec action ~ectx ~eenv

--- a/src/dune/action_exec.mli
+++ b/src/dune/action_exec.mli
@@ -1,10 +1,15 @@
 open! Stdune
 
-val exec_env : context:Context.t option -> env:Env.t option -> Env.t
+module Context : sig
+  type t
 
-val exec :
-     targets:Path.Build.Set.t
-  -> context:Context.t option
-  -> env:Env.t option
-  -> Action.t
-  -> unit Fiber.t
+  val make :
+       targets:Path.Build.Set.t
+    -> context:Context.t option
+    -> env:Env.t option
+    -> t
+
+  val env : t -> Env.t
+end
+
+val exec : Action.t -> Context.t -> unit Fiber.t

--- a/src/dune/action_exec.mli
+++ b/src/dune/action_exec.mli
@@ -1,5 +1,7 @@
 open! Stdune
 
+val exec_env : context:Context.t option -> env:Env.t option -> Env.t
+
 val exec :
      targets:Path.Build.Set.t
   -> context:Context.t option

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1380,12 +1380,7 @@ end = struct
           ~sandboxing_preference:t.sandboxing_preference
     in
     let rule_digest =
-      let env =
-        match (env, context) with
-        | None, None -> Env.initial
-        | Some e, _ -> e
-        | None, Some c -> c.env
-      in
+      let env = Action_exec.exec_env ~context ~env in
       let trace =
         ( Dep.Set.trace deps ~sandbox_mode ~env ~eval_pred
         , List.map targets_as_list ~f:(fun p -> Path.to_string (Path.build p))


### PR DESCRIPTION
Given that I confused myself about this, I figured that we could use this opportunity to make things a little more bulletproof. Now we compute the action's context and use it to extract the env for the digest. We no longer need to construct the correct environment twice.

By the way, I just noticed that we aren't taking the digest of the un-sandboxed action. It's probably harmless but a bit confusing.

@staronj might want to take a look as well