### PR TITLE
Make not being able to set target permissions a warning.

### DIFF
--- a/src/dune/cached_digest.ml
+++ b/src/dune/cached_digest.ml
@@ -114,7 +114,7 @@ let refresh_and_chmod fn =
     if Cache.cachable stats.st_kind then
       try
         Path.chmod ~stats:(Some stats) ~mode:0o222 ~op:`Remove fn
-      with _ ->
+      with Unix.Unix_error _ ->
         if not !chmod_error_reported then (
           chmod_error_reported := true;
           User_warning.emit ~loc:(Loc.in_file fn)


### PR DESCRIPTION
Fix issue #3714 .

We could warn once per filesystem instead of once and for all, but that sounds like a lot of work esp portability wise for a very small improvement.
We should provide the user with a way to disable removing write permission so they don't see this warning ad vitam eternam if their filesystem don't allow it. This could be a `(remove_target_write_permissions enabled/disabled)` stanza in the dune configuration file.