### PR TITLE
Disable merlin config server until  files stop being generated

### DIFF
--- a/src/dune/merlin_server.ml
+++ b/src/dune/merlin_server.ml
@@ -68,7 +68,7 @@ end
 
 (* [to_local p] makes absolute path [p] relative to the projects root and
    optionally removes the build context *)
-let to_local abs_file_path =
+let _to_local abs_file_path =
   let error msg = Error msg in
   let path_opt =
     String.drop_prefix
@@ -106,9 +106,15 @@ let out s =
   flush stdout
 
 let print_merlin_conf file =
-  let dir, _file = Filename.(dirname file, basename file) in
+  let _dir, _file = Filename.(dirname file, basename file) in
   let answer =
-    match to_local dir with
+    (* TODO Remove this permanent error when dune stops generating `.merlin`
+       files *)
+    match
+      Error
+        "No configuration file found. Try calling `dune build` to generate \
+         `.merlin` files."
+    with
     | Ok p -> load_merlin_file p
     | Error s -> Dot_merlin.make_error s
   in

--- a/test/blackbox-tests/test-cases/merlin/server.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/server.t/run.t
@@ -2,7 +2,7 @@
   $ dune ocaml-merlin  <<EOF
   > (4:File${#FILE}:$FILE)
   > EOF
-  ()
+  ((5:ERROR82:No configuration file found. Try calling `dune build` to generate `.merlin` files.))
 
   $ dune build @check 2>&1 | sed "s/(lang dune .*)/(lang dune <version>)/"
   Info: Creating file dune-project with this contents:
@@ -10,4 +10,4 @@
   $ dune ocaml-merlin  <<EOF
   > (4:File${#FILE}:$FILE)
   > EOF
-  ((17:EXCLUDE_QUERY_DIR)(1:B31:_build/default/.main.eobjs/byte)(1:B31:_build/default/.mylib.objs/byte)(1:S1:.)(3:FLG223:-open Mylib -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs))
+  ((5:ERROR82:No configuration file found. Try calling `dune build` to generate `.merlin` files.))


### PR DESCRIPTION
When Merlin will start relying on external readers, dune will not be immediately ready and continue to generate `.merlin` files in the source tree.

This PR thus disable the merlin configuration server and send an error message to Merlin that ask for a build of the project in order to generate the `.merlin` files.

In due time, dune will stop generating these files and send the configuration directly to merlin. (PR #3554)