### PR TITLE
[coq] Allow implicit composition with the boot theory.

### DIFF
--- a/src/dune/coq_lib.ml
+++ b/src/dune/coq_lib.ml
@@ -12,6 +12,7 @@ open! Stdune
 type t =
   { name : Loc.t * Coq_lib_name.t
   ; wrapper : string
+  ; implicit : bool (* Only useful for the stdlib *)
   ; src_root : Path.Build.t
   ; obj_root : Path.Build.t
   ; theories : (Loc.t * Coq_lib_name.t) list
@@ -20,6 +21,8 @@ type t =
   }
 
 let name l = snd l.name
+
+let implicit l = l.implicit
 
 let location l = fst l.name
 
@@ -84,6 +87,7 @@ module DB = struct
     ( name
     , { name = s.name
       ; wrapper = Coq_lib_name.wrapper name
+      ; implicit = s.boot
       ; obj_root = dir
       ; src_root = dir
       ; theories = s.buildable.theories

--- a/src/dune/coq_lib.mli
+++ b/src/dune/coq_lib.mli
@@ -8,6 +8,8 @@ type t
 
 val name : t -> Coq_lib_name.t
 
+val implicit : t -> bool
+
 (* this is not really a wrapper for the prefix path *)
 val wrapper : t -> string
 

--- a/src/dune/coq_rules.ml
+++ b/src/dune/coq_rules.ml
@@ -107,7 +107,8 @@ module Context = struct
     let setup_theory_flag lib =
       let wrapper = Coq_lib.wrapper lib in
       let dir = Coq_lib.src_root lib in
-      [ Command.Args.A "-Q"; Path (Path.build dir); A wrapper ]
+      let binding_flag = if Coq_lib.implicit lib then "-R" else "-Q" in
+      [ Command.Args.A binding_flag; Path (Path.build dir); A wrapper ]
     in
     fun t ->
       Command.of_result_map t.theories_deps ~f:(fun libs ->


### PR DESCRIPTION
Otherwise when composing with Coq itself, libraries not using `From Coq` won't compile.

This is until we deprecate the implicit nature of the Coq prefix, which I'm going to try in 8.12 cc: @Zimmi48 
