### PR TITLE
Specify conventional profile in .ocamlformat config

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,5 @@
 version=0.17.0
+profile=conventional
 break-separators=before
 dock-collection-brackets=false
 break-sequences=true


### PR DESCRIPTION
I've had this diff sitting around unstaged for some time, and finally decided to PR it. In short:

> The `conventional` profile is default for fresh installations of OCamlFormat, but is override-able via a global config file inside `$XDG_CONFIG_HOME. To ensure that formatting is reproducible on a per-project basis, it's necessary to override any settings in this global file.

I've had some issues with new contributors to projects accidentally reformatting the project due to this behaviour, so at some point decided to defend against it; perhaps this will avoid some grief here too :-)

A potential change to the semantics of global config files is tracked by [this issue](https://github.com/ocaml-ppx/ocamlformat/issues/1459).