### PR TITLE
`dune-action-plugin` - expressing dependencies directly in source code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,10 @@
 - Allow to mark directories as `data_only_dirs` and `vendored` directories
   without including them as `dirs` (#2619, fix #2584, @rgrinberg)
 
+- Add a `dune-action-plugin` library for describing dependencies direcly in
+  the executable source. Programs that use this feature can be run by a new
+  action (dynamic-run <progn> ...). (#2635, @staronj, @aalekseyev)
+
 1.11.3 (23/08/2019)
 -------------------
 

--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -36,6 +36,7 @@ type subdirs =
 let dirs =
   [ ("src/stdune/result", Some "Dune_result", No)
   ; ("src/stdune/caml", Some "Dune_caml", No)
+  ; ("src/dune_action_plugin", Some "Dune_action_plugin", No)
   ; ("src/stdune", Some "Stdune", No)
   ; ("src/fiber", Some "Fiber", No)
   ; ("src/xdg", Some "Xdg", No)

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -703,13 +703,6 @@ of your project. What you should write instead is:
 
 .. _dune-action-plugin:
 
-Dune action plugin
-==================
-
-``Dune-action-plugin`` provides a monadic interface to express program
-dependencies directly inside the source code. Programs using this feature
-should be declared using ``dynamic-run`` construction instead of usual ``run``.
-
 Sandboxing
 ==========
 

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -595,13 +595,18 @@ automatically handled by dune.
 The DSL is currently quite limited, so if you want to do something complicated
 it is recommended to write a small OCaml program and use the DSL to invoke it.
 You can use `shexp <https://github.com/janestreet/shexp>`__ to write portable
-scripts or :ref:`configurator` for configuration related tasks.
+scripts or :ref:`configurator` for configuration related tasks. You can also
+use :ref:`dune-action-plugin` to express program dependencies directly in the
+source code.
 
 The following constructions are available:
 
 - ``(run <prog> <args>)`` to execute a program. ``<prog>`` is resolved
   locally if it is available in the current workspace, otherwise it is
   resolved using the ``PATH``
+- ``(dynamic-run <prog> <args>)`` to execute a program that was linkied
+  against ``dune-action-plugin`` library. ``<prog>`` is resolved in
+  the same way as in ``run``
 - ``(chdir <dir> <DSL>)`` to change the current directory
 - ``(setenv <var> <value> <DSL>)`` to set an environment variable
 - ``(with-<outputs>-to <file> <DSL>)`` to redirect the output to a file, where
@@ -695,6 +700,15 @@ of your project. What you should write instead is:
      (target blah.ml)
      (deps   blah.mll)
      (action (chdir %{workspace_root} (run ocamllex -o %{target} %{deps}))))
+
+.. _dune-action-plugin:
+
+Dune action plugin
+==================
+
+``Dune-action-plugin`` provides a monadic interface to express program
+dependencies directly inside the source code. Programs using this feature
+should be declared using ``dynamic-run`` construction instead of usual ``run``.
 
 Sandboxing
 ==========

--- a/doc/dune-libs.rst
+++ b/doc/dune-libs.rst
@@ -166,3 +166,11 @@ everytime you commit your code the version would change and dune would
 need to rebuild all the binaries and everything that depend on them,
 such as tests. Instead Dune leaves a placeholder inside the binary and
 fills it during installation or promotion.
+
+
+Dune action plugin
+==================
+
+``Dune-action-plugin`` provides a monadic interface to express program
+dependencies directly inside the source code. Programs using this feature
+should be declared using ``dynamic-run`` construction instead of usual ``run``.

--- a/src/dune/action.mli
+++ b/src/dune/action.mli
@@ -68,6 +68,9 @@ val for_shell : t -> For_shell.t
 (** Return the list of directories the action chdirs to *)
 val chdirs : t -> Path.Set.t
 
+(** Checks, if action contains a [Dynamic_run]. *)
+val is_dynamic : t -> bool
+
 (** Ast where programs are not yet looked up in the PATH *)
 module Unresolved : sig
   type action = t

--- a/src/dune/action_ast.ml
+++ b/src/dune/action_ast.ml
@@ -57,6 +57,10 @@ struct
             , let+ prog = Program.decode
               and+ args = repeat String.decode in
               Run (prog, args) )
+          ; ( "dynamic-run"
+            , let+ prog = Program.decode
+              and+ args = repeat String.decode in
+              Dynamic_run (prog, args) )
           ; ( "chdir"
             , let+ dn = path
               and+ t = t in
@@ -129,6 +133,8 @@ struct
     let target = Target.encode in
     function
     | Run (a, xs) -> List (atom "run" :: program a :: List.map xs ~f:string)
+    | Dynamic_run (a, xs) ->
+      List (atom "run_dynamic" :: program a :: List.map xs ~f:string)
     | Chdir (a, r) -> List [ atom "chdir"; path a; encode r ]
     | Setenv (k, v, r) -> List [ atom "setenv"; string k; string v; encode r ]
     | Redirect_out (outputs, fn, r) ->

--- a/src/dune/action_dune_lang.ml
+++ b/src/dune/action_dune_lang.ml
@@ -29,6 +29,47 @@ include Action_ast.Make (String_with_vars) (String_with_vars)
           (Uast)
 module Mapper = Action_mapper.Make (Uast) (Uast)
 
+let ensure_at_most_one_dynamic_run ~loc action =
+  let rec loop : t -> bool = function
+    | Dynamic_run _ -> true
+    | Chdir (_, t)
+     |Setenv (_, _, t)
+     |Redirect_out (_, _, t)
+     |Redirect_in (_, _, t)
+     |Ignore (_, t) ->
+      loop t
+    | Run _
+     |Echo _
+     |Cat _
+     |Copy _
+     |Symlink _
+     |Copy_and_add_line_directive _
+     |System _
+     |Bash _
+     |Write_file _
+     |Rename _
+     |Remove_tree _
+     |Mkdir _
+     |Digest_files _
+     |Diff _
+     |Merge_files_into _ ->
+      false
+    | Progn ts ->
+      List.fold_left ts ~init:false ~f:(fun acc t ->
+          let have_dyn = loop t in
+          if acc && have_dyn then
+            User_error.raise ~loc
+              [ Pp.text
+                  "Multiple 'dynamic-run' commands within single action are \
+                   not supported."
+              ]
+          else
+            acc || have_dyn)
+  in
+  ignore (loop action)
+
+let validate ~loc t = ensure_at_most_one_dynamic_run ~loc t
+
 let remove_locs =
   let dir = String_with_vars.make_text Loc.none "" in
   let f_program ~dir:_ = String_with_vars.remove_locs in
@@ -42,7 +83,12 @@ let compare_no_locs t1 t2 = compare (remove_locs t1) (remove_locs t2)
 open Dune_lang.Decoder
 
 let decode =
-  if_list ~then_:decode
+  if_list
+    ~then_:
+      ( located decode
+      >>| fun (loc, action) ->
+      validate ~loc action;
+      action )
     ~else_:
       ( loc
       >>| fun loc ->

--- a/src/dune/action_dune_lang.ml
+++ b/src/dune/action_dune_lang.ml
@@ -29,6 +29,13 @@ include Action_ast.Make (String_with_vars) (String_with_vars)
           (Uast)
 module Mapper = Action_mapper.Make (Uast) (Uast)
 
+(* In [Action_exec] we rely on one-to-one mapping between the cwd-relative
+   paths seen by the action and [Path.t] seen by dune.
+
+   Having more than one dynamic_run with different cwds could break that.
+   Also, we didn't really want to think about how multiple dynamic actions would
+   interact (do we want dependencies requested by one to be visible to the
+   other?) *)
 let ensure_at_most_one_dynamic_run ~loc action =
   let rec loop : t -> bool = function
     | Dynamic_run _ -> true

--- a/src/dune/action_dune_lang.mli
+++ b/src/dune/action_dune_lang.mli
@@ -11,6 +11,9 @@ include
 
 include Dune_lang.Conv.S with type t := t
 
+(** Raises User_error on invalid action. *)
+val validate : loc:Loc.t -> t -> unit
+
 include
   Action_intf.Helpers
     with type t := t

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -3,6 +3,9 @@ open Import
 open Fiber.O
 module DAP = Dune_action_plugin.Private.Protocol
 
+(** A version of [Dune_action_plugin.Private.Protocol.Dependency] where all
+    relative paths are replaced by [Path.t]. (except the protocol doesn't
+    support Globs yet) *)
 module Dynamic_dep = struct
   module T = struct
     type t =

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -1,51 +1,90 @@
 open! Stdune
 open Import
 open Fiber.O
+module DAP = Dune_action_plugin.Private.Protocol
 
-module Context = struct
-  module For_exec = struct
+module Dynamic_dep = struct
+  module T = struct
     type t =
-      { working_dir : Path.t
-      ; env : Env.t
-      ; stdout_to : Process.Io.output Process.Io.t
-      ; stderr_to : Process.Io.output Process.Io.t
-      ; stdin_from : Process.Io.input Process.Io.t
-      }
+      | File of Path.t
+      | Glob of Path.t * Glob.t
+
+    let to_dep = function
+      | File fn -> Dep.file fn
+      | Glob (dir, glob) ->
+        Glob.to_pred glob |> File_selector.create ~dir |> Dep.file_selector
+
+    let of_DAP_dep ~working_dir : DAP.Dependency.t -> t =
+      let to_dune_path = Stdune.Path.relative working_dir in
+      function
+      | File fn -> File (to_dune_path fn)
+      | Directory dir -> Glob (to_dune_path dir, Glob.universal)
+
+    let compare x y =
+      match (x, y) with
+      | File x, File y -> Path.compare x y
+      | File _, _ -> Lt
+      | _, File _ -> Gt
+      | Glob (dir1, glob1), Glob (dir2, glob2) ->
+        Tuple.T2.compare Path.compare Glob.compare (dir1, glob1) (dir2, glob2)
+
+    let to_dyn =
+      let open Dyn.Encoder in
+      function
+      | File fn -> constr "File" [ Path.to_dyn fn ]
+      | Glob (dir, glob) -> constr "Glob" [ Path.to_dyn dir; Glob.to_dyn glob ]
   end
 
-  type t =
-    { context : Context.t option
-    ; purpose : Process.purpose
-    ; initial_env : Env.t
-    }
+  include T
+  module O = Comparable.Make (T)
 
-  let env t = t.initial_env
+  module Set = struct
+    include O.Set
 
-  let for_exec t =
-    { For_exec.working_dir = Path.root
-    ; env = t.initial_env
-    ; stdout_to = Process.Io.stdout
-    ; stderr_to = Process.Io.stderr
-    ; stdin_from = Process.Io.stdin
-    }
+    let to_dep_set t = t |> to_list |> List.map ~f:to_dep |> Dep.Set.of_list
 
-  let make ~targets ~(context : Context.t option) ~env =
-    let initial_env =
-      match (env, context) with
-      | None, None -> Env.initial
-      | Some e, _ -> e
-      | None, Some c -> c.env
-    in
-    let purpose = Process.Build_job targets in
-    { purpose; context; initial_env }
+    let of_DAP_dep_set ~working_dir t =
+      t |> DAP.Dependency.Set.to_list
+      |> List.map ~f:(of_DAP_dep ~working_dir)
+      |> of_list
+  end
 end
 
-let exec_run ~(ectx : Context.t) ~(eenv : Context.For_exec.t) prog args =
-  ( match ectx.context with
+module Exec_result = struct
+  type t = { dynamic_deps_stages : Dynamic_dep.Set.t List.t }
+end
+
+type done_or_more_deps =
+  | Done
+  (* This code assumes that there can be at most one 'dynamic-run' within
+     single action. [DAP.Dependency.t] stores relative paths so name clash
+     would possible if multiple 'dynamic-run' would be executed in different
+     subdirectories that contains targets having the same name. *)
+  | Need_more_deps of (DAP.Dependency.Set.t * Dynamic_dep.Set.t)
+
+type exec_context =
+  { targets : Path.Build.Set.t
+  ; context : Context.t option
+  ; purpose : Process.purpose
+  ; rule_loc : Loc.t
+  ; build_deps : Dep.Set.t -> unit Fiber.t
+  }
+
+type exec_environment =
+  { working_dir : Path.t
+  ; env : Env.t
+  ; stdout_to : Process.Io.output Process.Io.t
+  ; stderr_to : Process.Io.output Process.Io.t
+  ; stdin_from : Process.Io.input Process.Io.t
+  ; prepared_dependencies : DAP.Dependency.Set.t
+  }
+
+let validate_context_and_prog context prog =
+  match context with
   | None
-   |Some { for_host = None; _ } ->
+   |Some { Context.for_host = None; _ } ->
     ()
-  | Some ({ for_host = Some host; _ } as target) ->
+  | Some ({ Context.for_host = Some host; _ } as target) ->
     let invalid_prefix prefix =
       match Path.descendant prog ~of_:prefix with
       | None -> ()
@@ -59,10 +98,76 @@ let exec_run ~(ectx : Context.t) ~(eenv : Context.For_exec.t) prog args =
           ]
     in
     invalid_prefix (Path.relative Path.build_dir target.name);
-    invalid_prefix (Path.relative Path.build_dir ("install/" ^ target.name)) );
+    invalid_prefix (Path.relative Path.build_dir ("install/" ^ target.name))
+
+let exec_run ~ectx ~eenv prog args =
+  validate_context_and_prog ectx.context prog;
   Process.run Strict ~dir:eenv.working_dir ~env:eenv.env
     ~stdout_to:eenv.stdout_to ~stderr_to:eenv.stderr_to
     ~stdin_from:eenv.stdin_from ~purpose:ectx.purpose prog args
+
+let exec_run_dynamic_client ~ectx ~eenv prog args =
+  validate_context_and_prog ectx.context prog;
+  let run_arguments_fn = Filename.temp_file "" ".run_in_dune" in
+  let response_fn = Filename.temp_file "" ".response" in
+  let run_arguments =
+    let targets =
+      let to_relative path =
+        path |> Stdune.Path.build |> Stdune.Path.reach ~from:eenv.working_dir
+      in
+      Stdune.Path.Build.Set.to_list ectx.targets
+      |> List.map ~f:to_relative |> String.Set.of_list
+    in
+    DAP.Run_arguments.
+      { prepared_dependencies = eenv.prepared_dependencies; targets }
+  in
+  Io.String_path.write_file run_arguments_fn
+    (DAP.Run_arguments.serialize run_arguments);
+  let env =
+    let value = DAP.Greeting.(serialize { run_arguments_fn; response_fn }) in
+    Env.add eenv.env ~var:DAP.run_by_dune_env_variable ~value
+  in
+  let+ () =
+    Process.run Strict ~dir:eenv.working_dir ~env ~stdout_to:eenv.stdout_to
+      ~stderr_to:eenv.stderr_to ~stdin_from:eenv.stdin_from
+      ~purpose:ectx.purpose prog args
+  in
+  let response = Io.String_path.read_file response_fn in
+  Stdune.Path.(
+    unlink_no_err (of_string run_arguments_fn);
+    unlink_no_err (of_string response_fn));
+  let prog_name = Stdune.Path.reach ~from:eenv.working_dir prog in
+  match DAP.Response.deserialize response with
+  | Error _ when String.is_empty response ->
+    User_error.raise ~loc:ectx.rule_loc
+      [ Pp.textf
+          "Executable '%s' declared as using dune-action-plugin (declared \
+           with 'dynamic-run' tag) failed to respond to dune."
+          prog_name
+      ; Pp.nop
+      ; Pp.text
+          "If you don't use dynamic dependency discovery in your executable \
+           you may consider changing 'dynamic-run' to 'run' in your rule \
+           definition."
+      ]
+  | Error Parse_error ->
+    User_error.raise ~loc:ectx.rule_loc
+      [ Pp.textf
+          "Executable '%s' declared as using dune-action-plugin (declared \
+           with 'dynamic-run' tag) responded with invalid message."
+          prog_name
+      ]
+  | Error (Version_mismatch _) ->
+    User_error.raise ~loc:ectx.rule_loc
+      [ Pp.textf
+          "Executable '%s' is linked against a version of dune-action-plugin \
+           library that is incompatible with this version of dune."
+          prog_name
+      ]
+  | Ok Done -> Done
+  | Ok (Need_more_deps deps) ->
+    Need_more_deps
+      (deps, Dynamic_dep.Set.of_DAP_dep_set ~working_dir:eenv.working_dir deps)
 
 let exec_echo stdout_to str =
   Fiber.return (output_string (Process.Io.out_channel stdout_to) str)
@@ -70,28 +175,35 @@ let exec_echo stdout_to str =
 let rec exec t ~ectx ~eenv =
   match (t : Action.t) with
   | Run (Error e, _) -> Action.Prog.Not_found.raise e
-  | Run (Ok prog, args) -> exec_run ~ectx ~eenv prog args
+  | Run (Ok prog, args) ->
+    let+ () = exec_run ~ectx ~eenv prog args in
+    Done
+  | Dynamic_run (Error e, _) -> Action.Prog.Not_found.raise e
+  | Dynamic_run (Ok prog, args) ->
+    exec_run_dynamic_client ~ectx ~eenv prog args
   | Chdir (dir, t) -> exec t ~ectx ~eenv:{ eenv with working_dir = dir }
   | Setenv (var, value, t) ->
     exec t ~ectx ~eenv:{ eenv with env = Env.add eenv.env ~var ~value }
   | Redirect_out (Stdout, fn, Echo s) ->
     Io.write_file (Path.build fn) (String.concat s ~sep:" ");
-    Fiber.return ()
+    Fiber.return Done
   | Redirect_out (outputs, fn, t) ->
     let fn = Path.build fn in
     redirect_out t ~ectx ~eenv outputs fn
   | Redirect_in (inputs, fn, t) -> redirect_in t ~ectx ~eenv inputs fn
   | Ignore (outputs, t) -> redirect_out t ~ectx ~eenv outputs Config.dev_null
   | Progn ts -> exec_list ts ~ectx ~eenv
-  | Echo strs -> exec_echo eenv.stdout_to (String.concat strs ~sep:" ")
+  | Echo strs ->
+    let+ () = exec_echo eenv.stdout_to (String.concat strs ~sep:" ") in
+    Done
   | Cat fn ->
     Io.with_file_in fn ~f:(fun ic ->
         Io.copy_channels ic (Process.Io.out_channel eenv.stdout_to));
-    Fiber.return ()
+    Fiber.return Done
   | Copy (src, dst) ->
     let dst = Path.build dst in
     Io.copy_file ~src ~dst ();
-    Fiber.return ()
+    Fiber.return Done
   | Symlink (src, dst) ->
     ( if Sys.win32 then
       let dst = Path.build dst in
@@ -114,7 +226,7 @@ let rec exec t ~ectx ~eenv =
           Unix.symlink src dst
         )
       | exception _ -> Unix.symlink src dst );
-    Fiber.return ()
+    Fiber.return Done
   | Copy_and_add_line_directive (src, dst) ->
     Io.with_file_in src ~f:(fun ic ->
         Path.build dst
@@ -124,32 +236,36 @@ let rec exec t ~ectx ~eenv =
                  (Utils.line_directive ~filename:(Path.to_string fn)
                     ~line_number:1);
                Io.copy_channels ic oc));
