### PR TITLE
Add trailing `;;` in MDX code blocks for forward compat with mdx >= 1.11.0

### DIFF
--- a/test/blackbox-tests/test-cases/mdx-stanza/enabled-if.t/iffalse.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza/enabled-if.t/iffalse.md
@@ -1,3 +1,3 @@
 ```ocaml
-# print_endline "run in iffalse"
+# print_endline "run in iffalse";;
 ```

--- a/test/blackbox-tests/test-cases/mdx-stanza/enabled-if.t/iftrue.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza/enabled-if.t/iftrue.md
@@ -1,3 +1,3 @@
 ```ocaml
-# print_endline "run in iftrue"
+# print_endline "run in iftrue";;
 ```

--- a/test/blackbox-tests/test-cases/mdx-stanza/linked-libraries.t/README.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza/linked-libraries.t/README.md
@@ -1,6 +1,6 @@
 We can use our local libraries, in our documentation thanks to dune's mdx stanza:
 
 ```ocaml
-# Private_lib.x
+# Private_lib.x;;
 - : int = 42
 ```

--- a/test/blackbox-tests/test-cases/mdx-stanza/local-package.t/README.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza/local-package.t/README.md
@@ -1,8 +1,8 @@
 We can use our local packages, in our documentation thanks to dune's mdx stanza:
 
 ```ocaml
-# #require "pkg.public-lib"
-# Public_lib.x
+# #require "pkg.public-lib";;
+# Public_lib.x;;
 - : int = 0
 ```
 

--- a/test/blackbox-tests/test-cases/mdx-stanza/new-deps-field.t/README.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza/new-deps-field.t/README.md
@@ -1,13 +1,13 @@
 We can use our local packages, in our documentation thanks to dune's mdx stanza:
 
 ```ocaml
-# #require "pkg.public-lib"
-# Public_lib.x
+# #require "pkg.public-lib";;
+# Public_lib.x;;
 - : int = 1
 ```
 
 ```ocaml
-# #require "pkg2.public-lib2"
-# Public_lib2.x
+# #require "pkg2.public-lib2";;
+# Public_lib2.x;;
 - : int = 2
 ```

--- a/test/blackbox-tests/test-cases/mdx-stanza/preludes.t/README.md
+++ b/test/blackbox-tests/test-cases/mdx-stanza/preludes.t/README.md
@@ -3,7 +3,7 @@ code in the toplevel environments before checking a document. To do that
 you can set the prelude field of the stanza: `(preludes <prelude_file> ...)`.
 
 ```ocaml
-# x
+# x;;
 - : int = 1
 ```
 
@@ -12,11 +12,11 @@ Different environment can have their own prelude. This is set using the
 Here x and why are set in `alt.ml`.
 
 ```ocaml env=a
-# x + y
+# x + y;;
 - : int = 11
 ```
 
 ```ocaml env=b
-# x + y
+# x + y;;
 - : int = 21
 ```


### PR DESCRIPTION
Starting from mdx.1.11.0, toplevel phrases without termintating `;;` are deprecated in toplevel blocks.

Some of MDX stanza tests were lacking the semi-colons, triggering a warning from MDX. It's not a breaking change for regular users but it shows up in `dune runtest` output and therefore breaks the cram tests for the MDX stanza.