### PR TITLE
Add support for %{version:installed-pkg}

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -222,8 +222,9 @@ In addition, ``(action ...)`` fields support the following special variables:
      available
 
 - ``version:<package>`` expands to the version of the given
-  package. Note that this is only supported for packages that are
-  being defined in the current scope. How dune determines the version
+  package. Packages defined in the current scope have priority over the
+  public packages. Public packages that do not install any libraries
+  will not be detected. How dune determines the version
   of a package is described :ref:`here <package-version>`
 - ``read:<path>`` expands to the contents of the given file
 - ``read-lines:<path>`` expands to the list of lines in the given

--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -9,6 +9,7 @@ Test embedding of sites locations information
   > (lang dune 2.8)
   > (using dune_site 0.1)
   > (name $i)
+  > (version 0.$i)
   > (package (name $i) (sites (share data)))
   > EOF
   > done
@@ -301,3 +302,43 @@ Test compiling an external plugin
   e: $TESTCASE_ROOT/_install/share/e/data
   info.txt is found: true
   run c: registered:e,b.
+
+Test %{version:installed-pkg}
+-----------------------------
+
+  $ for i in f; do
+  >   mkdir -p $i
+  >   cat >$i/dune-project <<EOF
+  > (lang dune 2.8)
+  > (using dune_site 0.1)
+  > (name $i)
+  > (version 0.$i)
+  > (package (name $i) (sites (share data) (lib plugins)))
+  > EOF
+  > done
+
+  $ cat >f/dune <<EOF
+  > (rule
+  >  (target test.target)
+  >  (action
+  >   (with-stdout-to %{target}
+  >    (progn
+  >     (echo "a = %{version:a}\n")
+  >     (echo "e = %{version:e}\n")))))
+  > EOF
+
+  $ OCAMLPATH=_install/lib:$OCAMLPATH dune build --root=f
+  Entering directory 'f'
+  $ cat $(pwd)/f/_build/default/test.target
+  a = 0.a
+  e = 
+
+  $ cat f/dune | sed 's/version:a/version:a.test/' > f/dune.tmp && mv f/dune.tmp f/dune
+  $ OCAMLPATH=_install/lib:$OCAMLPATH dune build --root=f
+  Entering directory 'f'
+  File "dune", line 6, characters 17-32:
+  6 |     (echo "a = %{version:a.test}\n")
+                       ^^^^^^^^^^^^^^^
+  Error: Library names are not allowed in this position. Only package names are
+  allowed
+  [1]

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -115,19 +115,36 @@ let expand_env t pform s : Value.t list option =
       Some [ String (Option.value ~default (Env.get t.env var)) ]
 
 let expand_version scope pform s =
+  let value_from_version = function
+    | None -> [ Value.String "" ]
+    | Some s -> [ String s ]
+  in
   match
     Package.Name.Map.find
       (Dune_project.packages (Scope.project scope))
       (Package.Name.of_string s)
   with
-  | None ->
-    User_error.raise
-      ~loc:(String_with_vars.Var.loc pform)
-      [ Pp.textf "Package %S doesn't exist in the current project." s ]
-  | Some p -> (
-    match p.version with
-    | None -> [ Value.String "" ]
-    | Some s -> [ String s ] )
+  | Some p -> value_from_version p.version
+  | None -> (
+    let libname = Lib_name.of_string s in
+    let pkgname = Lib_name.package_name libname in
+    if not (String.equal (Package.Name.to_string pkgname) s) then
+      User_error.raise
+        ~loc:(String_with_vars.Var.loc pform)
+        [ Pp.textf
+            "Library names are not allowed in this position. Only package \
+             names are allowed"
+        ];
+    match Lib.DB.find (Scope.libs scope) libname with
+    | Some lib -> value_from_version (Lib_info.version (Lib.info lib))
+    | None ->
+      User_error.raise
+        ~loc:(String_with_vars.Var.loc pform)
+        [ Pp.textf
+            "Package %S doesn't exist in the current project and isn't \
+             installed either."
+            s
+        ] )
 
 let isn't_allowed_in_this_position pform =
   let loc = String_with_vars.Var.loc pform in


### PR DESCRIPTION
I'm not sure how to add this feature to the blackbox-tests but it works with:
```
$ cat dune
(rule
  (target test.target)
  (action (with-stdout-to %{target} (run echo "%{version:ppxlib}"))))
$ dune build
$ cat _build/default/test.target
0.20.0
```