### PR TITLE
Add necessary C++ flags for most common compilers

### DIFF
--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -160,7 +160,7 @@ type t =
   ; implicit_transitive_deps : bool
   ; wrapped_executables : bool
   ; dune_version : Dune_lang.Syntax.Version.t
-  ; add_cxx_flags : bool
+  ; use_standard_c_and_cxx_flags : bool
   ; generate_opam_files : bool
   ; file_key : File_key.t
   ; dialects : Dialect.DB.t
@@ -190,7 +190,7 @@ let file_key t = t.file_key
 
 let implicit_transitive_deps t = t.implicit_transitive_deps
 
-let add_cxx_flags t = t.add_cxx_flags
+let use_standard_c_and_cxx_flags t = t.use_standard_c_and_cxx_flags
 
 let generate_opam_files t = t.generate_opam_files
 
@@ -211,7 +211,7 @@ let to_dyn
     ; implicit_transitive_deps
     ; wrapped_executables
     ; dune_version
-    ; add_cxx_flags
+    ; use_standard_c_and_cxx_flags
     ; generate_opam_files
     ; file_key
     ; dialects
@@ -233,7 +233,7 @@ let to_dyn
     ; ("implicit_transitive_deps", bool implicit_transitive_deps)
     ; ("wrapped_executables", bool wrapped_executables)
     ; ("dune_version", Dune_lang.Syntax.Version.to_dyn dune_version)
-    ; ("add_cxx_flags", bool add_cxx_flags)
+    ; ("use_standard_c_and_cxx_flags", bool use_standard_c_and_cxx_flags)
     ; ("generate_opam_files", bool generate_opam_files)
     ; ("file_key", string file_key)
     ; ("dialects", Dialect.DB.to_dyn dialects)
@@ -609,7 +609,7 @@ let infer ~dir packages =
   ; extension_args
   ; parsing_context
   ; dune_version = lang.version
-  ; add_cxx_flags = false
+  ; use_standard_c_and_cxx_flags = false
   ; generate_opam_files = false
   ; file_key
   ; dialects = Dialect.DB.builtin
@@ -691,8 +691,8 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
              "It is useless since the Merlin configurations are not ambiguous \
               anymore."
            loc lang.syntax (2, 8) ~what:"This field"
-     and+ add_cxx_flags =
-       field_o_b "add_cxx_flags"
+     and+ use_standard_c_and_cxx_flags =
+       field_o_b "use_standard_c_and_cxx_flags"
          ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 8))
      and+ () = Dune_lang.Versioned_file.no_more_lang
      and+ generate_opam_files =
@@ -806,7 +806,9 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
          ~default:(strict_package_deps_default ~lang)
      in
      let dune_version = lang.version in
-     let add_cxx_flags = Option.value ~default:false add_cxx_flags in
+     let use_standard_c_and_cxx_flags =
+       Option.value ~default:false use_standard_c_and_cxx_flags
+     in
      let explicit_js_mode =
        Option.value explicit_js_mode ~default:(explicit_js_mode_default ~lang)
      in
@@ -856,7 +858,7 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
      ; implicit_transitive_deps
      ; wrapped_executables
      ; dune_version
-     ; add_cxx_flags
+     ; use_standard_c_and_cxx_flags
      ; generate_opam_files
      ; dialects
      ; explicit_js_mode

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -160,6 +160,7 @@ type t =
   ; implicit_transitive_deps : bool
   ; wrapped_executables : bool
   ; dune_version : Dune_lang.Syntax.Version.t
+  ; add_cxx_flags : bool
   ; generate_opam_files : bool
   ; file_key : File_key.t
   ; dialects : Dialect.DB.t
@@ -189,6 +190,8 @@ let file_key t = t.file_key
 
 let implicit_transitive_deps t = t.implicit_transitive_deps
 
+let add_cxx_flags t = t.add_cxx_flags
+
 let generate_opam_files t = t.generate_opam_files
 
 let dialects t = t.dialects
@@ -208,6 +211,7 @@ let to_dyn
     ; implicit_transitive_deps
     ; wrapped_executables
     ; dune_version
+    ; add_cxx_flags
     ; generate_opam_files
     ; file_key
     ; dialects
@@ -229,6 +233,7 @@ let to_dyn
     ; ("implicit_transitive_deps", bool implicit_transitive_deps)
     ; ("wrapped_executables", bool wrapped_executables)
     ; ("dune_version", Dune_lang.Syntax.Version.to_dyn dune_version)
