### PR TITLE
Reuse helpers.sh in basic file-watching tests

### DIFF
--- a/test/blackbox-tests/test-cases/subdir-stanza/basic.t
+++ b/test/blackbox-tests/test-cases/subdir-stanza/basic.t
@@ -133,4 +133,3 @@ Include stanzas within subdir stanzas
   Error: invalid sub-directory path "/absolute/path/to/bar"
   Hint: sub-directory path must be relative
   [1]
-

--- a/test/blackbox-tests/test-cases/watching/basic.t
+++ b/test/blackbox-tests/test-cases/watching/basic.t
@@ -1,27 +1,6 @@
-  $ DUNE_RUNNING=0
+Basic tests for the file-watching mode.
 
-  $ start_dune () {
-  >  ((dune build "$@" --passive-watch-mode > dune-output 2>&1) || (echo exit $? >> dune-output)) &
-  >   DUNE_PID=$!;
-  >   DUNE_RUNNING=1;
-  > }
-
-  $ timeout="$(command -v timeout || echo gtimeout)"
-
-  $ with_timeout () {
-  >   $timeout 2 "$@"
-  >   exit_code=$?
-  >   if [ "$exit_code" = 124 ]
-  >   then
-  >     printf "Timed out"
-  >   else
-  >     return "$exit_code"
-  >   fi
-  > }
-
-  $ build () {
-  >   with_timeout dune rpc build --wait "$@"
-  > }
+  $ . ./helpers.sh
 
 ----------------------------------------------------------------------------------
 * Compile a simple rule


### PR DESCRIPTION
I also moved the basic tests out of the separate subdirectory.

With the new name, building `@basic` runs both `subdir-stanza/basic.t` and `watching/basic.t`. I wonder: is it possible to tell Dune to build just one of them? I tried `@watching/basic` and (unsurprisingly) this didn't work. I don't think there is much point in trying to avoid name collisions, since in the long run it's hardly possible.