### PR TITLE
Remove ad-hoc memoization in [Env_node]

### DIFF
--- a/src/dune/env_node.ml
+++ b/src/dune/env_node.ml
@@ -13,171 +13,154 @@ type t =
   ; inherit_from : t Memo.Lazy.t option
   ; scope : Scope.t
   ; config : Dune_env.Stanza.t
-  ; mutable local_binaries : File_binding.Expanded.t list option
-  ; mutable ocaml_flags : Ocaml_flags.t option
-  ; mutable foreign_flags : string list Build.t Foreign.Language.Dict.t option
-  ; mutable external_ : Env.t option
-  ; mutable bin_artifacts : Artifacts.Bin.t option
-  ; mutable inline_tests : Dune_env.Stanza.Inline_tests.t option
-  ; mutable menhir_flags : string list Build.t option
-  ; mutable odoc : Odoc.t option
+  ; profile : Profile.t
+  ; expander : Expander.t
+  ; local_binaries : File_binding.Expanded.t list Memo.Lazy.t
+  ; ocaml_flags : Ocaml_flags.t Memo.Lazy.t
+  ; foreign_flags : string list Build.t Foreign.Language.Dict.t Memo.Lazy.t
+  ; external_ : Env.t Memo.Lazy.t
+  ; bin_artifacts : Artifacts.Bin.t Memo.Lazy.t
+  ; inline_tests : Dune_env.Stanza.Inline_tests.t Memo.Lazy.t
+  ; menhir_flags : string list Build.t Memo.Lazy.t
+  ; odoc : Odoc.t Memo.Lazy.t
   }
 
 let scope t = t.scope
 
