### PR TITLE
Fix markup in doc

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -502,7 +502,7 @@ Dependencies in ``dune`` files can be specified using one of the following:
 
 .. _source_tree:
 
-- ``(:name <dependencies>)`` will bind the the list of dependencies to the
+- ``(:name <dependencies>)`` will bind the list of dependencies to the
   ``name`` variable. This variable will be available as ``%{name}`` in actions.
 - ``(file <filename>)`` or simply ``<filename>``: depend on this file
 - ``(alias <alias-name>)``: depend on the construction of this alias, for

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -19,7 +19,7 @@ Writing documentation
 =====================
 
 Documentation comments will be automatically extracted from your OCaml source
-files following the syntax described in the the section ``Text formatting`` of
+files following the syntax described in the section ``Text formatting`` of
 the `OCaml manual <http://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html>`_.
 
 Additional documentation pages may by attached to a package can be attached

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -445,7 +445,7 @@ to use the :ref:`include_subdirs` stanza.
   when constructing the library archive file for the C stubs. ``<flags>`` uses
   the :ref:`ordered-set-language` and supports ``(:include ...)`` forms. When you
   are writing bindings for a C library named ``bar``, you should typically write
-  ``-lbar`` here, or whatever flags are necessary to to link against this
+  ``-lbar`` here, or whatever flags are necessary to link against this
   library
 
 - ``(modules_without_implementation <modules>)`` specifies a list of

--- a/doc/dune-libs.rst
+++ b/doc/dune-libs.rst
@@ -156,7 +156,7 @@ which produces a human readable version string of the form
 ``<version>-<commits-since-version>-<hash>[-dirty]``.
 
 Note that in the case where the version string is obtained from the
-the version control system, the version string will only be written in
+version control system, the version string will only be written in
 the binary once it is installed or promoted to the source tree. In
 particular, if you evaluate this expression as part of the build of
 your package, it will return ``None``. This is to ensure that

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -5,23 +5,23 @@ FAQ
 Why do many dune projects contain a Makefile?
 =============================================
 
-Many dune projects contain a root `Makefile`. It is often only there for
+Many dune projects contain a root ``Makefile``. It is often only there for
 convenience, for the following reasons:
 
 1. there are many different build systems out there, all with a different CLI.
    If you have been hacking for a long time, the one true invocation you know is
-   `make && make install`, possibly preceded by `./configure`
+   ``make && make install``, possibly preceded by ``./configure``
 
 2. you often have a few common operations that are not part of the build and
-   `make <blah>` is a good way to provide them
+   ``make <blah>`` is a good way to provide them
 
-3. `make` is shorter to type than `dune build @install`
+3. ``make`` is shorter to type than ``dune build @install``
 
 How to add a configure step to a dune project?
 ==============================================
 
 The with-configure-step_ example shows one way to do it which
-preserves composability; i.e. it doesn't require manually running `./configure`
+preserves composability; i.e. it doesn't require manually running ``./configure``
 script when working on multiple projects at the same time.
 
 .. _with-configure-step: https://github.com/ocaml/dune/tree/master/example/sample-projects/with-configure-step

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -100,7 +100,7 @@ printed on the console (and the parallelism is disabled so that the output stays
 readable).
 
 How can I generate an mli file from an ml file?
-=============================================
+===============================================
 
 When a module starts as just an implementation (``.ml`` file), it can be tedious
 to define the corresponding interface (``.mli`` file).

--- a/doc/goals.rst
+++ b/doc/goals.rst
@@ -32,7 +32,7 @@ In the rest of this page, we develop these points and give some
 insights into our current and future focuses.
 
 Have excellent backward compatibility properties
-===============================================
+================================================
 
 In an open-source community, there will always be groups of people
 with enough resources to continuously bring their projects up to date

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -240,7 +240,7 @@ Specifying inline test dependencies
 -----------------------------------
 
 If your tests are reading files, you must say it to dune by adding
-a ``deps`` field the the ``inline_tests`` field. The argument of this
+a ``deps`` field the ``inline_tests`` field. The argument of this
 ``deps`` field follows the usual :ref:`deps-field`. For instance:
 
 .. code:: ocaml

--- a/doc/variants.rst
+++ b/doc/variants.rst
@@ -158,7 +158,7 @@ Some of these are temporary.
   is, modules that aren't a part of the virtual library's cmi. Consequently, a
   module in an implementation either implements a virtual module or is private.
 
-* It's not possible to load virtual virtual libraries into utop. As a result,
+* It's not possible to load virtual libraries into utop. As a result,
   any directory that contains a virtual library will not work with ``$ dune
   utop``. This is an essential limitation, but it would be best to somehow skip
   these libraries or provide an implementation for them when loading a toplevel.


### PR DESCRIPTION
Hi,

This fixes markup (some warnings and some text that was in italics rather than in fixed width), and some duplicate words.