### PR TITLE
Configurator: fix noisy empty compiler command-line arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -152,6 +152,8 @@
 
 - Do not setup rules for disabled libraries (#2491, fixes #2272, @bobot)
 
+- Configurator: filter out empty flags from `pkg-config` (#2716, @AltGr)
+
 1.11.4 (09/10/2019)
 -------------------
 

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -631,7 +631,7 @@ module Pkg_config = struct
             (Process.run_capture_exn c ~dir ?env t.pkg_config [ what; package ])
         with
         | "" -> []
-        | s -> String.split s ~on:' '
+        | s -> String.extract_blank_separated_words s
       in
       Ok { libs = run "--libs"; cflags = run "--cflags" }
     else


### PR DESCRIPTION
I encountered cases where `pkg-config` answered with multiple
consecutive spaces. The built-in split function doesn't clean them up,
and this led to bogus empty-string arguments in the compilation commands.

This just filters them out ; maybe the use-cases of the split function
should be checked to see if it should already do this cleanup (I know
there are almost as many varieties of string splitting functions as
snowlfakes, but they generally tend to do that cleanup ;) )