### PR TITLE
added dune-watch.el to install targets

### DIFF
--- a/editor-integration/emacs/dune
+++ b/editor-integration/emacs/dune
@@ -3,4 +3,5 @@
  (section share_root)
  (files
   (dune.el as emacs/site-lisp/dune.el)
-  (dune-flymake.el as emacs/site-lisp/dune-flymake.el)))
+  (dune-flymake.el as emacs/site-lisp/dune-flymake.el)
+  (dune-watch.el as emacs/site-lisp/dune-watch.el)))


### PR DESCRIPTION
dune-watch is in the tree, but not made installed by opam. This is intended to fix that.