### PR TITLE
Make File_tree.t global

### DIFF
--- a/bench/dune_bench/file_tree_cache.ml
+++ b/bench/dune_bench/file_tree_cache.ml
@@ -11,14 +11,14 @@ let setup =
      Path.External.mkdir_p (Path.External.relative tmp deep_path);
      Path.set_root tmp;
      Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");
-     let ft = (Dune_load.load ~ancestor_vcs:None ()).file_tree in
+     let _conf = Dune_load.load ~ancestor_vcs:None () in
      let path = Path.Source.of_string deep_path in
      at_exit (fun () -> Sys.remove "./dune-project");
-     (ft, path))
+     path)
 
 let%bench_fun "File_tree.find_dir" =
-  let ft, path = Lazy.force setup in
+  let path = Lazy.force setup in
   fun () ->
     ignore
-      ( Sys.opaque_identity (File_tree.find_dir ft path)
+      ( Sys.opaque_identity (File_tree.find_dir path)
         : File_tree.Dir.t option )

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -74,7 +74,7 @@ let term =
       match Lazy.force targets with
       | [] -> ()
       | targets ->
-        Scheduler.go ~common (fun () -> do_build setup targets);
+        Scheduler.go ~common (fun () -> do_build targets);
         Hooks.End_of_build.run () );
     match prog_where with
     | `Search prog ->

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -135,7 +135,7 @@ let term =
         let open Fiber.O in
         let* setup = Import.Main.setup common ~external_lib_deps_mode:true in
         let targets = Target.resolve_targets_exn common setup targets in
-        let request = Target.request setup targets in
+        let request = Target.request targets in
         let+ deps = Build_system.all_lib_deps ~request in
         (setup, deps))
   in

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -90,5 +90,4 @@ let restore_cwd_and_execve (common : Common.t) prog argv env =
   in
   Proc.restore_cwd_and_execve prog argv ~env
 
-let do_build (setup : Main.build_system) targets =
-  Build_system.do_build ~request:(Target.request setup targets)
+let do_build targets = Build_system.do_build ~request:(Target.request targets)

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -80,7 +80,7 @@ end
 module File_ops_real (W : Workspace) : File_operations = struct
   open W
 
-  let get_vcs p = Dune.File_tree.nearest_vcs workspace.conf.file_tree p
+  let get_vcs p = Dune.File_tree.nearest_vcs p
 
   type 'a load_special_file_result =
     | No_version_needed

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -5,7 +5,7 @@ let run_build_command ~common ~targets =
   let once () =
     let open Fiber.O in
     let* setup = Main.setup common in
-    do_build setup (targets setup)
+    do_build (targets setup)
   in
   if Common.watch common then
     let once () =

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -123,8 +123,7 @@ let term =
           |> Path.Build.Set.fold ~init:[] ~f:(fun p acc -> Path.build p :: acc)
           |> Build.paths
         | _ ->
-          Target.resolve_targets_exn common setup targets
-          |> Target.request setup
+          Target.resolve_targets_exn common setup targets |> Target.request
       in
       let* rules = Build_system.evaluate_rules ~request ~recursive in
       let print oc =

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -11,7 +11,7 @@ type resolve_input =
   | Path of Path.t
   | Dep of Arg.Dep.t
 
-let request (setup : Dune.Main.build_system) targets =
+let request targets =
   List.fold_left targets ~init:(Build.return ()) ~f:(fun acc target ->
       let open Build.O in
       acc
@@ -24,7 +24,7 @@ let request (setup : Dune.Main.build_system) targets =
           Build_system.Alias.dep_rec_multi_contexts
         else
           Build_system.Alias.dep_multi_contexts )
-          ~dir ~name ~file_tree:setup.workspace.conf.file_tree ~contexts)
+          ~dir ~name ~contexts)
 
 let log_targets targets =
   List.iter targets ~f:(function
@@ -61,7 +61,7 @@ let resolve_path path ~(setup : Dune.Main.build_system) =
   let checked = Util.check_path setup.workspace.contexts path in
   let can't_build path = Error (target_hint setup path) in
   let as_source_dir src =
-    if Dune.File_tree.dir_exists setup.workspace.conf.file_tree src then
+    if Dune.File_tree.dir_exists src then
       Some
         [ Alias
             (Alias.in_dir ~name:"default" ~recursive:true

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -4,7 +4,7 @@ type t =
   | File of Path.t
   | Alias of Alias.t
 
-val request : Dune.Main.build_system -> t list -> unit Dune.Build.t
+val request : t list -> unit Dune.Build.t
 
 val resolve_target :
      Common.t

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -17,9 +17,8 @@ let term =
   let+ common = Common.term in
   Common.set_common common ~targets:[];
   Scheduler.go ~common (fun () ->
-      Dune.Upgrader.upgrade
-        (Dune.File_tree.load Path.Source.root ~recognize_jbuilder_projects:true
-           ~ancestor_vcs:None)
-      |> Fiber.return)
+      Dune.File_tree.init Path.Source.root ~recognize_jbuilder_projects:true
+        ~ancestor_vcs:None;
+      Dune.Upgrader.upgrade () |> Fiber.return)
 
 let command = (term, info)

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -48,7 +48,7 @@ let term =
           | Ok [ File target ] -> target
           | Ok _ -> assert false
         in
-        let+ () = do_build setup [ File target ] in
+        let+ () = do_build [ File target ] in
         (context, Path.to_string target))
   in
   Hooks.End_of_build.run ();

--- a/src/dune/alias.ml
+++ b/src/dune/alias.ml
@@ -68,8 +68,8 @@ let fully_qualified_name t = Path.Build.relative t.dir t.name
 
 let stamp_file t = Path.Build.relative (stamp_file_dir t) (t.name ^ suffix)
 
-let find_dir_specified_on_command_line ~dir ~file_tree =
-  match File_tree.find_dir file_tree dir with
+let find_dir_specified_on_command_line ~dir =
+  match File_tree.find_dir dir with
   | None ->
     User_error.raise
       [ Pp.textf "Don't know about directory %s specified on the command line!"

--- a/src/dune/alias.mli
+++ b/src/dune/alias.mli
@@ -50,8 +50,7 @@ val fmt : dir:Path.Build.t -> t
 (** Return the underlying stamp file *)
 val stamp_file : t -> Path.Build.t
 
-val find_dir_specified_on_command_line :
-  dir:Path.Source.t -> file_tree:File_tree.t -> File_tree.Dir.t
+val find_dir_specified_on_command_line : dir:Path.Source.t -> File_tree.Dir.t
 
 val is_standard : string -> bool
 

--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -163,11 +163,11 @@ let depend_on_dir_without_files =
   in
   fun dir -> Paths_glob (File_selector.create ~dir pred) |> ignore
 
-let source_tree ~dir ~file_tree =
+let source_tree ~dir =
   let prefix_with, dir = Path.extract_build_context_dir_exn dir in
   let paths, dirs_without_files =
     let init = (Path.Set.empty, return ()) in
-    match File_tree.find_dir file_tree dir with
+    match File_tree.find_dir dir with
     | None -> init
     | Some dir ->
       File_tree.Dir.fold dir ~init ~traverse:Sub_dirs.Status.Set.all

--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -72,7 +72,7 @@ val declare_targets : Path.Build.Set.t -> unit t
 
 (** Compute the set of source of all files present in the sub-tree starting at
     [dir] and record them as dependencies. *)
-val source_tree : dir:Path.t -> file_tree:File_tree.t -> Path.Set.t t
+val source_tree : dir:Path.t -> Path.Set.t t
 
 (** Record dynamic dependencies *)
 val dyn_paths : ('a * Path.t list) t -> 'a t

--- a/src/dune/build_system.mli
+++ b/src/dune/build_system.mli
@@ -11,7 +11,6 @@ open! Import
 val init :
      contexts:Context.t list
   -> ?memory:Dune_manager.Client.t
-  -> file_tree:File_tree.t
   -> sandboxing_preference:Sandbox_mode.t list
   -> unit
 
@@ -104,22 +103,14 @@ module Alias : sig
 
   (** Implements [@@alias] on the command line *)
   val dep_multi_contexts :
-       dir:Path.Source.t
-    -> name:string
-    -> file_tree:File_tree.t
-    -> contexts:string list
-    -> unit Build.t
+    dir:Path.Source.t -> name:string -> contexts:string list -> unit Build.t
 
   (** Implements [(alias_rec ...)] in dependency specification *)
-  val dep_rec : t -> loc:Loc.t -> file_tree:File_tree.t -> unit Build.t
+  val dep_rec : t -> loc:Loc.t -> unit Build.t
 
   (** Implements [@alias] on the command line *)
   val dep_rec_multi_contexts :
-       dir:Path.Source.t
-    -> name:string
-    -> file_tree:File_tree.t
-    -> contexts:string list
-    -> unit Build.t
+    dir:Path.Source.t -> name:string -> contexts:string list -> unit Build.t
 end
 
 (** {1 Building} *)

--- a/src/dune/cinaps.ml
+++ b/src/dune/cinaps.ml
@@ -44,9 +44,7 @@ let gen_rules sctx t ~dir ~scope =
   let main_module_name = Module_name.of_string "_cinaps" in
   (* Files checked by cinaps *)
   let cinapsed_files =
-    File_tree.files_of
-      (Super_context.file_tree sctx)
-      (Path.Build.drop_build_context_exn dir)
+    File_tree.files_of (Path.Build.drop_build_context_exn dir)
     |> Path.Source.Set.to_list
     |> List.filter_map ~f:(fun p ->
            if

--- a/src/dune/dir_status.ml
+++ b/src/dune/dir_status.ml
@@ -65,8 +65,7 @@ let check_no_module_consumer stanzas =
 
 module DB = struct
   type nonrec t =
-    { file_tree : File_tree.t
-    ; stanzas_per_dir : Dune_file.Stanzas.t Dir_with_dune.t Path.Build.Map.t
+    { stanzas_per_dir : Dune_file.Stanzas.t Dir_with_dune.t Path.Build.Map.t
     ; fn : (Path.Build.t, t) Memo.Sync.t
     }
 
@@ -80,9 +79,7 @@ module DB = struct
       | Some parent_dir -> current_group parent_dir (get ~dir:parent_dir)
     in
     match
-      Option.bind
-        (Path.Build.drop_build_context dir)
-        ~f:(File_tree.find_dir db.file_tree)
+      Option.bind (Path.Build.drop_build_context dir) ~f:File_tree.find_dir
     with
     | None -> (
       match enclosing_group ~dir with
@@ -120,7 +117,7 @@ module DB = struct
                 { stanzas = Some d; group_root }
             | No_group -> Standalone (Some (ft_dir, Some d)) ) ) )
 
-  let make file_tree ~stanzas_per_dir =
+  let make ~stanzas_per_dir =
     (* CR-someday aalekseyev: This local recursive module is a bit awkward. In
        the future the plan is to move the memo to the top-level to make it less
        awkward (and to dissolve the [DB] datatype). *)
@@ -129,8 +126,7 @@ module DB = struct
         val t : t
       end = struct
         let t =
-          { file_tree
-          ; stanzas_per_dir
+          { stanzas_per_dir
           ; fn =
               Memo.create "get-dir-status"
                 ~input:(module Path.Build)

--- a/src/dune/dir_status.mli
+++ b/src/dune/dir_status.mli
@@ -26,9 +26,7 @@ module DB : sig
   type status
 
   val make :
-       File_tree.t
-    -> stanzas_per_dir:Dune_file.Stanzas.t Dir_with_dune.t Path.Build.Map.t
-    -> t
+    stanzas_per_dir:Dune_file.Stanzas.t Dir_with_dune.t Path.Build.Map.t -> t
 
   val get : t -> dir:Path.Build.t -> status
 end

--- a/src/dune/dune_load.ml
+++ b/src/dune/dune_load.ml
@@ -187,8 +187,7 @@ end
 end
 
 type conf =
-  { file_tree : File_tree.t
-  ; dune_files : Dune_files.t
+  { dune_files : Dune_files.t
   ; packages : Package.t Package.Name.Map.t
   ; projects : Dune_project.t list
   }
@@ -204,12 +203,10 @@ let interpret ~dir ~project ~(dune_file : File_tree.Dune_file.t) =
   | Ocaml_script file -> Script { dir; project; file }
 
 let load ~ancestor_vcs () =
-  let ftree =
-    File_tree.load Path.Source.root ~ancestor_vcs
-      ~recognize_jbuilder_projects:false
-  in
+  File_tree.init Path.Source.root ~ancestor_vcs
+    ~recognize_jbuilder_projects:false;
   let projects =
-    File_tree.fold ftree
+    File_tree.fold
       ~traverse:{ data_only = false; vendored = true; normal = true } ~init:[]
       ~f:(fun dir acc ->
         let p = File_tree.Dir.project dir in
@@ -254,5 +251,5 @@ let load ~ancestor_vcs () =
       in
       String.Map.fold sub_dirs ~init:dune_files ~f:walk
   in
-  let dune_files = walk (File_tree.root ftree) [] in
-  { file_tree = ftree; dune_files; packages; projects }
+  let dune_files = walk (File_tree.root ()) [] in
+  { dune_files; packages; projects }

--- a/src/dune/dune_load.mli
+++ b/src/dune/dune_load.mli
@@ -18,8 +18,7 @@ module Dune_files : sig
 end
 
 type conf = private
-  { file_tree : File_tree.t
-  ; dune_files : Dune_files.t
+  { dune_files : Dune_files.t
   ; packages : Package.t Package.Name.Map.t
   ; projects : Dune_project.t list
   }

--- a/src/dune/file_tree.mli
+++ b/src/dune/file_tree.mli
@@ -59,41 +59,41 @@ module Dir : sig
   val to_dyn : t -> Dyn.t
 end
 
-(** A [t] value represent a view of the source tree. It is lazily constructed
-    by scanning the file system and interpreting a few stanzas in [dune] files. *)
-type t
-
-val load :
+(** [set source ~ancestor_vcs ~recognize_jbuilder_projects] set the root, the
+    default VCS, and if jbuilder project will be recognized. It must be called
+    before all other calls to the file tree. All of these settings can only be
+    set once per dune process *)
+val init :
      Path.Source.t
   -> ancestor_vcs:Vcs.t option
   -> recognize_jbuilder_projects:bool
-  -> t
+  -> unit
 
 (** Passing [~traverse_data_only_dirs:true] to this functions causes the whole
     source tree to be deeply scanned, including ignored sub-trees. *)
 val fold :
-  t -> traverse:Sub_dirs.Status.Set.t -> init:'a -> f:(Dir.t -> 'a -> 'a) -> 'a
+  traverse:Sub_dirs.Status.Set.t -> init:'a -> f:(Dir.t -> 'a -> 'a) -> 'a
 
-val root : t -> Dir.t
+val root : unit -> Dir.t
 
-val find_dir : t -> Path.Source.t -> Dir.t option
+val find_dir : Path.Source.t -> Dir.t option
 
 (** [nearest_dir t fn] returns the directory with the longest path that is an
     ancestor of [fn]. *)
-val nearest_dir : t -> Path.Source.t -> Dir.t
+val nearest_dir : Path.Source.t -> Dir.t
 
 (** [nearest_vcs t fn] returns the version control system with the longest root
     path that is an ancestor of [fn]. *)
-val nearest_vcs : t -> Path.Source.t -> Vcs.t option
+val nearest_vcs : Path.Source.t -> Vcs.t option
 
-val files_of : t -> Path.Source.t -> Path.Source.Set.t
+val files_of : Path.Source.t -> Path.Source.Set.t
 
 (** [true] iff the path is a directory *)
-val dir_exists : t -> Path.Source.t -> bool
+val dir_exists : Path.Source.t -> bool
 
 (** [dir_is_vendored t path] tells whether [path] is a vendored directory.
     Returns [None] if it doesn't describe a directory within [t]. *)
-val dir_is_vendored : t -> Path.Source.t -> bool option
+val dir_is_vendored : Path.Source.t -> bool option
 
 (** [true] iff the path is a file *)
-val file_exists : t -> Path.Source.t -> bool
+val file_exists : Path.Source.t -> bool

--- a/src/dune/format_rules.ml
+++ b/src/dune/format_rules.ml
@@ -77,8 +77,7 @@ let gen_rules_output sctx (config : Format_config.t) ~dialects ~expander
         add_diff sctx loc alias_formatted ~dir ~input:(Path.build input)
           ~output:(Path.build output))
   in
-  File_tree.files_of (Super_context.file_tree sctx) source_dir
-  |> Path.Source.Set.iter ~f:setup_formatting;
+  File_tree.files_of source_dir |> Path.Source.Set.iter ~f:setup_formatting;
   Rules.Produce.Alias.add_deps alias_formatted Path.Set.empty
 
 let gen_rules ~dir =

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -187,7 +187,7 @@ let gen_rules sctx dir_contents cctxs
   in
   let allow_approx_merlin =
     let dune_project = Scope.project scope in
-    let dir_is_vendored = Super_context.dir_is_vendored sctx src_dir in
+    let dir_is_vendored = Super_context.dir_is_vendored src_dir in
     dir_is_vendored || Dune_project.allow_approx_merlin dune_project
   in
   Option.iter (Merlin.merge_all ~allow_approx_merlin merlins) ~f:(fun m ->
@@ -307,11 +307,7 @@ let gen_rules ~sctx ~dir components :
                let dst = File_binding.Expanded.dst_path t ~dir in
                Super_context.add_rule sctx ~loc ~dir (Build.symlink ~src ~dst))
       | _ -> (
-        match
-          File_tree.find_dir
-            (Super_context.file_tree sctx)
-            (Path.Build.drop_build_context_exn dir)
-        with
+        match File_tree.find_dir (Path.Build.drop_build_context_exn dir) with
         | None ->
           (* We get here when [dir] is a generated directory, such as [.utop]
              or [.foo.objs]. *)
@@ -371,7 +367,7 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
 
 let gen ~contexts ?(external_lib_deps_mode = false) ?only_packages conf =
   let open Fiber.O in
-  let { Dune_load.file_tree; dune_files; packages; projects } = conf in
+  let { Dune_load.dune_files; packages; projects } = conf in
   let packages =
     match only_packages with
     | None -> packages
@@ -402,7 +398,7 @@ let gen ~contexts ?(external_lib_deps_mode = false) ?only_packages conf =
     in
     let* host, stanzas = Fiber.fork_and_join host stanzas in
     let sctx =
-      Super_context.create ?host ~context ~projects ~file_tree ~packages
+      Super_context.create ?host ~context ~projects ~packages
         ~external_lib_deps_mode ~stanzas
     in
     let+ () = Fiber.Ivar.fill (Table.find_exn sctxs context.name) sctx in

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -162,7 +162,7 @@ end = struct
     let init =
       Super_context.packages sctx
       |> Package.Name.Map.map ~f:(fun (pkg : Package.t) ->
-             let files = Super_context.source_files sctx ~src_path:pkg.path in
+             let files = Super_context.source_files ~src_path:pkg.path in
              let pkg_dir = Path.Build.append_source ctx.build_dir pkg.path in
              let init =
                let meta_file = Package_paths.meta_file ctx pkg in

--- a/src/dune/link_time_code_gen.ml
+++ b/src/dune/link_time_code_gen.ml
@@ -92,8 +92,6 @@ let findlib_init_code ~preds ~libs =
 let build_info_code cctx ~libs ~api_version =
   ( match api_version with
   | Lib_info.Special_builtin_support.Build_info.V1 -> () );
-  let sctx = CC.super_context cctx in
-  let file_tree = Super_context.file_tree sctx in
   (* [placeholders] is a mapping from source path to variable names. For each
      binding [(p, v)], we will generate the following code:
 
@@ -107,7 +105,7 @@ let build_info_code cctx ~libs ~api_version =
       s
   in
   let placeholder p =
-    match File_tree.nearest_vcs file_tree p with
+    match File_tree.nearest_vcs p with
     | None -> "None"
     | Some vcs -> (
       let p =

--- a/src/dune/main.ml
+++ b/src/dune/main.ml
@@ -83,8 +83,7 @@ let init_build_system ?only_packages ?external_lib_deps_mode
                      ( Package.Name.Map.keys w.conf.packages
                      |> List.map ~f:Package.Name.to_string ))));
   Build_system.reset ();
-  Build_system.init ~sandboxing_preference ~contexts:w.contexts
-    ~file_tree:w.conf.file_tree ?memory;
+  Build_system.init ~sandboxing_preference ~contexts:w.contexts ?memory;
   let+ scontexts =
     Gen_rules.gen w.conf ~contexts:w.contexts ?only_packages
       ?external_lib_deps_mode

--- a/src/dune/opam_create.ml
+++ b/src/dune/opam_create.ml
@@ -138,11 +138,10 @@ let opam_fields project (package : Package.t) =
     Opam_file.Create.normalise_field_order fields
 
 let opam_template sctx ~pkg =
-  let file_tree = Super_context.file_tree sctx in
   let opam_template_path =
     Package.opam_file pkg |> Path.Source.extend_basename ~suffix:".template"
   in
-  if File_tree.file_exists file_tree opam_template_path then
+  if File_tree.file_exists opam_template_path then
     let build_dir = Super_context.build_dir sctx in
     Some (Path.Build.append_source build_dir opam_template_path)
   else

--- a/src/dune/simple_rules.ml
+++ b/src/dune/simple_rules.ml
@@ -94,8 +94,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
     |> Glob.of_string_exn (String_with_vars.loc def.glob)
     |> Glob.to_pred
   in
-  let file_tree = Super_context.file_tree sctx in
-  if not (File_tree.dir_exists file_tree src_in_src) then
+  if not (File_tree.dir_exists src_in_src) then
     User_error.raise ~loc
       [ Pp.textf "Cannot find directory: %s" (Path.Source.to_string src_in_src)
       ];

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -16,7 +16,6 @@ val create :
      context:Context.t
   -> ?host:t
   -> projects:Dune_project.t list
-  -> file_tree:File_tree.t
   -> packages:Package.t Package.Name.Map.t
   -> stanzas:Dune_load.Dune_file.t list
   -> external_lib_deps_mode:bool
@@ -29,8 +28,6 @@ val stanzas : t -> Stanzas.t Dir_with_dune.t list
 val stanzas_in : t -> dir:Path.Build.t -> Stanzas.t Dir_with_dune.t option
 
 val packages : t -> Package.t Package.Name.Map.t
-
-val file_tree : t -> File_tree.t
 
 val artifacts : t -> Artifacts.t
 
@@ -84,7 +81,7 @@ val find_scope_by_project : t -> Dune_project.t -> Scope.t
 val find_project_by_key : t -> Dune_project.File_key.t -> Dune_project.t
 
 (** Tells whether the given source directory is marked as vendored *)
-val dir_is_vendored : t -> Path.Source.t -> bool
+val dir_is_vendored : Path.Source.t -> bool
 
 val add_rule :
      t
@@ -123,7 +120,7 @@ val add_alias_action :
   -> Action.t Build.t
   -> unit
 
-val source_files : t -> src_path:Path.Source.t -> String.Set.t
+val source_files : src_path:Path.Source.t -> String.Set.t
 
 (** [prog_spec t ?hint name] resolve a program. [name] is looked up in the
     workspace, if it is not found in the tree is is looked up in the PATH. If

--- a/src/dune/upgrader.ml
+++ b/src/dune/upgrader.ml
@@ -379,10 +379,10 @@ let upgrade_dir todo dir =
           upgrade_file todo fn' sexps comments
             ~look_for_jbuild_ignore:(Path.Source.equal fn fn'))
 
-let upgrade ft =
+let upgrade () =
   Dune_project.default_dune_language_version := (1, 0);
   let todo = { to_rename_and_edit = []; to_add = []; to_edit = [] } in
-  File_tree.fold ft ~traverse:Sub_dirs.Status.Set.normal_only ~init:()
+  File_tree.fold ~traverse:Sub_dirs.Status.Set.normal_only ~init:()
     ~f:(fun dir () -> upgrade_dir todo dir);
   let log fmt = Printf.ksprintf Console.print fmt in
   List.iter todo.to_edit ~f:(fun (fn, s) ->

--- a/src/dune/upgrader.mli
+++ b/src/dune/upgrader.mli
@@ -1,4 +1,4 @@
 (** Upgrade projects from jbuilder to Dune *)
 
 (** Upgrade all projects in this file tree *)
-val upgrade : File_tree.t -> unit
+val upgrade : unit -> unit

--- a/src/dune/utop.ml
+++ b/src/dune/utop.ml
@@ -24,7 +24,7 @@ let is_utop_dir dir = Path.Build.basename dir = utop_dir_basename
 let libs_under_dir sctx ~db ~dir =
   (let open Option.O in
   let* dir = Path.drop_build_context dir in
-  let+ dir = File_tree.find_dir (Super_context.file_tree sctx) dir in
+  let+ dir = File_tree.find_dir dir in
   File_tree.Dir.fold dir ~traverse:Sub_dirs.Status.Set.all ~init:[]
     ~f:(fun dir acc ->
       let dir =


### PR DESCRIPTION
The File_tree is now global and there's no need to pass it around
everywhere. The file_tree is reset once per run because it depends on
Memo.current_run.

This is mostly about changing about the API to File_tree. Proper memoziation can now be added without disturbing the callers. @diml is this the interface you had inn mind?