### PR TITLE
Make sandbox config a field of actions rather than a dependency

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -283,6 +283,7 @@ module Full = struct
       ; env : Env.t
       ; locks : Path.t list
       ; can_go_in_shared_cache : bool
+      ; sandbox : Sandbox_config.t
       }
 
     let empty =
@@ -290,14 +291,16 @@ module Full = struct
       ; env = Env.empty
       ; locks = []
       ; can_go_in_shared_cache = true
+      ; sandbox = Sandbox_config.default
       }
 
-    let combine { action; env; locks; can_go_in_shared_cache } x =
+    let combine { action; env; locks; can_go_in_shared_cache; sandbox } x =
       { action = combine action x.action
       ; env = Env.extend_env env x.env
       ; locks = locks @ x.locks
       ; can_go_in_shared_cache =
           can_go_in_shared_cache && x.can_go_in_shared_cache
+      ; sandbox = Sandbox_config.inter sandbox x.sandbox
       }
   end
 
@@ -305,8 +308,15 @@ module Full = struct
   include Monoid.Make (T)
 
   let make ?(env = Env.empty) ?(locks = []) ?(can_go_in_shared_cache = true)
-      action =
-    { action; env; locks; can_go_in_shared_cache }
+      ?(sandbox = Sandbox_config.default) action =
+    { action; env; locks; can_go_in_shared_cache; sandbox }
 
   let map t ~f = { t with action = f t.action }
+
+  let add_locks l t = { t with locks = t.locks @ l }
+
+  let add_can_go_in_shared_cache b t =
+    { t with can_go_in_shared_cache = t.can_go_in_shared_cache && b }
+
+  let add_sandbox s t = { t with sandbox = Sandbox_config.inter t.sandbox s }
 end

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -127,16 +127,29 @@ module Full : sig
     ; env : Env.t
     ; locks : Path.t list
     ; can_go_in_shared_cache : bool
+    ; sandbox : Sandbox_config.t
     }
 
   val make :
        ?env:Env.t (** default [Env.empty] *)
     -> ?locks:Path.t list (** default [\[\]] *)
     -> ?can_go_in_shared_cache:bool (** default [true] *)
+    -> ?sandbox:Sandbox_config.t (** default [Sandbox_config.default] *)
     -> action
     -> t
 
   val map : t -> f:(action -> action) -> t
+
+  (** The various [add_xxx] functions merge the given value with existing field
+      of the action. Put another way, [add_xxx x t] is the same as:
+
+      {[ combine t (make ~xxx:x (Progn [])) ]} *)
+
+  val add_locks : Path.t list -> t -> t
+
+  val add_sandbox : Sandbox_config.t -> t -> t
+
+  val add_can_go_in_shared_cache : bool -> t -> t
 
   include Monoid with type t := t
 end

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -6,7 +6,6 @@ type t = private
   | Alias of Alias.t
   | File_selector of File_selector.t
   | Universe
-  | Sandbox_config of Sandbox_config.t
 
 val file : Path.t -> t
 
@@ -18,16 +17,12 @@ val file_selector : File_selector.t -> t
 
 val alias : Alias.t -> t
 
-val sandbox_config : Sandbox_config.t -> t
-
 val compare : t -> t -> Ordering.t
 
 module Map : sig
   type dep := t
 
   include Map.S with type key := t
-
-  val sandbox_config : _ t -> Sandbox_config.t
 
   val has_universe : _ t -> bool
 
@@ -109,7 +104,7 @@ module Facts : sig
   (** Parent directories of all dependencies. *)
   val parent_dirs : t -> Path.Set.t
 
-  val digest : t -> sandbox_mode:Sandbox_mode.t -> env:Env.t -> Digest.t
+  val digest : t -> env:Env.t -> Digest.t
 
   val to_dyn : t -> Dyn.t
 end

--- a/src/dune_engine/reflection.ml
+++ b/src/dune_engine/reflection.ml
@@ -51,8 +51,7 @@ end = struct
         | File_selector g -> Build_system.eval_pred g
         | Alias a -> Expand.alias a
         | Env _
-        | Universe
-        | Sandbox_config _ ->
+        | Universe ->
           Memo.Build.return Path.Set.empty)
     >>| Path.Set.union_all
 end

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -93,8 +93,7 @@ val to_dyn : t -> Dyn.t
 (** [make] raises an error if the set of [targets] is not well-formed. See the
     [Targets.Validation_result] data type for the list of possible problems. *)
 val make :
