### PR TITLE
Add new configuration (skip_ppx_kind <bool>)

### DIFF
--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -740,3 +740,15 @@ let fields_mutually_exclusive ?on_dup ?default fields
   | _ :: _ :: _ as results ->
     let names = List.map ~f:fst results in
     fields_mutual_exclusion_violation loc names
+
+
+
+let hack keyword : (_, values) parser -> (_, values) parser -> (_, values) parser = fun left right (Values (_loc,_,_) as ctx) input  ->
+  match input with
+  | (Ast.List (_loc, (Atom (_,Atom.A h))::tl)) :: asttl when String.equal h keyword ->
+      begin
+        match right ctx tl with
+        | (ans,[]) -> (ans, asttl)
+        | (_,_) -> failwith "not all data is parsed"
+      end
+  | other -> left ctx other

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -263,3 +263,5 @@ val ( let* ) : ('a, 'k) parser -> ('a -> ('b, 'k) parser) -> ('b, 'k) parser
 val ( let+ ) : ('a, 'k) parser -> ('a -> 'b) -> ('b, 'k) parser
 
 val ( and+ ) : ('a, 'k) parser -> ('b, 'k) parser -> ('a * 'b, 'k) parser
+
+val hack : string  -> ('a, values) parser  -> ('a, values) parser -> ('a, values) parser

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -162,6 +162,7 @@ end = struct
                    | Re_export _
                    | Direct _ ->
                      None
+                   | NonPP _ -> failwith (Format.sprintf "not implemented %s %d" __FILE__ __LINE__)
                    | Select s -> Some s.result_fn))
           | _ -> Memo.Build.return [])
       >>| fun l -> String.Set.of_list (List.concat l)

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -555,6 +555,7 @@ module Library = struct
     ; c_library_flags : Ordered_set_lang.Unexpanded.t
     ; virtual_deps : (Loc.t * Lib_name.t) list
     ; wrapped : Wrapped.t Lib_info.Inherited.t
+    ; skip_ppx_kind : bool option
     ; optional : bool
     ; buildable : Buildable.t
     ; dynlink : Dynlink_supported.t
@@ -581,6 +582,7 @@ module Library = struct
        and+ public =
          field_o "public_name" (Public_lib.decode ~allow_deprecated_names:false)
        and+ synopsis = field_o "synopsis" string
+       and+ skip_ppx_kind = field_o "skip_ppx_kind" bool
        and+ install_c_headers =
          field "install_c_headers" (repeat string) ~default:[]
        and+ ppx_runtime_libraries =
@@ -721,6 +723,7 @@ module Library = struct
        ; c_library_flags
        ; virtual_deps
        ; wrapped
+       ; skip_ppx_kind
        ; optional
        ; buildable
        ; dynlink = Dynlink_supported.of_bool (not no_dynlink)
@@ -915,6 +918,7 @@ module Library = struct
     let implements = conf.implements in
     let default_implementation = conf.default_implementation in
     let wrapped = Some conf.wrapped in
+    let skip_ppx_kind = conf.skip_ppx_kind in
     let special_builtin_support = conf.special_builtin_support in
     let instrumentation_backend = conf.instrumentation_backend in
     let entry_modules = Lib_info.Source.Local in
@@ -924,6 +928,7 @@ module Library = struct
       ~foreign_archives ~native_archives ~foreign_dll_files ~jsoo_runtime
       ~jsoo_archive ~preprocess ~enabled ~virtual_deps ~dune_version ~virtual_
       ~entry_modules ~implements ~default_implementation ~modes ~wrapped
+      ~skip_ppx_kind
       ~special_builtin_support ~exit_module ~instrumentation_backend
 end
 

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -99,6 +99,7 @@ module Lib_deps = struct
            | Lib_dep.Re_export (_, s)
            | Lib_dep.Direct (_, s) ->
              add Required s acc
