### PR TITLE
Add a test for copy rules in file-watching mode

### DIFF
--- a/test/blackbox-tests/test-cases/watching/copy-rules.t
+++ b/test/blackbox-tests/test-cases/watching/copy-rules.t
@@ -1,0 +1,90 @@
+Test rules that copy source files in file-watching mode.
+
+  $ . ./helpers.sh
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >   (deps (glob_files *.txt))
+  >   (target summary)
+  >   (action (bash "cat %{deps} > %{target}")))
+  > EOF
+  $ echo a > a.txt
+
+  $ start_dune
+
+  $ build summary
+  Success
+  $ cat _build/default/summary
+  a
+
+Add [b.txt] manually. Dune notices this.
+
+  $ echo b > b.txt
+  $ build summary
+  Success
+  $ cat _build/default/summary
+  a
+  b
+
+Now add [c.txt] via a new rule. Note that we do not request [c.txt] to be built,
+only [summary], but Dune still builds it. Presumably, this isn't a bug but a
+consequence of using a glob in this directory, which forces all *.txt rules.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (deps (glob_files *.txt))
+  >   (target summary)
+  >   (action (bash "cat %{deps} > %{target}")))
+  > (rule
+  >   (target c.txt)
+  >   (action (write-file %{target} c)))
+  > EOF
+
+  $ build summary
+  Success
+  $ cat _build/default/summary
+  a
+  b
+  c
+
+Now demonstrate a bug: Dune fails to notice that [d.txt] appears via promotion.
+
+# CR-someday amokhov: Fix this test.
+
+  $ mkdir subdir
+  $ cat > subdir/dune <<EOF
+  > (rule
+  >   (target d.txt)
+  >   (mode (promote (into ..)))
+  >   (action (write-file %{target} d)))
+  > EOF
+  $ build summary subdir/d.txt
+  Success
+  $ cat _build/default/summary
+  a
+  b
+  c
+
+Note that [d.txt] is here but [c.txt] isn't (it's not promoted).
+
+  $ ls *.txt
+  a.txt
+  b.txt
+  d.txt
+
+We're done.
+
+  $ stop_dune
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...


### PR DESCRIPTION
Another test for file-watching mode, and another subtle bug: copy rules don't seem to interact well with `promote-into`.

I suspect the plain `promote` logic is broken too but it's masked by the fact that Dune sees the promoted files in the build directory. With the `into` option, the corresponding file is in a different directory and there is nothing to mask the bug.