### PR TITLE
Fix the error "end of file reading inotify pipe" .

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -582,9 +582,8 @@ let got_signal signal =
   if !Log.verbose then
     Log.info [ Pp.textf "Got signal %s, exiting." (Signal.name signal) ]
 
-let filesystem_wathcer_terminated () =
-  if !Log.verbose then
-    Log.info [ Pp.textf "Filesystem watcher terminated, exiting." ]
+let filesystem_watcher_terminated () =
+  Log.info [ Pp.textf "Filesystem watcher terminated, exiting." ]
 
 type saw_signal =
   | Ok
@@ -692,7 +691,7 @@ end = struct
           | Waiting_for_file_changes ivar -> Fill (ivar, File_system_changed)))
       | Rpc fill -> fill
       | File_system_watcher_terminated ->
-        filesystem_wathcer_terminated ();
+        filesystem_watcher_terminated ();
         raise (Abort Got_signal_or_watcher_failed)
       | Signal signal ->
         got_signal signal;

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -113,6 +113,7 @@ end
 module Event : sig
   type t =
     | File_system_changed of Fs_memo.Event.t Nonempty_list.t
+    | File_system_watcher_terminated
     | Job_completed of job * Proc.Process_info.t
     | Signal of Signal.t
     | Rpc of Fiber.fill
@@ -145,7 +146,7 @@ module Event : sig
     val register_rpc_started : t -> unit
 
     (** Send an event to the main thread. *)
-    val send_files_changed : t -> Path.t list -> unit
+    val send_file_watcher_events : t -> Dune_file_watcher.Event.t list -> unit
 
     val send_job_completed : t -> job -> Proc.Process_info.t -> unit
 
@@ -155,6 +156,7 @@ module Event : sig
 end = struct
   type t =
     | File_system_changed of Fs_memo.Event.t Nonempty_list.t
+    | File_system_watcher_terminated
     | Job_completed of job * Proc.Process_info.t
     | Signal of Signal.t
     | Rpc of Fiber.fill
