### PR TITLE
Reduce parallelism in [execute_rule], add some docs

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1665,14 +1665,20 @@ end = struct
     in
     start_rule t rule;
     let head_target = Path.Build.Set.choose_exn targets in
-    let* action, deps = exec_build_request action
-    and* execution_parameters =
+    let* execution_parameters =
       match Dpath.Target_dir.of_target dir with
       | Regular (With_context (_, dir))
       | Anonymous_action (With_context (_, dir)) ->
         Source_tree.execution_parameters_of_dir dir
       | _ -> Execution_parameters.default
     in
+    (* Note: we do not run [exec_build_request] in parallel with the above: if
+       we fail to compute action execution parameters, we have no use for the
+       action and might as well fail early, skipping unnecessary dependencies.
+       The function [Source_tree.execution_parameters_of_dir] is memoized, and
+       the result is not expected to change often, so we do not sacrifise too
+       much performance here by executing it sequentially. *)
+    let* action, deps = exec_build_request action in
     let wrap_fiber f =
       Memo.Build.of_reproducible_fiber
         (if Loc.is_none loc then

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -74,7 +74,10 @@ val sequential_iter : 'a list -> f:('a -> unit t) -> unit t
     however once the combining fiber has terminated, it is guaranteed that there
     are no fibers lingering around. *)
 
-(** Start two fibers and wait for their results. *)
+(** Start two fibers and wait for their result. Note that this function combines
+    both successes and errors: if one of the computations fails, we let the
+    other one run to completion, to give it a chance to raise its errors too.
+    All other parallel execution combinators have the same error semantics. *)
 val fork_and_join : (unit -> 'a t) -> (unit -> 'b t) -> ('a * 'b) t
 
 (** Same but assume the first fiber returns [unit]. *)

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -34,7 +34,18 @@ module Build : sig
 
   val return : 'a -> 'a t
 
+  (** Combine results of two computations executed in sequence. *)
   val both : 'a t -> 'b t -> ('a * 'b) t
+
+  (** Combine results of two computations executed in parallel. Note that this
+      function combines both successes and errors: if one of the computations
+      fails, we let the other one run to completion, to give it a chance to
+      raise its errors too. Regardless of the outcome (success or failure), the
+      result will collect dependencies from both of the computations. All other
+      parallel execution combinators have the same error/dependencies semantics. *)
+  val fork_and_join : (unit -> 'a t) -> (unit -> 'b t) -> ('a * 'b) t
+
+  val fork_and_join_unit : (unit -> unit t) -> (unit -> 'a t) -> 'a t
 
   (** This uses a sequential implementation. We use the short name to conform
       with the [Applicative] interface. See [all_concurrently] for the version
@@ -48,10 +59,6 @@ module Build : sig
   val sequential_map : 'a list -> f:('a -> 'b t) -> 'b list t
 
   val sequential_iter : 'a list -> f:('a -> unit t) -> unit t
-
-  val fork_and_join : (unit -> 'a t) -> (unit -> 'b t) -> ('a * 'b) t
-
-  val fork_and_join_unit : (unit -> unit t) -> (unit -> 'a t) -> 'a t
 
   val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
 


### PR DESCRIPTION
Parallelism has a cost of combining dependencies of both computations. It's worth clarifying that in the docs. As discussed, I also reduced parallelism in `execute_rule_impl`, to avoid accumulating too much dependencies if we fail to compute action execution parameters.