### PR TITLE
Switch to using [Fs_memo.dir_contents] in [Source_tree]

### DIFF
--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -28,7 +28,8 @@ module File = struct
   module Map = Map.Make (T)
 
   let of_source_path p =
-    (* CR aalekseyev: handle errors from [Path.stat] *)
+    (* CR-someday aalekseyev: handle errors from [Path.stat] *)
+    (* CR-someday amokhov: ... and use a tracked version of [Path.stat]. *)
     of_stats (Path.stat_exn (Path.source p))
 end
 
@@ -102,6 +103,7 @@ module Dune_file = struct
       match file_exists with
       | false -> (Plain, load_plain [] ~file ~from_parent ~project)
       | true ->
+        (* CR-someday amokhov: [Io.with_lexbuf_from_file] should be tracked. *)
         Io.with_lexbuf_from_file (Path.source file) ~f:(fun lb ->
             if Dune_lexer.is_script lb then
               let from_parent = load_plain [] ~file ~from_parent ~project in
@@ -192,6 +194,7 @@ end = struct
                 match kind with
                 | S_DIR -> (true, File.of_source_path path)
                 | S_LNK -> (
+                  (* CR-someday amokhov: [Path.stat] should be tracked. *)
                   match Path.stat (Path.source path) with
                   | Error _ -> (false, File.dummy)
                   | Ok ({ st_kind = S_DIR; _ } as st) -> (true, File.of_stats st)

--- a/src/dune_engine/source_tree.mli
+++ b/src/dune_engine/source_tree.mli
@@ -92,7 +92,6 @@ val nearest_dir : Path.Source.t -> Dir.t Memo.Build.t
 
 (** [nearest_vcs t fn] returns the version control system with the longest root
     path that is an ancestor of [fn]. *)
-
 val nearest_vcs : Path.Source.t -> Vcs.t option Memo.Build.t
 
 val files_of : Path.Source.t -> Path.Source.Set.t Memo.Build.t


### PR DESCRIPTION
Another follow up to #4543.

All remaining occurrences of `Path.Untracked.readdir_unsorted_with_kinds` are called on a build directory.