### PR TITLE
Fix pipe action

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -717,7 +717,8 @@ The following constructions are available:
   and targets. This is useful if you are generating dependencies in a way
   that Dune doesn't know about, for instance by calling an external build system.
 - ``(pipe-<outputs> <DSL> <DSL> <DSL>...)`` to execute several actions (at least two)
-  in sequence, piping the output of each one into the input of the next.
+  in sequence, filtering the ``<outputs>`` of the first command through the other
+  command, piping the standard output of each one into the input of the next.
   This action is available since dune 2.7.
 
 As mentioned ``copy#`` inserts a line directive at the beginning of

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -453,7 +453,9 @@ and exec_pipe outputs ts ~ectx ~eenv =
   | [] -> assert false
   | t1 :: ts -> (
     let out = tmp_file () in
-    let* done_or_deps = redirect_out t1 ~ectx ~eenv outputs out in
+    let* done_or_deps =
+      redirect_out t1 ~ectx ~eenv:multi_use_eenv outputs out
+    in
     match done_or_deps with
     | Need_more_deps _ as need -> Fiber.return need
     | Done -> loop ~in_:out ts )

--- a/src/dune_engine/dtemp.mli
+++ b/src/dune_engine/dtemp.mli
@@ -4,7 +4,7 @@ open Stdune
 (** This returns a build path, but we don't rely on that *)
 val file : prefix:string -> suffix:string -> Path.t
 
-(** Add the temp env var to the enviornment passed or return the initial
+(** Add the temp env var to the environment passed or return the initial
     environment with the temp var added. *)
 val add_to_env : Env.t -> Env.t
 

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -52,7 +52,7 @@ type purpose =
   | Build_job of Path.Build.Set.t
 
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its
-    termination *)
+    termination. [stdout_to] [stderr_to] are released *)
 val run :
      ?dir:Path.t
   -> ?stdout_to:Io.output Io.t

--- a/src/dune_rules/action_to_sh.ml
+++ b/src/dune_rules/action_to_sh.ml
@@ -162,14 +162,23 @@ and pp = function
              | File fn -> fn )
          ])
   | Pipe (l, outputs) ->
-    let pipe =
+    let first_pipe,end_ =
       match outputs with
-      | Stdout -> " | "
-      | Outputs -> " 2>&1 | "
-      | Stderr -> " 2>&1 >/dev/null | "
+      | Stdout -> " | ", ""
+      | Outputs -> " 2>&1 | ", ""
+      | Stderr ->
+        " 2> >( ", " 1>&2 )"
     in
-    Pp.hovbox ~indent:2
-      (Pp.concat ~sep:(Pp.verbatim pipe) (List.map l ~f:block))
+    match l with
+    | [] -> assert false
+    | first::l ->
+      Pp.hovbox ~indent:2
+        (Pp.concat ~sep:Pp.space
+           [block first;
+            Pp.verbatim first_pipe;
+            Pp.concat ~sep:(Pp.verbatim "|") (List.map l ~f:block);
+            Pp.verbatim end_
+           ])
 
 let rec pp_seq = function
   | [] -> Pp.verbatim "true"

--- a/test/blackbox-tests/test-cases/pipe-actions.t/append_to_line.ml
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/append_to_line.ml
@@ -1,0 +1,9 @@
+let () =
+  try
+    while true do
+      let s = read_line () in
+      Printf.printf  "%s | o %s\n%!" s Sys.argv.(1);
+      Printf.eprintf "%s | e %s\n%!" s Sys.argv.(1);
+      ()
+    done
+  with End_of_file -> ()

--- a/test/blackbox-tests/test-cases/pipe-actions.t/echo_outputs.ml
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/echo_outputs.ml
@@ -1,0 +1,2 @@
+let () = Printf.printf "o %s\n%!" Sys.argv.(1)
+let () = Printf.eprintf "e %s\n%!" Sys.argv.(1)

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -98,18 +98,16 @@ The makefile version of pipe actions uses actual pipes:
   $ dune build _build/default/target-stderr.stdout _build/default/target-stderr.stderr
   $ cat _build/default/target-stderr.stdout
   o a
-  e a | o b
-  e a | e b | o c
   $ cat _build/default/target-stderr.stderr
-  e a | e b | e c
+  e a | e b
+  e a | o b | o c
+  e a | o b | e c
   $ dune build _build/default/target-outputs.stdout _build/default/target-outputs.stderr
   $ cat _build/default/target-outputs.stdout
   o a | o b | o c
-  o a | e b | o c
   e a | o b | o c
-  e a | e b | o c
   $ cat _build/default/target-outputs.stderr
