### PR TITLE
Move locks to build_system

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1414,7 +1414,7 @@ end = struct
       match rule_need_rerun with
       | false -> Fiber.return ()
       | true ->
-        let from_Cache =
+        let from_cache =
           match (do_not_memoize, t.caching) with
           | true, _
           | _, None ->
@@ -1443,7 +1443,7 @@ end = struct
               Path.unlink_no_err (Path.build target))
         in
         let pulled_from_cache =
-          match from_Cache with
+          match from_cache with
           | Some (files, (module Caching)) when not cache_checking -> (
             let () = remove_targets () in
             let retrieve (file : Cache.File.t) =
@@ -1521,7 +1521,7 @@ end = struct
             (* Check cache. We don't check for missing file in the cache, since
                the file list is part of the rule hash this really never should
                happen. *)
-            match from_Cache with
+            match from_cache with
             | Some (cached, _) when cache_checking ->
               (* This being [false] is unexpected and means we have a hash
                  collision *)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -574,18 +574,13 @@ let remove_old_artifacts ~dir ~rules_here ~(subdirs_to_keep : Subdir_set.t) =
     List.iter files ~f:(fun (fn, kind) ->
         let path = Path.Build.relative dir fn in
         let path_is_a_target = Path.Build.Map.mem rules_here path in
-        if path_is_a_target then
-          ()
-        else
+        if not path_is_a_target then
           match kind with
           | Unix.S_DIR -> (
             match subdirs_to_keep with
             | All -> ()
             | These set ->
-              if String.Set.mem set fn then
-                ()
-              else
-                Path.rm_rf (Path.build path) )
+              if not (String.Set.mem set fn) then Path.rm_rf (Path.build path) )
           | _ -> Path.unlink (Path.build path))
 
 let no_rule_found t ~loc fn =


### PR DESCRIPTION
This allows for the locks to be cleaned up when the build system is re-created.