### PR TITLE
Remove File_tree.fold

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1183,9 +1183,10 @@ and get_rule t path =
       [ Pp.textf "File unavailable: %s" (Path.to_string_maybe_quoted path) ]
 
 let all_targets t =
+  let root = File_tree.root () in
   String.Map.to_list t.contexts
   |> List.fold_left ~init:Path.Build.Set.empty ~f:(fun acc (_, ctx) ->
-         File_tree.fold ~traverse:Sub_dirs.Status.Set.all ~init:acc
+         File_tree.Dir.fold root ~traverse:Sub_dirs.Status.Set.all ~init:acc
            ~f:(fun dir acc ->
              match
                load_dir

--- a/src/dune/dune_load.ml
+++ b/src/dune/dune_load.ml
@@ -206,7 +206,7 @@ let load ~ancestor_vcs () =
   File_tree.init Path.Source.root ~ancestor_vcs
     ~recognize_jbuilder_projects:false;
   let projects =
-    File_tree.fold
+    File_tree.Dir.fold (File_tree.root ())
       ~traverse:{ data_only = false; vendored = true; normal = true } ~init:[]
       ~f:(fun dir acc ->
         let p = File_tree.Dir.project dir in

--- a/src/dune/file_tree.ml
+++ b/src/dune/file_tree.ml
@@ -393,8 +393,6 @@ let get =
 
 let root () = get ()
 
-let fold ~traverse ~init ~f = Dir.fold (get ()) ~traverse ~init ~f
-
 let rec find_dir t = function
   | [] -> Some t
   | comp :: components ->

--- a/src/dune/file_tree.mli
+++ b/src/dune/file_tree.mli
@@ -69,11 +69,6 @@ val init :
   -> recognize_jbuilder_projects:bool
   -> unit
 
-(** Passing [~traverse_data_only_dirs:true] to this functions causes the whole
-    source tree to be deeply scanned, including ignored sub-trees. *)
-val fold :
-  traverse:Sub_dirs.Status.Set.t -> init:'a -> f:(Dir.t -> 'a -> 'a) -> 'a
-
 val root : unit -> Dir.t
 
 val find_dir : Path.Source.t -> Dir.t option

--- a/src/dune/upgrader.ml
+++ b/src/dune/upgrader.ml
@@ -382,7 +382,8 @@ let upgrade_dir todo dir =
 let upgrade () =
   Dune_project.default_dune_language_version := (1, 0);
   let todo = { to_rename_and_edit = []; to_add = []; to_edit = [] } in
-  File_tree.fold ~traverse:Sub_dirs.Status.Set.normal_only ~init:()
+  let root = File_tree.root () in
+  File_tree.Dir.fold root ~traverse:Sub_dirs.Status.Set.normal_only ~init:()
     ~f:(fun dir () -> upgrade_dir todo dir);
   let log fmt = Printf.ksprintf Console.print fmt in
   List.iter todo.to_edit ~f:(fun (fn, s) ->


### PR DESCRIPTION
This function is just as a helper function that is bloating the API. We have decided to move to a more spartan API by default.