### PR TITLE
Add etc_root.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,8 @@ Unreleased
 - Configurator: fix a bug introduced in 2.6.0 where the configurator V1 API doesn't work at 
   all when used outside of dune. (#4046, @aalekseyev)
 
+- Add support for `etc_root` in `install` directives (#4077, @toots)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1187,6 +1187,7 @@ The following sections are available:
 - ``share`` installs to ``<prefix>/share/<pkgname>/``
 - ``share_root`` installs to ``<prefix>/share/``
 - ``etc`` installs to ``<prefix>/etc/<pkgname>/``
+- ``etc_root`` installs to ``<prefix>/etc/``
 - ``doc`` installs to ``<prefix>/doc/<pkgname>/``
 - ``stublibs`` installs to ``<prefix>/lib/stublibs/`` with the
   executable bit set
@@ -1205,7 +1206,7 @@ Normally, Dune uses the basename of the file to install to determine
 the name of the file once installed.  However, you can change that
 fact by using the form ``(<filename> as <destination>)`` in the
 ``files`` field. For instance, to install a file ``mylib.el`` as
-``<prefix>/emacs/site-lisp/mylib.el`` you must write the following:
+``<prefix>/share/emacs/site-lisp/mylib.el`` you must write the following:
 
 .. code:: scheme
 

--- a/src/dune_engine/install.ml
+++ b/src/dune_engine/install.ml
@@ -121,6 +121,7 @@ module Section = struct
       ; share : Path.t
       ; share_root : Path.t
       ; etc : Path.t
+      ; etc_root : Path.t
       ; doc : Path.t
       ; stublibs : Path.t
       ; man : Path.t
@@ -134,7 +135,8 @@ module Section = struct
       let share_root = Path.relative destdir "share" in
       let etc_root = Path.relative destdir "etc" in
       let doc_root = Path.relative destdir "doc" in
-      { lib_root
+      { etc_root
+      ; lib_root
       ; libexec_root
       ; share_root
       ; bin = Path.relative destdir "bin"
@@ -161,6 +163,7 @@ module Section = struct
       | Share -> t.share
       | Share_root -> t.share_root
       | Etc -> t.etc
+      | Etc_root -> t.etc_root
       | Doc -> t.doc
       | Stublibs -> t.stublibs
       | Man -> t.man
@@ -269,6 +272,7 @@ module Entry = struct
         | Libexec -> (Libexec_root, dst_with_pkg_prefix)
         | Share -> (Share_root, dst_with_pkg_prefix)
         | Etc
+        | Etc_root
         | Doc ->
           User_error.raise
             [ Pp.textf "Can't have site in etc and doc for opam" ]

--- a/src/dune_engine/section.ml
+++ b/src/dune_engine/section.ml
@@ -42,6 +42,7 @@ let should_set_executable_bit = function
   | Share
   | Share_root
   | Etc
+  | Etc_root
   | Doc
   | Man
   | Misc ->

--- a/src/dune_engine/section.mli
+++ b/src/dune_engine/section.mli
@@ -11,6 +11,7 @@ type t =
   | Share
   | Share_root
   | Etc
+  | Etc_root
   | Doc
   | Stublibs
   | Man

--- a/src/section/dune_section.ml
+++ b/src/section/dune_section.ml
@@ -9,6 +9,7 @@ type t =
   | Share
   | Share_root
   | Etc
+  | Etc_root
   | Doc
   | Stublibs
   | Man
@@ -25,6 +26,7 @@ let all =
   ; (Share, "share")
   ; (Share_root, "share_root")
   ; (Etc, "etc")
+  ; (Etc_root, "etc_root")
   ; (Doc, "doc")
   ; (Stublibs, "stublibs")
   ; (Man, "man")

--- a/src/section/dune_section.mli
+++ b/src/section/dune_section.mli
@@ -9,6 +9,7 @@ type t =
   | Share
   | Share_root
   | Etc
+  | Etc_root
   | Doc
   | Stublibs
   | Man

--- a/test/blackbox-tests/test-cases/etc_root-target.t/run.t
+++ b/test/blackbox-tests/test-cases/etc_root-target.t/run.t
@@ -1,0 +1,26 @@
+Test etc_root install target
+============================
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section etc_root)
+  >  (files (bar as foo/bar)))
+  > EOF
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.8)
+  > (package (name x))
+  > EOF
+
+  $ touch bar
+
+  $ dune build @install
+
+  $ cat _build/default/x.install
+  lib: [
+    "_build/install/default/lib/x/META"
+    "_build/install/default/lib/x/dune-package"
+  ]
+  etc_root: [
+    "_build/install/default/etc/foo/bar" {"foo/bar"}
+  ]


### PR DESCRIPTION
This PR adds support for `etc_root` as an install target and fixes the documentation for destination syntax.

As we are progressively moving toward using exclusively `dune` for `liquidsoap`, support for `etc_root` seems needed in order to be able to install global files that we ship, in particular the bash completion file.

Couple of notes:
* It would be nice if `prefix` could be available at build time. The `liquidsoap` binary depends on certain path and scripts available at runtime. In the old `autoconf` workflow, target directories are fixed at configure time and can, thus, be hardcoded at build time. This is really useful when dealing with multiple versions installed concurrently.
* It would be nice it tests could be better documented. It's not obvious to figure out how to add a new test and run it exclusively. More documentation would make it easier for future contributors to add regression tests (c.f.: https://github.com/ocaml/dune/pull/3751)