### PR TITLE
No longer read installed META files for compiler libraries (-> fix "`vmthreads` only exists in OCaml < 4.09")

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -195,6 +195,9 @@ Unreleased
 - No longer reference deprecated Toploop functions when using dune files in
   OCaml syntax. (#4834, fixes #4830, @nojb)
 
+- Dune no longer reads installed META files for libraries distributed with the
+  compiler, instead using its own internal database. (#4946, @nojb)
+
 2.9.1 (07/09/2021)
 ------------------
 

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -57,6 +57,10 @@ set of predicates:
   it is linked as part of a driver or meant to add a ``-ppx`` argument
   to the compiler, choose the former behavior
 
+Note that Dune does not read *installed* ``META`` files for libraries
+distributed with the compiler (as these files are not installed by the compiler
+itself, but installed by `ocamlfind`, and are not always perfectly
+accurate). Instead Dune uses its own internal database for this information.
 
 Dynamic loading of packages with findlib
 ========================================

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -238,7 +238,6 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   in
   let dynlink = simple "dynlink" [] ~dir:"+" in
   let bytes = dummy "bytes" in
-  let result = dummy "result" in
   let uchar = dummy "uchar" in
   let seq = dummy "seq" in
   let threads =
@@ -292,12 +291,6 @@ let builtins ~stdlib_dir ~version:ocaml_version =
       ; bytes
       ; ocamldoc
       ]
-    in
-    let base =
-      if Ocaml_version.pervasives_includes_result ocaml_version then
-        result :: base
-      else
-        base
     in
     let base =
       if Ocaml_version.stdlib_includes_uchar ocaml_version then

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -244,21 +244,26 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   let threads =
     { name = Some (Lib_name.of_string "threads")
     ; entries =
-        [ version
-        ; main_modules [ "thread" ]
-        ; requires ~preds:[ Pos "mt"; Pos "mt_vm" ] [ "threads.vm" ]
-        ; requires ~preds:[ Pos "mt"; Pos "mt_posix" ] [ "threads.posix" ]
-        ; directory "+"
-        ; rule "type_of_threads" [] Set "posix"
-        ; rule "error" [ Neg "mt" ] Set "Missing -thread or -vmthread switch"
-        ; rule "error"
-            [ Neg "mt_vm"; Neg "mt_posix" ]
-            Set "Missing -thread or -vmthread switch"
-        ; Package
-            (simple "vm" [ "unix" ] ~dir:"+vmthreads" ~archive_name:"threads")
-        ; Package
-            (simple "posix" [ "unix" ] ~dir:"+threads" ~archive_name:"threads")
-        ]
+        ([ version
+         ; main_modules [ "thread" ]
+         ; requires ~preds:[ Pos "mt"; Pos "mt_vm" ] [ "threads.vm" ]
+         ; requires ~preds:[ Pos "mt"; Pos "mt_posix" ] [ "threads.posix" ]
+         ; directory "+"
+         ; rule "type_of_threads" [] Set "posix"
+         ; rule "error" [ Neg "mt" ] Set "Missing -thread or -vmthread switch"
+         ; rule "error"
+             [ Neg "mt_vm"; Neg "mt_posix" ]
+             Set "Missing -thread or -vmthread switch"
+         ; Package
+             (simple "posix" [ "unix" ] ~dir:"+threads" ~archive_name:"threads")
+         ]
+        @
+        if Ocaml_version.has_vmthreads ocaml_version then
+          [ Package
+              (simple "vm" [ "unix" ] ~dir:"+vmthreads" ~archive_name:"threads")
+          ]
+        else
+          [])
     }
   in
   let num =

--- a/src/dune_rules/ocaml_version.ml
+++ b/src/dune_rules/ocaml_version.ml
@@ -49,3 +49,5 @@ let custom_or_output_complete_exe version =
 let ocamlopt_always_calls_library_linker version = version < (4, 12, 0)
 
 let has_sys_opaque_identity version = version >= (4, 3, 0)
+
+let has_vmthreads version = version < (4, 9, 0)

--- a/src/dune_rules/ocaml_version.ml
+++ b/src/dune_rules/ocaml_version.ml
@@ -20,8 +20,6 @@ let supports_response_file version = version >= (4, 05, 0)
 
 let ocamlmklib_supports_response_file version = version >= (4, 08, 0)
 
-let pervasives_includes_result version = version >= (4, 03, 0)
-
 let stdlib_includes_uchar version = version >= (4, 03, 0)
 
 let stdlib_includes_bigarray version = version >= (4, 07, 0)

--- a/src/dune_rules/ocaml_version.mli
+++ b/src/dune_rules/ocaml_version.mli
@@ -68,3 +68,6 @@ val ocamlopt_always_calls_library_linker : t -> bool
 
 (** Whether [Sys.opaque_identity] is in the standard library *)
 val has_sys_opaque_identity : t -> bool
+
+(** Whether [vmthreads] exists *)
+val has_vmthreads : t -> bool

--- a/src/dune_rules/ocaml_version.mli
+++ b/src/dune_rules/ocaml_version.mli
@@ -29,9 +29,6 @@ val supports_response_file : t -> bool
 (** Does ocamlmklib support [-args0]? *)
 val ocamlmklib_supports_response_file : t -> bool
 
-(** Whether [Pervasives] includes the [result] type *)
-val pervasives_includes_result : t -> bool
-
 (** Whether the standard library includes the [Uchar] module *)
 val stdlib_includes_uchar : t -> bool
 

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -9,14 +9,12 @@ CRAM sanitization
   X
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/bytes)
    (B lib/findlib)
    (B /OCAMLC_WHERE)
    (B
     $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
    (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
-   (S lib/bytes)
    (S lib/findlib)
    (S /OCAMLC_WHERE)
    (S
@@ -65,12 +63,10 @@ CRAM sanitization
   Privmod
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/bytes)
    (B lib/findlib)
    (B /OCAMLC_WHERE)
    (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S lib/bytes)
    (S lib/findlib)
    (S /OCAMLC_WHERE)
    (S
@@ -87,12 +83,10 @@ CRAM sanitization
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
-   (B lib/bytes)
    (B lib/findlib)
    (B /OCAMLC_WHERE)
    (B
     $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
-   (S lib/bytes)
    (S lib/findlib)
    (S /OCAMLC_WHERE)
    (S


### PR DESCRIPTION
Fixes the following issue:

![image](https://user-images.githubusercontent.com/113560/134852365-7e5c3787-da41-4a92-8497-9cff813c4ae1.png)