### PR TITLE
Add test for finalize/fork behavior

### DIFF
--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -213,7 +213,9 @@ let%expect_test "collect_errors and termination" =
             Fiber.return 50))
   in
   test ~expect_never:true (backtrace_result int) fiber;
-  [%expect {| [PASS] Never raised as expected |}]
+  [%expect {|
+    Ok 50
+    [FAIL] expected Never to be raised but it wasn't |}]
 
 let must_set_flag f =
   let flag = ref false in

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -297,4 +297,5 @@ let%expect_test "finalize/fork behavior" =
     fork
     after fork
     fiber finished
-    [FAIL] |}]
+    finally
+    [PASS] |}]

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -288,14 +288,12 @@ let%expect_test "finalize/fork behavior" =
         let* () = log "after fork" in
         let* () = Fiber.Future.wait f in
         log "fiber finished")
-    |> Fiber.run
   in
-  ( match fiber with
-  | Some () -> print_endline "[PASS]"
-  | None -> print_endline "[FAIL]" );
-  [%expect {|
+  test unit fiber;
+  [%expect
+    {|
     fork
     after fork
     fiber finished
     finally
-    [PASS] |}]
+    () |}]


### PR DESCRIPTION
Forking, waiting for the thread, and then waiting for the finalizer to
run does not work.

@jeremiedimino this seems like an issue with fork. Seems like wait `deref`
should be called on `Future.wait`.

cc @andreypopp