### PR TITLE
Allow variables in ctypes headers

### DIFF
--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -117,7 +117,7 @@ location.
      (function_description
       (concurrency unlocked)
       (instance Function)
-      (functor Function_descriptio))
+      (functor Function_description))
      (generated_types Types_generated)
      (generated_entry_point C)))
 
@@ -250,6 +250,12 @@ descriptions by referencing them as the module specified in optional
 - ``(generated_entry_point <module-name>)`` is the name of a generated module
   that your instantiated ``Types`` and ``Function`` modules will instantiated
   under. We suggest calling it ``C``.
+
+- Headers can be added to the generated C files:
+   - ``(headers (include "include1" "include2" ...))`` adds ``#include
+     <include1>``, ``#include <include2>``. It uses the :ref:`ordered-set-language`.
+   - ``(headers (preamble <preamble>)`` adds directly the preamble. Variables
+     can be used in ``<preamble>`` such as ``%{read: }``.
 
 ``<optional-function-description-fields>`` are:
 

--- a/src/dune_rules/ctypes_stanza.ml
+++ b/src/dune_rules/ctypes_stanza.ml
@@ -52,21 +52,21 @@ end
 
 module Headers = struct
   type t =
-    | Include of string list
-    | Preamble of string
+    | Include of Ordered_set_lang.Unexpanded.t
+    | Preamble of String_with_vars.t
 
   let decode =
     let include_ =
-      let+ s = repeat string in
+      let+ s = Ordered_set_lang.Unexpanded.decode in
       Include s
     in
     let preamble =
-      let+ p = string in
+      let+ p = String_with_vars.decode in
       Preamble p
     in
     sum [ ("include", include_); ("preamble", preamble) ]
 
-  let default = Include []
+  let default = Include Ordered_set_lang.Unexpanded.standard
 end
 
 module Type_description = struct

--- a/src/dune_rules/ctypes_stanza.mli
+++ b/src/dune_rules/ctypes_stanza.mli
@@ -24,8 +24,8 @@ end
 
 module Headers : sig
   type t =
-    | Include of string list
-    | Preamble of string
+    | Include of Ordered_set_lang.Unexpanded.t
+    | Preamble of String_with_vars.t
 end
 
 module Type_description : sig

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored-preamble.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored-preamble.t/dune
@@ -16,7 +16,7 @@
     (build_flags_resolver
       (vendored
         (c_flags "-Ivendor")))
-    (headers (preamble "#include <example.h>"))
+    (headers (preamble "#include %{read:preamble.sexp}"))
     (type_description
       (instance Types)
       (functor Type_description))
@@ -24,3 +24,8 @@
       (instance Functions)
       (functor Function_description))
     (generated_entry_point C)))
+
+
+(rule
+ (action (with-stdout-to preamble.sexp (echo "<example.h>")))
+  )

--- a/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/exe-vendored.t/dune
@@ -16,7 +16,7 @@
     (build_flags_resolver
       (vendored
         (c_flags "-Ivendor")))
-    (headers (include "example.h"))
+    (headers (include (:include includes.sexp)))
     (type_description
       (instance Types)
       (functor Type_description))
@@ -24,3 +24,7 @@
       (instance Functions)
       (functor Function_description))
     (generated_entry_point C)))
+
+(rule
+ (action (with-stdout-to includes.sexp (echo "example.h")))
+  )


### PR DESCRIPTION
Allows ` (headers (preamble "#include %{read:preamble.sexp}"))` and `(headers (include (:include includes.sexp)))` and add documentation for `headers`
