### PR TITLE
More flexible metrics collection

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -1,27 +1,35 @@
 open Stdune
 open Import
 
+let with_metrics ~common f =
+  let start_time = Unix.gettimeofday () in
+  Fiber.finalize f ~finally:(fun () ->
+      let duration = Unix.gettimeofday () -. start_time in
+      (if Common.print_metrics common then
+        let gc_stat = Gc.quick_stat () in
+        Console.print_user_message
+          (User_message.make
+             ([ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ())
+              ; Pp.textf "(%.2fs total, %.1fM heap words)" duration
+                  (float_of_int gc_stat.heap_words /. 1_000_000.)
+              ; Pp.text "Timers:"
+              ]
+             @ List.map
+                 ~f:
+                   (fun (timer, { Metrics.Timer.Measure.cumulative_time; count })
+                        ->
+                   Pp.textf "%s - time spent = %.2fs, count = %d" timer
+                     cumulative_time count)
+                 (String.Map.to_list (Metrics.Timer.aggregated_timers ())))));
+      Fiber.return ())
+
 let run_build_system ~common ~request =
   let run ~(request : unit Action_builder.t) =
-    let build_started = Unix.gettimeofday () in
-    Fiber.finalize
-      (fun () ->
+    with_metrics ~common (fun () ->
         Build_system.run (fun () ->
             let open Memo.Build.O in
             let+ (), _facts = Action_builder.run request Eager in
             ()))
-      ~finally:(fun () ->
-        (if Common.print_metrics common then
-          let gc_stat = Gc.quick_stat () in
-          Console.print_user_message
-            (User_message.make
-               [ Pp.textf "%s" (Memo.Perf_counters.report_for_current_run ())
-               ; Pp.textf "(%.2fs total, %.2fs digests, %.1fM heap words)"
-                   (Unix.gettimeofday () -. build_started)
-                   (Metrics.Timer.read_seconds Digest.generic_timer)
-                   (float_of_int gc_stat.heap_words /. 1_000_000.)
-               ]));
-        Fiber.return ())
   in
   let open Fiber.O in
   Fiber.finalize

--- a/otherlibs/stdune-unstable/digest.ml
+++ b/otherlibs/stdune-unstable/digest.ml
@@ -55,8 +55,6 @@ let string = Impl.string
 
 let to_string_raw s = s
 
-let generic_timer = Metrics.Timer.create ()
-
 (* We use [No_sharing] to avoid generating different digests for inputs that
    differ only in how they share internal values. Without [No_sharing], if a
    command line contains duplicate flags, such as multiple occurrences of the
@@ -64,7 +62,7 @@ let generic_timer = Metrics.Timer.create ()
    on whether the corresponding strings ["-I"] point to the same memory location
    or to different memory locations. *)
 let generic a =
-  Metrics.Timer.record generic_timer ~f:(fun () ->
+  Metrics.Timer.record "generic_digest" ~f:(fun () ->
       string (Marshal.to_string a [ No_sharing ]))
 
 let file_with_executable_bit ~executable path =

--- a/otherlibs/stdune-unstable/digest.mli
+++ b/otherlibs/stdune-unstable/digest.mli
@@ -26,9 +26,6 @@ val to_string_raw : t -> string
 
 val generic : 'a -> t
 
-(** The total time spent in the function [generic] during the current build. *)
-val generic_timer : Metrics.Timer.t
-
 (** Digest a file and its stats. Does something sensible for directories. *)
 val file_with_stats : Path.t -> Unix.stats -> t
 

--- a/otherlibs/stdune-unstable/metrics.mli
+++ b/otherlibs/stdune-unstable/metrics.mli
@@ -7,14 +7,22 @@ val enable : unit -> unit
 val reset : unit -> unit
 
 module Timer : sig
+  module Measure : sig
+    type t =
+      { cumulative_time : float
+      ; count : int
+      }
+  end
+
   type t
 
-  (* Create a timer initialised to 0 and hooked to the global [reset]. *)
-  val create : unit -> t
+  val start : string -> t
 
-  val read_seconds : t -> float
+  val stop : t -> unit
 
   (** If metrics are enabled, increment the timer by the amount of seconds
       elapsed during the execution of [f]. *)
-  val record : t -> f:(unit -> 'a) -> 'a
+  val record : string -> f:(unit -> 'a) -> 'a
+
+  val aggregated_timers : unit -> Measure.t String.Map.t
 end

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -389,6 +389,13 @@ let parallel_iter_set (type a s)
   | 1 -> f (Option.value_exn (S.min_elt t)) k
   | n -> parallel_iter_generic ~n ~iter:(S.iter t) ~f k
 
+let record_metrics t ~tag =
+  of_thunk (fun () ->
+      let timer = Metrics.Timer.start tag in
+      let+ res = t in
+      Metrics.Timer.stop timer;
+      res)
+
 module Make_map_traversals (Map : Map.S) = struct
   let parallel_iter t ~f k =
     match Map.cardinal t with

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -105,6 +105,13 @@ val parallel_iter_set :
   -> f:('a -> unit t)
   -> unit t
 
+(** Returns a fiber which wraps the given fiber with calls to
+    Metrics.Timer.start/stop.
+
+    Note: This will measure the wall clock time between when the fiber starts
+    and finishes, including any time that it is inactive *)
+val record_metrics : 'a t -> tag:string -> 'a t
+
 (** Provide efficient parallel iter/map functions for maps. *)
 module Make_map_traversals (Map : Map.S) : sig
   val parallel_iter : 'a Map.t -> f:(Map.key -> 'a -> unit t) -> unit t


### PR DESCRIPTION
Changes metrics module to take in a string tag when recording metrics. Measurements are aggregated in a persistent map which is printed out at the end of a build. This makes it easier to add new timers as you don't need to expose the timer object to the build command.

Sample output:
```
Memo graph: 2/280162 restored/computed nodes, 663573 traversed edges
Memo cycle detection graph: 52313/86840/73878 nodes/edges/paths
(52.23s total, 68.0M heap words)
Timers:
generic_digest - time spent = 0.19s, count = 34536
```