### PR TITLE
Finer with-accepted-exit-code restrictions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,11 @@
   @fangyi-zhou and @diml)
 
 - Hint when trying to execute an executable defined in the current directory
-  without using the `./` prefix (#3041).
+  without using the `./` prefix (#3041, fixes #1094, @voodoos).
+
+- Extend the list of modifiers that can be nested under
+  `with-accepted-exit-codes` with `chdir`,  `setenv`, `ignore-<outputs>`,
+  `with-stdin-from` and `with-<outputs>-to` (#3027, fixes #3014, @voodoos)
 
 - It is now an error to have a preprocessing dependency on a ppx rewriter
   library that is not marked as `(kind ppx_rewriter)` (#3039, @snowleopard).

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -651,8 +651,10 @@ The following constructions are available:
 - ``(with-stdin-from <file> <DSL>)`` to redirect the input from a file
 - ``(with-accepted-exit-codes <pred> <DSL>)`` specifies the list of expected exit codes
   for the programs executed in ``<DSL>``. ``<pred>`` is a predicate on integer
-  values, and is specified using the :ref:`predicate-lang`. ``<DSL>`` must be
-  one of ``run``, ``bash`` or ``system``. This action is available since dune 2.0.
+  values, and is specified using the :ref:`predicate-lang`. ``<DSL>`` can only
+  contain nested occurences of ``run``, ``bash``, ``system``, ``chdir``,
+  ``setenv``, ``ignore-<outputs>``, ``with-stdin-from`` and
+  ``with-<outputs>-to``. This action is available since dune 2.0.
 - ``(progn <DSL>...)`` to execute several commands in sequence
 - ``(echo <string>)`` to output a string on stdout
 - ``(write-file <file> <string>)`` writes ``<string>`` to ``<file>``

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -2043,11 +2043,29 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias with-nested-exit-codes)
+ (deps (package dune) (source_tree test-cases/with-nested-exit-codes))
+ (action
+  (chdir
+   test-cases/with-nested-exit-codes
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias with-stdin-from)
  (deps (package dune) (source_tree test-cases/with-stdin-from))
  (action
   (chdir
    test-cases/with-stdin-from
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
+ (alias with-unsupported-nested-exit-codes)
+ (deps
+  (package dune)
+  (source_tree test-cases/with-unsupported-nested-exit-codes))
+ (action
+  (chdir
+   test-cases/with-unsupported-nested-exit-codes
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
@@ -2328,7 +2346,9 @@
   (alias virtual-libraries-vlib-wrong-default-impl)
   (alias windows-diff)
   (alias with-exit-codes)
+  (alias with-nested-exit-codes)
   (alias with-stdin-from)
+  (alias with-unsupported-nested-exit-codes)
   (alias workspace-paths)
   (alias workspaces)
   (alias wrapped-false-main-module-name)
@@ -2548,7 +2568,9 @@
   (alias virtual-libraries-vlib-wrong-default-impl)
   (alias windows-diff)
   (alias with-exit-codes)
+  (alias with-nested-exit-codes)
   (alias with-stdin-from)
+  (alias with-unsupported-nested-exit-codes)
   (alias workspace-paths)
   (alias workspaces)
   (alias wrapped-false-main-module-name)

--- a/test/blackbox-tests/test-cases/with-nested-exit-codes/run.t
+++ b/test/blackbox-tests/test-cases/with-nested-exit-codes/run.t
@@ -1,0 +1,108 @@
+  $ cat > dune-project << EOF
+  > (lang dune 2.2)
+  > (using action-plugin 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name exit)
+  >  (modules exit))
+  > (rule (with-stdout-to exit.ml (echo "let () = exit (int_of_string Sys.argv.(1))")))
+  > EOF
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias f)
+  >  (action (with-accepted-exit-codes 
+  >           1
+  >           (with-stdout-to out.txt 
+  >            (run ./exit.exe 1)))))
+  > EOF
+
+  $ dune build --display=short --root . @f
+      ocamldep .exit.eobjs/exit.ml.d
+        ocamlc .exit.eobjs/byte/dune__exe__Exit.{cmi,cmo,cmt}
+      ocamlopt .exit.eobjs/native/dune__exe__Exit.{cmx,o}
+      ocamlopt exit.exe
+          exit out.txt
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias f2)
+  >  (action (with-accepted-exit-codes
+  >           1
+  >           (with-stdin-from input
+  >            (chdir .
+  >             (run ./exit.exe 1))))))
+  > EOF
+
+  $ echo "Hello, Dune!" > input
+  $ dune build --display=short --root . @f2
+          exit alias f2
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias f3)
+  >  (action (with-accepted-exit-codes
+  >           0
+  >           (setenv VAR myvar
+  >            (chdir .
+  >             (system "echo \$VAR"))))))
+  > EOF
+
+  $ dune build --display=short --root . @f3
+            sh alias f3
+  myvar
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias f4)
+  >  (action (with-accepted-exit-codes
+  >           0
+  >           (setenv VAR myvar
+  >            (ignore-stdout
+  >             (bash "echo \$VAR"))))))
+  > EOF
+
+  $ dune build --display=short --root . @f4
+          bash alias f4
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias f5)
+  >  (action (with-accepted-exit-codes
+  >           0
+  >           (setenv VAR myvar
+  >            (with-stdin-from input
+  >             (chdir .
+  >              (with-stdout-to out2.txt
+  >               (run ./exit.exe 1))))))))
+  > EOF
+  $ echo "Hello, Dune!" > input
+  $ dune build --display=short --root . @f5
+          exit out2.txt (exit 1)
+  (cd _build/default && ./exit.exe 1) < _build/default/input > _build/default/out2.txt
+  [1]
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias g)
+  >  (action 
+  >   (with-accepted-exit-codes 
+  >    (not 0) 
+  >    (setenv VAR myvar
+  >     (chdir .
+  >      (with-stdout-to out.txt
+  >       (dynamic-run ./exit.exe 1)))))))
+  > EOF
+
+  $ dune build --display=short --root . @g
+  File "dune", line 46, characters 3-98:
+  46 |    (setenv VAR myvar
+  47 |     (chdir .
+  48 |      (with-stdout-to out.txt
+  49 |       (dynamic-run ./exit.exe 1)))))))
+  Error: Only "run", "bash", "system", "chdir", "setenv", "ignore-<outputs>",
+  "with-stdin-from" and "with-<outputs>-to" can be nested under
+  "with-accepted-exit-codes"
+  [1]

