### PR TITLE
[coq] pick flags from profile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 next
 ----
 
+- Read Coq flags from `env` (#3547 , fixes #3486, @gares)
+
 - Allow bisect_ppx to be enabled/disabled via dune-workspace. (#3404,
   @stephanieyou)
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1345,6 +1345,9 @@ Fields supported in ``<settings>`` are:
 - ``(odoc <fields>)``. This allows to pass options to Odoc, see
   :ref:`odoc-options` for more details.
 
+- ``(coq (flags <flags>))``. This allows to pass options to Coq, see
+  :ref:`coq-theory` for more details.
+
 .. _dune-subdirs:
 
 dirs (since 1.6)

--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -70,6 +70,16 @@ module Stanza = struct
          { warnings }
   end
 
+  module Coq = struct
+
+    type t = Ordered_set_lang.Unexpanded.t
+
+    let equal = Ordered_set_lang.Unexpanded.equal
+
+    let empty = Ordered_set_lang.Unexpanded.standard
+
+  end
+
   type config =
     { flags : Ocaml_flags.Spec.t
     ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t
@@ -78,6 +88,7 @@ module Stanza = struct
     ; inline_tests : Inline_tests.t option
     ; menhir_flags : Ordered_set_lang.Unexpanded.t
     ; odoc : Odoc.t
+    ; coq : Coq.t
     }
 
   let equal_config
@@ -88,6 +99,7 @@ module Stanza = struct
       ; inline_tests
       ; menhir_flags
       ; odoc
+      ; coq
       } t =
     Ocaml_flags.Spec.equal flags t.flags
     && Foreign.Language.Dict.equal Ordered_set_lang.Unexpanded.equal
@@ -97,6 +109,7 @@ module Stanza = struct
     && Option.equal Inline_tests.equal inline_tests t.inline_tests
     && Ordered_set_lang.Unexpanded.equal menhir_flags t.menhir_flags
     && Odoc.equal odoc t.odoc
+    && Coq.equal coq t.coq
 
   let hash_config = Hashtbl.hash
 
@@ -109,6 +122,7 @@ module Stanza = struct
     ; inline_tests = None
     ; menhir_flags = Ordered_set_lang.Unexpanded.standard
     ; odoc = Odoc.empty
+    ; coq = Coq.empty
     }
 
   type pattern =
@@ -155,6 +169,13 @@ module Stanza = struct
     field "odoc" ~default:Odoc.empty
       (Dune_lang.Syntax.since Stanza.syntax (2, 4) >>> Odoc.decode)
 
+  let coq_flags =
+    Ordered_set_lang.Unexpanded.field "flags"
+
+  let coq_field =
+    field "coq" ~default:Coq.empty
+      (Dune_lang.Syntax.since Stanza.syntax (2, 6) >>> fields coq_flags)
+
   let config =
     let+ flags = Ocaml_flags.Spec.decode
     and+ foreign_flags = foreign_flags ~since:(Some (1, 7))
@@ -165,7 +186,8 @@ module Stanza = struct
         >>> File_binding.Unexpanded.L.decode )
     and+ inline_tests = inline_tests_field
     and+ menhir_flags = menhir_flags ~since:(Some (2, 1))
-    and+ odoc = odoc_field in
+    and+ odoc = odoc_field
+    and+ coq = coq_field in
     { flags
     ; foreign_flags
     ; env_vars
@@ -173,6 +195,7 @@ module Stanza = struct
     ; inline_tests
     ; menhir_flags
     ; odoc
+    ; coq
     }
 
   let rule =

--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -70,16 +70,6 @@ module Stanza = struct
          { warnings }
   end
 
-  module Coq = struct
-
-    type t = Ordered_set_lang.Unexpanded.t
-
-    let equal = Ordered_set_lang.Unexpanded.equal
-
-    let empty = Ordered_set_lang.Unexpanded.standard
-
-  end
-
   type config =
     { flags : Ocaml_flags.Spec.t
     ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t
@@ -88,7 +78,7 @@ module Stanza = struct
     ; inline_tests : Inline_tests.t option
     ; menhir_flags : Ordered_set_lang.Unexpanded.t
     ; odoc : Odoc.t
-    ; coq : Coq.t
+    ; coq : Ordered_set_lang.Unexpanded.t
     }
 
   let equal_config
@@ -109,7 +99,7 @@ module Stanza = struct
     && Option.equal Inline_tests.equal inline_tests t.inline_tests
     && Ordered_set_lang.Unexpanded.equal menhir_flags t.menhir_flags
     && Odoc.equal odoc t.odoc
-    && Coq.equal coq t.coq
+    && Ordered_set_lang.Unexpanded.equal coq t.coq
 
   let hash_config = Hashtbl.hash
 
@@ -122,7 +112,7 @@ module Stanza = struct
     ; inline_tests = None
     ; menhir_flags = Ordered_set_lang.Unexpanded.standard
     ; odoc = Odoc.empty
