### PR TITLE
[ocamlformat] update to 0.19.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.18.0
+version=0.19.0
 profile=conventional
 break-separators=before
 dock-collection-brackets=false

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ mdx \
 menhir \
 "merlin>=3.4.0" \
 ocamlfind \
-ocamlformat.0.18.0 \
+ocamlformat.0.19.0 \
 "odoc>=1.5.0" \
 "ppx_expect>=v0.14" \
 ppx_inline_test \

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -31,6 +31,6 @@ let%bench_fun "single" =
 
 let l = List.init 100 ~f:ignore
 
-let%bench_fun ("many"[@indexed jobs = [ 1; 2; 4; 8 ]]) =
+let%bench_fun ("many" [@indexed jobs = [ 1; 2; 4; 8 ]]) =
   Lazy.force setup;
   fun () -> go ~jobs (fun () -> Fiber.parallel_iter l ~f:run)

--- a/bench/micro/main.ml
+++ b/bench/micro/main.ml
@@ -1,2 +1,1 @@
-;;
 Inline_benchmarks_public.Runner.main ~libname:"dune_bench"

--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -51,7 +51,8 @@ let modes =
 (* We don't want to list deprecated subcommands in help. *)
 let non_deprecated_modes = [ ("trim", Trim) ]
 
-(* We do want to print a nice error message if a deprecated subcommand is run. *)
+(* We do want to print a nice error message if a deprecated subcommand is
+   run. *)
 let deprecated_error () =
   User_error.raise
     [ Pp.text

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -304,14 +304,13 @@ module Component = struct
 
       let common (options : Options.Common.t) =
         name options.name
-        ::
-        (optional_field ~f:libraries options.libraries
-        @ optional_field ~f:pps options.pps)
+        :: (optional_field ~f:libraries options.libraries
+           @ optional_field ~f:pps options.pps)
     end
 
     let make kind common_options fields =
       (* Form the AST *)
-      List (atom kind :: fields @ Field.common common_options)
+      List ((atom kind :: fields) @ Field.common common_options)
       (* Convert to a CST *)
       |> Dune_lang.Ast.add_loc ~loc:Loc.none
       |> Cst.concrete (* Package as a list CSTs *) |> List.singleton

--- a/otherlibs/configurator/src/import.ml
+++ b/otherlibs/configurator/src/import.ml
@@ -309,7 +309,8 @@ module Io = struct
   let read_all =
     (* We use 65536 because that is the size of OCaml's IO buffers. *)
     let chunk_size = 65536 in
-    (* Generic function for channels such that seeking is unsupported or broken *)
+    (* Generic function for channels such that seeking is unsupported or
+       broken *)
     let read_all_generic t buffer =
       let rec loop () =
         Buffer.add_channel buffer t chunk_size;
@@ -329,7 +330,8 @@ module Io = struct
         let s = really_input_string t n in
         (* For some files [in_channel_length] returns an invalid value. For
            instance for files in /proc it returns [0]. So we try to read one
-           more character to make sure we did indeed reach the end of the file *)
+           more character to make sure we did indeed reach the end of the
+           file *)
         match input_char t with
         | exception End_of_file -> s
         | c ->

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -418,7 +418,7 @@ let compile_and_link_c_prog t ?(c_flags = []) ?(link_flags = []) code =
   let ok =
     if need_to_compile_and_link_separately t then
       run_ok (c_flags @ [ "-I"; t.stdlib_dir; "-c"; c_fname ])
-      && run_ok ("-o" :: exe_fname :: obj_fname :: t.c_libraries @ link_flags)
+      && run_ok (("-o" :: exe_fname :: obj_fname :: t.c_libraries) @ link_flags)
     else
       run_ok
         (List.concat
@@ -446,10 +446,8 @@ let compile_c_prog t ?(c_flags = []) code =
     Process.run_command_ok t ~dir
       (Process.command_args t.c_compiler
          (c_flags
-         @ "-I"
-           ::
-           t.stdlib_dir :: "-o" :: obj_fname :: "-c" :: c_fname :: t.c_libraries
-         ))
+         @ "-I" :: t.stdlib_dir :: "-o" :: obj_fname :: "-c" :: c_fname
+           :: t.c_libraries))
   in
   if ok then
     Ok obj_fname

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -143,8 +143,9 @@ module Process : sig
       logged.
 
       @param dir change to [dir] before running the command.
-      @param env specify additional environment variables as a list of the form
-      NAME=VALUE. *)
+      @param env
+        specify additional environment variables as a list of the form
+        NAME=VALUE. *)
   val run :
     t -> ?dir:string -> ?env:string list -> string -> string list -> result
 

--- a/otherlibs/stdune-unstable/console.ml
+++ b/otherlibs/stdune-unstable/console.ml
@@ -20,7 +20,8 @@ module Backend = struct
     let set_status_line _ = ()
 
     let print_if_no_status_line msg =
-      (* [Pp.cut] seems to be enough to force the terminating newline to appear. *)
+      (* [Pp.cut] seems to be enough to force the terminating newline to
+         appear. *)
       Ansi_color.prerr
         (Pp.seq (Pp.map_tags msg ~f:User_message.Print_config.default) Pp.cut)
 

--- a/otherlibs/stdune-unstable/dyn.ml
+++ b/otherlibs/stdune-unstable/dyn.ml
@@ -56,9 +56,8 @@ let string_in_ocaml_syntax str =
         (Pp.concat ~sep:Pp.newline
            (List.map ~f:Pp.verbatim
               (("\"" ^ String.escaped first ^ "\\n\\")
-               ::
-               List.map middle ~f:(fun s ->
-                   escape_protect_first_space s ^ "\\n\\")
+               :: List.map middle ~f:(fun s ->
+                      escape_protect_first_space s ^ "\\n\\")
               @ [ escape_protect_first_space last ^ "\"" ]))))
 
 let pp_sequence start stop x ~f =

