### PR TITLE
Re-implement File_tree on top of memoization

### DIFF
--- a/src/dune/file_tree.ml
+++ b/src/dune/file_tree.ml
@@ -27,8 +27,6 @@ module File = struct
 
     let to_dyn _ = Dyn.opaque
   end)
-
-  let of_source_path p = of_stats (Path.stat (Path.source p))
 end
 
 module Dune_file = struct
@@ -76,6 +74,8 @@ module Readdir : sig
     ; dirs : (string * Path.Source.t * File.t) list
     }
 
+  val to_dyn : t -> Dyn.t
+
   val of_source_path : Path.Source.t -> (t, Unix.error) Result.t
 end = struct
   type t =
@@ -83,7 +83,7 @@ end = struct
     ; dirs : (string * Path.Source.t * File.t) list
     }
 
-  let _to_dyn { files; dirs } =
+  let to_dyn { files; dirs } =
     let open Dyn.Encoder in
     record
       [ ("files", String.Set.to_dyn files)
@@ -139,25 +139,41 @@ end = struct
       |> Result.ok
 end
 
-module Dir = struct
+module Dir0 = struct
+  module Contents = struct
+    type t =
+      { files : String.Set.t
+      ; sub_dirs : (Sub_dirs.Status.t * Readdir.t) String.Map.t
+      ; dune_file : Dune_file.t option
+      }
+
+    let create ~files ~sub_dirs ~dune_file = { files; sub_dirs; dune_file }
+
+    let to_dyn { files; sub_dirs; dune_file } =
+      let open Dyn.Encoder in
+      record
+        [ ("files", String.Set.to_dyn files)
+        ; ( "sub_dirs"
+          , String.Map.to_dyn
+              (pair Sub_dirs.Status.to_dyn Readdir.to_dyn)
+              sub_dirs )
+        ; ("dune_file", Dyn.Encoder.(option opaque dune_file))
+        ; ("project", Dyn.opaque)
+        ]
+  end
+
   type t =
     { path : Path.Source.t
     ; status : Sub_dirs.Status.t
-    ; contents : contents Lazy.t
+    ; contents : Contents.t
     ; project : Dune_project.t
     ; vcs : Vcs.t option
-    }
-
-  and contents =
-    { files : String.Set.t
-    ; sub_dirs : t String.Map.t
-    ; dune_file : Dune_file.t option
     }
 
   let create ~project ~path ~status ~contents ~vcs =
     { path; status; contents; project; vcs }
 
-  let contents t = Lazy.force t.contents
+  let contents t = t.contents
 
   let path t = t.path
 
@@ -188,30 +204,12 @@ module Dir = struct
       ~f:(fun s _ acc ->
         Path.Source.Set.add acc (Path.Source.relative t.path s))
 
-  let rec fold t ~traverse ~init:acc ~f =
-    let must_traverse = Sub_dirs.Status.Map.find traverse t.status in
-    if must_traverse then
-      let acc = f t acc in
-      String.Map.fold (sub_dirs t) ~init:acc ~f:(fun t acc ->
-          fold t ~traverse ~init:acc ~f)
-    else
-      acc
-
-  let rec dyn_of_contents { files; sub_dirs; dune_file } =
-    let open Dyn in
-    Record
-      [ ("files", String.Set.to_dyn files)
-      ; ("sub_dirs", String.Map.to_dyn to_dyn sub_dirs)
-      ; ("dune_file", Dyn.Encoder.(option opaque dune_file))
-      ; ("project", Dyn.opaque)
-      ]
-
-  and to_dyn { path; status; contents = (lazy contents); project = _; vcs } =
+  let to_dyn { path; status; contents; project = _; vcs } =
     let open Dyn in
     Record
       [ ("path", Path.Source.to_dyn path)
       ; ("status", Sub_dirs.Status.to_dyn status)
-      ; ("contents", dyn_of_contents contents)
+      ; ("contents", Contents.to_dyn contents)
       ; ("vcs", Dyn.Encoder.option Vcs.to_dyn vcs)
       ]
 
@@ -222,7 +220,17 @@ module Dir = struct
     { project; path; status; vcs; contents = lazy empty_contents }
 end
 
-module Settings = struct
+module Settings : sig
+  type t =
+    { root : Path.Source.t
+    ; ancestor_vcs : Vcs.t option
+    ; recognize_jbuilder_projects : bool
+    }
+
+  val set : t -> unit
+
+  val get : unit -> t
+end = struct
   type t =
     { root : Path.Source.t
     ; ancestor_vcs : Vcs.t option
@@ -238,82 +246,31 @@ module Settings = struct
       ]
 
   let t = Fdecl.create to_dyn
+
+  let set = Fdecl.set t
+
+  let get () =
+    let (_ : Memo.Run.t) = Memo.current_run () in
+    Fdecl.get t
 end
 
-let get_vcs ~default:vcs ~path ~files ~dirs =
-  match
-    match
-      List.find_map dirs ~f:(fun (name, _, _) -> Vcs.Kind.of_filename name)
-    with
-    | Some kind -> Some kind
-    | None -> Vcs.Kind.of_dir_contents files
-  with
-  | Some kind -> Some { Vcs.kind; root = Path.(append_source root) path }
-  | None -> vcs
-
 let init root ~ancestor_vcs ~recognize_jbuilder_projects =
-  Fdecl.set Settings.t
-    { Settings.root; ancestor_vcs; recognize_jbuilder_projects }
+  Settings.set { Settings.root; ancestor_vcs; recognize_jbuilder_projects }
 
-let make_root
-    { Settings.root = path; ancestor_vcs; recognize_jbuilder_projects } =
-  let open Result.O in
-  let rec walk path ~dirs_visited ~project:parent_project ~vcs
-      ~(dir_status : Sub_dirs.Status.t) { Readdir.dirs; files } =
-    let project =
-      if dir_status = Data_only then
-        parent_project
-      else
-        Option.value
-          (Dune_project.load ~dir:path ~files
-             ~infer_from_opam_files:recognize_jbuilder_projects)
-          ~default:parent_project
-    in
-    let vcs = get_vcs ~default:vcs ~dirs ~files ~path in
-    let contents =
-      lazy
-        (let dune_file, sub_dirs =
-           if dir_status = Data_only then
-             (None, Sub_dirs.default)
-           else if
-             (not recognize_jbuilder_projects)
-             && String.Set.mem files Dune_file.jbuild_fname
-           then
-             User_error.raise
-               ~loc:
-                 (Loc.in_file
-                    (Path.source
-                       (Path.Source.relative path Dune_file.jbuild_fname)))
-               [ Pp.text
-                   "jbuild files are no longer supported, please convert this \
-                    file to a dune file instead."
-               ; Pp.text
-                   "Note: You can use \"dune upgrade\" to convert your \
-                    project to dune."
-               ]
-           else if not (String.Set.mem files Dune_file.fname) then
-             (None, Sub_dirs.default)
-           else (
-             ignore
-               ( Dune_project.ensure_project_file_exists project
-                 : Dune_project.created_or_already_exist );
-             let file = Path.Source.relative path Dune_file.fname in
-             let dune_file, sub_dirs = Dune_file.load file ~project in
-             (Some dune_file, sub_dirs)
-           )
-         in
-         let sub_dirs =
-           get_sub_dirs ~project ~dirs ~sub_dirs ~dir_status ~dirs_visited ~vcs
-         in
-         { Dir.files; sub_dirs; dune_file })
-    in
-    Dir.create ~path ~contents ~status:dir_status ~project ~vcs
-  and get_sub_dirs ~vcs ~project ~dirs ~sub_dirs ~dir_status ~dirs_visited =
+module rec Memoized : sig
+  val root : unit -> Dir0.t
+
+  val find_dir : Path.Source.t -> Dir0.t option
+end = struct
+  (* This function will read the contents of sub directories. This is because
+     we want to exclude directory names that are unreadable from being
+     processed by callers *)
+  let get_sub_dirs ~dirs ~sub_dirs ~(dir_status : Sub_dirs.Status.t) =
     let sub_dirs =
       Sub_dirs.eval sub_dirs ~dirs:(List.map ~f:(fun (a, _, _) -> a) dirs)
     in
     dirs
-    |> List.fold_left ~init:String.Map.empty ~f:(fun acc (fn, path, file) ->
+    |> List.fold_left ~init:String.Map.empty ~f:(fun acc (fn, path, _file) ->
            let status =
              if Bootstrap.data_only_path path then
                Sub_dirs.Status.Or_ignored.Ignored
@@ -329,92 +286,175 @@ let make_root
                | Vendored, Normal -> Vendored
                | _, _ -> status
              in
-             let dirs_visited =
-               if Sys.win32 then
-                 dirs_visited
-               else
-                 match File.Map.find dirs_visited file with
-                 | None -> File.Map.set dirs_visited file path
-                 | Some first_path ->
-                   User_error.raise
-                     [ Pp.textf
-                         "Path %s has already been scanned. Cannot scan it \
-                          again through symlink %s"
-                         (Path.Source.to_string_maybe_quoted first_path)
-                         (Path.Source.to_string_maybe_quoted path)
-                     ]
-             in
-             let dir =
-               match
-                 let+ x = Readdir.of_source_path path in
-                 walk path ~dirs_visited ~project ~dir_status ~vcs x
-               with
-               | Ok dir -> dir
-               | Error _ -> Dir.empty ~vcs ~project ~path ~status
-             in
-             String.Map.set acc fn dir)
-  in
-  let walk =
-    let+ x = Readdir.of_source_path path in
-    let project =
-      match
-        Dune_project.load ~dir:path ~files:x.files ~infer_from_opam_files:true
-      with
-      | None -> Dune_project.anonymous ~dir:path
-      | Some p -> p
+             match Readdir.of_source_path path with
+             | Ok dir -> String.Map.set acc fn (dir_status, dir)
+             | Error _ -> acc ))
+
+  let contents { Readdir.dirs; files } ~project ~path
+      ~(dir_status : Sub_dirs.Status.t) =
+    let recognize_jbuilder_projects =
+      let settings = Settings.get () in
+      settings.recognize_jbuilder_projects
     in
