### PR TITLE
Add performance counters and --watch-metrics flag

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -850,6 +850,7 @@ let term =
         at_exit (fun () -> Dune_stats.close stats);
         stats)
   in
+  if watch_perf_counters then Memo.For_tests.enable_perf_counters ();
   { debug_dep_path
   ; debug_findlib
   ; debug_backtraces

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -38,7 +38,7 @@ type t =
   ; rpc : Dune_rpc_impl.Server.t option
   ; default_target : Arg.Dep.t (* For build & runtest only *)
   ; watch : bool
-  ; watch_perf_counters : bool
+  ; watch_metrics : bool
   ; stats_trace_file : string option
   ; always_show_command_line : bool
   ; promote_install_files : bool
@@ -53,7 +53,7 @@ let root t = t.root
 
 let watch t = t.watch
 
-let watch_perf_counters t = t.watch_perf_counters
+let watch_metrics t = t.watch_metrics
 
 let file_watcher t = t.file_watcher
 
@@ -736,11 +736,11 @@ let term =
           ~doc:
             "Instead of terminating build after completion, wait continuously \
              for file changes.")
-  and+ watch_perf_counters =
+  and+ watch_metrics =
     Arg.(
       value & flag
-      & info [ "perf-counters" ] ~docs
-          ~doc:"Display performance counters in file-watching mode")
+      & info [ "watch-metrics" ] ~docs
+          ~doc:"Display various performance metrics in file-watching mode")
   and+ { Options_implied_by_dash_p.root
        ; only_packages
        ; ignore_promoted_rules
@@ -850,7 +850,7 @@ let term =
         at_exit (fun () -> Dune_stats.close stats);
         stats)
   in
-  if watch_perf_counters then Memo.Perf_counters.enable ();
+  if watch_metrics then Memo.Perf_counters.enable ();
   { debug_dep_path
   ; debug_findlib
   ; debug_backtraces
@@ -871,7 +871,7 @@ let term =
   ; store_orig_src_dir
   ; default_target
   ; watch
-  ; watch_perf_counters
+  ; watch_metrics
   ; stats_trace_file
   ; always_show_command_line
   ; promote_install_files

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -850,7 +850,7 @@ let term =
         at_exit (fun () -> Dune_stats.close stats);
         stats)
   in
-  if watch_perf_counters then Memo.For_tests.enable_perf_counters ();
+  if watch_perf_counters then Memo.Perf_counters.enable ();
   { debug_dep_path
   ; debug_findlib
   ; debug_backtraces

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -38,6 +38,7 @@ type t =
   ; rpc : Dune_rpc_impl.Server.t option
   ; default_target : Arg.Dep.t (* For build & runtest only *)
   ; watch : bool
+  ; watch_perf_counters : bool
   ; stats_trace_file : string option
   ; always_show_command_line : bool
   ; promote_install_files : bool
@@ -51,6 +52,8 @@ let capture_outputs t = t.capture_outputs
 let root t = t.root
 
 let watch t = t.watch
+
+let watch_perf_counters t = t.watch_perf_counters
 
 let file_watcher t = t.file_watcher
 
@@ -733,6 +736,11 @@ let term =
           ~doc:
             "Instead of terminating build after completion, wait continuously \
              for file changes.")
