### PR TITLE
Upgrade to ocamlformat 0.15.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.14.3
+version=0.15.0
 break-separators=before
 dock-collection-brackets=false
 break-sequences=true

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ menhir \
 merlin \
 ocaml-migrate-parsetree \
 ocamlfind \
-ocamlformat.0.14.3 \
+ocamlformat.0.15.0 \
 "odoc>=1.5.0" \
 "ppx_expect>=v0.14" \
 ppx_inline_test \

--- a/src/catapult/catapult.ml
+++ b/src/catapult/catapult.ml
@@ -28,7 +28,8 @@ let fake_gc_stat =
   ; compactions = 0
   ; top_heap_words = 0
   ; stack_size = 0
-  } [@ocaml.warning "-23"]
+  }
+  [@ocaml.warning "-23"]
 
 (* all fiels of record used *)
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -726,25 +726,21 @@ end = struct
                 } )
       in
       Alias.Name.Map.foldi aliases ~init:[]
-        ~f:(fun name
-                { Rules.Dir_rules.Alias_spec.deps; dyn_deps; actions }
-                rules
-                ->
+        ~f:(fun
+             name
+             { Rules.Dir_rules.Alias_spec.deps; dyn_deps; actions }
+             rules
+           ->
           let base_path =
             Path.Build.relative alias_dir (Alias.Name.to_string name)
           in
           let rules, action_stamp_files =
             List.fold_left (Appendable_list.to_list actions)
               ~init:(rules, Path.Set.empty)
-              ~f:(fun (rules, action_stamp_files)
-                      { Rules.Dir_rules.stamp
-                      ; action
-                      ; locks
-                      ; context
-                      ; loc
-                      ; env
-                      }
-                      ->
+              ~f:(fun
+                   (rules, action_stamp_files)
+                   { Rules.Dir_rules.stamp; action; locks; context; loc; env }
+                 ->
                 let path =
                   Path.Build.extend_basename base_path
                     ~suffix:("-" ^ Digest.to_string stamp)

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -504,9 +504,10 @@ let interpret_lang_and_extensions ~(lang : Lang.Instance.t) ~explicit_extensions
     in
     let extension_args, extension_stanzas =
       List.fold_left extensions ~init:(Univ_map.empty, [])
-        ~f:(fun (args_acc, stanzas_acc)
-                ((ext : Extension.automatic), is_explicit)
-                ->
+        ~f:(fun
+             (args_acc, stanzas_acc)
+             ((ext : Extension.automatic), is_explicit)
+           ->
           match ext with
           | Disabled _ -> (args_acc, stanzas_acc)
           | Enabled instance ->

--- a/src/dune_rules/coq_sources.ml
+++ b/src/dune_rules/coq_sources.ml
@@ -42,8 +42,7 @@ let extract t (stanza : Extraction.t) =
 let of_dir (d : _ Dir_with_dune.t) ~include_subdirs ~dirs =
   check_no_unqualified include_subdirs;
   let modules = coq_modules_of_files ~dirs in
-  List.fold_left d.data ~init:empty ~f:(fun acc ->
-    function
+  List.fold_left d.data ~init:empty ~f:(fun acc -> function
     | Coq_stanza.Theory.T coq ->
       let modules =
         Coq_module.eval ~dir:d.ctx_dir coq.modules ~standard:modules

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -92,8 +92,7 @@ let unnamed ~expander l =
   ()
 
 let named =
-  make_interpreter ~f:(fun expander ->
-    function
+  make_interpreter ~f:(fun expander -> function
     | Bindings.Unnamed p ->
       dep expander p
       |> Result.map ~f:(fun l ->

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -100,7 +100,8 @@ let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
     ~dir
       (* With sandboxing we get errors like: bar.c:2:19: fatal error: foo.cxx:
          No such file or directory #include "foo.cxx". (These errors happen only
-         when compiling c files.) *) ~sandbox:Sandbox_config.no_sandboxing
+         when compiling c files.) *)
+    ~sandbox:Sandbox_config.no_sandboxing
     (let src = Path.build (Foreign.Source.path src) in
      let c_compiler = Ocaml_config.c_compiler ctx.ocaml_config in
      (* We have to execute the rule in the library directory as the .o is

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -469,14 +469,14 @@ end = struct
             | None -> Lib_name.Map.empty
             | Some entries ->
               List.fold_left entries ~init:Lib_name.Map.empty
-                ~f:(fun acc
-                        { Dune_file.Library_redirect.old_name =
-                            old_public_name, _
-                        ; new_public_name = _, new_public_name
-                        ; loc
-                        ; _
-                        }
-                        ->
+                ~f:(fun
+                     acc
+                     { Dune_file.Library_redirect.old_name = old_public_name, _
+                     ; new_public_name = _, new_public_name
+                     ; loc
+                     ; _
+                     }
+                   ->
                   let old_public_name =
                     Dune_file.Public_lib.name old_public_name
                   in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -252,8 +252,7 @@ let lib_entries_of_package t pkg_name =
 let internal_lib_names t =
   List.fold_left t.stanzas ~init:Lib_name.Set.empty
     ~f:(fun acc { Dir_with_dune.data = stanzas; _ } ->
-      List.fold_left stanzas ~init:acc ~f:(fun acc ->
-        function
+      List.fold_left stanzas ~init:acc ~f:(fun acc -> function
         | Dune_file.Library lib ->
           Lib_name.Set.add
             ( match lib.visibility with

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -35,8 +35,7 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
       match Super_context.stanzas_in sctx ~dir with
       | None -> (acc, pps)
       | Some (d : _ Dir_with_dune.t) ->
-        List.fold_left d.data ~init:(acc, pps) ~f:(fun (acc, pps) ->
-          function
+        List.fold_left d.data ~init:(acc, pps) ~f:(fun (acc, pps) -> function
           | Dune_file.Library l -> (
             match
               Lib.DB.resolve_when_exists db

--- a/src/dune_rules/visibility.ml
+++ b/src/dune_rules/visibility.ml
@@ -19,8 +19,7 @@ let encode =
 
 let decode =
   let open Dune_lang.Decoder in
-  plain_string (fun ~loc ->
-    function
+  plain_string (fun ~loc -> function
     | "public" -> Public
     | "private" -> Private
     | _ ->

--- a/src/memo/implicit_output.ml
+++ b/src/memo/implicit_output.ml
@@ -33,15 +33,14 @@ end = struct
 
   type 'a t = (module T with type a = 'a)
 
-  let create (type a) (module I : Implicit_output with type t = a) =
-    ( ( module struct
-        type nonrec a = a
+  let create (type a) (module I : Implicit_output with type t = a) : a t =
+    ( module struct
+      type nonrec a = a
 
-        type _ w += W : a w
+      type _ w += W : a w
 
-        include I
-      end )
-      : a t )
+      include I
+    end )
 
   let get (type a) (module T : T with type a = a) =
     (module T : Implicit_output with type t = a)

--- a/src/stdune/type_eq.ml
+++ b/src/stdune/type_eq.ml
@@ -22,13 +22,12 @@ module Id = struct
     | M2.W -> true
     | _ -> false
 
-  let create (type a) () =
-    ( ( module struct
-        type nonrec a = a
+  let create (type a) () : a t =
+    ( module struct
+      type nonrec a = a
 
-        type _ w += W : a w
-      end )
-      : a t )
+      type _ w += W : a w
+    end )
 
   let same (type a b) ((module M1) : a t) ((module M2) : b t) =
     match M1.W with


### PR DESCRIPTION
Hi, this is what the project would look like after being reformated with the current version (candidate) of ocamlformat 0.15.0.
**Please do not merge until ocamlformat.0.15.0 is available with opam.**

The main changes are due to the improved inconsistency of option `indicate-multiline-delimiters`, a lot of spaces where missing before closing parentheses in the previous versions.
Please let me know if you see any regressions that I may have missed.