### PR TITLE
Detect auto-mode for dune-project files in emacs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ Unreleased
 - Improve location of variables and macros in error messages (#4205,
   @jeremiedimino)
 
+- Auto-detect `dune-project` files as `dune` files in Emacs (#4222, @shonfeder)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/editor-integration/emacs/dune.el
+++ b/editor-integration/emacs/dune.el
@@ -395,7 +395,7 @@ For customization purposes, use `dune-mode-hook'."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist
-             '("\\(?:\\`\\|/\\)dune\\(?:\\.inc\\)?\\'" . dune-mode))
+             '("\\(?:\\`\\|/\\)dune\\(?:\\.inc\|-project\\)?\\'" . dune-mode))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This lets emacs automatically switch to `dune-mode` when visiting a
`dune-project` file.

Signed-off-by: Shon Feder <shon.feder@gmail.com>