### PR TITLE
Future proof git init in tests

### DIFF
--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -11,7 +11,7 @@ Test embedding of build information
   > (package (name $i))
   > EOF
   >   (cd $i;
-  >    git init -q;
+  >    git init --initial-branch master -q
   >    git add .;
   >    git commit -q -m _;
   >    git tag -a 1.0+$i -m _)

--- a/test/blackbox-tests/test-cases/dune-project-meta/main.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/main.t/run.t
@@ -182,7 +182,7 @@ generated META and opam files.
   > EOF
 
   $ (cd version
-  >  git init -q
+  >  git init --initial-branch master -q
   >  git add .
   >  git commit -qm _
   >  git tag -a 1.0 -m 1.0
@@ -217,7 +217,7 @@ generated META and opam files.
   > EOF
 
   $ (cd version
-  >  git init -q
+  >  git init --initial-branch master -q
   >  git add .
   >  git commit -qm _
   >  git tag -a 1.0 -m 1.0

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -1,7 +1,7 @@
 This test demonstrates a bug when there's a package with a meta template and a
 custom version:
 
-  $ git init -q
+  $ git init --initial-branch master -q
   $ git add .
   $ git commit -qm _
   $ git tag -a 1.0 -m 1.0

--- a/test/blackbox-tests/test-cases/subst.t/run.t
+++ b/test/blackbox-tests/test-cases/subst.t/run.t
@@ -14,7 +14,7 @@ Project with opam files
 
   $ echo 'authors: [ "John Doe <john@doe.com>" ]' > foo.opam
 
-  $ git init --quiet
+  $ git init --initial-branch master -q
   $ git add .
   $ git commit -am _ --quiet
   $ git tag -a 1.0 -m 1.0
@@ -51,7 +51,7 @@ And without an opam file preset.
   > let version = "${X}VERSION${X}"
   > EOF
 
-  $ git init --quiet
+  $ git init --initial-branch master -q
   $ git add .
   $ git commit -am _ --quiet
   $ git tag -a 1.0 -m 1.0
@@ -88,7 +88,7 @@ Test subst and files with unicode (#3879)
   > let version = "${X}VERSION${X}"
   > EOF
 
-  $ git init --quiet
+  $ git init --initial-branch master -q
   $ git add .
   $ git commit -am _ --quiet
   $ git tag -a 1.0 -m 1.0

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -57,7 +57,10 @@ type action =
 
 let run_action (vcs : Vcs.t) action =
   match action with
-  | Init -> run vcs [ "init" ]
+  | Init -> (
+    match vcs.kind with
+    | Hg -> run vcs [ "init" ]
+    | Git -> run vcs [ "init"; "--initial-branch"; "master" ] )
   | Add fn -> run vcs [ "add"; fn ]
   | Commit -> (
     match vcs.kind with
@@ -147,7 +150,7 @@ let%expect_test _ =
   run Git script;
   [%expect
     {|
-$ git init
+$ git init --initial-branch master
 $ echo "-" > a
 $ git add a
 $ git commit -m 'commit message'


### PR DESCRIPTION
Newer versions of git complain that the default branch name is subject
to change and we shouldn't rely on it. This PR sets it explicitly for
all of our tests.