### PR TITLE
Replace all the Decoder.if_* functions by a single Decoder.alt

### DIFF
--- a/src/dune/action_dune_lang.ml
+++ b/src/dune/action_dune_lang.ml
@@ -93,16 +93,14 @@ let compare_no_locs t1 t2 = Poly.compare (remove_locs t1) (remove_locs t2)
 open Dune_lang.Decoder
 
 let decode =
-  alt
-    [ (let+ loc, action = located decode in
-       validate ~loc action;
-       action)
-    ; (let+ loc = loc in
-       User_error.raise ~loc
-         [ Pp.textf
-             "if you meant for this to be executed with bash, write (bash \
-              \"...\") instead"
-         ])
-    ]
+  (let+ loc, action = located decode in
+   validate ~loc action;
+   action)
+  <|> let+ loc = loc in
+      User_error.raise ~loc
+        [ Pp.textf
+            "if you meant for this to be executed with bash, write (bash \
+             \"...\") instead"
+        ]
 
 let to_dyn a = Dune_lang.to_dyn (encode a)

--- a/src/dune/action_dune_lang.ml
+++ b/src/dune/action_dune_lang.ml
@@ -93,17 +93,16 @@ let compare_no_locs t1 t2 = Poly.compare (remove_locs t1) (remove_locs t2)
 open Dune_lang.Decoder
 
 let decode =
-  if_list
-    ~then_:
-      ( located decode >>| fun (loc, action) ->
-        validate ~loc action;
-        action )
-    ~else_:
-      ( loc >>| fun loc ->
-        User_error.raise ~loc
-          [ Pp.textf
-              "if you meant for this to be executed with bash, write (bash \
-               \"...\") instead"
-          ] )
+  alt
+    [ (let+ loc, action = located decode in
+       validate ~loc action;
+       action)
+    ; (let+ loc = loc in
+       User_error.raise ~loc
+         [ Pp.textf
+             "if you meant for this to be executed with bash, write (bash \
+              \"...\") instead"
+         ])
+    ]
 
 let to_dyn a = Dune_lang.to_dyn (encode a)

--- a/src/dune/bindings.ml
+++ b/src/dune/bindings.ml
@@ -39,17 +39,15 @@ let to_dyn dyn_of_a bindings =
 let decode elem =
   let+ l =
     repeat
-      (alt
-         [ enter
-             (let+ loc, name =
-                located
-                  (atom_matching ~desc:"Atom of the form :<name>"
-                     (String.drop_prefix ~prefix:":"))
-              and+ values = repeat elem in
-              Left (loc, name, values))
-         ; (let+ value = elem in
-            Right value)
-         ])
+      ( enter
+          (let+ loc, name =
+             located
+               (atom_matching ~desc:"Atom of the form :<name>"
+                  (String.drop_prefix ~prefix:":"))
+           and+ values = repeat elem in
+           Left (loc, name, values))
+      <|> let+ value = elem in
+          Right value )
   in
   let rec loop vars acc = function
     | [] -> List.rev acc

--- a/src/dune/bindings.ml
+++ b/src/dune/bindings.ml
@@ -39,11 +39,17 @@ let to_dyn dyn_of_a bindings =
 let decode elem =
   let+ l =
     repeat
-      (if_paren_colon_form
-         ~then_:
-           (let+ values = repeat elem in
-            fun (loc, name) -> Left (loc, name, values))
-         ~else_:(elem >>| Either.right))
+      (alt
+         [ enter
+             (let+ loc, name =
+                located
+                  (atom_matching ~desc:"Atom of the form :<name>"
+                     (String.drop_prefix ~prefix:":"))
+              and+ values = repeat elem in
+              Left (loc, name, values))
+         ; (let+ value = elem in
+            Right value)
+         ])
   in
   let rec loop vars acc = function
     | [] -> List.rev acc

--- a/src/dune/blang.ml
+++ b/src/dune/blang.ml
@@ -80,14 +80,12 @@ let decode =
   in
   let decode =
     fix (fun t ->
-        alt
-          [ sum
-              ( ("or", repeat t >>| fun x -> Or x)
-              :: ("and", repeat t >>| fun x -> And x)
-              :: ops )
-          ; (let+ v = String_with_vars.decode in
-             Expr v)
-          ])
+        sum
+          ( ("or", repeat t >>| fun x -> Or x)
+          :: ("and", repeat t >>| fun x -> And x)
+          :: ops )
+        <|> let+ v = String_with_vars.decode in
+            Expr v)
   in
   let+ () = Dune_lang.Syntax.since Stanza.syntax (1, 1)
   and+ decode = decode in

