### PR TITLE
[2.9-backport] Path.Local: backslashes are not canonical on Windows (#4745)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@ unreleased - 2.9 branch
 
 - Add `(package ...)` to `(mdx ...)` (#4691, fixes #3756, @emillon)
 
+- Handle renaming of `coq.kernel` library to `coq-core.kernel` in Coq 8.14 (#4713, @proux01)
+
+- Fix generation of merlin configuration when using `(include_subdirs
+  unqualified)` on Windows (#4745, @nojb)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/src/stdune/path.ml
+++ b/src/stdune/path.ml
@@ -302,6 +302,10 @@ end = struct
       User_error.raise ?loc:error_loc
         [ Pp.textf "path outside the workspace: %s from %s" path (to_string t) ]
 
+  (* Check whether a path is in canonical form: no '.' or '..' components, no
+     repeated '/' components, no backslashes '\\' (on Windows only), and not
+     ending in a slash '/'. *)
+
   let is_canonicalized =
     let rec before_slash s i =
       if i < 0 then
@@ -310,6 +314,7 @@ end = struct
         match s.[i] with
         | '/' -> false
         | '.' -> before_dot_slash s (i - 1)
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     and before_dot_slash s i =
       if i < 0 then
@@ -318,6 +323,7 @@ end = struct
         match s.[i] with
         | '/' -> false
         | '.' -> before_dot_dot_slash s (i - 1)
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     and before_dot_dot_slash s i =
       if i < 0 then
@@ -325,6 +331,7 @@ end = struct
       else
         match s.[i] with
         | '/' -> false
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     and in_component s i =
       if i < 0 then
@@ -332,6 +339,7 @@ end = struct
       else
         match s.[i] with
         | '/' -> before_slash s (i - 1)
+        | '\\' when Sys.win32 -> false
         | _ -> in_component s (i - 1)
     in
     fun s ->


### PR DESCRIPTION
Backport of #4745