### PR TITLE
Relax parsing dune-package files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-2.1.0 (13/12/2019)
+2.1.0 (unreleased)
 ------------------
 
 - Attach cinaps stanza actions to both `@runtest` and `@cinaps` aliases
@@ -20,6 +20,13 @@
 - Support passing two arguments to `=`, `<>`, ... operators in package
   dependencies so that we can have things such as `(<> :os win32)`
   (#2965, @diml)
+
+2.0.1 (17/12/2019)
+------------------
+
+- Delay errors raised by invalid `dune-package` files. The error is now raised
+  only if the invalid package is treated as a library and used to build
+  something. (#2972, @rgrinberg)
 
 2.0.0 (20/11/2019)
 ------------------

--- a/src/dune/config.ml
+++ b/src/dune/config.ml
@@ -281,7 +281,7 @@ end)
 
 let () = Lang.register syntax ()
 
-let load_config_file p = load p ~f:(fun _lang -> decode)
+let load_config_file p = load_exn p ~f:(fun _lang -> decode)
 
 let load_user_config_file () =
   if Path.exists user_config_file then

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -362,11 +362,10 @@ module Or_meta = struct
          Dune_package package)
 
   let load p =
-    match Vfile.load_ast p with
+    let dir = Path.parent_exn p in
+    match Vfile.load p ~f:(fun lang -> decode ~lang ~dir) with
+    | Ok s -> Ok s
     | Error e -> Error (`Invalid_dune_package e)
-    | Ok ast ->
-      let dir = Path.parent_exn p in
-      Ok (Vfile.parse_ast ast ~f:(fun lang -> decode ~lang ~dir))
 
   let pp ~dune_version ppf t =
     let t = encode ~dune_version t in

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -363,7 +363,7 @@ module Or_meta = struct
 
   let load p =
     match Vfile.load_ast p with
-    | Error _ -> Error `Invalid_dune_package
+    | Error e -> Error (`Invalid_dune_package e)
     | Ok ast ->
       let dir = Path.parent_exn p in
       Ok (Vfile.parse_ast ast ~f:(fun lang -> decode ~lang ~dir))

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -363,9 +363,7 @@ module Or_meta = struct
 
   let load p =
     let dir = Path.parent_exn p in
-    match Vfile.load p ~f:(fun lang -> decode ~lang ~dir) with
-    | Ok s -> Ok s
-    | Error e -> Error (`Invalid_dune_package e)
+    Vfile.load p ~f:(fun lang -> decode ~lang ~dir)
 
   let pp ~dune_version ppf t =
     let t = encode ~dune_version t in

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -362,7 +362,11 @@ module Or_meta = struct
          Dune_package package)
 
   let load p =
-    Vfile.load p ~f:(fun lang -> decode ~lang ~dir:(Path.parent_exn p))
+    match Vfile.load_ast p with
+    | Error _ -> Error `Invalid_dune_package
+    | Ok ast ->
+      let dir = Path.parent_exn p in
+      Ok (Vfile.parse_ast ast ~f:(fun lang -> decode ~lang ~dir))
 
   let pp ~dune_version ppf t =
     let t = encode ~dune_version t in

--- a/src/dune/dune_package.mli
+++ b/src/dune/dune_package.mli
@@ -67,7 +67,7 @@ module Or_meta : sig
   val pp :
     dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
 
-  val load : Dpath.t -> t
+  val load : Dpath.t -> (t, [`Invalid_dune_package]) Result.t
 
   val to_dyn : t Dyn.Encoder.t
 end

--- a/src/dune/dune_package.mli
+++ b/src/dune/dune_package.mli
@@ -67,7 +67,7 @@ module Or_meta : sig
   val pp :
     dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
 
-  val load : Dpath.t -> (t, [`Invalid_dune_package]) Result.t
+  val load : Dpath.t -> (t, [`Invalid_dune_package of exn]) Result.t
 
   val to_dyn : t Dyn.Encoder.t
 end

