### PR TITLE
Handle non-existing file in `print_diff`

### DIFF
--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -56,6 +56,7 @@ module File = struct
 
   let do_promote ~correction_file ~dst =
     Path.Source.unlink_no_err dst;
+    Path.mkdir_p (Path.source (Path.Source.parent_exn dst));
     let chmod = Path.Permissions.add Path.Permissions.write in
     Io.copy_file ~chmod
       ~src:(Path.build correction_file)

--- a/test/blackbox-tests/test-cases/promote/non-existent.t/dune
+++ b/test/blackbox-tests/test-cases/promote/non-existent.t/dune
@@ -3,3 +3,7 @@
 (rule
  (alias blah-non-existent)
  (action (diff x-non-existent x.gen)))
+
+(rule
+ (alias blah-non-existent-in-sub-dir)
+ (action (diff subdir/x-non-existent-in-sub-dir x.gen)))

--- a/test/blackbox-tests/test-cases/promote/non-existent.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/non-existent.t/run.t
@@ -7,12 +7,29 @@ Tests for promoting with non existent reference
   [1]
 
   $ dune build @blah-non-existent
-  File "x-non-existent", line 1, characters 0-0:
-  Error: Files _build/default/x-non-existent and _build/default/x.gen differ.
+  File "_build/default/x-non-existent", line 1, characters 0-0:
+  Error:
+  --- _build/default/x-non-existent
+  +++ _build/default/x.gen
+  +toto
   [1]
 
   $ dune promote
   Promoting _build/default/x.gen to x-non-existent.
 
   $ cat x-non-existent
+  toto
+
+  $ dune build @blah-non-existent-in-sub-dir
+  File "_build/default/subdir/x-non-existent-in-sub-dir", line 1, characters 0-0:
+  Error:
+  --- _build/default/subdir/x-non-existent-in-sub-dir
+  +++ _build/default/x.gen
+  +toto
+  [1]
+
+  $ dune promote
+  Promoting _build/default/x.gen to subdir/x-non-existent-in-sub-dir.
+
+  $ cat subdir/x-non-existent-in-sub-dir
   toto


### PR DESCRIPTION
Diff command don't like that one of the file doesn't exist. The solution implemented is for dune to print the diff when one of the files doesn't exists.

However the current way we do diffing seems strange to me:
 - A `Format.eprintf "%a@?" Loc.render (Loc.pp loc);` is used in the middle of the code, so the line is printed at random place
 - The output of the diff command is directly connected to the stdout, so not buffered.

How to fix that (if it is needed)?
 - Perhaps we should do like for other commands `(run ...)`, but should the output of `(diff ...)` be redirected in case of `(write-stdout-to ...)`?

So it is still a draft:
  * [ ] It circumvents also user diff in this case, is it a problem?
  * [ ] It uses Printf.printf, it should be a problem.
  * [ ] It always uses ANSI colors, it is a problem

