### PR TITLE
New root detection algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -208,6 +208,9 @@
 
 - Allow `.opam.template` files to be generated using rules (#2866, @rgrinberg)
 
+- Modify the root detection algorithm to stop at the first `dune-project` or
+  `dune-workspace` encountered. (#2891, @rgrinberg)
+
 1.11.4 (09/10/2019)
 -------------------
 


### PR DESCRIPTION
The previous algorithm would attempt to find the top most root with the
lowest root. The new algorithm just stops at the first dir marker so
there's no longer a need for priorities.

The current root detection has been unintuitive for users and this is just the latest report: https://discuss.ocaml.org/t/finding-the-root-of-a-dune-project-request-for-comments/4676 

This PR brings the behavior more inline with tools such as git, which stop recursing once they find a single valid marker.