### PR TITLE
Memoize Opam Version

### DIFF
--- a/src/dune/lib_dep.ml
+++ b/src/dune/lib_dep.ml
@@ -36,7 +36,10 @@ module Select = struct
                  let prefix = name ^ "." in
                  (prefix, ext)
                in
-               if not (String.is_prefix file ~prefix && String.is_suffix file ~suffix)
+               if
+                 not
+                   ( String.is_prefix file ~prefix
+                   && String.is_suffix file ~suffix )
                then
                  User_error.raise ~loc:loc_file
                    [ Pp.textf

--- a/src/dune/process.mli
+++ b/src/dune/process.mli
@@ -56,7 +56,7 @@ val run :
   -> ?stdout_to:Io.output Io.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
-  -> env:Env.t
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (unit, 'a) failure_mode
   -> Path.t
@@ -68,7 +68,7 @@ val run_capture :
      ?dir:Path.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
-  -> env:Env.t
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (string, 'a) failure_mode
   -> Path.t
@@ -79,7 +79,7 @@ val run_capture_line :
      ?dir:Path.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
-  -> env:Env.t
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (string, 'a) failure_mode
   -> Path.t
@@ -90,7 +90,7 @@ val run_capture_lines :
      ?dir:Path.t
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
-  -> env:Env.t
+  -> ?env:Env.t
   -> ?purpose:purpose
   -> (string list, 'a) failure_mode
   -> Path.t

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -23,6 +23,10 @@ type t =
   ; mutable unix : string array option
   }
 
+let equal t { vars; unix = _ } = Map.equal ~equal:String.equal t.vars vars
+
+let hash { vars; unix = _ } = Hashtbl.hash vars
+
 let make vars = { vars; unix = None }
 
 let empty = make Map.empty

--- a/src/stdune/env.mli
+++ b/src/stdune/env.mli
@@ -8,6 +8,10 @@ end
 
 type t
 
+val equal : t -> t -> bool
+
+val hash : t -> int
+
 module Map : Map.S with type key = Var.t
 
 val empty : t

--- a/src/stdune/tuple.ml
+++ b/src/stdune/tuple.ml
@@ -1,6 +1,8 @@
 module T2 = struct
   type ('a, 'b) t = 'a * 'b
 
+  let to_dyn = Dyn.Encoder.pair
+
   let equal f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
   let hash f g (a, b) = Hashtbl.hash (f a, g b)
@@ -11,4 +13,10 @@ module T2 = struct
     | Eq -> g b1 b2
 
   let swap (x, y) = (y, x)
+end
+
+module T3 = struct
+  type ('a, 'b, 'c) t = 'a * 'b * 'c
+
+  let to_dyn = Dyn.Encoder.triple
 end

--- a/src/stdune/tuple.mli
+++ b/src/stdune/tuple.mli
@@ -1,6 +1,8 @@
 module T2 : sig
   type ('a, 'b) t = 'a * 'b
 
+  val to_dyn : ('a -> Dyn.t) -> ('b -> Dyn.t) -> ('a, 'b) t -> Dyn.t
+
   val hash : ('a -> int) -> ('b -> int) -> ('a, 'b) t -> int
 
   val equal :
@@ -18,4 +20,11 @@ module T2 : sig
     -> Ordering.t
 
   val swap : 'a * 'b -> 'b * 'a
+end
+
+module T3 : sig
+  type ('a, 'b, 'c) t = 'a * 'b * 'c
+
+  val to_dyn :
+    ('a -> Dyn.t) -> ('b -> Dyn.t) -> ('c -> Dyn.t) -> ('a, 'b, 'c) t -> Dyn.t
 end


### PR DESCRIPTION
We can use memoization to save the opam version rather than manually
storing it in a reference cell.
