### PR TITLE
Delete old cache configuration settings in 3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -103,6 +103,12 @@ Unreleased
   the root of the build dir (or sandbox) to `/workspace_root` (#4466,
   @jeremiedimino)
 
+- Simplify the implementation of build cache. We stop using the cache daemon to
+  access the cache and instead write to and read from it directly. The new cache
+  implementation is based on Jenga's cache library, which was thoroughly tested
+  on large-scale builds. Using Jenga's cache library will also make it easier
+  for us to port Jenga's cloud cache to Dune. (#4443, #4465, Andrey Mokhov)
+
 2.9.0 (unreleased)
 ------------------
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -165,8 +165,7 @@ let init ?log_file c =
       Enabled
         { storage_mode =
             Option.value config.cache_storage_mode ~default:Hardlink
-        ; reproducibility_check =
-            Check { check_probability = config.cache_check_probability }
+        ; reproducibility_check = config.cache_reproducibility_check
         }
   in
   Dune_rules.Main.init ~stats:c.stats
@@ -605,12 +604,11 @@ let shared_with_config_file =
         "Check build reproducibility by re-executing randomly chosen rules and \
          comparing their results with those stored in Dune cache. Note: by \
          increasing the probability of such checks you slow down the build. \
-         Default is `%s'."
-        (Float.to_string Dune_config.default.cache_check_probability)
+         The default probability is zero, i.e. no rules are checked."
     in
     Arg.(
       value
-      & opt float Dune_config.default.cache_check_probability
+      & opt (some float) None
       & info
           [ "cache-check-probability" ]
           ~docs
@@ -628,7 +626,9 @@ let shared_with_config_file =
   ; sandboxing_preference = Option.map sandboxing_preference ~f:(fun x -> [ x ])
   ; terminal_persistence
   ; cache_enabled
-  ; cache_check_probability = Some cache_check_probability
+  ; cache_reproducibility_check =
+      Option.map cache_check_probability
+        ~f:Dune_cache.Config.Reproducibility_check.check
   ; cache_storage_mode
   ; swallow_stdout_on_success = Option.some_if swallow_stdout_on_success true
   }

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -158,21 +158,15 @@ let init ?log_file c =
          (Dune_engine.Execution_parameters.builtin_default
          |> Dune_rules.Workspace.update_execution_parameters w));
   Dune_rules.Global.init ~capture_outputs:c.capture_outputs;
-  (* CR-soon amokhov: Right now, types [Dune_config.Caching.Duplication.t] and
-     [Dune_cache_storage.Mode.t] are the same. They will be unified after
-     removing the cache daemon and adapting the configuration format. *)
   let cache_config =
-    match config.cache_mode with
+    match config.cache_enabled with
     | Disabled -> Dune_cache.Config.Disabled
     | Enabled ->
       Enabled
         { storage_mode =
-            (match config.cache_duplication with
-            | None
-            | Some Hardlink ->
-              Dune_cache_storage.Mode.Hardlink
-            | Some Copy -> Copy)
-        ; check_probability = config.cache_check_probability
+            Option.value config.cache_storage_mode ~default:Hardlink
+        ; reproducibility_check =
+            Check { check_probability = config.cache_check_probability }
         }
   in
   Dune_rules.Main.init ~stats:c.stats
@@ -582,35 +576,37 @@ let shared_with_config_file =
       & opt (some (enum modes)) None
       & info [ "terminal-persistence" ] ~docs ~docv:"MODE" ~doc)
   and+ display = display_term
-  and+ cache_mode =
+  and+ cache_enabled =
     let doc =
-      Printf.sprintf "Activate binary cache (%s). Default is `%s'."
-        (Arg.doc_alts_enum Dune_config.Caching.Mode.all)
-        (Dune_config.Caching.Mode.to_string Dune_config.default.cache_mode)
+      Printf.sprintf "Enable or disable Dune cache (%s). Default is `%s'."
+        (Arg.doc_alts_enum Dune_config.Cache.Enabled.all)
+        (Dune_config.Cache.Enabled.to_string Dune_config.default.cache_enabled)
     in
     Arg.(
       value
-      & opt (some (enum Dune_config.Caching.Mode.all)) None
+      & opt (some (enum Dune_config.Cache.Enabled.all)) None
       & info [ "cache" ] ~docs ~env:(Arg.env_var ~doc "DUNE_CACHE") ~doc)
-  and+ cache_transport =
-    let doc = "Binary cache protocol" in
+  and+ cache_storage_mode =
+    let doc =
+      Printf.sprintf "Dune cache storage mode (%s). Default is `%s'."
+        (Arg.doc_alts_enum Dune_config.Cache.Storage_mode.all)
+        (Dune_config.Cache.Storage_mode.to_string
+           Dune_config.default.cache_storage_mode)
+    in
     Arg.(
       value
-      & opt (some (enum Dune_config.Caching.Transport.all)) None
-      & info [ "cache-transport" ] ~docs
-          ~env:(Arg.env_var ~doc "DUNE_CACHE_TRANSPORT")
-          ~doc)
-  and+ cache_duplication =
-    let doc = "Binary cache duplication mode" in
-    Arg.(
-      value
-      & opt (some (enum Dune_config.Caching.Duplication.all)) None
-      & info [ "cache-duplication" ] ~docs
-          ~env:(Arg.env_var ~doc "DUNE_CACHE_DUPLICATION")
+      & opt (some (enum Dune_config.Cache.Storage_mode.all)) None
+      & info [ "cache-storage-mode" ] ~docs
+          ~env:(Arg.env_var ~doc "DUNE_CACHE_STORAGE_MODE")
           ~doc)
   and+ cache_check_probability =
     let doc =
