### PR TITLE
[WIP] Simplify collection of build targets

### DIFF
--- a/bin/target.ml
+++ b/bin/target.ml
@@ -12,12 +12,11 @@ type resolve_input =
   | Dep of Arg.Dep.t
 
 let request targets =
-  List.fold_left targets ~init:(Build.return ()) ~f:(fun acc target ->
-      let open Build.O in
+  List.fold_left targets ~init:[] ~f:(fun acc target ->
       acc
-      >>>
+      @
       match target with
-      | File path -> Build.path path
+      | File path -> [ path ]
       | Alias { Alias.name; recursive; dir; contexts } ->
         let contexts = List.map ~f:Dune.Context.name contexts in
         ( if recursive then

--- a/src/dune/alias.ml
+++ b/src/dune/alias.ml
@@ -188,7 +188,7 @@ let private_doc = make_standard (Name.of_string "doc-private")
 
 let lint = make_standard (Name.of_string "lint")
 
-let all = make_standard (Name.of_string "all")
+let all = make_standard Name.all
 
 let check = make_standard (Name.of_string "check")
 

--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -73,8 +73,6 @@ let all_unit xs =
 
 let record_lib_deps lib_deps = Record_lib_deps lib_deps
 
-let lazy_no_targets t = Lazy_no_targets t
-
 let deps d = Deps d
 
 let dep d = Deps (Dep.Set.singleton d)
@@ -149,6 +147,8 @@ let paths_existing paths =
   all_unit
     (List.map paths ~f:(fun file ->
          if_file_exists file ~then_:(path file) ~else_:(return ())))
+
+let paths_existing_lazy paths = Lazy_no_targets (lazy (paths_existing paths))
 
 let fail ?targets x =
   match targets with

--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -25,10 +25,6 @@ val all : 'a t list -> 'a list t
 
 val all_unit : unit t list -> unit t
 
-(** Optimization to avoiding eagerly computing a [Build.t] value, assume it
-    contains no targets. *)
-val lazy_no_targets : 'a t Lazy.t -> 'a t
-
 (** Delay a static computation until the description is evaluated *)
 val delayed : (unit -> 'a) -> 'a t
 
@@ -57,9 +53,19 @@ val path_set : Path.Set.t -> unit t
     dependencies of the action produced by the build description. *)
 val paths_matching : loc:Loc.t -> File_selector.t -> Path.Set.t t
 
+(* CR amokhov: Do we need both [paths_existing] and [paths_existing_lazy]?
+   Inuitively, we always want to use [paths_existing_lazy] since it can save
+   some unnecessary file-system checks. *)
+
 (** [paths_existing paths] will require as dependencies the files that actually
     exist. *)
 val paths_existing : Path.t list -> unit t
+
+(** Like [path_existing] but lazy. Specifically, it is guaranteed that calling
+    [targets] on the resulting expression does not cause any file-system checks,
+    because we statically know that expressions built with [paths_existing_lazy]
+    do not declare any targets. *)
+val paths_existing_lazy : Path.t list -> unit t
 
 (** [env_var v] records [v] as an environment variable that is read by the
     action produced by the build description. *)

--- a/src/dune/build_system.mli
+++ b/src/dune/build_system.mli
@@ -104,24 +104,24 @@ module Alias : sig
   val package_install : context:Context.t -> pkg:Package.Name.t -> t
 
   (** [dep t = Build.path (stamp_file t)] *)
-  val dep : t -> unit Build.t
+  val dep : t -> Path.t
 
   (** Implements [@@alias] on the command line *)
   val dep_multi_contexts :
        dir:Path.Source.t
     -> name:Alias.Name.t
     -> contexts:Context_name.t list
-    -> unit Build.t
+    -> Path.t list
 
   (** Implements [(alias_rec ...)] in dependency specification *)
-  val dep_rec : t -> loc:Loc.t -> unit Build.t
+  val dep_rec : t -> loc:Loc.t -> (Path.t list, fail) result
 
   (** Implements [@alias] on the command line *)
   val dep_rec_multi_contexts :
        dir:Path.Source.t
     -> name:Alias.Name.t
     -> contexts:Context_name.t list
-    -> unit Build.t
+    -> Path.t list
 end
 
 (** {1 Building} *)


### PR DESCRIPTION
This is work in progress, doesn't compile, far from being finished and is likely to be completely wrong, so don't look at the code yet.

The PR's goal is to address the following problem.

When one calls the function `Import.do_build targets` (which happens when Dune is executed) the following things happen:

* We call `Target.request targets` to create a `request : unit Build.t` comprising all dependencies of `targets`, to be passed to `Build_system.do_build ~request`.

* `Target.request targets` collects all possible dependencies, that can be of type `File` or `Alias`, where the latter can also be recursive or not. The collection happens in the `Build.t` functor, and essentially contains a bunch of `Deps` declarations, some of which are guarded by `If_file_exists` predicates. When processing recursive aliases, we also wrap intermediate results into `Lazy_no_target`. 

* When `Build_system.do_build` receives the `request`, it is forwarded to `build_request`, and then to `shim_of_build_goal`, which does the following call:
    ````
    Internal_rule.shim_of_build_goal ~build:request ~static_deps:(static_deps request)
    ````
   The call to `static_deps` creates a `Fiber.Once` which, when evaluated, will call the dependency analysis function `Build.static_deps` on the `request`, thereby forcing the computation of all lazy `If_file_exists` predicates.

* The constructed `Internal_rule` is passed to `evaluate_rule_and_wait_for_dependencies`, which immediately calls `Fiber.Once.get` to extract the list of static dependencies. As far as I understand, this negates any benefit of using `Lazy_no_target`, so we might as well remove all the associated complexity and simplify `Target.request targets` so that it returns a `Path.t list` of dependencies, instead of creating an intermediate `Build.t` structure with lazy subexpressions.

If I'm not mistaken above, this could kill quite a bit of complexity.