### PR TITLE
Allow record valued counters

### DIFF
--- a/src/catapult/catapult.ml
+++ b/src/catapult/catapult.ml
@@ -1,10 +1,68 @@
 open Stdune
 
+module Json = struct
+  type t =
+    | Int of int
+    | Float of float
+    | String of string
+    | Array of t list
+    | Bool of bool
+    | Object of (string * t) list
+
+  let quote_string_to_buf s buf =
+    (* TODO: escaping is wrong here, in particular for control characters *)
+    Buffer.add_string buf (sprintf "%S" s)
+
+  let rec to_buf t buf =
+    match t with
+    | String s -> quote_string_to_buf s buf
+    | Int i -> Buffer.add_string buf (string_of_int i)
+    | Float f -> Buffer.add_string buf (string_of_float f)
+    | Bool b -> Buffer.add_string buf (string_of_bool b)
+    | Array l ->
+      Buffer.add_char buf '[';
+      array_body_to_buf l buf;
+      Buffer.add_char buf ']'
+    | Object o ->
+      Buffer.add_char buf '{';
+      object_body_to_buf o buf;
+      Buffer.add_char buf '}'
+
+  and array_body_to_buf t buf =
+    match t with
+    | [] -> ()
+    | [ x ] -> to_buf x buf
+    | x :: xs ->
+      to_buf x buf;
+      Buffer.add_char buf ',';
+      array_body_to_buf xs buf
+
+  and object_body_to_buf t buf =
+    match t with
+    | [] -> ()
+    | [ (x, y) ] ->
+      quote_string_to_buf x buf;
+      Buffer.add_char buf ':';
+      to_buf y buf
+    | (x, y) :: xs ->
+      quote_string_to_buf x buf;
+      Buffer.add_char buf ':';
+      to_buf y buf;
+      Buffer.add_char buf ',';
+      object_body_to_buf xs buf
+
+  let to_string t =
+    let buf = Buffer.create 0 in
+    to_buf t buf;
+    Buffer.contents buf
+end
+
 type t =
   { print : string -> unit
   ; close : unit -> unit
   ; get_time : unit -> float
   ; gc_stat : unit -> Gc.stat
+  ; buffer : Buffer.t
   ; mutable after_first_event : bool
   ; mutable next_id : int
   }
@@ -38,7 +96,15 @@ let fake time_ref buf =
   let close () = () in
   let get_time () = !time_ref in
   let gc_stat () = fake_gc_stat in
-  { print; close; get_time; gc_stat; after_first_event = false; next_id = 0 }
+  let buffer = Buffer.create 1024 in
+  { print
+  ; close
+  ; get_time
+  ; gc_stat
+  ; after_first_event = false
+  ; next_id = 0
+  ; buffer
+  }
 
 let close { print; close; _ } =
   print "]\n";
@@ -50,7 +116,15 @@ let make path =
   let close () = Stdlib.close_out channel in
   let get_time () = Unix.gettimeofday () in
   let gc_stat () = Gc.stat () in
-  { print; close; get_time; gc_stat; after_first_event = false; next_id = 0 }
+  let buffer = Buffer.create 1024 in
+  { print
+  ; close
+  ; get_time
+  ; gc_stat
+  ; after_first_event = false
+  ; next_id = 0
+  ; buffer
+  }
 
 let next_leading_char t =
   match t.after_first_event with
@@ -62,11 +136,6 @@ let next_leading_char t =
 let printf t format_string =
   let c = next_leading_char t in
   Printf.ksprintf t.print ("%c" ^^ format_string ^^ "\n") c
-
-let pp_args l =
-  l
-  |> List.map ~f:(Printf.sprintf "%S")
-  |> String.concat ~sep:"," |> Printf.sprintf "[%s]"
 
 let pp_time f =
   let n = int_of_float @@ (f *. 1_000_000.) in
@@ -80,32 +149,31 @@ let on_process_end t (id, name) =
     {|{"cat": "process", "name": %S, "id": %d, "pid": 0, "ph": "e", "ts": %s}|}
     name id (pp_time time)
 
-let gen_emit_counter t key pvalue value =
+let emit_counter t key values =
   let time = t.get_time () in
-  printf t
-    {|{"name": %S, "pid": 0, "tid": 0, "ph": "C", "ts": %s, "args": {%S: %a}}|}
-    key (pp_time time) "value" pvalue value
-
-let emit_counter t key value =
-  gen_emit_counter t key (Fun.const Int.to_string) value
-
-let emit_counter_float =
-  let float () f = Printf.sprintf "%.2f" f in
-  fun t key value -> gen_emit_counter t key float value
+  let values =
+    Buffer.clear t.buffer;
+    Json.to_buf (Json.Object values) t.buffer;
+    Buffer.contents t.buffer
+  in
+  printf t {|{"name": %S, "pid": 0, "tid": 0, "ph": "C", "ts": %s, "args": %s}|}
+    key (pp_time time) values
 
 let emit_gc_counters t =
   let stat = t.gc_stat () in
-  emit_counter t "live_words" stat.live_words;
-  emit_counter t "free_words" stat.free_words;
-  emit_counter t "stack_size" stat.stack_size;
-  emit_counter t "heap_words" stat.heap_words;
-  emit_counter t "top_heap_words" stat.top_heap_words;
-  emit_counter_float t "minor_words" stat.minor_words;
-  emit_counter_float t "major_words" stat.major_words;
-  emit_counter_float t "promoted_words" stat.promoted_words;
-  emit_counter t "compactions" stat.compactions;
-  emit_counter t "major_collections" stat.major_collections;
-  emit_counter t "minor_collections" stat.minor_collections
+  emit_counter t "gc"
+    [ ("live_words", Json.Int stat.live_words)
+    ; ("free_words", Int stat.free_words)
+    ; ("stack_size", Int stat.stack_size)
+    ; ("heap_words", Int stat.heap_words)
+    ; ("top_heap_words", Int stat.top_heap_words)
+    ; ("minor_words", Float stat.minor_words)
+    ; ("major_words", Float stat.major_words)
+    ; ("promoted_words", Float stat.promoted_words)
+    ; ("compactions", Int stat.compactions)
+    ; ("major_collections", Int stat.major_collections)
+    ; ("minor_collections", Int stat.minor_collections)
+    ]
 
 let next_id t =
   let r = t.next_id in