--- a/src/dune/dune_package.mli
+++ b/src/dune/dune_package.mli
@@ -67,7 +67,7 @@ module Or_meta : sig
   val pp :
     dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
 
-  val load : Dpath.t -> (t, [ `Invalid_dune_package of exn ]) Result.t
+  val load : Dpath.t -> t Or_exn.t
 
   val to_dyn : t Dyn.Encoder.t
 end

--- a/src/dune/dune_package.mli
+++ b/src/dune/dune_package.mli
@@ -67,7 +67,7 @@ module Or_meta : sig
   val pp :
     dune_version:Dune_lang.Syntax.Version.t -> Format.formatter -> t -> unit
 
-  val load : Dpath.t -> (t, [`Invalid_dune_package of exn]) Result.t
+  val load : Dpath.t -> (t, [ `Invalid_dune_package of exn ]) Result.t
 
   val to_dyn : t Dyn.Encoder.t
 end

--- a/src/dune/dune_project.ml
+++ b/src/dune/dune_project.ml
@@ -724,7 +724,8 @@ let parse ~dir ~lang ~opam_packages ~file =
 
 let load_dune_project ~dir opam_packages =
   let file = Path.Source.relative dir filename in
-  load (Path.source file) ~f:(fun lang -> parse ~dir ~lang ~opam_packages ~file)
+  load_exn (Path.source file) ~f:(fun lang ->
+      parse ~dir ~lang ~opam_packages ~file)
 
 let load ~dir ~files ~infer_from_opam_files =
   let opam_packages =

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -159,7 +159,7 @@ module Unavailable_reason = struct
     function
     | Not_found -> constr "Not_found" []
     | Invalid_dune_package why ->
-      constr "Invalid_dune_package" [Exn.to_dyn why]
+      constr "Invalid_dune_package" [ Exn.to_dyn why ]
     | Hidden lib ->
       let info = Dune_package.Lib.info lib in
       let obj_dir = Lib_info.obj_dir info in
@@ -451,7 +451,8 @@ end
    parse it and add its contents to [t.packages] *)
 let find_and_acknowledge_package t ~fq_name =
   let root_name = Lib_name.root_lib fq_name in
-  let rec loop dirs : (Discovered_package.t, [`Invalid_dune_package of exn]) Result.t option =
+  let rec loop dirs :
+      (Discovered_package.t, [ `Invalid_dune_package of exn ]) Result.t option =
     match dirs with
     | [] -> (
       match Lib_name.to_string root_name with

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -142,8 +142,10 @@ module Unavailable_reason = struct
   type t =
     | Not_found
     | Hidden of Dune_package.Lib.t
+    | Invalid_dune_package
 
   let to_string = function
+    | Invalid_dune_package -> "invalid dune package"
     | Not_found -> "not found"
     | Hidden pkg ->
       let info = Dune_package.Lib.info pkg in
@@ -156,6 +158,7 @@ module Unavailable_reason = struct
     let open Dyn.Encoder in
     function
     | Not_found -> constr "Not_found" []
+    | Invalid_dune_package -> constr "Invalid_dune_package" []
     | Hidden lib ->
       let info = Dune_package.Lib.info lib in
       let obj_dir = Lib_info.obj_dir info in
@@ -447,15 +450,15 @@ end
    parse it and add its contents to [t.packages] *)
 let find_and_acknowledge_package t ~fq_name =
   let root_name = Lib_name.root_lib fq_name in
-  let rec loop dirs : Discovered_package.t option =
+  let rec loop dirs : (Discovered_package.t, [`Invalid_dune_package]) Result.t option =
     match dirs with
     | [] -> (
       match Lib_name.to_string root_name with
-      | "dune" -> Some Discovered_package.builtin_for_dune
+      | "dune" -> Some (Ok Discovered_package.builtin_for_dune)
       | _ ->
         Lib_name.Map.find t.builtins root_name
         |> Option.map ~f:(fun meta ->
-               Discovered_package.Findlib (Meta_source.internal t ~meta)) )
+               Ok (Discovered_package.Findlib (Meta_source.internal t ~meta))) )
     | dir :: dirs -> (
       let dir = Path.relative dir (Lib_name.to_string root_name) in
       let dune = Path.relative dir Dune_package.fn in
@@ -463,19 +466,22 @@ let find_and_acknowledge_package t ~fq_name =
         if Path.exists dune then
           Dune_package.Or_meta.load dune
         else
-          Dune_package.Or_meta.Use_meta
+          Ok Dune_package.Or_meta.Use_meta
       with
-      | Dune_package p -> Some (Dune p)
-      | Use_meta -> (
+      | Error `Invalid_dune_package -> Some (Error `Invalid_dune_package)
+      | Ok (Dune_package p) -> Some (Ok (Dune p))
+      | Ok Use_meta -> (
         match Meta_source.discover ~dir ~name:root_name with
         | None -> loop dirs
-        | Some meta_source -> Some (Findlib meta_source) ) )
+        | Some meta_source -> Some (Ok (Findlib meta_source)) ) )
   in
   match loop t.paths with
   | None -> Table.set t.packages root_name (Error Not_found)
