### PR TITLE
Suppress build system early error reporting if we're shutting down

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -99,8 +99,9 @@ module Scheduler = struct
     let file_watcher = Common.file_watcher common in
     let run =
       let run () =
-        Scheduler.Run.poll (fun () ->
-            Fiber.finalize every ~finally:(fun () -> Fiber.return (finally ())))
+        Scheduler.Run.poll (fun ~report_error () ->
+            Fiber.finalize (every ~report_error) ~finally:(fun () ->
+                Fiber.return (finally ())))
       in
       match Common.rpc common with
       | None -> run

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2340,14 +2340,14 @@ let prefix_rules (prefix : unit Action_builder.t) ~f =
 
 module Alias = Alias0
 
-let report_early_exn exn =
+let report_early_exn ~report_error exn =
   let t = t () in
   let error = { Error.exn; id = Error.Id.gen () } in
   t.errors <- error :: t.errors;
   (match !Clflags.report_errors_config with
   | Early
   | Twice ->
-    Dune_util.Report_error.report exn
+    report_error exn
   | Deterministic -> ());
   t.handler.error [ Add error ]
 
@@ -2358,7 +2358,7 @@ let reraise_exn exn =
   | Deterministic ->
     Exn_with_backtrace.reraise exn
 
-let run f =
+let run ?(report_error = Dune_util.Report_error.report) f =
   let open Fiber.O in
   Hooks.End_of_build.once Promotion.finalize;
   let t = t () in
@@ -2374,7 +2374,7 @@ let run f =
     let* res =
       Fiber.with_error_handler ~on_error:reraise_exn (fun () ->
           Memo.Build.run_with_error_handler (f ())
-            ~handle_error_no_raise:report_early_exn)
+            ~handle_error_no_raise:(report_early_exn ~report_error))
     in
     let+ () = t.handler.build_event Finish in
     res

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -208,7 +208,10 @@ end
 
 (** {2 Running a build} *)
 
-val run : (unit -> 'a Memo.Build.t) -> 'a Fiber.t
+val run :
+     ?report_error:(Exn_with_backtrace.t -> unit)
+  -> (unit -> 'a Memo.Build.t)
+  -> 'a Fiber.t
 
 (** {2 Misc} *)
 

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -64,7 +64,11 @@ module Run : sig
 
       If [shutdown] is called, the current build will be canceled and new builds
       will not start. *)
-  val poll : (unit -> [ `Continue | `Stop ] Fiber.t) -> unit Fiber.t
+  val poll :
+       (   report_error:(Exn_with_backtrace.t -> unit)
+        -> unit
+        -> [ `Continue | `Stop ] Fiber.t)
+    -> unit Fiber.t
 
   val go :
        Config.t


### PR DESCRIPTION
This should fix some of the noise at shutdown that we've been seeing.
I tested this manually by calling [dune shutdown] while watching dune was building and not seeing any error.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>