### PR TITLE
Start cache daemon through an `exec`.

### DIFF
--- a/bin/cache_daemon.ml
+++ b/bin/cache_daemon.ml
@@ -25,12 +25,9 @@ let doc = "Manage the shared artifacts cache"
 
 let info = Term.info name ~doc ~man
 
-let start ~exit_no_client ~foreground ~port_path ~root ~quiet =
+let start ~exit_no_client ~foreground ~port_path ~root ~display =
   let show_endpoint ep =
-    if quiet then
-      Printf.printf "%s\n%!" ep
-    else
-      Printf.eprintf "listening on %s\n%!" ep
+    if display <> Some Config.Display.Quiet then Printf.printf "%s\n%!" ep
   in
   let config = { Dune_cache_daemon.exit_no_client } in
   let f started =
@@ -128,13 +125,10 @@ let term =
          value
          & opt (some int) None
          & info ~docv:"BYTES" [ "size" ] ~doc:"size to trim the cache to")
-     and+ quiet =
-       let doc = "Only output the daemon endpoint" in
-       Arg.(value & flag & info [ "quiet" ] ~doc)
-     in
+     and+ display = Common.display_term in
      match mode with
      | Some Start ->
-       `Ok (start ~exit_no_client ~foreground ~port_path ~root ~quiet)
+       `Ok (start ~exit_no_client ~foreground ~port_path ~root ~display)
      | Some Stop -> `Ok (stop ~port_path)
      | Some Trim -> `Ok (trim ~trimmed_size ~size)
      | None -> `Help (`Pager, Some name)

--- a/bin/cache_daemon.ml
+++ b/bin/cache_daemon.ml
@@ -25,8 +25,13 @@ let doc = "Manage the shared artifacts cache"
 
 let info = Term.info name ~doc ~man
 
-let start ~exit_no_client ~foreground ~port_path ~root =
-  let show_endpoint ep = Printf.eprintf "listening on %s\n%!" ep in
+let start ~exit_no_client ~foreground ~port_path ~root ~quiet =
+  let show_endpoint ep =
+    if quiet then
+      Printf.printf "%s\n%!" ep
+    else
+      Printf.eprintf "listening on %s\n%!" ep
+  in
   let config = { Dune_cache_daemon.exit_no_client } in
   let f started =
     let started content =
@@ -123,9 +128,13 @@ let term =
          value
          & opt (some int) None
          & info ~docv:"BYTES" [ "size" ] ~doc:"size to trim the cache to")
+     and+ quiet =
+       let doc = "Only output the daemon endpoint" in
+       Arg.(value & flag & info [ "quiet" ] ~doc)
      in
      match mode with
-     | Some Start -> `Ok (start ~exit_no_client ~foreground ~port_path ~root)
+     | Some Start ->
+       `Ok (start ~exit_no_client ~foreground ~port_path ~root ~quiet)
      | Some Stop -> `Ok (stop ~port_path)
      | Some Trim -> `Ok (trim ~trimmed_size ~size)
      | None -> `Help (`Pager, Some name)

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -312,6 +312,23 @@ module Options_implied_by_dash_p = struct
     | Some _ -> { t with profile }
 end
 
+let display_term =
+  one_of
+    (let+ verbose =
+       Arg.(
+         value & flag
+         & info [ "verbose" ] ~docs:copts_sect
+             ~doc:"Same as $(b,--display verbose)")
+     in
+     Option.some_if verbose Config.Display.Verbose)
+    Arg.(
+      value
+      & opt (some (enum Config.Display.all)) None
+      & info [ "display" ] ~docs:copts_sect ~docv:"MODE"
+          ~doc:
+            {|Control the display mode of Dune.
+         See $(b,dune-config\(5\)) for more details.|})
+
 let term =
   let docs = copts_sect in
   let+ concurrency =
@@ -381,21 +398,7 @@ let term =
             {|
          Changes how the log of build results are displayed to the
          console between rebuilds while in --watch mode. |})
