### PR TITLE
Add public name deps.

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,7 +1,7 @@
 (executable
  (name main)
- (libraries memo dune_lang fiber stdune unix cache_daemon cache dune
-   dune_util cmdliner threads.posix build_info dune_csexp)
+ (libraries memo dune-private-libs.dune-lang fiber dune-private-libs.stdune unix cache_daemon dune-private-libs.cache dune
+   dune-private-libs.dune_util cmdliner threads.posix dune-build-info dune-private-libs.dune_csexp)
  (preprocess future_syntax)
  (bootstrap_info bootstrap-info))
 

--- a/src/cache_daemon/dune
+++ b/src/cache_daemon/dune
@@ -1,4 +1,4 @@
 (library
  (name cache_daemon)
  (preprocess future_syntax)
- (libraries dune_util threads.posix cache stdune dune_csexp))
+ (libraries dune-private-libs.dune_util threads.posix dune-private-libs.cache dune-private-libs.stdune dune-private-libs.dune_csexp))

--- a/src/catapult/dune
+++ b/src/catapult/dune
@@ -1,4 +1,4 @@
 (library
  (name catapult)
  (synopsis "Emit catapult trace files, compatible with chrome://tracing")
- (libraries stdune))
+ (libraries dune-private-libs.stdune))

--- a/src/dag/dune
+++ b/src/dag/dune
@@ -1,4 +1,4 @@
 (library
  (name dag)
- (libraries stdune incremental_cycles)
+ (libraries dune-private-libs.stdune incremental_cycles)
  (synopsis "Directed Acyclic Graph library"))

--- a/src/dune/dune
+++ b/src/dune/dune
@@ -2,9 +2,9 @@
 
 (library
  (name dune)
- (libraries unix stdune fiber incremental_cycles dag memo xdg dune_re
-   threads.posix opam_file_format dune_lang cache_daemon cache dune_glob
-   ocaml_config catapult jbuild_support dune_action_plugin dune_util)
+ (libraries unix dune-private-libs.stdune fiber incremental_cycles dag memo dune-private-libs.xdg dune-private-libs.dune_re
+   threads.posix opam_file_format dune-private-libs.dune-lang cache_daemon dune-private-libs.cache dune-glob
+   dune-private-libs.ocaml-config catapult jbuild_support dune-action-plugin dune-private-libs.dune_util)
  (synopsis "Internal Dune library, do not use!")
  (preprocess future_syntax))
 

--- a/src/fiber/dune
+++ b/src/fiber/dune
@@ -1,5 +1,5 @@
 (library
  (name fiber)
- (libraries stdune)
+ (libraries dune-private-libs.stdune)
  (preprocess future_syntax)
  (synopsis "Monadic concurrency library"))

--- a/src/jbuild_support/dune
+++ b/src/jbuild_support/dune
@@ -1,6 +1,6 @@
 (library
  (name jbuild_support)
- (libraries stdune dune_lang)
+ (libraries dune-private-libs.stdune dune-private-libs.dune-lang)
  (synopsis "Internal Dune library, do not use!")
  (preprocess future_syntax))
 

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,5 +1,5 @@
 (library
  (name memo)
  (preprocess future_syntax)
- (libraries stdune dune_lang dag fiber)
+ (libraries dune-private-libs.stdune dune-private-libs.dune-lang dag fiber)
  (synopsis "Function memoizer"))


### PR DESCRIPTION
I'm building `dune-windows` using `dune -p dune -x windows` and it seems that private libs name do not work for that use case, so I had to use public libs names. This should be safe to merge I believe?