### PR TITLE
Detect sync-async dependencies in the memoization framework

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1841,6 +1841,9 @@ let package_deps pkg files =
            been filled so the following calls to [X.peek_exn] cannot raise. *)
         let static_deps = Fiber.Once.peek_exn ir.static_deps in
         let static_action_deps = Static_deps.action_deps static_deps in
+        (* CR-someday amokhov: It would be nice to statically rule out such
+           potential race conditions between [Sync] and [Async] functions, e.g.
+           by moving this code into a fiber. *)
         let _act, dynamic_action_deps =
           Memo.peek_exn evaluate_action_and_dynamic_deps_memo ir
         in

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -746,6 +746,10 @@ module DB = struct
         ~output:(Simple (module T))
         ~visibility:Hidden Sync
         (fun name ->
+          (* CR-someday amokhov: Here we assume that [get] is called after the
+             asynchronously running function [Create.memo] has completed. It
+             would be better to statically guarantee the completion, e.g. by
+             moving this code into a fiber. *)
           let contexts = Memo.peek_exn Create.memo () in
           List.find_exn contexts ~f:(fun c -> Context_name.equal name c.name))
     in

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -177,8 +177,8 @@ val create_hidden :
 
 (** The call [peek_exn t i] registers a dependency on [t i] and returns its
     value, failing if the value has not yet been computed. We do not expose
-    [peek] because the [None] case will necessarily trigger an internal error in
-    the memoization framework. *)
+    [peek] because the [None] case is hard to reason about, and currently there
+    are no use-cases for it. *)
 val peek_exn : ('i, 'o, _) t -> 'i -> 'o
 
 (** Execute a memoized function *)

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -175,9 +175,10 @@ val create_hidden :
   -> 'f
   -> ('i, 'o, 'f) t
 
-(** Check whether we already have a value for the given call *)
-val peek : ('i, 'o, _) t -> 'i -> 'o option
-
+(** The call [peek_exn t i] registers a dependency on [t i] and returns its
+    value, failing if the value has not yet been computed. We do not expose
+    [peek] because the [None] case will necessarily trigger an internal error in
+    the memoization framework. *)
 val peek_exn : ('i, 'o, _) t -> 'i -> 'o
 
 (** Execute a memoized function *)


### PR DESCRIPTION
It is possible to call `Memo.exec` on an asynchronous function from a synchronous one and then discard the result. The memoization framework does not support such sync-async dependencies and this PR adds a mechanism to detect and report them.

Surprisingly, with this change one of the tests fails on my machine, which means we do have such dependencies in Dune (or that I somehow messed up the detection). I'd like to see if the CI fails too.