### PR TITLE
Fix read_all on Windows for files open in text mode

### DIFF
--- a/src/catapult/catapult.ml
+++ b/src/catapult/catapult.ml
@@ -28,7 +28,9 @@ let fake_gc_stat =
   ; compactions = 0
   ; top_heap_words = 0
   ; stack_size = 0
-  } [@ocaml.warning "-23"]      (* all fiels of record used *)
+  } [@ocaml.warning "-23"]
+
+(* all fiels of record used *)
 
 let fake time_ref buf =
   let print s = Buffer.add_string buf s in

--- a/src/dune/cram_exec.ml
+++ b/src/dune/cram_exec.ml
@@ -126,7 +126,7 @@ let cram_stanzas lexbuf =
   loop []
 
 let run_expect_test file ~f =
-  let file_contents = Io.read_file file in
+  let file_contents = Io.read_file ~binary:false file in
   let open Fiber.O in
   let+ expected =
     let lexbuf =
@@ -136,7 +136,7 @@ let run_expect_test file ~f =
   in
   let corrected_file = Path.extend_basename file ~suffix:".corrected" in
   if file_contents <> expected then
-    Io.write_file corrected_file expected
+    Io.write_file ~binary:false corrected_file expected
   else if Path.exists corrected_file then
     Path.rm_rf corrected_file
 
@@ -289,7 +289,7 @@ let sanitize ~parent_script cram_to_output :
       | Command
           (block_result, ({ build_path_prefix_map; exit_code = _ } as entry)) ->
         let output =
-          Io.read_file block_result.output_file
+          Io.read_file ~binary:false block_result.output_file
           |> Ansi_color.strip
           |> rewrite_paths ~parent_script ~command_script:block_result.script
                build_path_prefix_map

--- a/src/stdune/io.ml
+++ b/src/stdune/io.ml
@@ -68,6 +68,31 @@ struct
           };
         f lb)
 
+  let rec eagerly_input_acc ic s ~pos ~len acc =
+    if len <= 0 then
+      acc
+    else
+      let r = input ic s pos len in
+      if r = 0 then
+        acc
+      else
+        eagerly_input_acc ic s ~pos:(pos + r) ~len:(len - r) (acc + r)
+
+  (* [eagerly_input_string ic len] tries to read [len] chars from the channel.
+     Unlike [really_input_string], if the file ends before [len] characters are
+     found, it returns the characters it was able to read instead of raising an
+     exception.
+
+     This can be detected by checking that the length of the resulting string is
+     less than [len]. *)
+  let eagerly_input_string ic len =
+    let buf = Bytes.create len in
+    let r = eagerly_input_acc ic buf ~pos:0 ~len 0 in
+    if r = len then
+      Bytes.unsafe_to_string buf
+    else
+      Bytes.sub_string buf ~pos:0 ~len:r
+
   let read_all =
     (* We use 65536 because that is the size of OCaml's IO buffers. *)
     let chunk_size = 65536 in
@@ -87,10 +112,16 @@ struct
       match in_channel_length t with
       | exception _ -> read_all_generic t (Buffer.create chunk_size)
       | n -> (
-        let s = really_input_string t n in
         (* For some files [in_channel_length] returns an invalid value. For
-           instance for files in /proc it returns [0]. So we try to read one
-           more character to make sure we did indeed reach the end of the file *)
+           instance for files in /proc it returns [0] and on Windows the
+           returned value is larger than expected (it counts linebreaks as 2
+           chars, even in text mode).
+
+           To be robust in both directions, we: - use [eagerly_input_string]
+           instead of [really_input_string] in case we reach the end of the file
+           early - read one more character to make sure we did indeed reach the
+           end of the file *)
+        let s = eagerly_input_string t n in
         match input_char t with
         | exception End_of_file -> s
         | c ->

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -84,8 +84,10 @@
  (applies_to windows-diff)
  (alias runtest-windows))
 
-(subdir cram
+(subdir
+ cram
  ;  mac has a different sh error message
  (cram
   (applies_to error)
-  (enabled_if (<> "macosx" %{ocaml-config:system}))))
+  (enabled_if
+   (<> "macosx" %{ocaml-config:system}))))


### PR DESCRIPTION
`Stdune.Io.read_all` fails on Windows when reading text files.

The reason is that `in_channel_length` does not actually give a correct estimate of the number of characters that will be read.

This PR makes us stop relying `in_channel_length` being a correct upper bound. Instead, we treat it as a hint, so the function succeeds both when the number is too high (on Windows) and when it's too low (on procfs).

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>