### PR TITLE
Split Stanza_common from include stanza

### DIFF
--- a/src/dune_engine/include_stanza.ml
+++ b/src/dune_engine/include_stanza.ml
@@ -1,0 +1,52 @@
+open Import
+
+type context =
+  { current_file : Path.Source.t
+  ; include_stack : (Loc.t * Path.Source.t) list
+  }
+
+let in_file file = { current_file = file; include_stack = [] }
+
+let error { current_file = file; include_stack } =
+  let last, rest =
+    match include_stack with
+    | [] -> assert false
+    | last :: rest -> (last, rest)
+  in
+  let loc = fst (Option.value (List.last rest) ~default:last) in
+  let line_loc (loc, file) =
+    sprintf "%s:%d"
+      (Path.Source.to_string_maybe_quoted file)
+      loc.Loc.start.pos_lnum
+  in
+  User_error.raise ~loc
+    [ Pp.text "Recursive inclusion of dune files detected:"
+    ; Pp.textf "File %s is included from %s"
+        (Path.Source.to_string_maybe_quoted file)
+        (line_loc last)
+    ; Pp.vbox
+        (Pp.concat_map rest ~sep:Pp.cut ~f:(fun x ->
+             Pp.box ~indent:3
+               (Pp.seq (Pp.verbatim "-> ")
+                  (Pp.textf "included from %s" (line_loc x)))))
+    ]
+
+let load_sexps ~context:{ current_file; include_stack } (loc, fn) =
+  let include_stack = (loc, current_file) :: include_stack in
+  let dir = Path.Source.parent_exn current_file in
+  let current_file = Path.Source.relative dir fn in
+  if not (Path.exists (Path.source current_file)) then
+    User_error.raise ~loc
+      [ Pp.textf "File %s doesn't exist."
+          (Path.Source.to_string_maybe_quoted current_file)
+      ];
+  if
+    List.exists include_stack ~f:(fun (_, f) ->
+        Path.Source.equal f current_file)
+  then
+    error { current_file; include_stack };
+  let sexps =
+    Dune_lang.Parser.load ~lexer:Dune_lang.Lexer.token
+      (Path.source current_file) ~mode:Many
+  in
+  (sexps, { current_file; include_stack })

--- a/src/dune_engine/include_stanza.mli
+++ b/src/dune_engine/include_stanza.mli
@@ -1,0 +1,8 @@
+open Import
+
+type context
+
+val in_file : Path.Source.t -> context
+
+val load_sexps :
+  context:context -> Loc.t * string -> Dune_lang.Ast.t list * context

--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -331,9 +331,7 @@ let decode_includes ~context =
              ~f:(fun fn dir -> Filename.concat dir fn)
              ~init:fn path
          in
-         let sexps, context =
-           Stanza_common.Include.load_sexps ~context (loc, fn)
-         in
+         let sexps, context = Include_stanza.load_sexps ~context (loc, fn) in
          let* () = set_input sexps in
          fields (decode ~context ~path ~inside_include:true))
     in
@@ -345,6 +343,6 @@ let decode_includes ~context =
 
 let decode ~file =
   let open Dune_lang.Decoder in
-  let* sexps = decode_includes ~context:(Stanza_common.Include.in_file file) in
+  let* sexps = decode_includes ~context:(Include_stanza.in_file file) in
   let* () = set_input [ List (Loc.none, sexps) ] in
   decode

--- a/src/dune_rules/coq_stanza.ml
+++ b/src/dune_rules/coq_stanza.ml
@@ -1,7 +1,6 @@
 open! Dune_engine
 open Import
 open Dune_lang.Decoder
-open Stanza_common
 
 module Coqpp = struct
   type t =
@@ -99,7 +98,8 @@ module Theory = struct
             | None -> Package.Name.of_string name
             | Some (pkg, _) -> Package.Name.of_string pkg
           in
-          Pkg.resolve project pkg |> Result.map ~f:(fun pkg -> Some (loc, pkg)))
+          Stanza_common.Pkg.resolve project pkg
+          |> Result.map ~f:(fun pkg -> Some (loc, pkg)))
 
   let select_deprecation ~package ~public =
     match (package, public) with
