### PR TITLE
Allow anonymous actions attached to a directory outside a build context

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -149,14 +149,12 @@ let init ?log_file c =
   Dune_config.init config;
   Dune_util.Log.init () ?file:log_file;
   Dune_engine.Source_tree.init
+    ~ancestor_vcs:(Memo.Build.return c.root.ancestor_vcs);
+  Dune_engine.Execution_parameters.init
     (let open Memo.Build.O in
-    let module S = Dune_engine.Source_tree.Settings in
     let+ w = Dune_rules.Workspace.workspace () in
-    S.builtin_default
-    |> S.set_ancestor_vcs c.root.ancestor_vcs
-    |> S.set_execution_parameters
-         (Dune_engine.Execution_parameters.builtin_default
-         |> Dune_rules.Workspace.update_execution_parameters w));
+    Dune_engine.Execution_parameters.builtin_default
+    |> Dune_rules.Workspace.update_execution_parameters w);
   Dune_rules.Global.init ~capture_outputs:c.capture_outputs;
   let cache_config =
     match config.cache_enabled with

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1566,8 +1566,11 @@ end = struct
     let head_target = Path.Build.Set.choose_exn targets in
     let* action, deps = exec_build_request action
     and* execution_parameters =
-      Source_tree.execution_parameters_of_dir
-        (Path.Build.drop_build_context_exn dir)
+      match Dpath.Target_dir.of_target dir with
+      | Regular (With_context (_, dir))
+      | Anonymous_action (With_context (_, dir)) ->
+        Source_tree.execution_parameters_of_dir dir
+      | _ -> Execution_parameters.default
     in
     Memo.Build.of_reproducible_fiber
       (let open Fiber.O in

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -38,3 +38,12 @@ let should_remove_write_permissions_on_generated_files t =
 let should_expand_aliases_when_sandboxing t = t.dune_version >= (3, 0)
 
 let swallow_stdout_on_success t = t.swallow_stdout_on_success
+
+let default = Fdecl.create Dyn.Encoder.opaque
+
+let init t = Fdecl.set default t
+
+let default =
+  let open Memo.Build.O in
+  let* () = Memo.Build.return () in
+  Fdecl.get default

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -31,6 +31,9 @@ val set_dune_version : Dune_lang.Syntax.Version.t -> t -> t
 
 val set_swallow_stdout_on_success : bool -> t -> t
 
+(** As configured by [init] *)
+val default : t Memo.Build.t
+
 (** {1 Accessors} *)
 
 val dune_version : t -> Dune_lang.Syntax.Version.t
@@ -40,3 +43,7 @@ val should_remove_write_permissions_on_generated_files : t -> bool
 val should_expand_aliases_when_sandboxing : t -> bool
 
 val swallow_stdout_on_success : t -> bool
+
+(** {1 Initialisation} *)
+
+val init : t Memo.Build.t -> unit

--- a/src/dune_engine/source_tree.mli
+++ b/src/dune_engine/source_tree.mli
@@ -70,23 +70,9 @@ module Dir : sig
   val to_dyn : t -> Dyn.t
 end
 
-module Settings : sig
-  (** Global source tree settings. *)
-  type t
-
-  val builtin_default : t
-
-  (** The default vcs. If there is no vcs at the root of the workspace, then
-      this is the vcs that will be used for the root. *)
-  val set_ancestor_vcs : Vcs.t option -> t -> t
-
-  (** The default execution parameters. *)
-  val set_execution_parameters : Execution_parameters.t -> t -> t
-end
-
-(** Set the global settings for this module. This function must be called
-    exactly once at the beginning of the process. *)
-val init : Settings.t Memo.Build.t -> unit
+(** Initialise the default vcs. If there is no vcs at the root of the workspace,
+    then this is the vcs that will be used for the root. *)
+val init : ancestor_vcs:Vcs.t option Memo.Build.t -> unit
 
 val root : unit -> Dir.t Memo.Build.t
 


### PR DESCRIPTION
We don't do that in Dune at the moment, but it is used by the Jenga rules inside Jane Street. Without this PR we get a loop between:

- find-dir-raw "." (the listing in source_tree of the root source dir)
- the filtering of files (in an upcoming PR) that goes through interpreting the .hgignore with the jenga rules
- calling `hg debugignore` via an anonymous action
- calling `Source_tree.execution_parameters_of_dir (Path.Build.drop_optional_build_context dir)` where `dir` is `_build/.actions`
- find-dir-raw "."
