### PR TITLE
Introduce [Stringlike]

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -2,8 +2,7 @@ open Stdune
 open Dune
 include Cmdliner.Arg
 
-let package_name =
-  conv ((fun p -> Ok (Package.Name.of_string p)), Package.Name.pp)
+let package_name = conv Package.Name.conv
 
 module Path = struct
   type t = string
@@ -17,10 +16,7 @@ end
 
 let path = Path.conv
 
-let profile =
-  conv
-    ( (fun p -> Ok (Profile.of_string p))
-    , fun fmt t -> Format.pp_print_string fmt (Profile.to_string t) )
+let profile = conv Dune.Profile.conv
 
 module Dep = struct
   module Dep_conf = Dep_conf
@@ -121,6 +117,5 @@ let bytes =
   in
   conv (decode, Format.pp_print_int)
 
-let context_name =
-  let printer ppf t = Format.pp_print_string ppf (Context_name.to_string t) in
-  (Context_name.arg_parse, printer)
+let context_name : Context_name.t conv =
+  conv Context_name.conv

--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -117,5 +117,4 @@ let bytes =
   in
   conv (decode, Format.pp_print_int)
 
-let context_name : Context_name.t conv =
-  conv Context_name.conv
+let context_name : Context_name.t conv = conv Context_name.conv

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -28,6 +28,7 @@ let atom_parser s =
 let atom_printer ppf a = Format.pp_print_string ppf (Dune_lang.Atom.to_string a)
 
 let component_name_parser s =
+  (* TODO refactor to use Lib_name.Local.conv *)
   let err_msg () =
     User_error.make
       [ Pp.textf "invalid component name `%s'" s ]
@@ -37,7 +38,11 @@ let component_name_parser s =
   in
   let open Result.O in
   let* atom = atom_parser s in
-  let* _ = Lib_name.Local.of_string s |> Result.map_error ~f:err_msg in
+  let* _ =
+    match Lib_name.Local.of_string_opt s with
+    | None -> Error (err_msg ())
+    | Some s -> Ok s
+  in
   Ok atom
 
 let atom_conv = Arg.conv (atom_parser, atom_printer)

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -31,8 +31,9 @@ let component_name_parser s =
   (* TODO refactor to use Lib_name.Local.conv *)
   let err_msg () =
     User_error.make
