### PR TITLE
Fix native code generation of empty libraries on MSVC

### DIFF
--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -426,6 +426,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; natdynlink_supported =
           Dynlink_supported.By_the_os.of_bool natdynlink_supported
       ; stdlib_dir
+      ; ccomp_type = Ocaml_config.ccomp_type ocfg
       }
     in
     let t =

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1079,7 +1079,7 @@ module Library = struct
       This (Some (Module_name.of_local_lib_name (snd t.name)))
 
   let to_lib_info conf ~dir
-      ~lib_config:({ Lib_config.has_native; ext_lib; ext_obj; _ } as lib_config)
+      ~lib_config:({ Lib_config.has_native; ext_lib; ext_obj; ccomp_type; _ } as lib_config)
       ~known_implementations =
     let _loc, lib_name = conf.name in
     let obj_dir = obj_dir ~dir conf in
@@ -1109,7 +1109,7 @@ module Library = struct
       in
       { Mode.Dict.byte = stubs
       ; native =
-          if not (Ordered_set_lang.is_empty conf.buildable.modules) then
+          if ccomp_type = "msvc" && not (Ordered_set_lang.is_empty conf.buildable.modules) then
             Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib)
             :: stubs
           else

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1109,8 +1109,11 @@ module Library = struct
       in
       { Mode.Dict.byte = stubs
       ; native =
-          Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib)
-          :: stubs
+          if not (Ordered_set_lang.is_empty conf.buildable.modules) then
+            Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib)
+            :: stubs
+          else
+            stubs
       }
     in
     let foreign_archives =

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -105,8 +105,10 @@ end = struct
             |> List.map ~f:(fun f -> (Visibility.Public, f))
           in
           cmi_file :: other_cm_files)
+      in
+    let archives =
+      Lib_archives.make ~ctx ~dir_contents ~dir ~is_empty:(module_files = []) lib
     in
-    let archives = Lib_archives.make ~ctx ~dir_contents ~dir lib in
     let execs = lib_ppxs sctx ~scope ~lib in
     List.concat
       [ sources

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -105,9 +105,13 @@ end = struct
             |> List.map ~f:(fun f -> (Visibility.Public, f))
           in
           cmi_file :: other_cm_files)
-      in
+    in
     let archives =
-      Lib_archives.make ~ctx ~dir_contents ~dir ~is_empty:(module_files = []) lib
+      let is_empty = (module_files = []) in
+      if is_empty && not (Ordered_set_lang.is_empty lib.buildable.modules) then
+        (* TODO !! *)
+        Printf.eprintf "A warning that dune-package may be corrupt should go here\n%!";
+      Lib_archives.make ~ctx ~dir_contents ~dir ~is_empty lib
     in
     let execs = lib_ppxs sctx ~scope ~lib in
     List.concat

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -11,7 +11,7 @@ let dlls t = t.dlls
 
 module Library = Dune_file.Library
 
-let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
+let make ~(ctx : Context.t) ~dir ~dir_contents ~is_empty (lib : Library.t) =
   let { Lib_config.has_native; ext_obj; ext_dll; ext_lib; _ } =
     ctx.lib_config
   in
@@ -43,9 +43,11 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
       ; if_
           (native && not virtual_library)
           (let files =
-             [ Library.archive ~dir lib ~ext:(Mode.compiled_lib_ext Native)
-             ; Library.archive ~dir lib ~ext:ext_lib
-             ]
+             (Library.archive ~dir lib ~ext:(Mode.compiled_lib_ext Native)) ::
+             (if ctx.ccomp_type = "msvc" && is_empty then
+                []
+              else
+                [Library.archive ~dir lib ~ext:ext_lib])
            in
            if
              Dynlink_supported.get lib.dynlink

--- a/src/dune/lib_archives.mli
+++ b/src/dune/lib_archives.mli
@@ -6,6 +6,7 @@ val make :
      ctx:Context.t
   -> dir:Path.Build.t
   -> dir_contents:Dir_contents.t
+  -> is_empty:bool
   -> Dune_file.Library.t
   -> t
 

--- a/src/dune/lib_config.ml
+++ b/src/dune/lib_config.ml
@@ -11,6 +11,7 @@ type t =
   ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
+  ; ccomp_type : string
   }
 
 let var_map =

--- a/src/dune/lib_config.mli
+++ b/src/dune/lib_config.mli
@@ -11,6 +11,7 @@ type t =
   ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
+  ; ccomp_type : string
   }
 
 val allowed_in_enabled_if : string list

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -252,7 +252,7 @@ let setup_build_archives (lib : Dune_file.Library.t) ~cctx
     Dep_graph.top_closed_implementations dep_graphs.impl impl_only
   in
   let modes = Compilation_context.modes cctx in
-  let is_empty = (source_modules = []) in
+  let is_empty = (Modules.entry_modules modules = [] && source_modules = []) in
   (let cm_files =
      Cm_files.make ~obj_dir ~ext_obj ~modules ~top_sorted_modules
    in

--- a/src/dune/ordered_set_lang.ml
+++ b/src/dune/ordered_set_lang.ml
@@ -110,6 +110,11 @@ let is_standard t =
   | Ast.Standard -> true
   | _ -> false
 
+let is_empty t =
+  match (t.ast : ast_expanded) with
+  | Ast.Union [] -> true
+  | _ -> false
+
 module type Key = sig
   type t
 

--- a/src/dune/ordered_set_lang.mli
+++ b/src/dune/ordered_set_lang.mli
@@ -61,6 +61,8 @@ val standard : t
 
 val is_standard : t -> bool
 
+val is_empty : t -> bool
+
 val field :
      ?check:unit Dune_lang.Decoder.t
   -> string


### PR DESCRIPTION
Fixes #2687 (hopefully)

Discovered in the wild in https://github.com/ocaml/stdlib-shims/issues/11 - the fact it affects stdlib-shims means the fix should probably go in 1.11 as well, and I've prepared a branch for that already (assuming this code is OK...)

This fixes the Dune side - in order to use these libraries, it's necessary to have https://github.com/ocaml/ocaml/pull/9011, so empty libraries will be non-portable for OCaml < 4.10.

Given that this has only so far been seen with stdlib-shims (which is a special case), I'd go with Dune not trying to workaround this problem further.