### PR TITLE
Move UI code from Scheduler

### DIFF
--- a/bench/dune_bench/scheduler_bench.ml
+++ b/bench/dune_bench/scheduler_bench.ml
@@ -19,7 +19,11 @@ let prog = Option.value_exn (Bin.which ~path:(Env.path Env.initial) "true")
 
 let run () = Process.run ~env:Env.initial Strict prog []
 
-let go ~jobs fiber = Scheduler.go { config with concurrency = jobs } fiber
+let go ~jobs fiber =
+  Scheduler.go
+    ~on_event:(fun _ _ -> ())
+    { config with concurrency = jobs }
+    fiber
 
 let%bench_fun "single" =
   Lazy.force setup;

--- a/bench/dune_bench/scheduler_bench.ml
+++ b/bench/dune_bench/scheduler_bench.ml
@@ -20,7 +20,7 @@ let prog = Option.value_exn (Bin.which ~path:(Env.path Env.initial) "true")
 let run () = Process.run ~env:Env.initial Strict prog []
 
 let go ~jobs fiber =
-  Scheduler.go
+  Scheduler.Run.go
     ~on_event:(fun _ _ -> ())
     { config with concurrency = jobs }
     fiber

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -55,6 +55,9 @@ val footer : Cmdliner.Manpage.block
 
 val term : t Cmdliner.Term.t
 
+(** Set whether Dune should print the "Entering directory '<dir>'" message *)
+val set_print_directory : t -> bool -> t
+
 val debug_backtraces : bool Cmdliner.Term.t
 
 val config_term : Dune_config.t Cmdliner.Term.t

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -143,7 +143,7 @@ module Scheduler = struct
 
   let on_event config = function
     | Scheduler.Build.Source_files_changed -> maybe_clear_screen config
-    | New_event -> Console.Status_line.refresh ()
+    | Tick -> Console.Status_line.refresh ()
     | Build_interrupted ->
       let status_line =
         Some

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -164,34 +164,6 @@ module Scheduler = struct
            (Some
               (Pp.seq message
                  (Pp.verbatim ", waiting for filesystem changes..."))))
-    | Chdir cwd ->
-      if not !Clflags.no_print_directory then
-        let dir =
-          match Dune_engine.Config.inside_dune with
-          | false -> cwd
-          | true -> (
-            let descendant_simple p ~of_ =
-              match String.drop_prefix p ~prefix:of_ with
-              | None
-              | Some "" ->
-                None
-              | Some s -> Some (String.drop s 1)
-            in
-            match descendant_simple cwd ~of_:Fpath.initial_cwd with
-            | Some s -> s
-            | None -> (
-              match descendant_simple Fpath.initial_cwd ~of_:cwd with
-              | None -> cwd
-              | Some s ->
-                let rec loop acc dir =
-                  if dir = Filename.current_dir_name then
-                    acc
-                  else
-                    loop (Filename.concat acc "..") (Filename.dirname dir)
-                in
-                loop ".." (Filename.dirname s) ) )
-        in
-        Console.print [ Pp.verbatim (sprintf "Entering directory '%s'" dir) ]
 
   let go ~(common : Common.t) f =
     let config = Common.config common in

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -142,7 +142,7 @@ module Scheduler = struct
            ])
 
   let on_event config = function
-    | Scheduler.Build.Source_files_changed -> maybe_clear_screen config
+    | Scheduler.Run.Event.Source_files_changed -> maybe_clear_screen config
     | Tick -> Console.Status_line.refresh ()
     | Build_interrupted ->
       let status_line =
@@ -169,13 +169,13 @@ module Scheduler = struct
     let config = Common.config common in
     let rpc = Common.rpc common |> Option.map ~f:Dune_rpc_impl.Server.config in
     let config = Dune_config.for_scheduler config rpc in
-    Scheduler.go config ~on_event f
+    Scheduler.Run.go config ~on_event f
 
   let poll ~(common : Common.t) ~once ~finally =
     let config = Common.config common in
     let rpc = Common.rpc common |> Option.map ~f:Dune_rpc_impl.Server.config in
     let config = Dune_config.for_scheduler config rpc in
-    Scheduler.poll config ~on_event ~once ~finally
+    Scheduler.Run.poll config ~on_event ~once ~finally
 end
 
 let restore_cwd_and_execve (common : Common.t) prog argv env =

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -154,7 +154,7 @@ module Scheduler = struct
     let on_event config = function
       | Scheduler.Build.Source_files_changed -> maybe_clear_screen config
       | New_event -> Console.Status_line.refresh ()
