### PR TITLE
Use Unix.create_process instead of fork

### DIFF
--- a/otherlibs/stdune-unstable/spawn.ml
+++ b/otherlibs/stdune-unstable/spawn.ml
@@ -1,25 +1,3 @@
-external sys_exit : int -> 'a = "caml_sys_exit"
-
-let rec file_descr_not_standard fd =
-  assert (not Sys.win32);
-  if (Obj.magic (fd : Unix.file_descr) : int) >= 3 then
-    fd
-  else
-    file_descr_not_standard (Unix.dup fd)
-
-let safe_close fd = try Unix.close fd with Unix.Unix_error _ -> ()
-
-let perform_redirections stdin stdout stderr =
-  let stdin = file_descr_not_standard stdin in
-  let stdout = file_descr_not_standard stdout in
-  let stderr = file_descr_not_standard stderr in
-  Unix.dup2 stdin Unix.stdin;
-  Unix.dup2 stdout Unix.stdout;
-  Unix.dup2 stderr Unix.stderr;
-  safe_close stdin;
-  safe_close stdout;
-  safe_close stderr
-
 (** Note that this function's behavior differs between windows and unix.
 
     - [Unix.create_process{,_env} prog] looks up prog in PATH
@@ -29,18 +7,6 @@ let spawn ?env ~prog ~argv ?(stdin = Unix.stdin) ?(stdout = Unix.stdout)
   let argv = Array.of_list argv in
   let env = Option.map ~f:Env.to_unix env in
   Pid.of_int
-    ( if Sys.win32 then
-      match env with
-      | None -> Unix.create_process prog argv stdin stdout stderr
-      | Some env -> Unix.create_process_env prog argv env stdin stdout stderr
-    else
-      match Unix.fork () with
-      | 0 -> (
-        try
-          ignore (Unix.sigprocmask SIG_SETMASK [] : int list);
-          perform_redirections stdin stdout stderr;
-          match env with
-          | None -> Unix.execv prog argv
-          | Some env -> Unix.execve prog argv env
-        with _ -> sys_exit 127 )
-      | pid -> pid )
+    ( match env with
+    | None -> Unix.create_process prog argv stdin stdout stderr
+    | Some env -> Unix.create_process_env prog argv env stdin stdout stderr )


### PR DESCRIPTION
In 4.12, create_process now uses posix_spawn instead of fork. Resulting
in some performance benefits. In my unscientific benchmarking, running
/bin/true in a loop of 1000 iterations is 1.37 vs. 1.82 seconds in favor
of create_process on a mac. The difference is likely smaller on Unix,
since forking on mac is quite slow.

In any case, we already get by without fork on Windows. So why not keep things
both consistent and fast by switching to create_process everywhere.