### PR TITLE
Fix incorrect message "unknown macro"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,10 @@
   linked in an executable. This help detecting who accidently pulls in
   `unix` for instance (#2570, @diml)
 
+- Fix incorrect error message when a variable is expanded in static context:
+  `%{lib:lib:..}` when the library does not exist. (#2597, fix #1541,
+  @rgrinberg)
+
 1.11.3 (23/08/2019)
 -------------------
 

--- a/test/blackbox-tests/test-cases/github1541/run.t
+++ b/test/blackbox-tests/test-cases/github1541/run.t
@@ -31,7 +31,8 @@ for libraries in the deps field:
   File "dune", line 1, characters 14-33:
   1 | (rule (deps %{lib:fakelib:bar.ml}) (target dummy) (action (with-stdout-to %{target} (echo foo))))
                     ^^^^^^^^^^^^^^^^^^^
-  Error: Unknown macro %{lib:..}
+  Error: Library "fakelib" not found.
+  Hint: try: dune external-lib-deps --missing ./dummy
   [1]
 
 for binaries in the deps field:
@@ -41,5 +42,6 @@ for binaries in the deps field:
   File "dune", line 1, characters 14-25:
   1 | (rule (deps %{bin:foobar}) (target dummy) (action (with-stdout-to %{target} (echo foo))))
                     ^^^^^^^^^^^
-  Error: Unknown macro %{bin:..}
+  Error: Program foobar not found in the tree or in PATH
+   (context: default)
   [1]


### PR DESCRIPTION
When using %{lib:..} in a non dynamic context should give us an error
straight away. Delaying the error doesn't make sense as we will not be
expanding these variables in a second step.