### PR TITLE
RPC - New subscription mechanism

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -3,26 +3,6 @@ open Dune_rpc.V1
 open Lwt.Syntax
 
 module V1 = struct
-  module Stream = struct
-    module In = struct
-      type 'a t = 'a Lwt_stream.t
-    end
-
-    module Out = struct
-      type 'a t = 'a option -> unit
-
-      let write s a =
-        s (Some a);
-        Lwt.return_unit
-
-      let close s =
-        s None;
-        Lwt.return_unit
-    end
-
-    let create () = Lwt_stream.create ()
-  end
-
   module Fiber = struct
     include Lwt
 
@@ -50,11 +30,6 @@ module V1 = struct
       let fill (_, u) x =
         Lwt.wakeup u x;
         Lwt.return_unit
-
-      let peek (x, _) =
-        match Lwt.state x with
-        | Return a -> Lwt.return (Some a)
-        | _ -> Lwt.return_none
 
       let read (x, _) = x
     end
@@ -106,7 +81,6 @@ module V1 = struct
               (fun sexp -> Lwt_io.write o (Csexp.to_string sexp))
               csexps
       end)
-      (Stream)
 
   module Where =
     Where.Make

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
@@ -5,7 +5,6 @@ module V1 : sig
     Client.S
       with type 'a fiber := 'a Lwt.t
        and type chan := Lwt_io.input_channel * Lwt_io.output_channel
-       and type 'a stream := 'a Lwt_stream.t
 
   module Where : Where.S with type 'a fiber := 'a Lwt.t
 

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
@@ -5,6 +5,7 @@ module V1 : sig
     Client.S
       with type 'a fiber := 'a Lwt.t
        and type chan := Lwt_io.input_channel * Lwt_io.output_channel
+       and type 'a stream := 'a Lwt_stream.t
 
   module Where : Where.S with type 'a fiber := 'a Lwt.t
 

--- a/otherlibs/dune-rpc/dune_rpc.ml
+++ b/otherlibs/dune-rpc/dune_rpc.ml
@@ -21,8 +21,6 @@ module V1 = struct
 
       type 'a fiber
 
-      type 'a stream
-
       type chan
 
       module Handler : sig
@@ -30,8 +28,6 @@ module V1 = struct
 
         val create :
              ?log:(Message.t -> unit fiber)
-          -> ?diagnostic:(Diagnostic.Event.t list -> unit fiber)
-          -> ?build_progress:(Progress.t -> unit fiber)
           -> ?abort:(Message.t -> unit fiber)
           -> unit
           -> t
@@ -48,14 +44,15 @@ module V1 = struct
 
       val disconnected : t -> unit fiber
 
-      module Subscription : sig
-        type t
+      module Stream : sig
+        type 'a t
 
-        val cancel : t -> unit fiber
+        val cancel : _ t -> unit fiber
+
+        val next : 'a t -> 'a option fiber
       end
 
-      val subscribe :
-        ?id:Id.t -> t -> 'a Sub.t -> (Subscription.t * 'a stream) fiber
+      val poll : ?id:Id.t -> t -> 'a Sub.t -> 'a Stream.t
 
       module Batch : sig
         type t

--- a/otherlibs/dune-rpc/dune_rpc.ml
+++ b/otherlibs/dune-rpc/dune_rpc.ml
@@ -10,7 +10,7 @@ module V1 = struct
   module Diagnostic = Diagnostic
   module Path = Path
   module Progress = Progress
-  module Subscribe = Subscribe
+  module Sub = Sub
   module Message = Message
   module Where = Where
   include Public
@@ -20,6 +20,8 @@ module V1 = struct
       type t
 
       type 'a fiber
+
+      type 'a stream
 
       type chan
 
@@ -45,6 +47,15 @@ module V1 = struct
       val notification : t -> 'a Notification.t -> 'a -> unit fiber
 
       val disconnected : t -> unit fiber
+
+      module Subscription : sig
+        type t
+
+        val cancel : t -> unit fiber
+      end
+
+      val subscribe :
+        ?id:Id.t -> t -> 'a Sub.t -> (Subscription.t * 'a stream) fiber
 
       module Batch : sig
         type t

--- a/otherlibs/dune-rpc/private/conv.ml
+++ b/otherlibs/dune-rpc/private/conv.ml
@@ -211,6 +211,13 @@ let unit =
       | _ -> raise_of_sexp "expected empty list")
     , fun () -> List [] )
 
+let option x =
+  let none = constr "None" unit (fun () -> None) in
+  let some = constr "Some" x (fun x -> Some x) in
+  sum [ econstr none; econstr some ] (function
+    | None -> case () none
+    | Some s -> case s some)
+
 let char =
   Iso
     ( Sexp

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -22,6 +22,8 @@ val list : ('a, values) t -> ('a list, values) t
 
 val pair : ('a, values) t -> ('b, values) t -> ('a * 'b, values) t
 
+val option : ('a, values) t -> ('a option, values) t
+
 val triple :
   ('a, values) t -> ('b, values) t -> ('c, values) t -> ('a * 'b * 'c, values) t
 

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -29,6 +29,7 @@ module Id = struct
 
   module C = Comparable.Make (T)
   module Set = C.Set
+  module Map = C.Map
 end
 
 module Version = struct

--- a/otherlibs/dune-rpc/private/types.mli
+++ b/otherlibs/dune-rpc/private/types.mli
@@ -20,6 +20,8 @@ module Id : sig
   val to_sexp : t -> Sexp.t
 
   module Set : Set.S with type elt = t
+
+  module Map : Stdune.Map.S with type key = t
 end
 
 module Version : sig

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -292,7 +292,7 @@ module Error = struct
     ; id : Id.t
     }
 
-  let id t = Id.to_int t.id
+  let id t = t.id
 
   let extract_dir annot =
     Process.With_directory_annot.check annot
@@ -2431,6 +2431,13 @@ module Progress = struct
     { number_of_rules_discovered : int
     ; number_of_rules_executed : int
     }
