### PR TITLE
Split-off Build_system.Alias

### DIFF
--- a/bin/alias.ml
+++ b/bin/alias.ml
@@ -61,10 +61,41 @@ let of_string (root : Workspace_root.t) ~recursive s ~contexts =
     let name = Dune_engine.Alias.Name.of_string (Path.basename path) in
     in_dir ~name ~recursive ~contexts dir
 
+let dep_on_alias_multi_contexts ~dir ~name ~contexts =
+  Stdlib.ignore
+    (Dune_engine.Source_tree.find_dir_specified_on_command_line ~dir
+      : _ Memo.Build.t);
+  let context_to_alias_expansion ctx =
+    let ctx_dir = Dune_engine.Context_name.build_dir ctx in
+    let dir = Path.Build.(append_source ctx_dir dir) in
+    Action_builder.alias (Dune_engine.Alias.make ~dir name)
+  in
+  Action_builder.all_unit (List.map contexts ~f:context_to_alias_expansion)
+
+let dep_on_alias_rec_multi_contexts ~dir:src_dir ~name ~contexts =
+  let open Action_builder.O in
+  let* dir =
+    Action_builder.memo_build
+      (Dune_engine.Source_tree.find_dir_specified_on_command_line ~dir:src_dir)
+  in
+  let+ is_nonempty_list =
+    Action_builder.all
+      (List.map contexts ~f:(fun ctx ->
+           Action_builder.dep_on_alias_rec name ctx dir))
+  in
+  let is_nonempty = List.exists is_nonempty_list ~f:Fun.id in
+  if (not is_nonempty) && not (Dune_engine.Alias.is_standard name) then
+    User_error.raise
+      [ Pp.textf "Alias %S specified on the command line is empty."
+          (Dune_engine.Alias.Name.to_string name)
+      ; Pp.textf "It is not defined in %s or any of its descendants."
+          (Path.Source.to_string_maybe_quoted src_dir)
+      ]
+
 let request { name; recursive; dir; contexts } =
   let contexts = List.map ~f:Dune_rules.Context.name contexts in
   (if recursive then
-    Build_system.Alias.dep_rec_multi_contexts
+    dep_on_alias_rec_multi_contexts
   else
-    Build_system.Alias.dep_multi_contexts)
+    dep_on_alias_multi_contexts)
     ~dir ~name ~contexts

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -148,6 +148,13 @@ val env_var : string -> unit t
 
 val alias : Alias.t -> unit t
 
+val dep_on_alias_if_exists : Alias.t -> bool t
+
+(** Depend on an alias recursively. Return [true] if the alias is defined in at
+    least one directory, and [false] otherwise. *)
+val dep_on_alias_rec :
+  Alias.Name.t -> Context_name.t -> Source_tree.Dir.t -> bool t
+
 (** Compute the set of source of all files present in the sub-tree starting at
     [dir] and record them as dependencies. *)
 val source_tree : dir:Path.t -> Path.Set.t t
