### PR TITLE
[RPC] Batching API

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -72,6 +72,9 @@ module V1 = struct
 
         let write (_, o) = function
           | None -> Lwt_io.close o
-          | Some csexp -> Lwt_io.write o (Csexp.to_string csexp)
+          | Some csexps ->
+            Lwt_list.iter_s
+              (fun sexp -> Lwt_io.write o (Csexp.to_string sexp))
+              csexps
       end)
 end

--- a/otherlibs/dune-rpc/dune_rpc.ml
+++ b/otherlibs/dune-rpc/dune_rpc.ml
@@ -45,6 +45,26 @@ module V1 = struct
 
     val notification : t -> 'a Notification.t -> 'a -> unit fiber
 
+    module Batch : sig
+      type t
+
+      type client
+
+      val create : client -> t
+
+      val request :
+           ?id:Id.t
+        -> t
+        -> ('a, 'b) Request.t
+        -> 'a
+        -> ('b, Response.Error.t) result fiber
+
+      val notification : t -> 'a Notification.t -> 'a -> unit
+
+      val submit : t -> unit fiber
+    end
+    with type client := t
+
     val connect :
          ?handler:Handler.t
       -> chan

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -228,6 +228,26 @@ module V1 : sig
 
     val notification : t -> 'a Notification.t -> 'a -> unit fiber
 
+    module Batch : sig
+      type t
+
+      type client
+
+      val create : client -> t
+
+      val request :
+           ?id:Id.t
+        -> t
+        -> ('a, 'b) Request.t
+        -> 'a
+        -> ('b, Response.Error.t) result fiber
+
+      val notification : t -> 'a Notification.t -> 'a -> unit
+
+      val submit : t -> unit fiber
+    end
+    with type client := t
+
     (** [connect ?on_handler session init ~f] connect to [session], initialize
         with [init] and call [f] once the client is initialized. [handler] is
         called for some notifications sent to [session] *)

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -279,7 +279,7 @@ module V1 : sig
 
     (* [write t x] writes the s-expression when [x] is [Some _], and closes the
        session if [x = None] *)
-    val write : t -> Csexp.t option -> unit Fiber.t
+    val write : t -> Csexp.t list option -> unit Fiber.t
 
     (* [read t] attempts to read from [t]. If an s-expression is read, it is
        returned as [Some sexp], otherwise [None] is returned and the session is

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -299,7 +299,7 @@ module Client (Fiber : sig
 end) (Chan : sig
   type t
 
-  val write : t -> Csexp.t option -> unit Fiber.t
+  val write : t -> Csexp.t list option -> unit Fiber.t
 
   val read : t -> Csexp.t option Fiber.t
 end) : S with type 'a fiber := 'a Fiber.t and type chan := Chan.t

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -234,6 +234,26 @@ module type S = sig
 
   val notification : t -> 'a Decl.notification -> 'a -> unit fiber
 
+  module Batch : sig
+    type t
+
+    type client
+
+    val create : client -> t
+
+    val request :
+         ?id:Id.t
+      -> t
+      -> ('a, 'b) Decl.request
+      -> 'a
+      -> ('b, Response.Error.t) result fiber
+
+    val notification : t -> 'a Decl.notification -> 'a -> unit
+
+    val submit : t -> unit fiber
+  end
+  with type client := t
+
   module Handler : sig
     type t
 

--- a/src/csexp_rpc/csexp_rpc.mli
+++ b/src/csexp_rpc/csexp_rpc.mli
@@ -24,7 +24,7 @@ module Session : sig
 
   (* [write t x] writes the s-expression when [x] is [Some sexp], and closes the
      session if [x = None ] *)
-  val write : t -> Sexp.t option -> unit Fiber.t
+  val write : t -> Sexp.t list option -> unit Fiber.t
 
   (** If [read] returns [None], the session is closed and all subsequent reads
       will return [None] *)

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -15,7 +15,7 @@ module Session = struct
   type 'a t =
     { queries : Packet.Query.t Fiber.Stream.In.t
     ; id : Id.t
-    ; send : Packet.Reply.t option -> unit Fiber.t
+    ; send : Packet.Reply.t list option -> unit Fiber.t
     ; mutable state : 'a state
     }
 
@@ -46,7 +46,7 @@ module Session = struct
     let call =
       { Call.params = Conv.to_sexp decl.req n; method_ = decl.method_ }
     in
-    t.send (Some (Notification call))
+    t.send (Some [ Notification call ])
 
   let request_close t = t.send None
 
@@ -155,7 +155,7 @@ module H = struct
           ~message:"Notification unexpected. You must initialize first."
       | Request (id, call) -> (
         match Initialize.Request.of_call ~version:t.version call with
-        | Error e -> session.send (Some (Response (id, Error e)))
+        | Error e -> session.send (Some [ Response (id, Error e) ])
         | Ok init ->
           if Initialize.Request.version init > t.version then
             let response =
@@ -169,7 +169,7 @@ module H = struct
                 (Response.Error.create ~payload ~kind:Version_error
                    ~message:"Unsupported version" ())
             in
-            session.send (Some (Response (id, response)))
+            session.send (Some [ Response (id, response) ])
           else
             let* a = t.on_init session init in
             let () =
@@ -181,7 +181,7 @@ module H = struct
                   (Initialize.Response.to_response
                      (Initialize.Response.create ()))
               in
-              session.send (Some (Response (id, response)))
+              session.send (Some [ Response (id, response) ])
             in
             let* () =
               Fiber.Stream.In.parallel_iter session.queries
@@ -211,7 +211,7 @@ module H = struct
                     Event.emit
                       (Message { kind; meth_; stage = Stop })
                       stats session.id;
-                    session.send (Some (Response (id, response))))
+                    session.send (Some [ Response (id, response) ]))
             in
             let* () = Session.request_close session in
             let+ () = t.on_terminate session in
@@ -396,7 +396,7 @@ let create_sequence f ~version conv =
 module Make (S : sig
   type t
 
-  val write : t -> Sexp.t option -> unit Fiber.t
+  val write : t -> Sexp.t list option -> unit Fiber.t
 
   val read : t -> Sexp.t option Fiber.t
 end) =
@@ -406,8 +406,8 @@ struct
   let serve sessions stats server =
     Fiber.Stream.In.parallel_iter sessions ~f:(fun session ->
         let session =
-          let send packet =
-            Option.map packet ~f:(Conv.to_sexp Packet.Reply.sexp)
+          let send packets =
+            Option.map packets ~f:(List.map ~f:(Conv.to_sexp Packet.Reply.sexp))
             |> S.write session
           in
           let queries =

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -92,7 +92,7 @@ module Make (S : sig
 
   (* [write t x] writes the s-expression when [x] is [Some _], and closes the
      session if [x = None] *)
-  val write : t -> Sexp.t option -> unit Fiber.t
+  val write : t -> Sexp.t list option -> unit Fiber.t
 
   (* [read t] attempts to read from [t]. If an s-expression is read, it is
      returned as [Some sexp], otherwise [None] is returned and the session is

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -47,7 +47,7 @@ let%expect_test "csexp server life cycle" =
       (fun () ->
         let log fmt = Logger.log client_log fmt in
         let* client = Client.connect client in
-        let* () = Session.write client (Some (List [ Atom "from client" ])) in
+        let* () = Session.write client (Some [ List [ Atom "from client" ] ]) in
         log "written";
         let* response = Session.read client in
         (match response with
@@ -68,7 +68,7 @@ let%expect_test "csexp server life cycle" =
                 Fiber.return ()
               | Some csexp ->
                 log "received %s" (Csexp.to_string csexp);
-                Session.write session (Some (List [ Atom "from server" ])))
+                Session.write session (Some [ List [ Atom "from server" ] ]))
         in
         log "sessions finished")
   in

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -23,7 +23,12 @@ module Chan = struct
 
   let create () = { in_ = Fiber.Stream.pipe (); out = Fiber.Stream.pipe () }
 
-  let write t s = Fiber.Stream.Out.write (snd t.out) s
+  let write t s =
+    match s with
+    | None -> Fiber.Stream.Out.write (snd t.out) None
+    | Some s ->
+      Fiber.sequential_iter s ~f:(fun s ->
+          Fiber.Stream.Out.write (snd t.out) (Some s))
 
   let read t = Fiber.Stream.In.read (fst t.in_)
 


### PR DESCRIPTION
RPC is currently flushing after request and notification. While that's usually
good enough, it's a poor way of doing IO when one is sending many requests.
This PR introduces an API to batch requests & notifications and submit them at
once.

Two limitations of this API are:

* The server is unable to batch notifications to the client. This can be easily fixed.
* It's not possible to batch requests/notifictions along with the initialization request. So it's not possible to initialize, send requests & notifications in a single round trip.