### PR TITLE
Remove [Scheduler.ignore_for_watch]

### DIFF
--- a/otherlibs/stdune-unstable/stdune.ml
+++ b/otherlibs/stdune-unstable/stdune.ml
@@ -68,9 +68,28 @@ module Temp = Temp
 module Queue = Queue
 module Caller_id = Caller_id
 module Metrics = Metrics
-module Unix_error = Dune_filesystem_stubs.Unix_error
-module File_kind = Dune_filesystem_stubs.File_kind
 module Dune_filesystem_stubs = Dune_filesystem_stubs
+
+module Unix_error = struct
+  include Dune_filesystem_stubs.Unix_error
+
+  module Detailed = struct
+    include Dune_filesystem_stubs.Unix_error.Detailed
+
+    let to_dyn (error, syscall, arg) =
+      Dyn.Record
+        [ ("error", String (Unix.error_message error))
+        ; ("syscall", String syscall)
+        ; ("arg", String arg)
+        ]
+  end
+end
+
+module File_kind = struct
+  include Dune_filesystem_stubs.File_kind
+
+  let to_dyn t = Dyn.String (to_string t)
+end
 
 module type Applicative = Applicative_intf.S
 

--- a/src/dune_engine/cached_digest.mli
+++ b/src/dune_engine/cached_digest.mli
@@ -13,6 +13,8 @@ module Digest_result : sig
   val equal : t -> t -> bool
 
   val to_option : t -> Digest.t option
+
+  val to_dyn : t -> Dyn.t
 end
 
 (** Digest the contents of a build artifact. *)

--- a/src/dune_engine/fs_cache.ml
+++ b/src/dune_engine/fs_cache.ml
@@ -24,6 +24,8 @@ let read { sample; cache; _ } path =
     Path.Table.add_exn cache path result;
     result
 
+let evict { cache; _ } path = Path.Table.remove cache path
+
 module Update_result = struct
   type t =
     | Skipped (* No need to update a given entry because it has no readers *)

--- a/src/dune_engine/fs_cache.mli
+++ b/src/dune_engine/fs_cache.mli
@@ -13,6 +13,9 @@ type 'a t
     then return it. *)
 val read : 'a t -> Path.t -> 'a
 
+(** Evict an entry from the cache. *)
+val evict : 'a t -> Path.t -> unit
+
 (** Result of updating a cache entry. *)
 module Update_result : sig
   type t =

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -170,7 +170,12 @@ let path_stat = declaring_dependency ~f:Fs_cache.(read Untracked.path_stat)
    instead. For now, we keep it here because it seems nice to group all tracked
    file system access functions in one place, and exposing an uncached version
    of [path_digest] seems error-prone. We may need to rethink this decision. *)
