### PR TITLE
Refactor target interpretation to remove call to `eval_build_request`

### DIFF
--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -1,4 +1,5 @@
 open Stdune
+open Dune_engine
 
 type t =
   { name : Dune_engine.Alias.Name.t
@@ -59,3 +60,11 @@ let of_string (root : Workspace_root.t) ~recursive s ~contexts =
     let dir = Path.parent_exn path in
     let name = Dune_engine.Alias.Name.of_string (Path.basename path) in
     in_dir ~name ~recursive ~contexts dir
+
+let request { name; recursive; dir; contexts } =
+  let contexts = List.map ~f:Dune_rules.Context.name contexts in
+  (if recursive then
+    Build_system.Alias.dep_rec_multi_contexts
+  else
+    Build_system.Alias.dep_multi_contexts)
+    ~dir ~name ~contexts

--- a/bin/alias.mli
+++ b/bin/alias.mli
@@ -1,4 +1,5 @@
 open Stdune
+open Dune_engine
 
 type t = private
   { name : Dune_engine.Alias.Name.t
@@ -22,3 +23,5 @@ val of_string :
   -> t
 
 val pp : t -> _ Pp.t
+
+val request : t -> unit Action_builder.t

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -1,15 +1,12 @@
 open Stdune
 open Import
 
-let run_build_system ?report_error ~common
-    ~(targets : unit -> Target.t list Memo.Build.t) () =
+let run_build_system ?report_error ~common ~(request : unit Action_builder.t) ()
+    =
   let build_started = Unix.gettimeofday () in
   Fiber.finalize
     (fun () ->
-      Build_system.run ?report_error (fun () ->
-          let open Memo.Build.O in
-          let* targets = targets () in
-          Build_system.build (Target.request targets)))
+      Build_system.run ?report_error (fun () -> Build_system.build request))
     ~finally:(fun () ->
       (if Common.print_metrics common then
         let gc_stat = Gc.quick_stat () in
@@ -26,43 +23,42 @@ let run_build_system ?report_error ~common
              ]));
       Fiber.return ())
 
-let run_build_command_poll ~(common : Common.t) ~config ~targets ~setup =
+let run_build_command_poll ~(common : Common.t) ~config ~request ~setup =
   let open Fiber.O in
   let every ~report_error () =
     Cached_digest.invalidate_cached_timestamps ();
     let* setup = setup () in
-    let* targets =
+    let* request =
       match
         let open Option.O in
         let* rpc = Common.rpc common in
         Dune_rpc_impl.Server.pending_build_action rpc
       with
-      | None -> Fiber.return (fun () -> targets setup)
+      | None -> Fiber.return (request setup)
       | Some (Build (targets, ivar)) ->
         let+ () = Fiber.Ivar.fill ivar Accepted in
-        fun () ->
-          Target.resolve_targets_exn (Common.root common) config setup targets
+        Target.interpret_targets (Common.root common) config setup targets
     in
