### PR TITLE
Get rid of implicit polymorphic equality in List.mem

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -317,7 +317,7 @@ module Component = struct
       |> Cst.concrete (* Package as a list CSTs *) |> List.singleton
 
     let add_to_list_set elem set =
-      if List.mem elem ~set then
+      if List.mem ~equal:Dune_lang.Atom.equal set elem then
         set
       else
         elem :: set

--- a/src/dune_engine/mode.ml
+++ b/src/dune_engine/mode.ml
@@ -4,6 +4,8 @@ type t =
   | Byte
   | Native
 
+let equal (x : t) (y : t) = Poly.equal x y
+
 let compare = Poly.compare
 
 let all = [ Byte; Native ]
@@ -43,6 +45,8 @@ let of_cm_kind : Cm_kind.t -> t = function
   | Cmx -> Native
 
 module Dict = struct
+  let mode_equal = equal
+
   type 'a t =
     { byte : 'a
     ; native : 'a
@@ -102,7 +106,9 @@ module Dict = struct
       l
 
     let of_list l =
-      { byte = List.mem Byte ~set:l; native = List.mem Native ~set:l }
+      { byte = List.mem l Byte ~equal:mode_equal
+      ; native = List.mem l Native ~equal:mode_equal
+      }
 
     let encode t = List.map ~f:encode (to_list t)
 

--- a/src/dune_engine/mode.mli
+++ b/src/dune_engine/mode.mli
@@ -4,6 +4,8 @@ type t =
   | Byte
   | Native
 
+val equal : t -> t -> bool
+
 val compare : t -> t -> Ordering.t
 
 val decode : t Dune_lang.Decoder.t

--- a/src/dune_rules/check_rules.ml
+++ b/src/dune_rules/check_rules.ml
@@ -10,7 +10,7 @@ let dev_files =
   in
   Predicate.create ~id ~f:(fun p ->
       let ext = Filename.extension p in
-      List.mem ext ~set:exts)
+      List.mem exts ext ~equal:String.equal)
 
 let add_obj_dir sctx ~obj_dir =
   if (Super_context.context sctx).merlin then

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -52,7 +52,8 @@ module Program = struct
       let fn = Path.relative dir (program ^ Bin.exe) in
       Option.some_if (Bin.exists fn) fn
     in
-    if List.mem program ~set:programs_for_which_we_prefer_opt_ext then
+    if List.mem programs_for_which_we_prefer_opt_ext program ~equal:String.equal
+    then
       match exe_path (program ^ ".opt") with
       | None -> exe_path program
       | Some _ as path -> path
@@ -702,7 +703,11 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     );
     Memo.Build.return t
   in
-  let implicit = not (List.mem ~set:targets Workspace.Context.Target.Native) in
+  let implicit =
+    not
+      (List.mem targets ~equal:Workspace.Context.Target.equal
+         Workspace.Context.Target.Native)
+  in
   let* native =
     create_one ~host:host_context ~findlib_toolchain:host_toolchain ~implicit
       ~name ~merlin

--- a/src/dune_rules/cram_exec.ml
+++ b/src/dune_rules/cram_exec.ml
@@ -171,7 +171,7 @@ let cat_eof ~dest oc lines =
       else
         sprintf "EOF%d" n
     in
-    if List.mem sentinel ~set:lines then
+    if List.mem lines sentinel ~equal:String.equal then
       loop (n + 1)
     else
       sentinel

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -19,6 +19,13 @@ module Linkage = struct
     ; flags : string list
     }
 
+  (* CR-someday aalekseyev: I find the uses of [equal] suspicious: they are used
+     to "inexhaustively match" on linkage modes, which is very brittle. *)
+  let equal x y =
+    Link_mode.equal x.mode y.mode
+    && String.equal x.ext y.ext
+    && List.equal String.equal x.flags y.flags
+
   let byte = { mode = Byte; ext = ".bc"; flags = [] }
 
   let native = { mode = Native; ext = ".exe"; flags = [] }
@@ -37,7 +44,8 @@ module Linkage = struct
 
   let js = { mode = Byte; ext = ".bc.js"; flags = [] }
 
-  let is_plugin t = List.mem t.ext ~set:(List.map ~f:Mode.plugin_ext Mode.all)
+  let is_plugin t =
+    List.mem (List.map ~f:Mode.plugin_ext Mode.all) t.ext ~equal:String.equal
 
   let c_flags = [ "-output-obj" ]
 

--- a/src/dune_rules/exe.mli
+++ b/src/dune_rules/exe.mli
@@ -14,6 +14,8 @@ end
 module Linkage : sig
   type t
 
+  val equal : t -> t -> bool
+
   (** Byte compilation, exetension [.bc] *)
   val byte : t
 

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -71,7 +71,7 @@ let o_files sctx ~dir ~expander ~(exes : Executables.t) ~linkages ~dir_contents
       else
         "stubs"
     in
-    if List.mem Exe.Linkage.byte ~set:linkages then
+    if List.mem linkages Exe.Linkage.byte ~equal:Exe.Linkage.equal then
       User_error.raise ~loc:exes.buildable.loc
         [ Pp.textf "Pure bytecode executables cannot contain foreign %s." what ]
         ~hints:
@@ -133,7 +133,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
         let add_empty_intf =
           let project = Scope.project scope in
           Dune_project.executables_implicit_empty_intf project
-          && List.mem name ~set:executable_names
+          && List.mem executable_names name ~equal:Module_name.equal
           && not (Module.has m ~ml_kind:Intf)
         in
         if add_empty_intf then
@@ -151,7 +151,9 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
     let js_of_ocaml =
       let js_of_ocaml = exes.buildable.js_of_ocaml in
       if explicit_js_mode then
