### PR TITLE
Make names containing "path" less ambiguous

### DIFF
--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -100,12 +100,12 @@ let clear_dir dir =
   remove_from_set ~set:tmp_files;
   remove_from_set ~set:tmp_dirs
 
-let temp_path =
+let temp_file =
   try_paths 1000 ~f:(fun candidate ->
       Result.map (create_temp_file candidate) ~f:(fun () -> candidate))
 
-let temp_dir ~parent_dir ~prefix ~suffix =
-  try_paths 1000 ~dir:parent_dir ~prefix ~suffix ~f:(fun candidate ->
+let temp_dir ~parent_dir =
+  try_paths 1000 ~dir:parent_dir ~f:(fun candidate ->
       Result.map (create_temp_dir candidate) ~f:(fun () -> candidate))
 
 module Monad (M : sig
@@ -114,13 +114,13 @@ module Monad (M : sig
   val protect : f:(unit -> 'a t) -> finally:(unit -> unit) -> 'a t
 end) =
 struct
-  let with_temp_path ~dir ~prefix ~suffix ~f =
-    match temp_path ~dir ~prefix ~suffix with
+  let with_temp_file ~dir ~prefix ~suffix ~f =
+    match temp_file ~dir ~prefix ~suffix with
     | exception e -> f (Error e)
-    | temp_path ->
+    | temp_file ->
       M.protect
-        ~f:(fun () -> f (Ok temp_path))
-        ~finally:(fun () -> Path.unlink_no_err temp_path)
+        ~f:(fun () -> f (Ok temp_file))
+        ~finally:(fun () -> Path.unlink_no_err temp_file)
 
   let with_temp_dir ~parent_dir ~prefix ~suffix ~f =
     match temp_dir ~parent_dir ~prefix ~suffix with
@@ -137,6 +137,6 @@ module Id = Monad (struct
   let protect = Exn.protect
 end)
 
-let with_temp_path = Id.with_temp_path
+let with_temp_file = Id.with_temp_file
 
 let with_temp_dir = Id.with_temp_dir

--- a/otherlibs/stdune-unstable/temp.mli
+++ b/otherlibs/stdune-unstable/temp.mli
@@ -20,25 +20,25 @@ val destroy : what -> Path.t -> unit
     itself. *)
 val clear_dir : Path.t -> unit
 
-(** [temp_path ~dir ~prefix ~suffix] creates a temporary file in [dir]. The base
+(** [temp_file ~dir ~prefix ~suffix] creates a temporary file in [dir]. The base
     name of the file is formed by concatenating [prefix], then a suitably chosen
     integer number, then [suffix]. Note that the file must be created to reserve
     the name in [dir] and prevent other processes from taking it concurrently.
     If you need a temporary file that does not exist on disk, you can create a
     temporary directory and safely use any file name there. *)
-val temp_path : dir:Path.t -> prefix:string -> suffix:string -> Path.t
+val temp_file : dir:Path.t -> prefix:string -> suffix:string -> Path.t
 
-(** Like [temp_path], but passes the temporary file to the callback [f], and
+(** Like [temp_file], but passes the temporary file to the callback [f], and
     makes sure the temporary file is deleted when [f] completes. If [f] raises
     an exception, the exception is re-raised (and the file is still deleted). *)
-val with_temp_path :
+val with_temp_file :
      dir:Path.t
   -> prefix:string
   -> suffix:string
   -> f:(Path.t Or_exn.t -> 'a)
   -> 'a
 
-(** Like [with_temp_path], but creates a temporary directory. *)
+(** Like [with_temp_file], but creates a temporary directory. *)
 val with_temp_dir :
      parent_dir:Path.t
   -> prefix:string
@@ -46,7 +46,7 @@ val with_temp_dir :
   -> f:(Path.t Or_exn.t -> 'a)
   -> 'a
 
-(** Versions of [with_temp_path] and [with_temp_dir] that are suitable for use
+(** Versions of [with_temp_file] and [with_temp_dir] that are suitable for use
     with concurrency monads. *)
 module Monad (M : sig
   type 'a t
@@ -54,7 +54,7 @@ module Monad (M : sig
   (** Like [Exn.protect] but lifted to [M]. *)
   val protect : f:(unit -> 'a t) -> finally:(unit -> unit) -> 'a t
 end) : sig
-  val with_temp_path :
+  val with_temp_file :
        dir:Path.t
     -> prefix:string
     -> suffix:string

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -58,12 +58,11 @@ end
 let link_even_if_there_are_too_many_links_already ~src ~dst =
   try Path.link src dst with
   | Unix.Unix_error (Unix.EMLINK, _, _) ->
-    Temp.with_temp_path ~dir:temp_path ~prefix:"dune" ~suffix:"copy"
-      ~f:(function
+    Temp.with_temp_file ~dir:temp_dir ~prefix:"dune" ~suffix:"copy" ~f:(function
       | Error e -> raise e
-      | Ok temp_path ->
-        Io.copy_file ~src ~dst:temp_path ();
-        Path.rename temp_path dst;
+      | Ok temp_file ->
+        Io.copy_file ~src ~dst:temp_file ();
+        Path.rename temp_file dst;
         Path.link src dst)
 
 module Artifacts = struct

--- a/src/dune_cache_storage/dune_cache_storage.ml
+++ b/src/dune_cache_storage/dune_cache_storage.ml
@@ -303,8 +303,8 @@ module Temp = Temp.Monad (struct
     Fiber.finalize f ~finally:(fun () -> finally () |> Fiber.return)
 end)
 
-let with_temp_path ?(prefix = "dune") ~suffix f =
-  Temp.with_temp_path ~dir:Layout.temp_path ~prefix ~suffix ~f
+let with_temp_file ?(prefix = "dune") ~suffix f =
+  Temp.with_temp_file ~dir:Layout.temp_dir ~prefix ~suffix ~f
 
 let with_temp_dir ?(prefix = "dune") ~suffix f =
-  Temp.with_temp_dir ~parent_dir:Layout.temp_path ~prefix ~suffix ~f
+  Temp.with_temp_dir ~parent_dir:Layout.temp_dir ~prefix ~suffix ~f

--- a/src/dune_cache_storage/dune_cache_storage.mli
+++ b/src/dune_cache_storage/dune_cache_storage.mli
@@ -110,18 +110,18 @@ module Metadata : sig
   end
 end
 
-(** [with_temp_path ?prefix ~suffix f] creates a file in [Layout.temp_path],
-    then passes it to the callback [f], and makes sure the file is deleted when
-    [f] completes or raises. The base name of the temporary file is formed by
+(** [with_temp_file ?prefix ~suffix f] creates a file in [Layout.temp_dir], then
+    passes it to the callback [f], and makes sure the file is deleted when [f]
+    completes or raises. The base name of the temporary file is formed by
     concatenating the [prefix] (which is set to "dune" by default), then a
     suitably chosen integer number, then [suffix]. *)
-val with_temp_path :
+val with_temp_file :
      ?prefix:string
   -> suffix:string
   -> (Path.t Or_exn.t -> 'a Fiber.t)
   -> 'a Fiber.t
 
-(** Like [with_temp_path] but creates a directory in [Layout.temp_path]. *)
+(** Like [with_temp_file] but creates a directory in [Layout.temp_dir]. *)
 val with_temp_dir :
      ?prefix:string
   -> suffix:string

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -1,14 +1,14 @@
 open Stdune
 
-let default_root_path () =
+let default_root_dir () =
   Path.L.relative
     (Path.of_filename_relative_to_initial_cwd Xdg.cache_dir)
     [ "dune"; "db" ]
 
-let root_path =
+let root_dir =
   let var = "DUNE_CACHE_ROOT" in
   match Sys.getenv_opt var with
-  | None -> default_root_path ()
+  | None -> default_root_dir ()
   | Some path ->
     if Filename.is_relative path then
       failwith (sprintf "%s should be an absolute path, but is %s" var path);
@@ -16,7 +16,7 @@ let root_path =
 
 let ( / ) = Path.relative
 
-let temp_path = root_path / "temp"
+let temp_dir = root_dir / "temp"
 
 let cache_path ~dir ~hex =
   let two_first_chars = sprintf "%c%c" hex.[0] hex.[1] in
@@ -48,48 +48,47 @@ let list_entries ~storage =
   | Error e -> User_error.raise [ Pp.text (Unix.error_message e) ]
 
 module Versioned = struct
-  let metadata_storage_path t =
-    root_path / "meta" / Version.Metadata.to_string t
+  let metadata_storage_dir t = root_dir / "meta" / Version.Metadata.to_string t
 
-  let file_storage_path t = root_path / "files" / Version.File.to_string t
+  let file_storage_dir t = root_dir / "files" / Version.File.to_string t
 
-  let value_storage_path t = root_path / "values" / Version.Value.to_string t
+  let value_storage_dir t = root_dir / "values" / Version.Value.to_string t
 
   let metadata_path t =
-    let dir = metadata_storage_path t in
+    let dir = metadata_storage_dir t in
     fun ~rule_or_action_digest ->
       cache_path ~dir ~hex:(Digest.to_string rule_or_action_digest)
 
   let file_path t =
-    let dir = file_storage_path t in
+    let dir = file_storage_dir t in
     fun ~file_digest -> cache_path ~dir ~hex:(Digest.to_string file_digest)
 
   let value_path t =
-    let dir = value_storage_path t in
+    let dir = value_storage_dir t in
     fun ~value_digest -> cache_path ~dir ~hex:(Digest.to_string value_digest)
 
-  let list_metadata_entries t = list_entries ~storage:(metadata_storage_path t)
+  let list_metadata_entries t = list_entries ~storage:(metadata_storage_dir t)
 
-  let list_file_entries t = list_entries ~storage:(file_storage_path t)
+  let list_file_entries t = list_entries ~storage:(file_storage_dir t)
 
-  let list_value_entries t = list_entries ~storage:(value_storage_path t)
+  let list_value_entries t = list_entries ~storage:(value_storage_dir t)
 end
 
-let metadata_storage_path =
-  Versioned.metadata_storage_path Version.Metadata.current
+let metadata_storage_dir =
+  Versioned.metadata_storage_dir Version.Metadata.current
 
 let metadata_path = Versioned.metadata_path Version.Metadata.current
 
-let file_storage_path = Versioned.file_storage_path Version.File.current
+let file_storage_dir = Versioned.file_storage_dir Version.File.current
 
 let file_path = Versioned.file_path Version.File.current
 
-let value_storage_path = Versioned.value_storage_path Version.Value.current
+let value_storage_dir = Versioned.value_storage_dir Version.Value.current
 
 let value_path = Versioned.value_path Version.Value.current
 
 let create_cache_directories () =
   List.iter
-    [ temp_path; metadata_storage_path; file_storage_path; value_storage_path ]
+    [ temp_dir; metadata_storage_dir; file_storage_dir; value_storage_dir ]
     ~f:(fun path ->
       ignore (Fpath.mkdir_p (Path.to_string path) : Fpath.mkdir_p_result))

--- a/src/dune_cache_storage/layout.mli
+++ b/src/dune_cache_storage/layout.mli
@@ -7,13 +7,10 @@
 
 open Stdune
 
-(** The default path to the root directory of the cache. *)
-val default_root_path : unit -> Path.t
-
 (** The path to the root directory of the cache. *)
-val root_path : Path.t
+val root_dir : Path.t
 
-(** Create a few subdirectories in [root_path]. We expose this function because
+(** Create a few subdirectories in [root_dir]. We expose this function because
     we don't want to modify the file system when the cache is disabled. *)
 val create_cache_directories : unit -> unit
 
@@ -22,12 +19,13 @@ val create_cache_directories : unit -> unit
     model, in reality we need to occasionally remove some outdated metadata
     files to free disk space.)
 
-    A metadata file coresponding to a build rule is named by the rule digest and
-    stores file names and content digests of all artifacts produced by the rule.
+    A metadata file corresponding to a build rule is named by the rule digest
+    and stores file names and content digests of all artifacts produced by the
+    rule.
 
-    A metadata file coresponding to an output-producing action is named by the
+    A metadata file corresponding to an output-producing action is named by the
     action digest and stores the content digest of the resulting output. *)
-val metadata_storage_path : Path.t
+val metadata_storage_dir : Path.t
 
 (** Path to the metadata file corresponding to a build action or rule with the
     given [rule_or_action_digest]. *)
@@ -37,7 +35,7 @@ val metadata_path : rule_or_action_digest:Digest.t -> Path.t
     the matching contents. We will create hard links to these files from build
     directories and rely on the hard link count, as well as on the last access
     time as useful metrics during cache trimming. *)
-val file_storage_path : Path.t
+val file_storage_dir : Path.t
 
 (** Path to the artifact corresponding to a given [file_digest]. *)
 val file_path : file_digest:Digest.t -> Path.t
@@ -48,29 +46,29 @@ val file_path : file_digest:Digest.t -> Path.t
     digests. However, these files will always have the hard link count equal to
     one because they do not appear anywhere in build directories. By storing
     them in a separate directory, we simplify the job of the cache trimmer. *)
-val value_storage_path : Path.t
+val value_storage_dir : Path.t
 
 (** Path to the value corresponding to a given [value_digest]. *)
 val value_path : value_digest:Digest.t -> Path.t
 
 (** This directory contains temporary files used for atomic file operations
     needed when storing new artifacts in the cache. See [write_atomically]. *)
-val temp_path : Path.t
+val temp_dir : Path.t
 
 (** Support for all versions of the layout, used by the cache trimmer. The
     functions provided by the top module are obtained by a partial application
     of the corresponding function defined here to a suitable current version. *)
 module Versioned : sig
-  val metadata_storage_path : Version.Metadata.t -> Path.t
+  val metadata_storage_dir : Version.Metadata.t -> Path.t
 
   val metadata_path :
     Version.Metadata.t -> rule_or_action_digest:Digest.t -> Path.t
 
-  val file_storage_path : Version.File.t -> Path.t
+  val file_storage_dir : Version.File.t -> Path.t
 
   val file_path : Version.File.t -> file_digest:Digest.t -> Path.t
 
-  val value_storage_path : Version.Value.t -> Path.t
+  val value_storage_dir : Version.Value.t -> Path.t
 
   val value_path : Version.Value.t -> value_digest:Digest.t -> Path.t
 

--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -46,10 +46,10 @@ let add_atomically ~mode ~src ~dst : Write_result.t =
 
 (* CR-someday amokhov: Switch to [renameat2] to go from two operations to one. *)
 let write_atomically ~mode ~content dst : Write_result.t =
-  Temp.with_temp_path ~dir:Layout.temp_path ~prefix:"dune" ~suffix:"write"
+  Temp.with_temp_file ~dir:Layout.temp_dir ~prefix:"dune" ~suffix:"write"
     ~f:(function
     | Error e -> Write_result.Error e
-    | Ok temp_path -> (
-      match Io.write_file ~binary:false temp_path content with
+    | Ok temp_file -> (
+      match Io.write_file ~binary:false temp_file content with
       | exception e -> Error e
-      | () -> add_atomically ~mode ~src:temp_path ~dst))
+      | () -> add_atomically ~mode ~src:temp_file ~dst))

--- a/src/dune_cache_storage/util.mli
+++ b/src/dune_cache_storage/util.mli
@@ -7,7 +7,7 @@ module Write_result : sig
     | Error of exn
 end
 
-(** Write a given [content] to a temporary file in [Layout.temp_path], and then
+(** Write a given [content] to a temporary file in [Layout.temp_dir], and then
     atomically move it to a specified destination.
 
     If the destination already exists, return [Already_present].

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -59,7 +59,7 @@ let of_config config scheduler stats =
               | Some p -> p
               | None -> Filename.get_temp_dir_name ())
           in
-          Temp.temp_path ~dir ~prefix:"dune" ~suffix:""
+          Temp.temp_file ~dir ~prefix:"dune" ~suffix:""
         in
         Unix.symlink (Path.to_string socket)
           (let from = Path.external_ (Path.External.cwd ()) in
@@ -79,7 +79,7 @@ let clients_dir =
 let client_address () =
   let dir = Lazy.force clients_dir |> Path.build in
   Path.mkdir_p dir;
-  Temp.temp_path ~dir ~prefix:"" ~suffix:".client" |> Path.as_in_build_dir_exn
+  Temp.temp_file ~dir ~prefix:"" ~suffix:".client" |> Path.as_in_build_dir_exn
 
 let waiting_clients scheduler =
   let waiting = Path.build (Lazy.force clients_dir) in


### PR DESCRIPTION
Renaming `Temp.temp_path` and adjusting a few similar names, as suggested in #4519.