### PR TITLE
[RPC] improve connection handling

### DIFF
--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -71,8 +71,7 @@ module Init = struct
             (module Monoid.Unit)
             ~on_error:(fun exn ->
               let+ () = Lazy.force close in
-              Dune_util.Report_error.report exn;
-              raise Dune_util.Report_error.Already_reported)
+              Dune_util.Report_error.report exn)
             (fun () ->
               Fiber.fork_and_join_unit forward_to_stdout forward_from_stdin)
         in

--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -22,7 +22,7 @@ module Init = struct
   let connect_persistent _common =
     let open Fiber.O in
     let* stdio = Csexp_rpc.Session.create stdin stdout in
-    let* sessions, client = Dune_rpc_impl.Run.Connect.connect_persistent () in
+    let sessions = Dune_rpc_impl.Run.Connect.connect_persistent () in
     Fiber.Stream.In.sequential_iter sessions ~f:(fun session ->
         let connect =
           Dune_rpc.Conv.to_sexp Dune_rpc.Persistent.In.sexp New_connection
@@ -85,14 +85,13 @@ module Init = struct
             | Error _ -> ())
           ~finally:(fun () ->
             let+ () = Lazy.force close in
-            Option.iter client ~f:Csexp_rpc.Client.stop;
             ()))
 
   let connect common =
     let where = wait_for_server common in
     let open Fiber.O in
     let* c = Dune_rpc_impl.Run.Connect.csexp_client where in
