### PR TITLE
Fix Lib.Compile.lib_deps_info for exe's

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -191,7 +191,8 @@ let rules ~sctx ~dir ~dir_contents ~scope ~expander
     Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope) exes.names
       exes.buildable.libraries ~pps ~dune_version
       ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
-      ~optional:exes.optional ~forbidden_libraries:exes.forbidden_libraries
+      ~preprocess:exes.buildable.preprocess ~optional:exes.optional
+      ~forbidden_libraries:exes.forbidden_libraries
   in
   let f () =
     executables_rules exes ~sctx ~dir ~dir_contents ~scope ~expander

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -201,6 +201,7 @@ module DB : sig
   val resolve_user_written_deps_for_exes :
        t
     -> (Loc.t * string) list
+    -> ?preprocess:Preprocess.With_instrumentation.t Preprocess.Per_module.t
     -> ?allow_overlaps:bool
     -> ?forbidden_libraries:(Loc.t * Lib_name.t) list
     -> Lib_dep.t list


### PR DESCRIPTION
This didn't break instrumentation, but meant that
`Buildable_rules.with_lib_deps` would not correctly detect the dependencies.