### PR TITLE
Surface Action.Full.t through the Super_context API

### DIFF
--- a/otherlibs/stdune-unstable/env.ml
+++ b/otherlibs/stdune-unstable/env.ml
@@ -83,7 +83,11 @@ let extend t ~vars =
   else
     make (Map.superpose t.vars vars)
 
-let extend_env x y = extend x ~vars:y.vars
+let extend_env x y =
+  if Map.is_empty x.vars then
+    y
+  else
+    extend x ~vars:y.vars
 
 let to_dyn t =
   let open Dyn.Encoder in

--- a/otherlibs/stdune-unstable/env.ml
+++ b/otherlibs/stdune-unstable/env.ml
@@ -77,7 +77,11 @@ let add t ~var ~value = make (Map.set t.vars var value)
 
 let remove t ~var = make (Map.remove t.vars var)
 
-let extend t ~vars = make (Map.superpose t.vars vars)
+let extend t ~vars =
+  if Map.is_empty vars then
+    t
+  else
+    make (Map.superpose t.vars vars)
 
 let extend_env x y = extend x ~vars:y.vars
 

--- a/otherlibs/stdune-unstable/monoid.mli
+++ b/otherlibs/stdune-unstable/monoid.mli
@@ -5,7 +5,7 @@ module type S = Monoid_intf.S
 (** This functor extends the basic definition of a monoid by adding a convenient
     operator synonym [( @ ) = combine], as well as derived functions [reduce]
     and [map_reduce]. *)
-module Make (M : Basic) : S with type t = M.t
+module Make (M : Basic) : S with type t := M.t
 [@@inlined always]
 
 (** The monoid you get with [empty = false] and [combine = ( || )]. *)

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -65,6 +65,8 @@ include
     with type string := string
     with type t := t
 
+include Monoid with type t := t
+
 module For_shell : sig
   include
     Action_intf.Ast

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -117,11 +117,24 @@ val is_useful_to_distribute : t -> is_useful
 val is_useful_to_memoize : t -> is_useful
 
 module Full : sig
+  type action := t
+
   (** A full action with its environment and list of locks *)
-  type nonrec t =
-    { action : t
+  type t =
+    { action : action
     ; env : Env.t
     ; locks : Path.t list
     ; can_go_in_shared_cache : bool
     }
+
+  val make :
+       ?env:Env.t (** default [Env.empty] *)
+    -> ?locks:Path.t list (** default [\[\]] *)
+    -> ?can_go_in_shared_cache:bool (** default [true] *)
+    -> action
+    -> t
+
+  val map : t -> f:(action -> action) -> t
+
+  include Monoid with type t := t
 end

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -172,6 +172,8 @@ module With_targets = struct
   module O = struct
     let ( >>> ) = seq
 
+    let ( >>| ) t f = map t ~f
+
     let ( and+ ) = both
 
     let ( let+ ) a f = map ~f a
@@ -193,7 +195,7 @@ module With_targets = struct
   let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
     add ~file_targets:[ fn ]
       (let+ s = s in
-       Action.Write_file (fn, perm, s))
+       Action.Full.make (Action.Write_file (fn, perm, s)))
 
   let memoize name t = { build = memoize name t.build; targets = t.targets }
 end
@@ -210,33 +212,41 @@ let with_no_targets build : _ With_targets.t =
 
 let write_file ?(perm = Action.File_perm.Normal) fn s =
   with_file_targets ~file_targets:[ fn ]
-    (return (Action.Write_file (fn, perm, s)))
+    (return (Action.Full.make (Action.Write_file (fn, perm, s))))
 
 let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
   with_file_targets ~file_targets:[ fn ]
     (let+ s = s in
-     Action.Write_file (fn, perm, s))
+     Action.Full.make (Action.Write_file (fn, perm, s)))
+
+let with_stdout_to ?(perm = Action.File_perm.Normal) fn t =
+  with_targets
+    ~targets:(Targets.Files.create (Path.Build.Set.singleton fn))
+    (let+ (act : Action.Full.t) = t in
+     { act with action = Action.with_stdout_to ~perm fn act.action })
 
 let copy ~src ~dst =
   with_file_targets ~file_targets:[ dst ]
