### PR TITLE
Fix non-portable use of 'echo' in the cram tests

### DIFF
--- a/test/blackbox-tests/test-cases/merlin/allow_approximate_merlin_warn.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/allow_approximate_merlin_warn.t/run.t
@@ -2,7 +2,7 @@ The vendored project does not trigger a third warning
 
 When the root project is on dune lang <= 2.7 it does not raise a warning
 However the non-vendored sub-dir on dune lang >= 2.8 does raise a warning
-  $ echo "(lang dune 2.7)\n (allow_approximate_merlin)" > dune-project
+  $ printf "(lang dune 2.7)\n (allow_approximate_merlin)" > dune-project
   $ dune build @check
   File "notvendor/dune-project", line 2, characters 0-26:
   2 | (allow_approximate_merlin)


### PR DESCRIPTION
Fix #4139. CC. @voodoos.