### PR TITLE
Add Fiber.fork_and_race

### DIFF
--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -229,6 +229,26 @@ type ('a, 'b) fork_and_join_state =
   | Got_a of 'a
   | Got_b of 'b
 
+let fork_and_race fa fb k =
+  let state = ref Nothing_yet in
+  EC.add_refs 1;
+  EC.apply fa () (fun a ->
+      match !state with
+      | Nothing_yet ->
+        EC.deref ();
+        state := Got_a ();
+        k (Left a)
+      | Got_a () -> assert false
+      | Got_b () -> ());
+  fb () (fun b ->
+      match !state with
+      | Nothing_yet ->
+        EC.deref ();
+        state := Got_b ();
+        k (Right b)
+      | Got_a () -> ()
+      | Got_b () -> assert false)
+
 let fork_and_join fa fb k =
   let state = ref Nothing_yet in
   EC.add_refs 1;

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -98,6 +98,8 @@ val sequential_iter : 'a list -> f:('a -> unit t) -> unit t
     ]} *)
 val fork_and_join : (unit -> 'a t) -> (unit -> 'b t) -> ('a * 'b) t
 
+val fork_and_race : (unit -> 'a t) -> (unit -> 'b t) -> ('a, 'b) Either.t t
+
 (** Same but assume the first fiber returns [unit]:
 
     {[

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -65,6 +65,19 @@ Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
 
 let%expect_test _ =
+  Scheduler.run
+    (Fiber.fork_and_race
+       (fun () ->
+         let+ () = Scheduler.yield () in
+         "unexpected")
+       (fun () -> Fiber.return 42))
+  |> Either.to_dyn String.to_dyn Int.to_dyn
+  |> print_dyn;
+  [%expect {|
+42
+|}]
+
+let%expect_test _ =
   ( try
       ignore
         ( Scheduler.run (Fiber.collect_errors never_fiber)


### PR DESCRIPTION
`fork_and_race` is a primitive for racing two fibers and fibers and
waiting for the completion of a single one.

It's not being used anywhere yet, but the API seemed a bit incomplete without
it, and it doesn't seem possible to implement efficiently outside the library.