### PR TITLE
Move opaque setting to Compilation_context

### DIFF
--- a/src/dune/cinaps.ml
+++ b/src/dune/cinaps.ml
@@ -95,7 +95,7 @@ let gen_rules sctx t ~dir ~scope =
   in
   let cctx =
     Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
-      ~modules ~opaque:false
+      ~modules ~opaque:(Explicit false)
       ~requires_compile:(Lib.Compile.direct_requires compile_info)
       ~requires_link:(Lib.Compile.requires_link compile_info)
       ~flags:(Ocaml_flags.of_list [ "-w"; "-24" ])

--- a/src/dune/compilation_context.ml
+++ b/src/dune/compilation_context.ml
@@ -39,6 +39,16 @@ module Includes = struct
   let empty = Cm_kind.Dict.make_all Command.Args.empty
 end
 
+type opaque =
+  | Explicit of bool
+  | Inherit_from_settings
+
+let eval_opaque (context : Context.t) = function
+  | Explicit b -> b
+  | Inherit_from_settings ->
+    Profile.is_dev context.profile
+    && Ocaml_version.supports_opaque_for_mli context.version
+
 type t =
   { super_context : Super_context.t
   ; scope : Scope.t
@@ -122,6 +132,7 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
     in
     Option.value ~default modes |> Mode.Dict.map ~f:Option.is_some
   in
+  let opaque = eval_opaque (Super_context.context super_context) opaque in
   { super_context
   ; scope
   ; expander

--- a/src/dune/compilation_context.mli
+++ b/src/dune/compilation_context.mli
@@ -10,6 +10,10 @@ open Import
     associated to each library, executable and executables stanza. *)
 type t
 
+type opaque =
+  | Explicit of bool
+  | Inherit_from_settings
+
 (** Create a compilation context. *)
 val create :
      super_context:Super_context.t
@@ -21,7 +25,7 @@ val create :
   -> requires_compile:Lib.t list Or_exn.t
   -> requires_link:Lib.t list Or_exn.t Lazy.t
   -> ?preprocessing:Preprocessing.t
-  -> opaque:bool
+  -> opaque:opaque
   -> ?stdlib:Ocaml_stdlib.t
   -> js_of_ocaml:Dune_file.Js_of_ocaml.t option
   -> dynlink:bool

--- a/src/dune/exe_rules.ml
+++ b/src/dune/exe_rules.ml
@@ -126,7 +126,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
     in
     Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
       ~modules ~flags ~requires_link ~requires_compile ~preprocessing:pp
-      ~js_of_ocaml ~opaque:(SC.opaque sctx) ~dynlink ~package:exes.package
+      ~js_of_ocaml ~opaque:Inherit_from_settings ~dynlink ~package:exes.package
   in
   let o_files =
     if not (Executables.has_foreign exes) then

--- a/src/dune/inline_tests.ml
+++ b/src/dune/inline_tests.ml
@@ -276,7 +276,7 @@ include Sub_system.Register_end_point (struct
        Build.With_targets.add ~targets:[ target ] action);
     let cctx =
       Compilation_context.create () ~super_context:sctx ~expander ~scope
-        ~obj_dir ~modules ~opaque:false ~requires_compile:runner_libs
+        ~obj_dir ~modules ~opaque:(Explicit false) ~requires_compile:runner_libs
         ~requires_link:(lazy runner_libs)
         ~flags:(Ocaml_flags.of_list [ "-w"; "-24"; "-g" ])
         ~js_of_ocaml:(Some lib.buildable.js_of_ocaml) ~dynlink:false

--- a/src/dune/lib_rules.ml
+++ b/src/dune/lib_rules.ml
@@ -355,7 +355,6 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
   let requires_compile = Lib.Compile.direct_requires compile_info in
   let requires_link = Lib.Compile.requires_link compile_info in
   let ctx = Super_context.context sctx in
-  let opaque = Super_context.opaque sctx in
   let dynlink =
     Dynlink_supported.get lib.dynlink ctx.supports_shared_libraries
   in
@@ -364,8 +363,9 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
     Dune_file.Mode_conf.Set.eval_detailed lib.modes ~has_native
   in
   Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
-    ~modules ~flags ~requires_compile ~requires_link ~preprocessing:pp ~opaque
-    ~js_of_ocaml:(Some lib.buildable.js_of_ocaml) ~dynlink ?stdlib:lib.stdlib
+    ~modules ~flags ~requires_compile ~requires_link ~preprocessing:pp
+    ~opaque:Inherit_from_settings ~js_of_ocaml:(Some lib.buildable.js_of_ocaml)
+    ~dynlink ?stdlib:lib.stdlib
     ~package:(Option.map lib.public ~f:(fun p -> p.package))
     ?vimpl ~modes
 

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -651,10 +651,6 @@ module Action = struct
       ~targets_dir ~targets:targets_written_by_user ~expander ~foreign_flags
 end
 
-let opaque t =
-  Profile.is_dev t.context.profile
-  && Ocaml_version.supports_opaque_for_mli t.context.version
-
 let dir_status_db t = t.dir_status_db
 
 module As_memo_key = struct

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -179,8 +179,6 @@ module Action : sig
   val map_exe : t -> Path.t -> Path.t
 end
 
-val opaque : t -> bool
-
 val expander : t -> dir:Path.Build.t -> Expander.t
 
 val dir_status_db : t -> Dir_status.DB.t

--- a/src/dune/toplevel.ml
+++ b/src/dune/toplevel.ml
@@ -179,8 +179,8 @@ module Stanza = struct
       Compilation_context.create () ~super_context:sctx ~scope ~obj_dir
         ~expander
         ~modules:(Source.modules source preprocessing)
-        ~opaque:false ~requires_compile ~requires_link ~flags ~js_of_ocaml:None
-        ~dynlink:false ~package:None ~preprocessing
+        ~opaque:(Explicit false) ~requires_compile ~requires_link ~flags
+        ~js_of_ocaml:None ~dynlink:false ~package:None ~preprocessing
     in
     let resolved = make ~cctx ~source ~preprocess:toplevel.pps in
     setup_rules resolved

--- a/src/dune/utop.ml
+++ b/src/dune/utop.ml
@@ -104,7 +104,7 @@ let setup sctx ~dir =
   in
   let cctx =
     Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
-      ~modules ~opaque:false
+      ~modules ~opaque:(Explicit false)
       ~requires_link:(lazy requires)
       ~requires_compile:requires ~flags ~js_of_ocaml:None ~dynlink:false
       ~package:None ~preprocessing


### PR DESCRIPTION
This setting is specific to OCaml compilation, so it should be in the
compilation context as much as possible.

This allows us to remove yet another function from Super_context