### PR TITLE
Remove tag label to Pp.tag

### DIFF
--- a/bin/init.ml
+++ b/bin/init.ml
@@ -67,11 +67,10 @@ let print_completion kind name =
   let open Pp.O in
   Console.print_user_message
     (User_message.make
-       [ Pp.tag (Pp.verbatim "Success") ~tag:User_message.Style.Ok
+       [ Pp.tag User_message.Style.Ok (Pp.verbatim "Success")
          ++ Pp.textf ": initialized %s component named " (Kind.to_string kind)
-         ++ Pp.tag
+         ++ Pp.tag User_message.Style.Kwd
               (Pp.verbatim (Dune_lang.Atom.to_string name))
-              ~tag:User_message.Style.Kwd
        ])
 
 (** {1 CLI} *)

--- a/src/dune/dune_init.ml
+++ b/src/dune/dune_init.ml
@@ -476,7 +476,7 @@ module Component = struct
       let open Pp.O in
       User_warning.emit
         [ Pp.textf "File "
-          ++ Pp.tag ~tag:User_message.Style.Kwd
+          ++ Pp.tag User_message.Style.Kwd
                (Pp.verbatim (Path.to_string_maybe_quoted path))
           ++ Pp.text " was not created because it already exists"
         ]

--- a/src/dune/dune_project.ml
+++ b/src/dune/dune_project.ml
@@ -264,7 +264,7 @@ module Project_file_edit = struct
       (User_message.make paragraphs
          ~prefix:
            (Pp.seq
-              (Pp.tag (Pp.verbatim "Info") ~tag:User_message.Style.Warning)
+              (Pp.tag User_message.Style.Warning (Pp.verbatim "Info"))
               (Pp.char ':')))
 
   let lang_stanza () =

--- a/src/dune/format_config.ml
+++ b/src/dune/format_config.ml
@@ -137,7 +137,7 @@ let of_config ~ext ~dune_lang =
       | Some explicit ->
         let dlang = encode_explicit explicit in
         [ Pp.textf "To port it to the new syntax, you can replace this part by:"
-        ; Pp.tag ~tag:User_message.Style.Details (Dune_lang.pp dlang)
+        ; Pp.tag User_message.Style.Details (Dune_lang.pp dlang)
         ]
       | None ->
         [ Pp.textf "To port it to the new syntax, you can delete this part." ]

--- a/src/dune/process.ml
+++ b/src/dune/process.ml
@@ -240,16 +240,15 @@ module Fancy = struct
         User_message.Style.Ansi_styles styles
       in
       Pp.seq (Pp.verbatim before)
-        (Pp.seq (Pp.tag (Pp.verbatim prog) ~tag:styles) (Pp.verbatim after))
+        (Pp.seq (Pp.tag styles (Pp.verbatim prog)) (Pp.verbatim after))
 
   let rec colorize_args = function
     | [] -> []
     | "-o" :: fn :: rest ->
       Pp.verbatim "-o"
       :: Pp.tag
+           (User_message.Style.Ansi_styles Ansi_color.Style.[ bold; fg_green ])
            (Pp.verbatim (String.quote_for_shell fn))
-           ~tag:
-             (User_message.Style.Ansi_styles Ansi_color.Style.[ bold; fg_green ])
       :: colorize_args rest
     | x :: rest -> Pp.verbatim (String.quote_for_shell x) :: colorize_args rest
 
@@ -310,7 +309,7 @@ module Fancy = struct
       | l ->
         let open Pp.O in
         pp ++ Pp.char ' '
-        ++ Pp.tag ~tag:User_message.Style.Details
+        ++ Pp.tag User_message.Style.Details
              ( Pp.char '['
              ++ Pp.concat_map l ~sep:(Pp.char ',') ~f:(fun ctx ->
                     Pp.verbatim (Context_name.to_string ctx))
@@ -329,9 +328,7 @@ let cmdline_approximate_length prog args =
 
 let pp_id id =
   let open Pp.O in
-  Pp.char '['
-  ++ Pp.tag ~tag:User_message.Style.Id (Pp.textf "%d" id)
-  ++ Pp.char ']'
+  Pp.char '[' ++ Pp.tag User_message.Style.Id (Pp.textf "%d" id) ++ Pp.char ']'
 
 module Exit_status = struct
   type error =
@@ -359,13 +356,13 @@ module Exit_status = struct
       Option.iter output ~f:(fun output ->
           Console.print_user_message
             (User_message.make
-               [ Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Output")
+               [ Pp.tag User_message.Style.Kwd (Pp.verbatim "Output")
                  ++ pp_id id ++ Pp.char ':'
                ; output
                ]));
       if not (ok_codes n) then
         User_warning.emit
-          [ Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Command")
+          [ Pp.tag User_message.Style.Kwd (Pp.verbatim "Command")
             ++ Pp.space ++ pp_id id
             ++ Pp.textf
                  " exited with code %d, but I'm ignoring it, hope that's OK." n
@@ -378,9 +375,9 @@ module Exit_status = struct
         | Signaled signame -> sprintf "got signal %s" signame
       in
       fail
-        ( Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Command")
+        ( Pp.tag User_message.Style.Kwd (Pp.verbatim "Command")
           ++ Pp.space ++ pp_id id ++ Pp.space ++ Pp.text msg ++ Pp.char ':'
-        :: Pp.tag ~tag:User_message.Style.Prompt (Pp.char '$')
+        :: Pp.tag User_message.Style.Prompt (Pp.char '$')
            ++ Pp.char ' ' ++ command_line
         :: Option.to_list output )
 
@@ -413,7 +410,7 @@ module Exit_status = struct
     let _, progname, _ = Fancy.split_prog prog in
     let progname_and_purpose tag =
       let progname = sprintf "%12s" progname in
-      Pp.tag ~tag (Pp.verbatim progname)
+      Pp.tag tag (Pp.verbatim progname)
       ++ Pp.char ' ' ++ Fancy.pp_purpose purpose
     in
     match t with
@@ -441,8 +438,8 @@ module Exit_status = struct
       in
       fail
         ( progname_and_purpose Error ++ Pp.char ' '
-          ++ Pp.tag ~tag:User_message.Style.Error (Pp.verbatim msg)
-        :: Pp.tag ~tag:User_message.Style.Details (Pp.verbatim command_line)
+          ++ Pp.tag User_message.Style.Error (Pp.verbatim msg)
+        :: Pp.tag User_message.Style.Details (Pp.verbatim command_line)
         :: Option.to_list output )
 end
 
@@ -475,7 +472,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
       in
       Console.print_user_message
         (User_message.make
-           [ Pp.tag ~tag:User_message.Style.Kwd (Pp.verbatim "Running")
+           [ Pp.tag User_message.Style.Kwd (Pp.verbatim "Running")
              ++ pp_id id ++ Pp.verbatim ": " ++ cmdline
            ]);
       cmdline

--- a/src/dune/scheduler.ml
+++ b/src/dune/scheduler.ml
@@ -753,7 +753,7 @@ end = struct
       Console.Status_line.set (fun () ->
           Some
             (Pp.seq
-               (Pp.tag ~tag:User_message.Style.Error (Pp.verbatim "Had errors"))
+               (Pp.tag User_message.Style.Error (Pp.verbatim "Had errors"))
                (Pp.verbatim ", killing current build...")))
     | _ -> () );
     match kill_and_wait_for_all_processes t () with
@@ -790,7 +790,7 @@ let maybe_clear_screen ~config =
     Console.print_user_message
       (User_message.make
          [ Pp.nop
-         ; Pp.tag ~tag:User_message.Style.Success
+         ; Pp.tag User_message.Style.Success
              (Pp.verbatim "********** NEW BUILD **********")
          ; Pp.nop
          ])
@@ -820,11 +820,11 @@ let poll ?config ~once ~finally () =
     finally ();
     match res with
     | Ok () ->
-      wait (Pp.tag ~tag:User_message.Style.Success (Pp.verbatim "Success"))
+      wait (Pp.tag User_message.Style.Success (Pp.verbatim "Success"))
       |> after_wait
     | Error Got_signal -> (Dune_util.Report_error.Already_reported, None)
     | Error Never ->
-      wait (Pp.tag ~tag:User_message.Style.Error (Pp.verbatim "Had errors"))
+      wait (Pp.tag User_message.Style.Error (Pp.verbatim "Had errors"))
       |> after_wait
     | Error Files_changed -> loop ()
     | Error (Exn (exn, bt)) -> (exn, Some bt)

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -12,7 +12,7 @@ let get_user_message = function
     let open Pp.O in
     ( Developer
     , User_message.make ?loc:e.loc
-        [ Pp.tag ~tag:User_message.Style.Error
+        [ Pp.tag User_message.Style.Error
             (Pp.textf
                "Internal error, please report upstream including the contents \
                 of _build/log.")

--- a/src/stdune/ansi_color.ml
+++ b/src/stdune/ansi_color.ml
@@ -151,7 +151,7 @@ let parse_line str styles =
       let s =
         match styles with
         | [] -> s
-        | _ -> Pp.tag s ~tag:styles
+        | _ -> Pp.tag styles s
       in
       Pp.seq acc s
   in

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -143,7 +143,7 @@ let text s = Text s
 
 let textf fmt = Printf.ksprintf text fmt
 
-let tag t ~tag = Tag (tag, t)
+let tag tag t = Tag (tag, t)
 
 let enumerate l ~f =
   vbox

--- a/src/stdune/pp.mli
+++ b/src/stdune/pp.mli
@@ -33,8 +33,8 @@ val text : string -> _ t
 (** Same as [text] but take a format string as argument. *)
 val textf : ('a, unit, string, _ t) format4 -> 'a
 
-(** [tag t ~tag] Tag the material printed by [t] with [tag] *)
-val tag : 'a t -> tag:'a -> 'a t
+(** [tag x t] Tag the material printed by [t] with [x] *)
+val tag : 'a -> 'a t -> 'a t
 
 (** {1 Break hints} *)
 

--- a/src/stdune/user_error.ml
+++ b/src/stdune/user_error.ml
@@ -1,9 +1,7 @@
 exception E of User_message.t
 
 let prefix =
-  Pp.seq
-    (Pp.tag (Pp.verbatim "Error") ~tag:User_message.Style.Error)
-    (Pp.char ':')
+  Pp.seq (Pp.tag User_message.Style.Error (Pp.verbatim "Error")) (Pp.char ':')
 
 let make ?loc ?hints paragraphs =
   User_message.make ?loc ?hints paragraphs ~prefix

--- a/src/stdune/user_message.ml
+++ b/src/stdune/user_message.ml
@@ -63,7 +63,7 @@ let pp { loc; paragraphs; hints } =
     | Some { Loc0.start; stop } ->
       let start_c = start.pos_cnum - start.pos_bol in
       let stop_c = stop.pos_cnum - start.pos_bol in
-      Pp.tag ~tag:Style.Loc
+      Pp.tag Style.Loc
         (Pp.textf "File %S, line %d, characters %d-%d:" start.pos_fname
            start.pos_lnum start_c stop_c)
       :: paragraphs

--- a/src/stdune/user_warning.ml
+++ b/src/stdune/user_warning.ml
@@ -10,5 +10,5 @@ let emit ?loc ?hints ?(is_error = false) paragraphs =
       (User_message.make paragraphs ?loc ?hints
          ~prefix:
            (Pp.seq
-              (Pp.tag (Pp.verbatim "Warning") ~tag:User_message.Style.Warning)
+              (Pp.tag User_message.Style.Warning (Pp.verbatim "Warning"))
               (Pp.char ':')))


### PR DESCRIPTION
Remove the `~tag` label of `Pp.tag`. I always found this label a bit annoying as it is redundant with the function name.

Before:

```ocaml
val tag : 'a t -> tag:'a -> 'a t
```

after:

```ocaml
val tag : 'a -> 'a t -> 'a t
```