### PR TITLE
Allow top-level libraries in `old_public_name`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -164,6 +164,13 @@
   stanza as well as the `(foreign_stubs ...)` and `(foreign_archives ...)` fields.
   (#2659, RFC #2650, @snowleopard)
 
+- Add (deprecated_package_names) field to (package) declaration in
+  dune-project. The names declared here can be used in the (old_public_name)
+  field of (deprecated_library_name) stanza. These names are interpreted as
+  library names (not prefixed by a package name) and appropiate redirections are
+  setup in their META files. This feaure is meant to migrate old libraries which
+  do not follow Dune's convention of prefixing libraries with the package
+  name. (#2696, @nojb)
 
 1.11.4 (09/10/2019)
 -------------------

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -237,6 +237,11 @@ It contains the following fields:
 
 - ``(tags <tags>)`` are the list of tags for the package
 
+- ``(deprecated_package_names <name list>)`` is a list of names that can be used
+  with the :ref:`deprecated-library-name` stanza to migrate legacy libraries
+  from other build systems which do not follow Dune's convention of prefixing
+  the public name of the library with the package name.
+
 The list of dependencies ``<dep-specification>`` is modeled after opam's own
 language: The syntax is as a list of the following elements:
 
@@ -494,6 +499,8 @@ JavaScript output.
 
 See :ref:`jsoo` for more information.
 
+.. _deprecated-library-name:
+
 deprecated_library_name
 -----------------------
 
@@ -511,6 +518,13 @@ When a developer uses the old public name in a list of library
 dependencies, it will be transparently replaced by the new name. Note
 that it is not necessary for the new name to exist at definition time
 as it is only resolved at the point where the old name is used.
+
+The ``old_public_name`` can also be one of the names declared in the
+``deprecated_package_names`` field of the package declaration in
+``dune-project`` file. In this case, the "old" library is understood to be a
+library whose name is not prefixed by the package name. Such a library cannot be
+defined in Dune, but other build systems allow it and this feature is meant to
+help migration from those systems.
 
 executable
 ----------

--- a/src/dune/dialect.ml
+++ b/src/dune/dialect.ml
@@ -14,10 +14,10 @@ module File_kind = struct
       [ ("kind", Ml_kind.to_dyn kind)
       ; ("extension", string extension)
       ; ( "preprocess"
-        , option (pair Loc.to_dyn Action_dune_lang.to_dyn) preprocess )
+        , option (fun (_, x) -> Action_dune_lang.to_dyn x) preprocess )
       ; ( "format"
         , option
-            (triple Loc.to_dyn Action_dune_lang.to_dyn (list string))
+            (fun (_, x, y) -> pair Action_dune_lang.to_dyn (list string) (x, y))
             format )
       ]
 end

--- a/src/dune/dialect.ml
+++ b/src/dune/dialect.ml
@@ -17,7 +17,8 @@ module File_kind = struct
         , option (fun (_, x) -> Action_dune_lang.to_dyn x) preprocess )
       ; ( "format"
         , option
-            (fun (_, x, y) -> pair Action_dune_lang.to_dyn (list string) (x, y))
+            (fun (_, x, y) ->
+              pair Action_dune_lang.to_dyn (list string) (x, y))
             format )
       ]
 end

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -119,6 +119,8 @@ module Public_lib : sig
     }
 
   val name : t -> Lib_name.t
+
+  val package : t -> Package.t
 end
 
 module Mode_conf : sig
@@ -464,11 +466,18 @@ module Include_subdirs : sig
 end
 
 module Deprecated_library_name : sig
+  module Old_public_name : sig
+    type t =
+      { deprecated : bool
+      ; public : Public_lib.t
+      }
+  end
+
   type t =
     { loc : Loc.t
     ; project : Dune_project.t
-    ; old_public_name : Public_lib.t
-    ; new_public_name : Lib_name.t
+    ; old_public_name : Old_public_name.t
+    ; new_public_name : Loc.t * Lib_name.t
     }
 end
 

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -194,6 +194,14 @@ module Lib = struct
   let wrapped t = Option.map t.modules ~f:Modules.wrapped
 
   let info dp = dp.info
+
+  let to_dyn { info ; modules ; main_module_name } =
+    let open Dyn.Encoder in
+    record
+      [ "info", Lib_info.to_dyn Path.to_dyn info
+      ; "modules", option Modules.to_dyn modules
+      ; "main_module_name", option Module_name.to_dyn main_module_name
+      ]
 end
 
 module Deprecated_library_name = struct
