### PR TITLE
Add a test exposing a bug in dependency cycle detection

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -2223,7 +2223,6 @@
   (alias output-obj)
   (alias path-variables)
   (alias pkg-config-quoting)
-  (alias ppx-runtime-dependencies)
   (alias preprocess-with-action)
   (alias private-modules)
   (alias project-root)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1373,6 +1373,14 @@
     (diff? run.t run.t.corrected)))))
 
 (alias
+ (name ppx-runtime-dependencies)
+ (deps (package dune) (source_tree test-cases/ppx-runtime-dependencies))
+ (action
+  (chdir
+   test-cases/ppx-runtime-dependencies
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(alias
  (name preprocess-with-action)
  (deps (package dune) (source_tree test-cases/preprocess-with-action))
  (action
@@ -2011,6 +2019,7 @@
   (alias path-variables)
   (alias pkg-config-quoting)
   (alias ppx-rewriter)
+  (alias ppx-runtime-dependencies)
   (alias preprocess-with-action)
   (alias private-modules)
   (alias private-public-overlap)
@@ -2214,6 +2223,7 @@
   (alias output-obj)
   (alias path-variables)
   (alias pkg-config-quoting)
+  (alias ppx-runtime-dependencies)
   (alias preprocess-with-action)
   (alias private-modules)
   (alias project-root)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -146,6 +146,7 @@ let exclusions =
   ; make "install-dry-run" ~external_deps:true
   ; make "install-libdir" ~external_deps:true
   ; make "lint" ~external_deps:true
+  ; make "ppx-runtime-dependecies" ~external_deps:true
   ; make "package-dep" ~external_deps:true
   ; make "merlin-tests" ~external_deps:true
   ; make "use-meta" ~external_deps:true

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -146,7 +146,7 @@ let exclusions =
   ; make "install-dry-run" ~external_deps:true
   ; make "install-libdir" ~external_deps:true
   ; make "lint" ~external_deps:true
-  ; make "ppx-runtime-dependecies" ~external_deps:true
+  ; make "ppx-runtime-dependencies" ~external_deps:true
   ; make "package-dep" ~external_deps:true
   ; make "merlin-tests" ~external_deps:true
   ; make "use-meta" ~external_deps:true

--- a/test/blackbox-tests/test-cases/ppx-runtime-dependencies/ppx.ml
+++ b/test/blackbox-tests/test-cases/ppx-runtime-dependencies/ppx.ml
@@ -1,0 +1,10 @@
+open Ppxlib
+
+let rules =
+  let extension =
+    Extension.declare "get_c" Expression Ast_pattern.__ (fun ~loc ~path:_ _ ->
+        Ast_builder.Default.evar ~loc "C.c")
+  in
+  [ Context_free.Rule.extension extension ]
+
+let () = Ppxlib.Driver.register_transformation "rules" ~rules

--- a/test/blackbox-tests/test-cases/ppx-runtime-dependencies/run.t
+++ b/test/blackbox-tests/test-cases/ppx-runtime-dependencies/run.t
@@ -1,0 +1,140 @@
+----------------------------------------------------------------------------------
+Testing
+
+  $ cat >sdune <<'EOF'
+  > #!/usr/bin/env bash
+  > DUNE_SANDBOX=symlink dune "$@"
+  > EOF
+  $ chmod +x sdune
+
+----------------------------------------------------------------------------------
+* Correct cycle detection
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name a)
+  >  (modules a)
+  >  (libraries b))
+  > (library
+  >  (name b)
+  >  (modules)
+  >  (libraries c))
+  > (library
+  >  (name c)
+  >  (modules c)
+  >  (libraries a))
+  > EOF
+
+  $ cat >a.ml <<EOF
+  > include B
+  > let a = 1
+  > EOF
+
+  $ cat >c.ml <<EOF
+  > include A
+  > let c = 3
+  > EOF
+
+  $ ./sdune build
+  Error: Dependency cycle detected between the following libraries:
+     "a" in _build/default
+  -> "b" in _build/default
+  -> "c" in _build/default
+  -> "a" in _build/default
+  -> required by library "c" in _build/default
+  [1]
+
+----------------------------------------------------------------------------------
+* Incorrect cycle detection due to ppx_runtime_libraries (TODO: fix this bug!)
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.0)
+  > (implicit_transitive_deps true)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name a)
+  >  (modules a)
+  >  (libraries b))
+  > (library
+  >  (name b)
+  >  (kind ppx_rewriter)
+  >  (modules b ppx)
+  >  (libraries ppxlib)
+  >  (ppx_runtime_libraries c))
+  > (library
+  >  (name c)
+  >  (modules c)
+  >  (libraries a))
+  > EOF
+
+  $ mkdir -p bin
+  $ cat >bin/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (preprocess (pps b))
+  >  (modules main))
+  > EOF
+
+  $ cat >a.ml <<EOF
+  > include B
+  > let a = B.b - 1
+  > EOF
+
+  $ cat >b.ml <<EOF
+  > let b = 2
+  > EOF
+
+  $ cat >c.ml <<EOF
+  > include A
+  > let c = A.a + 2
+  > EOF
+
+  $ cat >bin/main.ml <<EOF
+  > let () = Printf.printf "Should print 3: %d\n" [%get_c]
+  > EOF
+
+  $ ./sdune exec bin/main.exe
+  Error: Dependency cycle detected between the following libraries:
+     "a" in _build/default
+  -> "b" in _build/default
+  -> "c" in _build/default
+  -> "a" in _build/default
+  -> required by library "c" in _build/default
+  -> required by executable main in bin/dune:2
+  [1]
+
+----------------------------------------------------------------------------------
+* Make sure our usage of ppx_runtime_libraries is actually correct
+TODO: Delete after fixing the test above
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.0)
+  > (implicit_transitive_deps true)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name a)
+  >  (modules a))
+  > (library
+  >  (name b)
+  >  (kind ppx_rewriter)
+  >  (modules b ppx)
+  >  (libraries ppxlib)
+  >  (ppx_runtime_libraries c))
+  > (library
+  >  (name c)
+  >  (modules c)
+  >  (libraries a))
+  > EOF
+
+  $ cat >a.ml <<EOF
+  > let a = 2 - 1
+  > EOF
+
+  $ ./sdune exec bin/main.exe
+  Should print 3: 3

