### PR TITLE
Reference Merlin naming convention in copy rule documentation

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -700,7 +700,10 @@ The following constructions are available:
 - ``(echo <string>)`` to output a string on stdout
 - ``(write-file <file> <string>)`` writes ``<string>`` to ``<file>``
 - ``(cat <file>)`` to print the contents of a file to stdout
-- ``(copy <src> <dst>)`` to copy a file
+- ``(copy <src> <dst>)`` to copy a file. If these files are OCaml sources you
+  should follow the ``module_name.xxx.ml``
+  :ref:`naming convention <merlin-filenames>` to preserve Merlin's
+  functionality.
 - ``(copy# <src> <dst>)`` to copy a file and add a line directive at
   the beginning
 - ``(system <cmd>)`` to execute a command using the system shell: ``sh`` on Unix

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -594,6 +594,8 @@ be un-commented afterward. This feature does not aim at writing exact or correct
 ``.merlin`` files, its sole purpose is to lessen the burden of writing the
 configuration from scratch.
 
+.. _merlin-filenames:
+
 Non-standard filenames
 ----------------------
 


### PR DESCRIPTION
Fixes #4642