### PR TITLE
Do not recompute nodes with cutoff unnecessarily

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -599,8 +599,7 @@ let currently_considering (v : _ State.t) : _ State.t =
     if Run.is_current run then
       running
     else
-      Code_error.raise
-        "A zombie computation is encountered in [currently_considering]" []
+      Not_considering
 
 let get_cached_value_in_current_cycle (dep_node : _ Dep_node.t) =
   match dep_node.last_cached_value with

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -942,10 +942,10 @@ end = struct
                 | Ok cached_value -> (
                   match Value_id.equal cached_value.id v_id with
                   | true -> go deps
-                  | false -> Changed )
+                  | false -> Changed)
                 | Error (Cancelled { dependency_cycle }) ->
                   Cancelled { dependency_cycle }
-                | Error (Not_found | Out_of_date _) -> Changed )
+                | Error (Not_found | Out_of_date _) -> Changed)
               | Yes _equal -> (
                 (* If [dep] has a cutoff predicate, it is not sufficient to
                    check whether it is up to date: even if it isn't, after we
@@ -960,7 +960,7 @@ end = struct
                      value [id] will be new, so we will take the [false] branch. *)
                   match Value_id.equal cached_value.id v_id with
                   | true -> go deps
-                  | false -> Changed ) ) )
+                  | false -> Changed)))
           in
           go cached_value.deps
         in
@@ -1022,14 +1022,14 @@ end = struct
              let restore_result =
                restore_from_cache dep_node.last_cached_value
              in
-             ( match restore_result with
+             (match restore_result with
              | Ok _ -> dep_node.state <- Not_considering
-             | Error _ -> () );
+             | Error _ -> ());
              restore_result))
     in
     let compute =
       lazy
-        ( match Lazy.force restore_from_cache with
+        (match Lazy.force restore_from_cache with
         | Ok cached_value -> cached_value
         | Error cache_lookup_failure ->
           Call_stack.push_sync_frame frame (fun () ->
@@ -1039,7 +1039,7 @@ end = struct
               in
               dep_node.last_cached_value <- Some cached_value;
               dep_node.state <- Not_considering;
-              cached_value) )
+              cached_value))
     in
     let completion : _ Sample_attempt.Completion.Sync.t =
       { restore_from_cache; compute }
@@ -1057,7 +1057,7 @@ end = struct
     | Not_considering -> (
       match get_cached_value_in_current_cycle dep_node with
       | None -> newly_considering dep_node
-      | Some cv -> Finished cv )
+      | Some cv -> Finished cv)
     | Considering
         { running = { dag_node; deps_so_far = _ }
         ; completion = Sync completion
@@ -1131,11 +1131,11 @@ end = struct
                 | Ok cached_value -> (
                   match Value_id.equal cached_value.id v_id with
                   | true -> go deps
-                  | false -> Fiber.return Changed_or_not.Changed )
+                  | false -> Fiber.return Changed_or_not.Changed)
                 | Error (Cancelled { dependency_cycle }) ->
                   Fiber.return (Changed_or_not.Cancelled { dependency_cycle })
                 | Error (Not_found | Out_of_date _) ->
-                  Fiber.return Changed_or_not.Changed )
+                  Fiber.return Changed_or_not.Changed)
               | Yes _equal -> (
                 (* If [dep] has a cutoff predicate, it is not sufficient to
                    check whether it is up to date: even if it isn't, after we
@@ -1152,7 +1152,7 @@ end = struct
                      value [id] will be new, so we will take the [false] branch. *)
                   match Value_id.equal cached_value.id v_id with
                   | true -> go deps
-                  | false -> Fiber.return Changed_or_not.Changed ) ) )
+                  | false -> Fiber.return Changed_or_not.Changed)))
           in
           go cached_value.deps
         in
@@ -1214,9 +1214,9 @@ end = struct
               let+ restore_result =
                 restore_from_cache dep_node.last_cached_value
               in
-              ( match restore_result with
+              (match restore_result with
               | Ok _ -> dep_node.state <- Not_considering
-              | Error _ -> () );
+              | Error _ -> ());
               restore_result))
     in
     let compute =
