### PR TITLE
Add --show-{prefix,cdup,toplevel} and --build-path

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -64,6 +64,8 @@ let root t = t.root
 
 let config t = t.config
 
+let build_dir t = t.build_dir
+
 let only_packages t = t.only_packages
 
 let watch t = t.watch

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -12,6 +12,8 @@ val root : t -> Workspace_root.t
 
 val config : t -> Dune_engine.Config.t
 
+val build_dir : t -> string
+
 module Only_packages : sig
   type t =
     { names : Dune_engine.Package.Name.Set.t


### PR DESCRIPTION
Fixes #2925 

This is an early version (not yet ready for review) of a proposal to add the following flags:

- `--show-prefix` prints the current working directory relative to the workspace root
- `--show-cdup` prints the path of the workspace root relative to the current working directory (a sequence of `..`)
- `--show-toplevel` prints the absolute path of the workspace root
- `--build-path <path>` resolves `<path>` relative to the build directory

These flags are useful when driving `dune` from scripts or `Makefiles`, etc. They are inspired by similar options of `git rev-parse`.

These are currently attached to `git describe` but maybe that's not the best place to put them. Also the implementation is not very robust, and needs to be revisited, but am submitting the PR in order to gather some early feedback (if there is any :)).

**Examples**

If the workspace root is at `/foo/bar`, and you are standing at `/foo/bar/baz/bus`, then
- `--show-prefix` gives `baz/bus`
- `--show-cdup` gives `../..`
- `--show-toplevel` gives `/foo/bar`
- `--build-path bun` gives `../../_build/default/bun`