### PR TITLE
[RPC] allow persistent clients to wait for server disconnect

### DIFF
--- a/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
+++ b/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
@@ -159,7 +159,7 @@ let%expect_test "run and connect persistent" =
         let initialize = Initialize.create ~id:(Id.make (Csexp.Atom "test")) in
         Lwt.return ((), initialize, None)
       in
-      let on_connected () t =
+      let on_connected () _ t =
         Logger.log log_client "on_connected: %d" !count;
         let* res = Client.request t Request.ping () in
         let* () =

--- a/otherlibs/dune-rpc/dune_rpc.ml
+++ b/otherlibs/dune-rpc/dune_rpc.ml
@@ -56,7 +56,7 @@ module V1 = struct
          ?on_disconnect:('a -> unit fiber)
       -> chan
       -> on_connect:(unit -> ('a * Initialize.t * Handler.t option) fiber)
-      -> on_connected:('a -> t -> unit fiber)
+      -> on_connected:('a -> (unit -> unit fiber) -> t -> unit fiber)
       -> unit fiber
   end
 end

--- a/otherlibs/dune-rpc/dune_rpc.ml
+++ b/otherlibs/dune-rpc/dune_rpc.ml
@@ -53,10 +53,11 @@ module V1 = struct
       -> 'a fiber
 
     val connect_persistent :
-         ?on_disconnect:('a -> unit fiber)
-      -> chan
+         chan
       -> on_connect:(unit -> ('a * Initialize.t * Handler.t option) fiber)
-      -> on_connected:('a -> (unit -> unit fiber) -> t -> unit fiber)
+      -> on_connected:('a -> t -> unit fiber)
       -> unit fiber
+
+    val disconnected : t -> unit fiber
   end
 end

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -232,24 +232,19 @@ module V1 : sig
 
         When a server is discovered, [on_connect ()] is first run to produce the
         application's internal state [s], initialization data and handlers.
-        Next, [on_connected s wait_for_disconnect t] is called, where:
+        Next, [on_connected s t] is called, where [t] is the client object for
+        this session.
 
-        - [wait_for_disconnect ()] produces a fiber that is determined when the
-          server disconnects
-        - [t] is the client object for this session
-
-        Finally, if present, [on_disconnect s] will be called after the
-        resolution of [on_connected], before waiting for new server connections.
-
-        Note that [on_connect], [on_connected] and [on_disconnect] are
-        necessarily called in sequence, so blocking those fibers will cause a
-        deadlock, in which no new servers will be discovered. *)
+        Note that [on_connect] and [on_connected] are necessarily called in
+        sequence, so blocking those fibers will cause a deadlock, in which no
+        new servers will be discovered. *)
     val connect_persistent :
-         ?on_disconnect:('a -> unit fiber)
-      -> chan
+         chan
       -> on_connect:(unit -> ('a * Initialize.t * Handler.t option) fiber)
-      -> on_connected:('a -> (unit -> unit fiber) -> t -> unit fiber)
+      -> on_connected:('a -> t -> unit fiber)
       -> unit fiber
+
+    val disconnected : t -> unit fiber
   end
 
   (** Functor to create a client implementation *)

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -230,7 +230,7 @@ module V1 : sig
          ?on_disconnect:('a -> unit fiber)
       -> chan
       -> on_connect:(unit -> ('a * Initialize.t * Handler.t option) fiber)
-      -> on_connected:('a -> t -> unit fiber)
+      -> on_connected:('a -> (unit -> unit fiber) -> t -> unit fiber)
       -> unit fiber
   end
 

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -226,6 +226,24 @@ module V1 : sig
       -> f:(t -> 'a fiber)
       -> 'a fiber
 
+    (** [connect_persistent ?on_disconnect session ~on_connect ~on_connected]
+        connects to a [dune rpc init --persistent] process that waits for
+        possibly-transient server connections and connects to them in sequence.
+
+        When a server is discovered, [on_connect ()] is first run to produce the
+        application's internal state [s], initialization data and handlers.
+        Next, [on_connected s wait_for_disconnect t] is called, where:
+
+        - [wait_for_disconnect ()] produces a fiber that is determined when the
+          server disconnects
+        - [t] is the client object for this session
+
+        Finally, if present, [on_disconnect s] will be called after the
+        resolution of [on_connected], before waiting for new server connections.
+
+        Note that [on_connect], [on_connected] and [on_disconnect] are
+        necessarily called in sequence, so blocking those fibers will cause a
+        deadlock, in which no new servers will be discovered. *)
     val connect_persistent :
          ?on_disconnect:('a -> unit fiber)
       -> chan

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -252,7 +252,7 @@ module type S = sig
        ?on_disconnect:('a -> unit fiber)
     -> chan
     -> on_connect:(unit -> ('a * Initialize.Request.t * Handler.t option) fiber)
-    -> on_connected:('a -> t -> unit fiber)
+    -> on_connected:('a -> (unit -> unit fiber) -> t -> unit fiber)
     -> unit fiber
 end
 

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -249,11 +249,12 @@ module type S = sig
     -> 'a fiber
 
   val connect_persistent :
-       ?on_disconnect:('a -> unit fiber)
-    -> chan
+       chan
     -> on_connect:(unit -> ('a * Initialize.Request.t * Handler.t option) fiber)
-    -> on_connected:('a -> (unit -> unit fiber) -> t -> unit fiber)
+    -> on_connected:('a -> t -> unit fiber)
     -> unit fiber
+
+  val disconnected : t -> unit fiber
 end
 
 module Client (Fiber : sig


### PR DESCRIPTION
As per discussion in #4616. This adds an extra argument to the `on_connected` argument of `connect_persistent` providing a fiber that can be waited on to terminate a running client process if the session is closed from the server-side (such as if the server shuts down).

Signed-off-by: Cameron Wong <cwong@janestreet.com>