### PR TITLE
Add a new RPC outcome [Restart]

### DIFF
--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -199,8 +199,9 @@ module Build = struct
         match response with
         | Error (error : Dune_rpc_private.Response.Error.t) ->
           report_error error
-        | Ok Failure -> print_endline "Failure"
-        | Ok Success -> print_endline "Success")
+        | Ok Success -> print_endline "Success"
+        | Ok Restart -> print_endline "Restart"
+        | Ok Failure -> print_endline "Failure")
 
   let info =
     let doc =

--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -200,7 +200,9 @@ module Build = struct
         | Error (error : Dune_rpc_private.Response.Error.t) ->
           report_error error
         | Ok Success -> print_endline "Success"
-        | Ok Restart -> print_endline "Restart"
+        | Ok (Restart { details_hum }) ->
+          print_endline
+            (sprintf "Restart (%s)" (String.concat ~sep:", " details_hum))
         | Ok Failure -> print_endline "Failure")
 
   let info =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -278,6 +278,11 @@ module type Rule_generator = sig
 end
 
 module Handler = struct
+  (* CR-someday amokhov: The name [Interrupt] is not precise, because the build
+     is restarted, not, e.g. interrupted with Ctrl-C. Similarly, we have other
+     imprecise names, like [Cancelled_due_to_file_changes] in [Scheduler] where
+     the build is not just cancelled, it's restarted. We should make the naming
+     more consistent. *)
   type event =
     | Start
     | Finish

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1238,7 +1238,7 @@ module Run = struct
   module Build_outcome_for_rpc = struct
     type t =
       | Success
-      | Restart
+      | Restart of { details_hum : string list }
       | Failure
   end
 
@@ -1251,7 +1251,8 @@ module Run = struct
             Fiber.Ivar.fill response_ivar
               (match res with
               | Finished (Ok _) -> Build_outcome_for_rpc.Success
-              | Cancelled_due_to_file_changes _ -> Restart
+              | Cancelled_due_to_file_changes { details_hum } ->
+                Restart { details_hum }
               | Finished (Error _)
               | Shutdown ->
                 Build_outcome_for_rpc.Failure)

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1238,6 +1238,7 @@ module Run = struct
   module Build_outcome_for_rpc = struct
     type t =
       | Success
+      | Restart
       | Failure
   end
 
@@ -1250,8 +1251,8 @@ module Run = struct
             Fiber.Ivar.fill response_ivar
               (match res with
               | Finished (Ok _) -> Build_outcome_for_rpc.Success
+              | Cancelled_due_to_file_changes _ -> Restart
               | Finished (Error _)
-              | Cancelled_due_to_file_changes _
               | Shutdown ->
                 Build_outcome_for_rpc.Failure)
           in

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -73,7 +73,7 @@ module Run : sig
   module Build_outcome_for_rpc : sig
     type t =
       | Success
-      | Restart
+      | Restart of { details_hum : string list }
       | Failure
   end
 

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -73,6 +73,7 @@ module Run : sig
   module Build_outcome_for_rpc : sig
     type t =
       | Success
+      | Restart
       | Failure
   end
 

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -5,9 +5,12 @@ open Dune_rpc_private
 module Build_outcome = struct
   type t = Dune_engine.Scheduler.Run.Build_outcome_for_rpc.t =
     | Success
+    | Restart
     | Failure
 
-  let sexp = Conv.enum [ ("Success", Success); ("Failure", Failure) ]
+  let sexp =
+    Conv.enum
+      [ ("Success", Success); ("Restart", Restart); ("Failure", Failure) ]
 end
 
 module Status = struct

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -5,12 +5,22 @@ open Dune_rpc_private
 module Build_outcome = struct
   type t = Dune_engine.Scheduler.Run.Build_outcome_for_rpc.t =
     | Success
-    | Restart
+    | Restart of { details_hum : string list }
     | Failure
 
   let sexp =
