### PR TITLE
Remove [Build.Lazy_no_targets]

### DIFF
--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -62,10 +62,6 @@ val all : 'a t list -> 'a list t
 
 val all_unit : unit t list -> unit t
 
-(** Optimization to avoiding eagerly computing a [Build.t] value, assume it
-    contains no targets. *)
-val lazy_no_targets : 'a t Lazy.t -> 'a t
-
 (** Delay a static computation until the description is evaluated *)
 val delayed : (unit -> 'a) -> 'a t
 

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -187,10 +187,8 @@ module Alias0 = struct
            ~then_:(Build.path fn >>> Build.return false)
            ~else_:(Build.return true))
     in
-    Build.lazy_no_targets
-      ( lazy
-        (File_tree.Dir.fold dir ~traverse:Sub_dirs.Status.Set.normal_only
-           ~init:(Build.return true) ~f) )
+    File_tree.Dir.fold dir ~traverse:Sub_dirs.Status.Set.normal_only
+      ~init:(Build.return true) ~f
 
   let dep_rec t ~loc =
     let ctx_dir, src_dir =


### PR DESCRIPTION
We used to need a way to hide certain `Build.t` subexpressions behind `Lazy_no_targets` constructors. These constructors were not explored when computing the list of build targets (with `Build.targets`) and allowed us to avoid a cyclic dependency between computing the list of targets and resolving `If_file_exists` queries (hidden behind `Lazy_no_targets`).

Thanks to #3052, we no longer need to traverse `Build.t` expressions to compute the list of build targets, and we can therefore remove this bit of complexity.

Note that laziness here is used only to avoid cycles, i.e. it is not a performance optimisation, because we do evaluate everything when computing the list of static dependencies with `Build.static_deps`.

I checked that there is no degradation in performance or memory usage.