### PR TITLE
Cleanup a bit the API fo Dyn

### DIFF
--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -48,8 +48,7 @@ module Crawl = struct
             (Option.map (Module.source m ~ml_kind) ~f:Module.File.path)
         in
         let cmt ml_kind =
-          Dyn.option dyn_path
-            (Obj_dir.Module.cmt_file obj_dir m ~ml_kind)
+          Dyn.option dyn_path (Obj_dir.Module.cmt_file obj_dir m ~ml_kind)
         in
         Dyn.record
           [ ("name", Module_name.to_dyn (Module.name m))
@@ -85,8 +84,7 @@ module Crawl = struct
                           ~f:(fun (_, name) -> Dyn.String name)
                           exes.names) )
                  ; ( "requires"
-                   , Dyn.(list string) (List.map ~f:uid_of_library libs)
-                   )
+                   , Dyn.(list string) (List.map ~f:uid_of_library libs) )
                  ; ("modules", List modules_)
                  ; ("include_dirs", Dyn.list dyn_path include_dirs)
                  ]

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -44,14 +44,14 @@ module Crawl = struct
   let modules ~obj_dir =
     Modules.fold_no_vlib ~init:[] ~f:(fun m acc ->
         let source ml_kind =
-          Dyn.Encoder.option dyn_path
+          Dyn.option dyn_path
             (Option.map (Module.source m ~ml_kind) ~f:Module.File.path)
         in
         let cmt ml_kind =
-          Dyn.Encoder.option dyn_path
+          Dyn.option dyn_path
             (Obj_dir.Module.cmt_file obj_dir m ~ml_kind)
         in
-        Dyn.Encoder.record
+        Dyn.record
           [ ("name", Module_name.to_dyn (Module.name m))
           ; ("impl", source Impl)
           ; ("intf", source Intf)
@@ -78,17 +78,17 @@ module Crawl = struct
       Some
         (Dyn.Variant
            ( "executables"
-           , [ Dyn.Encoder.record
+           , [ Dyn.record
                  [ ( "names"
                    , List
                        (List.map
                           ~f:(fun (_, name) -> Dyn.String name)
                           exes.names) )
                  ; ( "requires"
-                   , Dyn.Encoder.(list string) (List.map ~f:uid_of_library libs)
+                   , Dyn.(list string) (List.map ~f:uid_of_library libs)
                    )
                  ; ("modules", List modules_)
-                 ; ("include_dirs", Dyn.Encoder.list dyn_path include_dirs)
+                 ; ("include_dirs", Dyn.list dyn_path include_dirs)
                  ]
              ] ))
 
@@ -112,10 +112,10 @@ module Crawl = struct
       in
       let include_dirs = Obj_dir.all_cmis obj_dir in
       Some
-        (let open Dyn.Encoder in
+        (let open Dyn in
         Dyn.Variant
           ( "library"
-          , [ Dyn.Encoder.record
+          , [ Dyn.record
                 [ ("name", Lib_name.to_dyn name)
                 ; ("uid", String (uid_of_library lib))
                 ; ("local", Bool (Lib.is_local lib))

--- a/otherlibs/action-plugin/src/protocol.ml
+++ b/otherlibs/action-plugin/src/protocol.ml
@@ -49,7 +49,7 @@ module Dependency = struct
         | Eq -> String.compare glob1 glob2
         | not_eq -> not_eq)
 
-    let to_dyn _ = Dyn.opaque
+    let to_dyn = Dyn.opaque
   end
 
   include T

--- a/otherlibs/dune-rpc/private/conv.ml
+++ b/otherlibs/dune-rpc/private/conv.ml
@@ -20,7 +20,7 @@ type error =
       }
 
 let dyn_of_error =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
   | Version_error { message; payload; until; since } ->
     record
@@ -282,7 +282,7 @@ let to_sexp : 'a. ('a, values) t -> 'a -> Sexp.t =
       with
       | Some v -> Atom v
       | None ->
-        let open Dyn.Encoder in
+        let open Dyn in
         Code_error.raise "enum does not include this value"
           [ ("valid values", list (fun (x, _) -> string x) choices) ])
   in

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -259,9 +259,9 @@ module Client = struct
           let dyn =
             match error with
             | Invalid_session e ->
-              Dyn.Encoder.constr "Invalid_session" [ Conv.dyn_of_error e ]
+              Dyn.variant "Invalid_session" [ Conv.dyn_of_error e ]
             | Server_aborted e ->
-              Dyn.Encoder.constr "Server_aborted"
+              Dyn.variant "Server_aborted"
                 [ Sexp.to_dyn (Message.to_sexp_unversioned e) ]
           in
           Some (Dyn.to_string dyn)

--- a/otherlibs/dune-rpc/private/exported_types.ml
+++ b/otherlibs/dune-rpc/private/exported_types.ml
@@ -79,7 +79,7 @@ module Path = struct
   let absolute abs =
     if Filename.is_relative abs then
       Code_error.raise "Path.absolute: accepts only absolute paths"
-        [ ("abs", Dyn.Encoder.string abs) ];
+        [ ("abs", Dyn.string abs) ];
     abs
 
   let relative = Filename.concat
@@ -116,7 +116,7 @@ module Diagnostic = struct
     let verbatim = constr "Verbatim" string (fun s -> Verbatim s) in
     let char = constr "Char" char (fun c -> Char c) in
     let newline = constr "Newline" unit (fun () -> Newline) in
-    let t_fdecl = Fdecl.create Dyn.Encoder.opaque in
+    let t_fdecl = Fdecl.create Dyn.opaque in
     let t = fdecl t_fdecl in
     let text = constr "Text" string (fun s -> Text s) in
     let seq = constr "Seq" (pair t t) (fun (x, y) -> Seq (x, y)) in

--- a/otherlibs/dune-rpc/private/registry.ml
+++ b/otherlibs/dune-rpc/private/registry.ml
@@ -29,7 +29,7 @@ module Dune = struct
         | Eq -> Where.compare t.where where)
 
     let to_dyn { root; pid; where } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("root", string root)
         ; ("pid", int pid)
@@ -77,7 +77,7 @@ module Dune = struct
       | E (Csexp { position; message }) ->
         Some
           (Dyn.to_string
-             (let open Dyn.Encoder in
+             (let open Dyn in
              record [ ("message", string message); ("position", int position) ]))
       | _ -> None)
 

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -67,7 +67,7 @@ module Call = struct
     }
 
   let to_dyn { method_; params } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("method_", String method_); ("params", Sexp.to_dyn params) ]
 
   let create ?(params = Sexp.List []) ~method_ () = { method_; params }
@@ -92,10 +92,10 @@ module Response = struct
       | Code_error
 
     let dyn_of_kind =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
-      | Invalid_request -> constr "Invalid_request" []
-      | Code_error -> constr "Code_error" []
+      | Invalid_request -> variant "Invalid_request" []
+      | Code_error -> variant "Code_error" []
 
     type t =
       { payload : Sexp.t option
@@ -143,7 +143,7 @@ module Response = struct
            (fun { payload; message; kind } -> (payload, message, kind)))
 
     let to_dyn { payload; message; kind } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("payload", option Sexp.to_dyn payload)
         ; ("message", string message)
@@ -152,8 +152,7 @@ module Response = struct
 
     let () =
       Printexc.register_printer (function
-        | E e ->
-          Some (Dyn.to_string (Dyn.Encoder.constr "Response.E" [ to_dyn e ]))
+        | E e -> Some (Dyn.to_string (Dyn.variant "Response.E" [ to_dyn e ]))
         | _ -> None)
   end
 
@@ -314,11 +313,11 @@ module Persistent = struct
       | Close_connection
 
     let to_dyn =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
-      | New_connection -> constr "New_connection" []
-      | Close_connection -> constr "Close_connection" []
-      | Packet sexp -> constr "Packet" [ Sexp.to_dyn sexp ]
+      | New_connection -> variant "New_connection" []
+      | Close_connection -> variant "Close_connection" []
+      | Packet sexp -> variant "Packet" [ Sexp.to_dyn sexp ]
 
     let sexp =
       let open Conv in

--- a/otherlibs/dune-rpc/private/where.ml
+++ b/otherlibs/dune-rpc/private/where.ml
@@ -60,11 +60,11 @@ let to_dbus : t -> Dbus_address.t = function
     { name = "tcp"; args = [ ("host", host); ("port", port) ] }
 
 let to_dyn : t -> Dyn.t =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | `Unix s -> constr "Unix" [ string s ]
+  | `Unix s -> variant "Unix" [ string s ]
   | `Ip (`Host host, `Port port) ->
-    constr "Ip" [ constr "Host" [ string host ]; constr "Port" [ int port ] ]
+    variant "Ip" [ variant "Host" [ string host ]; variant "Port" [ int port ] ]
 
 let to_string t = Dbus_address.to_string (to_dbus t)
 

--- a/otherlibs/dyn/dyn.ml
+++ b/otherlibs/dyn/dyn.ml
@@ -7,7 +7,9 @@ type t =
   | Opaque
   | Unit
   | Int of int
+  | Int32 of int32
   | Int64 of int64
+  | Nativeint of nativeint
   | Bool of bool
   | String of string
   | Bytes of bytes
@@ -82,7 +84,9 @@ let rec pp =
   | Opaque -> Pp.verbatim "<opaque>"
   | Unit -> Pp.verbatim "()"
   | Int i -> Pp.verbatim (string_of_int i)
+  | Int32 i -> Pp.verbatim (Int32.to_string i)
   | Int64 i -> Pp.verbatim (Int64.to_string i)
+  | Nativeint i -> Pp.verbatim (Nativeint.to_string i)
   | Bool b -> Pp.verbatim (string_of_bool b)
   | String s -> string_in_ocaml_syntax s
   | Bytes b -> string_in_ocaml_syntax (Bytes.to_string b)
@@ -118,50 +122,48 @@ let rec pp =
 
 let to_string t = Format.asprintf "%a" Pp.to_fmt (pp t)
 
-module Encoder = struct
-  type dyn = t
+type 'a builder = 'a -> t
 
-  type 'a t = 'a -> dyn
+let unit () = Unit
 
-  let unit () = Unit
+let char x = Char x
 
-  let char x = Char x
+let string x = String x
 
-  let string x = String x
+let int x = Int x
 
-  let int x = Int x
+let int32 x = Int32 x
 
-  let int64 x = Int64 x
+let int64 x = Int64 x
 
-  let float x = Float x
+let nativeint x = Nativeint x
 
-  let bool x = Bool x
+let float x = Float x
 
-  let pair f g (x, y) = Tuple [ f x; g y ]
+let bool x = Bool x
 
-  let triple f g h (x, y, z) = Tuple [ f x; g y; h z ]
+let pair f g (x, y) = Tuple [ f x; g y ]
 
-  let list f l = List (List.map ~f l)
+let triple f g h (x, y, z) = Tuple [ f x; g y; h z ]
 
-  let array f a = Array (Array.map ~f a)
+let list f l = List (List.map ~f l)
 
-  let option f x =
-    Option
-      (match x with
-      | None -> None
-      | Some x -> Some (f x))
+let array f a = Array (Array.map ~f a)
 
-  let record r = Record r
+let option f x =
+  Option
+    (match x with
+    | None -> None
+    | Some x -> Some (f x))
 
-  let opaque _ = Opaque
+let record r = Record r
 
-  let constr s args = Variant (s, args)
-end
+let opaque _ = Opaque
 
-let opaque = Opaque
-
-type dyn = t
+let variant s args = Variant (s, args)
 
 let hash = Stdlib.Hashtbl.hash
 
 let compare x y = compare x y
+
+let equal x y = x = y

--- a/otherlibs/dyn/dyn.mli
+++ b/otherlibs/dyn/dyn.mli
@@ -1,10 +1,14 @@
-(** Dyn stands for "dynamic values". The Dyn.t type is a representation of OCaml
-    values such that they can be processed without knowing their type. *)
+(** Dynamic values *)
+
+(** Representation of OCaml values such that they can be processed without
+    knowing their type. *)
 type t =
   | Opaque
   | Unit
   | Int of int
+  | Int32 of int32
   | Int64 of int64
+  | Nativeint of nativeint
   | Bool of bool
   | String of string
   | Bytes of bytes
@@ -19,51 +23,50 @@ type t =
   | Map of (t * t) list
   | Set of t list
 
-module Encoder : sig
-  type dyn
-
-  type 'a t = 'a -> dyn
-
-  val unit : unit t
-
-  val char : char t
-
-  val string : string t
-
-  val int : int t
-
-  val int64 : int64 t
-
-  val float : float t
-
-  val bool : bool t
-
-  val pair : 'a t -> 'b t -> ('a * 'b) t
-
-  val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
-
-  val list : 'a t -> 'a list t
-
-  val array : 'a t -> 'a array t
-
-  val option : 'a t -> 'a option t
-
-  val record : (string * dyn) list -> dyn
-
-  val opaque : _ t
-
-  val constr : string -> dyn list -> dyn
-end
-with type dyn := t
-
-val pp : t -> _ Pp.t
-
-val opaque : t
+val equal : t -> t -> bool
 
 val compare : t -> t -> int
 
 val hash : t -> int
 
+val pp : t -> _ Pp.t
+
 val to_string : t -> string
 
-type dyn = t
+(** {1 Constructors} *)
+
+type 'a builder = 'a -> t
+
+val unit : unit builder
+
+val char : char builder
+
+val string : string builder
+
+val int : int builder
+
+val int32 : int32 builder
+
+val int64 : int64 builder
+
+val nativeint : nativeint builder
+
+val float : float builder
+
+val bool : bool builder
+
+val pair : 'a builder -> 'b builder -> ('a * 'b) builder
+
+val triple : 'a builder -> 'b builder -> 'c builder -> ('a * 'b * 'c) builder
+
+val list : 'a builder -> 'a list builder
+
+val array : 'a builder -> 'a array builder
+
+val option : 'a builder -> 'a option builder
+
+val opaque : _ builder
+
+val record : (string * t) list -> t
+
+val variant : string -> t list -> t

--- a/otherlibs/stdune-unstable/ansi_color.ml
+++ b/otherlibs/stdune-unstable/ansi_color.ml
@@ -1,7 +1,7 @@
 module Style = struct
   type t = string
 
-  let to_dyn s = Dyn.Encoder.string s
+  let to_dyn s = Dyn.string s
 
   let fg_black = "30"
 

--- a/otherlibs/stdune-unstable/digest.ml
+++ b/otherlibs/stdune-unstable/digest.ml
@@ -42,9 +42,7 @@ let compare x y = Ordering.of_int (D.compare x y)
 
 let to_string = D.to_hex
 
-let to_dyn s =
-  let open Dyn.Encoder in
-  constr "digest" [ string (to_string s) ]
+let to_dyn s = Dyn.variant "digest" [ String (to_string s) ]
 
 let from_hex s =
   match D.from_hex s with

--- a/otherlibs/stdune-unstable/env.ml
+++ b/otherlibs/stdune-unstable/env.ml
@@ -9,7 +9,7 @@ module Var = struct
       else
         String.compare
 
-    let to_dyn = Dyn.Encoder.string
+    let to_dyn = Dyn.string
   end
 
   let temp_dir =
@@ -90,7 +90,7 @@ let extend_env x y =
     extend x ~vars:y.vars
 
 let to_dyn t =
-  let open Dyn.Encoder in
+  let open Dyn in
   Map.to_dyn string t.vars
 
 let diff x y =

--- a/otherlibs/stdune-unstable/exn_with_backtrace.ml
+++ b/otherlibs/stdune-unstable/exn_with_backtrace.ml
@@ -32,7 +32,7 @@ let map { exn; backtrace } ~f = { exn = f exn; backtrace }
 let map_and_reraise t ~f = reraise (map ~f t)
 
 let to_dyn { exn; backtrace } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("exn", string (Printexc.to_string exn))
     ; ("backtrace", string (Printexc.raw_backtrace_to_string backtrace))

--- a/otherlibs/stdune-unstable/fdecl.ml
+++ b/otherlibs/stdune-unstable/fdecl.ml
@@ -23,5 +23,5 @@ let get t =
 
 let to_dyn t =
   match t.state with
-  | Unset -> Dyn.Encoder.constr "Unset" []
-  | Set a -> Dyn.Encoder.constr "Set" [ t.to_dyn a ]
+  | Unset -> Dyn.variant "Unset" []
+  | Set a -> Dyn.variant "Set" [ t.to_dyn a ]

--- a/otherlibs/stdune-unstable/interned.ml
+++ b/otherlibs/stdune-unstable/interned.ml
@@ -86,7 +86,7 @@ module Make (R : Settings) () = struct
 
     let equal x y = compare x y = Ordering.Eq
 
-    let to_dyn = Dyn.Encoder.int
+    let to_dyn = Dyn.int
   end
 
   include T

--- a/otherlibs/stdune-unstable/map.ml
+++ b/otherlibs/stdune-unstable/map.ml
@@ -169,9 +169,7 @@ module Make (Key : Key) : S with type key = Key.t = struct
     | Some v -> v
     | None ->
       Code_error.raise "Map.find_exn: failed to find key"
-        [ ("key", Key.to_dyn key)
-        ; ("keys", Dyn.list Key.to_dyn (keys t))
-        ]
+        [ ("key", Key.to_dyn key); ("keys", Dyn.list Key.to_dyn (keys t)) ]
 
   let min_binding = min_binding_opt
 

--- a/otherlibs/stdune-unstable/map.ml
+++ b/otherlibs/stdune-unstable/map.ml
@@ -170,7 +170,7 @@ module Make (Key : Key) : S with type key = Key.t = struct
     | None ->
       Code_error.raise "Map.find_exn: failed to find key"
         [ ("key", Key.to_dyn key)
-        ; ("keys", Dyn.Encoder.list Key.to_dyn (keys t))
+        ; ("keys", Dyn.list Key.to_dyn (keys t))
         ]
 
   let min_binding = min_binding_opt

--- a/otherlibs/stdune-unstable/or_exn.mli
+++ b/otherlibs/stdune-unstable/or_exn.mli
@@ -6,6 +6,6 @@ val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
 val hash : ('a -> int) -> 'a t -> int
 
-val to_dyn : ('a -> Dyn.t) -> 'a t Dyn.Encoder.t
+val to_dyn : ('a -> Dyn.t) -> 'a t Dyn.builder
 
 include Monad_intf.S with type 'a t := 'a t

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -699,7 +699,7 @@ module Build = struct
 
   let build_dir = Fdecl.create Kind.to_dyn
 
-  let build_dir_prefix = Fdecl.create Dyn.Encoder.opaque
+  let build_dir_prefix = Fdecl.create Dyn.opaque
 
   let set_build_dir (new_build_dir : Kind.t) =
     let new_build_dir_prefix =
@@ -862,11 +862,11 @@ let parse_string_exn ~loc s =
 let of_string s = parse_string_exn ~loc:Loc0.none s
 
 let to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | In_build_dir s -> constr "In_build_dir" [ Local.to_dyn s ]
-  | In_source_tree s -> constr "In_source_tree" [ Local.to_dyn s ]
-  | External s -> constr "External" [ External.to_dyn s ]
+  | In_build_dir s -> variant "In_build_dir" [ Local.to_dyn s ]
+  | In_source_tree s -> variant "In_source_tree" [ Local.to_dyn s ]
+  | External s -> variant "External" [ External.to_dyn s ]
 
 let of_filename_relative_to_initial_cwd fn =
   external_

--- a/otherlibs/stdune-unstable/path_intf.ml
+++ b/otherlibs/stdune-unstable/path_intf.ml
@@ -32,7 +32,7 @@ module type S = sig
   module Set : sig
     include Set.S with type elt = t
 
-    val to_dyn : t Dyn.Encoder.t
+    val to_dyn : t Dyn.builder
 
     val of_listing : dir:elt -> filenames:string list -> t
   end
@@ -101,7 +101,7 @@ module type Local_gen = sig
     module Set : sig
       include Set.S with type elt = Root.w t
 
-      val to_dyn : t Dyn.Encoder.t
+      val to_dyn : t Dyn.builder
 
       val of_listing : dir:elt -> filenames:string list -> t
     end

--- a/otherlibs/stdune-unstable/result.ml
+++ b/otherlibs/stdune-unstable/result.ml
@@ -140,5 +140,5 @@ module Option = struct
 end
 
 let to_dyn ok err = function
-  | Ok e -> Dyn.Encoder.constr "Ok" [ ok e ]
-  | Error e -> Dyn.Encoder.constr "Error" [ err e ]
+  | Ok e -> Dyn.variant "Ok" [ ok e ]
+  | Error e -> Dyn.variant "Error" [ err e ]

--- a/otherlibs/stdune-unstable/result.mli
+++ b/otherlibs/stdune-unstable/result.mli
@@ -48,8 +48,7 @@ val map_error : ('a, 'error1) t -> f:('error1 -> 'error2) -> ('a, 'error2) t
 
 val to_option : ('a, 'error) t -> 'a option
 
-val to_dyn :
-  'a Dyn.builder -> 'error Dyn.builder -> ('a, 'error) t Dyn.builder
+val to_dyn : 'a Dyn.builder -> 'error Dyn.builder -> ('a, 'error) t Dyn.builder
 
 (** Produce [Error <message>] *)
 val errorf : ('a, unit, string, (_, string) t) format4 -> 'a

--- a/otherlibs/stdune-unstable/result.mli
+++ b/otherlibs/stdune-unstable/result.mli
@@ -49,7 +49,7 @@ val map_error : ('a, 'error1) t -> f:('error1 -> 'error2) -> ('a, 'error2) t
 val to_option : ('a, 'error) t -> 'a option
 
 val to_dyn :
-  'a Dyn.Encoder.t -> 'error Dyn.Encoder.t -> ('a, 'error) t Dyn.Encoder.t
+  'a Dyn.builder -> 'error Dyn.builder -> ('a, 'error) t Dyn.builder
 
 (** Produce [Error <message>] *)
 val errorf : ('a, unit, string, (_, string) t) format4 -> 'a

--- a/otherlibs/stdune-unstable/sexp.ml
+++ b/otherlibs/stdune-unstable/sexp.ml
@@ -41,7 +41,9 @@ let rec of_dyn : Dyn.t -> t = function
   | Opaque -> Atom "<opaque>"
   | Unit -> List []
   | Int i -> Atom (string_of_int i)
+  | Int32 i -> Atom (Int32.to_string i)
   | Int64 i -> Atom (Int64.to_string i)
+  | Nativeint i -> Atom (Nativeint.to_string i)
   | Bool b -> Atom (string_of_bool b)
   | String s -> Atom s
   | Bytes s -> Atom (Bytes.to_string s)

--- a/otherlibs/stdune-unstable/tuple.ml
+++ b/otherlibs/stdune-unstable/tuple.ml
@@ -1,7 +1,7 @@
 module T2 = struct
   type ('a, 'b) t = 'a * 'b
 
-  let to_dyn = Dyn.Encoder.pair
+  let to_dyn = Dyn.pair
 
   let equal f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
@@ -18,7 +18,7 @@ end
 module T3 = struct
   type ('a, 'b, 'c) t = 'a * 'b * 'c
 
-  let to_dyn = Dyn.Encoder.triple
+  let to_dyn = Dyn.triple
 
   let hash f g h (a, b, c) = Hashtbl.hash (f a, g b, h c)
 

--- a/otherlibs/stdune-unstable/univ_map.ml
+++ b/otherlibs/stdune-unstable/univ_map.ml
@@ -103,7 +103,7 @@ module Make () = struct
   let superpose = Int.Map.superpose
 
   let to_dyn (t : t) =
-    let open Dyn.Encoder in
+    let open Dyn in
     Dyn.Map
       (Int.Map.values t
       |> List.map ~f:(fun (Binding.T (key, v)) ->

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -183,7 +183,7 @@ module Session = struct
       | None -> Fiber.return ()
       | Some sexps ->
         Code_error.raise "attempting to write to a closed channel"
-          [ ("sexp", Dyn.Encoder.(list Sexp.to_dyn) sexps) ])
+          [ ("sexp", Dyn.(list Sexp.to_dyn) sexps) ])
     | Open { writer; out_channel; socket; _ } -> (
       match sexps with
       | None ->

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -111,7 +111,7 @@ module Cache = struct
       | None -> "auto"
       | Some mode -> Dune_cache_storage.Mode.to_string mode
 
-    let to_dyn = Dyn.Encoder.option Dune_cache_storage.Mode.to_dyn
+    let to_dyn = Dyn.option Dune_cache_storage.Mode.to_dyn
   end
 end
 
@@ -182,13 +182,13 @@ struct
       ; action_stdout_on_success
       ; action_stderr_on_success
       } =
-    Dyn.Encoder.record
+    Dyn.record
       [ ("display", field Scheduler.Config.Display.to_dyn display)
       ; ("concurrency", field Concurrency.to_dyn concurrency)
       ; ( "terminal_persistence"
         , field Terminal_persistence.to_dyn terminal_persistence )
       ; ( "sandboxing_preference"
-        , field (Dyn.Encoder.list Sandbox_mode.to_dyn) sandboxing_preference )
+        , field (Dyn.list Sandbox_mode.to_dyn) sandboxing_preference )
       ; ("cache_enabled", field Cache.Enabled.to_dyn cache_enabled)
       ; ( "cache_reproducibility_check"
         , field Dune_cache.Config.Reproducibility_check.to_dyn
@@ -236,7 +236,7 @@ module Partial = struct
     Make_to_dyn
       (M)
       (struct
-        let field f = Dyn.Encoder.option f
+        let field f = Dyn.option f
       end)
 end
 

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -33,7 +33,7 @@ module Prog = struct
     let raise t = raise (User_error.E (user_message t))
 
     let to_dyn { context; program; hint; loc = _ } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("context", Context_name.to_dyn context)
         ; ("program", string program)

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -38,10 +38,10 @@ module Dynamic_dep = struct
         Tuple.T2.compare Path.compare Glob.compare (dir1, glob1) (dir2, glob2)
 
     let to_dyn =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
-      | File fn -> constr "File" [ Path.to_dyn fn ]
-      | Glob (dir, glob) -> constr "Glob" [ Path.to_dyn dir; Glob.to_dyn glob ]
+      | File fn -> variant "File" [ Path.to_dyn fn ]
+      | Glob (dir, glob) -> variant "Glob" [ Path.to_dyn dir; Glob.to_dyn glob ]
   end
 
   include T

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -75,8 +75,7 @@ end = struct
   let of_string s =
     match of_string_opt s with
     | Some s -> s
-    | None ->
-      Code_error.raise "invalid alias name" [ ("s", Dyn.string s) ]
+    | None -> Code_error.raise "invalid alias name" [ ("s", Dyn.string s) ]
 
   let to_string s = s
 

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -76,7 +76,7 @@ end = struct
     match of_string_opt s with
     | Some s -> s
     | None ->
-      Code_error.raise "invalid alias name" [ ("s", Dyn.Encoder.string s) ]
+      Code_error.raise "invalid alias name" [ ("s", Dyn.string s) ]
 
   let to_string s = s
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -103,8 +103,8 @@ end = struct
       Dyn.Record
         [ ("rule_digest", Digest.to_dyn rule_digest)
         ; ( "dynamic_deps_stages"
-          , Dyn.Encoder.list
-              (Dyn.Encoder.pair Action_exec.Dynamic_dep.Set.to_dyn Digest.to_dyn)
+          , Dyn.list
+              (Dyn.pair Action_exec.Dynamic_dep.Set.to_dyn Digest.to_dyn)
               dynamic_deps_stages )
         ; ("targets_digest", Digest.to_dyn targets_digest)
         ]
@@ -202,7 +202,7 @@ end
 type extra_sub_directories_to_keep = Subdir_set.t
 
 module Rule_fn = struct
-  let loc_decl = Fdecl.create Dyn.Encoder.opaque
+  let loc_decl = Fdecl.create Dyn.opaque
 
   let loc () = Fdecl.get loc_decl ()
 end
@@ -341,7 +341,7 @@ type t =
       Path.Build.t -> unit Action_builder.t option Memo.Build.t
   }
 
-let t = Fdecl.create Dyn.Encoder.opaque
+let t = Fdecl.create Dyn.opaque
 
 let set x = Fdecl.set t x
 
@@ -1952,7 +1952,7 @@ end = struct
     let to_dyn t : Dyn.t =
       Record
         [ ("digest", Digest.to_dyn t.digest)
-        ; ("loc", Dyn.Encoder.option Loc.to_dyn t.action.loc)
+        ; ("loc", Dyn.option Loc.to_dyn t.action.loc)
         ]
   end
 

--- a/src/dune_engine/cm_kind.ml
+++ b/src/dune_engine/cm_kind.ml
@@ -37,8 +37,8 @@ module Dict = struct
 end
 
 let to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Cmi -> constr "cmi" []
-  | Cmo -> constr "cmo" []
-  | Cmx -> constr "cmx" []
+  | Cmi -> variant "cmi" []
+  | Cmo -> variant "cmo" []
+  | Cmx -> variant "cmx" []

--- a/src/dune_engine/compound_user_error.ml
+++ b/src/dune_engine/compound_user_error.ml
@@ -28,7 +28,7 @@ end
 include T
 
 let to_dyn { main; related } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("main", string (User_message.to_string main))
     ; ("related", (list string) (List.map related ~f:User_message.to_string))

--- a/src/dune_engine/cram_test.ml
+++ b/src/dune_engine/cram_test.ml
@@ -11,11 +11,11 @@ type t =
 let is_cram_suffix = String.is_suffix ~suffix:".t"
 
 let dyn_of_t =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | File f -> constr "File" [ Path.Source.to_dyn f ]
+  | File f -> variant "File" [ Path.Source.to_dyn f ]
   | Dir { file; dir } ->
-    constr "Dir"
+    variant "Dir"
       [ record
           [ ("file", Path.Source.to_dyn file); ("dir", Path.Source.to_dyn dir) ]
       ]

--- a/src/dune_engine/dialect.ml
+++ b/src/dune_engine/dialect.ml
@@ -28,7 +28,7 @@ module File_kind = struct
            ])
 
   let to_dyn { kind; extension; preprocess; format } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("kind", Ml_kind.to_dyn kind)
       ; ("extension", string extension)
@@ -49,7 +49,7 @@ type t =
 let name t = t.name
 
 let to_dyn { name; file_kinds } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("name", string name)
     ; ("file_kinds", Ml_kind.Dict.to_dyn File_kind.to_dyn file_kinds)

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -9,7 +9,7 @@ module Annot = struct
     }
 
   let to_dyn { in_source; in_build } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("in_source", Path.Source.to_dyn in_source)
       ; ("in_build", Path.Build.to_dyn in_build)
@@ -28,7 +28,7 @@ module File = struct
   let in_staging_area source = Path.Build.append_source staging_area source
 
   let to_dyn { src; staging; dst } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("src", Path.Build.to_dyn src)
       ; ("staging", option Path.Build.to_dyn staging)
@@ -96,7 +96,7 @@ module P = Persistent.Make (struct
 
   let version = 2
 
-  let to_dyn = Dyn.Encoder.list File.to_dyn
+  let to_dyn = Dyn.list File.to_dyn
 end)
 
 let db_file = Path.relative Path.build_dir ".to-promote"

--- a/src/dune_engine/dir_set.ml
+++ b/src/dune_engine/dir_set.ml
@@ -172,10 +172,10 @@ let rec is_subset t ~of_ =
     && String.Map.is_subset x.exceptions ~of_:y.exceptions ~f:is_subset
 
 let rec to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Empty -> constr "Empty" []
-  | Universal -> constr "Universal" []
+  | Empty -> variant "Empty" []
+  | Universal -> variant "Universal" []
   | Nontrivial { here; default; exceptions } ->
     let open Dyn in
     List

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -46,10 +46,10 @@ end = struct
     let equal a b = Ordering.is_eq (compare a b)
 
     let to_dyn =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
-      | Named n -> constr "Named" [ string n ]
-      | Anonymous p -> constr "Anonymous" [ Path.Source.to_dyn p ]
+      | Named n -> variant "Named" [ string n ]
+      | Anonymous p -> variant "Anonymous" [ Path.Source.to_dyn p ]
   end
 
   include T
@@ -225,7 +225,7 @@ let to_dyn
     ; cram
     ; expand_aliases_in_sandbox
     } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("name", Name.to_dyn name)
     ; ("root", Path.Source.to_dyn root)
@@ -301,7 +301,7 @@ module Extension = struct
     let name = Dune_lang.Syntax.name syntax in
     if Table.mem extensions name then
       Code_error.raise "Dune_project.Extension.register: already registered"
-        [ ("name", Dyn.Encoder.string name) ];
+        [ ("name", Dyn.string name) ];
     let key = Univ_map.Key.create ~name arg_to_dyn in
     let ext = { syntax; stanzas; key } in
     Table.add_exn extensions name (Extension (Packed ext));

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -92,7 +92,7 @@ let action_stdout_on_success t = t.action_stdout_on_success
 
 let action_stderr_on_success t = t.action_stderr_on_success
 
-let default = Fdecl.create Dyn.Encoder.opaque
+let default = Fdecl.create Dyn.opaque
 
 let init t = Fdecl.set default t
 

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -21,11 +21,10 @@ let create ~dir ?(only_generated_files = false) predicate =
   { dir; predicate; only_generated_files }
 
 let to_dyn { dir; predicate; only_generated_files } =
-  let open Dyn in
-  Record
+  Dyn.Record
     [ ("dir", Path.to_dyn dir)
     ; ("predicate", Predicate.to_dyn predicate)
-    ; ("only_generated_files", Encoder.bool only_generated_files)
+    ; ("only_generated_files", Bool only_generated_files)
     ]
 
 let encode { dir; predicate; only_generated_files } =

--- a/src/dune_engine/format_config.ml
+++ b/src/dune_engine/format_config.ml
@@ -24,10 +24,10 @@ module Language = struct
       | Dialect s1, Dialect s2 -> String.compare s1 s2
 
     let to_dyn =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
-      | Dialect name -> constr "dialect" [ string name ]
-      | Dune -> constr "dune" []
+      | Dialect name -> variant "dialect" [ string name ]
+      | Dune -> variant "dune" []
   end
 
   module Map = Map.Make (Key)
@@ -55,9 +55,9 @@ module Enabled_for = struct
     | All
 
   let to_dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
-    | Only l -> constr "only" [ Language.Set.to_dyn l ]
+    | Only l -> variant "only" [ Language.Set.to_dyn l ]
     | All -> string "all"
 
   let includes t =
@@ -96,7 +96,7 @@ type t = Enabled_for.t generic_t
 let includes t lang = Enabled_for.includes t.enabled_for lang
 
 let to_dyn { enabled_for; loc = _ } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record [ ("enabled_for", Enabled_for.to_dyn enabled_for) ]
 
 let dparse_args =

--- a/src/dune_engine/glob.ml
+++ b/src/dune_engine/glob.ml
@@ -12,7 +12,7 @@ let equal x y = String.equal (to_string x) (to_string y)
 
 let hash t = String.hash (to_string t)
 
-let to_dyn t = Dyn.Encoder.string (to_string t)
+let to_dyn t = Dyn.string (to_string t)
 
 let of_string_exn loc repr =
   match of_string_result repr with
@@ -30,9 +30,5 @@ let decode =
 let filter t = List.filter ~f:(test t)
 
 let to_pred t =
-  let id =
-    lazy
-      (let open Dyn.Encoder in
-      constr "Glob" [ string (to_string t) ])
-  in
+  let id = lazy (Dyn.variant "Glob" [ String (to_string t) ]) in
   Predicate.create ~id ~f:(test t)

--- a/src/dune_engine/glob.mli
+++ b/src/dune_engine/glob.mli
@@ -8,7 +8,7 @@ val compare : t -> t -> Ordering.t
 
 val hash : t -> int
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Dyn.builder
 
 val encode : t Dune_lang.Encoder.t
 

--- a/src/dune_engine/hooks.ml
+++ b/src/dune_engine/hooks.ml
@@ -32,7 +32,7 @@ module Make () = struct
     | [] -> ()
     | exns ->
       let exns = List.rev exns in
-      let open Dyn.Encoder in
+      let open Dyn in
       Code_error.raise "hooks failed"
         [ ("exns", (list Exn_with_backtrace.to_dyn) exns) ]
 end

--- a/src/dune_engine/install.ml
+++ b/src/dune_engine/install.ml
@@ -77,7 +77,7 @@ end = struct
 
   let encode = Dune_lang.Encoder.string
 
-  let to_dyn = Dyn.Encoder.string
+  let to_dyn = Dyn.string
 end
 
 module Section_with_site = struct
@@ -92,11 +92,11 @@ module Section_with_site = struct
   (* let compare : t -> t -> Ordering.t = Poly.compare *)
 
   let to_dyn x =
-    let open Dyn.Encoder in
+    let open Dyn in
     match x with
-    | Section s -> constr "Section" [ Section.to_dyn s ]
+    | Section s -> variant "Section" [ Section.to_dyn s ]
     | Site { pkg; site; loc = _ } ->
-      constr "Section" [ Package.Name.to_dyn pkg; Section.Site.to_dyn site ]
+      variant "Section" [ Package.Name.to_dyn pkg; Section.Site.to_dyn site ]
 
   let to_string = function
     | Section s -> Section.to_string s

--- a/src/dune_engine/mode.ml
+++ b/src/dune_engine/mode.ml
@@ -22,9 +22,7 @@ let to_string = choose "byte" "native"
 
 let encode t = Dune_lang.Encoder.string (to_string t)
 
-let to_dyn t =
-  let open Dyn.Encoder in
-  constr (to_string t) []
+let to_dyn t = Dyn.variant (to_string t) []
 
 let compiled_unit_ext = choose (Cm_kind.ext Cmo) (Cm_kind.ext Cmx)
 
@@ -57,7 +55,7 @@ module Dict = struct
   let for_all { byte; native } ~f = f byte && f native
 
   let to_dyn to_dyn { byte; native } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("byte", to_dyn byte); ("native", to_dyn native) ]
 
   let get t = function
@@ -86,7 +84,7 @@ module Dict = struct
     let equal = equal Bool.equal
 
     let to_dyn { byte; native } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record [ ("byte", bool byte); ("native", bool native) ]
 
     let all = { byte = true; native = true }

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -69,7 +69,7 @@ module Id = struct
       | s -> s
 
     let to_dyn { dir; name } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record [ ("name", Name.to_dyn name); ("dir", Path.Source.to_dyn dir) ]
   end
 
@@ -109,7 +109,7 @@ module Dependency = struct
       [ ("=", Eq); (">=", Gte); ("<=", Lte); (">", Gt); ("<", Lt); ("<>", Neq) ]
 
     let to_dyn =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
       | Eq -> string "Eq"
       | Gt -> string "Gt"
@@ -217,14 +217,14 @@ module Dependency = struct
           | _ -> sum (ops @ logops))
 
     let rec to_dyn =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
-      | Bvar v -> constr "Bvar" [ Var.to_dyn v ]
-      | Uop (b, x) -> constr "Uop" [ Op.to_dyn b; Var.to_dyn x ]
+      | Bvar v -> variant "Bvar" [ Var.to_dyn v ]
+      | Uop (b, x) -> variant "Uop" [ Op.to_dyn b; Var.to_dyn x ]
       | Bop (b, x, y) ->
-        constr "Bop" [ Op.to_dyn b; Var.to_dyn x; Var.to_dyn y ]
-      | And t -> constr "And" (List.map ~f:to_dyn t)
-      | Or t -> constr "Or" (List.map ~f:to_dyn t)
+        variant "Bop" [ Op.to_dyn b; Var.to_dyn x; Var.to_dyn y ]
+      | And t -> variant "And" (List.map ~f:to_dyn t)
+      | Or t -> variant "Or" (List.map ~f:to_dyn t)
   end
 
   type t =
@@ -281,7 +281,7 @@ module Dependency = struct
       | Some c -> Option (nopos, pkg, [ c ])
 
   let to_dyn { name; constraint_ } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("name", Name.to_dyn name)
       ; ("constr", Dyn.Option (Option.map ~f:Constraint.to_dyn constraint_))
@@ -306,10 +306,10 @@ module Source_kind = struct
       ; kind : kind
       }
 
-    let dyn_of_kind kind = kind |> to_string |> Dyn.Encoder.string
+    let dyn_of_kind kind = kind |> to_string |> Dyn.string
 
     let to_dyn { user; repo; kind } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("kind", dyn_of_kind kind)
         ; ("user", string user)
@@ -372,10 +372,10 @@ module Source_kind = struct
     | Url of string
 
   let to_dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
-    | Host h -> constr "Host" [ Host.to_dyn h ]
-    | Url url -> constr "Url" [ string url ]
+    | Host h -> variant "Host" [ Host.to_dyn h ]
+    | Url url -> variant "Url" [ string url ]
 
   let to_string = function
     | Host h -> Host.to_string h
@@ -460,7 +460,7 @@ module Info = struct
       ; documentation
       ; maintainers
       } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("source", (option Source_kind.to_dyn) source)
       ; ("license", (option string) license)
@@ -679,7 +679,7 @@ let to_dyn
     ; sites
     ; allow_empty
     } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("id", Id.to_dyn id)
     ; ("synopsis", option string synopsis)

--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -96,7 +96,7 @@ module Source_kind : sig
     | Host of Host.t
     | Url of string
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 
   val to_string : t -> string
 
@@ -125,7 +125,7 @@ module Info : sig
 
   val empty : t
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 
   val encode_fields : t -> Dune_lang.t list
 

--- a/src/dune_engine/predicate_lang.ml
+++ b/src/dune_engine/predicate_lang.ml
@@ -94,13 +94,13 @@ let rec encode f =
   | Inter xs -> constr "and" (list (encode f)) xs
 
 let rec to_dyn f =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
   | Element a -> f a
-  | Compl a -> constr "compl" [ to_dyn f a ]
+  | Compl a -> variant "compl" [ to_dyn f a ]
   | Standard -> string ":standard"
-  | Union xs -> constr "or" (List.map ~f:(to_dyn f) xs)
-  | Inter xs -> constr "and" (List.map ~f:(to_dyn f) xs)
+  | Union xs -> variant "or" (List.map ~f:(to_dyn f) xs)
+  | Inter xs -> variant "and" (List.map ~f:(to_dyn f) xs)
 
 let rec exec t ~standard elem =
   match (t : _ t) with
@@ -115,7 +115,7 @@ module Glob = struct
 
   type nonrec t = glob t
 
-  let to_dyn t = to_dyn (fun _ -> Dyn.Encoder.string "opaque") t
+  let to_dyn t = to_dyn (fun _ -> Dyn.string "opaque") t
 
   let decode : t Dune_lang.Decoder.t =
     let open Dune_lang.Decoder in

--- a/src/dune_engine/predicate_lang.mli
+++ b/src/dune_engine/predicate_lang.mli
@@ -27,7 +27,7 @@ val decode : 'a Dune_lang.Decoder.t -> 'a t Dune_lang.Decoder.t
 
 val encode : 'a Dune_lang.Encoder.t -> 'a t Dune_lang.Encoder.t
 
-val to_dyn : 'a Dyn.Encoder.t -> 'a t Dyn.Encoder.t
+val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
 
 val exec : 'a t -> standard:'a t -> ('a -> bool) -> bool
 

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -37,7 +37,7 @@ module Dir_rules = struct
       Dyn.Variant
         ("Alias", [ Record [ ("name", Alias.Name.to_dyn alias.name) ] ])
 
-  let to_dyn t = Dyn.Encoder.(list data_to_dyn) (Id.Map.values t)
+  let to_dyn t = Dyn.(list data_to_dyn) (Id.Map.values t)
 
   type ready =
     { rules : Rule.t list

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -145,7 +145,7 @@ let to_string = function
   | Some Patch_back_source_tree -> "patch_back_source_tree"
 
 let to_dyn =
-  Dyn.Encoder.option (function
+  Dyn.option (function
     | Symlink -> Variant ("Symlink", [])
     | Copy -> Variant ("Copy", [])
     | Hardlink -> Variant ("Hardlink", [])

--- a/src/dune_engine/section.ml
+++ b/src/dune_engine/section.ml
@@ -5,8 +5,8 @@ let compare : t -> t -> Ordering.t = Poly.compare
 
 let to_dyn x =
   let s = Dune_section.to_string x in
-  let open Dyn.Encoder in
-  constr (String.uppercase_ascii s) []
+  let open Dyn in
+  variant (String.uppercase_ascii s) []
 
 module Key = struct
   type nonrec t = t

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -10,7 +10,7 @@ module File = struct
       }
 
     let to_dyn { ino; dev } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record [ ("ino", Int.to_dyn ino); ("dev", Int.to_dyn dev) ]
 
     let compare a b =
@@ -139,7 +139,7 @@ end = struct
   let empty path = { path; files = String.Set.empty; dirs = [] }
 
   let _to_dyn { path; files; dirs } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("path", Path.Source.to_dyn path)
       ; ("files", String.Set.to_dyn files)
@@ -322,7 +322,7 @@ module Dir0 = struct
       ]
 
   and dyn_of_sub_dir { sub_dir_status; sub_dir_as_t; virtual_ } =
-    let open Dyn.Encoder in
+    let open Dyn in
     let path = Memo.Cell.input sub_dir_as_t in
     record
       [ ("status", Sub_dirs.Status.to_dyn sub_dir_status)
@@ -331,12 +331,12 @@ module Dir0 = struct
       ]
 
   and dyn_of_contents { files; sub_dirs; dune_file } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("files", String.Set.to_dyn files)
       ; ("sub_dirs", String.Map.to_dyn dyn_of_sub_dir sub_dirs)
-      ; ("dune_file", Dyn.Encoder.(option opaque dune_file))
-      ; ("project", Dyn.opaque)
+      ; ("dune_file", Dyn.(option opaque dune_file))
+      ; ("project", Opaque)
       ]
 
   module Contents = struct

--- a/src/dune_engine/string_with_vars.mli
+++ b/src/dune_engine/string_with_vars.mli
@@ -16,7 +16,7 @@ val equal_no_loc : t -> t -> bool
 (** [loc t] returns the location of [t] — typically, in the [dune] file. *)
 val loc : t -> Loc.t
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Dyn.builder
 
 include Dune_lang.Conv.S with type t := t
 

--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -25,7 +25,7 @@ module Status = struct
       | Normal -> normal
 
     let to_dyn f { data_only; vendored; normal } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("data_only", f data_only)
         ; ("vendored", f vendored)

--- a/src/dune_engine/subst_config.ml
+++ b/src/dune_engine/subst_config.ml
@@ -9,7 +9,7 @@ let to_string = function
   | Disabled -> "disabled"
   | Enabled -> "enabled"
 
-let to_dyn conf = to_string conf |> Dyn.Encoder.string
+let to_dyn conf = to_string conf |> Dyn.string
 
 let encode t = Dune_lang.Encoder.string (to_string t)
 

--- a/src/dune_engine/vcs.ml
+++ b/src/dune_engine/vcs.ml
@@ -30,7 +30,7 @@ module T = struct
     }
 
   let to_dyn { root; kind } =
-    Dyn.Encoder.record
+    Dyn.record
       [ ("root", Path.to_dyn root); ("kind", Kind.to_dyn kind) ]
 
   let equal { root = ra; kind = ka } { root = rb; kind = kb } =

--- a/src/dune_engine/vcs.ml
+++ b/src/dune_engine/vcs.ml
@@ -30,8 +30,7 @@ module T = struct
     }
 
   let to_dyn { root; kind } =
-    Dyn.record
-      [ ("root", Path.to_dyn root); ("kind", Kind.to_dyn kind) ]
+    Dyn.record [ ("root", Path.to_dyn root); ("kind", Kind.to_dyn kind) ]
 
   let equal { root = ra; kind = ka } { root = rb; kind = kb } =
     Path.equal ra rb && Kind.equal ka kb

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -28,7 +28,7 @@ module Fs_memo_event = struct
     | Unknown  (** Treated conservatively as any possible event. *)
 
   let dyn_of_kind kind =
-    Dyn.Encoder.string
+    Dyn.string
       (match kind with
       | Created -> "Created"
       | Deleted -> "Deleted"
@@ -41,7 +41,7 @@ module Fs_memo_event = struct
     }
 
   let to_dyn { path; kind } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("path", Path.to_dyn path); ("kind", dyn_of_kind kind) ]
 
   let create ~kind ~path =

--- a/src/dune_lang/atom.ml
+++ b/src/dune_lang/atom.ml
@@ -3,8 +3,8 @@ open Stdune
 type t = A of string [@@unboxed]
 
 let to_dyn (A s) =
-  let open Dyn.Encoder in
-  constr "A" [ string s ]
+  let open Dyn in
+  variant "A" [ string s ]
 
 let equal (A a) (A b) = String.equal a b
 

--- a/src/dune_lang/cst.ml
+++ b/src/dune_lang/cst.ml
@@ -8,13 +8,13 @@ type t =
   | Comment of Loc.t * string list
 
 let rec to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Atom (_, a) -> constr "Atom" [ Atom.to_dyn a ]
-  | Quoted_string (_, s) -> constr "Quoted_string" [ string s ]
-  | Template t -> constr "Template" [ Template.to_dyn t ]
-  | List (_, l) -> constr "List" [ list to_dyn l ]
-  | Comment (_, c) -> constr "Comment" [ Dyn.Encoder.(list string) c ]
+  | Atom (_, a) -> variant "Atom" [ Atom.to_dyn a ]
+  | Quoted_string (_, s) -> variant "Quoted_string" [ string s ]
+  | Template t -> variant "Template" [ Template.to_dyn t ]
+  | List (_, l) -> variant "List" [ list to_dyn l ]
+  | Comment (_, c) -> variant "Comment" [ Dyn.(list string) c ]
 
 let loc
     ( Atom (loc, _)

--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -22,7 +22,7 @@ module Name = struct
       | Eq -> String.compare a b
       | ne -> ne
 
-    let to_dyn = Dyn.Encoder.string
+    let to_dyn = Dyn.string
   end
 
   include T

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -10,7 +10,7 @@ module Version = struct
       | Eq -> Int.compare minor_a minor_b
 
     let to_dyn t =
-      let open Dyn.Encoder in
+      let open Dyn in
       pair int int t
   end
 
@@ -159,7 +159,7 @@ and key =
       }
 
 let to_dyn { name; desc; key = _; supported_versions; experimental } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("name", string name)
     ; ("desc", string desc)
@@ -176,7 +176,7 @@ module Key = struct
         }
 
   let to_dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
     | Active v -> Version.to_dyn v
     | Inactive { lang; dune_lang_ver } ->
@@ -359,7 +359,7 @@ let get_exn t =
   | None ->
     let+ context = get_all in
     Code_error.raise "Syntax identifier is unset"
-      [ ("name", Dyn.Encoder.string t.name)
+      [ ("name", Dyn.string t.name)
       ; ("supported_versions", Supported_versions.to_dyn t.supported_versions)
       ; ("context", Univ_map.to_dyn context)
       ]

--- a/src/dune_lang/syntax.mli
+++ b/src/dune_lang/syntax.mli
@@ -11,7 +11,7 @@ module Version : sig
 
   include Conv.S with type t := t
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 
   val hash : t -> int
 

--- a/src/dune_lang/t.ml
+++ b/src/dune_lang/t.ml
@@ -122,9 +122,9 @@ module Deprecated = struct
 end
 
 let rec to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
   | Atom (A a) -> string a
   | List s -> List (List.map s ~f:to_dyn)
   | Quoted_string s -> string s
-  | Template t -> constr "template" [ string (Template.to_string t) ]
+  | Template t -> variant "template" [ string (Template.to_string t) ]

--- a/src/dune_lang/t.mli
+++ b/src/dune_lang/t.mli
@@ -36,4 +36,4 @@ module Deprecated : sig
   val prepare_formatter : Format.formatter -> unit
 end
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Dyn.builder

--- a/src/dune_lang/template.ml
+++ b/src/dune_lang/template.ml
@@ -30,7 +30,7 @@ module Pform = struct
     | Some p -> before ^ name ^ ":" ^ p ^ after
 
   let to_dyn { loc = _; name; payload } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("name", string name); ("payload", option string payload) ]
 
   let with_name t ~name = { t with name }
@@ -156,11 +156,11 @@ let remove_locs t =
   }
 
 let dyn_of_part =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Text s -> constr "Text" [ string s ]
-  | Pform v -> constr "Pform" [ Pform.to_dyn v ]
+  | Text s -> variant "Text" [ string s ]
+  | Pform v -> variant "Pform" [ Pform.to_dyn v ]
 
 let to_dyn { quoted; parts; loc = _ } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record [ ("quoted", bool quoted); ("parts", list dyn_of_part parts) ]

--- a/src/dune_lang/versioned_file.ml
+++ b/src/dune_lang/versioned_file.ml
@@ -52,7 +52,7 @@ struct
       let name = Syntax.name syntax in
       if Table.mem langs name then
         Code_error.raise "Versioned_file.Lang.register: already registered"
-          [ ("name", Dyn.Encoder.string name) ];
+          [ ("name", Dyn.string name) ];
       Table.add_exn langs name { syntax; data }
 
     let parse first_line : Instance.t =

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -35,7 +35,7 @@ module Client = struct
   let create () = { next_id = 0 }
 
   let to_dyn { next_id = _ } =
-    let open Dyn.Encoder in
+    let open Dyn in
     opaque ()
 end
 
@@ -312,7 +312,7 @@ let build_event t (event : Build_system.Handler.event) =
       Long_poll.Instance.update (Long_poll.progress t.long_poll) progress)
 
 let create ~root =
-  let t = Fdecl.create Dyn.Encoder.opaque in
+  let t = Fdecl.create Dyn.opaque in
   let pending_build_jobs = Job_queue.create () in
   let handler = Dune_rpc_server.make (handler t) in
   let pool = Fiber.Pool.create () in

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -100,9 +100,9 @@ module Session = struct
     let compare x y = Id.compare x.id y.id
 
     let dyn_of_state f =
-      let open Dyn.Encoder in
+      let open Dyn in
       function
-      | Uninitialized -> constr "Uninitialized" []
+      | Uninitialized -> variant "Uninitialized" []
       | Initialized { init; state; closed } ->
         let record =
           record
@@ -111,11 +111,11 @@ module Session = struct
             ; ("closed", bool closed)
             ]
         in
-        constr "Initialized" [ record ]
+        variant "Initialized" [ record ]
 
     let to_dyn f { id; state; queries = _; send = _; on_upgrade = _; pool = _ }
         =
-      let open Dyn.Encoder in
+      let open Dyn in
       record [ ("id", Id.to_dyn id); ("state", dyn_of_state f state) ]
 
     let register_upgrade_callback t f = t.on_upgrade <- Some f

--- a/src/dune_rules/binary_kind.ml
+++ b/src/dune_rules/binary_kind.ml
@@ -28,9 +28,7 @@ let to_string = function
   | Plugin -> "plugin"
   | Js -> "js"
 
-let to_dyn t =
-  let open Dyn.Encoder in
-  constr (to_string t) []
+let to_dyn t = Dyn.variant (to_string t) []
 
 let encode t = Dune_lang.atom (to_string t)
 

--- a/src/dune_rules/bindings.ml
+++ b/src/dune_rules/bindings.ml
@@ -30,7 +30,7 @@ let empty = []
 let singleton x = [ Unnamed x ]
 
 let to_dyn dyn_of_a bindings =
-  let open Dyn.Encoder in
+  let open Dyn in
   Dyn.List
     (List.map bindings ~f:(function
       | Unnamed a -> dyn_of_a a

--- a/src/dune_rules/bindings.mli
+++ b/src/dune_rules/bindings.mli
@@ -20,7 +20,7 @@ val to_list : 'a t -> 'a list
 
 val singleton : 'a -> 'a t
 
-val to_dyn : 'a Dyn.Encoder.t -> 'a t Dyn.Encoder.t
+val to_dyn : 'a Dyn.builder -> 'a t Dyn.builder
 
 val decode : 'a Dune_lang.Decoder.t -> 'a t Dune_lang.Decoder.t
 

--- a/src/dune_rules/blang.ml
+++ b/src/dune_rules/blang.ml
@@ -20,7 +20,7 @@ module Op = struct
     | _, _ -> false
 
   let to_dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
     | Eq -> string "Eq"
     | Gt -> string "Gt"
@@ -60,14 +60,14 @@ let rec eval t ~dir ~f =
     Op.eval op (Value.L.compare_vals ~dir x y)
 
 let rec to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Const b -> constr "Const" [ bool b ]
-  | Expr e -> constr "Expr" [ String_with_vars.to_dyn e ]
-  | And t -> constr "And" (List.map ~f:to_dyn t)
-  | Or t -> constr "Or" (List.map ~f:to_dyn t)
+  | Const b -> variant "Const" [ bool b ]
+  | Expr e -> variant "Expr" [ String_with_vars.to_dyn e ]
+  | And t -> variant "And" (List.map ~f:to_dyn t)
+  | Or t -> variant "Or" (List.map ~f:to_dyn t)
   | Compare (o, s1, s2) ->
-    constr "Compare"
+    variant "Compare"
       [ Op.to_dyn o; String_with_vars.to_dyn s1; String_with_vars.to_dyn s2 ]
 
 let ops =

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -45,12 +45,12 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
         in
         Dyn.Tuple
           [ Path.Source.to_dyn (Path.Build.drop_build_context_exn dir)
-          ; Dyn.Encoder.option Module_name.to_dyn
+          ; Dyn.option Module_name.to_dyn
               (match Lib_info.main_module_name info with
               | From _ -> None
               | This x -> x)
           ; Dyn.Bool is_multi_dir
-          ; Dyn.Encoder.option Module_name.to_dyn special_builtin_support
+          ; Dyn.option Module_name.to_dyn special_builtin_support
           ])
   in
   Format.asprintf "%a@." Pp.to_fmt
@@ -69,7 +69,7 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
           ; def "local_libraries" (List locals)
           ; Pp.nop
           ; def "link_flags"
-              (let open Dyn.Encoder in
+              (let open Dyn in
               list (pair string (list string)) link_flags)
           ]))
 

--- a/src/dune_rules/check_rules.ml
+++ b/src/dune_rules/check_rules.ml
@@ -5,8 +5,8 @@ let dev_files =
   let exts = [ Ml_kind.cmt_ext Impl; Ml_kind.cmt_ext Intf; Cm_kind.ext Cmi ] in
   let id =
     lazy
-      (let open Dyn.Encoder in
-      constr "dev_files" (List.map ~f:string exts))
+      (let open Dyn in
+      variant "dev_files" (List.map ~f:string exts))
   in
   Predicate.create ~id ~f:(fun p ->
       let ext = Filename.extension p in

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -16,9 +16,9 @@ module Kind = struct
     | Opam of Opam.t
 
   let to_dyn : t -> Dyn.t = function
-    | Default -> Dyn.Encoder.string "default"
+    | Default -> Dyn.string "default"
     | Opam o ->
-      Dyn.Encoder.(
+      Dyn.(
         record [ ("root", option string o.root); ("switch", string o.switch) ])
 end
 
@@ -117,7 +117,7 @@ let hash t = Context_name.hash t.name
 let build_context t = t.build_context
 
 let to_dyn t : Dyn.t =
-  let open Dyn.Encoder in
+  let open Dyn in
   let path = Path.to_dyn in
   record
     [ ("name", Context_name.to_dyn t.name)
@@ -240,7 +240,7 @@ end = struct
 
       let to_dyn (env, root, switch) =
         Dyn.Tuple
-          [ Env.to_dyn env; Dyn.Encoder.(option string root); String switch ]
+          [ Env.to_dyn env; Dyn.(option string root); String switch ]
     end in
     let memo = Memo.create "opam-env" ~input:(module Input) impl in
     fun ~env ~root ~switch -> Memo.exec memo (env, root, switch)

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -239,8 +239,7 @@ end = struct
       let hash (env, root, switch) = Hashtbl.hash (Env.hash env, root, switch)
 
       let to_dyn (env, root, switch) =
-        Dyn.Tuple
-          [ Env.to_dyn env; Dyn.(option string root); String switch ]
+        Dyn.Tuple [ Env.to_dyn env; Dyn.(option string root); String switch ]
     end in
     let memo = Memo.create "opam-env" ~input:(module Input) impl in
     fun ~env ~root ~switch -> Memo.exec memo (env, root, switch)

--- a/src/dune_rules/coq_lib_name.ml
+++ b/src/dune_rules/coq_lib_name.ml
@@ -28,7 +28,7 @@ let encode : t Dune_lang.Encoder.t =
 
 let pp x = Pp.text (to_string x)
 
-let to_dyn = Dyn.Encoder.(list string)
+let to_dyn = Dyn.(list string)
 
 module Rep = struct
   type nonrec t = t

--- a/src/dune_rules/coq_module.ml
+++ b/src/dune_rules/coq_module.ml
@@ -83,7 +83,7 @@ let obj_files x ~wrapper_name ~mode ~obj_dir ~obj_files_mode =
   @ native_objs
 
 let to_dyn { source; prefix; name } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("source", Path.Build.to_dyn source)
     ; ("prefix", list string prefix)

--- a/src/dune_rules/cram_exec.ml
+++ b/src/dune_rules/cram_exec.ml
@@ -224,8 +224,8 @@ let read_exit_codes_and_prefix_maps file =
         | Some s -> s
         | None ->
           Code_error.raise "invalid metadata file"
-            [ ("entries", Dyn.Encoder.string s)
-            ; ("exit_code", Dyn.Encoder.string exit_code)
+            [ ("entries", Dyn.string s)
+            ; ("exit_code", Dyn.string exit_code)
             ]
       in
       loop ({ exit_code; build_path_prefix_map } :: acc) entries
@@ -233,7 +233,7 @@ let read_exit_codes_and_prefix_maps file =
     | [] ->
       List.rev acc
     | [ _ ] ->
-      Code_error.raise "odd number of elements" [ ("s", Dyn.Encoder.string s) ]
+      Code_error.raise "odd number of elements" [ ("s", Dyn.string s) ]
   in
   loop [] (String.split ~on:'\000' s)
 

--- a/src/dune_rules/cram_exec.ml
+++ b/src/dune_rules/cram_exec.ml
@@ -224,16 +224,13 @@ let read_exit_codes_and_prefix_maps file =
         | Some s -> s
         | None ->
           Code_error.raise "invalid metadata file"
-            [ ("entries", Dyn.string s)
-            ; ("exit_code", Dyn.string exit_code)
-            ]
+            [ ("entries", Dyn.string s); ("exit_code", Dyn.string exit_code) ]
       in
       loop ({ exit_code; build_path_prefix_map } :: acc) entries
     | [ "" ]
     | [] ->
       List.rev acc
-    | [ _ ] ->
-      Code_error.raise "odd number of elements" [ ("s", Dyn.string s) ]
+    | [ _ ] -> Code_error.raise "odd number of elements" [ ("s", Dyn.string s) ]
   in
   loop [] (String.split ~on:'\000' s)
 

--- a/src/dune_rules/dep_conf.mli
+++ b/src/dune_rules/dep_conf.mli
@@ -22,4 +22,4 @@ val remove_locs : t -> t
 
 include Dune_lang.Conv.S with type t := t
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Dyn.builder

--- a/src/dune_rules/dep_graph.ml
+++ b/src/dune_rules/dep_graph.ml
@@ -16,7 +16,7 @@ let deps_of t (m : Module.t) =
     Code_error.raise "Ocamldep.Dep_graph.deps_of"
       [ ("dir", Path.Build.to_dyn t.dir)
       ; ( "modules"
-        , Dyn.Encoder.(list Module_name.Unique.to_dyn)
+        , Dyn.(list Module_name.Unique.to_dyn)
             (Module.Obj_map.keys t.per_module |> List.map ~f:Module.obj_name) )
       ; ("m", Module.to_dyn m)
       ]

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -73,7 +73,7 @@ let mlds t (doc : Documentation.t) =
     Code_error.raise "Dir_contents.mlds"
       [ ("doc", Loc.to_dyn_hum doc.loc)
       ; ( "available"
-        , Dyn.Encoder.(list Loc.to_dyn_hum)
+        , Dyn.(list Loc.to_dyn_hum)
             (List.map map ~f:(fun (d, _) -> d.Documentation.loc)) )
       ]
 

--- a/src/dune_rules/dune_env.ml
+++ b/src/dune_rules/dune_env.ml
@@ -144,7 +144,7 @@ module Stanza = struct
   let hash { loc = _; rules } =
     List.hash (Tuple.T2.hash hash_pattern hash_config) rules
 
-  let to_dyn = Dyn.Encoder.opaque
+  let to_dyn = Dyn.opaque
 
   let equal { loc = _; rules } t =
     List.equal (Tuple.T2.equal equal_pattern equal_config) rules t.rules

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -417,9 +417,7 @@ module Mode_conf = struct
     | Native -> "native"
     | Best -> "best"
 
-  let to_dyn t =
-    let open Dyn.Encoder in
-    constr (to_string t) []
+  let to_dyn t = Dyn.variant (to_string t) []
 
   let encode t = Dune_lang.atom (to_string t)
 
@@ -1218,7 +1216,7 @@ module Executables = struct
           | Eq -> Poly.compare a.kind b.kind
           | ne -> ne)
 
-      let to_dyn _ = Dyn.opaque
+      let to_dyn = Dyn.opaque
     end
 
     include T
@@ -1280,7 +1278,7 @@ module Executables = struct
       match t with
       | Byte_complete -> Dyn.Variant ("Byte_complete", [])
       | Other { mode; kind } ->
-        let open Dyn.Encoder in
+        let open Dyn in
         Variant
           ( "Other"
           , [ record
@@ -1389,7 +1387,7 @@ module Executables = struct
         ~desc:"private extension to handle Dune bootstrap"
         [ ((0, 1), `Since (2, 0)) ]
     in
