### PR TITLE
Introduce `dune ocaml` command group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Unreleased
 - Fixed a bug that could result in needless recompilation under Windows due to
   case differences in the result of `Sys.getcwd` (observed under `emacs`).
   (#3966, @nojb).
-  
+
 - Fixed absence of executable bit for installed `.cmxs` (#4149, fixes #4148, @bobot)
 
 - Allow `%{version:pkg}` to work for external packages (#4104, @kit-ty-kate)
@@ -16,6 +16,9 @@ Unreleased
 
 - Automatically generate empty `.mli` files for executables and tests (#3768,
   fixes #3745, @CraigFe)
+
+- Add `ocaml` command subgroup for OCaml related commands such as `utop`, `top`,
+  and `merlin` (#3936, @rgrinberg).
 
 2.8.2 (21/01/2021)
 ------------------

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -29,6 +29,8 @@ module Profile = Dune_rules.Profile
 module Log = Dune_util.Log
 include Common.Let_syntax
 
+let in_group (t, info) = (Term.Group.Term t, info)
+
 let make_cache (config : Config.t) =
   let make_cache () =
     let command_handler (Cache.Dedup file) =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,31 +1,36 @@
 open! Stdune
 open Import
 
-let all =
-  [ Installed_libraries.command
-  ; External_lib_deps.command
-  ; Build_cmd.build
-  ; Build_cmd.runtest
-  ; command_alias Build_cmd.runtest "test"
-  ; Clean.command
-  ; Install_uninstall.install
-  ; Install_uninstall.uninstall
-  ; Exec.command
-  ; Subst.command
-  ; Print_rules.command
-  ; Utop.command
-  ; Init.command
-  ; Promote.command
-  ; Printenv.command
-  ; Help.command
-  ; Format_dune_file.command
-  ; Compute.command
-  ; Upgrade.command
-  ; Caching.command
-  ; Describe.command
-  ; Top.command
-  ; Ocaml_merlin.command
-  ]
+let all : _ Term.Group.t list =
+  let terms =
+    [ Installed_libraries.command
+    ; External_lib_deps.command
+    ; Build_cmd.build
+    ; Build_cmd.runtest
+    ; command_alias Build_cmd.runtest "test"
+    ; Clean.command
+    ; Install_uninstall.install
+    ; Install_uninstall.uninstall
+    ; Exec.command
+    ; Subst.command
+    ; Print_rules.command
+    ; Utop.command
+    ; Init.command
+    ; Promote.command
+    ; Printenv.command
+    ; Help.command
+    ; Format_dune_file.command
+    ; Compute.command
+    ; Upgrade.command
+    ; Caching.command
+    ; Describe.command
+    ; Top.command
+    ; Ocaml_merlin.command
+    ]
+    |> List.map ~f:in_group
+  in
+  let groups = [ Ocaml.group ] in
+  terms @ groups
 
 let common_commands_synopsis =
   (* Short reminders for the most used and useful commands *)
@@ -88,7 +93,7 @@ let default =
 let () =
   Colors.setup_err_formatter_colors ();
   try
-    match Term.eval_choice default all ~catch:false with
+    match Term.Group.eval default all ~catch:false with
     | `Error _ -> exit 1
     | _ -> exit 0
   with exn ->

--- a/bin/ocaml.ml
+++ b/bin/ocaml.ml
@@ -1,0 +1,11 @@
+open Import
+
+let info = Term.info "ocaml"
+
+let group =
+  ( Term.Group.Group
+      [ in_group Utop.command
+      ; in_group Ocaml_merlin.command
+      ; in_group Top.command
+      ]
+  , info )

--- a/bin/ocaml.mli
+++ b/bin/ocaml.mli
@@ -1,0 +1,3 @@
+open Import
+
+val group : unit Term.Group.t

--- a/bin/top.mli
+++ b/bin/top.mli
@@ -1,0 +1,1 @@
+val command : unit Cmdliner.Term.t * Cmdliner.Term.info

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -117,6 +117,15 @@
  (files   dune-installed-libraries.1))
 
 (rule
+ (with-stdout-to dune-ocaml.1
+  (run dune ocaml --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-ocaml.1))
+
+(rule
  (with-stdout-to dune-ocaml-merlin.1
   (run dune ocaml-merlin --help=groff)))
 

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -1,5 +1,14 @@
 
 (rule
+ (with-stdout-to dune-test.1
+  (run dune test --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-test.1))
+
+(rule
  (with-stdout-to dune-build.1
   (run dune build --help=groff)))
 
@@ -196,13 +205,4 @@
  (section man)
  (package dune)
  (files   dune-utop.1))
-
-(rule
- (with-stdout-to dune-test.1
-  (run dune test --help=groff)))
-
-(install
- (section man)
- (package dune)
- (files   dune-test.1))
 

--- a/doc/toplevel-integration.rst
+++ b/doc/toplevel-integration.rst
@@ -13,9 +13,9 @@ simply execute the following in your toplevel:
 
 .. code:: ocaml
 
-    # #use_output "dune top";;
+    # #use_output "dune ocaml top";;
 
-``dune top`` is a dune command that builds all the libraries in the
+``dune ocaml top`` is a dune command that builds all the libraries in the
 current directory and sub-directories and output the relevant toplevel
 directives (``#directory`` and ``#load``) to make the various modules
 available in the toplevel.
@@ -25,9 +25,9 @@ you type in the toplevel will be rewritten with these ppx rewriters.
 
 This command is available since Dune 2.5.0.
 
-Note that the ``#use_output`` directivce is only available since OCaml
-4.11. You can add the following snippet to your ``~/.ocamlinit`` file
-to make it available in older versions of OCaml:
+Note that the ``#use_output`` directive is only available since OCaml 4.11. You
+can add the following snippet to your ``~/.ocamlinit`` file to make it available
+in older versions of OCaml:
 
 .. code:: ocaml
 

--- a/doc/update-jbuild.sh
+++ b/doc/update-jbuild.sh
@@ -5,7 +5,7 @@
 set -e -o pipefail
 
 CMDS=$(dune --help=plain | \
-           sed -n '/COMMANDS/,/OPTIONS/p' | sed -En 's/^       ([a-z-]+) ?.*/\1/p')
+           sed -n '/COMMAND ALIASES/,/OPTIONS/p' | sed -En 's/^       ([a-z-]+) ?.*/\1/p')
 
 for cmd in $CMDS; do
     cat <<EOF

--- a/test/blackbox-tests/test-cases/cmdliner-dep-conf.t/run.t
+++ b/test/blackbox-tests/test-cases/cmdliner-dep-conf.t/run.t
@@ -14,13 +14,13 @@
   [1]
 
   $ dune build "(fi"
-  dune: TARGET... arguments: unclosed parenthesis at end of input
+  dune build: TARGET... arguments: unclosed parenthesis at end of input
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]
 
   $ dune build "()"
-  dune: TARGET... arguments: Unexpected list
+  dune build: TARGET... arguments: Unexpected list
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/describe.t/run.t
+++ b/test/blackbox-tests/test-cases/describe.t/run.t
@@ -94,10 +94,10 @@ Test errors
   [1]
 
   $ dune describe --lang 1.0
-  dune: Only --lang 0.1 is available at the moment as this command is not yet
-        stabilised. If you would like to release a software that relies on the output
-        of 'dune describe', please open a ticket on
-        https://github.com/ocaml/dune.
+  dune describe: Only --lang 0.1 is available at the moment as this command is not yet
+                 stabilised. If you would like to release a software that relies on the output
+                 of 'dune describe', please open a ticket on
+                 https://github.com/ocaml/dune.
   Usage: dune describe [OPTION]... [STRING]...
   Try `dune describe --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -239,10 +239,11 @@ Comments in dune files are preserved
 Will not create components with invalid names
 
   $ dune init lib invalid-component-name ./_test_lib
-  dune: NAME argument: invalid component name `invalid-component-name'
-        Library names must be non-empty and composed only of the
-        following
-        characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
+  dune init: NAME argument: invalid component name
+             `invalid-component-name'
+             Library names must be non-empty and composed only of the
+             following
+             characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
   Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]
@@ -252,8 +253,8 @@ Will not create components with invalid names
 Will fail and inform user when invalid component command is given
 
   $ dune init foo blah
-  dune: INIT_KIND argument: invalid value `foo', expected one of `executable',
-        `library', `project' or `test'
+  dune init: INIT_KIND argument: invalid value `foo', expected one of
+             `executable', `library', `project' or `test'
   Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/findlib-dynload.t/run.t
+++ b/test/blackbox-tests/test-cases/findlib-dynload.t/run.t
@@ -51,7 +51,7 @@
   b: called
   a: called
 
-  $ dune exe mytool_auto
+  $ dune exec mytool_auto
   m: init
   a: init
   b: init
@@ -59,7 +59,7 @@
   b: called
   a: called
 
-  $ dune exe mytool c_thread
+  $ dune exec mytool c_thread
   m: init
   c_thread: registering
 

--- a/test/blackbox-tests/test-cases/format-dune-file.t/run.t
+++ b/test/blackbox-tests/test-cases/format-dune-file.t/run.t
@@ -171,7 +171,7 @@ Files in OCaml syntax are copied verbatim (but error when passed in stdin).
 
 Non 0 error code:
 
-  $ echo "(" | dune format ; echo $?
+  $ echo "(" | dune format-dune-file ; echo $?
   File "", line 2, characters 0-0:
   Error: unclosed parenthesis at end of input
   1

--- a/test/blackbox-tests/test-cases/github3046.t/run.t
+++ b/test/blackbox-tests/test-cases/github3046.t/run.t
@@ -7,8 +7,8 @@ are given as parameters
 `dune init exe main --libs="str gsl"` returns an informative parsing error
 
   $ dune init exe main --libs="str gsl"
-  dune: option `--libs': invalid element in list (`str gsl'): expected a valid
-        dune atom
+  dune init: option `--libs': invalid element in list (`str gsl'): expected a
+             valid dune atom
   Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]
@@ -16,8 +16,8 @@ are given as parameters
 `dune init lib foo --ppx="foo bar"` returns an informative parsing error
 
   $ dune init lib foo --ppx="foo bar"
-  dune: option `--ppx': invalid element in list (`foo bar'): expected a valid
-        dune atom
+  dune init: option `--ppx': invalid element in list (`foo bar'): expected a
+             valid dune atom
   Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]
@@ -25,10 +25,11 @@ are given as parameters
 `dune init lib foo --public="some/invalid&name!"` returns an informative parsing error
 
   $ dune init lib foo --public="some/invalid&name!"
-  dune: option `--public': invalid component name `some/invalid&name!'
-        Library names must be non-empty and composed only of the
-        following
-        characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
+  dune init: option `--public': invalid component name
+             `some/invalid&name!'
+             Library names must be non-empty and composed only of the
+             following
+             characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
   Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/github3530.t/run.t
+++ b/test/blackbox-tests/test-cases/github3530.t/run.t
@@ -2,7 +2,7 @@ When an empty string is passed to `-p`, we get a nice error message.
 
   $ echo '(lang dune 2.0)' > dune-project
   $ dune build -p ''
-  dune: option `-p': Invalid package name: ""
+  dune build: option `-p': Invalid package name: ""
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]
@@ -10,7 +10,7 @@ When an empty string is passed to `-p`, we get a nice error message.
 This can happen in a list as well:
 
   $ dune build -p 'a,b,'
-  dune: option `-p': Invalid package name: ""
+  dune build: option `-p': Invalid package name: ""
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/misc.t/run.t
+++ b/test/blackbox-tests/test-cases/misc.t/run.t
@@ -6,37 +6,37 @@ Test that incompatible options are properly reported
 ----------------------------------------------------
 
   $ dune build --verbose --display quiet
-  dune: Cannot use --verbose and --display simultaneously
+  dune build: Cannot use --verbose and --display simultaneously
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]
 
   $ dune build -p toto --root .
