### PR TITLE
[2.9] Use `opam var` instead of `opam config var`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased - 2.9 branch
+-----------------------
+
+- Eliminate deprecation warning from opam 2.1 by using `opam var` instead of `opam config var` (#4828 @dra27)
+
 2.9.0 (29/06/2021)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The recommended way to install dune is via the [opam package manager][opam]:
 $ opam install dune
 ```
 
-If you are new to opam, make sure to run `eval $(opam config env)` to
+If you are new to opam, make sure to run `eval $(opam env)` to
 make `dune` available in your `PATH`. The dune binary is self
 contained and relocatable, so you can safely copy it somewhere else to
 make it permanently available.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -503,7 +503,7 @@ context:
 
 #. if an explicit ``--prefix <path>`` argument is passed, use this path
 #. if ``opam`` is present in the ``PATH`` and is configured, use the
-   output of ``opam config var prefix``
+   output of ``opam var prefix``
 #. otherwise, take the parent of the directory where ``ocamlc`` was found.
 
 As an exception to this rule, library files might be copied to a

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -152,8 +152,7 @@ let read_opam_config_var ~env (var : string) : string option Fiber.t =
   match Memo.Lazy.force opam with
   | None -> Fiber.return None
   | Some fn -> (
-    Process.run_capture (Accept Predicate_lang.any) fn ~env
-      [ "config"; "var"; var ]
+    Process.run_capture (Accept Predicate_lang.any) fn ~env [ "var"; var ]
     >>| function
     | Ok s -> Some (String.trim s)
     | Error _ -> None)

--- a/test/blackbox-tests/test-cases/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/github1946.t/run.t
@@ -3,7 +3,7 @@ in the same dune file, but require different ppx specifications
 
   $ dune build @all --profile release
   $ dune ocaml-merlin --dump-config=$(pwd) |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Usesppx1
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/github759.t/run.t
+++ b/test/blackbox-tests/test-cases/github759.t/run.t
@@ -1,6 +1,6 @@
   $ dune build foo.cma --profile release
   $ dune ocaml-merlin --dump-config=$(pwd) |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Foo
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)
@@ -13,7 +13,7 @@
   $ rm -f .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml-merlin --dump-config=$(pwd) |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Foo
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)
@@ -26,7 +26,7 @@
   $ echo toto > .merlin
   $ dune build foo.cma --profile release
   $ dune ocaml-merlin --dump-config=$(pwd) |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Foo
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/install-dry-run.t/run.t
+++ b/test/blackbox-tests/test-cases/install-dry-run.t/run.t
@@ -1,5 +1,5 @@
   $ dune build @install
-  $ dune install --dry-run 2>&1 | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#' | dune_cmd sanitize
+  $ dune install --dry-run 2>&1 | sed 's#'$(opam var prefix)'#OPAM_PREFIX#' | dune_cmd sanitize
   Installing OPAM_PREFIX/lib/mylib/META
   Installing OPAM_PREFIX/lib/mylib/dune-package
   Installing OPAM_PREFIX/lib/mylib/mylib$ext_lib
@@ -45,7 +45,7 @@
   Creating directory OPAM_PREFIX/lib/mylib
   Copying _build/install/default/lib/mylib/mylib.cmxs to OPAM_PREFIX/lib/mylib/mylib.cmxs (executable: true)
 
-  $ dune uninstall --dry-run 2>&1 | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#' | dune_cmd sanitize
+  $ dune uninstall --dry-run 2>&1 | sed 's#'$(opam var prefix)'#OPAM_PREFIX#' | dune_cmd sanitize
   Removing (if it exists) OPAM_PREFIX/lib/mylib/META
   Removing (if it exists) OPAM_PREFIX/lib/mylib/dune-package
   Removing (if it exists) OPAM_PREFIX/lib/mylib/mylib$ext_lib

--- a/test/blackbox-tests/test-cases/install-libdir.t/run.t
+++ b/test/blackbox-tests/test-cases/install-libdir.t/run.t
@@ -1,4 +1,4 @@
-  $ opam_prefix="$(opam config var prefix)"
+  $ opam_prefix="$(opam var prefix)"
   $ export BUILD_PATH_PREFIX_MAP="/OPAM_PREFIX=$opam_prefix:$BUILD_PATH_PREFIX_MAP"
 
 `dune install` should handle destination directories that don't exist

--- a/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
@@ -1,5 +1,5 @@
   $ export BUILD_PATH_PREFIX_MAP=\
-  > "OPAM_PREFIX=$(opam config var prefix):$BUILD_PATH_PREFIX_MAP"
+  > "OPAM_PREFIX=$(opam var prefix):$BUILD_PATH_PREFIX_MAP"
 
 If Merlin field is absent, default context is chosen
 

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -18,7 +18,7 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   lib-foo
 
   $ dune ocaml-merlin --dump-config="$(pwd)" |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Foo
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -4,7 +4,7 @@ We build the project
 
 Verify that merlin configuration was generated...
   $ dune ocaml-merlin --dump-config=$(pwd) |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Test
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)
@@ -47,12 +47,12 @@ Now we check that both querying from the root and the subfolder works
   $ FILE=$(pwd)/foo.ml
   $ FILE411=$(pwd)/411/test.ml
 
-  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
 
-  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin  <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE411}:$FILE411)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.foo.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.test.eobjs/byte)(?:S?:$TESTCASE_ROOT)(?:S?:$TESTCASE_ROOT/411)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -1,7 +1,7 @@
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
   $ dune ocaml-merlin --dump-config=$(pwd)/exe |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   X
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)
@@ -26,7 +26,7 @@ CRAM sanitization
 
   $ dune build ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
   $ dune ocaml-merlin --dump-config=$(pwd)/lib |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   File
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)
@@ -111,7 +111,7 @@ Make sure pp flag is correct and variables are expanded
 
   $ dune build ./pp-with-expand/.merlin-conf/exe-foobar --profile release
   $ dune ocaml-merlin --dump-config=$(pwd)/pp-with-expand |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Foobar
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)
@@ -128,7 +128,7 @@ Make sure pp flag is correct and variables are expanded
 Check hash of executables names if more than one
   $ dune build ./exes/.merlin-conf/exe-x-6562915302827c6dce0630390bfa68b7
   $ dune ocaml-merlin --dump-config=$(pwd)/exes |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Y
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -4,7 +4,7 @@ We dump the config for Foo and Bar modules but the pp.exe preprocessor
 should appear only once since only Foo is using it.
 
   $ dune ocaml-merlin --dump-config=$(pwd) |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Foo
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/server.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/server.t/run.t
@@ -6,13 +6,13 @@
 
   $ dune build @check
 
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.main.eobjs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Dune__exe?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
 
   $ FILE=$PWD/lib3.ml
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
@@ -22,7 +22,7 @@ we consider it as ``module_name.ml/i`
 This can be useful when some build scripts perform custom
 preprocessing and copy files around.
   $ FILE=lib3.foobar.ml
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
@@ -30,27 +30,27 @@ preprocessing and copy files around.
 If a directory has no configuration the configuration of its parent is used
 This can be useful when some build scripts copy files from subdirectories.
   $ FILE=some_sub_dir/lib3.foobar.ml
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
 
 Test of an valid invalid module name
   $ FILE=not-a-module-name.ml
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.not-a-module-name.eobjs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs?:-w?:-24)))
 
 Dune should also provide configuration when the file is in the build folder
   $ FILE=$PWD/_build/default/lib3.ml
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))
 
   $ FILE=_build/default/lib3.ml
