### PR TITLE
[RFC] Refine dependency analysis

### DIFF
--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -67,7 +67,8 @@ val requires_link : t -> Lib.t list Resolve.t
 
 val requires_compile : t -> Lib.t list Resolve.t
 
-val includes : t -> Command.Args.without_targets Command.Args.t Cm_kind.Dict.t
+val includes :
+  t -> Module.t -> Command.Args.without_targets Command.Args.t Cm_kind.Dict.t
 
 val preprocessing : t -> Pp_spec.t
 

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -215,12 +215,9 @@ let for_module cctx module_ =
   dict_of_func_concurrently (deps_of cctx (Normal module_))
 
 let rules cctx ~modules =
-  match Modules.as_singleton modules with
-  | Some m -> Memo.Build.return (Dep_graph.Ml_kind.dummy m)
-  | None ->
-    let dir = Compilation_context.dir cctx in
-    dict_of_func_concurrently (fun ~ml_kind ->
-        let+ per_module =
-          Modules.obj_map_build modules ~f:(deps_of cctx ~ml_kind)
-        in
-        Dep_graph.make ~dir ~per_module)
+  let dir = CC.dir cctx in
+  dict_of_func_concurrently (fun ~ml_kind ->
+      let+ per_module =
+        Modules.obj_map_build modules ~f:(deps_of cctx ~ml_kind)
+      in
+      Dep_graph.make ~dir ~per_module)

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -1,6 +1,107 @@
 open! Dune_engine
 open! Import
 open Memo.Build.O
+module CC = Compilation_context
+module SC = Super_context
+
+let interpret_deps cctx ~unit deps =
+  let dir = CC.dir cctx in
+  let modules = CC.modules cctx in
+  let deps = Ocamldep.parse_module_names ~unit ~modules deps in
+  let stdlib = CC.stdlib cctx in
+  if Option.is_none stdlib then
+    Modules.main_module_name modules
+    |> Option.iter ~f:(fun (main_module_name : Module_name.t) ->
+           if
+             Module_name.Infix.(Module.name unit <> main_module_name)
+             && (not (Module.kind unit = Alias))
+             && List.exists deps ~f:(fun x -> Module.name x = main_module_name)
+           then
+             User_error.raise
+               [ Pp.textf "Module %s in directory %s depends on %s."
+                   (Module_name.to_string (Module.name unit))
+                   (Path.to_string_maybe_quoted (Path.build dir))
+                   (Module_name.to_string main_module_name)
+               ; Pp.textf "This doesn't make sense to me."
+               ; Pp.nop
+               ; Pp.textf
+                   "%s is the main module of the library and is the only \
+                    module exposed outside of the library. Consequently, it \
+                    should be the one depending on all the other modules in \
+                    the library."
+                   (Module_name.to_string main_module_name)
+               ]);
+  match Modules.alias_for modules unit with
+  | None -> deps
+  | Some m -> m :: deps
+
+let deps_of ~cctx ~ml_kind unit =
+  let modules = CC.modules cctx in
+  let sctx = CC.super_context cctx in
+  let source = Option.value_exn (Module.source unit ~ml_kind) in
+  let obj_dir = CC.obj_dir cctx in
+  let dir = CC.dir cctx in
+  let dep = Obj_dir.Module.dep obj_dir in
+  let context = SC.context sctx in
+  let parse_module_names = Ocamldep.parse_module_names ~modules in
+  let all_deps_file = dep (Transitive (unit, ml_kind)) in
+  let ocamldep_output = dep (Immediate source) in
+  let open Memo.Build.O in
+  let* () =
+    SC.add_rule sctx ~dir
+      (let flags =
+         Option.value (Module.pp_flags unit) ~default:(Action_builder.return [])
+       in
+       Command.run context.ocamldep
+         ~dir:(Path.build context.build_dir)
+         [ A "-modules"
+         ; Command.Args.dyn flags
+         ; Command.Ml_kind.flag ml_kind
+         ; Dep (Module.File.path source)
+         ]
+         ~stdout_to:ocamldep_output)
+  in
+  let build_paths dependencies =
+    let dependency_file_path m =
+      let ml_kind m =
+        if Module.kind m = Alias then
+          None
+        else if Module.has m ~ml_kind:Intf then
+          Some Ml_kind.Intf
+        else
+          Some Impl
+      in
+      ml_kind m
+      |> Option.map ~f:(fun ml_kind ->
+             Path.build (dep (Transitive (m, ml_kind))))
+    in
+    List.filter_map dependencies ~f:dependency_file_path
+  in
+  let action =
+    let open Action_builder.O in
+    let paths =
+      let+ lines = Action_builder.lines_of (Path.build ocamldep_output) in
+      lines
+      |> Ocamldep.parse_deps_exn ~file:(Module.File.path source)
+      |> interpret_deps cctx ~unit
+      |> fun modules ->
+      ( build_paths modules
+      , List.map modules ~f:(fun m -> Module_name.to_string (Module.name m)) )
+    in
+    Action_builder.with_targets ~targets:[ all_deps_file ]
+      (let+ sources, extras =
+         Action_builder.dyn_paths
+           (let+ sources, extras = paths in
+            ((sources, extras), sources))
+       in
+       Action.Merge_files_into (sources, extras, all_deps_file))
+  in
+  let+ () = SC.add_rule sctx ~dir action in
+  let all_deps_file = Path.build all_deps_file in
+  Action_builder.memoize
+    (Path.to_string all_deps_file)
+    (Action_builder.map ~f:(parse_module_names ~unit)
+       (Action_builder.lines_of all_deps_file))
 
 let transitive_deps_contents modules =
   List.map modules ~f:(fun m -> Module_name.to_string (Module.name m))
