### PR TITLE
Fix project lookup for libraries

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1119,9 +1119,13 @@ end = struct
     let requires = map_error requires in
     let ppx_runtime_deps = map_error ppx_runtime_deps in
     let project =
-      let open Option.O in
-      let* package = Lib_info.package info in
-      Package.Name.Map.find db.projects_by_package package
+      let status = Lib_info.status info in
+      match Lib_info.Status.project status with
+      | Some _ as project -> project
+      | None ->
+        let open Option.O in
+        let* package = Lib_info.package info in
+        Package.Name.Map.find db.projects_by_package package
     in
     let t =
       { info


### PR DESCRIPTION
Whenever we know the library is defined in the context, we can look up
its project directly. There's no need to reverse engineer it from the
packages, as this would be incorrect for vendored packages in the same
workspace. For example:

```
vendor/
 foo/
  foo.opam
foo.opam
```

The current code would wrongly determine that libraries in either foo
packages are different in the same project.