### PR TITLE
Record instrumentation backends in dune-package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@ Unreleased
   the object file, as long as they are the same after parsing. (#3739, fixes
   #3736, @rgrinberg)
 
+- Record instrumentation backends in dune-package files. This makes it possible
+  to use instrumentation backends defined in installed libraries (eg via OPAM).
+  (#3735, @nojb)
+
 2.7.0 (13/08/2020)
 ------------------
 

--- a/src/dune/dune_package.ml
+++ b/src/dune/dune_package.ml
@@ -59,6 +59,7 @@ module Lib = struct
     in
     let jsoo_runtime = Lib_info.jsoo_runtime info in
     let virtual_ = Option.is_some (Lib_info.virtual_ info) in
+    let instrumentation_backend = Lib_info.instrumentation_backend info in
     record_fields
     @@ [ field "name" Lib_name.encode name
        ; field "kind" Lib_kind.encode kind
@@ -82,6 +83,8 @@ module Lib = struct
        ; field_o "modules" Modules.encode modules
        ; field_o "special_builtin_support"
            Lib_info.Special_builtin_support.encode special_builtin_support
+       ; field_o "instrumentation.backend" (no_loc Lib_name.encode)
+           instrumentation_backend
        ]
     @ ( Sub_system_name.Map.to_list sub_systems
       |> List.map ~f:(fun (name, info) ->
@@ -145,6 +148,8 @@ module Lib = struct
          field_o "special_builtin_support"
            ( Dune_lang.Syntax.since Stanza.syntax (1, 10)
            >>> Lib_info.Special_builtin_support.decode )
+       and+ instrumentation_backend =
+         field_o "instrumentation.backend" (located Lib_name.decode)
        in
        let modes = Mode.Dict.Set.of_list modes in
        let info : Path.t Lib_info.t =
@@ -176,7 +181,7 @@ module Lib = struct
            ~jsoo_runtime ~jsoo_archive ~preprocess ~enabled ~virtual_deps
            ~dune_version ~virtual_ ~implements ~default_implementation ~modes
            ~wrapped ~special_builtin_support ~exit_module:None
-           ~instrumentation_backend:None
+           ~instrumentation_backend
        in
        { info; main_module_name; modules })
 

--- a/test/blackbox-tests/test-cases/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/instrumentation.t/run.t
@@ -11,7 +11,6 @@ Dune!" at the beginning of the module.
   >  (modules main)
   >  (libraries mylib)
   >  (instrumentation (backend hello)))
-  > 
   > (library
   >  (name mylib)
   >  (modules mylib)
@@ -106,3 +105,29 @@ Per-context setting takes precedence over per-workspace setting.
   $ dune build
 
   $ _build/coverage/main.exe
+
+Next, we check the backend can be used when it is installed.
+
+  $ dune build ppx/hello.install
+  $ dune install hello --prefix _install 2>/dev/null
+  $ grep instrumentation.backend _install/lib/hello/dune-package
+   (instrumentation.backend hello.ppx))
+  $ mkdir -p installed
+  $ cat >installed/dune-workspace <<EOF
+  > (lang dune 2.7)
+  > (instrument_with hello)
+  > EOF
+  $ cat >installed/dune-project <<EOF
+  > (lang dune 2.7)
+  > EOF
+  $ cat >installed/dune <<EOF
+  > (executable
+  >  (name main)
+  >  (instrumentation (backend hello)))
+  > EOF
+  $ cat >installed/main.ml <<EOF
+  > EOF
+  $ OCAMLPATH=$PWD/_install/lib dune build --root installed
+  Entering directory 'installed'
+  $ installed/_build/default/main.exe
+  Hello, Dune!


### PR DESCRIPTION
Embarrassingly, it seems that `instrumentation` backends are not recorded in `dune-package` which renders the feature unusable across installed libraries (eg `opam`). Bug discovered by @patricoferris.