### PR TITLE
Add (alias ...), (mode ...) fields to (copy_files ...) stanza

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ next
 - Run exit hooks in jsoo separate compilation mode (#3626, fixes #3622,
   @rgrinberg)
 
+- Add (alias ...), (mode ...) fields to (copy_fields ...) stanza (#3631, @nojb)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1200,10 +1200,31 @@ The syntax is as follows:
 
 .. code:: scheme
 
-    (copy_files <glob>)
+    (copy_files
+     <optional-fields>
+     (glob <glob>))
 
 ``<glob>`` represents the set of files to copy, see the :ref:`glob
 <glob>` for details.
+
+``<optional-fields>`` are:
+
+- ``(alias <alias-name>)`` to specify an alias to which to attach the targets.
+
+- ``(mode <mode>)`` to specify how to handle the targets, see `modes`_
+  for details.
+
+The short form
+
+.. code:: scheme
+
+    (copy_files <glob>)
+
+is equivalent to
+
+.. code:: scheme
+
+    (copy_files (glob <glob>))
 
 The difference between ``copy_files`` and ``copy_files#`` is the same
 as the difference between the ``copy`` and ``copy#`` action. See the
@@ -1682,8 +1703,8 @@ mdx (since 2.4)
 ---------------
 
 MDX is a tool that helps you keep your markdown documentation up to date by
-checking that the code examples it contains are correct. When setting an MDX 
-stanza, the checks carried out by MDX are automatically attached to the 
+checking that the code examples it contains are correct. When setting an MDX
+stanza, the checks carried out by MDX are automatically attached to the
 ``runtest`` alias of the stanza's directory.
 
 See `MDX's repository <https://github.com/realworldocaml/mdx>`__ for more details.

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1202,7 +1202,7 @@ The syntax is as follows:
 
     (copy_files
      <optional-fields>
-     (glob <glob>))
+     (files <glob>))
 
 ``<glob>`` represents the set of files to copy, see the :ref:`glob
 <glob>` for details.
@@ -1224,7 +1224,7 @@ is equivalent to
 
 .. code:: scheme
 
-    (copy_files (glob <glob>))
+    (copy_files (files <glob>))
 
 The difference between ``copy_files`` and ``copy_files#`` is the same
 as the difference between the ``copy`` and ``copy#`` action. See the

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1736,15 +1736,17 @@ module Copy_files = struct
     }
 
   let long_form =
-    let+ alias = field_o "alias" Alias.Name.decode
-    and+ mode = field "mode" ~default:Rule.Mode.Standard Rule.Mode.decode
-    and+ files = field "files" String_with_vars.decode
+    let check = Dune_lang.Syntax.since Stanza.syntax (2, 7) in
+    let+ alias = field_o "alias" (check >>> Alias.Name.decode)
+    and+ mode =
+      field "mode" ~default:Rule.Mode.Standard (check >>> Rule.Mode.decode)
+    and+ files = field "files" (check >>> String_with_vars.decode)
     and+ syntax_version = Dune_lang.Syntax.get_exn Stanza.syntax in
     { add_line_directive = false; alias; mode; files; syntax_version }
 
   let decode =
     peek_exn >>= function
-    | List _ -> Dune_lang.Syntax.since Stanza.syntax (2, 7) >>> fields long_form
+    | List _ -> fields long_form
     | _ ->
       let+ files = String_with_vars.decode
       and+ syntax_version = Dune_lang.Syntax.get_exn Stanza.syntax in

--- a/src/dune/dune_file.ml
+++ b/src/dune/dune_file.ml
@@ -1731,27 +1731,27 @@ module Copy_files = struct
     { add_line_directive : bool
     ; alias : Alias.Name.t option
     ; mode : Rule.Mode.t
-    ; glob : String_with_vars.t
+    ; files : String_with_vars.t
     ; syntax_version : Dune_lang.Syntax.Version.t
     }
 
   let long_form =
     let+ alias = field_o "alias" Alias.Name.decode
     and+ mode = field "mode" ~default:Rule.Mode.Standard Rule.Mode.decode
-    and+ glob = field "glob" String_with_vars.decode
+    and+ files = field "files" String_with_vars.decode
     and+ syntax_version = Dune_lang.Syntax.get_exn Stanza.syntax in
-    { add_line_directive = false; alias; mode; glob; syntax_version }
+    { add_line_directive = false; alias; mode; files; syntax_version }
 
   let decode =
     peek_exn >>= function
     | List _ -> Dune_lang.Syntax.since Stanza.syntax (2, 7) >>> fields long_form
     | _ ->
