### PR TITLE
[memo] Add ~lifetime argument to Memo.create

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -161,6 +161,8 @@ module Run : sig
   (** Represent a run of the system *)
   type t
 
+  val to_dyn : t -> Dyn.t
+
   (** Return the current run *)
   val current : unit -> t
 
@@ -171,6 +173,8 @@ module Run : sig
   val restart : unit -> unit
 end = struct
   type t = bool ref
+
+  let to_dyn _ = Dyn.opaque
 
   let current = ref (ref true)
 
@@ -780,6 +784,16 @@ end
 module Async = struct
   type nonrec ('i, 'o) t = ('i, 'o, 'i -> 'o Fiber.t) t
 end
+
+let current_run =
+  let f () = Run.current () in
+  let memo =
+    create "current-run" ~doc:"current run"
+      ~input:(module Unit)
+      ~output:(Simple (module Run))
+      ~visibility:Hidden Sync f
+  in
+  fun () -> exec memo ()
 
 module Lazy_id = Stdune.Id.Make ()
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -158,6 +158,14 @@ val get_call_stack : unit -> Stack_frame.t list
 (** Call a memoized function by name *)
 val call : string -> Dune_lang.Ast.t -> Dyn.t Fiber.t
 
+module Run : sig
+  (** A single build run *)
+  type t
+end
+
+(** Introduces a dependency on the current build run *)
+val current_run : unit -> Run.t
+
 module Function_info : sig
   type t =
     { name : string


### PR DESCRIPTION
This argument can be used to create values that automatically expire at
the end of every run.

@diml @aalekseyev second attempt.