### PR TITLE
[RPC] fix handling of post-versioning aborts

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -692,6 +692,7 @@ module Client = struct
               ~menu
           in
           let* () = Fiber.Ivar.fill handler_var handler in
+          client.handler_initialized <- true;
           Fiber.finalize
             (fun () -> f client)
             ~finally:(fun () -> Chan.write chan None)

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -691,8 +691,8 @@ module Client = struct
               ~session_version:(fun () -> client.initialize.dune_version)
               ~menu
           in
-          let* () = Fiber.Ivar.fill handler_var handler in
           client.handler_initialized <- true;
+          let* () = Fiber.Ivar.fill handler_var handler in
           Fiber.finalize
             (fun () -> f client)
             ~finally:(fun () -> Chan.write chan None)


### PR DESCRIPTION
I should have caught this earlier. It doesn't actually change any observable behavior, but is probably a good change to make for hygiene's sake anyway.

Signed-off-by: Cameron Wong <cwong@janestreet.com>