### PR TITLE
Ml_sources: Make include_subdirs more lazy

### DIFF
--- a/src/dune/ml_sources.ml
+++ b/src/dune/ml_sources.ml
@@ -300,9 +300,9 @@ let check_no_qualified (loc, include_subdirs) =
       [ Pp.text "(include_subdirs qualified) is not supported yet" ]
 
 let make (d : _ Dir_with_dune.t) ~loc ~lookup_vlib ~include_subdirs ~dirs =
-  check_no_qualified include_subdirs;
   let libs_and_exes =
     Memo.lazy_ (fun () ->
+      check_no_qualified include_subdirs;
         let modules =
           let dialects = Dune_project.dialects (Scope.project d.scope) in
           List.fold_left dirs ~init:Module_name.Map.empty


### PR DESCRIPTION
The check should occur only when we need the OCaml modules

This also fixes the problem @ejgallego reported. It's not strictly necessary now that he's made the other fix, but i think we might as well preserve the old behavior to be safe.