-    let+ () = run_build_system ~report_error ~common ~targets () in
+    let+ () = run_build_system ~report_error ~common ~request () in
     `Continue
   in
   Scheduler.poll ~common ~config ~every ~finally:Hooks.End_of_build.run
 
-let run_build_command_once ~(common : Common.t) ~config ~targets ~setup =
+let run_build_command_once ~(common : Common.t) ~config ~request ~setup =
   let open Fiber.O in
   let once () =
     let* setup = setup () in
-    run_build_system ~common ~targets:(fun () -> targets setup) ()
+    run_build_system ~common ~request:(request setup) ()
   in
   Scheduler.go ~common ~config once
 
-let run_build_command ~(common : Common.t) ~config ~targets =
+let run_build_command ~(common : Common.t) ~config ~request =
   let setup () = Import.Main.setup () in
   (if Common.watch common then
     run_build_command_poll
   else
     run_build_command_once)
-    ~setup ~common ~config ~targets
+    ~setup ~common ~config ~request
 
 let runtest =
   let doc = "Run tests." in
@@ -85,15 +81,15 @@ let runtest =
     let+ common = Common.term
     and+ dirs = Arg.(value & pos_all string [ "." ] name_) in
     let config = Common.init common in
-    let targets (setup : Import.Main.build_system) =
-      Memo.Build.return
-      @@ List.map dirs ~f:(fun dir ->
+    let request (setup : Import.Main.build_system) =
+      Action_builder.all_unit
+        (List.map dirs ~f:(fun dir ->
              let dir = Path.(relative root) (Common.prefix_target common dir) in
-             Target.Alias
-               (Alias.in_dir ~name:Dune_engine.Alias.Name.runtest
-                  ~recursive:true ~contexts:setup.contexts dir))
+             Alias.in_dir ~name:Dune_engine.Alias.Name.runtest ~recursive:true
+               ~contexts:setup.contexts dir
+             |> Alias.request))
     in
-    run_build_command ~common ~config ~targets
+    run_build_command ~common ~config ~request
   in
   (term, Term.info "runtest" ~doc ~man)
 
@@ -126,9 +122,9 @@ let build =
       | _ :: _ -> targets
     in
     let config = Common.init common in
-    let targets setup =
-      Target.resolve_targets_exn (Common.root common) config setup targets
+    let request setup =
+      Target.interpret_targets (Common.root common) config setup targets
     in
-    run_build_command ~common ~config ~targets
+    run_build_command ~common ~config ~request
   in
   (term, Term.info "build" ~doc ~man)

--- a/bin/build_cmd.mli
+++ b/bin/build_cmd.mli
@@ -1,7 +1,9 @@
+open Dune_engine
+
 val run_build_command :
      common:Common.t
   -> config:Dune_config.t
-  -> targets:(Dune_rules.Main.build_system -> Target.t list Memo.Build.t)
+  -> request:(Dune_rules.Main.build_system -> unit Action_builder.t)
   -> unit
 
 val runtest : unit Cmdliner.Term.t * Cmdliner.Term.info

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -49,105 +49,80 @@ let term =
       let* setup = Import.Main.setup () in
       let sctx = Import.Main.find_scontext_exn setup ~name:context in
       let context = Dune_rules.Super_context.context sctx in
-      let path_relative_to_build_root p =
-        Common.prefix_target common p
-        |> Path.Build.relative context.build_dir
-        |> Path.build
+      let dir =
+        Path.Build.relative context.build_dir (Common.prefix_target common "")
       in
-      let prog_where =
-        match Filename.analyze_program_name prog with
-        | Absolute -> `This_abs (Path.of_string prog)
-        | In_path -> `Search prog
-        | Relative_to_current_dir ->
-          `This_rel (path_relative_to_build_root prog)
-      in
-      let targets =
-        Memo.Lazy.create (fun () ->
-            let open Memo.Build.O in
-            (match prog_where with
-            | `Search p ->
-              let p =
-                Path.Build.relative
-                  (Local_install_path.bin_dir ~context:context.name)
-                  p
-                |> Path.build
-              in
-              [ p; Path.extend_basename p ~suffix:Bin.exe ]
-            | `This_rel p when Sys.win32 ->
-              [ p; Path.extend_basename p ~suffix:Bin.exe ]
-            | `This_rel p -> [ p ]
-            | `This_abs p when Path.is_in_build_dir p -> [ p ]
-            | `This_abs _ -> [])
-            |> List.map ~f:(fun p -> Target.Path p)
-            |> Target.resolve_targets_mixed (Common.root common) config setup
-            >>| List.concat_map ~f:(function
-                  | Ok targets -> targets
-                  | Error _ -> []))
-      in
-      let* real_prog =
-        let+ () =
-          if no_rebuild then
-            Fiber.return ()
+      let build_prog p =
+        let open Memo.Build.O in
+        if no_rebuild then
+          if Path.exists p then
+            Memo.Build.return p
           else
-            Build_system.run (fun () ->
-                let open Memo.Build.O in
-                Memo.Lazy.force targets >>= function
-                | [] -> Memo.Build.return ()
-                | targets ->
-                  let+ () = Build_system.build (Target.request targets) in
-                  Hooks.End_of_build.run ())
-        in
-        match prog_where with
-        | `Search prog ->
-          let path =
-            Path.build (Local_install_path.bin_dir ~context:context.name)
-            :: context.path
-          in
-          Bin.which prog ~path
-        | `This_rel prog
-        | `This_abs prog ->
-          if Path.exists prog then
-            Some prog
-          else if not Sys.win32 then
-            None
-          else
-            let prog = Path.extend_basename prog ~suffix:Bin.exe in
-            Option.some_if (Path.exists prog) prog
+            User_error.raise
+              [ Pp.textf
+                  "Program %S isn't built yet. You need to build it first or \
+                   remove the --no-build option."
+                  prog
+              ]
+        else
+          let+ () = Build_system.build (Action_builder.path p) in
+          p
       in
-      (* Good candidates for the "./x.exe" instead of "x.exe" error are
-         executables present in the current directory *)
-      let hints () =
-        let+ candidates =
-          let path = path_relative_to_build_root "" in
-          let+ targets =
-            Build_system.run (fun () -> Build_system.targets_of ~dir:path)
+      let not_found () =
+        let open Memo.Build.O in
+        let+ hints =
+          (* Good candidates for the "./x.exe" instead of "x.exe" error are
+             executables present in the current directory *)
+          let+ candidates =
+            Build_system.targets_of ~dir:(Path.build dir)
+            >>| Path.Set.to_list
+            >>| List.filter ~f:(fun p -> Path.extension p = ".exe")
+            >>| List.map ~f:(fun p -> "./" ^ Path.basename p)
           in
-          Path.Set.to_list targets
-          |> List.filter ~f:(fun p -> Path.extension p = ".exe")
-          |> List.map ~f:(fun p -> "./" ^ Path.basename p)
+          User_message.did_you_mean prog ~candidates
         in
-        User_message.did_you_mean prog ~candidates
-      in
-      match (real_prog, no_rebuild) with
-      | None, true -> (
-        Memo.Build.run (Memo.Lazy.force targets) >>= function
-        | [] ->
-          let* hints = hints () in
-          User_error.raise ~hints [ Pp.textf "Program %S not found!" prog ]
-        | _ :: _ ->
-          User_error.raise
-            [ Pp.textf
-                "Program %S isn't built yet. You need to build it first or \
-                 remove the --no-build option."
-                prog
-            ])
-      | None, false ->
-        let* hints = hints () in
         User_error.raise ~hints [ Pp.textf "Program %S not found!" prog ]
-      | Some real_prog, _ ->
-        let real_prog = Path.to_string real_prog in
-        let argv = prog :: args in
-        restore_cwd_and_execve common real_prog argv
-          (Super_context.context_env sctx))
+      in
+      let* prog =
+        let open Memo.Build.O in
+        Build_system.run (fun () ->
+            match Filename.analyze_program_name prog with
+            | In_path -> (
+              Super_context.resolve_program sctx ~dir ~loc:None prog
+              >>= function
+              | Error (_ : Action.Prog.Not_found.t) -> not_found ()
+              | Ok prog -> build_prog prog)
+            | Relative_to_current_dir -> (
+              let path = Path.relative (Path.build dir) prog in
+              (Build_system.is_target path >>= function
+               | true -> Memo.Build.return (Some path)
+               | false -> (
+                 if not (Filename.check_suffix prog ".exe") then
+                   Memo.Build.return None
+                 else
+                   let path = Path.extend_basename path ~suffix:".exe" in
+                   Build_system.is_target path >>= function
+                   | true -> Memo.Build.return (Some path)
+                   | false -> Memo.Build.return None))
+              >>= function
+              | Some path -> build_prog path
+              | None -> not_found ())
+            | Absolute -> (
+              match
+                let prog = Path.of_string prog in
+                if Path.exists prog then
+                  Some prog
+                else if not Sys.win32 then
+                  None
+                else
+                  let prog = Path.extend_basename prog ~suffix:Bin.exe in
+                  Option.some_if (Path.exists prog) prog
+              with
+              | Some prog -> Memo.Build.return prog
+              | None -> not_found ()))
+      in
+      let prog = Path.to_string prog in
+      let argv = prog :: args in
+      restore_cwd_and_execve common prog argv (Super_context.context_env sctx))
 
 let command = (term, info)

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -121,9 +121,9 @@ let term =
                       Path.build p :: acc)
               >>| Action_builder.paths
             | _ ->
