### PR TITLE
Fix bootstrap in bytecode mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@
   anything else than a strict subdirectory or `*` will raise an error. The
   previous behavior was to just do nothing  (#3056, fixes #3019, @voodoos)
 
+- Fix bootstrap on bytecode only switches on windows or where `-j1` is set.
+  (#3112, @xclerc, @rgrinberg)
+
 2.2.0 (06/02/2020)
 ------------------
 

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1131,6 +1131,9 @@ let build_with_single_command ~ocaml_config:_ ~pp ~dependencies ~c_files
        [ [ "-o"
          ; Filename.concat ".." (name ^ ".exe")
          ; "-g"
+         ; ( match Config.mode with
+             | Byte -> [ Config.output_complete_obj_arg ]
+             | Native -> [] )
          ; "-no-alias-deps"
          ; "-w"
          ; "-49"

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1053,6 +1053,19 @@ let sort_files dependencies ~main =
   loop (Filename.basename main);
   List.rev !res
 
+let common_build_args name ~pp ~external_includes ~external_libraries =
+  List.concat
+    [ ["-o"
+      ; Filename.concat ".." (name ^ ".exe")
+      ; "-g"]
+    ; ( match Config.mode with
+        | Byte -> [ Config.output_complete_obj_arg ]
+        | Native -> [] )
+    ; pp
+    ; external_includes
+    ; external_libraries
+    ]
+
 let build ~ocaml_config ~pp ~dependencies ~c_files
     { target = name, main; external_libraries; _ } =
   let ext_obj =
@@ -1109,13 +1122,7 @@ let build ~ocaml_config ~pp ~dependencies ~c_files
   write_args "compiled_ml_files" compiled_ml_files;
   Process.run ~cwd:build_dir Config.compiler
     (List.concat
-       [ [ "-o"; Filename.concat ".." (name ^ ".exe"); "-g" ]
-       ; ( match Config.mode with
-         | Byte -> [ Config.output_complete_obj_arg ]
-         | Native -> [] )
-       ; pp
-       ; external_includes
-       ; external_libraries
+       [ common_build_args name ~pp ~external_includes ~external_libraries
        ; obj_files
        ; [ "-args"; "compiled_ml_files" ]
        ])
@@ -1128,19 +1135,11 @@ let build_with_single_command ~ocaml_config:_ ~pp ~dependencies ~c_files
   write_args "mods_list" (sort_files dependencies ~main);
   Process.run ~cwd:build_dir Config.compiler
     (List.concat
-       [ [ "-o"
-         ; Filename.concat ".." (name ^ ".exe")
-         ; "-g"
-         ; ( match Config.mode with
-             | Byte -> [ Config.output_complete_obj_arg ]
-             | Native -> [] )
-         ; "-no-alias-deps"
+       [ common_build_args name ~pp ~external_includes ~external_libraries
+       ; [ "-no-alias-deps"
          ; "-w"
          ; "-49"
          ]
-       ; pp
-       ; external_includes
-       ; external_libraries
        ; c_files
        ; [ "-args"; "mods_list" ]
        ])


### PR DESCRIPTION
Bootstrapping dune on a 1 core machine and a bytecode only switch is
broken because -custom is missing.

discovered by @xclerc