-    ; coq = Coq.empty
+    ; coq = Ordered_set_lang.Unexpanded.standard
     }
 
   type pattern =

--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -163,8 +163,8 @@ module Stanza = struct
     Ordered_set_lang.Unexpanded.field "flags"
 
   let coq_field =
-    field "coq" ~default:Coq.empty
-      (Dune_lang.Syntax.since Stanza.syntax (2, 6) >>> fields coq_flags)
+    field "coq" ~default:Ordered_set_lang.Unexpanded.standard
+      (Dune_lang.Syntax.since Stanza.syntax (2, 7) >>> fields coq_flags)
 
   let config =
     let+ flags = Ocaml_flags.Spec.decode

--- a/src/dune/dune_env.mli
+++ b/src/dune/dune_env.mli
@@ -24,6 +24,12 @@ module Stanza : sig
     val decode : t Dune_lang.Decoder.t
   end
 
+  module Coq : sig
+
+    type t = Ordered_set_lang.Unexpanded.t
+
+  end
+
   type config =
     { flags : Ocaml_flags.Spec.t
     ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t
@@ -32,6 +38,7 @@ module Stanza : sig
     ; inline_tests : Inline_tests.t option
     ; menhir_flags : Ordered_set_lang.Unexpanded.t
     ; odoc : Odoc.t
+    ; coq : Coq.t
     }
 
   type pattern =

--- a/src/dune/dune_env.mli
+++ b/src/dune/dune_env.mli
@@ -24,12 +24,6 @@ module Stanza : sig
     val decode : t Dune_lang.Decoder.t
   end
 
-  module Coq : sig
-
-    type t = Ordered_set_lang.Unexpanded.t
-
-  end
-
   type config =
     { flags : Ocaml_flags.Spec.t
     ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t
@@ -38,7 +32,7 @@ module Stanza : sig
     ; inline_tests : Inline_tests.t option
     ; menhir_flags : Ordered_set_lang.Unexpanded.t
     ; odoc : Odoc.t
-    ; coq : Coq.t
+    ; coq : Ordered_set_lang.Unexpanded.t
     }
 
   type pattern =

--- a/src/dune/env_node.ml
+++ b/src/dune/env_node.ml
@@ -8,6 +8,12 @@ module Odoc = struct
   type t = { warnings : warnings }
 end
 
+module Coq = struct
+
+  type t = Dune_env.Stanza.Coq.t
+
+end
+
 type t =
   { scope : Scope.t
   ; local_binaries : File_binding.Expanded.t list Memo.Lazy.t
@@ -18,6 +24,7 @@ type t =
   ; inline_tests : Dune_env.Stanza.Inline_tests.t Memo.Lazy.t
   ; menhir_flags : string list Build.t Memo.Lazy.t
   ; odoc : Odoc.t Memo.Lazy.t
+  ; coq : Coq.t Memo.Lazy.t
   }
 
 let scope t = t.scope
@@ -37,6 +44,8 @@ let inline_tests t = Memo.Lazy.force t.inline_tests
 let menhir_flags t = Memo.Lazy.force t.menhir_flags
 
 let odoc t = Memo.Lazy.force t.odoc
+
+let coq t = Memo.Lazy.force t.coq
 
 let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
     ~expander_for_artifacts ~default_context_flags ~default_env
@@ -122,6 +131,7 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
     inherited ~field:odoc ~root (fun { warnings } ->
         { warnings = Option.value config.odoc.warnings ~default:warnings })
   in
+  let coq = inherited ~field:coq ~root:config.coq (fun x -> x) in
   { scope
   ; ocaml_flags
   ; foreign_flags
@@ -131,4 +141,5 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
   ; inline_tests
   ; menhir_flags
   ; odoc
+  ; coq
   }

--- a/src/dune/env_node.ml
+++ b/src/dune/env_node.ml
@@ -10,7 +10,7 @@ end
 
 module Coq = struct
 
-  type t = Dune_env.Stanza.Coq.t
+  type t = Ordered_set_lang.Unexpanded.t
 
 end
 

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -10,6 +10,11 @@ module Odoc : sig
   type t = { warnings : warnings }
 end
 
+module Coq : sig
+
+  type t = Dune_env.Stanza.Coq.t
+end
+
 type t
 
 val make :
@@ -40,5 +45,7 @@ val local_binaries : t -> File_binding.Expanded.t list
 val bin_artifacts : t -> Artifacts.Bin.t
 
 val odoc : t -> Odoc.t
+
+val coq : t -> Coq.t
 
 val menhir_flags : t -> string list Build.t

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -12,7 +12,7 @@ end
 
 module Coq : sig
 
-  type t = Dune_env.Stanza.Coq.t
+  type t = Ordered_set_lang.Unexpanded.t
 end
 
 type t

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -321,6 +321,8 @@ let local_binaries t ~dir = get_node t.env_tree ~dir |> Env_node.local_binaries
 
 let odoc t ~dir = get_node t.env_tree ~dir |> Env_node.odoc
 
