### PR TITLE
Handle pkg-config from external toolchain

### DIFF
--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -562,7 +562,18 @@ module Pkg_config = struct
     }
 
   let get c =
-    Option.map (which c "pkg-config") ~f:(fun pkg_config ->
+    let pkg_config =
+      match
+        let (>>=) = Option.bind in
+        ocaml_config_var c "c_compiler" >>=
+        Filename.chop_suffix_opt ~suffix:"gcc" >>= fun pfx ->
+        let fn = pfx ^ "pkg-config" in
+        Option.some_if (Sys.file_exists fn) fn
+      with
+      | Some _ as s -> s
+      | None -> which c "pkg-config"
+    in
+    Option.map pkg_config ~f:(fun pkg_config ->
         { pkg_config; configurator = c })
 
   type package_conf =


### PR DESCRIPTION
This is a patch to Configurator for use with cross-compilation

This probably shouldn't be merged as is, but is something I needed
while attempting cross-compilation (using
https://github.com/ocaml-cross/opam-cross-windows and a C toolchain
provided by MXE)

In this case, the toolchain is defined by a variable _e.g._
`TOOLPREF64=xxx/x86_64-w64-mingw32.shared-`, which means that the
cross-compiling `gcc` will be found with this prefix, _i.e._
`xxx/x86_64-w64-mingw32.shared-gcc`.

My issue was that `pkg-config` should also be used from this
toolchain, which wasn't the case. Without any better source of
information about the toolchain, I just stripped the `gcc` suffix from
the `c_compiler` ocaml config var... hopefully there may be a cleaner
way. But well, this worked.