### PR TITLE
Add alias field to rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+2.1.0 (unreleased)
+----------------
+
+- Introduce `alias` and `package` fields to the `rule` stanza. This is the
+  preferred way of attaching rules to aliases. (#2744, @rgrinberg)
+
 2.0.0 (unreleased)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -795,6 +795,12 @@ See the :ref:`user-actions` section for more details.
 - ``(locks (<lock-names>))`` specify that the action must be run while
   holding the following locks. See the :ref:`locks` section for more details.
 
+- ``(alias <alias-name>)`` specify the alias this rule belongs to. Building this
+  alias means building the targets of this rule.
+
+- ``(package <package>)`` specify the package this rule belongs to. This rule
+  will be unavailable when installing other packages in release mode.
+
 Note that contrary to makefiles or other build systems, user rules currently
 don't support patterns, such as a rule to produce ``%.y`` from ``%.x`` for any
 given ``%``. This might be supported in the future.

--- a/src/dune/config.ml
+++ b/src/dune/config.ml
@@ -31,6 +31,8 @@ let inside_emacs = Option.is_some (Env.get Env.initial "INSIDE_EMACS")
 
 let inside_dune = Option.is_some (Env.get Env.initial "INSIDE_DUNE")
 
+let () = Dune_lang.Syntax.inside_dune := inside_dune
+
 let inside_ci = Option.is_some (Env.get Env.initial "CI")
 
 let show_full_command_on_error () =

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1794,10 +1794,10 @@ module Rule = struct
           | false, None -> Ok Standard)
     and+ enabled_if = enabled_if ~since:(Some (1, 4))
     and+ package = field_o "package"
-                     (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Pkg.decode)
+                     (Dune_lang.Syntax.since Stanza.syntax (2, 1) >>> Pkg.decode)
     and+ alias =
       field_o "alias"
-        (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Alias.Name.decode)
+        (Dune_lang.Syntax.since Stanza.syntax (2, 1) >>> Alias.Name.decode)
     in
     { targets; deps; action; mode; locks; loc; enabled_if; alias; package }
 

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1793,8 +1793,9 @@ module Rule = struct
           | true, None -> Ok Fallback
           | false, None -> Ok Standard)
     and+ enabled_if = enabled_if ~since:(Some (1, 4))
-    and+ package = field_o "package"
-                     (Dune_lang.Syntax.since Stanza.syntax (2, 1) >>> Pkg.decode)
+    and+ package =
+      field_o "package"
+        (Dune_lang.Syntax.since Stanza.syntax (2, 1) >>> Pkg.decode)
     and+ alias =
       field_o "alias"
         (Dune_lang.Syntax.since Stanza.syntax (2, 1) >>> Alias.Name.decode)

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1708,6 +1708,7 @@ module Rule = struct
     ; loc : Loc.t
     ; enabled_if : Blang.t
     ; alias : Alias.Name.t option
+    ; package : Package.t option
     }
 
   type action_or_field =
@@ -1756,6 +1757,7 @@ module Rule = struct
     ; loc
     ; enabled_if = Blang.true_
     ; alias = None
+    ; package = None
     }
 
   let long_form =
@@ -1791,11 +1793,13 @@ module Rule = struct
           | true, None -> Ok Fallback
           | false, None -> Ok Standard)
     and+ enabled_if = enabled_if ~since:(Some (1, 4))
+    and+ package = field_o "package"
+                     (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Pkg.decode)
     and+ alias =
       field_o "alias"
         (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Alias.Name.decode)
     in
-    { targets; deps; action; mode; locks; loc; enabled_if; alias }
+    { targets; deps; action; mode; locks; loc; enabled_if; alias; package }
 
   let decode =
     peek_exn
@@ -1867,6 +1871,7 @@ module Rule = struct
         ; loc
         ; enabled_if
         ; alias = None
+        ; package = None
         })
 
   let ocamlyacc_to_rule loc { modules; mode; enabled_if } =
@@ -1892,6 +1897,7 @@ module Rule = struct
         ; loc
         ; enabled_if
         ; alias = None
+        ; package = None
         })
 end
 
@@ -2393,6 +2399,7 @@ end
 let stanza_package = function
   | Library { public = Some { package; _ }; _ }
   | Alias { package = Some package; _ }
+  | Rule { package = Some package; _ }
   | Install { package; _ }
   | Executables { install_conf = Some { package; _ }; _ }
   | Documentation { package; _ }

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1707,6 +1707,7 @@ module Rule = struct
     ; locks : String_with_vars.t list
     ; loc : Loc.t
     ; enabled_if : Blang.t
