### PR TITLE
Revert optimization introduced in #2268

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@ next
   Configuration flags `ocamlc_cflags` and `ocamlc_cppflags` are always prepended
   to the compiler arguments. (#3565, fixes #3346, @voodoos)
 
+- Revert the build optimization in #2268. This optimization slows down building
+  individual executables when they're part of an `executables` stanza group
+  (#3644, @rgrinberg)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/exe.ml
+++ b/src/dune/exe.ml
@@ -139,16 +139,8 @@ let link_exe ~loc ~name ~(linkage : Linkage.t) ~cm_files ~link_time_code_gen
       | Some p -> Promote p )
     (let ocaml_flags = Ocaml_flags.get (CC.flags cctx) mode in
      let prefix =
-       let dune_version =
-         let scope = CC.scope cctx in
-         let project = Scope.project scope in
-         Dune_project.dune_version project
-       in
-       if dune_version >= (2, 0) then
-         Cm_files.unsorted_objects_and_cms cm_files ~mode |> Build.paths
-       else
-         Cm_files.top_sorted_objects_and_cms cm_files ~mode
-         |> Build.dyn_paths_unit
+       Cm_files.top_sorted_objects_and_cms cm_files ~mode
+       |> Build.dyn_paths_unit
      in
      let open Build.With_targets.O in
      (* NB. Below we take care to pass [link_args] last on the command-line for

--- a/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
@@ -8,9 +8,9 @@ Run inline tests using node js
   inline_test_runner_inline_tests_byte alias byte/runtest
   inline tests (Byte)
   inline tests (Byte)
-  inline_test_runner_inline_tests_native alias native/runtest
-  inline tests (Native)
-  inline tests (Native)
           node alias js/runtest
   inline tests (JS)
   inline tests (JS)
+  inline_test_runner_inline_tests_native alias native/runtest
+  inline tests (Native)
+  inline tests (Native)

--- a/test/blackbox-tests/test-cases/plugin-mode.t/run.t
+++ b/test/blackbox-tests/test-cases/plugin-mode.t/run.t
@@ -80,35 +80,35 @@ Testsuite for (mode plugin).
   > EOF
 
   $ dune build --display short @all 2>&1 | dune_cmd sanitize
-      ocamldep foo/.foo.objs/foo.ml.d
       ocamldep $ext_lib.eobjs/a.ml.d
-      ocamldep foo/.bar.objs/bar.ml.d
+      ocamldep foo/.foo.objs/foo.ml.d
       ocamldep .b.eobjs/b.ml.d
+      ocamldep foo/.bar.objs/bar.ml.d
       ocamldep main/.main.eobjs/main.ml.d
       ocamldep main2/.main.eobjs/main.ml.d
         ocamlc foo/.foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc main2/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
-        ocamlc $ext_lib.eobjs/byte/dune__exe__A.{cmi,cmo,cmt}
-        ocamlc foo/.bar.objs/byte/bar.{cmi,cmo,cmt}
-        ocamlc main/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
       ocamlopt foo/.foo.objs/native/foo.{cmx,o}
+        ocamlc foo/.bar.objs/byte/bar.{cmi,cmo,cmt}
+        ocamlc $ext_lib.eobjs/byte/dune__exe__A.{cmi,cmo,cmt}
         ocamlc foo/foo.cma
       ocamlopt main2/.main.eobjs/native/dune__exe__Main.{cmx,o}
-      ocamlopt $ext_lib.eobjs/native/dune__exe__A.{cmx,o}
-        ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
+      ocamlopt foo/foo.{a,cmxa}
       ocamlopt foo/.bar.objs/native/bar.{cmx,o}
         ocamlc foo/bar.cma
-      ocamlopt main/.main.eobjs/native/dune__exe__Main.{cmx,o}
-      ocamlopt foo/foo.{a,cmxa}
+      ocamlopt $ext_lib.eobjs/native/dune__exe__A.{cmx,o}
       ocamlopt main2/main.exe
-      ocamlopt a.cmxs
-      ocamlopt .b.eobjs/native/dune__exe__B.{cmx,o}
-      ocamlopt foo/bar.{a,cmxa}
-      ocamlopt a.exe
+        ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
       ocamlopt foo/foo.cmxs
-      ocamlopt main/main.exe
-      ocamlopt b.cmxs
+        ocamlc main/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
+      ocamlopt foo/bar.{a,cmxa}
+      ocamlopt a.cmxs
+      ocamlopt a.exe
+      ocamlopt .b.eobjs/native/dune__exe__B.{cmx,o}
+      ocamlopt main/.main.eobjs/native/dune__exe__Main.{cmx,o}
       ocamlopt foo/bar.cmxs
+      ocamlopt b.cmxs
+      ocamlopt main/main.exe
 
   $ (cd _build/default && main/main.exe)
   12


### PR DESCRIPTION
This optimization makes dune build too much when multiple executables
are defined in a single stanza.