### PR TITLE
[2.9] [coq] Library coq.kernel replaced by coq-core.kernel in Coq >= 8.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@ unreleased - 2.9 branch
   Dune's configure and `dune install` command. (#4744, fixes #4723,
   @ejgallego, thanks to @JasonGross for reporting this issue)
 
+- Handle renaming of `coq.kernel` library to `coq-core.kernel` in Coq 8.14 (#4713, @proux01)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1630,7 +1630,7 @@ The supported Coq language versions are:
 
 - ``0.1``: basic Coq theory support,
 - ``0.2``: support for the ``theories`` field, and composition of theories in the same scope,
-- ``0.3``: support for ``(mode native)``, requires Coq >= 8.10.
+- ``0.3``: support for ``(mode native)``, requires Coq >= 8.10 (and dune >= 2.9 for Coq >= 8.14).
 
 Guarantees with respect to stability are not provided yet,
 however, as implementation of features progresses, we hope to reach


### PR DESCRIPTION
backport of #4713

Signed-off-by: Pierre Roux <pierre.roux@onera.fr>