-    walk path
-      ~dirs_visited:(File.Map.singleton (File.of_source_path path) path)
-      ~dir_status:Normal ~project ~vcs:ancestor_vcs x
-  in
-  match walk with
-  | Ok dir -> dir
-  | Error m ->
-    User_error.raise
-      [ Pp.textf "Unable to load source %s.@.Reason:%s@."
-          (Path.Source.to_string_maybe_quoted path)
-          (Unix.error_message m)
-      ]
+    let dune_file, sub_dirs =
+      if dir_status = Data_only then
+        (None, Sub_dirs.default)
+      else if
+        (not recognize_jbuilder_projects)
+        && String.Set.mem files Dune_file.jbuild_fname
+      then
+        User_error.raise
+          ~loc:
+            (Loc.in_file
+               (Path.source (Path.Source.relative path Dune_file.jbuild_fname)))
+          [ Pp.text
+              "jbuild files are no longer supported, please convert this file \
+               to a dune file instead."
+          ; Pp.text
+              "Note: You can use \"dune upgrade\" to convert your project to \
+               dune."
+          ]
+      else if not (String.Set.mem files Dune_file.fname) then
+        (None, Sub_dirs.default)
+      else (
+        ignore
+          ( Dune_project.ensure_project_file_exists project
+            : Dune_project.created_or_already_exist );
+        let file = Path.Source.relative path Dune_file.fname in
+        let dune_file, sub_dirs = Dune_file.load file ~project in
+        (Some dune_file, sub_dirs)
+      )
+    in
+    let sub_dirs = get_sub_dirs ~dirs ~sub_dirs ~dir_status in
+    Dir0.Contents.create ~files ~sub_dirs ~dune_file
 