+    ; alias : Alias.Name.t option
     }
 
   type action_or_field =
@@ -1754,6 +1755,7 @@ module Rule = struct
     ; locks = []
     ; loc
     ; enabled_if = Blang.true_
+    ; alias = None
     }
 
   let long_form =
@@ -1788,8 +1790,12 @@ module Rule = struct
           | false, Some mode -> Ok mode
           | true, None -> Ok Fallback
           | false, None -> Ok Standard)
-    and+ enabled_if = enabled_if ~since:(Some (1, 4)) in
-    { targets; deps; action; mode; locks; loc; enabled_if }
+    and+ enabled_if = enabled_if ~since:(Some (1, 4))
+    and+ alias =
+      field_o "alias"
+        (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Alias.Name.decode)
+    in
+    { targets; deps; action; mode; locks; loc; enabled_if; alias }
 
   let decode =
     peek_exn
@@ -1860,6 +1866,7 @@ module Rule = struct
         ; locks = []
         ; loc
         ; enabled_if
+        ; alias = None
         })
 
   let ocamlyacc_to_rule loc { modules; mode; enabled_if } =
@@ -1884,6 +1891,7 @@ module Rule = struct
         ; locks = []
         ; loc
         ; enabled_if
+        ; alias = None
         })
 end
 

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -369,6 +369,7 @@ module Rule : sig
     ; loc : Loc.t
     ; enabled_if : Blang.t
     ; alias : Alias.Name.t option
+    ; package : Package.t option
     }
 end
 

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -368,6 +368,7 @@ module Rule : sig
     ; locks : String_with_vars.t list
     ; loc : Loc.t
     ; enabled_if : Blang.t
+    ; alias : Alias.Name.t option
     }
 end
 

--- a/src/dune/simple_rules.ml
+++ b/src/dune/simple_rules.ml
@@ -15,13 +15,8 @@ module Alias_rules = struct
     let dir = Alias.dir alias in
     SC.add_alias_action sctx alias ~dir ~loc ~locks ~stamp build
 
-  let add_empty sctx ~loc ~expander ~alias ~deps ~stamp =
-    let action =
-      let open Build.O in
-      SC.Deps.interpret_named sctx ~expander deps
-      |> Build.ignore
-      >>> Build.progn []
-    in
+  let add_empty sctx ~loc ~alias ~stamp =
+    let action = Build.return (Action.Progn []) in
     add sctx ~loc ~alias ~stamp action
 end
 
@@ -89,8 +84,7 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
         let stamp =
           Alias_rules.stamp ~deps:rule.deps ~action ~extra_bindings
         in
-        Alias_rules.add_empty sctx ~alias ~loc:(Some rule.loc) ~deps:rule.deps
-          ~expander ~stamp);
+        Alias_rules.add_empty sctx ~alias ~loc:(Some rule.loc) ~stamp);
     Path.Build.Set.empty
   | true -> (
     let targets : Expander.Targets.t =
@@ -187,9 +181,7 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
   in
   let loc = Some alias_conf.loc in
   match Expander.eval_blang expander alias_conf.enabled_if with
-  | false ->
-    Alias_rules.add_empty sctx ~loc ~expander ~alias ~deps:alias_conf.deps
-      ~stamp
+  | false -> Alias_rules.add_empty sctx ~loc ~alias ~stamp
   | true ->
     let locks = interpret_locks ~expander alias_conf.locks in
     let action =

--- a/src/dune/simple_rules.ml
+++ b/src/dune/simple_rules.ml
@@ -84,6 +84,7 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
         in
         let stamp_target = Path.Build.relative dir stamp in
         let () =
+          (* TODO do not add stamp_target to alias expansion *)
           let alias = Alias.make alias ~dir in
           let deps = Path.Set.singleton (Path.build stamp_target) in
           Rules.Produce.Alias.add_deps alias deps

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -244,20 +244,18 @@ let chdir_to_build_context_root t build =
       | Chdir _ -> action
       | _ -> Chdir (Path.build t.context.build_dir, action))
 
-let add_rule t ?sandbox ?mode ?locks ?loc ~dir build =
+let make_rule t ?sandbox ?mode ?locks ?loc ~dir build =
   let build = chdir_to_build_context_root t build in
   let env = Env.external_ t.env_context ~dir in
