### PR TITLE
Switch to cache v4

### DIFF
--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -66,19 +66,6 @@ let trim ~trimmed_size ~size =
       Cache.Local.make ~duplication_mode:Cache.Duplication_mode.Hardlink
         ~command_handler:ignore ()
     in
-    let () =
-      match Cache.Local.detect_unexpected_dirs_under_cache_root cache with
-      | Ok [] -> ()
-      | Ok dirs ->
-        User_error.raise
-          [ Pp.text "Unexpected directories found at the cache root:"
-          ; Pp.enumerate dirs ~f:(fun dir -> Path.to_string dir |> Pp.text)
-          ; Pp.text
-              "These directories are probably used by Dune of a different \
-               version. Please trim the cache manually."
-          ]
-      | Error e -> User_error.raise [ Pp.text (Unix.error_message e) ]
-    in
     let+ goal =
       match (trimmed_size, size) with
       | Some trimmed_size, None -> Result.Ok trimmed_size

--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -59,10 +59,10 @@ let trim ~trimmed_size ~size =
   let open Result.O in
   match
     let* cache =
-      (* CR-soon amokhov: The [Hadrlink] duplication mode is chosen artitrarily
-         here, instead of respecting the corresponding configuration setting,
-         because the mode doesn't matter for the trimmer. It would be better to
-         refactor the code to avoid such arbitrary choices. *)
+      (* CR-someday amokhov: The [Hadrlink] duplication mode is chosen
+         artitrarily here, instead of respecting the corresponding configuration
+         setting, because the mode doesn't matter for the trimmer. It would be
+         better to refactor the code to avoid such arbitrary choices. *)
       Cache.Local.make ~duplication_mode:Cache.Duplication_mode.Hardlink
         ~command_handler:ignore ()
     in

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -62,8 +62,8 @@ module FirstTwoCharsSubdir : FSScheme = struct
     let first_two_chars = String.sub digest ~pos:0 ~len:2 in
     Path.L.relative root [ first_two_chars; digest ]
 
