### PR TITLE
Move patch_back_source_tree an action property rather than a rule one

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -278,12 +278,24 @@ let is_useful_to_memoize = is_useful_to true true
 
 module Full = struct
   module T = struct
+    (* Invariant: if [patch_back_source_tree] then:
+
+       - [sandbox] is [Sandbox_mode.Set.singleton (Some Copy)] or
+       [Sandbox_mode.Set.empty]. The latter would cause Dune to crash as there
+       would be no sandboxing mode selectable, but it shouldn't happen as we
+       forbid to specify a sandbox configuration when using [(mode
+       patch-back-source-tree)]. Allowing [Sandbox_mode.Set.empty] in the
+       invariant makes it easier to preserve the invariant in the various
+       functions bellow.
+
+       - [can_go_in_shared_cache] is [true]. *)
     type nonrec t =
       { action : t
       ; env : Env.t
       ; locks : Path.t list
       ; can_go_in_shared_cache : bool
       ; sandbox : Sandbox_config.t
+      ; patch_back_source_tree : bool
       }
 
     let empty =
@@ -292,26 +304,59 @@ module Full = struct
       ; locks = []
       ; can_go_in_shared_cache = true
       ; sandbox = Sandbox_config.default
+      ; patch_back_source_tree = false
       }
 
-    let combine { action; env; locks; can_go_in_shared_cache; sandbox } x =
+    let combine
+        { action
+        ; env
+        ; locks
+        ; can_go_in_shared_cache
+        ; sandbox
+        ; patch_back_source_tree
+        } x =
       { action = combine action x.action
       ; env = Env.extend_env env x.env
       ; locks = locks @ x.locks
       ; can_go_in_shared_cache =
           can_go_in_shared_cache && x.can_go_in_shared_cache
       ; sandbox = Sandbox_config.inter sandbox x.sandbox
+      ; patch_back_source_tree =
+          patch_back_source_tree || x.patch_back_source_tree
       }
   end
 
   include T
   include Monoid.Make (T)
 
+  let adapt_action_for_patch_back_source_tree t =
+    if not t.patch_back_source_tree then
+      t
+    else
+      (* Rules that patch back the source tree cannot go in the shared cache *)
+      let can_go_in_shared_cache = false in
+      (* Rules that patch back the source tree must be sandboxed in copy
+         mode. *)
+      let sandbox = Sandbox_mode.Set.singleton (Some Copy) in
+      { t with can_go_in_shared_cache; sandbox }
+
   let make ?(env = Env.empty) ?(locks = []) ?(can_go_in_shared_cache = true)
-      ?(sandbox = Sandbox_config.default) action =
-    { action; env; locks; can_go_in_shared_cache; sandbox }
+      ?(sandbox = Sandbox_config.default) ?(patch_back_source_tree = false)
+      action =
+    let t =
+      { action
+      ; env
+      ; locks
+      ; can_go_in_shared_cache
+      ; sandbox
+      ; patch_back_source_tree
+      }
+    in
+    adapt_action_for_patch_back_source_tree t
 
   let map t ~f = { t with action = f t.action }
+
+  let add_env e t = { t with env = Env.extend_env t.env e }
 
   let add_locks l t = { t with locks = t.locks @ l }
 
@@ -319,4 +364,8 @@ module Full = struct
     { t with can_go_in_shared_cache = t.can_go_in_shared_cache && b }
 
   let add_sandbox s t = { t with sandbox = Sandbox_config.inter t.sandbox s }
+
+  let add_patch_back_source_tree x t =
+    adapt_action_for_patch_back_source_tree
+      { t with patch_back_source_tree = t.patch_back_source_tree || x }
 end

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -337,7 +337,9 @@ module Full = struct
       let can_go_in_shared_cache = false in
       (* Rules that patch back the source tree must be sandboxed in copy
          mode. *)