+  and+ watch_perf_counters =
+    Arg.(
+      value & flag
+      & info [ "perf-counters" ] ~docs
+          ~doc:"Display performance counters in file-watching mode")
   and+ { Options_implied_by_dash_p.root
        ; only_packages
        ; ignore_promoted_rules
@@ -862,6 +870,7 @@ let term =
   ; store_orig_src_dir
   ; default_target
   ; watch
+  ; watch_perf_counters
   ; stats_trace_file
   ; always_show_command_line
   ; promote_install_files

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -8,7 +8,7 @@ val rpc : t -> Dune_rpc_impl.Server.t option
 
 val stats : t -> Dune_stats.t option
 
-val watch_perf_counters : t -> bool
+val watch_metrics : t -> bool
 
 val watch : t -> bool
 

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -8,6 +8,8 @@ val rpc : t -> Dune_rpc_impl.Server.t option
 
 val stats : t -> Dune_stats.t option
 
+val watch_perf_counters : t -> bool
+
 val watch : t -> bool
 
 val file_watcher : t -> Dune_engine.Scheduler.Run.file_watcher

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -81,7 +81,7 @@ module Scheduler = struct
       if Common.watch_perf_counters common then
         Console.print_user_message
           (User_message.make
-             [ Pp.textf "%s" (Memo.For_tests.report_for_current_run ()) ]);
+             [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ()) ]);
       let message =
         match res with
         | Success -> Pp.tag User_message.Style.Success (Pp.verbatim "Success")

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -78,7 +78,7 @@ module Scheduler = struct
       in
       Console.Status_line.set_constant status_line
     | Build_finish (build_result, build_duration_in_seconds) ->
-      if Common.watch_perf_counters common then
+      if Common.watch_metrics common then
         Console.print_user_message
           (User_message.make
              [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ())

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -77,13 +77,15 @@ module Scheduler = struct
              (Pp.verbatim ", killing current build..."))
       in
       Console.Status_line.set_constant status_line
-    | Build_finish res ->
+    | Build_finish (build_result, build_duration_in_seconds) ->
       if Common.watch_perf_counters common then
         Console.print_user_message
           (User_message.make
-             [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ()) ]);
+             [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ())
+             ; Pp.textf "(%.2f sec)" build_duration_in_seconds
+             ]);
       let message =
-        match res with
+        match build_result with
         | Success -> Pp.tag User_message.Style.Success (Pp.verbatim "Success")
         | Failure -> Pp.tag User_message.Style.Error (Pp.verbatim "Had errors")
       in

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -713,7 +713,7 @@ module Run = struct
   let poll step =
     let* t = t () in
     let rec loop () : unit Fiber.t =
-      let build_started = Sys.time () in
+      let build_started = Unix.gettimeofday () in
       t.status <- Building;
       let* res =
         let on_error exn =
@@ -742,7 +742,7 @@ module Run = struct
           | Error _ -> Failure
           | Ok _ -> Success
         in
-        let build_duration = Sys.time () -. build_started in
+        let build_duration = Unix.gettimeofday () -. build_started in
         t.handler t.config (Build_finish (build_result, build_duration));
         let ivar = Fiber.Ivar.create () in
         t.status <- Waiting_for_file_changes ivar;

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -37,11 +37,13 @@ module Run : sig
       | Success
       | Failure
 
+    type build_duration_in_seconds = float
+
     type t =
       | Tick
       | Source_files_changed
       | Build_interrupted
-      | Build_finish of build_result
+      | Build_finish of build_result * build_duration_in_seconds
   end
 
   type file_watcher =

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1208,4 +1208,9 @@ module For_tests = struct
       (nodes_in_current_run ())
       (edges_traversed_in_current_run ())
       (edges_in_current_run ())
+
+  let assert_invariants () =
+    assert (nodes_computed_in_current_run () <= nodes_in_current_run ());
+    assert (edges_in_current_run () <= edges_traversed_in_current_run ());
+    assert (edges_traversed_in_current_run () <= 2 * edges_in_current_run ())
 end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -374,4 +374,7 @@ module For_tests : sig
   val edges_traversed_in_current_run : unit -> int
 
   val report_for_current_run : unit -> string
+
+  (** Raise if any internal invariants are violated. *)
+  val assert_invariants : unit -> unit
 end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -357,12 +357,21 @@ val unwrap_exn : (exn -> exn) ref
     a bit expensive to compute, but it helps debugging. *)
 val track_locations_of_lazy_values : bool ref
 
+(** These counters are reset to zero at the start of every run. *)
 module For_tests : sig
-  val nodes_considered_in_current_run : unit -> int
+  (** Number of nodes visited in the current run. *)
+  val nodes_in_current_run : unit -> int
 
-  val edges_considered_in_current_run : unit -> int
+  (** Number of dependency edges of the nodes visited in the current run. *)
+  val edges_in_current_run : unit -> int
 
