### PR TITLE
Accept manipulating build paths when the build dir is not set.

### DIFF
--- a/src/dune_manager/dune_manager.ml
+++ b/src/dune_manager/dune_manager.ml
@@ -342,6 +342,7 @@ let client_thread (events, client) =
       (Dyn.pp (Code_error.to_dyn e))
 
 let run ?(port_f = ignore) ?(port = 0) manager =
+  let () = Path.Build.reset_build_dir () in
   let rec accept_thread sock =
     let rec accept () =
       try Unix.accept sock

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -720,7 +720,8 @@ module Build = struct
         | In_source_dir p -> Local.Prefix.make p
         | External _ -> Local.Prefix.invalid
     and reset_build_dir () =
-      build_dir := Kind.In_source_dir (Local.of_string ".")
+      build_dir := Kind.In_source_dir (Local.of_string ".");
+      build_dir_prefix := Local.Prefix.invalid
     in
     let build_dir () = !build_dir in
     let build_dir_prefix () = !build_dir_prefix in

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -164,9 +164,11 @@ module Build : sig
     val of_string : string -> t
   end
 
-  (** set the build directory. Can only be called once and must be done before
-      paths are converted to strings elsewhere. *)
+  (** set the build directory *)
   val set_build_dir : Kind.t -> unit
+
+  (** reset to no build dir, making all build path relative paths *)
+  val reset_build_dir : unit -> unit
 
   val split_sandbox_root : t -> t option * t
 


### PR DESCRIPTION
The point of this change is to enable to use all the `Path` variants even if the build root is not set. In this case, build path are considered as relative paths. While we could store the build root as a an option, every access then becomes `if not set -> use "."`, so using "." as the default seems equivalent and simpler.