### PR TITLE
Add heap words to build metrics

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -11,7 +11,7 @@ let run_build_system ~common ~(targets : unit -> Target.t list Memo.Build.t) =
         Build_system.build (Target.request targets))
   in
   if Common.print_metrics common then
-    let gc_stat = Gc.stat () in
+    let gc_stat = Gc.quick_stat () in
     Console.print_user_message
       (User_message.make
          [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ())

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -11,10 +11,13 @@ let run_build_system ~common ~(targets : unit -> Target.t list Memo.Build.t) =
         Build_system.build (Target.request targets))
   in
   if Common.print_metrics common then
+    let gc_stat = Gc.stat () in
     Console.print_user_message
       (User_message.make
          [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ())
-         ; Pp.textf "(%.2f sec)" (Unix.gettimeofday () -. build_started)
+         ; Pp.textf "(%.2f sec, %d heap words)"
+             (Unix.gettimeofday () -. build_started)
+             gc_stat.heap_words
          ])
 
 let run_build_command_poll ~(common : Common.t) ~config ~targets ~setup =


### PR DESCRIPTION
With this PR, our metrics change to

```
38341/38366 computed/total nodes, 136891/136870 traversed/total edges
(2.28 sec, 18864128 heap words)
```