### PR TITLE
Fix error message for unknown aliases, add tests

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1158,7 +1158,7 @@ let get_alias_definition alias =
     let open Pp.O in
     let+ loc = Rule_fn.loc () in
     User_error.raise ?loc
-      [ Pp.text "No rule found for alias " ++ Alias.describe alias ]
+      [ Pp.text "No rule found for " ++ Alias.describe alias ]
   | Some x -> Memo.Build.return x
 
 type rule_execution_result =

--- a/test/blackbox-tests/test-cases/aliases.t/dune
+++ b/test/blackbox-tests/test-cases/aliases.t/dune
@@ -5,3 +5,7 @@
 (alias
  (name everywhere)
  (deps (alias_rec x)))
+
+(alias
+ (name alias-depending-on-unknown-alias)
+ (deps (alias unknown-alias)))

--- a/test/blackbox-tests/test-cases/aliases.t/run.t
+++ b/test/blackbox-tests/test-cases/aliases.t/run.t
@@ -18,3 +18,15 @@
   $ dune build @truc/x
   Error: Don't know about directory truc specified on the command line!
   [1]
+
+Test error messages for unknown aliases
+
+  $ dune build @unknown-alias
+  Error: Alias "unknown-alias" specified on the command line is empty.
+  It is not defined in . or any of its descendants.
+  [1]
+
+  $ dune build @alias-depending-on-unknown-alias
+  Error: No rule found for alias unknown-alias
+  -> required by alias alias-depending-on-unknown-alias in dune:9
+  [1]


### PR DESCRIPTION
I noticed that Dune can produce error messages like "Error: No rule found for alias alias foo" (with duplicated word "alias"). This PR fixes the duplication and adds some tests.

