### PR TITLE
verbose output with status line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,6 +141,9 @@ Unreleased
   a file that failed to build. This was a niche feature and it was
   getting in the way of making Dune's core better. (#4607, @jeremiedimino)
 
+- Make Dune display the progress indicator in all output modes except quiet
+  (#4618, @aalekseyev)
+
 2.9.0 (unreleased)
 ------------------
 

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -117,7 +117,7 @@ let () =
   let module Scheduler = Dune_engine.Scheduler in
   let config =
     { Scheduler.Config.concurrency = 10
-    ; display = Quiet
+    ; display = { verbosity = Quiet; status_line = false }
     ; rpc = None
     ; stats = None
     }

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -5,7 +5,7 @@ open Dune_engine
 
 let config =
   { Scheduler.Config.concurrency = 1
-  ; display = Short
+  ; display = { verbosity = Short; status_line = false }
   ; rpc = None
   ; stats = None
   }

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -514,7 +514,7 @@ let display_term =
          & info [ "verbose" ] ~docs:copts_sect
              ~doc:"Same as $(b,--display verbose)")
      in
-     Option.some_if verbose { Display.verbosity = Verbose; status_line = false })
+     Option.some_if verbose { Display.verbosity = Verbose; status_line = true })
     Arg.(
       value
       & opt (some (enum Display.all)) None

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -514,7 +514,7 @@ let display_term =
          & info [ "verbose" ] ~docs:copts_sect
              ~doc:"Same as $(b,--display verbose)")
      in
-     Option.some_if verbose Display.Verbose)
+     Option.some_if verbose { Display.verbosity = Verbose; status_line = false })
     Arg.(
       value
       & opt (some (enum Display.all)) None

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -61,7 +61,10 @@ let term =
   let+ () = Common.build_info
   and+ debug_backtraces = Common.debug_backtraces in
   let config : Dune_config.t =
-    { Dune_config.default with display = Quiet; concurrency = Fixed 1 }
+    { Dune_config.default with
+      display = { verbosity = Quiet; status_line = false }
+    ; concurrency = Fixed 1
+    }
   in
   Dune_engine.Clflags.debug_backtraces debug_backtraces;
   Path.set_root (Path.External.cwd ());

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -155,7 +155,7 @@ let resolve_targets_mixed root (config : Dune_config.t) setup user_targets =
           >>| Result.map_error ~f:(fun hints ->
                   (Arg.Dep.file (Path.to_string p), hints)))
     in
-    if config.display = Verbose then
+    if config.display.verbosity = Verbose then
       Log.info
         [ Pp.text "Actual targets:"
         ; Pp.enumerate

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -16,12 +16,14 @@ module Config = struct
       ; verbosity : verbosity
       }
 
+    (* Even though [status_line] is true by default in most of these, the status
+       line is actually not shown if the output is redirected to a file or a
+       pipe. *)
     let all =
       [ ("progress", { verbosity = Quiet; status_line = true })
-      ; ("verbose", { verbosity = Verbose; status_line = false })
-      ; ("short", { verbosity = Short; status_line = false })
+      ; ("verbose", { verbosity = Verbose; status_line = true })
+      ; ("short", { verbosity = Short; status_line = true })
       ; ("quiet", { verbosity = Quiet; status_line = false })
-      ; ("verbose+progress", { verbosity = Verbose; status_line = true })
       ]
 
     let verbosity_to_dyn : verbosity -> Dyn.t = function

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -6,31 +6,39 @@ module Config = struct
   include Config
 
   module Display = struct
-    type t =
-      | Progress
+    type verbosity =
+      | Quiet
       | Short
       | Verbose
-      | Quiet
+
+    type t =
+      { status_line : bool
+      ; verbosity : verbosity
+      }
 
     let all =