-    Dune_project.Extension.register syntax (return ((), [])) Dyn.Encoder.unit
+    Dune_project.Extension.register syntax (return ((), [])) Dyn.unit
 
   let common =
     let* dune_version = Dune_lang.Syntax.get_exn Stanza.syntax in
@@ -1666,7 +1664,7 @@ module Rule = struct
         ~desc:"experimental support for directory targets"
         [ ((0, 1), `Since (3, 0)) ]
     in
-    Dune_project.Extension.register syntax (return ((), [])) Dyn.Encoder.unit
+    Dune_project.Extension.register syntax (return ((), [])) Dyn.unit
 
   let long_form =
     let* deps =

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -25,7 +25,7 @@ end = struct
          let invalid_template stage =
            Code_error.raise
              "Jbuild_plugin.replace_in_template: invalid template"
-             [ ("stage", Dyn.Encoder.string stage) ]
+             [ ("stage", Dyn.string stage) ]
          in
          let rec parse1 = function
            | `Text s :: xs -> parse2 s xs

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -212,7 +212,7 @@ module Lib = struct
   let info dp = dp.info
 
   let to_dyn { info; modules; main_module_name } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("info", Lib_info.to_dyn Path.to_dyn info)
       ; ("modules", option Modules.to_dyn modules)
@@ -244,7 +244,7 @@ module Deprecated_library_name = struct
       ]
 
   let to_dyn { loc = _; old_public_name; new_public_name } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("old_public_name", Lib_name.to_dyn old_public_name)
       ; ("new_public_name", Lib_name.to_dyn new_public_name)
@@ -286,12 +286,12 @@ module Entry = struct
     ]
 
   let to_dyn x =
