### PR TITLE
Update link to configurator API in docs

### DIFF
--- a/doc/dune-libs.rst
+++ b/doc/dune-libs.rst
@@ -34,7 +34,7 @@ Usage
 
 We'll describe configurator with a simple example. Everything else can be easily
 learned by studying `configurator's API
-<https://github.com/ocaml/dune/blob/master/src/configurator/v1.mli>`__.
+<https://github.com/ocaml/dune/blob/master/otherlibs/configurator/src/v1.mli>`__.
 
 To use configurator, we write an executable that will query the system using
 configurator's API and output a set of targets reflecting the results. For


### PR DESCRIPTION
It was pointing to the previous location.