### PR TITLE
Don't print the short display when not in short display mode

### DIFF
--- a/otherlibs/action-plugin/test/depend-on-directory-without-targets/run.t
+++ b/otherlibs/action-plugin/test/depend-on-directory-without-targets/run.t
@@ -18,5 +18,4 @@
   $ cp ./bin/foo.exe ./
 
   $ dune runtest
-           foo alias runtest
   Directory listing: [some_file1; some_file2]

--- a/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/run.t
+++ b/otherlibs/action-plugin/test/dependency-rebuilt-but-not-changed/run.t
@@ -25,7 +25,6 @@ they were forced to rebuild.
 
   $ dune runtest
   Building some_file!
-           foo alias runtest
   Hello from some_file!
 
   $ dune runtest

--- a/otherlibs/action-plugin/test/depends-on-directory-with-glob/run.t
+++ b/otherlibs/action-plugin/test/depends-on-directory-with-glob/run.t
@@ -39,6 +39,5 @@
   $ dune runtest
   Building some_file!
   Building some_file_but_different!
-           foo alias runtest
   some_file
   some_file_but_different

--- a/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/run.t
+++ b/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/run.t
@@ -45,7 +45,6 @@ only the dependencies up to this stage are rebuilt.
   $ dune runtest
   Building foo_or_bar!
   Building foo!
-        client alias runtest
   Hello from foo!
 
   $ printf "bar" > foo_or_bar_source
@@ -55,5 +54,4 @@ only the dependencies up to this stage are rebuilt.
   $ dune runtest
   Building foo_or_bar!
   Building bar!
-        client alias runtest
   Hello from bar!

--- a/otherlibs/action-plugin/test/no-dependencies/run.t
+++ b/otherlibs/action-plugin/test/no-dependencies/run.t
@@ -16,5 +16,4 @@ but requires no dependencies can be successfully run.
   $ cp ./bin/foo.exe ./
 
   $ dune runtest
-           foo alias runtest
   Hello from foo!

--- a/otherlibs/action-plugin/test/one-dependency-with-chdir/run.t
+++ b/otherlibs/action-plugin/test/one-dependency-with-chdir/run.t
@@ -25,5 +25,4 @@ when we 'chdir' into different directory.
 
   $ cp ./bin/foo.exe ./some_dir
   $ dune runtest
-           foo alias runtest
   Hello from some_dependency!

--- a/otherlibs/action-plugin/test/one-dependency/run.t
+++ b/otherlibs/action-plugin/test/one-dependency/run.t
@@ -19,5 +19,4 @@ and requires one dependency can be successfully run.
   $ cp ./bin/foo.exe ./
 
   $ dune runtest
-           foo alias runtest
   Hello from some_dependency!

--- a/otherlibs/action-plugin/test/one-directory-dependency/run.t
+++ b/otherlibs/action-plugin/test/one-directory-dependency/run.t
@@ -32,7 +32,6 @@ directory to be build.
   $ cp ./bin/foo.exe ./
 
   $ dune runtest
-           foo alias runtest
   dune
   some_file1
   some_file2

--- a/otherlibs/action-plugin/test/one-undeclared-target/run.t
+++ b/otherlibs/action-plugin/test/one-undeclared-target/run.t
@@ -16,7 +16,5 @@
   1 | (rule
   2 |  (alias runtest)
   3 |  (action (dynamic-run ./foo.exe)))
-           foo alias runtest (exit 1)
-  (cd _build/default && ./foo.exe)
   bar is written despite not being declared as a target in dune file. To fix, add it to target list in dune file.
   [1]

--- a/otherlibs/action-plugin/test/ordinary-executable/run.t
+++ b/otherlibs/action-plugin/test/ordinary-executable/run.t
@@ -15,7 +15,6 @@ ordinary executable instead of one linked against dune-action-plugin.
   $ cp ./bin/foo.exe ./
 
   $ dune runtest