-    Fiber.return ()
+    Fiber.return Done
   | System cmd ->
     let path, arg =
       Utils.system_shell_exn ~needed_to:"interpret (system ...) actions"
     in
-    exec_run ~ectx ~eenv path [ arg; cmd ]
+    let+ () = exec_run ~ectx ~eenv path [ arg; cmd ] in
+    Done
   | Bash cmd ->
-    exec_run ~ectx ~eenv
-      (Utils.bash_exn ~needed_to:"interpret (bash ...) actions")
-      [ "-e"; "-u"; "-o"; "pipefail"; "-c"; cmd ]
+    let+ () =
+      exec_run ~ectx ~eenv
+        (Utils.bash_exn ~needed_to:"interpret (bash ...) actions")
+        [ "-e"; "-u"; "-o"; "pipefail"; "-c"; cmd ]
+    in
+    Done
   | Write_file (fn, s) ->
     Io.write_file (Path.build fn) s;
-    Fiber.return ()
+    Fiber.return Done
   | Rename (src, dst) ->
     Unix.rename (Path.Build.to_string src) (Path.Build.to_string dst);
-    Fiber.return ()
+    Fiber.return Done
   | Remove_tree path ->
     Path.rm_rf (Path.build path);
-    Fiber.return ()
+    Fiber.return Done
   | Mkdir path ->
     if Path.is_in_build_dir path then
       Path.mkdir_p path
     else
       Code_error.raise "Action_exec.exec: mkdir on non build dir"
         [ ("path", Path.to_dyn path) ];
-    Fiber.return ()
+    Fiber.return Done
   | Digest_files paths ->
     let s =
       let data =
@@ -158,7 +274,8 @@ let rec exec t ~ectx ~eenv =
       in
       Digest.generic data
     in
-    exec_echo eenv.stdout_to (Digest.to_string_raw s)
+    let+ () = exec_echo eenv.stdout_to (Digest.to_string_raw s) in
+    Done
   | Diff ({ optional; file1; file2; mode } as diff) ->
     let remove_intermediate_file () =
       if optional then
@@ -166,48 +283,51 @@ let rec exec t ~ectx ~eenv =
     in
     if Diff.eq_files diff then (
       remove_intermediate_file ();
-      Fiber.return ()
+      Fiber.return Done
     ) else
       let is_copied_from_source_tree file =
         match Path.extract_build_context_dir_maybe_sandboxed file with
         | None -> false
         | Some (_, file) -> Path.exists (Path.source file)
       in
-      Fiber.finalize
-        (fun () ->
-          if mode = Binary then
-            User_error.raise
-              [ Pp.textf "Files %s and %s differ."
-                  (Path.to_string_maybe_quoted file1)
-                  (Path.to_string_maybe_quoted file2)
-              ]
-          else
-            Print_diff.print file1 file2
-              ~skip_trailing_cr:(mode = Text && Sys.win32))
-        ~finally:(fun () ->
-          ( match optional with
-          | false ->
-            if
-              is_copied_from_source_tree file1
-              && not (is_copied_from_source_tree file2)
-            then
-              Promotion.File.register_dep
-                ~source_file:
-                  (snd
-                     (Option.value_exn
-                        (Path.extract_build_context_dir_maybe_sandboxed file1)))
-                ~correction_file:(Path.as_in_build_dir_exn file2)
-          | true ->
-            if is_copied_from_source_tree file1 then
-              Promotion.File.register_intermediate
-                ~source_file:
-                  (snd
-                     (Option.value_exn
-                        (Path.extract_build_context_dir_maybe_sandboxed file1)))
-                ~correction_file:(Path.as_in_build_dir_exn file2)
+      let+ () =
+        Fiber.finalize
+          (fun () ->
+            if mode = Binary then
+              User_error.raise
+                [ Pp.textf "Files %s and %s differ."
+                    (Path.to_string_maybe_quoted file1)
+                    (Path.to_string_maybe_quoted file2)
+                ]
             else
-              remove_intermediate_file () );
-          Fiber.return ())
+              Print_diff.print file1 file2
+                ~skip_trailing_cr:(mode = Text && Sys.win32))
+          ~finally:(fun () ->
+            ( match optional with
+            | false ->
+              if
+                is_copied_from_source_tree file1
+                && not (is_copied_from_source_tree file2)
+              then
+                Promotion.File.register_dep
+                  ~source_file:
+                    (snd
+                       (Option.value_exn
+                          (Path.extract_build_context_dir_maybe_sandboxed file1)))
+                  ~correction_file:(Path.as_in_build_dir_exn file2)
+            | true ->
+              if is_copied_from_source_tree file1 then
+                Promotion.File.register_intermediate
+                  ~source_file:
+                    (snd
+                       (Option.value_exn
+                          (Path.extract_build_context_dir_maybe_sandboxed file1)))
+                  ~correction_file:(Path.as_in_build_dir_exn file2)
+              else
+                remove_intermediate_file () );
+            Fiber.return ())
+      in
+      Done
   | Merge_files_into (sources, extras, target) ->
     let lines =
       List.fold_left
@@ -219,7 +339,7 @@ let rec exec t ~ectx ~eenv =
     in
     let target = Path.build target in
     Io.write_lines target (String.Set.to_list lines);
-    Fiber.return ()
+    Fiber.return Done
 
 and redirect_out t ~ectx ~eenv outputs fn =
   let out = Process.Io.file fn Process.Io.Out in
@@ -230,7 +350,9 @@ and redirect_out t ~ectx ~eenv outputs fn =
     | Outputs -> (out, out)
   in
   exec t ~ectx ~eenv:{ eenv with stdout_to; stderr_to }
-  >>| fun () -> Process.Io.release out
+  >>| fun result ->
+  Process.Io.release out;
+  result
 
 and redirect_in t ~ectx ~eenv inputs fn =
   let in_ = Process.Io.file fn Process.Io.In in
@@ -239,21 +361,56 @@ and redirect_in t ~ectx ~eenv inputs fn =
     | Stdin -> in_
   in
   exec t ~ectx ~eenv:{ eenv with stdin_from }
-  >>| fun () -> Process.Io.release in_
+  >>| fun result ->
+  Process.Io.release in_;
+  result
 
 and exec_list ts ~ectx ~eenv =
   match ts with
-  | [] -> Fiber.return ()
+  | [] -> Fiber.return Done
   | [ t ] -> exec t ~ectx ~eenv
-  | t :: rest ->
-    let* () =
+  | t :: rest -> (
+    let* done_or_deps =
       let stdout_to = Process.Io.multi_use eenv.stdout_to in
       let stderr_to = Process.Io.multi_use eenv.stderr_to in
       let stdin_from = Process.Io.multi_use eenv.stdin_from in
       exec t ~ectx ~eenv:{ eenv with stdout_to; stderr_to; stdin_from }
     in
-    exec_list rest ~ectx ~eenv
+    match done_or_deps with
+    | Need_more_deps _ as need -> Fiber.return need
+    | Done -> exec_list rest ~ectx ~eenv )
 
-let exec action (ectx : Context.t) =
-  let eenv = Context.for_exec ectx in
-  exec action ~ectx ~eenv
+let exec_until_all_deps_ready ~ectx ~eenv t =
+  let open DAP in
+  let stages = ref [] in
+  let rec loop ~eenv =
+    let* result = exec ~ectx ~eenv t in
+    match result with
+    | Done -> Fiber.return ()
+    | Need_more_deps (relative_deps, deps_to_build) ->
+      stages := deps_to_build :: !stages;
+      let* () = ectx.build_deps (Dynamic_dep.Set.to_dep_set deps_to_build) in
+      let eenv =
+        { eenv with
+          prepared_dependencies =
+            Dependency.Set.union eenv.prepared_dependencies relative_deps
+        }
+      in
+      loop ~eenv
+  in
+  let+ () = loop ~eenv in
+  Exec_result.{ dynamic_deps_stages = List.rev !stages }
+
+let exec ~targets ~context ~env ~rule_loc ~build_deps t =
+  let purpose = Process.Build_job targets in
+  let ectx = { targets; purpose; context; rule_loc; build_deps }
+  and eenv =
+    { working_dir = Path.root
+    ; env
+    ; stdout_to = Process.Io.stdout
+    ; stderr_to = Process.Io.stderr
+    ; stdin_from = Process.Io.stdin
+    ; prepared_dependencies = DAP.Dependency.Set.empty
+    }
+  in
+  exec_until_all_deps_ready t ~ectx ~eenv

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -61,7 +61,7 @@ type done_or_more_deps =
   | Done
   (* This code assumes that there can be at most one 'dynamic-run' within
      single action. [DAP.Dependency.t] stores relative paths so name clash
-     would possible if multiple 'dynamic-run' would be executed in different
+     would be possible if multiple 'dynamic-run' would be executed in different
      subdirectories that contains targets having the same name. *)
   | Need_more_deps of (DAP.Dependency.Set.t * Dynamic_dep.Set.t)
 

--- a/src/dune/action_intf.ml
+++ b/src/dune/action_intf.ml
@@ -22,6 +22,7 @@ module type Ast = sig
 
   type t =
     | Run of program * string list
