### PR TITLE
Write mdx files to .mdx dir to avoid running mdx as part of @all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 next
 ----
 
+- Write intermediate files in a `.mdx` folder for each `mdx` stanza
+  to prevent the corresponding actions to be executed as part of the `@all`
+  alias (#3659, @NathanReb)
+
 - Read Coq flags from `env` (#3547 , fixes #3486, @gares)
 
 - Allow bisect_ppx to be enabled/disabled via dune-workspace. (#3404,

--- a/src/dune/mdx.ml
+++ b/src/dune/mdx.ml
@@ -15,9 +15,11 @@ module Files = struct
   let deps_file build_path =
     Path.Build.extend_basename ~suffix:".mdx.deps" build_path
 
-  let from_source_file src =
-    let deps = deps_file src in
-    let corrected = corrected_file src in
+  let from_source_file ~mdx_dir src =
+    let basename = Path.Build.basename src in
+    let dot_mdx_path = Path.Build.relative mdx_dir basename in
+    let deps = deps_file dot_mdx_path in
+    let corrected = corrected_file dot_mdx_path in
     { src; deps; corrected }
 
   let diff_action { src; corrected; deps = _ } =
@@ -172,7 +174,8 @@ let files_to_mdx t ~sctx ~dir =
     [stanza]. *)
 let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog src =
   let loc = stanza.loc in
-  let files = Files.from_source_file src in
+  let mdx_dir = Path.Build.relative dir ".mdx" in
+  let files = Files.from_source_file ~mdx_dir src in
   (* Add the rule for generating the .mdx.deps file with ocaml-mdx deps *)
   Super_context.add_rule sctx ~loc ~dir (Deps.rule ~dir ~mdx_prog files);
   (* Add the rule for generating the .corrected file using ocaml-mdx test *)

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/run.t
@@ -33,8 +33,8 @@ You can use the mdx stanza to check your documentation in markdown and mli files
   $ dune runtest --root simple/
   Entering directory 'simple'
   File "README.md", line 1, characters 0-0:
-  Error: Files _build/default/README.md and _build/default/README.md.corrected
-  differ.
+  Error: Files _build/default/README.md and
+  _build/default/.mdx/README.md.corrected differ.
   [1]
 
 Dune should invoke `ocaml-mdx deps` to figure out the files and directories a markdown


### PR DESCRIPTION
This caused `dune build` to fail if mdx wasn't installed which can be confusing to users that expect mdx to be a test dependency.

The intermediate `.mdx.deps` and `.corrected` files are now written to a `.mdx` folder (as is done for cinaps for instance) to avoid
making their generation a part of the `@all` alias.