-           foo alias runtest
   Hello from foo!
   File "dune", line 1, characters 0-57:
   1 | (rule

--- a/otherlibs/action-plugin/test/two-stages-dependency-choose/run.t
+++ b/otherlibs/action-plugin/test/two-stages-dependency-choose/run.t
@@ -34,5 +34,4 @@ on based on dependency from the previous stage.
 
   $ dune runtest
   Building bar!
-        client alias runtest
   Hello from bar!

--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -358,7 +358,6 @@ Test compiling an external plugin
   run c: registered:e,b.
 
   $ OCAMLPATH=_install/lib:$OCAMLPATH dune build @runtest
-             c alias e/runtest
   run a
   a: $TESTCASE_ROOT/_build/install/default/share/a/data
   run c: a linked registered:.

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -416,19 +416,30 @@ let pp_id id =
   let open Pp.O in
   Pp.char '[' ++ Pp.tag User_message.Style.Id (Pp.textf "%d" id) ++ Pp.char ']'
 
-module Handle_exit_status
-    (*: sig open Exit_status
+module Handle_exit_status : sig
+  open Exit_status
 
-      val verbose : ('a, error) result -> id:int -> purpose:purpose ->
-      output:string -> command_line:User_message.Style.t Pp.t ->
-      dir:With_directory_annot.payload option -> 'a
+  val verbose :
+       ('a, error) result
+    -> id:int
+    -> purpose:purpose
+    -> output:string
+    -> command_line:User_message.Style.t Pp.t
+    -> dir:With_directory_annot.payload option
+    -> 'a
 
-      val non_verbose : ('a, error) result ->
-      verbosity:Scheduler.Config.Display.verbosity -> purpose:purpose ->
-      output:string -> prog:string -> command_line:string ->
-      dir:With_directory_annot.payload option -> has_unexpected_stdout:bool ->
-      has_unexpected_stderr:bool -> 'a end*) =
-struct
+  val non_verbose :
+       ('a, error) result
+    -> verbosity:Scheduler.Config.Display.verbosity
+    -> purpose:purpose
+    -> output:string
+    -> prog:string
+    -> command_line:string
+    -> dir:With_directory_annot.payload option
+    -> has_unexpected_stdout:bool
+    -> has_unexpected_stderr:bool
+    -> 'a
+end = struct
   open Exit_status
 
   type output =

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -209,6 +209,14 @@ let command_line ~prog ~args ~dir ~stdout_to ~stderr_to ~stdin_from =
   in
   prefix ^ s ^ suffix
 
+module Exit_status = struct
+  type error =
+    | Failed of int
+    | Signaled of string
+
+  type t = (int, error) result
+end
+
 module Fancy = struct
   let split_prog s =
     let len = String.length s in
@@ -240,6 +248,10 @@ module Fancy = struct
       let after = String.drop s prog_end in
       let prog = String.sub s ~pos:prog_start ~len:(prog_end - prog_start) in
       (before, prog, after)
+
+  let short_prog_name_of_prog s =
+    let _, s, _ = split_prog s in
+    s
 
   let color_combos =
     let open Ansi_color.Style in
@@ -285,7 +297,20 @@ module Fancy = struct
       command_line_enclosers ~dir ~stdout_to ~stderr_to ~stdin_from
     in
     Pp.verbatim prefix ++ pp ++ Pp.verbatim suffix
+end
 
+(* Implemt the rendering for [--display short] *)
+module Short_display : sig
+  val pp_ok : prog:string -> purpose:purpose -> User_message.Style.t Pp.t
+
+  val pp_error :
+       prog:string
+    -> purpose:purpose
+    -> has_unexpected_stdout:bool
+    -> has_unexpected_stderr:bool
+    -> error:Exit_status.error
+    -> User_message.Style.t Pp.t
+end = struct
   let pp_purpose = function
     | Internal_job _ -> Pp.verbatim "(internal)"
     | Build_job (_, _, targets) -> (
@@ -345,6 +370,36 @@ module Fancy = struct
              ++ Pp.concat_map l ~sep:(Pp.char ',') ~f:(fun ctx ->
                     Pp.verbatim (Context_name.to_string ctx))
              ++ Pp.char ']'))
+
+  let progname_and_purpose ~tag ~prog ~purpose =
+    let open Pp.O in
+    let progname = sprintf "%12s" (Fancy.short_prog_name_of_prog prog) in
+    Pp.tag tag (Pp.verbatim progname) ++ Pp.char ' ' ++ pp_purpose purpose
+
+  let pp_ok = progname_and_purpose ~tag:Ok
+
+  let pp_error ~prog ~purpose ~has_unexpected_stdout ~has_unexpected_stderr
+      ~(error : Exit_status.error) =
+    let open Pp.O in
+    let msg =
+      match error with
+      | Signaled signame -> sprintf "(got signal %s)" signame
+      | Failed n -> (
+        let unexpected_outputs =
+          List.filter_map
+            [ (has_unexpected_stdout, "stdout")
+            ; (has_unexpected_stderr, "stderr")
+            ] ~f:(fun (b, name) -> Option.some_if b name)
+        in
+        match (n, unexpected_outputs) with
+        | 0, _ :: _ ->
+          sprintf "(had unexpected output on %s)"
+            (String.enumerate_and unexpected_outputs)
+        | _ -> sprintf "(exit %d)" n)
+    in
+    progname_and_purpose ~prog ~tag:Error ~purpose
+    ++ Pp.char ' '
+    ++ Pp.tag User_message.Style.Error (Pp.verbatim msg)
 end
 
 let gen_id =
@@ -361,39 +416,20 @@ let pp_id id =
   let open Pp.O in
   Pp.char '[' ++ Pp.tag User_message.Style.Id (Pp.textf "%d" id) ++ Pp.char ']'
 
-module Exit_status : sig
-  type error =
-    | Failed of int
-    | Signaled of string
+module Handle_exit_status
+    (*: sig open Exit_status
 
-  type t = (int, error) result
+      val verbose : ('a, error) result -> id:int -> purpose:purpose ->
+      output:string -> command_line:User_message.Style.t Pp.t ->
+      dir:With_directory_annot.payload option -> 'a
 
-  val handle_verbose :
-       ('a, error) result
-    -> id:int
-    -> purpose:purpose
-    -> output:string
-    -> command_line:User_message.Style.t Pp.t
-    -> dir:With_directory_annot.payload option
-    -> 'a
-
-  val handle_non_verbose :
-       ('a, error) result
-    -> verbosity:Scheduler.Config.Display.verbosity
-    -> purpose:purpose
-    -> output:string
-    -> prog:string
-    -> command_line:string
-    -> dir:With_directory_annot.payload option
-    -> has_unexpected_stdout:bool
-    -> has_unexpected_stderr:bool
-    -> 'a
-end = struct
-  type error =
-    | Failed of int
-    | Signaled of string
-
-  type t = (int, error) result
+      val non_verbose : ('a, error) result ->
+      verbosity:Scheduler.Config.Display.verbosity -> purpose:purpose ->
+      output:string -> prog:string -> command_line:string ->
+      dir:With_directory_annot.payload option -> has_unexpected_stdout:bool ->
+      has_unexpected_stderr:bool -> 'a end*) =
+struct
+  open Exit_status
 
   type output =
     | No_output
@@ -403,9 +439,9 @@ end = struct
         ; has_embedded_location : bool
         }
 
-  let has_embedded_location = function
-    | No_output -> false
-    | Has_output t -> t.has_embedded_location
+  let pp_output = function
+    | No_output -> []
+    | Has_output t -> [ t.with_color ]
 
   let parse_output = function
     | "" -> No_output
@@ -420,38 +456,33 @@ end = struct
       in
       Has_output { with_color; without_color; has_embedded_location }
 
-  (* In this module, we don't need the "Error: " prefix given that it is already
-     included in the error message from the command. *)
-  let fail ~output ~purpose ~dir paragraphs =
-    let paragraphs : User_message.Style.t Pp.t list =
-      match output with
-      | No_output -> paragraphs
-      | Has_output output -> paragraphs @ [ output.with_color ]
-    in
-    let dir =
-      match dir with
-      | None -> Path.of_string (Sys.getcwd ())
-      | Some dir -> dir
-    in
+  let get_loc_and_annots ~dir ~purpose ~output =
     let loc, annots = loc_and_annots_of_purpose purpose in
+    let dir = Option.value dir ~default:Path.root in
     let annots = With_directory_annot.make dir :: annots in
     let annots =
-      if has_embedded_location output then
-        let annots = User_error.Annot.Has_embedded_location.make () :: annots in
-        match
-          match output with
-          | No_output -> None
-          | Has_output output ->
-            Compound_user_error.parse_output ~dir output.without_color
-        with
-        | None -> annots
-        | Some annot -> annot :: annots
-      else
-        annots
+      match output with
+      | No_output -> annots
+      | Has_output output ->
+        if output.has_embedded_location then
+          let annots =
+            User_error.Annot.Has_embedded_location.make () :: annots
+          in
+          match Compound_user_error.parse_output ~dir output.without_color with
+          | None -> annots
+          | Some annot -> annot :: annots
+        else
+          annots
     in
+    (loc, annots)
+
+  let fail ~loc ~annots paragraphs =
+    (* We don't use [User_error.make] as it would add the "Error: " prefix. We
+       don't need this prefix as it is already included in the output of the
+       command. *)
     raise (User_error.E (User_message.make ?loc paragraphs, annots))
 
-  let handle_verbose t ~id ~purpose ~output ~command_line ~dir =
+  let verbose t ~id ~purpose ~output ~command_line ~dir =
     let open Pp.O in
     let output = parse_output output in
     match t with
@@ -472,86 +503,70 @@ end = struct
         | Failed n -> sprintf "exited with code %d" n
         | Signaled signame -> sprintf "got signal %s" signame
       in
-      fail ~output ~purpose ~dir
-        [ Pp.tag User_message.Style.Kwd (Pp.verbatim "Command")
-          ++ Pp.space ++ pp_id id ++ Pp.space ++ Pp.text msg ++ Pp.char ':'
-        ; Pp.tag User_message.Style.Prompt (Pp.char '$')
-          ++ Pp.char ' ' ++ command_line
-        ]
+      let loc, annots = get_loc_and_annots ~dir ~purpose ~output in
+      fail ~loc ~annots
+        (Pp.tag User_message.Style.Kwd (Pp.verbatim "Command")
+         ++ Pp.space ++ pp_id id ++ Pp.space ++ Pp.text msg ++ Pp.char ':'
+        :: Pp.tag User_message.Style.Prompt (Pp.char '$')
+           ++ Pp.char ' ' ++ command_line
+        :: pp_output output)
 
-  let handle_non_verbose t ~verbosity ~purpose ~output ~prog ~command_line ~dir
-      ~has_unexpected_stdout ~has_unexpected_stderr =
-    let open Pp.O in
+  let non_verbose t ~(verbosity : Scheduler.Config.Display.verbosity) ~purpose
+      ~output ~prog ~command_line ~dir ~has_unexpected_stdout
+      ~has_unexpected_stderr =
     let output = parse_output output in
-    let has_embedded_location = has_embedded_location output in
     let show_command =
-      let show_full_command_on_error =
-        !Clflags.always_show_command_line
-        || (* We want to show command lines in the CI, but not when running
-              inside dune. Otherwise tests would yield different result whether
-              they are executed locally or in the CI. *)
-        (Config.inside_ci && not Config.inside_dune)
-      in
-      show_full_command_on_error || not has_embedded_location
+      !Clflags.always_show_command_line
+      || (* We want to show command lines in the CI, but not when running inside
+            dune. Otherwise tests would yield different result whether they are
+            executed locally or in the CI. *)
+      (Config.inside_ci && not Config.inside_dune)
     in
-    let _, progname, _ = Fancy.split_prog prog in
-    let progname_and_purpose tag =
-      let progname = sprintf "%12s" progname in
-      Pp.tag tag (Pp.verbatim progname)
-      ++ Pp.char ' ' ++ Fancy.pp_purpose purpose
+    let add_command_line paragraphs =
+      if show_command then
+        Pp.tag User_message.Style.Details (Pp.verbatim command_line)
+        :: paragraphs
+      else
+        paragraphs
     in
     match t with
     | Ok n ->
-      (if
-       (match output with
-       | No_output -> false
-       | Has_output _ -> true)
-       || (match verbosity with
-          | Scheduler.Config.Display.Short -> true
-          | Quiet -> false
-          | Verbose -> assert false)
-          &&
-          match purpose with
-          | Internal_job _ -> false
-          | Build_job _ -> true
-      then
-        let output =
-          match output with
-          | No_output -> []
-          | Has_output output -> [ output.with_color ]
-        in
-        Console.print_user_message
-          (User_message.make
-             (if show_command then
-               progname_and_purpose Ok :: output
-             else
-               output)));
-      n
-    | Error err ->
-      let msg =
-        match err with
-        | Signaled signame -> sprintf "(got signal %s)" signame
-        | Failed n ->
-          if show_command then
-            let unexpected_outputs =
-              List.filter_map
-                [ (has_unexpected_stdout, "stdout")
-                ; (has_unexpected_stderr, "stderr")
-                ] ~f:(fun (b, name) -> Option.some_if b name)
-            in
-            match (n, unexpected_outputs) with
-            | 0, _ :: _ ->
-              sprintf "(had unexpected output on %s)"
-                (String.enumerate_and unexpected_outputs)
-            | _ -> sprintf "(exit %d)" n
-          else
-            fail ~output ~purpose ~dir []
+      let paragraphs =
+        match output with
+        | No_output -> []
+        | Has_output output -> add_command_line [ output.with_color ]
       in
-      fail ~output ~purpose ~dir
-        [ progname_and_purpose Error ++ Pp.char ' '
-          ++ Pp.tag User_message.Style.Error (Pp.verbatim msg)
-        ; Pp.tag User_message.Style.Details (Pp.verbatim command_line)
-        ]
+      let paragraphs =
+        match (verbosity, purpose, output) with
+        | Short, Build_job _, _
+        | Short, Internal_job _, Has_output _ ->
+          Short_display.pp_ok ~prog ~purpose :: paragraphs
+        | _ -> paragraphs
+      in
+      if not (List.is_empty paragraphs) then
+        Console.print_user_message (User_message.make paragraphs);
+      n
+    | Error error ->
+      let loc, annots = get_loc_and_annots ~dir ~purpose ~output in
+      let paragraphs =
+        match verbosity with
+        | Short ->
+          Short_display.pp_error ~prog ~purpose ~error ~has_unexpected_stdout
+            ~has_unexpected_stderr
+          :: add_command_line (pp_output output)
+        | _ ->
+          add_command_line
+            (match output with
+            | Has_output output -> [ output.with_color ]
+            | No_output -> (
+              (* If the command has no output, we need to say something.
+                 Otherwise it's not clear what's going on. *)
+              match error with
+              | Failed n -> [ Pp.textf "Command exited with code %d." n ]
+              | Signaled signame ->
+                [ Pp.textf "Command got signal %s." signame ]))
+      in
+      fail ~loc ~annots paragraphs
 end
 
 let report_process_start stats ~id ~prog ~args ~now =
@@ -778,10 +793,10 @@ let run_internal ?dir ?(stdout_to = Io.stdout) ?(stderr_to = Io.stderr)
         match (display.verbosity, exit_status', output) with
         | Quiet, Ok n, "" -> n (* Optimisation for the common case *)
         | Verbose, _, _ ->
-          Exit_status.handle_verbose exit_status' ~id ~purpose ~dir
+          Handle_exit_status.verbose exit_status' ~id ~purpose ~dir
             ~command_line:fancy_command_line ~output
         | _ ->
-          Exit_status.handle_non_verbose exit_status' ~prog:prog_str ~dir
+          Handle_exit_status.non_verbose exit_status' ~prog:prog_str ~dir
             ~command_line ~output ~purpose ~verbosity:display.verbosity
             ~has_unexpected_stdout ~has_unexpected_stderr
       in

--- a/test/blackbox-tests/test-cases/actions/action-stdxxx-on-success.t
+++ b/test/blackbox-tests/test-cases/actions/action-stdxxx-on-success.t
@@ -22,9 +22,7 @@ Test for --action-stdxxx-on-success
 By default, stdout and stderr are always printed:
 
   $ dune build
-            sh alias default
   Hello, world!
-            sh alias default
   Something went wrong!
 
 swallow tests
@@ -44,27 +42,21 @@ printing the output of the action that had a non-empty output.
 
   $ dune clean
   $ dune build --action-stdout-on-success=must-be-empty
-            sh alias default
   Something went wrong!
   File "dune", line 1, characters 0-65:
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "echo 'Hello, world!'")))
-            sh alias default (had unexpected output on stdout)
-  (cd _build/default && sh -c 'echo '\''Hello, world!'\''')
   Hello, world!
   [1]
 
   $ dune clean
   $ dune build --action-stderr-on-success=must-be-empty
-            sh alias default
   Hello, world!
   File "dune", line 5, characters 0-77:
   5 | (rule
   6 |  (alias default)
   7 |  (action (system "echo 'Something went wrong!' >&2")))
-            sh alias default (had unexpected output on stderr)
-  (cd _build/default && sh -c 'echo '\''Something went wrong!'\'' >&2')
   Something went wrong!
   [1]
 
@@ -78,8 +70,6 @@ Same but with output on both stdout and stderr:
    9 | (rule
   10 |  (alias both-stdout-and-stderr-output)
   11 |  (action (system "echo stdout; echo stderr >&2")))
-            sh alias both-stdout-and-stderr-output (had unexpected output on stdout and stderr)
-  (cd _build/default && sh -c 'echo stdout; echo stderr >&2')
   stdout
   stderr
   [1]
@@ -102,9 +92,7 @@ it, actions that printed something to stdout or stderr are
 re-executed:
 
   $ dune build
-            sh alias default
   Hello, world!
-            sh alias default
   Something went wrong!
 
 However, we currently re-execute too much. In particular, we
@@ -122,19 +110,15 @@ re-execute actions whose outcome is not affected by the change:
 
   $ dune clean
   $ dune build --action-stdout-on-success=swallow
-            sh alias default
   a.stderr
-            sh alias default
   b.stderr
 
 You can observe in the below call that both actions are being
 re-executed:
 
   $ dune build
-            sh alias default
   a.stdout
   a.stderr
-            sh alias default
   b.stderr
 
 However, re-executing the second action was not necessary given that
@@ -160,8 +144,6 @@ In case of errors, we print everything no matter what.
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "echo 'Hello, world!'; exit 1")))
-            sh alias default (exit 1)
-  (cd _build/default && sh -c 'echo '\''Hello, world!'\''; exit 1')
   Hello, world!
   [1]
 
@@ -171,8 +153,6 @@ In case of errors, we print everything no matter what.
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "echo 'Hello, world!'; exit 1")))
-            sh alias default (exit 1)
-  (cd _build/default && sh -c 'echo '\''Hello, world!'\''; exit 1')
   Hello, world!
   [1]
 
@@ -182,8 +162,6 @@ In case of errors, we print everything no matter what.
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "echo 'Hello, world!'; exit 1")))
-            sh alias default (exit 1)
-  (cd _build/default && sh -c 'echo '\''Hello, world!'\''; exit 1')
   Hello, world!
   [1]
 
@@ -210,8 +188,6 @@ first command but not the second:
   4 |   (progn
   5 |    (system "echo 1")
   6 |    (system "echo 2; exit 1"))))
-            sh alias default (exit 1)
-  (cd _build/default && sh -c 'echo 2; exit 1')
   2
   [1]
 
@@ -236,8 +212,6 @@ better if we stop at the end of the whole action.
   4 |   (progn
   5 |    (system "echo 1")
   6 |    (system "echo 2"))))
