### PR TITLE
Use wait3 to accurately time spawned processes

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -88,24 +88,16 @@ let prepare_workspace () =
       Format.eprintf "cloning %s/%s@." pkg.org pkg.name;
       Package.clone pkg)
 
-let with_timer f =
-  let start = Unix.time () in
-  let res = f () in
-  let stop = Unix.time () in
-  (stop -. start, res)
-
 let dune_build () =
   let stdin_from = Process.(Io.null In) in
   let stdout_to = Process.(Io.file Config.dev_null Out) in
   let stderr_to = Process.(Io.file Config.dev_null Out) in
-  let start = Unix.time () in
   let open Fiber.O in
-  let+ () =
-    Process.run Strict (Lazy.force dune) ~stdin_from ~stdout_to ~stderr_to
+  let+ times =
+    Process.run_with_times (Lazy.force dune) ~stdin_from ~stdout_to ~stderr_to
       [ "build"; "@install"; "--root"; "." ]
   in
-  let stop = Unix.time () in
-  stop -. start
+  times.elapsed_time
 
 let run_bench () =
   let open Fiber.O in

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -1,4 +1,6 @@
 open Stdune
+module Process = Dune_engine.Process
+module Config = Dune_util.Config
 
 module Json = struct
   include Chrome_trace.Json
@@ -69,8 +71,6 @@ module Package = struct
   let make org name = { org; name }
 
   let clone t =
-    let module Process = Dune_engine.Process in
-    let module Config = Dune_util.Config in
     let stdout_to = Process.Io.(file Config.dev_null Out) in
     let stderr_to = Process.Io.(file Config.dev_null Out) in
     let stdin_from = Process.Io.(null In) in
@@ -83,6 +83,50 @@ let duniverse =
   [ pkg "ocaml-dune" "dune-bench" ]
 
 let prepare_workspace () =
+  Fiber.parallel_iter duniverse ~f:(fun (pkg : Package.t) ->
+      Fpath.rm_rf pkg.name;
+      Format.eprintf "cloning %s/%s@." pkg.org pkg.name;
+      Package.clone pkg)
+
+let with_timer f =
+  let start = Unix.time () in
+  let res = f () in
+  let stop = Unix.time () in
+  (stop -. start, res)
+
+let dune_build () =
+  let stdin_from = Process.(Io.null In) in
+  let stdout_to = Process.(Io.file Config.dev_null Out) in
+  let stderr_to = Process.(Io.file Config.dev_null Out) in
+  let start = Unix.time () in
+  let open Fiber.O in
+  let+ () =
+    Process.run Strict (Lazy.force dune) ~stdin_from ~stdout_to ~stderr_to
+      [ "build"; "@install"; "--root"; "." ]
+  in
+  let stop = Unix.time () in
+  stop -. start
+
+let run_bench () =
+  let open Fiber.O in
+  let* clean = dune_build () in
+  let+ zero =
+    let open Fiber.O in
+    let rec zero acc n =
+      if n = 0 then
+        Fiber.return (List.rev acc)
+      else
+        let* time = dune_build () in
+        zero (time :: acc) (pred n)
+    in
+    zero [] 5
+  in
+  (clean, zero)
+
+let () =
+  Dune_util.Log.init ~file:No_log_file ();
+  let dir = Temp.create Dir ~prefix:"dune." ~suffix:".bench" in
+  Sys.chdir (Path.to_string dir);
   let module Scheduler = Dune_engine.Scheduler in
   let config =
     { Scheduler.Config.concurrency = 10
@@ -91,42 +135,22 @@ let prepare_workspace () =
     ; stats = None
     }
   in
