### PR TITLE
Fix issue #3737

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ Unreleased
 
 - Add (enabled_if ...) to (copy_files ...) (#3756, @nojb)
 
+- Make sure Dune cleans up the status line before exiting (#3767,
+  fixes #3737, @dosaylazy)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -702,10 +702,10 @@ end = struct
     let fiber =
       Fiber.Var.set t_var t (fun () -> Fiber.with_error_handler f ~on_error)
     in
-    Console.Status_line.set (Fun.const None);
     match Fiber.run fiber ~iter with
     | res ->
       assert (Event.pending_jobs () = 0);
+      Console.Status_line.set (Fun.const None);
       Ok res
     | exception Abort err -> Error err
     | exception exn -> Error (Exn (Exn_with_backtrace.capture exn))

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -711,15 +711,16 @@ end = struct
 
   let run_and_cleanup t f =
     let res = run t f in
-    Console.Status_line.set
-      (Fun.const
-         ( match res with
-           | Error Files_changed ->
-             Some
-               (Pp.seq
-                  (Pp.tag User_message.Style.Error (Pp.verbatim "Had errors"))
-                  (Pp.verbatim ", killing current build..."))
-           | _ -> None ));
+    let opt =
+      match res with
+      | Error Files_changed ->
+        Some
+          (Pp.seq
+             (Pp.tag User_message.Style.Error (Pp.verbatim "Had errors"))
+             (Pp.verbatim ", killing current build..."))
+      | _ -> None
+    in
+    Console.Status_line.set (Fun.const opt);
     match kill_and_wait_for_all_processes t () with
     | Got_signal -> Error Got_signal
     | Ok -> res

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -711,7 +711,7 @@ end = struct
 
   let run_and_cleanup t f =
     let res = run t f in
-    let opt =
+    let status_line =
       match res with
       | Error Files_changed ->
         Some
@@ -720,7 +720,7 @@ end = struct
              (Pp.verbatim ", killing current build..."))
       | _ -> None
     in
-    Console.Status_line.set (Fun.const opt);
+    Console.Status_line.set (Fun.const status_line);
     match kill_and_wait_for_all_processes t () with
     | Got_signal -> Error Got_signal
     | Ok -> res


### PR DESCRIPTION
As @emillon bisected, the bug was introduced in https://github.com/ocaml/dune/commit/5c133a06f8c5f252abe2b7a855834530fd57d5cb. This commit rewrote `pump_events` as `iter`. However, while `pump_events` ran `Console.Status_line.set (Fun.const None)` after the jobs were done, the rewritten code only did so before the jobs were started.

I assume that it is okay to remove the call `Console.Status_line.set (Fun.const None)` that occurs before the jobs start running, but I'm not sure because I'm unfamiliar with the Dune codebase.