### PR TITLE
Drop already reported error code

### DIFF
--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -61,13 +61,9 @@ let i_must_not_crash =
       ]
     )
 
-let reported = ref Digest.Set.empty
-
 let report_backtraces_flag = ref false
 
 let report_backtraces b = report_backtraces_flag := b
-
-let clear_reported () = reported := Digest.Set.empty
 
 let print_memo_stacks = ref false
 
@@ -92,63 +88,59 @@ let report { Exn_with_backtrace.exn; backtrace } =
       else
         msg
     in
-    let hash = Digest.generic msg in
-    if not (Digest.Set.mem !reported hash) then (
-      reported := Digest.Set.add !reported hash;
-      let append (msg : User_message.t) pp =
-        { msg with paragraphs = msg.paragraphs @ pp }
-      in
-      let msg =
-        if who_is_responsible = User && not !report_backtraces_flag then
-          msg
-        else
-          append msg
-            (List.map
-               (Printexc.raw_backtrace_to_string backtrace |> String.split_lines)
-               ~f:(fun line -> Pp.box ~indent:2 (Pp.text line)))
-      in
-      let memo_stack =
-        if !print_memo_stacks then
-          memo_stack
-        else
-          match msg.loc with
-          | None ->
-            if has_embed_location then
-              []
-            else
-              memo_stack
-          | Some loc ->
-            if Filename.is_relative loc.start.pos_fname then
-              (* If the error points to a local file, we assume that we don't
-                 need to explain to the user how we reached this error. *)
-              []
-            else
-              memo_stack
-      in
-      let memo_stack =
-        match
-          List.filter_map memo_stack
-            ~f:Memo.Stack_frame.human_readable_description
-        with
-        | [] -> None
-        | pps ->
-          Some
-            (Pp.vbox
-               (Pp.concat ~sep:Pp.cut
-                  (List.map pps ~f:(fun pp ->
-                       Pp.box ~indent:3
-                         (Pp.seq (Pp.verbatim "-> ")
-                            (Pp.seq (Pp.text "required by ") pp))))))
-      in
-      let msg =
-        match memo_stack with
-        | None -> msg
-        | Some pp -> append msg [ pp ]
-      in
-      let msg =
-        match who_is_responsible with
-        | User -> msg
-        | Developer -> append msg (i_must_not_crash ())
-      in
-      Console.print_user_message msg
-    )
+    let append (msg : User_message.t) pp =
+      { msg with paragraphs = msg.paragraphs @ pp }
+    in
+    let msg =
+      if who_is_responsible = User && not !report_backtraces_flag then
+        msg
+      else
+        append msg
+          (List.map
+             (Printexc.raw_backtrace_to_string backtrace |> String.split_lines)
+             ~f:(fun line -> Pp.box ~indent:2 (Pp.text line)))
+    in
+    let memo_stack =
+      if !print_memo_stacks then
+        memo_stack
+      else
+        match msg.loc with
+        | None ->
+          if has_embed_location then
+            []
+          else
+            memo_stack
+        | Some loc ->
+          if Filename.is_relative loc.start.pos_fname then
+            (* If the error points to a local file, we assume that we don't need
+               to explain to the user how we reached this error. *)
+            []
+          else
+            memo_stack
+    in
+    let memo_stack =
+      match
+        List.filter_map memo_stack
+          ~f:Memo.Stack_frame.human_readable_description
+      with
+      | [] -> None
+      | pps ->
+        Some
+          (Pp.vbox
+             (Pp.concat ~sep:Pp.cut
+                (List.map pps ~f:(fun pp ->
+                     Pp.box ~indent:3
+                       (Pp.seq (Pp.verbatim "-> ")
+                          (Pp.seq (Pp.text "required by ") pp))))))
+    in
+    let msg =
+      match memo_stack with
+      | None -> msg
+      | Some pp -> append msg [ pp ]
+    in
+    let msg =
+      match who_is_responsible with
+      | User -> msg
+      | Developer -> append msg (i_must_not_crash ())
+    in
+    Console.print_user_message msg

--- a/src/dune_util/report_error.mli
+++ b/src/dune_util/report_error.mli
@@ -18,8 +18,5 @@ val report_backtraces : bool -> unit
     has already failed. *)
 exception Already_reported
 
-(** Clear the list of already reported errors. *)
-val clear_reported : unit -> unit
-
 (** Print the memo stacks of errors. *)
 val print_memo_stacks : bool ref


### PR DESCRIPTION
We've been deduplicating errors in Memo for a while, so there is no need for this special mechanism any more. In fact, since it uses a mutable set of already-reported errors, which is never cleared, it's not compatible with the incremental file-watching mode.