### PR TITLE
Build_system.run: catch the exceptions raised by f

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2341,8 +2341,7 @@ let run f =
     let build_end_status_reported = ref false in
     let* res =
       Fiber.collect_errors (fun () ->
-        Memo.Build.run_with_error_handler f
-            ~handle_error_no_raise:(fun exn ->
+          Memo.Build.run_with_error_handler f ~handle_error_no_raise:(fun exn ->
               let* () = report_early_exn exn in
               if !build_end_status_reported then
                 Fiber.return ()

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2341,7 +2341,7 @@ let run f =
     let build_end_status_reported = ref false in
     let* res =
       Fiber.collect_errors (fun () ->
-          Memo.Build.run_with_error_handler (Memo.Build.of_thunk f)
+        Memo.Build.run_with_error_handler f
             ~handle_error_no_raise:(fun exn ->
               let* () = report_early_exn exn in
               if !build_end_status_reported then

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2341,7 +2341,7 @@ let run f =
     let build_end_status_reported = ref false in
     let* res =
       Fiber.collect_errors (fun () ->
-          Memo.Build.run_with_error_handler (f ())
+          Memo.Build.run_with_error_handler (Memo.Build.of_thunk f)
             ~handle_error_no_raise:(fun exn ->
               let* () = report_early_exn exn in
               if !build_end_status_reported then

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1447,7 +1447,7 @@ module Build = struct
 
   let run_with_error_handler t ~handle_error_no_raise =
     Error_handler.with_error_handler handle_error_no_raise (fun () ->
-        let* res = report_and_collect_errors (fun () -> t) in
+        let* res = report_and_collect_errors t in
         match res with
         | Ok ok -> Fiber.return ok
         | Error ({ exns; reproducible = _ } : Collect_errors_monoid.t) ->
@@ -1460,7 +1460,7 @@ module Build = struct
        and non-toplevel [run] would be better. *)
     match is_top_level with
     | true ->
-      run_with_error_handler t ~handle_error_no_raise:(fun _exn ->
+      run_with_error_handler (fun () -> t) ~handle_error_no_raise:(fun _exn ->
           Fiber.return ())
     | false -> t
 end

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1460,8 +1460,9 @@ module Build = struct
        and non-toplevel [run] would be better. *)
     match is_top_level with
     | true ->
-      run_with_error_handler (fun () -> t) ~handle_error_no_raise:(fun _exn ->
-          Fiber.return ())
+      run_with_error_handler
+        (fun () -> t)
+        ~handle_error_no_raise:(fun _exn -> Fiber.return ())
     | false -> t
 end
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -42,7 +42,7 @@ module Build : sig
       each error through individual dependency edges instead of sending errors
       directly to the handler in scope. *)
   val run_with_error_handler :
-    (unit -> 'a t)
+       (unit -> 'a t)
     -> handle_error_no_raise:(Exn_with_backtrace.t -> unit Fiber.t)
     -> 'a Fiber.t
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -42,7 +42,7 @@ module Build : sig
       each error through individual dependency edges instead of sending errors
       directly to the handler in scope. *)
   val run_with_error_handler :
-       'a t
+    (unit -> 'a t)
     -> handle_error_no_raise:(Exn_with_backtrace.t -> unit Fiber.t)
     -> 'a Fiber.t
 

--- a/test/expect-tests/memo/run_with_error_handler.ml
+++ b/test/expect-tests/memo/run_with_error_handler.ml
@@ -55,8 +55,8 @@ let%expect_test "Memo.run_with_error_handler" =
   let trace1, trace2 =
     Scheduler.run
       (Fiber.fork_and_join
-         (fun () -> run_memo_and_collect_errors (Memo.Lazy.force n1))
-         (fun () -> run_memo_and_collect_errors (Memo.Lazy.force n2)))
+         (fun () -> run_memo_and_collect_errors (fun () -> Memo.Lazy.force n1))
+         (fun () -> run_memo_and_collect_errors (fun () -> Memo.Lazy.force n2)))
   in
   let print_trace l =
     List.iter (List.rev l) ~f:(fun (what, when_) ->


### PR DESCRIPTION
This shouldn't change any existing behavior as far as I know since I don't know any examples of `f` that raise exceptions, but as a general code cleanup it's much less surprising if the exceptions raised by f are treated the same as the exceptions raised inside the Memo.Build.t

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>