+
+  let complete t = t.number_of_rules_executed
+
+  let remaining t = t.number_of_rules_discovered - t.number_of_rules_executed
+
+  let is_determined { number_of_rules_discovered; number_of_rules_executed } =
+    number_of_rules_discovered <> 0 || number_of_rules_executed <> 0
 end
 
 let get_current_progress () =

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -9,6 +9,18 @@ module Action_builder := Action_builder0
 (** {2 Creation} *)
 
 module Error : sig
+  module Id : sig
+    type t
+
+    module Map : Map.S with type key = t
+
+    val compare : t -> t -> Ordering.t
+
+    val to_int : t -> int
+
+    val to_dyn : t -> Dyn.t
+  end
+
   (** Errors when building a target *)
   type t
 
@@ -16,7 +28,7 @@ module Error : sig
 
   val promotion : t -> Promotion.Annot.t option
 
-  val id : t -> int
+  val id : t -> Id.t
 end
 
 (** The current set of active errors *)
@@ -196,6 +208,12 @@ module Progress : sig
     { number_of_rules_discovered : int
     ; number_of_rules_executed : int
     }
+
+  val complete : t -> int
+
+  val remaining : t -> int
+
+  val is_determined : t -> bool
 end
 
 val get_current_progress : unit -> Progress.t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -86,6 +86,7 @@ module Run : sig
 
   val go :
        Config.t
