### PR TITLE
[Artifact] Move the artifact evaluation to its own private library

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -23,6 +23,7 @@ let local_libraries =
   ; ("otherlibs/action-plugin/src", Some "Dune_action_plugin", false, None)
   ; ("src/dune", Some "Dune", true, None)
   ; ("vendor/cmdliner/src", None, false, None)
+  ; ("src/artifact_evaluation", Some "Dune_artifact_eval", false, None)
   ; ("otherlibs/build-info/src", Some "Build_info", false,
     Some "build_info_data")
   ]

--- a/otherlibs/build-info/src/dune
+++ b/otherlibs/build-info/src/dune
@@ -5,4 +5,6 @@
  (special_builtin_support
   (build_info
    (data_module build_info_data)
-   (api_version 1))))
+   (api_version 1)))
+ (libraries dune-private-libs.artifact-eval)
+)

--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -60,6 +60,7 @@ Inside _build, we have no version information:
   n/a
   lib a: n/a
   lib b: n/a
+  lib dune-private-libs.artifact-eval: n/a
   lib dune-build-info: XXX
 
   $ grep version _build/install/default/lib/a/dune-package
@@ -74,6 +75,7 @@ Once installed, we have the version information:
   1.0+c
   lib a: 1.0+a
   lib b: 1.0+b
+  lib dune-private-libs.artifact-eval: n/a
   lib dune-build-info: XXX
 
   $ grep version _install/lib/a/dune-package
@@ -86,28 +88,16 @@ Check what the generated build info module looks like:
 
   $ cat _build/default/c/.c.eobjs/build_info_data.ml-gen \
   >   | sed 's/"dune-build-info".*/"dune-build-info", Some "XXX"/'
-  let eval s =
-    let len = String.length s in
-    if s.[0] = '=' then
-      let colon_pos = String.index_from s 1 ':' in
-      let vlen = int_of_string (String.sub s 1 (colon_pos - 1)) in
-      (* This [min] is because the value might have been truncated
-         if it was too large *)
-      let vlen = min vlen (len - colon_pos - 1) in
-      Some (String.sub s (colon_pos + 1) vlen)
-    else
-      None
-  [@@inline never]
-  
-  let p1 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:a%%%%%%%%%%%%%%%%%%%%%%%%%%"
-  let p2 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:b%%%%%%%%%%%%%%%%%%%%%%%%%%"
-  let p0 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:c%%%%%%%%%%%%%%%%%%%%%%%%%%"
+  let p1 = Dune_artifact_eval.eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:a%%%%%%%%%%%%%%%%%%%%%%%%%%"
+  let p2 = Dune_artifact_eval.eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:b%%%%%%%%%%%%%%%%%%%%%%%%%%"
+  let p0 = Dune_artifact_eval.eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:c%%%%%%%%%%%%%%%%%%%%%%%%%%"
   
   let version = p0
   
   let statically_linked_libraries =
     [ "a", p1
     ; "b", p2
+    ; "dune-private-libs.artifact-eval", None
     ; "dune-build-info", Some "XXX"
     ]
 
@@ -118,6 +108,7 @@ Test substitution when promoting
   1.0+c
   lib a: 1.0+a
   lib b: 1.0+b
+  lib dune-private-libs.artifact-eval: n/a
   lib dune-build-info: XXX
 
 Version is picked from dune-project if available
@@ -130,4 +121,5 @@ Version is picked from dune-project if available
   project-version
   lib a: 1.0+a
   lib b: 1.0+b
+  lib dune-private-libs.artifact-eval: n/a
   lib dune-build-info: XXX

--- a/src/artifact_evaluation/dune
+++ b/src/artifact_evaluation/dune
@@ -1,0 +1,4 @@
+(library
+ (name dune_artifact_eval)
+ (public_name dune-private-libs.artifact-eval)
+ (synopsis "[Internal] evaluation of artifact subtitution format"))

--- a/src/artifact_evaluation/dune_artifact_eval.ml
+++ b/src/artifact_evaluation/dune_artifact_eval.ml
@@ -1,0 +1,20 @@
+type t = string
+
+(* Parse the replacement format described in [artifact_substitution.ml]. *)
+let get s =
+  let len = String.length s in
+  if s.[0] = '=' then
+    let colon_pos = String.index_from s 1 ':' in
+    let vlen = int_of_string (String.sub s 1 (colon_pos - 1)) in
+    (* This [min] is because the value might have been truncated
+       if it was too large *)
+    let vlen = min vlen (len - colon_pos - 1) in
+    Some (String.sub s (colon_pos + 1) vlen)
+  else
+    None
+[@@inline never]
+
+let encoded x = x
+[@@inline never]
+
+let eval s = get s

--- a/src/artifact_evaluation/dune_artifact_eval.mli
+++ b/src/artifact_evaluation/dune_artifact_eval.mli
@@ -1,0 +1,5 @@
+type t
+
+val encoded: string -> t
+val get: t -> string option
+val eval: string -> string option

--- a/src/dune/link_time_code_gen.ml
+++ b/src/dune/link_time_code_gen.ml
@@ -145,22 +145,8 @@ let build_info_code cctx ~libs ~api_version =
               placeholder p ) ))
   in
   let buf = Buffer.create 1024 in
-  (* Parse the replacement format described in [artifact_substitution.ml]. *)
-  pr buf "let eval s =";
-  pr buf "  let len = String.length s in";
-  pr buf "  if s.[0] = '=' then";
-  pr buf "    let colon_pos = String.index_from s 1 ':' in";
-  pr buf "    let vlen = int_of_string (String.sub s 1 (colon_pos - 1)) in";
-  pr buf "    (* This [min] is because the value might have been truncated";
-  pr buf "       if it was too large *)";
-  pr buf "    let vlen = min vlen (len - colon_pos - 1) in";
-  pr buf "    Some (String.sub s (colon_pos + 1) vlen)";
-  pr buf "  else";
-  pr buf "    None";
-  pr buf "[@@inline never]";
-  pr buf "";
   Path.Source.Map.iteri !placeholders ~f:(fun path var ->
-      pr buf "let %s = eval %S" var
+      pr buf "let %s = Dune_artifact_eval.eval %S" var
         (Artifact_substitution.encode ~min_len:64 (Vcs_describe path)));
   if not (Path.Source.Map.is_empty !placeholders) then pr buf "";
   pr buf "let version = %s" version;


### PR DESCRIPTION
  * Adds an abstract type when we want to delay the decoding

From #3104, the evaluation is reused for sites_locations.