### PR TITLE
fix error handling in readdir C binding

### DIFF
--- a/otherlibs/stdune-unstable/dune_filesystem_stubs/readdir.c
+++ b/otherlibs/stdune-unstable/dune_filesystem_stubs/readdir.c
@@ -49,10 +49,15 @@ CAMLprim value caml__dune_filesystem_stubs__readdir(value vd)
   d = DIR_Val(vd);
   if (d == (DIR *) NULL) unix_error(EBADF, "readdir", Nothing);
   caml_enter_blocking_section();
+  errno = 0;
   e = readdir((DIR *) d);
   caml_leave_blocking_section();
   if (e == (directory_entry *) NULL) {
-    CAMLreturn(Val_int(0));
+    if(errno == 0) {
+      CAMLreturn(Val_int(0));
+    } else {
+      uerror("readdir", Nothing);
+    }
   }
   v_filename = caml_copy_string(e->d_name);
   v_tuple = caml_alloc_small(2, 0);


### PR DESCRIPTION
Looks like in readdir we're not handling the errors as man page says we should.

Fix that. It should not matter much in theory because the only possible error described in the man page is EBADF, which is a bug in the user code rather than the filesystem condition. However, we've seen some evidence that suggests this function may be returning errors in practice, so let's report those correctly.

By the way, this issue is also present in the OCaml unix library.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>