### PR TITLE
[cram] Add locks to the Cram stanza

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,8 @@ Unreleased
 - Add an option to swallow the output of actions when they succeed, to
   reduce noise of large builds (#4422, @jeremiedimino)
 
+- Add the possibility to use `locks` with the cram tests stanza (#4397, @voodoos)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -608,6 +608,8 @@ The ``cram`` stanza accepts the following fields:
 - ``alias`` - alias that can be used to run the test. In addition to the user
   alias, every test ``foo.t`` is attached to the ``@runtest`` alias and gets its
   own ``@foo`` alias to make it convenient to run individually.
+- ``(locks (<lock-names>))`` specify that the tests must be run while
+  holding the following locks. See the :ref:`locks` section for more details.
 - ``deps`` - dependencies of the test
 
 A single test may be configured by more than one ``cram`` stanza. In such cases,

--- a/src/dune_rules/cram_stanza.ml
+++ b/src/dune_rules/cram_stanza.ml
@@ -27,6 +27,7 @@ type t =
   ; alias : Alias.Name.t option
   ; deps : Dep_conf.t Bindings.t option
   ; enabled_if : Blang.t
+  ; locks : String_with_vars.t list
   ; package : Package.t option
   }
 
@@ -38,9 +39,14 @@ let decode =
      and+ alias = field_o "alias" Alias.Name.decode
      and+ deps = field_o "deps" (Bindings.decode Dep_conf.decode)
      and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:None ()
+     and+ locks =
+       field "locks"
+         (Dune_lang.Syntax.since Stanza.syntax (2, 9)
+         >>> repeat String_with_vars.decode)
+         ~default:[]
      and+ package =
        Stanza_common.Pkg.field_opt
          ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 8))
          ()
      in
-     { loc; alias; deps; enabled_if; applies_to; package })
+     { loc; alias; deps; enabled_if; locks; applies_to; package })

--- a/src/dune_rules/cram_stanza.mli
+++ b/src/dune_rules/cram_stanza.mli
@@ -6,11 +6,12 @@ type applies_to =
   | Files_matching_in_this_dir of Predicate_lang.Glob.t
 
 type t =
-  { loc : Loc.t
+  { loc : Loc.t (* ; dir : Path.t *)
   ; applies_to : applies_to
   ; alias : Alias.Name.t option
   ; deps : Dep_conf.t Bindings.t option
   ; enabled_if : Blang.t
+  ; locks : String_with_vars.t list
   ; package : Package.t option
   }
 

--- a/test/blackbox-tests/test-cases/tests-locks.t/dune-project
+++ b/test/blackbox-tests/test-cases/tests-locks.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.9)
+
+(cram enable)

--- a/test/blackbox-tests/test-cases/tests-locks.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-locks.t/run.t
@@ -1,0 +1,9 @@
+These tests are run with locks. They should not end together (<> expected)
+  $ dune build --root=. -j 2 --diff-command=diff @all-tests 2>&1 |
+  > grep "^> *" | uniq -c | [ $(wc -l) -eq 1 ] && echo '=' || echo '<>'
+  <>
+
+These tests are run without locks. They should end together (= expected)
+  $ dune build --root=. -j 2 --diff-command=diff @all-tests-nolocks 2>&1 |
+  > grep "^> *" | uniq -c | [ $(wc -l) -eq 1 ] && echo '=' || echo '<>'
+  =

--- a/test/blackbox-tests/test-cases/tests-locks.t/tests-no-locks/b.t
+++ b/test/blackbox-tests/test-cases/tests-locks.t/tests-no-locks/b.t
@@ -1,0 +1,1 @@
+  $ sleep 1 && date +%s

--- a/test/blackbox-tests/test-cases/tests-locks.t/tests-no-locks/dune
+++ b/test/blackbox-tests/test-cases/tests-locks.t/tests-no-locks/dune
@@ -1,0 +1,3 @@
+(cram
+ (applies_to :whole_subtree)
+ (alias all-tests-nolocks))

--- a/test/blackbox-tests/test-cases/tests-locks.t/tests-no-locks/sub/d.t
+++ b/test/blackbox-tests/test-cases/tests-locks.t/tests-no-locks/sub/d.t
@@ -1,0 +1,1 @@
+  $ sleep 1 && date +%s

--- a/test/blackbox-tests/test-cases/tests-locks.t/tests/a.t
+++ b/test/blackbox-tests/test-cases/tests-locks.t/tests/a.t
@@ -1,0 +1,1 @@
+  $ sleep 1 && date +%s

--- a/test/blackbox-tests/test-cases/tests-locks.t/tests/dune
+++ b/test/blackbox-tests/test-cases/tests-locks.t/tests/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to :whole_subtree)
+ (locks a)
+ (alias all-tests))

--- a/test/blackbox-tests/test-cases/tests-locks.t/tests/sub/b.t
+++ b/test/blackbox-tests/test-cases/tests-locks.t/tests/sub/b.t
@@ -1,0 +1,1 @@
+  $ sleep 1 && date +%s


### PR DESCRIPTION
This PR adds locks to the Cram stanza. This is necessary to run some mutually exclusive tests.
For example we have some tests of the Merlin server that fail randomly when executed concurrently.

Of course the hard part is testing these changes:
- I had to turn off `INSIDE_DUNE` but I believe this should not be too dangerous if I then always specify the `--root` of the workspace on the command line ?
- I make the assumption that two identical tests that run concurrently should finish at the same second. This is wrong (but luckily pleased the CI), and I guess we should loop and compute a mean.