### PR TITLE
Fix #3580

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ next
 - Fix a stack overflow when displaying large outputs (including diffs) (#3537,
   fixes #2767, #3490, @emillon)
 
+- Fix crash when caching is enabled (@rgrinberg, #3581, fixes #3580)
+
 2.6.0 (05/06/2020)
 ------------------
 

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -27,7 +27,9 @@ module Trimming_result = struct
 end
 
 let default_root () =
-  Path.L.relative (Path.of_string Xdg.cache_dir) [ "dune"; "db" ]
+  Path.L.relative
+    (Path.of_filename_relative_to_initial_cwd Xdg.cache_dir)
+    [ "dune"; "db" ]
 
 let file_store_version = "v3"
 


### PR DESCRIPTION
Properly convert the xdg cache dir to a `Path.t`