### PR TITLE
Add [Targets.Validated.t]

### DIFF
--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -30,7 +30,7 @@ end
 (** [root] should be the root of the current build context, or the root of the
     sandbox if the action is sandboxed. *)
 val exec :
-     targets:Targets.t
+     targets:Targets.Validated.t
   -> root:Path.t
   -> context:Build_context.t option
   -> env:Env.t

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -152,7 +152,7 @@ end
 
 type purpose =
   | Internal_job of Loc.t option * User_message.Annots.t
-  | Build_job of Loc.t option * User_message.Annots.t * Targets.t
+  | Build_job of Loc.t option * User_message.Annots.t * Targets.Validated.t
 
 let loc_and_annots_of_purpose = function
   | Internal_job (loc, annots) -> (loc, annots)
@@ -341,9 +341,8 @@ end = struct
               (add_ctx ctx ctxs_acc) rest)
       in
       let target_names, contexts =
-        let file_targets, directory_targets =
-          Targets.partition_map targets ~file:Fun.id ~dir:Fun.id
-        in
+        let file_targets = Path.Build.Set.to_list targets.files in
+        let directory_targets = Path.Build.Set.to_list targets.dirs in
         split_paths [] Context_name.Set.empty (file_targets @ directory_targets)
       in
       let targets =

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -56,7 +56,7 @@ end
     error messages. *)
 type purpose =
   | Internal_job of Loc.t option * User_message.Annots.t
-  | Build_job of Loc.t option * User_message.Annots.t * Targets.t
+  | Build_job of Loc.t option * User_message.Annots.t * Targets.Validated.t
 
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its
     termination. [stdout_to] [stderr_to] are released *)

--- a/src/dune_engine/reflection.ml
+++ b/src/dune_engine/reflection.ml
@@ -8,7 +8,7 @@ module Rule = struct
     ; dir : Path.Build.t
     ; deps : Dep.Set.t
     ; expanded_deps : Path.Set.t
-    ; targets : Targets.t
+    ; targets : Targets.Validated.t
     ; context : Build_context.t option
     ; action : Action.t
     }
@@ -101,5 +101,5 @@ let eval ~recursive ~request =
       ; Pp.chain cycle ~f:(fun rule ->
             Pp.verbatim
               (Path.to_string_maybe_quoted
-                 (Path.build (Targets.head_exn rule.targets))))
+                 (Path.build (Targets.Validated.head rule.targets))))
       ]

--- a/src/dune_engine/reflection.mli
+++ b/src/dune_engine/reflection.mli
@@ -9,7 +9,7 @@ module Rule : sig
     ; (* [expanded_deps] skips over non-file dependencies, such as: environment
          variables, universe, glob listings, sandbox requirements *)
       expanded_deps : Path.Set.t
