### PR TITLE
Simplify the signature of Action_builder.static_eval

### DIFF
--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -268,10 +268,8 @@ val action_stdout : Action_desc.t t -> string t
 
 (** {1 Analysis} *)
 
-(** Returns [Some (x, t)] if the following can be evaluated statically. The
-    returned [t] should be attached to the current action builder to record
-    dependencies and other informations. Otherwise return [None]. *)
-val static_eval : 'a t -> ('a * unit t) option
+(** Returns [Some (x, deps)] if the following can be evaluated statically. *)
+val static_eval : 'a t -> ('a * Dep.Set.t) option
 
 (** [goal t] ignores all facts that have been accumulated about the dependencies
     of [t]. For example, [goal (path p)] declares that a path [p] contributes to

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -275,8 +275,8 @@ end = struct
         (* Try to collect the dependency statically as it helps for [dune
            external-lib-deps]. *)
         match Action_builder.static_eval x with
-        | Some (x, builder) -> (
-          ( builder >>> Action_builder.return x
+        | Some (x, deps) -> (
+          ( Action_builder.deps deps >>> Action_builder.return x
           , match f x with
             | None -> acc
             | Some fn ->
@@ -310,8 +310,8 @@ end = struct
         (fn, acc)
       else
         match Action_builder.static_eval fn with
-        | Some (fn, fn_builder) ->
-          ( fn_builder >>> Action_builder.return fn
+        | Some (fn, deps) ->
+          ( Action_builder.deps deps >>> Action_builder.return fn
           , { acc with
               deps_if_exist =
                 { acc.deps_if_exist with


### PR DESCRIPTION
Now that `external-lib-deps` and `Action_builder`'s labels are gone, we can simplify the API of `Action_builder.static_eval` to just:

```ocaml
val static_eval : 'a t -> ('a * Dep.Set.t) option
```

rather than:

```ocaml
val static_eval : 'a t -> ('a * unit t) option
```

I need this for some change I was looking at.
