### PR TITLE
[RPC] fix another race in analyze_path

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -108,7 +108,8 @@ module V1 = struct
               Lwt.return
                 (match stat.st_kind with
                 | Unix.S_SOCK -> `Unix_socket
-                | _ -> `Normal_file))
+                | S_REG -> `Normal_file
+                | _ -> `Other))
             (fun _ -> Lwt.return `Other)
       end)
 

--- a/src/dune_rpc_impl/where.ml
+++ b/src/dune_rpc_impl/where.ml
@@ -26,12 +26,11 @@ module Where =
         | exception Unix.Unix_error (Unix.EINVAL, _, _) -> None
 
       let analyze_path s =
-        if Sys.file_exists s then
-          let stat = Unix.stat s in
-          match stat.st_kind with
-          | Unix.S_SOCK -> `Unix_socket
-          | _ -> `Normal_file
-        else
+        match (Unix.stat s).st_kind with
+        | Unix.S_SOCK -> `Unix_socket
+        | S_REG -> `Normal_file
+        | _
+        | (exception Unix.Unix_error (Unix.ENOENT, _, _)) ->
           `Other
     end)
 


### PR DESCRIPTION
It is possible that a file could be created after Sys.file_exists but
before Unix.stat. In which case, an incorrect result will be returned.
This PR changes analyze_path to only rely on Unix.stat

@aalekseyev It's not the race you've encountered, but it's good to fix anyway.