### PR TITLE
Add enabled_if to running inline_tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+- Add the `enabled_if` field to `inline_tests` within the `library` stanza.
+  This allows us to disable executing the inline tests while still allowing for
+  compilation (#4939, @rgrinberg)
+
 - Generate a `dune-project` when initializing projects with `dune init proj ...`
   (#4881, closes #4367, @shonfeder)
 

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -94,6 +94,7 @@ module Tests = struct
     ; executable : Ocaml_flags.Spec.t
     ; backend : (Loc.t * Lib_name.t) option
     ; libraries : (Loc.t * Lib_name.t) list
+    ; enabled_if : Blang.t
     }
 
   type Sub_system_info.t += T of t
@@ -122,8 +123,12 @@ module Tests = struct
          field "modes"
            (Dune_lang.Syntax.since syntax (1, 11) >>> Mode_conf.Set.decode)
            ~default:Mode_conf.Set.default
+       and+ enabled_if =
+         Enabled_if.decode ~allowed_vars:Any ~is_error:true
+           ~since:(Some (3, 0))
+           ()
        in
-       { loc; deps; flags; executable; backend; libraries; modes })
+       { loc; deps; flags; executable; backend; libraries; modes; enabled_if })
 
   (* We don't use this at the moment, but we could implement it for debugging
      purposes *)

--- a/src/dune_rules/inline_tests_info.mli
+++ b/src/dune_rules/inline_tests_info.mli
@@ -45,6 +45,7 @@ module Tests : sig
     ; executable : Ocaml_flags.Spec.t
     ; backend : (Loc.t * Lib_name.t) option
     ; libraries : (Loc.t * Lib_name.t) list
+    ; enabled_if : Blang.t
     }
 
   val backends : t -> (Loc.t * Lib_name.t) list option

--- a/test/blackbox-tests/test-cases/inline_tests/enabled-if.t
+++ b/test/blackbox-tests/test-cases/inline_tests/enabled-if.t
@@ -1,0 +1,22 @@
+enabled_if inside the inline_tests field in the library stanza
+
+  $ mkdir tmp && cd tmp
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+  $ cat >dune <<EOF
+  > (library
+  >  (name backend_mbc)
+  >  (modules ())
+  >  (inline_tests.backend
+  >   (generate_runner (echo "print_endline \"backend_mbc\""))))
+  > 
+  > (library
+  >  (name foo_mbc)
+  >  (inline_tests
+  >   (enabled_if false)
+  >   (backend backend_mbc))
+  >  (libraries backend_mbc))
+  > EOF
+
+  $ dune runtest


### PR DESCRIPTION
This is an improvement over enabled_if on the library itself as it still
allows to compile the library.