+  o a | e b
+  e a | e b
   o a | o b | e c
-  o a | e b | e c
   e a | o b | e c
-  e a | e b | e c

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -88,22 +88,19 @@ The makefile version of pipe actions uses actual pipes:
   >    ))))
   > EOF
 
-  $ dune build _build/default/target-stdout.stdout _build/default/target-stdout.stderr 2>&1 | sed -e "s/build[0-9a-z]*\.dune/buildxxx.dune/g" -e "s/dune-pipe-action-[0-9a-z]*/dune-pipe-action-/g"
-           apl target-stdout.{stderr,stdout} (exit 2)
-  (cd _build/default && ../install/default/bin/apl b) < /tmp/buildxxx.dune/buildxxx.dune/dune-pipe-action-.stdout > /tmp/buildxxx.dune/buildxxx.dune/dune-pipe-action-.stdout 2> _build/default/target-stdout.stderr
+  $ dune build _build/default/target-stdout.stdout _build/default/target-stdout.stderr
   $ cat _build/default/target-stdout.stdout
-  cat: _build/default/target-stdout.stdout: No such file or directory
-  [1]
+  o a | o b | o c
   $ cat _build/default/target-stdout.stderr
-  cat: _build/default/target-stdout.stderr: No such file or directory
-  [1]
+  e a
+  o a | e b
+  o a | o b | e c
   $ dune build _build/default/target-stderr.stdout _build/default/target-stderr.stderr
   $ cat _build/default/target-stderr.stdout
   o a
-  $ cat _build/default/target-stderr.stderr
-  e a | o b | o c
-  e a | o b | e c
+  e a | o b
   e a | e b | o c
+  $ cat _build/default/target-stderr.stderr
   e a | e b | e c
   $ dune build _build/default/target-outputs.stdout _build/default/target-outputs.stderr
   $ cat _build/default/target-outputs.stdout

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -61,7 +61,6 @@ The makefile version of pipe actions uses actual pipes:
   	../install/default/bin/a 2>&1 | ../install/default/bin/b 2>&1 | ../install/default/bin/c \
   	  &> target
   
-
   $ cat >dune <<EOF
   > (executable
   >  (public_name apl) (name append_to_line) (modules append_to_line))
@@ -71,21 +70,27 @@ The makefile version of pipe actions uses actual pipes:
   > (rule
   >  (action
   >   (with-stderr-to target-stdout.stderr
-  >   (with-stdout-to target-stdout.stdout
-  >       (pipe-stdout (run echo-outputs a) (run apl b) (run apl c))
-  >    ))))
+  >    (with-stdout-to target-stdout.stdout
+  >     (pipe-stdout
+  >      (run echo-outputs a)
+  >      (run apl b)
+  >      (run apl c))))))
   > (rule
   >  (action
   >   (with-stderr-to target-stderr.stderr
-  >   (with-stdout-to target-stderr.stdout
-  >       (pipe-stderr (run echo-outputs a) (run apl b) (run apl c))
-  >    ))))
+  >    (with-stdout-to target-stderr.stdout
+  >     (pipe-stderr
+  >      (run echo-outputs a)
+  >      (run apl b)
+  >      (run apl c))))))
   > (rule
   >  (action
   >   (with-stderr-to target-outputs.stderr
   >   (with-stdout-to target-outputs.stdout
-  >       (pipe-outputs (run echo-outputs a) (run apl b) (run apl c))
-  >    ))))
+  >    (pipe-outputs
+  >     (run echo-outputs a)
+  >     (run apl b)
+  >     (run apl c))))))
   > EOF
 
   $ dune build _build/default/target-stdout.stdout _build/default/target-stdout.stderr


### PR DESCRIPTION
The execution of the outputs of the first command was not duplicated so it could fail in some cases. The first commit shows such error but one for `pipe-stderr` can be also produced if both outputs are sent to one file. The second commits fixes the problem, but when we need to duplicate a `Process.Io` is not clear to me.

However the semantic of `pipe-stderr` and in some way `pipe-outputs` seems  strange. Usually piping is used for filtering from `stdin` to `stdout` (`grep`, `sed`, ... work on those not `stderr`). `stderr` is used for errors in the pipe, but are not also filtered by the others. For doing `pipe-outputs` in shell, usually one write `cmd |& cmd1 | cmd2 | cmd3` not `cmd |& cmd1 |& cmd2 |& cmd3`. If `pipe-stderr` filter only `stderr` not `stdout`, I believe the result of the filtering should go to `stderr`.

This change is a breaking change but since the the action was not clear and failing, it could be seen as a fix.