### PR TITLE
Directly call the C compiler 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,10 @@ next
 - (copy_files ...) now supports copying files from outside the workspace using
   absolute file names (#3639, @nojb)
 
+- Dune does not use `ocamlc` as an intermediary to call C compiler anymore.
+  Configuration flags `ocamlc_cflags` and `ocamlc_cppflags` are always prepended
+  to the compiler arguments. (#3565, fixes #3346, @voodoos)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -72,68 +72,45 @@ let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
          in
          Command.Args.S [ A "-I"; Path include_dir; dep_args ]))
 
-let build_c_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
-  let flags = Foreign.Source.flags src in
+let build_c_or_cxx_file ~language ~sctx ~dir ~expander ~include_flags
+    (loc, src, dst) =
   let ctx = Super_context.context sctx in
+  let flags =
+    let ctx_flags =
+      match language with
+      | Foreign.Language.C -> Fdo.c_flags ctx
+      | Foreign.Language.Cxx -> Fdo.cxx_flags ctx
+    in
+    let flags = Foreign.Source.flags src in
+    Super_context.foreign_flags sctx ~dir ~expander ~flags ~language
+    |> Build.map ~f:(List.append ctx_flags)
+  in
   let output_param =
     match ctx.lib_config.ccomp_type with
     | Msvc -> [ Command.Args.Concat ("", [ A "/Fo"; Target dst ]) ]
     | Other _ -> [ A "-o"; Target dst ]
-  in
-  let c_flags =
-    Super_context.foreign_flags sctx ~dir ~expander ~flags
-      ~language:Foreign.Language.C
-  in
-  let c_flags = Build.map c_flags ~f:(List.append (Fdo.c_flags ctx)) in
-  let ocamlc_flags =
-    Command.Args.[ A "-fPIC"; A "-D_FILE_OFFSET_BITS=64"; A "-D_REENTRANT" ]
   in
   Super_context.add_rule sctx ~loc
     ~dir
       (* With sandboxing we get errors like: bar.c:2:19: fatal error: foo.cxx:
-         No such file or directory #include "foo.cxx" *)
-    ~sandbox:Sandbox_config.no_sandboxing
+         No such file or directory #include "foo.cxx". (These errors happen only
+         when compiling c files.) *) ~sandbox:Sandbox_config.no_sandboxing
     (let src = Path.build (Foreign.Source.path src) in
      let c_compiler = Ocaml_config.c_compiler ctx.ocaml_config in
-     Command.run
      (* We have to execute the rule in the library directory as the .o is
-        produced in the current directory *) ~dir:(Path.build dir)
+        produced in the current directory *)
+     Command.run ~dir:(Path.build dir)
        (Super_context.resolve_program ~loc:None ~dir sctx c_compiler)