-    (path src >>> return (Action.Copy (src, dst)))
+    (path src >>> return (Action.Full.make (Action.Copy (src, dst))))
 
 let copy_and_add_line_directive ~src ~dst =
   with_file_targets ~file_targets:[ dst ]
-    (path src >>> return (Action.Copy_and_add_line_directive (src, dst)))
+    (path src
+    >>> return
+          (Action.Full.make (Action.Copy_and_add_line_directive (src, dst))))
 
 let symlink ~src ~dst =
   with_file_targets ~file_targets:[ dst ]
-    (path src >>> return (Action.Symlink (src, dst)))
+    (path src >>> return (Action.Full.make (Action.Symlink (src, dst))))
 
 let create_file ?(perm = Action.File_perm.Normal) fn =
   with_file_targets ~file_targets:[ fn ]
-    (return (Action.Redirect_out (Stdout, fn, perm, Action.empty)))
+    (return
+       (Action.Full.make (Action.Redirect_out (Stdout, fn, perm, Action.empty))))
 
 let progn ts =
   let open With_targets.O in
-  let+ actions = With_targets.all ts in
-  Action.Progn actions
+  With_targets.all ts >>| Action.Full.reduce
 
 let dyn_memo_build_deps t = dyn_deps (dyn_memo_build t)
 

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -220,8 +220,7 @@ let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
      Action.Full.make (Action.Write_file (fn, perm, s)))
 
 let with_stdout_to ?(perm = Action.File_perm.Normal) fn t =
-  with_targets
-    ~targets:(Targets.Files.create (Path.Build.Set.singleton fn))
+  with_targets ~targets:(Targets.File.create fn)
     (let+ (act : Action.Full.t) = t in
      { act with action = Action.with_stdout_to ~perm fn act.action })
 

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -24,7 +24,7 @@ module With_targets : sig
   val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 
   val write_file_dyn :
-    ?perm:Action.File_perm.t -> Path.Build.t -> string t -> Action.t t
+    ?perm:Action.File_perm.t -> Path.Build.t -> string t -> Action.Full.t t
 
   val all : 'a t list -> 'a list t
 
@@ -34,6 +34,8 @@ module With_targets : sig
 
   module O : sig
     val ( >>> ) : unit t -> 'a t -> 'a t
+
+    val ( >>| ) : 'a t -> ('a -> 'b) -> 'b t
 
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
 
@@ -144,26 +146,35 @@ val if_file_exists : Path.t -> then_:'a t -> else_:'a t -> 'a t
 
 (** Create a file with the given contents. *)
 val write_file :
-  ?perm:Action.File_perm.t -> Path.Build.t -> string -> Action.t With_targets.t
+     ?perm:Action.File_perm.t
+  -> Path.Build.t
+  -> string
+  -> Action.Full.t With_targets.t
 
 val write_file_dyn :
      ?perm:Action.File_perm.t
   -> Path.Build.t
   -> string t
-  -> Action.t With_targets.t
+  -> Action.Full.t With_targets.t
 
-val copy : src:Path.t -> dst:Path.Build.t -> Action.t With_targets.t
+val with_stdout_to :
+     ?perm:Action.File_perm.t
+  -> Path.Build.t
+  -> Action.Full.t t
+  -> Action.Full.t With_targets.t
+
+val copy : src:Path.t -> dst:Path.Build.t -> Action.Full.t With_targets.t
 
 val copy_and_add_line_directive :
-  src:Path.t -> dst:Path.Build.t -> Action.t With_targets.t
+  src:Path.t -> dst:Path.Build.t -> Action.Full.t With_targets.t
 
-val symlink : src:Path.t -> dst:Path.Build.t -> Action.t With_targets.t
+val symlink : src:Path.t -> dst:Path.Build.t -> Action.Full.t With_targets.t
 
 val create_file :
-  ?perm:Action.File_perm.t -> Path.Build.t -> Action.t With_targets.t
+  ?perm:Action.File_perm.t -> Path.Build.t -> Action.Full.t With_targets.t
 
 (** Merge a list of actions accumulating the sets of their targets. *)
