### PR TITLE
Add non applicative case in `Build.t` for staging

### DIFF
--- a/src/dune_engine/build.ml
+++ b/src/dune_engine/build.ml
@@ -384,7 +384,7 @@ struct
   module rec Execution : sig
     val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 
-    val build_deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
+    val build_static_rule_deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
   end = struct
     module Function = struct
       type 'a input = 'a memo
@@ -471,10 +471,10 @@ struct
         (f, deps)
       | Build b ->
         let* b, deps0 = exec b in
-        let+ r, deps1 = build_deps_and_exec b in
+        let+ r, deps1 = build_static_rule_deps_and_exec b in
         (r, Dep.Set.union deps0 deps1)
 
-    and build_deps_and_exec : type a. a t -> (a * Dep.Set.t) Fiber.t =
+    and build_static_rule_deps_and_exec : type a. a t -> (a * Dep.Set.t) Fiber.t =
      fun t ->
       let* () = Build_deps.build_deps (static_deps t).rule_deps in
       exec t

--- a/src/dune_engine/build.ml
+++ b/src/dune_engine/build.ml
@@ -370,12 +370,12 @@ let fold_labeled (type acc) t ~(init : acc) ~f =
 (* Execution *)
 
 module Expert = struct
-  let fiber f = Fiber f
-
-  let dyn_fiber f = Dyn_fiber f
-
   let build f = Build f
 end
+
+let fiber f = Fiber f
+
+let dyn_fiber f = Dyn_fiber f
 
 module Make_exec (Build_deps : sig
   val build_deps : Dep.Set.t -> unit Fiber.t

--- a/src/dune_engine/build.ml
+++ b/src/dune_engine/build.ml
@@ -26,7 +26,7 @@ type 'a t =
   | Memo : 'a memo -> 'a t
   | Catch : 'a t * (exn -> 'a) -> 'a t
   | Deps : Dep.Set.t -> unit t
-  | Fiber : 'a t Fiber.t -> 'a t
+  | Fiber : 'a Fiber.t -> 'a t
   | Build : 'a t t -> 'a t
 
 and 'a memo =
@@ -451,8 +451,8 @@ module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) 
             )
           | Memo m -> Memo.eval m
           | Fiber f ->
-            let* b = f in
-            go_deps b
+            let+ f = f in
+            (f, Dep.Set.empty)
           | Build b ->
             let* b, deps0 = go b in
             let+ r, deps1 = go_deps b in

--- a/src/dune_engine/build.ml
+++ b/src/dune_engine/build.ml
@@ -24,7 +24,7 @@ type 'a t =
   | Or_exn : 'a Or_exn.t t -> 'a t
   | Fail : fail -> _ t
   | Memo : 'a memo -> 'a t
-  | Catch : 'a t * (exn -> 'a) -> 'a t
+  | Don't_fail : 'a t * 'a -> 'a t
   | Deps : Dep.Set.t -> unit t
   | Fiber : 'a Fiber.t -> 'a t
   | Dyn_fiber : 'a Fiber.t t -> 'a t
@@ -115,7 +115,7 @@ let env_var s = Deps (Dep.Set.singleton (Dep.env s))
 
 let alias a = dep (Dep.alias a)
 
-let catch t ~on_error = Catch (t, on_error)
+let don't_fail t ~on_error = Don't_fail (t, on_error)
 
 let contents p = Contents p
 
@@ -317,7 +317,7 @@ end = struct
     | Or_exn _ -> Static_deps.empty
     | Fail _ -> Static_deps.empty
     | Memo m -> Memo.exec memo (Input.T m)
-    | Catch (t, _) -> static_deps t
+    | Don't_fail (t, _) -> static_deps t
     | Fiber _ -> Static_deps.empty
     | Dyn_fiber b -> static_deps b
     | Build b -> static_deps b
@@ -360,7 +360,7 @@ let fold_labeled (type acc) t ~(init : acc) ~f =
         loop else_ acc
     | Filter_existing_files p -> loop p acc
     | Memo m -> loop m.t acc
-    | Catch (t, _) -> loop t acc
+    | Don't_fail (t, _) -> loop t acc
     | Fiber _ -> acc
     | Dyn_fiber b -> loop b acc
     | Build b -> loop b acc
@@ -446,16 +446,15 @@ module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) 
         let+ (x, files), dyn_deps = exec p in
         let files = Path.Set.filter ~f:file_exists files in
         ((x, files), dyn_deps)
