### PR TITLE
Escape asterisk interpreted by sphinx as emphasis start without end.

### DIFF
--- a/doc/caching.rst
+++ b/doc/caching.rst
@@ -18,7 +18,7 @@ promoted to the cache, and subsequent builds will automatically check
 the cache for hits.
 
 The cached files are stored inside you `XDG_CACHE_HOME` directory on
-*nix systems, and `"HOME\\Local Settings\\Cache"` on Windows.
+\*nix systems, and `"HOME\\Local Settings\\Cache"` on Windows.
 
 
 Daemon


### PR DESCRIPTION
Fixes this warning:
```
/builddir/build/BUILD/dune-2.1.0/doc/caching.rst:20: WARNING: Inline emphasis start-string without end-string.
```