### PR TITLE
[cram] file generation

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -393,12 +393,12 @@ end = struct
           tmp_files := Files.empty;
           Files.iter fns ~f:(fun fn -> try Sys.remove fn with _ -> ()))
 
-    let create prefix suffix =
+    let file prefix suffix =
       let fn = Filename.temp_file prefix suffix in
       tmp_files := Files.add fn !tmp_files;
       fn
 
-    let destroy fn =
+    let destroy_file fn =
       (try Sys.remove fn with _ -> ());
       tmp_files := Files.remove fn !tmp_files
   end
@@ -444,7 +444,7 @@ end = struct
       done
 
     let open_temp_file () =
-      let out = Temp.create "duneboot-" ".output" in
+      let out = Temp.file "duneboot-" ".output" in
       let fd =
         Unix.openfile out [ O_WRONLY; O_CREAT; O_TRUNC; O_SHARE_DELETE ] 0o666
       in
@@ -452,7 +452,7 @@ end = struct
 
     let read_temp fn =
       let s = read_file fn in
-      Temp.destroy fn;
+      Temp.destroy_file fn;
       s
 
     let initial_cwd = Sys.getcwd ()

--- a/otherlibs/cram/bin/cram_lexer.mli
+++ b/otherlibs/cram/bin/cram_lexer.mli
@@ -1,8 +1,8 @@
 (** .t file parser *)
 
 (** A command or comment. Output blocks are skipped *)
-type block =
-  | Command of string list
+type 'command block =
+  | Command of 'command
   | Comment of string list
 
-val block : Lexing.lexbuf -> block option
+val block : Lexing.lexbuf -> string list block option

--- a/otherlibs/cram/bin/cram_lexer.mll
+++ b/otherlibs/cram/bin/cram_lexer.mll
@@ -1,6 +1,6 @@
 {
-type block =
-  | Command of string list
+type 'command block =
+  | Command of 'command
   | Comment of string list
 }
 

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -189,10 +189,17 @@ let create_sh_script cram_stanzas ~temp_dir ~sanitizer_command :
       let sanitized_output = file ~ext:".sanitized" in
       fprln oc ". %s > %s 2>&1" user_shell_code_file_sh_path
         user_shell_code_output_file_sh_path;
-      (* XXX stderr outputted by the sanitizer command is ignored. That's not
-         good. *)
-      fprln oc {|%s --exit-code $? < %s > %s|} sanitizer_command
-        user_shell_code_output_file_sh_path (sh_path sanitized_output);
+      fprln oc {|_CRAM_EXIT_CODE=$?|};
+      let () =
+        let sanitized_output = sh_path sanitized_output in
+        (* XXX stderr outputted by the sanitizer command is ignored. That's not
+           good. *)
+        fprln oc {|%s < %s > %s|} sanitizer_command
+          user_shell_code_output_file_sh_path sanitized_output;
+        fprln oc
+          {|([ "$_CRAM_EXIT_CODE" -ne "0" ] && echo "  [$_CRAM_EXIT_CODE]" >> %s) || true|}
+          sanitized_output
+      in
       Command { command = lines; output_file = sanitized_output }
   in
   let cram_to_output = List.mapi ~f:loop cram_stanzas in

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -106,7 +106,7 @@ let compose_cram_output cram_stanzas =
     Buffer.add_string buf line;
     Buffer.add_char buf '\n'
   in
-  let add_space_line line =
+  let add_line_prefixed_with_two_space line =
     Buffer.add_string buf "  ";
     add_line line
   in
@@ -122,10 +122,10 @@ let compose_cram_output cram_stanzas =
                 '>' )
               line
           in
-          add_space_line line);
+          add_line_prefixed_with_two_space line);
       Io.String_path.read_file output_file
       |> String.split_lines
-      |> List.iter ~f:add_space_line);
+      |> List.iter ~f:add_line_prefixed_with_two_space);
   Buffer.contents buf
 
 let create_sh_script cram_stanzas ~temp_dir ~sanitizer_command :

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -48,14 +48,16 @@ let run_expect_test file ~f =
 
 let remove_at_exit fn = at_exit (fun () -> try Sys.remove fn with _ -> ())
 
+let temp_prefix = "dune-test"
+
 let temp_file suffix =
-  let fn = Filename.temp_file "dune-test" suffix in
+  let fn = Filename.temp_file temp_prefix suffix in
   remove_at_exit fn;
   fn
 
 let open_temp_file suffix =
   let fn, oc =
-    Filename.open_temp_file "dune-test" suffix ~mode:[ Open_binary ]
+    Filename.open_temp_file temp_prefix suffix ~mode:[ Open_binary ]
   in
   remove_at_exit fn;
   (fn, oc)

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -134,6 +134,7 @@ let compose_cram_output cram_stanzas =
 let create_sh_script cram_stanzas ~temp_dir ~sanitizer_command :
     string * block_with_result list =
   let script, oc = Temp.Dir.open_file temp_dir ~suffix:".main.sh" in
+  let script = Path.to_string script in
   let loop i block =
     let i = succ i in
     match (block : Cram_lexer.block) with
@@ -141,7 +142,7 @@ let create_sh_script cram_stanzas ~temp_dir ~sanitizer_command :
     | Command lines ->
       let file ~ext =
         let suffix = sprintf "_%d%s" i ext in