@@ -1248,7 +1248,7 @@ end = struct
     | Not_considering -> (
       match get_cached_value_in_current_cycle dep_node with
       | None -> newly_considering dep_node
-      | Some cv -> Finished cv )
+      | Some cv -> Finished cv)
     | Considering
         { running = { dag_node; deps_so_far = _ }
         ; completion = Async completion

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -597,6 +597,10 @@ let currently_considering (v : _ State.t) : _ State.t =
     if Run.is_current run then
       running
     else
+      (* TODO: A computation can only become zombie if [restore_from_cache]
+         finished unsuccessfully. What's wrong with simply starting the
+         [compute] if we do reach a zombie? That seems to be harmless and
+         eliminates a non-trivial (and possibly incorrect) assumption. *)
       Code_error.raise
         "A zombie computation is encountered in [currently_considering]" []
 
@@ -821,6 +825,7 @@ let add_dep_from_caller (type i o f) ~called_from_peek
         match sample_attempt with
         | Finished _ -> None
         | Running { dag_node; _ } -> (
+          (* TODO: Due to [Deps_so_far.reset], we can now add an edge twice. *)
           match
             Dag.add_assuming_missing global_dep_dag
               caller.running_state.dag_node dag_node

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -939,7 +939,10 @@ end = struct
                   Exec_unknown.restore_from_cache_internal_from_sync dep
                 in
                 match restore_result with
-                | Ok _cached_value -> go deps
+                | Ok cached_value -> (
+                  match Value_id.equal cached_value.id v_id with
+                  | true -> go deps
+                  | false -> Changed )
                 | Error (Cancelled { dependency_cycle }) ->
                   Cancelled { dependency_cycle }
                 | Error (Not_found | Out_of_date _) -> Changed )
@@ -1125,7 +1128,10 @@ end = struct
                   Exec_unknown.restore_from_cache_internal dep
                 in
                 match restore_result with
-                | Ok _cached_value -> go deps
+                | Ok cached_value -> (
+                  match Value_id.equal cached_value.id v_id with
+                  | true -> go deps
+                  | false -> Fiber.return Changed_or_not.Changed )
                 | Error (Cancelled { dependency_cycle }) ->
                   Fiber.return (Changed_or_not.Cancelled { dependency_cycle })
                 | Error (Not_found | Out_of_date _) ->

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -599,10 +599,6 @@ let currently_considering (v : _ State.t) : _ State.t =
     if Run.is_current run then
       running
     else
-      (* TODO: A computation can only become zombie if [restore_from_cache]
-         finished unsuccessfully. What's wrong with simply starting the
-         [compute] if we do reach a zombie? That seems to be harmless and
-         eliminates a non-trivial (and possibly incorrect) assumption. *)
       Code_error.raise
         "A zombie computation is encountered in [currently_considering]" []
 

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1297,8 +1297,7 @@ let%expect_test "Test that there are no phantom dependencies" =
   Memo.Cell.invalidate cell;
   Memo.restart_current_run ();
   evaluate_and_print summit 0;
-  (* Note that we no longer depend on the [cell]. The corresponding message is
-     printed twice due to the known performance issue with nested nodes. *)
+  (* Note that we no longer depend on the [cell]. *)
   [%expect
     {|
     base = 8

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1079,19 +1079,13 @@ let%expect_test "deadlocks and zombies when creating a cycle twice" =
   evaluate_and_print summit 2;
   [%expect
     {|
-    f 0 = Error
-            [ { exn =
-                  "(\"A zombie computation is encountered in [currently_considering]\", {})"
-              ; backtrace = ""
-              }
-            ]
     Started evaluating summit
-    f 2 = Error
-            [ { exn =
-                  "(\"A zombie computation is encountered in [currently_considering]\", {})"
-              ; backtrace = ""
-              }
-            ]
+    Started evaluating middle
+    Started evaluating base
+    Started evaluating cycle_creator
+    f 0 = Error [ { exn = "Exit"; backtrace = "" } ]
+    Started evaluating summit
+    f 2 = Error [ { exn = "Exit"; backtrace = "" } ]
     |}]
 
 let%expect_test "Nested nodes with cutoff are recomputed optimally (sync)" =
@@ -1391,12 +1385,8 @@ let%expect_test "Abandoned node with no cutoff is not a zombie" =
     Evaluated base: 3
     Evaluated middle: 3
     *** Recalled captured base ***
-    f 0 = Error
-            [ { exn =
-                  "(\"A zombie computation is encountered in [currently_considering]\", {})"
-              ; backtrace = ""
-              }
-            ]
+    Evaluated summit: 1
+    f 0 = Ok 1
     |}]
 
 let print_exns f =

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1300,8 +1300,6 @@ let%expect_test "Test that there are no phantom dependencies" =
   (* Note that we no longer depend on the [cell]. *)
   [%expect
     {|
-    base = 8
-    *** middle does not depend on base ***
     Started evaluating summit
     *** middle does not depend on base ***
     Evaluated summit: 0

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1306,7 +1306,7 @@ let%expect_test "Test that there are no phantom dependencies" =
      unnecessary recomputations. *)
   [%expect {| f 0 = Ok 0 |}]
 
-let%expect_test "Abandoned node with no cutoff is handled correctly" =
+let%expect_test "Abandoned node with no cutoff is recomputed" =
   let count_runs = count_runs "base" in
   let which_base = ref 0 in
   let base () =
@@ -1387,7 +1387,9 @@ let%expect_test "Abandoned node with no cutoff is handled correctly" =
   Memo.restart_current_run ();
   evaluate_and_print summit 0;
   (* We will now attempt to force [compute] of a stale computation but this is
-     handled correctly by restarting the computation. *)
+     handled correctly by restarting the computation. Note that this causes an
+     additional increment of the counter, thus leading to an inconsisten value
+     of base observed by middlle (3) and summit (4) nodes. *)
   [%expect
     {|
     Started evaluating summit
@@ -1397,8 +1399,10 @@ let%expect_test "Abandoned node with no cutoff is handled correctly" =
     Evaluated base: 3
     Evaluated middle: 3
     *** Recalled captured base ***
-    Evaluated summit: 1
-    f 0 = Ok 1
+    Started evaluating base
+    Evaluated base: 4
+    Evaluated summit: 4
+    f 0 = Ok 4
     |}]
 
 let print_exns f =

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -749,7 +749,6 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     Evaluated base: 2
     Started evaluating no_cutoff
     Evaluated no_cutoff: 1
-    Started evaluating after_no_cutoff
     Evaluated after_no_cutoff: 2
     Started evaluating yes_cutoff
     Evaluated yes_cutoff: 1
@@ -910,10 +909,8 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated base: 2
     Started evaluating cycle_creator_no_cutoff
     Cycling to summit from cycle_creator_no_cutoff...
-    Started evaluating incrementing_chain_1_no_cutoff
-    Started evaluating incrementing_chain_2_yes_cutoff
-    Started evaluating incrementing_chain_3_no_cutoff
     Started evaluating incrementing_chain_4_yes_cutoff
+    Started evaluating incrementing_chain_3_no_cutoff
     Started evaluating the summit with input 0
     Dependency cycle detected:
     - ("incrementing_chain_plus_input", 2)
@@ -930,10 +927,10 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Started evaluating cycle_creator_yes_cutoff
     Cycling to summit from cycle_creator_yes_cutoff...
     Started evaluating incrementing_chain_1_yes_cutoff
-    Started evaluating incrementing_chain_2_no_cutoff
     Started evaluating incrementing_chain_3_yes_cutoff
-    Started evaluating incrementing_chain_4_no_cutoff
+    Started evaluating incrementing_chain_2_no_cutoff
     Started evaluating the summit with input 0
+    Started evaluating incrementing_chain_4_no_cutoff
     Dependency cycle detected:
     - ("incrementing_chain_plus_input", 2)
     - called by ("cycle_creator_yes_cutoff", ())

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1388,8 +1388,8 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
   evaluate_and_print summit 0;
   (* We will now attempt to force [compute] of a stale computation but this is
      handled correctly by restarting the computation. Note that this causes an
-     additional increment of the counter, thus leading to an inconsisten value
-     of base observed by middlle (3) and summit (4) nodes. *)
+     additional increment of the counter, thus leading to an inconsistent value
+     of [base] observed by the [middle] (3) and [summit] (4) nodes. *)
   [%expect
     {|
     Started evaluating summit

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -747,6 +747,7 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     {|
     Started evaluating base
     Evaluated base: 2
+    Started evaluating after_no_cutoff
     Started evaluating no_cutoff
     Evaluated no_cutoff: 1
     Evaluated after_no_cutoff: 2
@@ -907,6 +908,8 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     {|
     Started evaluating base
     Evaluated base: 2
+    Started evaluating incrementing_chain_2_yes_cutoff
+    Started evaluating incrementing_chain_1_no_cutoff
     Started evaluating cycle_creator_no_cutoff
     Cycling to summit from cycle_creator_no_cutoff...
     Started evaluating incrementing_chain_4_yes_cutoff
@@ -1091,7 +1094,7 @@ let%expect_test "deadlocks and zombies when creating a cycle twice" =
             ]
     |}]
 
-let%expect_test "Nested nodes with cutoff are recomputed unnecessarily (sync)" =
+let%expect_test "Nested nodes with cutoff are recomputed optimally (sync)" =
   let counter =
     create_sync ~with_cutoff:false "counter" (count_runs_sync "counter")
   in
@@ -1147,21 +1150,14 @@ let%expect_test "Nested nodes with cutoff are recomputed unnecessarily (sync)" =
   Memo.restart_current_run ();
   evaluate_and_print_sync summit 0;
   evaluate_and_print_sync summit 2;
-  (* In the second run, we recompute [base] three times and [middle] twice,
-     instead of just once. *)
+  (* In the second run, we don't recompute [base] three times as we did before. *)
   [%expect
     {|
-    Started evaluating counter
-    Evaluated counter: 2
-    Started evaluating base
-    Evaluated base: 2
-    Started evaluating middle
-    Started evaluating base
-    Evaluated base: 2
-    Evaluated middle: 2
     Started evaluating summit
     Started evaluating middle
     Started evaluating base
+    Started evaluating counter
+    Evaluated counter: 2
     Evaluated base: 2
     Evaluated middle: 2
     Evaluated summit: 2
@@ -1175,8 +1171,7 @@ let%expect_test "Nested nodes with cutoff are recomputed unnecessarily (sync)" =
     f 2 = Ok 4
     |}]
 
-let%expect_test "Nested nodes with cutoff are recomputed unnecessarily (async)"
-    =
+let%expect_test "Nested nodes with cutoff are recomputed optimally (async)" =
   let counter = create ~with_cutoff:false "counter" (count_runs "counter") in
   let summit =
     Memo.create "summit"
@@ -1230,21 +1225,14 @@ let%expect_test "Nested nodes with cutoff are recomputed unnecessarily (async)"
   Memo.restart_current_run ();
   evaluate_and_print summit 0;
   evaluate_and_print summit 2;
-  (* In the second run, we recompute [base] three times and [middle] twice,
-     instead of just once. *)
+  (* In the second run, we don't recompute [base] three times as we did before. *)
   [%expect
     {|
-    Started evaluating counter
-    Evaluated counter: 2
-    Started evaluating base
-    Evaluated middle: 2
-    Started evaluating middle
-    Started evaluating base
-    Evaluated middle: 2
-    Evaluated middle: 2
     Started evaluating summit
     Started evaluating middle
     Started evaluating base
+    Started evaluating counter
+    Evaluated counter: 2
     Evaluated middle: 2
     Evaluated middle: 2
     Evaluated summit: 2


### PR DESCRIPTION
Now if a node has no cutoff and we find out that it is out of date, we do not recompute it immediately but postpone recomputation until we know for sure that this node actually contributes to the final result.