### PR TITLE
Skip untracked file changes in incremental mode

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -866,11 +866,6 @@ end = struct
         match (all_changed_files_skipped, Memo.incremental_mode_enabled) with
         | true, true -> iter t (* Ignore the event *)
         | _, _ -> (
-          (* CR-someday amokhov: Once we implement fully incremental builds, we
-             should stop resetting [Memo] on file change events. *)
-          (* It might seem that the above [invalidate] calls are currently
-             completely meaningless since we immediately reset the [Memo], but
-             they do serve one purpose: computing [all_changed_files_skipped]. *)
           Memo.reset ();
           match t.status with
           | Shutting_down

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -849,25 +849,23 @@ end = struct
       match Event.Queue.next t.events with
       | Job_completed (job, status) -> Fiber.Fill (job.ivar, status)
       | Files_changed changed_files -> (
+        (* CR-someday amokhov: In addition to tracking files, we also need to
+           track directory listings. Otherwise, when a new file is added to a
+           source directory, [invalidate] will return [Skipped] because that
+           file was previously untracked. To fix this, we will need to introduce
+           new [Memo] cells for tracking directory listings, and [invalidate]
+           those cells when the listings change. *)
         (* If none of [changed_files] is tracked by the build system, we will
            ignore this [Files_changed] event to avoid unnecessary restarts. *)
-        let _all_changed_files_skipped =
+        let all_changed_files_skipped =
           List.for_all changed_files ~f:(fun path ->
               match Fs_notify_memo.invalidate path with
               | Skipped -> true
               | Invalidated -> false)
         in
-        (* CR-soon amokhov: For now, we disable this optimisation because it
-           breaks incremental builds when new files are added to a directory.
-           The reason is that these files have previously been untracked and
-           [invalidate] will therefore return [Skipped]. To fix this, we will
-           need to introduce new [Memo] cells for tracking directory listings.
-           When a new file is added to a directory, the corresponding cell will
-           become [Invalidated] and we will correctly restart the build. *)
-        let all_changed_files_skipped = false in
-        match all_changed_files_skipped with
-        | true -> iter t (* Ignore the event *)
-        | false -> (
+        match (all_changed_files_skipped, Memo.incremental_mode_enabled) with
+        | true, true -> iter t (* Ignore the event *)
+        | _, _ -> (
           (* CR-someday amokhov: Once we implement fully incremental builds, we
              should stop resetting [Memo] on file change events. *)
           (* It might seem that the above [invalidate] calls are currently

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1256,12 +1256,12 @@ struct
   let eval x = exec memo (Key.T x) >>| Value.get ~input_with_matching_id:x
 end
 
-let should_clear_caches =
+let incremental_mode_enabled =
   match Sys.getenv_opt "DUNE_WATCHING_MODE_INCREMENTAL" with
-  | Some "true" -> false
+  | Some "true" -> true
   | Some "false"
   | None ->
-    true
+    false
   | Some _ ->
     User_error.raise
       [ Pp.text "Invalid value of DUNE_WATCHING_MODE_INCREMENTAL" ]
@@ -1272,4 +1272,4 @@ let restart_current_run () =
 
 let reset () =
   restart_current_run ();
-  if should_clear_caches then Caches.clear ()
+  if not incremental_mode_enabled then Caches.clear ()

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -137,6 +137,11 @@ val reset : unit -> unit
     clear the memoization cache. *)
 val restart_current_run : unit -> unit
 
+(** Returns [true] if the user enabled the incremental mode via the environment
+    variable [DUNE_WATCHING_MODE_INCREMENTAL], and we should therefore assume
+    that the build system tracks all relevant side effects in the [Build] monad. *)
+val incremental_mode_enabled : bool
+
 module type Output_simple = sig
   type t
 


### PR DESCRIPTION
As pointed out by @aalekseyev, we should enable the optimisation introduced in #4512 if the user enabled the incremental mode via the environment variable `DUNE_WATCHING_MODE_INCREMENTAL`.
