### PR TITLE
Correct printed name of Dev profile

### DIFF
--- a/src/dune_rules/profile.ml
+++ b/src/dune_rules/profile.ml
@@ -56,6 +56,6 @@ let is_inline_test = function
 let to_dyn =
   let open Dyn.Encoder in
   function
-  | Dev -> constr "Dyn" []
+  | Dev -> constr "Dev" []
   | Release -> constr "Release" []
   | User_defined s -> constr "User_defined" [ string s ]


### PR DESCRIPTION
I think this is a typo, right?

```
dra@thor:~/dune$ dune printenv --verbose 2>&1 | fgrep 'profile =' -A2 -B2
 { name = "default"
 ; kind = "default"
 ; profile = Dyn
 ; merlin = true
 ; for_host = None
```