### PR TITLE
Add a --fail-on-non-empty-stderr flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,7 +54,7 @@ Unreleased
   of aliases. (#4303, @aalekseyev)
 
 - If an .ml file is not used by an executable, Dune no longer report
-  parsing error in this file (#...., @jeremiedimino)
+  parsing error in this file (#4510, @jeremiedimino)
 
 - Add support for sandboxing using hard links (#4360, @snowleopard)
 
@@ -86,6 +86,10 @@ Unreleased
 
 - Add an option to swallow the output of actions when they succeed, to
   reduce noise of large builds (#4422, @jeremiedimino)
+
+- Add an option to consider actions that have a non-empty stderr and
+  exit code of 0 as failing, again to reduce noise of large builds
+  (#...., @jeremiedimino)
 
 - Add the possibility to use `locks` with the cram tests stanza (#4397, @voodoos)
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -618,6 +618,12 @@ let shared_with_config_file =
       & info
           [ "swallow-stdout-on-success" ]
           ~doc:"Swallow the output of an action when it succeeds.")
+  and+ fail_on_non_empty_stderr =
+    Arg.(
+      value & flag
+      & info
+          [ "fail-on-non-empty-stderr" ]
+          ~doc:"Consider that actions with a non empty stderr as failed.")
   in
   { Dune_config.Partial.display
   ; concurrency
@@ -629,6 +635,7 @@ let shared_with_config_file =
         ~f:Dune_cache.Config.Reproducibility_check.check_with_probability
   ; cache_storage_mode
   ; swallow_stdout_on_success = Option.some_if swallow_stdout_on_success true
+  ; fail_on_non_empty_stderr = Option.some_if fail_on_non_empty_stderr true
   }
 
 let term =

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -145,6 +145,7 @@ module type S = sig
         Dune_cache.Config.Reproducibility_check.t field
     ; cache_storage_mode : Cache.Storage_mode.t field
     ; swallow_stdout_on_success : bool field
+    ; fail_on_non_empty_stderr : bool field
     }
 end
 
@@ -169,6 +170,8 @@ struct
     ; cache_storage_mode = field a.cache_storage_mode b.cache_storage_mode
     ; swallow_stdout_on_success =
         field a.swallow_stdout_on_success b.swallow_stdout_on_success
+    ; fail_on_non_empty_stderr =
+        field a.fail_on_non_empty_stderr b.fail_on_non_empty_stderr
     }
 end
 
@@ -188,6 +191,7 @@ struct
       ; cache_reproducibility_check
       ; cache_storage_mode
       ; swallow_stdout_on_success
+      ; fail_on_non_empty_stderr
       } =
     Dyn.Encoder.record
       [ ("display", field Scheduler.Config.Display.to_dyn display)
@@ -204,6 +208,8 @@ struct
         , field Cache.Storage_mode.to_dyn cache_storage_mode )
       ; ( "swallow_stdout_on_success"
         , field Dyn.Encoder.bool swallow_stdout_on_success )
+      ; ( "fail_on_non_empty_stderr"
+        , field Dyn.Encoder.bool fail_on_non_empty_stderr )
       ]
 end
 
@@ -225,6 +231,7 @@ module Partial = struct
     ; cache_reproducibility_check = None
     ; cache_storage_mode = None
     ; swallow_stdout_on_success = None
+    ; fail_on_non_empty_stderr = None
     }
 
   include
@@ -278,6 +285,7 @@ let default =
   ; cache_reproducibility_check = Skip
   ; cache_storage_mode = None
   ; swallow_stdout_on_success = false
+  ; fail_on_non_empty_stderr = false
   }
 
 let decode_generic ~min_dune_version =
@@ -323,6 +331,9 @@ let decode_generic ~min_dune_version =
   and+ swallow_stdout_on_success =
     field_o_b "swallow-stdout-on-success"
       ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
