### PR TITLE
Improve robustness of dev-deps make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ DESTDIR_ARG := $(if $(DESTDIR),--destdir $(DESTDIR),)
 INSTALL_ARGS := $(PREFIX_ARG) $(LIBDIR_ARG) $(DESTDIR_ARG)
 BIN := ./dune.exe
 
-# Dependencies used for developing and testing dune
-DEV_DEPS := \
+# Dependencies used for testing dune, when developed locally and
+# when tested in CI
+TEST_DEPS := \
 bisect_ppx \
 cinaps \
 coq \
@@ -22,12 +23,16 @@ ocaml-migrate-parsetree \
 ocamlfind \
 ocamlformat.0.14.3 \
 "odoc>=1.5.0" \
-patdiff \
 "ppx_expect>=v0.14" \
 ppx_inline_test \
 "ppxlib.0.13.0" \
 result \
 "utop>=2.6.0"
+
+# Dependencies recommended for developing dune locally,
+# but not wanted in CI
+DEV_DEPS := \
+patdiff
 
 -include Makefile.dev
 
@@ -55,14 +60,14 @@ uninstall:
 reinstall: uninstall install
 
 dev-deps:
-	opam install -y $(DEV_DEPS)
+	opam install -y $(TEST_DEPS)
 
 dev-switch:
 	opam update
 	# Ensuring that either a dev switch already exists or a new one is created
 	[[ $(shell opam switch show) == $(shell pwd) ]] || \
 		opam switch create -y . --deps-only --with-test
-	opam install -y $(DEV_DEPS)
+	opam install -y $(TEST_DEPS) $(DEV_DEPS)
 
 test: $(BIN)
 	$(BIN) runtest

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,13 @@ BIN := ./dune.exe
 
 # Dependencies used for developing and testing dune
 DEV_DEPS := \
-"csexp>=1.3.0" \
 bisect_ppx \
+cinaps \
 coq \
 core_bench \
+"csexp>=1.3.0" \
+js_of_ocaml-ppx \
+js_of_ocaml-compiler \
 "mdx=1.6.0" \
 menhir \
 merlin \
@@ -22,10 +25,7 @@ ocamlformat.0.14.3 \
 "ppx_expect>=v0.14" \
 ppx_inline_test \
 "ppxlib.0.13.0" \
-cinaps \
 result \
-js_of_ocaml-ppx \
-js_of_ocaml-compiler \
 "utop>=2.6.0"
 
 -include Makefile.dev

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,10 @@ dev-deps:
 	opam install -y $(DEV_DEPS)
 
 dev-switch:
-	opam switch create -y . --deps-only --with-test
+	opam update
+	# Ensuring that either a dev switch already exists or a new one is created
+	[[ $(shell opam switch show) == $(shell pwd) ]] || \
+		opam switch create -y . --deps-only --with-test
 	opam install -y $(DEV_DEPS)
 
 test: $(BIN)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ocaml-migrate-parsetree \
 ocamlfind \
 ocamlformat.0.14.3 \
 "odoc>=1.5.0" \
+patdiff \
 "ppx_expect>=v0.14" \
 ppx_inline_test \
 "ppxlib.0.13.0" \


### PR DESCRIPTION
This breaks out the testing deps install command into its
own script, so that this can be used by both travis and
the dev-deps make target.

This is aimed at resolving the recurring problem of new devs (or devs setting up a new environment) having to manually track down test dependencies. This was discussed with @lubegasimon and @rgrinberg several weeks back.