### PR TITLE
opam file generation: fix line endings

### DIFF
--- a/src/dune_engine/action_ast.ml
+++ b/src/dune_engine/action_ast.ml
@@ -179,7 +179,7 @@ struct
           ; ( "write-file"
             , let+ fn = target
               and+ s = string in
-              Write_file (fn, s) )
+              Write_file (fn, s, true) )
           ; ( "diff"
             , let+ diff = Diff.decode path target ~optional:false in
               Diff diff )
@@ -251,7 +251,9 @@ struct
       List [ atom "copy#"; path x; target y ]
     | System x -> List [ atom "system"; string x ]
     | Bash x -> List [ atom "bash"; string x ]
-    | Write_file (x, y) -> List [ atom "write-file"; target x; string y ]
+    | Write_file (x, y, b) ->
+      assert b;
+      List [ atom "write-file"; target x; string y ]
     | Rename (x, y) -> List [ atom "rename"; target x; target y ]
     | Remove_tree x -> List [ atom "remove-tree"; target x ]
     | Mkdir x -> List [ atom "mkdir"; path x ]
@@ -316,7 +318,7 @@ struct
 
   let bash s = Bash s
 
-  let write_file p s = Write_file (p, s)
+  let write_file p s = Write_file (p, s, true)
 
   let rename a b = Rename (a, b)
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -264,8 +264,8 @@ let rec exec t ~ectx ~eenv =
         [ "-e"; "-u"; "-o"; "pipefail"; "-c"; cmd ]
     in
     Done
-  | Write_file (fn, s) ->
-    Io.write_file (Path.build fn) s;
+  | Write_file (fn, s, binary) ->
+    Io.write_file ~binary (Path.build fn) s;
     Fiber.return Done
   | Rename (src, dst) ->
     Unix.rename (Path.Build.to_string src) (Path.Build.to_string dst);

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -39,7 +39,7 @@ module type Ast = sig
     | Copy_and_add_line_directive of path * target
     | System of string
     | Bash of string
-    | Write_file of target * string
+    | Write_file of target * string * bool
     | Rename of target * target
     | Remove_tree of target
     | Mkdir of path

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -37,7 +37,7 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
       Copy_and_add_line_directive (f_path ~dir x, f_target ~dir y)
     | System x -> System (f_string ~dir x)
     | Bash x -> Bash (f_string ~dir x)
-    | Write_file (x, y) -> Write_file (f_target ~dir x, f_string ~dir y)
+    | Write_file (x, y, b) -> Write_file (f_target ~dir x, f_string ~dir y, b)
     | Rename (x, y) -> Rename (f_target ~dir x, f_target ~dir y)
     | Remove_tree x -> Remove_tree (f_target ~dir x)
     | Mkdir x -> Mkdir (f_path ~dir x)

--- a/src/dune_engine/build.ml
+++ b/src/dune_engine/build.ml
@@ -215,7 +215,7 @@ module With_targets = struct
   let write_file_dyn fn s =
     add ~targets:[ fn ]
       (let+ s = s in
-       Action.Write_file (fn, s))
+       Action.Write_file (fn, s, true))
 
   let of_result_map res ~f ~targets =
     add ~targets
@@ -235,13 +235,14 @@ let with_targets build ~targets : _ With_targets.t =
 let with_no_targets build : _ With_targets.t =
   { build; targets = Path.Build.Set.empty }
 
-let write_file fn s =
-  with_targets ~targets:[ fn ] (return (Action.Write_file (fn, s)))
+let write_file ?(binary = true) fn s =
+  with_targets ~targets:[ fn ] (return (Action.Write_file (fn, s, binary)))
 
-let write_file_dyn fn s =
+let write_file_dyn ?(binary = Pure true) fn s =
   with_targets ~targets:[ fn ]