-        Temp.Dir.file temp_dir ~suffix
+        Temp.Dir.file temp_dir ~suffix |> Path.to_string
       in
       (* Shell code written by the user might not be properly terminated. For
          instance the user might forgot to write [EOF] after a [cat <<EOF]. If

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -169,6 +169,9 @@ let create_sh_script lexbuf ~temp_dir ~sanitizer_command =
   loop 1;
   script
 
+let display_with_bars s =
+  List.iter (String.split_lines s) ~f:(Printf.eprintf "| %s\n")
+
 let run ~sanitizer ~file lexbuf =
   let sanitizer_command =
     match sanitizer with
@@ -203,9 +206,9 @@ let run ~sanitizer ~file lexbuf =
     Printf.eprintf "Generated cram script exited with code %d!\n" n;
     Printf.eprintf "Script:\n";
     let script = Io.String_path.read_file script in
-    List.iter (String.split_lines script) ~f:(Printf.eprintf "| %s\n");
+    display_with_bars script;
     Printf.eprintf "Script output:\n";
-    List.iter (String.split_lines output) ~f:(Printf.eprintf "| %s\n");
+    display_with_bars output;
     exit 1
   );
   output

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -189,6 +189,8 @@ let create_sh_script cram_stanzas ~temp_dir ~sanitizer_command :
       let sanitized_output = file ~ext:".sanitized" in
       fprln oc ". %s > %s 2>&1" user_shell_code_file_sh_path
         user_shell_code_output_file_sh_path;
+      (* XXX stderr outputted by the sanitizer command is ignored. That's not
+         good. *)
       fprln oc {|%s --exit-code $? < %s > %s|} sanitizer_command
         user_shell_code_output_file_sh_path (sh_path sanitized_output);
       Command { command = lines; output_file = sanitized_output }

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -36,8 +36,10 @@ let quote_for_sh fn =
 
 let run_expect_test file ~f =
   let file_contents = Io.String_path.read_file file in
-  let lexbuf = Lexbuf.from_string file_contents ~fname:file in
-  let expected = f lexbuf in
+  let expected =
+    let lexbuf = Lexbuf.from_string file_contents ~fname:file in
+    f lexbuf
+  in
   let corrected_file = file ^ ".corrected" in
   if file_contents <> expected then
     Io.String_path.write_file corrected_file expected

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -114,7 +114,13 @@ type sh_script =
 let read_exit_codes_and_prefix_maps file =
   let s = Io.String_path.read_file ~binary:true file in
   let rec loop acc = function
-    | exit_code :: build_path_prefix_map :: entries ->
+    | [ "" ]
+    | [] ->
+      List.rev acc
+    | entry :: entries ->
+      let exit_code, build_path_prefix_map =
+        String.lsplit2_exn entry ~on:'\n'
+      in
       let exit_code =
         match Int.of_string exit_code with
         | Some s -> s
@@ -125,11 +131,6 @@ let read_exit_codes_and_prefix_maps file =
             ]
       in
       loop ({ exit_code; build_path_prefix_map } :: acc) entries
-    | [ "" ]
-    | [] ->
-      List.rev acc
-    | [ _ ] ->
-      Code_error.raise "odd number of elements" [ ("s", Dyn.Encoder.string s) ]
   in
   loop [] (String.split ~on:'\000' s)
 
@@ -238,7 +239,7 @@ let create_sh_script cram_stanzas ~temp_dir : sh_script =
       in
       fprln oc ". %s > %s 2>&1" user_shell_code_file_sh_path
         user_shell_code_output_file_sh_path;
-      fprln oc {|printf "$?\0$%s\0" >> %s|} _BUILD_PATH_PREFIX_MAP
+      fprln oc {|printf "$?\n$%s\0" >> %s|} _BUILD_PATH_PREFIX_MAP
         metadata_file_sh_path;
       Command { command = lines; output_file = user_shell_code_output_file }
   in

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -239,7 +239,13 @@ let run ~sanitizer ~file lexbuf =
   extend_build_path_prefix_map ~cwd;
   let n =
     let pid =
-      let fd = Unix.openfile "/dev/null" [ O_WRONLY ] 0 in
+      let null =
+        if Sys.win32 then
+          "nul"
+        else
+          "/dev/null"
+      in
+      let fd = Unix.openfile null [ O_WRONLY ] 0 in
       let pid = Unix.create_process "sh" [| "sh"; script |] Unix.stdin fd fd in
       Unix.close fd;
       pid

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -252,7 +252,7 @@ let display_with_bars s =
 let run ~sanitizer ~file lexbuf =
   let temp_dir =
     let suffix = Filename.basename file in
-    Temp.dir ~prefix:"dune.cram." ~suffix
+    Temp.create Dir ~prefix:"dune.cram." ~suffix
   in
   let cram_stanzas = cram_stanzas lexbuf in
   let sh_script = create_sh_script cram_stanzas ~temp_dir in

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -252,7 +252,7 @@ let display_with_bars s =
 let run ~sanitizer ~file lexbuf =
   let temp_dir =
     let suffix = Filename.basename file in
-    Temp.dir ~prefix:".dune.cram" ~suffix
+    Temp.dir ~prefix:"dune.cram." ~suffix
   in
   let cram_stanzas = cram_stanzas lexbuf in
   let sh_script = create_sh_script cram_stanzas ~temp_dir in

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -46,16 +46,18 @@ let run_expect_test file ~f =
     exit 0
   )
 
+let remove_at_exit fn = at_exit (fun () -> try Sys.remove fn with _ -> ())
+
 let temp_file suffix =
   let fn = Filename.temp_file "dune-test" suffix in
-  at_exit (fun () -> try Sys.remove fn with _ -> ());
+  remove_at_exit fn;
   fn
 
 let open_temp_file suffix =
   let fn, oc =
     Filename.open_temp_file "dune-test" suffix ~mode:[ Open_binary ]
   in
-  at_exit (fun () -> try Sys.remove fn with _ -> ());
+  remove_at_exit fn;
   (fn, oc)
 
 let extend_build_path_prefix_map ~cwd =

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -238,7 +238,7 @@ let create_sh_script cram_stanzas ~temp_dir : sh_script =
       in
       fprln oc ". %s > %s 2>&1" user_shell_code_file_sh_path
         user_shell_code_output_file_sh_path;
