### PR TITLE
Add a "plugin" linking mode for executables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,13 @@
 
 - Fix separate compilation of JS when findlib is not installed. (#3177, @nojb)
 
-- Add a `dune describe` command to obtain the topology of a dune
-  workspace, for projects such as ROTOR. (#3128, @diml)
+- Add a `dune describe` command to obtain the topology of a dune workspace, for
+  projects such as ROTOR. (#3128, @diml)
+
+- Add `plugin` linking mode for executables and the `(embed_in_plugin_libraries
+  ...)` field. (#3141, @nojb)
+
+- Add an `%{ext_plugin}` variable (#3141, @nojb)
 
 - Dune will no longer build shared objects for stubs if
   `supports_shared_libraries` is false (#3225, fixes #3222, @rgrinberg)

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -156,6 +156,8 @@ Dune supports the following variables:
 -  ``null`` is ``/dev/null`` on Unix or ``nul`` on Windows
 -  ``ext_obj``, ``ext_asm``, ``ext_lib``, ``ext_dll`` and ``ext_exe``
    are the file extension used for various artifacts
+- ``ext_plugin`` is ``.cmxs`` if ``natdynlink`` is supported and
+  ``.cma`` otherwise.
 - ``ocaml-config:v`` for every variable ``v`` in the output of
   ``ocamlc -config``. Note that dune processes the output
   of ``ocamlc -config`` in order to make it a bit more stable across

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -668,6 +668,12 @@ Executables can also be linked as object or shared object files. See
   pulled in. This field is available since the 2.0 version of the dune
   language.
 
+- ``(embed_in_plugin_libraries <library-list>)`` specifies a list of libraries
+  to link statically when using ``plugin`` linking mode. By default, no
+  libraries are linked in. Note that you may need to also use the ``-linkall``
+  flag if some of the libraries listed here are not referenced from any of the
+  plugin modules.
+
 Linking modes
 ~~~~~~~~~~~~~
 
@@ -692,6 +698,8 @@ compilation is not available.
   in OCaml for a non-OCaml application.
 - ``js`` for producing JavaScript from bytecode executables, see
   :ref:`explicit-js-mode`.
+- ``plugin`` for producing a plugin (``.cmxs`` if native or ``.cma``
+  if bytecode).
 
 For instance the following ``executables`` stanza will produce byte
 code executables and native shared objects:
@@ -711,6 +719,7 @@ Additionally, you can use the following short-hands:
 - ``byte`` for ``(byte exe)``
 - ``native`` for ``(native exe)``
 - ``js`` for ``(byte js)``
+- ``plugin`` for ``(best plugin)``
 
 For instance the following ``modes`` fields are all equivalent:
 
@@ -741,6 +750,9 @@ byte_complete               .bc.exe
 (native/best shared_object) %{ext_dll}
 c                           .bc.c
 js                          .bc.js
+(best plugin)               %{ext_plugin}
+(byte plugin)               .cma
+(native plugin)             .cmxs
 =========================== =================
 
 Where ``%{ext_obj}`` and ``%{ext_dll}`` are the extensions for object

--- a/src/dune/binary_kind.ml
+++ b/src/dune/binary_kind.ml
@@ -5,6 +5,7 @@ type t =
   | Exe
   | Object
   | Shared_object
+  | Plugin
   | Js
 
 let decode =
@@ -14,6 +15,7 @@ let decode =
     ; ("exe", return Exe)
     ; ("object", return Object)
     ; ("shared_object", return Shared_object)
+    ; ("plugin", Dune_lang.Syntax.since Stanza.syntax (2, 4) >>> return Plugin)
     ; ("js", Dune_lang.Syntax.since Stanza.syntax (1, 11) >>> return Js)
     ]
 
@@ -22,6 +24,7 @@ let to_string = function
   | Exe -> "exe"
   | Object -> "object"
   | Shared_object -> "shared_object"
+  | Plugin -> "plugin"
   | Js -> "js"
 
 let to_dyn t =
@@ -30,4 +33,4 @@ let to_dyn t =
 
 let encode t = Dune_lang.unsafe_atom_of_string (to_string t)
 
-let all = [ C; Exe; Object; Shared_object; Js ]
+let all = [ C; Exe; Object; Shared_object; Plugin; Js ]

--- a/src/dune/binary_kind.mli
+++ b/src/dune/binary_kind.mli
@@ -7,6 +7,7 @@ type t =
   | Exe
   | Object
   | Shared_object
+  | Plugin
   | Js
 
 include Dune_lang.Conv.S with type t := t

--- a/src/dune/compilation_context.ml
+++ b/src/dune/compilation_context.ml
@@ -186,3 +186,10 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
   }
 
 let for_wrapped_compat t = { t with includes = Includes.empty; stdlib = None }
+
+let for_plugin_executable t ~embed_in_plugin_libraries =
+  let libs = Scope.libs t.scope in
+  let requires_link =
+    lazy (Result.List.map ~f:(Lib.DB.resolve libs) embed_in_plugin_libraries)
+  in
+  { t with requires_link }

--- a/src/dune/compilation_context.mli
+++ b/src/dune/compilation_context.mli
@@ -78,3 +78,6 @@ val for_wrapped_compat : t -> t
 
 val for_module_generated_at_link_time :
   t -> requires:Lib.t list Or_exn.t -> module_:Module.t -> t
+
+val for_plugin_executable :
+  t -> embed_in_plugin_libraries:(Loc.t * Lib_name.t) list -> t

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -294,6 +294,7 @@ module Executables : sig
     ; package : Package.t option
     ; promote : Rule.Promote.t option
     ; install_conf : File_binding.Unexpanded.t Install_conf.t option
+    ; embed_in_plugin_libraries : (Loc.t * Lib_name.t) list
     ; forbidden_libraries : (Loc.t * Lib_name.t) list
     ; bootstrap_info : string option
     ; enabled_if : Blang.t

--- a/src/dune/exe.mli
+++ b/src/dune/exe.mli
@@ -41,6 +41,7 @@ val build_and_link :
   -> promote:Rule.Promote.t option
   -> ?link_args:Command.Args.static Command.Args.t Build.t
   -> ?o_files:Path.t list
+  -> ?embed_in_plugin_libraries:(Loc.t * Lib_name.t) list
   -> Compilation_context.t
   -> unit
 
@@ -50,6 +51,7 @@ val build_and_link_many :
   -> promote:Rule.Promote.t option
   -> ?link_args:Command.Args.static Command.Args.t Build.t
   -> ?o_files:Path.t list
+  -> ?embed_in_plugin_libraries:(Loc.t * Lib_name.t) list
   -> Compilation_context.t
   -> unit
 

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -5,7 +5,7 @@ module SC = Super_context
 module Executables = Dune_file.Executables
 
 let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
-    (exes : Dune_file.Executables.t) =
+    ~embed_in_plugin_libraries (exes : Dune_file.Executables.t) =
   (* Use "eobjs" rather than "objs" to avoid a potential conflict with a library
      of the same name *)
   let obj_dir = Dune_file.Executables.obj_dir exes ~dir in
@@ -161,7 +161,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   in
   let requires_compile = Compilation_context.requires_compile cctx in
   Exe.build_and_link_many cctx ~programs ~linkages ~link_args ~o_files
-    ~promote:exes.promote;
+    ~promote:exes.promote ~embed_in_plugin_libraries;
   ( cctx
   , Merlin.make () ~requires:requires_compile ~flags ~modules
       ~preprocess:(Dune_file.Buildable.single_preprocess exes.buildable)
@@ -181,7 +181,7 @@ let rules ~sctx ~dir ~dir_contents ~scope ~expander
   in
   let f () =
     executables_rules exes ~sctx ~dir ~dir_contents ~scope ~expander
-      ~compile_info
+      ~compile_info ~embed_in_plugin_libraries:exes.embed_in_plugin_libraries
   in
   SC.Libs.gen_select_rules sctx compile_info ~dir;
   Bootstrap_info.gen_rules sctx exes ~dir compile_info;

--- a/src/dune/link_time_code_gen.mli
+++ b/src/dune/link_time_code_gen.mli
@@ -3,7 +3,7 @@
 open Stdune
 
 type t =
-  { to_link : Lib.Lib_and_module.t list
+  { to_link : Lib.Lib_and_module.L.t
   ; force_linkall : bool
   }
 

--- a/src/dune/pform.ml
+++ b/src/dune/pform.ml
@@ -328,6 +328,13 @@ module Map = struct
       let model = Ocaml_config.model context.ocaml_config in
       let system = Ocaml_config.system context.ocaml_config in
       let version_string = Ocaml_config.version_string context.ocaml_config in
+      let ext_plugin =
+        Mode.plugin_ext
+          ( if Ocaml_config.natdynlink_supported context.ocaml_config then
+            Mode.Native
+          else
+            Mode.Byte )
+      in
       [ ("-verbose", values [])
       ; ("ocaml_bin", values [ Dir context.ocaml_bin ])
       ; ("ocaml_version", string version_string)
@@ -338,6 +345,7 @@ module Map = struct
       ; ("ext_lib", string context.lib_config.ext_lib)
       ; ("ext_dll", string context.lib_config.ext_dll)
       ; ("ext_exe", string ext_exe)
+      ; ("ext_plugin", since ~version:(2, 4) (Var.Values [ String ext_plugin ]))
       ; ("profile", string (Profile.to_string context.profile))
       ; ("workspace_root", values [ Value.Dir (Path.build context.build_dir) ])
       ; ("context_name", string (Context_name.to_string context.name))

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1637,6 +1637,16 @@
    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias plugin-mode)
+ (deps (package dune) (source_tree test-cases/plugin-mode))
+ (action
+  (chdir
+   test-cases/plugin-mode
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
+
+(rule
  (alias ppx-rewriter)
  (deps (package dune) (source_tree test-cases/ppx-rewriter))
  (action
@@ -2575,6 +2585,7 @@
   (alias package-dep)
   (alias path-variables)
   (alias pkg-config-quoting)
+  (alias plugin-mode)
   (alias ppx-rewriter)
   (alias ppx-runtime-dependencies)
   (alias preprocess-with-action)
@@ -2836,6 +2847,7 @@
   (alias output-obj)
   (alias path-variables)
   (alias pkg-config-quoting)
+  (alias plugin-mode)
   (alias preprocess-with-action)
   (alias private-modules)
   (alias project-root)

--- a/test/blackbox-tests/test-cases/plugin-mode/run.t
+++ b/test/blackbox-tests/test-cases/plugin-mode/run.t
@@ -1,0 +1,171 @@
+Testsuite for (mode plugin).
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.4)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name a)
+  >  (modules a)
+  >  (modes plugin exe)
+  >  (libraries foo))
+  > 
+  > (executable
+  >  (name b)
+  >  (modules b)
+  >  (modes plugin)
+  >  (libraries bar)
+  >  (embed_in_plugin_libraries foo))
+  > 
+  > (rule
+  >  (alias t)
+  >  (action (echo "%{ext_plugin}\n")))
+  > EOF
+
+  $ cat > a.ml <<EOF
+  > let () =
+  >   Foo.f ()
+  > EOF
+
+  $ cat > b.ml <<EOF
+  > let () =
+  >   Foo.f ()
+  > EOF
+
+  $ mkdir foo main main2
+
+  $ cat > foo/dune <<EOF
+  > (library
+  >  (name foo)
+  >  (modules foo))
+  > 
+  > (library
+  >  (name bar)
+  >  (libraries foo)
+  >  (modules bar))
+  > EOF
+
+  $ cat > foo/foo.ml <<EOF
+  > let f () =
+  >   print_endline "12"
+  > EOF
+
+  $ cat > foo/bar.ml <<EOF
+  > let g () =
+  >   Foo.f ()
+  > EOF
+
+  $ cat > main/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (link_flags -linkall)
+  >  (libraries dynlink foo))
+  > EOF
+
+  $ cat > main/main.ml <<EOF
+  > let () =
+  >   Dynlink.loadfile (Dynlink.adapt_filename "a.cma")
+  > EOF
+
+  $ cat > main2/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (libraries dynlink))
+  > EOF
+
+  $ cat > main2/main.ml <<EOF
+  > let () =
+  >   Dynlink.loadfile (Dynlink.adapt_filename "b.cma")
+  > EOF
+
+  $ dune build --display short @all
+      ocamldep foo/.foo.objs/foo.ml.d
+        ocamlc foo/.foo.objs/byte/foo.{cmi,cmo,cmt}
+        ocamlc foo/foo.cma
+      ocamldep $ext_lib.eobjs/a.ml.d
+        ocamlc $ext_lib.eobjs/byte/dune__exe__A.{cmi,cmo,cmt}
+      ocamlopt $ext_lib.eobjs/native/dune__exe__A.{cmx,o}
+      ocamlopt a.cmxs
+      ocamldep foo/.bar.objs/bar.ml.d
+        ocamlc foo/.bar.objs/byte/bar.{cmi,cmo,cmt}
+        ocamlc foo/bar.cma
+      ocamldep .b.eobjs/b.ml.d
+        ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
+      ocamlopt .b.eobjs/native/dune__exe__B.{cmx,o}
+      ocamldep main/.main.eobjs/main.ml.d
+        ocamlc main/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
+      ocamlopt main/.main.eobjs/native/dune__exe__Main.{cmx,o}
+      ocamldep main2/.main.eobjs/main.ml.d
+        ocamlc main2/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
+      ocamlopt main2/.main.eobjs/native/dune__exe__Main.{cmx,o}
+      ocamlopt main2/main.exe
+      ocamlopt foo/.foo.objs/native/foo.{cmx,o}
+      ocamlopt foo/foo.{a,cmxa}
+      ocamlopt b.cmxs
+      ocamlopt foo/.bar.objs/native/bar.{cmx,o}
+      ocamlopt foo/bar.{a,cmxa}
+      ocamlopt foo/bar.cmxs
+      ocamlopt foo/foo.cmxs
+      ocamlopt main/main.exe
+      ocamlopt a.exe
+
+  $ (cd _build/default && main/main.exe)
+  12
+
+  $ (cd _build/default && main2/main.exe)
+  12
+
+  $ dune build @t
+  .cmxs
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name a)
+  >  (modules a)
+  >  (embed_in_plugin_libraries xxx))
+  > EOF
+
+  $ dune build @all
+  File "dune", line 4, characters 28-31:
+  4 |  (embed_in_plugin_libraries xxx))
+                                  ^^^
+  Error: This field can only be used when linking a plugin.
+  [1]
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name a)
+  >  (modules a)
+  >  (modes plugin)
+  >  (libraries foo)
+  >  (embed_in_plugin_libraries xxx))
+  > EOF
+
+  $ dune build @all
+  File "dune", line 6, characters 28-31:
+  6 |  (embed_in_plugin_libraries xxx))
+                                  ^^^
+  Error: Library "xxx" not found.
+  [1]
+
+  $ cat > dune <<EOF
+  > (rule (with-stdout-to xxx.ml (echo "let () = print_endline \"Hello, xxx\"")))
+  > 
+  > (library
+  >  (name xxx)
+  >  (modules xxx))
+  > 
+  > (executable
+  >  (name a)
+  >  (modules a)
+  >  (link_flags -linkall)
+  >  (modes plugin)
+  >  (libraries foo)
+  >  (embed_in_plugin_libraries xxx))
+  > EOF
+
+  $ dune build @all
+  $ (cd _build/default && main/main.exe)
+  Hello, xxx
+  12


### PR DESCRIPTION
This PR implements https://github.com/ocaml/dune/issues/1544#issuecomment-439058759. Concretely, it adds a `plugin` linking mode for `executable` and `executables` stanzas, which produce a `.cmxs` (native) and `.cma` (bytecode) targets. By default the libraries in `(libraries ...)` are used for compilation, but are not linked into the resulting plugin. However, a new field is also added `(statically_linked_libraries ...)` (provisional name) which can specify an explicit list of libraries to be linked in.

Should solve #3136, #1544 and https://discuss.ocaml.org/t/dune-problems-using-dynlink-plugins/2874