### PR TITLE
test: remove dune 3.0 todo's

### DIFF
--- a/test/blackbox-tests/test-cases/deps-conf-vars.t/run.t
+++ b/test/blackbox-tests/test-cases/deps-conf-vars.t/run.t
@@ -2,13 +2,12 @@
   Entering directory 'static'
   deps: ../install/default/lib/foo/foo.cma
 
-TODO30: The following should fail saying that %{read:...} isn't
-allowed in this position, because it was indeed not supported by older
-versions of Dune. Due to improvements in the core of Dune, this is now
-supported. Because the error used to be discovered dynamically as we
-were trying to evaluate the dependencies, the new code simply doesn't
-detect it. Before we release 3.0, we should add a proper version check
-for this feature.
+The following should fail saying that %{read:...} isn't allowed in this
+position, because it was indeed not supported by older versions of Dune. Due to
+improvements in the core of Dune, this is now supported. Because the error used
+to be discovered dynamically as we were trying to evaluate the dependencies,
+the new code simply doesn't detect it. We should add a proper version check for
+this feature.
 
   $ dune build --root dynamic
   Entering directory 'dynamic'

--- a/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
@@ -227,7 +227,7 @@ of a (rule).
 The following (failing) test shows that the variables cannot yet be used in the (deps)
 field of a (rule).
 
-TODO30: this test is no longer failing. It should fail because
+This test is no longer failing. It should fail because
 %{cmo:...} wasn't allowed in the deps field in (lang dune <3.0).
 
   $ mkdir deps-fail


### PR DESCRIPTION
these issues are no longer blocking the release