### PR TITLE
Disable coq-native tests (and add alias for all coq tests)

### DIFF
--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -1,0 +1,10 @@
+; Coq for macos does not support native compilation yet.
+; TODO Enable tests when ready
+(cram
+ (applies_to native-compose native-single)
+ (enabled_if (<> %{system} macosx)))
+
+; An alias that runs all Coq tests
+(cram
+ (applies_to :whole_subtree)
+ (alias all-coq-tests))

--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -1,10 +1,13 @@
 ; Coq for macos does not support native compilation yet.
 ; TODO Enable tests when ready
+
 (cram
  (applies_to native-compose native-single)
- (enabled_if (<> %{system} macosx)))
+ (enabled_if
+  (<> %{system} macosx)))
 
 ; An alias that runs all Coq tests
+
 (cram
  (applies_to :whole_subtree)
  (alias all-coq-tests))


### PR DESCRIPTION
This prevent macos devs to run the coq-native tests.
These tests should be enabled again when Coq will support native mode in macos.

I also added an alias to easily run all tests in the coq folder `./dune.exe build @all-coq-tests`