### PR TITLE
[RPC] improve end to end tests

### DIFF
--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -66,7 +66,9 @@ let read_lines in_ =
     | Error `Stopped -> assert false
     | Error (`Exn e) ->
       (match e.exn with
-      | End_of_file -> ()
+      | End_of_file
+      | Sys_error _ ->
+        ()
       | _ ->
         Format.eprintf "Error reading channel: %a@.%!"
           Exn_with_backtrace.pp_uncaught e);


### PR DESCRIPTION
Treat `Sys_error` as EOF when reading from fd.

Should be harmless to ignore this.