### PR TITLE
Make `Stdune.Path.basename` fail when used on the root of build dir

### DIFF
--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -917,11 +917,19 @@ let append_local = append_local
 let append_source = append_local
 
 let basename t =
-  match kind t with
-  | In_source_dir t -> Local.basename t
-  | External t -> External.basename t
+  match t with
+  | In_build_dir p -> Local.basename p
+  | In_source_tree s -> Local.basename s
+  | External s -> External.basename s
+;;
 
-let basename_opt = basename_opt ~is_root ~basename
+let is_a_root = function
+  | In_build_dir p -> Local.is_root p
+  | In_source_tree s -> Local.is_root s
+  | External s -> External.is_root s
+;;
+
+let basename_opt = basename_opt ~is_root:is_a_root ~basename
 
 let parent = function
   | External s -> Option.map (External.parent s) ~f:external_

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -921,13 +921,11 @@ let basename t =
   | In_build_dir p -> Local.basename p
   | In_source_tree s -> Local.basename s
   | External s -> External.basename s
-;;
 
 let is_a_root = function
   | In_build_dir p -> Local.is_root p
   | In_source_tree s -> Local.is_root s
   | External s -> External.is_root s
-;;
 
 let basename_opt = basename_opt ~is_root:is_a_root ~basename
 


### PR DESCRIPTION
This change makes it so that the `basename` function does not use `Fdecl.get Build.build_dir` and therefore its semantics is stable even if the build directory path changes.

Pragmatically this was motivated by work on the internal janestreet fork of dune where we construct paths at toplevel, so we run into this `Fdecl.get` failing.