### PR TITLE
Remove duplicated fields in [Context.t]

### DIFF
--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -60,36 +60,9 @@ type t =
   ; arch_sixtyfour : bool
   ; opam_var_cache : (string, string) Table.t
   ; ocaml_config : Ocaml_config.t
-  ; version_string : string
   ; version : Ocaml_version.t
   ; stdlib_dir : Path.t
   ; ccomp_type : Lib_config.Ccomp_type.t
-  ; c_compiler : string
-  ; ocamlc_cflags : string list
-  ; ocamlopt_cflags : string list
-  ; bytecomp_c_libraries : string list
-  ; native_c_libraries : string list
-  ; cc_profile : string list
-  ; architecture : string
-  ; system : string
-  ; ext_asm : string
-  ; ext_exe : string
-  ; os_type : string
-  ; model : string
-  ; default_executable_name : string
-  ; host : string
-  ; target : string
-  ; flambda : bool
-  ; exec_magic_number : string
-  ; cmi_magic_number : string
-  ; cmo_magic_number : string
-  ; cma_magic_number : string
-  ; cmx_magic_number : string
-  ; cmxa_magic_number : string
-  ; ast_impl_magic_number : string
-  ; ast_intf_magic_number : string
-  ; cmxs_magic_number : string
-  ; cmt_magic_number : string
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; which_cache : (string, Path.t option) Table.t
   ; lib_config : Lib_config.t
@@ -454,7 +427,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     in
     let stdlib_dir = Path.of_string (Ocaml_config.standard_library ocfg) in
     let natdynlink_supported = Ocaml_config.natdynlink_supported ocfg in
-    let version_string = Ocaml_config.version_string ocfg in
     let version = Ocaml_version.of_ocaml_config ocfg in
     let arch_sixtyfour = Ocaml_config.word_size ocfg = 64 in
     let ocamlopt = get_ocaml_tool "ocamlopt" in
@@ -508,35 +480,8 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; opam_var_cache
       ; stdlib_dir
       ; ocaml_config = ocfg
-      ; version_string
       ; version
       ; ccomp_type
-      ; c_compiler = Ocaml_config.c_compiler ocfg
-      ; ocamlc_cflags = Ocaml_config.ocamlc_cflags ocfg
-      ; ocamlopt_cflags = Ocaml_config.ocamlopt_cflags ocfg
-      ; bytecomp_c_libraries = Ocaml_config.bytecomp_c_libraries ocfg
-      ; native_c_libraries = Ocaml_config.native_c_libraries ocfg
-      ; cc_profile = Ocaml_config.cc_profile ocfg
-      ; architecture = Ocaml_config.architecture ocfg
-      ; system = Ocaml_config.system ocfg
-      ; ext_asm = Ocaml_config.ext_asm ocfg
-      ; ext_exe = Ocaml_config.ext_exe ocfg
-      ; os_type = Ocaml_config.os_type ocfg
-      ; model = Ocaml_config.model ocfg
-      ; default_executable_name = Ocaml_config.default_executable_name ocfg
-      ; host = Ocaml_config.host ocfg
-      ; target = Ocaml_config.target ocfg
-      ; flambda = Ocaml_config.flambda ocfg
-      ; exec_magic_number = Ocaml_config.exec_magic_number ocfg
-      ; cmi_magic_number = Ocaml_config.cmi_magic_number ocfg
-      ; cmo_magic_number = Ocaml_config.cmo_magic_number ocfg
-      ; cma_magic_number = Ocaml_config.cma_magic_number ocfg
-      ; cmx_magic_number = Ocaml_config.cmx_magic_number ocfg
-      ; cmxa_magic_number = Ocaml_config.cmxa_magic_number ocfg
-      ; ast_impl_magic_number = Ocaml_config.ast_impl_magic_number ocfg
-      ; ast_intf_magic_number = Ocaml_config.ast_intf_magic_number ocfg
-      ; cmxs_magic_number = Ocaml_config.cmxs_magic_number ocfg
-      ; cmt_magic_number = Ocaml_config.cmt_magic_number ocfg
       ; supports_shared_libraries =
           Dynlink_supported.By_the_os.of_bool
             (Ocaml_config.supports_shared_libraries ocfg)

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -78,36 +78,9 @@ type t =
   ; arch_sixtyfour : bool
   ; opam_var_cache : (string, string) Table.t
   ; ocaml_config : Ocaml_config.t
-  ; version_string : string
   ; version : Ocaml_version.t
   ; stdlib_dir : Path.t
   ; ccomp_type : Lib_config.Ccomp_type.t