+    | Dynamic_run of program * string list
     | Chdir of path * t
     | Setenv of string * string * t
     (* It's not possible to use a build path here since jbuild supports

--- a/src/dune/action_mapper.ml
+++ b/src/dune/action_mapper.ml
@@ -16,6 +16,8 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
     match t with
     | Run (prog, args) ->
       Run (f_program ~dir prog, List.map args ~f:(f_string ~dir))
+    | Dynamic_run (prog, args) ->
+      Dynamic_run (f_program ~dir prog, List.map args ~f:(f_string ~dir))
     | Chdir (fn, t) -> Chdir (f_path ~dir fn, f t ~dir:fn)
     | Setenv (var, value, t) ->
       Setenv (f_string ~dir var, f_string ~dir value, f t ~dir)

--- a/src/dune/action_to_sh.ml
+++ b/src/dune/action_to_sh.ml
@@ -38,6 +38,7 @@ let simplify act =
   let rec loop (act : Action.For_shell.t) acc =
     match act with
     | Run (prog, args) -> Run (prog, args) :: acc
+    | Dynamic_run (prog, args) -> Run (prog, args) :: acc
     | Chdir (p, act) -> loop act (Chdir p :: mkdir p :: acc)
     | Setenv (k, v, act) -> loop act (Setenv (k, v) :: acc)
     | Redirect_out (outputs, fn, act) ->

--- a/src/dune/action_unexpanded.ml
+++ b/src/dune/action_unexpanded.ml
@@ -97,8 +97,7 @@ module Partial = struct
   end
 
   let rec expand t ~map_exe ~expander : Unresolved.t =
-    match t with
-    | Run (prog, args) ->
+    let expand_run prog args =
       let args = List.concat_map args ~f:(E.strings ~expander) in
       let prog, more_args = E.prog_and_args ~expander prog in
       let prog =
@@ -106,7 +105,15 @@ module Partial = struct
         | Search _ -> prog
         | This path -> This (map_exe path)
       in
-      Run (prog, more_args @ args)
+      (prog, more_args @ args)
+    in
+    match t with
+    | Run (prog, args) ->
+      let prog, args = expand_run prog args in
+      Run (prog, args)
+    | Dynamic_run (prog, args) ->
+      let prog, args = expand_run prog args in
+      Dynamic_run (prog, args)
     | Chdir (fn, t) ->
       let fn = E.path ~expander fn in
       let expander =
@@ -191,8 +198,7 @@ module E = struct
 end
 
 let rec partial_expand t ~map_exe ~expander : Partial.t =
-  match t with
-  | Run (prog, args) -> (
+  let partial_expand_exe prog args =
     let args =
       List.concat_map args ~f:(fun arg ->
           match E.strings ~expander arg with
@@ -207,8 +213,16 @@ let rec partial_expand t ~map_exe ~expander : Partial.t =
         | Search _ -> prog
         | This path -> This (map_exe path)
       in
-      Run (Left prog, more_args @ args)
-    | Right _ as prog -> Run (prog, args) )
+      (Left prog, more_args @ args)
+    | Right _ as prog -> (prog, args)
+  in
+  match t with
+  | Run (prog, args) ->
+    let prog, args = partial_expand_exe prog args in
+    Run (prog, args)
+  | Dynamic_run (prog, args) ->
+    let prog, args = partial_expand_exe prog args in
+    Dynamic_run (prog, args)
   | Chdir (fn, t) -> (
     let res = E.path ~expander fn in
     match res with
@@ -353,6 +367,7 @@ module Infer = struct
     let rec infer acc t =
       match t with
       | Run (prog, _) -> acc +<! prog
+      | Dynamic_run (prog, _) -> acc +<! prog
       | Redirect_out (_, fn, t) -> infer (acc +@+ fn) t
       | Redirect_in (_, fn, t) -> infer (acc +< fn) t
       | Cat fn -> acc +< fn

--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -263,7 +263,7 @@ let static_deps t ~list_targets =
       acc
     | Deps deps -> Static_deps.add_action_deps acc deps
     | Paths_for_rule fns -> Static_deps.add_rule_paths acc fns
-    | Paths_glob g -> Static_deps.add_action_dep acc (Dep.glob g)
+    | Paths_glob g -> Static_deps.add_action_dep acc (Dep.file_selector g)
     | If_file_exists (p, state) -> (
       match !state with
       | Decided (_, t) -> loop t acc false

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -169,6 +169,12 @@ module Internal_rule = struct
   (* Create a shim for the main build goal *)
   let shim_of_build_goal ~build ~static_deps =
     { root with id = Id.gen (); static_deps; build }
+
+  let effective_env rule =
+    match (rule.env, rule.context) with
+    | None, None -> Env.initial
+    | Some e, _ -> e
+    | None, Some c -> c.env
 end
 
 module Alias0 = struct
@@ -282,6 +288,7 @@ module Trace_db : sig
   module Entry : sig
     type t =
       { rule_digest : Digest.t
+      ; dynamic_deps_stages : (Action_exec.Dynamic_dep.Set.t * Digest.t) list
       ; targets_digest : Digest.t
       }
   end
@@ -293,6 +300,7 @@ end = struct
   module Entry = struct
     type t =
       { rule_digest : Digest.t
+      ; dynamic_deps_stages : (Action_exec.Dynamic_dep.Set.t * Digest.t) list
       ; targets_digest : Digest.t
       }
   end
@@ -307,7 +315,7 @@ end = struct
 
     let name = "INCREMENTAL-DB"
 
-    let version = 3
+    let version = 4
   end)
 
   let needs_dumping = ref false
@@ -1235,7 +1243,7 @@ end = struct
     Dep.Set.parallel_iter ~f:(function
       | Alias a -> build_file (Path.build (Alias.stamp_file a))
       | File f -> build_file f
-      | Glob g -> Pred.build g
+      | File_selector g -> Pred.build g
       | Universe
        |Env _
        |Sandbox_config _ ->
@@ -1348,11 +1356,27 @@ end = struct
       | exception Unix.Unix_error (ENOENT, _, _) -> ()
       | () -> () )
 
+  let compute_rule_digest (rule : Internal_rule.t) ~deps ~action ~sandbox_mode
+      =
+    let targets_as_list = Path.Build.Set.to_list rule.targets in
+    let env = Internal_rule.effective_env rule in
+    let trace =
+      ( Dep.Set.trace deps ~sandbox_mode ~env ~eval_pred
+      , List.map targets_as_list ~f:(fun p -> Path.to_string (Path.build p))
+      , Option.map rule.context ~f:(fun c -> c.name)
+      , Action.for_shell action )
+    in
+    Digest.generic trace
+
+  let compute_dependencies_digest deps ~sandbox_mode ~env ~eval_pred =
+    Dep.Set.trace deps ~sandbox_mode ~env ~eval_pred
+    |> (Digest.generic : Dep.Trace.t -> _)
+
   let execute_rule_impl rule =
     let t = t () in
     let { Internal_rule.dir
         ; targets
-        ; env
+        ; env = _
         ; context
         ; mode
         ; locks
@@ -1369,7 +1393,9 @@ end = struct
     Fs.mkdir_p dir;
     let targets_as_list = Path.Build.Set.to_list targets in
     let head_target = List.hd targets_as_list in
-    let prev_trace = Trace_db.get (Path.build head_target) in
+    let env = Internal_rule.effective_env rule in
+    let rule_loc = rule_loc ~file_tree:t.file_tree ~info ~dir in
+    let is_action_dynamic = Action.is_dynamic action in
     let sandbox_mode =
       match Action.is_useful_to_sandbox action with
       | Clearly_not ->
@@ -1377,35 +1403,16 @@ end = struct
         if Sandbox_config.mem config Sandbox_mode.none then
           Sandbox_mode.none
         else
-          User_error.raise
-            ~loc:(rule_loc ~file_tree:t.file_tree ~info ~dir)
+          User_error.raise ~loc:rule_loc
             [ Pp.text
                 "Rule dependencies are configured to require sandboxing, but \
                  the rule has no actions that could potentially require \
                  sandboxing."
             ]
       | Maybe ->
-        select_sandbox_mode
-          ~loc:(rule_loc ~file_tree:t.file_tree ~info ~dir)
+        select_sandbox_mode ~loc:rule_loc
           (Dep.Set.sandbox_config deps)
           ~sandboxing_preference:t.sandboxing_preference
-    in
-    let action_ctx = Action_exec.Context.make ~targets ~context ~env in
-    let rule_digest =
-      let env = Action_exec.Context.env action_ctx in
-      let trace =
-        ( Dep.Set.trace deps ~sandbox_mode ~env ~eval_pred
-        , List.map targets_as_list ~f:(fun p -> Path.to_string (Path.build p))
-        , Option.map context ~f:(fun c -> c.name)
-        , Action.for_shell action )
-      in
-      Digest.generic trace
-    in
-    let targets_digest = compute_targets_digest targets_as_list in
-    let sandbox =
-      Option.map sandbox_mode ~f:(fun mode ->
-          let digest = Digest.to_string rule_digest in
-          (Path.Build.relative sandbox_dir digest, mode))
     in
     let always_rerun =
       let force_rerun =
@@ -1414,27 +1421,67 @@ end = struct
       and depends_on_universe = Dep.Set.has_universe deps in
       force_rerun || depends_on_universe
     in
-    let something_changed =
-      match (prev_trace, targets_digest) with
-      | Some prev_trace, Some targets_digest ->
-        prev_trace.rule_digest <> rule_digest
-        || prev_trace.targets_digest <> targets_digest
-      | _ -> true
+    let rule_digest = compute_rule_digest rule ~deps ~action ~sandbox_mode in
+    let do_not_memoize = always_rerun || is_action_dynamic in
+    (* Here we determine if we need to rerun the action based on information
+       stored in Trace_db. *)
+    let* rule_need_rerun =
+      if always_rerun then
+        Fiber.return true
+      else
+        (* [prev_trace] will be [None] if rule is run for the first time. *)
+        let prev_trace = Trace_db.get (Path.build head_target) in
+        (* [targets_digest] will be [None] if not all targets were build. *)
+        let targets_digest = compute_targets_digest targets_as_list in
+        let rule_or_targets_changed =
+          match (prev_trace, targets_digest) with
+          | Some prev_trace, Some targets_digest ->
+            prev_trace.rule_digest <> rule_digest
+            || prev_trace.targets_digest <> targets_digest
+          | _ -> true
+        in
+        if rule_or_targets_changed then
+          Fiber.return true
+        else
+          let prev_trace = Option.value_exn prev_trace in
+          (* CR-someday aalekseyev: If there's a change at one of the last
+             stages, we still re-run all the previous stages, which is a bit of
+             a waste. We could remember what stage needs re-running and only
+             re-run that (and later stages). *)
+          let rec loop stages =
+            match stages with
+            | [] -> Fiber.return false
+            | (deps, old_digest) :: rest ->
+              let deps = Action_exec.Dynamic_dep.Set.to_dep_set deps in
+              let* () = build_deps deps in
+              let new_digest =
+                compute_dependencies_digest deps ~sandbox_mode ~env ~eval_pred
+              in
+              if old_digest <> new_digest then
+                Fiber.return true
+              else
+                loop rest
+          in
+          loop prev_trace.dynamic_deps_stages
+    in
+    let sandbox =
+      Option.map sandbox_mode ~f:(fun mode ->
+          let sandbox_suffix = rule_digest |> Digest.to_string in
+          (Path.Build.relative sandbox_dir sandbox_suffix, mode))
     in
     let* () =
-      if always_rerun || something_changed then (
+      if rule_need_rerun then (
         List.iter targets_as_list ~f:(fun target ->
             Path.unlink_no_err (Path.build target));
         let from_dune_memory =
-          if always_rerun then
-            None
-          else
-            Option.bind t.memory ~f:(fun memory ->
-                match Dune_manager.Client.search memory rule_digest with
-                | Ok (_, files) -> Some files
-                | Error msg ->
-                  Log.infof "cache miss: %s" msg;
-                  None)
+          match (do_not_memoize, t.memory) with
+          | false, Some memory -> (
+            match Dune_manager.Client.search memory rule_digest with
+            | Ok (_, files) -> Some files
+            | Error msg ->
+              Log.infof "cache miss: %s" msg;
+              None )
+          | _ -> None
         in
         match from_dune_memory with
         | Some files ->
@@ -1448,7 +1495,12 @@ end = struct
           in
           let digests = List.map files ~f:retrieve in
           Trace_db.set (Path.build head_target)
-            { rule_digest; targets_digest = Digest.generic digests };
+            (* We do not cache dynamic actions so [dynamic_deps_stages] is
+               always an empty list here. *)
+            { rule_digest
+            ; targets_digest = Digest.generic digests
+            ; dynamic_deps_stages = []
+            };
           Fiber.return ()
         | None ->
           pending_targets := Path.Build.Set.union targets !pending_targets;
@@ -1473,14 +1525,18 @@ end = struct
           in
           let chdirs = Action.chdirs action in
           Path.Set.iter chdirs ~f:Fs.(mkdir_p_or_check_exists ~loc);
-          let+ () =
+          let+ exec_result =
             with_locks locks ~f:(fun () ->
                 let copy_files_from_sandbox sandboxed =
                   List.iter targets_as_list ~f:(fun target ->
                       rename_optional_file ~src:(sandboxed target) ~dst:target)
                 in
-                let+ () = Action_exec.exec action action_ctx in
-                Option.iter sandboxed ~f:copy_files_from_sandbox)
+                let+ exec_result =
+                  Action_exec.exec ~context ~env ~targets ~rule_loc ~build_deps
+                    action
+                in
+                Option.iter sandboxed ~f:copy_files_from_sandbox;
+                exec_result)
           in
           Option.iter sandbox ~f:(fun (p, _mode) -> Path.rm_rf (Path.build p));
           (* All went well, these targets are no longer pending *)
@@ -1491,7 +1547,15 @@ end = struct
           Option.iter t.memory ~f:(fun memory ->
               ignore
                 (Dune_manager.Client.promote memory targets rule_digest [] None));
-          Trace_db.set (Path.build head_target) { rule_digest; targets_digest }
+          let dynamic_deps_stages =
+            List.map exec_result.dynamic_deps_stages ~f:(fun deps ->
+                ( deps
+                , Action_exec.Dynamic_dep.Set.to_dep_set deps
+                  |> compute_dependencies_digest ~sandbox_mode ~env ~eval_pred
+                ))
+          in
+          Trace_db.set (Path.build head_target)
+            { rule_digest; dynamic_deps_stages; targets_digest }
       ) else
         Fiber.return ()
     in

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1475,13 +1475,13 @@ end = struct
             Path.unlink_no_err (Path.build target));
         let from_dune_memory =
           match (do_not_memoize, t.memory) with
+          | true, _ | _, None -> None
           | false, Some memory -> (
             match Dune_manager.Client.search memory rule_digest with
             | Ok (_, files) -> Some files
             | Error msg ->
               Log.infof "cache miss: %s" msg;
               None )
-          | _ -> None
         in
         match from_dune_memory with
         | Some files ->

--- a/src/dune/dep.mli
+++ b/src/dune/dep.mli
@@ -4,7 +4,7 @@ type t = private
   | Env of Env.Var.t
   | File of Path.t
   | Alias of Alias.t
-  | Glob of File_selector.t
+  | File_selector of File_selector.t
   | Universe
   | Sandbox_config of Sandbox_config.t
 
@@ -14,7 +14,7 @@ val env : Env.Var.t -> t
 
 val universe : t
 
-val glob : File_selector.t -> t
+val file_selector : File_selector.t -> t
 
 val alias : Alias.t -> t
 

--- a/src/dune/dune
+++ b/src/dune/dune
@@ -4,7 +4,7 @@
  (name dune)
  (libraries unix stdune fiber incremental_cycles dag memo xdg dune_re
    threads.posix opam_file_format dune_lang dune_manager dune_memory
-   ocaml_config catapult jbuild_support)
+   ocaml_config catapult jbuild_support dune_action_plugin)
  (synopsis "Internal Dune library, do not use!")
  (preprocess future_syntax))
 

--- a/src/dune/glob.ml
+++ b/src/dune/glob.ml
@@ -6,6 +6,8 @@ type t =
   ; repr : string
   }
 
