### PR TITLE
Rename [--watch=passive] into [--passive-watch-mode]

### DIFF
--- a/test/blackbox-tests/test-cases/watching/test-1.t/run.t
+++ b/test/blackbox-tests/test-cases/watching/test-1.t/run.t
@@ -1,7 +1,7 @@
   $ DUNE_RUNNING=0
 
   $ start_dune () {
-  >  ((dune build "$@" --watch=passive > dune-output 2>&1) || (echo exit $? >> dune-output)) &
+  >  ((dune build "$@" --passive-watch-mode > dune-output 2>&1) || (echo exit $? >> dune-output)) &
   >   DUNE_PID=$!;
   >   DUNE_RUNNING=1;
   > }

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -117,7 +117,7 @@ let run_dump_out ~prog ~argv =
 
 let run_server ~root_dir =
   run ~prog:(Lazy.force dune_prog)
-    ~argv:[ "build"; "--watch=passive"; "--root"; root_dir ]
+    ~argv:[ "build"; "--passive-watch-mode"; "--root"; root_dir ]
 
 let dune_build client what =
   printfn "Building %s" what;

--- a/vendor/cmdliner/src/cmdliner_cline.ml
+++ b/vendor/cmdliner/src/cmdliner_cline.ml
@@ -101,7 +101,7 @@ let parse_opt_args ~peek_opts optidx cl args =
       match Cmdliner_trie.find optidx name with
       | `Ok a ->
           let value, args = match value, Cmdliner_info.arg_opt_kind a with
-          | Some v, (Cmdliner_info.Flag | Opt_vopt _) when is_short_opt name ->
+          | Some v, (Cmdliner_info.Flag) when is_short_opt name ->
             None, ("-" ^ v) :: args
           | Some _, _ -> value, args
           | None, Cmdliner_info.Flag -> value, args


### PR DESCRIPTION
... to avoid delving into deep corners of cmdliner.

Also, revert our cmdliner patch.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>