-  dune: Cannot use --root and -p simultaneously
+  dune build: Cannot use --root and -p simultaneously
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]
 
   $ dune build --for-release-of-packages toto --root .
-  dune: Cannot use --root and --for-release-of-packages simultaneously
+  dune build: Cannot use --root and --for-release-of-packages simultaneously
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]
 
   $ dune build --no-config --config x
-  dune: Cannot use --config and --no-config simultaneously
+  dune build: Cannot use --config and --no-config simultaneously
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]
 
   $ dune build -p toto --release
-  dune: Cannot use --release and -p simultaneously
+  dune build: Cannot use --release and -p simultaneously
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]
 
   $ dune build --release --root .
-  dune: Cannot use --root and --release simultaneously
+  dune build: Cannot use --root and --release simultaneously
   Usage: dune build [OPTION]... [TARGET]...
   Try `dune build --help' or `dune --help' for more information.
   [1]

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -52,7 +52,7 @@ The makefile version of pipe actions uses actual pipes:
   >    (pipe-outputs (run a) (run b) (run c)))))
   > EOF
 
-  $ dune rule -m target
+  $ dune rules -m target
   _build/default/target: _build/install/default/bin/a \
     _build/install/default/bin/b _build/install/default/bin/c
   	mkdir -p _build/default; \

