### PR TITLE
Memoize Lib rules

### DIFF
--- a/bin/top.ml
+++ b/bin/top.ml
@@ -50,7 +50,7 @@ let term =
             Dune_rules.Utop.libs_under_dir sctx ~db ~dir:(Path.build dir)
           in
           let* requires =
-            Dune_rules.Resolve.read_memo_build
+            Dune_rules.Resolve.Build.read_memo_build
               (Dune_rules.Lib.closure ~linking:true libs)
           in
           let include_paths =

--- a/otherlibs/stdune-unstable/array.ml
+++ b/otherlibs/stdune-unstable/array.ml
@@ -1,1 +1,15 @@
 include ArrayLabels
+
+let equal f x y =
+  let open Stdlib.Array in
+  let len = length x in
+  if len <> length y then
+    false
+  else
+    try
+      for i = 0 to len - 1 do
+        if not (f (get x i) (get y i)) then raise_notrace Exit
+      done;
+      true
+    with
+    | Exit -> false

--- a/otherlibs/stdune-unstable/monad.mli
+++ b/otherlibs/stdune-unstable/monad.mli
@@ -2,7 +2,15 @@
 
 module type Basic = Monad_intf.Basic
 
+module type S = Monad_intf.S
+
+module type List = Monad_intf.List
+
 module Make (M : Basic) : Monad_intf.S with type 'a t := 'a M.t
 [@@inlined always]
 
 module Id : Monad_intf.S with type 'a t = 'a
+
+module List (M : Monad_intf.S) : Monad_intf.List with type 'a t := 'a M.t
+
+module Option (M : Monad_intf.S) : Monad_intf.Option with type 'a t := 'a M.t

--- a/otherlibs/stdune-unstable/monad_intf.ml
+++ b/otherlibs/stdune-unstable/monad_intf.ml
@@ -29,3 +29,31 @@ module type S = sig
     val ( and* ) : 'a t -> 'b t -> ('a * 'b) t
   end
 end
+
+module type List = sig
+  type 'a t
+
+  val find_map : 'a list -> f:('a -> 'b option t) -> 'b option t
+
+  val map : 'a list -> f:('a -> 'b t) -> 'b list t
+
+  val concat_map : 'a list -> f:('a -> 'b list t) -> 'b list t
+
+  val exists : 'a list -> f:('a -> bool t) -> bool t
+
+  val iter : 'a list -> f:('a -> unit t) -> unit t
+
+  val filter : 'a list -> f:('a -> bool t) -> 'a list t
+
+  val filter_map : 'a list -> f:('a -> 'b option t) -> 'b list t
+
+  val fold_left : 'a list -> f:('acc -> 'a -> 'acc t) -> init:'acc -> 'acc t
+
+  val for_all : 'a list -> f:('a -> bool t) -> bool t
+end
+
+module type Option = sig
+  type 'a t
+
+  val iter : 'a option -> f:('a -> unit t) -> unit t
+end

--- a/otherlibs/stdune-unstable/state.ml
+++ b/otherlibs/stdune-unstable/state.ml
@@ -1,0 +1,31 @@
+module Make (S : sig
+  type t
+end)
+(M : Monad.S) =
+struct
+  module T = struct
+    type 'a t = S.t -> (S.t * 'a) M.t
+
+    let return a s = M.return (s, a)
+
+    let bind x ~f s =
+      let open M.O in
+      let* s', a = x s in
+      (f a) s'
+  end
+
+  open M.O
+  include T
+
+  let lift m s = m >>| fun a -> (s, a)
+
+  let modify f s = M.return (f s, ())
+
+  let get : S.t T.t = fun s -> M.return (s, s)
+
+  let set s _ = M.return (s, ())
+
+  let run t s = t s
+
+  include Monad.Make (T)
+end

--- a/otherlibs/stdune-unstable/state.mli
+++ b/otherlibs/stdune-unstable/state.mli
@@ -1,0 +1,28 @@
+(** State monad transformer. *)
+
+module Make (S : sig
+  (* The state isn't a type variable as is done traditionally, because we want
+     to reuse our existing monad machinery. All that machinery requires the
+     monad to have only one type variable *)
+  type t
+end)
+(M : Monad.S) : sig
+  include Monad.S
+
+  (** [run t state] runs computation [t] with [state] as the initial state. The
+      final state and the computed result are returned *)
+  val run : 'a t -> S.t -> (S.t * 'a) M.t
+
+  (** [get] returns the current state *)
+  val get : S.t t
+
+  (** [set s] sets the current state to [s] *)
+  val set : S.t -> unit t
+
+  (** [lift m] lifts [m] into the transformer *)
+  val lift : 'a M.t -> 'a t
+
+  (** [modify f] lifts [f] into the monad. [f] is executed with the current
+      state to produce a new state. *)
+  val modify : (S.t -> S.t) -> unit t
+end

--- a/otherlibs/stdune-unstable/stdune.ml
+++ b/otherlibs/stdune-unstable/stdune.ml
@@ -47,6 +47,7 @@ module Digest = Digest
 module Fdecl = Fdecl
 module Unit = Unit
 module Monad = Monad
+module State = State
 module Monoid = Monoid
 module Dyn = Dyn
 module Float = Float

--- a/src/dune_engine/action_builder0.mli
+++ b/src/dune_engine/action_builder0.mli
@@ -35,11 +35,7 @@ val all : 'a t list -> 'a list t
 
 val all_unit : unit t list -> unit t
 
-module List : sig
-  val map : 'a list -> f:('a -> 'b t) -> 'b list t
-
-  val concat_map : 'a list -> f:('a -> 'b list t) -> 'b list t
-end
+module List : Monad.List with type 'a t := 'a t
 
 val push_stack_frame :
      human_readable_description:(unit -> User_message.Style.t Pp.t)

--- a/src/dune_engine/action_dune_lang.ml
+++ b/src/dune_engine/action_dune_lang.ml
@@ -109,3 +109,5 @@ let decode =
         ]
 
 let to_dyn a = Dune_lang.to_dyn (encode a)
+
+let equal x y = Poly.equal x y

--- a/src/dune_engine/action_dune_lang.mli
+++ b/src/dune_engine/action_dune_lang.mli
@@ -27,3 +27,5 @@ val compare_no_locs : t -> t -> Ordering.t
 val to_dyn : t -> Dyn.t
 
 val remove_locs : t -> t
+
+val equal : t -> t -> bool

--- a/src/dune_engine/install.ml
+++ b/src/dune_engine/install.ml
@@ -280,9 +280,11 @@ module Entry = struct
 
   let make_with_site section ?dst get_section src =
     match section with
-    | Section_with_site.Section section -> make section ?dst src
+    | Section_with_site.Section section ->
+      Memo.Build.return (make section ?dst src)
     | Site { pkg; site; loc } ->
-      let section = get_section ~loc ~pkg ~site in
+      let open Memo.Build.O in
+      let+ section = get_section ~loc ~pkg ~site in
       let dst = adjust_dst' ~src ~dst ~section in
       let dst = Dst.add_prefix (Section.Site.to_string site) dst in
       let dst_with_pkg_prefix =

--- a/src/dune_engine/install.mli
+++ b/src/dune_engine/install.mli
@@ -89,9 +89,9 @@ module Entry : sig
     -> (   loc:Loc.t
         -> pkg:Package.Name.t
         -> site:Dune_section.Site.t
-        -> Section.t)
+        -> Section.t Memo.Build.t)
     -> Path.Build.t
-    -> Path.Build.t t
+    -> Path.Build.t t Memo.Build.t
 
   val set_src : _ t -> 'src -> 'src t
 

--- a/src/dune_engine/mode.ml
+++ b/src/dune_engine/mode.ml
@@ -83,6 +83,8 @@ module Dict = struct
   module Set = struct
     type nonrec t = bool t
 
+    let equal = equal Bool.equal
+
     let to_dyn { byte; native } =
       let open Dyn.Encoder in
       record [ ("byte", bool byte); ("native", bool native) ]

--- a/src/dune_engine/mode.mli
+++ b/src/dune_engine/mode.mli
@@ -80,6 +80,8 @@ module Dict : sig
 
     val encode : t -> Dune_lang.t list
 
+    val equal : t -> t -> bool
+
     val all : t
 
     val is_empty : t -> bool

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -739,6 +739,8 @@ let load_opam_file file name =
   ; sites = Section.Site.Map.empty
   }
 
+let equal = Poly.equal
+
 let missing_deps (t : t) ~effective_deps =
   let specified_deps =
     List.map t.depends ~f:(fun (dep : Dependency.t) -> dep.name)

--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -148,6 +148,8 @@ type t =
   ; sites : Section.t Section.Site.Map.t
   }
 
+val equal : t -> t -> bool
+
 val name : t -> Name.t
 
 val dir : t -> Path.Source.t

--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -60,7 +60,7 @@ module Public_libs = struct
   let create ~context ~public_libs = { context; public_libs }
 
   let file_of_lib t ~loc ~lib ~file =
-    let open Resolve.O in
+    let open Resolve.Build.O in
     let+ lib = Lib.DB.resolve t.public_libs (loc, lib) in
     if Lib.is_local lib then
       let package, rest = Lib_name.split (Lib.name lib) in

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -26,7 +26,7 @@ module Public_libs : sig
   (** [file_of_lib t ~from ~lib ~file] returns the path to a file in the
       directory of the given library. *)
   val file_of_lib :
-    t -> loc:Loc.t -> lib:Lib_name.t -> file:string -> Path.t Resolve.t
+    t -> loc:Loc.t -> lib:Lib_name.t -> file:string -> Path.t Resolve.Build.t
 end
 
 type t = private

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -10,7 +10,8 @@ let def name dyn =
 let rule sctx compile (exes : Dune_file.Executables.t) () =
   let* locals, externals =
     let+ libs =
