### PR TITLE
Introduce Lib_info.Shared.t

### DIFF
--- a/src/dune/dir_contents.ml
+++ b/src/dune/dir_contents.ml
@@ -229,7 +229,8 @@ end = struct
         | Library lib ->
           let src_dir = d.ctx_dir in
           let kind, main_module_name, wrapped =
-            match lib.implements with
+            let implements = Lib_info.Shared.implements lib.shared in
+            match implements with
             | None ->
               (* In the two following pattern matching, we can only get [From
                  _] if [lib] is an implementation. Since we know that it is not
@@ -292,7 +293,8 @@ end = struct
                    lib.private_modules)
           in
           let stdlib = lib.stdlib in
-          let implements = Option.is_some lib.implements in
+          let implements = Lib_info.Shared.implements lib.shared in
+          let implements = Option.is_some implements in
           let _loc, lib_name = lib.name in
           Left
             ( lib

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1109,11 +1109,10 @@ module Library = struct
     let dune_version = Some conf.dune_version in
     let wrapped = Some conf.wrapped in
     let shared = conf.shared in
-    Lib_info.create_with_shared ~loc ~name ~shared ~status ~src_dir
-      ~orig_src_dir ~obj_dir ~version ~main_module_name ~sub_systems ~requires
-      ~foreign_objects ~plugins ~archives ~foreign_archives ~jsoo_runtime
-      ~jsoo_archive ~pps ~enabled ~dune_version ~virtual_
-      ~known_implementations ~modes ~wrapped
+    Lib_info.create ~loc ~name ~shared ~status ~src_dir ~orig_src_dir ~obj_dir
+      ~version ~main_module_name ~sub_systems ~requires ~foreign_objects
+      ~plugins ~archives ~foreign_archives ~jsoo_runtime ~jsoo_archive ~pps
+      ~enabled ~dune_version ~virtual_ ~known_implementations ~modes ~wrapped
 end
 
 module Install_conf = struct

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -831,7 +831,7 @@ module Library = struct
            ( Dune_lang.Syntax.since Ocaml_stdlib.syntax (0, 1)
            >>> Ocaml_stdlib.decode )
        and+ enabled_if = enabled_if ~since:(Some (1, 10))
-       and+ shared = Lib_info.Shared.fields in
+       and+ shared = Lib_info.Shared.fields ~dune_file:true in
        let implements = Lib_info.Shared.implements shared in
        let special_builtin_support =
          Lib_info.Shared.special_builtin_support shared

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -190,15 +190,11 @@ module Library : sig
   type t =
     { name : Loc.t * Lib_name.Local.t
     ; public : Public_lib.t option
-    ; synopsis : string option
     ; install_c_headers : string list
-    ; ppx_runtime_libraries : (Loc.t * Lib_name.t) list
     ; modes : Mode_conf.Set.t
-    ; kind : Lib_kind.t
     ; library_flags : Ordered_set_lang.Unexpanded.t
     ; c_library_flags : Ordered_set_lang.Unexpanded.t
     ; self_build_stubs_archive : string option
-    ; virtual_deps : (Loc.t * Lib_name.t) list
     ; wrapped : Wrapped.t Lib_info.Inherited.t
     ; optional : bool
     ; buildable : Buildable.t
@@ -208,13 +204,10 @@ module Library : sig
     ; no_keep_locs : bool
     ; dune_version : Dune_lang.Syntax.Version.t
     ; virtual_modules : Ordered_set_lang.t option
-    ; implements : (Loc.t * Lib_name.t) option
-    ; variant : Variant.t option
-    ; default_implementation : (Loc.t * Lib_name.t) option
     ; private_modules : Ordered_set_lang.t option
     ; stdlib : Ocaml_stdlib.t option
-    ; special_builtin_support : Lib_info.Special_builtin_support.t option
     ; enabled_if : Blang.t
+    ; shared : Lib_info.Shared.t
     }
 
   val has_stubs : t -> bool

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -168,10 +168,10 @@ module Lib = struct
            Option.map modules ~f:Modules.wrapped
            |> Option.map ~f:(fun w -> Lib_info.Inherited.This w)
          in
-         Lib_info.create_with_shared ~loc ~name ~shared ~status ~src_dir
-           ~orig_src_dir ~obj_dir ~version ~main_module_name ~sub_systems
-           ~requires ~foreign_objects ~plugins ~archives ~foreign_archives
-           ~jsoo_runtime ~jsoo_archive ~pps ~enabled ~dune_version ~virtual_
+         Lib_info.create ~loc ~name ~shared ~status ~src_dir ~orig_src_dir
+           ~obj_dir ~version ~main_module_name ~sub_systems ~requires
+           ~foreign_objects ~plugins ~archives ~foreign_archives ~jsoo_runtime
+           ~jsoo_archive ~pps ~enabled ~dune_version ~virtual_
            ~known_implementations ~modes ~wrapped
        in
        { info; main_module_name; modules })

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -245,28 +245,16 @@ module Package = struct
     in
     let info : Path.t Lib_info.t =
       let name = name t in
