### PR TITLE
Context database

### DIFF
--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -15,10 +15,11 @@ let term =
   in
   Common.set_common common ~targets:[];
   let capture_outputs = Common.capture_outputs common in
-  let env = Import.Main.setup_env ~capture_outputs in
+  let _env : Env.t = Import.Main.setup_env ~capture_outputs in
   Scheduler.go ~common (fun () ->
       let open Fiber.O in
-      let* ctxs = Context.create ~env (Workspace.default ()) in
+      let () = Workspace.init () in
+      let* ctxs = Context.DB.all () in
       let ctx = List.hd ctxs in
       let findlib = ctx.findlib in
       if na then (

--- a/otherlibs/action-plugin/src/dune_action_plugin.ml
+++ b/otherlibs/action-plugin/src/dune_action_plugin.ml
@@ -168,8 +168,7 @@ module V1 = struct
     | Stage at -> run_outside_of_dune (at.action ())
 
   let do_run t =
-    let open Protocol in
-    match Context.create () with
+    match Protocol.Context.create () with
     | Run_outside_of_dune -> run_outside_of_dune t
     | Error message ->
       Execution_error.raise

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -35,77 +35,81 @@ module Env_nodes = struct
       (Dune_env.Stanza.find env_nodes.workspace ~profile).env_vars
 end
 
-type t =
-  { name : Context_name.t
-  ; kind : Kind.t
-  ; profile : Profile.t
-  ; merlin : bool
-  ; fdo_target_exe : Path.t option
-  ; disable_dynamically_linked_foreign_archives : bool
-  ; for_host : t option
-  ; implicit : bool
-  ; build_dir : Path.Build.t
-  ; env_nodes : Env_nodes.t
-  ; path : Path.t list
-  ; toplevel_path : Path.t option
-  ; ocaml_bin : Path.t
-  ; ocaml : Path.t
-  ; ocamlc : Path.t
-  ; ocamlopt : Path.t option
-  ; ocamldep : Path.t
-  ; ocamlmklib : Path.t
-  ; ocamlobjinfo : Path.t option
-  ; env : Env.t
-  ; findlib : Findlib.t
-  ; findlib_toolchain : Context_name.t option
-  ; arch_sixtyfour : bool
-  ; opam_var_cache : (string, string) Table.t
-  ; ocaml_config : Ocaml_config.t
-  ; version : Ocaml_version.t
-  ; stdlib_dir : Path.t
-  ; ccomp_type : Lib_config.Ccomp_type.t
-  ; supports_shared_libraries : Dynlink_supported.By_the_os.t
-  ; which_cache : (string, Path.t option) Table.t
-  ; lib_config : Lib_config.t
-  }
+module T = struct
+  type t =
+    { name : Context_name.t
+    ; kind : Kind.t
+    ; profile : Profile.t
+    ; merlin : bool
+    ; fdo_target_exe : Path.t option
+    ; disable_dynamically_linked_foreign_archives : bool
+    ; for_host : t option
+    ; implicit : bool
+    ; build_dir : Path.Build.t
+    ; env_nodes : Env_nodes.t
+    ; path : Path.t list
+    ; toplevel_path : Path.t option
+    ; ocaml_bin : Path.t
+    ; ocaml : Path.t
+    ; ocamlc : Path.t
+    ; ocamlopt : Path.t option
+    ; ocamldep : Path.t
+    ; ocamlmklib : Path.t
+    ; ocamlobjinfo : Path.t option
+    ; env : Env.t
+    ; findlib : Findlib.t
+    ; findlib_toolchain : Context_name.t option
+    ; arch_sixtyfour : bool
+    ; opam_var_cache : (string, string) Table.t
+    ; ocaml_config : Ocaml_config.t
+    ; version : Ocaml_version.t
+    ; stdlib_dir : Path.t
+    ; ccomp_type : Lib_config.Ccomp_type.t
+    ; supports_shared_libraries : Dynlink_supported.By_the_os.t
+    ; which_cache : (string, Path.t option) Table.t
+    ; lib_config : Lib_config.t
+    }
 
-let equal x y = Context_name.equal x.name y.name
+  let equal x y = Context_name.equal x.name y.name
 
-let hash t = Context_name.hash t.name
+  let hash t = Context_name.hash t.name
 
-let to_dyn t : Dyn.t =
-  let open Dyn.Encoder in
-  let path = Path.to_dyn in
-  record
-    [ ("name", Context_name.to_dyn t.name)
-    ; ("kind", Kind.to_dyn t.kind)
-    ; ("profile", Profile.to_dyn t.profile)
-    ; ("merlin", Bool t.merlin)
-    ; ( "for_host"
-      , option Context_name.to_dyn (Option.map t.for_host ~f:(fun t -> t.name))
-      )
-    ; ("fdo_target_exe", option path t.fdo_target_exe)
-    ; ("build_dir", Path.Build.to_dyn t.build_dir)
-    ; ("toplevel_path", option path t.toplevel_path)
-    ; ("ocaml_bin", path t.ocaml_bin)
-    ; ("ocaml", path t.ocaml)
-    ; ("ocamlc", path t.ocamlc)
-    ; ("ocamlopt", option path t.ocamlopt)
-    ; ("ocamldep", path t.ocamldep)
-    ; ("ocamlmklib", path t.ocamlmklib)
-    ; ("env", Env.to_dyn (Env.diff t.env Env.initial))
-    ; ("findlib_path", list path (Findlib.paths t.findlib))
-    ; ("arch_sixtyfour", Bool t.arch_sixtyfour)
-    ; ( "natdynlink_supported"
-      , Bool
-          (Dynlink_supported.By_the_os.get t.lib_config.natdynlink_supported)
-      )
-    ; ( "supports_shared_libraries"
-      , Bool (Dynlink_supported.By_the_os.get t.supports_shared_libraries) )
-    ; ("opam_vars", Table.to_dyn string t.opam_var_cache)
-    ; ("ocaml_config", Ocaml_config.to_dyn t.ocaml_config)
-    ; ("which", Table.to_dyn (option path) t.which_cache)
-    ]
+  let to_dyn t : Dyn.t =
+    let open Dyn.Encoder in
+    let path = Path.to_dyn in
+    record
+      [ ("name", Context_name.to_dyn t.name)
+      ; ("kind", Kind.to_dyn t.kind)
+      ; ("profile", Profile.to_dyn t.profile)
+      ; ("merlin", Bool t.merlin)
+      ; ( "for_host"
+        , option Context_name.to_dyn
+            (Option.map t.for_host ~f:(fun t -> t.name)) )
+      ; ("fdo_target_exe", option path t.fdo_target_exe)
+      ; ("build_dir", Path.Build.to_dyn t.build_dir)
+      ; ("toplevel_path", option path t.toplevel_path)
+      ; ("ocaml_bin", path t.ocaml_bin)
+      ; ("ocaml", path t.ocaml)
+      ; ("ocamlc", path t.ocamlc)
+      ; ("ocamlopt", option path t.ocamlopt)
+      ; ("ocamldep", path t.ocamldep)
+      ; ("ocamlmklib", path t.ocamlmklib)
+      ; ("env", Env.to_dyn (Env.diff t.env Env.initial))
+      ; ("findlib_path", list path (Findlib.paths t.findlib))
+      ; ("arch_sixtyfour", Bool t.arch_sixtyfour)
+      ; ( "natdynlink_supported"
+        , Bool
+            (Dynlink_supported.By_the_os.get t.lib_config.natdynlink_supported)
+        )
+      ; ( "supports_shared_libraries"
+        , Bool (Dynlink_supported.By_the_os.get t.supports_shared_libraries) )
+      ; ("opam_vars", Table.to_dyn string t.opam_var_cache)
+      ; ("ocaml_config", Ocaml_config.to_dyn t.ocaml_config)
+      ; ("which", Table.to_dyn (option path) t.which_cache)
+      ]
+end
+
+include T
 
 let to_dyn_concise t : Dyn.t = Context_name.to_dyn t.name
 
@@ -755,16 +759,25 @@ module DB = struct
       | None -> Code_error.raise "context settings not set yet" []
   end
 
-  let get dir =
-    match Path.Build.extract_build_context dir with
-    | None ->
-      Code_error.raise "Context.DB.get: invalid dir"
-        [ ("dir", Path.Build.to_dyn dir) ]
-    | Some (name, _) ->
-      let name = Context_name.of_string name in
-      let env, workspace = Settings.get () in
-      let contexts = Memo.peek_exn Create.memo (env, workspace) in
-      List.find_exn contexts ~f:(fun c -> Context_name.equal name c.name)
+  let get =
+    let memo =
+      Memo.create "context-db-get" ~doc:"get context from db"
+        ~input:(module Context_name)
+        ~output:(Simple (module T))
+        ~visibility:Hidden Sync
+        (fun name ->
+          let env, workspace = Settings.get () in
+          let contexts = Memo.peek_exn Create.memo (env, workspace) in
+          List.find_exn contexts ~f:(fun c -> Context_name.equal name c.name))
+    in
+    fun dir ->
+      match Path.Build.extract_build_context dir with
+      | None ->
+        Code_error.raise "Context.DB.get: invalid dir"
+          [ ("dir", Path.Build.to_dyn dir) ]
+      | Some (name, _) ->
+        let name = Context_name.of_string name in
+        Memo.exec memo name
 end
 
 let create ~env workspace =

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -127,3 +127,7 @@ val name : t -> Context_name.t
 val has_native : t -> bool
 
 val lib_config : t -> Lib_config.t
+
+module DB : sig
+  val get : Path.Build.t -> t
+end

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -42,7 +42,7 @@ module Env_nodes : sig
     }
 end
 
-type t =
+type t = private
   { name : Context_name.t
   ; kind : Kind.t
   ; profile : Profile.t

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -103,8 +103,6 @@ val to_dyn_concise : t -> Dyn.t
 (** Compare the context names *)
 val compare : t -> t -> Ordering.t
 
-val create : env:Env.t -> Workspace.t -> t list Fiber.t
-
 val which : t -> string -> Path.t option
 
 val opam_config_var : t -> string -> string option Fiber.t
@@ -130,4 +128,6 @@ val lib_config : t -> Lib_config.t
 
 module DB : sig
   val get : Path.Build.t -> t
+
+  val all : unit -> t list Fiber.t
 end

--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -54,6 +54,8 @@ module Stanza = struct
     && List.equal File_binding.Unexpanded.equal binaries t.binaries
     && Option.equal Inline_tests.equal inline_tests t.inline_tests
 
+  let hash_config = Hashtbl.hash
+
   let empty_config =
     { flags = Ocaml_flags.Spec.standard
     ; foreign_flags =
@@ -73,10 +75,17 @@ module Stanza = struct
     | Any, Any -> true
     | _, _ -> false
 
+  let hash_pattern = Hashtbl.hash
+
   type t =
     { loc : Loc.t
     ; rules : (pattern * config) list
     }
+
+  let hash { loc = _; rules } =
+    List.hash (Tuple.T2.hash hash_pattern hash_config) rules
+
+  let to_dyn = Dyn.Encoder.opaque
 
   let equal { loc = _; rules } t =
     List.equal (Tuple.T2.equal equal_pattern equal_config) rules t.rules

--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -20,6 +20,13 @@ module Stanza = struct
       | Disabled
       | Ignored
 
+    let equal x y =
+      match (x, y) with
+      | Enabled, Enabled -> true
+      | Disabled, Disabled -> true
+      | Ignored, Ignored -> true
+      | _, _ -> false
+
     let decode =
       enum
         [ ("enabled", Enabled); ("disabled", Disabled); ("ignored", Ignored) ]
@@ -38,6 +45,15 @@ module Stanza = struct
     ; inline_tests : Inline_tests.t option
     }
 
+  let equal_config { flags; foreign_flags; env_vars; binaries; inline_tests } t
+      =
+    Ocaml_flags.Spec.equal flags t.flags
+    && Foreign.Language.Dict.equal Ordered_set_lang.Unexpanded.equal
+         foreign_flags t.foreign_flags
+    && Env.equal env_vars t.env_vars
+    && List.equal File_binding.Unexpanded.equal binaries t.binaries
+    && Option.equal Inline_tests.equal inline_tests t.inline_tests
+
   let empty_config =
     { flags = Ocaml_flags.Spec.standard
     ; foreign_flags =
@@ -51,10 +67,19 @@ module Stanza = struct
     | Profile of Profile.t
     | Any
 
+  let equal_pattern x y =
+    match (x, y) with
+    | Profile x, Profile y -> Profile.equal x y
+    | Any, Any -> true
+    | _, _ -> false
+
   type t =
     { loc : Loc.t
     ; rules : (pattern * config) list
     }
+
+  let equal { loc = _; rules } t =
+    List.equal (Tuple.T2.equal equal_pattern equal_config) rules t.rules
 
   let inline_tests_field =
     field_o "inline_tests"

--- a/src/dune/dune_env.mli
+++ b/src/dune/dune_env.mli
@@ -31,6 +31,10 @@ module Stanza : sig
     ; rules : (pattern * config) list
     }
 
+  val hash : t -> int
+
+  val to_dyn : t -> Dyn.t
+
   val equal : t -> t -> bool
 
   val foreign_flags :

--- a/src/dune/dune_env.mli
+++ b/src/dune/dune_env.mli
@@ -31,6 +31,8 @@ module Stanza : sig
     ; rules : (pattern * config) list
     }
 
+  val equal : t -> t -> bool
+
   val foreign_flags :
        since:Dune_lang.Syntax.Version.t option
     -> Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t

--- a/src/dune/file_binding.ml
+++ b/src/dune/file_binding.ml
@@ -5,6 +5,8 @@ type ('src, 'dst) t =
   ; dst : 'dst option
   }
 