-      fprln oc {|printf "$?\0$%s\0" >> %s|} _BUILD_PATH_PREFIX_MAP
+      fprln oc {|printf "%%d\0%%s\0" $? $%s >> %s|} _BUILD_PATH_PREFIX_MAP
         metadata_file_sh_path;
       Command { command = lines; output_file = user_shell_code_output_file }
   in

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -263,7 +263,8 @@ let run ~sanitizer ~file lexbuf =
     let env = Env.add env ~var:"LC_ALL" ~value:"C" in
     let env = extend_build_path_prefix_map ~env ~cwd in
     let env =
-      Env.add env ~var:"TMPDIR" ~value:(Path.to_absolute_filename temp_dir)
+      Env.add env ~var:Env.Var.temp_dir
+        ~value:(Path.to_absolute_filename temp_dir)
     in
     Env.to_unix env
   in

--- a/otherlibs/cram/bin/run.ml
+++ b/otherlibs/cram/bin/run.ml
@@ -263,6 +263,8 @@ let run ~sanitizer ~file lexbuf =
     let env = Env.add env ~var:"LC_ALL" ~value:"C" in
     let env = extend_build_path_prefix_map ~env ~cwd in
     let env =
+      let temp_dir = Path.relative temp_dir "tmp" in
+      Path.mkdir_p temp_dir;
       Env.add env ~var:Env.Var.temp_dir
         ~value:(Path.to_absolute_filename temp_dir)
     in

--- a/otherlibs/cram/bin/sanitize.ml
+++ b/otherlibs/cram/bin/sanitize.ml
@@ -50,12 +50,7 @@ let make_ext_replace config =
         sprintf "%c%s" s.[0] (String.Map.find_exn map (String.drop s 1)))
 
 let term =
-  let+ exit_code =
-    Arg.(
-      value & opt int 0
-      & info [ "exit-code" ] ~docv:"NUM"
-          ~doc:"Exit code of the shell command we are sanitizing the output of.")
-  and+ file =
+  let+ file =
     Arg.(value & pos 0 (some string) None (Arg.info [] ~docv:"FILE"))
   in
   let ext_replace =
@@ -66,7 +61,7 @@ let term =
     s
   in
   let sanitize s = s |> Ansi_color.strip |> ext_replace |> rewrite_paths in
-  ( match file with
+  match file with
   | Some fn ->
     Io.String_path.read_file fn
     |> sanitize |> String.split_lines
@@ -79,8 +74,7 @@ let term =
         Printf.printf "  %s\n" (sanitize line);
         if isatty then flush stdout
       done
-    with End_of_file -> () ) );
-  if exit_code <> 0 then Printf.printf "  [%d]\n" exit_code
+    with End_of_file -> () )
 
 let command =
   (term, Term.info "sanitize" ~doc:"Sanitize the output of shell phrases.")

--- a/otherlibs/cram/bin/sanitize.ml
+++ b/otherlibs/cram/bin/sanitize.ml
@@ -4,23 +4,19 @@ open Import.Let_syntax
 module Re = Dune_re
 module Configurator = Configurator.V1
 
-let rewrite_paths =
-  let var = "BUILD_PATH_PREFIX_MAP" in
-  match Sys.getenv var with
-  | exception Not_found -> fun s -> s
-  | s -> (
-    match Build_path_prefix_map.decode_map s with
-    | Error msg ->
-      Printf.eprintf "Cannot decode %s: %s\n%!" var msg;
-      exit 2
-    | Ok map ->
-      let abs_path_re =
-        let not_dir = Printf.sprintf " \n\r\t%c" Bin.path_sep in
-        Re.(compile (seq [ char '/'; rep1 (diff any (set not_dir)) ]))
-      in
-      fun s ->
-        Re.replace abs_path_re s ~f:(fun g ->
-            Build_path_prefix_map.rewrite map (Re.Group.get g 0)) )
+let rewrite_paths build_path_prefix_map =
+  match Build_path_prefix_map.decode_map build_path_prefix_map with
+  | Error msg ->
+    Printf.eprintf "Cannot decode %s: %s\n%!" build_path_prefix_map msg;
+    exit 2
+  | Ok map ->
+    let abs_path_re =
+      let not_dir = Printf.sprintf " \n\r\t%c" Bin.path_sep in
+      Re.(compile (seq [ char '/'; rep1 (diff any (set not_dir)) ]))
+    in
+    fun s ->
+      Re.replace abs_path_re s ~f:(fun g ->
+          Build_path_prefix_map.rewrite map (Re.Group.get g 0))
 
 let make_ext_replace config =
   let tbl =
@@ -49,10 +45,7 @@ let make_ext_replace config =
         let s = Re.Group.get g 0 in
         sprintf "%c%s" s.[0] (String.Map.find_exn map (String.drop s 1)))
 
-let term =
-  let+ file =
-    Arg.(value & pos 0 (some string) None (Arg.info [] ~docv:"FILE"))
-  in
+let sanitizer =
   let ext_replace =
     if Option.is_some (Env.get Env.initial "INSIDE_DUNE") then
       make_ext_replace (Configurator.create "sanitizer")
@@ -60,20 +53,13 @@ let term =
       fun s ->
     s
   in
-  let sanitize s = s |> Ansi_color.strip |> ext_replace |> rewrite_paths in
-  match file with
-  | Some fn ->
-    Io.String_path.read_file fn
-    |> sanitize |> String.split_lines |> List.iter ~f:print_endline
-  | None -> (
-    let isatty = Unix.(isatty stdout) in
-    try
-      while true do
-        let line = input_line stdin in
-        print_endline (sanitize line);
-        if isatty then flush stdout
-      done
-    with End_of_file -> () )
+  fun (command : Sanitizer.Command.t) ->
+    command.output |> Ansi_color.strip |> ext_replace
+    |> rewrite_paths command.build_path_prefix_map
+
+let term =
+  let+ () = Term.pure () in
+  Sanitizer.impl_sanitizer sanitizer stdin stdout
 
 let command =
   (term, Term.info "sanitize" ~doc:"Sanitize the output of shell phrases.")

