### PR TITLE
Add examples to the manpages of major subcommands

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -111,6 +111,24 @@ let footer =
 
 let copts_sect = "COMMON OPTIONS"
 
+let examples =
+  let block_of_example index (intro, ex) =
+    let prose = `I (string_of_int (index + 1) ^ ".", String.trim intro ^ ":")
+    and code_lines =
+      ex |> String.trim |> String.split_lines
+      |> List.map ~f:(fun codeline -> [ `Noblank; `Pre ("      " ^ codeline) ])
+      |> List.flatten
+      (* suppress initial blank *)
+      |> List.tl
+    in
+    `Blocks (prose :: code_lines)
+  in
+  function
+  | _ :: _ as examples ->
+    let example_blocks = examples |> List.mapi ~f:block_of_example in
+    `Blocks (`S Cmdliner.Manpage.s_examples :: example_blocks)
+  | [] -> `Blocks []
+
 let help_secs =
   [ `S copts_sect
   ; `P "These options are common to all commands."

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -111,23 +111,22 @@ let footer =
 
 let copts_sect = "COMMON OPTIONS"
 
-let examples =
-  let block_of_example index (intro, ex) =
-    let prose = `I (string_of_int (index + 1) ^ ".", String.trim intro ^ ":")
-    and code_lines =
-      ex |> String.trim |> String.split_lines
-      |> List.map ~f:(fun codeline -> [ `Noblank; `Pre ("      " ^ codeline) ])
-      |> List.flatten
-      (* suppress initial blank *)
-      |> List.tl
-    in
-    `Blocks (prose :: code_lines)
-  in
-  function
+let examples = function
+  | [] -> `Blocks []
   | _ :: _ as examples ->
+    let block_of_example index (intro, ex) =
+      let prose = `I (Int.to_string (index + 1) ^ ".", String.trim intro ^ ":")
+      and code_lines =
+        ex |> String.trim |> String.split_lines
+        |> List.concat_map ~f:(fun codeline ->
+               [ `Noblank; `Pre ("      " ^ codeline) ])
+        (* suppress initial blank *)
+        |> List.tl
+      in
+      `Blocks (prose :: code_lines)
+    in
     let example_blocks = examples |> List.mapi ~f:block_of_example in
     `Blocks (`S Cmdliner.Manpage.s_examples :: example_blocks)
-  | [] -> `Blocks []
 
 let help_secs =
   [ `S copts_sect

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -46,6 +46,8 @@ val set_common_other :
     the root the current working directory *)
 val set_dirs : t -> unit
 
+val examples : (string * string) list -> Cmdliner.Manpage.block
+
 val help_secs : Cmdliner.Manpage.block list
 
 val footer : Cmdliner.Manpage.block

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -23,6 +23,11 @@ let man =
           working directory (or the value of $(b,--root) when ran outside of
           the project root)|}
   ; `Blocks Common.help_secs
+  ; Common.examples
+      [ ("Run the executable named `my_exec'", "dune exec my_exec")
+      ; ( "Run the executable defined in `foo.ml' with the argument `arg'"
+        , "dune exec ./foo.exe -- arg" )
+      ]
   ]
 
 let info = Term.info "exec" ~doc ~man

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -31,24 +31,23 @@ let man =
   ; `P
       {|The command can be used to add stanzas to existing dune files as
          well as for creating new dune files and basic component templates.|}
-  ; `S "EXAMPLES"
-  ; `Pre
-      {|
-Define an executable component named 'myexe' in a dune file in the
-current directory:
-
-          dune init exe myexe
-
-Define a library component named 'mylib' in a dune file in the ./src
-directory depending on the core and cmdliner libraries, the ppx_let
-and ppx_inline_test preprocessors, and declared as using inline tests:
-
-          dune init lib mylib src --libs core,cmdliner --ppx ppx_let,ppx_inline_test --inline-tests
-
-Define a library component named mytest in a dune file in the ./test
-directory that depends on mylib:
-
-        dune init test myexe test --libs mylib|}
+  ; Common.examples
+      [ ( {|Define an executable component named `myexe' in a dune file in the
+            current directory
+           |}
+        , {|dune init exe myexe|} )
+      ; ( {|Define a library component named `mylib' in a dune file in the ./src
+            directory depending on the core and cmdliner libraries, the ppx_let
+            and ppx_inline_test preprocessors, and declared as using inline
+            tests"
+           |}
+        , {|dune init lib mylib src --libs core,cmdliner --ppx ppx_let,ppx_inline_test --inline-tests"|}
+        )
+      ; ( {|Define a library component named `mytest' in a dune file in the
+            ./test directory that depends on `mylib'"
+           |}
+        , {|dune init test myexe test --libs mylib|} )
+      ]
   ]
 
 let info = Term.info "init" ~doc ~man

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -32,6 +32,15 @@ let build_targets =
     [ `S "DESCRIPTION"
     ; `P {|Targets starting with a $(b,@) are interpreted as aliases.|}
     ; `Blocks Common.help_secs
+    ; Common.examples
+        [ ("Build all targets in the current source tree", "dune build")
+        ; ("Build targets in the `./foo/bar' directory", "dune build ./foo/bar")
+        ; ( "Build the minimal set of targets required for tooling such as \
+             Merlin (useful for quickly detecting errors)"
+          , "dune build @check" )
+        ; ( "Run all code formatting tools in-place"
+          , "dune build --auto-promote @fmt" )
+        ]
     ]
   in
   let name_ = Arg.info [] ~docv:"TARGET" in
@@ -56,6 +65,13 @@ let runtest =
     ; `P {|This is a short-hand for calling:|}
     ; `Pre {|  dune build @runtest|}
     ; `Blocks Common.help_secs
+    ; Common.examples
+        [ ( "Run all tests in the current source tree (including those that \
+             passed on the last run)"
+          , "dune runtest --force" )
+        ; ( "Run tests sequentially without output buffering"
+          , "dune runtest --no-buffer -j 1" )
+        ]
     ]
   in
   let name_ = Arg.info [] ~docv:"DIR" in
@@ -190,6 +206,14 @@ let default =
               that it is highly tested and productive.
             |}
         ; `Blocks Common.help_secs
+        ; Common.examples
+            [ ("Initialise a new project named `foo'", "dune init project foo")
+            ; ("Build all targets in the current source tree", "dune build")
+            ; ("Run the executable named `bar'", "dune exec bar")
+            ; ("Run all tests in the current source tree", "dune runtest")
+            ; ("Install all components defined in the project", "dune install")
+            ; ("Remove all build artefacts", "dune clean")
+            ]
         ] )
 
 let () =


### PR DESCRIPTION
This partially resolves https://github.com/ocaml/dune/issues/3007 by adding short examples for the `build`, `runtest` and `exec` subcommands (as well as for the main `dune --help` page). For example, `dune exec --help` now contains the following section:

```
EXAMPLES
       1.  Run the executable named `my_exec':

             dune exec my_exec

       2.  Run the executable defined in `foo.ml' with the argument `arg':

             dune exec ./foo.exe -- arg
```

The `EXAMPLES` sections are positioned near the bottom of their respective man-pages [by convention](man7.org/linux/man-pages/man7/man-pages.7.html).