### PR TITLE
Add [Ordering.O.let=]

### DIFF
--- a/otherlibs/action-plugin/src/protocol.ml
+++ b/otherlibs/action-plugin/src/protocol.ml
@@ -43,11 +43,10 @@ module Dependency = struct
       | Directory x, Directory y -> String.compare x y
       | Directory _, _ -> Lt
       | _, Directory _ -> Gt
-      | Glob { path = path1; glob = glob1 }, Glob { path = path2; glob = glob2 }
-        -> (
-        match String.compare path1 path2 with
-        | Eq -> String.compare glob1 glob2
-        | not_eq -> not_eq)
+      | Glob { path; glob }, Glob t ->
+        let open Ordering.O in
+        let= () = String.compare path t.path in
+        String.compare glob t.glob
 
     let to_dyn = Dyn.opaque
   end

--- a/otherlibs/dune-rpc/private/registry.ml
+++ b/otherlibs/dune-rpc/private/registry.ml
@@ -20,13 +20,11 @@ module Dune = struct
       ; where : Where.t
       }
 
-    let compare t { root; pid; where } : Stdune.Ordering.t =
-      match Int.compare t.pid pid with
-      | (Lt | Gt) as s -> s
-      | Eq -> (
-        match String.compare t.root root with
-        | (Lt | Gt) as s -> s
-        | Eq -> Where.compare t.where where)
+    let compare t { root; pid; where } : Ordering.t =
+      let open Ordering.O in
+      let= () = Int.compare t.pid pid in
+      let= () = String.compare t.root root in
+      Where.compare t.where where
 
     let to_dyn { root; pid; where } =
       let open Dyn in

--- a/otherlibs/dune-rpc/private/registry.ml
+++ b/otherlibs/dune-rpc/private/registry.ml
@@ -20,7 +20,7 @@ module Dune = struct
       ; where : Where.t
       }
 
-    let compare t { root; pid; where } : Ordering.t =
+    let compare t { root; pid; where } =
       let open Ordering.O in
       let= () = Int.compare t.pid pid in
       let= () = String.compare t.root root in
@@ -38,8 +38,6 @@ module Dune = struct
   include T
   module C = Comparable.Make (T)
   module Set = C.Set
-
-  let compare x y = compare x y
 
   let create ~where ~root ~pid = { where; root; pid }
 

--- a/otherlibs/ordering/ordering.ml
+++ b/otherlibs/ordering/ordering.ml
@@ -40,3 +40,10 @@ let max f x y =
   | Gt ->
     x
   | Lt -> y
+
+module O = struct
+  let ( let= ) t f =
+    match t with
+    | (Lt | Gt) as result -> result
+    | Eq -> f ()
+end

--- a/otherlibs/ordering/ordering.mli
+++ b/otherlibs/ordering/ordering.mli
@@ -41,6 +41,10 @@ module O : sig
             Eq
       v}
 
-      to chain three comparisons instead of the usual triply nested [match]. *)
+      to chain three comparisons instead of the usual triply nested [match].
+
+      Note that the resulting code can be up to 2x slower than nested [match]ing
+      due to extra allocations that we are unable to eliminate (as of Nov 2021),
+      so you should use [let=] only where appropriate. *)
   val ( let= ) : t -> (unit -> t) -> t
 end

--- a/otherlibs/ordering/ordering.mli
+++ b/otherlibs/ordering/ordering.mli
@@ -17,3 +17,30 @@ val is_eq : t -> bool
 val min : ('a -> 'a -> t) -> 'a -> 'a -> 'a
 
 val max : ('a -> 'a -> t) -> 'a -> 'a -> 'a