-    let open Dyn.Encoder in
+    let open Dyn in
     match x with
-    | Library lib -> constr "Library" [ Lib.to_dyn lib ]
+    | Library lib -> variant "Library" [ Lib.to_dyn lib ]
     | Deprecated_library_name lib ->
-      constr "Deprecated_library_name" [ Deprecated_library_name.to_dyn lib ]
-    | Hidden_library lib -> constr "Hidden_library" [ Lib.to_dyn lib ]
+      variant "Deprecated_library_name" [ Deprecated_library_name.to_dyn lib ]
+    | Hidden_library lib -> variant "Hidden_library" [ Lib.to_dyn lib ]
 end
 
 type t =
@@ -400,7 +400,7 @@ let encode ~dune_version { entries; name; version; dir; sections; sites; files }
   prepend_version ~dune_version (List.concat [ sexp; entries ])
 
 let to_dyn { entries; name; version; dir; sections; sites; files } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("entries", list Entry.to_dyn (Lib_name.Map.values entries))
     ; ("name", Package.Name.to_dyn name)
@@ -446,8 +446,8 @@ module Or_meta = struct
       t
 
   let to_dyn x =
-    let open Dyn.Encoder in
+    let open Dyn in
     match x with
-    | Use_meta -> constr "Use_meta" []
-    | Dune_package t -> constr "Dune_package" [ to_dyn t ]
+    | Use_meta -> variant "Use_meta" []
+    | Dune_package t -> variant "Dune_package" [ to_dyn t ]
 end

