### PR TITLE
Remove Fiber.fork

### DIFF
--- a/src/dune/scheduler.ml
+++ b/src/dune/scheduler.ml
@@ -709,17 +709,11 @@ end = struct
     let fiber =
       Fiber.Var.set t_var t (fun () -> Fiber.with_error_handler f ~on_error)
     in
-    match
-      Fiber.run
-        (let* user_action_result = Fiber.fork (fun () -> fiber) in
-         let* pump_events_result = pump_events t in
-         let* user_action_result = Fiber.Future.peek user_action_result in
-         Fiber.return (pump_events_result, user_action_result))
-    with
-    | None -> Code_error.raise "[Scheduler.pump_events] got stuck somehow" []
+    match Fiber.run2 (fun () -> fiber) (fun () -> pump_events t) with
+    | _, None -> Code_error.raise "[Scheduler.pump_events] got stuck somehow" []
     | exception exn -> Error (Exn (exn, Printexc.get_raw_backtrace ()))
-    | Some (a, b) -> (
-      match (a, b) with
+    | a, Some b -> (
+      match (b, a) with
       | Done, None -> Error Never
       | Done, Some res -> Ok res
       | Got_signal, _ -> Error Got_signal

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -253,3 +253,7 @@ with type 'a fiber := 'a t
 (** [run t] runs a fiber. If the fiber doesn't complete immediately, [run t]
     returns [None]. *)
 val run : 'a t -> 'a option
+
+(** Similar to [run] but with two fibers. This function is a bit odd and might
+    eventually be replaced by something more idiomatic. *)
+val run2 : (unit -> 'a t) -> (unit -> 'b t) -> 'a option * 'b option

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -31,15 +31,10 @@ end = struct
 
   let run t =
     match
-      Fiber.run
-        (let* result = Fiber.fork (fun () -> t) in
-         let* () = restart_suspended () in
-         Fiber.Future.peek result)
+      Fiber.run (Fiber.fork_and_join (fun () -> t) restart_suspended >>| fst)
     with
-    | None
-    | Some None ->
-      raise Never
-    | Some (Some x) -> x
+    | None -> raise Never
+    | Some x -> x
 end
 
 let failing_fiber () : unit Fiber.t =


### PR DESCRIPTION
As discussed during yesterday's meeting, this PR removes `Fiber.fork` because it is difficult to reason about, especially in the presence of exceptions. `Fiber` instead becomes a [structured concurrency monad](https://en.wikipedia.org/wiki/Structured_concurrency), which is much simpler to reason about.

To remove the `Fiber.fork` in the scheduler, I introduced a `Fiber.run2` function. This function feels a bit ad-hoc and eventually we should replace it by something more idiomatic, but in the meantime it will do. In particular, it is required because of the way we handle polling; as soon as a file changes, we abort the whole computation immediately. Essentially we throw out the entire fiber tree and restart from scratch. This requires terminating as soon as a a certain event is received without waiting for completion of other fibers. In a way, this is a pretty abrupt notion of cancellation where we cancel everything at once.