### PR TITLE
Scheduler var access in iter

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2398,11 +2398,19 @@ let init ~stats ~contexts ?build_mutex ~promote_source ?caching
     ; stats
     }
   in
-  Console.Status_line.set (fun () ->
-      Some
-        (Pp.verbatim
-           (sprintf "Done: %u/%u (jobs: %u)" t.rule_done t.rule_total
-              (Scheduler.running_jobs_count ()))));
+  let scheduler = Scheduler.t () in
+  Console.Status_line.set (
+    let r = ref 0 in
+    (fun () ->
+       if !r > 0 then assert false;
+       incr r;
+    Some
+      (Pp.verbatim
+         (sprintf
+            "Done: %u/%u (jobs: %u)"
+            t.rule_done
+            t.rule_total
+            (Scheduler.running_jobs_count scheduler)))));
   set t
 
 let cache_teardown () =

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -804,8 +804,10 @@ type t =
 
 let t_var : t Fiber.Var.t = Fiber.Var.create ()
 
-let running_jobs_count () =
-  let t = Fiber.Var.get_exn t_var in
+let t () =
+  Fiber.Var.get_exn t_var
+
+let running_jobs_count t =
   Event.Queue.pending_jobs t.events
 
 let ignore_for_watch p =

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -72,6 +72,11 @@ module Run : sig
     -> 'a
 end
 
+type t
+
+(** Get the instance of the scheduler that runs the current fiber. *)
+val t : unit -> t
+
 (** [with_job_slot f] waits for one job slot (as per [-j <jobs] to become
     available and then calls [f]. *)
 val with_job_slot : (Config.t -> 'a Fiber.t) -> 'a Fiber.t
@@ -89,7 +94,7 @@ val wait_for_dune_cache : unit -> unit
 val ignore_for_watch : Path.t -> unit
 
 (** Number of jobs currently running in the background *)
-val running_jobs_count : unit -> int
+val running_jobs_count : t -> int
 
 (** Execute the given callback with current directory temporarily changed *)
 val with_chdir : dir:Path.t -> f:(unit -> 'a) -> 'a

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -881,10 +881,9 @@ let%expect_test "execution context in [iter] in [Fiber.run]" =
   in
   Scheduler.run fiber;
   [%expect {|
-    fiber-a: a
-    fiber-b: b
-    branch-a: <unset>
-    branch-b: <unset> |}];
+    0: <unset>
+    1: <unset>
+    2: <unset> |}];
   Scheduler.run (Fiber.Var.set var "x" (fun () ->
          Scheduler.yield_gen ~do_in_scheduler:(fun () -> print "value")));
   [%expect {|

--- a/test/expect-tests/test_scheduler/test_scheduler.ml
+++ b/test/expect-tests/test_scheduler/test_scheduler.ml
@@ -1,18 +1,28 @@
 open Stdune
 
-type t = unit Fiber.Ivar.t Queue.t
+type job =
+  | Job : (unit -> 'a) * 'a Fiber.Ivar.t -> job
+
+type t = job Queue.t
 
 let create () : t = Queue.create ()
 
 let yield t =
   let ivar = Fiber.Ivar.create () in
-  Queue.push t ivar;
+  Queue.push t (Job ((fun () -> ()), ivar));
+  Fiber.Ivar.read ivar
+
+let yield_gen (t : t) ~do_in_scheduler =
+  let ivar = Fiber.Ivar.create () in
+  Queue.push t (Job (do_in_scheduler, ivar));
   Fiber.Ivar.read ivar
 
 exception Never
 
 let run (t : t) fiber =
   Fiber.run fiber ~iter:(fun () ->
-      match Queue.pop t with
-      | None -> raise Never
-      | Some e -> Fiber.Fill (e, ()))
+    match Queue.pop t with
+    | None -> raise Never
+    | Some (Job (job, ivar)) ->
+      let v = job () in
+      Fiber.Fill (ivar, v))

--- a/test/expect-tests/test_scheduler/test_scheduler.mli
+++ b/test/expect-tests/test_scheduler/test_scheduler.mli
@@ -8,4 +8,6 @@ val create : unit -> t
 
 val yield : t -> unit Fiber.t
 
+val yield_gen : t -> do_in_scheduler:(unit -> 'a) -> 'a Fiber.t
+
 val run : t -> 'a Fiber.t -> 'a


### PR DESCRIPTION
We saw dune crash with an exception in `Fiber.Var.get_exn` called by `Status_line.refresh`.
I think this was caused by a `Tick` event, which is run by the scheduler in the `init` callback of `Fiber.run`, which, I think, does not have well-defined values for variables.

However, the story is not 100% clear because the tick handler doesn't seem to crash every time.

I added a test trying to demonstrate that `init` callback can sometimes observe a non-initial context, but simple approach wasn't enough.

This PR makes the change to get the scheduler outside of `Status_line.refresh`.