### PR TITLE
mkdir the initial working directory in sandbox

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,9 @@ Unreleased
   to be produced by the action. Old message is still produced on ENOENT, but other
   errors deserve a more detailed report. (#4501, @aalekseyev)
 
+- Fixed a bug where a sandboxed action would fail if it declares no dependencies in
+  its initial working directory or any directory it `chdir`s into. (#4509, @aalekseyev)
+
 2.9.0 (unreleased)
 ------------------
 

--- a/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
@@ -1,0 +1,18 @@
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ mkdir a
+  $ echo contents > x
+  $ cat >a/dune <<EOF
+  > (rule
+  >   (alias default)
+  >   (deps ../x)
+  >   (action (bash "cat ../x"))
+  > )
+  > EOF
+  $ dune build @default --sandbox=copy
+  Error: chdir: _build/.sandbox/4feb8bb98e202b4343a8ae2ce24c4614/default/a: No
+  such file or directory
+  [1]

--- a/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
@@ -3,6 +3,9 @@
   > (lang dune 3.0)
   > EOF
 
+You can `chdir` into a directory without declaring any dependencies
+and dune makes sure that the directory exists inside the sandbox.
+
   $ mkdir a
   $ echo contents > x
   $ cat >a/dune <<EOF
@@ -13,9 +16,8 @@
   > )
   > EOF
   $ dune build @a --sandbox=copy
-  Error: chdir: _build/.sandbox/54e7c39ec539e048ba2218cceb055bf6/default/a: No
-  such file or directory
-  [1]
+          bash alias a/a
+  contents
 
   $ cat >dune <<EOF
   > (rule
@@ -25,6 +27,5 @@
   > )
   > EOF
   $ dune build @root --sandbox=copy
-  Error: chdir: _build/.sandbox/cba1cf593884e3c67471e7bb90263e06/default/a: No
-  such file or directory
-  [1]
+          bash alias root
+  contents

--- a/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
@@ -7,12 +7,24 @@
   $ echo contents > x
   $ cat >a/dune <<EOF
   > (rule
-  >   (alias default)
+  >   (alias a)
   >   (deps ../x)
   >   (action (bash "cat ../x"))
   > )
   > EOF
-  $ dune build @default --sandbox=copy
-  Error: chdir: _build/.sandbox/4feb8bb98e202b4343a8ae2ce24c4614/default/a: No
+  $ dune build @a --sandbox=copy
+  Error: chdir: _build/.sandbox/54e7c39ec539e048ba2218cceb055bf6/default/a: No
+  such file or directory
+  [1]
+
+  $ cat >dune <<EOF
+  > (rule
+  >   (alias root)
+  >   (deps x)
+  >   (action (chdir a (bash "cat ../x")))
+  > )
+  > EOF
+  $ dune build @root --sandbox=copy
+  Error: chdir: _build/.sandbox/cba1cf593884e3c67471e7bb90263e06/default/a: No
   such file or directory
   [1]


### PR DESCRIPTION
If an action has no dependencies in its initial working directory, and sandboxing is used, then dune simply fails because it tries to "cd" into this directory that does not exist.

When sandboxing is not used, we already mkdir all the needed directories.
This PR makes it so that the directories are created in the sandbox as well.