### PR TITLE
[RPC] rename socket dir

### DIFF
--- a/otherlibs/dune-rpc/private/where.ml
+++ b/otherlibs/dune-rpc/private/where.ml
@@ -46,7 +46,7 @@ type error = Invalid_where of string
 
 exception E of error
 
-let rpc_socket_relative_to_build_dir = "rpc/dune"
+let rpc_socket_relative_to_build_dir = ".rpc/dune"
 
 let _DUNE_RPC = "DUNE_RPC"
 


### PR DESCRIPTION
Rename From rpc to .rpc. So it makes it possible to have a context named
"rpc"