### PR TITLE
Refactor target promotion and add more docs/tests 

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1911,7 +1911,7 @@ end = struct
           | Promote _, Some Never ->
             Fiber.return ()
           | Promote promote, (Some Automatically | None) ->
-            Target_promotion.promote ~dir ~targets ~promote
+            Target_promotion.promote ~dir ~targets_and_digests ~promote
               ~promote_source:(fun ~chmod -> t.promote_source ~chmod context)
         in
         t.rule_done <- t.rule_done + 1;

--- a/src/dune_engine/target_promotion.mli
+++ b/src/dune_engine/target_promotion.mli
@@ -4,7 +4,7 @@ open! Stdune
 
 val promote :
      dir:Path.Build.t
-  -> targets:Targets.t
+  -> targets_and_digests:(Path.Build.t * Digest.t) list
   -> promote:Rule.Promote.t
   -> promote_source:
        (   chmod:(int -> int)

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -108,12 +108,33 @@ Only "only1" should be promoted in the source tree:
   $ ls -1 only*
   only1
 
+Test that Dune restores only1 if it's deleted from the source tree
+
+  $ rm only1
+  $ dune build only2
+  $ ls -1 only*
+  only1
+
+Test that Dune restores only1 if it's modified in the source tree
+
+  $ cat only1
+  0
+  $ echo 1 > only1
+  $ dune build only2
+  $ cat only1
+  0
+
 Test for (promote (into ...)) + (enabled_if %{ignoring_promoted_rules}
 ----------------------------------------------------------------------
 
   $ dune build into+ignoring
+  $ ls -1 subdir/into*
+  subdir/into+ignoring
+
   $ dune clean
   $ dune build into+ignoring --ignore-promoted-rules
+  $ ls -1 _build/default/into*
+  _build/default/into+ignoring
 
 Reproduction case for #3069
 ---------------------------


### PR DESCRIPTION
This PR does a few things without changing existing behaviour:

* Instead of recomputing target digests, we reuse the digests that are already available after executing a rule. This is useful for an upcoming PR that implements promotion for directory targets (we won't need to recursively traverse the directories again).
* Add a few comments documenting ideas for further improvement.
* Add a test to ensure that promoted targets are restored when deleted or modified by the user. Also clarify the behaviour of another existing test.
* Move around some code to make the main target promotion logic more visible.