@@ -118,5 +186,8 @@ let on_process_start t ~program ~args =
   let time = t.get_time () in
   printf t
     {|{"cat": "process", "name": %S, "id": %d, "pid": 0, "ph": "b", "ts": %s, "args": %s}|}
-    name id (pp_time time) (pp_args args);
+    name id (pp_time time)
+    (* TODO: This looks at the very least un-idiomatic: [args] is normally an
+       object, but we have it as an array. *)
+    (Json.to_string (Array (List.map args ~f:(fun arg -> Json.String arg))));
   (id, name)

--- a/src/catapult/catapult.mli
+++ b/src/catapult/catapult.mli
@@ -1,5 +1,22 @@
-(** Output trace data to a file in catapult format. This format is compatible
-    with [chrome://tracing]. *)
+(** Output trace data to a file in Chrome's trace_event format. This format is
+    compatible with chrome trace viewer [chrome://tracing].
+
+    Trace viewer is a part of the catapult project
+    (https://github.com/catapult-project/catapult/blob/master/tracing/README.md).
+
+    The trace format is documented at:
+    https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview *)
+
+module Json : sig
+  (** Simplifies JSON type *)
+  type t =
+    | Int of int
+    | Float of float
+    | String of string
+    | Array of t list
+    | Bool of bool
+    | Object of (string * t) list
+end
 
 (** The (mutable) state of reporters. It is basically an output channel. *)
 type t
@@ -25,7 +42,7 @@ val on_process_start : t -> program:string -> args:string list -> event
 val on_process_end : t -> event -> unit
 
 (** Emit a counter event. This is measuring the value of an integer variable. *)
-val emit_counter : t -> string -> int -> unit
+val emit_counter : t -> string -> (string * Json.t) list -> unit
 
 (** Emit counter events for GC stats. *)
 val emit_gc_counters : t -> unit

--- a/src/dune_engine/stats.ml
+++ b/src/dune_engine/stats.ml
@@ -46,10 +46,13 @@ let catapult = ref None
 let record () =
   Option.iter !catapult ~f:(fun reporter ->
       Catapult.emit_gc_counters reporter;
-      Catapult.emit_counter reporter "evaluated-rules" !evaluated_rules;
+      Catapult.emit_counter reporter "evaluated-rules"
+        [ ("value", Catapult.Json.Int !evaluated_rules) ];
       match Fd_count.get () with
-      | This fds -> Catapult.emit_counter reporter "fds" fds
-      | Unknown -> ())
+      | Unknown -> ()
+      | This fds ->
+        Catapult.emit_counter reporter "fds"
+          [ ("value", Catapult.Json.Int fds) ])
 
 let enable path =
   let reporter = Catapult.make path in

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -16,17 +16,7 @@ This captures the commands that are being run:
 
 As well as data about the garbage collector:
 
-  $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/ [0-9]+/ .../g' | sort -u
-  {"name": "compactions", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "evaluated-rules", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "fds", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "free_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "heap_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "live_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "major_collections", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "major_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ....00}}
-  {"name": "minor_collections", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "minor_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ....00}}
-  {"name": "promoted_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ....00}}
-  {"name": "stack_size", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
-  {"name": "top_heap_words", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value": ...}}
+  $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/([^0-9])[0-9]+/\1.../g' | sort -u
+  {"name": "evaluated-rules", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value":...}}
+  {"name": "fds", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"value":...}}
+  {"name": "gc", "pid": ..., "tid": ..., "ph": "C", "ts": ..., "args": {"live_words":...,"free_words":...,"stack_size":...,"heap_words":...,"top_heap_words":...,"minor_words":....,"major_words":....,"promoted_words":....,"compactions":...,"major_collections":...,"minor_collections":...}}

--- a/test/expect-tests/catapult/catapult_tests.ml
+++ b/test/expect-tests/catapult/catapult_tests.ml
@@ -32,16 +32,6 @@ let%expect_test _ =
     {|
 [{"cat": "process", "name": "program", "id": 0, "pid": 0, "ph": "b", "ts": 10000000, "args": ["arg1","arg2"]}
 ,{"cat": "process", "name": "program", "id": 0, "pid": 0, "ph": "e", "ts": 30000000}
-,{"name": "live_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
-,{"name": "free_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
-,{"name": "stack_size", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
-,{"name": "heap_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
-,{"name": "top_heap_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
-,{"name": "minor_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0.00}}
-,{"name": "major_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0.00}}
-,{"name": "promoted_words", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0.00}}
-,{"name": "compactions", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
-,{"name": "major_collections", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
-,{"name": "minor_collections", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"value": 0}}
+,{"name": "gc", "pid": 0, "tid": 0, "ph": "C", "ts": 30000000, "args": {"live_words":0,"free_words":0,"stack_size":0,"heap_words":0,"top_heap_words":0,"minor_words":0.,"major_words":0.,"promoted_words":0.,"compactions":0,"major_collections":0,"minor_collections":0}}
 ]
 |}]


### PR DESCRIPTION
This allows us to record more than one time series at once.  Use this for the GC
stats.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>