### PR TITLE
Allow (subdir ...) in dune files used via (include ...)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,9 @@ next
 - Do not allow user actions to capture dune's stdin (#3677, fixes #3672,
   @rgrinberg)
 
+- `(subdir ...)` stanzas can now appear in dune files used via `(include ...)`.
+  (#3676, @nojb)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/file_tree.ml
+++ b/src/dune/file_tree.ml
@@ -78,8 +78,10 @@ module Dune_file = struct
     | None -> Sub_dirs.default
     | Some t -> Sub_dirs.or_default t.plain.contents.subdir_status
 
-  let load_plain sexps ~from_parent ~project =
-    let decoder = Dune_project.set_parsing_context project Sub_dirs.decode in
+  let load_plain sexps ~file ~from_parent ~project =
+    let decoder =
+      Dune_project.set_parsing_context project (Sub_dirs.decode ~file)
+    in
     let active =
       let parsed =
         Dune_lang.Decoder.parse decoder Univ_map.empty
@@ -95,15 +97,15 @@ module Dune_file = struct
   let load file ~file_exists ~from_parent ~project =
     let kind, plain =
       match file_exists with
-      | false -> (Plain, load_plain [] ~from_parent ~project)
+      | false -> (Plain, load_plain [] ~file ~from_parent ~project)
       | true ->
         Io.with_lexbuf_from_file (Path.source file) ~f:(fun lb ->
             if Dune_lexer.is_script lb then
-              let from_parent = load_plain [] ~from_parent ~project in
+              let from_parent = load_plain [] ~file ~from_parent ~project in
               (Ocaml_script, from_parent)
             else
               let sexps = Dune_lang.Parser.parse lb ~mode:Many in
-              (Plain, load_plain sexps ~from_parent ~project))
+              (Plain, load_plain sexps ~file ~from_parent ~project))
     in
     { path = file; kind; plain }
 end

--- a/src/dune/stanza_common.ml
+++ b/src/dune/stanza_common.ml
@@ -99,3 +99,56 @@ module Pkg = struct
 end
 
 let modules_field name = Ordered_set_lang.field name
+
+module Include = struct
+  type context =
+    { current_file : Path.Source.t
+    ; include_stack : (Loc.t * Path.Source.t) list
+    }
+
+  let in_file file = { current_file = file; include_stack = [] }
+
+  let error { current_file = file; include_stack } =
+    let last, rest =
+      match include_stack with
+      | [] -> assert false
+      | last :: rest -> (last, rest)
+    in
+    let loc = fst (Option.value (List.last rest) ~default:last) in
+    let line_loc (loc, file) =
+      sprintf "%s:%d"
+        (Path.Source.to_string_maybe_quoted file)
+        loc.Loc.start.pos_lnum
+    in
+    User_error.raise ~loc
+      [ Pp.text "Recursive inclusion of dune files detected:"
+      ; Pp.textf "File %s is included from %s"
+          (Path.Source.to_string_maybe_quoted file)
+          (line_loc last)
+      ; Pp.vbox
+          (Pp.concat_map rest ~sep:Pp.cut ~f:(fun x ->
+               Pp.box ~indent:3
+                 (Pp.seq (Pp.verbatim "-> ")
+                    (Pp.textf "included from %s" (line_loc x)))))
+      ]
+
+  let load_sexps ~context:{ current_file; include_stack } (loc, fn) =
+    let include_stack = (loc, current_file) :: include_stack in
+    let dir = Path.Source.parent_exn current_file in
+    let current_file = Path.Source.relative dir fn in
+    if not (Path.exists (Path.source current_file)) then
+      User_error.raise ~loc
+        [ Pp.textf "File %s doesn't exist."
+            (Path.Source.to_string_maybe_quoted current_file)
+        ];
+    if
+      List.exists include_stack ~f:(fun (_, f) ->
+          Path.Source.equal f current_file)
+    then
+      error { current_file; include_stack };
+    let sexps =
+      Dune_lang.Parser.load ~lexer:Dune_lang.Lexer.token
+        (Path.source current_file) ~mode:Many
+    in
+    (sexps, { current_file; include_stack })
+end

