### PR TITLE
Cleanup output of fiber tests

### DIFF
--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -101,15 +101,6 @@ Error []
 |}]
 
 let%expect_test _ =
-  test (backtrace_result unit)
-    (Fiber.collect_errors (fun () ->
-         Fiber.with_error_handler failing_fiber ~on_error:log_error));
-  [%expect {|
-raised Exit
-Error []
-|}]
-
-let%expect_test _ =
   test
     (backtrace_result (pair unit unit))
     (Fiber.collect_errors (fun () ->

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -88,19 +88,24 @@ let%expect_test _ =
 Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
 
+let log_error (e : Exn_with_backtrace.t) =
+  Printf.printf "raised %s\n" (Printexc.to_string e.exn)
+
 let%expect_test _ =
   test (backtrace_result unit)
     (Fiber.collect_errors (fun () ->
-         Fiber.with_error_handler failing_fiber ~on_error:ignore));
+         Fiber.with_error_handler failing_fiber ~on_error:log_error));
   [%expect {|
+raised Exit
 Error []
 |}]
 
 let%expect_test _ =
   test (backtrace_result unit)
     (Fiber.collect_errors (fun () ->
-         Fiber.with_error_handler failing_fiber ~on_error:ignore));
+         Fiber.with_error_handler failing_fiber ~on_error:log_error));
   [%expect {|
+raised Exit
 Error []
 |}]
 

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -59,9 +59,10 @@ let never_fiber () = Fiber.never
 let backtrace_result dyn_of_ok =
   Result.to_dyn dyn_of_ok (list Exn_with_backtrace.to_dyn)
 
+let test to_dyn f = Scheduler.run f |> to_dyn |> print_dyn
+
 let%expect_test _ =
-  Scheduler.run (Fiber.collect_errors failing_fiber)
-  |> backtrace_result unit |> print_dyn;
+  test (backtrace_result unit) (Fiber.collect_errors failing_fiber);
   [%expect {|
 Error [ { exn = "Exit"; backtrace = "" } ]
 |}]
@@ -77,8 +78,6 @@ let%expect_test _ =
   [%expect {|
 Ok ()
 |}]
-
-let test to_dyn f = Scheduler.run f |> to_dyn |> print_dyn
 
 let%expect_test _ =
   test (backtrace_result unit)


### PR DESCRIPTION
Print the exact results of tests where possible.

I'd also like to clean up the other tests that use flags. @jeremiedimino what
about just printing the value of the flag and whether Never was raised at the
end of the run?