### PR TITLE
Add a way to specify cutoff in [Memo.Lazy] and [Memo.Async.Lazy]

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -822,18 +822,13 @@ module Store = Store_intf
 
 let on_already_reported f = on_already_reported := f
 
-let lazy_ (type a) ?cutoff f =
-  let equal =
-    match cutoff with
-    | Some equal -> equal
-    | None -> ( == )
-  in
+let lazy_ (type a) ?(cutoff = ( == )) f =
   let module Output = struct
     type t = a
 
     let to_dyn _ = Dyn.Opaque
 
-    let equal = equal
+    let equal = cutoff
   end in
   let id = Lazy_id.gen () in
   let name = sprintf "lazy-%d" (Lazy_id.to_int id) in
@@ -848,18 +843,13 @@ let lazy_ (type a) ?cutoff f =
   let cell = Exec.make_dep_node ~spec ~state:Init ~input:() in
   fun () -> Cell.get_sync cell
 
-let lazy_async (type a) ?cutoff f =
-  let equal =
-    match cutoff with
-    | Some equal -> equal
-    | None -> ( == )
-  in
+let lazy_async (type a) ?(cutoff = ( == )) f =
   let module Output = struct
     type t = a
 
     let to_dyn _ = Dyn.Opaque
 
-    let equal = equal
+    let equal = cutoff
   end in
   let id = Lazy_id.gen () in
   let name = sprintf "lazy-async-%d" (Lazy_id.to_int id) in

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -822,13 +822,18 @@ module Store = Store_intf
 
 let on_already_reported f = on_already_reported := f
 
-let lazy_ (type a) f =
+let lazy_ (type a) ?cutoff f =
+  let equal =
+    match cutoff with
+    | Some equal -> equal
+    | None -> ( == )
+  in
   let module Output = struct
     type t = a
 
     let to_dyn _ = Dyn.Opaque
 
-    let equal = ( == )
+    let equal = equal
   end in
   let id = Lazy_id.gen () in
   let name = sprintf "lazy-%d" (Lazy_id.to_int id) in
@@ -843,13 +848,18 @@ let lazy_ (type a) f =
   let cell = Exec.make_dep_node ~spec ~state:Init ~input:() in
   fun () -> Cell.get_sync cell
 
-let lazy_async (type a) f =
+let lazy_async (type a) ?cutoff f =
+  let equal =
+    match cutoff with
+    | Some equal -> equal
+    | None -> ( == )
+  in
   let module Output = struct
     type t = a
 
     let to_dyn _ = Dyn.Opaque
 
-    let equal = ( == )
+    let equal = equal
   end in
   let id = Lazy_id.gen () in
   let name = sprintf "lazy-async-%d" (Lazy_id.to_int id) in
@@ -869,7 +879,7 @@ module Lazy = struct
 
   let of_val x () = x
 
-  let create f = lazy_ f
+  let create = lazy_
 
   let force f = f ()
 
@@ -884,7 +894,7 @@ module Lazy = struct
 
     let of_val a () = Fiber.return a
 
-    let create f = lazy_async f
+    let create = lazy_async
 
     let force f = f ()
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -243,7 +243,7 @@ module Lazy : sig
 
   val bind : 'a t -> f:('a -> 'b t) -> 'b t
 
-  val create : (unit -> 'a) -> 'a t
+  val create : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a t
 
   val of_val : 'a -> 'a t
 
@@ -254,7 +254,7 @@ module Lazy : sig
 
     val of_val : 'a -> 'a t
 
-    val create : (unit -> 'a Fiber.t) -> 'a t
+    val create : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a Fiber.t) -> 'a t
 
     val force : 'a t -> 'a Fiber.t
 
@@ -262,7 +262,10 @@ module Lazy : sig
   end
 end
 
-val lazy_ : (unit -> 'a) -> 'a Lazy.t
+val lazy_ : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a Lazy.t
+
+val lazy_async :
+  ?cutoff:('a -> 'a -> bool) -> (unit -> 'a Fiber.t) -> 'a Lazy.Async.t
 
 module With_implicit_output : sig
   type ('i, 'o, 'f) t

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -312,7 +312,12 @@ let%expect_test _ =
 Some [ ("id", "lazy: foo"); ("lazy_memo", "foo") ])
 |}]
 
-module Memo_lazy = Test_lazy (Memo.Lazy)
+module Memo_lazy = Test_lazy (struct
+  include Memo.Lazy
+
+  (* Here we hide the optional argument [cutoff] of [Memo.Lazy.create]. *)
+  let create f = create f
+end)
 
 let%expect_test _ =
   Memo_lazy.run () |> Dyn.Encoder.(pair string string) |> print_dyn;


### PR DESCRIPTION
This adds appropriate cutoff for OPAM config variables (#3150).

Once we memoize various file-system accessors, many other occurrences of `Memo.lazy_` will need to be annotated with appropriate equality checks for cutoff.