### PR TITLE
Reimplement Memo cycle detection

### DIFF
--- a/src/dag/dag.ml
+++ b/src/dag/dag.ml
@@ -34,6 +34,8 @@ module Make (Value : Value) : S with type value := Value.t = struct
 
     type vertex = node
 
+    let node_id { info; _ } = info.id
+
     let new_mark g =
       let m = g.fresh_mark in
       g.fresh_mark <- g.fresh_mark + 1;

--- a/src/dag/dag.ml
+++ b/src/dag/dag.ml
@@ -1,26 +1,22 @@
 open! Stdune
 include Dag_intf
 
-module Make (Value : Value) : S with type value := Value.t = struct
+module Make (Value : Value) () : S with type value := Value.t = struct
   (* Raw_graph here should have the same complexity than the assumed interface
      on the incremental_cycles proofs, in particular [get_outgoing] should run
      in constant time. *)
   module Raw_graph = struct
     type mark = int
 
-    type t =
-      { mutable fresh_id : int
-      ; mutable fresh_mark : int
-      }
-
-    type graph = t
+    type graph = unit
 
     module Node_map = Map.Make (Int)
 
+    module Id = Id.Make ()
+
     type node_info =
-      { id : int
-      ; (* only used for printing *)
-        mutable mark : mark
+      { id : Id.t
+      ; mutable mark : mark
       ; mutable level : int
       ; mutable deps : node list
       ; mutable rev_deps : node list
@@ -36,10 +32,12 @@ module Make (Value : Value) : S with type value := Value.t = struct
 
     let node_id { info; _ } = info.id
 
-    let new_mark g =
-      let m = g.fresh_mark in
-      g.fresh_mark <- g.fresh_mark + 1;
-      m
+    let new_mark =
+      let fresh_mark = ref 0 in
+      fun () ->
+        let mark = !fresh_mark in
+        incr fresh_mark;
+        mark
 
     let vertex_eq v1 v2 = v1 == v2
 
@@ -76,18 +74,15 @@ module Make (Value : Value) : S with type value := Value.t = struct
 
   exception Cycle of node list
 
-  let create () = { fresh_id = 1; fresh_mark = 0 }
-
-  let create_node_info g =
-    let id = g.fresh_id in
-    g.fresh_id <- g.fresh_id + 1;
+  let create_node_info () =
+    let id = Id.gen () in
     { id; mark = -1; level = 1; deps = []; rev_deps = []; parent = None }
 
   (* [add_assuming_missing dag v w] creates an arc going from [v] to [w]. @raise
      Cycle if creating the arc would create a cycle. This assumes that the arc
      does not already exist. *)
-  let add_assuming_missing g v w =
-    match IC.add_edge_or_detect_cycle g v w with
+  let add_assuming_missing v w =
+    match IC.add_edge_or_detect_cycle () v w with
     | IC.EdgeAdded -> ()
     | IC.EdgeCreatesCycle compute_cycle ->
       raise
@@ -101,8 +96,8 @@ module Make (Value : Value) : S with type value := Value.t = struct
     if depth >= 20 then
       Format.fprintf fmt "..."
     else
-      Format.fprintf fmt "(%d: k=%d) (%a) [@[%a@]]" n.info.id n.info.level
-        pp_value n.data
+      Format.fprintf fmt "(%d: k=%d) (%a) [@[%a@]]" (Id.to_int n.info.id)
+        n.info.level pp_value n.data
         (pp_depth (depth + 1) pp_value
         |> Format.pp_print_list ~pp_sep:(fun fmt () ->
                Format.fprintf fmt ";@, "))

--- a/src/dag/dag.mli
+++ b/src/dag/dag.mli
@@ -16,4 +16,4 @@ module type Value = Dag_intf.Value
 
 module type S = Dag_intf.S
 
-module Make (Value : Value) : S with type value := Value.t
+module Make (Value : Value) () : S with type value := Value.t

--- a/src/dag/dag_intf.ml
+++ b/src/dag/dag_intf.ml
@@ -6,10 +6,8 @@ module type Value = sig
   type t
 end
 
+(** A DAG (Directed Acyclic Graph). *)
 module type S = sig
-  (** A DAG (Directed Acyclic Graph). *)
-  type t
-
   (** Info about a node in the DAG. *)
   type node_info
 
@@ -21,24 +19,22 @@ module type S = sig
     ; info : node_info
     }
 
-  (* CR-soon amokhov: Switch to [Id.t]. *)
-  val node_id : node -> int
+  module Id : Id.S
+
+  val node_id : node -> Id.t
 
   (** A cycle has been found while adding an arc. *)
   exception Cycle of node list
 
-  (** [create ()] creates a directed acyclic graph. *)
-  val create : unit -> t
-
   (** [create_node_info dag v] creates new node info that belongs to [dag]. *)
-  val create_node_info : t -> node_info
+  val create_node_info : unit -> node_info
 
   (** [add_assuming_missing dag v w] creates an arc going from [v] to [w]
       assuming it doesn't already exists. If the arc does exist, the behaviour
       is undefined.
 
       @raise Cycle if creating the arc would create a cycle. *)
-  val add_assuming_missing : t -> node -> node -> unit
+  val add_assuming_missing : node -> node -> unit
 
   (** Pretty print a node. *)
   val pp_node :

--- a/src/dag/dag_intf.ml
+++ b/src/dag/dag_intf.ml
@@ -21,6 +21,9 @@ module type S = sig
     ; info : node_info
     }
 
