### PR TITLE
Improve library redirect behavior

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1990,7 +1990,10 @@ module Stanzas = struct
   let stanzas : constructors =
     [ ( "library"
       , let+ x = Library.decode in
-        [ Library x ] )
+        let base = [ Library x ] in
+        match Library_redirect.Local.of_lib x with
+        | None -> base
+        | Some r -> Library_redirect r :: base )
     ; ( "foreign_library"
       , let+ () = Dune_lang.Syntax.since Stanza.syntax (2, 0)
         and+ x = Foreign.Library.decode in

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -370,8 +370,6 @@ module Library_redirect : sig
 
   module Local : sig
     type nonrec t = (Loc.t * Lib_name.Local.t) t
-
-    val of_lib : Library.t -> t option
   end
 end
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -376,21 +376,12 @@ let gen_rules ~sctx ~dir components : Build_system.extra_sub_directories_to_keep
 
 let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
   List.filter_map ~f:(fun stanza ->
-      match Dune_file.stanza_package stanza with
-      | None -> Some stanza
-      | Some package -> (
-        if Package.Name.Map.mem visible_pkgs package.name then
-          Some stanza
-        else
-          match stanza with
-          | Library l ->
-            (* A public library should still be referable by its private name
-               even we filter it out. Therefore, we create a private -> public
-               name mapping for the filtered libraries *)
-            let open Option.O in
-            let+ dln = Library_redirect.Local.of_lib l in
-            Library_redirect dln
-          | _ -> None ))
+      let include_stanza =
+        match Dune_file.stanza_package stanza with
+        | None -> true
+        | Some package -> Package.Name.Map.mem visible_pkgs package.name
+      in
+      Option.some_if include_stanza stanza)
 
 let gen ~contexts ?only_packages conf =
   let open Fiber.O in

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -64,26 +64,12 @@ module DB = struct
               Dune_file.Deprecated_library_name.old_public_name s
             in
             [ Found_or_redirect.redirect old_public_name s.new_public_name ]
-          | Library (dir, (conf : Dune_file.Library.t)) -> (
+          | Library (dir, (conf : Dune_file.Library.t)) ->
             let info =
               Dune_file.Library.to_lib_info conf ~dir ~lib_config
               |> Lib_info.of_local
             in
-            match conf.visibility with
-            | Private ->
-              [ (Dune_file.Library.best_name conf, Found_or_redirect.found info)
-              ]
-            | Public p ->
-              let name = Dune_file.Public_lib.name p in
-              if Lib_name.equal name (Lib_name.of_local conf.name) then
-                [ (name, Found_or_redirect.found info) ]
-              else
-                let loc = Dune_file.Public_lib.loc p in
-                [ (name, Found_or_redirect.found info)
-                ; Found_or_redirect.redirect
-                    (Lib_name.of_local conf.name)
-                    (loc, name)
-                ] ))
+            [ (Dune_file.Library.best_name conf, Found_or_redirect.found info) ])
       |> Lib_name.Map.of_list_reducei
            ~f:(fun name (v1 : Found_or_redirect.t) v2 ->
              let res =


### PR DESCRIPTION
Previously, we'd add redirect for private libraries only if the
underlying libraries were filtered out. It's simpler, to just always add
a redirect and rmeove the additional logic for redirects when
constructing a library database.