### PR TITLE
Make Path.Build.chmod more flexible

### DIFF
--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -610,20 +610,20 @@ module Kind = struct
     | External x -> External (External.relative x (Local.to_string y))
 end
 
-let chmod_generic ~mode ?(stats = None) ?(op = `Set) path =
+let chmod_generic ~mode ?(op = `Set) path =
   let mode =
     match op with
     | `Set -> mode
-    | `Add
-    | `Remove -> (
+    | `Add stats
+    | `Remove stats -> (
       let stats =
         match stats with
         | Some stats -> stats
         | None -> Unix.stat path
       in
       match op with
-      | `Add -> stats.st_perm lor mode
-      | `Remove -> stats.st_perm land lnot mode
+      | `Add _ -> stats.st_perm lor mode
+      | `Remove _ -> stats.st_perm land lnot mode
       | `Set -> assert false)
   in
   Unix.chmod path mode
@@ -723,8 +723,7 @@ module Build = struct
 
   let of_local t = t
 
-  let chmod ~mode ?stats ?op path =
-    chmod_generic ~mode ?stats ?op (to_string path)
+  let chmod ~mode ?op path = chmod_generic ~mode ?op (to_string path)
 
   module Kind = Kind
 end
@@ -1300,8 +1299,7 @@ let string_of_file_kind = function
 let rename old_path new_path =
   Sys.rename (to_string old_path) (to_string new_path)
 
-let chmod ~mode ?stats ?op path =
-  chmod_generic ~mode ?stats ?op (to_string path)
+let chmod ~mode ?op path = chmod_generic ~mode ?op (to_string path)
 
 let follow_symlink path =
   Fpath.follow_symlink (to_string path) |> Result.map ~f:of_string

--- a/otherlibs/stdune-unstable/path.mli
+++ b/otherlibs/stdune-unstable/path.mli
@@ -164,7 +164,7 @@ module Build : sig
     val of_string : string -> t
   end
 
