### PR TITLE
Suppress stderr output for current-bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ ifeq (dune,$(firstword $(MAKECMDGOALS)))
 endif
 
 bench:
-	@dune exec -- ./bench/bench.exe
+	@dune exec -- ./bench/bench.exe 2> /dev/null
 
 dune: $(BIN)
 	$(BIN) $(RUN_ARGS)


### PR DESCRIPTION
Current-bench expects only json as output from the `make bench` target as of now, so any extraneous output will cause it to fail. Suppressing the stderr output for now to make it pass.