+           | NonPP _ -> failwith (Format.sprintf "not implemented %s %d" __FILE__ __LINE__)
            | Select { choices; _ } ->
              List.fold_left choices ~init:acc
                ~f:(fun acc (c : Lib_dep.Select.Choice.t) ->

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -136,6 +136,7 @@ module Library : sig
     ; c_library_flags : Ordered_set_lang.Unexpanded.t
     ; virtual_deps : (Loc.t * Lib_name.t) list
     ; wrapped : Wrapped.t Lib_info.Inherited.t
+    ; skip_ppx_kind: bool option
     ; optional : bool
     ; buildable : Buildable.t
     ; dynlink : Dynlink_supported.t

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -199,7 +199,7 @@ module Lib = struct
            ~jsoo_runtime ~jsoo_archive ~preprocess ~enabled ~virtual_deps
            ~dune_version ~virtual_ ~entry_modules ~implements
            ~default_implementation ~modes ~wrapped ~special_builtin_support
-           ~exit_module:None ~instrumentation_backend
+           ~exit_module:None ~instrumentation_backend ~skip_ppx_kind:None
        in
        { info; main_module_name; modules = Some modules })
 

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -337,6 +337,7 @@ end = struct
         let default_implementation = None in
         let wrapped = None in
         let dir_contents = Path.readdir_unsorted t.dir in
