### PR TITLE
Fix #4433

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- The OCaml compiler is now optional in workspaces that do not invoke it. This
+  is mainly useful for pure coq projects. (#4964, fix #4433, @rgrinberg)
+
 - Fix `foreign_stubs` inside a `tests` stanza. Previously, dune would crash
   when this field was present (#4942, fix #4946, @rgrinberg)
 

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -566,8 +566,9 @@ let install_uninstall ~what =
               let conf =
                 Dune_rules.Artifact_substitution.conf_for_install ~relocatable
                   ~default_ocamlpath:context.default_ocamlpath
-                  ~stdlib_dir:context.stdlib_dir ~prefix ~libdir ~mandir ~docdir
-                  ~etcdir
+                  ~stdlib_dir:
+                    (Result.ok_exn context.lib_config.ocaml).stdlib_dir ~prefix
+                  ~libdir ~mandir ~docdir ~etcdir
               in
               Fiber.sequential_iter entries_per_package
                 ~f:(fun (package, entries) ->

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -335,6 +335,8 @@ let create_from_inside_dune ~dest_dir ~log ~build_dir ~name =
     | None -> Temp.create_temp_dir ~prefix:"ocaml-configurator" ~suffix:""
   in
   let { ocamlc; vars = ocamlc_config } =
+    (* TODO don't read this stuff so eagerly. We should at least try to work if
+       ocamlc is absent *)
     read_dot_dune_configurator_file ~build_dir
   in
   let ocamlc_config_cmd = Process.command_line ocamlc [ "-config" ] in

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -30,7 +30,9 @@ module Prog = struct
       in
       Utils.program_not_found_message ?hint ~loc ~context program
 
-    let raise t = raise (User_error.E (user_message t, []))
+    let to_exn t = User_error.E (user_message t, [])
+
+    let raise t = raise (to_exn t)
 
     let to_dyn { context; program; hint; loc = _ } =
       let open Dyn.Encoder in

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -40,6 +40,8 @@ module Prog : sig
 
     val raise : t -> _
 
+    val to_exn : t -> exn
+
     val user_message : t -> User_message.t
   end
 

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -61,9 +61,11 @@ let conf_of_context (context : Context.t option) =
     }
   | Some context ->
     let get_location = Install.Section.Paths.get_local_location context.name in
-    let get_config_path = function
-      | Sourceroot -> Some (Path.source Path.Source.root)
-      | Stdlib -> Some context.stdlib_dir
+    let get_config_path t =
+      Some
+        (match t with
+        | Sourceroot -> Path.source Path.Source.root
+        | Stdlib -> (Result.ok_exn context.lib_config.ocaml).stdlib_dir)
     in
     let hardcoded_ocaml_path =
       let install_dir = Local_install_path.dir ~context:context.name in

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -99,4 +99,6 @@ val bin_annot : t -> bool
 
 val without_bin_annot : t -> t
 
+val ocaml_lib_config : t -> Lib_config.ocaml
+
 val root_module_entries : t -> Module_name.t list Action_builder.t

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -72,9 +72,9 @@ type t = private
   ; path : Path.t list  (** [OCAML_TOPLEVEL_PATH] *)
   ; toplevel_path : Path.t option
         (** Ocaml bin directory with all ocaml tools *)
-  ; ocaml_bin : Path.t
+  ; ocaml_bin : Path.t Or_exn.t
   ; ocaml : Action.Prog.t
-  ; ocamlc : Path.t
+  ; ocamlc : Action.Prog.t
   ; ocamlopt : Action.Prog.t
   ; ocamldep : Action.Prog.t
   ; ocamlmklib : Action.Prog.t
@@ -83,11 +83,9 @@ type t = private
   ; findlib : Findlib.t
   ; findlib_toolchain : Context_name.t option  (** Misc *)
   ; default_ocamlpath : Path.t list
-  ; arch_sixtyfour : bool
-  ; ocaml_config : Ocaml_config.t
-  ; ocaml_config_vars : Ocaml_config.Vars.t
-  ; version : Ocaml_version.t
-  ; stdlib_dir : Path.t
+  ; arch_sixtyfour : bool Or_exn.t
+  ; ocaml_config : Ocaml_config.t Or_exn.t
+  ; ocaml_config_vars : Ocaml_config.Vars.t Or_exn.t
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; which : string -> Path.t option Memo.Build.t
         (** Given a program name, e.g. ["ocaml"], find the path to a preferred

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -18,7 +18,7 @@ CCOMP
 
 let rules ~sctx ~dir =
   let file = Path.Build.relative dir Cxx_flags.preprocessed_filename in
-  let ocfg = (Super_context.context sctx).ocaml_config in
+  let ocfg = Result.ok_exn (Super_context.context sctx).ocaml_config in
   let open Memo.Build.O in
   let* prog =
     Super_context.resolve_program sctx ~dir ~loc:None

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -51,9 +51,10 @@ end = struct
 
   let write oc ~(context : Context.t) ~target ~exec_dir ~plugin ~plugin_contents
       =
+    let ocaml_config = Result.ok_exn context.ocaml_config in
     let ocamlc_config =
       let vars =
-        Ocaml_config.to_list context.ocaml_config
+        Ocaml_config.to_list ocaml_config
         |> List.map ~f:(fun (k, v) -> (k, Ocaml_config.Value.to_string v))
       in
       let longest = String.longest_map vars ~f:fst in
@@ -68,7 +69,7 @@ end = struct
         let ocamlc_config = [ %s ]
         |}
         (Context_name.to_string context.name)
-        (Ocaml_config.version_string context.ocaml_config)
+        (Ocaml_config.version_string ocaml_config)
         (Path.reach ~from:exec_dir (Path.build target))
         ocamlc_config
     in

--- a/src/dune_rules/env_node.mli
+++ b/src/dune_rules/env_node.mli
@@ -25,7 +25,8 @@ val make :
   -> profile:Profile.t
   -> expander:Expander.t Memo.Lazy.t
   -> expander_for_artifacts:Expander.t Memo.Lazy.t
-  -> default_context_flags:string list Action_builder.t Foreign_language.Dict.t
+  -> default_context_flags:
+       string list Action_builder.t Foreign_language.Dict.t Memo.Lazy.t
   -> default_env:Env.t
   -> default_bin_artifacts:Artifacts.Bin.t
   -> t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -172,7 +172,8 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       ~modules ~flags ~requires_link ~requires_compile ~preprocessing:pp
       ~js_of_ocaml ~opaque:Inherit_from_settings ~package:exes.package
   in
-  let stdlib_dir = ctx.Context.stdlib_dir in
+  let lib_config = Result.ok_exn ctx.lib_config.ocaml in
+  let stdlib_dir = lib_config.stdlib_dir in
   let* requires_compile = Compilation_context.requires_compile cctx in
   let* preprocess =
     Resolve.Build.read_memo_build
@@ -195,7 +196,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       Command.Args.S
         [ Command.Args.As flags
         ; Command.Args.S
-            (let ext_lib = ctx.lib_config.ext_lib in
+            (let ext_lib = lib_config.ext_lib in
              let foreign_archives =
                exes.buildable.foreign_archives |> List.map ~f:snd
              in

--- a/src/dune_rules/fdo.ml
+++ b/src/dune_rules/fdo.ml
@@ -190,10 +190,12 @@ module Linker_script = struct
     match ctx.fdo_target_exe with
     | None -> None
     | Some fdo_target_exe ->
+      let ocaml_version = (CC.ocaml_lib_config cctx).ocaml_version in
+      let ocaml_config = Result.ok_exn ctx.ocaml_config in
       if
         Path.equal name fdo_target_exe
-        && (Ocaml_version.supports_function_sections ctx.version
-           || Ocaml_config.is_dev_version ctx.ocaml_config)
+        && (Ocaml_version.supports_function_sections ocaml_version
+           || Ocaml_config.is_dev_version ocaml_config)
       then
         Some (linker_script_rule cctx fdo_target_exe)
       else

--- a/src/dune_rules/findlib/findlib.mli
+++ b/src/dune_rules/findlib/findlib.mli
@@ -8,7 +8,7 @@ type t
 
 val meta_fn : string
 
-val create : paths:Path.t list -> lib_config:Lib_config.t -> t
+val create : paths:Path.t list -> lib_config:Lib_config.ocaml Or_exn.t -> t
 
 (** The search path for this DB *)
 val paths : t -> Path.t list

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -159,7 +159,9 @@ let make (d : _ Dir_with_dune.t) ~(sources : Foreign.Sources.Unresolved.t)
         ]
       |> List.concat_map ~f:(fun sources ->
              String.Map.to_list_map sources ~f:(fun _ (loc, source) ->
-                 (Foreign.Source.object_name source ^ lib_config.ext_obj, loc)))
+                 ( Foreign.Source.object_name source
+                   ^ (Result.ok_exn lib_config.ocaml).ext_obj
+                 , loc )))
     in
     match String.Map.of_list objects with
     | Ok _ -> ()

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -131,7 +131,8 @@ end = struct
               in
               make_entry Lib source ?dst))
     in
