### PR TITLE
Insert yield points in memo

### DIFF
--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -100,6 +100,8 @@ val with_job_slot : (Config.t -> 'a Fiber.t) -> 'a Fiber.t
 (** Wait for the following process to terminate *)
 val wait_for_process : Pid.t -> Proc.Process_info.t Fiber.t
 
+val yield_if_there_are_pending_events : unit -> unit Fiber.t
+
 (** Make the scheduler ignore next change to a certain file in watch mode.
 
     This is used with promoted files that are copied back to the source tree

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -467,3 +467,5 @@ module For_tests : sig
       build run. *)
   val clear_memoization_caches : unit -> unit
 end
+
+val yield_if_there_are_pending_events : (unit -> unit Fiber.t) ref


### PR DESCRIPTION
To get better latency for RPC requests, file changes, signals, etc...

It works as follow:

- whenever we submit an event from a thread, we set the flag `got_event` to `true`
- in a strategic place in `memo.ml`, we call `Scheduler.yield_if_there_are_pending_events`, which checks if this flag is set and yield if yes, causing the execution to go through the scheduler
- we reset this flag just before the blocking `Condition.wait` in `Event.Queue.next`

I refactored a bit the code in `Event.Queue.next` to simplify the invariant around `available`. Now we only call `Condition.wait` after we have checked the various fields of the event queue and found no event to report.

I removed the deadlock check as it was now failing as soon as dune would yield and as discussed in the past, it is not really useful when the RPC is on.
