### PR TITLE
Path.Local: backslashes are not canonical on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -166,6 +166,9 @@ Unreleased
 
 - Handle renaming of `coq.kernel` library to `coq-core.kernel` in Coq 8.14 (#4713, @proux01)
 
+- Fix generation of merlin configuration when using `(include_subdirs
+  unqualified)` on Windows (#4745, @nojb)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -302,6 +302,10 @@ end = struct
       User_error.raise ?loc:error_loc
         [ Pp.textf "path outside the workspace: %s from %s" path (to_string t) ]
 
+  (* Check whether a path is in canonical form: no '.' or '..' components, no
+     repeated '/' components, no backslashes '\\' (on Windows only), and not
+     ending in a slash '/'. *)
+
   let is_canonicalized =
     let rec before_slash s i =
       if i < 0 then

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -310,6 +310,7 @@ end = struct
         match s.[i] with
         | '/' -> false
         | '.' -> before_dot_slash s (i - 1)
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     and before_dot_slash s i =
       if i < 0 then
@@ -318,6 +319,7 @@ end = struct
         match s.[i] with
         | '/' -> false
         | '.' -> before_dot_dot_slash s (i - 1)
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     and before_dot_dot_slash s i =
       if i < 0 then
@@ -325,6 +327,7 @@ end = struct
       else
         match s.[i] with
         | '/' -> false
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     and in_component s i =
       if i < 0 then
@@ -332,6 +335,7 @@ end = struct
       else
         match s.[i] with
         | '/' -> before_slash s (i - 1)
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     in
     fun s ->


### PR DESCRIPTION
Currently, `Path.Local_gen.parse_string_exn` has a fast path for when the argument is already "canonical", see
https://github.com/ocaml/dune/blob/26f5e57d1aef71f476a6dc40990b9d6a517f7849/otherlibs/stdune-unstable/path.ml#L341-L347

The function `is_canonicalized` checks a number of conditions such as whether there are two slashes in a row, etc. However, I think on Windows it should also check for the presence of backslashes since these are not canonical (a value of type `Path.Local.t` is represented with forward slashes only).

This PR should fix #4717 which is blocking the use of `merlin` on Windows when using `(include_subdirs unqualified)`. It would be fantastic if we could get this in 2.9.

Fixes #4717 