--- a/src/dune_rules/dune_package.mli
+++ b/src/dune_rules/dune_package.mli
@@ -27,7 +27,7 @@ module Lib : sig
     -> modules:Modules.t
     -> t
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 end
 
 module Deprecated_library_name : sig
@@ -37,7 +37,7 @@ module Deprecated_library_name : sig
     ; new_public_name : Lib_name.t
     }
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 end
 
 module Entry : sig
@@ -59,7 +59,7 @@ module Entry : sig
 
   val loc : t -> Loc.t
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 end
 
 type t =
@@ -72,7 +72,7 @@ type t =
   ; files : (Section.t * Install.Dst.t list) list
   }
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Dyn.builder
 
 module Or_meta : sig
   type nonrec t =
@@ -84,5 +84,5 @@ module Or_meta : sig
 
   val load : Dpath.t -> t Or_exn.t
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 end

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -17,7 +17,7 @@ module Rule = struct
     }
 
   let to_dyn { preds_required; preds_forbidden; value } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("preds_required", Ps.to_dyn preds_required)
       ; ("preds_forbidden", Ps.to_dyn preds_forbidden)
@@ -57,7 +57,7 @@ module Rules = struct
     }
 
   let to_dyn { set_rules; add_rules } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("set_rules", list Rule.to_dyn set_rules)
       ; ("add_rules", list Rule.to_dyn add_rules)
