### PR TITLE
Avoid fiber deadlocks

### DIFF
--- a/otherlibs/stdune-unstable/exn_with_backtrace.ml
+++ b/otherlibs/stdune-unstable/exn_with_backtrace.ml
@@ -10,6 +10,11 @@ let try_with f =
   | r -> Result.Ok r
   | exception exn -> Error (capture exn)
 
+let try_with_never_returns f =
+  match f () with
+  | (_ : Nothing.t) -> .
+  | exception exn -> capture exn
+
 let reraise { exn; backtrace } = Exn.raise_with_backtrace exn backtrace
 
 let pp_uncaught fmt { exn; backtrace } =

--- a/otherlibs/stdune-unstable/exn_with_backtrace.mli
+++ b/otherlibs/stdune-unstable/exn_with_backtrace.mli
@@ -7,6 +7,8 @@ type t =
 
 val try_with : (unit -> 'a) -> ('a, t) Result.t
 
+val try_with_never_returns : (unit -> Nothing.t) -> t
+
 (** This function should be the very first thing called in the exception handler
     if you want it to work correctly. Otherwise it might capture an incorrect
     backtrace. *)

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -145,7 +145,10 @@ with type 'a fiber := 'a t
     It is guaranteed that after the fiber has returned a value, [on_error] will
     never be called. *)
 val with_error_handler :
-  (unit -> 'a t) -> on_error:(Exn_with_backtrace.t -> unit t) -> 'a t
+  (unit -> 'a t) -> on_error:(Exn_with_backtrace.t -> Nothing.t t) -> 'a t
+
+val with_error_handler_unit :
+  (unit -> unit t) -> on_error:(Exn_with_backtrace.t -> unit t) -> unit t
 
 val map_reduce_errors :
      (module Monoid with type t = 'a)
@@ -373,3 +376,16 @@ type fill = Fill : 'a Ivar.t * 'a -> fill
     the scheduler, it should block waiting for an event and return an ivar to
     fill. *)
 val run : 'a t -> iter:(unit -> fill) -> 'a
+
+module For_tests : sig
+  (** This function is used internally to implement [map_reduce_errors],
+      so its behavior is worth testing.
+
+      However, note that this function violates the invariant that every fiber either
+      returns a value or fails with one or more errors.
+      (if [on_error] does not re-raise the exception, then the fiber returned by
+      [with_error_handler_internal] fails with 0 errors)
+  *)
+  val with_error_handler_internal :
+    (unit -> 'a t) -> on_error:(Exn_with_backtrace.t -> unit t) -> 'a t
+end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -81,7 +81,7 @@ module Build : sig
       the transition to the memo monad *)
 
   val with_error_handler :
-    (unit -> 'a t) -> on_error:(Exn_with_backtrace.t -> unit t) -> 'a t
+    (unit -> 'a t) -> on_error:(Exn_with_backtrace.t -> Nothing.t t) -> 'a t
 
   val map_reduce_errors :
        (module Monoid with type t = 'a)


### PR DESCRIPTION
This PR makes the following changes:

- `Scheduler` no longer silently ignores the `Never` errors, instead reporting them as a deadlock code_error
- We get rid of the uses of `with_error_handler` that were prone to causing these "deadlocks". In particular we use `Fiber.map_reduce_errors` in to collect errors in scheduler.ml itself.
- We change the type of `with_error_handler` to require that `on_error` fails, so it can still be used to catch&re-raise errors, but not to suppress them. Expose a couple of different versions as required by the tests.