### PR TITLE
[RFC] Add Dune_site_plugins.V1.load_script for compiling and loading an OCaml module at runtime

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -483,6 +483,8 @@ let install_uninstall ~what =
                 Dune_engine.Artifact_substitution.conf_for_install ~relocatable
                   ~default_ocamlpath:context.default_ocamlpath
                   ~stdlib_dir:context.stdlib_dir ~prefix ~libdir ~mandir
+                  ~ocamlc:context.ocamlc
+                  ~ocamlopt:(Result.to_option context.ocamlopt)
               in
               Fiber.sequential_iter entries_per_package
                 ~f:(fun (package, entries) ->

--- a/otherlibs/site/src/helpers.ml
+++ b/otherlibs/site/src/helpers.ml
@@ -74,7 +74,7 @@ let relocatable =
     | Relocatable -> true
     | _ -> false )
 
-let prefix =
+let relocatable_prefix =
   lazy
     (let path = Sys.executable_name in
      let bin = Filename.dirname path in
@@ -83,7 +83,7 @@ let prefix =
 
 let relocate_if_needed path =
   if Lazy.force relocatable then
-    Filename.concat (Lazy.force prefix) path
+    Filename.concat (Lazy.force relocatable_prefix) path
   else
     path
 
@@ -118,7 +118,7 @@ let ocamlpath =
        | Hardcoded_ocaml_path.None ->
          String.split_on_char path_sep (Sys.getenv "DUNE_OCAML_HARDCODED")
        | Hardcoded_ocaml_path.Relocatable ->
-         [ Filename.concat (Lazy.force prefix) "lib" ]
+         [ Filename.concat (Lazy.force relocatable_prefix) "lib" ]
        | Hardcoded_ocaml_path.Hardcoded l -> l
        | Hardcoded_ocaml_path.Findlib_config _ -> assert false
      in

--- a/otherlibs/site/src/helpers.mli
+++ b/otherlibs/site/src/helpers.mli
@@ -13,6 +13,8 @@ val site :
 
 val relocatable : bool Lazy.t
 
+val relocatable_prefix : string Lazy.t
+
 val ocamlpath : string list Lazy.t
 
 val sourceroot : string -> string option

--- a/otherlibs/site/src/plugins/dune_site_plugins.ml
+++ b/otherlibs/site/src/plugins/dune_site_plugins.ml
@@ -7,4 +7,6 @@ module V1 = struct
   let load = Plugins.load
 
   let available = Plugins.available
+
+  let load_script = Plugins.load_script
 end

--- a/otherlibs/site/src/plugins/dune_site_plugins.mli
+++ b/otherlibs/site/src/plugins/dune_site_plugins.mli
@@ -6,6 +6,15 @@ module V1 : sig
       can still fail if a dependency of the library is unavailable or if the
       loading of the modules fails. *)
   val available : string -> bool
+
+  (** Compile and load an ocaml module. All the currently loaded libraries are
+      made available to the script. It returns the standard and error output of
+      the compiler *)
+  val load_script :
+       ?open_:string list
+    -> ?warnings:string
+    -> string
+    -> [> `Compilation_failed | `Ok ] * string list * string list
 end
 
 (** **/ *)

--- a/otherlibs/site/src/plugins/dune_site_plugins_data.mli
+++ b/otherlibs/site/src/plugins/dune_site_plugins_data.mli
@@ -13,3 +13,8 @@ val already_linked_libraries : string list
     compiler. The META file are not always present, so version reduced to the
     needed information are included here. *)
 val builtin_library : (string * Meta_parser.t) list
+
+(** The path of the ocaml compilers. None when not available in the binary *)
+val ocamlc : string option
+
+val ocamlopt : string option