-  (** set the build directory. Can only be called once and must be done before
+  (** Set the build directory. Can only be called once and must be done before
       paths are converted to strings elsewhere. *)
   val set_build_dir : Kind.t -> unit
 
@@ -172,7 +172,17 @@ module Build : sig
 
   val of_local : Local.t -> t
 
-  val chmod : mode:int -> ?op:[ `Add | `Remove | `Set ] -> t -> unit
+  (** Modify permissions of a given path. [op] is [`Set] by default, which sets
+      the permissions exactly to [mode], while [`Add] adds [mode] to the current
+      permissions and [`Remove] removes them. [path] will be [stat]'ed in the
+      [`Add] and [`Remove] cases to determine the current permissions, unless
+      the already computed stats are passed as [stats] to save a system call. *)
+  val chmod :
+       mode:int
+    -> ?stats:Unix.stats option
+    -> ?op:[ `Add | `Remove | `Set ]
+    -> t
+    -> unit
 end
 
 type t = private
@@ -372,10 +382,10 @@ val string_of_file_kind : Unix.file_kind -> string
     oldpath. *)
 val rename : t -> t -> unit
 
-(** Set permissions on the designed files. [op] is [`Set] by default, which sets
-    the permissions exactly to [mode], while [`Add] will add the given [mode] to
-    the current permissions and [`Remove] remove them. [path] will be stat'd in
-    the `Add and `Remove case to determine the current permission, unless the
+(** Modify permissions of a given path. [op] is [`Set] by default, which sets
+    the permissions exactly to [mode], while [`Add] adds [mode] to the current
+    permissions and [`Remove] removes them. [path] will be [stat]'ed in the
+    [`Add] and [`Remove] cases to determine the current permissions, unless the
     already computed stats are passed as [stats] to save a system call. *)
 val chmod :
      mode:int

--- a/otherlibs/stdune-unstable/path.mli
+++ b/otherlibs/stdune-unstable/path.mli
@@ -176,11 +176,10 @@ module Build : sig
       the permissions exactly to [mode], while [`Add] adds [mode] to the current
       permissions and [`Remove] removes them. [path] will be [stat]'ed in the
       [`Add] and [`Remove] cases to determine the current permissions, unless
-      the already computed stats are passed as [stats] to save a system call. *)
+      the already computed stats are passed to save a system call. *)
   val chmod :
        mode:int
-    -> ?stats:Unix.stats option
-    -> ?op:[ `Add | `Remove | `Set ]
+    -> ?op:[ `Set | `Add of Unix.stats option | `Remove of Unix.stats option ]
     -> t
     -> unit
 end
@@ -386,11 +385,10 @@ val rename : t -> t -> unit
     the permissions exactly to [mode], while [`Add] adds [mode] to the current
     permissions and [`Remove] removes them. [path] will be [stat]'ed in the
     [`Add] and [`Remove] cases to determine the current permissions, unless the
-    already computed stats are passed as [stats] to save a system call. *)
+    already computed stats are passed to save a system call. *)
 val chmod :
      mode:int
-  -> ?stats:Unix.stats option
-  -> ?op:[ `Add | `Remove | `Set ]
+  -> ?op:[ `Set | `Add of Unix.stats option | `Remove of Unix.stats option ]
   -> t
   -> unit
 

--- a/otherlibs/stdune-unstable/path.mli
+++ b/otherlibs/stdune-unstable/path.mli
@@ -113,6 +113,17 @@ module External : sig
   val mkdir_p : ?perms:int -> t -> unit
 end
 
+module Permissions : sig
+  (** Write permissions. *)
+  val write : int
+
+  (** Add [mode] permissions to a given mask. *)
+  val add : mode:int -> int -> int
+
+  (** Remove [mode] permissions from a given mask. *)
+  val remove : mode:int -> int -> int
+end
+
 module Build : sig
   type w
 
@@ -172,16 +183,9 @@ module Build : sig
 
   val of_local : Local.t -> t
 
-  (** Modify permissions of a given path. [op] is [`Set] by default, which sets
-      the permissions exactly to [mode], while [`Add] adds [mode] to the current
-      permissions and [`Remove] removes them. [path] will be [stat]'ed in the
-      [`Add] and [`Remove] cases to determine the current permissions, unless
-      the already computed stats are passed to save a system call. *)
-  val chmod :
-       mode:int
-    -> ?op:[ `Set | `Add of Unix.stats option | `Remove of Unix.stats option ]
-    -> t
-    -> unit
+  (** Set permissions for a given path. You can use the [Permissions] module if
+      you need to modify existing permissions in a non-trivial way. *)
+  val chmod : t -> mode:int -> unit
 end
 
 type t = private
@@ -381,16 +385,9 @@ val string_of_file_kind : Unix.file_kind -> string
     oldpath. *)
 val rename : t -> t -> unit
 
-(** Modify permissions of a given path. [op] is [`Set] by default, which sets
-    the permissions exactly to [mode], while [`Add] adds [mode] to the current
-    permissions and [`Remove] removes them. [path] will be [stat]'ed in the
-    [`Add] and [`Remove] cases to determine the current permissions, unless the
-    already computed stats are passed to save a system call. *)
-val chmod :
-     mode:int
-  -> ?op:[ `Set | `Add of Unix.stats option | `Remove of Unix.stats option ]
-  -> t
-  -> unit
+(** Set permissions for a given path. You can use the [Permissions] module if
+    you need to modify existing permissions in a non-trivial way. *)
+val chmod : t -> mode:int -> unit
 
 (** Attempts to resolve a symlink. Returns [None] if the path isn't a symlink *)
 val follow_symlink : t -> (t, Fpath.follow_symlink_error) result

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -278,7 +278,10 @@ let promote_sync cache paths key metadata ~repository ~duplication =
             Path.rename tmp in_the_cache;
             (* Remove write permissions, making the cache entry immutable. We
                assume that users do not modify the files in the cache. *)
-            Path.chmod in_the_cache ~mode:(stat.st_perm land 0o555);
+            Path.chmod in_the_cache
+              ~mode:
+                (Path.Permissions.remove ~mode:Path.Permissions.write
+                   stat.st_perm);
             Result.Ok (Promoted { path; digest = effective_digest })))
   in
   let+ promoted = Result.List.map ~f:promote paths in

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -179,7 +179,7 @@ let refresh_and_chmod fn =
            whether the cache is activated. No need to be zealous in case the
            file is not cached anyway. See issue #3311. *)
         let perm = stats.st_perm land lnot 0o222 in
-        Path.chmod ~stats:(Some stats) ~mode:perm ~op:`Set fn;
+        Path.chmod ~mode:perm fn;
         { stats with st_perm = perm }
       | false -> stats)
   in

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -178,7 +178,9 @@ let refresh_and_chmod fn =
         (* We remove write permissions to uniformize behavior regardless of
            whether the cache is activated. No need to be zealous in case the
            file is not cached anyway. See issue #3311. *)
-        let perm = stats.st_perm land lnot 0o222 in
+        let perm =
+          Path.Permissions.remove ~mode:Path.Permissions.write stats.st_perm
+        in
         Path.chmod ~mode:perm fn;
         { stats with st_perm = perm }
       | false -> stats)


### PR DESCRIPTION
I'm factoring out a few smaller patches out of my upcoming PR on rewriting the shared cache.

This patch removes some code duplication and makes `Path.Build.chmod` more flexible.