### PR TITLE
[coq] Further Coq stdlib bootstrap tweaks

### DIFF
--- a/src/dune/coq_module.ml
+++ b/src/dune/coq_module.ml
@@ -30,9 +30,16 @@ let prefix x = x.prefix
 
 let name x = x.name
 
-let obj_file ~obj_dir ~ext x =
-  let vo_dir = List.fold_left x.prefix ~init:obj_dir ~f:Path.Build.relative in
-  Path.Build.relative vo_dir (x.name ^ ext)
+let build_vo_dir ~obj_dir x =
+  List.fold_left x.prefix ~init:obj_dir ~f:Path.Build.relative
+
+let dep_file ~obj_dir x =
+  let vo_dir = build_vo_dir ~obj_dir x in
+  Path.Build.relative vo_dir (x.name ^ ".v.d")
+
+let obj_file ~obj_dir x =
+  let vo_dir = build_vo_dir ~obj_dir x in
+  Path.Build.relative vo_dir (x.name ^ ".vo")
 
 let to_dyn { source; prefix; name } =
   let open Dyn.Encoder in

--- a/src/dune/coq_module.mli
+++ b/src/dune/coq_module.mli
@@ -32,7 +32,9 @@ val prefix : t -> string list
 
 val name : t -> string
 
-val obj_file : obj_dir:Path.Build.t -> ext:string -> t -> Path.Build.t
+val dep_file : obj_dir:Path.Build.t -> t -> Path.Build.t
+
+val obj_file : obj_dir:Path.Build.t -> t -> Path.Build.t
 
 val to_dyn : t -> Dyn.t
 

--- a/test/blackbox-tests/test-cases/coq/run.t
+++ b/test/blackbox-tests/test-cases/coq/run.t
@@ -18,29 +18,29 @@
 
   $ dune build --root ml_lib --display short --debug-dependency-path @all
   Entering directory 'ml_lib'
-         coqpp src_a/gram.ml
-      ocamldep src_a/.ml_plugin_a.objs/gram.ml.d
+        coqdep theories/a.v.d
+        ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
+      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
       ocamldep src_a/.ml_plugin_a.objs/gram.mli.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}
-        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/simple.ml.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Simple.{cmi,cmo,cmt}
-        ocamlc src_a/ml_plugin_a.cma
-        ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
-      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
+      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
       ocamldep src_b/.ml_plugin_b.objs/simple_b.ml.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b__Simple_b.{cmi,cmo,cmt}
         ocamlc src_b/ml_plugin_b.cma
-        coqdep theories/a.v.d
-      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Gram.{cmx,o}
-      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
-      ocamlopt src_a/ml_plugin_a.{a,cmxa}
-      ocamlopt src_a/ml_plugin_a.cmxs
+         coqpp src_a/gram.ml
+      ocamldep src_a/.ml_plugin_a.objs/gram.ml.d
+        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmo,cmt}
+        ocamlc src_a/ml_plugin_a.cma
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b__Simple_b.{cmx,o}
       ocamlopt src_b/ml_plugin_b.{a,cmxa}
       ocamlopt src_b/ml_plugin_b.cmxs
+      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Gram.{cmx,o}
+      ocamlopt src_a/ml_plugin_a.{a,cmxa}
+      ocamlopt src_a/ml_plugin_a.cmxs
           coqc theories/a.vo
 
   $ dune build --root base --display short --debug-dependency-path @default


### PR DESCRIPTION
- After changes upstream, passing `-coqlib` is not necessary now,
  `-boot` will disable hardcoded paths in Coq, the regular `-R` prefix
  adds the stdlib in scope.

- Install layout when a library has `(boot)` is a bit different, in
  particular we don't install in `user-contrib` but in theories.

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>