### PR TITLE
doc: fix minimum version for empty intf generation

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -747,7 +747,7 @@ binary at the same place as ``ocamlc`` was found.
 Executables can also be linked as object or shared object files. See
 `linking modes`_ for more information.
 
-Starting from Dune 2.9, it's possible to automatically generate empty interface
+Starting from Dune 3.0, it's possible to automatically generate empty interface
 files for executables. See `executables_implicit_empty_intf`_.
 
 ``<optional-fields>`` are:


### PR DESCRIPTION
it is introduced in 3.0 rather than 2.9

cc @hhugo 