-      | Build_failure ->
+      | Build_interrupted ->
         let status_line =
           Some
             (Pp.seq

--- a/bin/ocaml_merlin.ml
+++ b/bin/ocaml_merlin.ml
@@ -28,6 +28,7 @@ let term =
              debugging purposes only and should not be considered as a stable \
              ouptut.")
   in
+  let common = Common.set_print_directory common false in
   Common.set_common common ~log_file:No_log_file;
   Dune_engine.File_tree.init ~recognize_jbuilder_projects:true
     ~ancestor_vcs:None;

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -69,6 +69,7 @@ let term =
   Dune_config.init config;
   Log.init_disabled ();
   Dune_engine.Scheduler.go
+    ~on_event:(fun _ _ -> ())
     (Dune_config.for_scheduler config None)
     Watermarks.subst
 

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -68,7 +68,7 @@ let term =
   Path.Build.set_build_dir (Path.Build.Kind.of_string Common.default_build_dir);
   Dune_config.init config;
   Log.init_disabled ();
-  Dune_engine.Scheduler.go
+  Dune_engine.Scheduler.Run.go
     ~on_event:(fun _ _ -> ())
     (Dune_config.for_scheduler config None)
     Watermarks.subst

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -11,8 +11,6 @@ module Dune_rpc = Dune_rpc_private
 (* To make bug reports usable *)
 let () = Printexc.record_backtrace true
 
-let initial_cwd = Sys.getcwd ()
-
 let protect = Exn.protect
 
 let protectx = Exn.protectx

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -791,8 +791,6 @@ module Handler = struct
     { new_event : Config.t -> unit
     ; build_interrupted : Config.t -> unit
     }
-
-  let no_op = { new_event = (fun _ -> ()); build_interrupted = (fun _ -> ()) }
 end
 
 type t =
@@ -1087,7 +1085,15 @@ let poll config ~on_event ~once ~finally =
   | Some bt -> Exn.raise_with_backtrace exn bt
 
 let go config run =
-  let t = prepare config ~polling:false ~handler:Handler.no_op in
+  let t =
+    prepare config ~polling:false
+      ~handler:
+        { new_event = (fun _ -> ())
+        ; build_interrupted = (fun _ ->
+            (* can't interrupt a build when not in polling mode *)
+            assert false)
+        }
+  in
   Build.go t run
 
 let send_dedup d =

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -869,9 +869,9 @@ let prepare (config : Config.t) ~polling =
   Signal_watcher.init events;
   let process_watcher = Process_watcher.init events in
   let cwd = Sys.getcwd () in
-  if cwd <> initial_cwd && not !Clflags.no_print_directory then
-    Printf.eprintf "Entering directory '%s'\n%!"
-      ( match Config.inside_dune with
+  ( if cwd <> initial_cwd && not !Clflags.no_print_directory then
+    let message =
+      match Config.inside_dune with
       | false -> cwd
       | true -> (
         let descendant_simple p ~of_ =
@@ -893,7 +893,9 @@ let prepare (config : Config.t) ~polling =
               else
                 loop (Filename.concat acc "..") (Filename.dirname dir)
             in
-            loop ".." (Filename.dirname s) ) ) );
+            loop ".." (Filename.dirname s) ) )
+    in
+    Console.print [ Pp.verbatim (sprintf "Entering directory '%s'" dir) ] );
   let rpc = Rpc0.of_config events config.rpc in
   let t =
     { original_cwd = cwd

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -971,14 +971,14 @@ module Build = struct
     | Failure
 
   type event =
-    | New_event
+    | Tick
     | Source_files_changed
     | Build_interrupted
     | Build_finish of build_result
 
   let to_handler ~on_event =
     { Handler.build_interrupted = (fun cfg -> on_event cfg Build_interrupted)
-    ; new_event = (fun cfg -> on_event cfg New_event)
+    ; new_event = (fun cfg -> on_event cfg Tick)
     }
 
   let go t run =

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1009,23 +1009,6 @@ module Build = struct
     | Build_failure
     | Build_finish of build_result
 
-  type 'a t =
-    | Go : { run : unit -> 'a Fiber.t } -> 'a t
-    | Poll :
-        { once : unit -> [ `Continue | `Stop ] Fiber.t
-        ; finally : unit -> unit
-        ; on_event : Config.t -> event -> unit
-        }
-        -> unit t
-
-  let to_handler (type a) (t : a t) : Handler.t =
-    match t with
-    | Go _ -> Handler.no_op
-    | Poll p ->
-      { build_failure = (fun cfg -> p.on_event cfg Build_failure)
-      ; new_event = (fun cfg -> p.on_event cfg New_event)
-      }
-
   let go t run =
     let res =
       let f = Rpc0.with_rpc_serve t.rpc run in
@@ -1036,83 +1019,77 @@ module Build = struct
     | Ok res -> res
     | Error (Got_signal | Never) ->
       raise Dune_util.Report_error.Already_reported
-
-  let poll ~on_event ~once ~finally = Poll { on_event; once; finally }
-
-  let run (type a) t (build : a t) : a =
-    match build with
-    | Go { run } -> go t run
-    | Poll { once; finally; on_event } -> (
-      let watcher = File_watcher.create t.events in
-      let rec loop () : unit Fiber.t =
-        t.status <- Building;
-        let open Fiber.O in
-        let* res =
-          let+ res =
-            let on_error exn () =
-              match t.status with
-              | Building -> Report_error.report exn
-              | Restarting_build -> ()
-              | Waiting_for_file_changes _ ->
-                (* We are inside a build, so we aren't waiting for a file change
-                   event *)
-                assert false
-            in
-            Fiber.fold_errors ~init:() ~on_error once
-          in
-          finally ();
-          res
-        in
-        match t.status with
-        | Waiting_for_file_changes _ ->
-          (* We just finished a build, so there's no way this was set *)
-          assert false
-        | Restarting_build -> loop ()
-        | Building -> (
-          on_event t.config
-            (Build_finish
-               ( match res with
-               | Error _ -> Failure
-               | Ok _ -> Success ));
-          let ivar = Fiber.Ivar.create () in
-          t.status <- Waiting_for_file_changes ivar;
-          let* () = Fiber.Ivar.read ivar in
-          on_event t.config Source_files_changed;
-          match res with
-          | Error _
-          | Ok `Continue ->
-            loop ()
-          | Ok `Stop -> Fiber.return () )
-      in
-      let run = Rpc0.with_rpc_serve t.rpc loop in
-      let exn, bt =
-        match Run_once.run_and_cleanup t run with
-        | Ok () ->
-          (* Polling mode is an infinite loop. We aren't going to terminate *)
-          assert false
-        | Error (Got_signal | Never) ->
-          (Dune_util.Report_error.Already_reported, None)
-        | Error (Exn exn_with_bt) ->
-          (exn_with_bt.exn, Some exn_with_bt.backtrace)
-      in
-      ignore (wait_for_process t (File_watcher.pid watcher) : _ Fiber.t);
-      ignore (kill_and_wait_for_all_processes t : saw_signal);
-      match bt with
-      | None -> Exn.raise exn
-      | Some bt -> Exn.raise_with_backtrace exn bt )
-
-  let go run = Go { run }
 end
 
-let build (type a) config (build : a Build.t) : a =
-  let t =
-    let t = prepare config ~polling:true in
-    let handler = Build.to_handler build in
-    { t with handler }
+let poll config ~on_event ~once ~finally =
+  let handler : Handler.t =
+    { build_failure = (fun cfg -> on_event cfg (Build_failure : Build.event))
+    ; new_event = (fun cfg -> on_event cfg (New_event : Build.event))
+    }
   in
-  Build.run t build
+  let t = prepare config ~polling:true in
+  let t = { t with handler } in
+  let watcher = File_watcher.create t.events in
+  let rec loop () : unit Fiber.t =
+    t.status <- Building;
+    let open Fiber.O in
+    let* res =
+      let+ res =
+        let on_error exn () =
+          match t.status with
+          | Building -> Report_error.report exn
+          | Restarting_build -> ()
+          | Waiting_for_file_changes _ ->
+            (* We are inside a build, so we aren't waiting for a file change
+               event *)
+            assert false
+        in
+        Fiber.fold_errors ~init:() ~on_error once
+      in
+      finally ();
+      res
+    in
+    match t.status with
+    | Waiting_for_file_changes _ ->
+      (* We just finished a build, so there's no way this was set *)
+      assert false
+    | Restarting_build -> loop ()
+    | Building -> (
+      on_event t.config
+        (Build_finish
+           ( match res with
+           | Error _ -> Failure
+           | Ok _ -> Success ));
+      let ivar = Fiber.Ivar.create () in
+      t.status <- Waiting_for_file_changes ivar;
+      let* () = Fiber.Ivar.read ivar in
+      on_event t.config Source_files_changed;
+      match res with
+      | Error _
+      | Ok `Continue ->
+        loop ()
+      | Ok `Stop -> Fiber.return () )
+  in
+  let run = Rpc0.with_rpc_serve t.rpc loop in
+  let exn, bt =
+    match Run_once.run_and_cleanup t run with
+    | Ok () ->
+      (* Polling mode is an infinite loop. We aren't going to terminate *)
+      assert false
+    | Error (Got_signal | Never) ->
+      (Dune_util.Report_error.Already_reported, None)
+    | Error (Exn exn_with_bt) -> (exn_with_bt.exn, Some exn_with_bt.backtrace)
+  in
+  ignore (wait_for_process t (File_watcher.pid watcher) : _ Fiber.t);
+  ignore (kill_and_wait_for_all_processes t : saw_signal);
+  match bt with
+  | None -> Exn.raise exn
+  | Some bt -> Exn.raise_with_backtrace exn bt
 
-let go config run = build config (Go { run })
+let go config run =
+  let t = prepare config ~polling:false in
+  let t = { t with handler = Handler.no_op } in
+  Build.go t run
 
 let send_dedup d =
   let t = Option.value_exn !global in

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1089,9 +1089,10 @@ let go config run =
     prepare config ~polling:false
       ~handler:
         { new_event = (fun _ -> ())
-        ; build_interrupted = (fun _ ->
-            (* can't interrupt a build when not in polling mode *)
-            assert false)
+        ; build_interrupted =
+            (fun _ ->
+              (* can't interrupt a build when not in polling mode *)
+              assert false)
         }
   in
   Build.go t run

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -1,6 +1,6 @@
 (** Scheduling *)
-open! Import
 
+open! Import
 open Stdune
 
 module Config : sig
@@ -44,13 +44,27 @@ module Config : sig
     }
 end
 
-(** [go config fiber] runs the fiber until it terminates. *)
+module Build : sig
+  (** A build task producing ['a] after it's finished *)
+  type 'a t
+
+  (** Runs [once] in a loop, executing [finally] after every iteration, even if
+      Fiber.Never was encountered.
+
+      If any source files change in the middle of iteration, it gets canceled. *)
+  val poll :
+       once:(unit -> [ `Continue | `Stop ] Fiber.t)
+    -> finally:(unit -> unit)
+    -> unit t
+
+  (** [go config fiber] runs the fiber until it terminates. *)
+  val go : (unit -> 'a Fiber.t) -> 'a t
+end
+
+val build : Config.t -> 'a Build.t -> 'a
+
 val go : Config.t -> (unit -> 'a Fiber.t) -> 'a
 
-(** Runs [once] in a loop, executing [finally] after every iteration, even if
-    Fiber.Never was encountered.
-
-    If any source files change in the middle of iteration, it gets canceled. *)
 val poll :
      Config.t
   -> once:(unit -> [ `Continue | `Stop ] Fiber.t)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -48,12 +48,23 @@ module Build : sig
   (** A build task producing ['a] after it's finished *)
   type 'a t
 
+  type build_result =
+    | Success
+    | Failure
+
+  type event =
+    | Source_files_changed
+    | New_event
+    | Build_failure
+    | Build_finish of build_result
+
   (** Runs [once] in a loop, executing [finally] after every iteration, even if
       Fiber.Never was encountered.
 
       If any source files change in the middle of iteration, it gets canceled. *)
   val poll :
-       once:(unit -> [ `Continue | `Stop ] Fiber.t)
+       on_event:(Config.t -> event -> unit)
+    -> once:(unit -> [ `Continue | `Stop ] Fiber.t)
     -> finally:(unit -> unit)
     -> unit t
 
@@ -64,12 +75,6 @@ end
 val build : Config.t -> 'a Build.t -> 'a
 
 val go : Config.t -> (unit -> 'a Fiber.t) -> 'a
-
-val poll :
-     Config.t
-  -> once:(unit -> [ `Continue | `Stop ] Fiber.t)
-  -> finally:(unit -> unit)
-  -> unit
 
 (** [with_job_slot f] waits for one job slot (as per [-j <jobs] to become
     available and then calls [f]. *)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -54,7 +54,6 @@ module Build : sig
     | Source_files_changed
     | Build_interrupted
     | Build_finish of build_result
-    | Chdir of string
 end
 
 (** Runs [once] in a loop, executing [finally] after every iteration, even if

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -45,9 +45,6 @@ module Config : sig
 end
 
 module Build : sig
-  (** A build task producing ['a] after it's finished *)
-  type 'a t
-
   type build_result =
     | Success
     | Failure
@@ -57,22 +54,18 @@ module Build : sig
     | New_event
     | Build_failure
     | Build_finish of build_result
-
-  (** Runs [once] in a loop, executing [finally] after every iteration, even if
-      Fiber.Never was encountered.
-
-      If any source files change in the middle of iteration, it gets canceled. *)
-  val poll :
-       on_event:(Config.t -> event -> unit)
-    -> once:(unit -> [ `Continue | `Stop ] Fiber.t)
-    -> finally:(unit -> unit)
-    -> unit t
-
-  (** [go config fiber] runs the fiber until it terminates. *)
-  val go : (unit -> 'a Fiber.t) -> 'a t
 end
 
-val build : Config.t -> 'a Build.t -> 'a
+(** Runs [once] in a loop, executing [finally] after every iteration, even if
+    Fiber.Never was encountered.
+
+    If any source files change in the middle of iteration, it gets canceled. *)
+val poll :
+     Config.t
+  -> on_event:(Config.t -> Build.event -> unit)
+  -> once:(unit -> [ `Continue | `Stop ] Fiber.t)
+  -> finally:(unit -> unit)
+  -> unit
 
 val go : Config.t -> (unit -> 'a Fiber.t) -> 'a
 

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -50,9 +50,9 @@ module Build : sig
     | Failure
 
   type event =
-    | Source_files_changed
     | New_event
-    | Build_failure
+    | Source_files_changed
+    | Build_interrupted
     | Build_finish of build_result
 end
 

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -50,7 +50,7 @@ module Build : sig
     | Failure
 
   type event =
-    | New_event
+    | Tick
     | Source_files_changed
     | Build_interrupted
     | Build_finish of build_result

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -50,8 +50,10 @@ module Run : sig
       | Success
       | Failure
 
-    type t =
-      | Tick
+    type go = Tick
+
+    type poll =
+      | Go of go
       | Source_files_changed
       | Build_interrupted
       | Build_finish of build_result
@@ -63,14 +65,14 @@ module Run : sig
       If any source files change in the middle of iteration, it gets canceled. *)
   val poll :
        Config.t
-    -> on_event:(Config.t -> Event.t -> unit)
+    -> on_event:(Config.t -> Event.poll -> unit)
     -> once:(unit -> [ `Continue | `Stop ] Fiber.t)
     -> finally:(unit -> unit)
     -> unit
 
   val go :
        Config.t
-    -> on_event:(Config.t -> Event.t -> unit)
+    -> on_event:(Config.t -> Event.go -> unit)
     -> (unit -> 'a Fiber.t)
     -> 'a
 end

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -54,6 +54,7 @@ module Build : sig
     | Source_files_changed
     | Build_interrupted
     | Build_finish of build_result
+    | Chdir of string
 end
 
 (** Runs [once] in a loop, executing [finally] after every iteration, even if
@@ -67,7 +68,11 @@ val poll :
   -> finally:(unit -> unit)
   -> unit
 
-val go : Config.t -> (unit -> 'a Fiber.t) -> 'a
+val go :
+     Config.t
+  -> on_event:(Config.t -> Build.event -> unit)
+  -> (unit -> 'a Fiber.t)
+  -> 'a
 
 (** [with_job_slot f] waits for one job slot (as per [-j <jobs] to become
     available and then calls [f]. *)

--- a/src/stdune/fpath.ml
+++ b/src/stdune/fpath.ml
@@ -4,6 +4,8 @@ type mkdir_p =
   | Already_exists
   | Created
 
+let initial_cwd = Stdlib.Sys.getcwd ()
+
 let rec mkdir_p ?(perms = 0o777) t_s =
   if is_root t_s then
     Already_exists

--- a/src/stdune/fpath.mli
+++ b/src/stdune/fpath.mli
@@ -17,3 +17,5 @@ val follow_symlink : string -> (string, follow_symlink_error) result
 val unlink : string -> unit
 
 val unlink_no_err : string -> unit
+
+val initial_cwd : string

--- a/test/blackbox-tests/test-cases/dialects.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects.t/run.t
@@ -2,7 +2,6 @@ Test the (dialect ...) stanza inside the dune-project file.
 
   $ dune exec --root good ./main.exe
   Entering directory 'good'
-  Entering directory 'good'
 
   $ dune build --root good @fmt
   Entering directory 'good'

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -304,11 +304,9 @@ Can init and build a new executable project
 
   $ dune exec --root test_exec_proj ./bin/main.exe
   Entering directory 'test_exec_proj'
-  Entering directory 'test_exec_proj'
   Hello, World!
 
   $ dune exec --root test_exec_proj ./test/test_exec_proj.exe
-  Entering directory 'test_exec_proj'
   Entering directory 'test_exec_proj'
   $ rm -rf ./test_exec_proj
 

--- a/test/blackbox-tests/test-cases/enabled_if-exec.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if-exec.t/run.t
@@ -48,7 +48,6 @@ For dune 2.3 -> 2.5 it is a warning
   ocaml_version and context_name variables are allowed in this 'enabled_if'
   field. If you think that project_root should also be allowed, please file an
   issue about it.
-  Entering directory 'forbidden_var'
   bar
 
 For dune >= 2.6 it is an error
@@ -85,6 +84,5 @@ For dune >= 2.7 context_name allowed
   > (lang dune 2.7)
   > EOF
   $ dune exec ./foo.exe --root var_context_name
-  Entering directory 'var_context_name'
   Entering directory 'var_context_name'
   bar

--- a/test/blackbox-tests/test-cases/env/env-variables.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-variables.t/run.t
@@ -4,13 +4,11 @@ They can be set from the workspace:
 
   $ dune exec --root precedence ./printenv.exe VARIABLE_FROM_WORKSPACE
   Entering directory 'precedence'
-  Entering directory 'precedence'
   VARIABLE_FROM_WORKSPACE=value1
 
 From a (context) stanza in the workspace:
 
   $ dune exec --root precedence ./printenv.exe VARIABLE_FROM_CONTEXT
-  Entering directory 'precedence'
   Entering directory 'precedence'
   VARIABLE_FROM_CONTEXT=value2
 
@@ -18,7 +16,6 @@ When a variable is set from both a context and a global one, the context one is
 used.
 
   $ dune exec --root precedence ./printenv.exe VARIABLE_FROM_BOTH
-  Entering directory 'precedence'
   Entering directory 'precedence'
   VARIABLE_FROM_BOTH=from_workspace
 

--- a/test/blackbox-tests/test-cases/foreign-library.t/run.t
+++ b/test/blackbox-tests/test-cases/foreign-library.t/run.t
@@ -742,7 +742,6 @@ Testsuite for the (foreign_library ...) stanza.
 
   $ export OCAMLPATH=$PWD/external/install/lib; ./sdune exec ./main.exe --root=some/dir
   Entering directory 'some/dir'
-  Entering directory 'some/dir'
   Answer = 42
 
 ----------------------------------------------------------------------------------

--- a/test/blackbox-tests/test-cases/link-includes.t/run.t
+++ b/test/blackbox-tests/test-cases/link-includes.t/run.t
@@ -34,6 +34,5 @@ First we create an external library and implementation
 Then we make sure that it works fine.
   $ env OCAMLPATH=lib1/_build/install/default/lib: dune exec --root exe ./bar.exe
   Entering directory 'exe'
-  Entering directory 'exe'
   lib1: 42
 

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -46,5 +46,4 @@ custom version:
 
   $ OCAMLPATH=$PWD/_install/lib dune exec --root external ./main.exe
   Entering directory 'external'
-  Entering directory 'external'
   foobarlib

--- a/test/blackbox-tests/test-cases/multi-dir.t/run.t
+++ b/test/blackbox-tests/test-cases/multi-dir.t/run.t
@@ -61,5 +61,4 @@ Test for (include_subdir unqualified) with (preprocess (action ...))
 
   $ dune exec ./main.exe --root test4 @all
   Entering directory 'test4'
-  Entering directory 'test4'
   print_endline "foo"

--- a/test/blackbox-tests/test-cases/private-package-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/private-package-lib.t/run.t
@@ -157,7 +157,6 @@ Now we make sure such libraries are transitively usable when installed:
   $ export OCAMLPATH=$PWD/_build/install/default/lib
   $ dune exec --root use -- ./run.exe
   Entering directory 'use'
-  Entering directory 'use'
   Using library foo: from library foo secret string
 
 But we cannot use such libraries directly:
@@ -166,7 +165,6 @@ But we cannot use such libraries directly:
   > print_endline ("direct access attempt: " ^ Secret.secret)
   > EOF
   $ dune exec --root use -- ./run.exe
-  Entering directory 'use'
   Entering directory 'use'
   File "run.ml", line 1, characters 43-56:
   1 | print_endline ("direct access attempt: " ^ Secret.secret)

--- a/test/blackbox-tests/test-cases/private-public-overlap.t/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap.t/run.t
@@ -38,7 +38,6 @@ Unless they introduce private runtime dependencies:
 However, public binaries may accept private dependencies
   $ dune exec --root exes ./publicbin.exe
   Entering directory 'exes'
-  Entering directory 'exes'
 
 Private dependencies shouldn't make the library optional
   $ dune build @install --display short --root optional

--- a/test/blackbox-tests/test-cases/re-exported-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/re-exported-deps.t/run.t
@@ -1,7 +1,6 @@
 dependencies can be exported transitively:
   $ dune exec ./foo.exe --root transitive
   Entering directory 'transitive'
-  Entering directory 'transitive'
 
 transtive deps expressed in the dune-package
 

--- a/test/blackbox-tests/test-cases/toplevel-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/toplevel-stanza.t/run.t
@@ -1,7 +1,6 @@
 Simple example to run toplevel
   $ dune exec --root simple ./tt.exe -- -init simple/init.ml | sed -E 's/OCaml version .*$/OCaml version REDACTED/g'
   Entering directory 'simple'
-  Entering directory 'simple'
           OCaml version REDACTED
   
   Foo.x = 42
@@ -9,7 +8,6 @@ Simple example to run toplevel
 
 Running toplevel with preprocessor
   $ dune exec --root preprocessors ./tt.exe -- -init preprocessors/init.ml | sed -E 's/OCaml version .*$/Ocaml version REDACTED/g'
-  Entering directory 'preprocessors'
   Entering directory 'preprocessors'
           Ocaml version REDACTED
   

--- a/test/blackbox-tests/test-cases/utop/utop-default.t/run.t
+++ b/test/blackbox-tests/test-cases/utop/utop-default.t/run.t
@@ -19,5 +19,6 @@ Utop will load libs recursively:
 The message where the library path does not exist is different:
 
   $ dune utop --root nothing-in-root does-not-exist . -- -init ""
+  Entering directory 'nothing-in-root'
   Error: cannot find directory: does-not-exist
   [1]

--- a/test/blackbox-tests/test-cases/workspaces.t/run.t
+++ b/test/blackbox-tests/test-cases/workspaces.t/run.t
@@ -35,7 +35,6 @@ see how we can set a "native" target. Which is the default.
 
   $ dune exec ./foo.exe --root targets-native
   Entering directory 'targets-native'
-  Entering directory 'targets-native'
   message from targets-native test
 
 Workspaces also allow you to set the env for a context:

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -121,7 +121,7 @@ let run kind script =
     ; rpc = None
     }
   in
-  Scheduler.go
+  Scheduler.Run.go
     ~on_event:(fun _ _ -> ())
     config
     (fun () -> Fiber.sequential_iter script ~f:(run_action vcs))

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -121,8 +121,10 @@ let run kind script =
     ; rpc = None
     }
   in
-  Scheduler.go config (fun () ->
-      Fiber.sequential_iter script ~f:(run_action vcs))
+  Scheduler.go
+    ~on_event:(fun _ _ -> ())
+    config
+    (fun () -> Fiber.sequential_iter script ~f:(run_action vcs))
 
 let script =
   [ Init


### PR DESCRIPTION
This is an attempt to make the Scheduler more agnostic of the console UI. The
basic idea is that the scheduler should just fire events that a UI should
handle, and not know anything about the console backend. This is needed to make
it easier to incorporate dune's upcoming tui, which will be handling these
events differently.

@aalekseyev perhaps you could take a look?