### PR TITLE
Purify fiber

### DIFF
--- a/src/dune/scheduler.ml
+++ b/src/dune/scheduler.ml
@@ -730,12 +730,12 @@ end = struct
       Fiber.run
         (let* user_action_result = Fiber.fork (fun () -> fiber) in
          let* pump_events_result = pump_events t in
+         let* user_action_result = Fiber.Future.peek user_action_result in
          Fiber.return (pump_events_result, user_action_result))
     with
     | None -> Code_error.raise "[Scheduler.pump_events] got stuck somehow" []
     | exception exn -> Error (Exn (exn, Printexc.get_raw_backtrace ()))
     | Some (a, b) -> (
-      let b = Fiber.Future.peek b in
       match (a, b) with
       | Done, None -> Error Never
       | Done, Some res -> Ok res

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -387,10 +387,11 @@ module Ivar = struct
     | Full x -> k x
     | Empty q -> Queue.push (K.create k) q
 
-  let peek t =
-    match t.state with
-    | Full x -> Some x
-    | Empty _ -> None
+  let peek t k =
+    k
+      ( match t.state with
+      | Full x -> Some x
+      | Empty _ -> None )
 end
 
 module Future = struct

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -56,7 +56,7 @@ module Future : sig
   val wait : 'a t -> 'a fiber
 
   (** Return [Some x] if [t] has already returned. *)
-  val peek : 'a t -> 'a option
+  val peek : 'a t -> 'a option fiber
 end
 with type 'a fiber := 'a t
 
@@ -193,7 +193,7 @@ val finalize : (unit -> 'a t) -> finally:(unit -> unit t) -> 'a t
 
 (** Write once variables *)
 module Ivar : sig
-  type 'a fiber = 'a t
+  type 'a fiber
 
   (** A ivar is a synchronization variable that can be written only once. *)
   type 'a t
@@ -209,7 +209,7 @@ module Ivar : sig
   val fill : 'a t -> 'a -> unit fiber
 
   (** Return [Some x] is [fill t x] has been called previously. *)
-  val peek : 'a t -> 'a option
+  val peek : 'a t -> 'a option fiber
 end
 with type 'a fiber := 'a t
 

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -34,13 +34,12 @@ end = struct
       Fiber.run
         (let* result = Fiber.fork (fun () -> t) in
          let* () = restart_suspended () in
-         Fiber.return result)
+         Fiber.Future.peek result)
     with
-    | None -> raise Never
-    | Some future -> (
-      match Fiber.Future.peek future with
-      | None -> raise Never
-      | Some x -> x )
+    | None
+    | Some None ->
+      raise Never
+    | Some (Some x) -> x
 end
 
 let failing_fiber () : unit Fiber.t =


### PR DESCRIPTION
`Fiber.peek` and `Fiber.ivar` are the only two functions that are not pure in the API of Fiber. This PR makes them pure.