### PR TITLE
Add boot/duneboot.ml to .ocamlformat-ignore

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,1 +1,2 @@
+boot/duneboot.ml
 boot/libs.ml


### PR DESCRIPTION
Apparently `boot/duneboot.ml` is generated too. A follow up to #2906.
