### PR TITLE
Add more tests for the current behaviour of target promotion

### DIFF
--- a/test/blackbox-tests/test-cases/promote/dep-on-promoted-target.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/dep-on-promoted-target.t/run.t
@@ -1,0 +1,104 @@
+Depending on a promoted file works.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (mode promote)
+  >   (deps original)
+  >   (target promoted)
+  >   (action (copy %{deps} %{target})))
+  > (rule
+  >   (deps promoted)
+  >   (target result)
+  >   (action (bash "cat promoted promoted > result")))
+  > EOF
+
+  $ echo hi > original
+  $ dune build result
+  $ cat promoted
+  hi
+  $ cat _build/default/result
+  hi
+  hi
+
+Now change the [original] and rebuild.
+
+  $ echo bye > original
+  $ dune build result
+  $ cat promoted
+  bye
+  $ cat _build/default/result
+  bye
+  bye
+
+Now switch the mode to standard. Dune reports an error about multiple rules for
+[_build/default/promoted], as expected.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (mode standard)
+  >   (deps original)
+  >   (target promoted)
+  >   (action (copy %{deps} %{target})))
+  > (rule
+  >   (deps promoted)
+  >   (target result)
+  >   (action (bash "cat promoted promoted > result")))
+  > EOF
+
+  $ dune build result
+  Error: Multiple rules generated for _build/default/promoted:
+  - file present in source tree
+  - dune:1
+  Hint: rm -f promoted
+  [1]
+
+We use the hint and it starts to work.
+
+  $ rm -f promoted
+  $ dune build result
+  $ cat promoted
+  cat: promoted: No such file or directory
+  [1]
+  $ cat _build/default/promoted
+  bye
+  $ cat _build/default/result
+  bye
+  bye
+
+Now use [fallback] to override the rule that generates [promoted].
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (mode fallback)
+  >   (deps original)
+  >   (target promoted)
+  >   (action (copy %{deps} %{target})))
+  > (rule
+  >   (deps promoted)
+  >   (target result)
+  >   (action (bash "cat promoted promoted > result")))
+  > EOF
+
+At first, we don't have the source, so the rule is used.
+
+  $ dune build result
+  $ cat promoted
+  cat: promoted: No such file or directory
+  [1]
+  $ cat _build/default/promoted
+  bye
+  $ cat _build/default/result
+  bye
+  bye
+
+Now we create the source file and it overrides the rule.
+
+  $ echo hi > promoted
+  $ dune build result
+  $ cat promoted
+  hi
+  $ cat _build/default/promoted
+  hi
+  $ cat _build/default/result
+  hi
+  hi

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -108,14 +108,14 @@ Only "only1" should be promoted in the source tree:
   $ ls -1 only*
   only1
 
-Test that Dune restores only1 if it's deleted from the source tree
+Dune restores only1 if it's deleted from the source tree
 
   $ rm only1
   $ dune build only2
   $ ls -1 only*
   only1
 
-Test that Dune restores only1 if it's modified in the source tree
+Dune restores only1 if it's modified in the source tree
 
   $ cat only1
   0

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -1,0 +1,108 @@
+Test target promotion in file-watching mode.
+
+  $ . ./helpers.sh
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >   (mode promote)
+  >   (deps original)
+  >   (target promoted)
+  >   (action (copy %{deps} %{target})))
+  > (rule
+  >   (deps promoted)
+  >   (target result)
+  >   (action (bash "cat promoted promoted > result")))
+  > EOF
+  $ echo hi > original
+
+  $ start_dune
+
+  $ build result
+  Success
+  $ cat promoted
+  hi
+  $ cat _build/default/result
+  hi
+  hi
+
+Now change the [original] and rebuild.
+
+  $ echo bye > original
+  $ build result
+  Success
+  $ cat promoted
+  bye
+  $ cat _build/default/result
+  bye
+  bye
+
+Now try deleting the promoted file.
+
+  $ rm promoted
+  $ build result
+  Success
+  $ cat promoted
+  bye
+  $ cat _build/default/result
+  bye
+  bye
+
+Now try replacing its content.
+
+  $ echo hi > promoted
+  $ build result
+  Success
+  $ cat promoted
+  bye
+  $ cat _build/default/result
+  bye
+  bye
+
+Now replace the content and switch the mode to standard. Note that this case is
+currently not handled correctly: instead of succeeding, we should report a rule
+conflict, as we do in the batch build mode -- see [dep-on-promoted-target.t].
+
+# CR-someday amokhov: Fix this test.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (mode standard)
+  >   (deps original)
+  >   (target promoted)
+  >   (action (copy %{deps} %{target})))
+  > (rule
+  >   (deps promoted)
+  >   (target result)
+  >   (action (bash "cat promoted promoted > result")))
+  > EOF
+  $ echo hi > promoted
+
+  $ build result
+  Success
+  $ cat promoted
+  hi
+  $ cat _build/default/promoted
+  bye
+  $ cat _build/default/result
+  bye
+  bye
+
+We're done.
+
+  $ stop_dune
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...


### PR DESCRIPTION
I'm making some changes around the target promotion logic, so I'd like to add some more tests.

Note that this reveals a bug in the file-watching mode.