--- a/src/dune/blang.ml
+++ b/src/dune/blang.ml
@@ -80,7 +80,7 @@ let decode =
   in
   let decode =
     fix (fun t ->
-        sum
+        sum ~force_parens:true
           ( ("or", repeat t >>| fun x -> Or x)
           :: ("and", repeat t >>| fun x -> And x)
           :: ops )

--- a/src/dune/blang.ml
+++ b/src/dune/blang.ml
@@ -80,14 +80,14 @@ let decode =
   in
   let decode =
     fix (fun t ->
-        if_list
-          ~then_:
-            ( [ ("or", repeat t >>| fun x -> Or x)
-              ; ("and", repeat t >>| fun x -> And x)
-              ]
-              @ ops
-            |> sum )
-          ~else_:(String_with_vars.decode >>| fun v -> Expr v))
+        alt
+          [ sum
+              ( ("or", repeat t >>| fun x -> Or x)
+              :: ("and", repeat t >>| fun x -> And x)
+              :: ops )
+          ; (let+ v = String_with_vars.decode in
+             Expr v)
+          ])
   in
   let+ () = Dune_lang.Syntax.since Stanza.syntax (1, 1)
   and+ decode = decode in

--- a/src/dune/dep_conf.ml
+++ b/src/dune/dep_conf.ml
@@ -61,7 +61,11 @@ let decode =
       ; ("sandbox", decode_sandbox_config >>| fun x -> Sandbox_config x)
       ]
   in
-  if_list ~then_:decode ~else_:(String_with_vars.decode >>| fun x -> File x)
+  alt
+    [ decode
+    ; (let+ x = String_with_vars.decode in
+       File x)
+    ]
 
 open Dune_lang
 

--- a/src/dune/dep_conf.ml
+++ b/src/dune/dep_conf.ml
@@ -61,11 +61,9 @@ let decode =
       ; ("sandbox", decode_sandbox_config >>| fun x -> Sandbox_config x)
       ]
   in
-  alt
-    [ decode
-    ; (let+ x = String_with_vars.decode in
-       File x)
-    ]
+  decode
+  <|> let+ x = String_with_vars.decode in
+      File x
 
 open Dune_lang
 

--- a/src/dune/dep_conf.ml
+++ b/src/dune/dep_conf.ml
@@ -41,7 +41,7 @@ let decode_sandbox_config =
 let decode =
   let decode =
     let sw = String_with_vars.decode in
-    sum
+    sum ~force_parens:true
       [ ("file", sw >>| fun x -> File x)
       ; ("alias", sw >>| fun x -> Alias x)
       ; ("alias_rec", sw >>| fun x -> Alias_rec x)

--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -178,11 +178,11 @@ module Stanza = struct
   let rule =
     enter
       (let+ pat =
-         match_keyword
-           [ ("_", return Any) ]
-           ~fallback:
-             (let+ p = Profile.decode in
+         alt
+           [ keyword "_" >>> return Any
+           ; (let+ p = Profile.decode in
               Profile p)
+           ]
        and+ configs = fields config in
        (pat, configs))
 

--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -178,11 +178,9 @@ module Stanza = struct
   let rule =
     enter
       (let+ pat =
-         alt
-           [ keyword "_" >>> return Any
-           ; (let+ p = Profile.decode in
-              Profile p)
-           ]
+         keyword "_" >>> return Any
+         <|> let+ p = Profile.decode in
+             Profile p
        and+ configs = fields config in
        (pat, configs))
 

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1303,13 +1303,11 @@ module Executables = struct
     let simple = Dune_lang.Decoder.enum simple_representations
 
     let decode =
-      alt
-        [ enter
-            (let+ mode = Mode_conf.decode
-             and+ kind = Binary_kind.decode in
-             make mode kind)
-        ; simple
-        ]
+      enter
+        (let+ mode = Mode_conf.decode
+         and+ kind = Binary_kind.decode in
+         make mode kind)
+      <|> simple
 
     let simple_encode link_mode =
       let is_ok (_, candidate) = compare candidate link_mode = Eq in
@@ -1743,16 +1741,14 @@ module Rule = struct
     }
 
   let ocamllex =
-    alt
-      [ enter
-          (fields
-             (let+ modules = field "modules" (repeat string)
-              and+ mode = Mode.field
-              and+ enabled_if = enabled_if ~since:(Some (1, 4)) in
-              { modules; mode; enabled_if }))
-      ; (let+ modules = repeat string in
-         { modules; mode = Standard; enabled_if = Blang.true_ })
-      ]
+    enter
+      (fields
+         (let+ modules = field "modules" (repeat string)
+          and+ mode = Mode.field
+          and+ enabled_if = enabled_if ~since:(Some (1, 4)) in
+          { modules; mode; enabled_if }))
+    <|> let+ modules = repeat string in
+        { modules; mode = Standard; enabled_if = Blang.true_ }
 
   let ocamlyacc = ocamllex
 

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1741,14 +1741,13 @@ module Rule = struct
     }
 
   let ocamllex =
