### PR TITLE
Rework initialisation code

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -80,7 +80,7 @@ let runtest =
              let dir = Path.(relative root) (Common.prefix_target common dir) in
              Target.Alias
                (Alias.in_dir ~name:Dune_engine.Alias.Name.runtest
-                  ~recursive:true ~contexts:setup.workspace.contexts dir))
+                  ~recursive:true ~contexts:setup.contexts dir))
     in
     run_build_command ~common ~config ~targets
   in

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -73,7 +73,7 @@ let runtest =
   let term =
     let+ common = Common.term
     and+ dirs = Arg.(value & pos_all string [ "." ] name_) in
-    let config = Common.set_common common in
+    let config = Common.init common in
     let targets (setup : Import.Main.build_system) =
       Memo.Build.return
       @@ List.map dirs ~f:(fun dir ->
@@ -114,7 +114,7 @@ let build =
       | [] -> [ Common.default_target common ]
       | _ :: _ -> targets
     in
-    let config = Common.set_common common in
+    let config = Common.init common in
     let targets setup =
       Target.resolve_targets_exn (Common.root common) config setup targets
     in

--- a/bin/clean.ml
+++ b/bin/clean.ml
@@ -17,7 +17,7 @@ let command =
        includes deleting the log file. Not only creating the log file would be
        useless but with some FS this also causes [dune clean] to fail (cf
        https://github.com/ocaml/dune/issues/2964). *)
-    let _config = Common.set_common common ~log_file:No_log_file in
+    let _config = Common.init common ~log_file:No_log_file in
     Build_system.files_in_source_tree_to_delete ()
     |> Path.Set.iter ~f:Path.unlink_no_err;
     Path.rm_rf Path.build_dir

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -178,6 +178,7 @@ let set_common ?log_file ?(recognize_jbuilder_projects = false) c =
          (Dune_engine.Execution_parameters.builtin_default
          |> Dune_rules.Workspace.update_execution_parameters w)
     |> S.set_recognize_jbuilder_projects recognize_jbuilder_projects);
+  Dune_rules.Global.init ~capture_outputs:c.capture_outputs;
   Clflags.debug_dep_path := c.debug_dep_path;
   Clflags.debug_findlib := c.debug_findlib;
   Clflags.debug_backtraces c.debug_backtraces;

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -148,7 +148,7 @@ let print_entering_message c =
     in
     Console.print [ Pp.verbatim (sprintf "Entering directory '%s'" dir) ]
 
-let set_common ?log_file ?(recognize_jbuilder_projects = false) c =
+let init ?log_file ?(recognize_jbuilder_projects = false) c =
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;
   Path.set_root (normalize_path (Path.External.cwd ()));
   Path.Build.set_build_dir (Path.Build.Kind.of_string c.build_dir);

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -26,13 +26,13 @@ val default_target : t -> Arg.Dep.t
 
 val prefix_target : t -> string -> string
 
-(** [set_common] executes sequence of side-effecting actions to initialize
-    Dune's working environment based on the options determined in a [Common.t]
+(** [init] executes sequence of side-effecting actions to initialize Dune's
+    working environment based on the options determined in a [Common.t]
     record.contents.
 
     Return the final configuration, which is the same as the one returned in the
     [config] field of [Dune_rules.Workspace.workspace ()]) *)
-val set_common :
+val init :
      ?log_file:Dune_util.Log.File.t
   -> ?recognize_jbuilder_projects:bool
   -> t

--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -29,7 +29,7 @@ let term =
          & info [] ~docv:"INPUT"
              ~doc:"Use $(docv) as the input to the function.")
      in
-     let config = Common.set_common common in
+     let config = Common.init common in
      let action =
        Scheduler.go ~common ~config (fun () ->
            let open Fiber.O in

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -307,7 +307,7 @@ let term =
   and+ context_name = Common.context_arg ~doc:"Build context to use."
   and+ format = Format.arg
   and+ lang = Lang.arg in
-  let config = Common.set_common common in
+  let config = Common.init common in
   let what = What.parse what ~lang in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -43,7 +43,7 @@ let term =
       value & flag
       & info [ "no-build" ] ~doc:"don't rebuild target before executing")
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
-  let config = Common.set_common common in
+  let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup common config in

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -79,14 +79,12 @@ let make_cache (config : Dune_config.t) =
 module Main = struct
   include Dune_rules.Main
 
