### PR TITLE
Introduce execution parameters

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -207,7 +207,7 @@ let rec is_dynamic = function
 
 let prepare_managed_paths ~link ~sandboxed deps =
   let steps =
-    Path.Map.foldi (Dep.Facts.paths deps) ~init:[] ~f:(fun path _ acc ->
+    Path.Map.foldi deps ~init:[] ~f:(fun path _ acc ->
         match Path.as_in_build_dir path with
         | None ->
           (* This can actually raise if we try to sandbox the "copy from source

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -105,7 +105,7 @@ val sandbox :
      t
   -> sandboxed:(Path.Build.t -> Path.Build.t)
   -> mode:Sandbox_mode.some
-  -> deps:Dep.Fact.t Dep.Map.t
+  -> deps:_ Path.Map.t
   -> t
 
 type is_useful =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1638,6 +1638,15 @@ end = struct
                         | Some path -> Fs.mkdir_p (sandboxed path)))
                 in
                 let+ () = Memo.Build.run (Fs.mkdir_p (sandboxed dir)) in
+                let deps =
+                  if
+                    Execution_parameters.should_expand_aliases_when_sandboxing
+                      exec_params
+                  then
+                    Dep.Facts.paths deps
+                  else
+                    Dep.Facts.paths_without_expanding_aliases deps
+                in
                 ( Some sandboxed
                 , Action.sandbox action ~sandboxed ~mode:sandbox_mode ~deps )
             and* () =

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -209,6 +209,16 @@ module Facts = struct
         | Alias ps ->
           Path.Map.union acc ps.files ~f:(fun _ a _ -> Some a))
 