-            sh alias default (had unexpected output on stdout)
-  (cd _build/default && sh -c 'echo 1')
   1
   [1]
 

--- a/test/blackbox-tests/test-cases/cinaps/include-subdirs.t/run.t
+++ b/test/blackbox-tests/test-cases/cinaps/include-subdirs.t/run.t
@@ -22,8 +22,6 @@ cinaps doesn't work with (include_subdirs unqualified)
 
   $ dune runtest --diff-command diff 2>&1 | sed -E 's/[^ ]+sh/\$sh/'
   File "sub/test.ml", line 1, characters 0-0:
-            sh (internal) (exit 1)
-  (cd _build/default && $sh -c 'diff sub/test.ml sub/test.ml.cinaps-corrected')
   2,3c2
   < (*)
   < let x = 1

--- a/test/blackbox-tests/test-cases/cinaps/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/cinaps/simple.t/run.t
@@ -19,8 +19,6 @@ The cinaps actions should be attached to the runtest alias:
 
   $ dune runtest --diff-command diff 2>&1 | sed -E 's/[^ ]+sh/\$sh/'
   File "test.ml", line 1, characters 0-0:
-            sh (internal) (exit 1)
-  (cd _build/default && $sh -c 'diff test.ml test.ml.cinaps-corrected')
   1a2
   > hello
 