-      [ Pp.textf "invalid component name `%s'" s ]
-      ~hints:[ Lib_name.Local.valid_format_doc ]
+      [ Pp.textf "invalid component name `%s'" s
+      ; Lib_name.Local.valid_format_doc
+      ]
     |> User_message.to_string
     |> fun m -> `Msg m
   in

--- a/src/dune/alias.ml
+++ b/src/dune/alias.ml
@@ -34,6 +34,8 @@ module Name : sig
 end = struct
   include String
 
+  (* DUNE3 once we get rid the "loose" validation, implement this module using
+     [Stringlike] *)
   let of_string_opt_loose s = Option.some_if (Filename.basename s = s) s
 
   let of_string_opt = function

--- a/src/dune/cinaps.ml
+++ b/src/dune/cinaps.ml
@@ -88,8 +88,7 @@ let gen_rules sctx t ~dir ~scope =
   let compile_info =
     Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
       [ (t.loc, name) ]
-      ( Lib_dep.Direct (loc, Lib_name.of_string_exn "cinaps.runtime" ~loc:None)
-      :: t.libraries )
+      (Lib_dep.Direct (loc, Lib_name.of_string "cinaps.runtime") :: t.libraries)
       ~pps:(Dune_file.Preprocess_map.pps t.preprocess)
       ~dune_version ~variants:None ~optional:false
   in

--- a/src/dune/context_name.ml
+++ b/src/dune/context_name.ml
@@ -23,6 +23,8 @@ include (
   Stringlike.Make (struct
     type t = T.t
 
+    let description_of_valid_string = None
+
     let to_string = T.to_string
 
     let module_ = "Context_name"

--- a/src/dune/context_name.ml
+++ b/src/dune/context_name.ml
@@ -19,54 +19,31 @@ let build_dir t = Path.Build.relative Path.Build.root (to_string t)
 
 let is_default = equal default
 
-let of_string_opt name =
-  if
-    name = ""
-    || String.is_prefix name ~prefix:"."
-    || name = "log" || name = "install" || String.contains name '/'
-    || String.contains name '\\'
-  then
-    None
-  else
-    Some (make name)
+include (
+  Stringlike.Make (struct
+    type t = T.t
 
-let error_message = sprintf "%S is an invalid context name"
+    let to_string = T.to_string
 
-let invalid_context_name (loc, s) =
-  User_error.make ~loc [ Pp.text (error_message s) ]
+    let module_ = "Context_name"
 
-let of_string_user_error (loc, s) =
-  match of_string_opt s with
-  | Some s -> Ok s
-  | None -> Error (invalid_context_name (loc, s))
+    let description = "context name"
 
-let of_string name =
-  match of_string_opt name with
-  | Some p -> p
-  | None ->
-    Code_error.raise "Invalid context name"
-      [ ("name", Dyn.Encoder.string name) ]
-
-let parse_string_exn s =
-  match of_string_user_error s with
-  | Ok s -> s
-  | Error err -> raise (User_error.E err)
-
-let decode =
-  let open Dune_lang.Decoder in
-  map_validate (located string) ~f:of_string_user_error
-
-let encode t = Dune_lang.Encoder.(string (to_string t))
-
-let to_dyn t = Dyn.Encoder.string (to_string t)
+    let of_string_opt name =
+      if
+        name = ""
+        || String.is_prefix name ~prefix:"."
+        || name = "log" || name = "install" || String.contains name '/'
+        || String.contains name '\\'
+      then
+        None
+      else
+        Some (make name)
+  end) :
+    Stringlike_intf.S with type t := t )
 
 let target t ~toolchain =
   make (sprintf "%s.%s" (to_string t) (to_string toolchain))
-
-let arg_parse s =
-  match of_string_opt s with
-  | Some s -> `Ok s
-  | None -> `Error (error_message s)
 
 module Infix = Comparator.Operators (T)
 module Top_closure = Top_closure.Make (Set) (Monad.Id)

--- a/src/dune/context_name.mli
+++ b/src/dune/context_name.mli
@@ -14,21 +14,9 @@ val target : t -> toolchain:t -> t
 
 val equal : t -> t -> bool
 
-val of_string_opt : string -> t option
-
-val of_string : string -> t
-
-val to_string : t -> string
-
-val parse_string_exn : Loc.t * string -> t
-
-val arg_parse : string -> [ `Ok of t | `Error of string ]
-
-include Dune_lang.Conv.S with type t := t
+include Stringlike_intf.S with type t := t
 
 module Infix : Comparator.OPS with type t = t
-
-val to_dyn : t -> Dyn.t
 
 module Map : Map.S with type key = t
 

--- a/src/dune/dir_contents.ml
+++ b/src/dune/dir_contents.ml
@@ -219,10 +219,11 @@ let modules_of_files ~dialects ~dir ~files =
       (name, Module.File.make dialect (Path.relative dir fn))
     in
     let parse_name_or_warn ~fn s =
-      match Module_name.parse_string s with
+      let loc = Loc.in_dir dir in
+      match Module_name.of_string_opt s with
       | Some _ as s -> s
       | None ->
-        User_warning.emit ~loc:(Loc.in_dir dir)
+        User_warning.emit ~loc
           [ Pp.textf
               "The following source file corresponds to an invalid module name:"
           ; Pp.textf "- %s" fn

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -147,8 +147,7 @@ module Pps_and_flags = struct
             | None ->
               User_error.raise ~loc
                 [ Pp.text "No variables allowed in ppx library names" ]
-            | Some txt -> Left (loc, Lib_name.of_string_exn ~loc:(Some loc) txt)
-            ))
+            | Some txt -> Left (loc, Lib_name.parse_string_exn (loc, txt)) ))
     in
     let all_flags = more_flags @ Option.value flags ~default:[] in
     if syntax_version < (1, 10) then

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -916,12 +916,12 @@ module Library = struct
        let name =
          let open Dune_lang.Syntax.Version.Infix in
          match (name, public) with
-         | Some (loc, res), _ -> (loc, Lib_name.Local.validate (loc, res))
+         | Some (loc, res), _ -> (loc, res)
          | None, Some { name = loc, name; _ } ->
            if dune_version >= (1, 1) then
              match Lib_name.to_local name with
-             | Ok m -> (loc, m)
-             | Error () ->
+             | Some m -> (loc, m)
+             | None ->
                User_error.raise ~loc
                  [ Pp.textf "Invalid library name."
                  ; Pp.text

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -148,7 +148,7 @@ let expand_artifact ~dir ~loc t a s =
       | Some path -> Ok [ Value.Path (Path.build path) ] ) )
   | Lib mode -> (
     let+ lookup_library = t.lookup_library in
-    let name = Lib_name.of_string_exn ~loc:(Some loc) name in
+    let name = Lib_name.parse_string_exn (loc, name) in
     match lookup_library ~dir name with
     | None ->
       let msg =
@@ -291,7 +291,7 @@ let str_exp str = [ Value.String str ]
 let parse_lib_file ~loc s =
   match String.lsplit2 s ~on:':' with
   | None -> User_error.raise ~loc [ Pp.textf "invalid %%{lib:...} form: %s" s ]
-  | Some (lib, f) -> (Lib_name.of_string_exn ~loc:(Some loc) lib, f)
+  | Some (lib, f) -> (Lib_name.parse_string_exn (loc, lib), f)
 
 type expansion_kind =
   | Dynamic
@@ -428,7 +428,7 @@ let expand_and_record acc ~map_exe ~dep_kind ~expansion_kind
         else
           add_fail acc { fail = (fun () -> raise e) } ) )
   | Macro (Lib_available, s) ->
-    let lib = Lib_name.of_string_exn ~loc:(Some loc) s in
+    let lib = Lib_name.parse_string_exn (loc, s) in
     Resolved_forms.add_lib_dep acc lib Optional;
     Lib.DB.available (Scope.libs t.scope) lib
     |> string_of_bool |> str_exp |> Option.some

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -155,8 +155,8 @@ let builtin_for_dune : Dune_package.t =
   let entry =
     Dune_package.Entry.Deprecated_library_name
       { loc = Loc.of_pos __POS__
-      ; old_public_name = Lib_name.of_string_exn "dune.configurator" ~loc:None
-      ; new_public_name = Lib_name.of_string_exn "dune-configurator" ~loc:None
+      ; old_public_name = Lib_name.of_string "dune.configurator"
+      ; new_public_name = Lib_name.of_string "dune-configurator"
       }
   in
   { name = Opam_package.Name.of_string "dune"
@@ -222,11 +222,11 @@ end = struct
 
     let requires t =
       Vars.get_words t.vars "requires" preds
-      |> List.map ~f:(Lib_name.of_string_exn ~loc:None)
+      |> List.map ~f:(fun s -> Lib_name.parse_string_exn (Loc.none, s))
 
     let ppx_runtime_deps t =
       Vars.get_words t.vars "ppx_runtime_deps" preds
-      |> List.map ~f:(Lib_name.of_string_exn ~loc:None)
+      |> List.map ~f:(fun s -> Lib_name.parse_string_exn (Loc.none, s))
 
     let kind t =
       match Vars.get t.vars "library_kind" Ps.empty with
@@ -448,8 +448,7 @@ end = struct
     let subs : Meta.Simplified.t list =
       let rec loop = function
         | [] -> []
-        | name :: names ->
-          [ dummy (Lib_name.of_string_exn ~loc:None name) (loop names) ]
+        | name :: names -> [ dummy (Lib_name.of_string name) (loop names) ]
       in
       loop names
     in

--- a/src/dune/findlib/meta.ml
+++ b/src/dune/findlib/meta.ml
@@ -73,7 +73,8 @@ module Parse = struct
     | String s ->
       if String.contains s '.' then
         error lb "'.' not allowed in sub-package names";
-      Lib_name.of_string_exn ~loc:None s
+      let loc = Loc.of_lexbuf lb in
+      Lib_name.parse_string_exn (loc, s)
     | _ -> error lb "package name expected"
 
   let string lb =
@@ -247,7 +248,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
       | None -> name
       | Some a -> a
     in
-    let name = Lib_name.of_string_exn ~loc:None name in
+    let name = Lib_name.of_string name in
     let archives = archives archive_name in
     { name = Some name
     ; entries =
@@ -259,7 +260,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
     }
   in
   let dummy name =
-    { name = Some (Lib_name.of_string_exn ~loc:None name)
+    { name = Some (Lib_name.of_string name)
     ; entries = [ version ]
     }
   in
@@ -267,7 +268,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
     let sub name deps =
       Package (simple name deps ~archive_name:("ocaml" ^ name))
     in
-    { name = Some (Lib_name.of_string_exn ~loc:None "compiler-libs")
+    { name = Some (Lib_name.of_string "compiler-libs")
     ; entries =
         [ requires []
         ; version
@@ -297,7 +298,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   let uchar = dummy "uchar" in
   let seq = dummy "seq" in
   let threads =
-    { name = Some (Lib_name.of_string_exn ~loc:None "threads")
+    { name = Some (Lib_name.of_string "threads")
     ; entries =
         [ version
         ; requires ~preds:[ Pos "mt"; Pos "mt_vm" ] [ "threads.vm" ]
@@ -316,7 +317,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
     }
   in
   let num =
-    { name = Some (Lib_name.of_string_exn ~loc:None "num")
+    { name = Some (Lib_name.of_string "num")
     ; entries =
         [ requires [ "num.core" ]
         ; version

--- a/src/dune/findlib/meta.ml
+++ b/src/dune/findlib/meta.ml
@@ -260,9 +260,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
     }
   in
   let dummy name =
-    { name = Some (Lib_name.of_string name)
-    ; entries = [ version ]
-    }
+    { name = Some (Lib_name.of_string name); entries = [ version ] }
   in
   let compiler_libs =
     let sub name deps =

--- a/src/dune/gen_meta.ml
+++ b/src/dune/gen_meta.ml
@@ -192,7 +192,7 @@ let gen ~package ~version ?(add_directory_entry = true) entries =
              in
              Package pkg)
     in
-    { name = Some (Lib_name.of_string_exn ~loc:None name)
+    { name = Some (Lib_name.parse_string_exn (Loc.none, name))
     ; entries = entries @ subs
     }
   in

--- a/src/dune/js_of_ocaml_rules.ml
+++ b/src/dune/js_of_ocaml_rules.ml
@@ -36,7 +36,7 @@ let runtime_file ~dir ~sctx file =
   match
     Artifacts.Public_libs.file_of_lib (SC.artifacts sctx).public_libs
       ~loc:Loc.none
-      ~lib:(Lib_name.of_string_exn ~loc:None "js_of_ocaml-compiler")
+      ~lib:(Lib_name.of_string "js_of_ocaml-compiler")
       ~file
   with
   | Error _ -> (
@@ -153,7 +153,7 @@ let setup_separate_compilation_rules sctx components =
     | _ :: _ :: _ ->
       ()
     | [ pkg ] -> (
-      let pkg = Lib_name.of_string_exn ~loc:None pkg in
+      let pkg = Lib_name.parse_string_exn (Loc.none, pkg) in
       let ctx = SC.context sctx in
       match Lib.DB.find (SC.installed_libs sctx) pkg with
       | None -> ()

--- a/src/dune/lib_dep.ml
+++ b/src/dune/lib_dep.ml
@@ -18,10 +18,9 @@ module Select = struct
              ~before:
                (let+ s = string
                 and+ loc = loc in
-                let loc = Some loc in
                 match String.drop_prefix s ~prefix:"!" with
-                | Some s -> Right (Lib_name.of_string_exn ~loc s)
-                | None -> Left (Lib_name.of_string_exn ~loc s))
+                | Some s -> Right (Lib_name.parse_string_exn (loc, s))
+                | None -> Left (Lib_name.parse_string_exn (loc, s)))
              ~after:(located filename)
          in
          match file with

--- a/src/dune/lib_name.ml
+++ b/src/dune/lib_name.ml
@@ -1,9 +1,5 @@
 open Stdune
 
-let encode = Dune_lang.Encoder.string
-
-let decode = Dune_lang.Decoder.string
-
 module Local = struct
   type t = string
 
@@ -82,29 +78,27 @@ let pp_quoted fmt t = Format.fprintf fmt "%S" t
 
 let to_local = Local.of_string
 
-let to_dyn t = Dyn.String t
+include Stringlike.Make (struct
+  type nonrec t = string
 
-let to_string t = t
+  let to_string s = s
 
-let of_string_exn ~loc:_ s = s
+  let module_ = "Lib_name"
+
+  let description = "library name"
+
+  let of_string_opt s = Some s
+end)
 
 let of_local (_loc, t) = t
 
 let of_package_name p = Package.Name.to_string p
 
-type t = string
-
 let hash = String.hash
 
 let compare = String.compare
 
-include (
-  Comparator.Operators (struct
-    type nonrec t = t
-
-    let compare = compare
-  end) :
-    Comparator.OPS with type t := t )
+include (Comparator.Operators (String) : Comparator.OPS with type t := t)
 
 module O = Comparable.Make (String)
 module Map = O.Map

--- a/src/dune/lib_name.ml
+++ b/src/dune/lib_name.ml
@@ -5,8 +5,8 @@ module Local = struct
 
   let valid_format_doc =
     Pp.text
-      "library names must be non-empty and composed only of the following \
-       characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'"
+      "Library names must be non-empty and composed only of the following \
+       characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'."
 
   include (
     Stringlike.Make (struct

--- a/src/dune/lib_name.mli
+++ b/src/dune/lib_name.mli
@@ -7,21 +7,9 @@ val hash : t -> int
 include Stringlike_intf.S with type t := t
 
 module Local : sig
-  type t
+  include Stringlike_intf.S
 
-  val encode : t Dune_lang.Encoder.t
-
-  val decode_loc : (Loc.t * (t, unit) Result.t) Dune_lang.Decoder.t
-
-  val validate : Loc.t * (t, unit) Result.t -> t
-
-  val of_string_exn : string -> t
-
-  val of_string : string -> (t, unit) Result.t
-
-  val to_string : t -> string
-
-  (** Description of valid library banes *)
+  (** Description of valid library names *)
   val valid_format_doc : User_message.Style.t Pp.t
 
   val pp_quoted : t Fmt.t
@@ -39,7 +27,7 @@ val pp_quoted : t Fmt.t
 
 val of_local : Loc.t * Local.t -> t
 
-val to_local : t -> (Local.t, unit) Result.t
+val to_local : t -> Local.t option
 
 val split : t -> Package.Name.t * string list
 

--- a/src/dune/lib_name.mli
+++ b/src/dune/lib_name.mli
@@ -4,11 +4,7 @@ type t
 
 val hash : t -> int
 
-val of_string_exn : loc:Loc.t option -> string -> t
-
-val to_string : t -> string
-
-include Dune_lang.Conv.S with type t := t
+include Stringlike_intf.S with type t := t
 
 module Local : sig
   type t
@@ -60,5 +56,3 @@ module Set : sig
 end
 
 val nest : t -> t -> t
-
-val to_dyn : t -> Dyn.t

--- a/src/dune/link_time_code_gen.ml
+++ b/src/dune/link_time_code_gen.ml
@@ -203,10 +203,10 @@ let handle_special_libs cctx =
                findlib. That's why it's ok to use a dummy location. *)
             let+ dynlink =
               Lib.DB.resolve (SC.public_libs sctx)
-                (Loc.none, Lib_name.of_string_exn ~loc:None "dynlink")
+                (Loc.none, Lib_name.of_string "dynlink")
             and+ findlib =
               Lib.DB.resolve (SC.public_libs sctx)
-                (Loc.none, Lib_name.of_string_exn ~loc:None "findlib")
+                (Loc.none, Lib_name.of_string "findlib")
             in
             [ dynlink; findlib ]
           in

--- a/src/dune/module_name.ml
+++ b/src/dune/module_name.ml
@@ -9,6 +9,8 @@ include Stringlike.Make (struct
 
   let module_ = "Module_name"
 
+  let description_of_valid_string = None
+
   let is_valid_module_name name =
     match name with
     | "" -> false
@@ -56,7 +58,7 @@ module Infix = Comparator.Operators (String)
 
 let of_local_lib_name s = of_string (Lib_name.Local.to_string s)
 
-let to_local_lib_name s = Lib_name.Local.of_string_exn s
+let to_local_lib_name s = Lib_name.Local.of_string s
 
 module Per_item = Per_item.Make (String)
 

--- a/src/dune/module_name.ml
+++ b/src/dune/module_name.ml
@@ -1,54 +1,45 @@
 open Stdune
 
-module T = struct
+include Stringlike.Make (struct
   type t = string
 
-  let compare = Poly.compare
+  let to_string s = s
 
-  let to_dyn = Dyn.Encoder.string
-end
+  let description = "module name"
 
-include T
+  let module_ = "Module_name"
 
-let encode = Dune_lang.Encoder.string
+  let is_valid_module_name name =
+    match name with
+    | "" -> false
+    | s -> (
+      try
+        ( match s.[0] with
+        | 'A' .. 'Z'
+        | 'a' .. 'z' ->
+          ()
+        | _ -> raise_notrace Exit );
+        String.iter s ~f:(function
+          | 'A' .. 'Z'
+          | 'a' .. 'z'
+          | '0' .. '9'
+          | '\''
+          | '_' ->
+            ()
+          | _ -> raise_notrace Exit);
+        true
+      with Exit -> false )
+
+  let of_string_opt s =
+    if is_valid_module_name s then
+      Some (String.capitalize s)
+    else
+      None
+end)
+
+let compare = String.compare
 
 let add_suffix = ( ^ )
-
-let is_valid_module_name name =
-  match name with
-  | "" -> false
-  | s -> (
-    try
-      ( match s.[0] with
-      | 'A' .. 'Z'
-      | 'a' .. 'z' ->
-        ()
-      | _ -> raise_notrace Exit );
-      String.iter s ~f:(function
-        | 'A' .. 'Z'
-        | 'a' .. 'z'
-        | '0' .. '9'
-        | '\''
-        | '_' ->
-          ()
-        | _ -> raise_notrace Exit);
-      true
-    with Exit -> false )
-
-let parse_string s =
-  if is_valid_module_name s then
-    Some (String.capitalize s)
-  else
-    None
-
-let of_string s =
-  match parse_string s with
-  | Some s -> s
-  | None ->
-    Code_error.raise "Module_name.of_string: invalid name"
-      [ ("s", Dyn.Encoder.string s) ]
-
-let to_string x = x
 
 let uncapitalize = String.uncapitalize
 
@@ -61,24 +52,13 @@ module Set = struct
 end
 
 module Map = String.Map
-module Infix = Comparator.Operators (T)
+module Infix = Comparator.Operators (String)
 
 let of_local_lib_name s = of_string (Lib_name.Local.to_string s)
 
 let to_local_lib_name s = Lib_name.Local.of_string_exn s
 
-let invalid_module_name ~loc name =
-  User_error.raise ~loc [ Pp.textf "invalid module name: %S" name ]
-
-let decode =
-  let open Dune_lang.Decoder in
-  plain_string (fun ~loc name ->
-      if is_valid_module_name name then
-        of_string name
-      else
-        invalid_module_name ~loc name)
-
-module Per_item = Per_item.Make (T)
+module Per_item = Per_item.Make (String)
 
 module Unique = struct
   module T = struct

--- a/src/dune/module_name.mli
+++ b/src/dune/module_name.mli
@@ -3,19 +3,11 @@ open Stdune
 (** Represents a valid OCaml module name *)
 type t
 
-val to_dyn : t -> Dyn.t
-
-include Dune_lang.Conv.S with type t := t
+include Stringlike_intf.S with type t := t
 
 val add_suffix : t -> string -> t
 
 val compare : t -> t -> Ordering.t
-
-val parse_string : string -> t option
-
-val of_string : string -> t
-
-val to_string : t -> string
 
 val uncapitalize : t -> string
 
@@ -28,8 +20,6 @@ module Infix : Comparator.OPS with type t = t
 val of_local_lib_name : Lib_name.Local.t -> t
 
 val to_local_lib_name : t -> Lib_name.Local.t
-
-val decode : t Dune_lang.Decoder.t
 
 module Unique : sig
   type name

--- a/src/dune/odoc.ml
+++ b/src/dune/odoc.ml
@@ -14,14 +14,14 @@ end = struct
   let of_string sctx s =
     match String.rsplit2 s ~on:'@' with
     | None ->
-      (Lib_name.of_string_exn s ~loc:None, Super_context.public_libs sctx)
+      (Lib_name.parse_string_exn (Loc.none, s), Super_context.public_libs sctx)
     | Some (lib, key) ->
       let scope =
         Dune_project.File_key.of_string key
         |> Super_context.find_project_by_key sctx
         |> Super_context.find_scope_by_project sctx
       in
-      (Lib_name.of_string_exn lib ~loc:None, Scope.libs scope)
+      (Lib_name.parse_string_exn (Loc.none, lib), Scope.libs scope)
 
   let to_string lib project =
     let key = Dune_project.file_key project in

--- a/src/dune/package.ml
+++ b/src/dune/package.ml
@@ -28,8 +28,10 @@ module Name = struct
 
       let description = "package name"
 
+      let description_of_valid_string = None
+
       let of_string_opt s =
-        (* TODO verify no dots or spaces *)
+        (* DUNE3 verify no dots or spaces *)
         if s = "" then
           None
         else

--- a/src/dune/package.mli
+++ b/src/dune/package.mli
@@ -5,10 +5,6 @@ open! Stdune
 module Name : sig
   type t
 
-  val of_string : string -> t
-
-  val parse_string_exn : Loc.t * string -> t
-
   val opam_fn : t -> string
 
   val version_fn : t -> string
@@ -19,7 +15,7 @@ module Name : sig
 
   module Infix : Comparator.OPS with type t = t
 
-  val to_dyn : t -> Dyn.t
+  include Stringlike_intf.S with type t := t
 
   val of_opam_file_basename : string -> t option
 end

--- a/src/dune/profile.ml
+++ b/src/dune/profile.ml
@@ -5,22 +5,35 @@ type t =
   | Release
   | User_defined of string
 
+include (
+  Stringlike.Make (struct
+    type nonrec t = t
+
+    let description = "profile"
+
+    let module_ = "Profile"
+
+    let of_string_opt p =
+      (* TODO actually validate *)
+      Some
+        ( match p with
+        | "dev" -> Dev
+        | "release" -> Release
+        | s -> User_defined s )
+
+    let to_string = function
+      | Dev -> "dev"
+      | Release -> "release"
+      | User_defined s -> s
+  end) :
+    Stringlike_intf.S with type t := t )
+
 let equal x y =
   match (x, y) with
   | Dev, Dev -> true
   | Release, Release -> true
   | User_defined x, User_defined y -> String.equal x y
   | _, _ -> false
-
-let of_string = function
-  | "dev" -> Dev
-  | "release" -> Release
-  | s -> User_defined s
-
-let to_string = function
-  | Dev -> "dev"
-  | Release -> "release"
-  | User_defined s -> s
 
 let default = Dev
 
@@ -35,11 +48,6 @@ let is_release = function
 let is_inline_test = function
   | Release -> false
   | _ -> true
-
-let decode =
-  let open Dune_lang.Decoder in
-  let+ name = string in
-  of_string name
 
 let to_dyn =
   let open Dyn.Encoder in

--- a/src/dune/profile.ml
+++ b/src/dune/profile.ml
@@ -21,6 +21,8 @@ include (
         | "release" -> Release
         | s -> User_defined s )
 
+    let description_of_valid_string = None
+
     let to_string = function
       | Dev -> "dev"
       | Release -> "release"

--- a/src/dune/profile.mli
+++ b/src/dune/profile.mli
@@ -1,6 +1,5 @@
 (** Defines build profile for dune. Only one profile is active per context. Some
     profiles are treat specially by dune. *)
-open Stdune
 
 type t =
   | Dev
@@ -15,12 +14,6 @@ val is_release : t -> bool
 
 val is_inline_test : t -> bool
 
-val to_string : t -> string
-
-val of_string : string -> t (* TODO add error handling *)
+include Stringlike_intf.S with type t := t
 
 val default : t
-
-val decode : t Dune_lang.Decoder.t
-
-val to_dyn : t -> Dyn.t

--- a/src/dune/stringlike.ml
+++ b/src/dune/stringlike.ml
@@ -1,0 +1,42 @@
+open Import
+
+module Make (S : Stringlike_intf.S_base) = struct
+  include S
+
+  let of_string s : t =
+    match S.of_string_opt s with
+    | Some s -> s
+    | None ->
+      Code_error.raise
+        ("Invalid " ^ S.module_ ^ ".t")
+        [ ("s", Dyn.Encoder.string s) ]
+
+  let error_message s = Printf.sprintf "%S is an invalid %s" s S.description
+
+  let user_error (loc, s) = User_error.make ~loc [ Pp.text (error_message s) ]
+
+  let of_string_user_error (loc, s) =
+    match of_string_opt s with
+    | Some s -> Ok s
+    | None -> Error (user_error (loc, s))
+
+  let parse_string_exn (loc, s) =
+    match of_string_user_error (loc, s) with
+    | Ok s -> s
+    | Error err -> raise (User_error.E err)
+
+  let conv =
+    ( (fun s ->
+        match of_string_opt s with
+        | Some x -> Ok x
+        | None -> Error (`Msg (error_message s)))
+    , fun fmt t -> Format.pp_print_string fmt (to_string t) )
+
+  let decode =
+    let open Dune_lang.Decoder in
+    map_validate (located string) ~f:of_string_user_error
+
+  let encode t = Dune_lang.Encoder.(string (to_string t))
+
+  let to_dyn t = Dyn.Encoder.string (to_string t)
+end