@@ -217,6 +225,13 @@ module Deprecated_library_name = struct
     record_fields
       [ field "old_public_name" Lib_name.encode old_public_name
       ; field "new_public_name" Lib_name.encode new_public_name
+      ]
+
+  let to_dyn { loc = _; old_public_name; new_public_name } =
+    let open Dyn.Encoder in
+    record
+      [ "old_public_name", Lib_name.to_dyn old_public_name
+      ; "new_public_name", Lib_name.to_dyn new_public_name
       ]
 end
 
@@ -242,6 +257,14 @@ module Entry = struct
       , let+ x = Deprecated_library_name.decode in
         Deprecated_library_name x )
     ]
+
+  let to_dyn x =
+    let open Dyn.Encoder in
+    match x with
+    | Library lib ->
+      constr "Library" [Lib.to_dyn lib]
+    | Deprecated_library_name lib ->
+      constr "Deprecated_library_name" [Deprecated_library_name.to_dyn lib]
 end
 
 type t =
@@ -304,6 +327,15 @@ let encode ~dune_version { entries; name; version; dir } =
   in
   prepend_version ~dune_version (List.concat [ sexp; entries ])
 
+let to_dyn { entries; name; version; dir } =
+  let open Dyn.Encoder in
+  record
+    [ "entries", list Entry.to_dyn entries
+    ; "name", Package.Name.to_dyn name
+    ; "version", option string version
+    ; "dir", Path.to_dyn dir
+    ]
+
 module Or_meta = struct
   type nonrec t =
     | Use_meta
@@ -326,4 +358,14 @@ module Or_meta = struct
 
   let load p =
     Vfile.load p ~f:(fun lang -> decode ~lang ~dir:(Path.parent_exn p))
+
+  let pp ~dune_version ppf t =
+    let t = encode ~dune_version t in
+    Format.fprintf ppf "%a@." (Fmt.list ~pp_sep:Fmt.nl Dune_lang.Deprecated.pp) t
+
+  let to_dyn x =
+    let open Dyn.Encoder in
+    match x with
+    | Use_meta -> constr "Use_meta" []
+    | Dune_package t -> constr "Dune_package" [to_dyn t]
 end

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -195,12 +195,12 @@ module Lib = struct
 
   let info dp = dp.info
 
-  let to_dyn { info ; modules ; main_module_name } =
+  let to_dyn { info; modules; main_module_name } =
     let open Dyn.Encoder in
     record
