### PR TITLE
feature: install dir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
 - Allow rules producing directory targets to be not sandboxed (#6056,
   @rgrinberg)
 
+- Introduce a `dirs` field in the `install` stanza to install entire
+  directories (#5097, fixes #5059, @rgrinberg)
+
 3.4.1 (26-07-2022)
 ------------------
 

--- a/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
@@ -146,6 +146,8 @@ module Unix_error = struct
   module Detailed = struct
     type nonrec t = t * string * string
 
+    let raise (e, x, y) = raise (Unix.Unix_error (e, x, y))
+
     let create error ~syscall ~arg = (error, syscall, arg)
 
     let catch f x =

--- a/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.mli
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.mli
@@ -11,6 +11,8 @@ module Unix_error : sig
   module Detailed : sig
     type nonrec t = t * string * string
 
+    val raise : t -> 'a
+
     val create : Unix.error -> syscall:string -> arg:string -> t
 
     (** Apply a function to an argument, catching a detailed Unix error. *)

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -240,6 +240,13 @@ let symlink ~src ~dst =
   with_file_targets ~file_targets:[ dst ]
     (path src >>> return (Action.Full.make (Action.Symlink (src, dst))))
 
+let symlink_dir ~src ~dst =
+  with_targets
+    ~targets:
+      (Targets.create ~files:Path.Build.Set.empty
+         ~dirs:(Path.Build.Set.singleton dst))
+    (path src >>> return (Action.Full.make (Action.Symlink (src, dst))))
+
 let create_file ?(perm = Action.File_perm.Normal) fn =
   with_file_targets ~file_targets:[ fn ]
     (return

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -168,6 +168,8 @@ val copy : src:Path.t -> dst:Path.Build.t -> Action.Full.t With_targets.t
 
 val symlink : src:Path.t -> dst:Path.Build.t -> Action.Full.t With_targets.t
 
+val symlink_dir : src:Path.t -> dst:Path.Build.t -> Action.Full.t With_targets.t
+
 val create_file :
   ?perm:Action.File_perm.t -> Path.Build.t -> Action.Full.t With_targets.t
 

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -639,8 +639,10 @@ let coq_plugins_install_rules ~scope ~package ~dst_dir (s : Theory.t) =
              let dst =
                Path.Local.(to_string (relative dst_dir plugin_file_basename))
              in
-             let entry = Install.Entry.make Section.Lib_root ~dst plugin_file in
-             (* TODO this [loc] should come from [s.buildable.libraries] *)
+             let entry =
+               (* TODO this [loc] should come from [s.buildable.libraries] *)
+               Install.Entry.make Section.Lib_root ~dst ~kind:`File plugin_file
+             in
              Install.Entry.Sourced.create ~loc entry)
     else []
   in
@@ -678,6 +680,7 @@ let install_rules ~sctx ~dir s =
     let make_entry (orig_file : Path.Build.t) (dst_file : string) =
       let entry =
         Install.Entry.make Section.Lib_root ~dst:(to_dst dst_file) orig_file
+          ~kind:`File
       in
       Install.Entry.Sourced.create ~loc entry
     in

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -206,6 +206,7 @@ module Install_conf : sig
   type t =
     { section : Install.Section_with_site.t
     ; files : File_binding.Unexpanded.t list
+    ; dirs : File_binding.Unexpanded.t list
     ; package : Package.t
     ; enabled_if : Blang.t
     }

--- a/src/dune_rules/install.mli
+++ b/src/dune_rules/install.mli
@@ -6,6 +6,8 @@ module Dst : sig
 
   val to_string : t -> string
 
+  val concat_all : t -> string list -> t
+
   include Dune_lang.Conv.S with type t := t
 
   val to_dyn : t -> Dyn.t
@@ -91,6 +93,7 @@ end
 module Entry : sig
   type 'src t = private
     { src : 'src
+    ; kind : [ `File | `Directory ]
     ; dst : Dst.t
     ; section : Section.t
     }
@@ -116,7 +119,12 @@ module Entry : sig
     -> section:Section.t
     -> Dst.t
 
-  val make : Section.t -> ?dst:string -> Path.Build.t -> Path.Build.t t
+  val make :
+       Section.t
+    -> ?dst:string
+    -> kind:[ `File | `Directory ]
+    -> Path.Build.t
+    -> Path.Build.t t
 
   val make_with_site :
        Section_with_site.t
@@ -125,10 +133,13 @@ module Entry : sig
         -> pkg:Dune_engine.Package.Name.t
         -> site:Dune_engine.Section.Site.t
         -> Section.t Memo.t)
+    -> kind:[ `File | `Directory ]
     -> Path.Build.t
     -> Path.Build.t t Memo.t
 
   val set_src : _ t -> 'src -> 'src t
+
+  val map_dst : 'a t -> f:(Dst.t -> Dst.t) -> 'a t
 
   val relative_installed_path : _ t -> paths:Section.Paths.t -> Path.t
 

--- a/src/dune_rules/plugin_rules.ml
+++ b/src/dune_rules/plugin_rules.ml
@@ -48,6 +48,6 @@ let install_rules ~sctx ~sites ~dir ({ name; site = loc, (pkg, site); _ } as t)
         ~dst:(sprintf "%s/%s" (Package.Name.to_string name) Findlib.meta_fn)
         (Site { pkg; site; loc })
         (Sites.section_of_site sites)
-        meta
+        ~kind:`File meta
     in
     [ Install.Entry.Sourced.create ~loc entry ]

--- a/test/blackbox-tests/test-cases/directory-targets/install-dir-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/install-dir-target.t
@@ -1,0 +1,35 @@
+Allow directories to be installable
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.5)
+  > (package (name foo))
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (install
+  >  (dirs rules/bar)
+  >  (section share))
+  > EOF
+
+  $ mkdir rules
+  $ cat >rules/dune <<EOF
+  > (rule
+  >  (target (dir bar))
+  >  (deps (sandbox always))
+  >  (action (bash "mkdir -p %{target}/baz && touch %{target}/{x,y,z} && touch %{target}/baz/{a,b}")))
+  > EOF
+
+  $ dune build foo.install
+  $ cat _build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+  ]
+  share: [
+    "_build/install/default/share/foo/bar/baz/a" {"bar/baz/a"}
+    "_build/install/default/share/foo/bar/baz/b" {"bar/baz/b"}
+    "_build/install/default/share/foo/bar/x" {"bar/x"}
+    "_build/install/default/share/foo/bar/y" {"bar/y"}
+    "_build/install/default/share/foo/bar/z" {"bar/z"}
+  ]


### PR DESCRIPTION
This PR allows installing all the artifacts in a directory using the following syntax:

```
(install
 (dir foo/bar)
 (package pkg)
 (section baz))
```

This will build `foo/bar` and add its recursive listing to `pkg.install`.

This feature is particularly useful for installing things such as documentation, where there's a lot of overhead in listing the contents individually.