-  and+ display =
-    one_of
-      (let+ verbose =
-         Arg.(
-           value & flag
-           & info [ "verbose" ] ~docs ~doc:"Same as $(b,--display verbose)")
-       in
-       Option.some_if verbose Config.Display.Verbose)
-      Arg.(
-        value
-        & opt (some (enum Config.Display.all)) None
-        & info [ "display" ] ~docs ~docv:"MODE"
-            ~doc:
-              {|Control the display mode of Dune.
-                      See $(b,dune-config\(5\)) for more details.|})
+  and+ display = display_term
   and+ no_buffer =
     let doc =
       {|Do not buffer the output of commands executed by dune. By default dune

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -41,6 +41,8 @@ val footer : Cmdliner.Manpage.block
 
 val term : t Cmdliner.Term.t
 
+val display_term : Dune.Config.Display.t option Cmdliner.Term.t
+
 val context_arg : doc:string -> Dune.Context_name.t Cmdliner.Term.t
 
 (** A [--build-info] command line argument that print build informations

--- a/src/dune/config.ml
+++ b/src/dune/config.ml
@@ -184,7 +184,7 @@ let default =
   ; terminal_persistence = Terminal_persistence.Preserve
   ; sandboxing_preference = []
   ; cache_mode = Disabled
-  ; cache_transport = Direct
+  ; cache_transport = Daemon
   ; cache_check_probability = 0.01
   }
 

--- a/src/dune_cache_daemon/dune_cache_daemon.ml
+++ b/src/dune_cache_daemon/dune_cache_daemon.ml
@@ -392,7 +392,7 @@ module Client = struct
     let* cache = Result.map_error ~f:err (Dune_cache.Cache.make ignore) in
     let* port =
       let cmd =
-        Format.sprintf "%s cache start --quiet --exit-no-client"
+        Format.sprintf "%s cache start --display progress --exit-no-client"
           Sys.executable_name
       and f stdout =
         match Io.input_lines stdout with

--- a/src/dune_cache_daemon/dune_cache_daemon.ml
+++ b/src/dune_cache_daemon/dune_cache_daemon.ml
@@ -139,6 +139,8 @@ let endpoint m = m.endpoint
 
 let err msg = User_error.E (User_error.make [ Pp.text msg ])
 
+let errf msg = User_error.E (User_error.make msg)
+
 module Client = struct
   type t =
     { socket : out_channel
@@ -389,24 +391,27 @@ module Client = struct
     let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore in
     let* cache = Result.map_error ~f:err (Dune_cache.Cache.make ignore) in
     let* port =
-      let root = Dune_cache.default_root () in
-      Daemonize.daemonize ~workdir:root (default_port_file ())
-        (daemon ~root ~config:{ exit_no_client = true })
-      >>| (function
-            | Started (ep, _)
-            | Already_running (ep, _) ->
-              ep
-            | Finished ->
-              Code_error.raise "dune-cache was run in the foreground" [])
-      |> Result.map_error ~f:err
+      let cmd =
+        Format.sprintf "%s cache start --quiet --exit-no-client"
+          Sys.executable_name
+      and f stdout =
+        match Io.input_lines stdout with
+        | [] -> Result.Error (err "empty output starting cache")
+        | [ line ] -> Result.Ok line
+        | _ -> Result.Error (err "unrecognized output starting cache")
+      and finally stdout = ignore (Unix.close_process_in stdout) (* FIXME *) in
+      Exn.protectx (Unix.open_process_in cmd) ~finally ~f
     in
     let* addr, port =
       match String.split_on_char ~sep:':' port with
       | [ addr; port ] -> (
         match Int.of_string port with
-        | Some i -> Result.Ok (Unix.inet_addr_of_string addr, i)
-        | None -> Result.Error (err (Printf.sprintf "invalid port: %s" port)) )
-      | _ -> Result.Error (err (Printf.sprintf "invalid endpoint: %s" port))
+        | Some i -> (
+          try Result.Ok (Unix.inet_addr_of_string addr, i)
+          with Failure _ ->
+            Result.Error (errf [ Pp.textf "invalid address: %s" addr ]) )
+        | None -> Result.Error (errf [ Pp.textf "invalid port: %s" port ]) )
+      | _ -> Result.Error (errf [ Pp.textf "invalid endpoint: %s" port ])
     in
     let fd = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
     let* _ =


### PR DESCRIPTION
So far the code was just forking and running the daemon, which had the advantage of not requiring an `exec` or looking up the dune executable paths. However this was dangerous as we inherited some global status (e.g. the global build directory) and would now prevent re-opening the logs to a different location.

This branch starts the cache by executing `dune cache start ...`.