+    -> ?timeout:float
     -> ?file_watcher:file_watcher
     -> on_event:(Config.t -> Event.t -> unit)
     -> (unit -> 'a Fiber.t)

--- a/src/dune_rpc_impl/client.ml
+++ b/src/dune_rpc_impl/client.ml
@@ -1,10 +1,23 @@
-include
-  Dune_rpc_private.Client.Make
-    (struct
-      include Fiber
+module Stream = struct
+  module In = Fiber.Stream.In
 
-      let parallel_iter t ~f =
-        let stream = Fiber.Stream.In.create t in
-        Fiber.Stream.In.parallel_iter stream ~f
-    end)
-    (Csexp_rpc.Session)
+  module Out = struct
+    type 'a t = 'a Fiber.Stream.Out.t
+
+    let write w a = Fiber.Stream.Out.write w (Some a)
+
+    let close w = Fiber.Stream.Out.write w None
+  end
+
+  let create () = Fiber.Stream.pipe ()
+end
+
+module Fiber = struct
+  include Fiber
+
+  let parallel_iter t ~f =
+    let stream = Fiber.Stream.In.create t in
+    Fiber.Stream.In.parallel_iter stream ~f
+end
+
+include Dune_rpc_private.Client.Make (Fiber) (Csexp_rpc.Session) (Stream)

--- a/src/dune_rpc_impl/client.ml
+++ b/src/dune_rpc_impl/client.ml
@@ -1,17 +1,3 @@
-module Stream = struct
-  module In = Fiber.Stream.In
-
-  module Out = struct
-    type 'a t = 'a Fiber.Stream.Out.t
-
-    let write w a = Fiber.Stream.Out.write w (Some a)
-
-    let close w = Fiber.Stream.Out.write w None
-  end
-
-  let create () = Fiber.Stream.pipe ()
-end
-
 module Fiber = struct
   include Fiber
 
@@ -20,4 +6,4 @@ module Fiber = struct
     Fiber.Stream.In.parallel_iter stream ~f
 end
 
-include Dune_rpc_private.Client.Make (Fiber) (Csexp_rpc.Session) (Stream)
+include Dune_rpc_private.Client.Make (Fiber) (Csexp_rpc.Session)

--- a/src/dune_rpc_impl/diagnostics.ml
+++ b/src/dune_rpc_impl/diagnostics.ml
@@ -1,0 +1,80 @@
+open! Stdune
+module Dune_rpc = Dune_rpc_private
+module Initialize = Dune_rpc.Initialize
+module Public = Dune_rpc.Public
+module Server_notifications = Dune_rpc.Server_notifications
+module Sub = Dune_rpc.Sub
+module Progress = Dune_rpc.Progress
+module Id = Dune_rpc.Id
+module Diagnostic = Dune_rpc.Diagnostic
+module Conv = Dune_rpc.Conv
+module Dep_conf = Dune_rules.Dep_conf
+module Source_tree = Dune_engine.Source_tree
+module Build_system = Dune_engine.Build_system
+module Dune_project = Dune_engine.Dune_project
+module Promotion = Dune_engine.Promotion
+
+let absolutize_paths ~dir (loc : Loc.t) =
+  let make_path name =
+    Path.to_absolute_filename
+      (if Filename.is_relative name then
+        Path.append_local dir (Path.Local.parse_string_exn ~loc name)
+      else
+        Path.of_string name)
+  in
+  { Loc.start = { loc.start with pos_fname = make_path loc.start.pos_fname }
+  ; stop = { loc.stop with pos_fname = make_path loc.stop.pos_fname }
+  }
+
+let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
+    =
+ fun m ->
+  let message, related, dir = Build_system.Error.info m in
+  let make_loc loc =
+    match dir with
+    | None -> loc
+    | Some dir -> absolutize_paths ~dir loc
+  in
+  let loc = Option.map message.loc ~f:make_loc in
+  let make_message pars = Pp.map_tags (Pp.concat pars) ~f:(fun _ -> ()) in
+  let id =
+    Build_system.Error.id m |> Build_system.Error.Id.to_int
+    |> Diagnostic.Id.create
+  in
+  let promotion =
+    match Build_system.Error.promotion m with
+    | None -> []
+    | Some { in_source; in_build } ->
+      [ { Diagnostic.Promotion.in_source =
+            Path.to_absolute_filename (Path.source in_source)
+        ; in_build = Path.to_absolute_filename (Path.build in_build)
+        }
+      ]
+  in
+  let related =
+    List.map related ~f:(fun (related : User_message.t) ->
+        { Dune_rpc_private.Diagnostic.Related.message =
+            make_message related.paragraphs
+        ; loc = make_loc (Option.value_exn related.loc)
+        })
+  in
+  { severity = None
+  ; id
+  ; targets = []
+  ; message = make_message message.paragraphs
+  ; loc
+  ; promotion
+  ; related
+  ; directory =
+      Option.map
+        ~f:(fun p ->
+          Path.to_absolute_filename
+            (Path.drop_optional_build_context_maybe_sandboxed p))
+        dir
+  }
+
+let diagnostic_event_of_error_event (e : Build_system.Handler.error) :
+    Diagnostic.Event.t =
+  match e with
+  | Remove e -> Remove (diagnostic_of_error e)
+  | Add e -> Add (diagnostic_of_error e)

--- a/src/dune_rpc_impl/long_poll.ml
+++ b/src/dune_rpc_impl/long_poll.ml
@@ -1,0 +1,218 @@
+open! Stdune
+open Dune_rpc_server
+module Dune_rpc = Dune_rpc_private
+module Poll_comparable = Comparable.Make (Poller)
+module Poll_map = Poll_comparable.Map
+
+type ('a, 's) waiter =
+  | No_active_request of 's
+  | Waiting of 'a option Fiber.Ivar.t
+
+module Instance = struct
+  module type S = sig
+    module Spec : Poll_spec.S
+
+    val waiters : (Spec.response, Spec.state) waiter Poll_map.t ref
+  end
+
+  type ('r, 'u) t =
+    (module S with type Spec.response = 'r and type Spec.update = 'u)
+
+  let finish_waiter = function
+    | No_active_request _ -> Fiber.return ()
+    | Waiting a -> Fiber.Ivar.fill a None
+
+  let client_cancel (type r u) (t : (r, u) t) poller =
+    let module T = (val t) in
+    match Poll_map.find !T.waiters poller with
+    | None -> Fiber.return ()
+    | Some w ->
+      T.waiters := Poll_map.remove !T.waiters poller;
+      finish_waiter w
+
+  let poll (type r u) (t : (r, u) t) poller =
+    let module T = (val t) in
+    match Poll_map.find !T.waiters poller with
+    | Some (Waiting _) ->
+      (* TODO this means that the user polled again before waiting for the last
+         poll to complete. we should signal an error here. *)
+      assert false
+    | None ->
+      T.waiters :=
+        Poll_map.add_exn !T.waiters poller
+          (No_active_request (T.Spec.init_state ()));
+      Fiber.return (Some (T.Spec.current ()))
+    | Some (No_active_request s) -> (
+      match T.Spec.on_rest_request poller s with
+      | `Respond r ->
+        T.waiters :=
+          Poll_map.set !T.waiters poller
+            (No_active_request (T.Spec.init_state ()));
+        Fiber.return (Some r)
+      | `Delay ->
+        let ivar = Fiber.Ivar.create () in
+        T.waiters := Poll_map.set !T.waiters poller (Waiting ivar);
+        Fiber.Ivar.read ivar)
+
+  let update (type u r) (t : (r, u) t) (u : u) =
+    let module T = (val t) in
+    let to_notify = ref [] in
+    T.waiters :=
+      Poll_map.filter_map !T.waiters ~f:(fun a ->
+          match a with
+          | No_active_request s ->
+            T.Spec.on_update_inactive u s
+            |> Option.map ~f:(fun s -> No_active_request s)
+          | Waiting ivar ->
+            to_notify := ivar :: !to_notify;
+            Some (No_active_request (T.Spec.init_state ())));
+    match !to_notify with
+    | [] -> Fiber.return ()
+    | to_notify ->
+      let r = T.Spec.on_update_waiting u in
+      Fiber.parallel_iter to_notify ~f:(fun ivar ->
+          Fiber.Ivar.fill ivar (Some r))
+
+  let disconnect_session (type u r) (t : (r, u) t) session =
+    let module T = (val t) in
+    let cancel =
+      Poll_map.filteri !T.waiters ~f:(fun poller _ ->
+          Session.has_poller session poller)
+    in
+    T.waiters :=
+      if Poll_map.is_empty cancel then
+        !T.waiters
+      else
+        Poll_map.merge !T.waiters cancel ~f:(fun _ x y ->
+            match (x, y) with
+            | Some _, Some _ -> None
+            | Some _, _ -> y
+            | None, Some _
+            | None, None ->
+              assert false);
+    Poll_map.values cancel |> Fiber.parallel_iter ~f:finish_waiter
+end
+
+module Build_system = Dune_engine.Build_system
+
+module Progress = struct
+  module Progress = Dune_rpc.Progress
+
+  type state = unit
+
+  type response = Progress.t
+
+  type update = Progress.t
+
+  let init_state () = ()
+
+  let current () : Progress.t =
+    let p = Build_system.get_current_progress () in
+    match Build_system.Progress.is_determined p with
+    | false -> Waiting
+    | true ->
+      let complete = Build_system.Progress.complete p in
+      let remaining = Build_system.Progress.remaining p in
+      In_progress { complete; remaining }
+
+  let on_rest_request _poller () = `Delay
+
+  let on_update_inactive _ () = None
+
+  let on_update_waiting u = u
+end
+
+module Diagnostic = struct
+  module Diagnostic = Dune_rpc.Diagnostic
+
+  module Pending_diagnostics : sig
+    type t
+
+    val empty : t
+
+    val add_error : t -> Build_system.Handler.error -> t
+
+    val is_empty : t -> bool
+
+    val to_diagnostic_list : t -> Diagnostic.Event.t list
+  end = struct
+    module Error = Build_system.Error
+    module Map = Build_system.Error.Id.Map
+    module Handler = Build_system.Handler
+
+    type t = Handler.error Map.t
+
+    let empty = Map.empty
+
+    let is_empty t = Map.is_empty t
+
+    let add_error t (m : Handler.error) =
+      let id =
+        match m with
+        | Add e -> Error.id e
+        | Remove e -> Error.id e
+      in
+      Map.set t id m
+
+    let to_diagnostic_list t =
+      Map.to_list_map t ~f:(fun _ e ->
+          match (e : Handler.error) with
+          | Remove x ->
+            Diagnostic.Event.Remove (Diagnostics.diagnostic_of_error x)
+          | Add x -> Add (Diagnostics.diagnostic_of_error x))
+  end
+
+  type update = Build_system.Handler.error list
+
+  type response = Diagnostic.Event.t list
+
+  type state = Pending_diagnostics.t
+
+  let current () =
+    Build_system.errors ()
+    |> List.map ~f:(fun e ->
+           Diagnostic.Event.Add (Diagnostics.diagnostic_of_error e))
+
+  let init_state () = Pending_diagnostics.empty
+
+  let on_rest_request _poller pd =
+    if Pending_diagnostics.is_empty pd then
+      `Delay
+    else
+      `Respond (Pending_diagnostics.to_diagnostic_list pd)
+
+  let on_update_inactive errors init =
+    Some
+      (List.fold_left errors ~init ~f:(fun acc a ->
+           Pending_diagnostics.add_error acc a))
+
+  let on_update_waiting =
+    List.map ~f:Diagnostics.diagnostic_event_of_error_event
+end
+
+type t =
+  { diagnostic : (Diagnostic.response, Diagnostic.update) Instance.t
+  ; progress : (Progress.response, Progress.update) Instance.t
+  }
+
+let progress t = t.progress
+
+let diagnostic t = t.diagnostic
+
+let create () : t =
+  let module D = struct
+    module Spec = Diagnostic
+
+    let waiters = ref Poll_map.empty
+  end in
+  let module P = struct
+    module Spec = Progress
+
+    let waiters = ref Poll_map.empty
+  end in
+  { diagnostic = (module D); progress = (module P) }
+
+let disconnect_session { diagnostic; progress } session =
+  Fiber.fork_and_join_unit
+    (fun () -> Instance.disconnect_session diagnostic session)
+    (fun () -> Instance.disconnect_session progress session)

--- a/src/dune_rpc_impl/long_poll.mli
+++ b/src/dune_rpc_impl/long_poll.mli
@@ -1,0 +1,24 @@
+module Instance : sig
+  type ('r, 'u) t
+
+  val update : ('r, 'u) t -> 'u -> unit Fiber.t
+
+  val poll : ('r, 'u) t -> Dune_rpc_server.Poller.t -> 'r option Fiber.t
+
+  val client_cancel : (_, _) t -> Dune_rpc_server.Poller.t -> unit Fiber.t
+end
+
+type t
+
+val create : unit -> t
+
+val disconnect_session : t -> _ Dune_rpc_server.Session.t -> unit Fiber.t
+
+val progress :
+  t -> (Dune_rpc_private.Progress.t, Dune_rpc_private.Progress.t) Instance.t
+
+val diagnostic :
+     t
+  -> ( Dune_rpc_private.Diagnostic.Event.t list
+     , Dune_engine.Build_system.Handler.error list )
+     Instance.t

--- a/src/dune_rpc_impl/poll_spec.ml
+++ b/src/dune_rpc_impl/poll_spec.ml
@@ -1,0 +1,25 @@
+module type S = sig
+  (** type of internal state we keep per poller *)
+  type state
+
+  (** type of response the long polling request expects *)
+  type response
+
+  (** the type of updates we push down to pollers *)
+  type update
+
+  val current : unit -> response
+
+  (** initialize a new state for a waiting client *)
+  val init_state : unit -> state
+
+  (** subsequent request by a long poller. may be delayed until the next update *)
+  val on_rest_request :
+    Dune_rpc_server.Poller.t -> state -> [ `Delay | `Respond of response ]
+
+  (** an update for a poller without an active request *)
+  val on_update_inactive : update -> state -> state option
+
+  (** an update for all pollers that are waiting for a response *)
+  val on_update_waiting : update -> response
+end

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -2,10 +2,10 @@ open! Stdune
 open Fiber.O
 open Dune_rpc_server
 module Dune_rpc = Dune_rpc_private
-module Subscribe = Dune_rpc.Subscribe
 module Initialize = Dune_rpc.Initialize
 module Public = Dune_rpc.Public
 module Server_notifications = Dune_rpc.Server_notifications
+module Sub = Dune_rpc.Sub
 module Progress = Dune_rpc.Progress
 module Id = Dune_rpc.Id
 module Diagnostic = Dune_rpc.Diagnostic
@@ -26,62 +26,6 @@ end
 
 type pending_build_action =
   | Build of Dep_conf.t list * Build_outcome.t Fiber.Ivar.t
-
-let absolutize_paths ~dir (loc : Loc.t) =
-  let make_path name =
-    Path.to_absolute_filename
-      (if Filename.is_relative name then
-        Path.append_local dir (Path.Local.parse_string_exn ~loc name)
-      else
-        Path.of_string name)
-  in
-  { Loc.start = { loc.start with pos_fname = make_path loc.start.pos_fname }
-  ; stop = { loc.stop with pos_fname = make_path loc.stop.pos_fname }
-  }
-
-let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
-    =
- fun m ->
-  let message, related, dir = Build_system.Error.info m in
-  let make_loc loc =
-    match dir with
-    | None -> loc
-    | Some dir -> absolutize_paths ~dir loc
-  in
-  let loc = Option.map message.loc ~f:make_loc in
-  let make_message pars = Pp.map_tags (Pp.concat pars) ~f:(fun _ -> ()) in
-  let id = Build_system.Error.id m |> Diagnostic.Id.create in
-  let promotion =
-    match Build_system.Error.promotion m with
-    | None -> []
-    | Some { in_source; in_build } ->
-      [ { Diagnostic.Promotion.in_source =
-            Path.to_absolute_filename (Path.source in_source)
-        ; in_build = Path.to_absolute_filename (Path.build in_build)
-        }
-      ]
-  in
-  let related =
-    List.map related ~f:(fun (related : User_message.t) ->
-        { Dune_rpc_private.Diagnostic.Related.message =
-            make_message related.paragraphs
-        ; loc = make_loc (Option.value_exn related.loc)
-        })
-  in
-  { severity = None
-  ; id
-  ; targets = []
-  ; message = make_message message.paragraphs
-  ; loc
-  ; promotion
-  ; related
-  ; directory =
-      Option.map
-        ~f:(fun p ->
-          Path.to_absolute_filename
-            (Path.drop_optional_build_context_maybe_sandboxed p))
-        dir
-  }
 
 (* TODO un-copy-paste from dune/bin/arg.ml *)
 let dep_parser =
@@ -129,108 +73,6 @@ module Session_comparable = Comparable.Make (struct
 end)
 
 module Session_set = Session_comparable.Set
-
-module Subscribers : sig
-  type t
-
-  type _ what =
-    | Diagnostic : Diagnostic.Event.t list what
-    | Progress : Progress.t what
-
-  val empty : t
-
-  val remove : t -> 'a what -> 'a Subscription.t -> t
-
-  (** Remove all subscriptions of a sesssion *)
-  val remove_session : t -> Client.t Session.t -> t
-
-  val add : t -> 'a what -> 'a Subscription.t -> t
-
-  val notify : t -> 'a what -> 'a -> unit Fiber.t
-end = struct
-  module S = struct
-    let compare = Subscription.compare
-
-    let to_dyn x = Subscription.to_dyn x
-  end
-
-  module Progress_subs_comparable = Comparable.Make (struct
-    type t = Progress.t Subscription.t
-
-    include S
-  end)
-
-  module Progress_subs = Progress_subs_comparable.Set
-
-  module Diagnostic_subs_comparable = Comparable.Make (struct
-    type t = Diagnostic.Event.t list Subscription.t
-
-    include S
-  end)
-
-  module Diagnostic_subs = Diagnostic_subs_comparable.Set
-  module Session_map = Session_comparable.Map
-
-  module Sub_comparable = Comparable.Make (struct
-    type t = Subscription.packed
-
-    let compare x y = Subscription.compare_packed x y
-
-    let to_dyn (Subscription.E x) = Subscription.to_dyn x
-  end)
-
-  module Sub_map = Sub_comparable.Map
-
-  type t =
-    { build_progress : Progress.t Subscription.t Sub_map.t
-    ; diagnostic : Diagnostic.Event.t list Subscription.t Sub_map.t
-    }
-
-  type _ what =
-    | Diagnostic : Diagnostic.Event.t list what
-    | Progress : Progress.t what
-
-  let empty = { build_progress = Sub_map.empty; diagnostic = Sub_map.empty }
-
-  let with_sub_map (type a b) t (what : a what)
-      ~(f : a Subscription.t Sub_map.t -> b * a Subscription.t Sub_map.t) :
-      b * t =
-    match what with
-    | Progress ->
-      let res, build_progress = f t.build_progress in
-      (res, { t with build_progress })
-    | Diagnostic ->
-      let res, diagnostic = f t.diagnostic in
-      (res, { t with diagnostic })
-
-  let modify t what ~f =
-    let (), res = with_sub_map t what ~f:(fun map -> ((), f map)) in
-    res
-
-  let add (type a) t (what : a what) (sub : a Subscription.t) =
-    let key = Subscription.E sub in
-    modify t what ~f:(fun map -> Sub_map.add_exn map key sub)
-
-  let remove (type a) t (what : a what) (sub : a Subscription.t) =
-    let key = Subscription.E sub in
-    modify t what ~f:(fun map -> Sub_map.remove map key)
-
-  let remove_session t session =
-    Session.subscriptions session
-    |> List.fold_left ~init:t ~f:(fun t sub ->
-           { build_progress = Sub_map.remove t.build_progress sub
-           ; diagnostic = Sub_map.remove t.diagnostic sub
-           })
-
-  let notify (type a) t (what : a what) (a : a) =
-    let fiber, _map =
-      with_sub_map t what ~f:(fun map ->
-          ( Sub_map.values map
-            |> Fiber.parallel_iter ~f:(fun sub -> Subscription.update sub a)
-          , map ))
-    in
-    fiber
-end
 
 (** Primitive unbounded FIFO channel. Reads are blocking. Writes are not
     blocking. At most one read is allowed at a time. *)
@@ -287,7 +129,7 @@ type t =
       (Dep_conf.t list * Build_outcome.t Fiber.Ivar.t) Job_queue.t
   ; build_handler : Build_system.Handler.t
   ; pool : Fiber.Pool.t
-  ; mutable subscribers : Subscribers.t
+  ; long_poll : Long_poll.t
   ; mutable clients : Session_set.t
   }
 
@@ -302,8 +144,7 @@ let handler (t : t Fdecl.t) : 'a Dune_rpc_server.Handler.t =
   in
   let on_terminate session =
     let t = Fdecl.get t in
-    t.subscribers <- Subscribers.remove_session t.subscribers session;
-    Fiber.return ()
+    Long_poll.disconnect_session t.long_poll session
   in
   let rpc =
     Handler.create ~on_terminate ~on_init
@@ -363,48 +204,23 @@ let handler (t : t Fdecl.t) : 'a Dune_rpc_server.Handler.t =
   in
   let () =
     let info = Handler.public ~since:(3, 0) () in
-    Handler.subscription rpc info Sub.progress
-      ~on_subscribe:(fun _ -> Fiber.return ())
-      ~subscription:(fun _session () sub ->
-        let t = Fdecl.get t in
-        let* () =
-          let event =
-            match Build_system.last_event () with
-            | Some Fail -> Progress.Failed
-            | Some Interrupt -> Interrupted
-            | Some Finish -> Success
-            | None -> Progress.Waiting
-            | Some Start ->
-              let current_progress : Build_system.Progress.t =
-                Build_system.get_current_progress ()
-              in
-              let complete = current_progress.number_of_rules_executed in
-              In_progress
-                { complete
-                ; remaining =
-                    current_progress.number_of_rules_discovered - complete
-                }
-          in
-          Subscription.update sub event
-        in
-        t.subscribers <- Subscribers.add t.subscribers Progress sub;
-        let+ () = Subscription.finished sub in
-        t.subscribers <- Subscribers.remove t.subscribers Progress sub)
+    Handler.poll rpc info Sub.progress
+      ~on_cancel:(fun _session poller ->
+        let p = Long_poll.progress (Fdecl.get t).long_poll in
+        Long_poll.Instance.client_cancel p poller)
+      ~on_poll:(fun _session poller ->
+        let p = Long_poll.progress (Fdecl.get t).long_poll in
+        Long_poll.Instance.poll p poller)
   in
   let () =
     let info = Handler.public ~since:(3, 0) () in
-    Handler.subscription rpc info Sub.diagnostic
-      ~on_subscribe:(fun _ -> Fiber.return ())
-      ~subscription:(fun _session () sub ->
-        let t = Fdecl.get t in
-        let* () =
-          Build_system.errors ()
-          |> List.map ~f:(fun e -> Diagnostic.Event.Add (diagnostic_of_error e))
-          |> Subscription.update sub
-        in
-        t.subscribers <- Subscribers.add t.subscribers Diagnostic sub;
-        let+ () = Subscription.finished sub in
-        t.subscribers <- Subscribers.remove t.subscribers Diagnostic sub)
+    Handler.poll rpc info Sub.diagnostic
+      ~on_cancel:(fun _session poller ->
+        let p = Long_poll.diagnostic (Fdecl.get t).long_poll in
+        Long_poll.Instance.client_cancel p poller)
+      ~on_poll:(fun _session poller ->
+        let p = Long_poll.diagnostic (Fdecl.get t).long_poll in
+        Long_poll.Instance.poll p poller)
   in
   let () =
     let f () =
@@ -422,7 +238,7 @@ let handler (t : t Fdecl.t) : 'a Dune_rpc_server.Handler.t =
     let cb =
       let f () =
         Build_system.errors ()
-        |> List.map ~f:diagnostic_of_error
+        |> List.map ~f:Diagnostics.diagnostic_of_error
         |> Fiber.return
       in
       Handler.callback (Handler.public ~since:(1, 0) ()) f
@@ -485,11 +301,7 @@ let task t f =
 let error t errors =
   let t = Fdecl.get t in
   task t (fun () ->
-      List.map errors ~f:(fun (e : Build_system.Handler.error) ->
-          match e with
-          | Add x -> Diagnostic.Event.Add (diagnostic_of_error x)
-          | Remove x -> Remove (diagnostic_of_error x))
-      |> Subscribers.notify t.subscribers Diagnostic)
+      Long_poll.Instance.update (Long_poll.diagnostic t.long_poll) errors)
 
 let progress_of_build_event : Build_system.Handler.event -> Progress.t =
   function
@@ -501,14 +313,14 @@ let progress_of_build_event : Build_system.Handler.event -> Progress.t =
 let build_progress t ~complete ~remaining =
   let t = Fdecl.get t in
   task t (fun () ->
-      let notification = Progress.In_progress { complete; remaining } in
-      Subscribers.notify t.subscribers Progress notification)
+      let progress = Progress.In_progress { complete; remaining } in
+      Long_poll.Instance.update (Long_poll.progress t.long_poll) progress)
 
 let build_event t (event : Build_system.Handler.event) =
   let t = Fdecl.get t in
+  let progress = progress_of_build_event event in
   task t (fun () ->
-      let notification = progress_of_build_event event in
-      Subscribers.notify t.subscribers Progress notification)
+      Long_poll.Instance.update (Long_poll.progress t.long_poll) progress)
 
 let create () =
   let t = Fdecl.create Dyn.Encoder.opaque in
@@ -520,13 +332,14 @@ let create () =
     Build_system.Handler.create ~error:(error t)
       ~build_progress:(build_progress t) ~build_event:(build_event t)
   in
+  let long_poll = Long_poll.create () in
   let res =
     { config
     ; pending_build_jobs
-    ; subscribers = Subscribers.empty
     ; clients = Session_set.empty
     ; build_handler
     ; pool
+    ; long_poll
     }
   in
   Fdecl.set t res;

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -1,5 +1,48 @@
 open Stdune
 open Dune_rpc_private
+open Fiber.O
+
+module Subscription = struct
+  module Id = Stdune.Id.Make ()
+
+  type 'a t =
+    { send : 'a option -> unit Fiber.t
+    ; finished : unit Fiber.Ivar.t
+    ; mutable active : bool
+    ; id : Id.t
+    }
+
+  let to_dyn t = Id.to_dyn t.id
+
+  type packed = E : _ t -> packed
+
+  let compare x y = Id.compare x.id y.id
+
+  let compare_packed (E x) (E y) = Id.compare x.id y.id
+
+  let finished t = Fiber.Ivar.read t.finished
+
+  let active t = t.active
+
+  let finish' t ~by_ =
+    Fiber.of_thunk (fun () ->
+        match t.active with
+        | false -> Fiber.return ()
+        | true -> (
+          t.active <- false;
+          match by_ with
+          | `Client -> Fiber.Ivar.fill t.finished ()
+          | `Server ->
+            Fiber.fork_and_join_unit (Fiber.Ivar.fill t.finished) (fun () ->
+                t.send None)))
+
+  let finish = finish' ~by_:`Server
+
+  let update t a =
+    if not t.active then
+      Code_error.raise "trying to update an inactive subscription" [];
+    t.send (Some a)
+end
 
 module Session = struct
   type 'a state =
@@ -16,8 +59,12 @@ module Session = struct
     { queries : Packet.Query.t Fiber.Stream.In.t
     ; id : Id.t
     ; send : Packet.Reply.t list option -> unit Fiber.t
+    ; pool : Fiber.Pool.t
     ; mutable state : 'a state
+    ; mutable subscriptions : Subscription.packed Dune_rpc_private.Id.Map.t
     }
+
+  let subscriptions t = Dune_rpc_private.Id.Map.values t.subscriptions
 
   let set t state =
     match t.state with
@@ -40,7 +87,13 @@ module Session = struct
     | Uninitialized -> Code_error.raise "initialize: request not available" []
 
   let create ~queries ~send =
-    { queries; send; state = Uninitialized; id = Id.gen () }
+    { queries
+    ; send
+    ; state = Uninitialized
+    ; id = Id.gen ()
+    ; subscriptions = Dune_rpc_private.Id.Map.empty
+    ; pool = Fiber.Pool.create ()
+    }
 
   let notification t (decl : _ Decl.notification) n =
     let call =
@@ -68,9 +121,25 @@ module Session = struct
       in
       constr "Initialized" [ record ]
 
-  let to_dyn f { id; state; queries = _; send = _ } =
+  let to_dyn f { id; state; subscriptions = _; queries = _; send = _; pool = _ }
+      =
     let open Dyn.Encoder in
     record [ ("id", Id.to_dyn id); ("state", dyn_of_state f state) ]
+
+  let create_subscription t client_id sub =
+    let decl = Server_notifications.update_sub sub in
+    let send v = notification t decl (client_id, v) in
+    let sub =
+      { Subscription.send
+      ; finished = Fiber.Ivar.create ()
+      ; active = true
+      ; id = Subscription.Id.gen ()
+      }
+    in
+    t.subscriptions <-
+      Dune_rpc_private.Id.Map.add_exn t.subscriptions client_id
+        (Subscription.E sub);
+    sub
 end
 
 type message_kind =
@@ -136,7 +205,6 @@ module H = struct
     }
 
   let abort ?payload session ~message =
