### PR TITLE
Use a [Univ_map] for error annotations

### DIFF
--- a/otherlibs/site/src/plugins/meta_parser.ml
+++ b/otherlibs/site/src/plugins/meta_parser.ml
@@ -30,7 +30,7 @@ module Meta_parser = Dune_meta_parser.Meta_parser.Make (struct
   end
 
   module User_error = struct
-    module Annot = struct
+    module Annotations = struct
       type t = unit
     end
 

--- a/otherlibs/stdune-unstable/user_error.mli
+++ b/otherlibs/stdune-unstable/user_error.mli
@@ -1,40 +1,55 @@
 (** Error meant for humans *)
 
-module Annot : sig
-  type t
+(** A data structure carrying extra information that can be attached to errors.
 
-  module type S = sig
-    type payload
+    This is mostly used to provide further context, such as location information
+    for the RPC. *)
+module Annotations : sig
+  module Entry : sig
+    type 'a t
 
-    val make : payload -> t
+    module type S = sig
+      type payload
 
-    val check : t -> (payload -> 'a) -> (unit -> 'a) -> 'a
+      val entry : payload t
+    end
+
+    module Make (Payload : sig
+      type t
+
+      val name : string
+
+      val to_dyn : t -> Dyn.t
+    end) : S with type payload = Payload.t
   end
 
-  module Make (M : sig
-    type payload
+  type t
 
-    val to_dyn : payload -> Dyn.t
-  end) : S with type payload = M.payload
+  val none : t
+
+  val annotate : t -> 'a Entry.t -> 'a -> t
+
+  val singleton : 'a Entry.t -> 'a -> t
+
+  val lookup : t -> 'a Entry.t -> 'a option
+
+  val is_empty : t -> bool
 
   (** The message has a location embed in the text. *)
-  module Has_embedded_location : S with type payload = unit
+  module Has_embedded_location : Entry.S with type payload = unit
 end
 
 (** User errors are errors that users need to fix themselves in order to make
     progress. Since these errors are read by users, they should be simple to
-    understand for people who are not familiar with the dune codebase.
-
-    The additional [Annot.t] is intended to carry extra context for other,
-    non-user-facing purposes (such as data for the RPC). *)
-exception E of User_message.t * Annot.t list
+    understand for people who are not familiar with the dune codebase. *)
+exception E of User_message.t * Annotations.t
 
 (** Raise a user error. The arguments are interpreted in the same way as
     [User_message.make]. The first paragraph is prefixed with "Error:". *)
 val raise :
      ?loc:Loc0.t
   -> ?hints:User_message.Style.t Pp.t list
-  -> ?annots:Annot.t list
+  -> ?annots:Annotations.t
   -> User_message.Style.t Pp.t list
   -> _
 
@@ -50,8 +65,8 @@ val prefix : User_message.Style.t Pp.t
 
 (** Returns [true] if the message has an explicit location or one embed in the
     text. *)
-val has_location : User_message.t -> Annot.t list -> bool
+val has_location : User_message.t -> Annotations.t -> bool
 
 (** Returns [true] if the following list of annotations contains
     [Annot.Has_embedded_location]. *)
-val has_embed_location : Annot.t list -> bool
+val has_embed_location : Annotations.t -> bool

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -30,7 +30,8 @@ module Prog = struct
       in
       Utils.program_not_found_message ?hint ~loc ~context program
 
-    let raise t = raise (User_error.E (user_message t, []))
+    let raise t =
+      raise (User_error.E (user_message t, User_error.Annotations.none))
 
     let to_dyn { context; program; hint; loc = _ } =
       let open Dyn.Encoder in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -361,14 +361,12 @@ end
 module Error = struct
   type t = Exn_with_backtrace.t
 
-  let extract_dir annot =
-    Process.With_directory_annot.check annot
-      (fun dir -> Some dir)
-      (fun () -> None)
+  let extract_dir annots =
+    User_error.Annotations.lookup annots Process.With_directory_annot.entry
 
   let info (t : t) =
     match t.exn with
-    | User_error.E (msg, annots) -> (msg, List.find_map annots ~f:extract_dir)
+    | User_error.E (msg, annots) -> (msg, extract_dir annots)
     | e ->
       (* CR-someday jeremiedimino: Use [Report_error.get_user_message] here. *)
       (User_message.make [ Pp.text (Printexc.to_string e) ], None)

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -6,8 +6,10 @@ module Event = Chrome_trace.Event
 module Timestamp = Event.Timestamp
 module Action_output_on_success = Execution_parameters.Action_output_on_success
 
