### PR TITLE
[rpc] Fix registry paths

### DIFF
--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -69,7 +69,17 @@ let run config stats =
                        in
                        let dune =
                          let pid = Unix.getpid () in
-                         Registry.Dune.create ~where:t.where ~root:t.root ~pid
+                         let where =
+                           match t.where with
+                           | `Ip (host, port) -> `Ip (host, port)
+                           | `Unix a ->
+                             `Unix
+                               (if Filename.is_relative a then
+                                 Filename.concat (Sys.getcwd ()) a
+                               else
+                                 a)
+                         in
+                         Registry.Dune.create ~where ~root:t.root ~pid
                        in
                        Registry.Config.register registry_config dune
                      in

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -108,11 +108,20 @@ let%expect_test "turn on dune watch and wait until the connection is listed" =
     | None -> printfn "[FAILURE] unable to find connection"
     | Some dune ->
       let root = Registry.Dune.root dune in
-      let where = Where.to_string (Registry.Dune.where dune) in
-      printfn "[PASS] found %s at %s" root where
+      let where =
+        match Registry.Dune.where dune with
+        | `Ip (host, port) -> `Ip (host, port)
+        | `Unix path ->
+          let cwd = Sys.getcwd () in
+          `Unix
+            (match String.drop_prefix path ~prefix:cwd with
+            | None -> path
+            | Some s -> "$CWD" ^ s)
+      in
+      printfn "[PASS] found %s at %s" root (Where.to_string where)
   in
   run case;
   [%expect
     {|
     $PATH/dune build --passive-watch-mode --root . returned 1
-    [PASS] found . at unix:path=_build/.rpc/dune |}]
+    [PASS] found . at unix:path=%24CWD/_build/.rpc/dune |}]

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -1,5 +1,6 @@
 open Stdune
 open Fiber.O
+module Where = Dune_rpc_private.Where
 module Registry = Dune_rpc_private.Registry
 module Scheduler = Dune_engine.Scheduler
 open Dune_rpc_e2e
@@ -107,10 +108,11 @@ let%expect_test "turn on dune watch and wait until the connection is listed" =
     | None -> printfn "[FAILURE] unable to find connection"
     | Some dune ->
       let root = Registry.Dune.root dune in
-      printfn "[PASS] found %s" root
+      let where = Where.to_string (Registry.Dune.where dune) in
+      printfn "[PASS] found %s at %s" root where
   in
   run case;
   [%expect
     {|
     $PATH/dune build --passive-watch-mode --root . returned 1
-    [PASS] found . |}]
+    [PASS] found . at unix:path=_build/.rpc/dune |}]


### PR DESCRIPTION
Always print socket paths as absolute