### PR TITLE
[WIP] Expose Scheduler.flush_file_watcher via the RPC

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -1,3 +1,5 @@
+[@@@alert "-unstable"]
+
 open Dune_rpc.V1
 open Lwt.Syntax
 

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
@@ -1,3 +1,9 @@
+[@@@alert
+unstable
+  "The Dune_rpc_lwt API is not stabilized yet and might break without notice."]
+
+[@@@alert "-unstable"]
+
 module V1 : sig
   open Dune_rpc.V1
 

--- a/otherlibs/dune-rpc-lwt/test/dune
+++ b/otherlibs/dune-rpc-lwt/test/dune
@@ -6,6 +6,7 @@
  (foreign_stubs
   (language c)
   (names realpath_stubs))
+ (flags :standard -alert -unstable)
  (libraries
   dune_rpc
   csexp_rpc

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -32,6 +32,10 @@
 
 (* TODO make records private *)
 
+[@@@alert
+unstable
+  "The Dune_rpc API is not stabilized yet and might break without notice."]
+
 module V1 : sig
   module Id : sig
     (** Id's for requests, responses, sessions.

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -170,7 +170,7 @@ module V1 : sig
   end
 
   module Progress : sig
-    type t =
+    type status =
       | Waiting
       | In_progress of
           { complete : int
@@ -179,6 +179,12 @@ module V1 : sig
       | Failed
       | Interrupted
       | Success
+
+    type t =
+      { build_number : int
+            (** Build numbers start at 0. So the first build has number [0]. *)
+      ; status : status
+      }
   end
 
   module Sub : sig

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -236,7 +236,7 @@ module Diagnostic : sig
 end
 
 module Progress : sig
-  type t =
+  type status =
     | Waiting
     | In_progress of
         { complete : int
@@ -245,6 +245,11 @@ module Progress : sig
     | Failed
     | Interrupted
     | Success
+
+  type t =
+    { build_number : int
+    ; status : status
+    }
 end
 
 module Message : sig

--- a/otherlibs/dune-rpc/private/exported_types.mli
+++ b/otherlibs/dune-rpc/private/exported_types.mli
@@ -125,7 +125,7 @@ module Diagnostic : sig
 end
 
 module Progress : sig
-  type t =
+  type status =
     | Waiting
     | In_progress of
         { complete : int
@@ -135,7 +135,14 @@ module Progress : sig
     | Interrupted
     | Success
 
-  val sexp : (t, Conv.values) Conv.t
+  type t =
+    { build_number : int
+    ; status : status
+    }
+
+  val sexp_v1 : (t, Conv.values) Conv.t
+
+  val sexp_v2 : (t, Conv.values) Conv.t
 end
 
 module Message : sig

--- a/otherlibs/dune-rpc/private/procedures.ml
+++ b/otherlibs/dune-rpc/private/procedures.ml
@@ -124,8 +124,13 @@ module Poll = struct
 
     let v1 =
       Decl.Request.make_current_gen ~req:Id.sexp
-        ~resp:(Conv.option Progress.sexp)
+        ~resp:(Conv.option Progress.sexp_v1)
         ~version:1
+
+    let v2 =
+      Decl.Request.make_current_gen ~req:Id.sexp
+        ~resp:(Conv.option Progress.sexp_v2)
+        ~version:2
   end
 
   module Diagnostic = struct
@@ -139,7 +144,7 @@ module Poll = struct
 
   let progress =
     let open Progress in
-    make name [ v1 ]
+    make name [ v1; v2 ]
 
   let diagnostic =
     let open Diagnostic in

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -102,7 +102,8 @@ module Handler : sig
        error:(error list -> unit Fiber.t) (** Callback for build [error] *)
     -> build_progress:(complete:int -> remaining:int -> unit Fiber.t)
          (** Callback whenever there's build progress to report *)
-    -> build_event:(event -> unit Fiber.t) (** Called for every [event] *)
+    -> build_event:(build_number:int -> event -> unit Fiber.t)
+         (** Called for every [event] *)
     -> t
 end
 
@@ -215,4 +216,4 @@ end
 val get_current_progress : unit -> Progress.t
 
 (** Returns the last event reported to the handler *)
-val last_event : unit -> Handler.event option
+val last_event : unit -> (int * Handler.event) option

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -168,6 +168,24 @@ val sleep : float -> unit Fiber.t
     acknowledged by the scheduler. *)
 val flush_file_watcher : unit -> unit Fiber.t
 
+(** Number of times some event caused the build to be invalidated. This happens
+    whem:
+
+    - Dune is waiting for a file to change and receive a file change event that
+      invalidate the last build. At the moment, any FS event is counted as a
+      breakage, even if it doesn't invalidate the last build. We plan to change
+      this however.
+
+    - Dune is building and receives a FS event that invalidate the current build
+
+    During the restarting phase, i.e. between the time Dune receives the first
+    invalidating FS event and the time it actually starts a new build, any
+    subsequent FS change does not count as an additional restart. This ensures
+    that this number and the number of builds performed by [Build_system] are
+    synchronised. One can compare this number to the number of builds reported
+    by [Build_system] to determine if the build is fully caught up. *)
+val number_of_breakages : unit -> int Fiber.t
+
 (** Wait for a build input to change. If a build input change was seen but
     hasn't been handled yet, return immediately.
 

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -56,7 +56,7 @@ end
 
 module Flush_file_watcher = struct
   let v1 =
-    Decl.Request.make_current_gen ~req:Conv.unit ~resp:Conv.unit ~version:1
+    Decl.Request.make_current_gen ~req:Conv.unit ~resp:Conv.int ~version:1
 
   let decl = Decl.Request.make ~method_:"flush-file-watcher" ~generations:[ v1 ]
 end

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -54,6 +54,15 @@ module Build = struct
   let decl = Decl.Request.make ~method_:"build" ~generations:[ v1 ]
 end
 
+module Flush_file_watcher = struct
+  let v1 =
+    Decl.Request.make_current_gen ~req:Conv.unit ~resp:Conv.unit ~version:1
+
+  let decl = Decl.Request.make ~method_:"flush-file-watcher" ~generations:[ v1 ]
+end
+
 let build = Build.decl
 
 let status = Status.decl
+
+let flush_file_watcher = Flush_file_watcher.decl

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -27,3 +27,5 @@ end
 val build : (string list, Build_outcome.t) Decl.Request.t
 
 val status : (unit, Status.t) Decl.Request.t
+
+val flush_file_watcher : (unit, unit) Decl.Request.t

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -28,4 +28,6 @@ val build : (string list, Build_outcome.t) Decl.Request.t
 
 val status : (unit, Status.t) Decl.Request.t
 
-val flush_file_watcher : (unit, unit) Decl.Request.t
+(** Flush the file watcher queue and returns the number of breakages observed so
+    far, as defined by [Scheduler.number_of_breakages]. *)
+val flush_file_watcher : (unit, int) Decl.Request.t

--- a/src/dune_rpc_impl/import.ml
+++ b/src/dune_rpc_impl/import.ml
@@ -1,7 +1,8 @@
 module Dune_rpc = Dune_rpc_private
 
 let progress_of_build_event :
-    Dune_engine.Build_system.Handler.event -> Dune_rpc.Progress.t = function
+    Dune_engine.Build_system.Handler.event -> Dune_rpc.Progress.status =
+  function
   | Start -> In_progress { complete = 0; remaining = 0 }
   | Finish -> Success
   | Interrupt -> Interrupted

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -183,7 +183,8 @@ let handler (t : t Fdecl.t) : 'a Dune_rpc_server.Handler.t =
   in
   let () =
     Handler.implement_request rpc Decl.flush_file_watcher (fun _ () ->
-        Dune_engine.Scheduler.flush_file_watcher ())
+        let* () = Dune_engine.Scheduler.flush_file_watcher () in
+        Dune_engine.Scheduler.number_of_breakages ())
   in
   let () =
     let rec cancel_pending_jobs () =

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -182,6 +182,10 @@ let handler (t : t Fdecl.t) : 'a Dune_rpc_server.Handler.t =
     Handler.implement_request rpc Decl.build build
   in
   let () =
+    Handler.implement_request rpc Decl.flush_file_watcher (fun _ () ->
+        Dune_engine.Scheduler.flush_file_watcher ())
+  in
+  let () =
     let rec cancel_pending_jobs () =
       match Job_queue.pop_internal (Fdecl.get t).pending_build_jobs with
       | None -> Fiber.return ()


### PR DESCRIPTION
The aim is to use that in jengraph (Jane Street currently internal tool to monitor Jenga/Dune's performances). Recently, we had the following issue in jengraph: if jengraph makes a change that is absorbed by `Fs_cache` and doesn't cause a rebuild, then Dune doesn't start a new build and jengraph cannot observe that Dune acknowledged the change.

To cope with this, we changed Dune to start a new build even for FS events that shouldn't cause a new build. This is a bit sad.

After this PR, I intend to change jengraph to always emit a `flush_file_watcher` after doing some changes to the file system. If no new build has been observed by the time `flush_file_watcher` finishes, we can conclude that Dune observed the event but didn't restart a new build.

Once this is done, we can change Dune back to not start a new build if a FS event is not significant for the build.