-      let kind = Lib_kind.Normal in
       let sub_systems = Sub_system_name.Map.empty in
-      let synopsis = description t in
       let status = Lib_info.Status.Installed in
       let src_dir = Obj_dir.dir obj_dir in
       let version = version t in
       let dune_version = None in
-      let virtual_deps = [] in
-      let implements = None in
       let orig_src_dir = None in
       let main_module_name : Lib_info.Main_module_name.t = This None in
       let enabled = Lib_info.Enabled_status.Normal in
       let requires =
         requires t |> List.map ~f:(fun name -> Lib_dep.direct (add_loc name))
-      in
-      let ppx_runtime_deps = List.map ~f:add_loc (ppx_runtime_deps t) in
-      let special_builtin_support : Lib_info.Special_builtin_support.t option =
-        (* findlib has been around for much longer than dune, so it is
-           acceptable to have a special case in dune for findlib. *)
-        match Lib_name.to_string t.name with
-        | "findlib.dynload" -> Some Findlib_dynload
-        | _ -> None
       in
       let foreign_objects = Lib_info.Source.External [] in
       let plugins = plugins t in
@@ -275,16 +263,32 @@ module Package = struct
       let jsoo_archive = None in
       let pps = [] in
       let virtual_ = None in
-      let variant = None in
       let known_implementations = P.Map.empty in
-      let default_implementation = None in
       let wrapped = None in
-      Lib_info.create ~loc ~name ~kind ~status ~src_dir ~orig_src_dir ~obj_dir
-        ~version ~synopsis ~main_module_name ~sub_systems ~requires
-        ~foreign_objects ~plugins ~archives ~ppx_runtime_deps ~foreign_archives
-        ~jsoo_runtime ~jsoo_archive ~pps ~enabled ~virtual_deps ~dune_version
-        ~virtual_ ~implements ~variant ~known_implementations
-        ~default_implementation ~modes ~wrapped ~special_builtin_support
+      let shared =
+        let special_builtin_support : Lib_info.Special_builtin_support.t option
+            =
+          (* findlib has been around for much longer than dune, so it is
+             acceptable to have a special case in dune for findlib. *)
+          match Lib_name.to_string t.name with
+          | "findlib.dynload" -> Some Findlib_dynload
+          | _ -> None
+        in
+        let synopsis = description t in
+        let implements = None in
+        let kind = Lib_kind.Normal in
+        let default_implementation = None in
+        let variant = None in
+        let ppx_runtime_deps = List.map ~f:add_loc (ppx_runtime_deps t) in
+        let virtual_deps = [] in
+        Lib_info.Shared.create ~kind ~variant ~default_implementation ~synopsis
+          ~special_builtin_support ~ppx_runtime_deps ~implements ~virtual_deps
+      in
+      Lib_info.create ~loc ~name ~shared ~status ~src_dir ~orig_src_dir
+        ~obj_dir ~version ~main_module_name ~sub_systems ~requires
+        ~foreign_objects ~plugins ~archives ~foreign_archives ~jsoo_runtime
+        ~jsoo_archive ~pps ~enabled ~dune_version ~virtual_
+        ~known_implementations ~modes ~wrapped
     in
     Dune_package.Lib.make ~info ~modules:None ~main_module_name:None
 

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -27,7 +27,8 @@ module Stanzas_to_entries : sig
     Super_context.t -> (Loc.t option * Install.Entry.t) list Package.Name.Map.t
 end = struct
   let lib_ppxs sctx ~scope ~(lib : Dune_file.Library.t) =