-  (** List all entries in a given cache root. Returns the empty list of the root
-      doesn't exist. *)
+  (* List all entries in a given cache root. Returns the empty list of the root
+     doesn't exist. *)
   let list ~root =
     let open Result.O in
     let f dir =
@@ -249,8 +249,8 @@ let promote_sync cache paths key metadata ~repository ~duplication =
       Result.Error message
     ) else
       let in_the_cache = file_path cache effective_digest in
-      (* CR-soon: we assume that if the file with [effective_digest] exists in
-         the file storage, then its content matches the digest, i.e. the user
+      (* CR-someday: we assume that if the file with [effective_digest] exists
+         in the file storage, then its content matches the digest, i.e. the user
          never modifies it. In principle, we could add a consistency check but
          this would have a non-negligible performance cost. A good compromise
          seems to be to add a "paranoid" mode to Dune cache where we always
@@ -366,7 +366,7 @@ let make ?(root = default_root ())
     ; command_handler
     ; duplication_mode
     ; temp_dir =
-        (* CR-soon amokhov: Introduce [val getpid : unit -> t] in [pid.ml] so
+        (* CR-someday amokhov: Introduce [val getpid : unit -> t] in [pid.ml] so
            that we don't use the untyped version of pid anywhere. *)
         Path.temp_dir ~temp_dir:root "promoting."
           ("." ^ string_of_int (Unix.getpid ()))
@@ -453,8 +453,8 @@ let trim cache ~goal =
       trimmed_so_far
     else (
       Path.unlink path;
-      (* CR-soon amokhov: We should really be using block_size * #blocks because
-         that's how much we save actually. *)
+      (* CR-someday amokhov: We should really be using block_size * #blocks
+         because that's how much we save actually. *)
       Trimming_result.add trimmed_so_far ~bytes
     )
   in

--- a/src/cache/local.mli
+++ b/src/cache/local.mli
@@ -66,13 +66,6 @@ module Trimming_result : sig
   type t = { trimmed_bytes : int64 }
 end
 
-(** Return a list of unexpected paths that exist in the root directory of the
-    cache. A non-empty result suggests that the cache directory contains
-    multiple versions of the cache, making [trim] and [garbage_collect] less
-    effective. *)
-val detect_unexpected_dirs_under_cache_root :
-  t -> (Path.t list, Unix.error) result
-
 (** Trim the cache by removing a set of unused files from it so that the total
     freed space is greater or equal to the specificed [goal], in bytes. We call
     a cached file "unused" if there are currently no hard links to it from build

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1292,11 +1292,16 @@ end = struct
       | exception Unix.Unix_error (ENOENT, _, _) -> ()
       | () -> () )
 
+  (* The current version of the rule digest scheme. We should increment it when
+     making any changes to the scheme, to avoid collisions. *)
+  let rule_digest_version = 1
+
   let compute_rule_digest (rule : Rule.t) ~deps ~action ~sandbox_mode =
     let targets_as_list = Path.Build.Set.to_list rule.action.targets in
     let env = Rule.effective_env rule in
     let trace =
-      ( Dep.Set.trace deps ~sandbox_mode ~env
+      ( rule_digest_version (* Update when changing the rule digest scheme. *)
+      , Dep.Set.trace deps ~sandbox_mode ~env
       , List.map targets_as_list ~f:(fun p -> Path.to_string (Path.build p))
       , Option.map rule.context ~f:(fun c -> c.name)
       , Action.for_shell action )

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -26,7 +26,7 @@ end)
 
 let needs_dumping = ref false
 
-(* CR-soon amokhov: replace this mutable table with a memoized function. This
+(* CR-someday amokhov: replace this mutable table with a memoized function. This
    will probably require splitting this module in two, for dealing with source
    and target files, respectively. For source files, we receive updates via the
    file-watching API. For target files, we modify the digests ourselves, without

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -344,8 +344,8 @@ module Extension = struct
         -> Univ_map.t * Stanza.Parser.t list
     }
 
-  (* CR-soon amokhov: convert this mutable table to a memoized function, which
-     depends on the contents of dune files that declare extensions. *)
+  (* CR-someday amokhov: convert this mutable table to a memoized function,
+     which depends on the contents of dune files that declare extensions. *)
   let extensions = Table.create (module String) 32
 
   let register syntax stanzas arg_to_dyn =

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -107,7 +107,7 @@ end = struct
 
   let cond = Condition.create ()
 
-  (* CR-soon amokhov: The way we handle "ignored files" using this mutable table
+  (* CR-someday amokhov: The way we handle "ignored files" using a mutable table
      is fragile and also wrong. We use [ignored_files] for the [(mode promote)]
      feature: if a file is promoted, we call [ignore_next_file_change_event] so
      that the upcoming file-change event does not invalidate the current build.

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -614,7 +614,7 @@ let all_packages t =
            (Dune_package.Entry.name a)
            (Dune_package.Entry.name b))
 
-(* CR-soon amokhov: Remove the mutable table below and add:
+(* CR-someday amokhov: Remove the mutable table below and add:
 
    - A memoized function for finding packages by names (see [find]).
 

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1725,7 +1725,7 @@ module DB = struct
 
   type t = db
 
-  (* CR-soon amokhov: this whole module should be rewritten using the
+  (* CR-someday amokhov: this whole module should be rewritten using the
      memoization framework instead of using mutable state. *)
   let create ~parent ~resolve ~projects_by_package ~all ~lib_config () =
     { parent

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -733,7 +733,7 @@ end = struct
       if Run.is_current run then
         Waiting (state.sample_attempt, ())
       else
-        (* CR-soon amokhov: How can we end up here? If we can't raise an error. *)
+        (* CR-someday amokhov: How can we get here? If we can't raise an error. *)
         new_attempt ()
     | Done cv -> (
       match Cached_value.get_sync cv with

--- a/src/stdune/digest.ml
+++ b/src/stdune/digest.ml
@@ -39,4 +39,16 @@ let file_with_stats p (stats : Unix.stats) =
   | S_DIR ->
     generic (stats.st_size, stats.st_perm, stats.st_mtime, stats.st_ctime)
   | _ ->
-    generic (file p, stats.st_perm land 0o100 (* Only take USR_X in account *))
+    (* We follow the digest scheme used by Jenga. *)
+    let string_and_bool ~digest_hex ~bool =
+      D.string
+        ( digest_hex
+        ^
+        if bool then
+          "\001"
+        else
+          "\000" )
+    in
+    let content_digest = file p in
+    let executable = stats.st_perm land 0o100 <> 0 in
+    string_and_bool ~digest_hex:content_digest ~bool:executable

--- a/test/blackbox-tests/test-cases/deprecated-fields/d-allow-approx-merlin.t
+++ b/test/blackbox-tests/test-cases/deprecated-fields/d-allow-approx-merlin.t
@@ -1,12 +1,14 @@
   $ cat >dune-project <<EOF
-  > (lang dune 2.7) 
+  > (lang dune 2.7)
   > (allow_approximate_merlin true)
+  > EOF
 
   $ dune build @all
 
   $ cat >dune-project <<EOF
-  > (lang dune 2.8) 
+  > (lang dune 2.8)
   > (allow_approximate_merlin true)
+  > EOF
 
   $ dune build @all
   File "dune-project", line 2, characters 0-31:

--- a/test/blackbox-tests/test-cases/dune-cache/missing-data.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/missing-data.t/run.t
@@ -19,5 +19,5 @@ Check that missing data files simply make the cached rule invalid.
   > \_o< COIN
   > EOF
   $ env XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build --config-file=config target
-  $ rm -rf _build $PWD/.xdg-cache/dune/db/files/v3/
+  $ rm -rf _build $PWD/.xdg-cache/dune/db/files/v4/
   $ env XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build --config-file=config target

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -45,12 +45,13 @@ Build some more targets.
 
   $ env DUNE_CACHE=enabled DUNE_CACHE_EXIT_NO_CLIENT=1 XDG_RUNTIME_DIR=$PWD/.xdg-runtime XDG_CACHE_HOME=$PWD/.xdg-cache dune build target_a target_b
 
-Have a look at one of the metadata files and its size.
+Have a look at one of the metadata files and its size. If the rule digest changes,
+make sure to increment [rule_digest_version] in [build_system.ml].
 
-  $ cat $PWD/.xdg-cache/dune/db/meta/v4/9a/9a8995f866fa478a9a263b8470fb218f
+  $ cat $PWD/.xdg-cache/dune/db/meta/v4/95/95be12ef67548c59c691567564f2c158
   ((8:metadata)(5:files(16:default/target_b32:8a53bfae3829b48866079fa7f2d97781)))
 
-  $ dune_cmd stat size $PWD/.xdg-cache/dune/db/meta/v4/9a/9a8995f866fa478a9a263b8470fb218f
+  $ dune_cmd stat size $PWD/.xdg-cache/dune/db/meta/v4/95/95be12ef67548c59c691567564f2c158
   79
 
 Trimming the cache at this point should not remove anything, as all


### PR DESCRIPTION
This PR does a few changes to the Dune build cache: 

* It brings Dune in sync with Jenga by computing file digests in the same way.

* It implements a unified trimming for old (`v3`) and new (`v4`) cache entries, so that the cache is trimmed correctly even if the user switches between different versions of Dune (thus fixing #3542).

* Finally, we switch to prioritising the trimming of entries by *the last change time* `ctime` instead of the *last modification time* `mtime`, also for consistency with Jenga.

TODO: 
- [x] Fix tests
- [x] Update docs
- [x] Add versioning to rule digests