### PR TITLE
Rename jbuild to Dune/dune/[dune] as appropriate

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -38,7 +38,7 @@ $ make all-supported-ocaml-versions
 - `vendor/` contains dependencies of Dune, that have been vendored
 - `plugin/` contains the API given to `dune` files that are OCaml
   scripts
-- `src/` contains the core of `Dune`
+- `src/` contains the core of Dune
 - `bin/` contains the command line interface
 - `doc/` contains the manual and rules to generate the manual pages
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -196,7 +196,7 @@ module Options_implied_by_dash_p = struct
               {|Ignore stanzas referring to a package that is not in
                       $(b,PACKAGES). $(b,PACKAGES) is a comma-separated list
                       of package names. Note that this has the same effect
-                      as deleting the relevant stanzas from jbuild files.
+                      as deleting the relevant stanzas from dune files.
                       It is mostly meant for releases. During development,
                       it is likely that what you want instead is to
                       build a particular $(b,<package>.install) target.|})

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -13,7 +13,7 @@ let man =
   [ `S "DESCRIPTION"
   ; `P {|Print out the external libraries needed to build the given targets.|}
   ; `P
-      {|The output of $(b,jbuild external-lib-deps @install) should be included
+      {|The output of $(b,dune external-lib-deps @install) should be included
           in what is written in your $(i,<package>.opam) file.|}
   ; `Blocks Common.help_secs
   ]

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -7,7 +7,7 @@ let man =
   [ `S "DESCRIPTION"
   ; `P
       {|$(b,dune upgrade) upgrade all the jbuilder projects
-         in the workspace to dune|}
+         in the workspace to Dune|}
   ; `Blocks Common.help_secs
   ]
 

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -99,7 +99,7 @@ with type configurator := t
 
 module Flags : sig
   (** [write_sexp fname s] writes the list of strings [s] to the file [fname]
-      in an appropriate format so that it can used in jbuild files with
+      in an appropriate format so that it can used in [dune] files with
       [(:include [fname])]. *)
   val write_sexp : string -> string list -> unit
 

--- a/plugin/jbuild_plugin.mli
+++ b/plugin/jbuild_plugin.mli
@@ -1,5 +1,7 @@
 (** API for jbuild plugins *)
 
+(* CR-someday amokhov: rename to [dune_plugin]. *)
+
 module V1 : sig
   (** Current build context *)
   val context : string
@@ -11,10 +13,10 @@ module V1 : sig
   (** Output of [ocamlc -config] for this context *)
   val ocamlc_config : (string * string) list
 
-  (** [send s] send [s] to jbuilder. [s] should be the contents of a jbuild
-      file following the specification described in the manual. *)
+  (** [send s] send [s] to Dune. [s] should be the contents of a [dune] file
+      following the specification described in the manual. *)
   val send : string -> unit
 
-  (** Execute a command and read it's output *)
+  (** Execute a command and read its output *)
   val run_and_read_lines : string -> string list
 end

--- a/src/dune/action_intf.ml
+++ b/src/dune/action_intf.ml
@@ -27,7 +27,7 @@ module type Ast = sig
     | Chdir of path * t
     | Setenv of string * string * t
     (* It's not possible to use a build path here since jbuild supports
-       redirecting to /dev/null. In dune files this is replaced with %{null} *)
+       redirecting to /dev/null. In [dune] files this is replaced with %{null} *)
     | Redirect_out of Outputs.t * target * t
     | Redirect_in of Inputs.t * path * t
     | Ignore of Outputs.t * t

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -1,8 +1,8 @@
 (** Compilation contexts *)
 
-(** jbuild supports two different kind of contexts:
+(** Dune supports two different kind of contexts:
 
-    - the default context, which correspond to the environment jbuild is run,
+    - the default context, which correspond to the environment Dune is run,
     i.e. it takes [ocamlc] and other tools from the [PATH] and the ocamlfind
     configuration where it can find it
 
@@ -14,7 +14,7 @@
     - _build/default for the default context - _build/<switch> for other
     contexts
 
-    jbuild is able to build simultaneously against several contexts. In
+    Dune is able to build simultaneously against several contexts. In
     particular this allow for simple cross-compilation: when an executable
     running on the host is needed, it is obtained by looking in another
     context. *)

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -2,8 +2,8 @@ open! Stdune
 open Import
 open Dune_lang.Decoder
 
-(* This file defines the jbuild types as well as the S-expression syntax for
-   the various supported version of the specification. *)
+(* This file defines Dune types as well as the S-expression syntax for the
+   various supported versions of the specification. *)
 
 (* Deprecated *)
 module Jbuild_version = struct

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -523,7 +523,7 @@ module Stanzas : sig
       The stanzas are parsed in the context of the dune [project].
 
       The syntax [kind] determines whether the expected syntax is the
-      depreciated jbuilder syntax or the version of dune syntax specified by
+      depreciated jbuilder syntax or the version of Dune syntax specified by
       the current [project]. *)
   val parse : file:Path.Source.t -> Dune_project.t -> Dune_lang.Ast.t list -> t
 end

--- a/src/dune/dune_project.ml
+++ b/src/dune/dune_project.ml
@@ -2,12 +2,6 @@ open! Stdune
 open Import
 open Dune_lang.Decoder
 
-module Kind = struct
-  type t =
-    | Dune
-    | Jbuilder
-end
-
 module Name : sig
   type t = private
     | Named of string

--- a/src/dune/dune_project.mli
+++ b/src/dune/dune_project.mli
@@ -3,12 +3,6 @@ open! Stdune
 
 open Import
 
-module Kind : sig
-  type t =
-    | Dune
-    | Jbuilder
-end
-
 module Name : sig
   (** Invariants: - Named s -> s <> "" and s does not contain '.' or '/' -
       Anonymous p -> p is a local path in the source tree *)

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -192,8 +192,8 @@ module DB : sig
 
   val resolve : t -> Loc.t * Lib_name.t -> lib Or_exn.t
 
-  (** Resolve libraries written by the user in a jbuild file. The resulting
-      list of libraries is transitively closed and sorted by order of
+  (** Resolve libraries written by the user in a [dune] file. The resulting
+      list of libraries is transitively closed and sorted by the order of
       dependencies.
 
       This function is for executables stanzas. *)

--- a/src/dune/menhir.ml
+++ b/src/dune/menhir.ml
@@ -33,15 +33,15 @@ module type PARAMS = sig
   val cctx : Compilation_context.t
 
   (* [dir] is the directory inside [_build/<context>/...] where the build
-     happens. If the [(menhir ...)] stanza appears in [src/jbuild], then [dir]
-     is of the form [_build/<context>/src], e.g., [_build/default/src]. *)
+     happens. If the [(menhir ...)] stanza appears in [src/dune], then [dir] is
+     of the form [_build/<context>/src], e.g., [_build/default/src]. *)
   val dir : Path.Build.t
 
   (* [build_dir] is the base directory of the context; we run menhir from this
      directoy to we get correct error paths. *)
   val build_dir : Path.Build.t
 
-  (* [stanza] is the [(menhir ...)] stanza, as found in the [jbuild] file. *)
+  (* [stanza] is the [(menhir ...)] stanza, as found in the [dune] file. *)
 
   val stanza : stanza
 end

--- a/src/dune/modules_field_evaluator.ml
+++ b/src/dune/modules_field_evaluator.ml
@@ -255,7 +255,7 @@ let check_invalid_module_listing ~(buildable : Buildable.t) ~intf_only ~modules
 
 let eval ~modules:(all_modules : Module.Source.t Module_name.Map.t)
     ~buildable:(conf : Buildable.t) ~private_modules ~kind =
-  (* fake modules are modules that doesn't exists but it doesn't matter because
+  (* Fake modules are modules that do not exist but it doesn't matter because
      they are only removed from a set (for jbuild file compatibility) *)
   let fake_modules = ref Module_name.Map.empty in
   let eval = eval ~loc:conf.loc ~fake_modules ~all_modules in

--- a/src/dune/string_with_vars.mli
+++ b/src/dune/string_with_vars.mli
@@ -11,7 +11,7 @@ type t
 
 val compare_no_loc : t -> t -> Ordering.t
 
-(** [loc t] returns the location of [t] — typically, in the jbuild file. *)
+(** [loc t] returns the location of [t] — typically, in the [dune] file. *)
 val loc : t -> Loc.t
 
 val syntax_version : t -> Dune_lang.Syntax.Version.t

--- a/src/dune/sub_system.mli
+++ b/src/dune/sub_system.mli
@@ -1,7 +1,7 @@
 (** Dune sub-systems *)
 
 (** This module allows to define sub-systems. The aim is to define everything
-    related to the sub-system, such as the parser for jbuild files, the
+    related to the sub-system, such as the parser for [dune] files, the
     metadata attached to libraries and the specific rules in one place.
 
     A sub-system is generally split into two sub-systems:
@@ -20,13 +20,19 @@ include module type of struct
   include Sub_system_intf
 end
 
-(** Register a sub-system backend: - connect the parser to the jbuild files
-    parser - connect the metatada generator [M.to_sexp] so that metadata are
-    included in installed [<lib>.dune] files *)
+(** Register a sub-system backend:
+
+    - connect the parser to the [dune] file parser
+
+    - connect the metatada generator [M.to_sexp] so that metadata are included
+    in installed [<lib>.dune] files *)
 module Register_backend (M : Backend) : Registered_backend with type t := M.t
 
-(** Register a sub-system backend: - connect the parser to the jbuild files
-    parser - connect the rule generator to the rule generator for libraries *)
+(** Register a sub-system backend:
+
+    - connect the parser to the [dune] file parser
+
+    - connect the rule generator to the rule generator for libraries *)
 module Register_end_point (M : End_point) : sig end
 
 (** Scan the sub-systems used by the library and generate rules for all of the

--- a/src/dune/sub_system_info.mli
+++ b/src/dune/sub_system_info.mli
@@ -1,7 +1,7 @@
 open Stdune
 
 (** The type of all kind of sub-system information. This type is what we get
-    just after parsing a [jbuild] file. *)
+    just after parsing a [dune] file. *)
 type t = ..
 
 type sub_system = t = ..
@@ -16,13 +16,13 @@ module type S = sig
   (** Name of the sub-system *)
   val name : Sub_system_name.t
 
-  (** Location of the parameters in the jbuild/dune file. *)
+  (** Location of the parameters in the [jbuild] or [dune] file. *)
   val loc : t -> Loc.t
 
-  (** Syntax for jbuild/dune files *)
+  (** Syntax for [jbuild]/[dune] files *)
   val syntax : Dune_lang.Syntax.t
 
-  (** Parse parameters written by the user in jbuid/dune files *)
+  (** Parse parameters written by the user in [jbuild]/[dune] files *)
   val decode : t Dune_lang.Decoder.t
 
   (** Dump the sub-system configuration. This is used to generate dune-package

--- a/src/jbuild_support/string_with_vars.mli
+++ b/src/jbuild_support/string_with_vars.mli
@@ -1,8 +1,8 @@
 open Stdune
 
-(** Upgrade string with variables coming from a jbuild file to one suitable for
-    a dune file. Fail if the [<] variable is found and [allow_first_dep_var] is
-    [true]. *)
+(** Upgrade string with variables coming from a [jbuild] file to one suitable
+    for a [dune] file. Fail if the [<] variable is found and
+    [allow_first_dep_var] is [true]. *)
 val upgrade_to_dune :
      string
   -> loc:Loc.t


### PR DESCRIPTION
Just trying to tidy up comments/docs.

While doing this, I also found some leftover unused bits of code related to `jbuild` files, e.g. see changes to `dune_project.ml`.