### PR TITLE
Fix META generation wrt javascript deps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+- Generate correct META files for sub-libraries (of the form `lib.foo`) that
+  contain .js runtime files. (#3445, @hhugo)
+
 2.5.1 (17/04/2020)
 ------------------
 

--- a/test/blackbox-tests/test-cases/meta-gen/run.t
+++ b/test/blackbox-tests/test-cases/meta-gen/run.t
@@ -60,8 +60,8 @@
     archive(native) = "foobar_runtime_lib2.cmxa"
     plugin(byte) = "foobar_runtime_lib2.cma"
     plugin(native) = "foobar_runtime_lib2.cmxs"
-    linkopts(javascript) = "+foobar/foobar_runtime.js
-                            +foobar/foobar_runtime2.js"
+    linkopts(javascript) = "+foobar/runtime-lib2/foobar_runtime.js
+                            +foobar/runtime-lib2/foobar_runtime2.js"
     jsoo_runtime = "foobar_runtime.js foobar_runtime2.js"
   )
   package "sub" (


### PR DESCRIPTION
META generation for JavaScript runtime files was incorrect for sub-packages (installed in sub-directories).

The issue does not affect projects compiling with dune.

It only affect people relying on ocamlfind
```
$ ocamlfind query -r -predicates javascript core_kernel -o-format
+base/runtime.js
+base/runtime.js (expecting +base/base_internalhash_types/runtime.js)
+bin_prot/runtime.js
+ppx_expect/runtime.js (expecting +ppx_expect/collector/runtime.js)
+time_now/runtime.js
+base_bigstring/runtime.js
+core_kernel/strftime.js
+core_kernel/runtime.js
```