### PR TITLE
Make patch_back_source_tree a sandboxing mode.

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -549,7 +549,9 @@ let shared_with_config_file =
           ~doc:{|Run no more than $(i,JOBS) commands simultaneously.|})
   and+ sandboxing_preference =
     let arg =
-      simple_arg_conv ~of_string:Dune_engine.Sandbox_mode.of_string
+      simple_arg_conv
+        ~of_string:
+          Dune_engine.Sandbox_mode.of_string_except_patch_back_source_tree
         ~to_string:Dune_engine.Sandbox_mode.to_string
     in
     Arg.(
@@ -566,7 +568,8 @@ let shared_with_config_file =
                 certain sandboxing mode, so they will ignore this setting. The \
                 allowed values are: %s."
                (String.concat ~sep:", "
-                  (List.map Dune_engine.Sandbox_mode.all
+                  (List.map
+                     Dune_engine.Sandbox_mode.all_except_patch_back_source_tree
                      ~f:Dune_engine.Sandbox_mode.to_string))))
   and+ terminal_persistence =
     let modes = Dune_config.Terminal_persistence.all in

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -78,7 +78,7 @@ module Sandboxing_preference = struct
   let decode =
     repeat
       (plain_string (fun ~loc s ->
-           match Sandbox_mode.of_string s with
+           match Sandbox_mode.of_string_except_patch_back_source_tree s with
            | Error m -> User_error.raise ~loc [ Pp.text m ]
            | Ok s -> s))
 end

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -278,24 +278,12 @@ let is_useful_to_memoize = is_useful_to true true
 
 module Full = struct
   module T = struct
-    (* Invariant: if [patch_back_source_tree] then:
-
-       - [sandbox] is [Sandbox_mode.Set.singleton (Some Copy)] or
-       [Sandbox_mode.Set.empty]. The latter would cause Dune to crash as there
-       would be no sandboxing mode selectable, but it shouldn't happen as we
-       forbid to specify a sandbox configuration when using [(mode
-       patch-back-source-tree)]. Allowing [Sandbox_mode.Set.empty] in the
-       invariant makes it easier to preserve the invariant in the various
-       functions bellow.
-
-       - [can_go_in_shared_cache] is [true]. *)
     type nonrec t =
       { action : t
       ; env : Env.t
       ; locks : Path.t list
       ; can_go_in_shared_cache : bool
       ; sandbox : Sandbox_config.t
-      ; patch_back_source_tree : bool
       }
 
     let empty =
@@ -304,57 +292,24 @@ module Full = struct
       ; locks = []
       ; can_go_in_shared_cache = true
       ; sandbox = Sandbox_config.default
-      ; patch_back_source_tree = false
       }
 
-    let combine
-        { action
-        ; env
-        ; locks
-        ; can_go_in_shared_cache
-        ; sandbox
-        ; patch_back_source_tree
-        } x =
+    let combine { action; env; locks; can_go_in_shared_cache; sandbox } x =
       { action = combine action x.action
       ; env = Env.extend_env env x.env
       ; locks = locks @ x.locks
       ; can_go_in_shared_cache =
           can_go_in_shared_cache && x.can_go_in_shared_cache
       ; sandbox = Sandbox_config.inter sandbox x.sandbox
-      ; patch_back_source_tree =
-          patch_back_source_tree || x.patch_back_source_tree
       }
   end
 
   include T
   include Monoid.Make (T)
 
-  let adapt_action_for_patch_back_source_tree t =
-    if not t.patch_back_source_tree then
-      t
-    else
-      (* Rules that patch back the source tree cannot go in the shared cache *)
-      let can_go_in_shared_cache = false in
-      (* Rules that patch back the source tree must be sandboxed in copy
-         mode. *)
-      let sandbox =
-        Sandbox_config.inter t.sandbox (Sandbox_mode.Set.singleton (Some Copy))
-      in
-      { t with can_go_in_shared_cache; sandbox }
-
   let make ?(env = Env.empty) ?(locks = []) ?(can_go_in_shared_cache = true)
-      ?(sandbox = Sandbox_config.default) ?(patch_back_source_tree = false)
-      action =
-    let t =
-      { action
-      ; env
-      ; locks
-      ; can_go_in_shared_cache
-      ; sandbox
-      ; patch_back_source_tree
-      }
-    in
-    adapt_action_for_patch_back_source_tree t
+      ?(sandbox = Sandbox_config.default) action =
+    { action; env; locks; can_go_in_shared_cache; sandbox }
 
   let map t ~f = { t with action = f t.action }
 
