### PR TITLE
Unify and simplify the error handling

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -20,22 +20,22 @@ let run_build_system ~common ~(request : unit Action_builder.t) () =
 
 let run_build_command_poll ~(common : Common.t) ~config ~request ~setup =
   let open Fiber.O in
-  let every () =
-    Cached_digest.invalidate_cached_timestamps ();
-    let* setup = setup () in
-    let* request =
-      match
-        let open Option.O in
-        let* rpc = Common.rpc common in
-        Dune_rpc_impl.Server.pending_build_action rpc
-      with
-      | None -> Fiber.return (request setup)
-      | Some (Build (targets, ivar)) ->
-        let+ () = Fiber.Ivar.fill ivar Accepted in
-        Target.interpret_targets (Common.root common) config setup targets
-    in
-    let+ () = run_build_system ~common ~request () in
-    `Continue
+  let every =
+    Fiber.of_thunk (fun () ->
+        Cached_digest.invalidate_cached_timestamps ();
+        let* setup = setup () in
+        let* request =
+          match
+            let open Option.O in
+            let* rpc = Common.rpc common in
+            Dune_rpc_impl.Server.pending_build_action rpc
+          with
+          | None -> Fiber.return (request setup)
+          | Some (Build (targets, ivar)) ->
+            let+ () = Fiber.Ivar.fill ivar Accepted in
+            Target.interpret_targets (Common.root common) config setup targets
+        in
+        run_build_system ~common ~request ())
   in
   Scheduler.poll ~common ~config ~every ~finally:Hooks.End_of_build.run
 
@@ -43,7 +43,12 @@ let run_build_command_once ~(common : Common.t) ~config ~request ~setup =
   let open Fiber.O in
   let once () =
     let* setup = setup () in
-    run_build_system ~common ~request:(request setup) ()
+    let+ res = run_build_system ~common ~request:(request setup) () in
+    match res with
+    | Error `Already_reported ->
+      (* to ensure non-zero exit code *)
+      raise Dune_util.Report_error.Already_reported
+    | Ok () -> ()
   in
   Scheduler.go ~common ~config once
 

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -85,7 +85,7 @@ let term =
       in
       let* prog =
         let open Memo.Build.O in
