### PR TITLE
Use a tail-recursive List.map in Pp.map_tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ next
 - Improve error message when invalid package names (such as the empty string)
   are passed to `dune build -p`. (#3561, @emillon)
 
+- Fix a stack overflow when displaying large outputs (including diffs) (#3537,
+  fixes #2767, #3490, @emillon)
+
 2.6.0 (05/06/2020)
 ------------------
 

--- a/src/stdune/exn.ml
+++ b/src/stdune/exn.ml
@@ -1,4 +1,3 @@
-module List = Stdlib.ListLabels
 module String = Stdlib.StringLabels
 
 type t = exn
@@ -24,7 +23,7 @@ let pp_uncaught ~backtrace fmt exn =
   let s =
     Printf.sprintf "%s\n%s" (Printexc.to_string exn) backtrace
     |> String_split.split_lines
-    |> ListLabels.map ~f:(Printf.sprintf "| %s")
+    |> List.map ~f:(Printf.sprintf "| %s")
     |> String.concat ~sep:"\n"
   in
   let line = String.make 71 '-' in

--- a/src/stdune/pp.ml
+++ b/src/stdune/pp.ml
@@ -1,4 +1,9 @@
-module List = Stdlib.ListLabels
+module List = struct
+  include Stdlib.ListLabels
+
+  let map ~f t = rev (rev_map ~f t)
+end
+
 module String = Stdlib.StringLabels
 
 type +'a t =

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1347,6 +1347,14 @@
    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias github3490)
+ (deps (package dune) (source_tree test-cases/github3490) (alias test-deps))
+ (action
+  (chdir
+   test-cases/github3490
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias github3530)
  (deps (package dune) (source_tree test-cases/github3530) (alias test-deps))
  (action
@@ -3114,6 +3122,7 @@
   (alias github3046)
   (alias github3180)
   (alias github3440)
+  (alias github3490)
   (alias github3530)
   (alias github534)
   (alias github568)
@@ -3403,6 +3412,7 @@
   (alias github3046)
   (alias github3180)
   (alias github3440)
+  (alias github3490)
   (alias github3530)
   (alias github534)
   (alias github568)

--- a/test/blackbox-tests/test-cases/github3490/run.t
+++ b/test/blackbox-tests/test-cases/github3490/run.t
@@ -1,0 +1,25 @@
+Dune can process large amounts of process output.
+This happens in particular when diffs are processed.
+
+  $ echo '(lang dune 2.1)' > dune-project
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (with-stdout-to test.corrected
+  >   (bash "for i in {1..300000}; do echo $i; done")))
+  > (rule
+  >  (alias runtest)
+  >  (action (diff test test.corrected)))
+  > EOF
+
+  $ touch test
+
+`test` is empty, and `test.corrected` contains many lines. So the diff is long.
+
+We have to pass `--diff-command` because otherwise the output is suppressed in
+the test suite; but we do not need to print it so we can grep it out
+(redirecting stderr to /dev/null would also silence the stack overflow message).
+
+  $ dune runtest --diff-command 'diff -u' 2>&1 | grep -v +
+            sh (internal) (exit 1)
+  (cd _build/default && /usr/bin/sh -c 'diff -u test test.corrected')

--- a/test/blackbox-tests/test-cases/github3490/run.t
+++ b/test/blackbox-tests/test-cases/github3490/run.t
@@ -20,6 +20,5 @@ We have to pass `--diff-command` because otherwise the output is suppressed in
 the test suite; but we do not need to print it so we can grep it out
 (redirecting stderr to /dev/null would also silence the stack overflow message).
 
-  $ dune runtest --diff-command 'diff -u' 2>&1 | grep -v +
+  $ dune runtest --diff-command 'diff -u' 2>&1 | grep -v + | grep -v diff
             sh (internal) (exit 1)
-  (cd _build/default && /usr/bin/sh -c 'diff -u test test.corrected')


### PR DESCRIPTION
Pp is using plain ListLabels to avoid a dependency loop. This uses a tail recursive version instead.

This used to trigger stack overflows when displaying a large diff.

See #2767, #3490