-  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  $ dune ocaml-merlin <<EOF | sed -E "s/[[:digit:]]+:/\?:/g" | sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   > (4:File${#FILE}:$FILE)
   > EOF
   ((?:STDLIB?:OPAM_PREFIX/lib/ocaml)(?:EXCLUDE_QUERY_DIR)(?:B?:$TESTCASE_ROOT/_build/default/.mylib.objs/byte)(?:B?:$TESTCASE_ROOT/_build/default/.mylib3.objs/byte)(?:S?:$TESTCASE_ROOT)(?:FLG(?:-open?:Mylib?:-w?:@1..3@5..28@30..39@43@46..47@49..57@61..62-?:-strict-sequence?:-strict-formats?:-short-paths?:-keep-locs)))

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t/run.t
@@ -16,7 +16,7 @@ library also has more than one src dir.
 
   $ dune build lib2/.merlin-conf/lib-lib2
   $ dune ocaml-merlin --dump-config=$(pwd)/lib2 |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#'
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#'
   Lib2
   ((STDLIB OPAM_PREFIX/lib/ocaml)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -26,7 +26,7 @@ Dune ocaml-merlin also accepts paths relative to the current directory
 
   $ cd realsrc
   $ dune ocaml-merlin --dump-config="." --root=".." |
-  > sed 's#'$(opam config var prefix)'#OPAM_PREFIX#' |
+  > sed 's#'$(opam var prefix)'#OPAM_PREFIX#' |
   > head -n 2
   Entering directory '..'
   Foo


### PR DESCRIPTION
opam 2.1 has deprecated `opam config var` in favour of opam 2.0's `opam var`. Note that `opam var` was not available in OPAM 1.2.2, so `opam config var prefix` was 1.2.2/2.0 compatible, which we no longer care about.

The expectation with opam 2.1 is that programs and scripts which invoke opam should use CLI versioning to lock in these changes, so where `opam config var prefix` produces a deprecation warning `OPAMCLI=2.0 opam config var prefix` does not. However, Dune's usage is so simple that this feels overkill for this one - I've simply changed the command.