### PR TITLE
Fix capitalisation in "evaluating predicate..." message

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -2237,7 +2237,7 @@ end = struct
       Memo.create "eval-pred"
         ~human_readable_description:(fun glob ->
           Pp.concat
-            [ Pp.textf "evaluating predicate in directory %s"
+            [ Pp.textf "Evaluating predicate in directory %s"
                 (Path.to_string_maybe_quoted (File_selector.dir glob))
             ])
         ~input:(module File_selector)

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
@@ -81,7 +81,7 @@ This is a reproduction case from issue #4345
   $ dune build --root .
   Error: Dependency cycle between:
      Computing rules for package lib
-  -> evaluating predicate in directory _build/default
+  -> Evaluating predicate in directory _build/default
   -> Computing directory contents of _build/default/lib
   -> Computing rules for package lib
   [1]


### PR DESCRIPTION
The test added in #5039 bothered me due to inconsistent capitalisation, so I fixed it.