### PR TITLE
Remove all the symlink hackery

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -88,15 +88,6 @@ module V1 = struct
         let read_file s : (string, exn) result Lwt.t =
           Lwt_result.catch (Lwt_io.with_file ~mode:Input s Lwt_io.read)
 
-        let readlink s =
-          Lwt.catch
-            (fun () ->
-              let+ res = Lwt_unix.readlink s in
-              Ok (Some res))
-            (function
-              | Unix.Unix_error (Unix.EINVAL, _, _) -> Lwt.return (Ok None)
-              | exn -> Lwt.return (Error exn))
-
         let analyze_path s =
           Lwt.try_bind
             (fun () -> Lwt_unix.stat s)

--- a/otherlibs/dune-rpc-lwt/test/dune
+++ b/otherlibs/dune-rpc-lwt/test/dune
@@ -3,6 +3,9 @@
  (inline_tests
   (deps
    (package dune)))
+ (foreign_stubs
+  (language c)
+  (names realpath_stubs))
  (libraries
   dune_rpc
   csexp_rpc

--- a/otherlibs/dune-rpc-lwt/test/realpath_stubs.c
+++ b/otherlibs/dune-rpc-lwt/test/realpath_stubs.c
@@ -1,0 +1,46 @@
+/* taken from the core library */
+
+#define _GNU_SOURCE
+
+#include <limits.h>
+#include <stdlib.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+/* #include "ocaml_utils.h" */
+
+/* Pathname resolution */
+
+/* Seems like a sane approach to getting a reasonable bound for the
+   maximum path length */
+#ifdef PATH_MAX
+#define JANE_PATH_MAX ((PATH_MAX <= 0 || PATH_MAX > 65536) ? 65536 : PATH_MAX)
+#else
+#define JANE_PATH_MAX (65536)
+#endif
+
+#ifdef __GLIBC__
+CAMLprim value dune_realpath(value v_path)
+{
+  const char *path = String_val(v_path);
+  char *res = realpath(path, NULL);
+  if (res == NULL) uerror("realpath", v_path);
+  else {
+    value v_res = caml_copy_string(res);
+    free(res);
+    return v_res;
+  }
+}
+#else
+CAMLprim value dune_realpath(value v_path)
+{
+  char *path = String_val(v_path);
+  /* [realpath] is inherently broken without GNU-extension, and this
+     seems like a reasonable thing to do if we do not build against
+     GLIBC. */
+  char resolved_path[JANE_PATH_MAX];
+  if (realpath(path, resolved_path) == NULL) uerror("realpath", v_path);
+  return caml_copy_string(resolved_path);
+}
+#endif

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -429,8 +429,6 @@ module V1 : sig
     end) (IO : sig
       val read_file : string -> (string, exn) result Fiber.t
 
-      val readlink : string -> (string option, exn) result Fiber.t
-
       val analyze_path :
         string -> ([ `Unix_socket | `Normal_file | `Other ], exn) result Fiber.t
     end) : S with type 'a fiber := 'a Fiber.t

--- a/otherlibs/dune-rpc/private/where.mli
+++ b/otherlibs/dune-rpc/private/where.mli
@@ -41,8 +41,6 @@ module Make (Fiber : sig
 end) (IO : sig
   val read_file : string -> (string, exn) result Fiber.t
 
-  val readlink : string -> (string option, exn) result Fiber.t
-
   val analyze_path :
     string -> ([ `Unix_socket | `Normal_file | `Other ], exn) result Fiber.t
 end) : S with type 'a fiber := 'a Fiber.t

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -15,6 +15,79 @@ end
 
 module Session_id = Id.Make ()
 
