### PR TITLE
Add [Action.empty]

### DIFF
--- a/src/dune/action.ml
+++ b/src/dune/action.ml
@@ -180,6 +180,8 @@ let chdirs =
   in
   fun t -> loop Path.Set.empty t
 
+let empty = Progn []
+
 let rec is_dynamic = function
   | Dynamic_run _ -> true
   | Chdir (_, t)

--- a/src/dune/action.mli
+++ b/src/dune/action.mli
@@ -68,6 +68,9 @@ val for_shell : t -> For_shell.t
 (** Return the list of directories the action chdirs to *)
 val chdirs : t -> Path.Set.t
 
+(** The empty action that does nothing. *)
+val empty : t
+
 (** Checks, if action contains a [Dynamic_run]. *)
 val is_dynamic : t -> bool
 

--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -212,7 +212,7 @@ let symlink ~src ~dst =
   path src >>> action ~targets:[ dst ] (Symlink (src, dst))
 
 let create_file fn =
-  action ~targets:[ fn ] (Redirect_out (Stdout, fn, Progn []))
+  action ~targets:[ fn ] (Redirect_out (Stdout, fn, Action.empty))
 
 let remove_tree dir = return (Action.Remove_tree dir)
 

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -139,7 +139,7 @@ module Internal_rule = struct
     { id = Id.gen ()
     ; targets = Path.Build.Set.empty
     ; context = None
-    ; build = Build.return (Action.Progn [])
+    ; build = Build.return Action.empty
     ; static_deps = Memo.Lazy.of_val Static_deps.empty
     ; mode = Standard
     ; info = Internal
@@ -1765,7 +1765,7 @@ let shim_of_build_goal request =
   let request =
     let open Build.O in
     let+ () = request in
-    Action.Progn []
+    Action.empty
   in
   Internal_rule.shim_of_build_goal ~build:request
     ~static_deps:(Build.static_deps request ~file_exists)

--- a/src/dune/simple_rules.ml
+++ b/src/dune/simple_rules.ml
@@ -16,7 +16,7 @@ module Alias_rules = struct
     SC.add_alias_action sctx alias ~dir ~loc ~locks ~stamp build
 
   let add_empty sctx ~loc ~alias ~stamp =
-    let action = Build.return (Action.Progn []) in
+    let action = Build.return Action.empty in
     add sctx ~loc ~alias ~stamp action
 end
 
@@ -190,7 +190,8 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
       | None ->
         fun x ->
           let open Build.O in
-          Build.ignore x >>> Build.progn []
+          let+ (_ : Path.t Bindings.t) = x in
+          Action.empty
       | Some (loc, action) ->
         let bindings = dep_bindings ~extra_bindings alias_conf.deps in
         let expander = Expander.add_bindings expander ~bindings in


### PR DESCRIPTION
I came across a few occurrences of `Progn []` to denote the empty `Action` and I think such actions deserve a proper name.