### PR TITLE
[ocaml] [ci] Travis testing and compat for OCaml 4.12

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -54,19 +54,19 @@ fi
 case "$TARGET" in
   prepare)
     echo -en "travis_fold:start:ocaml\r"
-    if [ ! -e ~/ocaml/cached-version -o "$(cat ~/ocaml/cached-version)" != "$OCAML_VERSION.$OCAML_RELEASE" ] ; then
+    if [ ! -e ~/ocaml/cached-version -o "$(cat ~/ocaml/cached-version)" != "${OCAML_VERSION}${OCAML_RELEASE}" ] ; then
       rm -rf ~/ocaml
       mkdir -p ~/ocaml/src
       cd ~/ocaml/src
-      wget http://caml.inria.fr/pub/distrib/ocaml-$OCAML_VERSION/ocaml-$OCAML_VERSION.$OCAML_RELEASE.tar.gz
-      tar -xzf ocaml-$OCAML_VERSION.$OCAML_RELEASE.tar.gz
-      cd ocaml-$OCAML_VERSION.$OCAML_RELEASE
+      wget https://github.com/ocaml/ocaml/archive/${OCAML_VERSION}${OCAML_RELEASE}.tar.gz
+      tar -xzf ${OCAML_VERSION}${OCAML_RELEASE}.tar.gz
+      cd ocaml-${OCAML_VERSION}${OCAML_RELEASE}
       ./configure -prefix ~/ocaml
       make world.opt
       make install
       cd ../..
       rm -rf src
-      echo "$OCAML_VERSION.$OCAML_RELEASE" > ~/ocaml/cached-version
+      echo "${OCAML_VERSION}${OCAML_RELEASE}" > ~/ocaml/cached-version
     fi
     echo -en "travis_fold:end:ocaml\r"
     if [ $WITH_OPAM -eq 1 -o $OLD_OCAML -eq 1 ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,24 +15,30 @@ script: bash -ex .travis-ci.sh build
 matrix:
   include:
   - os: linux
-    env: OCAML_VERSION=4.02 OCAML_RELEASE=3 WITH_OPAM=0
+    env: OCAML_VERSION=4.02 OCAML_RELEASE=.3 WITH_OPAM=0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.08 OCAML_RELEASE=1 WITH_OPAM=0
+    env: OCAML_VERSION=4.08 OCAML_RELEASE=.1 WITH_OPAM=0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.09 OCAML_RELEASE=0 WITH_OPAM=0
+    env: OCAML_VERSION=4.09 OCAML_RELEASE=.0 WITH_OPAM=0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.10 OCAML_RELEASE=0 WITH_OPAM=0
+    env: OCAML_VERSION=4.10 OCAML_RELEASE=.0 WITH_OPAM=0
     stage: Build
   - os: linux
-    env: OCAML_VERSION=4.10 OCAML_RELEASE=0 WITH_OPAM=1
+    env: OCAML_VERSION=4.11 OCAML_RELEASE= WITH_OPAM=0
+    stage: Build
+  - os: linux
+    env: OCAML_VERSION=trunk OCAML_RELEASE= WITH_OPAM=0
+    stage: Build
+  - os: linux
+    env: OCAML_VERSION=4.10 OCAML_RELEASE=.0 WITH_OPAM=1
     stage: Test
     addons:
       apt:
         packages:
         - aspcud
   - os: osx
-    env: OCAML_VERSION=4.10 OCAML_RELEASE=0 WITH_OPAM=0
+    env: OCAML_VERSION=4.10 OCAML_RELEASE=.0 WITH_OPAM=0
     stage: Build_macOS

--- a/src/catapult/catapult.ml
+++ b/src/catapult/catapult.ml
@@ -10,7 +10,9 @@ type t =
   }
 
 let fake_gc_stat =
-  { Gc.minor_words = 0.
+  let init_gc = Gc.quick_stat () in
+  { init_gc with
+    Gc.minor_words = 0.
   ; promoted_words = 0.
   ; major_words = 0.
   ; minor_collections = 0
@@ -26,7 +28,7 @@ let fake_gc_stat =
   ; compactions = 0
   ; top_heap_words = 0
   ; stack_size = 0
-  }
+  } [@ocaml.warning "-23"]      (* all fiels of record used *)
 
 let fake time_ref buf =
   let print s = Buffer.add_string buf s in


### PR DESCRIPTION
OCaml 4.12 has introduced a new field in the `Gc.stats` record,
`forced_major_collections`. This makes compilation of Dune fail due to
`src/catapult/catapult.ml:fake_gc_stat`

We call `Gc.quick_stats` and override the set of safe fields.

We also add testing of OCaml `trunk` and 4.11 to Travis, to prevent further problems. This is a non-trivial change so it needs review.

Whether we should place the `trunk` test in `allow_failure` is open.

Fixes: #3583, fixes #2298