@@ -111,7 +111,7 @@ module Config = struct
     }
 
   let to_dyn { vars; preds } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("vars", String.Map.to_dyn Rules.to_dyn vars)
       ; ("preds", Ps.to_dyn preds)
@@ -147,11 +147,11 @@ module Unavailable_reason = struct
     | Invalid_dune_package of exn
 
   let to_dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
-    | Not_found -> constr "Not_found" []
+    | Not_found -> variant "Not_found" []
     | Invalid_dune_package why ->
-      constr "Invalid_dune_package" [ Exn.to_dyn why ]
+      variant "Invalid_dune_package" [ Exn.to_dyn why ]
 end
 
 let builtin_for_dune : Dune_package.t =
@@ -602,7 +602,7 @@ let memo =
   let module Input = struct
     type t = DB.t * Package.Name.t
 
-    let to_dyn = Dyn.Encoder.opaque
+    let to_dyn = Dyn.opaque
 
     let hash = Tuple.T2.hash DB.hash Package.Name.hash
 

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -8,20 +8,18 @@ end)
 
 include Meta_parser
 
-let dyn_of_action =
-  let open Dyn.Encoder in
-  function
-  | Set -> constr "Set" []
-  | Add -> constr "Add" []
+let dyn_of_action = function
+  | Set -> Dyn.variant "Set" []
+  | Add -> Dyn.variant "Add" []
 
 let dyn_of_predicate =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Pos s -> constr "Pos" [ String s ]
-  | Neg s -> constr "Neg" [ String s ]
+  | Pos s -> variant "Pos" [ String s ]
+  | Neg s -> variant "Neg" [ String s ]
 
 let dyn_of_rule { var; predicates; action; value } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("var", string var)
     ; ("predicates", list dyn_of_predicate predicates)
@@ -30,14 +28,14 @@ let dyn_of_rule { var; predicates; action; value } =
     ]
 
 let rec dyn_of_entry (entry : entry) =
-  let open Dyn.Encoder in
+  let open Dyn in
   match entry with
-  | Comment c -> constr "Comment" [ string c ]
-  | Rule r -> constr "Rule" [ dyn_of_rule r ]
-  | Package p -> constr "Package" [ to_dyn p ]
+  | Comment c -> variant "Comment" [ string c ]
+  | Rule r -> variant "Rule" [ dyn_of_rule r ]
+  | Package p -> variant "Package" [ to_dyn p ]
 
 and to_dyn { name; entries } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("name", option Lib_name.to_dyn name)
     ; ("entries", list dyn_of_entry entries)
@@ -61,7 +59,7 @@ module Simplified = struct
       }
 
     let to_dyn { set_rules; add_rules } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("set_rules", list dyn_of_rule set_rules)
         ; ("add_rules", list dyn_of_rule add_rules)
@@ -79,7 +77,7 @@ module Simplified = struct
   let hash = Poly.hash
 
   let rec to_dyn { name; vars; subs } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("name", option Lib_name.to_dyn name)
       ; ("vars", String.Map.to_dyn Rules.to_dyn vars)

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -200,8 +200,8 @@ let define_all_alias ~dir ~scope ~js_targets =
     let pred =
       let id =
         lazy
-          (let open Dyn.Encoder in
-          constr "exclude"
+          (let open Dyn in
+          variant "exclude"
             (List.map ~f:(fun p -> Path.Build.to_dyn p) js_targets))
       in
       List.iter js_targets ~f:(fun js_target ->

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -62,7 +62,7 @@ module Mode_conf = struct
 
     let compare (a : t) b = Poly.compare a b
 
-    let to_dyn _ = Dyn.opaque
+    let to_dyn = Dyn.opaque
   end
 
   include T

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -276,7 +276,7 @@ end = struct
       | e -> e
 
     let to_dyn { path; name } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record [ ("path", Path.to_dyn path); ("name", Lib_name.to_dyn name) ]
   end
 
@@ -340,7 +340,7 @@ module Hidden = struct
     { lib; path; reason }
 
   let to_dyn to_dyn { lib; path; reason } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("lib", to_dyn lib)
       ; ("path", Path.to_dyn path)
@@ -364,13 +364,13 @@ module Status = struct
     | Invalid of exn
 
   let to_dyn t =
-    let open Dyn.Encoder in
+    let open Dyn in
     match t with
-    | Invalid e -> constr "Invalid" [ Exn.to_dyn e ]
-    | Not_found -> constr "Not_found" []
+    | Invalid e -> variant "Invalid" [ Exn.to_dyn e ]
+    | Not_found -> variant "Not_found" []
     | Hidden { lib = _; path; reason } ->
-      constr "Hidden" [ Path.to_dyn path; string reason ]
-    | Found t -> constr "Found" [ to_dyn t ]
+      variant "Hidden" [ Path.to_dyn path; string reason ]
+    | Found t -> variant "Found" [ to_dyn t ]
 end
 
 type db =
@@ -1313,7 +1313,7 @@ end = struct
     let module Input = struct
       type t = db * Lib_name.t * Path.t Lib_info.t * string option
 
-      let to_dyn = Dyn.Encoder.opaque
+      let to_dyn = Dyn.opaque
 
       let hash x = Poly.hash x
 
@@ -1921,14 +1921,14 @@ module DB = struct
     let redirect db lib = Redirect (db, lib)
 
     let to_dyn x =
-      let open Dyn.Encoder in
+      let open Dyn in
       match x with
-      | Not_found -> constr "Not_found" []
-      | Invalid e -> constr "Invalid" [ Exn.to_dyn e ]
-      | Found lib -> constr "Found" [ Lib_info.to_dyn Path.to_dyn lib ]
+      | Not_found -> variant "Not_found" []
+      | Invalid e -> variant "Invalid" [ Exn.to_dyn e ]
+      | Found lib -> variant "Found" [ Lib_info.to_dyn Path.to_dyn lib ]
       | Hidden h ->
-        constr "Hidden" [ Hidden.to_dyn (Lib_info.to_dyn Path.to_dyn) h ]
-      | Redirect (_, (_, name)) -> constr "Redirect" [ Lib_name.to_dyn name ]
+        variant "Hidden" [ Hidden.to_dyn (Lib_info.to_dyn Path.to_dyn) h ]
+      | Redirect (_, (_, name)) -> variant "Redirect" [ Lib_name.to_dyn name ]
   end
 
   type t = db
@@ -1949,7 +1949,7 @@ module DB = struct
   let create_from_findlib ~lib_config ~projects_by_package findlib =
     create () ~parent:None ~lib_config ~projects_by_package
       ~modules_of_lib:
-        (let t = Fdecl.create Dyn.Encoder.opaque in
+        (let t = Fdecl.create Dyn.opaque in
          Fdecl.set t (fun ~dir ~name ->
              Code_error.raise "external libraries need no modules"
                [ ("dir", Path.Build.to_dyn dir)

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -171,7 +171,7 @@ module DB : sig
 
     val found : Lib_info.external_ -> t
 
-    val to_dyn : t Dyn.Encoder.t
+    val to_dyn : t Dyn.builder
 
     val redirect : db option -> Loc.t * Lib_name.t -> t
   end

--- a/src/dune_rules/lib_dep.ml
+++ b/src/dune_rules/lib_dep.ml
@@ -65,7 +65,7 @@ module Select = struct
            loop Lib_name.Set.empty Lib_name.Set.empty preds)
 
     let to_dyn { required; forbidden; file } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("required", Lib_name.Set.to_dyn required)
         ; ("forbidden", Lib_name.Set.to_dyn forbidden)
@@ -80,7 +80,7 @@ module Select = struct
     }
 
   let to_dyn { result_fn; choices; loc = _ } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("result_fn", string result_fn)
       ; ("choices", list Choice.to_dyn choices)
@@ -103,11 +103,11 @@ type t =
 let equal = Poly.equal
 
 let to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
   | Direct (_, name) -> Lib_name.to_dyn name
-  | Re_export (_, name) -> constr "re_export" [ Lib_name.to_dyn name ]
-  | Select s -> constr "select" [ Select.to_dyn s ]
+  | Re_export (_, name) -> variant "re_export" [ Lib_name.to_dyn name ]
+  | Select s -> variant "select" [ Select.to_dyn s ]
 
 let direct x = Direct x
 

--- a/src/dune_rules/lib_file_deps.ml
+++ b/src/dune_rules/lib_file_deps.ml
@@ -27,8 +27,8 @@ module Group = struct
           (* we cannot use globs because of bootstrapping. *)
           let id =
             lazy
-              (let open Dyn.Encoder in
-              constr "Lib_file_deps" [ string ext ])
+              (let open Dyn in
+              variant "Lib_file_deps" [ string ext ])
           in
           let pred =
             Predicate.create ~id ~f:(fun p ->

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -243,6 +243,6 @@ val create :
 
 val package : _ t -> Package.Name.t option
 
-val to_dyn : 'path Dyn.Encoder.t -> 'path t Dyn.Encoder.t
+val to_dyn : 'path Dyn.builder -> 'path t Dyn.builder
 
 val equal : 'a t -> 'a t -> bool

--- a/src/dune_rules/lib_kind.ml
+++ b/src/dune_rules/lib_kind.ml
@@ -9,7 +9,7 @@ module Ppx_args = struct
       }
 
     let to_dyn x =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("name", string x.name); ("value", String_with_vars.to_dyn x.value) ]
 
@@ -37,7 +37,7 @@ module Ppx_args = struct
   let empty = { cookies = [] }
 
   let to_dyn { cookies } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("cookies", list Cookie.to_dyn cookies) ]
 
   let decode =
@@ -61,11 +61,11 @@ type t =
 let equal = Poly.equal
 
 let to_dyn x =
-  let open Dyn.Encoder in
+  let open Dyn in
   match x with
-  | Normal -> constr "Normal" []
-  | Ppx_deriver args -> constr "Ppx_deriver" [ Ppx_args.to_dyn args ]
-  | Ppx_rewriter args -> constr "Ppx_rewriter" [ Ppx_args.to_dyn args ]
+  | Normal -> variant "Normal" []
+  | Ppx_deriver args -> variant "Ppx_deriver" [ Ppx_args.to_dyn args ]
+  | Ppx_rewriter args -> variant "Ppx_rewriter" [ Ppx_args.to_dyn args ]
 
 let decode =
   let open Dune_lang.Decoder in

--- a/src/dune_rules/lib_kind.mli
+++ b/src/dune_rules/lib_kind.mli
@@ -18,7 +18,7 @@ type t =
   | Ppx_deriver of Ppx_args.t
   | Ppx_rewriter of Ppx_args.t
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Dyn.builder
 
 val equal : t -> t -> bool
 

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -17,7 +17,7 @@ module File = struct
   let make dialect path = { dialect; path }
 
   let to_dyn { path; dialect } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("path", Path.to_dyn path); ("dialect", Dialect.to_dyn dialect) ]
 end
 
@@ -40,7 +40,7 @@ module Kind = struct
     | Wrapped_compat -> "wrapped_compat"
     | Root -> "root"
 
-  let to_dyn t = Dyn.Encoder.string (to_string t)
+  let to_dyn t = Dyn.string (to_string t)
 
   let encode t = Dune_lang.Encoder.string (to_string t)
 
@@ -76,7 +76,7 @@ module Source = struct
     }
 
   let to_dyn { name; files } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("name", Module_name.to_dyn name)
       ; ("files", Ml_kind.Dict.to_dyn (option File.to_dyn) files)
