### PR TITLE
Make iter callback of Fiber.run iter run in same execution context

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2398,12 +2398,15 @@ let init ~stats ~contexts ?build_mutex ~promote_source ?caching
     ; stats
     }
   in
+  let open Fiber.O in
+  let* scheduler = Scheduler.t () in
   Console.Status_line.set (fun () ->
       Some
         (Pp.verbatim
            (sprintf "Done: %u/%u (jobs: %u)" t.rule_done t.rule_total
-              (Scheduler.running_jobs_count ()))));
-  set t
+              (Scheduler.running_jobs_count scheduler))));
+  set t;
+  Fiber.return ()
 
 let cache_teardown () =
   match get_cache () with

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -26,7 +26,7 @@ val init :
   -> ?caching:caching
   -> sandboxing_preference:Sandbox_mode.t list
   -> unit
-  -> unit
+  -> unit Fiber.t
 
 val reset : unit -> unit
 

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -804,9 +804,9 @@ type t =
 
 let t_var : t Fiber.Var.t = Fiber.Var.create ()
 
-let running_jobs_count () =
-  let t = Fiber.Var.get_exn t_var in
-  Event.Queue.pending_jobs t.events
+let t () = Fiber.return (Fiber.Var.get_exn t_var)
+
+let running_jobs_count t = Event.Queue.pending_jobs t.events
 
 let ignore_for_watch p =
   let t = Fiber.Var.get_exn t_var in

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -72,6 +72,11 @@ module Run : sig
     -> 'a
 end
 
+type t
+
+(** Get the instance of the scheduler that runs the current fiber. *)
+val t : unit -> t Fiber.t
+
 (** [with_job_slot f] waits for one job slot (as per [-j <jobs] to become
     available and then calls [f]. *)
 val with_job_slot : (Config.t -> 'a Fiber.t) -> 'a Fiber.t
@@ -89,7 +94,7 @@ val wait_for_dune_cache : unit -> unit
 val ignore_for_watch : Path.t -> unit
 
 (** Number of jobs currently running in the background *)
-val running_jobs_count : unit -> int
+val running_jobs_count : t -> int
 
 (** Execute the given callback with current directory temporarily changed *)
 val with_chdir : dir:Path.t -> f:(unit -> 'a) -> 'a

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -66,9 +66,11 @@ let init_build_system ?stats ?only_packages ~sandboxing_preference ?caching
     let dst = Path.source dst in
     Artifact_substitution.copy_file ?chmod ~src ~dst ~conf ()
   in
-  Build_system.init ~stats ~sandboxing_preference ~promote_source
-    ~contexts:(List.map ~f:Context.build_context w.contexts)
-    ?caching ?build_mutex ();
+  let* () =
+    Build_system.init ~stats ~sandboxing_preference ~promote_source
+      ~contexts:(List.map ~f:Context.build_context w.contexts)
+      ?caching ?build_mutex ()
+  in
   List.iter w.contexts ~f:Context.init_configurator;
   let+ scontexts = Gen_rules.init w.conf ~contexts:w.contexts ?only_packages in
   { workspace = w; scontexts }

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -872,7 +872,10 @@ let run t ~iter =
         | Some res -> res
         | None ->
           let (Fill (ivar, v)) = iter () in
-          Ivar.fill ivar v ignore;
+          (* We use [EC.apply] so that the current execution context is
+             restored, ensuring that [iter] always run in the same execution
+             context. *)
+          EC.apply (fun () -> Ivar.fill ivar v) () ignore;
           loop ()
       in
       loop ())

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -877,10 +877,8 @@ let%expect_test "execution context preservation in iter callback" =
     | 3 -> Fiber.Fill (ivar3, ())
     | _ -> assert false
   in
-  (* BUG: [iter] should always be executed in the same execution context, and so
-     should always observe the same value for [var]. *)
   Fiber.run fiber ~iter;
   [%expect {|
     0: var = None
-    1: var = Some 1
-    2: var = Some 2 |}]
+    1: var = None
+    2: var = None |}]

--- a/test/expect-tests/test_scheduler/test_scheduler.ml
+++ b/test/expect-tests/test_scheduler/test_scheduler.ml
@@ -1,12 +1,19 @@
 open Stdune
 
-type t = unit Fiber.Ivar.t Queue.t
+type job = Job : (unit -> 'a) * 'a Fiber.Ivar.t -> job
+
+type t = job Queue.t
 
 let create () : t = Queue.create ()
 
 let yield t =
   let ivar = Fiber.Ivar.create () in
-  Queue.push t ivar;
+  Queue.push t (Job ((fun () -> ()), ivar));
+  Fiber.Ivar.read ivar
+
+let yield_gen (t : t) ~do_in_scheduler =
+  let ivar = Fiber.Ivar.create () in
+  Queue.push t (Job (do_in_scheduler, ivar));
   Fiber.Ivar.read ivar
 
 exception Never
@@ -15,4 +22,6 @@ let run (t : t) fiber =
   Fiber.run fiber ~iter:(fun () ->
       match Queue.pop t with
       | None -> raise Never
-      | Some e -> Fiber.Fill (e, ()))
+      | Some (Job (job, ivar)) ->
+        let v = job () in
+        Fiber.Fill (ivar, v))

--- a/test/expect-tests/test_scheduler/test_scheduler.mli
+++ b/test/expect-tests/test_scheduler/test_scheduler.mli
@@ -8,4 +8,6 @@ val create : unit -> t
 
 val yield : t -> unit Fiber.t
 
+val yield_gen : t -> do_in_scheduler:(unit -> 'a) -> 'a Fiber.t
+
 val run : t -> 'a Fiber.t -> 'a


### PR DESCRIPTION
Instead of the execution of the last fiber that happened to run. The first commit adds a test that demonstrate the issue, and the second commit fixes it.