### PR TITLE
[coq] Fix silly bug in native install rules when non-trivial theory wrappers are used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,6 +180,9 @@ Unreleased
 - Fix issue where Dune would ignore `(env ... (coq (flags ...)))`
   declarations appearing in `dune` files (#4749, fixes #4566, @ejgallego @rgrinberg)
 
+- Fix bug for the install of Coq native files when using `(include_subdirs qualified)`
+  (#4753, @ejgallego)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/src/dune_rules/coq_module.ml
+++ b/src/dune_rules/coq_module.ml
@@ -41,8 +41,9 @@ let build_vo_dir ~obj_dir x =
   List.fold_left x.prefix ~init:obj_dir ~f:Path.Build.relative
 
 let cmxs_of_mod ~wrapper_name x =
+  let wrapper_split = String.split wrapper_name ~on:'.' in
   let native_base =
-    "N" ^ String.concat ~sep:"_" (wrapper_name :: x.prefix @ [ x.name ])
+    "N" ^ String.concat ~sep:"_" (wrapper_split @ x.prefix @ [ x.name ])
   in
   [ native_base ^ ".cmi"; native_base ^ ".cmxs" ]
 

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -514,7 +514,7 @@ let install_rules ~sctx ~dir s =
       else
         coq_plugins_install_rules ~scope ~package ~dst_dir s
     in
-    let wrapper_name = dst_suffix in
+    let wrapper_name = Coq_lib_name.wrapper name in
     let to_path f = Path.reach ~from:(Path.build dir) (Path.build f) in
     let to_dst f = Path.Local.to_string @@ Path.Local.relative dst_dir f in
     let make_entry (orig_file : Path.Build.t) (dst_file : string) =

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/bar/dune
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/bar/dune
@@ -1,5 +1,5 @@
 (coq.theory
- (name bar)
+ (name bar.baz)
  (package base)
  (mode native)
  (theories foo)

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/foo/a/a.v
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/foo/a/a.v
@@ -1,0 +1,1 @@
+Definition aa := 3.

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/foo/dune
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/foo/dune
@@ -4,3 +4,5 @@
  (mode native)
  (modules :standard)
  (synopsis "Test Coq library"))
+
+(include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
@@ -1,8 +1,10 @@
   $ dune build --profile=release --display short --debug-dependency-path @all
         coqdep bar/bar.v.d
         coqdep foo/foo.v.d
+        coqdep foo/a/a.v.d
           coqc foo/.foo.aux,foo/Nfoo_foo.{cmi,cmxs},foo/foo.{glob,vo}
-          coqc bar/.bar.aux,bar/Nbar_bar.{cmi,cmxs},bar/bar.{glob,vo}
+          coqc foo/a/.a.aux,foo/a/Nfoo_a_a.{cmi,cmxs},foo/a/a.{glob,vo}
+          coqc bar/.bar.aux,bar/Nbar_baz_bar.{cmi,cmxs},bar/bar.{glob,vo}
 
   $ dune build --profile=release --debug-dependency-path @default
   lib: [
@@ -11,12 +13,16 @@
     "_build/install/default/lib/base/opam"
   ]
   lib_root: [
-    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmi" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmi"}
-    "_build/install/default/lib/coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs" {"coq/user-contrib/bar/.coq-native/Nbar_bar.cmxs"}
-    "_build/install/default/lib/coq/user-contrib/bar/bar.v" {"coq/user-contrib/bar/bar.v"}
-    "_build/install/default/lib/coq/user-contrib/bar/bar.vo" {"coq/user-contrib/bar/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/bar/baz/.coq-native/Nbar_baz_bar.cmi" {"coq/user-contrib/bar/baz/.coq-native/Nbar_baz_bar.cmi"}
+    "_build/install/default/lib/coq/user-contrib/bar/baz/.coq-native/Nbar_baz_bar.cmxs" {"coq/user-contrib/bar/baz/.coq-native/Nbar_baz_bar.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/bar/baz/bar.v" {"coq/user-contrib/bar/baz/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/bar/baz/bar.vo" {"coq/user-contrib/bar/baz/bar.vo"}
     "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmi"}
     "_build/install/default/lib/coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs" {"coq/user-contrib/foo/.coq-native/Nfoo_foo.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/foo/a/.coq-native/Nfoo_a_a.cmi" {"coq/user-contrib/foo/a/.coq-native/Nfoo_a_a.cmi"}
+    "_build/install/default/lib/coq/user-contrib/foo/a/.coq-native/Nfoo_a_a.cmxs" {"coq/user-contrib/foo/a/.coq-native/Nfoo_a_a.cmxs"}
+    "_build/install/default/lib/coq/user-contrib/foo/a/a.v" {"coq/user-contrib/foo/a/a.v"}
+    "_build/install/default/lib/coq/user-contrib/foo/a/a.vo" {"coq/user-contrib/foo/a/a.vo"}
     "_build/install/default/lib/coq/user-contrib/foo/foo.v" {"coq/user-contrib/foo/foo.v"}
     "_build/install/default/lib/coq/user-contrib/foo/foo.vo" {"coq/user-contrib/foo/foo.vo"}
   ]


### PR DESCRIPTION
Cherry-picked from #4750 ; submitting separately as this has been included already in 2.9.