### PR TITLE
Opam file generation: Use {dev} instead of {pinned} when calling dune subst

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,9 @@ next
   individual executables when they're part of an `executables` stanza group
   (#3644, @rgrinberg)
 
+- Use `{dev}` rather than `{pinned}` in the generated `.opam` file. (#3647,
+  @kit-ty-kate)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/dune-action-plugin.opam
+++ b/dune-action-plugin.opam
@@ -24,7 +24,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-build-info.opam
+++ b/dune-build-info.opam
@@ -20,7 +20,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -22,7 +22,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-glob.opam
+++ b/dune-glob.opam
@@ -15,7 +15,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-private-libs.opam
+++ b/dune-private-libs.opam
@@ -22,7 +22,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-private-libs.opam.template
+++ b/dune-private-libs.opam.template
@@ -1,5 +1,5 @@
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/src/dune/opam_create.ml
+++ b/src/dune/opam_create.ml
@@ -13,7 +13,7 @@ let default_build_command =
   [ "dune" "build" "-p" name "@doc"] {with-doc}
 ]
 |}))
-  and from_1_11 =
+  and from_1_11_before_2_7 =
     lazy
       (Opam_file.parse_value
          (Lexbuf.from_string ~fname:"<internal>"
@@ -27,13 +27,29 @@ let default_build_command =
   ]
 ]
 |}))
+  and from_2_7 =
+    lazy
+      (Opam_file.parse_value
+         (Lexbuf.from_string ~fname:"<internal>"
+            {|
+[
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+  ]
+]
+|}))
   in
   fun project ->
     Lazy.force
       ( if Dune_project.dune_version project < (1, 11) then
-        before_1_11
-      else
-        from_1_11 )
+          before_1_11
+        else if Dune_project.dune_version project < (2, 7) then
+          from_1_11_before_2_7
+        else
+          from_2_7 )
 
 let package_fields
     { Package.synopsis

--- a/test/blackbox-tests/test-cases/dune-project-meta/main/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/main/run.t
@@ -397,3 +397,30 @@ Same with version of the language >= 2.6, we now add the constraint:
   depends: [
     "dune" {>= "2.6"}
   ]
+
+When the version of the language >= 2.7 we use dev instead of pinned
+when calling dune subst:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A13 ^build: foo.opam
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+  ]


### PR DESCRIPTION
I'm not sure why I hadn't realized that before but the way opam packages are generated currently does not seem quite right.
In particular, if I'm correct `dune subst` should only be called when users are building a project from its git repository. Currently it is called if someone pins the package but pinned packages can be releases, they are not necessarily in a "dev state".

The [opam manual](https://opam.ocaml.org/doc/Manual.html#Package-variables) defines `{dev}` and `{pinned}` the following ways:
* `{pinned}`: whether the package is pinned
* `{dev}`: true if this is a development package, i.e. it was not built from a release archive

See https://github.com/ocaml/opam/blob/2.0/src/state/opamSwitchState.ml#L393 for the implementation details