### PR TITLE
Reduce interleaving between actions

### DIFF
--- a/test/blackbox-tests/test-cases/actions/actions-with-multiple-run.t
+++ b/test/blackbox-tests/test-cases/actions/actions-with-multiple-run.t
@@ -1,0 +1,46 @@
+Actions running multiple programs
+=================================
+
+In the bellow example, we have an action that executes several
+external programs in sequence. Several of these programs print
+something to stdout.
+
+We arange things so that while this sequence of programs are being
+executed, Dune ends up running another program from another
+independent action that also prints to stdout.
+
+To make sure things happen in the right order, we busy wait on files
+being created.
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat>dune <<EOF
+  > (rule
+  >  (alias default)
+  >  (deps (sandbox none))
+  >  (action
+  >   (progn
+  >    (run dune_cmd echo A)
+  >    (run touch x0)
+  >    (run dune_cmd wait-for-file-to-appear x1)
+  >    (run dune_cmd echo B))))
+  > 
+  > (rule
+  >  (alias default)
+  >  (deps (sandbox none))
+  >  (action
+  >   (progn
+  >    (run dune_cmd wait-for-file-to-appear x0)
+  >    (run dune_cmd echo Other)
+  >    (run touch x1))))
+  > EOF
+
+At the moment, the output of the two actions is interleaved, which is
+not great:
+
+  $ dune build -j2
+      dune_cmd alias default
+  A
+      dune_cmd alias default
+  Other
+      dune_cmd alias default
+  B

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -8,6 +8,35 @@ let register name of_args run =
       let t = of_args args in
       run t)
 
+module Echo = struct
+  let name = "echo"
+
+  let of_args args = args
+
+  let run l = print_endline (String.concat ~sep:" " l)
+
+  let () = register name of_args run
+end
+
+module Wait_for_file_to_appear = struct
+  type t = { file : Path.t }
+
+  let name = "wait-for-file-to-appear"
+
+  let of_args = function
+    | [ file ] ->
+      let file = Path.of_filename_relative_to_initial_cwd file in
+      { file }
+    | _ -> raise (Arg.Bad (sprintf "1 argument must be provided"))
+
+  let run { file } =
+    while not (Path.exists file) do
+      Unix.sleepf 0.01
+    done
+
+  let () = register name of_args run
+end
+
 module Stat = struct
   type data =
     | Hardlinks


### PR DESCRIPTION
This PR adds a test showing that the output of different actions may be interleaved when they run several programs, and then changes this behavior.