### PR TITLE
Add versioning for dune auto-formatting style

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -124,3 +124,5 @@ let bytes =
 let context_name : Context_name.t conv = conv Context_name.conv
 
 let lib_name = conv Dune_engine.Lib_name.conv
+
+let version = pair ~sep:'.' int int

--- a/bin/arg.mli
+++ b/bin/arg.mli
@@ -39,3 +39,5 @@ val package_name : Package.Name.t conv
 val profile : Profile.t conv
 
 val lib_name : Lib_name.t conv
+
+val version : Dune_lang.Syntax.Version.t conv

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -287,8 +287,11 @@ let print_as_sexp dyn =
     |> Dune_lang.Ast.add_loc ~loc:Loc.none
     |> Dune_lang.Cst.concrete
   in
+  let version =
+    Dune_lang.Syntax.greatest_supported_version Dune_engine.Stanza.syntax
+  in
   Pp.to_fmt Stdlib.Format.std_formatter
-    (Dune_engine.Format_dune_lang.pp_top_sexps [ cst ])
+    (Dune_engine.Format_dune_lang.pp_top_sexps ~version [ cst ])
 
 let term =
   let+ common = Common.term

--- a/bin/format_dune_file.ml
+++ b/bin/format_dune_file.ml
@@ -20,8 +20,15 @@ let term =
     let docv = "FILE" in
     let doc = "Path to the dune file to parse." in
     Arg.(value & pos 0 (some path) None & info [] ~docv ~doc)
+  and+ version =
+    let docv = "VERSION" in
+    let doc = "Which version of Dune language to use." in
+    let default =
+      Dune_lang.Syntax.greatest_supported_version Dune_engine.Stanza.syntax
+    in
+    Arg.(value & opt version default & info [ "dune-version" ] ~docv ~doc)
   in
   let input = Option.map ~f:Arg.Path.path path_opt in
-  Format_dune_lang.format_file ~input ~output:None
+  Format_dune_lang.format_file ~version ~input ~output:None
 
 let command = (term, info)

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -27,9 +27,12 @@ let pp ppf ~fields sexps =
         | _ -> false
       in
       if do_print then
+        let version =
+          Dune_lang.Syntax.greatest_supported_version Dune_engine.Stanza.syntax
+        in
         Dune_lang.Ast.add_loc sexp ~loc:Loc.none
         |> Dune_lang.Cst.concrete |> List.singleton
-        |> Dune_engine.Format_dune_lang.pp_top_sexps
+        |> Dune_engine.Format_dune_lang.pp_top_sexps ~version
         |> Format.fprintf ppf "%a@?" Pp.to_fmt)
 
 let term =

--- a/src/dune_engine/action_ast.ml
+++ b/src/dune_engine/action_ast.ml
@@ -276,8 +276,13 @@ struct
       List
         ( atom (sprintf "pipe-%s" (Outputs.to_string outputs))
         :: List.map l ~f:encode )
-    | Format_dune_file (src, dst) ->
-      List [ atom "format-dune-file"; path src; target dst ]
+    | Format_dune_file (ver, src, dst) ->
+      List
+        [ atom "format-dune-file"
+        ; Dune_lang.Syntax.Version.encode ver
+        ; path src
+        ; target dst
+        ]
     | Cram script -> List [ atom "cram"; path script ]
 
   let run prog args = Run (prog, args)
@@ -329,5 +334,5 @@ struct
   let diff ?(optional = false) ?(mode = Diff.Mode.Text) file1 file2 =
     Diff { optional; file1; file2; mode }
 
-  let format_dune_file src dst = Format_dune_file (src, dst)
+  let format_dune_file ~version src dst = Format_dune_file (version, src, dst)
 end

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -359,8 +359,8 @@ let rec exec t ~ectx ~eenv =
     Fiber.return Done
   | No_infer t -> exec t ~ectx ~eenv
   | Pipe (outputs, l) -> exec_pipe ~ectx ~eenv outputs l
