### PR TITLE
Remove the logic to handle the (fallback) field

### DIFF
--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1728,31 +1728,20 @@ module Rule = struct
     and+ deps =
       field "deps" (Bindings.decode Dep_conf.decode) ~default:Bindings.empty
     and+ locks = field "locks" (repeat String_with_vars.decode) ~default:[]
-    and+ mode =
-      (* DUNE2: forbid (fallback) *)
-      map_validate
-        (let+ fallback =
-           field_b
-             ~check:
-               (Dune_lang.Syntax.renamed_in Stanza.syntax (1, 0)
-                  ~to_:"(mode fallback)")
-             "fallback"
-         and+ mode = field_o "mode" Mode.decode in
-         (fallback, mode))
-        ~f:(function
-          | true, Some _ ->
-            Error
-              (User_error.make
-                 [ Pp.text
-                     "Cannot use both (fallback) and (mode ...) at the same \
-                      time."
-                 ; Pp.text
-                     "(fallback) is the same as (mode fallback), please use \
-                      the latter in new code."
-                 ])
-          | false, Some mode -> Ok mode
-          | true, None -> Ok Fallback
-          | false, None -> Ok Standard)
+    and+ () =
+      let+ fallback =
+        field_b
+          ~check:
+            (Dune_lang.Syntax.renamed_in Stanza.syntax (1, 0)
+               ~to_:"(mode fallback)")
+          "fallback"
+      in
+      (* The "fallback" field was only allowed in jbuild file, which we don't
+         support anymore. So this cannot be [true]. We just keep the parser to
+         provide a nice error message for people switching from jbuilder to
+         dune. *)
+      assert (not fallback)
+    and+ mode = field "mode" Mode.decode ~default:Mode.Standard
     and+ enabled_if = enabled_if ~since:(Some (1, 4))
     and+ package =
       field_o "package"


### PR DESCRIPTION
This was only allowed in jbuild files and we no longer support jbuild files. We only keep the parser in order to provide a better error message.
