### PR TITLE
Fix typo in `(cache-check-probablity)`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@ next
 - Fix crash when evaluating an `mdx` stanza that depends on unavailable
   packages. (#3650, @CraigFe)
 
+- Fix typo in `cache-check-probablity` field in dune config files. This field
+  now requires 2.7 as it wasn't usable before this version. (#3652, @edwintorok)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/config.ml
+++ b/src/dune/config.ml
@@ -263,8 +263,8 @@ let decode =
       (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Caching.Transport.decode)
       ~default:default.cache_transport
   and+ cache_check_probability =
-    field "cache-check-probablity"
-      (Dune_lang.Syntax.since Stanza.syntax (2, 0) >>> Dune_lang.Decoder.float)
+    field "cache-check-probability"
+      (Dune_lang.Syntax.since Stanza.syntax (2, 7) >>> Dune_lang.Decoder.float)
       ~default:default.cache_check_probability
   and+ cache_duplication =
     field "cache-duplication"


### PR DESCRIPTION
I was trying to use it as documented here, but there is a typo when used as a config file entry (the cmdline entry and the doc seems fine):
https://dune.readthedocs.io/en/stable/caching.html#reproducibility-check

Considering that the version with the typo is already released, fixing the typo would break user's configurations (hopefully those users would've raised an issue/PR like I did though), so not sure how you want to handle backwards compatibility on this one.