### PR TITLE
Accept dune-file as dune file name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,9 @@ Unreleased
 - The `@all` alias no longer depends directly on copies of files from the source
   directory (#4461, @nojb)
 
+- Allow dune-file as an alternative file name for dune files (needs to be
+  enabled in the dune-project file) (#4428, @nojb)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -320,6 +320,25 @@ In this mode, dune will populate the ``:standard`` set of C flags with the
 content of ``ocamlc_cflags`` and  ``ocamlc_cppflags``. These flags can be
 completed or overridden using the :ref:`ordered-set-language`.
 
+accept_alternative_dune_file_name
+---------------------------------
+
+Since Dune 3.0, it is possible to use the alternative file name ``dune-file``
+instead of ``dune`` to specify the build. This may be useful to avoid problems
+with ``dune`` files which have the executable permission in a directory that
+happens to be in the ``PATH`` (this can unwittingly happen under Windows).
+
+The feature must be enabled explicitly by adding the following field to
+``dune-project``:
+
+.. code:: scheme
+
+   (accept_alternative_dune_file_name)
+
+Note that ``dune`` continues to be accepted even after enabling this option, but
+if a file named ``dune-file`` is found in a directory, it will take precedence
+over ``dune``.
+
 dune
 ====
 

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -145,6 +145,7 @@ type t =
   ; implicit_transitive_deps : bool
   ; wrapped_executables : bool
   ; executables_implicit_empty_intf : bool
+  ; accept_alternative_dune_file_name : bool
   ; generate_opam_files : bool
   ; use_standard_c_and_cxx_flags : bool option
   ; file_key : File_key.t
@@ -199,6 +200,7 @@ let to_dyn
     ; implicit_transitive_deps
     ; wrapped_executables
     ; executables_implicit_empty_intf
+    ; accept_alternative_dune_file_name
     ; generate_opam_files
     ; use_standard_c_and_cxx_flags
     ; file_key
@@ -222,6 +224,8 @@ let to_dyn
     ; ("implicit_transitive_deps", bool implicit_transitive_deps)
     ; ("wrapped_executables", bool wrapped_executables)
     ; ("executables_implicit_empty_intf", bool executables_implicit_empty_intf)
+    ; ( "accept_alternative_dune_file_name"
+      , bool accept_alternative_dune_file_name )
     ; ("generate_opam_files", bool generate_opam_files)
     ; ("use_standard_c_and_cxx_flags", option bool use_standard_c_and_cxx_flags)
     ; ("file_key", string file_key)
@@ -496,6 +500,7 @@ let infer ~dir packages =
   ; implicit_transitive_deps
   ; wrapped_executables
   ; executables_implicit_empty_intf
+  ; accept_alternative_dune_file_name = false
   ; stanza_parser
   ; project_file
   ; extension_args
@@ -591,6 +596,9 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
         and+ executables_implicit_empty_intf =
           field_o_b "executables_implicit_empty_intf"
             ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 9))
+        and+ accept_alternative_dune_file_name =
+          field_b "accept_alternative_dune_file_name"
+            ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
         and+ () = Dune_lang.Versioned_file.no_more_lang
         and+ generate_opam_files =
           field_o_b "generate_opam_files"
@@ -767,6 +775,7 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
         ; implicit_transitive_deps
         ; wrapped_executables
         ; executables_implicit_empty_intf
+        ; accept_alternative_dune_file_name
         ; generate_opam_files
         ; use_standard_c_and_cxx_flags
         ; dialects
@@ -814,6 +823,8 @@ let set_parsing_context t parser =
 let wrapped_executables t = t.wrapped_executables
 
 let executables_implicit_empty_intf t = t.executables_implicit_empty_intf
+
+let accept_alternative_dune_file_name t = t.accept_alternative_dune_file_name
 
 let () =
   let open Dune_lang.Decoder in

--- a/src/dune_engine/dune_project.mli
+++ b/src/dune_engine/dune_project.mli
@@ -163,6 +163,8 @@ val wrapped_executables : t -> bool
 
 val executables_implicit_empty_intf : t -> bool
 
+val accept_alternative_dune_file_name : t -> bool
+
 val strict_package_deps : t -> bool
 
 val cram : t -> bool

--- a/src/dune_engine/source_tree.mli
+++ b/src/dune_engine/source_tree.mli
@@ -6,6 +6,8 @@ open! Import
 module Dune_file : sig
   val fname : string
 
+  val alternative_fname : string
+
   val jbuild_fname : string
 
   type kind = private

--- a/test/blackbox-tests/test-cases/alternative-dune-fname.t/run.t
+++ b/test/blackbox-tests/test-cases/alternative-dune-fname.t/run.t
@@ -1,0 +1,43 @@
+Check support for alternative dune file name "dune-file".
+
+The feature is not supported in < 3.0.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.8)
+  > (accept_alternative_dune_file_name)
+  > EOF
+  $ dune build
+  File "dune-project", line 2, characters 0-35:
+  2 | (accept_alternative_dune_file_name)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'accept_alternative_dune_file_name' is only available since version
+  3.0 of the dune language. Please update your dune-project file to have (lang
+  dune 3.0).
+  [1]
+
+The feature *is* supported in 3.0 and later, but it is opt-in:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule (alias foo) (action (echo "In dune")))
+  > EOF
+
+  $ cat >dune-file <<EOF
+  > (rule (alias foo) (action (echo "In dune-file")))
+  > EOF
+
+  $ dune build @foo
+  In dune
+
+Need to enable explicitly:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > (accept_alternative_dune_file_name)
+  > EOF
+
+  $ dune build @foo
+  In dune-file


### PR DESCRIPTION
As discussed in #4386 we decided to allow an alternative name for dune files. As a first step, the present PR allows `dune-file` as an alternative to `dune` (with `dune-file` taking precedence over `dune`). A couple of questions:

- do we version this change?

- what about the documentation? do we publicize `dune-file` as the "official" name from now on?

Fixes #4386 