--- a/otherlibs/stdune-unstable/io.ml
+++ b/otherlibs/stdune-unstable/io.ml
@@ -147,7 +147,8 @@ struct
   let read_all =
     (* We use 65536 because that is the size of OCaml's IO buffers. *)
     let chunk_size = 65536 in
-    (* Generic function for channels such that seeking is unsupported or broken *)
+    (* Generic function for channels such that seeking is unsupported or
+       broken *)
     let read_all_generic t buffer =
       let rec loop () =
         Buffer.add_channel buffer t chunk_size;

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ in pkgs.mkShell {
   buildInputs = (with pkgs; [
     coreutils
     # we prefer tools from outside our opam build plan to minimize conflicts
-    ocamlformat_0_18_0
+    ocamlformat_0_19_0
     ocamlPackages.ocaml-lsp
     git
     mercurial # for tests

--- a/src/chrome_trace/chrome_trace.ml
+++ b/src/chrome_trace/chrome_trace.ml
@@ -178,14 +178,14 @@ module Event = struct
         args_field [ ("labels", `String labels) ] :: common pid "process_labels"
       | Thread_name { tid; pid; name } ->
         ("tid", `Int tid)
-        :: args_field [ ("name", `String name) ] :: common pid "process_name"
+        :: args_field [ ("name", `String name) ]
+        :: common pid "process_name"
       | Process_sort_index { pid; sort_index } ->
         args_field [ ("sort_index", `Int sort_index) ]
         :: common pid "process_sort_index"
       | Thread_sort_index { pid; sort_index; tid } ->
         ("tid", `Int tid)
-        ::
-        args_field [ ("sort_index", `Int sort_index) ]
+        :: args_field [ ("sort_index", `Int sort_index) ]
         :: common pid "thread_sort_index"
     in
     phase "M" :: fields

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -121,7 +121,8 @@ module Artifacts = struct
           with
           | exception Unix.Unix_error (Unix.EEXIST, _, _) -> (
             (* We end up here if the cache already contains an entry for this
-               artifact. We deduplicate by keeping only one copy, in the cache. *)
+               artifact. We deduplicate by keeping only one copy, in the
+               cache. *)
             let path_in_build_dir = Path.build target in
             match
               Path.unlink_no_err path_in_temp_dir;

--- a/src/dune_cache/trimmer.ml
+++ b/src/dune_cache/trimmer.ml
@@ -50,7 +50,8 @@ let trim_broken_metadata_entries ~trimmed_so_far =
             | Ok stats ->
               let bytes = stats.st_size in
               (* If another process deletes [path] and the [unlink_no_err] below
-                 is a no-op, we take the credit and increase [trimmed_so_far]. *)
+                 is a no-op, we take the credit and increase
+                 [trimmed_so_far]. *)
               Path.unlink_no_err path;
               Trimming_result.add trimmed_so_far ~bytes
             | Error _ ->

--- a/src/dune_cache_storage/util.ml
+++ b/src/dune_cache_storage/util.ml
@@ -44,7 +44,8 @@ let add_atomically ~mode ~src ~dst : Write_result.t =
       | () -> Ok
       | exception e -> Error e))
 
-(* CR-someday amokhov: Switch to [renameat2] to go from two operations to one. *)
+(* CR-someday amokhov: Switch to [renameat2] to go from two operations to
+   one. *)
 let write_atomically ~mode ~content dst : Write_result.t =
   Temp.with_temp_file ~dir:Layout.temp_dir ~prefix:"dune" ~suffix:"write"
     ~f:(function

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -117,10 +117,9 @@ module Cache = struct
 
     let all =
       ("auto", None)
-      ::
-      List.map
-        ~f:(fun (name, mode) -> (name, Some mode))
-        Dune_cache_storage.Mode.all
+      :: List.map
+           ~f:(fun (name, mode) -> (name, Some mode))
+           Dune_cache_storage.Mode.all
 
     let decode = enum all
 

--- a/src/dune_engine/action_ast.ml
+++ b/src/dune_engine/action_ast.ml
@@ -286,7 +286,7 @@ struct
     | Pipe (outputs, l) ->
       List
         (atom (sprintf "pipe-%s" (Outputs.to_string outputs))
-         :: List.map l ~f:encode)
+        :: List.map l ~f:encode)
     | Format_dune_file (ver, src, dst) ->
       List
         [ atom "format-dune-file"

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -399,8 +399,8 @@ let rec exec t ~ectx ~eenv =
     let+ () =
       Fdecl.get
         cram_run
-        (* We don't pass cwd because Cram_exec will use the script's dir to run *)
-        ~env:eenv.env ~script
+        (* We don't pass cwd because Cram_exec will use the script's dir to
+           run *) ~env:eenv.env ~script
     in
     Done
 

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -35,7 +35,8 @@ module type Ast = sig
     | Chdir of path * t
     | Setenv of string * string * t
     (* It's not possible to use a build path here since jbuild supports
-       redirecting to /dev/null. In [dune] files this is replaced with %{null} *)
+       redirecting to /dev/null. In [dune] files this is replaced with
+       %{null} *)
     | Redirect_out of Outputs.t * target * File_perm.t * t
     | Redirect_in of Inputs.t * path * t
     | Ignore of Outputs.t * t

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -141,7 +141,7 @@ and pp = function
     Pp.hovbox ~indent:2
       (Pp.concat
          (quote prog
-          :: List.concat_map args ~f:(fun arg -> [ Pp.space; quote arg ])))
+         :: List.concat_map args ~f:(fun arg -> [ Pp.space; quote arg ])))
   | Chdir dir ->
     Pp.hovbox ~indent:2 (Pp.concat [ Pp.verbatim "cd"; Pp.space; quote dir ])
   | Setenv (k, v) -> Pp.concat [ Pp.verbatim k; Pp.verbatim "="; quote v ]

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -26,7 +26,8 @@ end = struct
 
        Note: if we find a way to reliably invalidate this function, its output
        should continue to have no cutoff because the callers might depend not
-       just on the existence of a directory but on its *continuous* existence. *)
+       just on the existence of a directory but on its *continuous*
+       existence. *)
     Memo.create "mkdir_p"
       ~input:(module Path.Build)
       (fun p ->
@@ -532,7 +533,8 @@ let compute_target_digests_or_raise_error exec_params ~loc targets =
        cache will remove write permission because of hardlink sharing anyway, so
        always removing them enables to catch mistakes earlier. *)
     (* FIXME: searching the dune version for each single target seems way
-       suboptimal. This information could probably be stored in rules directly. *)
+       suboptimal. This information could probably be stored in rules
+       directly. *)
     if Path.Build.Set.is_empty targets then
       false
     else
