### PR TITLE
Treat exceptions as proper values in the memoization framework

### DIFF
--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -2,8 +2,6 @@ open! Stdune
 
 type ('input, 'output, 'f) t
 
-val on_already_reported : (Exn_with_backtrace.t -> Nothing.t) -> unit
-
 module Sync : sig
   type nonrec ('i, 'o) t = ('i, 'o, 'i -> 'o) t
 end


### PR DESCRIPTION
This patch makes handling of normal values and exceptions more uniform, which simplifies the code, allowing us to get rid of the `Failed` state. We also remove some functionality related to `on_already_reported` which is no longer used.

I run some testing in file-watching mode to make sure errors are reported correctly (and eagerly) and we do not start to leak memory.