### PR TITLE
[coq] Disable sandboxing for `.vo` rules

### DIFF
--- a/src/dune/coq_rules.ml
+++ b/src/dune/coq_rules.ml
@@ -138,6 +138,10 @@ let setup_rule ~expander ~dir ~cc ~source_rule ~coq_flags ~file_flags
   [ coqdep_rule
   ; ( Build.with_no_targets deps_of
     >>>
+    (* The way we handle the transitive dependencies of .vo files is not
+       safe for sandboxing *)
+    Build.with_no_targets (Build.dep (Dep.sandbox_config Sandbox_config.no_sandboxing))
+    >>>
     let coq_flags =
       Expander.expand_and_eval_set expander coq_flags
         ~standard:(Build.return [])


### PR DESCRIPTION
In Coq, dependencies of a `.vo` file on other `.vo` files are
link-time dependencies given that Coq will load all the dependencies
transitively. For example, imagine the situation where we have a
dependency chain, `Require`-wise:

```
a.v ← b.v ← c.v
```

[that is to say, `c.v` only `Requires Import b.`]

In this case, loading `b` will trigger the loading of `a` too; this
means that the dependencies of `c.v` must be computed transitively.

Unfortunately, in the average case this leads to a quadratic grow of
dependency edges; moreover, would we add these edges naïvely that we
would be wasting quite a bit of effort due to a lack of sharing
among the users of `b`.

However, in order to improve integrity, the current implementation of
Coq does add to module `c` a table with the digest of all required
modules; this means we can optimize the rule given that `b` will
contain the digest of `a` so we don't need add the transitive
dependencies; it is guaranteed in that case that if `a.vo` changes so
will `b.vo`.

This optimization breaks sandboxing tho; as the compilation of `c.v`
only depends on `b.vo`

See also:

- https://github.com/ocaml/dune/issues/3113
- https://github.com/coq/coq/pull/11407