-      "Probability cached rules are rerun to check for reproducibility"
+      Printf.sprintf
+        "Check build reproducibility by re-executing randomly chosen rules and \
+         comparing their results with those stored in Dune cache. Note: by \
+         increasing the probability of such checks you slow down the build. \
+         Default is `%s'."
+        (Float.to_string Dune_config.default.cache_check_probability)
     in
     Arg.(
       value
@@ -631,12 +627,9 @@ let shared_with_config_file =
   ; concurrency
   ; sandboxing_preference = Option.map sandboxing_preference ~f:(fun x -> [ x ])
   ; terminal_persistence
-  ; cache_mode
-  ; cache_transport
+  ; cache_enabled
   ; cache_check_probability = Some cache_check_probability
-  ; cache_duplication
-  ; cache_trim_period = None
-  ; cache_trim_size = None
+  ; cache_storage_mode
   ; swallow_stdout_on_success = Option.some_if swallow_stdout_on_success true
   }
 
@@ -813,8 +806,8 @@ let term =
              digest cache entries in order for things to be reliable. This \
              option makes Dune wait for the file system clock to advance so \
              that it doesn't need to drop anything. You should probably not \
-             care about this option, it is mostly useful for Dune velopers to \
-             make Dune tests of the digest cache more reproducible.")
+             care about this option; it is mostly useful for Dune developers \
+             to make Dune tests of the digest cache more reproducible.")
   in
   let build_dir = Option.value ~default:default_build_dir build_dir in
   let root = Workspace_root.create ~specified_by_user:root in

--- a/doc/caching.rst
+++ b/doc/caching.rst
@@ -50,11 +50,13 @@ directory. There are two disadvantages of this mode:
 The `copy` mode
 ---------------
 
-If you specify `(cache-duplication copy)` in the configuration file, Dune will
+If you specify `(cache-storage-mode copy)` in the configuration file, Dune will
 copy files to and from the cache instead of using hard links. This mode is
 slower and has higher disk space usage. On the positive side, it is more
 portable and doesn't have the disadvantages of the `hardlink` mode (see above).
 
+You can also set or override the storage mode via the environment variable
+`DUNE_CACHE_STORAGE_MODE` and the command line flag `--cache-storage-mode`.
 
 Trimming the cache
 ==================

--- a/otherlibs/stdune-unstable/option.ml
+++ b/otherlibs/stdune-unstable/option.ml
@@ -102,3 +102,9 @@ end
 let hash f = function
   | None -> Stdlib.Hashtbl.hash None
   | Some s -> Stdlib.Hashtbl.hash (f s)
+
+let merge x y ~f =
+  match (x, y) with
+  | None, res -> res
+  | res, None -> res
+  | Some x, Some y -> Some (f x y)

