### PR TITLE
A couple of tiny tweaks

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -256,7 +256,7 @@ module Buildable = struct
                        (libname, flags))
                   and+ deps =
                     field "deps" ~default:[]
-                      (Dune_lang.Syntax.since Stanza.syntax (3, 0)
+                      (Dune_lang.Syntax.since Stanza.syntax (2, 9)
                       >>> repeat Dep_conf.decode)
                   in
                   (backend, deps))))

--- a/test/blackbox-tests/test-cases/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/instrumentation.t/run.t
@@ -109,8 +109,8 @@ We also check that we can declare dependencies to the ppx.
   File "dune", line 6, characters 65-83:
   6 |  (instrumentation (backend hello -place Spain -file input/input) (deps input/input)))
                                                                        ^^^^^^^^^^^^^^^^^^
-  Error: 'deps' is only available since version 3.0 of the dune language.
-  Please update your dune-project file to have (lang dune 3.0).
+  Error: 'deps' is only available since version 2.9 of the dune language.
+  Please update your dune-project file to have (lang dune 2.9).
   [1]
 
   $ cat >dune-project <<EOF

--- a/vendor/ocaml-inotify/src/inotify_stubs.c
+++ b/vendor/ocaml-inotify/src/inotify_stubs.c
@@ -17,7 +17,6 @@
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <limits.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -30,6 +29,7 @@
 
 #ifdef __linux__
 
+#include <unistd.h>
 #include <features.h>
 #include <sys/inotify.h>
 


### PR DESCRIPTION
- `unistd.h` does not exist on Windows (in `inotify_stubs.c`)
- fix version check for a feature that was backported to 2.9