### PR TITLE
More cleanup following dropping jbuilder support

### DIFF
--- a/src/dune_engine/format_dune_lang.ml
+++ b/src/dune_engine/format_dune_lang.ml
@@ -43,12 +43,8 @@ let print_wrapped_list ~version x =
 
 let pp_comment_line l = Pp.char ';' ++ Pp.verbatim l
 
-let pp_comment loc (comment : Dune_lang.Cst.Comment.t) =
-  match comment with
-  | Lines ls -> Pp.vbox (Pp.concat_map ~sep:Pp.cut ~f:pp_comment_line ls)
-  | Legacy ->
-    User_error.raise ~loc
-      [ Pp.text "Formatting is only supported with the dune syntax" ]
+let pp_comment lines =
+  Pp.vbox (Pp.concat_map ~sep:Pp.cut ~f:pp_comment_line lines)
 
 let pp_break attached =
   if attached then
@@ -61,8 +57,8 @@ let pp_list_with_comments pp_sexp sexps =
     match l with
     | x :: Comment (loc, c) :: xs ->
       let attached = Loc.on_same_line (Dune_lang.Cst.loc x) loc in
-      pp_sexp x ++ pp_break attached ++ pp_comment loc c ++ Pp.cut ++ go xs
-    | Comment (loc, c) :: xs -> pp_comment loc c ++ Pp.cut ++ go xs
+      pp_sexp x ++ pp_break attached ++ pp_comment c ++ Pp.cut ++ go xs
+    | Comment (_, c) :: xs -> pp_comment c ++ Pp.cut ++ go xs
     | [ x ] -> pp_sexp x
     | x :: xs -> pp_sexp x ++ Pp.cut ++ go xs
     | [] -> Pp.nop
@@ -77,7 +73,7 @@ let rec pp_sexp ~version : Dune_lang.Cst.t -> _ = function
         print_wrapped_list ~version sexps
       else
         pp_sexp_list ~version sexps)
-  | Comment (loc, c) -> pp_comment loc c
+  | Comment (_, c) -> pp_comment c
 
 and pp_sexp_list ~version sexps =
   Pp.char '(' ++ pp_list_with_comments (pp_sexp ~version) sexps ++ Pp.char ')'

--- a/src/dune_lang/atom.ml
+++ b/src/dune_lang/atom.ml
@@ -41,7 +41,12 @@ let is_valid =
     let len = String.length s in
     len > 0 && loop s 0 len
 
-let of_string s = A s
+let of_string s =
+  if is_valid s then
+    A s
+  else
+    Code_error.raise "Dune_lang.Atom.of_string got invalid atom"
+      [ ("atom", String s) ]
 
 let to_string (A s) = s
 
@@ -51,19 +56,12 @@ let parse s =
   else
     None
 
-let print (A s) =
-  if is_valid s then
-    s
-  else
-    Code_error.raise "atom cannot be printed in dune syntax"
-      [ ("atom", String s) ]
-
-let of_int i = of_string (string_of_int i)
+let of_int i = A (string_of_int i)
 
 let of_float x = of_string (string_of_float x)
 
-let of_bool x = of_string (string_of_bool x)
+let of_bool x = A (string_of_bool x)
 
-let of_digest d = of_string (Digest.to_string d)
+let of_digest d = A (Digest.to_string d)
 
-let of_int64 i = of_string (Int64.to_string i)
+let of_int64 i = A (Int64.to_string i)

--- a/src/dune_lang/atom.mli
+++ b/src/dune_lang/atom.mli
@@ -14,8 +14,6 @@ val to_string : t -> string
     otherwise it is [None] *)
 val parse : string -> t option
 
-val print : t -> string
-
 val of_int : int -> t
 
 val of_float : float -> t

--- a/src/dune_lang/cst.ml
+++ b/src/dune_lang/cst.ml
@@ -1,12 +1,11 @@
 open Stdune
-module Comment = Lexer.Token.Comment
 
 type t =
   | Atom of Loc.t * Atom.t
   | Quoted_string of Loc.t * string
   | Template of Template.t
   | List of Loc.t * t list
-  | Comment of Loc.t * Comment.t
+  | Comment of Loc.t * string list
 
 let rec to_dyn =
   let open Dyn.Encoder in
@@ -15,7 +14,7 @@ let rec to_dyn =
   | Quoted_string (_, s) -> constr "Quoted_string" [ string s ]
   | Template t -> constr "Template" [ Template.to_dyn t ]
   | List (_, l) -> constr "List" [ list to_dyn l ]
-  | Comment (_, c) -> constr "Comment" [ Comment.to_dyn c ]
+  | Comment (_, c) -> constr "Comment" [ Dyn.Encoder.(list string) c ]
 
 let loc
     ( Atom (loc, _)
@@ -24,28 +23,6 @@ let loc
     | Template { loc; _ }
     | Comment (loc, _) ) =
   loc
