### PR TITLE
Docs: replace `%{path:<path>}` with `%{dep:<path>}`

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -743,9 +743,9 @@ have this action in a ``src/foo/dune``:
 
 .. code:: lisp
 
-    (action (chdir ../../.. (echo %{path:dune})))
+    (action (chdir ../../.. (echo %{dep:dune})))
 
-Then ``%{path:dune}`` will expand to ``src/foo/dune``. When you run various
+Then ``%{dep:dune}`` will expand to ``src/foo/dune``. When you run various
 tools, they often use the filename given on the command line in error messages.
 As a result, if you execute the command from the original directory, it will
 only see the basename.


### PR DESCRIPTION
Using the former in a recent enough version of dune will produce the
following error:

Error: %{path:..} was renamed to '%{dep:..}' in the 2.1 version of the dune
language

Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>