### PR TITLE
[coq] Nit on documentation for extraction.

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1648,7 +1648,7 @@ process. This is done using the ``coq.extraction`` stanza:
     (extracted_modules <names>)
     <optional-fields>)
 
-- ``(prelude <name>)`` refers to the coq source that contains the extraction
+- ``(prelude <name>)`` refers to the Coq source that contains the extraction
   commands.
 
 - ``(extraced_modules <names>)`` is an exhaustive list of OCaml modules
@@ -1659,6 +1659,13 @@ process. This is done using the ``coq.extraction`` stanza:
 
 The extracted sources can then be used in ``executable`` or ``library`` stanzas
 as any other sources.
+
+Note that the sources are extracted to the directory where the
+``prelude`` file is; thus the common placement for the ``OCaml``
+stanzas is in the same ``dune`` file. **warning** using Coq's ``Cd``
+command to workaround problems with the output directory is not
+allowed when using extraction from Dune; moreover the ``Cd`` command
+will be deprecated in Coq 8.12.
 
 .. _dune-workspace:
 


### PR DESCRIPTION
Coq users are so used to doing `Cd` in extraction prelude files to
workaround the Coq output bug that we should warn them against that.

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>