### PR TITLE
Introduce Lib.Hidden

### DIFF
--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -1856,7 +1856,7 @@ module DB = struct
         match Findlib.find findlib name with
         | Ok (Library pkg) -> Found (Dune_package.Lib.info pkg)
         | Ok (Deprecated_library_name d) ->
-          Redirect (None, (Loc.none, d.new_public_name))
+          Redirect (None, (d.loc, d.new_public_name))
         | Ok (Hidden_library pkg) -> Hidden (Hidden.unsatisfied_exist_if pkg)
         | Error e -> (
           match e with

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -153,18 +153,17 @@ module DB : sig
   type t
 
   module Resolve_result : sig
-    type nonrec t =
-      | Not_found
-      | Found of Lib_info.external_
-      | Hidden of
-          { info : Lib_info.external_
-          ; reason : string
-          }
-      | Invalid of exn
-      | Redirect of t option * (Loc.t * Lib_name.t)
+    type t
+
+    type db
+
+    val not_found : t
 
     val to_dyn : t Dyn.Encoder.t
+
+    val redirect : db option -> Loc.t * Lib_name.t -> t
   end
+  with type db := t
 
   (** Create a new library database. [resolve] is used to resolve library names
       in this database.

--- a/src/dune/scope.ml
+++ b/src/dune/scope.ml
@@ -47,11 +47,11 @@ module DB = struct
 
   let resolve t public_libs name : Lib.DB.Resolve_result.t =
     match Lib_name.Map.find public_libs name with
-    | None -> Not_found
+    | None -> Lib.DB.Resolve_result.not_found
     | Some (Project project) ->
       let scope = find_by_project (Fdecl.get t) project in
-      Redirect (Some scope.db, (Loc.none, name))
-    | Some (Name name) -> Redirect (None, name)
+      Lib.DB.Resolve_result.redirect (Some scope.db) (Loc.none, name)
+    | Some (Name name) -> Lib.DB.Resolve_result.redirect None name
 
   let public_libs t ~stdlib_dir ~installed_libs stanzas =
     let public_libs =


### PR DESCRIPTION
Lib.Hidden is used to represent hidden libraries for both the status of libraries in the database and Resolve_result. This requires us to introduce a type parameter but we can keep it out of the public API by making Resolve_result abstract.