### PR TITLE
Memoize generation of rules for dune-package and meta files

### DIFF
--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -277,7 +277,7 @@ let gen_rules sctx dir_contents cctxs ~dir :
 
 let gen_rules ~sctx ~dir components :
     Build_system.extra_sub_directories_to_keep =
-  Install_rules.init_meta_and_dune_package sctx ~dir;
+  Install_rules.meta_and_dune_package_rules sctx ~dir;
   let subdirs_to_keep1 = Install_rules.gen_rules sctx ~dir in
   Opam_create.add_rules sctx ~dir;
   let subdirs_to_keep2 : Build_system.extra_sub_directories_to_keep =

--- a/src/dune/install_rules.mli
+++ b/src/dune/install_rules.mli
@@ -13,6 +13,10 @@ val meta_and_dune_package_rules : Super_context.t -> dir:Path.Build.t -> unit
 
 (* TODO: A seemingly more sensible approach for [meta_and_dune_package_rules]
    is to only generate rules for the given directory, or stop taking [dir]
-   altogether and take [project] instead. *)
+   altogether and take [project] instead.
+
+   aalekseyev: actually I think we should just remove
+   [meta_and_dune_package_rules] from the interface and have [gen_rules]
+   do everything. *)
 
 val packages : Super_context.t -> Package.Name.Set.t Path.Build.Map.t

--- a/src/dune/install_rules.mli
+++ b/src/dune/install_rules.mli
@@ -3,6 +3,16 @@ open Stdune
 val gen_rules :
   Super_context.t -> dir:Path.Build.t -> Build_system.Subdir_set.t
 
-val init_meta_and_dune_package : Super_context.t -> dir:Path.Build.t -> unit
+(** Generate rules for [.dune-package] and [META.<package-name>] files in a
+    given super context and directory. Surprisingly, the current implementation
+    generates rules for {b all} directories of the project, which are filtered
+    out later in the [build_system.ml]. This function is called multiple times
+    for the same project (with different [dir]), so we memoize it to avoid
+    duplicating work. *)
+val meta_and_dune_package_rules : Super_context.t -> dir:Path.Build.t -> unit
+
+(* TODO: A seemingly more sensible approach for [meta_and_dune_package_rules]
+   is to only generate rules for the given directory, or stop taking [dir]
+   altogether and take [project] instead. *)
 
 val packages : Super_context.t -> Package.Name.Set.t Path.Build.Map.t


### PR DESCRIPTION
In our internal repo this reduces the Dune's memory consumption from 11GB to 5GB.