### PR TITLE
Preview of ocamlformat 0.14.2

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.13.0
+version=0.14.2
 break-separators=before
 dock-collection-brackets=false
 break-sequences=true

--- a/src/dune/colors.ml
+++ b/src/dune/colors.ml
@@ -47,8 +47,8 @@ let setup_err_formatter_colors () =
     List.iter [ err_formatter; Dune_util.Report_error.ppf ] ~f:(fun ppf ->
         let funcs = (pp_get_formatter_tag_functions ppf () [@warning "-3"]) in
         pp_set_mark_tags ppf true;
-        (pp_set_formatter_tag_functions ppf
-           { funcs with
-             mark_close_tag = (fun _ -> Ansi_color.Style.escape_sequence [])
-           ; mark_open_tag
-           } [@warning "-3"]))
+        pp_set_formatter_tag_functions ppf
+          { funcs with
+            mark_close_tag = (fun _ -> Ansi_color.Style.escape_sequence [])
+          ; mark_open_tag
+          } [@warning "-3"])

--- a/src/dune_lang/t.ml
+++ b/src/dune_lang/t.ml
@@ -80,29 +80,29 @@ module Deprecated = struct
     let tfuncs =
       (Format.pp_get_formatter_tag_functions ppf () [@warning "-3"])
     in
-    (Format.pp_set_formatter_tag_functions ppf
-       { tfuncs with
-         mark_open_tag =
-           (function
-           | "atom" ->
-             state := In_atom :: !state;
-             ""
-           | "makefile-action" ->
-             state := In_makefile_action :: !state;
-             ""
-           | "makefile-stuff" ->
-             state := In_makefile_stuff :: !state;
-             ""
-           | s -> tfuncs.mark_open_tag s)
-       ; mark_close_tag =
-           (function
-           | "atom"
-           | "makefile-action"
-           | "makefile-stuff" ->
-             state := List.tl !state;
-             ""
-           | s -> tfuncs.mark_close_tag s)
-       } [@warning "-3"]);
+    Format.pp_set_formatter_tag_functions ppf
+      { tfuncs with
+        mark_open_tag =
+          (function
+          | "atom" ->
+            state := In_atom :: !state;
+            ""
+          | "makefile-action" ->
+            state := In_makefile_action :: !state;
+            ""
+          | "makefile-stuff" ->
+            state := In_makefile_stuff :: !state;
+            ""
+          | s -> tfuncs.mark_open_tag s)
+      ; mark_close_tag =
+          (function
+          | "atom"
+          | "makefile-action"
+          | "makefile-stuff" ->
+            state := List.tl !state;
+            ""
+          | s -> tfuncs.mark_close_tag s)
+      } [@warning "-3"];
     Format.pp_set_formatter_out_functions ppf
       { ofuncs with
         out_newline =


### PR DESCRIPTION
As of the new release process we are implementing for ocamlformat here is the preview of what the codebase would look like after ocamlformat-0.14.2 has been applied.
This preview is not definitive, as we need to make sure it is fitting with other main ocaml projects as well, please do not merge this PR.

The .ocamlformat file has been updated for consistency although the package has not been submitted to opam yet. If you wish to test this version, remove this line in the .ocamlformat file, and use the `master` version of ocamlformat (as of https://github.com/ocaml-ppx/ocamlformat/commit/6fb5a8c607b7fb93812870e059dcabe562f88bf5)

The diff you can see on src/dune/colors.ml and src/dune_lang/t.ml is due to the removal of unnecessary parentheses around the expression and attribute, as no disambiguation is required here.
Feel free to give your feedback on this PR or open an issue on https://github.com/ocaml-ppx/ocamlformat/issues