### PR TITLE
Remove the ad-hoc [which_cache]

### DIFF
--- a/src/dune/artifacts.ml
+++ b/src/dune/artifacts.ml
@@ -16,7 +16,7 @@ module Bin = struct
       match String.Map.find t.local_bins name with
       | Some path -> Ok (Path.build path)
       | None -> (
-        match Context.which t.context name with
+        match t.context.which name with
         | Some p -> Ok p
         | None ->
           Error

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -47,14 +47,7 @@ module Program = struct
   end
 
   let programs_for_which_we_prefer_opt_ext =
-    [ "ocaml"
-    ; "ocamlc"
-    ; "ocamldep"
-    ; "ocamlfind"
-    ; "ocamlmklib"
-    ; "ocamlobjinfo"
-    ; "ocamlopt"
-    ]
+    [ "ocamlc"; "ocamldep"; "ocamlmklib"; "ocamlobjinfo"; "ocamlopt" ]
 
   let best_path dir program =
     let exe_path program =

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -87,7 +87,9 @@ type t = private
   ; version : Ocaml_version.t
   ; stdlib_dir : Path.t
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
-  ; which_cache : (string, Path.t option) Table.t
+  ; which : string -> Path.t option
+        (** Given a program name, e.g. ["ocaml"], find the path to a preferred
+            executable in PATH, e.g. [Some "/path/to/ocaml.opt.exe"]. *)
   ; lib_config : Lib_config.t
   }
 
@@ -101,8 +103,6 @@ val to_dyn_concise : t -> Dyn.t
 
 (** Compare the context names *)
 val compare : t -> t -> Ordering.t
-
-val which : t -> string -> Path.t option
 
 val install_ocaml_libdir : t -> Path.t option Fiber.t
 


### PR DESCRIPTION
We also refactor code to make the mechanism of preferring `.opt` executables robust, by explicitly listing all programs for which we prefer the `.opt` versions instead of relying on the order of calls to `which`. We also discover and signpost a bug in the process.

I guess this might deserve a line in the change log, since the old `opt`-preferring behaviour was fragile and we could accidentally resolve some executables incorrectly.