### PR TITLE
Use command -v instead of which

### DIFF
--- a/test/blackbox-tests/test-cases/actions/action-stdxxx-on-success.t
+++ b/test/blackbox-tests/test-cases/actions/action-stdxxx-on-success.t
@@ -1,7 +1,7 @@
 Test for --action-stdxxx-on-success
 ====================================
 
-  $ export BUILD_PATH_PREFIX_MAP="sh=$(which sh):$BUILD_PATH_PREFIX_MAP"
+  $ export BUILD_PATH_PREFIX_MAP="sh=$(command -v sh):$BUILD_PATH_PREFIX_MAP"
 
   $ echo '(lang dune 3.0)' > dune-project
 


### PR DESCRIPTION
In the latest Debian release, this prints a warning that makes the expect test fail. It recommends using `command -v` which is the portable way to do so.
