### PR TITLE
Remove stdune from configurator and switch to csexp

### DIFF
--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -5,7 +5,7 @@
  (public_name dune-configurator)
  (preprocess future_syntax)
  (private_modules import dune_lang ocaml_config)
- (libraries dune-private-libs.dune_csexp)
+ (libraries unix dune-private-libs.dune_csexp)
  (flags
   (:standard
    -safe-string

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -5,8 +5,8 @@
  (public_name dune-configurator)
  (preprocess future_syntax)
  (private_modules import)
- (libraries dune-private-libs.ocaml-config dune-private-libs.stdune
-   dune-private-libs.dune-lang dune_csexp)
+ (libraries dune-private-libs.ocaml-config dune-private-libs.dune-lang
+   dune-private-libs.dune_csexp)
  (flags
   (:standard
    -safe-string

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -6,7 +6,7 @@
  (preprocess future_syntax)
  (private_modules import)
  (libraries dune-private-libs.ocaml-config dune-private-libs.stdune
-   dune-private-libs.dune-lang)
+   dune-private-libs.dune-lang dune_csexp)
  (flags
   (:standard
    -safe-string

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -4,8 +4,8 @@
  (name configurator)
  (public_name dune-configurator)
  (preprocess future_syntax)
- (private_modules import)
- (libraries dune-private-libs.dune-lang dune-private-libs.dune_csexp)
+ (private_modules import dune_lang ocaml_config)
+ (libraries dune-private-libs.dune_csexp)
  (flags
   (:standard
    -safe-string

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -4,7 +4,8 @@
  (name configurator)
  (public_name dune-configurator)
  (preprocess future_syntax)
- (libraries dune-private-libs.stdune dune-private-libs.ocaml-config
+ (private_modules import)
+ (libraries dune-private-libs.ocaml-config dune-private-libs.stdune
    dune-private-libs.dune-lang)
  (flags
   (:standard

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -5,8 +5,7 @@
  (public_name dune-configurator)
  (preprocess future_syntax)
  (private_modules import)
- (libraries dune-private-libs.ocaml-config dune-private-libs.dune-lang
-   dune-private-libs.dune_csexp)
+ (libraries dune-private-libs.dune-lang dune-private-libs.dune_csexp)
  (flags
   (:standard
    -safe-string

--- a/otherlibs/configurator/src/dune_lang.ml
+++ b/otherlibs/configurator/src/dune_lang.ml
@@ -1,0 +1,95 @@
+open Import
+
+module Escape : sig
+  val quoted : string -> string
+end = struct
+  let quote_length s =
+    let n = ref 0 in
+    let len = String.length s in
+    for i = 0 to len - 1 do
+      n :=
+        !n
+        +
+        match String.unsafe_get s i with
+        | '\"'
+        | '\\'
+        | '\n'
+        | '\t'
+        | '\r'
+        | '\b' ->
+          2
+        | '%' ->
+          if i + 1 < len && s.[i + 1] = '{' then
+            2
+          else
+            1
+        | ' ' .. '~' -> 1
+        | _ -> 4
+    done;
+    !n
+
+  let escape_to s ~dst:s' ~ofs =
+    let n = ref ofs in
+    let len = String.length s in
+    for i = 0 to len - 1 do
+      ( match String.unsafe_get s i with
+      | ('\"' | '\\') as c ->
+        Bytes.unsafe_set s' !n '\\';
+        incr n;
+        Bytes.unsafe_set s' !n c
+      | '\n' ->
+        Bytes.unsafe_set s' !n '\\';
+        incr n;
+        Bytes.unsafe_set s' !n 'n'
+      | '\t' ->
+        Bytes.unsafe_set s' !n '\\';
+        incr n;
+        Bytes.unsafe_set s' !n 't'
+      | '\r' ->
+        Bytes.unsafe_set s' !n '\\';
+        incr n;
+        Bytes.unsafe_set s' !n 'r'
+      | '\b' ->
+        Bytes.unsafe_set s' !n '\\';
+        incr n;
+        Bytes.unsafe_set s' !n 'b'
+      | '%' when i + 1 < len && s.[i + 1] = '{' ->
+        Bytes.unsafe_set s' !n '\\';
+        incr n;
+        Bytes.unsafe_set s' !n '%'
+      | ' ' .. '~' as c -> Bytes.unsafe_set s' !n c
+      | c ->
+        let a = Char.code c in
+        Bytes.unsafe_set s' !n '\\';
+        incr n;
+        Bytes.unsafe_set s' !n (Char.unsafe_chr (48 + (a / 100)));
+        incr n;
+        Bytes.unsafe_set s' !n (Char.unsafe_chr (48 + (a / 10 mod 10)));
+        incr n;
+        Bytes.unsafe_set s' !n (Char.unsafe_chr (48 + (a mod 10))) );
+      incr n
+    done
+
+  (* Surround [s] with quotes, escaping it if necessary. *)
+  let quoted s =
+    let len = String.length s in
+    let n = quote_length s in
+    let s' = Bytes.create (n + 2) in
+    Bytes.unsafe_set s' 0 '"';
+    if len = 0 || n > len then
+      escape_to s ~dst:s' ~ofs:1
+    else
+      Bytes.blit_string ~src:s ~src_pos:0 ~dst:s' ~dst_pos:1 ~len;
+    Bytes.unsafe_set s' (n + 1) '"';
+    Bytes.unsafe_to_string s'
+end
+
+type t =
+  | Quoted_string of string
+  | List of t list
+
+let rec to_string t =
+  match t with
+  | Quoted_string s -> Escape.quoted s
+  | List l ->
+    Printf.sprintf "(%s)" (List.map l ~f:to_string |> String.concat ~sep:" ")

--- a/otherlibs/configurator/src/dune_lang.mli
+++ b/otherlibs/configurator/src/dune_lang.mli
@@ -1,0 +1,6 @@
+(** Subset of dune_lang to print flag lists *)
+type t =
+  | Quoted_string of string
+  | List of t list
+
+val to_string : t -> string

--- a/otherlibs/configurator/src/import.ml
+++ b/otherlibs/configurator/src/import.ml
@@ -104,8 +104,28 @@ module String = struct
       | exception Not_found -> None
       | s -> Some s
 
+    let set t k v = add ~key:k ~data:v t
+
+    let of_list =
+      let rec loop acc = function
+        | [] -> Result.Ok acc
+        | (k, v) :: l -> (
+          match find acc k with
+          | None -> loop (set acc k v) l
+          | Some v_old -> Error (k, v_old, v) )
+      in
+      fun l -> loop empty l
+
     let of_list_exn l = of_seq (List.to_seq l)
   end
+
+  let take s i = sub s ~pos:0 ~len:(max i (String.length s))
+
+  let drop s n =
+    let len = length s in
+    sub s ~pos:(min n len) ~len:(max (len - n) 0)
+
+  let index = index_opt
 
   let split_lines s =
     let rec loop ~last_is_cr ~acc i j =

--- a/otherlibs/configurator/src/import.ml
+++ b/otherlibs/configurator/src/import.ml
@@ -1,0 +1,277 @@
+let sprintf = Printf.sprintf
+
+let eprintf = Printf.eprintf
+
+let ( ^/ ) = Filename.concat
+
+exception Fatal_error of string
+
+let die fmt = Printf.ksprintf (fun s -> raise (Fatal_error s)) fmt
+
+let warn fmt =
+  Printf.ksprintf (fun msg -> prerr_endline ("Warning: " ^ msg)) fmt
+
+module Exn = struct
+  external reraise : exn -> _ = "%reraise"
+
+  let protectx x ~f ~finally =
+    match f x with
+    | y ->
+      finally x;
+      y
+    | exception e ->
+      finally x;
+      raise e
+
+  let protect ~f ~finally = protectx () ~f ~finally
+
+  let raise_with_backtrace = Printexc.raise_with_backtrace
+end
+
+module Option = struct
+  let map t ~f =
+    match t with
+    | None -> None
+    | Some x -> Some (f x)
+
+  let some_if cond x =
+    if cond then
+      Some x
+    else
+      None
+
+  let try_with f =
+    match f () with
+    | exception _ -> None
+    | x -> Some x
+
+  let iter t ~f =
+    match t with
+    | None -> ()
+    | Some x -> f x
+
+  module O = struct
+    let ( let* ) x f =
+      match x with
+      | None -> None
+      | Some x -> f x
+
+    let ( let+ ) x f = map x ~f
+  end
+end
+
+module List = struct
+  include ListLabels
+
+  let rec find_map l ~f =
+    match l with
+    | [] -> None
+    | x :: l -> (
+      match f x with
+      | None -> find_map l ~f
+      | Some _ as res -> res )
+end
+
+module Array = ArrayLabels
+
+module Bool = struct
+  let of_string = bool_of_string_opt
+end
+
+module Int = struct
+  let of_string = int_of_string_opt
+
+  module Map = struct
+    include MoreLabels.Map.Make (Int)
+
+    let find m k =
+      match find k m with
+      | exception Not_found -> None
+      | s -> Some s
+
+    let of_list_exn l = of_seq (List.to_seq l)
+  end
+end
+
+module String = struct
+  include StringLabels
+
+  module Map = struct
+    include MoreLabels.Map.Make (String)
+
+    let find m k =
+      match find k m with
+      | exception Not_found -> None
+      | s -> Some s
+
+    let of_list_exn l = of_seq (List.to_seq l)
+  end
+
+  let split_lines s =
+    let rec loop ~last_is_cr ~acc i j =
+      if j = length s then
+        let acc =
+          if j = i || (j = i + 1 && last_is_cr) then
+            acc
+          else
+            sub s ~pos:i ~len:(j - i) :: acc
+        in
+        List.rev acc
+      else
+        match s.[j] with
+        | '\r' -> loop ~last_is_cr:true ~acc i (j + 1)
+        | '\n' ->
+          let line =
+            let len =
+              if last_is_cr then
+                j - i - 1
+              else
+                j - i
+            in
+            sub s ~pos:i ~len
+          in
+          loop ~acc:(line :: acc) (j + 1) (j + 1) ~last_is_cr:false
+        | _ -> loop ~acc i (j + 1) ~last_is_cr:false
+    in
+    loop ~acc:[] 0 0 ~last_is_cr:false
+
+  let exists =
+    let rec loop s i len f =
+      if i = len then
+        false
+      else
+        f (unsafe_get s i) || loop s (i + 1) len f
+    in
+    fun s ~f -> loop s 0 (length s) f
+
+  let is_empty = function
+    | "" -> true
+    | _ -> false
+
+  let extract_words s ~is_word_char =
+    let rec skip_blanks i =
+      if i = length s then
+        []
+      else if is_word_char s.[i] then
+        parse_word i (i + 1)
+      else
+        skip_blanks (i + 1)
+    and parse_word i j =
+      if j = length s then
+        [ sub s ~pos:i ~len:(j - i) ]
+      else if is_word_char s.[j] then
+        parse_word i (j + 1)
+      else
+        sub s ~pos:i ~len:(j - i) :: skip_blanks (j + 1)
+    in
+    skip_blanks 0
+
+  let extract_comma_space_separated_words s =
+    extract_words s ~is_word_char:(function
+      | ','
+      | ' '
+      | '\t'
+      | '\n' ->
+        false
+      | _ -> true)
+
+  let extract_blank_separated_words s =
+    extract_words s ~is_word_char:(function
+      | ' '
+      | '\t' ->
+        false
+      | _ -> true)
+
+  let split s ~on =
+    let rec loop i j =
+      if j = length s then
+        [ sub s ~pos:i ~len:(j - i) ]
+      else if s.[j] = on then
+        sub s ~pos:i ~len:(j - i) :: loop (j + 1) (j + 1)
+      else
+        loop i (j + 1)
+    in
+    loop 0 0
+end
+
+module Io = struct
+  let open_in ?(binary = true) fn =
+    if binary then
+      Stdlib.open_in_bin fn
+    else
+      Stdlib.open_in fn
+
+  let open_out ?(binary = true) fn =
+    if binary then
+      Stdlib.open_out_bin fn
+    else
+      Stdlib.open_out fn
+
+  let input_lines =
+    let rec loop ic acc =
+      match input_line ic with
+      | exception End_of_file -> List.rev acc
+      | line -> loop ic (line :: acc)
+    in
+    fun ic -> loop ic []
+
+  let with_file_in ?binary fn ~f =
+    Exn.protectx (open_in ?binary fn) ~finally:close_in ~f
+
+  let with_file_out ?binary p ~f =
+    Exn.protectx (open_out ?binary p) ~finally:close_out ~f
+
+  let write_file ?binary fn data =
+    with_file_out ?binary fn ~f:(fun oc -> output_string oc data)
+
+  let write_lines ?binary fn lines =
+    with_file_out ?binary fn ~f:(fun oc ->
+        List.iter
+          ~f:(fun line ->
+            output_string oc line;
+            output_string oc "\n")
+          lines)
+
+  let read_all =
+    (* We use 65536 because that is the size of OCaml's IO buffers. *)
+    let chunk_size = 65536 in
+    (* Generic function for channels such that seeking is unsupported or broken *)
+    let read_all_generic t buffer =
+      let rec loop () =
+        Buffer.add_channel buffer t chunk_size;
+        loop ()
+      in
+      try loop () with End_of_file -> Buffer.contents buffer
+    in
+    fun t ->
+      (* Optimisation for regular files: if the channel supports seeking, we
+         compute the length of the file so that we read exactly what we need and
+         avoid an extra memory copy. We expect that most files Dune reads are
+         regular files so this optimizations seems worth it. *)
+      match in_channel_length t with
+      | exception _ -> read_all_generic t (Buffer.create chunk_size)
+      | n -> (
+        let s = really_input_string t n in
+        (* For some files [in_channel_length] returns an invalid value. For
+           instance for files in /proc it returns [0]. So we try to read one
+           more character to make sure we did indeed reach the end of the file *)
+        match input_char t with
+        | exception End_of_file -> s
+        | c ->
+          (* The [+ chunk_size] is to make sure there is at least [chunk_size]
+             free space so that the first [Buffer.add_channel buffer t
+             chunk_size] in [read_all_generic] does not grow the buffer. *)
+          let buffer = Buffer.create (String.length s + 1 + chunk_size) in
+          Buffer.add_string buffer s;
+          Buffer.add_char buffer c;
+          read_all_generic t buffer )
+
+  let read_file ?binary fn = with_file_in fn ~f:read_all ?binary
+
+  let with_lexbuf_from_file fn ~f =
+    with_file_in fn ~f:(fun ic ->
+        let lb = Lexing.from_channel ic in
+        lb.lex_curr_p <-
+          { pos_fname = fn; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 };
+        f lb)
+end

--- a/otherlibs/configurator/src/import.ml
+++ b/otherlibs/configurator/src/import.ml
@@ -275,3 +275,14 @@ module Io = struct
           { pos_fname = fn; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 };
         f lb)
 end
+
+module Sexp = struct
+  module T = struct
+    type t =
+      | Atom of string
+      | List of t list
+  end
+
+  include T
+  include Dune_csexp.Csexp.Make (T)
+end

--- a/otherlibs/configurator/src/import.ml
+++ b/otherlibs/configurator/src/import.ml
@@ -93,6 +93,8 @@ module Int = struct
   end
 end
 
+module Bytes = StdLabels.Bytes
+
 module String = struct
   include StringLabels
 

--- a/otherlibs/configurator/src/ocaml_config.ml
+++ b/otherlibs/configurator/src/ocaml_config.ml
@@ -1,0 +1,29 @@
+open Import
+
+module Vars = struct
+  type t = string String.Map.t
+
+  let of_lines lines =
+    let rec loop acc = function
+      | [] -> Ok acc
+      | line :: lines -> (
+        match String.index line ':' with
+        | Some i ->
+          let x =
+            ( String.take line i
+            , String.drop line (i + 2) (* skipping the space *) )
+          in
+          loop (x :: acc) lines
+        | None -> Error (Printf.sprintf "Unrecognized line: %S" line) )
+    in
+    match loop [] lines with
+    | Error _ as e -> e
+    | Ok s -> (
+      match String.Map.of_list s with
+      | Ok _ as s -> s
+      | Error (var, _, _) -> Error (sprintf "Variable %S present twice." var) )
+
+  let of_list_exn = String.Map.of_list_exn
+
+  let find t x = String.Map.find t x
+end

--- a/otherlibs/configurator/src/ocaml_config.mli
+++ b/otherlibs/configurator/src/ocaml_config.mli
@@ -1,0 +1,12 @@
+(** Represent the parsed but uninterpreted output of [ocamlc -config] or
+    contents of [Makefile.config]. *)
+module Vars : sig
+  type t
+
+  val find : t -> string -> string option
+
+  val of_list_exn : (string * string) list -> t
+
+  (** Parse the output of [ocamlc -config] given as a list of lines. *)
+  val of_lines : string list -> (t, string) result
+end

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -245,7 +245,7 @@ let write_dot_dune_dir ~build_dir ~ocamlc ~ocaml_config_vars =
        (record_fields
           [ field "ocamlc" string (Path.to_absolute_filename ocamlc)
           ; field_l "ocaml_config_vars" (pair string string)
-              (String.Map.to_list ocaml_config_vars)
+              (Ocaml_config.Vars.to_list ocaml_config_vars)
           ]))
 
 let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -291,6 +291,12 @@ let split_prog s =
 module Vars = struct
   type t = string String.Map.t
 
+  let to_list = String.Map.to_list
+
+  let of_list_exn = String.Map.of_list_exn
+
+  let find = String.Map.find
+
   let of_lines lines =
     let rec loop acc = function
       | [] -> Ok acc

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -2,13 +2,11 @@
 
     This library is internal to dune and guarantees no API stability. *)
 
-open! Stdune
-
 (** Represent a parsed and interpreted output of [ocamlc -config] and contents
     of [Makefile.config]. *)
 type t
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Stdune.Dyn.Encoder.t
 
 module Prog_and_args : sig
   type t =
@@ -31,7 +29,7 @@ module Vars : sig
   val to_list : t -> (string * string) list
 
   (** Parse the output of [ocamlc -config] given as a list of lines. *)
-  val of_lines : string list -> (t, string) Result.t
+  val of_lines : string list -> (t, string) result
 end
 
 (** {1 Creation} *)
@@ -39,7 +37,7 @@ end
 module Origin : sig
   type t =
     | Ocamlc_config
-    | Makefile_config of Path.t
+    | Makefile_config of Stdune.Path.t
 end
 
 module Os_type : sig
@@ -56,14 +54,14 @@ module Ccomp_type : sig
     | Msvc
     | Other of string
 
-  val to_dyn : t -> Dyn.t
+  val to_dyn : t -> Stdune.Dyn.t
 
   val to_string : t -> string
 end
 
 (** Interpret raw bindings (this function also loads the [Makefile.config] file
     in the stdlib directory). *)
-val make : Vars.t -> (t, Origin.t * string) Result.t
+val make : Vars.t -> (t, Origin.t * string) result
 
 (** {1 Query} *)
 
@@ -180,7 +178,7 @@ module Value : sig
 
   val to_string : t -> string
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Stdune.Dyn.Encoder.t
 end
 
 val to_list : t -> (string * Value.t) list

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -22,7 +22,13 @@ end
 (** Represent the parsed but uninterpreted output of [ocamlc -config] or
     contents of [Makefile.config]. *)
 module Vars : sig
-  type t = string String.Map.t
+  type t
+
+  val find : t -> string -> string option
+
+  val of_list_exn : (string * string) list -> t
+
+  val to_list : t -> (string * string) list
 
   (** Parse the output of [ocamlc -config] given as a list of lines. *)
   val of_lines : string list -> (t, string) Result.t


### PR DESCRIPTION
- [x] Helper functions now exist in Import
- [x] I've made ocaml_config not export any stdune stuff
- [x] Conversion is done using csexp
- [x] vendor ocaml_config parsing in configurator.

@diml I'm wondering, perhaps we should just merge ocaml_config and configurator?