### PR TITLE
Package dependency handling

### DIFF
--- a/src/dune/build_system.ml
+++ b/src/dune/build_system.ml
@@ -149,10 +149,12 @@ module Alias0 = struct
             (Path.Source.to_string_maybe_quoted src_dir)
         ]
 
-  let package_install ~(context : Context.t) ~pkg =
+  let package_install ~(context : Context.t) ~(pkg : Package.t) =
+    let dir = Path.Build.append_source context.build_dir pkg.path in
     make
-      (Alias.Name.of_string (sprintf ".%s-files" (Package.Name.to_string pkg)))
-      ~dir:context.build_dir
+      (Alias.Name.of_string
+         (sprintf ".%s-files" (Package.Name.to_string pkg.name)))
+      ~dir
 end
 
 module Loaded = struct

--- a/src/dune/build_system.mli
+++ b/src/dune/build_system.mli
@@ -101,7 +101,7 @@ module Alias : sig
   type t = Alias.t
 
   (** Alias for all the files in [_build/install] that belong to this package *)
-  val package_install : context:Context.t -> pkg:Package.Name.t -> t
+  val package_install : context:Context.t -> pkg:Package.t -> t
 
   (** [dep t = Build.path (stamp_file t)] *)
   val dep : t -> unit Build.t

--- a/src/dune/install_rules.ml
+++ b/src/dune/install_rules.ml
@@ -639,13 +639,16 @@ let install_rules sctx (package : Package.t) =
   in
   let () =
     let target_alias =
-      Build_system.Alias.package_install ~context:ctx ~pkg:package.name
+      Build_system.Alias.package_install ~context:ctx ~pkg:package
     in
     Rules.Produce.Alias.add_deps target_alias files
       ~dyn_deps:
         (let+ packages = packages in
          Package.Name.Set.to_list packages
          |> Path.Set.of_list_map ~f:(fun pkg ->
+                let pkg =
+                  Package.Name.Map.find_exn (Super_context.packages sctx) pkg
+                in
                 Build_system.Alias.package_install ~context:ctx ~pkg
                 |> Alias.stamp_file |> Path.build))
   in
@@ -731,7 +734,6 @@ let memo =
         ( Dir_set.union_all
             [ Dir_set.subtree (Config.local_install_dir ~context:context_name)
             ; Dir_set.singleton (Package_paths.build_dir ctx pkg)
-            ; Dir_set.singleton ctx.build_dir
             ]
         , Thunk (fun () -> Finite (Rules.to_map (Memo.Lazy.force rules))) ))
 

--- a/src/dune/mdx.ml
+++ b/src/dune/mdx.ml
@@ -182,8 +182,11 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~mdx_prog src =
     let dyn_deps = Build.map deps ~f:(fun d -> ((), d)) in
     let pkg_deps =
       let context = Super_context.context sctx in
-      List.map stanza.packages ~f:(fun pkg ->
-          Build.alias (Build_system.Alias.package_install ~context ~pkg))
+      let packages = Super_context.packages sctx in
+      stanza.packages
+      |> List.map ~f:(fun pkg ->
+             let pkg = Package.Name.Map.find_exn packages pkg in
+             Build.alias (Build_system.Alias.package_install ~context ~pkg))
     in
     let prelude_args =
       List.concat_map stanza.preludes ~f:(Prelude.to_args ~dir)

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -573,8 +573,20 @@ module Deps = struct
       |> Result.map ~f:(fun pkg ->
              let pkg = Package.Name.of_string pkg in
              let+ () =
-               Build.alias
-                 (Build_system.Alias.package_install ~context:t.context ~pkg)
+               match Package.Name.Map.find t.packages pkg with
+               | None ->
+                 Build.fail
+                   { fail =
+                       (fun () ->
+                         let loc = String_with_vars.loc p in
+                         User_error.raise ~loc
+                           [ Pp.textf "Package %s does not exist"
+                               (Package.Name.to_string pkg)
+                           ])
+                   }
+               | Some pkg ->
+                 Build.alias
+                   (Build_system.Alias.package_install ~context:t.context ~pkg)
              in
              [])
     | Universe ->

--- a/test/blackbox-tests/test-cases/reporting-of-cycles/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles/run.t
@@ -6,9 +6,9 @@ the second run of dune.
 
   $ dune build @package-cycle
   Error: Dependency cycle between the following files:
-     _build/.aliases/default/.b-files-00000000000000000000000000000000
-  -> _build/.aliases/default/.a-files-00000000000000000000000000000000
-  -> _build/.aliases/default/.b-files-00000000000000000000000000000000
+     _build/.aliases/default/b/.b-files-00000000000000000000000000000000
+  -> _build/.aliases/default/a/.a-files-00000000000000000000000000000000
+  -> _build/.aliases/default/b/.b-files-00000000000000000000000000000000
   [1]
 
   $ dune build @simple-repro-case


### PR DESCRIPTION
* Properly error on missing packages in (package ..) definitions
* Move <pkg>-files aliases to the package dir. This makes rule loading
lazier.