### PR TITLE
[coq] Add `(boot)` library field to handle Coq's stdlib bootstrap.

### DIFF
--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1954,6 +1954,7 @@ module Coq = struct
     ; synopsis : string option
     ; modules : Ordered_set_lang.t
     ; flags : Ordered_set_lang.Unexpanded.t
+    ; boot : bool
     ; libraries : (Loc.t * Lib_name.t) list  (** ocaml libraries *)
     ; loc : Loc.t
     ; enabled_if : Blang.t
@@ -1970,6 +1971,8 @@ module Coq = struct
        and+ public = field_o "public_name" (Public_lib.decode ())
        and+ synopsis = field_o "synopsis" string
        and+ flags = Ordered_set_lang.Unexpanded.field "flags"
+       and+ boot = field_b "boot"
+                     ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 3))
        and+ modules = modules_field "modules"
        and+ libraries =
          field "libraries" (repeat (located Lib_name.decode)) ~default:[]
@@ -1978,7 +1981,7 @@ module Coq = struct
          let loc, res = name in
          (loc, Lib_name.Local.validate (loc, res))
        in
-       { name; public; synopsis; modules; flags; libraries; loc; enabled_if })
+       { name; public; synopsis; modules; flags; boot; libraries; loc; enabled_if })
 
   let best_name t =
     match t.public with

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -356,6 +356,7 @@ module Coq : sig
     ; synopsis : string option
     ; modules : Ordered_set_lang.t
     ; flags : Ordered_set_lang.Unexpanded.t
+    ; boot : bool
     ; libraries : (Loc.t * Lib_name.t) list  (** ocaml libraries *)
     ; loc : Loc.t
     ; enabled_if : Blang.t


### PR DESCRIPTION
We add an experimental `boot` field to the `coq.theory` stanza to mark
that the theory being compiled includes Coq's prelude.

When building the Coq prelude [or it is in scope in a composed build],
we must perform two special things:

- the implicit dependency on `Init.Prelude.vo` must be reflected
- the location of prelude's build artifacts has to be passed using `-coqlib`,
  as Coq heuristics to locate it will fail

There is a small hack in this PR, which is the special handling of the
`Init` library prefix, once we implement per-file flags that could be
relaxed; it doesn't matter much as both `Init` and `Init.Prelude` are
hardcoded into Coq as of today [we will likely lift this restriction
in a 2.0 coq language version]