### PR TITLE
Add back correct host for ppx.exe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,9 @@ Unreleased
   removed it to make room for new more important features (#4298,
   @jeremiedimino)
 
+- Fix `ppx.exe` being compiled for the wrong target when cross-compiling
+  (#3751, fixes #3698, @toots)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -383,6 +383,9 @@ let gen_rules sctx components =
 
 let ppx_driver_exe sctx libs =
   let key = Digest.to_string (Key.Decoded.of_libs libs |> Key.encode) in
+  (* Make sure to compile ppx.exe for the compiling host. See: #2252, #2286 and
+     #3698 *)
+  let sctx = SC.host sctx in
   ppx_exe sctx ~key
 
 let get_cookies ~loc ~expander ~lib_name libs =


### PR DESCRIPTION
Fixes: #3698, which is a regression from #2286. Should we add a test for it?