### PR TITLE
Don't leak temporary directory in cache daemon mode.

### DIFF
--- a/src/cache/client.ml
+++ b/src/cache/client.ml
@@ -110,4 +110,5 @@ let deduplicate client file = Local.deduplicate client.cache file
 let teardown client =
   ( try Unix.shutdown client.fd Unix.SHUTDOWN_SEND
     with Unix.Unix_error (Unix.ENOTCONN, _, _) -> () );
-  Thread.join client.thread
+  Thread.join client.thread;
+  Local.teardown client.cache

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -367,8 +367,8 @@ let make ?(root = default_root ())
       ; handler
       ; duplication_mode
       ; temp_dir =
-          Path.temp_dir ~temp_dir:root "promoting"
-            (string_of_int (Unix.getpid ()))
+          Path.temp_dir ~temp_dir:root "promoting."
+            ("." ^ string_of_int (Unix.getpid ()))
       }
     in
     Path.mkdir_p @@ root_metadata res;


### PR DESCRIPTION
The client implementation teardown now calls the underlying local implementation teardown, to ensure temporary directory are cleaned up. If you used daemon mode, you might have a lot of leaked `~/.cache/dune/db/v2/promoting*` empty directories worth removing manually.