### PR TITLE
Use the lisp lexer for code samples with non-Scheme characters

### DIFF
--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -215,7 +215,7 @@ Below is an example where we build ``my.cmxs`` containing ``foo.cmxa`` and
 ``d.cmx``. Note how we use a :ref:`library` stanza to set up the compilation of
 ``d.cmx``.
 
-.. code:: scheme
+.. code:: lisp
 
     (library
      (name foo)

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -83,7 +83,7 @@ error.
 Here's a simple example of a condition that expresses running on OSX and having
 an flambda compiler with the help of variable expansion:
 
-.. code:: scheme
+.. code:: lisp
 
    (and %{ocamlc-config:flambda} (= %{ocamlc-config:system} macosx))
 
@@ -247,7 +247,7 @@ Forms that expands to list of items, such as ``%{cc}``, ``%{deps}``,
 ``%{targets}`` or ``%{read-lines:...}``, are suitable to be used in, say,
 ``(run <prog> <arguments>)``.  For instance in:
 
-.. code:: scheme
+.. code:: lisp
 
     (run foo %{deps})
 
@@ -275,7 +275,7 @@ which is equivalent to the following shell command:
 Note that, since ``%{deps}`` is a list of items, the first one may be
 used as a program name, for instance:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (targets result.txt)
@@ -284,7 +284,7 @@ used as a program name, for instance:
 
 Here is another example:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (target foo.exe)
@@ -400,7 +400,7 @@ be an action that reads the file given as only dependency named
 More precisely, ``(preprocess (action <action>))`` acts as if
 you had setup a rule for every file of the form:
 
-   .. code:: scheme
+   .. code:: lisp
 
        (rule
         (target file.pp.ml)
@@ -456,7 +456,7 @@ names.
 
 For instance:
 
- .. code:: scheme
+ .. code:: lisp
 
     (preprocess (per_module
                  (((action (run ./pp.sh X=1 %{input-file})) foo bar))
@@ -537,7 +537,7 @@ in actions (like the ``%{deps}``, ``%{target}`` and ``%{targets}`` built in vari
 One instance where this is useful is for naming globs. Here's an
 example of an imaginary bundle command:
 
-.. code:: scheme
+.. code:: lisp
 
    (rule
     (target archive.tar)
@@ -696,7 +696,7 @@ Note: expansion of the special ``%{<kind>:...}`` is done relative to the current
 working directory of the part of the DSL being executed. So for instance if you
 have this action in a ``src/foo/dune``:
 
-.. code:: scheme
+.. code:: lisp
 
     (action (chdir ../../.. (echo %{path:dune})))
 
@@ -831,7 +831,7 @@ complicated tests. In order to prevent dune from running the
 actions at the same time, you can specify that both actions take the
 same lock:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (alias  runtest)
@@ -857,7 +857,7 @@ contexts setup, the same rule might still be executed concurrently between the
 two build contexts. If you want a lock that is global to all build contexts,
 simply use an absolute filename:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (alias   runtest)
@@ -957,7 +957,7 @@ Declaring a package
 To declare a package, simply add a ``package`` stanza to your
 ``dune-project`` file:
 
-.. code:: scheme
+.. code:: lisp
 
           (package
            (name mypackage)

--- a/doc/cross-compilation.rst
+++ b/doc/cross-compilation.rst
@@ -97,6 +97,6 @@ Some packages might still have to be updated to support cross-compilation. For
 instance if the ``foo.exe`` program in the previous example was using
 ``Sys.os_type``, it should instead take it as a command line argument:
 
-.. code:: scheme
+.. code:: lisp
 
   (rule (with-stdout-to blah (run ./foo.exe -os-type %{os_type})))

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -277,7 +277,7 @@ The syntax of ``dune`` files is described in :ref:`metadata-format` section.
 ``dune`` files are composed of stanzas. For instance a typical
 ``dune`` looks like:
 
-.. code:: scheme
+.. code:: lisp
 
     (library
      (name mylib)
@@ -871,7 +871,7 @@ time obvious what are the dependencies and targets.
 
 For instance:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (target b)
@@ -897,7 +897,7 @@ Note that in dune, targets must always be known
 statically. For instance, this ``(rule ...)``
 stanza is rejected by dune:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule (copy a b.%{read:file}))
 
@@ -906,7 +906,7 @@ ocamllex
 
 ``(ocamllex <names>)`` is essentially a shorthand for:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (target <name>.ml)
@@ -929,7 +929,7 @@ ocamlyacc
 
 ``(ocamlyacc <names>)`` is essentially a shorthand for:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (targets <name>.ml <name>.mli)
@@ -1074,7 +1074,7 @@ The syntax is as follows:
 
 The typical use of the ``alias`` stanza is to define tests:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (alias   runtest)
@@ -1240,7 +1240,7 @@ be used to override the test binary invocation, for example if you're using
 alcotest and wish to see all the test failures on the standard output when
 running dune runtest you can use the following stanza:
 
-.. code:: scheme
+.. code:: lisp
 
    (tests
     (names mytest)
@@ -1324,7 +1324,7 @@ the user the following operations:
 
 Examples:
 
-.. code:: scheme
+.. code:: lisp
 
    (dirs *) ;; include all directories
    (dirs :standard \ ocaml) ;; include all directories except ocaml
@@ -1374,7 +1374,7 @@ All of the specified ``<sub-dirn>`` will be ignored by dune. Note that users
 should rely on the ``dirs`` stanza along with the appropriate set operations
 instead of this stanza. For example:
 
-.. code:: scheme
+.. code:: lisp
 
   (dirs :standard \ <sub-dir1> <sub-dir2> ...)
 
@@ -1559,7 +1559,7 @@ writers avoid boilerplate we provide a `(coqpp ...)` stanza:
 
 which for each ``g_mod`` in ``<mlg_list>`` is equivalent to:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (targets g_mod.ml)

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -191,7 +191,7 @@ Removed variables
 A named dependency should be used instead of ``${<}``. For instance
 the following jbuild file:
 
-.. code:: scheme
+.. code:: lisp
 
           (alias
            ((name   runtest)
@@ -200,7 +200,7 @@ the following jbuild file:
 
 should be rewritten to the following dune file:
 
-.. code:: scheme
+.. code:: lisp
 
           (rule
            (alias  runtest)

--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -134,7 +134,7 @@ Using cppo
 
 Add this field to your ``library`` or ``executable`` stanzas:
 
-.. code:: scheme
+.. code:: lisp
 
     (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
 
@@ -150,7 +150,7 @@ Using the .cppo.ml style like the ocamlbuild plugin
 
 Write this in your ``dune`` file:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (targets foo.ml)
@@ -182,7 +182,7 @@ Defining a library with C stubs using pkg-config
 Same context as before, but using ``pkg-config`` to query the
 compilation and link flags. Write this ``dune`` file:
 
-.. code:: scheme
+.. code:: lisp
 
     (library
      (name            mylib)
@@ -239,7 +239,7 @@ Using a custom code generator
 
 To generate a file ``foo.ml`` using a program from another directory:
 
-.. code:: scheme
+.. code:: lisp
 
     (rule
      (targets foo.ml)

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -357,7 +357,7 @@ In this example, we put tests in comments of the form:
 
 The backend for such a framework looks like this:
 
-.. code:: scheme
+.. code:: lisp
 
           (library
            (name simple_tests)


### PR DESCRIPTION
Some code samples contain characters that the pygments Scheme lexer doesn't recognize, such as %.  This leads to warnings like this:
```
/builddir/build/BUILD/dune-2.1.0/doc/advanced-topics.rst:218: WARNING: Could not lex literal_block as "scheme". Highlighting skipped.
```
Use the lisp lexer instead for such samples.  The code is really neither Scheme nor Lisp, anyway.