### PR TITLE
Explicitly enumerate accepted DUNE_CACHE env values

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -542,7 +542,11 @@ let term =
           ~env:(Arg.env_var ~doc "DUNE_STORE_ORIG_SOURCE_DIR")
           ~doc)
   and+ cache_mode =
-    let doc = "Activate binary cache" in
+    let doc =
+      Printf.sprintf "Activate binary cache (%s). Default is `%s'."
+        (Arg.doc_alts_enum Config.Caching.Mode.all)
+        (Config.Caching.Mode.to_string Config.default.cache_mode)
+    in
     Arg.(
       value
       & opt (some (enum Config.Caching.Mode.all)) None

--- a/src/dune/config.mli
+++ b/src/dune/config.mli
@@ -81,6 +81,8 @@ module Caching : sig
     val all : (string * t) list
 
     val decode : t Dune_lang.Decoder.t
+
+    val to_string : t -> string
   end
 
   module Transport : sig


### PR DESCRIPTION
We already have an error message when this variable is incorrectly set, but I think it's a slightly better user experience this way.

We could do something similar for the other `DUNE_CACHE_*` variables if you like the idea.

CC. @mefyl