### PR TITLE
Add basic support for external directories in (include_dir ...)

### DIFF
--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -27,14 +27,19 @@ let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
                 contains not only files but also directories and traverse them
                 recursively in [Build_system.Exported.Pred]. *)
              let () =
-               match Path.readdir_unsorted include_dir with
-               | Error m ->
+               let error msg =
                  User_error.raise ~loc
-                   [ Pp.textf "Unable to read the include directory %S."
-                       (Path.to_string include_dir)
-                   ; Pp.textf "Reason: %s." (Unix.error_message m)
+                   [ Pp.textf "Unable to read the include directory."
+                   ; Pp.textf "Reason: %s." msg
                    ]
-               | Ok _ -> ()
+               in
+               match Path.is_directory_with_error include_dir with
+               | Error msg -> error msg
+               | Ok false ->
+                 error
+                   (Printf.sprintf "%S is not a directory"
+                      (Path.to_string include_dir))
+               | Ok true -> ()
              in
              let deps =
                Dep.Set.singleton

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1103,6 +1103,11 @@ let readdir_unsorted =
 let is_directory t =
   try Sys.is_directory (to_string t) with Sys_error _ -> false
 
+let is_directory_with_error t =
+  match Sys.is_directory (to_string t) with
+  | exception Sys_error e -> Error e
+  | bool -> Ok bool
+
 let is_file t = not (is_directory t)
 
 let rmdir t = Unix.rmdir (to_string t)

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -294,6 +294,8 @@ val readdir_unsorted : t -> (string list, Unix.error) Result.t
 
 val is_directory : t -> bool
 
+val is_directory_with_error : t -> (bool, string) Result.t
+
 val is_file : t -> bool
 
 val rmdir : t -> unit

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -2193,7 +2193,6 @@
   (alias findlib-error)
   (alias forbidden_libraries)
   (alias force-test)
-  (alias foreign-library)
   (alias foreign-stubs)
   (alias format-dune-file)
   (alias formatting)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -148,6 +148,7 @@ let exclusions =
   ; make "install-libdir" ~external_deps:true
   ; make "lint" ~external_deps:true
   ; make "ppx-runtime-dependencies" ~external_deps:true
+  ; make "foreign-library" ~external_deps:true
   ; make "package-dep" ~external_deps:true
   ; make "merlin-tests" ~external_deps:true
   ; make "use-meta" ~external_deps:true

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -525,6 +525,7 @@ Testsuite for the (foreign_library ...) stanza.
   > (library
   >  (name calc)
   >  (modules calc)
+  >  (libraries base)
   >  (foreign_stubs (language c) (names month))
   >  (foreign_archives addmul config))
   > (foreign_library
@@ -670,6 +671,7 @@ Testsuite for the (foreign_library ...) stanza.
   > (executable
   >  (modes exe)
   >  (name main)
+  >  (libraries base)
   >  (foreign_archives clib)
   >  (modules main))
   > EOF

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -3,7 +3,7 @@ Testsuite for the (foreign_library ...) stanza.
 
   $ cat >sdune <<'EOF'
   > #!/usr/bin/env bash
-  > dune "$@"
+  > DUNE_SANDBOX=symlink dune "$@"
   > EOF
   $ chmod +x sdune
 
@@ -525,7 +525,6 @@ Testsuite for the (foreign_library ...) stanza.
   > (library
   >  (name calc)
   >  (modules calc)
-  >  (libraries base)
   >  (foreign_stubs (language c) (names month))
   >  (foreign_archives addmul config))
   > (foreign_library
@@ -671,7 +670,6 @@ Testsuite for the (foreign_library ...) stanza.
   > (executable
   >  (modes exe)
   >  (name main)
-  >  (libraries base)
   >  (foreign_archives clib)
   >  (modules main))
   > EOF
@@ -685,17 +683,16 @@ Testsuite for the (foreign_library ...) stanza.
 * Using an external directory in (include_dir ...)
 
   $ cat >some/dir/dune <<EOF
-  > (executable
-  >  (modes exe)
-  >  (name main)
-  >  (libraries base)
-  >  (foreign_archives clib)
-  >  (modules main))
   > (foreign_library
   >  (archive_name clib)
   >  (language c)
   >  (include_dirs (lib answer) (lib base))
   >  (names src))
+  > (executable
+  >  (modes exe)
+  >  (name main)
+  >  (foreign_archives clib)
+  >  (modules main))
   > EOF
 
   $ cat >some/dir/src.c <<EOF

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -683,16 +683,17 @@ Testsuite for the (foreign_library ...) stanza.
 * Using an external directory in (include_dir ...)
 
   $ cat >some/dir/dune <<EOF
+  > (executable
+  >  (modes exe)
+  >  (name main)
+  >  (libraries base)
+  >  (foreign_archives clib)
+  >  (modules main))
   > (foreign_library
   >  (archive_name clib)
   >  (language c)
   >  (include_dirs (lib answer) (lib base))
   >  (names src))
-  > (executable
-  >  (modes exe)
-  >  (name main)
-  >  (foreign_archives clib)
-  >  (modules main))
   > EOF
 
   $ cat >some/dir/src.c <<EOF

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -3,7 +3,7 @@ Testsuite for the (foreign_library ...) stanza.
 
   $ cat >sdune <<'EOF'
   > #!/usr/bin/env bash
-  > DUNE_SANDBOX=symlink dune "$@"
+  > dune "$@"
   > EOF
   $ chmod +x sdune
 

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -249,8 +249,37 @@ Testsuite for the (foreign_library ...) stanza.
   File "lib/dune", line 12, characters 23-33:
   12 |  (include_dirs headers /some/path)
                               ^^^^^^^^^^
-  Error: Unable to read the include directory "/some/path".
-  Reason: No such file or directory.
+  Error: Unable to read the include directory.
+  Reason: /some/path: No such file or directory.
+  [1]
+
+----------------------------------------------------------------------------------
+* Error when specifying an external file in (include_dirs... )
+
+  $ cat >lib/dune <<EOF
+  > (foreign_library
+  >  (archive_name addmul)
+  >  (language c)
+  >  (names add mul))
+  > (library
+  >  (name calc)
+  >  (modules calc)
+  >  (foreign_archives addmul config))
+  > (foreign_library
+  >  (archive_name config)
+  >  (language cxx)
+  >  (include_dirs headers /usr/bin/env)
+  >  (extra_deps eight.h)
+  >  (flags -DCONFIG_VALUE=2000)
+  >  (names config))
+  > EOF
+
+  $ ./sdune build
+  File "lib/dune", line 12, characters 23-35:
+  12 |  (include_dirs headers /usr/bin/env)
+                              ^^^^^^^^^^^^
+  Error: Unable to read the include directory.
+  Reason: "/usr/bin/env" is not a directory.
   [1]
 
 ----------------------------------------------------------------------------------


### PR DESCRIPTION
This allows using external directories in `(include_dir ...)` fields of foreign stub declarations.

Note that the current implementation tracks external directories non-recursively which is not ideal. The plan is to implement recursive tracking eventually -- there is a TODO with a couple of pointers.
