### PR TITLE
[RPC] Fix end-of-build reporting via [Progress]

### DIFF
--- a/src/dune_rpc_impl/import.ml
+++ b/src/dune_rpc_impl/import.ml
@@ -1,1 +1,8 @@
 module Dune_rpc = Dune_rpc_private
+
+let progress_of_build_event :
+    Dune_engine.Build_system.Handler.event -> Dune_rpc.Progress.t = function
+  | Start -> In_progress { complete = 0; remaining = 0 }
+  | Finish -> Success
+  | Interrupt -> Interrupted
+  | Fail -> Failed

--- a/src/dune_rpc_impl/long_poll.ml
+++ b/src/dune_rpc_impl/long_poll.ml
@@ -1,6 +1,6 @@
 open! Stdune
 open Dune_rpc_server
-module Dune_rpc = Dune_rpc_private
+open Import
 module Poll_comparable = Comparable.Make (Poller)
 module Poll_map = Poll_comparable.Map
 
@@ -46,8 +46,7 @@ module Instance = struct
       match T.Spec.on_rest_request poller s with
       | `Respond r ->
         T.waiters :=
-          Poll_map.set !T.waiters poller
-            (No_active_request (T.Spec.init_state ()));
+          Poll_map.set !T.waiters poller (No_active_request (T.Spec.reset ()));
         Fiber.return (Some r)
       | `Delay ->
         let ivar = Fiber.Ivar.create () in
@@ -98,13 +97,25 @@ module Build_system = Dune_engine.Build_system
 module Progress = struct
   module Progress = Dune_rpc.Progress
 
-  type state = unit
+  (* If [Some], this particular poller hasn't seen this update yet. *)
+  type state = Progress.t option
 
   type response = Progress.t
 
   type update = Progress.t
 
-  let init_state () = ()
+  (* Certain progress states are expected to be "transient", i.e., a new update
+     is expected to come soon. In those cases, it's okay to `Delay any new polls
+     until that update arrives. However, the build system will also spend a lot
+     of time on certain "final states" (namely, Failure and Success), *)
+  let is_transient : Progress.t -> bool = function
+    | Progress.Waiting
+    | Interrupted
+    | In_progress _ ->
+      true
+    | Success
+    | Failed ->
+      false
 
   let current () : Progress.t =
     let p = Build_system.get_current_progress () in
@@ -115,9 +126,22 @@ module Progress = struct
       let remaining = Build_system.Progress.remaining p in
       In_progress { complete; remaining }
 
-  let on_rest_request _poller () = `Delay
+  let init_state () =
+    match Build_system.last_event () with
+    | Some evt -> Some (progress_of_build_event evt)
+    | None -> Some (current ())
 
-  let on_update_inactive _ () = None
+  let reset _ = None
+
+  let on_rest_request _poller = function
+    | None -> `Delay
+    | Some last_event ->
+      if is_transient last_event then
+        `Delay
+      else
+        `Respond last_event
+
+  let on_update_inactive evt _ = Some (Some evt)
 
   let on_update_waiting u = u
 end
@@ -174,6 +198,8 @@ module Diagnostic = struct
            Diagnostic.Event.Add (Diagnostics.diagnostic_of_error e))
 
   let init_state () = Pending_diagnostics.empty
+
+  let reset () = init_state ()
 
   let on_rest_request _poller pd =
     if Pending_diagnostics.is_empty pd then

--- a/src/dune_rpc_impl/poll_spec.ml
+++ b/src/dune_rpc_impl/poll_spec.ml
@@ -13,6 +13,9 @@ module type S = sig
   (** initialize a new state for a waiting client *)
   val init_state : unit -> state
 
+  (** called after the state is used to produce a response *)
+  val reset : unit -> state
+
   (** subsequent request by a long poller. may be delayed until the next update *)
   val on_rest_request :
     Dune_rpc_server.Poller.t -> state -> [ `Delay | `Respond of response ]

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -1,7 +1,7 @@
 open! Stdune
 open Fiber.O
 open Dune_rpc_server
-module Dune_rpc = Dune_rpc_private
+open Import
 module Initialize = Dune_rpc.Initialize
 module Public = Dune_rpc.Public
 module Versioned = Dune_rpc.Versioned
@@ -293,13 +293,6 @@ let error t errors =
   let t = Fdecl.get t in
   task t (fun () ->
       Long_poll.Instance.update (Long_poll.diagnostic t.long_poll) errors)
-
-let progress_of_build_event : Build_system.Handler.event -> Progress.t =
-  function
-  | Start -> Progress.In_progress { complete = 0; remaining = 0 }
-  | Finish -> Success
-  | Interrupt -> Interrupted
-  | Fail -> Failed
 
 let build_progress t ~complete ~remaining =
   let t = Fdecl.get t in


### PR DESCRIPTION
This fixes the issues with end-of-build progress reporting over the RPC.

First, the final `Success` event is often dropped. This is due to that event being sent in quick succession to the last progress event (in which `remaining` is 0) being sent -- any active long poll requests will receive the `In_progress` event, then there's a very narrow window for a new request to arrive before the `Success`. In most cases I could try, even with tight scheduling control, the `Success` was always being sent to zero waiting clients, and any subsequent polls hit the next issue.

Secondly, progress updates are edge-triggered, meaning that they are only sent out when the value is changed. This means that if a request arrives during a time where the build status is the same for a long time (i.e., when the build has completed or failed), it will stall until the build is restarted, which is pretty unfriendly.

This PR fixes both issues by marking the long-lived progress states with whether a given session has seen it, and sending it if not ("one-time level trigger").

Signed-off-by: Cameron Wong <cwong@janestreet.com>