### PR TITLE
Allow to set config parameters via the workspace file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,9 @@ Unreleased
 - Fix a bug that was causing Dune to re-hash generated files more
   often than necessary (#4419, @jeremiedimino)
 
+- Fields allowed in the config file are now also allowed in the
+  workspace file (#4426, @jeremiedimino)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -49,8 +49,8 @@ let in_dir ~name ~recursive ~contexts dir =
         ]
     }
 
-let of_string common ~recursive s ~contexts =
-  let path = Path.relative Path.root (Common.prefix_target common s) in
+let of_string (root : Workspace_root.t) ~recursive s ~contexts =
+  let path = Path.relative Path.root (root.reach_from_root_prefix ^ s) in
   if Path.is_root path then
     User_error.raise
       [ Pp.textf "@ on the command line must be followed by a valid alias name"

--- a/bin/alias.mli
+++ b/bin/alias.mli
@@ -15,7 +15,7 @@ val in_dir :
   -> t
 
 val of_string :
-     Common.t
+     Workspace_root.t
   -> recursive:bool
   -> string
   -> contexts:Dune_rules.Context.t list

--- a/bin/build_cmd.mli
+++ b/bin/build_cmd.mli
@@ -1,5 +1,6 @@
 val run_build_command :
      common:Common.t
+  -> config:Dune_config.t
   -> targets:(Dune_rules.Main.build_system -> Target.t list Memo.Build.t)
   -> unit
 

--- a/bin/caching.ml
+++ b/bin/caching.ml
@@ -94,7 +94,7 @@ let path_conv =
 
 let term =
   Term.ret
-  @@ let+ config = Common.config_term
+  @@ let+ config = Common.config_from_config_file
      and+ mode =
        Arg.(
          value
@@ -137,6 +137,7 @@ let term =
          & opt (some bytes) None
          & info ~docv:"BYTES" [ "size" ] ~doc:"size to trim the cache to")
      and+ display = Common.display_term in
+     let config = Dune_config.(superpose default) config in
      match mode with
      | Some Start ->
        let config =

--- a/bin/clean.ml
+++ b/bin/clean.ml
@@ -17,7 +17,7 @@ let command =
        includes deleting the log file. Not only creating the log file would be
        useless but with some FS this also causes [dune clean] to fail (cf
        https://github.com/ocaml/dune/issues/2964). *)
-    Common.set_common common ~log_file:No_log_file;
+    let _config = Common.set_common common ~log_file:No_log_file in
     Build_system.files_in_source_tree_to_delete ()
     |> Path.Set.iter ~f:Path.unlink_no_err;
     Path.rm_rf Path.build_dir

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -156,14 +156,14 @@ let set_common ?log_file c =
      can interpret errors in the workspace file. *)
   print_entering_message c;
   Dune_rules.Workspace.Clflags.set c.workspace_config;
-  let workspace =
+  let config =
     (* Here we make the assumption that this computation doesn't yield. *)
     Fiber.run
-      (Memo.Build.run (Dune_rules.Workspace.workspace ()))
+      (Memo.Build.run (Dune_rules.Workspace.workspace_config ()))
       ~iter:(fun () -> assert false)
   in
   let config =
-    Dune_config.adapt_display workspace.config
+    Dune_config.adapt_display config
       ~output_is_a_tty:(Lazy.force Ansi_color.stderr_supports_color)
   in
   Dune_config.init config;

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -1,20 +1,10 @@
 type t
 
-val workspace_file : t -> Arg.Path.t option
-
-val x : t -> Dune_engine.Context_name.t option
-
-val profile : t -> Dune_rules.Profile.t option
-
 val capture_outputs : t -> bool
 
 val root : t -> Workspace_root.t
 
-val config : t -> Dune_config.t
-
 val rpc : t -> Dune_rpc_impl.Server.t option
-
-val set_config : t -> Dune_config.t -> t
 
 val stats : t -> Stats.t option
 
@@ -36,12 +26,13 @@ val default_target : t -> Arg.Dep.t
 
 val prefix_target : t -> string -> string
 
-val instrument_with : t -> Dune_engine.Lib_name.t list option
-
 (** [set_common] executes sequence of side-effecting actions to initialize
     Dune's working environment based on the options determined in a [Common.t]
-    record.contents. *)
-val set_common : ?log_file:Dune_util.Log.File.t -> t -> unit
+    record.contents.
+
+    Return the final configuration, which is the same as the one returned in the
+    [config] field of [Dune_rules.Workspace.workspace ()]) *)
+val set_common : ?log_file:Dune_util.Log.File.t -> t -> Dune_config.t
 
 (** [examples \[("description", "dune cmd foo"); ...\]] is an [EXAMPLES] manpage
     section of enumerated examples illustrating how to run the documented
@@ -64,7 +55,7 @@ val set_print_directory : t -> bool -> t
 
 val debug_backtraces : bool Cmdliner.Term.t
 
-val config_term : Dune_config.t Cmdliner.Term.t
+val config_from_config_file : Dune_config.Partial.t Cmdliner.Term.t
 
 val display_term : Dune_engine.Scheduler.Config.Display.t option Cmdliner.Term.t
 

--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -29,11 +29,11 @@ let term =
          & info [] ~docv:"INPUT"
              ~doc:"Use $(docv) as the input to the function.")
      in
