### PR TITLE
Add support for Fiber cancellation

### DIFF
--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -124,7 +124,7 @@ end
 
 (** Variables local to a fiber *)
 module Var : sig
-  type 'a fiber = 'a t
+  type 'a fiber := 'a t
 
   type 'a t
 
@@ -147,7 +147,6 @@ module Var : sig
 
   val unset : 'a t -> (unit -> 'b fiber) -> 'b fiber
 end
-with type 'a fiber := 'a t
 
 (** {1 Error handling} *)
 
@@ -228,7 +227,7 @@ end
 with type 'a fiber := 'a t
 
 module Mutex : sig
-  type 'a fiber = 'a t
+  type 'a fiber := 'a t
 
   type t
 
@@ -236,12 +235,11 @@ module Mutex : sig
 
   val with_lock : t -> (unit -> 'a fiber) -> 'a fiber
 end
-with type 'a fiber := 'a t
 
 module Throttle : sig
   (** Limit the number of jobs *)
 
-  type 'a fiber = 'a t
+  type 'a fiber := 'a t
 
   type t
 
@@ -260,7 +258,6 @@ module Throttle : sig
   (** Return the number of jobs currently running *)
   val running : t -> int
 end
-with type 'a fiber := 'a t
 
 val repeat_while : f:('a -> 'a option t) -> init:'a -> unit t
 

--- a/src/fiber_util/fiber_util.ml
+++ b/src/fiber_util/fiber_util.ml
@@ -1,4 +1,5 @@
 open! Stdune
+open Fiber.O
 
 module Temp = Temp.Monad (struct
   type 'a t = 'a Fiber.t
@@ -6,3 +7,101 @@ module Temp = Temp.Monad (struct
   let protect ~f ~finally =
     Fiber.finalize f ~finally:(fun () -> finally () |> Fiber.return)
 end)
+
+module Cancellation = struct
+  type 'a outcome =
+    | Cancelled of 'a
+    | Not_cancelled
+
+  type handlers =
+    | End_of_handlers
+    | Handler of
+        { ivar : unit outcome Fiber.Ivar.t
+        ; mutable next : handlers
+        ; mutable prev : handlers
+        }
+
+  module State = struct
+    type t =
+      | Cancelled
+      | Not_cancelled of { mutable handlers : handlers }
+  end
+
+  type t = { mutable state : State.t }
+
+  let key = Fiber.Var.create ()
+
+  let create () = { state = Not_cancelled { handlers = End_of_handlers } }
+
+  let rec invoke_handlers = function
+    | Handler { ivar; next; prev = _ } ->
+      let* () = Fiber.Ivar.fill ivar (Cancelled ()) in
+      invoke_handlers next
+    | End_of_handlers -> Fiber.return ()
+
+  let fire t =
+    Fiber.of_thunk (fun () ->
+        match t.state with
+        | Cancelled -> Fiber.return ()
+        | Not_cancelled { handlers } ->
+          t.state <- Cancelled;
+          invoke_handlers handlers)
+
+  let set t fiber = Fiber.Var.set key t fiber
+
+  let cancelled =
+    Fiber.Var.get key >>| function
+    | None -> false
+    | Some t -> (
+      match t.state with
+      | Cancelled -> true
+      | Not_cancelled _ -> false)
+
+  let with_handler f ~on_cancellation =
+    Fiber.Var.get key >>= function
+    | None ->
+      let+ x = f () in
+      (x, Not_cancelled)
+    | Some t -> (
+      match t.state with
+      | Cancelled ->
+        let+ x, y = Fiber.fork_and_join f on_cancellation in
+        (x, Cancelled y)
+      | Not_cancelled h ->
+        let ivar = Fiber.Ivar.create () in
+        let node =
+          Handler { ivar; next = h.handlers; prev = End_of_handlers }
+        in
+        (match h.handlers with
+        | End_of_handlers -> ()
+        | Handler first -> first.prev <- node);
+        h.handlers <- node;
+        Fiber.fork_and_join
+          (fun () ->
+            let* y = f () in
+            match t.state with
+            | Cancelled -> Fiber.return y
+            | Not_cancelled h -> (
+              match node with
+              | End_of_handlers ->
+                (* We could avoid this [assert false] with GADT sorcery given
+                   that we created [node] just above and we know for sure it is
+                   the [Handler _] case, but it's not worth the code
+                   complexity. *)
+                assert false
+              | Handler node ->
+                (match node.prev with
+                | End_of_handlers -> h.handlers <- node.next
+                | Handler prev -> prev.next <- node.next);
+                (match node.next with
+                | End_of_handlers -> ()
+                | Handler next -> next.prev <- node.prev);
+                let+ () = Fiber.Ivar.fill ivar Not_cancelled in
+                y))
+          (fun () ->
+            Fiber.Ivar.read ivar >>= function
+            | Cancelled () ->
+              let+ x = on_cancellation () in
+              Cancelled x
+            | Not_cancelled -> Fiber.return Not_cancelled))
+end

--- a/src/fiber_util/fiber_util.mli
+++ b/src/fiber_util/fiber_util.mli
@@ -18,3 +18,48 @@ module Temp : sig
     -> f:(Path.t Or_exn.t -> 'a Fiber.t)
     -> 'a Fiber.t
 end
+
+(** Fiber cancellation *)
+module Cancellation : sig
+  (** This module provides a way to cancel long running computations.
+      Cancellation is fully explicit and fibers must explicitely check for it at
+      strategic points. *)
+
+  type t
+
+  val create : unit -> t
+
+  (** Activate a cancellation.
+
+      [fire] is idempotent, so calling [fire t] more than once has no effect. *)
+  val fire : t -> unit Fiber.t
+
+  (** [set t f] sets the current cancellation to [t] while running [f ()]. *)
+  val set : t -> (unit -> 'a Fiber.t) -> 'a Fiber.t
+
+  (** Return whether the current cancellation has been fired. Return [false] if
+      the current fiber doesn't have a cancellation set. *)
+  val cancelled : bool Fiber.t
+
+  type 'a outcome =
+    | Cancelled of 'a
+    | Not_cancelled
+
+  (** [with_handler ~on_cancel f] runs [f ()] with a cancellation handler. If
+      the current cancellation is fired during the execution of [f], then
+      [on_cancellation] is called.
+
+      The aim of [on_cancellation] is to somehow cut short the execution of [f].
+      A typical example is a function running an external command.
+      [on_cancellation] might send a [KILL] signal to the command to abort its
+      execution.
+
+      If [f ()] finished before the cancellation is fired, then
+      [on_cancellation] will never be invoked.
+
+      If the current fiber has no cancellation, this just executes [f ()]. *)
+  val with_handler :
+       (unit -> 'a Fiber.t)
+    -> on_cancellation:(unit -> 'b Fiber.t)
+    -> ('a * 'b outcome) Fiber.t
+end

--- a/test/expect-tests/fiber/dune
+++ b/test/expect-tests/fiber/dune
@@ -5,6 +5,7 @@
   dune_tests_common
   stdune
   fiber
+  fiber_util
   test_scheduler
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project

--- a/test/expect-tests/fiber/fiber_tests.ml
+++ b/test/expect-tests/fiber/fiber_tests.ml
@@ -939,3 +939,70 @@ let%expect_test "all_concurrently_unit" =
     print: 1
     successfully caught error
     multi element list |}]
+
+let%expect_test "cancel_test1" =
+  let cancel = Fiber_util.Cancellation.create () in
+  Scheduler.run
+    (Fiber_util.Cancellation.set cancel (fun () ->
+         let* x = Fiber_util.Cancellation.cancelled in
+         printf "%B\n" x;
+         let* () = Fiber_util.Cancellation.fire cancel in
+         let* x = Fiber_util.Cancellation.cancelled in
+         printf "%B\n" x;
+         Fiber.return ()));
+  [%expect {|
+    false
+    true |}]
+
+let%expect_test "cancel_test2" =
+  let cancel = Fiber_util.Cancellation.create () in
+  let ivar1 = Fiber.Ivar.create () in
+  let ivar2 = Fiber.Ivar.create () in
+  let (), what =
+    Scheduler.run
+      (Fiber_util.Cancellation.set cancel (fun () ->
+           Fiber_util.Cancellation.with_handler
+             (fun () ->
+               let* () = Fiber.Ivar.fill ivar1 () in
+               let* () = Fiber_util.Cancellation.fire cancel in
+               Fiber.Ivar.read ivar2)
+             ~on_cancellation:(fun () -> Fiber.Ivar.fill ivar2 ())))
+  in
+  print_endline
+    (match what with
+    | Cancelled () -> "PASS"
+    | Not_cancelled -> "FAIL");
+  [%expect {|
+    PASS |}]
+
+let%expect_test "cancel_test3" =
+  let cancel = Fiber_util.Cancellation.create () in
+  let (), what =
+    Scheduler.run
+      (Fiber_util.Cancellation.set cancel (fun () ->
+           Fiber_util.Cancellation.with_handler
+             (fun () -> Fiber.return ())
+             ~on_cancellation:(fun () -> assert false)))
+  in
+  print_endline
+    (match what with
+    | Cancelled () -> "FAIL"
+    | Not_cancelled -> "PASS");
+  [%expect {|
+    PASS |}]
+
+let%expect_test "cancel_test4" =
+  let cancel = Fiber_util.Cancellation.create () in
+  let (), what =
+    Scheduler.run
+      (let* () = Fiber_util.Cancellation.fire cancel in
+       Fiber_util.Cancellation.set cancel (fun () ->
+           Fiber_util.Cancellation.with_handler
+             (fun () -> Fiber.return ())
+             ~on_cancellation:(fun () -> Fiber.return ())))
+  in
+  print_endline
+    (match what with
+    | Cancelled () -> "PASS"
+    | Not_cancelled -> "FAIL");
+  [%expect {| PASS |}]


### PR DESCRIPTION
Inside JS, we need to be able to run background actions. This is currently broken because of the check inside `with_job_slot`. To workaround this, I'd to implement more fine-grained fiber cancellation so that we can cancel just the build and not all possible running fibers.

This PR add support for Fiber cancellation.