### PR TITLE
Cleanup a few tests

### DIFF
--- a/test/blackbox-tests/test-cases/c-stubs/run.t
+++ b/test/blackbox-tests/test-cases/c-stubs/run.t
@@ -1,14 +1,5 @@
-  $ dune exec ./qnativerun/run.exe --display short
-        ocamlc q/q_stub$ext_obj
-      ocamldep q/.q.objs/q.mli.d
-      ocamldep q/.q.objs/q.ml.d
-      ocamldep qnativerun/.run.eobjs/run.ml.d
-    ocamlmklib q/dllq_stubs$ext_dll,q/libq_stubs$ext_lib
-        ocamlc q/.q.objs/byte/q.{cmi,cmti}
-      ocamlopt q/.q.objs/native/q.{cmx,o}
-      ocamlopt q/q.{a,cmxa}
-        ocamlc qnativerun/.run.eobjs/byte/run.{cmi,cmo,cmt}
-      ocamlopt qnativerun/.run.eobjs/native/run.{cmx,o}
-      ocamlopt qnativerun/run.exe
+Test that an OCaml executables with C stubs works.
+
+  $ dune exec ./qnativerun/run.exe
   42
 #  $ dune exec ./qbyterun/run.bc --display short

--- a/test/blackbox-tests/test-cases/contents-depends-on-glob/run.t
+++ b/test/blackbox-tests/test-cases/contents-depends-on-glob/run.t
@@ -7,25 +7,8 @@ produce targets in the directory being globbed.
 on the directory listing)
 
   $ dune build @install
-  $ dune_cmd cat _build/default/bar/bar.install
-  lib: [
-    "_build/install/default/lib/bar/META"
-    "_build/install/default/lib/bar/bar$ext_lib"
-    "_build/install/default/lib/bar/bar.cma"
-    "_build/install/default/lib/bar/bar.cmi"
-    "_build/install/default/lib/bar/bar.cmt"
-    "_build/install/default/lib/bar/bar.cmx"
-    "_build/install/default/lib/bar/bar.cmxa"
-    "_build/install/default/lib/bar/bar.cmxs"
-    "_build/install/default/lib/bar/bar.ml"
-    "_build/install/default/lib/bar/bar__.cmi"
-    "_build/install/default/lib/bar/bar__.cmt"
-    "_build/install/default/lib/bar/bar__.cmx"
-    "_build/install/default/lib/bar/bar__.ml"
-    "_build/install/default/lib/bar/bar__Baz.cmi"
-    "_build/install/default/lib/bar/bar__Baz.cmt"
-    "_build/install/default/lib/bar/bar__Baz.cmx"
-    "_build/install/default/lib/bar/baz.ml"
-    "_build/install/default/lib/bar/dune-package"
-    "_build/install/default/lib/bar/opam"
-  ]
+
+Check that the command did build things:
+
+  $ ls _build/install/default/lib/bar/*.cmxa
+  _build/install/default/lib/bar/bar.cmxa

--- a/test/blackbox-tests/test-cases/copy_files/run.t
+++ b/test/blackbox-tests/test-cases/copy_files/run.t
@@ -1,19 +1,7 @@
-  $ dune build --root test1 test.exe .merlin --display short --debug-dependency-path
+Test that (copy_files ...) works
+
+  $ dune build --root test1 test.exe .merlin
   Entering directory 'test1'
-      ocamldep .foo.objs/dummy.ml.d
-        ocamlc bar$ext_obj
-      ocamllex lexers/lexer1.ml
-      ocamldep .test.eobjs/test.ml.d
-        ocamlc .foo.objs/byte/dummy.{cmi,cmo,cmt}
-    ocamlmklib dllfoo_stubs$ext_dll,libfoo_stubs$ext_lib
-      ocamldep .test.eobjs/lexer1.ml.d
-      ocamlopt .foo.objs/native/dummy.{cmx,o}
-      ocamlopt foo.{a,cmxa}
-        ocamlc .test.eobjs/byte/lexer1.{cmi,cmo,cmt}
-        ocamlc .test.eobjs/byte/test.{cmi,cmo,cmt}
-      ocamlopt .test.eobjs/native/lexer1.{cmx,o}
-      ocamlopt .test.eobjs/native/test.{cmx,o}
-      ocamlopt test.exe
   $ dune build --root test1 @bar-source --display short
   Entering directory 'test1'
   #line 1 "include/bar.h"


### PR DESCRIPTION
We were just looking at tests that need the sanitizer with Rudi, and our finding is that:

- there are not that many tests that need the extension sanitazation
- many of them can be simplified in a way that sanitization is not needed
- for the few remaining ones, we can just do it manually

This will simplify the cram system even more.

This PR just changes a few tests we looked at.