### PR TITLE
Print a message when the reason for restarting is unknown

### DIFF
--- a/otherlibs/stdune-unstable/list.ml
+++ b/otherlibs/stdune-unstable/list.ml
@@ -231,12 +231,9 @@ let split_while xs ~f =
   loop [] xs
 
 let truncate ~max_length xs =
-  let rec loop acc length xs =
-    if length >= max_length then
-      `Truncated (rev acc)
-    else
-      match xs with
-      | [] -> `Not_truncated (rev acc)
-      | hd :: tl -> loop (hd :: acc) (length + 1) tl
+  let rec loop acc length = function
+    | [] -> `Not_truncated (rev acc)
+    | _ :: _ when length >= max_length -> `Truncated (rev acc)
+    | hd :: tl -> loop (hd :: acc) (length + 1) tl
   in
   loop [] 0 xs

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1464,6 +1464,8 @@ module Invalidation = struct
        e.g. if there is a global reset because of [Event_queue_overflow], it may
        be better to ensure that this reason is included. *)
     match List.truncate ~max_length:max_elements details with
+    | `Not_truncated details when List.length details = 0 ->
+      [ "Restarting for an unknown reason, please report it as a bug" ]
     | `Not_truncated details -> details
     | `Truncated truncated_details -> (
       let extra_message =


### PR DESCRIPTION
This is a follow-up to #4926.

As discussed, we are now going to print a message when the reason for restarting Dune is unknown, encouraging the user to report this as a bug.

I also fixed a bug in `List.truncate` which marked the result as "truncated" when `max_length` was equal to the length of the original list.
