### PR TITLE
Fix a bug in [Memo.clear_caches]

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -737,13 +737,12 @@ end = struct
     | true -> invalidation
     | false ->
       (* In this mode, we do not assume that all file system dependencies are
-         declared correctly and therefore conservatively require a rebuild. *)
-      (* The fact that the [events] list is non-empty justifies clearing the
+         declared correctly and therefore conservatively require a rebuild.
+
+         The fact that the [events] list is non-empty justifies clearing the
          caches. *)
       let (_ : _ Nonempty_list.t) = events in
-      (* Since [clear_caches] is not sufficient to guarantee invalidation, we
-         pay attention to [invalidation] too, for good measure *)
-      Memo.Invalidation.combine Memo.Invalidation.clear_caches invalidation
+      Memo.Invalidation.clear_caches
 
   (** This function is the heart of the scheduler. It makes progress in
       executing fibers by doing the following:

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -186,17 +186,12 @@ module Invalidation : sig
 
   val is_empty : t -> bool
 
-  (** Indicates that all memoization tables should be cleared. We use it if
-      incremental mode is not enabled.
-
-      Bug: this is not sufficient to guarantee full recomputation because it
-      does not invalidate individual nodes, only tables, so if you hold on to a
-      node (via a [lazy_] or [cell] call), then that's going to keep its
-      potentially stale value. *)
+  (** Clear all memoization tables. We use it if the incremental mode is not
+      enabled. *)
   val clear_caches : t
 
-  (** Like [clear_caches] but only clears the cache of a given [memo] table. *)
-  val clear_cache : _ memo -> t
+  (** Invalidate all computations stored in a given [memo] table. *)
+  val invalidate_cache : _ memo -> t
 end
 
 (** Notify the memoization system that the build system has restarted. This

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -385,7 +385,7 @@ let upgrade () =
     if !v1_updates && not last then (
       (* Run the upgrader again to update new v1 projects to v2 No more than one
          additional upgrade should be needed *)
-      (* We reset thje memoization as a simple way to refresh the Source_tree *)
+      (* We reset memoization tables as a simple way to refresh the Source_tree *)
       Memo.reset Memo.Invalidation.clear_caches;
       aux true
     ) else if !v2_updates then (

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1799,7 +1799,7 @@ let%expect_test "Test Memo.clear_cache" =
   |}];
   print_perf_counters ();
   [%expect {| 4/4 computed/total nodes, 2/2 traversed/total edges |}];
-  let invalidation = Memo.Invalidation.clear_cache add_one in
+  let invalidation = Memo.Invalidation.invalidate_cache add_one in
   Memo.reset invalidation;
   evaluate_and_print add_one 1;
   evaluate_and_print add_one 2;


### PR DESCRIPTION
Building on `Store.iter` introduced in #4719, we use a more principled approach when clearing Memo caches: before dropping all of their contents, we traverse each table and invalidate the contained nodes. This makes sure that nodes that we hold on to via `lazy_` or `cell` references are invalidated too.