+  let paths_without_expanding_aliases t =
+    Map.fold t ~init:Path.Map.empty ~f:(fun fact acc ->
+        match (fact : Fact.t) with
+        | Nothing
+        | Alias _ ->
+          acc
+        | File (p, d) -> Path.Map.set acc p d
+        | File_selector (_, ps) ->
+          Path.Map.union acc ps.files ~f:(fun _ a _ -> Some a))
+
   let group_paths_as_fact_files ts =
     let fact_files, paths =
       List.fold_left ts ~init:([], Path.Map.empty) ~f:(fun acc t ->

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -87,6 +87,8 @@ module Facts : sig
   (** Return all the paths, expanding aliases *)
   val paths : t -> Digest.t Path.Map.t
 
+  val paths_without_expanding_aliases : t -> Digest.t Path.Map.t
+
   (** Create a single [Fact.Files.t] from all the paths contained in a list of
       fact maps. Does so while preserving as much sharing as possible with the
       original [Files.t]. *)

--- a/src/dune_engine/dune_project.mli
+++ b/src/dune_engine/dune_project.mli
@@ -168,3 +168,5 @@ val strict_package_deps : t -> bool
 val cram : t -> bool
 
 val info : t -> Package.Info.t
+
+val execution_parameters : t -> Execution_parameters.t

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -16,3 +16,5 @@ let to_dyn { dune_version } =
 
 let should_remove_write_permissions_on_generated_files t =
   t.dune_version >= (2, 4)
+
+let should_expand_aliases_when_sandboxing t = t.dune_version >= (3, 0)

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -1,0 +1,18 @@
+open Stdune
+
+type t = { dune_version : Dune_lang.Syntax.Version.t }
+
+let make ~dune_version = { dune_version }
+
+let equal { dune_version } t =
+  Dune_lang.Syntax.Version.equal dune_version t.dune_version
+
+let hash { dune_version } = Dune_lang.Syntax.Version.hash dune_version
+
+let dune_version t = t.dune_version
+
+let to_dyn { dune_version } =
+  Dyn.Record [ ("dune_version", Dune_lang.Syntax.Version.to_dyn dune_version) ]
+
+let should_remove_write_permissions_on_generated_files t =
+  t.dune_version >= (2, 4)

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -1,0 +1,30 @@
+(** Parameters that influence rule execution *)
+
+(** Such as:
+
+    - should target be set read-only?
+
+    - should aliases be expanded when sandboxing rules?
+
+    These often depend on the version of the Dune language used, which is
+    written in the [dune-project] file. Depending on the execution parameters
+    rather than the whole [dune-project] file means that when some part of the
+    [dune-project] file changes and this part does not have an effect on rule
+    execution, we can skip a bunch of work by not trying to re-execute all the
+    rules. *)
+
+open Stdune
+
+type t
+
+val equal : t -> t -> bool
+
+val hash : t -> int
+
+val to_dyn : t -> Dyn.t
+
+val make : dune_version:Dune_lang.Syntax.Version.t -> t
+
+val dune_version : t -> Dune_lang.Syntax.Version.t
+
+val should_remove_write_permissions_on_generated_files : t -> bool

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -28,3 +28,5 @@ val make : dune_version:Dune_lang.Syntax.Version.t -> t
 val dune_version : t -> Dune_lang.Syntax.Version.t
 
 val should_remove_write_permissions_on_generated_files : t -> bool
+
+val should_expand_aliases_when_sandboxing : t -> bool

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -675,6 +675,20 @@ let nearest_dir path =
   let* root = root () in
   nearest_dir root components
 
+let execution_parameters_of_dir =
+  let f path =
+    let+ dir = nearest_dir path in
+    Dune_project.execution_parameters (Dir0.project dir)
+  in
+  let memo =
+    Memo.create "execution-parameters-of-dir"
+      ~doc:"Return the execution parameters of a given directory"
+      ~input:(module Path.Source)
+      ~output:(Allow_cutoff (module Execution_parameters))
+      ~visibility:Hidden f
+  in
+  Memo.exec memo
+
 let nearest_vcs path = nearest_dir path >>| Dir0.vcs
 
 let files_of path =

--- a/src/dune_engine/source_tree.mli
+++ b/src/dune_engine/source_tree.mli
@@ -109,3 +109,7 @@ val is_vendored : Path.Source.t -> bool Memo.Build.t
 val file_exists : Path.Source.t -> bool Memo.Build.t
 
 val find_dir_specified_on_command_line : dir:Path.Source.t -> Dir.t Memo.Build.t
+
+(** Return the execution parameters for the following directory *)
+val execution_parameters_of_dir :
+  Path.Source.t -> Execution_parameters.t Memo.Build.t

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
@@ -3,7 +3,7 @@
   $ cd a
 
   $ cat >dune-project <<EOF
-  > (lang dune 2.9)
+  > (lang dune 3.0)
   > EOF
   $ echo old-contents > x
   $ cat >dune <<EOF
@@ -35,6 +35,23 @@ And the path does appear in the sandbox:
   $ dune build @b --sandbox copy 2>&1 | grep -v 'cd _build/.sandbox'
           bash alias b
   running b: new-contents
+
+However, this is only since 3.0, before that aliases where not
+expanded when creating the sandbox:
+
+  $ echo '(lang dune 2.8)' > dune-project
+  $ dune clean
+  $ dune build @b --sandbox copy 2>&1 | grep -v 'cd _build/.sandbox'
+  File "dune", line 5, characters 0-89:
+  5 | (rule
+  6 |   (alias b)
+  7 |   (deps (alias a))
+  8 |   (action (bash "echo -n \"running b: \"; cat x"))
+  9 | )
+          bash alias b (exit 1)
+  running b: cat: x: No such file or directory
+  $ echo '(lang dune 3.0)' > dune-project
+
 Now test that including an alias into another alias includes its expansion:
   $ cat >dune <<EOF
   > (alias


### PR DESCRIPTION
Which capture all the information that might influence rule execution. Right now, this is only the dune language version, but I plan to add `swallow_stdout_on_success` in there as well after. The new module `Execution_parameters` also collect the various behaviour that depend on the dune version, such as:

```
val should_remove_write_permissions_on_generated_files : t -> bool
```

This PR also adds a function `Source_tree.execution_parameters_of_dir` which has a cutoff. The rationale is to make `execute_rule` depend only on this value rather than on the whole `Dune_project.t`, which is bigger and might change more often.

The second commit introduce `should_expand_aliases_when_sandboxing : t -> bool` so that the expansion of aliases when sandboxing only takes effect when using lang dune >= 3.0.