-val progn : Action.t With_targets.t list -> Action.t With_targets.t
+val progn : Action.Full.t With_targets.t list -> Action.Full.t With_targets.t
 
 (** A version of [dyn_memo_build] that makes it convenient to declare dynamic
     action dependencies. *)

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -342,13 +342,17 @@ end
 module Set = struct
   include O.Map
 
-  module T = Monoid.Make (struct
+  module T = struct
     type t = unit Map.t
 
-    let empty = empty
+    include Monoid.Make (struct
+      type nonrec t = t
 
-    let combine = union ~f:(fun _ () () -> Some ())
-  end)
+      let empty = empty
+
+      let combine = union ~f:(fun _ () () -> Some ())
+    end)
+  end
 
   include T
 

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -508,7 +508,7 @@ let expand_no_targets t ~loc ~deps:deps_written_by_user ~expander ~what =
   let+ () = deps_builder
   and+ action = build in
   let dir = Path.build (Expander.dir expander) in
-  Action.Chdir (dir, action)
+  Action.Full.make (Action.Chdir (dir, action))
 
 let expand t ~loc ~deps:deps_written_by_user ~targets_dir
     ~targets:targets_written_by_user ~expander =
@@ -565,7 +565,7 @@ let expand t ~loc ~deps:deps_written_by_user ~targets_dir
     let+ () = deps_builder
     and+ action = build in
     let dir = Path.build (Expander.dir expander) in
-    Action.Chdir (dir, action)
+    Action.Full.make (Action.Chdir (dir, action))
   in
   Action_builder.with_targets ~targets build
 

--- a/src/dune_rules/action_unexpanded.mli
+++ b/src/dune_rules/action_unexpanded.mli
@@ -33,7 +33,7 @@ val expand :
   -> targets_dir:Path.Build.t
   -> targets:Path.Build.t Targets_spec.t
   -> expander:Expander.t
-  -> Action.t Action_builder.With_targets.t Memo.Build.t
+  -> Action.Full.t Action_builder.With_targets.t Memo.Build.t
 
 (** [what] as the same meaning as the argument of
     [Expander.Expanding_what.User_action_without_targets] *)
@@ -43,4 +43,4 @@ val expand_no_targets :
   -> deps:Dep_conf.t Bindings.t
   -> expander:Expander.t
   -> what:string
-  -> Action.t Action_builder.t
+  -> Action.Full.t Action_builder.t

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -13,7 +13,7 @@ let gen_select_rules t ~dir compile_info =
                let* src_fn = Resolve.read src_fn in
                let src = Path.build (Path.Build.relative dir src_fn) in
                let+ () = Action_builder.path src in
-               Action.Copy_and_add_line_directive (src, dst))))
+               Action.Full.make (Action.Copy_and_add_line_directive (src, dst)))))
 
 let with_lib_deps (t : Context.t) compile_info ~dir ~f =
   let prefix =

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -128,12 +128,14 @@ let gen_rules sctx t ~dir ~scope =
     let module A = Action in
     let cinaps_exe = Path.build cinaps_exe in
     let+ () = Action_builder.path cinaps_exe in
-    A.chdir (Path.build dir)
-      (A.progn
-         (A.run (Ok cinaps_exe) [ "-diff-cmd"; "-" ]
-         :: List.map cinapsed_files ~f:(fun fn ->
-                A.diff ~optional:true (Path.build fn)
-                  (Path.Build.extend_basename fn ~suffix:".cinaps-corrected"))))
+    Action.Full.make
+    @@ A.chdir (Path.build dir)
+         (A.progn
+            (A.run (Ok cinaps_exe) [ "-diff-cmd"; "-" ]
+            :: List.map cinapsed_files ~f:(fun fn ->
+                   A.diff ~optional:true (Path.build fn)
+                     (Path.Build.extend_basename fn ~suffix:".cinaps-corrected"))
+            ))
   in
   let cinaps_alias = alias ~dir in
   let* () =

--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -110,13 +110,13 @@ let run ~dir ?stdout_to prog args =
       | None -> action
       | Some path -> Action.with_stdout_to path action
     in
-    Action.chdir dir action)
+    Action.Full.make (Action.chdir dir action))
 
 let run' ~dir prog args =
   let open Action_builder.O in
   let+ () = dep_prog prog
   and+ args = expand_no_targets ~dir (S args) in
