### PR TITLE
Fix rpc shutdown

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -859,4 +859,5 @@ let shutdown () =
     | _ -> Fiber.return ()
   in
   t.status <- Shutting_down;
+  Process_watcher.killall t.process_watcher Sys.sigkill;
   fill_file_changes


### PR DESCRIPTION
Previously, it would not terminate current build processes when shutdown was
requested. This new implementation is exactly the same as sending a signal.