### PR TITLE
Fix the order of arguments of [cons]

### DIFF
--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -65,7 +65,7 @@ open O
 let rec all xs =
   match xs with
   | [] -> return []
-  | x :: xs -> Map2 ((fun x xs -> x :: xs), x, all xs)
+  | x :: xs -> Map2 (List.cons, x, all xs)
 
 let all_unit xs =
   let+ (_ : unit list) = all xs in

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -172,7 +172,7 @@ let rec equal eq xs ys =
 
 let hash f xs = Dune_caml.Hashtbl.hash (map ~f xs)
 
-let cons xs x = x :: xs
+let cons x xs = x :: xs
 
 (* copy&paste from [base] *)
 let fold_map t ~init ~f =

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -67,7 +67,7 @@ val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
 val hash : ('a -> int) -> 'a list -> int
 
-val cons : 'a t -> 'a -> 'a t
+val cons : 'a -> 'a t -> 'a t
 
 val fold_map : 'a list -> init:'b -> f:('b -> 'a -> 'b * 'c) -> 'b * 'c list
 


### PR DESCRIPTION
The current definition of `cons` is non-standard and unused. By flipping the arguments, we make it more useful.