### PR TITLE
Delete [promote-foo] syntax in favour of [promote foo]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -257,6 +257,9 @@ Unreleased
 - Add experimental support for directory targets (#3316, #5025, Andrey Mokhov),
   enabled via `(using directory-targets 0.1)` in `dune-project`.
 
+- Delete old `promote-into`, `promote-until-clean` and `promote-until-clean-into`
+  syntax (#5091, Andrey Mokhov).
+
 2.9.2 (unreleased)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1061,17 +1061,6 @@ this behavior using the ``mode`` field. The following modes are available:
     <dune-subdirs>`, specified using the :ref:`predicate-lang`. This feature
     has been available since Dune 1.10.
 
-- ``promote-until-clean`` is the same as ``(promote (until-clean))``.
-- ``(promote-into <dir>)`` is the same as ``(promote (into <dir>))``.
-- ``(promote-until-clean-into <dir>)`` is the same as ``(promote
-  (until-clean) (into <dir>))``.
-
-The ``(promote <options>)`` form has only been available since Dune
-1.10. Before Dune 1.10, you needed to use one of the ``promote-...``
-forms. The ``promote-...`` forms should disappear in Dune 2.0, so
-using the more generic ``(promote <options>)`` form is preferred
-for new projects.
-
 There are two use cases for ``promote`` rules. The first one is when the
 generated code is easier to review than the generator, so it's easier
 to commit the generated code and review it. The second is to cut down

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1541,22 +1541,35 @@ module Rule = struct
     include Rule.Mode
 
     let mode_decoders =
-      let promote_into lifetime =
-        let+ () = Dune_lang.Syntax.since Stanza.syntax (1, 8)
-        and+ into = Promote.into_decode in
-        Rule.Mode.Promote { lifetime; into = Some into; only = None }
-      in
       [ ("standard", return Rule.Mode.Standard)
       ; ("fallback", return Rule.Mode.Fallback)
       ; ( "promote"
         , let+ p = Promote.decode in
           Rule.Mode.Promote p )
       ; ( "promote-until-clean"
-        , return
-            (Rule.Mode.Promote
-               { lifetime = Until_clean; into = None; only = None }) )
-      ; ("promote-into", promote_into Unlimited)
-      ; ("promote-until-clean-into", promote_into Until_clean)
+        , let+ () =
+            Dune_lang.Syntax.deleted_in Stanza.syntax (3, 0)
+              ~extra_info:"Use the (promote (until-clean)) syntax instead."
+          in
+          Rule.Mode.Promote { lifetime = Until_clean; into = None; only = None }
+        )
+      ; ( "promote-into"
+        , let+ () = Dune_lang.Syntax.since Stanza.syntax (1, 8)
+          and+ () =
+            Dune_lang.Syntax.deleted_in Stanza.syntax (3, 0)
+              ~extra_info:"Use the (promote (into <dir>)) syntax instead."
+          and+ into = Promote.into_decode in
+          Rule.Mode.Promote
+            { lifetime = Unlimited; into = Some into; only = None } )
+      ; ( "promote-until-clean-into"
+        , let+ () = Dune_lang.Syntax.since Stanza.syntax (1, 8)
+          and+ () =
+            Dune_lang.Syntax.deleted_in Stanza.syntax (3, 0)
+              ~extra_info:
+                "Use the (promote (until-clean) (into <dir>)) syntax instead."
+          and+ into = Promote.into_decode in
+          Rule.Mode.Promote
+            { lifetime = Until_clean; into = Some into; only = None } )
       ]
 
     module Extended = struct

--- a/test/blackbox-tests/test-cases/promote/promote-foo-deleted.t
+++ b/test/blackbox-tests/test-cases/promote/promote-foo-deleted.t
@@ -1,0 +1,84 @@
+Test that [promote-foo] syntax is deleted in Dune 3.0 with good error messages.
+
+First, check that the syntax still works with Dune 2.9.
+
+  $ echo "(lang dune 2.9)" > dune-project
+  $ cat >dune <<EOF
+  > (rule
+  >  (targets promoted)
+  >  (action (with-stdout-to promoted (echo "Hello, world!")))
+  >  (mode (promote-into subdir)))
+  > (rule
+  >  (targets promoted-until-clean)
+  >  (action (with-stdout-to promoted-until-clean (echo "Hello again!")))
+  >  (mode promote-until-clean))
+  > EOF
+
+  $ mkdir subdir
+  $ dune build promoted promoted-until-clean
+  $ cat subdir/promoted
+  Hello, world!
+  $ cat promoted-until-clean
+  Hello again!
+  $ dune clean
+  $ cat subdir/promoted
+  Hello, world!
+  $ cat promoted-until-clean
+  cat: promoted-until-clean: No such file or directory
+  [1]
+
+Now switch to Dune 3.0.
+
+  $ echo "(lang dune 3.0)" > dune-project
+  $ dune build promoted
+  File "dune", line 4, characters 7-28:
+  4 |  (mode (promote-into subdir)))
+             ^^^^^^^^^^^^^^^^^^^^^
+  Error: 'promote-into' was deleted in version 3.0 of the dune language. Use
+  the (promote (into <dir>)) syntax instead.
+  [1]
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (targets promoted)
+  >  (action (with-stdout-to promoted (echo "Hello again!")))
+  >  (mode (promote-until-clean-into subdir)))
+  > EOF
+  $ dune build promoted
+  File "dune", line 4, characters 7-40:
+  4 |  (mode (promote-until-clean-into subdir)))
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: 'promote-until-clean-into' was deleted in version 3.0 of the dune
+  language. Use the (promote (until-clean) (into <dir>)) syntax instead.
+  [1]
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (targets promoted)
+  >  (action (with-stdout-to promoted (echo "Hello again!")))
+  >  (mode promote-until-clean))
+  > EOF
+  $ dune build promoted
+  File "dune", line 4, characters 7-26:
+  4 |  (mode promote-until-clean))
+             ^^^^^^^^^^^^^^^^^^^
+  Error: 'promote-until-clean' was deleted in version 3.0 of the dune language.
+  Use the (promote (until-clean)) syntax instead.
+  [1]
+
+Test that the hint works.
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (targets promoted)
+  >  (action (with-stdout-to promoted (echo "Hello again!")))
+  >  (mode (promote (until-clean))))
+  > EOF
+
+  $ dune build promoted
+  $ cat promoted
+  Hello again!
+  $ dune clean
+  $ cat promoted
+  cat: promoted: No such file or directory
+  [1]


### PR DESCRIPTION
We planned to delete the `promote-foo` syntax in Dune 2 but forgot. Let's do this now.