### PR TITLE
[RPC] support related messages in diagnostics

### DIFF
--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -112,7 +112,17 @@ module V1 : sig
       val create : int -> t
     end
 
+    module Related : sig
+      type t
+
+      val loc : t -> Loc.t
+
+      val message : t -> unit Pp.t
+    end
+
     type t
+
+    val related : t -> Related.t list
 
     val loc : t -> Loc.t option
 

--- a/otherlibs/dune-rpc/private/conv.ml
+++ b/otherlibs/dune-rpc/private/conv.ml
@@ -425,6 +425,12 @@ let seven a b c d e f g =
     (fun ((a, b, c), (d, e, f, g)) -> (a, b, c, d, e, f, g))
     (fun (a, b, c, d, e, f, g) -> ((a, b, c), (d, e, f, g)))
 
+let eight a b c d e f g h =
+  iso
+    (both (four a b c d) (four e f g h))
+    (fun ((a, b, c, d), (e, f, g, h)) -> (a, b, c, d, e, f, g, h))
+    (fun (a, b, c, d, e, f, g, h) -> ((a, b, c, d), (e, f, g, h)))
+
 let sexp = Sexp
 
 let required x = Required x

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -82,6 +82,17 @@ val seven :
   -> ('g, fields) t
   -> ('a * 'b * 'c * 'd * 'e * 'f * 'g, fields) t
 
+val eight :
+     ('a, fields) t
+  -> ('b, fields) t
+  -> ('c, fields) t
+  -> ('d, fields) t
+  -> ('e, fields) t
+  -> ('f, fields) t
+  -> ('g, fields) t
+  -> ('h, fields) t
+  -> ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h, fields) t
+
 val record : ('a, fields) t -> ('a, values) t
 
 val either : ('a, fields) t -> ('b, fields) t -> (('a, 'b) Either.t, fields) t

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -171,6 +171,17 @@ module Diagnostic : sig
     val create : int -> t
   end
 
+  module Related : sig
+    type t =
+      { message : unit Pp.t
+      ; loc : Loc.t
+      }
+
+    val message : t -> unit Pp.t
+
+    val loc : t -> Loc.t
+  end
+
   type t =
     { targets : Target.t list
     ; id : Id.t
@@ -179,7 +190,10 @@ module Diagnostic : sig
     ; severity : severity option
     ; promotion : Promotion.t list
     ; directory : string option
+    ; related : Related.t list
     }
+
+  val related : t -> Related.t list
 
   val id : t -> Id.t
 

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -37,6 +37,7 @@ let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
   ; message
   ; loc
   ; promotion
+  ; related = []
   ; directory =
       Option.map
         ~f:(fun p ->


### PR DESCRIPTION
LSP supports multiple messages/locations for a single diagnostic. It
would be great if dune would send multiple locations in this format for
some errors. For example in:

* mli/ml mismatch errors
* duplicate {library,module,executable} errors

Related to #4670 which will extract such related error from ocaml compilation
commands