--- a/otherlibs/stdune-unstable/option.mli
+++ b/otherlibs/stdune-unstable/option.mli
@@ -51,3 +51,5 @@ val try_with : (unit -> 'a) -> 'a option
 module List : sig
   val all : 'a option list -> 'a list option
 end
+
+val merge : 'a t -> 'a t -> f:('a -> 'a -> 'a) -> 'a t

--- a/src/dune_cache/config.ml
+++ b/src/dune_cache/config.ml
@@ -3,6 +3,8 @@ open Stdune
 (* CR-someday amokhov: We should probably switch from float [check_probability]
    to integer [check_frequency], as in Jenga, to avoid generating random floats. *)
 
+(* CR-soon amokhov: That that the reproducibility check actually works. *)
+
 module Reproducibility_check = struct
   (* CR-someday amokhov: Add [Check_and_repair] to rewrite cache entries if they
      disagree with the check. *)
@@ -18,6 +20,8 @@ module Reproducibility_check = struct
     | Skip -> Dyn.Variant ("Skip", [])
     | Check { check_probability } ->
       Dyn.Variant ("Check", [ Dyn.Float check_probability ])
+
+  let check check_probability = Check { check_probability }
 end
 
 type t =

--- a/src/dune_cache/config.ml
+++ b/src/dune_cache/config.ml
@@ -1,9 +1,28 @@
+open Stdune
+
 (* CR-someday amokhov: We should probably switch from float [check_probability]
    to integer [check_frequency], as in Jenga, to avoid generating random floats. *)
+
+module Reproducibility_check = struct
+  (* CR-someday amokhov: Add [Check_and_repair] to rewrite cache entries if they
+     disagree with the check. *)
+  type t =
+    | Skip
+    | Check of { check_probability : float }
+
+  let sample = function
+    | Skip -> false
+    | Check { check_probability } -> Random.float 1. < check_probability
+
+  let to_dyn = function
+    | Skip -> Dyn.Variant ("Skip", [])
+    | Check { check_probability } ->
+      Dyn.Variant ("Check", [ Dyn.Float check_probability ])
+end
 
 type t =
   | Disabled
   | Enabled of
       { storage_mode : Dune_cache_storage.Mode.t
-      ; check_probability : float
+      ; reproducibility_check : Reproducibility_check.t
       }

--- a/src/dune_cache/config.mli
+++ b/src/dune_cache/config.mli
@@ -14,6 +14,9 @@ module Reproducibility_check : sig
       [true] with the [check_probability]. *)
   val sample : t -> bool
 
+  (** A helper function to construct the [Check] variant. *)
+  val check : float -> t
+
   val to_dyn : t -> Dyn.t
 end
 

--- a/src/dune_cache/config.mli
+++ b/src/dune_cache/config.mli
@@ -1,7 +1,26 @@
+open Stdune
+
+(** While the main purpose of Dune cache is to speed up build times, it can also
+    be used to check build reproducibility. When the check is enabled, Dune will
+    re-execute randomly chosen build rules and compare their results with those
+    stored in the cache. If the results differ, the rule is not reproducible and
+    Dune will print out a corresponding warning. *)
+module Reproducibility_check : sig
+  type t =
+    | Skip
+    | Check of { check_probability : float }
+
+  (** If [t = Skip], this function always returns [false]. Otherwise, it returns
+      [true] with the [check_probability]. *)
+  val sample : t -> bool
+
+  val to_dyn : t -> Dyn.t
+end
+
 (** All configuration settings of Dune's local and cloud (in future) caches. *)
 type t =
   | Disabled
   | Enabled of
       { storage_mode : Dune_cache_storage.Mode.t
-      ; check_probability : float
+      ; reproducibility_check : Reproducibility_check.t
       }

--- a/src/dune_cache_storage/mode.ml
+++ b/src/dune_cache_storage/mode.ml
@@ -18,3 +18,7 @@ let to_string = function
 let to_dyn = function
   | Copy -> Dyn.Variant ("Copy", [])
   | Hardlink -> Dyn.Variant ("Hardlink", [])
+
+(* CR-someday amokhov: Check that hard links can actually be created and, if
+   not, return [Copy] instead. *)
+let default () = Hardlink

--- a/src/dune_cache_storage/mode.mli
+++ b/src/dune_cache_storage/mode.mli
@@ -32,5 +32,6 @@ val of_string : string -> (t, string) result
 
 val to_dyn : t -> Dyn.t
 
-(* CR-someday amokhov: Add a function to choose the mode by detecting whether
-   hard links can be created. *)
+(** Right now, this is hardcoded to be [Hardlink]. In future we plan to choose
+    the mode by detecting whether hard links can be created. *)
+val default : unit -> t

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -83,13 +83,13 @@ module Sandboxing_preference = struct
            | Ok s -> s))
 end
 
-module Caching = struct
-  module Mode = struct
+module Cache = struct
+  module Enabled = struct
     type t =
-      | Disabled
       | Enabled
+      | Disabled
 
-    let all = [ ("disabled", Disabled); ("enabled", Enabled) ]
+    let all = [ ("enabled", Enabled); ("disabled", Disabled) ]
 
     let to_string = function
       | Enabled -> "enabled"
@@ -102,21 +102,17 @@ module Caching = struct
     let decode = enum all
   end
 
-  module Transport = struct
+  module Transport_deprecated = struct
     type t =
       | Daemon
       | Direct
-
-    let to_dyn = function
-      | Daemon -> Dyn.Variant ("Daemon", [])
-      | Direct -> Variant ("Direct", [])
 
     let all = [ ("daemon", Daemon); ("direct", Direct) ]
 
     let decode = enum all
   end
 
-  module Duplication = struct
+  module Storage_mode = struct
     type t = Dune_cache_storage.Mode.t option
 
     let all =
@@ -128,7 +124,11 @@ module Caching = struct
 
     let decode = enum all
 
-    let to_dyn = Dune_cache_storage.Mode.to_dyn
+    let to_string = function
+      | None -> "auto"
+      | Some mode -> Dune_cache_storage.Mode.to_string mode
+
+    let to_dyn = Dyn.Encoder.option Dune_cache_storage.Mode.to_dyn
   end
 end
 
@@ -140,12 +140,9 @@ module type S = sig
     ; concurrency : Concurrency.t field
     ; terminal_persistence : Terminal_persistence.t field
     ; sandboxing_preference : Sandboxing_preference.t field
-    ; cache_mode : Caching.Mode.t field
-    ; cache_transport : Caching.Transport.t field
+    ; cache_enabled : Cache.Enabled.t field
     ; cache_check_probability : float field
