### PR TITLE
Add foreign compilation modes

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -86,7 +86,7 @@ let o_files sctx ~dir ~expander ~(exes : Executables.t) ~linkages ~dir_contents
     in
     Foreign_rules.build_o_files ~sctx ~dir ~expander ~requires:requires_compile
       ~dir_contents ~foreign_sources
-    |> List.map ~f:Path.build
+    |> List.filter_map ~f:Foreign.Object.build_path_native
 
 let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
     ~embed_in_plugin_libraries (exes : Dune_file.Executables.t) =

--- a/src/dune_rules/foreign.mli
+++ b/src/dune_rules/foreign.mli
@@ -70,9 +70,11 @@ module Archive : sig
   val dll_file : archive:t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
 end
 
-(* CR-amokhov: add docs. *)
+(** In some situations, it is useful to make compilation of foreign source files
+    conditional, and include the resulting objects only into native or bytecode
+    libraries, but not both. *)
 module Compilation_mode : sig
-  type t = private
+  type t =
     | Both_byte_and_native
     | Only_byte
     | Only_native
@@ -170,18 +172,27 @@ module Source : sig
   val make : stubs:Stubs.t -> path:Path.Build.t -> t
 end
 
+(** The [path] to a foreign object file along with the compilation [mode] that
+    specfies whether it should be included into native or bytecode libraries, or
+    into both (the latter is the most common case). *)
 module Object : sig
   type t =
     { path : Path.Build.t
     ; mode : Compilation_mode.t
     }
 
+  (** Should this file be included into both native and bytecode libraries? *)
   val both_byte_and_native : t -> bool
 
+  (** Path to the object file in the build directory. *)
   val build_path : t -> Path.t
 
+  (** Like [build_path] but returns [Some] only if the object should be included
+      into bytecode libraries. *)
   val build_path_byte : t -> Path.t option
 
+  (** Like [build_path] but returns [Some] only if the object should be included
+      into native libraries. *)
   val build_path_native : t -> Path.t option
 end
 

--- a/src/dune_rules/foreign.mli
+++ b/src/dune_rules/foreign.mli
@@ -70,6 +70,14 @@ module Archive : sig
   val dll_file : archive:t -> dir:Path.Build.t -> ext_dll:string -> Path.Build.t
 end
 
+(* CR-amokhov: add docs. *)
+module Compilation_mode : sig
+  type t = private
+    | Both_byte_and_native
+    | Only_byte
+    | Only_native
+end
+
 (** A type of foreign library "stubs", which includes all fields of the
     [Library.t] type except for the [archive_name] field. The type is parsed as
     an optional [foreign_stubs] field of the [library] stanza, or as part of the
@@ -88,6 +96,7 @@ module Stubs : sig
   type t =
     { loc : Loc.t
     ; language : Foreign_language.t
+    ; mode : Compilation_mode.t
     ; names : Ordered_set_lang.t
     ; flags : Ordered_set_lang.Unexpanded.t
     ; include_dirs : Include_dir.t list
@@ -148,6 +157,8 @@ module Source : sig
 
   val language : t -> Foreign_language.t
 
+  val mode : t -> Compilation_mode.t
+
   val flags : t -> Ordered_set_lang.Unexpanded.t
 
   val path : t -> Path.Build.t
@@ -159,12 +170,26 @@ module Source : sig
   val make : stubs:Stubs.t -> path:Path.Build.t -> t
 end
 
+module Object : sig
+  type t =
+    { path : Path.Build.t
+    ; mode : Compilation_mode.t
+    }
+
+  val both_byte_and_native : t -> bool
+
+  val build_path : t -> Path.t
+
+  val build_path_byte : t -> Path.t option
+
+  val build_path_native : t -> Path.t option
+end
+
 (** A map from object names to the corresponding sources. *)
 module Sources : sig
   type t = (Loc.t * Source.t) String.Map.t
 
-  val object_files :
-    t -> dir:Path.Build.t -> ext_obj:string -> Path.Build.t list
+  val object_files : t -> dir:Path.Build.t -> ext_obj:string -> Object.t list
 
   (** A map from object names to lists of possible language/path combinations. *)
   module Unresolved : sig

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -112,8 +112,7 @@ let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
          ; S [ A "-I"; Path ctx.stdlib_dir ]
          ; include_flags
          ]
-       @ output_param @ [ A "-c"; Dep src ] ));
-  dst
+       @ output_param @ [ A "-c"; Dep src ] ))
 
 (* TODO: [requires] is a confusing name, probably because it's too general: it
    looks like it's a list of libraries we depend on. *)
@@ -160,4 +159,5 @@ let build_o_files ~sctx ~foreign_sources ~(dir : Path.Build.t) ~expander
            | C -> build_c ~kind:Foreign_language.C
            | Cxx -> build_c ~kind:Foreign_language.Cxx
          in
-         build_file ~sctx ~dir ~expander ~include_flags (loc, src, dst))
+         build_file ~sctx ~dir ~expander ~include_flags (loc, src, dst);
+         { Foreign.Object.path = dst; mode = stubs.mode })