+let equal f g { src; dst } t = f src t.src && Option.equal g dst t.dst
+
 module Expanded = struct
   type nonrec t = (Loc.t * Path.Build.t, Loc.t * string) t
 
@@ -27,6 +29,8 @@ end
 
 module Unexpanded = struct
   type nonrec t = (String_with_vars.t, String_with_vars.t) t
+
+  let equal = equal String_with_vars.equal_no_loc String_with_vars.equal_no_loc
 
   let make ~src:(locs, src) ~dst:(locd, dst) =
     { src = String_with_vars.make_text locs src

--- a/src/dune/file_binding.mli
+++ b/src/dune/file_binding.mli
@@ -15,6 +15,8 @@ end
 module Unexpanded : sig
   type t
 
+  val equal : t -> t -> bool
+
   val make : src:Loc.t * string -> dst:Loc.t * string -> t
 
   val expand :

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -44,6 +44,8 @@ module Language = struct
       ; cxx : 'a
       }
 
+    let equal f { c; cxx } t = f c t.c && f cxx t.cxx
+
     let c t = t.c
 
     let cxx t = t.cxx

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -32,6 +32,8 @@ module Language : sig
       ; cxx : 'a
       }
 
+    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
     val c : 'a t -> 'a
 
     val cxx : 'a t -> 'a

