### PR TITLE
Protect link-time code generation placeholders with Sys.opaque_identity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@ next
 - `$ dune utop` no longer tries to load optional libraries that are unavailable
   (#3612, fixes #3188, @anuragsoni)
 
+- Fix dune-build-info on 4.10.0+flambda (#3599, @emillon, @jeremiedimino).
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -99,9 +99,9 @@ Check what the generated build info module looks like:
       None
   [@@inline never]
   
-  let p1 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:a%%%%%%%%%%%%%%%%%%%%%%%%%%"
-  let p2 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:b%%%%%%%%%%%%%%%%%%%%%%%%%%"
-  let p0 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:c%%%%%%%%%%%%%%%%%%%%%%%%%%"
+  let p1 = eval (Sys.opaque_identity "%%DUNE_PLACEHOLDER:64:vcs-describe:1:a%%%%%%%%%%%%%%%%%%%%%%%%%%")
+  let p2 = eval (Sys.opaque_identity "%%DUNE_PLACEHOLDER:64:vcs-describe:1:b%%%%%%%%%%%%%%%%%%%%%%%%%%")
+  let p0 = eval (Sys.opaque_identity "%%DUNE_PLACEHOLDER:64:vcs-describe:1:c%%%%%%%%%%%%%%%%%%%%%%%%%%")
   
   let version = p0
   

--- a/src/dune/ocaml_version.ml
+++ b/src/dune/ocaml_version.ml
@@ -45,3 +45,5 @@ let custom_or_output_complete_exe version =
     "-custom"
 
 let ocamlopt_always_calls_library_linker version = version < (4, 12, 0)
+
+let has_sys_opaque_identity version = version >= (4, 3, 0)

--- a/src/dune/ocaml_version.mli
+++ b/src/dune/ocaml_version.mli
@@ -63,3 +63,6 @@ val custom_or_output_complete_exe : t -> string
 
 (** ocamlopt -a always calls the native C linker, even for empty archives *)
 val ocamlopt_always_calls_library_linker : t -> bool
+
+(** Whether [Sys.opaque_identity] is in the standard library *)
+val has_sys_opaque_identity : t -> bool


### PR DESCRIPTION
This ensures that they are not inlined when using flambda. See discussion in #1930.