### PR TITLE
Add Fiber.Throttle and use it to implement job throttling

### DIFF
--- a/example/sample-projects/hello_world/run.t
+++ b/example/sample-projects/hello_world/run.t
@@ -1,16 +1,16 @@
   $ dune build @install @runtest --display short
       ocamldep lib/.hello_world.objs/hello_world.ml.d
-        ocamlc lib/.hello_world.objs/byte/hello_world.{cmi,cmo,cmt}
-        ocamlc lib/hello_world.cma
       ocamldep bin/.main.eobjs/main.ml.d
       ocamldep test/.test.eobjs/test.ml.d
+        ocamlc lib/.hello_world.objs/byte/hello_world.{cmi,cmo,cmt}
+        ocamlc lib/hello_world.cma
       ocamlopt lib/.hello_world.objs/native/hello_world.{cmx,o}
       ocamlopt lib/hello_world.{a,cmxa}
       ocamlopt lib/hello_world.cmxs
         ocamlc test/.test.eobjs/byte/test.{cmi,cmo,cmt}
-      ocamlopt test/.test.eobjs/native/test.{cmx,o}
-      ocamlopt test/test.exe
-          test test/test.output
         ocamlc bin/.main.eobjs/byte/main.{cmi,cmo,cmt}
+      ocamlopt test/.test.eobjs/native/test.{cmx,o}
       ocamlopt bin/.main.eobjs/native/main.{cmx,o}
+      ocamlopt test/test.exe
       ocamlopt bin/main.exe
+          test test/test.output

--- a/example/sample-projects/with-configure-step/run.t
+++ b/example/sample-projects/with-configure-step/run.t
@@ -1,9 +1,9 @@
   $ dune build @install @runtest --display short
          ocaml config.full
-      ocamldep src/.plop.eobjs/config.ml.d
       ocamldep src/.plop.eobjs/plop.ml.d
+      ocamldep src/.plop.eobjs/config.ml.d
         ocamlc src/.plop.eobjs/byte/config.{cmi,cmo,cmt}
         ocamlc src/.plop.eobjs/byte/plop.{cmi,cmo,cmt}
-      ocamlopt src/.plop.eobjs/native/plop.{cmx,o}
       ocamlopt src/.plop.eobjs/native/config.{cmx,o}
+      ocamlopt src/.plop.eobjs/native/plop.{cmx,o}
       ocamlopt src/plop.exe

--- a/src/dune/main.ml
+++ b/src/dune/main.ml
@@ -120,12 +120,15 @@ let auto_concurrency =
       n
 
 let set_concurrency (config : Config.t) =
-  let+ n =
+  let* n =
     match config.concurrency with
     | Fixed n -> Fiber.return n
     | Auto -> auto_concurrency ()
   in
-  if n >= 1 then Scheduler.set_concurrency n
+  if n >= 1 then
+    Scheduler.set_concurrency n
+  else
+    Fiber.return ()
 
 let find_context_exn t ~name =
   match List.find t.contexts ~f:(fun c -> Context_name.equal c.name name) with

--- a/src/dune/scheduler.mli
+++ b/src/dune/scheduler.mli
@@ -16,13 +16,17 @@ val poll :
   -> unit
   -> 'a
 
