### PR TITLE
Display an error message when -p '' is passed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ next
 - Fix crash when an unknown pform is found (such as `%{unknown}`) (#3560,
   @emillon)
 
+- Improve error message when invalid package names (such as the empty string)
+  are passed to `dune build -p`. (#3561, @emillon)
+
 2.6.0 (05/06/2020)
 ------------------
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -225,9 +225,14 @@ module Options_implied_by_dash_p = struct
 
   let packages =
     let parser s =
-      Ok
-        (Package.Name.Set.of_list_map ~f:Package.Name.of_string
-           (String.split s ~on:','))
+      let parse_one s =
+        match Package.Name.of_string_opt s with
+        | Some x -> Ok x
+        | None ->
+          ksprintf (fun s -> Error (`Msg s)) "Invalid package name: %S" s
+      in
+      String.split s ~on:',' |> List.map ~f:parse_one |> Result.List.all
+      |> Result.map ~f:Package.Name.Set.of_list
     in
     let printer ppf set =
       Format.pp_print_string ppf

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1347,6 +1347,14 @@
    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias github3530)
+ (deps (package dune) (source_tree test-cases/github3530) (alias test-deps))
+ (action
+  (chdir
+   test-cases/github3530
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias github534)
  (deps (package dune) (source_tree test-cases/github534) (alias test-deps))
  (action
@@ -3106,6 +3114,7 @@
   (alias github3046)
   (alias github3180)
   (alias github3440)
+  (alias github3530)
   (alias github534)
   (alias github568)
   (alias github597)
@@ -3394,6 +3403,7 @@
   (alias github3046)
   (alias github3180)
   (alias github3440)
+  (alias github3530)
   (alias github534)
   (alias github568)
   (alias github597)

--- a/test/blackbox-tests/test-cases/github3530/run.t
+++ b/test/blackbox-tests/test-cases/github3530/run.t
@@ -1,0 +1,16 @@
+When an empty string is passed to `-p`, we get a nice error message.
+
+  $ echo '(lang dune 2.0)' > dune-project
+  $ dune build -p ''
+  dune: option `-p': Invalid package name: ""
+  Usage: dune build [OPTION]... [TARGET]...
+  Try `dune build --help' or `dune --help' for more information.
+  [1]
+
+This can happen in a list as well:
+
+  $ dune build -p 'a,b,'
+  dune: option `-p': Invalid package name: ""
+  Usage: dune build [OPTION]... [TARGET]...
+  Try `dune build --help' or `dune --help' for more information.
+  [1]


### PR DESCRIPTION
Attempting to pass an invalid package name (on its own or in a list) would trigger an internal error. This calls the parse function and handles the error properly.

See #3530