### PR TITLE
Delay user errors in Dir_contents

### DIFF
--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -43,6 +43,7 @@ module Crawl = struct
         Dir_contents.get sctx ~dir:(Path.as_in_build_dir_exn src_dir)
         |> Dir_contents.ocaml
         |> Ml_sources.modules_of_library ~name
+        |> Result.ok_exn
         |> Modules.fold_no_vlib ~init:[] ~f:(fun m acc ->
                let source ml_kind =
                  Dyn.Encoder.option dyn_path

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -105,9 +105,15 @@ let expand_path common ~(setup : Dune.Main.build_system) ctx sv =
   in
   let expander = Dune.Super_context.expander sctx ~dir in
   let lookup ~f ~dir name =
-    f (Dune.Dir_contents.artifacts (Dune.Dir_contents.get sctx ~dir)) name
+    f
+      (Result.ok_exn
+         (Dune.Dir_contents.artifacts (Dune.Dir_contents.get sctx ~dir)))
+      name
   in
-  let lookup_module = lookup ~f:Dune.Ml_sources.Artifacts.lookup_module in
+  let lookup_module =
+    lookup ~f:(fun a m ->
+        Result.ok_exn (Dune.Ml_sources.Artifacts.lookup_module a m))
+  in
   let lookup_library = lookup ~f:Dune.Ml_sources.Artifacts.lookup_library in
   let expander = Dune.Expander.set_lookup_module expander ~lookup_module in
   let expander = Dune.Expander.set_lookup_library expander ~lookup_library in

--- a/src/dune/dir_contents.ml
+++ b/src/dune/dir_contents.ml
@@ -119,8 +119,13 @@ end = struct
       } =
     (* Interpret a few stanzas in order to determine the list of files generated
        by the user. *)
-    let lookup ~f ~dir name = f (artifacts (Load.get sctx ~dir)) name in
-    let lookup_module = lookup ~f:Ml_sources.Artifacts.lookup_module in
+    let lookup ~f ~dir name =
+      f (Result.ok_exn (artifacts (Load.get sctx ~dir))) name
+    in
+    let lookup_module =
+      lookup ~f:(fun a m ->
+          Result.ok_exn (Ml_sources.Artifacts.lookup_module a m))
+    in
     let lookup_library = lookup ~f:Ml_sources.Artifacts.lookup_library in
     let expander = Super_context.expander sctx ~dir in
     let expander = Expander.set_lookup_module expander ~lookup_module in

--- a/src/dune/dir_contents.mli
+++ b/src/dune/dir_contents.mli
@@ -25,7 +25,7 @@ val foreign_sources : t -> Foreign_sources.t
 val ocaml : t -> Ml_sources.t
 
 (** Artifacts defined in this directory *)
-val artifacts : t -> Ml_sources.Artifacts.t
+val artifacts : t -> Ml_sources.Artifacts.t Or_exn.t
 
 (** All mld files attached to this documentation stanza *)
 val mlds : t -> Dune_file.Documentation.t -> Path.Build.t list

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -14,6 +14,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   let modules =
     let ml_sources = Dir_contents.ocaml dir_contents in
     Ml_sources.modules_of_executables ml_sources ~first_exe ~obj_dir
+    |> Result.ok_exn
   in
   let pp =
     Preprocessing.make sctx ~dir ~dep_kind:Required ~scope ~expander

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -219,12 +219,9 @@ let expand_str t sw =
 
 module Or_exn = struct
   let expand t ~mode ~template =
-    match
-      String_with_vars.expand ~dir:(Path.build t.dir) ~mode template
-        ~f:(expand_var_exn t)
-    with
-    | x -> Ok x
-    | exception (User_error.E _ as e) -> Error e
+    User_error.catch (fun () ->
+        String_with_vars.expand ~dir:(Path.build t.dir) ~mode template
+          ~f:(expand_var_exn t))
 
   let expand_path t sw =
     expand t ~mode:Single ~template:sw

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -202,12 +202,13 @@ let gen_rules sctx dir_contents cctxs
   let expander =
     let lookup_module ~dir name =
       Ml_sources.Artifacts.lookup_module
-        (Dir_contents.artifacts (Dir_contents.get sctx ~dir))
+        (Result.ok_exn (Dir_contents.artifacts (Dir_contents.get sctx ~dir)))
         name
+      |> Result.ok_exn
     in
     let lookup_library ~dir name =
       Ml_sources.Artifacts.lookup_library
-        (Dir_contents.artifacts (Dir_contents.get sctx ~dir))
+        (Result.ok_exn (Dir_contents.artifacts (Dir_contents.get sctx ~dir)))
         name
     in
     Expander.set_lookup_library
