### PR TITLE
Wrap lines of external-lib-deps hints

### DIFF
--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -81,8 +81,7 @@ let run ~lib_deps ~by_dir ~setup ~only_missing ~sexp =
                ]
                ~hints:
                  [ Dune_engine.Utils.pp_command_hint
-                     ( "opam install" :: required_package_names
-                     |> String.concat ~sep:" " )
+                     ("opam install" :: required_package_names)
                  ]);
           true
       ) else if sexp then (

--- a/src/dune_engine/utils.ml
+++ b/src/dune_engine/utils.ml
@@ -65,7 +65,15 @@ let line_directive ~filename:fn ~line_number =
 
 let local_bin p = Path.Build.relative p ".bin"
 
+let esc_symbol =
+  if Sys.win32 then
+    '^'
+  else
+    '\\'
+
 let pp_command_hint command =
+  let esc = Format.sprintf " %c" esc_symbol in
+  let sep = Pp.custom_break ~fits:("", 1, "") ~breaks:(esc, 0, "") in
   let open Pp.O in
   Pp.textf "try:" ++ Pp.newline ++ Pp.cut
-  ++ Pp.hbox (Pp.textf "  " ++ Pp.verbatim command)
+  ++ Pp.hbox (Pp.textf "  " ++ Pp.concat ~sep (List.map ~f:Pp.verbatim command))

--- a/src/dune_engine/utils.mli
+++ b/src/dune_engine/utils.mli
@@ -27,4 +27,4 @@ val line_directive : filename:string -> line_number:int -> string
 val local_bin : Path.Build.t -> Path.Build.t
 
 (** Pretty-printer for suggesting a given shell command to the user *)
-val pp_command_hint : string -> _ Pp.t
+val pp_command_hint : string list -> _ Pp.t

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -36,11 +36,7 @@ module Error = struct
   let external_lib_deps_hint () =
     match !Clflags.external_lib_deps_hint with
     | [] -> []
-    | l ->
-      [ l
-        |> List.map ~f:String.quote_for_shell
-        |> String.concat ~sep:" " |> Utils.pp_command_hint
-      ]
+    | l -> [ l |> List.map ~f:String.quote_for_shell |> Utils.pp_command_hint ]
 
   let not_found ~loc ~name =
     make ~loc


### PR DESCRIPTION
Hi, I customized the pretty-printer to make it easier to copy-paste the suggested command line given as a hint (that's something I always found frustrating).

The motivation is to replace:
```
Hint: try: opam install capnp-rpc-lwt capnp-rpc-unix cohttp-lwt-unix current
current_ansi current_docker current_git current_github current_rpc
current_web dockerfile git-unix opam-0install prometheus prometheus-app
```

with
```
Hint: try: opam install capnp-rpc-lwt capnp-rpc-unix cohttp-lwt-unix \
current current_ansi current_docker current_git current_github current_rpc \
current_web dockerfile git-unix opam-0install prometheus prometheus-app
```