### PR TITLE
Show db save progress in status line

### DIFF
--- a/otherlibs/stdune-unstable/console.ml
+++ b/otherlibs/stdune-unstable/console.ml
@@ -154,6 +154,11 @@ module Status_line = struct
     | None -> ()
     | Some msg -> print_if_no_status_line msg);
     refresh ()
+
+  let set_live_temporarily x f =
+    let old = !status_line in
+    set_live x;
+    Exn.protect ~finally:(fun () -> set_live old) ~f
 end
 
 let () = User_warning.set_reporter print_user_message

--- a/otherlibs/stdune-unstable/console.mli
+++ b/otherlibs/stdune-unstable/console.mli
@@ -62,5 +62,9 @@ module Status_line : sig
       printed even if a dumb console backend is in use. *)
   val set_constant : t -> unit
 
+  (** [set_live_temporarily status f] sets the status line to a given live value
+      for the duration of [f] and then reverts to the old value. *)
+  val set_live_temporarily : (unit -> t) -> (unit -> 'a) -> 'a
+
   val refresh : unit -> unit
 end

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -289,7 +289,9 @@ end = struct
   let dump () =
     if !needs_dumping && Path.build_dir_exists () then (
       needs_dumping := false;
-      P.dump file (Lazy.force t)
+      Console.Status_line.set_live_temporarily
+        (fun () -> Some (Pp.hbox (Pp.text "Saving build trace db...")))
+        (fun () -> P.dump file (Lazy.force t))
     )
 
   let () = Hooks.End_of_build.always dump

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -117,8 +117,11 @@ let delete_very_recent_entries () =
 let dump () =
   if !needs_dumping && Path.build_dir_exists () then (
     needs_dumping := false;
-    delete_very_recent_entries ();
-    P.dump db_file (Lazy.force cache)
+    Console.Status_line.set_live_temporarily
+      (fun () -> Some (Pp.hbox (Pp.text "Saving digest db...")))
+      (fun () ->
+        delete_very_recent_entries ();
+        P.dump db_file (Lazy.force cache))
   )
 
 let () = Hooks.End_of_build.always dump


### PR DESCRIPTION
This feature makes dune change its status line when it saves caches to disk.

This is very useful to see why dune is suddenly stuck for 5 seconds.

Testing
-------
Ran without -verbose, saw the status line show these messages as expected.
