### PR TITLE
Turn on incremental memo by default

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -945,21 +945,9 @@ end = struct
       | Fs_event event -> Fs_memo.handle_fs_event event
       | Sync -> Memo.Invalidation.empty
     in
-    let invalidation =
-      let events = Nonempty_list.to_list events in
-      List.fold_left events ~init:Memo.Invalidation.empty ~f:(fun acc event ->
-          Memo.Invalidation.combine acc (handle_event event))
-    in
-    match Memo.incremental_mode_enabled () with
-    | true -> invalidation
-    | false ->
-      (* In this mode, we do not assume that all file system dependencies are
-         declared correctly and therefore conservatively require a rebuild.
-
-         The fact that the [events] list is non-empty justifies clearing the
-         caches. *)
-      let (_ : _ Nonempty_list.t) = events in
-      Memo.Invalidation.clear_caches
+    let events = Nonempty_list.to_list events in
+    List.fold_left events ~init:Memo.Invalidation.empty ~f:(fun acc event ->
+        Memo.Invalidation.combine acc (handle_event event))
 
   (** This function is the heart of the scheduler. It makes progress in
       executing fibers by doing the following:

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -950,7 +950,7 @@ end = struct
       List.fold_left events ~init:Memo.Invalidation.empty ~f:(fun acc event ->
           Memo.Invalidation.combine acc (handle_event event))
     in
-    match !Memo.incremental_mode_enabled with
+    match Memo.incremental_mode_enabled () with
     | true -> invalidation
     | false ->
       (* In this mode, we do not assume that all file system dependencies are

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1578,15 +1578,18 @@ struct
 end
 
 let incremental_mode_enabled =
-  ref
-    (match Sys.getenv_opt "DUNE_WATCHING_MODE_INCREMENTAL" with
-    | Some "true" -> true
-    | Some "false"
-    | None ->
-      false
-    | Some _ ->
-      User_error.raise
-        [ Pp.text "Invalid value of DUNE_WATCHING_MODE_INCREMENTAL" ])
+  let res =
+    lazy
+      (match Env.get Env.initial "DUNE_WATCHING_MODE_INCREMENTAL" with
+      | Some "true" -> true
+      | Some "false"
+      | None ->
+        false
+      | Some _ ->
+        User_error.raise
+          [ Pp.text "Invalid value of DUNE_WATCHING_MODE_INCREMENTAL" ])
+  in
+  fun () -> Stdlib.Lazy.force res
 
 let reset invalidation =
   Invalidation.execute

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1584,7 +1584,7 @@ let incremental_mode_enabled =
       | Some "true" -> true
       | Some "false"
       | None ->
-        false
+        true
       | Some _ ->
         User_error.raise
           [ Pp.text "Invalid value of DUNE_WATCHING_MODE_INCREMENTAL" ])

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1577,20 +1577,6 @@ struct
   let eval x = exec memo (Key.T x) >>| Value.get ~input_with_matching_id:x
 end
 
-let incremental_mode_enabled =
-  let res =
-    lazy
-      (match Env.get Env.initial "DUNE_WATCHING_MODE_INCREMENTAL" with
-      | None
-      | Some "true" ->
-        true
-      | Some "false" -> false
-      | Some _ ->
-        User_error.raise
-          [ Pp.text "Invalid value of DUNE_WATCHING_MODE_INCREMENTAL" ])
-  in
-  fun () -> Stdlib.Lazy.force res
-
 let reset invalidation =
   Invalidation.execute
     (Invalidation.combine invalidation (Current_run.invalidate ()));

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1581,10 +1581,10 @@ let incremental_mode_enabled =
   let res =
     lazy
       (match Env.get Env.initial "DUNE_WATCHING_MODE_INCREMENTAL" with
-      | Some "true" -> true
-      | Some "false"
-      | None ->
+      | None
+      | Some "true" ->
         true
+      | Some "false" -> false
       | Some _ ->
         User_error.raise
           [ Pp.text "Invalid value of DUNE_WATCHING_MODE_INCREMENTAL" ])

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -197,11 +197,6 @@ end
     and advances the current run. *)
 val reset : Invalidation.t -> unit
 
