### PR TITLE
do not rely on package names in Build_system

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -104,21 +104,23 @@ module Main = struct
                          |> List.map ~f:Package.Name.to_string )));
           Package.Name.Map.filter workspace.conf.packages ~f:(fun pkg ->
               let vendored =
-                match Dune_engine.File_tree.find_dir pkg.path with
+                let dir = Package.dir pkg in
+                match Dune_engine.File_tree.find_dir dir with
                 | None -> assert false
                 | Some d -> (
                   match Dune_engine.File_tree.Dir.status d with
                   | Vendored -> true
                   | _ -> false )
               in
-              let included = Package.Name.Set.mem names pkg.name in
+              let name = Package.name pkg in
+              let included = Package.Name.Set.mem names name in
               if vendored && included then
                 User_error.raise
                   [ Pp.textf
                       "Package %s is vendored and so will never be masked. It \
                        makes no sense to pass it to -p, --only-packages or \
                        --for-release-of-packages."
-                      (Package.Name.to_string pkg.name)
+                      (Package.Name.to_string name)
                   ];
               vendored || included))
     in

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -130,7 +130,7 @@ module File_ops_real (W : Workspace) : File_operations = struct
       match
         let open Option.O in
         let* package = Package.Name.Map.find workspace.conf.packages package in
-        get_vcs package.path
+        Package.dir package |> get_vcs
       with
       | None -> plain_copy ()
       | Some vcs ->
@@ -313,7 +313,8 @@ let file_operations ~dry_run ~workspace : (module File_operations) =
     end) )
 
 let package_is_vendored (pkg : Dune_engine.Package.t) =
-  match Dune_engine.File_tree.find_dir pkg.path with
+  let dir = Package.dir pkg in
+  match Dune_engine.File_tree.find_dir dir with
   | None -> assert false
   | Some d -> (
     match Dune_engine.File_tree.Dir.status d with
@@ -397,7 +398,8 @@ let install_uninstall ~what =
                 if package_is_vendored pkg then
                   acc
                 else
-                  pkg.name :: acc)
+                  let name = Package.name pkg in
+                  name :: acc)
             |> List.rev
           | l -> l
         in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -150,8 +150,12 @@ module Alias0 = struct
         ]
 
   let package_install ~(context : Build_context.t) ~(pkg : Package.t) =
-    let dir = Path.Build.append_source context.build_dir pkg.path in
-    sprintf ".%s-files" (Package.Name.to_string pkg.name)
+    let dir =
+      let dir = Package.dir pkg in
+      Path.Build.append_source context.build_dir dir
+    in
+    let name = Package.name pkg in
+    sprintf ".%s-files" (Package.Name.to_string name)
     |> Alias.Name.of_string |> make ~dir
 end
 
@@ -327,7 +331,7 @@ type t =
           option)
       Fdecl.t
   ; (* Package files are part of *)
-    packages : (Path.Build.t -> Package.Set.t) Fdecl.t
+    packages : (Path.Build.t -> Package.Id.Set.t) Fdecl.t
   ; mutable caching : caching option
   ; sandboxing_preference : Sandbox_mode.t list
   ; mutable rule_done : int
@@ -1762,7 +1766,7 @@ let set_packages f =
   let t = t () in
   Fdecl.set t.packages f
 
-let package_deps pkg files =
+let package_deps (pkg : Package.t) files =
   let t = t () in
   let rules_seen = ref Rule.Set.empty in
   let rec loop fn acc =
@@ -1773,10 +1777,10 @@ let package_deps pkg files =
       acc
     | Some fn ->
       let pkgs = Fdecl.get t.packages fn in
-      if Package.Set.is_empty pkgs || Package.Set.mem pkgs pkg then
+      if Package.Id.Set.is_empty pkgs || Package.Id.Set.mem pkgs pkg.id then
         loop_deps fn acc
       else
-        Package.Set.union acc pkgs
+        Package.Id.Set.union acc pkgs
   and loop_deps fn acc =
     match get_rule (Path.build fn) with
     | None -> acc
@@ -1802,7 +1806,7 @@ let package_deps pkg files =
   (* We know that after [Build.paths_for_rule], all transitive dependencies of
      [files] are computed and memoized and so the above call to
      [Build_request.peek_deps_exn] is safe. *)
-  Path.Set.fold files ~init:Package.Set.empty ~f:(fun fn acc ->
+  Path.Set.fold files ~init:Package.Id.Set.empty ~f:(fun fn acc ->
       match Path.as_in_build_dir fn with
       | None -> acc
       | Some fn -> loop_deps fn acc)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -327,7 +327,7 @@ type t =
           option)
       Fdecl.t
   ; (* Package files are part of *)
-    packages : (Path.Build.t -> Package.Name.Set.t) Fdecl.t
+    packages : (Path.Build.t -> Package.Set.t) Fdecl.t
   ; mutable caching : caching option
   ; sandboxing_preference : Sandbox_mode.t list
   ; mutable rule_done : int