-  Rules.Produce.rule
-    (Rule.make ?sandbox ?mode ?locks ~info:(Rule.Info.of_loc_opt loc)
-       ~context:(Some t.context) ~env:(Some env) build)
+  Rule.make ?sandbox ?mode ?locks ~info:(Rule.Info.of_loc_opt loc)
+    ~context:(Some t.context) ~env:(Some env) build
+
+let add_rule t ?sandbox ?mode ?locks ?loc ~dir build =
+  let rule = make_rule t ?sandbox ?mode ?locks ?loc ~dir build in
+  Rules.Produce.rule rule
 
 let add_rule_get_targets t ?sandbox ?mode ?locks ?loc ~dir build =
-  let build = chdir_to_build_context_root t build in
-  let env = Env.external_ t.env_context ~dir in
-  let rule =
-    Rule.make ?sandbox ?mode ?locks ~info:(Rule.Info.of_loc_opt loc)
-      ~context:(Some t.context) ~env:(Some env) build
-  in
+  let rule = make_rule t ?sandbox ?mode ?locks ?loc ~dir build in
   Rules.Produce.rule rule;
   rule.targets
 

--- a/src/dune/test_rules.ml
+++ b/src/dune/test_rules.ml
@@ -60,6 +60,7 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
           ; loc
           ; enabled_if = t.enabled_if
           ; alias = None
+          ; package = t.package
           }
         in
         add_alias ~loc ~action:(Diff diff) ~locks:t.locks;

--- a/src/dune/test_rules.ml
+++ b/src/dune/test_rules.ml
@@ -59,6 +59,7 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
           ; locks = t.locks
           ; loc
           ; enabled_if = t.enabled_if
+          ; alias = None
           }
         in
         add_alias ~loc ~action:(Diff diff) ~locks:t.locks;

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -43,6 +43,8 @@ module Version = struct
     parser_major = data_major && parser_minor >= data_minor
 end
 
+let inside_dune = ref false
+
 module Supported_versions = struct
   type t = int Int.Map.t
 
@@ -54,7 +56,7 @@ module Supported_versions = struct
 
   let is_supported t (major, minor) =
     match Int.Map.find t major with
-    | Some minor' -> minor' >= minor
+    | Some minor' -> minor' >= minor || !inside_dune
     | None -> false
 
   let supported_ranges t =

--- a/src/dune_lang/syntax.mli
+++ b/src/dune_lang/syntax.mli
@@ -101,3 +101,5 @@ val set : t -> Version.t -> ('a, 'k) Decoder.parser -> ('a, 'k) Decoder.parser
 val get_exn : t -> (Version.t, 'k) Decoder.parser
 
 val key : t -> Version.t Univ_map.Key.t
+
+val inside_dune : bool ref

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -878,6 +878,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (alias
+ (name github2681)
+ (deps (package dune) (source_tree test-cases/github2681))
+ (action
+  (chdir
+   test-cases/github2681
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name github534)
  (deps (package dune) (source_tree test-cases/github534))
  (action
@@ -1985,6 +1993,7 @@
   (alias github25)
   (alias github2584)
   (alias github2629)
+  (alias github2681)
   (alias github534)
   (alias github568)
   (alias github597)
@@ -2205,6 +2214,7 @@
   (alias github25)
   (alias github2584)
   (alias github2629)
+  (alias github2681)
   (alias github534)
   (alias github568)
   (alias github597)

--- a/test/blackbox-tests/test-cases/github2681/run.t
+++ b/test/blackbox-tests/test-cases/github2681/run.t
@@ -1,0 +1,23 @@
+A rule may have an alias field. This denotes that the action of the rule is a
+dependency of the alias.
+  $ mkdir simple && cd simple
+  $ cat > dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >  (action (with-stdout-to foo (echo "hello world")))
+  >  (alias bar))
+  > EOF
+  $ dune build @bar --display short
+  File "dune", line 2, characters 9-50:
+  2 |  (action (with-stdout-to foo (echo "hello world")))
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Rule has targets in different directories.
+  Targets:
+  - _build/.aliases/default/bar-fc3cef760337ee5dd7a56722c8e58053
+  - _build/default/foo
+  [1]
+  $ cat _build/default/foo
+  cat: _build/default/foo: No such file or directory
+  [1]

--- a/test/blackbox-tests/test-cases/github2681/run.t
+++ b/test/blackbox-tests/test-cases/github2681/run.t
@@ -10,8 +10,15 @@ dependency of the alias.
   >  (alias bar))
   > EOF
   $ dune build @bar --display short
+  File "dune", line 3, characters 1-12:
+  3 |  (alias bar))
+       ^^^^^^^^^^^
+  Error: 'alias' is only available since version 2.1 of the dune language.
+  Please update your dune-project file to have (lang 2.1).
+  [1]
   $ cat _build/default/foo
-  hello world
+  cat: _build/default/foo: No such file or directory
+  [1]
   $ cd ..
 
 A rule may now have an empty set of targets if it has an alias field
@@ -25,4 +32,9 @@ A rule may now have an empty set of targets if it has an alias field
   >  (alias bar))
   > EOF
   $ dune build @bar --display short
