### PR TITLE
Add support for relative foreign archives in libraries

### DIFF
--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -104,7 +104,13 @@ writing the following code ``src/dune``:
           (rule
            (deps (source_tree libfoo))
            (targets libfoo.a dllfoo.so)
-           (action (chdir libfoo (run make))))
+           (action (progn
+                    (chdir libfoo (run make))
+                    (copy libfoo/libfoo.a libfoo.a)
+                    (copy libfoo/libfoo.so dllfoo.so))))
+
+We copy the resulting archive files to the top directory where they can be
+declared as ``targets``.
 
 The last step is to attach these archives to an OCaml library as
 follows:
@@ -113,7 +119,7 @@ follows:
 
           (library
            (name bar)
-           (foreign_archives libfoo/foo))
+           (foreign_archives foo))
 
 Then, whenever you use the ``bar`` library, you will also be able to
 use C functions from ``libfoo``.

--- a/src/dune/dir_contents.mli
+++ b/src/dune/dir_contents.mli
@@ -30,7 +30,8 @@ val modules_of_library : t -> name:Lib_name.t -> Modules.t
 
 val foreign_sources_of_library : t -> name:Lib_name.t -> Foreign.Sources.t
 
-val foreign_sources_of_archive : t -> archive_name:string -> Foreign.Sources.t
+val foreign_sources_of_archive :
+  t -> archive_name:Foreign.Archive.Name.t -> Foreign.Sources.t
 
 (** Modules attached to a set of executables. *)
 val modules_of_executables :

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -90,7 +90,7 @@ module Buildable : sig
     ; modules : Ordered_set_lang.t
     ; modules_without_implementation : Ordered_set_lang.t
     ; libraries : Lib_dep.t list
-    ; foreign_archives : (Loc.t * string) list
+    ; foreign_archives : (Loc.t * Foreign.Archive.t) list
     ; foreign_stubs : Foreign.Stubs.t list
     ; preprocess : Preprocess_map.t
     ; preprocessor_deps : Dep_conf.t list
@@ -208,15 +208,12 @@ module Library : sig
   (** Check if the library has any foreign stubs or archives. *)
   val has_foreign : t -> bool
 
-  (** The name of the automatically built foreign stubs archive. *)
-  val stubs_archive_name : t -> string
-
-  (** The names of all foreign archives, including the foreign stubs archive. *)
-  val foreign_archive_names : t -> string list
+  (** The list of all foreign archives, including the foreign stubs archive. *)
+  val foreign_archives : t -> Foreign.Archive.t list
 
   (** The [lib*.a] files of all foreign archives, including foreign stubs. [dir]
       is the directory the library is declared in. *)
-  val foreign_archives :
+  val foreign_lib_files :
     t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t list
 
   (** The [dll*.so] files of all foreign archives, including foreign stubs.

--- a/src/dune/exe.ml
+++ b/src/dune/exe.ml
@@ -161,7 +161,7 @@ let link_exe ~loc ~name ~(linkage : Linkage.t) ~cm_files ~link_time_code_gen
            ; A "-o"
            ; Target exe
            ; As linkage.flags
-           ; Command.Args.Dyn link_args
+           ; Dyn link_args
            ; Command.of_result_map link_time_code_gen
                ~f:(fun { Link_time_code_gen.to_link; force_linkall } ->
                  S

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -106,7 +106,15 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
                      directories except for the root will have parents too. *)
                   | None -> Command.Args.empty
                   | Some dir ->
-                    Command.Args.S [ A "-ccopt"; A "-L"; A "-ccopt"; Path dir ]))))
+                    (* TODO: We should do -L or -I conditionally on linkage. *)
+                    Command.Args.S
+                      [ A "-ccopt"
+                      ; A "-L"
+                      ; A "-ccopt"
+                      ; Path dir
+                      ; A "-I"
+                      ; Path dir
+                      ]))))
   in
   let link_args =
     let+ flags = link_flags in

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -91,7 +91,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
      make the code more uniform. *)
   let ext_lib = ctx.lib_config.ext_lib in
   let link_args =