+  (** Number of nodes that were (re)computed in the current run. This number
+      cannot not exceed [nodes_in_current_run]. *)
   val nodes_computed_in_current_run : unit -> int
+
+  (** Number of edges that were traversed in the current run. Some edges may be
+      traversed twice, so this number can exceed [edges_in_current_run]. *)
+  val edges_traversed_in_current_run : unit -> int
 
   val report_for_current_run : unit -> string
 end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -373,6 +373,10 @@ module For_tests : sig
       traversed twice, so this number can exceed [edges_in_current_run]. *)
   val edges_traversed_in_current_run : unit -> int
 
+  (** This function must be called to enable performance counters. *)
+  val enable_perf_counters : unit -> unit
+
+  (** A concise summary of performance counters. *)
   val report_for_current_run : unit -> string
 
   (** Raise if any internal invariants are violated. *)

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -356,3 +356,13 @@ val unwrap_exn : (exn -> exn) ref
 (** If [true], this module will record the location of [Lazy.t] values. This is
     a bit expensive to compute, but it helps debugging. *)
 val track_locations_of_lazy_values : bool ref
+
+module For_tests : sig
+  val nodes_considered_in_current_run : unit -> int
+
+  val edges_considered_in_current_run : unit -> int
+
+  val nodes_computed_in_current_run : unit -> int
+
+  val report_for_current_run : unit -> string
+end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -357,8 +357,11 @@ val unwrap_exn : (exn -> exn) ref
     a bit expensive to compute, but it helps debugging. *)
 val track_locations_of_lazy_values : bool ref
 
-(** These counters are reset to zero at the start of every run. *)
-module For_tests : sig
+(** Various performance counters. Reset to zero at the start of every run. *)
+module Perf_counters : sig
+  (** This function must be called to enable performance counters. *)
+  val enable : unit -> unit
+
   (** Number of nodes visited in the current run. *)
   val nodes_in_current_run : unit -> int
 
@@ -372,9 +375,6 @@ module For_tests : sig
   (** Number of edges that were traversed in the current run. Some edges may be
       traversed twice, so this number can exceed [edges_in_current_run]. *)
   val edges_traversed_in_current_run : unit -> int
-
-  (** This function must be called to enable performance counters. *)
-  val enable_perf_counters : unit -> unit
 
   (** A concise summary of performance counters. *)
   val report_for_current_run : unit -> string

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -16,6 +16,8 @@ let () = init ()
 
 let printf = Printf.printf
 
+let () = Memo.For_tests.enable_perf_counters ()
+
 let print_perf_counters () =
   Memo.For_tests.assert_invariants ();
   printf "%s\n" (Memo.For_tests.report_for_current_run ())

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -16,11 +16,11 @@ let () = init ()
 
 let printf = Printf.printf
 
-let () = Memo.For_tests.enable_perf_counters ()
+let () = Memo.Perf_counters.enable ()
 
 let print_perf_counters () =
-  Memo.For_tests.assert_invariants ();
-  printf "%s\n" (Memo.For_tests.report_for_current_run ())
+  Memo.Perf_counters.assert_invariants ();
+  printf "%s\n" (Memo.Perf_counters.report_for_current_run ())
 
 let string_fn_create name =
   Memo.create name ~input:(module String) ~cutoff:String.equal

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -17,7 +17,9 @@ let () = init ()
 let printf = Printf.printf
 
 let print_perf_counters () =
-  printf "%s\n" (Memo.For_tests.report_for_current_run ())
+  let open Memo.For_tests in
+  assert (nodes_computed_in_current_run () <= nodes_considered_in_current_run ());
+  printf "%s\n" (report_for_current_run ())
 
 let string_fn_create name =
   Memo.create name ~input:(module String) ~cutoff:String.equal

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -16,6 +16,9 @@ let () = init ()
 
 let printf = Printf.printf
 
+let print_perf_counters () =
+  printf "%s\n" (Memo.For_tests.report_for_current_run ())
+
 let string_fn_create name =
   Memo.create name ~input:(module String) ~cutoff:String.equal
 
