### PR TITLE
Decouple versions of file and metadata stores in the cache

### DIFF
--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -66,6 +66,18 @@ let trim ~trimmed_size ~size =
       Cache.Local.make ~duplication_mode:Cache.Duplication_mode.Hardlink
         ~command_handler:ignore ()
     in
+    let () =
+      match Cache.Local.detect_unexpected_dirs_under_cache_root cache with
+      | [] -> ()
+      | dirs ->
+        User_error.raise
+          [ Pp.text "Unexpected directories found at the cache root:"
+          ; Pp.enumerate dirs ~f:Pp.text
+          ; Pp.text
+              "It is likely that these directories are in use by Dune of a \
+               different version. Please trim the cache manually."
+          ]
+    in
     let+ trimmed_size =
       match (trimmed_size, size) with
       | Some trimmed_size, None -> Result.Ok trimmed_size

--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -72,10 +72,10 @@ let trim ~trimmed_size ~size =
       | dirs ->
         User_error.raise
           [ Pp.text "Unexpected directories found at the cache root:"
-          ; Pp.enumerate dirs ~f:Pp.text
+          ; Pp.enumerate dirs ~f:(fun dir -> Path.to_string dir |> Pp.text)
           ; Pp.text
-              "It is likely that these directories are in use by Dune of a \
-               different version. Please trim the cache manually."
+              "These directories are probably used by Dune of a different \
+               version. Please trim the cache manually."
           ]
     in
     let+ trimmed_size =

--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -68,8 +68,8 @@ let trim ~trimmed_size ~size =
     in
     let () =
       match Cache.Local.detect_unexpected_dirs_under_cache_root cache with
-      | [] -> ()
-      | dirs ->
+      | Ok [] -> ()
+      | Ok dirs ->
         User_error.raise
           [ Pp.text "Unexpected directories found at the cache root:"
           ; Pp.enumerate dirs ~f:(fun dir -> Path.to_string dir |> Pp.text)
@@ -77,6 +77,7 @@ let trim ~trimmed_size ~size =
               "These directories are probably used by Dune of a different \
                version. Please trim the cache manually."
           ]
+      | Error e -> User_error.raise [ Pp.text (Unix.error_message e) ]
     in
     let+ trimmed_size =
       match (trimmed_size, size) with

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -31,7 +31,48 @@ module Trimming_result = struct
 end
 
 let default_root () =
-  Path.L.relative (Path.of_string Xdg.cache_dir) [ "dune"; "db"; "v2" ]
+  Path.L.relative (Path.of_string Xdg.cache_dir) [ "dune"; "db" ]
+
+let file_store_version = "v2"
+
+let metadata_store_version = "v2"
+
+let file_store_root cache =
+  Path.L.relative cache.root [ "files"; file_store_version ]
+
+let metadata_store_root cache =
+  Path.L.relative cache.root [ "meta"; metadata_store_version ]
+
+let detect_unexpected_dirs_under_cache_root cache =
+  let expected_in_root path =
+    (* We only report unexpected directories, since quite a few temporary files
+       are created at the cache root, and it would be tedious to keep track of
+       all of them. *)
+    match
+      (Sys.is_directory (Path.to_string (Path.relative cache.root path)), path)
+    with
+    | false, _ -> true
+    | true, "files"
+    | true, "meta" ->
+      true
+    | true, dir -> String.is_prefix ~prefix:"promoting." dir
+  in
+  let in_root =
+    Path.to_string cache.root |> Sys.readdir |> Array.to_list
+    |> List.filter ~f:(fun name -> not (expected_in_root name))
+  in
+  let in_files =
+    Path.relative cache.root "files"
+    |> Path.to_string |> Sys.readdir |> Array.to_list
+    |> List.filter ~f:(fun name -> not (String.equal name file_store_version))
+  in
+  let in_meta =
+    Path.relative cache.root "meta"
+    |> Path.to_string |> Sys.readdir |> Array.to_list
+    |> List.filter ~f:(fun name ->
+           not (String.equal name metadata_store_version))
+  in
+  in_root @ in_files @ in_meta
 
 (* Handling file digest collisions by appending suffices ".1", ".2", etc. to the
    files stored in the cache.
@@ -169,13 +210,10 @@ module Metadata_file = struct
   let parse path = Io.with_file_in path ~f:Csexp.input >>= of_sexp
 end
 
-let root_data cache = Path.relative cache.root "files"
+let metadata_path cache key =
+  FSSchemeImpl.path ~root:(metadata_store_root cache) key
 
-let root_metadata cache = Path.relative cache.root "meta"
-
-let path_metadata cache key = FSSchemeImpl.path ~root:(root_metadata cache) key
-
-let path_data cache key = FSSchemeImpl.path ~root:(root_data cache) key
+let file_path cache key = FSSchemeImpl.path ~root:(file_store_root cache) key
 
 let make_path cache path =
   match cache.build_root with
@@ -186,7 +224,7 @@ let make_path cache path =
          (Path.Local.to_string_maybe_quoted path))
 
 let search cache digest file =
