### PR TITLE
Move Build_system.For_command_line to bin/print_rules.ml

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -27,7 +27,162 @@ let man =
 
 let info = Term.info "rules" ~doc ~man
 
-let print_rule_makefile ppf (rule : Build_system.For_command_line.Rule.t) =
+module Eval_rules : sig
+  module Rule : sig
+    type t = private
+      { id : Dune_engine.Rule.Id.t
+      ; dir : Path.Build.t
+      ; deps : Dep.Set.t
+      ; expanded_deps : Path.Set.t
+      ; targets : Path.Build.Set.t
+      ; context : Dune_engine.Build_context.t option
+      ; action : Action.t
+      }
+  end
+
+  val eval :
+    recursive:bool -> request:unit Action_builder.t -> Rule.t list Memo.Build.t
+end = struct
+  open Dune_engine
+  module Non_evaluated_rule = Rule
+  open Memo.Build.O
+
+  module Rule = struct
+    type t =
+      { id : Rule.Id.t
+      ; dir : Path.Build.t
+      ; deps : Dep.Set.t
+      ; expanded_deps : Path.Set.t
+      ; targets : Path.Build.Set.t
+      ; context : Build_context.t option
+      ; action : Action.t
+      }
+  end
+
+  module Rule_top_closure =
+    Top_closure.Make (Non_evaluated_rule.Id.Set) (Memo.Build)
+
+  (* Evaluate a rule without building the action dependencies *)
+  module Eval_action_builder = Action_builder.Make_exec (struct
+    type fact = unit
+
+    let merge_facts = Dep.Set.union
+
+    let read_file p ~f =
+      let+ _digest = Build_system.build_file p in
+      f p
+
+    let register_action_deps deps = Memo.Build.return deps
+
+    let register_action_dep_pred g =
+      let+ ps = Build_system.eval_pred g in
+      (ps, ())
+
+    let file_exists = Build_system.file_exists
+
+    let alias_exists = Build_system.alias_exists
+
+    let execute_action ~observing_facts:_ _act =
+      (* We don't need to execute this action to compute the final action. *)
+      (* jeremiedimino: but maybe we should capture it somehow, it seems
+         relevant to display in the output of [dune rules] *)
+      Memo.Build.return ()
+
+    let execute_action_stdout ~observing_facts:deps act =
+      let* facts = Build_system.build_deps deps in
+      Build_system.execute_action_stdout ~observing_facts:facts act
+  end)
+
+  let eval_build_request = Eval_action_builder.exec
+
+  module rec Expand : sig
+    val alias : Alias.t -> Path.Set.t Memo.Build.t
+
+    val deps : Dep.Set.t -> Path.Set.t Memo.Build.t
+  end = struct
+    let alias =
+      let memo =
+        Memo.create "expand-alias"
+          ~input:(module Alias)
+          (fun alias ->
+            let* l =
+              Build_system.get_alias_definition alias
+              >>= Memo.Build.parallel_map ~f:(fun (loc, definition) ->
+                      Memo.push_stack_frame
+                        (fun () ->
+                          let+ (), deps = eval_build_request definition in
+                          deps)
+                        ~human_readable_description:(fun () ->
+                          Alias.describe alias ~loc))
+            in
+            let deps = List.fold_left l ~init:Dep.Set.empty ~f:Dep.Set.union in
+            Expand.deps deps)
+      in
+      Memo.exec memo
+
+    let deps deps =
+      Memo.Build.parallel_map (Dep.Set.to_list deps) ~f:(fun (dep : Dep.t) ->
+          match dep with
+          | File p -> Memo.Build.return (Path.Set.singleton p)
+          | File_selector g -> Build_system.eval_pred g
+          | Alias a -> Expand.alias a
+          | Env _
+          | Universe
+          | Sandbox_config _ ->
+            Memo.Build.return Path.Set.empty)
+      >>| Path.Set.union_all
+  end
+
+  let evaluate_rule =
+    let memo =
+      Memo.create "evaluate-rule"
+        ~input:(module Non_evaluated_rule)
+        (fun rule ->
+          let* action, deps = eval_build_request rule.action in
+          let* expanded_deps = Expand.deps deps in
+          Memo.Build.return
+            { Rule.id = rule.id
+            ; dir = rule.dir
+            ; deps
+            ; expanded_deps
+            ; targets = rule.targets
+            ; context = rule.context
+            ; action = action.action
+            })
+    in
+    Memo.exec memo
+
+  let eval ~recursive ~request =
+    let rules_of_deps deps =
+      Expand.deps deps >>| Path.Set.to_list
+      >>= Memo.Build.parallel_map ~f:(fun p ->
+              Build_system.get_rule p >>= function
+              | None -> Memo.Build.return None
+              | Some rule -> evaluate_rule rule >>| Option.some)
+      >>| List.filter_map ~f:Fun.id
+    in
+    let* (), deps = Eval_action_builder.exec request in
+    let* root_rules = rules_of_deps deps in
+    Rule_top_closure.top_closure root_rules
+      ~key:(fun rule -> rule.Rule.id)
+      ~deps:(fun rule ->
+        if recursive then
+          rules_of_deps rule.deps
+        else
+          Memo.Build.return [])
+    >>| function
+    | Ok l -> l
+    | Error cycle ->
+      User_error.raise
+        [ Pp.text "Dependency cycle detected:"
+        ; Pp.chain cycle ~f:(fun rule ->
+              Pp.verbatim
+                (Path.to_string_maybe_quoted
+                   (Path.build (Path.Build.Set.choose_exn rule.targets))))
+        ]
+end
+
+let print_rule_makefile ppf (rule : Eval_rules.Rule.t) =
   let action =
     Action.For_shell.Progn
       [ Mkdir (Path.to_string (Path.build rule.dir))
@@ -44,7 +199,7 @@ let print_rule_makefile ppf (rule : Build_system.For_command_line.Rule.t) =
           Format.fprintf ppf "@ %s" (Path.to_string dep)))
     Pp.to_fmt (Action_to_sh.pp action)
 
