### PR TITLE
Fix cram tests with bash 5.0.18.

### DIFF
--- a/test/blackbox-tests/test-cases/enabled_if/eif-context_name.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-context_name.t/run.t
@@ -3,6 +3,7 @@ Since dune 2.8 libraries `enabled_if` can use the `%{context_name}` variable.
 dune < 2.8
   $ cat >dune-project <<EOF
   > (lang dune 2.7)
+  > EOF
 
   $ dune build bar
   File "dune", line 8, characters 18-31:
@@ -16,6 +17,7 @@ dune < 2.8
 dune >= 2.8
   $ cat >dune-project <<EOF
   > (lang dune 2.8)
+  > EOF
 
 + Print the context
   $ dune build @print_context


### PR DESCRIPTION
Without EOF, Bash yields `sh: warning: here-document at line 1 delimited by end-of-file (wanted 'EOF')`, causing the test to fail.