### PR TITLE
Split out the cram test sanitizer

### DIFF
--- a/dune
+++ b/dune
@@ -5,7 +5,8 @@
  (_
   (binaries
    (src/ocaml-syntax-shims/pp.exe as ocaml-syntax-shims)
-   test/blackbox-tests/cram.exe)))
+    test/blackbox-tests/cram.exe
+    test/blackbox-tests/sanitizer.exe)))
 
 (rule
  (copy dune-private-libs.opam.template dune-configurator.opam.template))

--- a/example/dune
+++ b/example/dune
@@ -9,7 +9,7 @@
   (chdir
    sample-projects/hello_world
    (progn
-    (run %{exe:../test/blackbox-tests/cram.exe} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (rule
@@ -21,5 +21,5 @@
   (chdir
    sample-projects/with-configure-step
    (progn
-    (run %{exe:../test/blackbox-tests/cram.exe} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))

--- a/otherlibs/action-plugin/test/depend-on-directory-without-targets/dune
+++ b/otherlibs/action-plugin/test/depend-on-directory-without-targets/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/dune
+++ b/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/depends-on-directory-with-glob/dune
+++ b/otherlibs/action-plugin/test/depends-on-directory-with-glob/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/depends-on-its-target-by-read-dir/dune
+++ b/otherlibs/action-plugin/test/depends-on-its-target-by-read-dir/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/depends-on-its-target/dune
+++ b/otherlibs/action-plugin/test/depends-on-its-target/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/dune
+++ b/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/multiple-dynamic-run-within-single-action/dune
+++ b/otherlibs/action-plugin/test/multiple-dynamic-run-within-single-action/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/no-dependencies/dune
+++ b/otherlibs/action-plugin/test/no-dependencies/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/one-absent-dependency/dune
+++ b/otherlibs/action-plugin/test/one-absent-dependency/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/one-dependency-with-chdir/dune
+++ b/otherlibs/action-plugin/test/one-dependency-with-chdir/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/one-dependency/dune
+++ b/otherlibs/action-plugin/test/one-dependency/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/one-directory-dependency/dune
+++ b/otherlibs/action-plugin/test/one-directory-dependency/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/one-target/dune
+++ b/otherlibs/action-plugin/test/one-target/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/one-undeclared-target/dune
+++ b/otherlibs/action-plugin/test/one-undeclared-target/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/ordinary-executable/dune
+++ b/otherlibs/action-plugin/test/ordinary-executable/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/simple-copy/dune
+++ b/otherlibs/action-plugin/test/simple-copy/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/target-in-parent-directory/dune
+++ b/otherlibs/action-plugin/test/target-in-parent-directory/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/action-plugin/test/two-stages-dependency-choose/dune
+++ b/otherlibs/action-plugin/test/two-stages-dependency-choose/dune
@@ -10,7 +10,7 @@
   (chdir
    test
    (progn
-    (run %{bin:cram} -test run.t)
+    (run cram -sanitizer %{bin:sanitizer} run.t)
     (diff? run.t run.t.corrected)))))
 
 (alias

--- a/otherlibs/build-info/test/dune
+++ b/otherlibs/build-info/test/dune
@@ -5,5 +5,5 @@
   (package dune-build-info))
  (action
   (progn
-   (run cram -test %{dep:run.t})
+   (run cram %{dep:run.t} -sanitizer %{bin:sanitizer})
    (diff? run.t run.t.corrected))))

--- a/otherlibs/configurator/test/blackbox-tests/dune
+++ b/otherlibs/configurator/test/blackbox-tests/dune
@@ -11,7 +11,7 @@
   (chdir
    test-cases/configurator
    (progn
-    (run cram -test run.t)
+    (run cram run.t -sanitizer %{bin:sanitizer})
     (diff? run.t run.t.corrected))))
  (enabled_if
   (<> %{ocaml-config:system} win)))
@@ -27,5 +27,5 @@
   (chdir
    test-cases/configurator-gh1166
    (progn
-    (run cram -test run.t)
+    (run cram run.t -sanitizer %{bin:sanitizer})
     (diff? run.t run.t.corrected)))))

--- a/test/blackbox-tests/cram.mll
+++ b/test/blackbox-tests/cram.mll
@@ -8,20 +8,26 @@ type dot_t_block =
   | Command of string list
   | Comment of string list
 
-let cwd = ref (Sys.getcwd ())
-
 (* Translate a path for [sh]. On Windows, [sh] will come from Cygwin
    so if we are a real windows program we need to pass the path
    through [cygpath] *)
 let translate_path_for_sh =
   if not Sys.win32 then
-    fun _ fn -> fn
+    fun fn -> fn
   else