-    enter
-      (fields
-         (let+ modules = field "modules" (repeat string)
-          and+ mode = Mode.field
-          and+ enabled_if = enabled_if ~since:(Some (1, 4)) in
-          { modules; mode; enabled_if }))
-    <|> let+ modules = repeat string in
-        { modules; mode = Standard; enabled_if = Blang.true_ }
+    (let+ modules = repeat string in
+     { modules; mode = Standard; enabled_if = Blang.true_ })
+    <|> fields
+          (let+ modules = field "modules" (repeat string)
+           and+ mode = Mode.field
+           and+ enabled_if = enabled_if ~since:(Some (1, 4)) in
+           { modules; mode; enabled_if })
 
   let ocamlyacc = ocamllex
 

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -414,7 +414,7 @@ module Buildable = struct
            (field ~default:None "self_build_stubs_archive"
               ( Dune_lang.Syntax.deleted_in Stanza.syntax (2, 0)
                   ~extra_info:"Use the (foreign_archives ...) field instead."
-              >>> option string )))
+              >>> enter (maybe string) )))
     and+ modules_without_implementation =
       modules_field "modules_without_implementation"
     and+ libraries =
@@ -1303,13 +1303,13 @@ module Executables = struct
     let simple = Dune_lang.Decoder.enum simple_representations
 
     let decode =
-      if_list
-        ~then_:
-          (enter
-             (let+ mode = Mode_conf.decode
-              and+ kind = Binary_kind.decode in
-              make mode kind))
-        ~else_:simple
+      alt
+        [ enter
+            (let+ mode = Mode_conf.decode
+             and+ kind = Binary_kind.decode in
+             make mode kind)
+        ; simple
+        ]
 
     let simple_encode link_mode =
       let is_ok (_, candidate) = compare candidate link_mode = Eq in
@@ -1743,20 +1743,16 @@ module Rule = struct
     }
 
   let ocamllex =
-    if_eos
-      ~then_:
-        (return { modules = []; mode = Standard; enabled_if = Blang.true_ })
-      ~else_:
-        (if_list
-           ~then_:
-             (fields
-                (let+ modules = field "modules" (repeat string)
-                 and+ mode = Mode.field
-                 and+ enabled_if = enabled_if ~since:(Some (1, 4)) in
-                 { modules; mode; enabled_if }))
-           ~else_:
-             ( repeat string >>| fun modules ->
-               { modules; mode = Standard; enabled_if = Blang.true_ } ))
+    alt
+      [ enter
+          (fields
+             (let+ modules = field "modules" (repeat string)
+              and+ mode = Mode.field
+              and+ enabled_if = enabled_if ~since:(Some (1, 4)) in
+              { modules; mode; enabled_if }))
+      ; (let+ modules = repeat string in
+         { modules; mode = Standard; enabled_if = Blang.true_ })
+      ]
 
   let ocamlyacc = ocamllex
 

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -183,7 +183,7 @@ module Stubs = struct
         let+ loc, lib_name = sum [ ("lib", located Lib_name.decode) ] in
         Lib (loc, lib_name)
       in