-    ; cache_duplication : Caching.Duplication.t field
-    ; cache_trim_period : int field
-    ; cache_trim_size : int64 field
+    ; cache_storage_mode : Cache.Storage_mode.t field
     ; swallow_stdout_on_success : bool field
     }
 end
@@ -165,13 +162,10 @@ struct
     ; terminal_persistence = field a.terminal_persistence b.terminal_persistence
     ; sandboxing_preference =
         field a.sandboxing_preference b.sandboxing_preference
-    ; cache_mode = field a.cache_mode b.cache_mode
-    ; cache_transport = field a.cache_transport b.cache_transport
+    ; cache_enabled = field a.cache_enabled b.cache_enabled
     ; cache_check_probability =
         field a.cache_check_probability b.cache_check_probability
-    ; cache_duplication = field a.cache_duplication b.cache_duplication
-    ; cache_trim_period = field a.cache_trim_period b.cache_trim_period
-    ; cache_trim_size = field a.cache_trim_size b.cache_trim_size
+    ; cache_storage_mode = field a.cache_storage_mode b.cache_storage_mode
     ; swallow_stdout_on_success =
         field a.swallow_stdout_on_success b.swallow_stdout_on_success
     }
@@ -189,12 +183,9 @@ struct
       ; concurrency
       ; terminal_persistence
       ; sandboxing_preference
-      ; cache_mode
-      ; cache_transport
+      ; cache_enabled
       ; cache_check_probability
-      ; cache_duplication
-      ; cache_trim_period
-      ; cache_trim_size
+      ; cache_storage_mode
       ; swallow_stdout_on_success
       } =
     Dyn.Encoder.record
@@ -204,16 +195,11 @@ struct
         , field Terminal_persistence.to_dyn terminal_persistence )
       ; ( "sandboxing_preference"
         , field (Dyn.Encoder.list Sandbox_mode.to_dyn) sandboxing_preference )
-      ; ("cache_mode", field Caching.Mode.to_dyn cache_mode)
-      ; ("cache_transport", field Caching.Transport.to_dyn cache_transport)
+      ; ("cache_enabled", field Cache.Enabled.to_dyn cache_enabled)
       ; ( "cache_check_probability"
         , field Dyn.Encoder.float cache_check_probability )
-      ; ( "cache_duplication"
-        , field
-            (Dyn.Encoder.option Caching.Duplication.to_dyn)
-            cache_duplication )
-      ; ("cache_trim_period", field Dyn.Encoder.int cache_trim_period)
-      ; ("cache_trim_size", field Dyn.Encoder.int64 cache_trim_size)
+      ; ( "cache_storage_mode"
+        , field Cache.Storage_mode.to_dyn cache_storage_mode )
       ; ( "swallow_stdout_on_success"
         , field Dyn.Encoder.bool swallow_stdout_on_success )
       ]
@@ -233,12 +219,9 @@ module Partial = struct
     ; concurrency = None
     ; terminal_persistence = None
     ; sandboxing_preference = None
-    ; cache_mode = None
-    ; cache_transport = None
+    ; cache_enabled = None
     ; cache_check_probability = None
-    ; cache_trim_period = None
-    ; cache_trim_size = None
-    ; cache_duplication = None
+    ; cache_storage_mode = None
     ; swallow_stdout_on_success = None
     }
 
@@ -289,12 +272,9 @@ let default =
         Auto)
   ; terminal_persistence = Terminal_persistence.Preserve
   ; sandboxing_preference = []
-  ; cache_mode = Disabled
-  ; cache_transport = Daemon
+  ; cache_enabled = Disabled
   ; cache_check_probability = 0.
-  ; cache_trim_period = 10 * 60
-  ; cache_trim_size = 10_000_000_000L
-  ; cache_duplication = None
+  ; cache_storage_mode = None
   ; swallow_stdout_on_success = false
   }
 
@@ -310,31 +290,47 @@ let decode_generic ~min_dune_version =
     field_o "terminal-persistence" (1, 0) Terminal_persistence.decode
   and+ sandboxing_preference =
     field_o "sandboxing_preference" (1, 0) Sandboxing_preference.decode
-  and+ cache_mode = field_o "cache" (2, 0) Caching.Mode.decode
-  and+ cache_transport =
-    field_o "cache-transport" (2, 0) Caching.Transport.decode
+  and+ cache_enabled = field_o "cache" (2, 0) Cache.Enabled.decode
+  and+ _cache_transport_unused_since_3_0 =
+    field_o "cache-transport" (2, 0)
+      (Dune_lang.Syntax.deleted_in Stanza.syntax (3, 0)
+         ~extra_info:"Dune cache now uses only the direct transport mode."
+      >>> Cache.Transport_deprecated.decode)
   and+ cache_check_probability =
     field_o "cache-check-probability" (2, 7) Dune_lang.Decoder.float
   and+ cache_duplication =
