### PR TITLE
Fix adding include flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+2.1.1 (unreleased)
+------------------
+
+- Guess foreign archives & native archives for libraries defined using the
+  `META` format. (#2994, @rgrinberg, @anmonteiro)
+
 2.1.0 (21/12/2019)
 ------------------
 

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -479,7 +479,8 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; ocamlmklib = get_ocaml_tool_exn "ocamlmklib"
       ; ocamlobjinfo = which "ocamlobjinfo"
       ; env
-      ; findlib = Findlib.create ~stdlib_dir ~paths:findlib_paths ~version
+      ; findlib =
+          Findlib.create ~stdlib_dir ~paths:findlib_paths ~version ~lib_config
       ; findlib_toolchain
       ; arch_sixtyfour
       ; opam_var_cache

--- a/src/dune/findlib/findlib.mli
+++ b/src/dune/findlib/findlib.mli
@@ -9,7 +9,11 @@ type t
 val meta_fn : string
 
 val create :
-  stdlib_dir:Path.t -> paths:Path.t list -> version:Ocaml_version.t -> t
+     stdlib_dir:Path.t
+  -> paths:Path.t list
+  -> version:Ocaml_version.t
+  -> lib_config:Lib_config.t
+  -> t
 
 (** The search path for this DB *)
 val paths : t -> Path.t list
@@ -44,7 +48,8 @@ val all_packages : t -> Dune_package.Entry.t list
 val all_unavailable_packages : t -> (Lib_name.t * Unavailable_reason.t) list
 
 (** A dummy package. This is used to implement [external-lib-deps] *)
-val dummy_package : t -> name:Lib_name.t -> Dune_package.Lib.t
+val dummy_package :
+  t -> name:Lib_name.t -> lib_config:Lib_config.t -> Dune_package.Lib.t
 
 module Config : sig
   type t

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -124,8 +124,11 @@ module Archive = struct
 
     let stubs archive_name = archive_name ^ "_stubs"
 
+    let lib_file_prefix = "lib"
+
     let lib_file archive_name ~dir ~ext_lib =
-      Path.Build.relative dir (sprintf "lib%s%s" archive_name ext_lib)
+      Path.Build.relative dir
+        (sprintf "%s%s%s" lib_file_prefix archive_name ext_lib)
 
     let dll_file archive_name ~dir ~ext_dll =
       Path.Build.relative dir (sprintf "dll%s%s" archive_name ext_dll)

--- a/src/dune/foreign.mli
+++ b/src/dune/foreign.mli
@@ -93,6 +93,8 @@ module Archive : sig
 
     val stubs : string -> t
 
+    val lib_file_prefix : string
+
     val lib_file : t -> dir:Path.Build.t -> ext_lib:string -> Path.Build.t
 
     val dll_file : t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -1783,8 +1783,8 @@ module DB = struct
         Lib_name.Map.find map name |> Option.value ~default:Not_found)
       ~all:(fun () -> Lib_name.Map.keys map)
 
-  let create_from_findlib ?(external_lib_deps_mode = false) ~stdlib_dir findlib
-      =
+  let create_from_findlib ?(external_lib_deps_mode = false) ~stdlib_dir
+      ~lib_config findlib =
     create () ~stdlib_dir
       ~resolve:(fun name ->
         match Findlib.find findlib name with
@@ -1796,7 +1796,7 @@ module DB = struct
           | Invalid_dune_package why -> Invalid why
           | Not_found ->
             if external_lib_deps_mode then
-              let pkg = Findlib.dummy_package findlib ~name in
+              let pkg = Findlib.dummy_package findlib ~name ~lib_config in
               Found (Dune_package.Lib.info pkg)
             else
               Not_found

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -190,7 +190,11 @@ module DB : sig
     ?parent:t -> lib_config:Lib_config.t -> Library_related_stanza.t list -> t
 
   val create_from_findlib :
-    ?external_lib_deps_mode:bool -> stdlib_dir:Path.t -> Findlib.t -> t
+       ?external_lib_deps_mode:bool
+    -> stdlib_dir:Path.t
+    -> lib_config:Lib_config.t
+    -> Findlib.t
+    -> t
 
   val find : t -> Lib_name.t -> lib option
 

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -400,10 +400,11 @@ let get_installed_binaries stanzas ~(context : Context.t) =
 
 let create ~(context : Context.t) ?host ~projects ~packages ~stanzas
     ~external_lib_deps_mode =
+  let lib_config = Context.lib_config context in
   let installed_libs =
     let stdlib_dir = context.stdlib_dir in
     Lib.DB.create_from_findlib context.findlib ~stdlib_dir
-      ~external_lib_deps_mode
+      ~external_lib_deps_mode ~lib_config
   in
   let scopes, public_libs =
     let stanzas =
@@ -420,7 +421,6 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas
             Deprecated_library_name d :: acc
           | _ -> acc)
     in
