### PR TITLE
Add a test documenting various display modes of Dune

### DIFF
--- a/test/blackbox-tests/test-cases/display.t
+++ b/test/blackbox-tests/test-cases/display.t
@@ -1,0 +1,153 @@
+Document how Dune displays various things
+=========================================
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ export BUILD_PATH_PREFIX_MAP=SH=`command -v sh`
+
+Errors with location embed in their output
+------------------------------------------
+
+  $ cat >dune<<"EOF"
+  > (rule
+  >  (alias default)
+  >  (action (system "echo 'File \"foo\", line 1: blah'; exit 42")))
+  > EOF
+
+  $ dune clean; dune build
+  File "foo", line 1: blah
+  [1]
+
+  $ dune clean; dune build --always-show-command-line
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42')
+  File "foo", line 1: blah
+  [1]
+
+  $ dune clean; dune build --display short
+  File "foo", line 1: blah
+  [1]
+
+  $ dune clean; dune build --display short --always-show-command-line
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42')
+  File "foo", line 1: blah
+  [1]
+
+Errors without location embed in their output
+---------------------------------------------
+
+  $ cat >dune<<"EOF"
+  > (rule
+  >  (alias default)
+  >  (action (system "echo failure; exit 42")))
+  > EOF
+
+  $ dune clean; dune build
+  File "dune", line 1, characters 0-66:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "echo failure; exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'echo failure; exit 42')
+  failure
+  [1]
+
+  $ dune clean; dune build --always-show-command-line
+  File "dune", line 1, characters 0-66:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "echo failure; exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'echo failure; exit 42')
+  failure
+  [1]
+
+  $ dune clean; dune build --display short
+  File "dune", line 1, characters 0-66:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "echo failure; exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'echo failure; exit 42')
+  failure
+  [1]
+
+  $ dune clean; dune build --display short --always-show-command-line
+  File "dune", line 1, characters 0-66:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "echo failure; exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'echo failure; exit 42')
+  failure
+  [1]
+
+Errors with no output
+---------------------
+
+  $ cat >dune<<"EOF"
+  > (rule
+  >  (alias default)
+  >  (action (system "exit 42")))
+  > EOF
+
+  $ dune clean; dune build
+  File "dune", line 1, characters 0-52:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'exit 42')
+  [1]
+
+  $ dune clean; dune build --always-show-command-line
+  File "dune", line 1, characters 0-52:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'exit 42')
+  [1]
+
+  $ dune clean; dune build --display short
+  File "dune", line 1, characters 0-52:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'exit 42')
+  [1]
+
+  $ dune clean; dune build --display short --always-show-command-line
+  File "dune", line 1, characters 0-52:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (system "exit 42")))
+            sh alias default (exit 42)
+  (cd _build/default && SH -c 'exit 42')
+  [1]
+
+Successful commands with output
+-------------------------------
+
+  $ cat >dune<<"EOF"
+  > (rule
+  >  (alias default)
+  >  (action (system "echo 'Hello, world!'")))
+  > EOF
+
+  $ dune clean; dune build
+            sh alias default
+  Hello, world!
+
+  $ dune clean; dune build --always-show-command-line
+            sh alias default
+  Hello, world!
+
+  $ dune clean; dune build --display short
+            sh alias default
+  Hello, world!
+
+  $ dune clean; dune build --display short --always-show-command-line
+            sh alias default
+  Hello, world!


### PR DESCRIPTION
As can be seen, we are often still displaying the line that comes from `--display short`, which feels somewhat wrong.