### PR TITLE
Don't save Dune databases on every build run

### DIFF
--- a/otherlibs/stdune-unstable/console.ml
+++ b/otherlibs/stdune-unstable/console.ml
@@ -137,7 +137,7 @@ module Status_line = struct
     | Some pp ->
       (* Always put the status line inside a horizontal box to force the
          [Format] module to prefer a single line. In particular, it seems that
-         [Format.pp_print_text] split sthe line before the last word, unless it
+         [Format.pp_print_text] split the line before the last word, unless it
          is succeeded by a space. This seems like a bug in [Format] and putting
          the whole thing into a [hbox] works around this bug.
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -293,7 +293,12 @@ end = struct
         (fun () -> P.dump file (Lazy.force t))
     )
 
-  let () = Hooks.End_of_build.always dump
+  (* CR-someday amokhov: If this happens to be executed after we've cleared the
+     status line and printed some text afterwards, [dump] would overwrite that
+     text by the "Saving..." message. If this hypothetical scenario turns out to
+     be a real problem, we will need to add some synchronisation mechanism to
+     prevent clearing the status line too early. *)
+  let () = at_exit dump
 
   let get path =
     let t = Lazy.force t in

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -124,7 +124,7 @@ let dump () =
         P.dump db_file (Lazy.force cache))
   )
 
-let () = Hooks.End_of_build.always dump
+let () = at_exit dump
 
 let invalidate_cached_timestamps () =
   (if Lazy.is_val cache then


### PR DESCRIPTION
Saving Dune's databases can be slow if they are big. This PR changes Dune to save the databases only at exit.

This PR does a very simple but relatively dumb thing (just using `at_exit` instead of `Hooks.End_of_build`). As mentioned in the `CR-someday`, we might need to revisit the current implementation.

I tested that this interacts well with Ctrl-C handling: the first Ctrl-C starts the shutdown (including saving the database), the second Ctrl-C prints a message, the third Ctrl-C kills Dune (and discards the database).