@@ -28,8 +26,6 @@ but also to the cinaps alias:
 
   $ dune build @cinaps --diff-command diff 2>&1 | sed -E 's/[^ ]+sh/\$sh/'
   File "test.ml", line 1, characters 0-0:
-            sh (internal) (exit 1)
-  (cd _build/default && $sh -c 'diff test.ml test.ml.cinaps-corrected')
   1a2
   > hello
 

--- a/test/blackbox-tests/test-cases/cxx-extension.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-extension.t/run.t
@@ -21,7 +21,6 @@
 
 * .cxx extension is allowed
   $ dune build
-           bar alias default
   n = 42
 
   $ echo "(lang dune 1.11)" > dune-project
@@ -44,7 +43,6 @@
 
   $ dune clean
   $ dune build
-           bar alias default
   n = 42
 
 * Compilation fails when baz.cpp and baz.cxx conflict
@@ -100,7 +98,6 @@ This works because the translation layer from pre-2.0 to 2.0 replaces
 
   $ dune clean
   $ dune build
-           bar alias default
   n = 42
 
 * Compilation fails when using :standard in Dune 2.0

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t/run.t
@@ -23,18 +23,15 @@
   > )
   > EOF
   $ dune build @b
-          bash alias b
   running b: old-contents
   $ dune build @b
   $ echo new-contents > x
   $ dune build @b
-          bash alias b
   running b: new-contents
 ^ dune does re-run the action when a dependency declared 
 via an alias changes.
 And the path does appear in the sandbox:
   $ dune build @b --sandbox copy 2>&1 | grep -v 'cd _build/.sandbox'
-          bash alias b
   running b: new-contents
 
 However, this is only since 3.0, before that aliases where not
@@ -49,7 +46,6 @@ expanded when creating the sandbox:
   7 |   (deps (alias a))
   8 |   (action (bash "echo -n \"running b: \"; cat x"))
   9 | )
-          bash alias b (exit 1)
   running b: cat: x: No such file or directory
   $ cat >dune-project <<EOF
   > (lang dune 3.0)
@@ -79,14 +75,11 @@ Now test that including an alias into another alias includes its expansion:
   $ rm -r _build
   $ echo old-contents > x
   $ dune build @b
-          bash alias b
   running b: old-contents
   $ dune build @b
   $ echo new-contents > x
   $ dune build @b
-          bash alias b
   running b: new-contents
 The path still does appear in the sandbox:
   $ dune build @b --sandbox copy 2>&1 | grep -v 'cd _build/.sandbox'
-          bash alias b
   running b: new-contents

--- a/test/blackbox-tests/test-cases/depend-on/installed-packages.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/installed-packages.t/run.t
@@ -35,7 +35,6 @@
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest
   Entering directory 'b'
-           cat alias runtest
   Miaou
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest
@@ -60,7 +59,6 @@
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest
   Entering directory 'b'
-           cat alias runtest
   Ouaf
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest

--- a/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t/run.t
@@ -16,7 +16,6 @@ and dune makes sure that the directory exists inside the sandbox.
   > )
   > EOF
   $ dune build @a --sandbox=copy
-          bash alias a/a
   contents
 
   $ cat >dune <<EOF
@@ -27,5 +26,4 @@ and dune makes sure that the directory exists inside the sandbox.
   > )
   > EOF
   $ dune build @root --sandbox=copy
-          bash alias root
   contents

--- a/test/blackbox-tests/test-cases/dialects.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects.t/run.t
@@ -5,9 +5,7 @@ Test the (dialect ...) stanza inside the dune-project file.
 
   $ dune build --root good @fmt
   Entering directory 'good'
-           fmt .formatted/main.mf
   Formatting main.mf
-           fmt .formatted/main.mfi
   Formatting main.mfi
 
   $ dune build --root bad1

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
@@ -5,7 +5,6 @@
 
   $ dune build --root target @cat_dir
   Entering directory 'target'
-       cat_dir alias cat_dir
   bar:
   bar contents
   

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -238,7 +238,6 @@ the subdirectories included into the directory target.
 # CR-someday amokhov: Remove the files that action didn't depend on.
 
   $ dune build level1
-          bash level1
   output/a.txt output/b.txt
 
   $ cat _build/default/level1
@@ -250,7 +249,6 @@ the subdirectories included into the directory target.
 Depending on a glob in a subdirectory of a directory target works too.
 
   $ dune build level2
-          bash level2
   output/subdir/d.txt output/subdir/e
   $ cat _build/default/level2
   d.txt
@@ -292,9 +290,7 @@ rule to rerun when needed.
   $ echo b > src_b
   $ echo c > src_c
   $ dune build contents
-          bash output
   running
-          bash contents
   running
   $ cat _build/default/contents
   a:
@@ -309,9 +305,7 @@ mtime changes when the rule reruns. We can delete this when switching to (1).
   $ echo new-b > src_b
 
   $ dune build contents
-          bash output
   running
-          bash contents
   running
   $ cat _build/default/contents
   a:
@@ -325,9 +319,7 @@ skip the second action since the produced directory has the same contents.
   $ dune_cmd wait-for-fs-clock-to-advance
   $ echo new-cc > src_c
   $ dune build contents
-          bash output
   running
-          bash contents
   running
   $ cat _build/default/contents
   a:
@@ -342,9 +334,7 @@ and the second one because of the lack of early cutoff.
   $ dune_cmd wait-for-fs-clock-to-advance
   $ rm _build/default/output/a
   $ dune build contents
-          bash output
   running
-          bash contents
   running
 
 Check that Dune clears stale files from directory targets.
@@ -365,9 +355,7 @@ Check that Dune clears stale files from directory targets.
   > EOF
 
   $ dune build contents
-          bash output
   running
-          bash contents
   running
 
 Note that the stale "output/a" file got removed.

