### PR TITLE
Cache: don't choke on symlinks.

### DIFF
--- a/src/dune_manager/dune_manager.ml
+++ b/src/dune_manager/dune_manager.ml
@@ -320,7 +320,8 @@ let client_thread (events, client) =
             handle_cmd client cmd
           with
           | Result.Error e ->
-            Log.infof "%s: command error: %s" (peer_name client.peer) e
+            Log.infof "%s: command error: %s" (peer_name client.peer) e;
+            handle client
           | Result.Ok client -> handle client )
       in
       handle client

--- a/src/dune_manager/dune_manager.ml
+++ b/src/dune_manager/dune_manager.ml
@@ -321,7 +321,7 @@ let client_thread (events, client) =
           with
           | Result.Error e ->
             Log.infof "%s: command error: %s" (peer_name client.peer) e
-          | Result.Ok client -> (handle [@tailcall]) client )
+          | Result.Ok client -> handle client )
       in
       handle client
     and finally () =

--- a/src/dune_manager/dune_manager.ml
+++ b/src/dune_manager/dune_manager.ml
@@ -469,6 +469,9 @@ module Client = struct
       Result.Error (Printf.sprintf "invalid command: %s" (Sexp.to_string exp))
 
   let make ?finally handle =
+    (* This is a bit ugly as it is global, but flushing a closed socket will
+       nuke the program if we don't. *)
+    let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore in
     let open Result.O in
     let* memory = Result.map_error ~f:err (Dune_memory.make ()) in
     let* port =
@@ -528,14 +531,17 @@ module Client = struct
         [ Sexp.List [ Sexp.Atom "repo"; Sexp.Atom (string_of_int idx) ] ]
       | None -> []
     in
-    send client.socket
-      (Sexp.List
-         ( Sexp.Atom "promote"
-         :: Sexp.List [ Sexp.Atom "key"; Sexp.Atom key ]
-         :: Sexp.List (Sexp.Atom "files" :: List.map ~f paths)
-         :: Sexp.List [ Sexp.Atom "metadata"; Sexp.List metadata ]
-         :: repo ));
-    Result.Ok ()
+    try
+      send client.socket
+        (Sexp.List
+           ( Sexp.Atom "promote"
+           :: Sexp.List [ Sexp.Atom "key"; Sexp.Atom key ]
+           :: Sexp.List (Sexp.Atom "files" :: List.map ~f paths)
+           :: Sexp.List [ Sexp.Atom "metadata"; Sexp.List metadata ]
+           :: repo ));
+      Result.Ok ()
+    with Sys_error (* "Broken_pipe" *) _ ->
+      Result.Error "lost connection to cache daemon"
 
   let set_build_dir client path =
     send client.socket
@@ -548,6 +554,7 @@ module Client = struct
   let search client key = Dune_memory.Memory.search client.memory key
 
   let teardown client =
-    Unix.shutdown client.fd Unix.SHUTDOWN_SEND;
+    ( try Unix.shutdown client.fd Unix.SHUTDOWN_SEND
+      with Unix.Unix_error (Unix.ENOTCONN, _, _) -> () );
     Thread.join client.thread
 end

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -263,6 +263,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name dune-cache-symlink)
+ (deps (package dune) (source_tree test-cases/dune-cache-symlink))
+ (action
+  (chdir
+   test-cases/dune-cache-symlink
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name dune-init)
  (deps (package dune) (source_tree test-cases/dune-init))
  (action
@@ -1839,6 +1847,7 @@
   (alias dune-build-dir-exec-1101)
   (alias dune-cache-dedup)
   (alias dune-cache-promote)
+  (alias dune-cache-symlink)
   (alias dune-init)
   (alias dune-jbuild-var-case)
   (alias dune-package)
@@ -2054,6 +2063,7 @@
   (alias dune-build-dir-exec-1101)
   (alias dune-cache-dedup)
   (alias dune-cache-promote)
+  (alias dune-cache-symlink)
   (alias dune-init)
   (alias dune-jbuild-var-case)
   (alias dune-package)

--- a/test/blackbox-tests/test-cases/dune-cache-symlink/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache-symlink/run.t
@@ -1,0 +1,23 @@
+Check that while we refuse to cache symlinks, subsequent promotions still work.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >   (deps source)
+  >   (targets link)
+  >   (action (bash "ln -s source link")))
+  > (rule
+  >   (deps link)
+  >   (targets target)
+  >   (action (bash "cat link link > target")))
+  > EOF
+  $ cat > source <<EOF
+  > \_o< COIN
+  > EOF
+  $ env DUNE_CACHE=1 DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target
+  $ ./stat.sh --format=%h _build/default/source
+  2
+  $ ./stat.sh --format=%h _build/default/target
+  2

--- a/test/blackbox-tests/test-cases/dune-cache-symlink/stat.sh
+++ b/test/blackbox-tests/test-cases/dune-cache-symlink/stat.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+stat="stat"
+uname=$(uname -s)
+if [ "$uname" == "Darwin" ]; then
+    stat="gstat"
+fi;
+$stat $@


### PR DESCRIPTION
Although we refuse symlinks, keep caching. Improve resilience to the caching socket getting dropped.