-
-let fetch_legacy_comments t ~file_contents =
-  let rec loop t =
-    match t with
-    | Template _
-    | Quoted_string _
-    | Atom _
-    | Comment (_, Lines _) ->
-      t
-    | List (loc, l) -> List (loc, List.map l ~f:loop)
-    | Comment (loc, Legacy) ->
-      let start = loc.start.pos_cnum in
-      let stop = loc.stop.pos_cnum in
-      let s =
-        if file_contents.[start] = '#' && file_contents.[start + 1] = '|' then
-          String.sub file_contents ~pos:(start + 2) ~len:(stop - start - 4)
-        else
-          String.sub file_contents ~pos:start ~len:(stop - start)
-      in
-      Comment (loc, Lines (String.split s ~on:'\n'))
-  in
-  loop t
 
 let rec abstract : t -> Ast.t option = function
   | Atom (loc, atom) -> Some (Atom (loc, atom))

--- a/src/dune_lang/cst.mli
+++ b/src/dune_lang/cst.mli
@@ -1,20 +1,15 @@
 (** Concrete syntax tree *)
 
 open Stdune
-module Comment = Lexer.Token.Comment
 
 type t =
   | Atom of Loc.t * Atom.t
   | Quoted_string of Loc.t * string
   | Template of Template.t
   | List of Loc.t * t list
-  | Comment of Loc.t * Comment.t
+  | Comment of Loc.t * string list
 
 val loc : t -> Loc.t
-
-(** Replace all the [Comment Legacy] by [Comment (Lines _)] by extracting the
-    contents of comments from the original file. *)
-val fetch_legacy_comments : t -> file_contents:string -> t
 
 val abstract : t -> Ast.t option
 
@@ -25,6 +20,6 @@ val to_dyn : t -> Dyn.t
 val to_sexp : t -> T.t option
 
 (** Return all the comments contained in a concrete syntax tree *)
-val extract_comments : t list -> (Loc.t * Comment.t) list
+val extract_comments : t list -> (Loc.t * string list) list
 
 val tokenize : t list -> (Loc.t * Lexer.Token.t) list

--- a/src/dune_lang/encoder.ml
+++ b/src/dune_lang/encoder.ml
@@ -75,4 +75,4 @@ let record_fields (l : field list) =
     | Normal (name, v) -> Some (List [ Atom (Atom.of_string name); v ])
     | Inlined_list (name, l) -> Some (List (Atom (Atom.of_string name) :: l)))
 
-let unknown _ = unsafe_atom_of_string "<unknown>"
+let unknown _ = atom "<unknown>"

--- a/src/dune_lang/lexer.mli
+++ b/src/dune_lang/lexer.mli
@@ -6,7 +6,6 @@ module Token : sig
     | Quoted_string of string
     | Lparen
     | Rparen
-    | Sexp_comment
     | Eof
     | Template of Template.t
     | Comment of string list

--- a/src/dune_lang/lexer.mli
+++ b/src/dune_lang/lexer.mli
@@ -1,24 +1,6 @@
-open Stdune
+open! Stdune
 
 module Token : sig
-  module Comment : sig
-    type t =
-      | Lines of string list
-          (** The following comment:
-
-              {v ; abc ; def v}
-
-              is represented as:
-
-              {[ Lines [ " abc"; " def" ] ]} *)
-      | Legacy
-          (** Legacy for jbuild files: either block comments or sexp comments.
-              The programmer is responsible for fetching the comment contents
-              using the location. *)
-
-    val to_dyn : t -> Dyn.t
-  end
-
   type t =
     | Atom of Atom.t
     | Quoted_string of string
@@ -27,7 +9,17 @@ module Token : sig
     | Sexp_comment
     | Eof
     | Template of Template.t
-    | Comment of Comment.t
+    | Comment of string list
+        (** The following comment:
+
+            {v
+             ; abc
+             ; def
+            v}
+
+            is represented as:
+
+            {[ Lines [ " abc"; " def" ] ]} *)
 end
 
 type t = with_comments:bool -> Lexing.lexbuf -> Token.t

--- a/src/dune_lang/lexer.mll
+++ b/src/dune_lang/lexer.mll
@@ -4,18 +4,6 @@ open! Stdune
 open Stdune
 
 module Token = struct
-  module Comment = struct
-    type t =
-      | Lines of string list
-      | Legacy
-
-    let to_dyn =
-      let open Dyn.Encoder in
-      function
-      | Legacy -> constr "Legacy" []
-      | Lines l -> constr "Lines" [ list string l ]
-  end
-
   type t =
     | Atom of Atom.t
     | Quoted_string of string
@@ -24,7 +12,7 @@ module Token = struct
     | Sexp_comment
     | Eof
     | Template of Template.t
