### PR TITLE
Generate the list of libraries for the bootstrap

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -4,7 +4,8 @@
  (package dune)
  (libraries memo dune_lang fiber stdune unix dune_manager dune cmdliner
    threads.posix build_info)
- (preprocess future_syntax))
+ (preprocess future_syntax)
+ (bootstrap_info bootstrap-info))
 
 (deprecated_library_name
  (old_public_name dune.configurator)

--- a/boot/dune
+++ b/boot/dune
@@ -1,0 +1,7 @@
+(rule
+ (mode promote)
+ (action (copy ../bin/bootstrap-info libs.ml)))
+
+(alias
+ (name runtest)
+ (deps libs.ml))

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -1,0 +1,23 @@
+let external_libraries = [ "unix"; "threads.posix" ]
+
+let local_libraries =
+  [ ("src/stdune/caml", Some "Dune_caml", No)
+  ; ("src/stdune", Some "Stdune", No)
+  ; ("src/dune_lang", Some "Dune_lang", No)
+  ; ("vendor/incremental-cycles/src", Some "Incremental_cycles", No)
+  ; ("src/dag", Some "Dag", No)
+  ; ("src/fiber", Some "Fiber", No)
+  ; ("src/memo", Some "Memo", No)
+  ; ("src/xdg", Some "Xdg", No)
+  ; ("src/dune_memory", Some "Dune_memory", No)
+  ; ("src/dune_manager", Some "Dune_manager", No)
+  ; ("vendor/re/src", Some "Dune_re", No)
+  ; ("vendor/opam-file-format/src", None, No)
+  ; ("src/ocaml-config", Some "Ocaml_config", No)
+  ; ("src/catapult", Some "Catapult", No)
+  ; ("src/jbuild_support", Some "Jbuild_support", No)
+  ; ("otherlibs/action-plugin/src", Some "Dune_action_plugin", No)
+  ; ("src/dune", Some "Dune", Unqualified)
+  ; ("vendor/cmdliner/src", None, No)
+  ; ("otherlibs/build-info/src", Some "Build_info", No)
+  ]

--- a/dune-project
+++ b/dune-project
@@ -3,6 +3,9 @@
 
 (generate_opam_files true)
 
+; Reserved for Dune itself. This is to help with the bootstrap
+(using dune-bootstrap-info 0.1)
+
 (license MIT)
 (maintainers "Jane Street Group, LLC <opensource@janestreet.com>")
 (authors "Jane Street Group, LLC <opensource@janestreet.com>")

--- a/src/dune/bootstrap_info.ml
+++ b/src/dune/bootstrap_info.ml
@@ -1,0 +1,55 @@
+open Import
+open! No_io
+
+let gen_rules sctx (exes : Dune_file.Executables.t) ~dir compile =
+  Option.iter exes.bootstrap_info ~f:(fun fname ->
+      Super_context.add_rule sctx ~loc:exes.buildable.loc ~dir
+        (Build.write_file_dyn
+           (Path.Build.relative dir fname)
+           (Build.delayed (fun () ->
+                let libs =
+                  Result.ok_exn
+                    (Lazy.force (Lib.Compile.requires_link compile))
+                in
+                let locals, externals =
+                  List.partition_map libs ~f:(fun lib ->
+                      match Lib.Local.of_lib lib with
+                      | Some x -> Left x
+                      | None -> Right lib)
+                in
+                let open Pp.O in
+                let def name dyn =
+                  Pp.box ~indent:2 (Pp.textf "let %s = " name ++ Dyn.pp dyn)
+                in
+                Format.asprintf "%a@." Pp.render_ignore_tags
+                  (Pp.vbox
+                     (Pp.concat ~sep:Pp.cut
+                        [ def "external_libraries"
+                            (List
+                               (List.map externals ~f:(fun x ->
+                                    Lib.name x |> Lib_name.to_dyn)))
+                        ; Pp.nop
+                        ; def "local_libraries"
+                            (List
+                               (List.map locals ~f:(fun x ->
+                                    let info = Lib.Local.info x in
+                                    let dir = Lib_info.src_dir info in
+                                    Dyn.Tuple
+                                      [ Path.Source.to_dyn
+                                          (Path.Build.drop_build_context_exn
+                                             dir)
+                                      ; Dyn.Encoder.option Module_name.to_dyn
+                                          ( match
+                                              Lib_info.main_module_name info
+                                            with
+                                          | From _ -> None
+                                          | This x -> x )
+                                      ; ( match
+                                            Dir_contents.get sctx ~dir
+                                            |> Dir_contents.dirs
+                                          with
+                                        | _ :: _ :: _ ->
+                                          Dyn.Variant ("Unqualified", [])
+                                        | _ -> Dyn.Variant ("No", []) )
+                                      ])))
+                        ]))))))

--- a/src/dune/bootstrap_info.mli
+++ b/src/dune/bootstrap_info.mli
@@ -1,0 +1,14 @@
+(** Generate bootstrap info *)
+
+(** Generate an OCaml file containing a description of the dune sources for the
+    bootstrap procedure *)
+
+open Stdune
+
+(** Generate the rules to handle the stanza *)
+val gen_rules :
+     Super_context.t
+  -> Dune_file.Executables.t
+  -> dir:Path.Build.t
+  -> Lib.Compile.t
+  -> unit

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -323,6 +323,7 @@ module Executables : sig
     ; promote : Promote.t option
     ; install_conf : File_binding.Unexpanded.t Install_conf.t option
     ; forbidden_libraries : (Loc.t * Lib_name.t) list
+    ; bootstrap_info : string option
     }
 
   val has_stubs : t -> bool

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -150,4 +150,5 @@ let rules ~sctx ~dir ~dir_contents ~scope ~expander
       ~compile_info
   in
   SC.Libs.gen_select_rules sctx compile_info ~dir;
