### PR TITLE
Document "using" and warn that it does not imply a software dependency

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -16,6 +16,26 @@ contents of all configuration files read by Dune and looks like:
 
 Additionally, they can contains the following stanzas.
 
+.. _using:
+
+using
+-----
+
+The language of configuration files read by Dune can be extended to support
+additional stanzas (eg. ``menhir``, ``coq.theory``, ``mdx``). This is done by
+adding a line such as:
+
+.. code:: scheme
+
+    (using <plugin> <version>)
+
+in the ``dune-project`` file where ``<plugin>`` is the name of the plugin that
+defines this stanza and ``<version>`` describes the version of the configuration
+language. Note that this version has nothing to do with the version of the
+associated tool or library. In particular, adding a ``using`` stanza will not
+result in a build dependency in the generated ``.opam`` file, see
+:ref:`generate_opam_files <generate_opam_files>`.
+
 name
 ----
 
@@ -208,6 +228,8 @@ where ``<setting>`` is one of:
 - ``(enabled_for <languages>)`` can be used to restrict the languages that are
   considered for formatting.
 
+.. _generate_opam_files:
+
 generate_opam_files
 -------------------
 
@@ -302,6 +324,10 @@ language: The syntax is as a list of the following elements:
         | (name (<logop> (<stage> | <constr>)*))
 
    dep-specification = dep+
+
+Note that the use of a ``using`` stanza (see :ref:`using <using>`) does not
+automatically add the associated library or tool as a dependency. They have to
+be added explicitly.
 
 .. _always-add-cflags:
 


### PR DESCRIPTION
I recently opened #4486 to discover that it was in fact not an issue but a lack of comprehension from my part. This PR attempts to help by:

- documenting the `using` stanza in its own subsection of the `Stanza reference > dune-project` file, and
- adding a note in `Stanza reference > dune-project > package`.

The goal is to make the documentation a bit clearer so that me-from-the-past (or anyone else in the same situation) realises that the version in `(using menhir <version>)` has nothing to do with the version of Menhir and everything to do with the version of the DSL under the `(menhir ...)` stanza. As a consequence, having `(using menhir <version>)` in one's `dune-project` file does not make Menhir a dependency of the project.

I added a section about the `using` stanza right after the `lang` stanza because I believe they are related, considering both describe the DSL that will be accepted in configuration files. I am however very fine moving this section elsewhere or removing it altogether.

I hope this helps!

fix #4486