-      let sandbox = Sandbox_mode.Set.singleton (Some Copy) in
+      let sandbox =
+        Sandbox_config.inter t.sandbox (Sandbox_mode.Set.singleton (Some Copy))
+      in
       { t with can_go_in_shared_cache; sandbox }
 
   let make ?(env = Env.empty) ?(locks = []) ?(can_go_in_shared_cache = true)

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -129,7 +129,7 @@ module Full : sig
     ; can_go_in_shared_cache : bool
     ; sandbox : Sandbox_config.t
     ; patch_back_source_tree : bool
-          (** Apply all the changes that happend in the sandbox to the source
+          (** Apply all the changes that happened in the sandbox to the source
               tree. This includes:
 
               - applying changes to source files that were dependencies

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -122,12 +122,26 @@ module Full : sig
   type action := t
 
   (** A full action with its environment and list of locks *)
-  type t =
+  type t = private
     { action : action
     ; env : Env.t
     ; locks : Path.t list
     ; can_go_in_shared_cache : bool
     ; sandbox : Sandbox_config.t
+    ; patch_back_source_tree : bool
+          (** Apply all the changes that happend in the sandbox to the source
+              tree. This includes:
+
+              - applying changes to source files that were dependencies
+              - deleting source files that were dependencies and were deleted in
+                the sandbox
+              - promoting all targets
+              - promoting all files that were created and not declared as
+                dependencies or targets
+
+              This is a dirty setting, but it is necessary to port projects to
+              Dune that don't use a separate directory and have rules that go
+              and create/modify random files. *)
     }
 
   val make :
@@ -135,6 +149,7 @@ module Full : sig
     -> ?locks:Path.t list (** default [\[\]] *)
     -> ?can_go_in_shared_cache:bool (** default [true] *)
     -> ?sandbox:Sandbox_config.t (** default [Sandbox_config.default] *)
+    -> ?patch_back_source_tree:bool (** default [false] *)
     -> action
     -> t
 
@@ -145,11 +160,15 @@ module Full : sig
 
       {[ combine t (make ~xxx:x (Progn [])) ]} *)
 
+  val add_env : Env.t -> t -> t
+
   val add_locks : Path.t list -> t -> t
 
   val add_sandbox : Sandbox_config.t -> t -> t
 
   val add_can_go_in_shared_cache : bool -> t -> t
+
+  val add_patch_back_source_tree : bool -> t -> t
 
   include Monoid with type t := t
 end

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -222,7 +222,7 @@ let write_file_dyn ?(perm = Action.File_perm.Normal) fn s =
 let with_stdout_to ?(perm = Action.File_perm.Normal) fn t =
   with_targets ~targets:(Targets.File.create fn)
     (let+ (act : Action.Full.t) = t in
-     { act with action = Action.with_stdout_to ~perm fn act.action })
+     Action.Full.map act ~f:(Action.with_stdout_to ~perm fn))
 
 let copy ~src ~dst =
   with_file_targets ~file_targets:[ dst ]

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -46,7 +46,6 @@ module Mode = struct
     | Fallback
     | Promote of Promote.t
     | Ignore_source_files
-    | Patch_back_source_tree
 end
 
 module Id = Id.Make ()
@@ -130,6 +129,5 @@ module Anonymous_action = struct
     ; loc : Loc.t option
     ; dir : Path.Build.t
     ; alias : Alias.Name.t option
-    ; patch_back_source_tree : bool
     }
 end

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -45,20 +45,6 @@ module Mode : sig
         (** Just ignore the source files entirely. This is for cases where the
             targets are promoted only in a specific context, such as for
             .install files. *)
-    | Patch_back_source_tree
-        (** Apply all the changes that happend in the sandbox to the source
-            tree. This includes:
-
-            - applying changes to source files that were dependencies
-            - deleting source files that were dependencies and were deleted in
-              the sandbox
-            - promoting all targets
-            - promoting all files that were created and not declared as
-              dependencies or targets
-
-            This is a dirty setting, but it is necessary to port projects to
-            Dune that don't use a separate directory and have rules that go and
-            create/modify random files. *)
 end
 
 module Id : sig
