### PR TITLE
Update local cache db when restoring artifacts from shared-cache

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -739,6 +739,18 @@ let term =
       value & flag
       & info [ "debug-digests" ] ~docs
           ~doc:"Explain why Dune decides to re-digest some files")
+  and+ store_digest_preimage =
+    Arg.(
+      value & flag
+      & info
+          [ "debug-store-digest-preimage" ]
+          ~docs
+          ~doc:
+            "Store digest preimage for all computed digests, so that it's \
+             possible to reverse them later, for debugging. The digests are \
+             stored in the shared cache (see --cache flag) as values, even if \
+             cache is otherwise disabled. This should be used only for \
+             debugging, since it's slow and it litters the shared cache.")
   and+ no_buffer =
     let doc =
       {|Do not buffer the output of commands executed by dune. By default dune
@@ -905,6 +917,7 @@ let term =
         at_exit (fun () -> Dune_stats.close stats);
         stats)
   in
+  if store_digest_preimage then Dune_engine.Reversible_digest.enable ();
   if print_metrics then Memo.Perf_counters.enable ();
   { debug_dep_path
   ; debug_findlib

--- a/otherlibs/stdune-unstable/digest.mli
+++ b/otherlibs/stdune-unstable/digest.mli
@@ -32,3 +32,13 @@ val file_with_stats : Path.t -> Unix.stats -> t
 (** Digest a file taking its executable bit into account. Should not be called
     on a directory. *)
 val file_with_executable_bit : executable:bool -> Path.t -> t
+
+(** Override the implementations of digest computation. Can be used to record
+    the reverse digest map. *)
+val override_impl : file:(string -> t) -> string:(string -> t) -> unit
+
+(** [Direct_impl] does a plain hashing, with no heed to the overrides given by
+    [override_impl]. *)
+module Direct_impl : sig
+  val string : string -> t
+end

--- a/src/dune_cache_storage/dune_cache_storage.mli
+++ b/src/dune_cache_storage/dune_cache_storage.mli
@@ -127,3 +127,11 @@ val with_temp_dir :
   -> suffix:string
   -> (Path.t Or_exn.t -> 'a Fiber.t)
   -> 'a Fiber.t
+
+module Raw_value : sig
+  val store_unchecked :
+       mode:Mode.t
+    -> content:string
+    -> content_digest:Digest.t
+    -> Util.Write_result.t
+end

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -58,3 +58,4 @@ module Mode = Mode
 module Fs_memo = Fs_memo
 module Execution_parameters = Execution_parameters
 module Cache_debug_flags = Cache_debug_flags
+module Reversible_digest = Reversible_digest

--- a/src/dune_engine/reversible_digest.ml
+++ b/src/dune_engine/reversible_digest.ml
@@ -1,0 +1,28 @@
+module Caml_digest = Digest
+open! Stdune
+open Import
+
+let digest_string string =
+  let digest = Digest.Direct_impl.string string in
+  (match
+     (* CR-someday amokhov: Below we do not respect the [cache_storage_mode]
+        configuration setting. This will break if hard links are not supported. *)
+     Dune_cache_storage.Raw_value.store_unchecked ~content:string
+       ~content_digest:digest ~mode:Hardlink
+   with
+  | Ok
+  | Already_present ->
+    ()
+  | Error exn ->
+    Log.info
+      [ Pp.textf "error making digest reversible [%s]: %s"
+          (Stdune.Digest.to_string digest)
+          (Dyn.to_string (Exn.to_dyn exn))
+      ]);
+  digest
+
+let digest_file file =
+  let contents = Io.String_path.read_file ~binary:true file in
+  digest_string contents
+
+let enable () = Digest.override_impl ~file:digest_file ~string:digest_string


### PR DESCRIPTION
This PR fixes a bug where dune repeatedly tries to restore the same artifacts from shared-cache if the db has a stale value.