-  let scan_workspace (common : Common.t) =
-    let capture_outputs = Common.capture_outputs common in
-    scan_workspace ~capture_outputs ()
+  let scan_workspace = scan_workspace
 
   let setup ?build_mutex common config =
     let open Fiber.O in
     let* caching = make_cache config in
-    let* workspace = scan_workspace common in
+    let* workspace = Memo.Build.run (scan_workspace ()) in
     let* only_packages =
       match Common.only_packages common with
       | None -> Fiber.return None

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -209,7 +209,7 @@ let term =
       & opt (some (enum Component.Options.Project.Pkg.commands)) None
       & info [ "pkg" ] ~docv ~doc)
   in
-  let _config = Common.set_common common_term in
+  let _config = Common.init common_term in
   let open Component in
   let context = Init_context.make path in
   let common : Options.Common.t = { name; libraries; pps } in

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -26,8 +26,32 @@ let get_dirs context ~prefix_from_command_line ~libdir_from_command_line =
     in
     (prefix, libdir)
 
-let resolve_package_install setup pkg =
-  match Import.Main.package_install_file setup pkg with
+module Workspace = struct
+  type t =
+    { packages : Package.t Package.Name.Map.t
+    ; contexts : Context.t list
+    }
+
+  let get () =
+    let open Memo.Build.O in
+    Memo.Build.run
+      (let+ conf = Dune_rules.Dune_load.load ()
+       and+ contexts = Context.DB.all () in
+       { packages = conf.packages; contexts })
+
+  let package_install_file t pkg =
+    match Package.Name.Map.find t.packages pkg with
+    | None -> Error ()
+    | Some p ->
+      let name = Package.name p in
+      let dir = Package.dir p in
+      Ok
+        (Path.Source.relative dir
+           (Dune_engine.Utils.install_file ~package:name ~findlib_toolchain:None))
+end
+
+let resolve_package_install workspace pkg =
+  match Workspace.package_install_file workspace pkg with
   | Ok path -> path
   | Error () ->
     let pkg = Package.Name.to_string pkg in
