### PR TITLE
Replace Unix.select with Unix.sleepf

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -477,7 +477,7 @@ end = struct
   let wait_win32 () =
     while not (wait_nonblocking_win32 ()) do
       Mutex.unlock mutex;
-      Unix.sleepf 0.001;
+      Thread.delay 0.001;
       Mutex.lock mutex
     done
 

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -477,7 +477,7 @@ end = struct
   let wait_win32 () =
     while not (wait_nonblocking_win32 ()) do
       Mutex.unlock mutex;
-      ignore (Unix.select [] [] [] 0.001);
+      Unix.sleepf 0.001;
       Mutex.lock mutex
     done
 


### PR DESCRIPTION
select had no arguments, so it's the same as a sleep.