--- a/src/dune/global.ml
+++ b/src/dune/global.ml
@@ -1,0 +1,3 @@
+open Stdune
+
+let env = Fdecl.create Env.to_dyn

--- a/src/dune/global.mli
+++ b/src/dune/global.mli
@@ -1,0 +1,3 @@
+open Stdune
+
+val env : Env.t Fdecl.t

--- a/src/dune/install_rules.mli
+++ b/src/dune/install_rules.mli
@@ -16,7 +16,7 @@ val meta_and_dune_package_rules : Super_context.t -> dir:Path.Build.t -> unit
    altogether and take [project] instead.
 
    aalekseyev: actually I think we should just remove
-   [meta_and_dune_package_rules] from the interface and have [gen_rules]
-   do everything. *)
+   [meta_and_dune_package_rules] from the interface and have [gen_rules] do
+   everything. *)
 
 val packages : Super_context.t -> Package.Name.Set.t Path.Build.Map.t

--- a/src/dune/main.mli
+++ b/src/dune/main.mli
@@ -18,8 +18,7 @@ val package_install_file :
 
 (** Scan the source tree and discover the overall layout of the workspace. *)
 val scan_workspace :
-     ?workspace:Workspace.t
-  -> ?workspace_file:Path.t
+     ?workspace_file:Path.t
   -> ?x:Context_name.t
   -> ?capture_outputs:bool
   -> ?profile:Profile.t

