### PR TITLE
opam file generation: Add odoc {with-doc} to the dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@ next
 - Fix typo in `cache-check-probablity` field in dune config files. This field
   now requires 2.7 as it wasn't usable before this version. (#3652, @edwintorok)
 
+- Add `"odoc" {with-doc}` to the dependencies in the generated `.opam` files.
+  (#3667, @kit-ty-kate)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/test/blackbox-tests/test-cases/dune-project-meta/main/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/main/run.t
@@ -424,3 +424,96 @@ when calling dune subst:
       "@doc" {with-doc}
     ]
   ]
+
+When the version of the language >= 2.7, odoc is automatically added to
+the doc dependencies:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A3 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "odoc" {with-doc}
+  ]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends something))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A4 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "something"
+    "odoc" {with-doc}
+  ]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends odoc something))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A4 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "odoc"
+    "something"
+  ]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends (odoc :with-doc) something))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A4 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "odoc" {with-doc}
+    "something"
+  ]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends (odoc (and :with-doc (>= 1.5.0))) something))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A4 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "odoc" {with-doc & >= "1.5.0"}
+    "something"
+  ]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.7)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (depends (odoc :with-test) something))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A5 ^depends: foo.opam
+  depends: [
+    "dune" {>= "2.7"}
+    "odoc" {with-test}
+    "something"
+    "odoc" {with-doc}
+  ]


### PR DESCRIPTION
Unless the current dune project does not contain any `(library ..)` or `(executable ..)` stanzas, `odoc` is required when dune is requested to build the documentation (i.e. `dune build @doc`).
Currently the opam file generation does build the documentation when requested but nothing is telling opam that odoc is a required dependency in this case. This PR fixes the issue.