### PR TITLE
Fixup autoload regex for Emacs.

### DIFF
--- a/editor-integration/emacs/dune.el
+++ b/editor-integration/emacs/dune.el
@@ -395,7 +395,7 @@ For customization purposes, use `dune-mode-hook'."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist
-             '("\\(?:\\`\\|/\\)dune\\(?:\\.inc\|-project\\)?\\'" . dune-mode))
+             '("\\(?:\\`\\|/\\)dune\\(?:\\.inc\\|\\-project\\)?\\'" . dune-mode))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Fix for https://github.com/ocaml/dune/pull/4222 the regex is not correct.

```lisp
;; Original regex
;; NOTE 0 is true and nil is false (roughtly speaking)
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\|-project\\)?\\'" "dune")
0
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\|-project\\)?\\'" "dune.inc")
nil
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\|-project\\)?\\'" "dune-project")
nil

;; New regex
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\\|\\-project\\)?\\'" "dune")
0
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\\|\\-project\\)?\\'" "dune.inc")
0
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\\|\\-project\\)?\\'" "dune-project")
0
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\\|\\-project\\)?\\'" "dune-project.inc")
nil
(string-match "\\(?:\\`\\|/\\)dune\\(?:\\.inc\\|\\-project\\)?\\'" "dune-projects")
nil

;; Potentially simplier regex from regexp-opt though I'm not sure if this covers 
;; all possible cases. I have only tested on OSX and Linux.
(regexp-opt '("dune" "dune-project" "dune.inc"))
"\\(?:dune\\(?:-project\\|\\.inc\\)?\\)"
```