### PR TITLE
Remove files before installing them.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 2.0.0 (unreleased)
 ------------------
 
+- Remove existing destination files in `install`  before installing the new
+  ones. (#2885, fixes #2883, @bschommer)
+
 - The `action` field in the `alias` stanza is not available starting `lang dune
   2.0`. The `alias` field in the `rule` stanza is a replacement. (#2846, fixes
   2681, @rgrinberg)

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -418,6 +418,7 @@ let install_uninstall ~what =
                       in
                       let dir = Path.parent_exn dst in
                       if what = "install" then (
+                        Ops.remove_if_exists dst;
                         Printf.eprintf "Installing %s\n%!"
                           (Path.to_string_maybe_quoted dst);
                         Ops.mkdir_p dir;

--- a/test/blackbox-tests/test-cases/install-dry-run/run.t
+++ b/test/blackbox-tests/test-cases/install-dry-run/run.t
@@ -11,26 +11,37 @@
   Installing OPAM_PREFIX/lib/mylib/mylib.cmxs
   Installing OPAM_PREFIX/lib/mylib/mylib.ml
   Installing OPAM_PREFIX/lib/mylib/opam
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/META
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/META to OPAM_PREFIX/lib/mylib/META (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/dune-package
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/dune-package to OPAM_PREFIX/lib/mylib/dune-package (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib$ext_lib
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib$ext_lib to OPAM_PREFIX/lib/mylib/mylib$ext_lib (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cma
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cma to OPAM_PREFIX/lib/mylib/mylib.cma (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmi
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmi to OPAM_PREFIX/lib/mylib/mylib.cmi (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmt
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmt to OPAM_PREFIX/lib/mylib/mylib.cmt (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmx
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmx to OPAM_PREFIX/lib/mylib/mylib.cmx (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmxa
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmxa to OPAM_PREFIX/lib/mylib/mylib.cmxa (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.cmxs
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmxs to OPAM_PREFIX/lib/mylib/mylib.cmxs (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib.ml
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.ml to OPAM_PREFIX/lib/mylib/mylib.ml (executable: false)
+  Removing (if it exists) OPAM_PREFIX/lib/mylib/opam
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/opam to OPAM_PREFIX/lib/mylib/opam (executable: false)
 

--- a/test/blackbox-tests/test-cases/install-libdir/run.t
+++ b/test/blackbox-tests/test-cases/install-libdir/run.t
@@ -36,34 +36,49 @@ If prefix is passed, the default for libdir is `$prefix/lib`:
   Installing install/man/a-man-page-with-no-ext
   Installing install/man/man1/a-man-page.1
   Installing install/man/man3/another-man-page.3
+  Removing (if it exists) install/lib/foo/META
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/META to install/lib/foo/META (executable: false)
+  Removing (if it exists) install/lib/foo/dune-package
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/dune-package to install/lib/foo/dune-package (executable: false)
+  Removing (if it exists) install/lib/foo/foo$ext_lib
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to install/lib/foo/foo$ext_lib (executable: false)
+  Removing (if it exists) install/lib/foo/foo.cma
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to install/lib/foo/foo.cma (executable: false)
+  Removing (if it exists) install/lib/foo/foo.cmi
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to install/lib/foo/foo.cmi (executable: false)
+  Removing (if it exists) install/lib/foo/foo.cmt
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to install/lib/foo/foo.cmt (executable: false)
+  Removing (if it exists) install/lib/foo/foo.cmx
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to install/lib/foo/foo.cmx (executable: false)
+  Removing (if it exists) install/lib/foo/foo.cmxa
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to install/lib/foo/foo.cmxa (executable: false)
+  Removing (if it exists) install/lib/foo/foo.cmxs
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to install/lib/foo/foo.cmxs (executable: false)
+  Removing (if it exists) install/lib/foo/foo.ml
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to install/lib/foo/foo.ml (executable: false)
+  Removing (if it exists) install/lib/foo/opam
   Creating directory install/lib/foo
   Copying _build/install/default/lib/foo/opam to install/lib/foo/opam (executable: false)
+  Removing (if it exists) install/bin/exec
   Creating directory install/bin
   Copying _build/install/default/bin/exec to install/bin/exec (executable: true)
+  Removing (if it exists) install/man/a-man-page-with-no-ext
   Creating directory install/man
   Copying _build/install/default/man/a-man-page-with-no-ext to install/man/a-man-page-with-no-ext (executable: false)
+  Removing (if it exists) install/man/man1/a-man-page.1
   Creating directory install/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to install/man/man1/a-man-page.1 (executable: false)
+  Removing (if it exists) install/man/man3/another-man-page.3
   Creating directory install/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to install/man/man3/another-man-page.3 (executable: false)
 
@@ -86,34 +101,49 @@ destdir`:
   Installing OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
   Installing OPAM_VAR_PREFIX/man/man1/a-man-page.1
   Installing OPAM_VAR_PREFIX/man/man3/another-man-page.3
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/META
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/META to /OCAMLFIND_DESTDIR/foo/META (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/dune-package
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/dune-package to /OCAMLFIND_DESTDIR/foo/dune-package (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo$ext_lib
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to /OCAMLFIND_DESTDIR/foo/foo$ext_lib (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cma
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo.cma to /OCAMLFIND_DESTDIR/foo/foo.cma (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmi
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo.cmi to /OCAMLFIND_DESTDIR/foo/foo.cmi (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmt
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo.cmt to /OCAMLFIND_DESTDIR/foo/foo.cmt (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmx
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo.cmx to /OCAMLFIND_DESTDIR/foo/foo.cmx (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmxa
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo.cmxa to /OCAMLFIND_DESTDIR/foo/foo.cmxa (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.cmxs
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo.cmxs to /OCAMLFIND_DESTDIR/foo/foo.cmxs (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/foo.ml
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/foo.ml to /OCAMLFIND_DESTDIR/foo/foo.ml (executable: false)
+  Removing (if it exists) /OCAMLFIND_DESTDIR/foo/opam
   Creating directory /OCAMLFIND_DESTDIR/foo
   Copying _build/install/default/lib/foo/opam to /OCAMLFIND_DESTDIR/foo/opam (executable: false)
+  Removing (if it exists) OPAM_VAR_PREFIX/bin/exec
   Creating directory OPAM_VAR_PREFIX/bin
   Copying _build/install/default/bin/exec to OPAM_VAR_PREFIX/bin/exec (executable: true)
+  Removing (if it exists) OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
   Creating directory OPAM_VAR_PREFIX/man
   Copying _build/install/default/man/a-man-page-with-no-ext to OPAM_VAR_PREFIX/man/a-man-page-with-no-ext (executable: false)
+  Removing (if it exists) OPAM_VAR_PREFIX/man/man1/a-man-page.1
   Creating directory OPAM_VAR_PREFIX/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to OPAM_VAR_PREFIX/man/man1/a-man-page.1 (executable: false)
+  Removing (if it exists) OPAM_VAR_PREFIX/man/man3/another-man-page.3
   Creating directory OPAM_VAR_PREFIX/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to OPAM_VAR_PREFIX/man/man3/another-man-page.3 (executable: false)
   Removing (if it exists) /OCAMLFIND_DESTDIR/foo/META
@@ -156,34 +186,49 @@ in libdir:
   Installing OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
   Installing OPAM_VAR_PREFIX/man/man1/a-man-page.1
   Installing OPAM_VAR_PREFIX/man/man3/another-man-page.3
+  Removing (if it exists) /LIBDIR/foo/META
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/META to /LIBDIR/foo/META (executable: false)
+  Removing (if it exists) /LIBDIR/foo/dune-package
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/dune-package to /LIBDIR/foo/dune-package (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo$ext_lib
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to /LIBDIR/foo/foo$ext_lib (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo.cma
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cma to /LIBDIR/foo/foo.cma (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo.cmi
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmi to /LIBDIR/foo/foo.cmi (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo.cmt
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmt to /LIBDIR/foo/foo.cmt (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo.cmx
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmx to /LIBDIR/foo/foo.cmx (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo.cmxa
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmxa to /LIBDIR/foo/foo.cmxa (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo.cmxs
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.cmxs to /LIBDIR/foo/foo.cmxs (executable: false)
+  Removing (if it exists) /LIBDIR/foo/foo.ml
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/foo.ml to /LIBDIR/foo/foo.ml (executable: false)
+  Removing (if it exists) /LIBDIR/foo/opam
   Creating directory /LIBDIR/foo
   Copying _build/install/default/lib/foo/opam to /LIBDIR/foo/opam (executable: false)
+  Removing (if it exists) OPAM_VAR_PREFIX/bin/exec
   Creating directory OPAM_VAR_PREFIX/bin
   Copying _build/install/default/bin/exec to OPAM_VAR_PREFIX/bin/exec (executable: true)
+  Removing (if it exists) OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
   Creating directory OPAM_VAR_PREFIX/man
   Copying _build/install/default/man/a-man-page-with-no-ext to OPAM_VAR_PREFIX/man/a-man-page-with-no-ext (executable: false)
+  Removing (if it exists) OPAM_VAR_PREFIX/man/man1/a-man-page.1
   Creating directory OPAM_VAR_PREFIX/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to OPAM_VAR_PREFIX/man/man1/a-man-page.1 (executable: false)
+  Removing (if it exists) OPAM_VAR_PREFIX/man/man3/another-man-page.3
   Creating directory OPAM_VAR_PREFIX/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to OPAM_VAR_PREFIX/man/man3/another-man-page.3 (executable: false)
   Removing (if it exists) /LIBDIR/foo/META
@@ -226,34 +271,49 @@ This is the case when the prefix is implicit:
   Installing DESTDIR/OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
   Installing DESTDIR/OPAM_VAR_PREFIX/man/man1/a-man-page.1
   Installing DESTDIR/OPAM_VAR_PREFIX/man/man3/another-man-page.3
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/META
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/META to DESTDIR/OPAM_VAR_PREFIX/lib/foo/META (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/dune-package
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/dune-package to DESTDIR/OPAM_VAR_PREFIX/lib/foo/dune-package (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo$ext_lib
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo$ext_lib (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cma
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cma (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmi
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmi (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmt
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmt (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmx
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmx (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxa
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxa (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxs
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.cmxs (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.ml
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to DESTDIR/OPAM_VAR_PREFIX/lib/foo/foo.ml (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/lib/foo/opam
   Creating directory DESTDIR/OPAM_VAR_PREFIX/lib/foo
   Copying _build/install/default/lib/foo/opam to DESTDIR/OPAM_VAR_PREFIX/lib/foo/opam (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/bin/exec
   Creating directory DESTDIR/OPAM_VAR_PREFIX/bin
   Copying _build/install/default/bin/exec to DESTDIR/OPAM_VAR_PREFIX/bin/exec (executable: true)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/man/a-man-page-with-no-ext
   Creating directory DESTDIR/OPAM_VAR_PREFIX/man
   Copying _build/install/default/man/a-man-page-with-no-ext to DESTDIR/OPAM_VAR_PREFIX/man/a-man-page-with-no-ext (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/man/man1/a-man-page.1
   Creating directory DESTDIR/OPAM_VAR_PREFIX/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to DESTDIR/OPAM_VAR_PREFIX/man/man1/a-man-page.1 (executable: false)
+  Removing (if it exists) DESTDIR/OPAM_VAR_PREFIX/man/man3/another-man-page.3
   Creating directory DESTDIR/OPAM_VAR_PREFIX/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to DESTDIR/OPAM_VAR_PREFIX/man/man3/another-man-page.3 (executable: false)
 
@@ -275,34 +335,49 @@ But also when the prefix is explicit:
   Installing DESTDIR/prefix/man/a-man-page-with-no-ext
   Installing DESTDIR/prefix/man/man1/a-man-page.1
   Installing DESTDIR/prefix/man/man3/another-man-page.3
+  Removing (if it exists) DESTDIR/prefix/lib/foo/META
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/META to DESTDIR/prefix/lib/foo/META (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/dune-package
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/dune-package to DESTDIR/prefix/lib/foo/dune-package (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo$ext_lib
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/prefix/lib/foo/foo$ext_lib (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cma
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to DESTDIR/prefix/lib/foo/foo.cma (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmi
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/prefix/lib/foo/foo.cmi (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmt
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/prefix/lib/foo/foo.cmt (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmx
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/prefix/lib/foo/foo.cmx (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxa
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/prefix/lib/foo/foo.cmxa (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxs
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/prefix/lib/foo/foo.cmxs (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.ml
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to DESTDIR/prefix/lib/foo/foo.ml (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/opam
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/opam to DESTDIR/prefix/lib/foo/opam (executable: false)
+  Removing (if it exists) DESTDIR/prefix/bin/exec
   Creating directory DESTDIR/prefix/bin
   Copying _build/install/default/bin/exec to DESTDIR/prefix/bin/exec (executable: true)
+  Removing (if it exists) DESTDIR/prefix/man/a-man-page-with-no-ext
   Creating directory DESTDIR/prefix/man
   Copying _build/install/default/man/a-man-page-with-no-ext to DESTDIR/prefix/man/a-man-page-with-no-ext (executable: false)
+  Removing (if it exists) DESTDIR/prefix/man/man1/a-man-page.1
   Creating directory DESTDIR/prefix/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to DESTDIR/prefix/man/man1/a-man-page.1 (executable: false)
+  Removing (if it exists) DESTDIR/prefix/man/man3/another-man-page.3
   Creating directory DESTDIR/prefix/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to DESTDIR/prefix/man/man3/another-man-page.3 (executable: false)
 
@@ -324,33 +399,48 @@ DESTDIR can also be passed as a command line flag.
   Installing DESTDIR/prefix/man/a-man-page-with-no-ext
   Installing DESTDIR/prefix/man/man1/a-man-page.1
   Installing DESTDIR/prefix/man/man3/another-man-page.3
+  Removing (if it exists) DESTDIR/prefix/lib/foo/META
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/META to DESTDIR/prefix/lib/foo/META (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/dune-package
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/dune-package to DESTDIR/prefix/lib/foo/dune-package (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo$ext_lib
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo$ext_lib to DESTDIR/prefix/lib/foo/foo$ext_lib (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cma
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cma to DESTDIR/prefix/lib/foo/foo.cma (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmi
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmi to DESTDIR/prefix/lib/foo/foo.cmi (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmt
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmt to DESTDIR/prefix/lib/foo/foo.cmt (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmx
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmx to DESTDIR/prefix/lib/foo/foo.cmx (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxa
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxa to DESTDIR/prefix/lib/foo/foo.cmxa (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.cmxs
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.cmxs to DESTDIR/prefix/lib/foo/foo.cmxs (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/foo.ml
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/foo.ml to DESTDIR/prefix/lib/foo/foo.ml (executable: false)
+  Removing (if it exists) DESTDIR/prefix/lib/foo/opam
   Creating directory DESTDIR/prefix/lib/foo
   Copying _build/install/default/lib/foo/opam to DESTDIR/prefix/lib/foo/opam (executable: false)
+  Removing (if it exists) DESTDIR/prefix/bin/exec
   Creating directory DESTDIR/prefix/bin
   Copying _build/install/default/bin/exec to DESTDIR/prefix/bin/exec (executable: true)
+  Removing (if it exists) DESTDIR/prefix/man/a-man-page-with-no-ext
   Creating directory DESTDIR/prefix/man
   Copying _build/install/default/man/a-man-page-with-no-ext to DESTDIR/prefix/man/a-man-page-with-no-ext (executable: false)
+  Removing (if it exists) DESTDIR/prefix/man/man1/a-man-page.1
   Creating directory DESTDIR/prefix/man/man1
   Copying _build/install/default/man/man1/a-man-page.1 to DESTDIR/prefix/man/man1/a-man-page.1 (executable: false)
+  Removing (if it exists) DESTDIR/prefix/man/man3/another-man-page.3
   Creating directory DESTDIR/prefix/man/man3
   Copying _build/install/default/man/man3/another-man-page.3 to DESTDIR/prefix/man/man3/another-man-page.3 (executable: false)

--- a/test/blackbox-tests/test-cases/install-single-section/run.t
+++ b/test/blackbox-tests/test-cases/install-single-section/run.t
@@ -4,8 +4,10 @@ particularly useful if one wants to install binaries:
   $ dune install --dry-run --prefix ./ --sections bin,man
   Installing bin/foo
   Installing man/mp
+  Removing (if it exists) bin/foo
   Creating directory bin
   Copying _build/install/default/bin/foo to bin/foo (executable: true)
+  Removing (if it exists) man/mp
   Creating directory man
   Copying _build/install/default/man/mp to man/mp (executable: false)
 
@@ -13,6 +15,7 @@ Now let's install with the above command with one less section:
 
   $ dune install --dry-run --prefix ./ --sections bin
   Installing bin/foo
+  Removing (if it exists) bin/foo
   Creating directory bin
   Copying _build/install/default/bin/foo to bin/foo (executable: true)
 


### PR DESCRIPTION
This should avoid a failure with "file busy" if for example an
installed binary is running, as described in Issue #2883.