### PR TITLE
Upstream memo.ml tweaks

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -151,7 +151,7 @@ let handle events =
   match rebuild_required with
   | Yes -> Rebuild_required.Yes
   | No -> (
-    match Memo.incremental_mode_enabled with
+    match !Memo.incremental_mode_enabled with
     | true -> No
     | false ->
       (* In this mode, we do not assume that all file system dependencies are

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -182,7 +182,7 @@ val restart_current_run : unit -> unit
 (** Returns [true] if the user enabled the incremental mode via the environment
     variable [DUNE_WATCHING_MODE_INCREMENTAL], and we should therefore assume
     that the build system tracks all relevant side effects in the [Build] monad. *)
-val incremental_mode_enabled : bool
+val incremental_mode_enabled : bool ref
 
 module type Input = sig
   type t
@@ -360,6 +360,13 @@ end
 (** Create a "memoization cell" that focuses on a single input/output pair of a
     memoized function. *)
 val cell : ('i, 'o) t -> 'i -> ('i, 'o) Cell.t
+
+val lazy_cell :
+     ?cutoff:('a -> 'a -> bool)
+  -> ?name:string
+  -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
+  -> (unit -> 'a Build.t)
+  -> (unit, 'a) Cell.t
 
 (** Memoization of polymorphic functions ['a input -> 'a output Build.t]. The
     provided [id] function must be injective, i.e. there must be a one-to-one


### PR DESCRIPTION
Upstream some memo.ml tweaks made in Janestreet to reduce the diff.

Justifications for not reverting them in Janestreet fork, instead: 
- Memo.incremental_mode_enabled: we use it to enable incremental mode based on dune-workspace. We should probably upstream that change too and clean it up (stop using env var entirely), but it's a bit too tied up to upstream for now.
- The default size of memo table is 2: I'm generally thinking the smaller this number, the better. This change was made in a commit labelled "performance tweaks", so maybe it makes things slightly smaller, but I wouldn't hold my breath. (any effect is surely eclipsed by a ridiculous overhead of Table.create)
- `val lazy_cell` is exposed because, well, it's useful.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>