### PR TITLE
Relax the API of [Action_exec.exec] for internal JS actions

### DIFF
--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -30,7 +30,7 @@ end
 (** [root] should be the root of the current build context, or the root of the
     sandbox if the action is sandboxed. *)
 val exec :
-     targets:Targets.Validated.t
+     targets:Targets.Validated.t option (* Some internal JS actions use [None] *)
   -> root:Path.t
   -> context:Build_context.t option
   -> env:Env.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1524,8 +1524,8 @@ end = struct
     let+ exec_result =
       with_locks t locks ~f:(fun () ->
           let+ action_exec_result =
-            Action_exec.exec ~root ~context ~env ~targets ~rule_loc:loc
-              ~build_deps ~execution_parameters action
+            Action_exec.exec ~root ~context ~env ~targets:(Some targets)
+              ~rule_loc:loc ~build_deps ~execution_parameters action
           in
           let files_in_directory_targets =
             match sandbox with

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -152,7 +152,8 @@ end
 
 type purpose =
   | Internal_job of Loc.t option * User_message.Annots.t
-  | Build_job of Loc.t option * User_message.Annots.t * Targets.Validated.t
+  | Build_job of
+      Loc.t option * User_message.Annots.t * Targets.Validated.t option
 
 let loc_and_annots_of_purpose = function
   | Internal_job (loc, annots) -> (loc, annots)
@@ -341,8 +342,13 @@ end = struct
               (add_ctx ctx ctxs_acc) rest)
       in
       let target_names, contexts =
-        let file_targets = Path.Build.Set.to_list targets.files in
-        let directory_targets = Path.Build.Set.to_list targets.dirs in
+        let file_targets, directory_targets =
+          match targets with
+          | None -> ([], [])
+          | Some targets ->
+            ( Path.Build.Set.to_list targets.files
+            , Path.Build.Set.to_list targets.dirs )
+        in
         split_paths [] Context_name.Set.empty (file_targets @ directory_targets)
       in
       let targets =

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -56,7 +56,8 @@ end
     error messages. *)
 type purpose =
   | Internal_job of Loc.t option * User_message.Annots.t
-  | Build_job of Loc.t option * User_message.Annots.t * Targets.Validated.t
+  | Build_job of
+      Loc.t option * User_message.Annots.t * Targets.Validated.t option
 
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its
     termination. [stdout_to] [stderr_to] are released *)


### PR DESCRIPTION
The current API is awkward to use in situations where there are no targets.