### PR TITLE
Refactor [Foreign]

### DIFF
--- a/src/dune/dune_env.ml
+++ b/src/dune/dune_env.ml
@@ -12,7 +12,7 @@ module Stanza = struct
     in
     let+ c = Ordered_set_lang.Unexpanded.field "c_flags" ?check
     and+ cxx = Ordered_set_lang.Unexpanded.field "cxx_flags" ?check in
-    Foreign.Language.Dict.make ~c ~cxx
+    Foreign_language.Dict.make ~c ~cxx
 
   let menhir_flags ~since =
     let check =
@@ -72,7 +72,7 @@ module Stanza = struct
 
   type config =
     { flags : Ocaml_flags.Spec.t
-    ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t
+    ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign_language.Dict.t
     ; env_vars : Env.t
     ; binaries : File_binding.Unexpanded.t list
     ; inline_tests : Inline_tests.t option
@@ -92,7 +92,7 @@ module Stanza = struct
       ; coq
       } t =
     Ocaml_flags.Spec.equal flags t.flags
-    && Foreign.Language.Dict.equal Ordered_set_lang.Unexpanded.equal
+    && Foreign_language.Dict.equal Ordered_set_lang.Unexpanded.equal
          foreign_flags t.foreign_flags
     && Env.equal env_vars t.env_vars
     && List.equal File_binding.Unexpanded.equal binaries t.binaries
