### PR TITLE
Inject fibers into build

### DIFF
--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -58,9 +58,12 @@ let term =
      | `List ->
        let fns = Memo.registered_functions () in
        let longest =
-         String.longest_map fns ~f:(fun info -> info.Memo.Function.Info.name)
+         String.longest_map fns ~f:(fun info ->
+             Option.value_exn (Memo.Function.Info.name info))
        in
-       List.iter fns ~f:(fun { Memo.Function.Info.name; doc } ->
+       List.iter fns ~f:(fun info ->
+         let name = Option.value_exn (Memo.Function.Info.name info) in
+         let doc = Memo.Function.Info.doc info in
            Printf.printf "%-*s" longest name;
            Option.iter doc ~f:(Printf.printf ": %s");
            Printf.printf "\n");
@@ -68,9 +71,10 @@ let term =
        `Ok ()
      | `Show_doc fn ->
        let info = Memo.function_info fn in
-       let name = info.name in
+       let name = Option.value_exn (Memo.Function.Info.name info) in
+       let doc = Memo.Function.Info.doc info in
        Printf.printf "%s\n%s\n" name (String.make (String.length name) '=');
-       Option.iter info.doc ~f:(Printf.printf "%s\n");
+       Option.iter doc ~f:(Printf.printf "%s\n");
        `Ok ()
 
 let command = (term, info)

--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -192,11 +192,13 @@ val static_deps : _ t -> Static_deps.t
 (** Compute static library dependencies of a build description. *)
 val lib_deps : _ t -> Lib_deps_info.t
 
+val fiber : 'a Fiber.t -> 'a t
+
 (** {1 Execution} *)
 
 (** Execute a build description. Returns the result and the set of dynamic
     dependencies discovered during execution. *)
