### PR TITLE
Allow to create executable files in the action language

### DIFF
--- a/otherlibs/stdune-unstable/caller_id.mli
+++ b/otherlibs/stdune-unstable/caller_id.mli
@@ -1,6 +1,6 @@
 (** Who called me? *)
 
 (** [get ~skip] returns the first element of the call stack that is not in
-    [skip]. For instance, {[get ~skip:[__FILE__]]} will return the first call
+    [skip]. For instance, [get ~skip:\[__FILE__\]] will return the first call
     site outside of the current file. *)
 val get : skip:string list -> Loc.t option

--- a/otherlibs/stdune-unstable/io_intf.ml
+++ b/otherlibs/stdune-unstable/io_intf.ml
@@ -3,13 +3,18 @@ module type S = sig
 
   val open_in : ?binary:bool (* default true *) -> path -> in_channel
 
-  val open_out : ?binary:bool (* default true *) -> path -> out_channel
+  val open_out :
+    ?binary:bool (* default true *) -> ?perm:int -> path -> out_channel
 
   val with_file_in :
     ?binary:bool (* default true *) -> path -> f:(in_channel -> 'a) -> 'a
 
   val with_file_out :
-    ?binary:bool (* default true *) -> path -> f:(out_channel -> 'a) -> 'a
+       ?binary:bool (* default true *)
+    -> ?perm:int
+    -> path
+    -> f:(out_channel -> 'a)
+    -> 'a
 
   val with_lexbuf_from_file : path -> f:(Lexing.lexbuf -> 'a) -> 'a
 
@@ -20,13 +25,13 @@ module type S = sig
 
   val read_file : ?binary:bool -> path -> string
 
-  val write_file : ?binary:bool -> path -> string -> unit
+  val write_file : ?binary:bool -> ?perm:int -> path -> string -> unit
 
   val compare_files : path -> path -> Ordering.t
 
   val compare_text_files : path -> path -> Ordering.t
 
-  val write_lines : ?binary:bool -> path -> string list -> unit
+  val write_lines : ?binary:bool -> ?perm:int -> path -> string list -> unit
 
   val copy_file : ?chmod:(int -> int) -> src:path -> dst:path -> unit -> unit
 

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -3,6 +3,14 @@ open Import
 module Outputs = Action_ast.Outputs
 module Inputs = Action_ast.Inputs
 
+module File_perm = struct
+  include Action_intf.File_perm
+
+  let to_unix_perm = function
+    | Normal -> 0o666
+    | Executable -> 0o777
+end
+
 module Prog = struct
   module Not_found = struct
     type t =
@@ -121,7 +129,7 @@ let fold_one_step t ~init:acc ~f =
   match t with
   | Chdir (_, t)
   | Setenv (_, _, t)
-  | Redirect_out (_, _, t)
+  | Redirect_out (_, _, _, t)
   | Redirect_in (_, _, t)
   | Ignore (_, t)
   | With_accepted_exit_codes (_, t)
@@ -169,7 +177,7 @@ let rec is_dynamic = function
   | Dynamic_run _ -> true
   | Chdir (_, t)
   | Setenv (_, _, t)
-  | Redirect_out (_, _, t)
+  | Redirect_out (_, _, _, t)
   | Redirect_in (_, _, t)
   | Ignore (_, t)
   | With_accepted_exit_codes (_, t)
@@ -261,7 +269,7 @@ let is_useful_to distribute memoize =
     match t with
     | Chdir (_, t) -> loop t
     | Setenv (_, _, t) -> loop t
-    | Redirect_out (_, _, t) -> memoize || loop t
+    | Redirect_out (_, _, _, t) -> memoize || loop t
     | Redirect_in (_, _, t) -> loop t
     | Ignore (_, t)
     | With_accepted_exit_codes (_, t)

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -11,6 +11,14 @@ module Inputs : module type of struct
   include Action_intf.Inputs
 end
 
+module File_perm : sig
+  include module type of struct
+    include Action_intf.File_perm
+  end
+
+  val to_unix_perm : t -> int
+end
+
 (** result of the lookup of a program, the path to it or information about the
     failure and possibly a hint how to fix it *)
 module Prog : sig

--- a/src/dune_engine/action_ast.ml
+++ b/src/dune_engine/action_ast.ml
@@ -28,6 +28,14 @@ module type Target_intf = sig
   val is_dev_null : t -> bool
 end
 
+module File_perm = struct
+  include Action_intf.File_perm
+
+  let suffix = function
+    | Normal -> ""
+    | Executable -> "-executable"
+end
+
 module Make
     (Program : Dune_lang.Conv.S)
     (Path : Dune_lang.Conv.S)
@@ -45,7 +53,7 @@ struct
     if Target.is_dev_null fn then
       Ignore (output, action)
     else
-      Redirect_out (output, fn, action)
+      Redirect_out (output, fn, Normal, action)
 
   let two_or_more decode =
     let open Dune_lang.Decoder in
@@ -83,7 +91,7 @@ struct
                     | Setenv (_, _, t)
                     | Ignore (_, t)
                     | Redirect_in (_, _, t)
-                    | Redirect_out (_, _, t)
+                    | Redirect_out (_, _, _, t)
                     | No_infer t ->
                       if nesting_support then
                         is_ok t
@@ -179,7 +187,7 @@ struct
           ; ( "write-file"
             , let+ fn = target
               and+ s = string in
-              Write_file (fn, s) )
+              Write_file (fn, Normal, s) )
           ; ( "diff"
             , let+ diff = Diff.decode path target ~optional:false in
               Diff diff )
@@ -228,9 +236,12 @@ struct
       List (atom "run_dynamic" :: program a :: List.map xs ~f:string)
     | Chdir (a, r) -> List [ atom "chdir"; path a; encode r ]
     | Setenv (k, v, r) -> List [ atom "setenv"; string k; string v; encode r ]
-    | Redirect_out (outputs, fn, r) ->
+    | Redirect_out (outputs, fn, perm, r) ->
       List
-        [ atom (sprintf "with-%s-to" (Outputs.to_string outputs))
+        [ atom
+            (sprintf "with-%s-to%s"
+               (Outputs.to_string outputs)
+               (File_perm.suffix perm))
         ; target fn
         ; encode r
         ]
@@ -252,7 +263,8 @@ struct
       List [ atom "copy#"; path x; target y ]
     | System x -> List [ atom "system"; string x ]
     | Bash x -> List [ atom "bash"; string x ]
-    | Write_file (x, y) -> List [ atom "write-file"; target x; string y ]
+    | Write_file (x, perm, y) ->
+      List [ atom ("write-file" ^ File_perm.suffix perm); target x; string y ]
     | Rename (x, y) -> List [ atom "rename"; target x; target y ]
     | Remove_tree x -> List [ atom "remove-tree"; target x ]
     | Mkdir x -> List [ atom "mkdir"; path x ]
@@ -290,11 +302,14 @@ struct
 
   let setenv var value t = Setenv (var, value, t)
 
-  let with_stdout_to path t = Redirect_out (Stdout, path, t)
+  let with_stdout_to ?(perm = File_perm.Normal) path t =
+    Redirect_out (Stdout, path, perm, t)
 
-  let with_stderr_to path t = Redirect_out (Stderr, path, t)
+  let with_stderr_to ?(perm = File_perm.Normal) path t =
+    Redirect_out (Stderr, path, perm, t)
 
-  let with_outputs_to path t = Redirect_out (Outputs, path, t)
+  let with_outputs_to ?(perm = File_perm.Normal) path t =
+    Redirect_out (Outputs, path, perm, t)
 
   let with_stdin_from path t = Redirect_in (Stdin, path, t)
 
@@ -320,7 +335,7 @@ struct
 
   let bash s = Bash s
 
-  let write_file p s = Write_file (p, s)
+  let write_file ?(perm = File_perm.Normal) p s = Write_file (p, perm, s)
 
   let rename a b = Rename (a, b)
 

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -242,10 +242,10 @@ module With_targets = struct
       in
       { build = All (List.rev build); targets }
 
-  let write_file_dyn fn s =
+  let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
     add ~targets:[ fn ]
       (let+ s = s in
-       Action.Write_file (fn, s))
+       Action.Write_file (fn, perm, s))
 
   let of_result_map res ~f ~targets =
     add ~targets
@@ -267,13 +267,13 @@ let with_targets_set build ~targets : _ With_targets.t = { build; targets }
 let with_no_targets build : _ With_targets.t =
   { build; targets = Path.Build.Set.empty }
 
-let write_file fn s =
-  with_targets ~targets:[ fn ] (return (Action.Write_file (fn, s)))
+let write_file ?(perm = Action.File_perm.Normal) fn s =
+  with_targets ~targets:[ fn ] (return (Action.Write_file (fn, perm, s)))
 
-let write_file_dyn fn s =
+let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
   with_targets ~targets:[ fn ]
     (let+ s = s in
-     Action.Write_file (fn, s))
+     Action.Write_file (fn, perm, s))
 
 let copy ~src ~dst =
   with_targets ~targets:[ dst ] (path src >>> return (Action.Copy (src, dst)))
@@ -285,9 +285,9 @@ let copy_and_add_line_directive ~src ~dst =
 let symlink ~src ~dst =
   with_targets ~targets:[ dst ] (path src >>> return (Action.Symlink (src, dst)))
 
-let create_file fn =
+let create_file ?(perm = Action.File_perm.Normal) fn =
   with_targets ~targets:[ fn ]
-    (return (Action.Redirect_out (Stdout, fn, Action.empty)))
+    (return (Action.Redirect_out (Stdout, fn, perm, Action.empty)))
 
 let progn ts =
   let open With_targets.O in

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -39,7 +39,8 @@ module With_targets : sig
 
   val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 
-  val write_file_dyn : Path.Build.t -> string t -> Action.t t
+  val write_file_dyn :
+    ?perm:Action.File_perm.t -> Path.Build.t -> string t -> Action.t t
 
   val all : 'a t list -> 'a list t
 
@@ -198,9 +199,14 @@ val of_result_map : 'a Or_exn.t -> f:('a -> 'b t) -> 'b t
 val memoize : string -> 'a t -> 'a t
 
 (** Create a file with the given contents. *)
-val write_file : Path.Build.t -> string -> Action.t With_targets.t
+val write_file :
+  ?perm:Action.File_perm.t -> Path.Build.t -> string -> Action.t With_targets.t
 
-val write_file_dyn : Path.Build.t -> string t -> Action.t With_targets.t
+val write_file_dyn :
+     ?perm:Action.File_perm.t
+  -> Path.Build.t
+  -> string t
+  -> Action.t With_targets.t
 
 val copy : src:Path.t -> dst:Path.Build.t -> Action.t With_targets.t
 
@@ -209,7 +215,8 @@ val copy_and_add_line_directive :
 
 val symlink : src:Path.t -> dst:Path.Build.t -> Action.t With_targets.t
 
-val create_file : Path.Build.t -> Action.t With_targets.t
+val create_file :
+  ?perm:Action.File_perm.t -> Path.Build.t -> Action.t With_targets.t
 
 (** Merge a list of actions accumulating the sets of their targets. *)
 val progn : Action.t With_targets.t list -> Action.t With_targets.t

--- a/src/dune_engine/action_dune_lang.ml
+++ b/src/dune_engine/action_dune_lang.ml
@@ -44,7 +44,7 @@ let ensure_at_most_one_dynamic_run ~loc action =
     | Dynamic_run _ -> true
     | Chdir (_, t)
     | Setenv (_, _, t)
-    | Redirect_out (_, _, t)
+    | Redirect_out (_, _, _, t)
     | Redirect_in (_, _, t)
     | Ignore (_, t)
     | With_accepted_exit_codes (_, t)

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -11,6 +11,14 @@ module Inputs = struct
   type t = Stdin
 end
 
+module File_perm = struct
+  (** File mode, for when creating files. We only allow what Dune takes into
+      account when memoizing commands. *)
+  type t =
+    | Normal
+    | Executable
+end
+
 module type Ast = sig
   type program
 
@@ -28,7 +36,7 @@ module type Ast = sig
     | Setenv of string * string * t
     (* It's not possible to use a build path here since jbuild supports
        redirecting to /dev/null. In [dune] files this is replaced with %{null} *)
-    | Redirect_out of Outputs.t * target * t
+    | Redirect_out of Outputs.t * target * File_perm.t * t
     | Redirect_in of Inputs.t * path * t
     | Ignore of Outputs.t * t
     | Progn of t list
@@ -40,7 +48,7 @@ module type Ast = sig
     | Copy_and_add_line_directive of path * target
     | System of string
     | Bash of string
-    | Write_file of target * string
+    | Write_file of target * File_perm.t * string
     | Rename of target * target
     | Remove_tree of target
     | Mkdir of path
@@ -69,11 +77,11 @@ module type Helpers = sig
 
   val setenv : string -> string -> t -> t
 
-  val with_stdout_to : target -> t -> t
+  val with_stdout_to : ?perm:File_perm.t -> target -> t -> t
 
-  val with_stderr_to : target -> t -> t
+  val with_stderr_to : ?perm:File_perm.t -> target -> t -> t
 
-  val with_outputs_to : target -> t -> t
+  val with_outputs_to : ?perm:File_perm.t -> target -> t -> t
 
   val with_stdin_from : path -> t -> t
 
@@ -99,7 +107,7 @@ module type Helpers = sig
 
   val bash : string -> t
 
-  val write_file : target -> string -> t
+  val write_file : ?perm:File_perm.t -> target -> string -> t
 
   val rename : target -> target -> t
 

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -23,8 +23,8 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
     | Chdir (fn, t) -> Chdir (f_path ~dir fn, f t ~dir:fn)
     | Setenv (var, value, t) ->
       Setenv (f_string ~dir var, f_string ~dir value, f t ~dir)
-    | Redirect_out (outputs, fn, t) ->
-      Redirect_out (outputs, f_target ~dir fn, f t ~dir)
+    | Redirect_out (outputs, fn, perm, t) ->
+      Redirect_out (outputs, f_target ~dir fn, perm, f t ~dir)
     | Redirect_in (inputs, fn, t) ->
       Redirect_in (inputs, f_path ~dir fn, f t ~dir)
     | Ignore (outputs, t) -> Ignore (outputs, f t ~dir)
@@ -38,7 +38,8 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
       Copy_and_add_line_directive (f_path ~dir x, f_target ~dir y)
     | System x -> System (f_string ~dir x)
     | Bash x -> Bash (f_string ~dir x)
-    | Write_file (x, y) -> Write_file (f_target ~dir x, f_string ~dir y)
+    | Write_file (x, perm, y) ->
+      Write_file (f_target ~dir x, perm, f_string ~dir y)
     | Rename (x, y) -> Rename (f_target ~dir x, f_target ~dir y)
     | Remove_tree x -> Remove_tree (f_target ~dir x)
     | Mkdir x -> Mkdir (f_path ~dir x)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1362,7 +1362,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 3
+  let rule_digest_version = 4
 
   let compute_rule_digest (rule : Rule.t) ~deps ~action ~sandbox_mode =
     let env = Rule.effective_env rule in

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -98,14 +98,14 @@ module Io = struct
     let channel = lazy (channel_of_descr (Lazy.force fd) mode) in
     { kind = Null; mode; fd; channel; status = Close_after_exec }
 
-  let file : type a. _ -> a mode -> a t =
-   fun fn mode ->
+  let file : type a. _ -> ?perm:int -> a mode -> a t =
+   fun fn ?(perm = 0o666) mode ->
     let flags =
       match mode with
       | Out -> [ Unix.O_WRONLY; O_CREAT; O_TRUNC; O_SHARE_DELETE ]
       | In -> [ O_RDONLY; O_SHARE_DELETE ]
     in
-    let fd = lazy (Unix.openfile (Path.to_string fn) flags 0o666) in
+    let fd = lazy (Unix.openfile (Path.to_string fn) flags perm) in
     let channel = lazy (channel_of_descr (Lazy.force fd) mode) in
     { kind = File fn; mode; fd; channel; status = Close_after_exec }
 

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -37,7 +37,7 @@ module Io : sig
       input from the file. The returned channel can only be used by a single
       call to {!run}. If you want to use it multiple times, you need to use
       [clone]. *)
-  val file : Path.t -> 'a mode -> 'a t
+  val file : Path.t -> ?perm:int -> 'a mode -> 'a t
 
   (** Call this when you no longer need this redirection *)
   val release : 'a t -> unit

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -425,10 +425,10 @@ let rec expand (t : Action_dune_lang.t) : Action.t Action_expander.t =
         A.set_env ~var ~value:(E.string value)
           (let+ t = expand t in
            fun ~value -> O.Setenv (var, value, t)))
