### PR TITLE
Attempt to address #2295

### DIFF
--- a/src/dune/compilation_context.ml
+++ b/src/dune/compilation_context.ml
@@ -117,36 +117,10 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
     Sandbox_config.no_sandboxing
   in
   let modes =
-    let modes =
-      let default =
-        Mode.Dict.make_both (Some Dune_file.Mode_conf.Kind.Inherited)
-      in
-      Option.value ~default modes
-    in
-    let init = Mode.Dict.map ~f:Option.is_some modes in
-    match Lazy.force requires_link with
-    (* TODO it doesn't matter that we are assigning dummy modes here since
-       we'll get an error anyway *)
-    | Error _ -> init
-    | Ok libs ->
-      List.iter libs ~f:(fun lib ->
-          let info = Lib.info lib in
-          let lib_modes = Lib_info.modes info in
-          Mode.Dict.iteri modes ~f:(fun mode available ->
-              match available with
-              | None
-              | Some Dune_file.Mode_conf.Kind.Inherited ->
-                ()
-              | Some (Dune_file.Mode_conf.Kind.Requested loc) ->
-                if not (Mode.Dict.get lib_modes mode) then
-                  let name = Lib_info.name info in
-                  User_error.raise ~loc
-                    [ Pp.textf
-                        "mode %s isn't available. It's not provided in the \
-                         dependency: %s"
-                        (Mode.to_string mode) (Lib_name.to_string name)
-                    ]));
-      init
+    let default =
+      Mode.Dict.make_both (Some Dune_file.Mode_conf.Kind.Inherited) in
+    Option.value ~default modes
+    |> Mode.Dict.map ~f:Option.is_some
   in
   { super_context
   ; scope

--- a/src/dune/compilation_context.ml
+++ b/src/dune/compilation_context.ml
@@ -116,7 +116,12 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
        ocaml_modules/ocamlgraph/src/.graph.objs/byte/graph__Pack.cmi: *)
     Sandbox_config.no_sandboxing
   in
-  let modes = Option.value ~default:Mode.Dict.Set.all modes in
+  let modes =
+    let default =
+      Mode.Dict.make_both (Some Dune_file.Mode_conf.Kind.Inherited) in
+    Option.value ~default modes
+    |> Mode.Dict.map ~f:Option.is_some
+  in
   { super_context
   ; scope
   ; expander

--- a/src/dune/compilation_context.mli
+++ b/src/dune/compilation_context.mli
@@ -27,7 +27,7 @@ val create :
   -> dynlink:bool
   -> package:Package.t option
   -> ?vimpl:Vimpl.t
-  -> ?modes:Mode.Dict.Set.t
+  -> ?modes:Dune_file.Mode_conf.Set.Details.t Mode.Dict.t
   -> unit
   -> t
 

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -721,7 +721,7 @@ module Mode_conf = struct
         else
           None
 
-      let (|||) x y =
+      let ( ||| ) x y =
         if Option.is_some x then
           x
         else
@@ -738,8 +738,7 @@ module Mode_conf = struct
       let get key : Details.t =
         match Map.find t key with
         | None -> None
-        | Some Kind.Inherited ->
-          Option.some_if (exists key) Kind.Inherited
+        | Some Kind.Inherited -> Option.some_if (exists key) Kind.Inherited
         | Some (Kind.Requested loc) ->
           (* TODO always true for now, but we should delay this error *)
           let exists =
@@ -756,14 +755,12 @@ module Mode_conf = struct
       in
       let best = get Best in
       let open Details in
-      let byte = get Byte ||| (validate best ~if_:(best_mode = Byte)) in
-      let native = get Native ||| (validate best ~if_:(best_mode = Native)) in
+      let byte = get Byte ||| validate best ~if_:(best_mode = Byte) in
+      let native = get Native ||| validate best ~if_:(best_mode = Native) in
       { Mode.Dict.byte; native }
 
     let eval t ~has_native =
-      eval_detailed t ~has_native
-      |> Mode.Dict.map ~f:Option.is_some
-
+      eval_detailed t ~has_native |> Mode.Dict.map ~f:Option.is_some
   end
 end
 

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -721,7 +721,7 @@ module Mode_conf = struct
         else
           None
 
-      let ( ||| ) x y =
+      let (|||) x y =
         if Option.is_some x then
           x
         else
@@ -738,7 +738,8 @@ module Mode_conf = struct
       let get key : Details.t =
         match Map.find t key with
         | None -> None
-        | Some Kind.Inherited -> Option.some_if (exists key) Kind.Inherited
+        | Some Kind.Inherited ->
+          Option.some_if (exists key) Kind.Inherited
         | Some (Kind.Requested loc) ->
           (* TODO always true for now, but we should delay this error *)
           let exists =
@@ -755,12 +756,14 @@ module Mode_conf = struct
       in
       let best = get Best in
       let open Details in
-      let byte = get Byte ||| validate best ~if_:(best_mode = Byte) in
-      let native = get Native ||| validate best ~if_:(best_mode = Native) in
+      let byte = get Byte ||| (validate best ~if_:(best_mode = Byte)) in
+      let native = get Native ||| (validate best ~if_:(best_mode = Native)) in
       { Mode.Dict.byte; native }
 
     let eval t ~has_native =
-      eval_detailed t ~has_native |> Mode.Dict.map ~f:Option.is_some
+      eval_detailed t ~has_native
+      |> Mode.Dict.map ~f:Option.is_some
+
   end
 end
 

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -157,6 +157,12 @@ module Mode_conf : sig
     (** Byte inherited, Best is requested *)
     val default : t
 
+    module Details : sig
+      type t = Kind.t option
+    end
+
+    val eval_detailed : t -> has_native:bool -> Details.t Mode.Dict.t
+
     val eval : t -> has_native:bool -> Mode.Dict.Set.t
   end
 end

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -155,7 +155,7 @@ module Mode_conf : sig
     val decode : t Dune_lang.Decoder.t
 
     (** Byte inherited, Best is requested *)
-    val default : t
+    val default : Loc.t -> t
 
     module Details : sig
       type t = Kind.t option

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -91,7 +91,7 @@ end = struct
         else
           []
       in
-      let { Mode.Dict.byte; native } =
+      let { Mode.Dict.byte ; native } =
         Dune_file.Mode_conf.Set.eval lib.modes ~has_native
       in
       let virtual_library = Library.is_virtual lib in

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -91,7 +91,7 @@ end = struct
         else
           []
       in
-      let { Mode.Dict.byte ; native } =
+      let { Mode.Dict.byte; native } =
         Dune_file.Mode_conf.Set.eval lib.modes ~has_native
       in
       let virtual_library = Library.is_virtual lib in

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -15,7 +15,7 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
   let { Lib_config.has_native; ext_obj; ext_dll; ext_lib; _ } =
     ctx.lib_config
   in
-  let { Mode.Dict.byte ; native } =
+  let { Mode.Dict.byte; native } =
     Dune_file.Mode_conf.Set.eval lib.modes ~has_native
   in
   let if_ cond l =

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -15,7 +15,7 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
   let { Lib_config.has_native; ext_obj; ext_dll; ext_lib; _ } =
     ctx.lib_config
   in
-  let { Mode.Dict.byte; native } =
+  let { Mode.Dict.byte ; native } =
     Dune_file.Mode_conf.Set.eval lib.modes ~has_native
   in
   let if_ cond l =

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -385,7 +385,7 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
   in
   let modes =
     let { Lib_config.has_native; _ } = ctx.lib_config in
-    Dune_file.Mode_conf.Set.eval lib.modes ~has_native
+    Dune_file.Mode_conf.Set.eval_detailed lib.modes ~has_native
   in
   Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
     ~modules ~flags ~requires_compile ~requires_link ~preprocessing:pp ~opaque

--- a/src/dune/mode.ml
+++ b/src/dune/mode.ml
@@ -65,6 +65,10 @@ module Dict = struct
 
   let mapi t ~f = { byte = f Byte t.byte; native = f Native t.native }
 
+  let iteri t ~f =
+    f Byte t.byte;
+    f Native t.native
+
   let make_both x = { byte = x; native = x }
 
   let make ~byte ~native = { byte; native }

--- a/src/dune/mode.mli
+++ b/src/dune/mode.mli
@@ -61,6 +61,8 @@ module Dict : sig
 
   val mapi : 'a t -> f:(mode -> 'a -> 'b) -> 'b t
 
+  val iteri : 'a t -> f:(mode -> 'a -> unit) -> unit
+
   val make_both : 'a -> 'a t
 
   val make : byte:'a -> native:'a -> 'a t

--- a/src/dune/virtual_rules.ml
+++ b/src/dune/virtual_rules.ml
@@ -39,8 +39,9 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     add_rule ~loc:(Loc.of_pos __POS__) (Build.symlink ~src ~dst)
   in
   let { Lib_config.has_native; ext_obj; _ } = ctx.lib_config in
-  let { Mode.Dict.byte ; native } =
-    Dune_file.Mode_conf.Set.eval impl.modes ~has_native in
+  let { Mode.Dict.byte; native } =
+    Dune_file.Mode_conf.Set.eval impl.modes ~has_native
+  in
   let copy_obj_file m kind =
     let src = Obj_dir.Module.cm_file_unsafe vlib_obj_dir m ~kind in
     let dst = Obj_dir.Module.cm_file_unsafe impl_obj_dir m ~kind in

--- a/src/dune/virtual_rules.ml
+++ b/src/dune/virtual_rules.ml
@@ -39,9 +39,8 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     add_rule ~loc:(Loc.of_pos __POS__) (Build.symlink ~src ~dst)
   in
   let { Lib_config.has_native; ext_obj; _ } = ctx.lib_config in
-  let { Mode.Dict.byte; native } =
-    Dune_file.Mode_conf.Set.eval impl.modes ~has_native
-  in
+  let { Mode.Dict.byte ; native } =
+    Dune_file.Mode_conf.Set.eval impl.modes ~has_native in
   let copy_obj_file m kind =
     let src = Obj_dir.Module.cm_file_unsafe vlib_obj_dir m ~kind in
     let dst = Obj_dir.Module.cm_file_unsafe impl_obj_dir m ~kind in

--- a/src/dune/virtual_rules.ml
+++ b/src/dune/virtual_rules.ml
@@ -39,7 +39,8 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     add_rule ~loc:(Loc.of_pos __POS__) (Build.symlink ~src ~dst)
   in
   let { Lib_config.has_native; ext_obj; _ } = ctx.lib_config in
-  let modes = Dune_file.Mode_conf.Set.eval impl.modes ~has_native in
+  let { Mode.Dict.byte ; native } =
+    Dune_file.Mode_conf.Set.eval impl.modes ~has_native in
   let copy_obj_file m kind =
     let src = Obj_dir.Module.cm_file_unsafe vlib_obj_dir m ~kind in
     let dst = Obj_dir.Module.cm_file_unsafe impl_obj_dir m ~kind in
@@ -59,8 +60,8 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
       in
       copy_to_obj_dir ~src ~dst );
     if Module.has src ~ml_kind:Impl then (
-      if modes.byte then copy_obj_file src Cmo;
-      if modes.native then (
+      if byte then copy_obj_file src Cmo;
+      if native then (
         copy_obj_file src Cmx;
         let object_file dir =
           Obj_dir.Module.obj_file dir src ~kind:Cmx ~ext:ext_obj

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -1,74 +1,11 @@
   $ dune runtest --force --display short
-  description = "contains \"quotes\""
-  requires = "bytes"
-  archive(byte) = "foobar.cma"
-  archive(native) = "foobar.cmxa"
-  plugin(byte) = "foobar.cma"
-  plugin(native) = "foobar.cmxs"
-  package "baz" (
-    directory = "baz"
-    description = "sub library with modes set to byte"
-    requires = "bytes"
-    archive(byte) = "foobar_baz.cma"
-    archive(native) = "foobar_baz.cmxa"
-    plugin(byte) = "foobar_baz.cma"
-    plugin(native) = "foobar_baz.cmxs"
-  )
-  package "ppd" (
-    directory = "ppd"
-    description = "pp'd with a rewriter"
-    requires = "foobar foobar.baz foobar.runtime-lib2"
-    archive(byte) = "foobar_ppd.cma"
-    archive(native) = "foobar_ppd.cmxa"
-    plugin(byte) = "foobar_ppd.cma"
-    plugin(native) = "foobar_ppd.cmxs"
-  )
-  package "rewriter" (
-    directory = "rewriter"
-    description = "ppx rewriter"
-    requires(ppx_driver) = "foobar foobar.rewriter2"
-    archive(ppx_driver,byte) = "foobar_rewriter.cma"
-    archive(ppx_driver,native) = "foobar_rewriter.cmxa"
-    plugin(ppx_driver,byte) = "foobar_rewriter.cma"
-    plugin(ppx_driver,native) = "foobar_rewriter.cmxs"
-    # This is what dune uses to find out the runtime dependencies of
-    # a preprocessor
-    ppx_runtime_deps = "foobar.baz"
-    # This line makes things transparent for people mixing preprocessors
-    # and normal dependencies
-    requires(-ppx_driver) = "foobar.baz foobar.runtime-lib2"
-    ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
-  )
-  package "rewriter2" (
-    directory = "rewriter2"
-    description = "ppx rewriter expander"
-    requires = "foobar"
-    archive(byte) = "foobar_rewriter2.cma"
-    archive(native) = "foobar_rewriter2.cmxa"
-    plugin(byte) = "foobar_rewriter2.cma"
-    plugin(native) = "foobar_rewriter2.cmxs"
-    # This is what dune uses to find out the runtime dependencies of
-    # a preprocessor
-    ppx_runtime_deps = "foobar.runtime-lib2"
-  )
-  package "runtime-lib2" (
-    directory = "runtime-lib2"
-    description = "runtime library for foobar.rewriter2"
-    requires = ""
-    archive(byte) = "foobar_runtime_lib2.cma"
-    archive(native) = "foobar_runtime_lib2.cmxa"
-    plugin(byte) = "foobar_runtime_lib2.cma"
-    plugin(native) = "foobar_runtime_lib2.cmxs"
-    linkopts(javascript) = "+foobar/foobar_runtime.js
-                            +foobar/foobar_runtime2.js"
-    jsoo_runtime = "foobar_runtime.js foobar_runtime2.js"
-  )
-  package "sub" (
-    directory = "sub"
-    description = "sub library in a sub dir"
-    requires = "bytes"
-    archive(byte) = "foobar_sub.cma"
-    archive(native) = "foobar_sub.cmxa"
-    plugin(byte) = "foobar_sub.cma"
-    plugin(native) = "foobar_sub.cmxs"
-  )
+  File "dune", line 37, characters 0-145:
+  37 | (library
+  38 |  (name foobar_ppd)
+  39 |  (public_name foobar.ppd)
+  40 |  (synopsis "pp'd with a rewriter")
+  41 |  (libraries foobar)
+  42 |  (preprocess (pps foobar_rewriter)))
+  Error: mode native isn't available. It's not provided in the dependency:
+  foobar.baz
+  [1]

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -1,11 +1,74 @@
   $ dune runtest --force --display short
-  File "dune", line 37, characters 0-145:
-  37 | (library
-  38 |  (name foobar_ppd)
-  39 |  (public_name foobar.ppd)
-  40 |  (synopsis "pp'd with a rewriter")
-  41 |  (libraries foobar)
-  42 |  (preprocess (pps foobar_rewriter)))
-  Error: mode native isn't available. It's not provided in the dependency:
-  foobar.baz
-  [1]
+  description = "contains \"quotes\""
+  requires = "bytes"
+  archive(byte) = "foobar.cma"
+  archive(native) = "foobar.cmxa"
+  plugin(byte) = "foobar.cma"
+  plugin(native) = "foobar.cmxs"
+  package "baz" (
+    directory = "baz"
+    description = "sub library with modes set to byte"
+    requires = "bytes"
+    archive(byte) = "foobar_baz.cma"
+    archive(native) = "foobar_baz.cmxa"
+    plugin(byte) = "foobar_baz.cma"
+    plugin(native) = "foobar_baz.cmxs"
+  )
+  package "ppd" (
+    directory = "ppd"
+    description = "pp'd with a rewriter"
+    requires = "foobar foobar.baz foobar.runtime-lib2"
+    archive(byte) = "foobar_ppd.cma"
+    archive(native) = "foobar_ppd.cmxa"
+    plugin(byte) = "foobar_ppd.cma"
+    plugin(native) = "foobar_ppd.cmxs"
+  )
+  package "rewriter" (
+    directory = "rewriter"
+    description = "ppx rewriter"
+    requires(ppx_driver) = "foobar foobar.rewriter2"
+    archive(ppx_driver,byte) = "foobar_rewriter.cma"
+    archive(ppx_driver,native) = "foobar_rewriter.cmxa"
+    plugin(ppx_driver,byte) = "foobar_rewriter.cma"
+    plugin(ppx_driver,native) = "foobar_rewriter.cmxs"
+    # This is what dune uses to find out the runtime dependencies of
+    # a preprocessor
+    ppx_runtime_deps = "foobar.baz"
+    # This line makes things transparent for people mixing preprocessors
+    # and normal dependencies
+    requires(-ppx_driver) = "foobar.baz foobar.runtime-lib2"
+    ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
+  )
+  package "rewriter2" (
+    directory = "rewriter2"
+    description = "ppx rewriter expander"
+    requires = "foobar"
+    archive(byte) = "foobar_rewriter2.cma"
+    archive(native) = "foobar_rewriter2.cmxa"
+    plugin(byte) = "foobar_rewriter2.cma"
+    plugin(native) = "foobar_rewriter2.cmxs"
+    # This is what dune uses to find out the runtime dependencies of
+    # a preprocessor
+    ppx_runtime_deps = "foobar.runtime-lib2"
+  )
+  package "runtime-lib2" (
+    directory = "runtime-lib2"
+    description = "runtime library for foobar.rewriter2"
+    requires = ""
+    archive(byte) = "foobar_runtime_lib2.cma"
+    archive(native) = "foobar_runtime_lib2.cmxa"
+    plugin(byte) = "foobar_runtime_lib2.cma"
+    plugin(native) = "foobar_runtime_lib2.cmxs"
+    linkopts(javascript) = "+foobar/foobar_runtime.js
+                            +foobar/foobar_runtime2.js"
+    jsoo_runtime = "foobar_runtime.js foobar_runtime2.js"
+  )
+  package "sub" (
+    directory = "sub"
+    description = "sub library in a sub dir"
+    requires = "bytes"
+    archive(byte) = "foobar_sub.cma"
+    archive(native) = "foobar_sub.cmxa"
+    plugin(byte) = "foobar_sub.cma"
+    plugin(native) = "foobar_sub.cmxs"
+  )


### PR DESCRIPTION
This is my attempt at fixing 2295 which unfortunately failed. The issue is that my validation against the closure is too eager and breaks existing builds (as shown in the tests).

Moving on, I think the right approach is to stick this validation when we calculate the closure itself. So the closure wouldn't just compute the list of libraries but also which modes its available for:

```
type status =
  | Available
  | Unavailable of Lib.t (* library that doesn't have the closure *)
type closure =
  { closure : Lib.t list Or_exn.t
  ; modes : status Mode.Dict.t
  }
```

@diml does the above sound reasonable?

This PR isn't meant to be merged but I'll cherry pick some useful bits from it to master.

In any case, I don't think we should delay 2.0 for this.