### PR TITLE
dune-project: Add the (subst disabled/enabled) stanza

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -171,6 +171,10 @@ Unreleased
 - Always use 7 char hash prefix in build info version (#4857, @jberdine, fixes
   #4855)
 
+- Allow to explicitly disable/enable the use of `dune subst` by adding a
+  new `(subst <disable|enable>)` stanza to the `dune-project` file.
+  (#4864, @kit-ty-kate)
+
 2.9.1 (unreleased)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -228,6 +228,26 @@ where ``<setting>`` is one of:
 - ``(enabled_for <languages>)`` can be used to restrict the languages that are
   considered for formatting.
 
+.. _subst:
+
+subst
+----------
+
+Starting in dune 3.0, :ref:`dune-subst` can be explicitly disabled or enabled.
+By default it is enabled.
+controlled by using
+
+.. code:: scheme
+
+    (subst <setting>)
+
+where ``<setting>`` is one of:
+
+- ``disabled``, meaning that any call of `dune subst` in this project is
+  forbidden and will result in an error.
+
+- ``enabled``, allowing substitutions explicitly. This is the default.
+
 .. _generate_opam_files:
 
 generate_opam_files

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -28,6 +28,7 @@ module Source_tree = Source_tree
 module Opam_file = Opam_file
 module Action_dune_lang = Action_dune_lang
 module Format_config = Format_config
+module Subst_config = Subst_config
 module Dune_lexer = Dune_lexer
 module Predicate_lang = Predicate_lang
 module Section = Section

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -152,6 +152,7 @@ type t =
   ; dialects : Dialect.DB.t
   ; explicit_js_mode : bool
   ; format_config : Format_config.t option
+  ; subst_config : Subst_config.t option
   ; strict_package_deps : bool
   ; cram : bool
   }
@@ -207,6 +208,7 @@ let to_dyn
     ; dialects
     ; explicit_js_mode
     ; format_config
+    ; subst_config
     ; strict_package_deps
     ; cram
     } =
@@ -232,6 +234,7 @@ let to_dyn
     ; ("dialects", Dialect.DB.to_dyn dialects)
     ; ("explicit_js_mode", bool explicit_js_mode)
     ; ("format_config", option Format_config.to_dyn format_config)
+    ; ("subst_config", option Subst_config.to_dyn subst_config)
     ; ("strict_package_deps", bool strict_package_deps)
     ; ("cram", bool cram)
     ]
@@ -460,6 +463,8 @@ let format_config t =
   let version = dune_version t in
   Format_config.of_config ~ext ~dune_lang ~version
 
+let subst_config t = Subst_config.of_config t.subst_config
+
 let default_name ~dir ~(packages : Package.t Package.Name.Map.t) =
   match Package.Name.Map.min_binding packages with
   | None -> Name.anonymous dir
@@ -515,6 +520,7 @@ let infer ~dir packages =
   ; dialects = Dialect.DB.builtin
   ; explicit_js_mode
   ; format_config = None
+  ; subst_config = None
   ; strict_package_deps
   ; cram
   }
@@ -614,6 +620,7 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
           field_o_b "explicit_js_mode"
             ~check:(Dune_lang.Syntax.since Stanza.syntax (1, 11))
         and+ format_config = Format_config.field ~since:(2, 0)
+        and+ subst_config = Subst_config.field ~since:(3, 0)
         and+ strict_package_deps =
           field_o_b "strict_package_deps"
             ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 3))
@@ -796,6 +803,7 @@ let parse ~dir ~lang ~opam_packages ~file ~dir_status =
         ; dialects
         ; explicit_js_mode
         ; format_config
+        ; subst_config
         ; strict_package_deps
         ; cram
         }))

--- a/src/dune_engine/dune_project.mli
+++ b/src/dune_engine/dune_project.mli
@@ -71,6 +71,8 @@ val explicit_js_mode : t -> bool
 
 val format_config : t -> Format_config.t
 
+val subst_config : t -> Subst_config.t
+
 val equal : t -> t -> bool
 
 val hash : t -> int

--- a/src/dune_engine/subst_config.ml
+++ b/src/dune_engine/subst_config.ml
@@ -1,0 +1,25 @@
+open! Stdune
+open Import
+open Dune_lang.Decoder
+
+(* Can be extended later if needed *)
+type t =
+  | Disabled
+  | Enabled
+
+let to_dyn conf =
+  let open Dyn.Encoder in
+  match conf with
+  | Disabled -> string "disabled"
+  | Enabled -> string "enabled"
+
+let decoder =
+  keyword "disabled" >>> return Disabled
+  <|> (keyword "enabled" >>> return Enabled)
+
+let field ~since =
+  field_o "subst" (Dune_lang.Syntax.since Stanza.syntax since >>> decoder)
+
+let of_config = function
+  | None -> Enabled
+  | Some conf -> conf

