### PR TITLE
Make [:standard] names more useful in foreign stubs

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -1101,7 +1101,9 @@ Here is a complete list of supported subfields:
   raising an error if multiple source files map to the same object name.
   If you need to have multiple object files with the same name, you can
   package them into different :ref:`foreign-archives` via the
-  ``foreign_archives`` field.
+  ``foreign_archives`` field. This field uses the :ref:`ordered-set-language`
+  where the ``:standard`` value corresponds to the set of names of all
+  source files whose extensions match the specified ``language``.
 - ``flags`` are passed when compiling source files. This field is specified
   using the :ref:`ordered-set-language`, where the ``:standard`` value comes
   from the environment settings ``c_flags`` and ``cxx_flags``, respectively.

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -486,6 +486,7 @@ module Buildable = struct
       match names with
       | None -> foreign_stubs
       | Some names ->
+        let names = Ordered_set_lang.replace_standard_with_empty names in
         let flags =
           Option.value ~default:Ordered_set_lang.Unexpanded.standard flags
         in

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -138,7 +138,7 @@ module Stubs = struct
     and+ loc_archive_name, archive_name =
       located (field_o "archive_name" string)
     and+ language = field "language" Language.decode
-    and+ names = field "names" Ordered_set_lang.decode
+    and+ names = Ordered_set_lang.field "names"
     and+ flags = Ordered_set_lang.Unexpanded.field "flags"
     and+ include_dirs =
       field ~default:[] "include_dirs" (repeat Include_dir.decode)
@@ -195,6 +195,9 @@ module Source = struct
   let flags t = t.stubs.flags
 
   let path t = t.path
+
+  let object_name t =
+    t.path |> Path.Build.split_extension |> fst |> Path.Build.basename
 
   let make ~stubs ~path = { stubs; path }
 end

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -156,6 +156,10 @@ module Source : sig
 
   val path : t -> Path.Build.t
 
+  (* The name of the corresponding object file; for example, [name] for a
+     source file [some/path/name.cpp]. *)
+  val object_name : t -> string
+
   val make : stubs:Stubs.t -> path:Path.Build.t -> t
 end
 

--- a/src/dune/ordered_set_lang.ml
+++ b/src/dune/ordered_set_lang.ml
@@ -186,10 +186,10 @@ let standard = { ast = Ast.Standard; loc = None; context = Univ_map.empty }
 let replace_standard ~where ~with_ : ast_expanded generic =
   let rec f (t : ast_expanded) : ast_expanded =
     match t with
-    | Element x -> Element x
-    | Standard -> with_
-    | Union xs -> Union (List.map xs ~f)
-    | Diff (x, y) -> Diff (f x, f y)
+    | Ast.Element x -> Element x
+    | Ast.Standard -> with_
+    | Ast.Union xs -> Union (List.map xs ~f)
+    | Ast.Diff (x, y) -> Diff (f x, f y)
   in
   { ast = f where.ast; loc = where.loc; context = where.context }
 

--- a/src/dune/ordered_set_lang.ml
+++ b/src/dune/ordered_set_lang.ml
@@ -183,6 +183,19 @@ let eval_loc t ~parse ~eq ~standard =
 
 let standard = { ast = Ast.Standard; loc = None; context = Univ_map.empty }
 
+let replace_standard ~where ~with_ : ast_expanded generic =
+  let rec f (t : ast_expanded) : ast_expanded =
+    match t with
+    | Element x -> Element x
+    | Standard -> with_
+    | Union xs -> Union (List.map xs ~f)
+    | Diff (x, y) -> Diff (f x, f y)
+  in
+  { ast = f where.ast; loc = where.loc; context = where.context }
+
+let replace_standard_with_empty where =
+  replace_standard ~where ~with_:(Union [] : ast_expanded)
+
 let field ?check name =
   let decode =
     match check with

--- a/src/dune/ordered_set_lang.mli
+++ b/src/dune/ordered_set_lang.mli
@@ -30,6 +30,9 @@ val eval_loc :
 
 val standard : t
 
+(** Replace all occurrences of [:standard] with the empty set. *)
+val replace_standard_with_empty : t -> t
+
 val is_standard : t -> bool
 
 val field :

