### PR TITLE
Run all hooks - even on failure

### DIFF
--- a/src/dune_engine/hooks.mli
+++ b/src/dune_engine/hooks.mli
@@ -12,8 +12,6 @@ module type S = sig
   val run : unit -> unit
 end
 
-module Make () : S
-
 (** Every time a build ends, which includes every iteration in watch mode,
     including cancellation of build because of file changes. *)
 module End_of_build : S


### PR DESCRIPTION
When one hook fails, it prevents running all other hooks. This is wrong
because other hooks are still required to write various database files.
This PR makes sure that we try running all hooks even if one fails.