-let print_rule_sexp ppf (rule : Build_system.For_command_line.Rule.t) =
+let print_rule_sexp ppf (rule : Eval_rules.Rule.t) =
   let sexp_of_action action =
     Action.for_shell action |> Action.For_shell.encode
   in
@@ -125,9 +280,7 @@ let term =
                 (Target.interpret_targets (Common.root common) config setup
                    targets)
           in
-          let+ rules =
-            Build_system.For_command_line.evaluate_rules ~request ~recursive
-          in
+          let+ rules = Eval_rules.eval ~request ~recursive in
           let print oc =
             let ppf = Format.formatter_of_out_channel oc in
             Syntax.print_rules syntax ppf rules

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -71,7 +71,7 @@ val fmt : dir:Path.Build.t -> t
 
 val is_standard : Name.t -> bool
 
-val describe : t -> string
+val describe : ?loc:Loc.t -> t -> _ Pp.t
 
 (** Alias for all the files in [_build/install] that belong to this package *)
 val package_install : context:Build_context.t -> pkg:Package.t -> t

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -139,10 +139,39 @@ val package_deps :
 
 (** {1 Requests} *)
 
+(** Build a file and return the digest of its contents *)
+val build_file : Path.t -> Digest.t Memo.Build.t
+
 (** Build a request *)
 val build : 'a Action_builder.t -> 'a Memo.Build.t
 
+(** Return [true] if a file exists or is buildable *)
+val file_exists : Path.t -> bool Memo.Build.t
+
+val alias_exists : Alias.t -> bool Memo.Build.t
+
 val is_target : Path.t -> bool Memo.Build.t
+
+val build_deps : Dep.Set.t -> Dep.Facts.t Memo.Build.t
+
+(** Execute a action. The execution is cached. *)
+val execute_action :
+     observing_facts:Dep.Facts.t
+  -> Action_builder.Action_desc.t
+  -> unit Memo.Build.t
+
+(** Execute a action and capture its output. The execution is cached. *)
+val execute_action_stdout :
+     observing_facts:Dep.Facts.t
+  -> Action_builder.Action_desc.t
+  -> string Memo.Build.t
+
+(** Return the rule that has the given file has target, if any *)
+val get_rule : Path.t -> Rule.t option Memo.Build.t
+
+(** Return the definition of an alias *)
+val get_alias_definition :
+  Alias.t -> (Loc.t * unit Action_builder.t) list Memo.Build.t
 
 (** List of all buildable targets. *)
 val all_targets : unit -> Path.Build.Set.t Memo.Build.t
@@ -150,36 +179,6 @@ val all_targets : unit -> Path.Build.Set.t Memo.Build.t
 (** The set of files that were created in the source tree and need to be
     deleted. *)
 val files_in_source_tree_to_delete : unit -> Path.Set.t
-
-(** {2 Build rules} *)
-
-module For_command_line : sig
-  (** Functions in this module duplicate some work that is done by [build] and
-      other functions, so they not suitable to be called as part of a normal
-      build. However, we need them in some part of the command line. *)
-
-  (** A fully evaluated rule. *)
-  module Rule : sig
-    type t = private
-      { id : Rule.Id.t
-      ; dir : Path.Build.t
-      ; deps : Dep.Set.t
-      ; expanded_deps : Path.Set.t
-      ; targets : Path.Build.Set.t
-      ; context : Build_context.t option
-      ; action : Action.t
-      }
-  end
-
-  (** Return the list of fully evaluated rules used to build the given targets.
-      If [recursive] is [true], also include the rules needed to build the
-      transitive dependencies of the targets. *)
-  val evaluate_rules :
-    recursive:bool -> request:unit Action_builder.t -> Rule.t list Memo.Build.t
-
-  (** Similar to [build], but doesn't build the dependencies, only expand them *)
-  val eval_build_request : 'a Action_builder.t -> ('a * Dep.Set.t) Memo.Build.t
-end
 
 (** {2 Running a build} *)
 


### PR DESCRIPTION
This was the only place it was used. This is again preparatory work to simplify `Action_builder` and this also makes `Build_system` smaller.

To do that I had to expose a few more functions from `Build_system`. It felt special to expose the most basic functionnality of the build system:`Build_system.build_file`.
