### PR TITLE
Make it easier to create lazy nodes with no cutoff

### DIFF
--- a/otherlibs/stdune-unstable/fdecl.ml
+++ b/otherlibs/stdune-unstable/fdecl.ml
@@ -28,3 +28,8 @@ let get t =
   match t.state with
   | Unset -> Code_error.raise "Fdecl.get: not set" []
   | Set x -> x
+
+let to_dyn t =
+  match t.state with
+  | Unset -> Dyn.Encoder.constr "Unset" []
+  | Set a -> Dyn.Encoder.constr "Set" [ t.to_dyn a ]

--- a/otherlibs/stdune-unstable/fdecl.mli
+++ b/otherlibs/stdune-unstable/fdecl.mli
@@ -18,3 +18,5 @@ val set_idempotent : equal:('a -> 'a -> bool) -> 'a t -> 'a -> unit
 (** [get t] returns the [x] if [set comp x] was called. Raises if [set] has not
     been called yet. *)
 val get : 'a t -> 'a
+
+val to_dyn : 'a t -> Dyn.t

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -313,7 +313,8 @@ module Lazy : sig
 
   val bind : 'a t -> f:('a -> 'b t) -> 'b t
 
-  val create : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a t
+  val create :
+    ?cutoff:('a -> 'a -> bool) -> ?to_dyn:('a -> Dyn.t) -> (unit -> 'a) -> 'a t
 
   val of_val : 'a -> 'a t
 
@@ -324,7 +325,11 @@ module Lazy : sig
 
     val of_val : 'a -> 'a t
 
-    val create : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a Build.t) -> 'a t
+    val create :
+         ?cutoff:('a -> 'a -> bool)
+      -> ?to_dyn:('a -> Dyn.t)
+      -> (unit -> 'a Build.t)
+      -> 'a t
 
     val force : 'a t -> 'a Build.t
 
@@ -332,10 +337,17 @@ module Lazy : sig
   end
 end
 
-val lazy_ : ?cutoff:('a -> 'a -> bool) -> (unit -> 'a) -> 'a Lazy.t
+val lazy_ :
+     ?cutoff:('a -> 'a -> bool)
+  -> ?to_dyn:('a -> Dyn.t)
+  -> (unit -> 'a)
+  -> 'a Lazy.t
 
 val lazy_async :
-  ?cutoff:('a -> 'a -> bool) -> (unit -> 'a Build.t) -> 'a Lazy.Async.t
+     ?cutoff:('a -> 'a -> bool)
+  -> ?to_dyn:('a -> Dyn.t)
+  -> (unit -> 'a Build.t)
+  -> 'a Lazy.Async.t
 
 module With_implicit_output : sig
   type ('i, 'o, 'f) t


### PR DESCRIPTION
As a follow up to #4305, we are making it easier to create nodes with no cutoff, since they can be treated more efficiently.