-    field_o "cache-duplication" (2, 1) Caching.Duplication.decode
-  and+ cache_trim_period =
-    field_o "cache-trim-period" (2, 0) Dune_lang.Decoder.duration
-  and+ cache_trim_size =
-    field_o "cache-trim-size" (2, 0) Dune_lang.Decoder.bytes_unit
+    field_o "cache-duplication" (2, 1)
+      (Dune_lang.Syntax.renamed_in Stanza.syntax (3, 0)
+         ~to_:"cache-storage-mode"
+      >>> Cache.Storage_mode.decode)
+  and+ cache_storage_mode =
+    field_o "cache-storage-mode" (3, 0) Cache.Storage_mode.decode
+  and+ _cache_trim_period_unused_since_3_0 =
+    field_o "cache-trim-period" (2, 0)
+      (Dune_lang.Syntax.deleted_in Stanza.syntax (3, 0)
+         ~extra_info:"To trim the cache, see the 'dune cache trim' command."
+      >>> Dune_lang.Decoder.duration)
+  and+ _cache_trim_size_unused_since_3_0 =
+    field_o "cache-trim-size" (2, 0)
+      (Dune_lang.Syntax.deleted_in Stanza.syntax (3, 0)
+         ~extra_info:"To trim the cache, see the 'dune cache trim' command."
+      >>> Dune_lang.Decoder.bytes_unit)
   and+ swallow_stdout_on_success =
     field_o_b "swallow-stdout-on-success"
       ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
+  in
+  let cache_storage_mode =
+    Option.merge cache_duplication cache_storage_mode ~f:(fun _ _ ->
+        Code_error.raise "Both cache_duplication and cache_storage_mode are set"
+          [])
   in
   { Partial.display
   ; concurrency
   ; terminal_persistence
   ; sandboxing_preference
-  ; cache_mode
-  ; cache_transport
+  ; cache_enabled
   ; cache_check_probability
-  ; cache_duplication
-  ; cache_trim_period
-  ; cache_trim_size
+  ; cache_storage_mode
   ; swallow_stdout_on_success
   }
 

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -57,7 +57,8 @@ module type S = sig
     ; terminal_persistence : Terminal_persistence.t field
     ; sandboxing_preference : Sandboxing_preference.t field
     ; cache_enabled : Cache.Enabled.t field
-    ; cache_check_probability : float field
+    ; cache_reproducibility_check :
+        Dune_cache.Config.Reproducibility_check.t field
     ; cache_storage_mode : Cache.Storage_mode.t field
     ; swallow_stdout_on_success : bool field
     }

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -16,11 +16,11 @@ module Sandboxing_preference : sig
   type t = Dune_engine.Sandbox_mode.t list
 end
 
-module Caching : sig
-  module Mode : sig
+module Cache : sig
+  module Enabled : sig
     type t =
-      | Disabled
       | Enabled
+      | Disabled
 
     val all : (string * t) list
 
@@ -29,22 +29,14 @@ module Caching : sig
     val to_string : t -> string
   end
 
-  module Transport : sig
-    type t =
-      | Daemon
-      | Direct
-
-    val all : (string * t) list
-
-    val decode : t Dune_lang.Decoder.t
-  end
-
-  module Duplication : sig
+  module Storage_mode : sig
     type t = Dune_cache_storage.Mode.t option
 
     val all : (string * t) list
 
     val decode : t Dune_lang.Decoder.t
+
+    val to_string : t -> string
   end
 end
 
@@ -64,12 +56,9 @@ module type S = sig
     ; concurrency : Concurrency.t field
     ; terminal_persistence : Terminal_persistence.t field
     ; sandboxing_preference : Sandboxing_preference.t field
-    ; cache_mode : Caching.Mode.t field
-    ; cache_transport : Caching.Transport.t field
+    ; cache_enabled : Cache.Enabled.t field
     ; cache_check_probability : float field
-    ; cache_duplication : Caching.Duplication.t field
-    ; cache_trim_period : int field
-    ; cache_trim_size : int64 field
+    ; cache_storage_mode : Cache.Storage_mode.t field
     ; swallow_stdout_on_success : bool field
     }
 end

