### PR TITLE
Fix a few issues with [temp.ml]

### DIFF
--- a/otherlibs/stdune-unstable/fpath.ml
+++ b/otherlibs/stdune-unstable/fpath.ml
@@ -1,10 +1,11 @@
 let is_root t = Filename.dirname t = t
 
+let initial_cwd = Stdlib.Sys.getcwd ()
+
 type mkdir_result =
   | Already_exists
   | Created
-
-let initial_cwd = Stdlib.Sys.getcwd ()
+  | Missing_parent_directory
 
 let mkdir ?(perms = 0o777) t_s =
   try
@@ -12,21 +13,31 @@ let mkdir ?(perms = 0o777) t_s =
     Created
   with
   | Unix.Unix_error (EEXIST, _, _) -> Already_exists
+  | Unix.Unix_error (ENOENT, _, _) -> Missing_parent_directory
+
+type mkdir_p_result =
+  | Already_exists
+  | Created
 
 let rec mkdir_p ?(perms = 0o777) t_s =
-  try
-    Unix.mkdir t_s perms;
-    Created
-  with
-  | Unix.Unix_error (EEXIST, _, _) -> Already_exists
-  | Unix.Unix_error (ENOENT, _, _) as e ->
+  match mkdir ~perms t_s with
+  | Created -> Created
+  | Already_exists -> Already_exists
+  | Missing_parent_directory -> (
     if is_root t_s then
-      raise e
+      Code_error.raise
+        "Impossible happened: [Fpath.mkdir] refused to create a directory at \
+         the root, allegedly because its parent was missing"
+        []
     else
       let parent = Filename.dirname t_s in
-      let (_ : mkdir_result) = mkdir_p parent ~perms in
-      Unix.mkdir t_s perms;
-      Created
+      match mkdir_p ~perms parent with
+      | Created
+      | Already_exists ->
+        (* The [Already_exists] case might happen if some other process managed
+           to create the parent directory concurrently. *)
+        Unix.mkdir t_s perms;
+        Created)
 
 let resolve_link path =
   match Unix.readlink path with

--- a/otherlibs/stdune-unstable/fpath.ml
+++ b/otherlibs/stdune-unstable/fpath.ml
@@ -1,10 +1,20 @@
 let is_root t = Filename.dirname t = t
 
-type mkdir_p =
+type mkdir_result =
   | Already_exists
   | Created
 
 let initial_cwd = Stdlib.Sys.getcwd ()
+
+let mkdir ?(perms = 0o777) t_s =
+  if is_root t_s then
+    Already_exists
+  else
+    try
+      Unix.mkdir t_s perms;
+      Created
+    with
+    | Unix.Unix_error (EEXIST, _, _) -> Already_exists
 
 let rec mkdir_p ?(perms = 0o777) t_s =
   if is_root t_s then
@@ -20,7 +30,7 @@ let rec mkdir_p ?(perms = 0o777) t_s =
       if is_root parent then
         raise e
       else
-        let (_ : mkdir_p) = mkdir_p parent ~perms in
+        let (_ : mkdir_result) = mkdir_p parent ~perms in
         Unix.mkdir t_s perms;
         Created
 

--- a/otherlibs/stdune-unstable/fpath.mli
+++ b/otherlibs/stdune-unstable/fpath.mli
@@ -1,11 +1,13 @@
 (** Functions on paths that are represented as strings *)
 
-(** Represent the result of [mkdir_p] *)
-type mkdir_p =
-  | Already_exists  (** The path already exists. No action was taken *)
+(** The result of [mkdir] and [mkdir_p]. *)
+type mkdir_result =
+  | Already_exists  (** The directory already exists. No action was taken. *)
   | Created  (** The directory was created. *)
 
-val mkdir_p : ?perms:int -> string -> mkdir_p
+val mkdir : ?perms:int -> string -> mkdir_result
+
+val mkdir_p : ?perms:int -> string -> mkdir_result
 
 type follow_symlink_error =
   | Not_a_symlink

--- a/otherlibs/stdune-unstable/fpath.mli
+++ b/otherlibs/stdune-unstable/fpath.mli
@@ -1,13 +1,18 @@
 (** Functions on paths that are represented as strings *)
 
-(** The result of [mkdir] and [mkdir_p]. *)
 type mkdir_result =
   | Already_exists  (** The directory already exists. No action was taken. *)
   | Created  (** The directory was created. *)
+  | Missing_parent_directory
+      (** No parent directory, use [mkdir_p] if you want to create it too. *)
 
 val mkdir : ?perms:int -> string -> mkdir_result
 
-val mkdir_p : ?perms:int -> string -> mkdir_result
+type mkdir_p_result =
+  | Already_exists  (** The directory already exists. No action was taken. *)
+  | Created  (** The directory was created. *)
+
+val mkdir_p : ?perms:int -> string -> mkdir_p_result
 
 type follow_symlink_error =
   | Not_a_symlink

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -128,7 +128,7 @@ end = struct
     | Some p -> p
 
   let mkdir_p ?perms p =
