### PR TITLE
[coq] Preliminary support for split native compilation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -177,6 +177,9 @@ Unreleased
   new `(subst <disable|enable>)` stanza to the `dune-project` file.
   (#4864, @kit-ty-kate)
 
+- Support Coq's 8.14 standalone native compiler mode `coqnative` (#4750,
+  @ejgallego @ppedrot @Zimmi48)
+
 2.9.1 (07/09/2021)
 ------------------
 
@@ -193,7 +196,6 @@ Unreleased
   (#4860, @bobot)
 
 2.9.0 (29/06/2021)
-------------------
 
 - Add `(enabled_if ...)` to `(mdx ...)` (#4434, @emillon)
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1711,6 +1711,8 @@ The supported Coq language versions are:
 - ``0.1``: basic Coq theory support,
 - ``0.2``: support for the ``theories`` field, and composition of theories in the same scope,
 - ``0.3``: support for ``(mode native)``, requires Coq >= 8.10 (and dune >= 2.9 for Coq >= 8.14).
+  This mode is deprecated and we strongly recommend native users to move to version ``0.4``
+- ``0.4``: reworked ``(mode native)`` using the standalone Coq native compiler, requires Coq >= 8.14 and dune >= 3.0.
 
 Guarantees with respect to stability are not provided yet,
 however, as implementation of features progresses, we hope to reach
@@ -1773,18 +1775,26 @@ The stanza will build all ``.v`` files on the given directory. The semantics of 
   composition with the Coq's standard library is supported, but in
   this case the ``Coq`` prefix will be made available in a qualified
   way. Since Coq's lang version ``0.2``.
-- you can enable the production of Coq's native compiler object files
-  by setting ``<coq_native_mode>`` to ``native``, this will pass
-  ``-native-compiler on`` to Coq and install the corresponding object
-  files under ``.coq-native`` when in ``release`` profile. The regular
-  ``dev`` profile will skip native compilation to make the build
-  faster. Since Coq's lang version ``0.3``. Note that the support for
-  native compute is **experimental**, and requires Coq >= 8.12.1;
-  moreover, depending libraries *must* be built with ``(mode native)``
-  too for this to work; also Coq must be configured to support native
-  compilation. Note that Dune will explicitly disable output of native
-  compilation objects when ``(mode vo)`` even if the default Coq's
-  configure flag enabled it. This will be improved in the future.
+
+- you can control the production of Coq's native compiler object files
+  by setting ``<coq_native_mode>`` to ``native`` [the default] or to
+  ``vo``, to disable the rules relative to Coq native objects.
+
+  By default, Dune uses the ``coqnative`` binary introduced in Coq
+  8.14 and will setup the rules for the compilation and install of
+  native objects when using the ``release`` Dune profile. This can be
+  tweaked using the ``profile`` field, to enable such rules for
+  different profiles, for example ``(mode (native (profile dev
+  release)))`` will enable the rules for the dev profile too.
+
+  Additionally, Dune provides support for installing the native object
+  files to a different package; by default, Dune will place the Coq
+  native object files in the main package for the corresponding
+  ``(coq.theory ...)`` stanza, but users can override that to provide
+  split compilation using the ``package`` field; example, using:
+  ``(mode (native (package coq-bar-native)))`` will allow users to use
+  ``dune -p coq-bar`` and ``dune -p coq-bar-native`` to build the
+  native files separately, if so desired.
 
 Recursive qualification of modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/dune_rules/coq_lib.mli
+++ b/src/dune_rules/coq_lib.mli
@@ -43,5 +43,18 @@ module DB : sig
 
   val requires_for_user_written :
     t -> (Loc.t * Coq_lib_name.t) list -> lib list Or_exn.t
+
+  (** Reverse map from source names to a matching lib, plus the matching suffix;
+      this is only required because coqdep doesn't handle native dependencies,
+      so for a dependency [path/bar/foo.vo] we must correctly translate it to
+      its mangled Coq native form, which requires locating the library which a
+      source does belong to. The current matching function does return a triple
+      [lib,
+     prefix, name] for a given input path, or raises if not found.
+
+      Note that this may be useful in the future if we are able to implement a
+      [-modules] option in coqdep, so we could do the resolution
+      [file -> module] ourselves. *)
+  val module_of_source_file : t -> Path.Build.t -> lib * string list * string
 end
 with type lib := t

--- a/src/dune_rules/coq_mode.ml
+++ b/src/dune_rules/coq_mode.ml
@@ -11,7 +11,7 @@ type t =
   | VoOnly
   | Native
   | Split of
-      { package : string option
+      { package : Dune_engine.Package.t option
       ; profile : string list
       }
 
@@ -25,7 +25,7 @@ let decode_v04 =
   let open Dune_lang.Decoder in
   let native =
     fields
-      (let+ package = field_o "package" string
+      (let+ package = field_o "package" Stanza_common.Pkg.decode
        and+ profile =
          field ~default:default_profile "profile" (repeat string)
        in

--- a/src/dune_rules/coq_mode.ml
+++ b/src/dune_rules/coq_mode.ml
@@ -10,5 +10,25 @@ type t =
   | Legacy
   | VoOnly
   | Native
+  | Split of
+      { package : string option
+      ; profile : string list
+      }
 
-let decode = Dune_lang.Decoder.(enum [ ("vo", VoOnly); ("native", Native) ])
+let default_profile = [ "release" ]
+
+let default = Split { package = None; profile = default_profile }
+
+let decode_v03 = Dune_lang.Decoder.(enum [ ("vo", VoOnly); ("native", Native) ])
+
+let decode_v04 =
+  let open Dune_lang.Decoder in
+  let native =
+    fields
+      (let+ package = field_o "package" string
+       and+ profile =
+         field ~default:default_profile "profile" (repeat string)
+       in
+       Split { package; profile })
+  in
+  sum [ ("vo", return VoOnly); ("native", native) ]

--- a/src/dune_rules/coq_mode.mli
+++ b/src/dune_rules/coq_mode.mli
@@ -10,5 +10,14 @@ type t =
   | Legacy
   | VoOnly
   | Native
+  | Split of
+      { package : string option
+      ; profile : string list
+      }
 
-val decode : t Dune_lang.Decoder.t
+val default : t
+
+(* We provide two different decoders depending on the Coq language syntax *)
+val decode_v03 : t Dune_lang.Decoder.t
+
+val decode_v04 : t Dune_lang.Decoder.t

--- a/src/dune_rules/coq_mode.mli
+++ b/src/dune_rules/coq_mode.mli
@@ -11,7 +11,7 @@ type t =
   | VoOnly
   | Native
   | Split of
-      { package : string option
+      { package : Dune_engine.Package.t option
       ; profile : string list
       }
 

--- a/src/dune_rules/coq_module.mli
+++ b/src/dune_rules/coq_module.mli
@@ -46,8 +46,11 @@ type obj_files_mode =
   | Build
   | Install
 
-(** This returns a list of pairs [(obj_file, install_path)] due to native files
-    having a different install location *)
+(** [obj_files t wrapper_name mode obj_dir obj_files_mode] returns the list of
+    object files produced by a [coqc] invocation.
+
+    Note that This returns a list of pairs [(obj_file, install_path)] due to
+    native files having a different install / build location *)
 val obj_files :
      t
   -> wrapper_name:string
@@ -55,6 +58,39 @@ val obj_files :
   -> obj_dir:Path.Build.t
   -> obj_files_mode:obj_files_mode
   -> (Path.Build.t * string) list
+
+(** [obj_file t] returns just the .vo file of a module, this is the input to the
+    standalone Coq native compiler; we should likely refactor this to pass the
+    kind of object to obj_files as it was done some time ago by Rudi *)
+val vo_obj_file : t -> obj_dir:Path.Build.t -> Path.Build.t
+
+(** [native_obj_files] is the equivalent of [obj_files] but for the new
+    [coqnative] separate Coq native compiler, it is used in the setup of the
+    separate rules. *)
+val native_obj_files :
+     t
+  -> wrapper_name:string
+  -> obj_dir:Path.Build.t
+  -> (Path.Build.t * string) list
+
+(** [native_mangle_filename ~wrapper_name ~prefix ~name ~ext] will generate a
+    mangled Coq native module file name from its arguments, determining a Coq
+    module. Coq's native compiler needs to mangle filenames for a module
+    [bar/foo.vo] bound to a [wrapper_name] [baz] to [NBaz_Bar_Foo.cmxs] to
+    prevent collisions, as the OCaml compiler doesn't support encoding hiearchy
+    of modules using the filesystem. We should eventually improve the clients of
+    this API so we can just pass here a [Coq_module.t] *)
+val native_mangle_filename :
+     wrapper_name:string
+  -> prefix:string list
+  -> name:string
+  -> obj_dir:Path.Build.t
+  -> ext:string
+  -> Path.Build.t
+
+(** [vo_to_native file ~ext] will transform a file of the form , note we need a
+    reverse lookup from .vo file to Coq module *)
+(* val vo_to_native : Path.Build.t -> ext:string -> Path.Build.t *)
 
 val to_dyn : t -> Dyn.t
 

--- a/src/dune_rules/coq_rules.mli
+++ b/src/dune_rules/coq_rules.mli
@@ -17,11 +17,14 @@ val setup_rules :
   -> Theory.t
   -> Action.t Action_builder.With_targets.t list Memo.Build.t
 
+(* We allos to override the install package for some files, for example, those
+   coming from the Coq native compiler *)
 val install_rules :
      sctx:Super_context.t
   -> dir:Path.Build.t
   -> Theory.t
-  -> (Loc.t option * Path.Build.t Install.Entry.t) list Memo.Build.t
+  -> (Package.t * (Loc.t option * Path.Build.t Install.Entry.t)) list
+     Memo.Build.t
 
 val coqpp_rules :
      sctx:Super_context.t

--- a/src/dune_rules/coq_stanza.ml
+++ b/src/dune_rules/coq_stanza.ml
@@ -24,6 +24,7 @@ let coq_syntax =
     [ ((0, 1), `Since (1, 9))
     ; ((0, 2), `Since (2, 5))
     ; ((0, 3), `Since (2, 8))
+    ; ((0, 4), `Since (3, 0))
     ]
 
 module Buildable = struct
@@ -41,14 +42,20 @@ module Buildable = struct
     and+ mode =
       let* version = Dune_lang.Syntax.get_exn coq_syntax in
       let default =
-        if version < (0, 3) then
-          Coq_mode.Legacy
+        if version < (0, 4) then
+          if version < (0, 3) then
+            Coq_mode.Legacy
+          else
+            Coq_mode.VoOnly
         else
-          Coq_mode.VoOnly
+          Coq_mode.default
       in
       located
         (field "mode" ~default
-           (Dune_lang.Syntax.since coq_syntax (0, 3) >>> Coq_mode.decode))
+           (if version < (0, 4) then
+             Dune_lang.Syntax.since coq_syntax (0, 3) >>> Coq_mode.decode_v03
+           else
+             Dune_lang.Syntax.since coq_syntax (0, 4) >>> Coq_mode.decode_v04))
     and+ libraries =
       field "libraries" (repeat (located Lib_name.decode)) ~default:[]
     and+ theories =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -296,7 +296,7 @@ end = struct
         >>| List.map ~f:(fun entry -> (name, entry))
       | Coq_stanza.Theory.T coqlib ->
         Coq_rules.install_rules ~sctx ~dir coqlib
-        >>| List.map ~f:(fun entry -> name, entry)
+        >>| List.map ~f:(fun (pkg, entry) -> (Package.name pkg, entry))
       | Dune_file.Documentation d ->
         let* dc = Dir_contents.get sctx ~dir in
         let+ mlds = Dir_contents.mlds dc d in

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/src_a/dune
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/src_a/dune
@@ -2,6 +2,6 @@
  (public_name cplugin.ml_plugin_a)
  (name ml_plugin_a)
  (flags :standard -rectypes)
- (libraries coq.plugins.ltac))
+ (libraries coq-core.plugins.ltac))
 
 (coq.pp (modules gram))

--- a/test/blackbox-tests/test-cases/coq/github3624.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/github3624.t/run.t
@@ -12,5 +12,5 @@ that the error message is good when the coq extension is not enabled.
   1 | (coq.theory
   2 |  (name foo))
   Error: 'coq.theory' is available only when coq is enabled in the dune-project
-  file. You must enable it using (using coq 0.3) in your dune-project file.
+  file. You must enable it using (using coq 0.4) in your dune-project file.
   [1]

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/src_a/dune
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/src_a/dune
@@ -2,6 +2,6 @@
  (public_name ml_lib.ml_plugin_a)
  (name ml_plugin_a)
  (flags :standard -rectypes)
- (libraries coq.plugins.ltac))
+ (libraries coq-core.plugins.ltac))
 
 (coq.pp (modules gram))

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/bar/bar.v
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/bar/bar.v
@@ -1,0 +1,3 @@
+From foo Require Import foo.
+
+Definition mynum (i : mynat) := 3.

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/bar/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/bar/dune
@@ -1,0 +1,9 @@
+(coq.theory
+ (name bar)
+ (package base)
+ (mode
+  (native
+   (package base-native)))
+ (theories foo)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/baz/a/a.v
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/baz/a/a.v
@@ -1,0 +1,1 @@
+Definition aa := 4.

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/baz/b/uu.v
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/baz/b/uu.v
@@ -1,0 +1,1 @@
+Definition uu := 5.

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/baz/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/baz/dune
@@ -1,0 +1,6 @@
+(coq.theory
+ (name moo.baz)
+ (package base)
+ (theories foo bar))
+
+(include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/dune
@@ -1,0 +1,6 @@
+(rule
+ (alias default)
+ (action
+  (progn
+   (echo "%{read:base.install}")
+   (echo "%{read:base-native.install}"))))

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/dune-project
@@ -1,0 +1,10 @@
+(lang dune 3.0)
+(using coq 0.4)
+
+(package
+ (name base))
+
+(package
+ (name base-native)
+ (depends
+  (base (= :version))))

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/foo/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/foo/dune
@@ -1,0 +1,6 @@
+(coq.theory
+ (name foo)
+ (package base)
+ (mode native)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/foo/foo.v
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/foo/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/native-split-package.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-split-package.t/run.t
@@ -1,0 +1,43 @@
+  $ dune build --profile=release --display short --debug-dependency-path @all
+        coqdep bar/bar.v.d
+        coqdep foo/foo.v.d
+        coqdep baz/a/a.v.d
+        coqdep baz/b/uu.v.d
+          coqc foo/.foo.aux,foo/foo.{glob,vo}
+          coqc baz/a/.a.aux,baz/a/a.{glob,vo}
+          coqc baz/b/.uu.aux,baz/b/uu.{glob,vo}
+     coqnative foo/Nfoo_foo.{cmi,cmxs}
+          coqc bar/.bar.aux,bar/bar.{glob,vo}
+     coqnative baz/a/Nmoo_baz_a_a.{cmi,cmxs}
+     coqnative baz/b/Nmoo_baz_b_uu.{cmi,cmxs}
+     coqnative bar/Nbar_bar.{cmi,cmxs}
+
+  $ dune build --profile=release --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/bar/bar.v" {"coq/user-contrib/bar/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/bar/bar.vo" {"coq/user-contrib/bar/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.v" {"coq/user-contrib/foo/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.vo" {"coq/user-contrib/foo/foo.vo"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmi" {"coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmi"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmxs" {"coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/a.v" {"coq/user-contrib/moo/baz/a/a.v"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/a.vo" {"coq/user-contrib/moo/baz/a/a.vo"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmi" {"coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmi"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmxs" {"coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/uu.v" {"coq/user-contrib/moo/baz/b/uu.v"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/uu.vo" {"coq/user-contrib/moo/baz/b/uu.vo"}
+  ]
+  lib: [
+    "_build/install/default/lib/base-native/META"
+    "_build/install/default/lib/base-native/dune-package"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmi" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmi"}
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs"}
+  ]

--- a/test/blackbox-tests/test-cases/coq/native-split-profile.t/bar/bar.v
+++ b/test/blackbox-tests/test-cases/coq/native-split-profile.t/bar/bar.v
@@ -1,0 +1,3 @@
+From foo Require Import foo.
+
+Definition mynum (i : mynat) := 3.

--- a/test/blackbox-tests/test-cases/coq/native-split-profile.t/bar/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split-profile.t/bar/dune
@@ -1,0 +1,9 @@
+(coq.theory
+ (name bar)
+ (package base)
+ (mode
+  (native
+   (profile custom release)))
+ (theories foo)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-split-profile.t/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split-profile.t/dune
@@ -1,0 +1,5 @@
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))
+
+(env (custom (coq (flags -type-in-type))))

--- a/test/blackbox-tests/test-cases/coq/native-split-profile.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/native-split-profile.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.0)
+(using coq 0.4)

--- a/test/blackbox-tests/test-cases/coq/native-split-profile.t/foo/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split-profile.t/foo/dune
@@ -1,0 +1,8 @@
+(coq.theory
+ (name foo)
+ (package base)
+ (mode
+  (native
+   (profile dev custom release)))
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-split-profile.t/foo/foo.v
+++ b/test/blackbox-tests/test-cases/coq/native-split-profile.t/foo/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/native-split-profile.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-split-profile.t/run.t
@@ -1,0 +1,35 @@
+  $ dune build --profile=dev --display short --debug-dependency-path @all
+        coqdep bar/bar.v.d
+        coqdep foo/foo.v.d
+          coqc foo/.foo.aux,foo/foo.{glob,vo}
+     coqnative foo/Nfoo_foo.{cmi,cmxs}
+          coqc bar/.bar.aux,bar/bar.{glob,vo}
+
+  $ dune build --profile=custom --display short --debug-dependency-path @all
+          coqc foo/.foo.aux,foo/foo.{glob,vo}
+     coqnative foo/Nfoo_foo.{cmi,cmxs}
+          coqc bar/.bar.aux,bar/bar.{glob,vo}
+     coqnative bar/Nbar_bar.{cmi,cmxs}
+
+  $ dune build --profile=release --display short --debug-dependency-path @all
+          coqc foo/.foo.aux,foo/foo.{glob,vo}
+     coqnative foo/Nfoo_foo.{cmi,cmxs}
+          coqc bar/.bar.aux,bar/bar.{glob,vo}
+     coqnative bar/Nbar_bar.{cmi,cmxs}
+
+  $ dune build --profile=release --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+    "_build/install/default/lib/base/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmi" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmi"}
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/bar/bar.v" {"coq/user-contrib/bar/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/bar/bar.vo" {"coq/user-contrib/bar/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.v" {"coq/user-contrib/foo/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.vo" {"coq/user-contrib/foo/foo.vo"}
+  ]

--- a/test/blackbox-tests/test-cases/coq/native-split.t/bar/bar.v
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/bar/bar.v
@@ -1,0 +1,3 @@
+From foo Require Import foo.
+
+Definition mynum (i : mynat) := 3.

--- a/test/blackbox-tests/test-cases/coq/native-split.t/bar/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/bar/dune
@@ -1,0 +1,7 @@
+(coq.theory
+ (name bar)
+ (package base)
+ (mode native)
+ (theories foo)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-split.t/baz/a/a.v
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/baz/a/a.v
@@ -1,0 +1,1 @@
+Definition aa := 4.

--- a/test/blackbox-tests/test-cases/coq/native-split.t/baz/b/uu.v
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/baz/b/uu.v
@@ -1,0 +1,1 @@
+Definition uu := 5.

--- a/test/blackbox-tests/test-cases/coq/native-split.t/baz/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/baz/dune
@@ -1,0 +1,6 @@
+(coq.theory
+ (name moo.baz)
+ (package base)
+ (theories foo bar))
+
+(include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/coq/native-split.t/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/dune
@@ -1,0 +1,3 @@
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))

--- a/test/blackbox-tests/test-cases/coq/native-split.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.0)
+(using coq 0.4)

--- a/test/blackbox-tests/test-cases/coq/native-split.t/foo/dune
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/foo/dune
@@ -1,0 +1,6 @@
+(coq.theory
+ (name foo)
+ (package base)
+ (mode native)
+ (modules :standard)
+ (synopsis "Test Coq library"))

--- a/test/blackbox-tests/test-cases/coq/native-split.t/foo/foo.v
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/foo/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/native-split.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/run.t
@@ -1,0 +1,38 @@
+  $ dune build --profile=release --display short --debug-dependency-path @all
+        coqdep bar/bar.v.d
+        coqdep foo/foo.v.d
+        coqdep baz/a/a.v.d
+        coqdep baz/b/uu.v.d
+          coqc foo/.foo.aux,foo/foo.{glob,vo}
+          coqc baz/a/.a.aux,baz/a/a.{glob,vo}
+          coqc baz/b/.uu.aux,baz/b/uu.{glob,vo}
+     coqnative foo/Nfoo_foo.{cmi,cmxs}
+          coqc bar/.bar.aux,bar/bar.{glob,vo}
+     coqnative baz/a/Nmoo_baz_a_a.{cmi,cmxs}
+     coqnative baz/b/Nmoo_baz_b_uu.{cmi,cmxs}
+     coqnative bar/Nbar_bar.{cmi,cmxs}
+
+  $ dune build --profile=release --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+    "_build/install/default/lib/base/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmi" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmi"}
+    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/bar/bar.v" {"coq/user-contrib/bar/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/bar/bar.vo" {"coq/user-contrib/bar/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi"}
+    "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.v" {"coq/user-contrib/foo/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/foo/foo.vo" {"coq/user-contrib/foo/foo.vo"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmi" {"coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmi"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmxs" {"coq/user-contrib/moo/baz/a/.coq-native/Nmoo_baz_a_a.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/a.v" {"coq/user-contrib/moo/baz/a/a.v"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/a/a.vo" {"coq/user-contrib/moo/baz/a/a.vo"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmi" {"coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmi"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmxs" {"coq/user-contrib/moo/baz/b/.coq-native/Nmoo_baz_b_uu.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/uu.v" {"coq/user-contrib/moo/baz/b/uu.v"}
+    "_build/install/default/lib/coq/user-contrib/moo/baz/b/uu.vo" {"coq/user-contrib/moo/baz/b/uu.vo"}
+  ]


### PR DESCRIPTION
Coq 8.14 can generate native files independently from .vo file
generation by using a new `coqnative` compiler, which will do the `.vo
-> .cmxs` translation.

This allows Dune to have a simpler rule setup, as it is always
possible to rely on coqnative to compile native files, as opposed to
before where native file generation was controlled by a Coq-level
configure flag.

The new rule setup is enabled for `(lang coq 0.4)`, and we provide a
couple of configuration options in the `mode` field via a couple of
optional fields:

```lisp
(coq.theory
  ...
  (mode
   (native
     (package pkg)
     (profile p1 ... pn))))
```

The first field, `(package )` allows to override the package under
which native files for the corresponding theory will be
installed. This is useful for packagers willing to split the native
compilation under a different package, given that it can be extremely
resource-intensive. The default for this setting is the same package
name.

The second field controls under which profiles Dune will setup the
native build rules; the default for this setting is `release`, so Dune
will skip Coq's native compilation when in `dev` mode.

`(mode vo)` is still accepted, in case developers would like to
completely disable native generation.