+  and+ fail_on_non_empty_stderr =
+    field_o_b "fail-on-non-empty-stderr"
+      ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
   in
   let cache_storage_mode =
     Option.merge cache_duplication cache_storage_mode ~f:(fun _ _ ->
@@ -341,6 +352,7 @@ let decode_generic ~min_dune_version =
   ; cache_reproducibility_check
   ; cache_storage_mode
   ; swallow_stdout_on_success
+  ; fail_on_non_empty_stderr
   }
 
 let decode =

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -61,6 +61,7 @@ module type S = sig
         Dune_cache.Config.Reproducibility_check.t field
     ; cache_storage_mode : Cache.Storage_mode.t field
     ; swallow_stdout_on_success : bool field
+    ; fail_on_non_empty_stderr : bool field
     }
 end
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -549,7 +549,12 @@ let exec ~targets ~root ~context ~env ~rule_loc ~build_deps
           Process.Io.stdout_swallow_on_success
         else
           Process.Io.stdout)
-    ; stderr_to = Process.Io.stderr
+    ; stderr_to =
+        (if Execution_parameters.fail_on_non_empty_stderr execution_parameters
+        then
+          Process.Io.stderr_must_be_empty
+        else
+          Process.Io.stderr)
     ; stdin_from = Process.Io.null In
     ; prepared_dependencies = DAP.Dependency.Set.empty
     ; exit_codes = Predicate_lang.Element 0

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1381,9 +1381,10 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 5
+  let rule_digest_version = 6
 
-  let compute_rule_digest (rule : Rule.t) ~deps ~action ~sandbox_mode =
+  let compute_rule_digest (rule : Rule.t) ~deps ~action ~sandbox_mode
+      ~execution_parameters =
     let { Action.Full.action; env; locks; can_go_in_shared_cache } = action in
     let trace =
       ( rule_digest_version (* Update when changing the rule digest scheme. *)
@@ -1392,7 +1393,8 @@ end = struct
       , Option.map rule.context ~f:(fun c -> c.name)
       , Action.for_shell action
       , can_go_in_shared_cache
-      , List.map locks ~f:Path.to_string )
+      , List.map locks ~f:Path.to_string
+      , Execution_parameters.fail_on_non_empty_stderr execution_parameters )
     in
     Digest.generic trace
 
@@ -1618,7 +1620,10 @@ end = struct
         let force_rerun = !Clflags.force && is_test in
         force_rerun || Dep.Map.has_universe deps
       in
-      let rule_digest = compute_rule_digest rule ~deps ~action ~sandbox_mode in
+      let rule_digest =
+        compute_rule_digest rule ~deps ~action ~sandbox_mode
+          ~execution_parameters
+      in
       let can_go_in_shared_cache =
         action.can_go_in_shared_cache
         && not

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -4,31 +4,44 @@ module T = struct
   type t =
     { dune_version : Dune_lang.Syntax.Version.t
     ; swallow_stdout_on_success : bool
+    ; fail_on_non_empty_stderr : bool
     }
 
-  let equal { dune_version; swallow_stdout_on_success } t =
+  let equal
+      { dune_version; swallow_stdout_on_success; fail_on_non_empty_stderr } t =
     Dune_lang.Syntax.Version.equal dune_version t.dune_version
     && Bool.equal swallow_stdout_on_success t.swallow_stdout_on_success
+    && Bool.equal fail_on_non_empty_stderr t.fail_on_non_empty_stderr
 
-  let hash { dune_version; swallow_stdout_on_success } =
+  let hash { dune_version; swallow_stdout_on_success; fail_on_non_empty_stderr }
+      =
     Hashtbl.hash
-      (Dune_lang.Syntax.Version.hash dune_version, swallow_stdout_on_success)
+      ( Dune_lang.Syntax.Version.hash dune_version
+      , swallow_stdout_on_success
+      , fail_on_non_empty_stderr )
 
