### PR TITLE
Add tests of dependency on an alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,9 @@ Unreleased
   merlin configuration of a directory (defaulting to the current directory) in
   the Merlin configuration syntax. (#4250, @voodoos)
 
+- Dune will now re-run actions whose dependencies are declared through a chain 
+  of aliases (#4238, @aalekseyev)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,8 +60,9 @@ Unreleased
   merlin configuration of a directory (defaulting to the current directory) in
   the Merlin configuration syntax. (#4250, @voodoos)
 
-- Dune will now re-run actions whose dependencies are declared through a chain 
-  of aliases (#4238, @aalekseyev)
+- It is now possible to define action dependencies through a chain
+   of aliases. Such dependencies are still not available
+   when sandboxing is used, though. (#4238, @aalekseyev)
 
 2.8.2 (21/01/2021)
 ------------------

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -124,8 +124,10 @@ module Alias : sig
     -> contexts:Context_name.t list
     -> unit Action_builder.t
 
-  (** Implements [(alias_rec ...)] in dependency specification *)
-  val dep_rec : t -> loc:Loc.t -> unit Action_builder.t
+  (** Implements [(alias_rec ...)] in dependency specification.
+      Returns the list of all contributing alias stamp files , as a proxy
+      for alias expansion. *)
+  val dep_rec : t -> loc:Loc.t -> Path.t list Action_builder.t
 
   (** Implements [@alias] on the command line *)
   val dep_rec_multi_contexts :

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -528,7 +528,7 @@ let expand t ~loc ~deps:deps_written_by_user ~targets_dir
     ~targets:targets_written_by_user ~expander =
   let open Action_builder.O in
   let deps_builder, expander =
-    Dep_conf_eval.named ~expander deps_written_by_user
+    Dep_conf_eval.named ~expander ~alias_expansion:Empty deps_written_by_user
   in
   let expander =
     match (targets_written_by_user : Targets.Or_forbidden.t) with

--- a/src/dune_rules/cram_rules.ml
+++ b/src/dune_rules/cram_rules.ml
@@ -156,7 +156,7 @@ let rules ~sctx ~expander ~dir tests =
                 | Some deps ->
                   let deps : unit Action_builder.t =
                     let expander = Super_context.expander sctx ~dir in
-                    fst (Dep_conf_eval.named ~expander deps)
+                    fst (Dep_conf_eval.named ~alias_expansion:Empty ~expander deps)
                   in
                   deps :: acc.deps
               in

--- a/src/dune_rules/dep_conf_eval.mli
+++ b/src/dune_rules/dep_conf_eval.mli
@@ -6,10 +6,37 @@ open! Dune_engine
 (** Evaluates unnamed dependency specifications. *)
 val unnamed : expander:Expander.t -> Dep_conf.t list -> unit Action_builder.t
 
+<<<<<<< HEAD
 (** Evaluates named dependency specifications. Return the action build that
     register dependencies as well as an expander that can be used to expand to
     expand variables from the bindings. *)
+||||||| parent of ff33e0c28... depend on stamp files
+(** Evaluates to the actual list of dependencies, ignoring aliases, and
+    registers them as the action dependencies.
+
+    It returns bindings that are later used for action expansion. *)
+=======
+(** A variant specifying what set of paths should aliases be expand into. *)
+module Alias_expansion : sig
+  type t =
+    | Empty (** Expand into an empty set of paths. *)
+    | Stamp_file (** Expand into the alias stamp file. *)
+      (* CR-someday aalekseyev:
+         We should add a Full mode where the aliases are expanded to the list of
+         files contained within. *)
+end
+
+(** Evaluates to the actual list of dependencies, and registers them as the action
+    dependencies.
+
+    Aliases may or may not contribute to the final list of files, as specified by
+    [alias_expansion]. Regardless of [alias_expansion], the dependency on alias
+    stamp file is registered.
+
+    It returns bindings that are later used for action expansion. *)
+>>>>>>> ff33e0c28... depend on stamp files
 val named :
-     expander:Expander.t
+  alias_expansion:Alias_expansion.t
+  -> expander:Expander.t
   -> Dep_conf.t Bindings.t
   -> unit Action_builder.t * Expander.t

--- a/src/dune_rules/dep_conf_eval.mli
+++ b/src/dune_rules/dep_conf_eval.mli
@@ -6,16 +6,6 @@ open! Dune_engine
 (** Evaluates unnamed dependency specifications. *)
 val unnamed : expander:Expander.t -> Dep_conf.t list -> unit Action_builder.t
 
-<<<<<<< HEAD
-(** Evaluates named dependency specifications. Return the action build that
-    register dependencies as well as an expander that can be used to expand to
-    expand variables from the bindings. *)
-||||||| parent of ff33e0c28... depend on stamp files
-(** Evaluates to the actual list of dependencies, ignoring aliases, and
-    registers them as the action dependencies.
-
-    It returns bindings that are later used for action expansion. *)
-=======
 (** A variant specifying what set of paths should aliases be expand into. *)
 module Alias_expansion : sig
   type t =
@@ -26,15 +16,26 @@ module Alias_expansion : sig
          files contained within. *)
 end
 
-(** Evaluates to the actual list of dependencies, and registers them as the action
-    dependencies.
+(** TODO: get rid of this somehow, making alias expansions work in a more
+    straightforward manner. *)
+val named0 :
+  alias_expansion:Alias_expansion.t
+  -> expander:Expander.t
+  -> Dep_conf.t Bindings.t
+  ->
+  Path.t list Action_builder.t *
+  Dune_util.Value.t list Action_builder.t
+    Pform.Map.t
+
+(** Evaluates named dependency specifications. Return the action build that
+    register dependencies as well as an expander that can be used to expand to
+    expand variables from the bindings.
 
     Aliases may or may not contribute to the final list of files, as specified by
     [alias_expansion]. Regardless of [alias_expansion], the dependency on alias
     stamp file is registered.
 
     It returns bindings that are later used for action expansion. *)
->>>>>>> ff33e0c28... depend on stamp files
 val named :
   alias_expansion:Alias_expansion.t
   -> expander:Expander.t

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -213,16 +213,17 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
   | true ->
     match alias_conf.action with
     | None ->
-      Dep_conf_eval.named ~alias_expansion:Stamp_file ~expander alias_conf.deps
-      |> fun (deps, _expander) ->
+      Dep_conf_eval.named0 ~alias_expansion:Stamp_file ~expander alias_conf.deps
+      |> fun (deps, _bindings) ->
       let deps =
-        Action_builder.map deps ~f:(fun l -> Path.Set.of_list (Bindings.to_list l))
+        Action_builder.map deps ~f:(fun l -> Path.Set.of_list ( l))
       in
       Rules.Produce.Alias.add_deps alias ~dyn_deps:(deps) Path.Set.empty
     | Some (action_loc, action) ->
       (* One might think this branch is deprecated in favor of rule with empty deps
          (in #2681 and #2846), but it's actually used by [Test_rules] module.
          We could probably make this less confusing by using [rule] instead. *)
+      let locks = interpret_locks ~expander alias_conf.locks in
       let action =
         let builder, expander =
           Dep_conf_eval.named ~alias_expansion:Empty ~expander alias_conf.deps

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -213,7 +213,7 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
   | true ->
     match alias_conf.action with
     | None ->
-      Dep_conf_eval.named ~expander alias_conf.deps
+      Dep_conf_eval.named ~alias_expansion:Stamp_file ~expander alias_conf.deps
       |> fun (deps, _expander) ->
       let deps =
         Action_builder.map deps ~f:(fun l -> Path.Set.of_list (Bindings.to_list l))
@@ -224,7 +224,9 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
          (in #2681 and #2846), but it's actually used by [Test_rules] module.
          We could probably make this less confusing by using [rule] instead. *)
       let action =
-        let builder, expander = Dep_conf_eval.named ~expander alias_conf.deps in
+        let builder, expander =
+          Dep_conf_eval.named ~alias_expansion:Empty ~expander alias_conf.deps
+        in
         let open Action_builder.With_targets.O in
         let+ () = Action_builder.with_no_targets builder
         and+ action =

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
@@ -40,18 +40,24 @@ Nor does the path appear in the sandbox:
           bash alias b (exit 1)
   running b: cat: x: No such file or directory
 
-Bug (cont): surprisingly to me (aalekseyev), the same issue exists when
-the rule is a target-producing rule.
-(isn't this supposed to work because the alias stamp file changes?)
+In fact none of the alias stamp files even change
+when this dependency changes, so alias stamp files are useless here,
+even if we depended on them:
 
   $ echo old-contents > x
-  $ dune build b
-          bash b
-  running b: old-contents
-  $ cat _build/default/b
-  old-contents
-  $ dune build b
+  $ dune build @b &> /dev/null
+  $ md5sum _build/.aliases/default/* > stamp-files-old
+  $ rm -r _build 
+
   $ echo new-contents > x
-  $ dune build b
-  $ cat _build/default/b
-  old-contents
+  $ dune build @b &> /dev/null
+  $ md5sum _build/.aliases/default/* > stamp-files-new
+  $ rm -r _build
+
+  $ cat stamp-files-old
+  ba4d257a2d76880811986a1120e3d1ea  _build/.aliases/default/a-00000000000000000000000000000000
+  d41d8cd98f00b204e9800998ecf8427e  _build/.aliases/default/a-ff67d857b9b4f3d2e7bb31b302aa5bc4
+  9425f8e768d73fcee0cf05928f737277  _build/.aliases/default/b-00000000000000000000000000000000
+  d41d8cd98f00b204e9800998ecf8427e  _build/.aliases/default/b-de1ad9f2f2db598914453ffb73cfb3a2
+
+  $ diff stamp-files-old stamp-files-new

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
@@ -1,0 +1,57 @@
+
+  $ mkdir a
+  $ cd a
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.9)
+  > EOF
+
+  $ echo old-contents > x
+
+  $ cat >dune <<EOF
+  > (alias
+  >   (name a)
+  >   (deps x)
+  > )
+  > (rule
+  >   (alias b)
+  >   (deps (alias a))
+  >   (action (bash "echo -n \"running b: \"; cat x"))
+  > )
+  > (rule
+  >   (deps (alias a))
+  >   (action (progn (bash "echo -n \"running b: \"; cat x") (with-stdout-to b (bash "cat x"))))
+  > )
+  > EOF
+
+  $ dune build @b
+          bash alias b
+  running b: old-contents
+  $ dune build @b
+  $ echo new-contents > x
+  $ dune build @b
+
+^ Bug: dune does not re-run the action even though
+its declared dependencies changed.
+
+Nor does the path appear in the sandbox:
+
+  $ dune build @b --sandbox copy |& grep -v 'cd _build/.sandbox'
+          bash alias b (exit 1)
+  running b: cat: x: No such file or directory
+
+Bug (cont): surprisingly to me (aalekseyev), the same issue exists when
+the rule is a target-producing rule.
+(isn't this supposed to work because the alias stamp file changes?)
+
+  $ echo old-contents > x
+  $ dune build b
+          bash b
+  running b: old-contents
+  $ cat _build/default/b
+  old-contents
+  $ dune build b
+  $ echo new-contents > x
+  $ dune build b
+  $ cat _build/default/b
+  old-contents

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
@@ -76,5 +76,11 @@ Now test that including an alias into another alias includes its expansion:
 
   $ echo new-contents > x
   $ dune build @b
+          bash alias b
+  running b: new-contents
 
-^ BUG: we should re-run b here and have aliases "inherit" their expansion
+Still BUG: the path does not appear in the sandbox:
+
+  $ dune build @b --sandbox copy |& grep -v 'cd _build/.sandbox'
+          bash alias b (exit 1)
+  running b: cat: x: No such file or directory

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-package.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-package.t/run.t
@@ -1,0 +1,32 @@
+# Test dependency on a package in the tree
+
+  $ mkdir a b
+
+  $ cat >a/dune-project <<EOF
+  > (lang dune 2.9)
+  > (package (name a))
+  > EOF
+
+  $ cat >a/dune <<EOF
+  > (library (name a) (public_name a))
+  > EOF
+
+  $ cat > a/a.ml <<EOF
+  > let () = ()
+  > EOF
+
+  $ cat >b/dune-project <<EOF
+  > (lang dune 2.9)
+  > (package (name b))
+  > EOF
+
+  $ cat >b/dune <<'EOF'
+  > (rule (alias runtest) (deps (package a)) (action (bash "cat \"$(ocamlfind query a)\"/a.ml")))
+  > EOF
+
+  $ dune build @b/runtest
+
+  $ echo 'let () = Printf.printf "hello world"' >> a/a.ml
+
+  $ dune build @b/runtest
+

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-package.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-package.t/run.t
@@ -21,7 +21,11 @@
   > EOF
 
   $ cat >b/dune <<'EOF'
-  > (rule (alias runtest) (deps (package a)) (action (bash "cat \"$(ocamlfind query a)\"/a.ml")))
+  > (alias
+  > (name test-deps)
+  > (deps
+  >   (package a)))
+  > (rule (alias runtest) (deps (alias test-deps)) (action (bash "cat \"$(ocamlfind query a)\"/a.ml")))
   > EOF
 
   $ dune build @b/runtest


### PR DESCRIPTION
When a user declares a dependency on an alias, the intention is to depend on the alias *expansion*.

Expansion is the idea we discussed in #2681 and it was generally agreed that the files mentioned in the `deps` field of an alias should contribute to its expansion.

It turns out this is completely broken in Dune today: alias expansions only ever include the alias stamp files which is not what we want.
This PR fixes one source of the issue, while adding a test for the remaining issues.