### PR TITLE
Fix check-alias test on macos

### DIFF
--- a/test/blackbox-tests/test-cases/check-alias/run.t
+++ b/test/blackbox-tests/test-cases/check-alias/run.t
@@ -9,7 +9,8 @@ as well as the foo.{cmi,cmo,cmt} files.
   > (
   >   cd $1
   >   dune build @check
-  >   find _build \( -name '*.cm*' -o -name .merlin \) -printf '%f\n' | LANG=C sort
+  >   find _build \( -name '*.cm*' -o -name .merlin \) |
+  >   xargs basename | LANG=C sort
   > )
 
 Test the property for executables:

--- a/test/blackbox-tests/test-cases/check-alias/run.t
+++ b/test/blackbox-tests/test-cases/check-alias/run.t
@@ -9,8 +9,7 @@ as well as the foo.{cmi,cmo,cmt} files.
   > (
   >   cd $1
   >   dune build @check
-  >   find _build \( -name '*.cm*' -o -name .merlin \) |
-  >   xargs basename | LANG=C sort
+  >   find _build \( -name '*.cm*' -o -name .merlin \) -exec basename {} \; | LANG=C sort
   > )
 
 Test the property for executables:


### PR DESCRIPTION
Macos' version of `find` does not support the `-printf` option.
We use `xargs` as a workaround.