### PR TITLE
Encourage accessing the file system via [Fs_memo]

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -1,6 +1,5 @@
 open! Dune_engine
 open! Stdune
-open! Import
 module Dune_file = Dune_rules.Dune_file
 
 (** Because the dune_init utility deals with the addition of stanzas and fields

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -326,7 +326,7 @@ let rec exec t ~ectx ~eenv =
       let is_copied_from_source_tree file =
         match Path.extract_build_context_dir_maybe_sandboxed file with
         | None -> false
-        | Some (_, file) -> Path.exists (Path.source file)
+        | Some (_, file) -> Path.Untracked.exists (Path.source file)
       in
       let+ () =
         Fiber.finalize
@@ -346,7 +346,8 @@ let rec exec t ~ectx ~eenv =
               (* Promote if in the source tree or not a target. The second case
                  means that the diffing have been done with the empty file *)
               if
-                (is_copied_from_source_tree file1 || not (Path.exists file1))
+                (is_copied_from_source_tree file1
+                || not (Path.Untracked.exists file1))
                 && not (is_copied_from_source_tree (Path.build file2))
               then
                 Promotion.File.register_dep
@@ -356,7 +357,9 @@ let rec exec t ~ectx ~eenv =
                           (Path.extract_build_context_dir_maybe_sandboxed file1)))
                   ~correction_file:file2
             | true ->
-              if is_copied_from_source_tree file1 || not (Path.exists file1)
+              if
+                is_copied_from_source_tree file1
+                || not (Path.Untracked.exists file1)
               then
                 Promotion.File.register_intermediate
                   ~source_file:

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -34,7 +34,9 @@ end = struct
     Memo.create "assert_path_exists"
       ~input:(module Path)
       ~output:(No_cutoff (module Bool))
-      (fun p -> Memo.Build.return (Path.Untracked.exists p))
+      (* CR-someday amokhov: We can switch to using [Fs_memo.file_exists] here,
+         since we never call this function on build paths. *)
+        (fun p -> Memo.Build.return (Path.Untracked.exists p))
 
   let assert_exists ~loc path =
     Memo.exec assert_exists_def path >>| function
@@ -630,7 +632,7 @@ let rec with_locks t mutexes ~f =
       (fun () -> with_locks t mutexes ~f)
 
 let remove_old_artifacts ~dir ~rules_here ~(subdirs_to_keep : Subdir_set.t) =
-  match Path.readdir_unsorted_with_kinds (Path.build dir) with
+  match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
   | exception _ -> ()
   | Error _ -> ()
   | Ok files ->
@@ -650,7 +652,7 @@ let remove_old_artifacts ~dir ~rules_here ~(subdirs_to_keep : Subdir_set.t) =
    not. *)
 let remove_old_sub_dirs_in_anonymous_actions_dir ~dir
     ~(subdirs_to_keep : Subdir_set.t) =
-  match Path.readdir_unsorted_with_kinds (Path.build dir) with
+  match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
   | exception _ -> ()
   | Error _ -> ()
   | Ok files ->
@@ -1182,6 +1184,7 @@ let get_rule_or_source t path =
       let* loc = Rule_fn.loc () in
       no_rule_found t ~loc path
   else if Path.Untracked.exists path then
+    (* CR-someday amokhov: Switch the above to [Fs_memo.file_exists]. *)
     let+ d = Fs_memo.file_digest path in
     Source d
   else
@@ -1823,6 +1826,7 @@ end = struct
                 let dst = in_source_tree in
                 let in_source_tree = Path.source in_source_tree in
                 let* is_up_to_date =
+                  (* CR-someday amokhov: Switch to [Fs_memo.file_exists] here. *)
                   if not (Path.Untracked.exists in_source_tree) then
                     Fiber.return false
                   else

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -34,7 +34,7 @@ end = struct
     Memo.create "assert_path_exists"
       ~input:(module Path)
       ~output:(No_cutoff (module Bool))
-      (fun p -> Memo.Build.return (Path.exists p))
+      (fun p -> Memo.Build.return (Path.Untracked.exists p))
 
   let assert_exists ~loc path =
     Memo.exec assert_exists_def path >>| function
