### PR TITLE
Lowercase `windows.h`

### DIFF
--- a/src/stdune/fcntl_stubs.c
+++ b/src/stdune/fcntl_stubs.c
@@ -4,7 +4,7 @@
 # include <fcntl.h>
 # include <stdio.h>
 #else
-# include <Windows.h>
+# include <windows.h>
 #endif
 
 #include <caml/custom.h>


### PR DESCRIPTION
I'm updating the `dune-windows` package and this header is giving me grief. Apparently, lower or uppercase shouldn't matter on windows so I'm proposing we change it to lowercase, which works for me. See: https://stackoverflow.com/questions/15466613/lowercase-windows-h-and-uppercase-windows-h-difference