### PR TITLE
Add _opam and /boot.exe to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 _opam
 _build
 /_boot
-/boot.exe
 _perf
 *.install
 .merlin

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+_opam
 _build
 /_boot
+/boot.exe
 _perf
 *.install
 .merlin


### PR DESCRIPTION
- Adding `_opam` under the assumption that we generally develop dune in a sandbox (is this mistaken?)
- Adding `/boot.exe` since it is a build artifact

Signed-off-by: Shon Feder <shon.feder@gmail.com>