-let path_digest = declaring_dependency ~f:Fs_cache.(read Untracked.path_digest)
+let path_digest ?(force_update = false) path =
+  if force_update then (
+    Cached_digest.Untracked.invalidate_cached_timestamp path;
+    Fs_cache.evict Fs_cache.Untracked.path_digest path
+  );
+  declaring_dependency path ~f:Fs_cache.(read Untracked.path_digest)
 
 let dir_contents =
   declaring_dependency ~f:Fs_cache.(read Untracked.dir_contents)

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -36,7 +36,7 @@ let watch_path dune_file_watcher path =
   | Error `Does_not_exist -> (
     (* If we're at the root of the workspace (or the unix root) then we can't
        get ENOENT because dune can't start without a workspace and unix root
-       always exists, so this [_exn] can't raise (except if the user delets the
+       always exists, so this [_exn] can't raise (except if the user deletes the
        workspace dir under our feet, in which case all bets are off). *)
     let containing_dir = Path.parent_exn path in
     (* If the file is absent, we need to wait for it to be created by watching

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -21,8 +21,13 @@ val path_stat :
   -> (Fs_cache.Reduced_stats.t, Unix_error.Detailed.t) result Memo.Build.t
 
 (** Digest the contents of a source or external path and declare a dependency on
-    it. *)
-val path_digest : Path.t -> Cached_digest.Digest_result.t Memo.Build.t
+    it. When [force_update = true], evict the path from all file-system caches
+    and force the recomputation of the digest. This can be useful if Dune made a
+    change to the path and therefore knows that the cached digest is stale and
+    is about to be invalidated by an incoming file-system event. By not using
+    the cache in this situation, it's possible to avoid unnecessary restarts. *)
+val path_digest :
+  ?force_update:bool -> Path.t -> Cached_digest.Digest_result.t Memo.Build.t
 
 (** Like [Io.Untracked.with_lexbuf_from_file] but declares a dependency on the
     path. *)

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -21,8 +21,8 @@ val path_stat :
   -> (Fs_cache.Reduced_stats.t, Unix_error.Detailed.t) result Memo.Build.t
 
 (** Digest the contents of a source or external path and declare a dependency on
-    it. When [force_update = true], evict the path from all file-system caches
-    and force the recomputation of the digest. This can be useful if Dune made a
+    it. When [force_update = true], evict the path from all digest caches and
+    force the recomputation of the digest. This can be useful if Dune made a
     change to the path and therefore knows that the cached digest is stale and
     is about to be invalidated by an incoming file-system event. By not using
     the cache in this situation, it's possible to avoid unnecessary restarts. *)

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -874,14 +874,6 @@ let yield_if_there_are_pending_events () =
 let () =
   Memo.yield_if_there_are_pending_events := yield_if_there_are_pending_events
 
-let ignore_for_watch path =
-  let+ t = t () in
-  match t.file_watcher with
-  | None -> ()
-  | Some file_watcher ->
-    assert (Path.is_in_source_tree path);
-    Dune_file_watcher.ignore_next_file_change_event file_watcher path
-
 exception Build_cancelled
 
 let with_job_slot f =

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -127,12 +127,6 @@ val wait_for_process :
 
 val yield_if_there_are_pending_events : unit -> unit Fiber.t
 
-(** Make the scheduler ignore next change to a certain file in watch mode.
-
-    This is used with promoted files that are copied back to the source tree
-    after generation *)
-val ignore_for_watch : Path.t -> unit Fiber.t
-
 (** Number of jobs currently running in the background *)
 val running_jobs_count : t -> int
 

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -732,7 +732,3 @@ let add_watch t path =
   | Inotify inotify -> (
     try Ok (Inotify_lib.add inotify (Path.to_string path)) with
     | Unix.Unix_error (ENOENT, _, _) -> Error `Does_not_exist)
-
-let ignore_next_file_change_event t path =
-  assert (Path.is_in_source_tree path);
-  Table.set t.ignored_files (Path.to_absolute_filename path) ()

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -158,16 +158,6 @@ type kind =
 
 type t =
   { kind : kind
-        (* CR-someday amokhov: The way we handle "ignored files" using this
-           mutable table is fragile and also wrong. We use [ignored_files] for
-           the [(mode promote)] feature: if a file is promoted, we call
-           [ignore_next_file_change_event] so that the upcoming file-change
-           event does not invalidate the current build. However, instead of
-           ignoring the events, we should merely postpone them and restart the
-           build to take the promoted files into account if need be. *)
-        (* The [ignored_files] table should be accessed in the scheduler
-           thread. *)
-  ; ignored_files : (string, unit) Table.t
   ; sync_table : (string, Sync_id.t) Table.t
         (* Pending fs sync operations indexed by the special sync filename. *)
   }
@@ -198,33 +188,13 @@ module For_tests = struct
   let should_exclude = should_exclude
 end
 
-(* [process_inotify_event] needs to run in the scheduler thread because it
-   accesses [t.ignored_files]. *)
-let process_inotify_event ~ignored_files
-    (event : Async_inotify_for_dune.Async_inotify.Event.t) : Event.t list =
+(* CR-someday amokhov: This function runs on the scheduler thread because it
+   used to access the [ignored_files] table. Can we simplify this now? *)
+let process_inotify_event (event : Async_inotify_for_dune.Async_inotify.Event.t)
+    : Event.t list =
   let should_ignore =
     let all_paths = decompose_inotify_event event in
