### PR TITLE
Add findlib toolchain handling for dune install.

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -24,8 +24,8 @@ let get_dirs context ~prefix_from_command_line ~libdir_from_command_line =
     let+ libdir = libdir in
     (prefix, libdir)
 
-let resolve_package_install setup pkg =
-  match Import.Main.package_install_file setup pkg with
+let resolve_package_install ~findlib_toolchain setup pkg =
+  match Import.Main.package_install_file ~findlib_toolchain setup pkg with
   | Ok path -> path
   | Error () ->
     let pkg = Package.Name.to_string pkg in
@@ -342,6 +342,11 @@ let install_uninstall ~what =
           | None -> workspace.contexts
           | Some name -> [ Import.Main.find_context_exn workspace ~name ]
         in
+        let findlib_toolchain = Common.x common in
+        let contexts =
+          List.filter contexts
+            ~f:(fun ctx -> ctx.Context.findlib_toolchain = findlib_toolchain)
+        in
         let pkgs =
           match pkgs with
           | [] ->
@@ -356,7 +361,7 @@ let install_uninstall ~what =
         in
         let install_files, missing_install_files =
           List.concat_map pkgs ~f:(fun pkg ->
-              let fn = resolve_package_install workspace pkg in
+              let fn = resolve_package_install ~findlib_toolchain workspace pkg in
               List.map contexts ~f:(fun ctx ->
                   let fn =
                     Path.append_source (Path.build ctx.Context.build_dir) fn

--- a/src/dune/main.ml
+++ b/src/dune/main.ml
@@ -15,13 +15,13 @@ type build_system =
   ; scontexts : Super_context.t Context_name.Map.t
   }
 
-let package_install_file w pkg =
+let package_install_file ~findlib_toolchain w pkg =
   match Package.Name.Map.find w.conf.packages pkg with
   | None -> Error ()
   | Some p ->
     Ok
       (Path.Source.relative p.path
-         (Utils.install_file ~package:p.name ~findlib_toolchain:None))
+         (Utils.install_file ~package:p.name ~findlib_toolchain))
 
 let setup_env ~capture_outputs =
   let env =

--- a/src/dune/main.mli
+++ b/src/dune/main.mli
@@ -14,7 +14,10 @@ type build_system =
 
 (* Returns [Error ()] if [pkg] is unknown *)
 val package_install_file :
-  workspace -> Package.Name.t -> (Path.Source.t, unit) result
+     findlib_toolchain:Context_name.t option
+  -> workspace
+  -> Package.Name.t
+  -> (Path.Source.t, unit) result
 
 (** Scan the source tree and discover the overall layout of the workspace. *)
 val scan_workspace :

--- a/test/blackbox-tests/test-cases/cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation/run.t
@@ -40,3 +40,52 @@
   bin: [
     "_build/install/default.foo/bin/blah" {"../foo-sysroot/bin/blah"}
   ]
