### PR TITLE
[coq] Add support for native-mode compilation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,8 @@ Unreleased
 
 - [coq] Add `-q` flag to `:standard` `coqc` flags , fixes #3924, (#3931 , @ejgallego)
 
+- Add support for Coq's native compute compilation mode (@ejgallego, #3210)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BIN := ./dune.exe
 TEST_DEPS := \
 bisect_ppx \
 cinaps \
-coq \
+"coq>=8.12.1" \
 core_bench \
 "csexp>=1.3.0" \
 js_of_ocaml \

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1899,9 +1899,9 @@ a typical ``dune-workspace`` file looks like:
 .. code:: scheme
 
     (lang dune 2.8)
-    (context (opam (switch 4.02.3)))
-    (context (opam (switch 4.03.0)))
-    (context (opam (switch 4.04.0)))
+    (context (opam (switch 4.07.1)))
+    (context (opam (switch 4.08.1)))
+    (context (opam (switch 4.11.1)))
 
 The rest of this section describe the stanzas available.
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1625,6 +1625,7 @@ The basic form for defining Coq libraries is very similar to the OCaml form:
      (modules <ordered_set_lang>)
      (libraries <ocaml_libraries>)
      (flags <coq_flags>)
+     (mode <coq_native_mode>)
      (theories <coq_theories>))
 
 The stanza will build all ``.v`` files on the given directory. The semantics of fields is:
@@ -1668,6 +1669,13 @@ The stanza will build all ``.v`` files on the given directory. The semantics of 
   composition with the Coq's standard library is supported, but in
   this case the ``Coq`` prefix will be made available in a qualified
   way. Since Coq's lang version ``0.2``.
+- you can enable the production of Coq's native compiler object files
+  by setting ``<coq_native_mode>`` to ``native``, this will pass
+  ``-native-compiler on`` to Coq and install the corresponding object
+  files under `.coq-native`. Note that the support for native compute
+  is experimental, and requires Coq >= 8.12.1; moreover, depending
+  libraries *must* be built with ``(mode native)`` too for this to
+  work.
 
 Recursive qualification of modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1673,9 +1673,13 @@ The stanza will build all ``.v`` files on the given directory. The semantics of 
   by setting ``<coq_native_mode>`` to ``native``, this will pass
   ``-native-compiler on`` to Coq and install the corresponding object
   files under `.coq-native`. Note that the support for native compute
-  is experimental, and requires Coq >= 8.12.1; moreover, depending
+  is **experimental**, and requires Coq >= 8.12.1; moreover, depending
   libraries *must* be built with ``(mode native)`` too for this to
-  work.
+  work; also Coq must be configured to support native
+  compilation. Note that Dune will by explicitly disable output of
+  native compilation objects when `(mode vo)` even if the default
+  Coq's configure flag enabled it. This will be improved in the
+  future.
 
 Recursive qualification of modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/dune_rules/coq_lib.ml
+++ b/src/dune_rules/coq_lib.ml
@@ -2,6 +2,7 @@ open! Dune_engine
 
 (* This file is licensed under The MIT License *)
 (* (c) MINES ParisTech 2018-2019               *)
+(* (c) INRIA 2020                              *)
 (* Written by: Emilio Jesús Gallego Arias *)
 
 open! Stdune

--- a/src/dune_rules/coq_lib_name.mli
+++ b/src/dune_rules/coq_lib_name.mli
@@ -2,6 +2,7 @@ open! Dune_engine
 
 (* This file is licensed under The MIT License *)
 (* (c) MINES ParisTech 2018-2019               *)
+(* (c) INRIA 2020                              *)
 (* Written by: Emilio Jesús Gallego Arias *)
 
 open! Stdune