@@ -567,26 +569,26 @@ let compute_target_digests_or_raise_error exec_params ~loc targets =
               let expected_syscall_path = Path.to_string path in
               Pp.concat ~sep:(Pp.verbatim ": ")
                 (pp_path path
-                 ::
-                 (match exn with
-                 | Unix.Unix_error (error, syscall, p) ->
-                   [ (if String.equal expected_syscall_path p then
-                       Pp.verbatim syscall
-                     else
-                       Pp.concat
-                         [ Pp.verbatim syscall
-                         ; Pp.verbatim " "
-                         ; Pp.verbatim (String.maybe_quoted p)
-                         ])
-                   ; Pp.text (Unix.error_message error)
-                   ]
-                 | Sys_error msg ->
-                   [ Pp.verbatim
-                       (String.drop_prefix_if_exists
-                          ~prefix:(expected_syscall_path ^ ": ")
-                          msg)
-                   ]
-                 | exn -> [ Pp.verbatim (Printexc.to_string exn) ])))
+                ::
+                (match exn with
+                | Unix.Unix_error (error, syscall, p) ->
+                  [ (if String.equal expected_syscall_path p then
+                      Pp.verbatim syscall
+                    else
+                      Pp.concat
+                        [ Pp.verbatim syscall
+                        ; Pp.verbatim " "
+                        ; Pp.verbatim (String.maybe_quoted p)
+                        ])
+                  ; Pp.text (Unix.error_message error)
+                  ]
+                | Sys_error msg ->
+                  [ Pp.verbatim
+                      (String.drop_prefix_if_exists
+                         ~prefix:(expected_syscall_path ^ ": ")
+                         msg)
+                  ]
+                | exn -> [ Pp.verbatim (Printexc.to_string exn) ])))
         ])
 
 let sandbox_dir = Path.Build.relative Path.Build.root ".sandbox"
@@ -1089,7 +1091,8 @@ end = struct
       | Unrestricted ->
         (* In this case the parent isn't going to be able to create any
            generated granddescendant directories. (rules that attempt to do so
-           may run into the [allowed_by_parent] check or will be simply ignored) *)
+           may run into the [allowed_by_parent] check or will be simply
+           ignored) *)
         Memo.Build.return Dir_set.empty
       | Restricted restriction -> Memo.Lazy.force restriction
     in
@@ -1250,7 +1253,8 @@ end = struct
   let build_dep : Dep.t -> Dep.Fact.t Memo.Build.t = function
     | Alias a ->
       let+ digests = build_alias a in
-      (* Fact: alias [a] expand to the set of files with their digest [digests] *)
+      (* Fact: alias [a] expand to the set of files with their digest
+         [digests] *)
       Dep.Fact.alias a digests
     | File f ->
       let+ digest = build_file f in
@@ -1264,7 +1268,8 @@ end = struct
     | Universe
     | Env _
     | Sandbox_config _ ->
-      (* Facts about these dependencies are constructed in [Dep.Facts.digest]. *)
+      (* Facts about these dependencies are constructed in
+         [Dep.Facts.digest]. *)
       Memo.Build.return Dep.Fact.nothing
 
   let build_deps deps =

--- a/src/dune_engine/format_config.ml
+++ b/src/dune_engine/format_config.ml
@@ -174,6 +174,6 @@ let of_config ~ext ~dune_lang ~version =
     User_error.raise ~loc:ext.loc
       (Pp.textf
          "Starting with (lang dune 2.0), formatting is enabled by default."
-       :: suggestion)
+      :: suggestion)
 
 let equal { enabled_for; _ } t = Enabled_for.equal enabled_for t.enabled_for

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -174,8 +174,7 @@ module Dependency = struct
       | Bvar x -> Var.encode x
       | Uop (op, x) -> pair Op.encode Var.encode (op, x)
       | Bop (op, x, y) -> triple Op.encode Var.encode Var.encode (op, x, y)
-      | And conjuncts ->
-        list sexp (string "and" :: List.map ~f:encode conjuncts)
+      | And conjuncts -> list sexp (string "and" :: List.map ~f:encode conjuncts)
       | Or disjuncts -> list sexp (string "or" :: List.map ~f:encode disjuncts)
 
     let decode =

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -271,10 +271,9 @@ module Fancy = struct
     | [] -> []
     | "-o" :: fn :: rest ->
       Pp.verbatim "-o"
-      ::
-      Pp.tag
-        (User_message.Style.Ansi_styles Ansi_color.Style.[ bold; fg_green ])
-        (Pp.verbatim (String.quote_for_shell fn))
+      :: Pp.tag
+           (User_message.Style.Ansi_styles Ansi_color.Style.[ bold; fg_green ])
+           (Pp.verbatim (String.quote_for_shell fn))
       :: colorize_args rest
     | x :: rest -> Pp.verbatim (String.quote_for_shell x) :: colorize_args rest
 
@@ -667,7 +666,8 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
       in
       let event_common, started_at, pid =
         (* Output.fd might create the file with Unix.openfile. We need to make
-           sure to call it before doing the chdir as the path might be relative. *)
+           sure to call it before doing the chdir as the path might be
+           relative. *)
         let stdout = Io.fd stdout_to in
         let stderr = Io.fd stderr_to in
         let stdin = Io.fd stdin_from in

