### PR TITLE
Downgrade zed to make CI pass

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -18,6 +18,7 @@ opam_install_test_deps () {
          "$ODOC" \
          menhir \
          ocaml-migrate-parsetree \
+         result.1.4 \
          utop.2.4.2 \
          mdx.1.6.0
          # js_of_ocaml-ppx \


### PR DESCRIPTION
```
#=== ERROR while compiling zed.2.0.5 ==========================================#
662# context     2.0.5 | linux/x86_64 | ocaml-system.4.09.0 | https://opam.ocaml.org#20e0fd9d
663# path        ~/.opam/default/.opam-switch/build/zed.2.0.5
664# command     ~/.opam/default/bin/dune build -p zed -j 1
665# exit-code   1
666# env-file    ~/.opam/log/zed-26170-d8a3f7.env
667# output-file ~/.opam/log/zed-26170-d8a3f7.out
668### output ###
669# Error: The implementation src/zed_string.ml
670# [...]
671#          val compare_index :
672#            t ->
673#            ('a, 'b) result ->
674#            ('a, 'b) result ->
675#            ok:('a -> 'a -> int) -> error:('b -> 'b -> int) -> int
676#        is not included in
677#          val compare_index : t -> index -> index -> int
678#        File "src/zed_string.mli", line 184, characters 0-46:
679#          Expected declaration
680#        File "src/zed_string.ml", line 454, characters 6-19:
681#          Actual declaration
```