-      Resolve.read_memo_build (Lazy.force (Lib.Compile.requires_link compile))
+      Resolve.Build.read_memo_build
+        (Memo.Lazy.force (Lib.Compile.requires_link compile))
     in
     List.partition_map libs ~f:(fun lib ->
         match Lib.Local.of_lib lib with

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -3,7 +3,7 @@ open Stdune
 
 let gen_select_rules t ~dir compile_info =
   let open Memo.Build.O in
-  Resolve.read_memo_build (Lib.Compile.resolved_selects compile_info)
+  Resolve.Build.read_memo_build (Lib.Compile.resolved_selects compile_info)
   >>= Memo.Build.parallel_iter ~f:(fun rs ->
           let { Lib.Compile.Resolved_select.dst_fn; src_fn } = rs in
           let dst = Path.Build.relative dir dst_fn in

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -110,10 +110,10 @@ let gen_rules sctx t ~dir ~scope =
   in
   let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
   let cctx =
+    let requires_compile = Lib.Compile.direct_requires compile_info in
+    let requires_link = Lib.Compile.requires_link compile_info in
     Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
-      ~modules ~opaque:(Explicit false)
-      ~requires_compile:(Lib.Compile.direct_requires compile_info)
-      ~requires_link:(Lib.Compile.requires_link compile_info)
+      ~modules ~opaque:(Explicit false) ~requires_compile ~requires_link
       ~flags:(Ocaml_flags.of_list [ "-w"; "-24" ])
       ~js_of_ocaml:None ~package:None
   in

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -29,8 +29,8 @@ val create :
   -> obj_dir:Path.Build.t Obj_dir.t
   -> modules:Modules.t
   -> flags:Ocaml_flags.t
-  -> requires_compile:Lib.t list Resolve.t
-  -> requires_link:Lib.t list Resolve.t Lazy.t
+  -> requires_compile:Lib.t list Resolve.Build.t
+  -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
   -> ?preprocessing:Pp_spec.t
   -> opaque:opaque
   -> ?stdlib:Ocaml_stdlib.t
@@ -63,9 +63,9 @@ val modules : t -> Modules.t
 
 val flags : t -> Ocaml_flags.t
 
-val requires_link : t -> Lib.t list Resolve.t
+val requires_link : t -> Lib.t list Resolve.Build.t
 
-val requires_compile : t -> Lib.t list Resolve.t
+val requires_compile : t -> Lib.t list Resolve.Build.t
 
 val includes : t -> Command.Args.without_targets Command.Args.t Cm_kind.Dict.t
 
@@ -90,7 +90,7 @@ val for_wrapped_compat : t -> t
 val for_root_module : t -> t
 
 val for_module_generated_at_link_time :
-  t -> requires:Lib.t list Resolve.t -> module_:Module.t -> t
+  t -> requires:Lib.t list Resolve.Build.t -> module_:Module.t -> t
 
 val for_plugin_executable :
   t -> embed_in_plugin_libraries:(Loc.t * Lib_name.t) list -> t

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -350,10 +350,11 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       match findlib_toolchain with
       | None -> Memo.Build.return None
       | Some toolchain ->
-        let+ path = Memo.Lazy.force findlib_config_path in
+        let* path = Memo.Lazy.force findlib_config_path in
         let toolchain = Context_name.to_string toolchain in
         let context = Context_name.to_string name in
-        Some (Findlib.Config.load path ~toolchain ~context)
+        let+ config = Findlib.Config.load path ~toolchain ~context in
+        Some config
     in
     let get_tool_using_findlib_config prog =
       match

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -115,7 +115,8 @@ let dep expander = function
        let+ () =
          let pkg = Package.Name.of_string pkg in
          let context = Expander.context expander in
-         match Expander.find_package expander pkg with
+         Action_builder.memo_build (Expander.find_package expander pkg)
+         >>= function
          | Some (Local pkg) ->
            Action_builder.alias
              (Alias.package_install

--- a/src/dune_rules/dir_with_dune.ml
+++ b/src/dune_rules/dir_with_dune.ml
@@ -13,12 +13,20 @@ let data t = t.data
 
 let map t ~f = { t with data = f t.data }
 
-let rec deep_fold l ~init ~f =
-  match l with
-  | [] -> init
-  | t :: l -> inner_fold t t.data l ~init ~f
+module Deep_fold (M : Monad.S) = struct
+  let rec deep_fold l ~init ~f =
+    match l with
+    | [] -> M.return init
+    | t :: l -> inner_fold t t.data l ~init ~f
 
-and inner_fold t inner_list l ~init ~f =
-  match inner_list with
-  | [] -> deep_fold l ~init ~f
-  | x :: inner_list -> inner_fold t inner_list l ~init:(f t x init) ~f
+  and inner_fold t inner_list l ~init ~f =
+    match inner_list with
+    | [] -> deep_fold l ~init ~f
+    | x :: inner_list ->
+      let open M.O in
+      let* init = f t x init in
+      inner_fold t inner_list l ~init ~f
+end
+
+include Deep_fold (Monad.Id)
+module Memo = Deep_fold (Memo.Build)

--- a/src/dune_rules/dir_with_dune.mli
+++ b/src/dune_rules/dir_with_dune.mli
@@ -18,3 +18,11 @@ val map : 'a t -> f:('a -> 'b) -> 'b t
     corresponding directory information corresponding as first argument *)
 val deep_fold :
   'a list t list -> init:'acc -> f:('a list t -> 'a -> 'acc -> 'acc) -> 'acc
+
+module Memo : sig
+  val deep_fold :
+       'a list t list
+    -> init:'acc
+    -> f:('a list t -> 'a -> 'acc -> 'acc Memo.Build.t)
+    -> 'acc Memo.Build.t
+end

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -249,8 +249,10 @@ let build_and_link_many ~programs ~linkages ~promote ?link_args ?o_files
               match Linkage.is_plugin linkage with
               | false -> Memo.Build.return link_time_code_gen
               | true ->
-                Link_time_code_gen.handle_special_libs
-                  (CC.for_plugin_executable cctx ~embed_in_plugin_libraries)
+                let cc =
+                  CC.for_plugin_executable cctx ~embed_in_plugin_libraries
+                in
+                Link_time_code_gen.handle_special_libs cc
             in
             link_exe cctx ~loc ~name ~linkage ~cm_files ~link_time_code_gen
               ~promote ?link_args ?o_files))

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -121,12 +121,12 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       Lib.DB.instrumentation_backend (Scope.libs scope)
     in
     let* preprocess =
-      Resolve.read_memo_build
+      Resolve.Build.read_memo_build
         (Preprocess.Per_module.with_instrumentation exes.buildable.preprocess
            ~instrumentation_backend)
     in
     let* instrumentation_deps =
-      Resolve.read_memo_build
+      Resolve.Build.read_memo_build
         (Preprocess.Per_module.instrumentation_deps exes.buildable.preprocess
            ~instrumentation_backend)
     in
@@ -173,9 +173,9 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       ~js_of_ocaml ~opaque:Inherit_from_settings ~package:exes.package
   in
   let stdlib_dir = ctx.Context.stdlib_dir in
-  let requires_compile = Compilation_context.requires_compile cctx in
+  let* requires_compile = Compilation_context.requires_compile cctx in
   let* preprocess =
-    Resolve.read_memo_build
+    Resolve.Build.read_memo_build
       (Preprocess.Per_module.with_instrumentation exes.buildable.preprocess
          ~instrumentation_backend:
            (Lib.DB.instrumentation_backend (Scope.libs scope)))
@@ -222,7 +222,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
 let compile_info ~scope (exes : Dune_file.Executables.t) =
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let+ pps =
-    Resolve.read_memo_build
+    Resolve.Build.read_memo_build
       (Preprocess.Per_module.with_instrumentation exes.buildable.preprocess
          ~instrumentation_backend:
            (Lib.DB.instrumentation_backend (Scope.libs scope)))

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -23,7 +23,7 @@ val make :
   -> lib_artifacts:Artifacts.Public_libs.t
   -> lib_artifacts_host:Artifacts.Public_libs.t
   -> bin_artifacts_host:Artifacts.Bin.t
-  -> find_package:(Package.Name.t -> any_package option)
+  -> find_package:(Package.Name.t -> any_package option Memo.Build.t)
   -> t
 
 val set_foreign_flags :
@@ -150,4 +150,4 @@ val map_exe : t -> Path.t -> Path.t
 
 val artifacts : t -> Artifacts.Bin.t
 
-val find_package : t -> Package.Name.t -> any_package option
+val find_package : t -> Package.Name.t -> any_package option Memo.Build.t

--- a/src/dune_rules/findlib/findlib.mli
+++ b/src/dune_rules/findlib/findlib.mli
@@ -31,28 +31,30 @@ end
 (** Lookup a whole package, including sub-packages, in the given database.
     [root_name] must be a library name without dots. *)
 val find_root_package :
-  t -> Package.Name.t -> (Dune_package.t, Unavailable_reason.t) result
+     t
+  -> Package.Name.t
+  -> (Dune_package.t, Unavailable_reason.t) result Memo.Build.t
 
 val find :
-  t -> Lib_name.t -> (Dune_package.Entry.t, Unavailable_reason.t) result
-
-val available : t -> Lib_name.t -> bool
+     t
+  -> Lib_name.t
+  -> (Dune_package.Entry.t, Unavailable_reason.t) result Memo.Build.t
 
 (** List all the packages available in this Database *)
-val all_packages : t -> Dune_package.Entry.t list
+val all_packages : t -> Dune_package.Entry.t list Memo.Build.t
 
 (** List all the packages that have broken [dune-package] files *)
-val all_broken_packages : t -> (Package.Name.t * exn) list
+val all_broken_packages : t -> (Package.Name.t * exn) list Memo.Build.t
 
 (** A dummy package. This is used to implement [external-lib-deps] *)
-val dummy_lib : t -> name:Lib_name.t -> Dune_package.Lib.t
+val dummy_lib : t -> name:Lib_name.t -> Dune_package.Lib.t Memo.Build.t
 
 module Config : sig
   type t
 
   val to_dyn : t -> Dyn.t
 
-  val load : Path.t -> toolchain:string -> context:string -> t
+  val load : Path.t -> toolchain:string -> context:string -> t Memo.Build.t
 
   val get : t -> string -> string option
 

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -74,6 +74,10 @@ module Simplified = struct
     ; subs : t list
     }
 
+  let equal = Poly.equal
+
+  let hash = Poly.hash
+
   let rec to_dyn { name; vars; subs } =
     let open Dyn.Encoder in
     record
@@ -116,9 +120,14 @@ let rec complexify t =
 
 let parse_entries lb = Parse.entries lb 0 []
 
-let load p ~name =
+let of_lex lex ~name =
   let name = Option.map name ~f:Lib_name.of_package_name in
-  { name; entries = Io.with_lexbuf_from_file p ~f:parse_entries } |> simplify
+  let entries = parse_entries lex in
+  simplify { name; entries }
+
+let load p ~name = Fs_memo.with_lexbuf_from_file p ~f:(of_lex ~name)
+
+let of_string s ~name = of_lex (Lexing.from_string s) ~name
 
 let rule var predicates action value = Rule { var; predicates; action; value }
 

--- a/src/dune_rules/findlib/meta.mli
+++ b/src/dune_rules/findlib/meta.mli
@@ -54,12 +54,18 @@ module Simplified : sig
     ; subs : t list
     }
 
+  val equal : t -> t -> bool
+
+  val hash : t -> int
+
   val to_dyn : t -> Dyn.t
 end
 
 val complexify : Simplified.t -> t
 
-val load : Path.t -> name:Package.Name.t option -> Simplified.t
+val of_string : string -> name:Package.Name.t option -> Simplified.t
+
+val load : Path.t -> name:Package.Name.t option -> Simplified.t Memo.Build.t
 
 (** Builtin META files for libraries distributed with the compiler. For when
     ocamlfind is not installed. *)

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -14,18 +14,18 @@ module Source_tree_map_reduce =
 let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
   let scope = Expander.scope expander in
   let lib_dir loc lib_name =
