### PR TITLE
Remove Build_system.set_packages

### DIFF
--- a/bin/common.mli
+++ b/bin/common.mli
@@ -8,16 +8,6 @@ val rpc : t -> Dune_rpc_impl.Server.t option
 
 val stats : t -> Stats.t option
 
-module Only_packages : sig
-  type t = private
-    { names : Dune_engine.Package.Name.Set.t
-    ; command_line_option : string
-          (** Which of [-p], [--only-packages], ... was passed *)
-    }
-end
-
-val only_packages : t -> Only_packages.t option
-
 val watch : t -> bool
 
 val file_watcher : t -> Dune_engine.Scheduler.Run.file_watcher

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -84,42 +84,6 @@ module Main = struct
     let* caching = make_cache config
     and* conf = Memo.Build.run (Dune_rules.Dune_load.load ())
     and* contexts = Memo.Build.run (Context.DB.all ()) in
-    let* only_packages =
-      match Common.only_packages common with
-      | None -> Fiber.return None
-      | Some { Common.Only_packages.names; command_line_option } ->
-        Package.Name.Set.iter names ~f:(fun pkg_name ->
-            if not (Package.Name.Map.mem conf.packages pkg_name) then
-              let pkg_name = Package.Name.to_string pkg_name in
-              User_error.raise
-                [ Pp.textf "I don't know about package %s (passed through %s)"
-                    pkg_name command_line_option
-                ]
-                ~hints:
-                  (User_message.did_you_mean pkg_name
-                     ~candidates:
-                       (Package.Name.Map.keys conf.packages
-                       |> List.map ~f:Package.Name.to_string)));
-        Fiber.sequential_map (Package.Name.Map.values conf.packages)
-          ~f:(fun pkg ->
-            let+ vendored =
-              let dir = Package.dir pkg in
-              Memo.Build.run (Dune_engine.Source_tree.is_vendored dir)
-            in
-            let name = Package.name pkg in
-            let included = Package.Name.Set.mem names name in
-            if vendored && included then
-              User_error.raise
-                [ Pp.textf
-                    "Package %s is vendored and so will never be masked. It \
-                     makes no sense to pass it to -p, --only-packages or \
-                     --for-release-of-packages."
-                    (Package.Name.to_string name)
-                ];
-            Option.some_if (vendored || included) (name, pkg))
-        >>| List.filter_map ~f:Fun.id >>| Package.Name.Map.of_list_exn
-        >>| Option.some
-    in
     let stats = Common.stats common in
     List.iter contexts ~f:(fun (ctx : Context.t) ->
         let open Pp.O in
@@ -128,7 +92,7 @@ module Main = struct
               (Pp.text "Dune context:" ++ Pp.cut ++ Dyn.pp (Context.to_dyn ctx))
           ]);
     init_build_system ~stats ~sandboxing_preference:config.sandboxing_preference
-      ~caching ~only_packages ~conf ~contexts
+      ~caching ~conf ~contexts
 end
 
 module Scheduler = struct

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -105,13 +105,14 @@ val targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
 (** Load the rules for this directory. *)
 val load_dir : dir:Path.t -> unit Memo.Build.t
 
-(** Sets the package assignment *)
-val set_packages : (Path.Build.t -> Package.Id.Set.t Memo.Build.t) -> unit
-
 (** Assuming [files] is the list of files in [_build/install] that belong to
     package [pkg], [package_deps t pkg files] is the set of direct package
     dependencies of [package]. *)
-val package_deps : Package.t -> Path.Set.t -> Package.Id.Set.t Memo.Build.t
+val package_deps :
+     packages_of:(Path.Build.t -> Package.Id.Set.t Memo.Build.t)
+  -> Package.t
+  -> Path.Set.t
+  -> Package.Id.Set.t Memo.Build.t
 
 (** {2 Aliases} *)
 

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -37,5 +37,3 @@ let always_show_command_line = ref false
 let promote_install_files = ref false
 
 let ignore_promoted_rules = ref false
-
-let only_packages = ref None

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -54,6 +54,3 @@ val promote_install_files : bool ref
 
 (** Wether we are ignorimg rules with [(mode promote)] *)
 val ignore_promoted_rules : bool ref