-    let paths_to_relative_foreign_archives () =
+    let paths_to_transitive_foreign_archives () =
       Command.of_result_map
         (Lazy.force (Lib.Compile.requires_link compile_info))
         ~f:(fun libs ->
@@ -131,7 +131,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
           (List.map foreign_archives ~f:(fun archive ->
                let lib = Foreign.Archive.lib_file ~archive ~dir ~ext_lib in
                Command.Args.S [ A "-cclib"; Dep (Path.build lib) ]))
-      ; paths_to_relative_foreign_archives ()
+      ; paths_to_transitive_foreign_archives ()
       ]
   in
   let requires_compile = Lib.Compile.direct_requires compile_info in

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -104,16 +104,7 @@ let possible_sources ~language obj ~dune_version =
 
 module Archive = struct
   module Name = struct
-    module T = struct
-      type t = string
-
-      let compare = String.compare
-
-      let to_dyn = String.to_dyn
-    end
-
-    include T
-    include Comparable.Make (T)
+    include String
 
     let to_string t = t
 
@@ -133,10 +124,10 @@ module Archive = struct
 
     let stubs archive_name = archive_name ^ "_stubs"
 
-    let lib_file ~archive_name ~dir ~ext_lib =
+    let lib_file archive_name ~dir ~ext_lib =
       Path.Build.relative dir (sprintf "lib%s%s" archive_name ext_lib)
 
-    let dll_file ~archive_name ~dir ~ext_dll =
+    let dll_file archive_name ~dir ~ext_dll =
       Path.Build.relative dir (sprintf "dll%s%s" archive_name ext_dll)
   end
 
@@ -151,6 +142,8 @@ module Archive = struct
 
   let dir_path ~dir t = Path.Build.relative dir t.dir
 
+  let name t = t.name
+
   let stubs archive_name = { dir = "."; name = Name.stubs archive_name }
 
   let decode =
@@ -160,11 +153,11 @@ module Archive = struct
 
   let lib_file ~archive ~dir ~ext_lib =
     let dir = dir_path ~dir archive in
-    Name.lib_file ~archive_name:archive.name ~dir ~ext_lib
+    Name.lib_file archive.name ~dir ~ext_lib
 
   let dll_file ~archive ~dir ~ext_dll =
     let dir = dir_path ~dir archive in
-    Name.dll_file ~archive_name:archive.name ~dir ~ext_dll
+    Name.dll_file archive.name ~dir ~ext_dll
 end
 
 module Stubs = struct

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -131,6 +131,10 @@ module Archive = struct
       Path.Build.relative dir (sprintf "dll%s%s" archive_name ext_dll)
   end
 
+  (** Archive directories can appear as part of the [(foreign_archives ...)]
+      fields. For example, in [(foreign_archives some/dir/lib1 lib2)], the
+      archive [some/dir/lib1] has the directory [some/dir], whereas the archive
+      [lib2] does not specify the directory and is assumed to be located in [.]. *)
   module Dir = struct
     type t = string
   end

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -149,6 +149,8 @@ module Archive = struct
     ; name : Name.t
     }
 
+  let dir_path ~dir t = Path.Build.relative dir t.dir
+
   let stubs archive_name = { dir = "."; name = Name.stubs archive_name }
 
   let decode =
@@ -157,11 +159,11 @@ module Archive = struct
     { dir = Filename.dirname s; name = Filename.basename s }
 
   let lib_file ~archive ~dir ~ext_lib =
-    let dir = Path.Build.relative dir archive.dir in
+    let dir = dir_path ~dir archive in
     Name.lib_file ~archive_name:archive.name ~dir ~ext_lib
 
   let dll_file ~archive ~dir ~ext_dll =
