### PR TITLE
Make foreign archives work with sandboxing

### DIFF
--- a/src/dune/lib_file_deps.mli
+++ b/src/dune/lib_file_deps.mli
@@ -5,8 +5,8 @@ module Group : sig
     | Header
 end
 
-(** [file_deps t libs ~files] returns a list of path dependencies for all the
-    files with extension [files] of libraries [libs]. *)
+(** [deps t libs ~files] returns a list of path dependencies for all the files
+    with extension [files] of libraries [libs]. *)
 val deps : Lib.L.t -> groups:Group.t list -> Dep.Set.t
 
 val deps_with_exts : (Lib.t * Group.t list) list -> Dep.Set.t

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -1,6 +1,12 @@
 ----------------------------------------------------------------------------------
 Testsuite for the (foreign_library ...) stanza.
 
+  $ cat >sdune <<'EOF'
+  > #!/usr/bin/env bash
+  > DUNE_SANDBOX=symlink dune "$@"
+  > EOF
+  $ chmod +x sdune
+
 ----------------------------------------------------------------------------------
 * (foreign_library ...) is unavailable before Dune 2.0.
 
@@ -13,7 +19,7 @@ Testsuite for the (foreign_library ...) stanza.
   >  (names add))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "lib/dune", line 1, characters 0-44:
   1 | (foreign_library
   2 |  (language c)
@@ -28,7 +34,7 @@ Testsuite for the (foreign_library ...) stanza.
 
   $ echo "(lang dune 2.0)" > dune-project
 
-  $ dune build
+  $ ./sdune build
   File "lib/dune", line 1, characters 0-44:
   1 | (foreign_library
   2 |  (language c)
@@ -51,7 +57,7 @@ Testsuite for the (foreign_library ...) stanza.
   > value add(value x, value y) { return Val_int(Int_val(x) + Int_val(y)); }
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "lib/dune", line 4, characters 12-15:
   4 |  (names add mul))
                   ^^^
@@ -66,7 +72,7 @@ Testsuite for the (foreign_library ...) stanza.
   > value mul(value x, value y) { return Val_int(Int_val(x) * Int_val(y)); }
   > EOF
 
-  $ dune build
+  $ ./sdune build
 ----------------------------------------------------------------------------------
 * Error message for a missing C++ source file.
 
@@ -87,7 +93,7 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ rm -rf _build
-  $ dune build
+  $ ./sdune build
   File "lib/dune", line 13, characters 8-14:
   13 |  (names config))
                ^^^^^^
@@ -129,9 +135,9 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ rm -rf _build
-  $ dune build
+  $ ./sdune build
 
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   2009
 
   $ (cd _build/default && ocamlrun -I lib main.bc)
@@ -182,9 +188,9 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ rm -rf _build
-  $ dune build
+  $ ./sdune build
 
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   2019
 
   $ (cd _build/default && ocamlrun -I lib main.bc)
@@ -211,7 +217,7 @@ Testsuite for the (foreign_library ...) stanza.
   >  (names config))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "lib/dune", line 12, characters 23-34:
   12 |  (include_dirs headers another/dir)
                               ^^^^^^^^^^^
@@ -239,7 +245,7 @@ Testsuite for the (foreign_library ...) stanza.
   >  (names config))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "lib/dune", line 12, characters 23-37:
   12 |  (include_dirs headers /absolute/path)
                               ^^^^^^^^^^^^^^
@@ -277,7 +283,7 @@ Testsuite for the (foreign_library ...) stanza.
   >  (names config))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "lib/dune", line 6, characters 1-22:
   6 |  (archive_name addmul)
        ^^^^^^^^^^^^^^^^^^^^^
@@ -331,9 +337,9 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ rm -rf _build
-  $ dune build
+  $ ./sdune build
 
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   October 2019
 
   $ (cd _build/default && ocamlrun -I lib main.bc)
@@ -383,7 +389,7 @@ Testsuite for the (foreign_library ...) stanza.
   > let () = Printf.printf "%d %s %d" (day ()) (Calc.month ()) (Calc.calc 1 2 3)
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 1, characters 0-87:
   1 | (executable
   2 |  (name main)
@@ -441,9 +447,9 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ rm -rf _build
-  $ dune build
+  $ ./sdune build
 
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   8 October 2019
 
 ----------------------------------------------------------------------------------
@@ -481,7 +487,7 @@ Testsuite for the (foreign_library ...) stanza.
   >  (modules main))
   > EOF
 
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   8 October 2019
 
 ----------------------------------------------------------------------------------
@@ -547,7 +553,7 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ rm -rf _build
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   Today: 8 October 2019
 
 ----------------------------------------------------------------------------------