-  Action.chdir dir (Action.run prog args)
+  Action.Full.make (Action.chdir dir (Action.run prog args))
 
 let quote_args =
   let rec loop quote = function

--- a/src/dune_rules/command.mli
+++ b/src/dune_rules/command.mli
@@ -85,14 +85,14 @@ val run :
   -> ?stdout_to:Path.Build.t
   -> Action.Prog.t
   -> Args.any Args.t list
-  -> Action.t Action_builder.With_targets.t
+  -> Action.Full.t Action_builder.With_targets.t
 
 (** Same as [run], but for actions that don't produce targets *)
 val run' :
      dir:Path.t
   -> Action.Prog.t
   -> Args.without_targets Args.t list
-  -> Action.t Action_builder.t
+  -> Action.Full.t Action_builder.t
 
 (** [quote_args quote args] is [As \[quote; arg1; quote; arg2; ...\]] *)
 val quote_args : string -> string list -> _ Args.t

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -389,8 +389,8 @@ let coqc_rule (cctx : _ Context.t) ~file_flags coq_module =
 
 module Module_rule = struct
   type t =
-    { coqdep : Action.t Action_builder.With_targets.t
-    ; coqc : Action.t Action_builder.With_targets.t
+    { coqdep : Action.Full.t Action_builder.With_targets.t
+    ; coqc : Action.Full.t Action_builder.With_targets.t
     }
 end
 

--- a/src/dune_rules/coq_rules.mli
+++ b/src/dune_rules/coq_rules.mli
@@ -15,7 +15,7 @@ val setup_rules :
   -> dir:Path.Build.t
   -> dir_contents:Dir_contents.t
   -> Theory.t
-  -> Action.t Action_builder.With_targets.t list Memo.Build.t
+  -> Action.Full.t Action_builder.With_targets.t list Memo.Build.t
 
 val install_rules :
      sctx:Super_context.t
@@ -27,11 +27,11 @@ val coqpp_rules :
      sctx:Super_context.t
   -> dir:Path.Build.t
   -> Coqpp.t
-  -> Action.t Action_builder.With_targets.t list Memo.Build.t
+  -> Action.Full.t Action_builder.With_targets.t list Memo.Build.t
 
 val extraction_rules :
      sctx:Super_context.t
   -> dir:Path.Build.t
   -> dir_contents:Dir_contents.t
   -> Extraction.t
-  -> Action.t Action_builder.With_targets.t list Memo.Build.t
+  -> Action.Full.t Action_builder.With_targets.t list Memo.Build.t

--- a/src/dune_rules/cram_rules.ml
+++ b/src/dune_rules/cram_rules.ml
@@ -51,7 +51,7 @@ let test_rule ~sctx ~expander ~dir (spec : effective)
   | Error (Missing_run_t test) ->
     (* We error out on invalid tests even if they are disabled. *)
     Memo.Build.parallel_iter aliases ~f:(fun alias ->
-        Alias_rules.add sctx ~alias ~loc ~locks:[] (missing_run_t test))
+        Alias_rules.add sctx ~alias ~loc (missing_run_t test))
   | Ok test -> (
     match enabled with
     | false ->
@@ -73,6 +73,7 @@ let test_rule ~sctx ~expander ~dir (spec : effective)
               }
           ]
       in
+      let locks = Path.Set.to_list spec.locks in
       let cram =
         let open Action_builder.O in
         let+ () = Action_builder.path (Path.build script)
@@ -87,11 +88,10 @@ let test_rule ~sctx ~expander ~dir (spec : effective)
           Action_builder.dep
             (Dep.sandbox_config Sandbox_config.needs_sandboxing)
         in
-        action
+        Action.Full.make action ~locks
       in
-      let locks = Path.Set.to_list spec.locks in
       Memo.Build.parallel_iter aliases ~f:(fun alias ->
-          Alias_rules.add sctx ~alias ~loc cram ~locks))
+          Alias_rules.add sctx ~alias ~loc cram))
 
 let rules ~sctx ~expander ~dir tests =
   let stanzas =

