### PR TITLE
Fix cinaps on arm32

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,8 @@ Unreleased
 - Configurator: fix a bug introduced in 2.6.0 where the configurator V1 API doesn't work at 
   all when used outside of dune. (#4046, @aalekseyev)
 
+- Fix cinaps on arm32 by not passing `-nodynlink` (#4081, fixes #4069, @emillon)
+
 2.7.1 (2/09/2020)
 -----------------
 

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -101,7 +101,7 @@ let gen_rules sctx t ~dir ~scope =
       ~requires_compile:(Lib.Compile.direct_requires compile_info)
       ~requires_link:(Lib.Compile.requires_link compile_info)
       ~flags:(Ocaml_flags.of_list [ "-w"; "-24" ])
-      ~js_of_ocaml:None ~dynlink:false ~package:None
+      ~js_of_ocaml:None ~dynlink:true ~package:None
   in
   Exe.build_and_link cctx
     ~program:{ name; main_module_name; loc }


### PR DESCRIPTION
Closes #4069

When `dynlink:false` is passed, the ARM backend emits MOVW/MOVT instructions which have relocations incompatible with PIC code.

This is similar to #2527 (ocaml issue: ocaml/ocaml#8867).