### PR TITLE
Add systematic separators for temp prefix and suffix

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -112,7 +112,7 @@ let run_bench () =
 
 let () =
   Dune_util.Log.init ~file:No_log_file ();
-  let dir = Temp.create Dir ~prefix:"dune." ~suffix:".bench" in
+  let dir = Temp.create Dir ~prefix:"dune" ~suffix:"bench" in
   Sys.chdir (Path.to_string dir);
   let module Scheduler = Dune_engine.Scheduler in
   let config =

--- a/otherlibs/stdune-unstable/temp.ml
+++ b/otherlibs/stdune-unstable/temp.ml
@@ -9,7 +9,7 @@ let try_paths n ~dir ~prefix ~suffix ~f =
   let rec loop n =
     let path =
       let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
-      Path.relative dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
+      Path.relative dir (Printf.sprintf "%s_%06x_%s" prefix rnd suffix)
     in
     match f path with
     | Ok res -> res

--- a/otherlibs/stdune-unstable/temp.mli
+++ b/otherlibs/stdune-unstable/temp.mli
@@ -21,11 +21,11 @@ val destroy : what -> Path.t -> unit
 val clear_dir : Path.t -> unit
 
 (** [temp_file ~dir ~prefix ~suffix] creates a temporary file in [dir]. The base
-    name of the file is formed by concatenating [prefix], then a suitably chosen
-    integer number, then [suffix]. Note that the file must be created to reserve
-    the name in [dir] and prevent other processes from taking it concurrently.
-    If you need a temporary file that does not exist on disk, you can create a
-    temporary directory and safely use any file name there. *)
+    name of the file is [prefix_num_suffix], where [num] is a random integer
+    number. Note that the file must be created to reserve the name in [dir] and
+    prevent other processes from taking it concurrently. If you need a temporary
+    file that does not exist on disk, you can create a temporary directory and
+    safely use any file name there. *)
 val temp_file : dir:Path.t -> prefix:string -> suffix:string -> Path.t
 
 (** Like [temp_file], but passes the temporary file to the callback [f], and

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -58,8 +58,7 @@ end
 let link_even_if_there_are_too_many_links_already ~src ~dst =
   try Path.link src dst with
   | Unix.Unix_error (Unix.EMLINK, _, _) ->
-    Temp.with_temp_file ~dir:temp_dir ~prefix:"dune." ~suffix:".copy"
-      ~f:(function
+    Temp.with_temp_file ~dir:temp_dir ~prefix:"dune" ~suffix:"copy" ~f:(function
       | Error e -> raise e
       | Ok temp_file ->
         Io.copy_file ~src ~dst:temp_file ();

--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -46,7 +46,7 @@ let add_atomically ~mode ~src ~dst : Write_result.t =
 
 (* CR-someday amokhov: Switch to [renameat2] to go from two operations to one. *)
 let write_atomically ~mode ~content dst : Write_result.t =
-  Temp.with_temp_file ~dir:Layout.temp_dir ~prefix:"dune." ~suffix:"write"
+  Temp.with_temp_file ~dir:Layout.temp_dir ~prefix:"dune" ~suffix:"write"
     ~f:(function
     | Error e -> Write_result.Error e
     | Ok temp_file -> (

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -120,8 +120,8 @@ let exec_run ~ectx ~eenv prog args =
 
 let exec_run_dynamic_client ~ectx ~eenv prog args =
   validate_context_and_prog ectx.context prog;
-  let run_arguments_fn = Temp.create File ~prefix:"dune." ~suffix:".run" in
-  let response_fn = Temp.create File ~prefix:"dune." ~suffix:".response" in
+  let run_arguments_fn = Temp.create File ~prefix:"dune" ~suffix:"run" in
+  let response_fn = Temp.create File ~prefix:"dune" ~suffix:"response" in
   let run_arguments =
     let targets =
       let to_relative path =

--- a/src/dune_engine/dtemp.ml
+++ b/src/dune_engine/dtemp.ml
@@ -1,6 +1,6 @@
 open Stdune
 
-let temp_dir = lazy (Temp.create Dir ~prefix:"build" ~suffix:".dune")
+let temp_dir = lazy (Temp.create Dir ~prefix:"build" ~suffix:"dune")
 
 let temp_dir_value = lazy (Path.to_absolute_filename (Lazy.force temp_dir))
 

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -556,7 +556,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
           match Response_file.get ~prog with
           | Not_supported -> (args, None)
           | Zero_terminated_strings arg ->
-            let fn = Temp.create File ~prefix:"responsefile" ~suffix:".data" in
+            let fn = Temp.create File ~prefix:"responsefile" ~suffix:"data" in
             Stdune.Io.with_file_out fn ~f:(fun oc ->
                 List.iter args ~f:(fun arg ->
                     output_string oc arg;
@@ -579,7 +579,7 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
         | _, Terminal _
           when !Clflags.capture_outputs ->
           let capture () =
-            let fn = Temp.create File ~prefix:"dune." ~suffix:".output" in
+            let fn = Temp.create File ~prefix:"dune" ~suffix:"output" in
             (`Capture fn, Io.file fn Io.Out)
           in
           let stdout =
@@ -743,7 +743,7 @@ let run_with_times ?dir ?stdout_to ?stderr_to ?stdin_from ?env
 
 let run_capture_gen ?dir ?stderr_to ?stdin_from ?env ?(purpose = Internal_job)
     fail_mode prog args ~f =
-  let fn = Temp.create File ~prefix:"dune." ~suffix:".output" in
+  let fn = Temp.create File ~prefix:"dune" ~suffix:"output" in
   let+ run =
     run_internal ?dir ~stdout_to:(Io.file fn Io.Out) ?stderr_to ?stdin_from ?env
       ~purpose fail_mode prog args

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -51,7 +51,7 @@ end = struct
             | Some p -> p
             | None -> Filename.get_temp_dir_name ())
         in
-        Temp.temp_file ~dir ~prefix:"" ~suffix:".dune"
+        Temp.temp_file ~dir ~prefix:"" ~suffix:"dune"
       in
       let () =
         let dest =

--- a/src/dune_rules/cram_exec.ml
+++ b/src/dune_rules/cram_exec.ml
@@ -382,7 +382,7 @@ let run ~env ~script lexbuf : string Fiber.t =
       in
       "." ^ suffix
     in
-    Temp.create Dir ~prefix:"dune.cram." ~suffix
+    Temp.create Dir ~prefix:"dune_cram" ~suffix
   in
   let cram_stanzas = cram_stanzas lexbuf in
   let open Fiber.O in

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -107,7 +107,7 @@ module Fd_count = struct
   let try_to_use_lsof () =
     (* note: we do not use the Process module here, because it would create a
        circular dependency *)
-    let temp = Temp.create File ~prefix:"dune." ~suffix:".lsof" in
+    let temp = Temp.create File ~prefix:"dune" ~suffix:"lsof" in
     let stdout =
       Unix.openfile
         (Path.to_absolute_filename temp)

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -30,7 +30,7 @@ module Logger = struct
 end
 
 let%expect_test "csexp server life cycle" =
-  let tmp_dir = Temp.create Dir ~prefix:"test." ~suffix:".dune.rpc" in
+  let tmp_dir = Temp.create Dir ~prefix:"test" ~suffix:"dune_rpc" in
   let addr : Unix.sockaddr =
     if Sys.win32 then
       ADDR_INET (Unix.inet_addr_loopback, 0)

--- a/test/expect-tests/stdune/temp_tests.ml
+++ b/test/expect-tests/stdune/temp_tests.ml
@@ -5,7 +5,7 @@ open Dyn.Encoder
 let () = init ()
 
 let%expect_test "Temp.clear_dir works" =
-  let path = Temp.create Dir ~prefix:"dune." ~suffix:".unit_test" in
+  let path = Temp.create Dir ~prefix:"dune" ~suffix:"unit_test" in
   Path.touch (Path.relative path "foo");
   let print () =
     Path.readdir_unsorted path
@@ -17,4 +17,5 @@ let%expect_test "Temp.clear_dir works" =
   print ();
   [%expect {|
     Ok [ "foo" ]
-    Ok [] |}]
+    Ok []
+  |}]


### PR DESCRIPTION
As discussed in #4610.

I used underscores because:
* using `.` can lead to confusion with file extensions
* using `-` can be inconvenient if prefix is omitted, since the leading `-` might be confused with a command line flag -- for example, try `touch -test-`.