### PR TITLE
Fix archives for bytecode only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -103,6 +103,9 @@ Unreleased
   useless and deprecated. Dune now conflicts with `merlin < 3.4.0` and
   `ocaml-lsp-server < 1.3.0` (#3554, @voodoos)
 
+- Remove non-existent `(native_archives ..)` entries in `dune-package` files in
+  bytecode only libraries. (#4041, @rgrinberg)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -838,7 +838,11 @@ module Library = struct
     let virtual_library = is_virtual conf in
     let foreign_archives = foreign_lib_files conf ~dir ~ext_lib in
     let native_archives =
-      [ Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib) ]
+      if modes.native then
+        [ Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib)
+        ]
+      else
+        []
     in
     let foreign_dll_files = foreign_dll_files conf ~dir ~ext_dll in
     let exit_module = Option.bind conf.stdlib ~f:(fun x -> x.exit_module) in

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -809,22 +809,18 @@ module Library = struct
       ~lib_config:
         ( { Lib_config.has_native; ext_lib; ext_dll; natdynlink_supported; _ }
         as lib_config ) =
-    let _loc, lib_name = conf.name in
     let obj_dir = obj_dir ~dir conf in
-    let gen_archive_file ~dir ext =
-      Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext)
-    in
-    let archive_file = gen_archive_file ~dir in
+    let archive ?(dir = dir) ext = archive conf ~dir ~ext in
     let modes = Mode_conf.Set.eval ~has_native conf.modes in
-    let archive_file ~f_ext ~mode =
+    let archive_for_mode ~f_ext ~mode =
       if Mode.Dict.get modes mode then
-        Some (archive_file (f_ext mode))
+        Some (archive (f_ext mode))
       else
         None
     in
-    let archive_files ~f_ext =
+    let archives_for_mode ~f_ext =
       Mode.Dict.of_func (fun ~mode ->
-          archive_file ~f_ext ~mode |> Option.to_list)
+          archive_for_mode ~f_ext ~mode |> Option.to_list)
     in
     let jsoo_runtime =
       List.map conf.buildable.js_of_ocaml.javascript_files
@@ -839,8 +835,7 @@ module Library = struct
     let foreign_archives = foreign_lib_files conf ~dir ~ext_lib in
     let native_archives =
       if modes.native then
-        [ Path.Build.relative dir (Lib_name.Local.to_string lib_name ^ ext_lib)
-        ]
+        [ archive ext_lib ]
       else
         []
     in
@@ -850,7 +845,7 @@ module Library = struct
       (* XXX we shouldn't access the directory of the obj_dir directly. We
          should use something like [Obj_dir.Archive.obj] instead *)
       if modes.byte then
-        Some (gen_archive_file ~dir:(Obj_dir.obj_dir obj_dir) ".cma.js")
+        Some (archive ~dir:(Obj_dir.obj_dir obj_dir) ".cma.js")
       else
         None
     in
@@ -864,7 +859,7 @@ module Library = struct
       else
         let plugins =
           let archive_file ~mode =
-            archive_file ~f_ext:Mode.plugin_ext ~mode |> Option.to_list
+            archive_for_mode ~f_ext:Mode.plugin_ext ~mode |> Option.to_list
           in
           { Mode.Dict.native =
               ( if Dynlink_supported.get conf.dynlink natdynlink_supported then
@@ -874,7 +869,7 @@ module Library = struct
           ; byte = archive_file ~mode:Byte
           }
         in
-        (archive_files ~f_ext:Mode.compiled_lib_ext, plugins)
+        (archives_for_mode ~f_ext:Mode.compiled_lib_ext, plugins)
     in
     let main_module_name = main_module_name conf in
     let name = best_name conf in

--- a/test/blackbox-tests/test-cases/dune-package.t/dune
+++ b/test/blackbox-tests/test-cases/dune-package.t/dune
@@ -8,6 +8,13 @@
  (public_name a.b.c)
  (modules y))
 
+(library
+ (name d)
+ (public_name a.byte_only)
+ (modes byte)
+ (modules z))
+
 (rule (with-stdout-to x.ml (echo "")))
+(rule (with-stdout-to z.ml (echo "")))
 (rule (with-stdout-to y.ml (echo "")))
 (rule (with-stdout-to y.mli (echo "")))

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -41,6 +41,25 @@
       (kind alias)
       (impl))
      (wrapped true))))
+  (library
+   (name a.byte_only)
+   (kind normal)
+   (archives (byte byte_only/d.cma))
+   (plugins (byte byte_only/d.cma))
+   (native_archives byte_only/d$ext_lib)
+   (main_module_name D)
+   (modes byte)
+   (modules
+    (wrapped
+     (main_module_name D)
+     (modules ((name Z) (obj_name d__Z) (visibility public) (impl)))
+     (alias_module
+      (name D)
+      (obj_name d)
+      (visibility public)
+      (kind alias)
+      (impl))
+     (wrapped true))))
 
 Build with "--store-orig-source-dir" profile
   $ dune build --store-orig-source-dir
@@ -50,10 +69,16 @@ Build with "--store-orig-source-dir" profile
   --
    (orig_src_dir
     $TESTCASE_ROOT)
+  --
+   (orig_src_dir
+    $TESTCASE_ROOT)
 
 Build with "DUNE_STORE_ORIG_SOURCE_DIR=true" profile
   $ DUNE_STORE_ORIG_SOURCE_DIR=true dune build
   $ dune_cmd cat _build/install/default/lib/a/dune-package | grep -A 1 '(orig_src_dir'
+   (orig_src_dir
+    $TESTCASE_ROOT)
+  --
    (orig_src_dir
     $TESTCASE_ROOT)
   --

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -46,7 +46,6 @@
    (kind normal)
    (archives (byte byte_only/d.cma))
    (plugins (byte byte_only/d.cma))
-   (native_archives byte_only/d$ext_lib)
    (main_module_name D)
    (modes byte)
    (modules


### PR DESCRIPTION
We don't produce `<lib>.a` files for bytecode only libraries. Hence we should
not include this artifact in the dune-package.