### PR TITLE
Drop remaining references to visibility in Memo

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -12,9 +12,8 @@ module Fs : sig
   val assert_exists : loc:Loc.t -> Path.t -> unit Memo.Build.t
 end = struct
   let mkdir_p_def =
-    Memo.create "mkdir_p"
+    Memo.create_no_cutoff "mkdir_p"
       ~input:(module Path.Build)
-      ~output:(Simple (module Unit))
       (fun p ->
         Path.mkdir_p (Path.build p);
         Memo.Build.return ())
@@ -24,7 +23,7 @@ end = struct
   let assert_exists_def =
     Memo.create "assert_path_exists"
       ~input:(module Path)
-      ~output:(Simple (module Bool))
+      ~output:(No_cutoff (module Bool))
       (fun p -> Memo.Build.return (Path.exists p))
 
   let assert_exists ~loc path =
@@ -1137,7 +1136,7 @@ end = struct
   let load_dir =
     let load_dir_impl dir = load_dir_impl (t ()) ~dir in
     let memo =
-      Memo.create_hidden "load-dir" ~input:(module Path) load_dir_impl
+      Memo.create_no_cutoff "load-dir" ~input:(module Path) load_dir_impl
     in
     fun ~dir -> Memo.exec memo dir
 end
@@ -1923,7 +1922,7 @@ end = struct
     target
 
   let execute_action_generic_stage2_memo =
-    Memo.create_hidden "execute-action"
+    Memo.create_no_cutoff "execute-action"
       ~input:(module Action_desc)
       execute_action_generic_stage2_impl
 
@@ -2062,7 +2061,7 @@ end = struct
     let eval_memo =
       Memo.create "eval-pred"
         ~input:(module File_selector)
-        ~output:(Allow_cutoff (module Path.Set))
+        ~output:(Cutoff (module Path.Set))
         eval_impl
 
     let eval = Memo.exec eval_memo
@@ -2071,28 +2070,28 @@ end = struct
       Memo.exec
         (Memo.create "build-pred"
            ~input:(module File_selector)
-           ~output:(Allow_cutoff (module Dep.Fact.Files))
+           ~output:(Cutoff (module Dep.Fact.Files))
            build_impl)
   end
 
   let build_file_memo =
     Memo.create "build-file"
-      ~output:(Allow_cutoff (module Digest))
       ~input:(module Path)
+      ~output:(Cutoff (module Digest))
       build_file_impl
 
   let build_file = Memo.exec build_file_memo
 
   let build_alias_memo =
     Memo.create "build-alias"
-      ~output:(Allow_cutoff (module Dep.Fact.Files))
       ~input:(module Alias)
+      ~output:(Cutoff (module Dep.Fact.Files))
       build_alias_impl
 
   let build_alias = Memo.exec build_alias_memo
 
   let execute_rule_memo =
-    Memo.create_hidden "execute-rule"
+    Memo.create_no_cutoff "execute-rule"
       ~input:(module Rule)
       (execute_rule_impl ~rule_kind:Normal_rule)
 
@@ -2307,7 +2306,7 @@ end = struct
   end = struct
     let alias =
       let memo =