-     ?sandbox:Sandbox_config.t
-  -> ?mode:Mode.t
+     ?mode:Mode.t
   -> context:Build_context.t option
   -> ?info:Info.t
   -> targets:Targets.t

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -488,7 +488,7 @@ let rec expand (t : Action_dune_lang.t) : Action.t Action_expander.t =
 
 let expand_no_targets t ~loc ~deps:deps_written_by_user ~expander ~what =
   let open Action_builder.O in
-  let deps_builder, expander =
+  let deps_builder, expander, sandbox =
     Dep_conf_eval.named ~expander deps_written_by_user
   in
   let expander =
@@ -508,12 +508,12 @@ let expand_no_targets t ~loc ~deps:deps_written_by_user ~expander ~what =
   let+ () = deps_builder
   and+ action = build in
   let dir = Path.build (Expander.dir expander) in
-  Action.Full.make (Action.Chdir (dir, action))
+  Action.Full.make (Action.Chdir (dir, action)) ~sandbox
 
 let expand t ~loc ~deps:deps_written_by_user ~targets_dir
     ~targets:targets_written_by_user ~expander =
   let open Action_builder.O in
-  let deps_builder, expander =
+  let deps_builder, expander, sandbox =
     Dep_conf_eval.named ~expander deps_written_by_user
   in
   let expander =
@@ -565,7 +565,7 @@ let expand t ~loc ~deps:deps_written_by_user ~targets_dir
     let+ () = deps_builder
     and+ action = build in
     let dir = Path.build (Expander.dir expander) in
-    Action.Full.make (Action.Chdir (dir, action))
+    Action.Full.make (Action.Chdir (dir, action)) ~sandbox
   in
   Action_builder.with_targets ~targets build
 

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -904,6 +904,7 @@ let gen_configurator_rules t =
          ; env = Env.empty
          ; locks = []
          ; can_go_in_shared_cache = true
+         ; sandbox = Sandbox_config.no_special_requirements
          }))
   in
   let fn = configurator_v2 t in
@@ -927,6 +928,7 @@ let gen_configurator_rules t =
        ; env = Env.empty
        ; locks = []
        ; can_go_in_shared_cache = true
+       ; sandbox = Sandbox_config.no_special_requirements
        }))
 
 let force_configurator_files =

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -381,11 +381,10 @@ let coqc_rule (cctx : _ Context.t) ~file_flags coq_module =
   let open Action_builder.With_targets.O in
   (* The way we handle the transitive dependencies of .vo files is not safe for
      sandboxing *)
-  Action_builder.with_no_targets
-    (Action_builder.dep (Dep.sandbox_config Sandbox_config.no_sandboxing))
-  >>>
+  let sandbox = Sandbox_config.no_sandboxing in
   let coq_flags = Context.coq_flags cctx in
   Context.coqc cctx (Command.Args.dyn coq_flags :: file_flags)
+  >>| Action.Full.add_sandbox sandbox
 
 module Module_rule = struct
   type t =

--- a/src/dune_rules/cram_rules.ml
+++ b/src/dune_rules/cram_rules.ml
@@ -9,6 +9,7 @@ type effective =
   { loc : Loc.t
   ; alias : Alias.Name.Set.t
   ; deps : unit Action_builder.t list
+  ; sandbox : Sandbox_config.t
   ; enabled_if : Blang.t list
   ; locks : Path.Set.t
   ; packages : Package.Name.Set.t
@@ -20,6 +21,7 @@ let empty_effective =
   ; enabled_if = [ Blang.true_ ]
   ; locks = Path.Set.empty
   ; deps = []
+  ; sandbox = Sandbox_config.needs_sandboxing
   ; packages = Package.Name.Set.empty
   }
 
@@ -84,11 +86,8 @@ let test_rule ~sctx ~expander ~dir (spec : effective)
           | Dir { dir; file = _ } ->
             let dir = Path.build (Path.Build.append_source prefix_with dir) in
             Action_builder.source_tree ~dir
-        and+ () =
-          Action_builder.dep
-            (Dep.sandbox_config Sandbox_config.needs_sandboxing)
         in
-        Action.Full.make action ~locks
+        Action.Full.make action ~locks ~sandbox:spec.sandbox
       in
       Memo.Build.parallel_iter aliases ~f:(fun alias ->
           Alias_rules.add sctx ~alias ~loc cram))
@@ -144,15 +143,15 @@ let rules ~sctx ~expander ~dir tests =
             | false -> acc
             | true ->
               let* acc = acc in
-              let* deps =
+              let* deps, sandbox =
                 match spec.deps with
