### PR TITLE
Fix OSX issue by reverting "[scheduler] Remove running count"

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -420,11 +420,14 @@ end = struct
        in the build system. *)
     let table = Table.create (module Pid) 128
 
+    let running_count = ref 0
+
     let add job =
       match Table.find table job.pid with
       | None ->
         Table.set table job.pid (Running job);
-        if Table.length table = 1 then Condition.signal something_is_running_cv
+        incr running_count;
+        if !running_count = 1 then Condition.signal something_is_running_cv
       | Some (Zombie status) ->
         Table.remove table job.pid;
         Event.send_job_completed job status
@@ -434,6 +437,7 @@ end = struct
       match Table.find table pid with
       | None -> Table.set table pid (Zombie status)
       | Some (Running job) ->
+        decr running_count;
         Table.remove table pid;
         Event.send_job_completed job status
       | Some (Zombie _) -> assert false
@@ -444,7 +448,7 @@ end = struct
           | Running job -> f job
           | Zombie _ -> ())
 
-    let running_count () = Table.length table
+    let running_count () = !running_count
   end
 
   let register_job job =


### PR DESCRIPTION
This reverts commit 179d2d1383322416d87cc2812a8d7dadbff8314f and should fix the tests (and thus the CI) for macos.

This rollback or a  more cleaver mitigation should be merged before releasing 2.8.0.