### PR TITLE
[gen_rules] Don't load ml_sources eagerly in gen_rules

### DIFF
--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -250,10 +250,10 @@ let gen_rules sctx dir_contents cctxs
       Merlin.add_rules sctx ~dir:ctx_dir ~more_src_dirs ~expander
         (Merlin.add_source_dir m src_dir));
   let build_dir = Super_context.build_dir sctx in
-  let ml_sources = Dir_contents.ocaml dir_contents in
   List.iter stanzas ~f:(fun stanza ->
       match (stanza : Stanza.t) with
       | Menhir.T m when Expander.eval_blang expander m.enabled_if -> (
+        let ml_sources = Dir_contents.ocaml dir_contents in
         match
           List.find_map (Menhir_rules.module_names m) ~f:(fun name ->
               Option.bind (Ml_sources.lookup_module ml_sources name)


### PR DESCRIPTION
Fixes #3206 ; in particular one has to be careful to scan directories
before actual stanzas need it.