### PR TITLE
start working on ctypes stanza

### DIFF
--- a/src/dune_rules/ctypes.ml
+++ b/src/dune_rules/ctypes.ml
@@ -1,0 +1,33 @@
+open! Dune_engine
+
+type t =
+  { name : string
+  ; pkg_config_name : string option
+  ; c_headers : string option
+  ; generated_modules : string list
+  }
+
+let name = "ctypes"
+
+type Stanza.t += T of t
+
+let decode =
+  let open Dune_lang.Decoder in
+  fields
+    (let+ name = field "name" string
+     and+ pkg_config_name = field_o "pkg_config_name" string
+     and+ c_headers = field_o "c_headers" string
+     and+ generated_modules = field "generated_modules" (repeat string)
+     in
+     { name; pkg_config_name; c_headers; generated_modules })
+
+let syntax =
+  Dune_lang.Syntax.create ~name ~desc:"the ctypes extension"
+    (* XXX: insert the latest version of dune language *)
+    [ ((0, 1), `Since (2, 8))
+    ]
+
+let () =
+  let open Dune_lang.Decoder in
+  Dune_project.Extension.register_simple syntax
+    (return [ (name, decode >>| fun x -> [ T x ]) ])

--- a/src/dune_rules/ctypes.mli
+++ b/src/dune_rules/ctypes.mli
@@ -1,0 +1,13 @@
+(** Ctypes integration *)
+open! Dune_engine
+
+(** Ctypes is a library for generating C-stubs from pure OCaml.
+
+    These dune rules are to help reduce the boilerplate involved in
+    setting up the build system tooling to generate the stubs. *)
+
+type t
+
+type Stanza.t += T of t
+
+val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -161,6 +161,7 @@ module Buildable = struct
     ; flags : Ocaml_flags.Spec.t
     ; js_of_ocaml : Js_of_ocaml.t
     ; allow_overlapping_dependencies : bool
+    ; ctypes : Ctypes.t list
     }
 
   let decode ~in_library ~allow_re_export =
@@ -232,6 +233,8 @@ module Buildable = struct
         (multi_field "instrumentation"
            ( Dune_lang.Syntax.since Stanza.syntax (2, 7)
            >>> fields (field "backend" (located Lib_name.decode)) ))
+    and+ ctypes =
+      (multi_field "ctypes" Ctypes.decode)
     in
     let preprocess =
       let init =
@@ -285,6 +288,7 @@ module Buildable = struct
     ; flags
     ; js_of_ocaml
     ; allow_overlapping_dependencies
+    ; ctypes
     }
 
   let has_foreign t =

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -49,6 +49,7 @@ module Buildable : sig
     ; flags : Ocaml_flags.Spec.t
     ; js_of_ocaml : Js_of_ocaml.t
     ; allow_overlapping_dependencies : bool
+    ; ctypes : Ctypes.t list
     }
 
   (** Check if the buildable has any foreign stubs or archives. *)


### PR DESCRIPTION
as discussed in #135 

Rather than developing this privately and pushing a gigantic changeset of completed code, I thought it might be better to iterate on this as publicly as possible so we can all learn together :innocent: 

So far, there's just enough here to register an extension, "ctypes", and require its declaration in `dune-project` as `(using ctypes 0.1)`.  It also places a stub entry in `library` that doesn't quite do anything.

