### PR TITLE
[RPC] always close channel after client callback

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -22,6 +22,8 @@ module V1 = struct
             and+ () = parallel_iter ls ~f in
             ()
 
+        let finalize f ~finally = Lwt.finalize f finally
+
         module Ivar = struct
           type 'a t = 'a Lwt.t * 'a Lwt.u
 

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -284,6 +284,8 @@ module V1 : sig
 
     val parallel_iter : (unit -> 'a option t) -> f:('a -> unit t) -> unit t
 
+    val finalize : (unit -> 'a t) -> finally:(unit -> unit t) -> 'a t
+
     module O : sig
       val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
 

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -325,6 +325,8 @@ module Client (Fiber : sig
 
   val parallel_iter : (unit -> 'a option t) -> f:('a -> unit t) -> unit t
 
+  val finalize : (unit -> 'a t) -> finally:(unit -> unit t) -> 'a t
+
   module O : sig
     val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
 


### PR DESCRIPTION
This requires adding a `finalize` function in the `Client` functor