### PR TITLE
grammar change, there -> their

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -872,9 +872,9 @@ This is controlled by:
 Locks
 =====
 
-Given two rules that are independent, dune will assume that there
-associated action can be run concurrently. Two rules are considered
-independent if none of them depend on the other, either directly or
+Given two rules that are independent, dune will assume that their
+associated actions can be run concurrently. Two rules are considered
+independent if neither of them depend on the other, either directly or
 through a chain of dependencies. This basic assumption allows dune to
 parallelize the build.
 


### PR DESCRIPTION
Noticed this grammatical error while reading documentation, thought I would make a pull request!

This is my first pull request, so please let me know if I missed something

This is the offending documentation page:
![image](https://user-images.githubusercontent.com/8399057/131898985-aca9ca8d-c277-40c3-8f80-7b5de126bd5c.png)