-     Common.set_common common;
+     let config = Common.set_common common in
      let action =
-       Scheduler.go ~common (fun () ->
+       Scheduler.go ~common ~config (fun () ->
            let open Fiber.O in
-           let* _setup = Import.Main.setup common in
+           let* _setup = Import.Main.setup common config in
            match (fn, inp) with
            | "latest-lang-version", None ->
              Fiber.return

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -307,11 +307,11 @@ let term =
   and+ context_name = Common.context_arg ~doc:"Build context to use."
   and+ format = Format.arg
   and+ lang = Lang.arg in
-  Common.set_common common;
+  let config = Common.set_common common in
   let what = What.parse what ~lang in
-  Scheduler.go ~common (fun () ->
+  Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Import.Main.setup common config in
       let context =
         Import.Main.find_context_exn setup.workspace ~name:context_name
       in

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -43,10 +43,10 @@ let term =
       value & flag
       & info [ "no-build" ] ~doc:"don't rebuild target before executing")
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
-  Common.set_common common;
-  Scheduler.go ~common (fun () ->
+  let config = Common.set_common common in
+  Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Import.Main.setup common config in
       let sctx = Import.Main.find_scontext_exn setup ~name:context in
       let context = Dune_rules.Super_context.context sctx in
       let path_relative_to_build_root p =
@@ -77,7 +77,7 @@ let term =
             | `This_abs p when Path.is_in_build_dir p -> [ p ]
             | `This_abs _ -> [])
             |> List.map ~f:(fun p -> Target.Path p)
-            |> Target.resolve_targets_mixed common setup
+            |> Target.resolve_targets_mixed (Common.root common) config setup
             >>| List.concat_map ~f:(function
                   | Ok targets -> targets
                   | Error _ -> []))

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -209,7 +209,7 @@ let term =
       & opt (some (enum Component.Options.Project.Pkg.commands)) None
       & info [ "pkg" ] ~docv ~doc)
   in
-  Common.set_common common_term;
+  let _config = Common.set_common common_term in
   let open Component in
   let context = Init_context.make path in
   let common : Options.Common.t = { name; libraries; pps } in

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -378,8 +378,8 @@ let install_uninstall ~what =
               "Select context to install from. By default, install files from \
                all defined contexts.")
     and+ sections = Sections.term in
-    Common.set_common ~log_file:No_log_file common;
-    Scheduler.go ~common (fun () ->
+    let config = Common.set_common ~log_file:No_log_file common in
+    Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
         let* workspace = Import.Main.scan_workspace common in
         let contexts =

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -13,12 +13,11 @@ let term =
       & info [ "na"; "not-available" ]
           ~doc:"List libraries that are not available and explain why")
   in
-  Common.set_common common;
+  let config = Common.set_common common in
   let capture_outputs = Common.capture_outputs common in
