### PR TITLE
Deduplicate errors in [Memo.Build.run]

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -49,8 +49,6 @@ module Build0 = struct
     | true -> y ()
     | false -> return ()
 
-  let run = Fun.id
-
   let of_reproducible_fiber = Fun.id
 
   module Option = struct
@@ -1116,6 +1114,12 @@ module Build = struct
   let of_non_reproducible_fiber fiber =
     let* (_ : Run.t) = current_run () in
     fiber
+
+  let run t =
+    let* res = Fiber.collect_errors (fun () -> t) in
+    match res with
+    | Ok res -> Fiber.return res
+    | Error exns -> Fiber.reraise_all (Exn_set.of_list exns |> Exn_set.to_list)
 end
 
 module With_implicit_output = struct

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -18,6 +18,7 @@ module Build : sig
 
   include Build with type 'a t = 'a build
 
+  (* CR-someday amokhov: Return the set of exceptions explicitly. *)
   val run : 'a t -> 'a Fiber.t
 
   (** [of_reproducible_fiber fiber] injects a fiber into the build monad. The

--- a/test/blackbox-tests/test-cases/formatting.t/run.t
+++ b/test/blackbox-tests/test-cases/formatting.t/run.t
@@ -30,6 +30,21 @@ Formatting can be checked using the @fmt target:
   >  (enabled_for ocaml))
   > EOF
   $ dune build @fmt
+  File "enabled/dune", line 1, characters 0-0:
+  Error: Files _build/default/enabled/dune and
+  _build/default/enabled/.formatted/dune differ.
+  File "enabled/ocaml_file.ml", line 1, characters 0-0:
+  Error: Files _build/default/enabled/ocaml_file.ml and
+  _build/default/enabled/.formatted/ocaml_file.ml differ.
+  File "enabled/ocaml_file.mli", line 1, characters 0-0:
+  Error: Files _build/default/enabled/ocaml_file.mli and
+  _build/default/enabled/.formatted/ocaml_file.mli differ.
+  File "enabled/reason_file.re", line 1, characters 0-0:
+  Error: Files _build/default/enabled/reason_file.re and
+  _build/default/enabled/.formatted/reason_file.re differ.
+  File "enabled/reason_file.rei", line 1, characters 0-0:
+  Error: Files _build/default/enabled/reason_file.rei and
+  _build/default/enabled/.formatted/reason_file.rei differ.
   File "enabled/subdir/dune", line 1, characters 0-0:
   Error: Files _build/default/enabled/subdir/dune and
   _build/default/enabled/subdir/.formatted/dune differ.
@@ -48,39 +63,12 @@ Formatting can be checked using the @fmt target:
   File "partial/a.ml", line 1, characters 0-0:
   Error: Files _build/default/partial/a.ml and
   _build/default/partial/.formatted/a.ml differ.
-  File "enabled/dune", line 1, characters 0-0:
-  Error: Files _build/default/enabled/dune and
-  _build/default/enabled/.formatted/dune differ.
-  File "enabled/ocaml_file.ml", line 1, characters 0-0:
-  Error: Files _build/default/enabled/ocaml_file.ml and
-  _build/default/enabled/.formatted/ocaml_file.ml differ.
-  File "enabled/ocaml_file.mli", line 1, characters 0-0:
-  Error: Files _build/default/enabled/ocaml_file.mli and
-  _build/default/enabled/.formatted/ocaml_file.mli differ.
-  File "enabled/reason_file.re", line 1, characters 0-0:
-  Error: Files _build/default/enabled/reason_file.re and
-  _build/default/enabled/.formatted/reason_file.re differ.
-  File "enabled/reason_file.rei", line 1, characters 0-0:
-  Error: Files _build/default/enabled/reason_file.rei and
-  _build/default/enabled/.formatted/reason_file.rei differ.
   [1]
 
 Configuration files are taken into account for this action:
 
   $ touch enabled/.ocamlformat
   $ dune build @fmt
-  File "lang2/default/dune", line 1, characters 0-0:
-  Error: Files _build/default/lang2/default/dune and
-  _build/default/lang2/default/.formatted/dune differ.
-  File "lang2/default/e.ml", line 1, characters 0-0:
-  Error: Files _build/default/lang2/default/e.ml and
-  _build/default/lang2/default/.formatted/e.ml differ.
-  File "lang2/partial/a.ml", line 1, characters 0-0:
-  Error: Files _build/default/lang2/partial/a.ml and
-  _build/default/lang2/partial/.formatted/a.ml differ.
-  File "partial/a.ml", line 1, characters 0-0:
-  Error: Files _build/default/partial/a.ml and
-  _build/default/partial/.formatted/a.ml differ.
   File "enabled/dune", line 1, characters 0-0:
   Error: Files _build/default/enabled/dune and
   _build/default/enabled/.formatted/dune differ.
@@ -102,6 +90,18 @@ Configuration files are taken into account for this action:
   File "enabled/subdir/lib.ml", line 1, characters 0-0:
   Error: Files _build/default/enabled/subdir/lib.ml and
   _build/default/enabled/subdir/.formatted/lib.ml differ.
+  File "lang2/default/dune", line 1, characters 0-0:
+  Error: Files _build/default/lang2/default/dune and
+  _build/default/lang2/default/.formatted/dune differ.
+  File "lang2/default/e.ml", line 1, characters 0-0:
+  Error: Files _build/default/lang2/default/e.ml and
+  _build/default/lang2/default/.formatted/e.ml differ.
+  File "lang2/partial/a.ml", line 1, characters 0-0:
+  Error: Files _build/default/lang2/partial/a.ml and
+  _build/default/lang2/partial/.formatted/a.ml differ.
+  File "partial/a.ml", line 1, characters 0-0:
+  Error: Files _build/default/partial/a.ml and
+  _build/default/partial/.formatted/a.ml differ.
   [1]
 
 And fixable files can be promoted:


### PR DESCRIPTION
Change `Memo.Build.run` to catch, deduplicate and reraise all exceptions to fix the bug I introduced in #4623.