### PR TITLE
Cleanups from #3655

### DIFF
--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -112,9 +112,13 @@ module Mode_conf : sig
 end
 
 module Library : sig
+  type visibility =
+    | Public of Public_lib.t
+    | Private
+
   type t =
     { name : Loc.t * Lib_name.Local.t
-    ; public : Public_lib.t option
+    ; visibility : visibility
     ; synopsis : string option
     ; install_c_headers : string list
     ; ppx_runtime_libraries : (Loc.t * Lib_name.t) list
@@ -144,6 +148,10 @@ module Library : sig
     ; enabled_if : Blang.t
     ; instrumentation_backend : (Loc.t * Lib_name.t) option
     }
+
+  val sub_dir : t -> string option
+
+  val package : t -> Package.t option
 
   (** Check if the library has any foreign stubs or archives. *)
   val has_foreign : t -> bool

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -283,6 +283,7 @@ include Sub_system.Register_end_point (struct
        in
        Build.With_targets.add ~targets:[ target ] action);
     let cctx =
+      let package = Dune_file.Library.package lib in
       let flags =
         Ocaml_flags.append_common
           (Super_context.ocaml_flags sctx ~dir info.executable)
@@ -292,7 +293,7 @@ include Sub_system.Register_end_point (struct
         ~obj_dir ~modules ~opaque:(Explicit false) ~requires_compile:runner_libs
         ~requires_link:(lazy runner_libs)
         ~flags ~js_of_ocaml:(Some lib.buildable.js_of_ocaml) ~dynlink:false
-        ~package:(Option.map lib.public ~f:Dune_file.Public_lib.package)
+        ~package
     in
     let linkages =
       let modes =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -271,9 +271,7 @@ end = struct
                       (Super_context.get_site_of_packages sctx)
                       src ?dst ))
             | Dune_file.Library lib ->
-              let sub_dir =
-                Option.value_exn lib.public |> Dune_file.Public_lib.sub_dir
-              in
+              let sub_dir = Dune_file.Library.sub_dir lib in
               let dir_contents = Dir_contents.get sctx ~dir in
               lib_install_files sctx ~scope ~dir ~sub_dir lib ~dir_contents
             | Coq_stanza.Theory.T coqlib ->

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -367,12 +367,11 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
     let { Lib_config.has_native; _ } = ctx.lib_config in
     Dune_file.Mode_conf.Set.eval_detailed lib.modes ~has_native
   in
+  let package = Dune_file.Library.package lib in
   Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
     ~modules ~flags ~requires_compile ~requires_link ~preprocessing:pp
     ~opaque:Inherit_from_settings ~js_of_ocaml:(Some lib.buildable.js_of_ocaml)