@@ -162,7 +164,7 @@ end = struct
   module Queue = struct
     type t =
       { jobs_completed : (job * Proc.Process_info.t) Queue.t
-      ; mutable files_changed : Path.t list
+      ; mutable file_watcher_events : Dune_file_watcher.Event.t list
       ; mutable signals : Signal.Set.t
       ; mutex : Mutex.t
       ; cond : Condition.t
@@ -183,7 +185,7 @@ end = struct
     let create stats =
       let jobs_completed = Queue.create () in
       let rpc_completed = Queue.create () in
-      let files_changed = [] in
+      let file_watcher_events = [] in
       let signals = Signal.Set.empty in
       let mutex = Mutex.create () in
       let cond = Condition.create () in
@@ -191,7 +193,7 @@ end = struct
       let pending_jobs = 0 in
       let pending_rpc = 0 in
       { jobs_completed
-      ; files_changed
+      ; file_watcher_events
       ; signals
       ; mutex
       ; cond
@@ -212,7 +214,7 @@ end = struct
 
     let available q =
       not
-        (List.is_empty q.files_changed
+        (List.is_empty q.file_watcher_events
         && Queue.is_empty q.jobs_completed
         && Signal.Set.is_empty q.signals
         && Queue.is_empty q.rpc_completed)
@@ -229,7 +231,7 @@ end = struct
           q.signals <- Signal.Set.remove q.signals signal;
           Signal signal
         | None -> (
-          match q.files_changed with
+          match q.file_watcher_events with
           | [] -> (
             match Queue.pop q.jobs_completed with
             | None ->
@@ -239,10 +241,15 @@ end = struct
               q.pending_jobs <- q.pending_jobs - 1;
               assert (q.pending_jobs >= 0);
               Job_completed (job, proc_info))
-          | files_changed -> (
-            q.files_changed <- [];
+          | events -> (
+            q.file_watcher_events <- [];
+            let terminated = ref false in
             let events =
-              List.filter_map files_changed ~f:(fun path ->
+              List.filter_map events ~f:(function
+                | Watcher_terminated ->
+                  terminated := true;
+                  None
+                | File_changed path ->
                   let abs_path = Path.to_absolute_filename path in
                   if Table.mem q.ignored_files abs_path then (
                     (* only use ignored record once *)
@@ -252,9 +259,12 @@ end = struct
                     (* CR-soon amokhov: Generate more precise events. *)
                     Some (Fs_memo.Event.create ~kind:Unknown ~path))
             in
-            match Nonempty_list.of_list events with
-            | None -> loop ()
-            | Some events -> File_system_changed events))
+            match !terminated with
+            | true -> File_system_watcher_terminated
+            | false -> (
+              match Nonempty_list.of_list events with
+              | None -> loop ()
+              | Some events -> File_system_changed events)))
       in
       let ev = loop () in
       Mutex.unlock q.mutex;
@@ -267,10 +277,10 @@ end = struct
       if not avail then Condition.signal q.cond;
       Mutex.unlock q.mutex
 
-    let send_files_changed q files =
+    let send_file_watcher_events q files =
       Mutex.lock q.mutex;
       let avail = available q in
-      q.files_changed <- List.rev_append files q.files_changed;
+      q.file_watcher_events <- List.rev_append files q.file_watcher_events;
       if not avail then Condition.signal q.cond;
       Mutex.unlock q.mutex
 
@@ -572,6 +582,10 @@ let got_signal signal =
   if !Log.verbose then
     Log.info [ Pp.textf "Got signal %s, exiting." (Signal.name signal) ]
 
+let filesystem_wathcer_terminated () =
+  if !Log.verbose then
+    Log.info [ Pp.textf "Filesystem watcher terminated, exiting." ]
+
 type saw_signal =
   | Ok
   | Got_signal
@@ -623,7 +637,7 @@ let prepare (config : Config.t) ~(handler : Handler.t) =
 
 module Run_once : sig
   type run_error =
-    | Got_signal
+    | Got_signal_or_watcher_failed
     | Never
     | Exn of Exn_with_backtrace.t
 
@@ -631,7 +645,7 @@ module Run_once : sig
   val run_and_cleanup : t -> (unit -> 'a Fiber.t) -> ('a, run_error) Result.t
 end = struct
   type run_error =
-    | Got_signal
+    | Got_signal_or_watcher_failed
     | Never
     | Exn of Exn_with_backtrace.t
 
@@ -677,9 +691,12 @@ end = struct
             iter t
           | Waiting_for_file_changes ivar -> Fill (ivar, File_system_changed)))
       | Rpc fill -> fill
+      | File_system_watcher_terminated ->
+        filesystem_wathcer_terminated ();
+        raise (Abort Got_signal_or_watcher_failed)
       | Signal signal ->
         got_signal signal;
-        raise (Abort Got_signal)
+        raise (Abort Got_signal_or_watcher_failed)
     )
 
   let run t f : _ result =
@@ -696,7 +713,7 @@ end = struct
     let res = run t f in
     Console.Status_line.set_constant None;
     match kill_and_wait_for_all_processes t with
-    | Got_signal -> Error Got_signal
+    | Got_signal -> Error Got_signal_or_watcher_failed
     | Ok -> res
 end
 
@@ -765,13 +782,13 @@ module Run = struct
       | Detect_external ->
         Some
           (Dune_file_watcher.create_default
-             ~thread_safe_send_files_changed:(fun files_changed ->
-               Event_queue.send_files_changed t.events files_changed))
+             ~thread_safe_send_events:(fun files_changed ->
+               Event_queue.send_file_watcher_events t.events files_changed))
     in
     let result =
       match Run_once.run_and_cleanup t run with
       | Ok a -> Result.Ok a
