### PR TITLE
Generalise the Console module

### DIFF
--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -34,11 +34,7 @@ let start ~config ~foreground ~port_path ~root ~display =
       if foreground then show_endpoint content;
       started content
     in
-    Console.init
-      ( if foreground then
-        Verbose
-      else
-        Quiet );
+    Log.verbose := foreground;
     Cache_daemon.daemon ~root ~config started
   in
   match Daemonize.daemonize ~workdir:root ~foreground port_path f with

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -76,7 +76,7 @@ let set_dirs c =
   Path.Build.set_build_dir (Path.Build.Kind.of_string c.build_dir)
 
 let set_common_other ?log_file c ~targets =
-  Console.init c.config.display;
+  Config.init c.config;
   Dune_util.Log.init () ?file:log_file;
   Clflags.debug_dep_path := c.debug_dep_path;
   Clflags.debug_findlib := c.debug_findlib;

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -64,7 +64,7 @@ let term =
   in
   Path.set_root (Path.External.cwd ());
   Path.Build.set_build_dir (Path.Build.Kind.of_string Common.default_build_dir);
-  Console.init config.display;
+  Config.init config;
   Log.init_disabled ();
   Dune.Scheduler.go ~config Watermarks.subst
 

--- a/src/dune/config.mli
+++ b/src/dune/config.mli
@@ -47,7 +47,7 @@ module Terminal_persistence : sig
 end
 
 module Display : sig
-  type t = Stdune.Console.Display.t =
+  type t =
     | Progress  (** Single interactive status line *)
     | Short  (** One line per command *)
     | Verbose  (** Display all commands fully *)
@@ -56,6 +56,9 @@ module Display : sig
   val decode : t Dune_lang.Decoder.t
 
   val all : (string * t) list
+
+  (** The console backend corresponding to the selected display mode *)
+  val console_backend : t -> Console.Backend.t
 end
 
 module Concurrency : sig
@@ -140,5 +143,11 @@ val load_config_file : Path.t -> t
 (** Set display mode to [Quiet] if it is [Progress], the output is not a tty and
     we are not running inside emacs. *)
 val adapt_display : t -> output_is_a_tty:bool -> t
+
+(** The global configuration for the process *)
+val t : unit -> t
+
+(** Initialises the configuration for the process *)
+val init : t -> unit
 
 val to_dyn : t -> Dyn.t

--- a/src/dune/process.ml
+++ b/src/dune/process.ml
@@ -449,7 +449,7 @@ end
 let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     ?(stdin_from = Io.stdin) ~env ~purpose fail_mode prog args =
   let* scheduler = Scheduler.wait_for_available_job () in
-  let display = Console.display () in
+  let display = (Config.t ()).display in
   let dir =
     match dir with
     | None -> dir

--- a/src/dune/scheduler.ml
+++ b/src/dune/scheduler.ml
@@ -619,8 +619,7 @@ let rec restart_waiting_for_available_job t =
     restart_waiting_for_available_job t
 
 let got_signal signal =
-  if Console.display () = Verbose then
-    Log.infof "Got signal %s, exiting." (Signal.name signal)
+  if !Log.verbose then Log.infof "Got signal %s, exiting." (Signal.name signal)
 
 type saw_signal =
   | Ok
@@ -783,7 +782,7 @@ let maybe_clear_screen ~config =
     | Some cfg -> cfg.Config.terminal_persistence
     | None -> Preserve
   with
