### PR TITLE
Fix RPC reporting of [Memo.Error.E] values

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -368,7 +368,12 @@ module Error = struct
       (fun () -> None)
 
   let info (t : t) =
-    match t.exn with
+    let e =
+      match t.exn with
+      | Memo.Error.E e -> Memo.Error.get e
+      | e -> e
+    in
+    match e with
     | User_error.E (msg, annots) -> (msg, List.find_map annots ~f:extract_dir)
     | e ->
       (* CR-someday jeremiedimino: Use [Report_error.get_user_message] here. *)


### PR DESCRIPTION
With the change to `Dep_path`, any information attached to `User_error.E` exceptions currently get swallowed before reaching the RPC, producing an empty diagnostic with the message `"Memo.Error.E(_)"`. This fixes that.

Signed-off-by: Cameron Wong <cwong@janestreet.com>