### PR TITLE
Switch to ad-hoc lazy DAG nodes

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -328,13 +328,6 @@ module Value = struct
     | Cancelled { dependency_cycle } -> raise (Cycle_error.E dependency_cycle)
 end
 
-module Dag : Dag.S with type value := Dep_node_without_state.packed =
-  Dag.Make
-    (struct
-      type t = Dep_node_without_state.packed
-    end)
-    ()
-
 module Cache_lookup = struct
   (* Looking up a value cached in a previous run can fail in three possible
      ways:
@@ -364,6 +357,34 @@ module Cache_lookup = struct
   end
 end
 
+module Dag : Dag.S with type value := Dep_node_without_state.packed =
+  Dag.Make
+    (struct
+      type t = Dep_node_without_state.packed
+    end)
+    ()
+
+(* This is similar to [type t = Dag.node Lazy.t] but avoids creating a closure
+   with a [dep_node]; the latter is available when we need to [force] a [t]. *)
+module Lazy_dag_node = struct
+  type t = Dag.node option ref
+
+  let create () = ref None
+
+  let force t ~dep_node =
+    match !t with
+    | Some dag_node -> dag_node
+    | None ->
+      let (dag_node : Dag.node) =
+        if !Counters.enabled then incr Counters.nodes_in_cycle_detection_graph;
+        { info = Dag.create_node_info ()
+        ; data = Dep_node_without_state.T dep_node
+        }
+      in
+      t := Some dag_node;
+      dag_node
+end
+
 (* A "computation" is represented by an [ivar], filled when the computation is
    finished, and a [dag_node], used for cycle detection before getting blocked
    on reading the [ivar]. When a run completes, all computations are garbage
@@ -371,8 +392,11 @@ end
 module Computation0 = struct
   type 'a t =
     { ivar : 'a Fiber.Ivar.t
-    ; dag_node : Dag.node Lazy.t
+    ; dag_node : Lazy_dag_node.t
     }
+
+  let create () =
+    { ivar = Fiber.Ivar.create (); dag_node = Lazy_dag_node.create () }
 end
 
 (* Checking dependencies of a node can lead to one of these outcomes:
@@ -521,8 +545,8 @@ module M = struct
       can invalidate a node by setting its state to [Out_of_date]. *)
   and State : sig
     type 'a t =
-      | Out_of_date of { old_value : 'a Cached_value.t option }
       | Cached_value of 'a Cached_value.t
+      | Out_of_date of { old_value : 'a Cached_value.t option }
       | Restoring of
           { restore_from_cache :
               'a Cached_value.t Cache_lookup.Result.t Computation0.t
@@ -575,14 +599,14 @@ module Stack_frame_with_state : sig
 
   (* Create a new stack frame related to restoring or computing a [dep_node]. *)
   val create :
-       dag_node:Dag.node Lazy.t
+       dag_node:Lazy_dag_node.t
     -> phase
     -> dep_node:_ Dep_node_without_state.t
     -> t
 
   val dep_node : t -> Dep_node_without_state.packed
 
-  val dag_node : t -> Dag.node Lazy.t
+  val dag_node : t -> Dag.node
 
   (* This function accumulates dependencies of frames in the [Compute] phase.
      Calling it in the [Restore_from_cache] frame raises an exception. *)
@@ -600,7 +624,7 @@ end = struct
 
   type ('i, 'o) unpacked =
     { dep_node : ('i, 'o) Dep_node_without_state.t
-    ; dag_node : Dag.node Lazy.t
+    ; dag_node : Lazy_dag_node.t
     ; (* This [children_added_to_dag] table serves dual purpose:
 
          (1) guarantee that we never add the same edge twice to the cycle
@@ -641,7 +665,7 @@ end = struct
 
   let dep_node (T t) = Dep_node_without_state.T t.dep_node
 
-  let dag_node (T t) = t.dag_node
+  let dag_node (T t) = Lazy_dag_node.force t.dag_node ~dep_node:t.dep_node
 
   let add_dep (T t) ~dep_node =
     match t.phase with
@@ -700,9 +724,7 @@ module Call_stack = struct
              traversal. We might as well stop here and save time. *)
           Ok ()
         | false -> (
-          let caller_dag_node =
-            Lazy.force (Stack_frame_with_state.dag_node frame)
-          in
+          let caller_dag_node = Stack_frame_with_state.dag_node frame in
           match Dag.add_assuming_missing caller_dag_node dag_node with
           | exception Dag.Cycle cycle ->
             Error (List.map cycle ~f:(fun dag_node -> dag_node.Dag.data))
@@ -720,7 +742,7 @@ module Call_stack = struct
               Ok ())))
     in
     if !Counters.enabled then incr Counters.paths_in_cycle_detection_graph;
-    add_path_impl stack (Lazy.force dag_node)
+    add_path_impl stack dag_node
 
   (* Add a dependency on the [dep_node] from the caller, if there is one. *)
   let add_dep_from_caller =
@@ -801,18 +823,6 @@ end
 module Computation = struct
   include Computation0
 
-  let create ~dep_node =
-    let ivar = Fiber.Ivar.create () in
-    let dag_node =
-      lazy
-        (if !Counters.enabled then incr Counters.nodes_in_cycle_detection_graph;
-         ({ info = Dag.create_node_info ()
-          ; data = Dep_node_without_state.T dep_node
-          }
-           : Dag.node))
-    in
-    { ivar; dag_node }
-
   (* Each computation should be forced exactly once. Not forcing it will lead to
      a deadlock. Forcing it twice will lead to [Fiber.Ivar.fill] raising. *)
   let force { ivar; dag_node } ~phase ~dep_node fiber =
@@ -825,10 +835,11 @@ module Computation = struct
     let+ () = Fiber.Ivar.fill ivar result in
     result
 
-  let read_but_first_check_for_cycles { ivar; dag_node } =
+  let read_but_first_check_for_cycles { ivar; dag_node } ~dep_node =
     Fiber.Ivar.peek ivar >>= function
     | Some res -> Fiber.return (Ok res)
     | None -> (
+      let dag_node = Lazy_dag_node.force dag_node ~dep_node in
       Call_stack.add_path_to ~dag_node >>= function
       | Ok () -> Fiber.Ivar.read ivar >>| Result.ok
       | Error _ as cycle_error -> Fiber.return cycle_error)
@@ -1204,7 +1215,7 @@ end = struct
         -> cached_value:'o Cached_value.t
         -> 'o Cached_value.t Cache_lookup.Result.t Fiber.t =
    fun ~dep_node ~cached_value ->
-    let computation = Computation.create ~dep_node:dep_node.without_state in
+    let computation = Computation.create () in
     dep_node.state <- Restoring { restore_from_cache = computation };
     Computation.force computation ~phase:Restore_from_cache
       ~dep_node:dep_node.without_state (fun _stack_frame ->
@@ -1225,7 +1236,7 @@ end = struct
         -> old_value:'o Cached_value.t option
         -> 'o Cached_value.t Fiber.t =
    fun ~dep_node ~old_value ->
-    let computation = Computation.create ~dep_node:dep_node.without_state in
+    let computation = Computation.create () in
     dep_node.state <- Computing { old_value; compute = computation };
     Computation.force computation ~phase:Compute
       ~dep_node:dep_node.without_state (fun stack_frame ->
@@ -1243,19 +1254,23 @@ end = struct
         ('i, 'o) Dep_node.t -> 'o Cached_value.t Cache_lookup.Result.t Fiber.t =
    fun dep_node ->
     match dep_node.state with
-    | Out_of_date { old_value } ->
-      Fiber.return (Cache_lookup.Result.Failure (Out_of_date { old_value }))
     | Cached_value cached_value ->
+      (* CR-someday amokhov: The happy path here is excruciatingly slow: read
+         [dep_node.state], get [cached_value] via an indirection, jump through
+         another hoop [cached_value.last_validated_at] and then, finally, make
+         the [Run.is_current] check. We should try to find a shortcut. *)
       if Run.is_current cached_value.last_validated_at then
         Fiber.return (Cache_lookup.Result.Ok cached_value)
       else
         start_restoring ~dep_node ~cached_value
     | Restoring { restore_from_cache } -> (
       Computation.read_but_first_check_for_cycles restore_from_cache
+        ~dep_node:dep_node.without_state
       >>| function
       | Ok res -> res
       | Error dependency_cycle ->
         Cache_lookup.Result.Failure (Cancelled { dependency_cycle }))
+    | Out_of_date { old_value }
     | Computing { old_value; _ } ->
       Fiber.return (Cache_lookup.Result.Failure (Out_of_date { old_value }))
 
@@ -1273,7 +1288,9 @@ end = struct
     | Out_of_date { old_value } ->
       start_computing ~dep_node ~old_value >>| Result.ok
     | Computing { compute; _ } -> (
-      Computation.read_but_first_check_for_cycles compute >>| function
+      Computation.read_but_first_check_for_cycles compute
+        ~dep_node:dep_node.without_state
+      >>| function
       | Ok _ as result -> result
       | Error dependency_cycle as result ->
         dep_node.state <-

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -371,9 +371,13 @@ module Lazy_dag_node = struct
 
   let create () = ref None
 
-  let force t ~dep_node =
+  let force t ~(dep_node : _ Dep_node_without_state.t) =
     match !t with
-    | Some dag_node -> dag_node
+    | Some (({ data = T dep_node_passed_first; _ } : Dag.node) as dag_node) ->
+      (* CR-someday amokhov: It would be great to restructure the code to rule
+         out the potential inconsistency between [dep_node]s passed to [force]. *)
+      assert (Id.equal dep_node.id dep_node_passed_first.id);
+      dag_node
     | None ->
       let (dag_node : Dag.node) =
         if !Counters.enabled then incr Counters.nodes_in_cycle_detection_graph;


### PR DESCRIPTION
This makes creating `Computation`s a bit cheaper: instead of creating a lazy node with a closure holding a `dep_node`, we provide the `dep_node` when forcing our ad-hoc `Lazy_dag_node`.

Microbenchmarks show slightly better allocations across all scenarios (and also slightly better performance).

I also made a couple of tweaks to `State`-handling. These tweaks didn't have an effect on the microbenchmarks.

```
┌────────────────────────────────────┬──────────────┬─────────────┬───────────┬───────────┬────────────┐
│ Before                             │     Time/Run │     mWd/Run │  mjWd/Run │  Prom/Run │ Percentage │
├────────────────────────────────────┼──────────────┼─────────────┼───────────┼───────────┼────────────┤
│ 1-bind (create and compute)        │     497.86ns │     608.00w │           │           │      0.28% │
│ 1-bind (incr and recompute)        │     495.72ns │     581.00w │           │           │      0.28% │
│ 1-bind (restore from cache)        │     404.46ns │     473.00w │           │           │      0.23% │
│ 20-reads (create and compute)      │   2_390.19ns │   3_064.00w │     0.72w │     0.72w │      1.37% │
│ 20-reads (incr and recompute)      │   2_219.37ns │   2_804.00w │     0.47w │     0.47w │      1.27% │
│ 20-reads (restore from cache)      │   2_135.71ns │   2_696.00w │     0.42w │     0.42w │      1.22% │
│ clique (create and compute)        │  70_575.63ns │  70_343.00w │   339.93w │   339.93w │     40.35% │
│ clique (incr and recompute)        │  73_546.28ns │  76_200.00w │   185.58w │   185.58w │     42.05% │
│ clique (restore from cache)        │  21_403.97ns │  26_131.00w │    36.83w │    36.83w │     12.24% │
│ bipartite (create and compute)     │ 174_908.34ns │ 156_478.00w │ 2_563.79w │ 2_563.79w │    100.00% │
│ bipartite (incr and recompute)     │ 144_707.68ns │ 138_155.00w │   376.90w │   376.90w │     82.73% │
│ bipartite (restore from cache)     │  39_203.32ns │  51_116.00w │    26.91w │    26.91w │     22.41% │
│ memo diamonds (create and compute) │  10_281.90ns │  11_418.00w │    30.21w │    30.21w │      5.88% │
│ memo diamonds (incr and recompute) │  13_389.47ns │  15_330.00w │    24.23w │    24.23w │      7.66% │
│ memo diamonds (restore from cache) │   4_908.95ns │   5_466.00w │     7.11w │     7.11w │      2.81% │
└────────────────────────────────────┴──────────────┴─────────────┴───────────┴───────────┴────────────┘

┌────────────────────────────────────┬──────────────┬─────────────┬───────────┬───────────┬────────────┐
│ After                              │     Time/Run │     mWd/Run │  mjWd/Run │  Prom/Run │ Percentage │
├────────────────────────────────────┼──────────────┼─────────────┼───────────┼───────────┼────────────┤
│ 1-bind (create and compute)        │     488.57ns │     604.00w │           │           │      0.28% │
│ 1-bind (incr and recompute)        │     493.41ns │     577.00w │           │           │      0.28% │
│ 1-bind (restore from cache)        │     400.38ns │     469.00w │           │           │      0.23% │
│ 20-reads (create and compute)      │   2_402.22ns │   3_060.00w │     0.71w │     0.71w │      1.38% │
│ 20-reads (incr and recompute)      │   2_247.52ns │   2_800.00w │     0.46w │     0.46w │      1.29% │
│ 20-reads (restore from cache)      │   2_147.09ns │   2_692.00w │     0.41w │     0.41w │      1.23% │
│ clique (create and compute)        │  69_291.53ns │  70_215.00w │   335.79w │   335.79w │     39.77% │
│ clique (incr and recompute)        │  72_715.91ns │  75_948.00w │   185.55w │   185.55w │     41.74% │
│ clique (restore from cache)        │  21_243.65ns │  26_003.00w │    35.42w │    35.42w │     12.19% │
│ bipartite (create and compute)     │ 174_216.85ns │ 156_114.00w │ 2_553.79w │ 2_553.79w │    100.00% │
│ bipartite (incr and recompute)     │ 144_794.55ns │ 137_663.00w │   373.82w │   373.82w │     83.11% │
│ bipartite (restore from cache)     │  38_913.23ns │  50_752.00w │    26.24w │    26.24w │     22.34% │
│ memo diamonds (create and compute) │  10_252.94ns │  11_334.00w │    29.48w │    29.48w │      5.89% │
│ memo diamonds (incr and recompute) │  13_255.30ns │  15_166.00w │    23.61w │    23.61w │      7.61% │
│ memo diamonds (restore from cache) │   4_631.31ns │   5_382.00w │     6.78w │     6.78w │      2.66% │
└────────────────────────────────────┴──────────────┴─────────────┴───────────┴───────────┴────────────┘
```