@@ -256,8 +257,10 @@ let gen_rules sctx dir_contents cctxs
         let ml_sources = Dir_contents.ocaml dir_contents in
         match
           List.find_map (Menhir_rules.module_names m) ~f:(fun name ->
-              Option.bind (Ml_sources.lookup_module ml_sources name)
-                ~f:(fun buildable ->
+              let module_ =
+                Result.ok_exn (Ml_sources.lookup_module ml_sources name)
+              in
+              Option.bind module_ ~f:(fun buildable ->
                   List.find_map cctxs ~f:(fun (loc, cctx) ->
                       Option.some_if (Loc.equal loc buildable.loc) cctx)))
         with

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -69,6 +69,7 @@ end = struct
     let installable_modules =
       Dir_contents.ocaml dir_contents
       |> Ml_sources.modules_of_library ~name:(Library.best_name lib)
+      |> Result.ok_exn
       |> Modules.fold_no_vlib ~init:[] ~f:(fun m acc -> m :: acc)
     in
     let sources =
@@ -362,6 +363,7 @@ let gen_dune_package sctx pkg =
                 let modules =
                   Dir_contents.ocaml dir_contents
                   |> Ml_sources.modules_of_library ~name
+                  |> Result.ok_exn
                 in
                 Lib_name.Map.add_exn acc name
                   (Library

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -14,7 +14,9 @@ let has_native_archive lib config contents =
   ||
   let name = Dune_file.Library.best_name lib in
   let ml_sources = Dir_contents.ocaml contents in
-  let modules = Ml_sources.modules_of_library ml_sources ~name in
+  let modules =
+    Result.ok_exn (Ml_sources.modules_of_library ml_sources ~name)
+  in
   not (Modules.is_empty modules)
 
 module Library = Dune_file.Library

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -421,6 +421,7 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope :
     let source_modules =
       Dir_contents.ocaml dir_contents
       |> Ml_sources.modules_of_library ~name:(Library.best_name lib)
+      |> Result.ok_exn
     in
     let cctx =
       cctx lib ~sctx ~source_modules ~dir ~scope ~expander ~compile_info

--- a/src/dune/merlin.ml
+++ b/src/dune/merlin.ml
@@ -207,6 +207,7 @@ let lib_src_dirs ~sctx lib =
     let modules =
       Dir_contents.get sctx ~dir |> Dir_contents.ocaml
       |> Ml_sources.modules_of_library ~name
+      |> Result.ok_exn
     in
     Path.Set.map ~f:Path.drop_optional_build_context
       (Modules.source_dirs modules)

--- a/src/dune/ml_sources.mli
+++ b/src/dune/ml_sources.mli
@@ -9,24 +9,24 @@ module Artifacts : sig
   type t
 
   val lookup_module :
-    t -> Module_name.t -> (Path.Build.t Obj_dir.t * Module.t) option
+    t -> Module_name.t -> (Path.Build.t Obj_dir.t * Module.t) option Or_exn.t
 
   val lookup_library : t -> Lib_name.t -> Dune_file.Library.t option
 end
 
 type t
 
-val artifacts : t -> Artifacts.t
+val artifacts : t -> Artifacts.t Or_exn.t
 
 (** Modules attached to a library. [name] is the library best name. *)
-val modules_of_library : t -> name:Lib_name.t -> Modules.t
+val modules_of_library : t -> name:Lib_name.t -> Modules.t Or_exn.t
 
 (** Modules attached to a set of executables. *)
 val modules_of_executables :
-  t -> obj_dir:Path.Build.t Obj_dir.t -> first_exe:string -> Modules.t
+  t -> obj_dir:Path.Build.t Obj_dir.t -> first_exe:string -> Modules.t Or_exn.t
 
 (** Find out what buildable a module is part of *)
-val lookup_module : t -> Module_name.t -> Dune_file.Buildable.t option
+val lookup_module : t -> Module_name.t -> Dune_file.Buildable.t option Or_exn.t
 
 val empty : t
 

--- a/src/dune/odoc.ml
+++ b/src/dune/odoc.ml
@@ -434,6 +434,7 @@ let odocs sctx target =
       let name = Lib_info.name info in
       Dir_contents.get sctx ~dir |> Dir_contents.ocaml
       |> Ml_sources.modules_of_library ~name
+      |> Result.ok_exn
     in
     let obj_dir = Lib_info.obj_dir info in
     Modules.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
@@ -548,7 +549,7 @@ let entry_modules_by_lib sctx lib =
   let name = Lib.name (Lib.Local.to_lib lib) in
   Dir_contents.get sctx ~dir |> Dir_contents.ocaml
   |> Ml_sources.modules_of_library ~name
-  |> Modules.entry_modules
+  |> Result.ok_exn |> Modules.entry_modules
 
 let entry_modules sctx ~pkg =
   libs_of_pkg sctx ~pkg

--- a/src/dune/virtual_rules.ml
+++ b/src/dune/virtual_rules.ml
@@ -115,6 +115,7 @@ let impl sctx ~(lib : Dune_file.Library.t) ~scope =
               in
               Dir_contents.ocaml dir_contents
               |> Ml_sources.modules_of_library ~name
+              |> Result.ok_exn
               |> Modules.map_user_written ~f:(Pp_spec.pped_module pp_spec)
             in
             let foreign_objects =

--- a/src/stdune/user_error.ml
+++ b/src/stdune/user_error.ml
@@ -8,6 +8,11 @@ let make ?loc ?hints paragraphs =
 
 let raise ?loc ?hints paragraphs = raise (E (make ?loc ?hints paragraphs))
 
+let catch f =
+  match f () with
+  | x -> Ok x
+  | exception (E _ as e) -> Error e
+
 let () =
   Printexc.register_printer (function
     | E t ->

--- a/src/stdune/user_error.mli
+++ b/src/stdune/user_error.mli
@@ -22,3 +22,5 @@ val make :
 
 (** The "Error:" prefix *)
 val prefix : User_message.Style.t Pp.t
+
+val catch : (unit -> 'a) -> 'a Or_exn.t


### PR DESCRIPTION
User errors should be presented only when the rule is used to build a
target. This commit moves towards that by allowing callers to setup
rules prefixed with the exceptions.