### PR TITLE
Add a test to find old versions of Dune language in docs

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -12,7 +12,7 @@ like:
 
 .. code:: scheme
 
-          (lang dune 1.0)
+          (lang dune 2.3)
 
 Additionally, they can contains the following stanzas.
 
@@ -247,7 +247,7 @@ It contains the following fields:
   <url>)``, ``(documentation <url>)`` are the same (and take precedence over)
   the corresponding global fields. These fields are available since Dune 2.0.
 
-Adding libraries to different packages is done via  ``public_name`` field. See 
+Adding libraries to different packages is done via  ``public_name`` field. See
 :ref:`library` section for details.
 
 The list of dependencies ``<dep-specification>`` is modeled after opam's own
@@ -1625,7 +1625,7 @@ a typical ``dune-workspace`` file looks like:
 
 .. code:: scheme
 
-    (lang dune 1.0)
+    (lang dune 2.3)
     (context (opam (switch 4.02.3)))
     (context (opam (switch 4.03.0)))
     (context (opam (switch 4.04.0)))
@@ -1637,7 +1637,7 @@ containing exactly:
 
 .. code:: scheme
 
-    (lang dune 1.0)
+    (lang dune 2.3)
     (context default)
 
 This allows you to use an empty ``dune-workspace`` file to mark the root of your

--- a/doc/opam.rst
+++ b/doc/opam.rst
@@ -94,7 +94,7 @@ configuration will tell ``dune`` to generate two opam files: ``cohttp.opam`` and
 
 .. code:: scheme
 
-   (lang dune 2.1)
+   (lang dune 2.3)
    (name cohttp)
 
    (generate_opam_files true)

--- a/doc/test/dune
+++ b/doc/test/dune
@@ -1,0 +1,12 @@
+(rule
+ (alias check-lang-dune)
+ (deps (package dune) (glob_files ../*.rst))
+ (action
+  (progn
+    (run %{bin:cram} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected))))
+
+(alias
+ (name runtest)
+ (deps
+  (alias check-lang-dune)))

--- a/doc/test/run.t
+++ b/doc/test/run.t
@@ -1,0 +1,11 @@
+----------------------------------------------------------------------------------
+Reveal all occurrences of non-latest (lang dune ...) in examples.
+
+  $ touch dune
+  $ dune build > /dev/null 2> /dev/null
+  $ DUNE_LANG=$(cat dune-project)
+  $ grep '(lang dune' ../*.rst | grep -v "$DUNE_LANG"
+  ../formatting.rst:If using ``(lang dune 2.0)``, there is nothing to do, formatting will be set up
+  ../formatting.rst:.. note:: This section applies only to projects with ``(lang dune 1.x)``.
+  ../formatting.rst:In ``(lang dune 1.x)``, no formatting is done by default. This feature is
+  ../formatting.rst:(lang dune 2.0)

--- a/doc/test/run.t
+++ b/doc/test/run.t
@@ -1,5 +1,10 @@
 ----------------------------------------------------------------------------------
-Reveal all occurrences of non-latest (lang dune ...) in examples.
+Reveal all occurrences of non-latest (lang dune ...) version in documentation.
+
+When changing Dune version, you need to update the docs too to make this test pass.
+
+Occasionally we do want to mention an older Dune version in documentation. This
+is fine, but you then need to update the list of such exceptions below.
 
   $ touch dune
   $ dune build > /dev/null 2> /dev/null


### PR DESCRIPTION
Dune docs contain some outdated code examples suggesting to use `(lang dune 1.0)` which may be confusing to users. This commit adds a test that reveals all such occurrences, making it easier to keep the docs up-to-date.

Ideally, we also need to parse all examples using the latest Dune... some day!

