### PR TITLE
Fix 2584

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,9 @@
 
 - Drop support for `jbuild` and `jbuild-ignore` files (#2607, @diml)
 
+- Allow to mark directories as `data_only_dirs` without including them as `dirs`
+  (#2619, fix #2584, @rgrinberg)
+
 1.11.3 (23/08/2019)
 -------------------
 

--- a/src/dune/sub_dirs.ml
+++ b/src/dune/sub_dirs.ml
@@ -51,23 +51,10 @@ module Status = struct
   end
 end
 
-let status ({ Status.Map.normal; data_only; vendored } as t) ~dir :
-    Status.Or_ignored.t =
-  match
-    ( String.Set.mem normal dir
-    , String.Set.mem data_only dir
-    , String.Set.mem vendored dir )
-  with
-  | true, false, false -> Status Normal
-  | true, false, true -> Status Vendored
-  | true, true, _ -> Status Data_only
-  | false, false, _ -> Ignored
-  | false, true, false -> Status Data_only
-  | false, true, true ->
-    Code_error.raise "Sub_dirs.status: invalid combination"
-      [ ("t", Status.Map.to_dyn String.Set.to_dyn t)
-      ; ("dir", String.to_dyn dir)
-      ]
+let status status_by_dir ~dir : Status.Or_ignored.t =
+  match String.Map.find status_by_dir dir with
+  | None -> Ignored
+  | Some d -> Status d
 
 let default =
   let standard_dirs =
@@ -91,23 +78,30 @@ let make ~dirs ~data_only ~ignored_sub_dirs ~vendored_dirs =
 
 let eval (t : _ Status.Map.t) ~dirs =
   let normal = Predicate_lang.filter t.normal ~standard:default.normal dirs in
-  let to_set ~standard pred =
-    String.Set.of_list (Predicate_lang.filter pred ~standard dirs)
+  let eval ~standard pred = Predicate_lang.filter pred ~standard dirs in
+  let data_only = eval ~standard:default.data_only t.data_only in
+  let vendored = eval ~standard:default.vendored t.vendored in
+  let statuses =
+    List.fold_left normal ~init:String.Map.empty
+      ~f:(fun acc dir -> String.Map.set acc dir Status.Normal)
   in
-  let data_only = to_set ~standard:default.data_only t.data_only in
-  let vendored = to_set ~standard:default.vendored t.vendored in
-  let both_vendored_and_data = String.Set.inter data_only vendored in
-  match String.Set.choose both_vendored_and_data with
-  | None ->
-    let normal = String.Set.of_list normal in
-    { Status.Map.normal; data_only; vendored }
-  | Some dir ->
-    User_error.raise
-      [ Pp.textf
-          "Directory %s was marked as vendored and data_only, it can't be \
-           marked as both."
-          dir
-      ]
+  let statuses =
+    List.fold_left data_only ~init:statuses ~f:(fun acc dir ->
+      String.Map.set acc dir Status.Data_only)
+  in
+  List.fold_left vendored ~init:statuses ~f:(fun acc dir ->
+    String.Map.update acc dir ~f:(function
+      | None
+      | Some Status.Vendored
+      | Some Normal -> Some Vendored
+      | Some Data_only ->
+        User_error.raise
+          [ Pp.textf
+              "Directory %s was marked as vendored and data_only, it can't be \
+               marked as both."
+              dir
+          ]
+    ))
 
 let decode =
   let open Dune_lang.Decoder in

--- a/src/dune/sub_dirs.ml
+++ b/src/dune/sub_dirs.ml
@@ -17,6 +17,14 @@ module Status = struct
       | Data_only -> data_only
       | Vendored -> vendored
       | Normal -> normal
+
+    let to_dyn f { data_only; vendored; normal } =
+      let open Dyn.Encoder in
+      record
+        [ ("data_only", f data_only)
+        ; ("vendored", f vendored)
+        ; ("normal", f normal)
+        ]
   end
 
   let to_dyn t =
@@ -43,7 +51,7 @@ module Status = struct
   end
 end
 
-let status { Status.Map.normal; data_only; vendored } ~dir :
+let status ({ Status.Map.normal; data_only; vendored } as t) ~dir :
     Status.Or_ignored.t =
   match
     ( String.Set.mem normal dir
@@ -54,7 +62,11 @@ let status { Status.Map.normal; data_only; vendored } ~dir :
   | true, false, true -> Status Vendored
   | true, true, _ -> Status Data_only
   | false, false, _ -> Ignored
-  | false, true, _ -> assert false
+  | false, true, _ ->
+    Code_error.raise "Sub_dirs.status: invalid combination"
+      [ ("t", Status.Map.to_dyn String.Set.to_dyn t)
+      ; ("dir", String.to_dyn dir)
+      ]
 
 let default =
   let standard_dirs =

--- a/src/dune/sub_dirs.ml
+++ b/src/dune/sub_dirs.ml
@@ -89,12 +89,6 @@ let make ~dirs ~data_only ~ignored_sub_dirs ~vendored_dirs =
   let vendored = Option.value vendored_dirs ~default:default.vendored in
   { Status.Map.normal; data_only; vendored }
 
-let add_data_only_dirs (t : _ Status.Map.t) ~dirs =
-  { t with
-    Status.Map.data_only =
-      Predicate_lang.union [ t.data_only; Predicate_lang.of_string_set dirs ]
-  }
-
 let eval (t : _ Status.Map.t) ~dirs =
   let normal = Predicate_lang.filter t.normal ~standard:default.normal dirs in
   let to_set ~standard pred =

--- a/src/dune/sub_dirs.ml
+++ b/src/dune/sub_dirs.ml
@@ -76,6 +76,8 @@ let make ~dirs ~data_only ~ignored_sub_dirs ~vendored_dirs =
   let vendored = Option.value vendored_dirs ~default:default.vendored in
   { Status.Map.normal; data_only; vendored }
 
+type status_map = Status.t String.Map.t
+
 let eval (t : _ Status.Map.t) ~dirs =
   let normal = Predicate_lang.filter t.normal ~standard:default.normal dirs in
   let eval ~standard pred = Predicate_lang.filter pred ~standard dirs in

--- a/src/dune/sub_dirs.ml
+++ b/src/dune/sub_dirs.ml
@@ -62,7 +62,8 @@ let status ({ Status.Map.normal; data_only; vendored } as t) ~dir :
   | true, false, true -> Status Vendored
   | true, true, _ -> Status Data_only
   | false, false, _ -> Ignored
-  | false, true, _ ->
+  | false, true, false -> Status Data_only
+  | false, true, true ->
     Code_error.raise "Sub_dirs.status: invalid combination"
       [ ("t", Status.Map.to_dyn String.Set.to_dyn t)
       ; ("dir", String.to_dyn dir)

--- a/src/dune/sub_dirs.mli
+++ b/src/dune/sub_dirs.mli
@@ -38,11 +38,6 @@ end
 
 val default : Predicate_lang.t Status.Map.t
 
-val add_data_only_dirs :
-     Predicate_lang.t Status.Map.t
-  -> dirs:String.Set.t
-  -> Predicate_lang.t Status.Map.t
-
 val eval :
      Predicate_lang.t Status.Map.t
   -> dirs:string list

--- a/src/dune/sub_dirs.mli
+++ b/src/dune/sub_dirs.mli
@@ -24,6 +24,8 @@ module Status : sig
       }
 
     val find : 'a t -> status -> 'a
+
+    val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
   end
   with type status := t
 
@@ -41,9 +43,9 @@ val default : Predicate_lang.t Status.Map.t
 val eval :
      Predicate_lang.t Status.Map.t
   -> dirs:string list
-  -> String.Set.t Status.Map.t
+  -> Status.t String.Map.t
 
-val status : String.Set.t Status.Map.t -> dir:string -> Status.Or_ignored.t
+val status : Status.t String.Map.t -> dir:string -> Status.Or_ignored.t
 
 val decode :
   (Predicate_lang.t Status.Map.t * Dune_lang.Ast.t list) Dune_lang.Decoder.t

--- a/src/dune/sub_dirs.mli
+++ b/src/dune/sub_dirs.mli
@@ -40,12 +40,14 @@ end
 
 val default : Predicate_lang.t Status.Map.t
 
+type status_map
+
 val eval :
      Predicate_lang.t Status.Map.t
   -> dirs:string list
-  -> Status.t String.Map.t
+  -> status_map
 
-val status : Status.t String.Map.t -> dir:string -> Status.Or_ignored.t
+val status : status_map -> dir:string -> Status.Or_ignored.t
 
 val decode :
   (Predicate_lang.t Status.Map.t * Dune_lang.Ast.t list) Dune_lang.Decoder.t

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -815,6 +815,14 @@
     (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
 (alias
+ (name github2584)
+ (deps (package dune) (source_tree test-cases/github2584))
+ (action
+  (chdir
+   test-cases/github2584
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name github534)
  (deps (package dune) (source_tree test-cases/github534))
  (action
@@ -1868,6 +1876,7 @@
   (alias github24)
   (alias github2499)
   (alias github25)
+  (alias github2584)
   (alias github534)
   (alias github568)
   (alias github597)
@@ -2075,6 +2084,7 @@
   (alias github24)
   (alias github2499)
   (alias github25)
+  (alias github2584)
   (alias github534)
   (alias github568)
   (alias github597)

--- a/test/blackbox-tests/test-cases/github2584/run.t
+++ b/test/blackbox-tests/test-cases/github2584/run.t
@@ -5,30 +5,3 @@
   > EOF
   $ mkdir bar && touch bar/x
   $ dune build
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-  ("Sub_dirs.status: invalid combination",
-  {t = {data_only = set {"bar"};
-         vendored = set {};
-         normal = set {}};
-    dir = "bar"})
-  Backtrace:
-  Raised at file "src/stdune/code_error.ml", line 9, characters 30-62
-  Called from file "src/dune/file_tree.ml", line 272, characters 22-54
-  Called from file "list.ml", line 121, characters 24-34
-  Called from file "src/dune/file_tree.ml", line 265, characters 11-1023
-  Called from file "camlinternalLazy.ml", line 29, characters 17-27
-  Re-raised at file "camlinternalLazy.ml", line 36, characters 4-11
-  Called from file "src/dune/file_tree.ml" (inlined), line 93, characters 19-31
-  Called from file "src/dune/file_tree.ml", line 118, characters 22-34
-  Called from file "src/dune/dune_load.ml", line 212, characters 4-309
-  Called from file "src/dune/main.ml", line 41, characters 13-44
-  Called from file "bin/import.ml", line 55, characters 21-42
-  Called from file "src/fiber/fiber.ml", line 114, characters 10-15
-  
-  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
-  the little-death that brings total obliteration.  I will fully express
-  my cases.  Execution will pass over me and through me.  And when it
-  has gone past, I will unwind the stack along its path.  Where the
-  cases are handled there will be nothing.  Only I will remain.
-  [1]

--- a/test/blackbox-tests/test-cases/github2584/run.t
+++ b/test/blackbox-tests/test-cases/github2584/run.t
@@ -1,0 +1,34 @@
+  $ echo "(lang dune 1.11)" > dune-project
+  $ cat >dune <<EOF
+  > (dirs foo)
+  > (data_only_dirs bar)
+  > EOF
+  $ mkdir bar && touch bar/x
+  $ dune build
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+  ("Sub_dirs.status: invalid combination",
+  {t = {data_only = set {"bar"};
+         vendored = set {};
+         normal = set {}};
+    dir = "bar"})
+  Backtrace:
+  Raised at file "src/stdune/code_error.ml", line 9, characters 30-62
+  Called from file "src/dune/file_tree.ml", line 272, characters 22-54
+  Called from file "list.ml", line 121, characters 24-34
+  Called from file "src/dune/file_tree.ml", line 265, characters 11-1023
+  Called from file "camlinternalLazy.ml", line 29, characters 17-27
+  Re-raised at file "camlinternalLazy.ml", line 36, characters 4-11
+  Called from file "src/dune/file_tree.ml" (inlined), line 93, characters 19-31
+  Called from file "src/dune/file_tree.ml", line 118, characters 22-34
+  Called from file "src/dune/dune_load.ml", line 212, characters 4-309
+  Called from file "src/dune/main.ml", line 41, characters 13-44
+  Called from file "bin/import.ml", line 55, characters 21-42
+  Called from file "src/fiber/fiber.ml", line 114, characters 10-15
+  
+  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
+  the little-death that brings total obliteration.  I will fully express
+  my cases.  Execution will pass over me and through me.  And when it
+  has gone past, I will unwind the stack along its path.  Where the
+  cases are handled there will be nothing.  Only I will remain.
+  [1]


### PR DESCRIPTION
Allow for directories to be marked as data dirs without being included in `dirs`. I believe that this is the most intuitive behavior, even if we didn't mean to allow it before.