### PR TITLE
Don't restart the build when untracked files change

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2,8 +2,6 @@ open! Stdune
 open Import
 open Memo.Build.O
 
-let () = Hooks.End_of_build.always Memo.reset
-
 module Fs : sig
   val mkdir_p : Path.Build.t -> unit Memo.Build.t
 

--- a/src/dune_engine/fs_notify_memo.ml
+++ b/src/dune_engine/fs_notify_memo.ml
@@ -8,6 +8,17 @@ let memo =
     ~visibility:Hidden
     (fun _path -> Memo.Build.return ())
 
-let depend p = Memo.exec memo p
+let depend path = Memo.exec memo path
 
-let invalidate p = Memo.Cell.invalidate (Memo.cell memo p)
+module Invalidate_result = struct
+  type t =
+    | Invalidated
+    | Skipped
+end
+
+let invalidate path =
+  match Memo.Expert.previously_evaluated_cell memo path with
+  | None -> Invalidate_result.Skipped
+  | Some cell ->
+    Memo.Cell.invalidate cell;
+    Invalidated

--- a/src/dune_engine/fs_notify_memo.mli
+++ b/src/dune_engine/fs_notify_memo.mli
@@ -3,4 +3,10 @@ open Import
 
 val depend : Path.t -> unit Memo.Build.t
 
-val invalidate : Path.t -> unit
+module Invalidate_result : sig
+  type t =
+    | Invalidated
+    | Skipped  (** The given path is not tracked by the build system. *)
+end
+
+val invalidate : Path.t -> Invalidate_result.t

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1173,6 +1173,10 @@ end
 
 let cell = dep_node
 
+module Expert = struct
+  let previously_evaluated_cell t input = Store.find t.cache input
+end
+
 module Implicit_output = Implicit_output
 module Store = Store_intf
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -362,7 +362,22 @@ module Cell : sig
   val invalidate : _ t -> unit
 end
 
+(** Create a "memoization cell" that focuses on a single input/output pair of a
+    memoized function. *)
 val cell : ('i, 'o) t -> 'i -> ('i, 'o) Cell.t
+
+module Expert : sig
+  (** Like [cell] but returns [Nothing] if the given memoized function has never
+      been evaluated on the specified input. We use [previously_evaluated_cell]
+      to skip unnecessary rebuilds when receiving file system events for files
+      that we don't care about.
+
+      Note that this function is monotonic: its result can change from [Nothing]
+      to [Some cell] as new cells get evaluated. However, calling [reset] clears
+      all memoization tables, and therefore resets [previously_evaluated_cell]
+      to [Nothing] as well. *)
+  val previously_evaluated_cell : ('i, 'o) t -> 'i -> ('i, 'o) Cell.t option
+end
 
 (** Memoization of polymorphic functions ['a input -> 'a output Build.t]. The
     provided [id] function must be injective, i.e. there must be a one-to-one


### PR DESCRIPTION
Currently any `Files_changed` event triggers the restart of the build, even if the modified file is ignored by the build system. This PR changes the behaviour to only trigger restarts when the file change events correspond to files that are tracked by the build system, i.e. for which we called `Fs_notify_memo.depend`.