### PR TITLE
merlin: communicate STDLIB directive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@ Unreleased
 - Dune no longer automatically create or edit `dune-project` files
   (#4239, fixes #4108, @jeremiedimino)
 
+- Have `dune` communicate the location of the standard library directory to
+  `merlin` (#4211, fixes #4188, @nojb)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -159,6 +159,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       ~modules ~flags ~requires_link ~requires_compile ~preprocessing:pp
       ~js_of_ocaml ~opaque:Inherit_from_settings ~package:exes.package
   in
+  let stdlib_dir = ctx.Context.stdlib_dir in
   let requires_compile = Compilation_context.requires_compile cctx in
   let preprocess =
     Preprocess.Per_module.with_instrumentation exes.buildable.preprocess
@@ -197,7 +198,8 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       ~promote:exes.promote ~embed_in_plugin_libraries
   in
   ( cctx
-  , Merlin.make ~requires:requires_compile ~flags ~modules ~preprocess ~obj_dir
+  , Merlin.make ~requires:requires_compile ~stdlib_dir ~flags ~modules
+      ~preprocess ~obj_dir
       ~dialects:(Dune_project.dialects (Scope.project scope))
       ~ident:(Lib.Compile.merlin_ident compile_info)
       () )

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -386,6 +386,7 @@ let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
   let dir = Compilation_context.dir cctx in
   let scope = Compilation_context.scope cctx in
   let requires_compile = Compilation_context.requires_compile cctx in
+  let stdlib_dir = (Compilation_context.context cctx).Context.stdlib_dir in
   let dep_graphs = Dep_rules.rules cctx ~modules in
   Option.iter vimpl ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir);
   Check_rules.add_obj_dir sctx ~obj_dir;
@@ -415,8 +416,8 @@ let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
     ; compile_info
     };
   ( cctx
-  , Merlin.make ~requires:requires_compile ~flags ~modules ~preprocess
-      ~libname:(snd lib.name) ~obj_dir
+  , Merlin.make ~requires:requires_compile ~stdlib_dir ~flags ~modules
+      ~preprocess ~libname:(snd lib.name) ~obj_dir
       ~dialects:(Dune_project.dialects (Scope.project scope))
       ~ident:(Lib.Compile.merlin_ident compile_info)
       () )

--- a/src/dune_rules/merlin.mli
+++ b/src/dune_rules/merlin.mli
@@ -26,6 +26,7 @@ end
 
 val make :
      ?requires:Lib.t list Or_exn.t
+  -> stdlib_dir:Path.t
   -> flags:Ocaml_flags.t
   -> ?preprocess:
        Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t

--- a/test/blackbox-tests/test-cases/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/github1946.t/run.t
@@ -2,9 +2,11 @@ This test demonstrates that -ppx is no more missing when two stanzas are
 in the same dune file, but require different ppx specifications
 
   $ dune build @all --profile release
-  $ dune ocaml-merlin --dump-config=$(pwd)
+  $ dune ocaml-merlin --dump-config=$(pwd) |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Usesppx1
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.usesppx1.objs/byte)
    (S
@@ -17,7 +19,8 @@ in the same dune file, but require different ppx specifications
      'library-name="usesppx1"'"))
    (FLG (-open Usesppx1 -w -40)))
   Usesppx2
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.usesppx2.objs/byte)
    (S

--- a/test/blackbox-tests/test-cases/github759.t/run.t
+++ b/test/blackbox-tests/test-cases/github759.t/run.t
@@ -1,7 +1,9 @@
   $ dune build foo.cma --profile release
-  $ dune ocaml-merlin --dump-config=$(pwd)
+  $ dune ocaml-merlin --dump-config=$(pwd) |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S
@@ -10,9 +12,11 @@
 
   $ rm -f .merlin
   $ dune build foo.cma --profile release
-  $ dune ocaml-merlin --dump-config=$(pwd)
+  $ dune ocaml-merlin --dump-config=$(pwd) |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S
@@ -21,9 +25,11 @@
 
   $ echo toto > .merlin
   $ dune build foo.cma --profile release
-  $ dune ocaml-merlin --dump-config=$(pwd)
+  $ dune ocaml-merlin --dump-config=$(pwd) |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -17,9 +17,11 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   ..
   lib-foo
 
-  $ dune ocaml-merlin --dump-config="$(pwd)"
+  $ dune ocaml-merlin --dump-config="$(pwd)" |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/cross/.foo.objs/byte)
    (S

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -3,9 +3,11 @@ We build the project
   bar
 
 Verify that merlin configuration was generated...
-  $ dune ocaml-merlin --dump-config=$(pwd)
+  $ dune ocaml-merlin --dump-config=$(pwd) |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Test
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (B
@@ -22,7 +24,8 @@ Verify that merlin configuration was generated...
      -short-paths
      -keep-locs)))
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S
@@ -44,12 +47,12 @@ Now we check that both querying from the root and the subfolder works
   $ FILE=$(pwd)/foo.ml
   $ FILE411=$(pwd)/411/test.ml
 