-    (let+ s = s in
-     Action.Write_file (fn, s))
+    (let+ s = s
+     and+ binary = binary in
+     Action.Write_file (fn, s, binary))
 
 let copy ~src ~dst =
   with_targets ~targets:[ dst ] (path src >>> return (Action.Copy (src, dst)))

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -143,8 +143,8 @@ val dyn_path_set_reuse : Path.Set.t t -> Path.Set.t t
 val catch : 'a t -> on_error:(exn -> 'a) -> 'a t
 
 (** [contents path] returns a description that when run will return the contents
-    of the file at [path]. *)
-val contents : Path.t -> string t
+    of the file at [path]. Files are opened in binary mode by default. *)
+val contents : ?binary:bool -> Path.t -> string t
 
 (** [lines_of path] returns a description that when run will return the contents
     of the file at [path] as a list of lines. *)

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -181,10 +181,13 @@ val of_result_map : 'a Or_exn.t -> f:('a -> 'b t) -> 'b t
     its result is computed only once. *)
 val memoize : string -> 'a t -> 'a t
 
-(** Create a file with the given contents. *)
-val write_file : Path.Build.t -> string -> Action.t With_targets.t
+(** Create a file with the given contents. Files are written in binary mode by
+    default. *)
+val write_file :
+  ?binary:bool -> Path.Build.t -> string -> Action.t With_targets.t
 
-val write_file_dyn : Path.Build.t -> string t -> Action.t With_targets.t
+val write_file_dyn :
+  ?binary:bool t -> Path.Build.t -> string t -> Action.t With_targets.t
 
 val copy : src:Path.t -> dst:Path.Build.t -> Action.t With_targets.t
 

--- a/src/dune_lang/lexer.mll
+++ b/src/dune_lang/lexer.mll
@@ -99,7 +99,6 @@ module Template = struct
     val new_token : unit -> unit
     val get : unit -> Token.t
     val add_var : part -> unit
-    val add_text : string -> unit
     val add_text_c : char -> unit
   end = struct
     type state =
@@ -146,7 +145,6 @@ module Template = struct
         let parts = add_buf_to_parts parts in
         state := Template (v::parts)
 
-    let add_text   = Buffer.add_string text_buf
     let add_text_c = Buffer.add_char text_buf
   end
 end
@@ -214,9 +212,9 @@ and start_quoted_string = parse
     { quoted_string lexbuf }
 
 and block_string_start kind = parse
-  | newline as s
+  | newline
     { Lexing.new_line lexbuf;
-      Template.Buffer.add_text s;
+      Template.Buffer.add_text_c '\n';
       block_string_after_newline lexbuf
     }
   | ' '
@@ -231,9 +229,9 @@ and block_string_start kind = parse
     }
 
 and block_string = parse
-  | newline as s
+  | newline
     { Lexing.new_line lexbuf;
-      Template.Buffer.add_text s;
+      Template.Buffer.add_text_c '\n';
       block_string_after_newline lexbuf
     }
   | '\\'
@@ -264,9 +262,9 @@ and block_string_after_newline = parse
     }
 
 and raw_block_string = parse
-  | newline as s
+  | newline
     { Lexing.new_line lexbuf;
-      Template.Buffer.add_text s;
+      Template.Buffer.add_text_c '\n';
       block_string_after_newline lexbuf
     }
   | _ as c
@@ -289,9 +287,9 @@ and quoted_string = parse
     { Template.Buffer.add_var (template_variable lexbuf);
       quoted_string lexbuf
     }
-  | newline as s
+  | newline
     { Lexing.new_line lexbuf;
-      Template.Buffer.add_text s;
+      Template.Buffer.add_text_c '\n';
       quoted_string lexbuf
     }
   | _ as c

--- a/src/dune_rules/action_to_sh.ml
+++ b/src/dune_rules/action_to_sh.ml
@@ -65,7 +65,9 @@ let simplify act =
       :: acc
     | System x -> Sh x :: acc
     | Bash x -> Run ("bash", [ "-e"; "-u"; "-o"; "pipefail"; "-c"; x ]) :: acc
-    | Write_file (x, y) -> Redirect_out (echo y, Stdout, File x) :: acc
+    | Write_file (x, y, b) ->
+      assert b;
+      Redirect_out (echo y, Stdout, File x) :: acc
     | Rename (x, y) -> Run ("mv", [ x; y ]) :: acc
     | Remove_tree x -> Run ("rm", [ "-rf"; x ]) :: acc
     | Mkdir x -> mkdir x :: acc

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -177,8 +177,8 @@ module Partial = struct
       Copy_and_add_line_directive (E.path ~expander x, E.target ~expander y)
     | System x -> System (E.string ~expander x)
     | Bash x -> Bash (E.string ~expander x)