@@ -582,6 +588,6 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ rm -rf _build
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   Today: 08 October 2019
   Today: 14 October 2019

--- a/test/blackbox-tests/test-cases/foreign-stubs/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/run.t
@@ -1,6 +1,12 @@
 ----------------------------------------------------------------------------------
 Testsuite for the (foreign_stubs ...) field.
 
+  $ cat >sdune <<'EOF'
+  > #!/usr/bin/env bash
+  > DUNE_SANDBOX=symlink dune "$@"
+  > EOF
+  $ chmod +x sdune
+
 ----------------------------------------------------------------------------------
 * Error when using both (self_build_stubs_archive ...) and (c_names ...) before 2.0.
 
@@ -13,7 +19,7 @@ Testsuite for the (foreign_stubs ...) field.
   >  (self_build_stubs_archive (bar)))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 4, characters 1-33:
   4 |  (self_build_stubs_archive (bar)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +32,7 @@ Testsuite for the (foreign_stubs ...) field.
 
   $ echo "(lang dune 2.0)" > dune-project
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 3, characters 1-14:
   3 |  (c_names foo)
        ^^^^^^^^^^^^^
@@ -43,7 +49,7 @@ Testsuite for the (foreign_stubs ...) field.
   >  (c_names bar))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 3, characters 2-9:
   3 |  (c_names bar))
         ^^^^^^^
@@ -60,7 +66,7 @@ Testsuite for the (foreign_stubs ...) field.
   >  (self_build_stubs_archive (bar)))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 4, characters 1-33:
   4 |  (self_build_stubs_archive (bar)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,7 +84,7 @@ Testsuite for the (foreign_stubs ...) field.
   >  (self_build_stubs_archive (baz)))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 4, characters 2-26:
   4 |  (self_build_stubs_archive (baz)))
         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +101,7 @@ Testsuite for the (foreign_stubs ...) field.
   >  (foreign_archives bar))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 3, characters 36-39:
   3 |  (foreign_stubs (language c) (names foo))
                                           ^^^
@@ -110,7 +116,7 @@ Testsuite for the (foreign_stubs ...) field.
   > value foo(value unit) { return Val_int(9); }
   > EOF
 
-  $ dune build
+  $ ./sdune build
   Error: No rule found for libbar$ext_lib
   [1]
 
@@ -135,9 +141,13 @@ Testsuite for the (foreign_stubs ...) field.
   >  (targets libbar.a)
   >  (deps bar%{ext_obj})
   >  (action (run ar rcs %{targets} %{deps})))
+  > (rule
+  >  (targets dllbar%{ext_dll})
+  >  (deps bar%{ext_obj})
+  >  (action (run %{ocaml-config:c_compiler} -shared -o %{targets} %{deps})))
   > EOF
 
-  $ dune build
+  $ ./sdune build
 
 ----------------------------------------------------------------------------------
 * Error when specifying an (archive_name ...) in (foreign_stubs ...) stanza.
@@ -157,7 +167,7 @@ Testsuite for the (foreign_stubs ...) field.
   >  (action (run ar rcs %{targets} %{deps})))
   > EOF
 
-  $ dune build
+  $ ./sdune build
   File "dune", line 3, characters 16-34:
   3 |  (foreign_stubs (archive_name baz) (language c) (names foo))
                       ^^^^^^^^^^^^^^^^^^
@@ -233,9 +243,9 @@ Testsuite for the (foreign_stubs ...) field.
   > EOF
 
   $ rm -rf _build
-  $ dune build
+  $ ./sdune build
 
-  $ dune exec ./main.exe
+  $ ./sdune exec ./main.exe
   2019
 
   $ (cd _build/default && ocamlrun -I . ./main.bc)
@@ -247,4 +257,4 @@ Testsuite for the (foreign_stubs ...) field.
   $ touch foo.cpp
   $ touch foo.cxx
 
-  $ dune build
+  $ ./sdune build

--- a/test/blackbox-tests/test-cases/foreign-stubs/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/run.t
@@ -141,10 +141,6 @@ Testsuite for the (foreign_stubs ...) field.
   >  (targets libbar.a)
   >  (deps bar%{ext_obj})
   >  (action (run ar rcs %{targets} %{deps})))
-  > (rule
-  >  (targets dllbar%{ext_dll})
-  >  (deps bar%{ext_obj})
-  >  (action (run %{ocaml-config:c_compiler} -shared -o %{targets} %{deps})))
   > EOF
 
   $ ./sdune build


### PR DESCRIPTION
This fixes #2765.

We now run all foreign archive tests with sandboxing.

The rest of the testsuite still has plenty of failures when run with `DUNE_SANDBOX=symlink`.