### PR TITLE
Add [Needs_stack_trace] annotation for user errors

### DIFF
--- a/otherlibs/stdune-unstable/user_error.ml
+++ b/otherlibs/stdune-unstable/user_error.ml
@@ -40,6 +40,12 @@ module Annot = struct
 
     let to_dyn = Unit.to_dyn
   end)
+
+  module Needs_stack_trace = Make (struct
+    type payload = unit
+
+    let to_dyn = Unit.to_dyn
+  end)
 end
 
 exception E of User_message.t * Annot.t list
@@ -58,12 +64,16 @@ let is_loc_none loc =
   | None -> true
   | Some loc -> loc = Loc0.none
 
-let has_embed_location annots =
+let has_embedded_location annots =
   List.exists annots ~f:(fun annot ->
       Annot.Has_embedded_location.check annot (fun () -> true) (fun () -> false))
 
 let has_location (msg : User_message.t) annots =
-  (not (is_loc_none msg.loc)) || has_embed_location annots
+  (not (is_loc_none msg.loc)) || has_embedded_location annots
+
+let needs_stack_trace annots =
+  List.exists annots ~f:(fun annot ->
+      Annot.Needs_stack_trace.check annot (fun () -> true) (fun () -> false))
 
 let () =
   Printexc.register_printer (function

--- a/otherlibs/stdune-unstable/user_error.mli
+++ b/otherlibs/stdune-unstable/user_error.mli
@@ -19,6 +19,9 @@ module Annot : sig
 
   (** The message has a location embed in the text. *)
   module Has_embedded_location : S with type payload = unit
+
+  (** The message needs a stack trace for clarity. *)
+  module Needs_stack_trace : S with type payload = unit
 end
 
 (** User errors are errors that users need to fix themselves in order to make
@@ -48,10 +51,12 @@ val make :
 (** The "Error:" prefix *)
 val prefix : User_message.Style.t Pp.t
 
-(** Returns [true] if the message has an explicit location or one embed in the
-    text. *)
+(** Returns [true] if the message has an explicit location or one embedded in
+    the text. *)
 val has_location : User_message.t -> Annot.t list -> bool
 
-(** Returns [true] if the following list of annotations contains
-    [Annot.Has_embedded_location]. *)
-val has_embed_location : Annot.t list -> bool
+(** Returns [true] if the list contains [Annot.Has_embedded_location]. *)
+val has_embedded_location : Annot.t list -> bool
+
+(** Returns [true] if the list contains [Annot.Needs_stack_trace]. *)
+val needs_stack_trace : Annot.t list -> bool


### PR DESCRIPTION
In #5025 that introduces directory targets, I need a way to force a user error to include the stack trace even though it has an embedded location.

This PR makes this possible via the new `Needs_stack_trace` annotation. I also fix a naming inconsistency and rename `has_embed_location` to `has_embedded_location`.