### PR TITLE
Library coq.kernel replaced by coq-core.kernel in Coq >= 8.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,6 +161,8 @@ Unreleased
 
 - Add `(package ...)` to `(mdx ...)` (#4691, fixes #3756, @emillon)
 
+- Handle renaming of `coq.kernel` library to `coq-core.kernel` in Coq 8.14 (#4713, @proux01)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1690,7 +1690,7 @@ The supported Coq language versions are:
 
 - ``0.1``: basic Coq theory support,
 - ``0.2``: support for the ``theories`` field, and composition of theories in the same scope,
-- ``0.3``: support for ``(mode native)``, requires Coq >= 8.10.
+- ``0.3``: support for ``(mode native)``, requires Coq >= 8.10 (and dune >= 2.9 for Coq >= 8.14).
 
 Guarantees with respect to stability are not provided yet,
 however, as implementation of features progresses, we hope to reach

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -96,6 +96,16 @@ let select_native_mode ~sctx ~(buildable : Buildable.t) =
   else
     snd buildable.mode
 
+let rec resolve_first lib_db = function
+  | [] -> assert false
+  | [ n ] -> Lib.DB.resolve lib_db (Loc.none, Lib_name.of_string n)
+  | n :: l -> (
+    match
+      Lib.DB.resolve_when_exists lib_db (Loc.none, Lib_name.of_string n)
+    with
+    | Some l -> l
+    | None -> resolve_first lib_db l)
+
 module Context = struct
   type 'a t =
     { coqdep : Action.Prog.t
@@ -239,7 +249,7 @@ module Context = struct
     in
     let mode = select_native_mode ~sctx ~buildable in
     let native_includes =
-      Lib.DB.resolve lib_db (Loc.none, Lib_name.of_string "coq.kernel")
+      resolve_first lib_db [ "coq-core.kernel"; "coq.kernel" ]
       |> Resolve.map ~f:(fun lib -> Util.coq_nativelib_cmi_dirs [ lib ])
     in
     let+ native_theory_includes =


### PR DESCRIPTION
`mode native` seems broken with Coq master as it looks for `coq.kernel` whereas only `coq-core.kernel` is listed by ocamlfind.