### PR TITLE
Reorder checks in Memo.start_considering

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1161,17 +1161,17 @@ end = struct
   and start_considering :
         'i 'o. ('i, 'o) Dep_node.t -> 'o Cached_value.t Sample_attempt.t =
    fun dep_node ->
-    match currently_considering dep_node.state with
-    | Not_considering -> (
-      match get_cached_value_in_current_cycle dep_node with
-      | None -> newly_considering dep_node
-      | Some cv -> Finished cv)
-    | Considering
-        { running = { dag_node; deps_so_far = _ }
-        ; sample_attempt_result = result
-        ; _
-        } ->
-      Running { dag_node; result }
+    match get_cached_value_in_current_cycle dep_node with
+    | Some cv -> Finished cv
+    | None -> (
+      match currently_considering dep_node.state with
+      | Not_considering -> newly_considering dep_node
+      | Considering
+          { running = { dag_node; deps_so_far = _ }
+          ; sample_attempt_result = result
+          ; _
+          } ->
+        Running { dag_node; result })
 
   and consider :
         'i 'o.    ('i, 'o) Dep_node.t


### PR DESCRIPTION
We have two checks in `start_considering` and it makes sense to reorder them to make this function a bit faster on average:

* The `get_cached_value_in_current_cycle` is likely to succeed more often (because nodes often have multiple readers), in which case we can return `Finished cv` without looking at `dep_node.state`.
* In incremental (near) zero builds, there is little or no concurrency, so the `Considering` path should be happening pretty rarely, which justifies making it a bit slower (before this change, it required a single check, and now it will require two).
