### PR TITLE
Drop [Fdecl.peek]

### DIFF
--- a/src/dune/file_tree.ml
+++ b/src/dune/file_tree.ml
@@ -283,14 +283,7 @@ end = struct
 
   let t = Fdecl.create to_dyn
 
-  (* CR-soon amokhov: Move this to [Fdecl.set_idempotent] and drop [Fdecl.peek]. *)
-  let set x =
-    match Fdecl.peek t with
-    | None -> Fdecl.set t x
-    | Some x' ->
-      if not (equal x x') then
-        (* The next call will fail, but will give a good error message *)
-        Fdecl.set t x
+  let set x = Fdecl.set_idempotent ~equal t x
 
   let get () =
     let (_ : Memo.Run.t) = Memo.current_run () in

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -865,9 +865,6 @@ module Run = struct
     let set t x = Fdecl.set (Lazy.force t) x
 
     let get t = Fdecl.get (Lazy.force t)
-
-    (* CR-soon amokhov: Remove this unused function. *)
-    let peek t = Fdecl.peek (Lazy.force t)
   end
 
   include Run

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -221,8 +221,6 @@ module Run : sig
     (** [get t] returns the [x] if [set comp x] was called. Raises if [set] has
         not been called yet. *)
     val get : 'a t -> 'a
-
-    val peek : 'a t -> 'a option
   end
 end
 

--- a/src/stdune/fdecl.ml
+++ b/src/stdune/fdecl.ml
@@ -16,12 +16,15 @@ let set t new_ =
     Code_error.raise "Fdecl.set: already set"
       [ ("old", t.to_dyn old); ("new_", t.to_dyn new_) ]
 
+let set_idempotent ~equal t new_ =
+  match t.state with
+  | Unset -> t.state <- Set new_
+  | Set old ->
+    if not (equal new_ old) then
+      Code_error.raise "Fdecl.set_idempotent: already set to a different value"
+        [ ("old", t.to_dyn old); ("new_", t.to_dyn new_) ]
+
 let get t =
   match t.state with
   | Unset -> Code_error.raise "Fdecl.get: not set" []
   | Set x -> x
-
-let peek t =
-  match t.state with
-  | Unset -> None
-  | Set x -> Some x

--- a/src/stdune/fdecl.mli
+++ b/src/stdune/fdecl.mli
@@ -3,15 +3,18 @@
 type 'a t
 
 (** [create to_dyn] creates a forward declaration. The [to_dyn] parameter is
-    used for reporting errors in [set] and [get]. *)
+    used for reporting errors in [set], [set_idempotent] and [get]. *)
 val create : ('a -> Dyn.t) -> 'a t
 
-(** [set t x] sets the value that is returned by [get t] to [x]. Raises if [set]
-    was already called. *)
+(** [set t x] sets the value that will be returned by [get t] to [x]. Raises if
+    [set] was already called. *)
 val set : 'a t -> 'a -> unit
+
+(** [set_idempotent ~equal t x] sets the value that will be returned by [get t]
+    to [x]. Raises if [set] or [set_idempotent] was already called with a value
+    that is not [equal] to [x]. *)
+val set_idempotent : equal:('a -> 'a -> bool) -> 'a t -> 'a -> unit
 
 (** [get t] returns the [x] if [set comp x] was called. Raises if [set] has not
     been called yet. *)
 val get : 'a t -> 'a
-
-val peek : 'a t -> 'a option


### PR DESCRIPTION
It's useful to have a simple guarantee that forward declarations are read at most once via `Fdecl.get`, but currently `Fdecl.peek` gets in the way because it's unchecked. 

It appears that the only place we use `Fdecl.peek` is when implementing an "idempotent set" operation which permits multiple calls to `Fdecl.set` as long as they set the same value. 

This PR removes `Fdecl.peek` and adds `Fdecl.set_idempotent` instead.