### PR TITLE
Add dune meriln-file <PATH> command

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -154,6 +154,7 @@ let all =
   ; Compute.command
   ; Upgrade.command
   ; Cache_daemon.command
+  ; Merlin_file.command
   ]
 
 let default =

--- a/bin/merlin_file.ml
+++ b/bin/merlin_file.ml
@@ -1,0 +1,56 @@
+open Stdune
+open Import
+
+let doc = "Generate merlin files (internal)"
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P
+      {| $(b, dune merlin-file) generates a .merlin file for a particular file.
+       This operation is internal to dune.
+       |}
+  ]
+
+let info = Term.info "merlin-file" ~doc ~man
+
+let term =
+  let+ common = Common.term
+  and+ path =
+    let docv = "FILE" in
+    let doc = "Source file" in
+    Arg.(required & pos 0 (some Arg.path) None & info [] ~docv ~doc)
+  in
+  let path = Path.Source.of_string (Arg.Path.arg path) in
+  Common.set_common common ~targets:[];
+  Scheduler.go ~common (fun () ->
+      let open Fiber.O in
+      let* setup = Import.Main.setup common in
+      let src_dir =
+        match
+          let open Option.O in
+          let* parent = Path.Source.parent path in
+          Dune.File_tree.find_dir parent
+        with
+        | Some d -> Dune.File_tree.Dir.path d
+        | None ->
+          User_error.raise
+            [ Pp.textf "Invalid source file %s"
+                (Path.Source.to_string_maybe_quoted path)
+            ]
+      in
+      let context : Context.t =
+        match
+          setup.workspace.contexts
+          |> List.find ~f:(fun (ctx : Dune.Context.t) -> ctx.merlin)
+        with
+        | Some c -> c
+        | None -> User_error.raise [ Pp.textf "no merlin context is defined" ]
+      in
+      let target =
+        let dir = Path.Build.append_source context.build_dir src_dir in
+        Path.Build.relative dir Dune.Merlin.merlin_filename |> Path.build
+      in
+      let+ () = do_build [ File target ] in
+      Io.read_file target |> print_string)
+
+let command = (term, info)

--- a/bin/merlin_file.mli
+++ b/bin/merlin_file.mli
@@ -1,0 +1,1 @@
+val command : unit Cmdliner.Term.t * Cmdliner.Term.info

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -99,6 +99,15 @@
  (files   dune-installed-libraries.1))
 
 (rule
+ (with-stdout-to dune-merlin-file.1
+  (run dune merlin-file --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-merlin-file.1))
+
+(rule
  (with-stdout-to dune-printenv.1
   (run dune printenv --help=groff)))
 

--- a/src/dune/merlin.ml
+++ b/src/dune/merlin.ml
@@ -4,10 +4,12 @@ open Build.O
 open! No_io
 module SC = Super_context
 
+let merlin_filename = ".merlin"
+
 let warn_dropped_pp loc ~allow_approx_merlin ~reason =
   if not allow_approx_merlin then
     User_warning.emit ~loc
-      [ Pp.textf ".merlin generated is inaccurate. %s." reason
+      [ Pp.textf "%s generated is inaccurate. %s." merlin_filename reason
       ; Pp.text
           "Split the stanzas into different directories or silence this \
            warning by adding (allow_approximate_merlin) to your dune-project."
@@ -195,7 +197,7 @@ let dot_merlin sctx ~dir ~more_src_dirs ~expander ({ requires; flags; _ } as t)
     =
   Path.Build.drop_build_context dir
   |> Option.iter ~f:(fun remaindir ->
-         let merlin_file = Path.Build.relative dir ".merlin" in
+         let merlin_file = Path.Build.relative dir merlin_filename in
          (* We make the compilation of .ml/.mli files depend on the existence
             of .merlin so that they are always generated, however the command
             themselves don't read the merlin file, so we don't want to declare

--- a/src/dune/merlin.mli
+++ b/src/dune/merlin.mli
@@ -5,6 +5,8 @@ open Import
 
 type t
 
+val merlin_filename : string
+
 val make :
      ?requires:Lib.t list Or_exn.t
   -> flags:Ocaml_flags.t

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1214,6 +1214,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias merlin-file-command)
+ (deps (package dune) (source_tree test-cases/merlin-file-command))
+ (action
+  (chdir
+   test-cases/merlin-file-command
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias merlin-tests)
  (deps (package dune) (source_tree test-cases/merlin-tests))
  (action
@@ -2074,6 +2082,7 @@
   (alias loop)
   (alias macro-expand-error)
   (alias menhir)
+  (alias merlin-file-command)
   (alias merlin-tests)
   (alias meta-gen)
   (alias misc)
@@ -2292,6 +2301,7 @@
   (alias link-deps)
   (alias loop)
   (alias macro-expand-error)
+  (alias merlin-file-command)
   (alias meta-gen)
   (alias misc)
   (alias missing-loc-run)

--- a/test/blackbox-tests/test-cases/merlin-file-command/run.t
+++ b/test/blackbox-tests/test-cases/merlin-file-command/run.t
@@ -1,0 +1,18 @@
+Test the dune merlin-file command. This command is used to generate the .merlin
+config for a particular source file.
+
+  $ echo "(lang dune 2.0)" > dune-project
+  $ mkdir foo bar
+  $ cat >bar/dune <<EOF
+  > (library (name bar))
+  > EOF
+  $ cat >foo/dune <<EOF
+  > (library (name foo) (libraries bar))
+  > EOF
+  $ dune merlin-file ./foo/test.ml
+  EXCLUDE_QUERY_DIR
+  B ../_build/default/bar/.bar.objs/byte
+  B ../_build/default/foo/.foo.objs/byte
+  S ../bar
+  S .
+  FLG -open Foo -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs


### PR DESCRIPTION
The purpose of this command is to return the .merlin file for a
particular source. The current implementation simply uses the
directories .merlin file.