--- a/test/blackbox-tests/test-cases/dune-cache/config.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/config.t/run.t
@@ -1,0 +1,218 @@
+Check that old cache configuration format works fine with an old language
+
+  $ cat > config <<EOF
+  > (lang dune 2.1)
+  > (cache enabled)
+  > (cache-transport direct)
+  > (cache-duplication copy)
+  > (cache-trim-period 1h)
+  > (cache-trim-size 1GB)
+  > EOF
+  $ cat > dune-project <<EOF
+  > (lang dune 2.1)
+  > EOF
+  $ cat > dune <<EOF
+  > (rule
+  >   (deps source)
+  >   (targets target)
+  >   (action (copy source target)))
+  > EOF
+  $ cat > source <<EOF
+  > \_o< COIN
+  > EOF
+
+Test that DUNE_CACHE_ROOT can be used to control the cache location
+
+  $ export DUNE_CACHE_ROOT=$PWD/.cache
+
+Build succeeds and the 'copy' mode is respected
+
+  $ dune build --config-file config target
+  $ dune_cmd stat hardlinks _build/default/target
+  1
+
+Switch to the 'hardlink' mode now
+
+  $ cat > config <<EOF
+  > (lang dune 2.1)
+  > (cache enabled)
+  > (cache-transport direct)
+  > (cache-duplication hardlink)
+  > (cache-trim-period 1h)
+  > (cache-trim-size 1GB)
+  > EOF
+
+Build succeeds and the 'hardlink' mode is respected
+
+  $ rm -rf _build/default
+  $ dune build --config-file config target
+  $ dune_cmd stat hardlinks _build/default/target
+  3
+
+Now repeat the tests with the old configuration format but 3.0 language
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache enabled)
+  > (cache-transport direct)
+  > (cache-duplication copy)
+  > (cache-trim-period 1h)
+  > (cache-trim-size 1GB)
+  > EOF
+
+Build fails because 'cache-transport' was deleted
+
+  $ dune build --config-file config target
+  File "$TESTCASE_ROOT/config", line 3, characters 0-24:
+  3 | (cache-transport direct)
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'cache-transport' was deleted in version 3.0 of the dune language.
+  Dune cache now uses only the direct transport mode.
+  [1]
+
+So, we comply and delete it
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache enabled)
+  > (cache-duplication copy)
+  > (cache-trim-period 1h)
+  > (cache-trim-size 1GB)
+  > EOF
+
+Build fails because 'cache-duplication' was renamed
+
+  $ dune build --config-file config target
+  File "$TESTCASE_ROOT/config", line 3, characters 0-24:
+  3 | (cache-duplication copy)
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'cache-duplication' was renamed to 'cache-storage-mode' in the 3.0
+  version of the dune language
+  [1]
+
+So, we comply and rename it.
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache enabled)
+  > (cache-storage-mode copy)
+  > (cache-trim-period 1h)
+  > (cache-trim-size 1GB)
+  > EOF
+
+Build fails because 'cache-trim-period' was deleted
+
+  $ dune build --config-file config target
+  File "$TESTCASE_ROOT/config", line 4, characters 0-22:
+  4 | (cache-trim-period 1h)
+      ^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'cache-trim-period' was deleted in version 3.0 of the dune language.
+  To trim the cache, see the 'dune cache trim' command.
+  [1]
+
+So, we comply and delete it
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache enabled)
+  > (cache-storage-mode copy)
+  > (cache-trim-size 1GB)
+  > EOF
+
+Build fails because 'cache-trim-size' was deleted
+
+  $ dune build --config-file config target
+  File "$TESTCASE_ROOT/config", line 4, characters 0-21:
+  4 | (cache-trim-size 1GB)
+      ^^^^^^^^^^^^^^^^^^^^^
+  Error: 'cache-trim-size' was deleted in version 3.0 of the dune language. To
+  trim the cache, see the 'dune cache trim' command.
+  [1]
+
+So, we comply and delete it
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache enabled)
+  > (cache-storage-mode copy)
+  > EOF
+
+Build succeeds and the 'copy' mode is respected
+
+  $ rm -rf _build/default
+  $ dune build --config-file config target
+  $ dune_cmd stat hardlinks _build/default/target
+  1
+
+Switch to the 'hardlink' mode now
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache enabled)
+  > (cache-storage-mode hardlink)
+  > EOF
+
+Build succeeds and the 'hardlink' mode is respected
+
+  $ rm -rf _build/default
+  $ dune build --config-file config target
+  $ dune_cmd stat hardlinks _build/default/target
+  3
+
+Let's disable the cache
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache disabled)
+  > (cache-storage-mode hardlink)
+  > EOF
+
+Test that in this mode the shared cache directory is not created
+
+  $ rm -rf $DUNE_CACHE_ROOT
+  $ rm -rf _build/default
+  $ dune build --config-file config target
+  $ dune_cmd stat hardlinks _build/default/target
+  1
+  $ dune_cmd exists $DUNE_CACHE_ROOT
+  false
+
+Test that the cache can be enabled via the environment variable
+
+  $ rm -rf _build/default
+  $ DUNE_CACHE=enabled dune build --config-file config target
+  $ dune_cmd stat hardlinks _build/default/target
+  3
+  $ dune_cmd exists $DUNE_CACHE_ROOT
+  true
+
+Test that we can override the environment variable from the command line
+
+  $ rm -rf $DUNE_CACHE_ROOT
+  $ rm -rf _build/default
+  $ DUNE_CACHE=enabled dune build --config-file config target --cache=disabled
+  $ dune_cmd stat hardlinks _build/default/target
+  1
+  $ dune_cmd exists $DUNE_CACHE_ROOT
+  false
+
+Test that we can override the storage mode via the environment variable
+
+  $ cat > config <<EOF
+  > (lang dune 3.0)
+  > (cache enabled)
+  > (cache-storage-mode hardlink)
+  > EOF
+
+  $ rm -rf _build/default
+  $ DUNE_CACHE_STORAGE_MODE=copy dune build --config-file config target
+  $ dune_cmd stat hardlinks _build/default/target
+  1
+
+Test that we can override the environment variable from the command line
+
+  $ rm -rf $DUNE_CACHE_ROOT
+  $ rm -rf _build/default
+  $ DUNE_CACHE_STORAGE_MODE=copy dune build --config-file config target --cache-storage-mode=hardlink
+  $ dune_cmd stat hardlinks _build/default/target
+  3