--- a/src/dune_rules/coq_mode.ml
+++ b/src/dune_rules/coq_mode.ml
@@ -1,0 +1,10 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(* (c) INRIA 2020                              *)
+(* Written by: Emilio Jesús Gallego Arias *)
+
+type t =
+  | VoOnly
+  | Native
+
+let decode = Dune_lang.Decoder.(enum [ ("vo", VoOnly); ("native", Native) ])

--- a/src/dune_rules/coq_mode.mli
+++ b/src/dune_rules/coq_mode.mli
@@ -1,0 +1,10 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2018-2019               *)
+(* (c) INRIA 2020                              *)
+(* Written by: Emilio Jesús Gallego Arias *)
+
+type t =
+  | VoOnly
+  | Native
+
+val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/coq_module.mli
+++ b/src/dune_rules/coq_module.mli
@@ -38,13 +38,23 @@ val prefix : t -> string list
 
 val name : t -> Name.t
 
-type obj =
-  | Dep
-  | Aux
-  | Glob
-  | Obj
+val dep_file : t -> obj_dir:Path.Build.t -> Path.Build.t
 
-val obj_file : t -> obj -> obj_dir:Path.Build.t -> Path.Build.t
+(** Some of the object files should not be installed, we control this with the
+    following parameter *)
+type obj_files_mode =
+  | Build
+  | Install
+
+(** This returns a list of pairs [(obj_file, install_path)] due to native files
+    having a different install location *)
+val obj_files :
+     t
+  -> wrapper_name:string
+  -> mode:Coq_mode.t
+  -> obj_dir:Path.Build.t
+  -> obj_files_mode:obj_files_mode
+  -> (Path.Build.t * string) list
 
 val to_dyn : t -> Dyn.t
 

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -20,7 +20,7 @@ module Util = struct
         let info = Lib.info t in
         Lib_info.src_dir info)
 