-    let* session = Csexp_rpc.Client.connect c in
+    let* session = Csexp_rpc.Client.connect_exn c in
     let* stdio = Csexp_rpc.Session.create stdin stdout in
     let forward f t =
       Fiber.repeat_while ~init:() ~f:(fun () ->

--- a/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
+++ b/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
@@ -6,14 +6,9 @@ open Lwt.Syntax
 open Dune_rpc.V1
 open Dune_rpc_lwt.V1
 
-let connect ~root_dir ~persistent =
+let connect ~root_dir =
   let args = [| "dune"; "rpc"; "init"; "--root"; root_dir |] in
-  let args =
-    if persistent then
-      Array.append args [| "--persistent" |]
-    else
-      args
-  in
+  let args = args in
   Lwt_process.open_process ("dune", args)
 
 let build_watch ~root_dir ~suppress_stderr =
@@ -57,7 +52,7 @@ let%expect_test "run and connect" =
      let build = build_watch ~root_dir ~suppress_stderr:false in
      let rpc =
        let+ () = Lwt_unix.sleep 0.5 in
-       connect ~root_dir ~persistent:false
+       connect ~root_dir
      in
      let run_client =
        let* rpc = rpc in
@@ -116,117 +111,3 @@ module Logger = struct
   let print { messages; name } =
     List.rev messages |> List.iter ~f:(fun msg -> printfn "%s: %s" name msg)
 end
-
-let%expect_test "run and connect persistent" =
-  let test =
-    let* root_dir = Lwt_io.create_temp_dir () in
-    let log_build1 = Logger.create ~name:"build1" in
-    let log_build2 = Logger.create ~name:"build2" in
-    let log_client = Logger.create ~name:"client" in
-    let build () =
-      (* Dune prints "Success, waiting for filesystem changes" to stderr, which
-         is not deterministic because we race to shut down dune before it
-         finishes a build. *)
-      build_watch ~root_dir ~suppress_stderr:true
-    in
-    let build1 =
-      Logger.log log_build1 "connecting";
-      build ()
-    in
-    let build2 =
-      let+ _ = build1#status in
-      Logger.log log_build2 "connecting";
-      build ()
-    in
-    let rpc =
-      let+ () = Lwt_unix.sleep 0.5 in
-      connect ~root_dir ~persistent:true
-    in
-    let run_rpc =
-      let* rpc = rpc in
-      let+ res = rpc#status in
-      match res with
-      | WEXITED i -> Logger.log log_client "rpc init finished with %i" i
-      | _ -> assert false
-    in
-    let run_client =
-      let* rpc = rpc in
-      let chan = (rpc#stdout, rpc#stdin) in
-      let count = ref 0 in
-      let on_connect () =
-        incr count;
-        Logger.log log_client "incoming connection %d" !count;
-        let initialize = Initialize.create ~id:(Id.make (Csexp.Atom "test")) in
-        Lwt.return ((), initialize, None)
-      in
-      let on_connected () t =
-        Logger.log log_client "on_connected: %d" !count;
-        let* res = Client.request t Request.ping () in
-        let* () =
-          match res with
-          | Error _ -> failwith "unexpected"
-          | Ok () ->
-            Logger.log log_client "received ping. shutting down server";
-            Client.notification t Notification.shutdown ()
-        in
-        if !count = 3 then (
-          Logger.log log_client "received second session. shutting down";
-          let* () = Lwt_io.close rpc#stdout in
-          Lwt_io.close rpc#stdin
-        ) else
-          Lwt.return ()
-      in
-      let on_disconnect () =
-        Logger.log log_client "on_disconnect: %d" !count;
-        Lwt.return ()
-      in
-      Client.connect_persistent chan ~on_connected ~on_connect ~on_disconnect
-    in
-    let run_build1 =
-      let* _ = rpc in
-      let+ res = build1#status in
-      match res with
-      | WEXITED i -> Logger.log log_build1 "dune build finished with %i" i
-      | _ -> assert false
-    in
-    let run_build2 =
-      let* build2 = build2 in
-      let* _ = run_build1 in
-      let* _ = rpc in
-      let* res = build2#status in
-      match res with
-      | WEXITED i ->
-        Logger.log log_build2 "dune build finished with %i" i;
-        let+ rpc = rpc in
-        rpc#terminate
-      | _ -> assert false
-    in
-    Lwt.finalize
-      (fun () ->
-        run_with_timeout (fun () ->
-            Lwt.all [ run_client; run_rpc; run_build1; run_build2 ]))
-      (fun () ->
-        let* rpc = rpc in
-        rpc#terminate;
-        build1#terminate;
-        let+ build2 = build2 in
-        build2#terminate;
-        Logger.print log_build1;
-        Logger.print log_build2;
-        Logger.print log_client)
-  in
-  Lwt_main.run test;
-  [%expect
-    {|
-    build1: connecting
-    build1: dune build finished with 0
-    build2: connecting
-    build2: dune build finished with 0
-    client: incoming connection 1
-    client: on_connected: 1
-    client: received ping. shutting down server
-    client: on_disconnect: 1
-    client: incoming connection 2
-    client: on_connected: 2
-    client: received ping. shutting down server
-    client: on_disconnect: 2 |}]

--- a/src/csexp_rpc/csexp_rpc.mli
+++ b/src/csexp_rpc/csexp_rpc.mli
@@ -39,7 +39,9 @@ module Client : sig
 
   val stop : t -> unit
 
-  val connect : t -> Session.t Fiber.t
+  val connect_exn : t -> Session.t Fiber.t
+
+  val connect : t -> (Session.t, Exn_with_backtrace.t) result Fiber.t
 end
 
 module Server : sig

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -763,6 +763,14 @@ module Worker = struct
       match res with
       | Error exn -> Error (`Exn exn)
       | Ok e -> Ok e)
+
+  let task_exn t ~f =
+    let+ res = task t ~f in
+    match res with
+    | Ok a -> a
+    | Error `Stopped ->
+      Code_error.raise "Scheduler.Worker.task_exn: worker stopped" []
+    | Error (`Exn e) -> Exn_with_backtrace.reraise e
 end
 
 module Run = struct

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -89,6 +89,10 @@ module Worker : sig
     -> f:(unit -> 'a)
     -> ('a, [ `Exn of Exn_with_backtrace.t | `Stopped ]) result Fiber.t
 
+  (** Should be used for tasks never raise and always complete before stop is
+      called *)
+  val task_exn : t -> f:(unit -> 'a) -> 'a Fiber.t
+
   val stop : t -> unit
 end
 

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -145,7 +145,8 @@ let run config stats =
             Fiber.fork_and_join_unit
               (fun () ->
                 let* sessions = Csexp_rpc.Server.serve t.server in
-                Server.serve sessions t.stats t.handler)
+                let* () = Server.serve sessions t.stats t.handler in
+                Fiber.Pool.stop t.pool)
               (fun () -> Fiber.Pool.run t.pool))
           ~finally:(fun () ->
             Option.iter t.symlink_socket ~f:Symlink_socket.cleanup;

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -98,17 +98,7 @@ end = struct
       let waiter = Scheduler.Worker.create () in
       fun () ->
         let* waiter = waiter in
-        let+ res =
-          Scheduler.Worker.task waiter ~f:(fun () -> Unix.sleepf 0.2)
-        in
-        match res with
-        | Ok () -> ()
-        | Error `Stopped ->
-          (* we never call Worker.stop *)
-          assert false
-        | Error (`Exn _) ->
-          (* sleep cannot fail *)
-          assert false
+        Scheduler.Worker.task_exn waiter ~f:(fun () -> Unix.sleepf 0.2)
     in
     Fiber.Stream.In.create
       (let rec loop () =

--- a/src/dune_rpc_impl/run.mli
+++ b/src/dune_rpc_impl/run.mli
@@ -35,6 +35,4 @@ module Connect : sig
       This is needed for implementing low level functions such as
       [$ dune rpc init] *)
   val csexp_client : Dune_rpc.Where.t -> Csexp_rpc.Client.t Fiber.t
-
-  val connect_persistent : unit -> Csexp_rpc.Session.t Fiber.Stream.In.t
 end

--- a/src/dune_rpc_impl/run.mli
+++ b/src/dune_rpc_impl/run.mli
@@ -36,8 +36,5 @@ module Connect : sig
       [$ dune rpc init] *)
   val csexp_client : Dune_rpc.Where.t -> Csexp_rpc.Client.t Fiber.t
 
-  val connect_persistent :
-       unit
-    -> (Csexp_rpc.Session.t Fiber.Stream.In.t * Csexp_rpc.Client.t option)
-       Fiber.t
+  val connect_persistent : unit -> Csexp_rpc.Session.t Fiber.Stream.In.t
 end

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -46,7 +46,7 @@ let%expect_test "csexp server life cycle" =
     Fiber.fork_and_join_unit
       (fun () ->
         let log fmt = Logger.log client_log fmt in
-        let* client = Client.connect client in
+        let* client = Client.connect_exn client in
         let* () = Session.write client (Some [ List [ Atom "from client" ] ]) in
         log "written";
         let* response = Session.read client in


### PR DESCRIPTION
The previous code would wait for all waiting to initialize before
serving a single session. This would cause unnecessary delays if clients
would stall.

@cwong-ocaml I think this should fix the "delays" you've been
encountering

@jeremiedimino some advice on how to write this code cleanly would be
appreciated.