### PR TITLE
add a test for the dune memory cache invalidation

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/run.t
@@ -30,3 +30,53 @@
   $ cat _build/default/target
   \_o< COIN
   \_o< COIN
+
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+  $ cat > dune-v1 <<EOF
+  > (rule
+  >   (targets t1)
+  >   (action (bash "echo running; echo v1 > t1")))
+  > (rule
+  >   (deps t1)
+  >   (targets t2)
+  >   (action (bash "echo running; cat t1 t1 > t2")))
+  > EOF
+  $ cat > dune-v2 <<EOF
+  > (rule
+  >   (targets t1)
+  >   (action (bash "echo running; echo v2 > t1")))
+  > (rule
+  >   (deps t1)
+  >   (targets t2)
+  >   (action (bash "echo running; cat t1 t1 > t2")))
+  > EOF
+  $ cp dune-v1 dune
+  $ env DUNE_CACHE=1 DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build t2
+          bash t1
+  running
+          bash t2
+  running
+  $ cat _build/default/t2
+  v1
+  v1
+  $ cp dune-v2 dune
+  $ env DUNE_CACHE=1 DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build t2
+          bash t1
+  running
+          bash t2
+  running
+  $ cat _build/default/t2
+  v2
+  v2
+  $ cp dune-v1 dune
+  $ env DUNE_CACHE=1 DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build t2
+  $ cat _build/default/t1
+  v1
+  $ cat _build/default/t2
+  v2
+  v2
+
+^ Bug: the wrong cached version of t2 is used


### PR DESCRIPTION
It looks like dune memory does not update the digest cache when retrieving the artifact from cache.

Note that the obvious fix of calling `Cached_digest.refresh` on `file.in_the_build_directory` doesn't work because `file.in_the_build_directory` (incorrectly) counts as an external path.
We should probably change the promotion to no longer write absolute paths in there.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>