### PR TITLE
[WIP] Remove Rule.Id

### DIFF
--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -46,19 +46,8 @@ module Mode : sig
             .install files. *)
 end
 
-module Id : sig
-  type t
-
-  val compare : t -> t -> Ordering.t
-
-  module Map : Map.S with type key = t
-
-  module Set : Set.S with type elt = t
-end
-
 type t = private
-  { id : Id.t
-  ; context : Build_context.t option
+  { context : Build_context.t option
   ; targets : Path.Build.Set.t
   ; action : Action.Full.t Action_builder.t
   ; mode : Mode.t
@@ -66,12 +55,6 @@ type t = private
   ; loc : Loc.t
   ; (* Directory where all the targets are produced. *) dir : Path.Build.t
   }
-
-module Set : Set.S with type elt = t
-
-val equal : t -> t -> bool
-
-val hash : t -> int
 
 val to_dyn : t -> Dyn.t
 
@@ -92,6 +75,8 @@ val loc : t -> Loc.t
     rule.dir. Eg. [src/dune] for a rule with dir
     [_build/default/src/dune/.dune.objs]. *)
 val find_source_dir : t -> Source_tree.Dir.t Memo.Build.t
+
+val head_target : t -> Path.Build.t
 
 module Anonymous_action : sig
   (* jeremiedimino: this type correspond to a subset of [Rule.t]. We should


### PR DESCRIPTION
Whenever we create a `Rule.t`, we generate a fresh id that we put in the rule. This id is used for comparing rules, which is used for the memoized function `execute_rule : Rule.t -> rule_execution_result Memo.Build.t`.

`execute_rule` is memoized so that if a rule produce two targets `a` and `b`, `build_file a` and `build_file b` will not execute the rule twice.

However, because fresh ids are generated every time we create a rule, when we reload a directory all the ids of the rules for this directory are going to be refreshed. This means that the memo cache for `execute_rule` will just keep on growing.

This PR fixes this by sharing rule execution via a `Memo.Lazy.t` instead. This `Memo.Lazy.t` is stored in the rule map produced by the function that loads a directory. This PR then removes `Rule.Id`. They were a few places in the code where we were using rules' ids to create rules sets. I replaced these rules sets by heads targets sets.