-    List.exists all_paths ~f:(fun (path, event) ->
-        let path = Path.of_string path in
-        let abs_path = Path.to_absolute_filename path in
-        if Table.mem ignored_files abs_path then (
-          (match event with
-          | Created
-          | Unlinked
-          | Moved_away ->
-            (* The event is a part of promotion, but not the last step. The
-               typical sequence is [Created] followed by [Modified]. *)
-            ()
-          | Modified
-          | Moved_into ->
-            (* Got the final event in promotion sequence. With the current
-               promotion implementation the event will be [Modified], but if we
-               use renaming instead then [Moved_into] can be expected. *)
-            Table.remove ignored_files abs_path);
-          true
-        ) else
-          false)
-    || List.for_all all_paths ~f:(fun (path, _event) -> should_exclude path)
+    List.for_all all_paths ~f:(fun (path, _event) -> should_exclude path)
   in
   if should_ignore then
     []
@@ -421,8 +391,7 @@ let spawn_external_watcher ~root ~backend =
   Option.iter stderr ~f:Unix.close;
   ((r_stdout, parse_line, wait), pid)
 
-let create_inotifylib_watcher ~sync_table ~ignored_files
-    ~(scheduler : Scheduler.t) =
+let create_inotifylib_watcher ~sync_table ~(scheduler : Scheduler.t) =
   Inotify_lib.create ~spawn_thread:scheduler.spawn_thread
     ~modify_event_selector:`Closed_writable_fd
     ~send_emit_events_job_to_scheduler:(fun f ->
@@ -443,7 +412,7 @@ let create_inotifylib_watcher ~sync_table ~ignored_files
                   None
               in
               match is_fs_sync_event_generated_by_dune with
-              | None -> process_inotify_event ~ignored_files event
+              | None -> process_inotify_event event
               | Some path -> (
                 match consume_sync_event sync_table path with
                 | None -> []
@@ -451,14 +420,13 @@ let create_inotifylib_watcher ~sync_table ~ignored_files
     ~log_error:(fun error -> Console.print [ Pp.text error ])
 
 let create_no_buffering ~(scheduler : Scheduler.t) ~root ~backend =
-  let ignored_files = Table.create (module String) 64 in
   let sync_table = Table.create (module String) 64 in
   let (pipe, parse_line, wait), pid = spawn_external_watcher ~root ~backend in
   let worker_thread pipe =
     let buffer = Buffer.create ~capacity:buffer_capacity in
     while true do
-      (* the job must run on the scheduler thread because it accesses
-         [ignored_files] *)
+      (* CR-someday amokhov: This job runs on the scheduler thread because it
+         used to access the [ignored_files] table. Can we simplify this now? *)
       let job =
         match Buffer.read_lines buffer pipe with
         | `End_of_file _remaining -> fun () -> [ Event.Watcher_terminated ]
@@ -479,24 +447,15 @@ let create_no_buffering ~(scheduler : Scheduler.t) ~root ~backend =
                     let path =
                       Path.Expert.try_localize_external (Path.of_string path_s)
                     in
-                    let abs_path = Path.to_absolute_filename path in
-                    if Table.mem ignored_files abs_path then (
-                      (* only use ignored record once *)
-                      Table.remove ignored_files abs_path;
-                      []
-                    ) else
-                      [ Fs_memo_event
-                          (Fs_memo_event.create ~kind:File_changed ~path)
-                      ])
+                    [ Fs_memo_event
+                        (Fs_memo_event.create ~kind:File_changed ~path)
+                    ])
       in
       scheduler.thread_safe_send_emit_events_job job
     done
   in
   scheduler.spawn_thread (fun () -> worker_thread pipe);
-  { kind = Fswatch { pid; wait_for_watches_established = wait }
-  ; ignored_files
-  ; sync_table
-  }
+  { kind = Fswatch { pid; wait_for_watches_established = wait }; sync_table }
 
 let with_buffering ~create ~(scheduler : Scheduler.t) ~debounce_interval =
   let jobs = ref [] in
@@ -542,13 +501,10 @@ let with_buffering ~create ~(scheduler : Scheduler.t) ~debounce_interval =
 
 let create_inotifylib ~scheduler =
   prepare_sync ();
