### PR TITLE
Drop unnecessary [doc] arguments when using Memo

### DIFF
--- a/src/dune/command.ml
+++ b/src/dune/command.ml
@@ -153,7 +153,7 @@ module Args = struct
 
   let memo t =
     let memo =
-      Memo.create_hidden "Command.Args.memo" ~doc:"Command.Args.memo"
+      Memo.create_hidden "Command.Args.memo"
         ~input:(module Path)
         Sync
         (fun dir -> expand_static ~dir t)

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -521,7 +521,6 @@ let meta_and_dune_package_rules_impl (project, sctx) =
 
 let meta_and_dune_package_rules_memo =
   Memo.With_implicit_output.create "meta_and_dune_package_rules"
-    ~doc:"meta_and_dune_package_rules"
     ~input:(module Project_and_super_context)
     ~visibility:Hidden
     ~output:(module Unit)


### PR DESCRIPTION
This is a follow-up to #2895.