### PR TITLE
Fix #3766 - Libraries without modules

### DIFF
--- a/src/dune_engine/ordered_set_lang.ml
+++ b/src/dune_engine/ordered_set_lang.ml
@@ -124,6 +124,11 @@ let is_standard t =
   | Ast.Standard -> true
   | _ -> false
 
+let is_empty_ast t =
+  match (t.ast : ast_expanded) with
+  | Ast.Union [] -> true
+  | _ -> false
+
 module Eval = struct
   let of_ast ~diff ~singleton ~union t ~parse ~standard =
     let rec loop (t : ast_expanded) =

--- a/src/dune_engine/ordered_set_lang.mli
+++ b/src/dune_engine/ordered_set_lang.mli
@@ -35,6 +35,8 @@ val replace_standard_with_empty : t -> t
 
 val is_standard : t -> bool
 
+val is_empty_ast : t -> bool
+
 val field :
   ?check:unit Dune_lang.Decoder.t -> string -> t Dune_lang.Decoder.fields_parser
 

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -163,6 +163,8 @@ module Buildable = struct
     ; allow_overlapping_dependencies : bool
     }
 
+  let no_modules_specified t = Ordered_set_lang.is_empty_ast t.modules
+
   let decode ~in_library ~allow_re_export =
     let use_foreign =
       Dune_lang.Syntax.deleted_in Stanza.syntax (2, 0)
@@ -750,7 +752,11 @@ module Library = struct
     let virtual_library = is_virtual conf in
     let foreign_archives = foreign_lib_files conf ~dir ~ext_lib in
     let native_archives =
-      [ Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib) ]
+      if Buildable.no_modules_specified conf.buildable then
+        []
+      else
+        [ Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib)
+        ]
     in
     let foreign_dll_files = foreign_dll_files conf ~dir ~ext_dll in
     let exit_module = Option.bind conf.stdlib ~f:(fun x -> x.exit_module) in

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -51,6 +51,8 @@ module Buildable : sig
     ; allow_overlapping_dependencies : bool
     }
 
+  val no_modules_specified : t -> bool
+
   (** Check if the buildable has any foreign stubs or archives. *)
   val has_foreign : t -> bool
 end

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1947,9 +1947,10 @@ let to_dune_lib ({ info; _ } as lib) ~modules ~foreign_objects ~dir =
         else
           Direct (loc, lib.name))
   in
+  let has_modules = Modules.is_empty modules in
   let info =
     Lib_info.for_dune_package info ~ppx_runtime_deps ~requires ~foreign_objects
-      ~obj_dir ~implements ~default_implementation ~sub_systems
+      ~obj_dir ~implements ~default_implementation ~sub_systems ~has_modules
   in
   Dune_package.Lib.make ~info ~modules:(Some modules) ~main_module_name
 

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -345,7 +345,7 @@ let best_src_dir t = Option.value ~default:t.src_dir t.orig_src_dir
 let set_version t version = { t with version }
 
 let for_dune_package t ~ppx_runtime_deps ~requires ~foreign_objects ~obj_dir
-    ~implements ~default_implementation ~sub_systems =
+    ~implements ~default_implementation ~sub_systems ~has_modules =
   let foreign_objects = Source.External foreign_objects in
   let orig_src_dir =
     match !Clflags.store_orig_src_dir with
@@ -361,6 +361,12 @@ let for_dune_package t ~ppx_runtime_deps ~requires ~foreign_objects ~obj_dir
             Path.source src_dir |> Path.to_absolute_filename |> Path.of_string )
         )
   in
+  let native_archives =
+    if has_modules then
+      t.native_archives
+    else
+      []
+  in
   { t with
     ppx_runtime_deps
   ; requires
@@ -370,6 +376,7 @@ let for_dune_package t ~ppx_runtime_deps ~requires ~foreign_objects ~obj_dir
   ; default_implementation
   ; sub_systems
   ; orig_src_dir
+  ; native_archives
   }
 
 let user_written_deps t =

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -182,6 +182,7 @@ val for_dune_package :
   -> implements:(Loc.t * Lib_name.t) option
   -> default_implementation:(Loc.t * Lib_name.t) option
   -> sub_systems:Sub_system_info.t Sub_system_name.Map.t
+  -> has_modules:bool
   -> Path.t t
 
 val map_path : 'a t -> f:('a -> 'a) -> 'a t

--- a/test/blackbox-tests/test-cases/github3766.t
+++ b/test/blackbox-tests/test-cases/github3766.t
@@ -1,0 +1,11 @@
+  $ cat >dune <<EOF
+  > (library
+  >  (name nomodules))
+  > EOF
+  $ echo "(lang dune 2.8)" > dune-project
+  $ dune build @all
+  File "dune", line 1, characters 0-27:
+  1 | (library
+  2 |  (name nomodules))
+  Warning: This library does not contain any modules. This should be specified
+  explicitly by setting an empty field: (modules).


### PR DESCRIPTION
Libraries without any modules must specify (modules) so that dune knows
whether it needs a native archive for this library without evaluating
any rules.