### PR TITLE
Update the instructions to use dune-configurator

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -497,10 +497,9 @@ to use the :ref:`include_subdirs` stanza.
   :ref:`inline_tests` for a reference of corresponding options.
 
 Note that when binding C libraries, dune doesn't provide special support for
-tools such as ``pkg-config``, however it integrates easily with configurator_ by
+tools such as ``pkg-config``, however it integrates easily with
+:ref:`configurator` by
 using ``(c_flags (:include ...))`` and ``(c_library_flags (:include ...))``.
-
-.. _configurator: https://github.com/janestreet/configurator
 
 .. _foreign_library:
 

--- a/doc/dune-libs.rst
+++ b/doc/dune-libs.rst
@@ -26,8 +26,8 @@ Configurator is designed to be cross compilation friendly and avoids _running_
 any compiled code to extract any of the information above.
 
 Configurator started as an `independent library
-<https://github.com/janestreet/configurator>`__, but now lives in dune. You do
-not need to install anything to use configurator.
+<https://github.com/janestreet/configurator>`__, but now lives in dune.
+It is released as the package ``dune-configurator``.
 
 Usage
 -----
@@ -57,7 +57,8 @@ example:
 
   let () =
     C.main ~name:"foo" (fun c ->
-      let has_clock_gettime = C.c_test c clock_gettime_code ~link_flags:["-lrt"] in
+      let has_clock_gettime =
+        C.c_test c clock_gettime_code ~link_flags:["-lrt"] in
 
       C.C_define.gen_header_file c ~fname:"config.h"
         [ "HAS_CLOCK_GETTIME", Switch has_clock_gettime ]);
@@ -69,7 +70,7 @@ invoke it as an executable and tell dune about the targets that it produces:
 
   (executable
    (name discover)
-   (libraries dune.configurator))
+   (libraries dune-configurator))
 
   (rule
    (targets config.h)
@@ -106,9 +107,10 @@ the transition include:
 
 The following steps must be taken to transition from the old configurator:
 
-* Mentions of the ``configurator`` opam package should be removed.
+* Mentions of the ``configurator`` opam package should be replaced
+  with ``dune-configurator``.
 
-* The library name ``configurator`` should be changed ``dune.configurator``.
+* The library name ``configurator`` should be changed ``dune-configurator``.
 
 * The ``-ocamlc`` flag in rules that run configurator scripts should be removed.
   This information is now passed automatically by dune.

--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -234,7 +234,7 @@ Then create a ``config`` subdirectory and write this ``dune`` file:
 
     (executable
      (name discover)
-     (libraries dune.configurator))
+     (libraries dune-configurator))
 
 as well as this ``discover.ml`` file:
 


### PR DESCRIPTION
Update the instructions to use dune-configurator (now a separate package).

Signed-off-by: Christophe Troestler <Christophe.Troestler@umons.ac.be>