### PR TITLE
Workaround OCaml PR#8857 in Path.touch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@ Unreleased
 
 - Add support for instrumentation dependencies (#4210, fixes #3983, @nojb)
 
+- Workaround incorrect exception raised by Unix.utimes (OCaml PR#8857) in
+  Path.touch on Windows (#4223, @dra27)
+
 2.8.2 (21/01/2021)
 ------------------
 


### PR DESCRIPTION
Progresses #4167 prior to OCaml 4.13.

The guard must test for the file's presence, as you can't differentiate `EACCES` and `ENOENT` without ocaml/ocaml#10220.