--- a/src/dune_engine/response_file.ml
+++ b/src/dune_engine/response_file.ml
@@ -6,7 +6,8 @@ type t =
 
 (* This mutable table is safe under the assumption that a program path always
    points to the binary with the same version. While the assumption seems likely
-   to hold, it would be better to avoid the need for it to simplify reasoning. *)
+   to hold, it would be better to avoid the need for it to simplify
+   reasoning. *)
 let registry = Table.create (module Path) 128
 
 let get ~prog = Option.value (Table.find registry prog) ~default:Not_supported

--- a/src/dune_engine/reversible_digest.ml
+++ b/src/dune_engine/reversible_digest.ml
@@ -6,7 +6,8 @@ let digest_string string =
   let digest = Digest.Direct_impl.string string in
   (match
      (* CR-someday amokhov: Below we do not respect the [cache_storage_mode]
-        configuration setting. This will break if hard links are not supported. *)
+        configuration setting. This will break if hard links are not
+        supported. *)
      Dune_cache_storage.Raw_value.store_unchecked ~content:string
        ~content_digest:digest ~mode:Hardlink
    with

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -681,7 +681,8 @@ type status =
       Memo.Invalidation.t * unit Fiber.Ivar.t
   | (* Running a build *)
       Building
-  | (* Cancellation requested. Build jobs are immediately rejected in this state *)
+  | (* Cancellation requested. Build jobs are immediately rejected in this
+       state *)
       Restarting_build of
       Memo.Invalidation.t
   | (* Shut down requested. No new new builds will start *)
@@ -992,7 +993,8 @@ end = struct
           t.status <-
             Restarting_build
               (Memo.Invalidation.combine prev_invalidation invalidation);
-          (* We're already cancelling build, so file change events don't matter *)
+          (* We're already cancelling build, so file change events don't
+             matter *)
           iter t
         | Standing_by prev_invalidation ->
           t.status <-

--- a/src/dune_engine/utils.ml
+++ b/src/dune_engine/utils.ml
@@ -31,10 +31,11 @@ let bash_exn =
 let not_found fmt ?loc ?context ?hint x =
   User_error.make ?loc
     (Pp.textf fmt (String.maybe_quoted x)
-     ::
-     (match context with
-     | None -> []
-     | Some name -> [ Pp.textf " (context: %s)" (Context_name.to_string name) ]))
+    ::
+    (match context with
+    | None -> []
+    | Some name -> [ Pp.textf " (context: %s)" (Context_name.to_string name) ])
+    )
     ~hints:
       (match hint with
       | None -> []

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -34,7 +34,8 @@ type t =
            event does not invalidate the current build. However, instead of
            ignoring the events, we should merely postpone them and restart the
            build to take the promoted files into account if need be. *)
-        (* The [ignored_files] table should be accessed in the scheduler thread. *)
+        (* The [ignored_files] table should be accessed in the scheduler
+           thread. *)
   ; ignored_files : (string, unit) Table.t
   }
 
@@ -500,7 +501,8 @@ let add_watch t path =
   match t.kind with
   | Coarse _ ->
     (* Here we assume that the path is already being watched because the coarse
-       file watchers are expected to watch all the source files from the start *)
+       file watchers are expected to watch all the source files from the
+       start *)
     ()
   | Fine { inotify } -> Inotify_lib.add inotify (Path.to_string path)
 

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -215,7 +215,7 @@ module Error = struct
              Pp.space)
          ; Pp.text extra_info
          ]
-       :: repl)
+      :: repl)
 
   let inactive loc t ~dune_lang_ver ~what =
     let greatest_supported_version =
@@ -273,7 +273,7 @@ module Warning = struct
              Pp.space)
          ; Pp.text extra_info
          ]
-       :: repl)
+      :: repl)
 end
 
 let create ?(experimental = false) ~name ~desc supported_versions =

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -30,7 +30,8 @@ module Action_expander : sig
      - files that are detected as both targets and dependencies are removed from
      the dependency set
 
-     In addition to this, it embeds an expander for easily expanding templates. *)
+     In addition to this, it embeds an expander for easily expanding
+     templates. *)
 
   include Applicative
 
@@ -65,7 +66,8 @@ module Action_expander : sig
        such as in [(chdir <path> ...)] *)
     val path : String_with_vars.t -> Path.t t
 
-    (* Evaluate a path that "consumes" a target, such as in [(diff? ... <file>)] *)
+    (* Evaluate a path that "consumes" a target, such as in [(diff? ...
+       <file>)] *)
     val consume_file : String_with_vars.t -> Path.Build.t t
 
     val prog_and_args : String_with_vars.t -> (Action.Prog.t * string list) t

--- a/src/dune_rules/blang.ml
+++ b/src/dune_rules/blang.ml
@@ -86,7 +86,8 @@ let decode_gen decode_string =
     fix (fun t ->
         sum ~force_parens:true
           (("or", repeat t >>| fun x -> Or x)
-           :: ("and", repeat t >>| fun x -> And x) :: ops)
+          :: ("and", repeat t >>| fun x -> And x)
+          :: ops)
         <|> let+ v = decode_string in
             Expr v)
   in

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -131,10 +131,9 @@ let gen_rules sctx t ~dir ~scope =
     A.chdir (Path.build dir)
       (A.progn
          (A.run (Ok cinaps_exe) [ "-diff-cmd"; "-" ]
-          ::
-          List.map cinapsed_files ~f:(fun fn ->
-              A.diff ~optional:true (Path.build fn)
-                (Path.Build.extend_basename fn ~suffix:".cinaps-corrected"))))
+         :: List.map cinapsed_files ~f:(fun fn ->
+                A.diff ~optional:true (Path.build fn)
+                  (Path.Build.extend_basename fn ~suffix:".cinaps-corrected"))))
   in
   let cinaps_alias = alias ~dir in
   let* () =

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -128,7 +128,8 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
     (* With sandboxing, there are a few build errors in ocaml platform 1162238ae
        like: File "ocaml_modules/ocamlgraph/src/pack.ml", line 1: Error: The
        implementation ocaml_modules/ocamlgraph/src/pack.ml does not match the
-       interface ocaml_modules/ocamlgraph/src/.graph.objs/byte/graph__Pack.cmi: *)
+       interface
+       ocaml_modules/ocamlgraph/src/.graph.objs/byte/graph__Pack.cmi: *)
     Sandbox_config.no_sandboxing
   in
   let modes =

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1124,8 +1124,8 @@ module Executables = struct
                            to be a valid module name or add a \"name\" field \
                            with a valid module name."
                       ]
