### PR TITLE
Make [include_dirs] and [extra_deps] work in (foreign_stubs ...)

### DIFF
--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -153,7 +153,6 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       let o_files =
         Foreign_rules.build_o_files ~sctx ~dir ~expander
           ~requires:requires_compile ~dir_contents ~foreign_sources
-          ~extra_flags:Command.Args.empty ~extra_deps:[]
         |> List.map ~f:Path.build
       in
       Check_rules.add_files sctx ~dir o_files;

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -135,7 +135,10 @@ val dll_file :
 (** A foreign source file that has a [path] and all information of the
     corresponnding [Foreign.Stubs.t] declaration. *)
 module Source : sig
-  type t
+  type t =
+    { stubs : Stubs.t
+    ; path : Path.Build.t
+    }
 
   val language : t -> Language.t
 

--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -1,5 +1,54 @@
 open! Stdune
 
+(* Compute command line flags for the [include_dirs] field of [Foreign.Stubs.t]
+   and track all files in specified directories as [Hidden_deps] dependencies. *)
+let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
+  Command.Args.S
+    (List.map stubs.include_dirs ~f:(fun include_dir ->
+         let loc = String_with_vars.loc include_dir
+         and include_dir = Expander.expand_path expander include_dir in
+         match Path.extract_build_context_dir include_dir with
+         | None ->
+           (* TODO: Track files in external directories. *)
+           User_error.raise ~loc
+             [ Pp.textf
+                 "%S is an external directory; dependencies in external \
+                  directories are currently not tracked."
+                 (Path.to_string include_dir)
+             ]
+             ~hints:
+               [ Pp.textf
+                   "You can specify %S as an untracked include directory like \
+                    this:\n\n\
+                   \  (flags -I %s)\n"
+                   (Path.to_string include_dir)
+                   (Path.to_string include_dir)
+               ]
+         | Some (build_dir, source_dir) -> (
+           match File_tree.find_dir source_dir with
+           | None ->
+             User_error.raise ~loc
+               [ Pp.textf "Include directory %S does not exist."
+                   (Path.reach ~from:(Path.build dir) include_dir)
+               ]
+           | Some dir ->
+             Command.Args.S
+               [ A "-I"
+               ; Path include_dir
+               ; Command.Args.S
+                   (File_tree.Dir.fold dir ~traverse:Sub_dirs.Status.Set.all
+                      ~init:[] ~f:(fun t args ->
+                        let dir =
+                          Path.append_source build_dir (File_tree.Dir.path t)
+                        in
+                        let deps =
+                          Dep.Set.singleton
+                            (Dep.file_selector
+                               (File_selector.create ~dir Predicate.true_))
+                        in
+                        Command.Args.Hidden_deps deps :: args))
+               ] )))
+
 let build_c_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
   let flags = Foreign.Source.flags src in
   let ctx = Super_context.context sctx in
@@ -59,7 +108,7 @@ let build_cxx_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
 (* TODO: [requires] is a confusing name, probably because it's too general: it
    looks like it's a list of libraries we depend on. *)
 let build_o_files ~sctx ~foreign_sources ~(dir : Path.Build.t) ~expander
-    ~requires ~dir_contents ~extra_flags ~(extra_deps : Dep_conf.t list) =
+    ~requires ~dir_contents =
   let ctx = Super_context.context sctx in
   let all_dirs = Dir_contents.dirs dir_contents in
   let h_files =
@@ -83,17 +132,21 @@ let build_o_files ~sctx ~foreign_sources ~(dir : Path.Build.t) ~expander
               ])
       ]
   in