--- a/src/dune_rules/ctypes_rules.ml
+++ b/src/dune_rules/ctypes_rules.ml
@@ -389,7 +389,8 @@ let build_c_program ~sctx ~dir ~source_files ~scope ~cflags_sexp ~output () =
     Action_builder.with_file_targets action
       ~file_targets:[ Path.Build.relative dir output ]
   in
-  Super_context.add_rule sctx ~dir build
+  Super_context.add_rule sctx ~dir
+    (Action_builder.With_targets.map ~f:Action.Full.make build)
 
 let cctx_with_substitutions ?(libraries = []) ~modules ~dir ~loc ~scope ~cctx ()
     =

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -40,6 +40,6 @@ let rules ~sctx ~dir =
     let+ run_preprocessor =
       Command.run ~dir:(Path.build dir) ~stdout_to:file prog args
     in
-    Action.progn [ write_test_file; run_preprocessor ]
+    Action.Full.reduce [ Action.Full.make write_test_file; run_preprocessor ]
   in
   Super_context.add_rule sctx ~dir action

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -4,9 +4,9 @@ open Import
 let add_diff sctx loc alias ~dir ~input ~output =
   let open Action_builder.O in
   let action = Action.Chdir (Path.build dir, Action.diff input output) in
-  Super_context.add_alias_action sctx alias ~dir ~loc:(Some loc) ~locks:[]
+  Super_context.add_alias_action sctx alias ~dir ~loc:(Some loc)
     (Action_builder.paths [ input; Path.build output ]
-    >>> Action_builder.return action)
+    >>> Action_builder.return (Action.Full.make action))
 
 let rec subdirs_until_root dir =
   match Path.parent dir with
@@ -41,7 +41,7 @@ let gen_rules_output sctx (config : Format_config.t) ~version ~dialects
         @@
         let open Action_builder.O in
         let+ () = Action_builder.path input in
-        Action.format_dune_file ~version input output
+        Action.Full.make (Action.format_dune_file ~version input output)
       | _ ->
         let ext = Path.Source.extension file in
         let open Option.O in

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -147,7 +147,8 @@ include Sub_system.Register_end_point (struct
                            Action_unexpanded.expand_no_targets action ~loc
                              ~expander ~deps:[] ~what:"inline test generators"))))
            in
-           Action.with_stdout_to target (Action.progn actions)
+           Action.Full.reduce actions
+           |> Action.Full.map ~f:(Action.with_stdout_to target)
          in
          Action_builder.With_targets.add ~file_targets:[ target ] action)
     and* cctx =
@@ -250,13 +251,14 @@ include Sub_system.Register_end_point (struct
                | Ok p -> Action_builder.path p >>> Action_builder.return action)
            in
            let run_tests = Action.chdir (Path.build dir) action in
-           Action.progn
-             (run_tests
-             :: List.map source_files ~f:(fun fn ->
-                    Action.diff ~optional:true fn
-                      (Path.Build.extend_basename
-                         (Path.as_in_build_dir_exn fn)
-                         ~suffix:".corrected")))))
+           Action.Full.make
+           @@ Action.progn
+                (run_tests
+                :: List.map source_files ~f:(fun fn ->
+                       Action.diff ~optional:true fn
+                         (Path.Build.extend_basename
+                            (Path.as_in_build_dir_exn fn)
+                            ~suffix:".corrected")))))
 
   let gen_rules c ~(info : Info.t) ~backends =
     let open Memo.Build.O in

--- a/src/dune_rules/jsoo_rules.mli
+++ b/src/dune_rules/jsoo_rules.mli
@@ -9,7 +9,7 @@ val build_cm :
   -> js_of_ocaml:Dune_file.Js_of_ocaml.t
   -> src:Path.Build.t
   -> target:Path.Build.t
-  -> Action.t Action_builder.With_targets.t Memo.Build.t option
+  -> Action.Full.t Action_builder.With_targets.t Memo.Build.t option
 
 val build_exe :
      Compilation_context.t

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -28,7 +28,7 @@ module Files = struct
     let open Action_builder.O in
     let+ () = Action_builder.path src
     and+ () = Action_builder.path (Path.build corrected) in
-    Action.diff ~optional:false src corrected
+    Action.Full.make (Action.diff ~optional:false src corrected)
 end
 
 module Deps = struct

