### PR TITLE
Delay calling Memo.reset until the build is cancelled

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -682,7 +682,6 @@ end = struct
         match (Fs_memo.handle events : Fs_memo.Rebuild_required.t) with
         | No -> iter t (* Ignore the event *)
         | Yes -> (
-          Memo.reset ();
           match t.status with
           | Shutting_down
           | Restarting_build ->
@@ -764,7 +763,9 @@ module Run = struct
         (* We just finished a build, so there's no way this was set *)
         assert false
       | Shutting_down -> Fiber.return ()
-      | Restarting_build -> loop ()
+      | Restarting_build ->
+        Memo.reset ();
+        loop ()
       | Building -> (
         let build_result : Handler.Event.build_result =
           match res with


### PR DESCRIPTION
With the current change, the build no longer deadlocks but we memoize `got signal KILL` as result of cancelled computations and so build can't proceed anyway. So, we need a way to mark these computations as "cancelled" and not memoize them. I'm going to do this right in this PR.