-    | Comment of Comment.t
+    | Comment of string list
 end
 
 type t = with_comments:bool -> Lexing.lexbuf -> Token.t
@@ -193,7 +181,7 @@ and comment_trail acc = parse
   | newline blank* ';' (comment_body as s)
     { comment_trail (s :: acc) lexbuf }
   | ""
-    { Token.Comment (Lines (List.rev acc)) }
+    { Token.Comment (List.rev acc) }
 
 and atom acc start = parse
   | (atom_char # '%')+ as s

--- a/src/dune_lang/lexer.mll
+++ b/src/dune_lang/lexer.mll
@@ -9,7 +9,6 @@ module Token = struct
     | Quoted_string of string
     | Lparen
     | Rparen
-    | Sexp_comment
     | Eof
     | Template of Template.t
     | Comment of string list

--- a/src/dune_lang/parser.mli
+++ b/src/dune_lang/parser.mli
@@ -19,4 +19,4 @@ val load : ?lexer:Lexer.t -> Path.t -> mode:'a Mode.t -> 'a
 
 (** Insert comments in a concrete syntax tree. Comments are inserted based on
     their location. *)
-val insert_comments : Cst.t list -> (Loc.t * Cst.Comment.t) list -> Cst.t list
+val insert_comments : Cst.t list -> (Loc.t * string list) list -> Cst.t list

--- a/src/dune_lang/t.ml
+++ b/src/dune_lang/t.ml
@@ -14,18 +14,16 @@ let atom_or_quoted_string s =
 
 let atom s = Atom (Atom.of_string s)
 
-let unsafe_atom_of_string s = atom s
-
 let rec to_string t =
   match t with
-  | Atom a -> Atom.print a
+  | Atom (A s) -> s
   | Quoted_string s -> Escape.quoted s
   | List l ->
     Printf.sprintf "(%s)" (List.map l ~f:to_string |> String.concat ~sep:" ")
   | Template t -> Template.to_string t
 
 let rec pp = function
-  | Atom s -> Pp.verbatim (Atom.print s)
+  | Atom (A s) -> Pp.verbatim s
   | Quoted_string s -> Pp.verbatim (Escape.quoted s)
   | List [] -> Pp.verbatim "()"
   | List l ->
@@ -52,7 +50,7 @@ module Deprecated = struct
       Format.pp_print_string ppf (Escape.quoted s)
 
   let rec pp_split_strings ppf = function
-    | Atom s -> Format.pp_print_string ppf (Atom.print s)
+    | Atom (A s) -> Format.pp_print_string ppf s
     | Quoted_string s -> pp_print_quoted_string ppf s
     | List [] -> Format.pp_print_string ppf "()"
     | List (first :: rest) ->

--- a/src/dune_lang/t.mli
+++ b/src/dune_lang/t.mli
@@ -16,8 +16,6 @@ val atom : string -> t
 
 val atom_or_quoted_string : string -> t
 
-val unsafe_atom_of_string : string -> t
-
 (** Serialize a S-expression *)
 val to_string : t -> string
 

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -493,9 +493,7 @@ let rec expand (t : Action_dune_lang.t) : Action.t Action_expander.t =
         [ Pp.text
             "(mkdir ...) is not supported for paths outside of the workspace:"
         ; Pp.seq (Pp.verbatim "  ")
-            (Dune_lang.pp
-               (List
-                  [ Dune_lang.unsafe_atom_of_string "mkdir"; Dpath.encode path ]))
+            (Dune_lang.pp (List [ Dune_lang.atom "mkdir"; Dpath.encode path ]))
         ];
     O.Mkdir path
   | Diff { optional; file1; file2; mode } ->

--- a/src/dune_rules/binary_kind.ml
+++ b/src/dune_rules/binary_kind.ml
@@ -32,6 +32,6 @@ let to_dyn t =
   let open Dyn.Encoder in
   constr (to_string t) []
 
-let encode t = Dune_lang.unsafe_atom_of_string (to_string t)
+let encode t = Dune_lang.atom (to_string t)
 
 let all = [ C; Exe; Object; Shared_object; Plugin; Js ]

--- a/src/dune_rules/dep_conf.ml
+++ b/src/dune_rules/dep_conf.ml
@@ -78,16 +78,13 @@ let decode =
 open Dune_lang
 
 let encode = function
-  | File t ->
-    List [ Dune_lang.unsafe_atom_of_string "file"; String_with_vars.encode t ]
-  | Alias t ->
-    List [ Dune_lang.unsafe_atom_of_string "alias"; String_with_vars.encode t ]
+  | File t -> List [ Dune_lang.atom "file"; String_with_vars.encode t ]
+  | Alias t -> List [ Dune_lang.atom "alias"; String_with_vars.encode t ]
   | Alias_rec t ->
-    List
-      [ Dune_lang.unsafe_atom_of_string "alias_rec"; String_with_vars.encode t ]
+    List [ Dune_lang.atom "alias_rec"; String_with_vars.encode t ]
   | Glob_files { glob = t; recursive } ->
     List
-      [ Dune_lang.unsafe_atom_of_string
+      [ Dune_lang.atom
           (if recursive then
             "glob_files_rec"
           else
@@ -95,17 +92,10 @@ let encode = function
       ; String_with_vars.encode t
       ]
   | Source_tree t ->
-    List
-      [ Dune_lang.unsafe_atom_of_string "source_tree"
-      ; String_with_vars.encode t
-      ]
-  | Package t ->
-    List
-      [ Dune_lang.unsafe_atom_of_string "package"; String_with_vars.encode t ]
-  | Universe -> Dune_lang.unsafe_atom_of_string "universe"
-  | Env_var t ->
-    List
-      [ Dune_lang.unsafe_atom_of_string "env_var"; String_with_vars.encode t ]
+    List [ Dune_lang.atom "source_tree"; String_with_vars.encode t ]
+  | Package t -> List [ Dune_lang.atom "package"; String_with_vars.encode t ]
+  | Universe -> Dune_lang.atom "universe"
+  | Env_var t -> List [ Dune_lang.atom "env_var"; String_with_vars.encode t ]
   | Sandbox_config config ->
     if Sandbox_config.equal config Sandbox_config.no_special_requirements then
       List []

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -403,7 +403,7 @@ module Mode_conf = struct
     let open Dyn.Encoder in
     constr (to_string t) []
 
-  let encode t = Dune_lang.unsafe_atom_of_string (to_string t)
+  let encode t = Dune_lang.atom (to_string t)
 
   module Kind = struct
     type t =
@@ -1238,7 +1238,7 @@ module Executables = struct
     let simple_encode link_mode =
       let is_ok (_, candidate) = compare candidate link_mode = Eq in
       List.find ~f:is_ok simple_representations
-      |> Option.map ~f:(fun (s, _) -> Dune_lang.unsafe_atom_of_string s)
+      |> Option.map ~f:(fun (s, _) -> Dune_lang.atom s)
 
     let encode link_mode =
       match simple_encode link_mode with

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -221,10 +221,7 @@ let check_invalid_module_listing ~(buildable : Buildable.t) ~intf_only ~modules
           ; Pp.text "You need to add the following field to this stanza:"
           ; Pp.nop
           ; Pp.textf "  %s"
-              (let tag =
-                 Dune_lang.unsafe_atom_of_string
-                   "modules_without_implementation"
-               in
+              (let tag = Dune_lang.atom "modules_without_implementation" in
                let modules =
                  missing_intf_only |> uncapitalized
                  |> List.map ~f:Dune_lang.Encoder.string

--- a/src/dune_rules/ordered_set_lang.ml
+++ b/src/dune_rules/ordered_set_lang.ml
@@ -242,17 +242,13 @@ module Unexpanded = struct
       | Element s -> String_with_vars.encode s
       | Standard -> Dune_lang.atom ":standard"
       | Union l -> List (List.map l ~f:loop)
-      | Diff (a, b) ->
-        List [ loop a; Dune_lang.unsafe_atom_of_string "\\"; loop b ]
+      | Diff (a, b) -> List [ loop a; Dune_lang.atom "\\"; loop b ]
       | Include fn ->
-        List
-          [ Dune_lang.unsafe_atom_of_string ":include"
-          ; String_with_vars.encode fn
-          ]
+        List [ Dune_lang.atom ":include"; String_with_vars.encode fn ]
     in
     match t.ast with
     | Union l -> List.map l ~f:loop
-    | Diff (a, b) -> [ loop a; Dune_lang.unsafe_atom_of_string "\\"; loop b ]
+    | Diff (a, b) -> [ loop a; Dune_lang.atom "\\"; loop b ]
     | ast -> [ loop ast ]
 
   let standard = standard

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -321,10 +321,10 @@ world
   [%expect
     {|
 [ Atom A "hello"
-; Comment Lines [ " comment" ]
+; Comment [ " comment" ]
 ; Atom A "world"
-; Comment Lines [ " multiline"; " comment" ]
-; List [ Atom A "x"; Comment Lines [ " comment inside list" ]; Atom A "y" ]
+; Comment [ " multiline"; " comment" ]
+; List [ Atom A "x"; Comment [ " comment inside list" ]; Atom A "y" ]
 ]
 |}]
 


### PR DESCRIPTION
A bit more cleanup following dropping support for jbuilder:

- we no longer need to support "sexp comments" or "block comments" in the parser
- not all strings are valid `Atom.t` values. We didn't make the type strict in the past because it made the jbuilder support complicated, but now we can