### PR TITLE
Alert ill opam dune constraint

### DIFF
--- a/src/dune/opam_create.ml
+++ b/src/dune/opam_create.ml
@@ -116,10 +116,19 @@ let insert_dune_dep depends dune_version =
 
 let opam_fields project (package : Package.t) =
   let dune_version = Dune_project.dune_version project in
+  let dune_in_deps = List.exists ~f:(function dep -> Package.(Name.equal dep.Dependency.name dune_name)) package.depends in
   let package =
     if dune_version < (1, 11) || Package.Name.equal package.name dune_name then
+      let () =
+        if not (Package.Name.equal package.name dune_name) && not dune_in_deps then
+          User_warning.emit ?is_error:None ?loc:None ?hints:None [
+            Pp.text "I suggest you to add dune in the depends field or upgrade to dune lang >= 1.11" ] in
       package
     else
+      let () =
+        if not (Package.Name.equal package.name dune_name) && dune_in_deps  then
+          User_warning.emit ~is_error:(dune_version >= (2, 6)) ?loc:None ?hints:None [
+            Pp.text "I suggest you to remove dune in the depends field  because I will add myself automatically with the right constraint" ] in
       { package with depends = insert_dune_dep package.depends dune_version }
   in
   let package_fields = package_fields package ~project in


### PR DESCRIPTION
I used the opam generation file feature and I remarked that we could build invalid file and dune doesn't emit a warning/error. I have reported in the associated issue https://github.com/ocaml/dune/issues/1689#issuecomment-625576782 after I have posted my comment I have seen https://github.com/ocaml/dune/pull/3434 which partial fix the lower bound if missing. If a user have written `(dune (and (<= 2.0) (> 1.11) )` No warning is displayed.

So here:
- dune <= 2.6 no change nor I apply the check on bounds.
- dune > 2.6 I fail ony if no version of dune can be installed, otherwise I emit only a warning.

What do you think of that ?

Things I should do before it become ready to merge:
 - [x] format
 - [ ] add test 
 - [x] use loc and hints arguments (or use a correct function that I haven't seen)
 - [ ] write better error message ? (any suggestions)

Also my original goal is to generate dune-project from esy's package.json so we can easily publish package to opam very easily.