### PR TITLE
Add a Memo test with a non-uniformly cut diamond

### DIFF
--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -111,6 +111,10 @@ end
     cache, and cancels all pending computations. *)
 val reset : unit -> unit
 
+(** Notify the memoization system that the build system has restarted but do not
+    clear the memoization cache. *)
+val restart_current_run : unit -> unit
+
 module Function : sig
   module Type : sig
     type ('a, 'b, 'f) t =


### PR DESCRIPTION
This test seems to reveal a bug in the Memo's cutoff logic.