### PR TITLE
Uniformize handling of alias targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@ Unreleased
   directory unusable when `$ sudo dune install` modified permissions.  (fix
   #3857, @rgrinberg)
 
+- Fix handling of aliases given on the command line (using the `@` and `@@`
+  syntax) so as to correctly handle relative paths. (#3874, fixes #3850, @nojb)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -48,12 +48,12 @@ module Dep = struct
         else
           (1, true)
       in
-      let s = String.drop s pos in
-      let dir, alias =
-        let path = Stdune.Path.Local.of_string s in
-        Dune_engine.Alias.Name.parse_local_path (Loc.none, path)
-      in
-      Some (recursive, dir, alias)
+      let s = String_with_vars.make_text Loc.none (String.drop s pos) in
+      Some
+        ( if recursive then
+          Dep_conf.Alias_rec s
+        else
+          Dep_conf.Alias s )
 
   let dep_parser =
     Dune_lang.Syntax.set Stanza.syntax (Active Stanza.latest_version)
@@ -61,8 +61,7 @@ module Dep = struct
 
   let parser s =
     match parse_alias s with
-    | Some (true, dir, name) -> `Ok (alias_rec ~dir name)
-    | Some (false, dir, name) -> `Ok (alias ~dir name)
+    | Some dep -> `Ok dep
     | None -> (
       match
         Dune_lang.Decoder.parse dep_parser Univ_map.empty


### PR DESCRIPTION
Fixes #3850 

This aligns the handling of `dune build @foo` with that of `dune build '(alias_rec foo)'` (and similarly for the non-recursive variant).