+let coq t ~dir = get_node t.env_tree ~dir |> Env_node.coq
+
 let dump_env t ~dir =
   let t = t.env_tree in
   let open Build.O in

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -79,6 +79,9 @@ val local_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list
 (** odoc config in the corresponding [(env)] stanza. *)
 val odoc : t -> dir:Path.Build.t -> Env_node.Odoc.t
 
+(** coq config in the corresponding [(env)] stanza. *)
+val coq : t -> dir:Path.Build.t -> Env_node.Coq.t
+
 (** Dump a directory environment in a readable form *)
 val dump_env : t -> dir:Path.Build.t -> Dune_lang.t list Build.t
 

--- a/test/blackbox-tests/test-cases/coq/base_unsound/bar.v
+++ b/test/blackbox-tests/test-cases/coq/base_unsound/bar.v
@@ -1,0 +1,3 @@
+From basic Require Import foo.
+
+Definition false : t := t.

--- a/test/blackbox-tests/test-cases/coq/base_unsound/dune
+++ b/test/blackbox-tests/test-cases/coq/base_unsound/dune
@@ -1,0 +1,9 @@
+(coq.theory
+ (name basic)
+ (package base)
+ (modules :standard)
+ (synopsis "Test Coq library"))
+
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))

--- a/test/blackbox-tests/test-cases/coq/base_unsound/dune-project
+++ b/test/blackbox-tests/test-cases/coq/base_unsound/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.6)
+(lang dune 2.7)
 
 (using coq 0.1)

--- a/test/blackbox-tests/test-cases/coq/base_unsound/dune-project
+++ b/test/blackbox-tests/test-cases/coq/base_unsound/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.6)
+
+(using coq 0.1)

--- a/test/blackbox-tests/test-cases/coq/base_unsound/dune-workspace
+++ b/test/blackbox-tests/test-cases/coq/base_unsound/dune-workspace
@@ -1,2 +1,2 @@
-(lang dune 2.6)
+(lang dune 2.7)
 (env (unsound (coq (flags -type-in-type))))

--- a/test/blackbox-tests/test-cases/coq/base_unsound/dune-workspace
+++ b/test/blackbox-tests/test-cases/coq/base_unsound/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 2.6)
+(env (unsound (coq (flags -type-in-type))))

--- a/test/blackbox-tests/test-cases/coq/base_unsound/foo.v
+++ b/test/blackbox-tests/test-cases/coq/base_unsound/foo.v
@@ -1,0 +1,1 @@
+Definition t := Type.

--- a/test/blackbox-tests/test-cases/coq/run.t
+++ b/test/blackbox-tests/test-cases/coq/run.t
@@ -5,6 +5,13 @@
           coqc foo.vo
           coqc bar.vo
 
+  $ dune build --root base_unsound --display short --profile unsound --debug-dependency-path @all
+  Entering directory 'base_unsound'
+        coqdep bar.v.d
+        coqdep foo.v.d
+          coqc foo.vo
+          coqc bar.vo
+
   $ dune build --root rec_module --display short --debug-dependency-path @all
   Entering directory 'rec_module'
         coqdep a/bar.v.d


### PR DESCRIPTION
*disclaimer* I don't know the code of dune at all, this is symbol pushing

This PR adds `(coq (flags <osl>))` to profile

OUTDATED:
~This PR makes it possible to use different Coq compilation backends via profiles. Today Coq can produce object files in 3 ways:
- complete check (slow, safe)
- check statement, drop proofs (fast cpu, fast io, totally unsafe wrt proofs)
- check statements, keep proof "thunks" (fast cpu, slow io, mostly safe wrt proofs when the thunks are forced, see `@check-proofs` below)

Currently Coq names the files `.vo`, `.vos` and `.vio` respectively but internally the format is the same (it is a segment based format, some segments are optional). Via `make` Coq supports various workflows, and indeed the different file names are motivated by the fact that this way different make rules are easily written/selected. The idea discussed at a Coq call was to support *most* of these workflows/backends by
- letting one chose a backend via `--profile` (or `(profile ..)`)
- implement dune specific Coq options to name the output .vo independently of the backend (so that dune rules can stay the same).

This is a WIP, and I don't have yet a Coq branch supporting the `-vos-dune` and `-vio-dune` flags I used there (but I'm pretty sure I can do this). I open the draft PR mainly to gather feedback and avoid duplication of work for #3486 . `make test-coq` seems to suggest I'm calling Coq with the expected flags in the blackbox test I've added.

Things to be checked by someone understanding dune internals:
- when the backend changes the .vo files need to be rebuilt (invalidated)
- eventually one can add a target `@check-proofs`. This target succeed immediately with the first backend, always fails with the second. With the third backend it runs a rule that depends on all .vo files and runs a specific coqc invocation (all proofs can be checked in parallel)~

Fix #3486 
CC @Zimmi48 @ejgallego 