@@ -106,7 +106,7 @@ module Stanza = struct
   let empty_config =
     { flags = Ocaml_flags.Spec.standard
     ; foreign_flags =
-        Foreign.Language.Dict.make_both Ordered_set_lang.Unexpanded.standard
+        Foreign_language.Dict.make_both Ordered_set_lang.Unexpanded.standard
     ; env_vars = Env.empty
     ; binaries = []
     ; inline_tests = None

--- a/src/dune/dune_env.mli
+++ b/src/dune/dune_env.mli
@@ -26,7 +26,7 @@ module Stanza : sig
 
   type config =
     { flags : Ocaml_flags.Spec.t
-    ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t
+    ; foreign_flags : Ordered_set_lang.Unexpanded.t Foreign_language.Dict.t
     ; env_vars : Env.t
     ; binaries : File_binding.Unexpanded.t list
     ; inline_tests : Inline_tests.t option
@@ -52,7 +52,7 @@ module Stanza : sig
 
   val foreign_flags :
        since:Dune_lang.Syntax.Version.t option
-    -> Ordered_set_lang.Unexpanded.t Foreign.Language.Dict.t
+    -> Ordered_set_lang.Unexpanded.t Foreign_language.Dict.t
        Dune_lang.Decoder.fields_parser
 
   val decode : t Dune_lang.Decoder.t

--- a/src/dune/env_node.ml
+++ b/src/dune/env_node.ml
@@ -16,7 +16,7 @@ type t =
   { scope : Scope.t
   ; local_binaries : File_binding.Expanded.t list Memo.Lazy.t
   ; ocaml_flags : Ocaml_flags.t Memo.Lazy.t
-  ; foreign_flags : string list Build.t Foreign.Language.Dict.t Memo.Lazy.t
+  ; foreign_flags : string list Build.t Foreign_language.Dict.t Memo.Lazy.t
   ; external_env : Env.t Memo.Lazy.t
   ; bin_artifacts : Artifacts.Bin.t Memo.Lazy.t
   ; inline_tests : Dune_env.Stanza.Inline_tests.t Memo.Lazy.t
@@ -107,11 +107,11 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
   in
   let foreign_flags =
     inherited ~field:foreign_flags
-      ~root:(Foreign.Language.Dict.map ~f:Build.return default_context_flags)
+      ~root:(Foreign_language.Dict.map ~f:Build.return default_context_flags)
       (fun flags ->
         let expander = Expander.set_dir (Memo.Lazy.force expander) ~dir in
-        Foreign.Language.Dict.mapi config.foreign_flags ~f:(fun ~language f ->
-            let standard = Foreign.Language.Dict.get flags language in
+        Foreign_language.Dict.mapi config.foreign_flags ~f:(fun ~language f ->
+            let standard = Foreign_language.Dict.get flags language in
             Expander.expand_and_eval_set expander f ~standard))
   in
   let menhir_flags =

--- a/src/dune/env_node.mli
+++ b/src/dune/env_node.mli
@@ -24,7 +24,7 @@ val make :
   -> profile:Profile.t
   -> expander:Expander.t Memo.Lazy.t
   -> expander_for_artifacts:Expander.t Memo.Lazy.t
-  -> default_context_flags:string list Foreign.Language.Dict.t
+  -> default_context_flags:string list Foreign_language.Dict.t
   -> default_env:Env.t
   -> default_bin_artifacts:Artifacts.Bin.t
   -> t
@@ -37,7 +37,7 @@ val ocaml_flags : t -> Ocaml_flags.t
 
 val inline_tests : t -> Dune_env.Stanza.Inline_tests.t
 
-val foreign_flags : t -> string list Build.t Foreign.Language.Dict.t
+val foreign_flags : t -> string list Build.t Foreign_language.Dict.t
 
 val local_binaries : t -> File_binding.Expanded.t list
 

--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -35,7 +35,7 @@ type t =
   ; lookup_artifacts : (dir:Path.Build.t -> Ml_sources.Artifacts.t) option
   ; map_exe : Path.t -> Path.t
   ; foreign_flags :
-      dir:Path.Build.t -> string list Build.t Foreign.Language.Dict.t
+      dir:Path.Build.t -> string list Build.t Foreign_language.Dict.t
   ; find_package : Package.Name.t -> Package.t option
   }
 
@@ -328,7 +328,7 @@ let parse_lib_file ~loc s =
 let cc t ~dir =
   let open Build.O in
   let cc = t.foreign_flags ~dir in
-  Foreign.Language.Dict.map cc ~f:(fun cc ->
+  Foreign_language.Dict.map cc ~f:(fun cc ->
       let+ flags = cc in
       Value.L.strings (t.c_compiler :: flags))
 

--- a/src/dune/expander.mli
+++ b/src/dune/expander.mli
@@ -26,7 +26,7 @@ val make :
   -> t
 
 val set_foreign_flags :
-  t -> f:(dir:Path.Build.t -> string list Build.t Foreign.Language.Dict.t) -> t
+  t -> f:(dir:Path.Build.t -> string list Build.t Foreign_language.Dict.t) -> t
 
 val set_env : t -> var:string -> value:string -> t
 

--- a/src/dune/foreign_language.ml
+++ b/src/dune/foreign_language.ml
@@ -1,0 +1,82 @@
+open Stdune
+
+module T = struct
+  type t =
+    | C
+    | Cxx
+
+  let compare x y =
+    match (x, y) with
+    | C, C -> Eq
+    | C, _ -> Lt
+    | _, C -> Gt
+    | Cxx, Cxx -> Eq
+
+  let equal x y =
+    match (x, y) with
+    | C, C -> true
+    | Cxx, Cxx -> true
+    | _, _ -> false
+
+  let to_dyn = function
+    | C -> Dyn.Variant ("C", [])
+    | Cxx -> Dyn.Variant ("Cxx", [])
+end
+
+include T
+
+let proper_name = function
+  | C -> "C"
+  | Cxx -> "C++"
+
+include Comparable.Make (T)
+
+module Dict = struct
+  type 'a t =
+    { c : 'a
+    ; cxx : 'a
+    }
+
+  let equal f { c; cxx } t = f c t.c && f cxx t.cxx
+
+  let c t = t.c
+
+  let cxx t = t.cxx
+
+  let map { c; cxx } ~f = { c = f c; cxx = f cxx }
+
+  let mapi { c; cxx } ~f = { c = f ~language:C c; cxx = f ~language:Cxx cxx }
+
+  let make_both a = { c = a; cxx = a }
+
+  let make ~c ~cxx = { c; cxx }
+
+  let get { c; cxx } = function
+    | C -> c
+    | Cxx -> cxx
+
+  let add t k v =
+    match k with
+    | C -> { t with c = v }
+    | Cxx -> { t with cxx = v }
+
+  let update t k ~f =
+    let v = get t k in
+    add t k (f v)
+
+  let merge t1 t2 ~f = { c = f t1.c t2.c; cxx = f t1.cxx t2.cxx }
+end
+
+let header_extension = ".h"
+
+let source_extensions =
+  String.Map.of_list_exn
+    [ ("c", (C, (1, 0)))
+    ; ("cpp", (Cxx, (1, 0)))
+    ; ("cxx", (Cxx, (1, 8)))
+    ; ("cc", (Cxx, (1, 10)))
+    ]
+
+let has_foreign_extension ~fn =
+  let ext = Filename.extension fn in
+  ext = header_extension || String.Map.mem source_extensions (String.drop ext 1)

--- a/src/dune/foreign_language.mli
+++ b/src/dune/foreign_language.mli
@@ -1,0 +1,65 @@
+open Stdune
+
+(* CR-soon cwong: I am deeply unsatisfied with the refactoring that lead to the
+   existence of this module, and would like to delete it. This module (and the
+   last three functions) were intially part of [Foreign], but needed to be split
+   separately to keep [Foreign] cleanly in the front-end. However, the only real
+   backend use of these files is that [Utils] uses [has_foreign_extension],
+   which could theoretically be moved to the backedn by itself. However, that
+   function relies on the key set of [source_extensions], which ultimately pulls
+   in the rest of this infrastructure. In theory, we could just hardcode that
+   key set somewhere (such as in [Utils]), that would add extra maintenance
+   burden to ensure that the external keyset evolves in sync with the
+   [source_extensions] here, and so this module was created to hold it. *)
+
+type t =
+  | C
+  | Cxx
+
+val compare : t -> t -> ordering
+
+val equal : t -> t -> bool
+
+val to_dyn : t -> Dyn.t
+
+(** The proper name of a language, e.g. "C++" for [Cxx]. Useful for diagnostic
+    messages. *)
+val proper_name : t -> string
+
+module Map : Map.S with type key = t
+
+module Dict : sig
+  type language
+
+  type 'a t =
+    { c : 'a
+    ; cxx : 'a
+    }
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val c : 'a t -> 'a
+
+  val cxx : 'a t -> 'a
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  val mapi : 'a t -> f:(language:language -> 'a -> 'b) -> 'b t
+
+  val make_both : 'a -> 'a t
+
+  val make : c:'a -> cxx:'a -> 'a t
+
+  val update : 'a t -> language -> f:('a -> 'a) -> 'a t
+
+  val merge : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
+
+  val get : 'a t -> language -> 'a
+end
+with type language := t
+
+val source_extensions : (t * (int * int)) String.Map.t
+
+val header_extension : string
+
+val has_foreign_extension : fn:string -> bool

--- a/src/dune/foreign_rules.ml
+++ b/src/dune/foreign_rules.ml
@@ -77,14 +77,14 @@ let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
   let flags =
     let ctx_flags =
       match kind with
-      | Foreign.Language.C ->
+      | Foreign_language.C ->
         let cfg = ctx.ocaml_config in
         List.concat
           [ Ocaml_config.ocamlc_cflags cfg
           ; Ocaml_config.ocamlc_cppflags cfg
           ; Fdo.c_flags ctx
           ]
-      | Foreign.Language.Cxx -> Fdo.cxx_flags ctx
+      | Foreign_language.Cxx -> Fdo.cxx_flags ctx
     in
     let flags = Foreign.Source.flags src in
     Super_context.foreign_flags sctx ~dir ~expander ~flags ~language:kind
@@ -122,7 +122,8 @@ let build_o_files ~sctx ~foreign_sources ~(dir : Path.Build.t) ~expander
   let h_files =
     List.fold_left all_dirs ~init:[] ~f:(fun acc dc ->
         String.Set.fold (Dir_contents.text_files dc) ~init:acc ~f:(fun fn acc ->
-            if String.is_suffix fn ~suffix:Foreign.header_extension then
+            if String.is_suffix fn ~suffix:Foreign_language.header_extension
+            then
               Path.relative (Path.build (Dir_contents.dir dc)) fn :: acc
             else
               acc))
@@ -154,7 +155,7 @@ let build_o_files ~sctx ~foreign_sources ~(dir : Path.Build.t) ~expander
          in
          let build_file =
            match Foreign.Source.language src with
-           | C -> build_c ~kind:Foreign.Language.C
-           | Cxx -> build_c ~kind:Foreign.Language.Cxx
+           | C -> build_c ~kind:Foreign_language.C
+           | Cxx -> build_c ~kind:Foreign_language.Cxx
          in
          build_file ~sctx ~dir ~expander ~include_flags (loc, src, dst))

--- a/src/dune/foreign_sources.ml
+++ b/src/dune/foreign_sources.ml
@@ -36,7 +36,7 @@ let valid_name language ~loc s =
   | ".." ->
     User_error.raise ~loc
       [ Pp.textf "%S is not a valid %s name." s
-          (Foreign.Language.proper_name language)
+          (Foreign_language.proper_name language)
       ]
   | _ -> s
 
@@ -69,7 +69,7 @@ let eval_foreign_stubs (d : _ Dir_with_dune.t) foreign_stubs
       String.Map.filter_mapi sources ~f:(fun name srcs ->
           List.find_map srcs ~f:(fun (l, _) ->
               Option.some_if
-                (Foreign.Language.equal l language)
+                (Foreign_language.equal l language)
                 (stubs.loc, name)))
     in
     let names =
@@ -91,7 +91,7 @@ let eval_foreign_stubs (d : _ Dir_with_dune.t) foreign_stubs
           let* candidates = String.Map.find sources name in
           match
             List.filter_map candidates ~f:(fun (l, path) ->
-                Option.some_if (Foreign.Language.equal l language) path)
+                Option.some_if (Foreign_language.equal l language) path)
           with
           | [ path ] -> Some (loc, Foreign.Source.make ~stubs ~path)
           | [] -> None

--- a/src/dune/lib_archives.ml
+++ b/src/dune/lib_archives.ml
@@ -68,7 +68,7 @@ let make ~(ctx : Context.t) ~dir ~dir_contents (lib : Library.t) =
       ; List.map lib.buildable.js_of_ocaml.javascript_files
           ~f:(Path.Build.relative dir)
       ; List.map lib.install_c_headers ~f:(fun fn ->
-            Path.Build.relative dir (fn ^ Foreign.header_extension))
+            Path.Build.relative dir (fn ^ Foreign_language.header_extension))
       ]
   in
   let dll_files =

