### PR TITLE
setup-ocaml new home is under ocaml/

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 


### PR DESCRIPTION
> And of course, if you are still referencing avsm/setup-ocaml in your
> own workflow definition, this is a good time to change it to
> ocaml/setup-ocaml.

https://discuss.ocaml.org/t/github-actions-for-ocaml-now-stable-and-on-the-ocaml-org/7889