-  | Some (Findlib findlib_package) ->
+  | Some (Error `Invalid_dune_package) ->
+    Table.set t.packages root_name (Error Invalid_dune_package)
+  | Some (Ok (Findlib findlib_package)) ->
     Meta_source.parse_and_acknowledge findlib_package t
-  | Some (Dune pkg) ->
+  | Some (Ok (Dune pkg)) ->
     List.iter pkg.entries ~f:(fun entry ->
         let name = Dune_package.Entry.name entry in
         Table.set t.packages name (Ok entry))

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -142,10 +142,10 @@ module Unavailable_reason = struct
   type t =
     | Not_found
     | Hidden of Dune_package.Lib.t
-    | Invalid_dune_package
+    | Invalid_dune_package of exn
 
   let to_string = function
-    | Invalid_dune_package -> "invalid dune package"
+    | Invalid_dune_package _ -> "invalid dune package"
     | Not_found -> "not found"
     | Hidden pkg ->
       let info = Dune_package.Lib.info pkg in
@@ -158,7 +158,8 @@ module Unavailable_reason = struct
     let open Dyn.Encoder in
     function
     | Not_found -> constr "Not_found" []
-    | Invalid_dune_package -> constr "Invalid_dune_package" []
+    | Invalid_dune_package why ->
+      constr "Invalid_dune_package" [Exn.to_dyn why]
     | Hidden lib ->
       let info = Dune_package.Lib.info lib in
       let obj_dir = Lib_info.obj_dir info in
@@ -450,7 +451,7 @@ end
    parse it and add its contents to [t.packages] *)
 let find_and_acknowledge_package t ~fq_name =
   let root_name = Lib_name.root_lib fq_name in
-  let rec loop dirs : (Discovered_package.t, [`Invalid_dune_package]) Result.t option =
+  let rec loop dirs : (Discovered_package.t, [`Invalid_dune_package of exn]) Result.t option =
     match dirs with
     | [] -> (
       match Lib_name.to_string root_name with
@@ -468,7 +469,7 @@ let find_and_acknowledge_package t ~fq_name =
         else
           Ok Dune_package.Or_meta.Use_meta
       with
-      | Error `Invalid_dune_package -> Some (Error `Invalid_dune_package)
+      | Error e -> Some (Error e)
       | Ok (Dune_package p) -> Some (Ok (Dune p))
       | Ok Use_meta -> (
         match Meta_source.discover ~dir ~name:root_name with
@@ -477,8 +478,8 @@ let find_and_acknowledge_package t ~fq_name =
   in
   match loop t.paths with
   | None -> Table.set t.packages root_name (Error Not_found)
-  | Some (Error `Invalid_dune_package) ->
-    Table.set t.packages root_name (Error Invalid_dune_package)
+  | Some (Error (`Invalid_dune_package e)) ->
+    Table.set t.packages root_name (Error (Invalid_dune_package e))
   | Some (Ok (Findlib findlib_package)) ->
     Meta_source.parse_and_acknowledge findlib_package t
   | Some (Ok (Dune pkg)) ->

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -451,8 +451,7 @@ end
    parse it and add its contents to [t.packages] *)
 let find_and_acknowledge_package t ~fq_name =
   let root_name = Lib_name.root_lib fq_name in
-  let rec loop dirs :
-      (Discovered_package.t, [ `Invalid_dune_package of exn ]) Result.t option =
+  let rec loop dirs : Discovered_package.t Or_exn.t option =
     match dirs with
     | [] -> (
       match Lib_name.to_string root_name with
@@ -479,7 +478,7 @@ let find_and_acknowledge_package t ~fq_name =
   in
   match loop t.paths with
   | None -> Table.set t.packages root_name (Error Not_found)
-  | Some (Error (`Invalid_dune_package e)) ->
+  | Some (Error e) ->
     Table.set t.packages root_name (Error (Invalid_dune_package e))
   | Some (Ok (Findlib findlib_package)) ->
     Meta_source.parse_and_acknowledge findlib_package t

--- a/src/dune/findlib/findlib.mli
+++ b/src/dune/findlib/findlib.mli
@@ -24,6 +24,7 @@ module Unavailable_reason : sig
         (** The package is hidden because it contains an unsatisfied 'exist_if'
             clause *)
     | Hidden of Dune_package.Lib.t
+    | Invalid_dune_package
 
   val to_string : t -> string
 

--- a/src/dune/findlib/findlib.mli
+++ b/src/dune/findlib/findlib.mli
@@ -24,7 +24,7 @@ module Unavailable_reason : sig
         (** The package is hidden because it contains an unsatisfied 'exist_if'
             clause *)
     | Hidden of Dune_package.Lib.t
-    | Invalid_dune_package
+    | Invalid_dune_package of exn
 
   val to_string : t -> string
 

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -1785,6 +1785,7 @@ module DB = struct
           Redirect (None, (Loc.none, d.new_public_name))
         | Error e -> (
           match e with
+          | Invalid_dune_package
           | Not_found ->
             if external_lib_deps_mode then
               let pkg = Findlib.dummy_package findlib ~name in

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -740,7 +740,7 @@ let already_in_table info name x =
   let dyn =
     let open Dyn.Encoder in
     match x with
-    | St_invalid e -> constr "St_invalid" [Exn.to_dyn e]
+    | St_invalid e -> constr "St_invalid" [ Exn.to_dyn e ]
     | St_initializing x -> constr "St_initializing" [ Path.to_dyn x.path ]
     | St_found t ->
       let src_dir = Lib_info.src_dir t.info in
@@ -1594,7 +1594,7 @@ module DB = struct
       let open Dyn.Encoder in
       match x with
       | Not_found -> constr "Not_found" []
-      | Invalid e -> constr "Invalid" [Exn.to_dyn e]
+      | Invalid e -> constr "Invalid" [ Exn.to_dyn e ]
       | Found lib -> constr "Found" [ Lib_info.to_dyn Path.to_dyn lib ]
       | Hidden { info = lib; reason } ->
         constr "Hidden" [ Lib_info.to_dyn Path.to_dyn lib; string reason ]
@@ -1824,7 +1824,8 @@ module DB = struct
     | St_hidden (t, _, _) ->
       Some t
     | St_invalid _
-    | St_not_found -> None
+    | St_not_found ->
+      None
 
   let resolve t (loc, name) =
     match Resolve.find_internal t name ~stack:Dep_stack.empty with

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -317,6 +317,7 @@ type status =
   | St_found of t
   | St_not_found
   | St_hidden of t * Path.t * string
+  | St_invalid of exn
 
 (* reason *)
 
@@ -335,6 +336,7 @@ and resolve_result =
       { info : Lib_info.external_
       ; reason : string
       }
+  | Invalid of exn
   | Redirect of db option * (Loc.t * Lib_name.t)
 
 type lib = t
@@ -738,6 +740,7 @@ let already_in_table info name x =
   let dyn =
     let open Dyn.Encoder in
     match x with
+    | St_invalid e -> constr "St_invalid" [Exn.to_dyn e]
     | St_initializing x -> constr "St_initializing" [ Path.to_dyn x.path ]
     | St_found t ->
       let src_dir = Lib_info.src_dir t.info in
@@ -1158,6 +1161,7 @@ end = struct
     | St_initializing id -> Dep_stack.dependency_cycle stack id
     | St_found lib -> check_private_deps lib ~loc ~allow_private_deps
     | St_not_found -> Error.not_found ~loc ~name
+    | St_invalid why -> Error why
     | St_hidden (_, dir, reason) -> Error.hidden ~loc ~name ~dir ~reason
 
   let resolve_name db name ~stack =
@@ -1170,6 +1174,7 @@ end = struct
         Table.add_exn db.table name x;
         x )
     | Found info -> instantiate db name info ~stack ~hidden:None
+    | Invalid e -> St_invalid e
     | Not_found ->
       let res =
         match db.parent with
@@ -1582,12 +1587,14 @@ module DB = struct
           { info : Lib_info.external_
           ; reason : string
           }
+      | Invalid of exn
       | Redirect of db option * (Loc.t * Lib_name.t)
 
     let to_dyn x =
       let open Dyn.Encoder in
       match x with
       | Not_found -> constr "Not_found" []
+      | Invalid e -> constr "Invalid" [Exn.to_dyn e]
       | Found lib -> constr "Found" [ Lib_info.to_dyn Path.to_dyn lib ]
       | Hidden { info = lib; reason } ->
         constr "Hidden" [ Lib_info.to_dyn Path.to_dyn lib; string reason ]
@@ -1626,6 +1633,7 @@ module DB = struct
                    name)] where [name] is in [libmap] for sure and maps to
                    [Found _]. *)
                 match res with
+                | Invalid _
                 | Not_found
                 | Hidden _ ->
                   assert false
@@ -1785,7 +1793,7 @@ module DB = struct
           Redirect (None, (Loc.none, d.new_public_name))
         | Error e -> (
           match e with
-          | Invalid_dune_package
+          | Invalid_dune_package why -> Invalid why
           | Not_found ->
             if external_lib_deps_mode then
               let pkg = Findlib.dummy_package findlib ~name in
@@ -1805,6 +1813,7 @@ module DB = struct
     | St_initializing _ -> assert false
     | St_found t -> Some t
     | St_not_found
+    | St_invalid _
     | St_hidden _ ->
       None
 
@@ -1814,12 +1823,14 @@ module DB = struct
     | St_found t
     | St_hidden (t, _, _) ->
       Some t
+    | St_invalid _
     | St_not_found -> None
 
   let resolve t (loc, name) =
     match Resolve.find_internal t name ~stack:Dep_stack.empty with
     | St_initializing _ -> assert false
     | St_found t -> Ok t
+    | St_invalid w -> Error w
     | St_not_found -> Error.not_found ~loc ~name
     | St_hidden (_, dir, reason) -> Error.hidden ~loc ~name ~dir ~reason
 

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -157,6 +157,7 @@ module DB : sig
           { info : Lib_info.external_
           ; reason : string
           }
+      | Invalid of exn
       | Redirect of t option * (Loc.t * Lib_name.t)
 
     val to_dyn : t Dyn.Encoder.t

--- a/src/dune/workspace.ml
+++ b/src/dune/workspace.ml
@@ -422,8 +422,7 @@ let load ?x ?profile p =
       if Dune_lexer.eof_reached lb then
         default ?x ?profile ()
       else
-        let first_line = Dune_lang.Versioned_file.First_line.lex lb in
-        parse_contents lb first_line ~f:(fun _lang -> t ?x ?profile ()))
+        parse_contents lb ~f:(fun _lang -> t ?x ?profile ()))
 
 let default ?x ?profile () =
   let x = Option.map x ~f:(fun s -> Context.Target.Named s) in

--- a/src/dune_lang/versioned_file.ml
+++ b/src/dune_lang/versioned_file.ml
@@ -20,8 +20,7 @@ module type S = sig
 
   val load : Path.t -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
 
-  val parse_contents :
-    Lexing.lexbuf -> First_line.t -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
+  val parse_contents : Lexing.lexbuf -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
 end
 
 module Make (Data : sig
@@ -76,8 +75,8 @@ struct
       }
   end
 
-  let parse_contents lb first_line ~f =
-    let lang = Lang.parse first_line in
+  let parse_contents lb ~f =
+    let lang = Lang.parse (First_line.lex lb) in
     let sexp = Parser.parse lb ~mode:Many_as_one in
     let parsing_context =
       Univ_map.singleton (Syntax.key lang.syntax) lang.version
@@ -86,7 +85,7 @@ struct
 
   let load fn ~f =
     Io.with_lexbuf_from_file fn ~f:(fun lb ->
-        parse_contents lb (First_line.lex lb) ~f)
+        parse_contents lb ~f)
 end
 
 let no_more_lang =

--- a/src/dune_lang/versioned_file.mli
+++ b/src/dune_lang/versioned_file.mli
@@ -27,16 +27,12 @@ module type S = sig
     val get_exn : string -> Instance.t
   end
 
-  type ast
+  (** [load_exn fn ~f] loads a versioned file. It parses the first line, looks
+      up the language, checks that the version is supported and parses the rest
+      of the file with [f]. *)
+  val load_exn : Path.t -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
 
-  val load_ast : Path.t -> ast Or_exn.t
-
-  val parse_ast : ast -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
-
-  (** [load fn ~f] loads a versioned file. It parses the first line, looks up
-      the language, checks that the version is supported and parses the rest of
-      the file with [f]. *)
-  val load : Path.t -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
+  val load : Path.t -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a Or_exn.t
 
   (** Parse the contents of a versioned file after the first line has been read. *)
   val parse_contents :

--- a/src/dune_lang/versioned_file.mli
+++ b/src/dune_lang/versioned_file.mli
@@ -27,6 +27,12 @@ module type S = sig
     val get_exn : string -> Instance.t
   end
 
+  type ast
+
+  val load_ast : Path.t -> ast Or_exn.t
+
+  val parse_ast : ast -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
+
   (** [load fn ~f] loads a versioned file. It parses the first line, looks up
       the language, checks that the version is supported and parses the rest of
       the file with [f]. *)

--- a/src/dune_lang/versioned_file.mli
+++ b/src/dune_lang/versioned_file.mli
@@ -34,7 +34,7 @@ module type S = sig
 
   (** Parse the contents of a versioned file after the first line has been read. *)
   val parse_contents :
-    Lexing.lexbuf -> First_line.t -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
+    Lexing.lexbuf -> f:(Lang.Instance.t -> 'a Decoder.t) -> 'a
 end
 
 module Make (Data : sig

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1171,6 +1171,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias invalid-dune-package)
+ (deps (package dune) (source_tree test-cases/invalid-dune-package))
+ (action
+  (chdir
+   test-cases/invalid-dune-package
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias js_of_ocaml)
  (deps (package dune) (source_tree test-cases/js_of_ocaml))
  (action
@@ -2102,6 +2110,7 @@
   (alias install-with-var)
   (alias installable-dup-private-libs)
   (alias intf-only)
+  (alias invalid-dune-package)
   (alias lib)
   (alias lib-available)
   (alias lib-errors)
@@ -2326,6 +2335,7 @@
   (alias install-with-var)
   (alias installable-dup-private-libs)
   (alias intf-only)
+  (alias invalid-dune-package)
   (alias lib)
   (alias lib-available)
   (alias lib-errors)

--- a/test/blackbox-tests/test-cases/invalid-dune-package/run.t
+++ b/test/blackbox-tests/test-cases/invalid-dune-package/run.t
@@ -1,0 +1,13 @@
+This test demonstrates the handling of invalid dune-package files
+  $ mkdir -p findlib/baz
+  $ touch findlib/baz/dune-package
+  $ echo "(lang dune 2.0)" > dune-project
+  $ echo 'let () = print_endline "foo"' > foo.ml
+  $ cat >dune <<EOF
+  > (executable (name foo))
+  > (library (name bar) (libraries baz) (modules))
+  > EOF
+  $ OCAMLPATH=$PWD/findlib dune exec ./foo.exe
+  File "$TESTCASE_ROOT/findlib/baz/dune-package", line 1, characters 0-0:
+  Error: Invalid first line, expected: (lang <lang> <version>)
+  [1]

--- a/test/blackbox-tests/test-cases/invalid-dune-package/run.t
+++ b/test/blackbox-tests/test-cases/invalid-dune-package/run.t
@@ -15,9 +15,6 @@ Now we attempt to use an invalid dune-package library:
   > (executable (name foo) (libraries baz))
   > EOF
   $ OCAMLPATH=$PWD/findlib dune exec ./foo.exe
-  File "dune", line 1, characters 34-37:
-  1 | (executable (name foo) (libraries baz))
-                                        ^^^
-  Error: Library "baz" not found.
-  Hint: try: dune external-lib-deps --missing ./foo.exe
+  File "$TESTCASE_ROOT/findlib/baz/dune-package", line 1, characters 0-0:
+  Error: Invalid first line, expected: (lang <lang> <version>)
   [1]

--- a/test/blackbox-tests/test-cases/invalid-dune-package/run.t
+++ b/test/blackbox-tests/test-cases/invalid-dune-package/run.t
@@ -9,3 +9,15 @@ This test demonstrates the handling of invalid dune-package files
   > EOF
   $ OCAMLPATH=$PWD/findlib dune exec ./foo.exe
   foo
+
+Now we attempt to use an invalid dune-package library:
+  $ cat >dune <<EOF
+  > (executable (name foo) (libraries baz))
+  > EOF
+  $ OCAMLPATH=$PWD/findlib dune exec ./foo.exe
+  File "dune", line 1, characters 34-37:
+  1 | (executable (name foo) (libraries baz))
+                                        ^^^
+  Error: Library "baz" not found.
+  Hint: try: dune external-lib-deps --missing ./foo.exe
+  [1]

--- a/test/blackbox-tests/test-cases/invalid-dune-package/run.t
+++ b/test/blackbox-tests/test-cases/invalid-dune-package/run.t
@@ -8,6 +8,4 @@ This test demonstrates the handling of invalid dune-package files
   > (library (name bar) (libraries baz) (modules))
   > EOF
   $ OCAMLPATH=$PWD/findlib dune exec ./foo.exe
-  File "$TESTCASE_ROOT/findlib/baz/dune-package", line 1, characters 0-0:
-  Error: Invalid first line, expected: (lang <lang> <version>)
-  [1]
+  foo


### PR DESCRIPTION
@kit-ty-kate Here's an attempt to relax reading invalid or unrecognized dune-package files. This isn't perfect as we could improve the error messages here, but it's probably the better behavior as just because a library name is resolved, it doesn't mean that the library will be used to build something.

Or we could wait for a proper fix to the issue of not trying to resolve more libraries than we need to build `@install`. However, I fear that this isn't something that we'll solve in the short term.