### PR TITLE
[Fiber] add Fiber.parallel_all_unit

### DIFF
--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -379,6 +379,8 @@ let parallel_iter l ~f k =
   | [ x ] -> f x k
   | _ -> parallel_iter_generic ~n:(List.length l) ~iter:(List.iter l) ~f k
 
+let all_concurrently_unit l = parallel_iter l ~f:Fun.id
+
 let parallel_iter_set (type a s)
     (module S : Set.S with type elt = a and type t = s) t ~(f : a -> unit t) k =
   let len = S.cardinal t in

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -92,6 +92,10 @@ val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
 (** Like [all] but executes the fibers concurrently. *)
 val all_concurrently : 'a t list -> 'a list t
 
+(** Like [all_concurrently] but is specialized for [unit] fibers. The advantage
+    being that it doesn't allocate a return list. *)
+val all_concurrently_unit : unit t list -> unit t
+
 (** Iter over a list in parallel. *)
 val parallel_iter : 'a list -> f:('a -> unit t) -> unit t
 


### PR DESCRIPTION
Like all all_concurrently, but doesn't allocate any lists.

I'm using this in lsp, but I imagine it would be useful in dune as well.

If it's accepted, I can add some tests for this.