### PR TITLE
Add a reproduction case for #5122

### DIFF
--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -844,6 +844,14 @@ let install_rules sctx (package : Package.t) =
           ; Package.Name.Set.to_list missing_deps
             |> Pp.enumerate ~f:(fun name ->
                    Pp.text (Package.Name.to_string name))
+          ; (if Dune_project.implicit_transitive_deps dune_project then
+              Pp.text
+                "Recursive dependencies could be present since implicit \
+                 transitive dependencies are added when compiling. This could \
+                 be avoided by adding `(implicit_transitive_deps false)` in \
+                 the dune-project."
+            else
+              Pp.nop)
           ]
   in
   let* () =

--- a/test/blackbox-tests/test-cases/depend-on/dune-project-check.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dune-project-check.t/run.t
@@ -74,6 +74,9 @@
   Error: Package loud_cat is missing the following package dependencies
   - cat
   - story
+  Recursive dependencies could be present since implicit transitive
+  dependencies are added when compiling. This could be avoided by adding
+  `(implicit_transitive_deps false)` in the dune-project.
   -> required by _build/default/loud_cat.install
   -> required by alias install
   [1]
@@ -88,6 +91,9 @@
   Entering directory 'b'
   Error: Package loud_cat is missing the following package dependencies
   - story
+  Recursive dependencies could be present since implicit transitive
+  dependencies are added when compiling. This could be avoided by adding
+  `(implicit_transitive_deps false)` in the dune-project.
   -> required by _build/default/loud_cat.install
   -> required by alias install
   [1]
@@ -97,6 +103,16 @@
   $ cat >b/dune-project <<EOF
   > (lang dune 3.0)
   > (package (name loud_cat) (depends cat story))
+  > EOF
+
+  $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @install
+  Entering directory 'b'
+
+# Without implicit transitive deps
+  $ cat >b/dune-project <<EOF
+  > (lang dune 3.0)
+  > (implicit_transitive_deps false)
+  > (package (name loud_cat) (depends cat))
   > EOF
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @install

--- a/test/blackbox-tests/test-cases/depend-on/dune-project-check.t/run.t
+++ b/test/blackbox-tests/test-cases/depend-on/dune-project-check.t/run.t
@@ -1,0 +1,103 @@
+# Test dependency check in dune-project
+
+  $ mkdir a b prefix
+
+  $ cat >a/dune-project <<EOF
+  > (lang dune 3.0)
+  > (package (name story))
+  > (package (name cat) (depends story))
+  > EOF
+
+  $ cat >a/dune <<EOF
+  > (library (public_name cat) (modules cat) (libraries story))
+  > (library (public_name story) (modules story))
+  > EOF
+
+  $ cat >a/story.ml <<EOF
+  > let say = Printf.sprintf "I'm saying %s"
+  > EOF
+
+  $ cat >a/cat.ml <<EOF
+  > let story = Story.say "miaou"
+  > EOF
+
+  $ dune build --root a
+  Entering directory 'a'
+
+  $ dune install --root a --prefix $(pwd)/prefix
+  Entering directory 'a'
+  Installing $TESTCASE_ROOT/prefix/lib/cat/META
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.a
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.cma
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.cmx
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.cmxa
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.ml
+  Installing $TESTCASE_ROOT/prefix/lib/cat/dune-package
+  Installing $TESTCASE_ROOT/prefix/lib/cat/cat.cmxs
+  Installing $TESTCASE_ROOT/prefix/lib/story/META
+  Installing $TESTCASE_ROOT/prefix/lib/story/dune-package
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.a
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.cma
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.cmx
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.cmxa
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.ml
+  Installing $TESTCASE_ROOT/prefix/lib/story/story.cmxs
+
+  $ cat >b/dune-project <<EOF
+  > (lang dune 3.0)
+  > (package (name loud_cat))
+  > EOF
+
+  $ cat >b/dune <<EOF
+  > (library (public_name loud_cat) (modules loud_cat) (libraries cat))
+  > EOF
+
+  $ cat >b/loud_cat.ml <<EOF
+  > let story = String.uppercase_ascii Cat.story
+  > EOF
+
+# The missing dependency in `loud_cat` dune-project is not detected
+  $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @install
+  Entering directory 'b'
+
+# Once directory `a` is local, it is detected
+  $ rm -rf a/_build
+
+  $ cp -a a b/a
+
+  $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @install
+  Entering directory 'b'
+  Error: Package loud_cat is missing the following package dependencies
+  - cat
+  - story
+  -> required by _build/default/loud_cat.install
+  -> required by alias install
+  [1]
+
+# But all the transitive dependencies needs to be added to fix the check
+  $ cat >b/dune-project <<EOF
+  > (lang dune 3.0)
+  > (package (name loud_cat) (depends cat))
+  > EOF
+
+  $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @install
+  Entering directory 'b'
+  Error: Package loud_cat is missing the following package dependencies
+  - story
+  -> required by _build/default/loud_cat.install
+  -> required by alias install
+  [1]
+
+
+# With all the transitive dependencies
+  $ cat >b/dune-project <<EOF
+  > (lang dune 3.0)
+  > (package (name loud_cat) (depends cat story))
+  > EOF
+
+  $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @install
+  Entering directory 'b'


### PR DESCRIPTION
The issues:
 - The first installation doesn't detect any problems of dependencies in `dune-project`
 - Putting a dependency locally (`cp -r a b/a`) breaks the compilation: dune detects the dependency problem
 - All the transitive dependencies (`cat`, and `story`) needs to be added instead of just the first level `cat`.