### PR TITLE
Upgrade to ocamlformat 0.13.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.12
+version=0.13.0
 break-separators=before
 dock-collection-brackets=false
 break-sequences=true

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -43,8 +43,7 @@ module C_define : sig
       ["ARCH_SIXTYFOUR", Switch true] ]} *)
   val import :
        t
-    -> ?prelude:
-         string
+    -> ?prelude:string
          (** Define extra code be used with extracting values below. Note that
              the compiled code is never executed. *)
     -> ?c_flags:string list

--- a/src/dune/coq_module.mli
+++ b/src/dune/coq_module.mli
@@ -18,8 +18,7 @@ type t
 
 (** A Coq module [a.b.foo] defined in file [a/b/foo.v] *)
 val make :
-     source:
-       Path.Build.t
+     source:Path.Build.t
        (** file = .v source file; module name has to be the same so far *)
   -> prefix:string list (** Library-local qualified prefix *)
   -> name:Name.t (** Name of the module *)

--- a/src/stdune/daemonize.mli
+++ b/src/stdune/daemonize.mli
@@ -19,8 +19,8 @@ type status =
 
 val daemonize :
      ?workdir:Path.t (** The path to chdir to *)
-  -> ?foreground:
-       bool (** Whether to fork a daemon or run synchronously (defaults true) *)
+  -> ?foreground:bool
+       (** Whether to fork a daemon or run synchronously (defaults true) *)
   -> Path.t (** The path of the beacon file *)
   -> ((string -> unit) -> unit) (** The daemon main routine *)
   -> (status, string) Result.t

--- a/src/stdune/path_intf.ml
+++ b/src/stdune/path_intf.ml
@@ -12,8 +12,7 @@ module type S = sig
   val pp : Format.formatter -> t -> unit
 
   (** a directory is smaller than its descendants *)
-  include
-    Comparator.S with type t := t
+  include Comparator.S with type t := t
 
   include Comparator.OPS with type t := t
 


### PR DESCRIPTION
No option was added or removed between 0.12 and 0.13, there were only consistency fixes, so the upgrade should be painless.