### PR TITLE
Print --debug-cache messages without --verbose

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1600,12 +1600,13 @@ end = struct
         | `Always_rerun -> "not trying to use the cache"
         | `Dynamic_deps_changed -> "dynamic dependencies changed"
       in
-      Log.info
-        [ Pp.hbox
-            (Pp.textf "Workspace-local cache miss: %s: %s\n"
-               (Path.Build.to_string head_target)
-               reason)
-        ]
+      Console.print_user_message
+        (User_message.make
+           [ Pp.hbox
+               (Pp.textf "Workspace-local cache miss: %s: %s"
+                  (Path.Build.to_string head_target)
+                  reason)
+           ])
 
   let report_shared_cache_miss ~(cache_debug_flags : Cache_debug_flags.t)
       ~rule_digest ~head_target (reason : Shared_cache_miss_reason.t) =
@@ -1630,12 +1631,13 @@ end = struct
           "rerunning for reproducibility check"
         | Not_found_in_cache -> "not found in cache"
       in
-      Log.info
-        [ Pp.hbox
-            (Pp.textf "Shared cache miss %s: %s\n"
-               (shared_cache_key_string_for_log ~rule_digest ~head_target)
-               reason)
-        ]
+      Console.print_user_message
+        (User_message.make
+           [ Pp.hbox
+               (Pp.textf "Shared cache miss %s: %s"
+                  (shared_cache_key_string_for_log ~rule_digest ~head_target)
+                  reason)
+           ])
 
   let execute_rule_impl ~rule_kind rule =
     let t = t () in

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -86,9 +86,10 @@ let update_all : Path.t -> Fs_cache.Update_result.t =
     if !Clflags.debug_fs_cache then
       Console.print_user_message
         (User_message.make
-           [ Pp.textf "Updating %s cache for %S: %s" (Fs_cache.Debug.name t)
-               (Path.to_string path)
-               (Dyn.to_string (Fs_cache.Update_result.to_dyn result))
+           [ Pp.hbox
+               (Pp.textf "Updating %s cache for %S: %s" (Fs_cache.Debug.name t)
+                  (Path.to_string path)
+                  (Dyn.to_string (Fs_cache.Update_result.to_dyn result)))
            ]);
     result
   in

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
@@ -30,7 +30,16 @@ It's a duck. It quacks. (Yes, the author of this comment didn't get it.)
 Test that after the build, the files in the build directory have the hard link
 count of 1, because they are not shared with the corresponding cache entries.
 
-  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
+We expect to see both workspace-local and shared cache misses, because we've
+never built [target1] before.
+
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
+  >   2>&1 | grep '_build/default/source\|_build/default/target'
+  Workspace-local cache miss: _build/default/source: never seen this target before
+  Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
+  Workspace-local cache miss: _build/default/target1: never seen this target before
+  Shared cache miss [fccfd1af13c64ce19b45e2a76fb8132c] (_build/default/target1): not found in cache
+
   $ dune_cmd stat hardlinks _build/default/source
   1
   $ dune_cmd stat hardlinks _build/default/target1
@@ -40,19 +49,17 @@ count of 1, because they are not shared with the corresponding cache entries.
   $ dune_cmd exists _build/default/beacon
   true
 
-We expect to see both workspace-local and shared cache misses in the build log,
-because we've never built [target1] before.
-
-  $ cat _build/log | grep '_build/default/source\|_build/default/target'
-  # Workspace-local cache miss: _build/default/source: never seen this target before
-  # Shared cache miss [8b39c1a0b45579f8da18f42be8e6aca0] (_build/default/source): not found in cache
-  # Workspace-local cache miss: _build/default/target1: never seen this target before
-  # Shared cache miss [fccfd1af13c64ce19b45e2a76fb8132c] (_build/default/target1): not found in cache
-
 Test that rebuilding works.
 
+Now we expect to see only workspace-local cache misses, because we've cleaned
+[_build/default] but not the shared cache.
+
   $ rm -rf _build/default
-  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
+  >   2>&1 | grep '_build/default/source\|_build/default/target'
+  Workspace-local cache miss: _build/default/source: target missing from build dir
+  Workspace-local cache miss: _build/default/target1: target missing from build dir
+
   $ dune_cmd stat hardlinks _build/default/source
   1
   $ dune_cmd stat hardlinks _build/default/target1
@@ -69,19 +76,10 @@ Test that rebuilding works.
   \_o< COIN
   \_o< COIN
 
-Now we expect to see only workspace-local cache misses in the build log, because
-we've cleaned [_build/default] but not the shared cache.
-
-  $ cat _build/log | grep '_build/default/source\|_build/default/target'
-  # Workspace-local cache miss: _build/default/source: target missing from build dir
-  # (_build/default/source)
-  # Workspace-local cache miss: _build/default/target1: target missing from build dir
-  # (_build/default/target1)
-
 Test how zero the zero build is. We do not expect to see any cache misses.
 
-  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local
-  $ cat _build/log | grep '_build/default/source\|_build/default/target'
+  $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
+  >   2>&1 | grep '_build/default/source\|_build/default/target'
   [1]
 
 Test that the cache stores all historical build results.

--- a/test/blackbox-tests/test-cases/watching/test-1.t/run.t
+++ b/test/blackbox-tests/test-cases/watching/test-1.t/run.t
@@ -110,4 +110,3 @@
   waiting for inotify sync
   waited for inotify sync
   Success, waiting for filesystem changes...
-


### PR DESCRIPTION
This just makes it easier to debug.