### PR TITLE
Remove fiber.once

### DIFF
--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -431,34 +431,6 @@ let nfork_map l ~f k =
 
 let nfork l : _ Future.t list t = nfork_map l ~f:(fun f -> f ())
 
-module Once = struct
-  type 'a state =
-    | Running of 'a Future.t
-    | Not_started of (unit -> 'a t)
-    | Starting
-
-  type 'a t = { mutable state : 'a state }
-
-  let create f = { state = Not_started f }
-
-  let get t =
-    match t.state with
-    | Running fut -> Future.wait fut
-    | Not_started f ->
-      t.state <- Starting;
-      let* fut = fork f in
-      t.state <- Running fut;
-      Future.wait fut
-    | Starting -> failwith "Fiber.Once.get: recursive evaluation"
-
-  let peek t =
-    match t.state with
-    | Running fut -> Future.peek fut
-    | _ -> None
-
-  let peek_exn t = Option.value_exn (peek t)
-end
-
 module Mutex = struct
   type t =
     { mutable locked : bool

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -124,28 +124,6 @@ val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
     ]} *)
 val parallel_iter : 'a list -> f:('a -> unit t) -> unit t
 
-(** {1 Execute once fibers} *)
-
-module Once : sig
-  type 'a fiber = 'a t
-
-  type 'a t
-
-  val create : (unit -> 'a fiber) -> 'a t
-
-  (** [get t] returns the value of [t]. If [get] was never called before on this
-      [t], it is executed at this point, otherwise returns a fiber that waits
-      for the fiber from the first call to [get t] to terminate. *)
-  val get : 'a t -> 'a fiber
-
-  (** [peek t] returns [Some v] if [get t] has already been called and has
-      yielded a value [v]. *)
-  val peek : 'a t -> 'a option
-
-  val peek_exn : 'a t -> 'a
-end
-with type 'a fiber := 'a t
-
 (** {1 Local storage} *)
 
 (** Variables local to a fiber *)


### PR DESCRIPTION
And re-implement its only use case using simpler concepts.

This reduces the overall amount of code and concepts.