### PR TITLE
Rpc symlink creation race

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -775,7 +775,11 @@ module Client = struct
       | true -> k call
       | false ->
         let err =
-          Response.Error.create ~payload:call.params
+          let payload =
+            Sexp.record
+              [ ("method", Atom call.method_); ("params", call.params) ]
+          in
+          Response.Error.create ~payload
             ~message:"notification sent while connection is dead"
             ~kind:Code_error ()
         in

--- a/test/blackbox-tests/utils/dune_cmd.ml
+++ b/test/blackbox-tests/utils/dune_cmd.ml
@@ -75,15 +75,13 @@ module Wait_for_fs_clock_to_advance = struct
 end
 
 module Cat = struct
-  type t = File of Path.t
-
   let name = "cat"
 
   let of_args = function
-    | [ file ] -> File (Path.of_filename_relative_to_initial_cwd file)
+    | [ file ] -> file
     | _ -> raise (Arg.Bad "Usage: dune_cmd cat <file>")
 
-  let run (File p) = print_string (Io.read_file p)
+  let run p = print_string (Io.String_path.read_file p)
 
   let () = register name of_args run
 end

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -23,26 +23,13 @@ let init_chan ~root_dir =
       | Ok s -> Some s
       | Error _ -> None)
   in
-  let rec loop thread =
+  let rec loop () =
     let* res = once () in
     match res with
-    | Some res ->
-      (match thread with
-      | None -> ()
-      | Some th -> Scheduler.Worker.stop th);
-      Fiber.return res
-    | None ->
-      let* thread =
-        match thread with
-        | None -> Scheduler.Worker.create ()
-        | Some th -> Fiber.return th
-      in
-      let* () =
-        Scheduler.Worker.task_exn thread ~f:(fun () -> Unix.sleepf 0.2)
-      in
-      loop (Some thread)
+    | Some res -> Fiber.return res
+    | None -> Scheduler.sleep 0.2 >>= loop
   in
-  loop None
+  loop ()
 
 let run_client ?handler f =
   let* chan = init_chan ~root_dir:"." in


### PR DESCRIPTION
We are creating the symlink before the actual socket. Which means that it is possible for the client to observe a dead link. This PR changes the code to create the socket first.