-let make ~dir ~inherit_from ~scope ~config =
+let local_binaries t = Memo.Lazy.force t.local_binaries
+
+let ocaml_flags t = Memo.Lazy.force t.ocaml_flags
+
+let foreign_flags t = Memo.Lazy.force t.foreign_flags
+
+let external_ t = Memo.Lazy.force t.external_
+
+let bin_artifacts t = Memo.Lazy.force t.bin_artifacts
+
+let inline_tests t = Memo.Lazy.force t.inline_tests
+
+let menhir_flags t = Memo.Lazy.force t.menhir_flags
+
+let local_binaries_impl ~inherit_from ~dir ~config ~profile ~expander =
+  let default =
+    match inherit_from with
+    | None -> []
+    | Some t -> local_binaries (Memo.Lazy.force t)
+  in
+  default
+  @ List.map (Dune_env.Stanza.find config ~profile).binaries
+      ~f:
+        (File_binding.Unexpanded.expand ~dir ~f:(fun template ->
+             Expander.expand expander ~mode:Single ~template
+             |> Value.to_string ~dir:(Path.build dir)))
+
+let external_impl ~inherit_from ~dir ~config ~profile ~default_env =
+  let default =
+    match inherit_from with
+    | None -> default_env
+    | Some t -> external_ (Memo.Lazy.force t)
+  in
+  let env, have_binaries =
+    let cfg = Dune_env.Stanza.find config ~profile in
+    (Env.extend_env default cfg.env_vars, List.is_non_empty cfg.binaries)
+  in
+  if have_binaries then
+    let dir = Utils.local_bin dir |> Path.build in
+    Env.cons_path env ~dir
+  else
+    env
+
+let bin_artifacts_impl ~inherit_from ~dir ~config ~profile ~expander
+    ~default_bin_artifacts =
+  let default =
+    match inherit_from with
+    | None -> default_bin_artifacts
+    | Some t -> bin_artifacts (Memo.Lazy.force t)
+  in
+  local_binaries_impl ~inherit_from ~dir ~config ~profile ~expander
+  |> Artifacts.Bin.add_binaries default ~dir
+
+let ocaml_flags_impl ~inherit_from ~dir ~config ~scope ~profile ~expander =
+  let default =
+    match inherit_from with
+    | None ->
+      let project = Scope.project scope in
+      let dune_version = Dune_project.dune_version project in
+      Ocaml_flags.default ~profile ~dune_version
+    | Some t -> ocaml_flags (Memo.Lazy.force t)
+  in
+  let cfg = Dune_env.Stanza.find config ~profile in
+  let expander = Expander.set_dir expander ~dir in
+  Ocaml_flags.make ~spec:cfg.flags ~default
+    ~eval:(Expander.expand_and_eval_set expander)
+
+let inline_tests_impl ~inherit_from ~config ~profile =
+  match Dune_env.Stanza.find config ~profile with
+  | { inline_tests = None; _ } -> (
+    match inherit_from with
+    | None ->
+      if Profile.is_inline_test profile then
+        Dune_env.Stanza.Inline_tests.Enabled
+      else
+        Disabled
+    | Some t -> inline_tests (Memo.Lazy.force t) )
+  | { inline_tests = Some s; _ } -> s
+
+let foreign_flags_impl ~inherit_from ~dir ~config ~profile ~expander
+    ~default_context_flags =
+  let default =
+    match inherit_from with
+    | None -> Foreign.Language.Dict.map ~f:Build.return default_context_flags
+    | Some t -> foreign_flags (Memo.Lazy.force t)
+  in
+  let cfg = Dune_env.Stanza.find config ~profile in
+  let expander = Expander.set_dir expander ~dir in
+  Foreign.Language.Dict.mapi cfg.foreign_flags ~f:(fun ~language f ->
+      let default = Foreign.Language.Dict.get default language in
+      Expander.expand_and_eval_set expander f ~standard:default)
+
+let menhir_flags_impl ~dir ~inherit_from ~config ~profile ~expander =
+  let default =
+    match inherit_from with
+    | None -> Build.return []
+    | Some t -> menhir_flags (Memo.Lazy.force t)
+  in
+  let cfg = Dune_env.Stanza.find config ~profile in
+  let expander = Expander.set_dir expander ~dir in
+  Expander.expand_and_eval_set expander cfg.menhir_flags ~standard:default
+
+let make ~dir ~inherit_from ~scope ~config ~profile ~expander
+    ~default_context_flags ~default_env ~default_bin_artifacts =
   { dir
   ; inherit_from
   ; scope
   ; config
-  ; ocaml_flags = None
-  ; foreign_flags = None
-  ; external_ = None
-  ; bin_artifacts = None
-  ; local_binaries = None
-  ; inline_tests = None
-  ; menhir_flags = None
-  ; odoc = None
+  ; profile
+  ; expander
+  ; ocaml_flags =
+      Memo.lazy_ (fun () ->
+          ocaml_flags_impl ~inherit_from ~dir ~config ~scope ~profile ~expander)
+  ; foreign_flags =
+      Memo.lazy_ (fun () ->
+          foreign_flags_impl ~inherit_from ~dir ~config ~profile ~expander
+            ~default_context_flags)
+  ; external_ =
+      Memo.lazy_ (fun () ->
+          external_impl ~inherit_from ~dir ~config ~profile ~default_env)
+  ; bin_artifacts =
+      Memo.lazy_ (fun () ->
+          bin_artifacts_impl ~inherit_from ~dir ~config ~profile ~expander
+            ~default_bin_artifacts)
+  ; local_binaries =
+      Memo.lazy_ (fun () ->
+          local_binaries_impl ~inherit_from ~dir ~config ~profile ~expander)
+  ; inline_tests =
+      Memo.lazy_ (fun () -> inline_tests_impl ~inherit_from ~config ~profile)
+  ; menhir_flags =
+      Memo.lazy_ (fun () ->
+          menhir_flags_impl ~inherit_from ~dir ~config ~profile ~expander)
+  ; odoc
   }
