### PR TITLE
Add [goal] constructor to [Action_builder.t]

### DIFF
--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -84,8 +84,6 @@ let dyn_deps x = Dyn_deps x
 
 let path p = Deps (Dep.Set.singleton (Dep.file p))
 
-let goal t = Goal t
-
 let paths ps = Deps (Dep.Set.of_files ps)
 
 let path_set ps = Deps (Dep.Set.of_files_set ps)
@@ -277,6 +275,8 @@ let progn ts =
   let open With_targets.O in
   let+ actions = With_targets.all ts in
   Action.Progn actions
+
+let goal t = Goal t
 
 (* Execution *)
 

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -220,7 +220,7 @@ val static_eval : 'a t -> ('a * unit t) option
 (** [goal t] ignores all facts that have been accumulated about the dependencies
     of [t]. For example, [goal (path p)] declares that a path [p] contributes to
     the "goal" of the resulting action builder, which means [p] must be built,
-    but the content of [p] is irrelevant. *)
+    but the contents of [p] is irrelevant. *)
 val goal : 'a t -> 'a t
 
 module Expander : String_with_vars.Expander with type 'a app := 'a t

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -217,6 +217,12 @@ val progn : Action.t With_targets.t list -> Action.t With_targets.t
     dependencies and other informations. Otherwise return [None]. *)
 val static_eval : 'a t -> ('a * unit t) option
 
+(** [goal t] ignores all facts that have been accumulated about the dependencies
+    of [t]. For example, [goal (path p)] declares that a path [p] contributes to
+    the "goal" of the resulting action builder, which means [p] must be built,
+    but the content of [p] is irrelevant. *)
+val goal : 'a t -> 'a t
+
 module Expander : String_with_vars.Expander with type 'a app := 'a t
 
 (** {1 Execution} *)

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -18,9 +18,8 @@ let gen_select_rules t ~dir compile_info =
 let with_lib_deps (t : Context.t) compile_info ~dir ~f =
   let prefix =
     if t.merlin then
-      Merlin_ident.merlin_exists_path dir
-        (Lib.Compile.merlin_ident compile_info)
-      |> Path.build |> Action_builder.path
+      Merlin_ident.merlin_file_path dir (Lib.Compile.merlin_ident compile_info)
+      |> Path.build |> Action_builder.path |> Action_builder.goal
     else
       Action_builder.return ()
   in

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -380,24 +380,7 @@ module Unprocessed = struct
 end
 
 let dot_merlin sctx ~dir ~more_src_dirs ~expander (t : Unprocessed.t) =
-  let merlin_exist = Merlin_ident.merlin_exists_path dir t.ident in
   let merlin_file = Merlin_ident.merlin_file_path dir t.ident in
-
-  (* We make the compilation of .ml/.mli files depend on the existence of
-     .merlin so that they are always generated, however the command themselves
-     don't read the merlin file, so we don't want to declare a dependency on the
-     contents of the .merlin file.
-
-     Currently dune doesn't support declaring a dependency only on the existence
-     of a file, so we have to use this trick. *)
-  let open Memo.Build.O in
-  let* () =
-    SC.add_rule sctx ~dir
-      (let open Action_builder.With_targets.O in
-      Action_builder.with_no_targets
-        (Action_builder.path (Path.build merlin_file))
-      >>> Action_builder.create_file merlin_exist)
-  in
 
   Path.Set.singleton (Path.build merlin_file)
   |> Rules.Produce.Alias.add_static_deps (Alias.check ~dir);

--- a/src/dune_rules/merlin_ident.ml
+++ b/src/dune_rules/merlin_ident.ml
@@ -18,13 +18,7 @@ let to_string = function
     sprintf "exe-%s-%s" name Digest.(generic names |> to_string)
   | Exes [] -> assert false
 
-let merlin_exist_name = ".merlin-exist"
-
 let merlin_folder_name = ".merlin-conf"
-
-let merlin_exists_path path ident =
-  String.concat ~sep:"-" [ merlin_exist_name; to_string ident ]
-  |> Path.Build.relative path
 
 let merlin_file_path path ident =
   Filename.concat merlin_folder_name (to_string ident)

--- a/src/dune_rules/merlin_ident.mli
+++ b/src/dune_rules/merlin_ident.mli
@@ -11,8 +11,5 @@ val for_exes : names:string list -> t
 (** Merlin config folder name *)
 val merlin_folder_name : string
 
-(** Return the path of the merlin_exist file for a given stanza *)
-val merlin_exists_path : Path.Build.t -> t -> Path.Build.t
-
 (** Return the path of the merlin file for a given stanza *)
 val merlin_file_path : Path.Build.t -> t -> Path.Build.t


### PR DESCRIPTION
This makes it possible to get rid of `merlin-exists` files and is also useful for the Jenga -> Dune transition.