### PR TITLE
Move Ccomp_type to Ocaml_config

### DIFF
--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -64,7 +64,6 @@ module T = struct
     ; ocaml_config : Ocaml_config.t
     ; version : Ocaml_version.t
     ; stdlib_dir : Path.t
-    ; ccomp_type : Lib_config.Ccomp_type.t
     ; supports_shared_libraries : Dynlink_supported.By_the_os.t
     ; which_cache : (string, Path.t option) Table.t
     ; lib_config : Lib_config.t
@@ -455,7 +454,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     let version = Ocaml_version.of_ocaml_config ocfg in
     let arch_sixtyfour = Ocaml_config.word_size ocfg = 64 in
     let ocamlopt = get_ocaml_tool "ocamlopt" in
-    let ccomp_type = Lib_config.Ccomp_type.of_config ocfg in
     let lib_config =
       { Lib_config.has_native = Result.is_ok ocamlopt
       ; ext_obj = Ocaml_config.ext_obj ocfg
@@ -468,7 +466,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; natdynlink_supported =
           Dynlink_supported.By_the_os.of_bool natdynlink_supported
       ; stdlib_dir
-      ; ccomp_type
+      ; ccomp_type = Ocaml_config.ccomp_type ocfg
       }
     in
     if Option.is_some fdo_target_exe then
@@ -512,7 +510,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; stdlib_dir
       ; ocaml_config = ocfg
       ; version
-      ; ccomp_type
       ; supports_shared_libraries =
           Dynlink_supported.By_the_os.of_bool
             (Ocaml_config.supports_shared_libraries ocfg)
@@ -824,7 +821,7 @@ let best_mode t : Mode.t =
   | Error _ -> Byte
 
 let cc_g (ctx : t) =
-  match ctx.ccomp_type with
+  match ctx.lib_config.ccomp_type with
   | Msvc -> []
   | Other _ -> [ "-g" ]
 

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -85,7 +85,6 @@ type t = private
   ; ocaml_config : Ocaml_config.t
   ; version : Ocaml_version.t
   ; stdlib_dir : Path.t
-  ; ccomp_type : Lib_config.Ccomp_type.t
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; which_cache : (string, Path.t option) Table.t
   ; lib_config : Lib_config.t

--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -103,7 +103,7 @@ let build_cxx_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
   let flags = Foreign.Source.flags src in
   let ctx = Super_context.context sctx in
   let output_param =
-    match ctx.ccomp_type with
+    match ctx.lib_config.ccomp_type with
     | Msvc -> [ Command.Args.Concat ("", [ A "/Fo"; Target dst ]) ]
     | Other _ -> [ A "-o"; Target dst ]
   in

--- a/src/dune/lib_config.ml
+++ b/src/dune/lib_config.ml
@@ -1,27 +1,5 @@
 open! Stdune
 
-module Ccomp_type = struct
-  type t =
-    | Msvc
-    | Other of string
-
-  let to_dyn =
-    let open Dyn.Encoder in
-    function
-    | Msvc -> constr "Msvc" []
-    | Other s -> constr "Other" [ string s ]
-
-  let of_string = function
-    | "msvc" -> Msvc
-    | s -> Other s
-
-  let to_string = function
-    | Msvc -> "msvc"
-    | Other s -> s
-
-  let of_config ocfg = of_string (Ocaml_config.ccomp_type ocfg)
-end
-
 type t =
   { has_native : bool
   ; ext_lib : string
@@ -33,7 +11,7 @@ type t =
   ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
-  ; ccomp_type : Ccomp_type.t
+  ; ccomp_type : Ocaml_config.Ccomp_type.t
   }
 
 let var_map =
@@ -41,7 +19,7 @@ let var_map =
   ; ("system", fun t -> t.system)
   ; ("model", fun t -> t.model)
   ; ("os_type", fun t -> Ocaml_config.Os_type.to_string t.os_type)
-  ; ("ccomp_type", fun t -> Ccomp_type.to_string t.ccomp_type)
+  ; ("ccomp_type", fun t -> Ocaml_config.Ccomp_type.to_string t.ccomp_type)
   ]
 
 let allowed_in_enabled_if =

--- a/src/dune/lib_config.mli
+++ b/src/dune/lib_config.mli
@@ -1,15 +1,5 @@
 open Stdune
 