-module With_directory_annot = User_error.Annot.Make (struct
-  type payload = Path.t
+module With_directory_annot = User_error.Annotations.Entry.Make (struct
+  type t = Path.t
+
+  let name = "with_directory"
 
   let to_dyn = Path.to_dyn
 end)
@@ -378,10 +380,11 @@ module Exit_status = struct
       | None -> Path.of_string (Sys.getcwd ())
       | Some dir -> dir
     in
-    let annots = [ With_directory_annot.make dir ] in
+    let module A = User_error.Annotations in
+    let annots = A.singleton With_directory_annot.entry dir in
     let annots =
       if has_embedded_location then
-        User_error.Annot.Has_embedded_location.make () :: annots
+        A.annotate annots A.Has_embedded_location.entry ()
       else
         annots
     in

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -2,7 +2,8 @@
 
 open Import
 
-module With_directory_annot : User_error.Annot.S with type payload = Path.t
+module With_directory_annot :
+  User_error.Annotations.Entry.S with type payload = Path.t
 
 (** How to handle sub-process failures *)
 type ('a, 'b) failure_mode =

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -859,5 +859,4 @@ let shutdown () =
     | _ -> Fiber.return ()
   in
   t.status <- Shutting_down;
-  Process_watcher.killall t.process_watcher Sys.sigkill;
   fill_file_changes

--- a/src/dune_engine/string_with_vars.ml
+++ b/src/dune_engine/string_with_vars.ml
@@ -249,7 +249,7 @@ struct
               (* The [let+ () = A.return () in ...] is to delay the error until
                  the evaluation of the applicative *)
               let+ () = A.return () in
-              raise (User_error.E (msg, []))
+              raise (User_error.E (msg, User_error.Annotations.none))
             | Pform (source, p) ->
               let+ v = f ~source p in
               if t.quoted then
@@ -320,7 +320,8 @@ let encode t =
       ; parts =
           List.map t.parts ~f:(function
             | Text s -> Dune_lang.Template.Text s
-            | Error (_, msg) -> raise (User_error.E (msg, []))
+            | Error (_, msg) ->
+              raise (User_error.E (msg, User_error.Annotations.none))
             | Pform (source, pform) -> (
               match Pform.encode_to_latest_dune_lang_version pform with
               | Pform_was_deleted ->

--- a/src/dune_engine/utils.ml
+++ b/src/dune_engine/utils.ml
@@ -45,10 +45,16 @@ let program_not_found_message ?context ?hint ~loc prog =
     prog
 
 let program_not_found ?context ?hint ~loc prog =
-  raise (User_error.E (program_not_found_message ?context ?hint ~loc prog, []))
+  raise
+    (User_error.E
+       ( program_not_found_message ?context ?hint ~loc prog
+       , User_error.Annotations.none ))
 
 let library_not_found ?context ?hint lib =
-  raise (User_error.E (not_found "Library %s not found" ?context ?hint lib, []))
+  raise
+    (User_error.E
+       ( not_found "Library %s not found" ?context ?hint lib
+       , User_error.Annotations.none ))
 
 let install_file ~(package : Package.Name.t) ~findlib_toolchain =
   let package = Package.Name.to_string package in

--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -594,7 +594,7 @@ let map_validate t ~f ctx state1 =
       | Some _ -> msg
       | None -> { msg with loc = Some (loc_between_states ctx state1 state2) }
     in
-    raise (User_error.E (msg, []))
+    raise (User_error.E (msg, User_error.Annotations.none))
 
 (** TODO: Improve consistency of error messages, e.g. use %S consistently for
     field names: see [field_missing] and [field_present_too_many_times]. *)

--- a/src/dune_rules/coq_lib.ml
+++ b/src/dune_rules/coq_lib.ml
@@ -41,7 +41,9 @@ let package l = l.package
 
 module Error = struct
   let make ?loc ?hints paragraphs =
-    Error (User_error.E (User_error.make ?loc ?hints paragraphs, []))
+    Error
+      (User_error.E
+         (User_error.make ?loc ?hints paragraphs, User_error.Annotations.none))
 
   let duplicate_theory_name theory =
     let loc, name = theory.Coq_stanza.Theory.name in

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -139,7 +139,10 @@ let isn't_allowed_in_this_position_message ~source =
     ]
 
 let isn't_allowed_in_this_position ~source =
-  raise (User_error.E (isn't_allowed_in_this_position_message ~source, []))
+  raise
+    (User_error.E
+       ( isn't_allowed_in_this_position_message ~source
+       , User_error.Annotations.none ))
 
 let expand_artifact ~source t a s =
   match t.lookup_artifacts with

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -391,7 +391,7 @@ end = struct
                              (Path.to_string src_dir)
                          ; Pp.textf "error: %s" (Unix.error_message e)
                          ]
-                     , [] ))
+                     , User_error.Annotations.none ))
               | Ok files ->
                 let ext = Cm_kind.ext Cmi in
                 Result.List.filter_map files ~f:(fun fname ->
@@ -410,7 +410,9 @@ end = struct
                             (Loc.in_dir src_dir, name)
                         with
                         | Ok s -> Ok (Some s)
-                        | Error e -> Error (User_error.E (e, []))))))
+                        | Error e ->
+                          Error (User_error.E (e, User_error.Annotations.none))))
+              ))
         in
         Lib_info.create ~path_kind:External ~loc ~name:t.name ~kind ~status
           ~src_dir ~orig_src_dir ~obj_dir ~version ~synopsis ~main_module_name

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -435,7 +435,9 @@ let get_cookies ~loc ~expander ~lib_name libs =
            [ "--cookie"; sprintf "%s=%S" name value ])
   with
   | x -> Resolve.return x