-        Build_system.run (fun () ->
+        Build_system.run_exn (fun () ->
             match Filename.analyze_program_name prog with
             | In_path -> (
               Super_context.resolve_program sctx ~dir ~loc:None prog

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -99,9 +99,8 @@ module Scheduler = struct
     let file_watcher = Common.file_watcher common in
     let run =
       let run () =
-        Scheduler.Run.poll (fun ~report_error () ->
-            Fiber.finalize (every ~report_error) ~finally:(fun () ->
-                Fiber.return (finally ())))
+        Scheduler.Run.poll (fun () ->
+            Fiber.finalize every ~finally:(fun () -> Fiber.return (finally ())))
       in
       match Common.rpc common with
       | None -> run

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -99,8 +99,10 @@ module Scheduler = struct
     let file_watcher = Common.file_watcher common in
     let run =
       let run () =
-        Scheduler.Run.poll (fun () ->
-            Fiber.finalize every ~finally:(fun () -> Fiber.return (finally ())))
+        Scheduler.Run.poll
+          (Fiber.finalize
+             (fun () -> every)
+             ~finally:(fun () -> Fiber.return (finally ())))
       in
       match Common.rpc common with
       | None -> run

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -266,7 +266,7 @@ let term =
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup () in
-      Build_system.run (fun () ->
+      Build_system.run_exn (fun () ->
           let open Memo.Build.O in
           let* request =
             match targets with

--- a/bin/printenv.ml
+++ b/bin/printenv.ml
@@ -75,7 +75,7 @@ let term =
             User_error.raise
               [ Pp.text "Environment is not defined in install dirs" ])
       in
-      Build_system.run (fun () -> Build_system.build request) >>| function
+      Build_system.run_exn (fun () -> Build_system.build request) >>| function
       | [ (_, env) ] -> Format.printf "%a" (pp ~fields) env
       | l ->
         List.iter l ~f:(fun (name, env) ->

--- a/bin/top.ml
+++ b/bin/top.ml
@@ -33,7 +33,7 @@ let term =
   Scheduler.go ~common ~config (fun () ->
       let open Fiber.O in
       let* setup = Import.Main.setup () in
-      Build_system.run (fun () ->
+      Build_system.run_exn (fun () ->
           let open Memo.Build.O in
           let sctx =
             Dune_engine.Context_name.Map.find setup.scontexts ctx_name

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -29,7 +29,7 @@ let term =
     Scheduler.go ~common ~config (fun () ->
         let open Fiber.O in
         let* setup = Import.Main.setup () in
-        Build_system.run (fun () ->
+        Build_system.run_exn (fun () ->
             let open Memo.Build.O in
             let context = Import.Main.find_context_exn setup ~name:ctx_name in
             let sctx = Import.Main.find_scontext_exn setup ~name:ctx_name in

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2276,12 +2276,15 @@ let report_early_exn exn =
     | Deterministic -> ());
     t.handler.error [ Add error ]
 
-let reraise_exn exn =
+let handle_final_exns exns =
   match !Clflags.report_errors_config with
-  | Early -> raise Dune_util.Report_error.Already_reported
+  | Early -> ()
   | Twice
   | Deterministic ->
-    Exn_with_backtrace.reraise exn
+    let report exn =
+      if not (caused_by_cancellation exn) then Dune_util.Report_error.report exn
+    in
+    List.iter exns ~f:report
 
 let run f =
   let open Fiber.O in
@@ -2300,14 +2303,26 @@ let run f =
   let f () =
     let* () = t.handler.build_event Start in
     let* res =
-      Fiber.with_error_handler ~on_error:reraise_exn (fun () ->
+      Fiber.collect_errors (fun () ->
           Memo.Build.run_with_error_handler (f ())
             ~handle_error_no_raise:report_early_exn)
     in
-    let+ () = t.handler.build_event Finish in
-    res
+    match res with
+    | Ok res ->
+      let+ () = t.handler.build_event Finish in
+      Ok res
+    | Error exns ->
+      handle_final_exns exns;
+      Fiber.return (Error `Already_reported)
   in
   Fiber.Mutex.with_lock t.build_mutex f
+
+let run_exn f =
+  let open Fiber.O in
+  let+ res = run f in
+  match res with
+  | Ok res -> res
+  | Error `Already_reported -> raise Dune_util.Report_error.Already_reported
 
 let build_file = build_file
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2260,6 +2260,10 @@ let prefix_rules (prefix : unit Action_builder.t) ~f =
 let caused_by_cancellation (exn : Exn_with_backtrace.t) =
   match exn.exn with
   | Scheduler.Run.Build_cancelled -> true
+  | Memo.Error.E err ->
+    (match Memo.Error.get err with
+     | Scheduler.Run.Build_cancelled -> true
+     | _ -> false)
   | _ -> false
 
 let report_early_exn exn =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2260,10 +2260,10 @@ let prefix_rules (prefix : unit Action_builder.t) ~f =
 let caused_by_cancellation (exn : Exn_with_backtrace.t) =
   match exn.exn with
   | Scheduler.Run.Build_cancelled -> true
-  | Memo.Error.E err ->
-    (match Memo.Error.get err with
-     | Scheduler.Run.Build_cancelled -> true
-     | _ -> false)
+  | Memo.Error.E err -> (
+    match Memo.Error.get err with
+    | Scheduler.Run.Build_cancelled -> true
+    | _ -> false)
   | _ -> false
 
 let report_early_exn exn =

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -182,7 +182,11 @@ val files_in_source_tree_to_delete : unit -> Path.Set.t
 
 (** {2 Running a build} *)
 
-val run : (unit -> 'a Memo.Build.t) -> 'a Fiber.t
+val run :
+  (unit -> 'a Memo.Build.t) -> ('a, [ `Already_reported ]) Result.t Fiber.t
+
+(** A variant of [run] that raises an [Already_reported] exception on error. *)
+val run_exn : (unit -> 'a Memo.Build.t) -> 'a Fiber.t
 
 (** {2 Misc} *)
 

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -182,10 +182,7 @@ val files_in_source_tree_to_delete : unit -> Path.Set.t
 
 (** {2 Running a build} *)
 
-val run :
-     ?report_error:(Exn_with_backtrace.t -> unit)
-  -> (unit -> 'a Memo.Build.t)
-  -> 'a Fiber.t
+val run : (unit -> 'a Memo.Build.t) -> 'a Fiber.t
 
 (** {2 Misc} *)
 

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -798,5 +798,3 @@ let run_capture_line ?dir ?stderr_to ?stdin_from ?env
                 (Pp.concat_map l ~sep:Pp.cut ~f:(fun line ->
                      Pp.seq (Pp.verbatim "> ") (Pp.verbatim line)))
             ]))
-
-

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -798,3 +798,5 @@ let run_capture_line ?dir ?stderr_to ?stdin_from ?env
                 (Pp.concat_map l ~sep:Pp.cut ~f:(fun line ->
                      Pp.seq (Pp.verbatim "> ") (Pp.verbatim line)))
             ]))
+
+

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -57,6 +57,8 @@ module Run : sig
       cases *)
   exception Shutdown_requested
 
+  exception Build_cancelled
+
   (** Runs [once] in a loop, executing [finally] after every iteration, even if
       Fiber.Never was encountered.
 
@@ -64,11 +66,7 @@ module Run : sig
 
       If [shutdown] is called, the current build will be canceled and new builds
       will not start. *)
-  val poll :
-       (   report_error:(Exn_with_backtrace.t -> unit)
-        -> unit
-        -> [ `Continue | `Stop ] Fiber.t)
-    -> unit Fiber.t
+  val poll : (unit -> [ `Continue | `Stop ] Fiber.t) -> unit Fiber.t
 
   val go :
        Config.t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -66,7 +66,7 @@ module Run : sig
 
       If [shutdown] is called, the current build will be canceled and new builds
       will not start. *)
-  val poll : (unit -> [ `Continue | `Stop ] Fiber.t) -> unit Fiber.t
+  val poll : (unit, [ `Already_reported ]) Result.t Fiber.t -> unit Fiber.t
 
   val go :
        Config.t


### PR DESCRIPTION
This PR does the following:

- commit 1:
    - To detect (and ignore) errors caused by cancellation, we pattern-match on the exception instead of inspecting the scheduler state. This means that it is now possible to keep seeing errors during cancellations, but those errors are "real" errors so are not problematic.
    - Since we have that information in the exception, we don't need all these `report_error` callbacks whose purpose was to check if we're being cancelled.
- commit 2: 
    - Use that information to suppress such errors from being reported over RPC
- commit 3:
    - Move all error handling from `Scheduler.poll` to `Build_system.run` so that we don't have to keep synchronizing the two modules on how they handle errors.
    - As a result, the non-polling build errors are now reported by `Build_system.run`, not by the top-level handler in bin/main.ml, which seems like a good unification.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>