### PR TITLE
Introduce library to parse ocamlc errors

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -32,6 +32,7 @@ let local_libraries =
   ; ("otherlibs/dune-rpc/private", Some "Dune_rpc_private", false, None)
   ; ("src/dune_rpc_server", Some "Dune_rpc_server", false, None)
   ; ("src/thread_worker", Some "Thread_worker", false, None)
+  ; ("src/ocamlc_loc", Some "Ocamlc_loc", false, None)
   ; ("vendor/ocaml-inotify/src", Some "Ocaml_inotify", false, None)
   ; ("src/async_inotify_for_dune", Some "Async_inotify_for_dune", false,
     None)

--- a/src/dune_engine/compound_user_error.ml
+++ b/src/dune_engine/compound_user_error.ml
@@ -42,3 +42,45 @@ include Annot
 include User_error.Annot.Make (Annot)
 
 let make ~main ~related = make (create ~main ~related)
+
+let make_loc ~dir { Ocamlc_loc.path; chars; line } : Loc.t =
+  let pos_fname =
+    let dir = Path.drop_optional_build_context_maybe_sandboxed dir in
+    Path.to_absolute_filename (Path.relative dir path)
+  in
+  let pos_lnum_start, pos_lnum_stop =
+    match line with
+    | `Single i -> (i, i)
+    | `Range (i, j) -> (i, j)
+  in
+  let pos_cnum_start, pos_cnum_stop =
+    match chars with
+    | None -> (0, 0)
+    | Some (x, y) -> (x, y)
+  in
+  let pos = { Lexing.pos_fname; pos_lnum = 0; pos_bol = 0; pos_cnum = 0 } in
+  { Loc.start =
+      { pos with pos_lnum = pos_lnum_start; pos_cnum = pos_cnum_start }
+  ; Loc.stop = { pos with pos_lnum = pos_lnum_stop; pos_cnum = pos_cnum_stop }
+  }
+
+let make_message (msg : Ocamlc_loc.message) =
+  match msg with
+  | Raw s -> Pp.verbatim s
+  | Structured { file_excerpt = _; message; severity = _ } ->
+    Pp.verbatim message
+
+let parse_output ~dir s =
+  let reports = Ocamlc_loc.parse s in
+  match reports with
+  | [] -> None
+  | report :: _ ->
+    (* We assume that there's at most one error coming from a command for now.*)
+    let make_message (loc, message) =
+      let loc = make_loc ~dir loc in
+      let message = make_message message in
+      User_message.make ~loc [ message ]
+    in
+    let main = make_message (report.loc, report.message) in
+    let related = List.map report.related ~f:make_message in
+    Some (make ~main ~related)

--- a/src/dune_engine/compound_user_error.mli
+++ b/src/dune_engine/compound_user_error.mli
@@ -13,3 +13,5 @@ include User_error.Annot.S with type payload := t
 
 val make :
   main:User_message.t -> related:User_message.t list -> User_error.Annot.t
+
+val parse_output : dir:Path.t -> string -> User_error.Annot.t option

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -28,6 +28,7 @@
   dune_rpc_server
   thread_worker
   spawn
+  ocamlc_loc
   dune_file_watcher
   ocaml_inotify
   async_inotify_for_dune)

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -436,7 +436,15 @@ end = struct
     let annots = With_directory_annot.make dir :: annots in
     let annots =
       if has_embedded_location output then
-        User_error.Annot.Has_embedded_location.make () :: annots
+        let annots = User_error.Annot.Has_embedded_location.make () :: annots in
+        match
+          match output with
+          | No_output -> None
+          | Has_output output ->
+            Compound_user_error.parse_output ~dir output.without_color
+        with
+        | None -> annots
+        | Some annot -> annot :: annots
       else
         annots
     in

--- a/src/ocamlc_loc/dune
+++ b/src/ocamlc_loc/dune
@@ -1,3 +1,3 @@
 (library
  (name ocamlc_loc)
- (libraries dune_re))
+ (libraries dune_re stdune))

--- a/src/ocamlc_loc/dune
+++ b/src/ocamlc_loc/dune
@@ -1,0 +1,3 @@
+(library
+ (name ocamlc_loc)
+ (libraries dune_re))

