### PR TITLE
[memo] Introduce Memo.Cell.t

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -469,10 +469,17 @@ module Exec = struct
       ; data = Dep_node.T dep_node
       }
     in
-    add_rev_dep dag_node;
     dep_node.dag_node <- lazy dag_node;
     dep_node
 end
+
+let dep_node (type i o f) (t : (i, o, f) t) inp =
+  match Store.find t.cache inp with
+  | Some dep_node -> dep_node
+  | None ->
+    let dep_node = Exec.make_dep_node t ~input:inp ~state:Init in
+    Store.set t.cache inp dep_node;
+    dep_node
 
 module Exec_sync = struct
   let compute run inp dep_node =
@@ -530,41 +537,36 @@ module Exec_sync = struct
     dep_node.state <- Running_sync run;
     compute run inp dep_node
 
-  let exec t inp =
-    match Store.find t.cache inp with
-    | None ->
-      let run = Run.current () in
-      let dep_node =
-        Exec.make_dep_node t ~input:inp ~state:(Running_sync run)
-      in
-      Store.set t.cache inp dep_node;
-      compute run inp dep_node
-    | Some dep_node -> (
-      add_rev_dep (dag_node dep_node);
-      match dep_node.state with
-      | Init -> assert false
-      | Failed (run, exn) ->
-        if Run.is_current run then
-          Nothing.unreachable_code (!on_already_reported exn)
-        else
-          recompute inp dep_node
-      | Running_async _ -> assert false
-      | Running_sync run ->
-        if Run.is_current run then
-          (* hopefully this branch should be unreachable and [add_rev_dep]
-             reports a cycle above instead *)
-          Code_error.raise "bug: unreported sync dependency_cycle"
-            [ ("stack", Call_stack.get_call_stack_as_dyn ())
-            ; ("adding", Stack_frame.to_dyn (T dep_node))
-            ]
-        else
-          recompute inp dep_node
-      | Done cv -> (
+  let exec_dep_node dep_node inp =
+    add_rev_dep (dag_node dep_node);
+    match dep_node.state with
+    | Init ->
+      recompute inp dep_node
+    | Failed (run, exn) ->
+      if Run.is_current run then
+        Nothing.unreachable_code (!on_already_reported exn)
+      else
+        recompute inp dep_node
+    | Running_async _ -> assert false
+    | Running_sync run ->
+      if Run.is_current run then
+        (* hopefully this branch should be unreachable and [add_rev_dep]
+           reports a cycle above instead *)
+        Code_error.raise "bug: unreported sync dependency_cycle"
+          [ ("stack", Call_stack.get_call_stack_as_dyn ())
+          ; ("adding", Stack_frame.to_dyn (T dep_node))
+          ]
+      else
+        recompute inp dep_node
+    | Done cv -> (
         Cached_value.get_sync cv
         |> function
         | Some v -> v
-        | None -> recompute inp dep_node ) )
+        | None -> recompute inp dep_node )
+
+  let exec t inp = exec_dep_node (dep_node t inp) inp
 end
+
 
 module Exec_async = struct
   let compute inp ivar dep_node =
@@ -592,36 +594,29 @@ module Exec_async = struct
     dep_node.state <- Running_async (Run.current (), ivar);
     compute inp ivar dep_node
 
-  let exec t inp =
-    match Store.find t.cache inp with
-    | None ->
-      let ivar = Fiber.Ivar.create () in
-      let dep_node =
-        Exec.make_dep_node t ~input:inp
-          ~state:(Running_async (Run.current (), ivar))
-      in
-      Store.set t.cache inp dep_node;
-      compute inp ivar dep_node
-    | Some dep_node -> (
-      add_rev_dep (dag_node dep_node);
-      match dep_node.state with
-      | Init -> assert false
-      | Failed (run, exn) ->
-        if Run.is_current run then
-          already_reported exn
-        else
-          recompute inp dep_node
-      | Running_sync _ -> assert false
-      | Running_async (run, fut) ->
-        if Run.is_current run then
-          Fiber.Ivar.read fut
-        else
-          recompute inp dep_node
-      | Done cv -> (
+  let exec_dep_node dep_node inp =
+    add_rev_dep (dag_node dep_node);
+    match dep_node.state with
+    | Init ->
+      recompute inp dep_node
+    | Failed (run, exn) ->
+      if Run.is_current run then
+        already_reported exn
+      else
+        recompute inp dep_node
+    | Running_sync _ -> assert false
+    | Running_async (run, fut) ->
+      if Run.is_current run then
+        Fiber.Ivar.read fut
+      else
+        recompute inp dep_node
+    | Done cv -> (
         Cached_value.get_async cv
         >>= function
         | Some v -> Fiber.return v
-        | None -> recompute inp dep_node ) )
+        | None -> recompute inp dep_node )
+
+  let exec t inp = exec_dep_node (dep_node t inp) inp
 end
 
 let exec (type i o f) (t : (i, o, f) t) =