-    match lib.kind with
+    let kind = Lib_info.Shared.kind lib.shared in
+    match kind with
     | Normal
      |Ppx_deriver _ ->
       []

--- a/src/dune/lib_info.ml
+++ b/src/dune/lib_info.ml
@@ -131,6 +131,18 @@ module Shared = struct
     ; ppx_runtime_deps : (Loc.t * Lib_name.t) list
     }
 
+  let create ~synopsis ~kind ~variant ~default_implementation
+      ~special_builtin_support ~implements ~virtual_deps ~ppx_runtime_deps =
+    { synopsis
+    ; kind
+    ; variant
+    ; default_implementation
+    ; special_builtin_support
+    ; implements
+    ; virtual_deps
+    ; ppx_runtime_deps
+    }
+
   let fields ~dune_file =
     let open Dune_lang.Decoder in
     let variant =
@@ -319,53 +331,10 @@ let user_written_deps t =
   List.fold_left (t.shared.virtual_deps @ t.shared.ppx_runtime_deps)
     ~init:t.requires ~f:(fun acc s -> Lib_dep.Direct s :: acc)
 
-let create_with_shared ~loc ~name ~shared ~status ~src_dir ~orig_src_dir
-    ~obj_dir ~version ~main_module_name ~sub_systems ~requires ~foreign_objects
-    ~plugins ~archives ~foreign_archives ~jsoo_runtime ~jsoo_archive ~pps
-    ~enabled ~dune_version ~virtual_ ~known_implementations ~modes ~wrapped =
-  { loc
-  ; name
-  ; status
-  ; shared
-  ; src_dir
-  ; orig_src_dir
-  ; obj_dir
-  ; version
-  ; requires
-  ; main_module_name
-  ; foreign_objects
-  ; plugins
-  ; archives
-  ; foreign_archives
-  ; jsoo_runtime
-  ; jsoo_archive
-  ; pps
-  ; known_implementations
-  ; enabled
-  ; dune_version
-  ; sub_systems
-  ; virtual_
-  ; modes
-  ; wrapped
-  }
-
-let create ~loc ~name ~kind ~status ~src_dir ~orig_src_dir ~obj_dir ~version
-    ~synopsis ~main_module_name ~sub_systems ~requires ~foreign_objects
-    ~plugins ~archives ~ppx_runtime_deps ~foreign_archives ~jsoo_runtime
-    ~jsoo_archive ~pps ~enabled ~virtual_deps ~dune_version ~virtual_
-    ~implements ~variant ~known_implementations ~default_implementation ~modes
-    ~wrapped ~special_builtin_support =
-  let shared =
-    { Shared.kind
-    ; synopsis
-    ; default_implementation
-    ; special_builtin_support
-    ; ppx_runtime_deps
-    ; virtual_deps
-    ; variant
-    ; implements
-    }
-  in
+let create ~loc ~name ~shared ~status ~src_dir ~orig_src_dir ~obj_dir ~version
+    ~main_module_name ~sub_systems ~requires ~foreign_objects ~plugins
+    ~archives ~foreign_archives ~jsoo_runtime ~jsoo_archive ~pps ~enabled
+    ~dune_version ~virtual_ ~known_implementations ~modes ~wrapped =
   { loc
   ; name
   ; status

--- a/src/dune/lib_info.mli
+++ b/src/dune/lib_info.mli
@@ -66,13 +66,24 @@ end
 module Shared : sig
   type t
 
+  val create :
+       synopsis:string option
+    -> kind:Lib_kind.t
+    -> variant:(Loc.t * Variant.t) option
+    -> default_implementation:(Loc.t * Lib_name.t) option
+    -> special_builtin_support:Special_builtin_support.t option
+    -> implements:(Loc.t * Lib_name.t) option
+    -> virtual_deps:(Loc.t * Lib_name.t) list
+    -> ppx_runtime_deps:(Loc.t * Lib_name.t) list
+    -> t
+
   val fields : dune_file:bool -> t Dune_lang.Decoder.fields_parser
 
-  val implements : t -> (Stdune.Loc.t * Lib_name.t) option
+  val implements : t -> (Loc.t * Lib_name.t) option
 
-  val variant : t -> (Stdune.Loc.t * Variant.t) option
+  val variant : t -> (Loc.t * Variant.t) option
 
-  val default_implementation : t -> (Stdune.Loc.t * Lib_name.t) option
+  val default_implementation : t -> (Loc.t * Lib_name.t) option
 
   val special_builtin_support : t -> Special_builtin_support.t option
 
@@ -99,7 +110,7 @@ val src_dir : 'path t -> 'path
 
 val status : _ t -> Status.t
 
-val variant : 'a t -> (Stdune.Loc.t * Variant.t) option
+val variant : 'a t -> (Loc.t * Variant.t) option
 
 val default_implementation : _ t -> (Loc.t * Lib_name.t) option
 
@@ -171,40 +182,6 @@ val for_dune_package :
 val map_path : 'a t -> f:('a -> 'a) -> 'a t
 
 val create :
-     loc:Loc.t
-  -> name:Lib_name.t
-  -> kind:Lib_kind.t
-  -> status:Status.t
-  -> src_dir:'a
-  -> orig_src_dir:'a option
-  -> obj_dir:'a Obj_dir.t
-  -> version:string option
-  -> synopsis:string option
-  -> main_module_name:Main_module_name.t
-  -> sub_systems:Sub_system_info.t Sub_system_name.Map.t
-  -> requires:Lib_dep.t list
-  -> foreign_objects:'a list Source.t
-  -> plugins:'a list Mode.Dict.t
-  -> archives:'a list Mode.Dict.t
-  -> ppx_runtime_deps:(Loc.t * Lib_name.t) list
-  -> foreign_archives:'a list Mode.Dict.t
-  -> jsoo_runtime:'a list
-  -> jsoo_archive:'a option
-  -> pps:(Loc.t * Lib_name.t) list
-  -> enabled:Enabled_status.t
-  -> virtual_deps:(Loc.t * Lib_name.t) list
-  -> dune_version:Dune_lang.Syntax.Version.t option
-  -> virtual_:Modules.t Source.t option
-  -> implements:(Loc.t * Lib_name.t) option
-  -> variant:(Loc.t * Variant.t) option
-  -> known_implementations:(Loc.t * Lib_name.t) Variant.Map.t
-  -> default_implementation:(Loc.t * Lib_name.t) option
-  -> modes:Mode.Dict.Set.t
-  -> wrapped:Wrapped.t Inherited.t option
-  -> special_builtin_support:Special_builtin_support.t option
-  -> 'a t
-
-val create_with_shared :
      loc:Loc.t
   -> name:Lib_name.t
   -> shared:Shared.t

--- a/src/dune/lib_info.mli
+++ b/src/dune/lib_info.mli
@@ -63,7 +63,25 @@ module Main_module_name : sig
   type t = Module_name.t option Inherited.t
 end
 
+module Shared : sig
+  type t
+
+  val fields : dune_file:bool -> t Dune_lang.Decoder.fields_parser
+
+  val implements : t -> (Stdune.Loc.t * Lib_name.t) option
+
+  val variant : t -> (Stdune.Loc.t * Variant.t) option
+
+  val default_implementation : t -> (Stdune.Loc.t * Lib_name.t) option
+
+  val special_builtin_support : t -> Special_builtin_support.t option
+
+  val kind : t -> Lib_kind.t
+end
+
 type 'path t
+
+val shared : _ t -> Shared.t
 
 val name : _ t -> Lib_name.t
 
@@ -81,7 +99,7 @@ val src_dir : 'path t -> 'path
 
 val status : _ t -> Status.t
 
-val variant : _ t -> Variant.t option
+val variant : 'a t -> (Stdune.Loc.t * Variant.t) option
 
 val default_implementation : _ t -> (Loc.t * Lib_name.t) option
 
@@ -178,10 +196,37 @@ val create :
   -> dune_version:Dune_lang.Syntax.Version.t option
   -> virtual_:Modules.t Source.t option
   -> implements:(Loc.t * Lib_name.t) option
-  -> variant:Variant.t option
+  -> variant:(Loc.t * Variant.t) option
   -> known_implementations:(Loc.t * Lib_name.t) Variant.Map.t
   -> default_implementation:(Loc.t * Lib_name.t) option
   -> modes:Mode.Dict.Set.t
   -> wrapped:Wrapped.t Inherited.t option
   -> special_builtin_support:Special_builtin_support.t option
+  -> 'a t
+
+val create_with_shared :
+     loc:Loc.t
+  -> name:Lib_name.t
+  -> shared:Shared.t
+  -> status:Status.t
+  -> src_dir:'a
+  -> orig_src_dir:'a option
+  -> obj_dir:'a Obj_dir.t
+  -> version:string option
+  -> main_module_name:Main_module_name.t
+  -> sub_systems:Sub_system_info.t Sub_system_name.Map.t
+  -> requires:Lib_dep.t list
+  -> foreign_objects:'a list Source.t
+  -> plugins:'a list Mode.Dict.t
+  -> archives:'a list Mode.Dict.t
+  -> foreign_archives:'a list Mode.Dict.t
+  -> jsoo_runtime:'a list
+  -> jsoo_archive:'a option
+  -> pps:(Loc.t * Lib_name.t) list
+  -> enabled:Enabled_status.t
+  -> dune_version:Dune_lang.Syntax.Version.t option
+  -> virtual_:Modules.t Source.t option
+  -> known_implementations:(Loc.t * Lib_name.t) Variant.Map.t
+  -> modes:Mode.Dict.Set.t
+  -> wrapped:Wrapped.t Inherited.t option
   -> 'a t

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -63,11 +63,12 @@ let build_lib (lib : Library.t) ~sctx ~expander ~flags ~dir ~mode ~cm_files =
                        Command.quote_args "-cclib" (map_cclibs x)))
               ; Command.Args.dyn library_flags
               ; As
