### PR TITLE
Add %{ccomp_type} for enabled_if

### DIFF
--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -426,6 +426,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; natdynlink_supported =
           Dynlink_supported.By_the_os.of_bool natdynlink_supported
       ; stdlib_dir
+      ; ccomp_type = Ocaml_config.ccomp_type ocfg
       }
     in
     let t =

--- a/src/dune/lib_config.ml
+++ b/src/dune/lib_config.ml
@@ -11,6 +11,7 @@ type t =
   ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
+  ; ccomp_type : string
   }
 
 let var_map =
@@ -18,9 +19,15 @@ let var_map =
   ; ("system", fun t -> t.system)
   ; ("model", fun t -> t.model)
   ; ("os_type", fun t -> t.os_type)
+  ; ("ccomp_type", fun t -> t.ccomp_type)
   ]
 
-let allowed_in_enabled_if = List.map ~f:fst var_map
+let allowed_in_enabled_if =
+  let f = function
+  | "ccomp_type", _ -> ("ccomp_type", (2, 0))
+  | s, _ -> (s, (1, 10))
+  in
+    List.map ~f var_map
 
 let get_for_enabled_if t ~var =
   match List.assoc var_map var with

--- a/src/dune/lib_config.mli
+++ b/src/dune/lib_config.mli
@@ -11,8 +11,9 @@ type t =
   ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
+  ; ccomp_type : string
   }
 
-val allowed_in_enabled_if : string list
+val allowed_in_enabled_if : (string * Dune_lang.Syntax.Version.t) list
 
 val get_for_enabled_if : t -> var:string -> string

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -182,7 +182,7 @@ let renamed_in t ver ~to_ =
     let+ loc, what = desc () in
     Error.renamed_in loc t ver ~what ~to_
 
-let since ?(fatal = true) t ver =
+let since ?(desc = desc) ?(fatal = true) t ver =
   let open Version.Infix in
   let* current_ver = get_exn t in
   if current_ver >= ver then

--- a/src/dune_lang/syntax.mli
+++ b/src/dune_lang/syntax.mli
@@ -88,7 +88,12 @@ val renamed_in : t -> Version.t -> to_:string -> (unit, _) Decoder.parser
 (** Indicate the field/constructor being parsed was introduced in the given
     version. When [fatal] is false, simply emit a warning instead of error.
     [fatal] defaults to true. *)
-val since : ?fatal:bool -> t -> Version.t -> (unit, _) Decoder.parser
+val since :
+     ?desc:(unit -> (Stdune.Loc.t * string, 'a) Decoder.parser)
+  -> ?fatal:bool
+  -> t
+  -> Version.t
+  -> (unit, 'a) Decoder.parser
 
 (** {2 Low-level functions} *)
 


### PR DESCRIPTION
It's possible, but slightly, dirty, to infer this from other variables which are available.

I moved the validation of `Lib_config` variables into the parser - apologies for anything heinous I've done with the monads 🙂 