### PR TITLE
Deprecate actions in the alias Stanza

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -827,14 +827,14 @@ same lock:
 
 .. code:: scheme
 
-    (alias
-     (name   runtest)
+    (rule
+     (alias  runtest)
      (deps   foo)
      (locks  m)
      (action (run test.exe %{deps})))
 
     (alias
-     (name   runtest)
+     (rule   runtest)
      (deps   bar)
      (locks  m)
      (action (run test.exe %{deps})))
@@ -853,8 +853,8 @@ simply use an absolute filename:
 
 .. code:: scheme
 
-    (alias
-     (name   runtest)
+    (rule
+     (alias   runtest)
      (deps   foo)
      (locks  /tcp-port/1042)
      (action (run test.exe %{deps})))
@@ -913,8 +913,8 @@ More precisely, let's consider the following dune file:
    (rule
     (with-stdout-to data.out (run ./test.exe)))
 
-   (alias
-    (name   runtest)
+   (rule
+    (alias   runtest)
     (action (diff data.expected data.out)))
 
 Where ``data.expected`` is a file committed in the source

--- a/doc/dune
+++ b/doc/dune
@@ -29,7 +29,7 @@
    %{targets}
    (run bash %{dep:update-jbuild.sh}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff dune.inc dune.inc.gen)))

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1069,8 +1069,8 @@ The typical use of the ``alias`` stanza is to define tests:
 
 .. code:: scheme
 
-    (alias
-     (name   runtest)
+    (rule
+     (alias   runtest)
      (action (run %{exe:my-test-program.exe} blah)))
 
 See the section about :ref:`running-tests` for details.

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -202,8 +202,8 @@ should be rewritten to the following dune file:
 
 .. code:: scheme
 
-          (alias
-           (name   runtest)
+          (rule
+           (alias  runtest)
            (deps   (:x input))
            (action (run ./test.exe %{x})))
 

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -407,8 +407,8 @@ command. For instance let's consider this test:
           (rule
            (with-stdout-to tests.output (run ./tests.exe)))
 
-          (alias
-           (name runtest)
+          (rule
+           (alias runtest)
            (action (diff tests.expected test.output)))
 
 After having run ``tests.exe`` and dumping its output to ``tests.output``, dune

--- a/example/dune
+++ b/example/dune
@@ -1,7 +1,7 @@
 (data_only_dirs sample-projects)
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (package dune)
   (source_tree sample-projects/hello_world))
@@ -12,8 +12,8 @@
     (run %{exe:../test/blackbox-tests/cram.exe} -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (package dune)
   (source_tree sample-projects/with-configure-step))

--- a/otherlibs/action-plugin/test/depend-on-directory-without-targets/dune
+++ b/otherlibs/action-plugin/test/depend-on-directory-without-targets/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/depend-on-directory-without-targets/test/run.t
+++ b/otherlibs/action-plugin/test/depend-on-directory-without-targets/test/run.t
@@ -6,8 +6,8 @@
   $ cat > dune << EOF
   > (data_only_dirs some_dir)
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/dune
+++ b/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/test/run.t
+++ b/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/test/run.t
@@ -16,8 +16,8 @@ they were forced to rebuild.
   >   (echo "Building some_file!\n")
   >   (with-stdout-to %{target} (echo "Hello from some_file!")))))
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/depends-on-directory-with-glob/dune
+++ b/otherlibs/action-plugin/test/depends-on-directory-with-glob/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/depends-on-directory-with-glob/test/run.t
+++ b/otherlibs/action-plugin/test/depends-on-directory-with-glob/test/run.t
@@ -4,8 +4,8 @@
   > EOF
 
   $ cat > dune << EOF
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/depends-on-its-target-by-read-dir/dune
+++ b/otherlibs/action-plugin/test/depends-on-its-target-by-read-dir/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/depends-on-its-target/dune
+++ b/otherlibs/action-plugin/test/depends-on-its-target/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/dune
+++ b/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/test/run.t
+++ b/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/test/run.t
@@ -31,8 +31,8 @@ only the dependencies up to this stage are rebuilt.
   >    (echo "Building foo_or_bar!\n")
   >    (copy %{deps} %{target}))))
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./client.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/multiple-dynamic-run-within-single-action/dune
+++ b/otherlibs/action-plugin/test/multiple-dynamic-run-within-single-action/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/no-dependencies/dune
+++ b/otherlibs/action-plugin/test/no-dependencies/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/no-dependencies/test/run.t
+++ b/otherlibs/action-plugin/test/no-dependencies/test/run.t
@@ -7,8 +7,8 @@ but requires no dependencies can be successfully run.
   > EOF
 
   $ cat > dune << EOF
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/one-absent-dependency/dune
+++ b/otherlibs/action-plugin/test/one-absent-dependency/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/one-absent-dependency/test/run.t
+++ b/otherlibs/action-plugin/test/one-absent-dependency/test/run.t
@@ -7,8 +7,8 @@ and requires dependency that can not be build fails.
   > EOF
 
   $ cat > dune << EOF
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 
@@ -17,8 +17,8 @@ and requires dependency that can not be build fails.
   $ dune runtest --display short
            foo alias runtest
   File "dune", line 1, characters 0-57:
-  1 | (alias
-  2 |  (name runtest)
+  1 | (rule
+  2 |  (alias runtest)
   3 |  (action (dynamic-run ./foo.exe)))
   Error: No rule found for some_absent_dependency
   [1]

--- a/otherlibs/action-plugin/test/one-dependency-with-chdir/dune
+++ b/otherlibs/action-plugin/test/one-dependency-with-chdir/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/one-dependency-with-chdir/test/run.t
+++ b/otherlibs/action-plugin/test/one-dependency-with-chdir/test/run.t
@@ -7,11 +7,11 @@ when we 'chdir' into different directory.
   > EOF
 
   $ cat > dune << EOF
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action
   >   (chdir some_dir
-  >   (dynamic-run ./foo.exe))))
+  >    (dynamic-run ./foo.exe))))
   > EOF
 
   $ mkdir some_dir

--- a/otherlibs/action-plugin/test/one-dependency/dune
+++ b/otherlibs/action-plugin/test/one-dependency/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/one-dependency/test/run.t
+++ b/otherlibs/action-plugin/test/one-dependency/test/run.t
@@ -11,8 +11,8 @@ and requires one dependency can be successfully run.
   >  (target some_dependency)
   >  (action (with-stdout-to %{target} (echo "Hello from some_dependency!"))))
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/one-directory-dependency/dune
+++ b/otherlibs/action-plugin/test/one-directory-dependency/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/one-directory-dependency/test/run.t
+++ b/otherlibs/action-plugin/test/one-directory-dependency/test/run.t
@@ -8,8 +8,8 @@ directory to be build.
   > EOF
 
   $ cat > dune << EOF
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/one-target/dune
+++ b/otherlibs/action-plugin/test/one-target/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/one-target/test/run.t
+++ b/otherlibs/action-plugin/test/one-target/test/run.t
@@ -9,8 +9,8 @@
   >  (action
   >   (dynamic-run ./foo.exe)))
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (cat some_target)))
   > EOF
 

--- a/otherlibs/action-plugin/test/one-undeclared-target/dune
+++ b/otherlibs/action-plugin/test/one-undeclared-target/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/one-undeclared-target/test/run.t
+++ b/otherlibs/action-plugin/test/one-undeclared-target/test/run.t
@@ -4,8 +4,8 @@
   > EOF
 
   $ cat > dune << EOF
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 

--- a/otherlibs/action-plugin/test/ordinary-executable/dune
+++ b/otherlibs/action-plugin/test/ordinary-executable/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/ordinary-executable/test/run.t
+++ b/otherlibs/action-plugin/test/ordinary-executable/test/run.t
@@ -7,8 +7,8 @@ ordinary executable instead of one linked against dune-action-plugin.
   > EOF
 
   $ cat > dune << EOF
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./foo.exe)))
   > EOF
 
@@ -18,8 +18,8 @@ ordinary executable instead of one linked against dune-action-plugin.
            foo alias runtest
   Hello from foo!
   File "dune", line 1, characters 0-57:
-  1 | (alias
-  2 |  (name runtest)
+  1 | (rule
+  2 |  (alias runtest)
   3 |  (action (dynamic-run ./foo.exe)))
   Error: Executable 'foo.exe' declared as using dune-action-plugin (declared
   with 'dynamic-run' tag) failed to respond to dune.

--- a/otherlibs/action-plugin/test/simple-copy/dune
+++ b/otherlibs/action-plugin/test/simple-copy/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/simple-copy/test/run.t
+++ b/otherlibs/action-plugin/test/simple-copy/test/run.t
@@ -13,8 +13,8 @@
   >  (action
   >   (dynamic-run ./foo.exe)))
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action
   >   (progn
   >    (cat some_source)

--- a/otherlibs/action-plugin/test/target-in-parent-directory/dune
+++ b/otherlibs/action-plugin/test/target-in-parent-directory/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/target-in-parent-directory/test/run.t
+++ b/otherlibs/action-plugin/test/target-in-parent-directory/test/run.t
@@ -10,8 +10,8 @@
   >   (chdir some_dir
   >    (dynamic-run ./foo.exe))))
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (cat some_file)))
   > EOF
 

--- a/otherlibs/action-plugin/test/two-stages-dependency-choose/dune
+++ b/otherlibs/action-plugin/test/two-stages-dependency-choose/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test)
 