-                | None -> Memo.Build.return acc.deps
+                | None -> Memo.Build.return (acc.deps, acc.sandbox)
                 | Some deps ->
-                  let+ (deps : unit Action_builder.t) =
+                  let+ (deps : unit Action_builder.t), _, sandbox =
                     let+ expander = Super_context.expander sctx ~dir in
-                    fst (Dep_conf_eval.named ~expander deps)
+                    Dep_conf_eval.named ~expander deps
                   in
-                  deps :: acc.deps
+                  (deps :: acc.deps, Sandbox_config.inter acc.sandbox sandbox)
               in
               let enabled_if = spec.enabled_if :: acc.enabled_if in
               let alias =
@@ -174,7 +173,7 @@ let rules ~sctx ~expander ~dir tests =
                     >>| Path.relative (Path.build dir))
                 >>| Path.Set.of_list >>| Path.Set.union acc.locks
               in
-              { acc with enabled_if; locks; deps; alias; packages })
+              { acc with enabled_if; locks; deps; alias; packages; sandbox })
       in
       let test_rule () = test_rule ~sctx ~expander ~dir effective test in
       Only_packages.get () >>= function

--- a/src/dune_rules/dep_conf_eval.mli
+++ b/src/dune_rules/dep_conf_eval.mli
@@ -4,7 +4,10 @@ open! Stdune
 open! Dune_engine
 
 (** Evaluates unnamed dependency specifications. *)
