### PR TITLE
Skip looking up non cachable files.

### DIFF
--- a/src/dune/action.ml
+++ b/src/dune/action.ml
@@ -263,7 +263,7 @@ let is_useful_to memoize =
     match t with
     | Chdir (_, t) -> loop t
     | Setenv (_, _, t) -> loop t
-    | Redirect_out (_, _, t) -> loop t
+    | Redirect_out (_, _, t) -> memoize || loop t
     | Redirect_in (_, _, t) -> loop t
     | Ignore (_, t)
     | With_accepted_exit_codes (_, t) ->

--- a/src/dune/action.ml
+++ b/src/dune/action.ml
@@ -254,11 +254,11 @@ let sandbox t ~sandboxed ~mode ~deps ~eval_pred : t =
         ~f_program:(fun ~dir:_ -> Result.map ~f:(maybe_sandbox_path sandboxed))
     ]
 
-type is_useful_to_sandbox =
+type is_useful =
   | Clearly_not
   | Maybe
 
-let is_useful_to_sandbox =
+let is_useful_to memoize =
   let rec loop t =
     match t with
     | Chdir (_, t) -> loop t
@@ -270,17 +270,17 @@ let is_useful_to_sandbox =
       loop t
     | Progn l -> List.exists l ~f:loop
     | Echo _ -> false
-    | Cat _ -> false
-    | Copy _ -> false
+    | Cat _ -> memoize
+    | Copy _ -> memoize
     | Symlink _ -> false
-    | Copy_and_add_line_directive _ -> false
-    | Write_file _ -> false
-    | Rename _ -> false
+    | Copy_and_add_line_directive _ -> memoize
+    | Write_file _ -> memoize
+    | Rename _ -> memoize
     | Remove_tree _ -> false
-    | Diff _ -> false
+    | Diff _ -> memoize
     | Mkdir _ -> false
-    | Digest_files _ -> false
-    | Merge_files_into _ -> false
+    | Digest_files _ -> memoize
+    | Merge_files_into _ -> memoize
     | Run _ -> true
     | Dynamic_run _ -> true
     | System _ -> true
@@ -290,3 +290,7 @@ let is_useful_to_sandbox =
     match loop t with
     | true -> Maybe
     | false -> Clearly_not
+
+let is_useful_to_sandbox = is_useful_to false
+
+let is_useful_to_memoize = is_useful_to true

--- a/src/dune/action.mli
+++ b/src/dune/action.mli
@@ -105,8 +105,10 @@ val sandbox :
   -> eval_pred:Dep.eval_pred
   -> t
 
-type is_useful_to_sandbox =
+type is_useful =
   | Clearly_not
   | Maybe
 
-val is_useful_to_sandbox : t -> is_useful_to_sandbox
+val is_useful_to_sandbox : t -> is_useful
+
+val is_useful_to_memoize : t -> is_useful

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1431,7 +1431,10 @@ end = struct
       force_rerun || depends_on_universe
     in
     let rule_digest = compute_rule_digest rule ~deps ~action ~sandbox_mode in
-    let do_not_memoize = always_rerun || is_action_dynamic in
+    let do_not_memoize =
+      always_rerun || is_action_dynamic
+      || Action.is_useful_to_memoize action = Clearly_not
+    in
     (* Here we determine if we need to rerun the action based on information
        stored in Trace_db. *)
     let* rule_need_rerun =

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1610,9 +1610,19 @@ end = struct
             | _ -> ()
           in
           let f { cache = (module Caching : Dune_cache.Caching); _ } =
-            ignore
-              (Caching.Cache.promote Caching.cache targets rule_digest []
-                 ~repository:None ~duplication:None)
+            match
+              Caching.Cache.promote Caching.cache targets rule_digest []
+                ~repository:None ~duplication:None
+            with
+            | Result.Error msg ->
+              let targets =
+                Path.Build.Set.to_list rule.targets
+                |> List.map ~f:Path.Build.to_string
+                |> String.concat ~sep:", "
+              in
+              Log.info
+                (Format.sprintf "promotion failed for %s: %s" targets msg)
+            | Result.Ok () -> ()
           in
           Option.iter ~f t.caching;
           let dynamic_deps_stages =

--- a/src/dune_cache/dune_cache.ml
+++ b/src/dune_cache/dune_cache.ml
@@ -233,7 +233,9 @@ module Cache = struct
       let stat = Unix.lstat (Path.to_string abs_path) in
       let* stat =
         if stat.st_kind != S_REG then
-          Result.Error "invalid file type"
+          Result.Error
+            (Format.sprintf "invalid file type: %s"
+               (Path.string_of_file_kind stat.st_kind))
         else
           Result.Ok stat
       in

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1287,3 +1287,12 @@ let set_of_source_paths set =
 
 let set_of_build_paths_list =
   List.fold_left ~init:Set.empty ~f:(fun acc e -> Set.add acc (build e))
+
+let string_of_file_kind = function
+  | Unix.S_REG -> "regular file"
+  | Unix.S_DIR -> "directory"
+  | Unix.S_CHR -> "character device"
+  | Unix.S_BLK -> "block device"
+  | Unix.S_LNK -> "symbolic link"
+  | Unix.S_FIFO -> "named pipe"
+  | Unix.S_SOCK -> "socket"

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -350,3 +350,5 @@ val stat : t -> Unix.stats
 val set_of_source_paths : Source.Set.t -> Set.t
 
 val set_of_build_paths_list : Build.t list -> Set.t
+
+val string_of_file_kind : Unix.file_kind -> string

--- a/test/blackbox-tests/test-cases/lib/run.t
+++ b/test/blackbox-tests/test-cases/lib/run.t
@@ -135,6 +135,7 @@ TODO: Fix %{libexec} and %{libexec-private} variables and test them.
   $ cat >external/dune-project <<EOF
   > (lang dune 2.1)
   > (name external_library)
+  > EOF
   $ cat >external/dune <<EOF
   > (library
   >  (name extlib)


### PR DESCRIPTION
Do not waste time looking up the cache and report cache miss for clearly non cachable files. Cachability is similar ton sandboxability, but subtly different. For instance there is no point in sandboxing a copy, but we want to look it up the cache to benefit from deduplication.