### PR TITLE
Add Lib.link_deps

### DIFF
--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -401,7 +401,11 @@ module Link_params = struct
   type t =
     { include_dirs : Path.t list
     ; deps : Path.t list
+          (* List of files that will be read by the compiler at link time and
+             appear directly on the command line *)
     ; hidden_deps : Path.t list
+          (* List of files that will be read by the compiler at link time but do
+             not appear on the command line *)
     }
 
   let get t (mode : Link_mode.t) (lib_config : Lib_config.t) =

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -50,6 +50,10 @@ val equal : t -> t -> bool
 
 val hash : t -> int
 
+(** The list of files that will be read by the compiler when linking an
+    executable against this library *)
+val link_deps : t -> Link_mode.t -> Lib_config.t -> Path.t list
+
 (** Operations on list of libraries *)
 module L : sig
   type lib


### PR DESCRIPTION
This PR adds a function `Lib.link_deps` to compute the list of files that are needed to link a library in an executable. This is needed for the new toplevel support method.