### PR TITLE
Make the toplevel build pull-based

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -40,7 +40,7 @@ let run_build_command_once ~(common : Common.t) ~config ~targets ~setup =
   Scheduler.go ~common ~config once
 
 let run_build_command ~(common : Common.t) ~config ~targets =
-  let setup () = Import.Main.setup common config in
+  let setup () = Import.Main.setup () in
   (if Common.watch common then
     run_build_command_poll
   else

--- a/bin/compute.ml
+++ b/bin/compute.ml
@@ -33,7 +33,7 @@ let term =
      let action =
        Scheduler.go ~common ~config (fun () ->
            let open Fiber.O in
-           let* _setup = Import.Main.setup common config in
+           let* _setup = Import.Main.setup () in
            match (fn, inp) with
            | "latest-lang-version", None ->
              Fiber.return

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -309,7 +309,7 @@ let term =
   let what = What.parse what ~lang in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common config in
+      let* setup = Import.Main.setup () in
       let context = Import.Main.find_context_exn setup ~name:context_name in
       let+ res = Memo.Build.run (What.describe what setup context) in
       match format with

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -46,7 +46,7 @@ let term =
   let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common config in
+      let* setup = Import.Main.setup () in
       let sctx = Import.Main.find_scontext_exn setup ~name:context in
       let context = Dune_rules.Super_context.context sctx in
       let path_relative_to_build_root p =

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -110,7 +110,7 @@ let term =
   let out = Option.map ~f:Path.of_string out in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common config in
+      let* setup = Import.Main.setup () in
       Build_system.run (fun () ->
           let open Memo.Build.O in
           let* request =

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -49,7 +49,7 @@ let term =
   let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common config in
+      let* setup = Import.Main.setup () in
       let dir = Path.of_string dir in
       let checked = Util.check_path setup.contexts dir in
       let request =

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -32,7 +32,7 @@ let term =
   let config = Common.init common in
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
-      let* setup = Import.Main.setup common config in
+      let* setup = Import.Main.setup () in
       Build_system.run (fun () ->
           let open Memo.Build.O in
           let sctx =

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -28,7 +28,7 @@ let term =
   let sctx, utop_path =
     Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
-        let* setup = Import.Main.setup common config in
+        let* setup = Import.Main.setup () in
         Build_system.run (fun () ->
             let open Memo.Build.O in
             let context = Import.Main.find_context_exn setup ~name:ctx_name in

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -14,22 +14,13 @@ module Error : sig
   val message : t -> User_message.t
 end
 
-(** Initializes the build system. This must be called first. *)
-val init :
-     stats:Stats.t option
-  -> contexts:Build_context.t list
-  -> promote_source:
-       (   ?chmod:(int -> int)
-        -> src:Path.Build.t
-        -> dst:Path.Source.t
-        -> Build_context.t option
-        -> unit Fiber.t)
-  -> sandboxing_preference:Sandbox_mode.t list
-  -> cache_config:Dune_cache.Config.t
-  -> unit
-  -> unit Fiber.t
+module Context_or_install : sig
+  type t =
+    | Install of Context_name.t
+    | Context of Context_name.t
 
-val reset : unit -> unit
+  val to_dyn : t -> Dyn.t
+end
 
 module Subdir_set : sig
   type t =
@@ -47,37 +38,46 @@ end
 
 type extra_sub_directories_to_keep = Subdir_set.t
 
-module Context_or_install : sig
-  type t =
-    | Install of Context_name.t
-    | Context of Context_name.t
+module type Rule_generator = sig
+  (** The rule generator.
 
-  val to_dyn : t -> Dyn.t
+      This callback is used to generate the rules for a given directory in the
+      corresponding build context. It receives the directory for which to
+      generate the rules and the split part of the path after the build context.
+      It must return an additional list of sub-directories to keep. This is in
+      addition to the ones that are present in the source tree and the ones that
+      already contain rules.
+
+      It is expected that [gen_rules] only generate rules whose targets are
+      descendant of [dir].
+
+      The callback should return [None] if it doesn't know about the given
+      [Context_or_install.t]. *)
+  val gen_rules :
+       Context_or_install.t
+    -> dir:Path.Build.t
+    -> string list
+    -> (extra_sub_directories_to_keep * Rules.t) option Memo.Build.t
+
+  (** [global_rules] is a way to generate rules in arbitrary directories
+      upfront. *)
+  val global_rules : Rules.t Memo.Lazy.t
 end
 
-(** Set the rule generators callback. There must be one callback per build
-    context name.
-
-    Each callback is used to generate the rules for a given directory in the
-    corresponding build context. It receives the directory for which to generate
-    the rules and the split part of the path after the build context. It must
-    return an additional list of sub-directories to keep. This is in addition to
-    the ones that are present in the source tree and the ones that already
-    contain rules.
-
-    It is expected that [f] only generate rules whose targets are descendant of
-    [dir].
-
-    [init] can generate rules in any directory, so it's always called. *)
-val set_rule_generators :
-     init:(unit -> unit Memo.Build.t)
-  -> gen_rules:
-       (   Context_or_install.t
-        -> (   dir:Path.Build.t
-            -> string list
-            -> extra_sub_directories_to_keep Memo.Build.t)
-           option)
-  -> unit Fiber.t
+(** Initializes the build system. This must be called first. *)
+val init :
+     stats:Stats.t option
+  -> contexts:Build_context.t list Memo.Lazy.t
+  -> promote_source:
+       (   ?chmod:(int -> int)
+        -> src:Path.Build.t
+        -> dst:Path.Source.t
+        -> Build_context.t option
+        -> unit Fiber.t)
+  -> cache_config:Dune_cache.Config.t
+  -> sandboxing_preference:Sandbox_mode.t list
+  -> rule_generator:(module Rule_generator)
+  -> unit
 
 (** All other functions in this section must be called inside the rule generator
     callback. *)
@@ -145,8 +145,6 @@ val build : 'a Action_builder.t -> 'a Memo.Build.t
 
 val is_target : Path.t -> bool Memo.Build.t
 
-val contexts : unit -> Build_context.t Context_name.Map.t
-
 (** List of all buildable targets. *)
 val all_targets : unit -> Path.Build.Set.t Memo.Build.t
 
@@ -187,3 +185,14 @@ end
 (** {2 Running a build} *)
 
 val run : (unit -> 'a Memo.Build.t) -> 'a Fiber.t
+
+(** {2 Misc} *)
+
+module Progress : sig
+  type t =
+    { number_of_rules_discovered : int
+    ; number_of_rules_executed : int
+    }
+end
+
+val get_current_progress : unit -> Progress.t

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -136,7 +136,11 @@ val build_context : t -> Build_context.t
     an explicit installation directory. *)
 val install_prefix : t -> Path.t Fiber.t
 
-val init_configurator : t -> unit
+(** Generate the rules for producing the files needed by configurator. *)
+val gen_configurator_rules : t -> unit Memo.Build.t
+
+(** Force the files required by configurator at runtime to be produced. *)
+val force_configurator_files : unit Memo.Lazy.t
 
 module DB : sig
   val get : Path.Build.t -> t Memo.Build.t

--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -18,7 +18,7 @@ let preprocessed_filename = "ccomp"
 let ccomp_type dir =
   let open Action_builder.O in
   let filepath =
-    Path.Build.(relative (relative dir ".dune") preprocessed_filename)
+    Path.Build.(relative (relative dir ".dune/ccomp") preprocessed_filename)
   in
   let+ ccomp = Action_builder.contents (Path.build filepath) in
   match String.trim ccomp with

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -306,18 +306,11 @@ let gen_rules ~sctx ~dir components =
   let+ subdirs_to_keep1 = Install_rules.gen_rules sctx ~dir
   and+ (subdirs_to_keep2 : Build_system.extra_sub_directories_to_keep) =
     match components with
-    | ".dune" :: _ ->
-      (* Dummy rule to prevent dune from deleting this file. See comment
-         attached to [write_dot_dune_dir] in context.ml *)
-      let* () =
-        Super_context.add_rule sctx ~dir
-          (Action_builder.write_file
-             (Path.Build.relative dir "configurator")
-             "")
-      in
+    | [ ".dune"; "ccomp" ] ->
       (* Add rules for C compiler detection *)
       let+ () = Cxx_rules.rules ~sctx ~dir in
       S.These String.Set.empty
+    | ".dune" :: _ -> Memo.Build.return (S.These String.Set.empty)
     | ".js" :: rest -> (
       let+ () = Jsoo_rules.setup_separate_compilation_rules sctx rest in
       match rest with
@@ -387,19 +380,34 @@ let gen_rules ~sctx ~dir components =
   Build_system.Subdir_set.union_all
     [ subdirs_to_keep1; subdirs_to_keep2; subdirs_to_keep3 ]
 
-let init () =
-  let open Fiber.O in
-  let* sctxs = Memo.Build.run (Memo.Lazy.force Super_context.all) in
-  let+ () =
-    Build_system.set_rule_generators
-      ~init:(fun () ->
-        Memo.Build.parallel_iter (Context_name.Map.values sctxs) ~f:Odoc.init)
-      ~gen_rules:(function
-        | Install ctx ->
-          Option.map (Context_name.Map.find sctxs ctx) ~f:(fun sctx ~dir _ ->
-              Install_rules.gen_rules sctx ~dir)
-        | Context ctx ->
-          Context_name.Map.find sctxs ctx
-          |> Option.map ~f:(fun sctx -> gen_rules ~sctx))
-  in
-  sctxs
+let gen_rules ~sctx ~dir components =
+  let module S = Build_system.Subdir_set in
+  match components with
+  | [ ".dune" ] ->
+    (* [.dune] is treated specifically as generating the rules in all other
+       directories forces the production of the configurator files for which the
+       rules are setup in this branch. *)
+    let+ () = Context.gen_configurator_rules (Super_context.context sctx) in
+    S.These (String.Set.of_list [ "ccomp" ])
+  | _ ->
+    let* () = Memo.Lazy.force Context.force_configurator_files in
+    gen_rules ~sctx ~dir components
+
+let global_rules =
+  Memo.lazy_ (fun () ->
+      Rules.collect_unit (fun () ->
+          let* sctxs = Memo.Lazy.force Super_context.all in
+          Memo.Build.parallel_iter
+            (Context_name.Map.values sctxs)
+            ~f:Odoc.global_rules))
+
+let gen_rules ctx_or_install ~dir components =
+  match (ctx_or_install : Build_system.Context_or_install.t) with
+  | Install ctx ->
+    Super_context.find ctx
+    >>= Memo.Build.Option.map ~f:(fun sctx ->
+            Rules.collect (fun () -> Install_rules.gen_rules sctx ~dir))
+  | Context ctx ->
+    Super_context.find ctx
+    >>= Memo.Build.Option.map ~f:(fun sctx ->
+            Rules.collect (fun () -> gen_rules ~sctx ~dir components))

--- a/src/dune_rules/gen_rules.mli
+++ b/src/dune_rules/gen_rules.mli
@@ -2,6 +2,4 @@ open! Dune_engine
 open! Stdune
 open! Import
 
-(* Set the rule generator callback. Returns evaluated Dune files per context
-   names. *)
-val init : unit -> Super_context.t Context_name.Map.t Fiber.t
+include Build_system.Rule_generator

--- a/src/dune_rules/main.mli
+++ b/src/dune_rules/main.mli
@@ -2,20 +2,20 @@ open! Dune_engine
 open! Stdune
 open! Import
 
+(** Tie the knot between [Dune_engine] and [Dune_rules]. *)
+val init :
+     stats:Stats.t option
+  -> sandboxing_preference:Sandbox_mode.t list
+  -> cache_config:Dune_cache.Config.t
+  -> unit
+
 type build_system =
   { conf : Dune_load.conf
   ; contexts : Context.t list
   ; scontexts : Super_context.t Context_name.Map.t
   }
 
-(** Load dune files and initializes the build system *)
-val init_build_system :
-     stats:Stats.t option
-  -> sandboxing_preference:Sandbox_mode.t list
-  -> cache_config:Dune_cache.Config.t
-  -> conf:Dune_load.conf
-  -> contexts:Context.t list
-  -> build_system Fiber.t
+val get : unit -> build_system Memo.Build.t
 
 val find_context_exn : build_system -> name:Context_name.t -> Context.t
 

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -691,7 +691,7 @@ let setup_package_odoc_rules_def =
 let setup_package_odoc_rules sctx ~pkg =
   Memo.With_implicit_output.exec setup_package_odoc_rules_def (sctx, pkg)
 
-let init sctx =
+let global_rules sctx =
   let stanzas = SC.stanzas sctx in
   let ctx = Super_context.context sctx in
   let* () =

--- a/src/dune_rules/odoc.mli
+++ b/src/dune_rules/odoc.mli
@@ -11,7 +11,7 @@ val setup_library_odoc_rules :
   -> dep_graphs:Dep_graph.Ml_kind.t
   -> unit Memo.Build.t
 
-val init : Super_context.t -> unit Memo.Build.t
+val global_rules : Super_context.t -> unit Memo.Build.t
 
 val gen_rules :
   Super_context.t -> dir:Path.Build.t -> string list -> unit Memo.Build.t

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -665,7 +665,9 @@ let pp_stack () =
     ++ Pp.cut
     ++ Pp.chain stack ~f:(fun frame -> Dyn.pp (Stack_frame.to_dyn frame)))
 
-let dump_stack () = pp_stack () >>| Format.eprintf "%a" Pp.to_fmt
+let dump_stack () =
+  let+ pp = pp_stack () in
+  Console.print [ pp ]
 
 let get_cached_value_in_current_cycle (dep_node : _ Dep_node.t) =
   match dep_node.last_cached_value with

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -11,9 +11,9 @@ Default: use_standard_c_and_cxx_flags = false
   $ MsvcF="/TP"
 
 > Check that compiler detection is done
-  $ dune build .dune/ccomp
+  $ dune build .dune/ccomp/ccomp
 
-  $ cat _build/default/.dune/ccomp |
+  $ cat _build/default/.dune/ccomp/ccomp |
   > grep -ce "clang\|gcc\|msvc"
   1
 
@@ -47,9 +47,9 @@ With use_standard_c_and_cxx_flags = true
   > EOF
 
 > Check that compiler detection is done
-  $ dune build .dune/ccomp
+  $ dune build .dune/ccomp/ccomp
 
-  $ cat _build/default/.dune/ccomp |
+  $ cat _build/default/.dune/ccomp/ccomp |
   > grep -ce "clang\|gcc\|msvc"
   1
 


### PR DESCRIPTION
This PR changes things so that `Build_system.init` is now only used once at the beginning of the process to tie the knot between `Dune_engine` and `Dune_rules`, and is no longer called on every build in polling mode.

The various values required by `Gen_rules.gen_rules` are now pulled entirely via memo.

We still have a `Import.Main.setup` in `bin/import.ml`, however it is now much simpler and it's only job is to setup the status line.