### PR TITLE
Use invalid module name as source

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1549,6 +1549,16 @@
     (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias invalid-module-name)
+ (deps (package dune) (source_tree test-cases/invalid-module-name))
+ (action
+  (chdir
+   test-cases/invalid-module-name
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
+
+(rule
  (alias js_of_ocaml)
  (deps (package dune) (source_tree test-cases/js_of_ocaml))
  (action
@@ -2818,6 +2828,7 @@
   (alias installable-dup-private-libs)
   (alias intf-only)
   (alias invalid-dune-package)
+  (alias invalid-module-name)
   (alias lib)
   (alias lib-available)
   (alias lib-errors)
@@ -3068,6 +3079,7 @@
   (alias installable-dup-private-libs)
   (alias intf-only)
   (alias invalid-dune-package)
+  (alias invalid-module-name)
   (alias lib)
   (alias lib-available)
   (alias lib-errors)

--- a/test/blackbox-tests/test-cases/invalid-module-name/run.t
+++ b/test/blackbox-tests/test-cases/invalid-module-name/run.t
@@ -1,0 +1,14 @@
+Dune does not report an invalid module name as an error
+  $ echo "(lang dune 2.2)" > dune-project
+  $ cat >dune <<EOF
+  > (library (name foo))
+  > EOF
+  $ touch foo.ml foo-as-bar.ml
+  $ dune build @all --display short
+      ocamldep .foo.objs/foo.ml.d
+  File "foo__.ml-gen", line 2, characters 10-11:
+  2 | module Foo-as-bar = Foo__Foo-as-bar
+                ^
+  Error: Syntax error
+      ocamldep .foo.objs/foo-as-bar.ml.d
+  [1]


### PR DESCRIPTION
Reproduces an issue where dune is attempting to build with an invalid
module name.

@diml what do you think is the correct behavior here? Shall we just ignore such
sources or warn/error?