-    ignore (Fpath.mkdir_p ?perms (to_string p) : Fpath.mkdir_p)
+    ignore (Fpath.mkdir_p ?perms (to_string p) : Fpath.mkdir_result)
 
   let extension t = Filename.extension (to_string t)
 
@@ -551,7 +551,7 @@ end
 
 module Relative_to_source_root = struct
   let mkdir_p ?perms s =
-    ignore (Fpath.mkdir_p ?perms (Local.to_string s) : Fpath.mkdir_p)
+    ignore (Fpath.mkdir_p ?perms (Local.to_string s) : Fpath.mkdir_result)
 end
 
 module Source0 = Local

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -1112,9 +1112,11 @@ let ensure_build_dir_exists () =
   | In_source_dir p -> Relative_to_source_root.mkdir_p p ~perms
   | External p -> (
     let p = External.to_string p in
-    try Unix.mkdir p perms with
-    | Unix.Unix_error (EEXIST, _, _) -> ()
-    | Unix.Unix_error (ENOENT, _, _) ->
+    match Fpath.mkdir ~perms p with
+    | Created
+    | Already_exists ->
+      ()
+    | exception Unix.Unix_error (ENOENT, _, _) ->
       User_error.raise
         [ Pp.textf
             "Cannot create external build directory %s. Make sure that the \

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -127,8 +127,8 @@ end = struct
       Code_error.raise "Path.External.parent_exn called on a root path" []
     | Some p -> p
 
-  let mkdir_p ?perms p =
-    ignore (Fpath.mkdir_p ?perms (to_string p) : Fpath.mkdir_result)
+  let mkdir_p ?perms path =
+    ignore (Fpath.mkdir_p ?perms (to_string path) : Fpath.mkdir_p_result)
 
   let extension t = Filename.extension (to_string t)
 
@@ -550,8 +550,8 @@ end = struct
 end
 
 module Relative_to_source_root = struct
-  let mkdir_p ?perms s =
-    ignore (Fpath.mkdir_p ?perms (Local.to_string s) : Fpath.mkdir_result)
+  let mkdir_p ?perms path =
+    ignore (Fpath.mkdir_p ?perms (Local.to_string path) : Fpath.mkdir_p_result)
 end
 
 module Source0 = Local
@@ -1116,7 +1116,7 @@ let ensure_build_dir_exists () =
     | Created
     | Already_exists ->
       ()
-    | exception Unix.Unix_error (ENOENT, _, _) ->
+    | Missing_parent_directory ->
       User_error.raise
         [ Pp.textf
             "Cannot create external build directory %s. Make sure that the \

--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -4,8 +4,6 @@ type what =
 
 let prng = lazy (Random.State.make_self_init ())
 
-exception Retry
-
 let try_paths n ~dir ~prefix ~suffix ~f =
   assert (n > 0);
   let rec loop n =
@@ -13,8 +11,9 @@ let try_paths n ~dir ~prefix ~suffix ~f =
       let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
       Path.relative dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
     in
-    try f path with
-    | Retry ->
+    match f path with
+    | Ok res -> res
+    | Error `Retry ->
       if n = 1 then
         Code_error.raise "try_paths failed to find a good candidate" []
       else
@@ -28,7 +27,12 @@ let tmp_dirs = ref Path.Set.empty
 
 let create_temp_file ?(perms = 0o600) path =
   let file = Path.to_string path in
-  Unix.close (Unix.openfile file [ O_WRONLY; Unix.O_CREAT; Unix.O_EXCL ] perms)
+  match
+    Unix.close
+      (Unix.openfile file [ O_WRONLY; Unix.O_CREAT; Unix.O_EXCL ] perms)
+  with
+  | () -> Ok ()
+  | exception Unix.Unix_error (EEXIST, _, _) -> Error `Retry
 
 let destroy = function
   | Dir -> Path.rm_rf ~allow_external:true
@@ -37,8 +41,8 @@ let destroy = function
 let create_temp_dir ?perms path =
   let dir = Path.to_string path in
   match Fpath.mkdir ?perms dir with
-  | Created -> ()
-  | Already_exists -> raise Retry
+  | Created -> Ok ()
+  | Already_exists -> Error `Retry
 
 let set = function
   | Dir -> tmp_dirs
@@ -63,8 +67,7 @@ let temp_in_dir ?perms what ~dir ~prefix ~suffix =
   let path =
     let create = create ?perms what in
     try_paths 1000 ~dir ~prefix ~suffix ~f:(fun path ->
-        create path;
-        path)
+        Result.map (create path) ~f:(fun () -> path))
   in
   let set = set what in
   set := Path.Set.add !set path;
@@ -96,14 +99,11 @@ let clear_dir dir =
 
 let temp_path =
   try_paths 1000 ~f:(fun candidate ->
-      (try create_temp_file candidate with
-      | Unix.Unix_error (EEXIST, _, _) -> raise Retry);
-      candidate)
+      Result.map (create_temp_file candidate) ~f:(fun () -> candidate))
 
 let temp_dir ~parent_dir ~prefix ~suffix =
   try_paths 1000 ~dir:parent_dir ~prefix ~suffix ~f:(fun candidate ->
-      create_temp_dir candidate;
-      candidate)
+      Result.map (create_temp_dir candidate) ~f:(fun () -> candidate))
 
 module Monad (M : sig
   type 'a t

--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -15,7 +15,7 @@ let try_paths n ~dir ~prefix ~suffix ~f =
     | Ok res -> res
     | Error `Retry ->
       if n = 1 then
-        Code_error.raise "try_paths failed to find a good candidate" []
+        Code_error.raise "[Temp.try_paths] failed to find a good candidate" []
       else
         loop (n - 1)
   in
@@ -43,6 +43,9 @@ let create_temp_dir ?perms path =
   match Fpath.mkdir ?perms dir with
   | Created -> Ok ()
   | Already_exists -> Error `Retry
+  | Missing_parent_directory ->
+    Code_error.raise "[Temp.create_temp_dir] called in a non-existing directory"
+      []
 
 let set = function
   | Dir -> tmp_dirs

--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -36,7 +36,7 @@ let destroy = function
 
 let create_temp_dir ?perms path =
   let dir = Path.to_string path in
-  match Fpath.mkdir_p ?perms dir with
+  match Fpath.mkdir ?perms dir with
   | Created -> ()
   | Already_exists -> raise Retry
 
@@ -101,9 +101,8 @@ let temp_path =
 
 let temp_dir ~parent_dir ~prefix ~suffix =
   try_paths 1000 ~dir:parent_dir ~prefix ~suffix ~f:(fun candidate ->
-      match Fpath.mkdir_p (Path.to_string candidate) with
-      | Created -> candidate
-      | Already_exists -> raise Retry)
+      create_temp_dir candidate;
+      candidate)
 
 module Monad (M : sig
   type 'a t

--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -38,7 +38,7 @@ let create_temp_dir ?perms path =
   let dir = Path.to_string path in
   match Fpath.mkdir_p ?perms dir with
   | Created -> ()
-  | Already_exists -> raise (Unix.Unix_error (ENOENT, "mkdir", dir))
+  | Already_exists -> raise Retry
 
 let set = function
   | Dir -> tmp_dirs

--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -96,7 +96,8 @@ let clear_dir dir =
 
 let temp_path =
   try_paths 1000 ~f:(fun candidate ->
-      if Path.exists candidate then raise Retry;
+      (try create_temp_file candidate with
+      | Unix.Unix_error (EEXIST, _, _) -> raise Retry);
       candidate)
 
 let temp_dir ~parent_dir ~prefix ~suffix =

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -92,4 +92,4 @@ let create_cache_directories () =
   List.iter
     [ temp_path; metadata_storage_path; file_storage_path; value_storage_path ]
     ~f:(fun path ->
-      ignore (Fpath.mkdir_p (Path.to_string path) : Fpath.mkdir_result))
+      ignore (Fpath.mkdir_p (Path.to_string path) : Fpath.mkdir_p_result))

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -87,3 +87,9 @@ let file_path = Versioned.file_path Version.File.current
 let value_storage_path = Versioned.value_storage_path Version.Value.current
 
 let value_path = Versioned.value_path Version.Value.current
+
+let create_cache_directories () =
+  List.iter
+    [ temp_path; metadata_storage_path; file_storage_path; value_storage_path ]
+    ~f:(fun path ->
+      ignore (Fpath.mkdir_p (Path.to_string path) : Fpath.mkdir_result))

--- a/src/dune_cache_storage/layout.mli
+++ b/src/dune_cache_storage/layout.mli
@@ -13,6 +13,10 @@ val default_root_path : unit -> Path.t
 (** The path to the root directory of the cache. *)
 val root_path : Path.t
 
+(** Create a few subdirectories in [root_path]. We expose this function because
+    we don't want to modify the file system when the cache is disabled. *)
+val create_cache_directories : unit -> unit
+
 (** This directory stores metadata files, one per each historically executed
     build rule or output-producing action. (While this is a convenient mental
     model, in reality we need to occasionally remove some outdated metadata

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2361,6 +2361,11 @@ let init ~stats ~contexts ~promote_source ~cache_config ~sandboxing_preference
         Context_name.Map.of_list_map_exn contexts ~f:(fun c ->
             (c.Build_context.name, c)))
   in
+  let () =
+    match (cache_config : Dune_cache.Config.t) with
+    | Disabled -> ()
+    | Enabled _ -> Dune_cache_storage.Layout.create_cache_directories ()
+  in
   set
     { contexts
     ; rule_generator


### PR DESCRIPTION
This PR fixes a few issues with `temp.ml`:

- [x] Use `raise Retry` consistently. Not doing that led to throwing an exception to the user instead of retrying with a new path.
- [x] Avoid calling `mkdir_p` when creating temporary directories. The caller should ensure the temporary directory already exists.
- [x] Reserve the path in `with_temp_path`, so it can't be taken concurrently.