### PR TITLE
Make build-info work in bytecode-only builds (fixes #2777)

### DIFF
--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -482,15 +482,19 @@ module Lib_and_module = struct
              | Lib t -> link_flags t mode
              | Module (obj_dir, m) ->
                Command.Args.S
-                 [ Dep
+                 ( Dep
                      (Obj_dir.Module.cm_file_unsafe obj_dir m
                         ~kind:(Mode.cm_kind mode))
-                 ; Command.Args.Hidden_deps
-                     (Dep.Set.of_files
-                        [ Obj_dir.Module.o_file_unsafe obj_dir m
-                            ~ext_obj:lib_config.ext_obj
-                        ])
-                 ]) )
+                 ::
+                 ( match mode with
+                 | Native ->
+                   [ Command.Args.Hidden_deps
+                       (Dep.Set.of_files
+                          [ Obj_dir.Module.o_file_unsafe obj_dir m
+                              ~ext_obj:lib_config.ext_obj
+                          ])
+                   ]
+                 | Byte -> [] ) )) )
 
     let of_libs l = List.map l ~f:(fun x -> Lib x)
   end

--- a/test/blackbox-tests/test-cases/byte-code-only/run.t
+++ b/test/blackbox-tests/test-cases/byte-code-only/run.t
@@ -1,9 +1,4 @@
   $ env ORIG_PATH="$PATH" PATH="$PWD/ocaml-bin:$PATH" dune build @all --display short
-  File "bin-with-build-info/dune", line 2, characters 7-20:
-  2 |  (name print_version)
-             ^^^^^^^^^^^^^
-  Error: No rule found for
-  bin-with-build-info/.print_version.eobjs/native/build_info__Build_info_data$ext_obj
         ocamlc build-info/.build_info.objs/byte/build_info.{cmi,cmo,cmt}
         ocamlc build-info/build_info.cma
       ocamldep build-info/.build_info.objs/build_info_data.mli.d
@@ -11,14 +6,18 @@
         ocamlc bin-with-build-info/.print_version.eobjs/byte/build_info__Build_info_data.{cmo,cmt}
       ocamldep bin-with-build-info/.print_version.eobjs/print_version.ml.d
         ocamlc bin-with-build-info/.print_version.eobjs/byte/dune__exe__Print_version.{cmi,cmo,cmt}
+        ocamlc bin-with-build-info/print_version.exe
       ocamldep bin/.toto.eobjs/toto.ml.d
         ocamlc bin/.toto.eobjs/byte/dune__exe__Toto.{cmi,cmo,cmt}
         ocamlc bin/toto.bc
       ocamldep src/.foo.objs/foo.ml.d
         ocamlc src/.foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc src/foo.cma
+        ocamlc bin-with-build-info/print_version.bc
         ocamlc bin/toto.exe
-  [1]
+
+  $ _build/default/bin-with-build-info/print_version.exe
+  <version missing>
 
 Check that building a native only executable fails
   $ env ORIG_PATH="$PATH" PATH="$PWD/ocaml-bin:$PATH" dune build --display short native-only/foo.exe


### PR DESCRIPTION
Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>