### PR TITLE
Rename Memo.t to Memo.func

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1162,7 +1162,7 @@ and Exported : sig
   end
 
   (** Exported to inspect memoization cycles. *)
-  val build_file_memo : (Path.t, unit, Path.t -> unit Fiber.t) Memo.t
+  val build_file_memo : (Path.t, unit, Path.t -> unit Fiber.t) Memo.func
 end = struct
   open Used_recursively
 


### PR DESCRIPTION
So that we can reuse `Memo.t` for the memo monad