-    let open Fiber.O in
     let* () =
       Session.notification session Server_notifications.abort
         { Message.message; payload }
@@ -144,7 +212,6 @@ module H = struct
     session.send None
 
   let handle (type a) (t : a t) stats (session : a Session.t) =
-    let open Fiber.O in
     let* query = Fiber.Stream.In.read session.queries in
     match query with
     | None -> session.send None
@@ -230,14 +297,16 @@ module H = struct
     let public ?until ~since () = Public { since; until }
 
     type ('state, 'req, 'resp) callback =
-      { info : info
-      ; f : 'state Session.t -> 'req -> 'resp Fiber.t
+      { info : info (* XXX for notifications, the id always null *)
+      ; f : 'state Session.t -> Id.t option -> 'req -> 'resp Fiber.t
       }
 
-    let callback' info f = { info; f }
+    let callback' info f =
+      let f session _id req = f session req in
+      { info; f }
 
     let callback info f =
-      let f _ x = f x in
+      let f _session _id x = f x in
       { info; f }
 
     type 's n_handler =
@@ -246,13 +315,80 @@ module H = struct
     type 's r_handler =
       | R : ('s, 'a, 'b) callback * ('a, 'b) Decl.request -> 's r_handler
 
+    type 's sub =
+      | Sub :
+          info
+          * 'a Sub.t
+          * ('s Session.t -> 'init Fiber.t)
+          * ('s Session.t -> 'init -> 'a Subscription.t -> unit Fiber.t)
+          -> 's sub
+
     type 's t =
       { mutable notification_handlers : 's n_handler list
       ; mutable request_handlers : 's r_handler list
+      ; mutable subscriptions : 's sub list String.Map.t
       ; on_init : 's Session.t -> Initialize.Request.t -> 's Fiber.t
       ; on_terminate : 's Session.t -> unit Fiber.t
       ; version : int * int
       }
+
+    let find_cb cbs ~version ~info =
+      List.find cbs ~f:(fun cb ->
+          match info cb with
+          | Private -> true
+          | Public { since; until } -> (
+            version >= since
+            &&
+            match until with
+            | None -> true
+            | Some until -> version <= until))
+
+    let on_subscribe_request subscriptions =
+      let callback =
+        let info = public ~since:(3, 0) () in
+        let f session req_id what =
+          let req_id = Option.value_exn req_id in
+          match String.Map.find subscriptions what with
+          | None ->
+            let err =
+              let payload = Sexp.record [ ("what", Sexp.Atom what) ] in
+              Response.Error.create ~kind:Invalid_request ~payload
+                ~message:"Unknown subscription" ()
+            in
+            raise (Response.Error.E err)
+          | Some subs -> (
+            match
+              let version = (Session.initialize session).version in
+              find_cb subs ~version ~info:(fun (Sub (a, _, _, _)) -> a)
+            with
+            | None ->
+              abort session ~message:"No subscription matching version."
+                ~payload:(Sexp.record [ ("subscription", Atom what) ])
+            | Some (Sub (_info, sub, on_subscribe, init_subscription)) ->
+              let* init = on_subscribe session in
+              let subscription =
+                Session.create_subscription session req_id sub
+              in
+              Fiber.Pool.task session.pool ~f:(fun () ->
+                  init_subscription session init subscription))
+        in
+        { info; f }
+      in
+      R (callback, Sub.subscribe)
+
+    let on_unsubscribe_notification () =
+      let callback =
+        let info = public ~since:(3, 0) () in
+        let f (session : _ Session.t) _no_req_id sub_id =
+          match Id.Map.find session.subscriptions sub_id with
+          | None ->
+            (* TODO warn the user this is a no-op *)
+            Fiber.return ()
+          | Some (Subscription.E sub) -> Subscription.finish' sub ~by_:`Client
+        in
+        { info; f }
+      in
+      N (callback, Sub.cancel)
 
     let to_handler
         { on_init
@@ -260,28 +396,20 @@ module H = struct
         ; request_handlers
         ; version
         ; on_terminate
+        ; subscriptions
         } =
       let request_handlers, notification_handlers =
         let r = Table.create (module String) 16 in
         let n = Table.create (module String) 16 in
-        List.iter notification_handlers ~f:(fun (N (cb, decl)) ->
+        List.iter (on_unsubscribe_notification () :: notification_handlers)
+          ~f:(fun (N (cb, decl)) ->
             Table.Multi.cons n decl.method_ (N (cb, decl)));
-        List.iter request_handlers ~f:(fun (R (cb, decl)) ->
+        List.iter (on_subscribe_request subscriptions :: request_handlers)
+          ~f:(fun (R (cb, decl)) ->
             Table.Multi.cons r decl.method_ (R (cb, decl)));
         (* TODO This all needs proper validation. It shouldn't be possible for
            the same methods to overlap versions *)
         (r, n)
-      in
-      let find_cb cbs ~version ~info =
-        List.find cbs ~f:(fun cb ->
-            match info cb with
-            | Private -> true
-            | Public { since; until } -> (
-              version >= since
-              &&
-              match until with
-              | None -> true
-              | Some until -> version <= until))
       in
       let no_method_version_error ~method_ ~infos:_ =
         let payload = Sexp.record [ ("method", Atom method_) ] in
@@ -302,14 +430,14 @@ module H = struct
               ~payload:(Sexp.record [ ("method", Atom n.method_) ])
           | Some (N (cb, v)) -> (
             match Conv.of_sexp v.req ~version n.params with
-            | Ok v -> cb.f session v
+            | Ok v -> cb.f session None v
             | Error _ ->
               abort session ~message:"Invalid notification payload"
                 ~payload:
                   (Sexp.record
                      [ ("method", Atom n.method_); ("payload", n.params) ])))
       in
-      let on_request session (_id, (n : Call.t)) =
+      let on_request session (id, (n : Call.t)) =
         let version = Initialize.Request.version (Session.initialize session) in
         match Table.find request_handlers n.method_ with
         | None ->
@@ -328,8 +456,9 @@ module H = struct
             match Conv.of_sexp decl.req ~version n.params with
             | Error e -> Fiber.return (Error (Response.Error.of_conv e))
             | Ok input -> (
-              let open Fiber.O in
-              let+ r = Fiber.collect_errors (fun () -> cb.f session input) in
+              let+ r =
+                Fiber.collect_errors (fun () -> cb.f session (Some id) input)
+              in
               match r with
               | Ok s -> Ok (Conv.to_sexp decl.resp s)
               | Error
@@ -356,6 +485,7 @@ module H = struct
       ; on_init
       ; version
       ; on_terminate
+      ; subscriptions = String.Map.empty
       }
 
     let request (t : _ t) cb decl =
@@ -363,12 +493,18 @@ module H = struct
 
     let notification (t : _ t) cb decl =
       t.notification_handlers <- N (cb, decl) :: t.notification_handlers
+
+    let subscription (t : _ t) info (sub : _ Sub.t) ~on_subscribe ~subscription
+        =
+      t.subscriptions <-
+        String.Map.Multi.cons t.subscriptions sub.name
+          (Sub (info, sub, on_subscribe, subscription))
   end
 end
 
 type t = Server : 'a H.t -> t
 
-let make h = Server (H.Builder.to_handler h)
+let make (type a) (h : a H.Builder.t) : t = Server (H.Builder.to_handler h)
 
 let version (Server h) = h.version
 
@@ -377,14 +513,18 @@ let new_session (Server handler) stats ~queries ~send =
   object
     method id = session.id
 
-    method start = H.handle handler stats session
+    method start =
+      Fiber.fork_and_join_unit
+        (fun () -> Fiber.Pool.run session.pool)
+        (fun () ->
+          let* () = H.handle handler stats session in
+          Fiber.Pool.stop session.pool)
   end
 
 exception Invalid_session of Conv.error
 
 let create_sequence f ~version conv =
   let read () =
-    let open Fiber.O in
     let+ read = f () in
     Option.map read ~f:(fun sexp ->
         match Conv.of_sexp conv ~version sexp with

--- a/src/dune_util/log.ml
+++ b/src/dune_util/log.ml
@@ -5,6 +5,7 @@ module File = struct
     | Default
     | No_log_file
     | This of Path.t
+    | Out_channel of out_channel
 end
 
 type real =
@@ -21,6 +22,7 @@ let init ?(file = File.Default) () =
   let oc =
     match file with
     | No_log_file -> None
+    | Out_channel s -> Some s
     | This path -> Some (Io.open_out path)
     | Default ->
       Path.ensure_build_dir_exists ();

--- a/src/dune_util/log.mli
+++ b/src/dune_util/log.mli
@@ -6,6 +6,7 @@ module File : sig
     | Default
     | No_log_file
     | This of Path.t
+    | Out_channel of out_channel
 end
 
 (** Initialise the log file *)

--- a/test/expect-tests/dune_rpc/dune
+++ b/test/expect-tests/dune_rpc/dune
@@ -6,6 +6,7 @@
   ocaml_config
   dune_rpc_private
   dune_rpc_server
+  dune_rpc_impl
   stdune
   test_scheduler
   csexp

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.mli
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.mli
@@ -1,0 +1,1 @@
+(* intentionally empty *)

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -929,7 +929,7 @@ let%expect_test "all_concurrently_unit" =
              Fiber.all_concurrently_unit [ print 1; fail ])
        in
        match res with
-       | Error [ { exn = Exit; _ } ] -> printfn "successfully caught errror"
+       | Error [ { exn = Exit; _ } ] -> printfn "successfully caught error"
        | Ok () -> assert false
        | Error _ -> assert false
      in
@@ -937,5 +937,5 @@ let%expect_test "all_concurrently_unit" =
   [%expect
     {|
     print: 1
-    successfully caught errror
+    successfully caught error
     multi element list |}]


### PR DESCRIPTION
This PR introduces a new subscription mechanism with the following advantages:

* Consistent API to subscribe and unsubscribe
* A way to terminate a subscription from the server side
* Multiple subscriptions of the same type per connection (not useful yet)
* Formalizes the pattern of returning the initial value along with the subscription.
* Server API to define new types of things to subscribe for.

I've yet to use the new API for our current subscriptions. I'd like to get a round of review for the API first.