### PR TITLE
Add default values to Fdecl

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -71,7 +71,7 @@ let set_dirs c =
 let set_common_other c ~targets =
   Console.init c.config.display;
   Log.init ();
-  Clflags.debug_dep_path := c.debug_dep_path;
+  Fdecl.set Clflags.debug_dep_path c.debug_dep_path;
   Clflags.debug_findlib := c.debug_findlib;
   Clflags.debug_backtraces := c.debug_backtraces;
   Clflags.capture_outputs := c.capture_outputs;

--- a/src/dune/clflags.ml
+++ b/src/dune/clflags.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 module Promote = struct
   type t =
     | Automatically
@@ -6,7 +8,7 @@ end
 
 let debug_findlib = ref false
 
-let debug_dep_path = ref false
+let debug_dep_path = Fdecl.create ~default:false Dyn.Encoder.bool
 
 let external_lib_deps_hint = ref []
 

--- a/src/dune/clflags.mli
+++ b/src/dune/clflags.mli
@@ -1,7 +1,8 @@
 (** Command line flags *)
+open Stdune
 
 (** Print dependency path in case of error *)
-val debug_dep_path : bool ref
+val debug_dep_path : bool Fdecl.t
 
 (** Debug the findlib implementation *)
 val debug_findlib : bool ref

--- a/src/dune/main.ml
+++ b/src/dune/main.ml
@@ -195,7 +195,7 @@ let bootstrap () =
         , " always print exception backtraces" )
       ]
       anon "Usage: boot.exe [-j JOBS] [--dev]\nOptions are:";
-    Clflags.debug_dep_path := true;
+    Fdecl.set Clflags.debug_dep_path true;
     let config =
       (* Only load the configuration with --dev *)
       if !profile = Some Profile.Release then

--- a/src/dune/report_error.ml
+++ b/src/dune/report_error.ml
@@ -119,7 +119,7 @@ let report { Exn_with_backtrace.exn; backtrace } =
           (Printexc.raw_backtrace_to_string backtrace);
       let dependency_path =
         let dependency_path = Option.value dependency_path ~default:[] in
-        if !Clflags.debug_dep_path then
+        if Fdecl.get Clflags.debug_dep_path then
           dependency_path
         else
           (* Only keep the part that doesn't come from the build system *)

--- a/src/stdune/fdecl.ml
+++ b/src/stdune/fdecl.ml
@@ -1,16 +1,24 @@
 type 'a state =
   | Unset
   | Set of 'a
+  | Default of 'a
 
 type 'a t =
   { mutable state : 'a state
   ; to_dyn : 'a -> Dyn.t
   }
 
-let create to_dyn = { state = Unset; to_dyn }
+let create ?default to_dyn =
+  let state =
+    match default with
+    | None -> Unset
+    | Some s -> Default s
+  in
+  { state ; to_dyn }
 
 let set t new_ =
   match t.state with
+  | Default _
   | Unset -> t.state <- Set new_
   | Set old ->
     Code_error.raise "Fdecl.set: already set"
@@ -21,9 +29,15 @@ let reset t x = t.state <- Set x
 let get t =
   match t.state with
   | Unset -> Code_error.raise "Fdecl.get: not set" []
+  | Default x ->
+    t.state <- Set x;
+    x
   | Set x -> x
 
 let peek t =
   match t.state with
+  | Default d ->
+    t.state <- Set d;
+    Some d
   | Unset -> None
   | Set x -> Some x

--- a/src/stdune/fdecl.mli
+++ b/src/stdune/fdecl.mli
@@ -3,7 +3,7 @@
 type 'a t
 
 (** [create ()] creates a forward declaration. *)
-val create : ('a -> Dyn.t) -> 'a t
+val create : ?default:'a -> ('a -> Dyn.t) -> 'a t
 
 (** [set t x] set's the value that is returned by [get t] to [x]. Raise if
     [set] was already called *)


### PR DESCRIPTION
This is useful to allow the use of Fdecl.t for things like flags. These
values have a default value, but we want to make sure that once those
are access we can no longer modify it.

Another alternative is to create a separate type for this. The invariant that we want to force is that a value can no longer be modified once it has been "osberved".