### PR TITLE
[stdune] Improve for_all2

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1580,11 +1580,13 @@ end = struct
               (* This being [false] is unexpected and means we have a hash
                  collision *)
               let data_are_ok =
-                try
+                match
                   List.for_all2 targets cached
                     ~f:(fun (target, _) (c : Dune_memory.File.t) ->
                       Path.Build.equal target c.in_the_build_directory)
-                with _ -> false
+                with
+                | Ok b -> b
+                | Error `Length_mismatch -> false
               in
               if not data_are_ok then
                 let open Pp.O in

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -187,3 +187,13 @@ let fold_map t ~init ~f =
 
 let unzip l =
   fold_right ~init:([], []) ~f:(fun (x, y) (xs, ys) -> (x :: xs, y :: ys)) l
+
+let rec for_all2 x y ~f =
+  match x, y with
+  | [], [] -> Ok true
+  | x :: xs, y :: ys ->
+    if f x y then
+      for_all2 xs ys ~f
+    else
+      Ok false
+  | _, _ -> Error `Length_mismatch

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -72,3 +72,9 @@ val cons : 'a t -> 'a -> 'a t
 val fold_map : 'a list -> init:'b -> f:('b -> 'a -> 'b * 'c) -> 'b * 'c list
 
 val unzip : ('a * 'b) t -> 'a t * 'b t
+
+val for_all2 :
+     'a list
+  -> 'b list
+  -> f:('a -> 'b -> bool)
+  -> (bool, [`Length_mismatch]) Result.t


### PR DESCRIPTION
The current `for_all2` is fragile because it makes it easy to catch things
thrown by `f`. This is almost always unintended. The fix is to make `for_all2`
return a result type.

The second commit just gets rid of this use of `for_all2` in favor `List.equal`