### PR TITLE
[RPC] Richer diagnostic reporting

### DIFF
--- a/otherlibs/dune-rpc/dune_rpc.ml
+++ b/otherlibs/dune-rpc/dune_rpc.ml
@@ -8,6 +8,7 @@ module V1 = struct
   module Call = Call
   module Client = Client
   module Loc = Loc
+  module Target = Target
   module Diagnostic = Diagnostic
   module Build = Build
   module Progress = Progress

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -117,8 +117,8 @@ module V1 : sig
        to the workspace root. This is often, but not always, the directory of
        the first target in [targets].
 
-       If this is [None], then the error most likely arose from a dune-internal
-       operation, which has an effective directory of the workspace root. *)
+       If this is [None], then the error does not have an associated error (for
+       example, if your opam installation is too old). *)
     val directory : t -> string option
 
     module Event : sig

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -76,6 +76,16 @@ module V1 : sig
       }
   end
 
+  module Target : sig
+    type t =
+      | Path of string
+      | Alias of string
+      | Library of string
+      | Executables of string list
+      | Preprocess of string list
+      | Loc of Loc.t
+  end
+
   module Diagnostic : sig
     type severity =
       | Error
@@ -98,7 +108,18 @@ module V1 : sig
 
     val promotion : t -> Promotion.t list
 
-    val targets : t -> string list
+    (* The list of targets is ordered such that the first element is the
+       immediate ("innermost") target being built when the error was
+       encountered, which was required by the next element, and so on. *)
+    val targets : t -> Target.t list
+
+    (* The directory from which the action producing the error was run, relative
+       to the workspace root. This is often, but not always, the directory of
+       the first target in [targets].
+
+       If this is [None], then the error most likely arose from a dune-internal
+       operation, which has an effective directory of the workspace root. *)
+    val directory : t -> string option
 
     module Event : sig
       type nonrec t =

--- a/otherlibs/dune-rpc/private/conv.ml
+++ b/otherlibs/dune-rpc/private/conv.ml
@@ -413,6 +413,12 @@ let five a b c d e =
     (fun ((a, b), (c, d, e)) -> (a, b, c, d, e))
     (fun (a, b, c, d, e) -> ((a, b), (c, d, e)))
 
+let six a b c d e f =
+  iso
+    (both (three a b c) (three d e f))
+    (fun ((a, b, c), (d, e, f)) -> (a, b, c, d, e, f))
+    (fun (a, b, c, d, e, f) -> ((a, b, c), (d, e, f)))
+
 let sexp = Sexp
 
 let required x = Required x

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -63,6 +63,15 @@ val five :
   -> ('e, fields) t
   -> ('a * 'b * 'c * 'd * 'e, fields) t
 
+val six :
+     ('a, fields) t
+  -> ('b, fields) t
+  -> ('c, fields) t
+  -> ('d, fields) t
+  -> ('e, fields) t
+  -> ('f, fields) t
+  -> ('a * 'b * 'c * 'd * 'e * 'f, fields) t
+
 val record : ('a, fields) t -> ('a, values) t
 
 val either : ('a, fields) t -> ('b, fields) t -> (('a, 'b) Either.t, fields) t

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -123,6 +123,16 @@ module Loc : sig
     }
 end
 
+module Target : sig
+  type t =
+    | Path of string
+    | Alias of string
+    | Library of string
+    | Executables of string list
+    | Preprocess of string list
+    | Loc of Loc.t
+end
+
 module Diagnostic : sig
   type severity =
     | Error
@@ -136,11 +146,12 @@ module Diagnostic : sig
   end
 
   type t =
-    { targets : string list
+    { targets : Target.t list
     ; message : unit Pp.t
     ; loc : Loc.t option
     ; severity : severity option
     ; promotion : Promotion.t list
+    ; directory : string option
     }
 
   val loc : t -> Loc.t option
@@ -151,7 +162,9 @@ module Diagnostic : sig
 
   val promotion : t -> Promotion.t list
 
-  val targets : t -> string list
+  val targets : t -> Target.t list
+
+  val directory : t -> string option
 
   module Event : sig
     type nonrec t =

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -21,7 +21,13 @@ let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
   let message = Build_system.Error.message m in
   let loc = message.loc in
   let message = Pp.map_tags (Pp.concat message.paragraphs) ~f:(fun _ -> ()) in
-  { severity = None; targets = []; message; loc; promotion = [] }
+  { severity = None
+  ; targets = []
+  ; message
+  ; loc
+  ; promotion = []
+  ; directory = None
+  }
 
 (* TODO un-copy-paste from dune/bin/arg.ml *)
 let dep_parser =


### PR DESCRIPTION
This change is API-only.

This PR introduces two changes to the public-facing API.

- Make the `targets` field of `Diagnostic.t` less stringly-typed. This way, clients can have descriptive error messages independent of dune's rendering
- Add the `directory` field to diagnostics. In a lot of cases I expect this to be redundant with `targets`, but if an action decides to `cd` on its own or something, this can be useful. More selfishly, Jenga currently passes this field in its RPC, so a lot of our internal consumers would prefer to have this field directly (rather than try to infer it out of `targets`).