-              Target.resolve_targets_exn (Common.root common) config setup
-                targets
-              >>| Target.request
+              Memo.Build.return
+                (Target.interpret_targets (Common.root common) config setup
+                   targets)
           in
           let+ rules =
             Build_system.For_command_line.evaluate_rules ~request ~recursive

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -16,13 +16,7 @@ let request targets =
       >>>
       match target with
       | File path -> Action_builder.path path
-      | Alias { Alias.name; recursive; dir; contexts } ->
-        let contexts = List.map ~f:Dune_rules.Context.name contexts in
-        (if recursive then
-          Build_system.Alias.dep_rec_multi_contexts
-        else
-          Build_system.Alias.dep_multi_contexts)
-          ~dir ~name ~contexts)
+      | Alias a -> Alias.request a)
 
 let target_hint (_setup : Dune_rules.Main.build_system) path =
   assert (Path.is_managed path);
@@ -170,3 +164,9 @@ let resolve_targets_exn root config setup user_targets =
             ]
             ~hints
         | Ok targets -> targets)
+
+let interpret_targets root config setup user_targets =
+  let open Action_builder.O in
+  let* () = Action_builder.return () in
+  Action_builder.memo_build (resolve_targets_exn root config setup user_targets)
+  >>= request

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -3,7 +3,7 @@ module Log = Dune_util.Log
 module Context = Dune_rules.Context
 module Action_builder = Dune_engine.Action_builder
 module Build_system = Dune_engine.Build_system
