### PR TITLE
Avoid one initial call to Sys.getcwd

### DIFF
--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -142,7 +142,7 @@ end = struct
 
   let cwd () = make (Sys.getcwd ())
 
-  let initial_cwd = cwd ()
+  let initial_cwd = make Fpath.initial_cwd
 
   let as_local t =
     let s = to_string t in


### PR DESCRIPTION
We are calling `Sys.getcwd` at the toplevel of both Fpath and Path. Let's share this value.
