### PR TITLE
Simplify handling of [if_file_exists] build expressions

### DIFF
--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -134,10 +134,10 @@ let term =
   let setup, lib_deps =
     Scheduler.go ~common (fun () ->
         let open Fiber.O in
-        let* setup = Import.Main.setup common ~external_lib_deps_mode:true in
+        let+ setup = Import.Main.setup common ~external_lib_deps_mode:true in
         let targets = Target.resolve_targets_exn common setup targets in
         let request = Target.request targets in
-        let+ deps = Build_system.all_lib_deps ~request in
+        let deps = Build_system.all_lib_deps ~request in
         (setup, deps))
   in
   let failure = run ~by_dir ~setup ~lib_deps ~sexp ~only_missing in

--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -261,9 +261,9 @@ let static_deps t ~file_exists =
     | Paths_glob g -> Static_deps.add_action_dep acc (Dep.file_selector g)
     | If_file_exists (p, then_, else_) ->
       if file_exists p then
-        loop then_ acc targets_allowed
+        loop then_ acc false
       else
-        loop else_ acc targets_allowed
+        loop else_ acc false
     | Dyn_paths t -> loop t acc targets_allowed
     | Dyn_deps t -> loop t acc targets_allowed
     | Contents p -> Static_deps.add_rule_path acc p

--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -8,8 +8,7 @@ type 'a t =
   | Targets : Path.Build.Set.t -> unit t
   | Paths_for_rule : Path.Set.t -> unit t
   | Paths_glob : File_selector.t -> Path.Set.t t