+let compare x y = String.compare x.repr y.repr
+
 let equal x y = String.equal x.repr y.repr
 
 let hash t = String.hash t.repr
@@ -21,6 +23,10 @@ let of_string_exn loc repr =
   | Error (_, msg) -> User_error.raise ~loc [ Pp.textf "invalid glob: :%s" msg ]
   | Ok t -> t
 
+let encode t =
+  let open Dune_lang.Encoder in
+  string t.repr
+
 let decode =
   let open Dune_lang.Decoder in
   plain_string (fun ~loc str -> of_string_exn loc str)
@@ -30,6 +36,8 @@ let test t = Re.execp t.re
 let filter t = List.filter ~f:(test t)
 
 let empty = { re = Re.compile Re.empty; repr = "\000" }
+
+let universal = { re = Re.compile (Re.rep Re.any); repr = "**" }
 
 let to_pred t =
   let id =

--- a/src/dune/glob.mli
+++ b/src/dune/glob.mli
@@ -4,9 +4,13 @@ type t
 
 val equal : t -> t -> bool
 
+val compare : t -> t -> Ordering.t
+
 val hash : t -> int
 
 val to_dyn : t Dyn.Encoder.t
+
+val encode : t Dune_lang.Encoder.t
 
 val decode : t Dune_lang.Decoder.t
 
@@ -15,6 +19,8 @@ val test : t -> string -> bool
 val filter : t -> string list -> string list
 
 val empty : t
+
+val universal : t
 
 val of_string_exn : Loc.t -> string -> t
 

--- a/src/dune/lib_file_deps.ml
+++ b/src/dune/lib_file_deps.ml
@@ -42,7 +42,7 @@ let deps_of_lib (lib : Lib.t) ~groups =
   let obj_dir = Lib.obj_dir lib in
   List.map groups ~f:(fun g ->
       let dir = Group.obj_dir g obj_dir in
-      Group.to_predicate g |> File_selector.create ~dir |> Dep.glob)
+      Group.to_predicate g |> File_selector.create ~dir |> Dep.file_selector)
   |> Dep.Set.of_list
 
 let deps_with_exts =

--- a/src/dune_action_plugin/dune
+++ b/src/dune_action_plugin/dune
@@ -1,0 +1,6 @@
+(library
+ (name dune_action_plugin)
+ (public_name dune._dune_action_plugin)
+ (libraries stdune)
+ (synopsis
+   "Monadic interface for defining scripts with dynamic or complex set of depencencies."))

--- a/src/dune_action_plugin/dune
+++ b/src/dune_action_plugin/dune
@@ -3,4 +3,4 @@
  (public_name dune._dune_action_plugin)
  (libraries stdune)
  (synopsis
-   "Monadic interface for defining scripts with dynamic or complex set of depencencies."))
+   "Monadic interface for defining scripts with dynamic or complex sets of depencencies."))

