### PR TITLE
[WIP] Improve linking of exe dot o

### DIFF
--- a/src/dune/exe.mli
+++ b/src/dune/exe.mli
@@ -27,7 +27,13 @@ module Linkage : sig
   (** Javascript compilation, extension [.bc.js] *)
   val js : t
 
-  val make : mode:Mode.t -> ext:string -> ?flags:string list -> unit -> t
+  val make :
+       mode:Mode.t
+    -> ext:string
+    -> ?flags:string list
+    -> ?link_stubs_explicitly:bool
+    -> unit
+    -> t
 
   val of_user_config : Context.t -> Dune_file.Executables.Link_mode.t -> t
 end

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -391,6 +391,14 @@ let hash t = Id.hash (to_id t)
 
 include Comparable.Make (T)
 
+let link_flags t mode =
+  let archives = Lib_info.archives t.info in
+  let foreign_archives = Lib_info.foreign_archives t.info in
+  Command.Args.S
+    [ Deps (Mode.Dict.get archives mode)
+    ; Hidden_deps (Mode.Dict.get foreign_archives mode |> Dep.Set.of_files)
+    ]
+
 module L = struct
   type nonrec t = t list
 
@@ -427,29 +435,13 @@ module L = struct
 
   let c_include_flags ts = to_iflags (c_include_paths ts)
 
-  let link_flags ts ~mode =
-    Command.Args.S
-      ( c_include_flags ts
-      :: List.map ts ~f:(fun t ->
-             let archives = Lib_info.archives t.info in
-             Command.Args.Deps (Mode.Dict.get archives mode)) )
-
   let compile_and_link_flags ~compile ~link ~mode =
     let dirs = Path.Set.union (include_paths compile) (c_include_paths link) in
     Command.Args.S
-      ( to_iflags dirs
-      :: List.map link ~f:(fun t ->
-             let archives = Lib_info.archives t.info in
-             Command.Args.Deps (Mode.Dict.get archives mode)) )
+      (to_iflags dirs :: List.map link ~f:(fun t -> link_flags t mode))
 
   let jsoo_runtime_files ts =
     List.concat_map ts ~f:(fun t -> Lib_info.jsoo_runtime t.info)
-
-  let archive_files ts ~mode =
-    List.concat_map ts ~f:(fun t ->
-        let archives = Lib_info.archives t.info in
-        let foreign_archives = Lib_info.foreign_archives t.info in
-        Mode.Dict.get archives mode @ Mode.Dict.get foreign_archives mode)
 
   let remove_dups l =
     let rec loop acc l seen =
@@ -484,13 +476,7 @@ module Lib_and_module = struct
       Command.Args.S
         ( L.c_include_flags libs
         :: List.map ts ~f:(function
-             | Lib t ->
-               let archives = Lib_info.archives t.info in
-               let archive_files = L.archive_files [ t ] ~mode in
-               Command.Args.S
-                 [ Command.Args.Deps (Mode.Dict.get archives mode)
-                 ; Command.Args.Hidden_deps (Dep.Set.of_files archive_files)
-                 ]
+             | Lib t -> link_flags t mode
              | Module (obj_dir, m) ->
                Command.Args.S
                  [ Dep

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -93,7 +93,11 @@ module Lib_and_module : sig
     val of_libs : lib list -> t
 
     val link_flags :
-      t -> lib_config:Lib_config.t -> mode:Mode.t -> _ Command.Args.t
+         t
+      -> lib_config:Lib_config.t
+      -> mode:Mode.t
+      -> link_stubs_explicitly:bool
+      -> _ Command.Args.t
   end
 end
 with type lib := t

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -64,14 +64,8 @@ module L : sig
 
   val c_include_flags : t -> _ Command.Args.t
 
-  val link_flags : t -> mode:Mode.t -> _ Command.Args.t
-
   val compile_and_link_flags :
     compile:t -> link:t -> mode:Mode.t -> _ Command.Args.t
-
-  (** All the library archive files (.a, .cmxa, _stubs.a, ...) that should be
-      linked in when linking an executable. *)
-  val archive_files : t -> mode:Mode.t -> Path.t list
 
   val jsoo_runtime_files : t -> Path.t list
 

--- a/src/dune/preprocessing.ml
+++ b/src/dune/preprocessing.ml
@@ -314,8 +314,6 @@ let build_ppx_driver sctx ~dep_kind ~target ~pps ~pp_names =
   add_rule ~sandbox:Sandbox_config.no_special_requirements
     ( Build.record_lib_deps
         (Lib_deps.info ~kind:dep_kind (Lib_deps.of_pps pp_names))
-    >>> Build.of_result_map driver_and_libs ~f:(fun (_, libs) ->
-            Build.paths (Lib.L.archive_files libs ~mode))
     >>> Command.run (Ok compiler) ~dir:(Path.build ctx.build_dir)
           [ A "-o"
           ; Target target


### PR DESCRIPTION
Attempt at improving the handling of .exe.o.

- only link stubs when linking a .exe.o
- link stubs explicitly instead of relying on autolink