-  | Clear_on_rebuild -> Console.reset_terminal ()
+  | Clear_on_rebuild -> Console.reset ()
   | Preserve ->
     Console.print_user_message
       (User_message.make

--- a/src/dune_util/log.ml
+++ b/src/dune_util/log.ml
@@ -15,6 +15,8 @@ type real =
 
 let t = Fdecl.create Dyn.Encoder.opaque
 
+let verbose = ref false
+
 let init ?(file = File.Default) () =
   let oc =
     match file with
@@ -48,9 +50,7 @@ let info_internal { oc; _ } str =
     Format.pp_print_flush ppf ()
   in
   Option.iter ~f:(fun o -> write (Format.formatter_of_out_channel o)) oc;
-  match Console.display () with
-  | Verbose -> Console.print (Format.asprintf "%t" write)
-  | _ -> ()
+  if !verbose then Console.print (Format.asprintf "%t" write)
 
 let info s =
   match t () with

--- a/src/dune_util/log.mli
+++ b/src/dune_util/log.mli
@@ -28,3 +28,6 @@ val command :
   -> unit
 
 module StdLogger : Stdune.Logger.S
+
+(** Whether we are running in verbose mode *)
+val verbose : bool ref

--- a/src/stdune/console.ml
+++ b/src/stdune/console.ml
@@ -1,78 +1,130 @@
-module Display = struct
-  type t =
-    | Progress
-    | Short
-    | Verbose
-    | Quiet
+module Backend = struct
+  module type S = sig
+    val print : string -> unit
 
-  let all =
-    [ ("progress", Progress)
-    ; ("verbose", Verbose)
-    ; ("short", Short)
-    ; ("quiet", Quiet)
-    ]
-end
+    val print_user_message : User_message.t -> unit
 
-let reset_terminal () =
-  print_string "\x1bc";
-  flush stdout
+    val set_status_line : User_message.Style.t Pp.t option -> unit
 
-module T = struct
-  type t =
-    { display : Display.t
-    ; mutable status_line : Ansi_color.Style.t list Pp.t
-    ; mutable status_line_len : int
-    }
+    val reset : unit -> unit
+  end
 
-  let hide_status_line t =
-    if t.status_line_len > 0 then Printf.eprintf "\r%*s\r" t.status_line_len ""
+  type t = (module S)
 
-  let show_status_line t =
-    if t.status_line_len > 0 then Ansi_color.prerr t.status_line
+  module Dumb_no_flush : S = struct
+    let print = prerr_string
 
-  let update_status_line t status_line =
-    if t.display = Progress then (
-      let status_line =
-        Pp.map_tags status_line ~f:User_message.Print_config.default
-      in
-      let status_line_len =
-        String.length (Format.asprintf "%a" Pp.render_ignore_tags status_line)
-      in
-      hide_status_line t;
-      t.status_line <- status_line;
-      t.status_line_len <- status_line_len;
-      show_status_line t;
+    let print_user_message msg =
+      Option.iter msg.User_message.loc ~f:(Loc.print Format.err_formatter);
+      User_message.prerr { msg with loc = None }
+
+    let set_status_line _ = ()
+
+    let reset () = prerr_string "\x1bc"
+  end
+
+  module Dumb : S = struct
+    include Dumb_no_flush
+
+    let print msg =
+      print msg;
       flush stderr
-    )
 
-  let print t msg =
-    hide_status_line t;
-    prerr_string msg;
-    show_status_line t;
-    flush stderr
+    let print_user_message msg =
+      print_user_message msg;
+      flush stderr
 
-  let print_user_message t ?config msg =
-    hide_status_line t;
-    Option.iter msg.User_message.loc ~f:(Loc.print Format.err_formatter);
-    User_message.prerr ?config { msg with loc = None };
-    show_status_line t;
-    flush stderr
+    let reset () =
+      reset ();
+      flush stderr
+  end
 
-  let clear_status_line t =
-    hide_status_line t;
-    t.status_line <- Pp.nop;
-    t.status_line_len <- 0;
-    flush stderr
+  module Progress : S = struct
+    let status_line = ref Pp.nop
+
+    let status_line_len = ref 0
+
+    let hide_status_line () =
+      if !status_line_len > 0 then Printf.eprintf "\r%*s\r" !status_line_len ""
+
+    let show_status_line () =
+      if !status_line_len > 0 then Ansi_color.prerr !status_line
+
+    let set_status_line = function
+      | None ->
+        hide_status_line ();
+        status_line := Pp.nop;
+        status_line_len := 0;
+        flush stderr
+      | Some line ->
+        let line = Pp.map_tags line ~f:User_message.Print_config.default in
+        let line_len =
+          String.length (Format.asprintf "%a" Pp.render_ignore_tags line)
+        in
+        hide_status_line ();
+        status_line := line;
+        status_line_len := line_len;
+        show_status_line ();
+        flush stderr
+
+    let print msg =
+      hide_status_line ();
+      Dumb_no_flush.print msg;
+      show_status_line ();
+      flush stderr
+
+    let print_user_message msg =
+      hide_status_line ();
+      Dumb_no_flush.print_user_message msg;
+      show_status_line ();
+      flush stderr
+
+    let reset () = Dumb.reset ()
+  end
+
+  let dumb = (module Dumb : S)
+
+  let progress = (module Progress : S)
+
+  let main = ref dumb
+
+  let set t = main := t
+
+  let compose (module A : S) (module B : S) =
+    ( module struct
+      let print msg =
+        A.print msg;
+        B.print msg
+
+      let print_user_message msg =
+        A.print_user_message msg;
+        B.print_user_message msg
+
+      let set_status_line x =
+        A.set_status_line x;
+        B.set_status_line x
+
+      let reset () =
+        A.reset ();
+        B.reset ()
+    end : S )
 end
 
-let t_var = ref None
+let print msg =
+  let (module M : Backend.S) = !Backend.main in
+  M.print msg
 
-let init display =
-  t_var := Some { T.display; status_line = Pp.nop; status_line_len = 0 }
+let print_user_message msg =
+  let (module M : Backend.S) = !Backend.main in
+  M.print_user_message msg
 
-let t () = Option.value_exn !t_var
+let set_status_line line =
+  let (module M : Backend.S) = !Backend.main in
+  M.set_status_line line
 
-let display () = (t ()).display
+let reset () =
+  let (module M : Backend.S) = !Backend.main in
+  M.reset ()
 
 module Status_line = struct
   type t = unit -> User_message.Style.t Pp.t option
@@ -81,7 +133,7 @@ module Status_line = struct
 
   let refresh () =
     match !status_line () with
-    | None -> T.clear_status_line (t ())
+    | None -> set_status_line None
     | Some pp ->
       (* Always put the status line inside a horizontal to force the [Format]
          module to prefer a single line. In particular, it seems that
@@ -90,7 +142,7 @@ module Status_line = struct
          the whole thing into a [hbox] works around this bug.
 
          See https://github.com/ocaml/dune/issues/2779 *)
-      T.update_status_line (t ()) (Pp.hbox pp)
+      set_status_line (Some (Pp.hbox pp))
 
   let set x =
     status_line := x;
@@ -101,15 +153,5 @@ module Status_line = struct
     set x;
     Exn.protect ~finally:(fun () -> set old) ~f
 end
-
-let print msg =
-  match !t_var with
-  | None -> Printf.eprintf "%s%!" msg
-  | Some t -> T.print t msg
-
-let print_user_message ?config msg =
-  match !t_var with
-  | None -> User_message.prerr ?config msg
-  | Some t -> T.print_user_message t ?config msg
 
 let () = User_warning.set_reporter print_user_message

--- a/src/stdune/console.mli
+++ b/src/stdune/console.mli
@@ -1,39 +1,55 @@
-(** Manage printing user message and keeping progress information in the status
-    line *)
+(** Manages the console *)
 
-module Display : sig
-  type t =
-    | Progress
-    | Short
-    | Verbose
-    | Quiet
+(** The console is a system than can report messages and a status to the user.
+    It is usually the terminal the application is connected to, however it could
+    be something else. This module allow to set a global backend for the
+    application as well as composing backends. *)
 
-  val all : (string * t) list
+module Backend : sig
+  module type S = sig
+    (** Print a message to the console *)
+    val print : string -> unit
+
+    (** Format and print a user message to the console *)
+    val print_user_message : User_message.t -> unit
+
+    (** Change the status line *)
+    val set_status_line : User_message.Style.t Pp.t option -> unit
+
+    (** Reset the log output *)
+    val reset : unit -> unit
+  end
+
+  type t = (module S)
+
+  val set : t -> unit
+
+  (** [compose a b] produce a backend that sends message to both [a] and [b]
+      backends. *)
+  val compose : t -> t -> t
+
+  (** A dumb backend that hides the status line and simply dump the messages to
+      the terminal *)
+  val dumb : t
+
+  (** A backend that just displays the status line in the terminal *)
+  val progress : t
 end
 
-val print : string -> unit
-
-val print_user_message :
-  ?config:User_message.Print_config.t -> User_message.t -> unit
-
-val init : Display.t -> unit
-
-val reset_terminal : unit -> unit
-
-(** / *)
-
-(** Everything below this line requires [init] to have been called earlier. *)
+(** The main backend for the application *)
+include Backend.S
 
 module Status_line : sig
+  (** This module allows to buffer status updates so that they don't slow down
+      the application *)
+
   (** Function that produces the current status line *)
   type t = unit -> User_message.Style.t Pp.t option
 
-  (** Change the status line if the display is in progress mode. *)
+  (** Change the status line generator *)
   val set : t -> unit
 
   val set_temporarily : t -> (unit -> 'a) -> 'a
 
   val refresh : unit -> unit
 end
-
-val display : unit -> Display.t

--- a/test/expect-tests/common/dune_tests_common.ml
+++ b/test/expect-tests/common/dune_tests_common.ml
@@ -10,7 +10,7 @@ let init =
       ( Printexc.record_backtrace false;
         Path.set_root (Path.External.cwd ());
         Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");
-        Console.init Quiet;
+        Console.Backend.(set dumb);
         Dune_util.Log.init () )
   in
   fun () -> Lazy.force init

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -3,7 +3,9 @@ open Dune
 open Fiber.O
 open! Dune_tests_common
 
-let () = init ()
+let () =
+  init ();
+  Config.init { Config.default with display = Quiet }
 
 let printf = Printf.printf
 


### PR DESCRIPTION
This is in preparation for #3068. This PR generalises the `Console` module. The console is now seen as an abstract system that can report messages and a status the user.

The module now allows to set the actual backend, compose backends, etc... #3068 will simply provide a new backend for the console.