-let get =
-  let memo =
-    Memo.create "file-tree" ~doc:"file tree"
-      ~input:(module Unit)
-      ~visibility:Memo.Visibility.Hidden
-      ~output:(Simple (module Dir))
-      Sync
-      (fun () ->
-        let (_ : Memo.Run.t) = Memo.current_run () in
-        make_root (Fdecl.get Settings.t))
-  in
-  Memo.exec memo
+  let root =
+    let f () =
+      let settings = Settings.get () in
+      let path = settings.root in
+      let dir_status : Sub_dirs.Status.t = Normal in
+      let readdir =
+        match Readdir.of_source_path path with
+        | Ok dir -> dir
+        | Error m ->
+          User_error.raise
+            [ Pp.textf "Unable to load source %s.@.Reason:%s@."
+                (Path.Source.to_string_maybe_quoted path)
+                (Unix.error_message m)
+            ]
+      in
+      let project =
+        match
+          Dune_project.load ~dir:path ~files:readdir.files
+            ~infer_from_opam_files:true
+        with
+        | None -> Dune_project.anonymous ~dir:path
+        | Some p -> p
+      in
+      let vcs = settings.ancestor_vcs in
+      let contents = contents readdir ~project ~path ~dir_status in
+      Dir0.create ~project ~path ~status:dir_status ~contents ~vcs
+    in
+    let memo =
+      Memo.create "file-tree-root" ~doc:"file tree root"
+        ~input:(module Unit)
+        ~output:(Simple (module Dir0))
+        ~visibility:Memo.Visibility.Hidden Sync f
+    in
+    Memo.exec memo
 
