### PR TITLE
Simplify Fiber.run

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -261,9 +261,7 @@ let () =
     match Term.eval_choice default all ~catch:false with
     | `Error _ -> exit 1
     | _ -> exit 0
-  with
-  | Fiber.Never -> exit 1
-  | exn ->
+  with exn ->
     let exn = Exn_with_backtrace.capture exn in
     Dune.Report_error.report exn;
     exit 1

--- a/src/dune/scheduler.ml
+++ b/src/dune/scheduler.ml
@@ -699,7 +699,6 @@ end = struct
     | Files_changed
 
   let rec pump_events t =
-    let* () = Fiber.yield () in
     let count = Event.pending_jobs () in
     if count = 0 then (
       Console.Status_line.set (Fun.const None);

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -226,11 +226,6 @@ with type 'a fiber := 'a t
 
 (** {1 Running fibers} *)
 
-(** Wait for one iteration of the scheduler *)
-val yield : unit -> unit t
-
-(** [run t] runs a fiber until it (and all the fibers it forked) terminate.
-    Returns the result if it's determined in the end, otherwise raises [Never]. *)
-val run : 'a t -> 'a
-
-exception Never
+(** [run t] runs a fiber. If the fiber doesn't complete immediately, [run t]
+    returns [None]. *)
+val run : 'a t -> 'a option

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -6,21 +6,59 @@ open Dune_tests_common
 
 let () = init ()
 
-let failing_fiber () : unit Fiber.t = Fiber.yield () >>= fun () -> raise Exit
+module Scheduler : sig
+  exception Never
+
+  val yield : unit -> unit Fiber.t
+
+  val run : 'a Fiber.t -> 'a
+end = struct
+  let suspended = Queue.create ()
+
+  let yield () =
+    let ivar = Fiber.Ivar.create () in
+    Queue.push ivar suspended;
+    Fiber.Ivar.read ivar
+
+  let rec restart_suspended () =
+    if Queue.is_empty suspended then
+      Fiber.return ()
+    else
+      let* () = Fiber.Ivar.fill (Queue.pop suspended) () in
+      restart_suspended ()
+
+  exception Never
+
+  let run t =
+    match
+      Fiber.run
+        (let* result = Fiber.fork (fun () -> t) in
+         let* () = restart_suspended () in
+         Fiber.return result)
+    with
+    | None -> raise Never
+    | Some future -> (
+      match Fiber.Future.peek future with
+      | None -> raise Never
+      | Some x -> x )
+end
+
+let failing_fiber () : unit Fiber.t =
+  Scheduler.yield () >>= fun () -> raise Exit
 
 let long_running_fiber () =
   let rec loop n =
     if n = 0 then
       Fiber.return ()
     else
-      Fiber.yield () >>= fun () -> loop (n - 1)
+      Scheduler.yield () >>= fun () -> loop (n - 1)
   in
   loop 10
 
 let never_fiber () = Fiber.never
 
 let%expect_test _ =
-  Fiber.run (Fiber.collect_errors failing_fiber)
+  Scheduler.run (Fiber.collect_errors failing_fiber)
   |> Result.to_dyn unit (list Exn_with_backtrace.to_dyn)
   |> print_dyn;
   [%expect {|
@@ -30,17 +68,17 @@ Error [ { exn = "Exit"; backtrace = "" } ]
 let%expect_test _ =
   ( try
       ignore
-        ( Fiber.run (Fiber.collect_errors never_fiber)
+        ( Scheduler.run (Fiber.collect_errors never_fiber)
           : (unit, Exn_with_backtrace.t list) Result.t );
       Result.Error "should not reach here"
-    with Fiber.Never -> Result.ok () )
+    with Scheduler.Never -> Result.ok () )
   |> Result.to_dyn unit string |> print_dyn;
   [%expect {|
 Ok ()
 |}]
 
 let%expect_test _ =
-  Fiber.run
+  Scheduler.run
     (Fiber.collect_errors (fun () ->
          failing_fiber () >>= fun () -> failing_fiber ()))
   |> Result.to_dyn unit (list Exn_with_backtrace.to_dyn)
@@ -50,7 +88,7 @@ Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
 
 let%expect_test _ =
-  Fiber.run
+  Scheduler.run
     (Fiber.collect_errors (fun () ->
          Fiber.with_error_handler failing_fiber ~on_error:ignore))
   |> Result.to_dyn unit (list Exn_with_backtrace.to_dyn)
@@ -60,7 +98,7 @@ Error []
 |}]
 
 let%expect_test _ =
-  Fiber.run
+  Scheduler.run
     ( Fiber.collect_errors (fun () ->
           Fiber.with_error_handler failing_fiber ~on_error:ignore)
     >>| fun _result -> "" )
@@ -70,7 +108,7 @@ let%expect_test _ =
 |}]
 
 let%expect_test _ =
-  Fiber.run
+  Scheduler.run
     (Fiber.collect_errors (fun () ->
          Fiber.fork_and_join failing_fiber long_running_fiber))
   |> Result.to_dyn (pair unit unit) (list Exn_with_backtrace.to_dyn)
@@ -80,7 +118,7 @@ Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
 
 let%expect_test _ =
-  Fiber.run
+  Scheduler.run
     (Fiber.fork_and_join
        (fun () -> Fiber.collect_errors failing_fiber >>| fun _ -> "")
        long_running_fiber)
@@ -95,11 +133,11 @@ let never_raised = ref false
 
 let%expect_test _ =
   ( try
-      Fiber.run
+      Scheduler.run
         (Fiber.fork_and_join_unit never_fiber (fun () ->
              Fiber.collect_errors failing_fiber >>= fun _ ->
              long_running_fiber () >>= fun _ -> Fiber.return (flag_set := true)))
-    with Fiber.Never -> never_raised := true );
+    with Scheduler.Never -> never_raised := true );
   [%expect {| |}]
 
 let%expect_test _ =
@@ -116,7 +154,7 @@ let%expect_test _ =
   let forking_fiber () =
     let which = Bin.which ~path:(Env.path Env.initial) in
     Fiber.parallel_map [ 1; 2; 3; 4; 5 ] ~f:(fun x ->
-        Fiber.yield () >>= fun () ->
+        Scheduler.yield () >>= fun () ->
         if x mod 2 = 1 then
           Process.run Process.Strict ~env:Env.initial
             (Option.value_exn (which "true"))
@@ -127,11 +165,11 @@ let%expect_test _ =
             [])
   in
   ( try
-      Fiber.run
+      Scheduler.run
         (Fiber.fork_and_join_unit never_fiber (fun () ->
              Fiber.collect_errors forking_fiber >>= fun _ ->
              long_running_fiber () >>= fun _ -> Fiber.return (flag_set := true)))
-    with Fiber.Never -> never_raised := true )
+    with Scheduler.Never -> never_raised := true )
   |> unit |> print_dyn;
   [%expect {|
 ()

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -19,15 +19,17 @@ let int_fn_create name =
 (* to run a computation *)
 let run f v =
   let exn = ref None in
-  try
+  match
     Fiber.run
       (Fiber.with_error_handler
          (fun () -> f v)
          ~on_error:(fun e -> exn := Some e))
-  with Fiber.Never -> (
+  with
+  | Some x -> x
+  | None -> (
     match !exn with
     | Some exn -> Exn_with_backtrace.reraise exn
-    | None -> raise Fiber.Never )
+    | None -> assert false )
 
 let run_memo f v = run (Memo.exec f) v
 

--- a/test/unit-tests/artifact_substitution/artifact_substitution.ml
+++ b/test/unit-tests/artifact_substitution/artifact_substitution.ml
@@ -144,17 +144,18 @@ let compress_string s =
 let test input =
   let expected = simple_subst input in
   let buf = Buffer.create (String.length expected) in
-  Fiber.run
-    (let ofs = ref 0 in
-     let input buf pos len =
-       let to_copy = min len (String.length input - !ofs) in
-       Bytes.blit_string ~src:input ~dst:buf ~src_pos:!ofs ~dst_pos:pos
-         ~len:to_copy;
-       ofs := !ofs + to_copy;
-       to_copy
-     in
-     let output = Buffer.add_subbytes buf in
-     Artifact_substitution.copy ~get_vcs:(fun _ -> None) ~input ~output);
+  Option.value_exn
+  @@ Fiber.run
+       (let ofs = ref 0 in
+        let input buf pos len =
+          let to_copy = min len (String.length input - !ofs) in
+          Bytes.blit_string ~src:input ~dst:buf ~src_pos:!ofs ~dst_pos:pos
+            ~len:to_copy;
+          ofs := !ofs + to_copy;
+          to_copy
+        in
+        let output = Buffer.add_subbytes buf in
+        Artifact_substitution.copy ~get_vcs:(fun _ -> None) ~input ~output);
   let result = Buffer.contents buf in
   if result <> expected then
     fail


### PR DESCRIPTION
The only call to `Fiber.yield` in the codebase is superfluous, let's get rid of it and simplify `Fiber.run`. This allows to remove the only bit of scheduling logic that was left in the `Fiber` module and keep it entirely in `src/dune/scheduler.ml`, which is nice.

The fiber tests were relying on `Fiber.yield`, so I just added a micro scheduler built on top of `Fiber` in the fiber tests. This micro scheduler is similar to the old implementation but uses only standard features exposed in the `Fiber` API.
