### PR TITLE
Run end of build hook after doing `$ dune build`

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -16,14 +16,7 @@ let run_build_command ~common ~targets =
     Scheduler.poll ~common ~once ~finally:Hooks.End_of_build.run ()
   else
     Scheduler.go ~common once;
-  match Build_system.get_cache () with
-  | Some { cache = (module Caching : Cache.Caching); _ } ->
-    (* Synchronously wait for the end of the connection with the cache daemon,
-       ensuring all dedup messages have been queued. *)
-    Caching.Cache.teardown Caching.cache;
-    (* Hande all remaining dedup messages. *)
-    Scheduler.wait_for_dune_cache ()
-  | None -> ()
+  Build_system.cache_teardown ()
 
 let runtest =
   let doc = "Run tests." in

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -86,8 +86,10 @@ let term =
       | [] -> ()
       | targets ->
         Scheduler.go ~common (fun () -> Memo.Build.run (do_build targets));
-        Hooks.End_of_build.run ();
-        Build_system.cache_teardown () );
+        Build_system.cache_teardown ();
+        (* We must manually run the hook because Unix.exec will not run
+           [at_exit] hooks *)
+        Hooks.End_of_build.run () );
     match prog_where with
     | `Search prog ->
       let path =

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -86,7 +86,8 @@ let term =
       | [] -> ()
       | targets ->
         Scheduler.go ~common (fun () -> Memo.Build.run (do_build targets));
-        Hooks.End_of_build.run () );
+        Hooks.End_of_build.run ();
+        Build_system.cache_teardown () );
     match prog_where with
     | `Search prog ->
       let path =

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -182,3 +182,5 @@ val evaluate_rules :
   -> Evaluated_rule.t list Memo.Build.t
 
 val get_cache : unit -> caching option
+
+val cache_teardown : unit -> unit


### PR DESCRIPTION
Not sure how we omitted this, but we do this after `dune runtest` or `dune exec`