### PR TITLE
Remove old hard-coded exclude list from the file watcher

### DIFF
--- a/src/dune_engine/fs_cache.mli
+++ b/src/dune_engine/fs_cache.mli
@@ -69,7 +69,11 @@ module Untracked : sig
 
   val path_digest : Cached_digest.Digest_result.t t
 
-  val dir_contents : (Dir_contents.t, Unix_error.Detailed.t) result t
+  (** The directory listing with temporary files created by well known editors
+      such as emacs or vim filtered out. This include files named [xx~], [#xx],
+      [4914] (a vim oddity), ... *)
+  val dir_contents_without_temporary_editor_files :
+    (Dir_contents.t, Unix_error.Detailed.t) result t
 end
 
 module Debug : sig

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -97,7 +97,7 @@ let update_all : Path.t -> Fs_cache.Update_result.t =
     [ update Fs_cache.Untracked.path_exists
     ; update Fs_cache.Untracked.path_stat
     ; update Fs_cache.Untracked.path_digest
-    ; update Fs_cache.Untracked.dir_contents
+    ; update Fs_cache.Untracked.dir_contents_without_temporary_editor_files
     ]
 
 (* CR-someday amokhov: We use the same Memo table [memo] for tracking different
@@ -172,8 +172,9 @@ let path_stat = declaring_dependency ~f:Fs_cache.(read Untracked.path_stat)
    of [path_digest] seems error-prone. We may need to rethink this decision. *)
 let path_digest = declaring_dependency ~f:Fs_cache.(read Untracked.path_digest)
 
-let dir_contents =
-  declaring_dependency ~f:Fs_cache.(read Untracked.dir_contents)
+let dir_contents_without_temporary_editor_files =
+  declaring_dependency
+    ~f:Fs_cache.(read Untracked.dir_contents_without_temporary_editor_files)
 
 (* CR-someday amokhov: For now, we do not cache the result of this operation
    because the result's type depends on [f]. There are only two call sites of
@@ -188,7 +189,8 @@ let with_lexbuf_from_file path ~f =
       Io.Untracked.with_lexbuf_from_file path ~f)
 
 (* When a file or directory is created or deleted, we need to also invalidate
-   the parent directory, so that the [dir_contents] queries are re-executed. *)
+   the parent directory, so that the
+   [dir_contents_without_temporary_editor_files] queries are re-executed. *)
 let invalidate_path_and_its_parent path =
   Memo.Invalidation.combine (invalidate_path path)
     (match Path.parent path with
@@ -206,9 +208,10 @@ let invalidate_path_and_its_parent path =
    [Path.exists] function. Similarly for the case where [path_exists] is [false]
    and we receive a corresponding [Created] event.
 
-   - Finally, the result of [dir_contents] queries can be updated without
-   calling [Path.Untracked.readdir_unsorted_with_kinds]: we know which file or
-   directory should be added to or removed from the result. *)
+   - Finally, the result of [dir_contents_without_temporary_editor_files]
+   queries can be updated without calling
+   [Path.Untracked.readdir_unsorted_with_kinds]: we know which file or directory
+   should be added to or removed from the result. *)
 let handle_fs_event ({ kind; path } : Dune_file_watcher.Fs_memo_event.t) :
     Memo.Invalidation.t =
   match kind with

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -30,7 +30,7 @@ val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Memo.Build.t
 
 (** Read the contents of a source or external directory and declare a dependency
     on it. *)
-val dir_contents :
+val dir_contents_without_temporary_editor_files :
   Path.t -> (Fs_cache.Dir_contents.t, Unix_error.Detailed.t) result Memo.Build.t
 
 (** Handle file system event. *)

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -7,6 +7,5 @@
   stdune
   threads.posix
   ocaml_inotify
-  async_inotify_for_dune
-  dune_re)
+  async_inotify_for_dune)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -362,7 +362,9 @@ end = struct
         let virtual_ = None in
         let default_implementation = None in
         let wrapped = None in
-        let+ dir_contents = Fs_memo.dir_contents t.dir in
+        let+ dir_contents =
+          Fs_memo.dir_contents_without_temporary_editor_files t.dir
+        in
         let foreign_archives, native_archives =
           (* Here we scan [t.dir] and consider all files named [lib*.ext_lib] to
              be foreign archives, and all other files with the extension
@@ -634,7 +636,7 @@ let find t name =
 let root_packages (db : DB.t) =
   let+ pkgs =
     Memo.Build.List.concat_map db.paths ~f:(fun dir ->
-        Fs_memo.dir_contents dir >>= function
+        Fs_memo.dir_contents_without_temporary_editor_files dir >>= function
         | Error (ENOENT, _, _) -> Memo.Build.return []
         | Error (unix_error, _, _) ->
           User_error.raise

--- a/test/blackbox-tests/test-cases/watching/watching-dot-files.t
+++ b/test/blackbox-tests/test-cases/watching/watching-dot-files.t
@@ -45,13 +45,11 @@ Same but in a sub-directory (the exclude regexp is sensitive to that):
   $ cat _build/default/test/y
   1
 
-Currently it doesn't work because the event is filtered out:
-
   $ echo 2 > test/.x
   $ build test/y
   Success
   $ cat _build/default/test/y
-  1
+  2
 
   $ stop_dune
   waiting for inotify sync


### PR DESCRIPTION
It is no longer necessary given that we now correctly ignore events that don't impact the build. This fixes the issue demonstrated in #5092.

Keep ignoring `_opam` and `_esy` with the fswatch backend though, to be conservative.

Removed some old comment related to inotifywait that we no longer use.