### PR TITLE
Add FS sync ids

### DIFF
--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -38,11 +38,13 @@ module Fs_memo_event : sig
   val to_dyn : t -> Dyn.t
 end
 
+module Sync_id : Id.S
+
 module Event : sig
   type t =
     | Fs_memo_event of Fs_memo_event.t
     | Queue_overflow
-    | Sync
+    | Sync of Sync_id.t
     | Watcher_terminated
 end
 
@@ -71,7 +73,7 @@ val wait_for_initial_watches_established_blocking : t -> unit
 (** Cause a [Sync] event to be propagated through the notification subsystem to
     attempt to make sure that we've processed all the events that happened so
     far. *)
-val emit_sync : unit -> unit
+val emit_sync : t -> Sync_id.t
 
 val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
 

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -26,7 +26,7 @@ let%expect_test _ =
           events_buffer := [];
           Some
             (List.map list ~f:(function
-              | Dune_file_watcher.Event.Sync -> assert false
+              | Dune_file_watcher.Event.Sync _ -> assert false
               | Queue_overflow -> assert false
               | Fs_memo_event e -> e
               | Watcher_terminated -> assert false)))

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
@@ -26,7 +26,7 @@ let%expect_test _ =
           events_buffer := [];
           Some
             (List.map list ~f:(function
-              | Dune_file_watcher.Event.Sync -> assert false
+              | Dune_file_watcher.Event.Sync _ -> assert false
               | Queue_overflow -> assert false
               | Fs_memo_event e -> e
               | Watcher_terminated -> assert false)))


### PR DESCRIPTION
To differentiate multiple FS syncs.

This is not immediately useful, but will be in the next PR I'm writing.