@@ -188,7 +191,9 @@ let%expect_test _ =
     2001
     3080005411477819488
     2001
-  |}]
+  |}];
+  print_perf_counters ();
+  [%expect {| 2013/4005 nodes/edges considered, 2013 nodes computed |}]
 
 let make_f name = Memo.create name ~cutoff:String.equal
 
@@ -380,7 +385,10 @@ let%expect_test "fib linked list" =
     computing 6
     7th: 13
     prev: 8
-    prev: 5 |}]
+    prev: 5
+  |}];
+  print_perf_counters ();
+  [%expect {| 11/13 nodes/edges considered, 11 nodes computed |}]
 
 let%expect_test "previously_evaluated_cell" =
   let f x =
@@ -676,6 +684,7 @@ let%expect_test "diamond with non-uniform cutoff structure" =
   in
   let summit = Memo.create "summit" ~input:(module Int) summit in
   evaluate_and_print summit 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating summit with offset 0
@@ -691,16 +700,20 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     Evaluated after_yes_cutoff: 2
     Evaluated summit with offset 0: 4
     f 0 = Ok 4
-    |}];
+    14/7 nodes/edges considered, 14 nodes computed
+  |}];
   evaluate_and_print summit 1;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating summit with offset 1
     Evaluated summit with offset 1: 5
     f 1 = Ok 5
-    |}];
+    15/9 nodes/edges considered, 15 nodes computed
+  |}];
   Memo.restart_current_run ();
   evaluate_and_print summit 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating base
@@ -712,18 +725,24 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     Started evaluating yes_cutoff
     Evaluated yes_cutoff: 1
     f 0 = Ok 4
-    |}];
+    7/7 nodes/edges considered, 5 nodes computed
+  |}];
   evaluate_and_print summit 1;
-  [%expect {|
+  print_perf_counters ();
+  [%expect
+    {|
     f 1 = Ok 5
-    |}];
+    8/9 nodes/edges considered, 5 nodes computed
+  |}];
   evaluate_and_print summit 2;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating summit with offset 2
     Evaluated summit with offset 2: 6
     f 2 = Ok 6
-    |}]
+    9/11 nodes/edges considered, 6 nodes computed
+  |}]
 
 (* The test below sets up the following situation:
 
@@ -811,6 +830,7 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
   let _ = Memo.exec cycle_creator_no_cutoff () in
   [%expect {| |}];
   evaluate_and_print summit_no_cutoff 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating the summit with input 0
@@ -827,8 +847,11 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated incrementing_chain_3_no_cutoff: 4
     Evaluated incrementing_chain_4_yes_cutoff: 5
     Evaluated the summit with input 0: 5
-    f 0 = Ok 5 |}];
+    f 0 = Ok 5
+    16/18 nodes/edges considered, 13 nodes computed
+  |}];
   evaluate_and_print summit_yes_cutoff 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating the summit with input 0
@@ -843,21 +866,30 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated incrementing_chain_3_yes_cutoff: 4
     Evaluated incrementing_chain_4_no_cutoff: 5
     Evaluated the summit with input 0: 5
-    f 0 = Ok 5 |}];
+    f 0 = Ok 5
+    22/24 nodes/edges considered, 19 nodes computed
+  |}];
   evaluate_and_print summit_no_cutoff 2;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating the summit with input 2
     Evaluated the summit with input 2: 7
-    f 2 = Ok 7 |}];
+    f 2 = Ok 7
+    23/25 nodes/edges considered, 20 nodes computed
+  |}];
   evaluate_and_print summit_yes_cutoff 2;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating the summit with input 2
     Evaluated the summit with input 2: 7
-    f 2 = Ok 7 |}];
+    f 2 = Ok 7
+    24/26 nodes/edges considered, 21 nodes computed
+  |}];
   Memo.restart_current_run ();
   evaluate_and_print summit_no_cutoff 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating base
@@ -877,8 +909,11 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     - called by ("incrementing_chain_3_no_cutoff", ())
     - called by ("incrementing_chain_4_yes_cutoff", ())
     - called by ("incrementing_chain_plus_input", 2)