-  Scheduler.go ~common (fun () ->
+  Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* (_env : Env.t) = Import.Main.setup_env ~capture_outputs in
-      let* () = Memo.Build.run (Workspace.init ()) in
       let* ctxs = Memo.Build.run (Context.DB.all ()) in
       let ctx = List.hd ctxs in
       let findlib = ctx.findlib in

--- a/bin/internal_dump.ml
+++ b/bin/internal_dump.ml
@@ -18,7 +18,7 @@ let term =
   and+ file =
     Arg.(required & pos 0 (some Arg.path) None & Arg.info [] ~docv:"FILE")
   in
-  Common.set_common common;
+  let _config = Common.set_common common in
   let (Persistent.T ((module D), data)) =
     Persistent.load_exn (Arg.Path.path file)
   in

--- a/bin/ocaml_merlin.ml
+++ b/bin/ocaml_merlin.ml
@@ -29,18 +29,10 @@ let term =
              ouptut.")
   in
   let common = Common.set_print_directory common false in
-  Common.set_common common ~log_file:No_log_file;
-  Scheduler.go ~common (fun () ->
+  let config = Common.set_common common ~log_file:No_log_file in
+  Scheduler.go ~common ~config (fun () ->
       Dune_engine.Source_tree.init ~recognize_jbuilder_projects:true
         ~ancestor_vcs:None;
-      let x = Common.x common in
-      let workspace_file =
-        Common.workspace_file common |> Option.map ~f:Arg.Path.path
-      in
-      let open Fiber.O in
-      let* () =
-        Memo.Build.run (Dune_rules.Workspace.init ?x ?workspace_file ())
-      in
       match dump_config with
       | Some s -> Dune_rules.Merlin_server.dump s
       | None -> Dune_rules.Merlin_server.start ())
@@ -74,18 +66,10 @@ module Dump_dot_merlin = struct
               "The path to the folder of which the configuration should be \
                printed. Defaults to the current directory.")
     in
-    Common.set_common common ~log_file:No_log_file;
-    Scheduler.go ~common (fun () ->
+    let config = Common.set_common common ~log_file:No_log_file in
+    Scheduler.go ~common ~config (fun () ->
         Dune_engine.Source_tree.init ~recognize_jbuilder_projects:true
           ~ancestor_vcs:None;
-        let x = Common.x common in
-        let workspace_file =
-          Common.workspace_file common |> Option.map ~f:Arg.Path.path
-        in
-        let open Fiber.O in
-        let* () =
-          Memo.Build.run (Dune_rules.Workspace.init ?x ?workspace_file ())
-        in
         match path with
         | Some s -> Dune_rules.Merlin_server.dump_dot_merlin s
         | None -> Dune_rules.Merlin_server.dump_dot_merlin ".")

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -106,11 +106,11 @@ let term =
              the given targets.")
   and+ syntax = Syntax.term
   and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET") in
-  Common.set_common common;
+  let config = Common.set_common common in
   let out = Option.map ~f:Path.of_string out in
-  Scheduler.go ~common (fun () ->
+  Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Import.Main.setup common config in
       Build_system.run (fun () ->
           let open Memo.Build.O in
           let* request =
@@ -121,7 +121,9 @@ let term =
                       Path.build p :: acc)
               >>| Action_builder.paths
             | _ ->
-              Target.resolve_targets_exn common setup targets >>| Target.request
+              Target.resolve_targets_exn (Common.root common) config setup
+                targets
+              >>| Target.request
           in
           let+ rules =
             Build_system.For_command_line.evaluate_rules ~request ~recursive

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -46,10 +46,10 @@ let term =
             "Only print this field. This option can be repeated multiple times \
              to print multiple fields.")
   in
-  Common.set_common common;
-  Scheduler.go ~common (fun () ->
+  let config = Common.set_common common in
+  Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Import.Main.setup common config in
       let dir = Path.of_string dir in
       let checked = Util.check_path setup.workspace.contexts dir in
       let request =

--- a/bin/promote.ml
+++ b/bin/promote.ml
@@ -22,7 +22,7 @@ let command =
     and+ files =
       Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE")
     in
-    Common.set_common common;
+    let _config = Common.set_common common in
     Promotion.promote_files_registered_in_last_run
       (match files with
       | [] -> All

--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -26,8 +26,8 @@ let wait_for_server common =
 
 let client_term common f =
   let common = Common.set_print_directory common false in
-  Common.set_common common;
-  Scheduler.go ~common (fun () ->
+  let config = Common.set_common common in
+  Scheduler.go ~common ~config (fun () ->
       let where = wait_for_server common in
       let stats = Common.stats common in
       let run =

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -7,7 +7,7 @@ type t =
 val request : t list -> unit Dune_engine.Action_builder.t
 
 val resolve_target :
-     Common.t
+     Workspace_root.t
   -> setup:Dune_rules.Main.build_system
   -> Arg.Dep.t
   -> (t list, Arg.Dep.t * User_message.Style.t Pp.t list) result Memo.Build.t
@@ -17,14 +17,16 @@ type resolve_input =
   | Dep of Arg.Dep.t
 
 val resolve_targets_mixed :
-     Common.t
+     Workspace_root.t
+  -> Dune_config.t
   -> Dune_rules.Main.build_system
   -> resolve_input list
   -> (t list, Arg.Dep.t * User_message.Style.t Pp.t list) result list
      Memo.Build.t
 
 val resolve_targets_exn :
-     Common.t
+     Workspace_root.t
+  -> Dune_config.t
   -> Dune_rules.Main.build_system
   -> Arg.Dep.t list
   -> t list Memo.Build.t

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -29,10 +29,10 @@ let term =
   and+ ctx_name =
     Common.context_arg ~doc:{|Select context where to build/run utop.|}
   in
-  Common.set_common common;
-  Scheduler.go ~common (fun () ->
+  let config = Common.set_common common in
+  Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common in
+      let* setup = Import.Main.setup common config in
       Build_system.run (fun () ->
           let open Memo.Build.O in
           let sctx =

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -15,8 +15,8 @@ let info = Term.info "upgrade" ~doc ~man
 
 let term =
   let+ common = Common.term in
-  Common.set_common common;
-  Scheduler.go ~common (fun () ->
+  let config = Common.set_common common in
+  Scheduler.go ~common ~config (fun () ->
       Dune_engine.Source_tree.init ~recognize_jbuilder_projects:true
         ~ancestor_vcs:None;
       Dune_upgrader.upgrade ())

--- a/bin/workspace_root.mli
+++ b/bin/workspace_root.mli
@@ -11,6 +11,8 @@ end
 type t =
   { dir : string
   ; to_cwd : string list  (** How to reach the cwd from the root *)
+  ; reach_from_root_prefix : string
+        (** Prefix filenames with this to reach them from the root *)
   ; kind : Kind.t  (** Closest VCS in directories strictly above the root *)
   ; ancestor_vcs : Dune_engine.Vcs.t option
   }

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -34,11 +34,11 @@ let local_libraries =
   ; ("src/dune_rpc_server", Some "Dune_rpc_server", false, None)
   ; ("src/csexp_rpc", Some "Csexp_rpc", false, None)
   ; ("src/dune_engine", Some "Dune_engine", false, None)
+  ; ("src/dune_config", Some "Dune_config", false, None)
   ; ("src/dune_rules", Some "Dune_rules", true, None)
   ; ("src/upgrader", Some "Dune_upgrader", false, None)
   ; ("vendor/cmdliner/src", None, false, None)
   ; ("otherlibs/build-info/src", Some "Build_info", false,
     Some "Build_info_data")
-  ; ("src/dune_config", Some "Dune_config", false, None)
   ; ("src/dune_rpc_impl", Some "Dune_rpc_impl", false, None)
   ]

--- a/src/cache/cache_intf.ml
+++ b/src/cache/cache_intf.ml
@@ -40,6 +40,10 @@ module Duplication_mode = struct
   let to_string = function
     | Copy -> "copy"
     | Hardlink -> "hardlink"
+
+  let to_dyn = function
+    | Copy -> Dyn.Variant ("Copy", [])
+    | Hardlink -> Dyn.Variant ("Hardlink", [])
 end
 
 module type Cache = sig

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -75,19 +75,35 @@ end
 
 include S with type 'a field = 'a
 
-module Partial : S with type 'a field := 'a option
+module Partial : sig
+  include S with type 'a field := 'a option
 
-val decode : t Dune_lang.Decoder.t
+  val empty : t
 
-val merge : t -> Partial.t -> t
+  val superpose : t -> t -> t
+
+  val to_dyn : t -> Dyn.t
+end
+
+val decode : Partial.t Dune_lang.Decoder.t
+
+(** Decode the same fields as the one accepted in the configuration file, but
+    coming from the [dune-workspace] file. The main difference is that we
+    started accepting such parameters in the [dune-workspace] file starting from
+    Dune 3.0.0, so the version checks are different. *)
+val decode_fields_of_workspace_file : Partial.t Dune_lang.Decoder.fields_parser
+
+val superpose : t -> Partial.t -> t
 
 val default : t
 
 val user_config_file : Path.t
 
-val load_user_config_file : unit -> t
+(** We return a [Partial.t] here so that the result can easily be merged with
+    other sources of configurations. *)
+val load_user_config_file : unit -> Partial.t
 
-val load_config_file : Path.t -> t
+val load_config_file : Path.t -> Partial.t
 
 (** Set display mode to [Quiet] if it is [Progress], the output is not a tty and
     we are not running inside emacs. *)
@@ -97,6 +113,10 @@ val adapt_display : t -> output_is_a_tty:bool -> t
 val init : t -> unit
 
 val to_dyn : t -> Dyn.t
+
+val hash : t -> int
+
+val equal : t -> t -> bool
 
 val for_scheduler :
      t

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -55,3 +55,4 @@ module Report_error = Report_error
 module Pform = Pform
 module Cm_kind = Cm_kind
 module Mode = Mode
+module Fs_notify_memo = Fs_notify_memo

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -115,3 +115,9 @@ let to_string = function
   | Some Symlink -> "symlink"
   | Some Copy -> "copy"
   | Some Hardlink -> "hardlink"
+
+let to_dyn =
+  Dyn.Encoder.option (function
+    | Symlink -> Dyn.Variant ("Symlink", [])
+    | Copy -> Dyn.Variant ("Copy", [])
+    | Hardlink -> Dyn.Variant ("Hardlink", []))

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -64,3 +64,5 @@ val hardlink : t
 val of_string : string -> (t, string) Result.t
 
 val to_string : t -> string
+
+val to_dyn : t -> Dyn.t

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -22,11 +22,11 @@ module Config = struct
       ; ("quiet", Quiet)
       ]
 
-    let to_string = function
-      | Progress -> "progress"
-      | Quiet -> "quiet"
-      | Short -> "short"
-      | Verbose -> "verbose"
+    let to_dyn = function
+      | Progress -> Dyn.Variant ("Progress", [])
+      | Quiet -> Variant ("Quiet", [])
+      | Short -> Variant ("Short", [])
+      | Verbose -> Variant ("Verbose", [])
 
     let console_backend = function
       | Progress -> Console.Backend.progress

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -13,7 +13,7 @@ module Config : sig
 
     val all : (string * t) list
 
-    val to_string : t -> string
+    val to_dyn : t -> Dyn.t
 
     (** The console backend corresponding to the selected display mode *)
     val console_backend : t -> Console.Backend.t

--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -264,6 +264,10 @@ let capture ctx state =
   let f t = result ctx (t ctx state) in
   (f, [])
 
+let lazy_ t =
+  let+ f = capture in
+  lazy (f t)
+
 let end_of_list (Values (loc, cstr, _)) =
   match cstr with
   | None ->

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -124,6 +124,9 @@ val repeat1 : 'a t -> 'a list t
 (** Capture the rest of the input for later parsing *)
 val capture : ('a t -> 'a) t
 
+(** Delay the parsing of the rest of the input *)
+val lazy_ : 'a t -> 'a Lazy.t t
+
 (** [enter t] expect the next element of the input to be a list and parse its
     contents with [t]. *)
 val enter : 'a t -> 'a t

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -39,6 +39,20 @@ module Version = struct
       ~data_version:(data_major, data_minor) =
     let open Int.Infix in
     parser_major = data_major && parser_minor >= data_minor
+
+  let min a b =
+    match compare a b with
+    | Lt
+    | Eq ->
+      a
+    | Gt -> b
+
+  let max a b =
+    match compare a b with
+    | Lt
+    | Eq ->
+      b
+    | Gt -> a
 end
 
 module Supported_versions = struct

--- a/src/dune_lang/syntax.mli
+++ b/src/dune_lang/syntax.mli
@@ -24,6 +24,10 @@ module Version : sig
 
   val compare : t -> t -> Ordering.t
 
+  val min : t -> t -> t
+
+  val max : t -> t -> t
+
   module Infix : Comparator.OPS with type t = t
 end
 

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -19,7 +19,8 @@
   dune_meta_parser
   dune_section
   build_path_prefix_map
-  dune_engine)
+  dune_engine
+  dune_config)
  (synopsis "Internal Dune library, do not use!"))
 
 (ocamllex ocamlobjinfo cram_lexer)

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -42,14 +42,9 @@ let setup_env ~capture_outputs =
   let+ () = Memo.Build.run (Memo.Run.Fdecl.set Global.env env) in
   env
 
-let scan_workspace ?workspace_file ?x ?(capture_outputs = true) ?profile
-    ?instrument_with ~ancestor_vcs () =
+let scan_workspace ~capture_outputs ~ancestor_vcs () =
   let* env = setup_env ~capture_outputs in
   let* conf = Dune_load.load ~ancestor_vcs in
-  let* () =
-    Memo.Build.run
-      (Workspace.init ?x ?profile ?instrument_with ?workspace_file ())
-  in
   let+ contexts = Memo.Build.run (Context.DB.all ()) in
   List.iter contexts ~f:(fun (ctx : Context.t) ->
       let open Pp.O in

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -19,14 +19,7 @@ val package_install_file :
 
 (** Scan the source tree and discover the overall layout of the workspace. *)
 val scan_workspace :
-     ?workspace_file:Path.t
-  -> ?x:Context_name.t
-  -> ?capture_outputs:bool
-  -> ?profile:Profile.t
-  -> ?instrument_with:Lib_name.t list
-  -> ancestor_vcs:Vcs.t option
-  -> unit
-  -> workspace Fiber.t
+  capture_outputs:bool -> ancestor_vcs:Vcs.t option -> unit -> workspace Fiber.t
 
 (** Load dune files and initializes the build system *)
 val init_build_system :

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -104,3 +104,7 @@ end
 val filename : string
 
 val workspace : unit -> t Memo.Build.t
+
+(** Same as [workspace ()] except that if there are errors related to fields
+    other than the ones of [config], they are not reported. *)
+val workspace_config : unit -> Dune_config.t Memo.Build.t

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -65,11 +65,19 @@ end
 
 (** Representation of a workspace. The list of context is topologically sorted,
     i.e. a context always comes before the contexts where it is used as host
-    context. *)
+    context.
+
+    The various field aggregate all of, by order of precedence:
+
+    - the command line arguments
+    - the contents of the workspace file
+    - the contehts of the user configuration file
+    - the default values *)
 type t = private
   { merlin_context : Context_name.t option
   ; contexts : Context.t list
   ; env : Dune_env.Stanza.t
+  ; config : Dune_config.t
   }
 
 val equal : t -> t -> bool
@@ -78,13 +86,19 @@ val to_dyn : t -> Dyn.t
 
 val hash : t -> int
 
-val init :
-     ?x:Context_name.t
-  -> ?profile:Profile.t
-  -> ?instrument_with:Lib_name.t list
-  -> ?workspace_file:Path.t
-  -> unit
-  -> unit Memo.Build.t
+module Clflags : sig
+  type t =
+    { x : Context_name.t option
+    ; profile : Profile.t option
+    ; instrument_with : Lib_name.t list option
+    ; workspace_file : Path.t option
+    ; config_from_command_line : Dune_config.Partial.t
+    ; config_from_config_file : Dune_config.Partial.t
+    }
+
+  (** This must be called exactly once *)
+  val set : t -> unit
+end
 
 (** Default name of workspace files *)
 val filename : string

--- a/test/blackbox-tests/config/config-in-workspace-file.t
+++ b/test/blackbox-tests/config/config-in-workspace-file.t
@@ -1,0 +1,41 @@
+Test that we can write config parameters in both the configuration
+file and the workspace file.
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat >dune<<EOF
+  > (rule
+  >  (alias default)
+  >  (action (run echo "Hello, world!")))
+  > EOF
+
+Setting such options is not supported with older Dune:
+
+  $ cat >dune-workspace<<EOF
+  > (lang dune 2.8)
+  > (display short)
+  > EOF
+  $ dune build -f
+  File "dune-workspace", line 2, characters 0-15:
+  2 | (display short)
+      ^^^^^^^^^^^^^^^
+  Error: 'display' is only available since version 3.0 of the dune language.
+  Please update your dune-project file to have (lang dune 3.0).
+  [1]
+
+But is supported with Dune >= 3.0.0:
+
+  $ cat >dune-workspace<<EOF
+  > (lang dune 3.0)
+  > (display short)
+  > EOF
+  $ dune build -f
+          echo alias default
+  Hello, world!
+
+  $ cat >dune-workspace<<EOF
+  > (lang dune 3.0)
+  > (display verbose)
+  > EOF
+  $ dune build -f 2>&1 | grep Hello | sed 's/&&.*echo/\&\& echo/'
+  Running[1]: (cd _build/default && echo 'Hello, world!')
+  Hello, world!

--- a/test/blackbox-tests/config/config-in-workspace-file.t
+++ b/test/blackbox-tests/config/config-in-workspace-file.t
@@ -39,3 +39,32 @@ But is supported with Dune >= 3.0.0:
   $ dune build -f 2>&1 | grep Hello | sed 's/&&.*echo/\&\& echo/'
   Running[1]: (cd _build/default && echo 'Hello, world!')
   Hello, world!
+
+Make sure errors related to fields other than the ones allowed in the
+config field are not reported if we don't need to evaluate these
+fields:
+
+  $ mkdir errors
+  $ cd errors
+
+  $ cat >dune-workspace<<EOF
+  > (lang dune 3.0)
+  > (context (blah))
+  > EOF
+  $ cat >dune-project<<EOF
+  > (lang dune 3.0)
+  > (package (name foo))
+  > EOF
+
+  $ dune init project foo
+  Success: initialized project component named foo
+
+But if we do the build we do get an error:
+
+  $ dune build
+  File "dune-workspace", line 2, characters 10-14:
+  2 | (context (blah))
+                ^^^^
+  Error: Unknown constructor blah
+  [1]
+

--- a/test/expect-tests/dune_config/dune
+++ b/test/expect-tests/dune_config/dune
@@ -6,6 +6,7 @@
   dune_lang
   dune_config
   stdune
+  dune_engine
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config

--- a/test/expect-tests/dune_config/dune_config_test.ml
+++ b/test/expect-tests/dune_config/dune_config_test.ml
@@ -7,20 +7,27 @@ let parse s =
   let ast =
     Parser.parse_string ~fname:"expect_test" ~mode:Parser.Mode.Single s
   in
-  Dune_lang.Decoder.parse Dune_config.decode Stdune.Univ_map.empty ast
+  let decode =
+    Dune_lang.Syntax.set Dune_engine.Stanza.syntax
+      (Active (3, 0))
+      Dune_config.decode
+  in
+  Dune_lang.Decoder.parse decode Stdune.Univ_map.empty ast
+  |> Dune_config.(superpose default)
   |> Dune_config.to_dyn |> print_dyn
 
 let%expect_test _ =
   parse "(cache-trim-period 2m)";
   [%expect
     {|
-{ display = "quiet"
-; concurrency = "1"
-; terminal_persistence = "preserve"
+{ display = Quiet
+; concurrency = Fixed 1
+; terminal_persistence = Preserve
 ; sandboxing_preference = []
-; cache_mode = "disabled"
-; cache_transport = "daemon"
+; cache_mode = Disabled
+; cache_transport = Daemon
 ; cache_check_probability = 0.
+; cache_duplication = None
 ; cache_trim_period = 120
 ; cache_trim_size = 10000000000
 }
@@ -58,13 +65,14 @@ let%expect_test _ =
   parse "(cache-trim-size 2kB)";
   [%expect
     {|
-{ display = "quiet"
-; concurrency = "1"
-; terminal_persistence = "preserve"
+{ display = Quiet
+; concurrency = Fixed 1
+; terminal_persistence = Preserve
 ; sandboxing_preference = []
-; cache_mode = "disabled"
-; cache_transport = "daemon"
+; cache_mode = Disabled
+; cache_transport = Daemon
 ; cache_check_probability = 0.
+; cache_duplication = None
 ; cache_trim_period = 600
 ; cache_trim_size = 2000
 }


### PR DESCRIPTION
In preparation of #4422, plus it seems reasonable to allow settings such parameters on a per-workspace basis.

This also refactors the way we initialise the workspace parameters.

One difference is that we now read the workspace file earlier. GIven that many parameters are specific to OCaml, I arranged things so that the interpretation of all the fields that are not part of `Dune_config.t` is delayed.