### PR TITLE
Warn when lang versions have an ignored suffix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ Unreleased
 - Report cycles between virtual libraries and their implementation (#5050,
   fixes #2896, @rgrinberg)
 
+- Warn when lang versions have an ignored suffix. `(lang dune 2.3.4)` or `(lang
+  dune 2.3suffix)` were silently parsed as `2.3` and we know suggest to remove
+  the prefix. (#5040, @emillon)
+
 - Allow users to specify dynamic dependencies in rules. For example `(deps
   %{read:foo.gen})` (#4662, fixes #4089, @jeremiedimino)
 

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -32,7 +32,8 @@ module Version = struct
       match Scanf.sscanf s "%u.%u%s" (fun a b s -> ((a, b), s)) with
       | Ok (v, "") -> v
       | Ok (((a, b) as v), s) ->
-        User_warning.emit ~loc
+        let is_error = v >= (3, 0) in
+        User_warning.emit ~loc ~is_error
           [ Pp.textf "The %S part is ignored here." s
           ; Pp.textf "This version is parsed as just %d.%d." a b
           ];

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -29,8 +29,14 @@ module Version = struct
     let open Decoder in
     raw >>| function
     | Atom (loc, A s) -> (
-      match Scanf.sscanf s "%u.%u" (fun a b -> (a, b)) with
-      | Ok s -> s
+      match Scanf.sscanf s "%u.%u%s" (fun a b s -> ((a, b), s)) with
+      | Ok (v, "") -> v
+      | Ok (((a, b) as v), s) ->
+        User_warning.emit ~loc
+          [ Pp.textf "The %S part is ignored here." s
+          ; Pp.textf "This version is parsed as just %d.%d." a b
+          ];
+        v
       | Error () ->
         User_error.raise ~loc [ Pp.text "Atom of the form NNN.NNN expected" ])
     | sexp -> User_error.raise ~loc:(Ast.loc sexp) [ Pp.text "Atom expected" ]

--- a/test/blackbox-tests/test-cases/lang-dune-warning.t
+++ b/test/blackbox-tests/test-cases/lang-dune-warning.t
@@ -1,4 +1,5 @@
-If (lang dune) does not use a valid format, a warning is emitted:
+If (lang dune) does not use a valid format on a 2.x project, a warning is
+emitted:
 
   $ cat > dune-project << EOF
   > (lang dune 2.3.0)
@@ -22,10 +23,32 @@ If (lang dune) does not use a valid format, a warning is emitted:
   Warning: The "suffix" part is ignored here.
   This version is parsed as just 2.4.
 
-Of course if the version is valid, no warning is emitted:
+If the version is valid, no warning is emitted:
 
   $ cat > dune-project << EOF
   > (lang dune 2.2)
+  > EOF
+
+  $ dune build
+
+Starting with lang 3.0, the warning turns into an error.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.0suffix)
+  > EOF
+
+  $ dune build
+  File "dune-project", line 1, characters 11-20:
+  1 | (lang dune 3.0suffix)
+                 ^^^^^^^^^
+  Error: The "suffix" part is ignored here.
+  This version is parsed as just 3.0.
+  [1]
+
+And without suffix it is accepted.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
   > EOF
 
   $ dune build

--- a/test/blackbox-tests/test-cases/lang-dune-warning.t
+++ b/test/blackbox-tests/test-cases/lang-dune-warning.t
@@ -1,0 +1,31 @@
+If (lang dune) does not use a valid format, a warning is emitted:
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.3.0)
+  > EOF
+
+  $ dune build
+  File "dune-project", line 1, characters 11-16:
+  1 | (lang dune 2.3.0)
+                 ^^^^^
+  Warning: The ".0" part is ignored here.
+  This version is parsed as just 2.3.
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.4suffix)
+  > EOF
+
+  $ dune build
+  File "dune-project", line 1, characters 11-20:
+  1 | (lang dune 2.4suffix)
+                 ^^^^^^^^^
+  Warning: The "suffix" part is ignored here.
+  This version is parsed as just 2.4.
+
+Of course if the version is valid, no warning is emitted:
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.2)
+  > EOF
+
+  $ dune build


### PR DESCRIPTION
Syntax versions (the string after `lang dune` for example) are parsed with `Scanf.sscanf`. This only parses the longest matching prefix and ignored the rest of the string. So `lang dune 2.3.0` is silently interpreted as `2.3` and so is `lang dune 2.4suffix`.

This PR adds a warning when there is a suffix. An error could break existing projects.

The implementation adds a `%s` to match the suffix. This specifier stops on whitespace characters, but these can not appear in valid atoms.
