### PR TITLE
Fix blackbox test discovery

### DIFF
--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -255,10 +255,12 @@ let fold_find path ~init ~f =
     Sys.readdir path
     |> Array.fold_left ~init:acc ~f:(fun acc file ->
            let path = Filename.concat path file in
-           if Sys.is_directory path && (Unix.lstat path).st_kind <> S_LNK then
-             dir path acc
-           else
-             f acc path)
+           let recurse =
+             Sys.is_directory path
+             && (Unix.lstat path).st_kind <> S_LNK
+             && (Filename.basename path <> "_build")
+           in
+           if recurse then dir path acc else f acc path)
   in
   dir path init
 


### PR DESCRIPTION
This should fix the bug where blackbox-tests from `_build` directory are added to the generated dune rules.

I unfortunately was unable to reproduce the bug and therefore to test that fix.