### PR TITLE
Relocation Capability to the build info

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -15,7 +15,7 @@ let get_dirs context ~prefix_from_command_line ~libdir_from_command_line =
     Fiber.return (prefix, Some (Path.relative prefix dir))
   | None ->
     let open Fiber.O in
-    let* prefix = Context.install_prefix context in
+    let prefix = Context.install_prefix context in
     let libdir =
       match libdir_from_command_line with
       | None -> Context.install_ocaml_libdir context

--- a/otherlibs/build-info/src/build_info.ml
+++ b/otherlibs/build-info/src/build_info.ml
@@ -23,4 +23,32 @@ module V1 = struct
   end
 
   let version () = Build_info_data.version
+
+  module Path = struct
+    type t = string
+
+    let to_string t = t
+
+    let of_string t = t
+
+    let relative = Filename.concat
+  end
+
+  module Location = struct
+    type t =
+      | Etc
+      | Share of { package : string }
+
+    let component = function
+      | Etc -> "etc"
+      | Share { package } -> Printf.sprintf "share/%s" package
+  end
+
+  let registry_root =
+    lazy
+      ( match Sys.getenv_opt "DUNE_REGISTRY_ROOT" with
+      | Some s -> s
+      | None -> Build_info_data.artifact_root )
+
+  let get l = Path.relative (Lazy.force registry_root) (Location.component l)
 end

--- a/otherlibs/build-info/src/build_info.mli
+++ b/otherlibs/build-info/src/build_info.mli
@@ -29,4 +29,22 @@ module V1 : sig
 
     val find : name:string -> Statically_linked_library.t option
   end
+
+  module Path : sig
+    type t
+
+    val to_string : t -> string
+
+    val of_string : string -> t
+
+    val relative : t -> string -> t
+  end
+
+  module Location : sig
+    type t =
+      | Etc
+      | Share of { package : string }
+  end
+
+  val get : Location.t -> Path.t
 end

--- a/otherlibs/build-info/src/build_info_data.mli
+++ b/otherlibs/build-info/src/build_info_data.mli
@@ -3,3 +3,5 @@
 val version : string option
 
 val statically_linked_libraries : (string * string option) list
+
+val artifact_root : string

--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -85,7 +85,8 @@ Once installed, we have the version information:
 Check what the generated build info module looks like:
 
   $ cat _build/default/c/.c.eobjs/build_info_data.ml-gen \
-  >   | sed 's/"dune-build-info".*/"dune-build-info", Some "XXX"/'
+  >   | sed 's/"dune-build-info".*/"dune-build-info", Some "XXX"/' \
+  >   | sed 's/let artifact_root = .*/let artifact_root = " .. "/'
   let eval s =
     let len = String.length s in
     if s.[0] = '=' then
@@ -104,6 +105,7 @@ Check what the generated build info module looks like:
   let p0 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:c%%%%%%%%%%%%%%%%%%%%%%%%%%"
   
   let version = p0
+  let artifact_root = " .. "
   
   let statically_linked_libraries =
     [ "a", p1

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -765,8 +765,7 @@ end
 let which t s = which ~cache:t.which_cache ~path:t.path s
 
 let install_prefix t =
-  opam_config_var t "prefix"
-  >>| function
+  match Env.get t.env "OPAM_PREFIX" with
   | Some x -> Path.of_filename_relative_to_initial_cwd x
   | None -> Path.parent_exn t.ocaml_bin
 

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -107,7 +107,7 @@ val which : t -> string -> Path.t option
 
 val opam_config_var : t -> string -> string option Fiber.t
 
-val install_prefix : t -> Path.t Fiber.t
+val install_prefix : t -> Path.t
 
 val install_ocaml_libdir : t -> Path.t option Fiber.t
 

--- a/src/dune/link_time_code_gen.ml
+++ b/src/dune/link_time_code_gen.ml
@@ -136,6 +136,10 @@ let build_info_code cctx ~libs ~api_version =
       let p = Path.Build.drop_build_context_exn (CC.dir cctx) in
       placeholder p
   in
+  let artifact_root =
+    let context = Compilation_context.context cctx in
+    Context.install_prefix context |> Path.to_absolute_filename
+  in
   let libs =
     List.map libs ~f:(fun lib ->
         ( Lib.name lib
@@ -171,6 +175,7 @@ let build_info_code cctx ~libs ~api_version =
         (Artifact_substitution.encode ~min_len:64 (Vcs_describe path)));
   if not (Path.Source.Map.is_empty !placeholders) then pr buf "";
   pr buf "let version = %s" version;
+  pr buf "let artifact_root = %S" artifact_root;
   pr buf "";
   prlist buf "statically_linked_libraries" libs ~f:(fun (name, v) ->
       pr buf "%S, %s" (Lib_name.to_string name) v);


### PR DESCRIPTION
I find that the discussion in https://github.com/ocaml/dune/issues/1185 derailed us from implementing a fairly simple feature. I don't think it's necessary to get cover all use cases exhaustively before it's useful. So I've started a prototype that should cover most bases. If it doesn't, we'll always be able to extend it.

The PR is still not fully functional, but if there's a positive response from the maintainers, I can finish it up.

cc the parties who were interested in this feature: @bobot @emillon @ejgallego 