### PR TITLE
do not show bootstrap command outputs on stderr when probing cpus

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -191,13 +191,13 @@ let exe =
 
 let concurrency =
   let try_run_and_capture_line cmd =
-    let ic = Unix.open_process_in cmd in
+    let ic,oc,ec = Unix.open_process_full cmd [||] in
     let line =
       match input_line ic with
       | s -> Some s
       | exception _ -> None
     in
-    match (Unix.close_process_in ic, line) with
+    match (Unix.close_process_full (ic,oc,ec), line) with
     | WEXITED 0, Some s -> Some s
     | _ -> None
   in


### PR DESCRIPTION
on macOS, nproc doesnt exist and so bootstrap currently shows this
at build time:

```
./.duneboot.exe
/bin/sh: nproc: command not found
```

We now capture stderr in the bootstrap command invocation so that
the output is not sent onto the main console, making for a cleaner
build output on macOS.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>