### PR TITLE
[2.9] Opam file generation is broken: don't use `subst --root` in Opam files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -162,6 +162,11 @@ Unreleased
 - Allow depending on `ocamldoc` library when `ocamlfind` is not installed.
   (#4811, fixes #4809, @nojb)
 
+2.9.1 (unreleased)
+------------------
+
+- Don't use `subst --root` in Opam files (#4806, @MisterDA)
+
 2.9.0 (29/06/2021)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -162,7 +162,7 @@ Unreleased
 - Allow depending on `ocamldoc` library when `ocamlfind` is not installed.
   (#4811, fixes #4809, @nojb)
 
-2.9.0 (unreleased)
+2.9.0 (29/06/2021)
 ------------------
 
 - Add `(enabled_if ...)` to `(mdx ...)` (#4434, @emillon)

--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -142,7 +142,7 @@ Test with an opam like installation
     "odoc" {with-doc}
   ]
   build: [
-    ["dune" "subst" "--root" "."] {dev}
+    ["dune" "subst"] {dev}
     [
       "dune"
       "build"

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -48,7 +48,7 @@ let default_build_command =
          (Lexbuf.from_string ~fname:"<internal>"
             {|
 [
-  [ "dune" "subst" "--root" "." ] {dev}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs "--promote-install-files" "false"
       "@install"
       "@runtest" {with-test}


### PR DESCRIPTION
Introduced in Dune 2.9, Opam files are now generated with this line:

```
build: [
  ["dune" "subst" "--root" "."] {dev}
```

This was added in commit 88d8b0e199f7a9d6a805bba5c98022fd37e19a7e in PR #4730. 

The author probably forgot that Dune doesn't have the `subst --root .` option. Amusingly, an earlier issue refers to this problem:

> Oh no, sorry, I should have been clearer. It was really that in the futur we generate with the `--root .`, (I forgot dune was generating that). It is a regression that must be fixed.
> 
> And thank you for pointing that `dune subst` doesn't have contrary to the other command a `--root` option.

_Originally posted by @bobot in https://github.com/ocaml/dune/issues/4043#issuecomment-746465438_

As I see it, using Opam files generated by **Dune 2.9 only** is now broken as packages won't install. This only shows up when using a `(lang 2.9)` dune-project, so presumably people haven't updated this part of the build system yet, which is why the issue hasn't showed up yet (or at least I haven't found any references to it).

This also shows that Dune doesn't have tests with Opam integration... I think tests with e.g., opam-lint or `opam pin` should be added to test the validity of generated Opam files. We could also try to build Dune main with Dune main and install it through Opam.

I'd suggest releasing Dune 2.9.1 with this patch ;)

cc @bobot 