-    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
+    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ]
+    9/8 nodes/edges considered, 9 nodes computed
+  |}];
   evaluate_and_print summit_yes_cutoff 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating cycle_creator_yes_cutoff
@@ -896,8 +931,11 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     - called by ("incrementing_chain_3_yes_cutoff", ())
     - called by ("incrementing_chain_4_no_cutoff", ())
     - called by ("incrementing_chain_plus_input", 2)
-    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
+    f 0 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ]
+    16/15 nodes/edges considered, 16 nodes computed
+  |}];
   evaluate_and_print summit_no_cutoff 2;
+  print_perf_counters ();
   [%expect
     {|
     Dependency cycle detected:
@@ -908,8 +946,11 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     - called by ("incrementing_chain_3_no_cutoff", ())
     - called by ("incrementing_chain_4_yes_cutoff", ())
     - called by ("incrementing_chain_plus_input", 2)
-    f 2 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
+    f 2 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ]
+    16/15 nodes/edges considered, 16 nodes computed
+  |}];
   evaluate_and_print summit_yes_cutoff 2;
+  print_perf_counters ();
   [%expect
     {|
     Dependency cycle detected:
@@ -920,9 +961,12 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     - called by ("incrementing_chain_3_yes_cutoff", ())
     - called by ("incrementing_chain_4_no_cutoff", ())
     - called by ("incrementing_chain_plus_input", 2)
-    f 2 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ] |}];
+    f 2 = Error [ { exn = "Memo.Cycle_error.E(_)"; backtrace = "" } ]
+    16/15 nodes/edges considered, 16 nodes computed
+  |}];
   Memo.restart_current_run ();
   evaluate_and_print summit_no_cutoff 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating base
@@ -939,8 +983,11 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated incrementing_chain_4_yes_cutoff: 7
     Started evaluating the summit with input 0
     Evaluated the summit with input 0: 7
-    f 0 = Ok 7 |}];
+    f 0 = Ok 7
+    8/7 nodes/edges considered, 8 nodes computed
+  |}];
   evaluate_and_print summit_yes_cutoff 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating cycle_creator_yes_cutoff
@@ -955,19 +1002,27 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Started evaluating incrementing_chain_4_no_cutoff
     Evaluated incrementing_chain_4_no_cutoff: 7
     Evaluated the summit with input 0: 7
-    f 0 = Ok 7 |}];
+    f 0 = Ok 7
+    14/13 nodes/edges considered, 14 nodes computed
+  |}];
   evaluate_and_print summit_no_cutoff 2;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating the summit with input 2
     Evaluated the summit with input 2: 9
-    f 2 = Ok 9 |}];
+    f 2 = Ok 9
+    15/14 nodes/edges considered, 15 nodes computed
+  |}];
   evaluate_and_print summit_yes_cutoff 2;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating the summit with input 2
     Evaluated the summit with input 2: 9
-    f 2 = Ok 9 |}]
+    f 2 = Ok 9
+    16/15 nodes/edges considered, 16 nodes computed
+  |}]
 
 let%expect_test "deadlocks when creating a cycle twice" =
   let fdecl_base = Fdecl.create (fun _ -> Dyn.Opaque) in
@@ -1067,6 +1122,7 @@ let%expect_test "Nested nodes with cutoff are recomputed optimally" =
   in
   evaluate_and_print summit 0;
   evaluate_and_print summit 1;
+  print_perf_counters ();
   (* In the first run, everything is OK. *)
   [%expect
     {|
@@ -1086,10 +1142,12 @@ let%expect_test "Nested nodes with cutoff are recomputed optimally" =
     Evaluated middle: 1
     Evaluated summit: 2
     f 1 = Ok 2
-    |}];
+    8/7 nodes/edges considered, 8 nodes computed
+  |}];
   Memo.restart_current_run ();
   evaluate_and_print summit 0;
   evaluate_and_print summit 2;
