### PR TITLE
Fix a dune crash when `subdir` is an absolute path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,8 @@ Unreleased
 
 - Add support for sandboxing using hard links (#4360, @snowleopard)
 
+- Fix dune crash when `subdir` is an absolute path (#4366, @anmonteiro)
+
 2.8.2 (21/01/2021)
 ------------------
 

--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -190,13 +190,12 @@ end
 
 let descendant_path =
   Dune_lang.Decoder.plain_string (fun ~loc fn ->
-    if Filename.is_relative fn then
-      Path.Local.parse_string_exn ~loc fn |> Path.Local.explode
-    else
-      let msg = [ Pp.textf "invalid sub-directory path %S" fn ] in
-      let hints = [ Pp.textf "subdirectory path must be relative" ]
-      in
-      User_error.raise ~loc ~hints msg)
+      if Filename.is_relative fn then
+        Path.Local.parse_string_exn ~loc fn |> Path.Local.explode
+      else
+        let msg = [ Pp.textf "invalid sub-directory path %S" fn ] in
+        let hints = [ Pp.textf "subdirectory path must be relative" ] in
+        User_error.raise ~loc ~hints msg)
 
 let strict_subdir field_name =
   let open Dune_lang.Decoder in

--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -194,7 +194,7 @@ let descendant_path =
         Path.Local.parse_string_exn ~loc fn |> Path.Local.explode
       else
         let msg = [ Pp.textf "invalid sub-directory path %S" fn ] in
-        let hints = [ Pp.textf "subdirectory path must be relative" ] in
+        let hints = [ Pp.textf "sub-directory path must be relative" ] in
         User_error.raise ~loc ~hints msg)
 
 let strict_subdir field_name =

--- a/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
@@ -118,3 +118,19 @@ Include stanzas within subdir stanzas
   $ dune build --root . a/hello.txt
   $ cat _build/default/a/hello.txt
   Hello!
+
+
+  $ echo "(lang dune 2.5)" > dune-project
+  $ cat >dune <<EOF
+  > (rule (with-stdout-to foo.txt (echo "bar")))
+  > (subdir /absolute/path/to/bar
+  >  (rule (with-stdout-to foo.txt (echo "bar"))))
+  > EOF
+  $ dune build ./foo.txt ./bar/foo.txt
+  File "dune", line 2, characters 8-29:
+  2 | (subdir /absolute/path/to/bar
+              ^^^^^^^^^^^^^^^^^^^^^
+  Error: invalid sub-directory path "/absolute/path/to/bar"
+  Hint: subdirectory path must be relative
+  [1]
+

--- a/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/subdir-stanza.t/run.t
@@ -131,6 +131,6 @@ Include stanzas within subdir stanzas
   2 | (subdir /absolute/path/to/bar
               ^^^^^^^^^^^^^^^^^^^^^
   Error: invalid sub-directory path "/absolute/path/to/bar"
-  Hint: subdirectory path must be relative
+  Hint: sub-directory path must be relative
   [1]
 


### PR DESCRIPTION
Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>

Fixes a crash when mistakenly adding an absolute path to the `subdir` stanza. The error without this patch looks like:


```
  Error: exception { exn =
      ("Local.relative: received absolute path",
      { t = "."; path = "/absolute/path/to/bar" })
  ; backtrace =
      [ { ocaml =
            "Raised at Stdune__Code_error.raise in file
  \"otherlibs/stdune-unstable/code_error.ml\", line 9, characters 30-62\n\
             Called from Stdune__Path.Local_gen.relative in file
  \"otherlibs/stdune-unstable/path.ml\", line 297, characters 6-114\n\
             Called from Dune_engine__Sub_dirs.descedant_path.(fun) in file
  \"src/dune_engine/sub_dirs.ml\", line 193, characters 6-41\n\
             Called from Dune_lang__Decoder.next in file
  \"src/dune_lang/decoder.ml\", line 278, characters 22-28\n\
             Called from Dune_lang__Decoder.(>>=) in file
  \"src/dune_lang/decoder.ml\", line 137, characters 17-28\n\

... truncated
```