### PR TITLE
Add a missing call to [Memo.reset]

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -780,6 +780,7 @@ module Run = struct
         match next with
         | Shutdown_requested -> Fiber.return ()
         | File_system_changed -> (
+          Memo.reset ();
           t.handler t.config Source_files_changed;
           match res with
           | Error _


### PR DESCRIPTION
In #4579 I missed one of the code paths where we need to reset Memo which led to incremental builds getting stuck.