### PR TITLE
Fix "Linking Modes" so that it's not a top-level section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,10 @@ distclean: clean
 doc:
 	sphinx-build doc doc/_build
 
+# livedoc-deps: you may need to [pip3 install sphinx-autobuild] and [pip3 install sphinx-rtd-theme]
 livedoc:
 	cd doc && sphinx-autobuild . _build \
-	  -p 8888 -q  --host $(shell hostname) -r '\.#.*'
+	  --port 8888 -q  --host $(shell hostname) --re-ignore '\.#.*'
 
 update-jbuilds: $(BIN)
 	$(BIN) build @doc/runtest --auto-promote

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -848,7 +848,7 @@ files for executables. See `executables_implicit_empty_intf`_.
   available since the 3.0 version of the Dune language.
 
 Linking Modes
--------------
+~~~~~~~~~~~~~
 
 The ``modes`` field allows selecting which linking modes will be used
 to link executables. Each mode is a pair ``(<compilation-mode>

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -848,7 +848,7 @@ files for executables. See `executables_implicit_empty_intf`_.
   available since the 3.0 version of the Dune language.
 
 Linking Modes
-=============
+-------------
 
 The ``modes`` field allows selecting which linking modes will be used
 to link executables. Each mode is a pair ``(<compilation-mode>


### PR DESCRIPTION
fixes doc indentation issue reported here https://github.com/ocaml/dune/pull/3905#discussion_r739044538

updates sphinx-autobuild command-line arguments (-p and -r were removed in later versions)