@@ -1181,7 +1181,7 @@ let get_rule_or_source t path =
     | None ->
       let* loc = Rule_fn.loc () in
       no_rule_found t ~loc path
-  else if Path.exists path then
+  else if Path.Untracked.exists path then
     let+ d = Fs_memo.file_digest path in
     Source d
   else
@@ -1823,7 +1823,7 @@ end = struct
                 let dst = in_source_tree in
                 let in_source_tree = Path.source in_source_tree in
                 let* is_up_to_date =
-                  if not (Path.exists in_source_tree) then
+                  if not (Path.Untracked.exists in_source_tree) then
                     Fiber.return false
                   else
                     let in_build_dir_digest = Cached_digest.build_file path in

--- a/src/dune_engine/diff.ml
+++ b/src/dune_engine/diff.ml
@@ -32,11 +32,11 @@ let decode_binary path target =
 
 let eq_files { optional; mode; file1; file2 } =
   let file1 =
-    if Path.exists file1 then
+    if Path.Untracked.exists file1 then
       file1
     else
       Config.dev_null
   in
   let file2 = Path.build file2 in
-  (optional && not (Path.exists file2))
+  (optional && not (Path.Untracked.exists file2))
   || Mode.compare_files mode file1 file2 = Eq

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -34,7 +34,8 @@ let declaring_dependency path ~f =
   let+ () = depend path in
   f path
 
-let file_exists = declaring_dependency ~f:Path.exists
+(* Assuming our file system watcher is any good, this untracked call is safe. *)
+let file_exists = declaring_dependency ~f:Path.Untracked.exists
 
 (* CR-someday amokhov: It is unclear if we got the layers of abstraction right
    here. One could argue that caching is a higher-level concept compared to file

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -45,7 +45,9 @@ let file_exists = declaring_dependency ~f:Path.Untracked.exists
    of [file_digest] seems error-prone. We may need to rethink this decision. *)
 let file_digest = declaring_dependency ~f:Cached_digest.source_or_external_file
 
-let dir_contents = declaring_dependency ~f:Path.readdir_unsorted_with_kinds
+(* Assuming our file system watcher is any good, this untracked call is safe. *)
+let dir_contents =
+  declaring_dependency ~f:Path.Untracked.readdir_unsorted_with_kinds
 
 module Rebuild_required = struct
   type t =

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -9,6 +9,18 @@ module Ml_kind = Dune_util.Ml_kind
 module Dune_rpc = Dune_rpc_private
 module Config = Dune_util.Config
 
+module Path = struct
+  include Path
+
+  module Untracked = struct
+    let exists = exists
+  end
+
+  (* Encourage using [Fs_memo.file_exists] if possible. The untracked version is
+     still available as [Path.Untracked.exists]. *)
+  let exists = `Use_fs_memo_file_exists_instead
+end
+
 (* To make bug reports usable *)
 let () = Printexc.record_backtrace true
 

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -14,11 +14,17 @@ module Path = struct
 
   module Untracked = struct
     let exists = exists
+
+    let readdir_unsorted_with_kinds = readdir_unsorted_with_kinds
   end
 
   (* Encourage using [Fs_memo.file_exists] if possible. The untracked version is
      still available as [Path.Untracked.exists]. *)
   let exists = `Use_fs_memo_file_exists_instead