-      | Catch (t, on_error) -> (
+      | Don't_fail (t, on_error) -> (
           let+ res = Fiber.fold_errors
-                       ~init:None
-                       ~on_error:(fun bt _ -> Some (on_error bt.Exn_with_backtrace.exn))
+                       ~init:on_error
+                       ~on_error:(fun _ x -> x)
                        (fun () -> exec t)
           in
           match res with
           | Ok r -> r
-          | Error None -> assert false
-          | Error (Some r) -> (r, Dep.Set.empty)
+          | Error r -> (r, Dep.Set.empty)
         )
       | Memo m -> Memo.eval m
       | Fiber f ->

--- a/src/dune_engine/build.ml
+++ b/src/dune_engine/build.ml
@@ -474,7 +474,8 @@ struct
         let+ r, deps1 = build_static_rule_deps_and_exec b in
         (r, Dep.Set.union deps0 deps1)
 
-    and build_static_rule_deps_and_exec : type a. a t -> (a * Dep.Set.t) Fiber.t =
+    and build_static_rule_deps_and_exec : type a. a t -> (a * Dep.Set.t) Fiber.t
+        =
      fun t ->
       let* () = Build_deps.build_deps (static_deps t).rule_deps in
       exec t

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -216,23 +216,23 @@ end) : sig
       dependencies discovered during execution. *)
   val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 
-  (** Same as the previous function but also build the dependencies of the build
-      description *)
-  val build_deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
+  (** Same as [exec] but also builds the static rule dependencies of the build
+      description. *)
+  val build_static_rule_deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 end
 
+(** These functions are experimental and potentially unsafe to use. Each usage
+    must be discussed and justified. *)
 module Expert : sig
-  (** Those function are experimental in there usage. Each usage must be
-      discussed, avoid to use them if possible. Moreover they can be more tricky
-      to use. In a {!fiber} and {!dyn_fiber} should ensure that generated files
-      are already regenerated. The {!build} function turn dependencies that can
-      be though as static in dynamic dependencies, which can reduce the
-      parallelism. *)
-
+  (** If the fiber reads any files, you must ensure they are up to date. *)
   val fiber : 'a Fiber.t -> 'a t
 
+  (** If the fiber reads any files, you must ensure they are up to date. *)
   val dyn_fiber : 'a Fiber.t t -> 'a t
 
+  (** This function "stages" static dependencies and can therefore reduce build
+      parallelism: until the outer build description has been evaluated, the
+      static dependencies of the inner build description are unknown. *)
   val build : 'a t t -> 'a t
 end
 

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -217,6 +217,7 @@ module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) 
 end
 
 val do_not_use_stage_fiber: 'a Fiber.t -> 'a t
+val do_not_use_stage_dyn_fiber: 'a Fiber.t t -> 'a t
 val do_not_use_stage_build: 'a t t -> 'a t
 
 

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -209,8 +209,9 @@ val fold_labeled : _ t -> init:'acc -> f:(label -> 'acc -> 'acc) -> 'acc
 
 (** {1 Execution} *)
 
-module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) : sig
-
+module Make_exec (Build_deps : sig
+  val build_deps : Dep.Set.t -> unit Fiber.t
+end) : sig
   (** Execute a build description. Returns the result and the set of dynamic
       dependencies discovered during execution. *)
   val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
@@ -220,17 +221,19 @@ module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) 
   val build_deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 end
 
-module Expert: sig
+module Expert : sig
   (** Those function are experimental in there usage. Each usage must be
-     discussed, avoid to use them if possible. Moreover they can be more tricky
-     to use. In a {!fiber} and {!dyn_fiber} should ensure that generated files
-     are already regenerated. The {!build} function turn dependencies that can
-     be though as static in dynamic dependencies, which can reduce the
-     parallelism. *)
+      discussed, avoid to use them if possible. Moreover they can be more tricky
+      to use. In a {!fiber} and {!dyn_fiber} should ensure that generated files
+      are already regenerated. The {!build} function turn dependencies that can
+      be though as static in dynamic dependencies, which can reduce the
+      parallelism. *)
 