@@ -797,66 +792,12 @@ module Cell = struct
   type ('a, 'b, 'f) t = ('a, 'b, 'f) Dep_node.t
 
   let get_sync (type a b) (dep_node : (a, b, a -> b) Dep_node.t) =
-    add_rev_dep (dag_node dep_node);
-    match dep_node.state with
-    | Init ->
-      let run = Run.current () in
-      dep_node.state <- Running_sync run;
-      Exec_sync.compute run dep_node.input dep_node
-    | Failed (run, exn) ->
-      if Run.is_current run then
-        Nothing.unreachable_code (!on_already_reported exn)
-      else
-        Exec_sync.recompute dep_node.input dep_node
-    | Running_async _ -> assert false
-    | Running_sync run ->
-      if Run.is_current run then
-        (* hopefully this branch should be unreachable and [add_rev_dep]
-           reports a cycle above instead *)
-        Code_error.raise "bug: unreported sync dependency_cycle"
-          [ ("stack", Call_stack.get_call_stack_as_dyn ())
-          ; ("adding", Stack_frame.to_dyn (T dep_node))
-          ]
-      else
-        Exec_sync.recompute dep_node.input dep_node
-    | Done cv -> (
-        Cached_value.get_sync cv
-        |> function
-        | Some v -> v
-        | None -> Exec_sync.recompute dep_node.input dep_node )
-
+    Exec_sync.exec_dep_node dep_node dep_node.input
   let get_async (type a b) (dep_node : (a, b, a -> b Fiber.t) Dep_node.t) =
-    add_rev_dep (dag_node dep_node);
-    match dep_node.state with
-    | Init ->
-      let ivar = Fiber.Ivar.create () in
-      dep_node.state <- Running_async (Run.current (), ivar);
-      Exec_async.compute dep_node.input ivar dep_node
-    | Failed (run, exn) ->
-      if Run.is_current run then
-        already_reported exn
-      else
-        Exec_async.recompute dep_node.input dep_node
-    | Running_sync _ -> assert false
-    | Running_async (run, fut) ->
-      if Run.is_current run then
-        Fiber.Ivar.read fut
-      else
-        Exec_async.recompute dep_node.input dep_node
-    | Done cv -> (
-        Cached_value.get_async cv
-        >>= function
-        | Some v -> Fiber.return v
-        | None -> Exec_async.recompute dep_node.input dep_node )
+    Exec_async.exec_dep_node dep_node dep_node.input
 end
 
-let cell (type i o f) (t : (i, o, f) t) inp =
-  match Store.find t.cache inp with
-  | Some dep_node -> dep_node
-  | None ->
-    let dep_node = Exec.make_dep_node t ~input:inp ~state:Init in
-    Store.set t.cache inp dep_node;
-    dep_node
+let cell t inp = dep_node t inp
 
 module Implicit_output = Implicit_output
 module Store = Store_intf

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -251,4 +251,13 @@ module With_implicit_output : sig
   val exec : (_, _, 'f) t -> 'f
 end
 
+module Cell : sig
+  type ('a, 'b, 'f) t
+
+  val get_sync : ('a, 'b, 'a -> 'b) t -> 'b
+  val get_async : ('a, 'b, 'a -> 'b Fiber.t) t -> 'b Fiber.t
+end
+
+val cell : ('a, 'b, 'f) t -> 'a -> ('a, 'b, 'f) Cell.t
+
 module Implicit_output = Implicit_output

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -363,7 +363,7 @@ let%expect_test _ =
 (* Tests for Memo.Cell *)
 
 let%expect_test _ =
-  let f x = x ^ x in
+  let f x = "*" ^ x in
   let memo =
     Memo.create "for-cell" ~input:(module String)
       ~visibility:(Public Dune_lang.Decoder.string)
@@ -372,6 +372,8 @@ let%expect_test _ =
       Sync f
   in
   let cell = Memo.cell memo "foobar" in
-  let res = Cell.get_sync cell in
-  print_endline res;
-  [%expect{| foobarfoobar |}]
+  print_endline (Cell.get_sync cell);
+  print_endline (Cell.get_sync cell);
+  [%expect{|
+    *foobar
+    *foobar |}]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -359,3 +359,22 @@ let%expect_test _ =
     running foobar
     resetting memo
     running foobar |}]
+
+(* Tests for Memo.Cell *)
+
+let%expect_test _ =
+  let f x = x ^ x in
+  let memo =
+    Memo.create "for-cell" ~input:(module String)
+      ~visibility:(Public Dune_lang.Decoder.string)
+      ~output:(Allow_cutoff (module String))
+      ~doc:""
+      Sync f
+  in
+  let cell = Memo.cell memo "foobar" in
+  let res = Cell.get_sync cell in
+  print_endline res;
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  ( "(\"bug: unreported sync dependency_cycle\",\
+   \n{ stack = []; adding = (\"for-cell\", \"foobar\") })") |}]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -377,3 +377,58 @@ let%expect_test _ =
   [%expect{|
     *foobar
     *foobar |}]