--- a/src/dune/mode.ml
+++ b/src/dune/mode.ml
@@ -47,6 +47,8 @@ module Dict = struct
     ; native : 'a
     }
 
+  let equal f { byte; native } t = f byte t.byte && f native t.native
+
   let for_all { byte; native } ~f = f byte && f native
 
   let to_dyn to_dyn { byte; native } =

--- a/src/dune/mode.mli
+++ b/src/dune/mode.mli
@@ -34,6 +34,8 @@ module Dict : sig
     ; native : 'a
     }
 
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
   val for_all : 'a t -> f:('a -> bool) -> bool
 
   val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t

--- a/src/dune/ocaml_flags.ml
+++ b/src/dune/ocaml_flags.ml
@@ -62,8 +62,13 @@ type 'a t' =
   ; specific : 'a Mode.Dict.t
   }
 
+let equal f { common; specific } t =
+  f common t.common && Mode.Dict.equal f specific t.specific
+
 module Spec = struct
   type t = Ordered_set_lang.Unexpanded.t t'
+
+  let equal = equal Ordered_set_lang.Unexpanded.equal
 
   let standard =
     { common = Ordered_set_lang.Unexpanded.standard

--- a/src/dune/ocaml_flags.mli
+++ b/src/dune/ocaml_flags.mli
@@ -7,6 +7,8 @@ type t
 module Spec : sig
   type t
 
+  val equal : t -> t -> bool
+
   val decode : t Dune_lang.Decoder.fields_parser
 
   val standard : t

--- a/src/dune/ordered_set_lang.mli
+++ b/src/dune/ordered_set_lang.mli
@@ -40,10 +40,14 @@ val field :
   -> string
   -> t Dune_lang.Decoder.fields_parser
 
+val equal : t -> t -> bool
+
 module Unexpanded : sig
   type expanded = t
 
   type t
+
+  val equal : t -> t -> bool
 
   include Dune_lang.Conv.S with type t := t
 

--- a/src/dune/profile.ml
+++ b/src/dune/profile.ml
@@ -5,6 +5,13 @@ type t =
   | Release
   | User_defined of string
 
+let equal x y =
+  match (x, y) with
+  | Dev, Dev -> true
+  | Release, Release -> true
+  | User_defined x, User_defined y -> String.equal x y
+  | _, _ -> false
+
 let of_string = function
   | "dev" -> Dev
   | "release" -> Release

--- a/src/dune/profile.mli
+++ b/src/dune/profile.mli
@@ -7,6 +7,8 @@ type t =
   | Release
   | User_defined of string
 
+val equal : t -> t -> bool
+
 val is_dev : t -> bool
 
 val is_release : t -> bool

--- a/src/dune/simple_rules.ml
+++ b/src/dune/simple_rules.ml
@@ -156,7 +156,8 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
       ];
   (* add rules *)
   let src_in_build =