@@ -366,8 +321,4 @@ module Full = struct
     { t with can_go_in_shared_cache = t.can_go_in_shared_cache && b }
 
   let add_sandbox s t = { t with sandbox = Sandbox_config.inter t.sandbox s }
-
-  let add_patch_back_source_tree x t =
-    adapt_action_for_patch_back_source_tree
-      { t with patch_back_source_tree = t.patch_back_source_tree || x }
 end

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -128,20 +128,6 @@ module Full : sig
     ; locks : Path.t list
     ; can_go_in_shared_cache : bool
     ; sandbox : Sandbox_config.t
-    ; patch_back_source_tree : bool
-          (** Apply all the changes that happened in the sandbox to the source
-              tree. This includes:
-
-              - applying changes to source files that were dependencies
-              - deleting source files that were dependencies and were deleted in
-                the sandbox
-              - promoting all targets
-              - promoting all files that were created and not declared as
-                dependencies or targets
-
-              This is a dirty setting, but it is necessary to port projects to
-              Dune that don't use a separate directory and have rules that go
-              and create/modify random files. *)
     }
 
   val make :
@@ -149,7 +135,6 @@ module Full : sig
     -> ?locks:Path.t list (** default [\[\]] *)
     -> ?can_go_in_shared_cache:bool (** default [true] *)
     -> ?sandbox:Sandbox_config.t (** default [Sandbox_config.default] *)
-    -> ?patch_back_source_tree:bool (** default [false] *)
     -> action
     -> t
 
@@ -167,8 +152,6 @@ module Full : sig
   val add_sandbox : Sandbox_config.t -> t -> t
 
   val add_can_go_in_shared_cache : bool -> t -> t
-
-  val add_patch_back_source_tree : bool -> t -> t
 
   include Monoid with type t := t
 end

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -12,7 +12,6 @@ val map_path : t -> Path.Build.t -> Path.Build.t
 (** Create a new sandbox and copy or link dependencies inside it. *)
 val create :
      mode:Sandbox_mode.some
-  -> patch_back_source_tree:bool
   -> rule_loc:Loc.t
   -> deps:Dep.Facts.t
   -> rule_dir:Path.Build.t

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
@@ -36,9 +36,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [158799f889ef635e77efe9538c30b695] (_build/default/source): not found in cache
+  Shared cache miss [bfd46d3e78576b3273cc8897339fb1fb] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [227152a3a37f16da91ce766c636ed984] (_build/default/target1): not found in cache
+  Shared cache miss [418f8da32eb95ade2c3c399acbdd7ba3] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [158799f889ef635e77efe9538c30b695] (_build/default/source): not found in cache
+  Shared cache miss [bfd46d3e78576b3273cc8897339fb1fb] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [227152a3a37f16da91ce766c636ed984] (_build/default/target1): not found in cache
+  Shared cache miss [418f8da32eb95ade2c3c399acbdd7ba3] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [f67b942ca7d7e4988d8db6599b9e4163]: ((in_cache
+  Warning: cache store error [bc44ce73b59c0f57bdf081b00fab6c00]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [f67b942ca7d7e4988d8db6599b9e4163]: ((in_cache
+  Warning: cache store error [bc44ce73b59c0f57bdf081b00fab6c00]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [f67b942ca7d7e4988d8db6599b9e4163]: ((in_cache
+  Warning: cache store error [bc44ce73b59c0f57bdf081b00fab6c00]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -77,10 +77,10 @@ You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort)
-  ./bc/bce33d48d883ac93fa1855ebb2ab6006:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
-  ./c9/c9b3e2a160967a3a7ac43e2a046d3c77:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./51/51a45667e2e30bf7625cded8dee3af12:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
+  ./ef/ef724517861c7ec3645a4b4183e01831:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/c9/c9b3e2a160967a3a7ac43e2a046d3c77"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/ef/ef724517861c7ec3645a4b4183e01831"
   70
 
 Trimming the cache at this point should not remove any file entries because all


### PR DESCRIPTION
Since this is really what it is. The code seems more natural this way as well.

I ended up removing the invariant on `Action.Full.t` and convinced myself it is Ok. Instead, in `execute_rule` we force `can_go_in_shared_cache = false` if the selected sandboxing mode is `Some Patch_back_source_tree`.

In the end, it seems to me that not having the invariant on `Action.Full.t` simply means that we might end up creating more cache entries than necessary if we change the (ignored) `can_go_in_shared_cache` field of an action that has `sandbox = Sandbox_mode.singleton (Some Patch_back_source_tree)`, which doesn't seem terrible.