### PR TITLE
Fix native code generation of empty libraries on MSVC

### DIFF
--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -42,14 +42,6 @@ module Env_nodes : sig
     }
 end
 
-module Ccomp_type : sig
-  type t =
-    | Msvc
-    | Other of string
-
-  val to_dyn : t -> Dyn.t
-end
-
 type t =
   { name : Context_name.t
   ; kind : Kind.t
@@ -89,7 +81,7 @@ type t =
   ; version_string : string
   ; version : Ocaml_version.t
   ; stdlib_dir : Path.t
-  ; ccomp_type : Ccomp_type.t
+  ; ccomp_type : Lib_config.Ccomp_type.t
   ; c_compiler : string
   ; ocamlc_cflags : string list
   ; ocamlopt_cflags : string list

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -149,7 +149,10 @@ module DB : sig
     type nonrec t =
       | Not_found
       | Found of Lib_info.external_
-      | Hidden of Lib_info.external_ * string
+      | Hidden of
+          { info : Lib_info.external_
+          ; reason : string
+          }
       | Redirect of t option * (Loc.t * Lib_name.t)
 
     val to_dyn : t Dyn.Encoder.t

--- a/src/dune/lib_archives.mli
+++ b/src/dune/lib_archives.mli
@@ -2,6 +2,9 @@ open Stdune
 
 type t
 
+val has_native_archive :
+  Dune_file.Library.t -> Lib_config.t -> Dir_contents.t -> bool
+
 val make :
      ctx:Context.t
   -> dir:Path.Build.t

--- a/src/dune/lib_config.mli
+++ b/src/dune/lib_config.mli
@@ -1,5 +1,15 @@
 open Stdune
 
+module Ccomp_type : sig
+  type t =
+    | Msvc
+    | Other of string
+
+  val to_dyn : t -> Dyn.t
+
+  val of_config : Ocaml_config.t -> t
+end
+
 type t =
   { has_native : bool
   ; ext_lib : string
@@ -11,8 +21,11 @@ type t =
   ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
+  ; ccomp_type : Ccomp_type.t
   }
 
 val allowed_in_enabled_if : string list
 
 val get_for_enabled_if : t -> var:string -> string
+
+val linker_can_create_empty_archives : t -> bool

--- a/src/dune/modules.ml
+++ b/src/dune/modules.ml
@@ -195,6 +195,8 @@ module Wrapped = struct
     ; wrapped : Mode.t
     }
 
+  let empty t = Module_name.Map.is_empty t.modules
+
   let encode
       { modules; wrapped_compat; alias_module; main_module_name; wrapped } =
     let open Dune_lang.Encoder in
@@ -752,3 +754,11 @@ let relocate_alias_module t ~src_dir =
   match t with
   | Wrapped t -> Wrapped (Wrapped.relocate_alias_module t ~src_dir)
   | s -> s
+
+let is_empty = function
+  | Stdlib _
+  | Impl _
+  | Singleton _ ->
+    false
+  | Unwrapped w -> Module_name.Map.is_empty w
+  | Wrapped w -> Wrapped.empty w

--- a/src/dune/modules.mli
+++ b/src/dune/modules.mli
@@ -95,3 +95,5 @@ val exit_module : t -> Module.t option
 (** [relcoate_alias_module t ~src_dir] sets the source directory of the alias
     module to [src_dir]. Only works if [t] is wrapped. *)
 val relocate_alias_module : t -> src_dir:Path.t -> t
+
+val is_empty : t -> bool


### PR DESCRIPTION
This is a re-make of #2693. It depends #2828 to be merged first. At which point
I will implement `Lib_config.empty_native_archive` correctly.