-                      ~hints:
-                        (Module_name.valid_format_doc :: user_message.hints)))
+                      ~hints:(Module_name.valid_format_doc :: user_message.hints)
+                  ))
           else
             User_error.raise ~loc
               [ Pp.textf "%s field may not be omitted before dune version %s"

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -392,7 +392,7 @@ let encode ~dune_version { entries; name; version; dir; sections; sites; files }
         | Deprecated_library_name d ->
           list
             (Dune_lang.atom "deprecated_library_name"
-             :: Deprecated_library_name.encode d)
+            :: Deprecated_library_name.encode d)
         | Hidden_library lib ->
           Code_error.raise "Dune_package.encode got Hidden_library"
             [ ("lib", Lib.to_dyn lib) ])

--- a/src/dune_rules/enabled_if.ml
+++ b/src/dune_rules/enabled_if.ml
@@ -8,7 +8,8 @@ type allowed_vars =
 
 (* The following variables are the ones allowed in the enabled_if fields of
    libraries, executables and install stanzas. While allowed variables for
-   theses stanzas are the same, the version at which they were allowed differs. *)
+   theses stanzas are the same, the version at which they were allowed
+   differs. *)
 let common_vars_list =
   [ "architecture"
   ; "system"

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -186,7 +186,8 @@ let findlib_predicates_set_by_dune =
   Ps.of_list [ P.ppx_driver; P.mt; P.mt_posix ]
 
 module Loader : sig
-  (* Search for a <package>/{META,dune-package} file in the findlib search path *)
+  (* Search for a <package>/{META,dune-package} file in the findlib search
+     path *)
   val lookup_and_load :
     db -> Package.Name.t -> (Dune_package.t, Unavailable_reason.t) result
 
@@ -399,7 +400,8 @@ end = struct
                     | false -> Ok None
                     | true -> (
                       if
-                        (* We add this hack to skip manually mangled libraries *)
+                        (* We add this hack to skip manually mangled
+                           libraries *)
                         Re.execp (Lazy.force mangled_module_re) fname
                       then
                         Ok None

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -147,7 +147,8 @@ let archives ?(kind = [ Mode.Byte; Mode.Native ]) name =
       else
         None)
 
-(* fake entry we use to pass down the list of toplevel modules for root_module *)
+(* fake entry we use to pass down the list of toplevel modules for
+   root_module *)
 let main_modules names =
   List.map ~f:String.capitalize_ascii names
   |> String.concat ~sep:" " |> rule "main_modules" [] Set
@@ -177,11 +178,7 @@ let builtins ~stdlib_dir ~version:ocaml_version =
     let main_modules = main_modules in
     { name = Some name
     ; entries =
-        requires deps
-        ::
-        version
-        ::
-        main_modules
+        requires deps :: version :: main_modules
         ::
         (match dir with
         | None -> []

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -9,7 +9,8 @@ module Source_tree_map_reduce =
     end))
 
 (* Compute command line flags for the [include_dirs] field of [Foreign.Stubs.t]
-   and track all files in specified directories as [Hidden_deps] dependencies. *)
+   and track all files in specified directories as [Hidden_deps]
+   dependencies. *)
 let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
   let scope = Expander.scope expander in
   let lib_dir loc lib_name =
@@ -37,7 +38,8 @@ let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
                match Path.extract_build_context_dir include_dir with
                | None ->
                  (* This branch corresponds to an external directory. The
-                    current implementation tracks its contents NON-recursively. *)
+                    current implementation tracks its contents
+                    NON-recursively. *)
                  (* TODO: Track the contents recursively. One way to implement
                     this is to change [Build_system.Loaded.Non_build] so that it
                     contains not only files but also directories and traverse

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -117,7 +117,7 @@ include Sub_system.Register_end_point (struct
       let* more_libs =
         Resolve.List.map info.libraries ~f:(Lib.DB.resolve (Scope.libs scope))
       in
-      Lib.closure ~linking:true (lib :: libs @ more_libs)
+      Lib.closure ~linking:true ((lib :: libs) @ more_libs)
     in
     (* Generate the runner file *)
     let* () =
@@ -240,8 +240,7 @@ include Sub_system.Register_end_point (struct
                       runner)
                and* flags = flags in
                let action =
-                 Action.run prog
-                   (Path.reach exe ~from:(Path.build dir) :: flags)
+                 Action.run prog (Path.reach exe ~from:(Path.build dir) :: flags)
                in
                (* jeremiedimino: it feels like this pattern should be pushed
                   into [resolve_program] directly *)
@@ -252,12 +251,11 @@ include Sub_system.Register_end_point (struct
            let run_tests = Action.chdir (Path.build dir) action in
            Action.progn
              (run_tests
-              ::
-              List.map source_files ~f:(fun fn ->
-                  Action.diff ~optional:true fn
-                    (Path.Build.extend_basename
-                       (Path.as_in_build_dir_exn fn)
-                       ~suffix:".corrected")))))
+             :: List.map source_files ~f:(fun fn ->
+                    Action.diff ~optional:true fn
+                      (Path.Build.extend_basename
+                         (Path.as_in_build_dir_exn fn)
+                         ~suffix:".corrected")))))
 end)
 
 let linkme = ()

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -281,8 +281,9 @@ end = struct
             let meta_file = Package_paths.meta_file ctx pkg in
             let dune_package_file = Package_paths.dune_package_file ctx pkg in
             (None, Install.Entry.make Lib meta_file ~dst:Findlib.meta_fn)
