### PR TITLE
Reduce stack usage in fiber

### DIFF
--- a/test/blackbox-tests/test-cases/all-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias.t/run.t
@@ -4,8 +4,8 @@
   Entering directory 'private-exe'
       ocamldep .foo.eobjs/foo.ml.d
         ocamlc .foo.eobjs/byte/foo.{cmi,cmo,cmt}
-        ocamlc foo.bc
       ocamlopt .foo.eobjs/native/foo.{cmx,o}
+        ocamlc foo.bc
       ocamlopt foo.exe
 
 @all builds private libs

--- a/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
@@ -6,7 +6,6 @@
   - b
   - a
   - b
-  -> required by a/a.v.d
   -> required by a/a.vo
   -> required by install lib/coq/user-contrib/a/a.vo
   -> required by ccycle.install
@@ -18,7 +17,6 @@
   - a
   - b
   - a
-  -> required by b/b.v.d
   -> required by b/b.vo
   -> required by install lib/coq/user-contrib/b/b.vo
   -> required by ccycle.install

--- a/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
@@ -3,7 +3,6 @@
   4 |  (theories a))
                  ^
   Error: Theory a not found
-  -> required by b/b.v.d
   -> required by b/b.vo
   -> required by install lib/coq/user-contrib/b/b.vo
   -> required by cvendor.install

--- a/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
@@ -4,7 +4,6 @@
                  ^^^^^^^
   Error: Theory "private" is private, it cannot be a dependency of a public
   theory. You need to associate "private" to a package.
-  -> required by public/b.v.d
   -> required by public/b.vo
   -> required by install lib/coq/user-contrib/public/b.vo
   -> required by public.install

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds.t/run.t
@@ -8,8 +8,8 @@ Duplicate mld's in the same scope
           odoc lib1/.root_lib1.objs/byte/root_lib1.odoc
           odoc lib2/.root_lib2.objs/byte/root_lib2.odoc
           odoc _doc/_html/root/Root_lib1/.dummy,_doc/_html/root/Root_lib1/index.html
-          odoc _doc/_html/root/index.html
           odoc _doc/_html/root/Root_lib2/.dummy,_doc/_html/root/Root_lib2/index.html
+          odoc _doc/_html/root/index.html
 
 Duplicate mld's in different scope
   $ rm -rf diff-scope/_build
@@ -22,7 +22,7 @@ Duplicate mld's in different scope
         ocamlc scope2/.scope2.objs/byte/scope2.{cmi,cmo,cmt}
           odoc scope1/.scope1.objs/byte/scope1.odoc
           odoc scope2/.scope2.objs/byte/scope2.odoc
-          odoc _doc/_html/scope1/index.html
           odoc _doc/_html/scope1/Scope1/.dummy,_doc/_html/scope1/Scope1/index.html
-          odoc _doc/_html/scope2/index.html
+          odoc _doc/_html/scope1/index.html
           odoc _doc/_html/scope2/Scope2/.dummy,_doc/_html/scope2/Scope2/index.html
+          odoc _doc/_html/scope2/index.html

--- a/test/blackbox-tests/test-cases/plugin-mode.t/run.t
+++ b/test/blackbox-tests/test-cases/plugin-mode.t/run.t
@@ -83,23 +83,23 @@ Testsuite for (mode plugin).
         ocamlc foo/.foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc main2/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
         ocamlc $ext_lib.eobjs/byte/dune__exe__A.{cmi,cmo,cmt}
+      ocamlopt foo/.foo.objs/native/foo.{cmx,o}
         ocamlc foo/.bar.objs/byte/bar.{cmi,cmo,cmt}
         ocamlc main/.main.eobjs/byte/dune__exe__Main.{cmi,cmo,cmt}
-      ocamlopt foo/.foo.objs/native/foo.{cmx,o}
         ocamlc foo/foo.cma
       ocamlopt main2/.main.eobjs/native/dune__exe__Main.{cmx,o}
       ocamlopt $ext_lib.eobjs/native/dune__exe__A.{cmx,o}
+      ocamlopt foo/foo.{a,cmxa}
         ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
       ocamlopt foo/.bar.objs/native/bar.{cmx,o}
         ocamlc foo/bar.cma
       ocamlopt main/.main.eobjs/native/dune__exe__Main.{cmx,o}
-      ocamlopt foo/foo.{a,cmxa}
       ocamlopt main2/main.exe
       ocamlopt a.cmxs
-      ocamlopt .b.eobjs/native/dune__exe__B.{cmx,o}
-      ocamlopt foo/bar.{a,cmxa}
       ocamlopt a.exe
       ocamlopt foo/foo.cmxs
+      ocamlopt .b.eobjs/native/dune__exe__B.{cmx,o}
+      ocamlopt foo/bar.{a,cmxa}
       ocamlopt main/main.exe
       ocamlopt b.cmxs
       ocamlopt foo/bar.cmxs

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -105,7 +105,10 @@ let%expect_test "invalid client version" =
   ( "{ payload = Some [ [ \"supported versions until\"; [ \"2\"; \"0\" ] ] ]\
    \n; message = \"Unsupported version\"\
    \n; kind = Version_error\
-   \n}") |}]
+   \n}")
+  Trailing output
+  ---------------
+  server: finished. |}]
 
 let%expect_test "call private method" =
   let decl = Decl.request ~method_:"double" Conv.int Conv.int in

--- a/test/expect-tests/test_scheduler/test_scheduler.ml
+++ b/test/expect-tests/test_scheduler/test_scheduler.ml
@@ -7,11 +7,13 @@ type t = job Queue.t
 let create () : t = Queue.create ()
 
 let yield t =
+  Fiber.of_thunk @@ fun () ->
   let ivar = Fiber.Ivar.create () in
   Queue.push t (Job ((fun () -> ()), ivar));
   Fiber.Ivar.read ivar
 
 let yield_gen (t : t) ~do_in_scheduler =
+  Fiber.of_thunk @@ fun () ->
   let ivar = Fiber.Ivar.create () in
   Queue.push t (Job (do_in_scheduler, ivar));
   Fiber.Ivar.read ivar
@@ -19,6 +21,7 @@ let yield_gen (t : t) ~do_in_scheduler =
 exception Never
 
 let run (t : t) fiber =
+  Queue.clear t;
   Fiber.run fiber ~iter:(fun () ->
       match Queue.pop t with
       | None -> raise Never


### PR DESCRIPTION
At the moment, when we call `Ivar.fill` we immediately execute the fibers waiting on this ivar. This means that they might be executed on a stack that is quite deep. I've observed stack overflows because of this while trying Dune inside Jane Street.

This PR changes the implem so that when we call `Ivar.fill`, we only queue the execution of the fibers and actually execute from the toplevel, in `FIber.run`. We create one job queue per call to `Fiber.run` and store it in the execution context.

The code is actually a bit simpler as a result as we don't need to think about context switches anymore in various functions such as `Ivar.fill`, which is nice.

The tests are failing at the moment.