### PR TITLE
Fix handling of optional arguments in cmdliner

### DIFF
--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -150,8 +150,7 @@ Test with an opam like installation
       name
       "-j"
       jobs
-      "--promote-install-files"
-      "false"
+      "--promote-install-files=false"
       "@install"
       "@runtest" {with-test}
       "@doc" {with-doc}
@@ -159,7 +158,7 @@ Test with an opam like installation
     ["dune" "install" "-p" name "--create-install-files" name]
   ]
 
-  $ dune build -p a --promote-install-files "false" @install
+  $ dune build -p a --promote-install-files=false @install
 
   $ test -e a/a.install
   [1]

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -49,7 +49,7 @@ let default_build_command =
             {|
 [
   [ "dune" "subst" "--root" "." ] {dev}
-  [ "dune" "build" "-p" name "-j" jobs "--promote-install-files" "false"
+  [ "dune" "build" "-p" name "-j" jobs "--promote-install-files=false"
       "@install"
       "@runtest" {with-test}
       "@doc" {with-doc}

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -31,7 +31,7 @@ Clean up the library tests
 
 Can init library with a specified public name
 
-  $ dune init lib test_lib ./_test_lib_dir --public test_lib_public_name
+  $ dune init lib test_lib ./_test_lib_dir --public=test_lib_public_name
   Success: initialized library component named test_lib
   $ cat ./_test_lib_dir/dune
   (library

--- a/vendor/cmdliner/src/cmdliner_cline.ml
+++ b/vendor/cmdliner/src/cmdliner_cline.ml
@@ -104,8 +104,8 @@ let parse_opt_args ~peek_opts optidx cl args =
           | Some v, (Cmdliner_info.Flag | Opt_vopt _) when is_short_opt name ->
             None, ("-" ^ v) :: args
           | Some _, _ -> value, args
-          | None, Cmdliner_info.Flag -> value, args
-          | None, _ ->
+          | None, (Cmdliner_info.Flag | Cmdliner_info.Opt_vopt _) -> value, args
+          | None, Cmdliner_info.Opt ->
               match args with
               | [] -> None, args
               | v :: rest -> if is_opt v then None, args else Some v, rest


### PR DESCRIPTION
Optional arguments for command line flags in cmdliner are confusing.
For example, if `--promote-install-files` has an optional boolean argument (which it does), then the current behavior is like this:

    - `dune build --promote-install-files true bar` -> builds bar, promote-install-files=true
    - `dune build --promote-install-files bar` -> error (trying to parse "bar" as bool)
    - `dune build bar --promote-install-files` -> builds bar, promote-install-files gets its default value

This means that it's only possible to omit the optional argument value when the flag is the last argument on the command-line, which is weird!

This PR disallows the form `--promote-install-files true` completely, so it's now possible to omit the optional value anywhere on the command line. It's also possible to specify it using the already existing syntax `--promote-install-files=true`.

This also fixes the issue for the short form: `dune build -w foo` will now build the file `foo` in watching mode instead of trying to parse `foo` as the name of the watching mode.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>