@@ -120,6 +106,5 @@ module Anonymous_action : sig
           (** Directory the action is attached to. This is the directory where
               the outcome of the action will be cached. *)
     ; alias : Alias.Name.t option  (** For better error messages *)
-    ; patch_back_source_tree : bool
     }
 end

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -148,7 +148,7 @@ module Produce = struct
             Appendable_list.singleton (loc, Dir_rules.Alias_spec.Deps expansion)
         }
 
-    let add_action t ~context ~loc ~patch_back_source_tree action =
+    let add_action t ~context ~loc action =
       let action =
         let open Action_builder.O in
         let+ action = action in
@@ -157,7 +157,6 @@ module Produce = struct
         ; loc
         ; dir = Alias.dir t
         ; alias = Some (Alias.name t)
-        ; patch_back_source_tree
         }
       in
       alias t

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -79,15 +79,12 @@ module Produce : sig
     val add_deps :
       t -> ?loc:Stdune.Loc.t -> unit Action_builder.t -> unit Memo.Build.t
 
-    (** [add_action alias ~context ~loc ?patch_back_source_tree
-       action]
-        arrange things so that [action] is executed as part of the build of
-        alias [alias]. *)
+    (** [add_action alias ~context ~loc action] arrange things so that [action]
+        is executed as part of the build of alias [alias]. *)
     val add_action :
          t
       -> context:Build_context.t
       -> loc:Loc.t option
-      -> patch_back_source_tree:bool
       -> Action.Full.t Action_builder.t
       -> unit Memo.Build.t
   end

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -890,46 +890,36 @@ let gen_configurator_rules t =
       (Rule.make ~context:None ~targets:(Targets.File.create fn)
          (let open Action_builder.O in
          let+ () = Action_builder.return () in
-         { Action.Full.action =
-             Action.write_file fn
-               (List.map
-                  ~f:(fun x -> Dune_lang.to_string x ^ "\n")
-                  (let open Dune_lang.Encoder in
-                  record_fields
-                    [ field "ocamlc" string ocamlc
-                    ; field_l "ocaml_config_vars" (pair string string)
-                        ocaml_config_vars
-                    ])
-               |> String.concat ~sep:"")
-         ; env = Env.empty
-         ; locks = []
-         ; can_go_in_shared_cache = true
-         ; sandbox = Sandbox_config.no_special_requirements
-         }))
+         Action.Full.make
+           (Action.write_file fn
+              (List.map
+                 ~f:(fun x -> Dune_lang.to_string x ^ "\n")
+                 (let open Dune_lang.Encoder in
+                 record_fields
+                   [ field "ocamlc" string ocamlc
+                   ; field_l "ocaml_config_vars" (pair string string)
+                       ocaml_config_vars
+                   ])
+              |> String.concat ~sep:""))))
   in
   let fn = configurator_v2 t in
   Rules.Produce.rule
     (Rule.make ~context:None ~targets:(Targets.File.create fn)
        (let open Action_builder.O in
        let+ () = Action_builder.return () in
-       { Action.Full.action =
-           Action.write_file fn
-             (Csexp.to_string
-                (let open Sexp in
-                let ocaml_config_vars =
-                  Sexp.List
-                    (List.map ocaml_config_vars ~f:(fun (k, v) ->
-                         List [ Atom k; Atom v ]))
-                in
-                List
-                  [ List [ Atom "ocamlc"; Atom ocamlc ]
-                  ; List [ Atom "ocaml_config_vars"; ocaml_config_vars ]
-                  ]))
-       ; env = Env.empty
-       ; locks = []
-       ; can_go_in_shared_cache = true
-       ; sandbox = Sandbox_config.no_special_requirements
-       }))
+       Action.Full.make
+         (Action.write_file fn
+            (Csexp.to_string
+               (let open Sexp in
+               let ocaml_config_vars =
+                 Sexp.List
+                   (List.map ocaml_config_vars ~f:(fun (k, v) ->
+                        List [ Atom k; Atom v ]))
+               in
+               List
+                 [ List [ Atom "ocamlc"; Atom ocamlc ]
+                 ; List [ Atom "ocaml_config_vars"; ocaml_config_vars ]
+                 ])))))
 
 let force_configurator_files =
   Memo.lazy_ (fun () ->

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -305,6 +305,7 @@ module Rule : sig
     ; deps : Dep_conf.t Bindings.t
     ; action : Loc.t * Action_dune_lang.t
     ; mode : Rule.Mode.t
+    ; patch_back_source_tree : bool
     ; locks : String_with_vars.t list
     ; loc : Loc.t
     ; enabled_if : Blang.t

--- a/src/dune_rules/simple_rules.mli
+++ b/src/dune_rules/simple_rules.mli
@@ -10,7 +10,6 @@ module Alias_rules : sig
        Super_context.t
     -> alias:Alias.t
     -> loc:Loc.t option
-    -> ?patch_back_source_tree:bool
     -> Action.Full.t Action_builder.t
     -> unit Memo.Build.t
 

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -131,7 +131,6 @@ val add_alias_action :
   -> Alias.t
   -> dir:Path.Build.t
   -> loc:Loc.t option
-  -> ?patch_back_source_tree:bool
   -> Action.Full.t Action_builder.t
   -> unit Memo.Build.t
 

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -58,6 +58,7 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
                 , Action_unexpanded.Redirect_out
                     (Stdout, diff.file2, Normal, run_action) )
             ; mode = Standard
