### PR TITLE
Remove bloated api functions in Super_context

### DIFF
--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -60,7 +60,8 @@ let term =
             Dune.Context_name.Map.values setup.scontexts
             |> List.map ~f:(fun sctx ->
                    let dir =
-                     Path.Build.append_source (Super_context.build_dir sctx) dir
+                     Path.Build.append_source
+                       (Super_context.context sctx).build_dir dir
                    in
                    dump sctx ~dir)
           | External _ ->

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -34,9 +34,8 @@ let term =
         Dune.Context_name.Map.find setup.scontexts ctx_name |> Option.value_exn
       in
       let dir =
-        Path.Build.relative
-          (Super_context.build_dir sctx)
-          (Common.prefix_target common dir)
+        let build_dir = (Super_context.context sctx).build_dir in
+        Path.Build.relative build_dir (Common.prefix_target common dir)
       in
       let scope = Super_context.find_scope_by_dir sctx dir in
       let db = Dune.Scope.libs scope in

--- a/src/dune/cinaps.ml
+++ b/src/dune/cinaps.ml
@@ -61,7 +61,9 @@ let gen_rules sctx t ~dir ~scope =
              Predicate_lang.Glob.exec t.files (Path.Source.basename p)
                ~standard:Predicate_lang.any
            then
-             Some (Path.Build.append_source (Super_context.build_dir sctx) p)
+             Some
+               (Path.Build.append_source (Super_context.context sctx).build_dir
+                  p)
            else
              None)
   in

--- a/src/dune/compilation_context.ml
+++ b/src/dune/compilation_context.ml
@@ -157,7 +157,8 @@ let for_alias_module t =
   let flags =
     let project = Scope.project t.scope in
     let dune_version = Dune_project.dune_version project in
-    Ocaml_flags.default ~profile:(SC.profile t.super_context) ~dune_version
+    Ocaml_flags.default ~profile:(Super_context.context t.super_context).profile
+      ~dune_version
   in
   let sandbox =
     let ctx = Super_context.context t.super_context in

--- a/src/dune/coq_rules.ml
+++ b/src/dune/coq_rules.ml
@@ -162,7 +162,7 @@ module Context = struct
     let ml_flags, mlpack_rule =
       setup_ml_deps ~lib_db buildable.libraries theories_deps
     in