-(alias
- (name run_dynamic)
+(rule
+ (alias run_dynamic)
  (deps
   (package dune)
   (source_tree test/)

--- a/otherlibs/action-plugin/test/two-stages-dependency-choose/test/run.t
+++ b/otherlibs/action-plugin/test/two-stages-dependency-choose/test/run.t
@@ -25,8 +25,8 @@ on based on dependency from the previous stage.
   >  (target foo_or_bar)
   >  (action (with-stdout-to %{target} (echo "bar"))))
   > \
-  > (alias
-  >  (name runtest)
+  > (rule
+  >  (alias runtest)
   >  (action (dynamic-run ./client.exe)))
   > EOF
 

--- a/otherlibs/build-info/test/dune
+++ b/otherlibs/build-info/test/dune
@@ -1,5 +1,5 @@
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (package dune)
   (package dune-build-info))

--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -6,7 +6,7 @@ Test embedding of build information
   $ for i in a b c; do
   >   mkdir -p $i
   >   cat >$i/dune-project <<EOF
-  > (lang dune 1.11)
+  > (lang dune 2.0)
   > (name $i)
   > (package (name $i))
   > EOF

--- a/otherlibs/configurator/test/blackbox-tests/dune
+++ b/otherlibs/configurator/test/blackbox-tests/dune
@@ -1,7 +1,7 @@
 (data_only_dirs test-cases)
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (package dune-configurator)
  (deps
   (package dune)
@@ -16,8 +16,8 @@
  (enabled_if
   (<> %{ocaml-config:system} win)))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (package dune-configurator)
  (deps
   (package dune)

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1702,6 +1702,7 @@ module Rule = struct
       ; ("locks", Field)
       ; ("fallback", Field)
       ; ("mode", Field)
+      ; ("alias", Field)
       ]
 
   let short_form =

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1990,9 +1990,17 @@ module Alias_conf = struct
   let decode =
     fields
       (let+ name = field "name" Alias.Name.decode
-       and+ loc = loc
        and+ package = field_o "package" Pkg.decode
-       and+ action = field_o "action" (located Action_dune_lang.decode)
+       and+ action =
+         field_o "action"
+           (let extra_info =
+              "Use a rule stanza with the alias field instead"
+            in
+            let* () =
+              Dune_lang.Syntax.deleted_in ~extra_info Stanza.syntax (2, 0)
+            in
+            located Action_dune_lang.decode)
+       and+ loc = loc
        and+ locks = field "locks" (repeat String_with_vars.decode) ~default:[]
        and+ deps =
          field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty

--- a/test/blackbox-tests/dune
+++ b/test/blackbox-tests/dune
@@ -23,7 +23,7 @@
    %{targets}
    (run ./gen_tests.exe))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff dune.inc dune.inc.gen)))

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1,429 +1,429 @@
-(alias
- (name action-modifying-a-dependency)
+(rule
+ (alias action-modifying-a-dependency)
  (deps (package dune) (source_tree test-cases/action-modifying-a-dependency))
  (action
   (chdir
    test-cases/action-modifying-a-dependency
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name aliases)
+(rule
+ (alias aliases)
  (deps (package dune) (source_tree test-cases/aliases))
  (action
   (chdir
    test-cases/aliases
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name all-alias)
+(rule
+ (alias all-alias)
  (deps (package dune) (source_tree test-cases/all-alias))
  (action
   (chdir
    test-cases/all-alias
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name allow_approximate_merlin)
+(rule
+ (alias allow_approximate_merlin)
  (deps (package dune) (source_tree test-cases/allow_approximate_merlin))
  (action
   (chdir
    test-cases/allow_approximate_merlin
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name bad-alias-error)
+(rule
+ (alias bad-alias-error)
  (deps (package dune) (source_tree test-cases/bad-alias-error))
  (action
   (chdir
    test-cases/bad-alias-error
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name block-strings)
+(rule
+ (alias block-strings)
  (deps (package dune) (source_tree test-cases/block-strings))
  (action
   (chdir
    test-cases/block-strings
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name byte-code-only)
+(rule
+ (alias byte-code-only)
  (deps (package dune) (source_tree test-cases/byte-code-only))
  (action
   (chdir
    test-cases/byte-code-only
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name c-stubs)
+(rule
+ (alias c-stubs)
  (deps (package dune) (source_tree test-cases/c-stubs))
  (action
   (chdir
    test-cases/c-stubs
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name check-alias)
+(rule
+ (alias check-alias)
  (deps (package dune) (source_tree test-cases/check-alias))
  (action
   (chdir
    test-cases/check-alias
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name cinaps)
+(rule
+ (alias cinaps)
  (deps (package dune) (source_tree test-cases/cinaps))
  (action
   (chdir
    test-cases/cinaps
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name cmdliner-dep-conf)
+(rule
+ (alias cmdliner-dep-conf)
  (deps (package dune) (source_tree test-cases/cmdliner-dep-conf))
  (action
   (chdir
    test-cases/cmdliner-dep-conf
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name contents-depends-on-glob)
+(rule
+ (alias contents-depends-on-glob)
  (deps (package dune) (source_tree test-cases/contents-depends-on-glob))
  (action
   (chdir
    test-cases/contents-depends-on-glob
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name copy-files-non-sub-dir-error)
+(rule
+ (alias copy-files-non-sub-dir-error)
  (deps (package dune) (source_tree test-cases/copy-files-non-sub-dir-error))
  (action
   (chdir
    test-cases/copy-files-non-sub-dir-error
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name copy_files)
+(rule
+ (alias copy_files)
  (deps (package dune) (source_tree test-cases/copy_files))
  (action
   (chdir
    test-cases/copy_files
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name coq)
+(rule
+ (alias coq)
  (deps (package dune) (source_tree test-cases/coq))
  (action
   (chdir
    test-cases/coq
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name corrections)
+(rule
+ (alias corrections)
  (deps (package dune) (source_tree test-cases/corrections))
  (action
   (chdir
    test-cases/corrections
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name cross-compilation)
+(rule
+ (alias cross-compilation)
  (deps (package dune) (source_tree test-cases/cross-compilation))
  (action
   (chdir
    test-cases/cross-compilation
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name custom-build-dir)
+(rule
+ (alias custom-build-dir)
  (deps (package dune) (source_tree test-cases/custom-build-dir))
  (action
   (chdir
    test-cases/custom-build-dir
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name custom-cross-compilation)
+(rule
+ (alias custom-cross-compilation)
  (deps (package dune) (source_tree test-cases/custom-cross-compilation))
  (action
   (chdir
    test-cases/custom-cross-compilation
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name cxx-extension)
+(rule
+ (alias cxx-extension)
  (deps (package dune) (source_tree test-cases/cxx-extension))
  (action
   (chdir
    test-cases/cxx-extension
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name default-targets)
+(rule
+ (alias default-targets)
  (deps (package dune) (source_tree test-cases/default-targets))
  (action
   (chdir
    test-cases/default-targets
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dep-on-dir-that-does-not-exist)
+(rule
+ (alias dep-on-dir-that-does-not-exist)
  (deps (package dune) (source_tree test-cases/dep-on-dir-that-does-not-exist))
  (action
   (chdir
    test-cases/dep-on-dir-that-does-not-exist
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dep-vars)
+(rule
+ (alias dep-vars)
  (deps (package dune) (source_tree test-cases/dep-vars))
  (action
   (chdir
    test-cases/dep-vars
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name depend-on-the-universe)
+(rule
+ (alias depend-on-the-universe)
  (deps (package dune) (source_tree test-cases/depend-on-the-universe))
  (action
   (chdir
    test-cases/depend-on-the-universe
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name deprecated-library-name)
+(rule
+ (alias deprecated-library-name)
  (deps (package dune) (source_tree test-cases/deprecated-library-name))
  (action
   (chdir
    test-cases/deprecated-library-name
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name deps-conf-vars)
+(rule
+ (alias deps-conf-vars)
  (deps (package dune) (source_tree test-cases/deps-conf-vars))
  (action
   (chdir
    test-cases/deps-conf-vars
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dialects)
+(rule
+ (alias dialects)
  (deps (package dune) (source_tree test-cases/dialects))
  (action
   (chdir
    test-cases/dialects
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dir-target-dep)
+(rule
+ (alias dir-target-dep)
  (deps (package dune) (source_tree test-cases/dir-target-dep))
  (action
   (chdir
    test-cases/dir-target-dep
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name disable-promotion)
+(rule
+ (alias disable-promotion)
  (deps (package dune) (source_tree test-cases/disable-promotion))
  (action
   (chdir
    test-cases/disable-promotion
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name double-echo)
+(rule
+ (alias double-echo)
  (deps (package dune) (source_tree test-cases/double-echo))
  (action
   (chdir
    test-cases/double-echo
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-build-dir-exec-1101)
+(rule
+ (alias dune-build-dir-exec-1101)
  (deps (package dune) (source_tree test-cases/dune-build-dir-exec-1101))
  (action
   (chdir
    test-cases/dune-build-dir-exec-1101
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-cache-dedup)
+(rule
+ (alias dune-cache-dedup)
  (deps (package dune) (source_tree test-cases/dune-cache-dedup))
  (action
   (chdir
    test-cases/dune-cache-dedup
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-cache-dedup-direct)
+(rule
+ (alias dune-cache-dedup-direct)
  (deps (package dune) (source_tree test-cases/dune-cache-dedup-direct))
  (action
   (chdir
    test-cases/dune-cache-dedup-direct
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-cache-promote)
+(rule
+ (alias dune-cache-promote)
  (deps (package dune) (source_tree test-cases/dune-cache-promote))
  (action
   (chdir
    test-cases/dune-cache-promote
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-cache-promote-direct)
+(rule
+ (alias dune-cache-promote-direct)
  (deps (package dune) (source_tree test-cases/dune-cache-promote-direct))
  (action
   (chdir
    test-cases/dune-cache-promote-direct
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-cache-symlink)
+(rule
+ (alias dune-cache-symlink)
  (deps (package dune) (source_tree test-cases/dune-cache-symlink))
  (action
   (chdir
    test-cases/dune-cache-symlink
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-cache-symlink-direct)
+(rule
+ (alias dune-cache-symlink-direct)
  (deps (package dune) (source_tree test-cases/dune-cache-symlink-direct))
  (action
   (chdir
    test-cases/dune-cache-symlink-direct
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-cache-trim)
+(rule
+ (alias dune-cache-trim)
  (deps (package dune) (source_tree test-cases/dune-cache-trim))
  (action
   (chdir
    test-cases/dune-cache-trim
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-init)
+(rule
+ (alias dune-init)
  (deps (package dune) (source_tree test-cases/dune-init))
  (action
   (chdir
    test-cases/dune-init
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-jbuild-var-case)
+(rule
+ (alias dune-jbuild-var-case)
  (deps (package dune) (source_tree test-cases/dune-jbuild-var-case))
  (action
   (chdir
    test-cases/dune-jbuild-var-case
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-package)
+(rule
+ (alias dune-package)
  (deps (package dune) (source_tree test-cases/dune-package))
  (action
   (chdir
    test-cases/dune-package
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-ppx-driver-system)
+(rule
+ (alias dune-ppx-driver-system)
  (deps (package dune) (source_tree test-cases/dune-ppx-driver-system))
  (action
   (chdir
    test-cases/dune-ppx-driver-system
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-project-edition)
+(rule
+ (alias dune-project-edition)
  (deps (package dune) (source_tree test-cases/dune-project-edition))
  (action
   (chdir
    test-cases/dune-project-edition
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-project-meta)
+(rule
+ (alias dune-project-meta)
  (deps (package dune) (source_tree test-cases/dune-project-meta))
  (action
   (chdir
    test-cases/dune-project-meta
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune-project-no-opam)
+(rule
+ (alias dune-project-no-opam)
  (deps (package dune) (source_tree test-cases/dune-project-no-opam))
  (action
   (chdir
    test-cases/dune-project-no-opam
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dune_memory-and-the-universe)
+(rule
+ (alias dune_memory-and-the-universe)
  (deps (package dune) (source_tree test-cases/dune_memory-and-the-universe))
  (action
   (chdir
    test-cases/dune_memory-and-the-universe
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name dup-fields)
+(rule
+ (alias dup-fields)
  (deps (package dune) (source_tree test-cases/dup-fields))
  (action
   (chdir
    test-cases/dup-fields
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name duplicate-c-cxx)
+(rule
+ (alias duplicate-c-cxx)
  (deps (package dune) (source_tree test-cases/duplicate-c-cxx))
  (action
   (chdir
    test-cases/duplicate-c-cxx
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name duplicate-c-cxx-obj)
+(rule
+ (alias duplicate-c-cxx-obj)
  (deps (package dune) (source_tree test-cases/duplicate-c-cxx-obj))
  (action
   (chdir
    test-cases/duplicate-c-cxx-obj
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name duplicate-project-names)
+(rule
+ (alias duplicate-project-names)
  (deps (package dune) (source_tree test-cases/duplicate-project-names))
  (action
   (chdir
    test-cases/duplicate-project-names
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name duplicate-target-no-loc)
+(rule
+ (alias duplicate-target-no-loc)
  (deps (package dune) (source_tree test-cases/duplicate-target-no-loc))
  (action
   (chdir
    test-cases/duplicate-target-no-loc
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name embed-jbuild)
+(rule
+ (alias embed-jbuild)
  (deps (package dune) (source_tree test-cases/embed-jbuild))
  (action
   (chdir
    test-cases/embed-jbuild
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name enabled_if)
+(rule
+ (alias enabled_if)
  (deps (package dune) (source_tree test-cases/enabled_if))
  (action
   (chdir
    test-cases/enabled_if
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name env)
+(rule
+ (alias env)
  (deps (package dune) (source_tree test-cases/env))
  (action
   (chdir
@@ -432,32 +432,32 @@
     (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-and-flags-include)
+(rule
+ (alias env-and-flags-include)
  (deps (package dune) (source_tree test-cases/env-and-flags-include))
  (action
   (chdir
    test-cases/env-and-flags-include
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-bin-pform)
+(rule
+ (alias env-bin-pform)
  (deps (package dune) (source_tree test-cases/env-bin-pform))
  (action
   (chdir
    test-cases/env-bin-pform
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-bins)
+(rule
+ (alias env-bins)
  (deps (package dune) (source_tree test-cases/env-bins) (sandbox none))
  (action
   (chdir
    test-cases/env-bins
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-cflags)
+(rule
+ (alias env-cflags)
  (deps (package dune) (source_tree test-cases/env-cflags))
  (action
   (chdir
@@ -466,120 +466,120 @@
     (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-dune-file)
+(rule
+ (alias env-dune-file)
  (deps (package dune) (source_tree test-cases/env-dune-file))
  (action
   (chdir
    test-cases/env-dune-file
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-tracking)
+(rule
+ (alias env-tracking)
  (deps (package dune) (source_tree test-cases/env-tracking))
  (action
   (chdir
    test-cases/env-tracking
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-var-expansion)
+(rule
+ (alias env-var-expansion)
  (deps (package dune) (source_tree test-cases/env-var-expansion))
  (action
   (chdir
    test-cases/env-var-expansion
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name env-variables)
+(rule
+ (alias env-variables)
  (deps (package dune) (source_tree test-cases/env-variables))
  (action
   (chdir
    test-cases/env-variables
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name envs-and-contexts)
+(rule
+ (alias envs-and-contexts)
  (deps (package dune) (source_tree test-cases/envs-and-contexts))
  (action
   (chdir
    test-cases/envs-and-contexts
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name exclude-missing-module)
+(rule
+ (alias exclude-missing-module)
  (deps (package dune) (source_tree test-cases/exclude-missing-module))
  (action
   (chdir
    test-cases/exclude-missing-module
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name exe-name-mangle)
+(rule
+ (alias exe-name-mangle)
  (deps (package dune) (source_tree test-cases/exe-name-mangle))
  (action
   (chdir
    test-cases/exe-name-mangle
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name exec-cmd)
+(rule
+ (alias exec-cmd)
  (deps (package dune) (source_tree test-cases/exec-cmd))
  (action
   (chdir
    test-cases/exec-cmd
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name exec-missing)
+(rule
+ (alias exec-missing)
  (deps (package dune) (source_tree test-cases/exec-missing))
  (action
   (chdir
    test-cases/exec-missing
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name exes-with-c)
+(rule
+ (alias exes-with-c)
  (deps (package dune) (source_tree test-cases/exes-with-c))
  (action
   (chdir
    test-cases/exes-with-c
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name explicit_js_mode)
+(rule
+ (alias explicit_js_mode)
  (deps (package dune) (source_tree test-cases/explicit_js_mode))
  (action
   (chdir
    test-cases/explicit_js_mode
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name external-lib-deps)
+(rule
+ (alias external-lib-deps)
  (deps (package dune) (source_tree test-cases/external-lib-deps))
  (action
   (chdir
    test-cases/external-lib-deps
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name extra-lang-line)
+(rule
+ (alias extra-lang-line)
  (deps (package dune) (source_tree test-cases/extra-lang-line))
  (action
   (chdir
    test-cases/extra-lang-line
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name fallback-dune)
+(rule
+ (alias fallback-dune)
  (deps (package dune) (source_tree test-cases/fallback-dune))
  (action
   (chdir
    test-cases/fallback-dune
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name fdo)
+(rule
+ (alias fdo)
  (deps (package dune) (source_tree test-cases/fdo))
  (action
   (chdir
@@ -588,288 +588,288 @@
     (run %{exe:cram.exe} -skip-versions <4.11.0 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name findlib)
+(rule
+ (alias findlib)
  (deps (package dune) (source_tree test-cases/findlib))
  (action
   (chdir
    test-cases/findlib
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name findlib-dynload)
+(rule
+ (alias findlib-dynload)
  (deps (package dune) (source_tree test-cases/findlib-dynload))
  (action
   (chdir
    test-cases/findlib-dynload
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name findlib-error)
+(rule
+ (alias findlib-error)
  (deps (package dune) (source_tree test-cases/findlib-error))
  (action
   (chdir
    test-cases/findlib-error
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name forbidden_libraries)
+(rule
+ (alias forbidden_libraries)
  (deps (package dune) (source_tree test-cases/forbidden_libraries))
  (action
   (chdir
    test-cases/forbidden_libraries
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name force-test)
+(rule
+ (alias force-test)
  (deps (package dune) (source_tree test-cases/force-test))
  (action
   (chdir
    test-cases/force-test
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name foreign-library)
+(rule
+ (alias foreign-library)
  (deps (package dune) (source_tree test-cases/foreign-library))
  (action
   (chdir
    test-cases/foreign-library
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name foreign-stubs)
+(rule
+ (alias foreign-stubs)
  (deps (package dune) (source_tree test-cases/foreign-stubs))
  (action
   (chdir
    test-cases/foreign-stubs
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name format-dune-file)
+(rule
+ (alias format-dune-file)
  (deps (package dune) (source_tree test-cases/format-dune-file))
  (action
   (chdir
    test-cases/format-dune-file
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name formatting)
+(rule
+ (alias formatting)
  (deps (package dune) (source_tree test-cases/formatting))
  (action
   (chdir
    test-cases/formatting
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name gen-opam-install-file)
+(rule
+ (alias gen-opam-install-file)
  (deps (package dune) (source_tree test-cases/gen-opam-install-file))
  (action
   (chdir
    test-cases/gen-opam-install-file
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1019)
+(rule
+ (alias github1019)
  (deps (package dune) (source_tree test-cases/github1019))
  (action
   (chdir
    test-cases/github1019
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1099)
+(rule
+ (alias github1099)
  (deps (package dune) (source_tree test-cases/github1099))
  (action
   (chdir
    test-cases/github1099
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1231)
+(rule
+ (alias github1231)
  (deps (package dune) (source_tree test-cases/github1231))
  (action
   (chdir
    test-cases/github1231
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1342)
+(rule
+ (alias github1342)
  (deps (package dune) (source_tree test-cases/github1342))
  (action
   (chdir
    test-cases/github1342
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1372)
+(rule
+ (alias github1372)
  (deps (package dune) (source_tree test-cases/github1372))
  (action
   (chdir
    test-cases/github1372
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1395)
+(rule
+ (alias github1395)
  (deps (package dune) (source_tree test-cases/github1395))
  (action
   (chdir
    test-cases/github1395
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1426)
+(rule
+ (alias github1426)
  (deps (package dune) (source_tree test-cases/github1426))
  (action
   (chdir
    test-cases/github1426
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1529)
+(rule
+ (alias github1529)
  (deps (package dune) (source_tree test-cases/github1529))
  (action
   (chdir
    test-cases/github1529
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1541)
+(rule
+ (alias github1541)
  (deps (package dune) (source_tree test-cases/github1541))
  (action
   (chdir
    test-cases/github1541
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1549)
+(rule
+ (alias github1549)
  (deps (package dune) (source_tree test-cases/github1549))
  (action
   (chdir
    test-cases/github1549
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1560)
+(rule
+ (alias github1560)
  (deps (package dune) (source_tree test-cases/github1560))
  (action
   (chdir
    test-cases/github1560
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1616)
+(rule
+ (alias github1616)
  (deps (package dune) (source_tree test-cases/github1616))
  (action
   (chdir
    test-cases/github1616
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1811)
+(rule
+ (alias github1811)
  (deps (package dune) (source_tree test-cases/github1811))
  (action
   (chdir
    test-cases/github1811
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1855)
+(rule
+ (alias github1855)
  (deps (package dune) (source_tree test-cases/github1855))
  (action
   (chdir
    test-cases/github1855
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1856)
+(rule
+ (alias github1856)
  (deps (package dune) (source_tree test-cases/github1856))
  (action
   (chdir
    test-cases/github1856
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github1946)
+(rule
+ (alias github1946)
  (deps (package dune) (source_tree test-cases/github1946))
  (action
   (chdir
    test-cases/github1946
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github20)
+(rule
+ (alias github20)
  (deps (package dune) (source_tree test-cases/github20))
  (action
   (chdir
    test-cases/github20
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2033)
+(rule
+ (alias github2033)
  (deps (package dune) (source_tree test-cases/github2033))
  (action
   (chdir
    test-cases/github2033
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2061)
+(rule
+ (alias github2061)
  (deps (package dune) (source_tree test-cases/github2061))
  (action
   (chdir
    test-cases/github2061
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2123)
+(rule
+ (alias github2123)
  (deps (package dune) (source_tree test-cases/github2123))
  (action
   (chdir
    test-cases/github2123
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2206)
+(rule
+ (alias github2206)
  (deps (package dune) (source_tree test-cases/github2206))
  (action
   (chdir
    test-cases/github2206
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2228)
+(rule
+ (alias github2228)
  (deps (package dune) (source_tree test-cases/github2228))
  (action
   (chdir
    test-cases/github2228
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2272)
+(rule
+ (alias github2272)
  (deps (package dune) (source_tree test-cases/github2272))
  (action
   (chdir
    test-cases/github2272
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github24)
+(rule
+ (alias github24)
  (deps (package dune) (source_tree test-cases/github24))
  (action
   (chdir
    test-cases/github24
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2499)
+(rule
+ (alias github2499)
  (deps (package dune) (source_tree test-cases/github2499))
  (action
   (chdir
    test-cases/github2499
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github25)
+(rule
+ (alias github25)
  (deps (package dune) (source_tree test-cases/github25))
  (action
   (setenv
@@ -879,72 +879,72 @@
     test-cases/github25
     (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
-(alias
- (name github2584)
+(rule
+ (alias github2584)
  (deps (package dune) (source_tree test-cases/github2584))
  (action
   (chdir
    test-cases/github2584
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2629)
+(rule
+ (alias github2629)
  (deps (package dune) (source_tree test-cases/github2629))
  (action
   (chdir
    test-cases/github2629
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github2681)
+(rule
+ (alias github2681)
  (deps (package dune) (source_tree test-cases/github2681))
  (action
   (chdir
    test-cases/github2681
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github534)
+(rule
+ (alias github534)
  (deps (package dune) (source_tree test-cases/github534))
  (action
   (chdir
    test-cases/github534
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github568)
+(rule
+ (alias github568)
  (deps (package dune) (source_tree test-cases/github568))
  (action
   (chdir
    test-cases/github568
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github597)
+(rule
+ (alias github597)
  (deps (package dune) (source_tree test-cases/github597))
  (action
   (chdir
    test-cases/github597
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github644)
+(rule
+ (alias github644)
  (deps (package dune) (source_tree test-cases/github644))
  (action
   (chdir
    test-cases/github644
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github660)
+(rule
+ (alias github660)
  (deps (package dune) (source_tree test-cases/github660))
  (action
   (chdir
    test-cases/github660
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github717-odoc-index)
+(rule
+ (alias github717-odoc-index)
  (deps (package dune) (source_tree test-cases/github717-odoc-index))
  (action
   (chdir
@@ -953,32 +953,32 @@
     (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name github734)
+(rule
+ (alias github734)
  (deps (package dune) (source_tree test-cases/github734))
  (action
   (chdir
    test-cases/github734
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github759)
+(rule
+ (alias github759)
  (deps (package dune) (source_tree test-cases/github759))
  (action
   (chdir
    test-cases/github759
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github761)
+(rule
+ (alias github761)
  (deps (package dune) (source_tree test-cases/github761))
  (action
   (chdir
    test-cases/github761
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github764)
+(rule
+ (alias github764)
  (deps (package dune) (source_tree test-cases/github764))
  (action
   (chdir
@@ -986,152 +986,152 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))
  (enabled_if (<> %{ocaml-config:system} win)))
 
-(alias
- (name github784)
+(rule
+ (alias github784)
  (deps (package dune) (source_tree test-cases/github784))
  (action
   (chdir
    test-cases/github784
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name github992)
+(rule
+ (alias github992)
  (deps (package dune) (source_tree test-cases/github992))
  (action
   (chdir
    test-cases/github992
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name glob-deps)
+(rule
+ (alias glob-deps)
  (deps (package dune) (source_tree test-cases/glob-deps))
  (action
   (chdir
    test-cases/glob-deps
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name glob-deps-change)
+(rule
+ (alias glob-deps-change)
  (deps (package dune) (source_tree test-cases/glob-deps-change))
  (action
   (chdir
    test-cases/glob-deps-change
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name ignored_subdirs)
+(rule
+ (alias ignored_subdirs)
  (deps (package dune) (source_tree test-cases/ignored_subdirs))
  (action
   (chdir
    test-cases/ignored_subdirs
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name include-loop)
+(rule
+ (alias include-loop)
  (deps (package dune) (source_tree test-cases/include-loop))
  (action
   (chdir
    test-cases/include-loop
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name include-qualified)
+(rule
+ (alias include-qualified)
  (deps (package dune) (source_tree test-cases/include-qualified))
  (action
   (chdir
    test-cases/include-qualified
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name incremental-rebuilds)
+(rule
+ (alias incremental-rebuilds)
  (deps (package dune) (source_tree test-cases/incremental-rebuilds))
  (action
   (chdir
    test-cases/incremental-rebuilds
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name inline_tests)
+(rule
+ (alias inline_tests)
  (deps (package dune) (source_tree test-cases/inline_tests))
  (action
   (chdir
    test-cases/inline_tests
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name install-dry-run)
+(rule
+ (alias install-dry-run)
  (deps (package dune) (source_tree test-cases/install-dry-run))
  (action
   (chdir
    test-cases/install-dry-run
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name install-libdir)
+(rule
+ (alias install-libdir)
  (deps (package dune) (source_tree test-cases/install-libdir))
  (action
   (chdir
    test-cases/install-libdir
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name install-multiple-contexts)
+(rule
+ (alias install-multiple-contexts)
  (deps (package dune) (source_tree test-cases/install-multiple-contexts))
  (action
   (chdir
    test-cases/install-multiple-contexts
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name install-partial-package)
+(rule
+ (alias install-partial-package)
  (deps (package dune) (source_tree test-cases/install-partial-package))
  (action
   (chdir
    test-cases/install-partial-package
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name install-rule-order)
+(rule
+ (alias install-rule-order)
  (deps (package dune) (source_tree test-cases/install-rule-order))
  (action
   (chdir
    test-cases/install-rule-order
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name install-single-section)
+(rule
+ (alias install-single-section)
  (deps (package dune) (source_tree test-cases/install-single-section))
  (action
   (chdir
    test-cases/install-single-section
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name install-with-var)
+(rule
+ (alias install-with-var)
  (deps (package dune) (source_tree test-cases/install-with-var))
  (action
   (chdir
    test-cases/install-with-var
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name installable-dup-private-libs)
+(rule
+ (alias installable-dup-private-libs)
  (deps (package dune) (source_tree test-cases/installable-dup-private-libs))
  (action
   (chdir
    test-cases/installable-dup-private-libs
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name intf-only)
+(rule
+ (alias intf-only)
  (deps (package dune) (source_tree test-cases/intf-only))
  (action
   (chdir
    test-cases/intf-only
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name js_of_ocaml)
+(rule
+ (alias js_of_ocaml)
  (deps (package dune) (source_tree test-cases/js_of_ocaml))
  (action
   (setenv
@@ -1141,104 +1141,104 @@
     test-cases/js_of_ocaml
     (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
 
-(alias
- (name lib-available)
+(rule
+ (alias lib-available)
  (deps (package dune) (source_tree test-cases/lib-available))
  (action
   (chdir
    test-cases/lib-available
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name lib-errors)
+(rule
+ (alias lib-errors)
  (deps (package dune) (source_tree test-cases/lib-errors))
  (action
   (chdir
    test-cases/lib-errors
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name link-deps)
+(rule
+ (alias link-deps)
  (deps (package dune) (source_tree test-cases/link-deps))
  (action
   (chdir
    test-cases/link-deps
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name lint)
+(rule
+ (alias lint)
  (deps (package dune) (source_tree test-cases/lint))
  (action
   (chdir
    test-cases/lint
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name loop)
+(rule
+ (alias loop)
  (deps (package dune) (source_tree test-cases/loop))
  (action
   (chdir
    test-cases/loop
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name macro-expand-error)
+(rule
+ (alias macro-expand-error)
  (deps (package dune) (source_tree test-cases/macro-expand-error))
  (action
   (chdir
    test-cases/macro-expand-error
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name menhir)
+(rule
+ (alias menhir)
  (deps (package dune) (source_tree test-cases/menhir))
  (action
   (chdir
    test-cases/menhir
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name merlin-tests)
+(rule
+ (alias merlin-tests)
  (deps (package dune) (source_tree test-cases/merlin-tests))
  (action
   (chdir
    test-cases/merlin-tests
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name meta-gen)
+(rule
+ (alias meta-gen)
  (deps (package dune) (source_tree test-cases/meta-gen))
  (action
   (chdir
    test-cases/meta-gen
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name misc)
+(rule
+ (alias misc)
  (deps (package dune) (source_tree test-cases/misc))
  (action
   (chdir
    test-cases/misc
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name missing-loc-run)
+(rule
+ (alias missing-loc-run)
  (deps (package dune) (source_tree test-cases/missing-loc-run))
  (action
   (chdir
    test-cases/missing-loc-run
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name multi-dir)
+(rule
+ (alias multi-dir)
  (deps (package dune) (source_tree test-cases/multi-dir))
  (action
   (chdir
    test-cases/multi-dir
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name multiple-private-libs)
+(rule
+ (alias multiple-private-libs)
  (deps (package dune) (source_tree test-cases/multiple-private-libs))
  (action
   (chdir
@@ -1247,80 +1247,80 @@
     (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name multiple-targets)
+(rule
+ (alias multiple-targets)
  (deps (package dune) (source_tree test-cases/multiple-targets))
  (action
   (chdir
    test-cases/multiple-targets
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name name-field-validation)
+(rule
+ (alias name-field-validation)
  (deps (package dune) (source_tree test-cases/name-field-validation))
  (action
   (chdir
    test-cases/name-field-validation
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name no-installable-mode)
+(rule
+ (alias no-installable-mode)
  (deps (package dune) (source_tree test-cases/no-installable-mode))
  (action
   (chdir
    test-cases/no-installable-mode
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name no-name-field)
+(rule
+ (alias no-name-field)
  (deps (package dune) (source_tree test-cases/no-name-field))
  (action
   (chdir
    test-cases/no-name-field
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name null-dep)
+(rule
+ (alias null-dep)
  (deps (package dune) (source_tree test-cases/null-dep))
  (action
   (chdir
    test-cases/null-dep
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name ocaml-config-macro)
+(rule
+ (alias ocaml-config-macro)
  (deps (package dune) (source_tree test-cases/ocaml-config-macro))
  (action
   (chdir
    test-cases/ocaml-config-macro
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name ocaml-syntax)
+(rule
+ (alias ocaml-syntax)
  (deps (package dune) (source_tree test-cases/ocaml-syntax))
  (action
   (chdir
    test-cases/ocaml-syntax
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name ocamldep-multi-stanzas)
+(rule
+ (alias ocamldep-multi-stanzas)
  (deps (package dune) (source_tree test-cases/ocamldep-multi-stanzas))
  (action
   (chdir
    test-cases/ocamldep-multi-stanzas
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name odig-files-workspace)
+(rule
+ (alias odig-files-workspace)
  (deps (package dune) (source_tree test-cases/odig-files-workspace))
  (action
   (chdir
    test-cases/odig-files-workspace
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name odoc)
+(rule
+ (alias odoc)
  (deps (package dune) (source_tree test-cases/odoc))
  (action
   (chdir
@@ -1329,8 +1329,8 @@
     (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name odoc-package-mld-link)
+(rule
+ (alias odoc-package-mld-link)
  (deps (package dune) (source_tree test-cases/odoc-package-mld-link))
  (action
   (chdir
@@ -1339,8 +1339,8 @@
     (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name odoc-unique-mlds)
+(rule
+ (alias odoc-unique-mlds)
  (deps (package dune) (source_tree test-cases/odoc-unique-mlds))
  (action
   (chdir
@@ -1349,32 +1349,32 @@
     (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name old-dune-subsystem)
+(rule
+ (alias old-dune-subsystem)
  (deps (package dune) (source_tree test-cases/old-dune-subsystem))
  (action
   (chdir
    test-cases/old-dune-subsystem
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name optional)
+(rule
+ (alias optional)
  (deps (package dune) (source_tree test-cases/optional))
  (action
   (chdir
    test-cases/optional
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name optional-executable)
+(rule
+ (alias optional-executable)
  (deps (package dune) (source_tree test-cases/optional-executable))
  (action
   (chdir
    test-cases/optional-executable
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name output-obj)
+(rule
+ (alias output-obj)
  (deps (package dune) (source_tree test-cases/output-obj))
  (action
   (chdir
@@ -1385,24 +1385,24 @@
  (enabled_if
   (and (<> %{ocaml-config:system} macosx) (<> %{ocaml-config:system} win))))
 
-(alias
- (name package-dep)
+(rule
+ (alias package-dep)
  (deps (package dune) (source_tree test-cases/package-dep))
  (action
   (chdir
    test-cases/package-dep
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name path-variables)
+(rule
+ (alias path-variables)
  (deps (package dune) (source_tree test-cases/path-variables))
  (action
   (chdir
    test-cases/path-variables
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name pkg-config-quoting)
+(rule
+ (alias pkg-config-quoting)
  (deps
   (package dune)
   (source_tree test-cases/pkg-config-quoting)
@@ -1412,8 +1412,8 @@
    test-cases/pkg-config-quoting
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name ppx-rewriter)
+(rule
+ (alias ppx-rewriter)
  (deps (package dune) (source_tree test-cases/ppx-rewriter))
  (action
   (chdir
@@ -1422,224 +1422,224 @@
     (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name ppx-runtime-dependencies)
+(rule
+ (alias ppx-runtime-dependencies)
  (deps (package dune) (source_tree test-cases/ppx-runtime-dependencies))
  (action
   (chdir
    test-cases/ppx-runtime-dependencies
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name preprocess-with-action)
+(rule
+ (alias preprocess-with-action)
  (deps (package dune) (source_tree test-cases/preprocess-with-action))
  (action
   (chdir
    test-cases/preprocess-with-action
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name private-modules)
+(rule
+ (alias private-modules)
  (deps (package dune) (source_tree test-cases/private-modules))
  (action
   (chdir
    test-cases/private-modules
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name private-public-overlap)
+(rule
+ (alias private-public-overlap)
  (deps (package dune) (source_tree test-cases/private-public-overlap))
  (action
   (chdir
    test-cases/private-public-overlap
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name project-root)
+(rule
+ (alias project-root)
  (deps (package dune) (source_tree test-cases/project-root))
  (action
   (chdir
    test-cases/project-root
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name promote)
+(rule
+ (alias promote)
  (deps (package dune) (source_tree test-cases/promote))
  (action
   (chdir
    test-cases/promote
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name quoting)
+(rule
+ (alias quoting)
  (deps (package dune) (source_tree test-cases/quoting))
  (action
   (chdir
    test-cases/quoting
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name re-exported-deps)
+(rule
+ (alias re-exported-deps)
  (deps (package dune) (source_tree test-cases/re-exported-deps))
  (action
   (chdir
    test-cases/re-exported-deps
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name reason)
+(rule
+ (alias reason)
  (deps (package dune) (source_tree test-cases/reason))
  (action
   (chdir
    test-cases/reason
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name redirections)
+(rule
+ (alias redirections)
  (deps (package dune) (source_tree test-cases/redirections))
  (action
   (chdir
    test-cases/redirections
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name reporting-of-cycles)
+(rule
+ (alias reporting-of-cycles)
  (deps (package dune) (source_tree test-cases/reporting-of-cycles))
  (action
   (chdir
    test-cases/reporting-of-cycles
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name rule-target-external)
+(rule
+ (alias rule-target-external)
  (deps (package dune) (source_tree test-cases/rule-target-external))
  (action
   (chdir
    test-cases/rule-target-external
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name rule-target-inferrence)
+(rule
+ (alias rule-target-inferrence)
  (deps (package dune) (source_tree test-cases/rule-target-inferrence))
  (action
   (chdir
    test-cases/rule-target-inferrence
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name sandboxing)
+(rule
+ (alias sandboxing)
  (deps (package dune) (source_tree test-cases/sandboxing))
  (action
   (chdir
    test-cases/sandboxing
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name scope-bug)
+(rule
+ (alias scope-bug)
  (deps (package dune) (source_tree test-cases/scope-bug))
  (action
   (chdir
    test-cases/scope-bug
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name scope-ppx-bug)
+(rule
+ (alias scope-ppx-bug)
  (deps (package dune) (source_tree test-cases/scope-ppx-bug))
  (action
   (chdir
    test-cases/scope-ppx-bug
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name select)
+(rule
+ (alias select)
  (deps (package dune) (source_tree test-cases/select))
  (action
   (chdir
    test-cases/select
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name several-packages)
+(rule
+ (alias several-packages)
  (deps (package dune) (source_tree test-cases/several-packages))
  (action
   (chdir
    test-cases/several-packages
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name shadow-bindings)
+(rule
+ (alias shadow-bindings)
  (deps (package dune) (source_tree test-cases/shadow-bindings))
  (action
   (chdir
    test-cases/shadow-bindings
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name stale-artifact-removal)
+(rule
+ (alias stale-artifact-removal)
  (deps (package dune) (source_tree test-cases/stale-artifact-removal))
  (action
   (chdir
    test-cases/stale-artifact-removal
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name stdlib-compilation)
+(rule
+ (alias stdlib-compilation)
  (deps (package dune) (source_tree test-cases/stdlib-compilation))
  (action
   (chdir
    test-cases/stdlib-compilation
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name subst)
+(rule
+ (alias subst)
  (deps (package dune) (source_tree test-cases/subst))
  (action
   (chdir
    test-cases/subst
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name syntax-versioning)
+(rule
+ (alias syntax-versioning)
  (deps (package dune) (source_tree test-cases/syntax-versioning))
  (action
   (chdir
    test-cases/syntax-versioning
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name target-dir-alias)
+(rule
+ (alias target-dir-alias)
  (deps (package dune) (source_tree test-cases/target-dir-alias))
  (action
   (chdir
    test-cases/target-dir-alias
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name targets-with-vars)
+(rule
+ (alias targets-with-vars)
  (deps (package dune) (source_tree test-cases/targets-with-vars))
  (action
   (chdir
    test-cases/targets-with-vars
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name tests-stanza)
+(rule
+ (alias tests-stanza)
  (deps (package dune) (source_tree test-cases/tests-stanza))
  (action
   (chdir
    test-cases/tests-stanza
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name tests-stanza-action)
+(rule
+ (alias tests-stanza-action)
  (deps (package dune) (source_tree test-cases/tests-stanza-action))
  (action
   (chdir
    test-cases/tests-stanza-action
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name tests-stanza-action-syntax-version)
+(rule
+ (alias tests-stanza-action-syntax-version)
  (deps
   (package dune)
   (source_tree test-cases/tests-stanza-action-syntax-version))
@@ -1648,8 +1648,8 @@
    test-cases/tests-stanza-action-syntax-version
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name toplevel-stanza)
+(rule
+ (alias toplevel-stanza)
  (deps (package dune) (source_tree test-cases/toplevel-stanza))
  (action
   (chdir
@@ -1658,64 +1658,64 @@
     (run %{exe:cram.exe} -skip-versions <4.05.0 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name trace-file)
+(rule
+ (alias trace-file)
  (deps (package dune) (source_tree test-cases/trace-file))
  (action
   (chdir
    test-cases/trace-file
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name transitive-deps-mode)
+(rule
+ (alias transitive-deps-mode)
  (deps (package dune) (source_tree test-cases/transitive-deps-mode))
  (action
   (chdir
    test-cases/transitive-deps-mode
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name unreadable-src)
+(rule
+ (alias unreadable-src)
  (deps (package dune) (source_tree test-cases/unreadable-src))
  (action
   (chdir
    test-cases/unreadable-src
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name unused-preprocessor-deps)
+(rule
+ (alias unused-preprocessor-deps)
  (deps (package dune) (source_tree test-cases/unused-preprocessor-deps))
  (action
   (chdir
    test-cases/unused-preprocessor-deps
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name upgrader)
+(rule
+ (alias upgrader)
  (deps (package dune) (source_tree test-cases/upgrader))
  (action
   (chdir
    test-cases/upgrader
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name use-meta)
+(rule
+ (alias use-meta)
  (deps (package dune) (source_tree test-cases/use-meta))
  (action
   (chdir
    test-cases/use-meta
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name utop)
+(rule
+ (alias utop)
  (deps (package dune) (source_tree test-cases/utop))
  (action
   (chdir
    test-cases/utop
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name utop-default)
+(rule
+ (alias utop-default)
  (deps (package dune) (source_tree test-cases/utop-default))
  (action
   (chdir
@@ -1724,8 +1724,8 @@
     (run %{exe:cram.exe} -skip-versions <4.05.0 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name utop-default-implementation)
+(rule
+ (alias utop-default-implementation)
  (deps (package dune) (source_tree test-cases/utop-default-implementation))
  (action
   (chdir
@@ -1734,40 +1734,40 @@
     (run %{exe:cram.exe} -skip-versions <4.05.0 -test run.t)
     (diff? run.t run.t.corrected)))))
 
-(alias
- (name variables-for-artifacts)
+(rule
+ (alias variables-for-artifacts)
  (deps (package dune) (source_tree test-cases/variables-for-artifacts))
  (action
   (chdir
    test-cases/variables-for-artifacts
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variant-dep-stack)
+(rule
+ (alias variant-dep-stack)
  (deps (package dune) (source_tree test-cases/variant-dep-stack))
  (action
   (chdir
    test-cases/variant-dep-stack
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variants)
+(rule
+ (alias variants)
  (deps (package dune) (source_tree test-cases/variants))
  (action
   (chdir
    test-cases/variants
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variants-external-declaration)
+(rule
+ (alias variants-external-declaration)
  (deps (package dune) (source_tree test-cases/variants-external-declaration))
  (action
   (chdir
    test-cases/variants-external-declaration
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variants-external-declaration-conflict)
+(rule
+ (alias variants-external-declaration-conflict)
  (deps
   (package dune)
   (source_tree test-cases/variants-external-declaration-conflict))
@@ -1776,32 +1776,32 @@
    test-cases/variants-external-declaration-conflict
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variants-multi-project)
+(rule
+ (alias variants-multi-project)
  (deps (package dune) (source_tree test-cases/variants-multi-project))
  (action
   (chdir
    test-cases/variants-multi-project
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variants-only-package)
+(rule
+ (alias variants-only-package)
  (deps (package dune) (source_tree test-cases/variants-only-package))
  (action
   (chdir
    test-cases/variants-only-package
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variants-rogue-impl)
+(rule
+ (alias variants-rogue-impl)
  (deps (package dune) (source_tree test-cases/variants-rogue-impl))
  (action
   (chdir
    test-cases/variants-rogue-impl
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name variants-wrong-external-declaration)
+(rule
+ (alias variants-wrong-external-declaration)
  (deps
   (package dune)
   (source_tree test-cases/variants-wrong-external-declaration))
@@ -1810,16 +1810,16 @@
    test-cases/variants-wrong-external-declaration
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name vendor)
+(rule
+ (alias vendor)
  (deps (package dune) (source_tree test-cases/vendor))
  (action
   (chdir
    test-cases/vendor
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name vlib)
+(rule
+ (alias vlib)
  (deps
   (package dune)
   (source_tree test-cases/vlib)
@@ -1829,72 +1829,72 @@
    test-cases/vlib
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name vlib-default-impl)
+(rule
+ (alias vlib-default-impl)
  (deps (package dune) (source_tree test-cases/vlib-default-impl))
  (action
   (chdir
    test-cases/vlib-default-impl
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name vlib-wrong-default-impl)
+(rule
+ (alias vlib-wrong-default-impl)
  (deps (package dune) (source_tree test-cases/vlib-wrong-default-impl))
  (action
   (chdir
    test-cases/vlib-wrong-default-impl
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name windows-diff)
+(rule
+ (alias windows-diff)
  (deps (package dune) (source_tree test-cases/windows-diff))
  (action
   (chdir
    test-cases/windows-diff
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name with-exit-codes)
+(rule
+ (alias with-exit-codes)
  (deps (package dune) (source_tree test-cases/with-exit-codes))
  (action
   (chdir
    test-cases/with-exit-codes
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name with-stdin-from)
+(rule
+ (alias with-stdin-from)
  (deps (package dune) (source_tree test-cases/with-stdin-from))
  (action
   (chdir
    test-cases/with-stdin-from
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name workspace-paths)
+(rule
+ (alias workspace-paths)
  (deps (package dune) (source_tree test-cases/workspace-paths))
  (action
   (chdir
    test-cases/workspace-paths
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name workspaces)
+(rule
+ (alias workspaces)
  (deps (package dune) (source_tree test-cases/workspaces))
  (action
   (chdir
    test-cases/workspaces
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name wrapped-false-main-module-name)
+(rule
+ (alias wrapped-false-main-module-name)
  (deps (package dune) (source_tree test-cases/wrapped-false-main-module-name))
  (action
   (chdir
    test-cases/wrapped-false-main-module-name
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
-(alias
- (name wrapped-transition)
+(rule
+ (alias wrapped-transition)
  (deps (package dune) (source_tree test-cases/wrapped-transition))
  (action
   (chdir

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -42,9 +42,14 @@ module Platform = struct
 end
 
 let alias ?enabled_if ?action name ~deps =
-  Sexp.constr "alias"
+  let (stanza, alias_or_name) =
+    match action with
+    | None -> ("alias", "name")
+    | Some _ -> ("rule", "alias")
+  in
+  Sexp.constr stanza
     (Sexp.fields
-       ( [ ("name", [ Dune_lang.atom name ]); ("deps", deps) ]
+       ( [ (alias_or_name, [ Dune_lang.atom name ]); ("deps", deps) ]
        @ ( match action with
          | None -> []
          | Some a -> [ ("action", [ a ]) ] )

--- a/test/blackbox-tests/test-cases/cmdliner-dep-conf/dune
+++ b/test/blackbox-tests/test-cases/cmdliner-dep-conf/dune
@@ -1,5 +1,5 @@
-(alias
- (name foo)
+(rule
+ (alias foo)
  (action (echo Hello!)))
 
 (rule

--- a/test/blackbox-tests/test-cases/corrections/run.t
+++ b/test/blackbox-tests/test-cases/corrections/run.t
@@ -4,7 +4,7 @@
 It's OK if there's no correction:
 
   $ cat > dune <<EOF
-  > (alias (name no_correction)
+  > (rule (alias no_correction)
   >   (deps )
   >   (action (progn (diff? text-file text-file-corrected)))
   > )
@@ -15,7 +15,7 @@ Dependency on the first argument of diff? is automatically added
 and dune correctly complains
 
   $ cat > dune <<EOF
-  > (alias (name correction1)
+  > (rule (alias correction1)
   >   (deps)
   >   (action
   >     (progn (bash "> text-file-corrected echo corrected-contents-1")
@@ -41,7 +41,7 @@ When correction is no longer produced, dune no longer complains.
 (relies on stale artifact deletion, it seems)
 
   $ cat > dune <<EOF
-  > (alias (name correction1)
+  > (rule (alias correction1)
   >   (deps text-file)
   >   (action
   >     (progn 
@@ -54,7 +54,7 @@ When correction is no longer produced, dune no longer complains.
 Promotion should work when sandboxing is used:
 
   $ cat > dune <<EOF
-  > (alias (name correction1)
+  > (rule (alias correction1)
   >   (deps)
   >   (action
   >     (progn
@@ -76,7 +76,7 @@ Dependency on the second argument of diff? is *not* automatically added.
 This is fine because we think of it as an intermediate file rather than dep.
 
   $ cat > dune <<EOF
-  > (alias (name correction1)
+  > (rule (alias correction1)
   >   (deps)
   >   (action
   >     (progn
@@ -117,7 +117,7 @@ Sandboxing does help if the command producing the
 correction is non-trivial.
 
   $ cat > dune <<EOF
-  > (alias (name correction1)
+  > (rule (alias correction1)
   >   (deps)
   >   (action
   >     (progn

--- a/test/blackbox-tests/test-cases/cxx-extension/run.t
+++ b/test/blackbox-tests/test-cases/cxx-extension/run.t
@@ -96,8 +96,8 @@ This works because the translation layer from pre-2.0 to 2.0 replaces
   > (name bar)
   > (libraries foo)
   > (modules bar))
-  > (alias
-  > (name default)
+  > (rule
+  > (alias default)
   > (action (run ./bar.exe)))
   > EOF
 

--- a/test/blackbox-tests/test-cases/dune-project-edition/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-edition/run.t
@@ -1,7 +1,7 @@
   $ [ -e dune-project ] || echo File does not exist
   File does not exist
   $ mkdir src
-  $ echo '(alias (name runtest) (action (progn)))' >  src/dune
+  $ echo '(rule (alias runtest) (action (progn)))' >  src/dune
   $ dune build
   Info: Creating file dune-project with this contents:
   | (lang dune 2.0)

--- a/test/blackbox-tests/test-cases/glob-deps-change/run.t
+++ b/test/blackbox-tests/test-cases/glob-deps-change/run.t
@@ -17,8 +17,8 @@
   >   (progn
   >    (bash "ls -1 some_directory > some_target"))))
   > \
-  > (alias
-  >  (name some_alias)
+  > (rule
+  >  (alias some_alias)
   >  (deps (universe))
   >  (action (cat some_target)))
   > EOF
@@ -46,8 +46,8 @@
   >   (progn
   >    (bash "ls -1 some_directory > some_target"))))
   > \
-  > (alias
-  >  (name some_alias)
+  > (rule
+  >  (alias some_alias)
   >  (deps (universe))
   >  (action (cat some_target)))
   > EOF

--- a/test/blackbox-tests/test-cases/optional-executable/dune
+++ b/test/blackbox-tests/test-cases/optional-executable/dune
@@ -1,10 +1,8 @@
 (executable
  (public_name x)
  (libraries does-not-exist)
- (optional)
-)
+ (optional))
 
-(alias
- (name run-x)
- (action (run %{exe:x.exe}))
-)
+(rule
+ (alias run-x)
+ (action (run %{exe:x.exe})))

--- a/test/blackbox-tests/test-cases/select/run.t
+++ b/test/blackbox-tests/test-cases/select/run.t
@@ -1,4 +1,18 @@
   $ echo '(lang dune 1.0)' > dune-project
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries
+  >   (select bar.ml from
+  >    (unix -> bar_unix.ml)
+  >    (!unix -> bar_no_unix.ml))
+  >   (select foo.ml from
+  >    (fakefoobar -> foo_fake.ml)
+  >    (!fakefoobar -> foo_no_fake.ml))))
+  > (alias
+  >  (name runtest)
+  >  (action (run ./main.exe)))
+  > EOF
 
   $ dune runtest --display short
       ocamldep .main.eobjs/bar.ml.d
@@ -16,6 +30,20 @@
   foo has no fake
 
   $ echo '(lang dune 2.0)' > dune-project
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries
+  >   (select bar.ml from
+  >    (unix -> bar_unix.ml)
+  >    (!unix -> bar_no_unix.ml))
+  >   (select foo.ml from
+  >    (fakefoobar -> foo_fake.ml)
+  >    (!fakefoobar -> foo_no_fake.ml))))
+  > (rule
+  >  (alias runtest)
+  >  (action (run ./main.exe)))
+  > EOF
 
   $ dune runtest --display short
         ocamlc .main.eobjs/byte/dune__exe.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/with-exit-codes/run.t
+++ b/test/blackbox-tests/test-cases/with-exit-codes/run.t
@@ -11,8 +11,8 @@
   > EOF
 
   $ cat >> dune <<EOF
-  > (alias
-  >  (name a)
+  > (rule
+  >  (alias a)
   >  (action (with-accepted-exit-codes 0 (run ./exit.exe 1))))
   > EOF
 
@@ -26,8 +26,8 @@
   [1]
 
   $ cat >> dune <<EOF
-  > (alias
-  >  (name b)
+  > (rule
+  >  (alias b)
   >  (action (with-accepted-exit-codes (not 0) (run ./exit.exe 1))))
   > EOF
 
@@ -35,11 +35,11 @@
           exit alias b
 
   $ cat >> dune <<EOF
-  > (alias
-  >  (name c)
+  > (rule
+  >  (alias c)
   >  (action (with-accepted-exit-codes (or 1 2 3) (run ./exit.exe 2))))
-  > (alias
-  >  (name d)
+  > (rule
+  >  (alias d)
   >  (action (with-accepted-exit-codes (or 4 5 6) (run ./exit.exe 7))))
   > EOF
 
@@ -52,8 +52,8 @@
   [1]
 
   $ cat >> dune <<EOF
-  > (alias
-  >  (name e)
+  > (rule
+  >  (alias e)
   >  (action (with-accepted-exit-codes (not 0) (dynamic-run ./exit.exe 1))))
   > EOF
 

--- a/test/dune
+++ b/test/dune
@@ -3,18 +3,18 @@
 ;; $ ./_build/default/bin/main.exe build @test/fail-with-background-jobs-running
 ;;
 
-(alias
- (name sleep5)
+(rule
+ (alias sleep5)
  (action
   (system "sleep 5")))
 
-(alias
- (name sleep1-and-fail)
+(rule
+ (alias sleep1-and-fail)
  (action
   (system "sleep 1; exit 1")))
 
-(alias
- (name sleep4-and-fail)
+(rule
+ (alias sleep4-and-fail)
  (action
   (system "sleep 4; exit 1")))
 
@@ -30,8 +30,8 @@
 ;; $ ./_build/default/bin/main.exe build -j10 @test/locks
 ;;
 
-(alias
- (name locks)
+(rule
+ (alias locks)
  (deps
   (glob_files *.{foo,bar}))
  (action

--- a/test/unit-tests/dune
+++ b/test/unit-tests/dune
@@ -3,8 +3,8 @@
  (modules sexp_tests)
  (libraries stdune dune_lang jbuild_support))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (package dune-private-libs)
  (action
   (run ./sexp_tests.exe)))


### PR DESCRIPTION
As discussed, `rule` has enough features to completely replace this use case.