--- a/src/dune/stanza_common.mli
+++ b/src/dune/stanza_common.mli
@@ -12,3 +12,12 @@ module Pkg : sig
 end
 
 val modules_field : string -> Ordered_set_lang.t Dune_lang.Decoder.fields_parser
+
+module Include : sig
+  type context
+
+  val in_file : Path.Source.t -> context
+
+  val load_sexps :
+    context:context -> Loc.t * string -> Dune_lang.Ast.t list * context
+end

--- a/src/dune/sub_dirs.ml
+++ b/src/dune/sub_dirs.ml
@@ -329,7 +329,8 @@ let decode_includes ~context =
          let sexps, context =
            Stanza_common.Include.load_sexps ~context (loc, fn)
          in
-         fields (with_input sexps (decode ~context ~path)))
+         let* () = set_input sexps in
+         fields (decode ~context ~path))
     in
     let+ subdirs = multi_field "subdir" (subdir ~context ~path)
     and+ sexps = leftover_fields in
@@ -340,4 +341,5 @@ let decode_includes ~context =
 let decode ~file =
   let open Dune_lang.Decoder in
   let* sexps = decode_includes ~context:(Stanza_common.Include.in_file file) in
-  with_input [ List (Loc.none, sexps) ] decode
+  let* () = set_input [ List (Loc.none, sexps) ] in
+  decode

--- a/src/dune/sub_dirs.ml
+++ b/src/dune/sub_dirs.ml
@@ -307,16 +307,21 @@ let decode =
 
 let decode_includes ~context =
   let open Dune_lang.Decoder in
-  let rec subdir ~context ~path =
+  let rec subdir ~context ~path ~inside_include =
+    let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
     let* loc = loc in
     let* name, path =
       plain_string (fun ~loc s ->
           (Atom (loc, Dune_lang.Atom.of_string s), s :: path))
     in
-    let+ nodes = fields (decode ~context ~path) in
+    let+ nodes = fields (decode ~context ~path ~inside_include) in
+    let required_version = (2, 7) in
+    if inside_include && dune_version < required_version then
+      Dune_lang.Syntax.Error.since loc Stanza.syntax required_version
+        ~what:"Using a `subdir' stanza within an `include'd file";
     List
       (loc, Atom (Loc.none, Dune_lang.Atom.of_string "subdir") :: name :: nodes)
-  and decode ~context ~path =
+  and decode ~context ~path ~inside_include =
     let* includes =
       multi_field "include"
         (let* loc = loc
@@ -330,13 +335,13 @@ let decode_includes ~context =
            Stanza_common.Include.load_sexps ~context (loc, fn)
          in
          let* () = set_input sexps in
-         fields (decode ~context ~path))
+         fields (decode ~context ~path ~inside_include:true))
     in
-    let+ subdirs = multi_field "subdir" (subdir ~context ~path)
+    let+ subdirs = multi_field "subdir" (subdir ~context ~path ~inside_include)
     and+ sexps = leftover_fields in
     List.concat (sexps :: subdirs :: includes)
   in
-  enter (fields (decode ~context ~path:[]))
+  enter (fields (decode ~context ~path:[] ~inside_include:false))
 
 let decode ~file =
   let open Dune_lang.Decoder in

--- a/src/dune/sub_dirs.mli
+++ b/src/dune/sub_dirs.mli
@@ -69,4 +69,4 @@ module Dir_map : sig
   val root : t -> per_dir
 end
 
-val decode : Dir_map.t Dune_lang.Decoder.t
+val decode : file:Path.Source.t -> Dir_map.t Dune_lang.Decoder.t

--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -184,6 +184,35 @@ let parse t context sexp =
   let ctx = Values (Ast.loc sexp, None, context) in
   result ctx (t ctx [ sexp ])
 
