### PR TITLE
Replace some [Path.Untracked.exists] calls with [Fs_memo.path_exists]

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -29,13 +29,13 @@ let depend path =
    out explicitly by doing things in the right order.
 
    Currently, we do not expose this low-level primitive. If you need it, perhaps
-   you could add a higher-level primitive instead, such as [file_exists]? *)
+   you could add a higher-level primitive instead, such as [path_exists]? *)
 let declaring_dependency path ~f =
   let+ () = depend path in
   f path
 
 (* Assuming our file system watcher is any good, this untracked call is safe. *)
-let file_exists = declaring_dependency ~f:Path.Untracked.exists
+let path_exists = declaring_dependency ~f:Path.Untracked.exists
 
 (* CR-someday amokhov: It is unclear if we got the layers of abstraction right
    here. One could argue that caching is a higher-level concept compared to file
@@ -111,9 +111,9 @@ module Event = struct
      and robust but doesn't take advantage of all the information we receive.
      Here are some ideas for future optimisation:
 
-     - Don't invalidate [file_exists] queries on [File_changed] events.
+     - Don't invalidate [path_exists] queries on [File_changed] events.
 
-     - If a [file_exists] query currently returns [true] and we receive a
+     - If a [path_exists] query currently returns [true] and we receive a
      corresponding [File_deleted] event, we can change the query's result to
      [false] without rerunning the [Path.exists] function (and vice versa).
 

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -8,8 +8,8 @@ open Import
    only for source paths, because we don't watch external directories. We should
    try to implement at least a partial support for watching external paths. *)
 
-(** Check if a source or external file exists and declare a dependency on it. *)
-val file_exists : Path.t -> bool Memo.Build.t
+(** Check if a source or external path exists and declare a dependency on it. *)
+val path_exists : Path.t -> bool Memo.Build.t
 
 (** Digest the contents of a source or external file and declare a dependency on
     it. *)

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -622,10 +622,10 @@ let workspace_step1 =
       match clflags.workspace_file with
       | None ->
         let p = Path.of_string filename in
-        let+ exists = Dune_engine.Fs_memo.file_exists p in
+        let+ exists = Fs_memo.path_exists p in
         Option.some_if exists p
       | Some p -> (
-        Dune_engine.Fs_memo.file_exists p >>| function
+        Fs_memo.path_exists p >>| function
         | false ->
           User_error.raise
             [ Pp.textf "Workspace file %s does not exist"


### PR DESCRIPTION
A follow up to #4543.

Also rename `Fs_memo.file_exists` to `Fs_memo.path_exists` since we use it not only for files but for directories too.