### PR TITLE
[rpc] Use dune's latest version in versioning rpc

### DIFF
--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -32,7 +32,7 @@ end
 module Version = struct
   type t = int * int
 
-  let latest = (1, 0)
+  let latest = (3, 0)
 
   let sexp : t Conv.value =
     let open Conv in

--- a/src/dune_engine/stanza.ml
+++ b/src/dune_engine/stanza.ml
@@ -7,7 +7,10 @@ module Parser = struct
 end
 
 (* The actual latest version is defined in the rpc library. This is because rpc
-   client needs to know the version of dune to use to connect. *)
+   client needs to know the version of dune to use to connect.
+
+   To upgrade the latest version of the dune language, you need to edit the file
+   in the rpc library. *)
 let latest_version = Dune_rpc_private.Version.latest
 
 let since v = (v, `Since v)

--- a/src/dune_engine/stanza.ml
+++ b/src/dune_engine/stanza.ml
@@ -6,7 +6,9 @@ module Parser = struct
   type nonrec t = string * t list Dune_lang.Decoder.t
 end
 
-let latest_version = (3, 0)
+(* The actual latest version is defined in the rpc library. This is because rpc
+   client needs to know the version of dune to use to connect. *)
+let latest_version = Dune_rpc_private.Version.latest
 
 let since v = (v, `Since v)
 


### PR DESCRIPTION
@jeremiedimino I tried moving this to a shared file and using a copy rule like
we discussed, but then we need to complicate bootstrap. It doesn't seem worth it
to go through all that when we can just write it in the rpc.