### PR TITLE
[fiber] add reraise_all

### DIFF
--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -76,6 +76,8 @@ module Execution_context : sig
   (* Execute a callback with a fresh execution context. For the toplevel
      [Fiber.run] function. *)
   val new_run : (unit -> 'a) -> 'a
+
+  val reraise_all : Exn_with_backtrace.t list -> unit
 end = struct
   type t =
     { on_error : Exn_with_backtrace.t k option
@@ -125,6 +127,21 @@ end = struct
 
   and safe_run_k : type a. (a -> unit) -> a -> unit =
    fun k x -> try k x with exn -> forward_error exn
+
+  and forward_exn_with_bt =
+    let rec loop t exn =
+      match t.on_error with
+      | None -> Exn_with_backtrace.reraise exn
+      | Some { ctx; run } -> (
+        current := ctx;
+        try run exn
+        with exn ->
+          let exn = Exn_with_backtrace.capture exn in
+          loop ctx exn )
+    in
+    fun t exn ->
+      loop t exn;
+      deref t
 
   and forward_error =
     let rec loop t exn =
@@ -191,6 +208,11 @@ end = struct
   let apply f x k =
     let backup = !current in
     (try f x k with exn -> forward_error exn);
+    current := backup
+
+  let reraise_all exns =
+    let backup = !current in
+    List.iter exns ~f:(forward_exn_with_bt backup);
     current := backup
 
   let new_run f =
@@ -428,7 +450,7 @@ let reraise_all = function
   | [ exn ] -> Exn_with_backtrace.reraise exn
   | exns ->
     EC.add_refs (List.length exns - 1);
-    List.iter exns ~f:(fun exn -> EC.apply Exn_with_backtrace.reraise exn never);
+    EC.reraise_all exns;
     never
 
 let finalize f ~finally =

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -148,6 +148,9 @@ val collect_errors :
     fails or succeeds. *)
 val finalize : (unit -> 'a t) -> finally:(unit -> unit t) -> 'a t
 
+(** [reraise_all exns] re-raises all [exns] to the current error handler *)
+val reraise_all : Exn_with_backtrace.t list -> 'a t
+
 (** {1 Synchronization} *)
 
 (** Write once variables *)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -165,11 +165,7 @@ module Value = struct
   let get_async_exn = function
     | Ok a -> Fiber.return a
     | Error [] -> assert false
-    | Error exns ->
-      (* XXX perhaps Fiber should provide a function that does this more
-         efficiently *)
-      let* () = Fiber.parallel_iter exns ~f:Exn_with_backtrace.reraise in
-      Fiber.never
+    | Error exns -> Fiber.reraise_all exns
 end
 
 module Completion = struct

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -182,7 +182,7 @@ let%expect_test "collect errors inside with_error_handler" =
          | Ok () -> assert false
          | Error l ->
            print_endline "got the error out of collect_errors";
-           List.iter l ~f:Exn_with_backtrace.reraise;
+           let* () = Fiber.reraise_all l in
            assert false));
   [%expect
     {|


### PR DESCRIPTION
Re-raise all exceptions to the current handler. This function can be
more efficient in the future.