### PR TITLE
Report progress only in dune_load or upgraded

### DIFF
--- a/src/dune/dune_load.ml
+++ b/src/dune/dune_load.ml
@@ -206,7 +206,7 @@ let load ~ancestor_vcs () =
   File_tree.init Path.Source.root ~ancestor_vcs
     ~recognize_jbuilder_projects:false;
   let projects =
-    File_tree.Dir.fold (File_tree.root ())
+    File_tree.fold_with_progress
       ~traverse:{ data_only = false; vendored = true; normal = true } ~init:[]
       ~f:(fun dir acc ->
         let p = File_tree.Dir.project dir in

--- a/src/dune/file_tree.mli
+++ b/src/dune/file_tree.mli
@@ -71,6 +71,10 @@ val init :
 
 val root : unit -> Dir.t
 
+(** Traverse starting from the root and report progress in the status line *)
+val fold_with_progress :
+  traverse:Sub_dirs.Status.Set.t -> init:'a -> f:(Dir.t -> 'a -> 'a) -> 'a
+
 val find_dir : Path.Source.t -> Dir.t option
 
 (** [nearest_dir t fn] returns the directory with the longest path that is an

--- a/src/dune/upgrader.ml
+++ b/src/dune/upgrader.ml
@@ -382,9 +382,8 @@ let upgrade_dir todo dir =
 let upgrade () =
   Dune_project.default_dune_language_version := (1, 0);
   let todo = { to_rename_and_edit = []; to_add = []; to_edit = [] } in
-  let root = File_tree.root () in
-  File_tree.Dir.fold root ~traverse:Sub_dirs.Status.Set.normal_only ~init:()
-    ~f:(fun dir () -> upgrade_dir todo dir);
+  File_tree.fold_with_progress ~traverse:Sub_dirs.Status.Set.normal_only
+    ~init:() ~f:(fun dir () -> upgrade_dir todo dir);
   let log fmt = Printf.ksprintf Console.print fmt in
   List.iter todo.to_edit ~f:(fun (fn, s) ->
       log "Upgrading %s...\n" (Path.Source.to_string_maybe_quoted fn);


### PR DESCRIPTION
I added a specialized folding function that will be the only one to report progress. This implementation is completely memoization agnostic and should work with the memoized code without modification.

This is slightly different from what we talked about but seems like an even simpler way of solving the problem. In this case, we'll be reporting the progress even in polling mode but if anything that is an improvement.