### PR TITLE
Move CPU counting to scheduler.ml

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -126,19 +126,13 @@ end
 
 module Scheduler = struct
   include Dune_engine.Scheduler
-  open Fiber.O
 
   let go ~(common : Common.t) f =
     let config = Common.config common in
-    let f () = Main.set_concurrency config >>= f in
     Scheduler.go ~config f
 
   let poll ~(common : Common.t) ~once ~finally () =
     let config = Common.config common in
-    let once () =
-      let* () = Main.set_concurrency config in
-      once ()
-    in
     Scheduler.poll ~config ~once ~finally ()
 end
 

--- a/src/dune_engine/config.ml
+++ b/src/dune_engine/config.ml
@@ -19,12 +19,19 @@ let local_install_lib_dir ~context ~package =
     (local_install_lib_root ~context)
     (Package.Name.to_string package)
 
-let dev_null =
-  Path.of_filename_relative_to_initial_cwd
-    ( if Sys.win32 then
-      "nul"
-    else
-      "/dev/null" )
+let dev_null_fn =
+  if Sys.win32 then
+    "nul"
+  else
+    "/dev/null"
+
+let dev_null = Path.of_filename_relative_to_initial_cwd dev_null_fn
+
+let open_null flags = lazy (Unix.openfile dev_null_fn flags 0o666)
+
+let dev_null_in = open_null [ Unix.O_RDONLY ]
+
+let dev_null_out = open_null [ Unix.O_WRONLY ]
 
 let dune_keep_fname = ".dune-keep"
 

--- a/src/dune_engine/config.mli
+++ b/src/dune_engine/config.mli
@@ -16,6 +16,12 @@ val local_install_lib_dir :
 
 val dev_null : Path.t
 
+(** [dev_null] opened in read mode *)
+val dev_null_in : Unix.file_descr Lazy.t
+
+(** [dev_null] opened in write mode *)
+val dev_null_out : Unix.file_descr Lazy.t
+
 (** When this file is present in a directory dune will delete nothing in it if
     it knows to generate this file. *)
 val dune_keep_fname : string

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -86,24 +86,11 @@ module Io = struct
 
   let stdin = terminal (In_chan stdin)
 
-  let null_path =
-    lazy
-      ( if Sys.win32 then
-        "nul"
-      else
-        "/dev/null" )
-
-  let open_null flags = lazy (Unix.openfile (Lazy.force null_path) flags 0o666)
-
-  let null_in = open_null [ Unix.O_RDONLY ]
-
-  let null_out = open_null [ Unix.O_WRONLY ]
-
   let null (type a) (mode : a mode) : a t =
     let fd =
       match mode with
-      | In -> null_in
-      | Out -> null_out
+      | In -> Config.dev_null_in
+      | Out -> Config.dev_null_out
     in
     let channel = lazy (channel_of_descr (Lazy.force fd) mode) in
     { kind = Null; mode; fd; channel; status = Close_after_exec }
@@ -154,7 +141,7 @@ type purpose =
 let io_to_redirection_path (kind : Io.kind) =
   match kind with
   | Terminal -> None
-  | Null -> Some (Lazy.force Io.null_path)
+  | Null -> Some (Path.to_string Config.dev_null)
   | File fn -> Some (Path.to_string fn)
 
 let command_line_enclosers ~dir ~(stdout_to : Io.output Io.t)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -26,8 +26,6 @@ val wait_for_process : Pid.t -> Unix.process_status Fiber.t
 (** Wait for dune cache to be disconnected. Drop any other event. *)
 val wait_for_dune_cache : unit -> unit
 
-val set_concurrency : int -> unit Fiber.t
-
 (** Make the scheduler ignore next change to a certain file in watch mode.
 
     This is used with promoted files that are copied back to the source tree

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -42,6 +42,3 @@ val find_scontext_exn : build_system -> name:Context_name.t -> Super_context.t
 
 (** Setup the environment *)
 val setup_env : capture_outputs:bool -> Env.t
-
-(** Set the concurrency level according to the user configuration *)
-val set_concurrency : Config.t -> unit Fiber.t


### PR DESCRIPTION
This simplifies a bit the code as we don't need to call `Main.set_concurrency` anymore.

The old code was using `Process.run`, which we can't use in `scheduler.ml` without creating a dependency cycle between `Process` and `Scheduler`. I hesitated between adding a forward declaration and using `Unix.create_process` directly. Since the old detection was already done sequentially and the code is simple overall, I opted for the latter.