### PR TITLE
Report interrupt/fail events to RPC

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -78,6 +78,8 @@ module Handler : sig
   type event =
     | Start  (** New build started *)
     | Finish  (** Build finished successfully *)
+    | Fail
+    | Interrupt
 
   type error =
     | Add of Error.t  (** Error encountered while building *)

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -351,6 +351,8 @@ let build_event t (event : Build_system.Handler.event) =
     match event with
     | Start -> Build.Event.Start
     | Finish -> Finish
+    | Interrupt -> Interrupt
+    | Fail -> Fail
   in
   task t (fun () ->
       Subscribers.notify t.subscribers Build_progress ~f:(fun session ->


### PR DESCRIPTION
When a build is interrupted by cancellation or an error, report that
status to RPC

@aalekseyev I tried doing it via the scheduler handler, but it's not so easy
because the scheduler's handler doesn't allow for fiber operations. To
workaround this, I imagine that I'd need some sort of a queue with non blocking
`push`. It's a bit too complicated for this simple thing, so I just went back to
the hack. We can always revisit later.