+  $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf dune install --prefix=_prefix --dry-run -x foo
+  Installing _prefix/foo-sysroot/lib/p/META
+  Installing _prefix/foo-sysroot/lib/p/dune-package
+  Installing _prefix/foo-sysroot/lib/p/opam
+  Installing _prefix/foo-sysroot/lib/p/p$ext_lib
+  Installing _prefix/foo-sysroot/lib/p/p.cma
+  Installing _prefix/foo-sysroot/lib/p/p.cmi
+  Installing _prefix/foo-sysroot/lib/p/p.cmt
+  Installing _prefix/foo-sysroot/lib/p/p.cmx
+  Installing _prefix/foo-sysroot/lib/p/p.cmxa
+  Installing _prefix/foo-sysroot/lib/p/p.cmxs
+  Installing _prefix/foo-sysroot/lib/p/p.ml
+  Installing _prefix/foo-sysroot/bin/blah
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/META
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/META to _prefix/foo-sysroot/lib/p/META (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/dune-package
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/dune-package to _prefix/foo-sysroot/lib/p/dune-package (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/opam
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/opam to _prefix/foo-sysroot/lib/p/opam (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p$ext_lib
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p$ext_lib to _prefix/foo-sysroot/lib/p/p$ext_lib (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p.cma
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p.cma to _prefix/foo-sysroot/lib/p/p.cma (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p.cmi
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p.cmi to _prefix/foo-sysroot/lib/p/p.cmi (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p.cmt
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p.cmt to _prefix/foo-sysroot/lib/p/p.cmt (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p.cmx
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p.cmx to _prefix/foo-sysroot/lib/p/p.cmx (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p.cmxa
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p.cmxa to _prefix/foo-sysroot/lib/p/p.cmxa (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p.cmxs
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p.cmxs to _prefix/foo-sysroot/lib/p/p.cmxs (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/lib/p/p.ml
+  Creating directory _prefix/foo-sysroot/lib/p
+  Copying _build/install/default.foo/lib/p/p.ml to _prefix/foo-sysroot/lib/p/p.ml (executable: false)
+  Removing (if it exists) _prefix/foo-sysroot/bin/blah
+  Creating directory _prefix/foo-sysroot/bin
+  Copying _build/install/default.foo/bin/blah to _prefix/foo-sysroot/bin/blah (executable: true)


### PR DESCRIPTION
## Problem

For a given package `$PKG`, when explicitly providing a findlib toolchain with `-x $TOOLCHAIN`, `dune install` does two things that, in my understanding, are incorrect:

1. it will attempt to install targets for the default context, and not exclusively the targets for `$TOOLCHAIN`; and
2. it attempts to install:
    * `_build/default.$TOOLCHAIN/$PKG.install` instead of
    * `_build/default.$TOOLCHAIN/$PKG-$TOOLCHAIN.install`.

These two points can be validated currently on `master` by updating `./test/blackbox-tests/test-cases/cross-compilation/run.t` as follows:


```diff
   $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf dune install --prefix=_prefix --dry-run -x foo
+  Error: The following <package>.install are missing:
+  - _build/default/p.install
+  - _build/default.foo/p.install
+  Hint: try running: dune build @install
+  [1]
```

As stated in point 1, even though `-x foo` was passed, `_build/default/p.install` is expected to be present. And, as stated in point 2, the install file location is `_build/default.foo/p.install`, but should be `_build/default.foo/p-foo.install`. At least given my understanding of dune's path conventions for non-default toolchains.


## Solution

See the proposed behaviour in the first commit https://github.com/ocaml/dune/pull/3501/commits/479158ef043251dac21ece84568ec8e9f21076a4 for comparison with the current behaviour.

More specifically, in the presence of the `-x` option, the implementation of `dune install`:

* selects only the contexts that match the passed toolchain name; and
* resolves the package install filenames using the toolchain name.


## Alternatives

### Regarding 1

Keep the current functionality where `dune install -x $TOOLCHAIN ...` installs targets from the contexts that don't have the `$TOOLCHAIN`. As a workaround to only install the desired toolchain targets, `dune install -x $TOOLCHAIN --context=default.$TOOLCHAIN` can be used, assuming the `default` context.

I think this would be fine, even though the user has explicitly passed a toolchain. This behaviour is somewhat unexpected, but at least can be tuned.


### Regarding 2

The naming convention for install files could be changed in the build folder. Currently the generated files (with `--promote-install-files`) are:

* `./_build/default.$TOOLCHAIN/$PKG-$TOOLCHAIN.install` and;
* `./$PKG-$TOOLCHAIN.install`

Instead, dune could generate `./_build/default.$TOOLCHAIN/$PKG.install` internally. To my knowledge, no collisions are possible, because the `default.$TOOLCHAIN` context is used as a namespace.

This would also work, but introduces an unnecessary inconsistency for the install filenames.