### PR TITLE
Add a test for workspace-local cache and directory targets

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -471,7 +471,8 @@ let () =
       Path.Build.Set.iter fns ~f:(fun p -> Path.Build.unlink_no_err p))
 
 let compute_target_digests (targets : Targets.Validated.t) =
-  (* CR-someday amokhov: Do not ignore directory targets. *)
+  (* CR-someday amokhov: The workspace-local cache currently does not work for
+     directory targets because we ignore [targets.dirs] here. *)
   let file_targets = Path.Build.Set.to_list targets.files in
   Option.List.traverse file_targets ~f:(fun target ->
       Cached_digest.build_file target

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -86,6 +86,13 @@ Build directory target from the command line.
   $ cat _build/default/output/y
   y
 
+Test that workspace-local cache works for directory targets.
+
+# CR-someday amokhov: Actually, it doesn't work at the moment. We should fix it.
+
+  $ dune build output/x --debug-cache=workspace-local
+  Workspace-local cache miss: _build/default/output: target changed in build dir
+
 Requesting the directory target directly works too.
 
   $ cat > dune <<EOF


### PR DESCRIPTION
While working on target promotion I realised that the workspace-local cache is currently broken for directory targets. Adding a test to demonstrate this.
