### PR TITLE
Minor clean up of [Memo.Invalidation]

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1110,13 +1110,7 @@ module Run = struct
 
   let poll_iter t step =
     (match t.status with
-    | Standing_by invalidations ->
-      if false then
-        Console.print
-          [ Pp.text "Invalidating:"
-          ; Dyn.pp (Memo.Invalidation.to_dyn invalidations)
-          ];
-      Memo.reset invalidations
+    | Standing_by invalidations -> Memo.reset invalidations
     | _ ->
       Code_error.raise "[poll_iter]: expected the build status [Standing_by]" []);
     t.status <- Building;

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1653,7 +1653,7 @@ end
 let reset invalidation =
   (* We rely on [invalidation] to list the actual reasons for the reset, which
      justifies the [~reason:Unknown] below. *)
-  let invalidate_current_run = Current_run.invalidate ~reason:Test in
+  let invalidate_current_run = Current_run.invalidate ~reason:Unknown in
   Invalidation.execute
     (Invalidation.combine invalidation invalidate_current_run);
   Run.restart ();

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1356,13 +1356,6 @@ module Invalidation = struct
       | Upgrade
       | Test
 
-    let to_dyn = function
-      | Unknown -> Dyn.Variant ("Unknown", [])
-      | Path_changed path -> Dyn.Variant ("Path_changed", [ Path.to_dyn path ])
-      | Event_queue_overflow -> Dyn.Variant ("Event_queue_overflow", [])
-      | Upgrade -> Dyn.Variant ("Upgrade", [])
-      | Test -> Dyn.Variant ("Test", [])
-
     let to_string_hum = function
       | Unknown -> None
       | Path_changed path -> Some (Path.to_string path ^ " changed")
@@ -1382,19 +1375,6 @@ module Invalidation = struct
       { kind : kind
       ; reason : Reason.t
       }
-
-    let to_dyn { kind; reason } =
-      let kind =
-        match kind with
-        | Invalidate_node dep_node ->
-          Dyn.Variant
-            ( "Invalidate_node"
-            , [ Stack_frame_without_state.to_dyn (T dep_node.without_state) ] )
-        | Clear_cache _ -> Dyn.Variant ("Clear_cache", [ Dyn.Opaque ])
-        | Clear_caches -> Dyn.Variant ("Clear_caches", [])
-      in
-      let reason = Reason.to_dyn reason in
-      Dyn.Tuple [ kind; reason ]
 
     let to_string_hum { reason; _ } = Reason.to_string_hum reason
   end
@@ -1450,8 +1430,6 @@ module Invalidation = struct
     | x :: xs -> to_list_x_xs x xs acc
 
   let to_list t = to_list_x_xs t [] []
-
-  let to_dyn t = Dyn.List (List.map (to_list t) ~f:Leaf.to_dyn)
 
   let details_hum ?(max_elements = 5) t =
     assert (max_elements > 0);

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -213,8 +213,6 @@ module Invalidation : sig
   (** Invalidate all computations stored in a given [memo] table. *)
   val invalidate_cache : reason:Reason.t -> _ memo -> t
 
-  val to_dyn : t -> Dyn.t
-
   (** A list of human-readable strings explaining the reasons for invalidation.
       The list is truncated to [max_elements] elements, with [max_elements = 5]
       by default. Raises if [max_elements <= 0]. *)


### PR DESCRIPTION
After adding proper diagnostics for restarts, we no longer need some debugging code guarded by `if false`, so I'm deleting it to simplify things a bit. 

Also fixed a silly typo (`Test` vs `Unknown`) to bring code and comments in sync.