### PR TITLE
Move terminal persistence out of scheduler

### DIFF
--- a/bench/dune_bench/scheduler_bench.ml
+++ b/bench/dune_bench/scheduler_bench.ml
@@ -3,12 +3,7 @@
 open Stdune
 open Dune_engine
 
-let config =
-  { Scheduler.Config.concurrency = 1
-  ; terminal_persistence = Preserve
-  ; display = Short
-  ; rpc = None
-  }
+let config = { Scheduler.Config.concurrency = 1; display = Short; rpc = None }
 
 let setup =
   lazy

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -568,7 +568,7 @@ let term =
           [ "debug-artifact-substitution" ]
           ~docs ~doc:"Print debugging info about artifact substitution")
   and+ terminal_persistence =
-    let modes = Dune_engine.Scheduler.Config.Terminal_persistence.all in
+    let modes = Dune_config.Terminal_persistence.all in
     let doc =
       let f s = fst s |> Printf.sprintf "$(b,%s)" in
       Printf.sprintf

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -48,14 +48,21 @@ module Caching : sig
   end
 end
 
+module Terminal_persistence : sig
+  type t =
+    | Preserve
+    | Clear_on_rebuild
+
+  val all : (string * t) list
+end
+
 module type S = sig
   type 'a field
 
   type t =
     { display : Dune_engine.Scheduler.Config.Display.t field
     ; concurrency : Concurrency.t field
-    ; terminal_persistence :
-        Dune_engine.Scheduler.Config.Terminal_persistence.t field
+    ; terminal_persistence : Terminal_persistence.t field
     ; sandboxing_preference : Sandboxing_preference.t field
     ; cache_mode : Caching.Mode.t field
     ; cache_transport : Caching.Transport.t field

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -6,14 +6,6 @@ open Import
 module Config = struct
   include Config
 
-  module Terminal_persistence = struct
-    type t =
-      | Preserve
-      | Clear_on_rebuild
-
-    let all = [ ("preserve", Preserve); ("clear-on-rebuild", Clear_on_rebuild) ]
-  end
-
   module Display = struct
     type t =
       | Progress
@@ -53,7 +45,6 @@ module Config = struct
 
   type t =
     { concurrency : int
-    ; terminal_persistence : Terminal_persistence.t
     ; display : Display.t
     ; rpc : Rpc.t option
     }

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -4,14 +4,6 @@ open! Import
 open Stdune
 
 module Config : sig
-  module Terminal_persistence : sig
-    type t =
-      | Preserve
-      | Clear_on_rebuild
-
-    val all : (string * t) list
-  end
-
   module Display : sig
     type t =
       | Progress  (** Single interactive status line *)
@@ -38,7 +30,6 @@ module Config : sig
 
   type t =
     { concurrency : int
-    ; terminal_persistence : Terminal_persistence.t
     ; display : Display.t
     ; rpc : Rpc.t option
     }

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -116,11 +116,7 @@ let run kind script =
   Path.mkdir_p temp_dir;
   let vcs = { Vcs.kind; root = temp_dir } in
   let config =
-    { Scheduler.Config.concurrency = 1
-    ; terminal_persistence = Preserve
-    ; display = Short
-    ; rpc = None
-    }
+    { Scheduler.Config.concurrency = 1; display = Short; rpc = None }
   in
   Scheduler.Run.go
     ~on_event:(fun _ _ -> ())


### PR DESCRIPTION
It's no longer required now that we manage screen clearing outside of
scheduler.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>