### PR TITLE
Fix optional argument warnings for 4.12

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1980,7 +1980,7 @@ let load_dir_and_produce_its_rules ~dir =
 
 let load_dir ~dir = load_dir_and_produce_its_rules ~dir
 
-let init ~contexts ?caching ~sandboxing_preference =
+let init ~contexts ?caching ~sandboxing_preference () =
   let contexts =
     Context_name.Map.of_list_map_exn contexts ~f:(fun c ->
         (c.Build_context.name, c))

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -18,6 +18,7 @@ val init :
   -> ?caching:caching
   -> sandboxing_preference:Sandbox_mode.t list
   -> unit
+  -> unit
 
 val reset : unit -> unit
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -423,7 +423,7 @@ let gen ~contexts ?only_packages conf =
     in
     let* host, stanzas = Fiber.fork_and_join host stanzas in
     let sctx =
-      Super_context.create ?host ~context ~projects ~packages ~stanzas
+      Super_context.create ?host ~context ~projects ~packages ~stanzas ()
     in
     let+ () = Fiber.Ivar.fill (Table.find_exn sctxs context.name) sctx in
     (context.name, sctx)

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -75,7 +75,7 @@ let init_build_system ?only_packages ~sandboxing_preference ?caching w =
   Build_system.reset ();
   Build_system.init ~sandboxing_preference
     ~contexts:(List.map ~f:Context.to_build_context w.contexts)
-    ?caching;
+    ?caching ();
   List.iter w.contexts ~f:Context.init_configurator;
   let+ scontexts = Gen_rules.gen w.conf ~contexts:w.contexts ?only_packages in
   { workspace = w; scontexts }

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -499,7 +499,7 @@ let create_projects_by_package projects : Dune_project.t Package.Name.Map.t =
              (name, project)))
   |> Package.Name.Map.of_list_exn
 
-let create ~(context : Context.t) ?host ~projects ~packages ~stanzas =
+let create ~(context : Context.t) ?host ~projects ~packages ~stanzas () =
   let lib_config = Context.lib_config context in
   let projects_by_package = create_projects_by_package projects in
   let installed_libs =

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -17,6 +17,7 @@ val create :
   -> projects:Dune_project.t list
   -> packages:Package.t Package.Name.Map.t
   -> stanzas:Dune_load.Dune_file.t list
+  -> unit
   -> t
 
 val context : t -> Context.t


### PR DESCRIPTION
If a function has an optional argument, it should also have a positional one.
Somehow pre 4.12, these cases were not detected.