### PR TITLE
Make signature handling more consistent

### DIFF
--- a/src/dune/context_name.mli
+++ b/src/dune/context_name.mli
@@ -35,4 +35,4 @@ module Map : Map.S with type key = t
 module Set : Set.S with type elt = t
 
 module Top_closure :
-  Top_closure.S with type key := t and type 'a monad := 'a Monad.Id.t
+  Top_closure_intf.S with type key := t and type 'a monad := 'a Monad.Id.t

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -252,7 +252,7 @@ module Id : sig
   module Map : Map.S with type key = t
 
   module Top_closure :
-    Top_closure.S with type key := t and type 'a monad := 'a Monad.Id.t
+    Top_closure_intf.S with type key := t and type 'a monad := 'a Monad.Id.t
 end = struct
   module T = struct
     type t =

--- a/src/dune/module_name.mli
+++ b/src/dune/module_name.mli
@@ -21,7 +21,7 @@ val uncapitalize : t -> string
 
 val pp_quote : Format.formatter -> t -> unit
 
-module Per_item : Per_item.S with type key = t
+module Per_item : Per_item_intf.S with type key = t
 
 module Infix : Comparator.OPS with type t = t
 

--- a/src/dune/per_item.ml
+++ b/src/dune/per_item.ml
@@ -1,27 +1,6 @@
 open! Stdune
 