--- a/test/blackbox-tests/test-cases/with-unsupported-nested-exit-codes/run.t
+++ b/test/blackbox-tests/test-cases/with-unsupported-nested-exit-codes/run.t
@@ -1,0 +1,29 @@
+  $ cat > dune-project << EOF
+  > (lang dune 2.0)
+  > (using action-plugin 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name exit)
+  >  (modules exit))
+  > (rule (with-stdout-to exit.ml (echo "let () = exit (int_of_string Sys.argv.(1))")))
+  > EOF
+
+  $ cat >> dune <<EOF
+  > (rule
+  >  (alias a)
+  >  (action (with-accepted-exit-codes 
+  >           1
+  >           (with-stdout-to out.txt
+  >            (run ./exit.exe 1)))))
+  > EOF
+
+  $ dune build --display=short --root . @a
+  File "dune", line 9, characters 10-64:
+   9 |           (with-stdout-to out.txt
+  10 |            (run ./exit.exe 1)))))
+  Error: nesting modifiers under 'with-accepted-exit-codes' is only available
+  since version 2.2 of the dune language. Please update your dune-project file
+  to have (lang 2.2).
+  [1]


### PR DESCRIPTION
Add a recursive check of the `<DSL>` under `with-accepted-exit-code` constructs such that only `run`, `bash`, `system`, `chdir`, `setenv`, `ignore-<outputs>`, `with-stdin-from` and `with-<outputs>-to` can appear.

It was previously restricted to a first-child check accepting only run, bash and system.

This fixes #3014