### PR TITLE
Tweak dir triaging

### DIFF
--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -30,7 +30,8 @@ let in_dir ~name ~recursive ~contexts dir =
   | In_install_dir _ ->
     User_error.raise
       [ Pp.textf "Invalid alias: %s."
-          (Path.to_string_maybe_quoted Path.(relative build_dir "install"))
+          (Path.to_string_maybe_quoted
+             (Path.build Dune.Dpath.Build.install_dir))
       ; Pp.textf "There are no aliases in %s."
           (Path.to_string_maybe_quoted dir)
       ]

--- a/src/dune/alias.ml
+++ b/src/dune/alias.ml
@@ -150,12 +150,9 @@ let name t = t.name
 
 let dir t = t.dir
 
-(* Where we store stamp files for aliases *)
-let alias_dir = Path.Build.(relative root ".aliases")
-
 let stamp_file_dir t =
   let local = Path.Build.local t.dir in
-  Path.Build.append_local alias_dir local
+  Path.Build.append_local Dpath.Build.alias_dir local
 
 let fully_qualified_name t = Path.Build.relative t.dir (Name.to_string t.name)
 

--- a/src/dune/alias.mli
+++ b/src/dune/alias.mli
@@ -81,5 +81,3 @@ val find_dir_specified_on_command_line : dir:Path.Source.t -> File_tree.Dir.t
 val is_standard : Name.t -> bool
 
 val suffix : string
-
-val alias_dir : Path.Build.t

--- a/src/dune/config.ml
+++ b/src/dune/config.ml
@@ -1,11 +1,9 @@
 open! Stdune
 open! Import
 
-let local_install_dir =
-  let dir = Path.Build.relative Path.Build.root "install" in
-  fun ~context ->
-    let context = Context_name.to_string context in
-    Path.Build.relative dir context
+let local_install_dir ~context =
+  let context = Context_name.to_string context in
+  Path.Build.relative Dpath.Build.install_dir context
 
 let local_install_bin_dir ~context =
   Path.Build.relative (local_install_dir ~context) "bin"

--- a/src/dune/dpath.ml
+++ b/src/dune/dpath.ml
@@ -1,55 +1,82 @@
 open Stdune
 
+let install_dir_basename = "install"
+
+let alias_dir_basename = ".aliases"
+
+let install_dir = Path.Build.(relative root) install_dir_basename
+
+let alias_dir = Path.Build.(relative root) alias_dir_basename
+
 type target_kind =
   | Regular of Context_name.t * Path.Source.t
   | Alias of Context_name.t * Path.Source.t
   | Install of Context_name.t * Path.Source.t
   | Other of Path.Build.t
 
-type path_kind =
+module Target_dir = struct
+  type context_related =
+    | Root
+    | With_context of Context_name.t * Path.Source.t
+
+  let build_dir = function
+    | Root -> Path.Build.root
+    | With_context (ctx, s) ->
+      Path.Build.append_source (Context_name.build_dir ctx) s
+
+  type t =
+    | Install of context_related
+    | Alias of context_related
+    | Regular of context_related
+    | Invalid of Path.Build.t
+
+  (* _build/foo or _build/install/foo where foo is invalid *)
+
+  let of_target (fn as original_fn) =
+    match Path.Build.extract_first_component fn with
+    | None -> Regular Root
+    | Some (name, sub) -> (
+      if name = alias_dir_basename then
+        match Path.Local.split_first_component sub with
+        | None -> Alias Root
+        | Some (ctx, fn) ->
+          let ctx = Context_name.of_string ctx in
+          Alias (With_context (ctx, Path.Source.of_local fn))
+      else if name = install_dir_basename then
+        match Path.Local.split_first_component sub with
+        | None -> Install Root
+        | Some (ctx, fn) -> (
+          match Context_name.of_string_opt ctx with
+          | None -> Invalid original_fn
+          | Some ctx -> Install (With_context (ctx, Path.Source.of_local fn)) )
+      else
+        match Context_name.of_string_opt name with
+        | None -> Invalid fn
+        | Some ctx -> Regular (With_context (ctx, Path.Source.of_local sub)) )
+end
+
+type 'build path_kind =
   | Source of Path.Source.t
   | External of Path.External.t
-  | Build of target_kind
-
-let install_dir = Path.Build.(relative root) "install"
-
-let alias_dir = Path.Build.(relative root ".aliases")
+  | Build of 'build
 
 let analyse_target (fn as original_fn) : target_kind =