+    ; ("add_cxx_flags", bool add_cxx_flags)
     ; ("generate_opam_files", bool generate_opam_files)
     ; ("file_key", string file_key)
     ; ("dialects", Dialect.DB.to_dyn dialects)
@@ -604,6 +609,7 @@ let infer ~dir packages =
   ; extension_args
   ; parsing_context
   ; dune_version = lang.version
+  ; add_cxx_flags = false
   ; generate_opam_files = false
   ; file_key
   ; dialects = Dialect.DB.builtin
@@ -685,6 +691,9 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
              "It is useless since the Merlin configurations are not ambiguous \
               anymore."
            loc lang.syntax (2, 8) ~what:"This field"
+     and+ add_cxx_flags =
+       field_o_b "add_cxx_flags"
+         ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 8))
      and+ () = Dune_lang.Versioned_file.no_more_lang
      and+ generate_opam_files =
        field_o_b "generate_opam_files"
@@ -797,6 +806,7 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
          ~default:(strict_package_deps_default ~lang)
      in
      let dune_version = lang.version in
+     let add_cxx_flags = Option.value ~default:false add_cxx_flags in
      let explicit_js_mode =
        Option.value explicit_js_mode ~default:(explicit_js_mode_default ~lang)
      in
@@ -846,6 +856,7 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
      ; implicit_transitive_deps
      ; wrapped_executables
      ; dune_version
+     ; add_cxx_flags
      ; generate_opam_files
      ; dialects
      ; explicit_js_mode

--- a/src/dune_engine/dune_project.mli
+++ b/src/dune_engine/dune_project.mli
@@ -63,9 +63,11 @@ val root : t -> Path.Source.t
 
 val stanza_parser : t -> Stanza.t list Dune_lang.Decoder.t
 
-(** The option [add_cxx_flags] enables the automatic addition of flags necessary
-    to build c++ files with the active c compiler *)
-val add_cxx_flags : t -> bool
+(** The option [use_standard_c_and_cxx_flags] enables the automatic addition of
+    flags necessary to build c++ files with the active C compiler. It also
+    disables the automatic addition of C flags from [ocamlc -config] to the
+    compiler command line when building C stubs. *)
+val use_standard_c_and_cxx_flags : t -> bool
 
 val generate_opam_files : t -> bool
 

--- a/src/dune_engine/dune_project.mli
+++ b/src/dune_engine/dune_project.mli
@@ -63,6 +63,10 @@ val root : t -> Path.Source.t
 
 val stanza_parser : t -> Stanza.t list Dune_lang.Decoder.t
 
+(** The option [add_cxx_flags] enables the automatic addition of flags necessary
+    to build c++ files with the active c compiler *)
+val add_cxx_flags : t -> bool
+
 val generate_opam_files : t -> bool
 
 val dialects : t -> Dialect.DB.t

--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -1,0 +1,11 @@
+open! Stdune
+open Ocaml_config.Ccomp_type
+
+let base_cxx_flags =
+  [ (Gcc, [ "-x"; "c++"; "-lstdc++"; "-shared-libgcc" ])
+  ; (Clang, [ "-x"; "c++" ])
+  ; (Msvc, [ "/TP" ])
+  ]
+
+let get_flags ccomp_type =
+  List.assoc_opt ccomp_type base_cxx_flags |> Option.value ~default:[]

--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -23,9 +23,7 @@ let ccomp_type dir =
   let+ ccomp = Build.contents (Path.build filepath) in
   match String.trim ccomp with
   | "clang" -> Clang
-  | "gcc"
-  | "mingw" ->
-    Gcc
+  | "gcc" -> Gcc
   | "msvc" -> Msvc
   | s -> Other s
 

--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -7,11 +7,11 @@ type ccomp_type =
   | Clang
   | Other of string
 
-let base_cxx_flags =
-  [ (Gcc, [ "-x"; "c++"; "-lstdc++"; "-shared-libgcc" ])
-  ; (Clang, [ "-x"; "c++" ])
-  ; (Msvc, [ "/TP" ])
-  ]
+let base_cxx_flags = function
+  | Gcc -> [ "-x"; "c++"; "-lstdc++"; "-shared-libgcc" ]
+  | Clang -> [ "-x"; "c++" ]
+  | Msvc -> [ "/TP" ]
+  | _ -> []
 
 let preprocessed_filename = "ccomp"
 
@@ -42,4 +42,4 @@ let get_flags dir =
   let open Build.O in
   let+ ccomp_type = ccomp_type dir in
   check_warn ccomp_type;