-  let native_paths ts =
+  let coq_nativelib_cmi_dirs ts =
     List.fold_left ts ~init:Path.Set.empty ~f:(fun acc t ->
         let info = Lib.info t in
         (* We want the cmi files *)
@@ -229,7 +229,7 @@ module Context = struct
     let mode = select_native_mode ~sctx ~buildable in
     let native_includes =
       Lib.DB.resolve lib_db (Loc.none, Lib_name.of_string "coq.kernel")
-      |> Result.map ~f:(fun lib -> Util.native_paths [ lib ])
+      |> Result.map ~f:(fun lib -> Util.coq_nativelib_cmi_dirs [ lib ])
     in
     let native_theory_includes =
       setup_native_theory_includes ~sctx ~mode ~theories_deps ~theory_dirs

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -157,7 +157,9 @@ module Context = struct
 
   let coqc_native_flags cctx : _ Command.Args.t =
     match cctx.mode with
-    | Coq_mode.VoOnly -> Command.Args.empty
+    | Coq_mode.VoOnly ->
+      Command.Args.As
+        [ "-w"; "-native-compiler-disabled"; "-native-compiler"; "ondemand" ]
     | Coq_mode.Native ->
       let args =
         let open Result.O in

--- a/src/dune_rules/coq_rules.mli
+++ b/src/dune_rules/coq_rules.mli
@@ -2,6 +2,7 @@ open! Dune_engine
 
 (* This file is licensed under The MIT License *)
 (* (c) MINES ParisTech 2018-2019               *)
+(* (c) INRIA 2020                              *)
 (* Written by: Emilio Jesús Gallego Arias *)
 
 (* Build rules for Coq's .v -> .vo files *)

--- a/src/dune_rules/coq_sources.mli
+++ b/src/dune_rules/coq_sources.mli
@@ -10,6 +10,8 @@ val empty : t
 (** Coq modules of library [name] is the Coq library name. *)
 val library : t -> name:Coq_lib_name.t -> Coq_module.t list
 
+val directories : t -> name:Coq_lib_name.t -> Path.Build.t list
+
 val extract : t -> Coq_stanza.Extraction.t -> Coq_module.t
 
 val of_dir :

--- a/src/dune_rules/coq_stanza.ml
+++ b/src/dune_rules/coq_stanza.ml
@@ -21,11 +21,15 @@ end
 
 let coq_syntax =
   Dune_lang.Syntax.create ~name:"coq" ~desc:"the coq extension (experimental)"
-    [ ((0, 1), `Since (1, 9)); ((0, 2), `Since (2, 5)) ]
+    [ ((0, 1), `Since (1, 9))
+    ; ((0, 2), `Since (2, 5))
+    ; ((0, 3), `Since (2, 8))
+    ]
 
 module Buildable = struct
   type t =
     { flags : Ordered_set_lang.Unexpanded.t
+    ; mode : Loc.t * Coq_mode.t
     ; libraries : (Loc.t * Lib_name.t) list  (** ocaml libraries *)
     ; theories : (Loc.t * Coq_lib_name.t) list  (** coq libraries *)
     ; loc : Loc.t
@@ -34,6 +38,10 @@ module Buildable = struct
   let decode =
     let+ loc = loc
     and+ flags = Ordered_set_lang.Unexpanded.field "flags"
+    and+ mode =
+      located
+        (field "mode" ~default:Coq_mode.VoOnly
+           (Dune_lang.Syntax.since coq_syntax (0, 3) >>> Coq_mode.decode))
     and+ libraries =
       field "libraries" (repeat (located Lib_name.decode)) ~default:[]
     and+ theories =
@@ -41,7 +49,7 @@ module Buildable = struct
         (Dune_lang.Syntax.since coq_syntax (0, 2) >>> repeat Coq_lib_name.decode)
         ~default:[]
     in
-    { flags; libraries; theories; loc }
+    { flags; mode; libraries; theories; loc }
 end
 
 module Extraction = struct

--- a/src/dune_rules/coq_stanza.mli
+++ b/src/dune_rules/coq_stanza.mli
@@ -4,6 +4,7 @@ open Import
 module Buildable : sig
   type t =
     { flags : Ordered_set_lang.Unexpanded.t
+    ; mode : Loc.t * Coq_mode.t
     ; libraries : (Loc.t * Lib_name.t) list  (** ocaml libraries *)
     ; theories : (Loc.t * Coq_lib_name.t) list  (** coq libraries *)
     ; loc : Loc.t

--- a/src/dune_rules/profile.mli
+++ b/src/dune_rules/profile.mli
@@ -1,5 +1,5 @@
 (** Defines build profile for dune. Only one profile is active per context. Some
-    profiles are treat specially by dune. *)
+    profiles are treated specially by dune. *)
 open! Import
 
 type t =

--- a/test/blackbox-tests/test-cases/coq/github3624.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/github3624.t/run.t
@@ -5,4 +5,4 @@ In github #3624, dune created a dune-project with an incorrect using line.
   >  (name foo))
   > EOF
   $ dune build 2>&1 | grep using
-  Info: Appending this line to dune-project: (using coq 0.2)
+  Info: Appending this line to dune-project: (using coq 0.3)

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/bar/bar.v
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/bar/bar.v
@@ -1,0 +1,3 @@
+From foo Require Import foo.
+
+Definition mynum (i : mynat) := 3.

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/bar/dune
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/bar/dune
@@ -1,0 +1,7 @@
+(coq.theory
+ (name bar)
+ (package base)
+ (mode native)
+ (theories foo)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/dune
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/dune
@@ -1,0 +1,3 @@
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.8)
+
+(using coq 0.3)

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/foo/dune
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/foo/dune
@@ -1,0 +1,6 @@
+(coq.theory
+ (name foo)
+ (package base)
+ (mode native)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/foo/foo.v
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/foo/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
@@ -1,0 +1,22 @@
+  $ dune build --profile=release --display short --debug-dependency-path @all
+        coqdep bar/bar.v.d
+        coqdep foo/foo.v.d
+          coqc foo/.foo.aux,foo/Nfoo_foo.{cmi,cmxs},foo/foo.{glob,vo}
+          coqc bar/.bar.aux,bar/Nbar_bar.{cmi,cmxs},bar/bar.{glob,vo}
+
+  $ dune build --profile=release --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+    "_build/install/default/lib/base/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmi" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmi"}
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/bar/bar.v" {"coq/user-contrib/bar/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/bar/bar.vo" {"coq/user-contrib/bar/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.v" {"coq/user-contrib/foo/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.vo" {"coq/user-contrib/foo/foo.vo"}
+  ]

--- a/test/blackbox-tests/test-cases/coq/native-single.t/bar.v
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/bar.v
@@ -1,0 +1,3 @@
+From basic Require Import foo.
+
+Definition mynum (i : mynat) := 3.

--- a/test/blackbox-tests/test-cases/coq/native-single.t/dune
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/dune
@@ -1,0 +1,10 @@
+(coq.theory
+ (name basic)
+ (package base)
+ (mode native)
+ (modules :standard)
+ (synopsis "Test Coq library"))
+
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))

--- a/test/blackbox-tests/test-cases/coq/native-single.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.8)
+
+(using coq 0.3)

--- a/test/blackbox-tests/test-cases/coq/native-single.t/foo.v
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/native-single.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/run.t
@@ -1,0 +1,22 @@
+  $ dune build --profile=release --display short --debug-dependency-path @all
+        coqdep bar.v.d
+        coqdep foo.v.d
+          coqc .foo.aux,Nbasic_foo.{cmi,cmxs},foo.{glob,vo}
+          coqc .bar.aux,Nbasic_bar.{cmi,cmxs},bar.{glob,vo}
+
+  $ dune build --profile=release --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+    "_build/install/default/lib/base/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_bar.cmi" {"coq/user-contrib/basic/.coq-native/Nbasic_bar.cmi"}
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_bar.cmxs" {"coq/user-contrib/basic/.coq-native/Nbasic_bar.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_foo.cmi" {"coq/user-contrib/basic/.coq-native/Nbasic_foo.cmi"}
+    "_build/install/default/lib/coq/user-contrib/basic/.coq-native/Nbasic_foo.cmxs" {"coq/user-contrib/basic/.coq-native/Nbasic_foo.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/basic/bar.v" {"coq/user-contrib/basic/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/bar.vo" {"coq/user-contrib/basic/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.v" {"coq/user-contrib/basic/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.vo" {"coq/user-contrib/basic/foo.vo"}
+  ]


### PR DESCRIPTION
We add a `(mode ...)` field to the `(coq.theory ...)` stanza that when
set to `native` will have the Coq compiler to generate and install
"native" objects, that is to say, `.cmxs` libraries containing an
ML-level version of the corresponding Coq module.

As of today, Coq itself does call the `ocamlfind ocaml` to compile the
object files, this restriction may be lifted in the future however it
is not easy as tactics do have access to "Just-In-Time" native
compilation too.

The patch itself should have been straightforward except for a big
problem due to the way Coq outputs native targets and the limitations
of Dune.

By default, `coqc -native-compute on` will generate the OCaml-level
objects files under `.coq-native/`, and the regular `.vo` object in
the build dir. This scheme doesn't work well with the restriction than
a rule can only produce targets in the same directory.

To workaround this limitation, we pass a special flag to Coq so
`.coq-native` is dropped from the output path; at install time we do
set the rules up so indeed the objects will be installed under
`.coq-native` for compatibility. This means this feature will only
work in Coq >= 8.12.1

Moreover, the non-standard location of native objects defeats Coq's
default native include path, so we must pass the additional
non-standard include paths to `coqc`.

Note that native compilation is disabled by default in the `dev`
profile, as to speed up build. Please use the release or a custom
profile if you want to avoid this.
