### PR TITLE
Allow dune rules to accept aliases as arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- `dune rules` accepts aliases and other non-path rules (#4063, @mrmr1993)
+
 - Action `(diff reference test_result)` now accept `reference` to be absent and
   in that case consider that the reference is empty. Then running `dune promote`
   will create the reference file. (#3795, @bobot)

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -106,8 +106,7 @@ let term =
             "Print all rules needed to build the transitive dependencies of \
              the given targets.")
   and+ syntax = Syntax.term
-  and+ targets = Arg.(value & pos_all string [] & Arg.info [] ~docv:"TARGET") in
-  let targets = List.map ~f:Arg.Dep.file targets in
+  and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET") in
   Common.set_common common ~targets ~external_lib_deps_mode:true;
   let out = Option.map ~f:Path.of_string out in
   Scheduler.go ~common (fun () ->


### PR DESCRIPTION
This PR makes a tiny tweak to allow `dune rules -r @runtest` and the like to work.