### PR TITLE
Avoid project name comparison

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -746,7 +746,7 @@ module Library = struct
     let status =
       match conf.public with
       | None -> Lib_info.Status.Private conf.project
-      | Some p -> Public (Dune_project.name conf.project, p.package)
+      | Some p -> Public (conf.project, p.package)
     in
     let virtual_library = is_virtual conf in
     let foreign_archives = foreign_lib_files conf ~dir ~ext_lib in

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -177,15 +177,15 @@ end
 module Status = struct
   type t =
     | Installed
-    | Public of Dune_project.Name.t * Package.t
+    | Public of Dune_project.t * Package.t
     | Private of Dune_project.t
 
   let to_dyn x =
     let open Dyn.Encoder in
     match x with
     | Installed -> constr "Installed" []
-    | Public (name, package) ->
-      constr "Public" [ Dune_project.Name.to_dyn name; Package.to_dyn package ]
+    | Public (project, package) ->
+      constr "Public" [ Dune_project.to_dyn project; Package.to_dyn package ]
     | Private proj -> constr "Private" [ Dune_project.to_dyn proj ]
 
   let is_private = function
@@ -194,10 +194,11 @@ module Status = struct
     | Public _ ->
       false
 
-  let project_name = function
+  let project = function
     | Installed -> None
-    | Private project -> Some (Dune_project.name project)
-    | Public (name, _) -> Some name
+    | Private project
+    | Public (project, _) ->
+      Some project
 end
 
 module Source = struct

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -12,13 +12,13 @@ open Stdune
 module Status : sig
   type t =
     | Installed
-    | Public of Dune_project.Name.t * Package.t
+    | Public of Dune_project.t * Package.t
     | Private of Dune_project.t
 
   val is_private : t -> bool
 
-  (** For local libraries, return the project name they are part of *)
-  val project_name : t -> Dune_project.Name.t option
+  (** For local libraries, return the project they are part of *)
+  val project : t -> Dune_project.t option
 end
 
 (** For values like modules that need to be evaluated to be fetched *)

--- a/src/stdune/string.ml
+++ b/src/stdune/string.ml
@@ -187,12 +187,14 @@ let for_all =
   in
   fun s ~f -> loop s 0 (length s) f
 
+let quoted = Printf.sprintf "%S"
+
 let maybe_quoted s =
   let escaped = escaped s in
   if (s == escaped || s = escaped) && not (String.contains s ' ') then
     s
   else
-    Printf.sprintf {|"%s"|} escaped
+    quoted s
 
 module O = Comparable.Make (T)
 

--- a/src/stdune/string.mli
+++ b/src/stdune/string.mli
@@ -89,6 +89,8 @@ val for_all : t -> f:(char -> bool) -> bool
     whether to add the quote characters ends up being quite arbitrary. *) *)
 val maybe_quoted : t -> t
 
+val quoted : t -> t
+
 (** Produces: "x, y and z" *)
 val enumerate_and : string list -> string
 


### PR DESCRIPTION
Comparing by project name is unnecessary and a little fragile once we
allow duplicate project names in the same workspace.