--- a/test/blackbox-tests/test-cases/ppx-runtime-dependencies/run.t
+++ b/test/blackbox-tests/test-cases/ppx-runtime-dependencies/run.t
@@ -1,50 +1,11 @@
 ----------------------------------------------------------------------------------
-Testing
+Handling ppx_runtime_libraries dependencies correctly
 
   $ cat >sdune <<'EOF'
   > #!/usr/bin/env bash
   > DUNE_SANDBOX=symlink dune "$@"
   > EOF
   $ chmod +x sdune
-
-----------------------------------------------------------------------------------
-* Correct cycle detection
-
-  $ echo "(lang dune 2.0)" > dune-project
-
-  $ cat >dune <<EOF
-  > (library
-  >  (name a)
-  >  (modules a)
-  >  (libraries b))
-  > (library
-  >  (name b)
-  >  (modules)
-  >  (libraries c))
-  > (library
-  >  (name c)
-  >  (modules c)
-  >  (libraries a))
-  > EOF
-
-  $ cat >a.ml <<EOF
-  > include B
-  > let a = 1
-  > EOF
-
-  $ cat >c.ml <<EOF
-  > include A
-  > let c = 3
-  > EOF
-
-  $ ./sdune build
-  Error: Dependency cycle detected between the following libraries:
-     "a" in _build/default
-  -> "b" in _build/default
-  -> "c" in _build/default
-  -> "a" in _build/default
-  -> required by library "c" in _build/default
-  [1]
 
 ----------------------------------------------------------------------------------
 * Incorrect cycle detection due to ppx_runtime_libraries (TODO: fix this bug!)


### PR DESCRIPTION
This test exposes a bug in dependency cycle detection, where `ppx_runtime_libraries` are treated as build dependencies. Hope to find a fix soon.