### PR TITLE
[dunerpc] Cleanup requests table

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -290,7 +290,9 @@ struct
       | Packet.Notification n -> t.on_notification n
       | Response (id, response) -> (
         match Table.find t.requests id with
-        | Some ivar -> Fiber.Ivar.fill ivar response
+        | Some ivar ->
+          Table.remove t.requests id;
+          Fiber.Ivar.fill ivar response
         | None ->
           Code_error.raise "unexpected response"
             [ ("id", Id.to_dyn id); ("response", Response.to_dyn response) ] ))


### PR DESCRIPTION
After we fill a request, we can remove it from the table of pending
requests.