--- a/src/dune/lib_file_deps.ml
+++ b/src/dune/lib_file_deps.ml
@@ -11,7 +11,7 @@ module Group = struct
   let ext = function
     | Cmi -> Cm_kind.ext Cmi
     | Cmx -> Cm_kind.ext Cmx
-    | Header -> Foreign.header_extension
+    | Header -> Foreign_language.header_extension
 
   let obj_dir t obj_dir =
     match t with

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -9,7 +9,7 @@ let default_context_flags (ctx : Context.t) =
   let cxx =
     List.filter c ~f:(fun s -> not (String.is_prefix s ~prefix:"-std="))
   in
-  Foreign.Language.Dict.make ~c ~cxx
+  Foreign_language.Dict.make ~c ~cxx
 
 module Env_tree : sig
   type t
@@ -228,7 +228,8 @@ let lib_entries_of_package t pkg_name =
 let internal_lib_names t =
   List.fold_left t.stanzas ~init:Lib_name.Set.empty
     ~f:(fun acc { Dir_with_dune.data = stanzas; _ } ->
-      List.fold_left stanzas ~init:acc ~f:(fun acc -> function
+      List.fold_left stanzas ~init:acc ~f:(fun acc ->
+        function
         | Dune_file.Library lib ->
           Lib_name.Set.add
             ( match lib.public with
@@ -308,9 +309,9 @@ let ocaml_flags t ~dir (x : Dune_file.Buildable.t) =
 let foreign_flags t ~dir ~expander ~flags ~language =
   let ccg = Context.cc_g t.context in
   let default = get_node t.env_tree ~dir |> Env_node.foreign_flags in
-  let name = Foreign.Language.proper_name language in
+  let name = Foreign_language.proper_name language in
   Build.memoize (sprintf "%s flags" name)
-    (let default = Foreign.Language.Dict.get default language in
+    (let default = Foreign_language.Dict.get default language in
      let c = Expander.expand_and_eval_set expander flags ~standard:default in
      let open Build.O in
      let+ l = c in

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -62,7 +62,7 @@ val foreign_flags :
   -> dir:Path.Build.t
   -> expander:Expander.t
   -> flags:Ordered_set_lang.Unexpanded.t
-  -> language:Foreign.Language.t
+  -> language:Foreign_language.t
   -> string list Build.t
 
 val menhir_flags :

--- a/src/dune/utils.ml
+++ b/src/dune/utils.ml
@@ -56,7 +56,7 @@ let install_file ~(package : Package.Name.t) ~findlib_toolchain =
 
 let line_directive ~filename:fn ~line_number =
   let directive =
-    if Foreign.has_foreign_extension ~fn then
+    if Foreign_language.has_foreign_extension ~fn then
       "line"
     else
       ""


### PR DESCRIPTION
In the same vein as my other recent PRs.

This started as a refactoring of "definitely backend" modules that used `Lib_name`, but I noticed that `Foreign` was also mostly things that don't need to be in the engine.

I'm generally less satisfied with this one (see my rant in `foreign_langage.mli`), but I think it's a step in the right direction -- `foreign` feels like a front-end module, so we should move towards moving all of that infrastructure into the frontend.

Would appreciate other thoughts.

Signed-off-by: Cameron Wong <cwong@janestreet.com>