### PR TITLE
Add pipe actions

### DIFF
--- a/doc/bisect.rst
+++ b/doc/bisect.rst
@@ -14,7 +14,7 @@ like so:
 
 .. code:: scheme
 
-          (lang dune 2.6)
+          (lang dune 2.7)
           (using bisect_ppx 1.0)
 
 Then, we should use the ``(bisect_ppx)`` field. The dune file may look like
@@ -46,7 +46,7 @@ using ``(bisect_ppx)``. To enable code coverage, we can set the
 
 .. code:: scheme
 
-          (lang dune 2.6)
+          (lang dune 2.7)
           (context (default (bisect_enabled true)))
 
 Then, to build the project with code coverage, we can run:
@@ -59,7 +59,7 @@ We can also define different contexts in the ``dune-workspace`` file as follows:
 
 .. code:: scheme
 
-          (lang dune 2.6)
+          (lang dune 2.7)
           (context default)
           (context (default (name coverage) (bisect_enabled true)))
 

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -690,6 +690,9 @@ The following constructions are available:
 - ``(no-infer <DSL>)`` to perform an action without inference of dependencies
   and targets. This is useful if you are generating dependencies in a way
   that Dune doesn't know about, for instance by calling an external build system.
+- ``(pipe-<outputs> <DSL> <DSL> <DSL>...)`` to execute several actions (at least two)
+  in sequence, piping the output of each one into the input of the next.
+  This action is available since dune 2.7.
 
 As mentioned ``copy#`` inserts a line directive at the beginning of
 the destination file. More precisely, it inserts the following line:

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -12,7 +12,7 @@ like:
 
 .. code:: scheme
 
-          (lang dune 2.6)
+          (lang dune 2.7)
 
 Additionally, they can contains the following stanzas.
 
@@ -1743,7 +1743,7 @@ a typical ``dune-workspace`` file looks like:
 
 .. code:: scheme
 
-    (lang dune 2.6)
+    (lang dune 2.7)
     (context (opam (switch 4.02.3)))
     (context (opam (switch 4.03.0)))
     (context (opam (switch 4.04.0)))
@@ -1755,7 +1755,7 @@ containing exactly:
 
 .. code:: scheme
 
-    (lang dune 2.6)
+    (lang dune 2.7)
     (context default)
 
 This allows you to use an empty ``dune-workspace`` file to mark the root of your

--- a/doc/opam.rst
+++ b/doc/opam.rst
@@ -94,7 +94,7 @@ configuration will tell ``dune`` to generate two opam files: ``cohttp.opam`` and
 
 .. code:: scheme
 
-   (lang dune 2.6)
+   (lang dune 2.7)
    (name cohttp)
    ; version field is optional
    (version 1.0.0)

--- a/src/dune/action.ml
+++ b/src/dune/action.ml
@@ -161,7 +161,9 @@ let fold_one_step t ~init:acc ~f =
   | With_accepted_exit_codes (_, t)
   | No_infer t ->
     f acc t
-  | Progn l -> List.fold_left l ~init:acc ~f
+  | Progn l
+  | Pipe (_, l) ->
+    List.fold_left l ~init:acc ~f
   | Run _
   | Dynamic_run _
   | Echo _
@@ -205,7 +207,9 @@ let rec is_dynamic = function
   | With_accepted_exit_codes (_, t)
   | No_infer t ->
     is_dynamic t
-  | Progn l -> List.exists l ~f:is_dynamic
+  | Progn l
+  | Pipe (_, l) ->
+    List.exists l ~f:is_dynamic
   | Run _
   | System _
   | Bash _
@@ -285,7 +289,9 @@ let is_useful_to distribute memoize =
     | With_accepted_exit_codes (_, t)
     | No_infer t ->
       loop t
-    | Progn l -> List.exists l ~f:loop
+    | Progn l
+    | Pipe (_, l) ->
+      List.exists l ~f:loop
     | Echo _ -> false
     | Cat _ -> memoize
     | Copy _ -> memoize

