### PR TITLE
[stdune] introduce List.min_by

### DIFF
--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -193,3 +193,15 @@ let rec for_all2 x y ~f =
     else
       Ok false
   | _, _ -> Error `Length_mismatch
+
+let min xs ~f =
+  match xs with
+  | [] -> None
+  | init :: xs ->
+    Some
+      (fold_left xs ~init ~f:(fun min a ->
+           match f min a with
+           | Ordering.Gt -> a
+           | Lt
+           | Eq ->
+             min))

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -194,14 +194,11 @@ let rec for_all2 x y ~f =
       Ok false
   | _, _ -> Error `Length_mismatch
 
-let min xs ~f =
+let reduce xs ~f =
   match xs with
   | [] -> None
-  | init :: xs ->
-    Some
-      (fold_left xs ~init ~f:(fun min a ->
-           match f min a with
-           | Ordering.Gt -> a
-           | Lt
-           | Eq ->
-             min))
+  | init :: xs -> Some (fold_left xs ~init ~f)
+
+let min xs ~f = reduce xs ~f:(Ordering.min f)
+
+let max xs ~f = reduce xs ~f:(Ordering.max f)

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -79,4 +79,8 @@ val for_all2 :
   -> f:('a -> 'b -> bool)
   -> (bool, [ `Length_mismatch ]) result
 
+val reduce : 'a list -> f:('a -> 'a -> 'a) -> 'a option
+
 val min : 'a list -> f:('a -> 'a -> Ordering.t) -> 'a option
+
+val max : 'a list -> f:('a -> 'a -> Ordering.t) -> 'a option

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -78,3 +78,5 @@ val for_all2 :
   -> 'b list
   -> f:('a -> 'b -> bool)
   -> (bool, [ `Length_mismatch ]) result
+
+val min : 'a list -> f:('a -> 'a -> Ordering.t) -> 'a option

--- a/src/stdune/ordering.ml
+++ b/src/stdune/ordering.ml
@@ -32,3 +32,15 @@ let is_eq = function
   | Lt
   | Gt ->
     false
+
+let min f x y =
+  match f x y with
+  | Eq
+  | Lt -> x
+  | Gt -> y
+
+let max f x y =
+  match f x y with
+  | Eq
+  | Gt -> x
+  | Lt -> y

--- a/src/stdune/ordering.mli
+++ b/src/stdune/ordering.mli
@@ -15,3 +15,7 @@ val to_string : t -> string
 val neq : t -> bool
 
 val is_eq : t -> bool
+
+val min : ('a -> 'a -> t) -> 'a -> 'a -> 'a
+
+val max : ('a -> 'a -> t) -> 'a -> 'a -> 'a


### PR DESCRIPTION
This is necessary for me in ocaml-lsp. I figured that it's better to maintain
this stuff in one place.