### PR TITLE
Remove stale "This will become an error ..." messages

### DIFF
--- a/src/dune/modules_field_evaluator.ml
+++ b/src/dune/modules_field_evaluator.ml
@@ -216,10 +216,9 @@ let check_invalid_module_listing ~(buildable : Buildable.t) ~intf_only ~modules
       | None ->
         User_error.raise ~loc:buildable.loc
           [ Pp.text "Some modules don't have an implementation."
-          ; Pp.textf
-              "You need to add the following field to this stanza:\n\n\
-              \  %s\n\n\
-               This will become an error in the future."
+          ; Pp.text "You need to add the following field to this stanza:"
+          ; Pp.nop
+          ; Pp.textf "  %s"
               (let tag =
                  Dune_lang.unsafe_atom_of_string
                    "modules_without_implementation"
@@ -236,7 +235,6 @@ let check_invalid_module_listing ~(buildable : Buildable.t) ~intf_only ~modules
               "The following modules must be listed here as they don't have an \
                implementation:"
           ; line_list missing_intf_only
-          ; Pp.text "This will become an error in the future."
           ] );
     print
       [ Pp.text

--- a/test/blackbox-tests/test-cases/intf-only/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/run.t
@@ -30,8 +30,6 @@ Errors:
   You need to add the following field to this stanza:
   
     (modules_without_implementation x y)
-  
-  This will become an error in the future.
   [1]
   $ dune build --display short --root b foo.cma
   Entering directory 'b'
@@ -41,7 +39,6 @@ Errors:
   Error: The following modules must be listed here as they don't have an
   implementation:
   - Y
-  This will become an error in the future.
   [1]
   $ dune build --display short --root c foo.cma
   Entering directory 'c'

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib/run.t
@@ -64,8 +64,6 @@ virtual libraries may not implement their virtual modules
   You need to add the following field to this stanza:
   
     (modules_without_implementation m)
-  
-  This will become an error in the future.
   -------------------------
   impl: true. modules_without_implementation: true. virtual_modules: true. private_modules: false
   File "dune", line 4, characters 18-19:
@@ -115,8 +113,6 @@ virtual libraries may not implement their virtual modules
   You need to add the following field to this stanza:
   
     (modules_without_implementation m)
-  
-  This will become an error in the future.
   -------------------------
 
 Implementations cannot introduce new modules to the library's interface


### PR DESCRIPTION
Some error messages contain:

```
This will become an error in the future.
```

even though they are already errors. This dates from the time these were warnings. This PR updates these messages.