### PR TITLE
add link_flags field to inline_tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Add `link_flags` field to the `executable` field of `inline_tests` (#5088,
+  fix #1530, @jvillard)
+
 - In watch mode, use fsevents instead of fswatch on OSX (#4937, #4990, fixes
   #4896 @rgrinberg)
 

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -308,6 +308,26 @@ such libraries using a ``libraries`` field, such as:
      (backend qtest)
      (libraries bar)))
 
+Changing the flags of the linking step of the test runner
+---------------------------------------------------------
+
+You can use the ``link_flags`` field to change the linker flags
+passed to ``ocamlopt`` when building the test runner. By default the
+linking flags are ``-linkall`` and you probably want to keep
+``-linkall`` as one of the new list of flags unless you know what you
+are doing to force the linker to load your test module as the test
+runner itself does not depend on anything itself. This field supports
+``(:include ...)`` forms.
+
+.. code:: ocaml
+
+   (library
+    (name foo)
+    (inline_tests
+     (executable
+      (link_flags -linkall -noautolink -cclib -Wl,-Bstatic -cclib -lm)))
+    (preprocess (pps ppx_expect)))
+
 Defining your own inline test backend
 -------------------------------------
 

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -91,7 +91,8 @@ module Tests = struct
     ; deps : Dep_conf.t list
     ; modes : Mode_conf.Set.t
     ; flags : Ordered_set_lang.Unexpanded.t
-    ; executable : Ocaml_flags.Spec.t
+    ; executable_ocaml_flags : Ocaml_flags.Spec.t
+    ; executable_link_flags : Ordered_set_lang.Unexpanded.t
     ; backend : (Loc.t * Lib_name.t) option
     ; libraries : (Loc.t * Lib_name.t) list
     ; enabled_if : Blang.t
@@ -112,10 +113,18 @@ module Tests = struct
       (let+ loc = loc
        and+ deps = field "deps" (repeat Dep_conf.decode) ~default:[]
        and+ flags = Ordered_set_lang.Unexpanded.field "flags"
-       and+ executable =
-         field "executable" ~default:Ocaml_flags.Spec.standard
+       and+ executable_ocaml_flags, executable_link_flags =
+         field "executable"
+           ~default:
+             (Ocaml_flags.Spec.standard, Ordered_set_lang.Unexpanded.standard)
            (Dune_lang.Syntax.since Stanza.syntax (2, 8)
-           >>> fields Ocaml_flags.Spec.decode)
+           >>> fields
+                 (let+ ocaml_flags = Ocaml_flags.Spec.decode
+                  and+ link_flags =
+                    Ordered_set_lang.Unexpanded.field "link_flags"
+                      ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))
+                  in
+                  (ocaml_flags, link_flags)))
        and+ backend = field_o "backend" (located Lib_name.decode)
        and+ libraries =
          field "libraries" (repeat (located Lib_name.decode)) ~default:[]
@@ -128,7 +137,16 @@ module Tests = struct
            ~since:(Some (3, 0))
            ()
        in
-       { loc; deps; flags; executable; backend; libraries; modes; enabled_if })
+       { loc
+       ; deps
+       ; flags
+       ; executable_ocaml_flags
+       ; executable_link_flags
+       ; backend
+       ; libraries
+       ; modes
+       ; enabled_if
+       })
 
   (* We don't use this at the moment, but we could implement it for debugging
      purposes *)

--- a/src/dune_rules/inline_tests_info.mli
+++ b/src/dune_rules/inline_tests_info.mli
@@ -42,7 +42,8 @@ module Tests : sig
     ; deps : Dep_conf.t list
     ; modes : Mode_conf.Set.t
     ; flags : Ordered_set_lang.Unexpanded.t
-    ; executable : Ocaml_flags.Spec.t
+    ; executable_ocaml_flags : Ocaml_flags.Spec.t
+    ; executable_link_flags : Ordered_set_lang.Unexpanded.t
     ; backend : (Loc.t * Lib_name.t) option
     ; libraries : (Loc.t * Lib_name.t) list
     ; enabled_if : Blang.t


### PR DESCRIPTION
This adds the field and updates the documentation. I wasn't sure if/how I should add tests.

I tested this on a project by using the flag and inspecting dune's logs to verify that the link flags made it to the `ocamlopt` command for the test runner (also tested the `(:include <file>)` syntax).