### PR TITLE
Add --mandir to dune install

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   build paths of files in public and private libraries within the same
   project. (#2901, @snowleopard)
 
+- Add `--mandir` option to `$ dune install`. This option allows to override the
+  installation directory for man pages. (#2915, fixes #2670, @rgrinberg)
 
 2.0.0 (20/11/2019)
 ------------------

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -302,6 +302,11 @@ let install_uninstall ~what =
         & info [ "destdir" ] ~env:(env_var "DESTDIR") ~docv:"PATH"
             ~doc:
               "When passed, this directory is prepended to all installed paths.")
+    and+ mandir =
+      let doc =
+        "When passed, manually override the directory to install man pages"
+      in
+      Arg.(value & opt (some string) None & info [ "mandir" ] ~docv:"PATH" ~doc)
     and+ dry_run =
       Arg.(
         value & flag
@@ -397,6 +402,7 @@ let install_uninstall ~what =
         let (module Ops) = file_operations ~dry_run ~workspace in
         let files_deleted_in = ref Path.Set.empty in
         let+ () =
+          let mandir = Option.map mandir ~f:Path.of_string in
           Fiber.sequential_iter install_files_by_context
             ~f:(fun (context, entries_per_package) ->
               let* prefix, libdir =
@@ -407,7 +413,7 @@ let install_uninstall ~what =
                 ~f:(fun (package, entries) ->
                   let paths =
                     Install.Section.Paths.make ~package ~destdir:prefix ?libdir
-                      ()
+                      ?mandir ()
                   in
                   Fiber.sequential_iter entries ~f:(fun entry ->
                       let special_file = Special_file.of_entry entry in

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -402,7 +402,12 @@ let install_uninstall ~what =
         let (module Ops) = file_operations ~dry_run ~workspace in
         let files_deleted_in = ref Path.Set.empty in
         let+ () =
-          let mandir = Option.map mandir ~f:Path.of_string in
+          let mandir =
+            Option.map ~f:Path.of_string
+              ( match mandir with
+              | Some _ -> mandir
+              | None -> Dune.Setup.mandir )
+          in
           Fiber.sequential_iter install_files_by_context
             ~f:(fun (context, entries_per_package) ->
               let* prefix, libdir =

--- a/configure.ml
+++ b/configure.ml
@@ -15,20 +15,30 @@ let () =
   let bad fmt = ksprintf (fun s -> raise (Arg.Bad s)) fmt in
   let library_path = ref None in
   let library_destdir = ref None in
+  let mandir = ref None in
+  let cwd = lazy (Sys.getcwd ()) in
+  let dir_of_string s =
+    if Filename.is_relative s then
+      Filename.concat (Lazy.force cwd) s
+    else
+      s
+  in
   let set_libdir s =
-    let dir =
-      if Filename.is_relative s then
-        Filename.concat (Sys.getcwd ()) s
-      else
-        s
-    in
+    let dir = dir_of_string s in
     library_path := Some [ dir ];
     library_destdir := Some dir
+  in
+  let set_mandir s =
+    let dir = dir_of_string s in
+    mandir := Some dir
   in
   let args =
     [ ( "--libdir"
       , Arg.String set_libdir
       , "DIR where installed libraries are for the default build context" )
+    ; ( "--mandir"
+      , Arg.String set_mandir
+      , "DIR where man pages are installed are for the default build context" )
     ]
   in
   let anon s = bad "Don't know what to do with %s" s in
@@ -38,4 +48,5 @@ let () =
   let pr fmt = fprintf oc (fmt ^^ "\n") in
   pr "let library_path    = %s" (option (list string) !library_path);
   pr "let library_destdir = %s" (option string !library_destdir);
+  pr "let mandir = %s" (option string !mandir);
   close_out oc

--- a/src/dune/install.ml
+++ b/src/dune/install.ml
@@ -201,7 +201,8 @@ module Section = struct
       ; man : Path.t
       }
 
-    let make ~package ~destdir ?(libdir = Path.relative destdir "lib") () =
+    let make ~package ~destdir ?(libdir = Path.relative destdir "lib")
+        ?(mandir = Path.relative destdir "man") () =
       let package = Package.Name.to_string package in
       let lib_root = libdir in
       let libexec_root = libdir in
@@ -213,7 +214,7 @@ module Section = struct
       ; share_root
       ; bin = Path.relative destdir "bin"
       ; sbin = Path.relative destdir "sbin"
-      ; man = Path.relative destdir "man"
+      ; man = mandir
       ; toplevel = Path.relative libdir "toplevel"
       ; stublibs = Path.relative libdir "stublibs"
       ; lib = Path.relative lib_root package

--- a/src/dune/install.mli
+++ b/src/dune/install.mli
@@ -45,7 +45,12 @@ module Section : sig
     type t
 
     val make :
-      package:Package.Name.t -> destdir:Path.t -> ?libdir:Path.t -> unit -> t
+         package:Package.Name.t
+      -> destdir:Path.t
+      -> ?libdir:Path.t
+      -> ?mandir:Path.t
+      -> unit
+      -> t
 
     val install_path : t -> section -> Dst.t -> Path.t
   end

--- a/src/dune/setup.defaults.ml
+++ b/src/dune/setup.defaults.ml
@@ -1,3 +1,5 @@
 let library_path = None
 
 let library_destdir = None
+
+let mandir = None

--- a/src/dune/setup.mli
+++ b/src/dune/setup.mli
@@ -9,3 +9,6 @@ val library_path : string list option
 
 (** Where to install libraries for the default context. *)
 val library_destdir : string option
+
+(** Where to install manpages for the default context. *)
+val mandir : string option

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1083,6 +1083,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias install-mandir)
+ (deps (package dune) (source_tree test-cases/install-mandir))
+ (action
+  (chdir
+   test-cases/install-mandir
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias install-multiple-contexts)
  (deps (package dune) (source_tree test-cases/install-multiple-contexts))
  (action
@@ -2059,6 +2067,7 @@
   (alias inline_tests)
   (alias install-dry-run)
   (alias install-libdir)
+  (alias install-mandir)
   (alias install-multiple-contexts)
   (alias install-partial-package)
   (alias install-rule-order)
@@ -2279,6 +2288,7 @@
   (alias include-qualified)
   (alias incremental-rebuilds)
   (alias inline_tests)
+  (alias install-mandir)
   (alias install-multiple-contexts)
   (alias install-partial-package)
   (alias install-rule-order)

--- a/test/blackbox-tests/test-cases/install-mandir/run.t
+++ b/test/blackbox-tests/test-cases/install-mandir/run.t
@@ -1,0 +1,14 @@
+  $ echo "(lang dune 2.0)" > dune-project
+  $ touch foo.opam manfile
+  $ cat >dune <<EOF
+  > (install
+  >  (section man)
+  >  (files manfile))
+  > EOF
+  $ dune build @install
+  $ mkdir install mandir
+  $ dune install --dry-run --prefix ./install --mandir ./mandir 2>&1 | grep mandir
+  Installing mandir/manfile
+  Removing (if it exists) mandir/manfile
+  Creating directory mandir
+  Copying _build/install/default/man/manfile to mandir/manfile (executable: false)


### PR DESCRIPTION
This option allows us to override the target directory for install
mandir pages.

cc @olafhering 