### PR TITLE
Clean up scope module

### DIFF
--- a/src/dune/expander.ml
+++ b/src/dune/expander.ml
@@ -378,11 +378,12 @@ let expand_and_record_generic acc ~dep_kind ~(dir : Path.Build.t) ~pform t
       if lib_private then
         let open Result.O in
         let* lib = Lib.DB.resolve (Scope.libs t.scope) (loc, lib) in
-        let current_project_name = Scope.name t.scope
+        let current_project_name = Scope.project t.scope |> Dune_project.name
         and referenced_project_name =
           Lib.info lib |> Lib_info.status |> Lib_info.Status.project_name
         in
         if
+          (* TODO This breaks scoped packages and projects *)
           Option.equal Dune_project.Name.equal (Some current_project_name)
             referenced_project_name
         then

--- a/src/dune/scope.mli
+++ b/src/dune/scope.mli
@@ -8,8 +8,6 @@ type t
 
 val root : t -> Path.Build.t
 
-val name : t -> Dune_project.Name.t
-
 val project : t -> Dune_project.t
 
 (** Return the library database associated to this scope *)
@@ -28,7 +26,6 @@ module DB : sig
        projects:Dune_project.t list
     -> context:Context.t
     -> installed_libs:Lib.DB.t
-    -> lib_config:Lib_config.t
     -> Dune_load.Dune_file.t list
     -> t * Lib.DB.t
 

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -431,8 +431,7 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
   let lib_config = Context.lib_config context in
   let installed_libs = Lib.DB.create_from_findlib context.findlib ~lib_config in
   let scopes, public_libs =
-    Scope.DB.create_from_stanzas ~projects ~context ~installed_libs ~lib_config
-      stanzas
+    Scope.DB.create_from_stanzas ~projects ~context ~installed_libs stanzas
   in
   let stanzas =
     List.map stanzas ~f:(fun { Dune_load.Dune_file.dir; project; stanzas } ->


### PR DESCRIPTION
* do not save project name. we can obtain it from the project
* don't save [context] name. it's only used for an error message where it
  doesn't even help
* do not pass [lib_config] if there's a [context] available.
  [lib_config] can be obtained from context