-
-let find_config t ~profile = Dune_env.Stanza.find t.config ~profile
-
-let rec local_binaries t ~profile ~expander =
-  match t.local_binaries with
-  | Some x -> x
-  | None ->
-    let default =
-      match t.inherit_from with
-      | None -> []
-      | Some t -> local_binaries (Memo.Lazy.force t) ~profile ~expander
-    in
-    let local_binaries =
-      default
-      @ List.map (find_config t ~profile).binaries
-          ~f:
-            (File_binding.Unexpanded.expand ~dir:t.dir ~f:(fun template ->
-                 Expander.expand expander ~mode:Single ~template
-                 |> Value.to_string ~dir:(Path.build t.dir)))
-    in
-    t.local_binaries <- Some local_binaries;
-    local_binaries
-
-let rec external_ t ~profile ~default =
-  match t.external_ with
-  | Some x -> x
-  | None ->
-    let default =
-      match t.inherit_from with
-      | None -> default
-      | Some t -> external_ (Memo.Lazy.force t) ~default ~profile
-    in
-    let env, have_binaries =
-      let cfg = find_config t ~profile in
-      (Env.extend_env default cfg.env_vars, List.is_non_empty cfg.binaries)
-    in
-    let env =
-      if have_binaries then
-        let dir = Utils.local_bin t.dir |> Path.build in
-        Env.cons_path env ~dir
-      else
-        env
-    in
-    t.external_ <- Some env;
-    env
-
-let rec bin_artifacts t ~profile ~default ~expander =
-  match t.bin_artifacts with
-  | Some x -> x
-  | None ->
-    let default =
-      match t.inherit_from with
-      | None -> default
-      | Some t -> bin_artifacts (Memo.Lazy.force t) ~default ~profile ~expander
-    in
-    let bin_artifacts =
-      local_binaries t ~profile ~expander
-      |> Artifacts.Bin.add_binaries default ~dir:t.dir
-    in
-    t.bin_artifacts <- Some bin_artifacts;
-    bin_artifacts
-
-let rec ocaml_flags t ~profile ~expander =
-  match t.ocaml_flags with
-  | Some x -> x
-  | None ->
-    let default =
-      match t.inherit_from with
-      | None ->
-        let project = Scope.project t.scope in
-        let dune_version = Dune_project.dune_version project in
-        Ocaml_flags.default ~profile ~dune_version
-      | Some t -> ocaml_flags (Memo.Lazy.force t) ~profile ~expander
-    in
-    let flags =
-      let cfg = find_config t ~profile in
-      let expander = Expander.set_dir expander ~dir:t.dir in
-      Ocaml_flags.make ~spec:cfg.flags ~default
-        ~eval:(Expander.expand_and_eval_set expander)
-    in
-    t.ocaml_flags <- Some flags;
-    flags
-
-let rec inline_tests t ~profile =
-  match t.inline_tests with
-  | Some x -> x
-  | None ->
-    let state : Dune_env.Stanza.Inline_tests.t =
-      match find_config t ~profile with
-      | { inline_tests = None; _ } -> (
-        match t.inherit_from with
-        | None ->
-          if Profile.is_inline_test profile then
-            Enabled
-          else
-            Disabled
-        | Some t -> inline_tests (Memo.Lazy.force t) ~profile )
-      | { inline_tests = Some s; _ } -> s
-    in
-    t.inline_tests <- Some state;
-    state
-
-let rec foreign_flags t ~profile ~expander ~default_context_flags =
-  match t.foreign_flags with
-  | Some x -> x
-  | None ->
-    let default =
-      match t.inherit_from with
-      | None -> Foreign.Language.Dict.map ~f:Build.return default_context_flags
-      | Some t ->
-        foreign_flags (Memo.Lazy.force t) ~profile ~expander
-          ~default_context_flags
-    in
-    let flags =
-      let cfg = find_config t ~profile in
-      let expander = Expander.set_dir expander ~dir:t.dir in
-      Foreign.Language.Dict.mapi cfg.foreign_flags ~f:(fun ~language f ->
-          let default = Foreign.Language.Dict.get default language in
-          Expander.expand_and_eval_set expander f ~standard:default)
-    in
-    t.foreign_flags <- Some flags;
-    flags
-
-let rec menhir_flags t ~profile ~expander =
-  match t.menhir_flags with
-  | Some x -> x
-  | None ->
-    let default =
-      match t.inherit_from with
-      | None -> Build.return []
-      | Some t -> menhir_flags (Memo.Lazy.force t) ~profile ~expander
-    in
-    let flags =
-      let cfg = find_config t ~profile in
-      let expander = Expander.set_dir expander ~dir:t.dir in
-      Expander.expand_and_eval_set expander cfg.menhir_flags ~standard:default
-    in
-    t.menhir_flags <- Some flags;
-    flags
 
 let rec odoc t ~profile =
   match t.odoc with