+let fields_of_values sexps =
+  let unparsed =
+    List.fold_left sexps ~init:Name.Map.empty ~f:(fun acc sexp ->
+        match sexp with
+        | List (_, name_sexp :: values) -> (
+          match name_sexp with
+          | Atom (_, A name) ->
+            Name.Map.set acc name
+              { Fields.Unparsed.values
+              ; entry = sexp
+              ; prev = Name.Map.find acc name
+              }
+          | List (loc, _)
+          | Quoted_string (loc, _)
+          | Template { loc; _ } ->
+            User_error.raise ~loc [ Pp.text "Atom expected" ] )
+        | _ ->
+          User_error.raise ~loc:(Ast.loc sexp)
+            [ Pp.text "S-expression of the form (<name> <values>...) expected" ])
+  in
+  { Fields.unparsed; known = [] }
+
+let with_input : type a k. ast list -> (a, k) parser -> k context -> k -> a * k
+    =
+ fun sexps t context _ ->
+  match context with
+  | Values _ -> t context sexps
+  | Fields _ -> t context (fields_of_values sexps)
+
 let capture ctx state =
   let f t = result ctx (t ctx state) in
   (f, [])
@@ -272,6 +301,13 @@ let filename =
         User_error.raise ~loc
           [ Pp.textf "'.' and '..' are not valid filenames" ]
       | fn -> fn)
+
+let relative_file =
+  plain_string (fun ~loc fn ->
+      if Filename.is_relative fn then
+        fn
+      else
+        User_error.raise ~loc [ Pp.textf "relative filename expected" ])
 
 let enter t =
   next_with_user_context (fun uc sexp ->
@@ -577,27 +613,8 @@ let multi_field name t (Fields (_, _, uc)) (state : Fields.t) =
   (res, Fields.consume name state)
 
 let fields t (Values (loc, cstr, uc)) sexps =
-  let unparsed =
-    List.fold_left sexps ~init:Name.Map.empty ~f:(fun acc sexp ->
-        match sexp with
-        | List (_, name_sexp :: values) -> (
-          match name_sexp with
-          | Atom (_, A name) ->
-            Name.Map.set acc name
-              { Fields.Unparsed.values
-              ; entry = sexp
-              ; prev = Name.Map.find acc name
-              }
-          | List (loc, _)
-          | Quoted_string (loc, _)
-          | Template { loc; _ } ->
-            User_error.raise ~loc [ Pp.text "Atom expected" ] )
-        | _ ->
-          User_error.raise ~loc:(Ast.loc sexp)
-            [ Pp.text "S-expression of the form (<name> <values>...) expected" ])
-  in
   let ctx = Fields (loc, cstr, uc) in
-  let x = result ctx (t ctx { Fields.unparsed; known = [] }) in
+  let x = result ctx (t ctx (fields_of_values sexps)) in
   (x, [])
 
 let leftover_fields_generic t more_fields (Fields (loc, cstr, uc)) state =

--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -206,12 +206,11 @@ let fields_of_values sexps =
   in
   { Fields.unparsed; known = [] }
 
-let with_input : type a k. ast list -> (a, k) parser -> k context -> k -> a * k
-    =
- fun sexps t context _ ->
+let set_input : type k. ast list -> (unit, k) parser =
+ fun sexps context _ ->
   match context with
-  | Values _ -> t context sexps
-  | Fields _ -> t context (fields_of_values sexps)
+  | Values _ -> ((), sexps)
+  | Fields _ -> ((), fields_of_values sexps)
 
 let capture ctx state =
   let f t = result ctx (t ctx state) in

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -47,7 +47,7 @@ type 'a fields_parser = ('a, fields) parser
     information such as versions to individual parsers. *)
 val parse : 'a t -> Univ_map.t -> ast -> 'a
 
-val with_input : ast list -> ('a, 'k) parser -> ('a, 'k) parser
+val set_input : ast list -> (unit, 'k) parser
 
 val return : 'a -> ('a, _) parser
 

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -47,6 +47,8 @@ type 'a fields_parser = ('a, fields) parser
     information such as versions to individual parsers. *)
 val parse : 'a t -> Univ_map.t -> ast -> 'a
 
