### PR TITLE
Meta builtins: add entry for stdlib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ------------------
 
 - Add `mdx` extension and stanza version 0.1 (#3094, @NathanReb)
+- Fix separate compilation of JS when findlib is not installed. (#3177, @nojb)
 
 2.3.1 (20/02/2020)
 ------------------

--- a/src/dune/findlib/meta.ml
+++ b/src/dune/findlib/meta.ml
@@ -279,6 +279,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
         ]
     }
   in
+  let stdlib = dummy "stdlib" in
   let str = simple "str" [] ~dir:"+" in
   let unix = simple "unix" [] ~dir:"+" in
   let bigarray =
@@ -325,7 +326,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   in
   let libs =
     let base =
-      [ compiler_libs; str; unix; bigarray; threads; dynlink; bytes ]
+      [ stdlib; compiler_libs; str; unix; bigarray; threads; dynlink; bytes ]
     in
     let base =
       if Ocaml_version.pervasives_includes_result ocaml_version then


### PR DESCRIPTION
In particular, this fixes separate compilation of JS when `ocamlfind` is not installed.