### PR TITLE
Add support for using library names in (include_dirs...)

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -1106,10 +1106,14 @@ Here is a complete list of supported subfields:
   using the :ref:`ordered-set-language`, where the ``:standard`` value comes
   from the environment settings ``c_flags`` and ``cxx_flags``, respectively.
 - ``include_dirs`` are tracked as dependencies and passed to the compiler
-  via the ``-I`` flag. You can use :ref:`variables` in this field. The
-  contents of included directories is tracked recursively, e.g. if you
-  use ``(include_dir dir)`` and have headers ``dir/base.h`` and
-  ``dir/lib/lib.h`` then they both will be tracked as dependencies.
+  via the ``-I`` flag. You can use :ref:`variables` in this field, and
+  refer to a library source directory using the ``(lib library-name)`` syntax.
+  For example, ``(include_dirs dir1 (lib lib1) (lib lib2) dir2)`` specifies
+  the directory ``dir1``, the source directories of ``lib1`` and ``lib2``,
+  and the directory ``dir2``, in this order. The contents of included
+  directories is tracked recursively, e.g. if you use ``(include_dir dir)``
+  and have headers ``dir/base.h`` and ``dir/lib/lib.h`` then they both will
+  be tracked as dependencies.
 - ``extra_deps`` specifies any other dependencies that should be tracked.
   This is useful when dealing with ``#include`` statements that escape into
   a parent directory like ``#include "../a.h"``.

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -73,12 +73,22 @@ val possible_sources :
     an optional [foreign_stubs] field of the [library] stanza, or as part of
     the top-level [foreign_library] stanza. *)
 module Stubs : sig
+  (* Foreign sources can depend on a directly specified directory [Dir] or on a
+     source directory of a library [Lib]. *)
+  module Include_dir : sig
+    type t =
+      | Dir of String_with_vars.t
+      | Lib of Loc.t * Lib_name.t
+
+    val decode : t Dune_lang.Decoder.t
+  end
+
   type t =
     { loc : Loc.t
     ; language : Language.t
     ; names : Ordered_set_lang.t
     ; flags : Ordered_set_lang.Unexpanded.t
-    ; include_dirs : String_with_vars.t list
+    ; include_dirs : Include_dir.t list
     ; extra_deps : Dep_conf.t list
     }
 


### PR DESCRIPTION
This makes it possible to write `(include_dirs (lib foo))` in foreign stubs declarations, where `foo` is a library name.

Note that at the moment we do not support external dependencies in `include_dir`, which in particular means that `(include_dir (lib base))` fails with the following error:

```
  File "expansions/dune", line 4, characters 33-37:
  4 |  (include_dirs (lib answer) (lib base))
                                       ^^^^
  Error: "/usr/local/home/amokhov/code/.opam/default/lib/base" is an external
  directory; dependencies in external directories are currently not tracked.
  Hint: You can specify "/usr/local/home/amokhov/code/.opam/default/lib/base" as an
  untracked include directory like this:
  
    (flags -I /usr/local/home/amokhov/code/.opam/default/lib/base)
  
```

I will add support for external directories in a separate PR.