### PR TITLE
Extend `enabled_if` for alias stanza to variable available in actions Fixes #3832

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Unreleased
 
 - Make `patdiff` show refined diffs (#4257, fixes #4254, @hakuch)
 
+- Allow any variables in `enabled_if` fields of alias stanza (#3900, fixes
+  #3832,@bobot)
+
 - Allow `(package pkg)` in dependencies even if `pkg` is an installed package
   (#4170, @bobot)
 

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -185,7 +185,8 @@ Dune supports the following variables:
   For example, ``%{env:BIN=/usr/bin}``.
   Available since dune 1.4.0.
 
-In addition, ``(action ...)`` fields support the following special variables:
+In addition, ``(action ...)`` fields of any stanza and ``(enabled_if ...)``
+fields of ``alias`` stanza support the following special variables:
 
 - ``target`` expands to the one target
 - ``targets`` expands to the list of target

--- a/src/dune_rules/blang.mli
+++ b/src/dune_rules/blang.mli
@@ -23,6 +23,12 @@ val true_ : t
 
 val eval : t -> dir:Path.t -> f:Value.t list String_with_vars.expander -> bool
 
+val eval_partial :
+     t
+  -> dir:Path.t
+  -> f:Value.t list Action_builder.t String_with_vars.expander
+  -> bool Action_builder.t
+
 val to_dyn : t -> Dyn.t
 
 val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -620,4 +620,9 @@ let eval_blang t = function
   | Blang.Const x -> x (* common case *)
   | blang -> Blang.eval blang ~dir:(Path.build t.dir) ~f:(Static.expand_pform t)
 
+let eval_blang_partial t = function
+  | Blang.Const x -> Action_builder.return x (* common case *)
+  | blang ->
+    Blang.eval_partial blang ~dir:(Path.build t.dir) ~f:(expand_pform t)
+
 let find_package t pkg = t.find_package pkg

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -129,6 +129,8 @@ val expand_and_eval_set :
 
 val eval_blang : t -> Blang.t -> bool
 
+val eval_blang_partial : t -> Blang.t -> bool Action_builder.t
+
 val map_exe : t -> Path.t -> Path.t
 
 val artifacts : t -> Artifacts.Bin.t

--- a/test/blackbox-tests/test-cases/aliases/enabled_if.t/run.t
+++ b/test/blackbox-tests/test-cases/aliases/enabled_if.t/run.t
@@ -1,0 +1,180 @@
+# Without enabled_if the rule is ran even without the library
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.6)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >   (alias bar)
+  >   (deps (universe))
+  >   (action (run echo %{lib-available:mylib}))
+  > )
+  > 
+  > (alias
+  >   (name foo)
+  >   (deps (alias bar))
+  > )
+  > EOF
+
+  $ dune build @foo
+          echo alias bar
+  false
+
+# Extended enabled_if before 2.9 is an error
+  $ cat >dune <<EOF
+  > (rule
+  >   (alias bar)
+  >   (deps (universe))
+  >   (action (run echo %{lib-available:mylib}))
+  > )
+  > 
+  > (alias
+  >   (name foo)
+  >   (deps (alias bar))
+  >   (enabled_if %{lib-available:mylib})
+  > )
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 7, characters 0-80:
+   7 | (alias
+   8 |   (name foo)
+   9 |   (deps (alias bar))
+  10 |   (enabled_if %{lib-available:mylib})
+  11 | )
+  Error: Extended enabled_if is not compatible with dune lang < (2, 9).
+  [1]
+
+# If the library is not present the rule is not executed
+# but lib-available is known without additional dependencies
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.9)
+  > EOF
+
+  $ dune build @foo
+
+# If the library is present the rule is executed
+
+  $ cat >dune <<EOF
+  > (library
+  >  (modules )
+  >  (name mylib)
+  > )
+  > 
+  > (rule
+  >   (alias bar)
+  >   (deps (universe))
+  >   (action (run echo %{lib-available:mylib}))
+  > )
+  > 
+  > (alias
+  >   (name foo)
+  >   (deps (alias bar))
+  >   (enabled_if %{lib-available:mylib})
+  > )
+  > EOF
+
+  $ dune build @foo
+          echo alias bar
+  true
+
+# Enabled_if with a new dependency, without execution
+
+  $ cat >dune <<EOF
+  > (rule
+  >   (alias bar)
+  >   (deps (universe))
+  >   (action (run echo executed))
+  > )
+  > 
+  > (rule
+  >   (action (with-stdout-to flag.bool (echo false)))
+  > )
+  > 
+  > (alias
+  >   (name foo)
+  >   (deps (alias bar) flag.bool)
+  >   (enabled_if %{read-lines:flag.bool})
+  > )
+  > EOF
+
+  $ dune build @foo
+
+
+# Enabled_if with a new dependency, with execution
+
+  $ cat >dune <<EOF
+  > (rule
+  >   (alias bar)
+  >   (deps (universe))
+  >   (action (run echo executed))
+  > )
+  > 
+  > (rule
+  >   (action (with-stdout-to flag.bool (echo true)))
+  > )
+  > 
+  > (alias
+  >   (name foo)
+  >   (deps (alias bar))
+  >   (enabled_if %{read-lines:flag.bool})
+  > )
+  > EOF
+
+  $ dune build @foo
+          echo alias bar
+  executed
+
+  $ dune build @foo
+          echo alias bar
+  executed
+
+# Enabled_if with a wrong value
+
+  $ cat >dune <<EOF
+  > (rule
+  >   (alias bar)
+  >   (deps (universe))
+  >   (action (run echo executed))
+  > )
+  > 
+  > (rule
+  >   (action (with-stdout-to flag.bool (echo unknown)))
+  > )
+  > 
+  > (alias
+  >   (name foo)
+  >   (deps (alias bar))
+  >   (enabled_if %{read:flag.bool})
+  > )
+  > EOF
+
+  $ dune build @foo
+  File "dune", line 14, characters 14-31:
+  14 |   (enabled_if %{read:flag.bool})
+                     ^^^^^^^^^^^^^^^^^
+  Error: This value must be either true or false got:
+  "unknown"
+  [1]
+
+# Try to create a dependency cycle
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (target false.txt)
+  >  (deps (alias foo))
+  >  (action (write-file false.txt "false")))
+  > 
+  > (alias
+  >  (name foo)
+  >  (enabled_if %{read:false.txt}))
+  > EOF
+
+  $ dune build @foo
+  Error: Dependency cycle between the following files:
+     alias foo
+  -> _build/default/false.txt
+  -> alias foo
+  [1]


### PR DESCRIPTION
This MR allows to use variable like `%{lib-available:mylib}` in the enabled_if of alias stanza. It is possible because alias stanza don't have any targets. However it was harder to do because the expansion of an action or dependencies are a `Build.t`. So it depends on #3963. 

It is possible to simplify this MR since the action field is incompatible with extended `enable_if` by always computing the dependencies of the alias, and by using `Build.dyn_deps`. 