### PR TITLE
Add conflict with OCamlLSP < 2.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,7 +100,8 @@ Unreleased
 - Stop promoting `.merlin` files. Write per-stanza Merlin configurations in
   binary form. Add a new subcommand `dune ocaml-merlin` that Merlin can use to
   query the configuration files. The `allow_approximate_merlin` option is now
-  useless and deprecated. (#3554, @voodoos)
+  useless and deprecated. Dune now conflicts with `merlin < 3.4.0` and
+  `ocaml-lsp-server < 1.3.0` (#3554, @voodoos)
 
 2.7.1 (2/09/2020)
 -----------------

--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,7 @@
  ; The "depends" and "build" field are written in dune.opam.template
  (conflicts
   (merlin (< 3.4.0))
+  (ocaml-lsp-server (< 1.3.0))
   (dune-configurator (< 2.3.0))
   (odoc (< 1.3.0))
   (dune-release (< 1.3.0))

--- a/dune.opam
+++ b/dune.opam
@@ -28,6 +28,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 conflicts: [
   "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
   "dune-configurator" {< "2.3.0"}
   "odoc" {< "1.3.0"}
   "dune-release" {< "1.3.0"}


### PR DESCRIPTION
Dune 2.8.0 will stop writing `.merlin` files.

To ensure the smoothest transition possible we need to conflict with versions of Merlin and OCaml-LSP that do not support the new "external configuration readers", that is: `merlin < 3.4.0` and `ocaml-lsp-server < 1.3.0`.