### PR TITLE
Improve safety of gen_tests.ml

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -465,7 +465,7 @@
 
 (rule
  (alias env-env-bins)
- (deps (package dune) (source_tree test-cases/env/env-bins))
+ (deps (package dune) (source_tree test-cases/env/env-bins) (sandbox none))
  (action
   (chdir
    test-cases/env/env-bins
@@ -477,7 +477,9 @@
  (action
   (chdir
    test-cases/env/env-cflags
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-dune-file)
@@ -493,7 +495,9 @@
  (action
   (chdir
    test-cases/env/env-simple
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-tracking)
@@ -1891,7 +1895,10 @@
 
 (rule
  (alias virtual-libraries-vlib)
- (deps (package dune) (source_tree test-cases/virtual-libraries/vlib))
+ (deps
+  (package dune)
+  (source_tree test-cases/virtual-libraries/vlib)
+  (package dune-configurator))
  (action
   (chdir
    test-cases/virtual-libraries/vlib
@@ -2041,7 +2048,6 @@
   (alias env-env-tracking)
   (alias env-env-var-expansion)
   (alias env-env-variables)
-  (alias env-envs-and-contexts)
   (alias exclude-missing-module)
   (alias exe-name-mangle)
   (alias exec-cmd)
@@ -2278,7 +2284,6 @@
   (alias env-env-tracking)
   (alias env-env-var-expansion)
   (alias env-env-variables)
-  (alias env-envs-and-contexts)
   (alias exclude-missing-module)
   (alias exe-name-mangle)
   (alias exec-cmd)
@@ -2355,7 +2360,6 @@
   (alias loop)
   (alias macro-expand-error)
   (alias merlin-allow_approximate_merlin)
-  (alias merlin-merlin-tests)
   (alias meta-gen)
   (alias misc)
   (alias missing-loc-run)
@@ -2427,7 +2431,9 @@
   (alias wrapped-false-main-module-name)
   (alias wrapped-transition)))
 
-(alias (name runtest-disabled) (deps (alias cinaps) (alias fdo)))
+(alias
+ (name runtest-disabled)
+ (deps (alias cinaps) (alias env-envs-and-contexts) (alias fdo)))
 
 (alias (name runtest-js) (deps (alias explicit_js_mode) (alias js_of_ocaml)))
 

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -164,6 +164,8 @@ module Test = struct
     |> Dune_lang.pp |> Pp.render_ignore_tags fmt
 end
 
+module String_map = Map.Make (String)
+
 let exclusions =
   let make = Test.make_run_t in
   let odoc name =
@@ -195,7 +197,7 @@ let exclusions =
   ; make "ppx-runtime-dependencies" ~external_deps:true
   ; make "foreign-library" ~external_deps:true
   ; make "package-dep" ~external_deps:true
-  ; make "merlin-tests" ~external_deps:true
+  ; make "merlin/merlin-tests" ~external_deps:true
   ; make "use-meta" ~external_deps:true
   ; make "output-obj" ~skip_platforms:[ Mac; Win ] ~skip_ocaml:"<4.06.0"
   ; make "dune-cache/trim" ~skip_platforms:[ Mac ]
@@ -207,26 +209,26 @@ let exclusions =
   ; utop "utop-default"
   ; utop "utop-default-implementation"
   ; make "toplevel-stanza" ~skip_ocaml:"<4.05.0"
-  ; make "configurator" ~skip_platforms:[ Win ]
   ; make "github764" ~skip_platforms:[ Win ]
   ; make "gen-opam-install-file" ~external_deps:true
   ; make "scope-ppx-bug" ~external_deps:true
   ; make "findlib-dynload" ~external_deps:true
     (* The next test is disabled as it relies on configured opam swtiches and
        it's hard to get that working properly *)
-  ; make "envs-and-contexts" ~external_deps:true ~enabled:false
-  ; make "env" ~skip_ocaml:"<4.06.0"
-  ; make "env-cflags" ~skip_ocaml:"<4.06.0"
+  ; make "env/envs-and-contexts" ~external_deps:true ~enabled:false
+  ; make "env/env-simple" ~skip_ocaml:"<4.06.0"
+  ; make "env/env-cflags" ~skip_ocaml:"<4.06.0"
   ; make "wrapped-transition" ~skip_ocaml:"<4.06.0"
   ; make "explicit_js_mode" ~external_deps:true ~js:true
     (* for the following tests sandboxing is disabled because absolute paths end
        up appearing in the output if we sandbox *)
-  ; make "env-bins" ~disable_sandboxing:true
-  ; make "vlib"
+  ; make "env/env-bins" ~disable_sandboxing:true
+  ; make "virtual-libraries/vlib"
       ~additional_deps:[ Sexp.strings [ "package"; "dune-configurator" ] ]
   ; make "pkg-config-quoting"
       ~additional_deps:[ Sexp.strings [ "package"; "dune-configurator" ] ]
   ]
+  |> String_map.of_list_map_exn ~f:(fun (test : Test.t) -> (test.path, test))
 
 let fold_find path ~init ~f =
   let rec dir path acc =
@@ -242,19 +244,28 @@ let fold_find path ~init ~f =
 
 let all_tests =
   lazy
-    ( fold_find Test.root_dir ~init:[] ~f:(fun acc p ->
-          if Filename.extension p = ".t" then
-            p :: acc
-          else
-            acc)
-    |> List.map ~f:(fun path ->
-           match
-             List.find exclusions ~f:(fun (t : Test.t) -> t.path = path)
-           with
-           | None -> Test.make path
-           | Some t -> t)
-    |> List.sort ~compare:(fun t1 t2 ->
-           String.compare (Test.alias_name t1) (Test.alias_name t2)) )
+    (let exclusions, tests =
+       fold_find Test.root_dir ~init:[] ~f:(fun acc p ->
+           if Filename.extension p = ".t" then
+             p :: acc
+           else
+             acc)
+       |> List.fold_left ~init:(exclusions, [])
+            ~f:(fun (exclusions, tests) path ->
+              match String_map.find exclusions path with
+              | None -> (exclusions, Test.make path :: tests)
+              | Some t -> (String_map.remove exclusions path, t :: tests))
+     in
+     ( match String_map.values exclusions with
+     | [] -> ()
+     | not_found_tests ->
+       Format.eprintf
+         "Failed to discover .t files for the following tests:@.@[<v>%a@]@."
+         (Format.pp_print_list (fun fmt (t : Test.t) ->
+              Format.fprintf fmt "- %s" t.path))
+         not_found_tests );
+     List.sort tests ~compare:(fun t1 t2 ->
+         String.compare (Test.alias_name t1) (Test.alias_name t2)))
 
 let pp_group fmt (name, tests) =
   alias name


### PR DESCRIPTION
Manually defined tests should always have corresponding .t files in the
test directory. Previously, such tests would be silently ignored.

This check allows us to catch some invalid test definitions.