### PR TITLE
Make `bench` a .PHONY target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ ifeq (dune,$(firstword $(MAKECMDGOALS)))
   $(eval $(RUN_ARGS):;@:)
 endif
 
+.PHONY: bench
 bench:
 	@dune exec -- ./bench/bench.exe 2> /dev/null
 


### PR DESCRIPTION
Currently, continous benchmarking fails with the error `make: Nothing to be done for target 'bench'`, adding a .PHONY target forces it to make bench everytime.