### PR TITLE
Fix #2848

### DIFF
--- a/src/dune/simple_rules.ml
+++ b/src/dune/simple_rules.ml
@@ -152,6 +152,12 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
     User_error.raise ~loc
       [ Pp.textf "Cannot find directory: %s" (Path.Source.to_string src_in_src)
       ];
+  if Path.Source.equal src_in_src src_dir then
+    User_error.raise ~loc
+      [ Pp.textf
+          "Cannot copy files onto themselves. The format is <dir>/<glob> where \
+           <dir> is not the current directory."
+      ];
   (* add rules *)
   let src_in_build =
     let context = Context.DB.get dir in

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -947,6 +947,14 @@
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias github2848)
+ (deps (package dune) (source_tree test-cases\github2848))
+ (action
+  (chdir
+   test-cases\github2848
+   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias github534)
  (deps (package dune) (source_tree test-cases/github534))
  (action

--- a/test/blackbox-tests/test-cases/github2848/run.t
+++ b/test/blackbox-tests/test-cases/github2848/run.t
@@ -1,0 +1,56 @@
+----------------------------------------------------------------------------------
+Testsuite for https://github.com/ocaml/dune/issues/2848
+(copy_files ...) cannot copy files onto themselves. The format for the argument
+is <dir>/<glob> where <dir> is not the current directory.
+
+  $ cat >sdune <<'EOF'
+  > #!/usr/bin/env bash
+  > DUNE_SANDBOX=symlink dune "$@"
+  > EOF
+  $ chmod +x sdune
+
+----------------------------------------------------------------------------------
+* Good error message when <dir> is the current directory
+
+  $ echo "(lang dune 2.2)" > dune-project
+
+  $ cat >dune <<EOF
+  > (executable (name foo))
+  > (copy_files sub)
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > let () = Bar.bar ()
+  > EOF
+
+  $ mkdir -p sub
+
+  $ cat >sub/bar.ml <<EOF
+  > let bar () = print_endline "Hello, world!"
+  > EOF
+
+  $ ./sdune build
+  File "dune", line 2, characters 12-15:
+  2 | (copy_files sub)
+                  ^^^
+  Error: Cannot copy files onto themselves. The format is <dir>/<glob> where
+  <dir> is not the current directory.
+  [1]
+
+----------------------------------------------------------------------------------
+* Good error message when <dir> is missing
+
+  $ echo "(lang dune 2.2)" > dune-project
+
+  $ cat >dune <<EOF
+  > (executable (name foo))
+  > (copy_files bar.{ml})
+  > EOF
+
+  $ ./sdune build
+  File "dune", line 2, characters 12-20:
+  2 | (copy_files bar.{ml})
+                  ^^^^^^^^
+  Error: Cannot copy files onto themselves. The format is <dir>/<glob> where
+  <dir> is not the current directory.
+  [1]


### PR DESCRIPTION
I'd like to also do some refactoring: to move the rest of the parsing and error-reporting logic to `dune_file.ml` where we typically do such things.

EDIT: Actually, we first need to expand a `String_with_vars.t` and then continue parsing (extracting the directory) afterwards, so I guess we'll need to keep the code in `simple_rules.ml`.