+  print_perf_counters ();
   (* In the second run, we don't recompute [base] three times as we did before. *)
   [%expect
     {|
@@ -1109,7 +1167,8 @@ let%expect_test "Nested nodes with cutoff are recomputed optimally" =
     Evaluated middle: 2
     Evaluated summit: 4
     f 2 = Ok 4
-    |}]
+    8/7 nodes/edges considered, 8 nodes computed
+  |}]
 
 (* In addition to its direct purpose, this test also: (i) demonstrates what
    happens in the presence of non-determinism; and (ii) tests cell invalidation. *)
@@ -1218,6 +1277,7 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
         result)
   in
   evaluate_and_print summit 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating summit
@@ -1229,9 +1289,11 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
     *** Captured last base ***
     Evaluated summit: 1
     f 0 = Ok 1
-    |}];
+    6/5 nodes/edges considered, 4 nodes computed
+  |}];
   Memo.restart_current_run ();
   evaluate_and_print summit 0;
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating summit
@@ -1243,11 +1305,13 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
     *** Abandoned captured base ***
     Evaluated summit: 0
     f 0 = Ok 0
-    |}];
+    4/3 nodes/edges considered, 4 nodes computed
+  |}];
   (* At this point, [captured_base] is a stale computation: [restore_from_cache]
      failed but [compute] never started. *)
   Memo.restart_current_run ();
   evaluate_and_print summit 0;
+  print_perf_counters ();
   (* We will now attempt to force [compute] of a stale computation but this is
      handled correctly by restarting the computation. Note that this causes an
      additional increment of the counter, thus leading to an inconsistent value
@@ -1265,7 +1329,8 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
     Evaluated base: 4
     Evaluated summit: 4
     f 0 = Ok 4
-    |}]
+    5/5 nodes/edges considered, 5 nodes computed
+  |}]
 
 let print_exns f =
   let res =
@@ -1366,6 +1431,7 @@ let%expect_test "errors are cached" =
   in
   evaluate_and_print f 5;
   evaluate_and_print f (-5);
+  print_perf_counters ();
   [%expect
     {|
     Started evaluating 5
@@ -1373,16 +1439,19 @@ let%expect_test "errors are cached" =
     f 5 = Ok 25
     Started evaluating -5
     f -5 = Error [ { exn = "(Failure \"Negative input -5\")"; backtrace = "" } ]
-    |}];
+    17/13 nodes/edges considered, 17 nodes computed
+  |}];
   evaluate_and_print f 5;
   evaluate_and_print f (-5);
+  print_perf_counters ();
   (* Note that we do not see any "Started evaluating" messages because both [Ok]
      and [Error] results have been cached. *)
   [%expect
     {|
     f 5 = Ok 25
     f -5 = Error [ { exn = "(Failure \"Negative input -5\")"; backtrace = "" } ]
-    |}]
+    17/13 nodes/edges considered, 17 nodes computed
+  |}]
 
 let%expect_test "errors work with early cutoff" =
   let divide =
@@ -1412,6 +1481,7 @@ let%expect_test "errors work with early cutoff" =
   evaluate_and_print f 0;
   evaluate_and_print f 20;
   evaluate_and_print f 200;
+  print_perf_counters ();
   [%expect
     {|
     [negate] Started evaluating 0
@@ -1425,11 +1495,13 @@ let%expect_test "errors work with early cutoff" =
     [negate] Started evaluating 200
     [divide] Started evaluating 200
     f 200 = Error [ { exn = "Input_too_large(_)"; backtrace = "" } ]
-    |}];
+    23/19 nodes/edges considered, 23 nodes computed
+  |}];
   Memo.restart_current_run ();
   evaluate_and_print f 0;
   evaluate_and_print f 20;
   evaluate_and_print f 200;