@@ -150,7 +150,7 @@ let of_source ?obj_name ~visibility ~(kind : Kind.t) (source : Source.t) =
   | (Alias | Impl_vmodule | Wrapped_compat), Some _, Some _
   | (Intf_only | Virtual), Some _, _
   | (Intf_only | Virtual), _, None ->
-    let open Dyn.Encoder in
+    let open Dyn in
     Code_error.raise "Module.make: invalid kind, impl, intf combination"
       [ ("name", Module_name.to_dyn source.name)
       ; ("kind", Kind.to_dyn kind)
@@ -203,11 +203,10 @@ let src_dir t = Source.src_dir t.source
 let set_pp t pp = { t with pp }
 
 let to_dyn { source; obj_name; pp; visibility; kind } =
-  let open Dyn.Encoder in
-  record
+  Dyn.record
     [ ("source", Source.to_dyn source)
     ; ("obj_name", Module_name.Unique.to_dyn obj_name)
-    ; ("pp", (option string) (Option.map ~f:(fun _ -> "has pp") pp))
+    ; ("pp", Dyn.(option string) (Option.map ~f:(fun _ -> "has pp") pp))
     ; ("visibility", Visibility.to_dyn visibility)
     ; ("kind", Kind.to_dyn kind)
     ]

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -56,7 +56,7 @@ module Stdlib = struct
        { modules; main_module_name; exit_module; unwrapped })
 
   let to_dyn { modules; unwrapped; exit_module; main_module_name } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("modules", Module.Name_map.to_dyn modules)
       ; ("unwrapped", Module_name.Set.to_dyn unwrapped)
@@ -303,7 +303,7 @@ module Wrapped = struct
 
   let to_dyn
       { modules; wrapped_compat; alias_module; main_module_name; wrapped } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("modules", Module.Name_map.to_dyn modules)
       ; ("wrapped_compat", Module.Name_map.to_dyn wrapped_compat)
@@ -474,16 +474,16 @@ let decode ~version ~src_dir ~implements =
       ]
 
 let rec to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Singleton m -> constr "Singleton" [ Module.to_dyn m ]
-  | Unwrapped m -> constr "Unwrapped" [ Module.Name_map.to_dyn m ]
-  | Wrapped w -> constr "Wrapped" [ Wrapped.to_dyn w ]
-  | Stdlib s -> constr "Stdlib" [ Stdlib.to_dyn s ]
-  | Impl impl -> constr "Impl" [ dyn_of_impl impl ]
+  | Singleton m -> variant "Singleton" [ Module.to_dyn m ]
+  | Unwrapped m -> variant "Unwrapped" [ Module.Name_map.to_dyn m ]
+  | Wrapped w -> variant "Wrapped" [ Wrapped.to_dyn w ]
+  | Stdlib s -> variant "Stdlib" [ Stdlib.to_dyn s ]
+  | Impl impl -> variant "Impl" [ dyn_of_impl impl ]
 
 and dyn_of_impl { impl; vlib } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record [ ("impl", to_dyn impl); ("vlib", to_dyn vlib) ]
 
 let rec lib_interface = function

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -45,7 +45,7 @@ module External = struct
   let public_cmi_dir t = Option.value ~default:t.public_dir t.public_cmi_dir
 
   let to_dyn { public_dir; private_dir; public_cmi_dir } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("public_dir", Path.to_dyn public_dir)
       ; ("private_dir", option Path.to_dyn private_dir)
@@ -118,7 +118,7 @@ module Local = struct
 
   let to_dyn { dir; obj_dir; native_dir; byte_dir; public_cmi_dir; private_lib }
       =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("dir", Path.Build.to_dyn dir)
       ; ("obj_dir", Path.Build.to_dyn obj_dir)
@@ -243,11 +243,11 @@ let dir = get_path ~l:Local.dir ~e:External.dir
 let obj_dir = get_path ~l:Local.obj_dir ~e:External.obj_dir
 
 let to_dyn (type path) (t : path t) =
-  let open Dyn.Encoder in
+  let open Dyn in
   match t with
-  | Local e -> constr "Local" [ Local.to_dyn e ]
-  | Local_as_path e -> constr "Local_as_path" [ Local.to_dyn e ]
-  | External e -> constr "External" [ External.to_dyn e ]
+  | Local e -> variant "Local" [ Local.to_dyn e ]
+  | Local_as_path e -> variant "Local_as_path" [ Local.to_dyn e ]
+  | External e -> variant "External" [ External.to_dyn e ]
 
 let convert_to_external (t : Path.Build.t t) ~dir =
   match t with

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -304,8 +304,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
     >>| (* Extend the dependency stack as we don't have locations at this
            point *)
     Resolve.push_stack_frame ~human_readable_description:(fun () ->
-        Dyn.pp
-          (List [ String "pps"; Dyn.(list Lib_name.to_dyn) pp_names ]))
+        Dyn.pp (List [ String "pps"; Dyn.(list Lib_name.to_dyn) pp_names ]))
   in
   (* CR-someday diml: what we should do is build the .cmx/.cmo once and for all
      at the point where the driver is defined. *)

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -305,7 +305,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
            point *)
     Resolve.push_stack_frame ~human_readable_description:(fun () ->
         Dyn.pp
-          (List [ String "pps"; Dyn.Encoder.(list Lib_name.to_dyn) pp_names ]))
+          (List [ String "pps"; Dyn.(list Lib_name.to_dyn) pp_names ]))
   in
   (* CR-someday diml: what we should do is build the .cmx/.cmo once and for all
      at the point where the driver is defined. *)

--- a/src/dune_rules/profile.ml
+++ b/src/dune_rules/profile.ml
@@ -54,8 +54,8 @@ let is_inline_test = function
   | _ -> true
 
 let to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Dev -> constr "Dev" []
-  | Release -> constr "Release" []
-  | User_defined s -> constr "User_defined" [ string s ]
+  | Dev -> variant "Dev" []
+  | Release -> variant "Release" []
+  | User_defined s -> variant "User_defined" [ string s ]

--- a/src/dune_rules/resolve.mli
+++ b/src/dune_rules/resolve.mli
@@ -102,7 +102,7 @@ val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
 val hash : ('a -> int) -> 'a t -> int
 
-val to_dyn : ('a -> Dyn.t) -> 'a t Dyn.Encoder.t
+val to_dyn : ('a -> Dyn.t) -> 'a t Dyn.builder
 
 val of_result : ('a, exn) result -> 'a t
 

--- a/src/dune_rules/scheme.ml
+++ b/src/dune_rules/scheme.ml
@@ -150,7 +150,7 @@ let evaluate ~union_rules =
         Code_error.raise
           "Scheme attempted to generate rules in a directory it promised not \
            to touch"
-          [ ("directories", (Dyn.Encoder.list Path.Build.to_dyn) violations) ]);
+          [ ("directories", (Dyn.list Path.Build.to_dyn) violations) ]);
       Memo.Build.return (Evaluated.finite ~union_rules rules)
     | Thunk f -> f () >>= loop ~env
   in

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -246,7 +246,7 @@ module DB = struct
   let create ~projects_by_package ~context ~installed_libs ~modules_of_lib
       ~projects stanzas coq_stanzas =
     let open Memo.Build.O in
-    let t = Fdecl.create Dyn.Encoder.opaque in
+    let t = Fdecl.create Dyn.opaque in
     let public_libs =
       let lib_config = Context.lib_config context in
       public_libs t ~installed_libs ~lib_config ~projects_by_package

--- a/src/dune_rules/sub_system.ml
+++ b/src/dune_rules/sub_system.ml
@@ -26,7 +26,7 @@ module Register_backend (M : Backend) = struct
   include Comparable.Make (struct
     type t = M.t
 
-    let to_dyn _ = Dyn.opaque
+    let to_dyn = Dyn.opaque
 
     let compare a b =
       Lib.Id.compare (Lib.unique_id (M.lib a)) (Lib.unique_id (M.lib b))

--- a/src/dune_rules/sub_system_info.ml
+++ b/src/dune_rules/sub_system_info.ml
@@ -38,7 +38,7 @@ module Register (M : S) : sig end = struct
     match Sub_system_name.Table.get all name with
     | Some _ ->
       Code_error.raise "Sub_system_info.register: already registered"
-        [ ("name", Dyn.Encoder.string (Sub_system_name.to_string name)) ]
+        [ ("name", Dyn.string (Sub_system_name.to_string name)) ]
     | None -> (
       Sub_system_name.Table.set all ~key:name ~data:(Some (module M : S));
       let p = !record_parser in

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -572,7 +572,7 @@ let create_projects_by_package projects : Dune_project.t Package.Name.Map.t =
              (name, project)))
   |> Package.Name.Map.of_list_exn
 
-let modules_of_lib = Fdecl.create Dyn.Encoder.opaque
+let modules_of_lib = Fdecl.create Dyn.opaque
 
 let create ~(context : Context.t) ~host ~projects ~packages ~stanzas =
   let lib_config = Context.lib_config context in
@@ -580,7 +580,7 @@ let create ~(context : Context.t) ~host ~projects ~packages ~stanzas =
   let installed_libs =
     Lib.DB.create_from_findlib context.findlib ~lib_config ~projects_by_package
   in
-  let modules_of_lib_for_scope = Fdecl.create Dyn.Encoder.opaque in
+  let modules_of_lib_for_scope = Fdecl.create Dyn.opaque in
   let* scopes, public_libs =
     Scope.DB.create_from_stanzas ~projects ~projects_by_package ~context
       ~installed_libs ~modules_of_lib:modules_of_lib_for_scope stanzas

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -48,9 +48,7 @@ module Source = struct
   let pp_ml t ~include_dirs =
     let open Pp.O in
     let include_dirs =
-      Dyn.list
-        (fun d -> Dyn.string (Path.to_absolute_filename d))
-        include_dirs
+      Dyn.list (fun d -> Dyn.string (Path.to_absolute_filename d)) include_dirs
     in
     Pp.vbox ~indent:2
       (Pp.verbatim "Clflags.include_dirs :=" ++ Pp.cut ++ Dyn.pp include_dirs)

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -48,8 +48,8 @@ module Source = struct
   let pp_ml t ~include_dirs =
     let open Pp.O in
     let include_dirs =
-      Dyn.Encoder.list
-        (fun d -> Dyn.Encoder.string (Path.to_absolute_filename d))
+      Dyn.list
+        (fun d -> Dyn.string (Path.to_absolute_filename d))
         include_dirs
     in
     Pp.vbox ~indent:2
@@ -80,7 +80,7 @@ let pp_flags t =
         ~scope pps
     in
     let ppx =
-      Dyn.Encoder.list Dyn.Encoder.string
+      Dyn.list Dyn.string
         [ Path.to_absolute_filename (Path.build exe) :: "--as-ppx" :: flags
           |> String.concat ~sep:" "
         ]

--- a/src/dune_rules/visibility.ml
+++ b/src/dune_rules/visibility.ml
@@ -9,7 +9,7 @@ let to_string = function
   | Public -> "public"
   | Private -> "private"
 
-let to_dyn t = Dyn.Encoder.string (to_string t)
+let to_dyn t = Dyn.string (to_string t)
 
 let encode =
   let open Dune_lang.Encoder in

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -59,7 +59,7 @@ module Context = struct
       ; merlin : bool
       }
 
-    let to_dyn = Dyn.Encoder.opaque
+    let to_dyn = Dyn.opaque
 
     let equal
         { loc = _
@@ -187,7 +187,7 @@ module Context = struct
       }
 
     let to_dyn { base; switch; root } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("base", Common.to_dyn base)
         ; ("switch", string switch)
@@ -259,10 +259,10 @@ module Context = struct
   let hash = Hashtbl.hash
 
   let to_dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
-    | Default d -> constr "Default" [ Default.to_dyn d ]
-    | Opam o -> constr "Opam" [ Opam.to_dyn o ]
+    | Default d -> variant "Default" [ Default.to_dyn d ]
+    | Opam o -> variant "Opam" [ Opam.to_dyn o ]
 
   let equal x y =
     match (x, y) with
@@ -345,7 +345,7 @@ type t =
   }
 
 let to_dyn { merlin_context; contexts; env; config } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("merlin_context", option Context_name.to_dyn merlin_context)
     ; ("contexts", list Context.to_dyn contexts)
@@ -390,7 +390,7 @@ module Clflags = struct
       ; config_from_command_line
       ; config_from_config_file
       } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("x", option Context_name.to_dyn x)
       ; ("profile", option Profile.to_dyn profile)

--- a/src/dune_rules/wrapped.ml
+++ b/src/dune_rules/wrapped.ml
@@ -29,7 +29,7 @@ let to_bool = function
   | Yes_with_transition _ -> true
 
 let to_dyn =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Simple s -> constr "Simple" [ bool s ]
-  | Yes_with_transition s -> constr "Yes_with_transition" [ string s ]
+  | Simple s -> variant "Simple" [ bool s ]
+  | Yes_with_transition s -> variant "Yes_with_transition" [ string s ]

--- a/src/dune_util/log.ml
+++ b/src/dune_util/log.ml
@@ -14,7 +14,7 @@ type real =
   ; ppf : Format.formatter
   }
 
-let t = Fdecl.create Dyn.Encoder.opaque
+let t = Fdecl.create Dyn.opaque
 
 let verbose = ref false
 