-    let build_dir = Super_context.build_dir sctx in
+    let build_dir = (Super_context.context sctx).build_dir in
     { coqdep = rr "coqdep"
     ; coqc = (rr "coqc", coqc_dir)
     ; wrapper_name
@@ -330,7 +330,7 @@ let setup_rules ~sctx ~dir ~dir_contents (s : Theory.t) =
     let wrapper_name = Coq_lib.wrapper theory in
     (* Coq flags for depending libraries *)
     let theories_deps = Coq_lib.DB.requires coq_lib_db theory in
-    let coqc_dir = Super_context.build_dir sctx in
+    let coqc_dir = (Super_context.context sctx).build_dir in
     Context.create sctx ~coqc_dir ~dir ~wrapper_name ~theories_deps s.buildable
   in
 
@@ -438,7 +438,8 @@ let coqpp_rules ~sctx ~dir (s : Coqpp.t) =
     let source = Path.build (Path.Build.relative dir (m ^ ".mlg")) in
     let target = Path.Build.relative dir (m ^ ".ml") in
     let args = [ Command.Args.Dep source; Hidden_targets [ target ] ] in
-    Command.run ~dir:(Path.build (Super_context.build_dir sctx)) coqpp args
+    let build_dir = (Super_context.context sctx).build_dir in
+    Command.run ~dir:(Path.build build_dir) coqpp args
   in
   List.map ~f:mlg_rule s.modules
 

--- a/src/dune/jsoo_rules.ml
+++ b/src/dune/jsoo_rules.ml
@@ -3,7 +3,7 @@ open Import
 open! No_io
 module SC = Super_context
 
-let dev_mode sctx = Profile.is_dev (SC.profile sctx)
+let dev_mode sctx = Profile.is_dev (Super_context.context sctx).profile
 
 let separate_compilation_enabled = dev_mode
 

--- a/src/dune/mdx.ml
+++ b/src/dune/mdx.ml
@@ -162,7 +162,7 @@ let files_to_mdx t ~sctx ~dir =
     Predicate_lang.Glob.exec t.files ~standard:default_files file
   in
   let build_path src_path =
-    Path.Build.append_source (Super_context.build_dir sctx) src_path
+    Path.Build.append_source (Super_context.context sctx).build_dir src_path
   in
   List.filter_map src_dir_files ~f:(fun src_path ->
       if must_mdx src_path then

--- a/src/dune/menhir.ml
+++ b/src/dune/menhir.ml
@@ -56,7 +56,7 @@ module Run (P : PARAMS) : sig end = struct
 
   (* [build_dir] is the base directory of the context; we run menhir from this
      directory to we get correct error paths. *)
-  let build_dir = Super_context.build_dir sctx
+  let build_dir = (Super_context.context sctx).build_dir
 
   let expander = Compilation_context.expander cctx
 

--- a/src/dune/odoc.ml
+++ b/src/dune/odoc.ml
@@ -59,7 +59,8 @@ type odoc =
   }
 
 let add_rule sctx =
-  Super_context.add_rule sctx ~dir:(Super_context.build_dir sctx)
+  let dir = (Super_context.context sctx).build_dir in
+  Super_context.add_rule sctx ~dir
 
 module Paths = struct
   let root (context : Context.t) =
@@ -142,9 +143,8 @@ end = struct
 end
 
 let odoc sctx =
-  SC.resolve_program sctx
-    ~dir:(Super_context.build_dir sctx)
-    "odoc" ~loc:None ~hint:"opam install odoc"
+  let dir = (Super_context.context sctx).build_dir in
+  SC.resolve_program sctx ~dir "odoc" ~loc:None ~hint:"opam install odoc"
 
 let odoc_base_flags sctx build_dir =
   let conf = Super_context.odoc sctx ~dir:build_dir in

--- a/src/dune/opam_create.ml
+++ b/src/dune/opam_create.ml
@@ -248,7 +248,7 @@ let generate project pkg ~template =
 
 let add_rule sctx ~project ~pkg =
   let open Build.O in
-  let build_dir = Super_context.build_dir sctx in
+  let build_dir = (Super_context.context sctx).build_dir in
   let opam_path = Path.Build.append_source build_dir (Package.opam_file pkg) in
   let opam_rule =
     (let+ template = opam_template ~opam_path:(Path.build opam_path) in

--- a/src/dune/super_context.ml
+++ b/src/dune/super_context.ml
@@ -205,12 +205,6 @@ let stanzas_in t ~dir = Path.Build.Map.find t.stanzas_per_dir dir
 
 let packages t = t.packages
 
-let artifacts t = t.artifacts
-
-let build_dir t = t.context.build_dir
-
-let profile t = t.context.profile
-
 let equal = (( == ) : t -> t -> bool)
 
 let hash t = Context.hash t.context

--- a/src/dune/super_context.mli
+++ b/src/dune/super_context.mli
@@ -27,12 +27,6 @@ val stanzas_in :
 
 val packages : t -> Package.t Package.Name.Map.t
 
-val artifacts : t -> Artifacts.t
-
-val build_dir : t -> Path.Build.t
-
-val profile : t -> Profile.t
-
 val host : t -> t
 
 module Lib_entry : sig

--- a/src/dune/toplevel.ml
+++ b/src/dune/toplevel.ml
@@ -169,7 +169,7 @@ module Stanza = struct
     let requires_link = Lib.Compile.requires_link compile_info in
     let obj_dir = Source.obj_dir source in
     let flags =
-      let profile = Super_context.profile sctx in
+      let profile = (Super_context.context sctx).profile in
       Ocaml_flags.append_common
         (Ocaml_flags.default ~dune_version ~profile)
         [ "-w"; "-24" ]

--- a/src/dune/utop.ml
+++ b/src/dune/utop.ml
@@ -28,8 +28,7 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
   File_tree.Dir.fold_dune_files dir ~init:([], [])
     ~f:(fun ~basename:_ dir _dune_file (acc, pps) ->
       let dir =
-        Path.Build.append_source
-          (Super_context.build_dir sctx)
+        Path.Build.append_source (Super_context.context sctx).build_dir
           (File_tree.Dir.path dir)
       in
       match Super_context.stanzas_in sctx ~dir with
@@ -105,8 +104,9 @@ let setup sctx ~dir =
   let flags =
     let project = Scope.project scope in
     let dune_version = Dune_project.dune_version project in
+    let profile = (Super_context.context sctx).profile in
     Ocaml_flags.append_common
-      (Ocaml_flags.default ~dune_version ~profile:(Super_context.profile sctx))
+      (Ocaml_flags.default ~dune_version ~profile)
       [ "-w"; "-24" ]
   in
   let cctx =


### PR DESCRIPTION
* build_dir & profile are all unnecessary and can be obtained from
Context.

* artifacts wasn't used anywhere