### PR TITLE
Run exit hooks before Unix.exec'ing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,9 @@ Unreleased
 - Workaround incorrect exception raised by Unix.utimes (OCaml PR#8857) in
   Path.touch on Windows (#4223, @dra27)
 
+- Cleanup temporary files after running `$ dune exec`. (#4260, fixes #4243,
+  @rgrinberg)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/src/stdune/proc.ml
+++ b/src/stdune/proc.ml
@@ -13,5 +13,6 @@ let restore_cwd_and_execve prog argv ~env =
     | WSTOPPED _ -> assert false
   else (
     ignore (Unix.sigprocmask SIG_SETMASK [] : int list);
+    Stdlib.do_at_exit ();
     Unix.execve prog argv env
   )


### PR DESCRIPTION
Fixes #4243

I went for the private API. Worst case we'll need to change dune for a new
version of OCaml. We already do this almost every version anyways.