### PR TITLE
Workaround `opam config var` being removed in Opam 2.1

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -849,9 +849,7 @@ let map_exe (context : t) =
 let install_prefix t =
   let open Fiber.O in
   let* opam = Memo.Build.run (Opam.opam_binary_exn ()) in
-  let+ s =
-    Process.run_capture Strict opam ~env:t.env [ "config"; "var"; "prefix" ]
-  in
+  let+ s = Process.run_capture Strict opam ~env:t.env [ "var"; "prefix" ] in
   Path.of_filename_relative_to_initial_cwd (String.trim s)
 
 let dot_dune_dir t = Path.Build.relative t.build_dir ".dune"

--- a/test/blackbox-tests/test-cases/install-libdir.t/run.t
+++ b/test/blackbox-tests/test-cases/install-libdir.t/run.t
@@ -1,4 +1,4 @@
-  $ opam_prefix="$(opam config var prefix)"
+  $ opam_prefix="$(opam var prefix)"
   $ export BUILD_PATH_PREFIX_MAP="/OPAM_PREFIX=$opam_prefix:$BUILD_PATH_PREFIX_MAP"
 
 `dune install` should handle destination directories that don't exist


### PR DESCRIPTION
I recently updated to a beta version of Opam 2.1 and the following error shows when using `opam config var prefix`:
```
opam: var was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use opam var instead or set OPAMCLI environment variable to 2.0.
```

Two mitigations are possible:
1. Exporting `OPAMCLI=2.0`
2. Using `opam var prefix` instead

This PR implements option 2. However if I am not mistaken this will only work with `opam >= 2.0` ~~and I don't know if that is a satisfying constraint for Dune ?~~ Edit: the opam file does state `opam-version: "2.0"` so I guess this is not an issue.