### PR TITLE
Remove failwith from dunerpc

### DIFF
--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -245,7 +245,7 @@ module V1 : sig
           -> ?abort:(Message.t -> unit fiber)
                (** If [abort] is called, the server has terminated the
                    connection due to a protocol error. This should never be
-                   called unless there's a bug. *)
+                   called unless there's a server side bug. *)
           -> unit
           -> t
       end

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -31,6 +31,9 @@ val enum : (string * 'a) list -> ('a, values) t
 
 val iso : ('a, 'k) t -> ('a -> 'b) -> ('b -> 'a) -> ('b, 'k) t
 
+val iso_result :
+  ('a, 'k) t -> ('a -> ('b, exn) result) -> ('b -> 'a) -> ('b, 'k) t
+
 val version : ?until:int * int -> ('a, 'k) t -> since:int * int -> ('a, 'k) t
 
 (** {2 parsing records} *)

--- a/otherlibs/dune-rpc/private/dbus_address.mll
+++ b/otherlibs/dune-rpc/private/dbus_address.mll
@@ -118,7 +118,7 @@ and unescape = parse
     | [ '0'-'9' 'a'-'f' 'A'-'F' ] [ '0'-'9' 'a'-'f' 'A'-'F' ] as str
         { hex_decode str }
     | ""
-        { failwith "two hexdigits expected after '%'" }
+        { fail lexbuf "two hexdigits expected after '%%'" }
 
 {
   let of_string str =

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -104,8 +104,8 @@ let%expect_test "no methods in common" =
   [%expect.unreachable]
   [@@expect.uncaught_exn
     {|
-  (Failure
-    "Fatal error from server: Server and client have no method versions in common")
+  ( "Server_aborted\
+   \n  [ [ \"message\"; \"Server and client have no method versions in common\" ] ]")
   Trailing output
   ---------------
   server: finished. |}]


### PR DESCRIPTION
Allow converters to signal errors by returning result

Fix #4915 