### PR TITLE
Remove unnecessary functions from [Dir_contents]

### DIFF
--- a/src/dune/dir_contents.ml
+++ b/src/dune/dir_contents.ml
@@ -183,14 +183,7 @@ let modules_of_executables t ~obj_dir ~first_exe =
   let src_dir = Path.build (Obj_dir.obj_dir obj_dir) in
   String.Map.find_exn map first_exe |> Modules.relocate_alias_module ~src_dir
 
-let foreign_sources_of_executables t ~first_exe =
-  Foreign_sources.for_exes (Memo.Lazy.force t.foreign_sources) ~first_exe
-
-let foreign_sources_of_library t ~name =
-  Foreign_sources.for_lib (Memo.Lazy.force t.foreign_sources) ~name
-
-let foreign_sources_of_archive t ~archive_name =
-  Foreign_sources.for_archive (Memo.Lazy.force t.foreign_sources) ~archive_name
+let foreign_sources t = Memo.Lazy.force t.foreign_sources
 
 let lookup_module t name =
   Module_name.Map.find (Memo.Lazy.force t.modules).rev_map name

--- a/src/dune/dir_contents.ml
+++ b/src/dune/dir_contents.ml
@@ -4,6 +4,13 @@ module Menhir_rules = Menhir
 open Dune_file
 open! No_io
 
+let loc_of_dune_file ft_dir =
+  Loc.in_file
+    (Path.source
+       ( match File_tree.Dir.dune_file ft_dir with
+       | Some d -> File_tree.Dune_file.path d
+       | None -> Path.Source.relative (File_tree.Dir.path ft_dir) "_unknown_" ))
+
 module Dir_modules = struct
   type t =
     { libraries : Modules.t Lib_name.Map.t
@@ -544,16 +551,7 @@ end = struct
       in
       let libs_and_exes =
         Memo.lazy_ (fun () ->
-            let loc =
-              Loc.in_file
-                (Path.source
-                   ( match File_tree.Dir.dune_file ft_dir with
-                   | Some d -> File_tree.Dune_file.path d
-                   | None ->
-                     Path.Source.relative
-                       (File_tree.Dir.path ft_dir)
-                       "_unknown_" ))
-            in
+            let loc = loc_of_dune_file ft_dir in
             check_no_qualified loc qualif_mode;
             let modules =
               let dialects = Dune_project.dialects (Scope.project d.scope) in

--- a/src/dune/dir_contents.mli
+++ b/src/dune/dir_contents.mli
@@ -28,16 +28,11 @@ val text_files : t -> String.Set.t
 (** Modules attached to a library. [name] is the library best name. *)
 val modules_of_library : t -> name:Lib_name.t -> Modules.t
 
-val foreign_sources_of_library : t -> name:Lib_name.t -> Foreign.Sources.t
-
-val foreign_sources_of_archive :
-  t -> archive_name:Foreign.Archive.Name.t -> Foreign.Sources.t
+val foreign_sources : t -> Foreign_sources.t
 
 (** Modules attached to a set of executables. *)
 val modules_of_executables :
   t -> obj_dir:Path.Build.t Obj_dir.t -> first_exe:string -> Modules.t
-
-val foreign_sources_of_executables : t -> first_exe:string -> Foreign.Sources.t
 
 (** Find out what buildable a module is part of *)
 val lookup_module : t -> Module_name.t -> Dune_file.Buildable.t option

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -147,7 +147,8 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
                  exe)\"."
             ];
       let foreign_sources =
-        Dir_contents.foreign_sources_of_executables dir_contents ~first_exe
+        let foreign_sources = Dir_contents.foreign_sources dir_contents in
+        Foreign_sources.for_exes foreign_sources ~first_exe
       in
       let o_files =
         Foreign_rules.build_o_files ~sctx ~dir ~expander

--- a/src/dune/foreign_sources.ml
+++ b/src/dune/foreign_sources.ml
@@ -3,7 +3,13 @@ open Dune_file
 module Library = Dune_file.Library
 
 (* TODO: This is a strange module; it seems to add unnecessary indirection for
-   accessing foreign sources. It's worth checking if it can be simplified away. *)
+   accessing foreign sources. It's worth checking if it can be simplified away.
+
+   Before this module is removed, there should be a good way to handle new types
+   of source files without shoving everything into [Dir_contents].
+
+   Furthemore, this module is also responsible for details such as handling file
+   extensions and validing filenames. *)
 type t =
   { libraries : Foreign.Sources.t Lib_name.Map.t
   ; archives : Foreign.Sources.t Foreign.Archive.Name.Map.t

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -349,7 +349,8 @@ let gen_dune_package sctx pkg =
                 let name = Lib.name lib in
                 let foreign_objects =
                   let dir = Obj_dir.obj_dir obj_dir in
-                  Dir_contents.foreign_sources_of_library dir_contents ~name
+                  Dir_contents.foreign_sources dir_contents
+                  |> Foreign_sources.for_lib ~name
                   |> Foreign.Sources.object_files ~dir
                        ~ext_obj:ctx.lib_config.ext_obj
                   |> List.map ~f:Path.build

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -38,10 +38,9 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
           (byte && not virtual_library)
           [ Library.archive ~dir lib ~ext:(Mode.compiled_lib_ext Byte) ]
       ; ( if virtual_library then
-          let files =
-            Dir_contents.foreign_sources_of_library dir_contents
-              ~name:(Library.best_name lib)
-          in
+          let foreign_sources = Dir_contents.foreign_sources dir_contents in
+          let name = Library.best_name lib in
+          let files = Foreign_sources.for_lib foreign_sources ~name in
           Foreign.Sources.object_files files ~dir ~ext_obj
         else
           Library.foreign_lib_files lib ~dir ~ext_lib )

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -190,7 +190,8 @@ let foreign_rules (library : Foreign.Library.t) ~sctx ~expander ~dir
   let archive_name = library.archive_name in
   let o_files =
     let foreign_sources =
-      Dir_contents.foreign_sources_of_archive dir_contents ~archive_name
+      Dir_contents.foreign_sources dir_contents
+      |> Foreign_sources.for_archive ~archive_name
     in
     Foreign_rules.build_o_files ~sctx ~dir ~expander ~requires:(Result.ok [])
       ~dir_contents ~foreign_sources
@@ -207,8 +208,9 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents
   let sctx = Compilation_context.super_context cctx in
   let lib_o_files =
     let foreign_sources =
-      Dir_contents.foreign_sources_of_library dir_contents
-        ~name:(Library.best_name lib)
+      let foreign_sources = Dir_contents.foreign_sources dir_contents in
+      let name = Library.best_name lib in
+      Foreign_sources.for_lib foreign_sources ~name
     in
     Foreign_rules.build_o_files ~sctx ~dir ~expander ~requires ~dir_contents
       ~foreign_sources

--- a/src/dune/virtual_rules.ml
+++ b/src/dune/virtual_rules.ml
@@ -119,7 +119,8 @@ let impl sctx ~(lib : Dune_file.Library.t) ~scope =
             let foreign_objects =
               let ext_obj = (Super_context.context sctx).lib_config.ext_obj in
               let dir = Obj_dir.obj_dir (Lib.Local.obj_dir vlib) in
-              Dir_contents.foreign_sources_of_library dir_contents ~name
+              Dir_contents.foreign_sources dir_contents
+              |> Foreign_sources.for_lib ~name
               |> Foreign.Sources.object_files ~ext_obj ~dir
               |> List.map ~f:Path.build
             in


### PR DESCRIPTION
The foreign_source_of_* family of functions were just wrappers without
additional abstraction. It's just as easy to do the extra function call
in the callers.