### PR TITLE
Remove hack that was added just for bootstrap

### DIFF
--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -1,10 +1,5 @@
 open! Stdune
 
-(* HACK Otherwise ocamldep doesn't detect this module in bootstrap *)
-let () =
-  let module M = Sub_system_info in
-  ()
-
 module Vfile = Dune_lang.Versioned_file.Make (struct
   type t = unit
 end)


### PR DESCRIPTION
Bootstrap was fixed to properly account for dependencies in the mli

I'm making this a PR mostly just to make sure it doesn't break in CI.