### PR TITLE
Upstream multicore dune bootstrap patch

### DIFF
--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -65,9 +65,9 @@ let read_file fn =
   s
 
 let () =
-  let v = Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> (a, b)) in
+  let v, p = Scanf.sscanf Sys.ocaml_version "%d.%d%s@+%s" (fun a b c d -> (a, b), d) in
   let compiler, which =
-    if v >= min_supported_natively then
+    if v >= min_supported_natively && p <> "multicore" then
       ("ocamlc", None)
     else
       let compiler = "ocamlfind -toolchain secondary ocamlc" in


### PR DESCRIPTION
While looking at #3548 i stumbled across the patch used in the multicore repo to build dune using the secondary compiler.

This commit just pulls in @dra27 's patch (Thank you!, this has made exploring multicore really easy) from https://github.com/ocaml-multicore/multicore-opam/pull/20
I'm not sure if there was a specific reason for this patch to live in the multicore repo only instead of the main dune repo, but if this doesn't cause issues it'd make it easier to use dune when working in a multicore switch.

Signed-off-by: Anurag Soni <anurag@sonianurag.com>