### PR TITLE
Make restart reasons terser

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -63,15 +63,16 @@ module Scheduler = struct
     match dune_config.terminal_persistence with
     | Clear_on_rebuild -> Console.reset ()
     | Preserve ->
+      let message =
+        sprintf "********** NEW BUILD (%s) **********"
+          (String.concat ~sep:", " details_hum)
+      in
       Console.print_user_message
         (User_message.make
-           (List.map details_hum ~f:(fun reason_hum ->
-                Pp.tag User_message.Style.Details (Pp.verbatim reason_hum))
-           @ [ Pp.nop
-             ; Pp.tag User_message.Style.Success
-                 (Pp.verbatim "********** NEW BUILD **********")
-             ; Pp.nop
-             ]))
+           [ Pp.nop
+           ; Pp.tag User_message.Style.Success (Pp.verbatim message)
+           ; Pp.nop
+           ])
 
   let on_event dune_config _config = function
     | Scheduler.Run.Event.Tick -> Console.Status_line.refresh ()

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1431,7 +1431,7 @@ module Invalidation = struct
 
   let to_list t = to_list_x_xs t [] []
 
-  let details_hum ?(max_elements = 5) t =
+  let details_hum ?(max_elements = 1) t =
     assert (max_elements > 0);
     let details =
       List.filter_map ~f:Leaf.to_string_hum (to_list t)
@@ -1453,7 +1453,7 @@ module Invalidation = struct
           | true -> "s"
           | false -> ""
         in
-        sprintf " (plus %d more change%s)" remaining_details plural
+        sprintf ", and %d more change%s" remaining_details plural
       in
       match List.destruct_last truncated_details with
       | None -> assert false

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -214,7 +214,7 @@ module Invalidation : sig
   val invalidate_cache : reason:Reason.t -> _ memo -> t
 
   (** A list of human-readable strings explaining the reasons for invalidation.
-      The list is truncated to [max_elements] elements, with [max_elements = 5]
+      The list is truncated to [max_elements] elements, with [max_elements = 1]
       by default. Raises if [max_elements <= 0]. *)
   val details_hum : ?max_elements:int -> t -> string list
 end


### PR DESCRIPTION
As discussed on Slack, the list of restart reasons can sometimes make Dune's output overly verbose. At the same time, seeing some information about the reasons by default seems useful, e.g. to diagnose strange behaviour of other tools.

In this PR I'm changing the way we print out the restart reasons. I print at most one reason, and include it into the `NEW BUILD` line that we print anyway. Hopefully, this should give us the best of both worlds.

Here are some examples:

```
********** NEW BUILD (src/memo/memo.ml changed) **********
********** NEW BUILD (src/memo/memo.ml changed, and 1 more change) **********
********** NEW BUILD (src/memo/memo.ml changed, and 2 more changes) **********
```

I can imagine that someday we might want a flag to force Dune to print all reasons. I'll be lazy and keep this particular thunk unevaluated for now.