-  Scheduler.Run.go config
-    ~on_event:(fun _ _ -> ())
-    (fun () ->
-      Fiber.parallel_iter duniverse ~f:(fun (pkg : Package.t) ->
-          Fpath.rm_rf pkg.name;
-          Format.eprintf "cloning %s/%s@." pkg.org pkg.name;
-          Package.clone pkg))
-
-let with_timer f =
-  let start = Unix.time () in
-  let res = f () in
-  let stop = Unix.time () in
-  (stop -. start, res)
-
-let () =
-  Dune_util.Log.init ~file:No_log_file ();
-  let dir = Temp.create Dir ~prefix:"dune." ~suffix:".bench" in
-  Sys.chdir (Path.to_string dir);
-  prepare_workspace ();
-  let clean, _ =
-    with_timer (fun () -> Sys.command "dune build @install --root . 1>&2")
+  let clean, zero =
+    Scheduler.Run.go config
+      ~on_event:(fun _ _ -> ())
+      (fun () ->
+        let open Fiber.O in
+        let* () = prepare_workspace () in
+        run_bench ())
   in
-  let zeros =
-    List.init 5 ~f:(fun _ ->
-        let time, _ =
-          with_timer (fun () -> Sys.command "dune build @install --root . 1>&2")
-        in
-        `Float time)
-  in
+  let zero = List.map zero ~f:(fun t -> `Float t) in
   let size =
     let stat : Unix.stats = Path.stat_exn (Lazy.force dune) in
     stat.st_size
   in
   let results =
     [ { Output.name = "clean_build"; metrics = [ ("time", `Float clean) ] }
-    ; { Output.name = "zero_build"; metrics = [ ("time", `List zeros) ] }
+    ; { Output.name = "zero_build"; metrics = [ ("time", `List zero) ] }
     ; { Output.name = "dune_size"; metrics = [ ("size", `Int size) ] }
     ]
   in

--- a/otherlibs/stdune-unstable/dune
+++ b/otherlibs/stdune-unstable/dune
@@ -10,4 +10,4 @@
   dune_filesystem_stubs)
  (foreign_stubs
   (language c)
-  (names fcntl_stubs)))
+  (names fcntl_stubs wait3_stubs)))

--- a/otherlibs/stdune-unstable/proc.ml
+++ b/otherlibs/stdune-unstable/proc.ml
@@ -22,3 +22,18 @@ let restore_cwd_and_execve prog argv ~env =
     Stdlib.do_at_exit ();
     Unix.execve prog argv env
   )
+
+type resource_usage =
+  { utime : float
+  ; stime : float
+  }
+
+external stub_wait3 :
+  Unix.wait_flag list -> int * Unix.process_status * resource_usage
+  = "dune_wait3"
+
+let wait3 flags =
+  if Sys.win32 then
+    Code_error.raise "wait3 not available on windows" []
+  else
+    stub_wait3 flags

--- a/otherlibs/stdune-unstable/proc.mli
+++ b/otherlibs/stdune-unstable/proc.mli
@@ -1,8 +1,30 @@
 val restore_cwd_and_execve : string -> string list -> env:Env.t -> _
 
-type resource_usage =
-  { utime : float
-  ; stime : float
-  }
+module Resource_usage : sig
+  type t =
+    { user_cpu_time : float
+          (** Same as the "user" time reported by the "time" command *)
+    ; system_cpu_time : float
+          (** Same as the "sys" time reported by the "time" command *)
+    }
+end
 
-val wait3 : Unix.wait_flag list -> int * Unix.process_status * resource_usage
+module Times : sig
+  type t =
+    { elapsed_time : float
+          (** Same as the "real" time reported by the "time" command *)
+    ; resource_usage : Resource_usage.t option
+    }
+end
+
+module Process_info : sig
+  type t =
+    { pid : Pid.t
+    ; status : Unix.process_status
+    ; end_time : float  (** Time at which the process finished. *)
+    ; resource_usage : Resource_usage.t option
+    }
+end
+
+(** This function is not implemented on Windows *)
+val wait : Unix.wait_flag list -> Process_info.t

--- a/otherlibs/stdune-unstable/proc.mli
+++ b/otherlibs/stdune-unstable/proc.mli
@@ -1,1 +1,8 @@
 val restore_cwd_and_execve : string -> string list -> env:Env.t -> _
