### PR TITLE
Make memoization docs optional

### DIFF
--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -65,15 +65,18 @@ let term =
        in
        List.iter fns ~f:(fun { Memo.Function.Info.name; doc } ->
            let name = Memo.Function.Name.to_string name in
-           Printf.printf "%-*s : %s\n" longest name doc);
+           Printf.printf "%-*s" longest name;
+           Option.iter doc ~f:(Printf.printf ": %s");
+           Printf.printf "\n";
+         );
        flush stdout;
        `Ok ()
      | `Show_doc fn ->
        let info = Memo.function_info fn in
        let name = Memo.Function.Name.to_string info.name in
-       Printf.printf "%s\n%s\n%s\n" name
-         (String.make (String.length name) '=')
-         info.doc;
+       Printf.printf "%s\n%s\n" name
+         (String.make (String.length name) '=');
+       Option.iter info.doc ~f:(Printf.printf "%s\n");
        `Ok ()
 
 let command = (term, info)

--- a/src/memo/function.ml
+++ b/src/memo/function.ml
@@ -20,7 +20,7 @@ end
 module Info = struct
   type t =
     { name : Name.t
-    ; doc : string
+    ; doc : string option
     }
 end
 

--- a/src/memo/function.mli
+++ b/src/memo/function.mli
@@ -11,7 +11,7 @@ end
 module Info : sig
   type t =
     { name : Name.t
-    ; doc : string
+    ; doc : string option
     }
 end
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -61,7 +61,7 @@ module Function : sig
   module Info : sig
     type t =
       { name : Name.t
-      ; doc : string
+      ; doc : string option
       }
   end
 end
@@ -131,7 +131,7 @@ end
 val create_with_store :
      string
   -> store:(module Store.S with type key = 'i)
-  -> doc:string
+  -> ?doc:string
   -> input:(module Store.Input with type t = 'i)
   -> visibility:'i Visibility.t
   -> output:'o Output.t
@@ -159,7 +159,7 @@ val create_with_store :
     if it's user-facing then how to parse the values written by the user. *)
 val create :
      string
-  -> doc:string
+  -> ?doc:string
   -> input:(module Input with type t = 'i)
   -> visibility:'i Visibility.t
   -> output:'o Output.t
@@ -169,7 +169,7 @@ val create :
 
 val create_hidden :
      string
-  -> doc:string
+  -> ?doc:string
   -> input:(module Input with type t = 'i)
   -> ('i, 'o, 'f) Function.Type.t
   -> 'f
@@ -239,7 +239,7 @@ module With_implicit_output : sig
 
   val create :
        string
-    -> doc:string
+    -> ?doc:string
     -> input:(module Input with type t = 'i)
     -> visibility:'i Visibility.t
     -> output:(module Output_simple with type t = 'o)

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -36,12 +36,12 @@ let compdep x = Fiber.return (x ^ x)
 let mcompdep1 =
   string_fn_create "some"
     ~output:(Allow_cutoff (module String))
-    compdep ~doc:""
+    compdep
 
 let mcompdep2 =
   string_fn_create "another"
     ~output:(Allow_cutoff (module String))
-    compdep ~doc:""
+    compdep
 
 (* compute the dependencies once so they are present in the global hash table *)
 let () =
@@ -60,7 +60,7 @@ let comp x =
   String.sub a ~pos:0 ~len:(String.length a |> min 3) |> Fiber.return
 
 let mcomp =
-  string_fn_create "test" ~output:(Allow_cutoff (module String)) comp ~doc:""
+  string_fn_create "test" ~output:(Allow_cutoff (module String)) comp
 
 (* running it the first time should increase the counter, running it again
    should not, but should still return the same result *)
@@ -137,7 +137,7 @@ let mcompcycle =
   let fn =
     int_fn_create "cycle"
       ~output:(Allow_cutoff (module String))
-      compcycle ~doc:""
+      compcycle
   in
   Fdecl.set mcompcycle fn;
   fn
@@ -179,7 +179,7 @@ let mfib =
       mfib (x - 1) >>= fun r1 -> mfib (x - 2) >>| fun r2 -> r1 + r2
   in
   let fn =
-    int_fn_create "fib" ~output:(Allow_cutoff (module Int)) compfib ~doc:""
+    int_fn_create "fib" ~output:(Allow_cutoff (module Int)) compfib
   in
   Fdecl.set mfib fn;
   fn
@@ -217,7 +217,7 @@ let sync_fib =
   let fn =
     sync_int_fn_create "sync-fib"
       ~output:(Allow_cutoff (module Int))
-      compfib ~doc:""
+      compfib
   in
   Fdecl.set mfib fn;
   fn


### PR DESCRIPTION
Often, we just use dummy values for them anyway. Might as well not
bother in those cases.