@@ -122,13 +122,13 @@ module Theory = struct
   let decode =
     fields
       (let+ name = field "name" Coq_lib_name.decode
-       and+ package = field_o "package" Pkg.decode
+       and+ package = field_o "package" Stanza_common.Pkg.decode
        and+ project = Dune_project.get_exn ()
        and+ public = coq_public_decode
        and+ synopsis = field_o "synopsis" string
        and+ boot =
          field_b "boot" ~check:(Dune_lang.Syntax.since coq_syntax (0, 2))
-       and+ modules = modules_field "modules"
+       and+ modules = Stanza_common.modules_field "modules"
        and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:None ()
        and+ buildable = Buildable.decode in
        let package = select_deprecation ~package ~public in

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2062,16 +2062,14 @@ module Stanzas = struct
     List.concat_map sexps ~f:(parse stanza_parser)
     |> List.concat_map ~f:(function
          | Include (loc, fn) ->
-           let sexps, context =
-             Stanza_common.Include.load_sexps ~context (loc, fn)
-           in
+           let sexps, context = Include_stanza.load_sexps ~context (loc, fn) in
            parse_file_includes ~stanza_parser ~context sexps
          | stanza -> [ stanza ])
 
   let parse ~file (project : Dune_project.t) sexps =
     let stanza_parser = parser project in
     let stanzas =
-      let context = Stanza_common.Include.in_file file in
+      let context = Include_stanza.in_file file in
       parse_file_includes ~stanza_parser ~context sexps
     in
     let (_ : bool) =

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -1,4 +1,5 @@
-open Import
+open Stdune
+open Dune_engine
 open Dune_lang.Decoder
 
 (* Parse and resolve "package" fields *)
@@ -99,56 +100,3 @@ module Pkg = struct
 end
 
 let modules_field name = Ordered_set_lang.field name
-
-module Include = struct
-  type context =
-    { current_file : Path.Source.t
-    ; include_stack : (Loc.t * Path.Source.t) list
-    }
-
-  let in_file file = { current_file = file; include_stack = [] }
-
-  let error { current_file = file; include_stack } =
-    let last, rest =
-      match include_stack with
-      | [] -> assert false
-      | last :: rest -> (last, rest)
-    in
-    let loc = fst (Option.value (List.last rest) ~default:last) in
-    let line_loc (loc, file) =
-      sprintf "%s:%d"
-        (Path.Source.to_string_maybe_quoted file)
-        loc.Loc.start.pos_lnum
-    in
-    User_error.raise ~loc
-      [ Pp.text "Recursive inclusion of dune files detected:"
-      ; Pp.textf "File %s is included from %s"
-          (Path.Source.to_string_maybe_quoted file)
-          (line_loc last)
-      ; Pp.vbox
-          (Pp.concat_map rest ~sep:Pp.cut ~f:(fun x ->
-               Pp.box ~indent:3
-                 (Pp.seq (Pp.verbatim "-> ")
-                    (Pp.textf "included from %s" (line_loc x)))))
-      ]
-
-  let load_sexps ~context:{ current_file; include_stack } (loc, fn) =
-    let include_stack = (loc, current_file) :: include_stack in
-    let dir = Path.Source.parent_exn current_file in
-    let current_file = Path.Source.relative dir fn in
-    if not (Path.exists (Path.source current_file)) then
-      User_error.raise ~loc
-        [ Pp.textf "File %s doesn't exist."
-            (Path.Source.to_string_maybe_quoted current_file)
-        ];
-    if
-      List.exists include_stack ~f:(fun (_, f) ->
-          Path.Source.equal f current_file)
-    then
-      error { current_file; include_stack };
-    let sexps =
-      Dune_lang.Parser.load ~lexer:Dune_lang.Lexer.token
-        (Path.source current_file) ~mode:Many
-    in
-    (sexps, { current_file; include_stack })
-end

--- a/src/dune_rules/stanza_common.mli
+++ b/src/dune_rules/stanza_common.mli
@@ -1,4 +1,5 @@
-open Import
+open Stdune
+open Dune_engine
 
 module Pkg : sig
   val decode : Package.t Dune_lang.Decoder.t
@@ -12,12 +13,3 @@ module Pkg : sig
 end
 
 val modules_field : string -> Ordered_set_lang.t Dune_lang.Decoder.fields_parser
-
-module Include : sig
-  type context
-
-  val in_file : Path.Source.t -> context
-
-  val load_sexps :
-    context:context -> Loc.t * string -> Dune_lang.Ast.t list * context
-end


### PR DESCRIPTION
This allows to move most of the module to dune_rules. Since only the
include stanza is necessary in dune_engine.