--- a/src/dune/action.mli
+++ b/src/dune/action.mli
@@ -1,8 +1,10 @@
 open! Stdune
 open! Import
 
-module Outputs : module type of struct
-  include Action_intf.Outputs
+module Outputs : sig
+  include module type of Action_intf.Outputs
+
+  val to_string : t -> string
 end
 
 module Inputs : module type of struct

--- a/src/dune/action_ast.mli
+++ b/src/dune/action_ast.mli
@@ -15,8 +15,10 @@ module Inputs : module type of struct
   include Action_intf.Inputs
 end
 
-module Outputs : module type of struct
-  include Action_intf.Outputs
+module Outputs : sig
+  include module type of Action_intf.Outputs
+
+  val to_string : t -> string
 end
 
 module Make

--- a/src/dune/action_dune_lang.ml
+++ b/src/dune/action_dune_lang.ml
@@ -65,6 +65,7 @@ let ensure_at_most_one_dynamic_run ~loc action =
     | Diff _
     | Merge_files_into _ ->
       false
+    | Pipe (_, ts)
     | Progn ts ->
       List.fold_left ts ~init:false ~f:(fun acc t ->
           let have_dyn = loop t in

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -351,27 +351,39 @@ let rec exec t ~ectx ~eenv =
     Io.write_lines target (String.Set.to_list lines);
     Fiber.return Done
   | No_infer t -> exec t ~ectx ~eenv
+  | Pipe (outputs, l) -> exec_pipe ~ectx ~eenv outputs l
 
 and redirect_out t ~ectx ~eenv outputs fn =
-  let out = Process.Io.file fn Process.Io.Out in
-  let stdout_to, stderr_to =
-    match outputs with
-    | Stdout -> (out, eenv.stderr_to)
-    | Stderr -> (eenv.stdout_to, out)
-    | Outputs -> (out, out)
-  in
-  exec t ~ectx ~eenv:{ eenv with stdout_to; stderr_to } >>| fun result ->
-  Process.Io.release out;
-  result
+  redirect t ~ectx ~eenv ~out:(outputs, fn) ()
 
 and redirect_in t ~ectx ~eenv inputs fn =
-  let in_ = Process.Io.file fn Process.Io.In in
-  let stdin_from =
-    match inputs with
-    | Stdin -> in_
+  redirect t ~ectx ~eenv ~in_:(inputs, fn) ()
+
+and redirect t ~ectx ~eenv ?in_ ?out () =
+  let stdin_from, release_in =
+    match in_ with
+    | None -> (eenv.stdin_from, ignore)
+    | Some (Stdin, fn) ->
+      let in_ = Process.Io.file fn Process.Io.In in
+      (in_, fun () -> Process.Io.release in_)
   in
-  exec t ~ectx ~eenv:{ eenv with stdin_from } >>| fun result ->
-  Process.Io.release in_;
+  let stdout_to, stderr_to, release_out =
+    match out with
+    | None -> (eenv.stdout_to, eenv.stderr_to, ignore)
+    | Some (outputs, fn) ->
+      let out = Process.Io.file fn Process.Io.Out in
+      let stdout_to, stderr_to =
+        match outputs with
+        | Stdout -> (out, eenv.stderr_to)
+        | Stderr -> (eenv.stdout_to, out)
+        | Outputs -> (out, out)
+      in
+      (stdout_to, stderr_to, fun () -> Process.Io.release out)
+  in
+  exec t ~ectx ~eenv:{ eenv with stdin_from; stdout_to; stderr_to }
+  >>| fun result ->
+  release_in ();
+  release_out ();
   result
 
 and exec_list ts ~ectx ~eenv =
@@ -388,6 +400,38 @@ and exec_list ts ~ectx ~eenv =
     match done_or_deps with
     | Need_more_deps _ as need -> Fiber.return need
     | Done -> exec_list rest ~ectx ~eenv )