-  Collision_chain.search (path_data cache digest) file
+  Collision_chain.search (file_path cache digest) file
 
 let with_repositories cache repositories = { cache with repositories }
 
@@ -309,7 +347,7 @@ let promote_sync cache paths key metadata ~repository ~duplication =
              })
   in
   let+ promoted = Result.List.map ~f:promote paths in
-  let metadata_path = path_metadata cache key
+  let metadata_path = metadata_path cache key
   and metadata_tmp_path = Path.relative cache.temp_dir "metadata"
   and files =
     List.map promoted ~f:(function
@@ -346,7 +384,7 @@ let promote cache paths key metadata ~repository ~duplication =
     (promote_sync cache paths key metadata ~repository ~duplication)
 
 let search cache key =
-  let path = path_metadata cache key in
+  let path = metadata_path cache key in
   let* sexp =
     try Io.with_file_in path ~f:Csexp.input
     with Sys_error _ -> Error "no cached file"
@@ -388,32 +426,34 @@ let make ?(root = default_root ())
     ?(duplication_mode = detect_duplication_mode root)
     ?(log = Dune_util.Log.info) ?(warn = fun pp -> User_warning.emit pp)
     ~command_handler () =
-  if Path.basename root <> "v2" then
-    Result.Error "unable to read dune-cache"
-  else
-    let res =
-      { root
-      ; build_root = None
-      ; info = log
-      ; warn
-      ; repositories = []
-      ; command_handler
-      ; duplication_mode
-      ; temp_dir =
-          Path.temp_dir ~temp_dir:root "promoting."
-            ("." ^ string_of_int (Unix.getpid ()))
-      }
-    in
-    Path.mkdir_p @@ root_metadata res;
-    Path.mkdir_p @@ root_data res;
-    Result.ok res
+  let res =
+    { root
+    ; build_root = None
+    ; info = log
+    ; warn
+    ; repositories = []
+    ; command_handler
+    ; duplication_mode
+    ; temp_dir =
+        Path.temp_dir ~temp_dir:root "promoting."
+          ("." ^ string_of_int (Unix.getpid ()))
+    }
+  in
+  match
+    Path.mkdir_p @@ file_store_root res;
+    Path.mkdir_p @@ metadata_store_root res
+  with
+  | () -> Ok res
+  | exception exn ->
+    Error
+      ("Unable to set up the cache root directory: " ^ Printexc.to_string exn)
 
 let duplication_mode cache = cache.duplication_mode
 
 let trimmable stats = stats.Unix.st_nlink = 1
 
 let _garbage_collect default_trim cache =
-  let root = root_metadata cache in
+  let root = metadata_store_root cache in
   let metas =
     List.map ~f:(fun p -> (p, Metadata_file.parse p)) (FSSchemeImpl.list ~root)
   in
@@ -462,7 +502,7 @@ let _garbage_collect default_trim cache =
 let garbage_collect = _garbage_collect Trimming_result.empty
 
 let trim cache free =
-  let root = root_data cache in
+  let root = file_store_root cache in
   let files = FSSchemeImpl.list ~root in
   let f path =
     let stats = Path.stat path in
@@ -484,7 +524,7 @@ let trim cache free =
   _garbage_collect trim cache
 
 let overhead_size cache =
-  let root = root_data cache in
+  let root = file_store_root cache in
   let files = FSSchemeImpl.list ~root in
   let stats =
     let f p =

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -53,7 +53,8 @@ let detect_unexpected_dirs_under_cache_root cache =
     with
     | false, _ -> true
     | true, "files"
-    | true, "meta" ->
+    | true, "meta"
+    | true, "runtime" ->
       true
     | true, dir -> String.is_prefix ~prefix:"promoting." dir
   in
@@ -64,9 +65,10 @@ let detect_unexpected_dirs_under_cache_root cache =
     |> List.filter ~f:(fun name -> not (expected name))
     |> List.map ~f:(fun name -> Path.relative dir name)
   in
-  detect_in ~dir:cache.root expected_in_root
-  @ detect_in ~dir:(Path.relative cache.root "files") expected_in_files
-  @ detect_in ~dir:(Path.relative cache.root "meta") expected_in_meta
+  List.sort ~compare:Path.compare
+    ( detect_in ~dir:cache.root expected_in_root
+    @ detect_in ~dir:(Path.relative cache.root "files") expected_in_files
+    @ detect_in ~dir:(Path.relative cache.root "meta") expected_in_meta )
 
 (* Handling file digest collisions by appending suffices ".1", ".2", etc. to the
    files stored in the cache.

--- a/src/cache/local.mli
+++ b/src/cache/local.mli
@@ -70,15 +70,15 @@ module Trimming_result : sig
     }
 end
 
+(** Return a list of unexpected paths that exist in the root directory of the
+    cache. A non-empty result suggests that the cache directory contains
+    multiple versions of the cache, making [trim] and [garbage_collect] less
+    effective. *)
+val detect_unexpected_dirs_under_cache_root : t -> string list
+
 (** [trim cache size] removes files from [cache], starting with the least
     recently used one, until [size] bytes have been freed. *)
 val trim : t -> int -> Trimming_result.t
 
 (** Purge invalid or incomplete cached rules. *)
 val garbage_collect : t -> Trimming_result.t
-
-(** Path to a metadata file *)
-val path_metadata : t -> Key.t -> Path.t
-
-(** Path to a data file *)
-val path_data : t -> Key.t -> Path.t

--- a/src/cache/local.mli
+++ b/src/cache/local.mli
@@ -74,7 +74,8 @@ end
     cache. A non-empty result suggests that the cache directory contains
     multiple versions of the cache, making [trim] and [garbage_collect] less
     effective. *)
