### PR TITLE
Allow to fill more than one ivar at a time

### DIFF
--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -381,6 +381,6 @@ with type 'a fiber := 'a t
 type fill = Fill : 'a Ivar.t * 'a -> fill
 
 (** [run t ~iter] runs a fiber until it terminates. [iter] is used to implement
-    the scheduler, it should block waiting for an event and return an ivar to
-    fill. *)
-val run : 'a t -> iter:(unit -> fill) -> 'a
+    the scheduler, it should block waiting for an event and return at least one
+    ivar to fill. *)
+val run : 'a t -> iter:(unit -> fill Nonempty_list.t) -> 'a

--- a/src/fiber_util/fiber_util.mli
+++ b/src/fiber_util/fiber_util.mli
@@ -34,6 +34,10 @@ module Cancellation : sig
       [fire] is idempotent, so calling [fire t] more than once has no effect. *)
   val fire : t -> unit Fiber.t
 
+  (** Version of [fire] that is suitable to call from the [iter] callback of
+      [Fiber.run]. *)
+  val fire' : t -> Fiber.fill list
+
   (** [set t f] sets the current cancellation to [t] while running [f ()]. *)
   val set : t -> (unit -> 'a Fiber.t) -> 'a Fiber.t
 

--- a/test/expect-tests/test_scheduler/test_scheduler.ml
+++ b/test/expect-tests/test_scheduler/test_scheduler.ml
@@ -27,4 +27,4 @@ let run (t : t) fiber =
       | None -> raise Never
       | Some (Job (job, ivar)) ->
         let v = job () in
-        Fiber.Fill (ivar, v))
+        [ Fiber.Fill (ivar, v) ])


### PR DESCRIPTION
This is useful to be able to fire a cancellation from the scheduler core. I initially wondered about just making the `iter` callback return a general `unit Fiber.t`, but then it's a bit awkward if this fiber yields. We could detect it and raise, but I opted for a slightly heavier style and a compile time guarantee rather than more flexibility and a runtime check.