-      [ "info", Lib_info.to_dyn Path.to_dyn info
-      ; "modules", option Modules.to_dyn modules
-      ; "main_module_name", option Module_name.to_dyn main_module_name
+      [ ("info", Lib_info.to_dyn Path.to_dyn info)
+      ; ("modules", option Modules.to_dyn modules)
+      ; ("main_module_name", option Module_name.to_dyn main_module_name)
       ]
 end
 
@@ -230,8 +230,8 @@ module Deprecated_library_name = struct
   let to_dyn { loc = _; old_public_name; new_public_name } =
     let open Dyn.Encoder in
     record
-      [ "old_public_name", Lib_name.to_dyn old_public_name
-      ; "new_public_name", Lib_name.to_dyn new_public_name
+      [ ("old_public_name", Lib_name.to_dyn old_public_name)
+      ; ("new_public_name", Lib_name.to_dyn new_public_name)
       ]
 end
 
@@ -261,10 +261,9 @@ module Entry = struct
   let to_dyn x =
     let open Dyn.Encoder in
     match x with
-    | Library lib ->
-      constr "Library" [Lib.to_dyn lib]
+    | Library lib -> constr "Library" [ Lib.to_dyn lib ]
     | Deprecated_library_name lib ->
-      constr "Deprecated_library_name" [Deprecated_library_name.to_dyn lib]
+      constr "Deprecated_library_name" [ Deprecated_library_name.to_dyn lib ]
 end
 
 type t =
@@ -330,10 +329,10 @@ let encode ~dune_version { entries; name; version; dir } =
 let to_dyn { entries; name; version; dir } =
   let open Dyn.Encoder in
   record
-    [ "entries", list Entry.to_dyn entries
-    ; "name", Package.Name.to_dyn name
-    ; "version", option string version
-    ; "dir", Path.to_dyn dir
+    [ ("entries", list Entry.to_dyn entries)
+    ; ("name", Package.Name.to_dyn name)
+    ; ("version", option string version)
+    ; ("dir", Path.to_dyn dir)
     ]
 
 module Or_meta = struct
@@ -361,11 +360,13 @@ module Or_meta = struct
 
   let pp ~dune_version ppf t =
     let t = encode ~dune_version t in
-    Format.fprintf ppf "%a@." (Fmt.list ~pp_sep:Fmt.nl Dune_lang.Deprecated.pp) t
+    Format.fprintf ppf "%a@."
+      (Fmt.list ~pp_sep:Fmt.nl Dune_lang.Deprecated.pp)
+      t
 
   let to_dyn x =
     let open Dyn.Encoder in
     match x with
     | Use_meta -> constr "Use_meta" []
-    | Dune_package t -> constr "Dune_package" [to_dyn t]
+    | Dune_package t -> constr "Dune_package" [ to_dyn t ]
 end

--- a/src/dune/dune_package.mli
+++ b/src/dune/dune_package.mli
@@ -22,6 +22,8 @@ module Lib : sig
     -> main_module_name:Module_name.t option
     -> modules:Modules.t option
     -> t
+
+  val to_dyn : t Dyn.Encoder.t
 end
 
 module Deprecated_library_name : sig
@@ -30,6 +32,8 @@ module Deprecated_library_name : sig
     ; old_public_name : Lib_name.t
     ; new_public_name : Lib_name.t
     }
+
+  val to_dyn : t Dyn.Encoder.t
 end
 
 module Entry : sig
@@ -40,6 +44,8 @@ module Entry : sig
   val name : t -> Lib_name.t
 
   val version : t -> string option
+
+  val to_dyn : t Dyn.Encoder.t
 end
 
 type t =
@@ -49,12 +55,17 @@ type t =
   ; dir : Path.t
   }
 
+val to_dyn : t Dyn.Encoder.t
+
 module Or_meta : sig
   type nonrec t =
     | Use_meta
     | Dune_package of t
 
   val encode : dune_version:Dune_lang.Syntax.Version.t -> t -> Dune_lang.t list
+  val pp : dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
 
   val load : Dpath.t -> t
+
+  val to_dyn : t Dyn.Encoder.t
 end

--- a/src/dune/dune_package.mli
+++ b/src/dune/dune_package.mli
@@ -63,7 +63,9 @@ module Or_meta : sig
     | Dune_package of t
 
   val encode : dune_version:Dune_lang.Syntax.Version.t -> t -> Dune_lang.t list
-  val pp : dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
+
+  val pp :
+    dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
 
   val load : Dpath.t -> t
 

--- a/src/dune/gen_meta.mli
+++ b/src/dune/gen_meta.mli
@@ -5,5 +5,6 @@ open! Import
 val gen :
      package:string
   -> version:string option
+  -> ?add_directory_entry:bool
   -> Super_context.Lib_entry.t list
   -> Meta.t

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -11,12 +11,20 @@ module Package_paths = struct
   let meta_file (ctx : Context.t) pkg =
     Path.Build.append_source ctx.build_dir (Package.meta_file pkg)
 
+  let deprecated_meta_file (ctx : Context.t) pkg name =
+    Path.Build.append_source ctx.build_dir
+      (Package.deprecated_meta_file pkg name)
+
   let build_dir (ctx : Context.t) (pkg : Package.t) =
     Path.Build.append_source ctx.build_dir pkg.path
 
   let dune_package_file ctx pkg =
     Path.Build.relative (build_dir ctx pkg)
       (Package.Name.to_string pkg.name ^ ".dune-package")
+
+  let deprecated_dune_package_file ctx pkg name =
+    Path.Build.relative (build_dir ctx pkg)
+      (Package.Name.to_string name ^ ".dune-package")
 
   let meta_template ctx pkg =
     Path.Build.extend_basename (meta_file ctx pkg) ~suffix:".template"
@@ -170,17 +178,40 @@ end = struct
                let dune_package_file =
                  Package_paths.dune_package_file ctx pkg
                in
+               let deprecated_meta_and_dune_files =
+                 List.concat_map
+                   (Package.Name.Map.to_list pkg.deprecated_package_names)
+                   ~f:(fun (name, _) ->
+                     let meta_file =
+                       Package_paths.deprecated_meta_file ctx pkg name
+                     in
+                     let dune_package_file =
+                       Package_paths.deprecated_dune_package_file ctx pkg name
+                     in
+                     [ ( None
+                       , Install.Entry.make Lib_root meta_file
+                           ~dst:
+                             ( Package.Name.to_string name
+                             ^ "/" ^ Findlib.meta_fn ) )
+                     ; ( None
+                       , Install.Entry.make Lib_root dune_package_file
+                           ~dst:
+                             ( Package.Name.to_string name
+                             ^ "/" ^ Dune_package.fn ) )
+                     ])
+               in
                (None, Install.Entry.make Lib meta_file ~dst:Findlib.meta_fn)
                :: ( None
                   , Install.Entry.make Lib dune_package_file
                       ~dst:Dune_package.fn )
                ::
                ( match pkg.kind with
-               | Dune false -> []
+               | Dune false -> deprecated_meta_and_dune_files
                | Dune true
                | Opam ->
                  let opam_file = Package_paths.opam_file ctx pkg in
-                 [ (None, Install.Entry.make Lib opam_file ~dst:"opam") ] )
+                 (None, Install.Entry.make Lib opam_file ~dst:"opam")
+                 :: deprecated_meta_and_dune_files )
              in
              String.Set.fold files ~init ~f:(fun fn acc ->
                  if is_odig_doc_file fn then
@@ -262,6 +293,18 @@ let gen_dune_package sctx pkg =
   let dune_version =
     Dune_lang.Syntax.greatest_supported_version Stanza.syntax
   in
+  let lib_entries = Super_context.lib_entries_of_package sctx pkg.name in
+  let deprecated_dune_packages =
+    List.filter_map lib_entries ~f:(function
+      | Super_context.Lib_entry.Deprecated_library_name
+          ( { old_public_name = { deprecated = true; public = old_public_name }
+            ; _
+            } as t ) ->
+        Some
+          (Lib_name.package_name (Dune_file.Public_lib.name old_public_name), t)
+      | _ -> None)
+    |> Package.Name.Map.of_list_multi
+  in
   let action =
     let gen_dune_package () =
       let dune_package =
@@ -273,38 +316,49 @@ let gen_dune_package sctx pkg =
           Path.Build.L.relative pkg_root subdir
         in
         let entries =
-          Super_context.lib_entries_of_package sctx pkg.name
-          |> List.map ~f:(function
-               | Super_context.Lib_entry.Deprecated_library_name d ->
-                 Dune_package.Entry.Deprecated_library_name
-                   { loc = d.loc
-                   ; old_public_name = snd d.old_public_name.name
-                   ; new_public_name = d.new_public_name
-                   }
-               | Library lib ->
-                 let dir_contents =
-                   let info = Lib.Local.info lib in
-                   let dir = Lib_info.src_dir info in
-                   Dir_contents.get sctx ~dir
-                 in
-                 let obj_dir = Lib.Local.obj_dir lib in
-                 let lib = Lib.Local.to_lib lib in
-                 let name = Lib.name lib in
-                 let foreign_objects =
-                   let dir = Obj_dir.obj_dir obj_dir in
-                   Dir_contents.foreign_sources_of_library dir_contents ~name
-                   |> Foreign.Sources.object_files ~dir
-                        ~ext_obj:ctx.lib_config.ext_obj
-                   |> List.map ~f:Path.build
-                 in
-                 let modules =
-                   Dir_contents.modules_of_library dir_contents ~name
-                 in
-                 Library
+          List.filter_map lib_entries ~f:(function
+            | Super_context.Lib_entry.Deprecated_library_name
+                { old_public_name = { deprecated = true; _ }; _ } ->
+              None
+            | Super_context.Lib_entry.Deprecated_library_name
+                { old_public_name =
+                    { public = old_public_name; deprecated = false }
+                ; new_public_name = _, new_public_name
+                ; loc
+                ; _
+                } ->
+              Some
+                (Dune_package.Entry.Deprecated_library_name
+                   { loc
+                   ; old_public_name =
+                       Dune_file.Public_lib.name old_public_name
+                   ; new_public_name
+                   })
+            | Library lib ->
+              let dir_contents =
+                let info = Lib.Local.info lib in
+                let dir = Lib_info.src_dir info in
+                Dir_contents.get sctx ~dir
+              in
+              let obj_dir = Lib.Local.obj_dir lib in
+              let lib = Lib.Local.to_lib lib in
+              let name = Lib.name lib in
+              let foreign_objects =
+                let dir = Obj_dir.obj_dir obj_dir in
+                Dir_contents.foreign_sources_of_library dir_contents ~name
+                |> Foreign.Sources.object_files ~dir
+                     ~ext_obj:ctx.lib_config.ext_obj
+                |> List.map ~f:Path.build
+              in
+              let modules =
+                Dir_contents.modules_of_library dir_contents ~name
+              in
+              Some
+                (Library
                    (Result.ok_exn
                       (Lib.to_dune_lib lib
                          ~dir:(Path.build (lib_root lib))
-                         ~modules ~foreign_objects)))
+                         ~modules ~foreign_objects))))
         in
         Dune_package.Or_meta.Dune_package
           { Dune_package.version = pkg.version
@@ -321,10 +375,43 @@ let gen_dune_package sctx pkg =
            ~then_:(Build.return Dune_package.Or_meta.Use_meta)
            ~else_:(Build.delayed gen_dune_package)
        in
-       Dune_package.Or_meta.encode ~dune_version pkg
-       |> Format.asprintf "%a@."
-            (Fmt.list ~pp_sep:Fmt.nl Dune_lang.Deprecated.pp))
+       Format.asprintf "%a" (Dune_package.Or_meta.pp ~dune_version) pkg)
   in
