### PR TITLE
Remove libraries from build core

### DIFF
--- a/src/dune_engine/build.ml
+++ b/src/dune_engine/build.ml
@@ -1,6 +1,8 @@
 open! Stdune
 open Import
 
+type label = ..
+
 type 'a t =
   | Pure : 'a -> 'a t
   | Map : ('a -> 'b) * 'a t -> 'b t
@@ -12,7 +14,7 @@ type 'a t =
   | Lines_of : Path.t -> string list t
   | Dyn_paths : ('a * Path.Set.t) t -> 'a t
   | Dyn_deps : ('a * Dep.Set.t) t -> 'a t
-  | Record_lib_deps : Lib_deps_info.t -> unit t
+  | Label : label -> unit t
   | Fail : fail -> _ t
   | Memo : 'a memo -> 'a t
   | Catch : 'a t * (exn -> 'a) -> 'a t
@@ -68,7 +70,7 @@ let all_unit xs =
   let+ (_ : unit list) = all xs in
   ()
 
-let record_lib_deps lib_deps = Record_lib_deps lib_deps
+let label map = Label map
 
 let deps d = Deps d
 
@@ -300,7 +302,7 @@ end = struct
       { Static_deps.empty with rule_deps = Dep.Set.of_files [ p ] }
     | Lines_of p ->
       { Static_deps.empty with rule_deps = Dep.Set.of_files [ p ] }
-    | Record_lib_deps _ -> Static_deps.empty
+    | Label _ -> Static_deps.empty
     | Fail _ -> Static_deps.empty
     | Memo m -> Memo.exec memo (Input.T m)
     | Catch (t, _) -> static_deps t
@@ -310,9 +312,9 @@ let static_deps = Analysis.static_deps
 
 (* We do no memoization in this function because it is currently used only to
    support the [external-lib-deps] command and so it's not on the critical path. *)
-let lib_deps t =
+let fold_labeled (type acc) t ~(init : acc) ~f =
   let file_exists = Fdecl.get file_exists_fdecl in
-  let rec loop : type a. a t -> Lib_deps_info.t -> Lib_deps_info.t =
+  let rec loop : type a. a t -> acc -> acc =
    fun t acc ->
     match t with
     | Pure _ -> acc
@@ -327,7 +329,7 @@ let lib_deps t =
     | Dyn_deps t -> loop t acc
     | Contents _ -> acc
     | Lines_of _ -> acc
-    | Record_lib_deps deps -> Lib_deps_info.merge deps acc
+    | Label r -> f r acc
     | Fail _ -> acc
     | If_file_exists (p, then_, else_) ->
       if file_exists p then
@@ -337,7 +339,7 @@ let lib_deps t =
     | Memo m -> loop m.t acc
     | Catch (t, _) -> loop t acc
   in
-  loop t Lib_name.Map.empty
+  loop t init
 
 (* Execution *)
 
@@ -385,7 +387,7 @@ end = struct
       | Dyn_deps t ->
         let (x, dyn_deps), dyn_deps_x = go t in
         (x, Dep.Set.union dyn_deps dyn_deps_x)
-      | Record_lib_deps _ -> ((), Dep.Set.empty)
+      | Label _ -> ((), Dep.Set.empty)
       | Fail { fail } -> fail ()
       | If_file_exists (p, then_, else_) ->
         if file_exists p then

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -3,6 +3,9 @@
 open! Stdune
 open! Import
 
+(** Type of values allowed to be labeled *)
+type label = ..
+
 type 'a t
 
 include Applicative_intf.S1 with type 'a t := 'a t
@@ -82,10 +85,10 @@ val delayed : (unit -> 'a) -> 'a t
    -> t end
 
    (** Same as [t >>> arr (fun x -> Action_with_deps.add_file_dependency x p)]
-   but better as [p] is statically known *) val record_dependency : Path.t ->
+   but better as [p] is statically known *) val label_dependency : Path.t ->
    ('a, Action_with_deps.t) t -> ('a, Action_with_deps.t) t ]} *)
 
-(** [path p] records [p] as a file that is read by the action produced by the
+(** [path p] labels [p] as a file that is read by the action produced by the
     build description. *)
 val path : Path.t -> unit t
 
@@ -99,7 +102,7 @@ val paths : Path.t list -> unit t
 
 val path_set : Path.Set.t -> unit t
 
-(** Evaluate a predicate against all targets and record all the matched files as
+(** Evaluate a predicate against all targets and label all the matched files as
     dependencies of the action produced by the build description. *)
 val paths_matching : loc:Loc.t -> File_selector.t -> Path.Set.t t
 
@@ -107,17 +110,17 @@ val paths_matching : loc:Loc.t -> File_selector.t -> Path.Set.t t
     exist. *)
 val paths_existing : Path.t list -> unit t
 
-(** [env_var v] records [v] as an environment variable that is read by the
-    action produced by the build description. *)
+(** [env_var v] labels [v] as an environment variable that is read by the action
+    produced by the build description. *)
 val env_var : string -> unit t
 
 val alias : Alias.t -> unit t
 
 (** Compute the set of source of all files present in the sub-tree starting at
-    [dir] and record them as dependencies. *)
+    [dir] and label them as dependencies. *)
 val source_tree : dir:Path.t -> Path.Set.t t
 