-    Path.Build.append_source (SC.context sctx).build_dir src_in_src
+    let context = Context.DB.get dir in
+    Path.Build.append_source context.build_dir src_in_src
   in
   let files =
     Build_system.eval_pred

--- a/src/dune/string_with_vars.ml
+++ b/src/dune/string_with_vars.ml
@@ -14,6 +14,8 @@ let compare_no_loc t1 t2 =
   | (Ordering.Lt | Gt) as a -> a
   | Eq -> Dune_lang.Template.compare_no_loc t1.template t2.template
 
+let equal_no_loc t1 t2 = Ordering.is_eq (compare_no_loc t1 t2)
+
 let make_syntax = (1, 0)
 
 let make template = { template; syntax_version = make_syntax }

--- a/src/dune/string_with_vars.mli
+++ b/src/dune/string_with_vars.mli
@@ -11,6 +11,8 @@ type t
 
 val compare_no_loc : t -> t -> Ordering.t
 
+val equal_no_loc : t -> t -> bool
+
 (** [loc t] returns the location of [t] — typically, in the [dune] file. *)
 val loc : t -> Loc.t
 

--- a/src/dune/workspace.ml
+++ b/src/dune/workspace.ml
@@ -452,19 +452,12 @@ module DB = struct
 
     let equal = ( == )
 
