### PR TITLE
fix(cram): remove cram file after it is read

### DIFF
--- a/src/dune_rules/cram_exec.ml
+++ b/src/dune_rules/cram_exec.ml
@@ -135,6 +135,12 @@ let cram_stanzas lexbuf =
 
 let run_expect_test file ~f =
   let file_contents = Io.read_file ~binary:false file in
+  (* Nasty hack so that the user doesn't observe the test file while running the
+     test.
+
+     Eventually, we should just have a way to read the source from outside the
+     sandbox. *)
+  Path.unlink_no_err file;
   let open Fiber.O in
   let+ expected =
     let lexbuf =
@@ -144,6 +150,8 @@ let run_expect_test file ~f =
   in
   let corrected_file = Path.extend_basename file ~suffix:".corrected" in
   if file_contents <> expected then
+    (* we only need to restore the test file so the diff doesn't fail *)
+    let () = Io.write_file file file_contents in
     Io.write_file ~binary:false corrected_file expected
   else if Path.exists corrected_file then
     Path.rm_rf corrected_file

--- a/test/blackbox-tests/test-cases/github3857.t
+++ b/test/blackbox-tests/test-cases/github3857.t
@@ -3,4 +3,3 @@ dune install should not write anything to _build/
   $ dune install --prefix _install
   $ ls .
   dune-project
-  github3857.t

--- a/test/blackbox-tests/test-cases/menhir/promote.t/run.t
+++ b/test/blackbox-tests/test-cases/menhir/promote.t/run.t
@@ -14,4 +14,3 @@ Check what is being generated exactly:
   parser.ml
   parser.mli
   parser.mly
-  run.t

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -2,6 +2,7 @@ This test demonstrates a bug when there's a package with a meta template and a
 custom version:
 
   $ git init -q
+  $ touch foo
   $ git add .
   $ git commit -qm _
   $ git tag -a 1.0 -m 1.0


### PR DESCRIPTION
tests shouldn't be able to observe the test files

Fix #4776