### PR TITLE
Remove field install_prefix from Context.t

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -15,9 +15,7 @@ let get_dirs context ~prefix_from_command_line ~libdir_from_command_line =
     Fiber.return (prefix, Some (Path.relative prefix dir))
   | None ->
     let open Fiber.O in
-    let* prefix =
-      Memo.Build.run (Memo.Lazy.Async.force context.Context.install_prefix)
-    in
+    let* prefix = Memo.Build.run (Context.install_prefix context) in
     let libdir =
       match libdir_from_command_line with
       | None -> Memo.Build.run (Context.install_ocaml_libdir context)

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -84,7 +84,6 @@ type t = private
   ; findlib_toolchain : Context_name.t option  (** Misc *)
   ; default_ocamlpath : Path.t list
   ; arch_sixtyfour : bool
-  ; install_prefix : Path.t Memo.Lazy.Async.t
   ; ocaml_config : Ocaml_config.t
   ; ocaml_config_vars : Ocaml_config.Vars.t
   ; version : Ocaml_version.t
@@ -132,6 +131,10 @@ val lib_config : t -> Lib_config.t
 val map_exe : t -> Path.t -> Path.t
 
 val build_context : t -> Build_context.t
+
+(** Query where build artifacts should be installed if the user doesn't specify
+    an explicit installation directory. *)
+val install_prefix : t -> Path.t Memo.Build.t
 
 val init_configurator : t -> unit
 


### PR DESCRIPTION
It is only used once in the install command, no need to store it in the context.

/cc @bobot 