### PR TITLE
Update the vendored incremental-cycles

### DIFF
--- a/src/dag/dag.ml
+++ b/src/dag/dag.ml
@@ -60,9 +60,7 @@ module Make (Value : Value) : S with type value := Value.t = struct
     let set_parent _ v p = v.info.parent <- Some p
 
     let raw_add_edge _ v w =
-      v.info.deps <- w :: v.info.deps;
-      if v.info.level = w.info.level then
-        w.info.rev_deps <- v :: w.info.rev_deps
+      v.info.deps <- w :: v.info.deps
 
     let raw_add_vertex _ _ = ()
   end

--- a/vendor/incremental-cycles/src/incremental_cycles.ml
+++ b/vendor/incremental-cycles/src/incremental_cycles.ml
@@ -1,247 +1,264 @@
+
 include Incremental_cycles_intf
 
-module Make (Raw_graph : Raw_graph) :
-  S with type graph := Raw_graph.graph and type vertex := Raw_graph.vertex =
+module Make (Raw_graph : Raw_graph) : S
+  with type graph := Raw_graph.graph
+   and type vertex := Raw_graph.vertex =
 struct
-  (* This implements the algorithm of incremental cycle detection described in
-     Section 2 of the following paper:
 
-     A New Approach to Incremental Cycle Detection and Related Problems
+(* This implements the algorithm of incremental cycle detection described in
+   Section 2 of the following paper:
 
-     Bender, M. A., Fineman, J. T., Gilbert, S., & Tarjan, R. E. (2015).
+   A New Approach to Incremental Cycle Detection and Related Problems
 
-     https://dl.acm.org/citation.cfm?id=2756553 *)
+   Bender, M. A., Fineman, J. T., Gilbert, S., & Tarjan, R. E. (2015).
 
-  (******************************************************************************)
-  (* The implementation of the algorithm only depends on an abstract graph
-     structure, here implemented by [Raw_graph].
+   https://dl.acm.org/citation.cfm?id=2756553
+*)
 
-     Here, [raw_graph.ml] provides a concrete implementation, but the proof
-     only relies on the abstract interface it implements. In the final exported
-     code (see the export/ directory), [Raw_graph] becomes a functor parameter. *)
+(******************************************************************************)
+(* The implementation of the algorithm only depends on an abstract graph
+   structure, here implemented by [Raw_graph].
 
-  open Raw_graph
+   Here, [raw_graph.ml] provides a concrete implementation, but the proof
+   only relies on the abstract interface it implements. In the final exported
+   code (see the export/ directory), [Raw_graph] becomes a functor parameter.
+*)
 
-  (******************************************************************************)
-  (* Interruptible fold_left.
+open Raw_graph
 
-     At each step, the client function decides whether it wants to continue (by
-     using [Continue new_accumulator]) or stop (by using [Break return_value]).
+(******************************************************************************)
+(* Interruptible fold_left.
 
-     Ultimately, [interruptible_fold] returns either the last accumulator or
-     the value returned by [Break], along with a boolean indicating whether it
-     was interrupted prematurely. *)
+   At each step, the client function decides whether it wants to continue (by
+   using [Continue new_accumulator]) or stop (by using [Break return_value]).
 
-  type ('a, 'b) interruptible_fold_step =
-    | Continue of 'a
-    | Break of 'b
+   Ultimately, [interruptible_fold] returns either the last accumulator or the
+   value returned by [Break], along with a boolean indicating whether it was
+   interrupted prematurely.
+*)
 
-  let rec interruptible_fold f l acc =
-    match l with
-    | [] -> Continue acc
-    | x :: xs -> (
-      let res = f x acc in
-      match res with
-      | Continue acc -> interruptible_fold f xs acc
-      | Break _ -> res )
+type ('a, 'b) interruptible_fold_step =
+  | Continue of 'a
+  | Break of 'b
 
-  (******************************************************************************)
-  (* The cycle detection algorithm, implemented as an [add_edge] function on
-     [graph], which either successfully inserts the edge, or reports a cycle. *)
+let rec interruptible_fold f l acc =
+  match l with
+  | [] -> Continue acc
+  | x :: xs ->
+    let res = f x acc in
+    match res with
+    | Continue acc -> interruptible_fold f xs acc
+    | Break _ -> res
 
-  type visit_backward_result =
-    | VisitBackwardCompleted
-    | VisitBackwardInterrupted
-    | VisitBackwardCyclic
+(******************************************************************************)
+(* The cycle detection algorithm, implemented as an [add_edge] function on
+   [graph], which either successfully inserts the edge, or reports a cycle. *)
 
-  (* Traverse the graph backwards from entries in [stack], looking for
-     [target], and marking explored vertices with [mark].
+type visit_backward_result =
+  | VisitBackwardCompleted
+  | VisitBackwardInterrupted
+  | VisitBackwardCyclic
 
-     If a path to [target] is found, return [VisitBackwardCyclic].
+(* Traverse the graph backwards from entries in [stack], looking for [target],
+   and marking explored vertices with [mark].
 
-     If [fuel] runs out, return [VisitBackwardInterrupted].
+   If a path to [target] is found, return [VisitBackwardCyclic].
 
-     Otherwise, report that the search was complete with
-     [VisitBackwardCompleted]. *)
-  let rec visit_backward (g : graph) (target : vertex) (mark : mark)
-      (fuel : int) (stack : vertex list) : visit_backward_result =
-    (* fuel >= 0 *)
-    match stack with
-    | [] -> VisitBackwardCompleted
-    | vertex :: stack -> (
-      let res =
-        interruptible_fold
-          (fun y (stack, fuel) ->
-            if fuel = 0 then
-              (* There is no fuel left *)
-              Break true
-            else if is_marked g y mark then
-              (* This vertex has already been visited, skip it *)
-              Continue (stack, fuel - 1)
-            else if vertex_eq y target then
-              (* A path to [target] has been found *)
-              Break false
-            else (
-              set_mark g y mark;
-              set_parent g y vertex;
-              Continue (y :: stack, fuel - 1)
-            ))
-          (get_incoming g vertex) (stack, fuel)
-      in
-      match res with
-      | Break timeout ->
-        if timeout then
-          VisitBackwardInterrupted
-        else (
-          set_parent g target vertex;
-          VisitBackwardCyclic
-        )
-      | Continue (stack, fuel) -> visit_backward g target mark fuel stack )
+   If [fuel] runs out, return [VisitBackwardInterrupted].
 
-  type backward_search_result =
-    | BackwardForward of int * mark
-    | BackwardCyclic
-    | BackwardAcyclic
-
-  (* The whole backwards search phase (Step 2 of the algorithm). Explores the
-     graph backwards starting from [v], and looking for [w]. This function
-     mainly calls [visit_backward] and does some post-processing.
-
-     If [w] is found, return [BackwardCyclic].
-
-     If [w] is not found and the algorithm should continue with the forward
-     search phase, return [BackwardForward (new_w_level, visited)], where
-     [new_w_level] is the level at which [w] needs to be put, and [visited] is
-     the mark of vertices that have been visited during the search.
-
-     If [w] is not found and the algorithm should directly skip to the last
-     step, return [BackwardAcyclic]. *)
-  let backward_search (fuel : int) (g : graph) (v : vertex) (w : vertex) :
-      backward_search_result =
-    let mark = new_mark g in
-    let v_level = get_level g v in
-    set_mark g v mark;
-    match visit_backward g w mark fuel [ v ] with
-    | VisitBackwardCyclic -> BackwardCyclic
-    | VisitBackwardInterrupted ->
-      (* w_level < v_level + 1 *)
-      BackwardForward (v_level + 1, mark)
-    | VisitBackwardCompleted ->
-      let w_level = get_level g w in
-      if w_level = v_level then
-        BackwardAcyclic
-      else
-        (* w_level < v_level *)
-        BackwardForward (v_level, mark)
-
-  type forward_search_result =
-    | ForwardCyclic of vertex * vertex
-    | ForwardCompleted
-
-  (* Traverse the graph forwards. [stack] contains the current working set of
-     vertices; these are at level [new_level] but their neighbors have not been
-     yet all visited.
-
-     Only follow edges that point to vertices with a smaller level, but update
-     the incoming edges sets for all vertices encountered.
-
-     If a vertex that has been visited during the backward search phase is
-     encountered, return [ForwardCyclic]. Otherwise, return [ForwardCompleted]. *)
-  let rec visit_forward (g : graph) (new_level : int) (visited : mark)
-      (stack : vertex list) : forward_search_result =
-    match stack with
-    | [] -> ForwardCompleted
-    | x :: stack -> (
-      let res =
-        interruptible_fold
-          (fun y stack ->
-            if is_marked g y visited then
-              (* We found a path to a marked vertex *)
-              Break y
-            else
-              let y_level = get_level g y in
-              set_parent g y x;
-              if y_level < new_level then (
-                set_level g y new_level;
-                clear_incoming g y;
-                add_incoming g y x;
-                Continue (y :: stack)
-              ) else if y_level = new_level then (
-                add_incoming g y x;
-                Continue stack
-              ) else
-                (* y_level > new_level *)
-                Continue stack)
-          (get_outgoing g x) stack
-      in
-      match res with
-      | Break y -> ForwardCyclic (x, y)
-      | Continue stack -> visit_forward g new_level visited stack )
-
-  (* The whole forward search phase (Step 3 of the algorithm). Explores the
-     graph forwards starting from [w], updating the levels and incoming edges
-     sets.
-
-     This function is a simple wrapper over [visit_forward]. *)
-  let forward_search (g : graph) (w : vertex) (new_w_level : int)
-      (visited : mark) : forward_search_result =
-    clear_incoming g w;
-    set_level g w new_w_level;
-    visit_forward g new_w_level visited [ w ]
-
-  type add_edge_result =
-    | EdgeAdded
-    | EdgeCreatesCycle of (unit -> vertex list)
-
-  let rec list_of_parents (g : graph) (x : vertex) (y : vertex)
-      (acc : vertex list) : vertex list =
-    if vertex_eq x y then
-      acc
-    else
-      let p = get_parent g x in
-      let acc' = p :: acc in
-      if vertex_eq p y then
-        acc'
-      else
-        list_of_parents g p y acc'
-
-  (* (z, t) is an edge of the graph such that: - z has been visited by the
-     forward traversal - t has been visited by the backward traversal
-
-     So the path from w to v is of the form: w -> ... -> z -> t -> ... -> v
-
-     [compute_cycle] returns the list of nodes in that path (including w and
-     v). *)
-  let compute_cycle (g : graph) (v : vertex) (w : vertex) (z : vertex)
-      (t : vertex) =
-    list_of_parents g z w (z :: t :: List.rev (list_of_parents g t v []))
-
-  (* The core of the algorithm, wrapping up the previous phases.
-
-     This efficiently checks if there is a path from [w] to [v]. If there is
-     none, then it adds the edge [(v, w)] to the graph. *)
-  let add_edge_or_detect_cycle (g : graph) (v : vertex) (w : vertex) =
-    let succeed () =
-      raw_add_edge g v w;
-      EdgeAdded
+   Otherwise, report that the search was complete with [VisitBackwardCompleted].
+*)
+let rec visit_backward
+    (g: graph) (target: vertex) (mark: mark)
+    (fuel: int) (stack: vertex list):
+  visit_backward_result
+  =
+  (* fuel >= 0 *)
+  match stack with
+  | [] -> VisitBackwardCompleted
+  | vertex :: stack ->
+    let res = interruptible_fold (fun y (stack, fuel) ->
+      if fuel = 0 then
+        (* There is no fuel left *)
+        Break true
+      else if is_marked g y mark then
+        (* This vertex has already been visited, skip it *)
+        Continue (stack, fuel - 1)
+      else if vertex_eq y target then
+        (* A path to [target] has been found *)
+        Break false
+      else begin
+        set_mark g y mark;
+        set_parent g y vertex;
+        Continue (y :: stack, fuel - 1)
+      end
+    ) (get_incoming g vertex) (stack, fuel)
     in
-    if vertex_eq v w then
-      EdgeCreatesCycle (fun () -> [ v ])
-    else if get_level g w > get_level g v then
-      (* There cannot be a path from [w] to [v], as levels form a
-         pseudo-lexicographic ordering: edges always go to equal or increasing
-         levels. *)
-      succeed ()
-    else
-      match backward_search (get_level g v) g v w with
-      | BackwardCyclic ->
-        EdgeCreatesCycle (fun () -> w :: List.rev (list_of_parents g w v []))
-      | BackwardAcyclic -> succeed ()
-      | BackwardForward (new_level, visited) -> (
-        match forward_search g w new_level visited with
-        | ForwardCyclic (z, t) ->
-          EdgeCreatesCycle (fun () -> compute_cycle g v w z t)
-        | ForwardCompleted -> succeed () )
+    match res with
+    | Break timeout ->
+      if timeout then VisitBackwardInterrupted
+      else (set_parent g target vertex; VisitBackwardCyclic)
+    | Continue (stack, fuel) ->
+      visit_backward g target mark fuel stack
 
-  let add_vertex (g : graph) (v : vertex) = raw_add_vertex g v
+type backward_search_result =
+  | BackwardForward of int * mark
+  | BackwardCyclic
+  | BackwardAcyclic
+
+(* The whole backwards search phase (Step 2 of the algorithm). Explores the
+   graph backwards starting from [v], and looking for [w].
+   This function mainly calls [visit_backward] and does some post-processing.
+
+   If [w] is found, return [BackwardCyclic].
+
+   If [w] is not found and the algorithm should continue with the forward
+   search phase, return [BackwardForward (new_w_level, visited)], where
+   [new_w_level] is the level at which [w] needs to be put, and [visited]
+   is the mark of vertices that have been visited during the search.
+
+   If [w] is not found and the algorithm should directly skip to the last step,
+   return [BackwardAcyclic].
+*)
+let backward_search
+    (fuel: int)
+    (g: graph) (v: vertex) (w: vertex):
+  backward_search_result
+  =
+  let mark = new_mark g in
+  let v_level = get_level g v in
+  set_mark g v mark;
+  match visit_backward g w mark fuel [v] with
+  | VisitBackwardCyclic -> BackwardCyclic
+  | VisitBackwardInterrupted ->
+    (* w_level < v_level + 1 *)
+    BackwardForward (v_level + 1, mark)
+  | VisitBackwardCompleted ->
+    let w_level = get_level g w in
+    if w_level = v_level then
+      BackwardAcyclic
+    else
+      (* w_level < v_level *)
+      BackwardForward (v_level, mark)
+
+type forward_search_result =
+  | ForwardCyclic of vertex * vertex
+  | ForwardCompleted
+
+(* Traverse the graph forwards. [stack] contains the current working set of
+   vertices; these are at level [new_level] but their neighbors have not been
+   yet all visited.
+
+   Only follow edges that point to vertices with a smaller level, but update the
+   incoming edges sets for all vertices encountered.
+
+   If a vertex that has been visited during the backward search phase is
+   encountered, return [ForwardCyclic]. Otherwise, return [ForwardCompleted]. *)
+let rec visit_forward
+    (g: graph) (new_level: int) (visited: mark)
+    (stack: vertex list):
+  forward_search_result
+  =
+  match stack with
+  | [] -> ForwardCompleted
+  | x :: stack ->
+    let res = interruptible_fold (fun y stack ->
+      if is_marked g y visited then
+        (* We found a path to a marked vertex *)
+        Break y
+      else begin
+        let y_level = get_level g y in
+        set_parent g y x;
+        if y_level < new_level then begin
+          set_level g y new_level;
+          clear_incoming g y;
+          add_incoming g y x;
+          Continue (y :: stack)
+        end else if y_level = new_level then begin
+          add_incoming g y x;
+          Continue stack
+        end else (* y_level > new_level *)
+          Continue stack
+      end
+    ) (get_outgoing g x) stack
+    in
+    match res with
+    | Break y -> ForwardCyclic (x, y)
+    | Continue stack -> visit_forward g new_level visited stack
+
+(* The whole forward search phase (Step 3 of the algorithm). Explores the
+   graph forwards starting from [w], updating the levels and incoming edges
+   sets.
+
+   This function is a simple wrapper over [visit_forward].
+*)
+let forward_search
+    (g: graph) (w: vertex) (new_w_level: int) (visited: mark):
+  forward_search_result
+  =
+  clear_incoming g w;
+  set_level g w new_w_level;
+  visit_forward g new_w_level visited [w]
+
+
+type add_edge_result =
+  | EdgeAdded
+  | EdgeCreatesCycle of (unit -> vertex list)
+
+let rec list_of_parents
+  (g: graph) (x: vertex) (y: vertex) (acc: vertex list):
+  vertex list
+  =
+  if vertex_eq x y then acc
+  else
+    let p = get_parent g x in
+    let acc' = p :: acc in
+    if vertex_eq p y then acc'
+    else list_of_parents g p y acc'
+
+(* (z, t) is an edge of the graph such that:
+   - z has been visited by the forward traversal
+   - t has been visited by the backward traversal
+
+   So the path from w to v is of the form:
+   w -> ... -> z -> t -> ... -> v
+
+   [compute_cycle] returns the list of nodes in that path (including w and v).
+*)
+let compute_cycle (g: graph) (v: vertex) (w: vertex) (z: vertex) (t: vertex) =
+  list_of_parents g z w (z :: t :: List.rev (list_of_parents g t v []))
+
+(* The core of the algorithm, wrapping up the previous phases.
+
+   This efficiently checks if there is a path from [w] to [v].
+   If there is none, then it adds the edge [(v, w)] to the graph. *)
+let add_edge_or_detect_cycle (g: graph) (v: vertex) (w: vertex) =
+  let succeed () =
+    raw_add_edge g v w;
+    if get_level g v = get_level g w then
+      add_incoming g w v;
+    EdgeAdded
+  in
+  if vertex_eq v w then
+    EdgeCreatesCycle (fun () -> [v])
+  else if get_level g w > get_level g v then
+    (* There cannot be a path from [w] to [v], as levels form a
+       pseudo-lexicographic ordering: edges always go to equal or increasing
+       levels. *)
+    succeed ()
+  else match backward_search (get_level g v) g v w with
+    | BackwardCyclic ->
+      EdgeCreatesCycle (fun () -> w :: List.rev (list_of_parents g w v []))
+    | BackwardAcyclic -> succeed ()
+    | BackwardForward (new_level, visited) ->
+      match forward_search g w new_level visited with
+      | ForwardCyclic (z, t) ->
+        EdgeCreatesCycle (fun () -> compute_cycle g v w z t)
+      | ForwardCompleted -> succeed ()
+
+let add_vertex (g: graph) (v: vertex) =
+  raw_add_vertex g v
+
 end
+

--- a/vendor/incremental-cycles/src/incremental_cycles.mli
+++ b/vendor/incremental-cycles/src/incremental_cycles.mli
@@ -1,6 +1,47 @@
+(** An incremental cycle detection algorithm for directed graphs. *)
+
+(** {1 Functorial interface} *)
+
+(** Signature for the graph data structure on which the algorithm operates.
+    It is the input signature of the [Make] functor.
+
+   This corresponds to a standard imperative directed graph structure.
+
+   Additionally, extra meta-data is associated to each node, to hold internal
+   data of the cycle detection algorithm. The meta-data is written and accessed
+   by the algorithm through the corresponding [set_*] and [get_*] functions; it
+   must not be modified otherwise.
+
+   The standard graph operations provided by [Raw_graph] are:
+   - adding a new vertex;
+   - adding a new edge between two existing vertices;
+   - returning the list of successors of a vertex;
+   - testing for equality of vertices.
+
+
+   The extra meta-data that [Raw_graph] must provide is:
+   - Vertices can be marked, and it must be possible to generate fresh marks.
+     Intuitively, a mark can be implemented as an integer, and generating a
+     fresh mark as incrementing some mark counter.
+   - Each vertex has an associated integer  "level", which can be read and set.
+   - Each vertex has an associated list of "incoming" vertices.
+   - Each vertex has an associated "parent", which can be read and set to an
+     other vertex of the graph.
+
+   No particular assumption should be made by the implementor of [Raw_graph]
+   about the contents of these fields.
+*)
 module type Raw_graph = Incremental_cycles_intf.Raw_graph
+
+(** Output signature of the functor [Incremental_cycles.Make]. *)
 module type S = Incremental_cycles_intf.S
 
+(** The algorithm is provided as a functor parameterized over the directed graph
+   implementation [Raw_graph].
+
+   NB: The algorithm does not allocate or maintain (long-lived) data itself: it
+   only mutates the graph by calling the operations provided by [Raw_graph].
+*)
 module Make (Raw_graph : Raw_graph) : S
   with type graph := Raw_graph.graph
    and type vertex := Raw_graph.vertex

--- a/vendor/incremental-cycles/src/incremental_cycles_intf.ml
+++ b/vendor/incremental-cycles/src/incremental_cycles_intf.ml
@@ -1,39 +1,157 @@
 module type Raw_graph = sig
-  type mark
+  (** {1 Types} *)
+
+  (** The graph data structure that is modified by the operations below. *)
   type graph
+
+  (** The type of vertices of the graph. *)
   type vertex
 
-  val new_mark : graph -> mark
+  (** The type of marks (each vertex has an associated mark). *)
+  type mark
 
+  (** {1 Standard graph operations} *)
+
+  (** NB: One must {e not} call [raw_add_edge] and [raw_add_vertex] manually, as
+     it would break the internal invariants of the cycle detection algorithm.
+     One must use instead the safe wrappers [add_vertex] and
+     [add_edge_or_detect_cycle] that are provided as output of the
+     [Incremental_cycles.Make] functor. *)
+
+  (** [vertex_eq v1 v2] tests whether vertices [v1] and [v2] are equal. *)
   val vertex_eq : vertex -> vertex -> bool
 
-  val is_marked : graph -> vertex -> mark -> bool
-  val set_mark : graph -> vertex -> mark -> unit
-
-  val get_level : graph -> vertex -> int
-  val set_level : graph -> vertex -> int -> unit
-
-  val get_incoming : graph -> vertex -> vertex list
-  val clear_incoming : graph -> vertex -> unit
-  val add_incoming : graph -> vertex -> vertex -> unit
-
-  val get_parent : graph -> vertex -> vertex
-  val set_parent : graph -> vertex -> vertex -> unit
-
+  (** [get_outgoing g v] returns the list of successors of [v] in the graph. *)
   val get_outgoing : graph -> vertex -> vertex list
 
+  (** [raw_add_edge g v w] inserts a new (directed) arc between vertices [v] and
+     [w].
+
+      [v] and [w] must have been previously added to the graph using
+     [raw_add_vertex], and the arc [v]->[w] must not already be in the graph. *)
   val raw_add_edge : graph -> vertex -> vertex -> unit
+
+  (** [raw_add_vertex g v] inserts a new vertex [v] into the graph.
+
+      - The mark of a new vertex must be some "default mark" which is different
+        from all marks that can be returned by [new_mark].
+      - The level (returned by [get_level]) of a new vertex must be [1].
+      - The incoming vertices (returned by [get_incoming]) of a new vertex
+        must be [\[\]] (the empty list).
+  *)
   val raw_add_vertex : graph -> vertex -> unit
+
+
+  (** {1 Operations on graph meta-data} *)
+
+  (** [new_mark g] generates a fresh mark.
+
+     More specifically, this mark must be different from all the marks
+     previously returned by [new_mark g] (on the same graph [g]). It must also
+     be different from all the marks currently associated to vertices of the
+     graph [g]. *)
+  val new_mark : graph -> mark
+
+  (** [is_marked g v m] tests whether the vertex [v] has mark [m].
+
+     NB: [is_marked g v m] can only hold if [set_mark g v m] has been called
+     previously. *)
+  val is_marked : graph -> vertex -> mark -> bool
+
+  (** [set_mark g v m] sets the mark of vertex [v] to be [m]. *)
+  val set_mark : graph -> vertex -> mark -> unit
+
+  (** [get_level g v] returns the level of node [v].
+
+      It is either the value previously set by [set_level], or the default value
+     for a newly created vertex (i.e. [1], see [raw_add_vertex]). *)
+  val get_level : graph -> vertex -> int
+
+  (** [set_level g v l] sets the level of node [v] to be [l]. *)
+  val set_level : graph -> vertex -> int -> unit
+
+  (** [get_incoming g v] returns the list of "incoming" vertices of node [v].
+
+      It corresponds to either the default value for a newly created vertex
+     (i.e. the empty list, see [raw_add_vertex]), or the result of previous
+     calls to [clear_incoming] and [add_incoming]. *)
+  val get_incoming : graph -> vertex -> vertex list
+
+  (** [clear_incoming g v] sets the list of "incoming" vertices of [v] to be the
+     empty list. *)
+  val clear_incoming : graph -> vertex -> unit
+
+  (** [add_incoming g v w] adds [w] to the list of "incoming" vertices of [v]. *)
+  val add_incoming : graph -> vertex -> vertex -> unit
+
+  (** [get_parent g v] returns the "parent" of node [v], as set by [set_parent].
+
+      {e Note: there is no default value for [get_parent]}. It is fine for
+     [get_parent g v] to fail if it is called while [set_parent g v w] has not
+     be called beforehand. *)
+  val get_parent : graph -> vertex -> vertex
+
+  (** [set_parent g v w] sets the "parent" of node [v] to be [w]. *)
+  val set_parent : graph -> vertex -> vertex -> unit
+
+
+  (** {1 Asymptotic complexity} *)
+
+  (** All the operations provided by [Raw_graph] must run in constant time. *)
 end
 
 module type S = sig
+  (** The [graph] type from [Raw_graph].
+
+     NB: one must always start from an empty [graph], and add vertices and edges
+     using the functions [add_edge_or_detect_cycle] and [add_vertex] provided
+     below. It is {e not} safe to use these functions on a graph manually
+     constructed using the internal operations of [Raw_graph]. *)
   type graph
+
+  (** The [vertex] type from [Raw_graph]. *)
   type vertex
 
+  (** {1 Operations} *)
+
+  (** The result of [add_edge_or_detect_cycle]. *)
   type add_edge_result =
     | EdgeAdded
     | EdgeCreatesCycle of (unit -> vertex list)
 
-  val add_edge_or_detect_cycle : graph -> vertex -> vertex -> add_edge_result
+  (** [add_edge_or_detect_cycle g v w] adds the edge [v]->[w] to the graph [g],
+     provided doing so does not make the graph cyclic.
+
+      This assumes that [v] and [w] have previously been added to the graph
+     using [add_vertex], and that the edge [v]->[w] is not already in the graph.
+
+      - If adding the edge does not make the graph cyclic, the function returns
+     [EdgeAdded], and updates the graph [g].
+
+      - If adding the edge would make the graph cyclic (i.e. there is currently
+     a path from [w] to [v]), the function returns [EdgeCreatesCycle
+     compute_cycle]. Then, [compute_cycle ()] can be called to get the list of
+     vertices that form a path from [w] to [v] (in linear time).
+
+      In the [EdgeCreatesCycle] case, the edge [v]->[w] is not inserted in the
+     graph, but the internal invariants of the graph do not hold anymore. It is
+     {e not} safe to call again [add_edge_or_detect_cycle] or [add_vertex] on
+     the graph.
+  *)
+  val add_edge_or_detect_cycle :
+    graph -> vertex -> vertex ->
+    add_edge_result
+
+  (** [add_vertex g v] adds the vertex [v] to the graph [g]. *)
   val add_vertex : graph -> vertex -> unit
+
+  (** {1 Asymptotic complexity} *)
+
+  (** Inserting [n] vertices and [m] edges (using [add_edge_or_detect_cycle] and
+     [add_vertex]) has complexity [O(m * min(m^1/2, n^2/3) + n)].
+
+      Roughly speaking, in a sparse enough graph (for which this algorithm is
+     optimized), this means that each edge insertion has amortized complexity
+     [O(sqrt(m))] (as opposed to [O(m)] for a naive algorithm).
+  *)
 end

--- a/vendor/update-incremental-cycles.sh
+++ b/vendor/update-incremental-cycles.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=b20ca29dac1a9a3c9fce045122f0273ea88909ae
+version=1e2030a5d5183d84561cde142eecca40e03db2a3
 
 set -e -o pipefail
 


### PR DESCRIPTION
This PR updates the `incremental_cycles` vendored library to its last version.

I want to get this PR in before we start touching `incremental_cycles` as discussed in #2959 . 

This update comes with a minor API change for the [raw_add_edge] function, so I updated dag.ml accordingly. I wanted to make sure that the API change is properly accounted for, as it could be easily overseen.