### PR TITLE
[WIP] Merge dune-manager into dune

### DIFF
--- a/bin/cache_daemon.ml
+++ b/bin/cache_daemon.ml
@@ -1,5 +1,23 @@
 open Stdune
-open Dune_manager.Utils
+open Import
+
+let doc = "Manage the shared artifacts cache"
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P
+      {|Dune allows to share build artifacts between workspaces.
+        $(b,dune cache-daemon) is a daemon that runs in the background
+        and manages this shared cache. For instance, it makes sure that it
+        does not grow too big and try to maximise sharing between the various
+        workspace that are using the shared cache.|}
+  ; `P
+      {|The daemon is automatically started by Dune when the shared cache is
+        enabled. You do not need to run this command manually.|}
+  ; `Blocks Common.help_secs
+  ]
+
+let info = Term.info "cache-daemon" ~doc ~man
 
 let path_option name var help =
   ( Printf.sprintf "--%s" name
@@ -115,18 +133,4 @@ let main () =
            (Printf.sprintf "unknown mode \"%s\".\nUsage: %s %s" Sys.argv.(1)
               Sys.argv.(0) help))
 
-let () =
-  try main () with
-  | Arg.Bad reason ->
-    Printf.fprintf stderr "%s: command line error: %s\n%!" Sys.argv.(0) reason;
-    exit 1
-  | User_error.E msg ->
-    Printf.fprintf stderr "%s: user error: %s\n" Sys.argv.(0)
-      (Format.asprintf "%a@?" Pp.render_ignore_tags (User_message.pp msg));
-    exit 2
-  | Failure reason ->
-    Printf.fprintf stderr "%s: fatal error: %s\n%!" Sys.argv.(0) reason;
-    exit 3
-  | Arg.Help help ->
-    Printf.fprintf stdout "Usage: %s %s\n%!" Sys.argv.(0) help;
-    exit 0
+let command = (term, info)

--- a/bin/cache_daemon.mli
+++ b/bin/cache_daemon.mli
@@ -1,0 +1,1 @@
+val command : unit Cmdliner.Term.t * Cmdliner.Term.info

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -152,6 +152,7 @@ let all =
   ; Format_dune_file.command
   ; Compute.command
   ; Upgrade.command
+  ; Cache_daemon.command
   ]
 
 let default =

--- a/src/dune_manager/dune
+++ b/src/dune_manager/dune
@@ -3,11 +3,3 @@
  (modules utils dune_manager)
  (preprocess future_syntax)
  (libraries threads.posix dune_memory stdune))
-
-(executable
- (name main)
- (package dune)
- (modules main)
- (public_name dune-manager)
- (preprocess future_syntax)
- (libraries dune_manager dune_memory stdune threads.posix))


### PR DESCRIPTION
The dune manager code is not that big, so to simplify things we are just going to expose it as a `dune cache-daemon` sub-command.

TODO:
- [ ] finish porting the cli to cmdliner
- [ ] `s/dune-manager/dune cache-daemon/`