### PR TITLE
Memoize [Build.exec] using the memoization framework

### DIFF
--- a/src/dune/build.ml
+++ b/src/dune/build.ml
@@ -347,7 +347,7 @@ end = struct
 
     let id m = m.id
 
-    let to_dyn m = Dyn.Encoder.string m.name
+    let to_dyn m = Dyn.String m.name
 
     let eval m = Exec.exec m.t
   end

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -880,6 +880,9 @@ module Run = struct
   include Run
 end
 
+(** Memoization of polymorphic functions of type ['a input -> 'a output]. The
+    supplied [id] function must be a bijection, i.e. there must be a one-to-one
+    correspondence between [input]s and their [id]s. *)
 module Poly (Function : sig
   type 'a input
 
@@ -920,6 +923,10 @@ struct
     match exec memo (Key.T x) with
     | Value.T (id, res) -> (
       match Type_eq.Id.same id (Function.id x) with
-      | None -> assert false
+      | None ->
+        Code_error.raise
+          "Type_eq.Id.t mismatch in Memo.Poly: the most likely reason is that \
+           the provided Function.id returns different ids for the same input."
+          [ ("Function.name", Dyn.String Function.name) ]
       | Some Type_eq.T -> res )
 end

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -881,7 +881,7 @@ module Run = struct
 end
 
 (** Memoization of polymorphic functions of type ['a input -> 'a output]. The
-    supplied [id] function must be a bijection, i.e. there must be a one-to-one
+    supplied [id] function must be injective, i.e. there must be a one-to-one
     correspondence between [input]s and their [id]s. *)
 module Poly (Function : sig
   type 'a input

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -879,3 +879,47 @@ module Run = struct
 
   include Run
 end
+
+module Poly (Function : sig
+  type 'a input
+
+  type 'a output
+
+  val name : string
+
+  val eval : 'a input -> 'a output
+
+  val to_dyn : _ input -> Dyn.t
+
+  val id : 'a input -> 'a Type_eq.Id.t
+end) =
+struct
+  open Function
+
+  module Key = struct
+    type t = T : 'a input -> t
+
+    let to_dyn (T t) = to_dyn t
+
+    let hash (T t) = Type_eq.Id.hash (id t)
+
+    let equal (T x) (T y) = Type_eq.Id.equal (id x) (id y)
+  end
+
+  module Value = struct
+    type t = T : ('a Type_eq.Id.t * 'a output) -> t
+  end
+
+  let impl (key : Key.t) : Value.t =
+    match key with
+    | Key.T input -> Value.T (id input, eval input)
+
+  let memo = create_hidden name ~input:(module Key) Sync impl
+
+  let eval (type a) (x : a input) : a output =
+    match exec memo (Key.T x) with
+    | Value.T (id, res) -> (
+      match Type_eq.Id.same id (Function.id x) with
+      | None -> assert false
+      | Some Type_eq.T -> res )
+end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -282,3 +282,19 @@ end
 val cell : ('a, 'b, 'f) t -> 'a -> ('a, 'b, 'f) Cell.t
 
 module Implicit_output = Implicit_output
+
+module Poly (Function : sig
+  type 'a input
+
+  type 'a output
+
+  val name : string
+
+  val eval : 'a input -> 'a output
+
+  val to_dyn : _ input -> Dyn.t
+
+  val id : 'a input -> 'a Type_eq.Id.t
+end) : sig
+  val eval : 'a Function.input -> 'a Function.output
+end

--- a/src/stdune/type_eq.ml
+++ b/src/stdune/type_eq.ml
@@ -15,6 +15,13 @@ module Id = struct
 
   type 'a t = (module T with type a = 'a)
 
+  let hash (type a) ((module T) : a t) = Poly.hash T.W
+
+  let equal (type a b) ((module M1) : a t) ((module M2) : b t) =
+    match M1.W with
+    | M2.W -> true
+    | _ -> false
+
   let create (type a) () =
     ( ( module struct
         type nonrec a = a

--- a/src/stdune/type_eq.mli
+++ b/src/stdune/type_eq.mli
@@ -14,6 +14,10 @@ module Id : sig
 
   val create : unit -> 'a t
 
+  val hash : _ t -> int
+
+  val equal : _ t -> _ t -> bool
+
   val same : 'a t -> 'b t -> ('a, 'b) eq option
 end
 with type ('a, 'b) eq := ('a, 'b) t


### PR DESCRIPTION
This PR removes the ad-hoc memoization used in `Build.exec`, switching to `Memo` instead. 

Since `Build.exec` is a polymorphic function and requires some `Type_eq` tricks to memoize with `Memo`, we also add `Memo.Poly` -- a general mechanism for memoizing polymorphic functions.

I checked that there is no significant degradation of performance or memory usage. We do allocate a little more memory due to using `Memo` hash tables, but the overhead is less than 1% when building Dune with Dune.