### PR TITLE
Do not lock the filesystem when using the cache.

### DIFF
--- a/src/dune_cache/dune_cache.ml
+++ b/src/dune_cache/dune_cache.ml
@@ -275,7 +275,7 @@ module Cache = struct
     in
     let+ promoted = Result.List.map ~f:promote paths in
     let metadata_path = FSSchemeImpl.path (path_meta cache) key
-    and metadata_tmp_path = Path.relative cache.temp_dir "promoting-metadata"
+    and metadata_tmp_path = Path.relative cache.temp_dir "metadata"
     and files = List.map ~f:file_of_promotion promoted in
     let metadata_file : Metadata_file.t = { metadata; files } in
     let metadata = Csexp.to_string (Metadata_file.to_sexp metadata_file) in

--- a/src/dune_cache/dune_cache.ml
+++ b/src/dune_cache/dune_cache.ml
@@ -152,6 +152,7 @@ module Cache = struct
     ; repositories : repository list
     ; handler : handler
     ; duplication_mode : Duplication_mode.t
+    ; temp_dir : Path.t
     }
 
   let path_files cache = Path.relative cache.root "files"
@@ -331,7 +332,7 @@ module Cache = struct
 
   let set_build_dir cache p = { cache with build_root = Some p }
 
-  let teardown _ = ()
+  let teardown cache = Path.rm_rf cache.temp_dir
 
   let detect_duplication_mode root =
     let () = Path.mkdir_p root in
@@ -361,6 +362,9 @@ module Cache = struct
         ; repositories = []
         ; handler
         ; duplication_mode
+        ; temp_dir =
+            Path.temp_dir ~temp_dir:root "promoting"
+              (string_of_int (Unix.getpid ()))
         }
 
   let duplication_mode cache = cache.duplication_mode

--- a/src/dune_cache/dune_cache.ml
+++ b/src/dune_cache/dune_cache.ml
@@ -324,7 +324,7 @@ module Cache = struct
 
   let set_build_dir cache p = { cache with build_root = Some p }
 
-  let teardown cache = Path.rm_rf cache.temp_dir
+  let teardown cache = Path.rm_rf ~allow_external:true cache.temp_dir
 
   let detect_duplication_mode root =
     let () = Path.mkdir_p root in

--- a/src/dune_cache/dune_cache.ml
+++ b/src/dune_cache/dune_cache.ml
@@ -159,8 +159,6 @@ module Cache = struct
 
   let path_meta cache = Path.relative cache.root "meta"
 
-  let path_tmp cache = Path.relative cache.root "temp"
-
   let with_lock cache f =
     let lock = Lock_file.create (Path.relative cache.root ".lock") in
     let finally () = Lock_file.unlock lock in
@@ -241,14 +239,8 @@ module Cache = struct
           Result.Ok stat
       in
       let prepare path =
-        let tmp = path_tmp cache in
-        (* dune-cache uses a single writer model, the promoted file name can be
-           constant *)
-        let dest = Path.relative tmp "promoting" in
-        if Path.exists dest then
-          Path.unlink dest
-        else
-          Path.mkdir_p tmp;
+        let dest = Path.relative cache.temp_dir "data" in
+        if Path.exists dest then Path.unlink dest;
         duplicate ~duplication cache path dest;
         dest
       in

--- a/src/dune_cache/dune_cache.ml
+++ b/src/dune_cache/dune_cache.ml
@@ -281,13 +281,13 @@ module Cache = struct
     let metadata = Csexp.to_string (Metadata_file.to_sexp metadata_file) in
     Io.write_file metadata_tmp_path metadata;
     let () =
-      try
-        if Io.read_file metadata_path <> metadata then
-          User_warning.emit
-            [ Pp.textf "non reproductible collision on rule %s"
-                (Digest.to_string key)
-            ]
-      with Sys_error _ -> Path.mkdir_p (Path.parent_exn metadata_path)
+      match Io.read_file metadata_path with
+        | contents -> if contents <> metadata then
+                        User_warning.emit
+                          [ Pp.textf "non reproductible collision on rule %s"
+                              (Digest.to_string key)
+                          ]
+        | exception Sys_error _ -> Path.mkdir_p (Path.parent_exn metadata_path)
     in
     Path.rename metadata_tmp_path metadata_path;
     let f = function

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1172,8 +1172,8 @@ let rm_rf =
         | _ -> unlink_operation fn);
     Unix.rmdir dir
   in
