### PR TITLE
Add functionality for [dune nudge] RPC

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1584,6 +1584,25 @@ end = struct
                reason)
         ]
 
+  (* All actions that raised errors in [execute_rule_impl] depend on this cell.
+     By invalidating this cell, one can therefore force them to be rerun. *)
+  let error_cell = Memo.lazy_cell ~name:"error-cell" Memo.Build.return
+
+  let of_reproducible_fiber_with_error_cell_dependency fiber ~on_error =
+    let handled_error = ref false in
+    let on_error exn =
+      handled_error := true;
+      on_error exn
+    in
+    let fiber = Fiber.with_error_handler fiber ~on_error in
+    let* result = Memo.Build.of_non_reproducible_fiber fiber in
+    let+ () =
+      match !handled_error with
+      | true -> Memo.Cell.read error_cell
+      | false -> Memo.Build.return ()
+    in
+    result
+
   let execute_rule_impl ~rule_kind rule =
     let t = t () in
     let { Rule.id = _; targets; dir; context; mode; action; info = _; loc } =
@@ -1606,18 +1625,14 @@ end = struct
        much performance here by executing it sequentially. *)
     let* action, deps = exec_build_request action in
     let wrap_fiber f =
-      Memo.Build.of_reproducible_fiber
-        (if Loc.is_none loc then
-          f ()
-        else
-          Fiber.with_error_handler f ~on_error:(fun exn ->
-              match exn.exn with
-              | User_error.E (msg, annots)
-                when not (User_error.has_location msg annots) ->
-                let msg = { msg with loc = Some loc } in
-                Exn_with_backtrace.reraise
-                  { exn with exn = User_error.E (msg, annots) }
-              | _ -> Exn_with_backtrace.reraise exn))
+      of_reproducible_fiber_with_error_cell_dependency f ~on_error:(fun exn ->
+          match exn.exn with
+          | User_error.E (msg, annots)
+            when not (Loc.is_none loc || User_error.has_location msg annots) ->
+            let msg = { msg with loc = Some loc } in
+            Exn_with_backtrace.reraise
+              { exn with exn = User_error.E (msg, annots) }
+          | _ -> Exn_with_backtrace.reraise exn)
     in
     wrap_fiber (fun () ->
         let open Fiber.O in

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1214,6 +1214,8 @@ let exec (type i o) (t : (i, o) t) i = Exec.exec_dep_node (dep_node t i)
 let get_call_stack = Call_stack.get_call_stack_without_state
 
 module Invalidation = struct
+  type ('i, 'o) memo = ('i, 'o) t
+
   (* Represented as a tree mainly to get a tail-recursive execution, but being
      able to special-case empty invalidations is also useful. *)
   type t =
@@ -1249,6 +1251,11 @@ module Invalidation = struct
     | _ -> false
 
   let clear_caches = Leaf (fun () -> Caches.clear ())
+
+  let clear_cache { cache; _ } =
+    Leaf
+      (fun () ->
+        Store.iter cache ~f:(fun node -> node.last_cached_value <- None))
 end
 
 (* There are two approaches to invalidating memoization nodes. Currently, when a

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -176,6 +176,8 @@ exception Non_reproducible of exn
     memoization runs. These sets can be combined into larger sets to then be
     passed to [reset]. *)
 module Invalidation : sig
+  type ('input, 'output) memo = ('input, 'output) t
+
   type t
 
   val empty : t
@@ -184,7 +186,7 @@ module Invalidation : sig
 
   val is_empty : t -> bool
 
-  (** Indicates that memoization tables should be cleared. We use it if
+  (** Indicates that all memoization tables should be cleared. We use it if
       incremental mode is not enabled.
 
       Bug: this is not sufficient to guarantee full recomputation because it
@@ -192,6 +194,9 @@ module Invalidation : sig
       node (via a [lazy_] or [cell] call), then that's going to keep its
       potentially stale value. *)
   val clear_caches : t
+
+  (** Like [clear_caches] but only clears the cache of a given [memo] table. *)
+  val clear_cache : _ memo -> t
 end
 
 (** Notify the memoization system that the build system has restarted. This
@@ -229,6 +234,8 @@ module Store : sig
     val set : 'a t -> key -> 'a -> unit
 
     val find : 'a t -> key -> 'a option
+
+    val iter : 'a t -> f:('a -> unit) -> unit
   end
 end
 

--- a/src/memo/store.ml
+++ b/src/memo/store.ml
@@ -18,6 +18,8 @@ let make (type k v) (module S : Store_intf.S with type key = k) : (k, v) t =
     let find = S.find
 
     let clear = S.clear
+
+    let iter = S.iter
   end)
 
 let clear (type k v) ((module S) : (k, v) t) = S.clear S.store
@@ -26,6 +28,9 @@ let set (type k v) ((module S) : (k, v) t) (k : k) (v : v) = S.set S.store k v
 
 let find (type k v) ((module S) : (k, v) t) (k : k) : v option =
   S.find S.store k
+
+let iter (type k v) ((module S) : (k, v) t) ~(f : v -> unit) : unit =
+  S.iter S.store ~f
 
 let of_table (type k v) (table : (k, v) Table.t) : (k, v) t =
   (module struct
@@ -42,4 +47,6 @@ let of_table (type k v) (table : (k, v) Table.t) : (k, v) t =
     let find = Table.find
 
     let set = Table.set
+
+    let iter = Table.iter
   end)

--- a/src/memo/store.mli
+++ b/src/memo/store.mli
@@ -10,4 +10,6 @@ val clear : ('a, 'b) t -> unit
 
 val find : ('a, 'b) t -> 'a -> 'b option
 
+val iter : ('a, 'b) t -> f:('b -> unit) -> unit
+
 val of_table : ('a, 'b) Table.t -> ('a, 'b) t

--- a/src/memo/store_intf.ml
+++ b/src/memo/store_intf.ml
@@ -18,6 +18,8 @@ module type S = sig
   val set : 'a t -> key -> 'a -> unit
 
   val find : 'a t -> key -> 'a option
+
+  val iter : 'a t -> f:('a -> unit) -> unit
 end
 
 module type Instance = sig
@@ -32,6 +34,8 @@ module type Instance = sig
   val set : t -> key -> value -> unit
 
   val find : t -> key -> value option
+
+  val iter : t -> f:(value -> unit) -> unit
 
   val store : t
 end


### PR DESCRIPTION
We'd like to implement an RPC that makes it possible to "nudge" Dune to restart the build assuming that all files accesses need to be redone and all errors recomputed. Specifically, this PR adds:

* `Memo.Invalidation.clear_cache` to make it possible to invalidate a whole memoization table, such as `Fs_memo.memo`.
* `Build_system.error_cell` which is a dependency of all actions that raised errors: by invalidating this cell, we'll force Dune to rerun these actions.

There may be a slight performance cost because I moved the `Loc.is_none loc` check inside `Fiber.with_error_handler` to avoid wrapping the resulting fiber into another `Fiber.with_error_handler`. This seems acceptable.