### PR TITLE
[WIP] Introduce Memo.Ref

### DIFF
--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -171,6 +171,16 @@ val registered_functions : unit -> Function_info.t list
 (** Lookup function's info *)
 val function_info : string -> Function_info.t
 
+module Ref : sig
+  type 'a t
+
+  val create : 'a -> 'a t
+
+  val set : 'a t -> 'a -> unit
+
+  val get : 'a t -> 'a
+end
+
 module Lazy : sig
   type +'a t
 


### PR DESCRIPTION
This PR implements a reference cell that is memoization aware. The
intent is to make subsequent calls to get respect memoization (unless
the cell was modified).

Me and @diml agreed that implementing variables with the lifetime of a single build would be useful, so I tried implementing this variable. However, I'm not confident that I'm going about this the right way. I implemented a simpler type of variable that I think is going to be useful to build build-run variables: a plain old reference cell that can be safely used with memoization. I recall discussing such a feature with @aalekseyev, so I figured it would be useful regardless.

In particular, I'm not really liking this extra `time` field and the overhead by creating a memoization function for every single variable seems considerable.