### PR TITLE
Add a short delay to ensure Dune notices the new file

### DIFF
--- a/test/blackbox-tests/test-cases/watching/retriggering.t
+++ b/test/blackbox-tests/test-cases/watching/retriggering.t
@@ -11,6 +11,7 @@ Bad rule! You are not supposed to modify the source tree. No ice-cream for you!
   >   (target result)
   >   (action (bash "\| echo %{deps} > result
   >                 "\| touch ../../new-source.txt
+  >                 "\| sleep 0.01
   > )))
   > EOF
 
@@ -38,6 +39,8 @@ same, i.e. the empty file.
   new-source.txt old-source.txt
   $ cat _build/default/new-source.txt
 
+
+We are done.
 
   $ stop_dune
   waiting for inotify sync


### PR DESCRIPTION
I noticed that this test failed for me a couple of times with the `build` returning `Success` instead of `Restart`. The only explanation that I have is that Dune wasn't fast enough to react to the creation of the new file and reported successful completion of the build instead of restarting. I'm adding a short delay after touching the file to hopefully make such races much less likely. I wonder if @jeremiedimino's upcoming PR will make this `sleep` unnecessary (as discussed [here](https://github.com/ocaml/dune/pull/5108#issuecomment-963740138)).