### PR TITLE
[fiber] test sequential_iter and expcetions

### DIFF
--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -208,6 +208,20 @@ let must_set_flag f =
     check_set ();
     raise e
 
+let%expect_test "sequential_iter error handling" =
+  let fiber =
+    Fiber.finalize
+      ~finally:(fun () -> Fiber.return (print_endline "finally"))
+      (fun () ->
+        Fiber.sequential_iter [ 1; 2; 3 ] ~f:(fun x ->
+            if x = 2 then
+              failwith "bam"
+            else
+              Fiber.return (Printf.printf "count: %d\n" x)))
+  in
+  test unit fiber;
+  [%expect {||}]
+
 let%expect_test _ =
   must_set_flag (fun setter ->
       test ~expect_never:true unit

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -234,6 +234,22 @@ let%expect_test "sequential_iter error handling" =
   exn: (Failure bam)
   finally |}]
 
+let%expect_test "sequential_iter" =
+  let fiber =
+    Fiber.finalize
+      ~finally:(fun () -> Fiber.return (print_endline "finally"))
+      (fun () ->
+        Fiber.sequential_iter [ 1; 2; 3 ] ~f:(fun x ->
+            Fiber.return (Printf.printf "count: %d\n" x)))
+  in
+  test unit fiber;
+  [%expect {|
+    count: 1
+    count: 2
+    count: 3
+    finally
+    () |}]
+
 let%expect_test _ =
   must_set_flag (fun setter ->
       test ~expect_never:true unit


### PR DESCRIPTION
Raising inside the callback of `Fiber.sequential_iter` does not respect
the current execution context.

This test just causes an abnormal exit so the output can't even be
collected for the exepct tests.

@jeremiedimino is this intentional? In `fork` it sems like we careful to
avoid this.