+(** [with_job_slot f] waits for one job slot (as per [-j <jobs] to become
+    available and then calls [f]. *)
+val with_job_slot : (unit -> 'a Fiber.t) -> 'a Fiber.t
+
 (** Wait for the following process to terminate *)
 val wait_for_process : Pid.t -> Unix.process_status Fiber.t
 
 (** Wait for dune cache to be disconnected. Drop any other event. *)
 val wait_for_dune_cache : unit -> unit
 
-val set_concurrency : int -> unit
+val set_concurrency : int -> unit Fiber.t
 
 (** Make the scheduler ignore next change to a certain file in watch mode.
 
@@ -33,15 +37,8 @@ val ignore_for_watch : Path.t -> unit
 (** Number of jobs currently running in the background *)
 val running_jobs_count : unit -> int
 
-(** Scheduler information *)
-type t
-
-(** Wait until fewer than [!Clflags.concurrency] external processes are running
-    and return the scheduler information. *)
-val wait_for_available_job : unit -> t Fiber.t
-
 (** Execute the given callback with current directory temporarily changed *)
-val with_chdir : t -> dir:Path.t -> f:(unit -> 'a) -> 'a
+val with_chdir : dir:Path.t -> f:(unit -> 'a) -> 'a
 
 (** Notify the scheduler of a file to deduplicate from another thread *)
 val send_dedup : Cache.caching -> Cache.File.t -> unit

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -453,6 +453,50 @@ module Mutex = struct
   let create () = { locked = false; waiters = Queue.create () }
 end
 
+module Throttle = struct
+  type t =
+    { mutable size : int
+    ; mutable running : int
+    ; waiting : unit Ivar.t Queue.t
+    }
+
+  let create size = { size; running = 0; waiting = Queue.create () }
+
+  let size t = t.size
+
+  let running t = t.running
+
+  let rec restart t =
+    if t.running >= t.size then
+      return ()
+    else
+      match Queue.pop t.waiting with
+      | None -> return ()
+      | Some ivar ->
+        t.running <- t.running + 1;
+        let* () = Ivar.fill ivar () in
+        restart t
+
+  let resize t n =
+    t.size <- n;
+    restart t
+
+  let run t ~f =
+    finalize
+      ~finally:(fun () ->
+        t.running <- t.running - 1;
+        restart t)
+      (fun () ->
+        if t.running < t.size then (
+          t.running <- t.running + 1;
+          f ()
+        ) else
+          let waiting = Ivar.create () in
+          Queue.push t.waiting waiting;
+          let* () = Ivar.read waiting in
+          f ())
+end
+
 let run t =
   let result = ref None in
   EC.apply (fun () -> t) () (fun x -> result := Some x);

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -224,6 +224,30 @@ module Mutex : sig
 end
 with type 'a fiber := 'a t
 
+module Throttle : sig
+  (** Limit the number of jobs *)
+
+  type 'a fiber = 'a t
+
+  type t
+
+  (** [create n] creates a throttler that allows to run [n] jobs at once *)
+  val create : int -> t
+
+  (** How many jobs can run at the same time *)
+  val size : t -> int
+
+  (** Change the number of jobs that can run at once *)
+  val resize : t -> int -> unit fiber
+
+  (** Execute a fiber, waiting if too many jobs are already running *)
+  val run : t -> f:(unit -> 'a fiber) -> 'a fiber
+
+  (** Return the number of jobs currently running *)
+  val running : t -> int
+end
+with type 'a fiber := 'a t
+
 (** {1 Running fibers} *)
 
 (** [run t] runs a fiber. If the fiber doesn't complete immediately, [run t]

--- a/test/blackbox-tests/test-cases/byte-code-only/run.t
+++ b/test/blackbox-tests/test-cases/byte-code-only/run.t
@@ -1,19 +1,19 @@
   $ env ORIG_PATH="$PATH" PATH="$PWD/ocaml-bin:$PATH" dune build @all --display short
       ocamldep bin/.toto.eobjs/toto.ml.d
-        ocamlc bin/.toto.eobjs/byte/dune__exe__Toto.{cmi,cmo,cmt}
-        ocamlc bin/toto.bc
       ocamldep src/.foo.objs/foo.ml.d
-        ocamlc src/.foo.objs/byte/foo.{cmi,cmo,cmt}
-        ocamlc src/foo.cma
         ocamlc build-info/.build_info.objs/byte/build_info.{cmi,cmo,cmt}
-        ocamlc build-info/build_info.cma
       ocamldep build-info/.build_info.objs/build_info_data.mli.d
-        ocamlc build-info/.build_info.objs/byte/build_info__Build_info_data.{cmi,cmti}
-        ocamlc bin-with-build-info/.print_version.eobjs/byte/build_info__Build_info_data.{cmo,cmt}
       ocamldep bin-with-build-info/.print_version.eobjs/print_version.ml.d
-        ocamlc bin-with-build-info/.print_version.eobjs/byte/dune__exe__Print_version.{cmi,cmo,cmt}
-        ocamlc bin-with-build-info/print_version.exe
+        ocamlc bin/.toto.eobjs/byte/dune__exe__Toto.{cmi,cmo,cmt}
+        ocamlc src/.foo.objs/byte/foo.{cmi,cmo,cmt}
+        ocamlc build-info/build_info.cma
+        ocamlc build-info/.build_info.objs/byte/build_info__Build_info_data.{cmi,cmti}
+        ocamlc bin/toto.bc
         ocamlc bin/toto.exe
+        ocamlc src/foo.cma
+        ocamlc bin-with-build-info/.print_version.eobjs/byte/dune__exe__Print_version.{cmi,cmo,cmt}
+        ocamlc bin-with-build-info/.print_version.eobjs/byte/build_info__Build_info_data.{cmo,cmt}
+        ocamlc bin-with-build-info/print_version.exe
         ocamlc bin-with-build-info/print_version.bc
 
   $ _build/default/bin-with-build-info/print_version.exe

--- a/test/blackbox-tests/test-cases/c-stubs/run.t
+++ b/test/blackbox-tests/test-cases/c-stubs/run.t
@@ -1,12 +1,12 @@
   $ dune exec ./qnativerun/run.exe --display short
         ocamlc q/q_stub$ext_obj
-    ocamlmklib q/dllq_stubs$ext_dll,q/libq_stubs$ext_lib
       ocamldep q/.q.objs/q.mli.d
-        ocamlc q/.q.objs/byte/q.{cmi,cmti}
       ocamldep q/.q.objs/q.ml.d
+      ocamldep qnativerun/.run.eobjs/run.ml.d
+    ocamlmklib q/dllq_stubs$ext_dll,q/libq_stubs$ext_lib
+        ocamlc q/.q.objs/byte/q.{cmi,cmti}
       ocamlopt q/.q.objs/native/q.{cmx,o}
       ocamlopt q/q.{a,cmxa}
-      ocamldep qnativerun/.run.eobjs/run.ml.d
         ocamlc qnativerun/.run.eobjs/byte/run.{cmi,cmo,cmt}
       ocamlopt qnativerun/.run.eobjs/native/run.{cmx,o}
       ocamlopt qnativerun/run.exe

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -1,18 +1,18 @@
   $ dune build --root test1 test.exe .merlin --display short --debug-dependency-path
   Entering directory 'test1'
       ocamldep .foo.objs/dummy.ml.d
+        ocamlc bar$ext_obj
+      ocamllex lexers/lexer1.ml
+      ocamldep .test.eobjs/test.ml.d
         ocamlc .foo.objs/byte/dummy.{cmi,cmo,cmt}
+    ocamlmklib dllfoo_stubs$ext_dll,libfoo_stubs$ext_lib
+      ocamldep .test.eobjs/lexer1.ml.d
       ocamlopt .foo.objs/native/dummy.{cmx,o}
       ocamlopt foo.{a,cmxa}
-        ocamlc bar$ext_obj
-    ocamlmklib dllfoo_stubs$ext_dll,libfoo_stubs$ext_lib
-      ocamllex lexers/lexer1.ml
-      ocamldep .test.eobjs/lexer1.ml.d
-      ocamldep .test.eobjs/test.ml.d
         ocamlc .test.eobjs/byte/lexer1.{cmi,cmo,cmt}
         ocamlc .test.eobjs/byte/test.{cmi,cmo,cmt}
-      ocamlopt .test.eobjs/native/test.{cmx,o}
       ocamlopt .test.eobjs/native/lexer1.{cmx,o}
+      ocamlopt .test.eobjs/native/test.{cmx,o}
       ocamlopt test.exe
   $ dune build --root test1 @bar-source --display short
   Entering directory 'test1'

--- a/test/blackbox-tests/test-cases/coq/run.t
+++ b/test/blackbox-tests/test-cases/coq/run.t
@@ -16,10 +16,10 @@
   Entering directory 'rec_module'
         coqdep a/bar.v.d
         coqdep b/foo.v.d
-          coqc b/foo.vo
         coqdep c/d/bar.v.d
-          coqc c/d/bar.vo
         coqdep c/ooo.v.d
+          coqc b/foo.vo
+          coqc c/d/bar.vo
           coqc c/ooo.vo
           coqc a/bar.vo
 
@@ -27,27 +27,27 @@
   Entering directory 'ml_lib'
         coqdep theories/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
-      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
-      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
       ocamldep src_a/.ml_plugin_a.objs/gram.mli.d
-        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}
       ocamldep src_a/.ml_plugin_a.objs/simple.ml.d
-        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Simple.{cmi,cmo,cmt}
-      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
       ocamldep src_b/.ml_plugin_b.objs/simple_b.ml.d
-        ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b__Simple_b.{cmi,cmo,cmt}
-        ocamlc src_b/ml_plugin_b.cma
          coqpp src_a/gram.ml
+      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
+      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
+        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}
+        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Simple.{cmi,cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/gram.ml.d
+      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
+        ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b__Simple_b.{cmi,cmo,cmt}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmo,cmt}
-        ocamlc src_a/ml_plugin_a.cma
-      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b__Simple_b.{cmx,o}
-      ocamlopt src_b/ml_plugin_b.{a,cmxa}
-      ocamlopt src_b/ml_plugin_b.cmxs
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Gram.{cmx,o}
+        ocamlc src_b/ml_plugin_b.cma
+      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b__Simple_b.{cmx,o}
+        ocamlc src_a/ml_plugin_a.cma
       ocamlopt src_a/ml_plugin_a.{a,cmxa}
+      ocamlopt src_b/ml_plugin_b.{a,cmxa}
       ocamlopt src_a/ml_plugin_a.cmxs
+      ocamlopt src_b/ml_plugin_b.cmxs
           coqc theories/a.vo
 
   $ dune build --root base --display short --debug-dependency-path @default
@@ -85,8 +85,8 @@
   $ dune build --root compose_simple/ --display short --debug-dependency-path
   Entering directory 'compose_simple'
         coqdep a/a.v.d
-          coqc a/a.vo
         coqdep b/b.v.d
+          coqc a/a.vo
           coqc b/b.vo
   lib: [
     "_build/install/default/lib/csimple/META"
@@ -104,28 +104,28 @@
   Entering directory 'compose_plugin'
         coqdep thy1/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
-      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
-      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
       ocamldep src_a/.ml_plugin_a.objs/gram.mli.d
-        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}
       ocamldep src_a/.ml_plugin_a.objs/simple.ml.d
-        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Simple.{cmi,cmo,cmt}
-      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
       ocamldep src_b/.ml_plugin_b.objs/simple_b.ml.d
-        ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b__Simple_b.{cmi,cmo,cmt}
-        ocamlc src_b/ml_plugin_b.cma
         coqdep thy2/a.v.d
          coqpp src_a/gram.ml
+      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
+      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
+        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}
+        ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Simple.{cmi,cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/gram.ml.d
+      ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
+        ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b__Simple_b.{cmi,cmo,cmt}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmo,cmt}
-        ocamlc src_a/ml_plugin_a.cma
-      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b__Simple_b.{cmx,o}
-      ocamlopt src_b/ml_plugin_b.{a,cmxa}
-      ocamlopt src_b/ml_plugin_b.cmxs
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Gram.{cmx,o}
+        ocamlc src_b/ml_plugin_b.cma
+      ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b__Simple_b.{cmx,o}
+        ocamlc src_a/ml_plugin_a.cma
       ocamlopt src_a/ml_plugin_a.{a,cmxa}
+      ocamlopt src_b/ml_plugin_b.{a,cmxa}
       ocamlopt src_a/ml_plugin_a.cmxs
+      ocamlopt src_b/ml_plugin_b.cmxs
           coqc thy1/a.vo
           coqc thy2/a.vo
 

--- a/test/blackbox-tests/test-cases/cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation/run.t
@@ -1,24 +1,24 @@
   $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf dune build --display short -x foo file @install --promote-install-files
       ocamldep lib/.p.objs/p.ml.d [default.foo]
-        ocamlc lib/.p.objs/byte/p.{cmi,cmo,cmt} [default.foo]
-        ocamlc lib/p.cma [default.foo]
       ocamldep bin/.blah.eobjs/blah.ml.d [default.foo]
       ocamldep lib/.p.objs/p.ml.d
-        ocamlc lib/.p.objs/byte/p.{cmi,cmo,cmt}
-      ocamlopt lib/.p.objs/native/p.{cmx,o}
-      ocamlopt lib/p.{a,cmxa}
       ocamldep bin/.blah.eobjs/blah.ml.d
+        ocamlc lib/.p.objs/byte/p.{cmi,cmo,cmt} [default.foo]
+        ocamlc lib/.p.objs/byte/p.{cmi,cmo,cmt}
+        ocamlc lib/p.cma [default.foo]
+      ocamlopt lib/.p.objs/native/p.{cmx,o} [default.foo]
+      ocamlopt lib/.p.objs/native/p.{cmx,o}
+      ocamlopt lib/p.{a,cmxa} [default.foo]
+      ocamlopt lib/p.{a,cmxa}
+      ocamlopt lib/p.cmxs [default.foo]
+        ocamlc bin/.blah.eobjs/byte/blah.{cmi,cmo,cmt} [default.foo]
         ocamlc bin/.blah.eobjs/byte/blah.{cmi,cmo,cmt}
+      ocamlopt bin/.blah.eobjs/native/blah.{cmx,o} [default.foo]
       ocamlopt bin/.blah.eobjs/native/blah.{cmx,o}
+      ocamlopt bin/blah.exe [default.foo]
       ocamlopt bin/blah.exe
           blah file
-      ocamlopt lib/.p.objs/native/p.{cmx,o} [default.foo]
-      ocamlopt lib/p.{a,cmxa} [default.foo]
-      ocamlopt lib/p.cmxs [default.foo]
           blah file [default.foo]
-        ocamlc bin/.blah.eobjs/byte/blah.{cmi,cmo,cmt} [default.foo]
-      ocamlopt bin/.blah.eobjs/native/blah.{cmx,o} [default.foo]
-      ocamlopt bin/blah.exe [default.foo]
   $ cat _build/default.foo/file
   42
   $ ls *.install

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/run.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/run.t
@@ -1,12 +1,12 @@
   $ dune build --root ./normal --display short file @install
   Entering directory 'normal'
       ocamldep .p.eobjs/p.ml.d [cross]
-        ocamlc .p.eobjs/byte/p.{cmi,cmo,cmt} [cross]
-      ocamlopt .p.eobjs/native/p.{cmx,o} [cross]
-      ocamlopt p.exe [cross]
       ocamldep .p.eobjs/p.ml.d
+        ocamlc .p.eobjs/byte/p.{cmi,cmo,cmt} [cross]
         ocamlc .p.eobjs/byte/p.{cmi,cmo,cmt}
+      ocamlopt .p.eobjs/native/p.{cmx,o} [cross]
       ocamlopt .p.eobjs/native/p.{cmx,o}
+      ocamlopt p.exe [cross]
       ocamlopt p.exe
              p file [cross]
              p file

--- a/test/blackbox-tests/test-cases/default-targets/run.t
+++ b/test/blackbox-tests/test-cases/default-targets/run.t
@@ -2,16 +2,16 @@ Generates targets when modes is set for binaries:
   $ dune build --root bins --display short @all 2>&1 | grep '\.bc\|\.exe'
         ocamlc byteandnative.bc
         ocamlc bytecodeonly.bc
-      ocamlopt nativeonly.exe
-      ocamlopt byteandnative.exe
         ocamlc bytecodeonly.exe
+      ocamlopt byteandnative.exe
+      ocamlopt nativeonly.exe
 
 Generate targets when modes are set for libraries
 
   $ dune build --root libs --display short @all 2>&1 | grep 'cma\|cmxa\|cmxs'
         ocamlc byteandnative.cma
         ocamlc byteonly.cma
-      ocamlopt nativeonly.{a,cmxa}
-      ocamlopt nativeonly.cmxs
       ocamlopt byteandnative.{a,cmxa}
+      ocamlopt nativeonly.{a,cmxa}
       ocamlopt byteandnative.cmxs
+      ocamlopt nativeonly.cmxs

--- a/test/blackbox-tests/test-cases/dialects/run.t
+++ b/test/blackbox-tests/test-cases/dialects/run.t
@@ -3,12 +3,12 @@ Test the (dialect ...) stanza inside the dune-project file.
   $ dune build --root good --display short @install
   Entering directory 'good'
       ocamldep .fmt.eobjs/fmt.ml.d
-        ocamlc .fmt.eobjs/byte/fmt.{cmi,cmo,cmt}
-      ocamlopt .fmt.eobjs/native/fmt.{cmx,o}
-      ocamlopt fmt.exe
       ocamldep .main.eobjs/main.mf.d
+        ocamlc .fmt.eobjs/byte/fmt.{cmi,cmo,cmt}
       ocamldep .main.eobjs/main.mfi.d
+      ocamlopt .fmt.eobjs/native/fmt.{cmx,o}
         ocamlc .main.eobjs/byte/main.{cmi,cmti}
+      ocamlopt fmt.exe
       ocamlopt .main.eobjs/native/main.{cmx,o}
       ocamlopt main.exe
 

--- a/test/blackbox-tests/test-cases/exes-with-c/run.t
+++ b/test/blackbox-tests/test-cases/exes-with-c/run.t
@@ -1,13 +1,13 @@
   $ dune build --display short aa.exe bb.exe
         ocamlc .aa.eobjs/byte/dune__exe.{cmi,cmo,cmt}
-      ocamlopt .aa.eobjs/native/dune__exe.{cmx,o}
       ocamldep .aa.eobjs/aa.ml.d
-        ocamlc .aa.eobjs/byte/dune__exe__Aa.{cmi,cmo,cmt}
-      ocamlopt .aa.eobjs/native/dune__exe__Aa.{cmx,o}
       ocamldep .aa.eobjs/bb.ml.d
-        ocamlc .aa.eobjs/byte/dune__exe__Bb.{cmi,cmo,cmt}
-      ocamlopt .aa.eobjs/native/dune__exe__Bb.{cmx,o}
         ocamlc foo$ext_obj
+      ocamlopt .aa.eobjs/native/dune__exe.{cmx,o}
+        ocamlc .aa.eobjs/byte/dune__exe__Aa.{cmi,cmo,cmt}
+        ocamlc .aa.eobjs/byte/dune__exe__Bb.{cmi,cmo,cmt}
+      ocamlopt .aa.eobjs/native/dune__exe__Aa.{cmx,o}
+      ocamlopt .aa.eobjs/native/dune__exe__Bb.{cmx,o}
       ocamlopt bb.exe
       ocamlopt aa.exe
 

--- a/test/blackbox-tests/test-cases/formatting/run.t
+++ b/test/blackbox-tests/test-cases/formatting/run.t
@@ -42,19 +42,15 @@ Formatting can be checked using the @fmt target:
       ocamldep fake-tools/.ocamlformat.eobjs/ocamlformat.ml.d
       ocamldep fake-tools/.ocamlformat.eobjs/refmt.ml.d
         ocamlc fake-tools/.ocamlformat.eobjs/byte/ocamlformat.{cmi,cmo,cmt}
+        ocamlc fake-tools/.ocamlformat.eobjs/byte/refmt.{cmi,cmo,cmt}
       ocamlopt fake-tools/.ocamlformat.eobjs/native/ocamlformat.{cmx,o}
+      ocamlopt fake-tools/.ocamlformat.eobjs/native/refmt.{cmx,o}
       ocamlopt fake-tools/ocamlformat.exe
+      ocamlopt fake-tools/refmt.exe
    ocamlformat enabled/.formatted/ocaml_file.mli
   File "enabled/ocaml_file.mli", line 1, characters 0-0:
   Error: Files _build/default/enabled/ocaml_file.mli and
   _build/default/enabled/.formatted/ocaml_file.mli differ.
-        ocamlc fake-tools/.ocamlformat.eobjs/byte/refmt.{cmi,cmo,cmt}
-      ocamlopt fake-tools/.ocamlformat.eobjs/native/refmt.{cmx,o}
-      ocamlopt fake-tools/refmt.exe
-         refmt enabled/.formatted/reason_file.rei
-  File "enabled/reason_file.rei", line 1, characters 0-0:
-  Error: Files _build/default/enabled/reason_file.rei and
-  _build/default/enabled/.formatted/reason_file.rei differ.
    ocamlformat enabled/subdir/.formatted/lib.ml
   File "enabled/subdir/lib.ml", line 1, characters 0-0:
   Error: Files _build/default/enabled/subdir/lib.ml and
@@ -75,6 +71,10 @@ Formatting can be checked using the @fmt target:
   File "enabled/ocaml_file.ml", line 1, characters 0-0:
   Error: Files _build/default/enabled/ocaml_file.ml and
   _build/default/enabled/.formatted/ocaml_file.ml differ.
+         refmt enabled/.formatted/reason_file.rei
+  File "enabled/reason_file.rei", line 1, characters 0-0:
+  Error: Files _build/default/enabled/reason_file.rei and
+  _build/default/enabled/.formatted/reason_file.rei differ.
          refmt enabled/.formatted/reason_file.re
   File "enabled/reason_file.re", line 1, characters 0-0:
   Error: Files _build/default/enabled/reason_file.re and

--- a/test/blackbox-tests/test-cases/github1855/run.t
+++ b/test/blackbox-tests/test-cases/github1855/run.t
@@ -24,20 +24,20 @@ just quietly shadow the module in the virtual library.
 
   $ dune build @all --display short
         ocamlc vlib/.vlib1855.objs/byte/vlib1855.{cmi,cmo,cmt}
-      ocamlopt vlib/.vlib1855.objs/native/vlib1855.{cmx,o}
       ocamldep vlib/.vlib1855.objs/dom.mli.d
-        ocamlc vlib/.vlib1855.objs/byte/vlib1855__Dom.{cmi,cmti}
       ocamldep vlib/.vlib1855.objs/overlap.ml.d
-        ocamlc vlib/.vlib1855.objs/byte/vlib1855__Overlap.{cmi,cmo,cmt}
-      ocamlopt vlib/.vlib1855.objs/native/vlib1855__Overlap.{cmx,o}
       ocamldep impl/.impl1855.objs/dom.ml.d
         ocamlc impl/.impl1855.objs/byte/vlib1855__impl1855__.{cmi,cmo,cmt}
-        ocamlc impl/.impl1855.objs/byte/vlib1855__Dom.{cmo,cmt}
       ocamldep impl/.impl1855.objs/overlap.ml.d
-        ocamlc impl/.impl1855.objs/byte/vlib1855__impl1855____Overlap.{cmi,cmo,cmt}
-        ocamlc impl/impl1855.cma
-      ocamlopt impl/.impl1855.objs/native/vlib1855__Dom.{cmx,o}
+      ocamlopt vlib/.vlib1855.objs/native/vlib1855.{cmx,o}
+        ocamlc vlib/.vlib1855.objs/byte/vlib1855__Dom.{cmi,cmti}
+        ocamlc vlib/.vlib1855.objs/byte/vlib1855__Overlap.{cmi,cmo,cmt}
       ocamlopt impl/.impl1855.objs/native/vlib1855__impl1855__.{cmx,o}
+      ocamlopt vlib/.vlib1855.objs/native/vlib1855__Overlap.{cmx,o}
+        ocamlc impl/.impl1855.objs/byte/vlib1855__impl1855____Overlap.{cmi,cmo,cmt}
+        ocamlc impl/.impl1855.objs/byte/vlib1855__Dom.{cmo,cmt}
+      ocamlopt impl/.impl1855.objs/native/vlib1855__Dom.{cmx,o}
       ocamlopt impl/.impl1855.objs/native/vlib1855__impl1855____Overlap.{cmx,o}
+        ocamlc impl/impl1855.cma
       ocamlopt impl/impl1855.{a,cmxa}
       ocamlopt impl/impl1855.cmxs

--- a/test/blackbox-tests/test-cases/github2228/run.t
+++ b/test/blackbox-tests/test-cases/github2228/run.t
@@ -1,17 +1,17 @@
   $ dune build @install --display short
       ocamlopt mli-only/foobar.{a,cmxa}
-      ocamlopt mli-only/foobar.cmxs
         ocamlc mli-only/foobar.cma
       ocamldep mli-only/.foobar.objs/foobar.mli.d
-        ocamlc mli-only/.foobar.objs/byte/foobar.{cmi,cmti}
       ocamldep impl/.foobar_impl.objs/foobar.mli.d
-        ocamlc impl/.foobar_impl.objs/byte/foobar.{cmi,cmti}
       ocamldep impl/.foobar_impl.objs/foobar.ml.d
+      ocamlopt mli-only/foobar.cmxs
+        ocamlc mli-only/.foobar.objs/byte/foobar.{cmi,cmti}
+        ocamlc impl/.foobar_impl.objs/byte/foobar.{cmi,cmti}
+        ocamlc impl/.foobar_impl.objs/byte/foobar.{cmo,cmt}
       ocamlopt impl/.foobar_impl.objs/native/foobar.{cmx,o}
+        ocamlc impl/foobar_impl.cma
       ocamlopt impl/foobar_impl.{a,cmxa}
       ocamlopt impl/foobar_impl.cmxs
-        ocamlc impl/.foobar_impl.objs/byte/foobar.{cmo,cmt}
-        ocamlc impl/foobar_impl.cma
   $ dune runtest
           test alias test/runtest
   testing

--- a/test/blackbox-tests/test-cases/github25/run.t
+++ b/test/blackbox-tests/test-cases/github25/run.t
@@ -15,7 +15,6 @@ We need ocamlfind to run this test
 
   $ dune build @install --display short --only pas-de-bol 2>&1 | sed 's/[^ "]*findlib-packages/.../'
         ocamlc root/.pas_de_bol.objs/byte/pas_de_bol.{cmi,cmo,cmt}
-      ocamlopt root/.pas_de_bol.objs/native/pas_de_bol.{cmx,o}
       ocamldep root/.pas_de_bol.objs/a.ml.d
   File ".../plop/META", line 1, characters 0-0:
   Error: Library "une-lib-qui-nexiste-pas" not found.
@@ -24,3 +23,4 @@ We need ocamlfind to run this test
   Hint: try:
   dune external-lib-deps --missing --only pas-de-bol --display short @install
       ocamldep root/.pas_de_bol.objs/b.ml.d
+      ocamlopt root/.pas_de_bol.objs/native/pas_de_bol.{cmx,o}

--- a/test/blackbox-tests/test-cases/github568/run.t
+++ b/test/blackbox-tests/test-cases/github568/run.t
@@ -1,9 +1,9 @@
   $ dune runtest --display short -p lib1 --debug-dependency-path
       ocamldep .lib1.objs/lib1.ml.d
+      ocamldep .test1.eobjs/test1.ml.d
         ocamlc .lib1.objs/byte/lib1.{cmi,cmo,cmt}
       ocamlopt .lib1.objs/native/lib1.{cmx,o}
       ocamlopt lib1.{a,cmxa}
-      ocamldep .test1.eobjs/test1.ml.d
         ocamlc .test1.eobjs/byte/test1.{cmi,cmo,cmt}
       ocamlopt .test1.eobjs/native/test1.{cmx,o}
       ocamlopt test1.exe

--- a/test/blackbox-tests/test-cases/installable-dup-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/installable-dup-private-libs/run.t
@@ -1,13 +1,13 @@
   $ dune build @install --display short
       ocamldep a1/.a.objs/a.ml.d
-        ocamlc a1/.a.objs/byte/a.{cmi,cmo,cmt}
-        ocamlc a1/a.cma
       ocamldep a2/.a.objs/a.ml.d
+        ocamlc a1/.a.objs/byte/a.{cmi,cmo,cmt}
         ocamlc a2/.a.objs/byte/a.{cmi,cmo,cmt}
-        ocamlc a2/a.cma
+        ocamlc a1/a.cma
       ocamlopt a1/.a.objs/native/a.{cmx,o}
-      ocamlopt a1/a.{a,cmxa}
-      ocamlopt a1/a.cmxs
+        ocamlc a2/a.cma
       ocamlopt a2/.a.objs/native/a.{cmx,o}
+      ocamlopt a1/a.{a,cmxa}
       ocamlopt a2/a.{a,cmxa}
+      ocamlopt a1/a.cmxs
       ocamlopt a2/a.cmxs

--- a/test/blackbox-tests/test-cases/intf-only/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/run.t
@@ -4,18 +4,18 @@ Successes:
   Entering directory 'foo'
       ocamldep .foo.objs/foo.ml.d
         ocamlc .foo.objs/byte/foo__.{cmi,cmo,cmt}
-      ocamlopt .foo.objs/native/foo__.{cmx,o}
       ocamldep .foo.objs/intf.mli.d
+      ocamldep test/.bar.objs/bar.ml.d
+      ocamlopt .foo.objs/native/foo__.{cmx,o}
         ocamlc .foo.objs/byte/foo__Intf.{cmi,cmti}
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc foo.cma
-      ocamldep test/.bar.objs/bar.ml.d
-        ocamlc test/.bar.objs/byte/bar.{cmi,cmo,cmt}
-        ocamlc test/bar.cma
       ocamlopt .foo.objs/native/foo.{cmx,o}
+        ocamlc test/.bar.objs/byte/bar.{cmi,cmo,cmt}
       ocamlopt foo.{a,cmxa}
-      ocamlopt foo.cmxs
+        ocamlc test/bar.cma
       ocamlopt test/.bar.objs/native/bar.{cmx,o}
+      ocamlopt foo.cmxs
       ocamlopt test/bar.{a,cmxa}
       ocamlopt test/bar.cmxs
 

--- a/test/blackbox-tests/test-cases/menhir/cmly/run.t
+++ b/test/blackbox-tests/test-cases/menhir/cmly/run.t
@@ -1,14 +1,14 @@
   $ dune build test.exe --display short --debug-dependency-path
       ocamllex lexer1.ml
-      ocamldep .test.eobjs/lexer1.ml.d
       ocamldep .test.eobjs/test.ml.d
         menhir test_menhir1.{cmly,ml,mli}
+      ocamldep .test.eobjs/lexer1.ml.d
       ocamldep .test.eobjs/test_menhir1.mli.d
       ocamldep .test.eobjs/test_menhir1.ml.d
         ocamlc .test.eobjs/byte/test_menhir1.{cmi,cmti}
       ocamlopt .test.eobjs/native/test_menhir1.{cmx,o}
         ocamlc .test.eobjs/byte/lexer1.{cmi,cmo,cmt}
         ocamlc .test.eobjs/byte/test.{cmi,cmo,cmt}
-      ocamlopt .test.eobjs/native/test.{cmx,o}
       ocamlopt .test.eobjs/native/lexer1.{cmx,o}
+      ocamlopt .test.eobjs/native/test.{cmx,o}
       ocamlopt test.exe

--- a/test/blackbox-tests/test-cases/menhir/general-2.0/run.t
+++ b/test/blackbox-tests/test-cases/menhir/general-2.0/run.t
@@ -1,29 +1,29 @@
   $ dune build src/test.exe --display short --debug-dependency-path
       ocamllex src/lexer1.ml
-      ocamldep src/.test.eobjs/lexer1.ml.d
       ocamllex src/lexer2.ml
-      ocamldep src/.test.eobjs/lexer2.ml.d
       ocamldep src/.test.eobjs/test.ml.d
         menhir src/test_base__mock.ml.mock
-      ocamldep src/.test.eobjs/test_base__mock.ml.mock.d
-        ocamlc src/test_base__mock.mli.inferred
-        menhir src/test_base.{ml,mli}
-      ocamldep src/.test.eobjs/test_base.mli.d
         menhir src/test_menhir1__mock.ml.mock
+      ocamldep src/.test.eobjs/lexer1.ml.d
+      ocamldep src/.test.eobjs/lexer2.ml.d
+      ocamldep src/.test.eobjs/test_base__mock.ml.mock.d
       ocamldep src/.test.eobjs/test_menhir1__mock.ml.mock.d
+        ocamlc src/test_base__mock.mli.inferred
         ocamlc src/test_menhir1__mock.mli.inferred
+        menhir src/test_base.{ml,mli}
         menhir src/test_menhir1.{ml,mli}
-      ocamldep src/.test.eobjs/test_menhir1.mli.d
+      ocamldep src/.test.eobjs/test_base.mli.d
       ocamldep src/.test.eobjs/test_base.ml.d
+      ocamldep src/.test.eobjs/test_menhir1.mli.d
       ocamldep src/.test.eobjs/test_menhir1.ml.d
         ocamlc src/.test.eobjs/byte/test_menhir1.{cmi,cmti}
-      ocamlopt src/.test.eobjs/native/test_menhir1.{cmx,o}
         ocamlc src/.test.eobjs/byte/test_base.{cmi,cmti}
-      ocamlopt src/.test.eobjs/native/test_base.{cmx,o}
+      ocamlopt src/.test.eobjs/native/test_menhir1.{cmx,o}
         ocamlc src/.test.eobjs/byte/lexer1.{cmi,cmo,cmt}
-      ocamlopt src/.test.eobjs/native/lexer1.{cmx,o}
+      ocamlopt src/.test.eobjs/native/test_base.{cmx,o}
         ocamlc src/.test.eobjs/byte/lexer2.{cmi,cmo,cmt}
+      ocamlopt src/.test.eobjs/native/lexer1.{cmx,o}
         ocamlc src/.test.eobjs/byte/test.{cmi,cmo,cmt}
-      ocamlopt src/.test.eobjs/native/test.{cmx,o}
       ocamlopt src/.test.eobjs/native/lexer2.{cmx,o}
+      ocamlopt src/.test.eobjs/native/test.{cmx,o}
       ocamlopt src/test.exe

--- a/test/blackbox-tests/test-cases/menhir/general/run.t
+++ b/test/blackbox-tests/test-cases/menhir/general/run.t
@@ -1,23 +1,23 @@
   $ dune build src/test.exe --display short --debug-dependency-path
       ocamllex src/lexer1.ml
-      ocamldep src/.test.eobjs/lexer1.ml.d
       ocamllex src/lexer2.ml
-      ocamldep src/.test.eobjs/lexer2.ml.d
       ocamldep src/.test.eobjs/test.ml.d
         menhir src/test_base.{ml,mli}
-      ocamldep src/.test.eobjs/test_base.mli.d
         menhir src/test_menhir1.{ml,mli}
-      ocamldep src/.test.eobjs/test_menhir1.mli.d
+      ocamldep src/.test.eobjs/lexer1.ml.d
+      ocamldep src/.test.eobjs/lexer2.ml.d
+      ocamldep src/.test.eobjs/test_base.mli.d
       ocamldep src/.test.eobjs/test_base.ml.d
+      ocamldep src/.test.eobjs/test_menhir1.mli.d
       ocamldep src/.test.eobjs/test_menhir1.ml.d
         ocamlc src/.test.eobjs/byte/test_menhir1.{cmi,cmti}
-      ocamlopt src/.test.eobjs/native/test_menhir1.{cmx,o}
         ocamlc src/.test.eobjs/byte/test_base.{cmi,cmti}
-      ocamlopt src/.test.eobjs/native/test_base.{cmx,o}
+      ocamlopt src/.test.eobjs/native/test_menhir1.{cmx,o}
         ocamlc src/.test.eobjs/byte/lexer1.{cmi,cmo,cmt}
-      ocamlopt src/.test.eobjs/native/lexer1.{cmx,o}
+      ocamlopt src/.test.eobjs/native/test_base.{cmx,o}
         ocamlc src/.test.eobjs/byte/lexer2.{cmi,cmo,cmt}
+      ocamlopt src/.test.eobjs/native/lexer1.{cmx,o}
         ocamlc src/.test.eobjs/byte/test.{cmi,cmo,cmt}
-      ocamlopt src/.test.eobjs/native/test.{cmx,o}
       ocamlopt src/.test.eobjs/native/lexer2.{cmx,o}
+      ocamlopt src/.test.eobjs/native/test.{cmx,o}
       ocamlopt src/test.exe

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests/run.t
@@ -1,11 +1,11 @@
   $ dune build @print-merlins --display short --profile release
       ocamldep pp/.pp.eobjs/pp.ml.d
-        ocamlc pp/.pp.eobjs/byte/pp.{cmi,cmo,cmt}
-      ocamlopt pp/.pp.eobjs/native/pp.{cmx,o}
-      ocamlopt pp/pp.exe
       ocamldep sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/sanitize_dot_merlin.ml.d
+        ocamlc pp/.pp.eobjs/byte/pp.{cmi,cmo,cmt}
         ocamlc sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/byte/sanitize_dot_merlin.{cmi,cmo,cmt}
+      ocamlopt pp/.pp.eobjs/native/pp.{cmx,o}
       ocamlopt sanitize-dot-merlin/.sanitize_dot_merlin.eobjs/native/sanitize_dot_merlin.{cmx,o}
+      ocamlopt pp/pp.exe
       ocamlopt sanitize-dot-merlin/sanitize_dot_merlin.exe
   sanitize_dot_merlin alias print-merlins
   # Processing exe/.merlin

--- a/test/blackbox-tests/test-cases/multi-dir/run.t
+++ b/test/blackbox-tests/test-cases/multi-dir/run.t
@@ -64,12 +64,12 @@ Test for (include_subdir unqualified) with (preprocess (action ...))
       ocamldep .main.eobjs/main.ml.d
         ocamlc .main.eobjs/byte/main.{cmi,cmo,cmt}
       ocamlopt .main.eobjs/native/main.{cmx,o}
+        ocamlc main.bc
       ocamlopt main.exe
           main sub/foo.pp.ml
       ocamldep .foo.objs/foo.pp.ml.d
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc foo.cma
-        ocamlc main.bc
       ocamlopt .foo.objs/native/foo.{cmx,o}
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs

--- a/test/blackbox-tests/test-cases/odoc/multiple-private-libs/run.t
+++ b/test/blackbox-tests/test-cases/odoc/multiple-private-libs/run.t
@@ -3,10 +3,10 @@ This test checks that there is no clash when two private libraries have the same
   $ dune build --display short @doc-private
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
       ocamldep a/.test.objs/test.ml.d
-        ocamlc a/.test.objs/byte/test.{cmi,cmo,cmt}
-          odoc a/.test.objs/byte/test.odoc
-          odoc _doc/_html/test@6aabb9861046/Test/.dune-keep,_doc/_html/test@6aabb9861046/Test/index.html
       ocamldep b/.test.objs/test.ml.d
+        ocamlc a/.test.objs/byte/test.{cmi,cmo,cmt}
         ocamlc b/.test.objs/byte/test.{cmi,cmo,cmt}
+          odoc a/.test.objs/byte/test.odoc
           odoc b/.test.objs/byte/test.odoc
+          odoc _doc/_html/test@6aabb9861046/Test/.dune-keep,_doc/_html/test@6aabb9861046/Test/index.html
           odoc _doc/_html/test@ea8c79305c05/Test/.dune-keep,_doc/_html/test@ea8c79305c05/Test/index.html

--- a/test/blackbox-tests/test-cases/odoc/odoc-simple/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-simple/run.t
@@ -1,25 +1,25 @@
   $ dune build @doc --display short
       ocamldep .bar.objs/bar.ml.d
-        ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/bar/page-index.odoc
-          odoc .bar.objs/byte/bar.odoc
-          odoc _doc/_html/bar/index.html
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
       ocamldep .foo.objs/foo.ml.d
-        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/foo/page-index.odoc
-          odoc .foo.objs/byte/foo.odoc
       ocamldep .foo.objs/foo2.ml.d
-        ocamlc .foo.objs/byte/foo2.{cmi,cmo,cmt}
-          odoc .foo.objs/byte/foo2.odoc
       ocamldep .foo.objs/foo3.ml.d
-        ocamlc .foo.objs/byte/foo3.{cmi,cmo,cmt}
-          odoc .foo.objs/byte/foo3.odoc
       ocamldep .foo_byte.objs/foo_byte.ml.d
+        ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
+        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
+        ocamlc .foo.objs/byte/foo2.{cmi,cmo,cmt}
+        ocamlc .foo.objs/byte/foo3.{cmi,cmo,cmt}
         ocamlc .foo_byte.objs/byte/foo_byte.{cmi,cmo,cmt}
+          odoc .bar.objs/byte/bar.odoc
+          odoc .foo.objs/byte/foo.odoc
+          odoc .foo.objs/byte/foo2.odoc
+          odoc .foo.objs/byte/foo3.odoc
           odoc .foo_byte.objs/byte/foo_byte.odoc
-          odoc _doc/_html/foo/Foo2/.dune-keep,_doc/_html/foo/Foo2/index.html
+          odoc _doc/_html/bar/index.html
           odoc _doc/_html/bar/Bar/.dune-keep,_doc/_html/bar/Bar/index.html
+          odoc _doc/_html/foo/Foo2/.dune-keep,_doc/_html/foo/Foo2/index.html
           odoc _doc/_html/foo/Foo3/.dune-keep,_doc/_html/foo/Foo3/index.html
           odoc _doc/_html/foo/Foo_byte/.dune-keep,_doc/_html/foo/Foo_byte/index.html
           odoc _doc/_html/foo/index.html

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/run.t
@@ -4,8 +4,8 @@ Duplicate mld's in the same scope
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
         ocamlc lib1/.root_lib1.objs/byte/root_lib1.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/root/page-index.odoc
-          odoc lib1/.root_lib1.objs/byte/root_lib1.odoc
         ocamlc lib2/.root_lib2.objs/byte/root_lib2.{cmi,cmo,cmt}
+          odoc lib1/.root_lib1.objs/byte/root_lib1.odoc
           odoc lib2/.root_lib2.objs/byte/root_lib2.odoc
           odoc _doc/_html/root/Root_lib2/.dune-keep,_doc/_html/root/Root_lib2/index.html
           odoc _doc/_html/root/index.html
@@ -18,11 +18,11 @@ Duplicate mld's in different scope
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css
         ocamlc scope1/.scope1.objs/byte/scope1.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/scope1/page-index.odoc
-          odoc scope1/.scope1.objs/byte/scope1.odoc
-          odoc _doc/_html/scope1/index.html
         ocamlc scope2/.scope2.objs/byte/scope2.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/scope2/page-index.odoc
+          odoc scope1/.scope1.objs/byte/scope1.odoc
           odoc scope2/.scope2.objs/byte/scope2.odoc
-          odoc _doc/_html/scope2/index.html
+          odoc _doc/_html/scope1/index.html
           odoc _doc/_html/scope1/Scope1/.dune-keep,_doc/_html/scope1/Scope1/index.html
+          odoc _doc/_html/scope2/index.html
           odoc _doc/_html/scope2/Scope2/.dune-keep,_doc/_html/scope2/Scope2/index.html

--- a/test/blackbox-tests/test-cases/package-dep/run.t
+++ b/test/blackbox-tests/test-cases/package-dep/run.t
@@ -1,16 +1,16 @@
   $ dune runtest --display short
       ocamldep .foo.objs/foo.ml.d
-        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
       ocamldep .bar.objs/bar.ml.d
+        ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
         ocamlc bar.cma
       ocamlopt .bar.objs/native/bar.{cmx,o}
       ocamlopt bar.{a,cmxa}
       ocamlopt bar.cmxs
       ocamlopt .foo.objs/native/foo.{cmx,o}
+        ocamlc foo.cma
       ocamlopt foo.{a,cmxa}
       ocamlopt foo.cmxs
-        ocamlc foo.cma
      ocamlfind test.exe
           test alias runtest
   42 42

--- a/test/blackbox-tests/test-cases/plugin-mode/run.t
+++ b/test/blackbox-tests/test-cases/plugin-mode/run.t
@@ -81,34 +81,34 @@ Testsuite for (mode plugin).
 
   $ dune build --display short @all
       ocamldep foo/.foo.objs/foo.ml.d
-        ocamlc foo/.foo.objs/byte/foo.{cmi,cmo,cmt}
-        ocamlc foo/foo.cma
       ocamldep $ext_lib.eobjs/a.ml.d
-        ocamlc $ext_lib.eobjs/byte/dune__exe__A.{cmi,cmo,cmt}
-      ocamlopt $ext_lib.eobjs/native/dune__exe__A.{cmx,o}
-      ocamlopt a.cmxs
       ocamldep foo/.bar.objs/bar.ml.d
-        ocamlc foo/.bar.objs/byte/bar.{cmi,cmo,cmt}
-        ocamlc foo/bar.cma
       ocamldep .b.eobjs/b.ml.d
-        ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
-      ocamlopt .b.eobjs/native/dune__exe__B.{cmx,o}
       ocamldep main/.main.eobjs/main.ml.d
-        ocamlc main/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
-      ocamlopt main/.main.eobjs/native/dune__exe__Main.{cmx,o}
       ocamldep main2/.main.eobjs/main.ml.d
+        ocamlc foo/.foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc main2/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
-      ocamlopt main2/.main.eobjs/native/dune__exe__Main.{cmx,o}
-      ocamlopt main2/main.exe
+        ocamlc foo/foo.cma
       ocamlopt foo/.foo.objs/native/foo.{cmx,o}
+        ocamlc foo/.bar.objs/byte/bar.{cmi,cmo,cmt}
+        ocamlc main/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
+        ocamlc $ext_lib.eobjs/byte/dune__exe__A.{cmi,cmo,cmt}
+      ocamlopt main2/.main.eobjs/native/dune__exe__Main.{cmx,o}
       ocamlopt foo/foo.{a,cmxa}
-      ocamlopt b.cmxs
+        ocamlc foo/bar.cma
       ocamlopt foo/.bar.objs/native/bar.{cmx,o}
-      ocamlopt foo/bar.{a,cmxa}
-      ocamlopt foo/bar.cmxs
+        ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
+      ocamlopt main/.main.eobjs/native/dune__exe__Main.{cmx,o}
+      ocamlopt $ext_lib.eobjs/native/dune__exe__A.{cmx,o}
+      ocamlopt main2/main.exe
       ocamlopt foo/foo.cmxs
+      ocamlopt foo/bar.{a,cmxa}
+      ocamlopt .b.eobjs/native/dune__exe__B.{cmx,o}
       ocamlopt main/main.exe
       ocamlopt a.exe
+      ocamlopt a.cmxs
+      ocamlopt foo/bar.cmxs
+      ocamlopt b.cmxs
 
   $ (cd _build/default && main/main.exe)
   12

--- a/test/blackbox-tests/test-cases/redirections/run.t
+++ b/test/blackbox-tests/test-cases/redirections/run.t
@@ -1,8 +1,8 @@
   $ dune runtest --display short 2>&1 | sed "s/ cmd /  sh /"
             sh stderr,stdout
+            sh both
             sh stderr,stdout
+            sh both
           diff alias runtest
-            sh both
-            sh both
           diff alias runtest
           diff alias runtest

--- a/test/blackbox-tests/test-cases/scope-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-bug/run.t
@@ -1,24 +1,24 @@
   $ dune build --display short @install
       ocamldep blib/sub/.sub.objs/sub.ml.d
-        ocamlc blib/sub/.sub.objs/byte/sub.{cmi,cmo,cmt}
-        ocamlc blib/sub/sub.cma
       ocamldep blib/.blib.objs/blib.ml.d
-        ocamlc blib/.blib.objs/byte/blib.{cmi,cmo,cmt}
-        ocamlc blib/blib.cma
       ocamldep alib/.alib.objs/alib.ml.d
         ocamlc alib/.alib.objs/byte/alib__.{cmi,cmo,cmt}
-        ocamlc alib/.alib.objs/byte/alib.{cmi,cmo,cmt}
-      ocamlopt alib/.alib.objs/native/alib.{cmx,o}
       ocamldep alib/.alib.objs/main.ml.d
-        ocamlc alib/.alib.objs/byte/alib__Main.{cmi,cmo,cmt}
-        ocamlc alib/alib.cma
-      ocamlopt blib/sub/.sub.objs/native/sub.{cmx,o}
-      ocamlopt blib/sub/sub.{a,cmxa}
-      ocamlopt blib/sub/sub.cmxs
-      ocamlopt blib/.blib.objs/native/blib.{cmx,o}
-      ocamlopt blib/blib.{a,cmxa}
-      ocamlopt blib/blib.cmxs
+        ocamlc blib/sub/.sub.objs/byte/sub.{cmi,cmo,cmt}
       ocamlopt alib/.alib.objs/native/alib__.{cmx,o}
+        ocamlc blib/sub/sub.cma
+      ocamlopt blib/sub/.sub.objs/native/sub.{cmx,o}
+        ocamlc blib/.blib.objs/byte/blib.{cmi,cmo,cmt}
+      ocamlopt blib/sub/sub.{a,cmxa}
+        ocamlc blib/blib.cma
+      ocamlopt blib/.blib.objs/native/blib.{cmx,o}
+        ocamlc alib/.alib.objs/byte/alib__Main.{cmi,cmo,cmt}
+        ocamlc alib/.alib.objs/byte/alib.{cmi,cmo,cmt}
+      ocamlopt blib/sub/sub.cmxs
+      ocamlopt blib/blib.{a,cmxa}
       ocamlopt alib/.alib.objs/native/alib__Main.{cmx,o}
+        ocamlc alib/alib.cma
+      ocamlopt alib/.alib.objs/native/alib.{cmx,o}
+      ocamlopt blib/blib.cmxs
       ocamlopt alib/alib.{a,cmxa}
       ocamlopt alib/alib.cmxs

--- a/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
+++ b/test/blackbox-tests/test-cases/scope-ppx-bug/run.t
@@ -1,13 +1,13 @@
   $ dune build --display short @install --debug-dep
         ocamlc a/ppx/.a.objs/byte/a.{cmi,cmo,cmt}
-        ocamlc a/ppx/a.cma
         ocamlc a/kernel/.a_kernel.objs/byte/a_kernel.{cmi,cmo,cmt}
-        ocamlc a/kernel/a_kernel.cma
+        ocamlc a/ppx/a.cma
       ocamlopt a/ppx/.a.objs/native/a.{cmx,o}
-      ocamlopt a/ppx/a.{a,cmxa}
-      ocamlopt a/ppx/a.cmxs
+        ocamlc a/kernel/a_kernel.cma
       ocamlopt a/kernel/.a_kernel.objs/native/a_kernel.{cmx,o}
+      ocamlopt a/ppx/a.{a,cmxa}
       ocamlopt a/kernel/a_kernel.{a,cmxa}
+      ocamlopt a/ppx/a.cmxs
       ocamlopt a/kernel/a_kernel.cmxs
       ocamlopt .ppx/4446201c218fbdeaa1427094637d47e1/ppx.exe
       ocamlopt .ppx/d4bc37c50327ac62f01166e7ec37f9fa/ppx.exe

--- a/test/blackbox-tests/test-cases/select/run.t
+++ b/test/blackbox-tests/test-cases/select/run.t
@@ -19,11 +19,11 @@
       ocamldep .main.eobjs/foo.ml.d
       ocamldep .main.eobjs/main.ml.d
         ocamlc .main.eobjs/byte/bar.{cmi,cmo,cmt}
-      ocamlopt .main.eobjs/native/bar.{cmx,o}
         ocamlc .main.eobjs/byte/foo.{cmi,cmo,cmt}
+      ocamlopt .main.eobjs/native/bar.{cmx,o}
         ocamlc .main.eobjs/byte/main.{cmi,cmo,cmt}
-      ocamlopt .main.eobjs/native/main.{cmx,o}
       ocamlopt .main.eobjs/native/foo.{cmx,o}
+      ocamlopt .main.eobjs/native/main.{cmx,o}
       ocamlopt main.exe
           main alias runtest
   bar has unix
@@ -48,12 +48,12 @@
   $ dune runtest --display short
         ocamlc .main.eobjs/byte/dune__exe.{cmi,cmo,cmt}
         ocamlc .main.eobjs/byte/dune__exe__Bar.{cmi,cmo,cmt}
-      ocamlopt .main.eobjs/native/dune__exe__Bar.{cmx,o}
         ocamlc .main.eobjs/byte/dune__exe__Foo.{cmi,cmo,cmt}
-        ocamlc .main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
-      ocamlopt .main.eobjs/native/dune__exe__Main.{cmx,o}
       ocamlopt .main.eobjs/native/dune__exe.{cmx,o}
+      ocamlopt .main.eobjs/native/dune__exe__Bar.{cmx,o}
+        ocamlc .main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
       ocamlopt .main.eobjs/native/dune__exe__Foo.{cmx,o}
+      ocamlopt .main.eobjs/native/dune__exe__Main.{cmx,o}
       ocamlopt main.exe
           main alias runtest
   bar has unix

--- a/test/blackbox-tests/test-cases/tests-stanza/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/run.t
@@ -13,18 +13,18 @@
       ocamldep .expect_test.eobjs/regular_test.ml.d
       ocamldep .expect_test.eobjs/regular_test2.ml.d
         ocamlc .expect_test.eobjs/byte/regular_test.{cmi,cmo,cmt}
+        ocamlc .expect_test.eobjs/byte/regular_test2.{cmi,cmo,cmt}
+        ocamlc .expect_test.eobjs/byte/expect_test.{cmi,cmo,cmt}
       ocamlopt .expect_test.eobjs/native/regular_test.{cmx,o}
+      ocamlopt .expect_test.eobjs/native/regular_test2.{cmx,o}
+      ocamlopt .expect_test.eobjs/native/expect_test.{cmx,o}
       ocamlopt regular_test.exe
+      ocamlopt regular_test2.exe
+      ocamlopt expect_test.exe
   regular_test alias runtest
   regular test
-        ocamlc .expect_test.eobjs/byte/regular_test2.{cmi,cmo,cmt}
-      ocamlopt .expect_test.eobjs/native/regular_test2.{cmx,o}
-      ocamlopt regular_test2.exe
   regular_test2 alias runtest
   regular test2
-        ocamlc .expect_test.eobjs/byte/expect_test.{cmi,cmo,cmt}
-      ocamlopt .expect_test.eobjs/native/expect_test.{cmx,o}
-      ocamlopt expect_test.exe
    expect_test expect_test.output
   $ dune runtest --root generated --display short
   Entering directory 'generated'

--- a/test/blackbox-tests/test-cases/utop/utop-simple/run.t
+++ b/test/blackbox-tests/test-cases/utop/utop-simple/run.t
@@ -1,8 +1,8 @@
   $ dune utop --display short forutop -- init_forutop.ml
       ocamldep forutop/.forutop.objs/forutop.ml.d
+      ocamldep forutop/.utop/.utop.eobjs/utop.ml-gen.d
         ocamlc forutop/.forutop.objs/byte/forutop.{cmi,cmo,cmt}
         ocamlc forutop/forutop.cma
-      ocamldep forutop/.utop/.utop.eobjs/utop.ml-gen.d
         ocamlc forutop/.utop/.utop.eobjs/byte/dune__exe__Utop.{cmi,cmo,cmt}
         ocamlc forutop/.utop/utop.exe
   hello in utop

--- a/test/blackbox-tests/test-cases/variables-for-artifacts/run.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts/run.t
@@ -19,14 +19,14 @@ prefixed and unprefixed modules are built.
   $ ./sdune clean
   $ ./sdune build --display short @t1
       ocamldep .a1.objs/a.ml.d
-        ocamlc .a1.objs/byte/a1.{cmi,cmo,cmt}
-        ocamlc .a1.objs/byte/a1__A.{cmi,cmo,cmt}
       ocamldep .b.eobjs/b.ml.d
-        ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
       ocamldep .c1.objs/c.ml.d
-        ocamlc .c1.objs/byte/c.{cmi,cmo,cmt}
       ocamldep .c2.objs/d.ml.d
+        ocamlc .a1.objs/byte/a1.{cmi,cmo,cmt}
+        ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
+        ocamlc .c1.objs/byte/c.{cmi,cmo,cmt}
         ocamlc .c2.objs/byte/c2.{cmi,cmo,cmt}
+        ocamlc .a1.objs/byte/a1__A.{cmi,cmo,cmt}
         ocamlc .c2.objs/byte/c2__D.{cmi,cmo,cmt}
 
 Command line version.
@@ -80,8 +80,8 @@ The next test builds a native .cmxa.
   $ ./sdune clean
   $ ./sdune build --display short @t4
         ocamlc .a1.objs/byte/a1.{cmi,cmo,cmt}
-      ocamlopt .a1.objs/native/a1.{cmx,o}
       ocamldep .a1.objs/a.ml.d
+      ocamlopt .a1.objs/native/a1.{cmx,o}
         ocamlc .a1.objs/byte/a1__A.{cmi,cmo,cmt}
       ocamlopt .a1.objs/native/a1__A.{cmx,o}
       ocamlopt a1.{a,cmxa}
@@ -213,17 +213,17 @@ of a (rule).
 
   $ ./sdune build --display short _build/default/my.cmxs
       ocamldep .dummy.objs/x3.ml.d
-        ocamlc .dummy.objs/byte/dummy.{cmi,cmo,cmt}
-        ocamlc .dummy.objs/byte/dummy__X3.{cmi,cmo,cmt}
-      ocamlopt .dummy.objs/native/dummy__X3.{cmx,o}
         ocamlc .plugin.objs/byte/plugin.{cmi,cmo,cmt}
-      ocamlopt .plugin.objs/native/plugin.{cmx,o}
       ocamldep .plugin.objs/x1.ml.d
-        ocamlc .plugin.objs/byte/plugin__X1.{cmi,cmo,cmt}
-      ocamlopt .plugin.objs/native/plugin__X1.{cmx,o}
       ocamldep .plugin.objs/x2.ml.d
+        ocamlc .dummy.objs/byte/dummy.{cmi,cmo,cmt}
+      ocamlopt .plugin.objs/native/plugin.{cmx,o}
+        ocamlc .plugin.objs/byte/plugin__X1.{cmi,cmo,cmt}
         ocamlc .plugin.objs/byte/plugin__X2.{cmi,cmo,cmt}
+        ocamlc .dummy.objs/byte/dummy__X3.{cmi,cmo,cmt}
+      ocamlopt .plugin.objs/native/plugin__X1.{cmx,o}
       ocamlopt .plugin.objs/native/plugin__X2.{cmx,o}
+      ocamlopt .dummy.objs/native/dummy__X3.{cmx,o}
       ocamlopt plugin.{a,cmxa}
       ocamlopt my.cmxs
 


### PR DESCRIPTION
The old code in scheduler.ml was making assumption about the order in which things were executed by `Fiber.Ivar.fill`