+  Bootstrap_info.gen_rules sctx exes ~dir compile_info;
   SC.Libs.with_lib_deps sctx compile_info ~dir ~f

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -111,6 +111,12 @@ let concat_map ?(sep = Nop) l ~f =
   | [ x ] -> f x
   | l -> Concat (sep, List.map l ~f)
 
+let concat_mapi ?(sep = Nop) l ~f =
+  match l with
+  | [] -> Nop
+  | [ x ] -> f 0 x
+  | l -> Concat (sep, List.mapi l ~f)
+
 let box ?(indent = 0) t = Box (indent, t)
 
 let vbox ?(indent = 0) t = Vbox (indent, t)

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -19,6 +19,8 @@ val concat : ?sep:'a t -> 'a t list -> 'a t
 (** Convenience function for [List.map] followed by [concat] *)
 val concat_map : ?sep:'a t -> 'b list -> f:('b -> 'a t) -> 'a t
 
+val concat_mapi : ?sep:'a t -> 'b list -> f:(int -> 'b -> 'a t) -> 'a t
+
 (** An indivisible block of text *)
 val verbatim : string -> _ t
 

--- a/test/expect-tests/action_tests.ml
+++ b/test/expect-tests/action_tests.ml
@@ -22,13 +22,13 @@ let infer (a : Action.t) =
 let%expect_test _ =
   infer (Copy (p "a", b "b"));
   [%expect {|
-  (["a"], ["_build/b"])
+  ([ "a" ], [ "_build/b" ])
   |}]
 
 let%expect_test _ =
   infer (Progn [ Copy (p "a", b "b"); Copy (pb "b", b "c") ]);
   [%expect {|
-(["a"], ["_build/b"; "_build/c"])
+([ "a" ], [ "_build/b"; "_build/c" ])
 |}]
 
 let%expect_test _ =
@@ -37,5 +37,5 @@ let%expect_test _ =
      don't need to care about this too much. *)
   infer (Progn [ Copy (p "a", b "b"); Rename (b "b", b "c") ]);
   [%expect {|
-(["a"], ["_build/b"; "_build/c"])
+([ "a" ], [ "_build/b"; "_build/c" ])
 |}]

--- a/test/expect-tests/catapult/catapult_tests.ml
+++ b/test/expect-tests/catapult/catapult_tests.ml
@@ -26,22 +26,22 @@ let () = Catapult.close c
 let buffer_lines () = String.split_lines (Buffer.contents buf)
 
 let%expect_test _ =