--- a/test/blackbox-tests/test-cases/display.t
+++ b/test/blackbox-tests/test-cases/display.t
@@ -18,12 +18,12 @@ Errors with location embed in their output
   [1]
 
   $ dune clean; dune build --always-show-command-line
-            sh alias default (exit 42)
   (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42')
   File "foo", line 1: blah
   [1]
 
   $ dune clean; dune build --display short
+            sh alias default (exit 42)
   File "foo", line 1: blah
   [1]
 
@@ -47,8 +47,6 @@ Errors without location embed in their output
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "echo failure; exit 42")))
-            sh alias default (exit 42)
-  (cd _build/default && SH -c 'echo failure; exit 42')
   failure
   [1]
 
@@ -57,7 +55,6 @@ Errors without location embed in their output
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "echo failure; exit 42")))
-            sh alias default (exit 42)
   (cd _build/default && SH -c 'echo failure; exit 42')
   failure
   [1]
@@ -68,7 +65,6 @@ Errors without location embed in their output
   2 |  (alias default)
   3 |  (action (system "echo failure; exit 42")))
             sh alias default (exit 42)
-  (cd _build/default && SH -c 'echo failure; exit 42')
   failure
   [1]
 
@@ -96,8 +92,7 @@ Errors with no output
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "exit 42")))
-            sh alias default (exit 42)
-  (cd _build/default && SH -c 'exit 42')
+  Command exited with code 42.
   [1]
 
   $ dune clean; dune build --always-show-command-line
@@ -105,8 +100,8 @@ Errors with no output
   1 | (rule
   2 |  (alias default)
   3 |  (action (system "exit 42")))
-            sh alias default (exit 42)
   (cd _build/default && SH -c 'exit 42')
+  Command exited with code 42.
   [1]
 
   $ dune clean; dune build --display short
@@ -115,7 +110,6 @@ Errors with no output
   2 |  (alias default)
   3 |  (action (system "exit 42")))
             sh alias default (exit 42)
-  (cd _build/default && SH -c 'exit 42')
   [1]
 
   $ dune clean; dune build --display short --always-show-command-line
@@ -137,11 +131,10 @@ Successful commands with output
   > EOF
 
   $ dune clean; dune build
-            sh alias default
   Hello, world!
 
   $ dune clean; dune build --always-show-command-line