-let root () = get ()
+  let get_vcs ~default:vcs ~path ~readdir:{ Readdir.files; dirs } =
+    match
+      match
+        List.find_map dirs ~f:(fun (name, _, _) -> Vcs.Kind.of_filename name)
+      with
+      | Some kind -> Some kind
+      | None -> Vcs.Kind.of_dir_contents files
+    with
+    | None -> vcs
+    | Some kind -> Some { Vcs.kind; root = Path.(append_source root) path }
 
-let rec find_dir t = function
-  | [] -> Some t
-  | comp :: components ->
-    let open Option.O in
-    let* t = String.Map.find (Dir.sub_dirs t) comp in
+  let make_subdir =
+    let module Input = struct
+      type t = Dir0.t * Sub_dirs.Status.t * Readdir.t * string
+
+      let hash ((dir : Dir0.t), _, _, s) =
+        Tuple.T2.hash Path.Source.hash String.hash (dir.path, s)
+
+      let to_dyn (dir, status, readdir, name) =
+        let open Dyn.Encoder in
+        record
+          [ ("dir", Dir0.to_dyn dir)
+          ; ("status", Sub_dirs.Status.to_dyn status)
+          ; ("readdir", Readdir.to_dyn readdir)
+          ; ("name", String.to_dyn name)
+          ]
+
+      let equal ((d1, _, _, n1) : t) ((d2, _, _, n2) : t) =
+        Path.Source.equal d1.path d2.path && String.equal n1 n2
+    end in
+    let f
+        ( (parent : Dir0.t)
+        , (dir_status : Sub_dirs.Status.t)
+        , (readdir : Readdir.t)
+        , name ) =
+      let path = Path.Source.relative parent.path name in
+      let settings = Settings.get () in
+      let project =
+        if dir_status = Data_only then
+          parent.project
+        else
+          Option.value
+            (Dune_project.load ~dir:path ~files:readdir.files
+               ~infer_from_opam_files:settings.recognize_jbuilder_projects)
+            ~default:parent.project
+      in
+      let vcs = get_vcs ~default:parent.vcs ~readdir ~path in
+      let contents = contents readdir ~project ~path ~dir_status in
+      Dir0.create ~project ~path ~status:dir_status ~contents ~vcs
+    in
+    let memo =
+      Memo.create "make_subdir" ~doc:"make_subdir"
+        ~input:(module Input)
+        ~output:(Simple (module Dir0))
+        ~visibility:Memo.Visibility.Hidden Sync f
+    in
+    fun parent (dir_status, readdir) name ->
+      Memo.exec memo (parent, dir_status, readdir, name)
+
+  let rec find_dir t = function
+    | [] -> Some t
+    | comp :: components ->
+      let open Option.O in
+      let* subdir = String.Map.find (Dir0.sub_dirs t) comp in
+      let subdir = make_subdir t subdir comp in
+      find_dir subdir components
+
+  let find_dir path =
+    let t = root () in
+    let components = Path.Source.explode path in
     find_dir t components
+end
 