+        let skip_ppx_kind = None in
         let foreign_archives, native_archives =
           (* Here we scan [t.dir] and consider all files named [lib*.ext_lib] to
              be foreign archives, and all other files with the extension
@@ -420,6 +421,7 @@ end = struct
           ~jsoo_runtime ~jsoo_archive ~preprocess ~enabled ~virtual_deps
           ~dune_version ~virtual_ ~implements ~default_implementation ~modes
           ~wrapped ~special_builtin_support ~exit_module:None
+          ~skip_ppx_kind
           ~instrumentation_backend:None ~entry_modules
       in
       Dune_package.Lib.of_findlib info

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1472,6 +1472,7 @@ end = struct
               lib :: acc_res
             in
             (acc_res, acc_selects, acc_re_exports)
+          | NonPP _ -> failwith (Format.sprintf "not implemented %s %d" __FILE__ __LINE__)
           | Select select ->
             let res, resolved_select = resolve_select select in
             let acc_res =

--- a/src/dune_rules/lib_dep.mli
+++ b/src/dune_rules/lib_dep.mli
@@ -23,12 +23,15 @@ type t =
   | Direct of (Loc.t * Lib_name.t)
   | Re_export of (Loc.t * Lib_name.t)
   | Select of Select.t
+  | NonPP of Lib_name.t list
 
 val to_dyn : t -> Dyn.t
 
 val direct : Loc.t * Lib_name.t -> t
 
 val re_export : Loc.t * Lib_name.t -> t
+
+val non_pp : Lib_name.t list -> t
 
 val decode : allow_re_export:bool -> t Dune_lang.Decoder.t
 

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -292,6 +292,7 @@ type 'path t =
   ; implements : (Loc.t * Lib_name.t) option
   ; default_implementation : (Loc.t * Lib_name.t) option
   ; wrapped : Wrapped.t Inherited.t option
+  ; skip_ppx_kind : bool option
   ; main_module_name : Main_module_name.t
   ; modes : Mode.Dict.Set.t
   ; special_builtin_support : Special_builtin_support.t option
@@ -353,6 +354,8 @@ let implements t = t.implements
 let synopsis t = t.synopsis
 
 let wrapped t = t.wrapped
+
+let skip_ppx_kind t = t.skip_ppx_kind
 
 let special_builtin_support t = t.special_builtin_support
 
@@ -420,7 +423,7 @@ let create ~loc ~path_kind ~name ~kind ~status ~src_dir ~orig_src_dir ~obj_dir
     ~plugins ~archives ~ppx_runtime_deps ~foreign_archives ~native_archives
     ~foreign_dll_files ~jsoo_runtime ~jsoo_archive ~preprocess ~enabled
     ~virtual_deps ~dune_version ~virtual_ ~entry_modules ~implements
-    ~default_implementation ~modes ~wrapped ~special_builtin_support
+    ~default_implementation ~modes ~wrapped ~skip_ppx_kind ~special_builtin_support
     ~exit_module ~instrumentation_backend =
   { loc
   ; name
@@ -453,6 +456,7 @@ let create ~loc ~path_kind ~name ~kind ~status ~src_dir ~orig_src_dir ~obj_dir
   ; default_implementation
   ; modes
   ; wrapped
+  ; skip_ppx_kind
   ; special_builtin_support
   ; exit_module
   ; instrumentation_backend
@@ -528,6 +532,7 @@ let to_dyn path
     ; default_implementation
     ; modes
     ; wrapped
+    ; skip_ppx_kind
     ; special_builtin_support
     ; exit_module
     ; instrumentation_backend
@@ -566,6 +571,7 @@ let to_dyn path
     ; ( "default_implementation"
       , option (snd Lib_name.to_dyn) default_implementation )
     ; ("wrapped", option (Inherited.to_dyn Wrapped.to_dyn) wrapped)
+    ; ("skip_ppx_kind", option bool skip_ppx_kind)
     ; ("main_module_name", Main_module_name.to_dyn main_module_name)
     ; ("modes", Mode.Dict.Set.to_dyn modes)
     ; ( "special_builtin_support"

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -145,6 +145,8 @@ val main_module_name : _ t -> Main_module_name.t
 
 val wrapped : _ t -> Wrapped.t Inherited.t option
 
+val skip_ppx_kind : _ t -> bool option
+
 val special_builtin_support : _ t -> Special_builtin_support.t option
 
 val modes : _ t -> Mode.Dict.Set.t
@@ -236,6 +238,7 @@ val create :
   -> default_implementation:(Loc.t * Lib_name.t) option
   -> modes:Mode.Dict.Set.t
   -> wrapped:Wrapped.t Inherited.t option
+  -> skip_ppx_kind:bool option
   -> special_builtin_support:Special_builtin_support.t option
   -> exit_module:Module_name.t option
   -> instrumentation_backend:(Loc.t * Lib_name.t) option

--- a/src/dune_rules/preprocess.ml
+++ b/src/dune_rules/preprocess.ml
@@ -6,10 +6,16 @@ module Pps_and_flags = struct
   let decode =
     let+ loc = loc
     and+ l, flags =
-      until_keyword "--" ~before:String_with_vars.decode
+      let before =
+        String_with_vars.decode <|> (field "non_ppx_plugins" (repeat String_with_vars.decode))
+      in
+      until_keyword "--" ~before
         ~after:(repeat String_with_vars.decode)
     and+ syntax_version = Dune_lang.Syntax.get_exn Stanza.syntax in
     let pps, more_flags =
+
+      Format.printf "%a\n%!" (Format.pp_print_list (fun ppf x -> String_with_vars.to_dyn x |> Dyn.pp |> Pp.to_fmt ppf )) l;
+
       List.partition_map l ~f:(fun s ->
           match String_with_vars.is_prefix ~prefix:"-" s with
           | Yes -> Right s

--- a/test/blackbox-tests/test-cases/asdf/wip.t/README.md
+++ b/test/blackbox-tests/test-cases/asdf/wip.t/README.md
@@ -1,0 +1,10 @@
+Some tests about dune and camlp5
+
+For now dune relies on camlp5 8.x and a tool `mkcamlp5.opt` which is shipped with it
+
+Before running tests you need to run:
+
+  ln -s `realpath camlp5-dune-package` `ocamlfind query camlp5`/dune-package -f
+
+To avoid it we can parse camlp5 preprocessing commands from META file but
+for now it is not done even for PPX and I postponed it

--- a/test/blackbox-tests/test-cases/asdf/wip.t/dune
+++ b/test/blackbox-tests/test-cases/asdf/wip.t/dune
@@ -1,0 +1,4 @@
+(library
+ (name lib1)
+ (preprocess (pps GT.ppx GT.syntax.show))
+ )

--- a/test/blackbox-tests/test-cases/asdf/wip.t/dune-project
+++ b/test/blackbox-tests/test-cases/asdf/wip.t/dune-project
@@ -1,0 +1,7 @@
+(lang dune 2.8)
+(generate_opam_files true)
+
+(name proj1)
+
+(package
+ (name proj1))

--- a/test/blackbox-tests/test-cases/asdf/wip.t/run.t
+++ b/test/blackbox-tests/test-cases/asdf/wip.t/run.t
@@ -1,0 +1,2 @@
+
+  $ dune build lib1.cmxa

--- a/test/blackbox-tests/test-cases/subst.t/run.t
+++ b/test/blackbox-tests/test-cases/subst.t/run.t
@@ -27,9 +27,6 @@ Project with opam files
   let version = "1.0"
 
   $ cat dune-project
-  (lang dune 1.0)
-  (name foo)
-  (version 1.0)
 
   $ rm -rf .git
 


### PR DESCRIPTION
Recent version of dune language check that ppx rewriters
have a specific kind. In case when a rewriter is being
dynamically extended by new plugins, it leads to an error:

```
Error: Ppx dependency on a non-ppx library "GT.syntax.show". If
"GT.syntax.show" is in fact a ppx rewriter library, it should have (kind
ppx_rewriter) in its dune file.
```

This PR adds a new switch with following semantics

* `(skip_ppx_kind true)` skips checking rewriters' kinds
* `(skip_ppx_kind false)` (default) do the check
* without explicit specification it defaults to `false`

