### PR TITLE
Remove [to_dyn] of memoized function outputs

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -26,7 +26,7 @@ end = struct
        Note: if we find a way to reliably invalidate this function, its output
        should continue to have no cutoff because the callers might depend not
        just on the existence of a directory but on its *continuous* existence. *)
-    Memo.create_no_cutoff "mkdir_p"
+    Memo.create "mkdir_p"
       ~input:(module Path.Build)
       (fun p ->
         Path.mkdir_p (Path.build p);
@@ -1141,9 +1141,7 @@ end = struct
 
   let load_dir =
     let load_dir_impl dir = load_dir_impl (t ()) ~dir in
-    let memo =
-      Memo.create_no_cutoff "load-dir" ~input:(module Path) load_dir_impl
-    in
+    let memo = Memo.create "load-dir" ~input:(module Path) load_dir_impl in
     fun ~dir -> Memo.exec memo dir
 end
 
@@ -1937,7 +1935,7 @@ end = struct
     target
 
   let execute_action_generic_stage2_memo =
-    Memo.create_no_cutoff "execute-action"
+    Memo.create "execute-action"
       ~input:(module Action_desc)
       execute_action_generic_stage2_impl
 
@@ -2077,8 +2075,7 @@ end = struct
     let eval_memo =
       Memo.create "eval-pred"
         ~input:(module File_selector)
-        ~output:(Cutoff (module Path.Set))
-        eval_impl
+        ~cutoff:Path.Set.equal eval_impl
 
     let eval = Memo.exec eval_memo
 
@@ -2086,28 +2083,25 @@ end = struct
       Memo.exec
         (Memo.create "build-pred"
            ~input:(module File_selector)
-           ~output:(Cutoff (module Dep.Fact.Files))
-           build_impl)
+           ~cutoff:Dep.Fact.Files.equal build_impl)
   end
 
   let build_file_memo =
     Memo.create "build-file"
       ~input:(module Path)
-      ~output:(Cutoff (module Digest))
-      build_file_impl
+      ~cutoff:Digest.equal build_file_impl
 
   let build_file = Memo.exec build_file_memo
 
   let build_alias_memo =
     Memo.create "build-alias"
       ~input:(module Alias)
-      ~output:(Cutoff (module Dep.Fact.Files))
-      build_alias_impl
+      ~cutoff:Dep.Fact.Files.equal build_alias_impl
 
   let build_alias = Memo.exec build_alias_memo
 
   let execute_rule_memo =
-    Memo.create_no_cutoff "execute-rule"
+    Memo.create "execute-rule"
       ~input:(module Rule)
       (execute_rule_impl ~rule_kind:Normal_rule)
 
@@ -2322,7 +2316,7 @@ end = struct
   end = struct
     let alias =
       let memo =