--- a/test/blackbox-tests/test-cases/toplevel-integration.t/run.t
+++ b/test/blackbox-tests/test-cases/toplevel-integration.t/run.t
@@ -14,7 +14,7 @@ Test toplevel-init-file on a tiny project
   > let hello () = print_endline "hello"
   > EOF
 
-  $ dune top
+  $ dune ocaml top
   #directory "$TESTCASE_ROOT/_build/default/.test.objs/byte";;
   #directory "$TESTCASE_ROOT/_build/default/.test.objs/native";;
   #load "$TESTCASE_ROOT/_build/default/test.cma";;
@@ -22,7 +22,7 @@ Test toplevel-init-file on a tiny project
   $ ocaml -stdin <<EOF
   > #use "topfind";;
   > #use "use_output_compat";;
-  > #use_output "dune top";;
+  > #use_output "dune ocaml top";;
   > Test.Main.hello ();;
   > EOF
   hello
@@ -31,7 +31,7 @@ Test toplevel-init-file on a tiny project
   > let oops () = undefined_function ()
   > EOF
 
-  $ dune top
+  $ dune ocaml top
   File "error.ml", line 1, characters 14-32:
   1 | let oops () = undefined_function ()
                     ^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ Test toplevel-init-file on a tiny project
   $ ocaml -stdin <<EOF
   > #use "topfind";;
   > #use "use_output_compat";;
