### PR TITLE
Preview: upgrade to ocamlformat.0.18.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.17.0
+version=0.18.0
 profile=conventional
 break-separators=before
 dock-collection-brackets=false

--- a/otherlibs/stdune-unstable/caller_id.mli
+++ b/otherlibs/stdune-unstable/caller_id.mli
@@ -1,6 +1,9 @@
 (** Who called me? *)
 
 (** [get ~skip] returns the first element of the call stack that is not in
-    [skip]. For instance, {[get ~skip:[__FILE__]]} will return the first call
-    site outside of the current file. *)
+    [skip]. For instance,
+
+    {[ get ~skip:[ __FILE__ ] ]}
+
+    will return the first call site outside of the current file. *)
 val get : skip:string list -> Loc.t option

--- a/src/dune_engine/string_with_vars.ml
+++ b/src/dune_engine/string_with_vars.ml
@@ -230,7 +230,11 @@ struct
   open A.O
 
   let expand :
-        'a.    t -> mode:'a Mode.t -> dir:Path.t -> f:Value.t list A.t expander
+        'a.
+           t
+        -> mode:'a Mode.t
+        -> dir:Path.t
+        -> f:Value.t list A.t expander
         -> 'a A.t =
    fun t ~mode ~dir ~f ->
     match t.parts with


### PR DESCRIPTION
This is a preview of the not-yet-released ocamlformat.0.18.0, please wait until the package is published in opam to merge this PR.
The diff is composed of:
- moving an odoc code block in an .mli file to avoid an odoc warning reported when applying ocamlformat
- a break was added between polytype quantification and arrow-type body (spurious spaces are removed), causing the arrow-type to properly break




Signed-off-by: Guillaume Petiot <guillaume@tarides.com>