### PR TITLE
Add missing src for bench target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ ifeq (dune,$(firstword $(MAKECMDGOALS)))
 endif
 
 .PHONY: bench
-bench:
-	@dune exec -- ./bench/bench.exe 2> /dev/null
+bench: release
+	@dune exec -- ./bench/bench.exe _build/default/dune.exe   2> /dev/null
 
 dune: $(BIN)
 	$(BIN) $(RUN_ARGS)


### PR DESCRIPTION
The bench command was changed to add a src so that there's no confusion about which dune is running the benchmarks. The benchmarks should now run, but will fail on the parse step (which I will fix in the current-bench pipeline).

Signed-off-by: Gargi Sharma <gs051095@gmail.com>