### PR TITLE
Start caching errors in Memo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,14 @@ Unreleased
 
 - Fix a crash when clearing temporary directories (#4489, #4529, Andrey Mokhov)
 
+- Dune now memoizes all errors when running in the file-watching mode. This
+  speeds up incremental rebuilds but may be inconvenient in rare cases, e.g. if
+  a build action fails due to a spurious error, such as running out of memory.
+  Right now, the only way to force such actions to be rebuilt is to restart
+  Dune, which clears all memoized errors. In future, we would like to provide a
+  way to rerun all actions failed due to errors without restarting the build,
+  e.g. via a Dune RPC call. (#4522, Andrey Mokhov)
+
 2.9.0 (unreleased)
 ------------------
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -1,5 +1,12 @@
 open! Stdune
 
+(* CR-someday amokhov: The current implementation memoizes all errors, which may
+   be inconvenient in rare cases, e.g. if a build action fails due to a spurious
+   error, such as running out of memory. Right now, the only way to force such
+   actions to be rebuilt is to restart Dune, which clears all memoized errors.
+   In future, we would like to provide a way to rerun all actions failed due to
+   errors without restarting the build, e.g. via a Dune RPC call. *)
+
 type 'a build
 
 module type Build = sig

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -972,34 +972,34 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
   evaluate_and_print summit_no_cutoff 0;
   [%expect
     {|
-    Started evaluating the summit with input 0
-    Started evaluating incrementing_chain_4_yes_cutoff
-    Started evaluating incrementing_chain_3_no_cutoff
+    Started evaluating base
+    Evaluated base: 3
     Started evaluating incrementing_chain_2_yes_cutoff
     Started evaluating incrementing_chain_1_no_cutoff
     Started evaluating cycle_creator_no_cutoff
-    Started evaluating base
-    Evaluated base: 3
     Evaluated cycle_creator_no_cutoff: 3
     Evaluated incrementing_chain_1_no_cutoff: 4
     Evaluated incrementing_chain_2_yes_cutoff: 5
+    Started evaluating incrementing_chain_4_yes_cutoff
+    Started evaluating incrementing_chain_3_no_cutoff
     Evaluated incrementing_chain_3_no_cutoff: 6
     Evaluated incrementing_chain_4_yes_cutoff: 7
+    Started evaluating the summit with input 0
     Evaluated the summit with input 0: 7
     f 0 = Ok 7 |}];
   evaluate_and_print summit_yes_cutoff 0;
   [%expect
     {|
-    Started evaluating the summit with input 0
-    Started evaluating incrementing_chain_4_no_cutoff
-    Started evaluating incrementing_chain_3_yes_cutoff
-    Started evaluating incrementing_chain_2_no_cutoff
-    Started evaluating incrementing_chain_1_yes_cutoff
     Started evaluating cycle_creator_yes_cutoff
     Evaluated cycle_creator_yes_cutoff: 3
+    Started evaluating incrementing_chain_1_yes_cutoff
     Evaluated incrementing_chain_1_yes_cutoff: 4
+    Started evaluating incrementing_chain_3_yes_cutoff
+    Started evaluating incrementing_chain_2_no_cutoff
     Evaluated incrementing_chain_2_no_cutoff: 5
     Evaluated incrementing_chain_3_yes_cutoff: 6
+    Started evaluating the summit with input 0
+    Started evaluating incrementing_chain_4_no_cutoff
     Evaluated incrementing_chain_4_no_cutoff: 7
     Evaluated the summit with input 0: 7
     f 0 = Ok 7 |}];
@@ -1403,7 +1403,6 @@ let%expect_test "error handling and duplicate exceptions" =
   in
   Fdecl.set f_impl (fun x ->
       printf "Calling f %d\n" x;
-
       match x with
       | 0 -> Memo.exec forward_fail x
       | 1 -> Memo.exec forward_fail2 x
@@ -1419,4 +1418,36 @@ let%expect_test "error handling and duplicate exceptions" =
     Calling f 1
     Calling f 0
     Error [ "(Failure 42)" ]
+    |}]
+
+let%expect_test "errors are cached" =
+  Printexc.record_backtrace false;
+  let f =
+    Memo.create_hidden "area of a square"
+      ~input:(module Int)
+      (fun x ->
+        printf "Started evaluating %d\n" x;
+        if x < 0 then failwith (sprintf "Negative input %d" x);
+        let res = x * x in
+        printf "Evaluated %d: %d\n" x res;
+        Memo.Build.return res)
+  in
+  evaluate_and_print f 5;
+  evaluate_and_print f (-5);
+  [%expect
+    {|
+    Started evaluating 5
+    Evaluated 5: 25
+    f 5 = Ok 25
+    Started evaluating -5
+    f -5 = Error [ { exn = "(Failure \"Negative input -5\")"; backtrace = "" } ]
+    |}];
+  evaluate_and_print f 5;
+  evaluate_and_print f (-5);
+  (* Note that we do not see any "Started evaluating" messages because both [Ok]
+     and [Error] results have been cached. *)
+  [%expect
+    {|
+    f 5 = Ok 25
+    f -5 = Error [ { exn = "(Failure \"Negative input -5\")"; backtrace = "" } ]
     |}]


### PR DESCRIPTION
Start to cache errors in Memo just like normal values.

We assume that all Memo computations are deterministic, which means if we rerun a computation that previously led to raising a set of errors, we expect to get the same set of errors back and we might as well skip the unnecessary work. The downside is that if a computation is non-deterministic, there is no way to force rerunning it, apart from changing some of its dependencies.

To use consistent terminology, I also renamed `Cache_lookup.Result.Error` to `Cache_lookup.Result.Failure`.
