### PR TITLE
[dune subst] Interpret common command line flags.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,9 @@ Unreleased
   fixes problems with `dune subst` in the presence of unicode
   files. Fixes #3219 (#3879, @ejgallego)
 
+- `dune subst` now accepts common command-line arguments such as
+  `--debug-backtraces` (#3878, @ejgallego)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -58,14 +58,9 @@ let man =
 let info = Term.info "subst" ~doc ~man
 
 let term =
-  let+ () = Common.build_info in
-  let config : Config.t =
-    { Config.default with display = Quiet; concurrency = Fixed 1 }
-  in
-  Path.set_root (Path.External.cwd ());
-  Path.Build.set_build_dir (Path.Build.Kind.of_string Common.default_build_dir);
-  Config.init config;
-  Log.init_disabled ();
+  let+ common = Common.term in
+  Common.set_common ~log_file:No_log_file common ~targets:[];
+  let config = Common.config common in
   Dune_engine.Scheduler.go ~config Watermarks.subst
 
 let command = (term, info)


### PR DESCRIPTION
In particular I wanted this as to have `dune subst` interpret
`--debug-backtraces` in the context of #3219

I'm not sure if that's the way to go, so please consider this PR as a RFC

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>