### PR TITLE
Remove some unnecessary path absolution

### DIFF
--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -220,10 +220,7 @@ let process_inotify_event ~ignored_files
           true
         ) else
           false)
-    || List.for_all all_paths ~f:(fun (path, _event) ->
-           let path = Path.of_string path in
-           let abs_path = Path.to_string path in
-           should_exclude abs_path)
+    || List.for_all all_paths ~f:(fun (path, _event) -> should_exclude path)
   in
   if should_ignore then
     []


### PR DESCRIPTION
It's unnecessary following #5129 given that the patterns now match paths without `/` as well.