-open Memo.Build.O
+open Action_builder.O
 
 type t =
   | File of Path.t
@@ -11,7 +11,6 @@ type t =
 
 let request targets =
   List.fold_left targets ~init:(Action_builder.return ()) ~f:(fun acc target ->
-      let open Action_builder.O in
       acc
       >>>
       match target with
@@ -20,6 +19,7 @@ let request targets =
 
 let target_hint (_setup : Dune_rules.Main.build_system) path =
   assert (Path.is_managed path);
+  let open Memo.Build.O in
   let sub_dir = Option.value ~default:path (Path.parent path) in
   let+ candidates = Build_system.all_targets () >>| Path.Build.Set.to_list in
   let candidates =
@@ -44,6 +44,7 @@ let target_hint (_setup : Dune_rules.Main.build_system) path =
   User_message.did_you_mean (Path.to_string path) ~candidates
 
 let resolve_path path ~(setup : Dune_rules.Main.build_system) =
+  let open Memo.Build.O in
   let checked = Util.check_path setup.contexts path in
   let can't_build path =
     let+ hint = target_hint setup path in
@@ -96,14 +97,13 @@ let expand_path (root : Workspace_root.t)
     Path.Build.relative ctx.Context.build_dir
       (String.concat ~sep:Filename.dir_sep root.to_cwd)
   in
-  let* expander = Dune_rules.Super_context.expander sctx ~dir in
+  let* expander =
+    Action_builder.memo_build (Dune_rules.Super_context.expander sctx ~dir)
+  in
   let expander =
     Dune_rules.Dir_contents.add_sources_to_expander sctx expander
   in
-  let+ s, _deps =
-    Build_system.For_command_line.eval_build_request
-      (Dune_rules.Expander.expand_str expander sv)
-  in
+  let+ s = Dune_rules.Expander.expand_str expander sv in
   Path.relative Path.root (root.reach_from_root_prefix ^ s)
 
 let resolve_alias root ~recursive sv ~(setup : Dune_rules.Main.build_system) =
@@ -112,34 +112,35 @@ let resolve_alias root ~recursive sv ~(setup : Dune_rules.Main.build_system) =
     Ok [ Alias (Alias.of_string root ~recursive s ~contexts:setup.contexts) ]
   | None -> Error [ Pp.text "alias cannot contain variables" ]
 
-let resolve_target root ~setup = function
+let resolve_target root ~setup target =
+  match target with
   | Dune_rules.Dep_conf.Alias sv as dep ->
-    Memo.Build.return
+    Action_builder.return
       (Result.map_error
          ~f:(fun hints -> (dep, hints))
          (resolve_alias root ~recursive:false sv ~setup))
   | Alias_rec sv as dep ->
-    Memo.Build.return
+    Action_builder.return
       (Result.map_error
          ~f:(fun hints -> (dep, hints))
          (resolve_alias root ~recursive:true sv ~setup))
   | File sv as dep ->
     let f ctx =
       let* path = expand_path root ~setup ctx sv in
-      resolve_path path ~setup
+      Action_builder.memo_build (resolve_path path ~setup)
       >>| Result.map_error ~f:(fun hints -> (dep, hints))
     in
-    Memo.Build.parallel_map setup.contexts ~f
+    Action_builder.List.map setup.contexts ~f
     >>| Result.List.concat_map ~f:Fun.id
-  | dep -> Memo.Build.return (Error (dep, []))
+  | dep -> Action_builder.return (Error (dep, []))
 
 let resolve_targets root (config : Dune_config.t)
     (setup : Dune_rules.Main.build_system) user_targets =
   match user_targets with
-  | [] -> Memo.Build.return []
+  | [] -> Action_builder.return []
   | _ ->
     let+ targets =
-      Memo.Build.parallel_map user_targets ~f:(resolve_target root ~setup)
+      Action_builder.List.map user_targets ~f:(resolve_target root ~setup)
     in
     if config.display.verbosity = Verbose then
       Log.info
@@ -166,7 +167,5 @@ let resolve_targets_exn root config setup user_targets =
         | Ok targets -> targets)
 
 let interpret_targets root config setup user_targets =
