### PR TITLE
[tests] toplevel-integration has external dep

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -2900,7 +2900,6 @@
   (alias tests-stanza)
   (alias tests-stanza-action)
   (alias tests-stanza-action-syntax-version)
-  (alias toplevel-integration)
   (alias toplevel-stanza)
   (alias trace-file)
   (alias transitive-deps-mode)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -252,6 +252,7 @@ let exclusions =
   ; make "pkg-config-quoting"
       ~additional_deps:[ Sexp.strings [ "package"; "dune-configurator" ] ]
   ; make "mdx-stanza" ~external_deps:true
+  ; make "toplevel-integration" ~external_deps:true
   ]
   |> String_map.of_list_map_exn ~f:(fun (test : Test.t) -> (test.path, test))
 


### PR DESCRIPTION
topfind is provided by ocamlfind