+
+module O : sig
+  (** A convenient operator for efficiently chaining multiple comparisons
+      together. For example, you can write
+
+      {v
+          let compare { x; y; z } t =
+            let open Ordering.O in
+            let= () = compare_x x t.x in
+            let= () = compare_y y t.y in
+            compare_z z t.z
+      v}
+
+      or, a bit less compactly but more symmetrically
+
+      {v
+          let compare { x; y; z } t =
+            let open Ordering.O in
+            let= () = compare_x x t.x in
+            let= () = compare_y y t.y in
+            let= () = compare_z z t.z in
+            Eq
+      v}
+
+      to chain three comparisons instead of the usual triply nested [match]. *)
+  val ( let= ) : t -> (unit -> t) -> t
+end

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -35,7 +35,9 @@ module Dynamic_dep = struct
       | File _, _ -> Lt
       | _, File _ -> Gt
       | Glob (dir1, glob1), Glob (dir2, glob2) ->
-        Tuple.T2.compare Path.compare Glob.compare (dir1, glob1) (dir2, glob2)
+        let open Ordering.O in
+        let= () = Path.compare dir1 dir2 in
+        Glob.compare glob1 glob2
 
     let to_dyn =
       let open Dyn in

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -131,10 +131,10 @@ end
 
 include T
 
-let compare x y =
-  match Name.compare x.name y.name with
-  | (Lt | Gt) as x -> x
-  | Eq -> Path.Build.compare x.dir y.dir
+let compare { dir; name } t =
+  let open Ordering.O in
+  let= () = Name.compare name t.name in
+  Path.Build.compare dir t.dir
 
 let equal x y = compare x y = Eq
 

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -14,13 +14,11 @@ module Reduced_stats = struct
   let of_unix_stats (stats : Unix.stats) =
     { mtime = stats.st_mtime; size = stats.st_size; perm = stats.st_perm }
 
-  let compare a b =
-    match Float.compare a.mtime b.mtime with
-    | (Lt | Gt) as x -> x
-    | Eq -> (
-      match Int.compare a.size b.size with
-      | (Lt | Gt) as x -> x
-      | Eq -> Int.compare a.perm b.perm)
+  let compare { mtime; size; perm } t =
+    let open Ordering.O in
+    let= () = Float.compare mtime t.mtime in
+    let= () = Int.compare size t.size in
+    Int.compare perm t.perm
 end
 
 type file =

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -186,20 +186,19 @@ module Fact = struct
   end
 
   let compare a b =
+    let open Ordering.O in
     match (a, b) with
-    | Nothing, Nothing -> Ordering.Eq
+    | Nothing, Nothing -> Eq
     | Nothing, _ -> Lt
     | _, Nothing -> Gt
-    | File (f1, d1), File (f2, d2) -> (
-      match Path.compare f1 f2 with
-      | Eq -> Digest.compare d1 d2
-      | ne -> ne)
+    | File (f1, d1), File (f2, d2) ->
+      let= () = Path.compare f1 f2 in
+      Digest.compare d1 d2
     | File _, _ -> Lt
     | _, File _ -> Gt
-    | File_selector (d1, f1), File_selector (d2, f2) -> (
-      match Dyn.compare d1 d2 with
-      | Eq -> Files.compare f1 f2
-      | ne -> ne)
+    | File_selector (d1, f1), File_selector (d2, f2) ->
+      let= () = Dyn.compare d1 d2 in
+      Files.compare f1 f2
     | File_selector _, _ -> Lt
     | _, File_selector _ -> Gt
     | Alias f1, Alias f2 -> Files.compare f1 f2

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -12,10 +12,11 @@ let predicate t = t.predicate
 
 let only_generated_files t = t.only_generated_files
 
-let compare x y =
-  match Path.compare x.dir y.dir with
-  | (Ordering.Lt | Gt) as a -> a
-  | Eq -> Predicate.compare x.predicate y.predicate
+let compare { dir; predicate; only_generated_files } t =
+  let open Ordering.O in
+  let= () = Path.compare dir t.dir in
+  let= () = Predicate.compare predicate t.predicate in
+  Bool.compare only_generated_files t.only_generated_files
 
 let create ~dir ?(only_generated_files = false) predicate =
   { dir; predicate; only_generated_files }

--- a/src/dune_engine/install.ml
+++ b/src/dune_engine/install.ml
@@ -89,8 +89,6 @@ module Section_with_site = struct
         ; loc : Loc.t
         }
 
