### PR TITLE
[RPC] fix cpu spinning

### DIFF
--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -188,10 +188,11 @@ module Server = struct
         in
         if inter then
           None
-        else if accept then
+        else if accept then (
           let fd, _ = Unix.accept ~cloexec:true t.fd in
+          Unix.clear_nonblock fd;
           Some fd
-        else
+        ) else
           assert false
       | _, _, _ -> assert false
       | exception Unix.Unix_error (Unix.EAGAIN, _, _) -> accept t


### PR DESCRIPTION
The RPC server accepts on a non blocking socket, which yields us non
blocking clients. Sessions expect a blocking fd however, and so this
made dune rpc spin on reads from the rpc client fd. To fix the issue, we
clear the blocking flag on newly accepted connections.

@voodoos should fix the cpu pinning