### PR TITLE
Memoize [Source_tree.Readdir.of_source_path] with cutoff

### DIFF
--- a/otherlibs/stdune-unstable/stdune.ml
+++ b/otherlibs/stdune-unstable/stdune.ml
@@ -54,6 +54,7 @@ module Tuple = Tuple
 module Poly = Poly
 module Code_error = Code_error
 module User_error = User_error
+module Unix_error = Unix_error
 module User_message = User_message
 module User_warning = User_warning
 module Lexbuf = Lexbuf

--- a/otherlibs/stdune-unstable/unix_error.ml
+++ b/otherlibs/stdune-unstable/unix_error.ml
@@ -1,0 +1,279 @@
+type t = Unix.error
+
+(* CR-someday amokhov: It would be nice to derive this instead. For now let's
+   trust I haven't messed this up. *)
+let equal (x : t) (y : t) =
+  match (x, y) with
+  | E2BIG, E2BIG -> true
+  | E2BIG, _
+  | _, E2BIG ->
+    false
+  | EACCES, EACCES -> true
+  | EACCES, _
+  | _, EACCES ->
+    false
+  | EAGAIN, EAGAIN -> true
+  | EAGAIN, _
+  | _, EAGAIN ->
+    false
+  | EBADF, EBADF -> true
+  | EBADF, _
+  | _, EBADF ->
+    false
+  | EBUSY, EBUSY -> true
+  | EBUSY, _
+  | _, EBUSY ->
+    false
+  | ECHILD, ECHILD -> true
+  | ECHILD, _
+  | _, ECHILD ->
+    false
+  | EDEADLK, EDEADLK -> true
+  | EDEADLK, _
+  | _, EDEADLK ->
+    false
+  | EDOM, EDOM -> true
+  | EDOM, _
+  | _, EDOM ->
+    false
+  | EEXIST, EEXIST -> true
+  | EEXIST, _
+  | _, EEXIST ->
+    false
+  | EFAULT, EFAULT -> true
+  | EFAULT, _
+  | _, EFAULT ->
+    false
+  | EFBIG, EFBIG -> true
+  | EFBIG, _
+  | _, EFBIG ->
+    false
+  | EINTR, EINTR -> true
+  | EINTR, _
+  | _, EINTR ->
+    false
+  | EINVAL, EINVAL -> true
+  | EINVAL, _
+  | _, EINVAL ->
+    false
+  | EIO, EIO -> true
+  | EIO, _
+  | _, EIO ->
+    false
+  | EISDIR, EISDIR -> true
+  | EISDIR, _
+  | _, EISDIR ->
+    false
+  | EMFILE, EMFILE -> true
+  | EMFILE, _
+  | _, EMFILE ->
+    false
+  | EMLINK, EMLINK -> true
+  | EMLINK, _
+  | _, EMLINK ->
+    false
+  | ENAMETOOLONG, ENAMETOOLONG -> true
+  | ENAMETOOLONG, _
+  | _, ENAMETOOLONG ->
+    false
+  | ENFILE, ENFILE -> true
+  | ENFILE, _
+  | _, ENFILE ->
+    false
+  | ENODEV, ENODEV -> true
+  | ENODEV, _
+  | _, ENODEV ->
+    false
+  | ENOENT, ENOENT -> true
+  | ENOENT, _
+  | _, ENOENT ->
+    false
+  | ENOEXEC, ENOEXEC -> true
+  | ENOEXEC, _
+  | _, ENOEXEC ->
+    false
+  | ENOLCK, ENOLCK -> true
+  | ENOLCK, _
+  | _, ENOLCK ->
+    false
+  | ENOMEM, ENOMEM -> true
+  | ENOMEM, _
+  | _, ENOMEM ->
+    false
+  | ENOSPC, ENOSPC -> true
+  | ENOSPC, _
+  | _, ENOSPC ->
+    false
+  | ENOSYS, ENOSYS -> true
+  | ENOSYS, _
+  | _, ENOSYS ->
+    false
+  | ENOTDIR, ENOTDIR -> true
+  | ENOTDIR, _
+  | _, ENOTDIR ->
+    false
+  | ENOTEMPTY, ENOTEMPTY -> true
+  | ENOTEMPTY, _
+  | _, ENOTEMPTY ->
+    false
+  | ENOTTY, ENOTTY -> true
+  | ENOTTY, _
+  | _, ENOTTY ->
+    false
+  | ENXIO, ENXIO -> true
+  | ENXIO, _
+  | _, ENXIO ->
+    false
+  | EPERM, EPERM -> true
+  | EPERM, _
+  | _, EPERM ->
+    false
+  | EPIPE, EPIPE -> true
+  | EPIPE, _
+  | _, EPIPE ->
+    false
+  | ERANGE, ERANGE -> true
+  | ERANGE, _
+  | _, ERANGE ->
+    false
+  | EROFS, EROFS -> true
+  | EROFS, _
+  | _, EROFS ->
+    false
+  | ESPIPE, ESPIPE -> true
+  | ESPIPE, _
+  | _, ESPIPE ->
+    false
+  | ESRCH, ESRCH -> true
+  | ESRCH, _
+  | _, ESRCH ->
+    false
+  | EXDEV, EXDEV -> true
+  | EXDEV, _
+  | _, EXDEV ->
+    false
+  | EWOULDBLOCK, EWOULDBLOCK -> true
+  | EWOULDBLOCK, _
+  | _, EWOULDBLOCK ->
+    false
+  | EINPROGRESS, EINPROGRESS -> true
+  | EINPROGRESS, _
+  | _, EINPROGRESS ->
+    false
+  | EALREADY, EALREADY -> true
+  | EALREADY, _
+  | _, EALREADY ->
+    false
+  | ENOTSOCK, ENOTSOCK -> true
+  | ENOTSOCK, _
+  | _, ENOTSOCK ->
+    false
+  | EDESTADDRREQ, EDESTADDRREQ -> true
+  | EDESTADDRREQ, _
+  | _, EDESTADDRREQ ->
+    false
+  | EMSGSIZE, EMSGSIZE -> true
+  | EMSGSIZE, _
+  | _, EMSGSIZE ->
+    false
+  | EPROTOTYPE, EPROTOTYPE -> true
+  | EPROTOTYPE, _
+  | _, EPROTOTYPE ->
+    false
+  | ENOPROTOOPT, ENOPROTOOPT -> true
+  | ENOPROTOOPT, _
+  | _, ENOPROTOOPT ->
+    false
+  | EPROTONOSUPPORT, EPROTONOSUPPORT -> true
+  | EPROTONOSUPPORT, _
+  | _, EPROTONOSUPPORT ->
+    false
+  | ESOCKTNOSUPPORT, ESOCKTNOSUPPORT -> true
+  | ESOCKTNOSUPPORT, _
+  | _, ESOCKTNOSUPPORT ->
+    false
+  | EOPNOTSUPP, EOPNOTSUPP -> true
+  | EOPNOTSUPP, _
+  | _, EOPNOTSUPP ->
+    false
+  | EPFNOSUPPORT, EPFNOSUPPORT -> true
+  | EPFNOSUPPORT, _
+  | _, EPFNOSUPPORT ->
+    false
+  | EAFNOSUPPORT, EAFNOSUPPORT -> true
+  | EAFNOSUPPORT, _
+  | _, EAFNOSUPPORT ->
+    false
+  | EADDRINUSE, EADDRINUSE -> true
+  | EADDRINUSE, _
+  | _, EADDRINUSE ->
+    false
+  | EADDRNOTAVAIL, EADDRNOTAVAIL -> true
+  | EADDRNOTAVAIL, _
+  | _, EADDRNOTAVAIL ->
+    false
+  | ENETDOWN, ENETDOWN -> true
+  | ENETDOWN, _
+  | _, ENETDOWN ->
+    false
+  | ENETUNREACH, ENETUNREACH -> true
+  | ENETUNREACH, _
+  | _, ENETUNREACH ->
+    false
+  | ENETRESET, ENETRESET -> true
+  | ENETRESET, _
+  | _, ENETRESET ->
+    false
+  | ECONNABORTED, ECONNABORTED -> true
+  | ECONNABORTED, _
+  | _, ECONNABORTED ->
+    false
+  | ECONNRESET, ECONNRESET -> true
+  | ECONNRESET, _
+  | _, ECONNRESET ->
+    false
+  | ENOBUFS, ENOBUFS -> true
+  | ENOBUFS, _
+  | _, ENOBUFS ->
+    false
+  | EISCONN, EISCONN -> true
+  | EISCONN, _
+  | _, EISCONN ->
+    false
+  | ENOTCONN, ENOTCONN -> true
+  | ENOTCONN, _
+  | _, ENOTCONN ->
+    false
+  | ESHUTDOWN, ESHUTDOWN -> true
+  | ESHUTDOWN, _
+  | _, ESHUTDOWN ->
+    false
+  | ETOOMANYREFS, ETOOMANYREFS -> true
+  | ETOOMANYREFS, _
+  | _, ETOOMANYREFS ->
+    false
+  | ETIMEDOUT, ETIMEDOUT -> true
+  | ETIMEDOUT, _
+  | _, ETIMEDOUT ->
+    false
+  | ECONNREFUSED, ECONNREFUSED -> true
+  | ECONNREFUSED, _
+  | _, ECONNREFUSED ->
+    false
+  | EHOSTDOWN, EHOSTDOWN -> true
+  | EHOSTDOWN, _
+  | _, EHOSTDOWN ->
+    false
+  | EHOSTUNREACH, EHOSTUNREACH -> true
+  | EHOSTUNREACH, _
+  | _, EHOSTUNREACH ->
+    false
+  | ELOOP, ELOOP -> true
+  | ELOOP, _
+  | _, ELOOP ->
+    false
+  | EOVERFLOW, EOVERFLOW -> true
+  | EOVERFLOW, _
+  | _, EOVERFLOW ->
+    false
+  | EUNKNOWNERR x, EUNKNOWNERR y -> Int.equal x y

--- a/otherlibs/stdune-unstable/unix_error.mli
+++ b/otherlibs/stdune-unstable/unix_error.mli
@@ -1,0 +1,5 @@
+(** Auxiliary functions for working with Unix errors. *)
+
+type t = Unix.error
+
+val equal : t -> t -> bool

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -121,81 +121,6 @@ let filter_source_files =
   in
   ref (fun _ -> Memo.Build.return (fun _dir fn -> not (is_temp_file fn)))
 
-(* CR-someday amokhov: It would be nice to derive this instead. For now let's
-   trust I haven't messed this up. *)
-let unix_error_equal (x : Unix.error) (y : Unix.error) =
-  match (x, y) with
-  | E2BIG, E2BIG -> true
-  | EACCES, EACCES -> true
-  | EAGAIN, EAGAIN -> true
-  | EBADF, EBADF -> true
-  | EBUSY, EBUSY -> true
-  | ECHILD, ECHILD -> true
-  | EDEADLK, EDEADLK -> true
-  | EDOM, EDOM -> true
-  | EEXIST, EEXIST -> true
-  | EFAULT, EFAULT -> true
-  | EFBIG, EFBIG -> true
-  | EINTR, EINTR -> true
-  | EINVAL, EINVAL -> true
-  | EIO, EIO -> true
-  | EISDIR, EISDIR -> true
-  | EMFILE, EMFILE -> true
-  | EMLINK, EMLINK -> true
-  | ENAMETOOLONG, ENAMETOOLONG -> true
-  | ENFILE, ENFILE -> true
-  | ENODEV, ENODEV -> true
-  | ENOENT, ENOENT -> true
-  | ENOEXEC, ENOEXEC -> true
-  | ENOLCK, ENOLCK -> true
-  | ENOMEM, ENOMEM -> true
-  | ENOSPC, ENOSPC -> true
-  | ENOSYS, ENOSYS -> true
-  | ENOTDIR, ENOTDIR -> true
-  | ENOTEMPTY, ENOTEMPTY -> true
-  | ENOTTY, ENOTTY -> true
-  | ENXIO, ENXIO -> true
-  | EPERM, EPERM -> true
-  | EPIPE, EPIPE -> true
-  | ERANGE, ERANGE -> true
-  | EROFS, EROFS -> true
-  | ESPIPE, ESPIPE -> true
-  | ESRCH, ESRCH -> true
-  | EXDEV, EXDEV -> true
-  | EWOULDBLOCK, EWOULDBLOCK -> true
-  | EINPROGRESS, EINPROGRESS -> true
-  | EALREADY, EALREADY -> true
-  | ENOTSOCK, ENOTSOCK -> true
-  | EDESTADDRREQ, EDESTADDRREQ -> true
-  | EMSGSIZE, EMSGSIZE -> true
-  | EPROTOTYPE, EPROTOTYPE -> true
-  | ENOPROTOOPT, ENOPROTOOPT -> true
-  | EPROTONOSUPPORT, EPROTONOSUPPORT -> true
-  | ESOCKTNOSUPPORT, ESOCKTNOSUPPORT -> true
-  | EOPNOTSUPP, EOPNOTSUPP -> true
-  | EPFNOSUPPORT, EPFNOSUPPORT -> true
-  | EAFNOSUPPORT, EAFNOSUPPORT -> true
-  | EADDRINUSE, EADDRINUSE -> true
-  | EADDRNOTAVAIL, EADDRNOTAVAIL -> true
-  | ENETDOWN, ENETDOWN -> true
-  | ENETUNREACH, ENETUNREACH -> true
-  | ENETRESET, ENETRESET -> true
-  | ECONNABORTED, ECONNABORTED -> true
-  | ECONNRESET, ECONNRESET -> true
-  | ENOBUFS, ENOBUFS -> true
-  | EISCONN, EISCONN -> true
-  | ENOTCONN, ENOTCONN -> true
-  | ESHUTDOWN, ESHUTDOWN -> true
-  | ETOOMANYREFS, ETOOMANYREFS -> true
-  | ETIMEDOUT, ETIMEDOUT -> true
-  | ECONNREFUSED, ECONNREFUSED -> true
-  | EHOSTDOWN, EHOSTDOWN -> true
-  | EHOSTUNREACH, EHOSTUNREACH -> true
-  | ELOOP, ELOOP -> true
-  | EOVERFLOW, EOVERFLOW -> true
-  | EUNKNOWNERR x, EUNKNOWNERR y -> Int.equal x y
-  | _, _ -> false
-
 module Readdir : sig
   type t = private
     { path : Path.Source.t
@@ -307,7 +232,7 @@ end = struct
   let of_source_path_memo =
     Memo.create "readdir-of-source-path"
       ~input:(module Path.Source)
-      ~cutoff:(Result.equal equal unix_error_equal)
+      ~cutoff:(Result.equal equal Unix_error.equal)
       of_source_path_impl
 
   let of_source_path = Memo.exec of_source_path_memo


### PR DESCRIPTION
I noticed that no-op rebuilds lead to re-executing `execute_rule_impl` about a thousand times when building Iron, which was caused by the lack of cutoff on `Source_tree.Readdir.of_source_path`. After adding the cutoff, the no-op rebuilds got 3x faster for me.
