### PR TITLE
Improve error messages for missing rule

### DIFF
--- a/otherlibs/action-plugin/test/one-absent-dependency/run.t
+++ b/otherlibs/action-plugin/test/one-absent-dependency/run.t
@@ -20,4 +20,9 @@ and requires dependency that can not be build fails.
   2 |  (alias runtest)
   3 |  (action (dynamic-run ./foo.exe)))
   Error: No rule found for some_absent_dependency
+  May I interest you in one of the following targets instead?
+  - default/dune
+  - default/dune-project
+  - default/foo.exe
+  - default/run.t
   [1]

--- a/test/blackbox-tests/test-cases/all-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias.t/run.t
@@ -25,6 +25,8 @@
   Entering directory 'install-stanza'
   File "default/subdir/_unknown_", line 1, characters 0-0:
   Error: No rule found for subdir/foobar
+  May I interest you in one of the following targets instead?
+  - default/subdir/dune
   [1]
 
 @all builds user defined rules

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
@@ -11,6 +11,9 @@
   3 |  (deps dir)
   4 |  (action (bash "cat %{deps}/*")))
   Error: No rule found for dir
+  May I interest you in one of the following targets instead?
+  - default/dune
+  - default/dune-project
   [1]
 
 We should not be able to produce a directory in a rule that already exists

--- a/test/blackbox-tests/test-cases/env/env-bin-pform.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-bin-pform.t/run.t
@@ -6,6 +6,10 @@ binaries stanza. %{bin:foo} is visible on the other hand.
   6 |  (name default)
   7 |  (action (run %{exe:foo.exe})))
   Error: No rule found for foo.exe
+  May I interest you in one of the following targets instead?
+  - default/dune
+  - default/dune-project
+  - default/run.t
            foo alias default
   this is foo.exe
   [1]

--- a/test/blackbox-tests/test-cases/foreign-stubs.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs.t/run.t
@@ -119,6 +119,22 @@ Testsuite for the (foreign_stubs ...) field.
   $ ./sdune build 2>&1 | dune_cmd sanitize
   File "dune", line 1, characters 0-0:
   Error: No rule found for libbar$ext_lib
+  May I interest you in one of the following targets instead?
+  - default/.merlin
+  - default/.merlin-exists
+  - default/dllfoo_stubs$ext_dll
+  - default/dune
+  - default/dune-project
+  - default/foo$ext_lib
+  - default/foo.c
+  - default/foo.cma
+  - default/foo.cmxa
+  - default/foo.cmxs
+  - default/foo.ml-gen
+  - default/foo$ext_obj
+  - default/libfoo_stubs$ext_lib
+  - default/run.t
+  - default/sdune
 
 ----------------------------------------------------------------------------------
 * Build succeeds when a self-built archive exists.
@@ -527,6 +543,36 @@ setting [disable_dynamically_linked_foreign_archives] is [true] in the workspace
   4 |  (modules clock)
   5 |  (self_build_stubs_archive (time)))
   Error: No rule found for dlltime_stubs.so
+  May I interest you in one of the following targets instead?
+  - default/.merlin
+  - default/.merlin-exists
+  - default/META.foo
+  - default/bar.c
+  - default/baz.cpp
+  - default/clock.a
+  - default/clock.cma
+  - default/clock.cmxa
+  - default/clock.cmxs
+  - default/clock.ml
+  - default/clock.mli
+  - default/dune
+  - default/dune-project
+  - default/dune-workspace
+  - default/eight.h
+  - default/foo.c
+  - default/foo.cpp
+  - default/foo.cxx
+  - default/foo.dune-package
+  - default/foo.install
+  - default/libtime_stubs.a
+  - default/main.ml
+  - default/quad.ml
+  - default/quad.mli
+  - default/qux.cpp
+  - default/run.t
+  - default/sdune
+  - default/time.c
+  - default/time.o
   [1]
 
 ----------------------------------------------------------------------------------

--- a/test/blackbox-tests/test-cases/generated-source-dir-overlap.t/run.t
+++ b/test/blackbox-tests/test-cases/generated-source-dir-overlap.t/run.t
@@ -17,4 +17,5 @@ If a generated directory is "overlaid" by a source dir, then things break.
   1 | (cinaps (files *.ml))
       ^^^^^^^^^^^^^^^^^^^^^
   Error: No rule found for .cinaps/cinaps.exe
+  In fact, there are no rules defined in this directory
   [1]

--- a/test/blackbox-tests/test-cases/link-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/link-deps.t/run.t
@@ -11,4 +11,5 @@ file) and be created just before linking.
   4 |   (action (echo "link\n"))
   5 |   )
   Error: No rule found for .link_deps.eobjs/.byte_objs/link_deps.cmo
+  In fact, there are no rules defined in this directory
   [1]

--- a/test/blackbox-tests/test-cases/missing-loc-run.t/run.t
+++ b/test/blackbox-tests/test-cases/missing-loc-run.t/run.t
@@ -7,6 +7,9 @@ Exact path provided by the user:
   2 |  (name runtest)
   3 |  (action (run ./foo.exe)))
   Error: No rule found for foo.exe
+  May I interest you in one of the following targets instead?
+  - default/dune
+  - default/dune-project
   [1]
 
 Path that needs to be searched:
@@ -29,4 +32,7 @@ Path in deps field of alias stanza
   2 |  (name runtest)
   3 |  (deps foobar))
   Error: No rule found for foobar
+  May I interest you in one of the following targets instead?
+  - default/dune
+  - default/dune-project
   [1]

--- a/test/blackbox-tests/test-cases/no-infer.t/run.t
+++ b/test/blackbox-tests/test-cases/no-infer.t/run.t
@@ -23,6 +23,11 @@ should work if wrapped in (no-infer ...) but not otherwise.
   5 |    (run touch source)
   6 |    (copy source target))))
   Error: No rule found for source
+  May I interest you in one of the following targets instead?
+  - default/dune
+  - default/dune-project
+  - default/run.t
+  - default/target
   [1]
 
   $ cat >dune <<EOF


### PR DESCRIPTION
We can show the user the available targets in that directory. This is the first thing that I usually end up looking at if the rule is wrong. Seems like we should just include it in the output.