--- a/src/ocamlc_loc/ocamlc_loc.ml
+++ b/src/ocamlc_loc/ocamlc_loc.ml
@@ -1,0 +1,135 @@
+module Re = Dune_re
+
+type severity =
+  | Error
+  | Warning of
+      { code : int
+      ; name : string
+      }
+
+type message =
+  | Raw of string
+  | Structured of
+      { preview : string option
+      ; message : string
+      ; severity : severity
+      }
+
+type loc =
+  { path : string
+  ; line : [ `Single of int | `Range of int * int ]
+  ; chars : (int * int) option
+  }
+
+type report =
+  { loc : loc
+  ; message : message
+  ; related : (loc * message) list
+  }
+
+let re =
+  lazy
+    (let open Re in
+    let path = rep (compl [ char '"' ]) in
+    let number = group (rep1 digit) in
+    let range = seq [ number; char '-'; number ] in
+    let chars = seq [ str "characters"; rep1 space; range ] in
+    let file = seq [ str "File "; char '"'; group path; char '"'; char ',' ] in
+    let single_marker, line = mark (seq [ str "line"; rep1 space; number ]) in
+    let range_marker, lines = mark (seq [ str "lines"; rep1 space; range ]) in
+    let re =
+      seq
+        [ file
+        ; rep1 space
+        ; alt [ line; lines ]
+        ; opt (seq [ char ','; rep1 space; chars ])
+        ; char ':'
+        ; rep space
+        ]
+    in
+    (Re.compile re, single_marker, range_marker))
+
+let message_re =
+  lazy
+    (let open Re in
+    let error_marker, error = mark (str "Error") in
+    let warning =
+      seq
+        [ str "Warning "
+        ; group (rep1 digit)
+        ; rep1 space
+        ; char '['
+        ; group (rep1 (compl [ char ']' ]))
+        ; char ']'
+        ]
+    in
+    let severity = seq [ alt [ bol; bos ]; alt [ error; warning ]; char ':' ] in
+    let re =
+      seq
+        [ opt (group (rep1 any))
+        ; severity
+        ; rep space
+        ; group (rep any)
+        ; rep space
+        ]
+    in
+    (compile re, error_marker))
+
+let parse_message msg =
+  let re, error_marker = Lazy.force message_re in
+  match Re.exec re msg with
+  | exception Not_found -> Raw msg
+  | group ->
+    let preview =
+      if Re.Group.test group 1 then
+        Some (Re.Group.get group 1)
+      else
+        None
+    in
+    let severity =
+      if Re.Mark.test group error_marker then
+        Error
+      else
+        let code = int_of_string (Re.Group.get group 2) in
+        let name = Re.Group.get group 3 in
+        Warning { code; name }
+    in
+    Structured { preview; severity; message = Re.Group.get group 4 }
+
+let parse s : report list =
+  let re, single_marker, _ = Lazy.force re in
+  match Re.split_full re s with
+  | [] -> []
+  | [ `Text _ ] -> []
+  | (`Delim _ :: _ as rest)
+  | `Text _ :: rest ->
+    let loc_of_group group message =
+      let str_group = Re.Group.get group in
+      let int_group i = int_of_string (str_group i) in
+      let line =
+        if Re.Mark.test group single_marker then
+          `Single (int_group 2)
+        else
+          `Range (int_group 3, int_group 4)
+      in
+      let chars =
+        if Re.Group.test group 5 then
+          Some (int_group 5, int_group 6)
+        else
+          None
+      in
+      let message = parse_message message in
+      { loc = { path = str_group 1; line; chars }; message; related = [] }
+    in
+    let rec loop acc = function
+      | `Text _ :: _ -> assert false
+      | `Delim _ :: `Delim _ :: _ -> assert false
+      | `Delim g :: `Text m :: rest ->
+        let loc = loc_of_group g m in
+        loop (loc :: acc) rest
+      | [ `Delim g ] ->
+        let loc = loc_of_group g "" in
+        loc :: acc
+      | [] -> acc
+    in
+    List.rev (loop [] rest)

--- a/src/ocamlc_loc/ocamlc_loc.mli
+++ b/src/ocamlc_loc/ocamlc_loc.mli
@@ -14,7 +14,7 @@ type severity =
 type message =
   | Raw of string
   | Structured of
-      { preview : string option
+      { file_excerpt : string option
       ; message : string
       ; severity : severity
       }
@@ -24,5 +24,7 @@ type report =
   ; message : message
   ; related : (loc * message) list
   }
+
+val dyn_of_report : report -> Stdune.Dyn.t
 
 val parse : string -> report list

--- a/src/ocamlc_loc/ocamlc_loc.mli
+++ b/src/ocamlc_loc/ocamlc_loc.mli
@@ -1,0 +1,28 @@
+type loc =
+  { path : string
+  ; line : [ `Single of int | `Range of int * int ]
+  ; chars : (int * int) option
+  }
+
+type severity =
+  | Error
+  | Warning of
+      { code : int
+      ; name : string
+      }
+
+type message =
+  | Raw of string
+  | Structured of
+      { preview : string option
+      ; message : string
+      ; severity : severity
+      }
+
+type report =
+  { loc : loc
+  ; message : message
+  ; related : (loc * message) list
+  }
+
+val parse : string -> report list

--- a/src/ocamlc_loc/ocamlc_loc.mli
+++ b/src/ocamlc_loc/ocamlc_loc.mli
@@ -7,7 +7,7 @@ type loc =
 type severity =
   | Error
   | Warning of
-      { code : int
+      { code : int option
       ; name : string
       }
 

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -194,6 +194,16 @@ let setup_diagnostics f =
         | None -> path
         | Some s -> "$CWD" ^ s
       in
+      let sanitize_pp pp = Pp.verbatim (Format.asprintf "%a@." Pp.to_fmt pp) in
+      let sanitize_loc =
+        let sanitize_position (p : Lexing.position) =
+          { p with pos_fname = sanitize_path p.pos_fname }
+        in
+        fun (loc : Loc.t) ->
+          { Loc.start = sanitize_position loc.start
+          ; stop = sanitize_position loc.stop
+          }
+      in
       (* function to remove remove pp tags and hide junk from paths *)
       let sanitize (d : Dune_rpc.Diagnostic.t) =
         let directory = Option.map d.directory ~f:sanitize_path in
@@ -203,10 +213,19 @@ let setup_diagnostics f =
               let in_source = sanitize_path p.in_source in
               { Dune_rpc.Diagnostic.Promotion.in_build; in_source })
         in
+        let related =
+          List.map d.related
+            ~f:(fun (related : Dune_rpc.Diagnostic.Related.t) ->
+              let loc = sanitize_loc related.loc in
+              let message = sanitize_pp related.message in
+              { Dune_rpc.Diagnostic.Related.message; loc })
+        in
         { d with
-          message = Pp.verbatim (Format.asprintf "%a@." Pp.to_fmt d.message)
+          message = sanitize_pp d.message
+        ; loc = Option.map d.loc ~f:sanitize_loc
         ; directory
         ; promotion
+        ; related
         }
       in
       let on_diagnostic_event (e : Dune_rpc.Diagnostic.Event.t) =
@@ -275,19 +294,76 @@ let%expect_test "related error" =
     [ "Add"
     ; [ [ "directory"; "$CWD" ]
       ; [ "id"; "0" ]
+      ; [ "loc"
+        ; [ [ "start"
+            ; [ [ "pos_bol"; "0" ]
+              ; [ "pos_cnum"; "0" ]
+              ; [ "pos_fname"; "$CWD/foo.ml" ]
+              ; [ "pos_lnum"; "1" ]
+              ]
+            ]
+          ; [ "stop"
+            ; [ [ "pos_bol"; "0" ]
+              ; [ "pos_cnum"; "0" ]
+              ; [ "pos_fname"; "$CWD/foo.ml" ]
+              ; [ "pos_lnum"; "1" ]
+              ]
+            ]
+          ]
+        ]
       ; [ "message"
         ; [ "Verbatim"
-          ; "File \"foo.ml\", line 1:\n\
-             Error: The implementation foo.ml\n\
+          ; "The implementation foo.ml\n\
             \       does not match the interface .foo.objs/byte/foo.cmi:\n\
             \       Values do not match: val x : bool is not included in val x : int\n\
-            \       File \"foo.mli\", line 1, characters 0-11: Expected declaration\n\
-            \       File \"foo.ml\", line 1, characters 4-5: Actual declaration\n\
              "
           ]
         ]
       ; [ "promotion"; [] ]
-      ; [ "related"; [] ]
+      ; [ "related"
+        ; [ [ [ "loc"
+              ; [ [ "start"
+                  ; [ [ "pos_bol"; "0" ]
+                    ; [ "pos_cnum"; "0" ]
+                    ; [ "pos_fname"; "$CWD/foo.mli" ]
+                    ; [ "pos_lnum"; "1" ]
+                    ]
+                  ]
+                ; [ "stop"
+                  ; [ [ "pos_bol"; "0" ]
+                    ; [ "pos_cnum"; "11" ]
+                    ; [ "pos_fname"; "$CWD/foo.mli" ]
+                    ; [ "pos_lnum"; "1" ]
+                    ]
+                  ]
+                ]
+              ]
+            ; [ "message"; [ "Verbatim"; "Expected declaration\n\
+                                          " ] ]
+            ]
+          ; [ [ "loc"
+              ; [ [ "start"
+                  ; [ [ "pos_bol"; "0" ]
+                    ; [ "pos_cnum"; "4" ]
+                    ; [ "pos_fname"; "$CWD/foo.ml" ]
+                    ; [ "pos_lnum"; "1" ]
+                    ]
+                  ]
+                ; [ "stop"
+                  ; [ [ "pos_bol"; "0" ]
+                    ; [ "pos_cnum"; "5" ]
+                    ; [ "pos_fname"; "$CWD/foo.ml" ]
+                    ; [ "pos_lnum"; "1" ]
+                    ]
+                  ]
+                ]
+              ]
+            ; [ "message"; [ "Verbatim"; "Actual declaration\n\
+                                          \n\
+                                          " ] ]
+            ]
+          ]
+        ]
       ; [ "targets"; [] ]
       ]
     ]
@@ -513,13 +589,28 @@ let%expect_test "create and fix error" =
         [ "Add"
         ; [ [ "directory"; "$CWD" ]
           ; [ "id"; "0" ]
+          ; [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "23" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "26" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ]
+            ]
           ; [ "message"
             ; [ "Verbatim"
-              ; "File \"foo.ml\", line 1, characters 23-26:\n\
-                 1 | let () = print_endline 123\n\
-                \                           ^^^\n\
-                 Error: This expression has type int but an expression was expected of type\n\
+              ; "This expression has type int but an expression was expected of type\n\
                 \         string\n\
+                 \n\
                  "
               ]
             ]
@@ -538,13 +629,28 @@ let%expect_test "create and fix error" =
         [ "Remove"
         ; [ [ "directory"; "$CWD" ]
           ; [ "id"; "0" ]
+          ; [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "23" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "26" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ]
+            ]
           ; [ "message"
             ; [ "Verbatim"
-              ; "File \"foo.ml\", line 1, characters 23-26:\n\
-                 1 | let () = print_endline 123\n\
-                \                           ^^^\n\
-                 Error: This expression has type int but an expression was expected of type\n\
+              ; "This expression has type int but an expression was expected of type\n\
                 \         string\n\
+                 \n\
                  "
               ]
             ]

--- a/test/expect-tests/ocamlc_loc/dune
+++ b/test/expect-tests/ocamlc_loc/dune
@@ -1,0 +1,14 @@
+(library
+ (name ocamlc_loc_tests)
+ (libraries
+  ocamlc_loc
+  stdune
+  ;; deps below required because (implicit_transitive_deps false)
+  ppx_expect.config
+  ppx_expect.config_types
+  ppx_expect.common
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect))
+ (inline_tests))

--- a/test/expect-tests/ocamlc_loc/ocamlc_loc_tests.ml
+++ b/test/expect-tests/ocamlc_loc/ocamlc_loc_tests.ml
@@ -1,0 +1,169 @@
+open Stdune
+
+let cmd fmt =
+  Printf.ksprintf
+    (fun s ->
+      let (_ : int) = Sys.command s in
+      ())
+    fmt
+
+module Test = struct
+  type t = { dir : Path.t }
+
+  let restore_cwd =
+    let cwd = Sys.getcwd () in
+    fun () -> Sys.chdir cwd
+
+  let file t ~fname ~contents =
+    let path = Path.relative t.dir fname in
+    Io.write_file path contents;
+    path
+
+  let string_of_loc { Ocamlc_loc.path; line; chars } =
+    sprintf "file %s, line %s%s" path
+      (match line with
+      | `Single i -> string_of_int i
+      | `Range (x, y) -> sprintf "%d-%d" x y)
+      (match chars with
+      | None -> ""
+      | Some (x, y) -> sprintf ", chars %d-%d" x y)
+
+  let print_message message =
+    match (message : Ocamlc_loc.message) with
+    | Raw s -> printfn "raw message =\n%s" s
+    | Structured { preview; message; severity } ->
+      printfn "severity = %s"
+        (match severity with
+        | Error -> "error"
+        | Warning { code; name } -> sprintf "warning %d [%s]" code name);
+      Option.iter preview ~f:(printfn "preview =\n%s");
+      printfn "message = %s" message
+
+  let create f =
+    let dir = Temp.create Dir ~prefix:"dune." ~suffix:".test" in
+    let t = { dir } in
+    Sys.chdir (Path.to_string dir);
+    let out_file = Exn.protect ~f:(fun () -> f t) ~finally:restore_cwd in
+    let output = Io.read_file out_file in
+    (* Format.eprintf "print raw output:@.%s@.%!" output; *)
+    let locs = Ocamlc_loc.parse output in
+    List.iteri locs ~f:(fun i { Ocamlc_loc.loc; message; related } ->
+        printfn ">> error %d" i;
+        printfn "loc = %s" (string_of_loc loc);
+        print_message message;
+        if related <> [] then (
+          printfn "related errors:";
+          List.iter related ~f:(fun (loc, message) ->
+              print_message message;
+              printfn "loc = %s" (string_of_loc loc))
+        ))
+end
+
+let%expect_test "" =
+  Test.create (fun t ->
+      let open Test in
+      let (_ : Path.t) = file t ~fname:"test.ml" ~contents:"let () = 123" in
+      cmd "ocamlc -c test.ml 2> out";
+      Path.relative t.dir "out");
+  [%expect
+    {|
+    >> error 0
+    loc = file test.ml, line 1, chars 9-12
+    severity = error
+    preview =
+    1 | let () = 123
+                 ^^^
+
+    message = This expression has type int but an expression was expected of type
+             unit |}]
+
+let%expect_test "" =
+  Test.create (fun t ->
+      let open Test in
+      let (_ : Path.t) =
+        file t ~fname:"test.ml"
+          ~contents:
+            {ocaml|
+module X : sig
+  val x : int -> int
+end = struct
+  let x y = y +. 2.0
+end
+|ocaml}
+      in
+      cmd "ocamlc -c test.ml 2> out";
+      Path.relative t.dir "out");
+  [%expect
+    {|
+    >> error 0
+    loc = file test.ml, line 4-6, chars 6-3
+    severity = error
+    preview =
+    4 | ......struct
+    5 |   let x y = y +. 2.0
+    6 | end
+
+    message = Signature mismatch:
+           Modules do not match:
+             sig val x : float -> float end
+           is not included in
+             sig val x : int -> int end
+           Values do not match:
+             val x : float -> float
+           is not included in
+             val x : int -> int
+
+    >> error 1
+    loc = file test.ml, line 3, chars 2-20
+    raw message =
+    Expected declaration
+
+    >> error 2
+    loc = file test.ml, line 5, chars 6-7
+    raw message =
+    Actual declaration |}]
+
+let%expect_test "warning" =
+  Test.create (fun t ->
+      let open Test in
+      let (_ : Path.t) =
+        file t ~fname:"test.ml" ~contents:"let () = let x = 2 in ()"
+      in
+      cmd "ocamlc -c test.ml 2> out";
+      Path.relative t.dir "out");
+  [%expect
+    {|
+   >> error 0
+   loc = file test.ml, line 1, chars 13-14
+   severity = warning 26 [unused-var]
+   preview =
+   1 | let () = let x = 2 in ()
+                    ^
+
+   message = unused variable x. |}]
+
+let%expect_test "mli mismatch" =
+  Test.create (fun t ->
+      let open Test in
+      let (_ : Path.t) = file t ~fname:"test.mli" ~contents:"val x : int" in
+      let (_ : Path.t) = file t ~fname:"test.ml" ~contents:"let x = false" in
+      cmd "ocamlc -c test.mli 2> /dev/null";
+      cmd "ocamlc -c test.ml 2> out";
+      Path.relative t.dir "out");
+  [%expect
+    {|
+   >> error 0
+   loc = file test.ml, line 1
+   severity = error
+   message = The implementation test.ml does not match the interface test.cmi:
+          Values do not match: val x : bool is not included in val x : int
+
+   >> error 1
+   loc = file test.mli, line 1, chars 0-11
+   raw message =
+   Expected declaration
+
+   >> error 2
+   loc = file test.ml, line 1, chars 4-5
+   raw message =
+   Actual declaration |}]

--- a/test/expect-tests/ocamlc_loc/ocamlc_loc_tests.ml
+++ b/test/expect-tests/ocamlc_loc/ocamlc_loc_tests.ml
@@ -127,7 +127,7 @@ let%expect_test "warning" =
                     "
           ; message = "unused variable x.\n\
                        "
-          ; severity = Warning { code = 26; name = "unused-var" }
+          ; severity = Warning { code = Some 26; name = "unused-var" }
           }
     ; related = []
     } |}]


### PR DESCRIPTION
Starting to address #4668.

Some issues right off the bat:

- Do we try to parse the structured nature of OCaml errors? See the 2nd test for
  an example where sub-errors are present. Currently, I treat these as separate
  errors. In LSP, there's no way to reflect the nesting of errors anyway.
  
- It's a bit of a hassle to parse errors with `--no-buffer`. It would require us
  to redirect stdout/stderr manually as we'll need to feed this into the parser
  as well. Perhaps we can just skip error parsing when `--no-buffer` is on?