-    let { Lib_config.has_native; ext_obj; _ } = lib_config in
+    let has_native = lib_config.has_native in
+    let ext_obj = (Result.ok_exn lib_config.ocaml).ext_obj in
     let modes = Dune_file.Mode_conf.Set.eval lib.modes ~has_native in
     let { Mode.Dict.byte; native } = modes in
     let module_files =
@@ -182,7 +183,11 @@ end = struct
           other_cm_files)
     in
     let* lib_files, dll_files =
-      let+ lib_files = lib_files ~dir ~dir_contents ~lib_config info in
+      let+ lib_files =
+        lib_files ~dir ~dir_contents
+          ~lib_config:(Result.ok_exn lib_config.ocaml)
+          info
+      in
       let dll_files = dll_files ~modes ~dynlink:lib.dynlink ~ctx info in
       (lib_files, dll_files)
     in
@@ -473,7 +478,7 @@ end = struct
               foreign_sources
               |> Foreign_sources.for_lib ~name
               |> Foreign.Sources.object_files ~dir
-                   ~ext_obj:ctx.lib_config.ext_obj
+                   ~ext_obj:(Result.ok_exn ctx.lib_config.ocaml).ext_obj
               |> List.map ~f:Path.build
             and* modules =
               Dir_contents.ocaml dir_contents

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -13,7 +13,7 @@ val to_dyn : t -> Dyn.t
     or the [name] if not. *)
 val name : t -> Lib_name.t
 