--- a/src/dune_rules/menhir.ml
+++ b/src/dune_rules/menhir.ml
@@ -112,12 +112,12 @@ module Run (P : PARAMS) = struct
   (* [menhir args] generates a Menhir command line (a build action). *)
 
   let menhir (args : 'a args) :
-      Action.t Action_builder.With_targets.t Memo.Build.t =
+      Action.Full.t Action_builder.With_targets.t Memo.Build.t =
     Memo.Build.map menhir_binary ~f:(fun prog ->
         Command.run ~dir:(Path.build build_dir) prog args)
 
   let rule ?(mode = stanza.mode) :
-      Action.t Action_builder.With_targets.t -> unit Memo.Build.t =
+      Action.Full.t Action_builder.With_targets.t -> unit Memo.Build.t =
     SC.add_rule sctx ~dir ~mode ~loc:stanza.loc
 
   let expand_flags flags = Super_context.menhir_flags sctx ~dir ~expander ~flags

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -293,11 +293,12 @@ module Unprocessed = struct
             in
             Some Processed.{ flag = "-pp"; args }
         in
-        Action_builder.map action ~f:(function
-          | Run (exe, args) -> pp_of_action exe args
-          | Chdir (_, Run (exe, args)) -> pp_of_action exe args
-          | Chdir (_, Chdir (_, Run (exe, args))) -> pp_of_action exe args
-          | _ -> None))
+        Action_builder.map action ~f:(fun act ->
+            match act.action with
+            | Run (exe, args) -> pp_of_action exe args
+            | Chdir (_, Run (exe, args)) -> pp_of_action exe args
+            | Chdir (_, Chdir (_, Run (exe, args))) -> pp_of_action exe args
+            | _ -> None))
     | _ -> Action_builder.return None
 
   let pp_flags sctx ~expander libname preprocess :

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -271,20 +271,19 @@ let ocamlc_i ?(flags = []) ~deps cctx (m : Module.t) ~output =
     (Action_builder.With_targets.add ~file_targets:[ output ]
        (let open Action_builder.With_targets.O in
        Action_builder.with_no_targets cm_deps
-       >>> Action_builder.With_targets.map
-             ~f:(Action.with_stdout_to output)
-             (Command.run (Ok ctx.ocamlc) ~dir:(Path.build ctx.build_dir)
-                [ Command.Args.dyn ocaml_flags
-                ; A "-I"
-                ; Path (Path.build (Obj_dir.byte_dir obj_dir))
-                ; Command.Args.as_any (Cm_kind.Dict.get (CC.includes cctx) Cmo)
-                ; opens modules m
-                ; As flags
-                ; A "-short-paths"
-                ; A "-i"
-                ; Command.Ml_kind.flag Impl
-                ; Dep src
-                ])))
+       >>> Command.run (Ok ctx.ocamlc) ~dir:(Path.build ctx.build_dir)
+             ~stdout_to:output
+             [ Command.Args.dyn ocaml_flags
+             ; A "-I"
+             ; Path (Path.build (Obj_dir.byte_dir obj_dir))
+             ; Command.Args.as_any (Cm_kind.Dict.get (CC.includes cctx) Cmo)
+             ; opens modules m
+             ; As flags
+             ; A "-short-paths"
+             ; A "-i"
+             ; Command.Ml_kind.flag Impl
+             ; Dep src
+             ]))
 
 (* The alias module is an implementation detail to support wrapping library
    modules under a single toplevel name. Since OCaml doesn't have proper support

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -123,7 +123,10 @@ let deps_of ~cctx ~ml_kind unit =
        in
        Action.Merge_files_into (sources, extras, all_deps_file))
   in
-  let+ () = SC.add_rule sctx ~dir action in
+  let+ () =
+    SC.add_rule sctx ~dir
+      (Action_builder.With_targets.map ~f:Action.Full.make action)
+  in
   let all_deps_file = Path.build all_deps_file in
   Action_builder.memoize
     (Path.to_string all_deps_file)

--- a/src/dune_rules/ocamlobjinfo.mli
+++ b/src/dune_rules/ocamlobjinfo.mli
@@ -11,7 +11,7 @@ val rules :
      dir:Path.Build.t
   -> ctx:Context.t
   -> unit:Path.t
