### PR TITLE
[coq] Fix install path for theories with a composed name.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+2.5.1 (unreleased)
+------------------
+
+- [coq] Fix install path for theory names with level greater than 1
+  (#3358 , @ejgallego)
+
 2.5.0 (09/04/2020)
 ------------------
 

--- a/src/dune/coq_lib_name.ml
+++ b/src/dune/coq_lib_name.ml
@@ -9,8 +9,10 @@ open! Stdune
 type t = string list
 
 let to_string x = String.concat ~sep:"." x
+let to_dir x = String.concat ~sep:"/" x
 
 let wrapper x = to_string x
+let dir x = to_dir x
 
 (* We should add some further validation to Coq library names; the rules in Coq
    itself have been tweaked due to Unicode, etc... so this is not trivial *)

--- a/src/dune/coq_lib_name.mli
+++ b/src/dune/coq_lib_name.mli
@@ -9,7 +9,12 @@ open! Stdune
 (** A Coq library name is a dot-separated list of Coq module identifiers. *)
 type t
 
+(** Returns the wrapper name, a dot-separated list of Coq module identifies *)
 val wrapper : t -> string
+
+(** Returns the directoy name for a lib name, in this case library
+   name foo.bar lives in foo/bar *)
+val dir : t -> string
 
 val encode : t Dune_lang.Encoder.t
 

--- a/src/dune/coq_rules.ml
+++ b/src/dune/coq_rules.ml
@@ -389,7 +389,7 @@ let install_rules ~sctx ~dir s =
     let dir_contents = Dir_contents.get sctx ~dir in
     let name = snd s.name in
     (* This must match the wrapper prefix for now to remain compatible *)
-    let dst_suffix = Coq_lib_name.wrapper (snd s.name) in
+    let dst_suffix = Coq_lib_name.dir (snd s.name) in
     (* These are the rules for now, coq lang 2.0 will make this uniform *)
     let dst_dir =
       if s.boot then

--- a/test/blackbox-tests/test-cases/coq/compose_sub_theory/a/a.v
+++ b/test/blackbox-tests/test-cases/coq/compose_sub_theory/a/a.v
@@ -1,0 +1,1 @@
+Definition foo := 3.

--- a/test/blackbox-tests/test-cases/coq/compose_sub_theory/a/dune
+++ b/test/blackbox-tests/test-cases/coq/compose_sub_theory/a/dune
@@ -1,0 +1,3 @@
+(coq.theory
+ (name foo.a)
+ (package subtheory))

--- a/test/blackbox-tests/test-cases/coq/compose_sub_theory/b/b.v
+++ b/test/blackbox-tests/test-cases/coq/compose_sub_theory/b/b.v
@@ -1,0 +1,3 @@
+From foo Require Import a.
+
+Definition bar := a.foo.

--- a/test/blackbox-tests/test-cases/coq/compose_sub_theory/b/dune
+++ b/test/blackbox-tests/test-cases/coq/compose_sub_theory/b/dune
@@ -1,0 +1,4 @@
+(coq.theory
+ (name b)
+ (package subtheory)
+ (theories foo.a))

--- a/test/blackbox-tests/test-cases/coq/compose_sub_theory/dune
+++ b/test/blackbox-tests/test-cases/coq/compose_sub_theory/dune
@@ -1,0 +1,3 @@
+(rule
+ (alias default)
+ (action (echo "%{read:subtheory.install}")))

--- a/test/blackbox-tests/test-cases/coq/compose_sub_theory/dune-project
+++ b/test/blackbox-tests/test-cases/coq/compose_sub_theory/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.5)
+(using coq 0.2)

--- a/test/blackbox-tests/test-cases/coq/run.t
+++ b/test/blackbox-tests/test-cases/coq/run.t
@@ -162,6 +162,22 @@
   -> required by alias default
   [1]
 
+  $ dune build --root compose_sub_theory/ --display short --debug-dependency-path
+  Entering directory 'compose_sub_theory'
+        coqdep b/b.v.d
+        coqdep a/a.v.d
+          coqc a/a.vo
+          coqc b/b.vo
+  lib: [
+    "_build/install/default/lib/subtheory/META"
+    "_build/install/default/lib/subtheory/dune-package"
+    "_build/install/default/lib/subtheory/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/b/b.vo" {"coq/user-contrib/b/b.vo"}
+    "_build/install/default/lib/coq/user-contrib/foo/a/a.vo" {"coq/user-contrib/foo/a/a.vo"}
+  ]
+
   $ dune build --root compose_two_scopes/ --display short --debug-dependency-path
   Entering directory 'compose_two_scopes'
   File "b/dune", line 4, characters 11-12:


### PR DESCRIPTION
Theories with names such as `mathcomp.ssreflect` should be installed
in `mathcomp/ssreflect` for the common pattern `From mathcomp Require
Import ...` to work.

Thanks to Shachar Itzhaky for testing and reporting this issue.

The use of the recursive include is problematic upstream and a revamp
of its semantics is planned.