### PR TITLE
Remove an ad-hoc cache table for Opam config variables

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -15,7 +15,7 @@ let get_dirs context ~prefix_from_command_line ~libdir_from_command_line =
     Fiber.return (prefix, Some (Path.relative prefix dir))
   | None ->
     let open Fiber.O in
-    let* prefix = Context.install_prefix context in
+    let* prefix = Memo.Lazy.Async.force context.Context.install_prefix in
     let libdir =
       match libdir_from_command_line with
       | None -> Context.install_ocaml_libdir context

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -8,11 +8,12 @@
 
     - opam switch contexts, where one opam switch correspond to one context
 
-    each context is built into a sub-directory of Path.build_dir (usually
+    each context is built into a sub-directory of [Path.build_dir] (usually
     _build):
 
-    - _build/default for the default context - _build/<switch> for other
-    contexts
+    - _build/default for the default context
+
+    - _build/<switch> for other contexts
 
     Dune is able to build simultaneously against several contexts. In particular
     this allow for simple cross-compilation: when an executable running on the
@@ -39,17 +40,6 @@ module Env_nodes : sig
     { context : Dune_env.Stanza.t
     ; workspace : Dune_env.Stanza.t
     }
-end
-
-module Opam_config_var : sig
-  module Name : sig
-    type t = string
-  end
-
-  (* The [None] case means the variable is not set. *)
-  module Value : sig
-    type t = string option
-  end
 end
 
 type t = private
@@ -92,8 +82,7 @@ type t = private
   ; findlib : Findlib.t
   ; findlib_toolchain : Context_name.t option  (** Misc *)
   ; arch_sixtyfour : bool
-  ; opam_config_var_memo :
-      (Opam_config_var.Name.t, Opam_config_var.Value.t) Memo.Async.t
+  ; install_prefix : Path.t Memo.Lazy.Async.t
   ; ocaml_config : Ocaml_config.t
   ; version : Ocaml_version.t
   ; stdlib_dir : Path.t
@@ -115,11 +104,6 @@ val to_dyn_concise : t -> Dyn.t
 val compare : t -> t -> Ordering.t
 
 val which : t -> string -> Path.t option
-
-val opam_config_var :
-  t -> Opam_config_var.Name.t -> Opam_config_var.Value.t Fiber.t
-
-val install_prefix : t -> Path.t Fiber.t
 
 val install_ocaml_libdir : t -> Path.t option Fiber.t
 

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -41,6 +41,17 @@ module Env_nodes : sig
     }
 end
 
+module Opam_config_var : sig
+  module Name : sig
+    type t = string
+  end
+
+  (* The [None] case means the variable is not set. *)
+  module Value : sig
+    type t = string option
+  end
+end
+
 type t = private
   { name : Context_name.t
   ; kind : Kind.t
@@ -81,7 +92,8 @@ type t = private
   ; findlib : Findlib.t
   ; findlib_toolchain : Context_name.t option  (** Misc *)
   ; arch_sixtyfour : bool
-  ; opam_var_cache : (string, string) Table.t
+  ; opam_config_var_memo :
+      (Opam_config_var.Name.t, Opam_config_var.Value.t) Memo.Async.t
   ; ocaml_config : Ocaml_config.t
   ; version : Ocaml_version.t
   ; stdlib_dir : Path.t
@@ -104,7 +116,8 @@ val compare : t -> t -> Ordering.t
 
 val which : t -> string -> Path.t option
 
-val opam_config_var : t -> string -> string option Fiber.t
+val opam_config_var :
+  t -> Opam_config_var.Name.t -> Opam_config_var.Value.t Fiber.t
 
 val install_prefix : t -> Path.t Fiber.t
 

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -18,7 +18,8 @@ end
 
 module Map = Map.Make (Var)
 
-(* CR-soon amokhov: replace [mutable] with [Memo.Lazy]. *)
+(* The use of [mutable] here is safe, since we never call (back) to the
+   memoization framework when computing [unix]. *)
 type t =
   { vars : string Map.t
   ; mutable unix : string array option

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -18,6 +18,7 @@ end
 
 module Map = Map.Make (Var)
 
+(* CR-soon amokhov: replace [mutable] with [Memo.Lazy]. *)
 type t =
   { vars : string Map.t
   ; mutable unix : string array option
@@ -54,7 +55,7 @@ let of_unix arr =
          match String.lsplit2 s ~on:'=' with
          | None ->
            Code_error.raise
-             "Env.of_unix: entry without '=' found in the environ"
+             "Env.of_unix: entry without '=' found in the environment"
              [ ("var", String s) ]
          | Some (k, v) -> (k, v))
   |> Map.of_list_multi


### PR DESCRIPTION
It turned out we only ever look up two OPAM config variables: `lib` and `prefix`. Both can be turned into lazy values instead.