-  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g"
+  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
-  ((?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
+  ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
 
-  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g"
+  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE411}:$FILE411)
   > EOF
-  ((?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
+  ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -3,7 +3,8 @@ CRAM sanitization
   $ dune ocaml-merlin --dump-config=$(pwd)/exe |
   > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   X
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B OPAM_PREFIX/lib/bytes)
    (B OPAM_PREFIX/lib/findlib)
    (B OPAM_PREFIX/lib/ocaml)
@@ -27,7 +28,8 @@ CRAM sanitization
   $ dune ocaml-merlin --dump-config=$(pwd)/lib |
   > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   File
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
    (S
@@ -42,7 +44,8 @@ CRAM sanitization
      'library-name="bar"'"))
    (FLG (-open Bar -w -40)))
   Bar
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/lib/.bar.objs/byte)
    (S
@@ -57,7 +60,8 @@ CRAM sanitization
      'library-name="bar"'"))
    (FLG (-open Bar -w -40)))
   Privmod
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B OPAM_PREFIX/lib/bytes)
    (B OPAM_PREFIX/lib/findlib)
    (B OPAM_PREFIX/lib/ocaml)
@@ -78,7 +82,8 @@ CRAM sanitization
      'library-name="foo"'"))
    (FLG (-open Foo -w -40)))
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B OPAM_PREFIX/lib/bytes)
    (B OPAM_PREFIX/lib/findlib)
    (B OPAM_PREFIX/lib/ocaml)
@@ -108,7 +113,8 @@ Make sure pp flag is correct and variables are expanded
   $ dune ocaml-merlin --dump-config=$(pwd)/pp-with-expand |
   > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Foobar
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/pp-with-expand/.foobar.eobjs/byte)
    (S
@@ -124,7 +130,8 @@ Check hash of executables names if more than one
   $ dune ocaml-merlin --dump-config=$(pwd)/exes |
   > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Y
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
    (S
@@ -137,7 +144,8 @@ Check hash of executables names if more than one
      -short-paths
      -keep-locs)))
   X
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/exes/.x.eobjs/byte)
    (S

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -3,9 +3,11 @@
 We dump the config for Foo and Bar modules but the pp.exe preprocessor
 should appear only once since only Foo is using it.
 
-  $ dune ocaml-merlin --dump-config=$(pwd)
+  $ dune ocaml-merlin --dump-config=$(pwd) |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S
@@ -21,7 +23,8 @@ should appear only once since only Foo is using it.
      -short-paths
      -keep-locs)))
   Bar
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/byte)
    (S

--- a/test/blackbox-tests/test-cases/merlin/server.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/server.t/run.t
@@ -6,13 +6,13 @@
 
   $ dune build @check
 
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g"
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
-  ((?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.main.eobjs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Dune__exe?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
+  ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.main.eobjs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Dune__exe?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
 
   $ FILE=$PWD/lib3.ml
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g"
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
-  ((?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
+  ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t/run.t
@@ -15,9 +15,11 @@ library also has more than one src dir.
   > EOF
 
   $ dune build lib2/.merlin-conf/lib-lib2
-  $ dune ocaml-merlin --dump-config=$(pwd)/lib2
+  $ dune ocaml-merlin --dump-config=$(pwd)/lib2 |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Lib2
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/lib1/.lib1.objs/byte)
    (B

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -25,7 +25,9 @@ Dune ocaml-merlin also accepts paths relative to the current directory
   Foo
 
   $ cd realsrc
-  $ dune ocaml-merlin --dump-config="." --root=".." | head -n 2
+  $ dune ocaml-merlin --dump-config="." --root=".." |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#' |
+  > head -n 2
   Entering directory '..'
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)

--- a/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
@@ -1,9 +1,11 @@
   $ dune exec ./foo.exe
   42
 
-  $ dune ocaml-merlin --dump-config=$(pwd)
+  $ dune ocaml-merlin --dump-config=$(pwd) |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.eobjs/byte)
    (B
@@ -20,9 +22,11 @@
      -short-paths
      -keep-locs)))
 
-  $ dune ocaml-merlin --dump-config=$(pwd)/foo
+  $ dune ocaml-merlin --dump-config=$(pwd)/foo |
+  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
   Bar
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
    (S
@@ -37,7 +41,8 @@
      -short-paths
      -keep-locs)))
   Foo
-  ((EXCLUDE_QUERY_DIR)
+  ((STDLIB OPAM_PREFIX/lib/ocaml)
+   (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/foo/.foo.objs/byte)
    (S


### PR DESCRIPTION
Make it so that `dune` communicates the standard library directory to `merlin`. This makes it possible to use `merlin` with an OCaml compiler other than the one it was compiled with.

Fixes #4188