### PR TITLE
[Cram sanitization] path separator used to separate directory

### DIFF
--- a/otherlibs/cram/bin/sanitize.ml
+++ b/otherlibs/cram/bin/sanitize.ml
@@ -15,7 +15,8 @@ let rewrite_paths =
       exit 2
     | Ok map ->
       let abs_path_re =
-        Re.(compile (seq [ char '/'; rep1 (diff any (set " \n\r\t")) ]))
+        let not_dir = Printf.sprintf " \n\r\t%c" Bin.path_sep in
+        Re.(compile (seq [ char '/'; rep1 (diff any (set not_dir)) ]))
       in
       fun s ->
         Re.replace abs_path_re s ~f:(fun g ->


### PR DESCRIPTION
 Allows to sanitize list of directories that can be found in environment variables

From #3104, used just during debugging but still useful.