-val exec : 'a t -> 'a * Dep.Set.t
+val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 
 (**/**)
 

--- a/src/dune/build.mli
+++ b/src/dune/build.mli
@@ -194,6 +194,8 @@ val lib_deps : _ t -> Lib_deps_info.t
 
 val fiber : 'a Fiber.t -> 'a t
 
+val dyn_fiber : 'a Fiber.t t -> 'a t
+
 (** {1 Execution} *)
 
 (** Execute a build description. Returns the result and the set of dynamic

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -860,7 +860,7 @@ end = struct
         Unrestricted
       else
         Restricted
-          (Memo.Lazy.create (fun () ->
+          (Memo.Lazy.create ~loc:(Loc.of_pos __POS__) (fun () ->
                match load_dir ~dir:(Path.build dir) with
                | Non_build _ -> Dir_set.just_the_root
                | Build { allowed_subdirs; _ } ->

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -1757,9 +1757,11 @@ let package_deps pkg files =
       else
         Fiber.return (Package.Name.Set.union acc pkgs)
   and loop_deps fn acc =
+    Format.eprintf "fn: %s@.%!" (Path.Build.to_string fn);
     match get_rule (Path.build fn) with
     | None -> Fiber.return acc
     | Some ir ->
+      Format.eprintf "success@.%@.";
       if Rule.Set.mem !rules_seen ir then
         Fiber.return acc
       else (

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -139,7 +139,9 @@ let to_dyn_concise t : Dyn.t = Context_name.to_dyn t.name
 
 let compare a b = Poly.compare a.name b.name
 
-let opam = Memo.lazy_ (fun () -> Bin.which ~path:(Env.path Env.initial) "opam")
+let opam =
+  Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
+      Bin.which ~path:(Env.path Env.initial) "opam")
 
 let read_opam_config_var ~env (var : string) : string option Fiber.t =
   let (_ : Memo.Run.t) = Memo.current_run () in
@@ -268,7 +270,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     | Some x -> x
   in
   let findlib_config_path =
-    Memo.lazy_async ~cutoff:Path.equal (fun () ->
+    Memo.lazy_async ~loc:(Loc.of_pos __POS__) ~cutoff:Path.equal (fun () ->
         let fn = which_exn "ocamlfind" in
         (* When OCAMLFIND_CONF is set, "ocamlfind printconf" does print the
            contents of the variable, but "ocamlfind printconf conf" still prints
@@ -352,7 +354,8 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       | Some s -> Bin.parse_path s ~sep:ocamlpath_sep
     in
     let opam_config_var_lib =
-      Memo.lazy_async ~cutoff:(Option.equal String.equal) (fun () ->
+      Memo.lazy_async ~loc:(Loc.of_pos __POS__)
+        ~cutoff:(Option.equal String.equal) (fun () ->
           read_opam_config_var ~env "lib")
     in
     let findlib_paths () =
@@ -498,7 +501,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     in
     let ocaml_bin = dir in
     let install_prefix =
-      Memo.lazy_async ~cutoff:Path.equal (fun () ->
+      Memo.lazy_async ~loc:(Loc.of_pos __POS__) ~cutoff:Path.equal (fun () ->
           Fiber.map (read_opam_config_var ~env "prefix") ~f:(function
             | Some x -> Path.of_filename_relative_to_initial_cwd x
             | None -> Path.parent_exn ocaml_bin))

--- a/src/dune/dir_contents.ml
+++ b/src/dune/dir_contents.ml
@@ -78,7 +78,7 @@ let mlds t (doc : Documentation.t) =
 let build_mlds_map (d : _ Dir_with_dune.t) ~files =
   let dir = d.ctx_dir in
   let mlds =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
         String.Set.fold files ~init:String.Map.empty ~f:(fun fn acc ->
             match String.lsplit2 fn ~on:'.' with
             | Some (s, "mld") -> String.Map.set acc s fn
@@ -229,7 +229,7 @@ end = struct
       in
       let dirs = [ (dir, [], files) ] in
       let ml =
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
             let lookup_vlib = lookup_vlib sctx in
             let loc = loc_of_dune_file ft_dir in
             Ml_sources.make d ~loc ~include_subdirs ~lookup_vlib ~dirs)
@@ -240,13 +240,15 @@ end = struct
             ; dir
             ; text_files = files
             ; ml
-            ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
+            ; mlds =
+                Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
+                    build_mlds_map d ~files)
             ; foreign_sources =
-                Memo.lazy_ (fun () ->
+                Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
                     Foreign_sources.make d ~lib_config:ctx.lib_config
                       ~include_subdirs ~dirs)
             ; coq =
-                Memo.lazy_ (fun () ->
+                Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
                     Coq_sources.of_dir d ~include_subdirs ~dirs)
             }
         ; rules
@@ -266,17 +268,18 @@ end = struct
       in
       let dirs = (dir, [], files) :: subdirs in
       let ml =
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
             let lookup_vlib = lookup_vlib sctx in
             Ml_sources.make d ~loc ~lookup_vlib ~include_subdirs ~dirs)
       in
       let foreign_sources =
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
             Foreign_sources.make d ~include_subdirs ~lib_config:ctx.lib_config
               ~dirs)
       in
       let coq =
-        Memo.lazy_ (fun () -> Coq_sources.of_dir d ~dirs ~include_subdirs)
+        Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
+            Coq_sources.of_dir d ~dirs ~include_subdirs)
       in
       let subdirs =
         List.map subdirs ~f:(fun (dir, _local, files) ->
@@ -285,7 +288,9 @@ end = struct
             ; text_files = files
             ; ml
             ; foreign_sources
-            ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
+            ; mlds =
+                Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
+                    build_mlds_map d ~files)
             ; coq
             })
       in
@@ -295,7 +300,9 @@ end = struct
         ; text_files = files
         ; ml
         ; foreign_sources
-        ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
+        ; mlds =
+            Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
+                build_mlds_map d ~files)
         ; coq
         }
       in

--- a/src/dune/env_node.ml
+++ b/src/dune/env_node.ml
@@ -43,7 +43,7 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
     ~default_bin_artifacts =
   let config = Dune_env.Stanza.find config_stanza ~profile in
   let inherited ~field ~root extend =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
         extend
           ( match inherit_from with
           | None -> root

--- a/src/dune/fdo.ml
+++ b/src/dune/fdo.ml
@@ -92,7 +92,7 @@ let get_profile =
   let f (ctx : Context.t) =
     let path = ctx.fdo_target_exe |> Option.value_exn |> fdo_profile in
     let profile_exists =
-      Memo.lazy_ (fun () ->
+      Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
           path |> Path.as_in_source_tree
           |> Option.map ~f:File_tree.file_exists
           |> Option.value ~default:false)

--- a/src/dune/global.ml
+++ b/src/dune/global.ml
@@ -1,3 +1,3 @@
 open Stdune
 
-let env = Memo.Run.Fdecl.create Env.to_dyn
+let env = Memo.Run.Fdecl.create ~loc:(Loc.of_pos __POS__) Env.to_dyn

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -619,6 +619,12 @@ let install_rules sctx (package : Package.t) =
     Dune_project.strict_package_deps dune_project
   in
   let packages =
+    let () =
+      Format.eprintf "package: %s@. files: %a@."
+        (Package.Name.to_string package.name)
+        Pp.render_ignore_tags
+        (Dyn.pp (Path.Set.to_dyn files))
+    in
     let+ packages = Build_system.package_deps package.name files in
     match strict_package_deps with
     | false -> packages

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -83,8 +83,8 @@ end = struct
               make_entry Lib source ?dst))
     in
     let ctx = Super_context.context sctx in
-    let { Lib_config.has_native; ext_obj; _ } = ctx.lib_config in
     let module_files =
+      let { Lib_config.has_native; ext_obj; _ } = ctx.lib_config in
       let if_ cond l =
         if cond then
           l
@@ -725,7 +725,7 @@ let memo =
       let ctx = Super_context.context sctx in
       let context_name = ctx.name in
       let rules =
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
             Rules.collect_unit (fun () ->
                 install_rules sctx pkg;
                 install_alias ctx pkg))

--- a/src/dune/ml_sources.ml
+++ b/src/dune/ml_sources.ml
@@ -301,7 +301,7 @@ let check_no_qualified (loc, include_subdirs) =
 
 let make (d : _ Dir_with_dune.t) ~loc ~lookup_vlib ~include_subdirs ~dirs =
   let libs_and_exes =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
         check_no_qualified include_subdirs;
         let modules =
           let dialects = Dune_project.dialects (Scope.project d.scope) in

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -100,12 +100,14 @@ end = struct
         | None ->
           Code_error.raise "Super_context.Env.get called on invalid directory"
             [ ("dir", Path.Build.to_dyn dir) ]
-        | Some parent -> Memo.lazy_ (fun () -> get_node t ~dir:parent)
+        | Some parent ->
+          Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
+              get_node t ~dir:parent)
     in
     let config_stanza = get_env_stanza t ~dir in
     let default_context_flags = default_context_flags t.context in
     let expander_for_artifacts =
-      Memo.lazy_ (fun () ->
+      Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
           expander_for_artifacts ~scope ~root_expander:t.root_expander
             ~external_env:(external_env t ~dir) ~dir)
     in
@@ -457,13 +459,13 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
       ~bin_artifacts_host:artifacts_host.bin
   in
   let default_env =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
         let make ~inherit_from ~config_stanza =
           let dir = context.build_dir in
           let scope = Scope.DB.find_by_dir scopes dir in
           let default_context_flags = default_context_flags context in
           let expander_for_artifacts =
-            Memo.lazy_ (fun () ->
+            Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
                 Code_error.raise
                   "[expander_for_artifacts] in [default_env] is undefined" [])
           in
@@ -476,7 +478,7 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
         make ~config_stanza:context.env_nodes.context
           ~inherit_from:
             (Some
-               (Memo.lazy_ (fun () ->
+               (Memo.lazy_ ~loc:(Loc.of_pos __POS__) (fun () ->
                     make ~inherit_from:None
                       ~config_stanza:context.env_nodes.workspace))))
   in

--- a/src/dune/workspace.ml
+++ b/src/dune/workspace.ml
@@ -459,7 +459,7 @@ module DB = struct
         ; ("path", option Path.to_dyn path)
         ]
 
-    let t = Memo.Run.Fdecl.create to_dyn
+    let t = Memo.Run.Fdecl.create ~loc:(Loc.of_pos __POS__) to_dyn
   end
 end
 

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -231,6 +231,15 @@ let sequential_iter l ~f =
   in
   loop l
 
+let fold l ~f =
+  let rec loop acc = function
+    | [] -> return acc
+    | x :: l ->
+      let* acc = f x acc in
+      loop acc l
+  in
+  fun ~init -> loop init l
+
 type ('a, 'b) fork_and_join_state =
   | Nothing_yet
   | Got_a of 'a

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -81,6 +81,8 @@ val sequential_map : 'a list -> f:('a -> 'b t) -> 'b list t
 
 val sequential_iter : 'a list -> f:('a -> unit t) -> unit t
 
+val fold : 'a list -> f:('a -> 'acc -> 'acc t) -> init:'acc -> 'acc t
+
 (** {1 Forking + joining} *)
 
 (** The following functions combine forking 2 or more fibers followed by joining

--- a/src/memo/function.ml
+++ b/src/memo/function.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 module Type = struct
   type ('a, 'b, 'f) t =
     | Sync : ('a, 'b, 'a -> 'b) t
@@ -6,9 +8,28 @@ end
 
 module Info = struct
   type t =
-    { name : string
-    ; doc : string option
-    }
+    | Named of
+        { name : string
+        ; doc : string option
+        }
+    | Loc of Loc.t
+
+  let of_loc loc = Loc loc
+
+  let name = function
+    | Named { name ; doc = _ } -> Some name
+    | Loc _ -> None
+
+  let doc = function
+    | Named { doc ; name = _ } -> doc
+    | Loc _ -> None
+
+  let named ?doc ~name () = Named { name ; doc }
+
+  let to_dyn = function
+    | Named { name ; doc = _ } ->
+      Dyn.Tuple [String name]
+    | Loc loc -> Loc.to_dyn_hum loc
 end
 
 type ('a, 'b, 'f) t =

--- a/src/memo/function.mli
+++ b/src/memo/function.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 module Type : sig
   type ('a, 'b, 'f) t =
     | Sync : ('a, 'b, 'a -> 'b) t
@@ -5,10 +7,17 @@ module Type : sig
 end
 
 module Info : sig
-  type t =
-    { name : string
-    ; doc : string option
-    }
+  type t
+
+  val named : ?doc:string -> name:string -> unit -> t
+
+  val doc : t -> string option
+
+  val name : t -> string option
+
+  val of_loc : Loc.t -> t
+
+  val to_dyn : t -> Dyn.t
 end
 
 type ('a, 'b, 'f) t =

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -52,10 +52,11 @@ module Function : sig
   end
 
   module Info : sig
-    type t =
-      { name : string
-      ; doc : string option
-      }
+    type t
+
+    val name : t -> string option
+
+    val doc : t -> string option
   end
 end
 
@@ -205,7 +206,7 @@ module Run : sig
 
     (** [create to_dyn] creates a forward declaration. The [to_dyn] parameter is
         used for reporting errors in [set] and [get]. *)
-    val create : ('a -> Dyn.t) -> 'a t
+    val create : ?loc:Loc.t -> ('a -> Dyn.t) -> 'a t
 
     (** [set t x] sets the value that is returned by [get t] to [x]. Raises if
         [set] was already called. *)
@@ -235,7 +236,7 @@ module Lazy : sig
 
   val bind : 'a t -> f:('a -> 'b t) -> 'b t
 
-  val create : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a t
+  val create : ?loc:Loc.t -> ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a t
 
   val of_val : 'a -> 'a t
 
@@ -246,7 +247,8 @@ module Lazy : sig
 
     val of_val : 'a -> 'a t
 
-    val create : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a Fiber.t) -> 'a t
+    val create :
+      ?loc:Loc.t -> ?cutoff:('a -> 'a -> bool) -> (unit -> 'a Fiber.t) -> 'a t
 
     val force : 'a t -> 'a Fiber.t
 
@@ -254,10 +256,14 @@ module Lazy : sig
   end
 end
 
-val lazy_ : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a Lazy.t
+val lazy_ :
+  ?loc:Loc.t -> ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a Lazy.t
 
 val lazy_async :
-  ?cutoff:('a -> 'a -> bool) -> (unit -> 'a Fiber.t) -> 'a Lazy.Async.t
+     ?loc:Loc.t
+  -> ?cutoff:('a -> 'a -> bool)
+  -> (unit -> 'a Fiber.t)
+  -> 'a Lazy.Async.t
 
 module With_implicit_output : sig
   type ('i, 'o, 'f) t


### PR DESCRIPTION
As discussed before, the goal of this PR to make it easier to allow for the generation of rules under a fiber. We now have a primitive:

```ocaml
val fiber : 'a Fiber.t -> 'a Build.t
```

