### PR TITLE
[ci] [coq] [opam] Track opam upstream changes in Coq packaging.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ BIN := ./dune.exe
 TEST_DEPS := \
 bisect_ppx \
 cinaps \
+coq-native \
 "coq>=8.12.1" \
 core_bench \
 "csexp>=1.3.0" \


### PR DESCRIPTION
Upstream opam has split Coq's native support to a config-only package.
This unfortunately means that people need to run `opam update`.

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>