### PR TITLE
Add missing EOF to heredoc

### DIFF
--- a/test/blackbox-tests/test-cases/lib/run.t
+++ b/test/blackbox-tests/test-cases/lib/run.t
@@ -135,6 +135,7 @@ TODO: Fix %{libexec} and %{libexec-private} variables and test them.
   $ cat >external/dune-project <<EOF
   > (lang dune 2.1)
   > (name external_library)
+  > EOF
   $ cat >external/dune <<EOF
   > (library
   >  (name extlib)


### PR DESCRIPTION
Followup to #3013

Without this, tests on my local were failing with

```
@@ -135,6 +135,7 @@ TODO: Fix %{libexec} and %{libexec-private} variables and test them.
   $ cat >external/dune-project <<EOF
   > (lang dune 2.1)
   > (name external_library)
+  sh: line 2: warning: here-document at line 0 delimited by end-of-file (wanted `EOF')
   $ cat >external/dune <<EOF
   > (library
   >  (name extlib)
```