-  | exception User_error.E (msg, []) -> Resolve.fail msg
+  | exception User_error.E (msg, annots)
+    when User_error.Annotations.is_empty annots ->
+    Resolve.fail msg
 
 let ppx_driver_and_flags_internal sctx ~loc ~expander ~lib_name ~flags libs =
   let open Resolve.O in

--- a/src/dune_rules/resolve.ml
+++ b/src/dune_rules/resolve.ml
@@ -66,7 +66,9 @@ let args t =
     let open Action_builder.O in
     Command.Args.Dyn (read t >>| fun _ -> assert false)
 
-let fail msg = Error { exn = User_error.E (msg, []); stack_frames = [] }
+let fail msg =
+  Error
+    { exn = User_error.E (msg, User_error.Annotations.none); stack_frames = [] }
 
 let peek t = Result.map_error t ~f:ignore
 

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -45,7 +45,9 @@ module Pkg = struct
   let default_exn ~loc project stanza =
     match default project stanza with
     | Ok p -> p
-    | Error msg -> raise (User_error.E ({ msg with loc = Some loc }, []))
+    | Error msg ->
+      raise
+        (User_error.E ({ msg with loc = Some loc }, User_error.Annotations.none))
 
   let resolve (project : Dune_project.t) name =
     let packages = Dune_project.packages project in
@@ -88,7 +90,9 @@ module Pkg = struct
     and+ loc, name = located Package.Name.decode in
     match resolve p name with
     | Ok x -> x
-    | Error e -> raise (User_error.E ({ e with loc = Some loc }, []))
+    | Error e ->
+      raise
+        (User_error.E ({ e with loc = Some loc }, User_error.Annotations.none))
 
   let field ~stanza =
     map_validate

--- a/src/dune_rules/watermarks.ml
+++ b/src/dune_rules/watermarks.ml
@@ -341,7 +341,7 @@ let subst vcs =
     let version = Dune_project.dune_version dune_project.project in
     let ok_exn = function
       | Ok s -> s
-      | Error e -> raise (User_error.E (e, []))
+      | Error e -> raise (User_error.E (e, User_error.Annotations.none))
     in
     if version >= (3, 0) then
       metadata_from_dune_project ()

--- a/src/dune_util/stringlike.ml
+++ b/src/dune_util/stringlike.ml
@@ -34,7 +34,7 @@ module Make (S : Stringlike_intf.S_base) = struct
   let parse_string_exn (loc, s) =
     match of_string_user_error (loc, s) with
     | Ok s -> s
-    | Error err -> raise (User_error.E (err, []))
+    | Error err -> raise (User_error.E (err, User_error.Annotations.none))
 
   let conv =
     ( (fun s ->

--- a/src/meta_parser/meta_parser.ml
+++ b/src/meta_parser/meta_parser.ml
@@ -26,14 +26,14 @@ module Make (Stdune : sig
   end
 
   module User_error : sig
-    module Annot : sig
+    module Annotations : sig
       type t
     end
 
     val raise :
          ?loc:Loc.t
       -> ?hints:User_message.Style.t Pp.t list
-      -> ?annots:Annot.t list
+      -> ?annots:Annotations.t
       -> User_message.Style.t Pp.t list
       -> _
   end


### PR DESCRIPTION
I've had this sitting around for a bit, but with the changes to `Dep_path` I think I may as well put it forward.

Currently, error annotations are tracked as a list of `Annot.t` values. This PR replaces that list with a `Univ_map.t`.

Advantages:
- Any particular annotation is present at most once. This means there can be no possible confusion when attempting to look up an annotation.
- We can be much more principled about when a particular annotation is allowed to be looked up or discharged (via scoping the key). This is sort of already possible by hiding the variant constructor/`check` function in the current approach, but this one is more robust in that hiding the key prevents removal, as well.
- Morally, what we really want for annotations is an extensible product, not a list of extensible sums, and `Univ_map.t` is the closest thing we have to that.

Disadvantages:
- It's a lot more verbose (which may not be such a disadvantage -- I'm not sure how common I expect adding annotations to be, but if it's irritating to do, we'll have a very soft assurance that we aren't carrying around extraneous ones)
- Performance-wise, I imagine that a `Univ_map.t` is significantly heavier than a list.