-    fun cfg fn ->
-      Configurator.V1.Process.run_capture_exn cfg "cygpath" [fn]
-      |> String.split_lines
-      |> List.hd_opt
-      |> Option.value ~default:""
+    fun fn ->
+      let fdr, fdw = Unix.pipe () in
+      Unix.set_close_on_exec fdr;
+      let pid =
+        Unix.create_process "cygpath" [|"cygpath"; fn|]
+          Unix.stdin fdw Unix.stderr
+      in
+      Unix.close fdw;
+      let ic = Unix.in_channel_of_descr fdr in
+      let fn = input_line ic in
+      close_in ic;
+      assert (snd (Unix.waitpid [] pid) = Unix.WEXITED 0);
+      fn
 
 (* Quote a filename for sh, independently of whether we are on Windows
    or Unix. On Windows, we still generate a [sh] script so we need to
@@ -39,10 +45,6 @@ let quote_for_sh fn =
 let eol = '\n' | eof
 
 let blank = [' ' '\t' '\r' '\012']
-
-let ext = '.' ['a'-'z' 'A'-'Z' '0'-'9']+
-
-let abs_path = '/' ['a'-'z' 'A'-'Z' '0'-'9' '.' '-' '_' '/']+
 
 rule dot_t_block = parse
   | eof { None }
@@ -102,107 +104,7 @@ and command_cont acc = parse
   | ""
     { Command (List.rev acc)  }
 
-and postprocess_cwd b = parse
-  | eof { Buffer.contents b }
-  | (abs_path as path) {
-      let path =
-        match String.drop_prefix path ~prefix:!cwd with
-        | None -> path
-        | Some path -> "$TESTCASE_ROOT" ^ path
-      in
-      Buffer.add_string b path; postprocess_cwd b lexbuf
-    }
-  | _ as c { Buffer.add_char b c; postprocess_cwd b lexbuf }
-
-and postprocess_ext tbl b = parse
-  | eof { Buffer.contents b }
-  | ([^ '/'] as c) (ext as e)
-      { Buffer.add_char b c;
-        begin match List.assoc tbl e with
-        | Some res -> Buffer.add_string b res
-        | None     -> Buffer.add_string b e
-        end;
-        postprocess_ext tbl b lexbuf
-      }
-  | _ as c { Buffer.add_char b c; postprocess_ext tbl b lexbuf }
-
 {
-  module Configurator = Configurator.V1
-
-  let cwd_replace s =
-    let l = Lexing.from_string s in
-    postprocess_cwd (Buffer.create (String.length s)) l
-
-  let remove_std_arg =
-    let spacem, space = Re.mark (Re.rep Re.space) in
-    let re =
-      [ space
-      ; Re.str "-std="
-      ; Re.rep1 (Re.compl [Re.space])
-      ; space
-      ]
-      |> Re.seq
-      |> Re.compile
-    in
-    fun s -> Re.replace re s ~f:(fun g ->
-      if Re.Mark.test g spacem then
-        " "
-      else
-        "")
-
-  let config_var_replace config : string -> string =
-    let vars =
-      [ "ocamlc_cflags"
-      ; "ocamlc_cppflags"
-      ]
-    in
-    let vars =
-      List.filter_map vars ~f:(fun k ->
-        Configurator.ocaml_config_var config k
-        |> Option.map ~f:(fun v -> (k, v)))
-    in
-    (* we filter out stuff like -std=gnu99 to get the list of C++ flags *)
-    let vars =
-      match List.assoc vars "ocamlc_cflags" with
-      | None -> vars
-      | Some v -> ("cxx_flags", remove_std_arg v) :: vars
-    in
-    let values =
-      List.filter_map vars ~f:(fun (_, v) ->
-        match String.trim v with
-        | "" -> None
-        | v -> Some (Re.str v))
-    in
-    let re = Re.compile (Re.alt values) in
-    fun s -> Re.replace re ~f:(fun _ -> "$flags") s
-
-  let make_ext_replace config =
-    let tbl =
-      let var = Configurator.ocaml_config_var_exn config in
-      let exts =
-      [ var "ext_dll", "$ext_dll"
-      ; var "ext_asm", "$ext_asm"
-      ; var "ext_lib", "$ext_lib"
-      ; var "ext_obj", "$ext_obj"
-      ] in
-      (* need to special case exe since we can only remove this extension in
-         general *)
-      match (
-        match Configurator.ocaml_config_var config "ext_exe" with
-        | Some s -> s
-        | None ->
-          begin match Configurator.ocaml_config_var_exn config "system" with
-          | "Win32" -> ".exe"
-          | _ -> ""
-          end
-      ) with
-      | "" -> exts
-      | ext -> (ext, "") :: exts
-    in
-    List.iter tbl ~f:(fun (e, _) -> assert (e <> ""));
-    fun s ->
-      let l = Lexing.from_string s in
-      postprocess_ext tbl (Buffer.create (String.length s)) l
 
   type version = int * int * int
 
@@ -264,149 +166,127 @@ and postprocess_ext tbl b = parse
     at_exit (fun () -> try Sys.remove fn with _ -> ());
     fn, oc
 
-  let () =
-    let skip_versions = ref [] in
-    let expect_test = ref None in
-    let exit_code = ref 0 in
-    let sanitize = ref None in
-    let args =
-      [ "-skip-versions"
-      , Arg.String (fun s -> skip_versions := parse_skip_versions s)
-      , "VERSION Comma separated versions of ocaml where to skip test"
-      ; "-test"
-      , Arg.String (fun s -> expect_test := Some s)
-      , "FILE expect test file"
-      ; "-sanitize"
-      , Arg.String (fun s -> sanitize := Some s)
-      , "FILE Sanitize the command output contained in this file"
-      ; "-exit-code"
-      , Arg.Set_int exit_code
-      , "NUMBER Exit code of the command for which we are sanitizing the output"
-      ; "-cwd"
-      , Arg.Set_string cwd
-      , "DIR Set the cwd for sanitizing the command output"
+let () =
+  let sanitizer = ref "" in
+  let args =
+    Arg.align
+      [ "-sanitizer"
+      , Arg.Set_string sanitizer
+      , "PROGRAM Program used to sanitize output"
       ]
+  in
+  let expect_test = ref None in
+  let anon s =
+    match !expect_test with
+    | None -> expect_test := Some s
+    | Some _ ->
+      raise (Arg.Bad "Too many input files")
+  in
+  let usage = sprintf "%s [OPTIONS]" (Filename.basename Sys.executable_name) in
+  Arg.parse args anon usage;
+  let expect_test =
+    match !expect_test with
+    | None -> raise (Arg.Bad "Expect test file must be passed")
+    | Some p -> p
+  in
+  Unix.putenv "LC_ALL" "C";
+  let cwd = Sys.getcwd () in
+  run_expect_test expect_test ~f:(fun lexbuf ->
+    let script, oc = open_temp_file ".sh" in
+    let prln fmt = Printf.fprintf oc (fmt ^^ "\n") in
+    (* Shell code written by the user might not be properly
+       terminated. For instance the user might forgot to write
+       [EOF] after a [cat <<EOF]. If we wrote this shell code
+       directly in the main script, it would hide the rest of the
+       script. So instead, we dump each user written shell phrase
+       into a file and then source it in the main script. *)
+    let user_shell_code_file = temp_file ".sh" in
+    let user_shell_code_file_sh_path =
+      translate_path_for_sh  user_shell_code_file
     in
-    Configurator.main ~args ~name:"cram" (fun configurator ->
-      Option.iter !sanitize ~f:(fun fn ->
-        let sanitize_line =
-          let ext_replace = make_ext_replace configurator in
-          fun line ->
-            line
-            |> Ansi_color.strip
-            |> ext_replace
-            |> cwd_replace
-            |> config_var_replace configurator
-        in
-        List.iter (Io.String_path.lines_of_file fn) ~f:(fun line ->
-          Printf.printf "  %s\n" (sanitize_line line));
-        if !exit_code <> 0 then Printf.printf "  [%d]\n" !exit_code;
-        exit 0);
-      let expect_test =
-        match !expect_test with
-        | None -> raise (Arg.Bad "expect test file must be passed")
-        | Some p -> p in
-      begin
-        let ocaml_version =
-          Configurator.ocaml_config_var_exn configurator "version"
-          |> parse_version in
-        if List.exists !skip_versions ~f:(fun (op, v') ->
-          test op ocaml_version v') then
-          exit 0;
-      end;
-      Unix.putenv "LC_ALL" "C";
-      run_expect_test expect_test ~f:(fun lexbuf ->
-        let script, oc = open_temp_file ".sh" in
-        let prln fmt = Printf.fprintf oc (fmt ^^ "\n") in
-        (* Shell code written by the user might not be properly
-           terminated. For instance the user might forgot to write
-           [EOF] after a [cat <<EOF]. If we wrote this shell code
-           directly in the main script, it would hide the rest of the
-           script. So instead, we dump each user written shell phrase
-           into a file and then source it in the main script. *)
-        let user_shell_code_file = temp_file ".sh" in
-        let user_shell_code_file_sh_path =
-          translate_path_for_sh configurator user_shell_code_file
-        in
-        (* Where we store the output of shell code written by the user *)
-        let user_shell_code_output_file = temp_file ".output" in
-        let user_shell_code_output_file_sh_path =
-          translate_path_for_sh configurator user_shell_code_output_file
-        in
-        let executable_name_sh_path =
-          translate_path_for_sh configurator Sys.executable_name
-        in
-        (* Produce the following shell code:
+    (* Where we store the output of shell code written by the user *)
+    let user_shell_code_output_file = temp_file ".output" in
+    let user_shell_code_output_file_sh_path =
+      translate_path_for_sh  user_shell_code_output_file
+    in
+    let sanitizer =
+      if Filename.is_relative !sanitizer then
+        Filename.concat (Sys.getcwd ()) !sanitizer
+      else
+        !sanitizer
+    in
+    let sanitizer_sh_path = translate_path_for_sh sanitizer in
+    (* Produce the following shell code:
 
-           {v
+       {v
              cat <<"EOF_<n>"
              <data>
              EOF_<n>
            v}
 
-           choosing [<n>] such that [CRAM_EOF_<n>] doesn't appear in
-           [<data>]. *)
-        let cat_eof ?dest lines =
-          let rec loop n =
-            let sentinel = if n = 0 then "EOF" else sprintf "EOF%d" n in
-            if List.mem sentinel ~set:lines then
-              loop (n + 1)
+       choosing [<n>] such that [CRAM_EOF_<n>] doesn't appear in
+       [<data>]. *)
+    let cat_eof ?dest lines =
+      let rec loop n =
+        let sentinel = if n = 0 then "EOF" else sprintf "EOF%d" n in
+        if List.mem sentinel ~set:lines then
+          loop (n + 1)
+        else
+          sentinel
+      in
+      let sentinel = loop 0 in
+      (match dest with
+       | None -> prln "cat <<%S" sentinel
+       | Some fn -> prln "cat >%s <<%S" (quote_for_sh fn) sentinel);
+      List.iter lines ~f:(prln "%s");
+      prln "%s" sentinel
+    in
+    let rec loop () =
+      match dot_t_block lexbuf with
+      | None -> close_out oc
+      | Some block ->
+        match block with
+        | Comment lines ->
+          cat_eof lines;
+          loop ()
+        | Command lines ->
+          cat_eof (List.mapi lines ~f:(fun i line ->
+            if i = 0 then
+              "  $ " ^ line
             else
-              sentinel
-          in
-          let sentinel = loop 0 in
-          (match dest with
-           | None -> prln "cat <<%S" sentinel
-           | Some fn -> prln "cat >%s <<%S" (quote_for_sh fn) sentinel);
-          List.iter lines ~f:(prln "%s");
-          prln "%s" sentinel
-        in
-        let rec loop () =
-          match dot_t_block lexbuf with
-          | None -> close_out oc
-          | Some block ->
-            match block with
-            | Comment lines ->
-              cat_eof lines;
-              loop ()
-            | Command lines ->
-              cat_eof (List.mapi lines ~f:(fun i line ->
-                if i = 0 then
-                  "  $ " ^ line
-                else
-                  "  > " ^ line));
-              cat_eof lines ~dest:user_shell_code_file;
-              prln ". %s > %s 2>&1"
-                (quote_for_sh user_shell_code_file_sh_path)
-                (quote_for_sh user_shell_code_output_file_sh_path);
-              prln {|%s -cwd %s -exit-code $? -sanitize %s|}
-                (quote_for_sh executable_name_sh_path)
-                (quote_for_sh !cwd)
-                (quote_for_sh user_shell_code_output_file);
-              loop ()
-        in
-        loop ();
-        let output_file = temp_file ".output" in
-        let fd = Unix.openfile output_file [O_WRONLY; O_TRUNC] 0 in
-        let pid =
-          Unix.create_process "sh" [|"sh"; script|]
-            Unix.stdin fd fd
-        in
-        Unix.close fd;
-        let n =
-          match snd (Unix.waitpid [] pid) with
-          | WEXITED n -> n
-          | _ -> 255
-        in
-        let output = Io.String_path.read_file output_file in
-        if n <> 0 then begin
-          Printf.eprintf "Generated cram script exited with code %d!\n" n;
-          Printf.eprintf "Script:\n";
-          let script = Io.String_path.read_file script in
-          List.iter (String.split_lines script) ~f:(Printf.eprintf "| %s\n");
-          Printf.eprintf "Script output:\n";
-          List.iter (String.split_lines output) ~f:(Printf.eprintf "| %s\n");
-          exit 1
-        end;
-        output))
+              "  > " ^ line));
+          cat_eof lines ~dest:user_shell_code_file;
+          prln ". %s > %s 2>&1"
+            (quote_for_sh user_shell_code_file_sh_path)
+            (quote_for_sh user_shell_code_output_file_sh_path);
+          prln {|%s -cwd %s -exit-code $? %s|}
+            (quote_for_sh sanitizer_sh_path)
+            (quote_for_sh cwd)
+            (quote_for_sh user_shell_code_output_file);
+          loop ()
+    in
+    loop ();
+    let output_file = temp_file ".output" in
+    let fd = Unix.openfile output_file [O_WRONLY; O_TRUNC] 0 in
+    let pid =
+      Unix.create_process "sh" [|"sh"; script|]
+        Unix.stdin fd fd
+    in
+    Unix.close fd;
+    let n =
+      match snd (Unix.waitpid [] pid) with
+      | WEXITED n -> n
+      | _ -> 255
+    in
+    let output = Io.String_path.read_file output_file in
+    if n <> 0 then begin
+      Printf.eprintf "Generated cram script exited with code %d!\n" n;
+      Printf.eprintf "Script:\n";
+      let script = Io.String_path.read_file script in
+      List.iter (String.split_lines script) ~f:(Printf.eprintf "| %s\n");
+      Printf.eprintf "Script output:\n";
+      List.iter (String.split_lines output) ~f:(Printf.eprintf "| %s\n");
+      exit 1
+    end;
+    output)
 }

--- a/test/blackbox-tests/dune
+++ b/test/blackbox-tests/dune
@@ -3,7 +3,12 @@
 (executable
  (name cram)
  (modules cram)
- (libraries stdune dune_re dune configurator))
+ (libraries stdune dune))
+
+(executable
+ (name sanitizer)
+ (modules sanitizer)
+ (libraries stdune dune_re configurator))
 
 (ocamllex cram)
 

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -4,7 +4,9 @@
  (action
   (chdir
    test-cases/action-modifying-a-dependency
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias aliases)
@@ -12,7 +14,9 @@
  (action
   (chdir
    test-cases/aliases
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias all-alias)
@@ -20,7 +24,9 @@
  (action
   (chdir
    test-cases/all-alias
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias all-promotions)
@@ -28,7 +34,9 @@
  (action
   (chdir
    test-cases/all-promotions
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias bad-alias-error)
@@ -36,7 +44,9 @@
  (action
   (chdir
    test-cases/bad-alias-error
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias block-strings)
@@ -44,7 +54,9 @@
  (action
   (chdir
    test-cases/block-strings
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias byte-code-only)
@@ -52,7 +64,9 @@
  (action
   (chdir
    test-cases/byte-code-only
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias byte_complete)
@@ -60,7 +74,9 @@
  (action
   (chdir
    test-cases/byte_complete
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias c-stubs)
@@ -68,7 +84,9 @@
  (action
   (chdir
    test-cases/c-stubs
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias check-alias)
@@ -76,7 +94,9 @@
  (action
   (chdir
    test-cases/check-alias
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias cinaps)
@@ -84,7 +104,9 @@
  (action
   (chdir
    test-cases/cinaps
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias cmdliner-dep-conf)
@@ -92,7 +114,9 @@
  (action
   (chdir
    test-cases/cmdliner-dep-conf
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias contents-depends-on-glob)
@@ -100,7 +124,9 @@
  (action
   (chdir
    test-cases/contents-depends-on-glob
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias copy-files-non-sub-dir-error)
@@ -108,7 +134,9 @@
  (action
   (chdir
    test-cases/copy-files-non-sub-dir-error
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias copy_files)
@@ -116,7 +144,9 @@
  (action
   (chdir
    test-cases/copy_files
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias coq)
@@ -124,7 +154,9 @@
  (action
   (chdir
    test-cases/coq
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias corrections)
@@ -132,7 +164,9 @@
  (action
   (chdir
    test-cases/corrections
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias cram)
@@ -140,7 +174,9 @@
  (action
   (chdir
    test-cases/cram
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias cross-compilation)
@@ -148,7 +184,9 @@
  (action
   (chdir
    test-cases/cross-compilation
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias custom-build-dir)
@@ -156,7 +194,9 @@
  (action
   (chdir
    test-cases/custom-build-dir
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias custom-cross-compilation)
@@ -164,7 +204,9 @@
  (action
   (chdir
    test-cases/custom-cross-compilation
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias cxx-extension)
@@ -172,7 +214,9 @@
  (action
   (chdir
    test-cases/cxx-extension
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias cycle-detection-symlinks-2863)
@@ -180,7 +224,9 @@
  (action
   (chdir
    test-cases/cycle-detection-symlinks-2863
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias default-targets)
@@ -188,7 +234,9 @@
  (action
   (chdir
    test-cases/default-targets
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dep-on-dir-that-does-not-exist)
@@ -196,7 +244,9 @@
  (action
   (chdir
    test-cases/dep-on-dir-that-does-not-exist
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dep-vars)
@@ -204,7 +254,9 @@
  (action
   (chdir
    test-cases/dep-vars
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias depend-on-the-universe)
@@ -212,7 +264,9 @@
  (action
   (chdir
    test-cases/depend-on-the-universe
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias deprecated-library-name)
@@ -220,7 +274,9 @@
  (action
   (chdir
    test-cases/deprecated-library-name
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias deps-conf-vars)
@@ -228,7 +284,9 @@
  (action
   (chdir
    test-cases/deps-conf-vars
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dialects)
@@ -236,7 +294,9 @@
  (action
   (chdir
    test-cases/dialects
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dir-target-dep)
@@ -244,7 +304,9 @@
  (action
   (chdir
    test-cases/dir-target-dep
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias disable-promotion)
@@ -252,7 +314,9 @@
  (action
   (chdir
    test-cases/disable-promotion
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias double-echo)
@@ -260,7 +324,9 @@
  (action
   (chdir
    test-cases/double-echo
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-build-dir-exec-1101)
@@ -268,7 +334,9 @@
  (action
   (chdir
    test-cases/dune-build-dir-exec-1101
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-dedup)
@@ -276,7 +344,9 @@
  (action
   (chdir
    test-cases/dune-cache/dedup
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-dedup-direct)
@@ -284,7 +354,9 @@
  (action
   (chdir
    test-cases/dune-cache/dedup-direct
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-dedup-direct-copy)
@@ -292,7 +364,9 @@
  (action
   (chdir
    test-cases/dune-cache/dedup-direct-copy
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-promote)
@@ -300,7 +374,9 @@
  (action
   (chdir
    test-cases/dune-cache/promote
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-promote-copy)
@@ -308,7 +384,9 @@
  (action
   (chdir
    test-cases/dune-cache/promote-copy
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-promote-direct)
@@ -316,7 +394,9 @@
  (action
   (chdir
    test-cases/dune-cache/promote-direct
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-promote-direct-copy)
@@ -324,7 +404,9 @@
  (action
   (chdir
    test-cases/dune-cache/promote-direct-copy
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-promotion-in-source-tree)
@@ -334,7 +416,9 @@
  (action
   (chdir
    test-cases/dune-cache/promotion-in-source-tree
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-symlink)
@@ -342,7 +426,9 @@
  (action
   (chdir
    test-cases/dune-cache/symlink
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-symlink-direct)
@@ -350,7 +436,9 @@
  (action
   (chdir
    test-cases/dune-cache/symlink-direct
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-cache-trim)
@@ -358,7 +446,9 @@
  (action
   (chdir
    test-cases/dune-cache/trim
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
  (enabled_if (<> %{ocaml-config:system} macosx)))
 
 (rule
@@ -367,7 +457,9 @@
  (action
   (chdir
    test-cases/dune-init
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-jbuild-var-case)
@@ -375,7 +467,9 @@
  (action
   (chdir
    test-cases/dune-jbuild-var-case
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-package)
@@ -383,7 +477,9 @@
  (action
   (chdir
    test-cases/dune-package
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-ppx-driver-system)
@@ -391,7 +487,9 @@
  (action
   (chdir
    test-cases/dune-ppx-driver-system
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-project-edition)
@@ -399,7 +497,9 @@
  (action
   (chdir
    test-cases/dune-project-edition
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-project-meta)
@@ -407,7 +507,9 @@
  (action
   (chdir
    test-cases/dune-project-meta
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune-project-no-opam)
@@ -415,7 +517,9 @@
  (action
   (chdir
    test-cases/dune-project-no-opam
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dune_memory-and-the-universe)
@@ -423,7 +527,9 @@
  (action
   (chdir
    test-cases/dune_memory-and-the-universe
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias dup-fields)
@@ -431,7 +537,9 @@
  (action
   (chdir
    test-cases/dup-fields
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias duplicate-c-cxx)
@@ -439,7 +547,9 @@
  (action
   (chdir
    test-cases/duplicate-c-cxx
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias duplicate-c-cxx-obj)
@@ -447,7 +557,9 @@
  (action
   (chdir
    test-cases/duplicate-c-cxx-obj
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias duplicate-project-names)
@@ -455,7 +567,9 @@
  (action
   (chdir
    test-cases/duplicate-project-names
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias duplicate-target-no-loc)
@@ -463,7 +577,9 @@
  (action
   (chdir
    test-cases/duplicate-target-no-loc
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias embed-jbuild)
@@ -471,7 +587,9 @@
  (action
   (chdir
    test-cases/embed-jbuild
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias enabled_if)
@@ -479,7 +597,9 @@
  (action
   (chdir
    test-cases/enabled_if
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-and-flags-include)
@@ -487,7 +607,9 @@
  (action
   (chdir
    test-cases/env/env-and-flags-include
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-bin-pform)
@@ -495,7 +617,9 @@
  (action
   (chdir
    test-cases/env/env-bin-pform
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-bins)
@@ -503,7 +627,9 @@
  (action
   (chdir
    test-cases/env/env-bins
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-cflags)
@@ -512,8 +638,9 @@
   (chdir
    test-cases/env/env-cflags
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.06.0)))
 
 (rule
  (alias env-env-dune-file)
@@ -521,7 +648,9 @@
  (action
   (chdir
    test-cases/env/env-dune-file
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-simple)
@@ -530,8 +659,9 @@
   (chdir
    test-cases/env/env-simple
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.06.0)))
 
 (rule
  (alias env-env-tracking)
@@ -539,7 +669,9 @@
  (action
   (chdir
    test-cases/env/env-tracking
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-var-expansion)
@@ -547,7 +679,9 @@
  (action
   (chdir
    test-cases/env/env-var-expansion
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-env-variables)
@@ -555,7 +689,9 @@
  (action
   (chdir
    test-cases/env/env-variables
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias env-envs-and-contexts)
@@ -563,7 +699,9 @@
  (action
   (chdir
    test-cases/env/envs-and-contexts
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias exclude-missing-module)
@@ -571,7 +709,9 @@
  (action
   (chdir
    test-cases/exclude-missing-module
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias exe-name-mangle)
@@ -579,7 +719,9 @@
  (action
   (chdir
    test-cases/exe-name-mangle
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias exec-cmd)
@@ -587,7 +729,9 @@
  (action
   (chdir
    test-cases/exec-cmd
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias exec-missing)
@@ -595,7 +739,9 @@
  (action
   (chdir
    test-cases/exec-missing
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias exes-with-c)
@@ -603,7 +749,9 @@
  (action
   (chdir
    test-cases/exes-with-c
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias explicit_js_mode)
@@ -611,7 +759,9 @@
  (action
   (chdir
    test-cases/explicit_js_mode
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias external-lib-deps)
@@ -619,7 +769,9 @@
  (action
   (chdir
    test-cases/external-lib-deps
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias extra-lang-line)
@@ -627,7 +779,9 @@
  (action
   (chdir
    test-cases/extra-lang-line
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias fallback-dune)
@@ -635,7 +789,9 @@
  (action
   (chdir
    test-cases/fallback-dune
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias fdo)
@@ -644,8 +800,9 @@
   (chdir
    test-cases/fdo
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.11.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.11.0)))
 
 (rule
  (alias findlib)
@@ -653,7 +810,9 @@
  (action
   (chdir
    test-cases/findlib
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias findlib-dynload)
@@ -661,7 +820,9 @@
  (action
   (chdir
    test-cases/findlib-dynload
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias findlib-error)
@@ -669,7 +830,9 @@
  (action
   (chdir
    test-cases/findlib-error
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias forbidden_libraries)
@@ -677,7 +840,9 @@
  (action
   (chdir
    test-cases/forbidden_libraries
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias force-test)
@@ -685,7 +850,9 @@
  (action
   (chdir
    test-cases/force-test
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias foreign-library)
@@ -693,7 +860,9 @@
  (action
   (chdir
    test-cases/foreign-library
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias foreign-stubs)
@@ -701,7 +870,9 @@
  (action
   (chdir
    test-cases/foreign-stubs
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias format-dune-file)
@@ -709,7 +880,9 @@
  (action
   (chdir
    test-cases/format-dune-file
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias formatting)
@@ -717,7 +890,9 @@
  (action
   (chdir
    test-cases/formatting
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias gen-opam-install-file)
@@ -725,7 +900,9 @@
  (action
   (chdir
    test-cases/gen-opam-install-file
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1019)
@@ -733,7 +910,9 @@
  (action
   (chdir
    test-cases/github1019
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1099)
@@ -741,7 +920,9 @@
  (action
   (chdir
    test-cases/github1099
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1231)
@@ -749,7 +930,9 @@
  (action
   (chdir
    test-cases/github1231
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1342)
@@ -757,7 +940,9 @@
  (action
   (chdir
    test-cases/github1342
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1372)
@@ -765,7 +950,9 @@
  (action
   (chdir
    test-cases/github1372
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1395)
@@ -773,7 +960,9 @@
  (action
   (chdir
    test-cases/github1395
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1426)
@@ -781,7 +970,9 @@
  (action
   (chdir
    test-cases/github1426
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1529)
@@ -789,7 +980,9 @@
  (action
   (chdir
    test-cases/github1529
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1541)
@@ -797,7 +990,9 @@
  (action
   (chdir
    test-cases/github1541
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1549)
@@ -805,7 +1000,9 @@
  (action
   (chdir
    test-cases/github1549
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1560)
@@ -813,7 +1010,9 @@
  (action
   (chdir
    test-cases/github1560
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1616)
@@ -821,7 +1020,9 @@
  (action
   (chdir
    test-cases/github1616
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1811)
@@ -829,7 +1030,9 @@
  (action
   (chdir
    test-cases/github1811
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1855)
@@ -837,7 +1040,9 @@
  (action
   (chdir
    test-cases/github1855
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1856)
@@ -845,7 +1050,9 @@
  (action
   (chdir
    test-cases/github1856
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github1946)
@@ -853,7 +1060,9 @@
  (action
   (chdir
    test-cases/github1946
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github20)
@@ -861,7 +1070,9 @@
  (action
   (chdir
    test-cases/github20
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2033)
@@ -869,7 +1080,9 @@
  (action
   (chdir
    test-cases/github2033
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2061)
@@ -877,7 +1090,9 @@
  (action
   (chdir
    test-cases/github2061
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2123)
@@ -885,7 +1100,9 @@
  (action
   (chdir
    test-cases/github2123
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2206)
@@ -893,7 +1110,9 @@
  (action
   (chdir
    test-cases/github2206
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2228)
@@ -901,7 +1120,9 @@
  (action
   (chdir
    test-cases/github2228
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2272)
@@ -909,7 +1130,9 @@
  (action
   (chdir
    test-cases/github2272
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github24)
@@ -917,7 +1140,9 @@
  (action
   (chdir
    test-cases/github24
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2499)
@@ -925,7 +1150,9 @@
  (action
   (chdir
    test-cases/github2499
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github25)
@@ -936,7 +1163,9 @@
    ./findlib-packages
    (chdir
     test-cases/github25
-    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
+    (progn
+     (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+     (diff? run.t run.t.corrected))))))
 
 (rule
  (alias github2584)
@@ -944,7 +1173,9 @@
  (action
   (chdir
    test-cases/github2584
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2629)
@@ -952,7 +1183,9 @@
  (action
   (chdir
    test-cases/github2629
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2681)
@@ -960,7 +1193,9 @@
  (action
   (chdir
    test-cases/github2681
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2848)
@@ -968,7 +1203,9 @@
  (action
   (chdir
    test-cases/github2848
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github534)
@@ -976,7 +1213,9 @@
  (action
   (chdir
    test-cases/github534
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github568)
@@ -984,7 +1223,9 @@
  (action
   (chdir
    test-cases/github568
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github597)
@@ -992,7 +1233,9 @@
  (action
   (chdir
    test-cases/github597
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github644)
@@ -1000,7 +1243,9 @@
  (action
   (chdir
    test-cases/github644
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github660)
@@ -1008,7 +1253,9 @@
  (action
   (chdir
    test-cases/github660
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github734)
@@ -1016,7 +1263,9 @@
  (action
   (chdir
    test-cases/github734
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github759)
@@ -1024,7 +1273,9 @@
  (action
   (chdir
    test-cases/github759
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github761)
@@ -1032,7 +1283,9 @@
  (action
   (chdir
    test-cases/github761
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github764)
@@ -1040,7 +1293,9 @@
  (action
   (chdir
    test-cases/github764
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
  (enabled_if (<> %{ocaml-config:system} win)))
 
 (rule
@@ -1049,7 +1304,9 @@
  (action
   (chdir
    test-cases/github784
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github992)
@@ -1057,7 +1314,9 @@
  (action
   (chdir
    test-cases/github992
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias glob-deps)
@@ -1065,7 +1324,9 @@
  (action
   (chdir
    test-cases/glob-deps
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias glob-deps-change)
@@ -1073,7 +1334,9 @@
  (action
   (chdir
    test-cases/glob-deps-change
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias hints-root-executables)
@@ -1081,7 +1344,9 @@
  (action
   (chdir
    test-cases/hints-root-executables
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias ignored_subdirs)
@@ -1089,7 +1354,9 @@
  (action
   (chdir
    test-cases/ignored_subdirs
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias include-loop)
@@ -1097,7 +1364,9 @@
  (action
   (chdir
    test-cases/include-loop
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias include-qualified)
@@ -1105,7 +1374,9 @@
  (action
   (chdir
    test-cases/include-qualified
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias incremental-rebuilds)
@@ -1113,7 +1384,9 @@
  (action
   (chdir
    test-cases/incremental-rebuilds
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias inline_tests)
@@ -1121,7 +1394,9 @@
  (action
   (chdir
    test-cases/inline_tests
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-dry-run)
@@ -1129,7 +1404,9 @@
  (action
   (chdir
    test-cases/install-dry-run
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-libdir)
@@ -1137,7 +1414,9 @@
  (action
   (chdir
    test-cases/install-libdir
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-mandir)
@@ -1145,7 +1424,9 @@
  (action
   (chdir
    test-cases/install-mandir
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-multiple-contexts)
@@ -1153,7 +1434,9 @@
  (action
   (chdir
    test-cases/install-multiple-contexts
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-partial-package)
@@ -1161,7 +1444,9 @@
  (action
   (chdir
    test-cases/install-partial-package
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-rule-order)
@@ -1169,7 +1454,9 @@
  (action
   (chdir
    test-cases/install-rule-order
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-single-section)
@@ -1177,7 +1464,9 @@
  (action
   (chdir
    test-cases/install-single-section
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias install-with-var)
@@ -1185,7 +1474,9 @@
  (action
   (chdir
    test-cases/install-with-var
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias installable-dup-private-libs)
@@ -1193,7 +1484,9 @@
  (action
   (chdir
    test-cases/installable-dup-private-libs
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias intf-only)
@@ -1201,7 +1494,9 @@
  (action
   (chdir
    test-cases/intf-only
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias invalid-dune-package)
@@ -1209,7 +1504,9 @@
  (action
   (chdir
    test-cases/invalid-dune-package
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias js_of_ocaml)
@@ -1220,7 +1517,9 @@
    %{bin:node}
    (chdir
     test-cases/js_of_ocaml
-    (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected))))))
+    (progn
+     (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+     (diff? run.t run.t.corrected))))))
 
 (rule
  (alias lib)
@@ -1228,7 +1527,9 @@
  (action
   (chdir
    test-cases/lib
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias lib-available)
@@ -1236,7 +1537,9 @@
  (action
   (chdir
    test-cases/lib-available
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias lib-errors)
@@ -1244,7 +1547,9 @@
  (action
   (chdir
    test-cases/lib-errors
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias link-deps)
@@ -1252,7 +1557,9 @@
  (action
   (chdir
    test-cases/link-deps
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias link-includes)
@@ -1260,7 +1567,9 @@
  (action
   (chdir
    test-cases/link-includes
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias lint)
@@ -1268,7 +1577,9 @@
  (action
   (chdir
    test-cases/lint
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias loop)
@@ -1276,7 +1587,9 @@
  (action
   (chdir
    test-cases/loop
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias macro-expand-error)
@@ -1284,7 +1597,9 @@
  (action
   (chdir
    test-cases/macro-expand-error
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias menhir-cmly)
@@ -1292,7 +1607,9 @@
  (action
   (chdir
    test-cases/menhir/cmly
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias menhir-env)
@@ -1300,7 +1617,9 @@
  (action
   (chdir
    test-cases/menhir/env
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias menhir-general)
@@ -1308,7 +1627,9 @@
  (action
   (chdir
    test-cases/menhir/general
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias menhir-general-2.0)
@@ -1316,7 +1637,9 @@
  (action
   (chdir
    test-cases/menhir/general-2.0
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias menhir-promote)
@@ -1324,7 +1647,9 @@
  (action
   (chdir
    test-cases/menhir/promote
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias merlin-allow_approximate_merlin)
@@ -1334,7 +1659,9 @@
  (action
   (chdir
    test-cases/merlin/allow_approximate_merlin
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias merlin-merlin-tests)
@@ -1342,7 +1669,9 @@
  (action
   (chdir
    test-cases/merlin/merlin-tests
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias merlin-src-dirs-of-deps)
@@ -1350,7 +1679,9 @@
  (action
   (chdir
    test-cases/merlin/src-dirs-of-deps
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias meta-gen)
@@ -1358,7 +1689,9 @@
  (action
   (chdir
    test-cases/meta-gen
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias misc)
@@ -1366,7 +1699,9 @@
  (action
   (chdir
    test-cases/misc
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias missing-loc-run)
@@ -1374,7 +1709,9 @@
  (action
   (chdir
    test-cases/missing-loc-run
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias multi-dir)
@@ -1382,7 +1719,9 @@
  (action
   (chdir
    test-cases/multi-dir
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias multiple-targets)
@@ -1390,7 +1729,9 @@
  (action
   (chdir
    test-cases/multiple-targets
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias name-field-validation)
@@ -1398,7 +1739,9 @@
  (action
   (chdir
    test-cases/name-field-validation
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias no-installable-mode)
@@ -1406,7 +1749,9 @@
  (action
   (chdir
    test-cases/no-installable-mode
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias no-name-field)
@@ -1414,7 +1759,9 @@
  (action
   (chdir
    test-cases/no-name-field
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias null-dep)
@@ -1422,7 +1769,9 @@
  (action
   (chdir
    test-cases/null-dep
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias ocaml-config-macro)
@@ -1430,7 +1779,9 @@
  (action
   (chdir
    test-cases/ocaml-config-macro
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias ocaml-syntax)
@@ -1438,7 +1789,9 @@
  (action
   (chdir
    test-cases/ocaml-syntax
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias ocamldep-multi-stanzas)
@@ -1446,7 +1799,9 @@
  (action
   (chdir
    test-cases/ocamldep-multi-stanzas
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias odig-files-workspace)
@@ -1454,7 +1809,9 @@
  (action
   (chdir
    test-cases/odig-files-workspace
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias odoc-github717-odoc-index)
@@ -1463,8 +1820,9 @@
   (chdir
    test-cases/odoc/github717-odoc-index
    (progn
-    (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (<> %{ocaml_version} 4.02.3)))
 
 (rule
  (alias odoc-multiple-private-libs)
@@ -1473,8 +1831,9 @@
   (chdir
    test-cases/odoc/multiple-private-libs
    (progn
-    (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (<> %{ocaml_version} 4.02.3)))
 
 (rule
  (alias odoc-odoc-package-mld-link)
@@ -1483,8 +1842,9 @@
   (chdir
    test-cases/odoc/odoc-package-mld-link
    (progn
-    (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (<> %{ocaml_version} 4.02.3)))
 
 (rule
  (alias odoc-odoc-simple)
@@ -1493,8 +1853,9 @@
   (chdir
    test-cases/odoc/odoc-simple
    (progn
-    (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (<> %{ocaml_version} 4.02.3)))
 
 (rule
  (alias odoc-odoc-unique-mlds)
@@ -1503,8 +1864,9 @@
   (chdir
    test-cases/odoc/odoc-unique-mlds
    (progn
-    (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (<> %{ocaml_version} 4.02.3)))
 
 (rule
  (alias old-dune-subsystem)
@@ -1512,7 +1874,9 @@
  (action
   (chdir
    test-cases/old-dune-subsystem
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias optional)
@@ -1520,7 +1884,9 @@
  (action
   (chdir
    test-cases/optional
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias optional-executable)
@@ -1528,7 +1894,9 @@
  (action
   (chdir
    test-cases/optional-executable
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias output-obj)
@@ -1537,10 +1905,12 @@
   (chdir
    test-cases/output-obj
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
     (diff? run.t run.t.corrected))))
  (enabled_if
-  (and (<> %{ocaml-config:system} macosx) (<> %{ocaml-config:system} win))))
+  (and
+   (and (<> %{ocaml-config:system} macosx) (<> %{ocaml-config:system} win))
+   (>= %{ocaml_version} 4.06.0))))
 
 (rule
  (alias package-dep)
@@ -1548,7 +1918,9 @@
  (action
   (chdir
    test-cases/package-dep
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias path-variables)
@@ -1556,7 +1928,9 @@
  (action
   (chdir
    test-cases/path-variables
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias pkg-config-quoting)
@@ -1567,7 +1941,9 @@
  (action
   (chdir
    test-cases/pkg-config-quoting
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias ppx-rewriter)
@@ -1576,8 +1952,9 @@
   (chdir
    test-cases/ppx-rewriter
    (progn
-    (run %{exe:cram.exe} -skip-versions 4.02.3 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (<> %{ocaml_version} 4.02.3)))
 
 (rule
  (alias ppx-runtime-dependencies)
@@ -1585,7 +1962,9 @@
  (action
   (chdir
    test-cases/ppx-runtime-dependencies
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias preprocess-with-action)
@@ -1593,7 +1972,9 @@
  (action
   (chdir
    test-cases/preprocess-with-action
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias private-modules)
@@ -1601,7 +1982,9 @@
  (action
   (chdir
    test-cases/private-modules
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias private-public-overlap)
@@ -1609,7 +1992,9 @@
  (action
   (chdir
    test-cases/private-public-overlap
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias project-root)
@@ -1617,7 +2002,9 @@
  (action
   (chdir
    test-cases/project-root
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias promote)
@@ -1625,7 +2012,9 @@
  (action
   (chdir
    test-cases/promote
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias quoting)
@@ -1633,7 +2022,9 @@
  (action
   (chdir
    test-cases/quoting
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias re-exported-deps)
@@ -1641,7 +2032,9 @@
  (action
   (chdir
    test-cases/re-exported-deps
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias reason)
@@ -1649,7 +2042,9 @@
  (action
   (chdir
    test-cases/reason
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias redirections)
@@ -1657,7 +2052,9 @@
  (action
   (chdir
    test-cases/redirections
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias reporting-of-cycles)
@@ -1665,7 +2062,9 @@
  (action
   (chdir
    test-cases/reporting-of-cycles
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias rule-target-external)
@@ -1673,7 +2072,9 @@
  (action
   (chdir
    test-cases/rule-target-external
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias rule-target-inferrence)
@@ -1681,7 +2082,9 @@
  (action
   (chdir
    test-cases/rule-target-inferrence
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias sandboxing)
@@ -1689,7 +2092,9 @@
  (action
   (chdir
    test-cases/sandboxing
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias scope-bug)
@@ -1697,7 +2102,9 @@
  (action
   (chdir
    test-cases/scope-bug
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias scope-ppx-bug)
@@ -1705,7 +2112,9 @@
  (action
   (chdir
    test-cases/scope-ppx-bug
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias select)
@@ -1713,7 +2122,9 @@
  (action
   (chdir
    test-cases/select
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias select-2-0-rules)
@@ -1721,7 +2132,9 @@
  (action
   (chdir
    test-cases/select-2-0-rules
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias several-packages)
@@ -1729,7 +2142,9 @@
  (action
   (chdir
    test-cases/several-packages
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias shadow-bindings)
@@ -1737,7 +2152,9 @@
  (action
   (chdir
    test-cases/shadow-bindings
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias stale-artifact-removal)
@@ -1745,7 +2162,9 @@
  (action
   (chdir
    test-cases/stale-artifact-removal
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias stdlib-compilation)
@@ -1753,7 +2172,9 @@
  (action
   (chdir
    test-cases/stdlib-compilation
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias subst)
@@ -1761,7 +2182,9 @@
  (action
   (chdir
    test-cases/subst
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias syntax-versioning)
@@ -1769,7 +2192,9 @@
  (action
   (chdir
    test-cases/syntax-versioning
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias target-dir-alias)
@@ -1777,7 +2202,9 @@
  (action
   (chdir
    test-cases/target-dir-alias
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias targets-with-vars)
@@ -1785,7 +2212,9 @@
  (action
   (chdir
    test-cases/targets-with-vars
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias tests-stanza)
@@ -1793,7 +2222,9 @@
  (action
   (chdir
    test-cases/tests-stanza
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias tests-stanza-action)
@@ -1801,7 +2232,9 @@
  (action
   (chdir
    test-cases/tests-stanza-action
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias tests-stanza-action-syntax-version)
@@ -1811,7 +2244,9 @@
  (action
   (chdir
    test-cases/tests-stanza-action-syntax-version
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias toplevel-stanza)
@@ -1820,8 +2255,9 @@
   (chdir
    test-cases/toplevel-stanza
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.05.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.05.0)))
 
 (rule
  (alias trace-file)
@@ -1829,7 +2265,9 @@
  (action
   (chdir
    test-cases/trace-file
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias transitive-deps-mode)
@@ -1837,7 +2275,9 @@
  (action
   (chdir
    test-cases/transitive-deps-mode
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias unreadable-src)
@@ -1845,7 +2285,9 @@
  (action
   (chdir
    test-cases/unreadable-src
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias unused-preprocessor-deps)
@@ -1853,7 +2295,9 @@
  (action
   (chdir
    test-cases/unused-preprocessor-deps
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias upgrader)
@@ -1861,7 +2305,9 @@
  (action
   (chdir
    test-cases/upgrader
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias use-meta)
@@ -1869,7 +2315,9 @@
  (action
   (chdir
    test-cases/use-meta
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias utop-utop-default)
@@ -1878,8 +2326,9 @@
   (chdir
    test-cases/utop/utop-default
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.05.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.05.0)))
 
 (rule
  (alias utop-utop-default-implementation)
@@ -1890,8 +2339,9 @@
   (chdir
    test-cases/utop/utop-default-implementation
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.05.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.05.0)))
 
 (rule
  (alias utop-utop-simple)
@@ -1900,8 +2350,9 @@
   (chdir
    test-cases/utop/utop-simple
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.05.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.05.0)))
 
 (rule
  (alias variables-for-artifacts)
@@ -1909,7 +2360,9 @@
  (action
   (chdir
    test-cases/variables-for-artifacts
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants)
@@ -1917,7 +2370,9 @@
  (action
   (chdir
    test-cases/variants
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants-variant-dep-stack)
@@ -1925,7 +2380,9 @@
  (action
   (chdir
    test-cases/variants/variant-dep-stack
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants-variants-external-declaration)
@@ -1935,7 +2392,9 @@
  (action
   (chdir
    test-cases/variants/variants-external-declaration
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants-variants-external-declaration-conflict)
@@ -1945,7 +2404,9 @@
  (action
   (chdir
    test-cases/variants/variants-external-declaration-conflict
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants-variants-multi-project)
@@ -1955,7 +2416,9 @@
  (action
   (chdir
    test-cases/variants/variants-multi-project
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants-variants-only-package)
@@ -1963,7 +2426,9 @@
  (action
   (chdir
    test-cases/variants/variants-only-package
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants-variants-rogue-impl)
@@ -1971,7 +2436,9 @@
  (action
   (chdir
    test-cases/variants/variants-rogue-impl
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias variants-variants-wrong-external-declaration)
@@ -1981,7 +2448,9 @@
  (action
   (chdir
    test-cases/variants/variants-wrong-external-declaration
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias vendor)
@@ -1989,7 +2458,9 @@
  (action
   (chdir
    test-cases/vendor
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias vendor-dash-p-and-vendored-packages)
@@ -1999,7 +2470,9 @@
  (action
   (chdir
    test-cases/vendor/dash-p-and-vendored-packages
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias vendor-do-not-install-vendored-packages)
@@ -2009,7 +2482,9 @@
  (action
   (chdir
    test-cases/vendor/do-not-install-vendored-packages
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias virtual-libraries-vlib)
@@ -2020,7 +2495,9 @@
  (action
   (chdir
    test-cases/virtual-libraries/vlib
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias virtual-libraries-vlib-default-impl)
@@ -2030,7 +2507,9 @@
  (action
   (chdir
    test-cases/virtual-libraries/vlib-default-impl
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias virtual-libraries-vlib-wrong-default-impl)
@@ -2040,7 +2519,9 @@
  (action
   (chdir
    test-cases/virtual-libraries/vlib-wrong-default-impl
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias windows-diff)
@@ -2048,7 +2529,9 @@
  (action
   (chdir
    test-cases/windows-diff
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias with-exit-codes)
@@ -2056,7 +2539,9 @@
  (action
   (chdir
    test-cases/with-exit-codes
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias with-nested-exit-codes)
@@ -2064,7 +2549,9 @@
  (action
   (chdir
    test-cases/with-nested-exit-codes
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias with-stdin-from)
@@ -2072,7 +2559,9 @@
  (action
   (chdir
    test-cases/with-stdin-from
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias with-unsupported-nested-exit-codes)
@@ -2082,7 +2571,9 @@
  (action
   (chdir
    test-cases/with-unsupported-nested-exit-codes
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias workspace-paths)
@@ -2090,7 +2581,9 @@
  (action
   (chdir
    test-cases/workspace-paths
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias workspaces)
@@ -2098,7 +2591,9 @@
  (action
   (chdir
    test-cases/workspaces
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias wrapped-false-main-module-name)
@@ -2106,7 +2601,9 @@
  (action
   (chdir
    test-cases/wrapped-false-main-module-name
-   (progn (run %{exe:cram.exe} -test run.t) (diff? run.t run.t.corrected)))))
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
 
 (rule
  (alias wrapped-transition)
@@ -2115,8 +2612,9 @@
   (chdir
    test-cases/wrapped-transition
    (progn
-    (run %{exe:cram.exe} -skip-versions <4.06.0 -test run.t)
-    (diff? run.t run.t.corrected)))))
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+ (enabled_if (>= %{ocaml_version} 4.06.0)))
 
 (alias
  (name runtest)

--- a/test/blackbox-tests/sanitizer.ml
+++ b/test/blackbox-tests/sanitizer.ml
@@ -1,0 +1,114 @@
+open Stdune
+module Re = Dune_re
+module Configurator = Configurator.V1
+
+let replace_cwd cwd =
+  let abs_path_re = Re.(compile (str cwd)) in
+  fun s -> Re.replace_string abs_path_re s ~by:"$TESTCASE_ROOT"
+
+let replace_ext =
+  let ext_re =
+    Re.(compile (seq [ diff any (char '/'); char '.'; rep1 alnum ]))
+  in
+  fun tbl s ->
+    Re.replace ext_re s ~f:(fun g ->
+        let s = Re.Group.get g 0 in
+        match List.assoc tbl (String.drop s 1) with
+        | None -> s
+        | Some res -> sprintf "%c%s" s.[0] res)
+
+let remove_std_arg =
+  let spacem, marked_space = Re.mark (Re.rep Re.space) in
+  let re =
+    Re.(
+      compile
+        (seq [ marked_space; str "-std="; rep1 (diff any space); marked_space ]))
+  in
+  fun s ->
+    Re.replace re s ~f:(fun g ->
+        if Re.Mark.test g spacem then
+          " "
+        else
+          "")
+
+let config_var_replace config : string -> string =
+  let vars = [ "ocamlc_cflags"; "ocamlc_cppflags" ] in
+  let vars =
+    List.filter_map vars ~f:(fun k ->
+        Configurator.ocaml_config_var config k
+        |> Option.map ~f:(fun v -> (k, v)))
+  in
+  (* we filter out stuff like -std=gnu99 to get the list of C++ flags *)
+  let vars =
+    match List.assoc vars "ocamlc_cflags" with
+    | None -> vars
+    | Some v -> ("cxx_flags", remove_std_arg v) :: vars
+  in
+  let values =
+    List.filter_map vars ~f:(fun (_, v) ->
+        match String.trim v with
+        | "" -> None
+        | v -> Some (Re.str v))
+  in
+  let re = Re.(compile (alt values)) in
+  fun s -> Re.replace_string re s ~by:"$flags"
+
+let make_ext_replace config =
+  let tbl =
+    let var = Configurator.ocaml_config_var_exn config in
+    let exts =
+      [ (var "ext_dll", "$ext_dll")
+      ; (var "ext_asm", "$ext_asm")
+      ; (var "ext_lib", "$ext_lib")
+      ; (var "ext_obj", "$ext_obj")
+      ]
+    in
+    (* need to special case exe since we can only remove this extension in
+       general *)
+    match
+      match Configurator.ocaml_config_var config "ext_exe" with
+      | Some s -> s
+      | None -> (
+        match Configurator.ocaml_config_var_exn config "system" with
+        | "Win32" -> ".exe"
+        | _ -> "" )
+    with
+    | "" -> exts
+    | ext -> (ext, "") :: exts
+  in
+  List.iter tbl ~f:(fun (e, _) -> assert (e <> ""));
+  fun s -> replace_ext tbl s
+
+let () =
+  let exit_code = ref 0 in
+  let cwd = ref "" in
+  let args =
+    Arg.align
+      [ ( "-exit-code"
+        , Arg.Set_int exit_code
+        , "NUMBER Exit code of the command for which we are sanitizing the \
+           output" )
+      ; ( "-cwd"
+        , Arg.Set_string cwd
+        , "DIR Set the cwd for sanitizing the command output" )
+      ]
+  in
+  let files = ref [] in
+  let anon s = files := s :: !files in
+  let usage = sprintf "%s [OPTIONS]" (Filename.basename Sys.executable_name) in
+  Arg.parse args anon usage;
+  let cwd = !cwd
+  and exit_code = !exit_code
+  and files = List.rev !files in
+  let configurator = Configurator.create "sanitizer" in
+  let sanitize =
+    let ext_replace = make_ext_replace configurator in
+    fun s ->
+      s |> Ansi_color.strip |> ext_replace |> replace_cwd cwd
+      |> config_var_replace configurator
+  in
+  List.iter files ~f:(fun fn ->
+      Io.String_path.read_file fn
+      |> sanitize |> String.split_lines
+      |> List.iter ~f:(fun line -> Printf.printf "  %s\n" line));
+  if exit_code <> 0 then Printf.printf "  [%d]\n" exit_code


### PR DESCRIPTION
This is in preparation of making cram test available to users.

This PR is for two reasons:
- I plan to merge the cram test tool directly into dune, as `dune cram`. It is very small and that will make distribution easier
- users will be allowed to define their own sanitizer