+val with_input : ast list -> ('a, 'k) parser -> ('a, 'k) parser
+
 val return : 'a -> ('a, _) parser
 
 val ( >>= ) : ('a, 'k) parser -> ('a -> ('b, 'k) parser) -> ('b, 'k) parser
@@ -169,6 +171,9 @@ val plain_string : (loc:Loc.t -> string -> 'a) -> 'a t
 
 (** A valid filename, i.e. a string other than "." or ".." *)
 val filename : string t
+
+(** A relative filename *)
+val relative_file : string t
 
 val fix : ('a t -> 'a t) -> 'a t
 

--- a/test/blackbox-tests/test-cases/ocaml-syntax.t/run.t
+++ b/test/blackbox-tests/test-cases/ocaml-syntax.t/run.t
@@ -1,2 +1,19 @@
   $ dune runtest --force
   ocaml syntax
+
+Check that (include ...) works when generated using OCaml syntax.
+
+  $ mkdir -p foo && cd foo
+  $ cat >dune-project <<EOF
+  > (lang dune 2.5)
+  > EOF
+  $ cat >dune <<EOF
+  > (* -*- tuareg -*- *)
+  > let () = Jbuild_plugin.V1.send {|(include dune.inc)|}
+  > EOF
+  $ cat >dune.inc <<EOF
+  > (rule (with-stdout-to foo.txt (echo Hola!)))
+  > EOF
+  $ dune build --root . ./foo.txt
+  $ cat _build/default/foo.txt
+  Hola!

--- a/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
@@ -88,6 +88,18 @@ subdir stanzas can also appear in included files
   >   (action (with-stdout-to hello.txt (echo "Hello from subdir\n")))))
   > EOF
   $ dune build --root . subdir/hello.txt
+  File "dune.inc", line 1, characters 0-90:
+  1 | (subdir subdir
+  2 |  (rule
+  3 |   (action (with-stdout-to hello.txt (echo "Hello from subdir\n")))))
+  Error: Using a `subdir' stanza within an `include'd file is only available
+  since version 2.7 of the dune language. Please update your dune-project file
+  to have (lang dune 2.7).
+  [1]
+  $ cat >dune-project <<EOF
+  > (lang dune 2.7)
+  > EOF
+  $ dune build --root . subdir/hello.txt
   $ cat _build/default/subdir/hello.txt
   Hello from subdir
 

--- a/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
@@ -90,3 +90,19 @@ subdir stanzas can also appear in included files
   $ dune build --root . subdir/hello.txt
   $ cat _build/default/subdir/hello.txt
   Hello from subdir
+
+Include stanzas within subdir stanzas
+
+  $ mkdir -p subdir-include/a; cd subdir-include
+  $ cat >dune-project <<EOF
+  > (lang dune 2.5)
+  > EOF
+  $ cat >dune <<EOF
+  > (subdir a (include dune.inc))
+  > EOF
+  $ cat >a/dune.inc <<EOF
+  > (rule (with-stdout-to hello.txt (echo Hello!)))
+  > EOF
+  $ dune build --root . a/hello.txt
+  $ cat _build/default/a/hello.txt
+  Hello!

--- a/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
@@ -72,3 +72,21 @@ In conjunction with dune generated files:
   $ dune build ./sub/bar
   $ cat _build/default/sub/bar
   parent
+
+subdir stanzas can also appear in included files
+
+  $ mkdir -p include/subdir; cd include
+  $ cat >dune-project <<EOF
+  > (lang dune 2.5)
+  > EOF
+  $ cat >dune <<EOF
+  > (include dune.inc)
+  > EOF
+  $ cat >dune.inc <<EOF
+  > (subdir subdir
+  >  (rule
+  >   (action (with-stdout-to hello.txt (echo "Hello from subdir\n")))))
+  > EOF
+  $ dune build --root . subdir/hello.txt
+  $ cat _build/default/subdir/hello.txt
+  Hello from subdir


### PR DESCRIPTION
Currently, the `(include ...)` stanza is processed after the `(subdir ...)` stanzas have been removed from the input. This makes it impossible to support `(subdir ...)` in a file used via `(include ...)`. The PR adjusts things so that the `(include ...)` stanza is processed simultaneously with `(subdir ...)`, so that this is allowed.

I found the code that handles `(subdir ...)` a bit tricky, so would appreciate a review by someone familiar with it. Thanks!

Fixes #3419 