### PR TITLE
Move promote settings to `Rule`

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -118,7 +118,7 @@ module Internal_rule = struct
       ; targets : Path.Build.Set.t
       ; context : Context.t option
       ; build : Action.t Build.t
-      ; mode : Dune_file.Rule.Mode.t
+      ; mode : Rule.Mode.t
       ; info : Rule.Info.t
       ; dir : Path.Build.t
       ; env : Env.t option

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -258,27 +258,6 @@ module Install_conf : sig
     }
 end
 
-module Promote : sig
-  module Lifetime : sig
-    type t =
-      | Unlimited  (** The promoted file will be deleted by [dune clean] *)
-      | Until_clean
-  end
-
-  module Into : sig
-    type t =
-      { loc : Loc.t
-      ; dir : string
-      }
-  end
-
-  type t =
-    { lifetime : Lifetime.t
-    ; into : Into.t option
-    ; only : Predicate_lang.Glob.t option
-    }
-end
-
 module Executables : sig
   module Link_mode : sig
     type t =
@@ -319,7 +298,7 @@ module Executables : sig
     ; buildable : Buildable.t
     ; variants : (Loc.t * Variant.Set.t) option
     ; package : Package.t option
-    ; promote : Promote.t option
+    ; promote : Rule.Promote.t option
     ; install_conf : File_binding.Unexpanded.t Install_conf.t option
     ; forbidden_libraries : (Loc.t * Lib_name.t) list
     ; bootstrap_info : string option
@@ -329,6 +308,20 @@ module Executables : sig
   val has_foreign : t -> bool
 
   val obj_dir : t -> dir:Path.Build.t -> Path.Build.t Obj_dir.t
+end
+
+module Menhir : sig
+  type t =
+    { merge_into : string option
+    ; flags : Ordered_set_lang.Unexpanded.t
+    ; modules : string list
+    ; mode : Rule.Mode.t
+    ; loc : Loc.t
+    ; infer : bool
+    ; enabled_if : Blang.t
+    }
+
+  type Stanza.t += T of t
 end
 
 module Rule : sig
@@ -349,44 +342,17 @@ module Rule : sig
       | Infer
   end
 