-      if_list ~then_:parse_lib ~else_:parse_dir
+      alt [ parse_lib; parse_dir ]
   end
 
   type t =

--- a/src/dune/foreign.ml
+++ b/src/dune/foreign.ml
@@ -183,7 +183,7 @@ module Stubs = struct
         let+ loc, lib_name = sum [ ("lib", located Lib_name.decode) ] in
         Lib (loc, lib_name)
       in
-      alt [ parse_lib; parse_dir ]
+      parse_lib <|> parse_dir
   end
 
   type t =

--- a/src/dune/format_config.ml
+++ b/src/dune/format_config.ml
@@ -96,11 +96,7 @@ let dune2_record_syntax =
   Some { loc; enabled_for }
 
 let dune2_dec =
-  if_list
-    ~then_:(fields dune2_record_syntax)
-    ~else_:
-      (let+ () = keyword "disabled" in
-       None)
+  alt [ keyword "disabled" >>> return None; fields dune2_record_syntax ]
 
 let dune2_default = Some { loc = Loc.none; enabled_for = Enabled_for.All }
 

--- a/src/dune/format_config.ml
+++ b/src/dune/format_config.ml
@@ -96,7 +96,7 @@ let dune2_record_syntax =
   Some { loc; enabled_for }
 
 let dune2_dec =
-  alt [ keyword "disabled" >>> return None; fields dune2_record_syntax ]
+  keyword "disabled" >>> return None <|> fields dune2_record_syntax
 
 let dune2_default = Some { loc = Loc.none; enabled_for = Enabled_for.All }
 

