### PR TITLE
Document (inline_tests) in libraries

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -483,6 +483,10 @@ to use the :ref:`include_subdirs` stanza.
   the same as the value of the ``os_type`` parameter in the output of
   ``ocamlc -config``
 
+- ``(inline_tests)`` enables inline tests for this library. They can be
+  configured through options using ``(inline_tests <options>)``. See
+  :ref:`inline_tests` for a reference of corresponding options.
+
 Note that when binding C libraries, dune doesn't provide special support for
 tools such as ``pkg-config``, however it integrates easily with configurator_ by
 using ``(c_flags (:include ...))`` and ``(c_library_flags (:include ...))``.

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -55,6 +55,8 @@ You can also pass a directory argument to run the tests from a sub-tree. For
 instance ``dune runtest test`` will only run the tests from the ``test``
 directory and any sub-directory of ``test`` recursively.
 
+.. _inline_tests:
+
 Inline tests
 ============
 


### PR DESCRIPTION
The individual options (`(deps)` etc) are documented on the tests page but there was no pointer.