@@ -36,7 +60,7 @@ let resolve_package_install setup pkg =
       ~hints:
         (User_message.did_you_mean pkg
            ~candidates:
-             (Package.Name.Map.keys setup.conf.packages
+             (Package.Name.Map.keys workspace.packages
              |> List.map ~f:Package.Name.to_string))
 
 let print_unix_error f =
@@ -81,7 +105,7 @@ module type File_operations = sig
 end
 
 module type Workspace = sig
-  val workspace : Dune_rules.Main.workspace
+  val workspace : Workspace.t
 end
 
 module File_ops_dry_run : File_operations = struct
@@ -129,7 +153,7 @@ module File_ops_real (W : Workspace) : File_operations = struct
       plain_copy ()
     | No_version_needed -> plain_copy ()
     | Need_version print -> (
-      (match Package.Name.Map.find workspace.conf.packages package with
+      (match Package.Name.Map.find workspace.packages package with
       | None -> Fiber.return None
       | Some package -> Memo.Build.run (get_vcs (Package.dir package)))
       >>= function
@@ -381,16 +405,26 @@ let install_uninstall ~what =
     let config = Common.init ~log_file:No_log_file common in
     Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
-        let* workspace = Memo.Build.run (Import.Main.scan_workspace ()) in
+        let* workspace = Workspace.get () in
         let contexts =
           match context with
           | None -> workspace.contexts
-          | Some name -> [ Import.Main.find_context_exn workspace ~name ]
+          | Some name -> (
+            match
+              List.find workspace.contexts ~f:(fun c ->
+                  Dune_engine.Context_name.equal c.name name)
+            with
+            | Some ctx -> [ ctx ]
+            | None ->
+              User_error.raise
+                [ Pp.textf "Context %S not found!"
+                    (Dune_engine.Context_name.to_string name)
+                ])
         in
         let* pkgs =
           match pkgs with
           | [] ->
-            Fiber.parallel_map (Package.Name.Map.values workspace.conf.packages)
+            Fiber.parallel_map (Package.Name.Map.values workspace.packages)
               ~f:(fun pkg ->
                 package_is_vendored pkg >>| function
                 | true -> None

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -381,7 +381,7 @@ let install_uninstall ~what =
     let config = Common.set_common ~log_file:No_log_file common in
     Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
-        let* workspace = Import.Main.scan_workspace common in
+        let* workspace = Memo.Build.run (Import.Main.scan_workspace ()) in
         let contexts =
           match context with
           | None -> workspace.contexts

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -378,7 +378,7 @@ let install_uninstall ~what =
               "Select context to install from. By default, install files from \
                all defined contexts.")
     and+ sections = Sections.term in
-    let config = Common.set_common ~log_file:No_log_file common in
+    let config = Common.init ~log_file:No_log_file common in
     Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
         let* workspace = Memo.Build.run (Import.Main.scan_workspace ()) in

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -14,10 +14,8 @@ let term =
           ~doc:"List libraries that are not available and explain why")
   in
   let config = Common.set_common common in
-  let capture_outputs = Common.capture_outputs common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* (_env : Env.t) = Import.Main.setup_env ~capture_outputs in
       let* ctxs = Memo.Build.run (Context.DB.all ()) in
       let ctx = List.hd ctxs in
       let findlib = ctx.findlib in

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -13,7 +13,7 @@ let term =
       & info [ "na"; "not-available" ]
           ~doc:"List libraries that are not available and explain why")
   in
-  let config = Common.set_common common in
+  let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* ctxs = Memo.Build.run (Context.DB.all ()) in

--- a/bin/internal_dump.ml
+++ b/bin/internal_dump.ml
@@ -18,7 +18,7 @@ let term =
   and+ file =
     Arg.(required & pos 0 (some Arg.path) None & Arg.info [] ~docv:"FILE")
   in
-  let _config = Common.set_common common in
+  let _config = Common.init common in
   let (Persistent.T ((module D), data)) =
     Persistent.load_exn (Arg.Path.path file)
   in

--- a/bin/ocaml_merlin.ml
+++ b/bin/ocaml_merlin.ml
@@ -30,8 +30,7 @@ let term =
   in
   let common = Common.set_print_directory common false in
   let config =
-    Common.set_common common ~log_file:No_log_file
-      ~recognize_jbuilder_projects:true
+    Common.init common ~log_file:No_log_file ~recognize_jbuilder_projects:true
   in
   Scheduler.go ~common ~config (fun () ->
       match dump_config with
@@ -68,8 +67,7 @@ module Dump_dot_merlin = struct
                printed. Defaults to the current directory.")
     in
     let config =
-      Common.set_common common ~log_file:No_log_file
-        ~recognize_jbuilder_projects:true
+      Common.init common ~log_file:No_log_file ~recognize_jbuilder_projects:true
     in
     Scheduler.go ~common ~config (fun () ->
         match path with

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -106,7 +106,7 @@ let term =
              the given targets.")
   and+ syntax = Syntax.term
   and+ targets = Arg.(value & pos_all dep [] & Arg.info [] ~docv:"TARGET") in
-  let config = Common.set_common common in
+  let config = Common.init common in
   let out = Option.map ~f:Path.of_string out in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -51,7 +51,7 @@ let term =
       let open Fiber.O in
       let* setup = Import.Main.setup common config in
       let dir = Path.of_string dir in
-      let checked = Util.check_path setup.workspace.contexts dir in
+      let checked = Util.check_path setup.contexts dir in
       let request =
         Action_builder.all
           (match checked with

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -46,7 +46,7 @@ let term =
             "Only print this field. This option can be repeated multiple times \
              to print multiple fields.")
   in
-  let config = Common.set_common common in
+  let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup common config in

--- a/bin/promote.ml
+++ b/bin/promote.ml
@@ -22,7 +22,7 @@ let command =
     and+ files =
       Arg.(value & pos_all Cmdliner.Arg.file [] & info [] ~docv:"FILE")
     in
-    let _config = Common.set_common common in
+    let _config = Common.init common in
     Promotion.promote_files_registered_in_last_run
       (match files with
       | [] -> All

--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -26,7 +26,7 @@ let wait_for_server common =
 
 let client_term common f =
   let common = Common.set_print_directory common false in
-  let config = Common.set_common common in
+  let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let where = wait_for_server common in
       let stats = Common.stats common in

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -29,7 +29,7 @@ let term =
   and+ ctx_name =
     Common.context_arg ~doc:{|Select context where to build/run utop.|}
   in
-  let config = Common.set_common common in
+  let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup common config in

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -15,7 +15,7 @@ let info = Term.info "upgrade" ~doc ~man
 
 let term =
   let+ common = Common.term in
-  let config = Common.set_common common ~recognize_jbuilder_projects:true in
+  let config = Common.init common ~recognize_jbuilder_projects:true in
   Scheduler.go ~common ~config (fun () -> Dune_upgrader.upgrade ())
 
 let command = (term, info)

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -31,15 +31,9 @@ let term =
         let* setup = Import.Main.setup common config in
         Build_system.run (fun () ->
             let open Memo.Build.O in
-            let context =
-              Import.Main.find_context_exn setup.workspace ~name:ctx_name
-            in
+            let context = Import.Main.find_context_exn setup ~name:ctx_name in
             let sctx = Import.Main.find_scontext_exn setup ~name:ctx_name in
-            let setup =
-              { setup with
-                workspace = { setup.workspace with contexts = [ context ] }
-              }
-            in
+            let setup = { setup with contexts = [ context ] } in
             let* target =
               Target.resolve_target (Common.root common) ~setup utop_target
               >>| function

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -19,7 +19,7 @@ let term =
   and+ ctx_name =
     Common.context_arg ~doc:{|Select context where to build/run utop.|}
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
-  let config = Common.set_common common in
+  let config = Common.init common in
   if not (Path.is_directory (Path.of_string (Common.prefix_target common dir)))
   then
     User_error.raise

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -758,7 +758,7 @@ module rec Instantiate : sig
   val instantiate : Context_name.t -> t list Memo.Build.t
 end = struct
   let instantiate_impl name : t list Memo.Build.t =
-    let* env = Memo.Run.Fdecl.get Global.env in
+    let env = Global.env () in
     let* workspace = Workspace.workspace () in
     let context =
       List.find_exn workspace.contexts ~f:(fun ctx ->

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -19,5 +19,5 @@ type conf = private
   ; projects : Dune_project.t list
   }
 
-(** Initialize the file tree and load all dune files. *)
-val load : unit -> conf Fiber.t
+(** Load all dune files. *)
+val load : unit -> conf Memo.Build.t

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -29,6 +29,7 @@ module Utop = Utop
 module Setup = Setup
 module Meta = Meta
 module Toplevel = Toplevel
+module Global = Global
 
 (* Only for tests *)
 module Scheme = Scheme

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -407,7 +407,7 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
           Dune_file.Library_redirect redirect
         | _ -> None)
 
-let init ~contexts ?only_packages conf =
+let init ~contexts ~only_packages conf =
   let open Fiber.O in
   let { Dune_load.dune_files; packages; projects } = conf in
   let packages = Option.value only_packages ~default:packages in

--- a/src/dune_rules/gen_rules.mli
+++ b/src/dune_rules/gen_rules.mli
@@ -6,6 +6,6 @@ open! Import
    names. *)
 val init :
      contexts:Context.t list
-  -> ?only_packages:Package.t Package.Name.Map.t
+  -> only_packages:Package.t Package.Name.Map.t option
   -> Dune_load.conf
   -> Super_context.t Context_name.Map.t Fiber.t

--- a/src/dune_rules/global.ml
+++ b/src/dune_rules/global.ml
@@ -1,4 +1,19 @@
 open! Dune_engine
 open Stdune
 
-let env = Memo.Run.Fdecl.create Env.to_dyn
+let env = Fdecl.create Env.to_dyn
+
+let init ~capture_outputs =
+  Fdecl.set env
+    (let env =
+       if
+         (not capture_outputs)
+         || not (Lazy.force Ansi_color.stderr_supports_color)
+       then
+         Env.initial
+       else
+         Colors.setup_env_for_colors Env.initial
+     in
+     Env.add env ~var:"INSIDE_DUNE" ~value:"1")
+
+let env () = Fdecl.get env

--- a/src/dune_rules/global.mli
+++ b/src/dune_rules/global.mli
@@ -1,4 +1,9 @@
 open! Dune_engine
 open Stdune
 
-val env : Env.t Memo.Run.Fdecl.t
+(** The default environment in which to run commands. The environemnt of
+    individual build contexts augment this environment. *)
+val env : unit -> Env.t
+
+(** Initialises this module. *)
+val init : capture_outputs:bool -> unit

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -4,40 +4,14 @@ open Import
 
 let () = Inline_tests.linkme
 
-type workspace =
-  { contexts : Context.t list
-  ; conf : Dune_load.conf
-  }
-
 type build_system =
-  { workspace : workspace
+  { conf : Dune_load.conf
+  ; contexts : Context.t list
   ; scontexts : Super_context.t Context_name.Map.t
   }
 
-let package_install_file w pkg =
-  match Package.Name.Map.find w.conf.packages pkg with
-  | None -> Error ()
-  | Some p ->
-    let name = Package.name p in
-    let dir = Package.dir p in
-    Ok
-      (Path.Source.relative dir
-         (Utils.install_file ~package:name ~findlib_toolchain:None))
-
-let scan_workspace () =
-  let open Memo.Build.O in
-  let* conf = Dune_load.load () in
-  let+ contexts = Context.DB.all () in
-  List.iter contexts ~f:(fun (ctx : Context.t) ->
-      let open Pp.O in
-      Log.info
-        [ Pp.box ~indent:1
-            (Pp.text "Dune context:" ++ Pp.cut ++ Dyn.pp (Context.to_dyn ctx))
-        ]);
-  { contexts; conf }
-
-let init_build_system ?stats ?only_packages ~sandboxing_preference ?caching
-    ?build_mutex w =
+let init_build_system ~stats ~only_packages ~sandboxing_preference ~caching
+    ~build_mutex ~conf ~contexts =
   let open Fiber.O in
   Build_system.reset ();
   let promote_source ?chmod ~src ~dst ctx =
@@ -48,12 +22,12 @@ let init_build_system ?stats ?only_packages ~sandboxing_preference ?caching
   in
   let* () =
     Build_system.init ~stats ~sandboxing_preference ~promote_source
-      ~contexts:(List.map ~f:Context.build_context w.contexts)
+      ~contexts:(List.map ~f:Context.build_context contexts)
       ?caching ?build_mutex ()
   in
-  List.iter w.contexts ~f:Context.init_configurator;
-  let+ scontexts = Gen_rules.init w.conf ~contexts:w.contexts ?only_packages in
-  { workspace = w; scontexts }
+  List.iter contexts ~f:Context.init_configurator;
+  let+ scontexts = Gen_rules.init conf ~contexts ~only_packages in
+  { conf; contexts; scontexts }
 
 let find_context_exn t ~name =
   match List.find t.contexts ~f:(fun c -> Context_name.equal c.name name) with

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -5,7 +5,6 @@ open! Import
 type workspace =
   { contexts : Context.t list
   ; conf : Dune_load.conf
-  ; env : Env.t
   }
 
 type build_system =
@@ -18,7 +17,7 @@ val package_install_file :
   workspace -> Package.Name.t -> (Path.Source.t, unit) result
 
 (** Scan the source tree and discover the overall layout of the workspace. *)
-val scan_workspace : capture_outputs:bool -> unit -> workspace Fiber.t
+val scan_workspace : unit -> workspace Memo.Build.t
 
 (** Load dune files and initializes the build system *)
 val init_build_system :
@@ -33,6 +32,3 @@ val init_build_system :
 val find_context_exn : workspace -> name:Context_name.t -> Context.t
 
 val find_scontext_exn : build_system -> name:Context_name.t -> Super_context.t
-
-(** Setup the environment *)
-val setup_env : capture_outputs:bool -> Env.t Fiber.t

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -2,33 +2,23 @@ open! Dune_engine
 open! Stdune
 open! Import
 
-type workspace =
-  { contexts : Context.t list
-  ; conf : Dune_load.conf
-  }
-
 type build_system =
-  { workspace : workspace
+  { conf : Dune_load.conf
+  ; contexts : Context.t list
   ; scontexts : Super_context.t Context_name.Map.t
   }
 
-(* Returns [Error ()] if [pkg] is unknown *)
-val package_install_file :
-  workspace -> Package.Name.t -> (Path.Source.t, unit) result
-
-(** Scan the source tree and discover the overall layout of the workspace. *)
-val scan_workspace : unit -> workspace Memo.Build.t
-
 (** Load dune files and initializes the build system *)
 val init_build_system :
-     ?stats:Stats.t
-  -> ?only_packages:Package.t Package.Name.Map.t
+     stats:Stats.t option
+  -> only_packages:Package.t Package.Name.Map.t option
   -> sandboxing_preference:Sandbox_mode.t list
-  -> ?caching:Build_system.caching
-  -> ?build_mutex:Fiber.Mutex.t
-  -> workspace
+  -> caching:Build_system.caching option
+  -> build_mutex:Fiber.Mutex.t option
+  -> conf:Dune_load.conf
+  -> contexts:Context.t list
   -> build_system Fiber.t
 
-val find_context_exn : workspace -> name:Context_name.t -> Context.t
+val find_context_exn : build_system -> name:Context_name.t -> Context.t
 
 val find_scontext_exn : build_system -> name:Context_name.t -> Super_context.t

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1188,23 +1188,7 @@ module Lazy = struct
   let map t ~f = create (fun () -> Fiber.map ~f (t ()))
 end
 
-module Run = struct
-  module Fdecl = struct
-    (* [Lazy.t] is the simplest way to create a node in the memoization dag. *)
-    type nonrec 'a t = 'a Fdecl.t Lazy.t
-
-    let create to_dyn =
-      lazy_ ~to_dyn:Fdecl.to_dyn (fun () ->
-          let+ (_ : Run.t) = current_run () in
-          Fdecl.create to_dyn)
-
-    let set t x = Lazy.force t >>| fun value -> Fdecl.set value x
-
-    let get t = Lazy.force t >>| Fdecl.get
-  end
-
-  include Run
-end
+module Run = Run
 
 module Poly (Function : sig
   type 'a input

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -262,23 +262,6 @@ val call : string -> Dune_lang.Ast.t -> Dyn.t Build.t
 module Run : sig
   (** A single build run. *)
   type t
-
-  (** A forward declaration that is reset after every run. *)
-  module Fdecl : sig
-    type 'a t
-
-    (** [create to_dyn] creates a forward declaration. The [to_dyn] parameter is
-        used for reporting errors in [set] and [get]. *)
-    val create : ('a -> Dyn.t) -> 'a t
-
-    (** [set t x] sets the value that is returned by [get t] to [x]. Raises if
-        [set] was already called. *)
-    val set : 'a t -> 'a -> unit Build.t
-
-    (** [get t] returns the [x] if [set comp x] was called. Raises if [set] has
-        not been called yet. *)
-    val get : 'a t -> 'a Build.t
-  end
 end
 
 (** Introduces a dependency on the current build run. *)


### PR DESCRIPTION
This PR comes after #4422. It:

- Simplify the initialisation of `Global.env`
- Delete the now unused `Memo.Run.Fdecl`
- Move `Dune_load.load` to the `Memo.Build` monad
- Simplify `Dune_rules.Main`