### PR TITLE
Fix qualification handling in coq

### DIFF
--- a/src/dune/coq_rules.ml
+++ b/src/dune/coq_rules.ml
@@ -212,7 +212,10 @@ let setup_rules ~sctx ~dir ~dir_contents (s : Dune_file.Coq.t) =
       Path.Build.pp (Scope.root scope);
   let cc = create_ccoq sctx ~dir in
   let name = snd s.name in
-  let coq_modules = Dir_contents.coq_modules_of_library dir_contents ~name in
+  let coq_modules =
+    let coq = Dir_contents.coq dir_contents in
+    Coq_sources.library coq ~name
+  in
   (* coqdep requires all the files to be in the tree to produce correct
      dependencies *)
   let source_rule =
@@ -269,7 +272,8 @@ let install_rules ~sctx ~dir s =
     (* This must match the wrapper prefix for now to remain compatible *)
     let dst_suffix = coqlib_wrapper_name s in
     let dst_dir = Path.Local.relative coq_root dst_suffix in
-    Dir_contents.coq_modules_of_library dir_contents ~name
+    Dir_contents.coq dir_contents
+    |> Coq_sources.library ~name
     |> List.map ~f:(fun (vfile : Coq_module.t) ->
            let vofile = Coq_module.obj_file ~obj_dir:dir ~ext:".vo" vfile in
            let vofile_rel =

--- a/src/dune/coq_sources.ml
+++ b/src/dune/coq_sources.ml
@@ -1,0 +1,41 @@
+open Stdune
+
+(* TODO: Build reverse map and check duplicates, however, are duplicates
+   harmful?
+
+   In Coq all libs are "wrapped" so including a module twice is not so bad. *)
+type t = { libraries : Coq_module.t list Coq_lib_name.Map.t }
+
+let empty = { libraries = Coq_lib_name.Map.empty }
+
+let coq_modules_of_files ~subdirs =
+  let filter_v_files (dir, local, files) =
+    ( dir
+    , local
+    , String.Set.filter files ~f:(fun f -> Filename.check_suffix f ".v") )
+  in
+  let subdirs = List.map subdirs ~f:filter_v_files in
+  let build_mod_dir (dir, prefix, files) =
+    String.Set.to_list files
+    |> List.map ~f:(fun file ->
+           let name, _ = Filename.split_extension file in
+           let name = Coq_module.Name.make name in
+           Coq_module.make ~source:(Path.Build.relative dir file) ~prefix ~name)
+  in
+  List.concat_map ~f:build_mod_dir subdirs
+
+let build_coq_modules_map (d : _ Dir_with_dune.t) ~dir ~modules =
+  List.fold_left d.data ~init:Coq_lib_name.Map.empty ~f:(fun map ->
+    function
+    | Dune_file.Coq.T coq ->
+      let modules = Coq_module.eval ~dir coq.modules ~standard:modules in
+      Coq_lib_name.Map.add_exn map (snd coq.name) modules
+    | _ -> map)
+
+let library t ~name = Coq_lib_name.Map.find_exn t.libraries name
+
+let of_dir d ~subdirs =
+  { libraries =
+      build_coq_modules_map d ~dir:d.ctx_dir
+        ~modules:(coq_modules_of_files ~subdirs)
+  }

--- a/src/dune/coq_sources.ml
+++ b/src/dune/coq_sources.ml
@@ -34,7 +34,13 @@ let build_coq_modules_map (d : _ Dir_with_dune.t) ~dir ~modules =
 
 let library t ~name = Coq_lib_name.Map.find_exn t.libraries name
 
-let of_dir d ~subdirs =
+let check_no_unqualified loc (qualif_mode : Dune_file.Include_subdirs.t) =
+  if qualif_mode = Include Unqualified then
+    User_error.raise ~loc
+      [ Pp.text "(include_subdirs unqualified) is not supported yet" ]
+
+let of_dir d ~loc ~subdirs ~include_subdirs =
+  check_no_unqualified loc include_subdirs;
   { libraries =
       build_coq_modules_map d ~dir:d.ctx_dir
         ~modules:(coq_modules_of_files ~subdirs)

--- a/src/dune/coq_sources.mli
+++ b/src/dune/coq_sources.mli
@@ -1,0 +1,14 @@
+(** Handling of coq source files *)
+open Stdune
+
+type t
+
+val empty : t
+
+(** Coq modules of library [name] is the Coq library name. *)
+val library : t -> name:Coq_lib_name.t -> Coq_module.t list
+
+val of_dir :
+     Stanza.t list Dir_with_dune.t
+  -> subdirs:(Path.Build.t * string list * String.Set.t) list
+  -> t

--- a/src/dune/coq_sources.mli
+++ b/src/dune/coq_sources.mli
@@ -10,5 +10,7 @@ val library : t -> name:Coq_lib_name.t -> Coq_module.t list
 
 val of_dir :
      Stanza.t list Dir_with_dune.t
+  -> loc:Loc.t
   -> subdirs:(Path.Build.t * string list * String.Set.t) list
+  -> include_subdirs:Dune_file.Include_subdirs.t
   -> t

--- a/src/dune/dir_contents.mli
+++ b/src/dune/dir_contents.mli
@@ -48,8 +48,7 @@ val artifacts : t -> Dir_artifacts.t
 (** All mld files attached to this documentation stanza *)
 val mlds : t -> Dune_file.Documentation.t -> Path.Build.t list
 
-(** Coq modules of library [name] is the Coq library name. *)
-val coq_modules_of_library : t -> name:Coq_lib_name.t -> Coq_module.t list
+val coq : t -> Coq_sources.t
 
 (** Get the directory contents of the given directory. *)
 val get : Super_context.t -> dir:Path.Build.t -> t


### PR DESCRIPTION
The error message was incorrect. It mentioned that coq doesn't support
[(include_subdirs unqalified)], but in fact it doesn't support
[qualified].