### PR TITLE
Fix #3727

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1820,14 +1820,18 @@ module Library_redirect = struct
   module Local = struct
     type nonrec t = (Loc.t * Lib_name.Local.t) t
 
-    let of_lib (lib : Library.t) =
+    let of_lib (lib : Library.t) : t option =
       let open Option.O in
-      let+ public = lib.public in
-      { loc = Loc.none
-      ; project = lib.project
-      ; old_name = lib.name
-      ; new_public_name = public.name
-      }
+      let* public = lib.public in
+      if Lib_name.equal (Lib_name.of_local lib.name) (snd public.name) then
+        None
+      else
+        Some
+          { loc = Loc.none
+          ; project = lib.project
+          ; old_name = lib.name
+          ; new_public_name = public.name
+          }
   end
 end
 

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -331,21 +331,20 @@ module Include_subdirs : sig
 end
 
 module Deprecated_library_name : sig
-  module Old_public_name : sig
-    type kind =
+  module Old_name : sig
+    type deprecation =
       | Not_deprecated
       | Deprecated of { deprecated_package : Package.Name.t }
 
     type t =
-      { kind : kind
-      ; public : Public_lib.t
-      }
+      | Local of (Loc.t * Lib_name.Local.t)
+      | Public of Public_lib.t * deprecation
   end
 
   type t =
     { loc : Loc.t
     ; project : Dune_project.t
-    ; old_public_name : Old_public_name.t
+    ; old_name : Old_name.t
     ; new_public_name : Loc.t * Lib_name.t
     }
 end

--- a/src/dune_rules/gen_meta.ml
+++ b/src/dune_rules/gen_meta.ml
@@ -164,7 +164,7 @@ let gen ~(package : Package.t) ~add_directory_entry entries =
           | _package :: path ->
             (pub_name, gen_lib pub_name ~path (Lib.Local.to_lib lib) ~version) )
         | Deprecated_library_name
-            { old_name = Public (old_public_name, _)
+            { old_name = old_public_name, _
             ; new_public_name = _, new_public_name
             ; _
             } ->

--- a/src/dune_rules/gen_meta.ml
+++ b/src/dune_rules/gen_meta.ml
@@ -164,7 +164,7 @@ let gen ~(package : Package.t) ~add_directory_entry entries =
           | _package :: path ->
             (pub_name, gen_lib pub_name ~path (Lib.Local.to_lib lib) ~version) )
         | Deprecated_library_name
