### PR TITLE
Fix %{make} on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@ Unreleased
   installed and to be usable by other public libraries in the same project
   (#3655, fixes #1017, @rgrinberg)
 
+- Fix the `%{make}` variable on Windows by only checking for a `gmake` binary
+  on UNIX-like systems as a unrelated `gmake` binary might exist on Windows.
+  (#3853, @kit-ty-kate)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/src/stdune/bin.ml
+++ b/src/stdune/bin.ml
@@ -41,6 +41,12 @@ let which ~path prog =
       Option.some_if (exists fn) fn)
 
 let make ~path =
-  match which ~path "gmake" with
+  let gmake =
+    if Sys.unix then
+      which ~path "gmake"
+    else
+      None
+  in
+  match gmake with
   | None -> which ~path "make"
   | some -> some


### PR DESCRIPTION
Issue detected in https://github.com/aantron/luv/pull/72

The `gmake` binary does not exist on Cygwin and caused issues in `luv` when trying to use `%{make}` to fix the BSD support.
This PR fixes the issue by simply looking for `gmake` on unix systems only. This is also closer to what opam does: https://github.com/ocaml/opam/blob/a96a576a1be44b07128cef4554108d7319d0728f/src/state/opamStateConfig.ml#L44