-            ::
-            (None, Install.Entry.make Lib dune_package_file ~dst:Dune_package.fn)
+            :: ( None
+               , Install.Entry.make Lib dune_package_file ~dst:Dune_package.fn
+               )
             ::
             (if not pkg.has_opam_file then
               deprecated_meta_and_dune_files
@@ -603,7 +604,8 @@ end = struct
       let meta_template = Path.build (Package_paths.meta_template ctx pkg) in
       let meta_template_lines_or_fail =
         (* XXX this should really be lazy as it's only necessary for the then
-           clause. There's no way to express this in the action builder however. *)
+           clause. There's no way to express this in the action builder
+           however. *)
         let vlib =
           List.find_map entries ~f:(function
             | Super_context.Lib_entry.Library lib ->

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -145,10 +145,10 @@ module Error = struct
          ; pp_lib info
          ; Pp.char '.'
          ]
-       ::
-       (match dp with
-       | [] -> []
-       | _ -> [ Dep_path.pp dp ]))
+      ::
+      (match dp with
+      | [] -> []
+      | _ -> [ Dep_path.pp dp ]))
 
   let overlap ~in_workspace ~installed =
     make
@@ -533,8 +533,7 @@ module Link_params = struct
           Path.extend_basename obj_name ~suffix:(Cm_kind.ext Cmo) :: hidden_deps
         | Native ->
           Path.extend_basename obj_name ~suffix:(Cm_kind.ext Cmx)
-          ::
-          Path.extend_basename obj_name ~suffix:t.lib_config.ext_obj
+          :: Path.extend_basename obj_name ~suffix:t.lib_config.ext_obj
           :: hidden_deps)
     in
     { deps; hidden_deps; include_dirs }
@@ -633,10 +632,10 @@ module L = struct
       in
       Command.Args.S
         (to_iflags dirs
-         ::
-         List.map params ~f:(fun (p : Link_params.t) ->
-             Command.Args.S
-               [ Deps p.deps; Hidden_deps (Dep.Set.of_files p.hidden_deps) ])))
+        :: List.map params ~f:(fun (p : Link_params.t) ->
+               Command.Args.S
+                 [ Deps p.deps; Hidden_deps (Dep.Set.of_files p.hidden_deps) ])
+        ))
 
   let jsoo_runtime_files ts =
     List.concat_map ts ~f:(fun t -> Lib_info.jsoo_runtime t.info)
@@ -675,29 +674,27 @@ module Lib_and_module = struct
                  let+ p = Action_builder.memo_build (Link_params.get t mode) in
                  Command.Args.S
                    (Deps p.deps
-                    ::
-                    Hidden_deps (Dep.Set.of_files p.hidden_deps)
-                    ::
-                    List.map p.include_dirs ~f:(fun dir ->
-                        Command.Args.S [ A "-I"; Path dir ]))
+                   :: Hidden_deps (Dep.Set.of_files p.hidden_deps)
+                   :: List.map p.include_dirs ~f:(fun dir ->
+                          Command.Args.S [ A "-I"; Path dir ]))
                | Module (obj_dir, m) ->
                  Action_builder.return
                    (Command.Args.S
                       (Dep
                          (Obj_dir.Module.cm_file_exn obj_dir m
                             ~kind:(Mode.cm_kind (Link_mode.mode mode)))
-                       ::
-                       (match mode with
-                       | Native ->
-                         [ Command.Args.Hidden_deps
-                             (Dep.Set.of_files
-                                [ Obj_dir.Module.o_file_exn obj_dir m
-                                    ~ext_obj:lib_config.ext_obj
-                                ])
-                         ]
-                       | Byte
-                       | Byte_with_stubs_statically_linked_in ->
-                         [])))))
+                      ::
+                      (match mode with
+                      | Native ->
+                        [ Command.Args.Hidden_deps
+                            (Dep.Set.of_files
+                               [ Obj_dir.Module.o_file_exn obj_dir m
+                                   ~ext_obj:lib_config.ext_obj
+                               ])
+                        ]
+                      | Byte
+                      | Byte_with_stubs_statically_linked_in ->
+                        [])))))
          in
          Command.Args.S l)
 
@@ -1971,7 +1968,8 @@ module DB = struct
     }
 
   (* Here we omit the [only_ppx_deps_allowed] check because by the time we reach
-     this point, all preprocess dependencies should have been checked already. *)
+     this point, all preprocess dependencies should have been checked
+     already. *)
   let resolve_pps t pps =
     Resolve_names.resolve_simple_deps t ~private_deps:Allow_all pps
       ~stack:Dep_stack.empty

--- a/src/dune_rules/lib_kind.ml
+++ b/src/dune_rules/lib_kind.ml
@@ -82,8 +82,7 @@ let encode t =
     match t with
     | Normal -> Dune_lang.atom "normal"
     | Ppx_deriver x -> List (Dune_lang.atom "ppx_deriver" :: Ppx_args.encode x)
-    | Ppx_rewriter x ->
-      List (Dune_lang.atom "ppx_rewriter" :: Ppx_args.encode x)
+    | Ppx_rewriter x -> List (Dune_lang.atom "ppx_rewriter" :: Ppx_args.encode x)
   with
   | List [ x ] -> x
   | x -> x

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -366,7 +366,8 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
       (Preprocess.Per_module.instrumentation_deps lib.buildable.preprocess
          ~instrumentation_backend)
   in
