### PR TITLE
(copy_files ...): support external paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@ next
 
 - Add (alias ...), (mode ...) fields to (copy_fields ...) stanza (#3631, @nojb)
 
+- (copy_files ...) now supports copying files from outside the workspace using
+  absolute file names (#3639, @nojb)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/gen_rules.ml
+++ b/src/dune/gen_rules.ml
@@ -111,13 +111,17 @@ end = struct
       ; source_dirs = None
       }
     | Copy_files { files = glob; _ } ->
-      let source_dir =
+      let source_dirs =
         let loc = String_with_vars.loc glob in
         let src_glob = Expander.expand_str expander glob in
-        Path.Source.relative src_dir src_glob ~error_loc:loc
-        |> Path.Source.parent_exn
+        if Filename.is_relative src_glob then
+          Some
+            ( Path.Source.relative src_dir src_glob ~error_loc:loc
+            |> Path.Source.parent_exn )
+        else
+          None
       in
-      { merlin = None; cctx = None; js = None; source_dirs = Some source_dir }
+      { merlin = None; cctx = None; js = None; source_dirs }
     | Install i ->
       files_to_install i;
       empty_none

--- a/test/blackbox-tests/test-cases/copy_files.t/run.t
+++ b/test/blackbox-tests/test-cases/copy_files.t/run.t
@@ -44,3 +44,19 @@ Test (alias ...) and (mode ...) fields:
 
   $ cat test3/foo.txt
   Foo
+
+Test external paths:
+
+  $ mkdir -p test4
+  $ cat >test4/dune-project <<EOF
+  > (lang dune 2.7)
+  > EOF
+  $ P=$(mktemp)
+  $ echo Hola > $P
+  $ cat >test4/dune <<EOF
+  > (copy_files $P)
+  > EOF
+  $ dune build --root test4 $(basename $P)
+  Entering directory 'test4'
+  $ cat test4/_build/default/$(basename $P)
+  Hola


### PR DESCRIPTION
This PR adds support for copying files from outside of the workspace in `(copy_files ...)` (using absolute paths). This is currently unsupported (in fact, it causes a hard crash with backtrace).

Looks like it is working in simple cases, but a second opinion appreciated! 
