### PR TITLE
Attach unit tests to packages

### DIFF
--- a/dune-action-plugin.opam
+++ b/dune-action-plugin.opam
@@ -19,6 +19,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
   "dune-glob"
+  "ppx_expect" {test}
   "dune-private-libs" {= version}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -89,6 +89,7 @@ Among other things, dune-configurator allows one to:
  (name dune-action-plugin)
  (depends
   dune-glob
+  (ppx_expect :test)
   (dune-private-libs (= :version)))
  (synopsis "[experimental] API for writing dynamic Dune actions")
  (description "\

--- a/test/unit-tests/artifact_substitution/dune
+++ b/test/unit-tests/artifact_substitution/dune
@@ -1,4 +1,5 @@
 (test
  (name artifact_substitution)
+ (package dune-private-libs)
  (libraries stdune dune fiber dune_re)
  (preprocess future_syntax))

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -5,5 +5,6 @@
 
 (alias
  (name runtest)
+ (package dune-private-libs)
  (action
   (run ./sexp_tests.exe)))

--- a/test/unit-tests/ocaml-config/dune
+++ b/test/unit-tests/ocaml-config/dune
@@ -1,4 +1,5 @@
 (test
  (name gh637)
+ (package dune-private-libs)
  (libraries stdune ocaml_config)
  (deps Makefile.config))


### PR DESCRIPTION
This makes dune runtest -p not fail when exercised by opam.