-(** Record dynamic dependencies *)
+(** Label dynamic dependencies *)
 val dyn_paths : ('a * Path.t list) t -> 'a t
 
 val dyn_paths_unit : Path.t list t -> unit t
@@ -182,7 +185,7 @@ val create_file : Path.Build.t -> Action.t With_targets.t
 (** Merge a list of actions accumulating the sets of their targets. *)
 val progn : Action.t With_targets.t list -> Action.t With_targets.t
 
-val record_lib_deps : Lib_deps_info.t -> unit t
+val label : label -> unit t
 
 (** {1 Analysis} *)
 
@@ -190,7 +193,7 @@ val record_lib_deps : Lib_deps_info.t -> unit t
 val static_deps : _ t -> Static_deps.t
 
 (** Compute static library dependencies of a build description. *)
-val lib_deps : _ t -> Lib_deps_info.t
+val fold_labeled : _ t -> init:'acc -> f:(label -> 'acc -> 'acc) -> 'acc
 
 (** {1 Execution} *)
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1981,7 +1981,7 @@ end = struct
     let rules = rules_for_transitive_closure targets in
     let lib_deps =
       List.map rules ~f:(fun rule ->
-          let deps = Build.lib_deps rule.Rule.action.build in
+          let deps = Lib_deps_info.lib_deps rule.Rule.action.build in
           (rule, deps))
     in
     List.fold_left lib_deps ~init:[] ~f:(fun acc (rule, deps) ->

--- a/src/dune_engine/lib_deps_info.ml
+++ b/src/dune_engine/lib_deps_info.ml
@@ -35,3 +35,11 @@ let merge a b =
       | Some a, Some b -> Some (Kind.merge a b))
 
 let to_dyn = Lib_name.Map.to_dyn Kind.to_dyn
+
+type Build.label += Label of t
+
+let lib_deps t : t =
+  Build.fold_labeled t ~init:Lib_name.Map.empty ~f:(fun r acc ->
+      match r with
+      | Label u -> merge u acc
+      | _ -> acc)

--- a/src/dune_engine/lib_deps_info.mli
+++ b/src/dune_engine/lib_deps_info.mli
@@ -20,3 +20,7 @@ type t = Kind.t Lib_name.Map.t
 val merge : t -> t -> t
 
 val to_dyn : t -> Dyn.t
+
+type Build.label += Label of t
+
+val lib_deps : _ Build.t -> t

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -16,7 +16,9 @@ let gen_select_rules t ~dir compile_info =
           |> Build.with_targets ~targets:[ dst ] ))
 
 let with_lib_deps (t : Context.t) compile_info ~dir ~f =
-  let prefix = Build.record_lib_deps (Lib.Compile.lib_deps_info compile_info) in
+  let prefix =
+    Build.label (Lib_deps_info.Label (Lib.Compile.lib_deps_info compile_info))
+  in
   let prefix =
     if t.merlin then
       Path.Build.relative dir ".merlin-exists"

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -305,7 +305,7 @@ module Resolved_forms = struct
   let to_build t =
     let open Build.O in
     let ddeps = Pform.Expansion.Map.to_list t.ddeps in
-    let+ () = Build.record_lib_deps t.lib_deps
+    let+ () = Build.label (Lib_deps_info.Label t.lib_deps)
     and+ () = Build.path_set t.sdeps
     and+ values = Build.all (List.map ddeps ~f:snd)
     and+ () =

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -331,8 +331,9 @@ let build_ppx_driver sctx ~dep_kind ~target ~pps ~pp_names =
     |> Build.write_file_dyn ml );
   add_rule ~sandbox:Sandbox_config.no_special_requirements
     ( Build.with_no_targets
-        (Build.record_lib_deps
-           (Lib_deps.info ~kind:dep_kind (Lib_deps.of_pps pp_names)))
+        (Build.label
+           (Lib_deps_info.Label
+              (Lib_deps.info ~kind:dep_kind (Lib_deps.of_pps pp_names))))
     >>> Command.run compiler ~dir:(Path.build ctx.build_dir)
           [ A "-g"
           ; A "-o"


### PR DESCRIPTION
Allow library dependencies to be collected via an extensible type and
the `Record` constructor. This inverts the dependency between `Build` and
`Lib_deps_info`.

This isn't enough to get rid of `Lib_name` from the core, but it's a start. The
next step would be to figure out to move it out of `Dep_path` as well.