### PR TITLE
Extract information about the library kind from generated META files

### DIFF
--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -211,34 +211,12 @@ module Package = struct
     Vars.get_words t.vars "ppx_runtime_deps" preds
     |> List.map ~f:(Lib_name.of_string_exn ~loc:None)
 
-  (* If the META file contains no information about the library kind, we guess
-     the kind by looking at the presence of [ppx_driver] predicates which Dune
-     uses when the library's kind is not [Normal]. *)
   let kind t =
     match Vars.get t.vars "library_kind" Ps.empty with
-    | Some "normal" -> Lib_kind.Normal
+    | None -> Lib_kind.Normal
     | Some "ppx_rewriter" -> Ppx_rewriter Lib_kind.Ppx_args.empty
     | Some "ppx_deriver" -> Ppx_deriver Lib_kind.Ppx_args.empty
-    | Some s ->
-      User_error.raise [ Pp.textf "Unknown \"library_kind\" setting %S." s ]
-    | None -> (
-      match String.Map.find t.vars "requires" with
-      | None -> Lib_kind.Normal
-      | Some ({ set_rules; add_rules = _ } : Rules.t) ->
-        if
-          (* We set [ppx(-ppx_driver,...)] only for [Ppx_rewriter]. *)
-          List.exists set_rules ~f:(fun (rule : Rule.t) ->
-              Ps.mem rule.preds_forbidden P.ppx_driver)
-        then
-          Ppx_rewriter Lib_kind.Ppx_args.empty
-        else if
-          (* We set [ppxopt(-ppx_driver,...)] only for [Ppx_deriver]. *)
-          List.exists set_rules ~f:(fun (rule : Rule.t) ->
-              Ps.mem rule.preds_forbidden P.ppx_driver)
-        then
-          Ppx_deriver Lib_kind.Ppx_args.empty
-        else
-          Lib_kind.Normal )
+    | Some _other_string -> Lib_kind.Normal
 
   let archives t = make_archives t "archive" preds
 

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -211,23 +211,34 @@ module Package = struct
     Vars.get_words t.vars "ppx_runtime_deps" preds
     |> List.map ~f:(Lib_name.of_string_exn ~loc:None)
 
-  (* We need a way to figure out if a library is a ppx rewriter. To do that, we
-     currently rely on the presence of [ppx_driver] predicates which Dune uses
-     when the library's kind is not [Normal]. A cleaner way would be to add a
-     new variable to the generated META file, e.g. called [library_kind], but
-     this seems like an overkill given that we plan to stop supporting generated
-     META files soon. *)
+  (* If the META file contains no information about the library kind, we guess
+     the kind by looking at the presence of [ppx_driver] predicates which Dune
+     uses when the library's kind is not [Normal]. *)
   let kind t =
-    match String.Map.find t.vars "requires" with
-    | None -> Lib_kind.Normal
-    | Some ({ set_rules; add_rules } : Rules.t) ->
-      if
-        List.exists (set_rules @ add_rules) ~f:(fun (rule : Rule.t) ->
-            Ps.mem rule.preds_required P.ppx_driver)
-      then
-        Ppx_rewriter Lib_kind.Ppx_args.empty
-      else
-        Lib_kind.Normal
+    match Vars.get t.vars "library_kind" Ps.empty with
+    | Some "normal" -> Lib_kind.Normal
+    | Some "ppx_rewriter" -> Ppx_rewriter Lib_kind.Ppx_args.empty
+    | Some "ppx_deriver" -> Ppx_deriver Lib_kind.Ppx_args.empty
+    | Some s ->
+      User_error.raise [ Pp.textf "Unknown \"library_kind\" setting %S." s ]
+    | None -> (
+      match String.Map.find t.vars "requires" with
+      | None -> Lib_kind.Normal
+      | Some ({ set_rules; add_rules = _ } : Rules.t) ->
+        if
+          (* We set [ppx(-ppx_driver,...)] only for [Ppx_rewriter]. *)
+          List.exists set_rules ~f:(fun (rule : Rule.t) ->
+              Ps.mem rule.preds_forbidden P.ppx_driver)
+        then
+          Ppx_rewriter Lib_kind.Ppx_args.empty
+        else if
+          (* We set [ppxopt(-ppx_driver,...)] only for [Ppx_deriver]. *)
+          List.exists set_rules ~f:(fun (rule : Rule.t) ->
+              Ps.mem rule.preds_forbidden P.ppx_driver)
+        then
+          Ppx_deriver Lib_kind.Ppx_args.empty
+        else
+          Lib_kind.Normal )
 
   let archives t = make_archives t "archive" preds
 

--- a/src/dune/gen_meta.ml
+++ b/src/dune/gen_meta.ml
@@ -100,7 +100,7 @@ let gen_lib pub_name lib ~version =
         ; ppx_runtime_deps ppx_rt_deps
         ] )
     ; ( match kind with
-      | Normal -> [ rule "library_kind" [] Set "normal" ]
+      | Normal -> []
       | Ppx_rewriter _
       | Ppx_deriver _ ->
         (* Deprecated ppx method support *)

--- a/src/dune/gen_meta.ml
+++ b/src/dune/gen_meta.ml
@@ -100,7 +100,7 @@ let gen_lib pub_name lib ~version =
         ; ppx_runtime_deps ppx_rt_deps
         ] )
     ; ( match kind with
-      | Normal -> []
+      | Normal -> [ rule "library_kind" [] Set "normal" ]
       | Ppx_rewriter _
       | Ppx_deriver _ ->
         (* Deprecated ppx method support *)
@@ -120,6 +120,7 @@ let gen_lib pub_name lib ~version =
               [ rule "ppx"
                   [ no_ppx_driver; no_custom_ppx ]
                   Set "./ppx.exe --as-ppx"
+              ; rule "library_kind" [] Set "ppx_rewriter"
               ]
             | Ppx_deriver _ ->
               [ rule "requires"
@@ -129,6 +130,7 @@ let gen_lib pub_name lib ~version =
                   [ no_ppx_driver; no_custom_ppx ]
                   Set
                   ("ppx_deriving,package:" ^ Pub_name.to_string pub_name)
+              ; rule "library_kind" [] Set "ppx_deriver"
               ] )
           ] )
     ; ( match Lib_info.jsoo_runtime info with

--- a/src/dune/lib_kind.ml
+++ b/src/dune/lib_kind.ml
@@ -33,6 +33,8 @@ module Ppx_args = struct
 
   type t = { cookies : Cookie.t list }
 
+  let empty = { cookies = [] }
+
   let to_dyn { cookies } =
     let open Dyn.Encoder in
     record [ ("cookies", list Cookie.to_dyn cookies) ]

--- a/src/dune/lib_kind.mli
+++ b/src/dune/lib_kind.mli
@@ -7,6 +7,8 @@ module Ppx_args : sig
   end
 
   type t = { cookies : Cookie.t list }
+
+  val empty : t
 end
 
 type t =

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -5,6 +5,7 @@
   archive(native) = "foobar.cmxa"
   plugin(byte) = "foobar.cma"
   plugin(native) = "foobar.cmxs"
+  library_kind = "normal"
   package "baz" (
     directory = "baz"
     description = "sub library with modes set to byte"
@@ -13,6 +14,7 @@
     archive(native) = "foobar_baz.cmxa"
     plugin(byte) = "foobar_baz.cma"
     plugin(native) = "foobar_baz.cmxs"
+    library_kind = "normal"
   )
   package "ppd" (
     directory = "ppd"
@@ -22,6 +24,7 @@
     archive(native) = "foobar_ppd.cmxa"
     plugin(byte) = "foobar_ppd.cma"
     plugin(native) = "foobar_ppd.cmxs"
+    library_kind = "normal"
   )
   package "rewriter" (
     directory = "rewriter"
@@ -38,6 +41,7 @@
     # and normal dependencies
     requires(-ppx_driver) = "foobar.baz foobar.runtime-lib2"
     ppx(-ppx_driver,-custom_ppx) = "./ppx.exe --as-ppx"
+    library_kind = "ppx_rewriter"
   )
   package "rewriter2" (
     directory = "rewriter2"
@@ -50,6 +54,7 @@
     # This is what dune uses to find out the runtime dependencies of
     # a preprocessor
     ppx_runtime_deps = "foobar.runtime-lib2"
+    library_kind = "normal"
   )
   package "runtime-lib2" (
     directory = "runtime-lib2"
@@ -59,6 +64,7 @@
     archive(native) = "foobar_runtime_lib2.cmxa"
     plugin(byte) = "foobar_runtime_lib2.cma"
     plugin(native) = "foobar_runtime_lib2.cmxs"
+    library_kind = "normal"
     linkopts(javascript) = "+foobar/foobar_runtime.js
                             +foobar/foobar_runtime2.js"
     jsoo_runtime = "foobar_runtime.js foobar_runtime2.js"
@@ -71,4 +77,5 @@
     archive(native) = "foobar_sub.cmxa"
     plugin(byte) = "foobar_sub.cma"
     plugin(native) = "foobar_sub.cmxs"
+    library_kind = "normal"
   )

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -5,7 +5,6 @@
   archive(native) = "foobar.cmxa"
   plugin(byte) = "foobar.cma"
   plugin(native) = "foobar.cmxs"
-  library_kind = "normal"
   package "baz" (
     directory = "baz"
     description = "sub library with modes set to byte"
@@ -14,7 +13,6 @@
     archive(native) = "foobar_baz.cmxa"
     plugin(byte) = "foobar_baz.cma"
     plugin(native) = "foobar_baz.cmxs"
-    library_kind = "normal"
   )
   package "ppd" (
     directory = "ppd"
@@ -24,7 +22,6 @@
     archive(native) = "foobar_ppd.cmxa"
     plugin(byte) = "foobar_ppd.cma"
     plugin(native) = "foobar_ppd.cmxs"
-    library_kind = "normal"
   )
   package "rewriter" (
     directory = "rewriter"
@@ -54,7 +51,6 @@
     # This is what dune uses to find out the runtime dependencies of
     # a preprocessor
     ppx_runtime_deps = "foobar.runtime-lib2"
-    library_kind = "normal"
   )
   package "runtime-lib2" (
     directory = "runtime-lib2"
@@ -64,7 +60,6 @@
     archive(native) = "foobar_runtime_lib2.cmxa"
     plugin(byte) = "foobar_runtime_lib2.cma"
     plugin(native) = "foobar_runtime_lib2.cmxs"
-    library_kind = "normal"
     linkopts(javascript) = "+foobar/foobar_runtime.js
                             +foobar/foobar_runtime2.js"
     jsoo_runtime = "foobar_runtime.js foobar_runtime2.js"
@@ -77,5 +72,4 @@
     archive(native) = "foobar_sub.cmxa"
     plugin(byte) = "foobar_sub.cma"
     plugin(native) = "foobar_sub.cmxs"
-    library_kind = "normal"
   )


### PR DESCRIPTION
This is a (hacky) solution for the problem reported in https://github.com/ocaml/dune/issues/3057.

With this fix, Dune can build the example from #3057. Not sure it's worth adding a separate test.