-val detect_unexpected_dirs_under_cache_root : t -> Path.t list
+val detect_unexpected_dirs_under_cache_root :
+  t -> (Path.t list, Unix.error) result
 
 (** [trim cache size] removes files from [cache], starting with the least
     recently used one, until [size] bytes have been freed. *)

--- a/src/cache/local.mli
+++ b/src/cache/local.mli
@@ -74,7 +74,7 @@ end
     cache. A non-empty result suggests that the cache directory contains
     multiple versions of the cache, making [trim] and [garbage_collect] less
     effective. *)
-val detect_unexpected_dirs_under_cache_root : t -> string list
+val detect_unexpected_dirs_under_cache_root : t -> Path.t list
 
 (** [trim cache size] removes files from [cache], starting with the least
     recently used one, until [size] bytes have been freed. *)

--- a/test/blackbox-tests/test-cases/dune-cache/trim/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim/run.t
@@ -122,3 +122,27 @@ they are part of the same rule.
   $ rm -f _build/default/multi_a _build/default/multi_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 1B
   Freed 16 bytes
+
+  $ mkdir -p $PWD/.xdg-cache/dune/db/temp
+  $ mkdir -p $PWD/.xdg-cache/dune/db/v1
+  $ mkdir -p $PWD/.xdg-cache/dune/db/v2
+  $ mkdir -p $PWD/.xdg-cache/dune/db/v3
+  $ mkdir -p $PWD/.xdg-cache/dune/db/files/v1
+  $ mkdir -p $PWD/.xdg-cache/dune/db/files/v2
+  $ mkdir -p $PWD/.xdg-cache/dune/db/files/v3
+  $ mkdir -p $PWD/.xdg-cache/dune/db/meta/v1
+  $ mkdir -p $PWD/.xdg-cache/dune/db/meta/v2
+  $ mkdir -p $PWD/.xdg-cache/dune/db/meta/v3
+  $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 1B
+  Error: Unexpected directories found at the cache root:
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/temp
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/v1
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/v2
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/v3
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/files/v1
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/files/v3
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/meta/v1
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/meta/v3
+  These directories are probably used by Dune of a different version. Please
+  trim the cache manually.
+  [1]

--- a/test/blackbox-tests/test-cases/dune-cache/trim/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim/run.t
@@ -124,6 +124,7 @@ they are part of the same rule.
   Freed 16 bytes
 
   $ mkdir -p $PWD/.xdg-cache/dune/db/temp
+  $ mkdir -p $PWD/.xdg-cache/dune/db/runtime
   $ mkdir -p $PWD/.xdg-cache/dune/db/v1
   $ mkdir -p $PWD/.xdg-cache/dune/db/v2
   $ mkdir -p $PWD/.xdg-cache/dune/db/v3
@@ -135,14 +136,14 @@ they are part of the same rule.
   $ mkdir -p $PWD/.xdg-cache/dune/db/meta/v3
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 1B
   Error: Unexpected directories found at the cache root:
-  - $TESTCASE_ROOT/.xdg-cache/dune/db/temp
-  - $TESTCASE_ROOT/.xdg-cache/dune/db/v1
-  - $TESTCASE_ROOT/.xdg-cache/dune/db/v2
-  - $TESTCASE_ROOT/.xdg-cache/dune/db/v3
   - $TESTCASE_ROOT/.xdg-cache/dune/db/files/v1
   - $TESTCASE_ROOT/.xdg-cache/dune/db/files/v3
   - $TESTCASE_ROOT/.xdg-cache/dune/db/meta/v1
   - $TESTCASE_ROOT/.xdg-cache/dune/db/meta/v3
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/temp
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/v1
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/v2
+  - $TESTCASE_ROOT/.xdg-cache/dune/db/v3
   These directories are probably used by Dune of a different version. Please
   trim the cache manually.
   [1]


### PR DESCRIPTION
This implements the first step of #3357.