### PR TITLE
Fix #3180

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,6 @@
 
 - Fix separate compilation of JS when findlib is not installed. (#3177, @nojb)
 
-- Fix regression introduced by overly strict parsing of modules names. It's only
-  a warning now. (#3181, fixes #3180, @rgrinberg)
-
 2.3.1 (20/02/2020)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,11 @@
 ------------------
 
 - Add `mdx` extension and stanza version 0.1 (#3094, @NathanReb)
+
 - Fix separate compilation of JS when findlib is not installed. (#3177, @nojb)
+
+- Fix regression introduced by overly strict parsing of modules names. It's only
+  a warning now. (#3181, fixes #3180, @rgrinberg)
 
 2.3.1 (20/02/2020)
 ------------------

--- a/src/dune/dir_contents.ml
+++ b/src/dune/dir_contents.ml
@@ -218,21 +218,7 @@ let modules_of_files ~dialects ~dir ~files =
     let make_module dialect name fn =
       (name, Module.File.make dialect (Path.relative dir fn))
     in
-    let parse_name_or_warn ~fn s =
-      let loc = Loc.in_dir dir in
-      match Module_name.of_string_opt s with
-      | Some _ as s -> s
-      | None ->
-        User_warning.emit ~loc
-          [ Pp.textf
-              "The following source file corresponds to an invalid module name:"
-          ; Pp.textf "- %s" fn
-          ; Pp.textf
-              "This module is ignored by dune. If it's used to generate a \
-               module source, consider picking a different extension."
-          ];
-        None
-    in
+    let loc = Loc.in_dir dir in
     String.Set.to_list files
     |> List.filter_partition_map ~f:(fun fn ->
            (* we aren't using Filename.extension because we want to handle
@@ -243,12 +229,11 @@ let modules_of_files ~dialects ~dir ~files =
              match Dialect.DB.find_by_extension dialects ("." ^ ext) with
              | None -> Skip
              | Some (dialect, ml_kind) -> (
-               match parse_name_or_warn ~fn s with
-               | None -> Skip
-               | Some name -> (
-                 match ml_kind with
-                 | Impl -> Left (make_module dialect name fn)
-                 | Intf -> Right (make_module dialect name fn) ) ) ))
+               let name = Module_name.of_string_allow_invalid (loc, s) in
+               let module_ = make_module dialect name fn in
+               match ml_kind with
+               | Impl -> Left module_
+               | Intf -> Right module_ ) ))
   in
   let parse_one_set (files : (Module_name.t * Module.File.t) list) =
     match Module_name.Map.of_list files with

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -27,7 +27,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   in
   let programs =
     List.map exes.names ~f:(fun (loc, name) ->
-        let mod_name = Module_name.of_string name in
+        let mod_name = Module_name.of_string_warn (loc, name) in
         match Modules.find modules mod_name with
         | Some m ->
           if not (Module.has m ~ml_kind:Impl) then

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -27,7 +27,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   in
   let programs =
     List.map exes.names ~f:(fun (loc, name) ->
-        let mod_name = Module_name.of_string_warn (loc, name) in
+        let mod_name = Module_name.of_string_allow_invalid (loc, name) in
         match Modules.find modules mod_name with
         | Some m ->
           if not (Module.has m ~ml_kind:Impl) then

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -134,7 +134,7 @@ let expand_artifact ~dir ~loc t a s =
   match a with
   | Pform.Artifact.Mod kind -> (
     let+ lookup_module = t.lookup_module in
-    let name = Module_name.of_string name in
+    let name = Module_name.of_string_warn (loc, name) in
     match lookup_module ~dir name with
     | None ->
       let msg =

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -134,7 +134,7 @@ let expand_artifact ~dir ~loc t a s =
   match a with
   | Pform.Artifact.Mod kind -> (
     let+ lookup_module = t.lookup_module in
-    let name = Module_name.of_string_warn (loc, name) in
+    let name = Module_name.of_string_allow_invalid (loc, name) in
     match lookup_module ~dir name with
     | None ->
       let msg =

--- a/src/dune/link_time_code_gen.ml
+++ b/src/dune/link_time_code_gen.ml
@@ -16,7 +16,7 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name:basename ~lib ~code
     let name =
       let info = Lib.info lib in
       let loc = Lib_info.loc info in
-      Module_name.of_string_warn (loc, basename)
+      Module_name.of_string_allow_invalid (loc, basename)
     in
     let wrapped = Result.ok_exn (Lib.wrapped lib) in
     let src_dir = Path.build (Obj_dir.obj_dir obj_dir) in

--- a/src/dune/link_time_code_gen.ml
+++ b/src/dune/link_time_code_gen.ml
@@ -13,7 +13,11 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name:basename ~lib ~code
   let obj_dir = CC.obj_dir cctx in
   let dir = CC.dir cctx in
   let module_ =
-    let name = Module_name.of_string basename in
+    let name =
+      let info = Lib.info lib in
+      let loc = Lib_info.loc info in
+      Module_name.of_string_warn (loc, basename)
+    in
     let wrapped = Result.ok_exn (Lib.wrapped lib) in
     let src_dir = Path.build (Obj_dir.obj_dir obj_dir) in
     let gen_module = Module.generated ~src_dir name in

--- a/src/dune/menhir.ml
+++ b/src/dune/menhir.ml
@@ -185,7 +185,7 @@ module Run (P : PARAMS) : sig end = struct
          ; Target (mock_ml base)
          ]);
     (* 2. The OCaml compiler performs type inference. *)
-    let name = Module_name.of_string (mock base) in
+    let name = Module_name.of_string_warn (stanza.loc, mock base) in
     let mock_module : Module.t =
       let source =
         let impl = Module.File.make Dialect.ocaml (Path.build (mock_ml base)) in
@@ -284,7 +284,9 @@ let targets (stanza : Dune_file.Menhir.t) : string list =
   List.concat_map (modules stanza) ~f
 
 let module_names (stanza : Dune_file.Menhir.t) : Module_name.t list =
-  List.map (modules stanza) ~f:Module_name.of_string
+  List.map (modules stanza) ~f:(fun s ->
+      (* TODO the loc can improved here *)
+      Module_name.of_string_warn (stanza.loc, s))
 
 let gen_rules ~build_dir ~dir cctx stanza =
   let module R = Run (struct

--- a/src/dune/menhir.ml
+++ b/src/dune/menhir.ml
@@ -185,7 +185,7 @@ module Run (P : PARAMS) : sig end = struct
          ; Target (mock_ml base)
          ]);
     (* 2. The OCaml compiler performs type inference. *)
-    let name = Module_name.of_string_warn (stanza.loc, mock base) in
+    let name = Module_name.of_string_allow_invalid (stanza.loc, mock base) in
     let mock_module : Module.t =
       let source =
         let impl = Module.File.make Dialect.ocaml (Path.build (mock_ml base)) in
@@ -286,7 +286,7 @@ let targets (stanza : Dune_file.Menhir.t) : string list =
 let module_names (stanza : Dune_file.Menhir.t) : Module_name.t list =
   List.map (modules stanza) ~f:(fun s ->
       (* TODO the loc can improved here *)
-      Module_name.of_string_warn (stanza.loc, s))
+      Module_name.of_string_allow_invalid (stanza.loc, s))
 
 let gen_rules ~build_dir ~dir cctx stanza =
   let module R = Run (struct

--- a/src/dune/module_name.ml
+++ b/src/dune/module_name.ml
@@ -101,5 +101,17 @@ module Unique = struct
   module Set = Set
 end
 
+let of_string_warn (loc, s) =
+  match of_string_opt s with
+  | Some s -> s
+  | None ->
+    User_warning.emit ~loc
+      [ Pp.textf "%S is not a valid module name." s
+      ; Pp.text
+          "Switch to a proper module names as this will no be allowed in \
+           future versions of dune."
+      ];
+    s
+
 let wrap t ~with_ =
   sprintf "%s__%s" (Unique.of_name_assuming_needs_no_mangling with_) t

--- a/src/dune/module_name.ml
+++ b/src/dune/module_name.ml
@@ -101,17 +101,9 @@ module Unique = struct
   module Set = Set
 end
 
-let of_string_warn (loc, s) =
-  match of_string_opt s with
-  | Some s -> s
-  | None ->
-    User_warning.emit ~loc
-      [ Pp.textf "%S is not a valid module name." s
-      ; Pp.text
-          "Switch to a proper module names as this will no be allowed in \
-           future versions of dune."
-      ];
-    s
+let of_string_allow_invalid (_loc, s) =
+  (* TODO add a warning here that is possible to disable *)
+  String.capitalize s
 
 let wrap t ~with_ =
   sprintf "%s__%s" (Unique.of_name_assuming_needs_no_mangling with_) t

--- a/src/dune/module_name.mli
+++ b/src/dune/module_name.mli
@@ -66,3 +66,5 @@ module Set : sig
 
   val to_dyn : t -> Dyn.t
 end
+
+val of_string_warn : Loc.t * string -> t

--- a/src/dune/module_name.mli
+++ b/src/dune/module_name.mli
@@ -67,4 +67,4 @@ module Set : sig
   val to_dyn : t -> Dyn.t
 end
 
-val of_string_warn : Loc.t * string -> t
+val of_string_allow_invalid : Loc.t * string -> t

--- a/src/dune/modules_field_evaluator.ml
+++ b/src/dune/modules_field_evaluator.ml
@@ -24,7 +24,7 @@ let eval =
   in
   let module Unordered = Ordered_set_lang.Unordered (Module_name) in
   let parse ~all_modules ~fake_modules ~loc s =
-    let name = Module_name.of_string_warn (loc, s) in
+    let name = Module_name.of_string_allow_invalid (loc, s) in
     match Module_name.Map.find all_modules name with
     | Some m -> Ok m
     | None ->

--- a/src/dune/modules_field_evaluator.ml
+++ b/src/dune/modules_field_evaluator.ml
@@ -24,7 +24,7 @@ let eval =
   in
   let module Unordered = Ordered_set_lang.Unordered (Module_name) in
   let parse ~all_modules ~fake_modules ~loc s =
-    let name = Module_name.of_string s in
+    let name = Module_name.of_string_warn (loc, s) in
     match Module_name.Map.find all_modules name with
     | Some m -> Ok m
     | None ->

--- a/src/dune/ordered_set_lang.ml
+++ b/src/dune/ordered_set_lang.ml
@@ -40,6 +40,8 @@ let equal_generic f { ast; loc = _; context } t =
 
 type ast_expanded = (Loc.t * string, Ast.expanded) Ast.t
 
+(* TODO this type should really be parameterized by the type of elements
+   contained in the set, like we do with the predicate language. *)
 type t = ast_expanded generic
 
 let equal = equal_generic (Ast.equal (fun (_, x) (_, y) -> String.equal x y))

--- a/src/dune/toplevel.ml
+++ b/src/dune/toplevel.ml
@@ -11,7 +11,7 @@ module Source = struct
     }
 
   let main_module t =
-    let main_module_name = Module_name.of_string t.name in
+    let main_module_name = Module_name.of_string_warn (t.loc, t.name) in
     let src_dir = Path.build t.dir in
     Module.generated ~src_dir main_module_name
 

--- a/src/dune/toplevel.ml
+++ b/src/dune/toplevel.ml
@@ -11,7 +11,9 @@ module Source = struct
     }
 
   let main_module t =
-    let main_module_name = Module_name.of_string_warn (t.loc, t.name) in
+    let main_module_name =
+      Module_name.of_string_allow_invalid (t.loc, t.name)
+    in
     let src_dir = Path.build t.dir in
     Module.generated ~src_dir main_module_name
 

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1248,6 +1248,16 @@
     (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias github3180)
+ (deps (package dune) (source_tree test-cases/github3180))
+ (action
+  (chdir
+   test-cases/github3180
+   (progn
+    (run %{exe:cram.exe} run.t -sanitizer %{bin:sanitizer})
+    (diff? run.t run.t.corrected)))))
+
+(rule
  (alias github534)
  (deps (package dune) (source_tree test-cases/github534))
  (action
@@ -2808,6 +2818,7 @@
   (alias github2681)
   (alias github2848)
   (alias github3046)
+  (alias github3180)
   (alias github534)
   (alias github568)
   (alias github597)
@@ -3063,6 +3074,7 @@
   (alias github2681)
   (alias github2848)
   (alias github3046)
+  (alias github3180)
   (alias github534)
   (alias github568)
   (alias github597)

--- a/test/blackbox-tests/test-cases/github3180/run.t
+++ b/test/blackbox-tests/test-cases/github3180/run.t
@@ -3,88 +3,14 @@
   > (executable (name foo) (modules foo foo-bar))
   > EOF
   $ dune exec ./foo.exe
-  Error: exception { exn = ("Invalid Module_name.t", { s = "foo-bar" })
-  ; backtrace =
-      [ { ocaml =
-            "Raised at file \"src/stdune/code_error.ml\", line 9, characters 30-62\n\
-             Called from file \"src/dune/modules_field_evaluator.ml\", line 27, characters 15-38\n\
-             Called from file \"src/dune/ordered_set_lang.ml\" (inlined), line 185, characters 33-41\n\
-             Called from file \"src/dune/ordered_set_lang.ml\", line 188, characters 18-35\n\
-             Called from file \"src/dune/ordered_set_lang.ml\", line 130, characters 16-28\n\
-             Called from file \"list.ml\", line 103, characters 22-25\n\
-             Called from file \"src/stdune/list.ml\", line 5, characters 19-33\n\
-             Called from file \"src/dune/ordered_set_lang.ml\", line 133, characters 32-55\n\
-             Called from file \"src/dune/modules_field_evaluator.ml\", line 37, characters 18-62\n\
-             Called from file \"src/dune/modules_field_evaluator.ml\" (inlined), line 258, characters 13-58\n\
-             Called from file \"src/dune/modules_field_evaluator.ml\", line 259, characters 16-55\n\
-             Called from file \"src/dune/dir_contents.ml\", line 429, characters 12-194\n\
-             Called from file \"src/stdune/list.ml\", line 67, characters 12-15\n\
-             Called from file \"src/stdune/list.ml\" (inlined), line 72, characters 14-29\n\
-             Called from file \"src/stdune/list.ml\", line 75, characters 13-42\n\
-             Called from file \"src/stdune/exn_with_backtrace.ml\", line 9, characters 8-12\n\
-             "
-        ; memo = ("lazy-6", ())
-        }
-      ; { ocaml =
-            "Raised at file \"src/memo/memo.ml\", line 574, characters 10-204\n\
-             Called from file \"src/memo/memo.ml\" (inlined), line 874, characters 16-20\n\
-             Called from file \"src/memo/memo.ml\", line 876, characters 37-46\n\
-             Called from file \"src/stdune/exn_with_backtrace.ml\", line 9, characters 8-12\n\
-             "
-        ; memo = ("lazy-11", ())
-        }
-      ; { ocaml =
-            "Raised at file \"src/memo/memo.ml\", line 580, characters 48-68\n\
-             Called from file \"src/dune/dir_contents.ml\", line 172, characters 12-39\n\
-             Called from file \"src/dune/exe_rules.ml\", line 15, characters 4-72\n\
-             Called from file \"src/stdune/exn.ml\", line 13, characters 8-11\n\
-             Re-raised at file \"src/stdune/exn.ml\", line 19, characters 4-11\n\
-             Called from file \"src/memo/implicit_output.ml\", line 120, characters 4-162\n\
-             Called from file \"src/dune/rules.ml\" (inlined), line 192, characters 20-71\n\
-             Called from file \"src/dune/rules.ml\", line 195, characters 20-33\n\
-             Called from file \"src/dune/build_system.ml\", line 1742, characters 19-34\n\
-             Called from file \"src/dune/gen_rules.ml\", line 89, characters 8-70\n\
-             Called from file \"src/dune/gen_rules.ml\", line 135, characters 6-96\n\
-             Called from file \"list.ml\", line 121, characters 24-34\n\
-             Called from file \"src/dune/gen_rules.ml\", line 138, characters 4-112\n\
-             Called from file \"src/dune/gen_rules.ml\", line 230, characters 4-119\n\
-             Called from file \"src/dune/gen_rules.ml\", line 358, characters 24-59\n\
-             Called from file \"src/stdune/exn.ml\", line 13, characters 8-11\n\
-             Re-raised at file \"src/stdune/exn.ml\", line 19, characters 4-11\n\
-             Called from file \"src/memo/implicit_output.ml\", line 120, characters 4-162\n\
-             Called from file \"src/dune/rules.ml\" (inlined), line 192, characters 20-71\n\
-             Called from file \"src/dune/rules.ml\", line 195, characters 20-33\n\
-             Called from file \"src/dune/build_system.ml\", line 845, characters 6-76\n\
-             Called from file \"src/stdune/exn_with_backtrace.ml\", line 9, characters 8-12\n\
-             "
-        ; memo = ("load-dir", In_build_dir "default")
-        }
-      ]
-  ; outer_call_stack = []
-  }
-  Backtrace:
-  Raised at file "src/memo/memo.ml", line 580, characters 48-68
-  Called from file "src/dune/build_system.ml", line 590, characters 10-23
-  Called from file "src/stdune/exn_with_backtrace.ml", line 9, characters 8-12
-  Re-raised at file "src/stdune/exn.ml", line 37, characters 27-56
-  Called from file "src/dune/build_system.ml", line 1788, characters 34-74
-  Called from file "bin/target.ml", line 75, characters 7-34
-  Called from file "bin/target.ml", line 162, characters 12-35
-  Called from file "list.ml", line 103, characters 22-25
-  Called from file "src/stdune/list.ml", line 5, characters 19-33
-  Called from file "bin/target.ml", line 157, characters 6-245
-  Called from file "bin/exec.ml", line 62, characters 8-520
-  Called from file "camlinternalLazy.ml", line 31, characters 17-27
-  Re-raised at file "camlinternalLazy.ml", line 36, characters 4-11
-  Called from file "vendor/cmdliner/src/cmdliner_term.ml", line 25, characters 19-24
-  Called from file "vendor/cmdliner/src/cmdliner.ml", line 146, characters 9-16
-  Called from file "vendor/cmdliner/src/cmdliner.ml", line 176, characters 18-36
-  Called from file "vendor/cmdliner/src/cmdliner.ml", line 312, characters 20-46
-  Called from file "bin/main.ml", line 240, characters 10-51
-  
-  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
-  the little-death that brings total obliteration.  I will fully express
-  my cases.  Execution will pass over me and through me.  And when it
-  has gone past, I will unwind the stack along its path.  Where the
-  cases are handled there will be nothing.  Only I will remain.
+  File "dune", line 1, characters 36-43:
+  1 | (executable (name foo) (modules foo foo-bar))
+                                          ^^^^^^^
+  Warning: "foo-bar" is not a valid module name.
+  Switch to a proper module names as this will no be allowed in future versions
+  of dune.
+  File "dune", line 1, characters 36-43:
+  1 | (executable (name foo) (modules foo foo-bar))
+                                          ^^^^^^^
+  Error: Module foo-bar doesn't exist.
   [1]

--- a/test/blackbox-tests/test-cases/github3180/run.t
+++ b/test/blackbox-tests/test-cases/github3180/run.t
@@ -6,11 +6,5 @@
   File "dune", line 1, characters 36-43:
   1 | (executable (name foo) (modules foo foo-bar))
                                           ^^^^^^^
-  Warning: "foo-bar" is not a valid module name.
-  Switch to a proper module names as this will no be allowed in future versions
-  of dune.
-  File "dune", line 1, characters 36-43:
-  1 | (executable (name foo) (modules foo foo-bar))
-                                          ^^^^^^^
-  Error: Module foo-bar doesn't exist.
+  Error: Module Foo-bar doesn't exist.
   [1]

--- a/test/blackbox-tests/test-cases/github3180/run.t
+++ b/test/blackbox-tests/test-cases/github3180/run.t
@@ -1,0 +1,90 @@
+  $ echo "(lang dune 2.3)" > dune-project
+  $ cat >dune <<EOF
+  > (executable (name foo) (modules foo foo-bar))
+  > EOF
+  $ dune exec ./foo.exe
+  Error: exception { exn = ("Invalid Module_name.t", { s = "foo-bar" })
+  ; backtrace =
+      [ { ocaml =
+            "Raised at file \"src/stdune/code_error.ml\", line 9, characters 30-62\n\
+             Called from file \"src/dune/modules_field_evaluator.ml\", line 27, characters 15-38\n\
+             Called from file \"src/dune/ordered_set_lang.ml\" (inlined), line 185, characters 33-41\n\
+             Called from file \"src/dune/ordered_set_lang.ml\", line 188, characters 18-35\n\
+             Called from file \"src/dune/ordered_set_lang.ml\", line 130, characters 16-28\n\
+             Called from file \"list.ml\", line 103, characters 22-25\n\
+             Called from file \"src/stdune/list.ml\", line 5, characters 19-33\n\
+             Called from file \"src/dune/ordered_set_lang.ml\", line 133, characters 32-55\n\
+             Called from file \"src/dune/modules_field_evaluator.ml\", line 37, characters 18-62\n\
+             Called from file \"src/dune/modules_field_evaluator.ml\" (inlined), line 258, characters 13-58\n\
+             Called from file \"src/dune/modules_field_evaluator.ml\", line 259, characters 16-55\n\
+             Called from file \"src/dune/dir_contents.ml\", line 429, characters 12-194\n\
+             Called from file \"src/stdune/list.ml\", line 67, characters 12-15\n\
+             Called from file \"src/stdune/list.ml\" (inlined), line 72, characters 14-29\n\
+             Called from file \"src/stdune/list.ml\", line 75, characters 13-42\n\
+             Called from file \"src/stdune/exn_with_backtrace.ml\", line 9, characters 8-12\n\
+             "
+        ; memo = ("lazy-6", ())
+        }
+      ; { ocaml =
+            "Raised at file \"src/memo/memo.ml\", line 574, characters 10-204\n\
+             Called from file \"src/memo/memo.ml\" (inlined), line 874, characters 16-20\n\
+             Called from file \"src/memo/memo.ml\", line 876, characters 37-46\n\
+             Called from file \"src/stdune/exn_with_backtrace.ml\", line 9, characters 8-12\n\
+             "
+        ; memo = ("lazy-11", ())
+        }
+      ; { ocaml =
+            "Raised at file \"src/memo/memo.ml\", line 580, characters 48-68\n\
+             Called from file \"src/dune/dir_contents.ml\", line 172, characters 12-39\n\
+             Called from file \"src/dune/exe_rules.ml\", line 15, characters 4-72\n\
+             Called from file \"src/stdune/exn.ml\", line 13, characters 8-11\n\
+             Re-raised at file \"src/stdune/exn.ml\", line 19, characters 4-11\n\
+             Called from file \"src/memo/implicit_output.ml\", line 120, characters 4-162\n\
+             Called from file \"src/dune/rules.ml\" (inlined), line 192, characters 20-71\n\
+             Called from file \"src/dune/rules.ml\", line 195, characters 20-33\n\
+             Called from file \"src/dune/build_system.ml\", line 1742, characters 19-34\n\
+             Called from file \"src/dune/gen_rules.ml\", line 89, characters 8-70\n\
+             Called from file \"src/dune/gen_rules.ml\", line 135, characters 6-96\n\
+             Called from file \"list.ml\", line 121, characters 24-34\n\
+             Called from file \"src/dune/gen_rules.ml\", line 138, characters 4-112\n\
+             Called from file \"src/dune/gen_rules.ml\", line 230, characters 4-119\n\
+             Called from file \"src/dune/gen_rules.ml\", line 358, characters 24-59\n\
+             Called from file \"src/stdune/exn.ml\", line 13, characters 8-11\n\
+             Re-raised at file \"src/stdune/exn.ml\", line 19, characters 4-11\n\
+             Called from file \"src/memo/implicit_output.ml\", line 120, characters 4-162\n\
+             Called from file \"src/dune/rules.ml\" (inlined), line 192, characters 20-71\n\
+             Called from file \"src/dune/rules.ml\", line 195, characters 20-33\n\
+             Called from file \"src/dune/build_system.ml\", line 845, characters 6-76\n\
+             Called from file \"src/stdune/exn_with_backtrace.ml\", line 9, characters 8-12\n\
+             "
+        ; memo = ("load-dir", In_build_dir "default")
+        }
+      ]
+  ; outer_call_stack = []
+  }
+  Backtrace:
+  Raised at file "src/memo/memo.ml", line 580, characters 48-68
+  Called from file "src/dune/build_system.ml", line 590, characters 10-23
+  Called from file "src/stdune/exn_with_backtrace.ml", line 9, characters 8-12
+  Re-raised at file "src/stdune/exn.ml", line 37, characters 27-56
+  Called from file "src/dune/build_system.ml", line 1788, characters 34-74
+  Called from file "bin/target.ml", line 75, characters 7-34
+  Called from file "bin/target.ml", line 162, characters 12-35
+  Called from file "list.ml", line 103, characters 22-25
+  Called from file "src/stdune/list.ml", line 5, characters 19-33
+  Called from file "bin/target.ml", line 157, characters 6-245
+  Called from file "bin/exec.ml", line 62, characters 8-520
+  Called from file "camlinternalLazy.ml", line 31, characters 17-27
+  Re-raised at file "camlinternalLazy.ml", line 36, characters 4-11
+  Called from file "vendor/cmdliner/src/cmdliner_term.ml", line 25, characters 19-24
+  Called from file "vendor/cmdliner/src/cmdliner.ml", line 146, characters 9-16
+  Called from file "vendor/cmdliner/src/cmdliner.ml", line 176, characters 18-36
+  Called from file "vendor/cmdliner/src/cmdliner.ml", line 312, characters 20-46
+  Called from file "bin/main.ml", line 240, characters 10-51
+  
+  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
+  the little-death that brings total obliteration.  I will fully express
+  my cases.  Execution will pass over me and through me.  And when it
+  has gone past, I will unwind the stack along its path.  Where the
+  cases are handled there will be nothing.  Only I will remain.
+  [1]

--- a/test/blackbox-tests/test-cases/invalid-module-name/run.t
+++ b/test/blackbox-tests/test-cases/invalid-module-name/run.t
@@ -4,15 +4,5 @@ Dune does not report an invalid module name as an error
   > (library (name foo))
   > EOF
   $ touch foo.ml foo-as-bar.ml
-  $ dune build @all --display short
-  File "_build/default", line 1, characters 0-0:
-  Warning: The following source file corresponds to an invalid module name:
-  - foo-as-bar.ml
-  This module is ignored by dune. If it's used to generate a module source,
-  consider picking a different extension.
-      ocamldep .foo.objs/foo.ml.d
-        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
-        ocamlc foo.cma
-      ocamlopt .foo.objs/native/foo.{cmx,o}
-      ocamlopt foo.{a,cmxa}
-      ocamlopt foo.cmxs
+  $ dune build @all --display short 2>&1 | head -1
+  Error: exception { exn = ("Invalid Module_name.t", { s = "foo-as-bar" })


### PR DESCRIPTION
Instead of a hard error, we warn the user of the incorrect module name
in the [dune] file.