### PR TITLE
Remove custom opam-repository for testing 4.02.3

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -72,7 +72,6 @@ case "$TARGET" in
         eval $(opam config env)
 
         if [ $OLD_OCAML -eq 1 ] ; then
-          opam remote add secondary 'git+https://github.com/dra27/opam-repository.git#secondary'
           opam install ocamlfind-secondary
         fi
 


### PR DESCRIPTION
`ocaml-secondary-compiler` is now available upstream. Will merge once CI passes.