-    let lib_config = Context.lib_config context in
     Scope.DB.create ~projects ~context:context.name ~installed_libs ~lib_config
       stanzas
   in

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1205,6 +1205,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias link-includes)
+ (deps (package dune) (source_tree test-cases/link-includes))
+ (action
+  (chdir
+   test-cases/link-includes
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias lint)
  (deps (package dune) (source_tree test-cases/lint))
  (action
@@ -2128,6 +2136,7 @@
   (alias lib-available)
   (alias lib-errors)
   (alias link-deps)
+  (alias link-includes)
   (alias lint)
   (alias loop)
   (alias macro-expand-error)
@@ -2357,6 +2366,7 @@
   (alias lib-available)
   (alias lib-errors)
   (alias link-deps)
+  (alias link-includes)
   (alias loop)
   (alias macro-expand-error)
   (alias merlin-allow_approximate_merlin)

--- a/test/blackbox-tests/test-cases/link-includes/run.t
+++ b/test/blackbox-tests/test-cases/link-includes/run.t
@@ -1,0 +1,45 @@
+Test linktime includes for an external library with C stubs
+
+  $ mkdir lib1
+  $ echo "(lang dune 1.11)" > lib1/dune-project
+  $ echo "# DUNE_GEN" > lib1/META.dunetestlib1.template
+  $ touch lib1/dunetestlib1.opam
+  $ cat >lib1/lib1.ml <<EOF
+  > external id : int -> int = "dune_test_id"
+  > EOF
+  $ cat >lib1/lib_stubs.c <<EOF
+  > #include <caml/mlvalues.h>
+  > CAMLprim value dune_test_id(value v) { return v; }
+  > EOF
+  $ cat >lib1/dune <<EOF
+  > (library
+  >  (public_name dunetestlib1)
+  >  (name lib1)
+  >  (modules lib1)
+  >  (c_names lib_stubs))
+  > EOF
+  $ dune build --root lib1 @install
+  Entering directory 'lib1'
+
+First we create an external library and implementation
+  $ mkdir exe
+  $ echo "(lang dune 2.0)" > exe/dune-project
+  $ cat >exe/dune <<EOF
+  > (executable (name bar) (libraries dunetestlib1))
+  > EOF
+  $ cat >exe/bar.ml <<EOF
+  > let () = Printf.printf "lib1: %d\n" (Lib1.id 42)
+  > EOF
+
+Then we make sure that it works fine.
+  $ env OCAMLPATH=lib1/_build/install/default/lib: dune exec --root exe ./bar.exe
+  Entering directory 'exe'
+  Entering directory 'exe'
+      ocamlopt bar.exe (exit 2)
+  (cd _build/default && /Users/rgrinberg/.opam/4.09.0/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o bar.exe $TESTCASE_ROOT/lib1/_build/install/default/lib/dunetestlib1/lib1.cmxa .bar.eobjs/native/dune__exe__Bar.cmx)
+  ld: library not found for -llib1_stubs
+  clang: error: linker command failed with exit code 1 (use -v to see invocation)
+  File "caml_startup", line 1:
+  Error: Error during linking
+  [1]
+

--- a/test/blackbox-tests/test-cases/link-includes/run.t
+++ b/test/blackbox-tests/test-cases/link-includes/run.t
@@ -35,11 +35,5 @@ Then we make sure that it works fine.
   $ env OCAMLPATH=lib1/_build/install/default/lib: dune exec --root exe ./bar.exe
   Entering directory 'exe'
   Entering directory 'exe'
-      ocamlopt bar.exe (exit 2)
-  (cd _build/default && /Users/rgrinberg/.opam/4.09.0/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -o bar.exe $TESTCASE_ROOT/lib1/_build/install/default/lib/dunetestlib1/lib1.cmxa .bar.eobjs/native/dune__exe__Bar.cmx)
-  ld: library not found for -llib1_stubs
-  clang: error: linker command failed with exit code 1 (use -v to see invocation)
-  File "caml_startup", line 1:
-  Error: Error during linking
-  [1]
+  lib1: 42
 

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -14,8 +14,23 @@ let print_pkg ppf pkg =
 
 let findlib =
   let cwd = Path.of_filename_relative_to_initial_cwd (Sys.getcwd ()) in
+  let lib_config : Lib_config.t =
+    { has_native = true
+    ; ext_lib = ".a"
+    ; ext_obj = ".o"
+    ; os_type = ""
+    ; architecture = ""
+    ; system = ""
+    ; model = ""
+    ; natdynlink_supported = Dynlink_supported.By_the_os.of_bool true
+    ; ext_dll = ".so"
+    ; stdlib_dir = Path.root
+    ; ccomp_type = Other "gcc"
+    }
+  in
   Findlib.create ~stdlib_dir:cwd ~paths:[ db_path ]
     ~version:(Ocaml_version.make (4, 02, 3))
+    ~lib_config
 
 let%expect_test _ =
   let pkg =


### PR DESCRIPTION
Not really sure what to call this PR.

Fixes a regression introduced by https://github.com/ocaml/dune/pull/2920 and released in 2.1.0.

I'm opening this PR to get some early feedback while I try to find a minimal reproduction.

The failure mode for me is Dune failing to link an executable that depends on `libbigstringaf_stubs`.