### PR TITLE
Make `dune test` a command alias for `dune runtest`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 2.2.0 (unreleased)
 ------------------
 
+- `dune test` is now a command alias for `dune runtest`. This is to make the CLI
+  less idiosyncratic (#3006, @shonfeder)
+
 - Allow to set menhir flags in the `env` stanza using the `menhir_flags` field.
   (#2960, fix #2924, @bschommer)
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -139,6 +139,25 @@ let promote =
   in
   (term, Term.info "promote" ~doc ~man)
 
+(* Adapted from https://github.com/ocaml/opam/blob/fbbe93c3f67034da62d28c8666ec6b05e0a9b17c/src/client/opamArg.ml#L759 *)
+let command_alias cmd name =
+  let (term, info) = cmd in
+  let orig = Term.name info in
+  let doc = Printf.sprintf "An alias for $(b,%s)." orig in
+  let man =
+    [ `S "DESCRIPTION"
+    ; `P (Printf.sprintf "$(mname)$(b, %s) is an alias for $(mname)$(b, %s)."
+            name orig)
+    ; `P (Printf.sprintf "See $(mname)$(b, %s --help) for details."
+            orig)
+    ; `Blocks Common.help_secs
+    ]
+  in
+  term,
+  Term.info name
+    ~docs:"COMMAND ALIASES"
+    ~doc ~man
+
 let all =
   [ Installed_libraries.command
   ; External_lib_deps.command

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -163,6 +163,7 @@ let all =
   ; External_lib_deps.command
   ; build_targets
   ; runtest
+  ; command_alias runtest "test"
   ; clean
   ; Install_uninstall.install
   ; Install_uninstall.uninstall

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -170,3 +170,12 @@
  (package dune)
  (files   dune-utop.1))
 
+(rule
+ (with-stdout-to dune-test.1
+  (run dune test --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-test.1))
+

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -22,8 +22,9 @@ Running tests
 =============
 
 Whatever the tests of a project are, the usual way to run tests with dune is to
-call ``dune runtest`` from the shell. This will run all the tests defined in the
-current directory and any sub-directory recursively.
+call ``dune runtest`` from the shell (or the command alias ``dune test``). This
+will run all the tests defined in the current directory and any sub-directory
+recursively.
 
 Note that in any case, ``dune runtest`` is simply a short-hand for building the
 ``runtest`` alias, so you can always ask dune to run the tests in conjunction

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -308,14 +308,14 @@ Running tests
 There are two ways to run tests:
 
 -  ``dune build @runtest``
--  ``dune runtest``
+-  ``dune test`` (or the more explicit ``dune runtest``)
 
 The two commands are equivalent. They will run all the tests defined in the
 current directory and its children recursively. You can also run the tests in a
 specific sub-directory and its children by using:
 
 -  ``dune build @foo/bar/runtest``
--  ``dune runtest foo/bar``
+-  ``dune test foo/bar`` (or ``dune runtest foo/bar``)
 
 Watch mode
 ==========

--- a/vendor/cmdliner/src/cmdliner_manpage.ml
+++ b/vendor/cmdliner/src/cmdliner_manpage.ml
@@ -23,6 +23,7 @@ let s_name = "NAME"
 let s_synopsis = "SYNOPSIS"
 let s_description = "DESCRIPTION"
 let s_commands = "COMMANDS"
+let s_command_aliases = "COMMAND ALIASES"
 let s_arguments = "ARGUMENTS"
 let s_options = "OPTIONS"
 let s_common_options = "COMMON OPTIONS"
@@ -45,7 +46,7 @@ let s_see_also = "SEE ALSO"
 let s_created = ""
 let order =
   [| s_name; s_synopsis; s_description; s_created; s_commands;
-     s_arguments; s_options; s_common_options; s_exit_status;
+     s_command_aliases; s_arguments; s_options; s_common_options; s_exit_status;
      s_environment; s_files; s_examples; s_bugs; s_authors; s_see_also; |]
 
 let order_synopsis = 1


### PR DESCRIPTION
Closes #3006

As noted in the comment, this follows the approach opam uses for its command aliases, visible here https://github.com/ocaml/opam/blob/fbbe93c3f67034da62d28c8666ec6b05e0a9b17c/src/client/opamArg.ml#L759-L775

No meaningful tests have occurred to me, and I'd be grateful for any testing suggestions if they occur to someone else. 

The top-level help text looks like this:

```
COMMAND ALIASES
       test
           An alias for runtest.
```

where the `COMMAND ALIASES` section follows immediately after the `COMMANDS` section.

The `dune test --help` gives:

```
dune-test(1)                      Dune Manual                     dune-test(1)



NAME
       dune-test - An alias for runtest.

SYNOPSIS
       dune test [OPTION]... [DIR]...

DESCRIPTION
       dune test is an alias for dune runtest.

       See dune runtest --help for details.
``

before showing the common options.