### PR TITLE
Generate ./dune/configurator in the old format

### DIFF
--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -263,7 +263,7 @@ type config =
   }
 
 let read_dot_dune_configurator_file ~build_dir =
-  let file = Filename.concat build_dir ".dune/configurator" in
+  let file = Filename.concat build_dir ".dune/configurator.v2" in
   if not (Sys.file_exists file) then
     die "Cannot find special file %S produced by dune." file;
   let open Sexp in

--- a/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/config/run.ml
+++ b/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/config/run.ml
@@ -5,10 +5,12 @@ let () =
   | exception Not_found -> failwith "INSIDE_DUNE is not passed"
   | "1" -> print_endline "INSIDE_DUNE is from an old dune"
   | dir -> print_endline "INSIDE_DUNE is present";
-    if Sys.file_exists (Filename.concat dir ".dune/configurator") then
-      print_endline ".dune/configurator file present"
-    else
-      print_endline ".dune/configurator file not present"
+    let config_path = ".dune/configurator.v2" in
+    Printf.printf "%s file is %s\n" config_path
+      (if Sys.file_exists (Filename.concat dir config_path) then
+         "present"
+       else
+         "not present")
   end;
   Configurator.main ~name:"config" (fun t ->
     match Configurator.ocaml_config_var t "version" with

--- a/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/test-cases/configurator/run.t
@@ -1,7 +1,7 @@
 Show that config values are present
   $ dune exec config/run.exe
   INSIDE_DUNE is present
-  .dune/configurator file present
+  .dune/configurator.v2 file is present
   version is present
 
 We're able to compile C program successfully

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -238,21 +238,34 @@ let write_dot_dune_dir ~build_dir ~ocamlc ~ocaml_config_vars =
   Path.rm_rf dir;
   Path.mkdir_p dir;
   Io.write_file (Path.relative dir Config.dune_keep_fname) "";
-  let csexp =
-    let open Sexp in
-    let ocamlc = Atom (Path.to_absolute_filename ocamlc) in
-    let ocaml_config_vars =
-      Sexp.List
-        ( Ocaml_config.Vars.to_list ocaml_config_vars
-        |> List.map ~f:(fun (k, v) -> List [ Atom k; Atom v ]) )
-    in
-    List
-      [ List [ Atom "ocamlc"; ocamlc ]
-      ; List [ Atom "ocaml_config_vars"; ocaml_config_vars ]
-      ]
+  let ocamlc = Path.to_absolute_filename ocamlc in
+  let ocaml_config_vars = Ocaml_config.Vars.to_list ocaml_config_vars in
+  let () =
+    let open Dune_lang.Encoder in
+    Io.write_lines
+      (Path.relative dir "configurator")
+      (List.map ~f:Dune_lang.to_string
+         (record_fields
+            [ field "ocamlc" string ocamlc
+            ; field_l "ocaml_config_vars" (pair string string) ocaml_config_vars
+            ]))
   in
-  let path = Path.relative dir "configurator.v2" in
-  Io.write_file path (Csexp.to_string csexp)
+  let () =
+    let csexp =
+      let open Sexp in
+      let ocaml_config_vars =
+        Sexp.List
+          (List.map ocaml_config_vars ~f:(fun (k, v) -> List [ Atom k; Atom v ]))
+      in
+      List
+        [ List [ Atom "ocamlc"; Atom ocamlc ]
+        ; List [ Atom "ocaml_config_vars"; ocaml_config_vars ]
+        ]
+    in
+    let path = Path.relative dir "configurator.v2" in
+    Io.write_file path (Csexp.to_string csexp)
+  in
+  ()
 
 let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     ~host_context ~host_toolchain ~profile ~fdo_target_exe

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -251,7 +251,7 @@ let write_dot_dune_dir ~build_dir ~ocamlc ~ocaml_config_vars =
       ; List [ Atom "ocaml_config_vars"; ocaml_config_vars ]
       ]
   in
-  let path = Path.relative dir "configurator" in
+  let path = Path.relative dir "configurator.v2" in
   Io.write_file path (Csexp.to_string csexp)
 
 let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets


### PR DESCRIPTION
@jeremiedimino, as discussed, we support both versions of the configurator protocol