### PR TITLE
Document `%{env:<var>=<default>}`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1478,8 +1478,9 @@ Unreleased
   help Windows builds where paths are limited in length (#1511, fixes
   #1497, @diml)
 
-- Fix interpretation of environment variables under `setenv`. Also forbid
-  dynamic environment names or values (#1503, @rgrinberg).
+- Fix interpretation of `%{env:<var>=<default>}` environment variables
+  under `setenv`. Also forbid dynamic environment names or values
+  (#1503, @rgrinberg).
 
 1.4.0 (10/10/2018)
 ------------------
@@ -1526,6 +1527,10 @@ Unreleased
   installed (#1391, @nojb)
 
 - Take argument to self_build_stubs_archive into account. (#1395, @nojb)
+
+- New variable form `%{env:<var>=<default>}` that expands to the environment
+  variable `<var>`, or `<default>` if not found. Example: `%{env:BIN=/usr/bin}`.
+  (#1305, @trefis)
 
 - Fix bad interaction between `env` customization and vendored
   projects: when a vendored project didn't have its own `env` stanza,

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ distclean: clean
 	rm -f src/dune_rules/setup.ml
 
 doc:
-	cd doc && sphinx-build . _build
+	sphinx-build doc doc/_build
 
 livedoc:
 	cd doc && sphinx-autobuild . _build \

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -180,6 +180,10 @@ Dune supports the following variables:
   ``false`` otherwise
 - ``<ext>:<path>`` where ``<ext>`` is one of ``cmo``, ``cmi``, ``cma``,
   ``cmx``, or ``cmxa``. See :ref:`variables-for-artifacts`.
+- ``env:<var>=<default``, which expands to the value of the environment
+  variable ``<var>``, or ``<default>`` if it does not exist.
+  For example, ``%{env:BIN=/usr/bin}``.
+  Available since dune 1.4.0.
 
 In addition, ``(action ...)`` fields support the following special variables:
 


### PR DESCRIPTION
See https://github.com/ocaml/dune/issues/1506 for context: this feature is currently completely undocumented.

Note: the Variables documentation is a bit of a pain to read, in particular because variables are not listed in alphabetic order so it is difficult to tell if a variable is documented without grepping. (It could also be split between "simple" variables `%{var}` and the parametrized `%{var:arg}` form, or some other forms of categorization.)
