### PR TITLE
Fix a typo in the installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you do not have `make`, you can do the following:
 ```sh
 $ ocaml bootstrap.ml
 $ ./dune.exe build -p dune --profile dune-bootstrap
-$ ./dune.exe install dune --build-dir _boot
+$ ./dune.exe install dune --build-dir _build
 ```
 
 The first command builds the `dune.exe` binary. The second builds the

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you do not have `make`, you can do the following:
 ```sh
 $ ocaml bootstrap.ml
 $ ./dune.exe build -p dune --profile dune-bootstrap
-$ ./dune.exe install dune --build-dir _build
+$ ./dune.exe install dune
 ```
 
 The first command builds the `dune.exe` binary. The second builds the


### PR DESCRIPTION
The instruction with `_boot` didn't work for me, but with `_build` it does. So I hope this change is correct.