-
-(** Packages passed by --only-packages or -p *)
-val only_packages : Package.Name.Set.t option ref

--- a/src/dune_rules/cram_rules.ml
+++ b/src/dune_rules/cram_rules.ml
@@ -165,9 +165,10 @@ let rules ~sctx ~expander ~dir tests =
               { acc with enabled_if; deps; alias; packages })
       in
       let test_rule () = test_rule ~sctx ~expander ~dir effective test in
-      match !Clflags.only_packages with
+      Only_packages.get () >>= function
       | None -> test_rule ()
       | Some only ->
+        let only = Package.Name.Map.keys only |> Package.Name.Set.of_list in
         Memo.Build.if_
           (Package.Name.Set.is_empty effective.packages
           || Package.Name.Set.(not (is_empty (inter only effective.packages))))

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -252,3 +252,7 @@ let load () =
       ~f:(fun (dir, project, dune_file) -> interpret ~dir ~project ~dune_file)
   in
   { dune_files; packages; projects }
+
+let load =
+  let memo = Memo.lazy_ load in
+  fun () -> Memo.Lazy.force memo

--- a/src/dune_rules/dune_load.mli
+++ b/src/dune_rules/dune_load.mli
@@ -19,5 +19,5 @@ type conf = private
   ; projects : Dune_project.t list
   }
 
-(** Load all dune files. *)
+(** Load all dune files. This function is memoized. *)
 val load : unit -> conf Memo.Build.t

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -30,6 +30,7 @@ module Setup = Setup
 module Meta = Meta
 module Toplevel = Toplevel
 module Global = Global
+module Only_packages = Only_packages
 
 (* Only for tests *)
 module Scheme = Scheme

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -406,9 +406,10 @@ let filter_out_stanzas_from_hidden_packages ~visible_pkgs =
           Dune_file.Library_redirect redirect
         | _ -> None)
 
-let init ~contexts ~only_packages conf =
+let init ~contexts conf =
   let open Fiber.O in
   let { Dune_load.dune_files; packages; projects } = conf in
+  let* only_packages = Memo.Build.run (Only_packages.get ()) in
   let packages = Option.value only_packages ~default:packages in
   let* sctxs =
     let open Memo.Build.O in

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -390,22 +390,6 @@ let gen_rules ~sctx ~dir components =
 let init () =
   let open Fiber.O in
   let* sctxs = Memo.Build.run (Memo.Lazy.force Super_context.all) in
-  let () =
-    Build_system.set_packages (fun path ->
-        match
-          let open Option.O in
-          let* ctx_name, _ = Path.Build.extract_build_context path in
-          let* ctx_name = Context_name.of_string_opt ctx_name in
-          Context_name.Map.find sctxs ctx_name
-        with
-        | None -> Memo.Build.return Package.Id.Set.empty
-        | Some sctx ->
-          let open Memo.Build.O in
-          let+ map = Install_rules.packages sctx in
-          Option.value
-            (Path.Build.Map.find map path)
-            ~default:Package.Id.Set.empty)
-  in
   let+ () =
     Build_system.set_rule_generators
       ~init:(fun () ->

--- a/src/dune_rules/gen_rules.mli
+++ b/src/dune_rules/gen_rules.mli
@@ -4,7 +4,4 @@ open! Import
 
 (* Set the rule generator callback. Returns evaluated Dune files per context
    names. *)
-val init :
-     contexts:Context.t list
-  -> Dune_load.conf
-  -> Super_context.t Context_name.Map.t Fiber.t
+val init : unit -> Super_context.t Context_name.Map.t Fiber.t

--- a/src/dune_rules/gen_rules.mli
+++ b/src/dune_rules/gen_rules.mli
@@ -6,6 +6,5 @@ open! Import
    names. *)
 val init :
      contexts:Context.t list
-  -> only_packages:Package.t Package.Name.Map.t option
   -> Dune_load.conf
   -> Super_context.t Context_name.Map.t Fiber.t

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -20,5 +20,3 @@ val meta_and_dune_package_rules :
    aalekseyev: actually I think we should just remove
    [meta_and_dune_package_rules] from the interface and have [gen_rules] do
    everything. *)
