### PR TITLE
cram directory tests: skip empty directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ Unreleased
 
 - Resolve symlinks before running `$ git diff` (#3750, fixes #3740, @rgrinberg)
 
+- Cram tests: when checking that all test directories contain a `run.t` file,
+  skip empty directories. These can be left around by git. (#3753, @emillon)
+
 2.7.0 (13/08/2020)
 ------------------
 

--- a/src/dune_engine/file_tree.ml
+++ b/src/dune_engine/file_tree.ml
@@ -732,11 +732,15 @@ module Dir = struct
                    let file = Path.Source.relative dir fname in
                    Cram_test.Dir { file; dir }
                  in
-                 Some
-                   ( if String.Set.mem contents.contents.files fname then
-                     Ok test
-                   else
-                     Error (Missing_run_t test) ))
+                 let files = contents.contents.files in
+                 if String.Set.is_empty files then
+                   None
+                 else
+                   Some
+                     ( if String.Set.mem files fname then
+                       Ok test
+                     else
+                       Error (Missing_run_t test) ))
       in
       file_tests @ dir_tests
 end

--- a/test/blackbox-tests/test-cases/cram/kinds.t
+++ b/test/blackbox-tests/test-cases/cram/kinds.t
@@ -1,0 +1,73 @@
+Cram supports different kinds of tests.
+
+For any kind of test to work, the following has to be put in dune-project:
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.7)
+  > (cram enable)
+  > EOF
+
+Tests can be in a single file.
+
+  $ mkdir file
+  $ cat > file/file.t << EOF
+  >   $ echo File test
+  > EOF
+
+  $ dune runtest file
+  File "file/file.t", line 1, characters 0-0:
+  Error: Files _build/default/file/file.t and
+  _build/default/file/file.t.corrected differ.
+  [1]
+
+  $ dune promote file/file.t
+  Promoting _build/default/file/file.t.corrected to file/file.t.
+
+  $ cat file/file.t
+    $ echo File test
+    File test
+
+  $ dune runtest file
+
+They can be in a test directory. In this case, a run.t file must be present. All
+other files are visible within the test.
+
+  $ mkdir -p dir/dir.t
+  $ echo "Contents of file a" > dir/dir.t/a
+  $ cat > dir/dir.t/run.t << EOF
+  >   $ echo Dir test
+  >  
+  >   $ cat a
+  > EOF
+
+  $ dune runtest dir
+  File "dir/dir.t/run.t", line 1, characters 0-0:
+  Error: Files _build/default/dir/dir.t/run.t and
+  _build/default/dir/dir.t/run.t.corrected differ.
+  [1]
+
+  $ dune promote dir/dir.t/run.t
+  Promoting _build/default/dir/dir.t/run.t.corrected to dir/dir.t/run.t.
+
+  $ cat dir/dir.t/run.t
+    $ echo Dir test
+    Dir test
+   
+    $ cat a
+    Contents of file a
+
+  $ dune runtest dir
+
+If there is no run.t file, an error message is displayed.
+
+  $ mkdir -p dir-no-run/dir.t
+  $ echo "Contents of file a" > dir-no-run/dir.t/a
+  $ dune runtest dir-no-run
+  Error: Cram test directory dir-no-run/dir.t does not contain a run.t file.
+  [1]
+
+However, if the directory is empty, this check is skipped. (git can leave such
+empty directories)
+
+  $ mkdir -p dir-empty/dir.t
+  $ dune runtest dir-empty


### PR DESCRIPTION
In the case of cram directory tests (directories with a name that ends in .t), there's a check that they contain a `run.t` file. When that is not the case, the build errors out.

It can cause problems because empty directories are not tracked by git. An update can leave empty directories behind, which can make builds fail in a mysterious way.

This relaxes the existing check by skipping empty directories.