-            sh alias default
+  (cd _build/default && SH -c 'echo '\''Hello, world!'\''')
   Hello, world!
 
   $ dune clean; dune build --display short
@@ -150,4 +143,5 @@ Successful commands with output
 
   $ dune clean; dune build --display short --always-show-command-line
             sh alias default
+  (cd _build/default && SH -c 'echo '\''Hello, world!'\''')
   Hello, world!

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
@@ -109,18 +109,14 @@ Test that the cache stores all historical build results.
   > EOF
   $ cp dune-v1 dune
   $ dune build --config-file=config t2
-          bash t1
   running
-          bash t2
   running
   $ cat _build/default/t2
   v1
   v1
   $ cp dune-v2 dune
   $ dune build --config-file=config t2
-          bash t1
   running
-          bash t2
   running
   $ cat _build/default/t2
   v2

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
@@ -108,18 +108,14 @@ Test that the cache stores all historical build results.
   > EOF
   $ cp dune-v1 dune
   $ dune build --config-file=config t2
-          bash t1
   running
-          bash t2
   running
   $ cat _build/default/t2
   v1
   v1
   $ cp dune-v2 dune
   $ dune build --config-file=config t2
-          bash t1
   running
-          bash t2
   running
   $ cat _build/default/t2
   v2

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system.t/run.t
@@ -67,7 +67,6 @@ Test the argument syntax
 
   $ dune build --root driver-tests test_ppx_args.cma
   Entering directory 'driver-tests'
-           ppx test_ppx_args.pp.ml
   .ppx/454728df5270ab91f8a5af6b5e860eb0/ppx.exe
   -arg1
   -arg2
@@ -97,7 +96,6 @@ Test that going through the -ppx option of the compiler works
 
   $ dune build --root driver-tests test_ppx_staged.cma
   Entering directory 'driver-tests'
-        ocamlc .test_ppx_staged.objs/byte/test_ppx_staged.{cmi,cmo,cmt}
   tool name: ocamlc
   args:--as-ppx -arg1 -arg2 -arg3=Oreo -foo bar Snickerdoodle --cookie france="Petit Beurre" --cookie italy="Biscotti" --cookie library-name="test_ppx_staged"
 
@@ -107,7 +105,6 @@ Test using installed drivers
   Entering directory 'driver'
   $ OCAMLPATH=driver/_build/install/default/lib dune build --root use-external-driver driveruser.cma
   Entering directory 'use-external-driver'
-           ppx driveruser.pp.ml
   .ppx/35d69311d5da258d073875db2b34f33b/ppx.exe
   -arg1
   -arg2
@@ -129,7 +126,6 @@ Test using installed drivers
 
   $ OCAMLPATH=driver/_build/install/default/lib dune build --root replaces driveruser.cma
   Entering directory 'replaces'
-           ppx driveruser.pp.ml
   replacesdriver
   .ppx/886937db0da323b743b4366c6d3a795f/ppx.exe
   -arg1
@@ -154,7 +150,6 @@ Test using installed drivers
   Entering directory 'driver-replaces'
   $ OCAMLPATH=driver/_build/install/default/lib:driver-replaces/_build/install/default/lib dune build --root replaces-external driveruser.cma
   Entering directory 'replaces-external'
-           ppx driveruser.pp.ml
   replacesdriver
   .ppx/886937db0da323b743b4366c6d3a795f/ppx.exe
   -arg1

--- a/test/blackbox-tests/test-cases/env/env-bin-pform.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-bin-pform.t/run.t
@@ -1,7 +1,6 @@
 %{exe:foo.exe} should not be veisible if foo.exe is added to PATH via the
 binaries stanza. %{bin:foo} is visible on the other hand.
   $ dune build
-           foo alias default
   this is foo.exe
   Error: No rule found for foo.exe
   -> required by %{exe:foo.exe} at dune:7

--- a/test/blackbox-tests/test-cases/env/env-bins.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-bins.t/run.t
@@ -1,12 +1,10 @@
 Basic test that we can use private binaries as public ones
   $ dune build --root private-bin-import
   Entering directory 'private-bin-import'
-          priv alias using-priv/runtest
   Executing priv as priv
   PATH:
   	$TESTCASE_ROOT/private-bin-import/_build/default/using-priv/.bin
   	$TESTCASE_ROOT/private-bin-import/_build/install/default/bin
-  priv-renamed alias using-priv/runtest
   Executing priv as priv-renamed
   PATH:
   	$TESTCASE_ROOT/private-bin-import/_build/default/using-priv/.bin
@@ -15,27 +13,22 @@ Basic test that we can use private binaries as public ones
 Override public binary in env
   $ dune build --root override-bins
   Entering directory 'override-bins'
-           foo alias test/runtest
   private binary
-           foo alias default
   public binary
 
 Nest env binaries
   $ dune build --root nested-env
   Entering directory 'nested-env'
-          priv alias using-priv/nested/runtest
   Executing priv as priv
   PATH:
   	$TESTCASE_ROOT/nested-env/_build/default/using-priv/nested/.bin
   	$TESTCASE_ROOT/nested-env/_build/default/using-priv/.bin
   	$TESTCASE_ROOT/nested-env/_build/install/default/bin
-  priv-renamed alias using-priv/nested/runtest
   Executing priv as priv-renamed
   PATH:
   	$TESTCASE_ROOT/nested-env/_build/default/using-priv/nested/.bin
   	$TESTCASE_ROOT/nested-env/_build/default/using-priv/.bin
   	$TESTCASE_ROOT/nested-env/_build/install/default/bin
-  priv-renamed-nested alias using-priv/nested/runtest
   Executing priv as priv-renamed-nested
   PATH:
   	$TESTCASE_ROOT/nested-env/_build/default/using-priv/nested/.bin

--- a/test/blackbox-tests/test-cases/env/env-dune-file.t/flag-field/dune
+++ b/test/blackbox-tests/test-cases/env/env-dune-file.t/flag-field/dune
@@ -11,5 +11,5 @@
  (name default)
  (action
   (progn
-   (echo "var visible from dune: %{env:DUNE_FOO=absent}")
+   (echo "var visible from dune: %{env:DUNE_FOO=absent}\n")
    (run ./foo.exe))))

--- a/test/blackbox-tests/test-cases/env/env-dune-file.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-dune-file.t/run.t
@@ -6,14 +6,12 @@ env vars set in env should be visible to all subdirs
 env vars interpreted in various fields, such as flags
   $ dune build --force --root flag-field
   Entering directory 'flag-field'
-  var visible from dune: -principal         foo alias default
-  DUNE_FOO: -principal
+  var visible from dune: -principalDUNE_FOO: -principal
 
 global vars are overridden
   $ DUNE_FOO=blarg dune build --force --root flag-field
   Entering directory 'flag-field'
-  var visible from dune: -principal         foo alias default
-  DUNE_FOO: -principal
+  var visible from dune: -principalDUNE_FOO: -principal
 
 proper inheritance chain of env stanzas
   $ dune build --root inheritance

--- a/test/blackbox-tests/test-cases/env/env-tracking.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-tracking.t/run.t
@@ -2,7 +2,6 @@ Aliases without a (env) dependency are not rebuilt when the environment
 changes:
 
   $ dune build @without_dep
-             a alias without_dep
   X is not set
   Y is not set
   $ X=x dune build @without_dep
@@ -10,11 +9,9 @@ changes:
 But if there is a dependency, the alias gets rebuilt:
 
   $ dune build @with_dep
-             a alias with_dep
   X is not set
   Y is not set
   $ X=x dune build @with_dep
-             a alias with_dep
   X = "x"
   Y is not set
 

--- a/test/blackbox-tests/test-cases/exe-name-mangle.t/run.t
+++ b/test/blackbox-tests/test-cases/exe-name-mangle.t/run.t
@@ -5,7 +5,6 @@ Single module case. Here we technically don't need an alias module
 
   $ dune build --root single-module
   Entering directory 'single-module'
-           exe alias default
   this module is unlinkable
   this module is unlinkable
 
@@ -13,7 +12,6 @@ The multi module case always requires an alias.
 
   $ dune build --root multi-module
   Entering directory 'multi-module'
-           baz alias default
   not directly usable
 
 Multiple executables defined in the same directory

--- a/test/blackbox-tests/test-cases/force-test.t/run.t
+++ b/test/blackbox-tests/test-cases/force-test.t/run.t
@@ -1,11 +1,9 @@
 Running a test and then forcing a re-run will only re-run the test exe:
 
   $ dune runtest
-             f alias runtest
   Foo Bar
   $ dune runtest
 
 Note that nothing is rebuilt, only the binary is executed again:
   $ dune runtest --force
-             f alias runtest
   Foo Bar

--- a/test/blackbox-tests/test-cases/github1616.t/run.t
+++ b/test/blackbox-tests/test-cases/github1616.t/run.t
@@ -2,5 +2,4 @@ Regression test for #1616
 
   $ env PATH="$PWD/bin2:$PWD/bin1:$PATH" dune build --root root
   Entering directory 'root'
-          prog alias default
   Hello, World!

--- a/test/blackbox-tests/test-cases/github2228.t/run.t
+++ b/test/blackbox-tests/test-cases/github2228.t/run.t
@@ -3,7 +3,6 @@ would fail because the .cmi wasn't correctly copied to the _build/install dir.
 
   $ dune build @install
   $ dune runtest
-          test alias test/runtest
   testing
   $ dune install --prefix ./installed 2>&1 | grep -i cmi
   Installing installed/lib/foobar/foobar.cmi

--- a/test/blackbox-tests/test-cases/github3490.t/run.t
+++ b/test/blackbox-tests/test-cases/github3490.t/run.t
@@ -22,4 +22,3 @@ the test suite; but we do not need to print it so we can grep it out
 
   $ dune runtest --diff-command 'diff -u' 2>&1 | grep -v + | grep -v diff | grep -v "^--- test"
   File "test", line 1, characters 0-0:
-            sh (internal) (exit 1)

--- a/test/blackbox-tests/test-cases/github568.t/run.t
+++ b/test/blackbox-tests/test-cases/github568.t/run.t
@@ -1,3 +1,3 @@
   $ dune runtest -p lib1 --debug-dependency-path
-         test1 alias runtest
+  (cd _build/default && ./test1.exe)
   running test 1

--- a/test/blackbox-tests/test-cases/github660.t/run.t
+++ b/test/blackbox-tests/test-cases/github660.t/run.t
@@ -5,12 +5,10 @@ When there are explicit interfaces, modules must be rebuilt.
 
   $ dune runtest --root explicit-interfaces
   Entering directory 'explicit-interfaces'
-          main alias runtest
   hello
   $ echo 'let _x = 1' >> explicit-interfaces/lib_sub.ml
   $ dune runtest --root explicit-interfaces
   Entering directory 'explicit-interfaces'
-          main alias runtest
   hello
 
 When there are no interfaces, the situation is the same, but it is not possible
@@ -18,10 +16,8 @@ to rely on these.
 
   $ dune runtest --root no-interfaces
   Entering directory 'no-interfaces'
-          main alias runtest
   hello
   $ echo 'let _x = 1' >> no-interfaces/lib_sub.ml
   $ dune runtest --root no-interfaces
   Entering directory 'no-interfaces'
-          main alias runtest
   hello

--- a/test/blackbox-tests/test-cases/glob_files_rec.t/run.t
+++ b/test/blackbox-tests/test-cases/glob_files_rec.t/run.t
@@ -25,7 +25,6 @@ Leave a/b2/c empty to make sure we don't choke on empty dirs.
   $ touch foo/a/b3/x.other
 
   $ dune build @x
-          bash alias x
   foo/a/b1/c/x.txt
   foo/a/b1/c/y.txt
   foo/a/b3/x.txt
@@ -35,7 +34,7 @@ Leave a/b2/c empty to make sure we don't choke on empty dirs.
   $ find . -name \*.txt | dune_cmd count-lines
   10
   $ dune build @x --force 2>&1 | dune_cmd count-lines
-  6
+  5
 
 Check that generated files are taken into account
 -------------------------------------------------

--- a/test/blackbox-tests/test-cases/inline_tests-multi-mode.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests-multi-mode.t/run.t
@@ -29,7 +29,5 @@ Reproduction case for #3347
   $ touch test.ml
 
   $ dune runtest
-  inline_test_runner_test alias runtest
   Test byte
-  inline_test_runner_test alias runtest
   Test native

--- a/test/blackbox-tests/test-cases/inline_tests/dune-file.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/dune-file.t/run.t
@@ -4,7 +4,6 @@ externally installed.
 First we build and use the backend locally:
 
   $ dune runtest dune-file
-  inline_test_runner_foo_tests alias dune-file/runtest
   414243
 
 Then we install the backend and check that the "inline_tests.backend"
@@ -28,5 +27,4 @@ package:
 
   $ export OCAMLPATH=$PWD/_install/lib; dune runtest --root dune-file-user
   Entering directory 'dune-file-user'
-  inline_test_runner_foo_tests alias runtest
   414243

--- a/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
@@ -6,7 +6,6 @@ to be successful.
 
   $ dune runtest valid_options --root ./test-project
   Entering directory 'test-project'
-  inline_test_runner_valid_option_test alias valid_options/runtest
   backend_foo
 
 Lastly, we pass an invalid option to flags field expecting compilation

--- a/test/blackbox-tests/test-cases/inline_tests/many-backends-choose.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/many-backends-choose.t/run.t
@@ -21,5 +21,4 @@
   > EOF
 
   $ dune runtest
-  inline_test_runner_foo_mbc alias runtest
   backend_mbc1

--- a/test/blackbox-tests/test-cases/inline_tests/multiple-inline-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/multiple-inline-tests.t/run.t
@@ -27,7 +27,5 @@ Create a dummy backend and two libraries with inline_tests
 try to run them:
 
   $ env -u OCAMLRUNPARAM dune runtest
-  inline_test_runner_foo_simple1 alias runtest
   test
-  inline_test_runner_foo_simple2 alias runtest
   test

--- a/test/blackbox-tests/test-cases/inline_tests/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/simple.t/run.t
@@ -27,8 +27,6 @@
   File "dune", line 9, characters 1-40:
   9 |  (inline_tests (backend backend_simple)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  inline_test_runner_foo_simple alias runtest (exit 2)
-  (cd _build/default && .foo_simple.inline-tests/inline_test_runner_foo_simple.exe)
   Fatal error: exception File ".foo_simple.inline-tests/inline_test_runner_foo_simple.ml-gen", line 1, characters 40-46: Assertion failed
   [1]
 
@@ -43,7 +41,5 @@ The expected behavior for the following three tests is to output nothing: the te
   File "dune", line 9, characters 1-40:
   9 |  (inline_tests (backend backend_simple)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  inline_test_runner_foo_simple alias runtest (exit 2)
-  (cd _build/default && .foo_simple.inline-tests/inline_test_runner_foo_simple.exe)
   Fatal error: exception File ".foo_simple.inline-tests/inline_test_runner_foo_simple.ml-gen", line 1, characters 40-46: Assertion failed
   [1]

--- a/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
@@ -5,12 +5,9 @@ Run inline tests using node js
   > EOF
 
   $ dune runtest
-  inline_test_runner_inline_tests_byte alias byte/runtest
   inline tests (Byte)
   inline tests (Byte)
-          node alias js/runtest
   inline tests (JS)
   inline tests (JS)
-  inline_test_runner_inline_tests_native alias native/runtest
   inline tests (Native)
   inline tests (Native)

--- a/test/blackbox-tests/test-cases/multi-dir.t/run.t
+++ b/test/blackbox-tests/test-cases/multi-dir.t/run.t
@@ -3,7 +3,6 @@ Simple test with a multi dir exe
 
   $ dune build --root test1
   Entering directory 'test1'
-           foo alias default
   Hello, world!
 
 Test that include_subdirs stop the recursion
@@ -11,7 +10,6 @@ Test that include_subdirs stop the recursion
 
   $ dune build --root test2
   Entering directory 'test2'
-          main alias default
   Hello, world!
 
 Test with C stubs in sub-directories

--- a/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
@@ -25,9 +25,9 @@ These packages are in a nested env, the option is disabled, should success with 
 In release mode, no error:
 
   $ dune build -p foo_doc,foo_lib @doc
-          odoc _doc/_odoc/pkg/foo_doc/page-foo.odoc
+  (cd _build/default/_doc/_odoc/pkg/foo_doc && /home/dim/.opam/4.12.0/bin/odoc compile --pkg foo_doc -o page-foo.odoc ../../../../foo_doc/foo.mld)
   File "../../../../foo_doc/foo.mld", line 4, characters 0-0:
   End of text is not allowed in '[...]' (code).
-          odoc foo_lib/.foo.objs/byte/foo.odoc
+  (cd _build/default/foo_lib/.foo.objs/byte && /home/dim/.opam/4.12.0/bin/odoc compile -I . -I ../../../_doc/_odoc/pkg/foo_lib --pkg foo_lib -o foo.odoc foo.cmti)
   File "foo_lib/foo.mli", line 1, characters 7-7:
   End of text is not allowed in '[...]' (code).

--- a/test/blackbox-tests/test-cases/output-obj.t/run.t
+++ b/test/blackbox-tests/test-cases/output-obj.t/run.t
@@ -1,12 +1,8 @@
   $ dune build @all
   $ dune build @runtest 2>&1 | dune_cmd sanitize
-        static alias runtest
   OK: ./static.exe
-        static alias runtest
   OK: ./static.bc
-       dynamic alias runtest
   OK: ./dynamic.exe ./test.bc$ext_dll
-       dynamic alias runtest
   OK: ./dynamic.exe ./test$ext_dll
 #        static alias runtest
 #  OK: ./static.bc.c.exe

--- a/test/blackbox-tests/test-cases/package-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/package-dep.t/run.t
@@ -1,3 +1,2 @@
   $ dune runtest
-          test alias runtest
   42 42

--- a/test/blackbox-tests/test-cases/path-rewriting.t
+++ b/test/blackbox-tests/test-cases/path-rewriting.t
@@ -9,12 +9,10 @@ rewrite the current working directory:
   > EOF
 
   $ dune build
-            sh x
   /workspace_root
 
 It works with sandboxing as well:
 
   $ dune clean
   $ dune build --sandbox copy
-            sh x
   /workspace_root

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -33,7 +33,6 @@ You need to set the language to 2.7 or higher for it to work:
   > EOF
 
   $ dune build @pipe
-            tr alias pipe
   x
   y
   z

--- a/test/blackbox-tests/test-cases/ppx-rewriter.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter.t/run.t
@@ -1,5 +1,4 @@
   $ dune build ./w_omp_driver.exe
-           ppx w_omp_driver.pp.ml
   -arg: omp
 
 This test is broken because ppx_driver doesn't support migrate custom arguments

--- a/test/blackbox-tests/test-cases/private-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/private-modules.t/run.t
@@ -1,6 +1,5 @@
   $ dune build --root accessible-via-public
   Entering directory 'accessible-via-public'
-        runfoo alias default
   private module bar
 
   $ dune build --root inaccessible-in-deps 2>&1

--- a/test/blackbox-tests/test-cases/quoting.t/run.t
+++ b/test/blackbox-tests/test-cases/quoting.t/run.t
@@ -25,7 +25,6 @@ The targets should only be interpreted as a single path when quoted
 
   $ dune runtest --root quote-from-context
   Entering directory 'quote-from-context'
-    count_args alias runtest
   Number of args: 3
 
   $ dune runtest --root quotes-multi

--- a/test/blackbox-tests/test-cases/reason.t/run.t
+++ b/test/blackbox-tests/test-cases/reason.t/run.t
@@ -3,7 +3,6 @@ Tests for reason
 Build and run a reason binary:
 
   $ dune build @runtest
-          rbin alias runtest
   Cppome
   hello world
   Bar

--- a/test/blackbox-tests/test-cases/report-all-errors.t
+++ b/test/blackbox-tests/test-cases/report-all-errors.t
@@ -52,11 +52,9 @@ failing before it had a chance to start thinking about building `z`.
   File "dune", line 10, characters 0-42:
   10 | (rule (with-stdout-to y (run ./fail.exe)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          fail y (exit 1)
-  (cd _build/default && ./fail.exe) > _build/default/y
+  Command exited with code 1.
   File "dune", line 11, characters 0-42:
   11 | (rule (with-stdout-to z (run ./fail.exe)))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          fail z (exit 1)
-  (cd _build/default && ./fail.exe) > _build/default/z
+  Command exited with code 1.
   [1]

--- a/test/blackbox-tests/test-cases/select.t/run.t
+++ b/test/blackbox-tests/test-cases/select.t/run.t
@@ -15,7 +15,6 @@
   > EOF
 
   $ dune runtest
-          main alias runtest
   bar has unix
   foo has no fake
 
@@ -36,6 +35,5 @@
   > EOF
 
   $ dune runtest
-          main alias runtest
   bar has unix
   foo has no fake

--- a/test/blackbox-tests/test-cases/tests-stanza-action.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza-action.t/run.t
@@ -2,7 +2,6 @@ If there is an (action) field, it is used to invoke to the executable (in both
 regular and expect modes:
 
   $ dune build @explicit-regular/runtest
-       my_test alias explicit-regular/runtest
   argv[0] = "./my_test.exe"
   argv[1] = "arg1"
   argv[2] = "arg2"
@@ -13,5 +12,4 @@ regular and expect modes:
 If there is no field, the program is run with no arguments:
 
   $ dune build @default/runtest
-       my_test alias default/runtest
   argv[0] = "./my_test.exe"

--- a/test/blackbox-tests/test-cases/tests-stanza.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza.t/run.t
@@ -1,13 +1,10 @@
   $ dune runtest --root singular
   Entering directory 'singular'
-      singular alias runtest
   singular test
 
   $ dune runtest --root plural
   Entering directory 'plural'
-  regular_test alias runtest
   regular test
-  regular_test2 alias runtest
   regular test2
   $ dune runtest --root generated
   Entering directory 'generated'

--- a/test/blackbox-tests/test-cases/vendor/main.t/run.t
+++ b/test/blackbox-tests/test-cases/vendor/main.t/run.t
@@ -7,7 +7,6 @@ Aliases should not be resolved in vendored sub directories
 
   $ dune runtest --root duniverse
   Entering directory 'duniverse'
-          test alias tests/runtest
   Hello from main lib!
 
 When compiling vendored code, all warnings should be disabled

--- a/test/blackbox-tests/test-cases/virtual-libraries/impl-private-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/impl-private-modules.t/run.t
@@ -1,5 +1,4 @@
 They can only introduce private modules:
   $ dune build --debug-dependency-path
-          test alias default
   Private module Baz
   implementing bar

--- a/test/blackbox-tests/test-cases/virtual-libraries/impl-using-vlib-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/impl-using-vlib-modules.t/run.t
@@ -1,5 +1,4 @@
 Implementations may refer to virtual library's modules
   $ dune build
-          test alias default
   bar from vlib
   Foo.run implemented

--- a/test/blackbox-tests/test-cases/virtual-libraries/implements-external.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/implements-external.t/run.t
@@ -7,25 +7,21 @@ First we create an external library
 Then we make sure that we can implement it
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl --debug-dependency-path
   Entering directory 'impl'
-          test alias default
   bar from vlib
   Foo.run implemented
 
 Make sure that we can also implement native only variants
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl-native-only --debug-dependency-path
   Entering directory 'impl-native-only'
-           run alias default
   implement virtual module
 
 We can implement external variants with mli only modules
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl-intf-only --debug-dependency-path
   Entering directory 'impl-intf-only'
-           run alias default
   implemented mli only
   magic number: 42
 
 Implement external virtual libraries with private modules
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl-private-module --debug-dependency-path
   Entering directory 'impl-private-module'
-           run alias default
   Name: implement virtual module. Magic number: 42

--- a/test/blackbox-tests/test-cases/virtual-libraries/preprocess.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/preprocess.t/run.t
@@ -1,4 +1,3 @@
 Virtual libraries and preprocessed source
   $ dune build
-          test alias default
   foo

--- a/test/blackbox-tests/test-cases/virtual-libraries/private-modules-overlapping-names.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/private-modules-overlapping-names.t/run.t
@@ -1,6 +1,5 @@
 Implementations may have private modules that have overlapping names with the
 virtual lib
   $ dune build
-           foo alias default
   impl's own Priv.run
   implementation of foo

--- a/test/blackbox-tests/test-cases/virtual-libraries/unwrapped.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/unwrapped.t/run.t
@@ -1,6 +1,5 @@
 Unwrapped virtual library
   $ dune build
-           foo alias default
   Running from vlib_more
   running implementation
 
@@ -9,6 +8,5 @@ Unwrapped virtual library
   Entering directory 'vlib'
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl --debug-dependency-path
   Entering directory 'impl'
-           foo alias default
   Running from vlib_more
   running implementation

--- a/test/blackbox-tests/test-cases/virtual-libraries/variants-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/variants-simple.t/run.t
@@ -1,4 +1,3 @@
 Virtual library with a single module
   $ dune build
-           foo alias default
   running implementation

--- a/test/blackbox-tests/test-cases/virtual-libraries/variants-sub-module.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/variants-sub-module.t/run.t
@@ -1,4 +1,3 @@
 Virtual library where a wrapped module is virtual
   $ dune build
-           run alias default
   Impl's Vmd.run ()

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl.t/run.t
@@ -11,7 +11,6 @@ in an appropriate error message.
 Basic sample selecting implementation according to default library.
   $ dune build --root default-impl
   Entering directory 'default-impl'
-           bar alias default
   hi from lib.default
 
 Check that default implementation data is installed in the dune package file.
@@ -106,5 +105,4 @@ First we create an external library and implementation
 Then we make sure that it works fine.
   $ env OCAMLPATH=external/lib/_build/install/default/lib dune build --root external/exe --debug-dependency-path
   Entering directory 'external/exe'
-           bar alias default
   hey

--- a/test/blackbox-tests/test-cases/with-exit-codes.t/run.t
+++ b/test/blackbox-tests/test-cases/with-exit-codes.t/run.t
@@ -25,7 +25,6 @@
   6 |  (alias a)
   7 |  (action (with-accepted-exit-codes 0 (run ./exit.exe 1))))
           exit alias a (exit 1)
-  (cd _build/default && ./exit.exe 1)
   [1]
 
   $ cat >> dune <<EOF
@@ -55,7 +54,6 @@
   15 |  (alias d)
   16 |  (action (with-accepted-exit-codes (or 4 5 6) (run ./exit.exe 7))))
           exit alias d (exit 7)
-  (cd _build/default && ./exit.exe 7)
   [1]
 
   $ cat >> dune <<EOF

--- a/test/blackbox-tests/test-cases/with-nested-exit-codes.t/run.t
+++ b/test/blackbox-tests/test-cases/with-nested-exit-codes.t/run.t
@@ -90,7 +90,6 @@
   39 |              (with-stdout-to out2.txt
   40 |               (run ./exit.exe 1))))))))
           exit out2.txt (exit 1)
-  (cd _build/default && ./exit.exe 1) < _build/default/input > _build/default/out2.txt
   [1]
 
   $ cat >> dune <<EOF

--- a/test/blackbox-tests/test-cases/workspace-paths.t/run.t
+++ b/test/blackbox-tests/test-cases/workspace-paths.t/run.t
@@ -5,7 +5,6 @@ is prohibited.
   $ chmod u+w bin/hello.exe
 
   $ dune build
-         hello alias default
   Hello: $TESTCASE_ROOT/a:/c
 
   $ mkdir sub

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -417,7 +417,6 @@ let%expect_test "error from user rule" =
     stderr:
     waiting for inotify sync
     waited for inotify sync
-            bash foo
     foobar
     File "dune", line 1, characters 0-49:
     1 | (rule (target foo) (action (bash "echo foobar")))


### PR DESCRIPTION
The short display is a bit confusing if we are not in `--display short` mode. So stop printing it. When a command fails with no output, we ended up printing nothing so in this case I added a "Command exited with code N." line.

I also re-organised the printing code inside `process.ml` as it was spaghetti code.

One other visible change is that we print the full command line less often. We often have good locations in Dune, so it seems ok to me but that's up for discussion.