### PR TITLE
Test that shows the environment binaries not properly set up for cram tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+- Fix interpretation of `binaries` defined in the `env stanza`. Binaries
+  defined in `x/dune` wouldn't be visible in `x/*/**/dune. (#4975,
+  @Leonidas-from-XIV, @rgrinberg)
+
 - Do not list private libraries in package listings (#4945, fixes #4799,
   @rgrinberg)
 

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -77,17 +77,14 @@ let make ~dir ~inherit_from ~scope ~config_stanza ~profile ~expander
         | Some x -> Memo.Build.return x)
   in
   let local_binaries =
-    inherited ~field:local_binaries ~root:[] (fun binaries ->
-        let+ expanded =
-          Memo.Build.sequential_map config.binaries
-            ~f:
-              (File_binding.Unexpanded.expand ~dir ~f:(fun template ->
-                   let* expander_for_artifacts =
-                     Memo.Lazy.force expander_for_artifacts
-                   in
-                   Expander.No_deps.expand_str expander_for_artifacts template))
-        in
-        binaries @ expanded)
+    Memo.lazy_ (fun () ->
+        Memo.Build.sequential_map config.binaries
+          ~f:
+            (File_binding.Unexpanded.expand ~dir ~f:(fun template ->
+                 let* expander_for_artifacts =
+                   Memo.Lazy.force expander_for_artifacts
+                 in
+                 Expander.No_deps.expand_str expander_for_artifacts template)))
   in
   let external_env =
     inherited ~field:external_env ~root:default_env (fun env ->

--- a/test/blackbox-tests/test-cases/cram/env-binaries.t
+++ b/test/blackbox-tests/test-cases/cram/env-binaries.t
@@ -23,8 +23,7 @@ First we test case where the cram stanza is one level below
   $ mkdir tests
   $ cat >tests/run.t <<EOF
   >   $ helper
-  >   helper: command not found
-  >   [127]
+  >   Helper launched successfully
   > EOF
   $ printf "%s\n" $test_stanza > tests/dune
   $ printf "%s\n" $env_stanza > dune
@@ -39,11 +38,3 @@ env stanza:
   $ rm -r tests/
 
   $ dune runtest
-  File "run.t", line 1, characters 0-0:
-  Error: Files _build/default/run.t and _build/default/run.t.corrected differ.
-  [1]
-  $ dune promote
-  Promoting _build/default/run.t.corrected to run.t.
-  $ cat run.t
-    $ helper
-    Helper launched successfully

--- a/test/blackbox-tests/test-cases/cram/env-binaries.t
+++ b/test/blackbox-tests/test-cases/cram/env-binaries.t
@@ -1,0 +1,49 @@
+Cram and private binaries from the env stanza
+
+  $ mkdir fresh && cd fresh
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.8)
+  > (cram enable)
+  > EOF
+
+  $ mkdir helper
+  $ cat >helper/dune <<EOF
+  > (executable (name helper))
+  > EOF
+  $ cat >helper/helper.ml <<EOF
+  > print_endline "Helper launched successfully";;
+  > EOF
+
+  $ env_stanza="(env (_ (binaries (helper/helper.exe as helper))))"
+  $ test_stanza="(cram (deps %{bin:helper}))"
+
+First we test case where the cram stanza is one level below
+
+  $ mkdir tests
+  $ cat >tests/run.t <<EOF
+  >   $ helper
+  >   helper: command not found
+  >   [127]
+  > EOF
+  $ printf "%s\n" $test_stanza > tests/dune
+  $ printf "%s\n" $env_stanza > dune
+
+  $ dune runtest
+
+Next, we test the case where the cram stanza is in the same directory as the
+env stanza:
+
+  $ printf "%s\n%s\n" $env_stanza $test_stanza > dune
+  $ mv tests/run.t ./
+  $ rm -r tests/
+
+  $ dune runtest
+  File "run.t", line 1, characters 0-0:
+  Error: Files _build/default/run.t and _build/default/run.t.corrected differ.
+  [1]
+  $ dune promote
+  Promoting _build/default/run.t.corrected to run.t.
+  $ cat run.t
+    $ helper
+    Helper launched successfully


### PR DESCRIPTION
This test shows how declaring a helper binary in a higher-up level `dune` file doesn't work.

If checking `$PATH` in the cram test it prints `_build/default/test/blackbox-tests/test-cases/cram-env-binaries/.bin` in the very front of the path, so the place where the binaries would be symlinked to is prepared, but launching the test leads to failure because that folder is not actually created.

Moving the `env` stanza into the leaf dune file (and adjusting the path with `..`) makes it work, but causes a lot of verbosity if this stanza would need to be repeated in multiple subfolders with cram tests that use the helper binary.