-  module Mode : sig
-    type t =
-      | Standard  (** Only use this rule if the source files don't exist. *)
-      | Fallback  (** Silently promote the targets to the source tree. *)
-      | Promote of Promote.t
-          (** Just ignore the source files entirely. This is for cases where
-              the targets are promoted only in a specific context, such as for
-              .install files. *)
-      | Ignore_source_files
-
-    val decode : t Dune_lang.Decoder.t
-  end
-
   type t =
     { targets : Targets.t
     ; deps : Dep_conf.t Bindings.t
     ; action : Loc.t * Action_dune_lang.t
-    ; mode : Mode.t
+    ; mode : Rule.Mode.t
     ; locks : String_with_vars.t list
     ; loc : Loc.t
     ; enabled_if : Blang.t
     ; alias : Alias.Name.t option
     ; package : Package.t option
     }
-end
-
-module Menhir : sig
-  type t =
-    { merge_into : string option
-    ; flags : Ordered_set_lang.Unexpanded.t
-    ; modules : string list
-    ; mode : Rule.Mode.t
-    ; loc : Loc.t
-    ; infer : bool
-    ; enabled_if : Blang.t
-    }
-
-  type Stanza.t += T of t
 end
 
 module Coq : sig

--- a/src/dune/dune_load.ml
+++ b/src/dune/dune_load.ml
@@ -1,21 +1,21 @@
 open! Stdune
 open Import
-open Dune_file
 
 module Dune_file = struct
   type t =
     { dir : Path.Source.t
     ; project : Dune_project.t
-    ; stanzas : Stanzas.t
+    ; stanzas : Dune_file.Stanzas.t
     }
 
   let parse sexps ~dir ~file ~project =
-    let stanzas = Stanzas.parse ~file project sexps in
+    let stanzas = Dune_file.Stanzas.parse ~file project sexps in
     let stanzas =
       if !Clflags.ignore_promoted_rules then
         List.filter stanzas ~f:(function
-          | Rule { mode = Promote { only = None; _ }; _ }
-          | Dune_file.Menhir.T { mode = Promote { only = None; _ }; _ } ->
+          | Dune_file.Rule { mode = Rule.Mode.Promote { only = None; _ }; _ }
+          | Dune_file.Menhir.T
+              { mode = Rule.Mode.Promote { only = None; _ }; _ } ->
             false
           | _ -> true)
       else

--- a/src/dune/exe.mli
+++ b/src/dune/exe.mli
@@ -38,7 +38,7 @@ end
 val build_and_link :
      program:Program.t
   -> linkages:Linkage.t list
-  -> promote:Dune_file.Promote.t option
+  -> promote:Rule.Promote.t option
   -> ?link_args:Command.Args.static Command.Args.t Build.t
   -> ?o_files:Path.t list
   -> Compilation_context.t
@@ -47,7 +47,7 @@ val build_and_link :
 val build_and_link_many :
      programs:Program.t list
   -> linkages:Linkage.t list
-  -> promote:Dune_file.Promote.t option
+  -> promote:Rule.Promote.t option
   -> ?link_args:Command.Args.static Command.Args.t Build.t
   -> ?o_files:Path.t list
   -> Compilation_context.t

--- a/src/dune/js_of_ocaml_rules.ml
+++ b/src/dune/js_of_ocaml_rules.ml
@@ -196,7 +196,7 @@ let build_exe cc ~js_of_ocaml ~src ~(cm : Path.t list Build.t) ~flags ~promote
   let mk_target ext = Path.Build.extend_basename src ~suffix:ext in
   let target = mk_target ".js" in
   let standalone_runtime = mk_target ".runtime.js" in
-  let mode : Dune_file.Rule.Mode.t =
+  let mode : Rule.Mode.t =
     match promote with
     | None -> Standard
     | Some p -> Promote p

--- a/src/dune/js_of_ocaml_rules.mli
+++ b/src/dune/js_of_ocaml_rules.mli
@@ -2,22 +2,21 @@
 
 open! Stdune
 open Import
-open Dune_file
 
 val build_cm :
      Compilation_context.t
-  -> js_of_ocaml:Js_of_ocaml.t
+  -> js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> src:Path.Build.t
   -> target:Path.Build.t
   -> Action.t Build.t list
 
 val build_exe :
      Compilation_context.t
-  -> js_of_ocaml:Js_of_ocaml.t
+  -> js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> src:Path.Build.t
   -> cm:Path.t list Build.t
   -> flags:Command.Args.dynamic Command.Args.t
-  -> promote:Dune_file.Promote.t option
+  -> promote:Rule.Promote.t option
   -> unit
 
 val setup_separate_compilation_rules : Super_context.t -> string list -> unit

--- a/src/dune/opam_create.ml
+++ b/src/dune/opam_create.ml
@@ -184,8 +184,7 @@ let add_rule sctx ~project ~pkg =
   in
   let dir = Path.Build.append_source build_dir pkg.path in
   let mode =
-    Dune_file.Rule.Mode.Promote
-      { lifetime = Unlimited; into = None; only = None }
+    Rule.Mode.Promote { lifetime = Unlimited; into = None; only = None }
   in
   Super_context.add_rule sctx ~mode ~dir opam_rule;
   let aliases =

--- a/src/dune/rule.ml
+++ b/src/dune/rule.ml
@@ -18,20 +18,48 @@ module Info = struct
       None
 end
 
+module Promote = struct
+  module Lifetime = struct
+    type t =
+      | Unlimited
+      | Until_clean
+  end
+
+  module Into = struct
+    type t =
+      { loc : Loc.t
+      ; dir : string
+      }
+  end
+
+  type t =
+    { lifetime : Lifetime.t
+    ; into : Into.t option
+    ; only : Predicate_lang.Glob.t option
+    }
+end
+
+module Mode = struct
+  type t =
+    | Standard
+    | Fallback
+    | Promote of Promote.t
+    | Ignore_source_files
+end
+
 type t =
   { context : Context.t option
   ; env : Env.t option
   ; build : Action.t Build.t
   ; targets : Path.Build.Set.t
-  ; mode : Dune_file.Rule.Mode.t
+  ; mode : Mode.t
   ; locks : Path.t list
   ; info : Info.t
   ; dir : Path.Build.t
   }
 
-let make ?(sandbox = Sandbox_config.default)
-    ?(mode = Dune_file.Rule.Mode.Standard) ~context ~env ?(locks = [])
-    ?(info = Info.Internal) build =
+let make ?(sandbox = Sandbox_config.default) ?(mode = Mode.Standard) ~context
+    ~env ?(locks = []) ?(info = Info.Internal) build =
   let open Build.O in
   let build = Build.dep (Dep.sandbox_config sandbox) >>> build in
   let targets = Build.targets build in

--- a/src/dune/rule.mli
+++ b/src/dune/rule.mli
@@ -14,12 +14,44 @@ module Info : sig
   val loc : t -> Loc.t option
 end
 
+module Promote : sig
+  module Lifetime : sig
+    type t =
+      | Unlimited  (** The promoted file will be deleted by [dune clean] *)
+      | Until_clean
+  end
+
+  module Into : sig
+    type t =
+      { loc : Loc.t
+      ; dir : string
+      }
+  end
+
+  type t =
+    { lifetime : Lifetime.t
+    ; into : Into.t option
+    ; only : Predicate_lang.Glob.t option
+    }
+end
+
+module Mode : sig
+  type t =
+    | Standard  (** Only use this rule if the source files don't exist. *)
+    | Fallback  (** Silently promote the targets to the source tree. *)
+    | Promote of Promote.t
+        (** Just ignore the source files entirely. This is for cases where the
+            targets are promoted only in a specific context, such as for
+            .install files. *)
+    | Ignore_source_files
+end
+
 type t =
   { context : Context.t option
   ; env : Env.t option
   ; build : Action.t Build.t
   ; targets : Path.Build.Set.t
-  ; mode : Dune_file.Rule.Mode.t
+  ; mode : Mode.t
   ; locks : Path.t list
   ; info : Info.t  (** Directory where all the targets are produced *)
   ; dir : Path.Build.t
@@ -27,7 +59,7 @@ type t =
 
 val make :
      ?sandbox:Sandbox_config.t
-  -> ?mode:Dune_file.Rule.Mode.t
+  -> ?mode:Mode.t
   -> context:Context.t option
   -> env:Env.t option
   -> ?locks:Path.t list

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -6,7 +6,6 @@
 
 open! Stdune
 open Import
-open Dune_file
 
 type t
 
@@ -23,9 +22,10 @@ val create :
 
 val context : t -> Context.t
 
-val stanzas : t -> Stanzas.t Dir_with_dune.t list
+val stanzas : t -> Dune_file.Stanzas.t Dir_with_dune.t list
 
-val stanzas_in : t -> dir:Path.Build.t -> Stanzas.t Dir_with_dune.t option
+val stanzas_in :
+  t -> dir:Path.Build.t -> Dune_file.Stanzas.t Dir_with_dune.t option
 
 val packages : t -> Package.t Package.Name.Map.t
 
@@ -58,7 +58,8 @@ val internal_lib_names : t -> Lib_name.Set.t
 
 (** Compute the ocaml flags based on the directory environment and a buildable
     stanza *)
-val ocaml_flags : t -> dir:Path.Build.t -> Buildable.t -> Ocaml_flags.t
+val ocaml_flags :
+  t -> dir:Path.Build.t -> Dune_file.Buildable.t -> Ocaml_flags.t
 
 val foreign_flags :
      t
@@ -87,7 +88,7 @@ val dir_is_vendored : Path.Source.t -> bool
 val add_rule :
      t
   -> ?sandbox:Sandbox_config.t
-  -> ?mode:Dune_file.Rule.Mode.t
+  -> ?mode:Rule.Mode.t
   -> ?locks:Path.t list
   -> ?loc:Loc.t
   -> dir:Path.Build.t
@@ -97,7 +98,7 @@ val add_rule :
 val add_rule_get_targets :
      t
   -> ?sandbox:Sandbox_config.t
-  -> ?mode:Dune_file.Rule.Mode.t
+  -> ?mode:Rule.Mode.t
   -> ?locks:Path.t list
   -> ?loc:Loc.t
   -> dir:Path.Build.t


### PR DESCRIPTION
`Rule` is unusable without these types anyway and it allows us to create
rules without depending on `Dune_file.t`.