### PR TITLE
Roundtrip formatting through Janestreet style.

### DIFF
--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -384,14 +384,10 @@ let setup_rule cctx ~source_rule coq_module =
   if coq_debug then
     Format.eprintf "gen_rule coq_module: %a@\n%!" Pp.to_fmt
       (Dyn.pp (Coq_module.to_dyn coq_module));
-
   let file_flags = Context.coqc_file_flags cctx in
-
   let coqdep_rule = coqdep_rule cctx ~source_rule ~file_flags coq_module in
-
   (* Process coqdep and generate rules *)
   let deps_of = deps_of ~dir:cctx.dir ~boot_type:cctx.boot_type coq_module in
-
   (* Rules for the files *)
   { Module_rule.coqdep = coqdep_rule
   ; coqc =
@@ -423,9 +419,7 @@ let setup_rules ~sctx ~dir ~dir_contents (s : Theory.t) =
   let scope = SC.find_scope_by_dir sctx dir in
   let coq_lib_db = Scope.coq_libs scope in
   let theory = Coq_lib.DB.resolve coq_lib_db s.name |> Result.ok_exn in
-
   let* coq_dir_contents = Dir_contents.coq dir_contents in
-
   let+ cctx =
     let wrapper_name = Coq_lib.wrapper theory in
     let theories_deps = Coq_lib.DB.requires coq_lib_db theory in
@@ -435,10 +429,8 @@ let setup_rules ~sctx ~dir ~dir_contents (s : Theory.t) =
     Context.create sctx ~coqc_dir ~dir ~wrapper_name ~theories_deps ~theory_dirs
       s.buildable
   in
-
   (* List of modules to compile for this library *)
   let coq_modules = Coq_sources.library coq_dir_contents ~name in
-
   let source_rule =
     let theories =
       let open Result.O in

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -118,14 +118,12 @@ module Processed = struct
     Path.Set.iter src_dirs ~f:(fun p -> printf "S %s\n" (serialize_path p));
     List.iter extensions ~f:(fun { Ml_kind.Dict.impl; intf } ->
         printf "SUFFIX %s" (Printf.sprintf "%s %s" impl intf));
-
     (* We print all FLG directives as comments *)
     List.iter pp_configs
       ~f:
         (Module_name.Per_item.fold ~init:() ~f:(fun pp () ->
              Option.iter pp ~f:(fun { flag; args } ->
                  printf "# FLG %s\n" (flag ^ " " ^ quote_for_dot_merlin args))));
-
     List.iter flags ~f:(fun flags ->
         match flags with
         | [] -> ()
@@ -378,12 +376,10 @@ end
 let dot_merlin sctx ~dir ~more_src_dirs ~expander (t : Unprocessed.t) =
   let open Memo.Build.O in
   let merlin_file = Merlin_ident.merlin_file_path dir t.ident in
-
   let* () =
     Path.Set.singleton (Path.build merlin_file)
     |> Rules.Produce.Alias.add_static_deps (Alias.check ~dir)
   in
-
   let merlin = Unprocessed.process t sctx ~more_src_dirs ~expander in
   let action =
     Action_builder.With_targets.write_file_dyn merlin_file

--- a/src/dune_rules/merlin_server.ml
+++ b/src/dune_rules/merlin_server.ml
@@ -51,11 +51,9 @@ let make_relative_to_root p =
    absolute path - A path relative to [Path.initial_cwd] *)
 let to_local file_path =
   let error msg = Error msg in
-
   (* This ensure the path is absolute. If not it is prefixed with
      [Path.initial_cwd] *)
   let abs_file_path = Path.of_filename_relative_to_initial_cwd file_path in
-
   (* Then we make the path relative to [Path.root] (and not [Path.initial_cwd]) *)
   match make_relative_to_root abs_file_path with
   | Some path -> (


### PR DESCRIPTION
We developed an automated script to export patches from Janestreet internal repo instead of doing it manually.
The script ends up round-tripping via a different configuration of camlformat, and that roundtrip is not a no-op.

This PR accepts those changes (dropping some empty lines), so that the code roundtrips better.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>