-      [ ("progress", Progress)
-      ; ("verbose", Verbose)
-      ; ("short", Short)
-      ; ("quiet", Quiet)
+      [ ("progress", { verbosity = Quiet; status_line = true })
+      ; ("verbose", { verbosity = Verbose; status_line = false })
+      ; ("short", { verbosity = Short; status_line = false })
+      ; ("quiet", { verbosity = Quiet; status_line = false })
+      ; ("verbose+progress", { verbosity = Verbose; status_line = true })
       ]
 
-    let to_dyn = function
-      | Progress -> Dyn.Variant ("Progress", [])
+    let verbosity_to_dyn : verbosity -> Dyn.t = function
       | Quiet -> Variant ("Quiet", [])
       | Short -> Variant ("Short", [])
       | Verbose -> Variant ("Verbose", [])
 
-    let console_backend = function
-      | Progress -> Console.Backend.progress
-      | Short
-      | Verbose
-      | Quiet ->
-        Console.Backend.dumb
+    let to_dyn { status_line; verbosity } : Dyn.t =
+      Record
+        [ ("status_line", Dyn.Bool status_line)
+        ; ("verbosity", verbosity_to_dyn verbosity)
+        ]
+
+    let console_backend t =
+      match t.status_line with
+      | false -> Console.Backend.dumb
+      | true -> Console.Backend.progress
   end
 
   type t =

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -5,11 +5,15 @@ open Stdune
 
 module Config : sig
   module Display : sig
-    type t =
-      | Progress  (** Single interactive status line *)
+    type verbosity =
+      | Quiet  (** Only display errors *)
       | Short  (** One line per command *)
       | Verbose  (** Display all commands fully *)
-      | Quiet  (** Only display errors *)
+
+    type t =
+      { status_line : bool
+      ; verbosity : verbosity
+      }
 
     val all : (string * t) list
 

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -74,7 +74,7 @@ let%expect_test "csexp server life cycle" =
   in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = Quiet
+    ; display = { verbosity = Quiet; status_line = false }
     ; rpc = None
     ; stats = None
     }

--- a/test/expect-tests/dune_config/dune_config_test.ml
+++ b/test/expect-tests/dune_config/dune_config_test.ml
@@ -20,7 +20,7 @@ let%expect_test "cache-check-probability 0.1" =
   parse "(cache-check-probability 0.1)";
   [%expect
     {|
-    { display = Quiet
+    { display = { status_line = false; verbosity = Quiet }
     ; concurrency = Fixed 1
     ; terminal_persistence = Preserve
     ; sandboxing_preference = []
@@ -36,7 +36,7 @@ let%expect_test "cache-storage-mode copy" =
   parse "(cache-storage-mode copy)";
   [%expect
     {|
-    { display = Quiet
+    { display = { status_line = false; verbosity = Quiet }
     ; concurrency = Fixed 1
     ; terminal_persistence = Preserve
     ; sandboxing_preference = []
@@ -52,7 +52,7 @@ let%expect_test "cache-storage-mode hardlink" =
   parse "(cache-storage-mode hardlink)";
   [%expect
     {|
-    { display = Quiet
+    { display = { status_line = false; verbosity = Quiet }
     ; concurrency = Fixed 1
     ; terminal_persistence = Preserve
     ; sandboxing_preference = []

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -5,7 +5,7 @@ open Dune_engine
 let go =
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = Short
+    ; display = { verbosity = Short; status_line = false }
     ; rpc = None
     ; stats = None
     }

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -118,7 +118,7 @@ let run kind script =
   let vcs = { Vcs.kind; root = temp_dir } in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = Short
+    ; display = { verbosity = Short; status_line = false }
     ; rpc = None
     ; stats = None
     }


### PR DESCRIPTION
This PR makes it possible to run dune in verbose mode
while seeing the status line.

The CLI interface is quite ugly, so suggestions are welcome:

--display=verbose+progress

Maybe we should just change --verbose to mean verbose+progress, but
I'm not sure that's backwards-compatible, so doing this more cautious change.

Testing
-------
Ran dune with --display=verbose+progress, saw the expected verbose
log with progress line.