-  > #use_output "dune top";;
+  > #use_output "dune ocaml top";;
   > EOF
   File "error.ml", line 1, characters 14-32:
   1 | let oops () = undefined_function ()

--- a/vendor/cmdliner/src/cmdliner.mli
+++ b/vendor/cmdliner/src/cmdliner.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Declarative definition of command line interfaces.
@@ -22,7 +22,7 @@
     use. Open the module to use it, it defines only three modules in
     your scope.
 
-    {e v1.0.4-3-ga5ff0e8 — {{:http://erratique.ch/software/cmdliner }homepage}} *)
+    {e v1.0.4-24-gb0f156d — {{:http://erratique.ch/software/cmdliner }homepage}} *)
 
 (** {1:top Interface} *)
 
@@ -381,6 +381,31 @@ module Term : sig
       If the command name is unknown an error is reported. If the name
       is unspecified the "main" term [t] is evaluated. [i] defines the
       name and man page of the program. *)
+
+  module Group : sig
+    type 'a term
+
+    type 'a node =
+    | Term of 'a term
+    | Group of 'a t list
+    (** The type for an individual command or a command group.
+        {ul
+        {- [Term], individual command term.}
+        {- [Group], a list of command terms in the same group.}} *)
+
+    and 'a t = 'a node * info
+    (** An individual command or a command group annotated with an [info] *)
+
+    val eval :
+      ?help:Format.formatter -> ?err:Format.formatter -> ?catch:bool ->
+      ?env:(string -> string option) -> ?argv:string array ->
+      'a term * info -> 'a t list -> 'a result
+    (** [eval help err catch argv (t, i) choices] is like {!eval_choice}
+        except that it will search for term inside the command group [choices]
+
+        If a command group is selected without a sub command, the program will
+        exit with an error message. *)
+  end with type 'a term := 'a t
 
   val eval_peek_opts :
     ?version_opt:bool -> ?env:(string -> string option) ->
@@ -1255,7 +1280,7 @@ let cmd =
     `S Manpage.s_see_also; `P "$(b,rmdir)(1), $(b,unlink)(2)" ]
   in
   Term.(const rm $ prompt $ recursive $ files),
-  Term.info "rm" ~version:"v1.0.4-3-ga5ff0e8" ~doc ~exits:Term.default_exits ~man
+  Term.info "rm" ~version:"v1.0.4-24-gb0f156d" ~doc ~exits:Term.default_exits ~man
 
 let () = Term.(exit @@ eval cmd)
 ]}
@@ -1325,7 +1350,7 @@ let cmd =
       `P "Email them to <hehey at example.org>."; ]
   in
   Term.(ret (const cp $ verbose $ recurse $ force $ srcs $ dest)),
-  Term.info "cp" ~version:"v1.0.4-3-ga5ff0e8" ~doc ~exits ~man ~man_xrefs
+  Term.info "cp" ~version:"v1.0.4-24-gb0f156d" ~doc ~exits ~man ~man_xrefs
 
 let () = Term.(exit @@ eval cmd)
 ]}
@@ -1598,7 +1623,7 @@ let default_cmd =
   let exits = Term.default_exits in
   let man = help_secs in
   Term.(ret (const (fun _ -> `Help (`Pager, None)) $ copts_t)),
-  Term.info "darcs" ~version:"v1.0.4-3-ga5ff0e8" ~doc ~sdocs ~exits ~man
+  Term.info "darcs" ~version:"v1.0.4-24-gb0f156d" ~doc ~sdocs ~exits ~man
 
 let cmds = [initialize_cmd; record_cmd; help_cmd]
 

--- a/vendor/cmdliner/src/cmdliner_arg.ml
+++ b/vendor/cmdliner/src/cmdliner_arg.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 let rev_compare n0 n1 = compare n1 n0

--- a/vendor/cmdliner/src/cmdliner_arg.mli
+++ b/vendor/cmdliner/src/cmdliner_arg.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Command line arguments as terms. *)

--- a/vendor/cmdliner/src/cmdliner_base.ml
+++ b/vendor/cmdliner/src/cmdliner_base.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (* Invalid argument strings *)
@@ -82,6 +82,9 @@ let err_unknown ?(hints = []) ~kind v =
   let did_you_mean s = strf ", did you mean %s ?" s in
   let hints = match hints with [] -> "." | hs -> did_you_mean (alts_str hs) in
   strf "unknown %s %s%s" kind (quote v) hints
+
+let err_no_sub_command =
+  "is a command group and requires a command argument."
 
 let err_no kind s = strf "no %s %s" (quote s) kind
 let err_not_dir s = strf "%s is not a directory" (quote s)

--- a/vendor/cmdliner/src/cmdliner_base.mli
+++ b/vendor/cmdliner/src/cmdliner_base.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** A few helpful base definitions. *)
@@ -20,6 +20,7 @@ val err_ambiguous : kind:string -> string -> ambs:string list -> string
 val err_unknown : ?hints:string list -> kind:string -> string -> string
 val err_multi_def :
   kind:string -> string -> ('b -> string) -> 'b -> 'b -> string
+ val err_no_sub_command : string
 
 (** {1:conv Textual OCaml value converters} *)
 

--- a/vendor/cmdliner/src/cmdliner_cline.ml
+++ b/vendor/cmdliner/src/cmdliner_cline.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (* A command line stores pre-parsed information about the command

--- a/vendor/cmdliner/src/cmdliner_cline.mli
+++ b/vendor/cmdliner/src/cmdliner_cline.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Command lines. *)

--- a/vendor/cmdliner/src/cmdliner_docgen.ml
+++ b/vendor/cmdliner/src/cmdliner_docgen.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 let rev_compare n0 n1 = compare n1 n0
@@ -60,10 +60,13 @@ let term_info_subst ei = function
 
 let invocation ?(sep = ' ') ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_main -> term_name (Cmdliner_info.eval_main ei)
+| `Multiple_group
 | `Multiple_sub ->
-    strf "%s%c%s"
-      Cmdliner_info.(term_name @@ eval_main ei) sep
-      Cmdliner_info.(term_name @@ eval_term ei)
+    let sep = String.make 1 sep in
+    Cmdliner_info.eval_terms_rev ei
+    |> List.rev_map Cmdliner_info.term_name
+    |> String.concat sep
+    |> strf "%s"
 
 let plain_invocation ei = invocation ei
 let invocation ?sep ei = esc @@ invocation ?sep ei
@@ -81,6 +84,7 @@ let synopsis_pos_arg a =
 
 let synopsis ei = match Cmdliner_info.eval_kind ei with
 | `Multiple_main -> strf "$(b,%s) $(i,COMMAND) ..." @@ invocation ei
+| `Multiple_group
 | `Simple | `Multiple_sub ->
     let rev_cli_order (a0, _) (a1, _) =
       Cmdliner_info.rev_arg_pos_cli_order a0 a1
@@ -97,6 +101,7 @@ let synopsis ei = match Cmdliner_info.eval_kind ei with
 
 let cmd_docs ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_sub -> []
+| `Multiple_group
 | `Multiple_main ->
     let add_cmd acc t =
       let cmd = strf "$(b,%s)" @@ term_name t in

--- a/vendor/cmdliner/src/cmdliner_docgen.mli
+++ b/vendor/cmdliner/src/cmdliner_docgen.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 val plain_invocation : Cmdliner_info.eval -> string

--- a/vendor/cmdliner/src/cmdliner_info.mli
+++ b/vendor/cmdliner/src/cmdliner_info.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Terms, argument, env vars information.
@@ -111,17 +111,26 @@ val term_add_args : term -> args -> term
 
 type eval
 
-val eval :
-  term:term -> main:term -> choices:term list ->
-  env:(string -> string option) -> eval
+type eval_kind =
+| Simple of term
+| Main of { term : term ; choices : term list }
+| Sub_command of { term : term;
+                   (** is [term] is from a group, [path] are the ancestors
+                        direct with the direct parent *)
+                   path : term list;
+                   main : term;
+                   sibling_terms : term list }
+
+val eval : env:(string -> string option) -> eval_kind -> eval
 
 val eval_term : eval -> term
 val eval_main : eval -> term
 val eval_choices : eval -> term list
 val eval_env_var : eval -> string -> string option
-val eval_kind : eval -> [> `Multiple_main | `Multiple_sub | `Simple ]
+val eval_kind : eval -> [> `Multiple_main | `Multiple_group | `Multiple_sub | `Simple ]
 val eval_with_term : eval -> term -> eval
 val eval_has_choice : eval -> string -> bool
+val eval_terms_rev : eval -> term list
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli

--- a/vendor/cmdliner/src/cmdliner_manpage.ml
+++ b/vendor/cmdliner/src/cmdliner_manpage.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (* Manpages *)
@@ -23,7 +23,6 @@ let s_name = "NAME"
 let s_synopsis = "SYNOPSIS"
 let s_description = "DESCRIPTION"
 let s_commands = "COMMANDS"
-let s_command_aliases = "COMMAND ALIASES"
 let s_arguments = "ARGUMENTS"
 let s_options = "OPTIONS"
 let s_common_options = "COMMON OPTIONS"
@@ -46,7 +45,7 @@ let s_see_also = "SEE ALSO"
 let s_created = ""
 let order =
   [| s_name; s_synopsis; s_description; s_created; s_commands;
-     s_command_aliases; s_arguments; s_options; s_common_options; s_exit_status;
+     s_arguments; s_options; s_common_options; s_exit_status;
      s_environment; s_files; s_examples; s_bugs; s_authors; s_see_also; |]
 
 let order_synopsis = 1

--- a/vendor/cmdliner/src/cmdliner_manpage.mli
+++ b/vendor/cmdliner/src/cmdliner_manpage.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Manpages.

--- a/vendor/cmdliner/src/cmdliner_msg.ml
+++ b/vendor/cmdliner/src/cmdliner_msg.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 let strf = Printf.sprintf
@@ -68,7 +68,9 @@ let err_arg_missing a =
 
 (* Other messages *)
 
-let exec_name ei = Cmdliner_info.(term_name @@ eval_main ei)
+let exec_name_terms terms =
+  String.concat " " (List.rev_map Cmdliner_info.term_name terms)
+let exec_name ei = exec_name_terms (Cmdliner_info.eval_terms_rev ei)
 
 let pp_version ppf ei = match Cmdliner_info.(term_version @@ eval_main ei) with
 | None -> assert false
@@ -77,10 +79,16 @@ let pp_version ppf ei = match Cmdliner_info.(term_version @@ eval_main ei) with
 let pp_try_help ppf ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_main ->
     pp ppf "@[<2>Try `%s --help' for more information.@]" (exec_name ei)
+| `Multiple_group
 | `Multiple_sub ->
     let exec_cmd = Cmdliner_docgen.plain_invocation ei in
+    let parent =
+      Cmdliner_info.eval_terms_rev ei
+      |> List.tl
+      |> exec_name_terms
+    in
     pp ppf "@[<2>Try `%s --help' or `%s --help' for more information.@]"
-      exec_cmd (exec_name ei)
+      exec_cmd parent
 
 let pp_err ppf ei ~err = pp ppf "%s: @[%a@]@." (exec_name ei) pp_lines err
 

--- a/vendor/cmdliner/src/cmdliner_msg.mli
+++ b/vendor/cmdliner/src/cmdliner_msg.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Messages for the end-user. *)

--- a/vendor/cmdliner/src/cmdliner_suggest.ml
+++ b/vendor/cmdliner/src/cmdliner_suggest.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 let levenshtein_distance s t =

--- a/vendor/cmdliner/src/cmdliner_suggest.mli
+++ b/vendor/cmdliner/src/cmdliner_suggest.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 val value : string -> string list -> string list

--- a/vendor/cmdliner/src/cmdliner_term.ml
+++ b/vendor/cmdliner/src/cmdliner_term.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 type term_escape =

--- a/vendor/cmdliner/src/cmdliner_term.mli
+++ b/vendor/cmdliner/src/cmdliner_term.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Terms *)

--- a/vendor/cmdliner/src/cmdliner_trie.ml
+++ b/vendor/cmdliner/src/cmdliner_trie.ml
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 module Cmap = Map.Make (Char)                           (* character maps. *)

--- a/vendor/cmdliner/src/cmdliner_trie.mli
+++ b/vendor/cmdliner/src/cmdliner_trie.mli
@@ -1,7 +1,7 @@
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
-   cmdliner v1.0.4-3-ga5ff0e8
+   cmdliner v1.0.4-24-gb0f156d
   ---------------------------------------------------------------------------*)
 
 (** Tries.

--- a/vendor/update-cmdliner.sh
+++ b/vendor/update-cmdliner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=a5ff0e8b5a35569fb710d51d735fa05baa027117
+version=b0f156d3d07cf783b2cf2421495c2445ae190a38
 
 set -e -o pipefail
 


### PR DESCRIPTION
This is based on some patches to:
https://github.com/dbuenzli/cmdliner/issues/24#issuecomment-723720963

The work is still ongoing and I plan to improev things further, but we can
already start using it.

This PR uses the new API to introduce an `ocaml` subcommand that includes utop,
top, and merlin. The old commands remain for backwards compatibility.