-  | Format_dune_file (src, dst) ->
-    Format_dune_lang.format_file ~input:(Some src)
+  | Format_dune_file (version, src, dst) ->
+    Format_dune_lang.format_file ~version ~input:(Some src)
       ~output:(Some (Path.build dst));
     Fiber.return Done
   | Cram script ->

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -48,7 +48,7 @@ module type Ast = sig
     | Merge_files_into of path list * string list * target
     | No_infer of t
     | Pipe of Outputs.t * t list
-    | Format_dune_file of path * target
+    | Format_dune_file of Dune_lang.Syntax.Version.t * path * target
     | Cram of path
 end
 
@@ -111,5 +111,6 @@ module type Helpers = sig
 
   val diff : ?optional:bool -> ?mode:Diff.Mode.t -> path -> target -> t
 
-  val format_dune_file : path -> target -> t
+  val format_dune_file :
+    version:Dune_lang.Syntax.Version.t -> path -> target -> t
 end

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -51,8 +51,8 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
         , f_target ~dir target )
     | No_infer t -> No_infer (f t ~dir)
     | Pipe (outputs, l) -> Pipe (outputs, List.map l ~f:(fun t -> f t ~dir))
-    | Format_dune_file (src, dst) ->
-      Format_dune_file (f_path ~dir src, f_target ~dir dst)
+    | Format_dune_file (ver, src, dst) ->
+      Format_dune_file (ver, f_path ~dir src, f_target ~dir dst)
     | Cram script -> Cram (f_path ~dir script)
 
   let rec map t ~dir ~f_program ~f_string ~f_path ~f_target =

--- a/src/dune_engine/format_dune_lang.mli
+++ b/src/dune_engine/format_dune_lang.mli
@@ -8,11 +8,20 @@ type dune_file =
 val parse_file : Path.t option -> dune_file
 
 (** Write the formatted concrete syntax to the file at [path] *)
-val write_file : path:Path.t -> Dune_lang.Cst.t list -> unit
+val write_file :
+     version:Dune_lang.Syntax.Version.t
+  -> path:Path.t
+  -> Dune_lang.Cst.t list
+  -> unit
 
 (** Reformat a dune file. [None] in [input] corresponds to stdin. [None] in
     [output] corresponds to stdout. *)
-val format_file : input:Path.t option -> output:Path.t option -> unit
+val format_file :
+     version:Dune_lang.Syntax.Version.t
+  -> input:Path.t option
+  -> output:Path.t option
+  -> unit
 
 (** Pretty-print a list of toplevel s-expressions *)
-val pp_top_sexps : Dune_lang.Cst.t list -> _ Pp.t
+val pp_top_sexps :
+  version:Dune_lang.Syntax.Version.t -> Dune_lang.Cst.t list -> _ Pp.t

--- a/src/dune_rules/action_to_sh.ml
+++ b/src/dune_rules/action_to_sh.ml
@@ -91,9 +91,18 @@ let simplify act =
       :: acc
     | No_infer act -> loop act acc
     | Pipe (outputs, l) -> Pipe (List.map ~f:block l, outputs) :: acc
-    | Format_dune_file (src, dst) ->
+    | Format_dune_file (ver, src, dst) ->
       Redirect_out
-        ([ Run ("dune", [ "format-dune-file"; src ]) ], Stdout, File dst)
+        ( [ Run
+              ( "dune"
+              , [ "format-dune-file"
+                ; "--dune-version"
+                ; Dune_lang.Syntax.Version.to_string ver
+                ; src
+                ] )
+          ]
+        , Stdout
+        , File dst )
       :: acc
   and block act =
     match List.rev (loop act []) with

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -203,8 +203,8 @@ module Partial = struct
         , E.target ~expander target )
     | No_infer t -> No_infer (expand t ~expander)
     | Pipe (outputs, l) -> Pipe (outputs, List.map l ~f:(expand ~expander))
-    | Format_dune_file (src, dst) ->
-      Format_dune_file (E.path ~expander src, E.target ~expander dst)
+    | Format_dune_file (ver, src, dst) ->
+      Format_dune_file (ver, E.path ~expander src, E.target ~expander dst)
     | Cram script -> Cram (E.path ~expander script)
 end
 
