### PR TITLE
Mention Coq in the overview.

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -5,10 +5,10 @@ Overview
 Introduction
 ============
 
-Dune is a build system for OCaml and Reason. It is not intended as a
-completely generic build system that is able to build any given project
-in any language. On the contrary, it makes lots of choices in order to
-encourage a consistent development style.
+Dune is a build system for OCaml (with support for Reason and Coq).
+It is not intended as a completely generic build system that is able
+to build any given project in any language.  On the contrary, it makes
+lots of choices in order to encourage a consistent development style.
 
 This scheme is inspired from the one used inside Jane Street and adapted
 to the opam world. It has matured over a long time and is used daily by


### PR DESCRIPTION
Since #2531, there is no longer a Coq section in the documentation, and since #2535 there is no longer a Coq sub-section in the "Other topics" section.  Coq's documentation is only available through its dedicated stanzas.  This means that it is much harder to discover that Dune supports not just OCaml and Reason, but also Coq.  This is an attempt to fix that, although it might be controversial, especially given that Coq's support is still very much a work-in-progress.