### PR TITLE
Move OSL from engine

### DIFF
--- a/src/dune_rules/ordered_set_lang.ml
+++ b/src/dune_rules/ordered_set_lang.ml
@@ -1,5 +1,5 @@
 open! Stdune
-open! Import
+open! Dune_engine
 
 module Ast = struct
   [@@@warning "-37"]

--- a/src/dune_rules/ordered_set_lang.mli
+++ b/src/dune_rules/ordered_set_lang.mli
@@ -2,7 +2,7 @@
     strings, with some set like operations. *)
 open! Stdune
 
-open Import
+open Dune_engine
 
 type t
 

--- a/src/dune_rules/ordered_set_lang_intf.ml
+++ b/src/dune_rules/ordered_set_lang_intf.ml
@@ -1,4 +1,4 @@
-open Import
+open Stdune
 
 module type Key = sig
   type t


### PR DESCRIPTION
Ordered_set_lang can live inside the rules library