### PR TITLE
Remove some vestigial jbuilder code related to variable syntax

### DIFF
--- a/src/dune_lang/lexer.mll
+++ b/src/dune_lang/lexer.mll
@@ -369,7 +369,6 @@ and template_variable = parse
             }
         ; name
         ; payload
-        ; syntax = Percent
         }
   }
   | '}' | eof

--- a/src/dune_lang/template.mli
+++ b/src/dune_lang/template.mli
@@ -1,15 +1,9 @@
 open! Stdune
 
-type var_syntax =
-  | Dollar_brace
-  | Dollar_paren
-  | Percent
-
 type var =
   { loc : Loc.t
   ; name : string
   ; payload : string option
-  ; syntax : var_syntax
   }
 
 type part =

--- a/test/blackbox-tests/test-cases/output-obj/run.t
+++ b/test/blackbox-tests/test-cases/output-obj/run.t
@@ -3,10 +3,10 @@
         static alias runtest
   OK: ./static.exe
        dynamic alias runtest
+  OK: ./dynamic.exe ./test.bc$ext_dll
+       dynamic alias runtest
   OK: ./dynamic.exe ./test$ext_dll
         static alias runtest
   OK: ./static.bc
-       dynamic alias runtest
-  OK: ./dynamic.exe ./test.bc$ext_dll
 #        static alias runtest
 #  OK: ./static.bc.c.exe

--- a/test/blackbox-tests/test-cases/tests-stanza/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/run.t
@@ -12,10 +12,6 @@
       ocamldep .expect_test.eobjs/expect_test.ml.d
       ocamldep .expect_test.eobjs/regular_test.ml.d
       ocamldep .expect_test.eobjs/regular_test2.ml.d
-        ocamlc .expect_test.eobjs/byte/expect_test.{cmi,cmo,cmt}
-      ocamlopt .expect_test.eobjs/native/expect_test.{cmx,o}
-      ocamlopt expect_test.exe
-   expect_test expect_test.output
         ocamlc .expect_test.eobjs/byte/regular_test.{cmi,cmo,cmt}
       ocamlopt .expect_test.eobjs/native/regular_test.{cmx,o}
       ocamlopt regular_test.exe
@@ -26,6 +22,10 @@
       ocamlopt regular_test2.exe
   regular_test2 alias runtest
   regular test2
+        ocamlc .expect_test.eobjs/byte/expect_test.{cmi,cmo,cmt}
+      ocamlopt .expect_test.eobjs/native/expect_test.{cmx,o}
+      ocamlopt expect_test.exe
+   expect_test expect_test.output
   $ dune runtest --root generated --display short
   Entering directory 'generated'
       ocamldep .generated.eobjs/generated.ml.d

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -258,8 +258,7 @@ let tq x = Dune_lang.Template { quoted = true; parts = x; loc }
 
 let l x = Dune_lang.List x
 
-let var ?(syntax = Dune_lang.Template.Percent) ?payload name =
-  { Dune_lang.Template.loc; name; payload; syntax }
+let var ?payload name = { Dune_lang.Template.loc; name; payload }
 
 type syntax =
   | Dune


### PR DESCRIPTION
The only recognised syntax is `%{...}`, no need to support other older syntaxes. This simplifies a bit the code