-      | Error (Got_signal | Never) ->
+      | Error (Got_signal_or_watcher_failed | Never) ->
         let exn =
           if t.status = Shutting_down then
             Shutdown_requested

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -33,7 +33,7 @@ module Buffer = struct
     buffer.size <- buffer.size + len;
     if len = 0 then
       `End_of_file
-        (Bytes.sub_string buffer.data ~pos:0 ~len:(Bytes.length buffer.data))
+        (Bytes.sub_string buffer.data ~pos:0 ~len:(buffer.size))
     else
       `Ok
         (let lines = ref [] in
@@ -176,7 +176,8 @@ let create_no_buffering ~thread_safe_send_events ~root =
     while true do
       let lines =
         match Buffer.read_lines buffer pipe with
-        | `End_of_file _ -> [ Event.Watcher_terminated ]
+        | `End_of_file _remaining ->
+          [ Event.Watcher_terminated ]
         | `Ok lines ->
           List.map lines ~f:(fun line ->
               match parse_line line with

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -5,6 +5,12 @@ type t =
   ; wait_for_watches_established : unit -> unit
   }
 
+module Event = struct
+  type t =
+    | File_changed of Path.t
+    | Watcher_terminated
+end
+
 let pid t = t.pid
 
 let buffer_capacity = 65536
@@ -163,33 +169,32 @@ let spawn_external_watcher ~root =
   Option.iter stderr ~f:Unix.close;
   ((r_stdout, parse_line, wait), pid)
 
-let create_no_buffering ~thread_safe_send_files_changed ~root =
+let create_no_buffering ~thread_safe_send_events ~root =
   let (pipe, parse_line, wait), pid = spawn_external_watcher ~root in
   let worker_thread pipe =
     let buffer = Buffer.create ~capacity:buffer_capacity in
     while true do
       let lines =
-        List.map
-          (match Buffer.read_lines buffer pipe with
-          | `End_of_file _ -> failwith "end of file reading inotify pipe"
-          | `Ok lines -> lines)
-          ~f:(fun line ->
-            match parse_line line with
-            | Error s -> failwith s
-            | Ok path -> Path.of_string path)
+        match Buffer.read_lines buffer pipe with
+        | `End_of_file _ -> [ Event.Watcher_terminated ]
+        | `Ok lines ->
+          List.map lines ~f:(fun line ->
+              match parse_line line with
+              | Error s -> failwith s
+              | Ok path -> Event.File_changed (Path.of_string path))
       in
-      thread_safe_send_files_changed lines
+      thread_safe_send_events lines
     done
   in
   ignore (Thread.create worker_thread pipe : Thread.t);
   { pid; wait_for_watches_established = wait }
 
-let with_buffering ~create ~thread_safe_send_files_changed ~debounce_interval =
+let with_buffering ~create ~thread_safe_send_events ~debounce_interval =
   let files_changed = ref [] in
   let event_mtx = Mutex.create () in
   let event_cv = Condition.create () in
   let res =
-    create ~thread_safe_send_files_changed:(fun lines ->
+    create ~thread_safe_send_events:(fun lines ->
         Mutex.lock event_mtx;
         files_changed := List.rev_append lines !files_changed;
         Condition.signal event_cv;
@@ -215,18 +220,18 @@ let with_buffering ~create ~thread_safe_send_files_changed ~debounce_interval =
     let files = !files_changed in
     files_changed := [];
     Mutex.unlock event_mtx;
-    thread_safe_send_files_changed files;
+    thread_safe_send_events files;
     Thread.delay debounce_interval;
     buffer_thread ()
   in
   ignore (Thread.create buffer_thread () : Thread.t);
   res
 
-let create ~root ~debounce_interval ~thread_safe_send_files_changed =
+let create ~root ~debounce_interval ~thread_safe_send_events =
   match debounce_interval with
-  | None -> create_no_buffering ~root ~thread_safe_send_files_changed
+  | None -> create_no_buffering ~root ~thread_safe_send_events
   | Some debounce_interval ->
-    with_buffering ~thread_safe_send_files_changed ~debounce_interval
+    with_buffering ~thread_safe_send_events ~debounce_interval
       ~create:(create_no_buffering ~root)
 
 let create_default =

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -32,8 +32,7 @@ module Buffer = struct
     in
     buffer.size <- buffer.size + len;
     if len = 0 then
-      `End_of_file
-        (Bytes.sub_string buffer.data ~pos:0 ~len:(buffer.size))
+      `End_of_file (Bytes.sub_string buffer.data ~pos:0 ~len:buffer.size)
     else
       `Ok
         (let lines = ref [] in
@@ -176,8 +175,7 @@ let create_no_buffering ~thread_safe_send_events ~root =
     while true do
       let lines =
         match Buffer.read_lines buffer pipe with
-        | `End_of_file _remaining ->
-          [ Event.Watcher_terminated ]
+        | `End_of_file _remaining -> [ Event.Watcher_terminated ]
         | `Ok lines ->
           List.map lines ~f:(fun line ->
               match parse_line line with

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -2,16 +2,22 @@ open! Stdune
 
 type t
 
+module Event : sig
+  type t =
+    | File_changed of Path.t
+    | Watcher_terminated
+end
+
 (** Create a new file watcher. [debounce_interval] is measured in seconds and it
     controls the minimum time between calls to [thread_safe_send_files_changed]. *)
 val create :
      root:Path.t
   -> debounce_interval:float option
-  -> thread_safe_send_files_changed:(Path.t list -> unit)
+  -> thread_safe_send_events:(Event.t list -> unit)
   -> t
 
 (** Create a new file watcher with default settings. *)
-val create_default : thread_safe_send_files_changed:(Path.t list -> unit) -> t
+val create_default : thread_safe_send_events:(Event.t list -> unit) -> t
 
 (** Pid of the external file watcher process *)
 val pid : t -> Pid.t


### PR DESCRIPTION
In my previous PR I introduced a bug where dune fails with this message whenever the inotify watcher is killed:

```
Thread 3 killed on uncaught exception Failure("end of file reading inotify pipe")
```

That includes when the watcher is killed by dune itself, for example on exit (e.g. when you terminate it with a signal).

This PR fixes that bug by propagating the failure to the main thread and handling it explicitly.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>