--- a/otherlibs/cram/bin/sanitize.ml
+++ b/otherlibs/cram/bin/sanitize.ml
@@ -64,14 +64,13 @@ let term =
   match file with
   | Some fn ->
     Io.String_path.read_file fn
-    |> sanitize |> String.split_lines
-    |> List.iter ~f:(fun line -> Printf.printf "  %s\n" line)
+    |> sanitize |> String.split_lines |> List.iter ~f:print_endline
   | None -> (
     let isatty = Unix.(isatty stdout) in
     try
       while true do
         let line = input_line stdin in
-        Printf.printf "  %s\n" (sanitize line);
+        print_endline (sanitize line);
         if isatty then flush stdout
       done
     with End_of_file -> () )

--- a/otherlibs/cram/bin/sanitizer.ml
+++ b/otherlibs/cram/bin/sanitizer.ml
@@ -1,0 +1,70 @@
+open Stdune
+
+module Command = struct
+  type t =
+    { output : string
+    ; build_path_prefix_map : string
+    }
+
+  let of_sexp (csexp : Sexp.t) : t =
+    match csexp with
+    | List [ Atom build_path_prefix_map; Atom output ] ->
+      { build_path_prefix_map; output }
+    | _ -> Code_error.raise "Command.of_csexp: invalid csexp" []
+
+  let to_sexp { output; build_path_prefix_map } : Sexp.t =
+    List [ Atom build_path_prefix_map; Atom output ]
+end
+
+let run_sanitizer ?temp_dir ~prog ~argv commands =
+  let temp_dir =
+    match temp_dir with
+    | Some d -> d
+    | None -> Temp.dir ~prefix:"sanitizer" ~suffix:"unspecified"
+  in
+  let argv = prog :: argv in
+  let fname = Path.relative temp_dir in
+  let stdout_path = fname "sanitizer.stdout" in
+  let stdout =
+    Unix.openfile
+      (Path.to_string stdout_path)
+      [ Unix.O_WRONLY; O_CREAT; O_TRUNC; O_SHARE_DELETE ]
+      0o777
+  in
+  let stdin =
+    let path = fname "sanitizer.stdin" in
+    let csexp = List.map commands ~f:Command.to_sexp in
+    Io.with_file_out path ~f:(fun oc ->
+        List.iter csexp ~f:(Csexp.to_channel oc));
+    Unix.openfile (Path.to_string path) [ Unix.O_RDONLY; O_SHARE_DELETE ] 0o666
+  in
+  let pid = Spawn.spawn ~prog ~argv ~stdin ~stdout () in
+  Unix.close stdout;
+  Unix.close stdin;
+  match Unix.waitpid [] (Pid.to_int pid) with
+  | _, WEXITED 0 ->
+    Io.with_file_in stdout_path ~f:(fun ic ->
+        let rec loop acc =
+          match Csexp.input_opt ic with
+          | Ok None -> List.rev acc
+          | Ok (Some (Sexp.Atom s)) -> loop (s :: acc)
+          | Error error ->
+            Code_error.raise "invalid csexp" [ ("error", String error) ]
+          | Ok _ -> Code_error.raise "unexpected output" []
+        in
+        loop [])
+  | _ -> Code_error.raise "unexpected termination of sanitizer" []
+
+let impl_sanitizer f in_ out =
+  let rec loop () =
+    match Csexp.input_opt in_ with
+    | Error error ->
+      Code_error.raise "unable to parse csexp" [ ("error", String error) ]
+    | Ok None -> ()
+    | Ok (Some sexp) ->
+      let command = Command.of_sexp sexp in
+      Csexp.to_channel out (Atom (f command));
+      flush out;
+      loop ()
+  in
+  loop ()

--- a/otherlibs/cram/bin/sanitizer.ml
+++ b/otherlibs/cram/bin/sanitizer.ml
@@ -20,7 +20,7 @@ let run_sanitizer ?temp_dir ~prog ~argv commands =
   let temp_dir =
     match temp_dir with
     | Some d -> d
-    | None -> Temp.dir ~prefix:"sanitizer" ~suffix:"unspecified"
+    | None -> Temp.create Dir ~prefix:"sanitizer" ~suffix:"unspecified"
   in
   let argv = prog :: argv in
   let fname = Path.relative temp_dir in

--- a/otherlibs/cram/bin/sanitizer.ml
+++ b/otherlibs/cram/bin/sanitizer.ml
@@ -34,7 +34,7 @@ let run_sanitizer ?temp_dir ~prog ~argv commands =
   let stdin =
     let path = fname "sanitizer.stdin" in
     let csexp = List.map commands ~f:Command.to_sexp in
