### PR TITLE
Update jsoo example for dune 2.0

### DIFF
--- a/doc/jsoo.rst
+++ b/doc/jsoo.rst
@@ -29,7 +29,7 @@ With the following dune file:
 
 .. code:: scheme
 
-  (executable (name foo))
+  (executable (name foo) (modes js))
 
 And then request the ``.js`` target:
 


### PR DESCRIPTION
I had to modify the example to make it work with `dune 2.0.0`.

I believe we need `(modes js)` now because [`explicit-js-mode`](https://dune.readthedocs.io/en/latest/dune-files.html#explicit-js-mode) is the default for dune >= 2.0.0.