+
+and exec_pipe outputs ts ~ectx ~eenv =
+  let tmp_file () =
+    Temp.create
+      ~prefix:"dune-pipe-action-"
+      ~suffix:("." ^ Action.Outputs.to_string outputs)
+  in
+  let rec loop ~in_ ts =
+    match ts with
+    | [] -> assert false
+    | [ last_t ] ->
+      let+ result = redirect_in last_t ~ectx ~eenv Stdin in_ in
+      Temp.destroy in_;
+      result
+    | t :: ts -> (
+      let out = tmp_file () in
+      let* done_or_deps =
+        redirect t ~ectx ~eenv ~in_:(Stdin, in_) ~out:(outputs, out) ()
+      in
+      Temp.destroy in_;
+      match done_or_deps with
+      | Need_more_deps _ as need -> Fiber.return need
+      | Done -> loop ~in_:out ts )
+  in
+  match ts with
+  | [] -> assert false
+  | t1 :: ts -> (
+    let out = tmp_file () in
+    let* done_or_deps = redirect_out t1 ~ectx ~eenv outputs out in
+    match done_or_deps with
+    | Need_more_deps _ as need -> Fiber.return need
+    | Done -> loop ~in_:out ts )
 
 let exec_until_all_deps_ready ~ectx ~eenv t =
   let open DAP in

--- a/src/dune/action_intf.ml
+++ b/src/dune/action_intf.ml
@@ -47,6 +47,7 @@ module type Ast = sig
     | Diff of (path, target) Diff.t
     | Merge_files_into of path list * string list * target
     | No_infer of t
+    | Pipe of Outputs.t * t list
 end
 
 module type Helpers = sig

--- a/src/dune/action_mapper.ml
+++ b/src/dune/action_mapper.ml
@@ -50,6 +50,7 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
         , List.map extras ~f:(f_string ~dir)
         , f_target ~dir target )
     | No_infer t -> No_infer (f t ~dir)
+    | Pipe (outputs, l) -> Pipe (outputs, List.map l ~f:(fun t -> f t ~dir))
 
   let rec map t ~dir ~f_program ~f_string ~f_path ~f_target =
     map_one_step map t ~dir ~f_program ~f_string ~f_path ~f_target

--- a/src/dune/action_to_sh.ml
+++ b/src/dune/action_to_sh.ml
@@ -13,6 +13,7 @@ module Simplified = struct
     | Setenv of string * string
     | Redirect_out of t list * Action.Outputs.t * destination
     | Redirect_in of t list * Action.Inputs.t * source
+    | Pipe of t list * Action.Outputs.t
     | Sh of string
 end
 
@@ -87,6 +88,9 @@ let simplify act =
            (String.quote_for_shell target))
       :: acc
     | No_infer act -> loop act acc
+    | Pipe (outputs, l) ->
+      let actl = List.fold_left l ~init:acc ~f:(fun acc act -> loop act acc) in
+      Pipe (actl, outputs) :: acc
   and block act =
     match List.rev (loop act []) with
     | [] -> [ Run ("true", []) ]
@@ -153,6 +157,14 @@ and pp = function
              | Dev_null -> "/dev/null"
              | File fn -> fn )
          ])
+  | Pipe (l, outputs) ->
+    let pipe =
+      match outputs with
+      | Stdout -> "|"
+      | Outputs -> "2>&1 |"
+      | Stderr -> "2>&1 >/dev/null |"
+    in
+    Pp.hovbox ~indent:2 (Pp.concat ~sep:(Pp.verbatim pipe) (List.map l ~f:pp))
 
 let rec pp_seq = function
   | [] -> Pp.verbatim "true"

--- a/src/dune/action_unexpanded.ml
+++ b/src/dune/action_unexpanded.ml
@@ -201,6 +201,8 @@ module Partial = struct
         , List.map ~f:(E.string ~expander) extras
         , E.target ~expander target )
     | No_infer t -> No_infer (expand t ~expander)
