### PR TITLE
Change an error message: segfault -> crash

### DIFF
--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -64,13 +64,13 @@ let get_printer = function
     in
     make_printer ~backtrace:true pp
 
-let i_must_not_segfault =
+let i_must_not_crash =
   let x =
     lazy
       (at_exit (fun () ->
            prerr_endline
              "\n\
-              I must not segfault.  Uncertainty is the mind-killer.  \
+              I must not crash.  Uncertainty is the mind-killer.  \
               Exceptions are\n\
               the little-death that brings total obliteration.  I will fully \
               express\n\
@@ -123,5 +123,5 @@ let report ?(extra = fun _ -> None) { Exn_with_backtrace.exn; backtrace } =
       let s = Buffer.contents buf in
       Buffer.clear buf;
       Console.print s;
-      if p.backtrace then i_must_not_segfault ()
+      if p.backtrace then i_must_not_crash ()
     )

--- a/test/blackbox-tests/test-cases/dir-target-dep/run.t
+++ b/test/blackbox-tests/test-cases/dir-target-dep/run.t
@@ -40,7 +40,7 @@ directory target and (mode promote) results in a crash
   Error: exception Sys_error("Is a directory")
   Backtrace:
   
-  I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
+  I must not crash.  Uncertainty is the mind-killer.  Exceptions are
   the little-death that brings total obliteration.  I will fully express
   my cases.  Execution will pass over me and through me.  And when it
   has gone past, I will unwind the stack along its path.  Where the


### PR DESCRIPTION
Segfault means a specific thing that is in fact never accompanied by this message.
Let's change the message to not be misleading by saying "crash" instead of "segfault".

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>