### PR TITLE
.merlin: add a SUFFIX directive for each dialect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,10 @@ Unreleased
 
 - Add support for Coq's native compute compilation mode (@ejgallego, #3210)
 
+- Add a SUFFIX directive in `.merlin` files for each dialect with no
+  preprocessing, to let merlin know of additional file extensions
+  (#3977, @vouillon)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/src/dune_engine/dialect.ml
+++ b/src/dune_engine/dialect.ml
@@ -186,6 +186,8 @@ module DB = struct
         (dialect, kind))
       (String.Map.find by_extension extension)
 
+  let fold { by_name; _ } = String.Map.fold by_name
+
   let to_dyn { by_name; _ } = String.Map.to_dyn to_dyn by_name
 
   let builtin = of_list [ ocaml; reason ]

--- a/src/dune_engine/dialect.mli
+++ b/src/dune_engine/dialect.mli
@@ -51,6 +51,8 @@ module DB : sig
 
   val find_by_extension : t -> string -> (dialect * Ml_kind.t) option
 
+  val fold : t -> init:'a -> f:(dialect -> 'a -> 'a) -> 'a
+
   val to_dyn : t -> Dyn.t
 
   val builtin : t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -182,7 +182,8 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   ( cctx
   , Merlin.make () ~requires:requires_compile ~flags ~modules
       ~preprocess:(Preprocess.Per_module.single_preprocess preprocess)
-      ~obj_dir )
+      ~obj_dir
+      ~dialects:(Dune_project.dialects (Scope.project scope)) )
 
 let compile_info ~scope (exes : Dune_file.Executables.t) =
   let dune_version = Scope.project scope |> Dune_project.dune_version in

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -422,7 +422,8 @@ let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
   ( cctx
   , Merlin.make () ~requires:requires_compile ~flags ~modules
       ~preprocess:(Preprocess.Per_module.single_preprocess preprocess)
-      ~libname:(snd lib.name) ~obj_dir )
+      ~libname:(snd lib.name) ~obj_dir
+      ~dialects:(Dune_project.dialects (Scope.project scope)) )
 
 let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope :
     Compilation_context.t * Merlin.t =

--- a/src/dune_rules/merlin.mli
+++ b/src/dune_rules/merlin.mli
@@ -14,6 +14,7 @@ val make :
   -> ?source_dirs:Path.Source.Set.t
   -> modules:Modules.t
   -> obj_dir:Path.Build.t Obj_dir.t
+  -> dialects:Dialect.DB.t
   -> unit
   -> t
 


### PR DESCRIPTION
The SUFFIX directive lets merlin know of additional file extensions.

This is helpful in our case where the source code is already valid OCaml code and can be passed to the OCaml compiler as-is. I'm not sure whether it would be possible to extend this for when a preprocessing step is needed.