### PR TITLE
tests: DUNE_BUILD_DIR has weird interaction with sandbox.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,11 @@ dev-switch:
 		opam switch create -y . 4.10.0 --deps-only --with-test
 	opam install -y $(TEST_DEPS) $(DEV_DEPS)
 
-_esy:
-	mkdir _esy
+test: $(BIN)
+	$(BIN) runtest
 
-test: $(BIN) _esy
-	DUNE_BUILD_DIR=$$(pwd)/_esy/something $(BIN) runtest
-
-test-windows: $(BIN) _esy
-	DUNE_BUILD_DIR=$$(pwd)/_esy/something $(BIN) build @runtest-windows
+test-windows: $(BIN)
+	$(BIN) build @runtest-windows
 
 test-js: $(BIN)
 	$(BIN) build @runtest-js

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,14 @@ dev-switch:
 		opam switch create -y . 4.10.0 --deps-only --with-test
 	opam install -y $(TEST_DEPS) $(DEV_DEPS)
 
-test: $(BIN)
-	$(BIN) runtest
+_esy:
+	mkdir _esy
 
-test-windows: $(BIN)
-	$(BIN) build @runtest-windows
+test: $(BIN) _esy
+	DUNE_BUILD_DIR=$$(pwd)/_esy/something $(BIN) runtest
+
+test-windows: $(BIN) _esy
+	DUNE_BUILD_DIR=$$(pwd)/_esy/something $(BIN) build @runtest-windows
 
 test-js: $(BIN)
 	$(BIN) build @runtest-js

--- a/test/blackbox-tests/test-cases/github3805.t/run.t
+++ b/test/blackbox-tests/test-cases/github3805.t/run.t
@@ -1,0 +1,11 @@
+  $ mkdir _esy
+  $ mkdir _esy/something
+  $ dune runtest
+  $ find $(pwd) -name run.t.corrected
+  $ DUNE_BUILD_DIR=$(pwd)/_esy/something dune runtest 2>&1 | sed 's|[0-9a-f]\{32\}/default/sub-test|$SANDBOX_HASH/default/sub-test|'
+  Error:
+  $TESTCASE_ROOT/_esy/something/.sandbox/$SANDBOX_HASH/default/sub-test.t/run.t:
+  No such file or directory
+  Error: open:
+  $TESTCASE_ROOT/_esy/something/default/sub-test.t/.hello.eobjs/hello.ml.d:
+  No such file or directory

--- a/test/blackbox-tests/test-cases/github3805.t/sub-test.t/dune
+++ b/test/blackbox-tests/test-cases/github3805.t/sub-test.t/dune
@@ -1,0 +1,9 @@
+(executables
+ (names hello))
+
+(rule
+ (alias runtest)
+ (action
+  (with-stdout-to
+   hello.output
+   (run ./hello.exe))))

--- a/test/blackbox-tests/test-cases/github3805.t/sub-test.t/dune-project
+++ b/test/blackbox-tests/test-cases/github3805.t/sub-test.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.7)
+(cram enable)

--- a/test/blackbox-tests/test-cases/github3805.t/sub-test.t/hello.ml
+++ b/test/blackbox-tests/test-cases/github3805.t/sub-test.t/hello.ml
@@ -1,0 +1,1 @@
+let () = print_endline "Hello, world!"

--- a/test/blackbox-tests/test-cases/github3805.t/sub-test.t/run.t
+++ b/test/blackbox-tests/test-cases/github3805.t/sub-test.t/run.t
@@ -1,0 +1,9 @@
+  $ echo 'Hello, world!' > hello.expected
+  $ dune runtest
+  $ ls
+  _build
+  hello.expected
+  run.t
+  $ diff hello.output hello.expected
+  diff: hello.output: No such file or directory
+  [2]


### PR DESCRIPTION
Hello,

Why (can be skipped): I tried to speed-up your CI with the use of esy package manager. In esy ocaml is a regular deps and can be cached. This also has benefit to know ahead if part of the ecosystem will break or not. While I was preparing that I found that `dune runtest` always fail if `DUNE_BUILD_DIR` is set (I haven't tested to unset it)

I think out of source will always copy all files so I can make this optionnal and add both (maybe this is fine for CI but shorter for dev) in CI.

It seem opam CI is not tested on 4.10 so it build 1 ocaml and then up/downgrade.