### PR TITLE
FSEvents: multiple watchers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- In watch mode, use fsevents instead of fswatch on OSX (#4937, #4990, fixes
+  #4896 @rgrinberg)
+
 - Report cycles between virtual libraries and their implementation (#5050,
   fixes #2896, @rgrinberg)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Unreleased
 - In watch mode, use fsevents instead of fswatch on OSX (#4937, #4990, fixes
   #4896 @rgrinberg)
 
+- Remove `inotifywait` watch mode backend on Linux. We now use the inotify API
+  exclusively (#4941, @rgrinberg)
+
 - Report cycles between virtual libraries and their implementation (#5050,
   fixes #2896, @rgrinberg)
 

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -31,8 +31,9 @@ let t_ref = ref (Initialization_state.Uninitialized [])
    root is not sufficient to receive events for creation of "root/a/b/c/d".
    (however, subscribing to "root/a/b/c" is sufficient for that) *)
 let watch_path dune_file_watcher path =
-  try Dune_file_watcher.add_watch dune_file_watcher path with
-  | Unix.Unix_error (ENOENT, _, _) -> (
+  match Dune_file_watcher.add_watch dune_file_watcher path with
+  | Ok () -> ()
+  | Error `Does_not_exist -> (
     (* If we're at the root of the workspace (or the unix root) then we can't
        get ENOENT because dune can't start without a workspace and unix root
        always exists, so this [_exn] can't raise (except if the user delets the
@@ -42,9 +43,17 @@ let watch_path dune_file_watcher path =
        the parent. We still try to add a watch for the file itself after that
        succeeds, in case the file was created already before we started watching
        its parent. *)
-    Dune_file_watcher.add_watch dune_file_watcher containing_dir;
-    try Dune_file_watcher.add_watch dune_file_watcher path with
-    | Unix.Unix_error (ENOENT, _, _) -> ())
+    (match Dune_file_watcher.add_watch dune_file_watcher containing_dir with
+    | Ok () -> ()
+    | Error `Does_not_exist ->
+      Log.info
+        [ Pp.textf "attempted to add watch to non-existant directory %s"
+            (Path.to_string containing_dir)
+        ]);
+    match Dune_file_watcher.add_watch dune_file_watcher path with
+    | Error `Does_not_exist
+    | Ok () ->
+      ())
 
 let watch_path_using_ref path =
   match !t_ref with

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -72,7 +72,7 @@ val wait_for_initial_watches_established_blocking : t -> unit
     far. *)
 val emit_sync : unit -> unit
 
-val add_watch : t -> Path.t -> unit
+val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
 
 (** Ignore the ne next file change event about this file. *)
 val ignore_next_file_change_event : t -> Path.t -> unit

--- a/src/fsevents/bin/dune_fsevents.ml
+++ b/src/fsevents/bin/dune_fsevents.ml
@@ -8,8 +8,13 @@ let paths, latency =
   (!paths, !latency)
 
 let fsevents =
-  Fsevents.create ~paths ~latency ~f:(fun _ events ->
+  Fsevents.create ~paths ~latency ~f:(fun events ->
       ListLabels.iter events ~f:(fun evt ->
           Printf.printf "%s\n%!" (Dyn.to_string (Fsevents.Event.to_dyn_raw evt))))
 
-let () = Fsevents.start fsevents
+let () =
+  let runloop = Fsevents.RunLoop.in_current_thread () in
+  Fsevents.start fsevents runloop;
+  match Fsevents.RunLoop.run_current_thread runloop with
+  | Ok () -> ()
+  | Error e -> raise e

--- a/src/fsevents/dune
+++ b/src/fsevents/dune
@@ -6,4 +6,4 @@
  (foreign_stubs
   (language c)
   (names fsevents_stubs))
- (libraries dyn stdune))
+ (libraries dyn threads.posix stdune))

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -36,7 +36,9 @@ let%expect_test _ =
               | Watcher_terminated -> assert false)))
   in
   let print_events n = print_events ~try_to_get_events ~expected:n in
-  Dune_file_watcher.add_watch watcher (Path.of_string ".");
+  (match Dune_file_watcher.add_watch watcher (Path.of_string ".") with
+  | Error _ -> assert false
+  | Ok () -> ());
   Dune_file_watcher.wait_for_initial_watches_established_blocking watcher;
   Stdio.Out_channel.write_all "x" ~data:"x";
   print_events 2;
@@ -54,7 +56,9 @@ let%expect_test _ =
     { path = In_source_tree "y"; kind = "Created" }
 |}];
   let (_ : _) = Fpath.mkdir_p "d/w" in
-  Dune_file_watcher.add_watch watcher (Path.of_string "d/w");
+  (match Dune_file_watcher.add_watch watcher (Path.of_string "d/w") with
+  | Error _ -> assert false
+  | Ok () -> ());
   Stdio.Out_channel.write_all "d/w/x" ~data:"x";
   print_events 3;
   [%expect


### PR DESCRIPTION
Allow to create multiple fsevents watchers and receive all the events in one thread. This is a pre-req for watching external directories. 