### PR TITLE
Remove extra Env module in Process

### DIFF
--- a/src/dune/process.ml
+++ b/src/dune/process.ml
@@ -497,11 +497,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     let stdout = Io.fd stdout_to in
     let stderr = Io.fd stderr_to in
     let stdin = Io.fd stdin_from in
-    fun () ->
-      let env =
-        Option.map env ~f:(fun env -> Spawn.Env.of_array (Env.to_unix env))
-      in
-      Spawn.spawn () ~prog:prog_str ~argv ?env ~stdout ~stderr ~stdin
+    fun () -> Spawn.spawn () ~prog:prog_str ~argv ?env ~stdout ~stderr ~stdin
   in
   let pid =
     match dir with

--- a/src/stdune/spawn.ml
+++ b/src/stdune/spawn.ml
@@ -1,9 +1,3 @@
-module Env = struct
-  type t = string array
-
-  let of_array t = t
-end
-
 external sys_exit : int -> 'a = "caml_sys_exit"
 
 let rec file_descr_not_standard fd =
@@ -29,6 +23,7 @@ let perform_redirections stdin stdout stderr =
 let spawn ?env ~prog ~argv ?(stdin = Unix.stdin) ?(stdout = Unix.stdout)
     ?(stderr = Unix.stderr) () =
   let argv = Array.of_list argv in
+  let env = Option.map ~f:Env.to_unix env in
   Pid.of_int
     ( if Sys.win32 then
       match env with

--- a/src/stdune/spawn.mli
+++ b/src/stdune/spawn.mli
@@ -1,11 +1,5 @@
 (** Subset of https://github.com/janestreet/spawn/blob/master/src/spawn.mli *)
 
-module Env : sig
-  type t
-
-  val of_array : string array -> t
-end
-
 val spawn :
      ?env:Env.t
   -> prog:string


### PR DESCRIPTION
There's an Env in stdune

@jeremiedimino I noticed that Spawn.spawn behaves slightly differently on
windows and everywhere else. `Unix.create_process` looks up `prog` in `PATH`,
while `exec` does not.