+  Package.Name.Map.iteri pkg.deprecated_package_names ~f:(fun name _ ->
+      let dune_pkg =
+        let entries =
+          match Package.Name.Map.find deprecated_dune_packages name with
+          | None -> []
+          | Some entries ->
+            List.map entries
+              ~f:(fun { Dune_file.Deprecated_library_name.old_public_name =
+                          { public = old_public_name; _ }
+                      ; new_public_name = _, new_public_name
+                      ; loc
+                      ; _
+                      }
+                      ->
+                let old_public_name =
+                  Dune_file.Public_lib.name old_public_name
+                in
+                Dune_package.Entry.Deprecated_library_name
+                  { loc; old_public_name; new_public_name })
+        in
+        { Dune_package.version = pkg.version
+        ; name
+        ; entries
+        ; dir =
+            Path.build
+              (Config.local_install_lib_dir ~context:ctx.name ~package:name)
+        }
+      in
+      Build.write_file
+        (Package_paths.deprecated_dune_package_file ctx pkg
+           dune_pkg.Dune_package.name)
+        (Format.asprintf "%a"
+           (Dune_package.Or_meta.pp ~dune_version)
+           (Dune_package.Or_meta.Dune_package dune_pkg))
+      |> Super_context.add_rule sctx ~dir:ctx.build_dir);
   Super_context.add_rule sctx ~dir:ctx.build_dir action
 
 let init_meta_and_dune_package sctx ~dir =