-  (* let compare : t -> t -> Ordering.t = Poly.compare *)
-
   let to_dyn x =
     let open Dyn in
     match x with
@@ -227,13 +225,11 @@ module Entry = struct
       }
   end
 
-  let compare compare_src x y =
-    match Section.compare x.section y.section with
-    | (Lt | Gt) as c -> c
-    | Eq -> (
-      match Dst.compare x.dst y.dst with
-      | (Lt | Gt) as c -> c
-      | Eq -> compare_src x.src y.src)
+  let compare compare_src { src; dst; section } t =
+    let open Ordering.O in
+    let= () = Section.compare section t.section in
+    let= () = Dst.compare dst t.dst in
+    compare_src src t.src
 
   let adjust_dst_gen =
     let error (source_pform : Dune_lang.Template.Pform.t) =

--- a/src/dune_engine/mode.ml
+++ b/src/dune_engine/mode.ml
@@ -4,9 +4,20 @@ type t =
   | Byte
   | Native
 
-let equal (x : t) (y : t) = Poly.equal x y
+let equal x y =
+  match (x, y) with
+  | Byte, Byte -> true
+  | Byte, _
+  | _, Byte ->
+    false
+  | Native, Native -> true
 
-let compare = Poly.compare
+let compare x y =
+  match (x, y) with
+  | Byte, Byte -> Eq
+  | Byte, _ -> Lt
+  | _, Byte -> Gt
+  | Native, Native -> Eq
 
 let all = [ Byte; Native ]
 

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -63,10 +63,10 @@ module Id = struct
       ; dir : Path.Source.t
       }
 
-    let compare { dir; name } pkg =
-      match Name.compare pkg.name name with
-      | Eq -> Path.Source.compare dir pkg.dir
-      | s -> s
+    let compare { name; dir } pkg =
+      let open Ordering.O in
+      let= () = Name.compare name pkg.name in
+      Path.Source.compare dir pkg.dir
 
     let to_dyn { dir; name } =
       let open Dyn in

--- a/src/dune_engine/pform.ml
+++ b/src/dune_engine/pform.ml
@@ -158,9 +158,10 @@ module Macro = struct
     | Bin, Bin -> Eq
     | Bin, _ -> Lt
     | _, Bin -> Gt
-    | Lib { lib_exec; lib_private }, Lib y ->
-      Tuple.T2.compare Bool.compare Bool.compare (lib_exec, lib_private)
-        (y.lib_exec, y.lib_private)
+    | Lib { lib_exec; lib_private }, Lib t ->
+      let open Ordering.O in
+      let= () = Bool.compare lib_exec t.lib_exec in
+      Bool.compare lib_private t.lib_private
     | Lib _, _ -> Lt
     | _, Lib _ -> Gt
     | Lib_available, Lib_available -> Eq
@@ -232,7 +233,9 @@ module T = struct
     | Var _, _ -> Lt
     | _, Var _ -> Gt
     | Macro (m1, s1), Macro (m2, s2) ->
-      Tuple.T2.compare Macro.compare String.compare (m1, s1) (m2, s2)
+      let open Ordering.O in
+      let= () = Macro.compare m1 m2 in
+      String.compare s1 s2
 end
 
 include T

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -43,19 +43,12 @@ module Dict = struct
 
   let compare compare { none; symlink; copy; hardlink; patch_back_source_tree }
       t =
-    let ( let= ) ordering k =
-      match ordering with
-      | Eq -> k ()
-      | Lt
-      | Gt ->
-        ordering
-    in
+    let open Ordering.O in
     let= () = compare none t.none in
     let= () = compare symlink t.symlink in
     let= () = compare copy t.copy in
     let= () = compare hardlink t.hardlink in