-  List.assoc_opt ccomp_type base_cxx_flags |> Option.value ~default:[]
+  base_cxx_flags ccomp_type

--- a/src/dune_rules/cxx_flags.mli
+++ b/src/dune_rules/cxx_flags.mli
@@ -1,0 +1,6 @@
+(** This module contains a small database of flags that is used when compiling C
+    and C++ stubs. *)
+
+(** [get_flags c_compiler] returns the necessary flags to turn this compiler
+    into a c++ compiler for some of the most common compilers *)
+val get_flags : Ocaml_config.Ccomp_type.t -> string list

--- a/src/dune_rules/cxx_flags.mli
+++ b/src/dune_rules/cxx_flags.mli
@@ -1,6 +1,13 @@
 (** This module contains a small database of flags that is used when compiling C
     and C++ stubs. *)
+open! Stdune
+
+open Dune_engine
+
+(** The name of the file created in the .dune folder after calling the C
+    preprocessor *)
+val preprocessed_filename : string
 
 (** [get_flags c_compiler] returns the necessary flags to turn this compiler
     into a c++ compiler for some of the most common compilers *)
-val get_flags : Ocaml_config.Ccomp_type.t -> string list
+val get_flags : Path.Build.t -> string list Build.t

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -19,7 +19,7 @@ CCOMP
 |}
 
 let rules ~sctx ~dir =
-  let file = Path.Build.relative dir "ccomp" in
+  let file = Path.Build.relative dir Cxx_flags.preprocessed_filename in
   let ocfg = (Super_context.context sctx).ocaml_config in
   let prog =
     Super_context.resolve_program sctx ~dir ~loc:None

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -30,10 +30,11 @@ let rules ~sctx ~dir =
   let write_test_file = Action.write_file header_file header_file_content in
   let args =
     let open Command.Args in
-    ( match Ocaml_config.ccomp_type ocfg with
-    | Msvc -> [ A "/EP" ]
-    | Other _ -> [ A "-E"; A "-P" ] )
-    @ [ A Path.(to_absolute_filename (build header_file)) ]
+    [ ( match Ocaml_config.ccomp_type ocfg with
+      | Msvc -> A "/EP"
+      | Other _ -> As [ "-E"; "-P" ] )
+    ; A Path.(to_absolute_filename (build header_file))
+    ]
   in
   let action =
     let open Build.With_targets.O in

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -5,8 +5,6 @@ let header_file_content =
   {|
 #if defined( __clang__ )
   #define CCOMP clang
-#elif defined( __MINGW32__) || defined( __MINGW64__ )
-  #define CCOMP mingw
 #elif defined( _MSC_VER )
   #define CCOMP msvc
 #elif defined( __GNUC__ )

--- a/src/dune_rules/cxx_rules.mli
+++ b/src/dune_rules/cxx_rules.mli
@@ -1,0 +1,3 @@
+(** Preprocessing-based C compiler detection *)
+
+val rules : sctx:Super_context.t -> dir:Stdune.Path.Build.t -> unit

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -123,9 +123,7 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
             Disabled )
   in
   let foreign_flags =