@@ -10,20 +111,19 @@ let ooi_deps cctx ~vlib_obj_map ~(ml_kind : Ml_kind.t) (m : Module.t) =
   let cm_kind =
     match ml_kind with
     | Intf -> Cm_kind.Cmi
-    | Impl ->
-      Compilation_context.vimpl cctx |> Option.value_exn |> Vimpl.impl_cm_kind
+    | Impl -> CC.vimpl cctx |> Option.value_exn |> Vimpl.impl_cm_kind
   in
-  let sctx = Compilation_context.super_context cctx in
-  let dir = Compilation_context.dir cctx in
-  let obj_dir = Compilation_context.obj_dir cctx in
+  let sctx = CC.super_context cctx in
+  let dir = CC.dir cctx in
+  let obj_dir = CC.obj_dir cctx in
   let write, read =
-    let ctx = Super_context.context sctx in
+    let ctx = SC.context sctx in
     let unit =
       Obj_dir.Module.cm_file_exn obj_dir m ~kind:cm_kind |> Path.build
     in
     Ocamlobjinfo.rules ~dir ~ctx ~unit
   in
-  let add_rule = Super_context.add_rule sctx ~dir in
+  let add_rule = SC.add_rule sctx ~dir in
   let read =
     Action_builder.memoize "ocamlobjinfo"
       (let open Action_builder.O in
@@ -47,17 +147,17 @@ let ooi_deps cctx ~vlib_obj_map ~(ml_kind : Ml_kind.t) (m : Module.t) =
 let deps_of_module cctx ~ml_kind m =
   match Module.kind m with
   | Wrapped_compat ->
-    let modules = Compilation_context.modules cctx in
+    let modules = CC.modules cctx in
     let interface_module =
       match Modules.lib_interface modules with
       | Some m -> m
       | None -> Modules.compat_for_exn modules m
     in
     Action_builder.return (List.singleton interface_module) |> Memo.Build.return
-  | _ -> Ocamldep.deps_of ~cctx ~ml_kind m
+  | _ -> deps_of ~cctx ~ml_kind m
 
 let deps_of_vlib_module cctx ~ml_kind m =
-  let vimpl = Option.value_exn (Compilation_context.vimpl cctx) in
+  let vimpl = Option.value_exn (CC.vimpl cctx) in
   let vlib = Vimpl.vlib vimpl in
   match Lib.Local.of_lib vlib with
   | None ->
@@ -67,18 +167,16 @@ let deps_of_vlib_module cctx ~ml_kind m =
     let modules = Vimpl.vlib_modules vimpl in
     let info = Lib.Local.info lib in
     let vlib_obj_dir = Lib_info.obj_dir info in
-    let dir = Compilation_context.dir cctx in
+    let dir = CC.dir cctx in
     let src =
       Obj_dir.Module.dep vlib_obj_dir (Transitive (m, ml_kind)) |> Path.build
     in
     let dst =
-      let obj_dir = Compilation_context.obj_dir cctx in
+      let obj_dir = CC.obj_dir cctx in
       Obj_dir.Module.dep obj_dir (Transitive (m, ml_kind))
     in
-    let sctx = Compilation_context.super_context cctx in
-    let+ () =
-      Super_context.add_rule sctx ~dir (Action_builder.symlink ~src ~dst)
-    in
+    let sctx = CC.super_context cctx in
+    let+ () = SC.add_rule sctx ~dir (Action_builder.symlink ~src ~dst) in
     Ocamldep.read_deps_of ~obj_dir:vlib_obj_dir ~modules ~ml_kind m
 
 let rec deps_of cctx ~ml_kind (m : Modules.Sourced_module.t) =

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -44,6 +44,9 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name ~lib ~code ~requires
         Compilation_context.for_module_generated_at_link_time cctx ~requires
           ~module_
       in
+      (* FIXME: the following call is used just to set up the rule to generate
+         the files containing the dependencies of [module_]. *)
+      let* _ = Dep_rules.for_module cctx module_ in
       let+ () =
         Module_compilation.build_module
           ~dep_graphs:(Dep_graph.Ml_kind.dummy module_)

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -187,7 +187,7 @@ let build_cm cctx ~dep_graphs ~precompiled_cmi ~cm_kind (m : Module.t) ~phase =
           [ Command.Args.dyn flags
           ; cmt_args
           ; Command.Args.S obj_dirs
-          ; Command.Args.as_any (Cm_kind.Dict.get (CC.includes cctx) cm_kind)
+          ; Command.Args.as_any (Cm_kind.Dict.get (CC.includes cctx m) cm_kind)
           ; As extra_args
           ; A "-no-alias-deps"
           ; opaque_arg
@@ -277,7 +277,8 @@ let ocamlc_i ?(flags = []) ~deps cctx (m : Module.t) ~output =
                 [ Command.Args.dyn ocaml_flags
                 ; A "-I"
                 ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-                ; Command.Args.as_any (Cm_kind.Dict.get (CC.includes cctx) Cmo)
+                ; Command.Args.as_any
+                    (Cm_kind.Dict.get (CC.includes cctx m) Cmo)
                 ; opens modules m
                 ; As flags
                 ; A "-short-paths"

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -1,8 +1,6 @@
 open! Dune_engine
 open! Stdune
 open Import
-module CC = Compilation_context
-module SC = Super_context
 
 let parse_module_names ~(unit : Module.t) ~modules words =
   List.filter_map words ~f:(fun m ->
@@ -31,105 +29,6 @@ let parse_deps_exn ~file lines =
       if basename <> Path.basename file then invalid ();
       String.extract_blank_separated_words deps)
 
-let interpret_deps cctx ~unit deps =
-  let dir = CC.dir cctx in
-  let modules = CC.modules cctx in
-  let deps = parse_module_names ~unit ~modules deps in
-  let stdlib = CC.stdlib cctx in
-  if Option.is_none stdlib then
-    Modules.main_module_name modules
-    |> Option.iter ~f:(fun (main_module_name : Module_name.t) ->
-           if
-             Module_name.Infix.(Module.name unit <> main_module_name)
-             && (not (Module.kind unit = Alias))
-             && List.exists deps ~f:(fun x -> Module.name x = main_module_name)
-           then
-             User_error.raise
-               [ Pp.textf "Module %s in directory %s depends on %s."
-                   (Module_name.to_string (Module.name unit))
-                   (Path.to_string_maybe_quoted (Path.build dir))
-                   (Module_name.to_string main_module_name)
-               ; Pp.textf "This doesn't make sense to me."
-               ; Pp.nop
-               ; Pp.textf
-                   "%s is the main module of the library and is the only \
-                    module exposed outside of the library. Consequently, it \
-                    should be the one depending on all the other modules in \
-                    the library."
-                   (Module_name.to_string main_module_name)
-               ]);
-  match Modules.alias_for modules unit with
-  | None -> deps
-  | Some m -> m :: deps
-
-let deps_of ~cctx ~ml_kind unit =
-  let modules = Compilation_context.modules cctx in
-  let sctx = CC.super_context cctx in
-  let source = Option.value_exn (Module.source unit ~ml_kind) in
-  let obj_dir = Compilation_context.obj_dir cctx in
-  let dir = Compilation_context.dir cctx in
-  let dep = Obj_dir.Module.dep obj_dir in
-  let context = SC.context sctx in
-  let parse_module_names = parse_module_names ~modules in
-  let all_deps_file = dep (Transitive (unit, ml_kind)) in
-  let ocamldep_output = dep (Immediate source) in
-  let open Memo.Build.O in
-  let* () =
-    SC.add_rule sctx ~dir
-      (let flags =
-         Option.value (Module.pp_flags unit) ~default:(Action_builder.return [])
-       in
-       Command.run context.ocamldep
-         ~dir:(Path.build context.build_dir)
-         [ A "-modules"
-         ; Command.Args.dyn flags
-         ; Command.Ml_kind.flag ml_kind
-         ; Dep (Module.File.path source)
-         ]
-         ~stdout_to:ocamldep_output)
-  in
-  let build_paths dependencies =
-    let dependency_file_path m =
-      let ml_kind m =
-        if Module.kind m = Alias then
-          None
-        else if Module.has m ~ml_kind:Intf then
-          Some Ml_kind.Intf
-        else
-          Some Impl
-      in
-      ml_kind m
-      |> Option.map ~f:(fun ml_kind ->
-             Path.build (dep (Transitive (m, ml_kind))))
-    in
-    List.filter_map dependencies ~f:dependency_file_path
-  in
-  let action =
-    let open Action_builder.O in
-    let paths =
-      let+ lines = Action_builder.lines_of (Path.build ocamldep_output) in
-      lines
-      |> parse_deps_exn ~file:(Module.File.path source)
-      |> interpret_deps cctx ~unit
-      |> fun modules ->
-      ( build_paths modules
-      , List.map modules ~f:(fun m -> Module_name.to_string (Module.name m)) )
-    in
-    Action_builder.with_targets ~targets:[ all_deps_file ]
-      (let+ sources, extras =
-         Action_builder.dyn_paths
-           (let+ sources, extras = paths in
-            ((sources, extras), sources))
-       in
-       Action.Merge_files_into (sources, extras, all_deps_file))
-  in
-  let+ () = SC.add_rule sctx ~dir action in
-  let all_deps_file = Path.build all_deps_file in
-  Action_builder.memoize
-    (Path.to_string all_deps_file)
-    (Action_builder.map ~f:(parse_module_names ~unit)
-       (Action_builder.lines_of all_deps_file))
-
 let read_deps_of ~obj_dir ~modules ~ml_kind unit =
   let all_deps_file = Obj_dir.Module.dep obj_dir (Transitive (unit, ml_kind)) in
   Action_builder.memoize
@@ -137,3 +36,15 @@ let read_deps_of ~obj_dir ~modules ~ml_kind unit =
     (Action_builder.map
        ~f:(parse_module_names ~unit ~modules)
        (Action_builder.lines_of (Path.build all_deps_file)))
+
+let read_raw_deps_of ~obj_dir ~ml_kind unit =
+  match Module.source unit ~ml_kind with
+  | None -> None
+  | Some source ->
+    let dep = Path.build (Obj_dir.Module.dep obj_dir (Immediate source)) in
+    Some
+      (Action_builder.memoize (Path.to_string dep)
+         (let open Action_builder.O in
+         let+ lines = Action_builder.lines_of dep in
+         List.map ~f:Module_name.of_string
+           (parse_deps_exn ~file:(Module.File.path source) lines)))

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -3,11 +3,10 @@
 open! Dune_engine
 open Import
 
-val deps_of :
-     cctx:Compilation_context.t
-  -> ml_kind:Ml_kind.t
-  -> Module.t
-  -> Module.t list Action_builder.t Memo.Build.t
+val parse_module_names :
+  unit:Module.t -> modules:Modules.t -> string list -> Module.t list
+
+val parse_deps_exn : file:Path.t -> string list -> string list
 
 val read_deps_of :
      obj_dir:Path.Build.t Obj_dir.t
@@ -15,3 +14,9 @@ val read_deps_of :
   -> ml_kind:Ml_kind.t
   -> Module.t
   -> Module.t list Action_builder.t
+
+val read_raw_deps_of :
+     obj_dir:Path.Build.t Obj_dir.t
+  -> ml_kind:Ml_kind.t
+  -> Module.t
+  -> Module_name.t list Action_builder.t option


### PR DESCRIPTION
As discussed in the dev meeting, this PR proposes to refine the dependency analysis across libraries (currently every module of a library is assumed to depend on every other module in any of its library dependencies).

Concretely, we propose the following: given a library `A` that depends on a library `B`, we make it so that a module in `A` depends on all modules of `B` *if* at least one module of `B` is mentioned among the dependencies of that module (as returned by `ocamldep`).

Reasons for this approach: 1) applies to both wrapped and unwrapped libraries, 2) should cause a smaller increase in the size of the dependency DAG than the more refined "per-module" dependency analysis, 3) is simpler to implement.