+module Socket = struct
+  module type Unix_socket = sig
+    val connect : Unix.file_descr -> socket:string -> unit
+
+    val bind : Unix.file_descr -> socket:string -> unit
+  end
+
+  module U = struct
+    type sockaddr = Unix.sockaddr
+
+    let connect fd sock = Unix.connect fd sock
+
+    let bind fd sock = Unix.bind fd sock
+  end
+
+  module Mac : Unix_socket = struct
+    external pthread_chdir : string -> unit = "dune_pthread_chdir" [@@noalloc]
+
+    let with_chdir fd ~socket ~f =
+      let old = Sys.getcwd () in
+      let dir = Filename.dirname socket in
+      let sock = Filename.basename socket in
+      pthread_chdir dir;
+      Exn.protectx (Unix.ADDR_UNIX sock) ~f:(f fd) ~finally:(fun _ ->
+          pthread_chdir old)
+
+    let connect fd ~socket : unit = with_chdir fd ~socket ~f:Unix.connect
+
+    let bind fd ~socket : unit = with_chdir fd ~socket ~f:Unix.bind
+  end
+
+  module Unix : Unix_socket = struct
+    let addr socket =
+      Unix.ADDR_UNIX
+        (match
+           let cwd = Sys.getcwd () in
+           String.drop_prefix socket ~prefix:(cwd ^ "/")
+         with
+        | Some s -> "./" ^ s
+        | None -> socket)
+
+    let connect fd ~socket = Unix.connect fd (addr socket)
+
+    let bind fd ~socket = Unix.bind fd (addr socket)
+  end
+
+  module Fail : Unix_socket = struct
+    let connect _ ~socket:_ = Code_error.raise "Fail.connect" []
+
+    let bind _ ~socket:_ = Code_error.raise "Fail.bind" []
+  end
+
+  external is_osx : unit -> bool = "dune_pthread_chdir_is_osx" [@@noalloc]
+
+  module Sel = (val if is_osx () then
+                      (module Mac)
+                    else if Sys.unix then
+                      (module Unix)
+                    else
+                      (module Fail) : Unix_socket)
+
+  let max_len = 104 (* 108 on some systems but we keep it conservative *)
+
+  let make ~original ~backup fd (sa : U.sockaddr) =
+    match sa with
+    | ADDR_UNIX socket when String.length socket > max_len -> backup fd ~socket
+    | _ -> original fd sa
+
+  let bind = make ~original:U.bind ~backup:Sel.bind
+
+  let connect = make ~original:U.connect ~backup:Sel.connect
+end
+
 let debug = Option.is_some (Env.get Env.initial "DUNE_RPC_DEBUG")
 
 module Session = struct
@@ -167,7 +240,7 @@ module Server = struct
         Path.mkdir_p (Path.parent_exn p);
         at_exit (fun () -> Path.unlink_no_err p)
       | _ -> ());
-      Unix.bind fd sockaddr;
+      Socket.bind fd sockaddr;
       Unix.listen fd backlog;
       let r_interrupt_accept, w_interrupt_accept = Unix.pipe ~cloexec:true () in
       Unix.set_nonblock r_interrupt_accept;
@@ -282,7 +355,7 @@ module Client = struct
       { sockaddr; fd }
 
     let connect t =
-      let () = Unix.connect t.fd t.sockaddr in
+      let () = Socket.connect t.fd t.sockaddr in
       t.fd
   end
 

--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -1,4 +1,7 @@
 (library
  (name csexp_rpc)
  (synopsis "Threaded client & server that uses csexp for communication")
- (libraries stdune dune_util csexp dune_engine fiber))
+ (libraries stdune dune_util csexp dune_engine fiber)
+ (foreign_stubs
+  (language c)
+  (names pthread_chdir_stubs)))

--- a/src/csexp_rpc/pthread_chdir_stubs.c
+++ b/src/csexp_rpc/pthread_chdir_stubs.c
@@ -1,0 +1,57 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/signals.h>
+#include <caml/callback.h>
+#include <caml/unixsupport.h>
+
+#if defined(__APPLE__)
+
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+CAMLprim value dune_pthread_chdir_is_osx(value unit)
+{
+  CAMLparam1(unit);
+  CAMLreturn(Val_true);
+}
+
+
+#ifndef SYS___pthread_chdir
+# define SYS___pthread_chdir 348
+#endif
+
+int __pthread_chdir(const char *path)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+  return syscall(SYS___pthread_chdir, path);
+#pragma clang diagnostic pop
+}
+
+CAMLprim value dune_pthread_chdir(value dir) {
+  CAMLparam1(dir);
+  if (__pthread_chdir(String_val(dir))) {
+    uerror("__pthread_chdir", Nothing);
+  } 
+  CAMLreturn (Val_unit); 
+}
+
+#else
+
+CAMLprim value dune_pthread_chdir_is_osx(value unit)
+{
+  CAMLparam1(unit);
+  CAMLreturn(Val_false);
+}
+
+CAMLprim value dune_pthread_chdir(value unit) {
+  CAMLparam1(unit);
+  caml_invalid_argument("__pthread_chdir not implemented");
+  CAMLreturn (Val_unit); 
+}
+
+#endif

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -13,77 +13,6 @@ module Config = struct
         }
 end
 