@@ -333,6 +420,21 @@ let init_meta_and_dune_package sctx ~dir =
   |> Scope.project |> Dune_project.packages
   |> Package.Name.Map.iter ~f:(fun (pkg : Package.t) ->
          let entries = Super_context.lib_entries_of_package sctx pkg.name in
+         let deprecated_packages, entries =
+           List.partition_map entries ~f:(function
+             | Super_context.Lib_entry.Deprecated_library_name
+                 { old_public_name =
+                     { deprecated = true
+                     ; public = { sub_dir = None; name = _, name; _ }
+                     }
+                 ; _
+                 } as entry ->
+               Left (Lib_name.package_name name, entry)
+             | entry -> Right entry)
+         in
+         let deprecated_packages =
+           Package.Name.Map.of_list_multi deprecated_packages
+         in
          let meta = Package_paths.meta_file ctx pkg in
          let meta_template =
            Path.build (Package_paths.meta_template ctx pkg)
@@ -394,7 +496,22 @@ let init_meta_and_dune_package sctx ~dir =
             Format.pp_close_box ppf ();
             Format.pp_print_flush ppf ();
             Buffer.contents buf)
-           |> Build.write_file_dyn meta))
+           |> Build.write_file_dyn meta);
+         Package.Name.Map.iteri pkg.deprecated_package_names ~f:(fun name _ ->
+             let meta = Package_paths.deprecated_meta_file ctx pkg name in
+             Super_context.add_rule sctx ~dir:ctx.build_dir
+               ( (let meta =
+                    let entries =
+                      match Package.Name.Map.find deprecated_packages name with
+                      | None -> []
+                      | Some entries -> entries
+                    in
+                    Gen_meta.gen
+                      ~package:(Package.Name.to_string pkg.name)
+                      ~version:pkg.version entries ~add_directory_entry:false
+                  in
+                  Format.asprintf "@[<v>%a@,@]" Meta.pp meta.entries)
+               |> Build.write_file meta )))
 
 let symlink_installed_artifacts_to_build_install sctx
     (entries : (Loc.t option * Path.Build.t Install.Entry.t) list)

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -1511,6 +1511,15 @@ module DB = struct
       | Found of Lib_info.external_
       | Hidden of Lib_info.external_ * string
       | Redirect of db option * Lib_name.t