@@ -1773,10 +1773,10 @@ let package_deps pkg files =
       acc
     | Some fn ->
       let pkgs = Fdecl.get t.packages fn in
-      if Package.Name.Set.is_empty pkgs || Package.Name.Set.mem pkgs pkg then
+      if Package.Set.is_empty pkgs || Package.Set.mem pkgs pkg then
         loop_deps fn acc
       else
-        Package.Name.Set.union acc pkgs
+        Package.Set.union acc pkgs
   and loop_deps fn acc =
     match get_rule (Path.build fn) with
     | None -> acc
@@ -1802,7 +1802,7 @@ let package_deps pkg files =
   (* We know that after [Build.paths_for_rule], all transitive dependencies of
      [files] are computed and memoized and so the above call to
      [Build_request.peek_deps_exn] is safe. *)
-  Path.Set.fold files ~init:Package.Name.Set.empty ~f:(fun fn acc ->
+  Path.Set.fold files ~init:Package.Set.empty ~f:(fun fn acc ->
       match Path.as_in_build_dir fn with
       | None -> acc
       | Some fn -> loop_deps fn acc)

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -91,12 +91,12 @@ val targets_of : dir:Path.t -> Path.Set.t
 val load_dir : dir:Path.t -> unit
 
 (** Sets the package assignment *)
-val set_packages : (Path.Build.t -> Package.Name.Set.t) -> unit
+val set_packages : (Path.Build.t -> Package.Set.t) -> unit
 
 (** Assuming [files] is the list of files in [_build/install] that belong to
     package [pkg], [package_deps t pkg files] is the set of direct package
     dependencies of [package]. *)
-val package_deps : Package.Name.t -> Path.Set.t -> Package.Name.Set.t Build.t
+val package_deps : Package.t -> Path.Set.t -> Package.Set.t Build.t
 
 (** {2 Aliases} *)
 

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -91,12 +91,12 @@ val targets_of : dir:Path.t -> Path.Set.t
 val load_dir : dir:Path.t -> unit
 
 (** Sets the package assignment *)
-val set_packages : (Path.Build.t -> Package.Set.t) -> unit
+val set_packages : (Path.Build.t -> Package.Id.Set.t) -> unit
 
 (** Assuming [files] is the list of files in [_build/install] that belong to
     package [pkg], [package_deps t pkg files] is the set of direct package
     dependencies of [package]. *)
-val package_deps : Package.t -> Path.Set.t -> Package.Set.t Build.t
+val package_deps : Package.t -> Path.Set.t -> Package.Id.Set.t Build.t
 
 (** {2 Aliases} *)
 

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -695,7 +695,7 @@ let parse ~dir ~lang ~opam_packages ~file =
        else (
          ( match (packages, name) with
          | [ p ], Some (Named name) ->
-           if Package.Name.to_string p.name <> name then
+           if Package.Name.to_string (Package.name p) <> name then
              User_error.raise ~loc:p.loc
                [ Pp.textf
                    "when a single package is defined, it must have the same \
@@ -718,18 +718,19 @@ let parse ~dir ~lang ~opam_packages ~file =
                  ~f:package_defined_twice)
          in
          List.iter packages ~f:(fun p ->
-             match
-               Package.Name.Map.find deprecated_package_names p.Package.name
-             with
+             let name = Package.name p in
+             match Package.Name.Map.find deprecated_package_names name with
              | None -> ()
-             | Some loc -> package_defined_twice p.Package.name loc p.loc);
+             | Some loc -> package_defined_twice name loc p.loc);
          match
-           Package.Name.Map.of_list_map packages ~f:(fun p -> (p.name, p))
+           Package.Name.Map.of_list_map packages ~f:(fun p ->
+               (Package.name p, p))
          with
          | Error (_, _, p) ->
+           let name = Package.name p in
            User_error.raise ~loc:p.loc
              [ Pp.textf "package %s is already defined"
-                 (Package.Name.to_string p.name)
+                 (Package.Name.to_string name)
              ]
          | Ok packages ->
            Package.Name.Map.merge packages opam_packages

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -615,3 +615,17 @@ let missing_deps (t : t) ~effective_deps =
     |> Name.Set.of_list
   in
   Name.Set.diff effective_deps specified_deps
+
+module C = Comparable.Make (struct
+  type nonrec t = t
+
+  let to_dyn = to_dyn
+
+  let compare { path; name; _ } pkg =
+    match Name.compare pkg.name name with
+    | Eq -> Path.Source.compare path pkg.path
+    | s -> s
+end)
+
+module Set = C.Set
+module Map = C.Map

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -55,6 +55,34 @@ module Name = struct
   module Infix = Comparator.Operators (T)
 end
 
+module Id = struct
+  module T = struct
+    type t =
+      { name : Name.t
+      ; dir : Path.Source.t
+      }
+
+    let compare { dir; name } pkg =
+      match Name.compare pkg.name name with
+      | Eq -> Path.Source.compare dir pkg.dir
+      | s -> s
+
+    let to_dyn { dir; name } =
+      let open Dyn.Encoder in
+      record [ ("name", Name.to_dyn name); ("dir", Path.Source.to_dyn dir) ]
+  end
+
+  include T
+
+  let hash { name; dir } = Tuple.T2.hash Name.hash Path.Source.hash (name, dir)
+
+  let name t = t.name
+
+  module C = Comparable.Make (T)
+  module Set = C.Set
+  module Map = C.Map
+end
+
 module Dependency = struct
   module Op = struct
     type t =
@@ -428,7 +456,7 @@ module Info = struct
 end
 
 type t =
-  { name : Name.t
+  { id : Id.t
   ; loc : Loc.t
   ; synopsis : string option
   ; description : string option
@@ -436,7 +464,6 @@ type t =
   ; conflicts : Dependency.t list
   ; depopts : Dependency.t list
   ; info : Info.t
-  ; path : Path.Source.t
   ; version : string option
   ; has_opam_file : bool
   ; tags : string list
@@ -447,7 +474,11 @@ type t =
 (* Package name are globally unique, so we can reasonably expect that there will
    always be only a single value of type [t] with a given name in memory. That's
    why we only hash the name. *)
-let hash t = Name.hash t.name
+let hash t = Id.hash t.id
+
+let name t = t.id.name
+
+let dir t = t.id.dir
 
 let decode ~dir =
   let open Dune_lang.Decoder in
@@ -486,7 +517,8 @@ let decode ~dir =
          (pair Section.decode Section.Site.decode)
          Section.to_string "Site location name"
      in
-     { name
+     let id = { Id.name; dir } in
+     { id
      ; loc
      ; synopsis
      ; description
@@ -494,7 +526,6 @@ let decode ~dir =
      ; conflicts
      ; depopts
      ; info
-     ; path = dir
      ; version
      ; has_opam_file = false
      ; tags
@@ -503,8 +534,7 @@ let decode ~dir =
      }
 
 let to_dyn
-    { name
-    ; path
+    { id
     ; version
     ; synopsis
     ; description
@@ -520,8 +550,7 @@ let to_dyn
     } =
   let open Dyn.Encoder in
   record
-    [ ("name", Name.to_dyn name)
-    ; ("path", Path.Source.to_dyn path)
+    [ ("id", Id.to_dyn id)
     ; ("synopsis", option string synopsis)
     ; ("description", option string description)
     ; ("depends", list Dependency.to_dyn depends)
@@ -536,14 +565,14 @@ let to_dyn
     ; ("sites", Section.Site.Map.to_dyn Section.to_dyn sites)
     ]
 
-let opam_file t = Path.Source.relative t.path (Name.opam_fn t.name)
+let opam_file t = Path.Source.relative t.id.dir (Name.opam_fn t.id.name)
 
-let meta_file t = Path.Source.relative t.path (Name.meta_fn t.name)
+let meta_file t = Path.Source.relative t.id.dir (Name.meta_fn t.id.name)
 
 let file ~dir ~name = Path.relative dir (Name.to_string name ^ opam_ext)
 
 let deprecated_meta_file t name =
-  Path.Source.relative t.path (Name.meta_fn name)
+  Path.Source.relative t.id.dir (Name.meta_fn name)
 
 let load_opam_file file name =
   let open Option.O in
@@ -583,9 +612,9 @@ let load_opam_file file name =
       List.rev l
     | _ -> None
   in
-  { name
+  let id = { Id.name; dir = Path.Source.parent_exn file } in
+  { id
   ; loc
-  ; path = Path.Source.parent_exn file
   ; version = get_one "version"
   ; conflicts = []
   ; depends = []
@@ -615,17 +644,3 @@ let missing_deps (t : t) ~effective_deps =
     |> Name.Set.of_list
   in
   Name.Set.diff effective_deps specified_deps
-
-module C = Comparable.Make (struct
-  type nonrec t = t
-
-  let to_dyn = to_dyn
-
-  let compare { path; name; _ } pkg =
-    match Name.compare pkg.name name with
-    | Eq -> Path.Source.compare path pkg.path
-    | s -> s
-end)
-
-module Set = C.Set
-module Map = C.Map

--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -20,6 +20,16 @@ module Name : sig
   val of_opam_file_basename : string -> t option
 end
 
+module Id : sig
+  type t
+
+  val name : t -> Name.t
+
+  module Set : Set.S with type elt = t
+
+  module Map : Map.S with type key = t
+end
+
 module Dependency : sig
   module Op : sig
     type t =
@@ -115,7 +125,7 @@ module Info : sig
 end
 
 type t =
-  { name : Name.t
+  { id : Id.t
   ; loc : Loc.t
   ; synopsis : string option
   ; description : string option
@@ -123,13 +133,16 @@ type t =
   ; conflicts : Dependency.t list
   ; depopts : Dependency.t list
   ; info : Info.t
-  ; path : Path.Source.t
   ; version : string option
   ; has_opam_file : bool
   ; tags : string list
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Section.t Section.Site.Map.t
   }
+
+val name : t -> Name.t
+
+val dir : t -> Path.Source.t
 
 val file : dir:Path.t -> name:Name.t -> Path.t
 
@@ -151,7 +164,3 @@ val is_opam_file : Path.t -> bool
 val load_opam_file : Path.Source.t -> Name.t -> t
 
 val missing_deps : t -> effective_deps:Name.Set.t -> Name.Set.t
-
-module Set : Set.S with type elt = t
-
-module Map : Map.S with type key = t

--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -151,3 +151,7 @@ val is_opam_file : Path.t -> bool
 val load_opam_file : Path.Source.t -> Name.t -> t
 
 val missing_deps : t -> effective_deps:Name.Set.t -> Name.Set.t
+
+module Set : Set.S with type elt = t
+
+module Map : Map.S with type key = t

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -372,8 +372,8 @@ let coq_plugins_install_rules ~scope ~package ~dst_dir (s : Theory.t) =
     let info = Lib.info lib in
     (* Don't install libraries that don't belong to this package *)
     if
-      Option.equal Package.Name.equal (Lib_info.package info)
-        (Some package.Package.name)
+      let name = Package.name package in
+      Option.equal Package.Name.equal (Lib_info.package info) (Some name)
     then
       let loc = Lib_info.loc info in
       let plugins = Lib_info.plugins info in

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -659,7 +659,7 @@ module Library = struct
              [ Pp.textf
                  "This library has a pullic_name, it already belongs to the \
                   package %s"
-                 (Package.Name.to_string public.package.name)
+                 (Package.Name.to_string (Package.name public.package))
              ]
        in
        Option.both virtual_modules implements
@@ -1930,7 +1930,8 @@ module Library_redirect = struct
         None
       | Private (Some package) ->
         let loc, name = lib.name in
-        let new_public_name = (loc, Lib_name.mangled package.name name) in
+        let package_name = Package.name package in
+        let new_public_name = (loc, Lib_name.mangled package_name name) in
         Some (for_lib lib ~loc ~new_public_name)
 
     let of_lib (lib : Library.t) : t option =
@@ -1963,7 +1964,8 @@ module Deprecated_library_name = struct
           Lib_name.package_name (Public_lib.name public)
         in
         if
-          Package.Name.equal deprecated_package (Public_lib.package public).name
+          let name = Package.name (Public_lib.package public) in
+          Package.Name.equal deprecated_package name
         then
           Not_deprecated
         else

--- a/src/dune_rules/gen_meta.ml
+++ b/src/dune_rules/gen_meta.ml
@@ -180,7 +180,8 @@ let gen ~(package : Package.t) ~add_directory_entry entries =
                     (Lib_name.Local.of_string package)
                 in
                 let pub_name =
-                  Pub_name.of_list (Package.Name.to_string pkg.name :: path)
+                  let name = Package.name pkg in
+                  Pub_name.of_list (Package.Name.to_string name :: path)
                 in
                 (pub_name, path)
               | _ -> (pub_name, path)
@@ -225,4 +226,4 @@ let gen ~(package : Package.t) ~add_directory_entry entries =
     ; entries = entries @ subs
     }
   in
-  loop (Package.Name.to_string package.name) pkgs
+  loop (Package.Name.to_string (Package.name package)) pkgs

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -431,7 +431,7 @@ let gen ~contexts ?only_packages conf =
   let () =
     Build_system.set_packages (fun path ->
         let open Option.O in
-        Option.value ~default:Package.Name.Set.empty
+        Option.value ~default:Package.Set.empty
           (let* ctx_name, _ = Path.Build.extract_build_context path in
            let* ctx_name = Context_name.of_string_opt ctx_name in
            let* sctx = Context_name.Map.find sctxs ctx_name in

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -379,7 +379,9 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
       let include_stanza =
         match Dune_file.stanza_package stanza with
         | None -> true
-        | Some package -> Package.Name.Map.mem visible_pkgs package.name
+        | Some package ->
+          let name = Package.name package in
+          Package.Name.Map.mem visible_pkgs name
       in
       if include_stanza then
         Some stanza
@@ -431,7 +433,7 @@ let gen ~contexts ?only_packages conf =
   let () =
     Build_system.set_packages (fun path ->
         let open Option.O in
-        Option.value ~default:Package.Set.empty
+        Option.value ~default:Package.Id.Set.empty
           (let* ctx_name, _ = Path.Build.extract_build_context path in
            let* ctx_name = Context_name.of_string_opt ctx_name in
            let* sctx = Context_name.Map.find sctxs ctx_name in

--- a/src/dune_rules/generate_module_rules.ml
+++ b/src/dune_rules/generate_module_rules.ml
@@ -28,16 +28,17 @@ let sites_code sctx buf (loc, pkg) =
     | None ->
       User_error.raise ~loc [ Pp.text "dune_site used outside a package" ]
   in
+  let package_name = Package.name package in
   (* Parse the replacement format described in [artifact_substitution.ml]. *)
   Section.Site.Map.iteri package.sites ~f:(fun name section ->
       pr buf "    let %s = %s.site"
         (String.uncapitalize_ascii (Section.Site.to_string name))
         helpers;
-      pr buf "      ~package:%S" (Package.Name.to_string package.name);
+      pr buf "      ~package:%S" (Package.Name.to_string package_name);
       pr buf "      ~section:Dune_section.%s"
         (String.capitalize_ascii (Section.to_string section));
       pr buf "      ~suffix:%S" (Section.Site.to_string name);
-      pr buf "      ~encoded:%a" encode (Location (section, package.name)))
+      pr buf "      ~encoded:%a" encode (Location (section, package_name)))
 
 let plugins_code sctx buf pkg sites =
   let package =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -17,11 +17,13 @@ module Package_paths = struct
       (Package.deprecated_meta_file pkg name)
 
   let build_dir (ctx : Context.t) (pkg : Package.t) =
-    Path.Build.append_source ctx.build_dir pkg.path
+    let dir = Package.dir pkg in
+    Path.Build.append_source ctx.build_dir dir
 
   let dune_package_file ctx pkg =
+    let name = Package.name pkg in
     Path.Build.relative (build_dir ctx pkg)
-      (Package.Name.to_string pkg.name ^ ".dune-package")
+      (Package.Name.to_string name ^ ".dune-package")
 
   let deprecated_dune_package_file ctx pkg name =
     Path.Build.relative (build_dir ctx pkg)
@@ -292,10 +294,11 @@ end = struct
                  (None, Install.Entry.make Lib opam_file ~dst:"opam")
                  :: deprecated_meta_and_dune_files )
              in
-             match File_tree.find_dir pkg.path with
+             let pkg_dir = Package.dir pkg in
+             match File_tree.find_dir pkg_dir with
              | None -> init
              | Some dir ->
-               let pkg_dir = Path.Build.append_source ctx.build_dir pkg.path in
+               let pkg_dir = Path.Build.append_source ctx.build_dir pkg_dir in
                File_tree.Dir.files dir
                |> String.Set.fold ~init ~f:(fun fn acc ->
                       if is_odig_doc_file fn then
@@ -356,7 +359,8 @@ end = struct
             | Dune_file.Plugin t -> Plugin_rules.install_rules ~sctx ~dir t
             | _ -> []
           in
-          Package.Name.Map.Multi.add_all acc package.name new_entries)
+          let name = Package.name package in
+          Package.Name.Map.Multi.add_all acc name new_entries)
 
   let stanzas_to_entries =
     let memo =
@@ -381,9 +385,10 @@ module Meta_and_dune_package : sig
   val meta_and_dune_package_rules : Super_context.t -> dir:Path.Build.t -> unit
 end = struct
   let make_dune_package sctx lib_entries (pkg : Package.t) =
+    let pkg_name = Package.name pkg in
     let ctx = Super_context.context sctx in
     let pkg_root =
-      Config.local_install_lib_dir ~context:ctx.name ~package:pkg.name
+      Config.local_install_lib_dir ~context:ctx.name ~package:pkg_name
     in
     let lib_root lib =
       let subdir =
@@ -453,11 +458,11 @@ end = struct
       Section.Site.Map.values pkg.sites
       |> Section.Set.of_list |> Section.Set.to_map
       |> Section.Map.mapi ~f:(fun section () ->
-             Install.Section.Paths.get_local_location ctx.name section pkg.name)
+             Install.Section.Paths.get_local_location ctx.name section pkg_name)
     in
     Dune_package.Or_meta.Dune_package
       { Dune_package.version = pkg.version
-      ; name = pkg.name
+      ; name = pkg_name
       ; entries
       ; dir = Path.build pkg_root
       ; sections
@@ -469,7 +474,9 @@ end = struct
     let dune_version =
       Dune_lang.Syntax.greatest_supported_version Stanza.syntax
     in
-    let lib_entries = Super_context.lib_entries_of_package sctx pkg.name in
+    let lib_entries =
+      Super_context.lib_entries_of_package sctx (Package.name pkg)
+    in
     let action =
       let dune_package_file = Package_paths.dune_package_file ctx pkg in
       let meta_template = Package_paths.meta_template ctx pkg in
@@ -542,8 +549,9 @@ end = struct
 
   let gen_meta_file sctx (pkg : Package.t) =
     let ctx = Super_context.context sctx in
+    let pkg_name = Package.name pkg in
     let deprecated_packages, entries =
-      let entries = Super_context.lib_entries_of_package sctx pkg.name in
+      let entries = Super_context.lib_entries_of_package sctx pkg_name in
       List.partition_map entries ~f:(function
         | Super_context.Lib_entry.Deprecated_library_name
             { old_name = public, Deprecated { deprecated_package }; _ } as entry
@@ -578,7 +586,7 @@ end = struct
                     [ Pp.textf
                         "Package %s defines virtual library %s and has a META \
                          template. This is not allowed."
-                        (Package.Name.to_string pkg.name)
+                        (Package.Name.to_string pkg_name)
                         (Lib_name.to_string name)
                     ])
             }
@@ -693,11 +701,12 @@ let promote_install_file (ctx : Context.t) =
 
 let install_entries sctx (package : Package.t) =
   let packages = Stanzas_to_entries.stanzas_to_entries sctx in
-  Package.Name.Map.Multi.find packages package.name
+  Package.Name.Map.Multi.find packages (Package.name package)
 
 let install_rules sctx (package : Package.t) =
+  let package_name = Package.name package in
   let install_paths =
-    Install.Section.Paths.make ~package:package.name ~destdir:Path.root ()
+    Install.Section.Paths.make ~package:package_name ~destdir:Path.root ()
   in
   let entries =
     install_entries sctx package
@@ -718,17 +727,18 @@ let install_rules sctx (package : Package.t) =
     | true ->
       let missing_deps =
         let effective_deps =
-          Package.Set.to_list packages
-          |> Package.Name.Set.of_list_map ~f:(fun (pkg : Package.t) -> pkg.name)
+          Package.Id.Set.to_list packages
+          |> Package.Name.Set.of_list_map ~f:Package.Id.name
         in
         Package.missing_deps package ~effective_deps
       in
       if Package.Name.Set.is_empty missing_deps then
         packages
       else
+        let name = Package.name package in
         User_error.raise
           [ Pp.textf "Package %s is missing the following package dependencies"
-              (Package.Name.to_string package.name)
+              (Package.Name.to_string name)
           ; Package.Name.Set.to_list missing_deps
             |> Pp.enumerate ~f:(fun name ->
                    Pp.text (Package.Name.to_string name))
@@ -743,12 +753,11 @@ let install_rules sctx (package : Package.t) =
     Rules.Produce.Alias.add_deps target_alias files
       ~dyn_deps:
         (let+ packages = packages in
-         Package.Set.to_list packages
-         |> Path.Set.of_list_map ~f:(fun (pkg : Package.t) ->
+         Package.Id.Set.to_list packages
+         |> Path.Set.of_list_map ~f:(fun (pkg : Package.Id.t) ->
+                let name = Package.Id.name pkg in
                 let pkg =
-                  Package.Name.Map.find_exn
-                    (Super_context.packages sctx)
-                    pkg.name
+                  Package.Name.Map.find_exn (Super_context.packages sctx) name
                 in
                 Build_system.Alias.package_install
                   ~context:(Context.to_build_context ctx)
@@ -758,14 +767,14 @@ let install_rules sctx (package : Package.t) =
   let action =
     let install_file =
       Path.Build.relative pkg_build_dir
-        (Utils.install_file ~package:package.name
+        (Utils.install_file ~package:package_name
            ~findlib_toolchain:ctx.findlib_toolchain)
     in
     Build.write_file_dyn install_file
       (let+ () = Build.path_set files
        and+ () =
          if strict_package_deps then
-           Build.map packages ~f:(fun (_ : Package.Set.t) -> ())
+           Build.map packages ~f:(fun (_ : Package.Id.Set.t) -> ())
          else
            Build.return ()
        in
@@ -808,9 +817,10 @@ let memo =
     let to_dyn _ = Dyn.Opaque
   end in
   let install_alias (ctx : Context.t) (package : Package.t) =
+    let name = Package.name package in
     if not ctx.implicit then
       let install_fn =
-        Utils.install_file ~package:package.name
+        Utils.install_file ~package:name
           ~findlib_toolchain:ctx.findlib_toolchain
       in
       let path = Package_paths.build_dir ctx package in
@@ -877,10 +887,11 @@ let packages =
   in
   let f sctx =
     Super_context.packages sctx
-    |> Package.Name.Map.fold ~init:[] ~f:(fun pkg acc ->
+    |> Package.Name.Map.fold ~init:[] ~f:(fun (pkg : Package.t) acc ->
            List.fold_left (package_source_files sctx pkg) ~init:acc
-             ~f:(fun acc path -> (path, pkg) :: acc))
-    |> Path.Build.Map.of_list_fold ~init:Package.Set.empty ~f:Package.Set.add
+             ~f:(fun acc path -> (path, pkg.id) :: acc))
+    |> Path.Build.Map.of_list_fold ~init:Package.Id.Set.empty
+         ~f:Package.Id.Set.add
   in
   let memo =
     Memo.create "package-map" ~doc:"Return a map assining package to files"
@@ -889,11 +900,11 @@ let packages =
       ~output:
         (Allow_cutoff
            ( module struct
-             type t = Package.Set.t Path.Build.Map.t
+             type t = Package.Id.Set.t Path.Build.Map.t
 
-             let to_dyn = Path.Build.Map.to_dyn Package.Set.to_dyn
+             let to_dyn = Path.Build.Map.to_dyn Package.Id.Set.to_dyn
 
-             let equal = Path.Build.Map.equal ~equal:Package.Set.equal
+             let equal = Path.Build.Map.equal ~equal:Package.Id.Set.equal
            end ))
       Sync f
   in

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -19,4 +19,4 @@ val meta_and_dune_package_rules : Super_context.t -> dir:Path.Build.t -> unit
    [meta_and_dune_package_rules] from the interface and have [gen_rules] do
    everything. *)
 
-val packages : Super_context.t -> Package.Name.Set.t Path.Build.Map.t
+val packages : Super_context.t -> Package.Set.t Path.Build.Map.t

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -19,4 +19,4 @@ val meta_and_dune_package_rules : Super_context.t -> dir:Path.Build.t -> unit
    [meta_and_dune_package_rules] from the interface and have [gen_rules] do
    everything. *)
 
-val packages : Super_context.t -> Package.Set.t Path.Build.Map.t
+val packages : Super_context.t -> Package.Id.Set.t Path.Build.Map.t

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1878,7 +1878,7 @@ let to_dune_lib ({ info; _ } as lib) ~modules ~foreign_objects ~dir =
   let mangled_name lib =
     match Lib_info.status lib.info with
     | Private (_, Some pkg) ->
-      Lib_name.mangled pkg.name (Lib_name.to_local_exn lib.name)
+      Lib_name.mangled (Package.name pkg) (Lib_name.to_local_exn lib.name)
     | _ -> lib.name
   in
   let add_loc = List.map ~f:(fun x -> (loc, mangled_name x)) in

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -536,8 +536,8 @@ let package t =
   | Installed_private
   | Installed ->
     Some (Lib_name.package_name t.name)
-  | Public (_, p) -> Some p.name
-  | Private (_, p) -> Option.map p ~f:(fun t -> t.name)
+  | Public (_, p) -> Some (Package.name p)
+  | Private (_, p) -> Option.map p ~f:Package.name
 
 let has_native_archive lib_config modules =
   Lib_config.linker_can_create_empty_archives lib_config

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -119,7 +119,7 @@ let build_info_code cctx ~libs ~api_version =
   let version_of_package (p : Package.t) =
     match p.version with
     | Some v -> sprintf "Some %S" v
-    | None -> placeholder p.path
+    | None -> placeholder (Package.dir p)
   in
   let version =
     match Compilation_context.package cctx with

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -20,9 +20,11 @@ let package_install_file w pkg =
   match Package.Name.Map.find w.conf.packages pkg with
   | None -> Error ()
   | Some p ->
+    let name = Package.name p in
+    let dir = Package.dir p in
     Ok
-      (Path.Source.relative p.path
-         (Utils.install_file ~package:p.name ~findlib_toolchain:None))
+      (Path.Source.relative dir
+         (Utils.install_file ~package:name ~findlib_toolchain:None))
 
 let setup_env ~capture_outputs =
   let env =

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -535,13 +535,15 @@ let setup_pkg_html_rules sctx ~pkg ~libs =
 
 let setup_package_aliases sctx (pkg : Package.t) =
   let ctx = Super_context.context sctx in
+  let name = Package.name pkg in
   let alias =
-    let dir = Path.Build.append_source ctx.build_dir pkg.Package.path in
+    let pkg_dir = Package.dir pkg in
+    let dir = Path.Build.append_source ctx.build_dir pkg_dir in
     Alias.doc ~dir
   in
   Rules.Produce.Alias.add_deps alias
-    ( Dep.html_alias ctx (Pkg pkg.name)
-      :: ( libs_of_pkg sctx ~pkg:pkg.name
+    ( Dep.html_alias ctx (Pkg name)
+      :: ( libs_of_pkg sctx ~pkg:name
          |> List.map ~f:(fun lib -> Dep.html_alias ctx (Lib lib)) )
     |> Path.Set.of_list_map ~f:(fun f -> Path.build (Alias.stamp_file f)) )
 
@@ -698,5 +700,7 @@ let gen_rules sctx ~dir:_ rest =
     Option.iter
       (Package.Name.Map.find (SC.packages sctx)
          (Package.Name.of_string lib_unique_name_or_pkg))
-      ~f:(fun pkg -> setup_pkg_html_rules pkg.name)
+      ~f:(fun pkg ->
+        let name = Package.name pkg in
+        setup_pkg_html_rules name)
   | _ -> ()

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -59,8 +59,7 @@ let package_fields
     ; conflicts
     ; depopts
     ; info = _
-    ; name = _
-    ; path = _
+    ; id = _
     ; version = _
     ; has_opam_file = _
     ; tags
@@ -165,14 +164,15 @@ let insert_odoc_dep depends =
 
 let opam_fields project (package : Package.t) =
   let dune_version = Dune_project.dune_version project in
+  let package_name = Package.name package in
   let package =
-    if dune_version < (1, 11) || Package.Name.equal package.name dune_name then
+    if dune_version < (1, 11) || Package.Name.equal package_name dune_name then
       package
     else
       { package with depends = insert_dune_dep package.depends dune_version }
   in
   let package =
-    if dune_version < (2, 7) || Package.Name.equal package.name odoc_name then
+    if dune_version < (2, 7) || Package.Name.equal package_name odoc_name then
       package
     else
       { package with depends = insert_odoc_dep package.depends }
@@ -257,7 +257,7 @@ let add_rule sctx ~project ~pkg =
      generate project pkg ~template)
     |> Build.write_file_dyn opam_path
   in
-  let dir = Path.Build.append_source build_dir pkg.path in
+  let dir = Path.Build.append_source build_dir (Package.dir pkg) in
   let mode =
     Rule.Mode.Promote { lifetime = Unlimited; into = None; only = None }
   in

--- a/src/dune_rules/packages.ml
+++ b/src/dune_rules/packages.ml
@@ -22,7 +22,8 @@ let mlds_by_package_def =
                | Documentation d ->
                  let dc = Dir_contents.get sctx ~dir:w.ctx_dir in
                  let mlds = Dir_contents.mlds dc d in
-                 Some (d.package.name, mlds)
+                 let name = Package.name d.package in
+                 Some (name, mlds)
                | _ -> None))
       |> Package.Name.Map.of_list_reduce ~f:List.rev_append)
 

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -7,11 +7,13 @@ module Pkg = struct
   let listing packages =
     let longest_pkg =
       String.longest_map packages ~f:(fun p ->
-          Package.Name.to_string p.Package.name)
+          let name = Package.name p in
+          Package.Name.to_string name)
     in
     Pp.enumerate packages ~f:(fun pkg ->
+        let name = Package.name pkg in
         Printf.ksprintf Pp.verbatim "%-*s (because of %s)" longest_pkg
-          (Package.Name.to_string pkg.Package.name)
+          (Package.Name.to_string name)
           (Path.Source.to_string (Package.opam_file pkg)))
 
   let default (project : Dune_project.t) stanza =

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -461,7 +461,8 @@ let create_lib_entries_by_package ~public_libs stanzas =
         with
         | None -> acc
         | Some lib ->
-          (pkg.name, Lib_entry.Library (Lib.Local.of_lib_exn lib)) :: acc )
+          let name = Package.name pkg in
+          (name, Lib_entry.Library (Lib.Local.of_lib_exn lib)) :: acc )
       | Dune_file.Library { visibility = Public pub; _ } -> (
         match Lib.DB.find public_libs (Dune_file.Public_lib.name pub) with
         | None ->
@@ -469,14 +470,14 @@ let create_lib_entries_by_package ~public_libs stanzas =
              the libary name is always found somehow *)
           acc
         | Some lib ->
-          ( (Dune_file.Public_lib.package pub).name
-          , Lib_entry.Library (Lib.Local.of_lib_exn lib) )
-          :: acc )
+          let package = Dune_file.Public_lib.package pub in
+          let name = Package.name package in
+          (name, Lib_entry.Library (Lib.Local.of_lib_exn lib)) :: acc )
       | Dune_file.Deprecated_library_name
           ({ old_name = old_public_name, _; _ } as d) ->
-        ( (Dune_file.Public_lib.package old_public_name).name
-        , Lib_entry.Deprecated_library_name d )
-        :: acc
+        let package = Dune_file.Public_lib.package old_public_name in
+        let name = Package.name package in
+        (name, Lib_entry.Deprecated_library_name d) :: acc
       | _ -> acc)
   |> Package.Name.Map.of_list_multi
   |> Package.Name.Map.map
@@ -488,7 +489,9 @@ let create_projects_by_package projects : Dune_project.t Package.Name.Map.t =
   List.concat_map projects ~f:(fun project ->
       Dune_project.packages project
       |> Package.Name.Map.values
-      |> List.map ~f:(fun (pkg : Package.t) -> (pkg.name, project)))
+      |> List.map ~f:(fun (pkg : Package.t) ->
+             let name = Package.name pkg in
+             (name, project)))
   |> Package.Name.Map.of_list_exn
 
 let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =


### PR DESCRIPTION
We'd like to lift the restriction on packages with the same name
co-existing in the same workspace. The first step is to avoid this
reliance in `Build_system`. In `Build_system`, we rely on the user
creating a path to package map when generating the rules. This PR makes
it so that we don't use on package names in this map.

We use a set of packages where uniqueness is determined by the package
name + the package path. This is guaranteed to be unique.