### PR TITLE
Replace a few of_string functions by decode functions

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -527,11 +527,6 @@ let display_term =
             {|Control the display mode of Dune.
          See $(b,dune-config\(5\)) for more details.|})
 
-let simple_arg_conv ~to_string ~of_string =
-  Arg.conv
-    ( (fun s -> Result.map_error (of_string s) ~f:(fun s -> `Msg s))
-    , fun pp x -> Format.pp_print_string pp (to_string x) )
-
 let shared_with_config_file =
   let docs = copts_sect in
   let+ concurrency =
@@ -548,15 +543,13 @@ let shared_with_config_file =
       & info [ "j" ] ~docs ~docv:"JOBS"
           ~doc:{|Run no more than $(i,JOBS) commands simultaneously.|})
   and+ sandboxing_preference =
-    let arg =
-      simple_arg_conv
-        ~of_string:
-          Dune_engine.Sandbox_mode.of_string_except_patch_back_source_tree
-        ~to_string:Dune_engine.Sandbox_mode.to_string
+    let all =
+      List.map Dune_engine.Sandbox_mode.all_except_patch_back_source_tree
+        ~f:(fun s -> (Dune_engine.Sandbox_mode.to_string s, s))
     in
     Arg.(
       value
-      & opt (some arg) None
+      & opt (some (enum all)) None
       & info [ "sandbox" ]
           ~env:
             (Arg.env_var

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -19,23 +19,12 @@ module Terminal_persistence = struct
 
   let all = [ ("preserve", Preserve); ("clear-on-rebuild", Clear_on_rebuild) ]
 
-  let of_string = function
-    | "preserve" -> Ok Preserve
-    | "clear-on-rebuild" -> Ok Clear_on_rebuild
-    | _ ->
-      Error
-        "invalid terminal-persistence value, must be 'preserve' or \
-         'clear-on-rebuild'"
-
   let to_dyn = function
     | Preserve -> Dyn.Variant ("Preserve", [])
     | Clear_on_rebuild -> Dyn.Variant ("Clear_on_rebuild", [])
 
   let decode =
-    plain_string (fun ~loc s ->
-        match of_string s with
-        | Error m -> User_error.raise ~loc [ Pp.text m ]
-        | Ok s -> s)
+    enum [ ("perserve", Preserve); ("clear-on-rebuild", Clear_on_rebuild) ]
 end
 
 module Concurrency = struct
@@ -75,12 +64,7 @@ end
 module Sandboxing_preference = struct
   type t = Sandbox_mode.t list
 
-  let decode =
-    repeat
-      (plain_string (fun ~loc s ->
-           match Sandbox_mode.of_string_except_patch_back_source_tree s with
-           | Error m -> User_error.raise ~loc [ Pp.text m ]
-           | Ok s -> s))
+  let decode = repeat Sandbox_mode.decode
 end
 
 module Cache = struct

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -128,16 +128,14 @@ let copy = Some Copy
 
 let hardlink = Some Hardlink
 
-let error =
-  Error
-    "invalid sandboxing mode, must be 'none', 'symlink', 'copy' or 'hardlink'"
-
-let of_string_except_patch_back_source_tree = function
-  | "none" -> Ok None
-  | "symlink" -> Ok (Some Symlink)
-  | "copy" -> Ok (Some Copy)
-  | "hardlink" -> Ok (Some Hardlink)
-  | _ -> error
+let decode =
+  let open Dune_lang.Decoder in
+  enum
+    [ ("none", None)
+    ; ("symlink", Some Symlink)
+    ; ("copy", Some Copy)
+    ; ("hardlink", Some Hardlink)
+    ]
 
 let to_string = function
   | None -> "none"

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -90,8 +90,7 @@ val copy : t
 
 val hardlink : t
 
-(** Same comment as for [all_except_patch_back_source_tree] *)
-val of_string_except_patch_back_source_tree : string -> (t, string) Result.t
+val decode : t Dune_lang.Decoder.t
 
 val to_string : t -> string
 


### PR DESCRIPTION
That were used to parse the config file. This is so that we don't accidentally add new values without versioning them in the future.
