### PR TITLE
Don't ignore all events about dot files

### DIFF
--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -170,7 +170,7 @@ type t =
 let exclude_patterns =
   [ {|/_opam|}
   ; {|/_esy|}
-  ; {|/\..+|}
+  ; {|/\.#.*|}
   ; {|~$|}
   ; {|/#[^#]*#$|}
   ; {|4913|} (* https://github.com/neovim/neovim/issues/3460 *)

--- a/test/blackbox-tests/test-cases/watching/watching-dot-files.t
+++ b/test/blackbox-tests/test-cases/watching/watching-dot-files.t
@@ -45,13 +45,11 @@ Same but in a sub-directory (the exclude regexp is sensitive to that):
   $ cat _build/default/test/y
   1
 
-Currently it doesn't work because the event is filtered out:
-
   $ echo 2 > test/.x
   $ build test/y
   Success
   $ cat _build/default/test/y
-  1
+  2
 
   $ stop_dune
   waiting for inotify sync


### PR DESCRIPTION
Less ambitious version of #5094. We still want #5094, but we'll have to change a few more things before we can go ahead with this. This PR will do in the meantime.

-----

Only ignore events about .#... files.

Also remove a stale comment about inotifywait that we don't use
anymore.
