### PR TITLE
Make the function [Digest.generic] more robust

### DIFF
--- a/src/stdune/digest.ml
+++ b/src/stdune/digest.ml
@@ -26,7 +26,13 @@ let string = D.string
 
 let to_string_raw s = s
 
-let generic a = string (Marshal.to_string a [])
+(* We use [No_sharing] to avoid generating different digests for inputs that
+   differ only in how they share internal values. For example, if a command line
+   contains duplicate flags, such as multiple occurrences of the flag [-I], then
+   [Marshal.to_string] will produce different digests depending on whether the
+   corresponding strings ["-I"] point to the same memory location or to
+   different memory locations. *)
+let generic a = string (Marshal.to_string a [ No_sharing ])
 
 let file_with_stats p (stats : Unix.stats) =
   match stats.st_kind with

--- a/src/stdune/digest.ml
+++ b/src/stdune/digest.ml
@@ -27,11 +27,11 @@ let string = D.string
 let to_string_raw s = s
 
 (* We use [No_sharing] to avoid generating different digests for inputs that
-   differ only in how they share internal values. For example, if a command line
-   contains duplicate flags, such as multiple occurrences of the flag [-I], then
-   [Marshal.to_string] will produce different digests depending on whether the
-   corresponding strings ["-I"] point to the same memory location or to
-   different memory locations. *)
+   differ only in how they share internal values. Without [No_sharing], if a
+   command line contains duplicate flags, such as multiple occurrences of the
+   flag [-I], then [Marshal.to_string] will produce different digests depending
+   on whether the corresponding strings ["-I"] point to the same memory location
+   or to different memory locations. *)
 let generic a = string (Marshal.to_string a [ No_sharing ])
 
 let file_with_stats p (stats : Unix.stats) =

--- a/test/blackbox-tests/test-cases/dialects/run.t
+++ b/test/blackbox-tests/test-cases/dialects/run.t
@@ -14,8 +14,8 @@ Test the (dialect ...) stanza inside the dune-project file.
 
   $ dune build --root good --display short @fmt
   Entering directory 'good'
-           fmt .formatted/main.mfi
            fmt .formatted/main.mf
+           fmt .formatted/main.mfi
 
   $ dune build --root bad1
   Entering directory 'bad1'

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system/run.t
@@ -59,7 +59,7 @@ Test the argument syntax
   $ dune build --root driver-tests test_ppx_args.cma
   Entering directory 'driver-tests'
            ppx test_ppx_args.pp.ml
-  .ppx/a45c15d61f473f6a301551552d3f7586/ppx.exe
+  .ppx/454728df5270ab91f8a5af6b5e860eb0/ppx.exe
   -arg1
   -arg2
   -arg3=Oreo
@@ -102,7 +102,7 @@ Test using installed drivers
   $ OCAMLPATH=driver/_build/install/default/lib dune build --root use-external-driver driveruser.cma
   Entering directory 'use-external-driver'
            ppx driveruser.pp.ml
-  .ppx/631757a4a4789e0bd29628f7a73480f7/ppx.exe
+  .ppx/35d69311d5da258d073875db2b34f33b/ppx.exe
   -arg1
   -arg2
   -foo
@@ -125,7 +125,7 @@ Test using installed drivers
   Entering directory 'replaces'
            ppx driveruser.pp.ml
   replacesdriver
-  .ppx/97c3bec0ca445d915914eed462990a46/ppx.exe
+  .ppx/886937db0da323b743b4366c6d3a795f/ppx.exe
   -arg1
   -arg2
   -foo
@@ -150,7 +150,7 @@ Test using installed drivers
   Entering directory 'replaces-external'
            ppx driveruser.pp.ml
   replacesdriver
-  .ppx/97c3bec0ca445d915914eed462990a46/ppx.exe
+  .ppx/886937db0da323b743b4366c6d3a795f/ppx.exe
   -arg1
   -arg2
   -foo

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -36,10 +36,10 @@ Formatting can be checked using the @fmt target:
         ocamlc fake-tools/.ocamlformat.eobjs/byte/ocamlformat.{cmi,cmo,cmt}
       ocamlopt fake-tools/.ocamlformat.eobjs/native/ocamlformat.{cmx,o}
       ocamlopt fake-tools/ocamlformat.exe