--- a/test/blackbox-tests/test-cases/cxx-extension/run.t
+++ b/test/blackbox-tests/test-cases/cxx-extension/run.t
@@ -1,4 +1,116 @@
-.cxx extension is allowed
+* .cxx extension is allowed
   $ dune build
            bar alias default
   n = 42
+
+  $ echo "(lang dune 1.11)" > dune-project
+
+* Compilation succeeds when unused baz.cpp and baz.cxx exist
+
+  $ cat >baz.cpp <<EOF
+  > #include <stdio.h>
+  > extern "C" void foo () {
+  >   printf("m = %d\n", 42);
+  > }
+  > EOF
+
+  $ cat >baz.cxx <<EOF
+  > #include <stdio.h>
+  > extern "C" void foo () {
+  >   printf("k = %d\n", 42);
+  > }
+  > EOF
+
+  $ dune clean
+  $ dune build
+           bar alias default
+  n = 42
+
+* Compilation fails when baz.cpp and baz.cxx conflict
+* Note that this behaviour differs from earlier Dune version
+that simply pick one of the sources and compile it to baz.o
+
+  $ cat >dune <<EOF
+  > (library
+  > (name foo)
+  > (cxx_names baz)
+  > (modules foo))
+  > (executable
+  > (name bar)
+  > (libraries foo)
+  > (modules bar))
+  > (alias
+  > (name default)
+  > (action (run ./bar.exe)))
+  > EOF
+
+  $ dune clean
+  $ dune build
+  File "dune", line 3, characters 11-14:
+  3 | (cxx_names baz)
+                 ^^^
+  Error: Multiple sources map to the same object name "baz":
+  - baz.cpp
+  - baz.cxx
+  This is not allowed; please rename them or remove "baz" from object names.
+  Hint: You can also avoid the name clash by placing the objects into different
+  foreign archives and building them in different directories. Foreign archives
+  can be defined using the (foreign_library ...) stanza.
+  [1]
+
+* Compilation succeeds when using :standard in pre-2.0 Dune language.
+This works because the translation layer from pre-2.0 to 2.0 replaces
+:standard with the empty set.
+
+  $ cat >dune <<EOF
+  > (library
+  > (name foo)
+  > (cxx_names :standard foo)
+  > (c_names bar)
+  > (modules foo))
+  > (executable
+  > (name bar)
+  > (libraries foo)
+  > (modules bar))
+  > (alias
+  > (name default)
+  > (action (run ./bar.exe)))
+  > EOF
+
+  $ dune clean
+  $ dune build
+           bar alias default
+  n = 42
+
+* Compilation fails when using :standard in Dune 2.0
+
+  $ echo "(lang dune 2.0)" > dune-project
+
+  $ cat >dune <<EOF
+  > (library
+  > (name foo)
+  > (foreign_stubs (language cxx) (names :standard foo))
+  > (foreign_stubs (language c) (names bar))
+  > (modules foo))
+  > (executable
+  > (name bar)
+  > (libraries foo)
+  > (modules bar))
+  > (alias
+  > (name default)
+  > (action (run ./bar.exe)))
+  > EOF
+
+  $ dune clean
+  $ dune build
+  File "dune", line 3, characters 0-52:
+  3 | (foreign_stubs (language cxx) (names :standard foo))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Multiple sources map to the same object name "baz":
+  - baz.cpp
+  - baz.cxx
+  This is not allowed; please rename them or remove "baz" from object names.
+  Hint: You can also avoid the name clash by placing the objects into different
+  foreign archives and building them in different directories. Foreign archives
+  can be defined using the (foreign_library ...) stanza.
+  [1]

--- a/test/blackbox-tests/test-cases/duplicate-c-cxx-obj/run.t
+++ b/test/blackbox-tests/test-cases/duplicate-c-cxx-obj/run.t
@@ -18,8 +18,8 @@ user intended.
 
   $ dune build --root same-stanza @all
   Entering directory 'same-stanza'
