### PR TITLE
[RFC] Add support for manually packing libraries into .pack.ml files

### DIFF
--- a/src/dune/dep_graph.mli
+++ b/src/dune/dep_graph.mli
@@ -9,6 +9,8 @@ val make :
 
 val deps_of : t -> Module.t -> Module.t list Build.t
 
+val top_closed : t -> Module.t list -> Module.t list Build.t
+
 val top_closed_implementations : t -> Module.t list -> Module.t list Build.t
 
 module Ml_kind : sig


### PR DESCRIPTION
This PR proposes to add a new target for wrapped libraries allowing to "pack" them in a single `.ml` file for ease of distribution. Concretely, given a library `foo` with files `a.ml`, `b.mli`, `b.ml`, `c.mli` it generates in `foo.pack.ml` as follows:
```
module A = struct
<contents of a.ml>
end
module B : sig
<contents of b.mli>
end = struct
<contents of b.ml>
end
module C = struct
<contents of c.mli>
end
```
(note that the modules need to be sorted in dependency order)

Still to do:

- handle user-defined entry modules
- handle single module libraries
- fail in the presence of private modules
- fail in the case of virtual libraries

I am not very familiar with this part of the code, so the implementation is probably a bit kludgy. suggestions/opinions welcome!