--- a/otherlibs/site/src/plugins/filename_transitioning.ml
+++ b/otherlibs/site/src/plugins/filename_transitioning.ml
@@ -1,0 +1,187 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Xavier Leroy and Damien Doligez, INRIA Rocquencourt          *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+let generic_quote quotequote s =
+  let l = String.length s in
+  let b = Buffer.create (l + 20) in
+  Buffer.add_char b '\'';
+  for i = 0 to l - 1 do
+    if s.[i] = '\'' then
+      Buffer.add_string b quotequote
+    else
+      Buffer.add_char b s.[i]
+  done;
+  Buffer.add_char b '\'';
+  Buffer.contents b
+
+module type SYSDEPS = sig
+  val null : string
+
+  val quote_command :
+       string
+    -> ?stdin:string
+    -> ?stdout:string
+    -> ?stderr:string
+    -> string list
+    -> string
+end
+
+module Unix : SYSDEPS = struct
+  let null = "/dev/null"
+
+  let quote = generic_quote "'\\''"
+
+  let quote_command cmd ?stdin ?stdout ?stderr args =
+    String.concat " " (List.map quote (cmd :: args))
+    ^ ( match stdin with
+      | None -> ""
+      | Some f -> " <" ^ quote f )
+    ^ ( match stdout with
+      | None -> ""
+      | Some f -> " >" ^ quote f )
+    ^
+    match stderr with
+    | None -> ""
+    | Some f ->
+      if stderr = stdout then
+        " 2>&1"
+      else
+        " 2>" ^ quote f
+end
+
+module Win32 : SYSDEPS = struct
+  let null = "NUL"
+
+  let quote s =
+    let l = String.length s in
+    let b = Buffer.create (l + 20) in
+    Buffer.add_char b '\"';
+    let rec loop i =
+      if i = l then
+        Buffer.add_char b '\"'
+      else
+        match s.[i] with
+        | '\"' -> loop_bs 0 i
+        | '\\' -> loop_bs 0 i
+        | c ->
+          Buffer.add_char b c;
+          loop (i + 1)
+    and loop_bs n i =
+      if i = l then (
+        Buffer.add_char b '\"';
+        add_bs n
+      ) else
+        match s.[i] with
+        | '\"' ->
+          add_bs ((2 * n) + 1);
+          Buffer.add_char b '\"';
+          loop (i + 1)
+        | '\\' -> loop_bs (n + 1) (i + 1)
+        | _ ->
+          add_bs n;
+          loop i
+    and add_bs n =
+      for _j = 1 to n do
+        Buffer.add_char b '\\'
+      done
+    in
+    loop 0;
+    Buffer.contents b
+
+  (* Quoting commands for execution by cmd.exe is difficult. 1- Each argument is
+     first quoted using the "quote" function above, to protect it against the
+     processing performed by the C runtime system, then cmd.exe's special
+     characters are escaped with '^', using the "quote_cmd" function below. For
+     more details, see
+     https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23 2-
+     The command and the redirection files, if any, must be double-quoted in
+     case they contain spaces. This quoting is interpreted by cmd.exe, not by
+     the C runtime system, hence the "quote" function above cannot be used. The
+     two characters we don't know how to quote inside a double-quoted cmd.exe
+     string are double-quote and percent. We just fail if the command name or
+     the redirection file names contain a double quote (not allowed in Windows
+     file names, anyway) or a percent. See function "quote_cmd_filename" below.
+     3- The whole string passed to Sys.command is then enclosed in double
+     quotes, which are immediately stripped by cmd.exe. Otherwise, some of the
+     double quotes from step 2 above can be misparsed. See e.g.
+     https://stackoverflow.com/a/9965141 *)
+  let quote_cmd s =
+    let b = Buffer.create (String.length s + 20) in
+    String.iter
+      (fun c ->
+        match c with
+        | '('
+        | ')'
+        | '!'
+        | '^'
+        | '%'
+        | '\"'
+        | '<'
+        | '>'
+        | '&'
+        | '|' ->
+          Buffer.add_char b '^';
+          Buffer.add_char b c
+        | _ -> Buffer.add_char b c)
+      s;
+    Buffer.contents b
+
+  let quote_cmd_filename f =
+    if String.contains f '\"' || String.contains f '%' then
+      failwith ("Filename.quote_command: bad file name " ^ f)
+    else if String.contains f ' ' then
+      "\"" ^ f ^ "\""
+    else
+      f
+
+  (* Redirections in cmd.exe: see https://ss64.com/nt/syntax-redirection.html
+     and
+     https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490982(v=technet.10) *)
+  let quote_command cmd ?stdin ?stdout ?stderr args =
+    String.concat ""
+      [ "\""
+      ; quote_cmd_filename cmd
+      ; " "
+      ; quote_cmd (String.concat " " (List.map quote args))
+      ; ( match stdin with
+        | None -> ""
+        | Some f -> " <" ^ quote_cmd_filename f )
+      ; ( match stdout with
+        | None -> ""
+        | Some f -> " >" ^ quote_cmd_filename f )
+      ; ( match stderr with
+        | None -> ""
+        | Some f ->
+          if stderr = stdout then
+            " 2>&1"
+          else
+            " 2>" ^ quote_cmd_filename f )
+      ; "\""
+      ]
+end
+
+module Cygwin : SYSDEPS = struct
+  let null = "/dev/null"
+
+  let quote_command = Unix.quote_command
+end
+
+module Sysdeps =
+( val match Sys.os_type with
+      | "Win32" -> (module Win32 : SYSDEPS)
+      | "Cygwin" -> (module Cygwin : SYSDEPS)
+      | _ -> (module Unix : SYSDEPS) )
+
+include Sysdeps

--- a/otherlibs/site/src/plugins/filename_transitioning.mli
+++ b/otherlibs/site/src/plugins/filename_transitioning.mli
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Xavier Leroy and Damien Doligez, INRIA Rocquencourt          *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** transitioning copied from 4.11 *)
+
+val null : string
+
+val quote_command :
+     string
+  -> ?stdin:string
+  -> ?stdout:string
+  -> ?stderr:string
+  -> string list
+  -> string