-module type S = sig
-  type key
-
-  type 'a t
-
-  val for_all : 'a -> 'a t
-
-  val of_mapping :
-    (key list * 'a) list -> default:'a -> ('a t, key * 'a * 'a) result
-
-  val get : 'a t -> key -> 'a
-
-  val is_constant : _ t -> bool
-
-  val map : 'a t -> f:('a -> 'b) -> 'b t
-
-  val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
-
-  val exists : 'a t -> f:('a -> bool) -> bool
-end
-
-module Make (Key : Map.Key) : S with type key = Key.t = struct
+module Make (Key : Map.Key) : Per_item_intf.S with type key = Key.t = struct
   module Map = Map.Make (Key)
 
   type key = Key.t

--- a/src/dune/per_item.mli
+++ b/src/dune/per_item.mli
@@ -5,30 +5,4 @@
 
 open! Stdune
 
-module type S = sig
-  type key
-
-  type 'a t
-
-  (** Create a mapping where all keys map to the same value *)
-  val for_all : 'a -> 'a t
-
-  (** Create a mapping from a list of bindings *)
-  val of_mapping :
-    (key list * 'a) list -> default:'a -> ('a t, key * 'a * 'a) result
-
-  (** Get the configuration for the given item *)
-  val get : 'a t -> key -> 'a
-
-  (** Returns [true] if the mapping returns the same value for all keys. Note
-      that the mapping might still be constant if [is_constant] returns [false]. *)
-  val is_constant : _ t -> bool
-
-  val map : 'a t -> f:('a -> 'b) -> 'b t
-
-  val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
-
-  val exists : 'a t -> f:('a -> bool) -> bool
-end
-
-module Make (Key : Map.Key) : S with type key = Key.t
+module Make (Key : Map.Key) : Per_item_intf.S with type key = Key.t

--- a/src/dune/per_item_intf.ml
+++ b/src/dune/per_item_intf.ml
@@ -1,0 +1,25 @@
+module type S = sig
+  type key
+
+  type 'a t
+
+  (** Create a mapping where all keys map to the same value *)
+  val for_all : 'a -> 'a t
+
+  (** Create a mapping from a list of bindings *)
+  val of_mapping :
+    (key list * 'a) list -> default:'a -> ('a t, key * 'a * 'a) result
+
+  (** Get the configuration for the given item *)
+  val get : 'a t -> key -> 'a
+
+  (** Returns [true] if the mapping returns the same value for all keys. Note
+      that the mapping might still be constant if [is_constant] returns [false]. *)
+  val is_constant : _ t -> bool
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
+
+  val exists : 'a t -> f:('a -> bool) -> bool
+end

--- a/src/dune/top_closure.ml
+++ b/src/dune/top_closure.ml
@@ -1,30 +1,6 @@
 open! Stdune
 
-module type Keys = sig
-  type t
-
-  type elt
-
-  val empty : t
-
-  val add : t -> elt -> t
-
-  val mem : t -> elt -> bool
-end
-
-module type S = sig
-  type key
-
-  type 'a monad
-
-  val top_closure :
-       key:('a -> key)
-    -> deps:('a -> 'a list monad)
-    -> 'a list
-    -> ('a list, 'a list) result monad
-end
-
-module Make (Keys : Keys) (Monad : Monad.S) = struct
+module Make (Keys : Top_closure_intf.Keys) (Monad : Monad_intf.S) = struct
   open Monad
 
   let top_closure ~key ~deps elements =

--- a/src/dune/top_closure.mli
+++ b/src/dune/top_closure.mli
@@ -1,34 +1,11 @@
 open! Stdune
 
-module type Keys = sig
-  type t
+module Int :
+  Top_closure_intf.S with type key := int and type 'a monad := 'a Monad.Id.t
 
-  type elt
+module String :
+  Top_closure_intf.S with type key := string and type 'a monad := 'a Monad.Id.t
 
-  val empty : t
-
-  val add : t -> elt -> t
-
-  val mem : t -> elt -> bool
-end
-
-module type S = sig
-  type key
-
-  type 'a monad
-
-  (** Returns [Error cycle] in case the graph is not a DAG *)
-  val top_closure :
-       key:('a -> key)
-    -> deps:('a -> 'a list monad)
-    -> 'a list
-    -> ('a list, 'a list) result monad
-end
-
-module Int : S with type key := int and type 'a monad := 'a Monad.Id.t
-
-module String : S with type key := string and type 'a monad := 'a Monad.Id.t
-
-module Make (Keys : Keys) (Monad : Monad.S) :
-  S with type key := Keys.elt and type 'a monad := 'a Monad.t
+module Make (Keys : Top_closure_intf.Keys) (Monad : Monad_intf.S) :
+  Top_closure_intf.S with type key := Keys.elt and type 'a monad := 'a Monad.t
 [@@inlined always]

--- a/src/dune/top_closure_intf.ml
+++ b/src/dune/top_closure_intf.ml
@@ -1,0 +1,26 @@
+open Import
+
+module type Keys = sig
+  type t
+
+  type elt
+
+  val empty : t
+
+  val add : t -> elt -> t
+
+  val mem : t -> elt -> bool
+end
+
+module type S = sig
+  type key
+
+  type 'a monad
+
+  (** Returns [Error cycle] in case the graph is not a DAG *)
+  val top_closure :
+       key:('a -> key)
+    -> deps:('a -> 'a list monad)
+    -> 'a list
+    -> ('a list, 'a list) result monad
+end

--- a/src/stdune/io.ml
+++ b/src/stdune/io.ml
@@ -29,47 +29,6 @@ let copy_channels =
   in
   loop
 
-module type S = sig
-  type path
-
-  val open_in : ?binary:bool (* default true *) -> path -> in_channel
-
-  val open_out : ?binary:bool (* default true *) -> path -> out_channel
-
-  val with_file_in :
-    ?binary:bool (* default true *) -> path -> f:(in_channel -> 'a) -> 'a
-
-  val with_file_out :
-    ?binary:bool (* default true *) -> path -> f:(out_channel -> 'a) -> 'a
-
-  val with_lexbuf_from_file : path -> f:(Lexing.lexbuf -> 'a) -> 'a
-
-  val lines_of_file : path -> string list
-
-  val read_file : ?binary:bool -> path -> string
-
-  val write_file : ?binary:bool -> path -> string -> unit
-
-  val compare_files : path -> path -> Ordering.t
-
-  val compare_text_files : path -> path -> Ordering.t
-
-  val write_lines : ?binary:bool -> path -> string list -> unit
-
-  val copy_file : ?chmod:(int -> int) -> src:path -> dst:path -> unit -> unit
-
-  val setup_copy :
-       ?chmod:(int -> int)
-    -> src:path
-    -> dst:path
-    -> unit
-    -> in_channel * out_channel
-
-  val file_line : path -> int -> string
-
-  val file_lines : path -> start:int -> stop:int -> (string * string) list
-end
-
 module Make (Path : sig
   type t
 

--- a/src/stdune/io.mli
+++ b/src/stdune/io.mli
@@ -14,47 +14,6 @@ val copy_channels : in_channel -> out_channel -> unit
 
 val read_all : in_channel -> string
 
-module type S = sig
-  type path
+include Io_intf.S with type path = Path.t
 
-  val open_in : ?binary:bool (* default true *) -> path -> in_channel
-
-  val open_out : ?binary:bool (* default true *) -> path -> out_channel
-
-  val with_file_in :
-    ?binary:bool (* default true *) -> path -> f:(in_channel -> 'a) -> 'a
-
-  val with_file_out :
-    ?binary:bool (* default true *) -> path -> f:(out_channel -> 'a) -> 'a
-
-  val with_lexbuf_from_file : path -> f:(Lexing.lexbuf -> 'a) -> 'a
-
-  val lines_of_file : path -> string list
-
-  val read_file : ?binary:bool -> path -> string
-
-  val write_file : ?binary:bool -> path -> string -> unit
-
-  val compare_files : path -> path -> Ordering.t
-
-  val compare_text_files : path -> path -> Ordering.t
-
-  val write_lines : ?binary:bool -> path -> string list -> unit
-
-  val copy_file : ?chmod:(int -> int) -> src:path -> dst:path -> unit -> unit
-
-  val setup_copy :
-       ?chmod:(int -> int)
-    -> src:path
-    -> dst:path
-    -> unit
-    -> in_channel * out_channel
-
-  val file_line : path -> int -> string
-
-  val file_lines : path -> start:int -> stop:int -> (string * string) list
-end
-
-include S with type path = Path.t
-
-module String_path : S with type path = string
+module String_path : Io_intf.S with type path = string

--- a/src/stdune/io_intf.ml
+++ b/src/stdune/io_intf.ml
@@ -1,0 +1,40 @@
+module type S = sig
+  type path
+
+  val open_in : ?binary:bool (* default true *) -> path -> in_channel
+
+  val open_out : ?binary:bool (* default true *) -> path -> out_channel
+
+  val with_file_in :
+    ?binary:bool (* default true *) -> path -> f:(in_channel -> 'a) -> 'a
+
+  val with_file_out :
+    ?binary:bool (* default true *) -> path -> f:(out_channel -> 'a) -> 'a
+
+  val with_lexbuf_from_file : path -> f:(Lexing.lexbuf -> 'a) -> 'a
+
+  val lines_of_file : path -> string list
+
+  val read_file : ?binary:bool -> path -> string
+
+  val write_file : ?binary:bool -> path -> string -> unit
+
+  val compare_files : path -> path -> Ordering.t
+
+  val compare_text_files : path -> path -> Ordering.t
+
+  val write_lines : ?binary:bool -> path -> string list -> unit
+
+  val copy_file : ?chmod:(int -> int) -> src:path -> dst:path -> unit -> unit
+
+  val setup_copy :
+       ?chmod:(int -> int)
+    -> src:path
+    -> dst:path
+    -> unit
+    -> in_channel * out_channel
+
+  val file_line : path -> int -> string
+
+  val file_lines : path -> start:int -> stop:int -> (string * string) list
+end

--- a/src/stdune/monad.ml
+++ b/src/stdune/monad.ml
@@ -1,11 +1,3 @@
-module type S = sig
-  type 'a t
-
-  val return : 'a -> 'a t
-
-  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
-end
-
 module Id = struct
   type 'a t = 'a
 

--- a/src/stdune/monad.mli
+++ b/src/stdune/monad.mli
@@ -1,11 +1,3 @@
 (** Monad signatures *)
 
-module type S = sig
-  type 'a t
-
-  val return : 'a -> 'a t
-
-  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
-end
-
-module Id : S with type 'a t = 'a
+module Id : Monad_intf.S with type 'a t = 'a

--- a/src/stdune/monad_intf.ml
+++ b/src/stdune/monad_intf.ml
@@ -1,0 +1,7 @@
+module type S = sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+end

--- a/src/stdune/stdune.ml
+++ b/src/stdune/stdune.ml
@@ -62,6 +62,7 @@ module Scanf = Scanf
 module Sys = Sys
 module Pid = Pid
 module Applicative_intf = Applicative_intf
+module Monad_intf = Monad_intf
 module Applicative = Applicative
 module Spawn = Spawn
 


### PR DESCRIPTION
To avoid duplication, we store module signatures in separate modules.
This PR applies this style across the codebase.