### PR TITLE
Fix watch mode with fswatch

### DIFF
--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -1271,6 +1271,22 @@ module Source = struct
   let is_in_build_dir s = is_in_build_dir (path_of_local s)
 
   let to_local t = t
+
+  let drop_absolute_prefix ~prefix p =
+    match String.drop_prefix ~prefix:(Kind.to_absolute_filename prefix) p with
+    | None -> None
+    | Some "" -> Some Local.root
+    | Some p ->
+      Some
+        (Local.of_string
+           (if is_dir_sep p.[0] then
+             String.drop p 1
+           else
+             p))
+
+  let of_external p =
+    let p = External.to_string p in
+    drop_absolute_prefix ~prefix:(Kind.In_source_dir Local.root) p
 end
 
 let set_of_source_paths set =

--- a/otherlibs/stdune-unstable/path.mli
+++ b/otherlibs/stdune-unstable/path.mli
@@ -70,6 +70,18 @@ module Local : sig
   val explode : t -> string list
 end
 
+module External : sig
+  include Path_intf.S
+
+  val initial_cwd : t
+
+  val cwd : unit -> t
+
+  val relative : t -> string -> t
+
+  val mkdir_p : ?perms:int -> t -> unit
+end
+
 (** In the source section of the current workspace. *)
 module Source : sig
   type w
@@ -99,18 +111,8 @@ module Source : sig
   val descendant : t -> of_:t -> t option
 
   val to_local : t -> Local.t
-end
 
-module External : sig
-  include Path_intf.S
-
-  val initial_cwd : t
-
-  val cwd : unit -> t
-
-  val relative : t -> string -> t
-
-  val mkdir_p : ?perms:int -> t -> unit
+  val of_external : External.t -> t option
 end
 
 module Permissions : sig

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -336,7 +336,14 @@ let create_no_buffering ~(scheduler : Scheduler.t) ~root ~backend =
                 match parse_line line with
                 | Error s -> failwith s
                 | Ok path_s ->
-                  let path = Path.of_string path_s in
+                  let path =
+                    match Path.of_string path_s with
+                    | (In_source_tree _ | In_build_dir _) as p -> p
+                    | External e as p -> (
+                      match Path.Source.of_external e with
+                      | None -> p
+                      | Some e -> Path.source e)
+                  in
                   if is_special_file_for_inotify_sync path then
                     [ Event.Sync ]
                   else


### PR DESCRIPTION
Fsevents on macos (and possibly elsewhere?) returns absolute paths. We
should try to convert them to source paths whenever possible.