### PR TITLE
Implement #3432

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Unreleased
 - Experimental: Introduce specific installation sites. Allow to define plugins
   to be installed in these sites. (#3104, fixes #1185, @bobot)
 
+- Move all temporary files created by dune to run actions to a single directory
+  and make sure that actions executed by dune also use this directory by
+  settting `TMPDIR` (or `TEMP` on Windows). (#3691, fixes #3422, @rgrinberg)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -419,7 +419,7 @@ and exec_list ts ~ectx ~eenv =
 
 and exec_pipe outputs ts ~ectx ~eenv =
   let tmp_file () =
-    Temp.create File ~prefix:"dune-pipe-action-"
+    Dtemp.file ~prefix:"dune-pipe-action-"
       ~suffix:("." ^ Action.Outputs.to_string outputs)
   in
   let multi_use_eenv =
@@ -433,7 +433,7 @@ and exec_pipe outputs ts ~ectx ~eenv =
     | [] -> assert false
     | [ last_t ] ->
       let+ result = redirect_in last_t ~ectx ~eenv Stdin in_ in
-      Temp.destroy File in_;
+      Dtemp.destroy File in_;
       result
     | t :: ts -> (
       let out = tmp_file () in
@@ -441,7 +441,7 @@ and exec_pipe outputs ts ~ectx ~eenv =
         redirect t ~ectx ~eenv:multi_use_eenv ~in_:(Stdin, in_)
           ~out:(outputs, out) ()
       in
-      Temp.destroy File in_;
+      Dtemp.destroy File in_;
       match done_or_deps with
       | Need_more_deps _ as need -> Fiber.return need
       | Done -> loop ~in_:out ts )

--- a/src/dune_engine/dtemp.ml
+++ b/src/dune_engine/dtemp.ml
@@ -4,12 +4,6 @@ let temp_dir = lazy (Temp.create Dir ~prefix:"build" ~suffix:".dune")
 
 let temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force temp_dir))
 
-let init_env =
-  let putenv =
-    lazy (Unix.putenv Env.Var.temp_dir (Lazy.force temp_dir_value))
-  in
-  fun () -> Lazy.force putenv
-
 let file ~prefix ~suffix =
   Temp.temp_in_dir File ~dir:(Lazy.force temp_dir) ~suffix ~prefix
 

--- a/src/dune_engine/dtemp.ml
+++ b/src/dune_engine/dtemp.ml
@@ -1,0 +1,24 @@
+open Stdune
+
+let temp_dir = lazy (Temp.create Dir ~prefix:"build" ~suffix:".dune")
+
+let temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force temp_dir))
+
+let init_env =
+  let putenv =
+    lazy (Unix.putenv Env.Var.temp_dir (Lazy.force temp_dir_value))
+  in
+  fun () -> Lazy.force putenv
+
+let file ~prefix ~suffix =
+  Temp.temp_in_dir File ~dir:(Lazy.force temp_dir) ~suffix ~prefix
+
+let add_to_env env =
+  let value = Lazy.force temp_dir_value in
+  Env.add env ~var:Env.Var.temp_dir ~value
+
+let destroy = Temp.destroy
+
+let clear () = if Lazy.is_val temp_dir then Temp.clear_dir (Lazy.force temp_dir)
+
+let () = Hooks.End_of_build.always clear