#### Description of the commits: the first three commits are preliminary, the main commit is the last one.

1. the first commit consists purely in moving code around to make it possible to use `Ocamldep` from inside `Compilation_context`.
2. Revert an optimization #3847 that avoided computing dependencies for single-module buildables, since this per-module dependency information is now needed even in this case
3. Add a rule to compute dependencies for link-time generated modules (this is hacky, and should be done in a cleaner way)

#### Description of main commit (number 4).

First, let's recall how things work "before" this PR. All modules which are part of the same compilation context (typically a library or executable) are compiled with the same flags:

https://github.com/ocaml/dune/blob/42ece423c63ae81ef003472af8987b7de2111191/src/dune_rules/module_compilation.ml#L190

The function `Compilation_context.includes` returns a list of `-I` flags and a list of "hidden dependencies" for each module of the compilation context (the same for every module). The hidden dependencies are the `.cmi` (and `.cmx` in native-code) of every module of every library dependency of the compilation context.

After this PR, the function `Compilation_context.includes` becomes a function with argument `Module.t`. The idea is that the returned list of hidden dependencies will depend on the module being compiled and no longer be the same for every module (the list of include flags remains the same for every module at the moment).

In order to compute the list of hidden dependencies, we proceed as follows: we look at every library dependency, and make a map `Module_name.t -> Lib.Set.t` which maps every "entry" module name in each one of the libraries to the set of libraries to which such a name belongs (the same name can appear in more than one library). The set of libraries corresponding to each module name is a subset of the set of library dependencies of the compilation context.

Then, when computing the hidden dependencies for a given module, we read the `ocamldep`-returned dependencies of the module, and take the set of libraries that may contain any of them (from the map built previously). The hidden dependencies of the module are then `.cmi` (and `.cmx` in native-code) of the modules belonging to *this* set of libraries.

#### Request for comments

In order to keep the first version as simple as possible, I did not try to memoize or otherwise optimize in any way the new code (in fact the new code throws away some existing memoization). And so the current code degrades performance:
```
             Current branch Main branch
             ============== ===========
           | real 1.376s    real 1.298s
Full build | user 1.216s    user 1.088s
           | sys  0.159s    sys  0.209s

           | real 1.142s    real 0.912s
Zero build | user 1.071s    user 0.837s
           | sys  0.070s    sys  0.074s
```
I expect that improvement should be possible by memoizing appropriately, but I thought it would be better to get some feedback/hints from the Memo experts before trying to do that.

All comments warmly welcome (especially on the general approach and any suggestions for improving performance of the new code). Cheers!

cc @jeremiedimino @aalekseyev