### PR TITLE
remove unused Fiber.nfork* functions

### DIFF
--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -408,23 +408,6 @@ let fork f k =
   EC.apply f () (fun x -> Ivar.fill ivar x ignore);
   k ivar
 
-let nfork_map l ~f k =
-  match l with
-  | [] -> k []
-  | [ x ] -> fork (fun () -> f x) (fun ivar -> k [ ivar ])
-  | l ->
-    let n = List.length l in
-    EC.add_refs (n - 1);
-    let ivars =
-      List.map l ~f:(fun x ->
-          let ivar = Ivar.create () in
-          EC.apply f x (fun x -> Ivar.fill ivar x ignore);
-          ivar)
-    in
-    k ivars
-
-let nfork l : _ Future.t list t = nfork_map l ~f:(fun f -> f ())
-
 module Mutex = struct
   type t =
     { mutable locked : bool


### PR DESCRIPTION
Last time I looked at these functions, the implementation made me frown. Plus these are unused, so no point keeping unused functions that are not tested and might be broken.