-    let t : t option ref = ref None
-
-    let set x = t := Some x
-
-    let get () =
-      match !t with
-      | Some t -> t
-      | None -> Code_error.raise "workspace settings not set yet" []
+    let t = Fdecl.create to_dyn
   end
 end
 
 let init ?x ?profile ?path () =
-  DB.Settings.set { DB.Settings.x; profile; path }
+  Fdecl.set DB.Settings.t { DB.Settings.x; profile; path }
 
 let workspace =
   let module Store = Memo.Store.Cell (DB.Settings) in
@@ -481,4 +474,4 @@ let workspace =
       ~output:(Simple (module T))
       Sync f
   in
-  fun () -> Memo.exec memo (DB.Settings.get ())
+  fun () -> Memo.exec memo (Fdecl.get DB.Settings.t)

--- a/src/dune/workspace.mli
+++ b/src/dune/workspace.mli
@@ -68,6 +68,10 @@ type t = private
 
 val equal : t -> t -> bool
 
+val to_dyn : t -> Dyn.t
+
+val hash : t -> int
+
 val load : ?x:Context_name.t -> ?profile:Profile.t -> Path.t -> t
 
 (** Default name of workspace files *)

--- a/src/dune/workspace.mli
+++ b/src/dune/workspace.mli
@@ -72,10 +72,10 @@ val to_dyn : t -> Dyn.t
 
 val hash : t -> int
 
-val load : ?x:Context_name.t -> ?profile:Profile.t -> Path.t -> t
+val init :
+  ?x:Context_name.t -> ?profile:Profile.t -> ?path:Path.t -> unit -> unit
 
 (** Default name of workspace files *)
 val filename : string
 
-(** Default configuration *)
-val default : ?x:Context_name.t -> ?profile:Profile.t -> unit -> t
+val workspace : unit -> t

--- a/src/dune/workspace.mli
+++ b/src/dune/workspace.mli
@@ -66,6 +66,8 @@ type t = private
   ; env : Dune_env.Stanza.t
   }
 
+val equal : t -> t -> bool
+
 val load : ?x:Context_name.t -> ?profile:Profile.t -> Path.t -> t
 
 (** Default name of workspace files *)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -803,26 +803,6 @@ end
 let cell t inp = dep_node t inp
 
 module Implicit_output = Implicit_output
