### PR TITLE
Upgrade bench json version

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -2,4 +2,3 @@ FROM ocaml/opam:debian-10-ocaml-4.12
 RUN opam depext patdiff.v0.14.0
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir
-RUN opam exec -- make bench


### PR DESCRIPTION
- The PR is primarily an update to the benchmarking JSON schema to v2 to allow specifying units for the metrics.
- There's a second PR which removes an unnecessary duplicated `make bench` run from the `bench.Dockerfile`. 
