### PR TITLE
Add a test demonstrating that cycles can be created

### DIFF
--- a/test/expect-tests/dag/dag_tests.ml
+++ b/test/expect-tests/dag/dag_tests.ml
@@ -170,3 +170,128 @@ let%expect_test _ =
 23 22 21 20 14 13 12 11
 23
 |}]
+
+let%expect_test "creating cycle can succeed on a second attempt" =
+  let dag = Dag.create () in
+  let c1 = Dag.node dag { name = "c1" } in
+  let c2 = Dag.node dag { name = "c2" } in
+  let c3 = Dag.node dag { name = "c3" } in
+  let c4 = Dag.node dag { name = "c4" } in
+  Dag.add_assuming_missing dag c1 c2;
+  Dag.add_assuming_missing dag c2 c3;
+  Dag.add_assuming_missing dag c3 c4;
+  Format.printf "c1 = %a@.\n" dag_pp_mynode c1;
+  Format.printf "c2 = %a@.\n" dag_pp_mynode c2;
+  Format.printf "c3 = %a@.\n" dag_pp_mynode c3;
+  Format.printf "c4 = %a@.\n" dag_pp_mynode c4;
+  [%expect
+    {|
+    c1 = (1: k=1) (c1) [(2: k=1) (c2) [(3: k=1) (c3) [(4: k=2) (c4) []]]]
+
+    c2 = (2: k=1) (c2) [(3: k=1) (c3) [(4: k=2) (c4) []]]
+
+    c3 = (3: k=1) (c3) [(4: k=2) (c4) []]
+
+    c4 = (4: k=2) (c4) []
+  |}];
+  ( match Dag.add_assuming_missing dag c4 c2 with
+  | () -> Format.printf "added :o\n"
+  | exception Cycle _ -> Format.printf "cycle\n" );
+  Format.printf "c1 = %a@.\n" dag_pp_mynode c1;
+  Format.printf "c2 = %a@.\n" dag_pp_mynode c2;
+  Format.printf "c3 = %a@.\n" dag_pp_mynode c3;
+  Format.printf "c4 = %a@.\n" dag_pp_mynode c4;
+  [%expect
+    {|
+    cycle
+    c1 = (1: k=1) (c1) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) []]]]
+
+    c2 = (2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) []]]
+
+    c3 = (3: k=2) (c3) [(4: k=2) (c4) []]
+
+    c4 = (4: k=2) (c4) []
+  |}];
+  ( match Dag.add_assuming_missing dag c4 c2 with
+  | () -> Format.printf "added :o\n"
+  | exception Cycle _ -> Format.printf "cycle\n" );
+  Format.printf "c1 = %a@.\n" dag_pp_mynode c1;
+  Format.printf "c2 = %a@.\n" dag_pp_mynode c2;
+  Format.printf "c3 = %a@.\n" dag_pp_mynode c3;
+  Format.printf "c4 = %a@.\n" dag_pp_mynode c4;
+  [%expect
+    {|
+    added :o
+    c1 = (1: k=1) (c1) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [
+                                                               (2: k=2) (c2) [
+                                                               (3: k=2) (c3) [
+                                                               (4: k=2) (c4) [
+                                                               (2: k=2) (c2) [
+                                                               (3: k=2) (c3) [
+                                                               (4: k=2) (c4) [
+                                                               (2: k=2) (c2) [
+                                                               (3: k=2) (c3) [
+                                                               (4: k=2) (c4) [
+                                                               (2: k=2) (c2) [
+                                                               (3: k=2) (c3) [
+                                                               (4: k=2) (c4) [
+                                                               (2: k=2) (c2) [
+                                                               (3: k=2) (c3) [
+                                                               (4: k=2) (c4) [
+                                                               (2: k=2) (c2) [
+                                                               ...]]]]]]]]]]]]]]]]]]]]
+
+    c2 = (2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [(2: k=2) (c2) [(3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      ...]]]]]]]]]]]]]]]]]]]]
+
+    c3 = (3: k=2) (c3) [(4: k=2) (c4) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      ...]]]]]]]]]]]]]]]]]]]]
+
+    c4 = (4: k=2) (c4) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [(2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      (3: k=2) (c3) [
+                                                                      (4: k=2) (c4) [
+                                                                      (2: k=2) (c2) [
+                                                                      ...]]]]]]]]]]]]]]]]]]]]
+  |}]

--- a/test/expect-tests/dag/dag_tests.ml
+++ b/test/expect-tests/dag/dag_tests.ml
@@ -171,7 +171,7 @@ let%expect_test _ =
 23
 |}]
 
-let%expect_test "creating cycle can succeed on a second attempt" =
+let%expect_test "creating a cycle can succeed on the second attempt" =
   let dag = Dag.create () in
   let c1 = Dag.node dag { name = "c1" } in
   let c2 = Dag.node dag { name = "c2" } in
@@ -201,6 +201,8 @@ let%expect_test "creating cycle can succeed on a second attempt" =
   Format.printf "c2 = %a@.\n" dag_pp_mynode c2;
   Format.printf "c3 = %a@.\n" dag_pp_mynode c3;
   Format.printf "c4 = %a@.\n" dag_pp_mynode c4;
+  (* Note that the state of the nodes changed even though adding the edge has
+     failed. Specifically, the levels of nodes c2 and c3 increased to 2. *)
   [%expect
     {|
     cycle
@@ -216,9 +218,7 @@ let%expect_test "creating cycle can succeed on a second attempt" =
   | () -> Format.printf "added :o\n"
   | exception Cycle _ -> Format.printf "cycle\n" );
   Format.printf "c1 = %a@.\n" dag_pp_mynode c1;
-  Format.printf "c2 = %a@.\n" dag_pp_mynode c2;
-  Format.printf "c3 = %a@.\n" dag_pp_mynode c3;
-  Format.printf "c4 = %a@.\n" dag_pp_mynode c4;
+  (* The output is truncated at depth 20. *)
   [%expect
     {|
     added :o
@@ -240,58 +240,4 @@ let%expect_test "creating cycle can succeed on a second attempt" =
                                                                (4: k=2) (c4) [
                                                                (2: k=2) (c2) [
                                                                ...]]]]]]]]]]]]]]]]]]]]
-
-    c2 = (2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [(2: k=2) (c2) [(3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      ...]]]]]]]]]]]]]]]]]]]]
-
-    c3 = (3: k=2) (c3) [(4: k=2) (c4) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      ...]]]]]]]]]]]]]]]]]]]]
-
-    c4 = (4: k=2) (c4) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [(2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      (3: k=2) (c3) [
-                                                                      (4: k=2) (c4) [
-                                                                      (2: k=2) (c2) [
-                                                                      ...]]]]]]]]]]]]]]]]]]]]
   |}]


### PR DESCRIPTION
This is a minimal test that reveals a problem with our cycle detection library: adding an edge that creates a cycle is not an idempotent operation: first, it fails with an error (as it's supposed to) but after another attempt, it accepts the edge, creating a cycle (as it's not supposed to).