### PR TITLE
[RPC] Fix shutdown

### DIFF
--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -111,6 +111,7 @@ module V1 : sig
 
     val unsubscribe : Subscribe.t t
 
+    (** Request dune to shutdown. The current build job will be cancelled. *)
     val shutdown : unit t
   end
 

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -823,10 +823,10 @@ let with_job_slot f =
   let t = Fiber.Var.get_exn t_var in
   Fiber.Throttle.run t.job_throttle ~f:(fun () ->
       match t.status with
-      | Restarting_build -> raise Cancel_build
-      | Shutting_down
-      | Building ->
-        f t.config
+      | Restarting_build
+      | Shutting_down ->
+        raise Cancel_build
+      | Building -> f t.config
       | Waiting_for_file_changes _ ->
         (* At this stage, we're not running a build, so we shouldn't be running
            tasks here. *)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -54,7 +54,10 @@ module Run : sig
   (** Runs [once] in a loop, executing [finally] after every iteration, even if
       Fiber.Never was encountered.
 
-      If any source files change in the middle of iteration, it gets canceled. *)
+      If any source files change in the middle of iteration, it gets canceled.
+
+      If [shutdown] is called, no new builds will be queued after the current
+      one finishes. *)
   val poll :
        Config.t
     -> on_event:(Config.t -> Event.poll -> unit)
@@ -93,6 +96,10 @@ val with_chdir : dir:Path.t -> f:(unit -> 'a) -> 'a
 
 (** Send a task that will run in the scheduler thread *)
 val send_sync_task : (unit -> unit) -> unit
+
+(** Do not restart the build after the current one finishes and stop accepting
+    new RPC clients. Only works for [poll] *)
+val shutdown : unit -> unit Fiber.t
 
 module Rpc : sig
   (** Rpc related functions *)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -56,8 +56,8 @@ module Run : sig
 
       If any source files change in the middle of iteration, it gets canceled.
 
-      If [shutdown] is called, no new builds will be queued after the current
-      one finishes. *)
+      If [shutdown] is called, the current build will be canceled and new builds
+      will not start. *)
   val poll :
        Config.t
     -> on_event:(Config.t -> Event.poll -> unit)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -97,8 +97,8 @@ val with_chdir : dir:Path.t -> f:(unit -> 'a) -> 'a
 (** Send a task that will run in the scheduler thread *)
 val send_sync_task : (unit -> unit) -> unit
 
-(** Do not restart the build after the current one finishes and stop accepting
-    new RPC clients. Only works for [poll] *)
+(** Start the shutdown sequence. Among other things, it causes Dune to cancel
+    the current build and stop accepting RPC clients. *)
 val shutdown : unit -> unit Fiber.t
 
 module Rpc : sig

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -119,7 +119,8 @@ let handler (t : t Fdecl.t) : 'a Dune_rpc_server.Handler.t =
     in
     let shutdown () =
       (Fdecl.get t).pending_shutdown <- true;
-      cancel_pending_jobs ()
+      Fiber.fork_and_join_unit cancel_pending_jobs
+        Dune_engine.Scheduler.shutdown
     in
     Handler.notification rpc
       (Handler.callback Handler.private_ shutdown)

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -29,7 +29,6 @@ val build_mutex : t -> Fiber.Mutex.t
 val config : t -> Dune_engine.Scheduler.Config.Rpc.t
 
 type pending_build_action =
-  | Shutdown
   | Build of Dune_rules.Dep_conf.t list * Status.t Fiber.Ivar.t
 
 val pending_build_action : t -> pending_build_action option


### PR DESCRIPTION
This fixes the shutdown notification to work when the code is waiting for file
changes. Previously, a pending shutdown would wait until a file notification was
sent.