-   ocamlformat enabled/.formatted/ocaml_file.ml
-  File "enabled/ocaml_file.ml", line 1, characters 0-0:
-  Error: Files _build/default/enabled/ocaml_file.ml and
-  _build/default/enabled/.formatted/ocaml_file.ml differ.
+   ocamlformat enabled/.formatted/ocaml_file.mli
+  File "enabled/ocaml_file.mli", line 1, characters 0-0:
+  Error: Files _build/default/enabled/ocaml_file.mli and
+  _build/default/enabled/.formatted/ocaml_file.mli differ.
           dune enabled/.formatted/dune
   File "enabled/dune", line 1, characters 0-0:
   Error: Files _build/default/enabled/dune and
@@ -75,10 +75,10 @@ Formatting can be checked using the @fmt target:
   File "partial/a.ml", line 1, characters 0-0:
   Error: Files _build/default/partial/a.ml and
   _build/default/partial/.formatted/a.ml differ.
-   ocamlformat enabled/.formatted/ocaml_file.mli
-  File "enabled/ocaml_file.mli", line 1, characters 0-0:
-  Error: Files _build/default/enabled/ocaml_file.mli and
-  _build/default/enabled/.formatted/ocaml_file.mli differ.
+   ocamlformat enabled/.formatted/ocaml_file.ml
+  File "enabled/ocaml_file.ml", line 1, characters 0-0:
+  Error: Files _build/default/enabled/ocaml_file.ml and
+  _build/default/enabled/.formatted/ocaml_file.ml differ.
          refmt enabled/.formatted/reason_file.re
   File "enabled/reason_file.re", line 1, characters 0-0:
   Error: Files _build/default/enabled/reason_file.re and
@@ -113,14 +113,14 @@ Configuration files are taken into account for this action:
   File "partial/a.ml", line 1, characters 0-0:
   Error: Files _build/default/partial/a.ml and
   _build/default/partial/.formatted/a.ml differ.
-   ocamlformat enabled/.formatted/ocaml_file.mli
-  File "enabled/ocaml_file.mli", line 1, characters 0-0:
-  Error: Files _build/default/enabled/ocaml_file.mli and
-  _build/default/enabled/.formatted/ocaml_file.mli differ.
    ocamlformat enabled/.formatted/ocaml_file.ml
   File "enabled/ocaml_file.ml", line 1, characters 0-0:
   Error: Files _build/default/enabled/ocaml_file.ml and
   _build/default/enabled/.formatted/ocaml_file.ml differ.
+   ocamlformat enabled/.formatted/ocaml_file.mli
+  File "enabled/ocaml_file.mli", line 1, characters 0-0:
+  Error: Files _build/default/enabled/ocaml_file.mli and
+  _build/default/enabled/.formatted/ocaml_file.mli differ.
    ocamlformat enabled/subdir/.formatted/lib.ml
   File "enabled/subdir/lib.ml", line 1, characters 0-0:
   Error: Files _build/default/enabled/subdir/lib.ml and
@@ -157,11 +157,11 @@ All .ocamlformat files are considered dependencies:
   Error: Files _build/default/lang2/default/dune and
   _build/default/lang2/default/.formatted/dune differ.
          refmt enabled/.formatted/reason_file.re
+   ocamlformat enabled/.formatted/ocaml_file.ml
    ocamlformat enabled/.formatted/ocaml_file.mli
   File "enabled/ocaml_file.mli", line 1, characters 0-0:
   Error: Files _build/default/enabled/ocaml_file.mli and
   _build/default/enabled/.formatted/ocaml_file.mli differ.
-   ocamlformat enabled/.formatted/ocaml_file.ml
           dune enabled/.formatted/dune
    ocamlformat enabled/subdir/.formatted/lib.ml
   File "enabled/subdir/lib.ml", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin-tests/run.t
@@ -34,7 +34,7 @@
   S $LIB_PREFIX/lib/ocaml
   S .
   S subdir