-      let+ glob = String_with_vars.decode
+      let+ files = String_with_vars.decode
       and+ syntax_version = Dune_lang.Syntax.get_exn Stanza.syntax in
       { add_line_directive = false
       ; alias = None
       ; mode = Standard
-      ; glob
+      ; files
       ; syntax_version
       }
 end

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -260,7 +260,7 @@ module Copy_files : sig
     { add_line_directive : bool
     ; alias : Alias.Name.t option
     ; mode : Rule.Mode.t
-    ; glob : String_with_vars.t
+    ; files : String_with_vars.t
     ; syntax_version : Dune_lang.Syntax.Version.t
     }
 end

--- a/src/dune/dune_file.mli
+++ b/src/dune/dune_file.mli
@@ -255,6 +255,16 @@ module Menhir : sig
   type Stanza.t += T of t
 end
 
+module Copy_files : sig
+  type t =
+    { add_line_directive : bool
+    ; alias : Alias.Name.t option
+    ; mode : Rule.Mode.t
+    ; glob : String_with_vars.t
+    ; syntax_version : Dune_lang.Syntax.Version.t
+    }
+end
+
 module Rule : sig
   type t =
     { targets : String_with_vars.t Targets.t
@@ -278,14 +288,6 @@ module Alias_conf : sig
     ; package : Package.t option
     ; enabled_if : Blang.t
     ; loc : Loc.t
-    }
-end
-
-module Copy_files : sig
-  type t =
-    { add_line_directive : bool
-    ; glob : String_with_vars.t
-    ; syntax_version : Dune_lang.Syntax.Version.t
     }
 end
 

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -110,7 +110,7 @@ end = struct
       ; js = None
       ; source_dirs = None
       }
-    | Copy_files { glob; _ } ->
+    | Copy_files { files = glob; _ } ->
       let source_dir =
         let loc = String_with_vars.loc glob in
         let src_glob = Expander.expand_str expander glob in

--- a/src/dune/simple_rules.ml
+++ b/src/dune/simple_rules.ml
@@ -129,9 +129,9 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
       Path.Build.Set.empty )
 
 let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
-  let loc = String_with_vars.loc def.glob in
+  let loc = String_with_vars.loc def.files in
   let glob_in_src =
-    let src_glob = Expander.expand_str expander def.glob in
+    let src_glob = Expander.expand_str expander def.files in
     Path.Source.relative src_dir src_glob ~error_loc:loc
   in
   let since = (1, 3) in
@@ -146,9 +146,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
            (Path.Source.to_string_maybe_quoted src_dir));
   let src_in_src = Path.Source.parent_exn glob_in_src in
   let pred =
-    Path.Source.basename glob_in_src
-    |> Glob.of_string_exn (String_with_vars.loc def.glob)
-    |> Glob.to_pred
+    Path.Source.basename glob_in_src |> Glob.of_string_exn loc |> Glob.to_pred
   in
   if not (File_tree.dir_exists src_in_src) then
     User_error.raise ~loc

--- a/test/blackbox-tests/test-cases/copy_files.t/run.t
+++ b/test/blackbox-tests/test-cases/copy_files.t/run.t
@@ -10,3 +10,37 @@ Test that (copy_files ...) works
   Entering directory 'test2'
   # 1 "dummy.txt"
   hello
+
+Test (alias ...) and (mode ...) fields:
+
+  $ mkdir -p test3
+  $ cat >test3/dune-project <<EOF
+  > (lang dune 2.6)
+  > EOF
+  $ cat >test3/dune <<EOF
+  > (copy_files
+  >  (alias foo)
+  >  (mode promote-until-clean)
+  >  (files subdir/*.txt))
+  > EOF
+  $ mkdir -p test3/subdir
+  $ echo Foo >test3/subdir/foo.txt
+
+  $ dune build --root test3 @foo
+  Entering directory 'test3'
+  File "dune", line 2, characters 1-12:
+  2 |  (alias foo)
+       ^^^^^^^^^^^
+  Error: 'alias' is only available since version 2.7 of the dune language.
+  Please update your dune-project file to have (lang dune 2.7).
+  [1]
+
+  $ cat >test3/dune-project <<EOF
+  > (lang dune 2.7)
+  > EOF
+
+  $ dune build --root test3 @foo
+  Entering directory 'test3'
+
+  $ cat test3/foo.txt
+  Foo


### PR DESCRIPTION
What the title says:

- `(alias ...)` field to specify an alias to which to attach the `copy_files` stanza's targets.
- `(mode ...)` field with the same semantics as the one appearing in `(rule ...)`.

The full syntax looks like:
```
(copy_files
 (alias foo)
 (mode promote-until-clean)
 (glob <glob>))
```
(maybe `glob` should be called `names`).

What do you think?