### PR TITLE
Add support for anonymous actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -96,6 +96,21 @@ Unreleased
 
 - Fix dune crash when `subdir` is an absolute path (#4366, @anmonteiro)
 
+- Changed the implementation of actions attached to aliases, as in
+  `(rule (alias runtest) (action (run ./test)))`. A visible result for
+  users is that such actions are not memoized for longer. For
+  instance:
+  ```
+  $ echo '(rule (alias runtest) (action (echo "X=%{env:X=0}\n")))` > dune
+  $ X=1 dune runtest
+  X=1
+  $ X=2 dune runtest
+  X=2
+  $ X=1 dune runtest
+  ```
+  Previously, Dune would have re-executed the action again at the last
+  line. Now it remembers the result of the first execution.
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/bin/util.ml
+++ b/bin/util.ml
@@ -45,5 +45,6 @@ let check_path contexts =
       match Dune_engine.Dpath.analyse_target path with
       | Other _ -> internal_path ()
       | Alias (_, _) -> internal_path ()
+      | Anonymous_action _ -> internal_path ()
       | Install (name, src) -> In_install_dir (context_exn name, src)
       | Regular (name, src) -> In_build_dir (context_exn name, src))

--- a/otherlibs/action-plugin/test/one-undeclared-target/run.t
+++ b/otherlibs/action-plugin/test/one-undeclared-target/run.t
@@ -12,6 +12,10 @@
   $ cp ./bin/foo.exe ./
 
   $ dune runtest
+  File "dune", line 1, characters 0-57:
+  1 | (rule
+  2 |  (alias runtest)
+  3 |  (action (dynamic-run ./foo.exe)))
            foo alias runtest (exit 1)
   (cd _build/default && ./foo.exe)
   bar is written despite not being declared as a target in dune file. To fix, add it to target list in dune file.

--- a/otherlibs/stdune-unstable/env.ml
+++ b/otherlibs/stdune-unstable/env.ml
@@ -106,3 +106,5 @@ let path env =
   match get env "PATH" with
   | None -> []
   | Some s -> Bin.parse_path s
+
+let to_map t = t.vars

--- a/otherlibs/stdune-unstable/env.mli
+++ b/otherlibs/stdune-unstable/env.mli
@@ -45,6 +45,8 @@ val to_dyn : t -> Dyn.t
 
 val of_string_map : string String.Map.t -> t
 
+val to_map : t -> string Map.t
+
 val iter : t -> f:(string -> string -> unit) -> unit
 
 val cons_path : t -> dir:Path.t -> t

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -149,10 +149,6 @@ let name t = t.name
 
 let dir t = t.dir
 
-let stamp_file_dir t =
-  let local = Path.Build.local t.dir in
-  Path.Build.append_local Dpath.Build.alias_dir local
-
 let fully_qualified_name t = Path.Build.relative t.dir (Name.to_string t.name)
 
 (* This mutable table is safe: it's modified only at the top level. *)

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -43,8 +43,6 @@ val name : t -> Name.t
 
 val dir : t -> Path.Build.t
 
-val stamp_file_dir : t -> Path.Build.t
-
 val to_dyn : t -> Dyn.t
 
 val encode : t Dune_lang.Encoder.t

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -94,6 +94,8 @@ module Set : sig
 
   val of_list_map : 'a list -> f:('a -> dep) -> t
 
+  val fold : t -> init:'a -> f:(dep -> 'a -> 'a) -> 'a
+
   (** Return dependencies on all source files under a certain source directory.
 
       Dependency on a source_tree requires special care for empty directory, so
@@ -115,4 +117,6 @@ module Set : sig
   val encode : t -> Dune_lang.t
 
   val add_paths : t -> Path.Set.t -> t
+
+  val digest : t -> Digest.t
 end

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -9,7 +9,7 @@ module Target_dir : sig
 
   type t =
     | Install of context_related
-    | Alias of context_related
+    | Anonymous_action of context_related
     | Regular of context_related
     | Invalid of Path.Build.t
 
@@ -19,6 +19,7 @@ end
 type target_kind =
   | Regular of Context_name.t * Path.Source.t
   | Alias of Context_name.t * Path.Source.t
+  | Anonymous_action of Context_name.t
   | Install of Context_name.t * Path.Source.t
   | Other of Path.Build.t
 
@@ -54,9 +55,7 @@ module Build : sig
 
   val install_dir : t
 
-  val alias_dir : t
-
-  val is_alias_stamp_file : t -> bool
+  val anonymous_actions_dir : t
 end
 
 module External : sig

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -293,6 +293,10 @@ module Fancy = struct
           | Install (ctx, name) ->
             split_paths
               (("install " ^ Path.Source.to_string name) :: targets_acc)
+              (add_ctx ctx ctxs_acc) rest
+          | Anonymous_action ctx ->
+            split_paths
+              ("(internal)" :: targets_acc)
               (add_ctx ctx ctxs_acc) rest)
       in
       let targets = Path.Build.Set.to_list targets in

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -3,28 +3,14 @@ open! Stdune
 module Id = Id.Make ()
 
 module Dir_rules = struct
-  type alias_action =
-    { stamp : Digest.t
-    ; action : Action.t Action_builder.With_targets.t
-    ; locks : Path.t list
-    ; context : Build_context.t
-    ; env : Env.t option
-    ; loc : Loc.t option
-    }
-
   module Alias_spec = struct
-    type t =
-      { expansions : (Loc.t * unit Action_builder.t) Appendable_list.t
-      ; actions : alias_action Appendable_list.t
-      }
+    type t = { expansions : (Loc.t * unit Action_builder.t) Appendable_list.t }
+    [@@unboxed]
 
-    let empty =
-      { expansions = Appendable_list.empty; actions = Appendable_list.empty }
+    let empty = { expansions = Appendable_list.empty }
 
     let union x y =
-      { expansions = Appendable_list.( @ ) x.expansions y.expansions
-      ; actions = Appendable_list.( @ ) x.actions y.actions
-      }
+      { expansions = Appendable_list.( @ ) x.expansions y.expansions }
   end
 
   type alias =
@@ -155,32 +141,25 @@ module Produce = struct
            (Dir_rules.Nonempty.singleton (Alias { name; spec })))
 
     let add_deps t ?(loc = Loc.none) expansion =
-      alias t
-        { expansions = Appendable_list.singleton (loc, expansion)
-        ; actions = Appendable_list.empty
-        }
+      alias t { expansions = Appendable_list.singleton (loc, expansion) }
 
     let add_static_deps t ?(loc = Loc.none) deps =
       let expansion = Action_builder.deps (Dep.Set.of_files_set deps) in
-      alias t
-        { expansions = Appendable_list.singleton (loc, expansion)
-        ; actions = Appendable_list.empty
-        }
+      alias t { expansions = Appendable_list.singleton (loc, expansion) }
 
-    let add_action t ~context ~env ~loc ?(locks = []) ~stamp action =
-      alias t
-        { expansions = Appendable_list.empty
-        ; actions =
-            Appendable_list.singleton
-              ({ stamp = Digest.generic stamp
-               ; action
-               ; locks
-               ; context
-               ; loc
-               ; env
-               }
-                : Dir_rules.alias_action)
-        }
+    let add_action t ~context ~env ~loc ?(locks = []) action =
+      add_deps t ?loc
+        (Action_builder.action
+           (let open Action_builder.O in
+           let+ action = action in
+           { Action_builder.Action_desc.context = Some context
+           ; env
+           ; action
+           ; locks
+           ; loc
+           ; dir = Alias.dir t
+           ; alias = Some (Alias.name t)
+           }))
   end
 end
 

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -10,20 +10,9 @@ module Dir_rules : sig
 
   val union : t -> t -> t
 
-  type alias_action =
-    { stamp : Digest.t
-    ; action : Action.t Action_builder.With_targets.t
-    ; locks : Path.t list
-    ; context : Build_context.t
-    ; env : Env.t option
-    ; loc : Loc.t option
-    }
-
   module Alias_spec : sig
-    type t =
-      { expansions : (Loc.t * unit Action_builder.t) Appendable_list.t
-      ; actions : alias_action Appendable_list.t
-      }
+    type t = { expansions : (Loc.t * unit Action_builder.t) Appendable_list.t }
+    [@@unboxed]
   end
 
   (** A ready to process view of the rules of a directory *)
@@ -82,8 +71,7 @@ module Produce : sig
       -> env:Env.t option
       -> loc:Loc.t option
       -> ?locks:Path.t list
-      -> stamp:_
-      -> Action.t Action_builder.With_targets.t
+      -> Action.t Action_builder.t
       -> unit
   end
 end

--- a/src/dune_rules/action_unexpanded.mli
+++ b/src/dune_rules/action_unexpanded.mli
@@ -31,6 +31,16 @@ val expand :
   -> loc:Loc.t
   -> deps:Dep_conf.t Bindings.t
   -> targets_dir:Path.Build.t
-  -> targets:Targets.Or_forbidden.t
+  -> targets:Path.Build.t Targets.t
   -> expander:Expander.t
   -> Action.t Action_builder.With_targets.t
+
+(** [what] as the same meaning as the argument of
+    [Expander.Expanding_what.User_action_without_targets] *)
+val expand_no_targets :
+     t
+  -> loc:Loc.t
+  -> deps:Dep_conf.t Bindings.t
+  -> expander:Expander.t
+  -> what:string
+  -> Action.t Action_builder.t

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -127,9 +127,7 @@ let gen_rules sctx t ~dir ~scope =
   in
   let cinaps_alias = alias ~dir in
   let+ () =
-    Super_context.add_alias_action sctx ~dir ~loc:(Some loc) ~stamp:name
-      cinaps_alias
-      (Action_builder.with_no_targets action)
+    Super_context.add_alias_action sctx ~dir ~loc:(Some loc) cinaps_alias action
   in
   Rules.Produce.Alias.add_deps (Alias.runtest ~dir)
     (Action_builder.alias cinaps_alias)

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -58,7 +58,11 @@ module Expanding_what : sig
   type t =
     | Nothing_special
     | Deps_like_field
-    | User_action of Targets.Or_forbidden.t
+    | User_action of Path.Build.t Targets.t
+    | User_action_without_targets of { what : string }
+        (** [what] describe what the action is. It should be a plural and is
+            inserted in a sentence as follow: "<what> are not allowed to have
+            targets" *)
 end
 
 (** Used to improve error messages and handing special cases, such as:

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -5,10 +5,8 @@ let add_diff sctx loc alias ~dir ~input ~output =
   let open Action_builder.O in
   let action = Action.Chdir (Path.build dir, Action.diff input output) in
   Super_context.add_alias_action sctx alias ~dir ~loc:(Some loc) ~locks:[]
-    ~stamp:input
-    (Action_builder.with_no_targets
-       (Action_builder.paths [ input; Path.build output ]
-       >>> Action_builder.return action))
+    (Action_builder.paths [ input; Path.build output ]
+    >>> Action_builder.return action)
 
 let rec subdirs_until_root dir =
   match Path.parent dir with
@@ -69,8 +67,8 @@ let gen_rules_output sctx (config : Format_config.t) ~version ~dialects
         in
         let open Action_builder.With_targets.O in
         Action_builder.with_no_targets extra_deps
-        >>> Preprocessing.action_for_pp ~loc ~expander ~action ~src
-              ~target:(Some output)
+        >>> Preprocessing.action_for_pp_with_target ~loc ~expander ~action ~src
+              ~target:output
     in
     Memo.Build.Option.iter formatter ~f:(fun action ->
         let open Memo.Build.O in

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -210,8 +210,7 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog src =
   (* Attach the diff action to the @runtest for the src and corrected files *)
   let diff_action = Files.diff_action files in
   Super_context.add_alias_action sctx (Alias.runtest ~dir) ~loc:(Some loc) ~dir
-    ~stamp:("mdx", files.src)
-    (Action_builder.with_no_targets diff_action)
+    diff_action
 
 (** Generates the rules for a given mdx stanza *)
 let gen_rules t ~sctx ~dir ~expander =

--- a/src/dune_rules/per_item.ml
+++ b/src/dune_rules/per_item.ml
@@ -38,9 +38,9 @@ module Make (Key : Map.Key) : Per_item_intf.S with type key = Key.t = struct
 
   let is_constant t = Array.length t.values = 1
 
-  let map_with_targets { map; values } ~f =
-    let open Action_builder.With_targets.O in
+  let map_action_builder { map; values } ~f =
+    let open Action_builder.O in
     let l = Array.to_list values in
-    let+ new_values = List.map l ~f |> Action_builder.With_targets.all in
+    let+ new_values = List.map l ~f |> Action_builder.all in
     { map; values = Array.of_list new_values }
 end

--- a/src/dune_rules/per_item_intf.ml
+++ b/src/dune_rules/per_item_intf.ml
@@ -25,8 +25,6 @@ module type S = sig
 
   val exists : 'a t -> f:('a -> bool) -> bool
 
-  val map_with_targets :
-       'a t
-    -> f:('a -> 'b Action_builder.With_targets.t)
-    -> 'b t Action_builder.With_targets.t
+  val map_action_builder :
+    'a t -> f:('a -> 'b Action_builder.t) -> 'b t Action_builder.t
 end

--- a/src/dune_rules/preprocessing.mli
+++ b/src/dune_rules/preprocessing.mli
@@ -31,12 +31,12 @@ val gen_rules : Super_context.t -> string list -> unit Memo.Build.t
 
 val chdir : Action_unexpanded.t -> Action_unexpanded.t
 
-val action_for_pp :
+val action_for_pp_with_target :
      loc:Loc.t
   -> expander:Expander.t
   -> action:Action_unexpanded.t
   -> src:Path.Build.t
-  -> target:Path.Build.t option
+  -> target:Path.Build.t
   -> Action.t Action_builder.With_targets.t
 
 val ppx_exe :

--- a/src/dune_rules/simple_rules.mli
+++ b/src/dune_rules/simple_rules.mli
@@ -9,17 +9,15 @@ module Alias_rules : sig
   val add :
        Super_context.t
     -> alias:Alias.t
-    -> stamp:'a
     -> loc:Loc.t option
     -> locks:Path.t list
-    -> Action.t Action_builder.With_targets.t
+    -> Action.t Action_builder.t
     -> unit Memo.Build.t
 
   val add_empty :
        Super_context.t
     -> loc:Stdune.Loc.t option
     -> alias:Alias.t
-    -> stamp:'a
     -> unit Memo.Build.t
 end
 

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -336,11 +336,11 @@ let add_rule_get_targets t ?sandbox ?mode ?locks ?loc ~dir build =
 let add_rules t ?sandbox ~dir builds =
   Memo.Build.parallel_iter builds ~f:(add_rule t ?sandbox ~dir)
 
-let add_alias_action t alias ~dir ~loc ?locks ~stamp action =
+let add_alias_action t alias ~dir ~loc ?locks action =
   let+ env = get_node t.env_tree ~dir >>= Env_node.external_env in
   Rules.Produce.Alias.add_action
     ~context:(Context.build_context t.context)
-    ~env:(Some env) alias ~loc ?locks ~stamp action
+    ~env:(Some env) alias ~loc ?locks action
 
 let build_dir_is_vendored build_dir =
   match Path.Build.drop_build_context build_dir with

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -136,8 +136,7 @@ val add_alias_action :
   -> dir:Path.Build.t
   -> loc:Loc.t option
   -> ?locks:Path.t list
-  -> stamp:_
-  -> Action.t Action_builder.With_targets.t
+  -> Action.t Action_builder.t
   -> unit Memo.Build.t
 
 (** [resolve_program t ?hint name] resolves a program. [name] is looked up in

--- a/src/dune_rules/targets.ml
+++ b/src/dune_rules/targets.ml
@@ -34,12 +34,6 @@ type 'a t =
   | Static of 'a Static.t
   | Infer
 
-module Or_forbidden = struct
-  type nonrec t =
-    | Forbidden of string
-    | Targets of Path.Build.t t
-end
-
 let decode_static =
   let open Dune_lang.Decoder in
   let+ syntax_version = Dune_lang.Syntax.get_exn Stanza.syntax

--- a/src/dune_rules/targets.mli
+++ b/src/dune_rules/targets.mli
@@ -25,13 +25,5 @@ type 'a t =
   | Static of 'a Static.t
   | Infer
 
-module Or_forbidden : sig
-  (** In some situations, actions may not have targets. [Forbidden _] is used to
-      denote that *)
-  type nonrec t =
-    | Forbidden of string
-    | Targets of Path.Build.t t
-end
-
 (** target or targets with field with the correct multiplicity *)
 val field : String_with_vars.t t Dune_lang.Decoder.fields_parser

--- a/test/blackbox-tests/test-cases/cinaps/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/cinaps/simple.t/run.t
@@ -26,6 +26,9 @@ The cinaps actions should be attached to the runtest alias:
 but also to the cinaps alias:
 
   $ dune build @cinaps --diff-command diff 2>&1 | sed -E 's/[^ ]+sh/\$sh/'
+  File "dune", line 1, characters 0-21:
+  1 | (cinaps (files *.ml))
+      ^^^^^^^^^^^^^^^^^^^^^
             sh (internal) (exit 1)
   (cd _build/default && $sh -c 'diff test.ml test.ml.cinaps-corrected')
   1a2

--- a/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
@@ -10,8 +10,7 @@
   -> required by a/a.vo
   -> required by install lib/coq/user-contrib/a/a.vo
   -> required by ccycle.install
-  -> required by alias default
-  -> required by alias default
+  -> required by alias default in dune:1
   File "b/dune", line 2, characters 7-8:
   2 |  (name b)
              ^
@@ -23,6 +22,5 @@
   -> required by b/b.vo
   -> required by install lib/coq/user-contrib/b/b.vo
   -> required by ccycle.install
-  -> required by alias default
-  -> required by alias default
+  -> required by alias default in dune:1
   [1]

--- a/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
@@ -7,6 +7,5 @@
   -> required by b/b.vo
   -> required by install lib/coq/user-contrib/b/b.vo
   -> required by cvendor.install
-  -> required by alias default
-  -> required by alias default
+  -> required by alias default in dune:1
   [1]

--- a/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
@@ -8,6 +8,5 @@
   -> required by public/b.vo
   -> required by install lib/coq/user-contrib/public/b.vo
   -> required by public.install
-  -> required by alias default
-  -> required by alias default
+  -> required by alias default in dune:1
   [1]

--- a/test/blackbox-tests/test-cases/env/env-tracking.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-tracking.t/run.t
@@ -21,7 +21,4 @@ But if there is a dependency, the alias gets rebuilt:
 This only happens for tracked variables:
 
   $ dune build @with_dep
-             a alias with_dep
-  X is not set
-  Y is not set
   $ Y=y dune build @with_dep

--- a/test/blackbox-tests/test-cases/env/env-var-expansion.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-var-expansion.t/run.t
@@ -32,7 +32,6 @@ incrementality works properly, that (setenv ...) is taken into account, etc.
   Entering directory 'correct'
   $ DUNE_ENV_VAR=true dune build --root correct @echo1
   Entering directory 'correct'
-  true
 
 This test is broken because previous/new values should differ in these tests. In
 the dune file, the environment variable ends up being set locally, but this

--- a/test/blackbox-tests/test-cases/executables-implicit-empty-intf.t/run.t
+++ b/test/blackbox-tests/test-cases/executables-implicit-empty-intf.t/run.t
@@ -20,6 +20,9 @@ by Dune:
 as will test binaries:
 
   $ dune runtest
+  File "test/dune", line 2, characters 7-11:
+  2 |  (name test))
+             ^^^^
   File "test/test.ml", line 1, characters 4-10:
   1 | let unused = 1
           ^^^^^^

--- a/test/blackbox-tests/test-cases/formatting.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting.t/run.t
@@ -30,21 +30,6 @@ Formatting can be checked using the @fmt target:
   >  (enabled_for ocaml))
   > EOF
   $ dune build @fmt
-  File "enabled/dune", line 1, characters 0-0:
-  Error: Files _build/default/enabled/dune and
-  _build/default/enabled/.formatted/dune differ.
-  File "enabled/ocaml_file.ml", line 1, characters 0-0:
-  Error: Files _build/default/enabled/ocaml_file.ml and
-  _build/default/enabled/.formatted/ocaml_file.ml differ.
-  File "enabled/ocaml_file.mli", line 1, characters 0-0:
-  Error: Files _build/default/enabled/ocaml_file.mli and
-  _build/default/enabled/.formatted/ocaml_file.mli differ.
-  File "enabled/reason_file.re", line 1, characters 0-0:
-  Error: Files _build/default/enabled/reason_file.re and
-  _build/default/enabled/.formatted/reason_file.re differ.
-  File "enabled/reason_file.rei", line 1, characters 0-0:
-  Error: Files _build/default/enabled/reason_file.rei and
-  _build/default/enabled/.formatted/reason_file.rei differ.
   File "enabled/subdir/dune", line 1, characters 0-0:
   Error: Files _build/default/enabled/subdir/dune and
   _build/default/enabled/subdir/.formatted/dune differ.
@@ -63,6 +48,21 @@ Formatting can be checked using the @fmt target:
   File "partial/a.ml", line 1, characters 0-0:
   Error: Files _build/default/partial/a.ml and
   _build/default/partial/.formatted/a.ml differ.
+  File "enabled/dune", line 1, characters 0-0:
+  Error: Files _build/default/enabled/dune and
+  _build/default/enabled/.formatted/dune differ.
+  File "enabled/ocaml_file.ml", line 1, characters 0-0:
+  Error: Files _build/default/enabled/ocaml_file.ml and
+  _build/default/enabled/.formatted/ocaml_file.ml differ.
+  File "enabled/ocaml_file.mli", line 1, characters 0-0:
+  Error: Files _build/default/enabled/ocaml_file.mli and
+  _build/default/enabled/.formatted/ocaml_file.mli differ.
+  File "enabled/reason_file.re", line 1, characters 0-0:
+  Error: Files _build/default/enabled/reason_file.re and
+  _build/default/enabled/.formatted/reason_file.re differ.
+  File "enabled/reason_file.rei", line 1, characters 0-0:
+  Error: Files _build/default/enabled/reason_file.rei and
+  _build/default/enabled/.formatted/reason_file.rei differ.
   [1]
 
 Configuration files are taken into account for this action:

--- a/test/blackbox-tests/test-cases/github3490.t/run.t
+++ b/test/blackbox-tests/test-cases/github3490.t/run.t
@@ -21,4 +21,7 @@ the test suite; but we do not need to print it so we can grep it out
 (redirecting stderr to /dev/null would also silence the stack overflow message).
 
   $ dune runtest --diff-command 'diff -u' 2>&1 | grep -v + | grep -v diff | grep -v "^--- test"
+  File "dune", line 4, characters 0-60:
+  4 | (rule
+  5 |  (alias runtest)
             sh (internal) (exit 1)

--- a/test/blackbox-tests/test-cases/inline_tests/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/simple.t/run.t
@@ -24,6 +24,9 @@
   > EOF
 
   $ env -u OCAMLRUNPARAM dune runtest
+  File "dune", line 9, characters 1-40:
+  9 |  (inline_tests (backend backend_simple)))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   inline_test_runner_foo_simple alias runtest (exit 2)
   (cd _build/default && .foo_simple.inline-tests/inline_test_runner_foo_simple.exe)
   Fatal error: exception File ".foo_simple.inline-tests/inline_test_runner_foo_simple.ml-gen", line 1, characters 40-46: Assertion failed
@@ -37,6 +40,9 @@ The expected behavior for the following three tests is to output nothing: the te
   $ env -u OCAMLRUNPARAM dune runtest --profile ignore-inline-tests
 
   $ env -u OCAMLRUNPARAM dune runtest --profile enable-inline-tests
+  File "dune", line 9, characters 1-40:
+  9 |  (inline_tests (backend backend_simple)))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   inline_test_runner_foo_simple alias runtest (exit 2)
   (cd _build/default && .foo_simple.inline-tests/inline_test_runner_foo_simple.exe)
   Fatal error: exception File ".foo_simple.inline-tests/inline_test_runner_foo_simple.ml-gen", line 1, characters 40-46: Assertion failed

--- a/test/blackbox-tests/test-cases/link-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/link-deps.t/run.t
@@ -4,11 +4,8 @@ In particular, these can depend on the result of the compilation (like a .cmo
 file) and be created just before linking.
 
   $ dune build link_deps.exe
-  File "dune", line 1, characters 0-105:
-  1 | (alias
-  2 |   (name message)
-  3 |   (deps .link_deps.eobjs/.byte_objs/link_deps.cmo)
-  4 |   (action (echo "link\n"))
-  5 |   )
+  File "dune", line 8, characters 8-17:
+  8 |   (name link_deps)
+              ^^^^^^^^^
   Error: No rule found for .link_deps.eobjs/.byte_objs/link_deps.cmo
   [1]

--- a/test/blackbox-tests/test-cases/output-obj.t/run.t
+++ b/test/blackbox-tests/test-cases/output-obj.t/run.t
@@ -1,12 +1,12 @@
   $ dune build @all
   $ dune build @runtest 2>&1 | dune_cmd sanitize
         static alias runtest
+  OK: ./static.exe
+        static alias runtest
   OK: ./static.bc
        dynamic alias runtest
-  OK: ./dynamic.exe ./test$ext_dll
-       dynamic alias runtest
   OK: ./dynamic.exe ./test.bc$ext_dll
-        static alias runtest
-  OK: ./static.exe
+       dynamic alias runtest
+  OK: ./dynamic.exe ./test$ext_dll
 #        static alias runtest
 #  OK: ./static.bc.c.exe

--- a/test/blackbox-tests/test-cases/private-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/private-modules.t/run.t
@@ -5,6 +5,10 @@
 
   $ dune build --root inaccessible-in-deps 2>&1
   Entering directory 'inaccessible-in-deps'
+  File "dune", line 5, characters 0-49:
+  5 | (alias
+  6 |  (name default)
+  7 |  (action (run ./foo.exe)))
   File "foo.ml", line 1, characters 0-5:
   1 | X.run ();;
       ^^^^^

--- a/test/blackbox-tests/test-cases/report-all-errors.t
+++ b/test/blackbox-tests/test-cases/report-all-errors.t
@@ -49,8 +49,22 @@ failing before it had a chance to start thinking about building `z`.
   $ echo 'exit 1' > fail.ml
 
   $ dune build
+  File "dune", line 1, characters 0-73:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action
+  4 |   (progn
+  5 |    (cat %{read:x})
+  6 |    (cat y))))
           fail y (exit 1)
   (cd _build/default && ./fail.exe) > _build/default/y
+  File "dune", line 1, characters 0-73:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action
+  4 |   (progn
+  5 |    (cat %{read:x})
+  6 |    (cat y))))
           fail z (exit 1)
   (cd _build/default && ./fail.exe) > _build/default/z
   [1]

--- a/test/blackbox-tests/test-cases/shadow-bindings.t/run.t
+++ b/test/blackbox-tests/test-cases/shadow-bindings.t/run.t
@@ -1,5 +1,5 @@
 Bindings introduced by user dependencies should shadow existing bindings
 
   $ dune runtest
-  xb
   foo
+  xb

--- a/test/blackbox-tests/test-cases/tests-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza.t/run.t
@@ -5,10 +5,10 @@
 
   $ dune runtest --root plural
   Entering directory 'plural'
-  regular_test2 alias runtest
-  regular test2
   regular_test alias runtest
   regular test
+  regular_test2 alias runtest
+  regular test2
   $ dune runtest --root generated
   Entering directory 'generated'
   File "generated.expected", line 1, characters 0-0:

--- a/test/blackbox-tests/test-cases/virtual-libraries/double-implementation.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/double-implementation.t/run.t
@@ -1,10 +1,13 @@
 Executable that tries to use two implementations for the same virtual lib
   $ dune build
+  File "dune", line 11, characters 0-49:
+  11 | (alias
+  12 |  (name default)
+  13 |  (action (run ./foo.exe)))
   Error: Conflicting implementations for virtual library "vlib" in
   _build/default/vlib:
   - "impl1" in _build/default/impl1
     -> required by library "bar" in _build/default
   - "impl2" in _build/default/impl2
   This cannot work.
-  -> required by executable foo in dune:2
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/missing-implementation.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/missing-implementation.t/run.t
@@ -1,6 +1,9 @@
 Executable that tries to build against a virtual library without an implementation
   $ dune build
+  File "dune", line 5, characters 0-49:
+  5 | (alias
+  6 |  (name default)
+  7 |  (action (run ./foo.exe)))
   Error: No implementation found for virtual library "vlib" in
   _build/default/vlib.
-  -> required by executable foo in dune:2
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-wrong-default-impl.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-wrong-default-impl.t/run.t
@@ -2,6 +2,11 @@ Check that dune makes a proper error if the default implementation of a virtual
 library is not actually an implementation of the virtual library.
 
   $ dune build @default
+  File "exe/dune", line 5, characters 0-49:
+  5 | (rule
+  6 |  (alias default)
+  7 |  (action (run ./exe.exe)))
+  Error: "not_an_implem" is not an implementation of "vlibfoo".
   Error: "not_an_implem" is not an implementation of "vlibfoo".
   -> required by executable exe in exe/dune:2
   [1]

--- a/test/blackbox-tests/test-cases/windows-diff.t/run.t
+++ b/test/blackbox-tests/test-cases/windows-diff.t/run.t
@@ -14,5 +14,9 @@
   Hello, world!
 
   $ dune build @cmp
+  File "dune", line 12, characters 0-41:
+  12 | (alias
+  13 |  (name   cmp)
+  14 |  (action (cmp a b)))
   Error: Files _build/default/a and _build/default/b differ.
   [1]

--- a/test/blackbox-tests/test-cases/with-exit-codes.t/run.t
+++ b/test/blackbox-tests/test-cases/with-exit-codes.t/run.t
@@ -20,6 +20,10 @@
         ocamlc .exit.eobjs/byte/dune__exe__Exit.{cmi,cmo,cmt}
       ocamlopt .exit.eobjs/native/dune__exe__Exit.{cmx,o}
       ocamlopt exit.exe
+  File "dune", line 5, characters 0-75:
+  5 | (rule
+  6 |  (alias a)
+  7 |  (action (with-accepted-exit-codes 0 (run ./exit.exe 1))))
           exit alias a (exit 1)
   (cd _build/default && ./exit.exe 1)
   [1]
@@ -46,6 +50,10 @@
           exit alias c
 
   $ dune build --display=short --root . @d
+  File "dune", line 14, characters 0-84:
+  14 | (rule
+  15 |  (alias d)
+  16 |  (action (with-accepted-exit-codes (or 4 5 6) (run ./exit.exe 7))))
           exit alias d (exit 7)
   (cd _build/default && ./exit.exe 7)
   [1]

--- a/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
@@ -1,4 +1,8 @@
   $ dune build 2>&1 | grep -v ocamlc
+  File "dune", line 5, characters 0-52:
+  5 | (alias
+  6 |  (name default)
+  7 |  (action (run ./fooexe.exe)))
   File "fooexe.ml", line 3, characters 0-7:
   3 | Bar.run ();;
       ^^^^^^^


### PR DESCRIPTION
This PR adds support for "anymous actions". These are actions we can execute as part of the `Action_builder` monad without having to set up a full blown rule with targets.

There are two use cases for such actions:
- running a test
- capture the output of a command to compute part of another action (typically: ocamldep)

I re-implemented `Rules.Produce.Alias.add_action` using this feature, which both simplified a lot of a code and added locations to a lot of errors in the testsuite :tada: This change caused me to change the type of the argument of `add_action` from `Action.t Action_builder.With_target.t` to `Action.t Action_builder.t`, which caused a few changes in the code base.

## How are anonymous actions implemented?

We construct a rule on the fly that:

- run the anonymous action and then create a stamp file
- if we want to capture the ouptput, run the anonymous action redirecting its output to the stamp file

In both cases, the stamp file is of the form:

```
_build/.actions/<dir>/<digest>
```

or, if the actions is attached to an alias:

```
_build/.actions/<dir>/<alias>-<digest>
```

The latter format is purely for informative purposes, so that we can provide a better description of such internal pathes. `<digest>` is a digest of:

- the action
- the dependency of the action
- a few other things

## Limitations

Stamp files that correspond to stale anonymous actions are never deleted. Only stamp files that correspond to anonymous actions in stale directories are deleted.

## For later

A couple of errors in the testsuite now have two locations, and one error is printed twice. I haven't investigated this yet. I'd like to merge this now and leave a reminder to look into it before Dune 3.0.

