### PR TITLE
Remove js_of_ocaml-ppx from tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ cinaps \
 coq \
 core_bench \
 "csexp>=1.3.0" \
-js_of_ocaml-ppx \
+js_of_ocaml \
 js_of_ocaml-compiler \
 "mdx=1.6.0" \
 menhir \

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/bin/dune
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/bin/dune
@@ -3,5 +3,4 @@
  (libraries js_of_ocaml x)
  (js_of_ocaml
    (flags (:standard))
-   (javascript_files runtime.js))
- (preprocess (pps js_of_ocaml-ppx)))
+   (javascript_files runtime.js)))

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/bin/runtime.js
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/bin/runtime.js
@@ -1,3 +1,3 @@
-global.globalPrintFunciton = function(x){
+global.globalPrintFunction = function(x){
     console.log(x);
 }

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/bin/technologic.ml
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/bin/technologic.ml
@@ -2,6 +2,12 @@ module Js = Js_of_ocaml.Js
 
 let _ =
   print_endline X.buy_it;
-  Printf.printf "%s\n%!" (X.print (object%js val name = Js.string Z.use_it end));
+  let obj = Js.Unsafe.obj [|"name", Js.Unsafe.inject (Js.string Z.use_it)|] in
+  Printf.printf "%s\n%!" (X.print obj);
   X.external_print (Js.string "break it");
-  (fun x -> Js.Unsafe.global##globalPrintFunciton x) (Js.string "fix it")
+  (fun x ->
+     let global = Js.Unsafe.get Js.Unsafe.global "global" in
+     let globalPrintFunction : Js.js_string Js.t -> unit =
+       Js.Unsafe.get global "globalPrintFunction" in
+     globalPrintFunction x
+     ) (Js.string "fix it")

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/lib/dune
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name x)
+ (libraries js_of_ocaml)
  (public_name x)
  (js_of_ocaml
   (flags (--pretty)) (javascript_files runtime.js))
- (c_names stubs)
- (preprocess (pps js_of_ocaml-ppx)))
+ (c_names stubs))

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/lib/x.ml
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/lib/x.ml
@@ -1,5 +1,5 @@
 module Js = Js_of_ocaml.Js
 
 let buy_it = "buy " ^ Y.it
-let print x = Js.to_string x##.name
+let print x = Js.to_string (Js.Unsafe.get x "name")
 external external_print  : Js.js_string Js.t -> unit = "jsPrint"

--- a/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
@@ -3,20 +3,15 @@ Compilation using jsoo
   $ dune build --display short bin/technologic.bc.js @install  2>&1 | \
   > sed s,^\ *$(ocamlc -config-var c_compiler),\ \ C_COMPILER,g
     C_COMPILER lib/stubs.o
-      ocamlopt .ppx/7b799aed44581cc79b02033532c5f775/ppx.exe
+      ocamldep lib/.x.objs/x.ml.d
         ocamlc lib/.x.objs/byte/x__.{cmi,cmo,cmt}
+      ocamldep lib/.x.objs/y.ml.d
    js_of_ocaml .js/stdlib/std_exit.cmo.js
    js_of_ocaml bin/technologic.bc.runtime.js
+      ocamldep bin/.technologic.eobjs/technologic.ml.d
+      ocamldep bin/.technologic.eobjs/z.ml.d
     ocamlmklib lib/dllx_stubs.so,lib/libx_stubs.a
-           ppx lib/x.pp.ml
-           ppx lib/y.pp.ml
-           ppx bin/technologic.pp.ml
-           ppx bin/z.pp.ml
       ocamlopt lib/.x.objs/native/x__.{cmx,o}
-      ocamldep lib/.x.objs/x.pp.ml.d
-      ocamldep lib/.x.objs/y.pp.ml.d
-      ocamldep bin/.technologic.eobjs/technologic.pp.ml.d
-      ocamldep bin/.technologic.eobjs/z.pp.ml.d
         ocamlc lib/.x.objs/byte/x__Y.{cmi,cmo,cmt}
    js_of_ocaml .js/js_of_ocaml/js_of_ocaml.cma.js
    js_of_ocaml .js/stdlib/stdlib.cma.js


### PR DESCRIPTION
This puts an additional constraint on ppxlib and doesn't increase our
testing at all.