### PR TITLE
Remove VCS support from Dune cache

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -85,9 +85,6 @@ val set_rule_generators :
            option)
   -> unit Fiber.t
 
-(** Set the list of VCS repositiories contained in the source tree *)
-val set_vcs : Vcs.t list -> unit Fiber.t
-
 (** All other functions in this section must be called inside the rule generator
     callback. *)
 

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -17,7 +17,6 @@ type conf = private
   { dune_files : Dune_files.t
   ; packages : Package.t Package.Name.Map.t
   ; projects : Dune_project.t list
-  ; vcs : Vcs.t list
   }
 
 (** Initialize the file tree and load all dune files. *)

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -409,7 +409,7 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
 
 let init ~contexts ?only_packages conf =
   let open Fiber.O in
-  let { Dune_load.dune_files; packages; projects; vcs } = conf in
+  let { Dune_load.dune_files; packages; projects } = conf in
   let packages = Option.value only_packages ~default:packages in
   let* sctxs =
     let open Memo.Build.O in
@@ -468,7 +468,7 @@ let init ~contexts ?only_packages conf =
             (Path.Build.Map.find map path)
             ~default:Package.Id.Set.empty)
   in
-  let* () =
+  let+ () =
     Build_system.set_rule_generators
       ~init:(fun () ->
         Context_name.Map.iter sctxs ~f:Odoc.init |> Memo.Build.return)
@@ -480,5 +480,4 @@ let init ~contexts ?only_packages conf =
           Context_name.Map.find sctxs ctx
           |> Option.map ~f:(fun sctx -> gen_rules ~sctx))
   in
-  let+ () = Build_system.set_vcs vcs in
   sctxs


### PR DESCRIPTION
Stop keeping track of VCS commit in `build_system.ml`.

We found that in the cloud setting, restoring artifacts rule by rule is fast enough, so we no longer plan to support the bulk download mode where we fetch all artifacts corresponding to a git commit. This was the only reason to keep VCS information.

(This is extracted from #4443.)
