### PR TITLE
Improve locations of diffs

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -533,7 +533,7 @@ let extend_build_path_prefix_map env how map =
 
 let exec ~targets ~root ~context ~env ~rule_loc ~build_deps
     ~execution_parameters t =
-  let purpose = Process.Build_job targets in
+  let purpose = Process.Build_job (None, targets) in
   let env =
     extend_build_path_prefix_map env `New_rules_have_precedence
       [ Some

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -533,7 +533,7 @@ let extend_build_path_prefix_map env how map =
 
 let exec ~targets ~root ~context ~env ~rule_loc ~build_deps
     ~execution_parameters t =
-  let purpose = Process.Build_job (None, targets) in
+  let purpose = Process.Build_job (None, [], targets) in
   let env =
     extend_build_path_prefix_map env `New_rules_have_precedence
       [ Some

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -25,77 +25,88 @@ let print ?(skip_trailing_cr = Sys.win32) path1 path2 =
       (dir1, Path.source f1, Path.source f2)
     | _ -> (Path.root, path1, path2)
   in
-  let loc = Loc.in_file file1 in
-  let file1, file2 = Path.(to_string file1, to_string file2) in
-  let fallback () =
-    User_error.raise ~loc
-      [ Pp.textf "Files %s and %s differ."
-          (Path.to_string_maybe_quoted (Path.drop_optional_sandbox_root path1))
-          (Path.to_string_maybe_quoted (Path.drop_optional_sandbox_root path2))
-      ]
-  in
-  let normal_diff () =
-    let path, args, skip_trailing_cr_arg, files =
-      let which prog = Bin.which ~path:(Env.path Env.initial) prog in
-      match which "git" with
-      | Some path ->
-        ( path
-        , [ "--no-pager"; "diff"; "--no-index"; "--color=always"; "-u" ]
-        , "--ignore-cr-at-eol"
-        , List.map
-            ~f:(fun (path, file) -> resolve_link ~dir path file)
-            [ (path1, file1); (path2, file2) ] )
-      | None -> (
-        match which "diff" with
-        | Some path -> (path, [ "-u" ], "--strip-trailing-cr", [ file1; file2 ])
-        | None -> fallback ())
-    in
-    let args =
-      if skip_trailing_cr then
-        args @ [ skip_trailing_cr_arg ]
-      else
-        args
-    in
-    let args = args @ files in
-    Console.print
-      [ Pp.map_tags ~f:(fun Loc -> User_message.Style.Loc) (Loc.pp loc) ];
-    let* () = Process.run ~dir ~env:Env.initial Strict path args in
-    fallback ()
-  in
-  match !Clflags.diff_command with
-  | Some "-" -> fallback ()
-  | Some cmd ->
-    let sh, arg = Utils.system_shell_exn ~needed_to:"print diffs" in
-    let cmd =
-      sprintf "%s %s %s" cmd
-        (String.quote_for_shell file1)
-        (String.quote_for_shell file2)
-    in
-    let* () = Process.run ~dir ~env:Env.initial Strict sh [ arg; cmd ] in
-    User_error.raise
-      [ Pp.textf "command reported no differences: %s"
-          (if Path.is_root dir then
-            cmd
-          else
-            sprintf "cd %s && %s"
-              (String.quote_for_shell (Path.to_string dir))
-              cmd)
-      ]
-  | None -> (
-    if Config.inside_dune then
-      fallback ()
-    else
-      match Bin.which ~path:(Env.path Env.initial) "patdiff" with
-      | None -> normal_diff ()
-      | Some prog ->
-        let* () =
-          Process.run ~dir ~env:Env.initial Strict prog
-            ([ "-keep-whitespace"; "-location-style"; "omake" ]
-            @ (if Lazy.force Ansi_color.stderr_supports_color then
-                []
-              else
-                [ "-ascii" ])
-            @ [ file1; file2 ])
+  Fiber.with_error_handler
+    ~on_error:(fun exn ->
+      Exn_with_backtrace.reraise
+        (match exn.exn with
+        | User_error.E (msg, annot) when not (User_error.has_location msg annot)
+          ->
+          let loc = Loc.in_file file1 in
+          let msg = { msg with loc = Some loc } in
+          { exn with exn = User_error.E (msg, annot) }
+        | _ -> exn))
+    (fun () ->
+      let file1, file2 = Path.(to_string file1, to_string file2) in
+      let fallback () =
+        User_error.raise
+          [ Pp.textf "Files %s and %s differ."
+              (Path.to_string_maybe_quoted
+                 (Path.drop_optional_sandbox_root path1))
+              (Path.to_string_maybe_quoted
+                 (Path.drop_optional_sandbox_root path2))
+          ]
+      in
+      let normal_diff () =
+        let path, args, skip_trailing_cr_arg, files =
+          let which prog = Bin.which ~path:(Env.path Env.initial) prog in
+          match which "git" with
+          | Some path ->
+            ( path
+            , [ "--no-pager"; "diff"; "--no-index"; "--color=always"; "-u" ]
+            , "--ignore-cr-at-eol"
+            , List.map
+                ~f:(fun (path, file) -> resolve_link ~dir path file)
+                [ (path1, file1); (path2, file2) ] )
+          | None -> (
+            match which "diff" with
+            | Some path ->
+              (path, [ "-u" ], "--strip-trailing-cr", [ file1; file2 ])
+            | None -> fallback ())
         in
-        (* Use "diff" if "patdiff" reported no differences *)
-        normal_diff ())
+        let args =
+          if skip_trailing_cr then
+            args @ [ skip_trailing_cr_arg ]
+          else
+            args
+        in
+        let args = args @ files in
+        let* () = Process.run ~dir ~env:Env.initial Strict path args in
+        fallback ()
+      in
+      match !Clflags.diff_command with
+      | Some "-" -> fallback ()
+      | Some cmd ->
+        let sh, arg = Utils.system_shell_exn ~needed_to:"print diffs" in
+        let cmd =
+          sprintf "%s %s %s" cmd
+            (String.quote_for_shell file1)
+            (String.quote_for_shell file2)
+        in
+        let* () = Process.run ~dir ~env:Env.initial Strict sh [ arg; cmd ] in
+        User_error.raise
+          [ Pp.textf "command reported no differences: %s"
+              (if Path.is_root dir then
+                cmd
+              else
+                sprintf "cd %s && %s"
+                  (String.quote_for_shell (Path.to_string dir))
+                  cmd)
+          ]
+      | None -> (
+        if Config.inside_dune then
+          fallback ()
+        else
+          match Bin.which ~path:(Env.path Env.initial) "patdiff" with
+          | None -> normal_diff ()
+          | Some prog ->
+            let* () =
+              Process.run ~dir ~env:Env.initial Strict prog
+                ([ "-keep-whitespace" ]
+                @ (if Lazy.force Ansi_color.stderr_supports_color then
+                    []
+                  else
+                    [ "-ascii" ])
+                @ [ file1; file2 ])
+            in
+            (* Use "diff" if "patdiff" reported no differences *)
+            normal_diff ()))

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -154,8 +154,8 @@ module Io = struct
 end
 
 type purpose =
-  | Internal_job
-  | Build_job of Path.Build.Set.t
+  | Internal_job of Loc.t option
+  | Build_job of Loc.t option * Path.Build.Set.t
 
 let io_to_redirection_path (kind : Io.kind) =
   match kind with
@@ -284,8 +284,8 @@ module Fancy = struct
     Pp.verbatim prefix ++ pp ++ Pp.verbatim suffix
 
   let pp_purpose = function
-    | Internal_job -> Pp.verbatim "(internal)"
-    | Build_job targets -> (
+    | Internal_job _ -> Pp.verbatim "(internal)"
+    | Build_job (_, targets) -> (
       let rec split_paths targets_acc ctxs_acc = function
         | [] -> (List.rev targets_acc, Context_name.Set.to_list ctxs_acc)
         | path :: rest -> (
@@ -372,11 +372,16 @@ module Exit_status = struct
 
   (* In this module, we don't need the "Error: " prefix given that it is already
      included in the error message from the command. *)
-  let fail ~dir ~has_embedded_location paragraphs =
+  let fail ~purpose ~dir ~has_embedded_location paragraphs =
     let dir =
       match dir with
       | None -> Path.of_string (Sys.getcwd ())
       | Some dir -> dir
+    in
+    let loc =
+      match purpose with
+      | Internal_job loc -> loc
+      | Build_job (loc, _) -> loc
     in
     let annots = [ With_directory_annot.make dir ] in
     let annots =
@@ -385,7 +390,7 @@ module Exit_status = struct
       else
         annots
     in
-    raise (User_error.E (User_message.make paragraphs, annots))
+    raise (User_error.E (User_message.make ?loc paragraphs, annots))
 
   (* Check if the command output starts with a location, ignoring ansi escape
      sequences *)
@@ -406,7 +411,7 @@ module Exit_status = struct
     fun output ->
       loop output 0 (String.length output) [ 'F'; 'i'; 'l'; 'e'; ' ' ]
 
-  let handle_verbose t ~id ~output ~command_line ~dir =
+  let handle_verbose t ~id ~purpose ~output ~command_line ~dir =
     let open Pp.O in
     let has_embedded_location = outputs_starts_with_location output in
     let output = parse_output output in
@@ -426,7 +431,7 @@ module Exit_status = struct
         | Failed n -> sprintf "exited with code %d" n
         | Signaled signame -> sprintf "got signal %s" signame
       in
-      fail ~dir ~has_embedded_location
+      fail ~purpose ~dir ~has_embedded_location
         (Pp.tag User_message.Style.Kwd (Pp.verbatim "Command")
          ++ Pp.space ++ pp_id id ++ Pp.space ++ Pp.text msg ++ Pp.char ':'
          ::
@@ -463,7 +468,10 @@ module Exit_status = struct
            | Scheduler.Config.Display.Short -> true
            | Quiet -> false
            | Verbose -> assert false)
-           && purpose <> Internal_job
+           &&
+           match purpose with
+           | Internal_job _ -> false
+           | Build_job _ -> true
       then
         Console.print_user_message
           (User_message.make
@@ -489,10 +497,10 @@ module Exit_status = struct
                 (String.enumerate_and unexpected_outputs)
             | _ -> sprintf "(exit %d)" n
           else
-            fail ~dir ~has_embedded_location (Option.to_list output)
+            fail ~purpose ~dir ~has_embedded_location (Option.to_list output)
         | Signaled signame -> sprintf "(got signal %s)" signame
       in
-      fail ~dir ~has_embedded_location
+      fail ~purpose ~dir ~has_embedded_location
         (progname_and_purpose Error ++ Pp.char ' '
          ++ Pp.tag User_message.Style.Error (Pp.verbatim msg)
          ::
@@ -720,7 +728,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
         match (display.verbosity, exit_status', output) with
         | Quiet, Ok n, "" -> n (* Optimisation for the common case *)
         | Verbose, _, _ ->
-          Exit_status.handle_verbose exit_status' ~id ~dir
+          Exit_status.handle_verbose exit_status' ~id ~purpose ~dir
             ~command_line:fancy_command_line ~output
         | _ ->
           Exit_status.handle_non_verbose exit_status' ~prog:prog_str ~dir
@@ -729,8 +737,8 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
       in
       (res, times))
 
-let run ?dir ?stdout_to ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
-    fail_mode prog args =
+let run ?dir ?stdout_to ?stderr_to ?stdin_from ?env
+    ?(purpose = Internal_job None) fail_mode prog args =
   let+ run =
     run_internal ?dir ?stdout_to ?stderr_to ?stdin_from ?env ~purpose fail_mode
       prog args
@@ -739,13 +747,13 @@ let run ?dir ?stdout_to ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
   map_result fail_mode run ~f:ignore
 
 let run_with_times ?dir ?stdout_to ?stderr_to ?stdin_from ?env
-    ?(purpose = Internal_job) prog args =
+    ?(purpose = Internal_job None) prog args =
   run_internal ?dir ?stdout_to ?stderr_to ?stdin_from ?env ~purpose Strict prog
     args
   >>| snd
 
-let run_capture_gen ?dir ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
-    fail_mode prog args ~f =
+let run_capture_gen ?dir ?stderr_to ?stdin_from ?env
+    ?(purpose = Internal_job None) fail_mode prog args ~f =
   let fn = Temp.create File ~prefix:"dune" ~suffix:"output" in
   let+ run =
     run_internal ?dir ~stdout_to:(Io.file fn Io.Out) ?stderr_to ?stdin_from ?env
@@ -764,8 +772,8 @@ let run_capture_lines = run_capture_gen ~f:Stdune.Io.lines_of_file
 let run_capture_zero_separated =
   run_capture_gen ~f:Stdune.Io.zero_strings_of_file
 
-let run_capture_line ?dir ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
-    fail_mode prog args =
+let run_capture_line ?dir ?stderr_to ?stdin_from ?env
+    ?(purpose = Internal_job None) fail_mode prog args =
   run_capture_gen ?dir ?stderr_to ?stdin_from ?env ~purpose fail_mode prog args
     ~f:(fun fn ->
       match Stdune.Io.lines_of_file fn with

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -52,10 +52,10 @@ module Io : sig
   val multi_use : 'a t -> 'a t
 end
 
-(** Why a Fiber.t was run *)
+(** Why a Fiber.t was run. The location will be attached to error messages. *)
 type purpose =
-  | Internal_job
-  | Build_job of Path.Build.Set.t
+  | Internal_job of Loc.t option
+  | Build_job of Loc.t option * Path.Build.Set.t
 
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its
     termination. [stdout_to] [stderr_to] are released *)

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -52,10 +52,11 @@ module Io : sig
   val multi_use : 'a t -> 'a t
 end
 
-(** Why a Fiber.t was run. The location will be attached to error messages. *)
+(** Why a Fiber.t was run. The location and annotations will be attached to
+    error messages. *)
 type purpose =
-  | Internal_job of Loc.t option
-  | Build_job of Loc.t option * Path.Build.Set.t
+  | Internal_job of Loc.t option * User_error.Annot.t list
+  | Build_job of Loc.t option * User_error.Annot.t list * Path.Build.Set.t
 
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its
     termination. [stdout_to] [stderr_to] are released *)

--- a/test/blackbox-tests/test-cases/cinaps/include-subdirs.t/run.t
+++ b/test/blackbox-tests/test-cases/cinaps/include-subdirs.t/run.t
@@ -21,9 +21,7 @@ cinaps doesn't work with (include_subdirs unqualified)
   > EOF
 
   $ dune runtest --diff-command diff 2>&1 | sed -E 's/[^ ]+sh/\$sh/'
-  File "sub/dune", line 1, characters 0-24:
-  1 | (cinaps (files test.ml))
-      ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "sub/test.ml", line 1, characters 0-0:
             sh (internal) (exit 1)
   (cd _build/default && $sh -c 'diff sub/test.ml sub/test.ml.cinaps-corrected')
   2,3c2

--- a/test/blackbox-tests/test-cases/cinaps/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/cinaps/simple.t/run.t
@@ -18,9 +18,7 @@ Test of cinaps integration
 The cinaps actions should be attached to the runtest alias:
 
   $ dune runtest --diff-command diff 2>&1 | sed -E 's/[^ ]+sh/\$sh/'
-  File "dune", line 1, characters 0-21:
-  1 | (cinaps (files *.ml))
-      ^^^^^^^^^^^^^^^^^^^^^
+  File "test.ml", line 1, characters 0-0:
             sh (internal) (exit 1)
   (cd _build/default && $sh -c 'diff test.ml test.ml.cinaps-corrected')
   1a2
@@ -29,9 +27,7 @@ The cinaps actions should be attached to the runtest alias:
 but also to the cinaps alias:
 
   $ dune build @cinaps --diff-command diff 2>&1 | sed -E 's/[^ ]+sh/\$sh/'
-  File "dune", line 1, characters 0-21:
-  1 | (cinaps (files *.ml))
-      ^^^^^^^^^^^^^^^^^^^^^
+  File "test.ml", line 1, characters 0-0:
             sh (internal) (exit 1)
   (cd _build/default && $sh -c 'diff test.ml test.ml.cinaps-corrected')
   1a2

--- a/test/blackbox-tests/test-cases/github3490.t/run.t
+++ b/test/blackbox-tests/test-cases/github3490.t/run.t
@@ -21,7 +21,5 @@ the test suite; but we do not need to print it so we can grep it out
 (redirecting stderr to /dev/null would also silence the stack overflow message).
 
   $ dune runtest --diff-command 'diff -u' 2>&1 | grep -v + | grep -v diff | grep -v "^--- test"
-  File "dune", line 4, characters 0-60:
-  4 | (rule
-  5 |  (alias runtest)
+  File "test", line 1, characters 0-0:
             sh (internal) (exit 1)


### PR DESCRIPTION
Since some time, we have been adding locations to diffs printed by dune that were not really useful. This PR improves this.

It adds a location pointing to the first diffed file to errors produced by `Print_diff`. This is what was happening before with `patdiff` as we were passing `--location-style omake`. We now do it no matter what diff program is being used. This also remove a race condition when using `diff` or `git diff` as we used to print the location using `Console.print` and then raise an exception, thus allowing other stuff to be printed in between.