### PR TITLE
Add (enabled_if) support to the mdx stanza

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -136,6 +136,8 @@ Unreleased
 - Remove `dune compute`. It was broken and unused (#4540,
   @jeremiedimino)
 
+- Add `(enabled_if ...)` to `(mdx ...)` (#4434, @emillon)
+
 2.9.0 (unreleased)
 ------------------
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -136,7 +136,7 @@ end = struct
     | Cinaps.T cinaps ->
       let+ () = Cinaps.gen_rules sctx cinaps ~dir ~scope in
       empty_none
-    | Mdx.T mdx ->
+    | Mdx.T mdx when Expander.eval_blang expander (Mdx.enabled_if mdx) ->
       let+ () = Mdx.gen_rules ~sctx ~dir ~expander mdx in
       empty_none
     | _ -> Memo.Build.return empty_none

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -126,7 +126,10 @@ type t =
   ; files : Predicate_lang.Glob.t
   ; packages : (Loc.t * Package.Name.t) list
   ; preludes : Prelude.t list
+  ; enabled_if : Blang.t
   }
+
+let enabled_if t = t.enabled_if
 
 type Stanza.t += T of t
 
@@ -147,8 +150,11 @@ let decode =
        field "files" Predicate_lang.Glob.decode ~default:default_files
      and+ packages =
        field ~default:[] "packages" (repeat (located Package.Name.decode))
-     and+ preludes = field ~default:[] "preludes" (repeat Prelude.decode) in
-     { loc; files; packages; preludes })
+     and+ preludes = field ~default:[] "preludes" (repeat Prelude.decode)
+     and+ enabled_if =
+       Enabled_if.decode ~allowed_vars:Any ~since:(Some (2, 9)) ()
+     in
+     { loc; files; packages; preludes; enabled_if })
 
 let () =
   let open Dune_lang.Decoder in

--- a/src/dune_rules/mdx.mli
+++ b/src/dune_rules/mdx.mli
@@ -5,6 +5,8 @@ open Stdune
 
 type t
 
+val enabled_if : t -> Blang.t
+
 type Stanza.t += T of t
 
 (** Generates the rules to handle the given mdx stanza *)

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if-old-lang-dune/dune
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if-old-lang-dune/dune
@@ -1,0 +1,2 @@
+(mdx
+ (enabled_if true))

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if-old-lang-dune/dune-project
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if-old-lang-dune/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.8)
+(using mdx 0.1)

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/dune
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/dune
@@ -1,0 +1,7 @@
+(mdx
+ (files iftrue.md)
+ (enabled_if true))
+
+(mdx
+ (files iffalse.md)
+ (enabled_if false))

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/dune-project
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.9)
+(using mdx 0.1)

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/iffalse.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/iffalse.md
@@ -1,0 +1,3 @@
+```ocaml
+# print_endline "run in iffalse"
+```

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/iftrue.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/enabled-if/iftrue.md
@@ -1,0 +1,3 @@
+```ocaml
+# print_endline "run in iftrue"
+```

--- a/test/blackbox-tests/test-cases/mdx-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza.t/run.t
@@ -71,3 +71,23 @@ You can set MDX preludes using the preludes field of the stanza
 
   $ dune runtest --root preludes
   Entering directory 'preludes'
+
+The mdx stanza supports (enabled_if):
+
+  $ dune runtest --root enabled-if
+  Entering directory 'enabled-if'
+  File "iftrue.md", line 1, characters 0-0:
+  Error: Files _build/default/iftrue.md and
+  _build/default/.mdx/iftrue.md.corrected differ.
+  [1]
+
+(enabled_if) needs a recent (lang dune):
+
+  $ dune runtest --root enabled-if-old-lang-dune
+  Entering directory 'enabled-if-old-lang-dune'
+  File "dune", line 2, characters 1-18:
+  2 |  (enabled_if true))
+       ^^^^^^^^^^^^^^^^^
+  Error: 'enabled_if' is only available since version 2.9 of the dune language.
+  Please update your dune-project file to have (lang dune 2.9).
+  [1]


### PR DESCRIPTION
This brings useful workflows such as disabling failing mdx test depending on the OS.

This is an ad-hoc solution until #4080 is implemented but looks safer for 2.x.