### PR TITLE
Add [Fs_memo.with_lexbuf_from_file], use it in [Source_tree]

### DIFF
--- a/src/dune_engine/format_dune_lang.ml
+++ b/src/dune_engine/format_dune_lang.ml
@@ -14,7 +14,7 @@ let parse_lexbuf lb =
 
 let parse_file path_opt =
   match path_opt with
-  | Some path -> Io.with_lexbuf_from_file path ~f:parse_lexbuf
+  | Some path -> Io.Untracked.with_lexbuf_from_file path ~f:parse_lexbuf
   | None -> parse_lexbuf @@ Lexing.from_channel stdin
 
 let can_be_displayed_wrapped =

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -48,6 +48,10 @@ let path_stat = declaring_dependency ~f:Path.Untracked.stat
    of [file_digest] seems error-prone. We may need to rethink this decision. *)
 let file_digest = declaring_dependency ~f:Cached_digest.source_or_external_file
 
+let with_lexbuf_from_file path ~f =
+  declaring_dependency path ~f:(fun path ->
+      Io.Untracked.with_lexbuf_from_file path ~f)
+
 let dir_contents =
   declaring_dependency ~f:Path.Untracked.readdir_unsorted_with_kinds
 

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -18,6 +18,10 @@ val path_stat : Path.t -> (Unix.stats, Unix.error) result Memo.Build.t
     it. *)
 val file_digest : Path.t -> Digest.t Memo.Build.t
 
+(** Like [Io.Untracked.with_lexbuf_from_file] but declares a dependency on the
+    path. *)
+val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Memo.Build.t
+
 (** List the contents of a source or external directory and declare a dependency
     on it. The result is unsorted and includes both name and kind of each entry. *)
 val dir_contents :

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -42,6 +42,19 @@ module Path = struct
   let readdir_unsorted_with_kinds = `Use_fs_memo_dir_contents_instead
 end
 
+module Io = struct
+  include Io
+
+  module Untracked = struct
+    let with_lexbuf_from_file = with_lexbuf_from_file
+  end
+
+  (* Encourage using [Fs_memo] equivalents if possible. The untracked versions
+     are still available in the [Io.Untracked] module. *)
+
+  let with_lexbuf_from_file = `Use_fs_memo_with_lexbuf_from_file
+end
+
 (* To make bug reports usable *)
 let () = Printexc.record_backtrace true
 

--- a/src/dune_engine/opam_file.ml
+++ b/src/dune_engine/opam_file.ml
@@ -17,7 +17,7 @@ let parse =
 
 let parse_value = parse_gen OpamBaseParser.value
 
-let load fn = Io.with_lexbuf_from_file fn ~f:parse
+let load fn = Io.Untracked.with_lexbuf_from_file fn ~f:parse
 
 let get_field t name =
   List.find_map t.file_contents ~f:(function

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -97,12 +97,12 @@ module Dune_file = struct
     { Plain.contents; for_subdirs = active }
 
   let load file ~file_exists ~from_parent ~project =
-    let kind, plain =
+    let+ kind, plain =
       match file_exists with
-      | false -> (Plain, load_plain [] ~file ~from_parent ~project)
+      | false ->
+        Memo.Build.return (Plain, load_plain [] ~file ~from_parent ~project)
       | true ->
-        (* CR-someday amokhov: [Io.with_lexbuf_from_file] should be tracked. *)
-        Io.with_lexbuf_from_file (Path.source file) ~f:(fun lb ->
+        Fs_memo.with_lexbuf_from_file (Path.source file) ~f:(fun lb ->
             if Dune_lexer.is_script lb then
               let from_parent = load_plain [] ~file ~from_parent ~project in
               (Ocaml_script, from_parent)
@@ -471,7 +471,7 @@ end = struct
       else
         None
     in
-    let+ from_parent =
+    let* from_parent =
       match Path.Source.parent path with
       | None -> Memo.Build.return None
       | Some parent ->
@@ -485,19 +485,16 @@ end = struct
         in
         (dune_file.path, dir_map)
     in
-    let open Option.O in
-    let+ file =
+    let file =
       match (file_exists, from_parent) with
       | None, None -> None
       | Some fname, _ -> Some (Path.Source.relative path fname)
       | None, Some (path, _) -> Some path
     in
-    let from_parent =
-      let+ _, from_parent = from_parent in
-      from_parent
-    in
-    let file_exists = Option.is_some file_exists in
-    Dune_file.load file ~file_exists ~project ~from_parent
+    Memo.Build.Option.map file ~f:(fun file ->
+        let file_exists = Option.is_some file_exists in
+        let from_parent = Option.map from_parent ~f:snd in
+        Dune_file.load file ~file_exists ~project ~from_parent)
 
   let contents { Readdir.path; dirs; files } ~dirs_visited ~project
       ~(dir_status : Sub_dirs.Status.t) =


### PR DESCRIPTION
As far as I can see, this PR removes the last untracked file access from `Source_tree`.