-  hello world
+  File "dune", line 3, characters 1-12:
+  3 |  (alias bar))
+       ^^^^^^^^^^^
+  Error: 'alias' is only available since version 2.1 of the dune language.
+  Please update your dune-project file to have (lang 2.1).
+  [1]

--- a/test/blackbox-tests/test-cases/github2681/run.t
+++ b/test/blackbox-tests/test-cases/github2681/run.t
@@ -12,3 +12,17 @@ dependency of the alias.
   $ dune build @bar --display short
   $ cat _build/default/foo
   hello world
+  $ cd ..
+
+A rule may now have an empty set of targets if it has an alias field
+  $ mkdir no-targets && cd no-targets
+  $ cat > dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >  (action (echo "hello world"))
+  >  (alias bar))
+  > EOF
+  $ dune build @bar --display short
+  hello world

--- a/test/blackbox-tests/test-cases/github2681/run.t
+++ b/test/blackbox-tests/test-cases/github2681/run.t
@@ -10,14 +10,5 @@ dependency of the alias.
   >  (alias bar))
   > EOF
   $ dune build @bar --display short
-  File "dune", line 2, characters 9-50:
-  2 |  (action (with-stdout-to foo (echo "hello world")))
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Rule has targets in different directories.
-  Targets:
-  - _build/.aliases/default/bar-fc3cef760337ee5dd7a56722c8e58053
-  - _build/default/foo
-  [1]
   $ cat _build/default/foo
-  cat: _build/default/foo: No such file or directory
-  [1]
+  hello world

--- a/test/blackbox-tests/test-cases/github2681/run.t
+++ b/test/blackbox-tests/test-cases/github2681/run.t
@@ -2,7 +2,7 @@ A rule may have an alias field. This denotes that the action of the rule is a
 dependency of the alias.
   $ mkdir simple && cd simple
   $ cat > dune-project <<EOF
-  > (lang dune 2.0)
+  > (lang dune 2.1)
   > EOF
   $ cat > dune <<EOF
   > (rule
@@ -10,21 +10,14 @@ dependency of the alias.
   >  (alias bar))
   > EOF
   $ dune build @bar --display short
-  File "dune", line 3, characters 1-12:
-  3 |  (alias bar))
-       ^^^^^^^^^^^
-  Error: 'alias' is only available since version 2.1 of the dune language.
-  Please update your dune-project file to have (lang 2.1).
-  [1]
   $ cat _build/default/foo
-  cat: _build/default/foo: No such file or directory
-  [1]
+  hello world
   $ cd ..
 
 A rule may now have an empty set of targets if it has an alias field
   $ mkdir no-targets && cd no-targets
   $ cat > dune-project <<EOF
-  > (lang dune 2.0)
+  > (lang dune 2.1)
   > EOF
   $ cat > dune <<EOF
   > (rule
@@ -32,9 +25,4 @@ A rule may now have an empty set of targets if it has an alias field
   >  (alias bar))
   > EOF
   $ dune build @bar --display short
-  File "dune", line 3, characters 1-12:
-  3 |  (alias bar))
-       ^^^^^^^^^^^
-  Error: 'alias' is only available since version 2.1 of the dune language.
-  Please update your dune-project file to have (lang 2.1).
-  [1]
+  hello world


### PR DESCRIPTION
## Aliases for 2.0 check list:

### This PR

- [x] `rule` supports `alias` from `2.0`
- [x] rules no longer need a set of targets if there's an `alias` field.

### Upcoming PR's

- [ ] Using `action` in `alias` should be deprecated in 1.x. This deprecation warning will be quite annoying given that we have no way to silence it.
- [ ] Disallow using `action` in alias entirely for >= 2.0.
- [x] Allow for `pacakge` on rules.