--- a/src/dune_action_plugin/dune_action_plugin.ml
+++ b/src/dune_action_plugin/dune_action_plugin.ml
@@ -1,0 +1,197 @@
+module Path = Path
+open Protocol
+
+module Execution_error = struct
+  exception E of string
+
+  let raise string = raise (E string)
+
+  let raise_on_fs_error = function
+    | Error message -> raise message
+    | Ok result -> result
+end
+
+module Fs : sig
+  val read_directory : string -> (string list, string) Result.t
+
+  val read_file : string -> (string, string) Result.t
+
+  val write_file : string -> string -> (unit, string) Result.t
+end = struct
+  let catch_system_exceptions f ~name =
+    try Ok (f ()) with
+    | Unix.Unix_error (e, _, _) -> Error (name ^ ": " ^ Unix.error_message e)
+    | Sys_error error -> Error (name ^ ": " ^ error)
+
+  let read_directory =
+    let rec loop dh acc =
+      match Unix.readdir dh with
+      | "."
+       |".." ->
+        loop dh acc
+      | s -> loop dh (s :: acc)
+      | exception End_of_file -> acc
+    in
+    fun path ->
+      catch_system_exceptions ~name:"read_directory" (fun () ->
+          let dh = Unix.opendir path in
+          Stdune.Exn.protect
+            ~f:(fun () -> loop dh [] |> List.sort String.compare)
+            ~finally:(fun () -> Unix.closedir dh))
+
+  let read_file path =
+    catch_system_exceptions ~name:"read_file" (fun () ->
+        Stdune.Io.String_path.read_file path)
+
+  let write_file path data =
+    catch_system_exceptions ~name:"write_file" (fun () ->
+        Stdune.Io.String_path.write_file path data)
+end
+
+module Stage = struct
+  type 'a t =
+    { action : unit -> 'a
+    ; dependencies : Dependency.Set.t
+    ; targets : Stdune.String.Set.t
+    }
+
+  let map (t : 'a t) ~f = { t with action = (fun () -> f (t.action ())) }
+
+  let both (t1 : 'a t) (t2 : 'b t) =
+    { action = (fun () -> (t1.action (), t2.action ()))
+    ; dependencies = Dependency.Set.union t1.dependencies t2.dependencies
+    ; targets = Stdune.String.Set.union t1.targets t2.targets
+    }
+end
+
+(* Construction inspired by free monad. *)
+type 'a t =
+  | Pure of 'a
+  | Stage of 'a t Stage.t
+
+let lift_stage stage = Stage (Stage.map stage ~f:(fun a -> Pure a))
+
+let rec map (t : 'a t) ~f =
+  match t with
+  | Pure a -> Pure (f a)
+  | Stage at -> Stage (Stage.map ~f:(map ~f) at)
+
+let rec stage (t : 'a t) ~f =
+  match t with
+  | Pure a -> f a
+  | Stage at -> Stage (Stage.map ~f:(stage ~f) at)
+
+let return a = Pure a
+
+let rec both (t1 : 'a t) (t2 : 'b t) =
+  match (t1, t2) with
+  | Pure a1, _ -> map ~f:(fun a2 -> (a1, a2)) t2
+  | _, Pure a2 -> map ~f:(fun a1 -> (a1, a2)) t1
+  | Stage at1, Stage at2 ->
+    Stage (Stage.both at1 at2 |> Stage.map ~f:(fun (am1, am2) -> both am1 am2))
+
+let read_file ~path =
+  let path = Path.to_string path in
+  let action () = Fs.read_file path |> Execution_error.raise_on_fs_error in
+  lift_stage
+    { action
+    ; dependencies = Dependency.Set.singleton (File path)
+    ; targets = Stdune.String.Set.empty
+    }
+
+let write_file ~path ~data =
+  let path = Path.to_string path in
+  let action () =
+    Fs.write_file path data |> Execution_error.raise_on_fs_error
+  in
+  lift_stage
+    { action
+    ; dependencies = Dependency.Set.empty
+    ; targets = Stdune.String.Set.singleton path
+    }
+
+(* TODO jstaron: If program tries to read empty directory, dune does not copy
+   it to `_build` so we get a "No such file or directory" error. *)
+let read_directory ~path =
+  let path = Path.to_string path in
+  let action () =
+    Fs.read_directory path |> Execution_error.raise_on_fs_error
+  in
+  lift_stage
+    { action
+    ; dependencies = Dependency.Set.singleton (Directory path)
+    ; targets = Stdune.String.Set.empty
+    }
+
+let rec run_by_dune t context =
+  match t with
+  | Pure () -> Context.respond context Done
+  | Stage at ->
+    let allowed_targets = Context.targets context in
+    let disallowed_targets =
+      Stdune.String.Set.diff at.targets allowed_targets
+    in
+    ( match Stdune.String.Set.to_list disallowed_targets with
+    | [] -> ()
+    | [ t ] ->
+      Execution_error.raise
+        (Printf.sprintf
+           "%s is written despite not being declared as a target in dune \
+            file. To fix, add it to target list in dune file."
+           t)
+    | ts ->
+      Execution_error.raise
+        (Printf.sprintf
+           "Following files were written despite not being declared as \
+            targets in dune file:\n\
+            %sTo fix, add them to target list in dune file."
+           (ts |> String.concat "\n")) );
+    let prepared_dependencies = Context.prepared_dependencies context in
+    let required_dependencies =
+      Dependency.Set.diff at.dependencies prepared_dependencies
+    in
+    if Dependency.Set.is_empty required_dependencies then
+      run_by_dune (at.action ()) context
+    else
+      Context.respond context (Need_more_deps required_dependencies)
+
+(* If executable is not run by dune, assume that all dependencies are already
+   prepared and no target checking is done. *)
+let rec run_outside_of_dune t =
+  match t with
+  | Pure () -> ()
+  | Stage at -> run_outside_of_dune (at.action ())
+
+let do_run t =
+  let open Protocol in
+  match Context.create () with
+  | Run_outside_of_dune -> run_outside_of_dune t
+  | Error message ->
+    Execution_error.raise
+      (Printf.sprintf
+         "Error during communication with dune. %s Did you use different dune \
+          version to compile the executable?"
+         message)
+  | Ok context -> run_by_dune t context
+
+let run t =
+  try
+    do_run t;
+    exit 0
+  with Execution_error.E message ->
+    prerr_endline message;
+    exit 1
+
+module O = struct
+  let ( let+ ) at f = map at ~f
+
+  let ( and+ ) = both
+end
+
+module Private = struct
+  module Protocol = Protocol
+
+  let do_run = do_run
+
+  module Execution_error = Execution_error
+end

--- a/src/dune_action_plugin/dune_action_plugin.ml
+++ b/src/dune_action_plugin/dune_action_plugin.ml
@@ -1,191 +1,194 @@
-module Path = Path
-open Protocol
+module V1 = struct
 
-module Execution_error = struct
-  exception E of string
+  module Path = Path
+  open Protocol
 
-  let raise string = raise (E string)
 
-  let raise_on_fs_error = function
-    | Error message -> raise message
-    | Ok result -> result
-end
+  module Execution_error = struct
+    exception E of string
 
-module Fs : sig
-  val read_directory : string -> (string list, string) Result.t
+    let raise string = raise (E string)
 
-  val read_file : string -> (string, string) Result.t
+    let raise_on_fs_error = function
+      | Error message -> raise message
+      | Ok result -> result
+  end
 
-  val write_file : string -> string -> (unit, string) Result.t
-end = struct
-  let catch_system_exceptions f ~name =
-    try Ok (f ()) with
-    | Unix.Unix_error (e, _, _) -> Error (name ^ ": " ^ Unix.error_message e)
-    | Sys_error error -> Error (name ^ ": " ^ error)
+  module Fs : sig
+    val read_directory : string -> (string list, string) Result.t
 
-  let read_directory =
-    let rec loop dh acc =
-      match Unix.readdir dh with
-      | "."
-       |".." ->
-        loop dh acc
-      | s -> loop dh (s :: acc)
-      | exception End_of_file -> acc
-    in
-    fun path ->
-      catch_system_exceptions ~name:"read_directory" (fun () ->
+    val read_file : string -> (string, string) Result.t
+
+    val write_file : string -> string -> (unit, string) Result.t
+  end = struct
+    let catch_system_exceptions f ~name =
+      try Ok (f ()) with
+      | Unix.Unix_error (e, _, _) -> Error (name ^ ": " ^ Unix.error_message e)
+      | Sys_error error -> Error (name ^ ": " ^ error)
+
+    let read_directory =
+      let rec loop dh acc =
+        match Unix.readdir dh with
+        | "."
+        |".." ->
+          loop dh acc
+        | s -> loop dh (s :: acc)
+        | exception End_of_file -> acc
+      in
+      fun path ->
+        catch_system_exceptions ~name:"read_directory" (fun () ->
           let dh = Unix.opendir path in
           Stdune.Exn.protect
             ~f:(fun () -> loop dh [] |> List.sort String.compare)
             ~finally:(fun () -> Unix.closedir dh))
 
-  let read_file path =
-    catch_system_exceptions ~name:"read_file" (fun () ->
+    let read_file path =
+      catch_system_exceptions ~name:"read_file" (fun () ->
         Stdune.Io.String_path.read_file path)
 
-  let write_file path data =
-    catch_system_exceptions ~name:"write_file" (fun () ->
+    let write_file path data =
+      catch_system_exceptions ~name:"write_file" (fun () ->
         Stdune.Io.String_path.write_file path data)
-end
+  end
 
-module Stage = struct
+  module Stage = struct
+    type 'a t =
+      { action : unit -> 'a
+      ; dependencies : Dependency.Set.t
+      ; targets : Stdune.String.Set.t
+      }
+
+    let map (t : 'a t) ~f = { t with action = (fun () -> f (t.action ())) }
+
+    let both (t1 : 'a t) (t2 : 'b t) =
+      { action = (fun () -> (t1.action (), t2.action ()))
+      ; dependencies = Dependency.Set.union t1.dependencies t2.dependencies
+      ; targets = Stdune.String.Set.union t1.targets t2.targets
+      }
+  end
+
+  (* Construction inspired by free monad. *)
   type 'a t =
-    { action : unit -> 'a
-    ; dependencies : Dependency.Set.t
-    ; targets : Stdune.String.Set.t
-    }
+    | Pure of 'a
+    | Stage of 'a t Stage.t
 
-  let map (t : 'a t) ~f = { t with action = (fun () -> f (t.action ())) }
+  let lift_stage stage = Stage (Stage.map stage ~f:(fun a -> Pure a))
 
-  let both (t1 : 'a t) (t2 : 'b t) =
-    { action = (fun () -> (t1.action (), t2.action ()))
-    ; dependencies = Dependency.Set.union t1.dependencies t2.dependencies
-    ; targets = Stdune.String.Set.union t1.targets t2.targets
-    }
-end
+  let rec map (t : 'a t) ~f =
+    match t with
+    | Pure a -> Pure (f a)
+    | Stage at -> Stage (Stage.map ~f:(map ~f) at)
 
-(* Construction inspired by free monad. *)
-type 'a t =
-  | Pure of 'a
-  | Stage of 'a t Stage.t
+  let rec stage (t : 'a t) ~f =
+    match t with
+    | Pure a -> f a
+    | Stage at -> Stage (Stage.map ~f:(stage ~f) at)
 
-let lift_stage stage = Stage (Stage.map stage ~f:(fun a -> Pure a))
+  let return a = Pure a
 
-let rec map (t : 'a t) ~f =
-  match t with
-  | Pure a -> Pure (f a)
-  | Stage at -> Stage (Stage.map ~f:(map ~f) at)
+  let rec both (t1 : 'a t) (t2 : 'b t) =
+    match (t1, t2) with
+    | Pure a1, _ -> map ~f:(fun a2 -> (a1, a2)) t2
+    | _, Pure a2 -> map ~f:(fun a1 -> (a1, a2)) t1
+    | Stage at1, Stage at2 ->
+      Stage (Stage.both at1 at2 |> Stage.map ~f:(fun (am1, am2) -> both am1 am2))
 
-let rec stage (t : 'a t) ~f =
-  match t with
-  | Pure a -> f a
-  | Stage at -> Stage (Stage.map ~f:(stage ~f) at)
+  let read_file ~path =
+    let path = Path.to_string path in
+    let action () = Fs.read_file path |> Execution_error.raise_on_fs_error in
+    lift_stage
+      { action
+      ; dependencies = Dependency.Set.singleton (File path)
+      ; targets = Stdune.String.Set.empty
+      }
 
-let return a = Pure a
-
-let rec both (t1 : 'a t) (t2 : 'b t) =
-  match (t1, t2) with
-  | Pure a1, _ -> map ~f:(fun a2 -> (a1, a2)) t2
-  | _, Pure a2 -> map ~f:(fun a1 -> (a1, a2)) t1
-  | Stage at1, Stage at2 ->
-    Stage (Stage.both at1 at2 |> Stage.map ~f:(fun (am1, am2) -> both am1 am2))
-
-let read_file ~path =
-  let path = Path.to_string path in
-  let action () = Fs.read_file path |> Execution_error.raise_on_fs_error in
-  lift_stage
-    { action
-    ; dependencies = Dependency.Set.singleton (File path)
-    ; targets = Stdune.String.Set.empty
-    }
-
-let write_file ~path ~data =
-  let path = Path.to_string path in
-  let action () =
-    Fs.write_file path data |> Execution_error.raise_on_fs_error
-  in
-  lift_stage
-    { action
-    ; dependencies = Dependency.Set.empty
-    ; targets = Stdune.String.Set.singleton path
-    }
-
-(* TODO jstaron: If program tries to read empty directory, dune does not copy
-   it to `_build` so we get a "No such file or directory" error. *)
-let read_directory ~path =
-  let path = Path.to_string path in
-  let action () =
-    Fs.read_directory path |> Execution_error.raise_on_fs_error
-  in
-  lift_stage
-    { action
-    ; dependencies = Dependency.Set.singleton (Directory path)
-    ; targets = Stdune.String.Set.empty
-    }
-
-let rec run_by_dune t context =
-  match t with
-  | Pure () -> Context.respond context Done
-  | Stage at ->
-    let allowed_targets = Context.targets context in
-    let disallowed_targets =
-      Stdune.String.Set.diff at.targets allowed_targets
+  let write_file ~path ~data =
+    let path = Path.to_string path in
+    let action () =
+      Fs.write_file path data |> Execution_error.raise_on_fs_error
     in
-    ( match Stdune.String.Set.to_list disallowed_targets with
-    | [] -> ()
-    | [ t ] ->
+    lift_stage
+      { action
+      ; dependencies = Dependency.Set.empty
+      ; targets = Stdune.String.Set.singleton path
+      }
+
+  (* TODO jstaron: If program tries to read empty directory, dune does not copy
+     it to `_build` so we get a "No such file or directory" error. *)
+  let read_directory ~path =
+    let path = Path.to_string path in
+    let action () =
+      Fs.read_directory path |> Execution_error.raise_on_fs_error
+    in
+    lift_stage
+      { action
+      ; dependencies = Dependency.Set.singleton (Directory path)
+      ; targets = Stdune.String.Set.empty
+      }
+
+  let rec run_by_dune t context =
+    match t with
+    | Pure () -> Context.respond context Done
+    | Stage at ->
+      let allowed_targets = Context.targets context in
+      let disallowed_targets =
+        Stdune.String.Set.diff at.targets allowed_targets
+      in
+      ( match Stdune.String.Set.to_list disallowed_targets with
+        | [] -> ()
+        | [ t ] ->
+          Execution_error.raise
+            (Printf.sprintf
+               "%s is written despite not being declared as a target in dune \
+                file. To fix, add it to target list in dune file."
+               t)
+        | ts ->
+          Execution_error.raise
+            (Printf.sprintf
+               "Following files were written despite not being declared as \
+                targets in dune file:\n\
+                %sTo fix, add them to target list in dune file."
+               (ts |> String.concat "\n")) );
+      let prepared_dependencies = Context.prepared_dependencies context in
+      let required_dependencies =
+        Dependency.Set.diff at.dependencies prepared_dependencies
+      in
+      if Dependency.Set.is_empty required_dependencies then
+        run_by_dune (at.action ()) context
+      else
+        Context.respond context (Need_more_deps required_dependencies)
+
+  (* If executable is not run by dune, assume that all dependencies are already
+     prepared and no target checking is done. *)
+  let rec run_outside_of_dune t =
+    match t with
+    | Pure () -> ()
+    | Stage at -> run_outside_of_dune (at.action ())
+
+  let do_run t =
+    let open Protocol in
+    match Context.create () with
+    | Run_outside_of_dune -> run_outside_of_dune t
+    | Error message ->
       Execution_error.raise
         (Printf.sprintf
-           "%s is written despite not being declared as a target in dune \
-            file. To fix, add it to target list in dune file."
-           t)
-    | ts ->
-      Execution_error.raise
-        (Printf.sprintf
-           "Following files were written despite not being declared as \
-            targets in dune file:\n\
-            %sTo fix, add them to target list in dune file."
-           (ts |> String.concat "\n")) );
-    let prepared_dependencies = Context.prepared_dependencies context in
-    let required_dependencies =
-      Dependency.Set.diff at.dependencies prepared_dependencies
-    in
-    if Dependency.Set.is_empty required_dependencies then
-      run_by_dune (at.action ()) context
-    else
-      Context.respond context (Need_more_deps required_dependencies)
+           "Error during communication with dune. %s Did you use different dune \
+            version to compile the executable?"
+           message)
+    | Ok context -> run_by_dune t context
 
-(* If executable is not run by dune, assume that all dependencies are already
-   prepared and no target checking is done. *)
-let rec run_outside_of_dune t =
-  match t with
-  | Pure () -> ()
-  | Stage at -> run_outside_of_dune (at.action ())
+  let run t =
+    try
+      do_run t;
+      exit 0
+    with Execution_error.E message ->
+      prerr_endline message;
+      exit 1
 
-let do_run t =
-  let open Protocol in
-  match Context.create () with
-  | Run_outside_of_dune -> run_outside_of_dune t
-  | Error message ->
-    Execution_error.raise
-      (Printf.sprintf
-         "Error during communication with dune. %s Did you use different dune \
-          version to compile the executable?"
-         message)
-  | Ok context -> run_by_dune t context
+  module O = struct
+    let ( let+ ) at f = map at ~f
 
-let run t =
-  try
-    do_run t;
-    exit 0
-  with Execution_error.E message ->
-    prerr_endline message;
-    exit 1
-
-module O = struct
-  let ( let+ ) at f = map at ~f
-
-  let ( and+ ) = both
+    let ( and+ ) = both
 end
 
 module Private = struct
@@ -195,3 +198,6 @@ module Private = struct
 
   module Execution_error = Execution_error
 end
+end
+
+module Private = V1.Private

--- a/src/dune_action_plugin/dune_action_plugin.mli
+++ b/src/dune_action_plugin/dune_action_plugin.mli
@@ -7,11 +7,15 @@ module V1 : sig
 
       Note: Monadic "bind" is provided, but it can be very costly. It's called
       [stage] to discourage people from overusing it. When dune decides that
-      the action needs to be re-run, it runs stages one by one, and starts a
-      process from scratch for every stage. So a linear chain of binds leads to
-      a linear number of program re-runs, and therefore overall quadratic time
-      complexity. This also means that using non-deterministic mutable state
-      can lead to surprising results. *)
+      the action needs to be re-run, it runs (nontrivial) stages one by one,
+      and starts a process from scratch for every stage. So a linear chain of
+      binds leads to a linear number of program re-runs, and therefore overall
+      quadratic time complexity. This also means that using non-deterministic
+      mutable state can lead to surprising results.
+      (note that with the current implementation, nontrivial stages are those
+      that have some dependencies, so a stage that merely writes out some
+      targets is "free")
+  *)
 
   module Path = Path
 
@@ -67,7 +71,9 @@ module V1 : sig
 
   (** [read_directory ~path:directory] returns a computation depending on a
       listing of a [directory] and all source and target files contained in
-      that directory. Computation will result in a directory listing. *)
+      that directory. Computation will result in a directory listing.
+
+      BUG: [read_directory] doesn't work for empty directories. *)
   val read_directory : path:Path.t -> string list t
 
   (** {1:running Running the computation} *)

--- a/src/dune_action_plugin/dune_action_plugin.mli
+++ b/src/dune_action_plugin/dune_action_plugin.mli
@@ -1,0 +1,81 @@
+(** Applicative and monadic interface for declaring dependencies.
+
+    This module is intended to be used as a interface for declaring
+    dependencies of a computation. Dependencies can be declared dynamically -
+    the list of dependencies can be depend on previous dependencies.
+
+    Note: Monadic "bind" is provided, but it can be very costly. It's called
+    [stage] to discourage people from overusing it. *)
+
+module Path = Path
+
+type 'a t
+
+(** {1:monadic_interface Applicative/monadic interface} *)
+
+(** [return a] creates a pure computation resulting in [a]. *)
+val return : 'a -> 'a t
+
+(** If [at] is a computation resulting in [a] then [map at ~f] is a computation
+    resulting in [f a]. *)
+val map : 'a t -> f:('a -> 'b) -> 'b t
+
+(** If [at] is a computation resulting in [a] and [ab] is computation resulting
+    in [b] then [both at bt] is a computation resulting in [(a, b)]. *)
+val both : 'a t -> 'b t -> ('a * 'b) t
+
+(** If [at] is a computation resulting in value of type ['a] and [f] is a
+    function taking value of type ['a] and returning a computation [bt] then
+    [stage a ~f] is a computation that is equivalent to staging computation
+    [bt] after computation [at].
+
+    Note: This is a monadic "bind" function. This function is costly so
+    different name was chooden to discourage excessive use. *)
+val stage : 'a t -> f:('a -> 'b t) -> 'b t
+
+(** {1 Syntax sugar for applicative subset} *)
+
+(** Syntax sugar for applicative subset of the interface. Syntax sugar for
+    [stage] is not provided to prevent accidential use.*)
+module O : sig
+  (** {[ let+ a = g in h ]} is equivalent to {[ map g ~f:(fun a -> g) ]}. *)
+  val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+
+  (** {[ let+ a1 = g1 and+ a2 = g2 in h ]} is equivalent to {[ both g1 g2 |>
+      map ~f:(fun (a1, a2) -> g) ]}. *)
+  val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
+end
+
+(** {1:interaction Declaring dependencies and interacting with filesystem} *)
+
+(** [read_file ~path:file] returns a computation depending on a [file] to be
+    run and resulting in a file content. *)
+val read_file : path:Path.t -> string t
+
+(** [write_file ~path:file ~data] returns a computation that writes [data] to a
+    [file].
+
+    Note: [file] must be declared as a target in dune build file. *)
+val write_file : path:Path.t -> data:string -> unit t
+
+(** [read_directory ~path:directory] returns a computation depending on a
+    listing of a [directory] and all source and target files contained in that
+    directory. Computation will result in a directory listing. *)
+val read_directory : path:Path.t -> string list t
+
+(** {1:running Running the computation} *)
+
+(** Runs the computation. This function never returns. *)
+val run : unit t -> 'a
+
+(*_ See the Jane Street Style Guide for an explanation of [Private] submodules:
+  https://opensource.janestreet.com/standards/#private-submodules *)
+module Private : sig
+  module Protocol = Protocol
+
+  val do_run : unit t -> unit
+
+  module Execution_error : sig
+    exception E of string
+  end
+end

--- a/src/dune_action_plugin/dune_action_plugin.mli
+++ b/src/dune_action_plugin/dune_action_plugin.mli
@@ -1,86 +1,87 @@
-(** Applicative and monadic interface for declaring dependencies.
+module V1 : sig
+  (** Applicative and monadic interface for declaring dependencies.
 
-    This module is intended to be used as an interface for declaring
-    dependencies of a computation. Dependencies can be declared dynamically -
-    the list of dependencies can depend on previous dependencies.
+      This module is intended to be used as an interface for declaring
+      dependencies of a computation. Dependencies can be declared dynamically -
+      the list of dependencies can depend on previous dependencies.
 
-    Note: Monadic "bind" is provided, but it can be very costly.
-    It's called [stage] to discourage people from overusing it.
-    When dune decides that the action needs to be re-run, it runs stages
-    one by one, and starts a process from scratch for every stage.
-    So a linear chain of binds leads to a linear number of program re-runs,
-    and therefore overall quadratic time complexity.
-    This also means that using non-deterministic mutable state can lead
-    to surprising results.
-*)
+      Note: Monadic "bind" is provided, but it can be very costly. It's called
+      [stage] to discourage people from overusing it. When dune decides that
+      the action needs to be re-run, it runs stages one by one, and starts a
+      process from scratch for every stage. So a linear chain of binds leads to
+      a linear number of program re-runs, and therefore overall quadratic time
+      complexity. This also means that using non-deterministic mutable state
+      can lead to surprising results. *)
 
-module Path = Path
+  module Path = Path
 
-type 'a t
+  type 'a t
 
-(** {1:monadic_interface Applicative/monadic interface} *)
+  (** {1:monadic_interface Applicative/monadic interface} *)
 
-(** [return a] creates a pure computation resulting in [a]. *)
-val return : 'a -> 'a t
+  (** [return a] creates a pure computation resulting in [a]. *)
+  val return : 'a -> 'a t
 
-(** If [at] is a computation resulting in [a] then [map at ~f] is a computation
-    resulting in [f a]. *)
-val map : 'a t -> f:('a -> 'b) -> 'b t
+  (** If [at] is a computation resulting in [a] then [map at ~f] is a
+      computation resulting in [f a]. *)
+  val map : 'a t -> f:('a -> 'b) -> 'b t
 
-(** If [at] is a computation resulting in [a] and [bt] is computation resulting
-    in [b] then [both at bt] is a computation resulting in [(a, b)]. *)
-val both : 'a t -> 'b t -> ('a * 'b) t
+  (** If [at] is a computation resulting in [a] and [bt] is computation
+      resulting in [b] then [both at bt] is a computation resulting in [(a,
+      b)]. *)
+  val both : 'a t -> 'b t -> ('a * 'b) t
 
-(** If [at] is a computation resulting in value of type ['a] and [f] is a
-    function taking value of type ['a] and returning a computation [bt] then
-    [stage a ~f] is a computation that is equivalent to staging computation
-    [bt] after computation [at].
+  (** If [at] is a computation resulting in value of type ['a] and [f] is a
+      function taking value of type ['a] and returning a computation [bt] then
+      [stage a ~f] is a computation that is equivalent to staging computation
+      [bt] after computation [at].
 
-    Note: This is a monadic "bind" function. This function is costly so
-    different name was chosen to discourage excessive use. *)
-val stage : 'a t -> f:('a -> 'b t) -> 'b t
+      Note: This is a monadic "bind" function. This function is costly so
+      different name was chosen to discourage excessive use. *)
+  val stage : 'a t -> f:('a -> 'b t) -> 'b t
 
-(** {1 Syntax sugar for applicative subset} *)
+  (** {1 Syntax sugar for applicative subset} *)
 
-(** Syntax sugar for applicative subset of the interface. Syntax sugar for
-    [stage] is not provided to prevent accidential use.*)
-module O : sig
-  (** {[ let+ a = g in h ]} is equivalent to {[ map g ~f:(fun a -> g) ]}. *)
-  val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+  (** Syntax sugar for applicative subset of the interface. Syntax sugar for
+      [stage] is not provided to prevent accidential use.*)
+  module O : sig
+    (** {[ let+ a = g in h ]} is equivalent to {[ map g ~f:(fun a -> g) ]}. *)
+    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
 
-  (** {[ let+ a1 = g1 and+ a2 = g2 in h ]} is equivalent to {[ both g1 g2 |>
-      map ~f:(fun (a1, a2) -> g) ]}. *)
-  val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
+    (** {[ let+ a1 = g1 and+ a2 = g2 in h ]} is equivalent to {[ both g1 g2 |>
+        map ~f:(fun (a1, a2) -> g) ]}. *)
+    val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
+  end
+
+  (** {1:interaction Declaring dependencies and interacting with filesystem} *)
+
+  (** [read_file ~path:file] returns a computation depending on a [file] to be
+      run and resulting in a file content. *)
+  val read_file : path:Path.t -> string t
+
+  (** [write_file ~path:file ~data] returns a computation that writes [data] to
+      a [file].
+
+      Note: [file] must be declared as a target in dune build file. *)
+  val write_file : path:Path.t -> data:string -> unit t
+
+  (** [read_directory ~path:directory] returns a computation depending on a
+      listing of a [directory] and all source and target files contained in
+      that directory. Computation will result in a directory listing. *)
+  val read_directory : path:Path.t -> string list t
+
+  (** {1:running Running the computation} *)
+
+  (** Runs the computation. This function never returns. *)
+  val run : unit t -> 'a
 end
 
-(** {1:interaction Declaring dependencies and interacting with filesystem} *)
-
-(** [read_file ~path:file] returns a computation depending on a [file] to be
-    run and resulting in a file content. *)
-val read_file : path:Path.t -> string t
-
-(** [write_file ~path:file ~data] returns a computation that writes [data] to a
-    [file].
-
-    Note: [file] must be declared as a target in dune build file. *)
-val write_file : path:Path.t -> data:string -> unit t
-
-(** [read_directory ~path:directory] returns a computation depending on a
-    listing of a [directory] and all source and target files contained in that
-    directory. Computation will result in a directory listing. *)
-val read_directory : path:Path.t -> string list t
-
-(** {1:running Running the computation} *)
-
-(** Runs the computation. This function never returns. *)
-val run : unit t -> 'a
-
-(*_ See the Jane Street Style Guide for an explanation of [Private] submodules:
-  https://opensource.janestreet.com/standards/#private-submodules *)
+(* [Private] module should only be used by dune itself. Its stability will not
+   be maintained by the future library releases. *)
 module Private : sig
   module Protocol = Protocol
 
-  val do_run : unit t -> unit
+  val do_run : unit V1.t -> unit
 
   module Execution_error : sig
     exception E of string

--- a/src/dune_action_plugin/dune_action_plugin.mli
+++ b/src/dune_action_plugin/dune_action_plugin.mli
@@ -1,11 +1,18 @@
 (** Applicative and monadic interface for declaring dependencies.
 
-    This module is intended to be used as a interface for declaring
+    This module is intended to be used as an interface for declaring
     dependencies of a computation. Dependencies can be declared dynamically -
-    the list of dependencies can be depend on previous dependencies.
+    the list of dependencies can depend on previous dependencies.
 
-    Note: Monadic "bind" is provided, but it can be very costly. It's called
-    [stage] to discourage people from overusing it. *)
+    Note: Monadic "bind" is provided, but it can be very costly.
+    It's called [stage] to discourage people from overusing it.
+    When dune decides that the action needs to be re-run, it runs stages
+    one by one, and starts a process from scratch for every stage.
+    So a linear chain of binds leads to a linear number of program re-runs,
+    and therefore overall quadratic time complexity.
+    This also means that using non-deterministic mutable state can lead
+    to surprising results.
+*)
 
 module Path = Path
 
@@ -20,7 +27,7 @@ val return : 'a -> 'a t
     resulting in [f a]. *)
 val map : 'a t -> f:('a -> 'b) -> 'b t
 
-(** If [at] is a computation resulting in [a] and [ab] is computation resulting
+(** If [at] is a computation resulting in [a] and [bt] is computation resulting
     in [b] then [both at bt] is a computation resulting in [(a, b)]. *)
 val both : 'a t -> 'b t -> ('a * 'b) t
 
@@ -30,7 +37,7 @@ val both : 'a t -> 'b t -> ('a * 'b) t
     [bt] after computation [at].
 
     Note: This is a monadic "bind" function. This function is costly so
-    different name was chooden to discourage excessive use. *)
+    different name was chosen to discourage excessive use. *)
 val stage : 'a t -> f:('a -> 'b t) -> 'b t
 
 (** {1 Syntax sugar for applicative subset} *)

--- a/src/dune_action_plugin/examples/choosing_dependency.ml
+++ b/src/dune_action_plugin/examples/choosing_dependency.ml
@@ -1,0 +1,11 @@
+open Dune_action_plugin
+
+let action =
+  let open O in
+  let path_to_dependency = read_file ~path:(Path.of_string "foo_or_bar") in
+  path_to_dependency
+  |> stage ~f:(fun path_to_dependency ->
+         let+ data = read_file ~path:(Path.of_string path_to_dependency) in
+         print_endline data)
+
+let () = run action

--- a/src/dune_action_plugin/examples/choosing_dependency.ml
+++ b/src/dune_action_plugin/examples/choosing_dependency.ml
@@ -1,4 +1,4 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
   let open O in

--- a/src/dune_action_plugin/examples/dune
+++ b/src/dune_action_plugin/examples/dune
@@ -1,0 +1,7 @@
+(executables
+ (names simple_concatenation)
+ (libraries dune_action_plugin))
+
+(alias
+ (name examples)
+ (deps simple_concatenation.exe))

--- a/src/dune_action_plugin/examples/dune
+++ b/src/dune_action_plugin/examples/dune
@@ -1,5 +1,5 @@
 (executables
- (names simple_concatenation)
+ (names simple_concatenation choosing_dependency)
  (libraries dune_action_plugin))
 
 (alias

--- a/src/dune_action_plugin/examples/simple_concatenation.ml
+++ b/src/dune_action_plugin/examples/simple_concatenation.ml
@@ -1,0 +1,11 @@
+open Dune_action_plugin
+
+let action =
+  let source1 = read_file ~path:(Path.of_string "source1")
+  and source2 = read_file ~path:(Path.of_string "source2") in
+  both source1 source2
+  |> stage ~f:(fun (source1, source2) ->
+         let data = source1 ^ source2 in
+         write_file ~path:(Path.of_string "target") ~data)
+
+let () = run action

--- a/src/dune_action_plugin/examples/simple_concatenation.ml
+++ b/src/dune_action_plugin/examples/simple_concatenation.ml
@@ -1,4 +1,4 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
   let source1 = read_file ~path:(Path.of_string "source1")

--- a/src/dune_action_plugin/path.ml
+++ b/src/dune_action_plugin/path.ml
@@ -1,0 +1,19 @@
+type t = string
+
+let concat = Filename.concat
+
+let to_string t = t
+
+let of_string path =
+  match Filename.is_relative path with
+  | false ->
+    invalid_arg
+      (Printf.sprintf
+         "Path \"%s\" is absolute. All paths used with dune-action-plugin \
+          must be relative."
+         path)
+  | true -> path
+
+module O = struct
+  let ( ^/ ) = concat
+end

--- a/src/dune_action_plugin/path.mli
+++ b/src/dune_action_plugin/path.mli
@@ -1,0 +1,20 @@
+(** Representation of paths for "dune_action_plugin" library. *)
+
+(** We shouldn't use absolute paths when communicating with Dune, so this
+    module allows user to represent only relative paths. *)
+
+type t
+
+module O : sig
+  (** Concatenate two paths. *)
+  val ( ^/ ) : t -> t -> t
+end
+
+(** Concatenate two paths. *)
+val concat : t -> t -> t
+
+val to_string : t -> string
+
+(** Convert path to string. Throws an Invalid_argument exception if passed
+    string is not a relative path. *)
+val of_string : string -> t

--- a/src/dune_action_plugin/protocol.ml
+++ b/src/dune_action_plugin/protocol.ml
@@ -1,0 +1,189 @@
+open Stdune
+
+let run_by_dune_env_variable = "DUNE_DYNAMIC_RUN_CLIENT"
+
+let sexp_of_list sexp_of_t list : Sexp.t = List (List.map ~f:sexp_of_t list)
+
+let list_of_sexp (t_of_sexp : Sexp.t -> 'a Option.t) : Sexp.t -> _ = function
+  | List sexps -> List.map sexps ~f:t_of_sexp |> Option.List.all
+  | _ -> None
+
+let sexp_of_string string : Sexp.t = Atom string
+
+let string_of_sexp : Sexp.t -> _ = function
+  | Atom string -> Some string
+  | _ -> None
+
+module Dependency = struct
+  module T = struct
+    type t =
+      | File of string
+      | Directory of string
+
+    let sexp_of_t : _ -> Sexp.t = function
+      | File path -> List [ Atom "file"; Atom path ]
+      | Directory path -> List [ Atom "directory"; Atom path ]
+
+    let t_of_sexp : Sexp.t -> _ = function
+      | List [ Atom "file"; Atom path ] -> Some (File path)
+      | List [ Atom "directory"; Atom path ] -> Some (Directory path)
+      | _ -> None
+
+    let compare x y =
+      match (x, y) with
+      | File x, File y -> String.compare x y
+      | File _, _ -> Lt
+      | _, File _ -> Gt
+      | Directory x, Directory y -> String.compare x y
+
+    let to_dyn _ = Dyn.opaque
+  end
+
+  include T
+  module O = Comparable.Make (T)
+  module Map = O.Map
+
+  module Set = struct
+    include O.Set
+
+    let sexp_of_t (t : t) = to_list t |> sexp_of_list T.sexp_of_t
+
+    let t_of_sexp sexp = Option.O.(list_of_sexp T.t_of_sexp sexp >>| of_list)
+  end
+end
+
+module Greeting = struct
+  module T = struct
+    type t =
+      { run_arguments_fn : string
+      ; response_fn : string
+      }
+
+    let sexp_of_t { run_arguments_fn; response_fn } : Sexp.t =
+      List [ Atom run_arguments_fn; Atom response_fn ]
+
+    let t_of_sexp : Sexp.t -> _ = function
+      | List [ Atom run_arguments_fn; Atom response_fn ] ->
+        Some { run_arguments_fn; response_fn }
+      | _ -> None
+
+    let version = 0
+  end
+
+  include T
+  include Serializable_intf.Make (T)
+end
+
+module Run_arguments = struct
+  module T = struct
+    type t =
+      { prepared_dependencies : Dependency.Set.t
+      ; targets : String.Set.t
+      }
+
+    let sexp_of_t { prepared_dependencies; targets } : Sexp.t =
+      List
+        [ Dependency.Set.sexp_of_t prepared_dependencies
+        ; targets |> String.Set.to_list |> sexp_of_list sexp_of_string
+        ]
+
+    let t_of_sexp : Sexp.t -> _ = function
+      | List [ prepared_dependencies; targets ] ->
+        let open Option.O in
+        let* prepared_dependencies =
+          Dependency.Set.t_of_sexp prepared_dependencies
+        in
+        let+ targets = list_of_sexp string_of_sexp targets in
+        let targets = String.Set.of_list targets in
+        { prepared_dependencies; targets }
+      | _ -> None
+
+    let version = 0
+  end
+
+  include T
+  include Serializable_intf.Make (T)
+end
+
+module Response = struct
+  module T = struct
+    type t =
+      | Done
+      | Need_more_deps of Dependency.Set.t
+
+    let sexp_of_t : _ -> Sexp.t = function
+      | Done -> List [ Atom "done" ]
+      | Need_more_deps deps ->
+        List [ Atom "need_more_deps"; Dependency.Set.sexp_of_t deps ]
+
+    let t_of_sexp : Sexp.t -> _ = function
+      | List [ Atom "done" ] -> Some Done
+      | List [ Atom "need_more_deps"; sexp ] ->
+        Option.O.(
+          Dependency.Set.t_of_sexp sexp >>| fun xs -> Need_more_deps xs)
+      | _ -> None
+
+    let version = 0
+  end
+
+  include T
+  include Serializable_intf.Make (T)
+end
+
+module Context = struct
+  type t =
+    { response_fn : string
+    ; prepared_dependencies : Dependency.Set.t
+    ; targets : String.Set.t
+    }
+
+  type create_result =
+    | Ok of t
+    | Run_outside_of_dune
+    | Error of string
+
+  let cannot_parse_error = Error "Can not parse dune message."
+
+  let version_mismatch_error =
+    Error
+      "Dune version is incompatible with dune-action-plugin library version \
+       that was used to build this executable."
+
+  let cannot_read_file = Error "Cannot read file containing dune message."
+
+  let file_not_found_error = Error "Cannot find file containing dune message."
+
+  let create () =
+    match Sys.getenv_opt run_by_dune_env_variable with
+    | None -> Run_outside_of_dune
+    | Some value -> (
+      match Greeting.deserialize value with
+      | Error (Version_mismatch _) -> version_mismatch_error
+      | Error Parse_error -> cannot_parse_error
+      | Ok greeting -> (
+        match
+          ( Result.try_with (fun () ->
+                Io.String_path.read_file greeting.run_arguments_fn)
+          , Sys.file_exists greeting.response_fn )
+        with
+        | _, false -> file_not_found_error
+        | Error _, _ -> cannot_read_file
+        | Ok data, true -> (
+          match Run_arguments.deserialize data with
+          | Error (Version_mismatch _) -> version_mismatch_error
+          | Error Parse_error -> cannot_parse_error
+          | Ok { prepared_dependencies; targets } ->
+            Ok
+              { response_fn = greeting.response_fn
+              ; prepared_dependencies
+              ; targets
+              } ) ) )
+
+  let prepared_dependencies (t : t) = t.prepared_dependencies
+
+  let targets (t : t) = t.targets
+
+  let respond (t : t) response =
+    let data = Response.serialize response in
+    Io.String_path.write_file t.response_fn data
+end

--- a/src/dune_action_plugin/protocol.mli
+++ b/src/dune_action_plugin/protocol.mli
@@ -1,0 +1,65 @@
+open Stdune
+open Sexpable_intf
+open Serializable_intf
+
+module Dependency : sig
+  type t =
+    | File of string
+    | Directory of string
+
+  include Sexpable with type t := t
+
+  module Map : Map.S with type key = t
+
+  module Set : sig
+    include Set.S with type elt = t and type 'a map = 'a Map.t
+
+    include Sexpable with type t := t
+  end
+end
+
+module Greeting : sig
+  type t =
+    { run_arguments_fn : string
+    ; response_fn : string
+    }
+
+  include Serializable with type t := t
+end
+
+module Run_arguments : sig
+  type t =
+    { prepared_dependencies : Dependency.Set.t
+    ; targets : String.Set.t
+    }
+
+  include Serializable with type t := t
+end
+
+module Response : sig
+  type t =
+    | Done
+    | Need_more_deps of Dependency.Set.t
+
+  include Serializable with type t := t
+end
+
+(** Dune sets this environment variable to pass [Greeting.t] to client. *)
+val run_by_dune_env_variable : string
+
+module Context : sig
+  type t
+
+  type create_result =
+    | Ok of t
+    | Run_outside_of_dune
+    | Error of string
+
+  val create : unit -> create_result
+
+  val prepared_dependencies : t -> Dependency.Set.t
+
+  val targets : t -> Stdune.String.Set.t
+
+  val respond : t -> Response.t -> unit
+end

--- a/src/dune_action_plugin/serializable_intf.ml
+++ b/src/dune_action_plugin/serializable_intf.ml
@@ -1,0 +1,57 @@
+open Stdune
+open Sexpable_intf
+
+module Deserialization_error = struct
+  type t =
+    | Version_mismatch of int
+    | Parse_error
+end
+
+module type Serializable = sig
+  type t
+
+  val serialize : t -> String.t
+
+  val deserialize : String.t -> (t, Deserialization_error.t) Result.t
+end
+
+module type T = Serializable
+
+module type S = sig
+  include Sexpable
+
+  val version : int
+end
+
+module Make (TypeToSerialize : S) : T with type t := TypeToSerialize.t = struct
+  open TypeToSerialize
+
+  let parsing_error_of_option :
+      _ Option.t -> (_, Deserialization_error.t) Result.t = function
+    | Some data -> Ok data
+    | None -> Error Parse_error
+
+  let serialize t =
+    Sexp.(List [ Atom "version"; Atom (Int.to_string version); sexp_of_t t ])
+    |> Csexp.to_string
+
+  let deserialize data =
+    let open Result.O in
+    let* sexp =
+      Csexp.parse_string data
+      |> Result.map_error ~f:(fun _message ->
+             Deserialization_error.Parse_error)
+    in
+    let* format_version, data =
+      match sexp with
+      | List [ Atom "version"; Atom version; data ] -> Ok (version, data)
+      | _ -> Error Deserialization_error.Parse_error
+    in
+    let* format_version =
+      int_of_string_opt format_version |> parsing_error_of_option
+    in
+    if format_version <> version then
+      Error (Deserialization_error.Version_mismatch format_version)
+    else
+      t_of_sexp data |> parsing_error_of_option
+end

--- a/src/dune_action_plugin/sexpable_intf.ml
+++ b/src/dune_action_plugin/sexpable_intf.ml
@@ -1,0 +1,9 @@
+open Stdune
+
+module type Sexpable = sig
+  type t
+
+  val sexp_of_t : t -> Sexp.t
+
+  val t_of_sexp : Sexp.t -> t Option.t
+end

--- a/test/blackbox-tests/dune
+++ b/test/blackbox-tests/dune
@@ -5,6 +5,10 @@
  (modules cram)
  (libraries stdune dune_re test_common dune configurator))
 
+(env
+ (_
+  (binaries cram.exe)))
+
 (ocamllex cram)
 
 (executable

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/bin/foo.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let+ listing = read_directory ~path:(Path.of_string "some_dir") in
   String.concat "; " listing |> Printf.printf "Directory listing: [%s]"
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let+ listing = read_directory ~path:(Path.of_string "some_dir") in
+  String.concat "; " listing |> Printf.printf "Directory listing: [%s]"
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depend-on-directory-without-targets/test/run.t
@@ -1,0 +1,20 @@
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (data_only_dirs some_dir)
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ mkdir some_dir
+  $ touch some_dir/some_file1
+  $ touch some_dir/some_file2
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest
+           foo alias runtest
+  Directory listing: [some_file1; some_file2]

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/bin/foo.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let+ data = read_file ~path:(Path.of_string "some_file") in
   print_endline data
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let+ data = read_file ~path:(Path.of_string "some_file") in
+  print_endline data
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/dependency-rebuilt-but-not-changed/test/run.t
@@ -1,0 +1,30 @@
+This test checks that 'dynamic-run' will not be reexecuted if
+dependencies do not change (have the same digest) even if
+they were forced to rebuild.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_file)
+  >  (deps (universe))
+  >  (action
+  >   (progn
+  >   (echo "Building some_file!\n")
+  >   (with-stdout-to %{target} (echo "Hello from some_file!")))))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest
+  Building some_file!
+           foo alias runtest
+  Hello from some_file!
+
+  $ dune runtest --display short
+  Building some_file!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/bin/foo.ml
@@ -1,0 +1,13 @@
+open Dune_action_plugin
+
+let contains equal list elem = List.find list (equal elem) |> Option.is_some
+
+let action =
+  let open Dune_action_plugin.O in
+  let+ _ = read_directory ~path:(Path.of_string ".")
+  and+ _ =
+    write_file ~path:(Path.of_string "some_file") ~data:"Hello from some_file!"
+  in
+  ()
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/bin/foo.ml
@@ -1,9 +1,9 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let contains equal list elem = List.find list (equal elem) |> Option.is_some
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let+ _ = read_directory ~path:(Path.of_string ".")
   and+ _ =
     write_file ~path:(Path.of_string "some_file") ~data:"Hello from some_file!"

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/test/run.t
@@ -14,3 +14,7 @@
   Error: Dependency cycle between the following files:
      _build/default/some_file
   [1]
+
+^ This is not great. There is no actual dependency cycle, dune is just
+interpreting glob dependency too coarsely (it builds all files instead
+of just bringing the directory listing up to date).

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target-by-read-dir/test/run.t
@@ -1,0 +1,16 @@
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_file)
+  >  (action
+  >   (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune build some_file --display short
+           foo some_file
+  Error: Dependency cycle between the following files:
+     _build/default/some_file
+  [1]

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo1 foo2)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo1.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo1.ml
@@ -1,4 +1,4 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let path = Path.of_string "some_file1"
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo1.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo1.ml
@@ -1,0 +1,7 @@
+open Dune_action_plugin
+
+let path = Path.of_string "some_file1"
+
+let action = read_file ~path |> stage ~f:(fun data -> write_file ~path ~data)
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo2.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo2.ml
@@ -1,9 +1,9 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let path = Path.of_string "some_file2"
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   write_file ~path ~data:"Hello from some_file2!"
   |> stage ~f:(fun () ->
          let+ data = read_file ~path in

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo2.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/bin/foo2.ml
@@ -1,0 +1,12 @@
+open Dune_action_plugin
+
+let path = Path.of_string "some_file2"
+
+let action =
+  let open Dune_action_plugin.O in
+  write_file ~path ~data:"Hello from some_file2!"
+  |> stage ~f:(fun () ->
+         let+ data = read_file ~path in
+         print_endline data)
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/depends-on-its-target/test/run.t
@@ -1,0 +1,28 @@
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_file1)
+  >  (action
+  >   (dynamic-run ./foo1.exe)))
+  > \
+  > (rule
+  >  (target some_file2)
+  >  (action
+  >   (dynamic-run ./foo2.exe)))
+  > EOF
+
+  $ cp ../bin/foo1.exe ./
+  $ cp ../bin/foo2.exe ./
+
+  $ dune build some_file1 --display short
+          foo1 some_file1
+  Error: Dependency cycle between the following files:
+     _build/default/some_file1
+  [1]
+
+  $ dune build some_file2 --display short
+          foo2 some_file2
+  Error: Dependency cycle between the following files:
+     _build/default/some_file2
+  [1]

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/bin/client.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/bin/client.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let switch = read_file ~path:(Path.of_string "foo_or_bar") in
   stage switch ~f:(fun file ->
       let+ data = read_file ~path:(Path.of_string file) in

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/bin/client.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/bin/client.ml
@@ -1,0 +1,10 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let switch = read_file ~path:(Path.of_string "foo_or_bar") in
+  stage switch ~f:(fun file ->
+      let+ data = read_file ~path:(Path.of_string file) in
+      print_endline data)
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names client)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/test/run.t
@@ -1,5 +1,5 @@
 This test checks that in case the dependency of multi staged computation changes,
-only the dependencies up to this stage are rebuild.
+only the dependencies up to this stage are rebuilt.
 
   $ echo "(lang dune 2.0)" > dune-project
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/do-not-rebuild-unneeded-dependency/test/run.t
@@ -1,0 +1,60 @@
+This test checks that in case the dependency of multi staged computation changes,
+only the dependencies up to this stage are rebuild.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (deps   bar_source)
+  >  (target bar)
+  >  (action
+  >   (progn
+  >    (echo "Building bar!\n")
+  >    (copy %{deps} %{target}))))
+  > \
+  > (rule
+  >  (deps   foo_source)
+  >  (target foo)
+  >  (action
+  >   (progn
+  >    (echo "Building foo!\n")
+  >    (copy %{deps} %{target}))))
+  > \
+  > (rule
+  >  (deps   foo_or_bar_source)
+  >  (target foo_or_bar)
+  >  (action
+  >   (progn
+  >    (echo "Building foo_or_bar!\n")
+  >    (copy %{deps} %{target}))))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./client.exe)))
+  > EOF
+
+  $ cp ../bin/client.exe ./
+
+  $ printf "foo" > foo_or_bar_source
+  $ printf "Hello from foo!" > foo_source
+  $ printf "SHOULD NOT BE PRINTED!" > bar_source
+
+  $ dune runtest --display short
+        client alias runtest
+  Building foo_or_bar!
+        client alias runtest
+  Building foo!
+        client alias runtest
+  Hello from foo!
+
+  $ printf "bar" > foo_or_bar_source
+  $ printf "SHOULD NOT BE PRINTED!" > foo_source
+  $ printf "Hello from bar!" > bar_source
+
+  $ dune runtest --display short
+  Building foo_or_bar!
+        client alias runtest
+        client alias runtest
+  Building bar!
+        client alias runtest
+  Hello from bar!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/bin/foo.ml
@@ -1,0 +1,3 @@
+open Dune_action_plugin
+
+let () = run (return ())

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/bin/foo.ml
@@ -1,3 +1,3 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let () = run (return ())

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/multiple-dynamic-run-within-single-action/test/run.t
@@ -1,0 +1,29 @@
+Check that multiple 'dynamic-run' commands within single action are
+detected and error is printed even if the rule is not executed.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_file)
+  >  (action
+  >   (progn
+  >    (dynamic-run ./foo.exe some_arg)
+  >    (dynamic-run ./foo.exe another_arg))))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action
+  >   (echo "SHOULD NOT BE PRINTED")))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest
+  File "dune", line 4, characters 2-84:
+  4 |   (progn
+  5 |    (dynamic-run ./foo.exe some_arg)
+  6 |    (dynamic-run ./foo.exe another_arg))))
+  Error: Multiple 'dynamic-run' commands within single action are not
+  supported.
+  [1]

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/bin/foo.ml
@@ -1,0 +1,3 @@
+open Dune_action_plugin
+
+let () = run (return (print_endline "Hello from foo!"))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/bin/foo.ml
@@ -1,3 +1,3 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let () = run (return (print_endline "Hello from foo!"))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/no-dependencies/test/run.t
@@ -1,0 +1,16 @@
+This test checks that executable that uses 'dynamic-run'
+but requires no dependencies can be successfully run.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest
+  Hello from foo!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/bin/foo.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let+ data = read_file ~path:(Path.of_string "some_absent_dependency") in
   print_endline data
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let+ data = read_file ~path:(Path.of_string "some_absent_dependency") in
+  print_endline data
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-absent-dependency/test/run.t
@@ -1,0 +1,21 @@
+This test checks that executable that uses 'dynamic-run'
+and requires dependency that can not be build fails.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest
+  File "dune", line 1, characters 0-57:
+  1 | (alias
+  2 |  (name runtest)
+  3 |  (action (dynamic-run ./foo.exe)))
+  Error: No rule found for some_absent_dependency
+  [1]

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let+ data = read_file ~path:(Path.of_string "some_dependency") in
+  print_endline data
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/bin/foo.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let+ data = read_file ~path:(Path.of_string "some_dependency") in
   print_endline data
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency-with-chdir/test/run.t
@@ -1,0 +1,27 @@
+This test checks that 'dynamic-run' can work
+when we 'chdir' into different directory.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (alias
+  >  (name runtest)
+  >  (action
+  >   (chdir some_dir
+  >   (dynamic-run ./foo.exe))))
+  > EOF
+
+  $ mkdir some_dir
+
+  $ cat > some_dir/dune << EOF
+  > (rule
+  >  (target some_dependency)
+  >  (action
+  >   (with-stdout-to %{target} (echo "Hello from some_dependency!"))))
+  > EOF
+
+  $ cp ../bin/foo.exe ./some_dir
+  $ dune runtest --display short
+           foo alias runtest
+           foo alias runtest
+  Hello from some_dependency!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let+ data = read_file ~path:(Path.of_string "some_dependency") in
+  print_endline data
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/bin/foo.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let+ data = read_file ~path:(Path.of_string "some_dependency") in
   print_endline data
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-dependency/test/run.t
@@ -1,0 +1,21 @@
+This test checks that executable that uses 'dynamic-run'
+and requires one dependency can be successfully run.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_dependency)
+  >  (action (with-stdout-to %{target} (echo "Hello from some_dependency!"))))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest
+           foo alias runtest
+  Hello from some_dependency!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let+ listing = read_directory ~path:(Path.of_string "some_dir") in
+  String.concat "\n" listing |> print_endline
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/bin/foo.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let+ listing = read_directory ~path:(Path.of_string "some_dir") in
   String.concat "\n" listing |> print_endline
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-directory-dependency/test/run.t
@@ -1,0 +1,37 @@
+This test checks that executable that uses 'dynamic-run'
+and depends on directory listing forces all targets in that
+directory to be build.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ mkdir some_dir
+
+  $ cat > some_dir/dune << EOF
+  > (rule
+  >  (target some_file1)
+  >  (action (with-stdout-to %{target} (echo ""))))
+  > \
+  > (rule
+  >  (target some_file2)
+  >  (action (with-stdout-to %{target} (echo ""))))
+  > \
+  > (rule
+  >  (target some_file3)
+  >  (action (with-stdout-to %{target} (echo ""))))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest
+           foo alias runtest
+  dune
+  some_file1
+  some_file2
+  some_file3

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  write_file
+    ~path:(Path.of_string "some_target")
+    ~data:"Hello from some_target!"
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/bin/foo.ml
@@ -1,4 +1,4 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
   write_file

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-target/test/run.t
@@ -1,0 +1,18 @@
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_target)
+  >  (action
+  >   (dynamic-run ./foo.exe)))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action (cat some_target)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo some_target
+  Hello from some_target!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/bin/foo.ml
@@ -1,4 +1,4 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action = write_file ~path:(Path.of_string "bar") ~data:"Hello from bar!"
 

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/bin/foo.ml
@@ -1,0 +1,5 @@
+open Dune_action_plugin
+
+let action = write_file ~path:(Path.of_string "bar") ~data:"Hello from bar!"
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/one-undeclared-target/test/run.t
@@ -1,0 +1,15 @@
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest (exit 1)
+  (cd _build/default && ./foo.exe)
+  bar is written despite not being declared as a target in dune file. To fix, add it to target list in dune file.
+  [1]

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/bin/dune
@@ -1,0 +1,2 @@
+(executables
+ (names foo))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/bin/foo.ml
@@ -1,0 +1,1 @@
+let () = print_endline "Hello from foo!"

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/ordinary-executable/test/run.t
@@ -1,0 +1,27 @@
+This test checks that dune can gracefully handle situation when user provides
+ordinary executable instead of one linked against dune-action-plugin.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./foo.exe)))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest --display short
+           foo alias runtest
+  Hello from foo!
+  File "dune", line 1, characters 0-57:
+  1 | (alias
+  2 |  (name runtest)
+  3 |  (action (dynamic-run ./foo.exe)))
+  Error: Executable 'foo.exe' declared as using dune-action-plugin (declared
+  with 'dynamic-run' tag) failed to respond to dune.
+  
+  If you don't use dynamic dependency discovery in your executable you may
+  consider changing 'dynamic-run' to 'run' in your rule definition.
+  [1]
+

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/bin/foo.ml
@@ -1,0 +1,7 @@
+open Dune_action_plugin
+
+let action =
+  read_file ~path:(Path.of_string "some_source")
+  |> stage ~f:(fun data -> write_file ~path:(Path.of_string "some_copy") ~data)
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/bin/foo.ml
@@ -1,4 +1,4 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
   read_file ~path:(Path.of_string "some_source")

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/simple-copy/test/run.t
@@ -1,0 +1,25 @@
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_source)
+  >  (action (with-stdout-to %{target} (echo "Hello there!\n"))))
+  > \
+  > (rule
+  >  (target some_copy)
+  >  (action
+  >   (dynamic-run ./foo.exe)))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action
+  >   (progn
+  >    (cat some_source)
+  >    (cat some_copy))))
+  > EOF
+
+  $ cp ../bin/foo.exe ./
+
+  $ dune runtest
+  Hello there!
+  Hello there!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names foo)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/bin/foo.ml
@@ -1,4 +1,4 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
   write_file

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/bin/foo.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/bin/foo.ml
@@ -1,0 +1,8 @@
+open Dune_action_plugin
+
+let action =
+  write_file
+    ~path:(Path.of_string "../some_file")
+    ~data:"Hello from some_file!"
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/target-in-parent-directory/test/run.t
@@ -1,0 +1,21 @@
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target some_file)
+  >  (action
+  >   (chdir some_dir
+  >    (dynamic-run ./foo.exe))))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action (cat some_file)))
+  > EOF
+
+  $ mkdir some_dir
+
+  $ cp ../bin/foo.exe ./some_dir/
+
+  $ dune runtest --display short
+           foo some_file
+  Hello from some_file!

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/bin/client.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/bin/client.ml
@@ -1,7 +1,7 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
 
 let action =