+
+  (* Encourage using [Fs_memo.dir_contents] if possible. The untracked version
+     is still available as [Path.Untracked.readdir_unsorted_with_kinds]. *)
+  let readdir_unsorted_with_kinds = `Use_fs_memo_dir_contents_instead
 end
 
 (* To make bug reports usable *)

--- a/src/dune_engine/include_stanza.ml
+++ b/src/dune_engine/include_stanza.ml
@@ -35,7 +35,7 @@ let load_sexps ~context:{ current_file; include_stack } (loc, fn) =
   let include_stack = (loc, current_file) :: include_stack in
   let dir = Path.Source.parent_exn current_file in
   let current_file = Path.Source.relative dir fn in
-  if not (Path.exists (Path.source current_file)) then
+  if not (Path.Untracked.exists (Path.source current_file)) then
     User_error.raise ~loc
       [ Pp.textf "File %s doesn't exist."
           (Path.Source.to_string_maybe_quoted current_file)

--- a/src/dune_engine/promotion.ml
+++ b/src/dune_engine/promotion.ml
@@ -104,7 +104,7 @@ type files_to_promote =
 let do_promote db files_to_promote =
   let by_targets = group_by_targets db in
   let potential_build_contexts =
-    match Path.readdir_unsorted_with_kinds Path.build_dir with
+    match Path.Untracked.readdir_unsorted_with_kinds Path.build_dir with
     | exception _ -> []
     | Error _ -> []
     | Ok files ->

--- a/src/dune_engine/promotion.ml
+++ b/src/dune_engine/promotion.ml
@@ -40,7 +40,9 @@ module File = struct
 
   let promote { src; staging; dst } =
     let correction_file = Option.value staging ~default:src in
-    let correction_exists = Path.exists (Path.build correction_file) in
+    let correction_exists =
+      Path.Untracked.exists (Path.build correction_file)
+    in
     Console.print
       [ Pp.box ~indent:2
           (if correction_exists then
@@ -83,7 +85,7 @@ let db_file = Path.relative Path.build_dir ".to-promote"
 let dump_db db =
   if Path.build_dir_exists () then
     match db with
-    | [] -> if Path.exists db_file then Path.unlink_no_err db_file
+    | [] -> if Path.Untracked.exists db_file then Path.unlink_no_err db_file
     | l -> P.dump db_file l
 
 let load_db () = Option.value ~default:[] (P.load db_file)

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -166,7 +166,8 @@ end = struct
     { t with files = String.Set.filter t.files ~f:(fun fn -> f t.path fn) }
 
   let of_source_path path =
-    match Path.readdir_unsorted_with_kinds (Path.source path) with
+    (* CR-someday amokhov: Use [Fs_memo.dir_contents] instead. *)
+    match Path.Untracked.readdir_unsorted_with_kinds (Path.source path) with
     | Error unix_error ->
       User_warning.emit
         [ Pp.textf "Unable to read directory %s. Ignoring."

--- a/src/dune_rules/cram_exec.ml
+++ b/src/dune_rules/cram_exec.ml
@@ -1,5 +1,6 @@
 open! Dune_engine
-open Import
+open! Dune_engine.Import
+open! Stdune
 
 module Sanitizer : sig
   [@@@ocaml.warning "-32"]

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -1,6 +1,6 @@
 open! Dune_engine
+open! Dune_engine.Import
 open! Stdune
-open Import
 
 module Jbuild_plugin : sig
   val create_plugin_wrapper :

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -1,6 +1,6 @@
-open! Stdune
 open! Dune_engine
-open Import
+open! Dune_engine.Import
+open! Stdune
 module Opam_package = Package
 module P = Variant
 module Ps = Variant.Set

--- a/src/dune_rules/findlib/findlib.mli
+++ b/src/dune_rules/findlib/findlib.mli
@@ -1,8 +1,7 @@
 (** Findlib database *)
 
+open! Dune_engine
 open! Stdune
-open Dune_engine
-open Dune_engine.Import
 
 (** Findlib database *)
 type t

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -1,6 +1,5 @@
-open! Stdune
 open! Dune_engine
-open Import
+open! Stdune
 
 module Meta_parser = Dune_meta_parser.Meta_parser.Make (struct
   include Stdune

--- a/src/dune_rules/merlin_server.ml
+++ b/src/dune_rules/merlin_server.ml
@@ -1,6 +1,5 @@
 open! Dune_engine
 open! Stdune
-open Import
 open Fiber.O
 
 module Merlin_conf = struct

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -1,8 +1,7 @@
 open! Dune_engine
+open! Dune_engine.Import
 open! Stdune
-open Import
 open Dune_file
-open! No_io
 module SC = Super_context
 open Memo.Build.O
 

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -1,6 +1,5 @@
 open! Dune_engine
 open! Stdune
-open Import
 
 type rename_and_edit =
   { original_file : Path.Source.t


### PR DESCRIPTION
Hide `Path.exists` and `Path.readdir_unsorted_with_kinds` in Dune build engine, encouraging to use their tracked versions from `Fs_memo` instead. The untracked versions are still available from `Path.Untracked`.

This PR doesn't change any behaviour and switches to using `Path.Untracked` but leaves a couple of pointers for next steps.