### PR TITLE
Remove setenv from findlib test

### DIFF
--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1815,12 +1815,9 @@
   (source_tree test-cases/jsoo/github3622.t)
   (alias test-deps))
  (action
-  (setenv
-   NODE
-   %{bin:node}
-   (chdir
-    test-cases/jsoo/github3622.t
-    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected))))))
+  (chdir
+   test-cases/jsoo/github3622.t
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
  (alias jsoo-inline-tests)
@@ -1829,12 +1826,9 @@
   (source_tree test-cases/jsoo/inline-tests.t)
   (alias test-deps))
  (action
-  (setenv
-   NODE
-   %{bin:node}
-   (chdir
-    test-cases/jsoo/inline-tests.t
-    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected))))))
+  (chdir
+   test-cases/jsoo/inline-tests.t
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
  (alias jsoo-simple)
@@ -1843,12 +1837,9 @@
   (source_tree test-cases/jsoo/simple.t)
   (alias test-deps))
  (action
-  (setenv
-   NODE
-   %{bin:node}
-   (chdir
-    test-cases/jsoo/simple.t
-    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected))))))
+  (chdir
+   test-cases/jsoo/simple.t
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
  (alias lib)

--- a/test/blackbox-tests/dune.inc
+++ b/test/blackbox-tests/dune.inc
@@ -1317,12 +1317,9 @@
  (alias github25)
  (deps (package dune) (source_tree test-cases/github25.t) (alias test-deps))
  (action
-  (setenv
-   OCAMLPATH
-   ./findlib-packages
-   (chdir
-    test-cases/github25.t
-    (progn (run dune-cram run run.t) (diff? run.t run.t.corrected))))))
+  (chdir
+   test-cases/github25.t
+   (progn (run dune-cram run run.t) (diff? run.t run.t.corrected)))))
 
 (rule
  (alias github2584)

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -63,7 +63,6 @@ module Test = struct
 
   type t =
     { path : string
-    ; env : (string * Dune_lang.t) option
     ; only_ocaml : (string * string) option
     ; skip_platforms : Platform.t list
     ; enabled : bool
@@ -108,12 +107,11 @@ module Test = struct
 
   let dir t = Filename.dirname t.path
 
-  let make ?env ?only_ocaml ?(skip_platforms = []) ?(enabled = true)
-      ?(js = false) ?(coq = false) ?(external_deps = false)
-      ?(disable_sandboxing = false) ?(additional_deps = []) path =
+  let make ?only_ocaml ?(skip_platforms = []) ?(enabled = true) ?(js = false)
+      ?(coq = false) ?(external_deps = false) ?(disable_sandboxing = false)
+      ?(additional_deps = []) path =
     let external_deps = external_deps || coq || js in
     { path
-    ; env
     ; only_ocaml
     ; skip_platforms
     ; external_deps
@@ -124,9 +122,9 @@ module Test = struct
     ; additional_deps
     }
 
-  let make_run_t ?env ?only_ocaml ?skip_platforms ?enabled ?js ?coq
-      ?external_deps ?disable_sandboxing ?additional_deps path =
-    make ?env ?only_ocaml ?skip_platforms ?enabled ?js ?coq ?external_deps
+  let make_run_t ?only_ocaml ?skip_platforms ?enabled ?js ?coq ?external_deps
+      ?disable_sandboxing ?additional_deps path =
+    make ?only_ocaml ?skip_platforms ?enabled ?js ?coq ?external_deps
       ?disable_sandboxing ?additional_deps
       (Filename.concat root_dir (Filename.concat path "run.t"))
 
@@ -154,12 +152,6 @@ module Test = struct
             ; Sexp.strings [ "diff?"; filename; filename ^ ".corrected" ]
             ]
         ]
-    in
-    let action =
-      match t.env with
-      | None -> action
-      | Some (k, v) ->
-        List [ atom "setenv"; atom_or_quoted_string k; v; action ]
     in
     let enabled_if =
       match t.only_ocaml with
@@ -209,7 +201,7 @@ let exclusions =
   in
   let jsoo name =
     let name = Filename.concat "jsoo" name in
-    make ~external_deps:true name ~env:("NODE", Sexp.parse "%{bin:node}")
+    make ~external_deps:true name
   in
   let cinaps name =
     let name = Filename.concat "cinaps" name in

--- a/test/blackbox-tests/gen_tests.ml
+++ b/test/blackbox-tests/gen_tests.ml
@@ -220,7 +220,7 @@ let exclusions =
   ; jsoo "github3622.t"
   ; coq "main.t"
   ; coq "extract.t"
-  ; make "github25.t" ~env:("OCAMLPATH", Dune_lang.atom "./findlib-packages")
+  ; make "github25.t"
   ; odoc "odoc-simple.t"
   ; odoc "odoc-package-mld-link.t"
   ; odoc "odoc-unique-mlds.t"

--- a/test/blackbox-tests/test-cases/github25.t/run.t
+++ b/test/blackbox-tests/test-cases/github25.t/run.t
@@ -6,6 +6,8 @@ problem. So dune shouldn't crash because of "plop.ca-marche-pas"
 
 We need ocamlfind to run this test
 
+  $ export OCAMLPATH="./findlib-packages"
+
   $ dune build @install --only hello
 
   $ dune build @install --only pas-de-bol 2>&1 | sed 's/[^ "]*findlib-packages/.../'

--- a/test/blackbox-tests/test-cases/jsoo/github3622.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/github3622.t/run.t
@@ -15,13 +15,13 @@ Setup fixtures:
 Test without separate compilation:
 
   $ dune build --profile=release ./main.bc.js
-  $ $NODE _build/default/main.bc.js
+  $ node _build/default/main.bc.js
   bla
 
 Test with separate compilation:
 
   $ dune build --profile=dev ./main.bc.js
-  $ $NODE _build/default/main.bc.js
+  $ node _build/default/main.bc.js
   bla
 
 The result should be the same

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
@@ -31,7 +31,7 @@ Compilation using jsoo
       ocamlopt lib/x.cmxs
    js_of_ocaml bin/.technologic.eobjs/byte/technologic.cmo.js
    js_of_ocaml bin/technologic.bc.js
-  $ $NODE ./_build/default/bin/technologic.bc.js
+  $ node ./_build/default/bin/technologic.bc.js
   buy it
   use it
   break it
@@ -50,7 +50,7 @@ Compilation using jsoo
       ocamlopt lib/x.cmxs
         ocamlc bin/technologic.bc
    js_of_ocaml bin/technologic.bc.js
-  $ $NODE ./_build/default/bin/technologic.bc.js
+  $ node ./_build/default/bin/technologic.bc.js
   buy it
   use it
   break it


### PR DESCRIPTION
It's clearer to set the environment from the test itself. Also, it makes
it simpler to port to the cram stanza.