### PR TITLE
Fixed OCaml compilation flag error

### DIFF
--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -149,7 +149,7 @@ Write this ``dune`` file at the root of your project:
      (dev
       (flags (:standard -w +42)))
      (release
-      (flags (:standard -O3))))
+      (ocamlopt_flags (:standard -O3))))
 
 `dev` and `release` correspond to build profiles. The build profile
 can be selected from the command line with ``--profile foo`` or from a


### PR DESCRIPTION
For "Setting the OCaml compilation flags globally",

```
    (env
     (dev
      (flags (:standard -w +42)))
     (release
      (flags (:standard -O3))))
```

`(flags (:standard -O3))` will only cause an error (I don't know the reason but because of ocamlc still used I think). So instead, use `ocamlopt_flags` instead of `flags` and it will not error.

```
/usr/bin/ocamlc.opt: unknown option '-O3'.
```
Here is the error using `flags` instead of `ocamlopt_flags`.

```
Signed-off-by: Jack Murrow <jack.murrow122005@gmail.com>
```