-  let extra_deps =
-    let open Build.O in
-    let+ () = Super_context.Deps.interpret sctx extra_deps ~expander in
-    Command.Args.empty
-  in
-  let include_flags =
-    Command.Args.S [ includes; extra_flags; Dyn extra_deps ]
-  in
   String.Map.to_list foreign_sources
   |> List.map ~f:(fun (obj, (loc, src)) ->
          let dst = Path.Build.relative dir (obj ^ ctx.lib_config.ext_obj) in
+         let stubs = src.Foreign.Source.stubs in
+         let extra_flags = include_dir_flags ~expander ~dir src.stubs in
+         let extra_deps =
+           let open Build.O in
+           let+ () =
+             Super_context.Deps.interpret sctx stubs.extra_deps ~expander
+           in
+           Command.Args.empty
+         in
+         let include_flags =
+           Command.Args.S [ includes; extra_flags; Dyn extra_deps ]
+         in
          let build_file =
            match Foreign.Source.language src with
            | C -> build_c_file

--- a/src/dune/foreign_rules.mli
+++ b/src/dune/foreign_rules.mli
@@ -8,6 +8,4 @@ val build_o_files :
   -> expander:Expander.t
   -> requires:Lib.L.t Or_exn.t
   -> dir_contents:Dir_contents.t
-  -> extra_flags:Command.Args.dynamic Command.Args.t
-  -> extra_deps:Dep_conf.t list
   -> Path.Build.t list

--- a/test/blackbox-tests/test-cases/foreign-stubs/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/run.t
@@ -264,7 +264,7 @@ Testsuite for the (foreign_stubs ...) field.
   > value foo(value unit) { return Val_int(1 + EIGHT); }
   > EOF
 
-  $ ./sdune build |& grep eight.h
+  $ ./sdune build 2>&1 | grep eight.h
   foo.c:2:19: fatal error: eight.h: No such file or directory
    #include "eight.h"
 
@@ -328,7 +328,7 @@ Testsuite for the (foreign_stubs ...) field.
   > value foo(value unit) { return Val_int(ONE + EIGHT); }
   > EOF
 
-  $ ./sdune build |& grep another/dir/one.h
+  $ ./sdune build 2>&1 | grep another/dir/one.h
   foo.c:3:29: fatal error: another/dir/one.h: No such file or directory
    #include "another/dir/one.h"
 

--- a/test/blackbox-tests/test-cases/foreign-stubs/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/run.t
@@ -260,24 +260,18 @@ Testsuite for the (foreign_stubs ...) field.
 
   $ cat >foo.c <<EOF
   > #include <caml/mlvalues.h>
-  > #include "some/dir/eight.h"
+  > #include "eight.h"
   > value foo(value unit) { return Val_int(1 + EIGHT); }
   > EOF
 
-  $ ./sdune build
-        ocamlc foo$ext_obj (exit 2)
-  (cd _build/default && /usr/local/home/amokhov/code/.opam/default/bin/ocamlc.opt -g -ccopt -std=gnu99 -ccopt -O2 -ccopt -fno-strict-aliasing -ccopt -fwrapv -ccopt -fno-builtin-memcmp -ccopt -fPIC -ccopt -g -o foo$ext_obj foo.c)
-  foo.c:2:28: fatal error: some/dir/eight.h: No such file or directory
-   #include "some/dir/eight.h"
-                              ^
-  compilation terminated.
-  [1]
+  $ ./sdune build |& grep eight.h
+  foo.c:2:19: fatal error: eight.h: No such file or directory
+   #include "eight.h"
 
 ----------------------------------------------------------------------------------
 * Succeeds when (extra_deps ...) is present
 
-  $ mkdir -p some/dir
-  $ cat >some/dir/eight.h <<EOF
+  $ cat >eight.h <<EOF
   > #define EIGHT 8
   > EOF
 
@@ -285,7 +279,7 @@ Testsuite for the (foreign_stubs ...) field.
   > (library
   >  (name quad)
   >  (modules quad)
-  >  (foreign_stubs (language c) (names foo) (extra_deps some/dir/eight.h))
+  >  (foreign_stubs (language c) (names foo) (extra_deps eight.h))
   >  (foreign_archives bar qux)
   >  (foreign_stubs (language cxx) (names baz)))
   > (rule
@@ -329,19 +323,14 @@ Testsuite for the (foreign_stubs ...) field.
 
   $ cat >foo.c <<EOF
   > #include <caml/mlvalues.h>
-  > #include "some/dir/eight.h"
+  > #include "eight.h"
   > #include "another/dir/one.h"
   > value foo(value unit) { return Val_int(ONE + EIGHT); }
   > EOF
 
-  $ ./sdune build
-        ocamlc foo$ext_obj (exit 2)
-  (cd _build/default && /usr/local/home/amokhov/code/.opam/default/bin/ocamlc.opt -g -ccopt -std=gnu99 -ccopt -O2 -ccopt -fno-strict-aliasing -ccopt -fwrapv -ccopt -fno-builtin-memcmp -ccopt -fPIC -ccopt -g -o foo$ext_obj foo.c)
+  $ ./sdune build |& grep another/dir/one.h
   foo.c:3:29: fatal error: another/dir/one.h: No such file or directory
    #include "another/dir/one.h"
-                               ^
-  compilation terminated.
-  [1]
 
 ----------------------------------------------------------------------------------
 * Succeeds when (include_dirs ...) is present
@@ -355,7 +344,7 @@ Testsuite for the (foreign_stubs ...) field.
   > (library
   >  (name quad)
   >  (modules quad)
-  >  (foreign_stubs (language c) (names foo) (extra_deps some/dir/eight.h) (include_dirs another/dir))
+  >  (foreign_stubs (language c) (names foo) (extra_deps eight.h) (include_dirs another/dir))
   >  (foreign_archives bar qux)
   >  (foreign_stubs (language cxx) (names baz)))
   > (rule

--- a/test/blackbox-tests/test-cases/foreign-stubs/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/run.t
@@ -264,9 +264,8 @@ Testsuite for the (foreign_stubs ...) field.
   > value foo(value unit) { return Val_int(1 + EIGHT); }
   > EOF
 
-  $ ./sdune build 2>&1 | grep eight.h
-  foo.c:2:19: fatal error: eight.h: No such file or directory
-   #include "eight.h"
+  $ ./sdune build 2> /dev/null
+  [1]
 
 ----------------------------------------------------------------------------------
 * Succeeds when (extra_deps ...) is present
@@ -328,9 +327,8 @@ Testsuite for the (foreign_stubs ...) field.
   > value foo(value unit) { return Val_int(ONE + EIGHT); }
   > EOF
 
-  $ ./sdune build 2>&1 | grep another/dir/one.h
-  foo.c:3:29: fatal error: another/dir/one.h: No such file or directory
-   #include "another/dir/one.h"
+  $ ./sdune build 2> /dev/null
+  [1]
 
 ----------------------------------------------------------------------------------
 * Succeeds when (include_dirs ...) is present

--- a/test/blackbox-tests/test-cases/foreign-stubs/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/run.t
@@ -254,3 +254,142 @@ Testsuite for the (foreign_stubs ...) field.
   $ touch foo.cxx
 
   $ ./sdune build
+
+----------------------------------------------------------------------------------
+* Fails when (extra_deps ...) is missing
+
+  $ cat >foo.c <<EOF
+  > #include <caml/mlvalues.h>
+  > #include "some/dir/eight.h"
+  > value foo(value unit) { return Val_int(1 + EIGHT); }
+  > EOF
+
+  $ ./sdune build
+        ocamlc foo$ext_obj (exit 2)
+  (cd _build/default && /usr/local/home/amokhov/code/.opam/default/bin/ocamlc.opt -g -ccopt -std=gnu99 -ccopt -O2 -ccopt -fno-strict-aliasing -ccopt -fwrapv -ccopt -fno-builtin-memcmp -ccopt -fPIC -ccopt -g -o foo$ext_obj foo.c)
+  foo.c:2:28: fatal error: some/dir/eight.h: No such file or directory
+   #include "some/dir/eight.h"
+                              ^
+  compilation terminated.
+  [1]
+
+----------------------------------------------------------------------------------
+* Succeeds when (extra_deps ...) is present
+
+  $ mkdir -p some/dir
+  $ cat >some/dir/eight.h <<EOF
+  > #define EIGHT 8
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name quad)
+  >  (modules quad)
+  >  (foreign_stubs (language c) (names foo) (extra_deps some/dir/eight.h))
+  >  (foreign_archives bar qux)
+  >  (foreign_stubs (language cxx) (names baz)))
+  > (rule
+  >  (targets bar%{ext_obj})
+  >  (deps bar.c)
+  >  (action (run %{ocaml-config:c_compiler} -c -I %{ocaml-config:standard_library} -o %{targets} %{deps})))
+  > (rule
+  >  (targets libbar.a)
+  >  (deps bar%{ext_obj})
+  >  (action (run ar rcs %{targets} %{deps})))
+  > (rule
+  >  (targets dllbar%{ext_dll})
+  >  (deps bar%{ext_obj})
+  >  (action (run %{ocaml-config:c_compiler} -shared -o %{targets} %{deps})))
+  > (rule
+  >  (targets qux%{ext_obj})
+  >  (deps qux.cpp)
+  >  (action (run %{ocaml-config:c_compiler} -c -I %{ocaml-config:standard_library} -o %{targets} %{deps})))
+  > (rule
+  >  (targets libqux.a)
+  >  (deps qux%{ext_obj})
+  >  (action (run ar rcs %{targets} %{deps})))
+  > (rule
+  >  (targets dllqux%{ext_dll})
+  >  (deps qux%{ext_obj})
+  >  (action (run %{ocaml-config:c_compiler} -shared -o %{targets} %{deps})))
+  > (executable
+  >  (name main)
+  >  (libraries quad)
+  >  (modules main))
+  > EOF
+
+  $ ./sdune exec ./main.exe
+  2019
+
+  $ (cd _build/default && ocamlrun -I . ./main.bc)
+  2019
+
+----------------------------------------------------------------------------------
+* Fails when (include_dirs ...) is missing
+
+  $ cat >foo.c <<EOF
+  > #include <caml/mlvalues.h>
+  > #include "some/dir/eight.h"
+  > #include "another/dir/one.h"
+  > value foo(value unit) { return Val_int(ONE + EIGHT); }
+  > EOF
+
+  $ ./sdune build
+        ocamlc foo$ext_obj (exit 2)
+  (cd _build/default && /usr/local/home/amokhov/code/.opam/default/bin/ocamlc.opt -g -ccopt -std=gnu99 -ccopt -O2 -ccopt -fno-strict-aliasing -ccopt -fwrapv -ccopt -fno-builtin-memcmp -ccopt -fPIC -ccopt -g -o foo$ext_obj foo.c)
+  foo.c:3:29: fatal error: another/dir/one.h: No such file or directory
+   #include "another/dir/one.h"
+                               ^
+  compilation terminated.
+  [1]
+
+----------------------------------------------------------------------------------
+* Succeeds when (include_dirs ...) is present
+
+  $ mkdir -p another/dir
+  $ cat >another/dir/one.h <<EOF
+  > #define ONE 1
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name quad)
+  >  (modules quad)
+  >  (foreign_stubs (language c) (names foo) (extra_deps some/dir/eight.h) (include_dirs another/dir))
+  >  (foreign_archives bar qux)
+  >  (foreign_stubs (language cxx) (names baz)))
+  > (rule
+  >  (targets bar%{ext_obj})
+  >  (deps bar.c)
+  >  (action (run %{ocaml-config:c_compiler} -c -I %{ocaml-config:standard_library} -o %{targets} %{deps})))
+  > (rule
+  >  (targets libbar.a)
+  >  (deps bar%{ext_obj})
+  >  (action (run ar rcs %{targets} %{deps})))
+  > (rule
+  >  (targets dllbar%{ext_dll})
+  >  (deps bar%{ext_obj})
+  >  (action (run %{ocaml-config:c_compiler} -shared -o %{targets} %{deps})))
+  > (rule
+  >  (targets qux%{ext_obj})
+  >  (deps qux.cpp)
+  >  (action (run %{ocaml-config:c_compiler} -c -I %{ocaml-config:standard_library} -o %{targets} %{deps})))
+  > (rule
+  >  (targets libqux.a)
+  >  (deps qux%{ext_obj})
+  >  (action (run ar rcs %{targets} %{deps})))
+  > (rule
+  >  (targets dllqux%{ext_dll})
+  >  (deps qux%{ext_obj})
+  >  (action (run %{ocaml-config:c_compiler} -shared -o %{targets} %{deps})))
+  > (executable
+  >  (name main)
+  >  (libraries quad)
+  >  (modules main))
+  > EOF
+
+  $ ./sdune exec ./main.exe
+  2019
+
+  $ (cd _build/default && ocamlrun -I . ./main.bc)
+  2019


### PR DESCRIPTION
Apparently the initial implementation only supported these fields in `(foreign_library...)`.