-  let ignored_files = Table.create (module String) 64 in
   let sync_table = Table.create (module String) 64 in
-  let inotify =
-    create_inotifylib_watcher ~sync_table ~ignored_files ~scheduler
-  in
+  let inotify = create_inotifylib_watcher ~sync_table ~scheduler in
   Inotify_lib.add inotify (Lazy.force special_dir_for_fs_sync);
-  { kind = Inotify inotify; ignored_files; sync_table }
+  { kind = Inotify inotify; sync_table }
 
 let fsevents_callback_gen (scheduler : Scheduler.t) ~f events =
   scheduler.thread_safe_send_emit_events_job (fun () ->
@@ -560,7 +516,7 @@ let fsevents_callback (scheduler : Scheduler.t) ~f events =
         Fsevents.Event.path event |> Path.of_string
         |> Path.Expert.try_localize_external
       in
-      f event path)
+      Some (f event path))
 
 let fsevents ?exclusion_paths ~latency ~paths scheduler f =
   let paths = List.map paths ~f:Path.to_absolute_filename in
@@ -571,29 +527,23 @@ let fsevents ?exclusion_paths ~latency ~paths scheduler f =
       Fsevents.set_exclusion_paths fsevents ~paths);
   fsevents
 
-let fsevents_standard_event event ~ignored_files path =
-  let string_path = Fsevents.Event.path event in
-  if Table.mem ignored_files string_path then (
-    Table.remove ignored_files string_path;
-    None
-  ) else
-    let action = Fsevents.Event.action event in
-    let kind =
-      match action with
-      | Unknown -> Fs_memo_event.Unknown
-      | Create -> Created
-      | Remove -> Deleted
-      | Modify ->
-        if Fsevents.Event.kind event = File then
-          File_changed
-        else
-          Unknown
-    in
-    Some (Event.Fs_memo_event { Fs_memo_event.kind; path })
+let fsevents_standard_event event path =
+  let action = Fsevents.Event.action event in
+  let kind =
+    match action with
+    | Unknown -> Fs_memo_event.Unknown
+    | Create -> Created
+    | Remove -> Deleted
+    | Modify ->
+      if Fsevents.Event.kind event = File then
+        File_changed
+      else
+        Unknown
+  in
+  Event.Fs_memo_event { Fs_memo_event.kind; path }
 
 let create_fsevents ?(latency = 0.2) ~(scheduler : Scheduler.t) () =
   prepare_sync ();
-  let ignored_files = Table.create (module String) 64 in
   let sync_table = Table.create (module String) 64 in
   let sync =
     (* We don't use the [fsevents] function here as we want to match on the
@@ -628,8 +578,7 @@ let create_fsevents ?(latency = 0.2) ~(scheduler : Scheduler.t) () =
                 path))
       |> List.rev_map ~f:Path.to_absolute_filename
     in
-    fsevents ~latency scheduler ~exclusion_paths ~paths
-      (fsevents_standard_event ~ignored_files)
+    fsevents ~latency scheduler ~exclusion_paths ~paths fsevents_standard_event
   in
   let cv = Condition.create () in
   let runloop_ref = ref None in
@@ -656,7 +605,6 @@ let create_fsevents ?(latency = 0.2) ~(scheduler : Scheduler.t) () =
     Option.value_exn !runloop_ref
   in
   { kind = Fsevents { latency; scheduler; sync; source; external_; runloop }
-  ; ignored_files
   ; sync_table
   }
 
@@ -714,7 +662,7 @@ let add_watch t path =
         let watch =
           lazy
             (fsevents ~latency:f.latency f.scheduler ~paths:[ path ]
-               (fsevents_standard_event ~ignored_files:t.ignored_files))
+               fsevents_standard_event)
         in
         match Watch_trie.add f.external_ ext watch with
         | Watch_trie.Under_existing_node -> Ok ()

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -188,8 +188,6 @@ module For_tests = struct
   let should_exclude = should_exclude
 end
 
-(* CR-someday amokhov: This function runs on the scheduler thread because it
-   used to access the [ignored_files] table. Can we simplify this now? *)
 let process_inotify_event (event : Async_inotify_for_dune.Async_inotify.Event.t)
     : Event.t list =
   let should_ignore =
