### PR TITLE
Fix dune-package installation with meta templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,11 @@ Unreleased
   to use instrumentation backends defined in installed libraries (eg via OPAM).
   (#3735, @nojb)
 
-- Add missing `.aux` & `.glob` targets to coq rules (3721, fixes #3437,
+- Add missing `.aux` & `.glob` targets to coq rules (#3721, fixes #3437,
   @rgrinberg)
+
+- Fix `dune-package` installation when META templates are present (#3743, fixes
+  #3746, @rgrinberg)
 
 2.7.0 (13/08/2020)
 ------------------

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -167,7 +167,10 @@ module File_ops_real (W : Workspace) : File_operations = struct
     in
     if
       List.exists dp ~f:(function
-        | Dune_lang.List (Atom (A "version") :: _) -> true
+        | Dune_lang.List (Atom (A "version") :: _)
+        | Dune_lang.List [ Atom (A "use_meta"); Atom (A "true") ]
+        | Dune_lang.List [ Atom (A "use_meta") ] ->
+          true
         | _ -> false)
     then
       No_version_needed

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -22,16 +22,17 @@ custom version:
   > EOF
 
   $ cat >META.foobarlib.template <<EOF
+  > # DUNE_GEN
   > EOF
 
   $ dune build @install
 
-  $ cat _build/install/default/lib/foobarlib/dune-package
-  (lang dune 2.7)
-  (use_meta)
-
   $ dune install --prefix ./_install 2>&1 | grep -v Installing
   [1]
+
+  $ cat ./_install/lib/foobarlib/dune-package
+  (lang dune 2.7)
+  (use_meta)
 
   $ mkdir external
   $ echo "(lang dune 2.7)" > external/dune-project
@@ -45,8 +46,4 @@ custom version:
   $ OCAMLPATH=$PWD/_install/lib dune exec --root external ./main.exe
   Entering directory 'external'
   Entering directory 'external'
-  File "$TESTCASE_ROOT/_install/lib/foobarlib/dune-package", line 3, characters 1-8:
-  3 | (version 1.0)
-       ^^^^^^^
-  Error: Unknown field version
-  [1]
+  foobarlib

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -1,0 +1,52 @@
+This test demonstrates a bug when there's a package with a meta template and a
+custom version:
+
+  $ git init -q
+  $ git add .
+  $ git commit -qm _
+  $ git tag -a 1.0 -m 1.0
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.7)
+  > (package (name foobarlib))
+  > EOF
+
+  $ cat >foobarlib.ml <<EOF
+  > let foo () =
+  >   print_endline "foobarlib"
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name foobarlib))
+  > EOF
+
+  $ cat >META.foobarlib.template <<EOF
+  > EOF
+
+  $ dune build @install
+
+  $ cat _build/install/default/lib/foobarlib/dune-package
+  (lang dune 2.7)
+  (use_meta)
+
+  $ dune install --prefix ./_install 2>&1 | grep -v Installing
+  [1]
+
+  $ mkdir external
+  $ echo "(lang dune 2.7)" > external/dune-project
+  $ cat >external/main.ml <<EOF
+  > let () = Foobarlib.foo ()
+  > EOF
+  $ cat > external/dune <<EOF
+  > (executable (name main) (libraries foobarlib))
+  > EOF
+
+  $ OCAMLPATH=$PWD/_install/lib dune exec --root external ./main.exe
+  Entering directory 'external'
+  Entering directory 'external'
+  File "$TESTCASE_ROOT/_install/lib/foobarlib/dune-package", line 3, characters 1-8:
+  3 | (version 1.0)
+       ^^^^^^^
+  Error: Unknown field version
+  [1]


### PR DESCRIPTION
If (use_meta) is true, a version should not be added. It will be read
from the META file