### PR TITLE
[coq] Introduce Coq_scope

### DIFF
--- a/src/dune/coq_rules.ml
+++ b/src/dune/coq_rules.ml
@@ -240,8 +240,9 @@ let setup_rules ~sctx ~build_dir ~dir ~dir_contents (s : Dune_file.Coq.t) =
   let cc = create_ccoq sctx ~dir in
   let name = snd s.name in
   let scope = SC.find_scope_by_dir sctx dir in
+  let coq_scope = SC.find_coq_scope_by_dir sctx dir in
   let lib_db = Scope.libs scope in
-  let coq_lib_db = Scope.coq_libs scope in
+  let coq_lib_db = Coq_scope.libs coq_scope in
   let expander = SC.expander sctx ~dir in
 
   let theory = Coq_lib.DB.resolve coq_lib_db s.name |> Result.ok_exn in

--- a/src/dune/coq_scope.ml
+++ b/src/dune/coq_scope.ml
@@ -1,0 +1,59 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2019                    *)
+(* (c) INRIA 2020                              *)
+(* Written by: Emilio Jesús Gallego Arias *)
+
+open! Stdune
+
+type t = { db : Coq_lib.DB.t }
+
+let libs { db; _ } = db
+
+module DB = struct
+  type scope = t
+
+  type t =
+    { by_dir : scope Path.Source.Map.t
+    ; context : Context_name.t
+    }
+
+  let find_by_dir t (dir : Path.Source.t) =
+    let rec loop d =
+      match Path.Source.Map.find t.by_dir d with
+      | Some s -> s
+      | None -> (
+        match Path.Source.parent d with
+        | Some d -> loop d
+        | None ->
+          Code_error.raise "find_by_dir: invalid directory"
+            [ ("d", Path.Source.to_dyn d); ("dir", Path.Source.to_dyn dir) ] )
+    in
+    loop dir
+
+  let find_by_project t project =
+    Path.Source.Map.find_exn t.by_dir (Dune_project.root project)
+
+  let scopes_by_dir stanzas =
+    let stanzas_by_project_dir =
+      List.map stanzas
+        ~f:(fun ((dir, stanza) : Path.Build.t * Dune_file.Coq.t) ->
+          let project = stanza.project in
+          (Dune_project.root project, (dir, stanza)))
+      |> Path.Source.Map.of_list_multi
+    in
+    Path.Source.Map.map stanzas_by_project_dir ~f:(fun stanza ->
+        let db = Coq_lib.DB.create_from_coqlib_stanzas stanza in
+        { db })
+
+  let create ~context stanzas =
+    let by_dir = scopes_by_dir stanzas in
+    { by_dir; context }
+
+  let find_by_dir t dir =
+    if Path.Build.is_root dir then
+      Code_error.raise "Scope.DB.find_by_dir got an invalid path"
+        [ ("dir", Path.Build.to_dyn dir)
+        ; ("context", Context_name.to_dyn t.context)
+        ];
+    find_by_dir t (Path.Build.drop_build_context_exn dir)
+end

--- a/src/dune/coq_scope.mli
+++ b/src/dune/coq_scope.mli
@@ -1,0 +1,25 @@
+(* This file is licensed under The MIT License *)
+(* (c) MINES ParisTech 2019                    *)
+(* (c) INRIA 2020                              *)
+(* Written by: Emilio Jesús Gallego Arias *)
+
+open! Stdune
+
+type t
+
+(** Return the library database associated to this scope *)
+val libs : t -> Coq_lib.DB.t
+
+module DB : sig
+  type scope = t
+
+  type t
+
+  val create :
+    context:Context_name.t -> (Path.Build.t * Dune_file.Coq.t) list -> t
+
+  val find_by_dir : t -> Path.Build.t -> scope
+
+  val find_by_project : t -> Dune_project.t -> scope
+end
+with type scope := t

--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -1683,7 +1683,6 @@ module DB = struct
       | Library of Path.Build.t * Dune_file.Library.t
       | External_variant of Dune_file.External_variant.t
       | Deprecated_library_name of Dune_file.Deprecated_library_name.t
-      | Coq_theory of Path.Build.t * Dune_file.Coq.t
   end
 
   module Found_or_redirect = struct
@@ -1697,8 +1696,7 @@ module DB = struct
     List.iter stanzas ~f:(fun (stanza : Library_related_stanza.t) ->
         match stanza with
         | Library _
-        | Deprecated_library_name _
-        | Coq_theory _ ->
+        | Deprecated_library_name _ ->
           ()
         | External_variant ev -> (
           let loc, virtual_lib = ev.virtual_lib in
@@ -1816,10 +1814,7 @@ module DB = struct
               else
                 [ (name, Found info)
                 ; (Lib_name.of_local conf.name, Redirect p.name)
-                ] )
-          | Coq_theory _ ->
-            (* As of today Coq theories do live in a separate namespace *)
-            [])
+                ] ))
       |> Lib_name.Map.of_list_reducei
            ~f:(fun name (v1 : Found_or_redirect.t) v2 ->
              let res =

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -185,7 +185,6 @@ module DB : sig
       | Library of Path.Build.t * Dune_file.Library.t
       | External_variant of Dune_file.External_variant.t
       | Deprecated_library_name of Dune_file.Deprecated_library_name.t
-      | Coq_theory of Path.Build.t * Dune_file.Coq.t
   end
 
   (** Create a database from a list of library/variants stanzas *)

--- a/src/dune/scope.mli
+++ b/src/dune/scope.mli
@@ -15,8 +15,6 @@ val project : t -> Dune_project.t
 (** Return the library database associated to this scope *)
 val libs : t -> Lib.DB.t
 
-val coq_libs : t -> Coq_lib.DB.t
-
 (** Scope databases *)
 module DB : sig
   type scope = t

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -87,6 +87,8 @@ val dump_env : t -> dir:Path.Build.t -> Dune_lang.t list Build.t
 
 val find_scope_by_dir : t -> Path.Build.t -> Scope.t
 
+val find_coq_scope_by_dir : t -> Path.Build.t -> Coq_scope.t
+
 val find_scope_by_project : t -> Dune_project.t -> Scope.t
 
 val find_project_by_key : t -> Dune_project.File_key.t -> Dune_project.t


### PR DESCRIPTION
This PR is a RFC, as I'm not convinced at all this should be the way
to go before we introduce handling of public Coq theories as to allow
their inter-scope composition.

The current approach to handling Coq theories ─ introduced in #2053 ─
modified `Scope` and `Lib` adding a new library-like stanza type,
`Coq_theory`.

However, handling of libraries and theories is quite different so the
above approach led to a few spurious code cases.

There are two choices to improve this situation before we introduce
`coq_public_libs`:

- refactor `Scope` a bit more so we don't have to mess with
  `Lib.library_related_stanza`

  That's one option but still seems a bit invasive and messy for `scope.ml`, implemented in #3281 .

- split all Coq-related scope code to `Coq_scope` and handle things
  there. This is what this PR does.

This approach does introduce some code duplication, so it is not clear
if it is indeed a gain w.r.t. current status-quo.

Code duplication could be solved by using some programming
abstractions.

What you think folks (cc: @rgrinberg ) I lean towards taking #3281 

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>