-    let dir = Path.Build.relative dir archive.dir in
+    let dir = dir_path ~dir archive in
     Name.dll_file ~archive_name:archive.name ~dir ~ext_dll
 end
 

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -70,6 +70,49 @@ val possible_sources :
   -> dune_version:Dune_lang.Syntax.Version.t
   -> string list
 
+module Archive : sig
+  module Name : sig
+    type t
+
+    module Map : sig
+      include Map.S with type key = t
+    end
+
+    val to_dyn : t -> Dyn.t
+
+    val to_string : t -> string
+
+    val path : dir:Path.Build.t -> t -> Path.Build.t
+
+    val decode : t Dune_lang.Decoder.t
+
+    val stubs : string -> t
+
+    val lib_file :
+      archive_name:t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
+
+    val dll_file :
+      archive_name:t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
+  end
+
+  module Dir : sig
+    type t
+  end
+
+  type t =
+    { dir : Dir.t
+    ; name : Name.t
+    }
+
+  val stubs : string -> t
+
+  val decode : t Dune_lang.Decoder.t
+
+  val lib_file : archive:t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
+
+  val dll_file : archive:t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
+end
+
 (** A type of foreign library "stubs", which includes all fields of the
     [Library.t] type except for the [archive_name] field. The type is parsed as
     an optional [foreign_stubs] field of the [library] stanza, or as part of the
@@ -130,19 +173,13 @@ end
     [extra_deps] are tracked as dependencies. *)
 module Library : sig
   type t =
-    { archive_name : string
+    { archive_name : Archive.Name.t
     ; archive_name_loc : Loc.t
     ; stubs : Stubs.t
     }
 
   val decode : t Dune_lang.Decoder.t
 end
-
-val lib_file :
-  archive_name:string -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
-
-val dll_file :
-  archive_name:string -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
 
 (** A foreign source file that has a [path] and all information of the
     corresponnding [Foreign.Stubs.t] declaration. *)

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -98,14 +98,6 @@ module Archive : sig
     val dll_file : t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
   end
 
-  (** Archive directories can appear as part of the [(foreign_archives ...)]
-      fields. For example, in [(foreign_archives some/dir/lib1 lib2)], the
-      archive [some/dir/lib1] has the directory [some/dir], whereas the archive
-      [lib2] does not specify the directory and is assumed to be located in [.]. *)
-  module Dir : sig
-    type t
-  end
-
   type t
 
   val dir_path : dir:Path.Build.t -> t -> Path.Build.t

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -104,6 +104,8 @@ module Archive : sig
     ; name : Name.t
     }
 
+  val dir_path : dir:Path.Build.t -> t -> Path.Build.t
+
   val stubs : string -> t
 
   val decode : t Dune_lang.Decoder.t

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -20,9 +20,7 @@ module Language : sig
 
   val decode : t Dune_lang.Decoder.t
 
-  module Map : sig
-    include Map.S with type key = t
-  end
+  module Map : Map.S with type key = t
 
   module Dict : sig
     type language
@@ -70,13 +68,20 @@ val possible_sources :
   -> dune_version:Dune_lang.Syntax.Version.t
   -> string list
 
+(** Foreign archives appear in the [(foreign_archives ...)] field of libraries
+    and executables, for example [(foreign_archives some/dir/lib)]. When parsing
+    such fields, we separate the directory [some/dir] from the name [lib] of the
+    archive and store them as a [{dir : Dir.t; name : Name.t}] record. *)
 module Archive : sig
+  (** Archive names appear as part of the [(foreign_archives ...)] fields, as
+      well as in the [(archive_name ...)] field of the [(foreign_library ...)]
+      stanza. For example, both [(foreign_archives some/dir/lib)] and
+      [(archive_name lib)] specify the same archive name [lib]. Archive names
+      are not allowed to contain path separators. *)
   module Name : sig
     type t
 
-    module Map : sig
-      include Map.S with type key = t
-    end
+    module Map : Map.S with type key = t
 
     val to_dyn : t -> Dyn.t
 