-
-val packages : Super_context.t -> Package.Id.Set.t Path.Build.Map.t Memo.Build.t

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -25,7 +25,7 @@ let init_build_system ~stats ~sandboxing_preference ~caching ~conf ~contexts =
       ?caching ()
   in
   List.iter contexts ~f:Context.init_configurator;
-  let+ scontexts = Gen_rules.init conf ~contexts in
+  let+ scontexts = Gen_rules.init () in
   { conf; contexts; scontexts }
 
 let find_context_exn t ~name =

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -10,8 +10,7 @@ type build_system =
   ; scontexts : Super_context.t Context_name.Map.t
   }
 
-let init_build_system ~stats ~only_packages ~sandboxing_preference ~caching
-    ~conf ~contexts =
+let init_build_system ~stats ~sandboxing_preference ~caching ~conf ~contexts =
   let open Fiber.O in
   Build_system.reset ();
   let promote_source ?chmod ~src ~dst ctx =
@@ -26,7 +25,7 @@ let init_build_system ~stats ~only_packages ~sandboxing_preference ~caching
       ?caching ()
   in
   List.iter contexts ~f:Context.init_configurator;
-  let+ scontexts = Gen_rules.init conf ~contexts ~only_packages in
+  let+ scontexts = Gen_rules.init conf ~contexts in
   { conf; contexts; scontexts }
 
 let find_context_exn t ~name =

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -11,7 +11,6 @@ type build_system =
 (** Load dune files and initializes the build system *)
 val init_build_system :
      stats:Stats.t option
-  -> only_packages:Package.t Package.Name.Map.t option
   -> sandboxing_preference:Sandbox_mode.t list
   -> caching:Build_system.caching option
   -> conf:Dune_load.conf

--- a/src/dune_rules/only_packages.ml
+++ b/src/dune_rules/only_packages.ml
@@ -1,0 +1,68 @@
+open Import
+open Memo.Build.O
+
+module Clflags = struct
+  type t =
+    | No_restriction
+    | Restrict of
+        { names : Package.Name.Set.t
+        ; command_line_option : string
+        }
+
+  let to_dyn = function
+    | No_restriction -> Dyn.Variant ("No_restriction", [])
+    | Restrict { names; command_line_option } ->
+      Variant
+        ( "Restrict"
+        , [ Record
+              [ ("names", Package.Name.Set.to_dyn names)
+              ; ("command_line_option", String command_line_option)
+              ]
+          ] )
+
+  let t = Fdecl.create to_dyn
+
+  let set x = Fdecl.set t x
+
+  let t () = Fdecl.get t
+end
+
+type t = Package.t Package.Name.Map.t option
+
+let conf =
+  Memo.lazy_ (fun () ->
+      match Clflags.t () with
+      | No_restriction -> Memo.Build.return None
+      | Restrict { names; command_line_option } ->
+        let* conf = Dune_load.load () in
+        Package.Name.Set.iter names ~f:(fun pkg_name ->
+            if not (Package.Name.Map.mem conf.packages pkg_name) then
+              let pkg_name = Package.Name.to_string pkg_name in
+              User_error.raise
+                [ Pp.textf "I don't know about package %s (passed through %s)"
+                    pkg_name command_line_option
+                ]
+                ~hints:
+                  (User_message.did_you_mean pkg_name
+                     ~candidates:
+                       (Package.Name.Map.keys conf.packages
+                       |> List.map ~f:Package.Name.to_string)));
+        Memo.Build.sequential_map (Package.Name.Map.to_list conf.packages)
+          ~f:(fun (name, pkg) ->
+            let+ vendored =
+              Dune_engine.Source_tree.is_vendored (Package.dir pkg)
+            in
+            let included = Package.Name.Set.mem names name in
+            if vendored && included then
+              User_error.raise
+                [ Pp.textf
+                    "Package %s is vendored and so will never be masked. It is \
+                     redundant to pass it to %s."
+                    (Package.Name.to_string name)
+                    command_line_option
+                ];
+            Option.some_if (vendored || included) (name, pkg))
+        >>| List.filter_map ~f:Fun.id >>| Package.Name.Map.of_list_exn
+        >>| Option.some)
+
+let get () = Memo.Lazy.force conf