-  FLG -ppx '$PPX/eff0afe1b49c6b759cd98bcc60fefc58/ppx.exe --as-ppx --cookie '\''library-name="foo"'\'''
+  FLG -ppx '$PPX/4128e43a9cfb141a37f547484cc9bf46/ppx.exe --as-ppx --cookie '\''library-name="foo"'\'''
   FLG -open Foo -w -40 -open Bar -w -40
 
 Make sure a ppx directive is generated

--- a/test/blackbox-tests/test-cases/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/multiple-private-libs/run.t
@@ -2,11 +2,11 @@ This test checks that there is no clash when two private libraries have the same
 
   $ dune build --display short @doc-private
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
-      ocamldep b/.test.objs/test.ml.d
-        ocamlc b/.test.objs/byte/test.{cmi,cmo,cmt}
-          odoc b/.test.objs/byte/test.odoc
-          odoc _doc/_html/test@4f4e394aec41/Test/.dune-keep,_doc/_html/test@4f4e394aec41/Test/index.html
       ocamldep a/.test.objs/test.ml.d
         ocamlc a/.test.objs/byte/test.{cmi,cmo,cmt}
           odoc a/.test.objs/byte/test.odoc
-          odoc _doc/_html/test@574d7a9dbf61/Test/.dune-keep,_doc/_html/test@574d7a9dbf61/Test/index.html
+          odoc _doc/_html/test@6aabb9861046/Test/.dune-keep,_doc/_html/test@6aabb9861046/Test/index.html
+      ocamldep b/.test.objs/test.ml.d
+        ocamlc b/.test.objs/byte/test.{cmi,cmo,cmt}
+          odoc b/.test.objs/byte/test.odoc
+          odoc _doc/_html/test@ea8c79305c05/Test/.dune-keep,_doc/_html/test@ea8c79305c05/Test/index.html

--- a/test/blackbox-tests/test-cases/output-obj/run.t
+++ b/test/blackbox-tests/test-cases/output-obj/run.t
@@ -1,12 +1,12 @@
   $ dune build @all
   $ dune build @runtest
-       dynamic alias runtest
-  OK: ./dynamic.exe ./test.bc.so
-        static alias runtest
-  OK: ./static.bc
         static alias runtest
   OK: ./static.exe
        dynamic alias runtest
   OK: ./dynamic.exe ./test$ext_dll
+        static alias runtest
+  OK: ./static.bc
+       dynamic alias runtest
+  OK: ./dynamic.exe ./test.bc.so
 #        static alias runtest
 #  OK: ./static.bc.c.exe

--- a/test/blackbox-tests/test-cases/ppx-rewriter/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter/run.t
@@ -3,7 +3,7 @@
         ocamlc ppx/.fooppx.objs/byte/fooppx.{cmi,cmo,cmt}
       ocamlopt ppx/.fooppx.objs/native/fooppx.{cmx,o}
       ocamlopt ppx/fooppx.{a,cmxa}
-      ocamlopt .ppx/a0597253d899c1b15660d5431f244d21/ppx.exe
+      ocamlopt .ppx/7adb2b9c99ee32a09b9cc720f236f209/ppx.exe
            ppx w_omp_driver.pp.ml
   -arg: omp
       ocamldep .w_omp_driver.eobjs/w_omp_driver.pp.ml.d

--- a/test/blackbox-tests/test-cases/private-public-overlap/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/run.t
@@ -16,7 +16,7 @@ On the other hand, public libraries may have private preprocessors
         ocamlc .ppx_internal.objs/byte/ppx_internal.{cmi,cmo,cmt}
       ocamlopt .ppx_internal.objs/native/ppx_internal.{cmx,o}
       ocamlopt ppx_internal.{a,cmxa}
-      ocamlopt .ppx/7c2b363c472d29b86b00b0db993dada7/ppx.exe
+      ocamlopt .ppx/be26d3600214af2fa78c2c9ef25e9069/ppx.exe
            ppx mylib.pp.ml
       ocamldep .mylib.objs/mylib.pp.ml.d
         ocamlc .mylib.objs/byte/mylib.{cmi,cmo,cmt}
