### PR TITLE
Restart build system with no invalidation to inform RPC clients

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -80,6 +80,7 @@ module Scheduler = struct
     | Scheduler.Run.Event.Tick -> Console.Status_line.refresh ()
     | Source_files_changed { details_hum } ->
       maybe_clear_screen ~details_hum dune_config
+    | Skipped_restart -> ()
     | Build_interrupted ->
       Console.Status_line.set
         (Live

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -44,6 +44,7 @@ module Run : sig
     type t =
       | Tick
       | Source_files_changed of { details_hum : string list }
+      | Skipped_restart
       | Build_interrupted
       | Build_finish of build_result
   end


### PR DESCRIPTION
For one of our tools, we would like to know when Dune sees a filesystem event but chooses not to rebuild due to eager cutoff. To accomplish this, when we see an empty invalidation, we still restart the build system but with this empty invalidation. This will send the start and finish RPCs to any listening clients to let them know that Dune saw something, but won't actually cause any rebuilding.

This can be checked with --print-metrics, which will show 0 nodes restored/computed and 0 edges traversed.