-    let= () = compare patch_back_source_tree t.patch_back_source_tree in
-    Eq
+    compare patch_back_source_tree t.patch_back_source_tree
 
   let of_func (f : key -> _) =
     { none = f None

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -81,7 +81,15 @@ module Signal = struct
     | Quit -> Variant ("Quit", [])
     | Term -> Variant ("Term", [])
 
-  let compare : t -> t -> Ordering.t = Poly.compare
+  let compare x y =
+    match (x, y) with
+    | Int, Int -> Eq
+    | Int, _ -> Lt
+    | _, Int -> Gt
+    | Quit, Quit -> Eq
+    | Quit, _ -> Lt
+    | _, Quit -> Gt
+    | Term, Term -> Eq
 
   include Comparable.Make (struct
     type nonrec t = t

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -13,10 +13,10 @@ module File = struct
       let open Dyn in
       record [ ("ino", Int.to_dyn ino); ("dev", Int.to_dyn dev) ]
 
-    let compare a b =
-      match Int.compare a.ino b.ino with
-      | Eq -> Int.compare a.dev b.dev
-      | ne -> ne
+    let compare { ino; dev } t =
+      let open Ordering.O in
+      let= () = Int.compare ino t.ino in
+      Int.compare dev t.dev
   end
 
   include T

--- a/src/dune_engine/string_with_vars.ml
+++ b/src/dune_engine/string_with_vars.ml
@@ -13,19 +13,18 @@ type t =
   ; loc : Loc.t
   }
 
-let compare_no_loc t1 t2 =
-  match Bool.compare t1.quoted t2.quoted with
-  | (Ordering.Lt | Gt) as a -> a
-  | Eq ->
-    List.compare t1.parts t2.parts ~compare:(fun a b ->
-        match (a, b) with
-        | Text a, Text b -> String.compare a b
-        | Pform (_, a), Pform (_, b) -> Pform.compare a b
-        | Error (_, a), Error (_, b) -> Poly.compare a b
-        | Text _, _ -> Lt
-        | _, Text _ -> Gt
-        | Pform _, _ -> Lt
-        | _, Pform _ -> Gt)
+let compare_no_loc { quoted; parts; loc = _ } t =
+  let open Ordering.O in
+  let= () = Bool.compare quoted t.quoted in
+  List.compare parts t.parts ~compare:(fun a b ->
+      match (a, b) with
+      | Text a, Text b -> String.compare a b
+      | Pform (_, a), Pform (_, b) -> Pform.compare a b
+      | Error (_, a), Error (_, b) -> Poly.compare a b
+      | Text _, _ -> Lt
+      | _, Text _ -> Gt
+      | Pform _, _ -> Lt
+      | _, Pform _ -> Gt)
 
 let equal_no_loc t1 t2 = Ordering.is_eq (compare_no_loc t1 t2)
 

--- a/src/dune_graph/graph.ml
+++ b/src/dune_graph/graph.ml
@@ -69,10 +69,10 @@ module Edge = struct
     let to_dyn t =
       Dyn.Record [ ("src_id", Dyn.Int t.src_id); ("dst_id", Dyn.Int t.dst_id) ]
 
-    let compare a b =
-      match Int.compare a.src_id b.src_id with
-      | Eq -> Int.compare a.dst_id b.dst_id
-      | _ as neq -> neq
+    let compare { src_id; dst_id } t =
+      let open Ordering.O in
+      let= () = Int.compare src_id t.src_id in
+      Int.compare dst_id t.dst_id
   end
 
   include T

--- a/src/dune_lang/decoder.ml
+++ b/src/dune_lang/decoder.ml
@@ -16,11 +16,9 @@ module Name = struct
     type t = string
 
     let compare a b =
-      let alen = String.length a
-      and blen = String.length b in
-      match Int.compare alen blen with
-      | Eq -> String.compare a b
-      | ne -> ne
+      let open Ordering.O in
+      let= () = Int.compare (String.length a) (String.length b) in
+      String.compare a b
 
     let to_dyn = Dyn.string
   end

--- a/src/dune_lang/syntax.ml
+++ b/src/dune_lang/syntax.ml
@@ -5,9 +5,9 @@ module Version = struct
     type t = int * int
 
     let compare (major_a, minor_a) (major_b, minor_b) =
-      match Int.compare major_a major_b with
-      | (Gt | Lt) as ne -> ne
-      | Eq -> Int.compare minor_a minor_b
+      let open Ordering.O in
+      let= () = Int.compare major_a major_b in
+      Int.compare minor_a minor_b
 
     let to_dyn t =
       let open Dyn in
@@ -47,19 +47,9 @@ module Version = struct
     let open Int.Infix in
     parser_major = data_major && parser_minor >= data_minor
 
-  let min a b =
-    match compare a b with
-    | Lt
-    | Eq ->
-      a
-    | Gt -> b
+  let min = Ordering.min compare
 
-  let max a b =
-    match compare a b with
-    | Lt
-    | Eq ->
-      b
-    | Gt -> a
+  let max = Ordering.max compare
 end
 
 module Supported_versions = struct

--- a/src/dune_lang/template.ml
+++ b/src/dune_lang/template.ml
@@ -11,10 +11,10 @@ module Pform = struct
 
   let name { name; _ } = name
 
-  let compare_no_loc v1 v2 =
-    match String.compare v1.name v2.name with
-    | (Ordering.Lt | Gt) as a -> a
-    | Eq -> Option.compare String.compare v1.payload v2.payload
+  let compare_no_loc { name; payload; loc = _ } t =
+    let open Ordering.O in
+    let= () = String.compare name t.name in
+    Option.compare String.compare payload t.payload
 
   let full_name t =
     match t.payload with
@@ -64,10 +64,10 @@ let compare_part p1 p2 =
   | Text _, Pform _ -> Ordering.Lt
   | Pform _, Text _ -> Ordering.Gt
 
-let compare_no_loc t1 t2 =
-  match List.compare ~compare:compare_part t1.parts t2.parts with
-  | (Ordering.Lt | Gt) as a -> a
-  | Eq -> Bool.compare t1.quoted t2.quoted
+let compare_no_loc { quoted; parts; loc = _ } t =
+  let open Ordering.O in
+  let= () = List.compare ~compare:compare_part parts t.parts in
+  Bool.compare quoted t.quoted
 
 module Pp : sig
   val to_string : t -> string

--- a/src/dune_rules/binary_kind.ml
+++ b/src/dune_rules/binary_kind.ml
@@ -9,6 +9,25 @@ type t =
   | Plugin
   | Js
 
+let compare x y =
+  match (x, y) with
+  | C, C -> Eq
+  | C, _ -> Lt
+  | _, C -> Gt
+  | Exe, Exe -> Eq
+  | Exe, _ -> Lt
+  | _, Exe -> Gt
+  | Object, Object -> Eq
+  | Object, _ -> Lt
+  | _, Object -> Gt
+  | Shared_object, Shared_object -> Eq
+  | Shared_object, _ -> Lt
+  | _, Shared_object -> Gt
+  | Plugin, Plugin -> Eq
+  | Plugin, _ -> Lt
+  | _, Plugin -> Gt
+  | Js, Js -> Eq
+
 let decode =
   let open Dune_lang.Decoder in
   sum

--- a/src/dune_rules/binary_kind.mli
+++ b/src/dune_rules/binary_kind.mli
@@ -11,6 +11,8 @@ type t =
   | Plugin
   | Js
 
+val compare : t -> t -> Ordering.t
+
 include Dune_lang.Conv.S with type t := t
 
 val all : t list

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -405,7 +405,15 @@ module Mode_conf = struct
       | Native
       | Best
 
-    let compare (a : t) b = Poly.compare a b
+    let compare x y =
+      match (x, y) with
+      | Byte, Byte -> Eq
+      | Byte, _ -> Lt
+      | _, Byte -> Gt
+      | Native, Native -> Eq
+      | Native, _ -> Lt
+      | _, Native -> Gt
+      | Best, Best -> Eq
   end
 
   include T
@@ -1211,10 +1219,10 @@ module Executables = struct
         | Byte_complete, Byte_complete -> Eq
         | Byte_complete, _ -> Lt
         | _, Byte_complete -> Gt
-        | Other a, Other b -> (
-          match Poly.compare a.mode b.mode with
-          | Eq -> Poly.compare a.kind b.kind
-          | ne -> ne)
+        | Other { mode; kind }, Other t ->
+          let open Ordering.O in
+          let= () = Mode_conf.compare mode t.mode in
+          Binary_kind.compare kind t.kind
 
       let to_dyn = Dyn.opaque
     end

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -60,7 +60,18 @@ module Mode_conf = struct
       | Native
       | Best
 
-    let compare (a : t) b = Poly.compare a b
+    let compare x y =
+      match (x, y) with
+      | Byte, Byte -> Eq
+      | Byte, _ -> Lt
+      | _, Byte -> Gt
+      | Javascript, Javascript -> Eq
+      | Javascript, _ -> Lt
+      | _, Javascript -> Gt
+      | Native, Native -> Eq
+      | Native, _ -> Lt
+      | _, Native -> Gt
+      | Best, Best -> Eq
 
     let to_dyn = Dyn.opaque
   end

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -270,10 +270,10 @@ end = struct
       ; name : Lib_name.t
       }
 