-    ; targets : Targets.t
+    ; targets : Targets.Validated.t
     ; context : Build_context.t option
     ; action : Action.t
     }

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -54,7 +54,7 @@ module T = struct
   type t =
     { id : Id.t
     ; context : Build_context.t option
-    ; targets : Targets.t
+    ; targets : Targets.Validated.t
     ; action : Action.Full.t Action_builder.t
     ; mode : Mode.t
     ; info : Info.t
@@ -91,9 +91,11 @@ let make ?(mode = Mode.Standard) ~context ?(info = Info.Internal) ~targets
       Code_error.raise message
         [ ("info", Info.to_dyn info); ("targets", Targets.to_dyn targets) ]
   in
-  let dir =
+  (* CR-someday amokhov: Since [dir] and [targets] are produced together and are
+     logically related, we could make [dir] a field of [Targets.Validated.t]. *)
+  let dir, targets =
     match Targets.validate targets with
-    | Valid { parent_dir } -> parent_dir
+    | Valid { parent_dir; targets } -> (parent_dir, targets)
     | No_targets -> report_error "Rule has no targets specified"
     | Inconsistent_parent_dir ->
       report_error "Rule has targets in different directories."

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -60,7 +60,7 @@ end
 type t = private
   { id : Id.t
   ; context : Build_context.t option
-  ; targets : Targets.t
+  ; targets : Targets.Validated.t
   ; action : Action.Full.t Action_builder.t
   ; mode : Mode.t
   ; info : Info.t

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -31,7 +31,8 @@ module Dir_rules = struct
   let data_to_dyn = function
     | Rule rule ->
       Dyn.Variant
-        ("Rule", [ Record [ ("targets", Targets.to_dyn rule.targets) ] ])
+        ( "Rule"
+        , [ Record [ ("targets", Targets.Validated.to_dyn rule.targets) ] ] )
     | Alias alias ->
       Dyn.Variant
         ("Alias", [ Record [ ("name", Alias.Name.to_dyn alias.name) ] ])

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -1,10 +1,7 @@
 open! Stdune
 open! Import
 
-(** A set of targets of a build rule.
-
-    A rule can produce a set of files whose names are known upfront, as well as
-    a set of "opaque" directories whose contents is initially unknown. *)
+(** A non-validated set of targets of a build rule. *)
 type t
 
 (** The empty set of targets. Note that rules are not allowed to have the empty
@@ -30,13 +27,27 @@ end
 (** A set of file and directory targets. *)
 val create : files:Path.Build.Set.t -> dirs:Path.Build.Set.t -> t
 
-val files : t -> Path.Build.Set.t
+module Validated : sig
+  (** A rule can produce a set of files whose names are known upfront, as well
+      as a set of "opaque" directories whose contents is initially unknown. *)
+  type t = private
+    { files : Path.Build.Set.t
+    ; dirs : Path.Build.Set.t
+    }
 
-val dirs : t -> Path.Build.Set.t
+  (** If [t] contains at least one file, then it's the lexicographically first
+      target file. Otherwise, it's the lexicographically first target directory. *)
+  val head : t -> Path.Build.t
+
+  val to_dyn : t -> Dyn.t
+end
 
 module Validation_result : sig
   type t =
-    | Valid of { parent_dir : Path.Build.t }
+    | Valid of
+        { parent_dir : Path.Build.t
+        ; targets : Validated.t
+        }
     | No_targets
     | Inconsistent_parent_dir
     | File_and_directory_target_with_the_same_name of Path.Build.t
@@ -45,32 +56,9 @@ end
 (** Ensure that the set of targets is well-formed. *)
 val validate : t -> Validation_result.t
 
-(** The "head" target if [t] is non-empty. If [t] contains at least one file,
-    then it's the lexicographically first target file. Otherwise, it's the
-    lexicographically first target directory. *)
+(** Like [Validate.head] but can return [None], because [t] is not guaranteed to
+    be non-empty. *)
 val head : t -> Path.Build.t option
-
-(** Like [head] but raises a code error if the set of targets is empty. *)
-val head_exn : t -> Path.Build.t
-
-val partition_map :
-     t
-  -> file:(Path.Build.t -> 'a)
-  -> dir:(Path.Build.t -> 'b)
-  -> 'a list * 'b list
-
-val iter :
-  t -> file:(Path.Build.t -> unit) -> dir:(Path.Build.t -> unit) -> unit
-
-val map : t -> f:(files:Path.Build.Set.t -> dirs:Path.Build.Set.t -> 'a) -> 'a
-
-(** File targets are traversed before directory targets. *)
-val fold :
-     t
-  -> init:'a
-  -> file:(Path.Build.t -> 'a -> 'a)
-  -> dir:(Path.Build.t -> 'a -> 'a)
-  -> 'a
 
 val to_dyn : t -> Dyn.t
 

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -72,11 +72,11 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
   Expander.eval_blang expander rule.enabled_if >>= function
   | false -> (
     match rule.alias with
-    | None -> Memo.Build.return Targets.empty
+    | None -> Memo.Build.return None
     | Some name ->
       let alias = Alias.make ~dir name in
       let+ () = Alias_rules.add_empty sctx ~alias ~loc:(Some rule.loc) in
-      Targets.empty)
+      None)
   | true -> (
     let* targets =
       match rule.targets with
@@ -126,7 +126,7 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
     match rule_kind ~rule ~action with
     | No_alias ->
       let+ targets = add_user_rule sctx ~dir ~rule ~action ~expander in
-      targets
+      Some targets
     | Alias_with_targets (alias, alias_target) ->
       let* () =
         let alias = Alias.make alias ~dir in
@@ -134,12 +134,12 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
           (Action_builder.path (Path.build alias_target))
       in
       let+ targets = add_user_rule sctx ~dir ~rule ~action ~expander in
-      targets
+      Some targets
     | Alias_only name ->
       let alias = Alias.make ~dir name in
       let* action = interpret_and_add_locks ~expander rule.locks action.build in
       let+ () = Alias_rules.add sctx ~alias ~loc:(Some rule.loc) action in
-      Targets.empty)
+      None)
 
 let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
   let loc = String_with_vars.loc def.files in

--- a/src/dune_rules/simple_rules.mli
+++ b/src/dune_rules/simple_rules.mli
@@ -20,14 +20,14 @@ module Alias_rules : sig
     -> unit Memo.Build.t
 end
 
-(** Interpret a [(rule ...)] stanza and return the targets it produces. *)
+(** Interpret a [(rule ...)] stanza and return the targets it produces, if any. *)
 val user_rule :
      Super_context.t
   -> ?extra_bindings:Value.t list Pform.Map.t
   -> dir:Path.Build.t
   -> expander:Expander.t
   -> Rule.t
-  -> Targets.t Memo.Build.t
+  -> Targets.Validated.t option Memo.Build.t
 
 (** Interpret a [(copy_files ...)] stanza and return the targets it produces. *)
 val copy_files :

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -130,7 +130,7 @@ val add_rule_get_targets :
   -> ?loc:Loc.t
   -> dir:Path.Build.t
   -> Action.Full.t Action_builder.With_targets.t
-  -> Targets.t Memo.Build.t
+  -> Targets.Validated.t Memo.Build.t
 
 val add_rules :
      t

--- a/src/dune_rules/test_rules.ml
+++ b/src/dune_rules/test_rules.ml
@@ -117,9 +117,8 @@ let rules (t : Dune_file.Tests.t) ~sctx ~dir ~scope ~expander ~dir_contents =
                 ; package = t.package
                 }
               in
-
               add_alias ~loc ~action:(Diff diff) ~locks:t.locks
-              >>> let+ (_ignored_targets : Targets.t) =
+              >>> let+ (_ignored_targets : Targets.Validated.t option) =
                     Simple_rules.user_rule sctx rule ~extra_bindings ~dir
                       ~expander
                   in


### PR DESCRIPTION
As discussed, this PR introduces `Targets.Validated.t` that is guaranteed to satisfy a few properties. This allows us to make the code a bit more type-safe (getting rid of `head_exn`). Also, I decided to expose the underlying record `{files; dirs}` because it makes the code more natural in many places.

There is no change in behaviour.