### PR TITLE
[RPC] Remove Client.connect_raw

### DIFF
--- a/bin/diagnostics.ml
+++ b/bin/diagnostics.ml
@@ -1,8 +1,6 @@
 open! Stdune
 open Import
 
-let on_notification _ = Fiber.return ()
-
 let format_diagnostic (err : Dune_rpc_private.Diagnostic.t) : User_message.t =
   let prefix =
     Option.map err.severity ~f:(fun sev ->
@@ -36,7 +34,6 @@ let exec common =
     Dune_rpc_impl.Run.client where
       (Dune_rpc_private.Initialize.Request.create
          ~id:(Dune_rpc_private.Id.make (Sexp.Atom "diagnostics_cmd")))
-      ~on_notification
       ~f:(fun cli ->
         Dune_rpc_impl.Client.request cli
           Dune_rpc_private.Public.Request.diagnostics ())

--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -143,7 +143,6 @@ module Status = struct
     Dune_rpc_impl.Run.client where
       (Dune_rpc.Initialize.Request.create
          ~id:(Dune_rpc.Id.make (Sexp.Atom "status")))
-      ~on_notification:(fun _ -> assert false)
       ~f:(fun session ->
         let open Fiber.O in
         let+ response =
@@ -176,7 +175,6 @@ module Build = struct
     Dune_rpc_impl.Run.client_with_session ~session
       (Dune_rpc.Initialize.Request.create
          ~id:(Dune_rpc.Id.make (Sexp.Atom "build")))
-      ~on_notification:(fun _ -> assert false)
       ~f:(fun session ->
         let open Fiber.O in
         let+ response =
@@ -212,14 +210,12 @@ module Ping = struct
            [ Pp.text "Server appears to be responding normally" ])
     | Error e -> raise_rpc_error e
 
-  let on_notification _ = Fiber.return ()
-
   let exec common =
     let where = wait_for_server common in
     Dune_rpc_impl.Run.client where
       (Dune_rpc_private.Initialize.Request.create
          ~id:(Dune_rpc_private.Id.make (Sexp.Atom "ping_cmd")))
-      ~on_notification ~f:send_ping
+      ~f:send_ping
 
   let info =
     let doc = "Ping the build server running in the current directory" in

--- a/bin/shutdown.ml
+++ b/bin/shutdown.ml
@@ -5,14 +5,12 @@ let send_shutdown cli =
   Dune_rpc_impl.Client.notification cli
     Dune_rpc_private.Public.Notification.shutdown ()
 
-let on_notification _ = Fiber.return ()
-
 let exec common =
   let where = Rpc.wait_for_server common in
   Dune_rpc_impl.Run.client where
     (Dune_rpc_private.Initialize.Request.create
        ~id:(Dune_rpc_private.Id.make (Sexp.Atom "shutdown_cmd")))
-    ~on_notification ~f:send_shutdown
+    ~f:send_shutdown
 
 let info =
   let doc = "cancel and shutdown any builds in the current workspace" in

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -520,13 +520,6 @@ module Client = struct
         -> t
     end
 
-    val connect_raw :
-         chan
-      -> Initialize.Request.t
-      -> on_notification:(Call.t -> unit fiber)
-      -> f:(t -> 'a fiber)
-      -> 'a fiber
-
     val connect :
          ?handler:Handler.t
       -> chan
@@ -927,10 +920,6 @@ module Client = struct
         Handler.on_notification handler ~version:initialize.version
       in
       connect_raw chan initialize ~f ~on_notification
-
-    let connect_raw chan init ~on_notification ~f =
-      let chan = Chan.of_chan chan in
-      connect_raw chan init ~on_notification ~f
 
     let connect ?handler chan init ~f =
       let chan = Chan.of_chan chan in

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -327,13 +327,6 @@ module Client : sig
         -> t
     end
 
-    val connect_raw :
-         chan
-      -> Initialize.Request.t
-      -> on_notification:(Call.t -> unit fiber)
-      -> f:(t -> 'a fiber)
-      -> 'a fiber
-
     val connect :
          ?handler:Handler.t
       -> chan

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -134,11 +134,11 @@ module Connect = struct
   let csexp_client p = Csexp_rpc.Client.create (Where.to_socket p)
 end
 
-let client p init ~on_notification ~f =
+let client ?handler p init ~f =
   let open Fiber.O in
   let* c = Connect.csexp_client p in
   let* session = Csexp_rpc.Client.connect_exn c in
-  Client.connect_raw session init ~on_notification ~f
+  Client.connect ?handler session init ~f
 
-let client_with_session init ~session ~on_notification ~f =
-  Client.connect_raw session init ~on_notification ~f
+let client_with_session ?handler init ~session ~f =
+  Client.connect ?handler session init ~f

--- a/src/dune_rpc_impl/run.mli
+++ b/src/dune_rpc_impl/run.mli
@@ -23,17 +23,17 @@ val run : Config.t -> Dune_stats.t option -> unit Fiber.t
     [where], initializes it with [init]. Once initialization is done, cals [f]
     with the active client. All notifications are fed to [on_notification]*)
 val client :
-     Dune_rpc.Where.t
+     ?handler:Client.Handler.t
+  -> Dune_rpc.Where.t
   -> Dune_rpc.Initialize.Request.t
-  -> on_notification:(Dune_rpc.Call.t -> unit Fiber.t)
   -> f:(Client.t -> 'a Fiber.t)
   -> 'a Fiber.t
 
 (** Like [client], but start with an already-established session. *)
 val client_with_session :
-     Dune_rpc.Initialize.Request.t
+     ?handler:Client.Handler.t
+  -> Dune_rpc.Initialize.Request.t
   -> session:Csexp_rpc.Session.t
-  -> on_notification:(Dune_rpc.Call.t -> unit Fiber.t)
   -> f:(Client.t -> 'a Fiber.t)
   -> 'a Fiber.t
 


### PR DESCRIPTION
It's not longer necessary as we have a proper way to handler incoming
notifications from the server.