--- a/src/dune/env_node.ml
+++ b/src/dune/env_node.ml
@@ -86,7 +86,7 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
     match config with
     | { inline_tests = Some s; _ } -> Memo.Lazy.of_val s
     | { inline_tests = None; _ } ->
-      inherited ~field:inline_tests Fun.id
+      inherited ~field:inline_tests Fn.id
         ~root:
           ( if Profile.is_inline_test profile then
             Enabled

--- a/src/dune/env_node.ml
+++ b/src/dune/env_node.ml
@@ -13,7 +13,7 @@ type t =
   ; local_binaries : File_binding.Expanded.t list Memo.Lazy.t
   ; ocaml_flags : Ocaml_flags.t Memo.Lazy.t
   ; foreign_flags : string list Build.t Foreign.Language.Dict.t Memo.Lazy.t
-  ; external_ : Env.t Memo.Lazy.t
+  ; external_env : Env.t Memo.Lazy.t
   ; bin_artifacts : Artifacts.Bin.t Memo.Lazy.t
   ; inline_tests : Dune_env.Stanza.Inline_tests.t Memo.Lazy.t
   ; menhir_flags : string list Build.t Memo.Lazy.t
@@ -28,7 +28,7 @@ let ocaml_flags t = Memo.Lazy.force t.ocaml_flags
 
 let foreign_flags t = Memo.Lazy.force t.foreign_flags
 
-let external_ t = Memo.Lazy.force t.external_
+let external_env t = Memo.Lazy.force t.external_env
 
 let bin_artifacts t = Memo.Lazy.force t.bin_artifacts
 
@@ -55,8 +55,8 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
                    Expander.expand expander ~mode:Single ~template
                    |> Value.to_string ~dir:(Path.build dir))))
   in
