### PR TITLE
Explicitly mention usage of js_of_ocaml-ppx

### DIFF
--- a/doc/jsoo.rst
+++ b/doc/jsoo.rst
@@ -42,6 +42,12 @@ And then request the ``.js`` target:
 Similar targets are created for libraries, but we recommend sticking to the
 executable targets.
 
+To support js_of_ocaml syntax extensions ``preprocess`` field is required:
+
+.. code:: scheme
+
+  (executable (name foo) (modes js) (preprocess (pps js_of_ocaml-ppx)))
+
 Separate compilation
 ====================
 


### PR DESCRIPTION
Added note that preprocess field is required for js_of_ocaml syntax extensions. This is not obvious when coming directly from js_of_ocaml page.