### PR TITLE
Tests file-system events for promotion and fix an event filtering bug

### DIFF
--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -1,25 +1,6 @@
 open! Stdune
 module Inotify_lib = Async_inotify_for_dune.Async_inotify
 
-type path_event =
-  | Created
-  | Moved_into
-  | Unlinked
-  | Moved_away
-  | Modified
-
-let decompose_inotify_event (event : Inotify_lib.Event.t) =
-  match event with
-  | Created path -> [ (path, Created) ]
-  | Unlinked path -> [ (path, Unlinked) ]
-  | Modified path -> [ (path, Modified) ]
-  | Moved (Away path) -> [ (path, Moved_away) ]
-  | Moved (Into path) -> [ (path, Moved_into) ]
-  | Moved (Move (from, to_)) -> [ (from, Moved_away); (to_, Moved_into) ]
-  | Queue_overflow -> []
-
-let inotify_event_paths event = List.map ~f:fst (decompose_inotify_event event)
-
 module Fs_memo_event = struct
   type kind =
     | Created

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -3,8 +3,6 @@ module Inotify_lib := Async_inotify_for_dune.Async_inotify
 
 type t
 
-val inotify_event_paths : Inotify_lib.Event.t -> string list
-
 module Fs_memo_event : sig
   (* Here are some idealized assumptions the Fs_memo module in dune_engine makes
      about events:

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -167,7 +167,7 @@ Now test file-system events generated during target promotion.
 
   $ stop_dune > debug-output
 
-Show that we ignore the initial dune-workspace event (injected by Dune).
+Show that Dune ignores the initial "dune-workspace" events (injected by Dune).
 
   $ cat debug-output | grep dune-workspace
   Updating dir_contents cache for "dune-workspace": Skipped
@@ -175,15 +175,10 @@ Show that we ignore the initial dune-workspace event (injected by Dune).
   Updating path_stat cache for "dune-workspace": Skipped
   Updating path_exists cache for "dune-workspace": Updated { changed = false }
 
-Show that Dune processes events for both .#promoted.dune-temp and promoted.
-
-# CR amokhov: We shouldn't see events for .#promoted.dune-temp here.
+Show that Dune ignores "promoted" events. Events for ".#promoted.dune-temp" are
+filtered out by Dune's file watcher and don't show up here.
 
   $ cat debug-output | grep promoted
-  Updating dir_contents cache for ".#promoted.dune-temp": Skipped
-  Updating path_digest cache for ".#promoted.dune-temp": Skipped
-  Updating path_stat cache for ".#promoted.dune-temp": Skipped
-  Updating path_exists cache for ".#promoted.dune-temp": Skipped
   Updating dir_contents cache for "promoted": Skipped
   Updating path_digest cache for "promoted": Updated { changed = false }
   Updating path_stat cache for "promoted": Skipped
@@ -201,10 +196,6 @@ Show how Dune processes events for the . directory.
   Updating dir_contents cache for ".": Updated { changed = false }
   Updating path_digest cache for ".": Skipped
   Updating path_stat cache for ".": Updated { changed = true }
-  Updating path_exists cache for ".": Updated { changed = false }
-  Updating dir_contents cache for ".": Updated { changed = false }
-  Updating path_digest cache for ".": Skipped
-  Updating path_stat cache for ".": Updated { changed = false }
   Updating path_exists cache for ".": Updated { changed = false }
   Updating dir_contents cache for ".": Updated { changed = true }
   Updating path_digest cache for ".": Skipped

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -146,3 +146,67 @@ We're done.
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
   Success, waiting for filesystem changes...
+
+Now test file-system events generated during target promotion.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (mode promote)
+  >   (deps original)
+  >   (target promoted)
+  >   (action (copy %{deps} %{target})))
+  > (rule
+  >   (deps promoted)
+  >   (target result)
+  >   (action (bash "cat promoted promoted > result")))
+  > EOF
+
+  $ start_dune --debug-cache=fs
+  $ build result
+  Success
+
+  $ stop_dune > debug-output
+
+Show that we ignore the initial dune-workspace event (injected by Dune).
+
+  $ cat debug-output | grep dune-workspace
+  Updating dir_contents cache for "dune-workspace": Skipped
+  Updating path_digest cache for "dune-workspace": Skipped
+  Updating path_stat cache for "dune-workspace": Skipped
+  Updating path_exists cache for "dune-workspace": Updated { changed = false }
+
+Show that Dune processes events for both .#promoted.dune-temp and promoted.
+
+# CR amokhov: We shouldn't see events for .#promoted.dune-temp here.
+
+  $ cat debug-output | grep promoted
+  Updating dir_contents cache for ".#promoted.dune-temp": Skipped
+  Updating path_digest cache for ".#promoted.dune-temp": Skipped
+  Updating path_stat cache for ".#promoted.dune-temp": Skipped
+  Updating path_exists cache for ".#promoted.dune-temp": Skipped
+  Updating dir_contents cache for "promoted": Skipped
+  Updating path_digest cache for "promoted": Updated { changed = false }
+  Updating path_stat cache for "promoted": Skipped
+  Updating path_exists cache for "promoted": Skipped
+
+Show how Dune processes events for the . directory.
+
+# CR-someday amokhov: We see two events where [path_stat] changed but nothing
+# else did: specifically, the directory still exists and its content is unchanged.
+# We believe the [path_stat]'s changes are due to the [mtimes] field, which can
+# change, for example, because of creation of a temporary file. We should remove
+# [mtimes] from [Fs_cache.Reduced_stats] to avoid such unnecessary retriggering.
+
+  $ cat debug-output | grep '"."'
+  Updating dir_contents cache for ".": Updated { changed = false }
+  Updating path_digest cache for ".": Skipped
+  Updating path_stat cache for ".": Updated { changed = true }
+  Updating path_exists cache for ".": Updated { changed = false }
+  Updating dir_contents cache for ".": Updated { changed = false }
+  Updating path_digest cache for ".": Skipped
+  Updating path_stat cache for ".": Updated { changed = false }
+  Updating path_exists cache for ".": Updated { changed = false }
+  Updating dir_contents cache for ".": Updated { changed = true }
+  Updating path_digest cache for ".": Skipped
+  Updating path_stat cache for ".": Updated { changed = true }
+  Updating path_exists cache for ".": Updated { changed = false }


### PR DESCRIPTION
The first commit exposes a couple of problems with file-system event processing that happen during target promotion:

* We still receive events for temporary `.#promoted.dune-temp` files.
* We restart the build when `mtimes` of a directory changes, even if its contents is the same from Dune's point of view.

The second commit fixes the first problem. I'm going to look at the second problem in a separate PR.

The third commit removes some code, which I believe is no longer useful.

By the way, I believe this PR also fixes another bug: the way the code was written, I think we always ignored `Queue_overflow` because it contained no paths! Now we are no longer ignoring it.