-    inherited ~field:foreign_flags
-      ~root:(Foreign_language.Dict.map ~f:Build.return default_context_flags)
-      (fun flags ->
+    inherited ~field:foreign_flags ~root:default_context_flags (fun flags ->
         let expander = Expander.set_dir (Memo.Lazy.force expander) ~dir in
         Foreign_language.Dict.mapi config.foreign_flags ~f:(fun ~language f ->
             let standard = Foreign_language.Dict.get flags language in

--- a/src/dune_rules/env_node.mli
+++ b/src/dune_rules/env_node.mli
@@ -25,7 +25,7 @@ val make :
   -> profile:Profile.t
   -> expander:Expander.t Memo.Lazy.t
   -> expander_for_artifacts:Expander.t Memo.Lazy.t
-  -> default_context_flags:string list Foreign_language.Dict.t
+  -> default_context_flags:string list Build.t Foreign_language.Dict.t
   -> default_env:Env.t
   -> default_bin_artifacts:Artifacts.Bin.t
   -> t

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -86,9 +86,20 @@ let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
         ]
     | Foreign_language.Cxx ->
       let base_flags =
+        let ccomp_type = Ocaml_config.ccomp_type cfg in
         let scope = Super_context.find_scope_by_dir sctx dir in
         if Dune_project.add_cxx_flags (Scope.project scope) then
-          Cxx_flags.get_flags (Ocaml_config.ccomp_type cfg)
+          match ccomp_type with
+          | Ocaml_config.Ccomp_type.Other s ->
+            User_warning.emit
+              [ Pp.textf
+                  "Dune was not able to automatically infer the C compiler in \
+                   use: \"%s\". Please open an issue on github to help us \
+                   improve this feature."
+                  s
+              ];
+            []
+          | _ -> Cxx_flags.get_flags ccomp_type
         else
           []
       in

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -75,21 +75,23 @@ let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
 
 let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
   let ctx = Super_context.context sctx in
-  let flags =
-    let ctx_flags =
-      match kind with
-      | Foreign_language.C ->
-        let cfg = ctx.ocaml_config in
-        List.concat
-          [ Ocaml_config.ocamlc_cflags cfg
-          ; Ocaml_config.ocamlc_cppflags cfg
-          ; Fdo.c_flags ctx
-          ]
-      | Foreign_language.Cxx -> Fdo.cxx_flags ctx
-    in
+  let base_flags =
+    let cfg = ctx.ocaml_config in
+    match kind with
+    | Foreign_language.C ->
+      List.concat
+        [ Ocaml_config.ocamlc_cflags cfg
+        ; Ocaml_config.ocamlc_cppflags cfg
+        ; Fdo.c_flags ctx
+        ]
+    | Foreign_language.Cxx ->
+      List.concat
+        [ Cxx_flags.get_flags (Ocaml_config.ccomp_type cfg); Fdo.cxx_flags ctx ]
+  in
+  let with_user_and_std_flags =
     let flags = Foreign.Source.flags src in
     Super_context.foreign_flags sctx ~dir ~expander ~flags ~language:kind
-    |> Build.map ~f:(List.append ctx_flags)
+    |> Build.map ~f:(List.append base_flags)
   in
   let output_param =
     match ctx.lib_config.ccomp_type with
@@ -108,7 +110,7 @@ let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
         produced in the current directory *)
      Command.run ~dir:(Path.build dir)
        (Super_context.resolve_program ~loc:None ~dir sctx c_compiler)
-       ( [ Command.Args.dyn flags
+       ( [ Command.Args.dyn with_user_and_std_flags
          ; S [ A "-I"; Path ctx.stdlib_dir ]
          ; include_flags
          ]

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -84,26 +84,7 @@ let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
         ; Ocaml_config.ocamlc_cppflags cfg
         ; Fdo.c_flags ctx
         ]
-    | Foreign_language.Cxx ->
-      let base_flags =
-        let ccomp_type = Ocaml_config.ccomp_type cfg in
-        let scope = Super_context.find_scope_by_dir sctx dir in
-        if Dune_project.add_cxx_flags (Scope.project scope) then
-          match ccomp_type with
-          | Ocaml_config.Ccomp_type.Other s ->
-            User_warning.emit
-              [ Pp.textf
-                  "Dune was not able to automatically infer the C compiler in \
-                   use: \"%s\". Please open an issue on github to help us \
-                   improve this feature."
-                  s
-              ];
-            []
-          | _ -> Cxx_flags.get_flags ccomp_type
-        else
-          []
-      in
-      List.concat [ base_flags; Fdo.cxx_flags ctx ]
+    | Foreign_language.Cxx -> Fdo.cxx_flags ctx
   in
   let with_user_and_std_flags =
     let flags = Foreign.Source.flags src in

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -85,8 +85,14 @@ let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
         ; Fdo.c_flags ctx
         ]
     | Foreign_language.Cxx ->
-      List.concat
-        [ Cxx_flags.get_flags (Ocaml_config.ccomp_type cfg); Fdo.cxx_flags ctx ]
+      let base_flags =
+        let scope = Super_context.find_scope_by_dir sctx dir in
+        if Dune_project.add_cxx_flags (Scope.project scope) then
+          Cxx_flags.get_flags (Ocaml_config.ccomp_type cfg)
+        else
+          []
+      in
+      List.concat [ base_flags; Fdo.cxx_flags ctx ]
   in
   let with_user_and_std_flags =
     let flags = Foreign.Source.flags src in

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -301,6 +301,8 @@ let gen_rules ~sctx ~dir components : Build_system.extra_sub_directories_to_keep
          attached to [write_dot_dune_dir] in context.ml *)
       Super_context.add_rule sctx ~dir
         (Build.write_file (Path.Build.relative dir "configurator") "");
+      (* Add rules for C compiler detection *)
+      Cxx_rules.rules ~sctx ~dir;
       These String.Set.empty
     | ".js" :: rest -> (
       Jsoo_rules.setup_separate_compilation_rules sctx rest;

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -12,22 +12,13 @@ let default_context_flags (ctx : Context.t) ~project =
   in
   let cxx =
     if Dune_project.use_standard_c_and_cxx_flags project then
-      let ccomp_type = Ocaml_config.ccomp_type ctx.ocaml_config in
-      match ccomp_type with
-      | Ocaml_config.Ccomp_type.Other s ->
-        User_warning.emit
-          [ Pp.textf
-              "Dune was not able to automatically infer the C compiler in use: \
-               \"%s\". Please open an issue on github to help us improve this \
-               feature."
-              s
-          ];
-        cxx
-      | _ -> Cxx_flags.get_flags ccomp_type @ cxx
+      let open Build.O in
+      let+ db_flags = Cxx_flags.get_flags ctx.build_dir in
+      db_flags @ cxx
     else
-      cxx
+      Build.return cxx
   in
-  Foreign_language.Dict.make ~c ~cxx
+  Foreign_language.Dict.make ~c:(Build.return c) ~cxx
 
 module Env_tree : sig
   type t

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -11,7 +11,7 @@ let default_context_flags (ctx : Context.t) ~project =
     List.filter c ~f:(fun s -> not (String.is_prefix s ~prefix:"-std="))
   in
   let cxx =
-    if Dune_project.add_cxx_flags project then
+    if Dune_project.use_standard_c_and_cxx_flags project then
       let ccomp_type = Ocaml_config.ccomp_type ctx.ocaml_config in
       match ccomp_type with
       | Ocaml_config.Ccomp_type.Other s ->

--- a/test/blackbox-tests/test-cases/cxx-flags.t/baz.cpp
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/baz.cpp
@@ -1,0 +1,2 @@
+#include <caml/mlvalues.h>
+extern "C" value baz(value unit) { return Val_int(2046); }

--- a/test/blackbox-tests/test-cases/cxx-flags.t/dune
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/dune
@@ -7,3 +7,4 @@
  (name main)
  (libraries quad)
  (modules main))
+

--- a/test/blackbox-tests/test-cases/cxx-flags.t/dune
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/dune
@@ -1,0 +1,9 @@
+(library
+ (name quad)
+ (modules quad)
+ (foreign_stubs (language cxx) (names baz)))
+
+(executable
+ (name main)
+ (libraries quad)
+ (modules main))

--- a/test/blackbox-tests/test-cases/cxx-flags.t/main.ml
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/main.ml
@@ -1,0 +1,1 @@
+let () = Printf.printf "%d" (Quad.quad ())

--- a/test/blackbox-tests/test-cases/cxx-flags.t/quad.ml
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/quad.ml
@@ -1,0 +1,2 @@
+external baz : unit -> int = "baz"
+let quad x = baz x

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -2,9 +2,17 @@
   > (lang dune 2.8)
   > EOF
 
+The flags that Dune should use
   $ GCCF="-x c++ -lstdc++ -shared-libgcc"
   $ ClangF="-x c++"
   $ MsvcF="/TP"
+
+Check compiler detection
+  $ dune build .dune/ccomp
+
+  $ cat _build/default/.dune/ccomp |
+  > grep -ce "clang\|gcc\|msvc"
+  1
 
 Default: use_standard_c_and_cxx_flags = false
   $ dune rules baz.o | tr -s '\n' ' ' |

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -1,0 +1,38 @@
+  $ cat >dune-project <<EOF
+  > (lang dune 2.8)
+  > EOF
+
+  $ GCCF="-x c++ -lstdc++ -shared-libgcc"
+  $ ClangF="-x c++"
+  $ MsvcF="/TP"
+
+Default: add_cxx_flags = false
+  $ dune rules baz.o | tr -s '\n' ' ' |
+  > grep -ce "$GCCF\|$ClangF|$MsvcF"
+  0
+  [1]
+
+
+With add_cxx_flags = false
+  $ cat >dune-project <<EOF
+  > (lang dune 2.8)
+  > (no_forced_c_flags_and_more_cxx_flags false)
+  > EOF
+
+  $ dune rules baz.o | tr -s '\n' ' ' |
+  > grep -ce "$GCCF\|$ClangF|$MsvcF"
+  0
+  [1]
+
+With add_cxx_flags = true
+  $ cat >dune-project <<EOF
+  > (lang dune 2.8)
+  > (no_forced_c_flags_and_more_cxx_flags true)
+  > EOF
+
+  $ dune rules baz.o  | tr -s '\n' ' ' |
+  > grep -ce "$GCCF\|$ClangF\|$MsvcF"
+  1
+
+  $ dune exec ./main.exe
+  2046

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -6,17 +6,17 @@
   $ ClangF="-x c++"
   $ MsvcF="/TP"
 
-Default: add_cxx_flags = false
+Default: use_standard_c_and_cxx_flags = false
   $ dune rules baz.o | tr -s '\n' ' ' |
   > grep -ce "$GCCF\|$ClangF|$MsvcF"
   0
   [1]
 
 
-With add_cxx_flags = false
+With use_standard_c_and_cxx_flags = false
   $ cat >dune-project <<EOF
   > (lang dune 2.8)
-  > (no_forced_c_flags_and_more_cxx_flags false)
+  > (use_standard_c_and_cxx_flags false)
   > EOF
 
   $ dune rules baz.o | tr -s '\n' ' ' |
@@ -24,10 +24,10 @@ With add_cxx_flags = false
   0
   [1]
 
-With add_cxx_flags = true
+With use_standard_c_and_cxx_flags = true
   $ cat >dune-project <<EOF
   > (lang dune 2.8)
-  > (no_forced_c_flags_and_more_cxx_flags true)
+  > (use_standard_c_and_cxx_flags true)
   > EOF
 
   $ dune rules baz.o  | tr -s '\n' ' ' |

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -1,20 +1,23 @@
+Default: use_standard_c_and_cxx_flags = false
+=============================================
+
   $ cat >dune-project <<EOF
   > (lang dune 2.8)
   > EOF
 
-The flags that Dune should use
+> The flags that Dune should use
   $ GCCF="-x c++ -lstdc++ -shared-libgcc"
   $ ClangF="-x c++"
   $ MsvcF="/TP"
 
-Check compiler detection
+> Check that compiler detection is done
   $ dune build .dune/ccomp
 
   $ cat _build/default/.dune/ccomp |
   > grep -ce "clang\|gcc\|msvc"
   1
 
-Default: use_standard_c_and_cxx_flags = false
+> No specific flags added
   $ dune rules baz.o | tr -s '\n' ' ' |
   > grep -ce "$GCCF\|$ClangF|$MsvcF"
   0
@@ -22,22 +25,35 @@ Default: use_standard_c_and_cxx_flags = false
 
 
 With use_standard_c_and_cxx_flags = false
+=========================================
+
   $ cat >dune-project <<EOF
   > (lang dune 2.8)
   > (use_standard_c_and_cxx_flags false)
   > EOF
 
+> No specific flags added
   $ dune rules baz.o | tr -s '\n' ' ' |
   > grep -ce "$GCCF\|$ClangF|$MsvcF"
   0
   [1]
 
 With use_standard_c_and_cxx_flags = true
+========================================
+
   $ cat >dune-project <<EOF
   > (lang dune 2.8)
   > (use_standard_c_and_cxx_flags true)
   > EOF
 
+> Check that compiler detection is done
+  $ dune build .dune/ccomp
+
+  $ cat _build/default/.dune/ccomp |
+  > grep -ce "clang\|gcc\|msvc"
+  1
+
+> Specific flags added
   $ dune rules baz.o  | tr -s '\n' ' ' |
   > grep -ce "$GCCF\|$ClangF\|$MsvcF"
   1


### PR DESCRIPTION
This PR is an attempt to answer #3528.

It adds a new module with a small "database" of C++ flags that are necessary to the use of some of the most common C compiler to build C++ code.

Given the actual context and whether C or C++ code is being built, this module provide the set of necessary flags that should be added to the compiler command line : from the database mentioned above for C++ and from the config `ocamlc_cflags` and `ocamlc_cppflags` for C. For convenience it also add the FDO flags tot he list and also returns the output args that should be used for the specified compiler.

The main issue is that, because these C++ flags where not added by Dune before, users probably added them themselves and they will be duplicated in the command line. I am not sure whether this would break builds or not, but if it does we should consider enabling this change only for dune 2.8 or with a specific option in the dune-project file.

The added flags for C++ are the following:


Compiler | C++ flags
-|-
gcc | `-x c++ -lstdc++ -shared-libgcc` 
clang | `-x c++`
msvc |`/TP` 