-  (* Preprocess before adding the alias module as it doesn't need preprocessing *)
+  (* Preprocess before adding the alias module as it doesn't need
+     preprocessing *)
   let* pp =
     Preprocessing.make sctx ~dir ~scope ~preprocess ~expander
       ~preprocessor_deps:lib.buildable.preprocessor_deps ~instrumentation_deps
@@ -391,7 +392,8 @@ let cctx (lib : Library.t) ~sctx ~source_modules ~dir ~expander ~scope
 
 let library_rules (lib : Library.t) ~cctx ~source_modules ~dir_contents
     ~compile_info =
-  (* Preprocess before adding the alias module as it doesn't need preprocessing *)
+  (* Preprocess before adding the alias module as it doesn't need
+     preprocessing *)
   let source_modules =
     Modules.fold_user_written source_modules ~init:[] ~f:(fun m acc -> m :: acc)
   in

--- a/src/dune_rules/merlin_server.ml
+++ b/src/dune_rules/merlin_server.ml
@@ -54,7 +54,8 @@ let to_local file_path =
   (* This ensure the path is absolute. If not it is prefixed with
      [Path.initial_cwd] *)
   let abs_file_path = Path.of_filename_relative_to_initial_cwd file_path in
-  (* Then we make the path relative to [Path.root] (and not [Path.initial_cwd]) *)
+  (* Then we make the path relative to [Path.root] (and not
+     [Path.initial_cwd]) *)
   match make_relative_to_root abs_file_path with
   | Some path -> (
     try

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -231,7 +231,8 @@ let make_lib_modules (d : _ Dir_with_dune.t) ~lookup_vlib ~(lib : Library.t)
       let resolved =
         let name = Library.best_name lib in
         Lib.DB.find_even_when_hidden (Scope.libs d.scope) name
-        (* can't happen because this library is defined using the current stanza *)
+        (* can't happen because this library is defined using the current
+           stanza *)
         |> Option.value_exn
       in
       (* This [Option.value_exn] is correct because the above [lib.implements]

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -281,19 +281,18 @@ let setup_html sctx (odoc_file : odoc) ~pkg ~requires =
                    [ Action.Remove_tree to_remove
                    ; Action.Mkdir (Path.build odoc_file.html_dir)
                    ]))
-           ::
-           Command.run
-             ~dir:(Path.build (Paths.html_root ctx))
-             odoc
-             [ A "html"
-             ; odoc_base_flags
-             ; odoc_include_flags ctx pkg requires
-             ; A "-o"
-             ; Path (Path.build (Paths.html_root ctx))
-             ; Dep (Path.build odoc_file.odoc_input)
-             ; Hidden_targets [ odoc_file.html_file ]
-             ]
-           :: dummy))
+          :: Command.run
+               ~dir:(Path.build (Paths.html_root ctx))
+               odoc
+               [ A "html"
+               ; odoc_base_flags
+               ; odoc_include_flags ctx pkg requires
+               ; A "-o"
+               ; Path (Path.build (Paths.html_root ctx))
+               ; Dep (Path.build odoc_file.odoc_input)
+               ; Hidden_targets [ odoc_file.html_file ]
+               ]
+          :: dummy))
 
 let setup_library_odoc_rules cctx (library : Library.t) ~dep_graphs =
   let lib =
@@ -590,9 +589,8 @@ let setup_package_aliases sctx (pkg : Package.t) =
   Rules.Produce.Alias.add_deps alias
     (Action_builder.deps
        (Dep.html_alias ctx (Pkg name)
-        ::
-        (libs_of_pkg sctx ~pkg:name
-        |> List.map ~f:(fun lib -> Dep.html_alias ctx (Lib lib)))
+        :: (libs_of_pkg sctx ~pkg:name
+           |> List.map ~f:(fun lib -> Dep.html_alias ctx (Lib lib)))
        |> Dune_engine.Dep.Set.of_list_map ~f:(fun f -> Dune_engine.Dep.alias f)
        ))
 

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -300,7 +300,8 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
       ~f:(fun pps ->
         Driver.select pps ~loc:(Dot_ppx (target, pp_names))
         >>| Resolve.map ~f:(fun driver -> (driver, pps)))
-    >>| (* Extend the dependency stack as we don't have locations at this point *)
+    >>| (* Extend the dependency stack as we don't have locations at this
+           point *)
     Resolve.push_stack_frame ~human_readable_description:(fun () ->
         Dyn.pp
           (List [ String "pps"; Dyn.Encoder.(list Lib_name.to_dyn) pp_names ]))

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -169,7 +169,7 @@ module Stanza = struct
       Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
         [ (source.loc, source.name) ]
         (Lib_dep.Direct (source.loc, compiler_libs)
-         :: List.map toplevel.libraries ~f:(fun d -> Lib_dep.Direct d))
+        :: List.map toplevel.libraries ~f:(fun d -> Lib_dep.Direct d))
         ~pps ~dune_version ~allow_overlaps:false
     in
     let requires_compile = Lib.Compile.direct_requires compile_info in

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -306,10 +306,9 @@ module Context = struct
   let all_names t =
     let n = name t in
     n
-    ::
-    List.filter_map (targets t) ~f:(function
-      | Native -> None
-      | Named s -> Some (Context_name.target n ~toolchain:s))
+    :: List.filter_map (targets t) ~f:(function
+         | Native -> None
+         | Named s -> Some (Context_name.target n ~toolchain:s))
 
   let default ~x ~profile ~instrument_with =
     Default
@@ -331,12 +330,11 @@ module Context = struct
     let name = name t in
     let native = Build_context.create ~name ~host:(host_context t) in
     native
-    ::
-    List.filter_map (targets t) ~f:(function
-      | Native -> None
-      | Named toolchain ->
-        let name = Context_name.target name ~toolchain in
-        Some (Build_context.create ~name ~host:(Some native.name)))
+    :: List.filter_map (targets t) ~f:(function
+         | Native -> None
+         | Named toolchain ->
+           let name = Context_name.target name ~toolchain in
+           Some (Build_context.create ~name ~host:(Some native.name)))
 end
 
 type t =

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -560,7 +560,8 @@ module Mvar = struct
     }
 
   (* Invariant enforced on mvars. We don't actually call this function, but we
-     keep it here for documentation and to help understand the implementation: *)
+     keep it here for documentation and to help understand the
+     implementation: *)
   let _invariant t =
     match t.value with
     | None -> Queue.is_empty t.writers

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -375,7 +375,8 @@ module Lazy_dag_node = struct
     match !t with
     | Some (({ data = T dep_node_passed_first; _ } : Dag.node) as dag_node) ->
       (* CR-someday amokhov: It would be great to restructure the code to rule
-         out the potential inconsistency between [dep_node]s passed to [force]. *)
+         out the potential inconsistency between [dep_node]s passed to
+         [force]. *)
       assert (Id.equal dep_node.id dep_node_passed_first.id);
       dag_node
     | None ->
