### PR TITLE
Add %{dir:...} form

### DIFF
--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -188,6 +188,9 @@ let static_expand
     | Macro (Artifact a, s) when not artifacts_dynamic ->
       let loc = String_with_vars.Var.loc var in
       expand_artifact ~dir ~loc t a s
+    | Macro (Path_no_dep, s) ->
+      let error_loc = String_with_vars.Var.loc var in
+      Value [ Value.Dir (Path.build (Path.Build.relative ~error_loc dir s)) ]
     | expansion -> Deferred expansion )
 
 let cc_cxx_bindings =

--- a/src/dune/pform.ml
+++ b/src/dune/pform.ml
@@ -277,6 +277,7 @@ module Map = struct
         ; ("path-no-dep", deleted_in ~version:(1, 0) Macro.Path_no_dep)
         ; ("ocaml-config", macro Ocaml_config)
         ; ("env", since ~version:(1, 4) Macro.Env)
+        ; ("dir", since ~version:(2, 5) Macro.Path_no_dep)
         ]
       @ List.map ~f:artifact Artifact.all )
 

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -373,6 +373,14 @@
    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias dir-form)
+ (deps (package dune) (source_tree test-cases/dir-form) (alias test-deps))
+ (action
+  (chdir
+   test-cases/dir-form
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias dir-target-dep)
  (deps
   (package dune)
@@ -2989,6 +2997,7 @@
   (alias deps-conf-vars)
   (alias describe)
   (alias dialects)
+  (alias dir-form)
   (alias dir-target-dep)
   (alias disable-promotion)
   (alias double-echo)
@@ -3280,6 +3289,7 @@
   (alias deps-conf-vars)
   (alias describe)
   (alias dialects)
+  (alias dir-form)
   (alias dir-target-dep)
   (alias disable-promotion)
   (alias double-echo)

--- a/test/blackbox-tests/test-cases/dir-form/run.t
+++ b/test/blackbox-tests/test-cases/dir-form/run.t
@@ -1,0 +1,18 @@
+Check the expansion of %{dir:...}
+
+  $ touch dune-workspace
+
+  $ mkdir -p a/b/c
+
+  $ cat > a/b/dune-project <<EOF
+  > (lang dune 2.5)
+  > EOF
+
+  $ cat > a/b/dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (action (chdir %{workspace_root} (echo "%{dir:c}\n"))))
+  > EOF
+
+  $ dune build @foo
+  a/b/c


### PR DESCRIPTION
Hello. This PR does two things:

- Introduce a form `%{relpath:<path>}` that signals `dune` that `<path>` is to be consider relative to the current directory and so it should be adjusted when it changes directories (example below of a use-case). I believe this is what was discussed in #2856.

- Extend the plumbing of the variable expansion so that this form can be used in `(link_flags ...)`. I believe the same plumbing can be used to extend the use of such variables to other "flag" fields. There is still an **issue** with this, see below.

For background, this is my use-case: I have a rule that builds a static library:
```
(rule
 (name libfoo.a)
 (action ...))
```
and an OCaml executable that links it in:
```
(executable
 (name main)
 (link_deps libfoo.a)
 (link_flags -cclib ???/libfoo.a))
```
where `???` means the path from the workspace root. As far as I know there is no nice way to get this. With this PR I can write:
```
(executable
 (name main)
 (link_deps libfoo.a)
 (link_flags -cclib %{relpath:libfoo.a}))
```

**Outstanding problem:** if I change `%{relpath:libfoo.a}` by `%{relpath:.}/libfoo.a` in `(link_flags ...)` the form gets expanded to just `.`.  You can see this issue in the test file, where it says "Alas, the following does not work". Help **appreciated**!

The commits can be reviewed one-by-one and are mostly self-explanatory. However, in a nutshell to be able to use `%{relpath:...}` in `(link_flags ...)`, I extend `Expander.expand_and_eval_set` to return a `Value.t list` instead of "just" a `string list`. That way the command line fragment that corresponds to `(link_flags ...)` can be built with `Command.Args.Path` instead of "just" `Command.Args.A`.

What do you think?

Thanks!