--- a/src/dune_engine/dtemp.mli
+++ b/src/dune_engine/dtemp.mli
@@ -1,0 +1,15 @@
+(** Temp directory used by dune processes *)
+open Stdune
+
+(** Sets the environment for this process to reflect the temporary directory *)
+val init_env : unit -> unit
+
+(** This returns a build path, but we don't rely on that *)
+val file : prefix:string -> suffix:string -> Path.t
+
+(** Add the temp env var to the enviornment passed or return the initial
+    environment with the temp var added. *)
+val add_to_env : Env.t -> Env.t
+
+(** Destroy the temporary file or directory *)
+val destroy : Temp.what -> Path.t -> unit

--- a/src/dune_engine/dtemp.mli
+++ b/src/dune_engine/dtemp.mli
@@ -1,9 +1,6 @@
 (** Temp directory used by dune processes *)
 open Stdune
 
-(** Sets the environment for this process to reflect the temporary directory *)
-val init_env : unit -> unit
-
 (** This returns a build path, but we don't rely on that *)
 val file : prefix:string -> suffix:string -> Path.t
 

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -458,8 +458,11 @@ module Exit_status = struct
         :: Option.to_list output )
 end
 
+let default_env = lazy (Dtemp.add_to_env Env.initial)
+
 let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     ?(stdin_from = Io.null In) ~env ~purpose fail_mode prog args =
+  Dtemp.init_env ();
   Scheduler.with_job_slot (fun () ->
       let display = (Config.t ()).display in
       let dir =
@@ -531,8 +534,13 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
         let stdout = Io.fd stdout_to in
         let stderr = Io.fd stderr_to in
         let stdin = Io.fd stdin_from in
+        let env =
+          match env with
+          | None -> Lazy.force default_env
+          | Some env -> Dtemp.add_to_env env
+        in
         fun () ->
-          Spawn.spawn () ~prog:prog_str ~argv ?env ~stdout ~stderr ~stdin
+          Spawn.spawn () ~prog:prog_str ~argv ~env ~stdout ~stderr ~stdin
       in
       let pid =
         match dir with

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -462,7 +462,6 @@ let default_env = lazy (Dtemp.add_to_env Env.initial)
 
 let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
     ?(stdin_from = Io.null In) ~env ~purpose fail_mode prog args =
-  Dtemp.init_env ();
   Scheduler.with_job_slot (fun () ->
       let display = (Config.t ()).display in
       let dir =

--- a/src/stdune/env.mli
+++ b/src/stdune/env.mli
@@ -37,7 +37,7 @@ val remove : t -> var:Var.t -> t
 
 val diff : t -> t -> t
 
-val update : t -> var:string -> f:(string option -> string option) -> t
+val update : t -> var:Var.t -> f:(string option -> string option) -> t
 
 val to_dyn : t -> Dyn.t
 

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -316,6 +316,10 @@ val link : t -> t -> unit
 
 val rm_rf : ?allow_external:bool -> t -> unit
 
+(** [clear_dir t] deletes all the contents of directory [t] without removing [t]
+    itself *)
+val clear_dir : t -> unit
+
 val mkdir_p : ?perms:int -> t -> unit
 
 val touch : ?create:bool -> t -> unit

--- a/src/stdune/temp.mli
+++ b/src/stdune/temp.mli
@@ -8,6 +8,13 @@ type what =
   | Dir
   | File
 
+(** Create a temporary file or directory inside an existing directory*)
+val temp_in_dir : what -> dir:Path.t -> prefix:string -> suffix:string -> Path.t
+
 val create : what -> prefix:string -> suffix:string -> Path.t
 
 val destroy : what -> Path.t -> unit
+
+(** Delete the contents of a temporary directory without deleting the directory
+    itself. *)
+val clear_dir : Path.t -> unit

--- a/test/expect-tests/stdune/temp_tests.ml
+++ b/test/expect-tests/stdune/temp_tests.ml
@@ -1,0 +1,20 @@
+open Stdune
+open Dune_tests_common
+open Dyn.Encoder
+
+let () = init ()
+
+let%expect_test "Temp.clear_dir works" =
+  let path = Temp.create Dir ~prefix:"dune." ~suffix:".unit_test" in
+  Path.touch (Path.relative path "foo");
+  let print () =
+    Path.readdir_unsorted path
+    |> Result.to_dyn (list string) opaque
+    |> print_dyn
+  in
+  print ();
+  Temp.clear_dir path;
+  print ();
+  [%expect {|
+    Ok [ "foo" ]
+    Ok [] |}]


### PR DESCRIPTION
Use a temp dir that's inside the build directory. This makes it easier
to debug builds.