### PR TITLE
Remove duplicate mkdir implementation

### DIFF
--- a/src/stdune/set.ml
+++ b/src/stdune/set.ml
@@ -75,7 +75,7 @@ module Make (Key : Map_intf.Key) (M : Map_intf.S with type key = Key.t) = struct
   let to_map = fold ~init:M.empty ~f:(fun k acc -> M.set acc k ())
 
   let of_list_map xs ~f =
-    (* We don't [fold_left] & [add] over [xs] because [of_list] has
-       a specialized implementation *)
+    (* We don't [fold_left] & [add] over [xs] because [of_list] has a
+       specialized implementation *)
     List.map xs ~f |> of_list
 end


### PR DESCRIPTION
The implementation does mkdir_p relative to the appropriate [root] works
in both cases.