@@ -425,8 +423,7 @@ let create_no_buffering ~(scheduler : Scheduler.t) ~root ~backend =
   let worker_thread pipe =
     let buffer = Buffer.create ~capacity:buffer_capacity in
     while true do
-      (* CR-someday amokhov: This job runs on the scheduler thread because it
-         used to access the [ignored_files] table. Can we simplify this now? *)
+      (* This job runs on the scheduler thread because it uses [sync_table]. *)
       let job =
         match Buffer.read_lines buffer pipe with
         | `End_of_file _remaining -> fun () -> [ Event.Watcher_terminated ]

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -77,9 +77,6 @@ val emit_sync : t -> Sync_id.t
 
 val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
 
-(** Ignore the ne next file change event about this file. *)
-val ignore_next_file_change_event : t -> Path.t -> unit
-
 module For_tests : sig
   val should_exclude : string -> bool
 end

--- a/test/blackbox-tests/test-cases/watching/copy-rules.t
+++ b/test/blackbox-tests/test-cases/watching/copy-rules.t
@@ -38,7 +38,7 @@ consequence of using a glob in this directory, which forces all *.txt rules.
   >   (action (bash "cat %{deps} > %{target}")))
   > (rule
   >   (target c.txt)
-  >   (action (write-file %{target} c)))
+  >   (action (write-file %{target} "c\n")))
   > EOF
 
   $ build summary
@@ -48,16 +48,14 @@ consequence of using a glob in this directory, which forces all *.txt rules.
   b
   c
 
-Now demonstrate a bug: Dune fails to notice that [d.txt] appears via promotion.
-
-# CR-someday amokhov: Fix this test.
+Dune notices that [d.txt] appears via promotion.
 
   $ mkdir subdir
   $ cat > subdir/dune <<EOF
   > (rule
   >   (target d.txt)
   >   (mode (promote (into ..)))
-  >   (action (write-file %{target} d)))
+  >   (action (write-file %{target} "d\n")))
   > EOF
   $ build summary subdir/d.txt
   Success
@@ -65,6 +63,7 @@ Now demonstrate a bug: Dune fails to notice that [d.txt] appears via promotion.
   a
   b
   c
+  d
 
 Note that [d.txt] is here but [c.txt] isn't (it's not promoted).
 

--- a/test/blackbox-tests/test-cases/watching/copy-rules.t
+++ b/test/blackbox-tests/test-cases/watching/copy-rules.t
@@ -55,7 +55,7 @@ Dune notices that [d.txt] appears via promotion.
   > (rule
   >   (target d.txt)
   >   (mode (promote (into ..)))
-  >   (action (bash "echo d > %{target}; sleep 0.01")))
+  >   (action (write-file %{target} "d\n")))
   > EOF
   $ build summary subdir/d.txt
   Success

--- a/test/blackbox-tests/test-cases/watching/copy-rules.t
+++ b/test/blackbox-tests/test-cases/watching/copy-rules.t
@@ -55,7 +55,7 @@ Dune notices that [d.txt] appears via promotion.
   > (rule
   >   (target d.txt)
   >   (mode (promote (into ..)))
-  >   (action (write-file %{target} "d\n")))
+  >   (action (bash "echo d > %{target}; sleep 0.01")))
   > EOF
   $ build summary subdir/d.txt
   Success


### PR DESCRIPTION
Fixes #5087.

By getting rid of the `Scheduler.ignore_for_watch` hack, we fix two file-watching tests. These tests were previously broken due to ignoring the next event for the promoted path but that is just wrong because there are other functions that depend on that path's content and existence.

I also removed `Path.Source.unlink_no_err dst` for two reasons:
* First, it's unnecessary since `promote_source` uses `rename` under the hood which succeeds if the destination exists.
* Second, this operation may trigger the build restart too early, before we have finished copying the file. It's better to avoid non-atomic modifications of the source directory if possible.

I also added a CR-someday pointing out a problem with file promotion logic: when we promote a file, we can change its content because of artifact substitution, so we comparing wrong digests in `destination_is_up_to_date`. 