-    Conv.enum
-      [ ("Success", Success); ("Restart", Restart); ("Failure", Failure) ]
+    let open Conv in
+    let success = constr "Success" unit (fun () -> Success) in
+    let restart =
+      constr "Restart" (list string) (fun details_hum ->
+          Restart { details_hum })
+    in
+    let failure = constr "Failure" unit (fun () -> Failure) in
+    let variants = [ econstr success; econstr restart; econstr failure ] in
+    sum variants (function
+      | Success -> case () success
+      | Restart { details_hum } -> case details_hum restart
+      | Failure -> case () failure)
 end
 
 module Status = struct

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -5,7 +5,7 @@ open Dune_rpc_private
 module Build_outcome : sig
   type t = Dune_engine.Scheduler.Run.Build_outcome_for_rpc.t =
     | Success
-    | Restart
+    | Restart of { details_hum : string list }
     | Failure
 
   val sexp : (t, Conv.values) Conv.t

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -5,6 +5,7 @@ open Dune_rpc_private
 module Build_outcome : sig
   type t = Dune_engine.Scheduler.Run.Build_outcome_for_rpc.t =
     | Success
+    | Restart
     | Failure
 
   val sexp : (t, Conv.values) Conv.t

--- a/test/blackbox-tests/test-cases/watching/retriggering.t
+++ b/test/blackbox-tests/test-cases/watching/retriggering.t
@@ -17,7 +17,7 @@ Bad rule! You are not supposed to modify the source tree. No ice-cream for you!
   $ touch old-source.txt
   $ start_dune
 
-The build restarts because a new source file has been created.
+The build restarts because a new source file has been created at the root.
 
   $ build result
   Restart (. changed)
@@ -29,21 +29,15 @@ So, we come back for the result once again and now get it.
   $ build result
   Success
 
+The second time the rule sees new-source.txt because Dune copied it to the
+build directory. Note that the file watcher generates the next touch event for
+new-source.txt but it is ignored because the contents of new-source.txt is the
+same, i.e. the empty file.
+
   $ cat _build/default/result
   new-source.txt old-source.txt
   $ cat _build/default/new-source.txt
 
-Some notes explaining what's going on below:
-
-* The first time the rule is executed, it sees no *.txt files.
-
-* The build is restarted because dir_contents for "." changed.
-
-* The second time the rule sees new-source.txt because Dune copied it to the
-| build directory.
-
-* The file watcher generates the next touch event for new-source.txt but it is
-| ignored because the contents of new-source.txt (empty file) is the same.
 
   $ stop_dune
   waiting for inotify sync

--- a/test/blackbox-tests/test-cases/watching/retriggering.t
+++ b/test/blackbox-tests/test-cases/watching/retriggering.t
@@ -20,7 +20,7 @@ Bad rule! You are not supposed to modify the source tree. No ice-cream for you!
 The build restarts because a new source file has been created.
 
   $ build result
-  Restart
+  Restart (. changed)
 
   $ cat new-source.txt
 

--- a/test/blackbox-tests/test-cases/watching/retriggering.t
+++ b/test/blackbox-tests/test-cases/watching/retriggering.t
@@ -17,19 +17,14 @@ Bad rule! You are not supposed to modify the source tree. No ice-cream for you!
   $ touch old-source.txt
   $ start_dune
 
-This failure is not really a failure but is merely a re-triggering of the build
-because a new source file has been created. This is confusing: we should really
-send "Interrupted" or something like this via Dune RPC in this case.
-
-# CR-someday amokhov: Change Dune RPC to send "Interrupted" instead of "Failure"
-# when the current build is re-triggered.
+The build restarts because a new source file has been created.
 
   $ build result
-  Failure
+  Restart
 
   $ cat new-source.txt
 
-So, we try again and it works.
+So, we come back for the result once again and now get it.
 
   $ build result
   Success
@@ -42,7 +37,7 @@ Some notes explaining what's going on below:
 
 * The first time the rule is executed, it sees no *.txt files.
 
-* The build is re-triggered because dir_contents for "." changed.
+* The build is restarted because dir_contents for "." changed.
 
 * The second time the rule sees new-source.txt because Dune copied it to the
 | build directory.


### PR DESCRIPTION
Following up on #5103, I'm adding a new `Build_outcome_for_rpc` called `Restart`. I think this makes the behaviour less surprising.

I guess the clients will need to be changed to accept the new outcome. Do we need to bump some RPC version?