--- a/src/dune_rules/foreign_rules.mli
+++ b/src/dune_rules/foreign_rules.mli
@@ -9,4 +9,4 @@ val build_o_files :
   -> expander:Expander.t
   -> requires:Lib.L.t Or_exn.t
   -> dir_contents:Dir_contents.t
-  -> Path.Build.t list
+  -> Foreign.Object.t list

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -66,6 +66,7 @@ end = struct
           let name = Lib_info.name lib in
           let files = Foreign_sources.for_lib foreign_sources ~name in
           Foreign.Sources.object_files files ~dir ~ext_obj
+          |> List.map ~f:(fun (obj : Foreign.Object.t) -> obj.path)
         else
           Lib_info.foreign_archives lib )
       ; if_
@@ -439,7 +440,7 @@ end = struct
               |> Foreign_sources.for_lib ~name
               |> Foreign.Sources.object_files ~dir
                    ~ext_obj:ctx.lib_config.ext_obj
-              |> List.map ~f:Path.build
+              |> List.map ~f:Foreign.Object.build_path
             in
             let modules =
               Dir_contents.ocaml dir_contents

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -115,6 +115,8 @@ let gen_wrapped_compat_modules (lib : Library.t) cctx =
 (* Rules for building static and dynamic libraries using [ocamlmklib]. *)
 let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~foreign_objects
     ~vlib_stubs_o_files ~archive_name ~build_targets_together =
+  (* We can't build static and dynamic libraries together if one of the object
+     files should be treated specially. *)
   let build_targets_together =
     build_targets_together
     && List.for_all foreign_objects ~f:Foreign.Object.both_byte_and_native
@@ -125,6 +127,8 @@ let ocamlmklib ~loc ~c_library_flags ~sctx ~dir ~expander ~foreign_objects
     Foreign.Archive.Name.lib_file archive_name ~dir ~ext_lib
   in
   let build ~custom ~sandbox ~o_files targets =
+    (* CR amokhov: Should we include [vlib_stubs_o_files] into both static and
+       dynamic libraries? *)
     let o_files = vlib_stubs_o_files @ o_files in
     Super_context.add_rule sctx ~sandbox ~dir ~loc
       (let cclibs_args =

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -125,7 +125,7 @@ let impl sctx ~(lib : Dune_file.Library.t) ~scope =
               Dir_contents.foreign_sources dir_contents
               |> Foreign_sources.for_lib ~name
               |> Foreign.Sources.object_files ~ext_obj ~dir
-              |> List.map ~f:Path.build
+              |> List.map ~f:Foreign.Object.build_path
             in
             (modules, foreign_objects)
         in


### PR DESCRIPTION
Add ability to make compilation of foreign stubs conditional on the mode via `(mode byte)` or `(mode native)`, which is useful for building the OCaml compiler with Dune.

For example:

```
(library
 (name foo)
 (modules)
 (foreign_stubs (language c) (mode byte) (flags -DBYTE) (names foo_bytes))
 (foreign_stubs (language c) (mode native) (flags -DNATIVE) (names foo_native)))

(executable
 (name main_byte)
 (modes byte)
 (libraries foo)
 (modules main_byte))

(executable
 (name main_native)
 (modes native)
 (libraries foo)
 (modules main_native))
```

where both `foo_bytes.c` and `foo_native.c` are defined as follows:

```c
#include <caml/mlvalues.h>
#ifdef BYTE
value foo_byte(value unit) { return Val_int(1); }
#endif
#ifdef NATIVE
value foo_native(value unit) { return Val_int(2); }
#endif
value foo_common(value unit) { return Val_int(3); }
```

Here is what we see in the test (instead of a failure due to multiple definitions of `foo_common`):

```
  $ cat >main_byte.ml <<EOF
  > external foo_byte : unit -> int = "foo_byte"
  > external foo_common : unit -> int = "foo_common"
  > let () = Printf.printf "%d" (foo_byte () + foo_common ())
  > EOF

  $ cat >main_native.ml <<EOF
  > external foo_native : unit -> int = "foo_native"
  > external foo_common : unit -> int = "foo_common"
  > let () = Printf.printf "%d" (foo_native () + foo_common ())
  > EOF

  $ ./sdune clean
  $ ./sdune build _build/default/main_byte.bc
  $ (cd _build/default; ocamlrun -I . main_byte.bc)
  4
  $ ./sdune exec ./main_native.exe
  5
```

/cc @mshinwell @jeremiedimino 

P.S.: There is also `Byte_with_stubs_statically_linked_in` link mode, which I'm not handling correctly.