### PR TITLE
Add an option to debug Dune's metabolism

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -39,6 +39,7 @@ type t =
   ; debug_findlib : bool
   ; debug_backtraces : bool
   ; debug_artifact_substitution : bool
+  ; debug_digests : bool
   ; profile : Profile.t option
   ; workspace_file : Arg.Path.t option
   ; root : Workspace_root.t
@@ -132,6 +133,7 @@ let set_common ?log_file c =
   Clflags.debug_findlib := c.debug_findlib;
   Clflags.debug_backtraces c.debug_backtraces;
   Clflags.debug_artifact_substitution := c.debug_artifact_substitution;
+  Clflags.debug_digests := c.debug_digests;
   Clflags.capture_outputs := c.capture_outputs;
   Clflags.diff_command := c.diff_command;
   Clflags.promote := c.promote;
@@ -572,6 +574,11 @@ let term =
       & info
           [ "debug-artifact-substitution" ]
           ~docs ~doc:"Print debugging info about artifact substitution")
+  and+ debug_digests =
+    Arg.(
+      value & flag
+      & info [ "debug-digests" ] ~docs
+          ~doc:"Explain why Dune decides to re-digest some files")
   and+ terminal_persistence =
     let modes = Dune_config.Terminal_persistence.all in
     let doc =
@@ -797,6 +804,7 @@ let term =
   ; debug_findlib
   ; debug_backtraces
   ; debug_artifact_substitution
+  ; debug_digests
   ; profile
   ; capture_outputs = not no_buffer
   ; workspace_file

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -10,6 +10,8 @@ let debug_dep_path = ref false
 
 let debug_artifact_substitution = ref false
 
+let debug_digests = ref false
+
 let capture_outputs = ref true
 
 let debug_backtraces b =

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -15,6 +15,9 @@ val debug_backtraces : bool -> unit
 (** Print debug info about artifact substitution *)
 val debug_artifact_substitution : bool ref
 
+(** Print debug info for cached digests *)
+val debug_digests : bool ref
+
 (** Command to use to diff things *)
 val diff_command : string option ref
 

--- a/test/blackbox-tests/test-cases/debug/digests.t
+++ b/test/blackbox-tests/test-cases/debug/digests.t
@@ -1,0 +1,26 @@
+Test the --debug-digests command line option
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ touch x
+
+The bellow dune file make sure we wait for the fs clock to advance
+after building x and before finishing the build. This is to make this
+test more reproducible as Dune drops entries that have the same mtime
+as the file system clock when saving the digest cache to disk.
+
+  $ cat >dune<<EOF
+  > (rule
+  >  (alias default)
+  >  (deps x)
+  >  (action (run dune_cmd wait-for-fs-clock-to-advance)))
+  > EOF
+
+  $ dune build
+  $ echo 1 > x
+  $ dune build --debug-digests 2>&1 | sed 's/stats =.*/stats = XXX/' | grep -A 5 "file x "
+  Re-digested file x because its stats changed:
+  { old_digest = digest "b83631c134a9649ec383d0eb9c356803"
+  ; new_digest = digest "705e0d7e5030b1831b18211b1e398faf"
+  ; old_stats = XXX
+  ; new_stats = XXX
+  }


### PR DESCRIPTION
This PR add an option `--debug-digests` that makes Dune explain why it decides to re-digest some files:

```
$ dune build x --debug-digests
Re-digested file x because its stats changed:
{ old_digest = digest "b83631c134a9649ec383d0eb9c356803"
; new_digest = digest "705e0d7e5030b1831b18211b1e398faf"
; old_stats = { mtime = 1617030769.38; size = 0; perm = 436 }
; new_stats = { mtime = 1617030769.41; size = 2; perm = 436 }
}
```

I've sometimes wondered why Dune was re-digesting some files. This should help understand why.
