### PR TITLE
Improve Fiber.finalize

### DIFF
--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -113,6 +113,10 @@ val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
     (List.map futures ~f:Future.wait) ]} *)
 val parallel_iter : 'a list -> f:('a -> unit t) -> unit t
 
+(** Same as [parallel_iter l ~f:Exn_with_backtrace.reriase] but more efficient.
+    [l] must not be empty. *)
+val parallel_reraise : Exn_with_backtrace.t list -> _ t
+
 (** {1 Execute once fibers} *)
 
 module Once : sig


### PR DESCRIPTION
Given that the we know that the callback passed to `parallel_iter` systematically raise, we can avoid a  bunch of closures and `try...with`.

This PR adds an `Execution_context.reraise` (resp `parallel_reraise`) function that is a specialised version of `Execution_context.apply` (resp `parallel_iter`) where the callback is `Exn_with_backtrace.reraise`.