### PR TITLE
Fix #3222

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 - Add a `dune describe` command to obtain the topology of a dune
   workspace, for projects such as ROTOR. (#3128, @diml)
 
+- Dune will no longer build shared objects for stubs if
+  `supports_shared_libraries` is false (#3225, fixes #3222, @rgrinberg)
+
 2.3.1 (20/02/2020)
 ------------------
 

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -72,7 +72,7 @@ module T = struct
     ; profile : Profile.t
     ; merlin : bool
     ; fdo_target_exe : Path.t option
-    ; disable_dynamically_linked_foreign_archives : bool
+    ; dynamically_linked_foreign_archives : bool
     ; for_host : t option
     ; implicit : bool
     ; build_dir : Path.Build.t
@@ -253,7 +253,7 @@ let write_dot_dune_dir ~build_dir ~ocamlc ~ocaml_config_vars =
 
 let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     ~host_context ~host_toolchain ~profile ~fdo_target_exe
-    ~disable_dynamically_linked_foreign_archives =
+    ~dynamically_linked_foreign_archives =
   let prog_not_found_in_path prog =
     Utils.program_not_found prog ~context:name ~loc:None
   in
@@ -509,7 +509,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; profile
       ; merlin
       ; fdo_target_exe
-      ; disable_dynamically_linked_foreign_archives
+      ; dynamically_linked_foreign_archives
       ; env_nodes
       ; for_host = host
       ; build_dir
@@ -591,10 +591,10 @@ let extend_paths t ~env =
   Env.extend ~vars env
 
 let default ~merlin ~env_nodes ~env ~targets ~fdo_target_exe
-    ~disable_dynamically_linked_foreign_archives =
+    ~dynamically_linked_foreign_archives =
   let path = Env.path env in
   create ~kind:Default ~path ~env ~env_nodes ~merlin ~targets ~fdo_target_exe
-    ~disable_dynamically_linked_foreign_archives
+    ~dynamically_linked_foreign_archives
 
 let opam_version =
   let f opam =
@@ -625,7 +625,7 @@ let opam_version =
 
 let create_for_opam ~root ~env ~env_nodes ~targets ~profile ~switch ~name
     ~merlin ~host_context ~host_toolchain ~fdo_target_exe
-    ~disable_dynamically_linked_foreign_archives =
+    ~dynamically_linked_foreign_archives =
   let opam =
     match Memo.Lazy.force opam with
     | None -> Utils.program_not_found "opam" ~loc:None
@@ -675,7 +675,7 @@ let create_for_opam ~root ~env ~env_nodes ~targets ~profile ~switch ~name
   create
     ~kind:(Opam { root; switch })
     ~profile ~targets ~path ~env ~env_nodes ~name ~merlin ~host_context
-    ~host_toolchain ~fdo_target_exe ~disable_dynamically_linked_foreign_archives
+    ~host_toolchain ~fdo_target_exe ~dynamically_linked_foreign_archives
 
 let instantiate_context env (workspace : Workspace.t)
     ~(context : Workspace.Context.t) ~host_context =
@@ -694,7 +694,7 @@ let instantiate_context env (workspace : Workspace.t)
       ; paths
       ; loc = _
       ; fdo_target_exe
-      ; disable_dynamically_linked_foreign_archives
+      ; dynamically_linked_foreign_archives
       } ->
     let merlin =
       workspace.merlin_context = Some (Workspace.Context.name context)
@@ -709,8 +709,7 @@ let instantiate_context env (workspace : Workspace.t)
     in
     let env = extend_paths ~env paths in
     default ~env ~env_nodes ~profile ~targets ~name ~merlin ~host_context
-      ~host_toolchain ~fdo_target_exe
-      ~disable_dynamically_linked_foreign_archives
+      ~host_toolchain ~fdo_target_exe ~dynamically_linked_foreign_archives
   | Opam
       { base =
           { targets
@@ -722,7 +721,7 @@ let instantiate_context env (workspace : Workspace.t)
           ; paths
           ; loc = _
           ; fdo_target_exe
-          ; disable_dynamically_linked_foreign_archives
+          ; dynamically_linked_foreign_archives
           }
       ; switch
       ; root
@@ -731,7 +730,7 @@ let instantiate_context env (workspace : Workspace.t)
     let env = extend_paths ~env paths in
     create_for_opam ~root ~env_nodes ~env ~profile ~switch ~name ~merlin
       ~targets ~host_context ~host_toolchain:toolchain ~fdo_target_exe
-      ~disable_dynamically_linked_foreign_archives
+      ~dynamically_linked_foreign_archives
 
 module Create = struct
   module Output = struct

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -502,6 +502,12 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
             | Some x -> Path.of_filename_relative_to_initial_cwd x
             | None -> Path.parent_exn ocaml_bin))
     in
