### PR TITLE
Fix multiple location printing

### DIFF
--- a/src/dune_engine/dep_path.ml
+++ b/src/dune_engine/dep_path.ml
@@ -93,6 +93,17 @@ let is_loc_none loc =
   | None -> true
   | Some loc -> Loc.is_none loc
 
+(* Similar to [output_starts_with_location] in process.ml but operating on
+   [Pp.t]. *)
+let message_starts_with_location msg =
+  (* The implementation is heavy handed but it doesn't seem worth optimising
+     now. Indeed, we have been discussing the idea of extracting the location
+     from command run by Dune more systematically, so it's likely that this code
+     will go away eventually. *)
+  String.is_prefix
+    (Format.asprintf "%a" Pp.to_fmt (User_message.pp msg))
+    ~prefix:"File "
+
 let recover_loc (entries : Entry.t list) =
   match entries with
   (* In principle it makes sense to recover loc for more than just aliases, but
@@ -105,7 +116,7 @@ let recover_loc (entries : Entry.t list) =
 let augment_user_error_loc entries exn =
   match exn with
   | User_error.E (msg, annot) ->
-    if is_loc_none msg.loc then
+    if is_loc_none msg.loc && not (message_starts_with_location msg) then
       match recover_loc entries with
       | None -> exn
       | Some loc -> User_error.E ({ msg with loc = Some loc }, annot)

--- a/test/blackbox-tests/test-cases/executables-implicit-empty-intf.t/run.t
+++ b/test/blackbox-tests/test-cases/executables-implicit-empty-intf.t/run.t
@@ -22,9 +22,6 @@ as will test binaries:
 
   $ dune runtest 2>&1 |
   > sed -e 's,(warn.*32.*),(warning 32),g'
-  File "test/dune", line 2, characters 7-11:
-  2 |  (name test))
-             ^^^^
   File "test/test.ml", line 1, characters 4-10:
   1 | let unused = 1
           ^^^^^^

--- a/test/blackbox-tests/test-cases/private-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/private-modules.t/run.t
@@ -5,10 +5,6 @@
 
   $ dune build --root inaccessible-in-deps 2>&1
   Entering directory 'inaccessible-in-deps'
-  File "dune", line 5, characters 0-49:
-  5 | (alias
-  6 |  (name default)
-  7 |  (action (run ./foo.exe)))
   File "foo.ml", line 1, characters 0-5:
   1 | X.run ();;
       ^^^^^

--- a/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
+++ b/test/blackbox-tests/test-cases/wrapped-transition.t/run.t
@@ -1,8 +1,4 @@
   $ dune build 2>&1 | grep -v ocamlc
-  File "dune", line 5, characters 0-52:
-  5 | (alias
-  6 |  (name default)
-  7 |  (action (run ./fooexe.exe)))
   File "fooexe.ml", line 3, characters 0-7:
   3 | Bar.run ();;
       ^^^^^^^


### PR DESCRIPTION
Since a change in the git repo several weeks ago, Dune prints a location pointing to the dune file even if the output already contains a location. This is especially annoying for compiler errors.

This PR fixes that by not augmenting user messages with a location taken from the stack when the message starts with "File " (we already do a similar analysis in `process.ml`).

The difference can be observed in the tests that were updated.