+    | Pipe (outputs, l) ->
+      Pipe (outputs, List.map l ~f:(expand ~expander))
 end
 
 module E = Expand (struct
@@ -313,6 +315,8 @@ let rec partial_expand t ~expander : Partial.t =
       , List.map extras ~f:(E.string ~expander)
       , E.target ~expander target )
   | No_infer t -> No_infer (partial_expand t ~expander)
+  | Pipe (outputs, l) ->
+    Pipe (outputs, List.map l ~f:(partial_expand ~expander))
 
 module Infer : sig
   module Outcome : sig
@@ -418,7 +422,9 @@ end = struct
       | Setenv (_, _, t)
       | Ignore (_, t) ->
         infer acc t
-      | Progn l -> List.fold_left l ~init:acc ~f:infer
+      | Progn l
+      | Pipe (_, l) ->
+        List.fold_left l ~init:acc ~f:infer
       | Digest_files l -> List.fold_left l ~init:acc ~f:( +< )
       | Diff { optional; file1; file2; mode = _ } ->
         if optional then

--- a/src/dune/stanza.ml
+++ b/src/dune/stanza.ml
@@ -6,7 +6,7 @@ module Parser = struct
   type nonrec t = string * t list Dune_lang.Decoder.t
 end
 
-let latest_version = (2, 6)
+let latest_version = (2, 7)
 
 let since v = (v, `Since v)
 

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -2109,6 +2109,14 @@
    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias pipe-actions)
+ (deps (package dune) (source_tree test-cases/pipe-actions) (alias test-deps))
+ (action
+  (chdir
+   test-cases/pipe-actions
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias plugin-mode)
  (deps (package dune) (source_tree test-cases/plugin-mode) (alias test-deps))
  (action
@@ -3163,6 +3171,7 @@
   (alias output-obj)
   (alias package-dep)
   (alias path-variables)
+  (alias pipe-actions)
   (alias plugin-mode)
   (alias ppx-rewriter)
   (alias ppx-runtime-dependencies)
@@ -3432,6 +3441,7 @@
   (alias optional-executable)
   (alias output-obj)
   (alias path-variables)
+  (alias pipe-actions)
   (alias plugin-mode)
   (alias preprocess-with-action)
   (alias private-modules)

--- a/test/blackbox-tests/test-cases/merlin/server/run.t
+++ b/test/blackbox-tests/test-cases/merlin/server/run.t
@@ -4,9 +4,9 @@
   > EOF
   ()
 
-  $ dune build @check
+  $ dune build @check 2>&1 | sed "s/(lang dune .*)/(lang dune <version>)/"
   Info: Creating file dune-project with this contents:
-  | (lang dune 2.6)
+  | (lang dune <version>)
   $ dune ocaml-merlin  <<EOF
   > (4:File${#FILE}:$FILE)
   > EOF

--- a/test/blackbox-tests/test-cases/pipe-actions/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions/run.t
@@ -1,0 +1,30 @@
+The new pipe actions are only available since dune 2.7:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.6)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias pipe)
+  >  (action
+  >   (pipe-outputs (echo "a\nb\nc") (run grep "a\\\\|b") (run grep "b\\\\|c"))))
+  > EOF
+
+  $ dune build @pipe
+  File "dune", line 4, characters 2-71:
+  4 |   (pipe-outputs (echo "a\nb\nc") (run grep "a\\|b") (run grep "b\\|c"))))
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'pipe-outputs' is only available since version 2.7 of the dune
+  language. Please update your dune-project file to have (lang dune 2.7).
+  [1]
+
+You need to set the language to 2.7 or higher for it to work:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.7)
+  > EOF
+
+  $ dune build @pipe
+          grep alias pipe
+  b

--- a/test/blackbox-tests/test-cases/pipe-actions/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions/run.t
@@ -28,3 +28,25 @@ You need to set the language to 2.7 or higher for it to work:
   $ dune build @pipe
           grep alias pipe
   b
+
+The makefile version of pipe actious uses actual pipes.
+Note that we wrap the previous into a with-stdout-to so that we can easily refer
+to the target in the dune rule invocation below.
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias pipe)
+  >  (action
+  >   (with-outputs-to target
+  >    (pipe-outputs (echo "a\nb\nc") (run grep "'a\\\\|b'") (run grep "'b\\\\|c'")))))
+  > EOF
+
+  $ dune rule -m target
+  _build/default/target: /usr/bin/grep
+  	mkdir -p _build/default; \
+  	mkdir -p _build/default; \
+  	cd _build/default; \
+  	{ echo -n c; echo b; echo a; } 2>&1 | /usr/bin/grep a\|b 2>&1 | /usr/bin/grep \
+  	                                                                  b\|c &> \
+  	  target
+  

--- a/test/blackbox-tests/test-cases/pipe-actions/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions/run.t
@@ -29,24 +29,26 @@ You need to set the language to 2.7 or higher for it to work:
           grep alias pipe
   b
 
-The makefile version of pipe actious uses actual pipes.
-Note that we wrap the previous into a with-stdout-to so that we can easily refer
-to the target in the dune rule invocation below.
+The makefile version of pipe actious uses actual pipes:
 
+  $ touch a.ml b.ml c.ml dummy.opam
   $ cat >dune <<EOF
+  > (executables
+  >  (public_names a b c))
+  > 
   > (rule
   >  (alias pipe)
   >  (action
   >   (with-outputs-to target
-  >    (pipe-outputs (echo "a\nb\nc") (run grep "'a\\\\|b'") (run grep "'b\\\\|c'")))))
+  >    (pipe-outputs (run a) (run b) (run c)))))
   > EOF
 
   $ dune rule -m target
-  _build/default/target: /usr/bin/grep
+  _build/default/target: _build/install/default/bin/a \
+    _build/install/default/bin/b _build/install/default/bin/c
   	mkdir -p _build/default; \
   	mkdir -p _build/default; \
   	cd _build/default; \
-  	{ echo -n c; echo b; echo a; } 2>&1 | /usr/bin/grep a\|b 2>&1 | /usr/bin/grep \
-  	                                                                  b\|c &> \
-  	  target
+  	../install/default/bin/a 2>&1 | ../install/default/bin/b 2>&1 | ../install/default/bin/c \
+  	  &> target
   

--- a/test/blackbox-tests/test-cases/pipe-actions/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions/run.t
@@ -8,13 +8,20 @@ The new pipe actions are only available since dune 2.7:
   > (rule
   >  (alias pipe)
   >  (action
-  >   (pipe-outputs (echo "a\nb\nc") (run grep "a\\\\|b") (run grep "b\\\\|c"))))
+  >   (pipe-outputs
+  >    (echo "a\nb\nc")
+  >    (run tr a x)
+  >    (run tr b y)
+  >    (run tr c z))))
   > EOF
 
   $ dune build @pipe
-  File "dune", line 4, characters 2-71:
-  4 |   (pipe-outputs (echo "a\nb\nc") (run grep "a\\|b") (run grep "b\\|c"))))
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "dune", line 4, characters 2-84:
+  4 |   (pipe-outputs
+  5 |    (echo "a\nb\nc")
+  6 |    (run tr a x)
+  7 |    (run tr b y)
+  8 |    (run tr c z))))
   Error: 'pipe-outputs' is only available since version 2.7 of the dune
   language. Please update your dune-project file to have (lang dune 2.7).
   [1]
@@ -26,8 +33,10 @@ You need to set the language to 2.7 or higher for it to work:
   > EOF
 
   $ dune build @pipe
-          grep alias pipe
-  b
+            tr alias pipe
+  x
+  y
+  z
 
 The makefile version of pipe actious uses actual pipes:
 


### PR DESCRIPTION
Fixes #428 

This PR introduces `pipe-outputs`, `pipe-stdout` and `pipe-stderr` to the action language.

The tests don't cover much atm. In particular I'd like to make sure I got the `Action_to_sh` part right but I'm unsure what's the best way to test it.

I also believe I need to fix the stdout/stderr-only cases by adding a `multi_use` to the one that's not being piped.