+  print_perf_counters ();
   (* Here we reevaluate all calls to [divide] because they depend on the current
      run. Due to the early cutoff, we skip recomputing the outer [negate] for
      the inputs 0 (error) and 20 (success), because the results remain the same.
@@ -1445,4 +1517,5 @@ let%expect_test "errors work with early cutoff" =
     [divide] Started evaluating 200
     [negate] Started evaluating 200
     f 200 = Error [ { exn = "Input_too_large(_)"; backtrace = "" } ]
-    |}]
+    7/6 nodes/edges considered, 5 nodes computed
+  |}]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -17,11 +17,8 @@ let () = init ()
 let printf = Printf.printf
 
 let print_perf_counters () =
-  let open Memo.For_tests in
-  assert (nodes_computed_in_current_run () <= nodes_in_current_run ());
-  assert (edges_in_current_run () <= edges_traversed_in_current_run ());
-  assert (edges_traversed_in_current_run () <= 2 * edges_in_current_run ());
-  printf "%s\n" (report_for_current_run ())
+  Memo.For_tests.assert_invariants ();
+  printf "%s\n" (Memo.For_tests.report_for_current_run ())
 
 let string_fn_create name =
   Memo.create name ~input:(module String) ~cutoff:String.equal

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -268,7 +268,7 @@ let%expect_test _ =
 let%expect_test _ =
   (* This test used to demonstrate a bug due to a bad interaction between [lazy]
      and synchronous memoized functions. The dependency on [lazy] was only
-     registered by one of the dependants below, which meant we couldn't safely
+     registered by one of the dependents below, which meant we couldn't safely
      use [lazy] together with [Memo].
 
      Now that [Memo] doesn't support memoization of synchronous functions
@@ -1279,10 +1279,9 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
         printf "Evaluated summit: %d\n" result;
         result)
   in
+  Memo.restart_current_run ();
   evaluate_and_print summit 0;
   print_perf_counters ();
-  (* CR-someday amokhov: Here, in the first run, we consider 6 nodes but compute
-     only 4 of them. How does that happen? *)
   [%expect
     {|
     Started evaluating summit
@@ -1294,7 +1293,7 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
     *** Captured last base ***
     Evaluated summit: 1
     f 0 = Ok 1
-    6/5 nodes/edges considered, 4 nodes computed
+    4/4 nodes/edges considered, 4 nodes computed
   |}];
   Memo.restart_current_run ();
   evaluate_and_print summit 0;

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -830,7 +830,8 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
      in deadlocks and reappearance of zombie computations. The problem has now
      been fixed and so the line below is just a no-op. *)
   let _ = Memo.exec cycle_creator_no_cutoff () in
-  [%expect {| |}];
+  print_perf_counters ();
+  [%expect {| 9/11 nodes/edges considered, 6 nodes computed |}];
   evaluate_and_print summit_no_cutoff 0;
   print_perf_counters ();
   [%expect
@@ -1280,6 +1281,8 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
   in
   evaluate_and_print summit 0;
   print_perf_counters ();
+  (* CR-someday amokhov: Here, in the first run, we consider 6 nodes but compute
+     only 4 of them. How does that happen? *)
   [%expect
     {|
     Started evaluating summit


### PR DESCRIPTION
To assist performance tuning of Memo, I'd like to add some performance counters.

For now, they include:
* `nodes_in_current_run`: number of nodes visited in the current run.
* `edges_in_current_run`: number of dependency edges of the nodes visited in the current run.
* `nodes_computed_in_current_run`: number of nodes that were (re)computed in the current run. This number cannot not exceed `nodes_in_current_run`. 
* `edges_traversed_in_current_run`: number of edges that were traversed in the current run. Some edges may be traversed twice, so this number can exceed `edges_in_current_run`.

I added the counters to some Memo tests, so that we can catch possible regressions (e.g. changes in cutoff behaviour).

It's also possible to run Dune with `-w --watch-metrics` to display the counters after each build, as well as the time the build took, as follows:

```
59593/59593 computed/total nodes, 182876/182876 traversed/total edges
(8.38 sec)
                                          
********** NEW BUILD **********

59589/59614 computed/total nodes, 181027/181006 traversed/total edges
(3.26 sec)
Success, waiting for filesystem changes...
```

The above numbers are for rebuilding Dune's `runtest`.

We might also add some other counters, e.g. the number of loaded and executed rules, etc.