-  ; c_compiler : string
-  ; ocamlc_cflags : string list
-  ; ocamlopt_cflags : string list
-  ; bytecomp_c_libraries : string list
-  ; native_c_libraries : string list
-  ; cc_profile : string list
-  ; architecture : string
-  ; system : string
-  ; ext_asm : string
-  ; ext_exe : string
-  ; os_type : string
-  ; model : string
-  ; default_executable_name : string
-  ; host : string
-  ; target : string
-  ; flambda : bool
-  ; exec_magic_number : string
-  ; cmi_magic_number : string
-  ; cmo_magic_number : string
-  ; cma_magic_number : string
-  ; cmx_magic_number : string
-  ; cmxa_magic_number : string
-  ; ast_impl_magic_number : string
-  ; ast_intf_magic_number : string
-  ; cmxs_magic_number : string
-  ; cmt_magic_number : string
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; which_cache : (string, Path.t option) Table.t
   ; lib_config : Lib_config.t

--- a/src/dune/dune_load.ml
+++ b/src/dune/dune_load.ml
@@ -140,7 +140,8 @@ end
 # 1 %S
 %s|}
           (Context_name.to_string context.name)
-          context.version_string ocamlc_config
+          (Ocaml_config.version_string context.ocaml_config)
+          ocamlc_config
           (Path.reach ~from:exec_dir (Path.build target))
           (Path.to_string plugin) plugin_contents);
     check_no_requires plugin plugin_contents