-  (* The reference gets decided in Build_interpret.deps *)
-  | If_file_exists : Path.t * 'a if_file_exists_state ref -> 'a t
+  | If_file_exists : Path.t * 'a t * 'a t -> 'a t
   | Contents : Path.t -> string t
   | Lines_of : Path.t -> string list t
   | Dyn_paths : ('a * Path.Set.t) t -> 'a t
@@ -31,16 +30,6 @@ and 'a memo_state =
   | Unevaluated
   | Evaluating
   | Evaluated of 'a * Dep.Set.t
-
-and 'a if_file_exists_state =
-  | Undecided of 'a t * 'a t
-  | Decided of bool * 'a t
-
-let get_if_file_exists_exn state =
-  match !state with
-  | Decided (_, t) -> t
-  | Undecided _ ->
-    Code_error.raise "Build.get_if_file_exists_exn: got undecided" []
 
 let return x = Pure x
 
@@ -137,13 +126,15 @@ let read_sexp p =
   Dune_lang.Parser.parse_string s ~lexer:Dune_lang.Lexer.token
     ~fname:(Path.to_string p) ~mode:Single
 
-let if_file_exists p ~then_ ~else_ =
-  If_file_exists (p, ref (Undecided (then_, else_)))
+let if_file_exists p ~then_ ~else_ = If_file_exists (p, then_, else_)
 
 let file_exists p = if_file_exists p ~then_:(return true) ~else_:(return false)
 
-let file_exists_opt p t =
-  if_file_exists p ~then_:(map ~f:Option.some t) ~else_:(return None)
+let if_ ~file_exists p ~then_ ~else_ =
+  if file_exists p then
+    then_
+  else
+    else_
 
 let paths_existing paths =
   all_unit
@@ -259,7 +250,7 @@ let no_targets_allowed () =
     []
   [@@inline never]
 
-let static_deps t ~list_targets =
+let static_deps t ~file_exists =
   let rec loop : type a. a t -> Static_deps.t -> bool -> Static_deps.t =
    fun t acc targets_allowed ->
     match t with
@@ -274,19 +265,8 @@ let static_deps t ~list_targets =
     | Deps deps -> Static_deps.add_action_deps acc deps
     | Paths_for_rule fns -> Static_deps.add_rule_paths acc fns
     | Paths_glob g -> Static_deps.add_action_dep acc (Dep.file_selector g)
-    | If_file_exists (p, state) -> (
-      match !state with
-      | Decided (_, t) -> loop t acc false
-      | Undecided (then_, else_) ->
-        let dir = Path.parent_exn p in
-        let targets = list_targets ~dir in
-        if Path.Set.mem targets p then (
-          state := Decided (true, then_);
-          loop then_ acc false
-        ) else (
-          state := Decided (false, else_);
-          loop else_ acc false
-        ) )
+    | If_file_exists (p, then_, else_) ->
+      loop (if_ ~file_exists p ~then_ ~else_) acc targets_allowed
     | Dyn_paths t -> loop t acc targets_allowed
     | Dyn_deps t -> loop t acc targets_allowed
     | Contents p -> Static_deps.add_rule_path acc p
@@ -299,7 +279,7 @@ let static_deps t ~list_targets =
   in
   loop t Static_deps.empty true
 
-let lib_deps =
+let lib_deps t ~file_exists =
   let rec loop : type a. a t -> Lib_deps_info.t -> Lib_deps_info.t =
    fun t acc ->
     match t with
@@ -318,14 +298,15 @@ let lib_deps =
     | Lines_of _ -> acc
     | Record_lib_deps deps -> Lib_deps_info.merge deps acc
     | Fail _ -> acc
-    | If_file_exists (_, state) -> loop (get_if_file_exists_exn state) acc
+    | If_file_exists (p, then_, else_) ->
+      loop (if_ ~file_exists p ~then_ ~else_) acc
     | Memo m -> loop m.t acc
     | Catch (t, _) -> loop t acc
     | Lazy_no_targets t -> loop (Lazy.force t) acc
   in
-  fun t -> loop t Lib_name.Map.empty
+  loop t Lib_name.Map.empty
 
-let targets =
+let targets t =
   let rec loop : type a. a t -> Path.Build.Set.t -> Path.Build.Set.t =
    fun t acc ->
     match t with
@@ -344,32 +325,26 @@ let targets =
     | Lines_of _ -> acc
     | Record_lib_deps _ -> acc
     | Fail _ -> acc
-    | If_file_exists (_, state) -> (
-      match !state with
-      | Decided (v, _) ->
-        Code_error.raise "Build_interpret.targets got decided if_file_exists"
-          [ ("exists", Dyn.Encoder.bool v) ]
-      | Undecided (a, b) ->
-        let a = loop a Path.Build.Set.empty in
-        let b = loop b Path.Build.Set.empty in
-        if Path.Build.Set.is_empty a && Path.Build.Set.is_empty b then
-          acc
-        else
-          Code_error.raise
-            "Build_interpret.targets: cannot have targets under a \
-             [if_file_exists]"
-            [ ("targets-a", Path.Build.Set.to_dyn a)
-            ; ("targets-b", Path.Build.Set.to_dyn b)
-            ] )
+    | If_file_exists (_, then_, else_) ->
+      let then_ = loop then_ Path.Build.Set.empty in
+      let else_ = loop else_ Path.Build.Set.empty in
+      if Path.Build.Set.is_empty then_ && Path.Build.Set.is_empty else_ then
+        acc
+      else
+        Code_error.raise
+          "Build.targets: cannot have targets under [if_file_exists]"
+          [ ("targets-then", Path.Build.Set.to_dyn then_)
+          ; ("targets-else", Path.Build.Set.to_dyn else_)
+          ]
     | Memo m -> loop m.t acc
     | Catch (t, _) -> loop t acc
     | Lazy_no_targets _ -> acc
   in
-  fun t -> loop t Path.Build.Set.empty
+  loop t Path.Build.Set.empty
 
 (* Execution *)
 
-let exec ~(eval_pred : Dep.eval_pred) (t : 'a t) : 'a * Dep.Set.t =
+let exec t ~file_exists ~eval_pred =
   let rec exec : type a. Dep.Set.t ref -> a t -> a =
    fun dyn_deps t ->
     match t with
@@ -384,7 +359,7 @@ let exec ~(eval_pred : Dep.eval_pred) (t : 'a t) : 'a * Dep.Set.t =
     | Targets _ -> ()
     | Deps _ -> ()
     | Paths_for_rule _ -> ()
-    | Paths_glob g -> eval_pred g
+    | Paths_glob g -> (eval_pred g : Path.Set.t)
     | Contents p -> Io.read_file p
     | Lines_of p -> Io.lines_of_file p
     | Dyn_paths t ->
@@ -397,7 +372,8 @@ let exec ~(eval_pred : Dep.eval_pred) (t : 'a t) : 'a * Dep.Set.t =
       x
     | Record_lib_deps _ -> ()
     | Fail { fail } -> fail ()
-    | If_file_exists (_, state) -> exec dyn_deps (get_if_file_exists_exn state)
+    | If_file_exists (p, then_, else_) ->
+      exec dyn_deps (if_ ~file_exists p ~then_ ~else_)
     | Catch (t, on_error) -> ( try exec dyn_deps t with exn -> on_error exn )
     | Lazy_no_targets t -> exec dyn_deps (Lazy.force t)
     | Memo m -> (

--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -106,8 +106,6 @@ val read_sexp : Path.t -> Dune_lang.Ast.t t
     target of a rule. *)
 val file_exists : Path.t -> bool t
 
-(* CR-soon amokhov: change [Path.t] to [Path.Build.t] in [if_file_exists]. *)
-
 (** [if_file_exists p ~then ~else] is a description that behaves like [then_] if
     [file_exists p] evaluates to [true], and [else_] otherwise. *)
 val if_file_exists : Path.t -> then_:'a t -> else_:'a t -> 'a t

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -95,27 +95,20 @@ module Internal_rule = struct
   module Id = struct
     include Id.Make ()
 
-    module Top_closure_f =
-      Top_closure.Make
-        (Set)
-        (struct
-          type 'a t = 'a Fiber.t
-
-          let return = Fiber.return
-
-          let ( >>= ) = Fiber.O.( >>= )
-        end)
-
     module Top_closure = Top_closure.Make (Set) (Monad.Id)
   end
 
   module T = struct
     type t =
       { id : Id.t
-      ; static_deps : Static_deps.t Fiber.Once.t
       ; targets : Path.Build.Set.t
       ; context : Context.t option
       ; build : Action.t Build.t
+      ; (* Here we cache the result of [Build.static_deps t.build ~file_exists]
+           in [t.static_deps]. We do this lazily, because to compute it we need
+           the [file_exists] predicate which in turn depends on the [t.targets]
+           field, thus causing a cyclic dependency. *)
+        static_deps : Static_deps.t Memo.Lazy.t
       ; mode : Rule.Mode.t
       ; info : Rule.Info.t
       ; dir : Path.Build.t
@@ -140,20 +133,14 @@ module Internal_rule = struct
 
   let hash t = Id.hash t.id
 
-  let lib_deps t =
-    (* Forcing this lazy ensures that the various globs and [if_file_exists] are
-       resolved inside the [Build.t] value. *)
-    let+ _ = Fiber.Once.get t.static_deps in
-    Build.lib_deps t.build
-
   (* Represent the build goal given by the user. This rule is never actually
      executed and is only used starting point of all dependency paths. *)
   let root =
     { id = Id.gen ()
-    ; static_deps = Fiber.Once.create (fun () -> Fiber.return Static_deps.empty)
     ; targets = Path.Build.Set.empty
     ; context = None
     ; build = Build.return (Action.Progn [])
+    ; static_deps = Memo.Lazy.of_val Static_deps.empty
     ; mode = Standard
     ; info = Internal
     ; dir = Path.Build.root
@@ -163,7 +150,11 @@ module Internal_rule = struct
 
   (* Create a shim for the main build goal *)
   let shim_of_build_goal ~build ~static_deps =
-    { root with id = Id.gen (); static_deps; build }
+    { root with
+      id = Id.gen ()
+    ; build
+    ; static_deps = Memo.Lazy.of_val static_deps
+    }
 
   let effective_env rule =
     match (rule.env, rule.context) with
@@ -662,7 +653,7 @@ let no_rule_found t ~loc fn =
 module rec Load_rules : sig
   val load_dir : dir:Path.t -> Loaded.t
 
-  val static_deps : Action.t Build.t -> Static_deps.t Fiber.Once.t
+  val file_exists : Path.t -> bool
 
   val targets_of : dir:Path.t -> Path.Set.t
 end = struct
@@ -672,13 +663,13 @@ end = struct
     let { Pre_rule.context; env; build; targets; mode; locks; info; dir } =
       pre_rule
     in
-    let static_deps = static_deps build in
     let rule =
       let id = Internal_rule.Id.gen () in
       { Internal_rule.id
-      ; static_deps
       ; targets
       ; build
+      ; static_deps =
+          Memo.lazy_ (fun () -> Build.static_deps build ~file_exists)
       ; context
       ; env
       ; locks
@@ -688,10 +679,6 @@ end = struct
       }
     in
     (targets, rule)
-
-  let static_deps build =
-    Fiber.Once.create (fun () ->
-        Fiber.return (Build.static_deps build ~list_targets:targets_of))
 
   let create_copy_rules ~ctx_dir ~non_target_source_files =
     Path.Source.Set.to_list non_target_source_files
@@ -711,6 +698,11 @@ end = struct
         List.map (Path.Build.Set.to_list targets) ~f:(fun target ->
             (target, rule)))
     |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
+
+  (* CR amokhov: Is it worth memoizing this? *)
+  let file_exists fn =
+    let dir = Path.parent_exn fn in
+    Path.Set.mem (targets_of ~dir) fn
 
   let targets_of ~dir =
     match load_dir ~dir with
@@ -1264,10 +1256,11 @@ end = struct
   (* Evaluate a rule and return the action and set of dynamic dependencies *)
   let evaluate_action_and_dynamic_deps_memo =
     let f (rule : Internal_rule.t) =
-      let* static_deps = Fiber.Once.get rule.static_deps in
-      let rule_deps = Static_deps.rule_deps static_deps in
+      let rule_deps =
+        Static_deps.rule_deps (Memo.Lazy.force rule.static_deps)
+      in
       let+ () = build_deps rule_deps in
-      Build.exec ~eval_pred rule.build
+      Build.exec rule.build ~file_exists ~eval_pred
     in
     Memo.create "evaluate-action-and-dynamic-deps"
       ~output:(Simple (module Action_and_deps))
@@ -1318,9 +1311,10 @@ end = struct
         ]
 
   let evaluate_rule (rule : Internal_rule.t) =
-    let* static_deps = Fiber.Once.get rule.static_deps in
     let+ action, dynamic_action_deps = evaluate_action_and_dynamic_deps rule in
-    let static_action_deps = Static_deps.action_deps static_deps in
+    let static_action_deps =
+      Static_deps.action_deps (Memo.Lazy.force rule.static_deps)
+    in
     let action_deps = Dep.Set.union static_action_deps dynamic_action_deps in
     (action, action_deps)
 
@@ -1338,8 +1332,9 @@ end = struct
      the final action and set of dynamic dependencies. We do this to increase
      opportunities for parallelism. *)
   let evaluate_rule_and_wait_for_dependencies (rule : Internal_rule.t) =
-    let* static_deps = Fiber.Once.get rule.static_deps in
-    let static_action_deps = Static_deps.action_deps static_deps in
+    let static_action_deps =
+      Static_deps.action_deps (Memo.Lazy.force rule.static_deps)
+    in
     (* Build the static dependencies in parallel with evaluation the action and
        dynamic dependencies *)
     let* action, dynamic_action_deps =
@@ -1767,7 +1762,7 @@ let shim_of_build_goal request =
     Action.Progn []
   in
   Internal_rule.shim_of_build_goal ~build:request
-    ~static_deps:(static_deps request)
+    ~static_deps:(Build.static_deps request ~file_exists)
 
 let build_request ~request =
   let result = Fdecl.create Dyn.Encoder.opaque in
@@ -1853,10 +1848,11 @@ let package_deps pkg files =
         acc
       else (
         rules_seen := Internal_rule.Set.add !rules_seen ir;
+        let static_action_deps =
+          Static_deps.action_deps (Memo.Lazy.force ir.static_deps)
+        in
         (* We know that at this point of execution, all the relevant ivars have
            been filled so the following calls to [X.peek_exn] cannot raise. *)
-        let static_deps = Fiber.Once.peek_exn ir.static_deps in
-        let static_action_deps = Static_deps.action_deps static_deps in
         (* CR-someday amokhov: It would be nice to statically rule out such
            potential race conditions between [Sync] and [Async] functions, e.g.
            by moving this code into a fiber. *)
@@ -1929,6 +1925,7 @@ let all_targets () =
 
 let targets_of ~dir = entry_point_sync ~f:(fun () -> targets_of ~dir)
 
+(* CR-soon amokhov: shall this be replaced with [file_exists]? *)
 let is_target file = Path.Set.mem (targets_of ~dir:(Path.parent_exn file)) file
 
 module Print_rules : sig
@@ -2004,11 +2001,10 @@ include Print_rules
 
 module All_lib_deps : sig
   val all_lib_deps :
-       request:unit Build.t
-    -> Lib_deps_info.t Path.Source.Map.t Context_name.Map.t Fiber.t
+    request:unit Build.t -> Lib_deps_info.t Path.Source.Map.t Context_name.Map.t
 end = struct
   let static_deps_of_request request =
-    Static_deps.paths @@ Build.static_deps request ~list_targets:targets_of
+    Static_deps.paths @@ Build.static_deps request ~file_exists
 
   let rules_for_files paths =
     Path.Set.fold paths ~init:[] ~f:(fun path acc ->
@@ -2018,13 +2014,13 @@ end = struct
     |> Internal_rule.Set.of_list |> Internal_rule.Set.to_list
 
   let rules_for_targets targets =
-    Internal_rule.Id.Top_closure_f.top_closure (rules_for_files targets)
+    Internal_rule.Id.Top_closure.top_closure (rules_for_files targets)
       ~key:(fun (r : Internal_rule.t) -> r.id)
       ~deps:(fun (r : Internal_rule.t) ->
-        Fiber.Once.get r.static_deps
-        >>| Static_deps.paths ~eval_pred
-        >>| rules_for_files)
-    >>| function
+        Memo.Lazy.force r.static_deps
+        |> Static_deps.paths ~eval_pred
+        |> rules_for_files)
+    |> function
     | Ok l -> l
     | Error cycle ->
       User_error.raise
@@ -2039,10 +2035,10 @@ end = struct
   let all_lib_deps ~request =
     let t = t () in
     let targets = static_deps_of_request request ~eval_pred in
-    let* rules = rules_for_targets targets in
-    let+ lib_deps =
-      Fiber.parallel_map rules ~f:(fun rule ->
-          let+ deps = Internal_rule.lib_deps rule in
+    let rules = rules_for_targets targets in
+    let lib_deps =
+      List.map rules ~f:(fun rule ->
+          let deps = Build.lib_deps rule.Internal_rule.build ~file_exists in
           (rule, deps))
     in
     List.fold_left lib_deps ~init:[] ~f:(fun acc (rule, deps) ->

--- a/src/dune/build_system.mli
+++ b/src/dune/build_system.mli
@@ -139,8 +139,7 @@ val is_target : Path.t -> bool
 (** Return all the library dependencies (as written by the user) needed to build
     this request, by context name *)
 val all_lib_deps :
-     request:unit Build.t
-  -> Lib_deps_info.t Path.Source.Map.t Context_name.Map.t Fiber.t
+  request:unit Build.t -> Lib_deps_info.t Path.Source.Map.t Context_name.Map.t
 
 (** List of all buildable targets *)
 val all_targets : unit -> Path.Build.Set.t


### PR DESCRIPTION
`Build.t` expressions come with a few subtle invariants. This PR removes one of them, which requires that `Build.static_deps` is called before other type of static analysis so that `if_file_exists` queries are resolved at appropriate time.

(This is follows some initial investigation done in #2993.)