### PR TITLE
Add encode function for Package.t

### DIFF
--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -356,6 +356,12 @@ module Source_kind = struct
              let constr = to_string kind in
              (constr, decode))
 
+    let encode { user; repo; kind } =
+      let forge = to_string kind in
+      let path = repo ^ "/" ^ user in
+      let open Dune_lang.Encoder in
+      pair string string (forge, path)
+
     let to_string { user; repo; kind } =
       sprintf "git+https://%s/%s/%s.git" (host_of_kind kind) user repo
   end
@@ -373,6 +379,12 @@ module Source_kind = struct
   let to_string = function
     | Host h -> Host.to_string h
     | Url u -> u
+
+  let encode =
+    let open Dune_lang.Encoder in
+    function
+    | Url url -> pair string string ("uri", url)
+    | Host host -> Host.encode host
 
   let decode =
     let open Dune_lang.Decoder in

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -547,6 +547,41 @@ let name t = t.id.name
 
 let dir t = t.id.dir
 
+let encode
+    { id = _
+    ; loc = _
+    ; has_opam_file = _
+    ; synopsis
+    ; description
+    ; depends
+    ; conflicts
+    ; depopts
+    ; info
+    ; version
+    ; tags
+    ; deprecated_package_names
+    ; sites
+    } =
+  let open Dune_lang.Encoder in
+  let fields =
+    record_fields
+      [ field_o "synopsis" string synopsis
+      ; field_o "description" string description
+      ; field_l "depends" Dependency.encode depends
+      ; field_l "conflicts" Dependency.encode conflicts
+      ; field_l "depopts" Dependency.encode depopts
+      ; field_o "version" string version
+      ; field_l "tags" string tags
+      ; field_l "deprecated_package_names" Name.encode
+          (Name.Map.keys deprecated_package_names)
+      ; field_l "sits"
+          (pair Section.Site.encode Section.encode)
+          (Section.Site.Map.to_list sites)
+      ]
+    @ Info.encode info
+  in
+  constr "package" (list sexp) fields
+
 let decode ~dir =
   let open Dune_lang.Decoder in
   let name_map syntax of_list_map to_string name decode print_value error_msg =

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -452,6 +452,26 @@ module Info = struct
       ; ("authors", option (list string) authors)
       ]
 
+  let encode
+      { source
+      ; authors
+      ; license
+      ; homepage
+      ; documentation
+      ; bug_reports
+      ; maintainers
+      } =
+    let open Dune_lang.Encoder in
+    record_fields
+      [ field_o "source" Source_kind.encode source
+      ; field_o "authors" (list string) authors
+      ; field_o "license" string license
+      ; field_o "homepage" string homepage
+      ; field_o "documentation" string documentation
+      ; field_o "bug_reports" string bug_reports
+      ; field_o "maintainers" (list string) maintainers
+      ]
+
   let decode ?since () =
     let open Dune_lang.Decoder in
     let v default = Option.value since ~default in

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -125,6 +125,11 @@ module Dependency = struct
       | Gt -> `Gt
       | Lt -> `Lt
       | Neq -> `Neq
+
+    let encode x =
+      let f (_, op) = equal x op in
+      (* Assumes the [map] is complete, so exception is impossible *)
+      List.find_exn ~f map |> fst |> Dune_lang.Encoder.string
   end
 
   module Constraint = struct

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -94,6 +94,17 @@ module Dependency = struct
       | Lt
       | Neq
 
+    let equal a b =
+      match (a, b) with
+      | Eq, Eq
+      | Gte, Gte
+      | Lte, Lte
+      | Gt, Gt
+      | Lt, Lt
+      | Neq, Neq ->
+        true
+      | _ -> false
+
     let map =
       [ ("=", Eq); (">=", Gte); ("<=", Lte); (">", Gt); ("<", Lt); ("<>", Neq) ]
 

--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -154,6 +154,8 @@ val dir : t -> Path.Source.t
 
 val file : dir:Path.t -> name:Name.t -> Path.t
 
+val encode : t Dune_lang.Encoder.t
+
 val decode : dir:Path.Source.t -> t Dune_lang.Decoder.t
 
 val opam_file : t -> Path.Source.t

--- a/src/dune_lang/encoder.mli
+++ b/src/dune_lang/encoder.mli
@@ -17,7 +17,9 @@ val field_o : string -> 'a t -> 'a option -> field
 
 val field_b : string -> bool -> field
 
-(** Field with inlined list as value *)
+(** Field with inlined list as value
+
+    The field is left absent if the list is empty. *)
 val field_l : string -> 'a t -> 'a list -> field
 
 (** Same as [field_l] but to represent a single value *)


### PR DESCRIPTION
Adds an `encode` function for package data, as a prerequisite of adding an `encode` function for `Dune_project.t`,

- Towards #4702 
- Prerequisite of #4367

I'm starting with a small chunk of the encoding, so I can get feedback in case I'm going about this wrong.

I could particularly use advise on where/whether I should test this: It will ultimately get tested via black box tests, but seems the `encode` function itself could use some testing. But I haven't found clear precedent for testing `encode` functions in the current tests.