--- a/otherlibs/site/src/plugins/plugins.mli
+++ b/otherlibs/site/src/plugins/plugins.mli
@@ -21,3 +21,11 @@ val load : string -> unit
 
 (** Indicates if a library exists in the search path *)
 val available : string -> bool
+
+(** Compile and load an ocaml module. All the currently loaded libraries are
+    made available to the script *)
+val load_script :
+     ?open_:string list
+  -> ?warnings:string
+  -> string
+  -> [> `Compilation_failed | `Ok ] * string list * string list

--- a/src/dune_engine/artifact_substitution.mli
+++ b/src/dune_engine/artifact_substitution.mli
@@ -2,9 +2,14 @@
 
 open Stdune
 
+type mode =
+  | Byte
+  | Native
+
 type configpath =
   | Sourceroot
   | Stdlib
+  | OCamlCompiler of mode
 
 (** A symbolic representation of the value to substitute to *)
 type t =
@@ -37,6 +42,8 @@ val conf_for_install :
   -> prefix:Path.t
   -> libdir:Path.t option
   -> mandir:Path.t option
+  -> ocamlc:Path.t
+  -> ocamlopt:Path.t option
   -> conf
 
 val conf_dummy : conf

--- a/src/dune_engine/build_context.ml
+++ b/src/dune_engine/build_context.ml
@@ -8,7 +8,18 @@ type t =
   ; host : t option
   ; stdlib_dir : Path.t  (** todo try to remove it *)
   ; default_ocamlpath : Path.t list  (** todo try to remove it *)
+  ; ocamlc : Path.t  (** todo try to remove it *)
+  ; ocamlopt : Path.t option  (** todo try to remove it *)
   }
 
-let create ~name ~build_dir ~env ~host ~stdlib_dir ~default_ocamlpath =
-  { name; build_dir; env; host; stdlib_dir; default_ocamlpath }
+let create ~name ~build_dir ~env ~host ~stdlib_dir ~default_ocamlpath ~ocamlc
+    ~ocamlopt =
+  { name
+  ; build_dir
+  ; env
+  ; host
+  ; stdlib_dir
+  ; default_ocamlpath
+  ; ocamlc
+  ; ocamlopt
+  }

--- a/src/dune_engine/build_context.mli
+++ b/src/dune_engine/build_context.mli
@@ -13,6 +13,8 @@ type t = private
   ; host : t option
   ; stdlib_dir : Path.t
   ; default_ocamlpath : Path.t list
+  ; ocamlc : Path.t
+  ; ocamlopt : Path.t option
   }
 
 val create :
@@ -22,4 +24,6 @@ val create :
   -> host:t option
   -> stdlib_dir:Path.t
   -> default_ocamlpath:Path.t list
+  -> ocamlc:Path.t
+  -> ocamlopt:Path.t option
   -> t


### PR DESCRIPTION
This feature allows to remove the last `ocamlfind` dependency in Frama-C. The goal is just to compile and load a `.ml` which uses some packages. Since it is always possible for a user to use dune for compiling a plugin, the feature should stay simple and just focus on simple case. So:

 - It `-I` all the already loaded packages
 - It works with only one file, no .mli
 - The `-open` option can be specified
 - The warnings can be specified.
 - ppx can't be used

The added code in `dune_site_plugins`, is quite big because I tried to not add dependencies on Unix.

Another possibility would be to give the commands to run to the caller, but a simpler API is simpler to maintain and can more easily be extended to `js_of_ocaml` for example.

Note: private libraries should not be accessible since the `.cmi` are not directly in the directory