-  let open Dune_action_plugin.O in
+  let open Dune_action_plugin.V1.O in
   let switch = read_file ~path:(Path.of_string "foo_or_bar") in
   stage switch ~f:(fun file ->
       let+ data = read_file ~path:(Path.of_string file) in

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/bin/client.ml
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/bin/client.ml
@@ -1,0 +1,10 @@
+open Dune_action_plugin
+
+let action =
+  let open Dune_action_plugin.O in
+  let switch = read_file ~path:(Path.of_string "foo_or_bar") in
+  stage switch ~f:(fun file ->
+      let+ data = read_file ~path:(Path.of_string file) in
+      print_endline data)
+
+let () = run action

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/bin/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/bin/dune
@@ -1,0 +1,3 @@
+(executables
+ (names client)
+ (libraries dune._dune_action_plugin))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/dune
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/dune
@@ -1,0 +1,19 @@
+(data_only_dirs test)
+
+(alias
+ (name run_dynamic)
+ (deps
+  (package dune)
+  (source_tree test/)
+  (glob_files bin/*.exe))
+ (action
+  (chdir
+   test
+   (progn
+    (run %{bin:cram} -test run.t)
+    (diff? run.t run.t.corrected)))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias run_dynamic)))

--- a/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/test/run.t
+++ b/test/blackbox-tests/test-cases-with-libs/dune-action-plugin/two-stages-dependency-choose/test/run.t
@@ -1,0 +1,37 @@
+In this test client choose what to depend
+on based on dependency from the previous stage.
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat > dune << EOF
+  > (rule
+  >  (target bar)
+  >  (action
+  >   (progn
+  >    (echo "Building bar!\n")
+  >    (with-stdout-to %{target} (echo "Hello from bar!")))))
+  > \
+  > (rule
+  >  (target foo)
+  >  (action
+  >   (progn
+  >    (echo "SHOULD NOT BE PRINTED!\n")
+  >    (with-stdout-to %{target} (echo "Hello from foo!")))))
+  > \
+  > (rule
+  >  (target foo_or_bar)
+  >  (action (with-stdout-to %{target} (echo "bar"))))
+  > \
+  > (alias
+  >  (name runtest)
+  >  (action (dynamic-run ./client.exe)))
+  > EOF
+
+  $ cp ../bin/client.exe ./
+
+  $ dune runtest --display short
+        client alias runtest
+        client alias runtest
+  Building bar!
+        client alias runtest
+  Hello from bar!

--- a/test/blackbox-tests/test-cases/env-bins/run.t
+++ b/test/blackbox-tests/test-cases/env-bins/run.t
@@ -6,12 +6,14 @@ Basic test that we can use private binaries as public ones
   PATH:
   	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/default/using-priv/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/install/default/bin
+  	_build/default/test/blackbox-tests/.bin
   	_build/install/default/bin
   priv-renamed alias using-priv/runtest
   Executing priv as priv-renamed
   PATH:
   	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/default/using-priv/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/private-bin-import/_build/install/default/bin
+  	_build/default/test/blackbox-tests/.bin
   	_build/install/default/bin
 
 Override public binary in env
@@ -31,6 +33,7 @@ Nest env binaries
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/default/using-priv/nested/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/default/using-priv/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/install/default/bin
+  	_build/default/test/blackbox-tests/.bin
   	_build/install/default/bin
   priv-renamed alias using-priv/nested/runtest
   Executing priv as priv-renamed
@@ -38,6 +41,7 @@ Nest env binaries
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/default/using-priv/nested/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/default/using-priv/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/install/default/bin
+  	_build/default/test/blackbox-tests/.bin
   	_build/install/default/bin
   priv-renamed-nested alias using-priv/nested/runtest
   Executing priv as priv-renamed-nested
@@ -45,4 +49,5 @@ Nest env binaries
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/default/using-priv/nested/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/default/using-priv/.bin
   	_build/default/test/blackbox-tests/test-cases/env-bins/nested-env/_build/install/default/bin
+  	_build/default/test/blackbox-tests/.bin
   	_build/install/default/bin

--- a/test/blackbox-tests/test-cases/shadow-bindings/run.t
+++ b/test/blackbox-tests/test-cases/shadow-bindings/run.t
@@ -1,5 +1,5 @@
 Bindings introduced by user dependencies should shadow existing bindings
 
   $ dune runtest
-  xb
   foo
+  xb

--- a/test/expect-tests/dune_action_plugin/dune
+++ b/test/expect-tests/dune_action_plugin/dune
@@ -1,0 +1,10 @@
+(data_only_dirs foo_dir)
+
+(library
+ (name dune_action_unit_tests)
+ (inline_tests
+  (deps some_dir/some_file))
+ (libraries dune_action_plugin ppx_expect.config ppx_expect.common base
+   ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))

--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -1,4 +1,6 @@
-open Dune_action_plugin
+open Dune_action_plugin.V1
+
+module Private = Dune_action_plugin.Private
 
 let%expect_test _ =
   try ignore @@ Path.of_string "/some/absolute/path"

--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -1,0 +1,74 @@
+open Dune_action_plugin
+
+let%expect_test _ =
+  try ignore @@ Path.of_string "/some/absolute/path"
+  with Invalid_argument message ->
+    print_endline message;
+    [%expect
+      {| Path "/some/absolute/path" is absolute. All paths used with dune-action-plugin must be relative. |}]
+
+let%expect_test _ =
+  let action =
+    read_file ~path:(Path.of_string "some_dir/some_file")
+    |> map ~f:print_endline
+  in
+  Private.do_run action;
+  [%expect {|
+    Hello from foo!
+  |}]
+
+let%expect_test _ =
+  let action =
+    read_directory ~path:(Path.of_string "some_dir")
+    |> map ~f:(fun data -> String.concat "," data |> print_endline)
+  in
+  Private.do_run action;
+  [%expect {|
+    some_file
+  |}]
+
+let%expect_test _ =
+  let action =
+    write_file ~path:(Path.of_string "another_file") ~data:"Hello world!"
+  in
+  Private.do_run action;
+  [%expect {| |}]
+
+let run_action_expect_throws action =
+  try
+    Private.do_run action;
+    print_endline "SHOULD BE UNREACHABLE"
+  with Private.Execution_error.E message -> print_endline message
+
+let%expect_test _ =
+  let action =
+    read_file ~path:(Path.of_string "file_that_does_not_exist")
+    |> map ~f:ignore
+  in
+  run_action_expect_throws action;
+  [%expect
+    {|
+    read_file: file_that_does_not_exist: No such file or directory
+  |}]
+
+let%expect_test _ =
+  let action =
+    read_directory ~path:(Path.of_string "directory_that_does_not_exist")
+    |> map ~f:ignore
+  in
+  run_action_expect_throws action;
+  [%expect {|
+    read_directory: No such file or directory
+  |}]
+
+let%expect_test _ =
+  let action =
+    write_file
+      ~path:(Path.of_string "directory_that_does_not_exist/some_file")
+      ~data:"foo"
+  in
+  run_action_expect_throws action;
+  [%expect
+    {|
+    write_file: directory_that_does_not_exist/some_file: No such file or directory
+  |}]

--- a/test/expect-tests/dune_action_plugin/some_dir/some_file
+++ b/test/expect-tests/dune_action_plugin/some_dir/some_file
@@ -1,0 +1,1 @@
+Hello from foo!


### PR DESCRIPTION
This pull request adds `dune-action-plugin` library.

#### What it does

This change makes possible to describe dependencies directly in source code of executable and to express dependencies that are selected based on content of previous dependencies.

To use this feature in an executable, user needs to link it against `dune-action-plugin` library and use provided API to describe dependencies. Then the executable can be used as a part of build process by declaring it as a part of the rule action.

#### API
User-facing API can be found in `src/dune_action_plugin/dune_action_plugin.mli`.

#### Examples
Examples of use can be found in `src/dune_action_plugin/examples` directory.

#### Testing
Tests can be found in `test/blackbox-tests/test-cases-with-libs/dune-action-plugin` and in `test/expect-tests/dune_action_plugin`.

#### What changes inside dune
* New available construction in action definition: `dynamic-run`. 
This is similar to current `run` but tells dune, that the executable is using `dune-action-plugin`.
* New variant in `Action.t` type: `Dynamic_run` and some changes in `Action_exec` module to handle the `Dynamic_run` and communication with client executable.
* `Trace_db` in `build_system.ml` that is used to track when rule need to be rerun now stores more data to handle `Dynamic_run`.
 
Due to problem with package dependencies, this library will remain as a private dune package. After the `dune.configurator` split is done, this can be exposed as a public package.

