### PR TITLE
Improve printing of Sys_error and Unix_error exceptions

### DIFF
--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -21,12 +21,10 @@ let get_user_message = function
             (Pp.verbatim "  " ++ Dyn.pp (Code_error.to_dyn_without_loc e))
         ] )
   | Unix.Unix_error (err, func, fname) ->
-    let open Pp.O in
     ( User
     , User_error.make
-        [ User_error.prefix
-          ++ Pp.textf " %s: %s: %s" func fname (Unix.error_message err)
-        ] )
+        [ Pp.textf "%s: %s: %s" func fname (Unix.error_message err) ] )
+  | Sys_error msg -> (User, User_error.make [ Pp.text msg ])
   | exn ->
     let open Pp.O in
     let s = Printexc.to_string exn in

--- a/test/blackbox-tests/test-cases/dir-target-dep/run.t
+++ b/test/blackbox-tests/test-cases/dir-target-dep/run.t
@@ -36,4 +36,4 @@ Dune crashes if there's a file named after the directory target
 directory target and (mode promote) results in a crash
   $ dune build --root mode-promote @all 2>&1 | head -n2
   Entering directory 'mode-promote'
-  Error: exception Sys_error("Is a directory")
+  Error: Is a directory


### PR DESCRIPTION
- remove the second `Error: ` prefix for `Unix_error`
- drop the backtrace and only print the message for `Sys_error`