-val lib_config : t -> Lib_config.t
+val lib_config : t -> Lib_config.ocaml
 
 val implements : t -> t Resolve.Build.t option
 
@@ -111,7 +111,7 @@ module Lib_and_module : sig
     val of_libs : lib list -> t
 
     val link_flags :
-      t -> lib_config:Lib_config.t -> mode:Link_mode.t -> _ Command.Args.t
+      t -> lib_config:Lib_config.ocaml -> mode:Link_mode.t -> _ Command.Args.t
   end
 end
 with type lib := t

--- a/src/dune_rules/lib_config.mli
+++ b/src/dune_rules/lib_config.mli
@@ -1,30 +1,34 @@
 open! Dune_engine
 open Stdune
 
-type t =
-  { has_native : bool
-  ; ext_lib : string
+type ocaml =
+  { ext_lib : string
   ; ext_obj : string
   ; os_type : Ocaml_config.Os_type.t
   ; architecture : string
   ; system : string
   ; model : string  (** Native dynlink *)
-  ; natdynlink_supported : Dynlink_supported.By_the_os.t
   ; ext_dll : string
   ; stdlib_dir : Path.t
   ; ccomp_type : Ocaml_config.Ccomp_type.t
-  ; profile : Profile.t
   ; ocaml_version_string : string
   ; ocaml_version : Ocaml_version.t
+  }
+
+type t =
+  { has_native : bool
+  ; natdynlink_supported : Dynlink_supported.By_the_os.t
+  ; profile : Profile.t
   ; instrument_with : Lib_name.t list
   ; context_name : Context_name.t
+  ; ocaml : ocaml Or_exn.t
   }
 
 val allowed_in_enabled_if : (string * Dune_lang.Syntax.Version.t) list
 
-val get_for_enabled_if : t -> Pform.t -> string
+val get_for_enabled_if : t -> Pform.t -> string Or_exn.t
 
-val linker_can_create_empty_archives : t -> bool
+val linker_can_create_empty_archives : ocaml -> bool
 
 val hash : t -> int
 

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -162,7 +162,7 @@ let build_info_code cctx ~libs ~api_version =
         (Lib.name lib, v))
   in
   let context = CC.context cctx in
-  let ocaml_version = Ocaml_version.of_ocaml_config context.ocaml_config in
+  let ocaml_version = (Result.ok_exn context.lib_config.ocaml).ocaml_version in
   let buf = Buffer.create 1024 in
   (* Parse the replacement format described in [artifact_substitution.ml]. *)
   pr buf "let eval s =";
@@ -301,7 +301,7 @@ let handle_special_libs cctx =
             if plugins then
               Action_builder.return
                 (dune_site_plugins_code ~libs:all_libs
-                   ~builtins:(Findlib.builtins ctx.Context.findlib))
+                   ~builtins:(Findlib.builtins ctx.findlib))
             else
               Action_builder.return (dune_site_code ())
           in

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -305,7 +305,8 @@ module Unprocessed = struct
     let scope = Expander.scope expander in
     match
       Preprocess.remove_future_syntax preprocess ~for_:Merlin