-  | Redirect_out (outputs, fn, t) ->
+  | Redirect_out (outputs, fn, perm, t) ->
     let+ fn = E.target fn
     and+ t = expand t in
-    O.Redirect_out (outputs, fn, t)
+    O.Redirect_out (outputs, fn, perm, t)
   | Redirect_in (inputs, fn, t) ->
     let+ fn = E.dep fn
     and+ t = expand t in
@@ -468,10 +468,10 @@ let rec expand (t : Action_dune_lang.t) : Action.t Action_expander.t =
   | Bash x ->
     let+ x = E.string x in
     O.Bash x
-  | Write_file (fn, s) ->
+  | Write_file (fn, perm, s) ->
     let+ fn = E.target fn
     and+ s = E.string s in
-    O.Write_file (fn, s)
+    O.Write_file (fn, perm, s)
   | Rename (x, _) ->
     (* [Rename] is not part of the syntax so this case is not reachable. The
        reason it is not exposed to the user is because we can't easily decide

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -56,21 +56,21 @@ let gen_rules sctx t ~dir ~scope =
     File_tree.files_of (Path.Build.drop_build_context_exn dir)
     >>| Path.Source.Set.to_list
     >>| List.filter_map ~f:(fun p ->
-           if
-             Predicate_lang.Glob.exec t.files (Path.Source.basename p)
-               ~standard:Predicate_lang.any
-           then
-             Some
-               (Path.Build.append_source (Super_context.context sctx).build_dir
-                  p)
-           else
-             None)
-  (* Ask cinaps to produce a .ml file to build *)
+            if
+              Predicate_lang.Glob.exec t.files (Path.Source.basename p)
+                ~standard:Predicate_lang.any
+            then
+              Some
+                (Path.Build.append_source (Super_context.context sctx).build_dir
+                   p)
+            else
+              None)
   and* prog =
     Super_context.resolve_program sctx ~dir ~loc:(Some loc) name
       ~hint:"opam install cinaps"
   in
   let* () =
