### PR TITLE
Dune file watcher: use exclude patterns

### DIFF
--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -6,5 +6,6 @@
   stdune
   threads.posix
   ocaml_inotify
-  async_inotify_for_dune)
+  async_inotify_for_dune
+  dune_re)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -56,12 +56,30 @@ module Event = struct
     | Watcher_terminated
 end
 
+let exclude_patterns =
+  [ {|/_opam|}
+  ; {|/_esy|}
+  ; {|/\..+|}
+  ; {|~$|}
+  ; {|/#[^#]*#$|}
+  ; {|4913|} (* https://github.com/neovim/neovim/issues/3460 *)
+  ]
+
+module Re = Dune_re
+
+let exclude_regex =
+  Re.compile
+    (Re.alt (List.map exclude_patterns ~f:(fun pattern -> Re.Posix.re pattern)))
+
+let should_exclude path = Re.execp exclude_regex path
+
 (* [process_inotify_event] needs to run in the scheduler thread because it
    accesses [t.ignored_files]. *)
 let process_inotify_event ~ignored_files
     (event : Async_inotify_for_dune.Async_inotify.Event.t) : Event.t list =
   let should_ignore =
-    List.exists (inotify_event_paths event) ~f:(fun path ->
+    let all_paths = inotify_event_paths event in
+    List.exists all_paths ~f:(fun path ->
         let path = Path.of_string path in
         let abs_path = Path.to_absolute_filename path in
         if Table.mem ignored_files abs_path then (
@@ -70,6 +88,10 @@ let process_inotify_event ~ignored_files
           true
         ) else
           false)
+    || List.for_all all_paths ~f:(fun path ->
+           let path = Path.of_string path in
+           let abs_path = Path.to_absolute_filename path in
+           should_exclude abs_path)
   in
   if should_ignore then
     []
@@ -179,15 +201,6 @@ let special_file_for_inotify_sync =
   fun () -> Lazy.force path
 
 let command ~root ~backend =
-  let exclude_patterns =
-    [ {|/_opam|}
-    ; {|/_esy|}
-    ; {|/\..+|}
-    ; {|~$|}
-    ; {|/#[^#]*#$|}
-    ; {|4913|} (* https://github.com/neovim/neovim/issues/3460 *)
-    ]
-  in
   let exclude_paths =
     (* These paths should already exist on the filesystem when the watches are
        initially set up, otherwise the @<path> has no effect for inotifywait. If

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -90,7 +90,7 @@ let process_inotify_event ~ignored_files
           false)
     || List.for_all all_paths ~f:(fun path ->
            let path = Path.of_string path in
-           let abs_path = Path.to_absolute_filename path in
+           let abs_path = Path.to_string path in
            should_exclude abs_path)
   in
   if should_ignore then

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -240,7 +240,6 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog
                  (Package.Name.to_string pkg |> String_with_vars.make_text loc))
       in
       let mdx_generic_deps = Bindings.to_list stanza.deps in
-
       let executable, command_line =
         (*The old mdx stanza calls the [ocaml-mdx] executable, new ones the
           generated executable *)
@@ -255,7 +254,6 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog
           , [ A "test" ] @ prelude_args
             @ [ A "-o"; Target files.corrected; Dep (Path.build files.src) ] )
       in
-
       Action_builder.(
         with_no_targets
           (Dep_conf_eval.unnamed ~expander
@@ -277,7 +275,6 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
   let loc = t.loc in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let file = Path.Build.relative dir "mdx_gen.ml-gen" in
-
   (* Libs from the libraries field should have their include directories sent to
      mdx *)
   let open Resolve.O in
@@ -290,11 +287,8 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
           Some lib
         | _ -> Resolve.return None)
     in
-
     let mode = Context.best_mode (Super_context.context sctx) in
-
     let libs_include_paths = Lib.L.include_paths libs_to_include mode in
-
     let open Command.Args in
     let args =
       Path.Set.to_list libs_include_paths
@@ -302,11 +296,9 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
     in
     S args
   in
-
   let prelude_args =
     Command.Args.S (List.concat_map t.preludes ~f:(Prelude.to_args ~dir))
   in
-
   (* We call mdx to generate the testing executable source *)
   let action =
     Command.run ~dir:(Path.build dir) mdx_prog ~stdout_to:file
@@ -314,7 +306,6 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
   in
   let open Memo.Build.O in
   let* () = Super_context.add_rule sctx ~loc ~dir action in
-
   (* We build the generated executable linking in the libs from the libraries
      field *)
   let obj_dir = Obj_dir.make_exe ~dir ~name in


### PR DESCRIPTION
Since the proper solution to not-retriggering-on-hgignored-file-changes
continues to elude us, we can start with a hacky one:
bring back the event filtering that we used in the
external backends.

This PR does that.

Testing
-------
Manual testing: ran dune in watching mode while editing files, saw
that dune only retriggers when you save the files, not when you
start editing them.


Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>