-  let open Action_builder.O in
   let* () = Action_builder.return () in
-  Action_builder.memo_build (resolve_targets_exn root config setup user_targets)
-  >>= request
+  resolve_targets_exn root config setup user_targets >>= request

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -6,12 +6,6 @@ type t =
 
 val request : t list -> unit Dune_engine.Action_builder.t
 
-val resolve_target :
-     Workspace_root.t
-  -> setup:Dune_rules.Main.build_system
-  -> Arg.Dep.t
-  -> (t list, Arg.Dep.t * User_message.Style.t Pp.t list) result Memo.Build.t
-
 type resolve_input =
   | Path of Path.t
   | Dep of Arg.Dep.t

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -1,14 +1,8 @@
-open Stdune
+open! Stdune
 
-type t =
-  | File of Path.t
-  | Alias of Alias.t
-
-val request : t list -> unit Dune_engine.Action_builder.t
-
-val resolve_targets_exn :
+val interpret_targets :
      Workspace_root.t
   -> Dune_config.t
   -> Dune_rules.Main.build_system
   -> Arg.Dep.t list
-  -> t list Memo.Build.t
+  -> unit Dune_engine.Action_builder.t

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -6,18 +6,6 @@ type t =
 
 val request : t list -> unit Dune_engine.Action_builder.t
 
-type resolve_input =
-  | Path of Path.t
-  | Dep of Arg.Dep.t
-
-val resolve_targets_mixed :
-     Workspace_root.t
-  -> Dune_config.t
-  -> Dune_rules.Main.build_system
-  -> resolve_input list
-  -> (t list, Arg.Dep.t * User_message.Style.t Pp.t list) result list
-     Memo.Build.t
-
 val resolve_targets_exn :
      Workspace_root.t
   -> Dune_config.t

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -56,10 +56,7 @@ let term =
             Dune_rules.Lib.L.toplevel_include_paths requires
           in
           let* files = link_deps requires in