-
-module Store = struct
-  module Cell (I : Input) = struct
-    type key = I.t
-
-    type 'a t = (I.t * 'a) option ref
-
-    let create () = ref None
-
-    let clear s = s := None
-
-    let set s k v = s := Some (k, v)
-
-    let find s k =
-      let open Option.O in
-      let* k', v = !s in
-      Option.some_if (I.equal k k') v
-  end
-
-  include Store_intf
-end
+module Store = Store_intf
 
 let on_already_reported f = on_already_reported := f

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -803,6 +803,26 @@ end
 let cell t inp = dep_node t inp
 
 module Implicit_output = Implicit_output
-module Store = Store_intf
+
+module Store = struct
+  module Cell (I : Input) = struct
+    type key = I.t
+
+    type 'a t = (I.t * 'a) option ref
+
+    let create () = ref None
+
+    let clear s = s := None
+
+    let set s k v = s := Some (k, v)
+
+    let find s k =
+      let open Option.O in
+      let* k', v = !s in
+      Option.some_if (I.equal k k') v
+  end
+
+  include Store_intf
+end
 
 let on_already_reported f = on_already_reported := f

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -107,12 +107,6 @@ module Visibility : sig
 end
 
 module Store : sig
-  module type Input = sig
-    type t
-
-    val to_dyn : t -> Dyn.t
-  end
-
   module type S = sig
     type key
 
@@ -125,6 +119,14 @@ module Store : sig
     val set : 'a t -> key -> 'a -> unit
 
     val find : 'a t -> key -> 'a option
+  end
+
+  module Cell (I : Input) : S with type key = I.t
+
+  module type Input = sig
+    type t
+
+    val to_dyn : t -> Dyn.t
   end
 end
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -107,6 +107,12 @@ module Visibility : sig
 end
 
 module Store : sig
+  module type Input = sig
+    type t
+
+    val to_dyn : t -> Dyn.t
+  end
+
   module type S = sig
     type key
 
@@ -119,14 +125,6 @@ module Store : sig
     val set : 'a t -> key -> 'a -> unit
 
     val find : 'a t -> key -> 'a option
-  end
-
-  module Cell (I : Input) : S with type key = I.t
-
-  module type Input = sig
-    type t
-
-    val to_dyn : t -> Dyn.t
   end
 end
 

--- a/src/stdune/env.mli
+++ b/src/stdune/env.mli
@@ -8,8 +8,6 @@ end
 
 type t
 
-val equal : t -> t -> bool
-
 val hash : t -> int
 
 module Map : Map.S with type key = Var.t

--- a/src/stdune/env.mli
+++ b/src/stdune/env.mli
@@ -14,6 +14,8 @@ val hash : t -> int
 
 module Map : Map.S with type key = Var.t
 
+val equal : t -> t -> bool
+
 val empty : t
 
 val vars : t -> Var.Set.t

--- a/src/stdune/tuple.ml
+++ b/src/stdune/tuple.ml
@@ -19,4 +19,6 @@ module T3 = struct
   type ('a, 'b, 'c) t = 'a * 'b * 'c
 
   let to_dyn = Dyn.Encoder.triple
+
+  let hash f g h (a, b, c) = Hashtbl.hash (f a, g b, h c)
 end

--- a/src/stdune/tuple.mli
+++ b/src/stdune/tuple.mli
@@ -27,4 +27,6 @@ module T3 : sig
 
   val to_dyn :
     ('a -> Dyn.t) -> ('b -> Dyn.t) -> ('c -> Dyn.t) -> ('a, 'b, 'c) t -> Dyn.t
+
+  val hash : ('a -> int) -> ('b -> int) -> ('c -> int) -> ('a, 'b, 'c) t -> int
 end


### PR DESCRIPTION
As discussed, we want the following properties for accessing the context:

* We don't need the super context. Knowing the directory should be sufficient.

* The context isn't inside a Fiber. This allows us to access it without refactoring a lot of the existing code.

In return, we must enforce the following property:

The contexts are static and can only be set once per process.