### PR TITLE
Fix regression in zero builds

### DIFF
--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -207,6 +207,7 @@ module Artifacts = struct
           List.iter acc ~f:destroy;
           Error e
         | Ok v -> Ok (v :: acc))
+    |> Result.map ~f:List.rev
 
   type file_restore_error =
     | Not_found

--- a/test/blackbox-tests/test-cases/dune-cache/basic-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/basic-copy.t/run.t
@@ -38,6 +38,10 @@ counts greater than 1, because they are shared with the corresponding cache entr
   2
   $ dune_cmd exists _build/default/beacon
   true
+
+We expect to see both workspace-local and shared cache misses in the build log,
+because we've never built [target1] before.
+
   $ cat _build/log | grep '_build/default/source\|_build/default/target'
   # Workspace-local cache miss: _build/default/source: never seen this target before
   # Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
@@ -63,13 +67,17 @@ Test that rebuilding works.
   $ cat _build/default/target2
   \_o< COIN
   \_o< COIN
+
+Now we expect to see only workspace-local cache misses in the build log, because
+we've cleaned [_build/default] but not the shared cache.
+
   $ cat _build/log | grep '_build/default/source\|_build/default/target'
   # Workspace-local cache miss: _build/default/source: target missing from build dir
   # (_build/default/source)
   # Workspace-local cache miss: _build/default/target1: target missing from build dir
   # (_build/default/target1)
 
-Test how zero the zero build is.
+Test how zero the zero build is. We do not expect to see any cache misses.
 
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ cat _build/log | grep '_build/default/source\|_build/default/target'

--- a/test/blackbox-tests/test-cases/dune-cache/basic-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/basic-copy.t/run.t
@@ -16,8 +16,8 @@ variable, and via the [DUNE_CACHE_ROOT] variable. Here we test the former.
   $ cat > dune <<EOF
   > (rule
   >   (deps source)
-  >   (targets target)
-  >   (action (bash "touch beacon; cat source source > target")))
+  >   (targets target1 target2)
+  >   (action (bash "touch beacon; cat source > target1; cat source source > target2")))
   > EOF
 
 It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
@@ -27,31 +27,54 @@ It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
   > EOF
 
 Test that after the build, the files in the build directory have the hard link
-count of 2, because they are shared with the corresponding cache entries.
+counts greater than 1, because they are shared with the corresponding cache entries.
 
-  $ dune build --config-file=config target
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ dune_cmd stat hardlinks _build/default/source
+  3
+  $ dune_cmd stat hardlinks _build/default/target1
+  3
+  $ dune_cmd stat hardlinks _build/default/target2
   2
-  $ dune_cmd stat hardlinks _build/default/target
-  2
-  $ ls _build/default/beacon
-  _build/default/beacon
+  $ dune_cmd exists _build/default/beacon
+  true
+  $ cat _build/log | grep '_build/default/source\|_build/default/target'
+  # Workspace-local cache miss: _build/default/source: never seen this target before
+  # Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
+  # Workspace-local cache miss: _build/default/target1: never seen this target before
+  # Shared cache miss [fccfd1af13c64ce19b45e2a76fb8132c] (_build/default/target1): not found in cache
 
 Test that rebuilding works.
 
   $ rm -rf _build/default
-  $ dune build --config-file=config target
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ dune_cmd stat hardlinks _build/default/source
-  2
-  $ dune_cmd stat hardlinks _build/default/target
+  3
+  $ dune_cmd stat hardlinks _build/default/target1
+  3
+  $ dune_cmd stat hardlinks _build/default/target2
   2
   $ dune_cmd exists _build/default/beacon
   false
   $ cat _build/default/source
   \_o< COIN
-  $ cat _build/default/target
+  $ cat _build/default/target1
+  \_o< COIN
+  $ cat _build/default/target2
   \_o< COIN
   \_o< COIN
+  $ cat _build/log | grep '_build/default/source\|_build/default/target'
+  # Workspace-local cache miss: _build/default/source: target missing from build dir
+  # (_build/default/source)
+  # Workspace-local cache miss: _build/default/target1: target missing from build dir
+  # (_build/default/target1)
+
+Test how zero the zero build is. To be fixed in a subsequent commit.
+
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
+  $ cat _build/log | grep '_build/default/source\|_build/default/target'
+  # Workspace-local cache miss: _build/default/target1: target changed in build dir
+  # (_build/default/target1)
 
 Test that the cache stores all historical build results.
 

--- a/test/blackbox-tests/test-cases/dune-cache/basic-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/basic-copy.t/run.t
@@ -69,12 +69,11 @@ Test that rebuilding works.
   # Workspace-local cache miss: _build/default/target1: target missing from build dir
   # (_build/default/target1)
 
-Test how zero the zero build is. To be fixed in a subsequent commit.
+Test how zero the zero build is.
 
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ cat _build/log | grep '_build/default/source\|_build/default/target'
-  # Workspace-local cache miss: _build/default/target1: target changed in build dir
-  # (_build/default/target1)
+  [1]
 
 Test that the cache stores all historical build results.
 

