### PR TITLE
Fix ocamlc loc parsing in 4.11

### DIFF
--- a/src/ocamlc_loc/ocamlc_loc.mli
+++ b/src/ocamlc_loc/ocamlc_loc.mli
@@ -1,3 +1,8 @@
+type warning =
+  { code : int
+  ; name : string
+  }
+
 type loc =
   { path : string
   ; line : [ `Single of int | `Range of int * int ]
@@ -6,10 +11,7 @@ type loc =
 
 type severity =
   | Error
-  | Warning of
-      { code : int option
-      ; name : string
-      }
+  | Warning of warning option
 
 type message =
   | Raw of string

--- a/test/expect-tests/ocamlc_loc/ocamlc_loc_tests.ml
+++ b/test/expect-tests/ocamlc_loc/ocamlc_loc_tests.ml
@@ -127,7 +127,7 @@ let%expect_test "warning" =
                     "
           ; message = "unused variable x.\n\
                        "
-          ; severity = Warning { code = Some 26; name = "unused-var" }
+          ; severity = Warning Some { code = 26; name = "unused-var" }
           }
     ; related = []
     } |}]


### PR DESCRIPTION
Warning payloads are entirely optional.

Should fix the issue. Let me know if this is broken on any other version of the compiler.