-  File "dune", line 5, characters 14-21:
-  5 |  (c_names foo sub/foo))
+  File "dune", line 3, characters 14-21:
+  3 |  (c_names foo sub/foo))
                     ^^^^^^^
   Error: Relative part of stub is not necessary and should be removed. To
   include sources in subdirectories, use the (include_subdirs ...) stanza.
@@ -31,6 +31,7 @@ user intended.
   >  (name foo)
   >  (c_names foo))
   > EOF
+
   $ dune build --root same-stanza @all
   Entering directory 'same-stanza'
   File "dune", line 4, characters 10-13:
@@ -39,7 +40,7 @@ user intended.
   Error: Multiple sources map to the same object name "foo":
   - foo.c
   - sub/foo.c
-  This is not allowed; please rename them.
+  This is not allowed; please rename them or remove "foo" from object names.
   Hint: You can also avoid the name clash by placing the objects into different
   foreign archives and building them in different directories. Foreign archives
   can be defined using the (foreign_library ...) stanza.

--- a/test/blackbox-tests/test-cases/duplicate-c-cxx-obj/same-stanza/dune
+++ b/test/blackbox-tests/test-cases/duplicate-c-cxx-obj/same-stanza/dune
@@ -1,5 +1,3 @@
-(include_subdirs unqualified)
-
 (library
  (name foo)
  (c_names foo sub/foo))

--- a/test/blackbox-tests/test-cases/duplicate-c-cxx/run.t
+++ b/test/blackbox-tests/test-cases/duplicate-c-cxx/run.t
@@ -7,7 +7,7 @@ c_names and cxx_names with overlapping names in the same stanza
   Error: Multiple sources map to the same object name "foo":
   - foo.c
   - foo.cpp
-  This is not allowed; please rename them.
+  This is not allowed; please rename them or remove "foo" from object names.
   Hint: You can also avoid the name clash by placing the objects into different
   foreign archives and building them in different directories. Foreign archives
   can be defined using the (foreign_library ...) stanza.

--- a/test/blackbox-tests/test-cases/foreign-stubs/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/run.t
@@ -380,3 +380,50 @@ Testsuite for the (foreign_stubs ...) field.
 
   $ (cd _build/default && ocamlrun -I . ./main.bc)
   2019
+
+----------------------------------------------------------------------------------
+* Fails when using standard names in foreign stubs due to multiple C++ sources
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name quad)
+  >  (modules quad)
+  >  (foreign_stubs (language cxx)))
+  > EOF
+
+  $ ./sdune build --display short
+  File "dune", line 4, characters 1-31:
+  4 |  (foreign_stubs (language cxx)))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Multiple sources map to the same object name "foo":
+  - foo.cpp
+  - foo.cxx
+  This is not allowed; please rename them or remove "foo" from object names.
+  Hint: You can also avoid the name clash by placing the objects into different
+  foreign archives and building them in different directories. Foreign archives
+  can be defined using the (foreign_library ...) stanza.
+  [1]
+
+----------------------------------------------------------------------------------
+* Succeeds when using a subset of standard names
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name quad)
+  >  (modules quad)
+  >  (foreign_stubs (language cxx) (names :standard \ foo)))
+  > EOF
+
+  $ ./sdune clean
+  $ ./sdune build --display short
+           gcc baz$ext_obj
+           gcc qux$ext_obj
+    ocamlmklib dllquad_stubs$ext_dll,libquad_stubs$ext_lib
+      ocamldep .quad.objs/quad.mli.d
+        ocamlc .quad.objs/byte/quad.{cmi,cmti}
+      ocamldep .quad.objs/quad.ml.d
+        ocamlc .quad.objs/byte/quad.{cmo,cmt}
+        ocamlc quad.cma
+      ocamlopt .quad.objs/native/quad.{cmx,o}
+      ocamlopt quad.{a,cmxa}
+      ocamlopt quad.cmxs


### PR DESCRIPTION
In the initial implementation of foreign libraries, `standard` meant the empty list of `names`, but a more convenient and consistent (with library `modules`) meaning of `standard` is "all files with the relevant extension", as indicated by @aalekseyev's CR. This patch implements this new meaning of `standard`.

TODO:
- [x] Update documentation. 