### PR TITLE
Fix watch mode

### DIFF
--- a/src/dune/file_tree.ml
+++ b/src/dune/file_tree.ml
@@ -232,6 +232,12 @@ end = struct
     ; recognize_jbuilder_projects : bool
     }
 
+  let equal { root; ancestor_vcs; recognize_jbuilder_projects } y =
+    Path.Source.equal root y.root
+    && Option.equal Vcs.equal ancestor_vcs y.ancestor_vcs
+    && Bool.equal recognize_jbuilder_projects y.recognize_jbuilder_projects
+
+
   let to_dyn { root; ancestor_vcs; recognize_jbuilder_projects } =
     let open Dyn.Encoder in
     record
@@ -242,7 +248,13 @@ end = struct
 
   let t = Fdecl.create to_dyn
 
-  let set = Fdecl.set t
+  let set x =
+    match Fdecl.peek t with
+    | None -> Fdecl.set t x
+    | Some x' ->
+      if not (equal x x') then
+        (* The next call will fail, but will give a good error message *)
+        Fdecl.set t x
 
   let get () =
     let (_ : Memo.Run.t) = Memo.current_run () in

--- a/src/dune/vcs.mli
+++ b/src/dune/vcs.mli
@@ -17,6 +17,8 @@ type t =
   ; kind : Kind.t
   }
 
+val equal : t -> t -> bool
+
 val to_dyn : t -> Dyn.t
 
 (** Nice description of the current tip *)

--- a/src/stdune/fdecl.ml
+++ b/src/stdune/fdecl.ml
@@ -22,3 +22,8 @@ let get t =
   match t.state with
   | Unset -> Code_error.raise "Fdecl.get: not set" []
   | Set x -> x
+
+let peek t =
+  match t.state with
+  | Unset -> None
+  | Set x -> Some x

--- a/src/stdune/fdecl.mli
+++ b/src/stdune/fdecl.mli
@@ -16,3 +16,5 @@ val get : 'a t -> 'a
 (** [set t x] set's the value that is returned by [get t] to [x], overwritting
     it in needed *)
 val reset : 'a t -> 'a -> unit
+
+val peek : 'a t -> 'a option


### PR DESCRIPTION
Previously, watch mode was broken because File_tree.init was called more
than once. Now we allow multiple File_tree.init calls as long as they
are called with the same argument.