### PR TITLE
[coq] Adjust warnings on Coq 8.14 and `(lang coq (>= 0.3))`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -183,6 +183,9 @@ Unreleased
 - Fix bug for the install of Coq native files when using `(include_subdirs qualified)`
   (#4753, @ejgallego)
 
+- Disable some warnings on Coq 8.14 and `(lang coq (>= 0.3))` due to
+  the rework of the Coq "native" compilation system (#4760, @ejgallego)
+
 2.8.5 (28/03/2021)
 ------------------
 

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -168,7 +168,13 @@ module Context = struct
     | Coq_mode.Legacy -> Command.Args.As []
     | Coq_mode.VoOnly ->
       Command.Args.As
-        [ "-w"; "-native-compiler-disabled"; "-native-compiler"; "ondemand" ]
+        [ "-w"
+        ; "-deprecated-native-compiler-option"
+        ; "-w"
+        ; "-native-compiler-disabled"
+        ; "-native-compiler"
+        ; "ondemand"
+        ]
     | Coq_mode.Native ->
       let args =
         let open Resolve.O in
@@ -184,7 +190,8 @@ module Context = struct
         in
         (* This dir is relative to the file, by default [.coq-native/] *)
         Command.Args.S
-          [ Command.Args.As [ "-native-output-dir"; "." ]
+          [ Command.Args.As [ "-w"; "-deprecated-native-compiler-option" ]
+          ; Command.Args.As [ "-native-output-dir"; "." ]
           ; Command.Args.As [ "-native-compiler"; "on" ]
           ; Command.Args.S (List.rev native_include_ml_args)
           ; Command.Args.S (List.rev native_include_theory_output)

--- a/test/blackbox-tests/test-cases/coq/flags.t
+++ b/test/blackbox-tests/test-cases/coq/flags.t
@@ -17,7 +17,7 @@ Test case: default flags
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: :standard
 
@@ -29,7 +29,7 @@ TC: :standard
 
   $ rm _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: override :standard
 
@@ -40,7 +40,7 @@ TC: override :standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: add to :standard
 
@@ -51,7 +51,7 @@ TC: add to :standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -q -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: extend in workspace + override standard
 
@@ -67,7 +67,7 @@ TC: extend in workspace + override standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -type-in-type -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: extend in workspace + override standard
 
@@ -77,7 +77,7 @@ TC: extend in workspace + override standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -q -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: extend in dune (env) + override standard
 
@@ -89,7 +89,7 @@ TC: extend in dune (env) + override standard
 
   $ rm -rf _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -type-in-type -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: extend in dune (env) + standard
 
@@ -101,7 +101,7 @@ TC: extend in dune (env) + standard
 
   $ rm -rf _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -type-in-type -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -q -type-in-type -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
 
 TC: extend in dune (env) + workspace + standard
 
@@ -118,4 +118,4 @@ TC: extend in dune (env) + workspace + standard
 
   $ rm -rf _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -bt -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  coqc -q -type-in-type -bt -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)


### PR DESCRIPTION
This is due to the rework of the Coq "native" compilation system in
8.14.

Note that as in `(lang coq 0.3)` and upwards, this requires Coq >=
8.10.

Targeting 2.9 due to low risk and high annoyance for users of Coq 8.14 + `(coq lang 0.3)`

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>