-val unnamed : expander:Expander.t -> Dep_conf.t list -> unit Action_builder.t
+val unnamed :
+     expander:Expander.t
+  -> Dep_conf.t list
+  -> unit Action_builder.t * Sandbox_config.t
 
 (** Evaluates named dependency specifications. Return the action build that
     register dependencies as well as an expander that can be used to expand to
@@ -12,4 +15,4 @@ val unnamed : expander:Expander.t -> Dep_conf.t list -> unit Action_builder.t
 val named :
      expander:Expander.t
   -> Dep_conf.t Bindings.t
-  -> unit Action_builder.t * Expander.t
+  -> unit Action_builder.t * Expander.t * Sandbox_config.t

--- a/src/dune_rules/exe.mli
+++ b/src/dune_rules/exe.mli
@@ -45,6 +45,7 @@ val link_many :
      ?link_args:Command.Args.without_targets Command.Args.t Action_builder.t
   -> ?o_files:Path.t list
   -> ?embed_in_plugin_libraries:(Loc.t * Lib_name.t) list
+  -> ?sandbox:Sandbox_config.t
   -> dep_graphs:Dep_graph.t Import.Ml_kind.Dict.t
   -> programs:Program.t list
   -> linkages:Linkage.t list
@@ -56,6 +57,7 @@ val build_and_link :
      ?link_args:Command.Args.without_targets Command.Args.t Action_builder.t
   -> ?o_files:Path.t list
   -> ?embed_in_plugin_libraries:(Loc.t * Lib_name.t) list
+  -> ?sandbox:Sandbox_config.t
   -> program:Program.t
   -> linkages:Linkage.t list
   -> promote:Rule.Promote.t option
@@ -66,6 +68,7 @@ val build_and_link_many :
      ?link_args:Command.Args.without_targets Command.Args.t Action_builder.t
   -> ?o_files:Path.t list
   -> ?embed_in_plugin_libraries:(Loc.t * Lib_name.t) list
+  -> ?sandbox:Sandbox_config.t
   -> programs:Program.t list
   -> linkages:Linkage.t list
   -> promote:Rule.Promote.t option

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -173,11 +173,11 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   let+ () =
     (* Building an archive for foreign stubs, we link the corresponding object
        files directly to improve perf. *)
+    let link_deps, sandbox = Dep_conf_eval.unnamed ~expander exes.link_deps in
     let link_args =
       let standard = Action_builder.return [] in
       let open Action_builder.O in
       let link_flags =
-        let link_deps = Dep_conf_eval.unnamed ~expander exes.link_deps in
         link_deps
         >>> Expander.expand_and_eval_set expander exes.link_flags ~standard
       in
@@ -213,7 +213,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
     match buildable.Buildable.ctypes with
     | None ->
       Exe.build_and_link_many cctx ~programs ~linkages ~link_args ~o_files
-        ~promote:exes.promote ~embed_in_plugin_libraries
+        ~promote:exes.promote ~embed_in_plugin_libraries ~sandbox
     | Some _ctypes ->
       (* Ctypes stubgen builds utility .exe files that need to share modules
          with this compilation context. To support that, we extract the one-time
@@ -230,7 +230,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       in
       let* () = Module_compilation.build_all cctx ~dep_graphs in
       Exe.link_many ~programs ~dep_graphs ~linkages ~link_args ~o_files
-        ~promote:exes.promote ~embed_in_plugin_libraries cctx
+        ~promote:exes.promote ~embed_in_plugin_libraries cctx ~sandbox
   in
   ( cctx
   , Merlin.make ~requires:requires_compile ~stdlib_dir ~flags ~modules

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -227,7 +227,8 @@ include Sub_system.Register_end_point (struct
              Path.build (Path.Build.relative inline_test_dir (name ^ ext))
            in
            let open Action_builder.O in
-           let+ () = Dep_conf_eval.unnamed info.deps ~expander
+           let deps, sandbox = Dep_conf_eval.unnamed info.deps ~expander in
+           let+ () = deps
            and+ () = Action_builder.paths source_files
            and+ () = Action_builder.path exe
            and+ action =
@@ -251,7 +252,7 @@ include Sub_system.Register_end_point (struct
                | Ok p -> Action_builder.path p >>> Action_builder.return action)
            in
            let run_tests = Action.chdir (Path.build dir) action in
-           Action.Full.make
+           Action.Full.make ~sandbox
            @@ Action.progn
                 (run_tests
                 :: List.map source_files ~f:(fun fn ->

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -254,13 +254,14 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog
           , [ A "test" ] @ prelude_args
             @ [ A "-o"; Target files.corrected; Dep (Path.build files.src) ] )
       in
-      Action_builder.(
-        with_no_targets
-          (Dep_conf_eval.unnamed ~expander
-             (mdx_package_deps @ mdx_generic_deps)))
+      let deps, sandbox =
+        Dep_conf_eval.unnamed ~expander (mdx_package_deps @ mdx_generic_deps)
+      in
+      Action_builder.with_no_targets deps
       >>> Action_builder.with_no_targets (Action_builder.dyn_deps dyn_deps)
       >>> Command.run ~dir:(Path.build dir) ~stdout_to:files.corrected
             executable command_line
+      >>| Action.Full.add_sandbox sandbox
     in
     Super_context.add_rule sctx ~loc ~dir mdx_action
   in

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -123,7 +123,7 @@ end
 type t =
   { source : Source.t
   ; obj_name : Module_name.Unique.t
-  ; pp : string list Action_builder.t option
+  ; pp : (string list Action_builder.t * Sandbox_config.t) option
   ; visibility : Visibility.t
   ; kind : Kind.t
   }

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -56,7 +56,7 @@ val name : t -> Module_name.t
 
 val source : t -> ml_kind:Ml_kind.t -> File.t option
 
-val pp_flags : t -> string list Action_builder.t option
+val pp_flags : t -> (string list Action_builder.t * Sandbox_config.t) option
 
 val file : t -> ml_kind:Ml_kind.t -> Path.t option
 
@@ -75,7 +75,7 @@ val add_file : t -> Ml_kind.t -> File.t -> t
 val map_files : t -> f:(Ml_kind.t -> File.t -> File.t) -> t
 
 (** Set preprocessing flags *)
-val set_pp : t -> string list Action_builder.t option -> t
+val set_pp : t -> (string list Action_builder.t * Sandbox_config.t) option -> t
 
 val wrapped_compat : t -> t
 

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -76,17 +76,20 @@ let deps_of ~cctx ~ml_kind unit =
   let open Memo.Build.O in
   let* () =
     SC.add_rule sctx ~dir
-      (let flags =
-         Option.value (Module.pp_flags unit) ~default:(Action_builder.return [])
-       in
-       Command.run context.ocamldep
-         ~dir:(Path.build context.build_dir)
-         [ A "-modules"
-         ; Command.Args.dyn flags
-         ; Command.Ml_kind.flag ml_kind
-         ; Dep (Module.File.path source)
-         ]
-         ~stdout_to:ocamldep_output)
+      (let open Action_builder.With_targets.O in
+      let flags, sandbox =
+        Option.value (Module.pp_flags unit)
+          ~default:(Action_builder.return [], Sandbox_config.default)
+      in
+      Command.run context.ocamldep
+        ~dir:(Path.build context.build_dir)
+        [ A "-modules"
+        ; Command.Args.dyn flags
+        ; Command.Ml_kind.flag ml_kind
+        ; Dep (Module.File.path source)
+        ]
+        ~stdout_to:ocamldep_output
+      >>| Action.Full.add_sandbox sandbox)
   in
   let build_paths dependencies =
     let dependency_file_path m =

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -328,24 +328,23 @@ let extend_action t ~dir build =
   let env = Env.extend_env env act.env in
   { act with env; action }
 
-let make_rule t ?sandbox ?mode ?loc ~dir
-    { Action_builder.With_targets.build; targets } =
+let make_rule t ?mode ?loc ~dir { Action_builder.With_targets.build; targets } =
   let build = extend_action t build ~dir in
-  Rule.make ?sandbox ?mode ~info:(Rule.Info.of_loc_opt loc)
+  Rule.make ?mode ~info:(Rule.Info.of_loc_opt loc)
     ~context:(Some (Context.build_context t.context))
     ~targets build
 
-let add_rule t ?sandbox ?mode ?loc ~dir build =
-  let rule = make_rule t ?sandbox ?mode ?loc ~dir build in
+let add_rule t ?mode ?loc ~dir build =
+  let rule = make_rule t ?mode ?loc ~dir build in
   Rules.Produce.rule rule
 
-let add_rule_get_targets t ?sandbox ?mode ?loc ~dir build =
-  let rule = make_rule t ?sandbox ?mode ?loc ~dir build in
+let add_rule_get_targets t ?mode ?loc ~dir build =
+  let rule = make_rule t ?mode ?loc ~dir build in
   let+ () = Rules.Produce.rule rule in
   rule.targets
 
-let add_rules t ?sandbox ~dir builds =
-  Memo.Build.parallel_iter builds ~f:(add_rule t ?sandbox ~dir)
+let add_rules t ~dir builds =
+  Memo.Build.parallel_iter builds ~f:(add_rule t ~dir)
 
 let add_alias_action t alias ~dir ~loc ?(patch_back_source_tree = false) action
     =

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -106,7 +106,6 @@ val find_project_by_key : t -> Dune_project.File_key.t -> Dune_project.t
 
 val add_rule :
      t
-  -> ?sandbox:Sandbox_config.t
   -> ?mode:Rule.Mode.t
   -> ?loc:Loc.t
   -> dir:Path.Build.t
@@ -115,7 +114,6 @@ val add_rule :
 
 val add_rule_get_targets :
      t
-  -> ?sandbox:Sandbox_config.t
   -> ?mode:Rule.Mode.t
   -> ?loc:Loc.t
   -> dir:Path.Build.t
@@ -124,7 +122,6 @@ val add_rule_get_targets :
 
 val add_rules :
      t
-  -> ?sandbox:Sandbox_config.t
   -> dir:Path.Build.t
   -> Action.Full.t Action_builder.With_targets.t list
   -> unit Memo.Build.t

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
@@ -36,9 +36,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
+  Shared cache miss [63aaebd0dc5362f9939533a561b91930] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [fccfd1af13c64ce19b45e2a76fb8132c] (_build/default/target1): not found in cache
+  Shared cache miss [676360ac147f34e28acf07171eacec49] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
+  Shared cache miss [63aaebd0dc5362f9939533a561b91930] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [fccfd1af13c64ce19b45e2a76fb8132c] (_build/default/target1): not found in cache
+  Shared cache miss [676360ac147f34e28acf07171eacec49] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [c22cd66f69ccd6561b3b4d75f66ac0a8]: ((in_cache
+  Warning: cache store error [a19836dda3af8f67b5a5d1d6b1174565]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [c22cd66f69ccd6561b3b4d75f66ac0a8]: ((in_cache
+  Warning: cache store error [a19836dda3af8f67b5a5d1d6b1174565]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [c22cd66f69ccd6561b3b4d75f66ac0a8]: ((in_cache
+  Warning: cache store error [a19836dda3af8f67b5a5d1d6b1174565]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -77,10 +77,10 @@ You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort)
-  ./35/35e3c4c23bc41f4fc922c70f55c090d8:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./cc/cc55701449a53c9d88c1ae9c502b0668:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./56/5630df9c779ee6388a10f41ed819194d:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./7d/7d27d62a60f3631a6961f7b2be16d515:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/cc/cc55701449a53c9d88c1ae9c502b0668"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/7d/7d27d62a60f3631a6961f7b2be16d515"
   70
 
 Trimming the cache at this point should not remove any file entries because all


### PR DESCRIPTION
We use to plumb the sandbox configuration through the dependencies, which was a bit odd. This PR instead makes it a field of `Action.Full.t`. The syntax is unchanged, but from the implementation point of view, when interpreting dependencies written by the user we extract the sandbox configuration at this point and manually put it inside the `Action.Full.t` record.