### PR TITLE
Upgrade to Coq 8.11.1 in Travis

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -39,7 +39,7 @@ opam_install_test_deps () {
     # pressure to Dune's CI.
     keep_travis_happy \
         opam install \
-        coq.8.11.0
+        coq.8.11.1
         # js_of_ocaml-ppx \
         # js_of_ocaml-compiler \
 }

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -134,7 +134,7 @@ case "$TARGET" in
         opam update
         echo $DATE> ~/.opam/last-update
         UPDATE_OPAM=1
-        opam upgrade
+        keep_travis_happy opam upgrade
       fi
       if ! ./dune.exe build @runtest-no-deps &> $RUNTEST_NO_DEPS ; then
         cat $RUNTEST_NO_DEPS;


### PR DESCRIPTION
@snowleopard @ejgallego I believe this should unbreak travis. Looking at the log, it seems that it's because an opam command is trying to upgrade coq and doesn't go through the `keep_travis_happy`.

We might need a more general solution moving forward though.