-  val fiber: 'a Fiber.t -> 'a t
-  val dyn_fiber: 'a Fiber.t t -> 'a t
-  val build: 'a t t -> 'a t
+  val fiber : 'a Fiber.t -> 'a t
+
+  val dyn_fiber : 'a Fiber.t t -> 'a t
+
+  val build : 'a t t -> 'a t
 end
 
 (**/**)

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -214,6 +214,10 @@ module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) 
   (** Execute a build description. Returns the result and the set of dynamic
       dependencies discovered during execution. *)
   val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
+
+  (** Same as the previous function but also build the dependencies of the build
+      description *)
+  val deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 end
 
 val do_not_use_stage_fiber: 'a Fiber.t -> 'a t

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -137,9 +137,9 @@ val dyn_path_set : ('a * Path.Set.t) t -> 'a t
 
 val dyn_path_set_reuse : Path.Set.t t -> Path.Set.t t
 
-(** [don't_fail t ~on_error] evaluates to [on_error] if an exception is raised
-    during the evaluation of [t]. *)
-val don't_fail : 'a t -> on_error:'a -> 'a t
+(** [catch t ~on_error] evaluates to [on_error] if an exception is raised during
+    the evaluation of [t]. *)
+val catch : 'a t -> on_error:'a -> 'a t
 
 (** [contents path] returns a description that when run will return the contents
     of the file at [path]. *)

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -217,13 +217,21 @@ module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) 
 
   (** Same as the previous function but also build the dependencies of the build
       description *)
-  val deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
+  val build_deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 end
 
-val do_not_use_stage_fiber: 'a Fiber.t -> 'a t
-val do_not_use_stage_dyn_fiber: 'a Fiber.t t -> 'a t
-val do_not_use_stage_build: 'a t t -> 'a t
+module Expert: sig
+  (** Those function are experimental in there usage. Each usage must be
+     discussed, avoid to use them if possible. Moreover they can be more tricky
+     to use. In a {!fiber} and {!dyn_fiber} should ensure that generated files
+     are already regenerated. The {!build} function turn dependencies that can
+     be though as static in dynamic dependencies, which can reduce the
+     parallelism. *)
 
+  val fiber: 'a Fiber.t -> 'a t
+  val dyn_fiber: 'a Fiber.t t -> 'a t
+  val build: 'a t t -> 'a t
+end
 
 (**/**)
 

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -137,9 +137,9 @@ val dyn_path_set : ('a * Path.Set.t) t -> 'a t
 
 val dyn_path_set_reuse : Path.Set.t t -> Path.Set.t t
 
-(** [catch t ~on_error] evaluates to [on_error exn] if exception [exn] is raised
+(** [don't_fail t ~on_error] evaluates to [on_error] if an exception is raised
     during the evaluation of [t]. *)
-val catch : 'a t -> on_error:(exn -> 'a) -> 'a t
+val don't_fail : 'a t -> on_error:'a -> 'a t
 
 (** [contents path] returns a description that when run will return the contents
     of the file at [path]. *)

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -216,7 +216,7 @@ module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) 
   val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
 end
 
-val do_not_use_stage_fiber: 'a t Fiber.t -> 'a t
+val do_not_use_stage_fiber: 'a Fiber.t -> 'a t
 val do_not_use_stage_build: 'a t t -> 'a t
 
 

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -224,17 +224,21 @@ end
 (** These functions are experimental and potentially unsafe to use. Each usage
     must be discussed and justified. *)
 module Expert : sig
-  (** If the fiber reads any files, you must ensure they are up to date. *)
-  val fiber : 'a Fiber.t -> 'a t
-
-  (** If the fiber reads any files, you must ensure they are up to date. *)
-  val dyn_fiber : 'a Fiber.t t -> 'a t
-
   (** This function "stages" static dependencies and can therefore reduce build
       parallelism: until the outer build description has been evaluated, the
       static dependencies of the inner build description are unknown. *)
   val build : 'a t t -> 'a t
 end
+
+(** If you're thinking of using [Process.run] in the fiber, check that: (i) you
+    don't in fact need [Command.run], and that (ii) [Process.run] only reads the
+    declared build rule dependencies. *)
+val fiber : 'a Fiber.t -> 'a t
+
+(** If you're thinking of using [Process.run] in the fiber, check that: (i) you
+    don't in fact need [Command.run], and that (ii) [Process.run] only reads the
+    declared build rule dependencies. *)
+val dyn_fiber : 'a Fiber.t t -> 'a t
 
 (**/**)
 

--- a/src/dune_engine/build.mli
+++ b/src/dune_engine/build.mli
@@ -209,9 +209,16 @@ val fold_labeled : _ t -> init:'acc -> f:(label -> 'acc -> 'acc) -> 'acc
 
 (** {1 Execution} *)
 
-(** Execute a build description. Returns the result and the set of dynamic
-    dependencies discovered during execution. *)
-val exec : 'a t -> 'a * Dep.Set.t
+module Make_exec (Build_deps:sig val build_deps: Dep.Set.t -> unit Fiber.t end) : sig
+
+  (** Execute a build description. Returns the result and the set of dynamic
+      dependencies discovered during execution. *)
+  val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
+end
+
+val do_not_use_stage_fiber: 'a t Fiber.t -> 'a t
+val do_not_use_stage_build: 'a t t -> 'a t
+
 
 (**/**)
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1189,8 +1189,7 @@ end = struct
     let static_deps (type a) (t : a t) = Build.static_deps (build t)
 
     let evaluate_and_discover_dynamic_deps_unmemoized t =
-      let* () = build_deps (static_deps t).rule_deps in
-      Build_exec.exec (build t)
+      Build_exec.deps_and_exec (build t)
 
     let memo =
       Memo.create "evaluate-rule-and-discover-dynamic-deps"

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1172,7 +1172,9 @@ end = struct
       | Sandbox_config _ ->
         Fiber.return ())
 
