### PR TITLE
[menhir] Disable bin_annot for mock modules

### DIFF
--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -69,6 +69,7 @@ type t =
   ; package : Package.t option
   ; vimpl : Vimpl.t option
   ; modes : Mode.Dict.Set.t
+  ; bin_annot : bool
   }
 
 let super_context t = t.super_context
@@ -109,11 +110,14 @@ let vimpl t = t.vimpl
 
 let modes t = t.modes
 
+let bin_annot t = t.bin_annot
+
 let context t = Super_context.context t.super_context
 
 let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
     ~requires_compile ~requires_link ?(preprocessing = Preprocessing.dummy)
-    ~opaque ?stdlib ~js_of_ocaml ~dynlink ~package ?vimpl ?modes () =
+    ~opaque ?stdlib ~js_of_ocaml ~dynlink ~package ?vimpl ?modes
+    ?(bin_annot = true) () =
   let requires_compile =
     if Dune_project.implicit_transitive_deps (Scope.project scope) then
       Lazy.force requires_link
@@ -152,6 +156,7 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
   ; package
   ; vimpl
   ; modes
+  ; bin_annot
   }
 
 let for_alias_module t =
@@ -206,3 +211,5 @@ let for_plugin_executable t ~embed_in_plugin_libraries =
     lazy (Result.List.map ~f:(Lib.DB.resolve libs) embed_in_plugin_libraries)
   in
   { t with requires_link }
+
+let without_bin_annot t = { t with bin_annot = false }

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -39,6 +39,7 @@ val create :
   -> package:Package.t option
   -> ?vimpl:Vimpl.t
   -> ?modes:Dune_file.Mode_conf.Set.Details.t Mode.Dict.t
+  -> ?bin_annot:bool
   -> unit
   -> t
 
@@ -94,3 +95,7 @@ val for_module_generated_at_link_time :
 
 val for_plugin_executable :
   t -> embed_in_plugin_libraries:(Loc.t * Lib_name.t) list -> t
+
+val bin_annot : t -> bool
+
+val without_bin_annot : t -> t

--- a/src/dune_rules/menhir.ml
+++ b/src/dune_rules/menhir.ml
@@ -204,6 +204,7 @@ module Run (P : PARAMS) : sig end = struct
       Modules.singleton_exe mock_module
     in
     let dep_graphs = Dep_rules.rules cctx ~modules in
+    let cctx = Compilation_context.without_bin_annot cctx in
     Modules.iter_no_vlib modules ~f:(fun m ->
         Module_compilation.ocamlc_i ~dep_graphs cctx m
           ~output:(inferred_mli base));

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -120,8 +120,13 @@ let build_cm cctx ~dep_graphs ~precompiled_cmi ~cm_kind (m : Module.t) ~phase =
     | Cmx -> (other_targets, Command.Args.empty)
     | Cmi
     | Cmo ->
-      let fn = Option.value_exn (Obj_dir.Module.cmt_file obj_dir m ~ml_kind) in
-      (fn :: other_targets, A "-bin-annot")
+      if Compilation_context.bin_annot cctx then
+        let fn =
+          Option.value_exn (Obj_dir.Module.cmt_file obj_dir m ~ml_kind)
+        in
+        (fn :: other_targets, A "-bin-annot")
+      else
+        (other_targets, Command.Args.empty)
   in
   let opaque_arg =
     let intf_only = cm_kind = Cmi && not (Module.has m ~ml_kind:Impl) in


### PR DESCRIPTION
Small optimization and less possibility for confusing for editor tools.