### PR TITLE
In OCaml 4.12.0, empty archives no longer generate .a files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ next
 - Allow the use of the `context_name` variable in the `enabled_if` fields of
   executable(s) and install stanzas. (#3568, fixes #3566, @voodoos)
 
+- Fix compatibility with OCaml 4.12.0 when compiling empty archives; no .a file
+  is generated. (#3576, @dra27)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/context.ml
+++ b/src/dune/context.ml
@@ -503,7 +503,8 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; stdlib_dir
       ; ccomp_type = Ocaml_config.ccomp_type ocfg
       ; profile
-      ; ocaml_version = Ocaml_config.version_string ocfg
+      ; ocaml_version_string = Ocaml_config.version_string ocfg
+      ; ocaml_version = Ocaml_version.of_ocaml_config ocfg
       ; bisect_enabled
       }
     in

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -11,6 +11,7 @@ let dll_files t = t.dll_files
 
 let has_native_archive lib config contents =
   Lib_config.linker_can_create_empty_archives config
+  && Ocaml_version.ocamlopt_always_calls_library_linker config.ocaml_version
   ||
   let name = Dune_file.Library.best_name lib in
   let ml_sources = Dir_contents.ocaml contents in

--- a/src/dune/lib_config.ml
+++ b/src/dune/lib_config.ml
@@ -13,7 +13,8 @@ type t =
   ; stdlib_dir : Path.t
   ; ccomp_type : Ocaml_config.Ccomp_type.t
   ; profile : Profile.t
-  ; ocaml_version : string
+  ; ocaml_version_string : string
+  ; ocaml_version : Ocaml_version.t
   ; bisect_enabled : bool
   }
 
@@ -24,7 +25,7 @@ let var_map =
   ; ("os_type", fun t -> Ocaml_config.Os_type.to_string t.os_type)
   ; ("ccomp_type", fun t -> Ocaml_config.Ccomp_type.to_string t.ccomp_type)
   ; ("profile", fun t -> Profile.to_string t.profile)
-  ; ("ocaml_version", fun t -> t.ocaml_version)
+  ; ("ocaml_version", fun t -> t.ocaml_version_string)
   ]
 
 let allowed_in_enabled_if =

--- a/src/dune/lib_config.mli
+++ b/src/dune/lib_config.mli
@@ -13,7 +13,8 @@ type t =
   ; stdlib_dir : Path.t
   ; ccomp_type : Ocaml_config.Ccomp_type.t
   ; profile : Profile.t
-  ; ocaml_version : string
+  ; ocaml_version_string : string
+  ; ocaml_version : Ocaml_version.t
   ; bisect_enabled : bool
   }
 

--- a/src/dune/ocaml_version.ml
+++ b/src/dune/ocaml_version.ml
@@ -43,3 +43,5 @@ let custom_or_output_complete_exe version =
     "-output-complete-exe"
   else
     "-custom"
+
+let ocamlopt_always_calls_library_linker version = version < (4, 12, 0)

--- a/src/dune/ocaml_version.mli
+++ b/src/dune/ocaml_version.mli
@@ -60,3 +60,6 @@ val supports_function_sections : t -> bool
 
 (** [-custom] or [-output-complete-exe] depending on the version of OCaml *)
 val custom_or_output_complete_exe : t -> string
+
+(** ocamlopt -a always calls the native C linker, even for empty archives *)
+val ocamlopt_always_calls_library_linker : t -> bool

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -27,7 +27,8 @@ let findlib =
     ; stdlib_dir = Path.root
     ; ccomp_type = Other "gcc"
     ; profile = Profile.Dev
-    ; ocaml_version = "4.02.3"
+    ; ocaml_version_string = "4.02.3"
+    ; ocaml_version = Ocaml_version.make (4, 2, 3)
     ; bisect_enabled = false
     }
   in


### PR DESCRIPTION
As noted in https://github.com/ocaml/dune/issues/2687, MSVC has never created empty .lib files so .cmxa archives containing no modules didn't work. #2829 fixed this by not expecting .lib files to be produced by the linker only if the library being built contains no modules, and this was part of Dune 2.0.0.

However, `ocamlopt` itself is unable to use these archives, since it always expects `foo.cmxa` to be accompanied by `foo.lib`, so the fix in #2829 changed the problem from a Dune one back to an OCaml one! However, 4.11.0 includes ocaml/ocaml#9011 which fixes this behaviour.

There is a further change in that PR which is that from 4.12.0 a native archive will never be generated on any platform for an empty library.

This PR introduces `Ocaml_version.ocamlopt_always_calls_library_linker` and updates `Lib_archives.has_native_archive` to use it to override `Lib_config.linker_can_create_empty_archives` for OCaml 4.12+