### PR TITLE
Private libraries attached to a package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,10 @@ Unreleased
 - Fix cram tests inside vendored directories not being interpreted correctly.
   (@rgrinberg, #3860)
 
+- Add `package` field to private libraries. This allows such libraries to be
+  installed and to be usable by other public libraries in the same project
+  (#3655, fixes #1017, @rgrinberg)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -356,6 +356,12 @@ to use the :ref:`include_subdirs` stanza.
   want. The package name must be one of the packages that dune knows about,
   as determined by the :ref:`opam-files`
 
+- ``(package <package>)`` Install private library under the specified package.
+  Such a library is now usable by public libraries defined in the same project.
+  The findlib name for this library will be ``<package>.__private__.<name>``,
+  however the library's interface will be hidden from consumers outside the
+  project.
+
 - ``(synopsis <string>)`` should give a one-line description of the library.
   This is used by tools that list installed libraries
 

--- a/src/dune_engine/lib_name.mli
+++ b/src/dune_engine/lib_name.mli
@@ -11,6 +11,8 @@ module Local : sig
 
   (** Description of valid library names *)
   val valid_format_doc : User_message.Style.t Pp.t
+
+  val mangled_path_under_package : t -> string list
 end
 
 val compare : t -> t -> Ordering.t
@@ -21,11 +23,21 @@ val of_local : Loc.t * Local.t -> t
 
 val to_local : Loc.t * t -> (Local.t, User_message.t) result
 
+val to_local_exn : t -> Local.t
+
 val split : t -> Package.Name.t * string list
 
 val package_name : t -> Package.Name.t
 
 val of_package_name : Package.Name.t -> t
+
+type analyze =
+  | Public of Package.Name.t * string list
+  | Private of Package.Name.t * Local.t
+
+val analyze : t -> analyze
+
+val mangled : Package.Name.t -> Local.t -> t
 
 module Map : Map.S with type key = t
 

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -6,12 +6,12 @@ module SC = Super_context
 module Includes = struct
   type t = Command.Args.dynamic Command.Args.t Cm_kind.Dict.t
 
-  let make ~opaque ~requires : _ Cm_kind.Dict.t =
+  let make ~project ~opaque ~requires : _ Cm_kind.Dict.t =
     match requires with
     | Error exn ->
       Cm_kind.Dict.make_all (Command.Args.Fail { fail = (fun () -> raise exn) })
     | Ok libs ->
-      let iflags = Lib.L.include_flags libs in
+      let iflags = Lib.L.include_flags ~project libs in
       let cmi_includes =
         Command.Args.memo
           (Command.Args.S
@@ -118,8 +118,9 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
     ~requires_compile ~requires_link ?(preprocessing = Preprocessing.dummy)
     ~opaque ?stdlib ~js_of_ocaml ~dynlink ~package ?vimpl ?modes
     ?(bin_annot = true) () =
+  let project = Scope.project scope in
   let requires_compile =
-    if Dune_project.implicit_transitive_deps (Scope.project scope) then
+    if Dune_project.implicit_transitive_deps project then
       Lazy.force requires_link
     else
       requires_compile
@@ -146,7 +147,7 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
   ; flags
   ; requires_compile
   ; requires_link
-  ; includes = Includes.make ~opaque ~requires:requires_compile
+  ; includes = Includes.make ~project ~opaque ~requires:requires_compile
   ; preprocessing
   ; opaque
   ; stdlib

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -507,7 +507,7 @@ module Library = struct
 
   type visibility =
     | Public of Public_lib.t
-    | Private
+    | Private of Package.t option
 
   type t =
     { name : Loc.t * Lib_name.Local.t
@@ -609,6 +609,10 @@ module Library = struct
          field_o "instrumentation.backend"
            ( Dune_lang.Syntax.since Stanza.syntax (2, 7)
            >>> fields (field "ppx" (located Lib_name.decode)) )
+       and+ package =
+         field_o "package"
+           ( Dune_lang.Syntax.since Stanza.syntax (2, 8)
+           >>> located Stanza_common.Pkg.decode )
        in
        let wrapped =
          Wrapped.make ~wrapped ~implements ~special_builtin_support
@@ -646,9 +650,17 @@ module Library = struct
              ]
        in
        let visibility =
-         match public with
-         | None -> Private
-         | Some public -> Public public
+         match (public, package) with
+         | None, None -> Private None
+         | Some public, None -> Public public
+         | None, Some (_loc, package) -> Private (Some package)
+         | Some public, Some (loc, _) ->
+           User_error.raise ~loc
+             [ Pp.textf
+                 "This library has a pullic_name, it already belongs to the \
+                  package %s"
+                 (Package.Name.to_string public.package.name)
+             ]
        in
        Option.both virtual_modules implements
        |> Option.iter ~f:(fun (virtual_modules, (_, impl)) ->
@@ -694,12 +706,15 @@ module Library = struct
   let package t =
     match t.visibility with
     | Public p -> Some p.package
-    | Private -> None
+    | Private p -> p
 
   let sub_dir t =
     match t.visibility with
     | Public p -> p.sub_dir
-    | Private -> None
+    | Private None -> None
+    | Private (Some _) ->
+      Lib_name.Local.mangled_path_under_package (snd t.name)
+      |> String.concat ~sep:"/" |> Option.some
 
   let has_foreign t = Buildable.has_foreign t.buildable
 
@@ -723,7 +738,7 @@ module Library = struct
 
   let best_name t =
     match t.visibility with
-    | Private -> Lib_name.of_local t.name
+    | Private _ -> Lib_name.of_local t.name
     | Public p -> snd p.name
 
   let is_virtual t = Option.is_some t.virtual_modules
@@ -731,9 +746,16 @@ module Library = struct
   let is_impl t = Option.is_some t.implements
 
   let obj_dir ~dir t =
+    let private_lib =
+      match t.visibility with
+      | Private (Some _) -> true
+      | Private None
+      | Public _ ->
+        false
+    in
     Obj_dir.make_lib ~dir
       ~has_private_modules:(t.private_modules <> None)
-      (snd t.name)
+      ~private_lib (snd t.name)
 
   let main_module_name t : Lib_info.Main_module_name.t =
     match (t.implements, t.wrapped) with
@@ -772,7 +794,7 @@ module Library = struct
     in
     let status =
       match conf.visibility with
-      | Private -> Lib_info.Status.Private conf.project
+      | Private pkg -> Lib_info.Status.Private (conf.project, pkg)
       | Public p -> Public (conf.project, p.package)
     in
     let virtual_library = is_virtual conf in
@@ -835,6 +857,7 @@ module Library = struct
     let version =
       match status with
       | Public (_, pkg) -> pkg.version
+      | Installed_private
       | Installed
       | Private _ ->
         None
@@ -1897,19 +1920,22 @@ module Library_redirect = struct
 
     let of_lib (lib : Library.t) : t option =
       let open Option.O in
-      let* public =
+      let* public_name =
         match lib.visibility with
-        | Public p -> Some p
-        | Private -> None
+        | Public plib -> Some plib.name
+        | Private None -> None
+        | Private (Some package) ->
+          let loc, name = lib.name in
+          Some (loc, Lib_name.mangled package.name name)
       in
-      if Lib_name.equal (Lib_name.of_local lib.name) (snd public.name) then
+      if Lib_name.equal (Lib_name.of_local lib.name) (snd public_name) then
         None
       else
         Some
           { loc = Loc.none
           ; project = lib.project
           ; old_name = lib.name
-          ; new_public_name = public.name
+          ; new_public_name = public_name
           }
   end
 end

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -114,7 +114,7 @@ end
 module Library : sig
   type visibility =
     | Public of Public_lib.t
-    | Private
+    | Private of Package.t option
 
   type t =
     { name : Loc.t * Lib_name.Local.t

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -365,6 +365,8 @@ module Library_redirect : sig
 
   module Local : sig
     type nonrec t = (Loc.t * Lib_name.Local.t) t
+
+    val of_private_lib : Library.t -> t option
   end
 end
 

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -156,7 +156,11 @@ module Lib = struct
        let info : Path.t Lib_info.t =
          let src_dir = Obj_dir.dir obj_dir in
          let enabled = Lib_info.Enabled_status.Normal in
-         let status = Lib_info.Status.Installed in
+         let status =
+           match Lib_name.analyze name with
+           | Private (_, _) -> Lib_info.Status.Installed_private
+           | Public (_, _) -> Lib_info.Status.Installed
+         in
          let version = None in
          let main_module_name = Lib_info.Inherited.This main_module_name in
          let foreign_objects = Lib_info.Source.External foreign_objects in

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -297,7 +297,11 @@ end = struct
         let kind = kind t in
         let sub_systems = Sub_system_name.Map.empty in
         let synopsis = description t in
-        let status = Lib_info.Status.Installed in
+        let status =
+          match Lib_name.analyze t.name with
+          | Private (_, _) -> Lib_info.Status.Installed_private
+          | Public (_, _) -> Lib_info.Status.Installed
+        in
         let src_dir = Obj_dir.dir obj_dir in
         let version = version t in
         let dune_version = None in

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -381,7 +381,15 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
         | None -> true
         | Some package -> Package.Name.Map.mem visible_pkgs package.name
       in
-      Option.some_if include_stanza stanza)
+      if include_stanza then
+        Some stanza
+      else
+        match stanza with
+        | Library l ->
+          let open Option.O in
+          let+ redirect = Dune_file.Library_redirect.Local.of_private_lib l in
+          Dune_file.Library_redirect redirect
+        | _ -> None)
 
 let gen ~contexts ?only_packages conf =
   let open Fiber.O in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1022,6 +1022,9 @@ end = struct
     let status = Lib_info.status info in
     let private_deps =
       match status with
+      (* [Allow_all] is used for libraries that are installed because we don't
+         have to check it again. It has been checked when compiling the
+         libraries before their installation *)
       | Installed_private
       | Private _
       | Installed ->

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -66,9 +66,9 @@ module L : sig
 
   val to_iflags : Path.Set.t -> _ Command.Args.t
 
-  val include_paths : t -> Path.Set.t
+  val include_paths : ?project:Dune_project.t -> t -> Path.Set.t
 
-  val include_flags : t -> _ Command.Args.t
+  val include_flags : ?project:Dune_project.t -> t -> _ Command.Args.t
 
   val c_include_flags : t -> _ Command.Args.t
 
@@ -174,12 +174,17 @@ module DB : sig
   val create :
        parent:t option
     -> resolve:(Lib_name.t -> Resolve_result.t)
+    -> projects_by_package:Dune_project.t Package.Name.Map.t
     -> all:(unit -> Lib_name.t list)
     -> lib_config:Lib_config.t
     -> unit
     -> t
 
-  val create_from_findlib : lib_config:Lib_config.t -> Findlib.t -> t
+  val create_from_findlib :
+       lib_config:Lib_config.t
+    -> projects_by_package:Dune_project.t Package.Name.Map.t
+    -> Findlib.t
+    -> t
 
   val find : t -> Lib_name.t -> lib option
 

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -11,9 +11,10 @@ open Stdune
 
 module Status : sig
   type t =
+    | Installed_private
     | Installed
     | Public of Dune_project.t * Package.t
-    | Private of Dune_project.t
+    | Private of Dune_project.t * Package.t option
 
   val is_private : t -> bool
 
@@ -175,6 +176,7 @@ val set_version : 'a t -> string option -> 'a t
 
 val for_dune_package :
      Path.t t
+  -> name:Lib_name.t
   -> ppx_runtime_deps:(Loc.t * Lib_name.t) list
   -> requires:Lib_dep.t list
   -> foreign_objects:Path.t list

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -135,7 +135,9 @@ let build_info_code cctx ~libs ~api_version =
           | Some v -> sprintf "Some %S" v
           | None -> (
             match Lib_info.status (Lib.info lib) with
-            | Installed -> "None"
+            | Installed_private
+            | Installed ->
+              "None"
             | Public (_, p) -> version_of_package p
             | Private _ ->
               let p =

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -22,24 +22,32 @@ module External = struct
   type t =
     { public_dir : Path.t
     ; private_dir : Path.t option
+    ; public_cmi_dir : Path.t option
     }
 
-  let make ~dir ~has_private_modules =
+  let make ~dir ~has_private_modules ~private_lib =
     let private_dir =
       if has_private_modules then
         Some (Path.relative dir ".private")
       else
         None
     in
-    { public_dir = dir; private_dir }
+    let public_cmi_dir =
+      if private_lib then
+        Some (Path.relative dir ".public_cmi")
+      else
+        None
+    in
+    { public_dir = dir; private_dir; public_cmi_dir }
 
-  let public_cmi_dir t = t.public_dir
+  let public_cmi_dir t = Option.value ~default:t.public_dir t.public_cmi_dir
 
-  let to_dyn { public_dir; private_dir } =
+  let to_dyn { public_dir; private_dir; public_cmi_dir } =
     let open Dyn.Encoder in
     record
       [ ("public_dir", Path.to_dyn public_dir)
       ; ("private_dir", option Path.to_dyn private_dir)
+      ; ("public_cmi_dir", option Path.to_dyn public_cmi_dir)
       ]
 
   let cm_dir t (cm_kind : Cm_kind.t) (visibility : Visibility.t) =
@@ -47,25 +55,30 @@ module External = struct
     | Cmi, Private, Some p -> p
     | Cmi, Private, None ->
       Code_error.raise "External.cm_dir" [ ("t", to_dyn t) ]
-    | Cmi, Public, _
-    | (Cmo | Cmx), _, _ ->
-      t.public_dir
+    | Cmi, Public, _ -> public_cmi_dir t
+    | (Cmo | Cmx), _, _ -> t.public_dir
 
-  let encode { public_dir; private_dir } =
+  let encode { public_dir; private_dir; public_cmi_dir } =
     let open Dune_lang.Encoder in
     let extract d =
       Path.descendant ~of_:public_dir d |> Option.value_exn |> Path.to_string
     in
     let private_dir = Option.map ~f:extract private_dir in
-    record_fields [ field_o "private_dir" string private_dir ]
+    let public_cmi_dir = Option.map ~f:extract public_cmi_dir in
+    record_fields
+      [ field_o "private_dir" string private_dir
+      ; field_o "public_cmi_dir" string public_cmi_dir
+      ]
 
   let decode ~dir =
+    let public_dir = dir in
     let open Dune_lang.Decoder in
     fields
-      (let+ private_dir = field_o "private_dir" string in
-       let public_dir = dir in
+      (let+ private_dir = field_o "private_dir" string
+       and+ public_cmi_dir = field_o "public_cmi_dir" string in
        let private_dir = Option.map ~f:(Path.relative dir) private_dir in
-       { public_dir; private_dir })
+       let public_cmi_dir = Option.map ~f:(Path.relative dir) public_cmi_dir in
+       { public_dir; private_dir; public_cmi_dir })
 
   let byte_dir t = t.public_dir
 
@@ -79,8 +92,8 @@ module External = struct
 
   let all_obj_dirs t ~mode:_ = [ t.public_dir ]
 
-  let all_cmis { public_dir; private_dir } =
-    List.filter_opt [ Some public_dir; private_dir ]
+  let all_cmis { public_dir; private_dir; public_cmi_dir } =
+    List.filter_opt [ Some public_dir; private_dir; public_cmi_dir ]
 
   let cm_public_dir t (cm_kind : Cm_kind.t) =
     match cm_kind with
@@ -96,9 +109,11 @@ module Local = struct
     ; native_dir : Path.Build.t
     ; byte_dir : Path.Build.t
     ; public_cmi_dir : Path.Build.t option
+    ; private_lib : bool
     }
 
-  let to_dyn { dir; obj_dir; native_dir; byte_dir; public_cmi_dir } =
+  let to_dyn { dir; obj_dir; native_dir; byte_dir; public_cmi_dir; private_lib }
+      =
     let open Dyn.Encoder in
     record
       [ ("dir", Path.Build.to_dyn dir)
@@ -106,10 +121,11 @@ module Local = struct
       ; ("native_dir", Path.Build.to_dyn native_dir)
       ; ("byte_dir", Path.Build.to_dyn byte_dir)
       ; ("public_cmi_dir", option Path.Build.to_dyn public_cmi_dir)
+      ; ("private_lib", bool private_lib)
       ]
 
-  let make ~dir ~obj_dir ~native_dir ~byte_dir ~public_cmi_dir =
-    { dir; obj_dir; native_dir; byte_dir; public_cmi_dir }
+  let make ~dir ~obj_dir ~native_dir ~byte_dir ~public_cmi_dir ~private_lib =
+    { dir; obj_dir; native_dir; byte_dir; public_cmi_dir; private_lib }
 
   let need_dedicated_public_dir t = Option.is_some t.public_cmi_dir
 
@@ -134,7 +150,7 @@ module Local = struct
     in
     Path.Build.Set.of_list dirs |> Path.Build.Set.to_list
 
-  let make_lib ~dir ~has_private_modules lib_name =
+  let make_lib ~dir ~has_private_modules ~private_lib lib_name =
     let obj_dir = Paths.library_object_directory ~dir lib_name in
     let public_cmi_dir =
       Option.some_if has_private_modules (Paths.library_public_cmi_dir ~obj_dir)
@@ -142,14 +158,14 @@ module Local = struct
     make ~dir ~obj_dir
       ~native_dir:(Paths.library_native_dir ~obj_dir)
       ~byte_dir:(Paths.library_byte_dir ~obj_dir)
-      ~public_cmi_dir
+      ~public_cmi_dir ~private_lib
 
   let make_exe ~dir ~name =
     let obj_dir = Paths.executable_object_directory ~dir name in
     make ~dir ~obj_dir
       ~native_dir:(Paths.library_native_dir ~obj_dir)
       ~byte_dir:(Paths.library_byte_dir ~obj_dir)
-      ~public_cmi_dir:None
+      ~public_cmi_dir:None ~private_lib:false
 
   let cm_dir t cm_kind _ =
     match cm_kind with
@@ -190,11 +206,11 @@ let decode ~dir =
   let+ external_ = External.decode ~dir in
   External external_
 
-let make_lib ~dir ~has_private_modules lib_name =
-  Local (Local.make_lib ~dir ~has_private_modules lib_name)
+let make_lib ~dir ~has_private_modules ~private_lib lib_name =
+  Local (Local.make_lib ~dir ~has_private_modules ~private_lib lib_name)
 
 let make_external_no_private ~dir =
-  External (External.make ~dir ~has_private_modules:false)
+  External (External.make ~dir ~has_private_modules:false ~private_lib:false)
 
 let get_path :
     type a. a t -> l:(Local.t -> Path.Build.t) -> e:(External.t -> Path.t) -> a
@@ -226,7 +242,8 @@ let convert_to_external (t : Path.Build.t t) ~dir =
   match t with
   | Local e ->
     let has_private_modules = Local.need_dedicated_public_dir e in
-    External (External.make ~dir ~has_private_modules)
+    External
+      (External.make ~dir ~has_private_modules ~private_lib:e.private_lib)
   | _ -> assert false
 
 let all_cmis (type path) (t : path t) : path list =

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -57,6 +57,7 @@ val all_obj_dirs : 'path t -> mode:Mode.t -> 'path list
 val make_lib :
      dir:Path.Build.t
   -> has_private_modules:bool
+  -> private_lib:bool
   -> Lib_name.Local.t
   -> Path.Build.t t
 
@@ -71,8 +72,6 @@ val decode : dir:Path.t -> Path.t t Dune_lang.Decoder.t
 val convert_to_external : Path.Build.t t -> dir:Path.t -> Path.t t
 
 val cm_dir : 'path t -> Cm_kind.t -> Visibility.t -> 'path
-
-val cm_public_dir : 'path t -> Cm_kind.t -> 'path
 
 val to_dyn : _ t -> Dyn.t
 

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -35,9 +35,11 @@ let lib_unique_name lib =
   let info = Lib.info lib in
   let status = Lib_info.status info in
   match status with
-  | Installed -> assert false
+  | Installed_private
+  | Installed ->
+    assert false
   | Public _ -> Lib_name.to_string name
-  | Private project -> Scope_key.to_string name project
+  | Private (project, _) -> Scope_key.to_string name project
 
 let pkg_or_lnu lib =
   match Lib_info.package (Lib.info lib) with
@@ -645,7 +647,7 @@ let init sctx =
              | Dune_file.Library (l : Dune_file.Library.t) -> (
                match l.visibility with
                | Public _ -> None
-               | Private ->
+               | Private _ ->
                  let scope = SC.find_scope_by_dir sctx w.ctx_dir in
                  Library.best_name l
                  |> Lib.DB.find_even_when_hidden (Scope.libs scope)

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -60,7 +60,8 @@ end = struct
               let info = Lib.info lib in
               let status = Lib_info.status info in
               match status with
-              | Private scope_name -> Some scope_name
+              | Private (scope_name, _) -> Some scope_name
+              | Installed_private
               | Public _
               | Installed ->
                 None

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -76,11 +76,9 @@ module DB = struct
                match (v1, v2) with
                | Found info1, Found info2 ->
                  Error (Lib_info.loc info1, Lib_info.loc info2)
-               | Found info, Redirect (loc, r)
-               | Redirect (loc, r), Found info -> (
-                 match Lib_name.analyze r with
-                 | Private _ -> Ok (Found_or_redirect.found info)
-                 | Public _ -> Error (loc, Lib_info.loc info) )
+               | Found info, Redirect (loc, _)
+               | Redirect (loc, _), Found info ->
+                 Error (loc, Lib_info.loc info)
                | Redirect (loc1, lib1), Redirect (loc2, lib2) ->
                  if Lib_name.equal lib1 lib2 then
                    Ok v1

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -25,6 +25,7 @@ module DB : sig
   (** Return the new scope database as well as the public libraries database *)
   val create_from_stanzas :
        projects:Dune_project.t list
+    -> projects_by_package:Dune_project.t Package.Name.Map.t
     -> context:Context.t
     -> installed_libs:Lib.DB.t
     -> Dune_load.Dune_file.t list

--- a/test/blackbox-tests/test-cases/private-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/private-modules.t/run.t
@@ -15,10 +15,10 @@ Private modules are not excluded from the install file, but installed in the .pr
   $ dune build --root private-subdir | grep -i priv
   Entering directory 'private-subdir'
     "_build/install/default/lib/lib/.private/lib__Priv.cmi" {".private/lib__Priv.cmi"}
+    "_build/install/default/lib/lib/.private/lib__Priv.cmt" {".private/lib__Priv.cmt"}
     "_build/install/default/lib/lib/foo/.private/priv2.cmi" {"foo/.private/priv2.cmi"}
-    "_build/install/default/lib/lib/foo/priv2.cmt" {"foo/priv2.cmt"}
+    "_build/install/default/lib/lib/foo/.private/priv2.cmt" {"foo/.private/priv2.cmt"}
     "_build/install/default/lib/lib/foo/priv2.cmx" {"foo/priv2.cmx"}
     "_build/install/default/lib/lib/foo/priv2.ml" {"foo/priv2.ml"}
-    "_build/install/default/lib/lib/lib__Priv.cmt"
     "_build/install/default/lib/lib/lib__Priv.cmx"
     "_build/install/default/lib/lib/priv.ml"

--- a/test/blackbox-tests/test-cases/private-package-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/private-package-lib.t/run.t
@@ -1,0 +1,167 @@
+This test demonstrates private libraries that belong to a package. Such
+libraries are installed as public libraries under the package.__private__.<name>
+findlib name, and are only available to libraries and executables in the same
+package.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.8)
+  > (package (name foo))
+  > (package (name bar))
+  > EOF
+
+First, we define a private library:
+
+  $ mkdir private
+  $ cat >private/secret.ml <<EOF
+  > let secret = "secret string"
+  > EOF
+  $ cat >private/dune <<EOF
+  > (library
+  >  (name secret)
+  >  (package foo))
+  > EOF
+  $ dune build @all
+
+A public library may build against it:
+
+  $ mkdir public
+  $ cat >public/dune <<EOF
+  > (library
+  >  (name foo)
+  >  (libraries secret)
+  >  (public_name foo.bar))
+  > EOF
+  $ cat >public/foo.ml <<EOF
+  > let foo = "from library foo " ^ Secret.secret
+  > EOF
+  $ dune build @install
+
+The naming convention puts the artifacts of private libs under __private__:
+
+  $ ls _build/install/default/lib/foo/__private__/secret | grep -i \.cm
+  secret.cma
+  secret.cmx
+  secret.cmxa
+  secret.cmxs
+
+Note the name mangling convention in the META file:
+
+  $ cat _build/install/default/lib/foo/META
+  package "__private__" (
+    directory = "__private__"
+    package "secret" (
+      directory = "secret"
+      description = ""
+      requires = ""
+      archive(byte) = "secret.cma"
+      archive(native) = "secret.cmxa"
+      plugin(byte) = "secret.cma"
+      plugin(native) = "secret.cmxs"
+    )
+  )
+  package "bar" (
+    directory = "bar"
+    description = ""
+    requires = "secret"
+    archive(byte) = "foo.cma"
+    archive(native) = "foo.cmxa"
+    plugin(byte) = "foo.cma"
+    plugin(native) = "foo.cmxs"
+  )
+
+We want to see mangled names in the dune-package file as well:
+
+  $ cat _build/install/default/lib/foo/dune-package | grep __private__
+   (requires foo.__private__.secret)
+   (name foo.__private__.secret)
+    (byte __private__/secret/secret.cma)
+    (native __private__/secret/secret.cmxa))
+    (byte __private__/secret/secret.cma)
+    (native __private__/secret/secret.cmxs))
+   (native_archives __private__/secret/secret.a)
+
+Cmi for secret library must not be visible for normal users. Hence they must be
+hidden.
+
+  $ grep __private__ _build/default/foo.install
+    "_build/install/default/lib/foo/__private__/secret/.public_cmi/secret.cmi" {"__private__/secret/.public_cmi/secret.cmi"}
+    "_build/install/default/lib/foo/__private__/secret/.public_cmi/secret.cmt" {"__private__/secret/.public_cmi/secret.cmt"}
+    "_build/install/default/lib/foo/__private__/secret/secret.a" {"__private__/secret/secret.a"}
+    "_build/install/default/lib/foo/__private__/secret/secret.cma" {"__private__/secret/secret.cma"}
+    "_build/install/default/lib/foo/__private__/secret/secret.cmx" {"__private__/secret/secret.cmx"}
+    "_build/install/default/lib/foo/__private__/secret/secret.cmxa" {"__private__/secret/secret.cmxa"}
+    "_build/install/default/lib/foo/__private__/secret/secret.cmxs" {"__private__/secret/secret.cmxs"}
+    "_build/install/default/lib/foo/__private__/secret/secret.ml" {"__private__/secret/secret.ml"}
+
+We make sure that executables can use the secret library like they can use any other private library
+
+  $ mkdir bar
+  $ cat >bar/dune <<EOF
+  > (executable
+  >  (name bar)
+  >  (libraries secret))
+  > EOF
+  $ cat >bar/bar.ml <<EOF
+  > print_endline "from bar.ml"
+  > EOF
+  $ dune exec ./bar/bar.exe
+  from bar.ml
+
+Now we try to use the library in a subproject:
+
+  $ mkdir subproj
+  $ echo "(lang dune 2.8)" > subproj/dune-project
+  $ cat >subproj/dune <<EOF
+  > (executable
+  >  (name subproj)
+  >  (libraries foo.bar))
+  > EOF
+  $ cat >subproj/subproj.ml <<EOF
+  > print_endline Foo.foo
+  > EOF
+  $ dune exec ./subproj/subproj.exe
+  from library foo secret string
+
+But we shouldn't be able to access it directly:
+
+  $ cat >subproj/subproj.ml <<EOF
+  > print_endline Secret.secret
+  > EOF
+  $ dune exec ./subproj/subproj.exe
+  File "subproj/subproj.ml", line 1, characters 14-27:
+  1 | print_endline Secret.secret
+                    ^^^^^^^^^^^^^
+  Error: Unbound module Secret
+  [1]
+
+Now we make sure such libraries are transitively usable when installed:
+
+  $ mkdir use
+  $ cat >use/dune <<EOF
+  > (executable
+  >  (name run)
+  >  (libraries foo.bar))
+  > EOF
+  $ cat >use/run.ml <<EOF
+  > print_endline ("Using library foo: " ^ Foo.foo)
+  > EOF
+  $ echo "(lang dune 2.8)" > use/dune-project
+  $ export OCAMLPATH=$PWD/_build/install/default/lib
+  $ dune exec --root use -- ./run.exe
+  Entering directory 'use'
+  Entering directory 'use'
+  Using library foo: from library foo secret string
+
+But we cannot use such libraries directly:
+
+  $ cat >use/run.ml <<EOF
+  > print_endline ("direct access attempt: " ^ Secret.secret)
+  > EOF
+  $ dune exec --root use -- ./run.exe
+  Entering directory 'use'
+  Entering directory 'use'
+  File "run.ml", line 1, characters 43-56:
+  1 | print_endline ("direct access attempt: " ^ Secret.secret)
+                                                 ^^^^^^^^^^^^^
+  Error: Unbound module Secret
+  [1]


### PR DESCRIPTION
This PR implements the `(package ..)` field on libraries that lack a public name. For example:

```
(library
 (name foo)
 (package bar))
```

This makes `foo` available to the public libraries in `bar` but not to public libraries in any other package. `foo` will be installed as `bar.__private__.foo`. The name mangling encourages users to avoid using this library name directly.

I have a some questions about the implementation to @emillon and @jeremiedimino:

Initially, we agreed that the cmi's of such libraries will not be installed. I'm not entirely sure this is workable however. Consider this setup with 2 libraries and an executable in a single project

```
(library
 (name foo)
 (package bar))

(library
 (libraries foo)
 (public_name bar))

(executable
 (name baz)
 (libraries bar)
 (package baz))
```

Suppose that `(implicit_transitive_deps true)` is set. Do you expect the executable `baz` to see the cmi's of `foo`? If you think the answer is negative, then consider the situation if the executable was now:

```
(executable
 (name baz)
 (libraries bar foo)
 (package baz))
```

This definition is perfectly reasonable with the private libraries we have today, but to make it work with a package-private `foo`, we need to make sure the installed cmi's of `foo` are used. That's because `bar` is installed and we must build against the same version of `foo` that `bar` used.

Alternatively, we could simply disallow the usage of such libraries by executables from other packages. Though i think this is a serious limitation.

## Progress

- [x] Mangle names of libraries when installing them
- [x] Make private packge names visible when they are hidden by `-p`.
- [x] Allow libraries in the same scope to refer to such libraries.
- [x] Hide cmi's of such package private libraries from findlib users
- [x] Install cmi's of package private libraries into a separate directory
- [x] Hide cmi's of such package private libraries from users outside of the scope.
- [x] Document package private libraries
- [x] Restrict it to 2.8 and above.
- [x] Fix overlap checks
- [ ] Implement name mangling for package private libraries. 