+
+let printf = Printf.printf
+
+let%expect_test "fib linked list" =
+  let module Element = struct
+    type t = {
+      prev_cell : (int, t, int -> t) Memo.Cell.t;
+      value : int;
+      next_cell : (int, t, int -> t) Memo.Cell.t;
+    }
+
+    let to_dyn t = Dyn.Int t.value
+  end
+  in
+  let force cell : Element.t = Memo.Cell.get_sync cell in
+  let memo_fdecl = Fdecl.create Dyn.Encoder.opaque in
+  let compute_element x =
+    let memo = Fdecl.get memo_fdecl in
+    printf "computing %d\n" x;
+    let prev_cell = (Memo.cell memo (x - 1)) in
+    let value =
+      if x < 1 then 0
+      else if x = 1 then 1
+      else
+        (force prev_cell).value
+        + ((force ((force prev_cell).prev_cell))).value
+    in
+    { Element.next_cell = Memo.cell memo (x + 1)
+    ; prev_cell
+    ; value
+    }
+  in
+  let memo = (
+    Memo.create "fib"
+      ~input:(module Int)
+      ~visibility:Hidden Sync
+      ~output:(Simple (module Element)) compute_element ~doc:"")
+  in
+  Fdecl.set memo_fdecl memo;
+  let fourth = Memo.exec memo 4 in
+  printf "4th: %d\n" fourth.value;
+  printf "next: %d\n" (force (fourth.next_cell)).value;
+  let seventh = Memo.exec memo 7 in
+  printf "7th: %d\n" seventh.value;
+  printf "prev: %d\n" (force seventh.prev_cell).value;
+  printf "prev: %d\n" (force (force seventh.prev_cell).prev_cell).value;
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  "Assert_failure src/memo/memo.ml:367:23"
+  Trailing output
+  ---------------
+  computing 4
+  computing 3
+  computing 2
+  computing 1 |}]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -423,12 +423,17 @@ let%expect_test "fib linked list" =
   printf "7th: %d\n" seventh.value;
   printf "prev: %d\n" (force seventh.prev_cell).value;
   printf "prev: %d\n" (force (force seventh.prev_cell).prev_cell).value;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  "Assert_failure src/memo/memo.ml:367:23"
-  Trailing output
-  ---------------
-  computing 4
-  computing 3
-  computing 2
-  computing 1 |}]
+  [%expect{|
+    computing 4
+    computing 3
+    computing 2
+    computing 1
+    computing 0
+    4th: 3
+    computing 5
+    next: 5
+    computing 7
+    computing 6
+    7th: 13
+    prev: 8
+    prev: 5 |}]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -374,7 +374,4 @@ let%expect_test _ =
   let cell = Memo.cell memo "foobar" in
   let res = Cell.get_sync cell in
   print_endline res;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  ( "(\"bug: unreported sync dependency_cycle\",\
-   \n{ stack = []; adding = (\"for-cell\", \"foobar\") })") |}]
+  [%expect{| foobarfoobar |}]


### PR DESCRIPTION
A cell is just `Dep_node.t` that callers may use to avoid having to
lookup the input in the store.

----

Looks like my type hackery isn't enough to unify the `get_sync` and `get_async`
functions. I would appreciate a hand here.