--- a/src/dune_rules/only_packages.mli
+++ b/src/dune_rules/only_packages.mli
@@ -1,0 +1,21 @@
+(** Restrict the set of visible packages *)
+
+open Import
+
+module Clflags : sig
+  type t =
+    | No_restriction
+    | Restrict of
+        { names : Package.Name.Set.t
+        ; command_line_option : string
+              (** Which of [-p], [--only-packages], ... was passed *)
+        }
+
+  (** This must be called exactly once *)
+  val set : t -> unit
+end
+
+type t = Package.t Package.Name.Map.t option
+
+(** Returns the package restrictions. This function is memoized. *)
+val get : unit -> t Memo.Build.t

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -9,20 +9,16 @@ open Import
 
 type t
 
+val all : t Context_name.Map.t Memo.Lazy.t
+
+(** Find a super context by name. *)
+val find : Context_name.t -> t option Memo.Build.t
+
 val modules_of_lib :
   (* to avoid a cycle with [Dir_contents] *)
   (t -> dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.Build.t) Fdecl.t
 
 val to_dyn : t -> Dyn.t
-
-val create :
-     context:Context.t
-  -> ?host:t
-  -> projects:Dune_project.t list
-  -> packages:Package.t Package.Name.Map.t
-  -> stanzas:Dune_file.t list
-  -> unit
-  -> t
 
 val context : t -> Context.t
 

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -32,6 +32,16 @@ module Build = struct
       match option with
       | None -> return ()
       | Some a -> f a
+
+    let map option ~f =
+      match option with
+      | None -> return None
+      | Some a -> f a >>| Option.some
+
+    let bind option ~f =
+      match option with
+      | None -> return None
+      | Some a -> f a
   end
 
   module Result = struct

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -86,6 +86,10 @@ module Build : sig
 
   module Option : sig
     val iter : 'a option -> f:('a -> unit t) -> unit t
+
+    val map : 'a option -> f:('a -> 'b t) -> 'b option t
+
+    val bind : 'a option -> f:('a -> 'b option t) -> 'b option t
   end
 
   module Result : sig

--- a/test/blackbox-tests/test-cases/vendor/dash-p-and-vendored-packages.t/run.t
+++ b/test/blackbox-tests/test-cases/vendor/dash-p-and-vendored-packages.t/run.t
@@ -48,6 +48,6 @@ Keeping only "foo" via "-p" shouldn't mask "bar" since it is vendored:
 Asking to keep "bar" makes no sense since it is vendored:
 
   $ dune exec -p foo,bar ./foo.exe
-  Error: Package bar is vendored and so will never be masked. It makes no sense
-  to pass it to -p, --only-packages or --for-release-of-packages.
+  Error: Package bar is vendored and so will never be masked. It is redundant
+  to pass it to -p.
   [1]


### PR DESCRIPTION
This PR is part of an effort to make the initialisation code more "pull-based". i.e., in polling mode, instead of doing some toplevel (big) side effecting computations in a loop, I'd like to have a single call to `Memo.Build.run` which pulls the various bits it needs via memo.

This particular PR removes `Build_system.set_packages`. To do that, I had to add a memo for getting the list of all super contexts, which required making `Dune_load.load` and `only_packages` be pulled based as well. In the end:

- the first commit introduces a `Dune_rules.Only_packages` module with a `Clflags` sub-module similar to the one on the `Workspace` module;  we set it once at the beginning of the process and then we have a memo for the evaluation of the command line settings. I moved there all the logic related to this parameter there.

- the second commit moves all the super context creating logic to `Super_context` and makes it pull-based. We now have `Super_context.all : t Context_name.Map.t Memo.Lazy.t`

- the third commit actually removed `Build_system.set_packages` and move the logic for getting the list of packages a file is part of to `install_rules.ml` where it belongs

As sub-sequent work, we could generalise `Build_system.packages` so that it doesn't refer to `Package` directly. Which would be one step towards moving `Pacakge` to `Dune_rules`, since this is a concept that is higher-level than the core build system.