### PR TITLE
fix: sync events for fswatch

### DIFF
--- a/otherlibs/stdune-unstable/path.mli
+++ b/otherlibs/stdune-unstable/path.mli
@@ -111,8 +111,6 @@ module Source : sig
   val descendant : t -> of_:t -> t option
 
   val to_local : t -> Local.t
-
-  val of_external : External.t -> t option
 end
 
 module Permissions : sig
@@ -401,3 +399,11 @@ val chmod : t -> mode:int -> unit
 
 (** Attempts to resolve a symlink. Returns [None] if the path isn't a symlink *)
 val follow_symlink : t -> (t, Fpath.follow_symlink_error) result
+
+module Expert : sig
+  (** Attempt to convert external paths to source/build paths. Don't use this
+      function unless strictly necessary. It's not completely reliable and we
+      only use it out of necessity to work with file watchers that insist on
+      spitting absolute paths *)
+  val try_localize_external : t -> t
+end

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -337,12 +337,7 @@ let create_no_buffering ~(scheduler : Scheduler.t) ~root ~backend =
                 | Error s -> failwith s
                 | Ok path_s ->
                   let path =
-                    match Path.of_string path_s with
-                    | (In_source_tree _ | In_build_dir _) as p -> p
-                    | External e as p -> (
-                      match Path.Source.of_external e with
-                      | None -> p
-                      | Some e -> Path.source e)
+                    Path.Expert.try_localize_external (Path.of_string path_s)
                   in
                   if is_special_file_for_inotify_sync path then
                     [ Event.Sync ]


### PR DESCRIPTION
To receive sync events, we must try to parse build paths.

Note that this changes nothing functionally as sync events are only used for the tests. Nevertheless, I think we should stay on the safe side and keep the watchers as consistent as possible.