--- a/test/blackbox-tests/test-cases/dune-cache/basic-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/basic-hardlink.t/run.t
@@ -70,12 +70,11 @@ Test that rebuilding works.
   # Workspace-local cache miss: _build/default/target1: target missing from build dir
   # (_build/default/target1)
 
-Test how zero the zero build is. To be fixed in a subsequent commit.
+Test how zero the zero build is.
 
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ cat _build/log | grep '_build/default/source\|_build/default/target'
-  # Workspace-local cache miss: _build/default/target1: target changed in build dir
-  # (_build/default/target1)
+  [1]
 
 Test that the cache stores all historical build results.
 

--- a/test/blackbox-tests/test-cases/dune-cache/basic-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/basic-hardlink.t/run.t
@@ -39,6 +39,10 @@ count of 1, because they are not shared with the corresponding cache entries.
   1
   $ dune_cmd exists _build/default/beacon
   true
+
+We expect to see both workspace-local and shared cache misses in the build log,
+because we've never built [target1] before.
+
   $ cat _build/log | grep '_build/default/source\|_build/default/target'
   # Workspace-local cache miss: _build/default/source: never seen this target before
   # Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
@@ -64,13 +68,17 @@ Test that rebuilding works.
   $ cat _build/default/target2
   \_o< COIN
   \_o< COIN
+
+Now we expect to see only workspace-local cache misses in the build log, because
+we've cleaned [_build/default] but not the shared cache.
+
   $ cat _build/log | grep '_build/default/source\|_build/default/target'
   # Workspace-local cache miss: _build/default/source: target missing from build dir
   # (_build/default/source)
   # Workspace-local cache miss: _build/default/target1: target missing from build dir
   # (_build/default/target1)
 
-Test how zero the zero build is.
+Test how zero the zero build is. We do not expect to see any cache misses.
 
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ cat _build/log | grep '_build/default/source\|_build/default/target'

--- a/test/blackbox-tests/test-cases/dune-cache/basic-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/basic-hardlink.t/run.t
@@ -17,8 +17,8 @@ variable, and via the [DUNE_CACHE_ROOT] variable. Here we test the former.
   $ cat > dune <<EOF
   > (rule
   >   (deps source)
-  >   (targets target)
-  >   (action (bash "touch beacon; cat source source > target")))
+  >   (targets target1 target2)
+  >   (action (bash "touch beacon; cat source > target1; cat source source > target2")))
   > EOF
 
 It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
@@ -30,29 +30,52 @@ It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
 Test that after the build, the files in the build directory have the hard link
 count of 1, because they are not shared with the corresponding cache entries.
 
-  $ dune build --config-file=config target
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ dune_cmd stat hardlinks _build/default/source
   1
-  $ dune_cmd stat hardlinks _build/default/target
+  $ dune_cmd stat hardlinks _build/default/target1
   1
-  $ ls _build/default/beacon
-  _build/default/beacon
+  $ dune_cmd stat hardlinks _build/default/target2
+  1
+  $ dune_cmd exists _build/default/beacon
+  true
+  $ cat _build/log | grep '_build/default/source\|_build/default/target'
+  # Workspace-local cache miss: _build/default/source: never seen this target before
+  # Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
+  # Workspace-local cache miss: _build/default/target1: never seen this target before
+  # Shared cache miss [fccfd1af13c64ce19b45e2a76fb8132c] (_build/default/target1): not found in cache
 
 Test that rebuilding works.
 
   $ rm -rf _build/default
-  $ dune build --config-file=config target
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
   $ dune_cmd stat hardlinks _build/default/source
   1
-  $ dune_cmd stat hardlinks _build/default/target
+  $ dune_cmd stat hardlinks _build/default/target1
+  1
+  $ dune_cmd stat hardlinks _build/default/target2
   1
   $ dune_cmd exists _build/default/beacon
   false
   $ cat _build/default/source
   \_o< COIN
-  $ cat _build/default/target
+  $ cat _build/default/target1
+  \_o< COIN
+  $ cat _build/default/target2
   \_o< COIN
   \_o< COIN
+  $ cat _build/log | grep '_build/default/source\|_build/default/target'
+  # Workspace-local cache miss: _build/default/source: target missing from build dir
+  # (_build/default/source)
+  # Workspace-local cache miss: _build/default/target1: target missing from build dir
+  # (_build/default/target1)
+
+Test how zero the zero build is. To be fixed in a subsequent commit.
+
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
+  $ cat _build/log | grep '_build/default/source\|_build/default/target'
+  # Workspace-local cache miss: _build/default/target1: target changed in build dir
+  # (_build/default/target1)
 
 Test that the cache stores all historical build results.
 


### PR DESCRIPTION
When fixing the issues due to partial restoration of artifacts from the cache in #4665, we accidentally reversed the list of targets, which led to storing incorrect entries to Dune database and subsequent workspace-local cache failures.

The first commit adds a test to catch such regressions in future and the second commit fixes the bug. To demonstrate this bug, the existing test case had to be extended from one to two targets (reversing a singleton list is a no-op).