-        Option.some_if (List.mem ~set:linkages Exe.Linkage.js) js_of_ocaml
+        Option.some_if
+          (List.mem linkages Exe.Linkage.js ~equal:Exe.Linkage.equal)
+          js_of_ocaml
       else
         Some js_of_ocaml
     in

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -143,7 +143,7 @@ let archives ?(kind = [ Mode.Byte; Mode.Native ]) name =
     ; (Mode.Byte, plugin, Mode.compiled_lib_ext)
     ; (Mode.Native, plugin, Mode.plugin_ext)
     ] ~f:(fun (k, f, ext) ->
-      if List.mem k ~set:kind then
+      if List.mem kind k ~equal:Mode.equal then
         Some (f (Mode.to_string k) (name ^ ext k))
       else
         None)

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -971,7 +971,7 @@ end
 
 let instrumentation_backend ?(do_not_fail = false) instrument_with resolve
     libname =
-  if not (List.mem ~set:instrument_with (snd libname)) then
+  if not (List.mem ~equal:Lib_name.equal instrument_with (snd libname)) then
     None
   else
     match

--- a/src/dune_rules/link_mode.ml
+++ b/src/dune_rules/link_mode.ml
@@ -10,3 +10,15 @@ let mode : t -> Mode.t = function
   | Byte -> Byte
   | Native -> Native
   | Byte_with_stubs_statically_linked_in -> Byte
+
+let equal x y =
+  match (x, y) with
+  | Byte, Byte -> true
+  | Byte, _ -> false
+  | _, Byte -> false
+  | Native, Native -> true
+  | Native, _ -> false
+  | _, Native -> false
+  | Byte_with_stubs_statically_linked_in, Byte_with_stubs_statically_linked_in
+    ->
+    true

--- a/src/dune_rules/link_mode.mli
+++ b/src/dune_rules/link_mode.mli
@@ -7,3 +7,5 @@ type t =
   | Byte_with_stubs_statically_linked_in
 
 val mode : t -> Mode.t
+
+val equal : t -> t -> bool

--- a/src/dune_rules/menhir.ml
+++ b/src/dune_rules/menhir.ml
@@ -153,14 +153,14 @@ module Run (P : PARAMS) : sig end = struct
             | None -> ()
             | Some text ->
               if
-                List.mem text
-                  ~set:
-                    [ "--depend"
-                    ; "--raw-depend"
-                    ; "--infer"
-                    ; "--infer-write-query"
-                    ; "--infer-read-reply"
-                    ]
+                List.mem ~equal:String.equal
+                  [ "--depend"
+                  ; "--raw-depend"
+                  ; "--infer"
+                  ; "--infer-write-query"
+                  ; "--infer-read-reply"
+                  ]
+                  text
               then
                 User_error.raise ~loc:(String_with_vars.loc sw)
                   [ Pp.textf "The flag %s must not be used in a menhir stanza."

--- a/src/dune_rules/module_name.ml
+++ b/src/dune_rules/module_name.ml
@@ -15,6 +15,8 @@ include Section.Modulelike (struct
   let make s = String.capitalize s
 end)
 
+let equal = String.equal
+
 let compare = String.compare
 
 let add_suffix = ( ^ )

--- a/src/dune_rules/module_name.mli
+++ b/src/dune_rules/module_name.mli
@@ -10,6 +10,8 @@ include Stringlike_intf.S with type t := t
 
 val add_suffix : t -> string -> t
 
+val equal : t -> t -> bool
+
 val compare : t -> t -> Ordering.t
 
 val uncapitalize : t -> string

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -19,8 +19,10 @@ module Context = struct
     let equal x y =
       match (x, y) with
       | Native, Native -> true
+      | Native, _
+      | _, Native ->
+        false
       | Named x, Named y -> Context_name.equal x y
-      | _, _ -> false
 
     let t =
       let+ context_name = Context_name.decode in
@@ -32,7 +34,7 @@ module Context = struct
       match x with
       | None -> ts
       | Some t ->
-        if List.mem t ~set:ts then
+        if List.mem ts t ~equal then
           ts
         else
           ts @ [ t ]

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -9,6 +9,8 @@ module Context : sig
     type t =
       | Native
       | Named of Context_name.t
+
+    val equal : t -> t -> bool
   end
 
   module Common : sig

--- a/src/stdune/list.ml
+++ b/src/stdune/list.ml
@@ -219,3 +219,5 @@ let reduce xs ~f =
 let min xs ~f = reduce xs ~f:(Ordering.min f)
 
 let max xs ~f = reduce xs ~f:(Ordering.max f)
+
+let mem t a ~equal = exists t ~f:(equal a)

--- a/src/stdune/list.mli
+++ b/src/stdune/list.mli
@@ -88,3 +88,5 @@ val reduce : 'a list -> f:('a -> 'a -> 'a) -> 'a option
 val min : 'a list -> f:('a -> 'a -> Ordering.t) -> 'a option
 
 val max : 'a list -> f:('a -> 'a -> Ordering.t) -> 'a option
+
+val mem : 'a list -> 'a -> equal:('a -> 'a -> bool) -> bool


### PR DESCRIPTION
Get rid of implicit polymorphic equality in List.mem and align the type with Base.

In Ocaml stdlib and in dune before this PR, the type is
```
val mem : 'a -> set:'a list -> bool 
```

In base and in dune after this PR, the type is:

```
val mem : 'a list -> 'a -> equal:('a -> 'a -> bool) -> bool
```

One could imagine a middle-ground where the `set` argument is still named, but I didn't want to introduce a third version.