### PR TITLE
Do not log live_words and free_words in trace file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,6 +144,9 @@ Unreleased
 - Make Dune display the progress indicator in all output modes except quiet
   (#4618, @aalekseyev)
 
+- Do not log `live_words` and `free_words` in trace file. This allows using
+  `Gc.quick_stat` which does not scan the heap. (#4643, @emillon)
+
 2.9.0 (unreleased)
 ------------------
 

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -141,10 +141,8 @@ let record_gc_and_fd stats =
   let () =
     let common = Event.common_fields ~name:"gc" ~ts () in
     let args =
-      let stat = Gc.stat () in
-      [ ("live_words", `Int stat.live_words)
-      ; ("free_words", `Int stat.free_words)
-      ; ("stack_size", `Int stat.stack_size)
+      let stat = Gc.quick_stat () in
+      [ ("stack_size", `Int stat.stack_size)
       ; ("heap_words", `Int stat.heap_words)
       ; ("top_heap_words", `Int stat.top_heap_words)
       ; ("minor_words", `Float stat.minor_words)

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -12,6 +12,6 @@ This captures the commands that are being run:
 As well as data about the garbage collector:
 
   $ <trace.json grep '"C"' | cut -c 2- | sed -E 's/([^0-9])[0-9]+/\1.../g' | sort -u
-  {"ph":"C","args":{"live_words":...,"free_words":...,"stack_size":...,"heap_words":...,"top_heap_words":...,"minor_words":...,"major_words":...,"promoted_words":...,"compactions":...,"major_collections":...,"minor_collections":...},"name":"gc","cat":"","ts":...,"pid":...,"tid":...}
+  {"ph":"C","args":{"stack_size":...,"heap_words":...,"top_heap_words":...,"minor_words":...,"major_words":...,"promoted_words":...,"compactions":...,"major_collections":...,"minor_collections":...},"name":"gc","cat":"","ts":...,"pid":...,"tid":...}
   {"ph":"C","args":{"value":...},"name":"evaluated_rules","cat":"","ts":...,"pid":...,"tid":...}
   {"ph":"C","args":{"value":...},"name":"fds","cat":"","ts":...,"pid":...,"tid":...}


### PR DESCRIPTION
This allows using `Gc.quick_stat` which does not scan the heap.
