### PR TITLE
Fix cyclic-ish dependencies between [list] and [result]

### DIFF
--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -77,4 +77,4 @@ val for_all2 :
      'a list
   -> 'b list
   -> f:('a -> 'b -> bool)
-  -> (bool, [`Length_mismatch]) Result.t
+  -> (bool, [`Length_mismatch]) result


### PR DESCRIPTION
Jenga complains about the following tricky dependency structure:

* `list.mli` depends on `result.mli` (due to the use of `Result.t`)
* `result.ml` depends on `list.ml` (due to the use of `List.rev`)

While this is not strictly speaking a cycle, it does confuse Jenga.

/cc @rgrinberg This tricky dependency structure was introduced in this commit: https://github.com/ocaml/dune/commit/1b7078ba69303526d8bfc0a1b4b33d4998f2e8b8