### PR TITLE
Use Action.Prog.t to represent tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,8 +23,11 @@
 - Fix bootstrap on bytecode only switches on windows or where `-j1` is set.
   (#3112, @xclerc, @rgrinberg)
 
-- Allow `enabled_if` fields in `executable(s)` stanzas (#3137,
-  fixes #1690 @voodoos)
+- Allow `enabled_if` fields in `executable(s)` stanzas (#3137, fixes #1690
+  @voodoos)
+
+- Do not fail if `ocamldep`, `ocamlmklib`, or `ocaml` are absent. Wait for them
+  to be used to fail (#3138, @rgrinberg)
 
 2.2.0 (06/02/2020)
 ------------------

--- a/src/dune/action.ml
+++ b/src/dune/action.ml
@@ -42,6 +42,10 @@ module Prog = struct
     | Error (e : Not_found.t) -> Dune_lang.Encoder.string e.program
 
   let to_dyn t = Result.to_dyn Path.to_dyn Not_found.to_dyn t
+
+  let ok_exn = function
+    | Ok s -> s
+    | Error e -> Not_found.raise e
 end
 
 module type Ast =

--- a/src/dune/action.ml
+++ b/src/dune/action.ml
@@ -22,6 +22,14 @@ module Prog = struct
         | _ -> hint
       in
       Utils.program_not_found ?hint ~loc ~context program
+
+    let to_dyn { context; program; hint; loc = _ } =
+      let open Dyn.Encoder in
+      record
+        [ ("context", Context_name.to_dyn context)
+        ; ("program", string program)
+        ; ("hint", option string hint)
+        ]
   end
 
   type t = (Path.t, Not_found.t) result
@@ -32,6 +40,8 @@ module Prog = struct
   let encode = function
     | Ok s -> Dpath.encode s
     | Error (e : Not_found.t) -> Dune_lang.Encoder.string e.program
+
+  let to_dyn t = Result.to_dyn Path.to_dyn Not_found.to_dyn t
 end
 
 module type Ast =

--- a/src/dune/action.mli
+++ b/src/dune/action.mli
@@ -32,6 +32,8 @@ module Prog : sig
   end
 
   type t = (Path.t, Not_found.t) result
+
+  val to_dyn : t -> Dyn.t
 end
 
 include

--- a/src/dune/action.mli
+++ b/src/dune/action.mli
@@ -34,6 +34,8 @@ module Prog : sig
   type t = (Path.t, Not_found.t) result
 
   val to_dyn : t -> Dyn.t
+
+  val ok_exn : t -> Path.t
 end
 
 include

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -473,6 +473,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     in
     if Option.is_some fdo_target_exe then
       check_fdo_support lib_config.has_native ocfg ~name;
+    let ocaml = which_exn "ocaml" in
     let t =
       { name
       ; implicit
@@ -490,10 +491,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
             (Env.get env "OCAML_TOPLEVEL_PATH")
             ~f:Path.of_filename_relative_to_initial_cwd
       ; ocaml_bin = dir
-      ; ocaml =
-          ( match which "ocaml" with
-          | Some p -> p
-          | None -> prog_not_found_in_path "ocaml" )
+      ; ocaml
       ; ocamlc
       ; ocamlopt
       ; ocamldep = get_ocaml_tool "ocamldep"

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -71,7 +71,7 @@ type t = private
   ; toplevel_path : Path.t option
         (** Ocaml bin directory with all ocaml tools *)
   ; ocaml_bin : Path.t
-  ; ocaml : Path.t
+  ; ocaml : Action.Prog.t
   ; ocamlc : Path.t
   ; ocamlopt : Action.Prog.t
   ; ocamldep : Action.Prog.t

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -73,10 +73,10 @@ type t = private
   ; ocaml_bin : Path.t
   ; ocaml : Path.t
   ; ocamlc : Path.t
-  ; ocamlopt : Path.t option
-  ; ocamldep : Path.t
-  ; ocamlmklib : Path.t
-  ; ocamlobjinfo : Path.t option  (** Environment variables *)
+  ; ocamlopt : Action.Prog.t
+  ; ocamldep : Action.Prog.t
+  ; ocamlmklib : Action.Prog.t
+  ; ocamlobjinfo : Action.Prog.t
   ; env : Env.t
   ; findlib : Findlib.t
   ; findlib_toolchain : Context_name.t option  (** Misc *)
@@ -111,7 +111,7 @@ val install_prefix : t -> Path.t Fiber.t
 val install_ocaml_libdir : t -> Path.t option Fiber.t
 
 (** Return the compiler needed for this compilation mode *)
-val compiler : t -> Mode.t -> Path.t option
+val compiler : t -> Mode.t -> Action.Prog.t
 
 (** The best compilation mode for this context *)
 val best_mode : t -> Mode.t

--- a/src/dune/dune_load.ml
+++ b/src/dune/dune_load.ml
@@ -179,9 +179,9 @@ module Dune_files = struct
             ; [ Path.to_absolute_filename (Path.build wrapper) ]
             ]
         in
+        let ocaml = Action.Prog.ok_exn context.ocaml in
         let* () =
-          Process.run Strict ~dir:(Path.source dir) ~env:context.env
-            context.ocaml args
+          Process.run Strict ~dir:(Path.source dir) ~env:context.env ocaml args
         in
         if not (Path.exists (Path.build generated_dune_file)) then
           User_error.raise

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -48,7 +48,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   let linkages =
     let module L = Dune_file.Executables.Link_mode in
     let l =
-      let has_native = Option.is_some ctx.ocamlopt in
+      let has_native = Result.is_ok ctx.ocamlopt in
       let modes =
         let add_if_not_already_present modes mode loc =
           match L.Map.add exes.modes mode loc with

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -19,7 +19,7 @@ let build_lib (lib : Library.t) ~sctx ~dir_contents ~expander ~flags ~dir ~mode
     ~cm_files =
   let ctx = Super_context.context sctx in
   let { Lib_config.ext_lib; _ } = ctx.lib_config in
-  Option.iter (Context.compiler ctx mode) ~f:(fun compiler ->
+  Result.iter (Context.compiler ctx mode) ~f:(fun compiler ->
       let target = Library.archive lib ~dir ~ext:(Mode.compiled_lib_ext mode) in
       let stubs_flags =
         List.concat_map (Library.foreign_archives lib) ~f:(fun archive ->
@@ -132,7 +132,7 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
            ~standard:(Build.return [])
        in
        let ctx = Super_context.context sctx in
-       Command.run ~dir:(Path.build ctx.build_dir) (Ok ctx.ocamlmklib)
+       Command.run ~dir:(Path.build ctx.build_dir) ctx.ocamlmklib
          [ A "-g"
          ; ( if custom then
              A "-custom"
@@ -231,7 +231,7 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents
 
 let build_shared lib ~dir_contents ~sctx ~dir ~flags =
   let ctx = Super_context.context sctx in
-  Option.iter ctx.ocamlopt ~f:(fun ocamlopt ->
+  Result.iter ctx.ocamlopt ~f:(fun ocamlopt ->
       let ext_lib = ctx.lib_config.ext_lib in
       let src =
         let ext = Mode.compiled_lib_ext Native in

--- a/src/dune/module_compilation.ml
+++ b/src/dune/module_compilation.ml
@@ -56,7 +56,7 @@ let build_cm cctx ~dep_graphs ~precompiled_cmi ~cm_kind (m : Module.t) ~phase =
   let dynlink = CC.dynlink cctx in
   let sandbox = CC.sandbox cctx in
   (let open Option.O in
-  let* compiler = Context.compiler ctx mode in
+  let* compiler = Result.to_option (Context.compiler ctx mode) in
   let ml_kind = Cm_kind.source cm_kind in
   let+ src = Module.file m ~ml_kind in
   let dst = Obj_dir.Module.cm_file_unsafe obj_dir m ~kind:cm_kind in

--- a/src/dune/ocamldep.ml
+++ b/src/dune/ocamldep.ml
@@ -77,7 +77,7 @@ let deps_of ~cctx ~ml_kind unit =
     (let flags =
        Option.value (Module.pp_flags unit) ~default:(Build.return [])
      in
-     Command.run (Ok context.ocamldep)
+     Command.run context.ocamldep
        ~dir:(Path.build context.build_dir)
        [ A "-modules"
        ; Command.Args.dyn flags

--- a/src/dune/ocamlobjinfo.mll
+++ b/src/dune/ocamlobjinfo.mll
@@ -43,15 +43,6 @@ let rules ~dir ~(ctx : Context.t) ~unit =
     Path.Build.relative dir (Path.basename unit)
     |> Path.Build.extend_basename ~suffix:".ooi-deps"
   in
-  let bin =
-    match ctx.ocamlobjinfo with
-    | None ->
-      Error (
-        let context = Context.name ctx in
-        let program = "ocamlobjinfo" in
-        Action.Prog.Not_found.create ~context ~program ~loc:None ())
-    | Some bin -> Ok bin
-  in
   let no_approx =
     if Ocaml_version.ooi_supports_no_approx ctx.version then
       [Command.Args.A "-no-approx"]
@@ -64,7 +55,7 @@ let rules ~dir ~(ctx : Context.t) ~unit =
     else
       []
   in
-  ( Command.run ~dir:(Path.build dir) bin
+  ( Command.run ~dir:(Path.build dir) ctx.ocamlobjinfo
       (List.concat
          [ no_approx
          ; no_code

--- a/src/dune/pform.ml
+++ b/src/dune/pform.ml
@@ -193,8 +193,8 @@ module Map = struct
   let create ~(context : Context.t) =
     let ocamlopt =
       match context.ocamlopt with
-      | None -> Path.relative context.ocaml_bin "ocamlopt"
-      | Some p -> p
+      | Error _ -> Path.relative context.ocaml_bin "ocamlopt"
+      | Ok p -> p
     in
     let string s = values [ Value.String s ] in
     let path p = values [ Value.Path p ] in

--- a/src/dune/pform.ml
+++ b/src/dune/pform.ml
@@ -196,6 +196,11 @@ module Map = struct
       | Error _ -> Path.relative context.ocaml_bin "ocamlopt"
       | Ok p -> p
     in
+    let ocaml =
+      match context.ocaml with
+      | Error _ -> Path.relative context.ocaml_bin "ocaml"
+      | Ok p -> p
+    in
     let string s = values [ Value.String s ] in
     let path p = values [ Value.Path p ] in
     let make =
@@ -217,7 +222,7 @@ module Map = struct
             @ [ "-undef"; "-traditional"; "-x"; "c"; "-E" ] ) )
       ; ("cc", strings (c_compiler :: cflags))
       ; ("cxx", strings (c_compiler :: cxx_flags))
-      ; ("ocaml", path context.ocaml)
+      ; ("ocaml", path ocaml)
       ; ("ocamlc", path context.ocamlc)
       ; ("ocamlopt", path ocamlopt)
       ; ("arch_sixtyfour", string (string_of_bool context.arch_sixtyfour))

--- a/src/dune/preprocessing.ml
+++ b/src/dune/preprocessing.ml
@@ -303,7 +303,7 @@ let build_ppx_driver sctx ~dep_kind ~target ~pps ~pp_names =
     | Byte -> Byte_with_stubs_statically_linked_in
     | Native -> Native
   in
-  let compiler = Option.value_exn (Context.compiler ctx mode) in
+  let compiler = Context.compiler ctx mode in
   let jbuild_driver, pps, pp_names = (None, pps, pp_names) in
   let driver_and_libs =
     let open Result.O in
@@ -333,7 +333,7 @@ let build_ppx_driver sctx ~dep_kind ~target ~pps ~pp_names =
     ( Build.with_no_targets
         (Build.record_lib_deps
            (Lib_deps.info ~kind:dep_kind (Lib_deps.of_pps pp_names)))
-    >>> Command.run (Ok compiler) ~dir:(Path.build ctx.build_dir)
+    >>> Command.run compiler ~dir:(Path.build ctx.build_dir)
           [ A "-o"
           ; Target target
           ; A "-w"

--- a/src/stdune/result.ml
+++ b/src/stdune/result.ml
@@ -36,6 +36,11 @@ let map_error x ~f =
   | Ok _ as res -> res
   | Error x -> Error (f x)
 
+let iter t ~f =
+  match t with
+  | Ok x -> f x
+  | Error _ -> ()
+
 let to_option = function
   | Ok p -> Some p
   | Error _ -> None

--- a/src/stdune/result.mli
+++ b/src/stdune/result.mli
@@ -10,6 +10,8 @@ val is_ok : _ t -> bool
 
 val is_error : _ t -> bool
 
+val iter : ('a, _) t -> f:('a -> unit) -> unit
+
 val ok_exn : ('a, exn) t -> 'a
 
 val try_with : (unit -> 'a) -> ('a, exn) t


### PR DESCRIPTION
This is ultimately the value that we need to pass to Command to create
build rules that fail as late as possible.