### PR TITLE
Use external csexp in configurator

### DIFF
--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -20,6 +20,8 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.7" & >= "2.6.0"}
+  "result"
+  "csexp" {>= "1.3.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dune-project
+++ b/dune-project
@@ -79,7 +79,9 @@ no stability guarantee.
  (name dune-configurator)
  (depends
   (ocaml (>= 4.03.0))
-  (dune (>= 2.6.0)))
+  (dune (>= 2.6.0))
+  result
+  (csexp (>= 1.3.0)))
  (synopsis "Helper library for gathering system configuration")
  (description "\
 dune-configurator is a small library that helps writing OCaml scripts that

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -3,8 +3,8 @@
 (library
  (name configurator)
  (public_name dune-configurator)
- (private_modules import dune_lang ocaml_config csexp)
- (libraries unix)
+ (private_modules import dune_lang ocaml_config)
+ (libraries unix csexp result)
  (flags
   (:standard
    -safe-string
@@ -12,5 +12,3 @@
  (special_builtin_support
   (configurator
    (api_version 1))))
-
-(copy_files "%{project_root}/vendor/csexp/src/*.ml{,i}")


### PR DESCRIPTION
This is the first in the unvendoring of the dune repository. We will
only stick to vendored dependencies for the dune executable.

This should not cause any problems because csexp is stable and versioned.

cc @avsm just to make sure he's aware.