### PR TITLE
Fix a memory leak in the file-watching mode

### DIFF
--- a/src/dag/dag_intf.ml
+++ b/src/dag/dag_intf.ml
@@ -30,20 +30,12 @@ module type S = sig
   (** [create_node_info dag v] creates new node info that belongs to [dag]. *)
   val create_node_info : t -> node_info
 
-  (** [add_idempotent dag v w] creates an arc going from [v] to [w] unless it
-      already exists.
+  (** [add_assuming_missing dag v w] creates an arc going from [v] to [w]
+      assuming it doesn't already exists.
 
       @raise Cycle if creating the arc would create a cycle. *)
-  val add_idempotent : t -> node -> node -> unit
-
-  (** [children v] returns all nodes [w] for which an arc going from [v] to [w]
-      exists. *)
-  val children : node -> node list
+  val add_assuming_missing : t -> node -> node -> unit
 
   (** Pretty print a node. *)
   val pp_node : value Fmt.t -> node Fmt.t
-
-  (** [is_child v w] returns a boolean indicating if an arc going from [v] to
-      [w] exists. *)
-  val is_child : node -> node -> bool
 end

--- a/src/dag/dag_intf.ml
+++ b/src/dag/dag_intf.ml
@@ -31,7 +31,8 @@ module type S = sig
   val create_node_info : t -> node_info
 
   (** [add_assuming_missing dag v w] creates an arc going from [v] to [w]
-      assuming it doesn't already exists.
+      assuming it doesn't already exists. The the arc does exist, the behaviuor
+      is undefined.
 
       @raise Cycle if creating the arc would create a cycle. *)
   val add_assuming_missing : t -> node -> node -> unit

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -199,6 +199,10 @@ module M = struct
   end =
     Running_state
 
+  (* CR-soon amokhov: The current implementation relies on a few invariants
+     about moving from one state to another. As a result the code is full of
+     [Code_error]s and is hard to reason about. I would like to clean this up in
+     a separate semantics-preserving PR. *)
   and State : sig
     type ('a, 'b, 'f) t =
       (* [Running] includes computations that already terminated with an
@@ -486,7 +490,7 @@ let get_running_state_exn (type i o f) (state : (i, o, f) State.t) =
       (sprintf "[get_running_state_exn] got a non-running state.")
       []
 
-(* TODO: comments *)
+(* Add a dependency on the [node] from the caller, if there is one. *)
 let add_dep_from_caller (type i o f) ~called_from_peek
     (node : (i, o, f) Dep_node.t) =
   match Call_stack.get_call_stack_tip () with

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -20,10 +20,6 @@ module Stack_frame : sig
 
   val to_dyn : t -> Dyn.t
 
-  val equal : t -> t -> bool
-
-  val compare : t -> t -> Ordering.t
-
   val name : t -> string option
 
   val input : t -> Dyn.t

--- a/test/expect-tests/dag/dag_tests.ml
+++ b/test/expect-tests/dag/dag_tests.ml
@@ -30,10 +30,10 @@ let node21 = Dag.node dag { name = "child 2 1" }
 let node31 = Dag.node dag { name = "child 3 1" }
 
 let () =
-  Dag.add_idempotent dag node node11;
-  Dag.add_idempotent dag node node12;
-  Dag.add_idempotent dag node12 node21;
-  Dag.add_idempotent dag node21 node31
+  Dag.add_assuming_missing dag node node11;
+  Dag.add_assuming_missing dag node node12;
+  Dag.add_assuming_missing dag node12 node21;
+  Dag.add_assuming_missing dag node21 node31
 
 let pp_mynode fmt n = Format.fprintf fmt "%s" n.name
 
@@ -42,11 +42,11 @@ let dag_pp_mynode = Dag.pp_node pp_mynode
 let%expect_test _ =
   Format.printf "%a@." dag_pp_mynode node;
   let node41 = Dag.node dag { name = "child 4 1" } in
-  Dag.add_idempotent dag node31 node41;
+  Dag.add_assuming_missing dag node31 node41;
   Format.printf "%a@." dag_pp_mynode node;
   let name node = node.data.name in
   try
-    Dag.add_idempotent dag node41 node;
+    Dag.add_assuming_missing dag node41 node;
     print_endline "no cycle"
   with Dag.Cycle cycle ->
     let cycle = List.map cycle ~f:name in
@@ -80,7 +80,7 @@ let cycle_test variant =
   let edges = ref [] in
   let add d n1 n2 =
     edges := (n1.data, n2.data) :: !edges;
-    add_idempotent d n1 n2
+    add_assuming_missing d n1 n2
   in
   let d = Dag.create () in
   let _n1 = node d 1 in

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -80,7 +80,7 @@ let%expect_test _ =
   |> option (list (pair (option string) (fun x -> x)))
   |> print_dyn;
   [%expect {|
-Some [ (Some "another", "aa"); (Some "some", "a") ]
+Some [ (Some "some", "a"); (Some "another", "aa") ]
 |}]
 
 let%expect_test _ =
@@ -315,7 +315,7 @@ let%expect_test _ =
   [%expect
     {|
 (Some [ (Some "lazy_memo", "foo") ],
-Some [ (Some "id", "lazy: foo"); (Some "lazy_memo", "foo") ])
+Some [ (Some "lazy_memo", "foo"); (Some "id", "lazy: foo") ])
 |}]
 
 module Memo_lazy = Test_lazy (struct
@@ -335,8 +335,8 @@ let%expect_test _ =
   Memo_lazy.deps () |> print_dyn;
   [%expect
     {|
-(Some [ (None, ()); (Some "lazy_memo", "foo") ],
-Some [ (None, ()); (Some "lazy_memo", "foo") ])
+(Some [ (Some "lazy_memo", "foo"); (None, ()) ],
+Some [ (Some "lazy_memo", "foo"); (None, ()) ])
 |}]
 
 (* Tests for depending on the current run *)


### PR DESCRIPTION
Update: the memory leak is now fully fixed! :tada: 

We currently keep creating new nodes in `Memo.global_dep_dag` in every build run, never removing stale nodes from previous runs. Even worse, DAG nodes have pointers to all historically computed `Cached_value`s, preventing them from ever being garbage-collected.

This PR only addresses the latter issue: DAG nodes can no longer reach to `Cached_value`s.

There are also two side benefits:
* `Last_dep` dependencies in `Cached_value` are now listed in the correct order, addressing another (potential) performance issue related to file-watching mode and dynamic dependencies (see the removed CR).
* We simplified `dag_intf.ml`: it no longer needs to provide `children` and `add_idempotent`.

Unfortunately, my benchmarks show that file-watching mode still has a substantial memory leak after this patch, although the leak does seem to have been reduced.

@ejgallego This patch touches the code you wrote to address quadratic behaviour which was particularly problematic for Coq. I think this patch doesn't introduce any regression, but it would be nice if you give it a try.