### PR TITLE
Make Build_system.get_vcs private

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -70,9 +70,6 @@ val set_rule_generators :
 (** Set the list of VCS repositiories contained in the source tree *)
 val set_vcs : Vcs.t list -> unit Fiber.t
 
-(** Get the list of VCS repositiories contained in the source tree *)
-val get_vcs : unit -> Vcs.t list
-
 (** All other functions in this section must be called inside the rule generator
     callback. *)
 


### PR DESCRIPTION
This function isn't used outside of Build_system. We can remove it from
the interface.