### PR TITLE
Fix bench.Dockerfile: should not run make bench

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -2,4 +2,3 @@ FROM ocaml/opam:debian-10-ocaml-4.12
 RUN opam depext patdiff.v0.14.0
 COPY --chown=opam:opam . bench-dir
 WORKDIR bench-dir
-RUN opam exec -- make bench


### PR DESCRIPTION
This is a follow up on https://github.com/ocaml/dune/pull/5034 where a custom `bench.Dockerfile` was introduced. The dockerfile is used to create the image and should not run `make bench` itself since current-bench does it in a later stage. Sorry for the confusion!