### PR TITLE
Add Dune_engine.Process unit test

### DIFF
--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -112,7 +112,7 @@ module Io = struct
       | Out -> Config.dev_null_out
     in
     let channel = lazy (channel_of_descr (Lazy.force fd) mode) in
-    { kind = Null; mode; fd; channel; status = Close_after_exec }
+    { kind = Null; mode; fd; channel; status = Keep_open }
 
   let file : type a. _ -> ?perm:int -> a mode -> a t =
    fun fn ?(perm = 0o666) mode ->

--- a/src/dune_util/config.ml
+++ b/src/dune_util/config.ml
@@ -10,9 +10,9 @@ let dev_null = Path.of_filename_relative_to_initial_cwd dev_null_fn
 
 let open_null flags = lazy (Unix.openfile dev_null_fn flags 0o666)
 
-let dev_null_in = open_null [ Unix.O_RDONLY ]
+let dev_null_in = open_null [ Unix.O_RDONLY; Unix.O_CLOEXEC ]
 
-let dev_null_out = open_null [ Unix.O_WRONLY ]
+let dev_null_out = open_null [ Unix.O_WRONLY; Unix.O_CLOEXEC ]
 
 let inside_emacs = Option.is_some (Env.get Env.initial "INSIDE_EMACS")
 

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -25,4 +25,4 @@ let%expect_test "null output" =
   let stderr_to = Process.(Io.null Out) in
   let run () = Process.run ~stdout_to ~stderr_to Strict true_ [] in
   let _res = go run in
-  [%expect{||}]
+  [%expect {||}]

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -1,0 +1,34 @@
+open Stdune
+open! Dune_tests_common
+open Dune_engine
+
+let go =
+  let config =
+    { Scheduler.Config.concurrency = 1
+    ; display = Short
+    ; rpc = None
+    ; stats = None
+    }
+  in
+  Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ())
+
+let true_ = Bin.which "true" ~path:(Env.path Env.initial) |> Option.value_exn
+
+let%expect_test "null input" =
+  let stdin_from = Process.(Io.null In) in
+  let run () = Process.run ~stdin_from Strict true_ [] in
+  let _res = go run in
+  [%expect {||}]
+
+let%expect_test "null output" =
+  let stdout_to = Process.(Io.null Out) in
+  let stderr_to = Process.(Io.null Out) in
+  let run () = Process.run ~stdout_to ~stderr_to Strict true_ [] in
+  let _res = go run in
+  [%expect.unreachable]
+  [@@expect.uncaught_exn
+    {|
+  (Dune_util.Report_error.Already_reported)
+  Trailing output
+  ---------------
+  Error: close: : Bad file descriptor |}]

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -25,10 +25,4 @@ let%expect_test "null output" =
   let stderr_to = Process.(Io.null Out) in
   let run () = Process.run ~stdout_to ~stderr_to Strict true_ [] in
   let _res = go run in
-  [%expect.unreachable]
-  [@@expect.uncaught_exn
-    {|
-  (Dune_util.Report_error.Already_reported)
-  Trailing output
-  ---------------
-  Error: close: : Bad file descriptor |}]
+  [%expect{||}]


### PR DESCRIPTION
Test demonstrates that Process.Io.null cannot be used as input or
output.

This is an old issue that I encountered when changing the VCS code. I'm not sure
if this is intentional, but it does make Process.Io.null hard to use correctly.