-            { old_public_name = { public = old_public_name; _ }
+            { old_name = Public (old_public_name, _)
             ; new_public_name = _, new_public_name
             ; _
             } ->

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -375,11 +375,19 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
   List.filter_map ~f:(fun stanza ->
       match Dune_file.stanza_package stanza with
       | None -> Some stanza
-      | Some package ->
+      | Some package -> (
         if Package.Name.Map.mem visible_pkgs package.name then
           Some stanza
         else
-          None)
+          match stanza with
+          | Library l ->
+            (* A public library should still be referable by its private name
+               even we filter it out. Therefore, we create a private -> public
+               name mapping for the filtered libraries *)
+            let open Option.O in
+            let+ dln = Library_redirect.Local.of_lib l in
+            Library_redirect dln
+          | _ -> None ))
 
 let gen ~contexts ?only_packages conf =
   let open Fiber.O in

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -321,10 +321,10 @@ end = struct
       List.fold_left lib_entries ~init:Lib_name.Map.empty ~f:(fun acc stanza ->
           match stanza with
           | Super_context.Lib_entry.Deprecated_library_name
-              { old_name = Public (_, Deprecated _); _ } ->
+              { old_name = _, Deprecated _; _ } ->
             acc
           | Super_context.Lib_entry.Deprecated_library_name
-              { old_name = Public (old_public_name, Not_deprecated)
+              { old_name = old_public_name, Not_deprecated
               ; new_public_name = _, new_public_name
               ; loc
               ; project = _
@@ -392,7 +392,7 @@ end = struct
     let deprecated_dune_packages =
       List.filter_map lib_entries ~f:(function
         | Super_context.Lib_entry.Deprecated_library_name
-            ({ old_name = Public (old_public_name, Deprecated _); _ } as t) ->
+            ({ old_name = old_public_name, Deprecated _; _ } as t) ->
           Some
             ( Lib_name.package_name (Dune_file.Public_lib.name old_public_name)
             , t )
@@ -407,8 +407,8 @@ end = struct
             | Some entries ->
               List.fold_left entries ~init:Lib_name.Map.empty
                 ~f:(fun acc
-                        { Dune_file.Deprecated_library_name.old_name =
-                            Public (old_public_name, _)
+                        { Dune_file.Library_redirect.old_name =
+                            old_public_name, _
                         ; new_public_name = _, new_public_name
                         ; loc
                         ; _
@@ -444,8 +444,8 @@ end = struct
       let entries = Super_context.lib_entries_of_package sctx pkg.name in
       List.partition_map entries ~f:(function
         | Super_context.Lib_entry.Deprecated_library_name
-            { old_name = Public (public, Deprecated { deprecated_package }); _ }
-          as entry -> (
+            { old_name = public, Deprecated { deprecated_package }; _ } as entry
+          -> (
           match Dune_file.Public_lib.sub_dir public with
           | None -> Left (deprecated_package, entry)
           | Some _ -> Right entry )

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -321,11 +321,10 @@ end = struct
       List.fold_left lib_entries ~init:Lib_name.Map.empty ~f:(fun acc stanza ->
           match stanza with
           | Super_context.Lib_entry.Deprecated_library_name
-              { old_public_name = { kind = Deprecated _; _ }; _ } ->
+              { old_name = Public (_, Deprecated _); _ } ->
             acc
           | Super_context.Lib_entry.Deprecated_library_name
-              { old_public_name =
-                  { public = old_public_name; kind = Not_deprecated }
+              { old_name = Public (old_public_name, Not_deprecated)
               ; new_public_name = _, new_public_name
               ; loc
               ; project = _
@@ -393,10 +392,7 @@ end = struct
     let deprecated_dune_packages =
       List.filter_map lib_entries ~f:(function
         | Super_context.Lib_entry.Deprecated_library_name
-            ( { old_public_name =
-                  { kind = Deprecated _; public = old_public_name }
-              ; _
-              } as t ) ->
+            ({ old_name = Public (old_public_name, Deprecated _); _ } as t) ->
           Some
             ( Lib_name.package_name (Dune_file.Public_lib.name old_public_name)
             , t )
@@ -411,8 +407,8 @@ end = struct
             | Some entries ->
               List.fold_left entries ~init:Lib_name.Map.empty
                 ~f:(fun acc
-                        { Dune_file.Deprecated_library_name.old_public_name =
-                            { public = old_public_name; _ }
+                        { Dune_file.Deprecated_library_name.old_name =
+                            Public (old_public_name, _)
                         ; new_public_name = _, new_public_name
                         ; loc
                         ; _
@@ -448,10 +444,8 @@ end = struct
       let entries = Super_context.lib_entries_of_package sctx pkg.name in
       List.partition_map entries ~f:(function
         | Super_context.Lib_entry.Deprecated_library_name
-            { old_public_name =
-                { kind = Deprecated { deprecated_package }; public }
-            ; _
-            } as entry -> (
+            { old_name = Public (public, Deprecated { deprecated_package }); _ }
+          as entry -> (
           match Dune_file.Public_lib.sub_dir public with
           | None -> Left (deprecated_package, entry)
           | Some _ -> Right entry )

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1672,10 +1672,7 @@ module DB = struct
       List.concat_map stanzas ~f:(fun stanza ->
           match (stanza : Library_related_stanza.t) with
           | Deprecated_library_name
-              { old_public_name = { public = old_public_name; _ }
-              ; new_public_name
-              ; _
-              } ->
+              { old_name = Public (old_public_name, _); new_public_name; _ } ->
             [ ( Dune_file.Public_lib.name old_public_name
               , Found_or_redirect.Redirect new_public_name )
             ]

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -180,6 +180,7 @@ module DB : sig
   module Library_related_stanza : sig
     type t =
       | Library of Path.Build.t * Dune_file.Library.t
+      | Library_redirect of Dune_file.Library_redirect.Local.t
       | Deprecated_library_name of Dune_file.Deprecated_library_name.t
   end
 

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -62,10 +62,7 @@ module DB = struct
             Some (Dune_file.Public_lib.name p, Project project)
           | Library _ -> None
           | Deprecated_library_name
-              { old_public_name = { public = old_public_name; _ }
-              ; new_public_name
-              ; _
-              } ->
+              { old_name = Public (old_public_name, _); new_public_name; _ } ->
             Some
               (Dune_file.Public_lib.name old_public_name, Name new_public_name))
       |> Lib_name.Map.of_list
@@ -76,8 +73,7 @@ module DB = struct
           List.filter_map stanzas ~f:(fun stanza ->
               match stanza with
               | Library (_, { buildable = { loc; _ }; public = Some p; _ })
-              | Deprecated_library_name
-                  { loc; old_public_name = { public = p; _ }; _ } ->
+              | Deprecated_library_name { loc; old_name = Public (p, _); _ } ->
                 Option.some_if (name = Dune_file.Public_lib.name p) loc
               | _ -> None)
         with

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -173,7 +173,7 @@ module Lib_entry = struct
 
   let name = function
     | Library lib -> Lib.Local.to_lib lib |> Lib.name
-    | Deprecated_library_name { old_name = Public (old_public_name, _); _ } ->
+    | Deprecated_library_name { old_name = old_public_name, _; _ } ->
       Dune_file.Public_lib.name old_public_name
 end
 
@@ -513,9 +513,10 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
               , Lib_entry.Library (Option.value_exn (Lib.Local.of_lib lib)) )
               :: acc )
           | Dune_file.Deprecated_library_name
-              ({ old_name = Public (old_public_name, _); _ } as d) ->
+              ({ old_name = old_public_name, deprecated; _ } as d) ->
             ( (Dune_file.Public_lib.package old_public_name).name
-            , Lib_entry.Deprecated_library_name d )
+            , Lib_entry.Deprecated_library_name
+                { d with old_name = (old_public_name, deprecated) } )
             :: acc
           | _ -> acc)
       |> Package.Name.Map.of_list_multi

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -173,8 +173,7 @@ module Lib_entry = struct
 
   let name = function
     | Library lib -> Lib.Local.to_lib lib |> Lib.name
-    | Deprecated_library_name
-        { old_public_name = { public = old_public_name; _ }; _ } ->
+    | Deprecated_library_name { old_name = Public (old_public_name, _); _ } ->
       Dune_file.Public_lib.name old_public_name
 end
 
@@ -514,7 +513,7 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
               , Lib_entry.Library (Option.value_exn (Lib.Local.of_lib lib)) )
               :: acc )
           | Dune_file.Deprecated_library_name
-              ({ old_public_name = { public = old_public_name; _ }; _ } as d) ->
+              ({ old_name = Public (old_public_name, _); _ } as d) ->
             ( (Dune_file.Public_lib.package old_public_name).name
             , Lib_entry.Deprecated_library_name d )
             :: acc

--- a/test/blackbox-tests/test-cases/github3727.t
+++ b/test/blackbox-tests/test-cases/github3727.t
@@ -1,0 +1,44 @@
+This bug demonstrate a distinction between public & private names.
+
+When -p was used, private names would dissapear as they would be filtered by the
+stanza filter. This behavior is incorrect and private names should remain
+visible regardless if the stanzas were filtered.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.7)
+  > (package (name foo))
+  > (package (name bar))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name private_foo)
+  >  (public_name foo.bar)
+  >  (modules private_foo))
+  > 
+  > (executable
+  >  (public_name bin)
+  >  (libraries private_foo)
+  >  (modules bin)
+  >  (package bar))
+  > EOF
+
+  $ cat >bin.ml <<EOF
+  > print_endline Private_foo.secret
+  > EOF
+
+  $ cat >private_foo.ml <<EOF
+  > let secret = "private_foo"
+  > EOF
+
+  $ dune exec ./bin.exe
+  private_foo
+
+  $ dune build -p bar
+  File "dune", line 8, characters 12-23:
+  8 |  (libraries private_foo)
+                  ^^^^^^^^^^^
+  Error: Library "private_foo" not found.
+  Hint: try:
+    dune external-lib-deps --missing -p bar @install
+  [1]

--- a/test/blackbox-tests/test-cases/github3727.t
+++ b/test/blackbox-tests/test-cases/github3727.t
@@ -34,11 +34,21 @@ visible regardless if the stanzas were filtered.
   $ dune exec ./bin.exe
   private_foo
 
+  $ rm -rf _build
+  $ dune build -p foo
+  $ dune install foo --prefix ./_install
+  Installing _install/lib/foo/META
+  Installing _install/lib/foo/bar/private_foo.a
+  Installing _install/lib/foo/bar/private_foo.cma
+  Installing _install/lib/foo/bar/private_foo.cmi
+  Installing _install/lib/foo/bar/private_foo.cmt
+  Installing _install/lib/foo/bar/private_foo.cmx
+  Installing _install/lib/foo/bar/private_foo.cmxa
+  Installing _install/lib/foo/bar/private_foo.cmxs
+  Installing _install/lib/foo/bar/private_foo.ml
+  Installing _install/lib/foo/dune-package
+
+  $ export OCAMLPATH=$PWD/_install/lib
   $ dune build -p bar
-  File "dune", line 8, characters 12-23:
-  8 |  (libraries private_foo)
-                  ^^^^^^^^^^^
-  Error: Library "private_foo" not found.
-  Hint: try:
-    dune external-lib-deps --missing -p bar @install
-  [1]
+  $ _build/install/default/bin/bin
+  private_foo


### PR DESCRIPTION
To fix this problem, I reuse the machinery in the deprecated library alias
stanza to inject a fake translation stanza for the private name. This is what
Jeremie recommended that I do.

The diff looks quite noisy and I'd appreciate some suggestions on how to
organize things a bit better here.