### PR TITLE
doc/dune-files.rst: typo

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1714,7 +1714,7 @@ process. This is done using the ``coq.extraction`` stanza:
 - ``(prelude <name>)`` refers to the Coq source that contains the extraction
   commands.
 
-- ``(extraced_modules <names>)`` is an exhaustive list of OCaml modules
+- ``(extracted_modules <names>)`` is an exhaustive list of OCaml modules
   extracted.
 
 - ``<optional-fields>`` are ``flags``, ``theories``, and ``libraries``. All of


### PR DESCRIPTION
Just a typo.