### PR TITLE
fix(menhir): sandbox infer rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Sandbox infer rules for menhir. Fixes possible "inconsistent assumptions"
+  errors (#5015, @rgrinberg)
+
 - Experimental support for ctypes stubs (#3905, fixes #135, @mbacarella)
 
 - Fix interpretation of `binaries` defined in the `env stanza`. Binaries

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -104,6 +104,8 @@ let js_of_ocaml t = t.js_of_ocaml
 
 let sandbox t = t.sandbox
 
+let set_sandbox t sandbox = { t with sandbox }
+
 let package t = t.package
 
 let vimpl t = t.vimpl

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -79,6 +79,8 @@ val js_of_ocaml : t -> Dune_file.Js_of_ocaml.t option
 
 val sandbox : t -> Sandbox_config.t
 
+val set_sandbox : t -> Sandbox_config.t -> t
+
 val package : t -> Package.t option
 
 val vimpl : t -> Vimpl.t option

--- a/src/dune_rules/menhir.ml
+++ b/src/dune_rules/menhir.ml
@@ -204,7 +204,10 @@ module Run (P : PARAMS) = struct
         (Compilation_context.preprocessing cctx)
         name mock_module ~lint:false
     in
-    let cctx = Compilation_context.without_bin_annot cctx in
+    let cctx =
+      Compilation_context.set_sandbox cctx Sandbox_config.needs_sandboxing
+      |> Compilation_context.without_bin_annot
+    in
     let* deps = Dep_rules.for_module cctx mock_module in
     let* () =
       Module_compilation.ocamlc_i ~deps cctx mock_module


### PR DESCRIPTION
Infer rules should not observe any modules not listed as dependencies.
This can lead to "inconsistent assumptions" errors.

The issue can be reproduced by:

1. cloning this repo `https://github.com/andreypopp/type-systems`
2. running `$ dune build`
3. editing `syntax.ml` (any edit will do)
4. re-running `$ dune build`.

You will observe the following error:
```
File "hmx/parser__mock.ml.mock", line 1:
Error: The files hmx/.hmx.objs/byte/hmx__Syntax.cmi
       and hmx/.hmx.objs/byte/hmx.cmi make inconsistent assumptions
       over interface Hmx__Union_find
```

Despite a lot of effort, I was not able to minimize this project into a reproducible test case. In any case, the fix is very simple so it should be sufficient to convince onself that it's correct.

cc @andreypopp 