--- a/src/dune/inline_tests.ml
+++ b/src/dune/inline_tests.ml
@@ -169,15 +169,6 @@ include Sub_system.Register_end_point (struct
 
     type Sub_system_info.t += T of t
 
-    let empty loc =
-      { loc
-      ; deps = []
-      ; flags = Ordered_set_lang.Unexpanded.standard
-      ; backend = None
-      ; modes = Mode_conf.Set.default
-      ; libraries = []
-      }
-
     let loc t = t.loc
 
     let backends t = Option.map t.backend ~f:(fun x -> [ x ])
@@ -187,22 +178,19 @@ include Sub_system.Register_end_point (struct
     open Dune_lang.Decoder
 
     let decode =
-      if_eos ~then_:(loc >>| empty)
-        ~else_:
-          (fields
-             (let+ loc = loc
-              and+ deps = field "deps" (repeat Dep_conf.decode) ~default:[]
-              and+ flags = Ordered_set_lang.Unexpanded.field "flags"
-              and+ backend = field_o "backend" (located Lib_name.decode)
-              and+ libraries =
-                field "libraries" (repeat (located Lib_name.decode)) ~default:[]
-              and+ modes =
-                field "modes"
-                  ( Dune_lang.Syntax.since syntax (1, 11)
-                  >>> Mode_conf.Set.decode )
-                  ~default:Mode_conf.Set.default
-              in
-              { loc; deps; flags; backend; libraries; modes }))
+      fields
+        (let+ loc = loc
+         and+ deps = field "deps" (repeat Dep_conf.decode) ~default:[]
+         and+ flags = Ordered_set_lang.Unexpanded.field "flags"
+         and+ backend = field_o "backend" (located Lib_name.decode)
+         and+ libraries =
+           field "libraries" (repeat (located Lib_name.decode)) ~default:[]
+         and+ modes =
+           field "modes"
+             (Dune_lang.Syntax.since syntax (1, 11) >>> Mode_conf.Set.decode)
+             ~default:Mode_conf.Set.default
+         in
+         { loc; deps; flags; backend; libraries; modes })
 
     (* We don't use this at the moment, but we could implement it for debugging
        purposes *)

--- a/src/dune/lib_dep.ml
+++ b/src/dune/lib_dep.ml
@@ -124,7 +124,7 @@ let decode ~allow_re_export =
   let open Dune_lang.Decoder in
   let+ loc, t =
     located
-      ( sum
+      ( sum ~force_parens:true
           [ ( "re_export"
             , let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
               and+ loc, name = located Lib_name.decode in

--- a/src/dune/lib_dep.ml
+++ b/src/dune/lib_dep.ml
@@ -124,19 +124,17 @@ let decode ~allow_re_export =
   let open Dune_lang.Decoder in
   let+ loc, t =
     located
-      (alt
-         [ sum
-             [ ( "re_export"
-               , let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
-                 and+ loc, name = located Lib_name.decode in
-                 Re_export (loc, name) )
-             ; ( "select"
-               , let+ select = Select.decode in
-                 Select select )
-             ]
-         ; (let+ loc, name = located Lib_name.decode in
-            Direct (loc, name))
-         ])
+      ( sum
+          [ ( "re_export"
+            , let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
+              and+ loc, name = located Lib_name.decode in
+              Re_export (loc, name) )
+          ; ( "select"
+            , let+ select = Select.decode in
+              Select select )
+          ]
+      <|> let+ loc, name = located Lib_name.decode in
+          Direct (loc, name) )
   in
   match t with
   | Re_export _ when not allow_re_export ->

--- a/src/dune/lib_dep.ml
+++ b/src/dune/lib_dep.ml
@@ -122,25 +122,26 @@ let to_lib_names = function
 
 let decode ~allow_re_export =
   let open Dune_lang.Decoder in
-  if_list
-    ~then_:
-      (enter
-         (let* cloc, constr = located string in
-          match constr with
-          | "re_export" ->
-            if not allow_re_export then
-              User_error.raise ~loc:cloc
-                [ Pp.text "re_export is not allowed here" ];
-            let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
-            and+ loc, name = located Lib_name.decode in
-            Re_export (loc, name)
-          | "select" ->
-            let+ select = Select.decode in
-            Select select
-          | _ -> User_error.raise ~loc:cloc [ Pp.text "invalid constructor" ]))
-    ~else_:
-      (let+ loc, name = located Lib_name.decode in
-       Direct (loc, name))
+  let+ loc, t =
+    located
+      (alt
+         [ sum
+             [ ( "re_export"
+               , let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
+                 and+ loc, name = located Lib_name.decode in
+                 Re_export (loc, name) )
+             ; ( "select"
+               , let+ select = Select.decode in
+                 Select select )
+             ]
+         ; (let+ loc, name = located Lib_name.decode in
+            Direct (loc, name))
+         ])
+  in
+  match t with
+  | Re_export _ when not allow_re_export ->
+    User_error.raise ~loc [ Pp.text "re_export is not allowed here" ]
+  | _ -> t
 
 let encode =
   let open Dune_lang.Encoder in

--- a/src/dune/mdx.ml
+++ b/src/dune/mdx.ml
@@ -105,7 +105,7 @@ module Prelude = struct
       let+ file = path in
       Default file
     in
-    if_list ~then_:(enter decode_env) ~else_:decode_default
+    alt [ enter decode_env; decode_default ]
 
   let to_args ~dir t : _ Command.Args.t list =
     let bpath p = Path.build (Path.Build.append_local dir p) in

--- a/src/dune/mdx.ml
+++ b/src/dune/mdx.ml
@@ -105,7 +105,7 @@ module Prelude = struct
       let+ file = path in
       Default file
     in
-    alt [ enter decode_env; decode_default ]
+    enter decode_env <|> decode_default
 
   let to_args ~dir t : _ Command.Args.t list =
     let bpath p = Path.build (Path.Build.append_local dir p) in

--- a/src/dune/package.ml
+++ b/src/dune/package.ml
@@ -179,11 +179,9 @@ module Dependency = struct
       and+ expr = Constraint.decode in
       { name; constraint_ = Some expr }
     in
-    alt
-      [ enter constrained
-      ; (let+ name = Name.decode in
-         { name; constraint_ = None })
-      ]
+    enter constrained
+    <|> let+ name = Name.decode in
+        { name; constraint_ = None }
 
   let rec opam_constraint : Constraint.t -> OpamParserTypes.value =
     let nopos = Opam_file.nopos in

--- a/src/dune/package.ml
+++ b/src/dune/package.ml
@@ -123,11 +123,7 @@ module Dependency = struct
         List.map Op.map ~f:(fun (name, op) ->
             ( name
             , let+ x = Var.decode
-              and+ y =
-                if_eos ~then_:(return None)
-                  ~else_:
-                    (let+ v = Var.decode in
-                     Some v)
+              and+ y = maybe Var.decode
               and+ loc = loc
               and+ version = Dune_lang.Syntax.get_exn Stanza.syntax in
               match y with
@@ -183,10 +179,11 @@ module Dependency = struct
       and+ expr = Constraint.decode in
       { name; constraint_ = Some expr }
     in
-    if_list ~then_:(enter constrained)
-      ~else_:
-        (let+ name = Name.decode in
+    alt
+      [ enter constrained
+      ; (let+ name = Name.decode in
          { name; constraint_ = None })
+      ]
 
   let rec opam_constraint : Constraint.t -> OpamParserTypes.value =
     let nopos = Opam_file.nopos in

--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -138,19 +138,11 @@ let loc : type k. k context -> k -> Loc.t * k =
   | Values (loc, _, _) -> (loc, state)
   | Fields (loc, _, _) -> (loc, state)
 
-let at_eos : type k. k context -> k -> bool =
+let eos : type k. k context -> k -> bool * k =
  fun ctx state ->
   match ctx with
-  | Values _ -> state = []
-  | Fields _ -> Name.Map.is_empty state.unparsed
-
-let eos ctx state = (at_eos ctx state, state)
-
-let if_eos ~then_ ~else_ ctx state =
-  if at_eos ctx state then
-    then_ ctx state
-  else
-    else_ ctx state
+  | Values _ -> (state = [], state)
+  | Fields _ -> (Name.Map.is_empty state.unparsed, state)
 
 let repeat : 'a t -> 'a list t =
   let rec loop t acc ctx l =
@@ -238,17 +230,20 @@ let junk_everything : type k. (unit, k) parser =
 
 let keyword kwd =
   next (function
-    | Atom (_, s) when Atom.to_string s = kwd -> ()
+    | Atom (_, A s) when s = kwd -> ()
     | sexp ->
       User_error.raise ~loc:(Ast.loc sexp) [ Pp.textf "'%s' expected" kwd ])
 
-let match_keyword l ~fallback =
-  peek >>= function
-  | Some (Atom (_, A s)) -> (
-    match List.assoc l s with
-    | Some t -> junk >>> t
-    | None -> fallback )
-  | _ -> fallback
+let atom_matching f ~desc =
+  next (fun sexp ->
+      match
+        match sexp with
+        | Atom (_, A s) -> f s
+        | _ -> None
+      with
+      | Some x -> x
+      | None ->
+        User_error.raise ~loc:(Ast.loc sexp) [ Pp.textf "%s expected" desc ])
 
 let until_keyword kwd ~before ~after =
   let rec loop acc =
@@ -286,19 +281,33 @@ let enter t =
         result ctx (t ctx l)
       | sexp -> User_error.raise ~loc:(Ast.loc sexp) [ Pp.text "List expected" ])
 
-let if_list ~then_ ~else_ =
-  peek_exn >>= function
-  | List _ -> then_
-  | _ -> else_
-
-let if_paren_colon_form ~then_ ~else_ =
-  peek_exn >>= function
-  | List (_, Atom (loc, A s) :: _) when String.is_prefix s ~prefix:":" ->
-    let name = String.drop s 1 in
-    enter
-      ( junk >>= fun () ->
-        then_ >>| fun f -> f (loc, name) )
-  | _ -> else_
+let alt =
+  (* Before you read this code, close your eyes and internalise the fact that
+     this code is temporary. It is a temporary state as part of a larger work to
+     turn [Decoder.t] into a pure applicative. Once this is done, this function
+     will be implemented in a better way and with a much cleaner semantic. *)
+  let approximate_how_much_input_a_failing_branch_consumed
+      (exn : Exn_with_backtrace.t) =
+    Printexc.raw_backtrace_length exn.backtrace
+  in
+  let compare_input_consumed exn1 exn2 =
+    Int.compare
+      (approximate_how_much_input_a_failing_branch_consumed exn1)
+      (approximate_how_much_input_a_failing_branch_consumed exn2)
+  in
+  let best_error_candidate exns =
+    List.max exns ~f:compare_input_consumed |> Option.value_exn
+  in
+  let rec loop errors ts ctx state =
+    match ts with
+    | [] -> Exn_with_backtrace.reraise (best_error_candidate errors)
+    | t :: ts -> (
+      try t ctx state
+      with exn ->
+        let exn = Exn_with_backtrace.capture exn in
+        loop (exn :: errors) ts ctx state )
+  in
+  fun ts ctx state -> loop [] ts ctx state
 
 let fix f =
   let rec p = lazy (f r)
@@ -423,11 +432,7 @@ let bytes_unit =
     ; ("GB", 1000 * 1000 * 1000)
     ]
 
-let option t =
-  enter
-    (eos >>= function
-     | true -> return None
-     | false -> t >>| Option.some)
+let maybe t = alt [ t >>| Option.some; return None ]
 
 let find_cstr cstrs loc name ctx values =
   match List.assoc cstrs name with

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -179,8 +179,11 @@ val enum : (string * 'a) list -> 'a t
 (** Parser that parse a S-expression of the form
     [(<atom> <s-exp1> <s-exp2> ...)] or [<atom>]. [<atom>] is looked up in the
     list and the remaining s-expressions are parsed using the corresponding list
-    parser. *)
-val sum : (string * 'a t) list -> 'a t
+    parser.
+
+    If [force_parens] is [true], then the form [<atom>] is never accepted. The
+    default is [false]. *)
+val sum : ?force_parens:bool -> (string * 'a t) list -> 'a t
 
 (** Check the result of a list parser, and raise a properly located error in
     case of failure. *)

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -75,10 +75,10 @@ val set_many : Univ_map.t -> ('a, 'k) parser -> ('a, 'k) parser
 (** Return the location of the list currently being parsed. *)
 val loc : (Loc.t, _) parser
 
-(** [alt l] tries all the parser in [l] in sequence and uses the first one that
-    succeeds. If they all fail, the error from the one that consumed the most
-    input is returned. *)
-val alt : 'a t list -> 'a t
+(** [a <|> b] is either [a] or [b]. If [a] fails to parse the input, then try
+    [b]. If [b] fails as well, raise the error from the parser that consumed the
+    most input. *)
+val ( <|> ) : 'a t -> 'a t -> 'a t
 
 (** [atom_matching f] expects the next element to be an atom for which [f]
     returns [Some v]. [desc] is used to describe the atom in case of error. [f]
@@ -135,11 +135,9 @@ val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
 (** [maybe t] is a short-hand for:
 
     {[
-      alt
-        [ (let+ x = t in
-           Some x)
-        ; return None
-        ]
+      (let+ x = t in
+       Some x)
+      <|> return None
     ]} *)
 val maybe : 'a t -> 'a option t
 

--- a/test/blackbox-tests/test-cases/cmdliner-dep-conf/run.t
+++ b/test/blackbox-tests/test-cases/cmdliner-dep-conf/run.t
@@ -20,7 +20,7 @@
   [1]
 
   $ dune build "()"
-  dune: TARGET... arguments: Non-empty list expected
+  dune: TARGET... arguments: Unexpected list
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/re-exported-deps/run.t
+++ b/test/blackbox-tests/test-cases/re-exported-deps/run.t
@@ -43,8 +43,8 @@ transtive deps expressed in the dune-package
 Re-exporting deps in executables isn't allowed
   $ dune build --root re-export-exe @all
   Entering directory 're-export-exe'
-  File "dune", line 7, characters 13-22:
+  File "dune", line 7, characters 12-27:
   7 |  (libraries (re_export foo)))
-                   ^^^^^^^^^
+                  ^^^^^^^^^^^^^^^
   Error: re_export is not allowed here
   [1]


### PR DESCRIPTION
This is part of a larger work to make `Decoder.t` a pure applicative (or selective, will see how it goes). Once we remove `Decoder.(>>=)`, we need a lot more specialised `if_xxx` functions. To avoid their proliferation, this PR proposes to replace them all by a single and general `alt` combinator that tries a list of parsers in sequence and uses the first one that succeeds:

```ocaml
val alt : 'a t list -> 'a t
```

The difficult part is to decide which error to reraise when they all fail. Ideally, we want to reraise the one from the branch that matched the most structural elements. This is difficult to implement right now, so I used a rubbish implementation that will lead to bad error messages in some cases. However, once `Decoder.t` is a pure applicative, it should be easier to change it and even show a grammar of what is accepted to the user in case of error.