### PR TITLE
Refactor target promotion

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1921,7 +1921,10 @@ end = struct
           | Promote _, Some Never ->
             Fiber.return ()
           | Promote promote, (Some Automatically | None) ->
-            Target_promotion.promote ~dir ~targets_and_digests ~promote
+            (* Note that [files_to_promote] includes both [targets.files] and
+               all files discovered inside directory targets. *)
+            let files_to_promote = List.map targets_and_digests ~f:fst in
+            Target_promotion.promote ~dir ~files_to_promote ~promote
               ~promote_source:(fun ~chmod -> t.promote_source ~chmod context)
         in
         t.rule_done <- t.rule_done + 1;

--- a/src/dune_engine/target_promotion.mli
+++ b/src/dune_engine/target_promotion.mli
@@ -6,7 +6,7 @@ open! Stdune
 
 val promote :
      dir:Path.Build.t
-  -> targets_and_digests:(Path.Build.t * Digest.t) list
+  -> files_to_promote:Path.Build.t list
   -> promote:Rule.Promote.t
   -> promote_source:
        (   chmod:(int -> int)

--- a/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/promote/old-tests.t/run.t
@@ -150,7 +150,7 @@ Reproduction case for #3069
   File "dune", line 3, characters 22-25:
   3 |  (mode (promote (into dir))))
                             ^^^
-  Error: Directory "dir" does not exist.
+  Error: Directory "dir" does not exist. Please create it manually.
   -> required by _build/default/x
   [1]
 

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -196,8 +196,8 @@ Show how Dune processes events for the . directory.
   Updating dir_contents cache for ".": Updated { changed = false }
   Updating path_digest cache for ".": Skipped
   Updating path_stat cache for ".": Updated { changed = true }
-  Updating path_exists cache for ".": Updated { changed = false }
+  Updating path_exists cache for ".": Skipped
   Updating dir_contents cache for ".": Updated { changed = true }
   Updating path_digest cache for ".": Skipped
   Updating path_stat cache for ".": Updated { changed = true }
-  Updating path_exists cache for ".": Updated { changed = false }
+  Updating path_exists cache for ".": Skipped


### PR DESCRIPTION
This is a small refactoring to make the upcoming target promotion PR easier to review. 

* Instead of checking that the parent directory exists for every destination, we only check it once and only in the case of using the `into` feature. There is no point in checking this for other cases since the parent directory is guaranteed to exist (it should contain the corresponding `dune` file). Note how this improves one of the tests: a call to `path_exists` disappeared.
* We no longer need target digests, so I'm dropping them from the API.
* Use `Fiber.sequential_iter` since we don't really benefit from parallelism here.
