### PR TITLE
Set [file_exists] and [eval_pred] as forward declarations

### DIFF
--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -35,6 +35,14 @@ module With_targets : sig
   end
 end
 
+(** This function should be called before analysing build expressions using
+    [static_deps], [lib_deps] or [exec], which all require some file system
+    information. *)
+val set_file_system_accessors :
+     file_exists:(Path.t -> bool)
+  -> eval_pred:(File_selector.t -> Path.Set.t)
+  -> unit
+
 (** Add a set of targets to a build description, turning a target-less [Build.t]
     into [Build.With_targets.t]. *)
 val with_targets : 'a t -> targets:Path.Build.t list -> 'a With_targets.t
@@ -175,24 +183,17 @@ val record_lib_deps : Lib_deps_info.t -> unit t
 
 (** {1 Analysis} *)
 
-(** Compute static dependencies of a build description, given a function to
-    resolve file-existence queries. *)
-val static_deps : _ t -> file_exists:(Path.t -> bool) -> Static_deps.t
+(** Compute static dependencies of a build description. *)
+val static_deps : _ t -> Static_deps.t
 
-(** Compute static library dependencies of a build description, given a function
-    to resolve file-existence queries. *)
-val lib_deps : _ t -> file_exists:(Path.t -> bool) -> Lib_deps_info.t
+(** Compute static library dependencies of a build description. *)
+val lib_deps : _ t -> Lib_deps_info.t
 
 (** {1 Execution} *)
 
-(** Execute a build description, given functions to resolve file-existence
-    queries and file selectors. Returns the result and the set of dynamic
+(** Execute a build description. Returns the result and the set of dynamic
     dependencies discovered during execution. *)
-val exec :
-     'a t
-  -> file_exists:(Path.t -> bool)
-  -> eval_pred:Dep.eval_pred
-  -> 'a * Dep.Set.t
+val exec : 'a t -> 'a * Dep.Set.t
 
 (**/**)
 

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1249,8 +1249,6 @@ end = struct
 
   let eval_pred = Pred.eval
 
-  (* CR-soon amokhov: Memoize file system accessors to make sure the changes are
-     properly tracked between builds when using the file-watching build mode. *)
   let () = Build.set_file_system_accessors ~file_exists ~eval_pred
 
   (* Evaluate a rule and return the action and set of dynamic dependencies *)

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -660,8 +660,7 @@ end = struct
     let id = Internal_rule.Id.gen () in
     { Internal_rule.id
     ; action
-    ; static_deps =
-        Memo.lazy_ (fun () -> Build.static_deps action.build ~file_exists)
+    ; static_deps = Memo.lazy_ (fun () -> Build.static_deps action.build)
     ; context
     ; env
     ; locks
@@ -1250,6 +1249,10 @@ end = struct
 
   let eval_pred = Pred.eval
 
+  (* CR-soon amokhov: Memoize file system accessors to make sure the changes are
+     properly tracked between builds when using the file-watching build mode. *)
+  let () = Build.set_file_system_accessors ~file_exists ~eval_pred
+
   (* Evaluate a rule and return the action and set of dynamic dependencies *)
   let evaluate_action_and_dynamic_deps_memo =
     let f (rule : Internal_rule.t) =
@@ -1257,7 +1260,7 @@ end = struct
         Static_deps.rule_deps (Memo.Lazy.force rule.static_deps)
       in
       let+ () = build_deps rule_deps in
-      Build.exec rule.action.build ~file_exists ~eval_pred
+      Build.exec rule.action.build
     in
     Memo.create "evaluate-action-and-dynamic-deps"
       ~output:(Simple (module Action_and_deps))
@@ -1765,7 +1768,7 @@ let shim_of_build_goal request =
   in
   Internal_rule.shim_of_build_goal
     ~action:(Build.with_no_targets request)
-    ~static_deps:(Build.static_deps request ~file_exists)
+    ~static_deps:(Build.static_deps request)
 
 let build_request ~request =
   let result = Fdecl.create Dyn.Encoder.opaque in
@@ -2002,7 +2005,7 @@ module All_lib_deps : sig
     request:unit Build.t -> Lib_deps_info.t Path.Source.Map.t Context_name.Map.t
 end = struct
   let static_deps_of_request request =
-    Static_deps.paths @@ Build.static_deps request ~file_exists
+    Static_deps.paths @@ Build.static_deps request
 
   let rules_for_files paths =
     Path.Set.fold paths ~init:[] ~f:(fun path acc ->
@@ -2035,9 +2038,7 @@ end = struct
     let rules = rules_for_targets targets in
     let lib_deps =
       List.map rules ~f:(fun rule ->
-          let deps =
-            Build.lib_deps rule.Internal_rule.action.build ~file_exists
-          in
+          let deps = Build.lib_deps rule.Internal_rule.action.build in
           (rule, deps))
     in
     List.fold_left lib_deps ~init:[] ~f:(fun acc (rule, deps) ->


### PR DESCRIPTION
While working on memoizing `Build.static_deps` and `Build.exec` using `Memo`, we realised that `file_exists` and `eval_pred` never change within a single build, so it's better to treat them as top-level bindings instead (which will later turn into proper memoized function to track changes between builds).

Simply referring to `Build_system.file_exists` from within `build.ml` would create a cyclic module dependency, so we set `file_exists` and `eval_pred` via forward declarations. 