### PR TITLE
Make [Temp.temp_path] safe again and document why

### DIFF
--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -102,13 +102,6 @@ let clear_dir dir =
 
 let temp_path =
   try_paths 1000 ~f:(fun candidate ->
-      if Path.exists candidate then
-        Error `Retry
-      else
-        Ok candidate)
-
-let temp_file =
-  try_paths 1000 ~f:(fun candidate ->
       Result.map (create_temp_file candidate) ~f:(fun () -> candidate))
 
 let temp_dir ~parent_dir ~prefix ~suffix =
@@ -122,7 +115,7 @@ module Monad (M : sig
 end) =
 struct
   let with_temp_path ~dir ~prefix ~suffix ~f =
-    match temp_file ~dir ~prefix ~suffix with
+    match temp_path ~dir ~prefix ~suffix with
     | exception e -> f (Error e)
     | temp_path ->
       M.protect

--- a/otherlibs/stdune-unstable/temp.mli
+++ b/otherlibs/stdune-unstable/temp.mli
@@ -20,16 +20,17 @@ val destroy : what -> Path.t -> unit
     itself. *)
 val clear_dir : Path.t -> unit
 
-(** [temp_path ~dir ~prefix ~suffix] generates a temporary path in [dir]. The
-    base name of the temporary file is formed by concatenating [prefix], then a
-    suitably chosen integer number, then [suffix]. Note that the path isn't
-    actually created. *)
+(** [temp_path ~dir ~prefix ~suffix] creates a temporary file in [dir]. The base
+    name of the file is formed by concatenating [prefix], then a suitably chosen
+    integer number, then [suffix]. Note that the file must be created to reserve
+    the name in [dir] and prevent other processes from taking it concurrently.
+    If you need a temporary file that does not exist on disk, you can create a
+    temporary directory and safely use any file name there. *)
 val temp_path : dir:Path.t -> prefix:string -> suffix:string -> Path.t
 
-(** Like [temp_path], but creates and passes the temporary file to the callback
-    [f], and makes sure the temporary file is deleted when [f] completes. If [f]
-    raises an exception, the exception is reraised (and the file is still
-    deleted). *)
+(** Like [temp_path], but passes the temporary file to the callback [f], and
+    makes sure the temporary file is deleted when [f] completes. If [f] raises
+    an exception, the exception is re-raised (and the file is still deleted). *)
 val with_temp_path :
      dir:Path.t
   -> prefix:string

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -78,7 +78,7 @@ let clients_dir =
 
 let client_address () =
   let dir = Lazy.force clients_dir |> Path.build in
-  ignore (Fpath.mkdir_p (Path.to_string dir) : Fpath.mkdir_p_result);
+  Path.mkdir_p dir;
   Temp.temp_path ~dir ~prefix:"" ~suffix:".client" |> Path.as_in_build_dir_exn
 
 let waiting_clients scheduler =

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -77,9 +77,9 @@ let clients_dir =
     (Path.Build.relative (Lazy.force Dune_rpc_private.Where.rpc_dir) "clients")
 
 let client_address () =
-  let dir = Lazy.force clients_dir in
-  Temp.temp_path ~dir:(Path.build dir) ~prefix:"" ~suffix:".client"
-  |> Path.as_in_build_dir_exn
+  let dir = Lazy.force clients_dir |> Path.build in
+  ignore (Fpath.mkdir_p (Path.to_string dir) : Fpath.mkdir_p_result);
+  Temp.temp_path ~dir ~prefix:"" ~suffix:".client" |> Path.as_in_build_dir_exn
 
 let waiting_clients scheduler =
   let waiting = Path.build (Lazy.force clients_dir) in


### PR DESCRIPTION
@rgrinberg This PR essentially reverts this commit: https://github.com/ocaml/dune/commit/653462ad1213119597d2a9f157f70892765f23e3.

We recently changed the behaviour of `temp_path` because the behaviour that the above commit restores is unsafe: if you call `temp_path` concurrently, you may end up getting the same path as a result, because you don't "reserve" the path in any way. As a result, multiple processes may interfere by using the same temporary file. Since it's impossible to use such API safely, it seems better to not provide it at all.

I expanded the comment to make it clearer why the temporary files must be created and what to do if the call site doesn't want them to exist -- create a temporary directory and use any path inside, which is safe.

Note that `client_address` that was relying on this behaviour in a test was just silently failing to create a temporary path because the given directory didn't exist, so I changed it to create that directory. (I couldn't just leave it as is, because unlike the file existence check, creating a file does not fail silently.) The rest of the logic seems to cope fine with existing temporary files.