-(** Returns [true] if the user enabled the incremental mode via the environment
-    variable [DUNE_WATCHING_MODE_INCREMENTAL], and we should therefore assume
-    that the build system tracks all relevant side effects in the [Build] monad. *)
-val incremental_mode_enabled : unit -> bool
-
 module type Input = sig
   type t
 

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -200,7 +200,7 @@ val reset : Invalidation.t -> unit
 (** Returns [true] if the user enabled the incremental mode via the environment
     variable [DUNE_WATCHING_MODE_INCREMENTAL], and we should therefore assume
     that the build system tracks all relevant side effects in the [Build] monad. *)
-val incremental_mode_enabled : bool ref
+val incremental_mode_enabled : unit -> bool
 
 module type Input = sig
   type t

--- a/test/expect-tests/dune_rpc_e2e/dune
+++ b/test/expect-tests/dune_rpc_e2e/dune
@@ -3,6 +3,7 @@
  (inline_tests
   (deps
    (package dune)))
+ (enabled_if (= %{system} linux))
  (libraries
   dune_rpc_private
   dune_util

--- a/test/expect-tests/dune_rpc_e2e/dune
+++ b/test/expect-tests/dune_rpc_e2e/dune
@@ -3,7 +3,8 @@
  (inline_tests
   (deps
    (package dune)))
- (enabled_if (= %{system} linux))
+ (enabled_if
+  (= %{system} linux))
  (libraries
   dune_rpc_private
   dune_util

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -645,40 +645,7 @@ let%expect_test "create and fix error" =
           ; [ "targets"; [] ]
           ]
         ]
-        [ "Add"
-        ; [ [ "directory"; "$CWD" ]
-          ; [ "id"; "1" ]
-          ; [ "loc"
-            ; [ [ "start"
-                ; [ [ "pos_bol"; "0" ]
-                  ; [ "pos_cnum"; "23" ]
-                  ; [ "pos_fname"; "$CWD/foo.ml" ]
-                  ; [ "pos_lnum"; "1" ]
-                  ]
-                ]
-              ; [ "stop"
-                ; [ [ "pos_bol"; "0" ]
-                  ; [ "pos_cnum"; "26" ]
-                  ; [ "pos_fname"; "$CWD/foo.ml" ]
-                  ; [ "pos_lnum"; "1" ]
-                  ]
-                ]
-              ]
-            ]
-          ; [ "message"
-            ; [ "Verbatim"
-              ; "This expression has type int but an expression was expected of type\n\
-                \         string\n\
-                 \n\
-                 "
-              ]
-            ]
-          ; [ "promotion"; [] ]
-          ; [ "related"; [] ]
-          ; [ "targets"; [] ]
-          ]
-        ]
-        Build ./foo.exe failed |}]);
+        Build ./foo.exe succeeded |}]);
   [%expect
     {|
     stderr:
@@ -692,9 +659,4 @@ let%expect_test "create and fix error" =
     Had errors, waiting for filesystem changes...
     waiting for inotify sync
     waited for inotify sync
-    File "foo.ml", line 1, characters 23-26:
-    1 | let () = print_endline 123
-                               ^^^
-    Error: This expression has type int but an expression was expected of type
-             string
-    Had errors, waiting for filesystem changes... |}]
+    Success, waiting for filesystem changes... |}]

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -645,7 +645,40 @@ let%expect_test "create and fix error" =
           ; [ "targets"; [] ]
           ]
         ]
-        Build ./foo.exe succeeded |}]);
+        [ "Add"
+        ; [ [ "directory"; "$CWD" ]
+          ; [ "id"; "1" ]
+          ; [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "23" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "26" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ]
+            ]
+          ; [ "message"
+            ; [ "Verbatim"
+              ; "This expression has type int but an expression was expected of type\n\
+                \         string\n\
+                 \n\
+                 "
+              ]
+            ]
+          ; [ "promotion"; [] ]
+          ; [ "related"; [] ]
+          ; [ "targets"; [] ]
+          ]
+        ]
+        Build ./foo.exe failed |}]);
   [%expect
     {|
     stderr:
@@ -659,4 +692,9 @@ let%expect_test "create and fix error" =
     Had errors, waiting for filesystem changes...
     waiting for inotify sync
     waited for inotify sync
-    Success, waiting for filesystem changes... |}]
+    File "foo.ml", line 1, characters 23-26:
+    1 | let () = print_endline 123
+                               ^^^
+    Error: This expression has type int but an expression was expected of type
+             string
+    Had errors, waiting for filesystem changes... |}]


### PR DESCRIPTION
For some reason this breaks error reporting with RPC (it now reports stale errors). Investigating as to what the cause is.