### PR TITLE
Switch to hash tables in Deps_so_far

### DIFF
--- a/otherlibs/stdune-unstable/id.ml
+++ b/otherlibs/stdune-unstable/id.ml
@@ -3,7 +3,9 @@ module type S = sig
 
   module Set : Set.S with type elt = t
 
-  module Map : Map_intf.S with type key = t
+  module Map : Map.S with type key = t
+
+  module Table : Hashtbl.S with type key = t
 
   val gen : unit -> t
 
@@ -23,6 +25,7 @@ end
 module Make () : S = struct
   module Set = Int.Set
   module Map = Int.Map
+  module Table = Hashtbl.Make (Int)
 
   type t = int
 

--- a/otherlibs/stdune-unstable/id.mli
+++ b/otherlibs/stdune-unstable/id.mli
@@ -1,9 +1,11 @@
 module type S = sig
   type t
 
-  module Set : Set_intf.S with type elt = t
+  module Set : Set.S with type elt = t
 
-  module Map : Map_intf.S with type key = t
+  module Map : Map.S with type key = t
+
+  module Table : Hashtbl.S with type key = t
 
   (** Generate a new id. *)
   val gen : unit -> t


### PR DESCRIPTION
In my experiments, this significantly reduces the time and memory taken by Memo's cycle detection (saw reductions from 20% to 50% for both).