@@ -88,23 +93,24 @@ module Archive : sig
 
     val stubs : string -> t
 
-    val lib_file :
-      archive_name:t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
+    val lib_file : t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
 
-    val dll_file :
-      archive_name:t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
+    val dll_file : t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
   end
 
+  (** Archive directories can appear as part of the [(foreign_archives ...)]
+      fields. For example, in [(foreign_archives some/dir/lib1 lib2)], the
+      archive [some/dir/lib1] has the directory [some/dir], whereas the archive
+      [lib2] does not specify the directory and is assumed to be located in [.]. *)
   module Dir : sig
     type t
   end
 
-  type t =
-    { dir : Dir.t
-    ; name : Name.t
-    }
+  type t
 
   val dir_path : dir:Path.Build.t -> t -> Path.Build.t
+
+  val name : t -> Name.t
 
   val stubs : string -> t
 

--- a/src/dune/foreign_sources.mli
+++ b/src/dune/foreign_sources.mli
@@ -6,7 +6,7 @@ val empty : t
 
 val for_lib : t -> name:Lib_name.t -> Foreign.Sources.t
 
-val for_archive : t -> archive_name:string -> Foreign.Sources.t
+val for_archive : t -> archive_name:Foreign.Archive.Name.t -> Foreign.Sources.t
 
 val for_exes : t -> first_exe:string -> Foreign.Sources.t
 

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -398,14 +398,14 @@ let hash t = Id.hash (to_id t)
 include Comparable.Make (T)
 
 let link_flags t (mode : Link_mode.t) (lib_config : Lib_config.t) =
-  let archives = Lib_info.archives t.info in
-  let foreign_archives = Lib_info.foreign_archives t.info in
+  let archives = Lib_info.archives t.info
+  and lib_files = Lib_info.foreign_archives t.info
+  and dll_files = Lib_info.foreign_dll_files t.info in
   let hidden =
     match mode with
-    | Byte -> Lib_info.foreign_dll_files t.info
-    | Byte_with_stubs_statically_linked_in -> foreign_archives
-    | Native ->
-      List.rev_append (Lib_info.native_archives t.info) foreign_archives
+    | Byte -> dll_files
+    | Byte_with_stubs_statically_linked_in -> lib_files
+    | Native -> List.rev_append (Lib_info.native_archives t.info) lib_files
   in
   let hidden =
     match Lib_info.exit_module t.info with
@@ -423,9 +423,26 @@ let link_flags t (mode : Link_mode.t) (lib_config : Lib_config.t) =
         :: Path.extend_basename obj_name ~suffix:lib_config.ext_obj
         :: hidden )
   in
+  let transitive_foreign_archive_args =
+    (* TODO: Remove the unsafe call to [parent_exn] by separating files and
+       directories at the type level. Then any file will have a well-defined
+       parent directory, possibly ".". *)
+    let dirs files =
+      List.sort_uniq ~compare:Path.compare (List.map files ~f:Path.parent_exn)
+    in
+    match mode with
+    | Byte ->
+      List.concat_map (dirs dll_files) ~f:(fun dir ->
+          Command.Args.[ A "-I"; Path dir ])
+    | Byte_with_stubs_statically_linked_in
+    | Native ->
+      List.concat_map (dirs lib_files) ~f:(fun dir ->
+          Command.Args.[ A "-ccopt"; A "-L"; A "-ccopt"; Path dir ])
+  in
   Command.Args.S
     [ Deps (Mode.Dict.get archives (Link_mode.mode mode))
     ; Hidden_deps (Dep.Set.of_files hidden)
+    ; S transitive_foreign_archive_args
     ]
 
 module L = struct
@@ -498,32 +515,26 @@ module Lib_and_module = struct
     type nonrec t = t list
 
     let link_flags ts ~(lib_config : Lib_config.t) ~mode =
-      let libs =
-        List.filter_map ts ~f:(function
-          | Lib lib -> Some lib
-          | Module _ -> None)
-      in
       Command.Args.S
