### PR TITLE
Add include_dirs field to dune describe

### DIFF
--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -61,19 +61,21 @@ module Crawl = struct
                  ]
                :: acc)
       in
+      let include_dirs = Obj_dir.all_cmis obj_dir in
       Some
-        (Dyn.Variant
-           ( "library"
-           , [ Dyn.Encoder.record
-                 [ ("name", Lib_name.to_dyn name)
-                 ; ("uid", String (uid_of_library lib))
-                 ; ( "requires"
-                   , Dyn.Encoder.(list string)
-                       (List.map requires ~f:uid_of_library) )
-                 ; ("source_dir", dyn_path src_dir)
-                 ; ("modules", List modules_)
-                 ]
-             ] ))
+        (let open Dyn.Encoder in
+        Dyn.Variant
+          ( "library"
+          , [ Dyn.Encoder.record
+                [ ("name", Lib_name.to_dyn name)
+                ; ("uid", String (uid_of_library lib))
+                ; ( "requires"
+                  , (list string) (List.map requires ~f:uid_of_library) )
+                ; ("source_dir", dyn_path src_dir)
+                ; ("modules", List modules_)
+                ; ("include_dirs", (list dyn_path) include_dirs)
+                ]
+            ] ))
 
   let workspace { Dune.Main.workspace; scontexts } (context : Context.t) =
     let sctx = Context_name.Map.find_exn scontexts context.name in

--- a/test/blackbox-tests/test-cases/describe/run.t
+++ b/test/blackbox-tests/test-cases/describe/run.t
@@ -38,7 +38,8 @@ Describe various things
          (impl (_build/default/foo.ml))
          (intf ())
          (cmt (_build/default/.foo.objs/byte/foo.cmt))
-         (cmti ()))))))
+         (cmti ()))))
+     (include_dirs (_build/default/.foo.objs/byte))))
    (library
     ((name foo.x)
      (uid c17373aee51bab94097b4b7818553cf3)
@@ -49,7 +50,8 @@ Describe various things
          (impl (_build/default/foo_x.ml))
          (intf ())
          (cmt (_build/default/.foo_x.objs/byte/foo_x.cmt))
-         (cmti ())))))))
+         (cmti ()))))
+     (include_dirs (_build/default/.foo_x.objs/byte)))))
 
 Test other formats
 ------------------


### PR DESCRIPTION
This field contains the list of directories containing all the cmi's of
a library.