-let find_dir path =
-  let t = get () in
-  let components = Path.Source.explode path in
-  find_dir t components
+let root () = Memoized.root ()
+
+let find_dir path = Memoized.find_dir path
 
 let rec nearest_dir t = function
   | [] -> t
   | comp :: components -> (
-    match String.Map.find (Dir.sub_dirs t) comp with
+    match String.Map.find (Dir0.sub_dirs t) comp with
     | None -> t
-    | Some t -> nearest_dir t components )
+    | Some _ ->
+      let path = Path.Source.relative (Dir0.path t) comp in
+      let dir = Option.value_exn (find_dir path) in
+      nearest_dir dir components )
 
 let nearest_dir path =
   let components = Path.Source.explode path in
-  nearest_dir (get ()) components
+  nearest_dir (root ()) components
 
-let nearest_vcs path = Dir.vcs (nearest_dir path)
+let nearest_vcs path = Dir0.vcs (nearest_dir path)
 
 let files_of path =
   match find_dir path with
@@ -422,18 +462,41 @@ let files_of path =
   | Some dir ->
     Path.Source.Set.of_list
       (List.map
-         (String.Set.to_list (Dir.files dir))
+         (String.Set.to_list (Dir0.files dir))
          ~f:(Path.Source.relative path))
 
 let file_exists path =
   match find_dir (Path.Source.parent_exn path) with
   | None -> false
-  | Some dir -> String.Set.mem (Dir.files dir) (Path.Source.basename path)
+  | Some dir -> String.Set.mem (Dir0.files dir) (Path.Source.basename path)
 
 let dir_exists path = Option.is_some (find_dir path)
 
 let dir_is_vendored path =
-  Option.map ~f:(fun dir -> Dir.vendored dir) (find_dir path)
+  Option.map ~f:(fun dir -> Dir0.vendored dir) (find_dir path)
+
+module Dir = struct
+  include Dir0
+
+  let rec fold t ~traverse ~init:acc ~f =
+    let must_traverse = Sub_dirs.Status.Map.find traverse t.status in
+    if must_traverse then
+      let acc = f t acc in
+      String.Map.foldi (sub_dirs t) ~init:acc ~f:(fun dirname _ acc ->
+          let dir =
+            let subdir = Path.Source.relative t.path dirname in
+            Option.value_exn (Memoized.find_dir subdir)
+          in
+          fold dir ~traverse ~init:acc ~f)
+    else
+      acc
+
+  let sub_dirs (t : t) =
+    t.contents.sub_dirs
+    |> String.Map.mapi ~f:(fun name (_, _) ->
+           let path = Path.Source.relative t.path name in
+           Option.value_exn (find_dir path))
+end
 
 let fold_with_progress ~traverse ~init ~f =
   let root = root () in

--- a/test/blackbox-tests/test-cases/github764/run.t
+++ b/test/blackbox-tests/test-cases/github764/run.t
@@ -10,8 +10,8 @@
   $ cd c2/a && ln -s ../b x
   $ cd c2/b && ln -s ../a x
   $ cd c2 && dune build
-  Error: Path a has already been scanned. Cannot scan it again through symlink
-  a/x/x
+  Error: Path b has already been scanned. Cannot scan it again through symlink
+  a/x
   [1]
 
   $ mkdir symlink-outside-root
@@ -27,8 +27,8 @@
   $ cd symlink-outside-root2/other/b && ln -s ../a x
   $ cd symlink-outside-root2/root && ln -s ../other src
   $ cd symlink-outside-root2/root && dune build
-  Error: Path src/a has already been scanned. Cannot scan it again through
-  symlink src/a/x/x
+  Error: Path src/b has already been scanned. Cannot scan it again through
+  symlink src/a/x
   [1]
 
   $ mkdir -p symlink-outside-root3/root


### PR DESCRIPTION
Instead of generating a lazy file system tree, functions which read a
directory are memoized.

This PR is by no means done, and I realize that we need `Memo.Cell.t` before it's really usable but I'd like to push through anyway not to lose the progress I've made a couple of weeks ago.

There are three things left to do:

~Implement `Memo.Cell.t` will be done in a separate PR at first~ <- This one will be done separately.

- [x] Fix cycle detection.

- [x] Add progress reporting (of directories scanned).


The last two points I need some advice on. IIRC, there was a suggestion to have a memoized function `val dirs_visited : Path.t -> File.Set.t`, but I'm not entirely sure how that's going to work. 