-  -> Action.t Action_builder.With_targets.t * t Action_builder.t
+  -> Action.Full.t Action_builder.With_targets.t * t Action_builder.t
 
 (** For testing only *)
 val parse : string -> t

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -274,10 +274,11 @@ let setup_html sctx (odoc_file : odoc) ~pkg ~requires =
     >>> Action_builder.progn
           (Action_builder.with_no_targets
              (Action_builder.return
-                (Action.Progn
-                   [ Action.Remove_tree to_remove
-                   ; Action.Mkdir (Path.build odoc_file.html_dir)
-                   ]))
+                (Action.Full.make
+                   (Action.Progn
+                      [ Action.Remove_tree to_remove
+                      ; Action.Mkdir (Path.build odoc_file.html_dir)
+                      ])))
           :: Command.run
                ~dir:(Path.build (Paths.html_root ctx))
                odoc

--- a/src/dune_rules/preprocessing.mli
+++ b/src/dune_rules/preprocessing.mli
@@ -37,7 +37,7 @@ val action_for_pp_with_target :
   -> action:Action_unexpanded.t
   -> src:Path.Build.t
   -> target:Path.Build.t
-  -> Action.t Action_builder.With_targets.t
+  -> Action.Full.t Action_builder.With_targets.t
 
 val ppx_exe :
   Super_context.t -> scope:Scope.t -> Lib_name.t -> Path.Build.t Resolve.Build.t

--- a/src/dune_rules/simple_rules.mli
+++ b/src/dune_rules/simple_rules.mli
@@ -10,9 +10,8 @@ module Alias_rules : sig
        Super_context.t
     -> alias:Alias.t
     -> loc:Loc.t option
-    -> locks:Path.t list
     -> ?patch_back_source_tree:bool
-    -> Action.t Action_builder.t
+    -> Action.Full.t Action_builder.t
     -> unit Memo.Build.t
 
   val add_empty :

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -108,27 +108,25 @@ val add_rule :
      t
   -> ?sandbox:Sandbox_config.t
   -> ?mode:Rule.Mode.t
-  -> ?locks:Path.t list
   -> ?loc:Loc.t
   -> dir:Path.Build.t
-  -> Action.t Action_builder.With_targets.t
+  -> Action.Full.t Action_builder.With_targets.t
   -> unit Memo.Build.t
 
 val add_rule_get_targets :
      t
   -> ?sandbox:Sandbox_config.t
   -> ?mode:Rule.Mode.t
-  -> ?locks:Path.t list
   -> ?loc:Loc.t
   -> dir:Path.Build.t
-  -> Action.t Action_builder.With_targets.t
+  -> Action.Full.t Action_builder.With_targets.t
   -> Targets.t Memo.Build.t
 
 val add_rules :
      t
   -> ?sandbox:Sandbox_config.t
   -> dir:Path.Build.t
-  -> Action.t Action_builder.With_targets.t list
+  -> Action.Full.t Action_builder.With_targets.t list
   -> unit Memo.Build.t
 
 val add_alias_action :
@@ -136,9 +134,8 @@ val add_alias_action :
   -> Alias.t
   -> dir:Path.Build.t
   -> loc:Loc.t option
-  -> ?locks:Path.t list
   -> ?patch_back_source_tree:bool
-  -> Action.t Action_builder.t
+  -> Action.Full.t Action_builder.t
   -> unit Memo.Build.t
 
 (** [resolve_program t ?hint name] resolves a program. [name] is looked up in


### PR DESCRIPTION
`Super_context.add_rule` used to create the `Action.Full.t` needed by `Rule.make` on the fly. This made it complicated to attach actions parameters such as locks or sandboxing configuration at the point the action was created.

This PR changes `Super_context.add_rule` to take an `Action.Full.t` directly instead of an `Action.t` + the various other fields as argument. To make the code more natural, it also changes various functions such as `Action_unexpanded.expand` to return an `Action.Full.t` rather than an `Action.t`.

It also makes `Action.Full` a monoid to make it easier to combine lists of `Action.Full.t`, which we do in a few rules.