-    Io.with_file_out path ~f:(fun oc ->
+    Io.with_file_out ~binary:true path ~f:(fun oc ->
         List.iter csexp ~f:(Csexp.to_channel oc));
     Unix.openfile (Path.to_string path) [ Unix.O_RDONLY; O_SHARE_DELETE ] 0o666
   in

--- a/otherlibs/cram/bin/sanitizer.ml
+++ b/otherlibs/cram/bin/sanitizer.ml
@@ -56,6 +56,8 @@ let run_sanitizer ?temp_dir ~prog ~argv commands =
   | _ -> Code_error.raise "unexpected termination of sanitizer" []
 
 let impl_sanitizer f in_ out =
+  set_binary_mode_in in_ true;
+  set_binary_mode_out out true;
   let rec loop () =
     match Csexp.input_opt in_ with
     | Error error ->

--- a/otherlibs/cram/bin/sanitizer.mli
+++ b/otherlibs/cram/bin/sanitizer.mli
@@ -1,0 +1,17 @@
+open Stdune
+
+module Command : sig
+  type t =
+    { output : string
+    ; build_path_prefix_map : string
+    }
+end
+
+val impl_sanitizer : (Command.t -> string) -> in_channel -> out_channel -> unit
+
+val run_sanitizer :
+     ?temp_dir:Path.t
+  -> prog:string
+  -> argv:string list
+  -> Command.t list
+  -> string list

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -407,7 +407,7 @@ and exec_list ts ~ectx ~eenv =
 
 and exec_pipe outputs ts ~ectx ~eenv =
   let tmp_file () =
-    Temp.create ~prefix:"dune-pipe-action-"
+    Temp.file ~prefix:"dune-pipe-action-"
       ~suffix:("." ^ Action.Outputs.to_string outputs)
   in
   let multi_use_eenv =
@@ -421,7 +421,7 @@ and exec_pipe outputs ts ~ectx ~eenv =
     | [] -> assert false
     | [ last_t ] ->
       let+ result = redirect_in last_t ~ectx ~eenv Stdin in_ in
-      Temp.destroy in_;
+      Temp.destroy_file in_;
       result
     | t :: ts -> (
       let out = tmp_file () in
@@ -429,7 +429,7 @@ and exec_pipe outputs ts ~ectx ~eenv =
         redirect t ~ectx ~eenv:multi_use_eenv ~in_:(Stdin, in_)
           ~out:(outputs, out) ()
       in
-      Temp.destroy in_;
+      Temp.destroy_file in_;
       match done_or_deps with
       | Need_more_deps _ as need -> Fiber.return need
       | Done -> loop ~in_:out ts )

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -407,7 +407,7 @@ and exec_list ts ~ectx ~eenv =
 
 and exec_pipe outputs ts ~ectx ~eenv =
   let tmp_file () =
-    Temp.file ~prefix:"dune-pipe-action-"
+    Temp.create File ~prefix:"dune-pipe-action-"
       ~suffix:("." ^ Action.Outputs.to_string outputs)
   in
   let multi_use_eenv =
@@ -421,7 +421,7 @@ and exec_pipe outputs ts ~ectx ~eenv =
     | [] -> assert false
     | [ last_t ] ->
       let+ result = redirect_in last_t ~ectx ~eenv Stdin in_ in
-      Temp.destroy_file in_;
+      Temp.destroy File in_;
       result
     | t :: ts -> (
       let out = tmp_file () in
@@ -429,7 +429,7 @@ and exec_pipe outputs ts ~ectx ~eenv =
         redirect t ~ectx ~eenv:multi_use_eenv ~in_:(Stdin, in_)
           ~out:(outputs, out) ()
       in
-      Temp.destroy_file in_;
+      Temp.destroy File in_;
       match done_or_deps with
       | Need_more_deps _ as need -> Fiber.return need
       | Done -> loop ~in_:out ts )

--- a/src/dune/process.ml
+++ b/src/dune/process.ml
@@ -464,7 +464,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
       match Response_file.get ~prog with
       | Not_supported -> (args, None)
       | Zero_terminated_strings arg ->
-        let fn = Temp.file ~prefix:"responsefile" ~suffix:".data" in
+        let fn = Temp.create File ~prefix:"responsefile" ~suffix:".data" in
         Stdune.Io.with_file_out fn ~f:(fun oc ->
             List.iter args ~f:(fun arg ->
                 output_string oc arg;
@@ -479,7 +479,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     | Terminal, _
     | _, Terminal
       when !Clflags.capture_outputs ->
-      let fn = Temp.file ~prefix:"dune" ~suffix:".output" in
+      let fn = Temp.create File ~prefix:"dune" ~suffix:".output" in
       let terminal = Io.file fn Io.Out in
       let get (out : Io.output Io.t) =
         if out.kind = Terminal then (
@@ -515,7 +515,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     | None -> ""
     | Some fn ->
       let s = Stdune.Io.read_file fn in
-      Temp.destroy_file fn;
+      Temp.destroy File fn;
       s
   in
   Log.command ~command_line ~output ~exit_status;
@@ -545,14 +545,14 @@ let run ?dir ?stdout_to ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
 
 let run_capture_gen ?dir ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
     fail_mode prog args ~f =
-  let fn = Temp.file ~prefix:"dune" ~suffix:".output" in
+  let fn = Temp.create File ~prefix:"dune" ~suffix:".output" in
   let+ run =
     run_internal ?dir ~stdout_to:(Io.file fn Io.Out) ?stderr_to ?stdin_from ~env
       ~purpose fail_mode prog args
   in
   map_result fail_mode run ~f:(fun () ->
       let x = f fn in
-      Temp.destroy_file fn;
+      Temp.destroy File fn;
       x)
 
 let run_capture = run_capture_gen ~f:Stdune.Io.read_file

--- a/src/dune/process.ml
+++ b/src/dune/process.ml
@@ -464,7 +464,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
       match Response_file.get ~prog with
       | Not_supported -> (args, None)
       | Zero_terminated_strings arg ->
-        let fn = Temp.create ~prefix:"responsefile" ~suffix:".data" in
+        let fn = Temp.file ~prefix:"responsefile" ~suffix:".data" in
         Stdune.Io.with_file_out fn ~f:(fun oc ->
             List.iter args ~f:(fun arg ->
                 output_string oc arg;
@@ -479,7 +479,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     | Terminal, _
     | _, Terminal
       when !Clflags.capture_outputs ->
-      let fn = Temp.create ~prefix:"dune" ~suffix:".output" in
+      let fn = Temp.file ~prefix:"dune" ~suffix:".output" in
       let terminal = Io.file fn Io.Out in
       let get (out : Io.output Io.t) =
         if out.kind = Terminal then (
@@ -515,7 +515,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     | None -> ""
     | Some fn ->
       let s = Stdune.Io.read_file fn in
-      Temp.destroy fn;
+      Temp.destroy_file fn;
       s
   in
   Log.command ~command_line ~output ~exit_status;
@@ -545,14 +545,14 @@ let run ?dir ?stdout_to ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
 
 let run_capture_gen ?dir ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
     fail_mode prog args ~f =
-  let fn = Temp.create ~prefix:"dune" ~suffix:".output" in
+  let fn = Temp.file ~prefix:"dune" ~suffix:".output" in
   let+ run =
     run_internal ?dir ~stdout_to:(Io.file fn Io.Out) ?stderr_to ?stdin_from ~env
       ~purpose fail_mode prog args
   in
   map_result fail_mode run ~f:(fun () ->
       let x = f fn in
-      Temp.destroy fn;
+      Temp.destroy_file fn;
       x)
 
 let run_capture = run_capture_gen ~f:Stdune.Io.read_file

--- a/src/stdune/env.ml
+++ b/src/stdune/env.ml
@@ -12,6 +12,12 @@ module Var = struct
     let to_dyn = Dyn.Encoder.string
   end
 
+  let temp_dir =
+    if Sys.win32 then
+      "TEMP"
+    else
+      "TMPDIR"
+
   include Comparable.Make (T)
   include T
 end

--- a/src/stdune/env.mli
+++ b/src/stdune/env.mli
@@ -3,6 +3,8 @@ module Var : sig
 
   val compare : t -> t -> Ordering.t
 
+  val temp_dir : t
+
   module Set : Set.S with type elt = t
 end
 

--- a/src/stdune/fpath.ml
+++ b/src/stdune/fpath.ml
@@ -1,0 +1,23 @@
+let is_root t = Filename.dirname t = t
+
+type mkdir_p =
+  | Already_exists
+  | Created
+
+let rec mkdir_p ?(perms = 0o777) t_s =
+  if is_root t_s then
+    Already_exists
+  else
+    try
+      Unix.mkdir t_s perms;
+      Created
+    with
+    | Unix.Unix_error (EEXIST, _, _) -> Already_exists
+    | Unix.Unix_error (ENOENT, _, _) as e ->
+      let parent = Filename.dirname t_s in
+      if is_root parent then
+        raise e
+      else
+        let (_ : mkdir_p) = mkdir_p parent ~perms in
+        Unix.mkdir t_s perms;
+        Created

--- a/src/stdune/fpath.mli
+++ b/src/stdune/fpath.mli
@@ -1,0 +1,5 @@
+type mkdir_p =
+  | Already_exists
+  | Created
+
+val mkdir_p : ?perms:int -> string -> mkdir_p

--- a/src/stdune/fpath.mli
+++ b/src/stdune/fpath.mli
@@ -1,5 +1,8 @@
+(** Functions on paths that are represented as strings *)
+
+(** Represent the result of [mkdir_p] *)
 type mkdir_p =
-  | Already_exists
-  | Created
+  | Already_exists  (** The path already exists. No action was taken *)
+  | Created  (** The directory was created. *)
 
 val mkdir_p : ?perms:int -> string -> mkdir_p

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -127,7 +127,8 @@ end = struct
       Code_error.raise "Path.External.parent_exn called on a root path" []
     | Some p -> p
 
-  let mkdir_p ?perms p = ignore (Fpath.mkdir_p ?perms (to_string p))
+  let mkdir_p ?perms p =
+    ignore (Fpath.mkdir_p ?perms (to_string p) : Fpath.mkdir_p)
 
   let extension t = Filename.extension (to_string t)
 
@@ -549,7 +550,8 @@ end = struct
 end
 
 module Relative_to_source_root = struct
-  let mkdir_p ?perms s = ignore (Fpath.mkdir_p ?perms (Local.to_string s))
+  let mkdir_p ?perms s =
+    ignore (Fpath.mkdir_p ?perms (Local.to_string s) : Fpath.mkdir_p)
 end
 
 module Source0 = Local

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1,31 +1,5 @@
 module Sys = Stdlib.Sys
 
-module Fpath = struct
-  let is_root t = Filename.dirname t = t
-
-  type mkdir_p =
-    | Already_exists
-    | Created
-
-  let rec mkdir_p ?(perms = 0o777) t_s =
-    if is_root t_s then
-      Already_exists
-    else
-      try
-        Unix.mkdir t_s perms;
-        Created
-      with
-      | Unix.Unix_error (EEXIST, _, _) -> Already_exists
-      | Unix.Unix_error (ENOENT, _, _) as e ->
-        let parent = Filename.dirname t_s in
-        if is_root parent then
-          raise e
-        else
-          let (_ : mkdir_p) = mkdir_p parent ~perms in
-          Unix.mkdir t_s perms;
-          Created
-end
-
 let basename_opt ~is_root ~basename t =
   if is_root t then
     None

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -46,6 +46,14 @@ module Unspecified : sig
   type w = Path_intf.Unspecified.w
 end
 
+module Fpath : sig
+  type mkdir_p =
+    | Already_exists
+    | Created
+
+  val mkdir_p : ?perms:int -> string -> mkdir_p
+end
+
 (** Relative path with unspecified root.
 
     Either root, or a '/' separated list of components other that ".", ".." and

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -46,14 +46,6 @@ module Unspecified : sig
   type w = Path_intf.Unspecified.w
 end
 
-module Fpath : sig
-  type mkdir_p =
-    | Already_exists
-    | Created
-
-  val mkdir_p : ?perms:int -> string -> mkdir_p
-end
-
 (** Relative path with unspecified root.
 
     Either root, or a '/' separated list of components other that ".", ".." and

--- a/src/stdune/sexp.ml
+++ b/src/stdune/sexp.ml
@@ -69,3 +69,7 @@ let rec of_dyn : Dyn.t -> t = function
     List (List.map fields ~f:(fun (field, f) -> List [ Atom field; of_dyn f ]))
   | Variant (s, []) -> Atom s
   | Variant (s, xs) -> List (Atom s :: List.map xs ~f:of_dyn)
+
+let rec to_dyn : t -> Dyn.t = function
+  | Atom s -> String s
+  | List xs -> List (List.map ~f:to_dyn xs)

--- a/src/stdune/sexp.mli
+++ b/src/stdune/sexp.mli
@@ -15,3 +15,5 @@ val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 
 val of_dyn : Dyn.t -> t
+
+val to_dyn : t -> Dyn.t

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -20,12 +20,8 @@ let tmp_files = ref Path.Set.empty
 
 let tmp_dirs = ref Path.Set.empty
 
-external open_desc : string -> open_flag list -> int -> int = "caml_sys_open"
-
-external close_desc : int -> unit = "caml_sys_close"
-
 let create_temp_file name =
-  close_desc (open_desc name [ Open_wronly; Open_creat; Open_excl ] 0o600)
+  Unix.close (Unix.openfile name [ O_WRONLY; Unix.O_CREAT; Unix.O_EXCL ] 0o600)
 
 let create_temp_dir name =
   match Fpath.mkdir_p name with

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -12,12 +12,7 @@ let try_times n ~f =
 
 let prng = lazy (Random.State.make_self_init ())
 
-let temp_file_name ?temp_dir ~prefix ~suffix () =
-  let temp_dir =
-    match temp_dir with
-    | None -> Filename.get_temp_dir_name ()
-    | Some t -> t
-  in
+let temp_file_name ~temp_dir ~prefix ~suffix =
   let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
   Filename.concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
 
@@ -49,8 +44,9 @@ let () =
 
 let temp ~set ~prefix ~suffix ~create =
   let path =
+    let temp_dir = Filename.get_temp_dir_name () in
     try_times 1000 ~f:(fun _ ->
-        let name = temp_file_name ~prefix ~suffix () in
+        let name = temp_file_name ~temp_dir ~prefix ~suffix in
         create name;
         name)
     |> Path.of_string

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -14,3 +14,29 @@ let create ~prefix ~suffix =
 let destroy fn =
   Path.unlink_no_err fn;
   tmp_files := Path.Set.remove !tmp_files fn
+
+module Dir = struct
+  type t = string
+
+  let prng = lazy (Random.State.make_self_init ())
+
+  let temp_file_name temp_dir prefix suffix =
+    let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
+    Filename.concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
+
+  let create ~for_script =
+    let dir = Filename.get_temp_dir_name () in
+    let t = temp_file_name dir ".dune.cram." (Filename.basename for_script) in
+    let path = Path.External.of_string t in
+    Path.External.mkdir_p path;
+    at_exit (fun () -> Path.rm_rf ~allow_external:true (Path.external_ path));
+    t
+
+  let file t ~suffix = Filename.temp_file ~temp_dir:t "" suffix
+
+  let open_file t ~suffix =
+    let fn, oc =
+      Filename.open_temp_file ~temp_dir:t "" suffix ~mode:[ Open_binary ]
+    in
+    (fn, oc)
+end

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -1,31 +1,69 @@
+let try_times n ~f =
+  assert (n > 0);
+  let rec loop n =
+    if n = 1 then
+      f n
+    else
+      match f n with
+      | exception _ -> loop (n - 1)
+      | r -> r
+  in
+  loop n
+
+let prng = lazy (Random.State.make_self_init ())
+
+let temp_file_name ?temp_dir ~prefix ~suffix () =
+  let temp_dir =
+    match temp_dir with
+    | None -> Filename.get_temp_dir_name ()
+    | Some t -> t
+  in
+  let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
+  Filename.concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
+
 let tmp_files = ref Path.Set.empty
 
+let tmp_dirs = ref Path.Set.empty
+
+external open_desc : string -> open_flag list -> int -> int = "caml_sys_open"
+
+external close_desc : int -> unit = "caml_sys_close"
+
+let create_temp_file name =
+  close_desc (open_desc name [ Open_wronly; Open_creat; Open_excl ] 0o600)
+
+let create_temp_dir name =
+  match Path.Fpath.mkdir_p name with
+  | Created -> ()
+  | Already_exists -> failwith "temp dir exists"
+
 let () =
+  let iter_and_clear r ~f =
+    let tmp = !r in
+    r := Path.Set.empty;
+    Path.Set.iter tmp ~f
+  in
   at_exit (fun () ->
-      let fns = !tmp_files in
-      tmp_files := Path.Set.empty;
-      Path.Set.iter fns ~f:Path.unlink_no_err)
+      iter_and_clear tmp_files ~f:Path.unlink_no_err;
+      iter_and_clear tmp_dirs ~f:(Path.rm_rf ~allow_external:true))
+
+let temp ~set ~prefix ~suffix ~create =
+  let path =
+    try_times 1000 ~f:(fun _ ->
+        let name = temp_file_name ~prefix ~suffix () in
+        create name;
+        name)
+    |> Path.of_string
+  in
+  set := Path.Set.add !set path;
+  path
 
 let create ~prefix ~suffix =
-  let fn = Path.of_string (Filename.temp_file prefix suffix) in
-  tmp_files := Path.Set.add !tmp_files fn;
-  fn
+  temp ~set:tmp_files ~prefix ~suffix ~create:create_temp_file
 
 let destroy fn =
   Path.unlink_no_err fn;
   tmp_files := Path.Set.remove !tmp_files fn
 
-let prng = lazy (Random.State.make_self_init ())
-
-let temp_file_name temp_dir prefix suffix =
-  let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
-  Filename.concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
-
 let dir ~prefix ~suffix =
-  let dir = Filename.get_temp_dir_name () in
-  let t = temp_file_name dir prefix suffix in
-  let path = Path.External.of_string t in
-  Path.External.mkdir_p path;
-  let path = Path.external_ path in
-  at_exit (fun () -> Path.rm_rf ~allow_external:true path);
-  path
+  temp ~set:tmp_dirs ~prefix ~suffix ~create:create_temp_dir

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -35,7 +35,7 @@ let create_temp_file name =
 let create_temp_dir name =
   match Fpath.mkdir_p name with
   | Created -> ()
-  | Already_exists -> failwith "temp dir exists"
+  | Already_exists -> raise (Unix.Unix_error (ENOENT, "mkdir", name))
 
 let () =
   let iter_and_clear r ~f =

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -15,33 +15,17 @@ let destroy fn =
   Path.unlink_no_err fn;
   tmp_files := Path.Set.remove !tmp_files fn
 
-module Dir = struct
-  type t = Path.t
+let prng = lazy (Random.State.make_self_init ())
 
-  let prng = lazy (Random.State.make_self_init ())
+let temp_file_name temp_dir prefix suffix =
+  let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
+  Filename.concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
 
-  let temp_file_name temp_dir prefix suffix =
-    let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
-    Filename.concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
-
-  let create ~for_script =
-    let dir = Filename.get_temp_dir_name () in
-    let t = temp_file_name dir ".dune.cram." (Filename.basename for_script) in
-    let path = Path.External.of_string t in
-    Path.External.mkdir_p path;
-    let path = Path.external_ path in
-    at_exit (fun () -> Path.rm_rf ~allow_external:true path);
-    path
-
-  let file t ~suffix =
-    let t = Path.to_absolute_filename t in
-    Filename.temp_file ~temp_dir:t "" suffix
-    |> Path.External.of_string |> Path.external_
-
-  let open_file t ~suffix =
-    let t = Path.to_string t in
-    let fn, oc =
-      Filename.open_temp_file ~temp_dir:t "" suffix ~mode:[ Open_binary ]
-    in
-    (Path.external_ (Path.External.of_string fn), oc)
-end
+let dir ~prefix ~suffix =
+  let dir = Filename.get_temp_dir_name () in
+  let t = temp_file_name dir prefix suffix in
+  let path = Path.External.of_string t in
+  Path.External.mkdir_p path;
+  let path = Path.external_ path in
+  at_exit (fun () -> Path.rm_rf ~allow_external:true path);
+  path

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -58,10 +58,10 @@ let temp ~set ~prefix ~suffix ~create =
   set := Path.Set.add !set path;
   path
 
-let create ~prefix ~suffix =
+let file ~prefix ~suffix =
   temp ~set:tmp_files ~prefix ~suffix ~create:create_temp_file
 
-let destroy fn =
+let destroy_file fn =
   Path.unlink_no_err fn;
   tmp_files := Path.Set.remove !tmp_files fn
 

--- a/src/stdune/temp.ml
+++ b/src/stdune/temp.ml
@@ -33,7 +33,7 @@ let create_temp_file name =
   close_desc (open_desc name [ Open_wronly; Open_creat; Open_excl ] 0o600)
 
 let create_temp_dir name =
-  match Path.Fpath.mkdir_p name with
+  match Fpath.mkdir_p name with
   | Created -> ()
   | Already_exists -> failwith "temp dir exists"
 

--- a/src/stdune/temp.mli
+++ b/src/stdune/temp.mli
@@ -7,3 +7,14 @@
 val create : prefix:string -> suffix:string -> Path.t
 
 val destroy : Path.t -> unit
+
+module Dir : sig
+  (** Temporary directory API*)
+  type t
+
+  val create : for_script:string -> t
+
+  val open_file : t -> suffix:string -> string * out_channel
+
+  val file : t -> suffix:string -> string
+end

--- a/src/stdune/temp.mli
+++ b/src/stdune/temp.mli
@@ -8,13 +8,4 @@ val create : prefix:string -> suffix:string -> Path.t
 
 val destroy : Path.t -> unit
 
-module Dir : sig
-  (** Temporary directory API*)
-  type t
-
-  val create : for_script:string -> t
-
-  val open_file : t -> suffix:string -> Path.t * out_channel
-
-  val file : t -> suffix:string -> Path.t
-end
+val dir : prefix:string -> suffix:string -> Path.t

--- a/src/stdune/temp.mli
+++ b/src/stdune/temp.mli
@@ -4,8 +4,8 @@
     that all temporary files created by the application are systematically
     cleaned up on exit. *)
 
-val create : prefix:string -> suffix:string -> Path.t
+val file : prefix:string -> suffix:string -> Path.t
 
-val destroy : Path.t -> unit
+val destroy_file : Path.t -> unit
 
 val dir : prefix:string -> suffix:string -> Path.t

--- a/src/stdune/temp.mli
+++ b/src/stdune/temp.mli
@@ -4,8 +4,10 @@
     that all temporary files created by the application are systematically
     cleaned up on exit. *)
 
-val file : prefix:string -> suffix:string -> Path.t
+type what =
+  | Dir
+  | File
 
-val destroy_file : Path.t -> unit
+val create : what -> prefix:string -> suffix:string -> Path.t
 
-val dir : prefix:string -> suffix:string -> Path.t
+val destroy : what -> Path.t -> unit

--- a/src/stdune/temp.mli
+++ b/src/stdune/temp.mli
@@ -14,7 +14,7 @@ module Dir : sig
 
   val create : for_script:string -> t
 
-  val open_file : t -> suffix:string -> string * out_channel
+  val open_file : t -> suffix:string -> Path.t * out_channel
 
-  val file : t -> suffix:string -> string
+  val file : t -> suffix:string -> Path.t
 end


### PR DESCRIPTION

- [x] All artifacts are produced in a single directory
- [x] We no longer rely on the output of the shell script for the final output.
- [x] There's a sanitizer protocol
- [x] exit code handling is moved outside the sanitizer.
- [x] BUILD_PATH_PREFIX_MAP modifications are respected.