### PR TITLE
Fix a cycle detection bug and update documentation

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1091,7 +1091,9 @@ let peek_exn (type i o f) (t : (i, o, f) t) inp =
         let res =
           add_dep_from_caller ~called_from_peek:true dep_node Finished
         in
-        assert (Result.is_ok res);
+        ( match res with
+        | Ok () -> ()
+        | Error cycle_error -> raise (Cycle_error.E cycle_error) );
         Value.get_sync_exn cv.value ) )
 
 let get_deps (type i o f) (t : (i, o, f) t) inp =

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -300,6 +300,17 @@ module M = struct
   end =
     Running_state
 
+  (* Why do we store a [run] in the [Considering] state?
+
+     Nodes can currently be invalidated and a build run restarted while some
+     computations are still under way (are in the [Considering] state). We could
+     enforce a separation between the computation and invalidation phases, which
+     could make the implementation simpler, but for now we allow the phases to
+     partially overlap. To distinguish "current" computations from "stale" ones,
+     each computation stores the [run] in which it was started. In this way,
+     before subscribing to an [Ivar.t] from the [completion], we can check if it
+     corresponds to the "current" run, and if not, the computation should be
+     restarted. *)
   and State : sig
     type ('a, 'b, 'f) t =
       (* [Considering] marks computations currently being considered (either

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -766,9 +766,14 @@ end = struct
             match dep_node.last_cached_value with
             | None -> Prev_cycle_cache_lookup_result.Invalid No_value
             | Some cv -> (
-              match Result.is_error cv.value with
-              | true -> Invalid No_value
-              | false -> (
+              match cv.value with
+              | Error _ ->
+                (* For errors, the dependencies are not always recorded
+                   correctly. In particular, dependency cycle errors have
+                   missing deps. Because of this, we can't use [deps_changed] in
+                   this case. *)
+                Invalid No_value
+              | Ok _ -> (
                 let res = deps_changed cv.deps in
                 match res with
                 | Unchanged ->
@@ -929,10 +934,14 @@ end = struct
             | None ->
               Fiber.return (Prev_cycle_cache_lookup_result.Invalid No_value)
             | Some cv -> (
-              match Result.is_error cv.value with
-              | true ->
+              match cv.value with
+              | Error _ ->
+                (* For errors, the dependencies are not always recorded
+                   correctly. In particular, dependency cycle errors have
+                   missing deps. Because of this, we can't use [deps_changed] in
+                   this case. *)
                 Fiber.return (Prev_cycle_cache_lookup_result.Invalid No_value)
-              | false -> (
+              | Ok _ -> (
                 let+ res = deps_changed cv.deps in
                 match res with
                 | Unchanged ->

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -856,39 +856,39 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluating count_runs: 2
     Started evaluating cycle_creator_no_cutoff
     Cycling to summit from cycle_creator_no_cutoff...
-    f 0 = Error
-            [ { exn =
-                  "(\"Attempted to create a cached value based on some stale inputs (old run)\",\n\
-                   {})"
-              ; backtrace = ""
-              }
-            ]
-    Memoized function stack:
-       ("cycle_creator_no_cutoff", ())
-    -> ("incrementing_chain_1_no_cutoff", ())
-    -> ("incrementing_chain_2_yes_cutoff", ())
-    -> ("incrementing_chain_3_no_cutoff", ())
-    -> ("incrementing_chain_4_yes_cutoff", ())
-    -> ("incrementing_chain_plus_input", 0) |}];
+    Starting evaluating incrementing_chain_1_no_cutoff
+    Starting evaluating incrementing_chain_2_yes_cutoff
+    Starting evaluating incrementing_chain_3_no_cutoff
+    Starting evaluating incrementing_chain_4_yes_cutoff
+    Started evaluating the summit with input 0
+    Dependency cycle detected:
+    - ("incrementing_chain_plus_input", 2)
+    - called by ("cycle_creator_no_cutoff", ())
+    - called by ("incrementing_chain_1_no_cutoff", ())
+    - called by ("incrementing_chain_2_yes_cutoff", ())
+    - called by ("incrementing_chain_3_no_cutoff", ())
+    - called by ("incrementing_chain_4_yes_cutoff", ())
+    - called by ("incrementing_chain_plus_input", 2)
+    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
   print_result summit_yes_cutoff 0;
   [%expect
     {|
     Started evaluating cycle_creator_yes_cutoff
     Cycling to summit from cycle_creator_yes_cutoff...
-    f 0 = Error
-            [ { exn =
-                  "(\"Attempted to create a cached value based on some stale inputs (old run)\",\n\
-                   {})"
-              ; backtrace = ""
-              }
-            ]
-    Memoized function stack:
-       ("cycle_creator_yes_cutoff", ())
-    -> ("incrementing_chain_1_yes_cutoff", ())
-    -> ("incrementing_chain_2_no_cutoff", ())
-    -> ("incrementing_chain_3_yes_cutoff", ())
-    -> ("incrementing_chain_4_no_cutoff", ())
-    -> ("incrementing_chain_plus_input", 0) |}]
+    Starting evaluating incrementing_chain_1_yes_cutoff
+    Starting evaluating incrementing_chain_2_no_cutoff
+    Starting evaluating incrementing_chain_3_yes_cutoff
+    Starting evaluating incrementing_chain_4_no_cutoff
+    Started evaluating the summit with input 0
+    Dependency cycle detected:
+    - ("incrementing_chain_plus_input", 2)
+    - called by ("cycle_creator_yes_cutoff", ())
+    - called by ("incrementing_chain_1_yes_cutoff", ())
+    - called by ("incrementing_chain_2_no_cutoff", ())
+    - called by ("incrementing_chain_3_yes_cutoff", ())
+    - called by ("incrementing_chain_4_no_cutoff", ())
+    - called by ("incrementing_chain_plus_input", 2)
+    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}]
 
 let print_exns f =
   let res =

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -728,8 +728,10 @@ let%expect_test "diamond with non-uniform cutoff structure" =
 
    - In the initial run, there are no dependency cycles.
 
-   - In all subsequent runs, [first_base_then_summit] gets an additional dynamic
-   dependency and eventually cycles back to itself.
+   - In the second run, [base_or_summit] gets an additional dynamic dependency
+   and eventually cycles back to itself.
+
+   - In all subsequent runs, we are back to having no dependency cycles.
 
    The dependency chains in the new test have alternating cutoff/no-cutoff
    structure, to make sure that cycle detection can handle such cases. *)
@@ -739,15 +741,15 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     printf "Started evaluating %s\n" which;
     let* base = Memo.exec base () in
     match base with
-    | 1 ->
-      printf "Evaluated %s: 1\n" which;
-      Build.return 1
-    | input ->
+    | input when input = 2 ->
       let summit = Fdecl.get summit_fdecl in
       printf "Cycling to summit from %s...\n" which;
       let+ result = Memo.exec summit input in
       printf "Miraculously evaluated %s: %d\n" which result;
       result
+    | input ->
+      printf "Evaluated %s: %d\n" which input;
+      Build.return input
   in
   let rec incrementing_chain ~end_with_cutoff ~from n =
     match n with
@@ -888,7 +890,77 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     - called by ("incrementing_chain_3_yes_cutoff", ())
     - called by ("incrementing_chain_4_no_cutoff", ())
     - called by ("incrementing_chain_plus_input", 2)
-    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}]
+    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
+  print_result summit_no_cutoff 2;
+  [%expect
+    {|
+    Dependency cycle detected:
+    - ("incrementing_chain_plus_input", 2)
+    - called by ("cycle_creator_no_cutoff", ())
+    - called by ("incrementing_chain_1_no_cutoff", ())
+    - called by ("incrementing_chain_2_yes_cutoff", ())
+    - called by ("incrementing_chain_3_no_cutoff", ())
+    - called by ("incrementing_chain_4_yes_cutoff", ())
+    - called by ("incrementing_chain_plus_input", 2)
+    f 2 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
+  print_result summit_yes_cutoff 2;
+  [%expect
+    {|
+    Dependency cycle detected:
+    - ("incrementing_chain_plus_input", 2)
+    - called by ("cycle_creator_yes_cutoff", ())
+    - called by ("incrementing_chain_1_yes_cutoff", ())
+    - called by ("incrementing_chain_2_no_cutoff", ())
+    - called by ("incrementing_chain_3_yes_cutoff", ())
+    - called by ("incrementing_chain_4_no_cutoff", ())
+    - called by ("incrementing_chain_plus_input", 2)
+    f 2 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
+  Memo.restart_current_run ();
+  print_result summit_no_cutoff 0;
+  [%expect
+    {|
+    Started evaluating the summit with input 0
+    Starting evaluating incrementing_chain_4_yes_cutoff
+    Starting evaluating incrementing_chain_3_no_cutoff
+    Starting evaluating incrementing_chain_2_yes_cutoff
+    Starting evaluating incrementing_chain_1_no_cutoff
+    Started evaluating cycle_creator_no_cutoff
+    Evaluating count_runs: 3
+    Evaluated cycle_creator_no_cutoff: 3
+    Evaluated incrementing_chain_1_no_cutoff: 4
+    Evaluated incrementing_chain_2_yes_cutoff: 5
+    Evaluated incrementing_chain_3_no_cutoff: 6
+    Evaluated incrementing_chain_4_yes_cutoff: 7
+    Evaluated the summit with input 0: 7
+    f 0 = Ok 7 |}];
+  print_result summit_yes_cutoff 0;
+  [%expect
+    {|
+    Started evaluating the summit with input 0
+    Starting evaluating incrementing_chain_4_no_cutoff
+    Starting evaluating incrementing_chain_3_yes_cutoff
+    Starting evaluating incrementing_chain_2_no_cutoff
+    Starting evaluating incrementing_chain_1_yes_cutoff
+    Started evaluating cycle_creator_yes_cutoff
+    Evaluated cycle_creator_yes_cutoff: 3
+    Evaluated incrementing_chain_1_yes_cutoff: 4
+    Evaluated incrementing_chain_2_no_cutoff: 5
+    Evaluated incrementing_chain_3_yes_cutoff: 6
+    Evaluated incrementing_chain_4_no_cutoff: 7
+    Evaluated the summit with input 0: 7
+    f 0 = Ok 7 |}];
+  print_result summit_no_cutoff 2;
+  [%expect
+    {|
+    Started evaluating the summit with input 2
+    Evaluated the summit with input 2: 9
+    f 2 = Ok 9 |}];
+  print_result summit_yes_cutoff 2;
+  [%expect
+    {|
+    Started evaluating the summit with input 2
+    Evaluated the summit with input 2: 9
+    f 2 = Ok 9 |}]
 
 let print_exns f =
   let res =


### PR DESCRIPTION
This fixes the bug revealed in #4240.

Here is how the bug is happening.

Consider the following chain of dependencies: `A -> B -> C ..... -> Y -> Z -> C`.

* When we enter the node `C` for the second time via the edge `Z -> C`, we create a cycle, which causes `add_dep_from_caller` to raise the `Cycle_error` exception, which propagates to the caller.

* At this point, the caller `Z` was in the `dep_changed` function. The exception is uncaught and is propagated to the `do_validate` function, where it's also uncaught, which in particular means that the corresponding `ivar` will never be filled. Note that `do_validate` is called after registering the edge `Y -> Z`, so `Y`'s dependencies are updated correctly.

* The uncaught exception propagates further to the caller of `Z`, which is `Y`. Here the situation is different: `Y` catches the exception and so the resulting value is `Error`. We proceed with capturing the values of all the dependencies of the node `Y`, and at this point we hit the assertion: one of `Y`'s dependencies, namely `Z`, is stale, because it's evaluation never finished. Hence the assertion.

In this fix, we stop using the `Cycle_error` exceptions internally. We treat `Cycle_error` as a new possible outcome of the internal `exec_dep_node_internal` function and make sure that all dependent computations record the cycle error. In the user-facing function `exec_dep_node` we raise the `Cycle_error` exception as before.

Note that the edge `Z -> C` that would have actually created a cycle is not added to the graph and `C` is not registered as a dependency of `Z`. As a result, the list of `Z`'s dependencies is going to be incomplete, which is why the "attempting to capture a stale value" assertion is no longer triggered.