### PR TITLE
Fix typo in documentation

### DIFF
--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -29,7 +29,7 @@ let man =
   ; `Pre {|  \$ git describe --always --dirty|}
   ; `P
       {|$(b,dune subst) substitutes the variables that topkg substitutes with
-          the defatult configuration:|}
+          the default configuration:|}
   ; var "NAME" "the name of the project (from the dune-project file)"
   ; var "VERSION" "output of $(b,git describe --always --dirty)"
   ; var "VERSION_NUM"


### PR DESCRIPTION
Ran across this when grepping through my `_opam` so I thought I might as well submit the fix.