### PR TITLE
Fix the precedence of homepage, bug_reports per-package fields

### DIFF
--- a/src/dune/opam_create.ml
+++ b/src/dune/opam_create.ml
@@ -109,22 +109,22 @@ let opam_fields project (package : Package.t) =
     Package.Info.superpose (Dune_project.info project) package.Package.info
   in
   let optional_fields =
-    [ ("bug-reports", info.Package.Info.bug_reports)
-    ; ("homepage", info.Package.Info.homepage)
-    ; ("doc", info.Package.Info.documentation)
-    ; ("license", info.Package.Info.license)
+    [ ("bug-reports", Package.Info.bug_reports info)
+    ; ("homepage", Package.Info.homepage info)
+    ; ("doc", Package.Info.documentation info)
+    ; ("license", Package.Info.license info)
     ; ("version", Dune_project.version project)
     ; ( "dev-repo"
       , Option.map
           ~f:(Format.asprintf "%a" Package.Source_kind.pp)
-          info.Package.Info.source )
+          (Package.Info.source info) )
     ]
     |> List.filter_map ~f:(fun (k, v) ->
            Option.map v ~f:(fun v -> (k, string v)))
   in
   let list_fields =
-    [ ("maintainer", info.Package.Info.maintainers)
-    ; ("authors", info.Package.Info.authors)
+    [ ("maintainer", Package.Info.maintainers info)
+    ; ("authors", Package.Info.authors info)
     ]
     |> List.filter_map ~f:(fun (k, v) ->
            match v with

--- a/src/dune/package.ml
+++ b/src/dune/package.ml
@@ -276,6 +276,28 @@ module Info = struct
     ; maintainers : string list option
     }
 
+  let source t = t.source
+
+  let license t = t.license
+
+  let authors t = t.authors
+
+  let homepage t =
+    match (t.homepage, t.source) with
+    | None, Some (Github (user, repo)) ->
+      Some (sprintf "https://github.com/%s/%s" user repo)
+    | s, _ -> s
+
+  let bug_reports t =
+    match (t.bug_reports, t.source) with
+    | None, Some (Github (user, repo)) ->
+      Some (sprintf "https://github.com/%s/%s/issues" user repo)
+    | s, _ -> s
+
+  let documentation t = t.documentation
+
+  let maintainers t = t.maintainers
+
   let empty =
     { source = None
     ; license = None
@@ -330,18 +352,6 @@ module Info = struct
     and+ maintainers =
       field_o "maintainers"
         (Dune_lang.Syntax.since Stanza.syntax (v (1, 10)) >>> repeat string)
-    in
-    let homepage =
-      match (homepage, source) with
-      | None, Some (Github (user, repo)) ->
-        Some (sprintf "https://github.com/%s/%s" user repo)
-      | s, _ -> s
-    in
-    let bug_reports =
-      match (bug_reports, source) with
-      | None, Some (Github (user, repo)) ->
-        Some (sprintf "https://github.com/%s/%s/issues" user repo)
-      | s, _ -> s
     in
     { source
     ; authors

--- a/src/dune/package.mli
+++ b/src/dune/package.mli
@@ -82,15 +82,21 @@ module Source_kind : sig
 end
 
 module Info : sig
-  type t =
-    { source : Source_kind.t option
-    ; license : string option
-    ; authors : string list option
-    ; homepage : string option
-    ; bug_reports : string option
-    ; documentation : string option
-    ; maintainers : string list option
-    }
+  type t
+
+  val source : t -> Source_kind.t option
+
+  val license : t -> string option
+
+  val authors : t -> string list option
+
+  val homepage : t -> string option
+
+  val bug_reports : t -> string option
+
+  val documentation : t -> string option
+
+  val maintainers : t -> string list option
 
   val empty : t
 

--- a/test/blackbox-tests/test-cases/dune-project-meta/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/run.t
@@ -72,7 +72,7 @@ Package information fields can be overriden per-package:
   opam-version: "2.0"
   authors: ["Foo" "Bar"]
   license: "MIT"
-  homepage: "https://github.com/mirage/foo"
+  homepage: "https://my.home.page"
   bug-reports: "https://github.com/mirage/foo/issues"
   depends: [
     "dune" {>= "2.0"}

--- a/test/blackbox-tests/test-cases/dune-project-meta/test-fields-with-override/dune-project
+++ b/test/blackbox-tests/test-cases/dune-project-meta/test-fields-with-override/dune-project
@@ -3,6 +3,7 @@
 (source (github mirage/ocaml-cohttp))
 (license ISC)
 (authors "Anil Madhavapeddy" "Rudi Grinberg")
+(homepage https://my.home.page)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
See https://github.com/ocaml/dune/pull/2774#issuecomment-544378242

This makes it so that global `homepage` and `bug_reports` fields take precedence over the per-package ones, even when they are inferred from the `source` field.