-  match Path.Build.extract_first_component fn with
-  | None -> Other fn
-  | Some (name, sub) -> (
-    if name = Path.Build.basename alias_dir then
-      match Path.Local.split_first_component sub with
-      | None -> Other fn
-      | Some (ctx, fn) ->
-        if Path.Local.is_root fn then
-          Other original_fn
-        else
-          let basename =
-            match String.rsplit2 (Path.Local.basename fn) ~on:'-' with
-            | None -> assert false
-            | Some (name, digest) ->
-              assert (String.length digest = 32);
-              name
-          in
-          let ctx = Context_name.of_string ctx in
-          Alias
-            ( ctx
-            , Path.Source.relative
-                (Path.Source.of_local (Path.Local.parent_exn fn))
-                basename )
-    else if name = Path.Build.basename install_dir then
-      match Path.Local.split_first_component sub with
-      | None -> Other original_fn
-      | Some (ctx, fn) -> (
-        match Context_name.of_string_opt ctx with
-        | None -> Other original_fn
-        | Some ctx -> Install (ctx, Path.Source.of_local fn) )
-    else
-      match Context_name.of_string_opt name with
-      | None -> Other fn
-      | Some ctx -> Regular (ctx, Path.Source.of_local sub) )
+  match Target_dir.of_target fn with
+  | Invalid _
+  | Alias Root
+  | Install Root
+  | Regular Root ->
+    Other fn
+  | Install (With_context (ctx, src_dir)) -> Install (ctx, src_dir)
+  | Regular (With_context (ctx, src_dir)) -> Regular (ctx, src_dir)
+  | Alias (With_context (ctx, fn)) -> (
+    match String.rsplit2 (Path.Source.basename fn) ~on:'-' with
+    | None -> assert false
+    | Some (basename, digest) ->
+      if String.length digest = 32 then
+        Alias (ctx, Path.Source.relative (Path.Source.parent_exn fn) basename)
+      else
+        Other original_fn )
 
 let describe_target fn =
   let ctx_suffix name =
@@ -83,6 +110,12 @@ let analyse_path (fn : Path.t) =
   | In_source_tree src -> Source src
   | External e -> External e
   | In_build_dir build -> Build (analyse_target build)
+
+let analyse_dir (fn : Path.t) =
+  match fn with
+  | In_source_tree src -> Source src
+  | External e -> External e
+  | In_build_dir build -> Build (Target_dir.of_target build)
 
 type t = Path.t
 

--- a/src/dune/dpath.mli
+++ b/src/dune/dpath.mli
@@ -33,4 +33,10 @@ module Build : sig
   include Dune_lang.Conv.S with type t = Path.Build.t
 
   val is_dev_null : t -> bool
+
+  val install_dir : t
+
+  val alias_dir : t
+
+  val is_alias_stamp_file : t -> bool
 end

--- a/src/dune/dpath.mli
+++ b/src/dune/dpath.mli
@@ -1,20 +1,38 @@
 open Stdune
 
+module Target_dir : sig
+  type context_related =
+    | Root
+    | With_context of Context_name.t * Path.Source.t
+
+  val build_dir : context_related -> Path.Build.t
+
+  type t =
+    | Install of context_related
+    | Alias of context_related
+    | Regular of context_related
+    | Invalid of Path.Build.t
+
+  val of_target : Path.Build.t -> t
+end
+
 type target_kind =
   | Regular of Context_name.t * Path.Source.t
   | Alias of Context_name.t * Path.Source.t
   | Install of Context_name.t * Path.Source.t
   | Other of Path.Build.t
 
-type path_kind =
+type 'build path_kind =
   | Source of Path.Source.t
   | External of Path.External.t
-  | Build of target_kind
+  | Build of 'build
 
 (** Return the name of an alias from its stamp file *)
 val analyse_target : Path.Build.t -> target_kind
 
-val analyse_path : Path.t -> path_kind
+val analyse_path : Path.t -> target_kind path_kind
+
+val analyse_dir : Path.t -> Target_dir.t path_kind
 
 (** Nice description of a target *)
 val describe_target : Path.Build.t -> string

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -689,11 +689,6 @@ module Build = struct
     | None ->
       Code_error.raise "Path.Build.drop_build_context_exn" [ ("t", to_dyn t) ]
 
-  (* CR-someday rgrinberg: I think we should just move this function to the
-     alias module. *)
-  let is_alias_stamp_file s =
-    String.is_prefix (Local.to_string s) ~prefix:".aliases/"
-
   let build_dir = Fdecl.create Kind.to_dyn
 
   let build_dir_prefix = Fdecl.create Dyn.Encoder.opaque

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -154,8 +154,6 @@ module Build : sig
       "righter" type. *)
   val extract_first_component : t -> (string * Local.t) option
 
-  val is_alias_stamp_file : t -> bool
-
   module Kind : sig
     type t = private
       | External of External.t


### PR DESCRIPTION
The current code has two problems:

* It hard codes the names of special directories like `_build/.aliases` and
  `_build/install`.
  
* The logic for analyzing target directories and targets is duplicated.

I attempt to address both of these problems. The first problem is solved by
moving the special directories to the `Dpath` module. The second problem is
addressed by reusing some of the code from `Dpath.analyse_target`.

PS: I also got rid of the `assert false` in `Dpath.analyse_target`. I recall it
was discussed that it was desirable, but I must have forgot about this.