### PR TITLE
Don't crash when trimming while the cache directory does not exist.

### DIFF
--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -140,9 +140,14 @@ module Metadata_file = struct
     >>= of_sexp
 end
 
-let path_files cache = Path.relative cache.root "files"
+let path_ cache d =
+  let res = Path.relative cache.root d in
+  Path.mkdir_p res;
+  res
 
-let path_meta cache = Path.relative cache.root "meta"
+let path_files cache = path_ cache "files"
+
+let path_meta cache = path_ cache "meta"
 
 let make_path cache path =
   match cache.build_root with

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -140,10 +140,7 @@ module Metadata_file = struct
     >>= of_sexp
 end
 
-let path_ cache d =
-  let res = Path.relative cache.root d in
-  Path.mkdir_p res;
-  res
+let path_ cache d = Path.relative cache.root d
 
 let path_files cache = path_ cache "files"
 
@@ -347,7 +344,7 @@ let make ?(root = default_root ())
   if Path.basename root <> "v2" then
     Result.Error "unable to read dune-cache"
   else
-    Result.ok
+    let res =
       { root
       ; build_root = None
       ; repositories = []
@@ -357,6 +354,10 @@ let make ?(root = default_root ())
           Path.temp_dir ~temp_dir:root "promoting"
             (string_of_int (Unix.getpid ()))
       }
+    in
+    Path.mkdir_p @@ path_meta res;
+    Path.mkdir_p @@ path_files res;
+    Result.ok res
 
 let duplication_mode cache = cache.duplication_mode
 

--- a/test/blackbox-tests/test-cases/dune-cache/trim/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim/run.t
@@ -12,6 +12,13 @@
   >   (targets multi_a multi_b)
   >   (action (bash "touch beacon_multi; echo multi_a > multi_a; echo multi_b > multi_b")))
   > EOF
+
+Check that trimming does not crash when the cache directory does not exist.
+
+  $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --size 0B
+
+Build some targets.
+
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a target_b
 
 Trimming the cache at this point should not remove anything, as both

--- a/test/blackbox-tests/test-cases/dune-cache/trim/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim/run.t
@@ -16,6 +16,7 @@
 Check that trimming does not crash when the cache directory does not exist.
 
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --size 0B
+  Freed 0 bytes
 
 Build some targets.
 


### PR DESCRIPTION
Fix #3204.