### PR TITLE
[coq] Rework Coq_lib.DB handling as not to interfere with `Lib`

### DIFF
--- a/src/dune/lib.ml
+++ b/src/dune/lib.ml
@@ -1683,7 +1683,6 @@ module DB = struct
       | Library of Path.Build.t * Dune_file.Library.t
       | External_variant of Dune_file.External_variant.t
       | Deprecated_library_name of Dune_file.Deprecated_library_name.t
-      | Coq_theory of Path.Build.t * Dune_file.Coq.t
   end
 
   module Found_or_redirect = struct
@@ -1697,8 +1696,7 @@ module DB = struct
     List.iter stanzas ~f:(fun (stanza : Library_related_stanza.t) ->
         match stanza with
         | Library _
-        | Deprecated_library_name _
-        | Coq_theory _ ->
+        | Deprecated_library_name _ ->
           ()
         | External_variant ev -> (
           let loc, virtual_lib = ev.virtual_lib in
@@ -1816,10 +1814,7 @@ module DB = struct
               else
                 [ (name, Found info)
                 ; (Lib_name.of_local conf.name, Redirect p.name)
-                ] )
-          | Coq_theory _ ->
-            (* As of today Coq theories do live in a separate namespace *)
-            [])
+                ] ))
       |> Lib_name.Map.of_list_reducei
            ~f:(fun name (v1 : Found_or_redirect.t) v2 ->
              let res =

--- a/src/dune/lib.mli
+++ b/src/dune/lib.mli
@@ -185,7 +185,6 @@ module DB : sig
       | Library of Path.Build.t * Dune_file.Library.t
       | External_variant of Dune_file.External_variant.t
       | Deprecated_library_name of Dune_file.Deprecated_library_name.t
-      | Coq_theory of Path.Build.t * Dune_file.Coq.t
   end
 
   (** Create a database from a list of library/variants stanzas *)

--- a/src/dune/scope.mli
+++ b/src/dune/scope.mli
@@ -30,6 +30,7 @@ module DB : sig
     -> installed_libs:Lib.DB.t
     -> lib_config:Lib_config.t
     -> Lib.DB.Library_related_stanza.t list
+    -> (Path.Build.t * Dune_file.Coq.t) list
     -> t * Lib.DB.t
 
   val find_by_dir : t -> Path.Build.t -> scope

--- a/src/dune/scope.mli
+++ b/src/dune/scope.mli
@@ -24,13 +24,12 @@ module DB : sig
   type t
 
   (** Return the new scope database as well as the public libraries database *)
-  val create :
+  val create_from_stanzas :
        projects:Dune_project.t list
-    -> context:Context_name.t
+    -> context:Context.t
     -> installed_libs:Lib.DB.t
     -> lib_config:Lib_config.t
-    -> Lib.DB.Library_related_stanza.t list
-    -> (Path.Build.t * Dune_file.Coq.t) list
+    -> Dune_load.Dune_file.t list
     -> t * Lib.DB.t
 
   val find_by_dir : t -> Path.Build.t -> scope

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -429,28 +429,8 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas
       ~external_lib_deps_mode
   in
   let scopes, public_libs =
-    let stanzas =
-      Dune_load.Dune_file.fold_stanzas stanzas ~init:[]
-        ~f:(fun dune_file stanza acc ->
-          match stanza with
-          | Dune_file.Library lib ->
-            let ctx_dir =
-              Path.Build.append_source context.build_dir dune_file.dir
-            in
-            Left (Lib.DB.Library_related_stanza.Library (ctx_dir, lib)) :: acc
-          | Dune_file.External_variant ev -> Left (External_variant ev) :: acc
-          | Dune_file.Deprecated_library_name d ->
-            Left (Deprecated_library_name d) :: acc
-          | Dune_file.Coq.T coq_lib ->
-            let ctx_dir =
-              Path.Build.append_source context.build_dir dune_file.dir
-            in
-            Right (ctx_dir, coq_lib) :: acc
-          | _ -> acc)
-    in
-    let stanzas, coq_stanzas = List.partition_map stanzas ~f:Fun.id in
-    Scope.DB.create ~projects ~context:context.name ~installed_libs ~lib_config
-      stanzas coq_stanzas
+    Scope.DB.create_from_stanzas ~projects ~context ~installed_libs ~lib_config
+      stanzas
   in
   let stanzas =
     List.map stanzas ~f:(fun { Dune_load.Dune_file.dir; project; stanzas } ->

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -437,19 +437,20 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas
             let ctx_dir =
               Path.Build.append_source context.build_dir dune_file.dir
             in
-            Lib.DB.Library_related_stanza.Library (ctx_dir, lib) :: acc
-          | Dune_file.External_variant ev -> External_variant ev :: acc
+            Left (Lib.DB.Library_related_stanza.Library (ctx_dir, lib)) :: acc
+          | Dune_file.External_variant ev -> Left (External_variant ev) :: acc
           | Dune_file.Deprecated_library_name d ->
-            Deprecated_library_name d :: acc
+            Left (Deprecated_library_name d) :: acc
           | Dune_file.Coq.T coq_lib ->
             let ctx_dir =
               Path.Build.append_source context.build_dir dune_file.dir
             in
-            Coq_theory (ctx_dir, coq_lib) :: acc
+            Right (ctx_dir, coq_lib) :: acc
           | _ -> acc)
     in
+    let stanzas, coq_stanzas = List.partition_map stanzas ~f:Fun.id in
     Scope.DB.create ~projects ~context:context.name ~installed_libs ~lib_config
-      stanzas
+      stanzas coq_stanzas
   in
   let stanzas =
     List.map stanzas ~f:(fun { Dune_load.Dune_file.dir; project; stanzas } ->


### PR DESCRIPTION
We make the handling of Coq theories to be independent of `Lib`, which
deals with OCaml libs. This is in preparation for the introduction of
composition with inter-scope public Coq theories.

This is softer alternative to #3280, at the cost of introducing some
uglier code in `Scope`.