### PR TITLE
Fix odoc warnings

### DIFF
--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1143,7 +1143,7 @@ let rec rm_rf fn =
   | _ -> Unix.unlink fn
   | exception Unix.Unix_error (ENOENT, _, _) -> ()
 
-(** {2 Bootstrap process *)
+(** {2 Bootstrap process} *)
 let main () =
   rm_rf build_dir;
   Unix.mkdir build_dir 0o777;

--- a/otherlibs/action-plugin/src/dune_action_plugin.mli
+++ b/otherlibs/action-plugin/src/dune_action_plugin.mli
@@ -48,11 +48,25 @@ module V1 : sig
   (** Syntax sugar for applicative subset of the interface. Syntax sugar for
       [stage] is not provided to prevent accidental use.*)
   module O : sig
-    (** {[ let+ a = g in h ]} is equivalent to {[ map g ~f:(fun a -> g) ]}. *)
+    (** {[
+          let+ a = g in
+          h
+        ]}
+
+        is equivalent to:
+
+        {[ map g ~f:(fun a -> g) ]} *)
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
 
-    (** {[ let+ a1 = g1 and+ a2 = g2 in h ]} is equivalent to {[ both g1 g2 |>
-        map ~f:(fun (a1, a2) -> g) ]}. *)
+    (** {[
+          let+ a1 = g1
+          and+ a2 = g2 in
+          h
+        ]}
+
+        is equivalent to:
+
+        {[ both g1 g2 |> map ~f:(fun (a1, a2) -> g) ]} *)
     val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
   end
 

--- a/otherlibs/action-plugin/src/dune_action_plugin.mli
+++ b/otherlibs/action-plugin/src/dune_action_plugin.mli
@@ -55,7 +55,7 @@ module V1 : sig
 
         is equivalent to:
 
-        {[ map g ~f:(fun a -> g) ]} *)
+        {[ map g ~f:(fun a -> h) ]} *)
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
 
     (** {[
@@ -66,7 +66,7 @@ module V1 : sig
 
         is equivalent to:
 
-        {[ both g1 g2 |> map ~f:(fun (a1, a2) -> g) ]} *)
+        {[ both g1 g2 |> map ~f:(fun (a1, a2) -> h) ]} *)
     val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
   end
 

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -143,8 +143,9 @@ module Process : sig
       status together with the content of stdout and stderr. The action is
       logged.
 
-      @param dir change to [dir] before running the command. @param env specify
-      additional environment variables as a list of the form NAME=VALUE. *)
+      @param dir change to [dir] before running the command.
+      @param env specify additional environment variables as a list of the form
+      NAME=VALUE. *)
   val run :
     t -> ?dir:string -> ?env:string list -> string -> string list -> result
 

--- a/src/dune/ordered_set_lang.mli
+++ b/src/dune/ordered_set_lang.mli
@@ -82,7 +82,7 @@ module Unexpanded : sig
 
   (** Fold a function over all strings in a set. The callback receive whether
       the string is in position or negative position, i.e. on the left or right
-      of a [\] operator. *)
+      of a \ operator. *)
   val fold_strings :
     t -> init:'a -> f:(position -> String_with_vars.t -> 'a -> 'a) -> 'a
 end


### PR DESCRIPTION
These happen when running `make fmt`.