### PR TITLE
Introduce a memo monad

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -3,9 +3,10 @@ open Import
 
 let run_build_command ~common ~targets =
   let once () =
-    let open Fiber.O in
-    let* setup = Import.Main.setup common in
-    do_build (targets setup)
+    Memo.Build.run
+      (let open Memo.Build.O in
+      let* setup = Import.Main.setup common in
+      do_build (targets setup))
   in
   if Common.watch common then
     let once () =

--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -33,7 +33,7 @@ let term =
      let action =
        Scheduler.go ~common (fun () ->
            let open Fiber.O in
-           let* _setup = Import.Main.setup common in
+           let* _setup = Memo.Build.run (Import.Main.setup common) in
            match (fn, inp) with
            | "list", None -> Fiber.return `List
            | "list", Some _ ->
@@ -44,7 +44,7 @@ let term =
                Dune_lang.Parser.parse_string ~fname:"<command-line>"
                  ~mode:Dune_lang.Parser.Mode.Single inp
              in
-             let+ res = Memo.call fn sexp in
+             let+ res = Memo.Build.run (Memo.call fn sexp) in
              `Result res
            | fn, None ->
              Fiber.return (`Error (sprintf "argument missing for '%s'" fn)))

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -140,7 +140,7 @@ module Crawl = struct
       |> Lib.Set.to_list
       |> List.filter_map ~f:(library sctx)
     in
-    let open Fiber.O in
+    let open Memo.Build.O in
     let+ dune_files =
       Dune_load.Dune_files.eval workspace.conf.dune_files ~context
     in
@@ -221,7 +221,7 @@ module What = struct
   let describe t setup context =
     match t with
     | Workspace -> Crawl.workspace setup context
-    | Opam_files -> Fiber.return (Opam_files.get ())
+    | Opam_files -> Memo.Build.return (Opam_files.get ())
 end
 
 module Format = struct
@@ -308,11 +308,11 @@ let term =
   let what = What.parse what ~lang in
   Scheduler.go ~common (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Memo.Build.run (Import.Main.setup common) in
       let context =
         Import.Main.find_context_exn setup.workspace ~name:context_name
       in
-      let+ res = What.describe what setup context in
+      let+ res = Memo.Build.run (What.describe what setup context) in
       match format with
       | Csexp -> Csexp.to_channel stdout (Sexp.of_dyn res)
       | Sexp -> print_as_sexp res)

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -44,7 +44,9 @@ let term =
       & info [ "no-build" ] ~doc:"don't rebuild target before executing")
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
   Common.set_common common ~targets:[ Arg.Dep.file prog ];
-  let setup = Scheduler.go ~common (fun () -> Import.Main.setup common) in
+  let setup =
+    Scheduler.go ~common (fun () -> Memo.Build.run (Import.Main.setup common))
+  in
   let sctx = Import.Main.find_scontext_exn setup ~name:context in
   let context = Dune_rules.Super_context.context sctx in
   let path_relative_to_build_root p =
@@ -83,7 +85,7 @@ let term =
       match Lazy.force targets with
       | [] -> ()
       | targets ->
-        Scheduler.go ~common (fun () -> do_build targets);
+        Scheduler.go ~common (fun () -> Memo.Build.run (do_build targets));
         Hooks.End_of_build.run () );
     match prog_where with
     | `Search prog ->

--- a/bin/external_lib_deps.ml
+++ b/bin/external_lib_deps.ml
@@ -176,7 +176,7 @@ let term =
   let setup, lib_deps =
     Scheduler.go ~common (fun () ->
         let open Fiber.O in
-        let+ setup = Import.Main.setup common in
+        let+ setup = Memo.Build.run (Import.Main.setup common) in
         let targets = Target.resolve_targets_exn common setup targets in
         let request = Target.request targets in
         let deps = all_lib_deps ~request in

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -83,8 +83,8 @@ module Main = struct
       ~ancestor_vcs ()
 
   let setup common =
-    let open Fiber.O in
-    let* caching = make_cache (Common.config common) in
+    let open Memo.Build.O in
+    let* caching = Memo.Build.of_fiber (make_cache (Common.config common)) in
     let* workspace = scan_workspace common in
     let only_packages =
       Option.map (Common.only_packages common)

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -19,7 +19,7 @@ let term =
   Scheduler.go ~common (fun () ->
       let open Fiber.O in
       let () = Workspace.init () in
-      let* ctxs = Context.DB.all () in
+      let* ctxs = Memo.Build.run (Context.DB.all ()) in
       let ctx = List.hd ctxs in
       let findlib = ctx.findlib in
       if na then (

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -111,7 +111,7 @@ let term =
   let out = Option.map ~f:Path.of_string out in
   Scheduler.go ~common (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Memo.Build.run (Import.Main.setup common) in
       let request =
         match targets with
         | [] ->
@@ -120,7 +120,9 @@ let term =
           |> Action_builder.paths
         | _ -> Target.resolve_targets_exn common setup targets |> Target.request
       in
-      let* rules = Build_system.evaluate_rules ~request ~recursive in
+      let* rules =
+        Memo.Build.run (Build_system.evaluate_rules ~request ~recursive)
+      in
       let print oc =
         let ppf = Format.formatter_of_out_channel oc in
         Syntax.print_rules syntax ppf rules;

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -49,7 +49,7 @@ let term =
   Common.set_common common ~targets:[];
   Scheduler.go ~common (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Memo.Build.run (Import.Main.setup common) in
       let dir = Path.of_string dir in
       let checked = Util.check_path setup.workspace.contexts dir in
       let request =
@@ -75,7 +75,7 @@ let term =
             User_error.raise
               [ Pp.text "Environment is not defined in install dirs" ] )
       in
-      Build_system.do_build ~request >>| function
+      Memo.Build.run (Build_system.do_build ~request) >>| function
       | [ (_, env) ] -> Format.printf "%a" (pp ~fields) env
       | l ->
         List.iter l ~f:(fun (name, env) ->

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -30,7 +30,7 @@ let term =
   Common.set_common common ~targets:[];
   Scheduler.go ~common (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Memo.Build.run (Import.Main.setup common) in
       let sctx =
         Dune_engine.Context_name.Map.find setup.scontexts ctx_name
         |> Option.value_exn
@@ -49,7 +49,9 @@ let term =
       in
       let include_paths = Dune_rules.Lib.L.include_paths requires in
       let files = link_deps requires in
-      let* () = do_build (List.map files ~f:(fun f -> Target.File f)) in
+      let* () =
+        Memo.Build.run (do_build (List.map files ~f:(fun f -> Target.File f)))
+      in
       let files_to_load =
         List.filter files ~f:(fun p ->
             let ext = Path.extension p in

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -29,7 +29,7 @@ let term =
   let sctx, utop_path =
     Scheduler.go ~common (fun () ->
         let open Fiber.O in
-        let* setup = Import.Main.setup common in
+        let* setup = Memo.Build.run (Import.Main.setup common) in
         let context =
           Import.Main.find_context_exn setup.workspace ~name:ctx_name
         in
@@ -48,7 +48,7 @@ let term =
           | Ok [ File target ] -> target
           | Ok _ -> assert false
         in
-        let+ () = do_build [ File target ] in
+        let+ () = Memo.Build.run (do_build [ File target ]) in
         (sctx, Path.to_string target))
   in
   Hooks.End_of_build.run ();

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -213,15 +213,15 @@ val fold_labeled : _ t -> init:'acc -> f:(label -> 'acc -> 'acc) -> 'acc
 (** {1 Execution} *)
 
 module Make_exec (Build_deps : sig
-  val build_deps : Dep.Set.t -> unit Fiber.t
+  val build_deps : Dep.Set.t -> unit Memo.Build.t
 end) : sig
   (** Execute an action builder. Returns the result and the set of dynamic
       dependencies discovered during execution. *)
-  val exec : 'a t -> ('a * Dep.Set.t) Fiber.t
+  val exec : 'a t -> ('a * Dep.Set.t) Memo.Build.t
 
   (** Same as [exec] but also builds the static rule dependencies of the action
       builder. *)
-  val build_static_rule_deps_and_exec : 'a t -> ('a * Dep.Set.t) Fiber.t
+  val build_static_rule_deps_and_exec : 'a t -> ('a * Dep.Set.t) Memo.Build.t
 end
 
 (** These functions are experimental and potentially unsafe to use. Each usage
@@ -230,18 +230,18 @@ module Expert : sig
   (** This function "stages" static dependencies and can therefore reduce build
       parallelism: until the outer action builder has been evaluated, the static
       dependencies of the inner action builder are unknown. *)
-  val build : 'a t t -> 'a t
+  val action_builder : 'a t t -> 'a t
 end
 
-(** If you're thinking of using [Process.run] in the fiber, check that: (i) you
-    don't in fact need [Command.run], and that (ii) [Process.run] only reads the
-    declared build rule dependencies. *)
-val fiber : 'a Fiber.t -> 'a t
+(** If you're thinking of using [Process.run] here, check that: (i) you don't in
+    fact need [Command.run], and that (ii) [Process.run] only reads the declared
+    build rule dependencies. *)
+val memo_build : 'a Memo.Build.t -> 'a t
 
-(** If you're thinking of using [Process.run] in the fiber, check that: (i) you
-    don't in fact need [Command.run], and that (ii) [Process.run] only reads the
-    declared build rule dependencies. *)
-val dyn_fiber : 'a Fiber.t t -> 'a t
+(** If you're thinking of using [Process.run] here, check that: (i) you don't in
+    fact need [Command.run], and that (ii) [Process.run] only reads the declared
+    build rule dependencies. *)
+val dyn_memo_build : 'a Memo.Build.t t -> 'a t
 
 (**/**)
 

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -75,7 +75,7 @@ val set_rule_generators :
   -> unit
 
 (** Set the list of VCS repositiories contained in the source tree *)
-val set_vcs : Vcs.t list -> unit Fiber.t
+val set_vcs : Vcs.t list -> unit Memo.Build.t
 
 (** All other functions in this section must be called inside the rule generator
     callback. *)
@@ -140,7 +140,7 @@ end
     callback. *)
 
 (** Do the actual build *)
-val do_build : request:'a Action_builder.t -> 'a Fiber.t
+val do_build : request:'a Action_builder.t -> 'a Memo.Build.t
 
 (** {2 Other queries} *)
 
@@ -179,6 +179,6 @@ end
 val evaluate_rules :
      recursive:bool
   -> request:unit Action_builder.t
-  -> Evaluated_rule.t list Fiber.t
+  -> Evaluated_rule.t list Memo.Build.t
 
 val get_cache : unit -> caching option

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -205,8 +205,8 @@ module Set = struct
 
   include T
 
-  let parallel_iter t ~f = Fiber.parallel_iter_set (module T) t ~f
+  let parallel_iter t ~f = Memo.Build.parallel_iter_set (module T) t ~f
 
   let parallel_iter_files t ~f =
-    paths t |> Fiber.parallel_iter_set (module Path.Set) ~f
+    paths t |> Memo.Build.parallel_iter_set (module Path.Set) ~f
 end

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -51,9 +51,10 @@ module Set : sig
 
   val add_paths : t -> Path.Set.t -> t
 
-  val parallel_iter : t -> f:(elt -> unit Fiber.t) -> unit Fiber.t
+  val parallel_iter : t -> f:(elt -> unit Memo.Build.t) -> unit Memo.Build.t
 
-  val parallel_iter_files : t -> f:(Path.t -> unit Fiber.t) -> unit Fiber.t
+  val parallel_iter_files :
+    t -> f:(Path.t -> unit Memo.Build.t) -> unit Memo.Build.t
 
   val dirs : t -> Path.Set.t
 end

--- a/src/dune_engine/vcs.ml
+++ b/src/dune_engine/vcs.ml
@@ -61,9 +61,10 @@ let git, hg =
   (get "git", get "hg")
 
 let select git hg t =
-  match t.kind with
-  | Git -> git t
-  | Hg -> hg t
+  Memo.Build.of_fiber
+    ( match t.kind with
+    | Git -> git t
+    | Hg -> hg t )
 
 let prog t =
   Lazy.force

--- a/src/dune_engine/vcs.mli
+++ b/src/dune_engine/vcs.mli
@@ -22,13 +22,13 @@ val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
 
 (** Nice description of the current tip *)
-val describe : t -> string Fiber.t
+val describe : t -> string Memo.Build.t
 
 (** String uniquely identifying the current head commit *)
-val commit_id : t -> string Fiber.t
+val commit_id : t -> string Memo.Build.t
 
 (** List of files committed in the repo *)
-val files : t -> Path.t list Fiber.t
+val files : t -> Path.t list Memo.Build.t
 
 (** VCS commands *)
 val git : Path.t Lazy.t

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -133,7 +133,7 @@ let eval t ~conf =
   | Vcs_describe p -> (
     match conf.get_vcs p with
     | None -> Fiber.return ""
-    | Some vcs -> Vcs.describe vcs )
+    | Some vcs -> Memo.Build.run (Vcs.describe vcs) )
   | Location (name, lib_name) ->
     Fiber.return (relocatable (conf.get_location name lib_name))
   | Configpath d ->

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -108,7 +108,7 @@ val to_dyn_concise : t -> Dyn.t
 (** Compare the context names *)
 val compare : t -> t -> Ordering.t
 
-val install_ocaml_libdir : t -> Path.t option Fiber.t
+val install_ocaml_libdir : t -> Path.t option Memo.Build.t
 
 (** Return the compiler needed for this compilation mode *)
 val compiler : t -> Mode.t -> Action.Prog.t
@@ -138,5 +138,5 @@ val init_configurator : t -> unit
 module DB : sig
   val get : Path.Build.t -> t
 
-  val all : unit -> t list Fiber.t
+  val all : unit -> t list Memo.Build.t
 end

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -22,7 +22,7 @@ module Dune_files : sig
       dune files in ocaml syntax *)
   type t
 
-  val eval : t -> context:Context.t -> Dune_file.t list Fiber.t
+  val eval : t -> context:Context.t -> Dune_file.t list Memo.Build.t
 end
 
 type conf = private

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -385,7 +385,7 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
         | _ -> None)
 
 let gen ~contexts ?only_packages conf =
-  let open Fiber.O in
+  let open Memo.Build.O in
   let { Dune_load.dune_files; packages; projects; vcs } = conf in
   let packages = Option.value only_packages ~default:packages in
   let rec sctxs =
@@ -394,10 +394,10 @@ let gen ~contexts ?only_packages conf =
     lazy
       (Context_name.Map.of_list_map_exn contexts ~f:(fun (c : Context.t) ->
            (c.name, Memo.Lazy.Async.create (fun () -> make_sctx c))))
-  and make_sctx (context : Context.t) : _ Fiber.t =
+  and make_sctx (context : Context.t) =
     let host () =
       match context.for_host with
-      | None -> Fiber.return None
+      | None -> Memo.Build.return None
       | Some h ->
         let+ sctx =
           Memo.Lazy.Async.force
@@ -417,7 +417,7 @@ let gen ~contexts ?only_packages conf =
                   dir_conf.stanzas
             })
     in
-    let+ host, stanzas = Fiber.fork_and_join host stanzas in
+    let+ host, stanzas = Memo.Build.fork_and_join host stanzas in
     let sctx =
       Super_context.create ?host ~context ~projects ~packages ~stanzas ()
     in
@@ -425,7 +425,7 @@ let gen ~contexts ?only_packages conf =
   in
   let* sctxs =
     Lazy.force sctxs |> Context_name.Map.to_list
-    |> Fiber.parallel_map ~f:(fun (name, sctx) ->
+    |> Memo.Build.parallel_map ~f:(fun (name, sctx) ->
            let+ sctx = Memo.Lazy.Async.force sctx in
            (name, sctx))
     >>| Context_name.Map.of_list_exn

--- a/src/dune_rules/gen_rules.mli
+++ b/src/dune_rules/gen_rules.mli
@@ -7,4 +7,4 @@ val gen :
      contexts:Context.t list
   -> ?only_packages:Package.t Package.Name.Map.t
   -> Dune_load.conf
-  -> Super_context.t Context_name.Map.t Fiber.t
+  -> Super_context.t Context_name.Map.t Memo.Build.t

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -1,7 +1,7 @@
 open! Dune_engine
 open! Stdune
 open Import
-open Fiber.O
+open Memo.Build.O
 
 let () = Inline_tests.linkme
 

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -26,7 +26,7 @@ val scan_workspace :
   -> ?instrument_with:Lib_name.t list
   -> ancestor_vcs:Vcs.t option
   -> unit
-  -> workspace Fiber.t
+  -> workspace Memo.Build.t
 
 (** Load dune files and initializes the build system *)
 val init_build_system :
@@ -34,7 +34,7 @@ val init_build_system :
   -> sandboxing_preference:Sandbox_mode.t list
   -> ?caching:Build_system.caching
   -> workspace
-  -> build_system Fiber.t
+  -> build_system Memo.Build.t
 
 val find_context_exn : workspace -> name:Context_name.t -> Context.t
 

--- a/src/dune_rules/watermarks.ml
+++ b/src/dune_rules/watermarks.ml
@@ -267,12 +267,13 @@ let make_watermark_map ~commit ~version ~dune_project ~info =
 
 let subst vcs =
   let+ (version, commit), files =
-    Fiber.fork_and_join
-      (fun () ->
-        Fiber.fork_and_join
-          (fun () -> Vcs.describe vcs)
-          (fun () -> Vcs.commit_id vcs))
-      (fun () -> Vcs.files vcs)
+    Memo.Build.run
+      (Memo.Build.fork_and_join
+         (fun () ->
+           Memo.Build.fork_and_join
+             (fun () -> Vcs.describe vcs)
+             (fun () -> Vcs.commit_id vcs))
+         (fun () -> Vcs.files vcs))
   in
   let dune_project : Dune_project.t =
     match

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -2,6 +2,14 @@ open! Stdune
 open Fiber.O
 module Function = Function
 
+module Build = struct
+  include Fiber
+
+  let run = Fun.id
+
+  let of_fiber = Fun.id
+end
+
 let unwrap_exn = ref Fun.id
 
 module Code_error_with_memo_backtrace = struct

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -78,7 +78,7 @@ let run_action (vcs : Vcs.t) action =
       | Hg when not has_hg -> { vcs with kind = Git }
       | _ -> vcs
     in
-    Vcs.describe vcs >>| fun s ->
+    Memo.Build.run (Vcs.describe vcs) >>| fun s ->
     let processed =
       String.split s ~on:'-'
       |> List.map ~f:(fun s ->

--- a/test/unit-tests/artifact_substitution/dune
+++ b/test/unit-tests/artifact_substitution/dune
@@ -1,4 +1,4 @@
 (test
  (name artifact_substitution)
  (package dune-private-libs)
- (libraries stdune dune_engine dune_rules fiber dune_re))
+ (libraries stdune dune_engine dune_rules fiber dune_re memo))


### PR DESCRIPTION
This PR is a first step towards a memo monad. It adds a `Memo.Build` monad that is currently just fiber, update the `Memo` API to use it rather than `Fiber.t` and update the client code. There are probably too many `Memo.Build.run`/`Memo.Build.of_fiber` but it's a start.