### PR TITLE
Do not automatically add the .opt suffix when calling binaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@
   shared cache. In particular, make them writable by the user (#3043,
   fixes #3026, @diml)
 
+- Only detect internal OCaml tools with `.opt` extensions. Previously, this
+  detection applied to other binaries as well (@kit-ty-kate, @rgrinberg, #3051).
+
 2.1.3 (16/01/2020)
 ------------------
 


### PR DESCRIPTION
When I tried to fix `elpi` regarding https://github.com/ocaml/dune/issues/3050, I switch the use of the `(system "camlp5o ...")` function to `(run camlp5o ...)` but the following error message appeared:
```
     camlp5o src/parser.pp.mli (exit 2)
(cd _build/default && /home/kit_ty_kate/.opam/4.10/bin/camlp5o.opt -I . -I +camlp5 pa_extend.cmo pa_lexer.cmo src/parser.mli) > _build/default/src/parser.pp.mli
Error while loading "pa_extend.cmo": native-code program cannot do a dynamic load.
     camlp5o src/parser.pp.ml (exit 2)
(cd _build/default && /home/kit_ty_kate/.opam/4.10/bin/camlp5o.opt -I . -I +camlp5 pa_extend.cmo pa_lexer.cmo src/parser.ml) > _build/default/src/parser.pp.ml
Error while loading "pa_extend.cmo": native-code program cannot do a dynamic load.
```
Since camlp5 installs binaries with the `.opt` suffix, dune automatically uses them, however the semantics is a bit different than the ones in the ocaml compiler this feature was used for.

I believe this is safe anyway because since OCaml 4.04 the ocaml executables are native by default. See https://github.com/ocaml/ocaml/blob/646d30404e6b5fa0d49aea3860cbf4efe3910601/Changes#L4316