--- a/src/dune/stringlike.ml
+++ b/src/dune/stringlike.ml
@@ -11,13 +11,13 @@ module Make (S : Stringlike_intf.S_base) = struct
         ("Invalid " ^ S.module_ ^ ".t")
         [ ("s", Dyn.Encoder.string s) ]
 
-  let error_message s = Printf.sprintf "%S is an invalid %s" s S.description
+  let error_message s = Printf.sprintf "%S is an invalid %s." s S.description
 
   let user_error (loc, s) =
     let valid_desc =
       match S.description_of_valid_string with
       | None -> []
-      | Some m -> [m]
+      | Some m -> [ m ]
     in
     User_error.make ~loc (Pp.text (error_message s) :: valid_desc)
 

--- a/src/dune/stringlike.mli
+++ b/src/dune/stringlike.mli
@@ -1,0 +1,5 @@
+(** Create a standard set of functions from a base pair of to/from string
+    converters *)
+(* CR-someday aalekseyev: make the return type [with type t = private S.t] for better
+   safety against accidental injection of unvalidated values *)
+module Make (S : Stringlike_intf.S_base) : Stringlike_intf.S with type t = S.t

--- a/src/dune/stringlike.mli
+++ b/src/dune/stringlike.mli
@@ -1,5 +1,6 @@
+(* CR-someday aalekseyev: make the return type [with type t = private S.t] for
+   better safety against accidental injection of unvalidated values *)
+
 (** Create a standard set of functions from a base pair of to/from string
     converters *)
