### PR TITLE
Fix crash on unknown pform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ next
 - Formatting of dune files is now done in the executing dune process instead of
   in a separate process. (#3536, @nojb)
 
+- Fix crash when an unknown pform is found (such as `%{unknown}`) (#3560,
+  @emillon)
+
 2.6.0 (05/06/2020)
 ------------------
 

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -550,13 +550,14 @@ end = struct
       ~(dynamic_expansions : Value.t list Pform.Expansion.Map.t)
       ~(deps_written_by_user : Path.t Bindings.t) ~expand_var t var
       syntax_version =
-    let key = Pform.Map.expand_exn t.bindings var syntax_version in
-    ( match Pform.Expansion.Map.find dynamic_expansions key with
-    | Some v -> Some v
-    | None ->
-      expand_var t var syntax_version
-      |> Expanded.to_value_opt ~on_deferred:(fun exp ->
-             Some (expand_special_vars ~deps_written_by_user ~var exp)) )
+    let open Option.O in
+    (let* key = Pform.Map.expand t.bindings var syntax_version in
+     match Pform.Expansion.Map.find dynamic_expansions key with
+     | Some v -> Some v
+     | None ->
+       expand_var t var syntax_version
+       |> Expanded.to_value_opt ~on_deferred:(fun exp ->
+              Some (expand_special_vars ~deps_written_by_user ~var exp)))
     |> Expanded.of_value_opt
 
   let add_ddeps_and_bindings t ~dynamic_expansions ~deps_written_by_user =

--- a/src/dune/pform.ml
+++ b/src/dune/pform.ml
@@ -423,16 +423,6 @@ module Map = struct
       ; ("macros", String.Map.to_dyn (to_dyn Macro.to_dyn) macros)
       ]
 
-  let expand_exn t pform syntax_version =
-    match expand t pform syntax_version with
-    | Some v -> v
-    | None ->
-      Code_error.raise "Pform.Map.expand_exn"
-        [ ("t", to_dyn t)
-        ; ("pform", String_with_vars.Var.to_dyn pform)
-        ; ("syntax_version", Dune_lang.Syntax.Version.to_dyn syntax_version)
-        ]
-
   let empty = { vars = String.Map.empty; macros = String.Map.empty }
 
   let singleton k v =

--- a/src/dune/pform.mli
+++ b/src/dune/pform.mli
@@ -71,8 +71,6 @@ module Map : sig
 
   val expand : t -> Expansion.t option String_with_vars.expander
 
-  val expand_exn : t -> Expansion.t String_with_vars.expander
-
   val empty : t
 
   type stamp

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1655,6 +1655,17 @@
    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias invalid-pform)
+ (deps
+  (package dune)
+  (source_tree test-cases/invalid-pform)
+  (alias test-deps))
+ (action
+  (chdir
+   test-cases/invalid-pform
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias js_of_ocaml)
  (deps (package dune) (source_tree test-cases/js_of_ocaml) (alias test-deps))
  (action
@@ -3127,6 +3138,7 @@
   (alias intf-only)
   (alias invalid-dune-package)
   (alias invalid-module-name)
+  (alias invalid-pform)
   (alias lib)
   (alias lib-available)
   (alias lib-errors)
@@ -3411,6 +3423,7 @@
   (alias intf-only)
   (alias invalid-dune-package)
   (alias invalid-module-name)
+  (alias invalid-pform)
   (alias lib)
   (alias lib-available)
   (alias lib-errors)

--- a/test/blackbox-tests/test-cases/invalid-pform/run.t
+++ b/test/blackbox-tests/test-cases/invalid-pform/run.t
@@ -1,0 +1,10 @@
+When an unknown pform is encountered, a sensible message is printed out.
+
+  $ echo '(lang dune 2.0)' > dune-project
+  $ echo '(rule (copy %{unknown} x.ml))' > dune
+  $ dune build
+  File "dune", line 1, characters 14-22:
+  1 | (rule (copy %{unknown} x.ml))
+                    ^^^^^^^^
+  Error: Unknown variable "unknown"
+  [1]


### PR DESCRIPTION
The test case would otherwise trigger a raw exception from `expand_exn`. Instead we can thread the `None` to `of_value_opt`, which does the right thing.