### PR TITLE
filter unavailable optional libs for utop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ next
 - Fix compatibility with OCaml 4.12.0 when compiling empty archives; no .a file
   is generated. (#3576, @dra27)
 
+- `$ dune utop` no longer tries to load optional libraries that are unavailable
+  (#3612, fixes #3188, @anuragsoni)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/utop.ml
+++ b/src/dune/utop.ml
@@ -51,7 +51,15 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
                  Implementations are selected using the default implementation
                  feature. *)
               let not_impl = Option.is_none (Lib_info.implements info) in
-              if not_impl && Path.is_descendant ~of_:(Path.build dir) src_dir
+              let not_hidden =
+                match Lib_info.enabled info with
+                | Normal -> true
+                | Optional -> Result.is_ok (Lib.requires lib)
+                | Disabled_because_of_enabled_if -> false
+              in
+              if
+                not_impl && not_hidden
+                && Path.is_descendant ~of_:(Path.build dir) src_dir
               then
                 match Lib_info.kind info with
                 | Lib_kind.Ppx_rewriter _

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1339,6 +1339,14 @@
    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
+ (alias github3188)
+ (deps (package dune) (source_tree test-cases/github3188) (alias test-deps))
+ (action
+  (chdir
+   test-cases/github3188
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
+
+(rule
  (alias github3440)
  (deps (package dune) (source_tree test-cases/github3440) (alias test-deps))
  (action
@@ -3121,6 +3129,7 @@
   (alias github3043)
   (alias github3046)
   (alias github3180)
+  (alias github3188)
   (alias github3440)
   (alias github3490)
   (alias github3530)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -253,6 +253,7 @@ let exclusions =
   ; make "mdx-stanza" ~external_deps:true
   ; make "toplevel-integration" ~external_deps:true
   ; make "bisect-ppx/main" ~external_deps:true
+  ; make "github3188" ~external_deps:true
   ]
   |> String_map.of_list_map_exn ~f:(fun (test : Test.t) -> (test.path, test))
 

--- a/test/blackbox-tests/test-cases/github3188/run.t
+++ b/test/blackbox-tests/test-cases/github3188/run.t
@@ -1,0 +1,15 @@
+This test makes sure that the utop subcommand does not load optional libraries.
+
+  $ mkdir testutop
+  $ cat <<EOF > testutop/dune
+  > (library
+  >  (name testutop)
+  >  (optional)
+  >  (libraries does_not_exist))
+  > EOF
+  $ echo 'let run () = print_endline "this will never run"' > testutop/testutop.ml
+  $ echo "(lang dune 2.0)" > dune-project
+  $ echo 'let () = print_endline "No Error"' > init_test.ml
+
+  $ dune utop testutop -- init_test.ml
+  No Error


### PR DESCRIPTION
I hit this error recently. I am not too familiar with the internals of dune but this diff seemed to be the way to go to filter out libraries that aren't available for some reason (optional libraries with missing deps, or libraries disabled via a enabled_if)

Reference: #3188

Signed-off-by: Anurag Soni <anurag@sonianurag.com>