### PR TITLE
Mark all remaining mutable tables as safe or to-be-removed

### DIFF
--- a/src/dune/alias.ml
+++ b/src/dune/alias.ml
@@ -170,6 +170,7 @@ let find_dir_specified_on_command_line ~dir =
       ]
   | Some dir -> dir
 
+(* This mutable table is safe: it's modified only at the top level. *)
 let standard_aliases = Table.create (module Name) 7
 
 let is_standard name = Table.mem standard_aliases name

--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -205,7 +205,7 @@ end = struct
       }
   end
 
-  (* Keyed by the first target *)
+  (* Keyed by the first target of the rule. *)
   type t = Entry.t Path.Table.t
 
   let file = Path.relative Path.build_dir ".db"
@@ -221,9 +221,13 @@ end = struct
   let needs_dumping = ref false
 
   let t =
+    (* This [lazy] is safe: it does not call any memoized functions. *)
     lazy
       ( match P.load file with
       | Some t -> t
+      (* This mutable table is safe: it's only used by [execute_rule_impl] to
+         decide whether to rebuild a rule or not; [execute_rule_impl] ensures
+         that the targets are produced deterministically. *)
       | None -> Path.Table.create 1024 )
 
   let dump () =
@@ -464,6 +468,7 @@ let compute_targets_digest_or_raise_error ~loc targets =
 
 let sandbox_dir = Path.Build.relative Path.Build.root ".sandbox"
 
+(* This mutable table is safe: it merely maps paths to lazily created mutexes. *)
 let locks : (Path.t, Fiber.Mutex.t) Table.t = Table.create (module Path) 32
 
 let rec with_locks mutexes ~f =

--- a/src/dune/cached_digest.ml
+++ b/src/dune/cached_digest.ml
@@ -26,6 +26,11 @@ end)
 
 let needs_dumping = ref false
 
+(* CR-soon amokhov: replace this mutable table with a memoized function. This
+   will probably require splitting this module in two, for dealing with source
+   and target files, respectively. For source files, we receive updates via the
+   file-watching API. For target files, we modify the digests ourselves, without
+   subscribing for file-watching updates. *)
 let cache =
   lazy
     ( match P.load db_file with

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -469,7 +469,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     in
     let stdlib_dir = Path.of_string (Ocaml_config.standard_library ocfg) in
     let natdynlink_supported = Ocaml_config.natdynlink_supported ocfg in
-    let version = Ocaml_version.of_ocaml_config ocfg in
     let arch_sixtyfour = Ocaml_config.word_size ocfg = 64 in
     let ocamlopt = get_ocaml_tool "ocamlopt" in
     let lib_config =

--- a/src/dune/dune_project.ml
+++ b/src/dune/dune_project.ml
@@ -348,6 +348,8 @@ module Extension = struct
         -> Univ_map.t * Stanza.Parser.t list
     }
 
+  (* CR-soon amokhov: convert this mutable table to a memoized function, which
+     depends on the contents of dune files that declare extensions. *)
   let extensions = Table.create (module String) 32
 
   let register ?(experimental = false) syntax stanzas arg_to_dyn =

--- a/src/dune/findlib/findlib.ml
+++ b/src/dune/findlib/findlib.ml
@@ -562,6 +562,11 @@ let all_packages t =
            (Dune_package.Entry.name a)
            (Dune_package.Entry.name b))
 
