### PR TITLE
Simplify filtering hidden libs in utop rules

### DIFF
--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -193,6 +193,10 @@ module DB : sig
 
   val resolve : t -> Loc.t * Lib_name.t -> lib Or_exn.t
 
+  (** Like [resolve], but will return [None] instead of an error if we are
+      unable to find the library. *)
+  val resolve_when_exists : t -> Loc.t * Lib_name.t -> lib Or_exn.t option
+
   (** Resolve libraries written by the user in a [dune] file. The resulting list
       of libraries is transitively closed and sorted by the order of
       dependencies.

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -39,10 +39,14 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
           function
           | Dune_file.Library l -> (
             match
-              Lib.DB.find_even_when_hidden db (Dune_file.Library.best_name l)
+              Lib.DB.resolve_when_exists db
+                (l.buildable.loc, Dune_file.Library.best_name l)
             with
-            | None -> (acc, pps) (* library is defined but outside our scope *)
-            | Some lib ->
+            | None
+            | Some (Error _) ->
+              (acc, pps)
+              (* library is defined but outside our scope or is disabled *)
+            | Some (Ok lib) ->
               (* still need to make sure that it's not coming from an external
                  source *)
               let info = Lib.info lib in
@@ -51,15 +55,7 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
                  Implementations are selected using the default implementation
                  feature. *)
               let not_impl = Option.is_none (Lib_info.implements info) in
-              let not_hidden =
-                match Lib_info.enabled info with
-                | Normal -> true
-                | Optional -> Result.is_ok (Lib.requires lib)
-                | Disabled_because_of_enabled_if -> false
-              in
-              if
-                not_impl && not_hidden
-                && Path.is_descendant ~of_:(Path.build dir) src_dir
+              if not_impl && Path.is_descendant ~of_:(Path.build dir) src_dir
               then
                 match Lib_info.kind info with
                 | Lib_kind.Ppx_rewriter _


### PR DESCRIPTION
Previously, we'd use Lib.DB.find_even_when_hidden and then reverse
engineer whether the library is hidden. Now, we just ask the DB to
distinguish between a library that doesn't exist and a library that is
hidden.