### PR TITLE
Make Obj_dir functions a little safer

### DIFF
--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -19,7 +19,7 @@ let ooi_deps cctx ~vlib_obj_map ~(ml_kind : Ml_kind.t) (m : Module.t) =
   let write, read =
     let ctx = Super_context.context sctx in
     let unit =
-      Obj_dir.Module.cm_file_unsafe obj_dir m ~kind:cm_kind |> Path.build
+      Obj_dir.Module.cm_file_exn obj_dir m ~kind:cm_kind |> Path.build
     in
     Ocamlobjinfo.rules ~dir ~ctx ~unit
   in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -544,14 +544,14 @@ module Lib_and_module = struct
           | Module (obj_dir, m) ->
             Command.Args.S
               ( Dep
-                  (Obj_dir.Module.cm_file_unsafe obj_dir m
+                  (Obj_dir.Module.cm_file_exn obj_dir m
                      ~kind:(Mode.cm_kind (Link_mode.mode mode)))
               ::
               ( match mode with
               | Native ->
                 [ Command.Args.Hidden_deps
                     (Dep.Set.of_files
-                       [ Obj_dir.Module.o_file_unsafe obj_dir m
+                       [ Obj_dir.Module.o_file_exn obj_dir m
                            ~ext_obj:lib_config.ext_obj
                        ])
                 ]

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -100,13 +100,15 @@ module Module : sig
 
   val obj_file : 'path t -> Module.t -> kind:Cm_kind.t -> ext:string -> 'path
 
-  (** Same as [cm_file] but doesn't raise if [cm_kind] is [Cmo] or [Cmx] and the
-      module has no implementation.*)
-  val cm_file_unsafe : 'path t -> Module.t -> kind:Cm_kind.t -> 'path
+  (** Same as [cm_file] but raises if [cm_kind] is [Cmo] or [Cmx] and the module
+      has no implementation.*)
+  val cm_file_exn : 'path t -> Module.t -> kind:Cm_kind.t -> 'path
 
-  val o_file_unsafe : 'path t -> Module.t -> ext_obj:string -> 'path
+  val o_file : 'path t -> Module.t -> ext_obj:string -> 'path option
 
-  val cm_public_file_unsafe : 'path t -> Module.t -> kind:Cm_kind.t -> 'path
+  val o_file_exn : 'path t -> Module.t -> ext_obj:string -> 'path
+
+  val cm_public_file_exn : 'path t -> Module.t -> kind:Cm_kind.t -> 'path
 
   (** Either the .cmti, or .cmt if the module has no interface *)
   val cmti_file : 'path t -> Module.t -> 'path

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -44,8 +44,8 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
     Dune_file.Mode_conf.Set.eval impl.modes ~has_native
   in
   let copy_obj_file m kind =
-    let src = Obj_dir.Module.cm_file_unsafe vlib_obj_dir m ~kind in
-    let dst = Obj_dir.Module.cm_file_unsafe impl_obj_dir m ~kind in
+    let src = Obj_dir.Module.cm_file_exn vlib_obj_dir m ~kind in
+    let dst = Obj_dir.Module.cm_file_exn impl_obj_dir m ~kind in
     copy_to_obj_dir ~src ~dst
   in
   let copy_objs src =
@@ -54,20 +54,14 @@ let setup_copy_rules_for_impl ~sctx ~dir vimpl =
       Module.visibility src = Public
       && Obj_dir.need_dedicated_public_dir impl_obj_dir
     then
-      let dst =
-        Obj_dir.Module.cm_public_file_unsafe impl_obj_dir src ~kind:Cmi
-      in
-      let src =
-        Obj_dir.Module.cm_public_file_unsafe vlib_obj_dir src ~kind:Cmi
-      in
+      let dst = Obj_dir.Module.cm_public_file_exn impl_obj_dir src ~kind:Cmi in
+      let src = Obj_dir.Module.cm_public_file_exn vlib_obj_dir src ~kind:Cmi in
       copy_to_obj_dir ~src ~dst );
     if Module.has src ~ml_kind:Impl then (
       if byte then copy_obj_file src Cmo;
       if native then (
         copy_obj_file src Cmx;
-        let object_file dir =
-          Obj_dir.Module.obj_file dir src ~kind:Cmx ~ext:ext_obj
-        in
+        let object_file dir = Obj_dir.Module.o_file_exn dir src ~ext_obj in
         copy_to_obj_dir ~src:(object_file vlib_obj_dir)
           ~dst:(object_file impl_obj_dir)
       )


### PR DESCRIPTION
The family of unsafe functions would return a file path even if it's not
supposed to exist. It was the responsibility of the caller to make sure
that these functions were called correctly. Instead, these functions now
make sure they are called with correct module/visibility/cm_kind
combinations.