### PR TITLE
[Scheduler] add timer mechanism

### DIFF
--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -120,7 +120,7 @@ val t : unit -> t Fiber.t
 val with_job_slot : (Config.t -> 'a Fiber.t) -> 'a Fiber.t
 
 (** Wait for the following process to terminate *)
-val wait_for_process : Pid.t -> Proc.Process_info.t Fiber.t
+val wait_for_process : ?timeout:float -> Pid.t -> Proc.Process_info.t Fiber.t
 
 val yield_if_there_are_pending_events : unit -> unit Fiber.t
 
@@ -138,3 +138,8 @@ val running_jobs_count : t -> int
 val shutdown : unit -> unit Fiber.t
 
 val inject_memo_invalidation : Memo.Invalidation.t -> unit Fiber.t
+
+(** [sleep duration] wait for [duration] to elapse. Sleepers are checked for
+    wake up at a rate of once per 0.1 seconds. So [duration] should be at least
+    this long. *)
+val sleep : float -> unit Fiber.t

--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -7,6 +7,7 @@
  (modules :standard \ vcs_tests)
  (libraries
   ocaml_config
+  spawn
   dune_tests_common
   stdune
   dune_util

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -88,7 +88,7 @@ let run ~prog ~argv =
   Unix.close stdout_w;
   Unix.close stderr_w;
   ( pid
-  , (let+ proc = Scheduler.wait_for_process (Pid.of_int pid) in
+  , (let+ proc = Scheduler.wait_for_process ~timeout:3.0 (Pid.of_int pid) in
      Unix.close stdout_i;
      Unix.close stderr_i;
      if proc.status <> Unix.WEXITED 0 then

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -1,0 +1,56 @@
+open Stdune
+open Fiber.O
+module Scheduler = Dune_engine.Scheduler
+
+let config =
+  { Scheduler.Config.concurrency = 1
+  ; display = { verbosity = Short; status_line = false }
+  ; rpc = None
+  ; stats = None
+  }
+
+let%expect_test "create and wait for timer" =
+  Scheduler.Run.go
+    ~on_event:(fun _ _ -> ())
+    config
+    (fun () ->
+      let now () = Unix.gettimeofday () in
+      let start = now () in
+      let duration = 0.2 in
+      let+ () = Scheduler.sleep duration in
+      assert (now () -. start >= duration);
+      print_endline "timer finished successfully");
+  [%expect {| timer finished successfully |}]
+
+let%expect_test "multiple timers" =
+  Scheduler.Run.go
+    ~on_event:(fun _ _ -> ())
+    config
+    (fun () ->
+      [ 0.3; 0.2; 0.1 ]
+      |> Fiber.parallel_iter ~f:(fun duration ->
+             let+ () = Scheduler.sleep duration in
+             printfn "finished %0.2f" duration));
+  [%expect {|
+    finished 0.10
+    finished 0.20
+    finished 0.30 |}]
+
+let%expect_test "run process with timeout" =
+  Scheduler.Run.go
+    ~on_event:(fun _ _ -> ())
+    config
+    (fun () ->
+      let pid =
+        let prog =
+          let path =
+            Env.get Env.initial "PATH" |> Option.value_exn |> Bin.parse_path
+          in
+          Bin.which ~path "sleep" |> Option.value_exn |> Path.to_string
+        in
+        Spawn.spawn ~prog ~argv:[ prog; "100000" ] () |> Pid.of_int
+      in
+      let+ _ = Scheduler.wait_for_process ~timeout:0.1 pid in
+      print_endline "sleep timed out");
+  [%expect {|
+    sleep timed out |}]


### PR DESCRIPTION
Allow waiting for a duration to elapse before resuming a fiber

- [x] Scheduler.sleep
- [x] Scheduler.wait_for_process_with_timeout