### PR TITLE
Fix the CI

### DIFF
--- a/test/blackbox-tests/test-cases/merlin/github4125.t/dune-workspace
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/dune-workspace
@@ -1,9 +1,0 @@
-(lang dune 2.0)
-
-(context (default))
-
-(context
- (opam
-  (name cross)
-  (switch default)
-  (merlin)))

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -1,3 +1,15 @@
+We call `$(opam switch show)` so that this test always uses an existing switch
+
+  $ cat >dune-workspace <<EOF
+  > (lang dune 2.0)
+  > (context (default))
+  > (context
+  > (opam
+  >  (name cross)
+  >  (switch $(opam switch show))
+  >  (merlin)))
+  > EOF
+
   $ dune build
 
   $ ls -a _build/cross/.merlin-conf


### PR DESCRIPTION
CI is broken due to a test using a switch named `default` to test cross-compilation settings.

I used `opam switch show` to trick the test in always using an existing switch: the current one.