### PR TITLE
Simplify building of "build requests"

### DIFF
--- a/src/dune/rule.ml
+++ b/src/dune/rule.ml
@@ -133,7 +133,3 @@ let effective_env t =
   | None, None -> Env.initial
   | Some e, _ -> e
   | None, Some c -> c.env
-
-let rule_deps t = (Build.static_deps t.action.build).rule_deps
-
-let static_action_deps t = (Build.static_deps t.action.build).action_deps

--- a/src/dune/rule.ml
+++ b/src/dune/rule.ml
@@ -137,22 +137,3 @@ let effective_env t =
 let rule_deps t = (Build.static_deps t.action.build).rule_deps
 
 let static_action_deps t = (Build.static_deps t.action.build).action_deps
-
-(* CR-soon amokhov: Build [request] directly instead of going via a fake rule. *)
-let shim_of_build_goal request =
-  let request =
-    let open Build.O in
-    let+ () = request in
-    Action.empty
-  in
-  { id = Id.gen ()
-  ; context = None
-  ; dir = Path.Build.root
-  ; env = None
-  ; action =
-      Build.With_targets.memoize "Rule.shim_of_build_goal"
-        (Build.with_no_targets request)
-  ; mode = Mode.Standard
-  ; locks = []
-  ; info = Info.Internal
-  }

--- a/src/dune/rule.mli
+++ b/src/dune/rule.mli
@@ -92,6 +92,3 @@ val effective_env : t -> Env.t
 val rule_deps : t -> Dep.Set.t
 
 val static_action_deps : t -> Dep.Set.t
-
-(** Create a shim for the main build goal. *)
-val shim_of_build_goal : unit Build.t -> t

--- a/src/dune/rule.mli
+++ b/src/dune/rule.mli
@@ -88,7 +88,3 @@ val with_prefix : t -> build:unit Build.t -> t
 val loc : t -> Loc.t
 
 val effective_env : t -> Env.t
-
-val rule_deps : t -> Dep.Set.t
-
-val static_action_deps : t -> Dep.Set.t


### PR DESCRIPTION
This removes `Rule.shim_of_build_goal` that was used to create fake rules for build requests with no targets, executed at the start of the build system. Note that we previously memoized the evaluation of "build requests" which seems unnecessary since they are evaluated only once. We therefore drop memoization, make this explicit by using the `Non_memoized` constructor.