### PR TITLE
docs: `name` -> `module` in `(generate_sites_module ...)`

### DIFF
--- a/doc/sites.rst
+++ b/doc/sites.rst
@@ -83,7 +83,7 @@ site using the :ref:`generate sites module stanza<generate_sites_module>`
     (libraries dune-site))
 
    (generate_sites_module
-    (name mysites)
+    (module mysites)
     (sites mygui))
 
 The generated module `mysites` depends on the library `dune-site` provided by


### PR DESCRIPTION
I found this out when trying sites in my project. `generate_sites_module` should take `(module module_name)` and not `(name ...)`

Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>