+    let supports_shared_libraries =
+      Ocaml_config.supports_shared_libraries ocfg
+    in
+    let dynamically_linked_foreign_archives =
+      supports_shared_libraries && dynamically_linked_foreign_archives
+    in
     let t =
       { name
       ; implicit
@@ -535,8 +541,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; ocaml_config = ocfg
       ; version
       ; supports_shared_libraries =
-          Dynlink_supported.By_the_os.of_bool
-            (Ocaml_config.supports_shared_libraries ocfg)
+          Dynlink_supported.By_the_os.of_bool supports_shared_libraries
       ; which
       ; lib_config
       }

--- a/src/dune/context.mli
+++ b/src/dune/context.mli
@@ -51,12 +51,13 @@ type t = private
         (** [Some path/to/foo.exe] if this contexts is for feedback-directed
             optimization of target path/to/foo.exe *)
   ; fdo_target_exe : Path.t option
-        (* By default Dune builds and installs dynamically linked foreign
-           archives (usually named [dll*.so]). It is possible to disable this by
-           adding (disable_dynamically_linked_foreign_archives true) to the
-           workspace file, in which case bytecode executables will be built with
-           all foreign archives statically linked into the runtime system. *)
-  ; disable_dynamically_linked_foreign_archives : bool
+        (** By default Dune builds and installs dynamically linked foreign
+            archives (usually named [dll*.so]). It is possible to disable this
+            by adding (disable_dynamically_linked_foreign_archives true) to the
+            workspace file, in which case bytecode executables will be built
+            with all foreign archives statically linked into the runtime
+            system. *)
+  ; dynamically_linked_foreign_archives : bool
         (** If this context is a cross-compilation context, you need another
             context for building tools used for the compilation that run on the
             host. *)

--- a/src/dune/exe.ml
+++ b/src/dune/exe.ml
@@ -52,13 +52,13 @@ module Linkage = struct
       | Other { mode; _ } -> (
         match mode with
         | Byte ->
-          if ctx.disable_dynamically_linked_foreign_archives then
-            (* When [disable_dynamically_linked_foreign_archives] is set to
-               [true] in the workspace, we link in all stub archives statically
-               into the runtime system. *)
-            Byte_with_stubs_statically_linked_in
-          else
+          if ctx.dynamically_linked_foreign_archives then
             Byte
+          else
+            (* When [dynamically_linked_foreign_archives] is set to [false] in
+               the workspace, we link in all stub archives statically into the
+               runtime system. *)
+            Byte_with_stubs_statically_linked_in
         | Native -> Native
         | Best ->
           if Result.is_ok ctx.ocamlopt then

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -74,7 +74,7 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
     if_
       ( byte
       && Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries
-      && not ctx.disable_dynamically_linked_foreign_archives )
+      && ctx.dynamically_linked_foreign_archives )
       (Library.foreign_dll_files lib ~dir ~ext_dll)
   in
   { lib_files; dll_files }

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -122,9 +122,6 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
   let static_target =
     Foreign.Archive.Name.lib_file archive_name ~dir ~ext_lib
   in
-  let dynamic_target =
-    Foreign.Archive.Name.dll_file archive_name ~dir ~ext_dll
-  in
   let build ~custom ~sandbox targets =
     Super_context.add_rule sctx ~sandbox ~dir ~loc
       (let cclibs_args =
@@ -153,6 +150,9 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
                   | Other _ -> As cclibs))
          ; Hidden_targets targets
          ])
+  in
+  let dynamic_target =
+    Foreign.Archive.Name.dll_file archive_name ~dir ~ext_dll
   in
   if build_targets_together then
     (* Build both the static and dynamic targets in one [ocamlmklib] invocation,

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -158,10 +158,10 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
     (* Build both the static and dynamic targets in one [ocamlmklib] invocation,
        unless dynamically linked foreign archives are disabled. *)
     build ~sandbox:Sandbox_config.no_special_requirements ~custom:false
-      ( if ctx.disable_dynamically_linked_foreign_archives then
-        [ static_target ]
+      ( if ctx.dynamically_linked_foreign_archives then
+        [ static_target; dynamic_target ]
       else
-        [ static_target; dynamic_target ] )
+        [ static_target ] )
   else (
     (* Build the static target only by passing the [-custom] flag. *)
     build ~sandbox:Sandbox_config.no_special_requirements ~custom:true
@@ -177,7 +177,7 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~o_files ~archive_name
        "optional targets", allowing us to run [ocamlmklib] with the [-failsafe]
        flag, which always produces the static target and sometimes produces the
        dynamic target too. *)
-    if not ctx.disable_dynamically_linked_foreign_archives then
+    if ctx.dynamically_linked_foreign_archives then
       build ~sandbox:Sandbox_config.needs_sandboxing ~custom:false
         [ dynamic_target ]
   )

