### PR TITLE
Fix OCaml 4.07 build

### DIFF
--- a/src/dune/watermarks.ml
+++ b/src/dune/watermarks.ml
@@ -127,7 +127,15 @@ let subst_file path ~map =
 
 (* Extending the Dune_project APIs, but adding capability to modify *)
 module Dune_project = struct
-  include Dune_project
+  (* The below incantation hides [Dune_project.t] preventing name conflicts in
+     OCaml 4.07. It can be replaced simply with [include Dune_project] once we
+     stop supporting OCaml 4.07. *)
+  include (
+    Dune_project :
+      module type of struct
+        include Dune_project
+      end
+      with type t := Dune_project.t )
 
   type 'a simple_field =
     { loc : Loc.t


### PR DESCRIPTION
Looks like OCaml 4.07 build was broken by this commit: https://github.com/ocaml/dune/commit/f941609a4852f10fc0e13353ce8141ca92fb0b6c. This PR should fix it.