### PR TITLE
Add default_ocamlpath to OCAMLPATH

### DIFF
--- a/otherlibs/site/test/plugin_with_dot.t
+++ b/otherlibs/site/test/plugin_with_dot.t
@@ -97,10 +97,10 @@ Test error messages
   > EOF
 
   $ dune exec -- c/c.exe "inexistent" 2>&1 | sed -e 's&default/lib:.*&default/lib:..."&g'
-  The library "inexistent" can't be found in the search paths "$TESTCASE_ROOT/_build/install/default/lib:..."
+  The library "inexistent" can't be found in the search paths "OCAMLPATH:$TESTCASE_ROOT/_build/install/default/lib:..."
 
   $ dune exec -- c/c.exe "b.b.b"
   run b
 
   $ dune exec -- c/c.exe "b.b.inexistent" 2>&1  | sed -e 's&default/lib:.*&default/lib:..."&g'
-  The sub-library "inexistent" can't be found in the library b.b in the search paths "$TESTCASE_ROOT/_build/install/default/lib:..."
+  The sub-library "inexistent" can't be found in the library b.b in the search paths "OCAMLPATH:$TESTCASE_ROOT/_build/install/default/lib:..."


### PR DESCRIPTION
Fixes #4196

This adds `default_ocamlpath` to the `OCAMLPATH` variable passed to subprocesses to fix the situation where `ocamlfind` is part of the workspace.