+  (* CR-soon amokhov: Switch to [Id.t]. *)
+  val node_id : node -> int
+
   (** A cycle has been found while adding an arc. *)
   exception Cycle of node list
 
@@ -31,7 +34,7 @@ module type S = sig
   val create_node_info : t -> node_info
 
   (** [add_assuming_missing dag v w] creates an arc going from [v] to [w]
-      assuming it doesn't already exists. The the arc does exist, the behaviuor
+      assuming it doesn't already exists. If the arc does exist, the behaviour
       is undefined.
 
       @raise Cycle if creating the arc would create a cycle. *)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1262,7 +1262,6 @@ end = struct
               | Failure _ -> ());
               restore_result))
     in
-    let dag_node = Stack_frame_with_state.dag_node restore_from_cache_frame in
     let compute =
       Once.create ~must_not_raise:(fun () ->
           (* We do not use [Once.force_with_blocking_check] here because cycle

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -617,7 +617,11 @@ end = struct
   type ('i, 'o) unpacked =
     { dep_node : ('i, 'o) Dep_node_without_state.t
     ; dag_node : Dag.node Lazy.t
-    ; (* CR-soon amokhov: Benchmark if it's worth switching to [Dag.Id.Table.t]. *)
+    ; (* CR-soon amokhov: Benchmark if it's worth switching to [Dag.Id.Table.t].
+         For now, I chose to use [Dag.Id.Set.t] for two reasons: (i) we don't
+         have hash sets in Stdune and using [unit] hash tables is disturbing;
+         (ii) the new cycle detection algorithm reduces the size of the DAG, so
+         [children_added_to_dag] will often be empty or small. *)
       (* CR-someday aalekseyev: This children_added_to_dag table serves dual
          purpose:
 
@@ -628,7 +632,7 @@ end = struct
          already added to the cycle detection graph
 
          Now consider that we have up to two stacks per cycle-detection DAG
-         node, so it makess a difference if something is per-dag-node or
+         node, so it makes a difference if something is per-dag-node or
          per-stack.
 
          It's clear that (1) needs to be per-cycle-detection-DAG-node, while (2)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -624,7 +624,7 @@ end = struct
       mutable deps_rev : Dep_node.packed list
     }
 
-  type t = T : ('i, 'o) unpacked -> t
+  type t = T : ('i, 'o) unpacked -> t [@@unboxed]
 
   let to_dyn (T t) = Stack_frame_without_state.to_dyn (T t.dep_node)
 
@@ -636,7 +636,6 @@ end = struct
       ; dag_node
       ; children_added_to_dag = Dag.Id.Set.empty
       }
-    [@@inline]
 
   let dep_node (T t) = Dep_node_without_state.T t.dep_node
 

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -839,7 +839,7 @@ let dump_stack () =
   let+ pp = pp_stack () in
   Console.print [ pp ]
 
-let get_cached_value_in_current_cycle (dep_node : _ Dep_node.t) =
+let get_cached_value_in_current_run (dep_node : _ Dep_node.t) =
   match dep_node.last_cached_value with
   | None -> None
   | Some cv ->
@@ -854,7 +854,7 @@ module Cached_value = struct
   let capture_deps ~deps_rev =
     if !Debug.check_invariants then
       List.iter deps_rev ~f:(function Dep_node.T dep_node ->
-          (match get_cached_value_in_current_cycle dep_node with
+          (match get_cached_value_in_current_run dep_node with
           | None ->
             let reason =
               match dep_node.last_cached_value with
@@ -1199,7 +1199,7 @@ end = struct
   and start_considering :
         'i 'o. ('i, 'o) Dep_node.t -> 'o Cached_value.t Sample_attempt.t =
    fun dep_node ->
-    match get_cached_value_in_current_cycle dep_node with
+    match get_cached_value_in_current_run dep_node with
     | Some cv -> Finished cv
     | None -> (
       match currently_considering dep_node.state with
@@ -1538,7 +1538,7 @@ module For_tests = struct
     match Store.find t.cache inp with
     | None -> None
     | Some dep_node -> (
-      match get_cached_value_in_current_cycle dep_node with
+      match get_cached_value_in_current_run dep_node with
       | None -> None
       | Some cv ->
         Some

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -664,7 +664,7 @@ module Sample_attempt = struct
     add_path_impl stack (Lazy.force dag_node)
 
   let force_and_check_for_cycles once dag_node =
-    Once.force_with_blocking_check once ~on_blocking_wait:(fun () ->
+    Once.force_with_blocking_check once ~on_blocking:(fun () ->
         add_path_to ~dag_node)
 
   (* Add a dependency on the [dep_node] from the caller, if there is one. *)

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -793,6 +793,17 @@ module Sample_attempt = struct
   include Sample_attempt0
 
   let force_and_check_for_cycles once ~dag_node =
+    (* CR-someday aalekseyev:
+       It's weird that we have to take [dag_node] as a parameter
+       here even though the stack frame itself is available in the closure that [once]
+       is holding. I think either of these would be an improvement:
+       - Make [once] aware of that [Stack_frame_with_state] instead of embedding it
+       into a closure, and extract it here
+       - Make [once] aware of the whole "cycle detection algorithm" and do everything
+       for us.
+       Once we have access to that stack frame, I think the logic in [add_path_to] will be
+       simpler (we can mark the stack frame itself as "added" instead of inferring that
+       from the table entry). *)
     Once.force_with_blocking_check once ~on_blocking:(fun () ->
         Call_stack.add_path_to ~dag_node)
 

--- a/src/memo/once.ml
+++ b/src/memo/once.ml
@@ -1,0 +1,41 @@
+open Stdune
+open Fiber.O
+
+(* CR-someday amokhov: We could introduce another variant to represent the
+   result of fiber evaluation, e.g. [Finished of 'a]. That would allow us to
+   simplify some logic in Memo, specifically, remove [Sample_attempt.t]. *)
+type 'a state =
+  | Not_forced of { must_not_raise : unit -> 'a Fiber.t }
+  | Forced of 'a Fiber.Ivar.t
+
+type 'a t = { mutable state : 'a state }
+
+(* If a given thunk does in fact raise an exception, forcing it will propagate
+   the exception to the first caller, and leave all subsequent callers stuck,
+   forever waiting for the unfilled [Ivar.t]. *)
+let create ~must_not_raise = { state = Not_forced { must_not_raise } }
+
+let force t =
+  Fiber.of_thunk (fun () ->
+      match t.state with
+      | Forced ivar -> Fiber.Ivar.read ivar
+      | Not_forced { must_not_raise } ->
+        let ivar = Fiber.Ivar.create () in
+        t.state <- Forced ivar;
+        let* result = must_not_raise () in
+        let+ () = Fiber.Ivar.fill ivar result in
+        result)
+
+let force_with_blocking_check t ~on_blocking_wait =
+  Fiber.of_thunk (fun () ->
+      match t.state with
+      | Forced ivar -> (
+        on_blocking_wait () >>= function
+        | Ok () -> Fiber.Ivar.read ivar >>| Result.ok
+        | Error _ as error -> Fiber.return error)
+      | Not_forced { must_not_raise } ->
+        let ivar = Fiber.Ivar.create () in
+        t.state <- Forced ivar;
+        let* result = must_not_raise () in
+        let+ () = Fiber.Ivar.fill ivar result in
+        Ok result)

--- a/src/memo/once.ml
+++ b/src/memo/once.ml
@@ -26,11 +26,11 @@ let force t =
         let+ () = Fiber.Ivar.fill ivar result in
         result)
 
-let force_with_blocking_check t ~on_blocking_wait =
+let force_with_blocking_check t ~on_blocking =
   Fiber.of_thunk (fun () ->
       match t.state with
       | Forced ivar -> (
-        on_blocking_wait () >>= function
+        on_blocking () >>= function
         | Ok () -> Fiber.Ivar.read ivar >>| Result.ok
         | Error _ as error -> Fiber.return error)
       | Not_forced { must_not_raise } ->

--- a/src/memo/once.mli
+++ b/src/memo/once.mli
@@ -1,0 +1,27 @@
+open Stdune
+
+(* CR-someday amokhov: We could try to encapsulate all Memo's cycle-detection
+   logic in [Once]. Creating DAG nodes and edges should be relatively simple,
+   but passing information about Memo's call stack seems a bit awkward. *)
+
+(** A fiber that can be shared but will be computed at most once. An equivalent
+    of ['a Lazy.t] but for asynchronous computations. *)
+type 'a t
+
+(** Note that side effects of the shared fiber will happen only when the fiber
+    returned by [force] is executed. *)
+val create : must_not_raise:(unit -> 'a Fiber.t) -> 'a t
+
+(** Execute a shared fiber, or block until the result becomes available if the
+    fiber is already being executed. Note that this can introduce deadlocks if
+    fibers depend on each other in a cycle. See [force_with_blocking_check] that
+    allows the caller to detect cycles and avoid such deadlocks. *)
+val force : 'a t -> 'a Fiber.t
+
+(** Like [force] but the [on_blocking_wait] argument can be used to avoid
+    deadlocks: [on_blocking_wait] will be called before blocking the caller,
+    giving it a chance to detect a cycle and return [Error] to bail out early. *)
+val force_with_blocking_check :
+     'a t
+  -> on_blocking_wait:(unit -> (unit, 'b) result Fiber.t)
+  -> ('a, 'b) result Fiber.t

--- a/src/memo/once.mli
+++ b/src/memo/once.mli
@@ -18,10 +18,10 @@ val create : must_not_raise:(unit -> 'a Fiber.t) -> 'a t
     allows the caller to detect cycles and avoid such deadlocks. *)
 val force : 'a t -> 'a Fiber.t
 
-(** Like [force] but the [on_blocking_wait] argument can be used to avoid
-    deadlocks: [on_blocking_wait] will be called before blocking the caller,
-    giving it a chance to detect a cycle and return [Error] to bail out early. *)
+(** Like [force] but the [on_blocking] argument can be used to avoid deadlocks:
+    [on_blocking] will be called before blocking the caller, giving it a chance
+    to detect a cycle and return [Error] to bail out early. *)
 val force_with_blocking_check :
      'a t
-  -> on_blocking_wait:(unit -> (unit, 'b) result Fiber.t)
+  -> on_blocking:(unit -> (unit, 'b) result Fiber.t)
   -> ('a, 'b) result Fiber.t

--- a/test/expect-tests/dag/dag_tests.ml
+++ b/test/expect-tests/dag/dag_tests.ml
@@ -5,65 +5,52 @@ let () = init ()
 
 type mynode = { name : string }
 
-module DagF = Dag
-
-module Dag = struct
-  include Dag.Make (struct
-    type t = mynode
-  end)
-
-  let node dag data = { info = create_node_info dag; data }
-end
-
-open Dag
-
-let dag = Dag.create ()
-
-let node = Dag.node dag { name = "root" }
-
-let node11 = Dag.node dag { name = "child 1 1" }
-
-let node12 = Dag.node dag { name = "child 1 2" }
-
-let node21 = Dag.node dag { name = "child 2 1" }
-
-let node31 = Dag.node dag { name = "child 3 1" }
-
-let () =
-  Dag.add_assuming_missing dag node node11;
-  Dag.add_assuming_missing dag node node12;
-  Dag.add_assuming_missing dag node12 node21;
-  Dag.add_assuming_missing dag node21 node31
-
 let pp_mynode fmt n = Format.fprintf fmt "%s" n.name
 
-let dag_pp_mynode = Dag.pp_node pp_mynode
-
 let%expect_test _ =
-  Format.printf "%a@." dag_pp_mynode node;
-  let node41 = Dag.node dag { name = "child 4 1" } in
-  Dag.add_assuming_missing dag node31 node41;
-  Format.printf "%a@." dag_pp_mynode node;
+  let open
+    Dag.Make
+      (struct
+        type t = mynode
+      end)
+      () in
+  let node data = { info = create_node_info (); data } in
+  let root = node { name = "root" } in
+  let node11 = node { name = "child 1 1" } in
+  let node12 = node { name = "child 1 2" } in
+  let node21 = node { name = "child 2 1" } in
+  let node31 = node { name = "child 3 1" } in
+  add_assuming_missing root node11;
+  add_assuming_missing root node12;
+  add_assuming_missing node12 node21;
+  add_assuming_missing node21 node31;
+  let dag_pp_mynode = pp_node pp_mynode in
+  Format.printf "%a@." dag_pp_mynode root;
+  let node41 = node { name = "child 4 1" } in
+  add_assuming_missing node31 node41;
+  Format.printf "%a@." dag_pp_mynode root;
   let name node = node.data.name in
   try
-    Dag.add_assuming_missing dag node41 node;
+    add_assuming_missing node41 root;
     print_endline "no cycle"
   with
-  | Dag.Cycle cycle ->
+  | Cycle cycle ->
+    print_endline "cycle:";
     let cycle = List.map cycle ~f:name in
     List.map ~f:Pp.text cycle |> Pp.concat ~sep:Pp.space |> print;
     [%expect
       {|
-(1: k=1) (root) [(3: k=1) (child 1 2) [(4: k=1) (child 2 1) [(5: k=2) (child 3 1) [
-                                                             ]]];
-                  (2: k=1) (child 1 1) []]
-(1: k=1) (root) [(3: k=1) (child 1 2) [(4: k=1) (child 2 1) [(5: k=2) (child 3 1) [
-                                                             (6: k=2) (child 4 1) [
-                                                             ]]]];
-                  (2: k=1) (child 1 1) []]
-child 4 1 child 3 1 child 2 1 child 1 2
-root
-|}]
+      (0: k=1) (root) [(2: k=1) (child 1 2) [(3: k=1) (child 2 1) [(4: k=2) (child 3 1) [
+                                                                   ]]];
+                        (1: k=1) (child 1 1) []]
+      (0: k=1) (root) [(2: k=1) (child 1 2) [(3: k=1) (child 2 1) [(4: k=2) (child 3 1) [
+                                                                   (5: k=2) (child 4 1) [
+                                                                   ]]]];
+                        (1: k=1) (child 1 1) []]
+      cycle:
+      child 4 1 child 3 1 child 2 1 child 1 2
+      root
+    |}]
 
 let rec adjacent_pairs l =
   match l with
@@ -73,82 +60,83 @@ let rec adjacent_pairs l =
   | x :: y :: rest -> (x, y) :: adjacent_pairs (y :: rest)
 
 let cycle_test variant =
-  let module Dag = DagF.Make (struct
-    type t = int
-  end) in
-  let open Dag in
-  let node dag data = { info = create_node_info dag; data } in
+  let open
+    Dag.Make
+      (struct
+        type t = int
+      end)
+      () in
+  let node data = { info = create_node_info (); data } in
   let edges = ref [] in
-  let add d n1 n2 =
+  let add n1 n2 =
     edges := (n1.data, n2.data) :: !edges;
-    add_assuming_missing d n1 n2
+    add_assuming_missing n1 n2
   in
-  let d = Dag.create () in
-  let _n1 = node d 1 in
-  let n2 = node d 2 in
-  let n3 = node d 3 in
+  let _n1 = node 1 in
+  let n2 = node 2 in
+  let n3 = node 3 in
   (* the two variants are equivalent, but they end up taking a different code
      path when producing the cycle for some reason (or at least they did in
      2019-03) *)
   (match variant with
-  | `a -> add d n2 n3
+  | `a -> add n2 n3
   | `b -> ());
-  let n4 = node d 4 in
-  add d n3 n4;
-  let n5 = node d 5 in
-  add d n5 n2;
-  let n6 = node d 6 in
-  add d n6 n3;
-  let n7 = node d 7 in
-  let n8 = node d 8 in
-  add d n7 n8;
-  let n9 = node d 9 in
-  add d n8 n9;
-  let n10 = node d 10 in
-  add d n9 n10;
-  let n11 = node d 11 in
-  add d n10 n11;
-  let n12 = node d 12 in
-  add d n11 n12;
-  let n13 = node d 13 in
-  add d n12 n13;
-  let n14 = node d 14 in
-  add d n13 n14;
-  let n15 = node d 15 in
-  add d n14 n15;
-  let n16 = node d 16 in
-  add d n15 n16;
-  let n17 = node d 17 in
-  add d n16 n17;
-  let n18 = node d 18 in
-  add d n17 n18;
-  let n19 = node d 19 in
-  add d n12 n19;
-  let n20 = node d 20 in
-  add d n10 n20;
-  let n21 = node d 21 in
-  add d n20 n21;
-  let n22 = node d 22 in
-  add d n21 n22;
-  let n23 = node d 23 in
-  add d n22 n23;
-  let n24 = node d 24 in
-  add d n23 n24;
-  let n25 = node d 25 in
-  add d n24 n25;
-  let n26 = node d 26 in
-  add d n25 n26;
-  let n27 = node d 27 in
-  add d n26 n27;
-  let n28 = node d 28 in
-  add d n21 n28;
-  let n29 = node d 29 in
-  add d n10 n29;
-  let n30 = node d 30 in
-  add d n8 n30;
-  let _n31 = node d 31 in
-  add d n14 n20;
-  match add d n23 n11 with
+  let n4 = node 4 in
+  add n3 n4;
+  let n5 = node 5 in
+  add n5 n2;
+  let n6 = node 6 in
+  add n6 n3;
+  let n7 = node 7 in
+  let n8 = node 8 in
+  add n7 n8;
+  let n9 = node 9 in
+  add n8 n9;
+  let n10 = node 10 in
+  add n9 n10;
+  let n11 = node 11 in
+  add n10 n11;
+  let n12 = node 12 in
+  add n11 n12;
+  let n13 = node 13 in
+  add n12 n13;
+  let n14 = node 14 in
+  add n13 n14;
+  let n15 = node 15 in
+  add n14 n15;
+  let n16 = node 16 in
+  add n15 n16;
+  let n17 = node 17 in
+  add n16 n17;
+  let n18 = node 18 in
+  add n17 n18;
+  let n19 = node 19 in
+  add n12 n19;
+  let n20 = node 20 in
+  add n10 n20;
+  let n21 = node 21 in
+  add n20 n21;
+  let n22 = node 22 in
+  add n21 n22;
+  let n23 = node 23 in
+  add n22 n23;
+  let n24 = node 24 in
+  add n23 n24;
+  let n25 = node 25 in
+  add n24 n25;
+  let n26 = node 26 in
+  add n25 n26;
+  let n27 = node 27 in
+  add n26 n27;
+  let n28 = node 28 in
+  add n21 n28;
+  let n29 = node 29 in
+  add n10 n29;
+  let n30 = node 30 in
+  add n8 n30;
+  let _n31 = node 31 in
+  add n14 n20;
+  match add n23 n11 with
   | _ -> assert false
   | exception Cycle c ->
     let c = List.map c ~f:(fun x -> x.data) in
@@ -161,41 +149,48 @@ let cycle_test variant =
 let%expect_test _ =
   cycle_test `a;
   [%expect {|
-23 22 21 20 14 13 12
-11
-|}]
+    23 22 21 20 14 13 12
+    11
+  |}]
 
 let%expect_test _ =
   cycle_test `b;
   [%expect {|
-23 22 21 20 14 13 12
-11
-|}]
+    23 22 21 20 14 13 12
+    11
+  |}]
 
 let%expect_test "creating a cycle can succeed on the second attempt" =
-  let dag = Dag.create () in
-  let c1 = Dag.node dag { name = "c1" } in
-  let c2 = Dag.node dag { name = "c2" } in
-  let c3 = Dag.node dag { name = "c3" } in
-  let c4 = Dag.node dag { name = "c4" } in
-  Dag.add_assuming_missing dag c1 c2;
-  Dag.add_assuming_missing dag c2 c3;
-  Dag.add_assuming_missing dag c3 c4;
+  let open
+    Dag.Make
+      (struct
+        type t = mynode
+      end)
+      () in
+  let node data = { info = create_node_info (); data } in
+  let c1 = node { name = "c1" } in
+  let c2 = node { name = "c2" } in
+  let c3 = node { name = "c3" } in
+  let c4 = node { name = "c4" } in
+  add_assuming_missing c1 c2;
+  add_assuming_missing c2 c3;
+  add_assuming_missing c3 c4;
+  let dag_pp_mynode = pp_node pp_mynode in
   Format.printf "c1 = %a@.\n" dag_pp_mynode c1;
   Format.printf "c2 = %a@.\n" dag_pp_mynode c2;
   Format.printf "c3 = %a@.\n" dag_pp_mynode c3;
   Format.printf "c4 = %a@.\n" dag_pp_mynode c4;
   [%expect
     {|
-    c1 = (1: k=1) (c1) [(2: k=1) (c2) [(3: k=1) (c3) [(4: k=2) (c4) []]]]
+    c1 = (0: k=1) (c1) [(1: k=1) (c2) [(2: k=1) (c3) [(3: k=2) (c4) []]]]
 
-    c2 = (2: k=1) (c2) [(3: k=1) (c3) [(4: k=2) (c4) []]]
+    c2 = (1: k=1) (c2) [(2: k=1) (c3) [(3: k=2) (c4) []]]
 
-    c3 = (3: k=1) (c3) [(4: k=2) (c4) []]
+    c3 = (2: k=1) (c3) [(3: k=2) (c4) []]
 
-    c4 = (4: k=2) (c4) []
+    c4 = (3: k=2) (c4) []
   |}];
-  (match Dag.add_assuming_missing dag c4 c2 with
+  (match add_assuming_missing c4 c2 with
   | () -> Format.printf "added :o\n"
   | exception Cycle _ -> Format.printf "cycle\n");
   Format.printf "c1 = %a@.\n" dag_pp_mynode c1;
@@ -207,15 +202,15 @@ let%expect_test "creating a cycle can succeed on the second attempt" =
   [%expect
     {|
     cycle
-    c1 = (1: k=1) (c1) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) []]]]
+    c1 = (0: k=1) (c1) [(1: k=2) (c2) [(2: k=2) (c3) [(3: k=2) (c4) []]]]
 
-    c2 = (2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) []]]
+    c2 = (1: k=2) (c2) [(2: k=2) (c3) [(3: k=2) (c4) []]]
 
-    c3 = (3: k=2) (c3) [(4: k=2) (c4) []]
+    c3 = (2: k=2) (c3) [(3: k=2) (c4) []]
 
-    c4 = (4: k=2) (c4) []
+    c4 = (3: k=2) (c4) []
   |}];
-  (match Dag.add_assuming_missing dag c4 c2 with
+  (match add_assuming_missing c4 c2 with
   | () -> Format.printf "added :o\n"
   | exception Cycle _ -> Format.printf "cycle\n");
   Format.printf "c1 = %a@.\n" dag_pp_mynode c1;
@@ -223,22 +218,22 @@ let%expect_test "creating a cycle can succeed on the second attempt" =
   [%expect
     {|
     added :o
-    c1 = (1: k=1) (c1) [(2: k=2) (c2) [(3: k=2) (c3) [(4: k=2) (c4) [
-                                                               (2: k=2) (c2) [
-                                                               (3: k=2) (c3) [
-                                                               (4: k=2) (c4) [
-                                                               (2: k=2) (c2) [
-                                                               (3: k=2) (c3) [
-                                                               (4: k=2) (c4) [
-                                                               (2: k=2) (c2) [
-                                                               (3: k=2) (c3) [
-                                                               (4: k=2) (c4) [
-                                                               (2: k=2) (c2) [
-                                                               (3: k=2) (c3) [
-                                                               (4: k=2) (c4) [
-                                                               (2: k=2) (c2) [
-                                                               (3: k=2) (c3) [
-                                                               (4: k=2) (c4) [
-                                                               (2: k=2) (c2) [
+    c1 = (0: k=1) (c1) [(1: k=2) (c2) [(2: k=2) (c3) [(3: k=2) (c4) [
+                                                               (1: k=2) (c2) [
+                                                               (2: k=2) (c3) [
+                                                               (3: k=2) (c4) [
+                                                               (1: k=2) (c2) [
+                                                               (2: k=2) (c3) [
+                                                               (3: k=2) (c4) [
+                                                               (1: k=2) (c2) [
+                                                               (2: k=2) (c3) [
+                                                               (3: k=2) (c4) [
+                                                               (1: k=2) (c2) [
+                                                               (2: k=2) (c3) [
+                                                               (3: k=2) (c4) [
+                                                               (1: k=2) (c2) [
+                                                               (2: k=2) (c3) [
+                                                               (3: k=2) (c4) [
+                                                               (1: k=2) (c2) [
                                                                ...]]]]]]]]]]]]]]]]]]]]
   |}]

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -214,7 +214,7 @@ let%expect_test _ =
   [%expect
     {|
       Memo: 2001/2001 computed/total nodes, 3998/3998 traversed/total edges
-      Memo's cycle detection graph: 2000/2000 nodes/edges
+      Memo's cycle detection graph: 0/0 nodes/edges
   |}]
 
 let make_f name = Memo.create name ~cutoff:String.equal
@@ -418,7 +418,7 @@ let%expect_test "fib linked list" =
   [%expect
     {|
     Memo: 8/8 computed/total nodes, 18/18 traversed/total edges
-    Memo's cycle detection graph: 5/5 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}]
 
 let%expect_test "previously_evaluated_cell" =
@@ -747,7 +747,7 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     Evaluated summit with offset 0: 4
     f 0 = Ok 4
     Memo: 7/7 computed/total nodes, 7/7 traversed/total edges
-    Memo's cycle detection graph: 6/6 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit 1;
@@ -775,7 +775,7 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     Evaluated yes_cutoff: 1
     f 0 = Ok 4
     Memo: 5/7 computed/total nodes, 11/7 traversed/total edges
-    Memo's cycle detection graph: 6/6 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit 1;
@@ -910,7 +910,7 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated the summit with input 0: 5
     f 0 = Ok 5
     Memo: 7/7 computed/total nodes, 7/7 traversed/total edges
-    Memo's cycle detection graph: 6/6 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit_yes_cutoff 0;
@@ -931,7 +931,7 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated the summit with input 0: 5
     f 0 = Ok 5
     Memo: 6/6 computed/total nodes, 6/6 traversed/total edges
-    Memo's cycle detection graph: 5/5 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit_no_cutoff 2;
@@ -990,7 +990,7 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
               }
             ]
     Memo: 9/9 computed/total nodes, 16/8 traversed/total edges
-    Memo's cycle detection graph: 8/8 nodes/edges
+    Memo's cycle detection graph: 5/5 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit_yes_cutoff 0;
@@ -1025,7 +1025,7 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
               }
             ]
     Memo: 7/7 computed/total nodes, 14/7 traversed/total edges
-    Memo's cycle detection graph: 6/6 nodes/edges
+    Memo's cycle detection graph: 5/5 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit_no_cutoff 2;
@@ -1104,7 +1104,7 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated the summit with input 0: 7
     f 0 = Ok 7
     Memo: 8/8 computed/total nodes, 14/7 traversed/total edges
-    Memo's cycle detection graph: 7/7 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit_yes_cutoff 0;
@@ -1125,7 +1125,7 @@ let%expect_test "dynamic cycles with non-uniform cutoff structure" =
     Evaluated the summit with input 0: 7
     f 0 = Ok 7
     Memo: 6/6 computed/total nodes, 12/6 traversed/total edges
-    Memo's cycle detection graph: 5/5 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.Perf_counters.reset ();
   evaluate_and_print summit_no_cutoff 2;
@@ -1303,7 +1303,7 @@ let%expect_test "Nested nodes with cutoff are recomputed optimally" =
     Evaluated summit: 2
     f 1 = Ok 2
     Memo: 8/8 computed/total nodes, 7/7 traversed/total edges
-    Memo's cycle detection graph: 6/6 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.reset Memo.Invalidation.empty;
   evaluate_and_print summit 0;
@@ -1329,7 +1329,7 @@ let%expect_test "Nested nodes with cutoff are recomputed optimally" =
     Evaluated summit: 4
     f 2 = Ok 4
     Memo: 8/10 computed/total nodes, 11/7 traversed/total edges
-    Memo's cycle detection graph: 9/9 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}]
 
 (* In addition to its direct purpose, this test also: (i) demonstrates what
@@ -1451,7 +1451,7 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
     Evaluated summit: 1
     f 0 = Ok 1
     Memo: 4/4 computed/total nodes, 4/4 traversed/total edges
-    Memo's cycle detection graph: 3/3 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.reset Memo.Invalidation.empty;
   evaluate_and_print summit 0;
@@ -1468,7 +1468,7 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
     Evaluated summit: 0
     f 0 = Ok 0
     Memo: 4/5 computed/total nodes, 6/3 traversed/total edges
-    Memo's cycle detection graph: 5/5 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   (* At this point, [captured_base] is a stale computation: [restore_from_cache]
      failed but [compute] never started. *)
@@ -1493,7 +1493,7 @@ let%expect_test "Abandoned node with no cutoff is recomputed" =
     Evaluated summit: 4
     f 0 = Ok 4
     Memo: 5/6 computed/total nodes, 9/5 traversed/total edges
-    Memo's cycle detection graph: 6/6 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}]
 
 let print_exns f =
@@ -1695,7 +1695,7 @@ let%expect_test "errors work with early cutoff" =
     [divide] Started evaluating 200
     f 200 = Error [ { exn = "Input_too_large <first run>"; backtrace = "" } ]
     Memo: 7/7 computed/total nodes, 6/6 traversed/total edges
-    Memo's cycle detection graph: 4/4 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.reset Memo.Invalidation.empty;
   evaluate_and_print f 0;
@@ -1718,7 +1718,7 @@ let%expect_test "errors work with early cutoff" =
     [negate] Started evaluating 200
     f 200 = Error [ { exn = "Input_too_large <second run>"; backtrace = "" } ]
     Memo: 5/7 computed/total nodes, 10/6 traversed/total edges
-    Memo's cycle detection graph: 4/4 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}]
 
 (* This test uses non-deterministic tasks to show that adding old dependency
@@ -1784,7 +1784,7 @@ let%expect_test "Test that there are no spurious cycles" =
   [%expect
     {|
     Memo: 2/2 computed/total nodes, 1/1 traversed/total edges
-    Memo's cycle detection graph: 1/1 nodes/edges
+    Memo's cycle detection graph: 0/0 nodes/edges
   |}];
   Memo.reset (Memo.Cell.invalidate (Memo.cell task_b 0));
   evaluate_and_print task_a 0;
@@ -1891,9 +1891,9 @@ let%expect_test "Test Memo.clear_cache" =
    gets blocked waiting for C to eventually complete. As a result, during the
    restore_from_cache phase in the second run, the cycle detection algorithm
    will add the path A -> B -> C to the DAG. Then, in the compute phase, B will
-   get blocked on X, adding the path A -> X -> B -> X to the DAG, detecting the
-   cycle. If the two phases are not cleanly separated, the second path might get
-   cut down to just B -> X, hiding the cycle and leading to a deadlock. *)
+   get blocked on X, adding the path A -> X -> B -> X to the DAG, thus detecting
+   the cycle. If the two phases are not cleanly separated, the second path might
+   get cut down to just B -> X, missing the cycle and leading to a deadlock. *)
 let%expect_test "restore_from_cache and compute phases are well-separated" =
   let task_c =
     Memo.create "C"
@@ -1969,7 +1969,10 @@ let%expect_test "restore_from_cache and compute phases are well-separated" =
     Evaluated A
   |}];
   print_perf_counters ();
-  [%expect {| 4/4 computed/total nodes, 3/3 traversed/total edges |}];
+  [%expect
+    {|
+    Memo: 4/4 computed/total nodes, 3/3 traversed/total edges
+    Memo's cycle detection graph: 2/2 nodes/edges |}];
   Memo.reset Invalidation.empty;
   (match
      Scheduler.run


### PR DESCRIPTION
The main idea behind the optimisation is as follows. Cycles can only appear when we subscribe to a `Once.t` computation that is currently running, because that's where multiple threads of computation might deadlock waiting for each other to complete. To prevent such deadlocks, it is sufficient to only add the edges that lead to such "subscribing" edges to the cycle detection graph. All other edges can be skipped. This can reduce the number of edges in the cycle detection graph significantly. In particular, we no longer add the edges that force `Once.t` computations for the first time. This means that when doing an incremental zero rebuild, we are not going to add any edges to the cycle detection graph at all, because there is no build parallelism and we are never going to subscribe to a running `Once.t` computation.

Another important aspect of this PR is getting rid of `Deps_so_far`, essentially simplifying it to just a list. Instead of checking for duplicates when adding every dependency edge, we now check for duplicates only in the rare case of adding paths to the cycle detection graph.

Benchmarking shows 30-40% time saving for incremental zero rebuilds on a large target (millions of Memo nodes).

Below are also some microbenchmarks that show a clear improvement too.

```
┌────────────────────────────────────┬──────────────┬─────────────┬───────────┬───────────┬────────────┐
│ New Memo                           │     Time/Run │     mWd/Run │  mjWd/Run │  Prom/Run │ Percentage │
├────────────────────────────────────┼──────────────┼─────────────┼───────────┼───────────┼────────────┤
│ 1-bind (create and compute)        │     569.51ns │     802.00w │     0.14w │     0.14w │      0.33% │
│ 1-bind (incr and recompute)        │     573.71ns │     776.00w │     0.12w │     0.12w │      0.34% │
│ 1-bind (restore from cache)        │     422.36ns │     577.00w │           │           │      0.25% │
│ 20-reads (create and compute)      │   2_149.55ns │   3_201.00w │     0.80w │     0.80w │      1.26% │
│ 20-reads (incr and recompute)      │   2_003.69ns │   2_942.00w │     0.52w │     0.52w │      1.17% │
│ 20-reads (restore from cache)      │   1_845.77ns │   2_743.00w │     0.45w │     0.45w │      1.08% │
│ clique (create and compute)        │  64_872.94ns │  75_218.00w │   397.17w │   397.17w │     37.92% │
│ clique (incr and recompute)        │  66_085.04ns │  77_701.00w │   275.82w │   275.82w │     38.63% │
│ clique (restore from cache)        │  40_344.54ns │  57_360.00w │   112.07w │   112.07w │     23.58% │
│ bipartite (create and compute)     │ 171_070.29ns │ 171_702.00w │ 2_862.21w │ 2_862.21w │    100.00% │
│ bipartite (incr and recompute)     │ 131_568.96ns │ 146_851.00w │   395.95w │   395.95w │     76.91% │
│ bipartite (restore from cache)     │  81_704.26ns │ 118_270.00w │    54.09w │    54.09w │     47.76% │
│ memo diamonds (create and compute) │  12_345.55ns │  15_472.00w │    46.25w │    46.25w │      7.22% │
│ memo diamonds (incr and recompute) │  13_646.74ns │  17_209.00w │    38.42w │    38.42w │      7.98% │
│ memo diamonds (restore from cache) │   7_660.55ns │  10_070.00w │    18.26w │    18.26w │      4.48% │
└────────────────────────────────────┴──────────────┴─────────────┴───────────┴───────────┴────────────┘

┌────────────────────────────────────┬──────────────┬─────────────┬───────────┬───────────┬────────────┐
│ Old Memo                           │     Time/Run │     mWd/Run │  mjWd/Run │  Prom/Run │ Percentage │
├────────────────────────────────────┼──────────────┼─────────────┼───────────┼───────────┼────────────┤
│ 1-bind (create and compute)        │     627.01ns │     839.00w │     0.16w │     0.16w │      0.27% │
│ 1-bind (incr and recompute)        │     634.36ns │     813.00w │     0.15w │     0.15w │      0.28% │
│ 1-bind (restore from cache)        │     454.18ns │     614.00w │           │           │      0.20% │
│ 20-reads (create and compute)      │   2_411.09ns │   3_542.00w │     0.87w │     0.87w │      1.06% │
│ 20-reads (incr and recompute)      │   2_277.85ns │   3_283.00w │     0.60w │     0.60w │      1.00% │
│ 20-reads (restore from cache)      │   2_089.54ns │   3_084.00w │     0.44w │     0.44w │      0.91% │
│ clique (create and compute)        │  87_088.65ns │  91_243.00w │   594.45w │   594.45w │     38.11% │
│ clique (incr and recompute)        │  89_773.85ns │  94_408.00w │   544.31w │   544.31w │     39.29% │
│ clique (restore from cache)        │  58_674.81ns │  72_453.00w │   253.95w │   253.95w │     25.68% │
│ bipartite (create and compute)     │ 228_515.60ns │ 202_459.00w │ 3_692.17w │ 3_692.17w │    100.00% │
│ bipartite (incr and recompute)     │ 186_227.89ns │ 178_254.00w │   779.32w │   779.32w │     81.49% │
│ bipartite (restore from cache)     │ 124_748.66ns │ 147_107.00w │   295.20w │   295.20w │     54.59% │
│ memo diamonds (create and compute) │  15_792.98ns │  18_299.00w │    62.73w │    62.73w │      6.91% │
│ memo diamonds (incr and recompute) │  17_705.61ns │  20_476.00w │    54.94w │    54.94w │      7.75% │
│ memo diamonds (restore from cache) │   9_147.40ns │  10_577.00w │    24.19w │    24.19w │      4.00% │
└────────────────────────────────────┴──────────────┴─────────────┴───────────┴───────────┴────────────┘
```