### PR TITLE
Improve src dir detection in merlin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 - Guess foreign archives & native archives for libraries defined using the
   `META` format. (#2994, @rgrinberg, @anmonteiro)
 
+- Fix generation of `.merlin` files when depending on local libraries with more
+  than one source directory. (#2983, @rgrinberg)
+
 2.1.0 (21/12/2019)
 ------------------
 

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -152,6 +152,16 @@ let gen_format_rules sctx ~expander ~output_dir =
   with_format sctx ~dir:output_dir
     ~f:(Format_rules.gen_rules_output sctx ~dialects ~expander ~output_dir)
 
+(* This is used to determine the list of source directories to give to Merlin.
+   This serves the same purpose as [Merlin.lib_src_dirs] and has a similar
+   implementation, but this definition is used for the current library, while
+   [Merlin.lib_src_dirs] is used for the dependencies. It would be nice to unify
+   them at some point. *)
+let lib_src_dirs ~dir_contents =
+  Dir_contents.dirs dir_contents
+  |> List.map ~f:(fun dc ->
+         Path.Build.drop_build_context_exn (Dir_contents.dir dc))
+
 (* Stanza *)
 
 let gen_rules sctx dir_contents cctxs
@@ -196,10 +206,7 @@ let gen_rules sctx dir_contents cctxs
   in
   Option.iter (Merlin.merge_all ~allow_approx_merlin merlins) ~f:(fun m ->
       let more_src_dirs =
-        Dir_contents.dirs dir_contents
-        |> List.map ~f:(fun dc ->
-               Path.Build.drop_build_context_exn (Dir_contents.dir dc))
-        |> List.rev_append source_dirs
+        lib_src_dirs ~dir_contents |> List.rev_append source_dirs
       in
       Merlin.add_rules sctx ~dir:ctx_dir ~more_src_dirs ~expander
         (Merlin.add_source_dir m src_dir));

--- a/src/dune/modules.ml
+++ b/src/dune/modules.ml
@@ -761,3 +761,9 @@ let is_empty = function
     false
   | Unwrapped w -> Module_name.Map.is_empty w
   | Wrapped w -> Wrapped.empty w
+
+let source_dirs =
+  fold_user_written ~init:Path.Set.empty ~f:(fun m acc ->
+      Module.sources m
+      |> List.fold_left ~init:acc ~f:(fun acc f ->
+             Path.Set.add acc (Path.parent_exn f)))

--- a/src/dune/modules.mli
+++ b/src/dune/modules.mli
@@ -97,3 +97,5 @@ val exit_module : t -> Module.t option
 val relocate_alias_module : t -> src_dir:Path.t -> t
 
 val is_empty : t -> bool
+
+val source_dirs : t -> Path.Set.t

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1263,6 +1263,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias merlin-src-dirs-of-deps)
+ (deps (package dune) (source_tree test-cases/merlin/src-dirs-of-deps))
+ (action
+  (chdir
+   test-cases/merlin/src-dirs-of-deps
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias meta-gen)
  (deps (package dune) (source_tree test-cases/meta-gen))
  (action
@@ -2143,6 +2151,7 @@
   (alias menhir)
   (alias merlin-allow_approximate_merlin)
   (alias merlin-merlin-tests)
+  (alias merlin-src-dirs-of-deps)
   (alias meta-gen)
   (alias misc)
   (alias missing-loc-run)
@@ -2370,6 +2379,7 @@
   (alias loop)
   (alias macro-expand-error)
   (alias merlin-allow_approximate_merlin)
+  (alias merlin-src-dirs-of-deps)
   (alias meta-gen)
   (alias misc)
   (alias missing-loc-run)

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps/run.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps/run.t
@@ -18,5 +18,6 @@ library also has more than one src dir.
   B ../_build/default/lib1/.lib1.objs/byte
   B ../_build/default/lib2/.lib2.objs/byte
   S ../lib1
+  S ../lib1/sub
   S .
   FLG -open Lib2 -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps/run.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps/run.t
@@ -1,0 +1,22 @@
+We create two libraries where one depends on the the other. The dependency
+library also has more than one src dir.
+
+  $ echo "(lang dune 2.0)" > dune-project
+  $ mkdir -p lib1/sub
+  $ cat >lib1/dune <<EOF
+  > (include_subdirs unqualified)
+  > (library (name lib1))
+  $ touch lib1/sub/foo.ml
+  $ touch lib1/bar.ml
+  $ mkdir lib2
+  $ cat >lib2/dune <<EOF
+  > (library (name lib2) (libraries lib1) (modules ()))
+  > EOF
+  $ dune build lib2/.merlin
+  $ cat lib2/.merlin
+  EXCLUDE_QUERY_DIR
+  B ../_build/default/lib1/.lib1.objs/byte
+  B ../_build/default/lib2/.lib2.objs/byte
+  S ../lib1
+  S .
+  FLG -open Lib2 -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs


### PR DESCRIPTION
Currently, the .merlin generation only considers the root directory as
the location of all source dirs. This assumption does not work with
`(include_subdirs ..)`. Instead, we fetch all the modules for local
libraries and then get their directories.