-(* CR-someday aalekseyev: make the return type [with type t = private S.t] for better
-   safety against accidental injection of unvalidated values *)
 module Make (S : Stringlike_intf.S_base) : Stringlike_intf.S with type t = S.t

--- a/src/dune/stringlike_intf.ml
+++ b/src/dune/stringlike_intf.ml
@@ -3,13 +3,17 @@ open Import
 module type S_base = sig
   type t
 
-  (** The name of the module, for use in error messages. For example ["Lib_name"],
-      ["Context_name"]. *)
+  (** The name of the module, for use in error messages. For example
+      ["Lib_name"], ["Context_name"]. *)
   val module_ : string
 
   (** A short description of the type, for use in user-facing error messages.
       For example "context name", "library name". *)
   val description : string
+
+  (** A description of valid identifiers. Will be added to error messages if
+      present *)
+  val description_of_valid_string : 'a Pp.t option
 
   val of_string_opt : string -> t option
 
@@ -38,4 +42,6 @@ module type S = sig
     * (Format.formatter -> t -> unit)
 
   include Dune_lang.Conv.S with type t := t
+
+  val decode_loc : (Loc.t * t) Dune_lang.Decoder.t
 end

--- a/src/dune/stringlike_intf.ml
+++ b/src/dune/stringlike_intf.ml
@@ -1,0 +1,41 @@
+open Import
+
+module type S_base = sig
+  type t
+
+  (** The name of the module, for use in error messages. For example ["Lib_name"],
+      ["Context_name"]. *)
+  val module_ : string
+
+  (** A short description of the type, for use in user-facing error messages.
+      For example "context name", "library name". *)
+  val description : string
+
+  val of_string_opt : string -> t option
+
+  val to_string : t -> string
+end
+
+module type S = sig
+  (** An interface for types that are convertible from/to strings. *)
+  type t
+
+  (** [of_string] should only be used on strings that are known to represent a
+      valid [t]. *)
+  val of_string : string -> t
+
+  val to_string : t -> string
+
+  val parse_string_exn : Loc.t * string -> t
+
+  val to_dyn : t -> Dyn.t
+
+  val of_string_opt : string -> t option
+
+  (** From&to string conversions, for use with [Cmdliner.Arg.conv] *)
+  val conv :
+    (string -> (t, [> `Msg of string ]) result)
+    * (Format.formatter -> t -> unit)
+
+  include Dune_lang.Conv.S with type t := t
+end

--- a/src/dune/toplevel.ml
+++ b/src/dune/toplevel.ml
@@ -102,7 +102,7 @@ module Stanza = struct
     let dune_version = Scope.project scope |> Dune_project.dune_version in
     let compile_info =
       let compiler_libs =
-        Lib_name.of_string_exn ~loc:(Some source.loc) "compiler-libs.toplevel"
+        Lib_name.parse_string_exn (source.loc, "compiler-libs.toplevel")
       in
       Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
         [ (source.loc, source.name) ]

--- a/src/dune/utop.ml
+++ b/src/dune/utop.ml
@@ -71,7 +71,7 @@ let setup sctx ~dir =
   let modules = Toplevel.Source.modules source in
   let requires =
     let open Result.O in
-    (loc, Lib_name.of_string_exn ~loc:(Some loc) "utop")
+    (loc, Lib_name.of_string "utop")
     |> Lib.DB.resolve db
     >>| (fun utop -> utop :: libs)
     >>= Lib.closure ~linking:true

--- a/test/blackbox-tests/test-cases/dune-init/run.t
+++ b/test/blackbox-tests/test-cases/dune-init/run.t
@@ -240,9 +240,9 @@ Will not create components with invalid names
 
   $ dune init lib invalid-component-name ./_test_lib
   dune: NAME argument: invalid component name `invalid-component-name'
-        Hint: library names must be non-empty and composed only of the
+        Library names must be non-empty and composed only of the
         following
-        characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'
+        characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
   Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/github3046/run.t
+++ b/test/blackbox-tests/test-cases/github3046/run.t
@@ -26,9 +26,9 @@ are given as paramters
 
   $ dune init lib foo --public="some/invalid&name!"
   dune: option `--public': invalid component name `some/invalid&name!'
-        Hint: library names must be non-empty and composed only of the
+        Library names must be non-empty and composed only of the
         following
-        characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'
+        characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
   Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/name-field-validation/run.t
+++ b/test/blackbox-tests/test-cases/name-field-validation/run.t
@@ -2,7 +2,7 @@
   File "dune", line 3, characters 7-14:
   3 |  (name foo.bar)
              ^^^^^^^
-  Error: "foo.bar" is an invalid library name
-  library names must be non-empty and composed only of the following
-  characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'
+  Error: "foo.bar" is an invalid library name.
+  Library names must be non-empty and composed only of the following
+  characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
   [1]

--- a/test/blackbox-tests/test-cases/name-field-validation/run.t
+++ b/test/blackbox-tests/test-cases/name-field-validation/run.t
@@ -2,7 +2,7 @@
   File "dune", line 3, characters 7-14:
   3 |  (name foo.bar)
              ^^^^^^^
-  Error: Invalid library name.
-  Hint: library names must be non-empty and composed only of the following
+  Error: "foo.bar" is an invalid library name
+  library names must be non-empty and composed only of the following
   characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'
   [1]

--- a/test/blackbox-tests/test-cases/no-name-field/run.t
+++ b/test/blackbox-tests/test-cases/no-name-field/run.t
@@ -35,8 +35,8 @@ there's only a public name but it's invalid as a name
   Public library names don't have this restriction. You can either change this
   public name to be a valid library name or add a "name" field with a valid
   library name.
-  Hint: library names must be non-empty and composed only of the following
-  characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'
+  Hint: Library names must be non-empty and composed only of the following
+  characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
   [1]
 
 there's only a public name which is invalid, but sine the library is unwrapped,
@@ -51,6 +51,6 @@ it's just a warning
   Public library names don't have this restriction. You can either change this
   public name to be a valid library name or add a "name" field with a valid
   library name.
-  Hint: library names must be non-empty and composed only of the following
-  characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'
+  Hint: Library names must be non-empty and composed only of the following
+  characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
   [1]

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -34,7 +34,7 @@ let findlib =
 
 let%expect_test _ =
   let pkg =
-    match Findlib.find findlib (Lib_name.of_string_exn ~loc:None "foo") with
+    match Findlib.find findlib (Lib_name.of_string "foo") with
     | Ok (Library x) -> x
     | _ -> assert false
   in


### PR DESCRIPTION
This module enforces our convention regarding string conversion and
validation. It includes standard ways to read strings from sexp and from
the command line.