--- a/src/dune/workspace.ml
+++ b/src/dune/workspace.ml
@@ -47,7 +47,7 @@ module Context = struct
       ; host_context : Context_name.t option
       ; paths : (string * Ordered_set_lang.t) list
       ; fdo_target_exe : Path.t option
-      ; disable_dynamically_linked_foreign_archives : bool
+      ; dynamically_linked_foreign_archives : bool
       }
 
     let to_dyn = Dyn.Encoder.opaque
@@ -62,7 +62,7 @@ module Context = struct
         ; host_context
         ; paths
         ; fdo_target_exe
-        ; disable_dynamically_linked_foreign_archives
+        ; dynamically_linked_foreign_archives
         } t =
       Profile.equal profile t.profile
       && List.equal Target.equal targets t.targets
@@ -74,8 +74,8 @@ module Context = struct
            (Tuple.T2.equal String.equal Ordered_set_lang.equal)
            paths t.paths
       && Option.equal Path.equal fdo_target_exe t.fdo_target_exe
-      && Bool.equal disable_dynamically_linked_foreign_archives
-           t.disable_dynamically_linked_foreign_archives
+      && Bool.equal dynamically_linked_foreign_archives
+           t.dynamically_linked_foreign_archives
 
     let fdo_suffix t =
       match t.fdo_target_exe with
@@ -95,9 +95,10 @@ module Context = struct
       and+ toolchain =
         field_o "toolchain"
           (Dune_lang.Syntax.since syntax (1, 5) >>> Context_name.decode)
-      and+ disable_dynamically_linked_foreign_archives =
+      and+ dynamically_linked_foreign_archives =
         field ~default:false "disable_dynamically_linked_foreign_archives"
-          (Dune_lang.Syntax.since syntax (2, 0) >>> bool)
+          (let+ disable = Dune_lang.Syntax.since syntax (2, 0) >>> bool in
+           not disable)
       and+ fdo_target_exe =
         let f file =
           let ext = Filename.extension file in
@@ -148,7 +149,7 @@ module Context = struct
       ; toolchain
       ; paths
       ; fdo_target_exe
-      ; disable_dynamically_linked_foreign_archives
+      ; dynamically_linked_foreign_archives
       }
   end
 
@@ -279,7 +280,7 @@ module Context = struct
       ; toolchain = None
       ; paths = []
       ; fdo_target_exe = None
-      ; disable_dynamically_linked_foreign_archives = false
+      ; dynamically_linked_foreign_archives = true
       }
 end
 

--- a/src/dune/workspace.mli
+++ b/src/dune/workspace.mli
@@ -21,13 +21,13 @@ module Context : sig
       ; host_context : Context_name.t option
       ; paths : (string * Ordered_set_lang.t) list
       ; fdo_target_exe : Path.t option
-            (* By default Dune builds and installs dynamically linked foreign
-               archives (usually named [dll*.so]). It is possible to disable
-               this by setting [disable_dynamically_linked_foreign_archives] to
-               [true] in the workspace file, in which case bytecode executables
-               will be built with all foreign archives statically linked into
-               the runtime system. *)
-      ; disable_dynamically_linked_foreign_archives : bool
+            (** By default Dune builds and installs dynamically linked foreign
+                archives (usually named [dll*.so]). It is possible to disable
+                this by setting [disable_dynamically_linked_foreign_archives] to
+                [true] in the workspace file, in which case bytecode executables
+                will be built with all foreign archives statically linked into
+                the runtime system. *)
+      ; dynamically_linked_foreign_archives : bool
       }
   end
 


### PR DESCRIPTION
[dynamically_linked_foreign_archives] should respect
[supports_shared_libraries]

There are also some refactoring commits that are easier to read individually.

@avsm to confirm this fix, could you paste the output of:

``` sh
ocamlc -config | grep -i supports_shared_libraries
```

in your switch