### PR TITLE
fix typo in documentation: %{ocamlc-config} → %{ocaml-config}

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -85,7 +85,7 @@ an flambda compiler with the help of variable expansion:
 
 .. code:: lisp
 
-   (and %{ocamlc-config:flambda} (= %{ocamlc-config:system} macosx))
+   (and %{ocaml-config:flambda} (= %{ocaml-config:system} macosx))
 
 .. _predicate-lang:
 


### PR DESCRIPTION
I hope I am not mistaken and this is indeed an error. I did have to change that in my `dune` files to make them do what I wanted.