-        ( L.c_include_flags libs
-        :: List.map ts ~f:(function
-             | Lib t -> link_flags t mode lib_config
-             | Module (obj_dir, m) ->
-               Command.Args.S
-                 ( Dep
-                     (Obj_dir.Module.cm_file_unsafe obj_dir m
-                        ~kind:(Mode.cm_kind (Link_mode.mode mode)))
-                 ::
-                 ( match mode with
-                 | Native ->
-                   [ Command.Args.Hidden_deps
-                       (Dep.Set.of_files
-                          [ Obj_dir.Module.o_file_unsafe obj_dir m
-                              ~ext_obj:lib_config.ext_obj
-                          ])
-                   ]
-                 | Byte
-                 | Byte_with_stubs_statically_linked_in ->
-                   [] ) )) )
+        (List.map ts ~f:(function
+          | Lib t -> link_flags t mode lib_config
+          | Module (obj_dir, m) ->
+            Command.Args.S
+              ( Dep
+                  (Obj_dir.Module.cm_file_unsafe obj_dir m
+                     ~kind:(Mode.cm_kind (Link_mode.mode mode)))
+              ::
+              ( match mode with
+              | Native ->
+                [ Command.Args.Hidden_deps
+                    (Dep.Set.of_files
+                       [ Obj_dir.Module.o_file_unsafe obj_dir m
+                           ~ext_obj:lib_config.ext_obj
+                       ])
+                ]
+              | Byte
+              | Byte_with_stubs_statically_linked_in ->
+                [] ) )))
 
     let of_libs l = List.map l ~f:(fun x -> Lib x)
   end

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -44,7 +44,7 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
           in
           Foreign.Sources.object_files files ~dir ~ext_obj
         else
