### PR TITLE
[coq] Default for mode vo/native according to coqc configuration

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1762,9 +1762,8 @@ The stanza will build all ``.v`` files on the given directory. The semantics of 
   native compute is **experimental**, and requires Coq >= 8.12.1;
   moreover, depending libraries *must* be built with ``(mode native)``
   too for this to work; also Coq must be configured to support native
-  compilation. Note that Dune will explicitly disable output of native
-  compilation objects when ``(mode vo)`` even if the default Coq's
-  configure flag enabled it. This will be improved in the future.
+  compilation. When no value is given, choose default according to
+  Coq's configure flags (as retrieved by ``coqc -config``).
 
 Recursive qualification of modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/dune_rules/coq_stanza.ml
+++ b/src/dune_rules/coq_stanza.ml
@@ -43,6 +43,11 @@ module Buildable = struct
       let default =
         if version < (0, 3) then
           Coq_mode.Legacy
+        else if
+          Unix.system "coqc -config | grep -q \"NATIVE_COMPILER_DEFAULT=yes\""
+          = Unix.WEXITED 0
+        then
+          Coq_mode.Native
         else
           Coq_mode.VoOnly
       in


### PR DESCRIPTION
This is probably not perfect but is already making dune work with the coq-native OPAM package.