-    let compare t { path; name } =
-      match Lib_name.compare t.name name with
-      | Eq -> Path.compare t.path path
-      | e -> e
+    let compare { path; name } t =
+      let open Ordering.O in
+      let= () = Lib_name.compare name t.name in
+      Path.compare path t.path
 
     let to_dyn { path; name } =
       let open Dyn in

--- a/src/dune_rules/preprocess.ml
+++ b/src/dune_rules/preprocess.ml
@@ -50,17 +50,13 @@ module Pps = struct
     && List.equal String_with_vars.equal_no_loc t.flags flags
     && Bool.equal t.staged staged
 
-  let compare_no_locs compare_pps
-      { loc = _; pps = pps1; flags = flags1; staged = s1 }
-      { loc = _; pps = pps2; flags = flags2; staged = s2 } =
-    match Bool.compare s1 s2 with
-    | (Lt | Gt) as t -> t
-    | Eq -> (
-      match
-        List.compare flags1 flags2 ~compare:String_with_vars.compare_no_loc
-      with
-      | (Lt | Gt) as t -> t
-      | Eq -> List.compare pps1 pps2 ~compare:compare_pps)
+  let compare_no_locs compare_pps { pps; flags; staged; loc = _ } t =
+    let open Ordering.O in
+    let= () = Bool.compare staged t.staged in
+    let= () =
+      List.compare flags t.flags ~compare:String_with_vars.compare_no_loc
+    in
+    List.compare pps t.pps ~compare:compare_pps
 end
 
 type 'a t =

