### PR TITLE
Fix stat test to be cross platform

### DIFF
--- a/test/blackbox-tests/test-cases/dune-cache/trim/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim/run.t
@@ -27,7 +27,7 @@ Have a look at one of the metadata files and its size.
   $ cat $PWD/.xdg-cache/dune/db/meta/v3/9a/9a8995f866fa478a9a263b8470fb218f
   ((8:metadata)(5:files(16:default/target_b32:de8852e356e79df9dddd6b2f2cced43f)))
 
-  $ stat --printf=%s $PWD/.xdg-cache/dune/db/meta/v3/9a/9a8995f866fa478a9a263b8470fb218f
+  $ dune_cmd stat size $PWD/.xdg-cache/dune/db/meta/v3/9a/9a8995f866fa478a9a263b8470fb218f
   79
 
 Trimming the cache at this point should not remove anything, as both

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -11,6 +11,7 @@ module Stat = struct
   type data =
     | Hardlinks
     | Permissions
+    | Size
 
   type t =
     { file : Path.t
@@ -18,6 +19,7 @@ module Stat = struct
     }
 
   let data_of_string = function
+    | "size" -> Size
     | "hardlinks" -> Hardlinks
     | "permissions" -> Permissions
     | s ->
@@ -28,6 +30,7 @@ module Stat = struct
 
   let pp_stats data (stats : Unix.stats) =
     match data with
+    | Size -> Int.to_string stats.st_size
     | Hardlinks -> Int.to_string stats.st_nlink
     | Permissions -> sprintf "%o" stats.st_perm
 


### PR DESCRIPTION
Use dune_cmd stat rather than the non portable stat