-  let open Dyn.Encoder in
-  buffer_lines () |> list string |> print_dyn;
+  Format.printf "%a@." Pp.render_ignore_tags
+    (Pp.vbox (Pp.concat_map (buffer_lines ()) ~sep:Pp.cut ~f:Pp.verbatim));
   [%expect
     {|
-["[{\"cat\": \"process\", \"name\": \"program\", \"id\": 0, \"pid\": 0, \"ph\": \"b\", \"ts\": 10000000, \"args\": [\"arg1\",\"arg2\"]}";
-",{\"cat\": \"process\", \"name\": \"program\", \"id\": 0, \"pid\": 0, \"ph\": \"e\", \"ts\": 30000000}";
-",{\"name\": \"live_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-",{\"name\": \"free_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-",{\"name\": \"stack_size\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-",{\"name\": \"heap_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-",{\"name\": \"top_heap_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-",{\"name\": \"minor_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0.00}}";
-",{\"name\": \"major_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0.00}}";
-",{\"name\": \"promoted_words\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0.00}}";
-",{\"name\": \"compactions\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-",{\"name\": \"major_collections\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-",{\"name\": \"minor_collections\", \"pid\": 0, \"tid\": 0, \"ph\": \"C\", \"ts\": 30000000, \"args\": {\"value\": 0}}";
-"]"]
+[{"cat": "process", "name": "program", "id": 0, "pid": 0, "ph": "b", "ts": 10000000, "args": ["arg1","arg2"]}
+,{"cat": "process", "name": "program", "id": 0, "pid": 0, "ph": "e", "ts": 30000000}
+,{"name": "live_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "free_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "stack_size", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "heap_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "top_heap_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "minor_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0.00}}
+,{"name": "major_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0.00}}
+,{"name": "promoted_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0.00}}
+,{"name": "compactions", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "major_collections", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "minor_collections", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+]
 |}]

--- a/test/expect-tests/dune_file_tests.ml
+++ b/test/expect-tests/dune_file_tests.ml
@@ -15,44 +15,38 @@ let%expect_test _ =
   (* Link modes can be read as a (<mode> <kind>) list *)
   test "(best exe)";
   [%expect {|
-{mode = best;
-  kind = exe}
+{ mode = best; kind = exe }
 |}]
 
 let%expect_test _ =
   (* Some shortcuts also exist *)
   test "exe";
   [%expect {|
-{mode = best;
-  kind = exe}
+{ mode = best; kind = exe }
 |}]
 
 let%expect_test _ =
   test "object";
   [%expect {|
-{mode = best;
-  kind = object}
+{ mode = best; kind = object }
 |}]
 
 let%expect_test _ =
   test "shared_object";
   [%expect {|
-{mode = best;
-  kind = shared_object}
+{ mode = best; kind = shared_object }
 |}]
 
 let%expect_test _ =
   test "byte";
   [%expect {|
-{mode = byte;
-  kind = exe}
+{ mode = byte; kind = exe }
 |}]
 
 let%expect_test _ =
   test "native";
   [%expect {|
-{mode = native;
-  kind = exe}
+{ mode = native; kind = exe }
 |}]
 
 (* Dune_file.Executables.Link_mode.encode *)
@@ -67,7 +61,7 @@ let%expect_test _ =
     }
   |> Dune_lang.to_dyn |> print_dyn;
   [%expect {|
-["byte"; "shared_object"]
+[ "byte"; "shared_object" ]
 |}]
 
 (* But the specialized ones are serialized in the minimal version *)

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -42,7 +42,7 @@ let%expect_test _ =
   |> Dyn.Encoder.(list int)
   |> print_dyn;
   [%expect {|
-[1; 2]
+[ 1; 2 ]
 |}]
 
 type 'res parse_result_diff =
@@ -96,7 +96,7 @@ let parse s =
 let%expect_test _ =
   parse {| # ## x##y x||y a#b|c#d copy# |};
   [%expect {|
-Same Ok ["#"; "##"; "x##y"; "x||y"; "a#b|c#d"; "copy#"]
+Same Ok [ "#"; "##"; "x##y"; "x||y"; "a#b|c#d"; "copy#" ]
 |}]
 
 let%expect_test _ =
@@ -104,8 +104,7 @@ let%expect_test _ =
   [%expect
     {|
 Different
-  {jbuild = Ok ["x"; "y"];
-    dune = Ok ["x"; "#|"; "comment"; "|#"; "y"]}
+  { jbuild = Ok [ "x"; "y" ]; dune = Ok [ "x"; "#|"; "comment"; "|#"; "y" ] }
 |}]
 
 let%expect_test _ =
@@ -113,8 +112,7 @@ let%expect_test _ =
   [%expect
     {|
 Different
-  {jbuild = Error "jbuild atoms cannot contain #|";
-    dune = Ok ["x#|y"]}
+  { jbuild = Error "jbuild atoms cannot contain #|"; dune = Ok [ "x#|y" ] }
 |}]
 
 let%expect_test _ =
@@ -122,86 +120,82 @@ let%expect_test _ =
   [%expect
     {|
 Different
-  {jbuild = Error "jbuild atoms cannot contain |#";
-    dune = Ok ["x|#y"]}
+  { jbuild = Error "jbuild atoms cannot contain |#"; dune = Ok [ "x|#y" ] }
 |}]
 
 let%expect_test _ =
   parse {|"\a"|};
   [%expect
     {|
-Different {jbuild = Ok ["\\a"];
-            dune = Error "unknown escape sequence"}
+Different { jbuild = Ok [ "\\a" ]; dune = Error "unknown escape sequence" }
 |}]
 
 let%expect_test _ =
   parse {|"\%{x}"|};
   [%expect
     {|
-Different {jbuild = Ok ["\\%{x}"];
-            dune = Ok ["%{x}"]}
+Different { jbuild = Ok [ "\\%{x}" ]; dune = Ok [ "%{x}" ] }
 |}]
 
 let%expect_test _ =
   parse {|"$foo"|};
   [%expect {|
-Same Ok ["$foo"]
+Same Ok [ "$foo" ]
 |}]
 
 let%expect_test _ =
   parse {|"%foo"|};
   [%expect {|
-Same Ok ["%foo"]
+Same Ok [ "%foo" ]
 |}]
 
 let%expect_test _ =
   parse {|"bar%foo"|};
   [%expect {|
-Same Ok ["bar%foo"]
+Same Ok [ "bar%foo" ]
 |}]
 
 let%expect_test _ =
   parse {|"bar$foo"|};
   [%expect {|
-Same Ok ["bar$foo"]
+Same Ok [ "bar$foo" ]
 |}]
 
 let%expect_test _ =
   parse {|"%bar$foo%"|};
   [%expect {|
-Same Ok ["%bar$foo%"]
+Same Ok [ "%bar$foo%" ]
 |}]
 
 let%expect_test _ =
   parse {|"$bar%foo%"|};
   [%expect {|
-Same Ok ["$bar%foo%"]
+Same Ok [ "$bar%foo%" ]
 |}]
 
 let%expect_test _ =
   parse {|\${foo}|};
   [%expect {|
-Same Ok ["\\${foo}"]
+Same Ok [ "\\${foo}" ]
 |}]
 
 let%expect_test _ =
   parse {|\%{foo}|};
   [%expect
     {|
-Different {jbuild = Ok ["\\%{foo}"];
-            dune = Ok [template "\\%{foo}"]}
+Different { jbuild = Ok [ "\\%{foo}" ]; dune = Ok [ template "\\%{foo}" ] }
 |}]
 
 let%expect_test _ =
   parse {|\$bar%foo%|};
   [%expect {|
-Same Ok ["\\$bar%foo%"]
+Same Ok [ "\\$bar%foo%" ]
 |}]
 
 let%expect_test _ =
   parse {|\$bar\%foo%|};
   [%expect {|
-Same Ok ["\\$bar\\%foo%"]
+Same Ok [ "\\$bar\\%foo%" ]
 |}]
 
 let%expect_test _ =
@@ -209,48 +203,46 @@ let%expect_test _ =
   [%expect
     {|
 Different
-  {jbuild = Ok ["\\$bar\\%foo%{bar}"];
-    dune = Ok [template "\\$bar\\%foo%{bar}"]}
+  { jbuild = Ok [ "\\$bar\\%foo%{bar}" ]
+  ; dune = Ok [ template "\\$bar\\%foo%{bar}" ]
+  }
 |}]
 
 let%expect_test _ =
   parse {|"bar%{foo}"|};
   [%expect
     {|
-Different {jbuild = Ok ["bar%{foo}"];
-            dune = Ok [template "\"bar%{foo}\""]}
+Different
+  { jbuild = Ok [ "bar%{foo}" ]; dune = Ok [ template "\"bar%{foo}\"" ] }
 |}]
 
 let%expect_test _ =
   parse {|"bar\%{foo}"|};
   [%expect
     {|
-Different {jbuild = Ok ["bar\\%{foo}"];
-            dune = Ok ["bar%{foo}"]}
+Different { jbuild = Ok [ "bar\\%{foo}" ]; dune = Ok [ "bar%{foo}" ] }
 |}]
 
 let%expect_test _ =
   parse {|bar%{foo}|};
   [%expect
     {|
-Different {jbuild = Ok ["bar%{foo}"];
-            dune = Ok [template "bar%{foo}"]}
+Different { jbuild = Ok [ "bar%{foo}" ]; dune = Ok [ template "bar%{foo}" ] }
 |}]
 
 let%expect_test _ =
   parse {|"bar%{foo}"|};
   [%expect
     {|
-Different {jbuild = Ok ["bar%{foo}"];
-            dune = Ok [template "\"bar%{foo}\""]}
+Different
+  { jbuild = Ok [ "bar%{foo}" ]; dune = Ok [ template "\"bar%{foo}\"" ] }
 |}]
 
 let%expect_test _ =
   parse {|"bar\%foo"|};
   [%expect
     {|
-Different {jbuild = Ok ["bar\\%foo"];
-            dune = Ok ["bar%foo"]}
+Different { jbuild = Ok [ "bar\\%foo" ]; dune = Ok [ "bar%foo" ] }
 |}]
 
 (* Printing tests *)
@@ -338,28 +330,22 @@ let%expect_test _ =
   [%expect.unreachable]
   [@@expect.uncaught_exn
     {|
-  ( "({pos_fname = \"<none>\";\
-   \n   start = {pos_lnum = 1;\
-   \n             pos_bol = 0;\
-   \n             pos_cnum = 0};\
-   \n   stop = {pos_lnum = 1;\
-   \n            pos_bol = 0;\
-   \n            pos_cnum = 0}},\
-   \n\"Invalid text in unquoted template\", {s = \"x%{\"})") |}]
+  ( "({ pos_fname = \"<none>\"\
+   \n ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\
+   \n ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\
+   \n },\
+   \n\"Invalid text in unquoted template\", { s = \"x%{\" })") |}]
 
 let%expect_test _ =
   test Dune (t [ Text "x%"; Text "{" ]);
   [%expect.unreachable]
   [@@expect.uncaught_exn
     {|
-  ( "({pos_fname = \"<none>\";\
-   \n   start = {pos_lnum = 1;\
-   \n             pos_bol = 0;\
-   \n             pos_cnum = 0};\
-   \n   stop = {pos_lnum = 1;\
-   \n            pos_bol = 0;\
-   \n            pos_cnum = 0}},\
-   \n\"Invalid text in unquoted template\", {s = \"x%{\"})") |}]
+  ( "({ pos_fname = \"<none>\"\
+   \n ; start = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\
+   \n ; stop = { pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }\
+   \n },\
+   \n\"Invalid text in unquoted template\", { s = \"x%{\" })") |}]
 
 let%expect_test _ =
   (* This round trip failure is expected *)
@@ -393,9 +379,12 @@ world
   |> print_dyn;
   [%expect
     {|
-[Atom A "hello"; Comment Lines [" comment"]; Atom A "world";
-Comment Lines [" multiline"; " comment"];
-List [Atom A "x"; Comment Lines [" comment inside list"]; Atom A "y"]]
+[ Atom A "hello"
+; Comment Lines [ " comment" ]
+; Atom A "world"
+; Comment Lines [ " multiline"; " comment" ]
+; List [ Atom A "x"; Comment Lines [ " comment inside list" ]; Atom A "y" ]
+]
 |}]
 
 let jbuild_file =
@@ -427,9 +416,12 @@ let%expect_test _ =
   |> print_dyn;
   [%expect
     {|
-[Atom A "hello"; Comment Lines [" comment"]; Atom A "world";
-Comment Lines [" multiline"; " comment"];
-List [Atom A "x"; Comment Lines [" comment inside list"]; Atom A "y"];
-Comment Lines ["(sexp"; "comment)"];
-Comment Lines ["old style"; "block"; "comment"]]
+[ Atom A "hello"
+; Comment Lines [ " comment" ]
+; Atom A "world"
+; Comment Lines [ " multiline"; " comment" ]
+; List [ Atom A "x"; Comment Lines [ " comment inside list" ]; Atom A "y" ]
+; Comment Lines [ "(sexp"; "comment)" ]
+; Comment Lines [ "old style"; "block"; "comment" ]
+]
 |}]

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -24,8 +24,7 @@ let%expect_test _ =
   |> Result.to_dyn unit (list Exn_with_backtrace.to_dyn)
   |> print_dyn;
   [%expect {|
-Error [{exn = "Exit";
-         backtrace = ""}]
+Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
 
 let%expect_test _ =
@@ -47,8 +46,7 @@ let%expect_test _ =
   |> Result.to_dyn unit (list Exn_with_backtrace.to_dyn)
   |> print_dyn;
   [%expect {|
-Error [{exn = "Exit";
-         backtrace = ""}]
+Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
 
 let%expect_test _ =
@@ -78,8 +76,7 @@ let%expect_test _ =
   |> Result.to_dyn (pair unit unit) (list Exn_with_backtrace.to_dyn)
   |> print_dyn;
   [%expect {|
-Error [{exn = "Exit";
-         backtrace = ""}]
+Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
 
 let%expect_test _ =

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -29,7 +29,7 @@ let%expect_test _ =
   let dyn = Dyn.Encoder.list Lib_dep.to_dyn requires in
   let pp = Dyn.pp dyn in
   Format.printf "%a@." Pp.render_ignore_tags pp;
-  [%expect {|["baz"]|}]
+  [%expect {|[ "baz" ]|}]
 
 (* Meta parsing/simplification *)
 
@@ -39,20 +39,27 @@ let%expect_test _ =
   |> Meta.Simplified.to_dyn |> print_dyn;
   [%expect
     {|
-    {name = Some "foo";
-      vars =
-        map {"requires" :
-             {set_rules =
-                [{var = "requires";
-                   predicates = [];
-                   action = Set;
-                   value = "bar"};
-                {var = "requires";
-                  predicates = [Pos "ppx_driver"];
-                  action = Set;
-                  value = "baz"}];
-               add_rules = []}};
-      subs = []} |}]
+    { name = Some "foo"
+    ;
+    vars =
+      map
+        {
+        "requires" :
+          {
+          set_rules =
+            [ { var = "requires"; predicates = []; action = Set; value = "bar" }
+            ;
+            { var = "requires"
+            ; predicates = [ Pos "ppx_driver" ]
+            ; action = Set
+            ; value = "baz"
+            }
+            ]
+          ; add_rules = []
+          }
+        }
+    ; subs = []
+    } |}]
 
 let conf =
   Findlib.Config.load
@@ -63,13 +70,23 @@ let%expect_test _ =
   print_dyn (Findlib.Config.to_dyn conf);
   [%expect
     {|
-    {vars =
-       map {"FOO_BAR" :
-            {set_rules =
-               [{preds_required = set {6; 7};
-                  preds_forbidden = set {};
-                  value = "my variable"}];
-              add_rules = []}};
-      preds = set {6}} |}];
+    {
+    vars =
+      map
+        {
+        "FOO_BAR" :
+          {
+          set_rules =
+            [
+            { preds_required = set { 6; 7 }
+            ; preds_forbidden = set {}
+            ; value = "my variable"
+            }
+            ]
+          ; add_rules = []
+          }
+        }
+    ; preds = set { 6 }
+    } |}];
   print_dyn (Env.to_dyn (Findlib.Config.env conf));
-  [%expect {| map {"FOO_BAR" : "my variable"} |}]
+  [%expect {| map { "FOO_BAR" : "my variable" } |}]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -84,7 +84,7 @@ let%expect_test _ =
   |> option (list (pair string (fun x -> x)))
   |> print_dyn;
   [%expect {|
-Some [("another", "aa"); ("some", "a")]
+Some [ ("another", "aa"); ("some", "a") ]
 |}]
 
 let%expect_test _ =
@@ -165,7 +165,7 @@ let%expect_test _ =
 - 0
 - 2
 4
-[("cycle", 2); ("cycle", 1); ("cycle", 0); ("cycle", 5)]
+[ ("cycle", 2); ("cycle", 1); ("cycle", 0); ("cycle", 5) ]
 |}]
 
 let mfib =
@@ -318,8 +318,8 @@ let%expect_test _ =
   Builtin_lazy.deps () |> print_dyn;
   [%expect
     {|
-(Some [("lazy_memo", "foo")],
-Some [("id", "lazy: foo"); ("lazy_memo", "foo")])
+(Some [ ("lazy_memo", "foo") ],
+Some [ ("id", "lazy: foo"); ("lazy_memo", "foo") ])
 |}]
 
 module Memo_lazy = Test_lazy (Memo.Lazy)
@@ -334,8 +334,8 @@ let%expect_test _ =
   Memo_lazy.deps () |> print_dyn;
   [%expect
     {|
-(Some [("lazy-0", ()); ("lazy_memo", "foo")],
-Some [("lazy-0", ()); ("lazy_memo", "foo")])
+(Some [ ("lazy-0", ()); ("lazy_memo", "foo") ],
+Some [ ("lazy-0", ()); ("lazy_memo", "foo") ])
 |}]
 
 (* Tests for depending on the current run*)

--- a/test/expect-tests/ocamlobjinfo_tests.ml
+++ b/test/expect-tests/ocamlobjinfo_tests.ml
@@ -83,20 +83,69 @@ let%expect_test _ =
   parse fixture;
   [%expect
     {|
-{impl =
-   set {"Printf"; "Stdune__Array"; "Stdune__Bin"; "Stdune__Exn";
-   "Stdune__List"; "Stdune__Map"; "Stdune__Set"; "Stdune__Sexp";
-   "Stdune__String"; "Sys"; "Unix"};
-  intf =
-    set {"ArrayLabels"; "Buffer"; "CamlinternalBigarray";
-    "CamlinternalFormatBasics"; "Complex"; "Dune_caml"; "Dune_caml__";
-    "Dune_caml__Result"; "Dune_caml__Result_compat"; "Format"; "Hashtbl";
-    "Lexing"; "ListLabels"; "Map"; "MoreLabels"; "Pervasives"; "Printexc";
-    "Printf"; "Set"; "Stdune__"; "Stdune__Array"; "Stdune__Bin";
-    "Stdune__Comparator"; "Stdune__Either"; "Stdune__Env"; "Stdune__Exn";
-    "Stdune__Hashable"; "Stdune__Hashtbl"; "Stdune__Hashtbl_intf";
-    "Stdune__List"; "Stdune__Loc"; "Stdune__Map"; "Stdune__Map_intf";
-    "Stdune__Ordering"; "Stdune__Path"; "Stdune__Result"; "Stdune__Set";
-    "Stdune__Set_intf"; "Stdune__Sexp"; "Stdune__Sexp_intf";
-    "Stdune__String"; "StringLabels"; "Sys"; "Uchar"; "Unix"}}
+{
+impl =
+  set
+    { "Printf"
+    ; "Stdune__Array"
+    ; "Stdune__Bin"
+    ; "Stdune__Exn"
+    ; "Stdune__List"
+    ; "Stdune__Map"
+    ; "Stdune__Set"
+    ; "Stdune__Sexp"
+    ; "Stdune__String"
+    ; "Sys"
+    ; "Unix"
+    }
+;
+intf =
+  set
+    { "ArrayLabels"
+    ; "Buffer"
+    ; "CamlinternalBigarray"
+    ; "CamlinternalFormatBasics"
+    ; "Complex"
+    ; "Dune_caml"
+    ; "Dune_caml__"
+    ; "Dune_caml__Result"
+    ; "Dune_caml__Result_compat"
+    ; "Format"
+    ; "Hashtbl"
+    ; "Lexing"
+    ; "ListLabels"
+    ; "Map"
+    ; "MoreLabels"
+    ; "Pervasives"
+    ; "Printexc"
+    ; "Printf"
+    ; "Set"
+    ; "Stdune__"
+    ; "Stdune__Array"
+    ; "Stdune__Bin"
+    ; "Stdune__Comparator"
+    ; "Stdune__Either"
+    ; "Stdune__Env"
+    ; "Stdune__Exn"
+    ; "Stdune__Hashable"
+    ; "Stdune__Hashtbl"
+    ; "Stdune__Hashtbl_intf"
+    ; "Stdune__List"
+    ; "Stdune__Loc"
+    ; "Stdune__Map"
+    ; "Stdune__Map_intf"
+    ; "Stdune__Ordering"
+    ; "Stdune__Path"
+    ; "Stdune__Result"
+    ; "Stdune__Set"
+    ; "Stdune__Set_intf"
+    ; "Stdune__Sexp"
+    ; "Stdune__Sexp_intf"
+    ; "Stdune__String"
+    ; "StringLabels"
+    ; "Sys"
+    ; "Uchar"
+    ; "Unix"
+    }
+}
 |}]

--- a/test/expect-tests/stdune/map_tests.ml
+++ b/test/expect-tests/stdune/map_tests.ml
@@ -10,5 +10,5 @@ let%expect_test _ =
   |> String.Map.to_dyn (list int)
   |> print_dyn;
   [%expect {|
-map {"a" : [1; 2; 3]; "b" : [1; 2]}
+map { "a" : [ 1; 2; 3 ]; "b" : [ 1; 2 ] }
 |}]

--- a/test/expect-tests/stdune/path_tests.ml
+++ b/test/expect-tests/stdune/path_tests.ml
@@ -218,19 +218,19 @@ None
 let%expect_test _ =
   explode "a/b/c";
   [%expect {|
-Some ["a"; "b"; "c"]
+Some [ "a"; "b"; "c" ]
 |}]
 
 let%expect_test _ =
   explode "a/b";
   [%expect {|
-Some ["a"; "b"]
+Some [ "a"; "b" ]
 |}]
 
 let%expect_test _ =
   explode "a";
   [%expect {|
-Some ["a"]
+Some [ "a" ]
 |}]
 
 let%expect_test _ =
@@ -299,8 +299,7 @@ let%expect_test _ =
   [@@expect.uncaught_exn
     {|
   ( "(\"Path.insert_after_build_dir_exn\",\
-   \n{path = In_source_tree \".\";\
-   \n  insert = \"foobar\"})") |}]
+   \n{ path = In_source_tree \".\"; insert = \"foobar\" })") |}]
 
 let%expect_test _ =
   insert_after_build_dir_exn Path.build_dir "foobar";
@@ -340,7 +339,7 @@ let%expect_test _ =
   [@@expect.uncaught_exn
     {|
   ( "(\"Path.rm_rf called on external dir\",\
-   \n{t = External \"/does/not/exist/foo/bar/baz\"})") |}]
+   \n{ t = External \"/does/not/exist/foo/bar/baz\" })") |}]
 
 let%expect_test _ =
   drop_build_context (Path.relative Path.build_dir "foo/bar");


### PR DESCRIPTION
This PR adds a rule to generate the list of libraries we put in the bootstrap file. This will be one less thing to maintain by hand while we work on dune.

At the moment the list is still duplicated in bootstrap.ml because putting `#use ...` makes ocamlformat unhappy. But we will use it for the new bootstrap procedure.