### PR TITLE
Fix reproducibility of a merlin test

### DIFF
--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -99,8 +99,8 @@ CRAM sanitization
      'library-name="foo"'"))
    (FLG (-open Foo -w -40)))
 
-Make sure a ppx directive is generated
-  $ dune ocaml-merlin --dump-config=$(pwd)/lib | grep -q ppx
+Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
+  $ dune ocaml-merlin --dump-config=$(pwd)/lib | grep ppx > /dev/null
 
 Make sure pp flag is correct and variables are expanded
 


### PR DESCRIPTION
`grep -q` closes the input once it finds a match which causes `dune ocaml-merlin` to fail with an error if it isn't quick enough to write the output completely. The fix removes `-q` and simply redirects `grep`'s output to `/dev/null`.