-        Memo.create_hidden "expand-alias"
+        Memo.create_no_cutoff "expand-alias"
           ~input:(module Alias)
           (fun alias ->
             let* l = expand_alias_gen alias ~eval_build_request in
@@ -2331,7 +2330,7 @@ end = struct
 
   let evaluate_rule =
     let memo =
-      Memo.create_hidden "evaluate-rule"
+      Memo.create_no_cutoff "evaluate-rule"
         ~input:(module Non_evaluated_rule)
         (fun rule ->
           let* action, deps = eval_build_request rule.action in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -12,6 +12,16 @@ module Fs : sig
   val assert_exists : loc:Loc.t -> Path.t -> unit Memo.Build.t
 end = struct
   let mkdir_p_def =
+    (* CR-someday amokhov: It's difficult to think about the correctness of this
+       memoized function. Right now, we never invalidate it, so if we delete a
+       stale build directory, we'll not be able to recreate it later. Perhaps,
+       we should create directories as part of running actions that need them.
+       That would be less efficient, as we'd call [mkdir] on the same directory
+       multiple times, but it would be easier to guarantee correctness.
+
+       Note: if we find a way to reliably invalidate this function, its output
+       should continue to have no cutoff because the callers might depend not
+       just on the existence of a directory but on its *continuous* existence. *)
     Memo.create_no_cutoff "mkdir_p"
       ~input:(module Path.Build)
       (fun p ->

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -5,9 +5,8 @@ open Memo.Build.O
 (* Files and directories have non-overlapping sets of paths, so we can track
    them using the same memoization table. *)
 let memo =
-  Memo.create "fs_memo"
+  Memo.create_no_cutoff "fs_memo"
     ~input:(module Path)
-    ~output:(Simple (module Unit))
     (fun _path -> Memo.Build.return ())
 
 (* Declare a dependency on a path. Instead of calling [depend] directly, you

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -616,7 +616,7 @@ end = struct
     let memo =
       Memo.create "find-dir-raw"
         ~input:(module Path.Source)
-        ~output:(Simple (module Output))
+        ~output:(No_cutoff (module Output))
         find_dir_raw_impl
     in
     Memo.cell memo
@@ -658,7 +658,7 @@ let execution_parameters_of_dir =
   let memo =
     Memo.create "execution-parameters-of-dir"
       ~input:(module Path.Source)
-      ~output:(Allow_cutoff (module Execution_parameters))
+      ~output:(Cutoff (module Execution_parameters))
       f
   in
   Memo.exec memo

--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -163,7 +163,7 @@ module Args = struct
 
   let memo t =
     let memo =
-      Memo.create_hidden "Command.Args.memo"
+      Memo.create_no_cutoff "Command.Args.memo"
         ~input:(module Path)
         (fun dir -> Memo.Build.return (expand_static ~dir t))
     in

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -64,82 +64,77 @@ module Program = struct
     List.find_map path ~f:(fun dir -> best_path dir program)
 end
 
-module T = struct
-  type t =
-    { name : Context_name.t
-    ; kind : Kind.t
-    ; profile : Profile.t
-    ; merlin : bool
-    ; fdo_target_exe : Path.t option
-    ; dynamically_linked_foreign_archives : bool
-    ; for_host : t option
-    ; implicit : bool
-    ; build_dir : Path.Build.t
-    ; env_nodes : Env_nodes.t
-    ; path : Path.t list
-    ; toplevel_path : Path.t option
-    ; ocaml_bin : Path.t
-    ; ocaml : Action.Prog.t
-    ; ocamlc : Path.t
-    ; ocamlopt : Action.Prog.t
-    ; ocamldep : Action.Prog.t
-    ; ocamlmklib : Action.Prog.t
-    ; ocamlobjinfo : Action.Prog.t
-    ; env : Env.t
-    ; findlib : Findlib.t
-    ; findlib_toolchain : Context_name.t option
-    ; default_ocamlpath : Path.t list
-    ; arch_sixtyfour : bool
-    ; ocaml_config : Ocaml_config.t
-    ; ocaml_config_vars : Ocaml_config.Vars.t
-    ; version : Ocaml_version.t
-    ; stdlib_dir : Path.t
-    ; supports_shared_libraries : Dynlink_supported.By_the_os.t
-    ; which : string -> Path.t option Memo.Build.t
-    ; lib_config : Lib_config.t
-    ; build_context : Build_context.t
-    }
+type t =
+  { name : Context_name.t
+  ; kind : Kind.t
+  ; profile : Profile.t
+  ; merlin : bool
+  ; fdo_target_exe : Path.t option
+  ; dynamically_linked_foreign_archives : bool
+  ; for_host : t option
+  ; implicit : bool
+  ; build_dir : Path.Build.t
+  ; env_nodes : Env_nodes.t
+  ; path : Path.t list
+  ; toplevel_path : Path.t option
+  ; ocaml_bin : Path.t
+  ; ocaml : Action.Prog.t
+  ; ocamlc : Path.t
+  ; ocamlopt : Action.Prog.t
+  ; ocamldep : Action.Prog.t
+  ; ocamlmklib : Action.Prog.t
+  ; ocamlobjinfo : Action.Prog.t
+  ; env : Env.t
+  ; findlib : Findlib.t
+  ; findlib_toolchain : Context_name.t option
+  ; default_ocamlpath : Path.t list
+  ; arch_sixtyfour : bool
+  ; ocaml_config : Ocaml_config.t
+  ; ocaml_config_vars : Ocaml_config.Vars.t
+  ; version : Ocaml_version.t
+  ; stdlib_dir : Path.t
+  ; supports_shared_libraries : Dynlink_supported.By_the_os.t
+  ; which : string -> Path.t option Memo.Build.t
+  ; lib_config : Lib_config.t
+  ; build_context : Build_context.t
+  }
 
-  let equal x y = Context_name.equal x.name y.name
+let equal x y = Context_name.equal x.name y.name
 
-  let hash t = Context_name.hash t.name
+let hash t = Context_name.hash t.name
 
-  let build_context t = t.build_context
+let build_context t = t.build_context
 
-  let to_dyn t : Dyn.t =
-    let open Dyn.Encoder in
-    let path = Path.to_dyn in
-    record
-      [ ("name", Context_name.to_dyn t.name)
-      ; ("kind", Kind.to_dyn t.kind)
-      ; ("profile", Profile.to_dyn t.profile)
-      ; ("merlin", Bool t.merlin)
-      ; ( "for_host"
-        , option Context_name.to_dyn
-            (Option.map t.for_host ~f:(fun t -> t.name)) )
-      ; ("fdo_target_exe", option path t.fdo_target_exe)
-      ; ("build_dir", Path.Build.to_dyn t.build_dir)
-      ; ("toplevel_path", option path t.toplevel_path)
-      ; ("ocaml_bin", path t.ocaml_bin)
-      ; ("ocaml", Action.Prog.to_dyn t.ocaml)
-      ; ("ocamlc", path t.ocamlc)
-      ; ("ocamlopt", Action.Prog.to_dyn t.ocamlopt)
-      ; ("ocamldep", Action.Prog.to_dyn t.ocamldep)
-      ; ("ocamlmklib", Action.Prog.to_dyn t.ocamlmklib)
-      ; ("env", Env.to_dyn (Env.diff t.env Env.initial))
-      ; ("findlib_path", list path (Findlib.paths t.findlib))
-      ; ("arch_sixtyfour", Bool t.arch_sixtyfour)
-      ; ( "natdynlink_supported"
-        , Bool
-            (Dynlink_supported.By_the_os.get t.lib_config.natdynlink_supported)
-        )
-      ; ( "supports_shared_libraries"
-        , Bool (Dynlink_supported.By_the_os.get t.supports_shared_libraries) )
-      ; ("ocaml_config", Ocaml_config.to_dyn t.ocaml_config)
-      ]
-end
-
-include T
+let to_dyn t : Dyn.t =
+  let open Dyn.Encoder in
+  let path = Path.to_dyn in
+  record
+    [ ("name", Context_name.to_dyn t.name)
+    ; ("kind", Kind.to_dyn t.kind)
+    ; ("profile", Profile.to_dyn t.profile)
+    ; ("merlin", Bool t.merlin)
+    ; ( "for_host"
+      , option Context_name.to_dyn (Option.map t.for_host ~f:(fun t -> t.name))
+      )
+    ; ("fdo_target_exe", option path t.fdo_target_exe)
+    ; ("build_dir", Path.Build.to_dyn t.build_dir)
+    ; ("toplevel_path", option path t.toplevel_path)
+    ; ("ocaml_bin", path t.ocaml_bin)
+    ; ("ocaml", Action.Prog.to_dyn t.ocaml)
+    ; ("ocamlc", path t.ocamlc)
+    ; ("ocamlopt", Action.Prog.to_dyn t.ocamlopt)
+    ; ("ocamldep", Action.Prog.to_dyn t.ocamldep)
+    ; ("ocamlmklib", Action.Prog.to_dyn t.ocamlmklib)
+    ; ("env", Env.to_dyn (Env.diff t.env Env.initial))
+    ; ("findlib_path", list path (Findlib.paths t.findlib))
+    ; ("arch_sixtyfour", Bool t.arch_sixtyfour)
+    ; ( "natdynlink_supported"
+      , Bool (Dynlink_supported.By_the_os.get t.lib_config.natdynlink_supported)
+      )
+    ; ( "supports_shared_libraries"
+      , Bool (Dynlink_supported.By_the_os.get t.supports_shared_libraries) )
+    ; ("ocaml_config", Ocaml_config.to_dyn t.ocaml_config)
+    ]
 
 let to_dyn_concise t : Dyn.t = Context_name.to_dyn t.name
 
@@ -236,7 +231,7 @@ end = struct
         Dyn.Tuple
           [ Env.to_dyn env; Dyn.Encoder.(option string root); String switch ]
     end in
-    let memo = Memo.create_hidden "opam-env" ~input:(module Input) impl in
+    let memo = Memo.create_no_cutoff "opam-env" ~input:(module Input) impl in
     fun ~env ~root ~switch -> Memo.exec memo (env, root, switch)
 end
 
@@ -334,7 +329,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     Memo.create
       (sprintf "which-memo-for-%s" (Context_name.to_string name))
       ~input:(module Program.Name)
-      ~output:(Allow_cutoff (module Program.Which_path))
+      ~output:(Cutoff (module Program.Which_path))
       (fun p -> Memo.Build.return (Program.which ~path p))
   in
   let which = Memo.exec which_memo in
@@ -705,12 +700,6 @@ let create_for_opam ~loc ~root ~env ~env_nodes ~targets ~profile ~switch ~name
     ~host_toolchain ~fdo_target_exe ~dynamically_linked_foreign_archives
     ~instrument_with
 
-module T_list = struct
-  type nonrec t = t list
-
-  let to_dyn = Dyn.Encoder.list to_dyn
-end
-
 module rec Instantiate : sig
   val instantiate : Context_name.t -> t list Memo.Build.t
 end = struct
@@ -790,10 +779,9 @@ end = struct
         ~dynamically_linked_foreign_archives ~instrument_with
 
   let memo =
-    Memo.create "instantiate-context"
+    Memo.create_no_cutoff "instantiate-context"
       ~input:(module Context_name)
-      ~output:(Simple (module T_list))
-      instantiate_impl
+      ~output_to_dyn:(Dyn.Encoder.list to_dyn) instantiate_impl
 
   let instantiate name = Memo.exec memo name
 end
@@ -816,18 +804,17 @@ module DB = struct
       all
     in
     let memo =
-      Memo.create "build-contexts"
+      Memo.create_no_cutoff "build-contexts"
         ~input:(module Unit)
-        ~output:(Simple (module T_list))
-        impl
+        ~output_to_dyn:(Dyn.Encoder.list to_dyn) impl
     in
     Memo.exec memo
 
   let get =
     let memo =
-      Memo.create "context-db-get"
+      Memo.create_no_cutoff "context-db-get"
         ~input:(module Context_name)
-        ~output:(Simple (module T))
+        ~output_to_dyn:to_dyn
         (fun name ->
           let+ contexts = all () in
           List.find_exn contexts ~f:(fun c -> Context_name.equal name c.name))

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -346,15 +346,7 @@ end = struct
         }
 
   let memo0 =
-    let module Output = struct
-      type t = result0
-
-      let to_dyn _ = Dyn.Opaque
-    end in
-    Memo.create "dir-contents-get0"
-      ~input:(module Key)
-      ~output:(Simple (module Output))
-      get0_impl
+    Memo.create_no_cutoff "dir-contents-get0" ~input:(module Key) get0_impl
 
   let get sctx ~dir =
     Memo.exec memo0 (sctx, dir) >>= function

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -11,19 +11,17 @@ module T = struct
   type t =
     | Generated
     | Source_only of Source_tree.Dir.t
-    | Standalone of Source_tree.Dir.t * Stanza.t list Dir_with_dune.t
-    (* Directory not part of a multi-directory group. *)
-    | Group_root of
+    | (* Directory not part of a multi-directory group *)
+        Standalone of
+        Source_tree.Dir.t * Stanza.t list Dir_with_dune.t
+    | (* Directory with [(include_subdirs x)] where [x] is not [no] *)
+        Group_root of
         Source_tree.Dir.t
         * (Loc.t * Include_subdirs.qualification)
         * Stanza.t list Dir_with_dune.t
-    (* Directory with [(include_subdirs x)] where [x] is not [no] *)
-    | Is_component_of_a_group_but_not_the_root of
+    | (* Sub-directory of a [Group_root _] *)
+        Is_component_of_a_group_but_not_the_root of
         is_component_of_a_group_but_not_the_root
-
-  (* Sub-directory of a [Group_root _] *)
-
-  let to_dyn _ = Dyn.String "<dir-status>"
 end
 
 include T
@@ -137,9 +135,9 @@ module DB = struct
         let t =
           { stanzas_per_dir
           ; fn =
-              Memo.create "get-dir-status"
+              Memo.create_no_cutoff "get-dir-status"
                 ~input:(module Path.Build)
-                ~output:(Simple (module T))
+                ~output_to_dyn:(fun _ -> Dyn.String "<dir-status>")
                 Fn.get
           }
       end

--- a/src/dune_rules/fdo.ml
+++ b/src/dune_rules/fdo.ml
@@ -45,7 +45,7 @@ let get_flags var =
     Env.get ctx.env var |> Option.value ~default:""
     |> String.extract_blank_separated_words |> Memo.Build.return
   in
-  let memo = Memo.create_hidden var ~input:(module Context) f in
+  let memo = Memo.create_no_cutoff var ~input:(module Context) f in
   Memo.exec memo
 
 let ocamlfdo_flags = get_flags "OCAMLFDO_FLAGS"
@@ -113,7 +113,7 @@ let get_profile =
     else
       None
   in
-  let memo = Memo.create_hidden Mode.var ~input:(module Context) f in
+  let memo = Memo.create_no_cutoff Mode.var ~input:(module Context) f in
   Memo.exec memo
 
 let opt_rule cctx m =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -360,7 +360,7 @@ end = struct
         | Some (name, entries) ->
           Package.Name.Map.Multi.add_all acc name entries)
     |> Package.Name.Map.map ~f:(fun entries ->
-           (* Sort entries so that the ordering in [dune-package] is independant
+           (* Sort entries so that the ordering in [dune-package] is independent
               of Dune's current implementation. *)
            (* jeremiedimino: later on, we group this list by section and sort
               each section. It feels like we should just do this here once and
@@ -370,17 +370,8 @@ end = struct
 
   let stanzas_to_entries =
     let memo =
-      Memo.create
+      Memo.create_no_cutoff
         ~input:(module Super_context.As_memo_key)
-        ~output:
-          (Simple
-             (module struct
-               type t =
-                 (Loc.t option * Path.Build.t Install.Entry.t) list
-                 Package.Name.Map.t
-
-               let to_dyn _ = Dyn.Opaque
-             end))
         "stanzas-to-entries" stanzas_to_entries
     in
     Memo.exec memo
@@ -766,7 +757,7 @@ let packages =
     Memo.create "package-map"
       ~input:(module Super_context.As_memo_key)
       ~output:
-        (Allow_cutoff
+        (Cutoff
            (module struct
              type t = Package.Id.Set.t Path.Build.Map.t
 
@@ -896,11 +887,6 @@ let install_rules sctx (package : Package.t) =
     action
 
 let memo =
-  let module Rules_scheme = struct
-    type t = Rules.Dir_rules.t Scheme.t
-
-    let to_dyn _ = Dyn.Opaque
-  end in
   let module Sctx_and_package = struct
     module Super_context = Super_context.As_memo_key
 
@@ -927,9 +913,8 @@ let memo =
     else
       Memo.Build.return ()
   in
-  Memo.create
+  Memo.create_no_cutoff
     ~input:(module Sctx_and_package)
-    ~output:(Simple (module Rules_scheme))
     "install-rules-and-pkg-entries"
     (fun (sctx, pkg) ->
       Memo.Build.return
@@ -954,9 +939,9 @@ let memo =
 let scheme sctx pkg = Memo.exec memo (sctx, pkg)
 
 let scheme_per_ctx_memo =
-  Memo.create
+  Memo.create_no_cutoff
     ~input:(module Super_context.As_memo_key)
-    ~output:(Memo.Output.simple ()) "install-rule-scheme"
+    "install-rule-scheme"
     (fun sctx ->
       let packages = Package.Name.Map.values (Super_context.packages sctx) in
       let* schemes = Memo.Build.sequential_map packages ~f:(scheme sctx) in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -183,7 +183,7 @@ end = struct
 
         let memo =
           Memo.exec
-            (Memo.create_hidden "env-nodes-memo"
+            (Memo.create_no_cutoff "env-nodes-memo"
                ~input:(module Path.Build)
                (fun path -> Memo.Build.return (get_impl env_tree path)))
 

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -638,7 +638,9 @@ let workspace_step1 =
     | None -> default_step1 clflags
     | Some p -> load_step1 clflags p
   in
-  let memo = Memo.create_hidden "workspaces-internal" ~input:(module Unit) f in
+  let memo =
+    Memo.create_no_cutoff "workspaces-internal" ~input:(module Unit) f
+  in
   Memo.exec memo
 
 let workspace_config () =
@@ -653,10 +655,7 @@ let workspace =
     Lazy.force step1.t
   in
   let memo =
-    Memo.create "workspace"
-      ~input:(module Unit)
-      ~output:(Allow_cutoff (module T))
-      f
+    Memo.create "workspace" ~input:(module Unit) ~output:(Cutoff (module T)) f
   in
   Memo.exec memo
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -149,13 +149,13 @@ val restart_current_run : unit -> unit
     that the build system tracks all relevant side effects in the [Build] monad. *)
 val incremental_mode_enabled : bool
 
-module type Output_simple = sig
+module type Output_no_cutoff = sig
   type t
 
   val to_dyn : t -> Dyn.t
 end
 
-module type Output_allow_cutoff = sig
+module type Output_cutoff = sig
   type t
 
   val to_dyn : t -> Dyn.t
@@ -163,20 +163,18 @@ module type Output_allow_cutoff = sig
   val equal : t -> t -> bool
 end
 
-(** When we recompute the function and find that its output is the same as what
-    we computed before, we can sometimes skip recomputing the values that depend
-    on it.
-
-    [Allow_cutoff] specifies how to compare the output values for that purpose.
+(** When we recompute a function and find that its output is the same as what we
+    computed before, we can sometimes skip recomputing the values that depend on
+    it. [Cutoff] specifies how to compare the output values for that purpose.
 
     Note that currently Dune wipes all memoization caches on every run, so
     cutoff is not effective. *)
 module Output : sig
   type 'o t =
-    | Simple of (module Output_simple with type t = 'o)
-    | Allow_cutoff of (module Output_allow_cutoff with type t = 'o)
+    | No_cutoff of (module Output_no_cutoff with type t = 'o)
+    | Cutoff of (module Output_cutoff with type t = 'o)
 
-  val simple : ?to_dyn:('a -> Dyn.t) -> unit -> 'a t
+  val no_cutoff : ?to_dyn:('a -> Dyn.t) -> unit -> 'a t
 end
 
 module type Input = sig
@@ -207,6 +205,7 @@ module Store : sig
   end
 end
 
+(** Like [create] but accepts a custom [store] for memoization. *)
 val create_with_store :
      string
   -> store:(module Store.S with type key = 'i)
@@ -215,7 +214,7 @@ val create_with_store :
   -> ('i -> 'o Fiber.t)
   -> ('i, 'o) t
 
-(** [create name ~input ~output f] creates a memoized version of
+(** [create name ~input ~output f] creates a memoized version of the function
     [f : 'i -> 'o Build.t]. The result of [f] for a given input is cached, so
     that the second time [exec t x] is called, the previous result is re-used if
     possible.
@@ -224,11 +223,8 @@ val create_with_store :
     the result of such dependent call changes, [exec t x] will automatically
     recompute [f x].
 
-    Running the computation may raise [Memo.Cycle_error.E] if a cycle is
-    detected.
-
-    [visibility] determines whether the function is user-facing or internal and
-    if it's user-facing then how to parse the values written by the user. *)
+    Running the computation may raise [Memo.Cycle_error.E] if a dependency cycle
+    is detected. *)
 val create :
      string
   -> input:(module Input with type t = 'i)
@@ -236,9 +232,11 @@ val create :
   -> ('i -> 'o Build.t)
   -> ('i, 'o) t
 
-val create_hidden :
+(** A version of [create] for memoizing functions with no cutoff. *)
+val create_no_cutoff :
      string
   -> input:(module Input with type t = 'i)
+  -> ?output_to_dyn:('o -> Dyn.t)
   -> ('i -> 'o Build.t)
   -> ('i, 'o) t
 
@@ -325,7 +323,7 @@ module With_implicit_output : sig
   val create :
        string
     -> input:(module Input with type t = 'i)
-    -> output:(module Output_simple with type t = 'o)
+    -> output:(module Output_no_cutoff with type t = 'o)
     -> implicit_output:'io Implicit_output.t
     -> ('i -> 'o Build.t)
     -> ('i, 'o) t

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -205,7 +205,9 @@ module Store : sig
   end
 end
 
-(** Like [create] but accepts a custom [store] for memoization. *)
+(** Like [create] but accepts a custom [store] for memoization. This is useful
+    when there is a custom data structure indexed by keys of type ['i] that is
+    more efficient than the one that Memo uses by default (a plain hash table). *)
 val create_with_store :
      string
   -> store:(module Store.S with type key = 'i)


### PR DESCRIPTION
I noticed that #4540 left `create_hidden` whose name is now out of date.

I initially wanted to rename it to `create_simple` but after discussing with @aalekseyev, we thought that it would be better to rename `Output.Simple` to `Output.Cutoff` and `create_hidden` to `create_no_cutoff` for greater clarity at call sites.

While doing the renaming, I noticed that in a few places we can simplify the code by using `create_no_cutoff` instead of `create`, which doesn't require to pass the `Output` module, which was often created on the spot.