### PR TITLE
Add annotations required by OCaml PR#10277

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+- Fix compatibility with ocaml/ocaml#10277 (#4508, @dra27)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/src/cache/local.ml
+++ b/src/cache/local.ml
@@ -187,8 +187,7 @@ let deduplicate cache (file : File.t) =
       Path.unlink_no_err tmpname;
       Path.link path_in_cache tmpname;
       Path.rename tmpname path
-    with
-    | Unix.Unix_error (e, syscall, _) ->
+    with Unix.Unix_error (e, syscall, _) ->
       Path.unlink_no_err tmpname;
       cache.warn
         [ Pp.textf "error handling dune-cache command: %s: %s" syscall
@@ -208,7 +207,7 @@ let promote_sync cache paths key metadata ~repository ~duplication =
     | Some idx -> (
       match List.nth cache.repositories idx with
       | None -> Result.Error (Printf.sprintf "repository out of range: %i" idx)
-      | repo -> Result.Ok repo)
+      | repo -> Result.Ok repo )
   in
   let metadata =
     apply
@@ -279,7 +278,7 @@ let promote_sync cache paths key metadata ~repository ~duplication =
             (* Remove write permissions, making the cache entry immutable. We
                assume that users do not modify the files in the cache. *)
             Path.chmod in_the_cache ~mode:(stat.st_perm land 0o555);
-            Result.Ok (Promoted { path; digest = effective_digest })))
+            Result.Ok (Promoted { path; digest = effective_digest }) ))
   in
   let+ promoted = Result.List.map ~f:promote paths in
   let metadata_path = metadata_path cache key

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -998,20 +998,20 @@ module With_implicit_output = struct
     match typ with
     | Function.Type.Sync ->
       let memo =
-        create name ?doc ~input ~visibility ~output Sync (fun i ->
+        create name ?doc ~input ~visibility ~output Sync (fun (i : i) ->
             Implicit_output.collect_sync implicit_output (fun () -> impl i))
       in
       ( fun input ->
-          let res, output = exec memo input in
+          let res, output = exec memo (input : i) in
           Implicit_output.produce_opt implicit_output output;
           res
         : f )
     | Function.Type.Async ->
       let memo =
-        create name ?doc ~input ~visibility ~output Async (fun i ->
+        create name ?doc ~input ~visibility ~output Async (fun (i : i) ->
             Implicit_output.collect_async implicit_output (fun () -> impl i))
       in
-      ( fun input ->
+      ( fun (input : i) ->
           Fiber.map (exec memo input) ~f:(fun (res, output) ->
               Implicit_output.produce_opt implicit_output output;
               res)


### PR DESCRIPTION
Restores the ability to build 2.8 with trunk OCaml after ocaml/ocaml#10277. It's just waiting on absolute confirmation that letting the code through without annotations was in fact a bug.

Assuming this is merged, it needs to go in 2.9 as well - note that main/3.0 is unaffected as this code was deleted by #4392.