### PR TITLE
Improve error/exn reporting to RPC

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -78,6 +78,8 @@ module Handler : sig
   type event =
     | Start  (** New build started *)
     | Finish  (** Build finished successfully *)
+    | Fail
+    | Interrupt
 
   type error =
     | Add of Error.t  (** Error encountered while building *)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -57,6 +57,9 @@ module Run : sig
       cases *)
   exception Shutdown_requested
 
+  (** Raised by fibers that are terminated because the build was interrupted *)
+  exception Build_cancelled
+
   (** Runs [once] in a loop, executing [finally] after every iteration, even if
       Fiber.Never was encountered.
 


### PR DESCRIPTION
- stop reporting cancellation errors as normal errors
- report build interrupt/fail events