-  fun t ->
-    if not (is_managed t) then
+  fun ?(allow_external = false) t ->
+    if (not allow_external) && not (is_managed t) then
       Code_error.raise "Path.rm_rf called on external dir" [ ("t", to_dyn t) ];
     let fn = to_string t in
     match Unix.lstat fn with

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1325,3 +1325,6 @@ let temp_dir ?(temp_dir = get_temp_dir_name ()) ?(mode = 0o700) prefix suffix =
           [ ("error", String (Unix.error_message e)) ]
   in
   loop 0
+
+let rename old_path new_path =
+  Sys.rename (to_string old_path) (to_string new_path)

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1307,7 +1307,7 @@ let temp_dir ?(temp_dir = get_temp_dir_name ()) ?(mode = 0o700) prefix suffix =
   let attempts = 512 in
   let rec loop count =
     if Stdlib.( >= ) count attempts then
-      Code_error.raise "mk_temp_dir: too many failing attemps"
+      Code_error.raise "Path.temp_dir: too many failing attemps"
         [ ("attempts", Int attempts) ]
     else
       let dir =
@@ -1320,9 +1320,6 @@ let temp_dir ?(temp_dir = get_temp_dir_name ()) ?(mode = 0o700) prefix suffix =
       with
       | Unix.Unix_error (Unix.EEXIST, _, _) -> loop (count - 1)
       | Unix.Unix_error (Unix.EINTR, _, _) -> loop count
-      | Unix.Unix_error (e, _, _) ->
-        Code_error.raise "mk_temp_dir: system error"
-          [ ("error", String (Unix.error_message e)) ]
   in
   loop 0
 

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -308,7 +308,7 @@ val unlink_no_err : t -> unit
 
 val link : t -> t -> unit
 
-val rm_rf : t -> unit
+val rm_rf : ?allow_external:bool -> t -> unit
 
 val mkdir_p : ?perms:int -> t -> unit
 

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -358,9 +358,9 @@ val string_of_file_kind : Unix.file_kind -> string
     by concatenating prefix, then a suitably chosen integer number, then suffix.
     The optional argument temp_dir indicates the temporary directory to use,
     defaulting to the current result of Filename.get_temp_dir_name. The
-    temporary directory with permissions 0700. The directory is guaranteed to be
-    different from any other directory that existed when temp_dir was called.
-    Raise Sys_error if the file could not be created. *)
+    temporary directory is created with permissions [mode], defaulting to 0700.
+    The directory is guaranteed to be different from any other directory that
+    existed when temp_dir was called. *)
 val temp_dir : ?temp_dir:t -> ?mode:int -> string -> string -> t
 
 (** Rename a file. rename oldpath newpath renames the file called oldpath,

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -362,3 +362,9 @@ val string_of_file_kind : Unix.file_kind -> string
     different from any other directory that existed when temp_dir was called.
     Raise Sys_error if the file could not be created. *)
 val temp_dir : ?temp_dir:t -> ?mode:int -> string -> string -> t
+
+(** Rename a file. rename oldpath newpath renames the file called oldpath,
+    giving it newpath as its new name, moving it between directories if needed.
+    If newpath already exists, its contents will be replaced with those of
+    oldpath. *)
+val rename : t -> t -> unit

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -352,3 +352,13 @@ val set_of_source_paths : Source.Set.t -> Set.t
 val set_of_build_paths_list : Build.t list -> Set.t
 
 val string_of_file_kind : Unix.file_kind -> string
+
+(** temp_dir prefix suffix returns the name of a fresh temporary directory in
+    the temporary directory. The base name of the temporary directory is formed
+    by concatenating prefix, then a suitably chosen integer number, then suffix.
+    The optional argument temp_dir indicates the temporary directory to use,
+    defaulting to the current result of Filename.get_temp_dir_name. The
+    temporary directory with permissions 0700. The directory is guaranteed to be
+    different from any other directory that existed when temp_dir was called.
+    Raise Sys_error if the file could not be created. *)
+val temp_dir : ?temp_dir:t -> ?mode:int -> string -> string -> t


### PR DESCRIPTION
In OPAM CI's model, multiple process use the cache simultaneously. They need to operate without interlocking lest the cache actually slows down the build. Atomic filesystem operation should guarantee that conflicting concurrent use trigger no hard errors, just cache misses at worst.