+    (* Ask cinaps to produce a .ml file to build *)
     Super_context.add_rule sctx ~loc:t.loc ~dir
       (Command.run ~dir:(Path.build dir) prog
          [ A "-staged"

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -55,8 +55,8 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
             ; deps = Bindings.empty
             ; action =
                 ( loc
-                , Action_unexpanded.Redirect_out (Stdout, diff.file2, run_action)
-                )
+                , Action_unexpanded.Redirect_out
+                    (Stdout, diff.file2, Normal, run_action) )
             ; mode = Standard
             ; locks = t.locks
             ; loc

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -70,10 +70,10 @@ version number. This number is stored in the [rule_digest_version]
 variable in [build_system.ml].
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v4"; grep -rws . -e 'metadata' | sort)
-  ./a5/a5577fffaa751cd2aa8b2345ac11119a:((8:metadata)(5:files(16:default/target_a32:5637dd9730e430c7477f52d46de3909c)))
-  ./c5/c5af296726141def07847e5510a680c6:((8:metadata)(5:files(16:default/target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./06/061fb516fd28c9a632c573f380b8a120:((8:metadata)(5:files(16:default/target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./50/50148ac6fcde0b35e357cbd120131dbc:((8:metadata)(5:files(16:default/target_b32:8a53bfae3829b48866079fa7f2d97781)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v4/a5/a5577fffaa751cd2aa8b2345ac11119a"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v4/06/061fb516fd28c9a632c573f380b8a120"
   79
 
 Trimming the cache at this point should not remove anything, as all


### PR DESCRIPTION
This is useful for creating helper scripts, which is something we do inside Jane Street and we need it for the transition to Dune.

This PR only adds the internal support for now, it doesn't expose it through the syntax.
