### PR TITLE
@all: do not depend directly on file copies from source files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,7 +90,7 @@ Unreleased
 - Add the possibility to use `locks` with the cram tests stanza (#4397, @voodoos)
 
 - The `@all` alias no longer depends directly on copies of files from the source
-  directory (@nojb)
+  directory (#4461, @nojb)
 
 2.8.5 (28/03/2021)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,9 @@ Unreleased
 
 - Add the possibility to use `locks` with the cram tests stanza (#4397, @voodoos)
 
+- The `@all` alias no longer depends directly on copies of files from the source
+  directory (@nojb)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/otherlibs/stdune-unstable/bool.ml
+++ b/otherlibs/stdune-unstable/bool.ml
@@ -17,3 +17,5 @@ let to_string = string_of_bool
 let of_string s = Option.try_with (fun () -> bool_of_string s)
 
 let to_dyn t = Dyn.Bool t
+
+let hash (t : bool) = Hashtbl.hash t

--- a/otherlibs/stdune-unstable/bool.mli
+++ b/otherlibs/stdune-unstable/bool.mli
@@ -9,3 +9,5 @@ val to_string : t -> string
 val of_string : string -> t option
 
 val to_dyn : t -> Dyn.t
+
+val hash : t -> int

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1990,15 +1990,11 @@ end = struct
       load_dir ~dir >>| function
       | Non_build targets -> Path.Set.filter targets ~f:(File_selector.test g)
       | Build { rules_here; _ } ->
-        let include_source_file_copies =
-          File_selector.include_source_file_copies g
-        in
+        let only_generated_files = File_selector.only_generated_files g in
         Path.Build.Map.foldi ~init:[] rules_here
           ~f:(fun s { Rule.info; _ } acc ->
             match info with
-            | Rule.Info.Source_file_copy _ when not include_source_file_copies
-              ->
-              acc
+            | Rule.Info.Source_file_copy _ when only_generated_files -> acc
             | _ ->
               let s = Path.build s in
               if File_selector.test g s then

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -3,31 +3,43 @@ open Stdune
 type t =
   { dir : Path.t
   ; predicate : string Predicate.t
+  ; include_source_file_copies : bool
   }
 
 let dir t = t.dir
 
 let predicate t = t.predicate
 
+let include_source_file_copies t = t.include_source_file_copies
+
 let compare x y =
   match Path.compare x.dir y.dir with
   | (Ordering.Lt | Gt) as a -> a
   | Eq -> Predicate.compare x.predicate y.predicate
 
-let create ~dir predicate = { dir; predicate }
+let create ~dir ?(include_source_file_copies = true) predicate =
+  { dir; predicate; include_source_file_copies }
 
-let to_dyn { dir; predicate } =
+let to_dyn { dir; predicate; include_source_file_copies } =
   let open Dyn in
-  Record [ ("dir", Path.to_dyn dir); ("predicate", Predicate.to_dyn predicate) ]
+  Record
+    [ ("dir", Path.to_dyn dir)
+    ; ("predicate", Predicate.to_dyn predicate)
+    ; ("include_source_file_copies", Encoder.bool include_source_file_copies)
+    ]
 
-let encode { dir; predicate } =
+let encode { dir; predicate; include_source_file_copies } =
   let open Dune_lang.Encoder in
   record
-    [ ("dir", Dpath.encode dir); ("predicate", Predicate.encode predicate) ]
+    [ ("dir", Dpath.encode dir)
+    ; ("predicate", Predicate.encode predicate)
+    ; ("include_source_file_copies", bool include_source_file_copies)
+    ]
 
 let equal x y = compare x y = Eq
 
-let hash { dir; predicate } =
-  Tuple.T2.hash Path.hash Predicate.hash (dir, predicate)
+let hash { dir; predicate; include_source_file_copies } =
+  Tuple.T3.hash Path.hash Predicate.hash Bool.hash
+    (dir, predicate, include_source_file_copies)
 
 let test t path = Predicate.test t.predicate (Path.basename path)

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -3,43 +3,43 @@ open Stdune
 type t =
   { dir : Path.t
   ; predicate : string Predicate.t
-  ; include_source_file_copies : bool
+  ; only_generated_files : bool
   }
 
 let dir t = t.dir
 
 let predicate t = t.predicate
 
-let include_source_file_copies t = t.include_source_file_copies
+let only_generated_files t = t.only_generated_files
 
 let compare x y =
   match Path.compare x.dir y.dir with
   | (Ordering.Lt | Gt) as a -> a
   | Eq -> Predicate.compare x.predicate y.predicate
 
-let create ~dir ?(include_source_file_copies = true) predicate =
-  { dir; predicate; include_source_file_copies }
+let create ~dir ?(only_generated_files = false) predicate =
+  { dir; predicate; only_generated_files }
 
-let to_dyn { dir; predicate; include_source_file_copies } =
+let to_dyn { dir; predicate; only_generated_files } =
   let open Dyn in
   Record
     [ ("dir", Path.to_dyn dir)
     ; ("predicate", Predicate.to_dyn predicate)
-    ; ("include_source_file_copies", Encoder.bool include_source_file_copies)
+    ; ("only_generated_files", Encoder.bool only_generated_files)
     ]
 
-let encode { dir; predicate; include_source_file_copies } =
+let encode { dir; predicate; only_generated_files } =
   let open Dune_lang.Encoder in
   record
     [ ("dir", Dpath.encode dir)
     ; ("predicate", Predicate.encode predicate)
-    ; ("include_source_file_copies", bool include_source_file_copies)
+    ; ("only_generated_files", bool only_generated_files)
     ]
 
 let equal x y = compare x y = Eq
 
-let hash { dir; predicate; include_source_file_copies } =
+let hash { dir; predicate; only_generated_files } =
   Tuple.T3.hash Path.hash Predicate.hash Bool.hash
-    (dir, predicate, include_source_file_copies)
+    (dir, predicate, only_generated_files)
 
 let test t path = Predicate.test t.predicate (Path.basename path)

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -9,10 +9,9 @@ val dir : t -> Path.t
 
 val predicate : t -> string Predicate.t
 
-val include_source_file_copies : t -> bool
+val only_generated_files : t -> bool
 
-val create :
-  dir:Path.t -> ?include_source_file_copies:bool -> string Predicate.t -> t
+val create : dir:Path.t -> ?only_generated_files:bool -> string Predicate.t -> t
 
 val equal : t -> t -> bool
 

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -9,7 +9,10 @@ val dir : t -> Path.t
 
 val predicate : t -> string Predicate.t
 
-val create : dir:Path.t -> string Predicate.t -> t
+val include_source_file_copies : t -> bool
+
+val create :
+  dir:Path.t -> ?include_source_file_copies:bool -> string Predicate.t -> t
 
 val equal : t -> t -> bool
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -206,7 +206,8 @@ let define_all_alias ~dir ~scope ~js_targets =
       in
       Predicate.create ~id ~f
     in
-    File_selector.create ~dir:(Path.build dir) pred
+    File_selector.create ~dir:(Path.build dir) ~include_source_file_copies:false
+      pred
     |> Action_builder.paths_matching_unit ~loc:Loc.none
   in
   Rules.Produce.Alias.add_deps (Alias.all ~dir) deps

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -206,8 +206,10 @@ let define_all_alias ~dir ~scope ~js_targets =
       in
       Predicate.create ~id ~f
     in
-    File_selector.create ~dir:(Path.build dir) ~include_source_file_copies:false
-      pred
+    let include_source_file_copies =
+      Dune_project.dune_version (Scope.project scope) < (3, 0)
+    in
+    File_selector.create ~dir:(Path.build dir) ~include_source_file_copies pred
     |> Action_builder.paths_matching_unit ~loc:Loc.none
   in
   Rules.Produce.Alias.add_deps (Alias.all ~dir) deps

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -206,10 +206,10 @@ let define_all_alias ~dir ~scope ~js_targets =
       in
       Predicate.create ~id ~f
     in
-    let include_source_file_copies =
-      Dune_project.dune_version (Scope.project scope) < (3, 0)
+    let only_generated_files =
+      Dune_project.dune_version (Scope.project scope) >= (3, 0)
     in
-    File_selector.create ~dir:(Path.build dir) ~include_source_file_copies pred
+    File_selector.create ~dir:(Path.build dir) ~only_generated_files pred
     |> Action_builder.paths_matching_unit ~loc:Loc.none
   in
   Rules.Produce.Alias.add_deps (Alias.all ~dir) deps

--- a/test/blackbox-tests/test-cases/all-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias.t/run.t
@@ -51,7 +51,7 @@ Add two files
 
 An empty project, should not copy any file.
 
-  $ dune build --root .
+  $ dune build
   $ find _build/default -name '*.ml'
 
 A project that only uses a.ml, should not copy b.ml
@@ -59,7 +59,7 @@ A project that only uses a.ml, should not copy b.ml
   $ cat > dune <<EOF
   > (library (name a) (modules a))
   > EOF
-  $ dune build --root .
+  $ dune build
   $ find _build/default -name '*.ml'
   _build/default/a.ml
 
@@ -68,7 +68,7 @@ A project that uses both files, should copy both.
   $ cat > dune <<EOF
   > (library (name a))
   > EOF
-  $ dune build --root .
+  $ dune build
   $ find _build/default -name '*.ml' | sort
   _build/default/a.ml
   _build/default/b.ml

--- a/test/blackbox-tests/test-cases/all-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias.t/run.t
@@ -36,3 +36,39 @@
   $ dune build --display short --root install-alias @all
   Entering directory 'install-alias'
           echo foo
+
+@all does not depend directly on file copies from the source tree
+
+  $ mkdir -p source-file-copies
+  $ cd source-file-copies
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+Add two files
+
+  $ touch a.ml b.ml
+
+An empty project, should not copy any file.
+
+  $ dune build --root .
+  $ find _build/default -name '*.ml'
+
+A project that only uses a.ml, should not copy b.ml
+
+  $ cat > dune <<EOF
+  > (library (name a) (modules a))
+  > EOF
+  $ dune build --root .
+  $ find _build/default -name '*.ml'
+  _build/default/a.ml
+
+A project that uses both files, should copy both.
+
+  $ cat > dune <<EOF
+  > (library (name a))
+  > EOF
+  $ dune build --root .
+  $ find _build/default -name '*.ml'
+  _build/default/a.ml
+  _build/default/b.ml

--- a/test/blackbox-tests/test-cases/all-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias.t/run.t
@@ -69,6 +69,6 @@ A project that uses both files, should copy both.
   > (library (name a))
   > EOF
   $ dune build --root .
-  $ find _build/default -name '*.ml'
+  $ find _build/default -name '*.ml' | sort
   _build/default/a.ml
   _build/default/b.ml


### PR DESCRIPTION
As discussed during the dev meeting this PR changes `@all` (for 3.0 and later) so that it does not depend directly on source tree file copies.

This means that unless a file from the source tree is a dependency of some rule or alias, it will not be copied to the build directory when doing `dune build` or `dune build @all`.

Fixes #4438