### PR TITLE
Virtual_rules: use copy instead of symlink when copying signatures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@ Unreleased
 
 - Add a META rule for 'compiler-libs.native-toplevel' (#4175, @altgr)
 
+- No longer call `chmod` on symbolic links (fixes #4195, @dannywillems)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -104,7 +104,7 @@ let refresh fn =
   refresh_ stats fn
 
 let refresh_and_chmod fn =
-  let stats = Path.stat fn in
+  let stats = Path.lstat fn in
   let () =
     (* We remove write permissions to uniformize behavior regardless of whether
        the cache is activated. No need to be zealous in case the file is not

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -1263,6 +1263,8 @@ let local_part = function
 
 let stat t = Unix.stat (to_string t)
 
+let lstat t = Unix.lstat (to_string t)
+
 include (Comparator.Operators (T) : Comparator.OPS with type t := t)
 
 let path_of_local = of_local

--- a/src/stdune/path.mli
+++ b/src/stdune/path.mli
@@ -358,6 +358,8 @@ val local_part : t -> Local.t
 
 val stat : t -> Unix.stats
 
+val lstat : t -> Unix.stats
+
 (* it would be nice to call this [Set.of_source_paths], but it's annoying to
    change the [Set] signature because then we don't comply with [Path_intf.S] *)
 val set_of_source_paths : Source.Set.t -> Set.t


### PR DESCRIPTION
Fix https://github.com/ocaml/dune/issues/4195

In sandbox, symlink requires rw permissions on the directory of the sources to create a symlink. Copy does not require.
To test, you can build this branch, and try to install `bls12-381-unix` or `bls12-381-js`.

In addition to the comments in #4195, this issue has not been detected by the CI of bls12-381 (installing via opam is verified here: https://gitlab.com/dannywillems/ocaml-bls12-381/-/blob/master/.gitlab-ci.yml#L136) or by the CI of the public opam-repository (see https://github.com/ocaml/opam-repository/pull/18112) because I think sandbox is not used.