-module Symlink_socket : sig
-  (** This module encapsulates the trick of using symlinks to get around the
-      restriction on length of domain sockets. *)
-
-  type t
-
-  val create : Path.t -> t
-
-  (* Actually create the symlink (if necessary). This function is idempotent *)
-  val link : t -> unit
-
-  val cleanup : t -> unit
-
-  val socket : t -> Path.t
-end = struct
-  (* Maximum path before we resort to the trick *)
-  let max_path_length = 100
-
-  type t =
-    { symlink : Path.t option
-    ; socket : Path.t
-    ; cleanup : unit Lazy.t
-    ; link : unit Lazy.t
-    }
-
-  let link t = Lazy.force t.link
-
-  let make_cleanup ~symlink ~socket =
-    lazy
-      (Option.iter symlink ~f:Path.unlink_no_err;
-       Path.unlink_no_err socket)
-
-  let cleanup t = Lazy.force t.cleanup
-
-  let create desired_path =
-    let desired_path_s = Path.to_absolute_filename desired_path in
-    if String.length desired_path_s <= max_path_length then
-      let cleanup = make_cleanup ~symlink:None ~socket:desired_path in
-      { symlink = None; socket = desired_path; cleanup; link = lazy () }
-    else
-      let socket =
-        let dir =
-          Path.of_string
-            (match Xdg.runtime_dir (Lazy.force Dune_util.xdg) with
-            | None -> Filename.get_temp_dir_name ()
-            | Some p ->
-              let p = Filename.concat p "dune/s" in
-              (match Fpath.mkdir_p p with
-              | Already_exists
-              | Created ->
-                ());
-              p)
-        in
-        Temp.temp_file ~dir ~prefix:"" ~suffix:"dune"
-      in
-      let link =
-        let dest =
-          let from = Path.external_ (Path.External.cwd ()) in
-          Path.mkdir_p (Path.parent_exn desired_path);
-          Path.reach_for_running ~from desired_path
-        in
-        lazy (Unix.symlink (Path.to_string socket) dest)
-      in
-      let cleanup = make_cleanup ~symlink:(Some desired_path) ~socket in
-      let t = { symlink = Some desired_path; socket; cleanup; link } in
-      at_exit (fun () -> Lazy.force cleanup);
-      t
-
-  let socket t = t.socket
-end
-
 type t =
   | Client
   | Server of
@@ -92,7 +21,6 @@ type t =
       ; pool : Fiber.Pool.t
       ; where : Dune_rpc_private.Where.t
       ; stats : Dune_stats.t option
-      ; symlink_socket : Symlink_socket.t option
       ; root : string
       }
 
@@ -105,17 +33,8 @@ let of_config config stats =
   | Config.Client -> Client
   | Config.Server { handler; backlog; pool; root } ->
     let where = Where.default () in
-    let real_where, symlink_socket =
-      match where with
-      | `Ip _ -> (Where.to_socket where, None)
-      | `Unix path ->
-        let path = Path.of_string path in
-        let symlink_socket = Symlink_socket.create path in
-        ( Unix.ADDR_UNIX (Path.to_string (Symlink_socket.socket symlink_socket))
-        , Some symlink_socket )
-    in
-    let server = Csexp_rpc.Server.create real_where ~backlog in
-    Server { server; handler; where; symlink_socket; stats; pool; root }
+    let server = Csexp_rpc.Server.create (Where.to_socket where) ~backlog in
+    Server { server; handler; where; stats; pool; root }
 
 let run config stats =
   let t = of_config config stats in
@@ -142,7 +61,6 @@ let run config stats =
                Fiber.fork_and_join_unit
                  (fun () ->
                    let* sessions = Csexp_rpc.Server.serve t.server in
-                   Option.iter t.symlink_socket ~f:Symlink_socket.link;
                    let () =
                      let (`Caller_should_write { Registry.File.path; contents })
                          =
@@ -167,7 +85,6 @@ let run config stats =
                  (fun () -> Fiber.Pool.run t.pool)))
           ~finally:(fun () ->
             run_cleanup_registry ();
-            Option.iter t.symlink_socket ~f:Symlink_socket.cleanup;
             Fiber.return ()))
 
 let stop () =

--- a/src/dune_rpc_impl/where.ml
+++ b/src/dune_rpc_impl/where.ml
@@ -16,12 +16,6 @@ module Where =
     (struct
       let read_file f = Ok (Io.String_path.read_file f)
 
-      let readlink s =
-        match Unix.readlink s with
-        | s -> Ok (Some s)
-        | exception Unix.Unix_error (Unix.EINVAL, _, _) -> Ok None
-        | exception (Unix.Unix_error _ as e) -> Error e
-
       let analyze_path s =
         match (Unix.stat s).st_kind with
         | Unix.S_SOCK -> Ok `Unix_socket


### PR DESCRIPTION
As discussed, use bindat/connectat on *nix and __pthread_chdir on macos.

EDIT: looks like bindat/connectat is BSD only. Fortunately, it appears that we don't need the hack at all on Linux as the temp paths in the tests are short enough. 