### PR TITLE
Implement [Hashtbl.set] using [replace]

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -245,7 +245,7 @@ end = struct
   let set path e =
     let t = Lazy.force t in
     needs_dumping := true;
-    Path.Table.replace t ~key:path ~data:e
+    Path.Table.set t path e
 end
 
 module Subdir_set = struct

--- a/src/dune/cached_digest.ml
+++ b/src/dune/cached_digest.ml
@@ -82,14 +82,13 @@ let set_with_stat fn digest stat =
   let permissions = stat.Unix.st_perm in
   needs_dumping := true;
   set_max_timestamp cache stat;
-  Path.Table.replace cache.table ~key:fn
-    ~data:
-      { digest
-      ; timestamp = stat.st_mtime
-      ; stats_checked = cache.checked_key
-      ; size = stat.st_size
-      ; permissions
-      }
+  Path.Table.set cache.table fn
+    { digest
+    ; timestamp = stat.st_mtime
+    ; stats_checked = cache.checked_key
+    ; size = stat.st_size
+    ; permissions
+    }
 
 let set fn digest =
   let stat = Path.stat fn in

--- a/src/dune/scheduler.ml
+++ b/src/dune/scheduler.ml
@@ -122,9 +122,7 @@ end = struct
 
   let ignore_next_file_change_event path =
     assert (Path.is_in_source_tree path);
-    String.Table.replace ignored_files
-      ~key:(Path.to_absolute_filename path)
-      ~data:()
+    String.Table.set ignored_files (Path.to_absolute_filename path) ()
 
   let available () =
     not

--- a/src/stdune/hashtbl.ml
+++ b/src/stdune/hashtbl.ml
@@ -8,6 +8,8 @@ end) =
 struct
   include MoreLabels.Hashtbl.Make (H)
 
+  let[@ocaml.warning "-32"] add = `Use_set
+
   let find = find_opt
 
   let find_exn t key =
@@ -15,7 +17,7 @@ struct
     | Some v -> v
     | None -> Code_error.raise "Hashtbl.find_exn" [ ("key", H.to_dyn key) ]
 
-  let set t key data = add t ~key ~data
+  let set t key data = replace t ~key ~data
 
   let find_or_add t key ~f =
     match find t key with

--- a/src/stdune/hashtbl_intf.ml
+++ b/src/stdune/hashtbl_intf.ml
@@ -1,5 +1,17 @@
 module type S = sig
-  include MoreLabels.Hashtbl.S
+  type 'a t
+
+  type key
+
+  val create : int -> 'a t
+
+  val clear : 'a t -> unit
+
+  val mem : 'a t -> key -> bool
+
+  val remove : 'a t -> key -> unit
+
+  val to_seq_values : 'a t -> 'a Seq.t
 
   val iter : 'a t -> f:('a -> unit) -> unit
 


### PR DESCRIPTION
Stdune's hash tables do not support multiple bindings.

While I'm at it, should we rename all the names in hashtable that involve `add` into `set`? We don't support multiple bindings so our naming should reflect that.

thanks @giltho!