### PR TITLE
Improve the CLI help for the init subcommand

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -181,6 +181,15 @@ let examples = function
     let example_blocks = examples |> List.mapi ~f:block_of_example in
     `Blocks (`S Cmdliner.Manpage.s_examples :: example_blocks)
 
+(* Short reminders for the most used and useful commands *)
+let command_synopsis commands =
+  let format_command c acc =
+    `Noblank :: `P (Printf.sprintf "$(b,dune %s)" c) :: acc
+  in
+  [ `S "SYNOPSIS"
+  ; `Blocks (List.fold_right ~init:[] ~f:format_command commands)
+  ]
+
 let help_secs =
   [ `S copts_sect
   ; `P "These options are common to all commands."

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -56,7 +56,15 @@ val set_common_other :
     the root the current working directory *)
 val set_dirs : t -> unit
 
+(** [examples \[("description", "dune cmd foo"); ...\]] is an [EXAMPLES] manpage
+    section of enumerated examples illustrating how to run the documented
+    commands. *)
 val examples : (string * string) list -> Cmdliner.Manpage.block
+
+(** [command_syposis subcommands] is a custom [SYNOPSIS] manpage section listing
+    the given [subcommands]. Each subcommand is prefixed with the `dune`
+    top-level command. *)
+val command_synopsis : string list -> Cmdliner.Manpage.block list
 
 val help_secs : Cmdliner.Manpage.block list
 

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -77,36 +77,65 @@ let print_completion kind name =
 
 let doc = "Initialize dune components"
 
+let synopsis =
+  Common.command_synopsis
+    [ "init proj NAME [PATH] [OPTION]... "
+    ; "init exec NAME [PATH] [OPTION]... "
+    ; "init lib NAME [PATH] [OPTION]... "
+    ; "init test NAME [PATH] [OPTION]... "
+    ]
+
 let man =