@@ -319,7 +326,3 @@ val dyn_memo_build : 'a Memo.Build.t t -> 'a t
 (** A version of [dyn_memo_build] that makes it convenient to declare dynamic
     action dependencies. *)
 val dyn_memo_build_deps : ('a * Dep.Set.t) Memo.Build.t t -> 'a t
-
-(**/**)
-
-val dep_on_alias_if_exists : Alias.t -> bool t

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -206,3 +206,12 @@ let describe alias =
       (Path.Source.to_string_maybe_quoted
          (Path.Source.relative dir_in_context (Name.to_string alias.name)))
       (ctx_suffix ctx)
+
+let package_install ~(context : Build_context.t) ~(pkg : Package.t) =
+  let dir =
+    let dir = Package.dir pkg in
+    Path.Build.append_source context.build_dir dir
+  in
+  let name = Package.name pkg in
+  sprintf ".%s-files" (Package.Name.to_string name)
+  |> Name.of_string |> make ~dir

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -72,3 +72,6 @@ val fmt : dir:Path.Build.t -> t
 val is_standard : Name.t -> bool
 
 val describe : t -> string
+
+(** Alias for all the files in [_build/install] that belong to this package *)
+val package_install : context:Build_context.t -> pkg:Package.t -> t

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -104,6 +104,8 @@ val init :
   -> sandboxing_preference:Sandbox_mode.t list
   -> rule_generator:(module Rule_generator)
   -> handler:Handler.t option
+  -> implicit_default_alias:
+       (Path.Build.t -> unit Action_builder.t option Memo.Build.t)
   -> unit
 
 (** {2 Primitive for rule generations} *)
@@ -132,35 +134,6 @@ val package_deps :
   -> Package.t
   -> Path.Set.t
   -> Package.Id.Set.t Memo.Build.t
-
-(** {2 Aliases} *)
-
-module Alias : sig
-  type t = Alias.t
-
-  (** Alias for all the files in [_build/install] that belong to this package *)
-  val package_install : context:Build_context.t -> pkg:Package.t -> t
-
-  (** Depend on the expansion of this alias. *)
-  val dep : t -> unit Action_builder.t
-
-  (** Implements [@@alias] on the command line *)
-  val dep_multi_contexts :
-       dir:Path.Source.t
-    -> name:Alias.Name.t
-    -> contexts:Context_name.t list
-    -> unit Action_builder.t
-
-  (** Implements [(alias_rec ...)] in dependency specification *)
-  val dep_rec : t -> loc:Loc.t -> unit Action_builder.t
-
-  (** Implements [@alias] on the command line *)
-  val dep_rec_multi_contexts :
-       dir:Path.Source.t
-    -> name:Alias.Name.t
-    -> contexts:Context_name.t list
-    -> unit Action_builder.t
-end
 
 (** {1 Requests} *)
 

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -829,9 +829,7 @@ let install_rules sctx (package : Package.t) =
   in
   let* () =
     let context = Context.build_context ctx in
-    let target_alias =
-      Build_system.Alias.package_install ~context ~pkg:package
-    in
+    let target_alias = Alias.package_install ~context ~pkg:package in
     let open Action_builder.O in
     Rules.Produce.Alias.add_deps target_alias
       (Action_builder.dyn_deps
@@ -846,8 +844,7 @@ let install_rules sctx (package : Package.t) =
                        (Super_context.packages sctx)
                        name
                    in
-                   Build_system.Alias.package_install ~context ~pkg |> Dep.alias)
-          )))
+                   Alias.package_install ~context ~pkg |> Dep.alias) )))
   in
   let action =
     let install_file =

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -10,6 +10,32 @@ type build_system =
   ; scontexts : Super_context.t Context_name.Map.t
   }
 
+let implicit_default_alias dir =
+  let open Memo.Build.O in
+  match Path.Build.extract_build_context dir with
+  | None -> Memo.Build.return None
+  | Some (ctx_name, src_dir) -> (
+    Source_tree.find_dir src_dir >>| function
+    | None -> None
+    | Some dir ->
+      let default_alias =
+        let dune_version =
+          Source_tree.Dir.project dir |> Dune_project.dune_version
+        in
+        if dune_version >= (2, 0) then
+          Alias.Name.all
+        else
+          Alias.Name.install
+      in
+      Some
+        (let open Action_builder.O in
+        let+ _ =
+          Action_builder.dep_on_alias_rec default_alias
+            (Context_name.of_string ctx_name)
+            dir
+        in
+        ()))
+
 let init ~stats ~sandboxing_preference ~cache_config ~cache_debug_flags ~handler
     =
   let promote_source ?chmod ~src ~dst ctx =
@@ -31,7 +57,7 @@ let init ~stats ~sandboxing_preference ~cache_config ~cache_debug_flags ~handler
            Workspace.workspace () >>| Workspace.build_contexts))
     ~cache_config ~cache_debug_flags
     ~rule_generator:(module Gen_rules)
-    ~handler
+    ~handler ~implicit_default_alias
 
 let get () =
   let open Memo.Build.O in

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -128,7 +128,7 @@ val add_rules :
 
 val add_alias_action :
      t
-  -> Build_system.Alias.t
+  -> Alias.t
   -> dir:Path.Build.t
   -> loc:Loc.t option
   -> ?locks:Path.t list


### PR DESCRIPTION
This module contained:
- functions to interpet `(alias* ...)` in dune file, these were moved to `Dune_rules.Dep_conv_eval`
- functions to interpret `@...` on the command line, these were moved to the `bin/` directory
- some code to setup a default alias when it isn't defined. This doesn't need to belong to the core so I made it configurable and moved the current definition to Dune_rules

This PR should make it easier to "reverse" the dependency between `Action_builder` and `Build_system`, and then simplify the implementation of `Action_builder`. Additionally, it also makes the `Build_system` module a bit smaller.