### PR TITLE
Improve error messages on unreadable targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,10 @@ Unreleased
   implementation is based on Jenga's cache library, which was thoroughly tested
   on large-scale builds. Using Jenga's cache library will also make it easier
   for us to port Jenga's cloud cache to Dune. (#4443, #4465, Andrey Mokhov)
+  
+- More informative error message when Dune can't read a target that's supposed 
+  to be produced by the action. Old message is still produced on ENOENT, but other
+  errors deserve a more detailed report. (#4501, @aalekseyev)
 
 2.9.0 (unreleased)
 ------------------

--- a/otherlibs/stdune-unstable/digest.ml
+++ b/otherlibs/stdune-unstable/digest.ml
@@ -53,7 +53,11 @@ let file_with_stats path (stats : Unix.stats) =
   match stats.st_kind with
   | S_DIR ->
     generic (stats.st_size, stats.st_perm, stats.st_mtime, stats.st_ctime)
-  | S_BLK | S_CHR | S_LNK | S_FIFO | S_SOCK ->
+  | S_BLK
+  | S_CHR
+  | S_LNK
+  | S_FIFO
+  | S_SOCK ->
     failwith "Unexpected file kind"
   | S_REG ->
     let executable = stats.st_perm land 0o100 <> 0 in

--- a/otherlibs/stdune-unstable/digest.ml
+++ b/otherlibs/stdune-unstable/digest.ml
@@ -53,6 +53,8 @@ let file_with_stats path (stats : Unix.stats) =
   match stats.st_kind with
   | S_DIR ->
     generic (stats.st_size, stats.st_perm, stats.st_mtime, stats.st_ctime)
-  | _ ->
+  | S_BLK | S_CHR | S_LNK | S_FIFO | S_SOCK ->
+    failwith "Unexpected file kind"
+  | S_REG ->
     let executable = stats.st_perm land 0o100 <> 0 in
     file_with_executable_bit ~executable path

--- a/otherlibs/stdune-unstable/string.ml
+++ b/otherlibs/stdune-unstable/string.ml
@@ -69,6 +69,11 @@ let drop_prefix s ~prefix =
   else
     None
 
+let drop_prefix_if_exists s ~prefix =
+  match drop_prefix s ~prefix with
+  | None -> s
+  | Some s -> s
+
 let drop_suffix s ~suffix =
   if is_suffix s ~suffix then
     if length s = length suffix then
@@ -77,6 +82,11 @@ let drop_suffix s ~suffix =
       Some (sub s ~pos:0 ~len:(length s - length suffix))
   else
     None
+
+let drop_suffix_if_exists s ~suffix =
+  match drop_suffix s ~suffix with
+  | None -> s
+  | Some s -> s
 
 let extract_words s ~is_word_char =
   let rec skip_blanks i =

--- a/otherlibs/stdune-unstable/string.mli
+++ b/otherlibs/stdune-unstable/string.mli
@@ -31,7 +31,11 @@ val split_n : t -> int -> t * t
 
 val drop_prefix : t -> prefix:t -> t option
 
+val drop_prefix_if_exists : t -> prefix:t -> t
+
 val drop_suffix : t -> suffix:t -> t option
+
+val drop_suffix_if_exists : t -> suffix:t -> t
 
 (** These only change ASCII characters *)
 val capitalize : t -> t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -587,7 +587,7 @@ let compute_target_digests_or_raise_error exec_params ~loc targets =
       | [] -> []
       | _ ->
         [ Pp.textf "Error trying to read targets after a rule was run:"
-        ; Pp.enumerate errors ~f:(fun (path, exn) ->
+        ; Pp.enumerate (List.rev errors) ~f:(fun (path, exn) ->
               let path = Path.build path in
               let expected_syscall_path = Path.to_string path in
               Pp.concat ~sep:(Pp.verbatim ": ")

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -177,7 +177,10 @@ let refresh fn ~remove_write_permissions : Refresh_result.t =
       | stats ->
         let stats =
           match stats.st_kind with
-          | Unix.S_LNK -> Path.stat_exn fn
+          | Unix.S_LNK -> (
+            try Path.stat_exn fn with
+            | Unix.Unix_error (ENOENT, _, _) ->
+              raise (Sys_error "Broken symlink"))
           | Unix.S_REG -> (
             match remove_write_permissions with
             | false -> stats

--- a/src/dune_engine/cached_digest.mli
+++ b/src/dune_engine/cached_digest.mli
@@ -12,11 +12,17 @@ val peek_file : Path.t -> Digest.t option
 (** Digest the contents of an artefact *)
 val build_file : Path.Build.t -> Digest.t
 
-(** Same as [build_file], but forces the digest of the file to be re-computed *)
-val refresh : Path.Build.t -> Digest.t
+module Refresh_result : sig
+  type t =
+    | Ok of Digest.t
+    | No_such_file
+    | Error of exn
+end
 
-(** Same as {!refresh} but also remove write permissions on the file *)
-val refresh_and_chmod : Path.Build.t -> Digest.t
+(** Same as [build_file], but forces the digest of the file to be re-computed.
+
+    If [remove_write_permissions] is true, also remove write permissions on the file. *)
+val refresh : Path.Build.t -> remove_write_permissions:bool -> Refresh_result.t
 
 (** {1 Managing the cache} *)
 

--- a/src/dune_engine/cached_digest.mli
+++ b/src/dune_engine/cached_digest.mli
@@ -21,7 +21,8 @@ end
 
 (** Same as [build_file], but forces the digest of the file to be re-computed.
 
-    If [remove_write_permissions] is true, also remove write permissions on the file. *)
+    If [remove_write_permissions] is true, also remove write permissions on the
+    file. *)
 val refresh : Path.Build.t -> remove_write_permissions:bool -> Refresh_result.t
 
 (** {1 Managing the cache} *)

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
@@ -3,6 +3,16 @@
   bar contents
   foo contents
 
+  $ dune build --root target @cat_dir
+  Entering directory 'target'
+       cat_dir alias cat_dir
+  bar:
+  bar contents
+  
+  foo:
+  foo contents
+  
+
   $ dune build --root dep
   Entering directory 'dep'
   File "dune", line 1, characters 0-68:

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/target/cat_dir.ml
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/target/cat_dir.ml
@@ -1,0 +1,25 @@
+let dir = Sys.argv.(1)
+
+let write f =
+  let path = Filename.concat dir f in
+  let out = open_out path in
+  output_string out (f ^ " contents\n");
+  close_out_noerr out
+
+let input_all t =
+  let buffer = Buffer.create 0 in
+  let rec loop () =
+    Buffer.add_channel buffer t 65536;
+    loop ()
+  in
+  try loop () with
+  | End_of_file -> Buffer.contents buffer
+
+let () =
+  let files =
+    Sys.readdir dir |> Array.to_list |> ListLabels.sort ~cmp:String.compare
+  in
+  ListLabels.iter files ~f:(fun file ->
+    let inp = open_in (Filename.concat dir file) in
+    Printf.printf "%s:\n%s\n" file (input_all inp)
+  )

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/target/cat_dir.ml
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/target/cat_dir.ml
@@ -1,11 +1,5 @@
 let dir = Sys.argv.(1)
 
-let write f =
-  let path = Filename.concat dir f in
-  let out = open_out path in
-  output_string out (f ^ " contents\n");
-  close_out_noerr out
-
 let input_all t =
   let buffer = Buffer.create 0 in
   let rec loop () =

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/target/dune
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/target/dune
@@ -1,5 +1,11 @@
 (executable
  (name foo)
+ (modules foo)
+ (libraries unix))
+
+(executable
+ (name cat_dir)
+ (modules cat_dir)
  (libraries unix))
 
 (rule
@@ -9,3 +15,9 @@
 (alias
  (name default)
  (deps dir))
+
+(alias
+ (name cat_dir)
+ (deps dir)
+ (action (run ./cat_dir.exe dir))
+ )

--- a/test/blackbox-tests/test-cases/unreadable-target.t/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-target.t/run.t
@@ -16,5 +16,5 @@
   3 |   (action (bash "echo content > a; chmod -r a; ln -s foo b")))
   Error: Error trying to read targets after a rule was run:
   - b: Broken symlink
-  - a: _build/default/a: Permission denied
+  - a: Permission denied
   [1]

--- a/test/blackbox-tests/test-cases/unreadable-target.t/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-target.t/run.t
@@ -15,6 +15,6 @@
   2 |   (targets a b)
   3 |   (action (bash "echo content > a; chmod -r a; ln -s foo b")))
   Error: Error trying to read targets after a rule was run:
-  - b: stat: No such file or directory
+  - b: Broken symlink
   - a: _build/default/a: Permission denied
   [1]

--- a/test/blackbox-tests/test-cases/unreadable-target.t/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-target.t/run.t
@@ -1,0 +1,22 @@
+  $ cat > dune-project <<EOF
+  > (lang dune 2.9)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (targets a b)
+  >   (action (bash "echo content > a; chmod -r a; ln -s foo b")))
+  > 
+  > EOF
+
+  $ dune build b
+  File "dune", line 1, characters 0-84:
+  1 | (rule
+  2 |   (targets a b)
+  3 |   (action (bash "echo content > a; chmod -r a; ln -s foo b")))
+  Error: Error trying to read targets after a rule was run:
+  [ ("default/b",
+    "Unix.Unix_error(Unix.ENOENT, \"stat\", \"_build/default/b\")")
+  ; ("default/a", "Sys_error(\"_build/default/a: Permission denied\")")
+  ]
+  [1]

--- a/test/blackbox-tests/test-cases/unreadable-target.t/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-target.t/run.t
@@ -15,8 +15,6 @@
   2 |   (targets a b)
   3 |   (action (bash "echo content > a; chmod -r a; ln -s foo b")))
   Error: Error trying to read targets after a rule was run:
-  [ ("default/b",
-    "Unix.Unix_error(Unix.ENOENT, \"stat\", \"_build/default/b\")")
-  ; ("default/a", "Sys_error(\"_build/default/a: Permission denied\")")
-  ]
+  - b: stat: No such file or directory
+  - a: _build/default/a: Permission denied
   [1]

--- a/test/blackbox-tests/test-cases/unreadable-target.t/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-target.t/run.t
@@ -15,6 +15,6 @@
   2 |   (targets a b)
   3 |   (action (bash "echo content > a; chmod -r a; ln -s foo b")))
   Error: Error trying to read targets after a rule was run:
-  - b: Broken symlink
   - a: Permission denied
+  - b: Broken symlink
   [1]


### PR DESCRIPTION
Before this PR, Dune says "Rule failed to generate the following targets" indiscriminately regardless of the reasons why it couldn't read the targets.
In this PR, we make Dune produce that error message only on ENOENT. All the other causes should produce a more informative error message.