### PR TITLE
Do not hash context name as int

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1386,7 +1386,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 6
+  let rule_digest_version = 7
 
   let compute_rule_digest (rule : Rule.t) ~deps ~action ~sandbox_mode
       ~execution_parameters =
@@ -1395,7 +1395,7 @@ end = struct
       ( rule_digest_version (* Update when changing the rule digest scheme. *)
       , Dep.Facts.digest deps ~sandbox_mode ~env
       , Path.Build.Set.to_list_map rule.targets ~f:Path.Build.to_string
-      , Option.map rule.context ~f:(fun c -> c.name)
+      , Option.map rule.context ~f:(fun c -> Context_name.to_string c.name)
       , Action.for_shell action
       , can_go_in_shared_cache
       , List.map locks ~f:Path.to_string

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [6ec44a424c52333d35bc6365f2e7f23c]: ((in_cache
+  Warning: cache store error [c22cd66f69ccd6561b3b4d75f66ac0a8]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [6ec44a424c52333d35bc6365f2e7f23c]: ((in_cache
+  Warning: cache store error [c22cd66f69ccd6561b3b4d75f66ac0a8]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [6ec44a424c52333d35bc6365f2e7f23c]: ((in_cache
+  Warning: cache store error [c22cd66f69ccd6561b3b4d75f66ac0a8]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -77,10 +77,10 @@ You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort)
-  ./3c/3c88ff1c5f6067928e7e90902e6defa2:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
-  ./c3/c31593b485b2e11105d5c897464ea8e4:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./35/35e3c4c23bc41f4fc922c70f55c090d8:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./cc/cc55701449a53c9d88c1ae9c502b0668:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/3c/3c88ff1c5f6067928e7e90902e6defa2"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/cc/cc55701449a53c9d88c1ae9c502b0668"
   70
 
 Trimming the cache at this point should not remove any file entries because all


### PR DESCRIPTION
Context names are represented with ints internally, so marshalling them is a bug.
This PR fixes that bug by marshalling the corresponding string, instead.