### PR TITLE
Pass ocaml configuration to configurator through a file

### DIFF
--- a/dune-action-plugin.opam
+++ b/dune-action-plugin.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.3"}
   "dune-glob"
   "ppx_expect" {with-test}
   "dune-private-libs" {= version}

--- a/dune-build-info.opam
+++ b/dune-build-info.opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.3"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [

--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.3"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dune-glob.opam
+++ b/dune-glob.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.3"}
   "dune-private-libs" {= version}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dune-private-libs.opam
+++ b/dune-private-libs.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.3"}
   "ocaml" {>= "4.07"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.3)
 (name dune)
 
 (generate_opam_files true)

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -9,4 +9,7 @@
  (flags
   (:standard
    -safe-string
-   (:include flags/flags.sexp))))
+   (:include flags/flags.sexp)))
+ (special_builtin_support
+  (configurator
+   (api_version 1))))

--- a/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/config/run.ml
+++ b/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/config/run.ml
@@ -1,9 +1,14 @@
 module Configurator = Configurator.V1
 
 let () =
-  begin match Sys.getenv "DUNE_CONFIGURATOR" with
-  | exception Not_found -> failwith "DUNE_CONFIGURATOR is not passed"
-  | _ -> print_endline "DUNE_CONFIGURATOR is present"
+  begin match Sys.getenv "INSIDE_DUNE" with
+  | exception Not_found -> failwith "INSIDE_DUNE is not passed"
+  | "1" -> print_endline "INSIDE_DUNE is from an old dune"
+  | dir -> print_endline "INSIDE_DUNE is present";
+    if Sys.file_exists (Filename.concat dir ".dune/configurator") then
+      print_endline ".dune/configurator file present"
+    else
+      print_endline ".dune/configurator file not present"
   end;
   Configurator.main ~name:"config" (fun t ->
     match Configurator.ocaml_config_var t "version" with

--- a/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/run.t
@@ -1,6 +1,7 @@
 Show that config values are present
   $ dune exec config/run.exe
-  DUNE_CONFIGURATOR is present
+  INSIDE_DUNE is present
+  .dune/configurator file present
   version is present
 
 We're able to compile C program successfully

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -288,6 +288,12 @@ let gen_rules ~sctx ~dir components : Build_system.extra_sub_directories_to_keep
   Opam_create.add_rules sctx ~dir;
   let subdirs_to_keep2 : Build_system.extra_sub_directories_to_keep =
     match components with
+    | ".dune" :: _ ->
+      (* Dummy rule to prevent dune from deleting this file. See comment
+         attached to [write_dot_dune_dir] in context.ml *)
+      Super_context.add_rule sctx ~dir
+        (Build.write_file (Path.Build.relative dir "configurator") "");
+      These String.Set.empty
     | ".js" :: rest -> (
       Js_of_ocaml_rules.setup_separate_compilation_rules sctx rest;
       match rest with
@@ -342,7 +348,7 @@ let gen_rules ~sctx ~dir components : Build_system.extra_sub_directories_to_keep
     match components with
     | [] ->
       Build_system.Subdir_set.These
-        (String.Set.of_list [ ".js"; "_doc"; ".ppx" ])
+        (String.Set.of_list [ ".js"; "_doc"; ".ppx"; ".dune" ])
     | _ -> These String.Set.empty
   in
   Build_system.Subdir_set.union_all

--- a/src/dune/lib_info.mli
+++ b/src/dune/lib_info.mli
@@ -46,9 +46,16 @@ module Special_builtin_support : sig
       }
   end
 
+  module Configurator : sig
+    type api_version = V1
+
+    type t = { api_version : api_version }
+  end
+
   type t =
     | Findlib_dynload
     | Build_info of Build_info.t
+    | Configurator of Configurator.t
 
   include Dune_lang.Conv.S with type t := t
 end

--- a/src/dune/link_time_code_gen.ml
+++ b/src/dune/link_time_code_gen.ml
@@ -231,6 +231,10 @@ let handle_special_libs cctx =
           in
           process_libs libs
             ~to_link_rev:(LM.Module (obj_dir, module_) :: Lib lib :: to_link_rev)
-            ~force_linkall:true ) )
+            ~force_linkall:true
+        | Configurator _ ->
+          process_libs libs
+            ~to_link_rev:(LM.Lib lib :: to_link_rev)
+            ~force_linkall ) )
   in
   process_libs all_libs ~to_link_rev:[] ~force_linkall:false


### PR DESCRIPTION
Currently, every time we call a program using `dune-configurator`, it systematically calls `ocamlc -config`. And after the recent changes to cram test, for every shell phrase we call a sanitizer that uses `dune-configurator` (to obtain the various os dependent file extensions).

This is not very efficient.

To avoid this, this PR changes things so that the ocaml configuration is passed from dune to dune-configurator through a file. This file is stored as `_build/<context>/.dune/configurator`. Since we don't have a convenient way to detect that a binary will read this file and we don't want user of configurator to manually add this dependency, we simply create this file eagerly when setting up the context.

The last thing dune needs to pass to `dune-configurator` through an environment variable is the path to this file. I changed the code as follow:
- dune no longer sets `DUNE_CONFIGURATOR`
- instead of setting `INSIDE_DUNE` to just 1, it sets it to the root of the build context
- `dune-configurator` looks for the file at `$INSIDE_DUNE/.dune/configurator`

This  way, if we need to pass other such information in the future we can add more files there.

Finally, this PR adds a field `(special_builtin_support (configurator (api_version v1)))` to `dune-configurator`. It does nothing for now, but hopefully in the future we will make it mean to depend on the `.dune/configurator` file.