+            ; patch_back_source_tree = false
             ; locks = t.locks
             ; loc
             ; enabled_if = t.enabled_if

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
@@ -36,9 +36,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [63aaebd0dc5362f9939533a561b91930] (_build/default/source): not found in cache
+  Shared cache miss [158799f889ef635e77efe9538c30b695] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [676360ac147f34e28acf07171eacec49] (_build/default/target1): not found in cache
+  Shared cache miss [227152a3a37f16da91ce766c636ed984] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [63aaebd0dc5362f9939533a561b91930] (_build/default/source): not found in cache
+  Shared cache miss [158799f889ef635e77efe9538c30b695] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [676360ac147f34e28acf07171eacec49] (_build/default/target1): not found in cache
+  Shared cache miss [227152a3a37f16da91ce766c636ed984] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [a19836dda3af8f67b5a5d1d6b1174565]: ((in_cache
+  Warning: cache store error [f67b942ca7d7e4988d8db6599b9e4163]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [a19836dda3af8f67b5a5d1d6b1174565]: ((in_cache
+  Warning: cache store error [f67b942ca7d7e4988d8db6599b9e4163]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [a19836dda3af8f67b5a5d1d6b1174565]: ((in_cache
+  Warning: cache store error [f67b942ca7d7e4988d8db6599b9e4163]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -77,10 +77,10 @@ You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort)
-  ./56/5630df9c779ee6388a10f41ed819194d:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./7d/7d27d62a60f3631a6961f7b2be16d515:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./bc/bce33d48d883ac93fa1855ebb2ab6006:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./c9/c9b3e2a160967a3a7ac43e2a046d3c77:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/7d/7d27d62a60f3631a6961f7b2be16d515"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/c9/c9b3e2a160967a3a7ac43e2a046d3c77"
   70
 
 Trimming the cache at this point should not remove any file entries because all

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -126,8 +126,8 @@ Interaction with explicit sandboxing
   3 |  (deps (sandbox none))
   4 |  (alias default)
   5 |  (action (system "echo 'Hello, world!'")))
-  Error: This rule forbids all sandboxing modes (but it also requires
-  sandboxing)
+  Error: Rules with (mode patch-back-source-tree) cannot have an explicit
+  sandbox configuration has it is implied by (mode patch-back-source-tree).
   [1]
 
 Selecting an explicit sandbox mode via the command line doesn't affect


### PR DESCRIPTION
Morally, this is a property of the action rather than the rule.