+
+type resource_usage =
+  { utime : float
+  ; stime : float
+  }
+
+val wait3 : Unix.wait_flag list -> int * Unix.process_status * resource_usage

--- a/otherlibs/stdune-unstable/wait3_stubs.c
+++ b/otherlibs/stdune-unstable/wait3_stubs.c
@@ -1,0 +1,73 @@
+#include <caml/mlvalues.h>
+
+#ifdef _WIN32
+#include <caml/fail.h>
+
+void dune_wait3(value flags) {
+  caml_failwith("wait3: not supported on windows");
+}
+
+#else
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include <caml/unixsupport.h>
+
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#define TAG_WEXITED 0
+#define TAG_WSIGNALED 1
+#define TAG_WSTOPPED 2
+
+CAMLextern int caml_convert_signal_number(int);
+CAMLextern int caml_rev_convert_signal_number(int);
+
+static value alloc_process_status(int status) {
+  value st;
+
+  if (WIFEXITED(status)) {
+    st = caml_alloc_small(1, TAG_WEXITED);
+    Field(st, 0) = Val_int(WEXITSTATUS(status));
+  } else if (WIFSTOPPED(status)) {
+    st = caml_alloc_small(1, TAG_WSTOPPED);
+    Field(st, 0) = Val_int(caml_rev_convert_signal_number(WSTOPSIG(status)));
+  } else {
+    st = caml_alloc_small(1, TAG_WSIGNALED);
+    Field(st, 0) = Val_int(caml_rev_convert_signal_number(WTERMSIG(status)));
+  }
+  return st;
+}
+
+static int wait_flag_table[] = {WNOHANG, WUNTRACED};
+
+value dune_wait3(value flags) {
+  CAMLparam1(flags);
+  CAMLlocal2(times, res);
+
+  int pid, status, cv_flags;
+  cv_flags = caml_convert_flag_list(flags, wait_flag_table);
+
+  struct rusage ru;
+
+  caml_enter_blocking_section();
+  pid = wait3(&status, cv_flags, &ru);
+  caml_leave_blocking_section();
+  if (pid == -1)
+    uerror("wait3", Nothing);
+
+  times = caml_alloc_small(2 * Double_wosize, Double_array_tag);
+  Store_double_field(times, 0, ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6);
+  Store_double_field(times, 1, ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
+
+  res = caml_alloc_tuple(3);
+  Store_field(res, 0, Val_int(pid));
+  Store_field(res, 1, alloc_process_status(status));
+  Store_field(res, 2, times);
+  CAMLreturn(res);
+}
+
+#endif

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -69,6 +69,17 @@ val run :
   -> string list
   -> 'a Fiber.t
 
+val run_with_times :
+     ?dir:Path.t
+  -> ?stdout_to:Io.output Io.t
+  -> ?stderr_to:Io.output Io.t
+  -> ?stdin_from:Io.input Io.t
+  -> ?env:Env.t
+  -> ?purpose:purpose
+  -> Path.t
+  -> string list
+  -> Proc.Times.t Fiber.t
+
 (** Run a command and capture its output *)
 val run_capture :
      ?dir:Path.t

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -52,7 +52,7 @@ end
 
 type job =
   { pid : Pid.t
-  ; ivar : (Unix.process_status * Proc.resource_usage option) Fiber.Ivar.t
+  ; ivar : Proc.Process_info.t Fiber.Ivar.t
   }
 
 module Signal = struct
@@ -113,7 +113,7 @@ end
 module Event : sig
   type t =
     | Files_changed of Path.t list
-    | Job_completed of job * Unix.process_status * Proc.resource_usage option
+    | Job_completed of job * Proc.Process_info.t
     | Signal of Signal.t
     | Rpc of Fiber.fill
 
@@ -150,27 +150,23 @@ module Event : sig
     (** Send an event to the main thread. *)
     val send_files_changed : t -> Path.t list -> unit
 
-    val send_job_completed :
-      t -> job -> Unix.process_status -> Proc.resource_usage option -> unit
+    val send_job_completed : t -> job -> Proc.Process_info.t -> unit
 
     val send_signal : t -> Signal.t -> unit
 
     val send_sync_task : t -> (unit -> unit) -> unit
-
-    val track_resources : t -> bool
   end
   with type event := t
 end = struct
   type t =
     | Files_changed of Path.t list
-    | Job_completed of job * Unix.process_status * Proc.resource_usage option
+    | Job_completed of job * Proc.Process_info.t
     | Signal of Signal.t
     | Rpc of Fiber.fill
 
   module Queue = struct
     type t =
-      { jobs_completed :
-          (job * Unix.process_status * Proc.resource_usage option) Queue.t
+      { jobs_completed : (job * Proc.Process_info.t) Queue.t
       ; sync_tasks : (unit -> unit) Queue.t
       ; mutable files_changed : Path.t list
       ; mutable signals : Signal.Set.t
@@ -260,10 +256,10 @@ end = struct
               | None ->
                 q.pending_rpc <- q.pending_rpc - 1;
                 Rpc (Queue.pop_exn q.rpc_completed)
-              | Some (job, status, resource_usage) ->
+              | Some (job, proc_info) ->
                 q.pending_jobs <- q.pending_jobs - 1;
                 assert (q.pending_jobs >= 0);
-                Job_completed (job, status, resource_usage))
+                Job_completed (job, proc_info))
             | fns -> (
               q.files_changed <- [];
               let files =
@@ -298,10 +294,10 @@ end = struct
       if not avail then Condition.signal q.cond;
       Mutex.unlock q.mutex
 
-    let send_job_completed q job status resource_usage =
+    let send_job_completed q job proc_info =
       Mutex.lock q.mutex;
       let avail = available q in
-      Queue.push q.jobs_completed (job, status, resource_usage);
+      Queue.push q.jobs_completed (job, proc_info);
       if not avail then Condition.signal q.cond;
       Mutex.unlock q.mutex
 
@@ -322,8 +318,6 @@ end = struct
     let pending_jobs q = q.pending_jobs
 
     let pending_rpc q = q.pending_rpc
-
-    let track_resources q = Option.is_some q.stats
   end
 end
 
@@ -506,7 +500,7 @@ module Process_watcher : sig
 end = struct
   type process_state =
     | Running of job
-    | Zombie of Unix.process_status
+    | Zombie of Proc.Process_info.t
 
   (* This mutable table is safe: it does not interact with the state we track in
      the build system. *)
@@ -521,12 +515,7 @@ end = struct
   module Process_table : sig
     val add : t -> job -> unit
 
-    val remove :
-         t
-      -> pid:Pid.t
-      -> Unix.process_status
-      -> Proc.resource_usage option
-      -> unit
+    val remove : t -> Proc.Process_info.t -> unit
 
     val running_count : t -> int
 
@@ -538,18 +527,18 @@ end = struct
         Table.set t.table job.pid (Running job);
         t.running_count <- t.running_count + 1;
         if t.running_count = 1 then Condition.signal t.something_is_running
-      | Some (Zombie status) ->
+      | Some (Zombie proc_info) ->
         Table.remove t.table job.pid;
-        Event.Queue.send_job_completed t.events job status None
+        Event.Queue.send_job_completed t.events job proc_info
       | Some (Running _) -> assert false
 
-    let remove t ~pid status ru =
-      match Table.find t.table pid with
-      | None -> Table.set t.table pid (Zombie status)
+    let remove t (proc_info : Proc.Process_info.t) =
+      match Table.find t.table proc_info.pid with
+      | None -> Table.set t.table proc_info.pid (Zombie proc_info)
       | Some (Running job) ->
         t.running_count <- t.running_count - 1;
-        Table.remove t.table pid;
-        Event.Queue.send_job_completed t.events job status ru
+        Table.remove t.table proc_info.pid;
+        Event.Queue.send_job_completed t.events job proc_info
       | Some (Zombie _) -> assert false
 
     let iter t ~f =
@@ -574,19 +563,28 @@ end = struct
         | Unix.Unix_error _ -> ());
     Mutex.unlock t.mutex
 
-  exception Finished of job * Unix.process_status
+  exception Finished of Proc.Process_info.t
 
   let wait_nonblocking_win32 t =
     try
       Process_table.iter t ~f:(fun job ->
           let pid, status = Unix.waitpid [ WNOHANG ] (Pid.to_int job.pid) in
-          if pid <> 0 then raise_notrace (Finished (job, status)));
+          if pid <> 0 then
+            let now = Unix.gettimeofday () in
+            let info : Proc.Process_info.t =
+              { pid = Pid.of_int pid
+              ; status
+              ; end_time = now
+              ; resource_usage = None
+              }
+            in
+            raise_notrace (Finished info));
       false
     with
