### PR TITLE
Remove the cycle detection timer

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -13,11 +13,8 @@ let run_build_system ?report_error ~common ~(request : unit Action_builder.t) ()
         Console.print_user_message
           (User_message.make
              [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ())
-             ; Pp.textf
-                 "(%.2fs total, %.2fs cycle detection, %.2fs digests, %.1fM \
-                  heap words)"
+             ; Pp.textf "(%.2fs total, %.2fs digests, %.1fM heap words)"
                  (Unix.gettimeofday () -. build_started)
-                 (Metrics.Timer.read_seconds Memo.cycle_detection_timer)
                  (Metrics.Timer.read_seconds Digest.generic_timer)
                  (float_of_int gc_stat.heap_words /. 1_000_000.)
              ]));

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -855,8 +855,6 @@ module Cached_value = struct
       not (Exn_set.equal prev_exns cur_exns)
 end
 
-let cycle_detection_timer = Metrics.Timer.create ()
-
 (* Add a dependency on the [dep_node] from the caller, if there is one. Returns
    an [Error] if the new dependency would introduce a dependency cycle. *)
 let add_dep_from_caller (type i o) (dep_node : (i, o) Dep_node.t)
@@ -864,38 +862,36 @@ let add_dep_from_caller (type i o) (dep_node : (i, o) Dep_node.t)
   let+ caller = Call_stack.get_call_stack_tip () in
   (* Not counting the above computation of the [caller] towards cycle detection,
      to avoid inserting an extra Fiber map or bind. *)
-  Metrics.Timer.record cycle_detection_timer ~f:(fun () ->
-      match caller with
-      | None -> Ok ()
-      | Some (Stack_frame_with_state.T caller) -> (
-        let deps_so_far_of_caller = caller.running_state.deps_so_far in
-        match
-          Id.Table.mem deps_so_far_of_caller.added_to_dag
-            dep_node.without_state.id
-        with
-        | true ->
-          Deps_so_far.add_dep deps_so_far_of_caller dep_node.without_state.id
-            (Dep_node.T dep_node);
-          Ok ()
-        | false -> (
-          let cycle_error =
-            match sample_attempt with
-            | Finished _ -> None
-            | Running { dag_node; _ } -> (
-              match
-                Dag.add_assuming_missing global_dep_dag
-                  caller.running_state.dag_node dag_node
-              with
-              | () -> None
-              | exception Dag.Cycle cycle ->
-                Some (List.map cycle ~f:(fun dag_node -> dag_node.Dag.data)))
-          in
-          match cycle_error with
-          | None ->
-            Deps_so_far.add_dep deps_so_far_of_caller dep_node.without_state.id
-              (Dep_node.T dep_node);
-            Ok ()
-          | Some cycle -> Error cycle)))
+  match caller with
+  | None -> Ok ()
+  | Some (Stack_frame_with_state.T caller) -> (
+    let deps_so_far_of_caller = caller.running_state.deps_so_far in
+    match
+      Id.Table.mem deps_so_far_of_caller.added_to_dag dep_node.without_state.id
+    with
+    | true ->
+      Deps_so_far.add_dep deps_so_far_of_caller dep_node.without_state.id
+        (Dep_node.T dep_node);
+      Ok ()
+    | false -> (
+      let cycle_error =
+        match sample_attempt with
+        | Finished _ -> None
+        | Running { dag_node; _ } -> (
+          match
+            Dag.add_assuming_missing global_dep_dag
+              caller.running_state.dag_node dag_node
+          with
+          | () -> None
+          | exception Dag.Cycle cycle ->
+            Some (List.map cycle ~f:(fun dag_node -> dag_node.Dag.data)))
+      in
+      match cycle_error with
+      | None ->
+        Deps_so_far.add_dep deps_so_far_of_caller dep_node.without_state.id
+          (Dep_node.T dep_node);
+        Ok ()
+      | Some cycle -> Error cycle))
 
 type ('input, 'output) t =
   { spec : ('input, 'output) Spec.t

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -452,9 +452,6 @@ module Perf_counters : sig
   val reset : unit -> unit
 end
 
-(** Total time taken by the cycle detection functionality. *)
-val cycle_detection_timer : Metrics.Timer.t
-
 module Expert : sig
   (** Like [cell] but returns [Nothing] if the given memoized function has never
       been evaluated on the specified input. We use [previously_evaluated_cell]


### PR DESCRIPTION
The cycle detection timer has a big performance impact (~10% for incremental zero builds) and even when it's disabled it might have negative effect on the hot path in Memo, so it seems best to remove it and use `perf` for benchmarking & optimisation.