--- a/test/blackbox-tests/test-cases/dune-cache/config.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/config.t/run.t
@@ -107,7 +107,7 @@ Build fails because 'cache-trim-period' was deleted
   4 | (cache-trim-period 1h)
       ^^^^^^^^^^^^^^^^^^^^^^
   Error: 'cache-trim-period' was deleted in version 3.0 of the dune language.
-  To trim the cache, see the 'dune cache trim' command.
+  To trim the cache, use the 'dune cache trim' command.
   [1]
 
 So, we comply and delete it
@@ -126,7 +126,7 @@ Build fails because 'cache-trim-size' was deleted
   4 | (cache-trim-size 1GB)
       ^^^^^^^^^^^^^^^^^^^^^
   Error: 'cache-trim-size' was deleted in version 3.0 of the dune language. To
-  trim the cache, see the 'dune cache trim' command.
+  trim the cache, use the 'dune cache trim' command.
   [1]
 
 So, we comply and delete it

--- a/test/blackbox-tests/test-cases/dune-cache/promote-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/promote-copy.t/run.t
@@ -45,8 +45,8 @@ Clean + rebuild: Dune should restore artifacts from the cache by copying
 
 The rule wasn't run:
 
-  $ test -e _build/default/rule-was-run
-  [1]
+  $ dune_cmd exists _build/default/rule-was-run
+  false
 
 The files have been restored correctly:
 

--- a/test/blackbox-tests/test-cases/dune-cache/promote-direct-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/promote-direct-copy.t/run.t
@@ -36,8 +36,8 @@ It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
   1
   $ dune_cmd stat hardlinks _build/default/target
   1
-  $ test -e _build/default/beacon
-  [1]
+  $ dune_cmd exists _build/default/beacon
+  false
   $ cat _build/default/source
   \_o< COIN
   $ cat _build/default/target

--- a/test/blackbox-tests/test-cases/dune-cache/promote-direct.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/promote-direct.t/run.t
@@ -28,8 +28,8 @@
   2
   $ dune_cmd stat hardlinks _build/default/target
   2
-  $ test -e _build/default/beacon
-  [1]
+  $ dune_cmd exists _build/default/beacon
+  false
   $ cat _build/default/source
   \_o< COIN
   $ cat _build/default/target

--- a/test/blackbox-tests/test-cases/dune-cache/promote.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/promote.t/run.t
@@ -27,8 +27,8 @@
   2
   $ dune_cmd stat hardlinks _build/default/target
   2
-  $ test -e _build/default/beacon
-  [1]
+  $ dune_cmd exists _build/default/beacon
+  false
   $ cat _build/default/source
   \_o< COIN
   $ cat _build/default/target

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -112,8 +112,10 @@ trimmed.
   2
   $ dune_cmd stat hardlinks _build/default/target_b
   2
-  $ test -e _build/default/beacon_a
-  $ ! test -e _build/default/beacon_b
+  $ dune_cmd exists _build/default/beacon_a
+  true
+  $ dune_cmd exists _build/default/beacon_b
+  false
 
 Now let's remove the remaining targets, left from the very first build and rerun
 the trimmer. That will delete unused [files/v3] and the corresponding metadata
@@ -154,8 +156,10 @@ target_a:
   2
   $ dune_cmd stat hardlinks _build/default/target_b
   2
-  $ ! test -e _build/default/beacon_a
-  $ test -e _build/default/beacon_b
+  $ dune_cmd exists _build/default/beacon_a
+  false
+  $ dune_cmd exists _build/default/beacon_b
+  true
 
   $ reset
 
@@ -173,8 +177,10 @@ order of trimming.
   2
   $ dune_cmd stat hardlinks _build/default/target_b
   2
-  $ test -e _build/default/beacon_a
-  $ ! test -e _build/default/beacon_b
+  $ dune_cmd exists _build/default/beacon_a
+  true
+  $ dune_cmd exists _build/default/beacon_b
+  false
 
   $ reset
 

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -88,6 +88,20 @@ module Cat = struct
   let () = register name of_args run
 end
 
+module Exists = struct
+  type t = Path of Path.t
+
+  let name = "exists"
+
+  let of_args = function
+    | [ path ] -> Path (Path.of_filename_relative_to_initial_cwd path)
+    | _ -> raise (Arg.Bad "Usage: dune_arg exists <path>")
+
+  let run (Path path) = print_string (Path.exists path |> Bool.to_string)
+
+  let () = register name of_args run
+end
+
 module Expand_lines = struct
   let name = "expand_lines"
 

--- a/test/expect-tests/dune_config/dune_config_test.ml
+++ b/test/expect-tests/dune_config/dune_config_test.ml
@@ -25,7 +25,7 @@ let%expect_test "cache-check-probability 0.1" =
     ; terminal_persistence = Preserve
     ; sandboxing_preference = []
     ; cache_enabled = Disabled