-       ( Command.Args.
-           [ S [ A "-I"; Path ctx.stdlib_dir ]; include_flags; dyn c_flags ]
-       @ ocamlc_flags @ output_param @ [ A "-c"; Dep src ] ));
-  dst
-
-let build_cxx_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
-  let flags = Foreign.Source.flags src in
-  let ctx = Super_context.context sctx in
-  let output_param =
-    match ctx.lib_config.ccomp_type with
-    | Msvc -> [ Command.Args.Concat ("", [ A "/Fo"; Target dst ]) ]
-    | Other _ -> [ A "-o"; Target dst ]
-  in
-  let cxx_flags =
-    Super_context.foreign_flags sctx ~dir ~expander ~flags
-      ~language:Foreign.Language.Cxx
-  in
-  let cxx_flags = Build.map cxx_flags ~f:(List.append (Fdo.cxx_flags ctx)) in
-  Super_context.add_rule sctx ~loc
-    ~dir
-      (* this seems to work with sandboxing, but for symmetry with
-         [build_c_file] disabling that here too *)
-    ~sandbox:Sandbox_config.no_sandboxing
-    (let src = Path.build (Foreign.Source.path src) in
-     let c_compiler = Ocaml_config.c_compiler ctx.ocaml_config in
-     Command.run
-     (* We have to execute the rule in the library directory as the .o is
-        produced in the current directory *) ~dir:(Path.build dir)
-       (Super_context.resolve_program ~loc:None ~dir sctx c_compiler)
-       ( [ Command.Args.S [ A "-I"; Path ctx.stdlib_dir ]
+       ( [ Command.Args.dyn flags
+         ; S [ A "-I"; Path ctx.stdlib_dir ]
          ; include_flags
-         ; Command.Args.dyn cxx_flags
          ]
        @ output_param @ [ A "-c"; Dep src ] ));
   dst
+
+let build_c_file = build_c_or_cxx_file ~language:Foreign.Language.C
+
+let build_cxx_file = build_c_or_cxx_file ~language:Foreign.Language.Cxx
 
 (* TODO: [requires] is a confusing name, probably because it's too general: it
    looks like it's a list of libraries we depend on. *)

--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -75,28 +75,33 @@ let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
 let build_c_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
   let flags = Foreign.Source.flags src in
   let ctx = Super_context.context sctx in
+  let output_param =
+    match ctx.lib_config.ccomp_type with
+    | Msvc -> [ Command.Args.Concat ("", [ A "/Fo"; Target dst ]) ]
+    | Other _ -> [ A "-o"; Target dst ]
+  in
   let c_flags =
     Super_context.foreign_flags sctx ~dir ~expander ~flags
       ~language:Foreign.Language.C
   in
   let c_flags = Build.map c_flags ~f:(List.append (Fdo.c_flags ctx)) in
+  let ocamlc_flags =
+    Command.Args.[ A "-fPIC"; A "-D_FILE_OFFSET_BITS=64"; A "-D_REENTRANT" ]
+  in
   Super_context.add_rule sctx ~loc
     ~dir
       (* With sandboxing we get errors like: bar.c:2:19: fatal error: foo.cxx:
          No such file or directory #include "foo.cxx" *)
     ~sandbox:Sandbox_config.no_sandboxing
     (let src = Path.build (Foreign.Source.path src) in
+     let c_compiler = Ocaml_config.c_compiler ctx.ocaml_config in
      Command.run
      (* We have to execute the rule in the library directory as the .o is
         produced in the current directory *) ~dir:(Path.build dir)
-       (Ok ctx.ocamlc)
-       [ A "-g"
-       ; include_flags
-       ; Dyn (Build.map c_flags ~f:(fun x -> Command.quote_args "-ccopt" x))
-       ; A "-o"
-       ; Target dst
-       ; Dep src
-       ]);
+       (Super_context.resolve_program ~loc:None ~dir sctx c_compiler)
+       ( Command.Args.
+           [ S [ A "-I"; Path ctx.stdlib_dir ]; include_flags; dyn c_flags ]
+       @ ocamlc_flags @ output_param @ [ A "-c"; Dep src ] ));
   dst
 
 let build_cxx_file ~sctx ~dir ~expander ~include_flags (loc, src, dst) =

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -2,9 +2,16 @@ open! Stdune
 open Import
 
 let default_context_flags (ctx : Context.t) =
-  let c = Ocaml_config.ocamlc_cflags ctx.ocaml_config in
+  (* TODO (v3) Current flag behavior is different when calling the C compiler or
+     the C++ compiler: 1.[ocamlc_cflags] and [ocamlc_cppflags] are always
+     prenpended to the C compiler arguments to reproduce [ocamlc]'s behavior, 2.
+     [ocamlc_cflags] are present in [:standard] and prepended to the C++
+     compiler arguments only if the user didn't redefined them (or used
+     [:standard] to extend them) *)
+  let c = [] in
   let cxx =
-    List.filter c ~f:(fun s -> not (String.is_prefix s ~prefix:"-std="))
+    Ocaml_config.ocamlc_cflags ctx.ocaml_config
+    |> List.filter ~f:(fun s -> not (String.is_prefix s ~prefix:"-std="))
   in
   Foreign.Language.Dict.make ~c ~cxx
 

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -84,7 +84,11 @@ val c_compiler : t -> string
 
 val ocamlc_cflags : t -> string list
 
+val ocamlc_cppflags : t -> string list
+
 val ocamlopt_cflags : t -> string list
+
+val ocamlopt_cppflags : t -> string list
 
 val bytecomp_c_compiler : t -> Prog_and_args.t
 

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
@@ -1,7 +1,8 @@
 Compilation using jsoo
 
-  $ dune build --display short bin/technologic.bc.js @install
-        ocamlc lib/stubs.o
+  $ dune build --display short bin/technologic.bc.js @install  2>&1 | \
+  > sed s,^\ *$(ocamlc -config-var c_compiler),\ \ C_COMPILER,g
+    C_COMPILER lib/stubs.o
       ocamlopt .ppx/7b799aed44581cc79b02033532c5f775/ppx.exe
         ocamlc lib/.x.objs/byte/x__.{cmi,cmo,cmt}
    js_of_ocaml .js/stdlib/std_exit.cmo.js


### PR DESCRIPTION
This fixes  #3346 
Before that PR the C compiler was called via `ocamlc`. Now, like the C++ compiler the C compiler is called directly by dune.

~~However, `ocamlc` added a number of flags that were lost in this process: `-fPIC`, `-D_FILE_OFFSET_BITS=64` and `-D_REENTRANT`.~~

~~As a first mitigation I decided to hard-code these in the call of the C compiler. It is probably not the best solution, and I will be happy to update this PR with a more programmatic and flexible way to do that. In fact, I am wondering why these flags are not recovered by `Fdo.c_flags ctx` ?~~