@@ -36,7 +36,7 @@ Unless they introduce private runtime dependencies:
         ocamlc .private_ppx.objs/byte/private_ppx.{cmi,cmo,cmt}
       ocamlopt .private_ppx.objs/native/private_ppx.{cmx,o}
       ocamlopt private_ppx.{a,cmxa}
-      ocamlopt .ppx/1646e695232ddc3002c2a70d93a17f14/ppx.exe
+      ocamlopt .ppx/9ab0f533c010a2f808b2ba93118d36d0/ppx.exe
            ppx mylib.pp.ml
       ocamldep .mylib.objs/mylib.pp.ml.d
   [1]

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -9,8 +9,8 @@
       ocamlopt a/kernel/.a_kernel.objs/native/a_kernel.{cmx,o}
       ocamlopt a/kernel/a_kernel.{a,cmxa}
       ocamlopt a/kernel/a_kernel.cmxs
-      ocamlopt .ppx/3beabc6280a815808859f1884170b996/ppx.exe
-      ocamlopt .ppx/631b31a68eb10e1850cf7721d41e5b84/ppx.exe
+      ocamlopt .ppx/4446201c218fbdeaa1427094637d47e1/ppx.exe
+      ocamlopt .ppx/d4bc37c50327ac62f01166e7ec37f9fa/ppx.exe
            ppx b/b.pp.ml
       ocamldep b/.b.objs/b.pp.ml.d
         ocamlc b/.b.objs/byte/b.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/shadow-bindings/run.t
+++ b/test/blackbox-tests/test-cases/shadow-bindings/run.t
@@ -1,5 +1,5 @@
 Bindings introduced by user dependencies should shadow existing bindings
 
   $ dune runtest
-  xb
   foo
+  xb

--- a/test/blackbox-tests/test-cases/tests-stanza/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/run.t
@@ -12,20 +12,20 @@
       ocamldep .expect_test.eobjs/expect_test.ml.d
       ocamldep .expect_test.eobjs/regular_test.ml.d
       ocamldep .expect_test.eobjs/regular_test2.ml.d
-        ocamlc .expect_test.eobjs/byte/regular_test2.{cmi,cmo,cmt}
-      ocamlopt .expect_test.eobjs/native/regular_test2.{cmx,o}
-      ocamlopt regular_test2.exe
-  regular_test2 alias runtest
-  regular test2
+        ocamlc .expect_test.eobjs/byte/expect_test.{cmi,cmo,cmt}
+      ocamlopt .expect_test.eobjs/native/expect_test.{cmx,o}
+      ocamlopt expect_test.exe
+   expect_test expect_test.output
         ocamlc .expect_test.eobjs/byte/regular_test.{cmi,cmo,cmt}
       ocamlopt .expect_test.eobjs/native/regular_test.{cmx,o}
       ocamlopt regular_test.exe
   regular_test alias runtest
   regular test
-        ocamlc .expect_test.eobjs/byte/expect_test.{cmi,cmo,cmt}
-      ocamlopt .expect_test.eobjs/native/expect_test.{cmx,o}
-      ocamlopt expect_test.exe
-   expect_test expect_test.output
+        ocamlc .expect_test.eobjs/byte/regular_test2.{cmi,cmo,cmt}
+      ocamlopt .expect_test.eobjs/native/regular_test2.{cmx,o}
+      ocamlopt regular_test2.exe
+  regular_test2 alias runtest
+  regular test2
   $ dune runtest --root generated --display short
   Entering directory 'generated'
       ocamldep .generated.eobjs/generated.ml.d


### PR DESCRIPTION
We currently use `Marshal.to_string` with sharing enabled when computing digests of values of arbitrary types. It's better to use the `No_sharing` setting to avoid generating different digests for inputs that differ only in how they share internal values. For example, if a command line contains duplicate flags, such as multiple occurrences of the flag `-I`, then `Marshal.to_string` will produce different digests depending on whether the corresponding strings `"-I"` point to the same memory location or to different memory locations.

Note that a few digests in the testsuite changed. Presumably this is because the `No_sharing` setting is reflected in the resulting digest. 