@@ -470,7 +471,8 @@ module M = struct
            wasted since [f 0] does depend on it.
 
            Another important reason to list [deps] according to a linearisation
-           of the dependency order is to eliminate spurious dependency cycles. *)
+           of the dependency order is to eliminate spurious dependency
+           cycles. *)
         mutable deps : Deps.t
       }
   end =
@@ -650,7 +652,8 @@ end = struct
          we are accumulating dependencies only during the [Compute] phase. We
          can drop it if we find a way to statically guarantee this property. *)
       phase : phase
-    ; (* [deps_rev] are accumulated only when [phase = Compute], see [add_dep]. *)
+    ; (* [deps_rev] are accumulated only when [phase = Compute], see
+         [add_dep]. *)
       mutable deps_rev : Dep_node.packed list
     }
 
@@ -1116,7 +1119,8 @@ end = struct
     match cached_value.value with
     | Cancelled _dependency_cycle ->
       (* Dependencies of cancelled computations are not accurate (in fact, they
-         are set to [Deps.empty]), so we can't use [deps_changed] in this case. *)
+         are set to [Deps.empty]), so we can't use [deps_changed] in this
+         case. *)
       Fiber.return
         (Cache_lookup.Result.Failure (Out_of_date { old_value = None }))
     | Error { reproducible = false; _ } ->
@@ -1156,7 +1160,8 @@ end = struct
               match dep.has_cutoff with
               | false ->
                 (* If [dep] has no cutoff, it is sufficient to check whether it
-                   is up to date. If not, we must recompute the [cached_value]. *)
+                   is up to date. If not, we must recompute the
+                   [cached_value]. *)
                 Fiber.return Changed_or_not.Changed
               | true -> (
                 (* If [dep] has a cutoff predicate, it is not sufficient to
@@ -1279,7 +1284,8 @@ end = struct
       Fiber.return (Cache_lookup.Result.Failure (Out_of_date { old_value }))
 
   (* This function assumes that restoring the value from cache failed, which
-     means we can only be in two possible states: [Out_of_date] or [Computing]. *)
+     means we can only be in two possible states: [Out_of_date] or
+     [Computing]. *)
   and consider_and_compute_without_adding_dep :
         'i 'o.
         ('i, 'o) Dep_node.t -> ('o Cached_value.t, Cycle_error.t) result Fiber.t
@@ -1659,7 +1665,8 @@ module Run = struct
 end
 
 (* By placing this definition at the end of the file we prevent Merlin from
-   using [build] instead of [Fiber.t] when showing types throughout this file. *)
+   using [build] instead of [Fiber.t] when showing types throughout this
+   file. *)
 type 'a build = 'a Fiber.t
 
 module type Build = sig

--- a/src/meta_parser/meta_parser.ml
+++ b/src/meta_parser/meta_parser.ml
@@ -83,10 +83,9 @@ struct
           entry :: map_entries entries ~rev_path ~has_version ~has_rules
         | Rule rule ->
           entry
-          ::
-          map_entries entries ~rev_path
-            ~has_version:(has_version || String.equal rule.var "version")
-            ~has_rules:true
+          :: map_entries entries ~rev_path
+               ~has_version:(has_version || String.equal rule.var "version")
+               ~has_rules:true
         | Package t ->
           Package (map_package t ~rev_path)
           :: map_entries entries ~rev_path ~has_version ~has_rules)

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -385,7 +385,8 @@ let upgrade () =
     if !v1_updates && not last then (
       (* Run the upgrader again to update new v1 projects to v2 No more than one
          additional upgrade should be needed *)
-      (* We reset memoization tables as a simple way to refresh the Source_tree *)
+      (* We reset memoization tables as a simple way to refresh the
+         Source_tree *)
       Memo.reset Memo.Invalidation.clear_caches;
       aux true
     ) else if !v2_updates then (

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -42,7 +42,8 @@ let test ?(expect_never = false) to_dyn f =
   | Test_scheduler.Never -> never_raised := true);
   match (!never_raised, expect_never) with
   | false, false ->
-    (* We don't raise in this case b/c we assume something else is being tested *)
+    (* We don't raise in this case b/c we assume something else is being
+       tested *)
     ()
   | true, true -> print_endline "[PASS] Never raised as expected"
   | false, true ->

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1341,7 +1341,8 @@ let%expect_test "Nested nodes with cutoff are recomputed optimally" =
   evaluate_and_print summit 0;
   evaluate_and_print summit 2;
   print_perf_counters ();
-  (* In the second run, we don't recompute [base] three times as we did before. *)
+  (* In the second run, we don't recompute [base] three times as we did
+     before. *)
   [%expect
     {|
     Started evaluating summit
@@ -1365,7 +1366,8 @@ let%expect_test "Nested nodes with cutoff are recomputed optimally" =
   |}]
 
 (* In addition to its direct purpose, this test also: (i) demonstrates what
-   happens in the presence of non-determinism; and (ii) tests cell invalidation. *)
+   happens in the presence of non-determinism; and (ii) tests cell
+   invalidation. *)
 let%expect_test "Test that there are no phantom dependencies" =
   let counter = ref 0 in
   let const_8 =

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -40,7 +40,8 @@ let run (vcs : Vcs.t) args =
   Process.run Strict (Lazy.force prog) real_args
     ~env:
       ((* One of the reasons to set GIT_DIR is to override any GIT_DIR set by
-          the environment, which helps for example during [git rebase --exec]. *)
+          the environment, which helps for example during [git rebase
+          --exec]. *)
        Env.add Env.initial ~var:"GIT_DIR"
          ~value:(Filename.concat (Path.to_absolute_filename vcs.root) ".git"))
     ~dir:vcs.root


### PR DESCRIPTION
Followed https://github.com/ocaml/dune/pull/4801

Steps:
1. Update `.ocamlformat`, `Makefile`, and `shell.nix` to use ocamlformat v0.19.0
2. Run `make fmt`