--- a/src/dune/exe.ml
+++ b/src/dune/exe.ml
@@ -95,7 +95,8 @@ module Linkage = struct
       | Object -> o_flags
       | Shared_object -> (
         let so_flags =
-          if String.equal ctx.os_type "Win32" then
+          let os_type = Ocaml_config.os_type ctx.ocaml_config in
+          if String.equal os_type "Win32" then
             so_flags_windows
           else
             so_flags_unix
@@ -104,7 +105,10 @@ module Linkage = struct
         | Native ->
           (* The compiler doesn't pass these flags in native mode. This looks
              like a bug in the compiler. *)
-          List.concat_map ctx.native_c_libraries ~f:(fun flag ->
+          let native_c_libraries =
+            Ocaml_config.native_c_libraries ctx.ocaml_config
+          in
+          List.concat_map native_c_libraries ~f:(fun flag ->
               [ "-cclib"; flag ])
           @ so_flags
         | Byte

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -200,7 +200,7 @@ let make ~scope ~(context : Context.t) ~lib_artifacts ~bin_artifacts_host =
   let dir = context.build_dir in
   let bindings = Pform.Map.create ~context in
   let env = context.env in
-  let c_compiler = context.c_compiler in
+  let c_compiler = Ocaml_config.c_compiler context.ocaml_config in
   { dir
   ; hidden_env = Env.Var.Set.empty
   ; env

--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -118,10 +118,11 @@ let build_cxx_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
          [build_c_file] disabling that here too *)
     ~sandbox:Sandbox_config.no_sandboxing
     (let src = Path.build (Foreign.Source.path src) in
+     let c_compiler = Ocaml_config.c_compiler ctx.ocaml_config in
      Command.run
      (* We have to execute the rule in the library directory as the .o is
         produced in the current directory *) ~dir:(Path.build dir)
-       (Super_context.resolve_program ~loc:None ~dir sctx ctx.c_compiler)
+       (Super_context.resolve_program ~loc:None ~dir sctx c_compiler)
        ( [ Command.Args.S [ A "-I"; Path ctx.stdlib_dir ]
          ; include_flags
          ; Command.Args.dyn cxx_flags

--- a/src/dune/pform.ml
+++ b/src/dune/pform.ml
@@ -193,20 +193,20 @@ module Map = struct
       | None -> string "make"
       | Some p -> path p
     in
-    let cflags = context.ocamlc_cflags in
+    let cflags = Ocaml_config.ocamlc_cflags context.ocaml_config in
     let cxx_flags =
-      List.filter context.ocamlc_cflags ~f:(fun s ->
-          not (String.is_prefix s ~prefix:"-std="))
+      List.filter cflags ~f:(fun s -> not (String.is_prefix s ~prefix:"-std="))
     in
     let strings s = values (Value.L.strings s) in
     let lowercased =
-      [ ("cpp", strings ((context.c_compiler :: cflags) @ [ "-E" ]))
+      let c_compiler = Ocaml_config.c_compiler context.ocaml_config in
+      [ ("cpp", strings ((c_compiler :: cflags) @ [ "-E" ]))
       ; ( "pa_cpp"
         , strings
-            ( (context.c_compiler :: cflags)
+            ( (c_compiler :: cflags)
             @ [ "-undef"; "-traditional"; "-x"; "c"; "-E" ] ) )
-      ; ("cc", strings (context.c_compiler :: cflags))
-      ; ("cxx", strings (context.c_compiler :: cxx_flags))
+      ; ("cc", strings (c_compiler :: cflags))
+      ; ("cxx", strings (c_compiler :: cxx_flags))
       ; ("ocaml", path context.ocaml)
       ; ("ocamlc", path context.ocamlc)
       ; ("ocamlopt", path ocamlopt)
@@ -219,28 +219,32 @@ module Map = struct
           (String.uppercase k, renamed_in ~new_name:k ~version:(1, 0)))
     in
     let other =
+      let ext_asm = Ocaml_config.ext_asm context.ocaml_config in
+      let ext_exe = Ocaml_config.ext_exe context.ocaml_config in
+      let os_type = Ocaml_config.os_type context.ocaml_config in
+      let architecture = Ocaml_config.architecture context.ocaml_config in
+      let model = Ocaml_config.model context.ocaml_config in
+      let system = Ocaml_config.system context.ocaml_config in
+      let version_string = Ocaml_config.version_string context.ocaml_config in
       [ ("-verbose", values [])
       ; ("ocaml_bin", values [ Dir context.ocaml_bin ])
-      ; ("ocaml_version", string context.version_string)
+      ; ("ocaml_version", string version_string)
       ; ("ocaml_where", string (Path.to_string context.stdlib_dir))
       ; ("null", string (Path.to_string Config.dev_null))
       ; ("ext_obj", string context.lib_config.ext_obj)
-      ; ("ext_asm", string context.ext_asm)
+      ; ("ext_asm", string ext_asm)
       ; ("ext_lib", string context.lib_config.ext_lib)
       ; ("ext_dll", string context.lib_config.ext_dll)
-      ; ("ext_exe", string context.ext_exe)
+      ; ("ext_exe", string ext_exe)
       ; ("profile", string (Profile.to_string context.profile))
       ; ("workspace_root", values [ Value.Dir (Path.build context.build_dir) ])
       ; ("context_name", string (Context_name.to_string context.name))
       ; ("ROOT", renamed_in ~version:(1, 0) ~new_name:"workspace_root")
-      ; ( "os_type"
-        , since ~version:(1, 10) (Var.Values [ String context.os_type ]) )
+      ; ("os_type", since ~version:(1, 10) (Var.Values [ String os_type ]))
       ; ( "architecture"
-        , since ~version:(1, 10) (Var.Values [ String context.architecture ])
-        )
-      ; ( "system"
-        , since ~version:(1, 10) (Var.Values [ String context.system ]) )
-      ; ("model", since ~version:(1, 10) (Var.Values [ String context.model ]))
+        , since ~version:(1, 10) (Var.Values [ String architecture ]) )
+      ; ("system", since ~version:(1, 10) (Var.Values [ String system ]))
+      ; ("model", since ~version:(1, 10) (Var.Values [ String model ]))
       ; ( "ignoring_promoted_rules"
         , since ~version:(1, 10)
             (Var.Values

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -223,10 +223,9 @@ end = struct
       ~expander:(expander t ~dir)
 
   let default_context_flags (ctx : Context.t) =
-    let c = ctx.ocamlc_cflags in
+    let c = Ocaml_config.ocamlc_cflags ctx.ocaml_config in
     let cxx =
-      List.filter ctx.ocamlc_cflags ~f:(fun s ->
-          not (String.is_prefix s ~prefix:"-std="))
+      List.filter c ~f:(fun s -> not (String.is_prefix s ~prefix:"-std="))
     in
     Foreign.Language.Dict.make ~c ~cxx
 

--- a/src/stdune/scanf.ml
+++ b/src/stdune/scanf.ml
@@ -6,6 +6,7 @@ let unescaped x =
   | x -> Ok x
 
 exception E
+
 let sscanf x fmt f =
   match Scanf.ksscanf x (fun _ _ -> raise_notrace E) fmt f with
   | exception E -> Error ()

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -42,7 +42,7 @@ module Platform = struct
 end
 
 let alias ?enabled_if ?action name ~deps =
-  let (stanza, alias_or_name) =
+  let stanza, alias_or_name =
     match action with
     | None -> ("alias", "name")
     | Some _ -> ("rule", "alias")


### PR DESCRIPTION
Lots of fields in [Context.t] are just copies of the underlying
[Ocaml_config.t]. There's no need to repeat them.