-          let* () =
-            Build_system.build
-              (Target.request (List.map files ~f:(fun f -> Target.File f)))
-          in
+          let* () = Build_system.build (Action_builder.paths files) in
           let files_to_load =
             List.filter files ~f:(fun p ->
                 let ext = Path.extension p in

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -20,11 +20,11 @@ let term =
     Common.context_arg ~doc:{|Select context where to build/run utop.|}
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
   let config = Common.init common in
-  if not (Path.is_directory (Path.of_string (Common.prefix_target common dir)))
-  then
+  let dir = Common.prefix_target common dir in
+  if not (Path.is_directory (Path.of_string dir)) then
     User_error.raise
       [ Pp.textf "cannot find directory: %s" (String.maybe_quoted dir) ];
-  let utop_target = Arg.Dep.file (Filename.concat dir Utop.utop_exe) in
+  let utop_target = Filename.concat dir Utop.utop_exe in
   let sctx, utop_path =
     Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
@@ -33,20 +33,18 @@ let term =
             let open Memo.Build.O in
             let context = Import.Main.find_context_exn setup ~name:ctx_name in
             let sctx = Import.Main.find_scontext_exn setup ~name:ctx_name in
-            let setup = { setup with contexts = [ context ] } in
-            let* target =
-              Target.resolve_target (Common.root common) ~setup utop_target
-              >>| function
-              | Error _ ->
-                User_error.raise
-                  [ Pp.textf "no library is defined in %s"
-                      (String.maybe_quoted dir)
-                  ]
-              | Ok [ File target ] -> target
-              | Ok _ -> assert false
+            let utop_target =
+              Path.build (Path.Build.relative context.build_dir utop_target)
             in
-            let+ () = Build_system.build (Target.request [ File target ]) in
-            (sctx, Path.to_string target)))
+            Build_system.is_target utop_target >>= function
+            | false ->
+              User_error.raise
+                [ Pp.textf "no library is defined in %s"
+                    (String.maybe_quoted dir)
+                ]
+            | true ->
+              let+ () = Build_system.build (Action_builder.path utop_target) in
+              (sctx, Path.to_string utop_target)))
   in
   Hooks.End_of_build.run ();
   restore_cwd_and_execve common utop_path (utop_path :: args)

--- a/test/blackbox-tests/test-cases/overlapping-deps.t
+++ b/test/blackbox-tests/test-cases/overlapping-deps.t
@@ -69,6 +69,7 @@ And we see the error:
        $TESTCASE_ROOT/use/../external/_build/install/default/lib/some_package1
   -> required by _build/default/proj2/.bar.objs/byte/bar.cmo
   -> required by _build/default/proj2/bar.cma
+  -> required by %{cma:proj2/bar} at command line:1
   [1]
 
 We can fix the error by allow overlapping dependencies:


### PR DESCRIPTION
The goal of this PR is to remove the call to `eval_build_request` in `bin/target.ml` so that functions in `Build_system.For_command_line` are only called for `dune rules`. This will allow to simplify the implementation of `Action_builder`, and hopefully make it more efficient.

To do that, this PR refactors the code interpreting targets.

The first three commits are preparatory work to simplify the API of `Target`:

- the first commit removes `Target.resolve_target` and adapt the code in utop.ml which was the only user of this function
- the second commit removes `Target.resolve_target_mixed` and adapt the code in exec.ml which was the only user of this function
- the third commit merges `Target.resolve_targets_exn` and `Target.request` into a single `Target.interpret_targets` function, since they were always used this way

After this work, the `Target` modules exposes a single function:

```ocaml
val interpret_targets :
     Workspace_root.t
  -> Dune_config.t
  -> Dune_rules.Main.build_system
  -> Arg.Dep.t list
  -> unit Dune_engine.Action_builder.t
```

This allows us to move all the implementation to the `Action_builder` monad and remove the call to `eval_build_request`, whose only purpose was to go from `Action_builder` to `Memo.Build`. The last commit does this.