-    | Write_file (x, y) ->
-      Write_file (E.target ~expander x, E.string ~expander y)
+    | Write_file (x, y, z) ->
+      Write_file (E.target ~expander x, E.string ~expander y, z)
     | Rename (x, y) -> Rename (E.target ~expander x, E.target ~expander y)
     | Remove_tree x -> Remove_tree (E.target ~expander x)
     | Mkdir x -> (
@@ -295,7 +295,8 @@ let rec partial_expand t ~expander : Partial.t =
     Copy_and_add_line_directive (E.path ~expander x, E.target ~expander y)
   | System x -> System (E.string ~expander x)
   | Bash x -> Bash (E.string ~expander x)
-  | Write_file (x, y) -> Write_file (E.target ~expander x, E.string ~expander y)
+  | Write_file (x, y, z) ->
+    Write_file (E.target ~expander x, E.string ~expander y, z)
   | Rename (x, y) -> Rename (E.target ~expander x, E.target ~expander y)
   | Remove_tree x -> Remove_tree (E.target ~expander x)
   | Mkdir x ->
@@ -425,7 +426,7 @@ end = struct
       | Redirect_out (_, fn, t) -> infer (acc +@+ fn) t
       | Redirect_in (_, fn, t) -> infer (acc +< fn) t
       | Cat fn -> acc +< fn
-      | Write_file (fn, _) -> acc +@+ fn
+      | Write_file (fn, _, _) -> acc +@+ fn
       | Rename (src, dst) -> acc +<+ src +@+ dst
       | Copy (src, dst)
       | Copy_and_add_line_directive (src, dst)

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -222,7 +222,7 @@ let opam_template ~opam_path =
   let opam_template_path = template_file opam_path in
   Build.if_file_exists opam_template_path
     ~then_:
-      (let+ contents = Build.contents opam_template_path in
+      (let+ contents = Build.contents ~binary:false opam_template_path in
        Some (opam_template_path, contents))
     ~else_:(Build.return None)
 


### PR DESCRIPTION
This starts from something I noticed a while ago when opam file generation was added, but hadn't a chance to look at properly. At present, dune writes opam files using binary channels. When checking out Git repositories on Windows with `core.autocrlf` on (the default), opam files committed in the repository will be checked out with CRLF line endings. On first run, Dune will generate files with LF-only line endings and promote these, triggering an unnecessary change status. Actually, it's often slightly worse than that - Dune will write lines it's generated with LF-only endings, but `.template` file parts with the ending in the repository (so CRLF, usually) and also parts of fields (for example, newlines in `(description ...)` with the endings in the repository for `dune-project` so you actually a file with mixed endings which is dreadfully wrong!

The fix is in three parts, all of which can be viewed independently. The first two commits fix the _mixed_ endings problem. With just these two commits, Dune should consistently emit Unix line-endings (but you still get the Git checkout irritation on Windows). The third commit then writes the opam file with the line endings of any _existing_ .opam file in the repository (so if it's been checked out CRLF, Dune will generate CRLF, etc.).

In more detail:

1. `Build.contents` is augmented with `?binary` (i.e. exposing the parameter already present in `Io`) to control whether the file is opened in binary mode. The `.template` file is then read in text mode. Technically this doesn't fix the issue for a CRLF checkout on Unix (this isn't as crazy as it sounds - for example, using WSL in `/mnt`)
2. The dune_lang lexer is altered so that when it processes a newline in a string (which may be LF or CRLF) it _always_ just adds `\n` to the stream. This shouldn't have any unexpected consequences - indeed, it's probably more sensible. Internally, Dune can assume `\n` means a newline and CRLF/LF is only worried about at the API boundary with the file system (fun fact: Linux does this internally too... Unix tty's require CRLF endings, just like Windows!)
3. The .opam in the source tree is read - if it exists - solely to determine the ending kind. If _any_ `\n` is preceded with `\r` then the file will be written with CRLF endings (which is done by turning text mode off). As with 1, this is technically incorrect on a CRLF checkout on Unix.