### PR TITLE
Handle Windows paths better in [gen_tests.ml]

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -948,10 +948,10 @@
 
 (rule
  (alias github2848)
- (deps (package dune) (source_tree test-cases\github2848))
+ (deps (package dune) (source_tree test-cases/github2848))
  (action
   (chdir
-   test-cases\github2848
+   test-cases/github2848
    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
 
 (rule

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -74,12 +74,13 @@ module Test = struct
     ; additional_deps : Dune_lang.t list
     }
 
-  let alias_name t =
-    (* Make sure we can split Windows paths. *)
+  let path_separator =
     let dir_sep = Filename.dir_sep in
     assert (String.length dir_sep == 1);
-    let dir_sep = dir_sep.[0] in
-    match String.split t.path ~on:dir_sep with
+    dir_sep.[0]
+
+  let alias_name t =
+    match String.split t.path ~on:path_separator with
     | [] -> assert false
     | dir :: dirs ->
       assert (dir = root_dir);
@@ -133,12 +134,9 @@ module Test = struct
     let enabled_if = Platform.enabled_if t.skip_platforms in
     let dir = dir t in
     (* Make sure we generate paths with forward slashes even on Windows. *)
-    let dir_sep = Filename.dir_sep in
-    assert (String.length dir_sep == 1);
-    let dir_sep = dir_sep.[0] in
     let dir =
       String.map dir ~f:(fun c ->
-          if c == dir_sep then
+          if c == path_separator then
             '/'
           else
             c)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -75,7 +75,11 @@ module Test = struct
     }
 
   let alias_name t =
-    match String.split t.path ~on:'/' with
+    (* Make sure we can split Windows paths. *)
+    let dir_sep = Filename.dir_sep in
+    assert (String.length dir_sep == 1);
+    let dir_sep = dir_sep.[0] in
+    match String.split t.path ~on:dir_sep with
     | [] -> assert false
     | dir :: dirs ->
       assert (dir = root_dir);
@@ -128,6 +132,17 @@ module Test = struct
     in
     let enabled_if = Platform.enabled_if t.skip_platforms in
     let dir = dir t in
+    (* Make sure we generate paths with forward slashes even on Windows. *)
+    let dir_sep = Filename.dir_sep in
+    assert (String.length dir_sep == 1);
+    let dir_sep = dir_sep.[0] in
+    let dir =
+      String.map dir ~f:(fun c ->
+          if c == dir_sep then
+            '/'
+          else
+            c)
+    in
     let filename = filename t in
     let action =
       List


### PR DESCRIPTION
Still not perfect, but this commit allows me to at least generate the right stanza when adding a new test. 

Incidentally, this fixes the incorrect path separator committed in #3080.  