### PR TITLE
Remove Ocaml_flags.get_for_cm and add map_common

### DIFF
--- a/src/dune/module_compilation.ml
+++ b/src/dune/module_compilation.ml
@@ -128,7 +128,7 @@ let build_cm cctx ~dep_graphs ~precompiled_cmi ~cm_kind (m : Module.t) =
       (ctx.build_dir, As [])
   in
   let flags =
-    let flags = Ocaml_flags.get_for_cm (CC.flags cctx) ~cm_kind in
+    let flags = Ocaml_flags.get (CC.flags cctx) mode in
     match Module.pp_flags m with
     | None -> flags
     | Some pp ->
@@ -204,7 +204,7 @@ let ocamlc_i ?(flags = []) ~dep_graphs cctx (m : Module.t) ~output =
       List.concat_map deps ~f:(fun m ->
           [ Path.build (Obj_dir.Module.cm_file_unsafe obj_dir m ~kind:Cmi) ]))
   in
-  let ocaml_flags = Ocaml_flags.get_for_cm (CC.flags cctx) ~cm_kind:Cmo in
+  let ocaml_flags = Ocaml_flags.get (CC.flags cctx) Mode.Byte in
   let modules = Compilation_context.modules cctx in
   SC.add_rule sctx ~sandbox ~dir
     (Build.action_dyn ~targets:[ output ]

--- a/src/dune/ocaml_flags.ml
+++ b/src/dune/ocaml_flags.ml
@@ -111,21 +111,18 @@ let get t mode =
   and+ specific = Mode.Dict.get t.specific mode in
   common @ specific
 
-let get_for_cm t ~cm_kind = get t (Mode.of_cm_kind cm_kind)
+let map_common t ~f =
+  let common =
+    let+ l = t.common in
+    f l
+  in
+  { t with common }
 
 let append_common t flags =
-  { t with
-    common =
-      (let+ l = t.common in
-       l @ flags)
-  }
+  map_common t ~f:(fun l -> l @ flags)
 
 let prepend_common flags t =
-  { t with
-    common =
-      (let+ l = t.common in
-       flags @ l)
-  }
+  map_common t ~f:(fun l -> flags @ l)
 
 let with_vendored_warnings t = append_common t vendored_warnings
 

--- a/src/dune/ocaml_flags.mli
+++ b/src/dune/ocaml_flags.mli
@@ -29,8 +29,6 @@ val of_list : string list -> t
 
 val get : t -> Mode.t -> string list Build.t
 
-val get_for_cm : t -> cm_kind:Cm_kind.t -> string list Build.t
-
 val append_common : t -> string list -> t
 
 val prepend_common : string list -> t -> t


### PR DESCRIPTION
* [Ocaml_flags.get_for_cm] is redunant
* The `*_common` functions are easily implemented via map_common

I'm a bit on the fence for removing `*_common` entirely.