### PR TITLE
Add missing EOF terminators to blackbox tests.

### DIFF
--- a/test/blackbox-tests/test-cases/byte_complete/run.t
+++ b/test/blackbox-tests/test-cases/byte_complete/run.t
@@ -24,6 +24,7 @@ Test the `byte_complete` executable mode
   > CAMLprim value foo() {
   >   return caml_copy_string("OCaml, plus fort que le segfault!");
   > }
+  > EOF
 
   $ echo 'external foo : unit -> string = "foo"' > foo.ml
   $ echo 'print_endline (Foo.foo ())' > prog.ml

--- a/test/blackbox-tests/test-cases/cram/run.t
+++ b/test/blackbox-tests/test-cases/cram/run.t
@@ -21,13 +21,6 @@ The environment is preserved accross phrases
   $TESTCASE_ROOT/toto
   $ cd ..
 
-Broken phrases don't break the system
-
-  $ cat <<EOF
-  > Hello, world!
-  > EOF
-  Hello, world!
-
 Printing stuff with backslashes
 
   $ cat <<EOF

--- a/test/blackbox-tests/test-cases/cram/run.t
+++ b/test/blackbox-tests/test-cases/cram/run.t
@@ -25,6 +25,7 @@ Broken phrases don't break the system
 
   $ cat <<EOF
   > Hello, world!
+  > EOF
   Hello, world!
 
 Printing stuff with backslashes


### PR DESCRIPTION
My shell emits a warning, which breaks the tests.

```
+  /tmp/dune-teste7152a.sh: line 6: warning: here-document at line 1 delimited by end-of-file (wanted `EOF')
```

Signed-off-by: mefyl <mefyl@gruntech.org>