--- a/src/dune_util/ml_kind.ml
+++ b/src/dune_util/ml_kind.ml
@@ -51,6 +51,6 @@ module Dict = struct
     f Intf t.intf
 
   let to_dyn f { impl; intf } =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("impl", f impl); ("intf", f intf) ]
 end

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -42,9 +42,7 @@ let get_error_from_exn = function
         ~dyn_without_loc:
           (Dyn.Tuple
              [ String "internal dependency cycle"
-             ; Record
-                 [ ("frames", Dyn.(list Memo.Stack_frame.to_dyn) frames)
-                 ]
+             ; Record [ ("frames", Dyn.(list Memo.Stack_frame.to_dyn) frames) ]
              ])
     | Some last ->
       let first = List.hd cycle in

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -43,7 +43,7 @@ let get_error_from_exn = function
           (Dyn.Tuple
              [ String "internal dependency cycle"
              ; Record
-                 [ ("frames", Dyn.Encoder.(list Memo.Stack_frame.to_dyn) frames)
+                 [ ("frames", Dyn.(list Memo.Stack_frame.to_dyn) frames)
                  ]
              ])
     | Some last ->

--- a/src/dune_util/stringlike.ml
+++ b/src/dune_util/stringlike.ml
@@ -7,9 +7,7 @@ module Make (S : Stringlike_intf.S_base) = struct
     match S.of_string_opt s with
     | Some s -> s
     | None ->
-      Code_error.raise
-        ("Invalid " ^ S.module_ ^ ".t")
-        [ ("s", Dyn.string s) ]
+      Code_error.raise ("Invalid " ^ S.module_ ^ ".t") [ ("s", Dyn.string s) ]
 
   let error_message s = Printf.sprintf "%S is an invalid %s." s S.description
 

--- a/src/dune_util/stringlike.ml
+++ b/src/dune_util/stringlike.ml
@@ -9,7 +9,7 @@ module Make (S : Stringlike_intf.S_base) = struct
     | None ->
       Code_error.raise
         ("Invalid " ^ S.module_ ^ ".t")
-        [ ("s", Dyn.Encoder.string s) ]
+        [ ("s", Dyn.string s) ]
 
   let error_message s = Printf.sprintf "%S is an invalid %s." s S.description
 
@@ -56,5 +56,5 @@ module Make (S : Stringlike_intf.S_base) = struct
 
   let encode t = Dune_lang.Encoder.(string (to_string t))
 
-  let to_dyn t = Dyn.Encoder.string (to_string t)
+  let to_dyn t = Dyn.string (to_string t)
 end

--- a/src/dune_util/value.ml
+++ b/src/dune_util/value.ml
@@ -15,12 +15,10 @@ let compare x y =
   | _, Dir _ -> Gt
   | Path x, Path y -> Path.compare x y
 
-let to_dyn =
-  let open Dyn.Encoder in
-  function
-  | String s -> constr "string" [ string s ]
-  | Path p -> constr "path" [ Path.to_dyn p ]
-  | Dir p -> constr "dir" [ Path.to_dyn p ]
+let to_dyn = function
+  | String s -> Dyn.variant "string" [ String s ]
+  | Path p -> Dyn.variant "path" [ Path.to_dyn p ]
+  | Dir p -> Dyn.variant "dir" [ Path.to_dyn p ]
 
 let string_of_path ~dir p = Path.reach ~from:dir p
 

--- a/src/fiber/fiber.ml
+++ b/src/fiber/fiber.ml
@@ -465,7 +465,7 @@ module Var = struct
 
   let unset var f k = EC.set_vars (Univ_map.remove (EC.vars ()) var) f () k
 
-  let create () = create ~name:"var" (fun _ -> Dyn.Encoder.string "var")
+  let create () = create ~name:"var" (fun _ -> Dyn.string "var")
 end
 
 (* This function violates the invariant that every fiber either returns a value

--- a/src/fsevents/fsevents.ml
+++ b/src/fsevents/fsevents.ml
@@ -142,7 +142,7 @@ module Event = struct
         ; item_is_last_hardlink
         ; item_cloned
         } =
-      let open Dyn.Encoder in
+      let open Dyn in
       record
         [ ("must_scan_subdirs", bool must_scan_subdirs)
         ; ("user_dropped", bool user_dropped)
@@ -173,7 +173,7 @@ module Event = struct
   external raw : Int32.t -> Raw.t = "dune_fsevents_raw"
 
   let to_dyn_raw t =
-    let open Dyn.Encoder in
+    let open Dyn in
     record [ ("flags", Raw.to_dyn (raw t.flags)); ("path", string t.path) ]
 
   let id t = t.id
@@ -186,7 +186,7 @@ module Event = struct
     | Dir_and_descendants
 
   let dyn_of_kind kind =
-    Dyn.Encoder.string
+    Dyn.string
       (match kind with
       | Dir -> "Dir"
       | File -> "File"
@@ -207,7 +207,7 @@ module Event = struct
   let action t = action t.flags
 
   let dyn_of_action a =
-    Dyn.Encoder.string
+    Dyn.string
       (match a with
       | Create -> "Create"
       | Remove -> "Remove"
@@ -215,7 +215,7 @@ module Event = struct
       | Unknown -> "Unknown")
 
   let to_dyn t =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("action", dyn_of_action (action t))
       ; ("kind", dyn_of_kind (kind t))
@@ -299,7 +299,7 @@ let set_exclusion_paths t ~paths =
   if List.length paths > 8 then
     Code_error.raise
       "Fsevents.set_exclusion_paths: 8 directories should be enough for anybody"
-      [ ("paths", Dyn.Encoder.(list string) paths) ];
+      [ ("paths", Dyn.(list string) paths) ];
   State.critical_section t (fun t ->
       match State.get t with
       | Stop _ -> Code_error.raise "Fsevents.set_exclusion_paths: stop" []

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -187,7 +187,7 @@ module Cycle_error = struct
 
   let get t = t
 
-  let to_dyn = Dyn.Encoder.list Stack_frame_without_state.to_dyn
+  let to_dyn = Dyn.list Stack_frame_without_state.to_dyn
 end
 
 module Error = struct
@@ -245,10 +245,10 @@ module Error = struct
       | _ -> { exn; rev_stack = [ stack_frame ] })
 
   let to_dyn t =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("exn", Exn.to_dyn t.exn)
-      ; ("stack", Dyn.Encoder.list Stack_frame_without_state.to_dyn (stack t))
+      ; ("stack", Dyn.list Stack_frame_without_state.to_dyn (stack t))
       ]
 end
 
@@ -260,13 +260,13 @@ exception Non_reproducible of exn
 let () =
   Printexc.register_printer (fun exn ->
       let dyn =
-        let open Dyn.Encoder in
+        let open Dyn in
         match exn with
-        | Error.E err -> Some (constr "Memo.Error.E" [ Error.to_dyn err ])
+        | Error.E err -> Some (variant "Memo.Error.E" [ Error.to_dyn err ])
         | Cycle_error.E frames ->
-          Some (constr "Cycle_error.E" [ Cycle_error.to_dyn frames ])
+          Some (variant "Cycle_error.E" [ Cycle_error.to_dyn frames ])
         | Non_reproducible exn ->
-          Some (constr "Memo.Non_reproducible" [ Exn.to_dyn exn ])
+          Some (variant "Memo.Non_reproducible" [ Exn.to_dyn exn ])
         | _ -> None
       in
       Option.map dyn ~f:Dyn.to_string)
@@ -889,7 +889,7 @@ end = struct
              Memo invariants and causing more confusing exceptions, but
              hopefully this code_error will be a hint. *)
           Code_error.raise "Memo error handler raised an exception"
-            [ ("exns", Dyn.Encoder.list Exn_with_backtrace.to_dyn e) ])
+            [ ("exns", Dyn.list Exn_with_backtrace.to_dyn e) ])
 
   let deduplicate_errors f =
     let reported = ref Exn_set.empty in

--- a/src/memo/run.ml
+++ b/src/memo/run.ml
@@ -4,7 +4,7 @@ type t = int
 
 let compare = Int.compare
 
-let to_dyn = Dyn.Encoder.int
+let to_dyn = Dyn.int
 
 let current = ref 0
 

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -19,7 +19,7 @@ module Value = struct
     | Prog_and_args of Prog_and_args.t
 
   let to_dyn : t -> Dyn.t =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
     | Bool x -> Bool x
     | Int x -> Int x
@@ -58,10 +58,10 @@ module Ccomp_type = struct
     | Other of string
 
   let to_dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     function
-    | Msvc -> constr "Msvc" []
-    | Other s -> constr "Other" [ string s ]
+    | Msvc -> variant "Msvc" []
+    | Other s -> variant "Other" [ string s ]
 
   let of_string = function
     | "msvc" -> Msvc

--- a/src/ocaml-config/ocaml_config.mli
+++ b/src/ocaml-config/ocaml_config.mli
@@ -6,7 +6,7 @@
     of [Makefile.config]. *)
 type t
 
-val to_dyn : t Dyn.Encoder.t
+val to_dyn : t Dyn.builder
 
 module Prog_and_args : sig
   type t =
@@ -182,7 +182,7 @@ module Value : sig
 
   val to_string : t -> string
 
-  val to_dyn : t Dyn.Encoder.t
+  val to_dyn : t Dyn.builder
 end
 
 val to_list : t -> (string * Value.t) list

--- a/src/ocamlc_loc/ocamlc_loc.ml
+++ b/src/ocamlc_loc/ocamlc_loc.ml
@@ -6,7 +6,7 @@ type warning =
   }
 
 let dyn_of_warning { code; name } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record [ ("code", int code); ("name", string name) ]
 
 type severity =
@@ -34,17 +34,17 @@ type report =
   }
 
 let dyn_of_severity =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Error -> constr "Error" []
-  | Warning w -> constr "Warning" [ option dyn_of_warning w ]
+  | Error -> variant "Error" []
+  | Warning w -> variant "Warning" [ option dyn_of_warning w ]
 
 let dyn_of_message =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Raw s -> constr "Raw" [ string s ]
+  | Raw s -> variant "Raw" [ string s ]
   | Structured { file_excerpt; message; severity } ->
-    constr "Structured"
+    variant "Structured"
       [ record
           [ ("file_excerpt", (option string) file_excerpt)
           ; ("message", string message)
@@ -53,18 +53,18 @@ let dyn_of_message =
       ]
 
 let dyn_of_loc { path; line; chars } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("path", string path)
     ; ( "line"
       , match line with
-        | `Single i -> constr "Single" [ int i ]
-        | `Range (i, j) -> constr "Range" [ int i; int j ] )
+        | `Single i -> variant "Single" [ int i ]
+        | `Range (i, j) -> variant "Range" [ int i; int j ] )
     ; ("chars", option (pair int int) chars)
     ]
 
 let dyn_of_report { loc; message; related } =
-  let open Dyn.Encoder in
+  let open Dyn in
   record
     [ ("loc", dyn_of_loc loc)
     ; ("message", dyn_of_message message)

--- a/test/blackbox-tests/test-cases/actions/bin/sub_process.ml
+++ b/test/blackbox-tests/test-cases/actions/bin/sub_process.ml
@@ -3,8 +3,11 @@ let () =
   | [| _ |] ->
     exit (Sys.command (Filename.quote_command Sys.executable_name [ "sub" ]))
   | [| _; "sub" |] ->
-    let oc = open_out (Sys.getenv "BEACON_FILE") in
+    let beacon_file = Sys.getenv "BEACON_FILE" in
+    Printf.printf "Creating %s...\n%!" beacon_file;
+    let oc = open_out beacon_file in
     Printf.fprintf oc "%d" (Unix.getpid ());
     close_out oc;
+    Printf.printf "Done.\n%!";
     Unix.sleep max_int
   | _ -> assert false

--- a/test/blackbox-tests/test-cases/actions/stray-process.t
+++ b/test/blackbox-tests/test-cases/actions/stray-process.t
@@ -3,25 +3,48 @@ Shows what happens when Dune tries to kill an action that has sub-processes.
   $ . ../watching/helpers.sh
   $ export PATH=$PWD/bin:$PATH
 
+  $ mkdir test; cd test
+
   $ echo '(lang dune 3.0)' > dune-project
   $ cat >dune <<"EOF"
   > (rule
-  >  (action
-  >   (progn
-  >    (run sub_process.exe)
-  >    (with-stdout-to x (echo "")))))
+  >  (alias default)
+  >  (action (system "sub_process.exe > ../../../output")))
   > EOF
 
   $ export BEACON_FILE=$PWD/test-started
 
   $ start_dune
-  $ build x >/dev/null 2>&1 &
+  $ build . > /dev/null 2>&1 &
 
 sub_process.exe spawns a sub-process that creates $BEACON_FILE. We
 wait for the beacon to be notified that the sub-process has started:
 
   $ with_timeout dune_cmd wait-for-file-to-appear $BEACON_FILE
   $ CHILD_PID=`cat $BEACON_FILE`
+
+  $ cat ../output
+  Creating $TESTCASE_ROOT/test/test-started...
+  Done.
+
+  $ find
+  .
+  ./_build
+  ./_build/default
+  ./_build/default/.dune
+  ./_build/default/.dune/configurator.v2
+  ./_build/default/.dune/configurator
+  ./_build/.actions
+  ./_build/.actions/default
+  ./_build/log
+  ./_build/.filesystem-clock
+  ./_build/.rpc
+  ./_build/.rpc/dune
+  ./_build/.sync
+  ./test-started
+  ./dune-output
+  ./dune
+  ./dune-project
 
 Now we stop Dune, which should normally kill all sub-processes:
 

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -39,7 +39,7 @@ let of_sexp : int list t = enter (fields (multi_field "foo" int))
 
 let%expect_test _ =
   parse of_sexp Univ_map.empty (Lazy.force sexp)
-  |> Dyn.Encoder.(list int)
+  |> Dyn.(list int)
   |> print_dyn;
   [%expect {|
 [ 1; 2 ]
@@ -61,7 +61,7 @@ let parse s =
     | e -> Error (Printexc.to_string e)
   in
   print_dyn
-    (Result.to_dyn (Dyn.Encoder.list Dune_lang.to_dyn) Dyn.Encoder.string res)
+    (Result.to_dyn (Dyn.list Dune_lang.to_dyn) Dyn.string res)
 
 let%expect_test _ =
   parse {| # ## x##y x||y a#b|c#d copy# |};
@@ -218,9 +218,9 @@ type syntax =
 type sexp = S of syntax * Dune_lang.t
 
 let dyn_of_sexp (S (syntax, dlang)) =
-  let open Dyn.Encoder in
-  constr "S"
-    [ Dyn.Encoder.pair
+  let open Dyn in
+  variant "S"
+    [ Dyn.pair
         (function
           | Dune -> Variant ("Dune", [])
           | Jbuild -> Variant ("Jbuild", []))
@@ -235,11 +235,11 @@ type round_trip_result =
   | Did_not_parse_back of string
 
 let dyn_of_round_trip_result =
-  let open Dyn.Encoder in
+  let open Dyn in
   function
-  | Round_trip_success -> constr "Round_trip_success" []
-  | Did_not_round_trip s -> constr "Did_not_round_trip" [ Dune_lang.to_dyn s ]
-  | Did_not_parse_back s -> constr "Did_not_parse_back" [ string s ]
+  | Round_trip_success -> variant "Round_trip_success" []
+  | Did_not_round_trip s -> variant "Did_not_round_trip" [ Dune_lang.to_dyn s ]
+  | Did_not_parse_back s -> variant "Did_not_parse_back" [ string s ]
 
 let test syntax sexp =
   let res =
@@ -257,7 +257,7 @@ let test syntax sexp =
       | exception User_error.E msg ->
         Did_not_parse_back (string_of_user_error msg) )
   in
-  let open Dyn.Encoder in
+  let open Dyn in
   pair dyn_of_sexp dyn_of_round_trip_result res |> print_dyn
 
 let%expect_test _ =
@@ -316,7 +316,7 @@ world
 (x ; comment inside list
  y)
 |})
-  |> Dyn.Encoder.list Dune_lang.Cst.to_dyn
+  |> Dyn.list Dune_lang.Cst.to_dyn
   |> print_dyn;
   [%expect
     {|

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -38,9 +38,7 @@ Error: Field "foo" is present too many times
 let of_sexp : int list t = enter (fields (multi_field "foo" int))
 
 let%expect_test _ =
-  parse of_sexp Univ_map.empty (Lazy.force sexp)
-  |> Dyn.(list int)
-  |> print_dyn;
+  parse of_sexp Univ_map.empty (Lazy.force sexp) |> Dyn.(list int) |> print_dyn;
   [%expect {|
 [ 1; 2 ]
 |}]
@@ -60,8 +58,7 @@ let parse s =
     | User_error.E msg -> Error (string_of_user_error msg)
     | e -> Error (Printexc.to_string e)
   in
-  print_dyn
-    (Result.to_dyn (Dyn.list Dune_lang.to_dyn) Dyn.string res)
+  print_dyn (Result.to_dyn (Dyn.list Dune_lang.to_dyn) Dyn.string res)
 
 let%expect_test _ =
   parse {| # ## x##y x||y a#b|c#d copy# |};

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -1,6 +1,6 @@
 open Stdune
 open Fiber.O
-open Dyn.Encoder
+open Dyn
 open Dune_tests_common
 
 let printf = Printf.printf

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -52,7 +52,7 @@ let%expect_test _ =
   (* "foo" should depend on "baz" *)
   let info = Dune_package.Lib.info pkg in
   let requires = Lib_info.requires info in
-  let dyn = Dyn.Encoder.list Lib_dep.to_dyn requires in
+  let dyn = Dyn.list Lib_dep.to_dyn requires in
   let pp = Dyn.pp dyn in
   Format.printf "%a@." Pp.to_fmt pp;
   [%expect {|[ "baz" ]|}]

--- a/test/expect-tests/fsevents/fsevents_tests.ml
+++ b/test/expect-tests/fsevents/fsevents_tests.ml
@@ -84,7 +84,7 @@ let test f =
 
 let print_event ~logger ~cwd e =
   let dyn =
-    let open Dyn.Encoder in
+    let open Dyn in
     record
       [ ("action", Event.dyn_of_action (Event.action e))
       ; ("kind", Event.dyn_of_kind (Event.kind e))

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -88,7 +88,7 @@ let%expect_test _ =
   |}]
 
 let print_deps memo input =
-  let open Dyn.Encoder in
+  let open Dyn in
   Memo.For_tests.get_deps memo input
   |> option (list (pair (option string) (fun x -> x)))
   |> print_dyn
@@ -136,7 +136,7 @@ let dump_stack v =
   Memo.Build.return v
 
 let mcompcycle =
-  let mcompcycle = Fdecl.create Dyn.Encoder.opaque in
+  let mcompcycle = Fdecl.create Dyn.opaque in
   let compcycle x =
     let* x = Memo.Build.return x >>= dump_stack in
     counter := !counter + 1;
@@ -161,11 +161,11 @@ let%expect_test _ =
     print (Pp.textf "%d" !counter);
     !stack
     |> List.map ~f:(fun st ->
-           let open Dyn.Encoder in
+           let open Dyn in
            pair (option string)
              (fun x -> x)
              (Stack_frame.name st, Stack_frame.input st))
-    |> Dyn.Encoder.list (fun x -> x)
+    |> Dyn.list (fun x -> x)
     |> print_dyn;
     [%expect
       {|
@@ -181,7 +181,7 @@ let%expect_test _ =
     |}]
 
 let mfib =
-  let mfib = Fdecl.create Dyn.Encoder.opaque in
+  let mfib = Fdecl.create Dyn.opaque in
   let compfib x =
     let mfib = Memo.exec (Fdecl.get mfib) in
     counter := !counter + 1;
@@ -266,7 +266,7 @@ struct
        Memo.Build.return (x, y))
 
   let deps () =
-    let open Dyn.Encoder in
+    let open Dyn in
     let conv = option (list (pair (option string) (fun x -> x))) in
     pair conv conv
       (For_tests.get_deps f1_def "foo", For_tests.get_deps f2_def "foo")
@@ -281,7 +281,7 @@ module Builtin_lazy = Test_lazy (struct
 end)
 
 let%expect_test _ =
-  Builtin_lazy.run () |> Dyn.Encoder.(pair string string) |> print_dyn;
+  Builtin_lazy.run () |> Dyn.(pair string string) |> print_dyn;
   [%expect {|
     ("f1: lazy: foo", "f2: lazy: foo")
   |}]
@@ -309,7 +309,7 @@ module Memo_lazy = Test_lazy (struct
 end)
 
 let%expect_test _ =
-  Memo_lazy.run () |> Dyn.Encoder.(pair string string) |> print_dyn;
+  Memo_lazy.run () |> Dyn.(pair string string) |> print_dyn;
   [%expect {|
     ("f1: lazy: foo", "f2: lazy: foo")
   |}]
@@ -367,7 +367,7 @@ let%expect_test "fib linked list" =
       }
   end in
   let force cell : Element.t Memo.Build.t = Memo.Cell.read cell in
-  let memo_fdecl = Fdecl.create Dyn.Encoder.opaque in
+  let memo_fdecl = Fdecl.create Dyn.opaque in
   let compute_element x =
     let memo = Fdecl.get memo_fdecl in
     printf "computing %d\n" x;
@@ -520,7 +520,7 @@ let print_result arg res =
                     exn
                   | _ -> exn)))
   in
