### PR TITLE
Remove ocaml-syntax-shims from (binaries)

### DIFF
--- a/dune
+++ b/dune
@@ -1,11 +1,7 @@
-;; We embed a copy of ocaml-syntax-shims until we drop support for
-;; OCaml < 4.08
-
 (env
  (_
   (binaries
-   (otherlibs/cram/bin/dune_cram.exe as dune-cram)
-   (src/ocaml-syntax-shims/pp.exe as ocaml-syntax-shims))))
+   (otherlibs/cram/bin/dune_cram.exe as dune-cram))))
 
 (rule
  (copy dune-private-libs.opam.template dune-configurator.opam.template))


### PR DESCRIPTION
As the comment states, we do not need this anymore now that 4.07 support is dropped.