### PR TITLE
[Experiment] Produce & Promote man page with sphinx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,11 @@ clean: $(BIN)
 distclean: clean
 	rm -f src/dune_rules/setup.ml
 
+man: $(BIN)
+	$(BIN) build @man
+
 doc:
-	cd doc && sphinx-build . _build
+	cd doc && sphinx-build -b man . man
 
 livedoc:
 	cd doc && sphinx-autobuild . _build \

--- a/doc/man/dune
+++ b/doc/man/dune
@@ -1,0 +1,11 @@
+(rule
+ (alias man)
+ (deps (glob_files ../*.py) (glob_files ../*.rst))
+ (mode promote)
+ (target dune.1)
+ (action (chdir .. (run sphinx-build -b man . man))))
+
+(install
+ (section man)
+ (package dune)
+ (files dune.1 as dune-manual.1))

--- a/doc/man/dune.1
+++ b/doc/man/dune.1
@@ -1,0 +1,8817 @@
+.\" Man page generated from reStructuredText.
+.
+.TH "DUNE" "1" "Nov 05, 2020" "" "dune"
+.SH NAME
+dune \- dune Documentation
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.SH OVERVIEW
+.SS Introduction
+.sp
+Dune is a build system for OCaml (with support for Reason and Coq).
+It is not intended as a completely generic build system that is able
+to build any given project in any language.  On the contrary, it makes
+lots of choices in order to encourage a consistent development style.
+.sp
+This scheme is inspired from the one used inside Jane Street and adapted
+to the opam world. It has matured over a long time and is used daily by
+hundreds of developers, which means that it is highly tested and
+productive.
+.sp
+When using dune, you give very little and high\-level information to
+the build system, which in turn takes care of all the low\-level
+details, from the compilation of your libraries, executables and
+documentation, to the installation, setting up of tests, setting up of
+the development tools such as merlin, etc.
+.sp
+In addition to the normal features one would expect from a build system
+for OCaml, dune provides a few additional ones that detach it from
+the crowd:
+.INDENT 0.0
+.IP \(bu 2
+you never need to tell dune where things such as libraries are.
+Dune will always discover them automatically. In particular, this
+means that when you want to re\-organize your project you need to do no
+more than rename your directories, dune will do the rest
+.IP \(bu 2
+things always work the same whether your dependencies are local or
+installed on the system. In particular, this means that you can always
+drop in the source for a dependency of your project in your working
+copy and dune will start using it immediately. This makes dune a
+great choice for multi\-project development
+.IP \(bu 2
+cross\-platform: as long as your code is portable, dune will be
+able to cross\-compile it (note that dune is designed internally
+to make this easy but the actual support is not implemented yet)
+.IP \(bu 2
+release directly from any revision: dune needs no setup stage. To
+release your project, you can simply point to a specific tag. You can
+of course add some release steps if you want to, but it is not
+necessary
+.UNINDENT
+.sp
+The first section of this document defines some terms used in the rest
+of this manual. The second section specifies the dune metadata
+format and the third one describes how to use the \fBdune\fP command.
+.SS Terminology
+.INDENT 0.0
+.IP \(bu 2
+\fBpackage\fP: a package is a set of libraries, executables, ... that
+are built and installed as one by opam
+.IP \(bu 2
+\fBproject\fP: a project is a source tree, maybe containing one or more
+packages
+.IP \(bu 2
+\fBroot\fP: the root is the directory from where dune can build
+things. Dune knows how to build targets that are descendants of
+the root. Anything outside of the tree starting from the root is
+considered part of the \fBinstalled world\fP\&. How the root is
+determined is explained in finding\-root\&.
+.IP \(bu 2
+\fBworkspace\fP: the workspace is the subtree starting from the root.
+It can contain any number of projects that will be built
+simultaneously by dune
+.IP \(bu 2
+\fBinstalled world\fP: anything outside of the workspace, that dune
+takes for granted and doesn\(aqt know how to build
+.IP \(bu 2
+\fBinstallation\fP: this is the action of copying build artifacts or
+other files from the \fB<root>/_build\fP directory to the installed
+world
+.IP \(bu 2
+\fBscope\fP: a scope determines where private items are
+visible. Private items include libraries or binaries that will not
+be installed. In dune, scopes are sub\-trees rooted where at
+least one \fB<package>.opam\fP file is present. Moreover, scopes are
+exclusive. Typically, every project defines a single scope. See
+scopes for more details
+.IP \(bu 2
+\fBbuild context\fP: a build context is a subdirectory of the
+\fB<root>/_build\fP directory. It contains all the build artifacts of
+the workspace built against a specific configuration. Without
+specific configuration from the user, there is always a \fBdefault\fP
+build context, which corresponds to the environment in which dune
+is executed. Build contexts can be specified by writing a
+dune\-workspace file
+.IP \(bu 2
+\fBbuild context root\fP: the root of a build context named \fBfoo\fP is
+\fB<root>/_build/<foo>\fP
+.IP \(bu 2
+\fBalias\fP: an alias is a build target that doesn\(aqt produce any file and has
+configurable dependencies. Aliases are per\-directory. However, on the command
+line, asking for an alias to be built in a given directory will trigger the
+construction of the alias in all children directories recursively. Dune
+defines several builtin\-aliases\&.
+.IP \(bu 2
+\fBenvironment\fP: in dune, each directory has an environment
+attached to it. The environment determines the default values of
+various parameters, such as the compilation flags. Inside a scope,
+each directory inherit the environment from its parent. At the root
+of every scope, a default environment is used. At any point, the
+environment can be altered using an dune\-env stanza.
+.IP \(bu 2
+\fBbuild profile\fP: a global setting that influence various
+defaults. It can be set from the command line using \fB\-\-profile
+<profile>\fP or from \fBdune\-workspace\fP files. The following
+profiles are standard:
+.INDENT 2.0
+.IP \(bu 2
+\fBrelease\fP which is the profile used for opam releases
+.IP \(bu 2
+\fBdev\fP which is the default profile when none is set explicitly, it
+has stricter warnings that the \fBrelease\fP one
+.UNINDENT
+.UNINDENT
+.SS Project layout
+.sp
+A typical dune project will have a \fBdune\-project\fP and one or more
+\fB<package>.opam\fP file at the root as well as \fBdune\fP files wherever
+interesting things are: libraries, executables, tests, documents to install,
+etc...
+.sp
+It is recommended to organize your project so that you have exactly one library
+per directory. You can have several executables in the same directory, as long
+as they share the same build configuration. If you\(aqd like to have multiple
+executables with different configurations in the same directory, you will have
+to make an explicit module list for every executable using \fBmodules\fP\&.
+.SH QUICKSTART
+.sp
+This document gives simple usage examples of dune. You can also look at
+\fI\%examples\fP for complete
+examples of projects using dune.
+.SS Building a hello world program
+.sp
+In a directory of your choice, write this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+;; This declares the hello_world executable implemented by hello_world.ml
+(executable
+ (name hello_world))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This \fBhello_world.ml\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+print_endline "Hello, world!"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And build it with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build hello_world.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The executable will be built as \fB_build/default/hello_world.exe\fP\&. Note that
+native code executables will have the \fB\&.exe\fP extension on all platforms
+(including non\-Windows systems). The executable can be built and run in a single
+step with \fBdune exec ./hello_world.exe\fP\&.
+.SS Building a hello world program using Lwt
+.sp
+In a directory of your choice, write this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name hello_world)
+ (libraries lwt.unix))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This \fBhello_world.ml\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+Lwt_main.run (Lwt_io.printf "Hello, world!\en")
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And build it with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build hello_world.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The executable will be built as \fB_build/default/hello_world.exe\fP
+.SS Building a hello world program using Core and Jane Street PPXs
+.sp
+Write this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name hello_world)
+ (libraries core)
+ (preprocess (pps ppx_jane)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This \fBhello_world.ml\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+open Core
+
+let () =
+  Sexp.to_string_hum [%sexp ([3;4;5] : int list)]
+  |> print_endline
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And build it with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build hello_world.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The executable will be built as \fB_build/default/hello_world.exe\fP
+.SS Defining a library using Lwt and ocaml\-re
+.sp
+Write this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name        mylib)
+ (public_name mylib)
+ (libraries re lwt))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The library will be composed of all the modules in the same directory.
+Outside of the library, module \fBFoo\fP will be accessible as
+\fBMylib.Foo\fP, unless you write an explicit \fBmylib.ml\fP file.
+.sp
+You can then use this library in any other directory by adding \fBmylib\fP
+to the \fB(libraries ...)\fP field.
+.SS Building a hello world program in byte\-code
+.sp
+In a directory of your choice, write this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+;; This declares the hello_world executable implemented by hello_world.ml
+;; to be build as native (.exe) or byte\-code (.bc) version.
+(executable
+ (name hello_world)
+ (modes byte exe))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This \fBhello_world.ml\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+print_endline "Hello, world!"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And build it with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build hello_world.bc
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The executable will be built as \fB_build/default/hello_world.bc\fP\&.
+The executable can be built and run in a single
+step with \fBdune exec ./hello_world.bc\fP\&. This byte\-code version allows the usage of
+\fBocamldebug\fP\&.
+.SS Setting the OCaml compilation flags globally
+.sp
+Write this \fBdune\fP file at the root of your project:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(env
+ (dev
+  (flags (:standard \-w +42)))
+ (release
+  (flags (:standard \-O3))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fIdev\fP and \fIrelease\fP correspond to build profiles. The build profile
+can be selected from the command line with \fB\-\-profile foo\fP or from a
+\fIdune\-workspace\fP file by writing:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(profile foo)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Using cppo
+.sp
+Add this field to your \fBlibrary\fP or \fBexecutable\fP stanzas:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(preprocess (action (run %{bin:cppo} \-V OCAML:%{ocaml_version} %{input\-file})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Additionally, if you want to include a \fBconfig.h\fP file, you need to
+declare the dependency to this file via:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(preprocessor_deps config.h)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Using the .cppo.ml style like the ocamlbuild plugin
+.sp
+Write this in your \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (targets foo.ml)
+ (deps    (:first\-dep foo.cppo.ml) <other files that foo.ml includes>)
+ (action  (run %{bin:cppo} %{first\-dep} \-o %{targets})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Defining a library with C stubs
+.sp
+Assuming you have a file called \fBmystubs.c\fP, that you need to pass
+\fB\-I/blah/include\fP to compile it and \fB\-lblah\fP at link time, write
+this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name            mylib)
+ (public_name     mylib)
+ (libraries       re lwt)
+ (foreign_stubs
+  (language c)
+  (names mystubs)
+  (flags \-I/blah/include))
+ (c_library_flags (\-lblah)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Defining a library with C stubs using pkg\-config
+.sp
+Same context as before, but using \fBpkg\-config\fP to query the
+compilation and link flags. Write this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name            mylib)
+ (public_name     mylib)
+ (libraries       re lwt)
+ (foreign_stubs
+  (language c)
+  (names mystubs)
+  (flags (:include c_flags.sexp)))
+ (c_library_flags (:include c_library_flags.sexp)))
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (action  (run ./config/discover.exe)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Then create a \fBconfig\fP subdirectory and write this \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name discover)
+ (libraries dune\-configurator))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+as well as this \fBdiscover.ml\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+module C = Configurator.V1
+
+let () =
+C.main ~name:"foo" (fun c \->
+let default : C.Pkg_config.package_conf =
+  { libs   = ["\-lgst\-editing\-services\-1.0"]
+  ; cflags = []
+  }
+in
+let conf =
+  match C.Pkg_config.get c with
+  | None \-> default
+  | Some pc \->
+     match (C.Pkg_config.query pc ~package:"gst\-editing\-services\-1.0") with
+     | None \-> default
+     | Some deps \-> deps
+in
+
+
+C.Flags.write_sexp "c_flags.sexp"         conf.cflags;
+C.Flags.write_sexp "c_library_flags.sexp" conf.libs)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Using a custom code generator
+.sp
+To generate a file \fBfoo.ml\fP using a program from another directory:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (targets foo.ml)
+ (deps    (:gen ../generator/gen.exe))
+ (action  (run %{gen} \-o %{targets})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Defining tests
+.sp
+Write this in your \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(test (name my_test_program))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And run the tests with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune runtest
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+It will run the test program (the main module is \fBmy_test_program.ml\fP) and
+error if it exits with a nonzero code.
+.sp
+In addition, if a \fBmy_test_program.expected\fP file exists, it will be compared
+to the standard output of the test program and the differences will be
+displayed. It is possible to replace the \fB\&.expected\fP file with the last output
+using:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune promote
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Building a custom toplevel
+.sp
+A toplevel is simply an executable calling \fBTopmain.main ()\fP and linked with
+the compiler libraries and \fB\-linkall\fP\&. Moreover, currently toplevels can only
+be built in bytecode.
+.sp
+As a result, write this in your \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name       mytoplevel)
+ (libraries  compiler\-libs.toplevel mylib)
+ (link_flags (\-linkall))
+ (modes      byte))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And write this in \fBmytoplevel.ml\fP
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+let () = Topmain.main ()
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH COMMAND-LINE INTERFACE
+.sp
+This section describe usage of dune from the shell.
+.SS Initializing components
+.sp
+NOTE: The \fBdune init\fP command is still under development and subject to
+change.
+.sp
+Dune\(aqs \fBinit\fP subcommand provides limited support for generating dune file
+stanzas and folder structures to define components. \fBdune init\fP can be used to
+quickly add new projects, libraries, tests, or executables without having to
+manually create dune files, or it can be composed to programmatically generate
+parts of a multi\-component project.
+.SS Initializing a project
+.sp
+To initialize a new \fBdune\fP project that uses the \fBbase\fP and \fBcmdliner\fP
+libraries and supports inline tests, you can run
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune init proj myproj \-\-libs base,cmdliner \-\-inline\-tests \-\-ppx ppx_inline_test
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will create a new directory called \fBmyproj\fP including sub directories and
+\fBdune\fP files for library, executable, and test components. Each component\(aqs
+\fBdune\fP file will also include the declarations required for the given
+dependencies.
+.sp
+This is the quickest way to get a basic \fBdune\fP project up and building.
+.SS Initializing an executable
+.sp
+To add a new executable to a \fBdune\fP file in the current directory
+(creating the file if necessary), run
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune init exe myexe \-\-libs base,containers,notty \-\-ppx ppx_deriving
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will add the following stanza to the \fBdune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name main)
+ (libraries base containers notty)
+ (preprocess
+  (pps ppx_deriving)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Initializing a library
+.sp
+To create a new directory \fBsrc\fP, initialized as a library, you can run:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune init lib mylib src \-\-libs core \-\-inline\-tests \-\-public
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will ensure the file \fB\&./src/dune\fP contains the following stanza (creating
+the file and directory, if needed):
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (public_name mylib)
+ (inline_tests)
+ (name mylib)
+ (libraries core)
+ (preprocess
+  (pps ppx_inline_tests)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Consult the manual page \fBdune init \-\-help\fP for more details.
+.SS Finding the root
+.sp
+The root of the current workspace is determined by looking up a
+\fBdune\-workspace\fP or \fBdune\-project\fP file in the current directory
+and parent directories.
+.sp
+\fBdune\fP prints out the root when starting if it is not the current
+directory:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune runtest
+Entering directory \(aq/home/jdimino/code/dune\(aq
+\&...
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+More precisely, it will choose the outermost ancestor directory containing a
+\fBdune\-workspace\fP file as root. For instance if you are in
+\fB/home/me/code/myproject/src\fP, then dune will look for all these files in
+order:
+.INDENT 0.0
+.IP \(bu 2
+\fB/dune\-workspace\fP
+.IP \(bu 2
+\fB/home/dune\-workspace\fP
+.IP \(bu 2
+\fB/home/me/dune\-workspace\fP
+.IP \(bu 2
+\fB/home/me/code/dune\-workspace\fP
+.IP \(bu 2
+\fB/home/me/code/myproject/dune\-workspace\fP
+.IP \(bu 2
+\fB/home/me/code/myproject/src/dune\-workspace\fP
+.UNINDENT
+.sp
+The first entry to match in this list will determine the root. In
+practice this means that if you nest your workspaces, dune will
+always use the outermost one.
+.sp
+In addition to determining the root, \fBdune\fP will read this file
+to setup the configuration of the workspace unless the \fB\-\-workspace\fP
+command line option is used. See the section dune\-workspace
+for the syntax of this file.
+.sp
+The \fBEntering directory\fP message can be suppressed with the
+\fB\-\-no\-print\-directory\fP command line option (as in GNU make).
+.SS Current directory
+.sp
+If the previous rule doesn\(aqt apply, i.e. no ancestor directory has a
+file named \fBdune\-workspace\fP, then the current directory will be used
+as root.
+.SS Forcing the root (for scripts)
+.sp
+You can pass the \fB\-\-root\fP option to \fBdune\fP to select the root
+explicitly. This option is intended for scripts to disable the automatic lookup.
+.sp
+Note that when using the \fB\-\-root\fP option, targets given on the command line
+will be interpreted relative to the given root, not relative to the current
+directory as this is normally the case.
+.SS Interpretation of targets
+.sp
+This section describes how \fBdune\fP interprets the targets given on
+the command line. When no targets are specified, \fBdune\fP builds the
+\fBdefault\fP alias, see \fI\%Default alias\fP for more details.
+.SS Resolution
+.sp
+All targets that dune knows how to build live in the \fB_build\fP
+directory.  Although, some are sometimes copied to the source tree for
+the need of external tools. These includes:
+.INDENT 0.0
+.IP \(bu 2
+\fB\&.merlin\fP files
+.IP \(bu 2
+\fB<package>.install\fP files (when either \fB\-p\fP or
+\fB\-\-promote\-install\-files\fP is passed on the command line)
+.UNINDENT
+.sp
+As a result, if you want to ask \fBdune\fP to produce a particular \fB\&.exe\fP
+file you would have to type:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build _build/default/bin/prog.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+However, for convenience when a target on the command line doesn\(aqt
+start with \fB_build\fP, \fBdune\fP will expand it to the
+corresponding target in all the build contexts where it knows how to
+build it. When using \fB\-\-verbose\fP, It prints out the actual set of
+targets when starting:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build bin/prog.exe \-\-verbose
+\&...
+Actual targets:
+\- _build/default/bin/prog.exe
+\- _build/4.03.0/bin/prog.exe
+\- _build/4.04.0/bin/prog.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Aliases
+.sp
+Targets starting with a \fB@\fP are interpreted as aliases. For instance
+\fB@src/runtest\fP means the alias \fBruntest\fP in all descendant of
+\fBsrc\fP in all build contexts where it is defined. If you want to
+refer to a target starting with a \fB@\fP, simply write: \fB\&./@foo\fP\&.
+.sp
+To build and run the tests for a particular build context, use
+\fB@_build/default/runtest\fP instead.
+.sp
+So for instance:
+.INDENT 0.0
+.IP \(bu 2
+\fBdune build @_build/foo/runtest\fP will run the tests only for
+the \fBfoo\fP build context
+.IP \(bu 2
+\fBdune build @runtest\fP will run the tests for all build contexts
+.UNINDENT
+.sp
+You can also build an alias non\-recursively by using \fB@@\fP instead of
+\fB@\fP\&. For instance to run tests only from the current directory:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build @@runtest
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note that it\(aqs currently not possible to build a target directly if that target
+lives in a directory that starts with the \fB@\fP character. In the rare cases
+where you need to do that, you can declare an alias like so:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(alias
+ (name foo)
+ (deps @foo/some.exe))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB@foo/some.exe\fP can then be built with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build @foo
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Default alias
+.sp
+When no targets are given to \fBdune build\fP, it builds the special
+\fBdefault\fP alias. Effectively \fBdune build\fP is equivalent to:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build @@default
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+When a directory doesn\(aqt explicitly define what the \fBdefault\fP alias
+means via an alias\-stanza stanza, the following implicit
+definition is assumed:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(alias
+ (name default)
+ (deps (alias_rec all)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Which means that by default \fBdune build\fP will build everything that
+is installable.
+.sp
+When using a directory as a target, it will be interpreted as building the
+default target in the directory. The directory must exist in the source tree.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build dir
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Is equivalent to:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build @@dir/default
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Built\-in Aliases
+.sp
+There\(aqs a few aliases that dune automatically creates for the user
+.INDENT 0.0
+.IP \(bu 2
+\fBdefault\fP \- this alias includes all the targets that dune will build if a
+target isn\(aqt specified, i.e. \fB$ dune build\fP\&. By default, this is set to the
+\fBall\fP alias. Note that for dune 1.x, this was set to the \fBinstall\fP alias.
+.IP \(bu 2
+\fBruntest\fP \- this is the alias to run all the tests, building them if
+necessary.
+.IP \(bu 2
+\fBinstall\fP \- build all public artifacts \- those that will be installed.
+.IP \(bu 2
+\fBdoc\fP \- build documentation for public libraries.
+.IP \(bu 2
+\fBdoc\-private\fP \- build documentation for all libraries \- public & private.
+.IP \(bu 2
+\fBlint\fP \- run linting tools.
+.IP \(bu 2
+\fBall\fP \- build all available targets in a directory and installable artifacts
+defined in that directory.
+.IP \(bu 2
+\fBcheck\fP \- This alias will build the minimal set of targets required for
+tooling support. Essentially, this is \fB\&.cmi\fP, \fB\&.cmt\fP, \fB\&.cmti\fP, and
+\fB\&.merlin\fP files.
+.UNINDENT
+.SS Variables for artifacts
+.sp
+It is possible to build specific artifacts by using the corresponding variable
+on the command line, e.g.:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune build \(aq%{cmi:foo}\(aq
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+See variables\-for\-artifacts for more information.
+.SS Finding external libraries
+.sp
+When a library is not available in the workspace, dune will look it
+up in the installed world, and expect it to be already compiled.
+.sp
+It looks up external libraries using a specific list of search paths. A
+list of search paths is specific to a given build context and is
+determined as follows:
+.INDENT 0.0
+.IP 1. 3
+if the \fBocamlfind\fP is present in the \fBPATH\fP of the context, use each line
+in the output of \fBocamlfind printconf path\fP as a search path
+.IP 2. 3
+otherwise, if \fBopam\fP is present in the \fBPATH\fP, use the output of \fBopam
+config var lib\fP
+.IP 3. 3
+otherwise, take the directory where \fBocamlc\fP was found, and append
+\fB\&../lib\fP to it. For instance if \fBocamlc\fP is found in \fB/usr/bin\fP, use
+\fB/usr/lib\fP
+.UNINDENT
+.SS Running tests
+.sp
+There are two ways to run tests:
+.INDENT 0.0
+.IP \(bu 2
+\fBdune build @runtest\fP
+.IP \(bu 2
+\fBdune test\fP (or the more explicit \fBdune runtest\fP)
+.UNINDENT
+.sp
+The two commands are equivalent. They will run all the tests defined in the
+current directory and its children recursively. You can also run the tests in a
+specific sub\-directory and its children by using:
+.INDENT 0.0
+.IP \(bu 2
+\fBdune build @foo/bar/runtest\fP
+.IP \(bu 2
+\fBdune test foo/bar\fP (or \fBdune runtest foo/bar\fP)
+.UNINDENT
+.SS Watch mode
+.sp
+The \fBdune build\fP and \fBdune runtest\fP commands support a \fB\-w\fP (or
+\fB\-\-watch\fP) flag. When it is passed, dune will perform the action as usual, and
+then wait for file changes and rebuild (or rerun the tests). This feature
+requires \fBinotifywait\fP or \fBfswatch\fP to be installed.
+.SS Launching the Toplevel (REPL)
+.sp
+Dune supports launching a \fI\%utop\fP instance
+with locally defined libraries loaded.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune utop <dir> \-\- <args>
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Where \fB<dir>\fP is a directory under which dune will search (recursively) for
+all libraries that will be loaded. \fB<args>\fP will be passed as arguments to the
+utop command itself. For example, \fBdune utop lib \-\- \-implicit\-bindings\fP will
+start \fButop\fP with the libraries defined in \fBlib\fP and implicit bindings for
+toplevel expressions.
+.SS Requirements & Limitations
+.INDENT 0.0
+.IP \(bu 2
+utop version >= 2.0 is required for this to work.
+.IP \(bu 2
+This subcommand only supports loading libraries. Executables aren\(aqt supported.
+.IP \(bu 2
+Libraries that are dependencies of utop itself cannot be loaded. For example
+\fI\%Camomile\fP\&.
+.IP \(bu 2
+Loading libraries that are defined in different directories into one utop
+instance isn\(aqt possible.
+.UNINDENT
+.SS Restricting the set of packages
+.sp
+You can restrict the set of packages from your workspace that dune can see with
+the \fB\-\-only\-packages\fP option:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build \-\-only\-packages pkg1,pkg2,... @install
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This option acts as if you went through all the dune files and
+commented out the stanzas referring to a package that is not in the list
+given to \fBdune\fP\&.
+.SS Distributing Projects
+.sp
+Dune provides support for building and installing your project. However it
+doesn\(aqt provide helpers for distributing it. It is recommended to use
+\fI\%dune\-release\fP for this purpose.
+.sp
+The common defaults are that your projects include the following files:
+.INDENT 0.0
+.IP \(bu 2
+\fBREADME.md\fP
+.IP \(bu 2
+\fBCHANGES.md\fP
+.IP \(bu 2
+\fBLICENSE.md\fP
+.UNINDENT
+.sp
+And that if your project contains several packages, then all the package names
+must be prefixed by the shortest one.
+.SS dune subst
+.sp
+One of the features \fBdune\-release\fP provides is watermarking; it replaces
+various strings of the form \fB%%ID%%\fP in all files of your project
+before creating a release tarball or when the package is pinned by the
+user using opam.
+.sp
+This is especially interesting for the \fBVERSION\fP watermark, which gets
+replaced by the version obtained from the vcs. For instance if you are using
+git, dune\-release invokes this command to find out the version:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ git describe \-\-always \-\-dirty
+1.0+beta9\-79\-g29e9b37
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Projects using dune usually only need dune\-release for creating and
+publishing releases. However they might still want to substitute the
+watermarks when the package is pinned by the user. To help with this,
+dune provides the \fBsubst\fP sub\-command.
+.sp
+\fBdune subst\fP performs the same substitution \fBdune\-release\fP does
+with the default configuration. i.e. calling \fBdune subst\fP at the
+root of your project will rewrite in place all the files in your
+project.
+.sp
+More precisely, it replaces all the following watermarks in source files:
+.INDENT 0.0
+.IP \(bu 2
+\fBNAME\fP, the name of the project
+.IP \(bu 2
+\fBVERSION\fP, output of \fBgit describe \-\-always \-\-dirty\fP
+.IP \(bu 2
+\fBVERSION_NUM\fP, same as \fBVERSION\fP but with a potential leading
+\fBv\fP or \fBV\fP dropped
+.IP \(bu 2
+\fBVCS_COMMIT_ID\fP, commit hash from the vcs
+.IP \(bu 2
+\fBPKG_MAINTAINER\fP, contents of the \fBmaintainer\fP field from the
+opam file
+.IP \(bu 2
+\fBPKG_AUTHORS\fP, contents of the \fBauthors\fP field from the opam file
+.IP \(bu 2
+\fBPKG_HOMEPAGE\fP, contents of the \fBhomepage\fP field from the opam file
+.IP \(bu 2
+\fBPKG_ISSUES\fP, contents of the \fBissues\fP field from the opam file
+.IP \(bu 2
+\fBPKG_DOC\fP, contents of the \fBdoc\fP field from the opam file
+.IP \(bu 2
+\fBPKG_LICENSE\fP, contents of the \fBlicense\fP field from the opam file
+.IP \(bu 2
+\fBPKG_REPO\fP, contents of the \fBrepo\fP field from the opam file
+.UNINDENT
+.sp
+The name of the project is obtained by reading the \fBdune\-project\fP
+file in the directory where \fBdune subst\fP is called. The
+\fBdune\-project\fP file must exist and contain a valid \fB(name ...)\fP
+field.
+.sp
+Note that \fBdune subst\fP is meant to be called from the opam file and
+in particular behaves a bit different to other \fBdune\fP commands. In
+particular it doesn\(aqt try to detect the root of the workspace and must
+be called from the root of the project.
+.SS Custom Build Directory
+.sp
+By default dune places all build artifacts in the \fB_build\fP directory relative
+to the user\(aqs workspace. However, one can customize this directory by using the
+\fB\-\-build\-dir\fP flag or the \fBDUNE_BUILD_DIR\fP environment variable.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build \-\-build\-dir _build\-foo
+
+# this is equivalent to:
+$ DUNE_BUILD_DIR=_build\-foo dune build
+
+# Absolute paths are also allowed
+$ dune build \-\-build\-dir /tmp/build foo.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Installing a package
+.SS Via opam
+.sp
+When releasing a package using Dune in opam there is nothing special
+to do.  Dune generates a file called \fB<package\-name>.install\fP at the
+root of the project.  This contains a list of files to install and
+opam reads it in order to perform the installation.
+.SS Manually
+.sp
+When not using opam or when you want to manually install a package,
+you can ask Dune to perform the installation via the \fBinstall\fP
+command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune install [PACKAGE]...
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This command takes a list of package names to install.  If no packages
+are specified, Dune will install all the packages available in the
+workspace.  When several build contexts are specified via a
+dune\-workspace file, the installation will be performed in all the
+build contexts.
+.SS Destination directory
+.sp
+The \fB<prefix>\fP directory is determined as follows for a given build
+context:
+.INDENT 0.0
+.IP 1. 3
+if an explicit \fB\-\-prefix <path>\fP argument is passed, use this path
+.IP 2. 3
+if \fBopam\fP is present in the \fBPATH\fP and is configured, use the
+output of \fBopam config var prefix\fP
+.IP 3. 3
+otherwise, take the parent of the directory where \fBocamlc\fP was found.
+.UNINDENT
+.sp
+As an exception to this rule, library files might be copied to a
+different location. The reason for this is that they often need to be
+copied to a particular location for the various build system used in
+OCaml projects to find them and this location might be different from
+\fB<prefix>/lib\fP on some systems.
+.sp
+Historically, the location where to store OCaml library files was
+configured through \fI\%findlib\fP and the
+\fBocamlfind\fP command line tool was used to both install these files
+and locate them. Many Linux distributions or other packaging systems
+are using this mechanism to setup where OCaml library files should be
+copied.
+.sp
+As a result, if none of \fB\-\-libdir\fP and \fB\-\-prefix\fP is passed to \fBdune
+install\fP and \fBocamlfind\fP is present in the \fBPATH\fP, then library files will
+be copied to the directory reported by \fBocamlfind printconf destdir\fP\&. This
+ensures that \fBdune install\fP can be used without opam. When using opam,
+\fBocamlfind\fP is configured to point to the opam directory, so this rule makes
+no difference.
+.sp
+Note that \fB\-\-prefix\fP and \fB\-\-libdir\fP are only supported if a single build
+context is in use.
+.SS Relocation Mode
+.sp
+The installation can be done in specific mode (\fB\-\-relocation\fP) for creating a
+directory that can be moved around. In that case the executables installed will
+lookup the sites (cf sites) of the packages relatively to its location.
+The \fI\-\-prefix\fP directory should be used to specify the destination.
+.sp
+If you are using plugins that depends on installed libraries which are not
+dependencies of the executables \-\- so libraries that need to be loaded at
+runtime \-\- you must copy the libraries manually to the destination directory.
+.SH STANZA REFERENCE
+.SS dune\-project
+.sp
+These files are used to mark the root of projects as well as define project\-wide
+parameters. The first line of \fBdune\-project\fP must be a \fBlang\fP stanza with no
+extra whitespace or comments. The \fBlang\fP stanza controls the names and
+contents of all configuration files read by Dune and looks like:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Additionally, they can contains the following stanzas.
+.SS name
+.sp
+Sets the name of the project. This is used by dune subst
+and error messages.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(name <name>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS version
+.sp
+Sets the version of the project:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(version <version>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS implicit_transitive_deps
+.sp
+By default, dune allows transitive dependencies of dependencies to be used
+directly when compiling OCaml. However, this setting can be controlled per
+project:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(implicit_transitive_deps <bool>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+When set to \fBfalse\fP, all dependencies that are directly used by a library
+or an executable must be directly added in the \fBlibraries\fP field. We
+recommend users to experiment with this mode and report any problems.
+.sp
+Note that you must use \fBthreads.posix\fP instead of \fBthreads\fP when using this
+mode. This is not an important limitation as \fBthreads.vm\fP are deprecated
+anyways.
+.sp
+In some situations, it\(aqs desirable to selectively preserve the
+behavior of transitive dependencies being available to users of a
+library. For example, if we define a library \fBfoo_more\fP, that
+extends \fBfoo\fP, we might want users of \fBfoo_more\fP to immediately
+have \fBfoo\fP available as well. To do this, we must define the
+dependency on \fBfoo\fP as re\-exported:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo_more)
+ (libraries (re_export foo)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS wrapped_executables
+.sp
+Executables are made of compilation units whose names may collide with the
+compilation units of libraries. To avoid this possibility, dune prefixes these
+compilation unit names with \fBDune__exe__\fP\&. This is entirely transparent to
+users except for when such executables are debugged. In which case the mangled
+names will be visible in the debugger.
+.sp
+Starting from dune 1.11, an option is available to turn on/off name mangling for
+executables on a per project basis:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(wrapped_executables <bool>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Starting from dune 2.0, dune mangles compilation units of executables by
+default. However, this can still be turned off using \fB(wrapped_executables
+false)\fP
+.SS explicit_js_mode
+.sp
+Traditionally, JavaScript targets were defined for every bytecode executable.
+This was not very precise and did not interact well with the \fB@all\fP alias.
+.sp
+You can opt out of this behaviour by using:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(explicit_js_mode)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+When this mode is enabled, an explicit \fBjs\fP mode needs to be added to the
+\fB(modes ...)\fP field of executables in order to trigger JavaScript
+compilation. Explicit JS targets declared like this will be attached to the
+\fB@all\fP alias.
+.sp
+Starting from dune 2.0 this behaviour is the default, and there is no way to
+disable it.
+.SS dialect
+.sp
+A dialect is an alternative frontend to OCaml (such as ReasonML). It is
+described by a pair of file extensions, one corresponding to interfaces and one
+to implementations.
+.sp
+A dialect can use the standard OCaml syntax or it can specify an action to
+convert from a custom syntax to a binary OCaml abstract syntax tree.
+.sp
+Similarly, a dialect can specify a custom formatter to implement the \fB@fmt\fP
+alias, see formatting\-main\&.
+.sp
+When not using a custom syntax or formatting action, a dialect is nothing but a
+way to specify custom file extensions for OCaml code.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(dialect
+ (name <name>)
+ (implementation
+  (extension <string>)
+  <optional fields>)
+ (interface
+  (extension <string>)
+  <optional fields>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<name>\fP is the name of the dialect being defined. It must be unique in a
+given project.
+.sp
+\fB(extension <string>)\fP specifies the file extension used for this dialect, for
+interfaces and implementations. The extension string must not contain any dots,
+and be unique in a given project (so that a given extension can be mapped back
+to a corresponding dialect).
+.sp
+\fB<optional fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(preprocess <action>)\fP is the action to run to produce a valid OCaml
+abstract syntax tree. It is expected to read the file given in the variable
+named \fBinput\-file\fP and output a \fIbinary\fP abstract syntax tree on its
+standard output. See preprocessing\-actions for more information.
+.sp
+If the field is not present, it is assumed that the corresponding source code
+is already valid OCaml code and can be passed to the OCaml compiler as\-is.
+.IP \(bu 2
+\fB(format <action>)\fP is the action to run to format source code for this
+dialect. The action is expected to read the file given in the variable named
+\fBinput\-file\fP and output the formatted source code on its standard
+output. For more information. See formatting\-main for more information.
+.sp
+If the field is not present, then if \fB(preprocess <action>)\fP is not present
+(so that the dialect consists of valid OCaml code), then by default the
+dialect will be formatted as any other OCaml code. Otherwise no special
+formatting will be done.
+.UNINDENT
+.SS formatting
+.sp
+Starting in dune 2.0, formatting\-main is automatically enabled. This can be
+controlled by using
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(formatting <setting>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+where \fB<setting>\fP is one of:
+.INDENT 0.0
+.IP \(bu 2
+\fBdisabled\fP, meaning that automatic formatting is disabled
+.IP \(bu 2
+\fB(enabled_for <languages>)\fP can be used to restrict the languages that are
+considered for formatting.
+.UNINDENT
+.SS generate_opam_files
+.sp
+Dune is able to use metadata specified in the \fBdune\-project\fP file to generate
+\fB\&.opam\fP files, see opam\-generation\&. To enable this integration, add the
+following field to the \fBdune\-project\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(generate_opam_files true)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Dune uses the following global fields to set the metadata for all packages
+defined in the project:
+.INDENT 0.0
+.IP \(bu 2
+\fB(license <name>)\fP \- Specifies the license of the project, ideally as an
+identifier from the \fI\%SPDX License List\fP
+.IP \(bu 2
+\fB(authors <authors>)\fP \- A list of authors
+.IP \(bu 2
+\fB(maintainers <maintainers>)\fP \- A list of maintainers
+.IP \(bu 2
+\fB(source <source>)\fP \- where the source is specified two ways:
+\fB(github <user/repo>)\fP or \fB(uri <uri>)\fP
+.IP \(bu 2
+\fB(bug_reports <url>)\fP \- Where to report bugs. This defaults to the GitHub
+issue tracker if the source is specified as a GitHub repository
+.IP \(bu 2
+\fB(homepage <url>)\fP \- The homepage of the project
+.IP \(bu 2
+\fB(documentation <url>)\fP \- Where the documentation is hosted
+.UNINDENT
+.sp
+With this fields in, every time dune is called to execute some rules (either via
+\fBdune build\fP, \fBdune runtest\fP or something else), the opam files get
+generated.
+.sp
+Some or all of these fields may be overridden for each package of the project, see
+\fI\%package\fP\&.
+.SS package
+.sp
+Package specific information is specified in the \fB(package <package>)\fP stanza.
+It contains the following fields:
+.INDENT 0.0
+.IP \(bu 2
+\fB(name <string>)\fP is the name of the package. This must be specified.
+.IP \(bu 2
+\fB(synopsis <string>)\fP is a short package description
+.IP \(bu 2
+\fB(description <string>)\fP is a longer package description
+.IP \(bu 2
+\fB(depends <dep\-specification>)\fP are package dependencies
+.IP \(bu 2
+\fB(conflicts <dep\-specification)\fP are package conflicts
+.IP \(bu 2
+\fB(depopts <dep\-specification)\fP are optional package dependencies
+.IP \(bu 2
+\fB(tags <tags>)\fP are the list of tags for the package
+.IP \(bu 2
+\fB(deprecated_package_names <name list>)\fP is a list of names that can be used
+with the \fI\%deprecated_library_name\fP stanza to migrate legacy libraries
+from other build systems which do not follow Dune\(aqs convention of prefixing
+the public name of the library with the package name.
+.IP \(bu 2
+\fB(license <name>)\fP, \fB(authors <authors>)\fP, \fB(maintainers
+<maintainers>)\fP, \fB(source <source>)\fP, \fB(bug_reports <url>)\fP, \fB(homepage
+<url>)\fP, \fB(documentation <url>)\fP are the same (and take precedence over)
+the corresponding global fields. These fields are available since Dune 2.0.
+.IP \(bu 2
+\fB(sites (<section> <name>) ...)\fP define a site named \fB<name>\fP in the
+section \fB<section>\fP\&.
+.UNINDENT
+.sp
+Adding libraries to different packages is done via  \fBpublic_name\fP field. See
+\fI\%library\fP section for details.
+.sp
+The list of dependencies \fB<dep\-specification>\fP is modeled after opam\(aqs own
+language: The syntax is as a list of the following elements:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+op := \(aq=\(aq | \(aq<\(aq | \(aq>\(aq | \(aq<>\(aq | \(aq>=\(aq | \(aq<=\(aq
+
+stage := :with\-test | :build | :dev
+
+constr := (<op> <version>)
+
+logop := or | and
+
+dep := (name <stage>)
+     | (name <constr>)
+     | (name (<logop> (<stage> | <constr>)*))
+
+dep\-specification = dep+
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS dune
+.sp
+\fBdune\fP files are the main part of dune. They are used to describe libraries,
+executables, tests, and everything dune needs to know about.
+.sp
+The syntax of \fBdune\fP files is described in metadata\-format section.
+.sp
+\fBdune\fP files are composed of stanzas. For instance a typical
+\fBdune\fP looks like:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name mylib)
+ (libraries base lwt))
+
+(rule
+ (target foo.ml)
+ (deps   generator/gen.exe)
+ (action (run %{deps} \-o %{target})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The following sections describe the available stanzas and their meaning.
+.SS jbuild_version
+.sp
+Deprecated. This stanza is no longer used and will be removed in the
+future.
+.SS library
+.sp
+The \fBlibrary\fP stanza must be used to describe OCaml libraries. The
+format of library stanzas is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name <library\-name>)
+ <optional\-fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<library\-name>\fP is the real name of the library. It determines the
+names of the archive files generated for the library as well as the
+module name under which the library will be available, unless
+\fB(wrapped false)\fP is used (see below). It must be a valid OCaml
+module name but doesn\(aqt need to start with a uppercase letter.
+.sp
+For instance, the modules of a library named \fBfoo\fP will be
+available as \fBFoo.XXX\fP outside of \fBfoo\fP itself. It is however
+allowed to write an explicit \fBFoo\fP module, in which case this will
+be the interface of the library and you are free to expose only the
+modules you want.
+.sp
+Note that by default libraries and other things that consume
+OCaml/Reason modules only consume modules from the directory where the
+stanza appear. In order to declare a multi\-directory library, you need
+to use the \fI\%include_subdirs\fP stanza.
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(public_name <name>)\fP this is the name under which the library can be
+referred to as a dependency when it is not part of the current workspace,
+i.e. when it is installed. Without a \fB(public_name ...)\fP field, the library
+will not be installed by dune. The public name must start by the package
+name it is part of and optionally followed by a dot and anything else you
+want. The package name must be one of the packages that dune knows about,
+as determined by the opam\-files
+.IP \(bu 2
+\fB(package <package>)\fP Install private library under the specified package.
+Such a library is now usable by public libraries defined in the same project.
+The findlib name for this library will be \fB<package>.__private__.<name>\fP,
+however the library\(aqs interface will be hidden from consumers outside the
+project.
+.IP \(bu 2
+\fB(synopsis <string>)\fP should give a one\-line description of the library.
+This is used by tools that list installed libraries
+.IP \(bu 2
+\fB(modules <modules>)\fP specifies what modules are part of the library. By
+default dune will use all the .ml/.re files in the same directory as the
+\fBdune\fP file. This include ones that are present in the file system as well
+as ones generated by user rules. You can restrict this list by using a
+\fB(modules <modules>)\fP field. \fB<modules>\fP uses the ordered\-set\-language
+where elements are module names and don\(aqt need to start with a uppercase
+letter. For instance to exclude module \fBFoo\fP: \fB(modules (:standard \e
+foo))\fP
+.IP \(bu 2
+\fB(libraries <library\-dependencies>)\fP is used to specify the dependencies
+of the library. See the section about library\-deps for more details
+.IP \(bu 2
+\fB(wrapped <boolean>)\fP specifies whether the modules of the library should be
+available only through the top\-level library module, or should all be exposed
+at the top level. The default is \fBtrue\fP and it is highly recommended to keep
+it this way. Because OCaml top\-level modules must all be unique when linking
+an executables, polluting the top\-level namespace will make your library
+unusable with other libraries if there is a module name clash. This option is
+only intended for libraries that manually prefix all their modules by the
+library name and to ease porting of existing projects to dune
+.IP \(bu 2
+\fB(wrapped (transition <message>))\fP Is the same as \fB(wrapped true)\fP except
+that it will also generate unwrapped (not prefixed by the library name)
+modules to preserve compatibility. This is useful for libraries that would
+like to transition from \fB(wrapped false)\fP to \fB(wrapped true)\fP without
+breaking compatibility for users. The \fB<message>\fP will be included in the
+deprecation notice for the unwrapped modules.
+.IP \(bu 2
+\fB(preprocess <preprocess\-spec>)\fP specifies how to preprocess files if
+needed. The default is \fBno_preprocessing\fP\&. Other options are described in the
+preprocessing\-spec section
+.IP \(bu 2
+\fB(preprocessor_deps (<deps\-conf list>))\fP specifies extra dependencies of the
+preprocessor, for instance if the preprocessor reads a generated file. The
+specification of dependencies is described in the deps\-field
+section
+.IP \(bu 2
+\fB(optional)\fP, if present it indicates that the library should only be built
+and installed if all the dependencies are available, either in the workspace
+or in the installed world. You can use this to provide extra features without
+adding hard dependencies to your project
+.IP \(bu 2
+\fB(foreign_stubs <foreign\-stubs\-spec>)\fP specifies foreign source files, e.g.
+C or C++ stubs, to be compiled and packaged together with the library. See
+the section foreign\-sources\-and\-archives for more details. This field
+replaces the now deleted fields \fBc_names\fP, \fBc_flags\fP, \fBcxx_names\fP
+and \fBcxx_flags\fP\&.
+.IP \(bu 2
+\fB(foreign_archives <foreign\-archives\-list>)\fP specifies archives of foreign
+object files to be packaged with the library. See the section
+foreign\-archives for more details. This field replaces the now
+deleted field \fBself_build_stubs_archive\fP\&.
+.IP \(bu 2
+\fB(install_c_headers (<names>))\fP, if your library has public C header files
+that must be installed, you must list them in this field, without the \fB\&.h\fP
+extension
+.IP \(bu 2
+\fB(modes <modes>)\fP modes which should be built by default. The
+most common use for this feature is to disable native compilation
+when writing libraries for the OCaml toplevel. The following modes
+are available: \fBbyte\fP, \fBnative\fP and \fBbest\fP\&. \fBbest\fP is
+\fBnative\fP or \fBbyte\fP when native compilation is not available
+.IP \(bu 2
+\fB(no_dynlink)\fP is to disable dynamic linking of the library. This is for
+advanced use only, by default you shouldn\(aqt set this option
+.IP \(bu 2
+\fB(kind <kind>)\fP is the kind of the library. The default is \fBnormal\fP, other
+available choices are \fBppx_rewriter\fP and \fBppx_deriver\fP and must be set
+when the library is intended to be used as a ppx rewriter or a \fB[@@deriving
+\&...]\fP plugin. The reason why \fBppx_rewriter\fP and \fBppx_deriver\fP are split
+is historical and hopefully we won\(aqt need two options soon. Both ppx kinds
+support an optional field \fB(cookies <cookies>)\fP where \fB<cookies>\fP is a
+list of pairs \fB(<name> <value>)\fP with \fB<name>\fP being the cookie name and
+\fB<value>\fP is a string that supports variables evaluated
+by each invocation of the preprocessor (note: libraries that share
+cookies with the same name should agree on their expanded value)
+.IP \(bu 2
+\fB(ppx_runtime_libraries (<library\-names>))\fP is for when the library is a ppx
+rewriter or a \fB[@@deriving ...]\fP plugin and has runtime dependencies. You
+need to specify these runtime dependencies here
+.IP \(bu 2
+\fB(virtual_deps (<opam\-packages>)\fP\&. Sometimes opam packages enable a specific
+feature only if another package is installed. This is for instance the case of
+\fBctypes\fP which will only install \fBctypes.foreign\fP if the dummy
+\fBctypes\-foreign\fP package is installed. You can specify such virtual
+dependencies here. You don\(aqt need to do so unless you use dune to
+synthesize the \fBdepends\fP and \fBdepopts\fP sections of your opam file
+.IP \(bu 2
+\fBjs_of_ocaml\fP sets options for JavaScript compilation, see \fI\%js_of_ocaml\fP
+.IP \(bu 2
+\fBflags\fP, \fBocamlc_flags\fP and \fBocamlopt_flags\fP\&. See the section about
+ocaml\-flags
+.IP \(bu 2
+\fB(library_flags (<flags>))\fP is a list of flags that are passed as it to
+\fBocamlc\fP and \fBocamlopt\fP when building the library archive files. You can
+use this to specify \fB\-linkall\fP for instance. \fB<flags>\fP is a list of
+strings supporting variables
+.IP \(bu 2
+\fB(c_library_flags <flags>)\fP specifies the flags to pass to the C compiler
+when constructing the library archive file for the C stubs. \fB<flags>\fP uses
+the ordered\-set\-language and supports \fB(:include ...)\fP forms. When you
+are writing bindings for a C library named \fBbar\fP, you should typically write
+\fB\-lbar\fP here, or whatever flags are necessary to link against this
+library
+.IP \(bu 2
+\fB(modules_without_implementation <modules>)\fP specifies a list of
+modules that have only a \fB\&.mli\fP or \fB\&.rei\fP but no \fB\&.ml\fP or
+\fB\&.re\fP file. Such modules are usually referred as \fImli only
+modules\fP\&. They are not officially supported by the OCaml compiler,
+however they are commonly used. Such modules must only define
+types. Since it is not reasonably possible for dune to check
+that this is the case, dune requires the user to explicitly list
+such modules to avoid surprises.  Note that the
+\fBmodules_without_implementation\fP field is not merged in \fBmodules\fP, which
+represents the total set of modules in a library. If a directory has more
+than one stanza and thus a \fBmodules\fP field must be specified, \fB<modules>\fP
+still need to be added in \fBmodules\fP\&.
+.IP \(bu 2
+\fB(private_modules <modules>)\fP specifies a list of modules that will be
+marked as private. Private modules are inaccessible from outside the libraries
+they are defined in. Note that the \fBprivate_modules\fP field is not merged in
+\fBmodules\fP, which represents the total set of modules in a library. If a
+directory has more than one stanza and thus a \fBmodules\fP field must be
+specified, \fB<modules>\fP still need to be added in \fBmodules\fP\&.
+.IP \(bu 2
+\fB(allow_overlapping_dependencies)\fP allows external dependencies to
+overlap with libraries that are present in the workspace
+.IP \(bu 2
+\fB(enabled_if <blang expression>)\fP conditionally disables
+a library. A disabled library cannot be built and will not be
+installed. The condition is specified using the blang, and the
+field allows for the \fB%{os_type}\fP variable, which is expanded to
+the type of OS being targeted by the current build. Its value is
+the same as the value of the \fBos_type\fP parameter in the output of
+\fBocamlc \-config\fP
+.IP \(bu 2
+\fB(inline_tests)\fP enables inline tests for this library. They can be
+configured through options using \fB(inline_tests <options>)\fP\&. See
+inline_tests for a reference of corresponding options.
+.UNINDENT
+.sp
+Note that when binding C libraries, dune doesn\(aqt provide special support for
+tools such as \fBpkg\-config\fP, however it integrates easily with
+configurator by
+using \fB(c_flags (:include ...))\fP and \fB(c_library_flags (:include ...))\fP\&.
+.SS foreign_library
+.sp
+The \fBforeign_library\fP stanza describes archives of separately compiled
+foreign object files that can be packaged with an OCaml library or linked
+into an OCaml executable. See foreign\-sources\-and\-archives for
+further details and examples.
+.SS js_of_ocaml
+.sp
+In \fBlibrary\fP and \fBexecutables\fP stanzas, you can specify \fBjs_of_ocaml\fP
+options using \fB(js_of_ocaml (<js_of_ocaml\-options>))\fP\&.
+.sp
+\fB<js_of_ocaml\-options>\fP are all optional:
+.INDENT 0.0
+.IP \(bu 2
+\fB(flags <flags>)\fP to specify flags passed to \fBjs_of_ocaml\fP\&. This field
+supports \fB(:include ...)\fP forms
+.IP \(bu 2
+\fB(javascript_files (<files\-list>))\fP to specify \fBjs_of_ocaml\fP JavaScript
+runtime files.
+.UNINDENT
+.sp
+\fB<flags>\fP is specified in the ordered\-set\-language\&.
+.sp
+The default value for \fB(flags ...)\fP depends on the selected build profile. The
+build profile \fBdev\fP (the default) will enable sourcemap and the pretty
+JavaScript output.
+.sp
+See jsoo for more information.
+.SS deprecated_library_name
+.sp
+The \fBdeprecated_library_name\fP stanza enables redirecting an old
+deprecated name after a library has been renamed. It\(aqs syntax is as
+follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(deprecated_library_name
+ (old_public_name <name>)
+ (new_public_name <name>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+When a developer uses the old public name in a list of library
+dependencies, it will be transparently replaced by the new name. Note
+that it is not necessary for the new name to exist at definition time
+as it is only resolved at the point where the old name is used.
+.sp
+The \fBold_public_name\fP can also be one of the names declared in the
+\fBdeprecated_package_names\fP field of the package declaration in
+\fBdune\-project\fP file. In this case, the "old" library is understood to be a
+library whose name is not prefixed by the package name. Such a library cannot be
+defined in Dune, but other build systems allow it and this feature is meant to
+help migration from those systems.
+.SS executable
+.sp
+The \fBexecutable\fP stanza must be used to describe an executable. The
+format of executable stanzas is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name <name>)
+ <optional\-fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<name>\fP is a module name that contains the main entry point of the
+executable. There can be additional modules in the current directory,
+you only need to specify the entry point. Given an \fBexecutable\fP
+stanza with \fB(name <name>)\fP, dune will know how to build
+\fB<name>.exe\fP\&. If requested, it will also know how to build
+\fB<name>.bc\fP and \fB<name>.bc.js\fP (dune 2.0 and up also need specific
+configuration, see the \fBmodes\fP optional field below). \fB<name>.exe\fP
+is a native code executable, \fB<name>.bc\fP is a bytecode executable
+which requires \fBocamlrun\fP to run and \fB<name>.bc.js\fP is a JavaScript
+generated using js_of_ocaml.
+.sp
+Note that in case native compilation is not available, \fB<name>.exe\fP
+will in fact be a custom byte\-code executable. Custom in the sense of
+\fBocamlc \-custom\fP, meaning that it is a native executable that embeds
+the \fBocamlrun\fP virtual machine as well as the byte code. As such you
+can always rely on \fB<name>.exe\fP being available. Moreover, it is
+usually preferable to use \fB<name>.exe\fP in custom rules or when
+calling the executable by hand. This is because running a byte\-code
+executable often requires loading shared libraries that are locally
+built, and so requires additional setup such as setting specific
+environment variables and dune doesn\(aqt do at the moment.
+.sp
+Native compilation is considered not available when there is no \fBocamlopt\fP
+binary at the same place as where \fBocamlc\fP was found.
+.sp
+Executables can also be linked as object or shared object files. See
+\fI\%linking modes\fP for more information.
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(public_name <public\-name>)\fP specifies that the executable should be
+installed under that name. It is the same as adding the following stanza to
+your \fBdune\fP file:
+.INDENT 2.0
+.INDENT 3.5
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(install
+ (section bin)
+ (files (<name>.exe as <public\-name>)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.IP \(bu 2
+\fB(package <package>)\fP if there is a \fB(public_name ...)\fP field, this
+specifies the package the executables are part of
+.IP \(bu 2
+\fB(libraries <library\-dependencies>)\fP specifies the library dependencies.
+See the section about library\-deps for more details
+.IP \(bu 2
+\fB(link_flags <flags>)\fP specifies additional flags to pass to the linker.
+This field supports \fB(:include ...)\fP forms
+.IP \(bu 2
+\fB(link_deps (<deps\-conf list>))\fP specifies the dependencies used only by the
+linker, for example when using a version script. See the deps\-field
+section for more details.
+.IP \(bu 2
+\fB(modules <modules>)\fP specifies which modules in the current directory
+dune should consider when building this executable. Modules not listed
+here will be ignored and cannot be used inside the executable described by
+the current stanza. It is interpreted in the same way as the \fB(modules
+\&...)\fP field of \fI\%library\fP
+.IP \(bu 2
+\fB(modes (<modes>))\fP sets the \fI\%linking modes\fP\&. The default is
+\fB(exe)\fP\&. Before 2.0, it used to be \fB(byte exe)\fP\&.
+.IP \(bu 2
+\fB(preprocess <preprocess\-spec>)\fP is the same as the \fB(preprocess ...)\fP
+field of \fI\%library\fP
+.IP \(bu 2
+\fB(preprocessor_deps (<deps\-conf list>))\fP is the same as the
+\fB(preprocessor_deps ...)\fP field of \fI\%library\fP
+.IP \(bu 2
+\fBjs_of_ocaml\fP\&. See the section about \fI\%js_of_ocaml\fP
+.IP \(bu 2
+\fBflags\fP, \fBocamlc_flags\fP and \fBocamlopt_flags\fP\&. See the section about
+specifying ocaml\-flags
+.IP \(bu 2
+\fB(modules_without_implementation <modules>)\fP is the same as the
+corresponding field of \fI\%library\fP
+.IP \(bu 2
+\fB(allow_overlapping_dependencies)\fP is the same as the
+corresponding field of \fI\%library\fP
+.IP \(bu 2
+\fB(optional)\fP is the same as the corresponding field of \fI\%library\fP
+.IP \(bu 2
+\fB(enabled_if <blang expression>)\fP is the same as the corresponding field of \fI\%library\fP
+.IP \(bu 2
+\fB(promote <options>)\fP allows promoting the linked executables to
+the source tree. The options are the same as for the \fI\%rule
+promote mode\fP\&. Adding \fB(promote (until\-clean))\fP to an
+\fBexecutable\fP stanza will cause Dune to copy the \fB\&.exe\fP files to
+the source tree and \fBdune clean\fP to delete them
+.IP \(bu 2
+\fB(foreign_stubs <foreign\-stubs\-spec>)\fP specifies foreign source
+files, e.g. C or C++ stubs, to be linked into the executable. See the
+section foreign\-sources\-and\-archives for more details.
+.IP \(bu 2
+\fB(foreign_archives <foreign\-archives\-list>)\fP specifies archives of
+foreign object files to be linked into the executable. See the section
+foreign\-archives for more details.
+.IP \(bu 2
+\fB(forbidden_libraries <libraries>)\fP ensures that the given
+libraries are not linked in the resulting executable. If they end up
+being pulled in, either through a direct or transitive dependency,
+Dune fails with an error message explaining how the library was
+pulled in. This field is available since the 2.0 version of the dune
+language.
+.IP \(bu 2
+\fB(embed_in_plugin_libraries <library\-list>)\fP specifies a list of libraries
+to link statically when using \fBplugin\fP linking mode. By default, no
+libraries are linked in. Note that you may need to also use the \fB\-linkall\fP
+flag if some of the libraries listed here are not referenced from any of the
+plugin modules.
+.UNINDENT
+.SS Linking modes
+.sp
+The \fBmodes\fP field allows selecting what linking modes should be used
+to link executables. Each mode is a pair \fB(<compilation\-mode>
+<binary\-kind>)\fP where \fB<compilation\-mode>\fP describes whether the
+byte code or native code backend of the OCaml compiler should be used
+and \fB<binary\-kind>\fP describes what kind of file should be produced.
+.sp
+\fB<compilation\-mode>\fP must be \fBbyte\fP, \fBnative\fP or \fBbest\fP, where
+\fBbest\fP is \fBnative\fP with a fallback to byte\-code when native
+compilation is not available.
+.sp
+\fB<binary\-kind>\fP is one of:
+.INDENT 0.0
+.IP \(bu 2
+\fBc\fP for producing OCaml bytecode embedded in a C file
+.IP \(bu 2
+\fBexe\fP for normal executables
+.IP \(bu 2
+\fBobject\fP for producing static object files that can be manually
+linked into C applications
+.IP \(bu 2
+\fBshared_object\fP for producing object files that can be dynamically
+loaded into an application. This mode can be used to write a plugin
+in OCaml for a non\-OCaml application.
+.IP \(bu 2
+\fBjs\fP for producing JavaScript from bytecode executables, see
+\fI\%explicit_js_mode\fP\&.
+.IP \(bu 2
+\fBplugin\fP for producing a plugin (\fB\&.cmxs\fP if native or \fB\&.cma\fP
+if bytecode).
+.UNINDENT
+.sp
+For instance the following \fBexecutables\fP stanza will produce byte
+code executables and native shared objects:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executables
+  (names a b c)
+  (modes (byte exe) (native shared_object)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Additionally, you can use the following short\-hands:
+.INDENT 0.0
+.IP \(bu 2
+\fBc\fP for \fB(byte c)\fP
+.IP \(bu 2
+\fBexe\fP for \fB(best exe)\fP
+.IP \(bu 2
+\fBobject\fP for \fB(best object)\fP
+.IP \(bu 2
+\fBshared_object\fP for \fB(best shared_object)\fP
+.IP \(bu 2
+\fBbyte\fP for \fB(byte exe)\fP
+.IP \(bu 2
+\fBnative\fP for \fB(native exe)\fP
+.IP \(bu 2
+\fBjs\fP for \fB(byte js)\fP
+.IP \(bu 2
+\fBplugin\fP for \fB(best plugin)\fP
+.UNINDENT
+.sp
+For instance the following \fBmodes\fP fields are all equivalent:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(modes (exe object shared_object))
+(modes ((best exe)
+        (best object)
+        (best shared_object)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And finally, you can use the special mode \fBbyte_complete\fP for
+building a bytecode executable as a native self\-contained
+executable. I.e. an executable that does not require the \fBocamlrun\fP
+program to run and does not requires the C stubs to be installed as
+shared object files.
+.sp
+The extensions for the various linking modes are chosen as follows:
+.TS
+center;
+|l|l|.
+_
+T{
+linking mode
+T}	T{
+extensions
+T}
+_
+T{
+byte
+T}	T{
+\&.bc
+T}
+_
+T{
+native/best
+T}	T{
+\&.exe
+T}
+_
+T{
+byte_complete
+T}	T{
+\&.bc.exe
+T}
+_
+T{
+(byte object)
+T}	T{
+\&.bc%{ext_obj}
+T}
+_
+T{
+(native/best object)
+T}	T{
+\&.exe%{ext_obj}
+T}
+_
+T{
+(byte shared_object)
+T}	T{
+\&.bc%{ext_dll}
+T}
+_
+T{
+(native/best shared_object)
+T}	T{
+%{ext_dll}
+T}
+_
+T{
+c
+T}	T{
+\&.bc.c
+T}
+_
+T{
+js
+T}	T{
+\&.bc.js
+T}
+_
+T{
+(best plugin)
+T}	T{
+%{ext_plugin}
+T}
+_
+T{
+(byte plugin)
+T}	T{
+\&.cma
+T}
+_
+T{
+(native plugin)
+T}	T{
+\&.cmxs
+T}
+_
+.TE
+.sp
+Where \fB%{ext_obj}\fP and \fB%{ext_dll}\fP are the extensions for object
+and shared object files. Their value depends on the OS, for instance
+on Unix \fB%{ext_obj}\fP is usually \fB\&.o\fP and \fB%{ext_dll}\fP is usually
+\fB\&.so\fP while on Windows \fB%{ext_obj}\fP is \fB\&.obj\fP and \fB%{ext_dll}\fP
+is \fB\&.dll\fP\&.
+.sp
+Up to version 3.0 of the dune language, when \fBbyte\fP is specified but
+none of \fBnative\fP, \fBexe\fP or \fBbyte_complete\fP are specified Dune
+implicitly adds a linking mode that is the same as \fBbyte_complete\fP
+but using the extension \fB\&.exe\fP\&. \fB\&.bc\fP files require additional
+files at runtime that are not currently tracked by Dune, so you should
+not run \fB\&.bc\fP files during the build. Run the \fB\&.bc.exe\fP or
+\fB\&.exe\fP ones instead as these are self\-contained.
+.sp
+Lastly, note that \fB\&.bc\fP executables cannot contain C stubs. If your
+executable contains C stubs you may want to use \fB(modes exe)\fP\&.
+.SS executables
+.sp
+The \fBexecutables\fP stanza is the same as the \fBexecutable\fP stanza, except that
+it is used to describe several executables sharing the same configuration.
+.sp
+It shares the same fields as the \fBexecutable\fP stanza, except that instead of
+\fB(name ...)\fP and \fB(public_name ...)\fP you must use:
+.INDENT 0.0
+.IP \(bu 2
+\fB(names <names>)\fP where \fB<names>\fP is a list of entry point names. As for
+\fBexecutable\fP you only need to specify the modules containing the entry point
+of each executable
+.IP \(bu 2
+\fB(public_names <names>)\fP describes under what name each executable should
+be installed. The list of names must be of the same length as the list in the
+\fB(names ...)\fP field. Moreover you can use \fB\-\fP for executables that
+shouldn\(aqt be installed
+.UNINDENT
+.SS rule
+.sp
+The \fBrule\fP stanza is used to create custom user rules. It tells dune how
+to generate a specific set of files from a specific set of dependencies.
+.sp
+The syntax is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target[s] <filenames>)
+ (action  <action>)
+ <optional\-fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<filenames>\fP is a list of file names (if defined with \fBtargets\fP)
+or exactly one file name (if defined with \fBtarget\fP). Note that
+currently dune only supports user rules with targets in the current
+directory.
+.sp
+\fB<action>\fP is the action to run to produce the targets from the dependencies.
+See the user\-actions section for more details.
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(deps <deps\-conf list>)\fP to specify the dependencies of the
+rule. See the deps\-field section for more details.
+.IP \(bu 2
+\fB(mode <mode>)\fP to specify how to handle the targets, see \fI\%modes\fP
+for details
+.IP \(bu 2
+\fB(fallback)\fP is deprecated and is the same as \fB(mode fallback)\fP
+.IP \(bu 2
+\fB(locks (<lock\-names>))\fP specify that the action must be run while
+holding the following locks. See the locks section for more details.
+.IP \(bu 2
+\fB(alias <alias\-name>)\fP specify the alias this rule belongs to. Building this
+alias means building the targets of this rule.
+.IP \(bu 2
+\fB(package <package>)\fP specify the package this rule belongs to. This rule
+will be unavailable when installing other packages in release mode.
+.IP \(bu 2
+\fB(enabled_if <blang expression>)\fP specifies the boolean condition that must
+be true for the rule to be considered. The condition is specified using the blang, and
+the field allows for variables to appear in the expressions.
+.UNINDENT
+.sp
+Note that contrary to makefiles or other build systems, user rules currently
+don\(aqt support patterns, such as a rule to produce \fB%.y\fP from \fB%.x\fP for any
+given \fB%\fP\&. This might be supported in the future.
+.SS modes
+.sp
+By default, the target of a rule must not exist in the source tree and
+dune will error out when this is the case.
+.sp
+However, it is possible to change this behavior using the \fBmode\fP
+field. The following modes are available:
+.INDENT 0.0
+.IP \(bu 2
+\fBstandard\fP, this is the standard mode
+.IP \(bu 2
+\fBfallback\fP, in this mode, when the targets are already present in
+the source tree, dune will ignore the rule. It is an error if
+only a subset of the targets are present in the tree. The common use
+of fallback rules is to generate default configuration files that
+may be generated by a configure script.
+.UNINDENT
+.INDENT 0.0
+.IP \(bu 2
+\fBpromote\fP or \fB(promote <options>)\fP, in this mode, the files
+in the source tree will be ignored. Once the rule has been executed,
+the targets will be copied back to the source tree
+The following options are available:
+.INDENT 2.0
+.IP \(bu 2
+\fB(until\-clean)\fP means that \fBdune clean\fP will remove the promoted files
+from the source tree.
+.IP \(bu 2
+\fB(into <dir>)\fP means that the files are promoted in \fB<dir>\fP instead of
+the current directory. This feature is available since Dune 1.8.
+.IP \(bu 2
+\fB(only <predicate>)\fP means that only a subset of the targets should be
+promoted. The argument is similar to the argument of \fI\%(dirs ...)\fP, specified using the predicate\-lang\&. This feature is
+available since dune 1.10.
+.UNINDENT
+.IP \(bu 2
+\fBpromote\-until\-clean\fP is the same as \fB(promote (until\-clean))\fP
+.IP \(bu 2
+\fB(promote\-into <dir>)\fP is the same as \fB(promote (into <dir>))\fP
+.IP \(bu 2
+\fB(promote\-until\-clean\-into <dir>)\fP is the same as \fB(promote
+(until\-clean) (into <dir>))\fP
+.UNINDENT
+.sp
+The \fB(promote <options>)\fP form is only available since Dune
+1.10. Before Dune 1.10, you need to use one of the \fBpromote\-...\fP
+forms. The \fBpromote\-...\fP forms should disappear in Dune 2.0, so
+using the more generic \fB(promote <options>)\fP form should be preferred
+in new projects.
+.sp
+There are two use cases for promote rules. The first one is when the
+generated code is easier to review than the generator, so it\(aqs easier
+to commit the generated code and review it. The second is to cut down
+dependencies during releases: by passing \fB\-\-ignore\-promoted\-rules\fP
+to dune, rules with \fB(mode promote)\fP will be ignored and the source
+files will be used instead. The \fB\-p/\-\-for\-release\-of\-packages\fP flag
+implies \fB\-\-ignore\-promote\-rules\fP\&. However, rules that promotes only
+a subset of their targets via \fB(only ...)\fP are never ignored.
+.SS inferred rules
+.sp
+When using the action DSL (see user\-actions), it is most of the
+time obvious what are the dependencies and targets.
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target b)
+ (deps   a)
+ (action (copy %{deps} %{target})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+In this example it is obvious by inspecting the action what the
+dependencies and targets are. When this is the case you can use the
+following shorter syntax, where dune infers dependencies and
+targets for you:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule <action>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule (copy a b))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note that in dune, targets must always be known
+statically. For instance, this \fB(rule ...)\fP
+stanza is rejected by dune:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule (copy a b.%{read:file}))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS ocamllex
+.sp
+\fB(ocamllex <names>)\fP is essentially a shorthand for:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target <name>.ml)
+ (deps   <name>.mll)
+ (action (chdir %{workspace_root}
+          (run %{bin:ocamllex} \-q \-o %{target} %{deps}))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+To use a different rule mode, use the long form:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(ocamllex
+ (modules <names>)
+ (mode    <mode>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS ocamlyacc
+.sp
+\fB(ocamlyacc <names>)\fP is essentially a shorthand for:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (targets <name>.ml <name>.mli)
+ (deps    <name>.mly)
+ (action  (chdir %{workspace_root}
+           (run %{bin:ocamlyacc} %{deps}))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+To use a different rule mode, use the long form:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(ocamlyacc
+ (modules <names>)
+ (mode    <mode>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS menhir
+.sp
+A \fBmenhir\fP stanza is available to support the \fI\%menhir\fP parser generator.
+.sp
+To use menhir in a dune project, the language version should be selected in the
+\fBdune\-project\fP file. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(using menhir 2.0)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will enable support for menhir stanzas in the current project. If the
+language version is absent, dune will automatically add this line with the
+latest menhir version to the project file once a menhir stanza is used anywhere.
+.sp
+The basic form for defining \fI\%menhir\-git\fP parsers (analogous to \fI\%ocamlyacc\fP) is:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(menhir
+ (modules <parser1> <parser2> ...)
+ <optional\-fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(merge_into <base_name>)\fP is used to define modular parsers. This
+correspond to the \fB\-\-base\fP command line option of \fBmenhir\fP\&. With this
+option, a single parser named \fBbase_name\fP is generated.
+.IP \(bu 2
+\fB(flags <option1> <option2> ...)\fP can be used to pass extra flags can be
+passed to menhir.
+.IP \(bu 2
+\fB(infer <bool>)\fP can be used to enable using menhir with type
+inference. This option is enabled by default with Menhir language 2.0.
+.UNINDENT
+.sp
+Menhir supports writing the grammar and automaton to \fB\&.cmly\fP file. Therefore,
+if this is flag is passed to menhir, dune will know to introduce a \fB\&.cmly\fP
+target for the module.
+.SS cinaps
+.sp
+A \fBcinaps\fP stanza is available to support the \fBcinaps\fP tool.  See
+the \fI\%cinaps website\fP for more
+details.
+.SS documentation
+.sp
+Additional manual pages may be attached to packages using the \fBdocumentation\fP
+stanza. These \fB\&.mld\fP files must contain text in the same syntax as ocamldoc
+comments.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(documentation (<optional\-fields>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Where \fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(package <name>)\fP the package this documentation should be attached to. If
+this absent, dune will try to infer it based on the location of the
+stanza.
+.IP \(bu 2
+\fB(mld_files <arg>)\fP where \fB<arg>\fP field follows the
+ordered\-set\-language\&. This is a set of extension\-less, mld file base
+names that are attached to the package. Where \fB:standard\fP refers to all the
+\fB\&.mld\fP files in the stanza\(aqs directory.
+.UNINDENT
+.sp
+The \fBindex.mld\fP file (specified as \fBindex\fP in \fBmld_files\fP) is treated
+specially by dune. This will be the file used to generate the entry page for the
+package. This is the page that will be linked from the main package listing. If
+you omit writing an \fBindex.mld\fP, dune will generate one with the entry modules
+for your package. But this generated will not be installed.
+.sp
+All mld files attached to a package will be included in the generated
+\fB\&.install\fP file for that package, and hence will be installed by opam.
+.SS alias
+.sp
+The \fBalias\fP stanza lets you add dependencies to an alias, or specify an action
+to run to construct the alias.
+.sp
+The syntax is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(alias
+ (name    <alias\-name>)
+ (deps    <deps\-conf list>)
+ <optional\-fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<name>\fP is an alias name such as \fBruntest\fP\&.
+.sp
+\fB<deps\-conf list>\fP specifies the dependencies of the alias. See the
+deps\-field section for more details.
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB<action>\fP, an action to run when constructing the alias. See the
+user\-actions section for more details. Note that this is removed in the
+2.0 version of the dune language. Users should port their code to use the
+\fBrule\fP stanza with the \fBalias\fP field instead.
+.IP \(bu 2
+\fB(package <name>)\fP indicates that this alias stanza is part of package
+\fB<name>\fP and should be filtered out if \fB<name>\fP is filtered out from the
+command line, either with \fB\-\-only\-packages <pkgs>\fP or \fB\-p <pkgs>\fP
+.IP \(bu 2
+\fB(locks (<lock\-names>))\fP specify that the action must be run while
+holding the following locks. See the locks section for more details.
+.IP \(bu 2
+\fB(enabled_if <blang expression>)\fP specifies the boolean condition that must
+be true for the tests to run. The condition is specified using the blang, and
+the field allows for variables to appear in the expressions.
+.UNINDENT
+.sp
+The typical use of the \fBalias\fP stanza is to define tests:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (alias   runtest)
+ (action (run %{exe:my\-test\-program.exe} blah)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+See the section about running\-tests for details.
+.sp
+Note that if your project contains several packages and you run the tests
+from the opam file using a \fBbuild\-test\fP field, then all your \fBruntest\fP alias
+stanzas should have a \fB(package ...)\fP field in order to partition the set of
+tests.
+.SS install
+.sp
+Dune supports installing packages on the system, i.e. copying freshly built
+artifacts from the workspace to the system. The \fBinstall\fP stanza takes three
+pieces of information:
+.INDENT 0.0
+.IP \(bu 2
+the list of files to install
+.IP \(bu 2
+the package to attach these files to. This field is optional if your
+project contains a single package
+.IP \(bu 2
+the section in which the files will be installed
+.UNINDENT
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(install
+ (files hello.txt)
+ (section share)
+ (package mypackage))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Indicate that the file \fBhello.txt\fP in the current directory is to be
+installed in \fB<prefix>/share/mypackage\fP\&.
+.sp
+The following sections are available:
+.INDENT 0.0
+.IP \(bu 2
+\fBlib\fP installs to \fB<prefix>/lib/<pkgname>/\fP
+.IP \(bu 2
+\fBlib_root\fP installs to \fB<prefix>/lib/\fP
+.IP \(bu 2
+\fBlibexec\fP installs to \fB<prefix>/lib/<pkgname>/\fP with the
+executable bit set
+.IP \(bu 2
+\fBlibexec_root\fP installs to \fB<prefix>/lib/\fP with the executable
+bit set
+.IP \(bu 2
+\fBbin\fP installs to \fB<prefix>/bin/\fP with the executable bit set
+.IP \(bu 2
+\fBsbin\fP installs to \fB<prefix>/sbin/\fP with the executable bit set
+.IP \(bu 2
+\fBtoplevel\fP installs to \fB<prefix>/lib/toplevel/\fP
+.IP \(bu 2
+\fBshare\fP installs to \fB<prefix>/share/<pkgname>/\fP
+.IP \(bu 2
+\fBshare_root\fP installs to \fB<prefix>/share/\fP
+.IP \(bu 2
+\fBetc\fP installs to \fB<prefix>/etc/<pkgname>/\fP
+.IP \(bu 2
+\fBdoc\fP installs to \fB<prefix>/doc/<pkgname>/\fP
+.IP \(bu 2
+\fBstublibs\fP installs to \fB<prefix>/lib/stublibs/\fP with the
+executable bit set
+.IP \(bu 2
+\fBman\fP installs relative to \fB<prefix>/man\fP with the destination
+directory extracted from the extension of the source file (so that
+installing \fBfoo.1\fP is equivalent to a destination of
+\fBman1/foo.1\fP)
+.IP \(bu 2
+\fBmisc\fP requires files to specify an absolute destination, and the
+user will be prompted before the installation when it is done via
+opam. Only use this for advanced cases.
+.IP \(bu 2
+\fB(site (<package> <site>))\fP install in the \fB<site>\fP directory of
+\fB<package>\fP\&. If the prefix is not the same than the one used when installing
+\fB<package>\fP, \fB<package>\fP will not find the files.
+.UNINDENT
+.sp
+Normally, Dune uses the basename of the file to install to determine
+the name of the file once installed.  However, you can change that
+fact by using the form \fB(<filename> as <destination>)\fP in the
+\fBfiles\fP field. For instance, to install a file \fBmylib.el\fP as
+\fB<prefix>/emacs/site\-lisp/mylib.el\fP you must write the following:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(install
+ (section share_root)
+ (files   (mylib.el as emacs/site\-lisp/mylib.el)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Handling of the .exe extension on Windows
+.sp
+Under Microsoft Windows, executables must be suffixed with
+\fB\&.exe\fP\&. Dune tries to make sure that executables are always
+installed with this extension on Windows.
+.sp
+More precisely, when installing a file via an \fB(install ...)\fP
+stanza, if the source file has extension \fB\&.exe\fP or \fB\&.bc\fP, then
+dune implicitly adds the \fB\&.exe\fP extension to the destination, if
+not already present.
+.SS copy_files
+.sp
+The \fBcopy_files\fP and \fBcopy_files#\fP stanzas allow to specify that
+files from another directory could be copied if needed to the current
+directory.
+.sp
+The syntax is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(copy_files
+ <optional\-fields>
+ (files <glob>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<glob>\fP represents the set of files to copy, see the glob for details.
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(alias <alias\-name>)\fP to specify an alias to which to attach the targets.
+.IP \(bu 2
+\fB(mode <mode>)\fP to specify how to handle the targets, see \fI\%modes\fP
+for details.
+.IP \(bu 2
+\fB(enabled_if <blang expression>)\fP conditionally disables this stanza. The
+condition is specified using the blang\&.
+.UNINDENT
+.sp
+The short form
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(copy_files <glob>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+is equivalent to
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(copy_files (files <glob>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The difference between \fBcopy_files\fP and \fBcopy_files#\fP is the same
+as the difference between the \fBcopy\fP and \fBcopy#\fP action. See the
+user\-actions section for more details.
+.SS include
+.sp
+The \fBinclude\fP stanza allows including the contents of another file in the
+current dune file. Currently, the included file cannot be generated and must be
+present in the source tree. This feature is intended to be used in conjunction
+with promotion, when parts of a dune file are to be generated.
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(include dune.inc)
+
+(rule (with\-stdout\-to dune.inc.gen (run ./gen\-dune.exe)))
+
+(rule
+ (alias  runtest)
+ (action (diff dune.inc dune.inc.gen)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+With this dune file, running dune as follows will replace the
+\fBdune.inc\fP file in the source tree by the generated one:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build @runtest \-\-auto\-promote
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS tests
+.sp
+The \fBtests\fP stanza allows one to easily define multiple tests. For example we
+can define two tests at once with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(tests
+ (names mytest expect_test)
+ <optional fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will define an executable named \fBmytest.exe\fP that will be executed as
+part of the \fBruntest\fP alias. If the directory also contains an
+\fBexpect_test.expected\fP file, then \fBexpect_test\fP will be used to define an
+expect test. That is, the test will be executed and its output will be compared
+to \fBexpect_test.expected\fP\&.
+.sp
+The optional fields that are supported are a subset of the alias and executables
+fields. In particular, all fields except for \fBpublic_names\fP are supported from
+the \fI\%executables stanza\fP\&. Alias fields apart from
+\fBname\fP are allowed.
+.sp
+By default the test binaries are run without options.  The \fBaction\fP field can
+be used to override the test binary invocation, for example if you\(aqre using
+alcotest and wish to see all the test failures on the standard output when
+running dune runtest you can use the following stanza:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(tests
+ (names mytest)
+ (libraries alcotest mylib)
+ (action (run %{test} \-e)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS test
+.sp
+The \fBtest\fP stanza is the singular form of \fBtests\fP\&. The only difference is
+that it\(aqs of the form:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(test
+ (name foo)
+ <optional fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+where the \fBname\fP field is singular. The same optional fields are supported.
+.SS env
+.sp
+The \fBenv\fP stanza allows one to modify the environment. The syntax is as
+follow:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(env
+ (<profile1> <settings1>)
+ (<profile2> <settings2>)
+ ...
+ (<profilen> <settingsn>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The first form \fB(<profile> <settings>)\fP that correspond to the
+selected build profile will be used to modify the environment in this
+directory. You can use \fB_\fP to match any build profile.
+.sp
+Fields supported in \fB<settings>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+any OCaml flags field, see ocaml\-flags for more details.
+.IP \(bu 2
+\fB(c_flags <flags>)\fP and \fB(cxx_flags <flags>)\fP
+to specify compilation flags for C and C++ stubs, respectively.
+See \fI\%library\fP for more details.
+.IP \(bu 2
+\fB(env\-vars (<var1> <val1>) .. (<varN> <valN>))\fP\&. This will add the
+corresponding variables to the environment in which the build commands are
+executed, and under which \fBdune exec\fP runs.
+.IP \(bu 2
+\fB(menhir_flags <flags>))\fP to specify flags for menhir stanzas.
+.IP \(bu 2
+\fB(binaries <binaries>)\fP where \fB<binaries>\fP is a list of entries
+of the form \fB(<filepath> as <name>)\fP\&. \fB(<filepath> as <name>)\fP
+makes the binary \fB<filepath>\fP available in the command search as
+just \fB<name>\fP\&. For instance in a \fB(run <name> ...)\fP action
+\fB<name>\fP will resolve to this file path. You can also write just
+the file path, in which case the name will be inferred from the
+basename of \fB<filepath>\fP by dropping the \fB\&.exe\fP suffix if it
+exists. For instance \fB(binaries bin/foo.exe (bin/main.exe as
+bar))\fP would add the commands \fBfoo\fP and \fBbar\fP to the search
+path.
+.IP \(bu 2
+\fB(inline_tests <state>)\fP where state is either \fBenabled\fP, \fBdisabled\fP or
+\fBignored\fP\&. This field is available since Dune 1.11. It controls the value
+of the variable \fB%{inline_tests}\fP that is read by the inline test framework.
+The default value is \fBdisabled\fP for the \fBrelease\fP profile and \fBenabled\fP
+otherwise.
+.IP \(bu 2
+\fB(odoc <fields>)\fP\&. This allows to pass options to Odoc, see
+odoc\-options for more details.
+.IP \(bu 2
+\fB(coq (flags <flags>))\fP\&. This allows to pass options to Coq, see
+\fI\%coq.theory\fP for more details.
+.UNINDENT
+.SS dirs (since 1.6)
+.sp
+The \fBdirs\fP stanza allows specifying the sub\-directories dune will
+include in a build. The syntax is based on dune\(aqs predicate\-lang and allows
+the user the following operations:
+.INDENT 0.0
+.IP \(bu 2
+The special value \fB:standard\fP which refers to the default set of used
+directories. These are the directories that don\(aqt start with \fB\&.\fP or \fB_\fP\&.
+.IP \(bu 2
+Set operations. Differences are expressed with backslash: \fB* \e bar\fP, unions
+are done by listing multiple items.
+.IP \(bu 2
+Sets can be defined using globs.
+.UNINDENT
+.sp
+Examples:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(dirs *) ;; include all directories
+(dirs :standard \e ocaml) ;; include all directories except ocaml
+(dirs :standard \e test* foo*) ;; exclude all directories that start with test or foo
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+A directory that is not included by this stanza will not be eagerly scanned by
+Dune. Any \fBdune\fP or other special files in it won\(aqt be interpreted either and
+will be treated as raw data. It is however possible to depend on files inside
+ignored sub\-directories.
+.SS data_only_dirs (since 1.6)
+.sp
+Dune allows the user to treat directories as \fIdata only\fP\&. Dune files in these
+directories will not be evaluated for their rules, but the contents of these
+directories will still be usable as dependencies for other rules.
+.sp
+The syntax is the same as for the \fBdirs\fP stanza except that \fB:standard\fP
+is by default empty.
+.sp
+Example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+;; dune files in fixtures_* dirs are ignored
+(data_only_dirs fixtures_*)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS ignored_subdirs (deprecated in 1.6)
+.sp
+One may also specify \fIdata only\fP directories using the \fBignored_subdirs\fP
+stanza. The meaning is the same as \fBdata_only_dirs\fP but the syntax isn\(aqt as
+flexible and only accepts a list of directory names. It is advised to switch to
+the new \fBdata_only_dirs\fP stanza.
+.sp
+Example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(ignored_subdirs (<sub\-dir1> <sub\-dir2> ...))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+All of the specified \fB<sub\-dirn>\fP will be ignored by dune. Note that users
+should rely on the \fBdirs\fP stanza along with the appropriate set operations
+instead of this stanza. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(dirs :standard \e <sub\-dir1> <sub\-dir2> ...)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS vendored_dirs (since 1.11)
+.sp
+Dune supports vendoring of other dune\-based projects natively since simply
+copying a project into a subdirectory of your own project will work. Simply
+doing that has a few limitations though. You can workaround those by explicitly
+marking such directories as containing vendored code.
+.sp
+Example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(vendored_dirs vendor)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Dune will not resolve aliases in vendored directories meaning by default it will
+not build all installable targets, run the test, format or lint the code located
+in such a directory while still building the parts your project depend upon.
+Libraries and executable in vendored directories will also be built with a \fB\-w
+\-a\fP flag to suppress all warnings and prevent pollution of your build output.
+.SS include_subdirs
+.sp
+The \fBinclude_subdirs\fP stanza is used to control how dune considers
+sub\-directories of the current directory. The syntax is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(include_subdirs <mode>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Where \fB<mode>\fP maybe be one of:
+.INDENT 0.0
+.IP \(bu 2
+\fBno\fP, the default
+.IP \(bu 2
+\fBunqualified\fP
+.UNINDENT
+.sp
+When the \fBinclude_subdirs\fP stanza is not present or \fB<mode>\fP is
+\fBno\fP, dune considers sub\-directories as independent. When \fB<mode>\fP
+is \fBunqualified\fP, dune will assume that the sub\-directories of the
+current directory are part of the same group of directories. In
+particular, dune will scan all these directories at once when looking
+for OCaml/Reason files. This allows you to split a library between
+several directories. \fBunqualified\fP means that modules in
+sub\-directories are seen as if they were all in the same directory. In
+particular, you cannot have two modules with the same name in two
+different directories. It is planned to add a \fBqualified\fP mode in
+the future.
+.sp
+Note that sub\-directories are included recursively, however the
+recursion will stop when encountering a sub\-directory that contains
+another \fBinclude_subdirs\fP stanza. Additionally, it is not allowed
+for a sub\-directory of a directory with \fB(include_subdirs <x>)\fP
+where \fB<x>\fP is not \fBno\fP to contain one of the following stanzas:
+.INDENT 0.0
+.IP \(bu 2
+\fBlibrary\fP
+.IP \(bu 2
+\fBexecutable(s)\fP
+.IP \(bu 2
+\fBtest(s)\fP
+.UNINDENT
+.SS toplevel
+.sp
+The \fBtoplevel\fP stanza allows one to define custom toplevels. Custom toplevels
+automatically load a set of specified libraries and are runnable like normal
+executables. Example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(toplevel
+ (name tt)
+ (libraries str))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will create a toplevel with the \fBstr\fP library loaded. We may build and
+run this toplevel with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune exec ./tt.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB(preprocess (pps ...))\fP is the same as the \fB(preprocess (pps ...))\fP field
+of \fI\%library\fP\&. Currently, \fBaction\fP and \fBfuture_syntax\fP are not supported
+in the toplevel.
+.SS subdir
+.sp
+The \fBsubdir\fP stanza can be used to evaluate stanzas in sub directories. This is
+useful for generated files or to override stanzas in vendored directories
+without editing vendored dune files.
+.sp
+In this example, a \fBbar\fP target is created in the \fBfoo\fP directory, and a bar
+target will be created in \fBa/b/bar\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(subdir foo (rule (with\-stdout\-to bar (echo baz))))
+(subdir a/b (rule (with\-stdout\-to bar (echo baz))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS external_variant
+.sp
+This stanza was experimental and removed in dune 2.6. see dune\-variants
+.SS coq.theory
+.sp
+Dune is also able to build Coq developments. A Coq project is a mix of
+Coq \fB\&.v\fP files and (optionally) OCaml libraries linking to the Coq
+API (in which case we say the project is a \fICoq plugin\fP). To enable
+Coq support in a dune project, the language version should be selected
+in the \fBdune\-project\fP file. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(using coq 0.2)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will enable support for the \fBcoq.theory\fP stanza in the current project. If the
+language version is absent, dune will automatically add this line with the
+latest Coq version to the project file once a \fB(coq.theory ...)\fP stanza is used anywhere.
+.sp
+The supported Coq language versions are \fB0.1\fP, and \fB0.2\fP which
+adds support for the \fBtheories\fP field. We don\(aqt provide any
+guarantees with respect to stability yet, however, as implementation
+of features progresses, we hope reach \fB1.0\fP soon. The \fB1.0\fP
+version will commit to a stable set of functionality; all the features
+below are expected to reach 1.0 unchanged or minimally modified.
+.sp
+The basic form for defining Coq libraries is very similar to the OCaml form:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(coq.theory
+ (name <module_prefix>)
+ (package <package>)
+ (synopsis <text>)
+ (modules <ordered_set_lang>)
+ (libraries <ocaml_libraries>)
+ (flags <coq_flags>)
+ (theories <coq_theories>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The stanza will build all \fB\&.v\fP files on the given directory. The semantics of fields is:
+.INDENT 0.0
+.IP \(bu 2
+\fB<module_prefix>\fP is a dot\-separated list of valid Coq module
+names and determines the module scope under which the theory is
+compiled [\fB\-R\fP option]. For example, if \fB<module_prefix>\fP is
+\fBfoo.Bar\fP, the theory modules will be named as
+\fBfoo.Bar.module1\fP, \fBfoo.Bar.module2\fP, etc... Note that modules
+in the same theory don\(aqt see the \fBfoo.Bar\fP prefix, in the same
+way that OCaml \fBwrapped\fP libraries do. For compatibility reasons,
+the 1.0 version of the Coq language installs a theory named
+\fBfoo.Bar\fP under \fBfoo/Bar\fP\&. Also note that Coq supports composing
+a module path from different theories, thus you can name a theory
+\fBfoo.Bar\fP and a second one \fBfoo.Baz\fP and things will work
+properly,
+.IP \(bu 2
+the \fBmodules\fP field enables constraining the set of modules
+included in the theory, similarly to its OCaml counterpart. Modules
+are specified in Coq notation, that is to say \fBA/b.v\fP is written
+\fBA.b\fP in this field,
+.IP \(bu 2
+if \fBpackage\fP is present, Dune will generate install rules for the
+\fB\&.vo\fP files on the theory. \fBpkg_name\fP must be a valid package
+name. Note that the 1.0 version of the language uses the Coq legacy
+install setup, where all packages share a common root namespace and
+install directory, \fBlib/coq/user\-contrib/<module_prefix>\fP, as
+customary in the make\-based Coq package ecosystem. For
+compatibility, we also install under the \fBuser\-contrib\fP prefix the
+\fB\&.cmxs\fP files appearing in \fB<ocaml_libraries>\fP,
+.IP \(bu 2
+\fB<coq_flags>\fP will be passed to \fBcoqc\fP as command\-line options,
+.IP \(bu 2
+the path to installed locations of \fB<ocaml_libraries>\fP will be passed to
+\fBcoqdep\fP and \fBcoqc\fP using Coq\(aqs \fB\-I\fP flag; this allows for a Coq
+theory to depend on a ML plugin,
+.IP \(bu 2
+your Coq theory can depend on other theories by specifying them in
+the \fB<coq_theories>\fP field. Dune will then pass to Coq the
+corresponding flags for everything to compile correctly [ \fB\-Q\fP
+]. As of today, we only support composition with libraries defined
+in the same scope (that is to say, under the same \fBdune\-project\fP
+domain). We will lift this restriction in the future. Note that
+composition with the Coq\(aqs standard library is supported, but in
+this case the \fBCoq\fP prefix will be made available in a qualified
+way. Since Coq\(aqs lang version \fB0.2\fP\&.
+.UNINDENT
+.SS Recursive qualification of modules
+.sp
+If you add:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(include_subdirs qualified)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+to a \fBdune\fP file, Dune will consider all the modules in the
+directory and its sub\-directories, adding a prefix to the module name in the usual
+Coq style for sub\-directories. For example, file \fBA/b/C.v\fP will be module
+\fBA.b.C\fP\&.
+.SS Limitations
+.INDENT 0.0
+.IP \(bu 2
+\fB\&.v\fP files always depend on the native version of Coq / plugins,
+.IP \(bu 2
+a \fBfoo.mlpack\fP file must the present in directories of locally
+defined plugins for things to work, this is a limitation of
+\fBcoqdep\fP, see the template at
+<\fI\%https://github.com/ejgallego/coq\-plugin\-template\fP>
+.UNINDENT
+.SS coq.pp
+.sp
+Coq plugin writers usually need to write \fB\&.mlg\fP files to extend Coq
+grammar. Such files are pre\-processed with \fIcoqpp\fP; to help plugin
+writers avoid boilerplate we provide a \fI(coqpp ...)\fP stanza:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(coq.pp (modules <mlg_list>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+which for each \fBg_mod\fP in \fB<mlg_list>\fP is equivalent to:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (targets g_mod.ml)
+ (deps (:mlg\-file g_mod.mlg))
+ (action (run coqpp %{mlg\-file})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS coq.extraction
+.sp
+Coq may be instructed to \fIextract\fP OCaml sources as part of the compilation
+process. This is done using the \fBcoq.extraction\fP stanza:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(coq.extraction
+ (prelude <name>)
+ (extracted_modules <names>)
+ <optional\-fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.IP \(bu 2
+\fB(prelude <name>)\fP refers to the Coq source that contains the extraction
+commands.
+.IP \(bu 2
+\fB(extraced_modules <names>)\fP is an exhaustive list of OCaml modules
+extracted.
+.IP \(bu 2
+\fB<optional\-fields>\fP are \fBflags\fP, \fBtheories\fP, and \fBlibraries\fP\&. All of
+these fields have the same meaning as in the \fBcoq.theory\fP stanza.
+.UNINDENT
+.sp
+The extracted sources can then be used in \fBexecutable\fP or \fBlibrary\fP stanzas
+as any other sources.
+.sp
+Note that the sources are extracted to the directory where the
+\fBprelude\fP file is; thus the common placement for the \fBOCaml\fP
+stanzas is in the same \fBdune\fP file. \fBwarning\fP using Coq\(aqs \fBCd\fP
+command to workaround problems with the output directory is not
+allowed when using extraction from Dune; moreover the \fBCd\fP command
+will be deprecated in Coq 8.12.
+.SS mdx (since 2.4)
+.sp
+MDX is a tool that helps you keep your markdown documentation up to date by
+checking that the code examples it contains are correct. When setting an MDX
+stanza, the checks carried out by MDX are automatically attached to the
+\fBruntest\fP alias of the stanza\(aqs directory.
+.sp
+See \fI\%MDX\(aqs repository\fP for more details.
+.sp
+You can define an MDX stanza to specify which files you want checked.
+.sp
+Note that this feature is still experimental and needs to be enabled in your
+\fBdune\-project\fP with the following \fBusing\fP stanza:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(using mdx 0.1)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The syntax is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(mdx <optional\-fields>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Where \fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(files <globs>)\fP are the files that you want MDX to check, described as a
+list of globs (see the Glob language specification ).
+It defaults to \fB*.md\fP\&.
+.IP \(bu 2
+\fB(packages <packages>)\fP are the local dune packages that your documentation
+code blocks depend on. I.e. if your documentation examples depend on a public
+executable or library defined from a local package, it has to be specified in
+the stanza.
+.IP \(bu 2
+\fB(preludes <files>)\fP are the prelude files you want to pass to MDX.
+See \fI\%MDX\(aqs documentation\fP for more
+details on preludes.
+.UNINDENT
+.SS plugin (since 2.8)
+.sp
+Plugins are a way to load ocaml libraries at runtime. The \fBplugin\fP stanza
+allows to declare the name of the plugin, in which sites it should be
+present, and which libraries it will load.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(plugin
+ (name <name>)
+ (libraries <libaries>)
+ (site (<package> <site name>))
+ (<optional\-fields>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(package <package>)\fP if there is more than one package defined in the
+current scope, this specifies during the installation of which package the
+plugin will be installed. A plugin can be installed by one package in the site
+of another package.
+.IP \(bu 2
+\fB(optional)\fP will not declare the plugin if the libraries are not available
+.UNINDENT
+.sp
+The loading of the plugin is done using the facilities generated by
+\fI\%generate_module (since 2.8)\fP
+.SS generate_module (since 2.8)
+.sp
+Dune proposes some facilities for dealing with sites in a program. The
+\fBgenerate_module\fP stanza will generate code for looking up the correct locations
+of the sites directories and for loading plugins. It works after installation
+with or without the relocation mode, inside dune rules, when using dune exec.
+For promotion it works only if the generated modules are only in the executable (or
+library statically linked) promoted; generated modules in plugins will not work.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(generate_module
+ (module <name>)
+ <facilities>)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The code of the module is generated in the directory with the given name. The
+code is populated according to the requested facilities.
+.sp
+The available \fB<facilities>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fBsourceroot\fP : adds in the generated module a value \fBval sourceroot: string option\fP
+which contains the value of \fB%{workspace_root}\fP if the code have been built
+locally. It could be used to keep configuration file of the tool locally when
+executed with \fBdune exec\fP or after promotion. The value is \fBNone\fP once it has been installed.
+.IP \(bu 2
+\fBrelocatable\fP : adds in the generated module a value \fBval relocatable: bool\fP
+which indicates if the binary has been installed in the relocatable mode
+.IP \(bu 2
+\fB(sites <package>)\fP : adds in the sub\-module \fISites\fP of the generated module a value
+\fBval <site>: string list\fP for each \fB<site>\fP of \fB<package>\fP\&. The
+identifier <site> is uncapitalized.
+.IP \(bu 2
+\fB(plugins (<package> <site>) ...)\fP: adds in the sub\-module \fBPlugins\fP of the
+generated module a sub\-module \fB<site>\fP with the following signature \fBS\fP\&. The
+identifier \fB<site>\fP is capitalized.
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+module type S = sig
+  val paths: string list
+  (** return the locations of the directory containing the plugins *)
+
+  val list: unit \-> string list
+  (** return the list of available plugins *)
+
+  val load_all: unit \-> unit
+  (** load all the plugins and their dependencies *)
+
+  val load: string \-> unit
+  (** load the specified plugin and its dependencies *)
+end
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The generated module as a dependency on the library \fBdune\-site\fP,
+and if the facilities \fB(plugins ...)\fP is used, it as a dependency on the library
+\fBdune\-site.plugins\fP\&. Those dependencies are not automatically added
+to the library or executable which use the module (cf. plugins).
+.SS dune\-workspace
+.sp
+By default, a workspace has only one build context named \fBdefault\fP which
+correspond to the environment in which \fBdune\fP is run. You can define more
+contexts by writing a \fBdune\-workspace\fP file.
+.sp
+You can point \fBdune\fP to an explicit \fBdune\-workspace\fP file with the
+\fB\-\-workspace\fP option. For instance it is good practice to write a
+\fBdune\-workspace.dev\fP in your project with all the version of OCaml your
+projects support. This way developers can tests that the code builds with all
+version of OCaml by simply running:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build \-\-workspace dune\-workspace.dev @all @runtest
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The \fBdune\-workspace\fP file uses the S\-expression syntax. This is what
+a typical \fBdune\-workspace\fP file looks like:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(context (opam (switch 4.02.3)))
+(context (opam (switch 4.03.0)))
+(context (opam (switch 4.04.0)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The rest of this section describe the stanzas available.
+.sp
+Note that an empty \fBdune\-workspace\fP file is interpreted the same as one
+containing exactly:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(context default)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This allows you to use an empty \fBdune\-workspace\fP file to mark the root of your
+project.
+.SS profile
+.sp
+The build profile can be selected in the \fBdune\-workspace\fP file by write a
+\fB(profile ...)\fP stanza. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(profile release)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note that the command line option \fB\-\-profile\fP has precedence over this stanza.
+.SS env
+.sp
+The \fBenv\fP stanza can be used to set the base environment for all contexts in
+this workspace. This environment has the lowest precedence of all other \fBenv\fP
+stanzas. The syntax for this stanza is the same dune\(aqs \fI\%env\fP stanza.
+.SS context
+.sp
+The \fB(context ...)\fP stanza declares a build context. The argument
+can be either \fBdefault\fP or \fB(default)\fP for the default build
+context or can be the description of an opam switch, as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(context (opam (switch <opam\-switch\-name>)
+               <optional\-fields>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(name <name>)\fP is the name of the subdirectory of \fB_build\fP
+where the artifacts for this build context will be stored.
+.IP \(bu 2
+\fB(root <opam\-root>)\fP is the opam root. By default it will take
+the opam root defined by the environment in which \fBdune\fP is
+run which is usually \fB~/.opam\fP\&.
+.IP \(bu 2
+\fB(merlin)\fP instructs dune to use this build context for
+merlin.
+.IP \(bu 2
+\fB(profile <profile>)\fP to set a different profile for a build
+context. This has precedence over the command line option
+\fB\-\-profile\fP\&.
+.IP \(bu 2
+\fB(env <env>)\fP to set the environment for a particular context. This is of
+higher precedence than the root \fBenv\fP stanza in the workspace file. This
+field the same options as the \fI\%env\fP stanza.
+.IP \(bu 2
+\fB(toolchain <findlib_toolchain>)\fP set findlib toolchain for the context.
+.IP \(bu 2
+\fB(host <host_context>)\fP choose a different context to build binaries that
+are meant to be executed on the host machine, such as preprocessors.
+.IP \(bu 2
+\fB(paths (<var1> <val1>) .. (<varN> <valN>))\fP allows setting the value of any
+\fBPATH\fP\-like variables in this context. If \fBPATH\fP itself is modified in
+this way, its value will be used to resolve binaries in the workspace,
+including finding the compiler and related tools. These variables will also be
+passed as part of the environment to any program launched by \fBdune\fP\&. For
+each variable, the value is specified using the ordered\-set\-language\&.
+Relative paths are interpreted with respect to the workspace root, see
+finding\-root\&.
+.IP \(bu 2
+\fB(fdo <target_exe>)\fP build this context with feedback\-direct
+optimizations. Requires \fI\%OCamlFDO\fP\&. \fB<target_exe>\fP is a
+path interpreted relative to the workspace root, see
+finding\-root\&. \fB<target_exe>\fP specifies which executable to
+optimize. Users should define a different context for each target
+executable built with FDO. The name of the context is derived
+automatically from the default name and \fB<target\-exe>\fP, unless
+explicitly specified using \fB(name ...)\fP field.  For example, if
+\fB<target_exe>\fP is \fIsrc/foo.exe\fP in a default context, then the
+name of the context is \fIdefault\-fdo\-foo\fP and the name of the file
+that contains execution counters is \fIsrc/fdo.exe.fdo\-profile\fP\&.  This
+feature is \fBexperimental\fP and no backwards compatibility is
+implied.
+.IP \(bu 2
+By default Dune builds and installs dynamically linked foreign
+archives (usually named \fBdll*.so\fP). It is possible to disable
+this by setting
+\fB(disable_dynamically_linked_foreign_archives true)\fP in the
+workspace file, in which case bytecode executables will be built
+with all foreign archives statically linked into the runtime system.
+.UNINDENT
+.sp
+Both \fB(default ...)\fP and \fB(opam ...)\fP accept a \fBtargets\fP field in order to
+setup cross compilation. See cross\-compilation for more
+information.
+.sp
+Merlin reads compilation artifacts and it can only read the compilation
+artifacts of a single context. Usually, you should use the artifacts from the
+\fBdefault\fP context, and if you have the \fB(context default)\fP stanza in your
+\fBdune\-workspace\fP file, that is the one dune will use.
+.sp
+For rare cases where this is not what you want, you can force dune to use a
+different build contexts for merlin by adding the field \fB(merlin)\fP to this
+context.
+.SH GENERAL CONCEPTS
+.SS Scopes
+.sp
+Any directory containing at least one \fB<package>.opam\fP file defines
+a scope. This scope is the sub\-tree starting from this directory,
+excluding any other scopes rooted in sub\-directories.
+.sp
+Typically, any given project will define a single scope. Libraries and
+executables that are not meant to be installed will be visible inside
+this scope only.
+.sp
+Because scopes are exclusive, if you wish to include the dependencies
+of the project you are currently working on into your workspace, you
+may copy them in a \fBvendor\fP directory, or any other name of your
+choice. Dune will look for them there rather than in the installed
+world and there will be no overlap between the various scopes.
+.SS Ordered set language
+.sp
+A few fields take as argument an ordered set and can be specified using a small
+DSL.
+.sp
+This DSL is interpreted by dune into an ordered set of strings using the
+following rules:
+.INDENT 0.0
+.IP \(bu 2
+\fB:standard\fP denotes the standard value of the field when it is absent
+.IP \(bu 2
+an atom not starting with a \fB:\fP is a singleton containing only this atom
+.IP \(bu 2
+a list of sets is the concatenation of its inner sets
+.IP \(bu 2
+\fB(<sets1> \e <sets2>)\fP is the set composed of elements of \fB<sets1>\fP that do
+not appear in \fB<sets2>\fP
+.UNINDENT
+.sp
+In addition, some fields support the inclusion of an external file using the
+syntax \fB(:include <filename>)\fP\&. This is useful for instance when you need to
+run a script to figure out some compilation flags. \fB<filename>\fP is expected to
+contain a single S\-expression and cannot contain \fB(:include ...)\fP forms.
+.sp
+Note that inside an ordered set, the first element of a list cannot be
+an atom except if it starts with \fI\-\fP or \fI:\fP\&. The reason for this is
+that we are planning to add simple programmatic features in the
+futures so that one may write:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(flags (if (>= %{ocaml_version} 4.06) ...))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This restriction will allow to add this feature without introducing a
+breaking changes. If you want to write a list where the first element
+doesn\(aqt start by \fI\-\fP, you can simply quote it: \fB("x" y z)\fP\&.
+.sp
+Most fields using the ordered set language also support \fI\%Variables\fP\&.
+Variables are expanded after the set language is interpreted.
+.SS Boolean language
+.sp
+The boolean language allows the user to define simple boolean expressions that
+dune can evaluate. Here\(aqs a semi formal specification of the language:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+op := \(aq=\(aq | \(aq<\(aq | \(aq>\(aq | \(aq<>\(aq | \(aq>=\(aq | \(aq<=\(aq
+
+expr := (and <expr>+)
+      | (or <expr>+)
+      | (<op> <template> <template>)
+      | <template>
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+After an expression is evaluated, it must be exactly the string \fBtrue\fP or
+\fBfalse\fP to be considered as a boolean. Any other value will be treated as an
+error.
+.sp
+Here\(aqs a simple example of a condition that expresses running on OSX and having
+an flambda compiler with the help of variable expansion:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(and %{ocamlc\-config:flambda} (= %{ocamlc\-config:system} macosx))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Predicate language
+.sp
+The predicate language allows the user to define simple predicates
+(boolean\-valued functions) that dune can evaluate. Here is a semi formal
+specification of the language:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+pred := (and <pred> <pred>)
+      | (or <pred> <pred>)
+      | (not <pred>)
+      | :standard
+      | <element>
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The exact meaning of \fB:standard\fP and the nature of \fB<element>\fP depends on
+the context. For example, in the case of the dune\-subdirs, an
+\fB<element>\fP corresponds to file glob patterns. Another example is the user
+action \fI\%(with\-accepted\-exit\-codes ...)\fP, where an \fB<element>\fP
+corresponds to a literal integer.
+.SS Variables
+.sp
+Some fields can contains variables that are expanded by dune.
+The syntax of variables is as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+%{var}
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+or, for more complex forms that take an argument:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+%{fun:arg}
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+In order to write a plain \fB%{\fP, you need to write \fB\e%{\fP in a
+string.
+.sp
+Dune supports the following variables:
+.INDENT 0.0
+.IP \(bu 2
+\fBproject_root\fP is the root of the current project. It is typically the root
+of your project and as long as you have a \fBdune\-project\fP file there,
+\fBproject_root\fP is independent of the workspace configuration
+.IP \(bu 2
+\fBworkspace_root\fP is the root of the current workspace. Note that
+the value of \fBworkspace_root\fP is not constant and depends on
+whether your project is vendored or not
+.IP \(bu 2
+\fBCC\fP is the C compiler command line (list made of the compiler
+name followed by its flags) that was used to compile OCaml in the
+current build context
+.IP \(bu 2
+\fBCXX\fP is the C++ compiler command line being used in the
+current build context
+.IP \(bu 2
+\fBocaml_bin\fP is the path where \fBocamlc\fP lives
+.IP \(bu 2
+\fBocaml\fP is the \fBocaml\fP binary
+.IP \(bu 2
+\fBocamlc\fP is the \fBocamlc\fP binary
+.IP \(bu 2
+\fBocamlopt\fP is the \fBocamlopt\fP binary
+.IP \(bu 2
+\fBocaml_version\fP is the version of the compiler used in the
+current build context
+.IP \(bu 2
+\fBocaml_where\fP is the output of \fBocamlc \-where\fP
+.IP \(bu 2
+\fBarch_sixtyfour\fP is \fBtrue\fP if using a compiler targeting a
+64 bit architecture and \fBfalse\fP otherwise
+.IP \(bu 2
+\fBnull\fP is \fB/dev/null\fP on Unix or \fBnul\fP on Windows
+.IP \(bu 2
+\fBext_obj\fP, \fBext_asm\fP, \fBext_lib\fP, \fBext_dll\fP and \fBext_exe\fP
+are the file extension used for various artifacts
+.IP \(bu 2
+\fBext_plugin\fP is \fB\&.cmxs\fP if \fBnatdynlink\fP is supported and
+\fB\&.cma\fP otherwise.
+.IP \(bu 2
+\fBocaml\-config:v\fP for every variable \fBv\fP in the output of
+\fBocamlc \-config\fP\&. Note that dune processes the output
+of \fBocamlc \-config\fP in order to make it a bit more stable across
+versions, so the exact set of variables accessible this way might
+not be exactly the same as what you can see in the output of
+\fBocamlc \-config\fP\&. In particular, variables added in new versions
+of OCaml needs to be registered in dune before they can be used
+.IP \(bu 2
+\fBprofile\fP the profile selected via \fB\-\-profile\fP
+.IP \(bu 2
+\fBcontext_name\fP the name of the context (\fBdefault\fP or defined in the
+workspace file)
+.IP \(bu 2
+\fBos_type\fP is the type of the OS the build is targeting. This is
+the same as \fBocaml\-config:os_type\fP
+.IP \(bu 2
+\fBarchitecture\fP is the type of the architecture the build is targeting. This
+is the same as \fBocaml\-config:architecture\fP
+.IP \(bu 2
+\fBmodel\fP is the type of the CPU the build is targeting. This is
+the same as \fBocaml\-config:model\fP
+.IP \(bu 2
+\fBsystem\fP is the name of the OS the build is targeting. This is the same as
+\fBocaml\-config:system\fP
+.IP \(bu 2
+\fBignoring_promoted_rule\fP is \fBtrue\fP if
+\fB\-\-ignore\-promoted\-rules\fP was passed on the command line and
+\fBfalse\fP otherwise
+.IP \(bu 2
+\fB<ext>:<path>\fP where \fB<ext>\fP is one of \fBcmo\fP, \fBcmi\fP, \fBcma\fP,
+\fBcmx\fP, or \fBcmxa\fP\&. See variables\-for\-artifacts\&.
+.UNINDENT
+.sp
+In addition, \fB(action ...)\fP fields support the following special variables:
+.INDENT 0.0
+.IP \(bu 2
+\fBtarget\fP expands to the one target
+.IP \(bu 2
+\fBtargets\fP expands to the list of target
+.IP \(bu 2
+\fBdeps\fP expands to the list of dependencies
+.IP \(bu 2
+\fB^\fP expands to the list of dependencies, separated by spaces
+.IP \(bu 2
+\fBdep:<path>\fP expands to \fB<path>\fP (and adds \fB<path>\fP as a dependency of
+the action)
+.IP \(bu 2
+\fBexe:<path>\fP is the same as \fB<path>\fP, except when cross\-compiling, in
+which case it will expand to \fB<path>\fP from the host build context
+.IP \(bu 2
+\fBbin:<program>\fP expands to a path to \fBprogram\fP\&. If \fBprogram\fP
+is installed by a package in the workspace (see install stanzas),
+the locally built binary will be used, otherwise it will be searched
+in the \fBPATH\fP of the current build context. Note that \fB(run
+%{bin:program} ...)\fP and \fB(run program ...)\fP behave in the same
+way. \fB%{bin:...}\fP is only necessary when you are using \fB(bash
+\&...)\fP or \fB(system ...)\fP
+.IP \(bu 2
+\fBlib:<public\-library\-name>:<file>\fP expands to the installation path of
+the file \fB<file>\fP in the library \fB<public\-library\-name>\fP\&. If
+\fB<public\-library\-name>\fP is available in the current workspace, the local
+file will be used, otherwise the one from the installed world will be used.
+.IP \(bu 2
+\fBlib\-private:<library\-name>:<file>\fP expands to the build path of the file
+\fB<file>\fP in the library \fB<library\-name>\fP\&. Both public and private library
+names are allowed as long as they refer to libraries within the same project.
+.IP \(bu 2
+\fBlibexec:<public\-library\-name>:<file>\fP is the same as \fBlib:...\fP except
+when cross\-compiling, in which case it will expand to the file from the host
+build context.
+.IP \(bu 2
+\fBlibexec\-private:<library\-name>:<file>\fP is the same as \fBlib\-private:...\fP
+except when cross\-compiling, in which case it will expand to the file from the
+host build context.
+.IP \(bu 2
+\fBlib\-available:<library\-name>\fP expands to \fBtrue\fP or \fBfalse\fP depending on
+whether the library is available or not. A library is available iff at least
+one of the following conditions holds:
+.INDENT 2.0
+.IP \(bu 2
+it is part the installed worlds
+.IP \(bu 2
+it is available locally and is not optional
+.IP \(bu 2
+it is available locally and all its library dependencies are
+available
+.UNINDENT
+.IP \(bu 2
+\fBversion:<package>\fP expands to the version of the given
+package. Note that this is only supported for packages that are
+being defined in the current scope. How dune determines the version
+of a package is described here
+.IP \(bu 2
+\fBread:<path>\fP expands to the contents of the given file
+.IP \(bu 2
+\fBread\-lines:<path>\fP expands to the list of lines in the given
+file
+.IP \(bu 2
+\fBread\-strings:<path>\fP expands to the list of lines in the given
+file, unescaped using OCaml lexical convention
+.UNINDENT
+.sp
+The \fB%{<kind>:...}\fP forms are what allows you to write custom rules that work
+transparently whether things are installed or not.
+.sp
+Note that aliases are ignored by \fB%{deps}\fP
+.sp
+The intent of this last form is to reliably read a list of strings
+generated by an OCaml program via:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+List.iter (fun s \-> print_string (String.escaped s)) l
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.IP 1. 3
+Expansion of lists
+.UNINDENT
+.sp
+Forms that expands to list of items, such as \fB%{cc}\fP, \fB%{deps}\fP,
+\fB%{targets}\fP or \fB%{read\-lines:...}\fP, are suitable to be used in, say,
+\fB(run <prog> <arguments>)\fP\&.  For instance in:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(run foo %{deps})
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+if there are two dependencies \fBa\fP and \fBb\fP, the produced command
+will be equivalent to the shell command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ foo "a" "b"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+If you want the two dependencies to be passed as a single argument,
+you have to quote the variable as in:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(run foo "%{deps}")
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+which is equivalent to the following shell command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ foo "a b"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+(the items of the list are concatenated with space).
+Note that, since \fB%{deps}\fP is a list of items, the first one may be
+used as a program name, for instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (targets result.txt)
+ (deps    foo.exe (glob_files *.txt))
+ (action  (run %{deps})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Here is another example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target foo.exe)
+ (deps   foo.c)
+ (action (run %{cc} \-o %{target} %{deps} \-lfoolib)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Library dependencies
+.sp
+Dependencies on libraries are specified using \fB(libraries ...)\fP fields in
+\fBlibrary\fP and \fBexecutables\fP stanzas.
+.sp
+For libraries defined in the current scope, you can use either the real name or
+the public name. For libraries that are part of the installed world, or for
+libraries that are part of the current workspace but in another scope, you need
+to use the public name. For instance: \fB(libraries base re)\fP\&.
+.sp
+When resolving libraries, libraries that are part of the workspace are always
+preferred to ones that are part of the installed world.
+.SS Alternative dependencies
+.sp
+In addition to direct dependencies you can specify alternative dependencies.
+This is described in the \fI\%Alternative dependencies\fP
+section
+.sp
+It is sometimes the case that one wants to not depend on a specific library, but
+instead on whatever is already installed. For instance to use a different
+backend depending on the target.
+.sp
+Dune allows this by using a \fB(select ... from ...)\fP form inside the list
+of library dependencies.
+.sp
+Select forms are specified as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(select <target\-filename> from
+ (<literals> \-> <filename>)
+ (<literals> \-> <filename>)
+ ...)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB<literals>\fP are lists of literals, where each literal is one of:
+.INDENT 0.0
+.IP \(bu 2
+\fB<library\-name>\fP, which will evaluate to true if \fB<library\-name>\fP is
+available, either in the workspace or in the installed world
+.IP \(bu 2
+\fB!<library\-name>\fP, which will evaluate to true if \fB<library\-name>\fP is not
+available in the workspace or in the installed world
+.UNINDENT
+.sp
+When evaluating a select form, dune will create \fB<target\-filename>\fP by
+copying the file given by the first \fB(<literals> \-> <filename>)\fP case where
+all the literals evaluate to true. It is an error if none of the clauses are
+selectable. You can add a fallback by adding a clause of the form \fB(\->
+<file>)\fP at the end of the list.
+.SS Re\-exported dependencies
+.sp
+A dependency \fBfoo\fP may be marked as always \fIre\-exported\fP using the
+following syntax:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(re_export foo)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name bar)
+ (libraries (re_export foo)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This states that this library explicitly re\-exports the interface of
+\fBfoo\fP\&.  Concretely, when something depends on \fBbar\fP it will also
+be able to see \fBfoo\fP independently of whether implicit
+transitive dependencies are allowed or
+not. When they are allowed, which is the default, all transitive
+dependencies are visible whether they are marked as re\-exported or
+not.
+.SS Preprocessing specification
+.sp
+Dune accepts three kinds of preprocessing:
+.INDENT 0.0
+.IP \(bu 2
+\fBno_preprocessing\fP, meaning that files are given as it to the compiler, this
+is the default
+.IP \(bu 2
+\fB(action <action>)\fP to preprocess files using the given action
+.IP \(bu 2
+\fB(pps <ppx\-rewriters\-and\-flags>)\fP to preprocess files using the given list
+of ppx rewriters
+.IP \(bu 2
+\fB(staged_pps <ppx\-rewriters\-and\-flags>)\fP is similar to \fB(pps ...)\fP
+but behave slightly differently and is needed for certain ppx rewriters
+(see below for details)
+.IP \(bu 2
+\fBfuture_syntax\fP is a special value that brings some of the newer
+OCaml syntaxes to older compilers. See \fI\%Future syntax\fP for more details
+.UNINDENT
+.sp
+Dune normally assumes that the compilation pipeline is sequenced as
+follow:
+.INDENT 0.0
+.IP \(bu 2
+code generation (including preprocessing)
+.IP \(bu 2
+dependency analysis
+.IP \(bu 2
+compilation
+.UNINDENT
+.sp
+Dune uses this fact to optimize the pipeline and in particular share
+the result of code generation and preprocessing between the dependency
+analysis and compilation phases. However, some specific code
+generators or preprocessors require feedback from the compilation
+phase. As a result they must be applied in stages as follows:
+.INDENT 0.0
+.IP \(bu 2
+first stage of code generation
+.IP \(bu 2
+dependency analysis
+.IP \(bu 2
+second step of code generation in parallel with compilation
+.UNINDENT
+.sp
+This is the case for ppx rewriters using the OCaml typer for
+instance. When using such ppx rewriters, you must use \fBstaged_pps\fP
+instead of \fBpps\fP in order to force Dune to use the second pipeline,
+which is slower but necessary in this case.
+.SS Preprocessing with actions
+.sp
+\fB<action>\fP uses the same DSL as described in the \fI\%User actions\fP
+section, and for the same reason given in that section, it will be
+executed from the root of the current build context. It is expected to
+be an action that reads the file given as only dependency named
+\fBinput\-file\fP and outputs the preprocessed file on its standard output.
+.sp
+More precisely, \fB(preprocess (action <action>))\fP acts as if
+you had setup a rule for every file of the form:
+.INDENT 0.0
+.INDENT 3.5
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target file.pp.ml)
+ (deps   file.ml)
+ (action (with\-stdout\-to %{target}
+          (chdir %{workspace_root} <action>))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.sp
+The equivalent of a \fB\-pp <command>\fP option passed to the OCaml compiler is
+\fB(system "<command> %{input\-file}")\fP\&.
+.SS Preprocessing with ppx rewriters
+.sp
+\fB<ppx\-rewriters\-and\-flags>\fP is expected to be a sequence where each
+element is either a command line flag if starting with a \fB\-\fP or the
+name of a library.  If you want to pass command line flags that do not
+start with a \fB\-\fP, you can separate library names from flags using
+\fB\-\-\fP\&. So for instance from the following \fBpreprocess\fP field:
+.INDENT 0.0
+.INDENT 3.5
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(preprocess (pps ppx1 \-foo ppx2 \-\- \-bar 42))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.sp
+The list of libraries will be \fBppx1\fP and \fBppx2\fP and the command line
+arguments will be: \fB\-foo \-bar 42\fP\&.
+.sp
+Libraries listed here should be libraries implementing an OCaml AST rewriter and
+registering themselves using the \fI\%ocaml\-migrate\-parsetree.driver API\fP\&.
+.sp
+Dune will build a single executable by linking all these libraries and their
+dependencies. Note that it is important that all these libraries are linked with
+\fB\-linkall\fP\&. Dune automatically uses \fB\-linkall\fP when the \fB(kind ...)\fP
+field is set to \fBppx_rewriter\fP or \fBppx_deriver\fP\&.
+.SS Per module preprocessing specification
+.sp
+By default a preprocessing specification will apply to all modules in the
+library/set of executables. It is possible to select the preprocessing on a
+module\-by\-module basis by using the following syntax:
+.INDENT 0.0
+.INDENT 3.5
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(preprocess (per_module
+             (<spec1> <module\-list1>)
+             (<spec2> <module\-list2>)
+             ...))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.sp
+Where \fB<spec1>\fP, \fB<spec2>\fP, ... are preprocessing specifications
+and \fB<module\-list1>\fP, \fB<module\-list2>\fP, ... are list of module
+names.
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(preprocess (per_module
+             (((action (run ./pp.sh X=1 %{input\-file})) foo bar))
+             (((action (run ./pp.sh X=2 %{input\-file})) baz))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.SS Future syntax
+.sp
+The \fBfuture_syntax\fP preprocessing specification is equivalent to
+\fBno_preprocessing\fP when using one of the most recent versions of the
+compiler. When using an older one, it is a shim preprocessor that
+backports some of the newer syntax elements. This allows you to use some of
+the new OCaml features while keeping compatibility with older
+compilers.
+.sp
+One example of supported syntax is the custom let\-syntax that was
+introduced in 4.08, allowing the user to define custom let operators.
+.sp
+Note that this feature is implemented by the third\-party
+\fIocaml\-syntax\-shims project
+<https://github.com/ocaml\-ppx/ocaml\-syntax\-shims>\fP, so if you use this
+feature you must also declare a dependency on this package.
+.SS Preprocessor dependencies
+.sp
+If your preprocessor needs extra dependencies you should use the
+\fBpreprocessor_deps\fP field available in the \fBlibrary\fP, \fBexecutable\fP and
+\fBexecutables\fP stanzas.
+.SS Dependency specification
+.sp
+Dependencies in \fBdune\fP files can be specified using one of the following:
+.INDENT 0.0
+.IP \(bu 2
+\fB(:name <dependencies>)\fP will bind the list of dependencies to the
+\fBname\fP variable. This variable will be available as \fB%{name}\fP in actions.
+.IP \(bu 2
+\fB(file <filename>)\fP or simply \fB<filename>\fP: depend on this file
+.IP \(bu 2
+\fB(alias <alias\-name>)\fP: depend on the construction of this alias, for
+instance: \fB(alias src/runtest)\fP
+.IP \(bu 2
+\fB(alias_rec <alias\-name>)\fP: depend on the construction of this
+alias recursively in all children directories wherever it is
+defined. For instance: \fB(alias_rec src/runtest)\fP might depend on
+\fB(alias src/runtest)\fP, \fB(alias src/foo/bar/runtest)\fP, ...
+.IP \(bu 2
+\fB(glob_files <glob>)\fP: depend on all files matched by \fB<glob>\fP, see the
+\fI\%glob\fP for details
+.IP \(bu 2
+\fB(source_tree <dir>)\fP: depend on all source files in the subtree with root
+\fB<dir>\fP
+.IP \(bu 2
+\fB(universe)\fP: depend on everything in the universe. This is for
+cases where dependencies are too hard to specify. Note that dune
+will not be able to cache the result of actions that depend on the
+universe. In any case, this is only for dependencies in the
+installed world, you must still specify all dependencies that come
+from the workspace.
+.IP \(bu 2
+\fB(package <pkg>)\fP depend on all files installed by \fB<package>\fP, as well
+as on the transitive package dependencies of \fB<package>\fP\&. This can be used
+to test a command against the files that will be installed
+.IP \(bu 2
+\fB(env_var <var>)\fP: depend on the value of the environment variable \fB<var>\fP\&.
+If this variable becomes set, becomes unset, or changes value, the target
+will be rebuilt.
+.IP \(bu 2
+\fB(sandbox <config>)\fP: require a particular sandboxing configuration.
+\fB<config>\fP can be one (or many) of:
+.INDENT 2.0
+.IP \(bu 2
+\fBalways\fP: the action requires a clean environment.
+.IP \(bu 2
+\fBnone\fP: the action must run in the build directory.
+.IP \(bu 2
+\fBpreserve_file_kind\fP: the action needs the files it reads to look
+like normal files (so dune won\(aqt use symlinks for sandboxing)
+.UNINDENT
+.UNINDENT
+.sp
+In all these cases, the argument supports \fI\%Variables\fP\&.
+.SS Named Dependencies
+.sp
+dune allows a user to organize dependency lists by naming them. The user is
+allowed to assign a group of dependencies a name that can later be referred to
+in actions (like the \fB%{deps}\fP, \fB%{target}\fP and \fB%{targets}\fP built in variables).
+.sp
+One instance where this is useful is for naming globs. Here\(aqs an
+example of an imaginary bundle command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target archive.tar)
+ (deps
+  index.html
+  (:css (glob_files *.css))
+  (:js foo.js bar.js)
+  (:img (glob_files *.png) (glob_files *.jpg)))
+ (action
+  (run %{bin:bundle} index.html \-css %{css} \-js %{js} \-img %{img} \-o %{target})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note that such named dependency list can also include unnamed
+dependencies (like \fBindex.html\fP in the example above). Also, such
+user defined names will shadow built in variables. So
+\fB(:workspace_root x)\fP will shadow the built in \fB%{workspace_root}\fP
+variable.
+.SS Glob
+.sp
+You can use globs to declare dependencies on a set of files. Note that globs
+will match files that exist in the source tree as well as buildable targets, so
+for instance you can depend on \fB*.cmi\fP\&.
+.sp
+Currently dune only supports globbing files in a single directory. And in
+particular the glob is interpreted as follows:
+.INDENT 0.0
+.IP \(bu 2
+anything before the last \fB/\fP is taken as a literal path
+.IP \(bu 2
+anything after the last \fB/\fP, or everything if the glob contains no \fB/\fP, is
+interpreted using the glob syntax
+.UNINDENT
+.sp
+The glob syntax is interpreted as follows:
+.INDENT 0.0
+.IP \(bu 2
+\fB\e<char>\fP matches exactly \fB<char>\fP, even if it is a special character
+(\fB*\fP, \fB?\fP, ...)
+.IP \(bu 2
+\fB*\fP matches any sequence of characters, except if it comes first in which
+case it matches any character that is not \fB\&.\fP followed by anything
+.IP \(bu 2
+\fB**\fP matches any character that is not \fB\&.\fP followed by anything, except if
+it comes first in which case it matches anything
+.IP \(bu 2
+\fB?\fP matches any single character
+.IP \(bu 2
+\fB[<set>]\fP matches any character that is part of \fB<set>\fP
+.IP \(bu 2
+\fB[!<set>]\fP matches any character that is not part of \fB<set>\fP
+.IP \(bu 2
+\fB{<glob1>,<glob2>,...,<globn>}\fP matches any string that is matched by one of
+\fB<glob1>\fP, \fB<glob2>\fP, ...
+.UNINDENT
+.SS OCaml flags
+.sp
+In \fBlibrary\fP, \fBexecutable\fP, \fBexecutables\fP and \fBenv\fP stanzas,
+you can specify OCaml compilation flags using the following fields:
+.INDENT 0.0
+.IP \(bu 2
+\fB(flags <flags>)\fP to specify flags passed to both \fBocamlc\fP and
+\fBocamlopt\fP
+.IP \(bu 2
+\fB(ocamlc_flags <flags>)\fP to specify flags passed to \fBocamlc\fP only
+.IP \(bu 2
+\fB(ocamlopt_flags <flags>)\fP to specify flags passed to \fBocamlopt\fP only
+.UNINDENT
+.sp
+For all these fields, \fB<flags>\fP is specified in the \fI\%Ordered set language\fP\&.
+These fields all support \fB(:include ...)\fP forms.
+.sp
+The default value for \fB(flags ...)\fP is taken from the environment,
+as a result it is recommended to write \fB(flags ...)\fP fields as
+follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(flags (:standard <my options>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS User actions
+.sp
+\fB(action ...)\fP fields describe user actions.
+.sp
+User actions are always run from the same subdirectory of the current build
+context as the dune file they are defined in. So for instance an action defined
+in \fBsrc/foo/dune\fP will be run from \fB$build/<context>/src/foo\fP\&.
+.sp
+The argument of \fB(action ...)\fP fields is a small DSL that is interpreted by
+dune directly and doesn\(aqt require an external shell. All atoms in the DSL
+support \fI\%Variables\fP\&. Moreover, you don\(aqt need to specify dependencies
+explicitly for the special \fB%{<kind>:...}\fP forms, these are recognized and
+automatically handled by dune.
+.sp
+The DSL is currently quite limited, so if you want to do something complicated
+it is recommended to write a small OCaml program and use the DSL to invoke it.
+You can use \fI\%shexp\fP to write portable
+scripts or configurator for configuration related tasks. You can also
+use \fI\%Sandboxing\fP to express program dependencies directly in the
+source code.
+.sp
+The following constructions are available:
+.INDENT 0.0
+.IP \(bu 2
+\fB(run <prog> <args>)\fP to execute a program. \fB<prog>\fP is resolved
+locally if it is available in the current workspace, otherwise it is
+resolved using the \fBPATH\fP
+.IP \(bu 2
+\fB(dynamic\-run <prog> <args>)\fP to execute a program that was linked
+against \fBdune\-action\-plugin\fP library. \fB<prog>\fP is resolved in
+the same way as in \fBrun\fP
+.IP \(bu 2
+\fB(chdir <dir> <DSL>)\fP to change the current directory
+.IP \(bu 2
+\fB(setenv <var> <value> <DSL>)\fP to set an environment variable
+.IP \(bu 2
+\fB(with\-<outputs>\-to <file> <DSL>)\fP to redirect the output to a file, where
+\fB<outputs>\fP is one of: \fBstdout\fP, \fBstderr\fP or \fBoutputs\fP (for both
+\fBstdout\fP and \fBstderr\fP)
+.IP \(bu 2
+\fB(ignore\-<outputs> <DSL>)\fP to ignore the output, where
+\fB<outputs>\fP is one of: \fBstdout\fP, \fBstderr\fP or \fBoutputs\fP
+.IP \(bu 2
+\fB(with\-stdin\-from <file> <DSL>)\fP to redirect the input from a file
+.IP \(bu 2
+\fB(with\-accepted\-exit\-codes <pred> <DSL>)\fP specifies the list of expected exit codes
+for the programs executed in \fB<DSL>\fP\&. \fB<pred>\fP is a predicate on integer
+values, and is specified using the \fI\%Predicate language\fP\&. \fB<DSL>\fP can only
+contain nested occurrences of \fBrun\fP, \fBbash\fP, \fBsystem\fP, \fBchdir\fP,
+\fBsetenv\fP, \fBignore\-<outputs>\fP, \fBwith\-stdin\-from\fP and
+\fBwith\-<outputs>\-to\fP\&. This action is available since dune 2.0.
+.IP \(bu 2
+\fB(progn <DSL>...)\fP to execute several commands in sequence
+.IP \(bu 2
+\fB(echo <string>)\fP to output a string on stdout
+.IP \(bu 2
+\fB(write\-file <file> <string>)\fP writes \fB<string>\fP to \fB<file>\fP
+.IP \(bu 2
+\fB(cat <file>)\fP to print the contents of a file to stdout
+.IP \(bu 2
+\fB(copy <src> <dst>)\fP to copy a file
+.IP \(bu 2
+\fB(copy# <src> <dst>)\fP to copy a file and add a line directive at
+the beginning
+.IP \(bu 2
+\fB(system <cmd>)\fP to execute a command using the system shell: \fBsh\fP on Unix
+and \fBcmd\fP on Windows
+.IP \(bu 2
+\fB(bash <cmd>)\fP to execute a command using \fB/bin/bash\fP\&. This is obviously
+not very portable
+.IP \(bu 2
+\fB(diff <file1> <file2>)\fP is similar to \fB(run diff <file1>
+<file2>)\fP but is better and allows promotion.  See \fI\%Diffing and
+promotion\fP for more details
+.IP \(bu 2
+\fB(diff? <file1> <file2>)\fP is similar to \fB(diff <file1>
+<file2>)\fP except that \fB<file2>\fP should be produced by a part of the
+same action rather than be a dependency, is optional and will
+be consumed by \fBdiff?\fP\&.
+.IP \(bu 2
+\fB(cmp <file1> <file2>)\fP is similar to \fB(run cmp <file1>
+<file2>)\fP but allows promotion.  See \fI\%Diffing and promotion\fP for
+more details
+.IP \(bu 2
+\fB(no\-infer <DSL>)\fP to perform an action without inference of dependencies
+and targets. This is useful if you are generating dependencies in a way
+that Dune doesn\(aqt know about, for instance by calling an external build system.
+.IP \(bu 2
+\fB(pipe\-<outputs> <DSL> <DSL> <DSL>...)\fP to execute several actions (at least two)
+in sequence, filtering the \fB<outputs>\fP of the first command through the other
+command, piping the standard output of each one into the input of the next.
+This action is available since dune 2.7.
+.UNINDENT
+.sp
+As mentioned \fBcopy#\fP inserts a line directive at the beginning of
+the destination file. More precisely, it inserts the following line:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+# 1 "<source file name>"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Most languages recognize such lines and update their current location,
+in order to report errors in the original file rather than the
+copy. This is important as the copy exists only under the \fB_build\fP
+directory and in order for editors to jump to errors when parsing the
+output of the build system, errors must point to files that exist in
+the source tree. In the beta versions of dune, \fBcopy#\fP was
+called \fBcopy\-and\-add\-line\-directive\fP\&. However, most of time one
+wants this behavior rather than a bare copy, so it was renamed to
+something shorter.
+.sp
+Note: expansion of the special \fB%{<kind>:...}\fP is done relative to the current
+working directory of the part of the DSL being executed. So for instance if you
+have this action in a \fBsrc/foo/dune\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(action (chdir ../../.. (echo %{dep:dune})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Then \fB%{dep:dune}\fP will expand to \fBsrc/foo/dune\fP\&. When you run various
+tools, they often use the filename given on the command line in error messages.
+As a result, if you execute the command from the original directory, it will
+only see the basename.
+.sp
+To understand why this is important, let\(aqs consider this dune file living in
+\fBsrc/foo\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target blah.ml)
+ (deps   blah.mll)
+ (action (run ocamllex \-o %{target} %{deps})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Here the command that will be executed is:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+ocamllex \-o blah.ml blah.mll
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And it will be executed in \fB_build/<context>/src/foo\fP\&. As a result, if there
+is an error in the generated \fBblah.ml\fP file it will be reported as:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+File "blah.ml", line 42, characters 5\-10:
+Error: ...
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Which can be a problem as you editor might think that \fBblah.ml\fP is at the root
+of your project. What you should write instead is:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (target blah.ml)
+ (deps   blah.mll)
+ (action (chdir %{workspace_root} (run ocamllex \-o %{target} %{deps}))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Sandboxing
+.sp
+The user actions that run external commands (\fBrun\fP, \fBbash\fP, \fBsystem\fP)
+are opaque to dune, so dune has to rely on manual specification of dependencies
+and targets. One problem with manual specification is that it\(aqs error\-prone.
+It\(aqs often hard to know in advance what files the command will read.
+And knowing a correct set of dependencies is very important for build
+reproducibility and incremental build correctness.
+.sp
+To help with this problem dune supports sandboxing.
+An idealized view of sandboxing is that it runs the action in an environment
+where it can\(aqt access anything except for its declared dependencies.
+.sp
+In practice we have to make compromises and have some trade\-offs between
+simplicity, information leakage, performance and portability.
+.sp
+The way sandboxing is currently implemented is that for each sandboxed action
+we build a separate directory tree (sandbox directory) that mirrors the build
+directory, filtering it to only contain the files that were declared as
+dependencies. Then we run the action in that directory, and then we copy
+the targets back to the build directory.
+.sp
+You can configure dune to use sandboxing modes \fBsymlink\fP or \fBcopy\fP, which
+determines how the individual files are populated (they will be symlinked or
+copied into the sandbox directory).
+.sp
+This approach is very simple and portable, but that comes with
+certain limitations:
+.INDENT 0.0
+.IP \(bu 2
+The actions in the sandbox can use absolute paths to refer to anywhere outside
+the sandbox. This means that only dependencies on relative paths in the build
+tree can be enforced/detected by sandboxing.
+.IP \(bu 2
+The sandboxed actions still run with full permissions of dune itself so
+sandboxing is not a security feature. It won\(aqt prevent network access either.
+.IP \(bu 2
+We don\(aqt erase the environment variables of the sandboxed
+commands. This is something we want to change.
+.IP \(bu 2
+Performance impact is usually small, but it can get noticeable for
+fast actions with very large sets of dependencies.
+.UNINDENT
+.SS Per\-action sandboxing configuration
+.sp
+Some actions may rely on sandboxing to work correctly.
+For example an action may need the input directory to contain nothing
+except the input files, or the action might create temporary files that
+break other build actions.
+.sp
+Some other actions may refuse to work with sandboxing, for example
+if they rely on absolute path to the build directory staying fixed,
+or if they deliberately use some files without declaring dependencies
+(this is usually a very bad idea, by the way).
+.sp
+Generally it\(aqs better to improve the action so it works with or without
+sandboxing (especially with), but sometimes you just can\(aqt do that.
+.sp
+Things like this can be described using the "sandbox" field in the dependency
+specification language (see \fI\%Dependency specification\fP).
+.SS Global sandboxing configuration
+.sp
+Dune always respects per\-action sandboxing specification.
+You can configure it globally to prefer a certain sandboxing mode if
+the action allows it.
+.sp
+This is controlled by:
+.INDENT 0.0
+.IP \(bu 2
+\fBdune \-\-sandbox <...>\fP cli flag (see \fBman dune\-build\fP)
+.IP \(bu 2
+\fBDUNE_SANDBOX\fP environment (see \fBman dune\-build\fP)
+.IP \(bu 2
+\fB(sandboxing_preference ..)\fP field in the dune config (see \fBman dune\-config\fP)
+.UNINDENT
+.SS Locks
+.sp
+Given two rules that are independent, dune will assume that there
+associated action can be run concurrently. Two rules are considered
+independent if none of them depend on the other, either directly or
+through a chain of dependencies. This basic assumption allows dune to
+parallelize the build.
+.sp
+However, it is sometimes the case that two independent rules cannot be
+executed concurrently. For instance this can happen for more
+complicated tests. In order to prevent dune from running the
+actions at the same time, you can specify that both actions take the
+same lock:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (alias  runtest)
+ (deps   foo)
+ (locks  m)
+ (action (run test.exe %{deps})))
+
+(alias
+ (rule   runtest)
+ (deps   bar)
+ (locks  m)
+ (action (run test.exe %{deps})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Dune will make sure that the executions of \fBtest.exe foo\fP and
+\fBtest.exe bar\fP are serialized.
+.sp
+Although they don\(aqt live in the filesystem, lock names are interpreted as file
+names. So for instance \fB(with\-lock m ...)\fP in \fBsrc/dune\fP and \fB(with\-lock
+\&../src/m)\fP in \fBtest/dune\fP refer to the same lock.
+.sp
+Note also that locks are per build context. So if your workspace has two build
+contexts setup, the same rule might still be executed concurrently between the
+two build contexts. If you want a lock that is global to all build contexts,
+simply use an absolute filename:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (alias   runtest)
+ (deps   foo)
+ (locks  /tcp\-port/1042)
+ (action (run test.exe %{deps})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Diffing and promotion
+.sp
+\fB(diff <file1> <file2>)\fP is very similar to \fB(run diff <file1>
+<file2>)\fP\&. In particular it behaves in the same way:
+.INDENT 0.0
+.IP \(bu 2
+when \fB<file1>\fP and \fB<file2>\fP are equal, it does nothing
+.IP \(bu 2
+when they are not, the differences are shown and the action fails
+.UNINDENT
+.sp
+However, it is different for the following reason:
+.INDENT 0.0
+.IP \(bu 2
+the exact command used to diff files can be configured via the
+\fB\-\-diff\-command\fP command line argument. Note that it is only
+called when the files are not byte equals
+.IP \(bu 2
+by default, it will use \fBpatdiff\fP if it is installed. \fBpatdiff\fP
+is a better diffing program. You can install it via opam with:
+.INDENT 2.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ opam install patdiff
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+on Windows, both \fB(diff a b)\fP and \fB(diff? a b)\fP normalize
+end\-of\-line characters before comparing the files
+.IP \(bu 2
+since \fB(diff a b)\fP is a builtin action, dune knows that \fBa\fP
+and \fBb\fP are needed and so you don\(aqt need to specify them
+explicitly as dependencies
+.IP \(bu 2
+you can use \fB(diff? a b)\fP after a command that might or might not
+produce \fBb\fP\&. For cases where commands optionally produce a
+\fIcorrected\fP file
+.IP \(bu 2
+if \fB<file1>\fP doesn\(aqt exists it will compare with the empty file
+.IP \(bu 2
+it allows promotion. See below
+.UNINDENT
+.sp
+Note that \fB(cmp a b)\fP does no end\-of\-line normalization and doesn\(aqt
+print a diff when the files differ. \fBcmp\fP is meant to be used with
+binary files.
+.SS Promotion
+.sp
+Whenever an action \fB(diff <file1> <file2>)\fP or \fB(diff?  <file1>
+<file2>)\fP fails because the two files are different, dune allows
+you to promote \fB<file2>\fP as \fB<file1>\fP if \fB<file1>\fP is a source
+file and \fB<file2>\fP is a generated file.
+.sp
+More precisely, let\(aqs consider the following dune file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (with\-stdout\-to data.out (run ./test.exe)))
+
+(rule
+ (alias   runtest)
+ (action (diff data.expected data.out)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Where \fBdata.expected\fP is a file committed in the source
+repository. You can use the following workflow to update your test:
+.INDENT 0.0
+.IP \(bu 2
+update the code of your test
+.IP \(bu 2
+run \fBdune runtest\fP\&. The diff action will fail and a diff will
+be printed
+.IP \(bu 2
+check the diff to make sure it is what you expect
+.IP \(bu 2
+run \fBdune promote\fP\&. This will copy the generated \fBdata.out\fP
+file to \fBdata.expected\fP directly in the source tree
+.UNINDENT
+.sp
+You can also use \fBdune runtest \-\-auto\-promote\fP which will
+automatically do the promotion.
+.SS Package specification
+.sp
+Installation is the process of copying freshly built libraries,
+binaries and other files from the build directory to the system.  Dune
+offers two way of doing this: via opam or directly via the \fBinstall\fP
+command.  In particular, the installation model implemented by Dune
+was copied from opam. Opam is the standard OCaml package manager.
+.sp
+In both cases, Dune only know how to install whole packages.  A
+package being a collection of executables, libraries and other files.
+In this section, we will describe how to define a package, how to
+"attach" various elements to it and how to proceed with installing it
+on the system.
+.SS Declaring a package
+.sp
+To declare a package, simply add a \fBpackage\fP stanza to your
+\fBdune\-project\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(package
+ (name mypackage)
+ (synopsis "My first Dune package!")
+ (description "\e| This is my first attempt at creating
+              "\e| a project with Dune.
+))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Once you have done this, Dune will know about the package named
+\fBmypackage\fP and you will be able to attach various elements to it.
+The \fBpackage\fP stanza accepts more fields, such as dependencies.
+.sp
+Note that package names are in a global namespace so the name you choose must
+be universally unique.  In particular, package managers never allow to
+release two packages with the same name.
+.sp
+In older projects using Dune, packages were defined by manually writing a file
+called \fB<package\-name>.opam\fP at the root of the project. However, it is not
+recommended to use this method in new projects as we expect to deprecate it in
+the future. The right way to define a package is with a \fBpackage\fP stanza in
+the \fBdune\-project\fP file.
+.sp
+See opam\-generation for instructions on configuring dune to automatically
+generate \fB\&.opam\fP files based on the \fBpackage\fP stanzas.
+.SS Attaching elements to a package
+.sp
+Attaching an element to a package means declaring to Dune that this
+element is part of the said package.  The method to attach an element
+to a package depends on the kind of the element.  In this sub\-section
+we will go through the various kinds of elements and describe how to
+attach each of them to a package.
+.sp
+In the rest of this section, \fB<prefix>\fP refers to the directory in
+which the user chooses to install packages.  When installing via opam,
+it is opam who sets this directory.  When calling \fBdune install\fP,
+the installation directory is either guessed or can be manually
+specified by the user.  This is described more in detail in the last
+section of this page.
+.SS Sites of a package
+.sp
+When packages need additional resources outside their binary, their location
+could be hard to find. Moreover some packages could add resources to another
+package, for example in the case of plugins. These location are called sites in
+dune. One package can define them. During execution one site corresponds to a
+list of directories. They are like layers, the first directories have an higher
+priority. Examples and precisions are available at sites\&.
+.SS Libraries
+.sp
+In order to attach a library to a package all you need to do is add a
+\fBpublic_name\fP field to your library.  This is the name that external
+users of your libraries must use in order to refer to it.  Dune
+requires that the public name of a library is either the name of the
+package it is part of or start with the package name followed by a dot
+character.
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name mylib)
+ (public_name mypackage.mylib))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+After you have added a public name to a library, Dune will know to
+install it as part of the package it is attached to.  Dune installs
+the library files in a directory \fB<prefix>/lib/<package\-name>\fP\&.
+.sp
+If the library name contains dots, the full directory in which the
+library files are installed is \fBlib/<comp1>/<comp2/.../<compn>\fP
+where \fB<comp1>\fP, \fB<comp2>\fP, ... \fB<compn>\fP are the dot separated
+component of the public library name.  By definition, \fB<comp1>\fP is
+always the package name.
+.SS Executables
+.sp
+Similarly to libraries, to attach an executable to a package simply
+add a \fBpublic_name\fP field to your \fBexecutable\fP stanza, or a
+\fBpublic_names\fP field for \fBexecutables\fP stanzas.  The name that
+goes in there is the name under which the executables will be
+available through the \fBPATH\fP once installed, i.e. the name users
+will need to type in there shell to execute the program.  Because Dune
+cannot guess which package an executable is part of from its public
+name, you also need to add a \fBpackage\fP field unless the project
+contains a single package, in which case the executable will be
+attached to this package.
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name main)
+ (public_name myprog)
+ (package mypackage))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Once \fBmypackage\fP is installed on the system, the user will be able
+to type the following in their shell:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ myprog
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+to execute the program.
+.SS Other files
+.sp
+For all other kinds of elements, you need to attach them manually via
+an install stanza.
+.SS Foreign sources and archives
+.sp
+Dune provides basic support for including foreign source files as well
+as archives of foreign object files into OCaml projects via the
+\fBforeign_stubs\fP and \fBforeign_archives\fP fields.
+.SS Foreign stubs
+.sp
+You can specify foreign sources using the \fBforeign_stubs\fP field of the
+\fBlibrary\fP and \fBexecutable\fP stanzas. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name lib)
+ (foreign_stubs (language c) (names src1 src2))
+ (foreign_stubs (language cxx) (names src3) (flags \-O2)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Here we declare an OCaml library \fBlib\fP, which contains two C sources
+\fBsrc1\fP and \fBsrc2\fP, and one C++ source \fBsrc3\fP that needs to be
+compiled with \fB\-O2\fP\&. These source files will be compiled and packaged
+with the library, along with the link\-time flags to be used when
+linking the final executables. When matching \fBnames\fP to source files,
+Dune treats \fB*.c\fP files as C sources, and \fB*.cpp\fP, \fB*.cc\fP and
+\fB*.cxx\fP files as C++ sources.
+.sp
+Here is a complete list of supported subfields:
+.INDENT 0.0
+.IP \(bu 2
+\fBlanguage\fP specifies the source language, where \fBc\fP means C and
+\fBcxx\fP means C++. In future, more languages may be supported.
+.IP \(bu 2
+\fBnames\fP specifies the \fInames\fP of source files. When specifying a source
+file, you should omit the extension and any relative parts of the path;
+Dune will scan all library directories, finding all matching files and
+raising an error if multiple source files map to the same object name.
+If you need to have multiple object files with the same name, you can
+package them into different \fI\%Foreign archives\fP via the
+\fBforeign_archives\fP field. This field uses the \fI\%Ordered set language\fP
+where the \fB:standard\fP value corresponds to the set of names of all
+source files whose extensions match the specified \fBlanguage\fP\&.
+.IP \(bu 2
+\fBflags\fP are passed when compiling source files. This field is specified
+using the \fI\%Ordered set language\fP, where the \fB:standard\fP value comes
+from the environment settings \fBc_flags\fP and \fBcxx_flags\fP, respectively.
+.IP \(bu 2
+\fBinclude_dirs\fP are tracked as dependencies and passed to the compiler
+via the \fB\-I\fP flag. You can use \fI\%Variables\fP in this field, and
+refer to a library source directory using the \fB(lib library\-name)\fP syntax.
+For example, \fB(include_dirs dir1 (lib lib1) (lib lib2) dir2)\fP specifies
+the directory \fBdir1\fP, the source directories of \fBlib1\fP and \fBlib2\fP,
+and the directory \fBdir2\fP, in this order. The contents of included
+directories is tracked recursively, e.g. if you use \fB(include_dir dir)\fP
+and have headers \fBdir/base.h\fP and \fBdir/lib/lib.h\fP then they both will
+be tracked as dependencies.
+.IP \(bu 2
+\fBextra_deps\fP specifies any other dependencies that should be tracked.
+This is useful when dealing with \fB#include\fP statements that escape into
+a parent directory like \fB#include "../a.h"\fP\&.
+.UNINDENT
+.SS Foreign archives
+.sp
+You can also specify archives of separately compiled foreign object files
+that need to be packaged with an OCaml library or linked into an OCaml
+executable. To do that, use the \fBforeign_archives\fP field of the
+corresponding \fBlibrary\fP or \fBexecutable\fP stanza. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name lib)
+ (foreign_stubs (language c) (names src1 src2))
+ (foreign_stubs (language cxx) (names src3) (flags \-O2))
+ (foreign_archives arch1 some/dir/arch2))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Here, in addition to \fI\%Foreign stubs\fP, we also specify foreign archives
+\fBarch1\fP and \fBarch2\fP, where the latter is stored in a subdirectory
+\fBsome/dir\fP\&.
+.sp
+You can build a foreign archive manually, e.g. using a custom \fBrule\fP as
+described in foreign\-sandboxing, or ask Dune to build it via the
+\fBforeign_library\fP stanza:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(foreign_library
+ (archive_name arch1)
+ (language c)
+ (names src4 src5)
+ (include_dir headers))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This asks Dune to compile C source files \fBsrc4\fP and \fBsrc5\fP with
+headers tracked in the \fBheaders\fP directory, and put the resulting
+object files into an archive \fBarch1\fP, whose full name is typically
+\fBlibarch1.a\fP for static linking and \fBdllarch1.so\fP for dynamic
+linking.
+.sp
+The \fBforeign_library\fP stanza supports all \fI\%Foreign stubs\fP fields plus
+the \fBarchive_name\fP field, which specifies the archive\(aqs name. You can refer
+to the same archive name from multiple OCaml libraries and executables, so a
+foreign archive is a bit like a foreign library, hence the name of the stanza.
+.sp
+Foreign archives are particularly useful when embedding a library written in
+a foreign language and/or built with another build system. See
+foreign\-sandboxing for more details.
+.SH WRITING AND RUNNING TESTS
+.sp
+Dune tries to streamline the testing story as much as possible, so
+that you can focus on the tests themselves and not bother with setting
+up with various test frameworks.
+.sp
+In this section, we will explain the workflow to deal with tests in dune. In
+particular we will see how to run the testsuite of a project, how to describe
+your tests to dune and how to promote tests result as expectation.
+.sp
+We distinguish three kinds of tests:
+.INDENT 0.0
+.IP \(bu 2
+inline tests \- written directly inside the ml files of a library
+.IP \(bu 2
+custom tests \- run an executable, possibly followed by an action such as
+diffing the produced output.
+.IP \(bu 2
+cram tests \- expect tests written in \fI\%cram\fP style.
+.UNINDENT
+.SS Running tests
+.sp
+Whatever the tests of a project are, the usual way to run tests with dune is to
+call \fBdune runtest\fP from the shell (or the command alias \fBdune test\fP). This
+will run all the tests defined in the current directory and any sub\-directory
+recursively.
+.sp
+Note that in any case, \fBdune runtest\fP is simply a short\-hand for building the
+\fBruntest\fP alias, so you can always ask dune to run the tests in conjunction
+with other targets by passing \fB@runtest\fP to \fBdune build\fP\&. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build @install @runtest
+$ dune build @install @test/runtest
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Running a single test
+.sp
+If you would only like to run a single test for your project, you may use \fBdune
+exec\fP to run the test executable (for the sake of this example,
+\fBproject/tests/myTest.ml\fP):
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune exec project/tests/myTest.exe
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Running tests in a directory
+.sp
+You can also pass a directory argument to run the tests from a sub\-tree. For
+instance \fBdune runtest test\fP will only run the tests from the \fBtest\fP
+directory and any sub\-directory of \fBtest\fP recursively.
+.SS Inline tests
+.sp
+There are several inline tests framework available for OCaml, such as
+\fI\%ppx_inline_test\fP and \fI\%qtest\fP\&. We will use \fI\%ppx_inline_test\fP as an
+example as at the time of writing this document it has the necessary
+setup to be used with dune out of the box.
+.sp
+\fI\%ppx_inline_test\fP allows one to write tests directly inside ml files as
+follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+let rec fact n = if n = 1 then 1 else n * fact (n \- 1)
+
+let%test _ = fact 5 = 120
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The file has to be preprocessed with the ppx_inline_test ppx rewriter,
+so for instance the \fBdune\fP file might look like this:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (preprocess (pps ppx_inline_test)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+In order to instruct dune that our library contains inline tests,
+all we have to do is add an \fBinline_tests\fP field:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests)
+ (preprocess (pps ppx_inline_test)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+We can now build and execute this test by running \fBdune runtest\fP\&. For
+instance, if we make the test fail by replacing \fB120\fP by \fB0\fP we get:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune runtest
+[...]
+File "src/fact.ml", line 3, characters 0\-25: <<(fact 5) = 0>> is false.
+
+FAILED 1 / 1 tests
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note that in this case Dune knew how to build and run the tests
+without any special configuration. This is because ppx_inline_test
+defines an inline tests backend and it is used by the library. Some
+other frameworks, such as \fI\%qtest\fP don\(aqt have any special library or ppx
+rewriter. To use such a framework, you must tell dune about it
+since it cannot guess it. You can do that by adding a \fBbackend\fP
+field:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests (backend qtest.lib)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+In the example above, the name \fIqtest.lib\fP comes from the \fIpublic_name\fP field
+in \fIqtest\fP\(aqs own \fIdune\fP file.
+.SS Inline expectation tests
+.sp
+Inline expectation tests are a special case of inline tests where you
+write a bit of OCaml code that prints something followed by what you
+expect this code to print. For instance, using \fI\%ppx_expect\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+let%expect_test _ =
+  print_endline "Hello, world!";
+  [%expect{|
+    Hello, world!
+  |}]
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The test procedure consist of executing the OCaml code and replacing
+the contents of the \fB[%expect]\fP extension point by the real
+output. You then get a new file that you can compare to the original
+source file. Expectation tests are a neat way to write tests as the
+following test elements are clearly identified:
+.INDENT 0.0
+.IP \(bu 2
+the code of the test
+.IP \(bu 2
+the test expectation
+.IP \(bu 2
+the test outcome
+.UNINDENT
+.sp
+You can have a look at \fI\%this blog post\fP to find out
+more about expectation tests. To dune, the workflow for
+expectation tests is always as follows:
+.INDENT 0.0
+.IP \(bu 2
+write the test with some empty expect nodes in it
+.IP \(bu 2
+run the tests
+.IP \(bu 2
+check the suggested correction and promote it as the original source
+file if you are happy with it
+.UNINDENT
+.sp
+Dune makes this workflow very easy, simply add \fBppx_expect\fP to
+your list of ppx rewriters as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests)
+ (preprocess (pps ppx_expect)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Then calling \fBdune runtest\fP will run these tests and in case of
+mismatch dune will print a diff of the original source file and
+the suggested correction. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune runtest
+[...]
+\-src/fact.ml
++src/fact.ml.corrected
+File "src/fact.ml", line 5, characters 0\-1:
+let rec fact n = if n = 1 then 1 else n * fact (n \- 1)
+
+let%expect_test _ =
+  print_int (fact 5);
+\-  [%expect]
++  [%expect{| 120 |}]
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+In order to accept the correction, simply run:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune promote
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You can also make dune automatically accept the correction after
+running the tests by typing:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune runtest \-\-auto\-promote
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Finally, some editor integration is possible to make the editor do the
+promotion and make the workflow even smoother.
+.SS Running a subset of the test suite
+.sp
+You may also run a group of tests located under a directory with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+dune runtest mylib/tests
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The above command will run all tests defined in tests and its sub\-directories.
+.SS Running tests in bytecode or JavaScript
+.sp
+By default Dune run inline tests in native mode, except if native
+compilation is not available in which case it runs them in bytecode.
+.sp
+You can change this setting to choose which modes tests should run
+in. To do that, add a \fBmodes\fP field to the \fBinline_tests\fP
+field.  Available modes are:
+.INDENT 0.0
+.IP \(bu 2
+\fBbyte\fP for running tests in byte code
+.IP \(bu 2
+\fBnative\fP for running tests in native mode
+.IP \(bu 2
+\fBbest\fP for running tests in native mode with fallback to byte code
+if native compilation is not available
+.IP \(bu 2
+\fBjs\fP for running tests in JavaScript using Node.js
+.UNINDENT
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests (modes byte best js))
+ (preprocess (pps ppx_expect)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Specifying inline test dependencies
+.sp
+If your tests are reading files, you must say it to dune by adding
+a \fBdeps\fP field the \fBinline_tests\fP field. The argument of this
+\fBdeps\fP field follows the usual deps\-field\&. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests (deps data.txt))
+ (preprocess (pps ppx_expect)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Passing special arguments to the test runner
+.sp
+Under the hood, a test executable is built by dune. Depending on
+the backend used this runner might take useful command line
+arguments. You can specify such flags by using a \fBflags\fP field, such
+as:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests (flags (\-foo bar)))
+ (preprocess (pps ppx_expect)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The argument of the \fBflags\fP field follows the ordered\-set\-language\&.
+.SS Passing special arguments to the test executable
+.sp
+To control how the test executable is built, it’s possible to customize a subset
+of compilation options for an executable using the \fBexecutable\fP field. Dune
+gives you the right to do that by simply specifying command line arguments as flags.
+You can specify such flags by using \fBflags\fP field. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests
+  (flags (\-foo bar)
+  (executable
+   (flags (\-foo bar))))
+  (preprocess (pps ppx_expect))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The argument of the \fBflags\fP field follows the ordered\-set\-language\&.
+.SS Using additional libraries in the test runner
+.sp
+When tests are not part of the library code, it is possible that tests
+require additional libraries than the library being tested. This is
+the case with \fI\%qtest\fP as tests are written in comments. You can specify
+such libraries using a \fBlibraries\fP field, such as:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (inline_tests
+  (backend qtest)
+  (libraries bar)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Defining your own inline test backend
+.sp
+If you are writing a test framework, or for specific cases, you might
+want to define your own inline tests backend. If your framework is
+naturally implemented by a library or ppx rewriter that the user must
+use when they want to write tests, then you should define this library
+has a backend. Otherwise simply create an empty library with the name
+you want to give for your backend.
+.sp
+In order to define a library as an inline tests backend, simply add an
+\fBinline_tests.backend\fP field to the library stanza. An inline tests
+backend is specified by thee parameters:
+.INDENT 0.0
+.IP 1. 3
+How to create the test runner
+.IP 2. 3
+How to build the test runner
+.IP 3. 3
+How to run the test runner
+.UNINDENT
+.sp
+These three parameters can be specified inside the
+\fBinline_tests.backend\fP field, which accepts the following fields:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(generate_runner   <action>)
+(runner_libraries (<ocaml\-libraries>))
+(flags             <flags>)
+(extends          (<backends>))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+For instance:
+.sp
+\fB<action>\fP follows the user\-actions specification. It
+describe an action that should be executed in the directory of
+libraries using this backend for their tests.  It is expected that the
+action produces some OCaml code on its standard output. This code will
+constitute the test runner. The action can use the following
+additional variables:
+.INDENT 0.0
+.IP \(bu 2
+\fB%{library\-name}\fP which is the name of the library being tested
+.IP \(bu 2
+\fB%{impl\-files}\fP which is the list of implementation files in the
+library, i.e. all the \fB\&.ml\fP and \fB\&.re\fP files
+.IP \(bu 2
+\fB%{intf\-files}\fP which is the list of interface files in the library,
+i.e. all the \fB\&.mli\fP and \fB\&.rei\fP files
+.UNINDENT
+.sp
+The \fBrunner_libraries\fP field specifies what OCaml libraries the test
+runner uses. For instance, if the \fBgenerate_runner\fP actions
+generates something like \fBMy_test_framework.runtests ()\fP, the you
+should probably put \fBmy_test_framework\fP in the \fBrunner_libraries\fP
+field.
+.sp
+If you test runner needs specific flags, you should pass them in the
+\fBflags\fP field. You can use the \fB%{library\-name}\fP variable in this
+field.
+.sp
+Finally, a backend can be an extension of another backend. In this
+case you must specify by in the \fBextends\fP field. For instance,
+\fI\%ppx_expect\fP is an extension of \fI\%ppx_inline_test\fP\&. It is possible to use
+a backend with several extensions in a library, however there must be
+exactly one \fIroot backend\fP, i.e. exactly one backend that is not an
+extension of another one.
+.sp
+When using a backend with extensions, the various fields are simply
+concatenated. The order in which they are concatenated is unspecified,
+however if a backend \fBb\fP extends of a backend \fBa\fP, then \fBa\fP will
+always come before \fBb\fP\&.
+.SS Example of backend
+.sp
+In this example, we put tests in comments of the form:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(*TEST: assert (fact 5 = 120) *)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The backend for such a framework looks like this:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name simple_tests)
+ (inline_tests.backend
+  (generate_runner (run sed "s/(\e\e*TEST:\e\e(.*\e\e)\e\e*)/let () = \e\e1;;/" %{impl\-files}))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Now all you have to do is write \fB(inline_tests ((backend
+simple_tests)))\fP wherever you want to write such tests. Note that
+this is only an example, we do not recommend using \fBsed\fP in your
+build as this would cause portability problems.
+.SS Custom tests
+.sp
+We said in \fI\%Running tests\fP that to run tests dune simply builds
+the \fBruntest\fP alias. As a result, to define custom tests, you simply
+need to add an action to this alias in any directory. For instance if
+you have a binary \fBtests.exe\fP that you want to run as part of
+running your testsuite, simply add this to a dune file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (alias  runtest)
+ (action (run ./tests.exe)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Hence to define an a test a pair of alias and executable stanzas are required.
+To simplify this common pattern, dune provides a tests\-stanza stanza to
+define multiple tests and their aliases at once:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(tests (names test1 test2))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Diffing the result
+.sp
+It is often the case that we want to compare the output of a test to
+some expected one. For that, dune offers the \fBdiff\fP command,
+which in essence is the same as running the \fBdiff\fP tool, except that
+it is more integrated in dune and especially with the \fBpromote\fP
+command. For instance let\(aqs consider this test:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (with\-stdout\-to tests.output (run ./tests.exe)))
+
+(rule
+ (alias runtest)
+ (action (diff tests.expected test.output)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+After having run \fBtests.exe\fP and dumping its output to \fBtests.output\fP, dune
+will compare the latter to \fBtests.expected\fP\&. In case of mismatch, dune will
+print a diff and then the \fBdune promote\fP command can be used to copy over the
+generated \fBtest.output\fP file to \fBtests.expected\fP in the source tree.
+.sp
+Alternatively, the tests\-stanza also supports this style of tests.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(tests (names tests))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Where dune expects a \fBtests.expected\fP file to exist to infer that this is an
+expect tests.
+.sp
+This provides a nice way of dealing with the usual \fIwrite code\fP,
+\fIrun\fP, \fIpromote\fP cycle of testing. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune runtest
+[...]
+\-tests.expected
++tests.output
+File "tests.expected", line 1, characters 0\-1:
+\-Hello, world!
++Good bye!
+$ dune promote
+Promoting _build/default/tests.output to tests.expected.
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note that if available, the diffing is done using the \fI\%patdiff\fP tool,
+which displays nicer looking diffs that the standard \fBdiff\fP
+tool. You can change that by passing \fB\-\-diff\-command CMD\fP to
+dune.
+.SS Cram Tests
+.sp
+Cram tests are expectation tests written in a shell\-like syntax. They are ideal
+for testing binaries. Cram tests are auto discovered from files or directories
+with a \fB\&.t\fP extension, so they must be enabled manually in the
+\fBdune\-project\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(cram enable)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS File Tests
+.sp
+To define a standalone test, we create a \fB\&.t\fP file. For example, \fBfoo.t\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+Simplest possible cram test
+  $ echo "testing"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This simple example demonstrates two components of cram tests:
+.INDENT 0.0
+.IP \(bu 2
+Comments \- Anything that doesn\(aqt start with a 2 space indentation is a comment
+.IP \(bu 2
+Commands \- A command starts with 2 spaces followed by a \fB$\fP\&. It is executed
+in the shell and the output is diffed against the output below. In this
+example, there\(aqs no output yet.
+.UNINDENT
+.sp
+To run the test and promote the results:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune runtest
+$ dune promote
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+We now see the output of the command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+Simplest possible cram test
+  $ echo "testing"
+  testing
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This is the main advantage of expect tests. We don\(aqt need to write assertions
+manually, instead we detect failure when the command produces a different output
+than what is recorded in the test script.
+.sp
+For example, here\(aqs an example of how we\(aqd test the \fBwc\fP utility. \fBwc.t\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+We create a test artifact called foo
+  $ cat >foo <<EOF
+  > foo
+  > bar
+  > baz
+  > EOF
+
+After creating the fixture, we want to verify that \(ga\(gawc\(ga\(ga gives us the right
+result:
+  $ wc \-l foo | awk \(aq{ print $1 }\(aq
+  4
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The above example uses the here doc syntax to pipe the subsequent lines to
+\fBcat\fP\&. This is convenient for creating small test artifacts.
+.SS Directory Tests
+.sp
+In the above example we used \fBcat\fP to create the test artifact, but what if
+there are too many artifacts to comfortably fit in test file? Or some of the
+artifacts are binary? It\(aqs possible to include the artifacts as normal files or
+directories provided the test is defined as a directory. The name of the test
+directory must end with \fB\&.t\fP and must include a \fBrun.t\fP as the test script.
+Everything else in that directory is treated as raw data for the test. It\(aqs not
+possible to define rules using \fBdune\fP files in such a directory.
+.sp
+We convert the \fBwc\fP test above into a directory test \fBwc.t\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ ls wc.t
+  run.t foo.txt bar/
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This defines a directory test \fBwc.t\fP which must include a \fBrun.t\fP file as
+the test script, with \fBfool.txt\fP and \fBbar\fP are test artifacts. We may then
+access their contents in the test script \fBrun.t\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ wc \-l foo | awk \(aq{ print $1 }\(aq
+4
+$ wc \-l $(ls bar) | awk \(aq{ print $1 }\(aq
+1231
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Test Options
+.sp
+When testing binaries, it\(aqs important to to specify a dependency on the binary
+for two reasons:
+.INDENT 0.0
+.IP \(bu 2
+Dune must know to re\-run the test when a dependency changes
+.IP \(bu 2
+The dependencies must be specified to guarantee that they are visible to the
+test when running it.
+.UNINDENT
+.sp
+We can specify dependencies using the \fBdeps\fP field using the usual syntax:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(cram
+ (deps ../foo.exe))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This introduces a dependency on \fBfoo.exe\fP on all cram tests in this directory.
+To apply the stanza to a particular test, it\(aqs possible to use \fBapplies_to\fP
+field:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(cram
+ (applies_to * \e foo bar)
+ (deps ../foo.exe))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+We use the predicate\-lang to apply this stanza to all tests in this
+directory except for \fBfoo.t\fP and \fBbar.t\fP\&. The \fBapplies_to\fP field also
+accepts the special value \fB:whole_subtree\fP in order to apply the options to all tests
+in all sub directories (recursively). This is useful to apply common options to
+an entire test suite.
+.sp
+The \fBcram\fP stanza accepts the following fields:
+.INDENT 0.0
+.IP \(bu 2
+\fBenabled_if\fP \- controls whether the tests are enabled
+.IP \(bu 2
+\fBalias\fP \- alias that can be used to run the test. In addition to the user
+alias, every test \fBfoo.t\fP is attached to the \fB@runtest\fP alias and gets its
+own \fB@foo\fP alias to make it convenient to run individually.
+.IP \(bu 2
+\fBdeps\fP \- dependencies of the test
+.UNINDENT
+.sp
+A single test may be configured by more than one \fBcram\fP stanza. In such cases,
+the values from all applicable \fBcram\fP stanzas are merged together to get the
+final values for all the fields.
+.SS Testing an OCaml Program
+.sp
+The most common testing situation involves testing an executable that is defined
+in dune. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name wc)
+ (public_name wc))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+To use this binary in the cram test, we should depend on the binary in the test:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(cram
+ (deps %{bin:wc}))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Sandboxing
+.sp
+Since cram tests often create intermediate artifacts, it\(aqs important that cram
+tests are executed in a clean environment. This is why all cram tests are
+sandboxed. To respect sandboxing, every test should specify dependency on any
+artifact that might rely on using the \fBdeps\fP field.
+.sp
+See dune\-action\-plugin for details about the sandboxing mechanism.
+.SS Test Output Sanitation
+.sp
+In some situations, cram tests emit non portable or non deterministic output. We
+recommend to sanitize such outputs using pipes. For example, we can scrub the
+ocaml magic number using sed as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ ocamlc \-config | grep "cmi_magic_number:" | sed \(aqs/Caml.*/$SPECIAL_CODE/\(aq
+cmi_magic_number: $SPECIAL_CODE
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+By default, dune will scrub the some paths from the output of the tests. The
+default list of paths is:
+.INDENT 0.0
+.IP \(bu 2
+The \fBPWD\fP of the test will be replaced by \fB$TESTCASE_ROOT\fP
+.IP \(bu 2
+The temporary directory for the current script will be replaced by \fB$TMPDIR\fP
+.UNINDENT
+.sp
+To add additional paths to this sanitation mechanism, it\(aqs sufficient to modify
+the standard \fI\%BUILD_PATH_PREFIX_MAP\fP environment variable. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ export BUILD_PATH_PREFIX_MAP="HOME=$HOME:$BUILD_PATH_PREFIX_MAP"
+$ echo $HOME
+$HOME
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH INSTRUMENTATION
+.sp
+In this section, we will explain how define and use instrumentation backends
+(such as \fBbisect_ppx\fP or \fBlandmarks\fP) so that you can enable and disable
+coverage via \fBdune\-workspace\fP files or by passing a command\-line flag or
+environment variable. In addition to providing an easy way to toggle
+instrumentation of your code, this setup avoids creating a hard dependency on
+the precise instrumentation backend in your project.
+.SS Specifying what to instrument
+.sp
+When an instrumentation backend is activated, Dune will only instrument
+libraries and executables for which the user has requested instrumentation.
+.sp
+To request instrumentation, one must add the following field to a library or
+executable stanza:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name ...)
+ (instrumentation
+  (backend <name>)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This field can be repeated multiple times in order to support various
+backends. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (modules foo)
+ (instrumentation (backend bisect_ppx))
+ (instrumentation (backend landmarks)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will instruct Dune that when either the \fBbisect_ppx\fP or \fBlandmarks\fP
+instrumentation is activated, the library should be instrumented with this
+backend.
+.sp
+By default, these fields are simply ignored. However, when the corresponding
+instrumentation backend is activated, Dune will implicitly add the relevant \fBppx\fP
+rewriter to the list of \fBppx\fP rewriters.
+.sp
+At the moment, it is not possible to instrument code that is preprocessed via an
+action preprocessors. As these preprocessors are quite rare nowadays, there is
+no plan to add support for them in the future.
+.SS Enabling/disabling instrumentation
+.sp
+Activating an instrumentation backend can be done via the command line or the
+\fBdune\-workspace\fP file.
+.sp
+Via the command line, it is done as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build \-\-instrument\-with <names>
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Here \fB<names>\fP is a comma\-separated list of instrumentation backends. For example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build \-\-instrument\-with bisect_ppx,landmarks
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This will instruct Dune to activate the given backend globally, i.e. in all
+defined build contexts.
+.sp
+It is also possible to enable instrumentation backends via the
+\fBdune\-workspace\fP file, either globally, or for specific builds contexts.
+.sp
+To enable an instrumentation backend globally, you can type in your
+\fBdune\-workspace\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(instrument_with bisect_ppx)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+or for each context individually:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(context default)
+(context (default (name coverage) (instrument_with bisect_ppx)))
+(context (default (name profiling) (instrument_with landmarks)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+If both the global and local fields are present, the precedence is the same as
+for the \fBprofile\fP field: the per\-context setting takes precedence over the
+command\-line flag, which takes precedence over the global field.
+.SS Declaring an instrumentation backend
+.sp
+Instrumentation backends are libraries with the special field
+\fB(instrumentation.backend)\fP\&. This field instructs Dune that the library can be
+used as an intrumentation backend and also provides the parameters that are
+specific to this backend.
+.sp
+Currently, Dune will only support \fBppx\fP instrumentation tools, and the
+instrumentation library must specify the \fBppx\fP rewriters that instruments the
+code. This can be done as follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ ...
+ (instrumentation.backend
+   (ppx <ppx\-rewriter\-name>)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+When such an instrumentation backend is activated, Dune will implicitly add the
+mentioned \fBppx\fP rewriter to the list of \fBppx\fP rewriters for libraries and
+executables that specify this instrumentation backend.
+.SH DEALING WITH FOREIGN LIBRARIES
+.sp
+The OCaml programming language can interface with libraries written
+in foreign languages such as C. This section explains how to do this
+with Dune. Note that it does not cover how to write the C stubs
+themselves, this is covered by the
+\fI\%OCaml manual\fP
+.sp
+More precisely, this section covers:
+\- how to add C/C++ stubs to an OCaml library
+\- how to pass specific compilation flags for compiling the stubs
+\- how to build a library with a foreign build system
+.sp
+Note that in general Dune has limited support for building source
+files written in foreign languages. This support is suitable for most
+OCaml projects containing C stubs, but is too limited for building
+complex libraries written in C or other languages. For such cases,
+Dune can integrate a foreign build system into a normal Dune
+build.
+.SS Adding C/C++ stubs to an OCaml library
+.sp
+To add C stubs to an OCaml library, simply list the C files without
+the \fB\&.c\fP extension in the foreign\-stubs field. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name mylib)
+ (foreign_stubs (language c) (names file1 file2)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You can also add C++ stubs to an OCaml library by specifying
+\fB(language cxx)\fP instead.
+.sp
+Dune is currently not flexible regarding the extension of the C/C++
+source files. They have to be \fB\&.c\fP for C files and \fB\&.cpp\fP, \fB\&.cc\fP
+or \fB\&.cxx\fP for C++ files. If you have source files with other
+extensions and you want to build them with Dune, you need to rename
+them first. Alternatively, you can use the
+\fI\%foreign build sandboxing\fP method described
+below.
+.SS Header files
+.sp
+C/C++ source files may include header files in the same directory as
+the C/C++ source files or in the same directory group when using
+include_subdirs\&.
+.sp
+The header files must have the \fB\&.h\fP extension.
+.SS Installing header files
+.sp
+It is sometimes desirable to install header files with the
+library. For that you have two choices: install them explicitly with
+an install stanza or use the \fBinstall_c_headers\fP field of the
+library stanza. This field takes a list of header files names
+without the \fB\&.h\fP extension. When a library install header files,
+these are made visible to users of the library via the include search
+path.
+.SS Foreign build sandboxing
+.sp
+When the build of a C library is too complicated to express in the
+Dune language, it is possible to simply \fIsandbox\fP a foreign
+build. Note that this method can be used to build other things, not
+just C libraries.
+.sp
+To do that, follow the following procedure:
+.INDENT 0.0
+.IP \(bu 2
+put all the foreign code in a sub\-directory
+.IP \(bu 2
+tell Dune not to interpret configuration files in this directory via an
+data_only_dirs stanza
+.IP \(bu 2
+write a custom rule that:
+.INDENT 2.0
+.IP \(bu 2
+depends on this directory recursively via source_tree
+.IP \(bu 2
+invokes the external build system
+.UNINDENT
+.IP \(bu 2
+\fIattach\fP the C archive files to an OCaml library via foreign\-archives\&.
+.UNINDENT
+.sp
+For instance, let\(aqs assume that you want to build a C library
+\fBlibfoo\fP using \fBlibfoo\fP\(aqs own build system and attach it to an
+OCaml library called \fBfoo\fP\&.
+.sp
+The first step is to put the sources of \fBlibfoo\fP in your project,
+for instance in \fBsrc/libfoo\fP\&. Then tell dune to consider
+\fBsrc/libfoo\fP as raw data by writing the following in \fBsrc/dune\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(data_only_dirs libfoo)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The next step is to setup the rule to build \fBlibfoo\fP\&. For this,
+writing the following code \fBsrc/dune\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (deps (source_tree libfoo))
+ (targets libfoo.a dllfoo.so)
+ (action
+ (no\-infer
+  (progn
+   (chdir libfoo (run make))
+   (copy libfoo/libfoo.a libfoo.a)
+   (copy libfoo/libfoo.so dllfoo.so)))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+We copy the resulting archive files to the top directory where they can be
+declared as \fBtargets\fP\&. The build is done in a \fBno\-infer\fP action because
+\fBlibfoo/libfoo.a\fP and \fBlibfoo/libfoo.so\fP are dependencies produced by
+an external build system.
+.sp
+The last step is to attach these archives to an OCaml library as
+follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name bar)
+ (foreign_archives foo))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Then, whenever you use the \fBbar\fP library, you will also be able to
+use C functions from \fBlibfoo\fP\&.
+.SS Limitations
+.sp
+When using the sandboxing method, the following limitations apply:
+.INDENT 0.0
+.IP \(bu 2
+the build of the foreign code will be sequential
+.IP \(bu 2
+the build of the foreign code won\(aqt be incremental
+.UNINDENT
+.sp
+both these points could be improved. If you are interested in helping
+make this happen, please let the Dune team know and someone will guide
+you.
+.SS Real example
+.sp
+The \fI\%re2 project\fP uses this
+method to build the re2 C library. You can look at the file
+\fBre2/src/re2_c/dune\fP in this project to see a full working
+example.
+.SH GENERATING DOCUMENTATION
+.SS Prerequisites
+.sp
+Documentation in dune is done courtesy of the \fI\%odoc\fP tool. Therefore, to
+generate documentation in dune, you will need to install this tool. This
+should likely be done with opam:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ opam install odoc
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Writing documentation
+.sp
+Documentation comments will be automatically extracted from your OCaml source
+files following the syntax described in the section \fBText formatting\fP of
+the \fI\%OCaml manual\fP\&.
+.sp
+Additional documentation pages may by attached to a package can be attached
+using the documentation\-stanza stanza.
+.SS Building documentation
+.sp
+Building the documentation using the \fB@doc\fP alias. Hence, all that is required
+to generate documentation for your project is building this alias:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build @doc
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+An index page containing links to all the opam packages in your project can be
+found in:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ open _build/default/_doc/_html/index.html
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Documentation for private libraries may also be built with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build @doc\-private
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+But this libraries will not be in the main html listing above, since they do not
+belong to any particular package. But the generated html will still be found in
+\fB_build/default/_doc/_html/<library>\fP\&.
+.SS Examples
+.sp
+This stanza use attach all the .mld files in the current directory in a project
+with a single package.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(documentation)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This stanza will attach three mld files to package foo. The \fBmld\fP files should
+be named \fBfoo.mld\fP, \fBbar.mld\fP, and \fBbaz.mld\fP
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(documentation
+ (package foo)
+  (mld_files foo bar baz))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This stanza will attach all mld files excluding \fBwip.mld\fP in the current
+directory to the inferred package:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(documentation
+ (mld_files :standard \e wip))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Passing options to Odoc
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(env
+ (<profile>
+  (odoc <optional\-fields>)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+See dune\-env for more details on the \fB(env ...)\fP stanza.
+\fB<optional\-fields>\fP are:
+.INDENT 0.0
+.IP \(bu 2
+\fB(warnings <mode>)\fP specifies how warnings should be handled.
+\fB<mode>\fP can be: \fBfatal\fP or \fBnonfatal\fP\&.
+The default value is \fBnonfatal\fP\&.
+This field is available since Dune 2.4.0 and requires Odoc 1.5.0.
+.UNINDENT
+.SH JAVASCRIPT COMPILATION
+.sp
+\fI\%js_of_ocaml\fP is a compiler from OCaml to JavaScript. The compiler works by
+translating OCaml bytecode to JS files. The compiler can be installed with opam:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ opam install js_of_ocaml\-compiler
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Compiling to JS
+.sp
+Dune has full support building js_of_ocaml libraries and executables transparently.
+There\(aqs no need to customize or enable anything to compile ocaml
+libraries/executables to JS.
+.sp
+To build a JS executable, just define an executable as you would normally.
+Consider this example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+echo \(aqprint_endline "hello from js"\(aq > foo.ml
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+With the following dune file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable (name foo) (modes js))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And then request the \fB\&.js\fP target:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build ./foo.bc.js
+$ node _build/default/foo.bc.js
+hello from js
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Similar targets are created for libraries, but we recommend sticking to the
+executable targets.
+.sp
+If you\(aqre using the js_of_ocaml syntax extension, you must remember to add the
+appropriate ppx in the \fBpreprocess\fP field:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name foo)
+ (modes js)
+ (preprocess (pps js_of_ocaml\-ppx)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Separate compilation
+.sp
+Dune supports two modes of compilation
+.INDENT 0.0
+.IP \(bu 2
+Direct compilation of a bytecode program to JavaScript. This mode allows
+js_of_ocaml to perform whole program deadcode elimination and whole program
+inlining.
+.IP \(bu 2
+Separate compilation, where compilation units are compiled to JavaScript
+separately and then linked together. This mode is useful during development as
+it builds more quickly.
+.UNINDENT
+.sp
+The separate compilation mode will be selected when the build profile is
+\fBdev\fP, which is the default. There is currently no other way to control this
+behaviour.
+.SH HOW TO LOAD ADDITIONAL FILES AT RUNTIME
+.sp
+There are many ways for applications to load files at runtime and Dune provides
+a well tested, key\-in\-hand portable system for doing so. The Dune model works by
+defining \fBsites\fP where files will be installed and looked up at runtime. At
+runtime each site is associated to a list of directories which contain the
+files added in the site.
+.SS Sites
+.SS Defining a site
+.sp
+A site is defined in a package package in the \fBdune\-project\fP file. It
+consists of a name and a section (e.g \fBlib\fP, \fBshare\fP,
+\fBetc\fP) where the site will be installed as a sub\-directory.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(name mygui)
+(package (name mygui) (sites (share themes)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Adding files to a site
+.sp
+Here the package \fBmygui\fP defines a site named \fBthemes\fP that will be located
+in the section \fBshare\fP\&. This package can add files to this \fBsites\fP using the
+install stanza:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(install
+  (section (site mygui themes))
+  (files
+    (layout.css as default/layout.css)
+    (ok.png  as default/ok.png)
+    (ko.png  as default/ko.png)
+  )
+)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Another package \fBmygui_material_theme\fP can install files inside \fBmygui\fP directory for adding a new
+theme. Inside the scope of \fBmygui_material_theme\fP the \fBdune\fP file contains:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(install
+  (section (site mygui themes))
+  (files
+    (layout.css as material/layout.css)
+    (ok.png  as material/ok.png)
+    (ko.png  as material/ko.png)
+  )
+)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The package \fBmygui\fP must be present in the workspace or installed.
+.sp
+\fBWARNING:\fP
+.INDENT 0.0
+.INDENT 3.5
+Two files should not be installed by different packages at the same destination.
+.UNINDENT
+.UNINDENT
+.SS Getting the locations of a site at runtime
+.sp
+The executable \fBmygui\fP will be able to get the locations of the \fBthemes\fP
+site using the generate module stanza
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+   (name mygui)
+   (modules mygui mysites)
+   (libraries dune\-site)
+)
+
+(generate_module (name mysites) (sites mygui))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The generated module \fImysites\fP depends on the library \fIdune\-site\fP provided by Dune.
+.sp
+Then inside \fBmygui.ml\fP module the locations can be recovered and used:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(** Locations of the site for the themes *)
+let themes_locations : string list = Mysites.Sites.themes
+
+(** Merge the content of the directories in [dirs] *)
+let rec readdirs dirs =
+  List.concat
+    (List.map
+       (fun dir \-> Array.to_list (Sys.readdir dir))
+       (List.filter Sys.file_exists dirs))
+
+(** Get the lists of the available themes  *)
+let find_available_themes () : string list = lookup_dirs themes_locations
+
+(** Lookup a file in the directories *)
+let rec lookup_file filename = function
+  | [] \-> raise Not_found
+  | dir::dirs \->
+     let filename\(aq = Filename.concat dir filename in
+     if Sys.file_exists filename\(aq then filename\(aq
+     else lookup_file filename dirs
+
+(** [lookup_theme_file theme file] get the [file] of the [theme] *)
+let lookup_theme_file file theme =
+  lookup_file (Filename.concat theme file) themes_locations
+
+let get_layout_css = lookup_theme_file "layout.css"
+let get_ok_ico = lookup_theme_file "ok.png"
+let get_ko_ico = lookup_theme_file "ko.png"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Tests
+.sp
+During tests the files are copied into the sites through the dependency
+\fB(package mygui)\fP and \fB(package mygui_material_theme)\fP as for other files in
+install stanza.
+.SS Installation
+.sp
+Installation is done simply with \fBdune install\fP, however if one want to
+install this tool such that it is relocatable, one can use \fBdune
+install \-\-relocatable \-\-prefix $dir\fP\&. The files will be copied to the directory
+\fB$dir\fP but the binary \fB$dir/bin/mygui\fP will find the site location relatively
+to its location. So even if the directory \fB$dir\fP is moved, \fBthemes_locations\fP will
+be correct.
+.SS Implementation details
+.sp
+The main difficulty for sites is that their directories are
+found at different locations at different times:
+.INDENT 0.0
+.IP \(bu 2
+When the package is available locally, the location is inside \fB_build\fP
+.IP \(bu 2
+When the package is installed, the location is inside the install prefix
+.IP \(bu 2
+If a local package wants to install files to the site of another installed
+package the location is at the same time in \fB_build\fP and in the install prefix
+of the second package.
+.UNINDENT
+.sp
+With the last example we see that the location of a site is not always a single directory,
+but can consist of a sequence of directories: \fB["dir1";"dir2"]\fP\&. So a lookup must first look
+into "dir1", then into "dir2".
+.SS Plugins and dynamic loading of packages
+.sp
+Dune allows to define and load plugins without having to deal with specific
+compilation, installation directories, dependencies or the module \fIDynlink\fP\&.
+Here we show an example of an executable which can be extended using plugins,
+and the definition of one plugin in another package. The sites used for plugins
+are not particular, but it is better to use them just for that pupose and not install
+other files in them.
+.SS Example
+.SS Main executable (C)
+.INDENT 0.0
+.IP \(bu 2
+\fBdune\-project\fP file:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(name c)
+(package (name c) (sites (lib plugins)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.IP \(bu 2
+\fBdune\fP file:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (public_name c)
+ (modules sites c)
+ (libraries c.register dune\-site dune\-site.plugins))
+
+(library
+ (public_name c.register)
+ (name c_register)
+ (modules c_register))
+
+(generate_module (module sites)  (plugins (c plugins)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The generated module \fIsites\fP depends here also on the library
+\fIdune\-site.plugins\fP because the plugins optional field is requested.
+.INDENT 0.0
+.IP \(bu 2
+The module \fBc_register.ml\fP of the library \fBc.register\fP:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+let todo = Queue.create ()
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.IP \(bu 2
+The code of the exectuable \fBc.ml\fP:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(* load all the available plugins *)
+let () = Sites.Plugins.Plugins.load_all ()
+(* Execute the code registered by the plugins *)
+let () = Queue.iter (fun f \-> f ()) !C_register.todo
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS One plugin (B)
+.INDENT 0.0
+.IP \(bu 2
+\fBdune\-project\fP file:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(name b)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.IP \(bu 2
+\fBdune\fP file:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (public_name b)
+ (libraries c.register))
+
+(plugin
+ (name b)
+ (libraries b)
+ (site (c plugins)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.IP \(bu 2
+The code of the plugin \fBb.ml\fP:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+let () = Queue.add (fun () \-> print_endline "B is doing something") C_register.todo
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH OPAM INTEGRATION
+.sp
+\fI\%opam\fP is the official package manager for OCaml, and dune offers some
+integration with it.
+.SS Invocation from opam
+.sp
+You should set the \fBbuild:\fP field of your \fB<package>.opam\fP file as
+follows:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "\-p" name "\-j" jobs]
+]
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fB\-p pkg\fP is a shorthand for \fB\-\-root . \-\-only\-packages pkg \-\-profile
+release \-\-default\-target @install\fP\&. \fB\-p\fP is the short version of
+\fB\-\-for\-release\-of\-packages\fP\&.
+.sp
+This has the following effects:
+.INDENT 0.0
+.IP \(bu 2
+it tells dune to build everything that is installable and to
+ignore packages other than \fBname\fP defined in your project
+.IP \(bu 2
+it sets the root to prevent dune from looking it up
+.IP \(bu 2
+it silently ignores all rules with \fB(mode promote)\fP
+.IP \(bu 2
+it sets the build profile to \fBrelease\fP
+.IP \(bu 2
+it uses whatever concurrency option opam provides
+.IP \(bu 2
+it sets the default target to \fB@install\fP rather than \fB@@default\fP
+.UNINDENT
+.sp
+Note that \fBname\fP and \fBjobs\fP are variables expanded by opam. \fBname\fP expands
+to the package name and \fBjobs\fP to the number of jobs available to build the
+package.
+.SS Tests
+.sp
+To setup the building and running of tests in opam, add this line to your
+\fB<package>.opam\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+build: [
+  (* Previous lines here... *)
+  ["dune" "runtest" "\-p" name "\-j" jobs] {with\-test}
+]
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS <package>.opam files
+.sp
+When a \fB<package>.opam\fP file is present, dune will know that the
+package named \fB<package>\fP exists. It will know how to construct a
+\fB<package>.install\fP file in the same directory to handle installation
+via \fI\%opam\fP\&. Dune also defines the
+recursive \fBinstall\fP alias, which depends on all the buildable
+\fB<package>.install\fP files in the workspace. So for instance to build
+everything that is installable in a workspace, run at the root:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build @install
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Declaring a package this way will allow you to add elements such as libraries,
+executables, documentation, ... to your package by declaring them in \fBdune\fP
+files.
+.sp
+Such elements can only be declared in the scope defined by the
+corresponding \fB<package>.opam\fP file. Typically, your
+\fB<package>.opam\fP files should be at the root of your project, since
+this is where \fBopam pin ...\fP will look for them.
+.sp
+Note that \fB<package>\fP must be non\-empty, so in particular \fB\&.opam\fP
+files are ignored.
+.SS Generating opam files
+.sp
+dune will generate \fB\&.opam\fP files if the \fBdune\-project\fP file
+.INDENT 0.0
+.IP \(bu 2
+sets \fB(generate_opam_files true)\fP, and
+.IP \(bu 2
+declares one or more packages as per, declaring\-a\-package\&.
+.UNINDENT
+.sp
+Here\(aqs a complete example of a \fBdune\-project\fP file with opam metadata. This
+configuration will tell \fBdune\fP to generate two opam files: \fBcohttp.opam\fP and
+\fBcohttp\-async.opam\fP\&. (See )
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(lang dune 2.8)
+(name cohttp)
+; version field is optional
+(version 1.0.0)
+
+(generate_opam_files true)
+
+(source (github mirage/ocaml\-cohttp))
+(license ISC)
+(authors "Anil Madhavapeddy" "Rudi Grinberg")
+(maintainers "team@mirage.org")
+
+(package
+ (name cohttp)
+ (synopsis "An OCaml library for HTTP clients and servers")
+ (description "A longer description")
+ (depends
+  (alcotest :with\-test)
+  (dune (> 1.5))
+  (foo (and :dev (> 1.5) (< 2.0)))
+  (uri (>= 1.9.0))
+  (uri (< 2.0.0))
+  (fieldslib (> v0.12))
+  (fieldslib (< v0.13))))
+
+(package
+ (name cohttp\-async)
+ ; optional version override to allow single package point
+ ; releases.
+ (version 1.0.1)
+ (synopsis "HTTP client and server for the Async library")
+ (description "A _really_ long description")
+ (depends
+  (cohttp (>= 1.0.2))
+  (conduit\-async (>= 1.0.3))
+  (async (>= v0.10.0))
+  (async (< v0.12))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Opam template
+.sp
+A user may want to manually fill in some field in the opam file. In these
+situations, dune provides an escape hatch in the form of a user written opam
+template. An opam template must be named \fB<package>.opam.template\fP and should
+be a syntactically valid opam file. Any field defined in this template file will
+be taken as is by dune and never overwritten.
+.sp
+\fINote\fP the template file cannot be generated by a rule and must be available in
+the source tree.
+.SS Odig conventions
+.sp
+Dune follows the \fI\%odig\fP
+conventions and automatically installs any README*, CHANGE*, HISTORY*
+and LICENSE* files in the same directory as the \fB<package>.opam\fP file
+to a location where odig will find them.
+.sp
+Note that this includes files present in the source tree as well as
+generated files. So for instance a changelog generated by a user rule
+will be automatically installed as well.
+.SH VIRTUAL LIBRARIES & VARIANTS
+.sp
+Virtual libraries correspond to dune\(aqs ability to compile parameterized
+libraries and delay the selection of concrete implementations until linking an
+executable.
+.sp
+The feature introduces two kinds of libraries: virtual and implementations. A
+\fIvirtual library\fP corresponds to an interface (although it may contain partial
+implementation). An \fIimplementation\fP of a virtual library fills in all
+unimplemented modules in the virtual library.
+.sp
+The benefit of this partition is that other libraries may depend and compile
+against the virtual library and only select concrete implementations for these
+virtual libraries when linking executables. An example where this might be
+useful would be a virtual, cross platform, \fBclock\fP library. This library would
+have \fBclock.unix\fP and \fBclock.win\fP implementations. Executable using
+\fBclock\fP or libraries that use \fBclock\fP would conditionally select one of the
+implementations, depending on the target platform.
+.SS Virtual library
+.sp
+To define a virtual library, a \fBvirtual_modules\fP field must be added to an
+ordinary library stanza and the version of the dune language must be at least
+1.5. This field defines modules for which only an interface would be present
+(mli only):
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name clock)
+ ;; clock.mli must be present, but clock.ml must not be
+ (virtual_modules clock))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Apart from this field, the virtual library is defined just like a normal library
+and may use all the other fields. A virtual library may include other modules
+(with or without implementations), which is why it\(aqs not a pure "interface"
+library.
+.sp
+Note: the \fBvirtual_modules\fP field is not merged in \fBmodules\fP, which
+represents the total set of modules in a library. If a directory has more than
+one stanza and thus a \fBmodules\fP field must be specified, virtual modules
+still need to be added in \fBmodules\fP\&.
+.SS Implementation
+.sp
+An implementation for a library is defined as:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name clock_unix)
+ ;; clock.ml must be present, but clock.mli must not be
+ (implements clock))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The \fBname\fP field is slightly different for an implementation than it is for a
+normal library. The \fBname\fP is just an internal name to refer to the
+implementation, it does not correspond to any particular module like it does in
+the virtual library.
+.sp
+Other libraries may then depend on the virtual library as if it was a regular
+library:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name calendar)
+ (libraries clock))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+But when it comes to creating an executable, we must now select a valid
+implementation for every virtual library that we\(aqve used:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name birthday\-reminder)
+ (libraries
+  clock_unix ;; leaving this dependency will make dune loudly complain
+  calendar))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Variants
+.sp
+Variants were an experimental feature that were removed in dune 2.6.
+.SS Default implementation
+.sp
+A virtual library may select a default implementation, which is enabled after
+variant resolution, if no suitable implementation has been found.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name time)
+ (virtual_modules time)
+ (default_implementation time\-js))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+The default implementation must live in the same package as the virtual library.
+In the example above, that would mean that the \fBtime\-js\fP and \fBtime\fP
+libraries must be in the same package
+.sp
+Before version 2.6, this was feature was experimental and was guarded under the
+\fBlibrary_variants\fP language. In 2.6, this feature was promoted to the stable
+language of dune and all uses of \fB(using library_variants)\fP are forbidden
+since 2.6.
+.SS Limitations
+.sp
+The current implementation of virtual libraries suffers from a few limitations.
+Some of these are temporary.
+.INDENT 0.0
+.IP \(bu 2
+It is not possible to link more than one implementation for the same
+virtual library in one executable.
+.IP \(bu 2
+It is not possible for implementations to introduce new public modules. That
+is, modules that aren\(aqt a part of the virtual library\(aqs cmi. Consequently, a
+module in an implementation either implements a virtual module or is private.
+.IP \(bu 2
+It\(aqs not possible to load virtual libraries into utop. As a result,
+any directory that contains a virtual library will not work with \fB$ dune
+utop\fP\&. This is an essential limitation, but it would be best to somehow skip
+these libraries or provide an implementation for them when loading a toplevel.
+.IP \(bu 2
+Virtual libraries must be defined using dune. It\(aqs not possible for dune to
+implement virtual libraries created outside of dune. On the other hand,
+virtual libraries and implementations defined using dune should be usable with
+findlib based build systems.
+.IP \(bu 2
+It is not possible for a library to be both virtual and implement another
+library. This isn\(aqt very useful, but technically, it could be used to create
+partial implementations. It is possible to lift this restriction if there\(aqs
+enough demand for this.
+.UNINDENT
+.SH AUTOMATIC FORMATTING
+.sp
+Dune can be set up to run automatic formatters for source code.
+.sp
+It can use \fI\%ocamlformat\fP to format OCaml source code (\fB*.ml\fP and \fB*.mli\fP
+files) and \fI\%refmt\fP to format Reason source code (\fB*.re\fP and \fB*.rei\fP files).
+.sp
+Furthermore it can be used to format code of any defined dialect (see
+dialect).
+.SS Configuring automatic formatting (dune 2.0)
+.sp
+If using \fB(lang dune 2.0)\fP, there is nothing to setup in dune, formatting will
+be set up by default. However, \fI\%ocamlformat\fP will still refuse to format sources
+without an \fB\&.ocamlformat\fP file present in the project root.
+.sp
+By default, formatting will be enabled for all languages and dialects present in
+the project that dune knows about. This is not always desirable, for example if
+in a mixed Reason/OCaml project, one only wants to format the Reason files to
+avoid pulling \fI\%ocamlformat\fP as a dependency.
+.sp
+It is possible to restrict the languages considered for formatting or disable it
+altogether by using the formatting stanza.
+.SS Formatting a project
+.sp
+When this feature is active, an alias named \fBfmt\fP is defined. When built, it
+will format the source files in the corresponding project and display the
+differences:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune build @fmt
+\-\-\- hello.ml
++++ hello.ml.formatted
+@@ \-1,3 +1 @@
+\-let () =
+\-  print_endline
+\-    "hello, world"
++let () = print_endline "hello, world"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+It is then possible to accept the correction by calling \fBdune promote\fP to
+replace the source files by the corrected versions.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune promote
+Promoting _build/default/hello.ml.formatted to hello.ml.
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+As usual with promotion, it is possible to combine these two steps by running
+\fBdune build @fmt \-\-auto\-promote\fP\&.
+.SS Enabling and configuring automatic formatting (dune 1.x)
+.sp
+\fBNOTE:\fP
+.INDENT 0.0
+.INDENT 3.5
+This section applies only to projects with \fB(lang dune 1.x)\fP\&.
+.UNINDENT
+.UNINDENT
+.sp
+In \fB(lang dune 1.x)\fP, no formatting is done by default. This feature is
+enabled by adding the following to the \fBdune\-project\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(using fmt 1.2)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Languages can be configured using the following syntax:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(using fmt 1.2 (enabled_for reason))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Version history
+.SS (lang dune 2.0)
+.INDENT 0.0
+.IP \(bu 2
+Formatting is enabled by default.
+.UNINDENT
+.SS (using fmt 1.2)
+.INDENT 0.0
+.IP \(bu 2
+Format dialects (see dialect).
+.UNINDENT
+.SS (using fmt 1.1)
+.INDENT 0.0
+.IP \(bu 2
+Format Dune files.
+.UNINDENT
+.SS (using fmt 1.0)
+.INDENT 0.0
+.IP \(bu 2
+Format OCaml (using \fI\%ocamlformat\fP) and Reason (using \fI\%refmt\fP) source code.
+.UNINDENT
+.SH CROSS COMPILATION
+.sp
+Dune allows for cross compilation by defining build contexts with
+multiple targets. Targets are specified by adding a \fBtargets\fP field
+to the definition of a build context.
+.sp
+\fBtargets\fP takes a list of target name. It can be either:
+.INDENT 0.0
+.IP \(bu 2
+\fBnative\fP which means using the native tools that can build
+binaries that run on the machine doing the build
+.IP \(bu 2
+the name of an alternative toolchain
+.UNINDENT
+.sp
+Note that at the moment, there is no official support for
+cross\-compilation in OCaml. Dune supports the opam\-cross\-x
+repositories from the \fI\%ocaml\-cross organization on GitHub\fP, such as:
+.INDENT 0.0
+.IP \(bu 2
+\fI\%opam\-cross\-windows\fP
+.IP \(bu 2
+\fI\%opam\-cross\-android\fP
+.IP \(bu 2
+\fI\%opam\-cross\-ios\fP
+.UNINDENT
+.sp
+In particular:
+.INDENT 0.0
+.IP \(bu 2
+to build Windows binaries using opam\-cross\-windows, write \fBwindows\fP
+in the list of targets
+.IP \(bu 2
+to build Android binaries using opam\-cross\-android, write
+\fBandroid\fP in the list of targets
+.IP \(bu 2
+to build IOS binaries using opam\-cross\-ios, write \fBios\fP in the
+list of targets
+.UNINDENT
+.sp
+For example, the following workspace file defines three different
+targets for the \fBdefault\fP build context:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(context (default (targets (native windows android))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+This configuration defines three build contexts:
+.INDENT 0.0
+.IP \(bu 2
+\fBdefault\fP
+.IP \(bu 2
+\fBdefault.windows\fP
+.IP \(bu 2
+\fBdefault.android\fP
+.UNINDENT
+.sp
+Note that the \fBnative\fP target is always implicitly added when not
+present. However, when implicitly added \fBdune build @install\fP
+will skip this context, i.e. \fBdefault\fP will only be used for
+building executables needed by the other contexts.
+.sp
+With such a setup, calling \fBdune build @install\fP will build all
+the packages three times.
+.sp
+Note that instead of writing a \fBdune\-workspace\fP file, you can also
+use the \fB\-x\fP command line option. Passing \fB\-x foo\fP to \fBdune\fP
+without having a \fBdune\-workspace\fP file is the same as writing the
+following \fBdune\-workspace\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(context (default (targets (foo))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+If you have a \fBdune\-workspace\fP and pass a \fB\-x foo\fP option,
+\fBfoo\fP will be added as target of all context stanzas.
+.SS How does it work?
+.sp
+In such a setup, binaries that need to be built and executed in the
+\fBdefault.windows\fP or \fBdefault.android\fP contexts as part of the
+build, will no longer be executed. Instead, all the binaries that will
+be executed will come from the \fBdefault\fP context. One consequence of
+this is that all preprocessing (ppx or otherwise) will be done using
+binaries built in the \fBdefault\fP context.
+.sp
+To clarify this with an example, let\(aqs assume that you have the following
+\fBsrc/dune\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable (name foo))
+(rule (with\-stdout\-to blah (run ./foo.exe)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+When building \fB_build/default/src/blah\fP, dune will resolve \fB\&./foo.exe\fP to
+\fB_build/default/src/foo.exe\fP as expected. However, for
+\fB_build/default.windows/src/blah\fP dune will resolve \fB\&./foo.exe\fP to
+\fB_build/default/src/foo.exe\fP
+.sp
+Assuming that the right packages are installed or that your workspace
+has no external dependencies, dune will be able to cross\-compile a
+given package without doing anything special.
+.sp
+Some packages might still have to be updated to support cross\-compilation. For
+instance if the \fBfoo.exe\fP program in the previous example was using
+\fBSys.os_type\fP, it should instead take it as a command line argument:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule (with\-stdout\-to blah (run ./foo.exe \-os\-type %{os_type})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH DUNE LIBRARIES
+.SS Configurator
+.sp
+Configurator is a small library designed to query features available on the
+system, in order to generate configuration for dune builds. Such generated
+configuration is usually in the form of command line flags, generated headers,
+stubs, but there are no limitations on this.
+.sp
+Configurator allows you to query for the following features:
+.INDENT 0.0
+.IP \(bu 2
+Variables defined in \fBocamlc \-config\fP,
+.IP \(bu 2
+\fI\%pkg\-config\fP flags for packages,
+.IP \(bu 2
+Test features by compiling C code,
+.IP \(bu 2
+Extract compile time information such as \fB#define\fP variables.
+.UNINDENT
+.sp
+Configurator is designed to be cross compilation friendly and avoids _running_
+any compiled code to extract any of the information above.
+.sp
+Configurator started as an \fI\%independent library\fP, but now lives in dune.
+It is released as the package \fBdune\-configurator\fP\&.
+.SS Usage
+.sp
+We\(aqll describe configurator with a simple example. Everything else can be easily
+learned by studying \fI\%configurator\(aqs API\fP\&.
+.sp
+To use configurator, we write an executable that will query the system using
+configurator\(aqs API and output a set of targets reflecting the results. For
+example:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+module C = Configurator.V1
+
+let clock_gettime_code = {|
+#include <time.h>
+
+int main()
+{
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  return 0;
+}
+|}
+
+let () =
+  C.main ~name:"foo" (fun c \->
+    let has_clock_gettime =
+      C.c_test c clock_gettime_code ~link_flags:["\-lrt"] in
+
+    C.C_define.gen_header_file c ~fname:"config.h"
+      [ "HAS_CLOCK_GETTIME", Switch has_clock_gettime ]);
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Usually, the module above would be named \fBdiscover.ml\fP\&. The next step is to
+invoke it as an executable and tell dune about the targets that it produces:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(executable
+ (name discover)
+ (libraries dune\-configurator))
+
+(rule
+ (targets config.h)
+ (action (run ./discover.exe)))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Another common pattern is to produce a flags file with configurator and then use
+this flag file using \fB:include\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name mylib)
+ (foreign_stubs (language c) (names foo))
+ (c_library_flags (:include (flags.sexp))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+For this, generate the list of flags for your library — for example
+using \fBConfigurator.V1.Pkg_config\fP — and then write them to a file,
+in the above example \fBflags.sexp\fP, with
+\fBConfigurator.V1.write_flags "flags.sexp" flags\fP\&.
+.SS Upgrading from the old Configurator
+.sp
+The old configurator is the independent \fI\%configurator\fP opam package. It is deprecated
+and users are encouraged to migrate to dune\(aqs own configurator. The advantage of
+the transition include:
+.INDENT 0.0
+.IP \(bu 2
+No extra dependencies,
+.IP \(bu 2
+No need to manually pass \fB\-ocamlc\fP flag,
+.IP \(bu 2
+New configurator is cross compilation compatible.
+.UNINDENT
+.sp
+The following steps must be taken to transition from the old configurator:
+.INDENT 0.0
+.IP \(bu 2
+Mentions of the \fBconfigurator\fP opam package should be replaced
+with \fBdune\-configurator\fP\&.
+.IP \(bu 2
+The library name \fBconfigurator\fP should be changed \fBdune\-configurator\fP\&.
+.IP \(bu 2
+The \fB\-ocamlc\fP flag in rules that run configurator scripts should be removed.
+This information is now passed automatically by dune.
+.IP \(bu 2
+The new configurator API is versioned explicitly. The version that is
+compatible with old configurator is under the \fBV1\fP module. Hence, to
+transition one\(aqs code it\(aqs enough to add this module alias:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+module Configurator = Configurator.V1
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS build\-info
+.sp
+Dune can embed build information such as versions in executables
+via the special \fBdune\-build\-info\fP library. This library exposes
+some information about how the executable was built such as the
+version of the project containing the executable or the list of
+statically linked libraries with their versions. Printing the version
+at which the current executable was built is as simple as:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+Printf.printf "version: %s\en"
+  (match Build_info.V1.version () with
+   | None \-> "n/a"
+   | Some v \-> Build_info.V1.Version.to_string v)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+For libraries and executables from development repositories that don\(aqt
+have version information written directly in the \fBdune\-project\fP
+file, the version is obtained by querying the version control
+system. For instance, the following git command is used in git
+repositories:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git describe \-\-always \-\-dirty
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+which produces a human readable version string of the form
+\fB<version>\-<commits\-since\-version>\-<hash>[\-dirty]\fP\&.
+.sp
+Note that in the case where the version string is obtained from the
+version control system, the version string will only be written in
+the binary once it is installed or promoted to the source tree. In
+particular, if you evaluate this expression as part of the build of
+your package, it will return \fBNone\fP\&. This is to ensure that
+committing does not hurt your development experience. Indeed, if dune
+stored the version directly inside the freshly built binaries, then
+every time you commit your code the version would change and dune would
+need to rebuild all the binaries and everything that depend on them,
+such as tests. Instead Dune leaves a placeholder inside the binary and
+fills it during installation or promotion.
+.SS (Experimental) Dune action plugin
+.sp
+\fIThis library is experimental and no backwards compatibility is implied. Use at
+your own risk.\fP
+.sp
+\fBDune\-action\-plugin\fP provides a monadic interface to express program
+dependencies directly inside the source code. Programs using this feature
+should be declared using \fBdynamic\-run\fP construction instead of usual \fBrun\fP\&.
+.SH OTHER TOPICS
+.sp
+This section describes some details of dune for advanced users.
+.SS META file generation
+.sp
+Dune uses \fBMETA\fP files from the \fI\%findlib library
+manager\fP in order
+to interoperate with the rest of the world when installing libraries. It
+is able to generate them automatically. However, for the rare cases
+where you would need a specific \fBMETA\fP file, or to ease the transition
+of a project to dune, it is allowed to write/generate a specific
+one.
+.sp
+In order to do that, write or setup a rule to generate a
+\fBMETA.<package>.template\fP file in the same directory as the
+\fB<package>.opam\fP file. Dune will generate a \fBMETA.<package>\fP
+file from the \fBMETA.<package>.template\fP file by replacing lines of
+the form \fB# DUNE_GEN\fP by the contents of the \fBMETA\fP it would
+normally generate.
+.sp
+For instance if you want to extend the \fBMETA\fP file generated by
+dune you can write the following \fBMETA.foo.template\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+# DUNE_GEN
+blah = "..."
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Findlib integration
+.sp
+Dune uses \fBMETA\fP files to support external libraries. However, it
+doesn\(aqt export the full power of findlib to the user, and especially
+it doesn\(aqt let the user specify \fIpredicates\fP\&.
+.sp
+The reason for this limitation is that so far they haven\(aqt been
+needed, and adding full support for them would complicate things quite
+a lot. In particular, complex \fBMETA\fP files are often hand\-written and
+the various features they offer are only available once the package is
+installed, which goes against the root ideas dune is built on.
+.sp
+In practice, dune interprets \fBMETA\fP files assuming the following
+set of predicates:
+.INDENT 0.0
+.IP \(bu 2
+\fBmt\fP: what this means is that using a library that can be used
+with or without threads with dune will force the threaded
+version
+.IP \(bu 2
+\fBmt_posix\fP: forces the use of posix threads rather than VM
+threads. VM threads are deprecated and are likely to go away soon
+.IP \(bu 2
+\fBppx_driver\fP: when a library acts differently depending on whether
+it is linked as part of a driver or meant to add a \fB\-ppx\fP argument
+to the compiler, choose the former behavior
+.UNINDENT
+.SS Dynamic loading of packages with findlib
+.sp
+The prefered way for new developement is to use plugins\&.
+.sp
+Dune supports the \fBfindlib.dynload\fP package from \fI\%findlib\fP that enables
+dynamically loading packages and their dependencies (using the OCaml Dynlink module).
+So adding the ability for an application to have plugins just requires to add
+\fBfindlib.dynload\fP to the set of library dependencies:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+  (name mytool)
+  (public_name mytool)
+  (modules ...)
+)
+
+(executable
+  (name main)
+  (public_name mytool)
+  (libraries mytool findlib.dynload)
+  (modules ...)
+)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Then you could use in your application \fBFl_dynload.load_packages l\fP
+that will load the list \fBl\fP of packages. The packages are loaded
+only once. So trying to load a package statically linked does nothing.
+.sp
+A plugin creator just need to link to your library:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+  (name mytool_plugin_a)
+  (public_name mytool\-plugin\-a)
+  (libraries mytool)
+)
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+By choosing some naming convention, for example all the plugins of
+\fBmytool\fP should start with \fBmytool\-plugin\-\fP\&. You can automatically
+load all the plugins installed for your tool by listing the existing packages:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+let () = Findlib.init ()
+let () =
+  let pkgs = Fl_package_base.list_packages () in
+  let pkgs =
+    List.filter
+      (fun pkg \-> 14 <= String.length pkg && String.sub pkg 0 14 = "mytool\-plugin\-")
+      pkgs
+  in
+  Fl_dynload.load_packages pkgs
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Classical ppx
+.sp
+\fIclassical ppx\fP refers to running ppx using the \-ppx compiler option, which is
+composed using Findlib. Even though this is useful to run some (usually old)
+ppx\(aqs which don\(aqt support drivers, dune does not support preprocessing with
+ppx this way. but a workaround exists using the \fI\%ppxfind\fP tool.
+.SS Profiling dune
+.sp
+If \fB\-\-trace\-file FILE\fP is passed, dune will write detailed data about internal
+operations, such as the timing of commands that are run by dune.
+.sp
+The format is compatible with \fI\%Catapult trace\-viewer\fP\&. In particular, these
+files can be loaded into Chromium\(aqs \fBchrome://tracing\fP\&. Note that the exact
+format is subject to change between versions.
+.SS Package version
+.sp
+Dune determine the version of a package by looking at the \fBversion\fP
+field in the package stanza\&. If the version field is
+not set, it looks at the toplevel \fBversion\fP field in the
+\fBdune\-project\fP field. If neither are set, dune assume that we are in
+development mode and reads the version from the VCS if any. The way it
+obtains the version from the VCS in described in the build\-info
+section\&.
+.sp
+When installing the files of a package on the system, dune
+automatically inserts the package version into various metadata files
+such as \fBMETA\fP and \fBdune\-package\fP files.
+.SS OCaml syntax
+.sp
+If a \fBdune\fP file starts with \fB(* \-*\- tuareg \-*\- *)\fP, then it is
+interpreted as an OCaml script that generates the \fBdune\fP file as described
+in the rest of this section. The code in the script will have access to a
+\fI\%Jbuild_plugin\fP
+module containing details about the build context it is executed in.
+.sp
+The OCaml syntax gives you an escape hatch for when the S\-expression
+syntax is not enough. It is not clear whether the OCaml syntax will be
+supported in the long term as it doesn\(aqt work well with incremental
+builds. It is possible that it will be replaced by just an \fBinclude\fP
+stanza where one can include a generated file.
+.sp
+Consequently \fByou must not\fP build complex systems based on it.
+.SS Variables for artifacts
+.sp
+For specific situations where one needs to refer to individual compilation
+artifacts, special variables (see variables) are provided so that the
+user does not need to be aware of the particular naming conventions or directory
+layout implemented by \fBdune\fP\&.
+.sp
+These variables can appear wherever a deps\-field is expected and also
+inside user\-actions\&. When used inside user\-actions, they
+implicitly declare a dependency on the corresponding artifact.
+.sp
+The variables have the form \fB%{<ext>:<path>}\fP, where \fB<path>\fP is
+interpreted relative to the current directory:
+.INDENT 0.0
+.IP \(bu 2
+\fBcmo:<path>\fP, \fBcmx:<path>\fP, \fBcmi:<path>\fP expand to the path of the
+corresponding artifact for the module specified by \fB<path>\fP\&. The basename of
+\fB<path>\fP should be the name of a module as specified in a \fB(modules)\fP
+field.
+.IP \(bu 2
+\fBcma:<path>\fP, \fBcmxa:<path>\fP expands to the path of the corresponding
+artifact for the library specified by \fB<path>\fP\&. The basename of \fB<path>\fP
+should be the name of the library as specified in the \fB(name)\fP field of a
+\fBlibrary\fP stanza (\fInot\fP its public name).
+.UNINDENT
+.sp
+In each case, the expansion of the variable is a path pointing inside the build
+context (i.e. \fB_build/<context>\fP).
+.SS Building an ad\-hoc \fB\&.cmxs\fP
+.sp
+In the model exposed by \fBdune\fP, a \fB\&.cmxs\fP target is created for each
+library.  However, the \fB\&.cmxs\fP format itself is more flexible than that and is
+capable to containing arbitrary \fB\&.cmxa\fP and \fB\&.cmx\fP files.
+.sp
+For the specific cases where this extra flexibility is needed, one can use
+\fI\%Variables for artifacts\fP to write explicit rules to build \fB\&.cmxs\fP files
+not associated to any library.
+.sp
+Below is an example where we build \fBmy.cmxs\fP containing \fBfoo.cmxa\fP and
+\fBd.cmx\fP\&. Note how we use a library stanza to set up the compilation of
+\fBd.cmx\fP\&.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(library
+ (name foo)
+ (modules a b c))
+
+(library
+ (name dummy)
+ (modules d))
+
+(rule
+ (targets my.cmxs)
+ (action (run %{ocamlopt} \-shared \-o %{targets} %{cmxa:foo} %{cmx:d})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH LEXICAL CONVENTIONS
+.sp
+All configuration files read by Dune are using a syntax similar to the
+one of S\-expressions, which is very simple. The Dune language can
+represent three kinds of values: atoms, strings and lists. By
+combining these, it is possible to construct arbitrarily complex
+project descriptions.
+.sp
+A Dune configuration file is a sequence of atoms, strings or lists
+separated by spaces, newlines and comments. The other sections of this
+manual describe how each configuration file is interpreted. We
+describe below the syntax of the language.
+.SS Comments
+.sp
+The Dune language only has end of line comments. End of line comments
+are introduced with a semicolon and span up to the end of the end of
+the current line. Everything from the semicolon to the end of the line
+is ignored. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+; This is a comment
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Atoms
+.sp
+An atom is a non\-empty contiguous sequences of character other than
+special characters. Special characters are:
+.INDENT 0.0
+.IP \(bu 2
+spaces, horizontal tabs, newlines and form feed
+.IP \(bu 2
+opening and closing parenthesis
+.IP \(bu 2
+double quotes
+.IP \(bu 2
+semicolons
+.UNINDENT
+.sp
+For instance \fBhello\fP or \fB+\fP are valid atoms.
+.sp
+Note that backslashes inside atoms have no special meaning are always
+interpreted as plain backslashes characters.
+.SS Strings
+.sp
+A string is a sequence of characters surrounded by double quotes. A
+string represent the exact text between the double quotes, except for
+escape sequences. Escape sequence are introduced by the a backslash
+character. Dune recognizes and interprets the following escape
+sequences:
+.INDENT 0.0
+.IP \(bu 2
+\fB\en\fP to represent a newline character
+.IP \(bu 2
+\fB\er\fP to represent a carriage return (character with ASCII code 13)
+.IP \(bu 2
+\fB\eb\fP to represent ASCII character 8
+.IP \(bu 2
+\fB\et\fP to represent a horizontal tab
+.IP \(bu 2
+\fB\eNNN\fP, a backslash followed by three decimal characters to
+represent the character with ASCII code \fBNNN\fP
+.IP \(bu 2
+\fB\exHH\fP, a backslash followed by two hexadecimal characters to
+represent the character with ASCII code \fBHH\fP in hexadecimal
+.IP \(bu 2
+\fB\e\e\fP, a double backslash to represent a single backslash
+.IP \(bu 2
+\fB\e%{\fP to represent \fB%{\fP (see variables)
+.UNINDENT
+.sp
+Additionally, a backslash that comes just before the end of the line
+is used to skip the newline up to the next non\-space character. For
+instance the following two strings represent the same text:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+"abcdef"
+"abc\e
+   def"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+In most places where Dune expect a string, it will also accept an
+atom. As a result it possible to write most Dune configuration file
+using very few double quotes. This is very convenient in practice.
+.SS End of line strings
+.sp
+End of line strings are another way to write strings. The are a
+convenient way to write blocks of text inside a Dune file.
+.sp
+End of line strings are introduced by \fB"\e|\fP or \fB"\e>\fP and span up
+the end of the current line. If the next line starts as well by
+\fB"\e|\fP or \fB"\e>\fP it is the continuation of the same string. For
+readability, it is necessary that the text that follows the delimiter
+is either empty or starts with a space that is ignored.
+.sp
+For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+"\e| this is a block
+"\e| of text
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+represent the same text as the string \fB"this is a block\enof text"\fP\&.
+.sp
+Escape sequences are interpreted in text that follows \fB"\e|\fP but not
+in text that follows \fB"\e>\fP\&. Both delimiters can be mixed inside the
+same block of text.
+.SS Lists
+.sp
+Lists are sequences of values enclosed by parentheses. For instance
+\fB(x y z)\fP is a list containing the three atoms \fBx\fP, \fBy\fP and
+\fBz\fP\&. Lists can be empty, for instance: \fB()\fP\&.
+.sp
+Lists can be nested, allowing to represent arbitrarily complex
+descriptions. For instance:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(html
+ (head (title "Hello world!"))
+ (body
+   This is a simple example of using S\-expressions))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH FAQ
+.SS Why do many dune projects contain a Makefile?
+.sp
+Many dune projects contain a root \fBMakefile\fP\&. It is often only there for
+convenience, for the following reasons:
+.INDENT 0.0
+.IP 1. 3
+there are many different build systems out there, all with a different CLI.
+If you have been hacking for a long time, the one true invocation you know is
+\fBmake && make install\fP, possibly preceded by \fB\&./configure\fP
+.IP 2. 3
+you often have a few common operations that are not part of the build and
+\fBmake <blah>\fP is a good way to provide them
+.IP 3. 3
+\fBmake\fP is shorter to type than \fBdune build @install\fP
+.UNINDENT
+.SS How to add a configure step to a dune project?
+.sp
+The \fI\%with\-configure\-step\fP example shows one way to do it which
+preserves composability; i.e. it doesn\(aqt require manually running \fB\&./configure\fP
+script when working on multiple projects at the same time.
+.SS Can I use topkg with dune?
+.sp
+It\(aqs possible using the \fI\%topkg\-jbuilder\fP but it\(aqs not recommended. \fI\%dune\-release\fP
+subsumes topkg\-jbuilder and is specifically tailored to dune projects.
+.SS How do I publish my packages with dune?
+.sp
+Dune is just a build system and considers publishing outside of its scope.
+However, the \fI\%dune\-release\fP project is specifically designed for releasing dune
+projects to opam. We recommend using tool for publishing dune packages.
+.SS Where can I find some examples of projects using dune?
+.sp
+The \fI\%dune\-universe\fP repository contains a snapshot of the latest versions of all
+opam packages depending on dune. It is therefore a useful reference to
+search through to find different approaches to constructing build rules.
+.SS What is Jenga?
+.sp
+\fI\%jenga\fP is a build system developed by Jane Street mainly for internal use. It
+was never usable outside of Jane Street, and hence not recommended for general
+use. It has no relationship to dune apart from dune being the successor to Jenga
+externally. Eventually, dune is expected to replace Jenga internally at Jane
+Street as well.
+.SS How to make warnings non\-fatal?
+.sp
+\fBjbuilder\fP used to display warnings, but most of them would not stop the
+build. But \fBdune\fP makes all warnings fatal by default. This can be a
+challenge when porting a codebase to \fBdune\fP\&. There are two ways to make warnings
+non\-fatal:
+.INDENT 0.0
+.IP \(bu 2
+the \fBjbuilder\fP compatibility executable works even with \fBdune\fP files. You
+can use it while some warnings remain, and then switch over to the \fBdune\fP
+executable. This is the recommended way to handle the situation.
+.IP \(bu 2
+you can pass \fB\-\-profile release\fP to \fBdune\fP\&. It will set up different
+compilation options that usually make sense for release builds, including
+making warnings non\-fatal. This is done by default when installing packages
+from opam.
+.IP \(bu 2
+you can change the flags that are used by the \fBdev\fP profile by adding the
+following stanza to a \fBdune\fP file:
+.UNINDENT
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(env
+  (dev
+    (flags (:standard \-warn\-error \-A))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS How to display the output of commands as they run?
+.sp
+When \fBdune\fP runs external commands, it redirects and saves their output and
+displays it when they have completed. This ensures that there is no interleaving
+when writing to the console.
+.sp
+But this might not be what the you want, for example when debugging a hanging
+build.
+.sp
+In that case, one can pass \fB\-j1 \-\-no\-buffer\fP so that the commands are directly
+printed on the console (and the parallelism is disabled so that the output stays
+readable).
+.SS How can I generate an mli file from an ml file?
+.sp
+When a module starts as just an implementation (\fB\&.ml\fP file), it can be tedious
+to define the corresponding interface (\fB\&.mli\fP file).
+.sp
+It is possible to use the \fBocaml\-print\-intf\fP program (available on opam
+through \fBopam install ocaml\-print\-intf\fP) to generate the right \fBmli\fP file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+$ dune exec \-\- ocaml\-print\-intf ocaml_print_intf.ml
+val root_from_verbose_output : string list \-> string
+val target_from_verbose_output : string list \-> string
+val build_cmi : string \-> string
+val print_intf : string \-> unit
+val version : unit \-> string
+val usage : unit \-> unit
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+It has special support for dune so it will automatically understand external
+dependencies.
+.SH KNOWN ISSUES
+.SS mli only modules
+.sp
+These are supported, however using them might cause make it impossible for
+non\-dune users to use your library. We tried to use them for some internal
+module generated by dune and it broke the build of projects not using
+dune:
+.sp
+\fI\%https://github.com/ocaml/dune/issues/567\fP
+.sp
+So, while they are supported, you should be careful where you use them. Using a
+\fI\&.ml\fP only module is still preferable.
+.SS parallel dune invocations on the same tree
+.sp
+One can invoke dune multiple times in parallel, as long as the invocations are not
+under the same root. That is to say, two dune runs cannot share the same target
+\fI_build\fP directory.
+.sp
+This is tracked under \fI\%https://github.com/ocaml/dune/issues/236\fP\&.
+.SH MIGRATION
+.sp
+Dune was initially called Jbuilder. Up to mid\-2018, the package was still called
+\fIjbuilder\fP which only installed a \fIjbuilder\fP binary. This document explain how
+the migration to Dune will happen.
+.SS Timeline
+.sp
+The general idea is that the migration is gradual and existing
+Jbuilder projects don\(aqt need to be updated all at once. We encourage
+users to switch their development repositories and continue their
+usual release cycle. There is no need to re\-release existing packages
+just to switch to Dune immediately.
+.sp
+The plan is as follows:
+.SS July 2018: release of Dune 1.0.0
+.sp
+First release of the opam package \fIdune\fP\&. The \fIjbuilder\fP package
+becomes a transitional package that depends on \fIdune\fP\&.
+.sp
+The \fIdune\fP package installs two binaries: \fIdune\fP and \fIjbuilder\fP\&. These
+two binaries are exactly the same and they work on both Jbuilder and
+Dune projects. Additionally they recognize both Jbuilder and Dune
+configuration files. The new Dune configuration files are described
+later in this document.
+.SS January 2019: deprecation of Jbuilder
+.sp
+At this point, the \fIjbuilder\fP binary emits a warning on every startup
+inviting users to switch to \fIdune\fP\&. When encountering \fIjbuild\fP or
+other Jbuilder configuration files, both binaries emit a warning. The
+rest is unchanged.
+.sp
+During this period, it makes sense for projects to do new releases
+just to switch to Dune if none of their existing releases is using
+Dune.
+.SS July 2019: support for Jbuilder is dropped
+.sp
+\fIjbuilder\fP is now a dummy executable that always exit with an error
+message on startup. \fIdune\fP no longer reads \fIjbuild\fP or other Jbuidler
+configuration files but still prints a warning when encountering
+them.
+.sp
+At this point, a conflict with newer versions of \fIdune\fP will be added
+to all opam packages that rely on the \fIjbuilder\fP binary or Jbuilder
+configuration files.
+.SS January 2020: the jbuilder binary goes away
+.sp
+The \fIdune\fP package no longer installs a \fIjbuilder\fP binary. The rest is
+unchanged.
+.SS Distant future
+.sp
+Once we are sure there are no more \fIjbuild\fP files out there, Dune will
+completely ignore \fIjbuild\fP and other Jbuilder configuration files.
+.SS Check list
+.sp
+This section is a concise list of migration tasks that will be required to
+transition from jbuilder to dune.
+.SS New configuration files
+.sp
+Until July 2019, \fIdune\fP will still read \fIjbuild\fP and other Jbuilder
+configuration files. There is no change in these files.
+.sp
+However, based on the experience acquired since the first release of
+Jbuilder, we made a few changes in the configuration files read by
+Dune. The most notable ones are the following:
+.INDENT 0.0
+.IP \(bu 2
+\fIjbuild\fP files are renamed simply \fIdune\fP
+.IP \(bu 2
+projects now have a \fIdune\-project\fP file at their root
+.IP \(bu 2
+\fIjbuild\-ignore\fP files are replaced by \fIignored_subdirs\fP stanzas in
+\fIdune\fP files
+.IP \(bu 2
+\fIjbuild\-workspace\fP are replaced by \fIdune\-workspace\fP files
+.IP \(bu 2
+\fIjbuild\-workspace<suffix>\fP files no longer mean anything
+.UNINDENT
+.sp
+Following are detailed explanation of the differences between the
+Jbuilder configuration files and the Dune ones.
+.SS dune\-project files
+.sp
+These are a new kind of file. With Jbuilder, projects used to be
+identified by the presence of at least one \fI<package>.opam\fP file in a
+directory. This will still be supported until July 2019, however as
+Jbuilder evolved it became clear that we needed project files, so Dune
+introduces \fIdune\-project\fP files to mark the root of projects.
+.sp
+Eventually, we are hoping that Dune will generate opam files. So users
+will only have to write a \fIdune\-project\fP file.
+.sp
+The purpose of this file is to:
+.INDENT 0.0
+.IP \(bu 2
+delimit projects in larger workspaces
+.IP \(bu 2
+set a few project\-wide parameters, such as the name, the version of the Dune
+language in use or specification of extra features (plugins) used in the
+project
+.UNINDENT
+.sp
+Eventually, for users who wish to do so it should be possible to
+centralize all the configuration of a project in this file.
+.SS dune files
+.sp
+These are the same as \fIjbuild\fP files.
+.SS dune\-workspace
+.sp
+These are the same as \fIjbuild\-workspace\fP files.
+.sp
+When looking for the root of the workspace, Jbuilder also looks for
+files whose name start with \fIjbuild\-workspace\fP, such as
+\fIjbuild\-workspace.in\fP\&. This rule will be kept until July 2019, however
+it is not preserved for \fIdune\-workspace\fP files. I.e. a
+\fIdune\-workspace.in\fP file means nothing.
+.sp
+This rule was only useful when we didn\(aqt have project files.
+.SS Variable syntax
+.sp
+\fB${foo} and $(foo)\fP are no longer valid variable syntax in dune files.
+Variables are defined as \fB%{foo}\fP\&. This change is done to simplify
+interoperability with bash commands which also use the \fB${foo}\fP syntax.
+.SS \fB(files_recursively_in ..)\fP is removed
+.sp
+The \fBfiles_recursively_in\fP dependency specification is invalid in dune files.
+A source_tree stanza has been introduced to reflect the
+actual function of this stanza.
+.SS Escape sequences
+.sp
+Invalid escape sequences of the form \fB\ex\fP where \fBx\fP is a character other
+than \fB[0\-9]\fP, \fBx\fP, \fBn\fP, \fBr\fP, \fBt\fP, \fBb\fP are not allowed in dune files.
+.SS Comments syntax
+.sp
+Block comments of the form \fB#| ... |#\fP and comments of the form \fB#;\fP are not
+supported in dune files.
+.SS Renamed variables
+.sp
+All existing variables have been lowercased for consistency. Other variables
+have always been renamed. Refer to this table for details:
+.TS
+center;
+|l|l|.
+_
+T{
+Jbuild
+T}	T{
+Dune
+T}
+_
+T{
+\fB${@}\fP
+T}	T{
+\fB%{targets}\fP
+T}
+_
+T{
+\fB${^}\fP
+T}	T{
+\fB%{deps}\fP
+T}
+_
+T{
+\fB${path:file}\fP
+T}	T{
+\fB%{dep:file}\fP
+T}
+_
+T{
+\fB${SCOPE_ROOT}\fP
+T}	T{
+\fB%{project_root}\fP
+T}
+_
+T{
+\fB${ROOT}\fP
+T}	T{
+\fB%{workspace_root}\fP
+T}
+_
+T{
+\fB${findlib:..}\fP
+T}	T{
+\fB%{lib:..}\fP
+T}
+_
+T{
+\fB${CPP}\fP
+T}	T{
+\fB%{cpp}\fP
+T}
+_
+T{
+\fB${CC}\fP
+T}	T{
+\fB%{cc}\fP
+T}
+_
+T{
+\fB${CXX}\fP
+T}	T{
+\fB%{cxx}\fP
+T}
+_
+T{
+\fB${OCAML}\fP
+T}	T{
+\fB%{ocaml}\fP
+T}
+_
+T{
+\fB${OCAMLC}\fP
+T}	T{
+\fB%{ocamlc}\fP
+T}
+_
+T{
+\fB${OCAMLOPT}\fP
+T}	T{
+\fB%{ocamlopt}\fP
+T}
+_
+T{
+\fB${ARCH_SIXTYFOUR}\fP
+T}	T{
+\fB%{arch_sixtyfour}\fP
+T}
+_
+T{
+\fB${MAKE}\fP
+T}	T{
+\fB%{make}\fP
+T}
+_
+.TE
+.SS Removed variables
+.sp
+\fB${path\-no\-dep:file}\fP and \fB${<}\fP have been removed.
+.sp
+A named dependency should be used instead of \fB${<}\fP\&. For instance
+the following jbuild file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(alias
+ ((name   runtest)
+  (deps   (input))
+  (action (run ./test.exe %{<}))))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+should be rewritten to the following dune file:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+(rule
+ (alias  runtest)
+ (deps   (:x input))
+ (action (run ./test.exe %{x})))
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS \fB# JBUILDER_GEN\fP renamed
+.sp
+\fB# DUNE_GEN\fP should be used instead of \fB# JBUILDER_GEN\fP in META templates.
+.SS jbuild\-ignore (deprecated)
+.sp
+\fBjbuild\-ignore\fP files are deprecated and replaced by
+dune\-subdirs stanzas in \fBdune\fP files.
+.SH CACHING
+.sp
+Dune has the ability to cache built files for later retrieval. This
+can greatly speedup subsequent builds when some dependencies are
+rebuilt in different workspaces, switching branches or iterating on
+code back and forth.
+.SS Configuration
+.sp
+The cache is, for now, an opt\-in feature. Add \fI(cache enabled)\fP to
+your dune configuration file (default \fI~/.config/dune/config\fP) to
+activate it. When turned on, built files will automatically be
+promoted to the cache, and subsequent builds will automatically check
+the cache for hits.
+.sp
+The cached files are stored inside you \fIXDG_CACHE_HOME\fP directory on
+*nix systems, and \fI"HOME\eLocal Settings\eCache"\fP on Windows.
+.SS Daemon
+.sp
+By default, most cache operations go through the dune cache daemon, a
+separate process that dune instances connect to. This enables
+promotions to happen asynchronously and not slow the build
+process. The daemon is automatically started if needed when dune needs
+accessing the cache, and lives on for further use.
+.sp
+Although the daemon concept is totally transparent, one can control it
+via the \fIdune cache\fP subcommand.
+.SS Starting the daemon
+.sp
+Use \fIdune cache start\fP to start the caching daemon if not running and
+print its endpoint, or retrieve the endpoint of the currently running
+daemon otherwise. A notable option is \fI\-\-foreground\fP to not detach the
+daemon, which can help inspecting its log output.
+.SS Stopping the daemon
+.sp
+Use \fIdune cache stop\fP to stop the caching daemon. Although the daemon,
+when idle, should consume zero resources, you may want to get rid of
+the process. Also useful to restart the daemon with \fI\-\-foreground\fP\&.
+.SS Filesystem implementation
+.SS Hardlink mode
+.sp
+By default the cache works by creating hardlinks to built files inside
+the cache directory when promoted, and in other build trees when
+retrieved. This has the great advantage of having zero disk space
+overhead for files still living in a build directory. This has two
+main constraints:
+.INDENT 0.0
+.IP \(bu 2
+The cache root must be on the same partition as the build tree.
+.IP \(bu 2
+Produced files will be stripped from write permissions, as they are
+shared between build trees. Note that modifying built files is bad
+practice in any case.
+.UNINDENT
+.SS Copy mode
+.sp
+If one specifies \fI(cache\-duplication copy)\fP in the configuration file,
+dune will copy files to and from the cache instead of using hardlinks.
+This can be useful if the build cache is on a different partition.
+.SS On\-disk size
+.sp
+The cache daemon will perform periodic trimming to limit the overhead.
+Every 10 minutes, it will purge the least recently used files so the
+cache overhead does not exceed 10G. This is configurable through the
+\fI(cache\-trim\-period SECONDS)\fP and \fI(cache\-trim\-size BYTES)\fP
+configuration entries. Note that this operation will only consider the
+cache overhead, i.e. files not currently hard\-linked in a build
+directory, as removing files currently used would not free any disk
+space.
+.sp
+On can run \fIdune cache trim \-\-size=BYTES\fP to manually trigger trimming
+in the cache daemon.
+.SS Reproducibility
+.SS Reproducibility check
+.sp
+While default mode of operation of the cache is to speedup build times
+by not re\-running some rules, it can also be used to check build
+reproducibility. If \fI(cache\-check\-probability FLOAT)\fP or
+\fI\-\-cache\-check\-probability=FLOAT\fP is specified either respectively in
+the configuration file or the command line, in case of a cache hit
+dune will rerun the rule anyway with the given probability and compare
+the resulting files against a potential cache hit. If the files
+differ, the rule is not reproducible and a warning will be emitted.
+.SS Non\-reproducible rules
+.sp
+If you know that some rule is not reproducible (e.g. because it
+downloads a non\-fixed file from the internet) and should never be
+cached, then you can mark it as such by using \fI(deps (universe))\fP\&.
+See deps\-field\&.
+.SS Daemon\-less mode
+.sp
+While the cache daemon provides asynchronous promotions to speedup
+builds and background trimming amongst other things, in some
+situations direct access can be preferable. This can be the case when
+running in an isolated environment like Docker or OPAM sandboxes,
+where only one instance of dune will ever be running at a time, and
+access to external cache is prohibited. Direct filesystem access can
+be obtained by specifying \fI(cache\-transport direct)\fP in the
+configuration file or passing \fI\-\-cache\-transport=direct\fP on the
+command line.
+.SH TOPLEVEL INTEGRATION
+.sp
+OCaml provides a small repl to use the language interactively. We
+generally call this tool a toplevel. The compiler distribution comes
+with a small repl called simply \fBocaml\fP and the community has
+developed enhanced versions such as \fI\%utop\fP\&.
+.sp
+It\(aqs possible to load dune projects in any toplevel. To do that,
+simply execute the following in your toplevel:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+# #use_output "dune top";;
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\fBdune top\fP is a dune command that builds all the libraries in the
+current directory and sub\-directories and output the relevant toplevel
+directives (\fB#directory\fP and \fB#load\fP) to make the various modules
+available in the toplevel.
+.sp
+Additionally, if some of the libraries are ppx rewriters the phrases
+you type in the toplevel will be rewritten with these ppx rewriters.
+.sp
+This command is available since Dune 2.5.0.
+.sp
+Note that the \fB#use_output\fP directivce is only available since OCaml
+4.11. You can add the following snippet to your \fB~/.ocamlinit\fP file
+to make it available in older versions of OCaml:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+ #directory "+compiler\-libs"
+
+ let try_finally ~always f =
+   match f () with
+   | x \->
+     always ();
+     x
+   | exception e \->
+     always ();
+     raise e
+
+ let use_output command =
+   let fn = Filename.temp_file "ocaml" "_toploop.ml" in
+   try_finally
+     ~always:(fun () \-> try Sys.remove fn with Sys_error _ \-> ())
+     (fun () \->
+       match
+         Printf.ksprintf Sys.command "%s > %s" command (Filename.quote fn)
+       with
+       | 0 \-> ignore (Toploop.use_file Format.std_formatter fn : bool)
+       | n \-> Format.printf "Command exited with code %d.@." n)
+
+ let () =
+   let name = "use_output" in
+   if not (Hashtbl.mem Toploop.directive_table name) then
+     Hashtbl.add Toploop.directive_table name
+       (Toploop.Directive_string use_output)
+
+;;
+#remove_directory "+compiler\-libs"
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH GOAL OF DUNE
+.sp
+The main goal of the Dune project is to provide the best possible
+build tool for the whole of the OCaml community; from individual
+developers who work on open source projects during their free time all
+the way to larger companies such as Jane Street passing by communities
+such as MirageOS. And to the extent that is reasonably possible, help
+provide the same features for friend communities such as Coq and
+possibly Reason/Bucklescript in the future.
+.sp
+We haven\(aqt reached this goal yet and Dune still lacks in some areas in
+order to be such a tool, but we are steadily working towards that goal.
+On a practical level, there are a few boxes to check. There are in
+fact a ton details to sort out, but at a high\-level a tool that works
+for everyone in the OCaml community should at least:
+.INDENT 0.0
+.IP 1. 3
+have excellent backward compatibility properties
+.IP 2. 3
+have a robust and scalable core
+.IP 3. 3
+remain a no\-brainer dependency
+.IP 4. 3
+remain accessible
+.IP 5. 3
+have very good support for the OCaml language
+.IP 6. 3
+be extensible
+.UNINDENT
+.sp
+At this point, we have done a good job at 1, 3, 4 and 5, we are
+working towards 2 and are doing the preparatory work for 6. Once all
+these boxes have been checked, we will consider that the Dune project
+is feature complete.
+.sp
+In the rest of this page, we develop these points and give some
+insights into our current and future focuses.
+.SS Have excellent backward compatibility properties
+.sp
+In an open\-source community, there will always be groups of people
+with enough resources to continuously bring their projects up to date
+as well as people who work on their free time and cannot provide the
+same level of continuous support and updates.
+.sp
+From the point of view of Dune, we have to assume that a released
+project with \fBdune\fP files is a precious piece that will potentially
+never change. So changing Dune in a way that it could no longer
+understand a released project is by default a no\-no.
+.sp
+Of course, we can\(aqt give a 100% guarantee that Dune will always behave
+exactly the same. That would be unrealistic and would prevent the
+project from moving forward.  In order for us to provide good backward
+compatibility properties while still keeping the project fresh and
+dynamic, we have to make sure to properly delimit, document and
+version the set of behaviours on which users should rely. And for this
+to be manageable, the surface API of Dune has to remain small.
+.sp
+A distinguishing feature of Dune is that it lets the user declare which
+version of the \fBdune\fP tool their project was written against, and
+\fBdune\fP will morph itself to behave the same as this version of the
+\fBdune\fP binary, even if it is a newer version. As a result, a recent
+version of the \fBdune\fP binary is able to understand a wide range of
+dune projects written against many different version of Dune. And
+while we strictly follow \fI\%semantic versioning\fP, new major versions of
+Dune effectively introduce very few breaking changes and most projects
+do not need upper bounds on Dune.
+.sp
+This guarantee is of course limited to documented behaviours.
+.SS Have a robust and scalable core
+.sp
+Tech companies tend be fond of big mono repositories, so to be able to
+work for them Dune needs to be able to eat up large repositories
+without blinking. It not only needs to build fast, but more
+importantly it must not get in the way of fast feedback during
+development, no matter the size of the repository.
+.sp
+Note that Dune will only be tested on repositories as large as people
+participating in the development of Dune require. Currently, the
+largest user is Jane Street. If someone wanted to use Dune on much
+larger repositories than the ones used at Jane Street and this
+required a significant amount of effort on Dune, this wouldn\(aqt be
+considered unless we get some help to do so and we can keep the other
+promises.
+.sp
+In particular, while making Dune scalable we must also make sure to
+not turn Dune into a monster because no one wants to force their users
+to install a monster to build their project. This brings us to the
+next point of Dune being a no\-brainer dependency.
+.SS Remain a no\-brainer dependency
+.sp
+Dune is a hard dependency of any Dune project. Anyone using Dune
+to develop their project will have to ask their user to install
+Dune. For this reason, it is very important to keep Dune as lean as
+possible.
+.sp
+This is why we have to be careful when we start relying on an external
+piece of software, or when we introduce new concepts. We must make
+sure to not introduce duplication or useless stuff. The overall
+projects has to remain lean.
+.sp
+It is also important to keep Dune as easy to install as
+possible. Currently, the only requirement to build Dune is a
+working OCaml compiler. Nothing else is required, not even a shell and
+we should keep it this way.
+.SS Remain accessible
+.sp
+Since Dune aims to be the best possible tool for the whole OCaml
+community, it is important for Dune to remain accessible. Getting
+started and learning Dune should be straightforward.
+.sp
+For that purpose, when designing the language, the command line
+interface or the documentation, we must take on the perspective
+of a user who is just discovering Dune and its features.
+.sp
+Because Dune must be suitable for everyone, it must also provide
+advanced and more complex features for expert users. However, the
+documentation should always flow from the simpler concepts and common
+tasks to the more complex ones. Even if the simpler features can be
+explained as instances of the more general ones.
+.SS Have very good support for the OCaml language
+.sp
+There are many many build systems out there. What makes Dune different
+is that it primarily targets the OCaml community. So Dune must come
+with excellent support for the OCaml language and OCaml projects in
+general.
+.sp
+If it didn\(aqt, then Dune would just be yet another build system.
+.sp
+Perhaps in the future some of the general build system will take over
+and Dune might just become a plugin in this system, or even disappear
+into the language if the compiler gains a lot of higher level
+features. But for now, Dune is a standalone build system that is
+primarily serving the needs of the OCaml community, and to the extent
+that is reasonably possible the needs of friend communities.
+.SS Be extensible
+.sp
+No matter how good the support for the OCaml language is, it will
+never be enough to cover every single project need. For this reason,
+Dune needs to provide some form of openness for projects that need
+something that doesn\(aqt completely fit in the model provided by Dune.
+.sp
+In the long run, extensibility tends to get in the way of innovation
+and we should always strive to make sure that all the general needs
+are covered by the main Dune language, but we will always need an
+escape hatch for Dune to remain a practical choice.
+.sp
+It is pretty clear to us that extensibility must be done via OCaml
+code, and currently it is a bit difficult to use OCaml as a proper
+extension language, though some work is being done to help on that
+front.
+.SH AUTHOR
+Jérémie Dimino
+.SH COPYRIGHT
+2017, Jérémie Dimino
+.\" Generated by docutils manpage writer.
+.


### PR DESCRIPTION
This allows us to ship the entire dune manual as one big man page. That
already makes it pretty useful to browse docs offline.

It's possible to split the man pages up, but this is just an experiment
for now.

I'm not a huge fan of checking in the man pages like this. Perhaps
there's a way to do this step as part of dune-release?

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>


----

#