-  [ `S "DESCRIPTION"
+  [ `Blocks synopsis
+  ; `S "DESCRIPTION"
   ; `P
-      {|$(b,dune init {library,executable,test,project} NAME [PATH]) initialize
-         a new dune component of the specified kind, named $(b,NAME), with
-         fields determined by the supplied options.|}
-  ; `P
-      {|Any prefix of the component kinds can be supplied, e.g., $(b,dune init
-         proj myproject).|}
+      {|$(b,dune init COMPONENT NAME [PATH] [OPTION]...) initializes a new dune
+        configuration for a component of the kind specified by $(b,COMPONENT),
+        named $(b,NAME), with fields determined by the supplied $(b,OPTION)s.|}
   ; `P
       {|If the optional $(b,PATH) is provided, the component will be created
-         there. Otherwise, it is created in the current working directory.|}
+        there. Otherwise, it is created in the current working directory.|}
   ; `P
-      {|The command can be used to add stanzas to existing dune files as
-         well as for creating new dune files and basic component templates.|}
+      {|The command can be used to add stanzas to existing dune files and for
+        creating new dune files and composing basic component templates.|}
+  ; `P {|Supported $(b,COMPONENT)s:|}
+  ; `I
+      ( "$(b,project)"
+      , {|A project is a predefined composition of components arranged in a
+          standard directory structure. The kind of project initialized is
+          determined by the value of the $(b,--kind) flag and defaults to an
+          executable project, composed of a library, an executable, and a test
+          component.|}
+      )
+  ; `I ("$(b,executable)", {|A binary executable.|})
+  ; `I ("$(b,library)", {|An OCaml library.|})
+  ; `I
+      ( "$(b,test)"
+      , {|A separate test harness. (For inline tests, use the
+        $(b,--inline-tests) flag along with the other component kinds.)|}
+      )
+  ; `P
+      {|Any prefix of the $(b,COMPONENT) kind names can be supplied in place of
+        full name (as illustrated in the synopsis).|}
+  ; `P
+      {|For more details, see https://dune.readthedocs.io/en/stable/usage.html#initializing-components|}
   ; Common.examples
-      [ ( {|Define an executable component named `myexe' in a dune file in the
-            current directory
-           |}
+      [ ( {|Generate a project skeleton for an executable named `myproj' in a
+            new directory named `myproj', depending on the bos library and
+            using inline tests along with ppx_inline_test |}
+        , {|dune init proj myproj --libs bos --ppx ppx_inline_test --inline-tests|}
+        )
+      ; ( {|Configure an executable component named `myexe' in a dune file in the
+            current directory|}
         , {|dune init exe myexe|} )
-      ; ( {|Define a library component named `mylib' in a dune file in the ./src
+      ; ( {|Configure a library component named `mylib' in a dune file in the ./src
             directory depending on the core and cmdliner libraries, the ppx_let
             and ppx_inline_test preprocessors, and declared as using inline
-            tests"
-           |}
-        , {|dune init lib mylib src --libs core,cmdliner --ppx ppx_let,ppx_inline_test --inline-tests"|}
+            tests|}
+        , {|dune init lib mylib src --libs core,cmdliner --ppx ppx_let,ppx_inline_test --inline-tests|}
         )
-      ; ( {|Define a library component named `mytest' in a dune file in the
-            ./test directory that depends on `mylib'"
-           |}
+      ; ( {|Configure a library component named `mytest' in a dune file in the
+            ./test directory that depends on `mylib'|}
         , {|dune init test myexe test --libs mylib|} )
       ]
   ]
@@ -118,7 +147,7 @@ let term =
   and+ kind =
     (* TODO(shonfeder): Replace with nested subcommand once we have support for
        that *)
-    let docv = "INIT_KIND" in
+    let docv = "COMPONENT" in
     Arg.(required & pos 0 (some (enum Kind.commands)) None & info [] ~docv)
   and+ name =
     let docv = "NAME" in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -32,9 +32,9 @@ let all : _ Term.Group.t list =
   let groups = [ Ocaml.group; Rpc.group ] in
   terms @ groups
 
+(* Short reminders for the most used and useful commands *)
 let common_commands_synopsis =
-  (* Short reminders for the most used and useful commands *)
-  let commands =
+  Common.command_synopsis
     [ "build [--watch]"
     ; "runtest [--watch]"
     ; "exec NAME"
@@ -42,13 +42,6 @@ let common_commands_synopsis =
     ; "install"
     ; "init project NAME [PATH] [--libs=l1,l2 --ppx=p1,p2 --inline-tests]"
     ]
-  in
-  let format_command c acc =
-    `Noblank :: `P (Printf.sprintf "$(b,dune %s)" c) :: acc
-  in
-  [ `S "SYNOPSIS"
-  ; `Blocks (List.fold_right ~init:[] ~f:format_command commands)
-  ]
 
 let default =
   let doc = "composable build system for OCaml" in

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -232,7 +232,7 @@ Will not create components with invalid names
              Library names must be non-empty and composed only of the
              following
              characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
-  Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
+  Usage: dune init [OPTION]... COMPONENT NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]
   $ test -f ./_test_lib
@@ -241,9 +241,9 @@ Will not create components with invalid names
 Will fail and inform user when invalid component command is given
 
   $ dune init foo blah
-  dune init: INIT_KIND argument: invalid value `foo', expected one of
+  dune init: COMPONENT argument: invalid value `foo', expected one of
              `executable', `library', `project' or `test'
-  Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
+  Usage: dune init [OPTION]... COMPONENT NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]
 

--- a/test/blackbox-tests/test-cases/github3046.t/run.t
+++ b/test/blackbox-tests/test-cases/github3046.t/run.t
@@ -9,7 +9,7 @@ are given as parameters
   $ dune init exe main --libs="str gsl"
   dune init: option `--libs': invalid element in list (`str gsl'): expected a
              valid dune atom
-  Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
+  Usage: dune init [OPTION]... COMPONENT NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]
 
@@ -18,7 +18,7 @@ are given as parameters
   $ dune init lib foo --ppx="foo bar"
   dune init: option `--ppx': invalid element in list (`foo bar'): expected a
              valid dune atom
-  Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
+  Usage: dune init [OPTION]... COMPONENT NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]
 
@@ -30,6 +30,6 @@ are given as parameters
              Library names must be non-empty and composed only of the
              following
              characters: 'A'..'Z', 'a'..'z', '_' or '0'..'9'.
-  Usage: dune init [OPTION]... INIT_KIND NAME [PATH]
+  Usage: dune init [OPTION]... COMPONENT NAME [PATH]
   Try `dune init --help' or `dune --help' for more information.
   [1]


### PR DESCRIPTION
Closes #3602

Provides more detailed and better structured information in the manpage for `dune init`.
