### PR TITLE
Launch process without stdin by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,9 @@ next
 - Add `"odoc" {with-doc}` to the dependencies in the generated `.opam` files.
   (#3667, @kit-ty-kate)
 
+- Do not allow user actions to capture dune's stdin (#3677, fixes #3672,
+  @rgrinberg)
+
 2.6.1 (02/07/2020)
 ------------------
 

--- a/src/dune/action_exec.ml
+++ b/src/dune/action_exec.ml
@@ -476,7 +476,7 @@ let exec ~targets ~context ~env ~rule_loc ~build_deps t =
     ; env
     ; stdout_to = Process.Io.stdout
     ; stderr_to = Process.Io.stderr
-    ; stdin_from = Process.Io.stdin
+    ; stdin_from = Process.Io.null In
     ; prepared_dependencies = DAP.Dependency.Set.empty
     ; exit_codes = Predicate_lang.Element 0
     }

--- a/src/dune/process.mli
+++ b/src/dune/process.mli
@@ -28,6 +28,8 @@ module Io : sig
 
   val stdin : input t
 
+  val null : 'a mode -> 'a t
+
   (** Return a buffered channel for this output. The channel is created lazily. *)
   val out_channel : output t -> out_channel
 

--- a/test/blackbox-tests/test-cases/github3672.t
+++ b/test/blackbox-tests/test-cases/github3672.t
@@ -1,0 +1,6 @@
+  $ echo "(lang dune 2.7)" > dune-project
+  $ cat >dune <<EOF
+  > (rule (with-stdout-to file.txt (run cat)))
+  > EOF
+  $ echo foo | dune build
+  $ cat _build/default/file.txt


### PR DESCRIPTION
Introduce a `null` input/output for processes. This can be used for
redirecting to /dev/null or running a process without stdin.

Change the default for Process.run to not read anything from stdin.
Previously, processes would inherit stdin from dune. That seems like a
bad default.