### PR TITLE
Deforest eval_pred and file_exists

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -679,8 +679,12 @@ end = struct
      executing the very same [Build.t] with [Build.exec] -- the results of both
      [Build.static_deps] and [Build.exec] are cached. *)
   let file_exists fn =
-    let dir = Path.parent_exn fn in
-    Path.Set.mem (targets_of ~dir) fn
+    match load_dir ~dir:(Path.parent_exn fn) with
+    | Non_build targets -> Path.Set.mem targets fn
+    | Build { rules_here; _ } -> (
+      match Path.as_in_build_dir fn with
+      | None -> false
+      | Some fn -> Path.Build.Map.mem rules_here fn )
 
   let targets_of ~dir =
     match load_dir ~dir with


### PR DESCRIPTION
`load_dir_fold` is a bit ugly, but it's used to optimize the code paths that seem to allocate the most in clean builds. So it seems to be worth it.

I've also discovered that our use of set operations in `build.ml` can also be quite slow if the sets grow large. Perhaps it's worth switching the accumulation to lists, and only then converting to sets.