-    | Finished (job, status) ->
+    | Finished proc_info ->
       (* We need to do the [Unix.waitpid] and remove the process while holding
          the lock, otherwise the pid might be reused in between. *)
-      Process_table.remove t ~pid:job.pid status None;
+      Process_table.remove t proc_info;
       true
 
   let wait_win32 t =
@@ -598,17 +596,9 @@ end = struct
 
   let wait_unix t =
     Mutex.unlock t.mutex;
-    let pid, status, resource_usage =
-      if Event.Queue.track_resources t.events then
-        let pid, status, ru = Proc.wait3 [] in
-        (pid, status, Some ru)
-      else
-        let pid, status = Unix.wait () in
-        (pid, status, None)
-    in
+    let proc_info = Proc.wait [] in
     Mutex.lock t.mutex;
-    let pid = Pid.of_int pid in
-    Process_table.remove t ~pid status resource_usage
+    Process_table.remove t proc_info
 
   let wait =
     if Sys.win32 then
@@ -864,8 +854,7 @@ end = struct
     else (
       t.handler t.config Tick;
       match Event.Queue.next t.events with
-      | Job_completed (job, status, resource_usage) ->
-        Fiber.Fill (job.ivar, (status, resource_usage))
+      | Job_completed (job, proc_info) -> Fiber.Fill (job.ivar, proc_info)
       | Files_changed changed_files -> (
         (* CR-someday amokhov: In addition to tracking files, we also need to
            track directory listings. Otherwise, when a new file is added to a

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -80,8 +80,7 @@ val t : unit -> t Fiber.t
 val with_job_slot : (Config.t -> 'a Fiber.t) -> 'a Fiber.t
 
 (** Wait for the following process to terminate *)
-val wait_for_process :
-  Pid.t -> (Unix.process_status * Proc.resource_usage option) Fiber.t
+val wait_for_process : Pid.t -> Proc.Process_info.t Fiber.t
 
 (** Wait for dune cache to be disconnected. Drop any other event. *)
 val wait_for_dune_cache : unit -> unit

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -80,7 +80,8 @@ val t : unit -> t Fiber.t
 val with_job_slot : (Config.t -> 'a Fiber.t) -> 'a Fiber.t
 
 (** Wait for the following process to terminate *)
-val wait_for_process : Pid.t -> Unix.process_status Fiber.t
+val wait_for_process :
+  Pid.t -> (Unix.process_status * Proc.resource_usage option) Fiber.t
 
 (** Wait for dune cache to be disconnected. Drop any other event. *)
 val wait_for_dune_cache : unit -> unit

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -2,17 +2,12 @@
 
 This captures the commands that are being run:
 
-  $ <trace.json grep '"[be]"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g'
-  {"args":{"process_args":["-config"]},"ph":"b","id":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"ph":"e","id":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-modules","-impl","prog.ml"]},"ph":"b","id":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"ph":"e","id":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]},"ph":"b","id":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"ph":"e","id":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]},"ph":"b","id":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"ph":"e","id":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]},"ph":"b","id":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"ph":"e","id":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g'
+  {"args":{"process_args":["-config"]},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-modules","-impl","prog.ml"]},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"]},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"]},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"]},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
 
 As well as data about the garbage collector:
 


### PR DESCRIPTION
We fallback to the old method on win32.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>