-          Library.foreign_archives lib ~dir ~ext_lib )
+          Library.foreign_lib_files lib ~dir ~ext_lib )
       ; if_
           (native && not virtual_library)
           (let files =

--- a/src/dune/lib_info.mli
+++ b/src/dune/lib_info.mli
@@ -71,14 +71,17 @@ val loc : _ t -> Loc.t
 
 val archives : 'path t -> 'path list Mode.Dict.t
 
-(** All the [.a/.lib/...] files for stubs *)
+(* TODO: Rename [foreign_archives] to [foreign_lib_files] and [native_archives]
+   to [native_lib_files] for consistent naming with [foreign_dll_files]. *)
+
+(** All the [lib*.a] files for stubs *)
 val foreign_archives : 'path t -> 'path list
 
-(** The [.a/.lib/...] files for the OCaml code when compiling to native mode *)
+(** The [lib*.a] files for the OCaml code when compiling to native mode *)
 val native_archives : 'path t -> 'path list
 
-(** [.so/.dll/...] files for stubs. These are read when linking a bytecode
-    executable and are loaded dynamically at runtime by bytecode executables. *)
+(** [dll*.so] files for stubs. These are read when linking a bytecode executable
+    and are loaded dynamically at runtime by bytecode executables. *)
 val foreign_dll_files : 'path t -> 'path list
 
 val foreign_objects : 'path t -> 'path list Source.t

--- a/src/dune/lib_info.mli
+++ b/src/dune/lib_info.mli
@@ -69,6 +69,10 @@ val name : _ t -> Lib_name.t
 
 val loc : _ t -> Loc.t
 
+(** The [*.cma] and [*.cmxa] files for OCaml libraries. Libraries built by Dune
+    will always have zero or one element in the list (zero if they are not
+    buildable in the corresponding mode). External libraries, however, can have
+    more than one element in the list, because the format allows for that. *)
 val archives : 'path t -> 'path list Mode.Dict.t
 
 (* TODO: Rename [foreign_archives] to [foreign_lib_files] and [native_archives]

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -239,6 +239,12 @@ let build_shared lib ~dir_contents ~sctx ~dir ~flags =
         let ext = Mode.plugin_ext Native in
         Library.archive lib ~dir ~ext
       in
+      let include_flags_for_relative_foreign_archives =
+        Command.Args.S
+          (List.map lib.buildable.foreign_archives ~f:(fun (_loc, archive) ->
+               let dir = Foreign.Archive.dir_path ~dir archive in
+               Command.Args.S [ A "-I"; Path (Path.build dir) ]))
+      in
       let build =
         Build.paths
           (Library.foreign_lib_files lib ~dir ~ext_lib |> List.map ~f:Path.build)
@@ -248,6 +254,7 @@ let build_shared lib ~dir_contents ~sctx ~dir ~flags =
               ; A "-linkall"
               ; A "-I"
               ; Path (Path.build dir)
+              ; include_flags_for_relative_foreign_archives
               ; A "-o"
               ; Target dst
               ; Dep src

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -24,7 +24,9 @@ let build_lib (lib : Library.t) ~sctx ~dir_contents ~expander ~flags ~dir ~mode
       let target = Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext mode) in
       let stubs_flags =
         List.concat_map (Library.foreign_archives lib) ~f:(fun archive ->
-            let lname = "-l" ^ Foreign.Archive.Name.to_string archive.name in
+            let lname =
+              "-l" ^ Foreign.Archive.(name archive |> Name.to_string)
+            in
             let cclib = [ "-cclib"; lname ] in
             let dllib = [ "-dllib"; lname ] in
             match mode with
@@ -118,10 +120,10 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
   let ctx = Super_context.context sctx in
   let { Lib_config.ext_lib; ext_dll; _ } = ctx.lib_config in
   let static_target =
-    Foreign.Archive.Name.lib_file ~archive_name ~dir ~ext_lib
+    Foreign.Archive.Name.lib_file archive_name ~dir ~ext_lib
   in
   let dynamic_target =
-    Foreign.Archive.Name.dll_file ~archive_name ~dir ~ext_dll
+    Foreign.Archive.Name.dll_file archive_name ~dir ~ext_dll
   in
   let build ~custom ~sandbox targets =
     Super_context.add_rule sctx ~sandbox ~dir ~loc

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -23,8 +23,8 @@ let build_lib (lib : Library.t) ~sctx ~dir_contents ~expander ~flags ~dir ~mode
   Option.iter (Context.compiler ctx mode) ~f:(fun compiler ->
       let target = Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext mode) in
       let stubs_flags =
-        List.concat_map (Library.foreign_archive_names lib) ~f:(fun name ->
-            let lname = "-l" ^ name in
+        List.concat_map (Library.foreign_archives lib) ~f:(fun archive ->
+            let lname = "-l" ^ Foreign.Archive.Name.to_string archive.name in
             let cclib = [ "-cclib"; lname ] in
             let dllib = [ "-dllib"; lname ] in
             match mode with
@@ -117,8 +117,12 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
     ~build_targets_together =
   let ctx = Super_context.context sctx in
   let { Lib_config.ext_lib; ext_dll; _ } = ctx.lib_config in
-  let static_target = Foreign.lib_file ~archive_name ~dir ~ext_lib in
-  let dynamic_target = Foreign.dll_file ~archive_name ~dir ~ext_dll in
+  let static_target =
+    Foreign.Archive.Name.lib_file ~archive_name ~dir ~ext_lib
+  in
+  let dynamic_target =
+    Foreign.Archive.Name.dll_file ~archive_name ~dir ~ext_dll
+  in
   let build ~custom ~sandbox targets =
     Super_context.add_rule sctx ~sandbox ~dir ~loc
       (let cclibs_args =
@@ -133,7 +137,7 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
            else
              Command.Args.empty )
          ; A "-o"
-         ; Path (Path.build (Path.Build.relative dir archive_name))
+         ; Path (Path.build (Foreign.Archive.Name.path ~dir archive_name))
          ; Deps o_files
          ; Dyn
              (* The [c_library_flags] is needed only for the [dynamic_target]
@@ -213,7 +217,8 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents
   | [] -> ()
   | o_files ->
     let ctx = Super_context.context sctx in
-    let archive_name = Library.stubs_archive_name lib in
+    let lib_name = Lib_name.Local.to_string (snd lib.name) in
+    let archive_name = Foreign.Archive.Name.stubs lib_name in
     let modes = Compilation_context.modes cctx in
     let build_targets_together =
       modes.native && modes.byte
@@ -236,7 +241,7 @@ let build_shared lib ~dir_contents ~sctx ~dir ~flags =
       in
       let build =
         Build.paths
-          (Library.foreign_archives lib ~dir ~ext_lib |> List.map ~f:Path.build)
+          (Library.foreign_lib_files lib ~dir ~ext_lib |> List.map ~f:Path.build)
         >>> Command.run ~dir:(Path.build ctx.build_dir) (Ok ocamlopt)
               [ Command.Args.dyn (Ocaml_flags.get flags Native)
               ; A "-shared"

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -201,6 +201,9 @@ val of_filename_relative_to_initial_cwd : string -> t
     root has been set. [root] is the root directory of local paths *)
 val to_absolute_filename : t -> string
 
+(** Reach a given path [from] a directory. For example, let [p] be a path to the
+    file [some/dir/file] and [d] be a path to the directory [some/another/dir].
+    Then [reach p ~from:d] evaluates to [../../dir/file]. *)
 val reach : t -> from:t -> string
 
 (** [from] defaults to [Path.root] *)
@@ -288,6 +291,8 @@ val insert_after_build_dir_exn : t -> string -> t
 val exists : t -> bool
 
 val readdir_unsorted : t -> (string list, Unix.error) Result.t
+
+val is_dir_sep : char -> bool
 
 val is_directory : t -> bool
 

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -814,8 +814,8 @@ Testsuite for the (foreign_library ...) stanza.
   >  (foreign_archives dir/id)
   >  (modules bug))
   > (executable
-  >  (modes exe)
   >  (name main)
+  >  (modes byte exe)
   >  (libraries bug)
   >  (modules main))
   > EOF
@@ -834,4 +834,8 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
 
   $ ./sdune exec github2914/main.exe
+  Bug #2914 has been fixed
+
+  $ ./sdune build @github2914/all
+  $ (cd _build/default/github2914 && ocamlrun -I dir main.bc)
   Bug #2914 has been fixed

--- a/test/blackbox-tests/test-cases/foreign-library/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library/run.t
@@ -839,3 +839,28 @@ Testsuite for the (foreign_library ...) stanza.
   $ ./sdune build @github2914/all
   $ (cd _build/default/github2914 && ocamlrun -I dir main.bc)
   Bug #2914 has been fixed
+
+----------------------------------------------------------------------------------
+* Make sure the [Byte_with_stubs_statically_linked_in] mode works too
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 2.0)
+  > (context
+  >   (default (disable_dynamically_linked_foreign_archives true)))
+  > EOF
+
+  $ cat >github2914/dune <<EOF
+  > (library
+  >  (name bug)
+  >  (foreign_archives dir/id)
+  >  (modules bug))
+  > (executable
+  >  (name main)
+  >  (modes byte)
+  >  (libraries bug)
+  >  (modules main))
+  > EOF
+
+  $ ./sdune clean
+  $ ./sdune exec github2914/main.exe
+  Bug #2914 has been fixed


### PR DESCRIPTION
As reported in #2914, it's currently not possible to have a library with a foreign archive in a subdirectory:

`(library ... (foreign_archive dir/lib) ...)`

To support such "relative" foreign archives in libraries, we need to pass the `-L dir` flag when linking the executables, which depend on such libraries.

This patch does a fair amount of refactoring, to make the logic less error prone due to the confusion between various `string`-like types.

TODO:
- [x] Fix bytecode executables too.
- [x] Fix documentation.