### PR TITLE
Add rule locations to build errors

### DIFF
--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -121,6 +121,8 @@ module V1 : sig
        example, if your opam installation is too old). *)
     val directory : t -> string option
 
+    val rule_source : t -> string option
+
     module Event : sig
       type nonrec t =
         | Add of t

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -121,7 +121,7 @@ module V1 : sig
        example, if your opam installation is too old). *)
     val directory : t -> string option
 
-    val rule_source : t -> string option
+    val rule_source : t -> Loc.t option
 
     module Event : sig
       type nonrec t =

--- a/otherlibs/dune-rpc/private/conv.ml
+++ b/otherlibs/dune-rpc/private/conv.ml
@@ -419,6 +419,12 @@ let six a b c d e f =
     (fun ((a, b, c), (d, e, f)) -> (a, b, c, d, e, f))
     (fun (a, b, c, d, e, f) -> ((a, b, c), (d, e, f)))
 
+let seven a b c d e f g =
+  iso
+    (both (three a b c) (four d e f g))
+    (fun ((a, b, c), (d, e, f, g)) -> (a, b, c, d, e, f, g))
+    (fun (a, b, c, d, e, f, g) -> ((a, b, c), (d, e, f, g)))
+
 let sexp = Sexp
 
 let required x = Required x

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -72,6 +72,16 @@ val six :
   -> ('f, fields) t
   -> ('a * 'b * 'c * 'd * 'e * 'f, fields) t
 
+val seven :
+     ('a, fields) t
+  -> ('b, fields) t
+  -> ('c, fields) t
+  -> ('d, fields) t
+  -> ('e, fields) t
+  -> ('f, fields) t
+  -> ('g, fields) t
+  -> ('a * 'b * 'c * 'd * 'e * 'f * 'g, fields) t
+
 val record : ('a, fields) t -> ('a, values) t
 
 val either : ('a, fields) t -> ('b, fields) t -> (('a, 'b) Either.t, fields) t

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -166,7 +166,7 @@ module Diagnostic = struct
     ; severity : severity option
     ; promotion : Promotion.t list
     ; directory : string option
-    ; rule_source : string option
+    ; rule_source : Loc.t option
     }
 
   let sexp_pp : (unit Stdune.Pp.t, Conv.values) Conv.t =
@@ -269,7 +269,7 @@ module Diagnostic = struct
     let targets = field "targets" (required (list Target.sexp)) in
     let severity = field "severity" (optional sexp_severity) in
     let directory = field "directory" (optional string) in
-    let rule_source = field "rule_source" (optional string) in
+    let rule_source = field "rule_source" (optional Loc.sexp) in
     let promotion = field "promotion" (required (list Promotion.sexp)) in
     iso
       (record

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -166,6 +166,7 @@ module Diagnostic = struct
     ; severity : severity option
     ; promotion : Promotion.t list
     ; directory : string option
+    ; rule_source : string option
     }
 
   let sexp_pp : (unit Stdune.Pp.t, Conv.values) Conv.t =
@@ -247,25 +248,33 @@ module Diagnostic = struct
 
   let directory t = t.directory
 
+  let rule_source t = t.rule_source
+
   let sexp_severity =
     let open Conv in
     enum [ ("error", Error); ("warning", Warning) ]
 
   let sexp =
     let open Conv in
-    let from { targets; message; loc; severity; promotion; directory } =
-      (targets, message, loc, severity, promotion, directory)
+    let from
+        { targets; message; loc; severity; promotion; directory; rule_source } =
+      (targets, message, loc, severity, promotion, directory, rule_source)
     in
-    let to_ (targets, message, loc, severity, promotion, directory) =
-      { targets; message; loc; severity; promotion; directory }
+    let to_ (targets, message, loc, severity, promotion, directory, rule_source)
+        =
+      { targets; message; loc; severity; promotion; directory; rule_source }
     in
     let loc = field "loc" (optional Loc.sexp) in
     let message = field "message" (required sexp_pp) in
     let targets = field "targets" (required (list Target.sexp)) in
     let severity = field "severity" (optional sexp_severity) in
     let directory = field "directory" (optional string) in
+    let rule_source = field "rule_source" (optional string) in
     let promotion = field "promotion" (required (list Promotion.sexp)) in
-    iso (record (six targets message loc severity promotion directory)) to_ from
+    iso
+      (record
+         (seven targets message loc severity promotion directory rule_source))
+      to_ from
 
   module Event = struct
     type nonrec t =

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -154,7 +154,7 @@ module Diagnostic : sig
     ; severity : severity option
     ; promotion : Promotion.t list
     ; directory : string option
-    ; rule_source : string option
+    ; rule_source : Loc.t option
     }
 
   val loc : t -> Loc.t option
@@ -169,7 +169,7 @@ module Diagnostic : sig
 
   val directory : t -> string option
 
-  val rule_source : t -> string option
+  val rule_source : t -> Loc.t option
 
   module Event : sig
     type nonrec t =

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -154,6 +154,7 @@ module Diagnostic : sig
     ; severity : severity option
     ; promotion : Promotion.t list
     ; directory : string option
+    ; rule_source : string option
     }
 
   val loc : t -> Loc.t option
@@ -167,6 +168,8 @@ module Diagnostic : sig
   val targets : t -> Target.t list
 
   val directory : t -> string option
+
+  val rule_source : t -> string option
 
   module Event : sig
     type nonrec t =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -362,7 +362,7 @@ end
 module Error = struct
   type t =
     { exn : Exn_with_backtrace.t
-    ; rule_source : Path.Source.t option
+    ; rule_source : Loc.t option
     }
 
   let extract_dir annot =
@@ -1284,7 +1284,7 @@ and Exported : sig
 
   val execute_rule : Rule.t -> rule_execution_result Memo.Build.t
 
-  val rule_source : unit -> Path.Source.t option Memo.Build.t
+  val rule_source : unit -> Loc.t option Memo.Build.t
 
   (* The below two definitions are useless, but if we remove them we get an
      "Undefined_recursive_module" exception. *)
@@ -2268,10 +2268,12 @@ end = struct
     List.find_map stack ~f:(fun frame ->
         match Memo.Stack_frame.as_instance_of frame ~of_:execute_rule_memo with
         | None -> None
-        | Some (r : Rule.t) -> (
-          match r.info with
-          | Source_file_copy source -> Some source
-          | _ -> None))
+        | Some (r : Rule.t) ->
+          let loc = Rule.loc r in
+          if Loc.is_none loc then
+            None
+          else
+            Some loc)
 
   let execute_rule = Memo.exec execute_rule_memo
 

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -11,6 +11,8 @@ module Error : sig
   (** Errors when building a target *)
   type t
 
+  val rule_source : t -> Path.Source.t option
+
   val info : t -> User_message.t * Path.t option
 end
 

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -11,7 +11,7 @@ module Error : sig
   (** Errors when building a target *)
   type t
 
-  val rule_source : t -> Path.Source.t option
+  val rule_source : t -> Loc.t option
 
   val info : t -> User_message.t * Path.t option
 end

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -15,9 +15,7 @@ end
 
 type pending_build_action = Build of Dep_conf.t list * Status.t Fiber.Ivar.t
 
-let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
-    =
- fun m ->
+let diagnostic_of_error (m : Build_system.Error.t) : Diagnostic.t =
   let message, dir = Build_system.Error.info m in
   let loc = message.loc in
   let message = Pp.map_tags (Pp.concat message.paragraphs) ~f:(fun _ -> ()) in
@@ -27,6 +25,8 @@ let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
   ; loc
   ; promotion = []
   ; directory = Option.map ~f:Path.to_string dir
+  ; rule_source =
+      Option.map ~f:Path.Source.to_string (Build_system.Error.rule_source m)
   }
 
 (* TODO un-copy-paste from dune/bin/arg.ml *)

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -25,8 +25,7 @@ let diagnostic_of_error (m : Build_system.Error.t) : Diagnostic.t =
   ; loc
   ; promotion = []
   ; directory = Option.map ~f:Path.to_string dir
-  ; rule_source =
-      Option.map ~f:Path.Source.to_string (Build_system.Error.rule_source m)
+  ; rule_source = Build_system.Error.rule_source m
   }
 
 (* TODO un-copy-paste from dune/bin/arg.ml *)


### PR DESCRIPTION
When the error does not have a location, we can use the location of the rule that generated it.