--- a/src/dune_util/ml_kind.ml
+++ b/src/dune_util/ml_kind.ml
@@ -28,9 +28,9 @@ module Dict = struct
     }
 
   let compare f { impl; intf } t =
-    match f impl t.impl with
-    | (Gt | Lt) as x -> x
-    | Eq -> f intf t.intf
+    let open Ordering.O in
+    let= () = f impl t.impl in
+    f intf t.intf
 
   let get t = function
     | Impl -> t.impl


### PR DESCRIPTION
Continuing the conversation started in #5166, this PR adds `let=` to chain comparisons, so one can write:

```ocaml
let compare { x; y; z } t =
  let open Ordering.O in
  let= () = compare_x x t.x in
  let= () = compare_y y t.y in
  compare_z z t.z
```
or, a bit less compactly but more symmetrically:
```ocaml
let compare { x; y; z } t =
  let open Ordering.O in
  let= () = compare_x x t.x in
  let= () = compare_y y t.y in
  let= () = compare_z z t.z in
  Eq
```
The resulting code is pleasant to read but I'm not entirely sure it has no overhead compared to manual `match`ing.

@jeremiedimino Btw, I couldn't use `let?` because `?` isn't an allowed operator character.

P.S.: I converted only a couple of comparison functions but if we decide that going this way is a good idea, I'm happy to adapt the rest of the Dune's code base.