-  let open Dyn.Encoder in
+  let open Dyn in
   Format.printf "f %d = %a@." arg Pp.to_fmt
     (Dyn.pp (Result.to_dyn int (list Exn_with_backtrace.to_dyn) res))
 
@@ -1453,13 +1453,13 @@ let print_exns f =
       Error (List.map exns ~f:(fun (e : Exn_with_backtrace.t) -> e.exn))
     | exception exn -> Error [ exn ]
   in
-  let open Dyn.Encoder in
+  let open Dyn in
   Format.printf "%a@." Pp.to_fmt
     (Dyn.pp (Result.to_dyn unit (list Exn.to_dyn) res))
 
 let%expect_test "error handling with diamonds" =
   Printexc.record_backtrace true;
-  let f_impl = Fdecl.create Dyn.Encoder.opaque in
+  let f_impl = Fdecl.create Dyn.opaque in
   let f =
     int_fn_create "error-diamond: f" ~cutoff:Unit.equal (fun x ->
         Fdecl.get f_impl x)
@@ -1491,7 +1491,7 @@ let%expect_test "error handling with diamonds" =
 
 let%expect_test "error handling and duplicate exceptions" =
   Printexc.record_backtrace true;
-  let f_impl = Fdecl.create Dyn.Encoder.opaque in
+  let f_impl = Fdecl.create Dyn.opaque in
   let f =
     int_fn_create "test8: duplicate-exception: f" ~cutoff:Unit.equal (fun x ->
         Fdecl.get f_impl x)

--- a/test/expect-tests/scheme_tests.ml
+++ b/test/expect-tests/scheme_tests.ml
@@ -128,8 +128,8 @@ let print_rules scheme ~dir =
     Code_error.raise
       "Naive [collect_rules_simple] gives result inconsistent with \
        [Scheme.evaluate]"
-      [ ("res1", Dyn.Encoder.(list string) res1)
-      ; ("res2", Dyn.Encoder.(list string) res2)
+      [ ("res1", Dyn.(list string) res1)
+      ; ("res2", Dyn.(list string) res2)
       ]
   else
     let print_log log =

--- a/test/expect-tests/scheme_tests.ml
+++ b/test/expect-tests/scheme_tests.ml
@@ -128,9 +128,7 @@ let print_rules scheme ~dir =
     Code_error.raise
       "Naive [collect_rules_simple] gives result inconsistent with \
        [Scheme.evaluate]"
-      [ ("res1", Dyn.(list string) res1)
-      ; ("res2", Dyn.(list string) res2)
-      ]
+      [ ("res1", Dyn.(list string) res1); ("res2", Dyn.(list string) res2) ]
   else
     let print_log log =
       let log =

--- a/test/expect-tests/stdune/ansi_color_tests.ml
+++ b/test/expect-tests/stdune/ansi_color_tests.ml
@@ -1,24 +1,25 @@
 open Stdune
 
 let dyn_of_pp tag pp =
-  let open Dyn.Encoder in
-  let rec conv = function
-    | Pp.Ast.Nop -> constr "Nop" []
-    | Seq (x, y) -> constr "Seq" [ conv x; conv y ]
-    | Concat (x, y) -> constr "Concat" [ conv x; list conv y ]
-    | Box (i, x) -> constr "Box" [ int i; conv x ]
-    | Vbox (i, x) -> constr "Vbox" [ int i; conv x ]
-    | Hbox x -> constr "Hbox" [ conv x ]
-    | Hvbox (i, x) -> constr "Hvbox" [ int i; conv x ]
-    | Hovbox (i, x) -> constr "Hovbox" [ int i; conv x ]
-    | Verbatim s -> constr "Verbatim" [ string s ]
-    | Char c -> constr "Char" [ char c ]
+  let rec conv =
+    let open Dyn in
+    function
+    | Pp.Ast.Nop -> variant "Nop" []
+    | Seq (x, y) -> variant "Seq" [ conv x; conv y ]
+    | Concat (x, y) -> variant "Concat" [ conv x; list conv y ]
+    | Box (i, x) -> variant "Box" [ int i; conv x ]
+    | Vbox (i, x) -> variant "Vbox" [ int i; conv x ]
+    | Hbox x -> variant "Hbox" [ conv x ]
+    | Hvbox (i, x) -> variant "Hvbox" [ int i; conv x ]
+    | Hovbox (i, x) -> variant "Hovbox" [ int i; conv x ]
+    | Verbatim s -> variant "Verbatim" [ string s ]
+    | Char c -> variant "Char" [ char c ]
     | Break (x, y) ->
       let f = triple string int string in
-      constr "Break" [ f x; f y ]
-    | Newline -> constr "Newline" []
-    | Tag (ta, t) -> constr "Tag" [ tag ta; conv t ]
-    | Text s -> constr "Text" [ string s ]
+      variant "Break" [ f x; f y ]
+    | Newline -> variant "Newline" []
+    | Tag (ta, t) -> variant "Tag" [ tag ta; conv t ]
+    | Text s -> variant "Text" [ string s ]
   in
   conv
     (match Pp.to_ast pp with
@@ -46,7 +47,7 @@ let%expect_test "reproduce #2664" =
     {|
     Original : "\027[34m1\027[39m\027[34m2\027[39m\027[34m3\027[39m\027[34m4\027[39m\027[34m5\027[39m\027[34m6\027[39m\027[34m7\027[39m\027[34m8\027[39m\027[34m9\027[39m\027[34m10\027[39m\027[34m11\027[39m\027[34m12\027[39m\027[34m13\027[39m\027[34m14\027[39m\027[34m15\027[39m\027[34m16\027[39m\027[34m17\027[39m\027[34m18\027[39m\027[34m19\027[39m\027[34m20\027[39m"
     From PP  : "\027[34m1\027[0m\027[34m2\027[0m\027[34m3\027[0m\027[34m4\027[0m\027[34m5\027[0m\027[34m6\027[0m\027[34m7\027[0m\027[34m8\027[0m\027[34m9\027[0m\027[34m10\027[0m\027[34m11\027[0m\027[34m12\027[0m\027[34m13\027[0m\027[34m14\027[0m\027[34m15\027[0m\027[34m16\027[0m\027[34m17\027[0m\027[34m18\027[0m\027[34m19\027[0m\027[34m20\027[0m" |}];
-  let pp = dyn_of_pp (Dyn.Encoder.list Ansi_color.Style.to_dyn) pp |> Dyn.pp in
+  let pp = dyn_of_pp (Dyn.list Ansi_color.Style.to_dyn) pp |> Dyn.pp in
   Format.printf "%a@.%!" Pp.to_fmt pp;
   [%expect
     {|

--- a/test/expect-tests/stdune/map_tests.ml
+++ b/test/expect-tests/stdune/map_tests.ml
@@ -5,7 +5,7 @@ let () = init ()
 
 (* Check that [of_alist_multi] groups elements in the right order *)
 let%expect_test _ =
-  let open Dyn.Encoder in
+  let open Dyn in
   String.Map.of_list_multi [ ("a", 1); ("b", 1); ("a", 2); ("a", 3); ("b", 2) ]
   |> String.Map.to_dyn (list int)
   |> print_dyn;

--- a/test/expect-tests/stdune/path_tests.ml
+++ b/test/expect-tests/stdune/path_tests.ml
@@ -16,8 +16,7 @@ let of_filename_relative_to_initial_cwd s =
 let descendant p ~of_ =
   Dyn.option Path.to_dyn (Path.descendant p ~of_) |> print_dyn
 
-let is_descendant p ~of_ =
-  Dyn.bool (Path.is_descendant p ~of_) |> print_dyn
+let is_descendant p ~of_ = Dyn.bool (Path.is_descendant p ~of_) |> print_dyn
 
 let explode s =
   let open Dyn in
@@ -372,8 +371,7 @@ true
 |}]
 
 let%expect_test _ =
-  Path.is_strict_descendant_of_build_dir Path.build_dir
-  |> Dyn.bool |> print_dyn;
+  Path.is_strict_descendant_of_build_dir Path.build_dir |> Dyn.bool |> print_dyn;
   [%expect {|
 false
 |}]

--- a/test/expect-tests/stdune/path_tests.ml
+++ b/test/expect-tests/stdune/path_tests.ml
@@ -14,25 +14,25 @@ let of_filename_relative_to_initial_cwd s =
   Path.of_filename_relative_to_initial_cwd s |> Path.to_dyn |> print_dyn
 
 let descendant p ~of_ =
-  Dyn.Encoder.option Path.to_dyn (Path.descendant p ~of_) |> print_dyn
+  Dyn.option Path.to_dyn (Path.descendant p ~of_) |> print_dyn
 
 let is_descendant p ~of_ =
-  Dyn.Encoder.bool (Path.is_descendant p ~of_) |> print_dyn
+  Dyn.bool (Path.is_descendant p ~of_) |> print_dyn
 
 let explode s =
-  let open Dyn.Encoder in
+  let open Dyn in
   let exploded = Path.explode (Path.of_string s) in
   option (list string) exploded |> print_dyn
 
 let reach p ~from =
   let p = Path.of_string p in
   let from = Path.of_string from in
-  let open Dyn.Encoder in
+  let open Dyn in
   let reach = Path.reach p ~from in
   string reach |> print_dyn
 
 let reach_for_running p ~from =
-  Path.reach_for_running p ~from |> Dyn.Encoder.string |> print_dyn
+  Path.reach_for_running p ~from |> Dyn.string |> print_dyn
 
 let relative p s = Path.to_dyn (Path.relative p s) |> print_dyn
 
@@ -42,7 +42,7 @@ let insert_after_build_dir_exn p s =
 let append_source x y = Path.append_source x y |> Path.to_dyn |> print_dyn
 
 let drop_build_context p =
-  let open Dyn.Encoder in
+  let open Dyn in
   Path.drop_build_context p |> option Path.Source.to_dyn |> print_dyn
 
 let local_part p = Path.local_part p |> Path.Local.to_dyn |> print_dyn
@@ -288,7 +288,7 @@ External "/absolute/path"
 |}]
 
 let%expect_test _ =
-  Path.is_managed (e "relative/path") |> Dyn.Encoder.bool |> print_dyn;
+  Path.is_managed (e "relative/path") |> Dyn.bool |> print_dyn;
   [%expect {|
 false
 |}]
@@ -334,7 +334,7 @@ External "/root/foo"
 
 let%expect_test _ =
   Path.rm_rf (Path.of_string "/does/not/exist/foo/bar/baz")
-  |> Dyn.Encoder.unit |> print_dyn;
+  |> Dyn.unit |> print_dyn;
   [%expect.unreachable]
   [@@expect.uncaught_exn
     {|
@@ -366,21 +366,21 @@ None
 |}]
 
 let%expect_test _ =
-  Path.is_in_build_dir Path.build_dir |> Dyn.Encoder.bool |> print_dyn;
+  Path.is_in_build_dir Path.build_dir |> Dyn.bool |> print_dyn;
   [%expect {|
 true
 |}]
 
 let%expect_test _ =
   Path.is_strict_descendant_of_build_dir Path.build_dir
-  |> Dyn.Encoder.bool |> print_dyn;
+  |> Dyn.bool |> print_dyn;
   [%expect {|
 false
 |}]
 
 let%expect_test _ =
   Path.reach_for_running Path.build_dir ~from:Path.root
-  |> Dyn.Encoder.string |> print_dyn;
+  |> Dyn.string |> print_dyn;
   [%expect {|
 "./_build"
 |}]
@@ -439,7 +439,7 @@ let%expect_test _ =
 
 let%expect_test _ =
   Path.Build.extract_first_component Path.Build.root
-  |> Dyn.Encoder.(option (pair string Local.to_dyn))
+  |> Dyn.(option (pair string Local.to_dyn))
   |> print_dyn;
   [%expect {|
 None

--- a/test/expect-tests/stdune/string_tests.ml
+++ b/test/expect-tests/stdune/string_tests.ml
@@ -1,5 +1,5 @@
 open! Stdune
-open Dyn.Encoder
+open Dyn
 open Dune_tests_common
 
 let () = init ()

--- a/test/expect-tests/stdune/temp_tests.ml
+++ b/test/expect-tests/stdune/temp_tests.ml
@@ -1,6 +1,6 @@
 open Stdune
 open Dune_tests_common
-open Dyn.Encoder
+open Dyn
 
 let () = init ()
 


### PR DESCRIPTION
Since it's now public.

- inline `Dyn.Encoder`
- rename `Dyn.constr` to `Dyn.variant` to match the constructor name
- add `Int32` and `Nativeint`