-        (Super_context.context sctx).version
+        (Result.ok_exn (Super_context.context sctx).lib_config.ocaml)
+          .ocaml_version
     with
     | Action (loc, (action : Action_dune_lang.t)) ->
       pp_flag_of_action ~expander ~loc ~action

--- a/src/dune_rules/ocamlobjinfo.mll
+++ b/src/dune_rules/ocamlobjinfo.mll
@@ -44,14 +44,15 @@ let rules ~dir ~(ctx : Context.t) ~unit =
     Path.Build.relative dir (Path.basename unit)
     |> Path.Build.extend_basename ~suffix:".ooi-deps"
   in
+  let version = (Result.ok_exn ctx.lib_config.ocaml).ocaml_version in
   let no_approx =
-    if Ocaml_version.ooi_supports_no_approx ctx.version then
+    if Ocaml_version.ooi_supports_no_approx version then
       [Command.Args.A "-no-approx"]
     else
       []
   in
   let no_code =
-    if Ocaml_version.ooi_supports_no_code ctx.version then
+    if Ocaml_version.ooi_supports_no_code version then
       [Command.Args.A "-no-code"]
     else
       []

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -599,7 +599,8 @@ let make sctx ~dir ~expander ~lint ~preprocess ~preprocessor_deps
   let preprocess =
     Module_name.Per_item.map preprocess ~f:(fun pp ->
         Preprocess.remove_future_syntax ~for_:Compiler pp
-          (Super_context.context sctx).version)
+          (Result.ok_exn (Super_context.context sctx).lib_config.ocaml)
+            .ocaml_version)
   in
   let preprocessor_deps =
     Dep_conf_eval.unnamed preprocessor_deps ~expander

--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -10,4 +10,5 @@
 
 (cram
  (applies_to :whole_subtree)
+ (deps %{bin:coqc} %{bin:coqdep})
  (alias all-coq-tests))

--- a/test/blackbox-tests/test-cases/coq/without-ocamlc.t
+++ b/test/blackbox-tests/test-cases/coq/without-ocamlc.t
@@ -1,0 +1,28 @@
+Dune should build coq projects even if ocamlc is absent
+
+First, we hide everything except for coq, dune, and cat (because it's required for cram)
+
+  $ mkdir _bin
+  $ ln -s $(command -v coqc) _bin/coqc
+  $ ln -s $(command -v coqdep) _bin/coqdep
+  $ DUNE_DIR=$(dirname $(command -v dune))
+  $ CAT_DIR=$(dirname $(command -v cat))
+  $ export PATH=$PWD/_bin:$DUNE_DIR:$CAT_DIR
+
+Now we create a dummy coq project
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.0)
+  > (using coq 0.3)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (coq.theory
+  >  (name basic)
+  >  (modules :standard)
+  >  (synopsis "Test Coq library"))
+  > EOF
+
+And then make sure it builds
+
+  $ dune build @all

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -19,26 +19,21 @@ let print_pkg ppf pkg =
   Format.fprintf ppf "<package:%s>" (Lib_name.to_string name)
 
 let findlib =
-  let lib_config : Lib_config.t =
-    { has_native = true
-    ; ext_lib = ".a"
+  let lib_config : Lib_config.ocaml =
+    { Lib_config.ext_lib = ".a"
     ; ext_obj = ".o"
     ; os_type = Ocaml_config.Os_type.Other ""
     ; architecture = ""
     ; system = ""
     ; model = ""
-    ; natdynlink_supported = Dynlink_supported.By_the_os.of_bool true
     ; ext_dll = ".so"
     ; stdlib_dir = Path.root
     ; ccomp_type = Other "gcc"
-    ; profile = Profile.Dev
     ; ocaml_version_string = "4.02.3"
     ; ocaml_version = Ocaml_version.make (4, 2, 3)
-    ; instrument_with = []
-    ; context_name = Context_name.of_string "default"
     }
   in
-  Findlib.create ~paths:[ db_path ] ~lib_config
+  Findlib.create ~paths:[ db_path ] ~lib_config:(Ok lib_config)
 
 let%expect_test _ =
   let pkg =


### PR DESCRIPTION
Delay loading `ocamlc -config` just enough to allow trivial coq projects to build.  This patch is quite hacky just because its takes far too much effort to delay the errors correctly everywhere. Nevertheless, I delayed things enough to make it possible to build a trivial coq only project.