### PR TITLE
Replace -printf with awk

### DIFF
--- a/test/blackbox-tests/test-cases/check-alias/run.t
+++ b/test/blackbox-tests/test-cases/check-alias/run.t
@@ -9,7 +9,7 @@ as well as the foo.{cmi,cmo,cmt} files.
   > (
   >   cd $1
   >   dune build @check
-  >   find _build \( -name '*.cm*' -o -name .merlin \) -printf '%f\n' | LANG=C sort
+  >   find _build \( -name '*.cm*' -o -name .merlin \) | awk -F/ '{ print $NF }' | LANG=C sort
   > )
 
 Test the property for executables:


### PR DESCRIPTION
-printf isn't available in macos find