--- a/src/dune_engine/subst_config.ml
+++ b/src/dune_engine/subst_config.ml
@@ -13,9 +13,7 @@ let to_dyn conf =
   | Disabled -> string "disabled"
   | Enabled -> string "enabled"
 
-let decoder =
-  keyword "disabled" >>> return Disabled
-  <|> (keyword "enabled" >>> return Enabled)
+let decoder = enum [ ("disabled", Disabled); ("enabled", Enabled) ]
 
 let field ~since =
   field_o "subst" (Dune_lang.Syntax.since Stanza.syntax since >>> decoder)

--- a/src/dune_engine/subst_config.mli
+++ b/src/dune_engine/subst_config.mli
@@ -1,0 +1,13 @@
+open! Stdune
+open Import
+
+type t =
+  | Disabled
+  | Enabled
+
+val to_dyn : t -> Dyn.t
+
+val field :
+  since:Dune_lang.Syntax.Version.t -> t option Dune_lang.Decoder.fields_parser
+
+val of_config : t option -> t

--- a/src/dune_rules/watermarks.ml
+++ b/src/dune_rules/watermarks.ml
@@ -310,6 +310,19 @@ let subst vcs =
           [ Pp.text "dune subst must be executed from the root of the project."
           ]
   in
+  (match Dune_project.subst_config dune_project.project with
+  | Dune_engine.Subst_config.Disabled ->
+    User_error.raise
+      [ Pp.text
+          "dune subst has been disabled in this project. Any use of it is \
+           forbidden."
+      ]
+      ~hints:
+        [ Pp.text
+            "If you wish to re-enable it, change to (subst enabled) in the \
+             dune-project file."
+        ]
+  | Dune_engine.Subst_config.Enabled -> ());
   let info =
     let loc, name =
       match dune_project.name with

--- a/test/blackbox-tests/test-cases/dune-project-meta/main.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/main.t/run.t
@@ -517,3 +517,58 @@ the doc dependencies:
     "something"
     "odoc" {with-doc}
   ]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (name foo)
+  > (generate_opam_files true)
+  > (subst disabled)
+  > (package (name foo) (depends (odoc :with-test) something))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A15 ^build: foo.opam
+  build: [
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "--promote-install-files"
+      "false"
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+    ["dune" "install" "-p" name "--create-install-files" name]
+  ]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (name foo)
+  > (generate_opam_files true)
+  > (subst enabled)
+  > (package (name foo) (depends (odoc :with-test) something))
+  > EOF
+
+  $ dune build foo.opam
+  $ grep -A16 ^build: foo.opam
+  build: [
+    ["dune" "subst"] {dev}
+    [
+      "dune"
+      "build"
+      "-p"
+      name
+      "-j"
+      jobs
+      "--promote-install-files"
+      "false"
+      "@install"
+      "@runtest" {with-test}
+      "@doc" {with-doc}
+    ]
+    ["dune" "install" "-p" name "--create-install-files" name]
+  ]

--- a/test/blackbox-tests/test-cases/subst.t/run.t
+++ b/test/blackbox-tests/test-cases/subst.t/run.t
@@ -106,4 +106,29 @@ Test subst and files with unicode (#3879)
   (version 1.0)
   (package (name foo) (authors "John Doe <john@doe.com>"))
 
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (name foo)
+  > (version 1.0)
+  > (package (name foo) (authors "John Doe <john@doe.com>"))
+  > (subst disabled)
+  > EOF
+
+  $ dune subst
+  Error: dune subst has been disabled in this project. Any use of it is
+  forbidden.
+  Hint: If you wish to re-enable it, change to (subst enabled) in the
+  dune-project file.
+  [1]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (name foo)
+  > (version 1.0)
+  > (package (name foo) (authors "John Doe <john@doe.com>"))
+  > (subst enabled)
+  > EOF
+
+  $ dune subst
+
   $ rm -rf .git


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/4848
The only difference is that I switched to `(subst <disabled|enabled>)` instead of `(enable_subst <bool>)` to be more future proof, in case other options are made available in the future.