### PR TITLE
Do not pass native include dirs when compiling bytecode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ Unreleased
 - Add `ocaml` command subgroup for OCaml related commands such as `utop`, `top`,
   and `merlin` (#3936, @rgrinberg).
 
+- Do not pass include directories containing native objects when compiling
+  bytecode (#4200, @nojb)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -47,7 +47,9 @@ let term =
       let requires =
         Dune_rules.Lib.closure ~linking:true libs |> Result.ok_exn
       in
-      let include_paths = Dune_rules.Lib.L.include_paths requires in
+      let include_paths =
+        Dune_rules.Lib.L.include_paths requires Dune_rules.Mode.Byte
+      in
       let files = link_deps requires in
       let* () =
         Memo.Build.run (do_build (List.map files ~f:(fun f -> Target.File f)))

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -11,16 +11,18 @@ module Includes = struct
     | Error exn ->
       Cm_kind.Dict.make_all (Command.Args.Fail { fail = (fun () -> raise exn) })
     | Ok libs ->
-      let iflags = Lib.L.include_flags ~project libs in
+      let iflags mode = Lib.L.include_flags ~project libs mode in
       let cmi_includes =
         Command.Args.memo
           (Command.Args.S
-             [ iflags; Hidden_deps (Lib_file_deps.deps libs ~groups:[ Cmi ]) ])
+             [ iflags Byte
+             ; Hidden_deps (Lib_file_deps.deps libs ~groups:[ Cmi ])
+             ])
       in
       let cmx_includes =
         Command.Args.memo
           (Command.Args.S
-             [ iflags
+             [ iflags Native
              ; Hidden_deps
                  ( if opaque then
                    List.map libs ~f:(fun lib ->

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -70,9 +70,9 @@ module L : sig
 
   val to_iflags : Path.Set.t -> _ Command.Args.t
 
-  val include_paths : ?project:Dune_project.t -> t -> Path.Set.t
+  val include_paths : ?project:Dune_project.t -> t -> Mode.t -> Path.Set.t
 
-  val include_flags : ?project:Dune_project.t -> t -> _ Command.Args.t
+  val include_flags : ?project:Dune_project.t -> t -> Mode.t -> _ Command.Args.t
 
   val c_include_flags : t -> _ Command.Args.t
 

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -105,7 +105,9 @@ let setup_module_rules t =
   let main_ml =
     Action_builder.of_result_map requires_compile ~f:(fun libs ->
         Action_builder.return
-          (let include_dirs = Path.Set.to_list (Lib.L.include_paths libs) in
+          (let include_dirs =
+             Path.Set.to_list (Lib.L.include_paths libs Mode.Byte)
+           in
            let pp_ppx = pp_flags t in
            let pp_dirs = Source.pp_ml t.source ~include_dirs in
            let pp = Pp.seq pp_ppx pp_dirs in

--- a/test/blackbox-tests/test-cases/toplevel-integration.t/run.t
+++ b/test/blackbox-tests/test-cases/toplevel-integration.t/run.t
@@ -16,7 +16,6 @@ Test toplevel-init-file on a tiny project
 
   $ dune ocaml top
   #directory "$TESTCASE_ROOT/_build/default/.test.objs/byte";;
-  #directory "$TESTCASE_ROOT/_build/default/.test.objs/native";;
   #load "$TESTCASE_ROOT/_build/default/test.cma";;
 
   $ ocaml -stdin <<EOF


### PR DESCRIPTION
When `dune` builds `.cmo` or `.cmi` files, it passes the `native` directories via `-I` which is unnecessary. The present PR changes this so that these directories (which contain the `.cmx` files) are only passed when compiling other native files.