@@ -319,8 +319,8 @@ let rec partial_expand t ~expander : Partial.t =
       , E.target ~expander target )
   | No_infer t -> No_infer (partial_expand t ~expander)
   | Pipe (outputs, l) -> Pipe (outputs, List.map l ~f:(partial_expand ~expander))
-  | Format_dune_file (src, dst) ->
-    Format_dune_file (E.path ~expander src, E.target ~expander dst)
+  | Format_dune_file (ver, src, dst) ->
+    Format_dune_file (ver, E.path ~expander src, E.target ~expander dst)
   | Cram script -> Cram (E.path ~expander script)
 
 module Infer : sig
@@ -454,7 +454,7 @@ end = struct
       | Mkdir _
       | No_infer _ ->
         acc
-      | Format_dune_file (src, dst) -> acc +< src +@+ dst
+      | Format_dune_file (_, src, dst) -> acc +< src +@+ dst
 
     let infer t =
       let { deps; deps_if_exist; targets } =

--- a/src/dune_rules/dune_init.ml
+++ b/src/dune_rules/dune_init.ml
@@ -152,7 +152,10 @@ module File = struct
 
   let write_dune_file (dune_file : dune) =
     let path = Path.relative dune_file.path dune_file.name in
-    Format_dune_lang.write_file ~path dune_file.content
+    let version =
+      Dune_lang.Syntax.greatest_supported_version Dune_engine.Stanza.syntax
+    in
+    Format_dune_lang.write_file ~version ~path dune_file.content
 
   let write f =
     let path = full_path f in

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -21,8 +21,8 @@ let depend_on_files ~named dir =
 
 let formatted = ".formatted"
 
-let gen_rules_output sctx (config : Format_config.t) ~dialects ~expander
-    ~output_dir =
+let gen_rules_output sctx (config : Format_config.t) ~version ~dialects
+    ~expander ~output_dir =
   assert (formatted = Path.Build.basename output_dir);
   let loc = Format_config.loc config in
   let dir = Path.Build.parent_exn output_dir in
@@ -42,7 +42,7 @@ let gen_rules_output sctx (config : Format_config.t) ~dialects ~expander
         @@
         let open Build.O in
         let+ () = Build.path input in
-        Action.format_dune_file input output
+        Action.format_dune_file ~version input output
       | _ ->
         let ext = Path.Source.extension file in
         let open Option.O in

--- a/src/dune_rules/format_rules.mli
+++ b/src/dune_rules/format_rules.mli
@@ -9,6 +9,7 @@ val gen_rules : dir:Path.Build.t -> unit
 val gen_rules_output :
      Super_context.t
   -> Format_config.t
+  -> version:Dune_lang.Syntax.Version.t
   -> dialects:Dialect.DB.t
   -> expander:Expander.t
   -> output_dir:Path.Build.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -160,8 +160,11 @@ let gen_format_rules sctx ~expander ~output_dir =
   let scope = Super_context.find_scope_by_dir sctx output_dir in
   let project = Scope.project scope in
   let dialects = Dune_project.dialects project in
+  let version = Dune_project.dune_version project in
   with_format sctx ~dir:output_dir
-    ~f:(Format_rules.gen_rules_output sctx ~dialects ~expander ~output_dir)
+    ~f:
+      (Format_rules.gen_rules_output sctx ~version ~dialects ~expander
+         ~output_dir)
 
 (* This is used to determine the list of source directories to give to Merlin.
    This serves the same purpose as [Merlin.lib_src_dirs] and has a similar


### PR DESCRIPTION
See https://github.com/ocaml/dune/pull/3928#issuecomment-727015097

This PR adds versioning for the auto-formatting style for the `dune` language.

- The `format-dune-file` subcommand now carries an optional flag `--dune-version` to specify the version wanted (note that this command is not used by `dune` itself, since the formatting is done in-core since #3536)

- `dune describe`, `dune printenv` and `dune init` use the latest version, since it seemed frivolous to add a flag to set the style version.