-  let to_dyn { dune_version; swallow_stdout_on_success } =
+  let to_dyn
+      { dune_version; swallow_stdout_on_success; fail_on_non_empty_stderr } =
     Dyn.Record
       [ ("dune_version", Dune_lang.Syntax.Version.to_dyn dune_version)
       ; ("swallow_stdout_on_success", Bool swallow_stdout_on_success)
+      ; ("fail_on_non_empty_stderr", Bool fail_on_non_empty_stderr)
       ]
 end
 
 include T
 
 let builtin_default =
-  { dune_version = Stanza.latest_version; swallow_stdout_on_success = false }
+  { dune_version = Stanza.latest_version
+  ; swallow_stdout_on_success = false
+  ; fail_on_non_empty_stderr = false
+  }
 
 let set_dune_version x t = { t with dune_version = x }
 
 let set_swallow_stdout_on_success x t = { t with swallow_stdout_on_success = x }
+
+let set_fail_on_non_empty_stderr x t = { t with fail_on_non_empty_stderr = x }
 
 let dune_version t = t.dune_version
 
@@ -38,6 +51,8 @@ let should_remove_write_permissions_on_generated_files t =
 let should_expand_aliases_when_sandboxing t = t.dune_version >= (3, 0)
 
 let swallow_stdout_on_success t = t.swallow_stdout_on_success
+
+let fail_on_non_empty_stderr t = t.fail_on_non_empty_stderr
 
 let default = Fdecl.create Dyn.Encoder.opaque
 

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -31,6 +31,8 @@ val set_dune_version : Dune_lang.Syntax.Version.t -> t -> t
 
 val set_swallow_stdout_on_success : bool -> t -> t
 
+val set_fail_on_non_empty_stderr : bool -> t -> t
+
 (** As configured by [init] *)
 val default : t Memo.Build.t
 
@@ -43,6 +45,8 @@ val should_remove_write_permissions_on_generated_files : t -> bool
 val should_expand_aliases_when_sandboxing : t -> bool
 
 val swallow_stdout_on_success : t -> bool
+
+val fail_on_non_empty_stderr : t -> bool
 
 (** {1 Initialisation} *)
 

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -30,6 +30,10 @@ module Io : sig
 
   val stderr : output t
 
+  (** Same [stderr] but consider that the program failed if it prints something
+      on [stderr]. *)
+  val stderr_must_be_empty : output t
+
   val stdin : input t
 
   val null : 'a mode -> 'a t

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -667,7 +667,10 @@ let workspace =
   Memo.exec memo
 
 let update_execution_parameters t ep =
-  Execution_parameters.set_swallow_stdout_on_success
-    t.config.swallow_stdout_on_success ep
+  ep
+  |> Execution_parameters.set_swallow_stdout_on_success
+       t.config.swallow_stdout_on_success
+  |> Execution_parameters.set_fail_on_non_empty_stderr
+       t.config.fail_on_non_empty_stderr
 
 let build_contexts t = List.concat_map t.contexts ~f:Context.build_contexts