-  let external_ =
-    inherited ~field:external_ ~root:default_env (fun env ->
+  let external_env =
+    inherited ~field:external_env ~root:default_env (fun env ->
         let env, have_binaries =
           (Env.extend_env env config.env_vars, List.is_non_empty config.binaries)
         in
@@ -111,7 +111,7 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
   { scope
   ; ocaml_flags
   ; foreign_flags
-  ; external_
+  ; external_env
   ; bin_artifacts
   ; local_binaries
   ; inline_tests

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -17,34 +17,27 @@ val make :
   -> inherit_from:t Memo.Lazy.t option
   -> scope:Scope.t
   -> config:Dune_env.Stanza.t
+  -> profile:Profile.t
+  -> expander:Expander.t
+  -> default_context_flags:string list Foreign.Language.Dict.t
+  -> default_env:Env.t
+  -> default_bin_artifacts:Artifacts.Bin.t
   -> t
 
 val scope : t -> Scope.t
 
-val external_ : t -> profile:Profile.t -> default:Env.t -> Env.t
+val external_ : t -> Env.t
 
-val ocaml_flags : t -> profile:Profile.t -> expander:Expander.t -> Ocaml_flags.t
+val ocaml_flags : t -> Ocaml_flags.t
 
-val inline_tests : t -> profile:Profile.t -> Dune_env.Stanza.Inline_tests.t
+val inline_tests : t -> Dune_env.Stanza.Inline_tests.t
 
-val foreign_flags :
-     t
-  -> profile:Profile.t
-  -> expander:Expander.t
-  -> default_context_flags:string list Foreign.Language.Dict.t
-  -> string list Build.t Foreign.Language.Dict.t
+val foreign_flags : t -> string list Build.t Foreign.Language.Dict.t
 
-val local_binaries :
-  t -> profile:Profile.t -> expander:Expander.t -> File_binding.Expanded.t list
+val local_binaries : t -> File_binding.Expanded.t list
 
-val bin_artifacts :
-     t
-  -> profile:Profile.t
-  -> default:Artifacts.Bin.t
-  -> expander:Expander.t
-  -> Artifacts.Bin.t
+val bin_artifacts : t -> Artifacts.Bin.t
 
-val menhir_flags :
-  t -> profile:Profile.t -> expander:Expander.t -> string list Build.t
+val odoc : t -> Odoc.t
 
-val odoc : t -> profile:Profile.t -> Odoc.t
+val menhir_flags : t -> string list Build.t

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -14,7 +14,7 @@ type t
 
 val make :
      dir:Path.Build.t
-  -> inherit_from:t Lazy.t option
+  -> inherit_from:t Memo.Lazy.t option
   -> scope:Scope.t
   -> config:Dune_env.Stanza.t
   -> t

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -16,7 +16,7 @@ val make :
      dir:Path.Build.t
   -> inherit_from:t Memo.Lazy.t option
   -> scope:Scope.t
-  -> config:Dune_env.Stanza.t
+  -> config_stanza:Dune_env.Stanza.t
   -> profile:Profile.t
   -> expander:Expander.t
   -> default_context_flags:string list Foreign.Language.Dict.t

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -18,7 +18,8 @@ val make :
   -> scope:Scope.t
   -> config_stanza:Dune_env.Stanza.t
   -> profile:Profile.t
-  -> expander:Expander.t
+  -> expander:Expander.t Memo.Lazy.t
+  -> expander_for_artifacts:Expander.t Memo.Lazy.t
   -> default_context_flags:string list Foreign.Language.Dict.t
   -> default_env:Env.t
   -> default_bin_artifacts:Artifacts.Bin.t

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -26,7 +26,7 @@ val make :
 
 val scope : t -> Scope.t
 
-val external_ : t -> Env.t
+val external_env : t -> Env.t
 
 val ocaml_flags : t -> Ocaml_flags.t
 

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -159,11 +159,12 @@ end = struct
             | None -> raise_notrace Exit
             | Some parent -> Memo.lazy_ (fun () -> get t ~dir:parent ~scope)
         in
-        let config = get_env_stanza t ~dir in
+        let config_stanza = get_env_stanza t ~dir in
         let default_context_flags = default_context_flags t.context in
-        Env_node.make ~dir ~scope ~config ~inherit_from:(Some inherit_from)
-          ~profile:t.profile ~expander:t.expander ~default_context_flags
-          ~default_env:t.context_env ~default_bin_artifacts:t.bin_artifacts
+        Env_node.make ~dir ~scope ~config_stanza
+          ~inherit_from:(Some inherit_from) ~profile:t.profile
+          ~expander:t.expander ~default_context_flags ~default_env:t.context_env
+          ~default_bin_artifacts:t.bin_artifacts
       in
       Table.set t.env dir node;
       node
@@ -479,20 +480,21 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas
   in
   let default_env =
     Memo.lazy_ (fun () ->
-        let make ~inherit_from ~config =
+        let make ~inherit_from ~config_stanza =
           let dir = context.build_dir in
           let default_context_flags = default_context_flags context in
           Env_node.make ~dir
             ~scope:(Scope.DB.find_by_dir scopes dir)
-            ~inherit_from ~config ~profile:context.profile ~expander
+            ~inherit_from ~config_stanza ~profile:context.profile ~expander
             ~default_context_flags ~default_env:context.env
             ~default_bin_artifacts:artifacts.bin
         in
-        make ~config:context.env_nodes.context
+        make ~config_stanza:context.env_nodes.context
           ~inherit_from:
             (Some
                (Memo.lazy_ (fun () ->
-                    make ~inherit_from:None ~config:context.env_nodes.workspace))))
+                    make ~inherit_from:None
+                      ~config_stanza:context.env_nodes.workspace))))
   in
   let env_context =
     { Env_context.env

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -130,10 +130,11 @@ val add_alias_action :
 
 val source_files : src_path:Path.Source.t -> String.Set.t
 
-(** [prog_spec t ?hint name] resolve a program. [name] is looked up in the
-    workspace, if it is not found in the tree is is looked up in the PATH. If it
-    is not found at all, the resulting [Prog_spec.t] will either return the
-    resolved path or a record with details about the error and possibly a hint.
+(** [resolve_program t ?hint name] resolves a program. [name] is looked up in
+    the workspace, if it is not found in the tree is is looked up in the PATH.
+    If it is not found at all, the resulting [Action.Prog.t] will either return
+    the resolved path or a record with details about the error and possibly a
+    hint.
 
     [hint] should tell the user what to install when the program is not found. *)
 val resolve_program :

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -622,6 +622,18 @@
     (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias env-env-affects-expander-affects-env)
+ (deps
+  (package dune)
+  (source_tree test-cases/env/env-affects-expander-affects-env))
+ (action
+  (chdir
+   test-cases/env/env-affects-expander-affects-env
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
+
+(rule
  (alias env-env-and-flags-include)
  (deps (package dune) (source_tree test-cases/env/env-and-flags-include))
  (action
@@ -2770,6 +2782,7 @@
   (alias embed-jbuild)
   (alias enabled_if)
   (alias enabled_if-exec)
+  (alias env-env-affects-expander-affects-env)
   (alias env-env-and-flags-include)
   (alias env-env-bin-pform)
   (alias env-env-bins)
@@ -3031,6 +3044,7 @@
   (alias embed-jbuild)
   (alias enabled_if)
   (alias enabled_if-exec)
+  (alias env-env-affects-expander-affects-env)
   (alias env-env-and-flags-include)
   (alias env-env-bin-pform)
   (alias env-env-bins)

--- a/test/blackbox-tests/test-cases/env/env-affects-expander-affects-env/dune
+++ b/test/blackbox-tests/test-cases/env/env-affects-expander-affects-env/dune
@@ -1,0 +1,8 @@
+(library
+ (name whatever)
+ (inline_tests)
+ (libraries ))
+
+(env
+ (_
+  (ocamlc_flags "%{inline_tests}%{cmi:foo}")))

--- a/test/blackbox-tests/test-cases/env/env-affects-expander-affects-env/run.t
+++ b/test/blackbox-tests/test-cases/env/env-affects-expander-affects-env/run.t
@@ -5,7 +5,6 @@ Given that we only have a few string_with_vars in env, a reasonable
 example is hard to come up with, but here's a contrived one.
 
   $ echo '(lang dune 2.0)' > dune-project
-  
   $ cat > dune <<EOF
   > (library
   >  (name whatever)

--- a/test/blackbox-tests/test-cases/env/env-affects-expander-affects-env/run.t
+++ b/test/blackbox-tests/test-cases/env/env-affects-expander-affects-env/run.t
@@ -1,0 +1,21 @@
+Current directory (and also current env, even though that's not demonstrated here)
+can affect an expander, and expander is in turn used to expand things in env.
+
+Given that we only have a few string_with_vars in env, a reasonable
+example is hard to come up with, but here's a contrived one.
+
+  $ echo '(lang dune 2.0)' > dune-project
+  
+  $ cat > dune <<EOF
+  > (library
+  >  (name whatever)
+  >  (inline_tests)
+  >  (libraries ))
+  > 
+  > (env
+  >  (_
+  >   (ocamlc_flags "%{inline_tests}")))
+  > EOF
+
+  $ dune printenv --root . . | grep ocamlc_flags
+    (ocamlc_flags (enabled))


### PR DESCRIPTION
This removes mutation from `Env_node`, switching to `Memo.Lazy`. 

The logic is also slightly simplified by factoring out some common patterns (e.g. `inherited`). The resulting code is still rather convoluted due to the proliferation of lazy computations but hopefully the new state is still an improvement.

When implementing, we noticed that tests were not very good (the first draft was wrong yet passed the testsuite), so we've also added a test to make sure we use the right expanders.