-    ; cache_check_probability = 0.1
+    ; cache_reproducibility_check = Check 0.1
     ; cache_storage_mode = None
     ; swallow_stdout_on_success = false
     }
@@ -40,7 +40,7 @@ let%expect_test "cache-storage-mode copy" =
     ; terminal_persistence = Preserve
     ; sandboxing_preference = []
     ; cache_enabled = Disabled
-    ; cache_check_probability = 0.
+    ; cache_reproducibility_check = Skip
     ; cache_storage_mode = Some Copy
     ; swallow_stdout_on_success = false
     }
@@ -55,7 +55,7 @@ let%expect_test "cache-storage-mode hardlink" =
     ; terminal_persistence = Preserve
     ; sandboxing_preference = []
     ; cache_enabled = Disabled
-    ; cache_check_probability = 0.
+    ; cache_reproducibility_check = Skip
     ; cache_storage_mode = Some Hardlink
     ; swallow_stdout_on_success = false
     }

--- a/test/expect-tests/dune_config/dune_config_test.ml
+++ b/test/expect-tests/dune_config/dune_config_test.ml
@@ -16,80 +16,47 @@ let parse s =
   |> Dune_config.(superpose default)
   |> Dune_config.to_dyn |> print_dyn
 
-let%expect_test _ =
-  parse "(cache-trim-period 2m)";
+let%expect_test "cache-check-probability 0.1" =
+  parse "(cache-check-probability 0.1)";
   [%expect
     {|
-{ display = Quiet
-; concurrency = Fixed 1
-; terminal_persistence = Preserve
-; sandboxing_preference = []
-; cache_mode = Disabled
-; cache_transport = Daemon
-; cache_check_probability = 0.
-; cache_duplication = None
-; cache_trim_period = 120
-; cache_trim_size = 10000000000
-; swallow_stdout_on_success = false
-}
+    { display = Quiet
+    ; concurrency = Fixed 1
+    ; terminal_persistence = Preserve
+    ; sandboxing_preference = []
+    ; cache_enabled = Disabled
+    ; cache_check_probability = 0.1
+    ; cache_storage_mode = None
+    ; swallow_stdout_on_success = false
+    }
  |}]
 
-let%expect_test _ =
-  parse "(cache-trim-period 2)";
-  [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
-  ( "File\
-   \n\"expect_test\",\
-   \nline\
-   \n1,\
-   \ncharacters\
-   \n19-20:\
-   \nError: missing suffix, use one of s, m, h\
-   \n") |}]
-
-let%expect_test _ =
-  parse "(cache-trim-period 2k)";
-  [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
-  ( "File\
-   \n\"expect_test\",\
-   \nline\
-   \n1,\
-   \ncharacters\
-   \n19-21:\
-   \nError: invalid suffix, use one of s, m, h\
-   \n") |}]
-
-let%expect_test _ =
-  parse "(cache-trim-size 2kB)";
+let%expect_test "cache-storage-mode copy" =
+  parse "(cache-storage-mode copy)";
   [%expect
     {|
-{ display = Quiet
-; concurrency = Fixed 1
-; terminal_persistence = Preserve
-; sandboxing_preference = []
-; cache_mode = Disabled
-; cache_transport = Daemon
-; cache_check_probability = 0.
-; cache_duplication = None
-; cache_trim_period = 600
-; cache_trim_size = 2000
-; swallow_stdout_on_success = false
-}
+    { display = Quiet
+    ; concurrency = Fixed 1
+    ; terminal_persistence = Preserve
+    ; sandboxing_preference = []
+    ; cache_enabled = Disabled
+    ; cache_check_probability = 0.
+    ; cache_storage_mode = Some Copy
+    ; swallow_stdout_on_success = false
+    }
  |}]
 
-let%expect_test _ =
-  parse "(cache-trim-size 42)";
-  [%expect.unreachable]
-  [@@expect.uncaught_exn
+let%expect_test "cache-storage-mode hardlink" =
+  parse "(cache-storage-mode hardlink)";
+  [%expect
     {|
-  ( "File\
-   \n\"expect_test\",\
-   \nline\
-   \n1,\
-   \ncharacters\
-   \n17-19:\
-   \nError: missing suffix, use one of B, kB, KB, MB, GB\
-   \n") |}]
+    { display = Quiet
+    ; concurrency = Fixed 1
+    ; terminal_persistence = Preserve
+    ; sandboxing_preference = []
+    ; cache_enabled = Disabled
+    ; cache_check_probability = 0.
+    ; cache_storage_mode = Some Hardlink
+    ; swallow_stdout_on_success = false
+    }
+ |}]


### PR DESCRIPTION
Also improve new cache configuration and associated help messages.

I added a test to make sure the changes of the configuration file are appropriately versioned, and that environment variables and command flags can override them, as advertised.

I added `dune_cmd exists` for convenient and portable checking of file/directory existence.

This completes the rewrite of Dune cache. The next step is implementing the cloud cache on top of the new foundation.