+(* CR-soon amokhov: Remove the mutable table below and add:
+
+   - A memoized function for finding packages by names (see [find]).
+
+   - A [Memo.Lazy.t] storing the set of all packages (see [root_packages]). *)
 let create ~stdlib_dir ~paths ~version ~lib_config =
   { stdlib_dir
   ; paths

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -404,6 +404,9 @@ let gen ~contexts ?(external_lib_deps_mode = false) ?only_packages conf =
   let open Fiber.O in
   let { Dune_load.dune_files; packages; projects } = conf in
   let packages = Option.value only_packages ~default:packages in
+  (* CR-soon amokhov: this mutable table is safe because [Ivar]s are created,
+     read and filled in the same memoization node (the one that calls [gen]). We
+     better rewrite this code using async memoized functions for clarity. *)
   let sctxs = Table.create (module Context_name) 4 in
   List.iter contexts ~f:(fun c ->
       Table.add_exn sctxs c.Context.name (Fiber.Ivar.create ()));

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -624,6 +624,8 @@ module Sub_system = struct
     val get : lib -> t option
   end
 
+  (* This mutable table is safe under the assumption that subsystems are
+     registered at the top level, which is currently true. *)
   let all = Sub_system_name.Table.create ~default_value:None
 
   module Register (M : S) = struct
@@ -1644,6 +1646,8 @@ module DB = struct
 
   type t = db
 
+  (* CR-soon amokhov: this whole module should be rewritten using the
+     memoization framework instead of using mutable state. *)
   let create ~parent ~stdlib_dir ~resolve ~all () =
     { parent
     ; resolve

--- a/src/dune/opam_file.ml
+++ b/src/dune/opam_file.ml
@@ -115,6 +115,7 @@ module Create = struct
         |]
       in
       let table =
+        (* This [lazy] and the mutable table below are pure and hence safe. *)
         lazy
           (let table = Table.create (module String) (Array.length fields) in
            Array.iteri fields ~f:(fun i field -> Table.add_exn table field i);

--- a/src/dune/preprocessing.ml
+++ b/src/dune/preprocessing.ml
@@ -75,6 +75,7 @@ end = struct
       { pps; project_root = Option.map project ~f:Dune_project.root }
   end
 
+  (* This mutable table is safe: it caches a pure function. *)
   let reverse_table : (Digest.t, Decoded.t) Table.t =
     Table.create (module Digest) 128
 

--- a/src/dune/preprocessing.ml
+++ b/src/dune/preprocessing.ml
@@ -75,7 +75,9 @@ end = struct
       { pps; project_root = Option.map project ~f:Dune_project.root }
   end
 
-  (* This mutable table is safe: it caches a pure function. *)
+  (* This mutable table is safe. Even though it can have stale entries remaining
+     from previous runs, the entries themselves are correct, so this seems
+     harmless apart from the lack of error in [decode] in this situation. *)
   let reverse_table : (Digest.t, Decoded.t) Table.t =
     Table.create (module Digest) 128
 

--- a/src/dune/response_file.ml
+++ b/src/dune/response_file.ml
@@ -4,6 +4,9 @@ type t =
   | Not_supported
   | Zero_terminated_strings of string
 
+(* This mutable table is safe under the assumption that a program path always
+   points to the binary with the same version. While the assumption seems likely
+   to hold, it would be better to avoid the need for it to simplify reasoning. *)
 let registry = Table.create (module Path) 128
 
 let get ~prog = Option.value (Table.find registry prog) ~default:Not_supported

--- a/src/dune/scheduler.ml
+++ b/src/dune/scheduler.ml
@@ -108,6 +108,12 @@ end = struct
 
   let cond = Condition.create ()
 
+  (* CR-soon amokhov: The way we handle "ignored files" using this mutable table
+     is fragile and also wrong. We use [ignored_files] for the [(mode promote)]
+     feature: if a file is promoted, we call [ignore_next_file_change_event] so
+     that the upcoming file-change event does not invalidate the current build.
+     However, instead of ignoring the events, we should merely postpone them and
+     restart the build to take the promoted files into account if need be. *)
   let ignored_files = String.Table.create 64
 
   let pending_jobs = ref 0
@@ -416,6 +422,8 @@ end = struct
       | Running of job
       | Zombie of Unix.process_status
 
+    (* This mutable table is safe: it does not interact with the state we track
+       in the build system. *)
     (* Invariant: [!running_count] is equal to the number of [Running _] values
        in [table]. *)
     let table = Table.create (module Pid) 128

--- a/src/dune/sub_system_info.ml
+++ b/src/dune/sub_system_info.ml
@@ -21,6 +21,8 @@ module type S = sig
   val encode : t -> Dune_lang.Syntax.Version.t * Dune_lang.t list
 end
 
+(* This mutable table is safe under the assumption that subsystems are
+   registered at the top level, which is currently true. *)
 let all = Sub_system_name.Table.create ~default_value:None
 
 (* For parsing config files in the workspace *)

--- a/src/dune_lang/versioned_file.ml
+++ b/src/dune_lang/versioned_file.ml
@@ -44,6 +44,8 @@ struct
         }
     end
 
+    (* This mutable table is safe under the assumption that we call [register]
+       only at the top level, which is currently true. *)
     let langs = Table.create (module String) 32
 
     let register syntax data =

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -91,6 +91,9 @@ module Spec = struct
 
   type packed = T : (_, _, _) t -> packed [@@unboxed]
 
+  (* This mutable table is safe under the assumption that [register] is called
+     only at the top level, which is currently true. This means that all
+     memoization tables created not at the top level are hidden. *)
   let by_name : packed String.Table.t = String.Table.create 256
 
   let find name = String.Table.find by_name name
@@ -512,6 +515,7 @@ let create_with_store (type i) name
 
 let create (type i) name ?doc ~input:(module Input : Input with type t = i)
     ~visibility ~output typ f =
+  (* This mutable table is safe: the implementation tracks all dependencies. *)
   let cache = Store.of_table (Table.create (module Input) 16) in
   let input = (module Input : Store_intf.Input with type t = i) in
   create_with_cache name ~cache ?doc ~input ~visibility ~output typ f

--- a/src/stdune/interned.ml
+++ b/src/stdune/interned.ml
@@ -24,8 +24,7 @@ end
 
 module Make (R : Settings) () = struct
   (* The mutable tables in this module can be made safe if we stop leaking
-     information about the string representation, e.g. by switching from [int]s
-     to an opaque data type. *)
+     information about the representation, e.g. by not exposing [compare]. *)
   let ids = Table.create (module String) 1024
 
   let next = ref 0

--- a/src/stdune/interned.ml
+++ b/src/stdune/interned.ml
@@ -23,6 +23,9 @@ module type Settings = sig
 end
 
 module Make (R : Settings) () = struct
+  (* The mutable tables in this module can be made safe if we stop leaking
+     information about the string representation, e.g. by switching from [int]s
+     to an opaque data type. *)
   let ids = Table.create (module String) 1024
 
   let next = ref 0


### PR DESCRIPTION
Also delete redundant recalculation of `Ocaml_version`.