### PR TITLE
Remove api bloat in File_tree

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -101,8 +101,12 @@ module Main = struct
                          |> List.map ~f:Package.Name.to_string )));
           Package.Name.Map.filter workspace.conf.packages ~f:(fun pkg ->
               let vendored =
-                Dune.File_tree.find_dir pkg.path
-                |> Option.value_exn |> Dune.File_tree.Dir.vendored
+                match Dune.File_tree.find_dir pkg.path with
+                | None -> assert false
+                | Some d -> (
+                  match Dune.File_tree.Dir.status d with
+                  | Vendored -> true
+                  | _ -> false )
               in
               let included = Package.Name.Set.mem names pkg.name in
               if vendored && included then

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -270,8 +270,12 @@ let file_operations ~dry_run ~workspace : (module File_operations) =
     end) )
 
 let package_is_vendored (pkg : Dune.Package.t) =
-  Dune.File_tree.find_dir pkg.path
-  |> Option.value_exn |> Dune.File_tree.Dir.vendored
+  match Dune.File_tree.find_dir pkg.path with
+  | None -> assert false
+  | Some d -> (
+    match Dune.File_tree.Dir.status d with
+    | Vendored -> true
+    | _ -> false )
 
 let install_uninstall ~what =
   let doc = sprintf "%s packages." (String.capitalize what) in

--- a/src/dune/dune_load.ml
+++ b/src/dune/dune_load.ml
@@ -240,7 +240,7 @@ let load ~ancestor_vcs () =
                 ]))
   in
   let rec walk dir dune_files =
-    if File_tree.Dir.data_only dir then
+    if File_tree.Dir.status dir = Data_only then
       dune_files
     else
       let path = File_tree.Dir.path dir in

--- a/src/dune/file_tree.ml
+++ b/src/dune/file_tree.ml
@@ -228,9 +228,7 @@ module Dir0 = struct
 
   let path t = t.path
 
-  let data_only t = t.status = Data_only
-
-  let vendored t = t.status = Vendored
+  let status t = t.status
 
   let files t = (contents t).files
 
@@ -534,9 +532,6 @@ let file_exists path =
   | Some dir -> String.Set.mem (Dir0.files dir) (Path.Source.basename path)
 
 let dir_exists path = Option.is_some (find_dir path)
-
-let dir_is_vendored path =
-  Option.map ~f:(fun dir -> Dir0.vendored dir) (find_dir path)
 
 module Dir = struct
   include Dir0

--- a/src/dune/file_tree.mli
+++ b/src/dune/file_tree.mli
@@ -37,14 +37,9 @@ module Dir : sig
 
   val sub_dir_names : t -> String.Set.t
 
-  (** Whether this directory is ignored by an [ignored_subdirs] stanza in one of
-      its ancestor directories. Or the directory is set to data only *)
-  val data_only : t -> bool
-
-  (** Whether this directory is vendored or sits within a vendored directory *)
-  val vendored : t -> bool
-
   val vcs : t -> Vcs.t option
+
+  val status : t -> Sub_dirs.Status.t
 
   val fold :
     t -> traverse:Sub_dirs.Status.Set.t -> init:'a -> f:(t -> 'a -> 'a) -> 'a
@@ -85,10 +80,6 @@ val files_of : Path.Source.t -> Path.Source.Set.t
 
 (** [true] iff the path is a directory *)
 val dir_exists : Path.Source.t -> bool
-
-(** [dir_is_vendored t path] tells whether [path] is a vendored directory.
-    Returns [None] if it doesn't describe a directory within [t]. *)
-val dir_is_vendored : Path.Source.t -> bool option
 
 (** [true] iff the path is a file *)
 val file_exists : Path.Source.t -> bool

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -229,7 +229,16 @@ let gen_rules sctx dir_contents cctxs
   in
   let allow_approx_merlin =
     let dune_project = Scope.project scope in
-    let dir_is_vendored = Super_context.dir_is_vendored src_dir in
+    let status =
+      let open Option.O in
+      let+ src_dir = File_tree.find_dir src_dir in
+      File_tree.Dir.status src_dir
+    in
+    let dir_is_vendored =
+      match status with
+      | Some Vendored -> true
+      | _ -> false
+    in
     dir_is_vendored || Dune_project.allow_approx_merlin dune_project
   in
   Option.iter (Merlin.merge_all ~allow_approx_merlin merlins) ~f:(fun m ->

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -280,14 +280,12 @@ let partial_expand sctx ~dep_kind ~targets_written_by_user ~map_exe ~expander t
   let partial = Action_unexpanded.partial_expand t ~expander ~map_exe in
   (partial, acc)
 
-let dir_is_vendored src_dir =
-  Option.value ~default:false (File_tree.dir_is_vendored src_dir)
-
 let build_dir_is_vendored build_dir =
   let opt =
     let open Option.O in
-    let+ src_dir = Path.Build.drop_build_context build_dir in
-    dir_is_vendored src_dir
+    let* src_dir = Path.Build.drop_build_context build_dir in
+    let+ src_dir = File_tree.find_dir src_dir in
+    Sub_dirs.Status.Vendored = File_tree.Dir.status src_dir
   in
   Option.value ~default:false opt
 

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -88,9 +88,6 @@ val find_scope_by_project : t -> Dune_project.t -> Scope.t
 
 val find_project_by_key : t -> Dune_project.File_key.t -> Dune_project.t
 
-(** Tells whether the given source directory is marked as vendored *)
-val dir_is_vendored : Path.Source.t -> bool
-
 val add_rule :
      t
   -> ?sandbox:Sandbox_config.t


### PR DESCRIPTION
There's quite a few functions that just wrap various ways of donig
projections. The API is easier to understand if we get rid of all this
stuff.