-    let open Resolve.O in
+    let open Resolve.Build.O in
     let+ lib = Lib.DB.resolve (Scope.libs scope) (loc, lib_name) in
     Lib_info.src_dir (Lib.info lib)
   in
   Command.Args.S
     (List.map stubs.include_dirs ~f:(fun include_dir ->
-         Resolve.args
-           (let open Resolve.O in
+         Resolve.Build.args
+           (let open Resolve.Build.O in
            let+ loc, include_dir =
              match (include_dir : Foreign.Stubs.Include_dir.t) with
              | Dir dir ->
-               Resolve.return
+               Resolve.Build.return
                  (String_with_vars.loc dir, Expander.expand_path expander dir)
              | Lib (loc, lib_name) ->
                let+ lib_dir = lib_dir loc lib_name in

--- a/src/dune_rules/gen_meta.ml
+++ b/src/dune_rules/gen_meta.ml
@@ -97,25 +97,28 @@ let gen_lib pub_name lib ~path ~version =
     | _ -> name
   in
   let to_names = Lib_name.Set.of_list_map ~f:name in
-  let* lib_deps = Resolve.read_memo_build (Lib.requires lib) >>| to_names in
+  let* lib_deps =
+    Resolve.Build.read_memo_build (Lib.requires lib) >>| to_names
+  in
   let* ppx_rt_deps =
-    Resolve.read_memo_build (Lib.ppx_runtime_deps lib) >>| to_names
+    Lib.ppx_runtime_deps lib
+    |> Memo.Build.bind ~f:Resolve.read_memo_build
+    |> Memo.Build.map ~f:to_names
   in
   let+ ppx_runtime_deps_for_deprecated_method =
-    Resolve.read_memo_build
-      (let open Resolve.O in
-      (* For the deprecated method, we need to put all the runtime dependencies
-         of the transitive closure.
+    (* For the deprecated method, we need to put all the runtime dependencies of
+       the transitive closure.
 
-         We need to do this because [ocamlfind ocamlc -package ppx_foo] will not
-         look for the transitive dependencies of [foo], and the runtime
-         dependencies might be attached to a dependency of [foo] rather than
-         [foo] itself.
+       We need to do this because [ocamlfind ocamlc -package ppx_foo] will not
+       look for the transitive dependencies of [foo], and the runtime
+       dependencies might be attached to a dependency of [foo] rather than [foo]
+       itself.
 
-         Sigh... *)
-      Lib.closure [ lib ] ~linking:false
-      >>= Resolve.List.concat_map ~f:Lib.ppx_runtime_deps
-      >>| to_names)
+       Sigh... *)
+    let open Resolve.Build.O in
+    Lib.closure [ lib ] ~linking:false
+    >>= Resolve.Build.List.concat_map ~f:Lib.ppx_runtime_deps
+    >>| to_names |> Resolve.Build.read_memo_build
   in
   List.concat
     [ version

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -11,7 +11,7 @@ module Backend = struct
     type t =
       { info : Info.t
       ; lib : Lib.t
-      ; runner_libraries : Lib.t list Resolve.t
+      ; runner_libraries : Lib.t list Resolve.Build.t
       ; extends : t list Resolve.t
       }
 
@@ -34,26 +34,27 @@ module Backend = struct
       let+ extends =
         Memo.Build.parallel_map info.extends ~f:(fun ((loc, name) as x) ->
             Resolve.Build.bind (resolve x) ~f:(fun lib ->
-                get ~loc lib >>| function
+                get ~loc lib >>= function
                 | None ->
-                  Resolve.fail
+                  Resolve.Build.fail
                     (User_error.make ~loc
                        [ Pp.textf "%S is not an %s" (Lib_name.to_string name)
                            (desc ~plural:false)
                        ])
-                | Some t -> Resolve.return t))
+                | Some t -> Resolve.Build.return t))
         >>| Resolve.List.map ~f:Fun.id
       in
       { info
       ; lib
-      ; runner_libraries = Resolve.List.map info.runner_libraries ~f:resolve
+      ; runner_libraries =
+          Resolve.Build.List.map info.runner_libraries ~f:resolve
       ; extends
       }
 
     let public_info t =
-      let open Resolve.O in
+      let open Resolve.Build.O in
       let+ runner_libraries = t.runner_libraries
-      and+ extends = t.extends in
+      and+ extends = Memo.Build.return t.extends in
       { Info.loc = t.info.loc
       ; flags = t.info.flags
       ; generate_runner = t.info.generate_runner
@@ -106,16 +107,17 @@ include Sub_system.Register_end_point (struct
     let modules = Modules.singleton_exe main_module in
     let* expander = Super_context.expander sctx ~dir in
     let runner_libs =
-      let open Resolve.O in
+      let open Resolve.Build.O in
       let* libs =
-        Resolve.List.concat_map backends ~f:(fun (backend : Backend.t) ->
+        Resolve.Build.List.concat_map backends ~f:(fun (backend : Backend.t) ->
             backend.runner_libraries)
       in
       let* lib =
         Lib.DB.resolve (Scope.libs scope) (loc, Dune_file.Library.best_name lib)
       in
       let* more_libs =
-        Resolve.List.map info.libraries ~f:(Lib.DB.resolve (Scope.libs scope))
+        Resolve.Build.List.map info.libraries
+          ~f:(Lib.DB.resolve (Scope.libs scope))
       in
       Lib.closure ~linking:true ((lib :: libs) @ more_libs)
     in
@@ -155,7 +157,7 @@ include Sub_system.Register_end_point (struct
       let flags = Ocaml_flags.append_common ocaml_flags [ "-w"; "-24"; "-g" ] in
       Compilation_context.create () ~super_context:sctx ~expander ~scope
         ~obj_dir ~modules ~opaque:(Explicit false) ~requires_compile:runner_libs
-        ~requires_link:(lazy runner_libs)
+        ~requires_link:(Memo.lazy_ (fun () -> runner_libs))
         ~flags ~js_of_ocaml:(Some lib.buildable.js_of_ocaml) ~package
     in
     let linkages =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -47,7 +47,7 @@ end = struct
     | Ppx_rewriter _ ->
       let name = Dune_file.Library.best_name lib in
       let+ ppx_exe =
-        Resolve.read_memo_build (Preprocessing.ppx_exe sctx ~scope name)
+        Resolve.Build.read_memo_build (Preprocessing.ppx_exe sctx ~scope name)
       in
       [ ppx_exe ]
 
@@ -208,10 +208,10 @@ end = struct
     let+ keep =
       match (stanza : Stanza.t) with
       | Dune_file.Library lib ->
-        Memo.Build.return
-          ((not lib.optional)
-          || Lib.DB.available (Scope.libs scope)
-               (Dune_file.Library.best_name lib))
+        if lib.optional then
+          Lib.DB.available (Scope.libs scope) (Dune_file.Library.best_name lib)
+        else
+          Memo.Build.return true
       | Dune_file.Documentation _ -> Memo.Build.return true
       | Dune_file.Install { enabled_if; _ } ->
         Expander.eval_blang expander enabled_if
@@ -223,12 +223,12 @@ end = struct
           if not exes.optional then
             Memo.Build.return true
           else
-            let+ compile_info =
+            let* compile_info =
               let dune_version =
                 Scope.project scope |> Dune_project.dune_version
               in
               let+ pps =
-                Resolve.read_memo_build
+                Resolve.Build.read_memo_build
                   (Preprocess.Per_module.with_instrumentation
                      exes.buildable.preprocess
                      ~instrumentation_backend:
@@ -239,7 +239,8 @@ end = struct
                 exes.names exes.buildable.libraries ~pps ~dune_version
                 ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
             in
-            Resolve.is_ok (Lib.Compile.direct_requires compile_info))
+            let+ requires = Lib.Compile.direct_requires compile_info in
+            Resolve.is_ok requires)
       | Coq_stanza.Theory.T d -> Memo.Build.return (Option.is_some d.package)
       | _ -> Memo.Build.return false
     in
@@ -330,14 +331,16 @@ end = struct
                   in
                   let section = i.section in
                   Memo.Build.List.map i.files ~f:(fun unexpanded ->
-                      let+ fb = path_expander unexpanded in
+                      let* fb = path_expander unexpanded in
                       let loc = File_binding.Expanded.src_loc fb in
                       let src = File_binding.Expanded.src fb in
                       let dst = File_binding.Expanded.dst fb in
-                      ( Some loc
-                      , Install.Entry.make_with_site section
+                      let+ entry =
+                        Install.Entry.make_with_site section
                           (Super_context.get_site_of_packages sctx)
-                          src ?dst ))
+                          src ?dst
+                      in
+                      (Some loc, entry))
                 | Dune_file.Library lib ->
                   let sub_dir = Dune_file.Library.sub_dir lib in
                   let* dir_contents = Dir_contents.get sctx ~dir in
@@ -353,8 +356,7 @@ end = struct
                           ~dst:
                             (sprintf "odoc-pages/%s" (Path.Build.basename mld))
                           Section.Doc mld ))
-                | Dune_file.Plugin t ->
-                  Memo.Build.return (Plugin_rules.install_rules ~sctx ~dir t)
+                | Dune_file.Plugin t -> Plugin_rules.install_rules ~sctx ~dir t
                 | _ -> Memo.Build.return []
               in
               let name = Package.name package in

--- a/src/dune_rules/jsoo_rules.ml
+++ b/src/dune_rules/jsoo_rules.ml
@@ -50,11 +50,12 @@ let js_of_ocaml_rule sctx ~sub_command ~dir ~flags ~spec ~target =
     ]
 
 let standalone_runtime_rule cc ~javascript_files ~target ~flags =
+  let libs = Compilation_context.requires_link cc in
   let spec =
     Command.Args.S
-      [ Resolve.args
-          (let open Resolve.O in
-          let+ libs = Compilation_context.requires_link cc in
+      [ Resolve.Build.args
+          (let open Resolve.Build.O in
+          let+ libs = libs in
           Command.Args.Deps (Lib.L.jsoo_runtime_files libs))
       ; Deps javascript_files
       ]
@@ -68,11 +69,12 @@ let standalone_runtime_rule cc ~javascript_files ~target ~flags =
 let exe_rule cc ~javascript_files ~src ~target ~flags =
   let dir = Compilation_context.dir cc in
   let sctx = Compilation_context.super_context cc in
+  let libs = Compilation_context.requires_link cc in
   let spec =
     Command.Args.S
-      [ Resolve.args
-          (let open Resolve.O in
-          let+ libs = Compilation_context.requires_link cc in
+      [ Resolve.Build.args
+          (let open Resolve.Build.O in
+          let+ libs = libs in
           Command.Args.Deps (Lib.L.jsoo_runtime_files libs))
       ; Deps javascript_files
       ; Dep (Path.build src)
@@ -101,8 +103,8 @@ let link_rule cc ~runtime ~target cm =
   let requires = Compilation_context.requires_link cc in
   let get_all =
     Action_builder.map cm ~f:(fun cm ->
-        Resolve.args
-          (let open Resolve.O in
+        Resolve.Build.args
+          (let open Resolve.Build.O in
           let+ libs = requires in
           let all_libs = List.concat_map libs ~f:(jsoo_archives ~ctx) in
           (* Special case for the stdlib because it is not referenced in the
@@ -150,7 +152,8 @@ let setup_separate_compilation_rules sctx components =
       | [ pkg ] -> (
         let pkg = Lib_name.parse_string_exn (Loc.none, pkg) in
         let ctx = SC.context sctx in
-        match Lib.DB.find (SC.installed_libs sctx) pkg with
+        let open Memo.Build.O in
+        Lib.DB.find (SC.installed_libs sctx) pkg >>= function
         | None -> Memo.Build.return ()
         | Some pkg ->
           let info = Lib.info pkg in

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -15,7 +15,7 @@ val name : t -> Lib_name.t
 
 val lib_config : t -> Lib_config.t
 
-val implements : t -> t Resolve.t option
+val implements : t -> t Resolve.Build.t option
 
 (** Directory where the object files for the library are located. *)
 val obj_dir : t -> Path.t Obj_dir.t
@@ -25,22 +25,22 @@ val is_local : t -> bool
 
 val info : t -> Path.t Lib_info.t
 
-val main_module_name : t -> Module_name.t option Resolve.t
+val main_module_name : t -> Module_name.t option Resolve.Build.t
 
-val entry_module_names : t -> Module_name.t list Resolve.t Memo.Build.t
+val entry_module_names : t -> Module_name.t list Resolve.Build.t
 
 val src_dirs : t -> Path.Set.t Memo.Build.t
 
-val wrapped : t -> Wrapped.t option Resolve.t
+val wrapped : t -> Wrapped.t option Resolve.Build.t
 
 (** [is_impl lib] returns [true] if the library is an implementation of a
     virtual library *)
 val is_impl : t -> bool
 
 (** Direct library dependencies of this library *)
-val requires : t -> t list Resolve.t
+val requires : t -> t list Resolve.Build.t
 
-val ppx_runtime_deps : t -> t list Resolve.t
+val ppx_runtime_deps : t -> t list Resolve.Build.t
 
 (** A unique integer identifier. It is only unique for the duration of the
     process *)
@@ -92,8 +92,8 @@ module L : sig
   val top_closure :
        'a list
     -> key:('a -> lib)
-    -> deps:('a -> 'a list Resolve.t)
-    -> ('a list, 'a list) Result.t Resolve.t
+    -> deps:('a -> 'a list Resolve.Build.t)
+    -> ('a list, 'a list) Result.t Resolve.Build.t
 end
 with type lib := t
 
@@ -128,10 +128,10 @@ module Compile : sig
   type lib
 
   (** Return the list of dependencies needed for linking this library/exe *)
-  val requires_link : t -> L.t Resolve.t Lazy.t
+  val requires_link : t -> L.t Resolve.t Memo.Lazy.t
 
   (** Dependencies listed by the user + runtime dependencies from ppx *)
-  val direct_requires : t -> L.t Resolve.t
+  val direct_requires : t -> L.t Resolve.Build.t
 
   module Resolved_select : sig
     type t =
@@ -141,10 +141,10 @@ module Compile : sig
   end
 
   (** Resolved select forms *)
-  val resolved_selects : t -> Resolved_select.t list Resolve.t
+  val resolved_selects : t -> Resolved_select.t list Resolve.Build.t
 
   (** Transitive closure of all used ppx rewriters *)
-  val pps : t -> L.t Resolve.t
+  val pps : t -> L.t Resolve.Build.t
 
   val merlin_ident : t -> Merlin_ident.t
 
@@ -186,9 +186,9 @@ module DB : sig
       [all] returns the list of names of libraries available in this database. *)
   val create :
        parent:t option
-    -> resolve:(Lib_name.t -> Resolve_result.t)
+    -> resolve:(Lib_name.t -> Resolve_result.t Memo.Build.t)
     -> projects_by_package:Dune_project.t Package.Name.Map.t
-    -> all:(unit -> Lib_name.t list)
+    -> all:(unit -> Lib_name.t list Memo.Build.t)
     -> modules_of_lib:
          (dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.Build.t) Fdecl.t
     -> lib_config:Lib_config.t
@@ -201,21 +201,23 @@ module DB : sig
     -> Findlib.t
     -> t
 
-  val find : t -> Lib_name.t -> lib option
+  val find : t -> Lib_name.t -> lib option Memo.Build.t
 
-  val find_even_when_hidden : t -> Lib_name.t -> lib option
+  val find_even_when_hidden : t -> Lib_name.t -> lib option Memo.Build.t
 
-  val available : t -> Lib_name.t -> bool
+  val available : t -> Lib_name.t -> bool Memo.Build.t
 
   (** Retrieve the compile information for the given library. Works for
       libraries that are optional and not available as well. *)
-  val get_compile_info : t -> ?allow_overlaps:bool -> Lib_name.t -> Compile.t
+  val get_compile_info :
+    t -> ?allow_overlaps:bool -> Lib_name.t -> Compile.t Memo.Build.t
 
-  val resolve : t -> Loc.t * Lib_name.t -> lib Resolve.t
+  val resolve : t -> Loc.t * Lib_name.t -> lib Resolve.Build.t
 
   (** Like [resolve], but will return [None] instead of an error if we are
       unable to find the library. *)
-  val resolve_when_exists : t -> Loc.t * Lib_name.t -> lib Resolve.t option
+  val resolve_when_exists :
+    t -> Loc.t * Lib_name.t -> lib Resolve.t option Memo.Build.t
 
   (** Resolve libraries written by the user in a [dune] file. The resulting list
       of libraries is transitively closed and sorted by the order of
@@ -232,22 +234,22 @@ module DB : sig
     -> dune_version:Dune_lang.Syntax.Version.t
     -> Compile.t
 
-  val resolve_pps : t -> (Loc.t * Lib_name.t) list -> L.t Resolve.t
+  val resolve_pps : t -> (Loc.t * Lib_name.t) list -> L.t Resolve.Build.t
 
   (** Return the list of all libraries in this database. If [recursive] is true,
       also include libraries in parent databases recursively. *)
-  val all : ?recursive:bool -> t -> Set.t
+  val all : ?recursive:bool -> t -> Set.t Memo.Build.t
 
   val instrumentation_backend :
        t
     -> Loc.t * Lib_name.t
-    -> Preprocess.Without_instrumentation.t option Resolve.t
+    -> Preprocess.Without_instrumentation.t option Resolve.Build.t
 end
 with type lib := t
 
 (** {1 Transitive closure} *)
 
-val closure : L.t -> linking:bool -> L.t Resolve.t
+val closure : L.t -> linking:bool -> L.t Resolve.Build.t
 
 (** {1 Sub-systems} *)
 
@@ -264,13 +266,13 @@ module Sub_system : sig
     type sub_system += T of t
 
     val instantiate :
-         resolve:(Loc.t * Lib_name.t -> lib Resolve.t)
+         resolve:(Loc.t * Lib_name.t -> lib Resolve.Build.t)
       -> get:(loc:Loc.t -> lib -> t option Memo.Build.t)
       -> lib
       -> Info.t
       -> t Memo.Build.t
 
-    val public_info : (t -> Info.t Resolve.t) option
+    val public_info : (t -> Info.t Resolve.Build.t) option
   end
 
   module Register (M : S) : sig
@@ -285,7 +287,7 @@ val to_dune_lib :
   -> modules:Modules.t
   -> foreign_objects:Path.t list
   -> dir:Path.t
-  -> Dune_package.Lib.t Resolve.t Memo.Build.t
+  -> Dune_package.Lib.t Resolve.Build.t
 
 (** Local libraries *)
 module Local : sig

--- a/src/dune_rules/lib_config.ml
+++ b/src/dune_rules/lib_config.ml
@@ -49,3 +49,7 @@ let linker_can_create_empty_archives t =
   match t.ccomp_type with
   | Msvc -> false
   | Other _ -> true
+
+let hash = Poly.hash
+
+let equal = Poly.equal

--- a/src/dune_rules/lib_config.mli
+++ b/src/dune_rules/lib_config.mli
@@ -25,3 +25,7 @@ val allowed_in_enabled_if : (string * Dune_lang.Syntax.Version.t) list
 val get_for_enabled_if : t -> Pform.t -> string
 
 val linker_can_create_empty_archives : t -> bool
+
+val hash : t -> int
+
+val equal : t -> t -> bool

--- a/src/dune_rules/lib_dep.ml
+++ b/src/dune_rules/lib_dep.ml
@@ -100,6 +100,8 @@ type t =
   | Re_export of (Loc.t * Lib_name.t)
   | Select of Select.t
 
+let equal = Poly.equal
+
 let to_dyn =
   let open Dyn.Encoder in
   function

--- a/src/dune_rules/lib_dep.mli
+++ b/src/dune_rules/lib_dep.mli
@@ -24,6 +24,8 @@ type t =
   | Re_export of (Loc.t * Lib_name.t)
   | Select of Select.t
 
+val equal : t -> t -> bool
+
 val to_dyn : t -> Dyn.t
 
 val direct : Loc.t * Lib_name.t -> t

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -244,3 +244,5 @@ val create :
 val package : _ t -> Package.Name.t option
 
 val to_dyn : 'path Dyn.Encoder.t -> 'path t Dyn.Encoder.t
+
+val equal : 'a t -> 'a t -> bool

--- a/src/dune_rules/lib_kind.ml
+++ b/src/dune_rules/lib_kind.ml
@@ -58,6 +58,8 @@ type t =
   | Ppx_deriver of Ppx_args.t
   | Ppx_rewriter of Ppx_args.t
 
+let equal = Poly.equal
+
 let to_dyn x =
   let open Dyn.Encoder in
   match x with

--- a/src/dune_rules/lib_kind.mli
+++ b/src/dune_rules/lib_kind.mli
@@ -20,4 +20,6 @@ type t =
 
 val to_dyn : t Stdune.Dyn.Encoder.t
 
+val equal : t -> t -> bool
+
 include Dune_lang.Conv.S with type t := t

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -357,12 +357,12 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
     Lib.DB.instrumentation_backend (Scope.libs scope)
   in
   let* preprocess =
-    Resolve.read_memo_build
+    Resolve.Build.read_memo_build
       (Preprocess.Per_module.with_instrumentation lib.buildable.preprocess
          ~instrumentation_backend)
   in
   let* instrumentation_deps =
-    Resolve.read_memo_build
+    Resolve.Build.read_memo_build
       (Preprocess.Per_module.instrumentation_deps lib.buildable.preprocess
          ~instrumentation_backend)
   in
@@ -404,7 +404,7 @@ let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
   let sctx = Compilation_context.super_context cctx in
   let dir = Compilation_context.dir cctx in
   let scope = Compilation_context.scope cctx in
-  let requires_compile = Compilation_context.requires_compile cctx in
+  let* requires_compile = Compilation_context.requires_compile cctx in
   let stdlib_dir = (Compilation_context.context cctx).Context.stdlib_dir in
   let* dep_graphs = Dep_rules.rules cctx ~modules
   and* () =
@@ -437,7 +437,7 @@ let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
       ; compile_info
       }
   and+ preprocess =
-    Resolve.read_memo_build
+    Resolve.Build.read_memo_build
       (Preprocess.Per_module.with_instrumentation lib.buildable.preprocess
          ~instrumentation_backend:
            (Lib.DB.instrumentation_backend (Scope.libs scope)))
@@ -450,7 +450,7 @@ let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
       () )
 
 let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope =
-  let compile_info =
+  let* compile_info =
     Lib.DB.get_compile_info (Scope.libs scope) (Library.best_name lib)
       ~allow_overlaps:lib.buildable.allow_overlapping_dependencies
   in

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -13,43 +13,43 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name ~lib ~code ~requires
   let sctx = CC.super_context cctx in
   let obj_dir = CC.obj_dir cctx in
   let dir = CC.dir cctx in
-  Resolve.Build.bind
-    (let open Resolve.O in
-    let* wrapped = Lib.wrapped lib in
-    let src_dir = Path.build (Obj_dir.obj_dir obj_dir) in
-    let gen_module = Module.generated ~src_dir name in
+  let open Resolve.Build.O in
+  let src_dir = Path.build (Obj_dir.obj_dir obj_dir) in
+  let gen_module = Module.generated ~src_dir name in
+  let* wrapped = Lib.wrapped lib in
+  let* module_ =
     match wrapped with
-    | None -> Resolve.return gen_module
+    | None -> Resolve.Build.return gen_module
     | Some (Yes_with_transition _) ->
       (* XXX this needs a comment. Why is this impossible? *)
       assert false
-    | Some (Simple false) -> Resolve.return gen_module
+    | Some (Simple false) -> Resolve.Build.return gen_module
     | Some (Simple true) ->
       let+ main_module_name = Lib.main_module_name lib in
       let main_module_name = Option.value_exn main_module_name in
       (* XXX this is fishy. We shouldn't be introducing a toplevel module into a
          wrapped library with a single module *)
-      Module.with_wrapper gen_module ~main_module_name)
-    ~f:(fun module_ ->
-      let open Memo.Build.O in
-      let* () =
-        SC.add_rule ~dir sctx
-          (let ml =
-             Module.file module_ ~ml_kind:Impl
-             |> Option.value_exn |> Path.as_in_build_dir_exn
-           in
-           Action_builder.write_file_dyn ml code)
-      in
-      let cctx =
-        Compilation_context.for_module_generated_at_link_time cctx ~requires
-          ~module_
-      in
-      let+ () =
-        Module_compilation.build_module
-          ~dep_graphs:(Dep_graph.Ml_kind.dummy module_)
-          ~precompiled_cmi cctx module_
-      in
-      Resolve.return module_)
+      Module.with_wrapper gen_module ~main_module_name
+  in
+  let open Memo.Build.O in
+  let* () =
+    SC.add_rule ~dir sctx
+      (let ml =
+         Module.file module_ ~ml_kind:Impl
+         |> Option.value_exn |> Path.as_in_build_dir_exn
+       in
+       Action_builder.write_file_dyn ml code)
+  in
+  let cctx =
+    Compilation_context.for_module_generated_at_link_time cctx ~requires
+      ~module_
+  in
+  let+ () =
+    Module_compilation.build_module
+      ~dep_graphs:(Dep_graph.Ml_kind.dummy module_)
+      ~precompiled_cmi cctx module_
+  in
+  Resolve.return module_
 
 let pr buf fmt = Printf.bprintf buf (fmt ^^ "\n")
 
@@ -233,89 +233,85 @@ let dune_site_plugins_code ~libs ~builtins =
   Buffer.contents buf
 
 let handle_special_libs cctx =
-  let ( let** ) m f = Memo.Build.bind m ~f:(fun x -> Resolve.Build.bind x ~f) in
-  Resolve.Build.bind (CC.requires_link cctx) ~f:(fun all_libs ->
-      let obj_dir = Compilation_context.obj_dir cctx |> Obj_dir.of_local in
-      let sctx = CC.super_context cctx in
-      let ctx = Super_context.context sctx in
-      let module LM = Lib.Lib_and_module in
-      let rec process_libs ~to_link_rev ~force_linkall libs =
-        match libs with
-        | [] ->
-          Memo.Build.return
-            (Resolve.return { to_link = List.rev to_link_rev; force_linkall })
-        | lib :: libs -> (
-          match Lib_info.special_builtin_support (Lib.info lib) with
-          | None ->
-            process_libs libs
-              ~to_link_rev:(LM.Lib lib :: to_link_rev)
-              ~force_linkall
-          | Some special -> (
-            match special with
-            | Build_info { data_module; api_version } ->
-              let** module_ =
-                generate_and_compile_module cctx ~name:data_module ~lib
-                  ~code:
-                    (Action_builder.memo_build
-                       (build_info_code cctx ~libs:all_libs ~api_version))
-                  ~requires:(Resolve.return [ lib ])
-                  ~precompiled_cmi:true
-              in
-              process_libs libs
-                ~to_link_rev:
-                  (LM.Lib lib :: Module (obj_dir, module_) :: to_link_rev)
-                ~force_linkall
-            | Findlib_dynload ->
-              (* If findlib.dynload is linked, we stores in the binary the
-                 packages linked by linking just after findlib.dynload a module
-                 containing the info *)
-              let requires =
-                (* This shouldn't fail since findlib.dynload depends on dynlink
-                   and findlib. That's why it's ok to use a dummy location. *)
-                let db = SC.public_libs sctx in
-                let open Resolve.O in
-                let+ dynlink =
-                  Lib.DB.resolve db (Loc.none, Lib_name.of_string "dynlink")
-                and+ findlib =
-                  Lib.DB.resolve db (Loc.none, Lib_name.of_string "findlib")
-                in
-                [ dynlink; findlib ]
-              in
-              let** module_ =
-                generate_and_compile_module cctx ~lib
-                  ~name:(Module_name.of_string "findlib_initl")
-                  ~code:
-                    (Action_builder.return
-                       (findlib_init_code
-                          ~preds:Findlib.findlib_predicates_set_by_dune
-                          ~libs:all_libs))
-                  ~requires ~precompiled_cmi:false
-              in
-              process_libs libs
-                ~to_link_rev:
-                  (LM.Module (obj_dir, module_) :: Lib lib :: to_link_rev)
-                ~force_linkall:true
-            | Configurator _ ->
-              process_libs libs
-                ~to_link_rev:(LM.Lib lib :: to_link_rev)
-                ~force_linkall
-            | Dune_site { data_module; plugins } ->
-              let code =
-                if plugins then
-                  Action_builder.return
-                    (dune_site_plugins_code ~libs:all_libs
-                       ~builtins:(Findlib.builtins ctx.Context.findlib))
-                else
-                  Action_builder.return (dune_site_code ())
-              in
-              let** module_ =
-                generate_and_compile_module cctx ~name:data_module ~lib ~code
-                  ~requires:(Resolve.return [ lib ])
-                  ~precompiled_cmi:true
-              in
-              process_libs libs
-                ~to_link_rev:
-                  (LM.Lib lib :: Module (obj_dir, module_) :: to_link_rev)
-                ~force_linkall))
-      in
-      process_libs all_libs ~to_link_rev:[] ~force_linkall:false)
+  let ( let& ) m f = Resolve.Build.bind m ~f in
+  let& all_libs = CC.requires_link cctx in
+  let obj_dir = Compilation_context.obj_dir cctx |> Obj_dir.of_local in
+  let sctx = CC.super_context cctx in
+  let ctx = Super_context.context sctx in
+  let module LM = Lib.Lib_and_module in
+  let rec process_libs ~to_link_rev ~force_linkall libs =
+    match libs with
+    | [] ->
+      Resolve.Build.return { to_link = List.rev to_link_rev; force_linkall }
+    | lib :: libs -> (
+      match Lib_info.special_builtin_support (Lib.info lib) with
+      | None ->
+        process_libs libs
+          ~to_link_rev:(LM.Lib lib :: to_link_rev)
+          ~force_linkall
+      | Some special -> (
+        match special with
+        | Build_info { data_module; api_version } ->
+          let& module_ =
+            generate_and_compile_module cctx ~name:data_module ~lib
+              ~code:
+                (Action_builder.memo_build
+                   (build_info_code cctx ~libs:all_libs ~api_version))
+              ~requires:(Resolve.Build.return [ lib ])
+              ~precompiled_cmi:true
+          in
+          process_libs libs
+            ~to_link_rev:(LM.Lib lib :: Module (obj_dir, module_) :: to_link_rev)
+            ~force_linkall
+        | Findlib_dynload ->
+          (* If findlib.dynload is linked, we stores in the binary the packages
+             linked by linking just after findlib.dynload a module containing
+             the info *)
+          let requires =
+            (* This shouldn't fail since findlib.dynload depends on dynlink and
+               findlib. That's why it's ok to use a dummy location. *)
+            let db = SC.public_libs sctx in
+            let open Resolve.Build.O in
+            let+ dynlink =
+              Lib.DB.resolve db (Loc.none, Lib_name.of_string "dynlink")
+            and+ findlib =
+              Lib.DB.resolve db (Loc.none, Lib_name.of_string "findlib")
+            in
+            [ dynlink; findlib ]
+          in
+          let& module_ =
+            generate_and_compile_module cctx ~lib
+              ~name:(Module_name.of_string "findlib_initl")
+              ~code:
+                (Action_builder.return
+                   (findlib_init_code
+                      ~preds:Findlib.findlib_predicates_set_by_dune
+                      ~libs:all_libs))
+              ~requires ~precompiled_cmi:false
+          in
+          process_libs libs
+            ~to_link_rev:(LM.Module (obj_dir, module_) :: Lib lib :: to_link_rev)
+            ~force_linkall:true
+        | Configurator _ ->
+          process_libs libs
+            ~to_link_rev:(LM.Lib lib :: to_link_rev)
+            ~force_linkall
+        | Dune_site { data_module; plugins } ->
+          let code =
+            if plugins then
+              Action_builder.return
+                (dune_site_plugins_code ~libs:all_libs
+                   ~builtins:(Findlib.builtins ctx.Context.findlib))
+            else
+              Action_builder.return (dune_site_code ())
+          in
+          let& module_ =
+            generate_and_compile_module cctx ~name:data_module ~lib ~code
+              ~requires:(Resolve.Build.return [ lib ])
+              ~precompiled_cmi:true
+          in
+          process_libs libs
+            ~to_link_rev:(LM.Lib lib :: Module (obj_dir, module_) :: to_link_rev)
+            ~force_linkall))
+  in
+  process_libs all_libs ~to_link_rev:[] ~force_linkall:false

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -202,8 +202,8 @@ let virtual_modules lookup_vlib vlib =
 let make_lib_modules (d : _ Dir_with_dune.t) ~lookup_vlib ~(lib : Library.t)
     ~modules =
   let src_dir = d.ctx_dir in
-  let+ res =
-    let open Resolve.O in
+  let open Resolve.Build.O in
+  let+ kind, main_module_name, wrapped =
     match lib.implements with
     | None ->
       (* In the two following pattern matching, we can only get [From _] if
@@ -228,40 +228,36 @@ let make_lib_modules (d : _ Dir_with_dune.t) ~lookup_vlib ~(lib : Library.t)
       Memo.Build.return (Resolve.return (kind, main_module_name, wrapped))
     | Some _ ->
       assert (Option.is_none lib.virtual_modules);
-      let resolved =
+      let open Memo.Build.O in
+      let* resolved =
         let name = Library.best_name lib in
         Lib.DB.find_even_when_hidden (Scope.libs d.scope) name
         (* can't happen because this library is defined using the current
            stanza *)
-        |> Option.value_exn
+        >>| Option.value_exn
       in
+      let open Resolve.Build.O in
       (* This [Option.value_exn] is correct because the above [lib.implements]
          is [Some _] and this [lib] variable correspond to the same library. *)
-      Resolve.Build.bind
-        (Option.value_exn (Lib.implements resolved))
-        ~f:(fun vlib ->
-          Memo.Build.map (virtual_modules lookup_vlib vlib) ~f:(fun impl ->
-              let kind : Modules_field_evaluator.kind = Implementation impl in
-              let+ main_module_name, wrapped =
-                let open Resolve.O in
-                let* main_module_name = Lib.main_module_name resolved in
-                let+ wrapped = Lib.wrapped resolved in
-                (main_module_name, Option.value_exn wrapped)
-              in
-              (kind, main_module_name, wrapped)))
+      let* vlib = Option.value_exn (Lib.implements resolved) in
+      let* wrapped = Lib.wrapped resolved in
+      let wrapped = Option.value_exn wrapped in
+      let* main_module_name = Lib.main_module_name resolved in
+      let+ impl = Resolve.Build.lift_memo (virtual_modules lookup_vlib vlib) in
+      let kind : Modules_field_evaluator.kind = Implementation impl in
+      (kind, main_module_name, wrapped)
   in
-  Resolve.map res ~f:(fun (kind, main_module_name, wrapped) ->
-      let modules =
-        Modules_field_evaluator.eval ~modules ~buildable:lib.buildable ~kind
-          ~private_modules:
-            (Option.value ~default:Ordered_set_lang.standard lib.private_modules)
-          ~src_dir
-      in
-      let stdlib = lib.stdlib in
-      let implements = Option.is_some lib.implements in
-      let _loc, lib_name = lib.name in
-      Modules_group.lib ~stdlib ~implements ~lib_name ~src_dir ~modules
-        ~main_module_name ~wrapped)
+  let modules =
+    Modules_field_evaluator.eval ~modules ~buildable:lib.buildable ~kind
+      ~private_modules:
+        (Option.value ~default:Ordered_set_lang.standard lib.private_modules)
+      ~src_dir
+  in
+  let stdlib = lib.stdlib in
+  let implements = Option.is_some lib.implements in
+  let _loc, lib_name = lib.name in
+  Modules_group.lib ~stdlib ~implements ~lib_name ~src_dir ~modules
+    ~main_module_name ~wrapped
 
 let libs_and_exes (d : _ Dir_with_dune.t) ~lookup_vlib ~modules =
   Memo.Build.parallel_map d.data ~f:(fun stanza ->

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -395,6 +395,8 @@ and impl =
   ; vlib : t
   }
 
+let equal (x : t) (y : t) = Poly.equal x y
+
 let rec encode t =
   let open Dune_lang in
   match t with

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -7,6 +7,8 @@ type t
 
 val to_dyn : t -> Dyn.t
 
+val equal : t -> t -> bool
+
 val lib :
      src_dir:Path.Build.t
   -> main_module_name:Module_name.t option

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -25,6 +25,8 @@ module External = struct
     ; public_cmi_dir : Path.t option
     }
 
+  let equal : t -> t -> bool = Poly.equal
+
   let make ~dir ~has_private_modules ~private_lib =
     let private_dir =
       if has_private_modules then
@@ -112,6 +114,8 @@ module Local = struct
     ; private_lib : bool
     }
 
+  let equal : t -> t -> bool = Poly.equal
+
   let to_dyn { dir; obj_dir; native_dir; byte_dir; public_cmi_dir; private_lib }
       =
     let open Dyn.Encoder in
@@ -185,6 +189,13 @@ type _ t =
   | External : External.t -> Path.t t
   | Local : Local.t -> Path.Build.t t
   | Local_as_path : Local.t -> Path.t t
+
+let equal (type a) (x : a t) (y : a t) =
+  match (x, y) with
+  | External x, External y -> External.equal x y
+  | Local x, Local y -> Local.equal x y
+  | Local_as_path x, Local_as_path y -> Local.equal x y
+  | _, _ -> false
 
 let of_local : Path.Build.t t -> Path.t t =
  fun t ->

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -32,6 +32,8 @@ type 'path t
 
 val of_local : Path.Build.t t -> Path.t t
 
+val equal : 'a t -> 'a t -> bool
+
 (** The source_root directory *)
 val dir : 'path t -> 'path
 

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -295,11 +295,12 @@ let setup_html sctx (odoc_file : odoc) ~pkg ~requires =
           :: dummy))
 
 let setup_library_odoc_rules cctx (library : Library.t) ~dep_graphs =
-  let lib =
+  let open Memo.Build.O in
+  let* lib =
     let scope = Compilation_context.scope cctx in
     Library.best_name library
     |> Lib.DB.find_even_when_hidden (Scope.libs scope)
-    |> Option.value_exn
+    >>| Option.value_exn
   in
   let local_lib = Lib.Local.of_lib_exn lib in
   (* Using the proper package name doesn't actually work since odoc assumes that
@@ -307,7 +308,7 @@ let setup_library_odoc_rules cctx (library : Library.t) ~dep_graphs =
   let pkg_or_lnu = pkg_or_lnu lib in
   let sctx = Compilation_context.super_context cctx in
   let ctx = Super_context.context sctx in
-  let requires = Compilation_context.requires_compile cctx in
+  let* requires = Compilation_context.requires_compile cctx in
   let info = Lib.info lib in
   let package = Lib_info.package info in
   let odoc_include_flags =
@@ -323,7 +324,6 @@ let setup_library_odoc_rules cctx (library : Library.t) ~dep_graphs =
         in
         compiled :: acc)
   in
-  let open Memo.Build.O in
   let* modules_and_odoc_files =
     Memo.Build.all_concurrently modules_and_odoc_files
   in
@@ -551,7 +551,7 @@ let setup_pkg_html_rules_def =
     ~input:(module Input)
     ~implicit_output:Rules.implicit_output
     (fun (sctx, pkg, (libs : Lib.Local.t list)) ->
-      let requires =
+      let* requires =
         let libs = (libs :> Lib.t list) in
         Lib.closure libs ~linking:false
       in
@@ -695,23 +695,26 @@ let global_rules sctx =
         (* setup @doc to build the correct html for the package *)
         setup_package_aliases sctx pkg)
   in
+  let* action =
+    stanzas
+    |> Memo.Build.List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
+           Memo.Build.List.filter_map w.data ~f:(function
+             | Dune_file.Library (l : Dune_file.Library.t) -> (
+               match l.visibility with
+               | Public _ -> Memo.Build.return None
+               | Private _ ->
+                 let scope = SC.find_scope_by_dir sctx w.ctx_dir in
+                 Library.best_name l
+                 |> Lib.DB.find_even_when_hidden (Scope.libs scope)
+                 >>| fun lib ->
+                 Option.value_exn lib |> Lib.Local.of_lib_exn |> Option.some)
+             | _ -> Memo.Build.return None))
+    >>| Dune_engine.Dep.Set.of_list_map ~f:(fun (lib : Lib.Local.t) ->
+            Lib lib |> Dep.html_alias ctx |> Dune_engine.Dep.alias)
+  in
   Rules.Produce.Alias.add_deps
     (Alias.private_doc ~dir:ctx.build_dir)
-    (Action_builder.deps
-       (stanzas
-       |> List.concat_map ~f:(fun (w : _ Dir_with_dune.t) ->
-              List.filter_map w.data ~f:(function
-                | Dune_file.Library (l : Dune_file.Library.t) -> (
-                  match l.visibility with
-                  | Public _ -> None
-                  | Private _ ->
-                    let scope = SC.find_scope_by_dir sctx w.ctx_dir in
-                    Library.best_name l
-                    |> Lib.DB.find_even_when_hidden (Scope.libs scope)
-                    |> Option.value_exn |> Lib.Local.of_lib_exn |> Option.some)
-                | _ -> None))
-       |> Dune_engine.Dep.Set.of_list_map ~f:(fun (lib : Lib.Local.t) ->
-              Lib lib |> Dep.html_alias ctx |> Dune_engine.Dep.alias)))
+    (Action_builder.deps action)
 
 let gen_rules sctx ~dir:_ rest =
   match rest with
@@ -726,7 +729,8 @@ let gen_rules sctx ~dir:_ rest =
   | "_odoc" :: "lib" :: lib :: _ -> (
     let lib, lib_db = Scope_key.of_string sctx lib in
     (* diml: why isn't [None] some kind of error here? *)
-    match Lib.DB.find lib_db lib with
+    let* lib = Lib.DB.find lib_db lib in
+    match lib with
     | None -> Memo.Build.return ()
     | Some lib ->
       (* TODO instead of this hack, call memoized function that generates the
@@ -743,10 +747,9 @@ let gen_rules sctx ~dir:_ rest =
       setup_pkg_html_rules sctx ~pkg ~libs:pkg_libs
     in
     (* jeremiedimino: why isn't [None] some kind of error here? *)
-    let lib =
-      let open Option.O in
-      let* lib = Lib.DB.find lib_db lib in
-      Lib.Local.of_lib lib
+    let* lib =
+      let+ lib = Lib.DB.find lib_db lib in
+      Option.bind ~f:Lib.Local.of_lib lib
     in
     let+ () =
       match lib with
@@ -754,8 +757,8 @@ let gen_rules sctx ~dir:_ rest =
       | Some lib -> (
         match Lib_info.package (Lib.Local.info lib) with
         | None ->
-          setup_lib_html_rules sctx lib
-            ~requires:(Lib.closure ~linking:false [ Lib.Local.to_lib lib ])
+          let* requires = Lib.closure ~linking:false [ Lib.Local.to_lib lib ] in
+          setup_lib_html_rules sctx lib ~requires
         | Some pkg -> setup_pkg_html_rules pkg)
     and+ () =
       match

--- a/src/dune_rules/per_item_intf.ml
+++ b/src/dune_rules/per_item_intf.ml
@@ -6,6 +6,8 @@ module type S = sig
 
   type 'a t
 
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
   (** Create a mapping where all keys map to the same value *)
   val for_all : 'a -> 'a t
 
@@ -25,12 +27,15 @@ module type S = sig
   val fold : 'a t -> init:'acc -> f:('a -> 'acc -> 'acc) -> 'acc
 
   val fold_resolve :
-    'a t -> init:'acc -> f:('a -> 'acc -> 'acc Resolve.t) -> 'acc Resolve.t
+       'a t
+    -> init:'acc
+    -> f:('a -> 'acc -> 'acc Resolve.Build.t)
+    -> 'acc Resolve.Build.t
 
   val exists : 'a t -> f:('a -> bool) -> bool
 
   val map_action_builder :
     'a t -> f:('a -> 'b Action_builder.t) -> 'b t Action_builder.t
 
-  val map_resolve : 'a t -> f:('a -> 'b Resolve.t) -> 'b t Resolve.t
+  val map_resolve : 'a t -> f:('a -> 'b Resolve.Build.t) -> 'b t Resolve.Build.t
 end

--- a/src/dune_rules/plugin_rules.ml
+++ b/src/dune_rules/plugin_rules.ml
@@ -1,6 +1,7 @@
 open! Stdune
 open Dune_file.Plugin
 open! Dune_engine
+open Memo.Build.O
 
 let meta_file ~dir { name; libraries = _; site = _, (pkg, site); _ } =
   Path.Build.L.relative dir
@@ -12,15 +13,15 @@ let meta_file ~dir { name; libraries = _; site = _, (pkg, site); _ } =
     ]
 
 let resolve_libs ~sctx t =
-  Resolve.List.map t.libraries
+  Resolve.Build.List.map t.libraries
     ~f:(Lib.DB.resolve (Super_context.public_libs sctx))
 
 let setup_rules ~sctx ~dir t =
   let meta = meta_file ~dir t in
   Super_context.add_rule sctx ~dir
     (Action_builder.write_file_dyn meta
-       (Resolve.read
-          (let open Resolve.O in
+       (Resolve.Build.read
+          (let open Resolve.Build.O in
           let+ requires = resolve_libs ~sctx t in
           let meta =
             { Meta.name = None
@@ -34,14 +35,21 @@ let setup_rules ~sctx ~dir t =
             (Pp.vbox (Pp.seq (Meta.pp meta.entries) Pp.cut)))))
 
 let install_rules ~sctx ~dir ({ name; site = loc, (pkg, site); _ } as t) =
-  if t.optional && Resolve.is_error (resolve_libs ~sctx t) then
-    []
+  let* skip_files =
+    if t.optional then
+      Resolve.Build.is_error (resolve_libs ~sctx t)
+    else
+      Memo.Build.return false
+  in
+  if skip_files then
+    Memo.Build.return []
   else
     let meta = meta_file ~dir t in
-    [ ( Some loc
-      , Install.Entry.make_with_site
-          ~dst:(sprintf "%s/%s" (Package.Name.to_string name) Findlib.meta_fn)
-          (Site { pkg; site; loc })
-          (Super_context.get_site_of_packages sctx)
-          meta )
-    ]
+    let+ entry =
+      Install.Entry.make_with_site
+        ~dst:(sprintf "%s/%s" (Package.Name.to_string name) Findlib.meta_fn)
+        (Site { pkg; site; loc })
+        (Super_context.get_site_of_packages sctx)
+        meta
+    in
+    [ (Some loc, entry) ]

--- a/src/dune_rules/plugin_rules.mli
+++ b/src/dune_rules/plugin_rules.mli
@@ -10,4 +10,4 @@ val install_rules :
      sctx:Super_context.t
   -> dir:Path.Build.t
   -> Dune_file.Plugin.t
-  -> (Loc.t option * Path.Build.t Dune_engine.Install.Entry.t) list
+  -> (Loc.t option * Path.Build.t Dune_engine.Install.Entry.t) list Memo.Build.t

--- a/src/dune_rules/preprocess.mli
+++ b/src/dune_rules/preprocess.mli
@@ -18,6 +18,8 @@ type 'a t =
   | Pps of 'a Pps.t
   | Future_syntax of Loc.t
 
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
 val map : 'a t -> f:('a -> 'b) -> 'b t
 
 module Without_instrumentation : sig
@@ -34,6 +36,8 @@ module With_instrumentation : sig
         ; deps : Dep_conf.t list
         ; flags : String_with_vars.t list
         }
+
+  val equal : t -> t -> bool
 end
 
 val decode : Without_instrumentation.t t Dune_lang.Decoder.t
@@ -64,6 +68,8 @@ module Per_module : sig
 
   type 'a t = 'a preprocess Module_name.Per_item.t
 
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
   val decode : Without_instrumentation.t t Dune_lang.Decoder.t
 
   val no_preprocessing : unit -> 'a t
@@ -92,13 +98,15 @@ module Per_module : sig
   val with_instrumentation :
        With_instrumentation.t t
     -> instrumentation_backend:
-         (Loc.t * Lib_name.t -> Without_instrumentation.t option Resolve.t)
-    -> Without_instrumentation.t t Resolve.t
+         (   Loc.t * Lib_name.t
+          -> Without_instrumentation.t option Resolve.Build.t)
+    -> Without_instrumentation.t t Resolve.Build.t
 
   val instrumentation_deps :
        With_instrumentation.t t
     -> instrumentation_backend:
-         (Loc.t * Lib_name.t -> Without_instrumentation.t option Resolve.t)
-    -> Dep_conf.t list Resolve.t
+         (   Loc.t * Lib_name.t
+          -> Without_instrumentation.t option Resolve.Build.t)
+    -> Dep_conf.t list Resolve.Build.t
 end
 with type 'a preprocess := 'a t

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -209,17 +209,18 @@ module Driver = struct
       { info; lib; replaces }
 
     let public_info t =
-      let open Resolve.O in
-      let+ replaces = t.replaces in
-      { Info.loc = t.info.loc
-      ; flags = t.info.flags
-      ; as_ppx_flags = t.info.as_ppx_flags
-      ; lint_flags = t.info.lint_flags
-      ; main = t.info.main
-      ; replaces =
-          List.map2 t.info.replaces replaces ~f:(fun (loc, _) t ->
-              (loc, Lib.name t.lib))
-      }
+      Memo.Build.return
+        (let open Resolve.O in
+        let+ replaces = t.replaces in
+        { Info.loc = t.info.loc
+        ; flags = t.info.flags
+        ; as_ppx_flags = t.info.as_ppx_flags
+        ; lint_flags = t.info.lint_flags
+        ; main = t.info.main
+        ; replaces =
+            List.map2 t.info.replaces replaces ~f:(fun (loc, _) t ->
+                (loc, Lib.name t.lib))
+        })
   end
 
   include M
@@ -295,11 +296,11 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
   let open Memo.Build.O in
   let ctx = SC.context sctx in
   let* driver_and_libs =
-    Resolve.Build.bind
-      (Resolve.bind pps ~f:(Lib.closure ~linking:true))
-      ~f:(fun pps ->
-        Driver.select pps ~loc:(Dot_ppx (target, pp_names))
-        >>| Resolve.map ~f:(fun driver -> (driver, pps)))
+    let ( let& ) t f = Resolve.Build.bind t ~f in
+    let& pps = Resolve.Build.lift pps in
+    let& pps = Lib.closure ~linking:true pps in
+    Driver.select pps ~loc:(Dot_ppx (target, pp_names))
+    >>| Resolve.map ~f:(fun driver -> (driver, pps))
     >>| (* Extend the dependency stack as we don't have locations at this
            point *)
     Resolve.push_stack_frame ~human_readable_description:(fun () ->
@@ -337,13 +338,16 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
   let* cctx =
     let+ expander = Super_context.expander sctx ~dir in
     let requires_compile = Resolve.map driver_and_libs ~f:snd in
-    let requires_link = lazy requires_compile in
+    let requires_link =
+      Memo.lazy_ (fun () -> Memo.Build.return requires_compile)
+    in
     let flags = Ocaml_flags.of_list [ "-g"; "-w"; "-24" ] in
     let opaque = Compilation_context.Explicit false in
     let modules = Modules.singleton_exe module_ in
     Compilation_context.create ~super_context:sctx ~scope ~expander ~obj_dir
-      ~modules ~flags ~requires_compile ~requires_link ~opaque ~js_of_ocaml:None
-      ~package:None ~bin_annot:false ()
+      ~modules ~flags
+      ~requires_compile:(Memo.Build.return requires_compile)
+      ~requires_link ~opaque ~js_of_ocaml:None ~package:None ~bin_annot:false ()
   in
   Exe.build_and_link ~program ~linkages cctx ~promote:None
 
@@ -369,7 +373,8 @@ let get_rules sctx key =
       in
       (pps, scope)
   in
-  let pps =
+  let open Memo.Build.O in
+  let* pps =
     let lib_db = Scope.libs scope in
     List.map pp_names ~f:(fun x -> (Loc.none, x)) |> Lib.DB.resolve_pps lib_db
   in
@@ -450,11 +455,11 @@ let ppx_driver_and_flags_internal sctx ~loc ~expander ~lib_name ~flags libs =
 
 let ppx_driver_and_flags sctx ~lib_name ~expander ~scope ~loc ~flags pps =
   let open Action_builder.O in
-  let* libs = Resolve.read (Lib.DB.resolve_pps (Scope.libs scope) pps) in
+  let* libs = Resolve.Build.read (Lib.DB.resolve_pps (Scope.libs scope) pps) in
   let* exe, flags =
     ppx_driver_and_flags_internal sctx ~loc ~expander ~lib_name ~flags libs
   in
-  let* libs = Resolve.read (Lib.closure libs ~linking:true) in
+  let* libs = Resolve.Build.read (Lib.closure libs ~linking:true) in
   let+ driver =
     Action_builder.memo_build (Driver.select libs ~loc:(User_file (loc, pps)))
     >>= Resolve.read
@@ -718,10 +723,10 @@ let make sctx ~dir ~expander ~lint ~preprocess ~preprocessor_deps
 
 let get_ppx_driver sctx ~loc ~expander ~scope ~lib_name ~flags pps =
   let open Action_builder.O in
-  let* libs = Resolve.read (Lib.DB.resolve_pps (Scope.libs scope) pps) in
+  let* libs = Resolve.Build.read (Lib.DB.resolve_pps (Scope.libs scope) pps) in
   ppx_driver_and_flags_internal sctx ~loc ~expander ~lib_name ~flags libs
 
 let ppx_exe sctx ~scope pp =
-  let open Resolve.O in
+  let open Resolve.Build.O in
   let+ libs = Lib.DB.resolve_pps (Scope.libs scope) [ (Loc.none, pp) ] in
   ppx_driver_exe sctx libs

--- a/src/dune_rules/preprocessing.mli
+++ b/src/dune_rules/preprocessing.mli
@@ -40,4 +40,4 @@ val action_for_pp_with_target :
   -> Action.t Action_builder.With_targets.t
 
 val ppx_exe :
-  Super_context.t -> scope:Scope.t -> Lib_name.t -> Path.Build.t Resolve.t
+  Super_context.t -> scope:Scope.t -> Lib_name.t -> Path.Build.t Resolve.Build.t

--- a/src/dune_rules/resolve.ml
+++ b/src/dune_rules/resolve.ml
@@ -22,14 +22,14 @@ end)
 
 let error_equal { exn; stack_frames } b =
   Exn.equal exn b.exn
-  && List.equal
+  && Stdune.List.equal
        (fun (lazy a) (lazy b) -> Poly.equal a b)
        stack_frames b.stack_frames
 
 let equal f = Result.equal f error_equal
 
 let error_hash { exn; stack_frames } =
-  Poly.hash (Exn.hash exn, List.map stack_frames ~f:Lazy.force)
+  Poly.hash (Exn.hash exn, Stdune.List.map stack_frames ~f:Lazy.force)
 
 let to_dyn f t =
   Result.to_dyn f Exn.to_dyn (Result.map_error t ~f:(fun x -> x.exn))
@@ -37,6 +37,10 @@ let to_dyn f t =
 let hash f = Result.hash f error_hash
 
 let of_result = Result.map_error ~f:(fun exn -> { exn; stack_frames = [] })
+
+let to_result x = x
+
+let of_error x = Error x
 
 let error_to_memo_build { stack_frames; exn } =
   let open Memo.Build.O in
@@ -80,13 +84,6 @@ let push_stack_frame ~human_readable_description:f t =
   | Error err ->
     Error { err with stack_frames = Lazy.from_fun f :: err.stack_frames }
 
-module Build = struct
-  let bind t ~f =
-    match t with
-    | Error _ as err -> Memo.Build.return err
-    | Ok x -> Memo.Build.map (f x) ~f:Fun.id
-end
-
 module List = struct
   let map = Result.List.map
 
@@ -106,4 +103,64 @@ module Option = struct
     match x with
     | None -> return ()
     | Some x -> f x
+end
+
+module Build = struct
+  open Memo.Build.O
+
+  module T = struct
+    type nonrec 'a t = 'a t Memo.Build.t
+
+    let return x = Memo.Build.return (Ok x)
+
+    let bind t ~f =
+      let* t = t in
+      match t with
+      | Ok s -> f s
+      | Error e -> Memo.Build.return (Error e)
+  end
+
+  module M = struct
+    include T
+    include Monad.Make (T)
+  end
+
+  module List = Monad.List (M)
+  include M
+
+  let push_stack_frame ~human_readable_description f =
+    let+ t = Memo.push_stack_frame ~human_readable_description f in
+    push_stack_frame ~human_readable_description t
+
+  let lift t = Memo.Build.return t
+
+  let lift_memo t = Memo.Build.map t ~f:(fun x -> Ok x)
+
+  let is_ok t = Memo.Build.map ~f:is_ok t
+
+  let is_error t = Memo.Build.map ~f:is_error t
+
+  module Option = struct
+    let iter t ~f : unit t =
+      match t with
+      | None -> return ()
+      | Some t -> f t
+  end
+
+  let all = List.map ~f:Fun.id
+
+  let read_memo_build t =
+    let* t = t in
+    read_memo_build t
+
+  let read (type a) (t : a t) : a Action_builder.t =
+    Action_builder.memo_build (read_memo_build t)
+
+  let fail s = Memo.Build.return (fail s)
+
+  let args s = Command.Args.Dyn (read s)
+
+  let of_result s = Memo.Build.return (of_result s)
+
+  let peek t = Memo.Build.map t ~f:(Result.map_error ~f:ignore)
 end

--- a/src/dune_rules/resolve.mli
+++ b/src/dune_rules/resolve.mli
@@ -96,7 +96,7 @@ open Dune_engine
 
 type 'a t
 
-include Monad with type 'a t := 'a t
+include Monad.S with type 'a t := 'a t
 
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
@@ -105,6 +105,12 @@ val hash : ('a -> int) -> 'a t -> int
 val to_dyn : ('a -> Dyn.t) -> 'a t Dyn.Encoder.t
 
 val of_result : ('a, exn) result -> 'a t
+
+type error
+
+val to_result : 'a t -> ('a, error) result
+
+val of_error : error -> 'a t
 
 (** Read a [Resolve.t] value inside the action builder monad. *)
 val read : 'a t -> 'a Action_builder.t
@@ -136,10 +142,6 @@ val push_stack_frame :
 
 val all : 'a t list -> 'a list t
 
-module Build : sig
-  val bind : 'a t -> f:('a -> 'b t Memo.Build.t) -> 'b t Memo.Build.t
-end
-
 module List : sig
   val map : 'a list -> f:('a -> 'b t) -> 'b list t
 
@@ -155,3 +157,51 @@ end
 module Option : sig
   val iter : 'a option -> f:('a -> unit t) -> unit t
 end
+
+module Build : sig
+  type 'a resolve
+
+  type 'a t = 'a resolve Memo.Build.t
+
+  val all : 'a t list -> 'a list t
+
+  include Monad.S with type 'a t := 'a t
+
+  val push_stack_frame :
+       human_readable_description:(unit -> User_message.Style.t Pp.t)
+    -> (unit -> 'a t)
+    -> 'a t
+
+  val lift_memo : 'a Memo.Build.t -> 'a t
+
+  val lift : 'a resolve -> 'a t
+
+  val is_ok : 'a t -> bool Memo.Build.t
+
+  (** [is_ok t] is the same as [Result.is_error (peek t)] *)
+  val is_error : 'a t -> bool Memo.Build.t
+
+  module List : Monad.List with type 'a t := 'a t
+
+  module Option : sig
+    val iter : 'a option -> f:('a -> unit t) -> unit t
+  end
+
+  (** Same as [read] but in the memo build monad. Use with caution! *)
+  val read_memo_build : 'a t -> 'a Memo.Build.t
+
+  (** Read a [Resolve.t] value inside the action builder monad. *)
+  val read : 'a t -> 'a Action_builder.t
+
+  (** [args] allows to easily inject a resolve monad computing some command line
+      arguments into an command line specification. *)
+  val args : Command.Args.without_targets Command.Args.t t -> 'a Command.Args.t
+
+  val fail : User_message.t -> _ t
+
+  val of_result : ('a, exn) result -> 'a t
+
+  (** Read the value immediatly, ignoring actual errors. *)
+  val peek : 'a t -> ('a, unit) result Memo.Build.t
+end
+with type 'a resolve := 'a t

--- a/src/dune_rules/sub_system_info.ml
+++ b/src/dune_rules/sub_system_info.ml
@@ -4,6 +4,8 @@ open Dune_lang.Decoder
 
 type t = ..
 
+let equal (x : t) (y : t) = x == y
+
 type sub_system = t = ..
 
 module type S = sig

--- a/src/dune_rules/sub_system_info.mli
+++ b/src/dune_rules/sub_system_info.mli
@@ -40,3 +40,5 @@ val record_parser :
      Dune_lang.Decoder.parser
 
 val get : Sub_system_name.t -> (module S)
+
+val equal : t -> t -> bool

--- a/src/dune_rules/sub_system_intf.ml
+++ b/src/dune_rules/sub_system_intf.ml
@@ -13,7 +13,7 @@ module type S = sig
 
   (** Create an instance of the sub-system *)
   val instantiate :
-       resolve:(Loc.t * Lib_name.t -> Lib.t Resolve.t)
+       resolve:(Loc.t * Lib_name.t -> Lib.t Resolve.Build.t)
     -> get:(loc:Loc.t -> Lib.t -> t option Memo.Build.t)
     -> Lib.t
     -> Info.t
@@ -37,7 +37,7 @@ module type Backend = sig
   (** Return the processed information. This is what is serialised in
       [dune-package] files. Typically, it should be the original info with the
       private library names replaced by public ones. *)
-  val public_info : t -> Info.t Resolve.t
+  val public_info : t -> Info.t Resolve.Build.t
 end
 
 module type Registered_backend = sig
@@ -46,7 +46,7 @@ module type Registered_backend = sig
   val get : Lib.t -> t option Memo.Build.t
 
   (** Resolve a backend name *)
-  val resolve : Lib.DB.t -> Loc.t * Lib_name.t -> t Resolve.t Memo.Build.t
+  val resolve : Lib.DB.t -> Loc.t * Lib_name.t -> t Resolve.Build.t
 
   module Selection_error : sig
     type nonrec t =
@@ -66,7 +66,7 @@ module type Registered_backend = sig
        ?written_by_user:t list
     -> extends:(t -> t list Resolve.t)
     -> Lib.t list
-    -> (t list, Selection_error.t) result Resolve.t Memo.Build.t
+    -> (t list, Selection_error.t) result Resolve.Build.t
 
   (** Choose a backend by either using the ones written by the user or by
       scanning the dependencies.

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -34,10 +34,15 @@ val packages : t -> Package.t Package.Name.Map.t
 
 val host : t -> t
 
-val any_package : t -> Package.Name.t -> Expander.any_package option
+val any_package :
+  t -> Package.Name.t -> Expander.any_package option Memo.Build.t
 
 val get_site_of_packages :
-  t -> loc:Loc.t -> pkg:Package.Name.t -> site:Section.Site.t -> Section.t
+     t
+  -> loc:Loc.t
+  -> pkg:Package.Name.t
+  -> site:Section.Site.t
+  -> Section.t Memo.Build.t
 
 module Lib_entry : sig
   type t =

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -104,7 +104,7 @@ let setup_module_rules t =
   let main_ml =
     let open Action_builder.O in
     Action_builder.write_file_dyn path
-      (let* libs = Resolve.read requires_compile in
+      (let* libs = Resolve.Build.read requires_compile in
        let include_dirs =
          Path.Set.to_list (Lib.L.include_paths libs Mode.Byte)
        in

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -52,52 +52,48 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
         match Super_context.stanzas_in sctx ~dir with
         | None -> Memo.Build.return Libs_and_ppxs.empty
         | Some (d : _ Dir_with_dune.t) ->
-          Memo.Build.return
-          @@ List.fold_left d.data ~init:Libs_and_ppxs.empty
-               ~f:(fun (acc, pps) -> function
-               | Dune_file.Library l -> (
-                 match
-                   Option.map
-                     (Lib.DB.resolve_when_exists db
-                        (l.buildable.loc, Dune_file.Library.best_name l))
-                     ~f:Resolve.peek
-                 with
-                 | None
-                 | Some (Error ()) ->
-                   (acc, pps)
-                   (* library is defined but outside our scope or is disabled *)
-                 | Some (Ok lib) ->
-                   (* still need to make sure that it's not coming from an
-                      external source *)
-                   let info = Lib.info lib in
-                   let src_dir = Lib_info.src_dir info in
-                   (* Only select libraries that are not implementations.
-                      Implementations are selected using the default
-                      implementation feature. *)
-                   let not_impl = Option.is_none (Lib_info.implements info) in
-                   if
-                     not_impl
-                     && Path.is_descendant ~of_:(Path.build dir) src_dir
-                   then
-                     match Lib_info.kind info with
-                     | Lib_kind.Ppx_rewriter _
-                     | Ppx_deriver _ ->
-                       ( Appendable_list.( @ )
-                           (Appendable_list.singleton lib)
-                           acc
-                       , Appendable_list.( @ )
-                           (Appendable_list.singleton
-                              (Lib_info.loc info, Lib_info.name info))
-                           pps )
-                     | Normal ->
-                       ( Appendable_list.( @ )
-                           (Appendable_list.singleton lib)
-                           acc
-                       , pps )
-                   else
-                     (acc, pps)
-                   (* external lib with a name matching our private name *))
-               | _ -> (acc, pps)))
+          Memo.Build.List.fold_left d.data ~init:Libs_and_ppxs.empty
+            ~f:(fun (acc, pps) -> function
+            | Dune_file.Library l -> (
+              let+ lib =
+                let open Memo.Build.O in
+                let+ resolve =
+                  Lib.DB.resolve_when_exists db
+                    (l.buildable.loc, Dune_file.Library.best_name l)
+                in
+                Option.map resolve ~f:Resolve.peek
+                (* external lib with a name matching our private name *)
+              in
+              match lib with
+              | None
+              | Some (Error ()) ->
+                (acc, pps)
+                (* library is defined but outside our scope or is disabled *)
+              | Some (Ok lib) ->
+                (* still need to make sure that it's not coming from an external
+                   source *)
+                let info = Lib.info lib in
+                let src_dir = Lib_info.src_dir info in
+                (* Only select libraries that are not implementations.
+                   Implementations are selected using the default implementation
+                   feature. *)
+                let not_impl = Option.is_none (Lib_info.implements info) in
+                if not_impl && Path.is_descendant ~of_:(Path.build dir) src_dir
+                then
+                  match Lib_info.kind info with
+                  | Lib_kind.Ppx_rewriter _
+                  | Ppx_deriver _ ->
+                    ( Appendable_list.( @ ) (Appendable_list.singleton lib) acc
+                    , Appendable_list.( @ )
+                        (Appendable_list.singleton
+                           (Lib_info.loc info, Lib_info.name info))
+                        pps )
+                  | Normal ->
+                    ( Appendable_list.( @ ) (Appendable_list.singleton lib) acc
+                    , pps )
+                else
+                  (acc, pps))
+            | _ -> Memo.Build.return (acc, pps)))
     >>| fun (libs, pps) ->
     (Appendable_list.to_list libs, Appendable_list.to_list pps)
 
@@ -126,7 +122,7 @@ let setup sctx ~dir =
   let loc = Toplevel.Source.loc source in
   let* modules = Toplevel.Source.modules source preprocessing in
   let requires =
-    let open Resolve.O in
+    let open Resolve.Build.O in
     (loc, Lib_name.of_string "utop")
     |> Lib.DB.resolve db
     >>| (fun utop -> utop :: libs)
@@ -141,9 +137,9 @@ let setup sctx ~dir =
       [ "-w"; "-24" ]
   in
   let cctx =
+    let requires_link = Memo.lazy_ (fun () -> requires) in
     Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
-      ~modules ~opaque:(Explicit false)
-      ~requires_link:(lazy requires)
+      ~modules ~opaque:(Explicit false) ~requires_link
       ~requires_compile:requires ~flags ~js_of_ocaml:None ~package:None
       ~preprocessing
   in

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -82,7 +82,7 @@ let impl sctx ~(lib : Dune_file.Library.t) ~scope =
   match lib.implements with
   | None -> Memo.Build.return None
   | Some (loc, implements) -> (
-    match Lib.DB.find (Scope.libs scope) implements with
+    Lib.DB.find (Scope.libs scope) implements >>= function
     | None ->
       User_error.raise ~loc
         [ Pp.textf "Cannot implement %s as that library isn't available"
@@ -116,7 +116,7 @@ let impl sctx ~(lib : Dune_file.Library.t) ~scope =
             Dir_contents.get sctx ~dir
           in
           let* preprocess =
-            Resolve.read_memo_build
+            Resolve.Build.read_memo_build
               (Preprocess.Per_module.with_instrumentation
                  lib.buildable.preprocess
                  ~instrumentation_backend:

--- a/src/dune_rules/wrapped.ml
+++ b/src/dune_rules/wrapped.ml
@@ -6,6 +6,8 @@ type t =
   | Simple of bool
   | Yes_with_transition of string
 
+let equal = Poly.equal
+
 let decode =
   sum
     [ ("true", return (Simple true))

--- a/src/dune_rules/wrapped.mli
+++ b/src/dune_rules/wrapped.mli
@@ -5,6 +5,8 @@ type t =
   | Simple of bool
   | Yes_with_transition of string
 
+val equal : t -> t -> bool
+
 include Dune_lang.Conv.S with type t := t
 
 val to_bool : t -> bool

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -66,6 +66,8 @@ module Build0 = struct
   end
 
   module List = struct
+    include Monad.List (Fiber)
+
     let map = parallel_map
 
     let concat_map l ~f = map l ~f >>| List.concat
@@ -1671,13 +1673,9 @@ end
 type 'a build = 'a Fiber.t
 
 module type Build = sig
-  include Monad
+  include Monad.S
 
-  module List : sig
-    val map : 'a list -> f:('a -> 'b t) -> 'b list t
-
-    val concat_map : 'a list -> f:('a -> 'b list t) -> 'b list t
-  end
+  module List : Monad.List with type 'a t := 'a t
 
   val memo_build : 'a build -> 'a t
 end

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -3,13 +3,9 @@ open! Stdune
 type 'a build
 
 module type Build = sig
-  include Monad
+  include Monad.S
 
-  module List : sig
-    val map : 'a list -> f:('a -> 'b t) -> 'b list t
-
-    val concat_map : 'a list -> f:('a -> 'b list t) -> 'b list t
-  end
+  module List : Monad.List with type 'a t := 'a t
 
   val memo_build : 'a build -> 'a t
 end

--- a/test/blackbox-tests/test-cases/lib-errors.t/dune
+++ b/test/blackbox-tests/test-cases/lib-errors.t/dune
@@ -19,10 +19,3 @@
  (modules cycle))
 
 (rule (with-stdout-to cycle.ml (echo "")))
-
-(executable
- (name select_error)
- (libraries (select x from))
- (modules select_error))
-
-(rule (with-stdout-to select_error.ml (echo "")))

--- a/test/blackbox-tests/test-cases/lib-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/lib-errors.t/run.t
@@ -4,23 +4,31 @@ Cycle detection
 ---------------
 
   $ dune build cycle.exe
-  Error: Dependency cycle detected between the following libraries:
-     "a" in _build/default
-  -> "b" in _build/default
-  -> "c" in _build/default
-  -> "a" in _build/default
-  -> required by library "c" in _build/default
-  -> required by executable cycle in dune:17
-  -> required by _build/default/cycle.exe
+  Error: Dependency cycle between:
+     library "a" in _build/default
+  -> library "c" in _build/default
+  -> library "b" in _build/default
+  -> library "a" in _build/default
   [1]
 
 Select with no solution
 -----------------------
 
+  $ mkdir select
+  $ cd select
+  $ echo "(lang dune 3.0)" > dune-project
+  $ cat <<EOF > dune
+  > (executable
+  >  (name select_error)
+  >  (libraries (select x from))
+  >  (modules select_error))
+  > (rule (with-stdout-to select_error.ml (echo "")))
+  > EOF
+
   $ dune build select_error.exe
-  File "dune", line 25, characters 12-27:
-  25 |  (libraries (select x from))
-                   ^^^^^^^^^^^^^^^
+  File "dune", line 3, characters 12-27:
+  3 |  (libraries (select x from))
+                  ^^^^^^^^^^^^^^^
   Error: No solution found for this select form.
   [1]
 

--- a/test/blackbox-tests/test-cases/ppx-runtime-dependencies.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx-runtime-dependencies.t/run.t
@@ -59,14 +59,11 @@ Handling ppx_runtime_libraries dependencies correctly
   > EOF
 
   $ ./sdune exec bin/main.exe
-  Error: Dependency cycle detected between the following libraries:
-     "a" in _build/default
-  -> "b" in _build/default
-  -> "c" in _build/default
-  -> "a" in _build/default
-  -> required by library "c" in _build/default
-  -> required by executable main in bin/dune:2
-  -> required by _build/default/bin/main.exe
+  Error: Dependency cycle between:
+     library "a" in _build/default
+  -> library "c" in _build/default
+  -> library "b" in _build/default
+  -> library "a" in _build/default
   [1]
 
 ----------------------------------------------------------------------------------
@@ -164,12 +161,9 @@ Note that pps dependencies are separated by a runtime dependency.
   > EOF
 
   $ ./sdune exec bin/main.exe
-  Error: Dependency cycle detected between the following libraries:
-     "gen_c" in _build/default
-  -> "ppx" in _build/default
-  -> "c" in _build/default
-  -> "gen_c" in _build/default
-  -> required by library "c" in _build/default
-  -> required by executable main in bin/dune:2
-  -> required by _build/default/bin/main.exe
+  Error: Dependency cycle between:
+     library "gen_c" in _build/default
+  -> library "c" in _build/default
+  -> library "ppx" in _build/default
+  -> library "gen_c" in _build/default
   [1]

--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -16,6 +16,7 @@
   fiber
   dune_lang
   memo
+  test_scheduler
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   ppx_expect.config


### PR DESCRIPTION
- Change Lib to use memoization instead of an explicit tables. This
  requires essentially lib functions are returning Memo.Build.t

- Introduce Resolve.Build.t for library resolution in Memo.Build.t

This isn't yet ready as I'm not handling cycle errors correctly.