-        Memo.create_no_cutoff "expand-alias"
+        Memo.create "expand-alias"
           ~input:(module Alias)
           (fun alias ->
             let* l = expand_alias_gen alias ~eval_build_request in
@@ -2346,7 +2340,7 @@ end = struct
 
   let evaluate_rule =
     let memo =
-      Memo.create_no_cutoff "evaluate-rule"
+      Memo.create "evaluate-rule"
         ~input:(module Non_evaluated_rule)
         (fun rule ->
           let* action, deps = eval_build_request rule.action in

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -19,40 +19,35 @@ module Action_output_on_success = struct
   let hash = Poly.hash
 end
 
-module T = struct
-  type t =
-    { dune_version : Dune_lang.Syntax.Version.t
-    ; action_stdout_on_success : Action_output_on_success.t
-    ; action_stderr_on_success : Action_output_on_success.t
-    }
+type t =
+  { dune_version : Dune_lang.Syntax.Version.t
+  ; action_stdout_on_success : Action_output_on_success.t
+  ; action_stderr_on_success : Action_output_on_success.t
+  }
 
-  let equal { dune_version; action_stdout_on_success; action_stderr_on_success }
-      t =
-    Dune_lang.Syntax.Version.equal dune_version t.dune_version
-    && Action_output_on_success.equal action_stdout_on_success
-         t.action_stdout_on_success
-    && Action_output_on_success.equal action_stderr_on_success
-         t.action_stderr_on_success
+let equal { dune_version; action_stdout_on_success; action_stderr_on_success } t
+    =
+  Dune_lang.Syntax.Version.equal dune_version t.dune_version
+  && Action_output_on_success.equal action_stdout_on_success
+       t.action_stdout_on_success
+  && Action_output_on_success.equal action_stderr_on_success
+       t.action_stderr_on_success
 
-  let hash { dune_version; action_stdout_on_success; action_stderr_on_success }
-      =
-    Hashtbl.hash
-      ( Dune_lang.Syntax.Version.hash dune_version
-      , Action_output_on_success.hash action_stdout_on_success
-      , Action_output_on_success.hash action_stderr_on_success )
+let hash { dune_version; action_stdout_on_success; action_stderr_on_success } =
+  Hashtbl.hash
+    ( Dune_lang.Syntax.Version.hash dune_version
+    , Action_output_on_success.hash action_stdout_on_success
+    , Action_output_on_success.hash action_stderr_on_success )
 
-  let to_dyn
-      { dune_version; action_stdout_on_success; action_stderr_on_success } =
-    Dyn.Record
-      [ ("dune_version", Dune_lang.Syntax.Version.to_dyn dune_version)
-      ; ( "action_stdout_on_success"
-        , Action_output_on_success.to_dyn action_stdout_on_success )
-      ; ( "action_stderr_on_success"
-        , Action_output_on_success.to_dyn action_stderr_on_success )
-      ]
-end
-
-include T
+let to_dyn { dune_version; action_stdout_on_success; action_stderr_on_success }
+    =
+  Dyn.Record
+    [ ("dune_version", Dune_lang.Syntax.Version.to_dyn dune_version)
+    ; ( "action_stdout_on_success"
+      , Action_output_on_success.to_dyn action_stdout_on_success )
+    ; ( "action_stderr_on_success"
+      , Action_output_on_success.to_dyn action_stderr_on_success )
+    ]
 
 let builtin_default =
   { dune_version = Stanza.latest_version

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -5,9 +5,7 @@ open Memo.Build.O
 (* Files and directories have non-overlapping sets of paths, so we can track
    them using the same memoization table. *)
 let memo =
-  Memo.create_no_cutoff "fs_memo"
-    ~input:(module Path)
-    (fun _path -> Memo.Build.return ())
+  Memo.create "fs_memo" ~input:(module Path) (fun _path -> Memo.Build.return ())
 
 (* Declare a dependency on a path. Instead of calling [depend] directly, you
    should prefer using the helper function [declaring_dependency], because it

--- a/src/dune_engine/vcs.ml
+++ b/src/dune_engine/vcs.ml
@@ -109,16 +109,13 @@ let hg_describe t =
   in
   s ^ dirty_suffix
 
-let make_fun name ~output_to_dyn ~git ~hg =
-  let memo =
-    Memo.create_no_cutoff name ~input:(module T) ~output_to_dyn (select git hg)
-  in
+let make_fun name ~git ~hg =
+  let memo = Memo.create name ~input:(module T) (select git hg) in
   Staged.stage (Memo.exec memo)
 
 let describe =
   Staged.unstage
   @@ make_fun "vcs-describe"
-       ~output_to_dyn:(Dyn.Encoder.option String.to_dyn)
        ~git:(fun t -> run_git t [ "describe"; "--always"; "--dirty" ])
        ~hg:(fun x ->
          let open Fiber.O in
@@ -128,7 +125,6 @@ let describe =
 let commit_id =
   Staged.unstage
   @@ make_fun "vcs-commit-id"
-       ~output_to_dyn:(Dyn.Encoder.option String.to_dyn)
        ~git:(fun t -> run_git t [ "rev-parse"; "HEAD" ])
        ~hg:(fun t ->
          let open Fiber.O in
@@ -158,7 +154,6 @@ let files =
   in
   Staged.unstage
   @@ make_fun "vcs-files"
-       ~output_to_dyn:(Dyn.Encoder.list Path.to_dyn)
        ~git:
          (f run_zero_separated_git
             [ "ls-tree"; "-z"; "-r"; "--name-only"; "HEAD" ])

--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -163,7 +163,7 @@ module Args = struct
 
   let memo t =
     let memo =
-      Memo.create_no_cutoff "Command.Args.memo"
+      Memo.create "Command.Args.memo"
         ~input:(module Path)
         (fun dir -> Memo.Build.return (expand_static ~dir t))
     in

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -345,8 +345,7 @@ end = struct
             Path.Build.Map.of_list_map_exn subdirs ~f:(fun x -> (x.dir, x))
         }
 
-  let memo0 =
-    Memo.create_no_cutoff "dir-contents-get0" ~input:(module Key) get0_impl
+  let memo0 = Memo.create "dir-contents-get0" ~input:(module Key) get0_impl
 
   let get sctx ~dir =
     Memo.exec memo0 (sctx, dir) >>= function

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -134,11 +134,7 @@ module DB = struct
       end = struct
         let t =
           { stanzas_per_dir
-          ; fn =
-              Memo.create_no_cutoff "get-dir-status"
-                ~input:(module Path.Build)
-                ~output_to_dyn:(fun _ -> Dyn.String "<dir-status>")
-                Fn.get
+          ; fn = Memo.create "get-dir-status" ~input:(module Path.Build) Fn.get
           }
       end
 

--- a/src/dune_rules/fdo.ml
+++ b/src/dune_rules/fdo.ml
@@ -45,7 +45,7 @@ let get_flags var =
     Env.get ctx.env var |> Option.value ~default:""
     |> String.extract_blank_separated_words |> Memo.Build.return
   in
-  let memo = Memo.create_no_cutoff var ~input:(module Context) f in
+  let memo = Memo.create var ~input:(module Context) f in
   Memo.exec memo
 
 let ocamlfdo_flags = get_flags "OCAMLFDO_FLAGS"
@@ -113,7 +113,7 @@ let get_profile =
     else
       None
   in
-  let memo = Memo.create_no_cutoff Mode.var ~input:(module Context) f in
+  let memo = Memo.create Mode.var ~input:(module Context) f in
   Memo.exec memo
 
 let opt_rule cctx m =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -370,7 +370,7 @@ end = struct
 
   let stanzas_to_entries =
     let memo =
-      Memo.create_no_cutoff
+      Memo.create
         ~input:(module Super_context.As_memo_key)
         "stanzas-to-entries" stanzas_to_entries
     in
@@ -693,7 +693,6 @@ end = struct
     end in
     Memo.With_implicit_output.create "meta_and_dune_package_rules"
       ~input:(module Project_and_super_context)
-      ~output:(module Unit)
       ~implicit_output:Rules.implicit_output meta_and_dune_package_rules_impl
 
   let meta_and_dune_package_rules sctx ~dir =
@@ -756,15 +755,7 @@ let packages =
   let memo =
     Memo.create "package-map"
       ~input:(module Super_context.As_memo_key)
-      ~output:
-        (Cutoff
-           (module struct
-             type t = Package.Id.Set.t Path.Build.Map.t
-
-             let to_dyn = Path.Build.Map.to_dyn Package.Id.Set.to_dyn
-
-             let equal = Path.Build.Map.equal ~equal:Package.Id.Set.equal
-           end))
+      ~cutoff:(Path.Build.Map.equal ~equal:Package.Id.Set.equal)
       f
   in
   fun sctx -> Memo.exec memo sctx
@@ -913,7 +904,7 @@ let memo =
     else
       Memo.Build.return ()
   in
-  Memo.create_no_cutoff
+  Memo.create
     ~input:(module Sctx_and_package)
     "install-rules-and-pkg-entries"
     (fun (sctx, pkg) ->
@@ -939,7 +930,7 @@ let memo =
 let scheme sctx pkg = Memo.exec memo (sctx, pkg)
 
 let scheme_per_ctx_memo =
-  Memo.create_no_cutoff
+  Memo.create
     ~input:(module Super_context.As_memo_key)
     "install-rule-scheme"
     (fun sctx ->

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -517,7 +517,6 @@ let setup_lib_html_rules_def =
   Memo.With_implicit_output.create "setup-library-html-rules"
     ~implicit_output:Rules.implicit_output
     ~input:(module Input)
-    ~output:(module Unit)
     f
 
 let setup_lib_html_rules sctx lib ~requires =
@@ -548,9 +547,8 @@ let setup_pkg_html_rules_def =
         ]
   end in
   Memo.With_implicit_output.create "setup-package-html-rules"
-    ~output:(module Unit)
-    ~implicit_output:Rules.implicit_output
     ~input:(module Input)
+    ~implicit_output:Rules.implicit_output
     (fun (sctx, pkg, (libs : Lib.Local.t list)) ->
       let requires =
         let libs = (libs :> Lib.t list) in
@@ -657,9 +655,8 @@ let setup_package_odoc_rules_def =
     let to_dyn (_, name) = Dyn.Tuple [ Package.Name.to_dyn name ]
   end in
   Memo.With_implicit_output.create "setup-package-odoc-rules"
-    ~output:(module Unit)
-    ~implicit_output:Rules.implicit_output
     ~input:(module Input)
+    ~implicit_output:Rules.implicit_output
     (fun (sctx, pkg) ->
       let* mlds = Packages.mlds sctx pkg in
       let mlds = check_mlds_no_dupes ~pkg ~mlds in

--- a/src/dune_rules/packages.ml
+++ b/src/dune_rules/packages.ml
@@ -5,15 +5,9 @@ open Dune_file
 open Memo.Build.O
 
 let mlds_by_package_def =
-  let module Output = struct
-    type t = Path.Build.t list Package.Name.Map.t
-
-    let to_dyn _ = Dyn.Opaque
-  end in
   Memo.With_implicit_output.create "mlds by package"
     ~implicit_output:Rules.implicit_output
     ~input:(module Super_context.As_memo_key)
-    ~output:(module Output)
     (fun sctx ->
       let stanzas = Super_context.stanzas sctx in
       Memo.Build.parallel_map stanzas ~f:(fun (w : _ Dir_with_dune.t) ->

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -183,7 +183,7 @@ end = struct
 
         let memo =
           Memo.exec
-            (Memo.create_no_cutoff "env-nodes-memo"
+            (Memo.create "env-nodes-memo"
                ~input:(module Path.Build)
                (fun path -> Memo.Build.return (get_impl env_tree path)))
 

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -92,7 +92,7 @@ module Spec = struct
     ; f : 'i -> 'o Fiber.t
     }
 
-  let create ~name ~input ?cutoff ~f =
+  let create ~name ~input ?cutoff f =
     let name =
       match name with
       | None when !track_locations_of_lazy_values ->
@@ -695,7 +695,7 @@ end
 
 let create_with_cache (type i o) name ~cache ~input ?cutoff (f : i -> o Fiber.t)
     =
-  let spec = Spec.create ~name:(Some name) ~input ?cutoff ~f in
+  let spec = Spec.create ~name:(Some name) ~input ?cutoff f in
   Caches.register ~clear:(fun () -> Store.clear cache);
   { cache; spec }
 
@@ -1067,7 +1067,7 @@ module Implicit_output = Implicit_output
 module Store = Store_intf
 
 let lazy_cell ?cutoff f =
-  let spec = Spec.create ~name:None ~input:(module Unit) ?cutoff ~f in
+  let spec = Spec.create ~name:None ~input:(module Unit) ?cutoff f in
   make_dep_node ~spec ~input:()
 
 let lazy_ ?cutoff f =

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -66,55 +66,10 @@ module Allow_cutoff = struct
     | Yes of ('o -> 'o -> bool)
 end
 
-module type Output_no_cutoff = sig
-  type t
-
-  val to_dyn : t -> Dyn.t
-end
-
-module type Output_cutoff = sig
-  type t
-
-  val to_dyn : t -> Dyn.t
-
-  val equal : t -> t -> bool
-end
-
 module type Input = sig
   type t
 
   include Table.Key with type t := t
-end
-
-module Output = struct
-  type 'o t =
-    | No_cutoff of (module Output_no_cutoff with type t = 'o)
-    | Cutoff of (module Output_cutoff with type t = 'o)
-
-  let no_cutoff (type a) ?to_dyn () =
-    let to_dyn = Option.value to_dyn ~default:(fun _ -> Dyn.Opaque) in
-    No_cutoff
-      (module struct
-        type t = a
-
-        let to_dyn = to_dyn
-      end)
-
-  let cutoff (type a) ?to_dyn ~(equal : a -> a -> bool) () =
-    let to_dyn = Option.value to_dyn ~default:(fun _ -> Dyn.Opaque) in
-    Cutoff
-      (module struct
-        type t = a
-
-        let to_dyn = to_dyn
-
-        let equal = equal
-      end)
-
-  let create ?cutoff:cutoff_arg ?to_dyn () =
-    match cutoff_arg with
-    | None -> no_cutoff ?to_dyn ()
-    | Some equal -> cutoff ?to_dyn ~equal ()
 end
 
 module Exn_comparable = Comparable.Make (struct
@@ -132,13 +87,12 @@ module Spec = struct
   type ('i, 'o) t =
     { name : string option
     ; input : (module Store_intf.Input with type t = 'i)
-    ; output : (module Output_no_cutoff with type t = 'o)
     ; allow_cutoff : 'o Allow_cutoff.t
     ; witness : 'i Type_eq.Id.t
     ; f : 'i -> 'o Fiber.t
     }
 
-  let create (type o) ~name ~input ~(output : o Output.t) ~f =
+  let create ~name ~input ?cutoff ~f =
     let name =
       match name with
       | None when !track_locations_of_lazy_values ->
@@ -148,12 +102,12 @@ module Spec = struct
             sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
       | _ -> name
     in
-    let (output : (module Output_no_cutoff with type t = o)), allow_cutoff =
-      match output with
-      | No_cutoff (module Output) -> ((module Output), Allow_cutoff.No)
-      | Cutoff (module Output) -> ((module Output), Yes Output.equal)
+    let allow_cutoff =
+      match cutoff with
+      | None -> Allow_cutoff.No
+      | Some equal -> Yes equal
     in
-    { name; input; output; allow_cutoff; witness = Type_eq.Id.create (); f }
+    { name; input; allow_cutoff; witness = Type_eq.Id.create (); f }
 end
 
 module Id = Id.Make ()
@@ -739,26 +693,23 @@ module Stack_frame = struct
     | None -> None
 end
 
-let create_with_cache (type i o) name ~cache ~input ~output (f : i -> o Fiber.t)
+let create_with_cache (type i o) name ~cache ~input ?cutoff (f : i -> o Fiber.t)
     =
-  let spec = Spec.create ~name:(Some name) ~input ~output ~f in
+  let spec = Spec.create ~name:(Some name) ~input ?cutoff ~f in
   Caches.register ~clear:(fun () -> Store.clear cache);
   { cache; spec }
 
 let create_with_store (type i) name
-    ~store:(module S : Store_intf.S with type key = i) ~input ~output f =
+    ~store:(module S : Store_intf.S with type key = i) ~input ?cutoff f =
   let cache = Store.make (module S) in
-  create_with_cache name ~cache ~input ~output f
+  create_with_cache name ~cache ~input ?cutoff f
 
-let create (type i) name ~input:(module Input : Input with type t = i) ~output f
+let create (type i) name ~input:(module Input : Input with type t = i) ?cutoff f
     =
   (* This mutable table is safe: the implementation tracks all dependencies. *)
   let cache = Store.of_table (Table.create (module Input) 16) in
   let input = (module Input : Store_intf.Input with type t = i) in
-  create_with_cache name ~cache ~input ~output f
-
-let create_no_cutoff name ~input ?output_to_dyn f =
-  create name ~input ~output:(Output.no_cutoff ?to_dyn:output_to_dyn ()) f
+  create_with_cache name ~cache ~input ?cutoff f
 
 let make_dep_node ~spec ~input : _ Dep_node.t =
   let dep_node_without_state : _ Dep_node_without_state.t =
@@ -1063,8 +1014,7 @@ let invalidate_dep_node (node : _ Dep_node.t) = node.last_cached_value <- None
 module Current_run = struct
   let f () = Run.current () |> Build0.return
 
-  let memo =
-    create "current-run" ~input:(module Unit) ~output:(No_cutoff (module Run)) f
+  let memo = create "current-run" ~input:(module Unit) f
 
   let exec () = exec memo ()
 
@@ -1084,17 +1034,9 @@ end
 module With_implicit_output = struct
   type ('i, 'o) t = 'i -> 'o Fiber.t
 
-  let create (type o) name ~input
-      ~output:(module O : Output_no_cutoff with type t = o) ~implicit_output
-      impl =
-    let output =
-      Output.no_cutoff
-        ~to_dyn:(fun (o, _io) ->
-          Dyn.List [ O.to_dyn o; Dyn.String "<implicit output is opaque>" ])
-        ()
-    in
+  let create name ~input ~implicit_output impl =
     let memo =
-      create name ~input ~output (fun i ->
+      create name ~input (fun i ->
           Implicit_output.collect implicit_output (fun () -> impl i))
     in
     fun input ->
@@ -1124,13 +1066,12 @@ end
 module Implicit_output = Implicit_output
 module Store = Store_intf
 
-let lazy_cell ?cutoff ?to_dyn f =
-  let output = Output.create ?cutoff ?to_dyn () in
-  let spec = Spec.create ~name:None ~input:(module Unit) ~output ~f in
+let lazy_cell ?cutoff f =
+  let spec = Spec.create ~name:None ~input:(module Unit) ?cutoff ~f in
   make_dep_node ~spec ~input:()
 
-let lazy_ ?cutoff ?to_dyn f =
-  let cell = lazy_cell ?cutoff ?to_dyn f in
+let lazy_ ?cutoff f =
+  let cell = lazy_cell ?cutoff f in
   fun () -> Cell.read cell
 
 module Lazy = struct
@@ -1189,7 +1130,7 @@ struct
   end
 
   let memo =
-    create_no_cutoff name
+    create name
       ~input:(module Key)
       (function
         | Key.T input -> eval input >>| fun v -> Value.T (id input, v))

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -16,9 +16,10 @@ let () = init ()
 
 let printf = Printf.printf
 
-let string_fn_create name = Memo.create name ~input:(module String)
+let string_fn_create name =
+  Memo.create name ~input:(module String) ~cutoff:String.equal
 
-let int_fn_create name = Memo.create name ~input:(module Int)
+let int_fn_create name ~cutoff = Memo.create name ~input:(module Int) ~cutoff
 
 (* to run a computation *)
 let run m = Scheduler.run (Memo.Build.run m)
@@ -29,10 +30,9 @@ let run_memo f v = run (Memo.exec f v)
 let compdep x = Memo.Build.return (x ^ x)
 
 (* our two dependencies are called some and another *)
-let mcompdep1 = string_fn_create "some" ~output:(Cutoff (module String)) compdep
+let mcompdep1 = string_fn_create "some" compdep
 
-let mcompdep2 =
-  string_fn_create "another" ~output:(Cutoff (module String)) compdep
+let mcompdep2 = string_fn_create "another" compdep
 
 (* compute the dependencies once so they are present in the global hash table *)
 let () =
@@ -51,7 +51,7 @@ let comp x =
   counter := !counter + 1;
   String.sub a ~pos:0 ~len:(String.length a |> min 3)
 
-let mcomp = string_fn_create "test" ~output:(Cutoff (module String)) comp
+let mcomp = string_fn_create "test" comp
 
 (* running it the first time should increase the counter, running it again
    should not, but should still return the same result *)
@@ -124,7 +124,7 @@ let mcompcycle =
     else
       failwith "cycle"
   in
-  let fn = int_fn_create "cycle" ~output:(Cutoff (module String)) compcycle in
+  let fn = int_fn_create "cycle" compcycle ~cutoff:Int.equal in
   Fdecl.set mcompcycle fn;
   fn
 
@@ -172,7 +172,7 @@ let mfib =
       let+ r2 = mfib (x - 2) in
       r1 + r2
   in
-  let fn = int_fn_create "fib" ~output:(Cutoff (module Int)) compfib in
+  let fn = int_fn_create "fib" compfib ~cutoff:Int.equal in
   Fdecl.set mfib fn;
   fn
 
@@ -190,13 +190,10 @@ let%expect_test _ =
     2001
   |}]
 
-let make_f name f ~input ~output =
-  Memo.create name ~input ~output:(Cutoff output) f
+let make_f name = Memo.create name ~cutoff:String.equal
 
 let id =
-  let f =
-    make_f "id" Memo.Build.return ~input:(module String) ~output:(module String)
-  in
+  let f = make_f "id" ~input:(module String) Memo.Build.return in
   Memo.exec f
 
 module Test_lazy (Lazy : sig
@@ -209,7 +206,7 @@ end) =
 struct
   let lazy_memo =
     let f =
-      Memo.create_no_cutoff "lazy_memo"
+      Memo.create "lazy_memo"
         ~input:(module String)
         (fun s -> Memo.Build.return (Lazy.create (fun () -> id ("lazy: " ^ s))))
     in
@@ -218,22 +215,20 @@ struct
   let f1_def, f1 =
     let f =
       make_f "f1"
+        ~input:(module String)
         (fun s ->
           let+ s = lazy_memo s >>= Lazy.force in
           "f1: " ^ s)
-        ~input:(module String)
-        ~output:(module String)
     in
     (f, Memo.exec f)
 
   let f2_def, f2 =
     let f =
       make_f "f2"
+        ~input:(module String)
         (fun s ->
           let+ s = lazy_memo s >>= Lazy.force in
           "f2: " ^ s)
-        ~input:(module String)
-        ~output:(module String)
     in
     (f, Memo.exec f)
 
@@ -304,7 +299,7 @@ let%expect_test _ =
 let depends_on_run =
   Memo.create "foobar"
     ~input:(module Unit)
-    ~output:(Cutoff (module Unit))
+    ~cutoff:Unit.equal
     (fun () ->
       let+ (_ : Memo.Run.t) = Memo.current_run () in
       print_endline "running foobar")
@@ -325,10 +320,7 @@ let%expect_test _ =
 let%expect_test _ =
   let f x = Memo.Build.return ("*" ^ x) in
   let memo =
-    Memo.create "for-cell"
-      ~input:(module String)
-      ~output:(Cutoff (module String))
-      f
+    Memo.create "for-cell" ~input:(module String) ~cutoff:String.equal f
   in
   let cell = Memo.cell memo "foobar" in
   print_endline (run (Cell.read cell));
@@ -344,8 +336,6 @@ let%expect_test "fib linked list" =
       ; value : int
       ; next_cell : (int, t) Memo.Cell.t
       }
-
-    let to_dyn t = Dyn.Int t.value
   end in
   let force cell : Element.t Memo.Build.t = Memo.Cell.read cell in
   let memo_fdecl = Fdecl.create Dyn.Encoder.opaque in
@@ -366,12 +356,7 @@ let%expect_test "fib linked list" =
     in
     { Element.next_cell = Memo.cell memo (x + 1); prev_cell; value }
   in
-  let memo =
-    Memo.create "fib"
-      ~input:(module Int)
-      ~output:(No_cutoff (module Element))
-      compute_element
-  in
+  let memo = Memo.create "fib" ~input:(module Int) compute_element in
   Fdecl.set memo_fdecl memo;
   let fourth = run (Memo.exec memo 4) in
   printf "4th: %d\n" fourth.value;
@@ -403,10 +388,7 @@ let%expect_test "previously_evaluated_cell" =
     Memo.Build.return ("[" ^ x ^ "]")
   in
   let memo =
-    Memo.create "boxed"
-      ~input:(module String)
-      ~output:(Cutoff (module String))
-      f
+    Memo.create "boxed" ~input:(module String) ~cutoff:String.equal f
   in
   let evaluate_and_print name =
     let cell = Memo.cell memo name in
@@ -598,9 +580,7 @@ let evaluate_and_print f x =
 
 let%expect_test "error handling and memo" =
   let f =
-    int_fn_create "f"
-      ~output:(Cutoff (module Int))
-      (fun x ->
+    int_fn_create "f" ~cutoff:Int.equal (fun x ->
         printf "Calling f %d\n" x;
         if x = 42 then
           failwith "42"
@@ -657,12 +637,8 @@ let increment which which_memo () =
 
 (* Create a memoization node with or without cutoff. *)
 let create ~with_cutoff name f =
-  let output =
-    match with_cutoff with
-    | true -> Memo.Output.Cutoff (module Int)
-    | false -> No_cutoff (module Int)
-  in
-  Memo.create name ~input:(module Unit) ~output f
+  let cutoff = Option.some_if with_cutoff Int.equal in
+  Memo.create name ~input:(module Unit) ?cutoff f
 
 let%expect_test "diamond with non-uniform cutoff structure" =
   let base = create ~with_cutoff:true "base" (count_runs "base") in
@@ -698,7 +674,7 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     printf "Evaluated summit with offset %d: %d\n" offset result;
     result
   in
-  let summit = Memo.create_no_cutoff "summit" ~input:(module Int) summit in
+  let summit = Memo.create "summit" ~input:(module Int) summit in
   evaluate_and_print summit 0;
   [%expect
     {|
@@ -802,14 +778,10 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
       printf "Evaluated the summit with input %d: %d\n" input result;
       result
     in
-    let output =
-      match end_with_cutoff with
-      | true -> Memo.Output.Cutoff (module Int)
-      | false -> No_cutoff (module Int)
-    in
+    let cutoff = Option.some_if end_with_cutoff Int.equal in
     Memo.create "incrementing_chain_plus_input"
       ~input:(module Int)
-      ~output plus_input
+      ?cutoff plus_input
   in
   let summit_fdecl = Fdecl.create (fun _ -> Dyn.Opaque) in
   let cycle_creator_no_cutoff =
@@ -1032,7 +1004,7 @@ let%expect_test "deadlocks when creating a cycle twice" =
         result)
   in
   let summit =
-    Memo.create_no_cutoff "summit"
+    Memo.create "summit"
       ~input:(module Int)
       (fun offset ->
         printf "Started evaluating summit\n";
@@ -1070,7 +1042,7 @@ let%expect_test "deadlocks when creating a cycle twice" =
 let%expect_test "Nested nodes with cutoff are recomputed optimally" =
   let counter = create ~with_cutoff:false "counter" (count_runs "counter") in
   let summit =
-    Memo.create_no_cutoff "summit"
+    Memo.create "summit"
       ~input:(module Int)
       (fun offset ->
         printf "Started evaluating summit\n";
@@ -1151,7 +1123,7 @@ let%expect_test "Test that there are no phantom dependencies" =
   in
   let cell = Memo.cell const_8 () in
   let summit =
-    Memo.create_no_cutoff "summit"
+    Memo.create "summit"
       ~input:(module Int)
       (fun offset ->
         printf "Started evaluating summit\n";
@@ -1213,7 +1185,7 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
   let last_created_base = ref None in
   let captured_base = ref None in
   let middle =
-    Memo.create_no_cutoff "middle"
+    Memo.create "middle"
       ~input:(module Unit)
       (fun () ->
         printf "Started evaluating middle\n";
@@ -1224,7 +1196,7 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
         result)
   in
   let summit =
-    Memo.create_no_cutoff "summit"
+    Memo.create "summit"
       ~input:(module Int)
       (fun input ->
         printf "Started evaluating summit\n";
@@ -1315,9 +1287,8 @@ let%expect_test "error handling with diamonds" =
   Printexc.record_backtrace true;
   let f_impl = Fdecl.create Dyn.Encoder.opaque in
   let f =
-    int_fn_create "error-diamond: f"
-      ~output:(Cutoff (module Unit))
-      (fun x -> Fdecl.get f_impl x)
+    int_fn_create "error-diamond: f" ~cutoff:Unit.equal (fun x ->
+        Fdecl.get f_impl x)
   in
   Fdecl.set f_impl (fun x ->
       printf "Calling f %d\n" x;
@@ -1348,24 +1319,19 @@ let%expect_test "error handling and duplicate exceptions" =
   Printexc.record_backtrace true;
   let f_impl = Fdecl.create Dyn.Encoder.opaque in
   let f =
-    int_fn_create "test8: duplicate-exception: f"
-      ~output:(Cutoff (module Unit))
-      (fun x -> Fdecl.get f_impl x)
+    int_fn_create "test8: duplicate-exception: f" ~cutoff:Unit.equal (fun x ->
+        Fdecl.get f_impl x)
   in
   let fail =
-    int_fn_create "test8: fail"
-      ~output:(Cutoff (module Unit))
-      (fun _x -> failwith "42")
+    int_fn_create "test8: fail" ~cutoff:Unit.equal (fun _x -> failwith "42")
   in
   let forward_fail =
-    int_fn_create "test8: forward fail"
-      ~output:(Cutoff (module Unit))
-      (fun x -> Memo.exec fail x)
+    int_fn_create "test8: forward fail" ~cutoff:Unit.equal (fun x ->
+        Memo.exec fail x)
   in
   let forward_fail2 =
-    int_fn_create "test8: forward fail2"
-      ~output:(Cutoff (module Unit))
-      (fun x -> Memo.exec fail x)
+    int_fn_create "test8: forward fail2" ~cutoff:Unit.equal (fun x ->
+        Memo.exec fail x)
   in
   Fdecl.set f_impl (fun x ->
       printf "Calling f %d\n" x;
@@ -1389,7 +1355,7 @@ let%expect_test "error handling and duplicate exceptions" =
 let%expect_test "errors are cached" =
   Printexc.record_backtrace false;
   let f =
-    Memo.create_no_cutoff "area of a square"
+    Memo.create "area of a square"
       ~input:(module Int)
       (fun x ->
         printf "Started evaluating %d\n" x;
@@ -1423,7 +1389,7 @@ let%expect_test "errors work with early cutoff" =
     let exception Input_too_large of Memo.Run.t in
     Memo.create "divide 100 by input"
       ~input:(module Int)
-      ~output:(Cutoff (module Int))
+      ~cutoff:Int.equal
       (fun x ->
         let+ run = Memo.current_run () in
         printf "[divide] Started evaluating %d\n" x;
@@ -1435,7 +1401,7 @@ let%expect_test "errors work with early cutoff" =
         res)
   in
   let f =
-    Memo.create_no_cutoff "Negate"
+    Memo.create "Negate"
       ~input:(module Int)
       (fun x ->
         printf "[negate] Started evaluating %d\n" x;


### PR DESCRIPTION
As discussed in #4542, we are removing the requirement to provide `to_dyn` for outputs of memoized functions. This helps us to simplify the API and get rid of some internal complexity.