### PR TITLE
fix thread leak in --wait mode

### DIFF
--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -41,7 +41,11 @@ let retry_loop once =
       | Some s -> Scheduler.Worker.stop s);
       Fiber.return result
     | None ->
-      let* sleeper = Scheduler.Worker.create () in
+      let* sleeper =
+        match sleeper with
+        | None -> Scheduler.Worker.create ()
+        | Some sleeper -> Fiber.return sleeper
+      in
       let* () =
         Scheduler.Worker.task_exn sleeper ~f:(fun () -> Unix.sleepf 0.2)
       in


### PR DESCRIPTION
Prevent `dune rpc init --wait` from leaking threads by only calling `Scheduler.Worker.create ()` if there isn't currently a sleeping poll thread.

Signed-off-by: Cameron Wong <cwong@janestreet.com>