### PR TITLE
Bump dune-project to 2.5

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.3)
+(lang dune 2.5)
 (name dune)
 
 (generate_opam_files true)


### PR DESCRIPTION
It looks like the Dune's `dune-project` file has fallen behind, and some useful features (like #3092) are not enabled leading to problems like those discussed in #3376.

Let's bump the version to `2.5`. 

Shall we do any other adjustments to `dune-project` to safely transition to the new version?