+
+    let to_dyn x =
+      let open Dyn.Encoder in
+      match x with
+      | Not_found -> constr "Not_found" []
+      | Found lib -> constr "Found" [ Lib_info.to_dyn Path.to_dyn lib ]
+      | Hidden (lib, s) ->
+        constr "Hidden" [ Lib_info.to_dyn Path.to_dyn lib; string s ]
+      | Redirect (_, name) -> constr "Redirect" [ Lib_name.to_dyn name ]
   end
 
   type t = db

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -332,7 +332,7 @@ and resolve_result =
   | Not_found
   | Found of Lib_info.external_
   | Hidden of Lib_info.external_ * string
-  | Redirect of db option * Lib_name.t
+  | Redirect of db option * (Loc.t * Lib_name.t)
 
 type lib = t
 
@@ -1088,7 +1088,7 @@ end = struct
 
   let resolve_name db name ~stack =
     match db.resolve name with
-    | Redirect (db', name') -> (
+    | Redirect (db', (_, name')) -> (
       let db' = Option.value db' ~default:db in
       match find_internal db' name' ~stack with
       | St_initializing _ as x -> x
@@ -1510,7 +1510,7 @@ module DB = struct
       | Not_found
       | Found of Lib_info.external_
       | Hidden of Lib_info.external_ * string
-      | Redirect of db option * Lib_name.t
+      | Redirect of db option * (Loc.t * Lib_name.t)
 
     let to_dyn x =
       let open Dyn.Encoder in
@@ -1519,7 +1519,7 @@ module DB = struct
       | Found lib -> constr "Found" [ Lib_info.to_dyn Path.to_dyn lib ]
       | Hidden (lib, s) ->
         constr "Hidden" [ Lib_info.to_dyn Path.to_dyn lib; string s ]
-      | Redirect (_, name) -> constr "Redirect" [ Lib_name.to_dyn name ]
+      | Redirect (_, (_, name)) -> constr "Redirect" [ Lib_name.to_dyn name ]
   end
 
   type t = db
@@ -1558,7 +1558,7 @@ module DB = struct
                 | Hidden _ ->
                   assert false
                 | Found x -> x
-                | Redirect (_, name') -> (
+                | Redirect (_, (_, name')) -> (
                   match Lib_name.Map.find libmap name' with
                   | Some (Found x) -> x
                   | _ -> assert false ))
@@ -1614,9 +1614,13 @@ module DB = struct
       List.concat_map stanzas ~f:(fun stanza ->
           match (stanza : Library_related_stanza.t) with
           | External_variant _ -> []
-          | Deprecated_library_name x ->
-            [ ( Dune_file.Public_lib.name x.old_public_name
-              , Redirect (None, x.new_public_name) )
+          | Deprecated_library_name
+              { old_public_name = { public = old_public_name; _ }
+              ; new_public_name
+              ; _
+              } ->
+            [ ( Dune_file.Public_lib.name old_public_name
+              , Redirect (None, new_public_name) )
             ]
           | Library (dir, (conf : Dune_file.Library.t)) -> (
             (* In the [implements] field of library stanzas, the user might use
@@ -1659,41 +1663,38 @@ module DB = struct
                 [ (name, Found info) ]
               else
                 [ (name, Found info)
-                ; (Lib_name.of_local conf.name, Redirect (None, name))
+                ; (Lib_name.of_local conf.name, Redirect (None, p.name))
                 ] ))
-      |> Lib_name.Map.of_list
-      |> function
-      | Ok x -> x
-      | Error (name, _, _) -> (
-        match
-          List.filter_map stanzas ~f:(function
-            | Library (_, conf) ->
-              if
-                Lib_name.equal name (Lib_name.of_local conf.name)
-                ||
-                match conf.public with
-                | None -> false
-                | Some p -> Lib_name.equal name (Dune_file.Public_lib.name p)
-              then
-                Some conf.buildable.loc
-              else
-                None
-            | Deprecated_library_name x ->
-              Option.some_if
-                (Lib_name.equal name
-                   (Dune_file.Public_lib.name x.old_public_name))
-                x.loc
-            | External_variant _ -> None)
-        with
-        | []
-        | [ _ ] ->
-          assert false
-        | loc1 :: loc2 :: _ ->
-          User_error.raise
-            [ Pp.textf "Library %s is defined twice:" (Lib_name.to_string name)
-            ; Pp.textf "- %s" (Loc.to_file_colon_line loc1)
-            ; Pp.textf "- %s" (Loc.to_file_colon_line loc2)
-            ] )
+      |> Lib_name.Map.of_list_reducei ~f:(fun name v1 v2 ->
+             let res =
+               match (v1, v2) with
+               | Found info1, Found info2 ->
+                 Error (Lib_info.loc info1, Lib_info.loc info2)
+               | Found info, Redirect (None, (loc, _))
+               | Redirect (None, (loc, _)), Found info ->
+                 Error (loc, Lib_info.loc info)
+               | Redirect (None, (loc1, lib1)), Redirect (None, (loc2, lib2))
+                 ->
+                 if Lib_name.equal lib1 lib2 then
+                   Ok v1
+                 else
+                   Error (loc1, loc2)
+               | _ ->
+                 Code_error.raise
+                   "create_from_stanzas produced unexpected result"
+                   [ ("v1", Resolve_result.to_dyn v1)
+                   ; ("v2", Resolve_result.to_dyn v2)
+                   ]
+             in
+             match res with
+             | Ok x -> x
+             | Error (loc1, loc2) ->
+               User_error.raise
+                 [ Pp.textf "Library %s is defined twice:"
+                     (Lib_name.to_string name)
+                 ; Pp.textf "- %s" (Loc.to_file_colon_line loc1)
+                 ; Pp.textf "- %s" (Loc.to_file_colon_line loc2)
+                 ])
     in
     (* We need to check that [external_variant] stanzas are correct, i.e.
        contain valid [virtual_library] fields now since this is the last time
@@ -1710,7 +1711,8 @@ module DB = struct
       ~resolve:(fun name ->
         match Findlib.find findlib name with
         | Ok (Library pkg) -> Found (Dune_package.Lib.info pkg)
-        | Ok (Deprecated_library_name d) -> Redirect (None, d.new_public_name)
+        | Ok (Deprecated_library_name d) ->
+          Redirect (None, (Loc.none, d.new_public_name))
         | Error e -> (
           match e with
           | Not_found ->

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -147,6 +147,8 @@ module DB : sig
       | Found of Lib_info.external_
       | Hidden of Lib_info.external_ * string
       | Redirect of t option * Lib_name.t
+
+    val to_dyn : t Dyn.Encoder.t
   end
 
   (** Create a new library database. [resolve] is used to resolve library names

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -146,7 +146,7 @@ module DB : sig
       | Not_found
       | Found of Lib_info.external_
       | Hidden of Lib_info.external_ * string
-      | Redirect of t option * Lib_name.t
+      | Redirect of t option * (Loc.t * Lib_name.t)
 
     val to_dyn : t Dyn.Encoder.t
   end

--- a/src/dune/lib_info.mli
+++ b/src/dune/lib_info.mli
@@ -185,3 +185,5 @@ val create :
   -> wrapped:Wrapped.t Inherited.t option
   -> special_builtin_support:Special_builtin_support.t option
   -> 'a t
+
+val to_dyn : 'path Dyn.Encoder.t -> 'path t Dyn.Encoder.t

--- a/src/dune/lib_kind.ml
+++ b/src/dune/lib_kind.ml
@@ -7,6 +7,11 @@ module Ppx_args = struct
       ; value : String_with_vars.t
       }
 
+    let to_dyn x =
+      let open Dyn.Encoder in
+      record
+        [ ("name", string x.name); ("value", String_with_vars.to_dyn x.value) ]
+
     let decode =
       let open Dune_lang.Decoder in
       let* () = Dune_lang.Syntax.since Stanza.syntax (1, 10) in
@@ -28,6 +33,10 @@ module Ppx_args = struct
 
   type t = { cookies : Cookie.t list }
 
+  let to_dyn { cookies } =
+    let open Dyn.Encoder in
+    record [ ("cookies", list Cookie.to_dyn cookies) ]
+
   let decode =
     let open Dune_lang.Decoder in
     let args =
@@ -45,6 +54,13 @@ type t =
   | Normal
   | Ppx_deriver of Ppx_args.t
   | Ppx_rewriter of Ppx_args.t
+
+let to_dyn x =
+  let open Dyn.Encoder in
+  match x with
+  | Normal -> constr "Normal" []
+  | Ppx_deriver args -> constr "Ppx_deriver" [ Ppx_args.to_dyn args ]
+  | Ppx_rewriter args -> constr "Ppx_rewriter" [ Ppx_args.to_dyn args ]
 
 let decode =
   let open Dune_lang.Decoder in

--- a/src/dune/lib_kind.mli
+++ b/src/dune/lib_kind.mli
@@ -14,4 +14,6 @@ type t =
   | Ppx_deriver of Ppx_args.t
   | Ppx_rewriter of Ppx_args.t
 
+val to_dyn : t Stdune.Dyn.Encoder.t
+
 include Dune_lang.Conv.S with type t := t

--- a/src/dune/opam_create.ml
+++ b/src/dune/opam_create.ml
@@ -47,6 +47,7 @@ let package_fields
     ; kind = _
     ; tags
     ; loc = _
+    ; deprecated_package_names = _
     } ~project =
   let open Opam_file.Create in
   let tags =

--- a/src/dune/package.mli
+++ b/src/dune/package.mli
@@ -81,6 +81,7 @@ type t =
   ; version : string option
   ; kind : Kind.t
   ; tags : string list
+  ; deprecated_package_names : Loc.t Name.Map.t
   }
 
 val file : dir:Path.t -> name:Name.t -> Path.t
@@ -90,6 +91,8 @@ val decode : dir:Path.Source.t -> t Dune_lang.Decoder.t
 val opam_file : t -> Path.Source.t
 
 val meta_file : t -> Path.Source.t
+
+val deprecated_meta_file : t -> Name.t -> Path.Source.t
 
 val to_dyn : t -> Dyn.t
 

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -27,7 +27,9 @@ module Lib_entry = struct
 
   let name = function
     | Library lib -> Lib.Local.to_lib lib |> Lib.name
-    | Deprecated_library_name d -> snd d.old_public_name.name
+    | Deprecated_library_name
+        { old_public_name = { public = old_public_name; _ }; _ } ->
+      Dune_file.Public_lib.name old_public_name
 end
 
 type t =
@@ -525,8 +527,10 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas
               ( pub.package.name
               , Lib_entry.Library (Option.value_exn (Lib.Local.of_lib lib)) )
               :: acc )
-          | Dune_file.Deprecated_library_name d ->
-            ( d.old_public_name.package.name
+          | Dune_file.Deprecated_library_name
+              ({ old_public_name = { public = old_public_name; _ }; _ } as d)
+            ->
+            ( (Dune_file.Public_lib.package old_public_name).name
             , Lib_entry.Deprecated_library_name d )
             :: acc
           | _ -> acc)


### PR DESCRIPTION
This PR proposes to extend `(deprecated_library name ...)` to allow `old_public_name` to be a top-level library that is not a sub-package of the main package. While it is not possible to define such libraries with `dune`, it is possible to do so using other build systems (e.g. `menhir` does this). The intent of this PR is to help migration of such projects to `dune`.

The syntax to redirect a top-level library `foo` belonging to a package `p` to `bar` is
```
(deprecated_library_name
 (old_public_name foo)
 (package p)
 (new_public_name bar))
```
Suggestions for a better syntax are welcome!

**There is one subtlety though.** Suppose by way of example that we have a legacy project `p` with a top-level library `mylib` (main module: `MyLib`) that we are porting to `dune`. Naturally we will now give the library the name `mylib` (since it has to match the name of the main module) and public name `p.mylib`. 
```
(library
 (name mylib)
 (public_name p.mylib))
```
In order to maintain backwards compatibility we would like to do:
```
(deprecated_library_name
 (old_public_name mylib)
 (package p)
 (new_public_name p.mylib))
```
The problem is that `dune` will complain that there are two definitions of the library `mylib` (one for each stanza).

The last commit ("Fix (?) ...") tries to fix this issue, it seems to work fine, but am not 100% sure about its implications and would appreciate a second opinion.