### PR TITLE
Add a test demonstrating that Dune doesn't watch dot files

### DIFF
--- a/test/blackbox-tests/test-cases/watching/watching-dot-files.t
+++ b/test/blackbox-tests/test-cases/watching/watching-dot-files.t
@@ -1,0 +1,63 @@
+Test what happens in watch mode when we depend on dot files
+
+  $ . ./helpers.sh
+
+  $ echo '(lang dune 3.0)' > dune-project
+  $ cat > dune <<EOF
+  > (rule
+  >  (targets y)
+  >  (deps .x)
+  >  (action (system "cat .x > y")))
+  > EOF
+
+  $ start_dune
+
+  $ echo 1 > .x
+  $ build y
+  Success
+  $ cat _build/default/y
+  1
+
+  $ echo 2 > .x
+  $ build y
+  Success
+  $ cat _build/default/y
+  2
+
+  $ stop_dune
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+
+Same but in a sub-directory (the exclude regexp is sensitive to that):
+
+  $ mkdir test
+  $ mv dune test/dune
+
+  $ start_dune
+
+  $ echo 1 > test/.x
+  $ build test/y
+  Success
+  $ cat _build/default/test/y
+  1
+
+Currently it doesn't work because the event is filtered out:
+
+  $ echo 2 > test/.x
+  $ build test/y
+  Success
+  $ cat _build/default/test/y
+  1
+
+  $ stop_dune
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+  waiting for inotify sync
+  waited for inotify sync
+  Success, waiting for filesystem changes...
+


### PR DESCRIPTION
Which is a problem when a rule depend on a dot files.

And for the facepalm effect: dot files are watched iff they are at the root.