### PR TITLE
Avoid repeatedly opening /dev/null

### DIFF
--- a/src/dune/process.ml
+++ b/src/dune/process.ml
@@ -93,13 +93,18 @@ module Io = struct
       else
         "/dev/null" )
 
+  let open_null flags = lazy (Unix.openfile (Lazy.force null_path) flags 0o666)
+
+  let null_in = open_null [ Unix.O_RDONLY ]
+
+  let null_out = open_null [ Unix.O_WRONLY ]
+
   let null (type a) (mode : a mode) : a t =
-    let flags =
+    let fd =
       match mode with
-      | Out -> [ Unix.O_WRONLY ]
-      | In -> [ O_RDONLY ]
+      | In -> null_in
+      | Out -> null_out
     in
-    let fd = lazy (Unix.openfile (Lazy.force null_path) flags 0o666) in
     let channel = lazy (channel_of_descr (Lazy.force fd) mode) in
     { kind = Null; mode; fd; channel; status = Close_after_exec }
 


### PR DESCRIPTION
Recently I started getting the following errors when building moderately-sized workspaces:
```
Error: open: /dev/null: Too many open files
Error: open: /tmp/dune528db4.output: Too many open files
Error: open: /tmp/dune93b269.output: Too many open files
Error: open: /tmp/duneb4d3c8.output: Too many open files
Error: open: /tmp/dune472f36.output: Too many open files
Error: open: /tmp/dune62787e.output: Too many open files
Error: open: /tmp/dune0a6e20.output: Too many open files
Error: open: /tmp/dune096c63.output: Too many open files
Error: open: /tmp/dune955bb3.output: Too many open files
Error: open: /tmp/dune2bc4c9.output: Too many open files
Error: open: /tmp/dune5fb45e.output: Too many open files
Error: /tmp/dune887f90.output: Too many open files
Error: /tmp/dune974539.output: Too many open files
Error: /tmp/duneef1640.output: Too many open files
Error: /tmp/dune3efdc3.output: Too many open files
Error: /tmp/dunede8b6d.output: Too many open files
Error: /tmp/dune73cade.output: Too many open files
Error: /tmp/duned68216.output: Too many open files
Done: 3397/3910 (jobs: 1)Fatal error: exception Sys_error("_build/.db: Too many open files")
```
As @emillon pointed out this seems to be related to #3677: it looks like the null device is repeatedly being opened (and not being closed?). The PR seems to fix the problem for me.