-    ~dynlink ?stdlib:lib.stdlib
-    ~package:(Option.map lib.public ~f:Dune_file.Public_lib.package)
-    ?vimpl ~modes
+    ~dynlink ?stdlib:lib.stdlib ~package ?vimpl ~modes
 
 let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
     ~compile_info =

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -643,9 +643,9 @@ let init sctx =
     |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
            List.filter_map w.data ~f:(function
              | Dune_file.Library (l : Dune_file.Library.t) -> (
-               match l.public with
-               | Some _ -> None
-               | None ->
+               match l.visibility with
+               | Public _ -> None
+               | Private ->
                  let scope = SC.find_scope_by_dir sctx w.ctx_dir in
                  Library.best_name l
                  |> Lib.DB.find_even_when_hidden (Scope.libs scope)

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -69,11 +69,11 @@ module DB = struct
               Dune_file.Library.to_lib_info conf ~dir ~lib_config
               |> Lib_info.of_local
             in
-            match conf.public with
-            | None ->
+            match conf.visibility with
+            | Private ->
               [ (Dune_file.Library.best_name conf, Found_or_redirect.found info)
               ]
-            | Some p ->
+            | Public p ->
               let name = Dune_file.Public_lib.name p in
               if Lib_name.equal name (Lib_name.of_local conf.name) then
                 [ (name, Found_or_redirect.found info) ]
@@ -153,7 +153,7 @@ module DB = struct
     let public_libs =
       List.filter_map stanzas ~f:(fun (stanza : Library_related_stanza.t) ->
           match stanza with
-          | Library (_, { project; public = Some p; _ }) ->
+          | Library (_, { project; visibility = Public p; _ }) ->
             Some (Dune_file.Public_lib.name p, Project project)
           | Library _
           | Library_redirect _ ->
@@ -171,7 +171,8 @@ module DB = struct
           List.filter_map stanzas ~f:(fun stanza ->
               let named p loc = Option.some_if (name = p) loc in
               match stanza with
-              | Library (_, { buildable = { loc; _ }; public = Some p; _ }) ->
+              | Library (_, { buildable = { loc; _ }; visibility = Public p; _ })
+                ->
                 named (Dune_file.Public_lib.name p) loc
               | Deprecated_library_name d ->
                 let old_name =

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -256,9 +256,9 @@ let internal_lib_names t =
         function
         | Dune_file.Library lib ->
           Lib_name.Set.add
-            ( match lib.public with
-            | None -> acc
-            | Some public ->
+            ( match lib.visibility with
+            | Private -> acc
+            | Public public ->
               Lib_name.Set.add acc (Dune_file.Public_lib.name public) )
             (Lib_name.of_local lib.name)
         | _ -> acc))
@@ -455,7 +455,7 @@ let get_installed_binaries stanzas ~(context : Context.t) =
 let create_lib_entries_by_package ~public_libs stanzas =
   Dir_with_dune.deep_fold stanzas ~init:[] ~f:(fun _ stanza acc ->
       match stanza with
-      | Dune_file.Library { public = Some pub; _ } -> (
+      | Dune_file.Library { visibility = Public pub; _ } -> (
         match Lib.DB.find public_libs (Dune_file.Public_lib.name pub) with
         | None ->
           (* Skip hidden or unavailable libraries. TODO we should assert that

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -452,6 +452,32 @@ let get_installed_binaries stanzas ~(context : Context.t) =
           acc
       | _ -> acc)
 
+let create_lib_entries_by_package ~public_libs stanzas =
+  Dir_with_dune.deep_fold stanzas ~init:[] ~f:(fun _ stanza acc ->
+      match stanza with
+      | Dune_file.Library { public = Some pub; _ } -> (
+        match Lib.DB.find public_libs (Dune_file.Public_lib.name pub) with
+        | None ->
+          (* Skip hidden or unavailable libraries. TODO we should assert that
+             the libary name is always found somehow *)
+          acc
+        | Some lib ->
+          ( (Dune_file.Public_lib.package pub).name
+          , Lib_entry.Library (Lib.Local.of_lib_exn lib) )
+          :: acc )
+      | Dune_file.Deprecated_library_name
+          ({ old_name = old_public_name, deprecated; _ } as d) ->
+        ( (Dune_file.Public_lib.package old_public_name).name
+        , Lib_entry.Deprecated_library_name
+            { d with old_name = (old_public_name, deprecated) } )
+        :: acc
+      | _ -> acc)
+  |> Package.Name.Map.of_list_multi
+  |> Package.Name.Map.map
+       ~f:
+         (List.sort ~compare:(fun a b ->
+              Lib_name.compare (Lib_entry.name a) (Lib_entry.name b)))
+
 let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
   let lib_config = Context.lib_config context in
   let installed_libs = Lib.DB.create_from_findlib context.findlib ~lib_config in
@@ -563,6 +589,9 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
     Dune_project.File_key.Map.of_list_map_exn projects ~f:(fun project ->
         (Dune_project.file_key project, project))
   in
+  let lib_entries_by_package =
+    create_lib_entries_by_package ~public_libs stanzas
+  in
   { context
   ; root_expander
   ; host
@@ -573,28 +602,7 @@ let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
   ; stanzas_per_dir
   ; packages
   ; artifacts
-  ; lib_entries_by_package =
-      Dir_with_dune.deep_fold stanzas ~init:[] ~f:(fun _ stanza acc ->
-          match stanza with
-          | Dune_file.Library { public = Some pub; _ } -> (
-            match Lib.DB.find public_libs (Dune_file.Public_lib.name pub) with
-            | None -> acc
-            | Some lib ->
-              ( (Dune_file.Public_lib.package pub).name
-              , Lib_entry.Library (Option.value_exn (Lib.Local.of_lib lib)) )
-              :: acc )
-          | Dune_file.Deprecated_library_name
-              ({ old_name = old_public_name, deprecated; _ } as d) ->
-            ( (Dune_file.Public_lib.package old_public_name).name
-            , Lib_entry.Deprecated_library_name
-                { d with old_name = (old_public_name, deprecated) } )
-            :: acc
-          | _ -> acc)
-      |> Package.Name.Map.of_list_multi
-      |> Package.Name.Map.map
-           ~f:
-             (List.sort ~compare:(fun a b ->
-                  Lib_name.compare (Lib_entry.name a) (Lib_entry.name b)))
+  ; lib_entries_by_package
   ; env_tree
   ; default_env
   ; dir_status_db


### PR DESCRIPTION
Unrelated changes from #3655 that make it easier to review the other PR.

* We change `lib.public` to `visibility`. This is consistent with how we handle
private/public everywhere else.

* `lib_entries_by_package` is moved to own function