--- a/test/blackbox-tests/test-cases/actions/fail-on-non-empty-stderr.t
+++ b/test/blackbox-tests/test-cases/actions/fail-on-non-empty-stderr.t
@@ -1,0 +1,84 @@
+Test for --fail-on-non-empty-stderr
+===================================
+
+  $ export BUILD_PATH_PREFIX_MAP="sh=$(which sh):$BUILD_PATH_PREFIX_MAP"
+
+  $ echo '(lang dune 3.0)' > dune-project
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias default)
+  >  (action (system "echo 'Something went wrong!' >&2")))
+  > EOF
+
+By default, an action printing something to stderr but returning 0 is
+considered as a success:
+
+  $ dune build
+            sh alias default
+  Something went wrong!
+
+With the option, the action is considered as failed:
+
+  $ dune clean
+  $ dune build --fail-on-non-empty-stderr
+  File "dune", line 1, characters 0-77:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "echo 'Something went wrong!' >&2")))
+            sh alias default (exit 0)
+  (cd _build/default && sh -c 'echo '\''Something went wrong!'\'' >&2')
+  Something went wrong!
+  [1]
+
+Incremental builds
+------------------
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias default)
+  >  (action (system "echo 'Hello, world!'")))
+  > EOF
+
+  $ dune build
+            sh alias default
+  Hello, world!
+
+If we suddently enable the option, we re-run everything, including all
+actions that succeed and have to stderr output at all:
+
+  $ dune build --fail-on-non-empty-stderr
+            sh alias default
+  Hello, world!
+
+It feels like we could do better and only re-run the actions that
+previously add a non-empty stderr.
+
+With compound actions
+---------------------
+
+At the moment, if two programs print to stderr without failing, we
+stop at the first program. That's not terrible, but it would seem
+better if we stop at the end of the whole action.
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias default)
+  >  (action
+  >   (progn
+  >    (system "echo 1 >&2")
+  >    (system "echo 2 >&2"))))
+  > EOF
+
+  $ dune build --fail-on-non-empty-stderr
+  File "dune", line 1, characters 0-93:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action
+  4 |   (progn
+  5 |    (system "echo 1 >&2")
+  6 |    (system "echo 2 >&2"))))
+            sh alias default (exit 0)
+  (cd _build/default && sh -c 'echo 1 >&2')
+  1
+  [1]

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [d7a59c882db29d4533f0ebd369764a7f]: ((in_cache
+  Warning: cache store error [eaa4da97eb35237ee689912890a9fd2b]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [d7a59c882db29d4533f0ebd369764a7f]: ((in_cache
+  Warning: cache store error [eaa4da97eb35237ee689912890a9fd2b]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [d7a59c882db29d4533f0ebd369764a7f]: ((in_cache
+  Warning: cache store error [eaa4da97eb35237ee689912890a9fd2b]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -77,10 +77,10 @@ You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort)
-  ./71/71a631749bd743e4c107ba109224c12f:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./a7/a70b2a31baf647239dabd57aa93ccf57:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./3b/3b4ccbf0cd30cacd60a1a090982b2ff3:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./3e/3ec3343ca27bf5ce7d7d5331689493fa:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/71/71a631749bd743e4c107ba109224c12f"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/3b/3b4ccbf0cd30cacd60a1a090982b2ff3"
   70
 
 Trimming the cache at this point should not remove any file entries because all

--- a/test/expect-tests/dune_config/dune_config_test.ml
+++ b/test/expect-tests/dune_config/dune_config_test.ml
@@ -28,6 +28,7 @@ let%expect_test "cache-check-probability 0.1" =
     ; cache_reproducibility_check = Check_with_probability 0.1
     ; cache_storage_mode = None
     ; swallow_stdout_on_success = false
+    ; fail_on_non_empty_stderr = false
     }
  |}]
 
@@ -43,6 +44,7 @@ let%expect_test "cache-storage-mode copy" =
     ; cache_reproducibility_check = Skip
     ; cache_storage_mode = Some Copy
     ; swallow_stdout_on_success = false
+    ; fail_on_non_empty_stderr = false
     }
  |}]
 
@@ -58,5 +60,6 @@ let%expect_test "cache-storage-mode hardlink" =
     ; cache_reproducibility_check = Skip
     ; cache_storage_mode = Some Hardlink
     ; swallow_stdout_on_success = false
+    ; fail_on_non_empty_stderr = false
     }
  |}]


### PR DESCRIPTION
Continuation of the work to reduce noise on large builds. This PR adds an option `fail-on-non-empty-stderr` that can be set:

- via the command line
- via the dune-workspace file
- via the config file

(just like `--swallow-stdout-on-success`).


When this option is enabled, any command that prints something to stderr but has an exit code of 0 is still considered has having failed. This way, a successful clean build has really zero output. This is important for large workspaces. Contrary to `--swallow-stdout-on-success`, setting this option might cause the build to start failing. To account for that, the status of this option is recorded in the rule digest. This is an over-approximation as it means that suddenly setting this option will cause everything to be re-executed, while we could instead only re-executed actions that previously had a non-empty stderr. This part is left as a future improvement.