-module Ccomp_type : sig
-  type t =
-    | Msvc
-    | Other of string
-
-  val to_dyn : t -> Dyn.t
-
-  val of_config : Ocaml_config.t -> t
-end
-
 type t =
   { has_native : bool
   ; ext_lib : string
@@ -21,7 +11,7 @@ type t =
   ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
-  ; ccomp_type : Ccomp_type.t
+  ; ccomp_type : Ocaml_config.Ccomp_type.t
   }
 
 val allowed_in_enabled_if : (string * Dune_lang.Syntax.Version.t) list

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -34,7 +34,7 @@ let build_lib (lib : Library.t) ~sctx ~dir_contents ~expander ~flags ~dir ~mode
       in
       let map_cclibs =
         (* https://github.com/ocaml/dune/issues/119 *)
-        match ctx.ccomp_type with
+        match ctx.lib_config.ccomp_type with
         | Msvc -> msvc_hack_cclibs
         | Other _ -> Fn.id
       in
@@ -146,7 +146,7 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
                 case, but we pass them unconditionally for simplicity. *)
              (Build.map cclibs_args ~f:(fun cclibs ->
                   (* https://github.com/ocaml/dune/issues/119 *)
-                  match ctx.ccomp_type with
+                  match ctx.lib_config.ccomp_type with
                   | Msvc ->
                     let cclibs = msvc_hack_cclibs cclibs in
                     Command.quote_args "-ldopt" cclibs

--- a/src/ocaml-config/dune
+++ b/src/ocaml-config/dune
@@ -2,5 +2,5 @@
  (name ocaml_config)
  (public_name dune-private-libs.ocaml-config)
  (preprocess future_syntax)
- (libraries stdune)
+ (libraries stdune dune_lang)
  (synopsis "[Internal] Interpret the output of 'ocamlc -config'"))

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -52,13 +52,33 @@ module Os_type = struct
     | Other s -> s
 end
 
+module Ccomp_type = struct
+  type t =
+    | Msvc
+    | Other of string
+
+  let to_dyn =
+    let open Dyn.Encoder in
+    function
+    | Msvc -> constr "Msvc" []
+    | Other s -> constr "Other" [ string s ]
+
+  let of_string = function
+    | "msvc" -> Msvc
+    | s -> Other s
+
+  let to_string = function
+    | Msvc -> "msvc"
+    | Other s -> s
+end
+
 type t =
   { version : int * int * int
   ; version_string : string
   ; standard_library_default : string
   ; standard_library : string
   ; standard_runtime : string
-  ; ccomp_type : string
+  ; ccomp_type : Ccomp_type.t
   ; c_compiler : string
   ; ocamlc_cflags : string list
   ; ocamlopt_cflags : string list
@@ -207,7 +227,7 @@ let to_list t : (string * Value.t) list =
   ; ("standard_library_default", String t.standard_library_default)
   ; ("standard_library", String t.standard_library)
   ; ("standard_runtime", String t.standard_runtime)
-  ; ("ccomp_type", String t.ccomp_type)
+  ; ("ccomp_type", String (Ccomp_type.to_string t.ccomp_type))
   ; ("c_compiler", String t.c_compiler)
   ; ("ocamlc_cflags", Words t.ocamlc_cflags)
   ; ("ocamlopt_cflags", Words t.ocamlopt_cflags)
@@ -408,7 +428,7 @@ let make vars =
         (get_opt vars "standard_runtime")
         ~default:"the_standard_runtime_variable_was_deleted"
     in
-    let ccomp_type = get vars "ccomp_type" in
+    let ccomp_type = Ccomp_type.of_string (get vars "ccomp_type") in
     let bytecomp_c_libraries = get_words vars "bytecomp_c_libraries" in
     let native_c_libraries = get_words vars "native_c_libraries" in
     let cc_profile = get_words vars "cc_profile" in

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -45,6 +45,16 @@ module Os_type : sig
   val to_string : t -> string
 end
 
+module Ccomp_type : sig
+  type t =
+    | Msvc
+    | Other of string
+
+  val to_dyn : t -> Dyn.t
+
+  val to_string : t -> string
+end
+
 (** Interpret raw bindings (this function also loads the [Makefile.config] file
     in the stdlib directory). *)
 val make : Vars.t -> (t, Origin.t * string) Result.t
@@ -64,7 +74,7 @@ val standard_library : t -> string
 
 val standard_runtime : t -> string
 
-val ccomp_type : t -> string
+val ccomp_type : t -> Ccomp_type.t
 
 val c_compiler : t -> string
 

--- a/src/stdune/dyn.ml
+++ b/src/stdune/dyn.ml
@@ -71,7 +71,7 @@ let pp_sequence start stop x ~f =
               ( ( if i = 0 then
                   Pp.verbatim (start ^ " ")
                 else
-                  Pp.verbatim sep)
+                  Pp.verbatim sep )
               ++ f x ))
       ++ Pp.space ++ Pp.verbatim stop )
 


### PR DESCRIPTION
This check is useful for other users of Ocaml_config. I also get rid of the
duplication in Lib_config and Context.