-                  ( match lib.kind with
-                  | Normal -> []
-                  | Ppx_deriver _
-                   |Ppx_rewriter _ ->
-                    [ "-linkall" ] )
+                  (let kind = Lib_info.Shared.kind lib.shared in
+                   match kind with
+                   | Normal -> []
+                   | Ppx_deriver _
+                    |Ppx_rewriter _ ->
+                     [ "-linkall" ])
               ; Dyn
                   ( Cm_files.top_sorted_cms cm_files ~mode
                   |> Build.map ~f:(fun x -> Command.Args.Deps x) )

--- a/src/dune/variant.ml
+++ b/src/dune/variant.ml
@@ -25,3 +25,12 @@ let plugin = make "plugin"
 let encode t = Dune_lang.atom_or_quoted_string (to_string t)
 
 let decode = Dune_lang.Decoder.plain_string (fun ~loc:_ s -> make s)
+
+let syntax =
+  let syntax =
+    Dune_lang.Syntax.create ~name:"library_variants"
+      ~desc:"the experimental library variants feature." [ (0, 2) ]
+  in
+  Dune_project.Extension.register_simple ~experimental:true syntax
+    (Dune_lang.Decoder.return []);
+  syntax

--- a/src/dune/variant.mli
+++ b/src/dune/variant.mli
@@ -23,3 +23,5 @@ val plugin : t
 val encode : t Dune_lang.Encoder.t
 
 val decode : t Dune_lang.Decoder.t
+
+val syntax : Dune_lang.Syntax.t

--- a/src/dune/virtual_rules.ml
+++ b/src/dune/virtual_rules.ml
@@ -74,7 +74,8 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
   Modules.iter_no_vlib vlib_modules ~f:(fun m -> copy_objs m)
 
 let impl sctx ~(lib : Dune_file.Library.t) ~scope =
-  Option.map lib.implements ~f:(fun (loc, implements) ->
+  let implements = Lib_info.Shared.implements lib.shared in
+  Option.map implements ~f:(fun (loc, implements) ->
       match Lib.DB.find (Scope.libs scope) implements with
       | None ->
         User_error.raise ~loc


### PR DESCRIPTION
This record contains the information that is shared between Lib_info and
Dune_file.Library.t. This simplifies the conversion requires when
constructing Lib_info.t from Dune_file.Library.t

