### PR TITLE
Allow libraries to be enabled/disabled based on the build profile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,10 @@ Unreleased
 - Fix a bug preventing one from running inline tests in multiple modes
   (#3352, @diml)
 
+- Allow the use of the `%{profile}` variable in the `enabled_if` field of the
+  library stanza.
+  (#3344, @mrmr1993)
+
 2.4.0 (06/03/2020)
 ------------------
 

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -483,6 +483,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
           Dynlink_supported.By_the_os.of_bool natdynlink_supported
       ; stdlib_dir
       ; ccomp_type = Ocaml_config.ccomp_type ocfg
+      ; profile = Profile.to_string profile
       }
     in
     if Option.is_some fdo_target_exe then

--- a/src/dune/lib_config.ml
+++ b/src/dune/lib_config.ml
@@ -12,6 +12,7 @@ type t =
   ; ext_dll : string
   ; stdlib_dir : Path.t
   ; ccomp_type : Ocaml_config.Ccomp_type.t
+  ; profile : string
   }
 
 let var_map =
@@ -20,12 +21,14 @@ let var_map =
   ; ("model", fun t -> t.model)
   ; ("os_type", fun t -> Ocaml_config.Os_type.to_string t.os_type)
   ; ("ccomp_type", fun t -> Ocaml_config.Ccomp_type.to_string t.ccomp_type)
+  ; ("profile", fun t -> t.profile)
   ]
 
 let allowed_in_enabled_if =
   List.map var_map ~f:(fun (var, _) ->
       let min_version =
         match var with
+        | "profile" -> (2, 5)
         | "ccomp_type" -> (2, 0)
         | _ -> (1, 0)
       in

--- a/src/dune/lib_config.mli
+++ b/src/dune/lib_config.mli
@@ -12,6 +12,7 @@ type t =
   ; ext_dll : string
   ; stdlib_dir : Path.t
   ; ccomp_type : Ocaml_config.Ccomp_type.t
+  ; profile : string
   }
 
 val allowed_in_enabled_if : (string * Dune_lang.Syntax.Version.t) list

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -26,6 +26,7 @@ let findlib =
     ; ext_dll = ".so"
     ; stdlib_dir = Path.root
     ; ccomp_type = Other "gcc"
+    ; profile = "dev"
     }
   in
   Findlib.create ~stdlib_dir:cwd ~paths:[ db_path ]


### PR DESCRIPTION
This PR exposes the `%{profile}` variable to `(enabled_if ...)` stanzas for libraries.