### PR TITLE
Unambiguous and futur proof commandline?

### DIFF
--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -150,8 +150,7 @@ Test with an opam like installation
       name
       "-j"
       jobs
-      "--promote-install-files"
-      "false"
+      "--promote-install-files=false"
       "@install"
       "@runtest" {with-test}
       "@doc" {with-doc}
@@ -159,7 +158,7 @@ Test with an opam like installation
     ["dune" "install" "-p" name "--create-install-files" name]
   ]
 
-  $ dune build -p a --promote-install-files "false" @install
+  $ dune build -p a --promote-install-files=false @install
 
   $ test -e a/a.install
   [1]

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -49,7 +49,7 @@ let default_build_command =
             {|
 [
   [ "dune" "subst" ] {dev}
-  [ "dune" "build" "-p" name "-j" jobs "--promote-install-files" "false"
+  [ "dune" "build" "-p" name "-j" jobs "--promote-install-files=false"
       "@install"
       "@runtest" {with-test}
       "@doc" {with-doc}

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -31,7 +31,7 @@ Clean up the library tests
 
 Can init library with a specified public name
 
-  $ dune init lib test_lib ./_test_lib_dir --public test_lib_public_name
+  $ dune init lib test_lib ./_test_lib_dir --public=test_lib_public_name
   Success: initialized library component named test_lib
   $ cat ./_test_lib_dir/dune
   (library

--- a/vendor/cmdliner/src/cmdliner.mli
+++ b/vendor/cmdliner/src/cmdliner.mli
@@ -1168,14 +1168,17 @@ The value of an option can be specified in three different ways.
 {ul
 {- As the next token on the command line: ["-o a.out"], ["--output a.out"].}
 {- Glued to a short name: ["-oa.out"].}
+{- Glued to a short name after an equal character: ["-o=a.out"].}
 {- Glued to a long name after an equal character: ["--output=a.out"].}}
 
 Glued forms are especially useful if the value itself starts with a
-dash as is the case for negative numbers, ["--min=-10"].
+dash as is the case for negative numbers, ["--min=-10"]. In the case
+of an optional argument with an optional value (see the [~vopt] argument of
+{!Arg.opt}) only the forms with an equal character are allowed.
 
 An optional argument without a value is either a {e flag} (see
-{!Arg.flag}, {!Arg.vflag}) or an optional argument with an optional
-value (see the [~vopt] argument of {!Arg.opt}).
+{!Arg.flag}, {!Arg.vflag}) or an optional argument with an absent optional
+value.
 
 Short flags can be grouped together to share a single dash and the
 group can end with a short option. For example assuming ["-v"] and
@@ -1193,8 +1196,7 @@ Positional arguments are tokens on the command line that are not
 option names and are not the value of an optional argument. They are
 numbered from left to right starting with zero.
 
-Since positional arguments may be mistaken as the optional value of an
-optional argument or they may need to look like option names, anything
+Since positional arguments may need to look like option names, anything
 that follows the special token ["--"] on the command line is
 considered to be a positional argument.
 


### PR DESCRIPTION
  Currently argument with optional values can't be used for extending the meaning
  of a flag in a backward compatible way. For example if `--foo` is a flag and we
  want to add to it an arguments, the `x` in `dune build --foo x` will be parsed
  before as a positional argument and after as the optional value of `--foo`.

Moreover optional value as noted in #4791 by @aalekseyev are currently very confusing `cmd --opt --flag pos` could be parsed but removing `--flag` breaks it. It is frustrating to fall in those trap when editing a command line (moreover since `--help` has an optional argument).

  So:
   - optional values must always be introduced with an equal character `--foo=v`
   - same for short options (with optional values) `-f=v`, `-fv` is `-f -v` if `-f` has an optional
   value.

  For option with required value nothing change