### PR TITLE
Fix handling of signals

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -786,8 +786,12 @@ module Run = struct
       | Detect_external ->
         Some
           (Dune_file_watcher.create_default
-             ~thread_safe_send_events:(fun files_changed ->
-               Event_queue.send_file_watcher_events t.events files_changed))
+             ~scheduler:
+               { spawn_thread = Thread.spawn
+               ; thread_safe_send_events =
+                   (fun files_changed ->
+                     Event_queue.send_file_watcher_events t.events files_changed)
+               })
     in
     let result =
       match Run_once.run_and_cleanup t run with


### PR DESCRIPTION
Fix the issue described [here](https://github.com/ocaml/dune/pull/4571#issuecomment-833354432). 

More precisely, fix the last reason why we are sometimes seeing the following when doing Ctrl+C:

```
Thread 3 killed on uncaught exception Failure("end of file reading inotify pipe")
```

The fix is to pass the `Thread.create` function defined in `scheduler.ml` to `Dune_file_watcher` and use it instead of the regular `Thread.create`. I used an API that is similar to the one used in `Csexp_rpc`. I'm thinking that it might be worth adding a `Thread` module in `Stdune` that would do this overriding once and for all. We might want to generalise this trick, for instance so that it can work with any signals the application might be interested in, so I'm leaving that for future work for now.