-  module Build_exec = Build.Make_exec(struct let build_deps = build_deps end)
+  module Build_exec = Build.Make_exec (struct
+    let build_deps = build_deps
+  end)
 
   let () = Build.set_file_system_accessors ~file_exists
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1189,7 +1189,7 @@ end = struct
     let static_deps (type a) (t : a t) = Build.static_deps (build t)
 
     let evaluate_and_discover_dynamic_deps_unmemoized t =
-      Build_exec.deps_and_exec (build t)
+      Build_exec.build_deps_and_exec (build t)
 
     let memo =
       Memo.create "evaluate-rule-and-discover-dynamic-deps"

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1172,6 +1172,8 @@ end = struct
       | Sandbox_config _ ->
         Fiber.return ())
 
+  module Build_exec = Build.Make_exec(struct let build_deps = build_deps end)
+
   let () = Build.set_file_system_accessors ~file_exists
 
   module Build_request = struct
@@ -1187,8 +1189,8 @@ end = struct
     let static_deps (type a) (t : a t) = Build.static_deps (build t)
 
     let evaluate_and_discover_dynamic_deps_unmemoized t =
-      let+ () = build_deps (static_deps t).rule_deps in
-      Build.exec (build t)
+      let* () = build_deps (static_deps t).rule_deps in
+      Build_exec.exec (build t)
 
     let memo =
       Memo.create "evaluate-rule-and-discover-dynamic-deps"

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1191,7 +1191,7 @@ end = struct
     let static_deps (type a) (t : a t) = Build.static_deps (build t)
 
     let evaluate_and_discover_dynamic_deps_unmemoized t =
-      Build_exec.build_deps_and_exec (build t)
+      Build_exec.build_static_rule_deps_and_exec (build t)
 
     let memo =
       Memo.create "evaluate-rule-and-discover-dynamic-deps"

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -168,7 +168,7 @@ module Unprocessed = struct
     in
     let cu_config =
       { requires
-      ; flags = Build.catch flags ~on_error:(fun _ -> [])
+      ; flags = Build.don't_fail flags ~on_error:[]
       ; preprocess
       ; libname
       ; source_dirs

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -168,7 +168,7 @@ module Unprocessed = struct
     in
     let cu_config =
       { requires
-      ; flags = Build.don't_fail flags ~on_error:[]
+      ; flags = Build.catch flags ~on_error:[]
       ; preprocess
       ; libname
       ; source_dirs


### PR DESCRIPTION
This MR merge additions to `Build.t` from #3900 @bobot and #3131 by @rgrinberg . The name, as proposed by  @jeremiedimino during a meeting, make sure that we ponder each uses.

```
val do_not_use_stage_fiber: 'a Fiber.t -> 'a t
val do_not_use_stage_dyn_fiber: 'a Fiber.t t -> 'a t
val do_not_use_stage_build: 'a t t -> 'a t
```

The goal is to make them available and to discuss only when we are going to use them if their use is justified.