### PR TITLE
Ensure Dune can build itself in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -82,6 +82,9 @@ jobs:
       # away this makes it possible to see build errors as soon as possible
       - run: opam exec -- make dune.exe
 
+      # Ensure Dune can build itself
+      - run: opam exec -- ./dune.exe build -p dune --profile dune-bootstrap
+
       - name: run test suite
         run: opam exec -- ocaml .github/workflows/ci.ml test
         if: env.SKIP_TEST != 'true'


### PR DESCRIPTION
The testsuite is already failing on the 2.8 branch - this additional step fails the 4.08 and 4.09 test builds as well.

The problem doesn't show in the CI jobs which run tests because they install `ocamlfind`

Signed-off-by: David Allsopp <david.allsopp@metastack.com>