### PR TITLE
Introduce a strict_package_deps field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,9 @@
 - Do not fail if `ocamldep`, `ocamlmklib`, or `ocaml` are absent. Wait for them
   to be used to fail (#3138, @rgrinberg)
 
+- Introduce a `strict_package_deps` mode that verifies that dependencies between
+  packages in the workspace are specified correctly. (@rgrinberg, #3117)
+
 2.2.0 (06/02/2020)
 ------------------
 

--- a/src/dune/dune_project.mli
+++ b/src/dune/dune_project.mli
@@ -170,3 +170,5 @@ val implicit_transitive_deps : t -> bool
 val dune_version : t -> Dune_lang.Syntax.Version.t
 
 val wrapped_executables : t -> bool
+
+val strict_package_deps : t -> bool

--- a/src/dune/package.ml
+++ b/src/dune/package.ml
@@ -556,3 +556,10 @@ let load_opam_file file name =
   ; tags = Option.value (get_many "tags") ~default:[]
   ; deprecated_package_names = Name.Map.empty
   }
+
+let missing_deps (t : t) ~effective_deps =
+  let specified_deps =
+    List.map t.depends ~f:(fun (dep : Dependency.t) -> dep.name)
+    |> Name.Set.of_list
+  in
+  Name.Set.diff effective_deps specified_deps

--- a/src/dune/package.mli
+++ b/src/dune/package.mli
@@ -137,3 +137,5 @@ val is_opam_file : Path.t -> bool
 
 (** Construct a package description from an opam file. *)
 val load_opam_file : Path.Source.t -> Name.t -> t
+
+val missing_deps : t -> effective_deps:Name.Set.t -> Name.Set.t

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -399,9 +399,8 @@ let get_installed_binaries stanzas ~(context : Context.t) =
       | Dune_file.Executables
           ({ install_conf = Some { section = Bin; files; _ }; _ } as exes) ->
         let compile_info =
-          let dune_version =
-            Scope.project d.scope |> Dune_project.dune_version
-          in
+          let project = Scope.project d.scope in
+          let dune_version = Dune_project.dune_version project in
           Lib.DB.resolve_user_written_deps_for_exes (Scope.libs d.scope)
             exes.names exes.buildable.libraries
             ~pps:(Dune_file.Preprocess_map.pps exes.buildable.preprocess)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -2197,6 +2197,16 @@
     (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias strict-package-deps)
+ (deps (package dune) (source_tree test-cases/strict-package-deps))
+ (action
+  (chdir
+   test-cases/strict-package-deps
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
+
+(rule
  (alias subst)
  (deps (package dune) (source_tree test-cases/subst))
  (action
@@ -2850,6 +2860,7 @@
   (alias shadow-bindings)
   (alias stale-artifact-removal)
   (alias stdlib-compilation)
+  (alias strict-package-deps)
   (alias subst)
   (alias syntax-versioning)
   (alias target-dir-alias)
@@ -3080,6 +3091,7 @@
   (alias shadow-bindings)
   (alias stale-artifact-removal)
   (alias stdlib-compilation)
+  (alias strict-package-deps)
   (alias subst)
   (alias syntax-versioning)
   (alias target-dir-alias)

--- a/test/blackbox-tests/test-cases/strict-package-deps/run.t
+++ b/test/blackbox-tests/test-cases/strict-package-deps/run.t
@@ -1,0 +1,30 @@
+In strict package deps mode, dependencies between packages are checked against
+the package dependencies inferred by dune:
+  $ cat >dune-project <<EOF
+  > (lang dune 2.3)
+  > (strict_package_deps)
+  > (package (name bar))
+  > (package (name foo))
+  > EOF
+  $ mkdir foo
+  $ mkdir bar
+  $ touch foo/foo.ml
+  $ touch bar/bar.ml
+  $ cat >foo/dune <<EOF
+  > (executable (public_name foo) (libraries bar) (package foo))
+  > EOF
+  $ cat >bar/dune <<EOF
+  > (library (public_name bar))
+  > EOF
+  $ dune build @install
+  Error: Package foo is missing the following package dependencies
+  - bar
+  [1]
+
+  $ cat >foo/dune <<EOF
+  > (library (public_name foo) (libraries bar))
+  > EOF
+  $ dune build @install
+  Error: Package foo is missing the following package dependencies
+  - bar
+  [1]


### PR DESCRIPTION
In this mode, dune makes sure that all the package dependencies that it
infers are present in the opam file