### PR TITLE
Add Fiber.Stream

### DIFF
--- a/test/expect-tests/fiber/dune
+++ b/test/expect-tests/fiber/dune
@@ -5,7 +5,6 @@
   dune_tests_common
   stdune
   fiber
-  dune
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -1,4 +1,3 @@
-open Dune
 open Stdune
 open Fiber.O
 open Dyn.Encoder
@@ -222,17 +221,12 @@ let%expect_test _ =
 
 let%expect_test _ =
   let forking_fiber () =
-    let which = Bin.which ~path:(Env.path Env.initial) in
     Fiber.parallel_map [ 1; 2; 3; 4; 5 ] ~f:(fun x ->
         Scheduler.yield () >>= fun () ->
         if x mod 2 = 1 then
-          Process.run Process.Strict ~env:Env.initial
-            (Option.value_exn (which "true"))
-            []
+          Fiber.return ()
         else
-          Process.run Process.Strict ~env:Env.initial
-            (Option.value_exn (which "false"))
-            [])
+          Printf.ksprintf failwith "%d" x)
   in
   must_set_flag (fun setter ->
       test ~expect_never:true unit


### PR DESCRIPTION
To allow iterating in parallel over infinite lists without leaking memory.