### PR TITLE
[merlin] Handle filenames with dot-separated sections

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -280,8 +280,8 @@ There's a few aliases that dune automatically creates for the user
   defined in that directory.
 
 * ``check`` - This alias will build the minimal set of targets required for
-  tooling support. Essentially, this is ``.cmi``, ``.cmt``, ``.cmti``, and
-  ``.merlin`` files.
+  tooling support. Essentially, this is ``.cmi``, ``.cmt``, ``.cmti`` files and
+  Merlin configurations.
 
 Variables for artifacts
 -----------------------
@@ -587,6 +587,16 @@ be un-commented afterward. This feature does not aim at writing exact or correct
 ``.merlin`` files, its sole purpose is to lessen the burden of writing the
 configuration from scratch.
 
-Both these commands also support an optional path to specify the target
-directory. This directory must be in a Dune workspace and the project must have
-already been built.
+Non-standard filenames
+----------------------
+
+Merlin configuration loading is based on filename. That means that if you have
+files which are preprocessed by custom rules before they are built, they should
+respect the following naming convention: the unprocessed file should start with
+the name of the resulting processed file followed by a dot and then the rest
+does not matter. Only the name before the first dot will be used by Dune to
+match with available configurations.
+
+For example, if you use the ``cppo`` preprocessor to generate the file
+``real_module_name.ml`` then the source file could be named
+``real_module_name.cppo.ml``.

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -126,7 +126,10 @@ module Processed = struct
     (* We only match the first part of the filename : foo.ml -> foo foo.cppo.ml
        -> foo *)
     let fname =
-      String.split_on_char ~sep:'.' filename |> List.hd |> String.lowercase
+      String.lsplit2 filename ~on:'.'
+      |> Option.map ~f:fst
+      |> Option.value ~default:filename
+      |> String.lowercase
     in
     List.find_opt modules ~f:(fun name ->
         let fname' = Module_name.to_string name |> String.lowercase in

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -123,7 +123,11 @@ module Processed = struct
     Buffer.contents b
 
   let get { modules; pp_config; config } ~filename =
-    let fname = Filename.remove_extension filename |> String.lowercase in
+    (* We only match the first part of the filename : foo.ml -> foo foo.cppo.ml
+       -> foo *)
+    let fname =
+      String.split_on_char ~sep:'.' filename |> List.hd |> String.lowercase
+    in
     List.find_opt modules ~f:(fun name ->
         let fname' = Module_name.to_string name |> String.lowercase in
         String.equal fname fname')

--- a/test/blackbox-tests/test-cases/merlin/server.t/dune
+++ b/test/blackbox-tests/test-cases/merlin/server.t/dune
@@ -11,3 +11,8 @@
  (name main)
  (modules main lib2)
  (libraries mylib mylib3))
+
+(executable
+ (name not-a-module-name)
+ (modules not-a-module-name)
+ (flags :standard -w -24))

--- a/test/blackbox-tests/test-cases/merlin/server.t/not-a-module-name.ml
+++ b/test/blackbox-tests/test-cases/merlin/server.t/not-a-module-name.ml
@@ -1,0 +1,1 @@
+print_endline "I do not bear a valid module name."

--- a/test/blackbox-tests/test-cases/merlin/server.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/server.t/run.t
@@ -34,3 +34,10 @@ This can be useful when some build scripts copy files from subdirectories.
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
+
+Test of an valid invalid module name
+  $ FILE=not-a-module-name.ml
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > (4:File${#FILE}:$FILE)
+  > EOF
+  ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-w?:-24)))

--- a/test/blackbox-tests/test-cases/merlin/server.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/server.t/run.t
@@ -16,3 +16,21 @@
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
+
+If a file has a name of the kind `module_name.xx.xxx.ml/i`
+we consider it as ``module_name.ml/i`
+This can be useful when some build scripts perform custom
+preprocessing and copy files around.
+  $ FILE=lib3.foobar.ml
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > (4:File${#FILE}:$FILE)
+  > EOF
+  ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
+
+If a directory has no configuration the configuration of its parent is used
+This can be useful when some build scripts copy files from subdirectories.
+  $ FILE=some_sub_dir/lib3.foobar.ml
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > (4:File${#FILE}:$FILE)
+  > EOF
+  ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))


### PR DESCRIPTION
This is part of #4217
Fixes ocaml/merlin#1262

It implements the [proposed solution n°  2](https://github.com/ocaml/dune/issues/4217#issuecomment-781468553) to handle more gracefully source files with uncommon names.

For example it is somehow regular to have a file `my_module.ccpo.ml` that will be be preprocessed by a rule with target `my_module.ml`.

However the user-edited file is `my_module.ccpo.ml` and we want Merlin to work as expected even if the configuration has been generated by Dune for `my_module.ml`. 

This PR implement the simplest solution to that issue: by convention, the first component of a filename whose parts are separated by dots is used to match with the generated configurations. 