### PR TITLE
Refactor cache trimming

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -115,6 +115,9 @@ let bytes =
     | exception User_error.E msg ->
       Result.Error (`Msg (User_message.to_string msg))
   in
-  conv (decode, Format.pp_print_int)
+  let pp_print_int64 state i =
+    Format.pp_print_string state (Int64.to_string i)
+  in
+  conv (decode, pp_print_int64)
 
 let context_name : Context_name.t conv = conv Context_name.conv

--- a/bin/arg.mli
+++ b/bin/arg.mli
@@ -25,7 +25,7 @@ module Dep : sig
   val to_string_maybe_quoted : t -> string
 end
 
-val bytes : int conv
+val bytes : int64 conv
 
 val context_name : Context_name.t conv
 

--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -79,17 +79,19 @@ let trim ~trimmed_size ~size =
           ]
       | Error e -> User_error.raise [ Pp.text (Unix.error_message e) ]
     in
-    let+ trimmed_size =
+    let+ goal =
       match (trimmed_size, size) with
       | Some trimmed_size, None -> Result.Ok trimmed_size
-      | None, Some size -> Result.Ok (Cache.Local.overhead_size cache - size)
+      | None, Some size ->
+        Result.Ok (Int64.sub (Cache.Local.overhead_size cache) size)
       | _ -> Result.Error "specify either --size or --trimmed-size"
     in
-    Cache.Local.trim cache trimmed_size
+    Cache.Local.trim cache ~goal
   with
   | Error s -> User_error.raise [ Pp.text s ]
-  | Ok { trimmed_files_size = size; _ } ->
-    User_message.print (User_message.make [ Pp.textf "Freed %i bytes" size ])
+  | Ok { trimmed_bytes } ->
+    User_message.print
+      (User_message.make [ Pp.textf "Freed %Li bytes" trimmed_bytes ])
 
 type mode =
   | Start

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -14,20 +14,16 @@ type t =
   }
 
 module Trimming_result = struct
-  type t =
-    { trimmed_files_size : int
-    ; trimmed_files : Path.t list
-    ; trimmed_metafiles : Path.t list
-    }
+  type t = { trimmed_bytes : int64 }
 
-  let empty =
-    { trimmed_files_size = 0; trimmed_files = []; trimmed_metafiles = [] }
+  let empty = { trimmed_bytes = 0L }
 
-  let add t ~size ~file =
-    { t with
-      trimmed_files = file :: t.trimmed_files
-    ; trimmed_files_size = size + t.trimmed_files_size
-    }
+  (* CR-someday amokhov: Right now Dune doesn't support large (>1Gb) files on
+     32-bit platforms due to the pervasive use of [int] for representing
+     individual file sizes. It's not fundamentally difficult to switch to
+     [int64], so we should do it if it becomes a real issue. *)
+  let add t ~(bytes : int) =
+    { trimmed_bytes = Int64.add t.trimmed_bytes (Int64.of_int bytes) }
 end
 
 let default_root () =
@@ -408,79 +404,74 @@ let make ?(root = default_root ())
 
 let duplication_mode cache = cache.duplication_mode
 
-let trimmable stats = stats.Unix.st_nlink = 1
-
-let _garbage_collect default_trim cache =
+let _garbage_collect cache ~trimmed_so_far =
   let root = metadata_store_root cache in
   let metas =
     List.map ~f:(fun p -> (p, Metadata_file.parse p)) (FSSchemeImpl.list ~root)
   in
-  let f default_trim = function
-    | p, Result.Error msg ->
-      cache.warn
-        [ Pp.textf "remove invalid metadata file %s: %s"
-            (Path.to_string_maybe_quoted p)
-            msg
-        ];
-      Path.unlink_no_err p;
-      { default_trim with Trimming_result.trimmed_metafiles = [ p ] }
-    | p, Result.Ok { Metadata_file.files; _ } ->
-      if
-        List.for_all
-          ~f:(fun { File.digest; _ } -> Path.exists (file_path cache digest))
-          files
-      then
-        default_trim
-      else (
-        cache.info
-          [ Pp.textf
-              "remove metadata file %s as some produced files are missing"
-              (Path.to_string_maybe_quoted p)
+  let f trimmed_so_far (path, metadata) =
+    let should_be_removed =
+      match metadata with
+      | Result.Error msg ->
+        cache.warn
+          [ Pp.textf "remove invalid metadata file %s: %s"
+              (Path.to_string_maybe_quoted path)
+              msg
           ];
-        let res =
-          List.fold_left ~init:default_trim
-            ~f:(fun trim f ->
-              let path_in_cache = file_path cache f.File.digest in
-              try
-                let stats = Path.stat path_in_cache in
-                if trimmable stats then (
-                  Path.unlink_no_err path_in_cache;
-                  Trimming_result.add trim ~file:path_in_cache
-                    ~size:stats.st_size
-                ) else
-                  trim
-              with Unix.Unix_error (Unix.ENOENT, _, _) -> trim)
+        true
+      | Result.Ok { Metadata_file.files; _ } ->
+        if
+          List.for_all
+            ~f:(fun { File.digest; _ } -> Path.exists (file_path cache digest))
             files
-        in
-        Path.unlink_no_err p;
-        res
-      )
+        then
+          false
+        else (
+          cache.info
+            [ Pp.textf "remove metadata file %s as it refers to missing files"
+                (Path.to_string_maybe_quoted path)
+            ];
+          true
+        )
+    in
+    if should_be_removed then (
+      let bytes = (Path.stat path).st_size in
+      Path.unlink_no_err path;
+      Trimming_result.add trimmed_so_far ~bytes
+    ) else
+      trimmed_so_far
   in
-  List.fold_left ~init:default_trim ~f metas
+  List.fold_left ~init:trimmed_so_far ~f metas
 
-let garbage_collect = _garbage_collect Trimming_result.empty
+let garbage_collect = _garbage_collect ~trimmed_so_far:Trimming_result.empty
 
-let trim cache free =
+(* We call a cached file "unused" if there are currently no hard links to it
+   from build directories. Note that [st_nlink] can return 0 in some *)
+let is_unused_file ~stats = stats.Unix.st_nlink = 1
+
+let trim cache ~goal =
   let root = file_store_root cache in
   let files = FSSchemeImpl.list ~root in
   let f path =
     let stats = Path.stat path in
-    if trimmable stats then
+    if is_unused_file ~stats then
       Some (path, stats.st_size, stats.st_mtime)
     else
       None
   and compare (_, _, t1) (_, _, t2) = Ordering.of_int (Stdlib.compare t1 t2) in
   let files = List.sort ~compare (List.filter_map ~f files)
-  and delete (trim : Trimming_result.t) (path, size, _) =
-    if trim.trimmed_files_size >= free then
-      trim
+  and delete (trimmed_so_far : Trimming_result.t) (path, bytes, _) =
+    if trimmed_so_far.trimmed_bytes >= goal then
+      trimmed_so_far
     else (
       Path.unlink path;
-      Trimming_result.add trim ~size ~file:path
+      Trimming_result.add trimmed_so_far ~bytes
     )
   in
-  let trim = List.fold_left ~init:Trimming_result.empty ~f:delete files in
-  _garbage_collect trim cache
+  let trimmed_so_far =
+    List.fold_left ~init:Trimming_result.empty ~f:delete files
+  in
+  _garbage_collect cache ~trimmed_so_far
 
 let overhead_size cache =
   let root = file_store_root cache in
@@ -489,12 +480,12 @@ let overhead_size cache =
     let f p =
       try
         let stats = Path.stat p in
-        if trimmable stats then
-          stats.st_size
+        if is_unused_file ~stats then
+          Int64.of_int stats.st_size
         else
-          0
-      with Unix.Unix_error (Unix.ENOENT, _, _) -> 0
+          0L
+      with Unix.Unix_error (Unix.ENOENT, _, _) -> 0L
     in
     List.map ~f files
   in
-  List.fold_left ~f:(fun acc size -> acc + size) ~init:0 stats
+  List.fold_left ~f:Int64.add ~init:0L stats

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -446,7 +446,7 @@ let _garbage_collect cache ~trimmed_so_far =
 let garbage_collect = _garbage_collect ~trimmed_so_far:Trimming_result.empty
 
 (* We call a cached file "unused" if there are currently no hard links to it
-   from build directories. Note that [st_nlink] can return 0 in some *)
+   from build directories. *)
 let is_unused_file ~stats = stats.Unix.st_nlink = 1
 
 let trim cache ~goal =
@@ -465,6 +465,8 @@ let trim cache ~goal =
       trimmed_so_far
     else (
       Path.unlink path;
+      (* CR-soon amokhov: We should really be using block_size * #blocks because
+         that's how much we save actually. *)
       Trimming_result.add trimmed_so_far ~bytes
     )
   in

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -405,14 +405,11 @@ let make ?(root = default_root ())
 let duplication_mode cache = cache.duplication_mode
 
 let _garbage_collect cache ~trimmed_so_far =
-  let root = metadata_store_root cache in
-  let metas =
-    List.map ~f:(fun p -> (p, Metadata_file.parse p)) (FSSchemeImpl.list ~root)
-  in
-  List.fold_left metas ~init:trimmed_so_far
-    ~f:(fun trimmed_so_far (path, metadata) ->
+  let metadata_files = FSSchemeImpl.list ~root:(metadata_store_root cache) in
+  List.fold_left metadata_files ~init:trimmed_so_far
+    ~f:(fun trimmed_so_far path ->
       let should_be_removed =
-        match metadata with
+        match Metadata_file.parse path with
         | Result.Error msg ->
           cache.warn
             [ Pp.textf "remove invalid metadata file %s: %s"

--- a/src/cache_daemon/utils.ml
+++ b/src/cache_daemon/utils.ml
@@ -11,6 +11,17 @@ let int_of_string ?where s =
          | None -> "" )
          s)
 
+let int64_of_string ?where s =
+  match Int64.of_string s with
+  | res -> Ok res
+  | exception _exn ->
+    Result.Error
+      (Printf.sprintf "invalid 64-bit integer%s: %s"
+         ( match where with
+         | Some l -> " in " ^ l
+         | None -> "" )
+         s)
+
 let retry ?message ?(count = 100) f =
   let rec loop = function
     | x when x >= count ->

--- a/src/dune/config.ml
+++ b/src/dune/config.ml
@@ -196,7 +196,7 @@ module type S = sig
     ; cache_check_probability : float field
     ; cache_duplication : Caching.Duplication.t field
     ; cache_trim_period : int field
-    ; cache_trim_size : int field
+    ; cache_trim_size : int64 field
     }
 end
 
@@ -240,7 +240,7 @@ let default =
   ; cache_transport = Daemon
   ; cache_check_probability = 0.
   ; cache_trim_period = 10 * 60
-  ; cache_trim_size = 10 * 1000 * 1000 * 1000
+  ; cache_trim_size = 10_000_000_000L
   ; cache_duplication = None
   }
 
@@ -347,7 +347,7 @@ let to_dyn config =
     ; ( "cache_check_probability"
       , Dyn.Encoder.float config.cache_check_probability )
     ; ("cache_trim_period", Dyn.Encoder.int config.cache_trim_period)
-    ; ("cache_trim_size", Dyn.Encoder.int config.cache_trim_size)
+    ; ("cache_trim_size", Dyn.Encoder.int64 config.cache_trim_size)
     ]
 
 let global = Fdecl.create to_dyn

--- a/src/dune/config.mli
+++ b/src/dune/config.mli
@@ -120,7 +120,7 @@ module type S = sig
     ; cache_check_probability : float field
     ; cache_duplication : Caching.Duplication.t field
     ; cache_trim_period : int field
-    ; cache_trim_size : int field
+    ; cache_trim_size : int64 field
     }
 end
 

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -146,7 +146,7 @@ val duration : int t
 
 (** Consume the next element as a number of bytes, requiring 'B', 'KB', 'MB' or
     'GB' suffix *)
-val bytes_unit : int t
+val bytes_unit : int64 t
 
 (** Unparsed next element of the input *)
 val raw : ast t

--- a/src/stdune/dyn.ml
+++ b/src/stdune/dyn.ml
@@ -7,6 +7,7 @@ type t =
   | Opaque
   | Unit
   | Int of int
+  | Int64 of int64
   | Bool of bool
   | String of string
   | Bytes of bytes
@@ -81,6 +82,7 @@ let rec pp =
   | Opaque -> Pp.verbatim "<opaque>"
   | Unit -> Pp.verbatim "()"
   | Int i -> Pp.verbatim (string_of_int i)
+  | Int64 i -> Pp.verbatim (Int64.to_string i)
   | Bool b -> Pp.verbatim (string_of_bool b)
   | String s -> string_in_ocaml_syntax s
   | Bytes b -> string_in_ocaml_syntax (Bytes.to_string b)
@@ -128,6 +130,8 @@ module Encoder = struct
   let string x = String x
 
   let int x = Int x
+
+  let int64 x = Int64 x
 
   let float x = Float x
 

--- a/src/stdune/dyn.mli
+++ b/src/stdune/dyn.mli
@@ -2,6 +2,7 @@ type t =
   | Opaque
   | Unit
   | Int of int
+  | Int64 of int64
   | Bool of bool
   | String of string
   | Bytes of bytes
@@ -28,6 +29,8 @@ module Encoder : sig
   val string : string t
 
   val int : int t
+
+  val int64 : int64 t
 
   val float : float t
 

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -49,6 +49,7 @@ let rec of_dyn : Dyn.t -> t = function
   | Opaque -> Atom "<opaque>"
   | Unit -> List []
   | Int i -> Atom (string_of_int i)
+  | Int64 i -> Atom (Int64.to_string i)
   | Bool b -> Atom (string_of_bool b)
   | String s -> Atom s
   | Bytes s -> Atom (Bytes.to_string s)

--- a/test/blackbox-tests/test-cases/dune-cache/trim/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim/run.t
@@ -22,6 +22,14 @@ Build some targets.
 
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a target_b
 
+Have a look at one of the metadata files and its size.
+
+  $ cat $PWD/.xdg-cache/dune/db/meta/v3/9a/9a8995f866fa478a9a263b8470fb218f
+  ((8:metadata)(5:files(16:default/target_b32:de8852e356e79df9dddd6b2f2cced43f)))
+
+  $ stat --printf=%s $PWD/.xdg-cache/dune/db/meta/v3/9a/9a8995f866fa478a9a263b8470fb218f
+  79
+
 Trimming the cache at this point should not remove anything, as both
 files are still hard-linked in the build directory.
 
@@ -36,7 +44,7 @@ If we unlink one file in the build tree, it can be reclaimed when trimming.
 
   $ rm -f _build/default/target_a _build/default/beacon_a _build/default/beacon_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 1B
-  Freed 9 bytes
+  Freed 88 bytes
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a target_b
   $ dune_cmd stat hardlinks _build/default/target_a
   2
@@ -49,7 +57,7 @@ Reset build tree and cache.
 
   $ rm -f _build/default/beacon_a _build/default/target_a _build/default/beacon_b _build/default/target_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 18B
-  Freed 18 bytes
+  Freed 176 bytes
 
 The cache deletes oldest files first.
 
@@ -58,7 +66,7 @@ The cache deletes oldest files first.
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a
   $ rm -f _build/default/beacon_a _build/default/target_a _build/default/beacon_b _build/default/target_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 1B
-  Freed 9 bytes
+  Freed 88 bytes
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a target_b
   $ dune_cmd stat hardlinks _build/default/target_a
   2
@@ -71,7 +79,7 @@ Reset build tree and cache.
 
   $ rm -f _build/default/beacon_a _build/default/target_a _build/default/beacon_b _build/default/target_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 18B
-  Freed 18 bytes
+  Freed 176 bytes
 
 When a file is pulled from the cache, its mtime is touched so it's deleted last.
 
@@ -83,7 +91,7 @@ When a file is pulled from the cache, its mtime is touched so it's deleted last.
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a target_b
   $ rm -f _build/default/beacon_a _build/default/target_a _build/default/beacon_b _build/default/target_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 1B
-  Freed 9 bytes
+  Freed 88 bytes
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a target_b
   $ dune_cmd stat hardlinks _build/default/target_a
   2
@@ -97,7 +105,7 @@ Reset build tree and cache.
 
   $ rm -f _build/default/beacon_a _build/default/target_a _build/default/beacon_b _build/default/target_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 18B
-  Freed 18 bytes
+  Freed 176 bytes
 
 Check background trimming.
 
@@ -113,7 +121,7 @@ Reset build tree and cache.
 
   $ rm -f _build/default/beacon_a _build/default/target_a _build/default/beacon_b _build/default/target_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 18B
-  Freed 9 bytes
+  Freed 88 bytes
 
 Check garbage collection: both multi_a and multi_b must be removed as
 they are part of the same rule.
@@ -121,7 +129,7 @@ they are part of the same rule.
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build multi_a multi_b
   $ rm -f _build/default/multi_a _build/default/multi_b
   $ XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune cache trim --trimmed-size 1B
-  Freed 16 bytes
+  Freed 141 bytes
 
 Check reporting of unexpected directories at the cache root while trimming:
 


### PR DESCRIPTION
This PR does a few things:

* As discussed with @mefyl, cache trimming no longer removes unused files that are referenced from broken metadata files because doing so may in turn break more metadata files.

* I simplified `Trimming_result` since two of its fields were unused (and in some cases were not updated correctly).

* We now take into account the size of removed metadata files in `Trimming_result`.

* As discussed with @jeremiedimino, I switched to using `int64` for aggregating file sizes to make this  work on 32-bit platforms. As noted in a comment, we still can't support files larger than 1GB on 32-bit platforms because we pervasively use `int` for representing individual file size. We can improve this in future.

* The latter required to add some support for `int64` to Stdune.
