### PR TITLE
fix(watch): track looked up binaries

### DIFF
--- a/otherlibs/stdune-unstable/bin.mli
+++ b/otherlibs/stdune-unstable/bin.mli
@@ -13,6 +13,9 @@ val cons_path : Path.t -> _PATH:string option -> string
 (** Extension to append to executable filenames *)
 val exe : string
 
+(** Adds an [.exe] suffix unless it is already present *)
+val add_exe : string -> string
+
 (** Check if a file exists *)
 val exists : Path.t -> bool
 


### PR DESCRIPTION
Now dune's watch mode will be responsive when binaries it uses changes.
Note: some basic binaries are exempt from this ($vcs, cygpath, bash, sh,
etc.)