### PR TITLE
When restarting a build, don't cancel fibers unrelated to the build

### DIFF
--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -7,6 +7,7 @@
   stdune
   dyn
   fiber
+  fiber_util
   incremental_cycles
   dag
   memo

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -127,6 +127,10 @@ val wait_for_process :
 
 val yield_if_there_are_pending_events : unit -> unit Fiber.t
 
+(** If the current build was cancelled, raise
+    [Memo.Non_reproducible Run.Build_cancelled]. *)
+val abort_if_build_was_cancelled : unit Fiber.t
+
 (** Number of jobs currently running in the background *)
 val running_jobs_count : t -> int
 

--- a/src/fiber_util/fiber_util.mli
+++ b/src/fiber_util/fiber_util.mli
@@ -38,32 +38,26 @@ module Cancellation : sig
       [Fiber.run]. *)
   val fire' : t -> Fiber.fill list
 
-  (** [set t f] sets the current cancellation to [t] while running [f ()]. *)
-  val set : t -> (unit -> 'a Fiber.t) -> 'a Fiber.t
-
-  (** Return whether the current cancellation has been fired. Return [false] if
-      the current fiber doesn't have a cancellation set. *)
-  val cancelled : bool Fiber.t
+  (** Return whether the given cancellation has been fired. *)
+  val fired : t -> bool
 
   type 'a outcome =
     | Cancelled of 'a
     | Not_cancelled
 
-  (** [with_handler ~on_cancel f] runs [f ()] with a cancellation handler. If
-      the current cancellation is fired during the execution of [f], then
-      [on_cancellation] is called.
+  (** [with_handler t ~on_cancellation f] runs [f ()] with a cancellation handler. If
+      [t] is fired during the execution of [f], then [on_cancellation] is called.
 
       The aim of [on_cancellation] is to somehow cut short the execution of [f].
       A typical example is a function running an external command.
       [on_cancellation] might send a [KILL] signal to the command to abort its
       execution.
 
-      If [f ()] finished before the cancellation is fired, then
-      [on_cancellation] will never be invoked.
-
-      If the current fiber has no cancellation, this just executes [f ()]. *)
+      If [f ()] finished before [t] is fired, then [on_cancellation] will never
+      be invoked. *)
   val with_handler :
-       (unit -> 'a Fiber.t)
+       t
+    -> (unit -> 'a Fiber.t)
     -> on_cancellation:(unit -> 'b Fiber.t)
     -> ('a * 'b outcome) Fiber.t
 end

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1109,7 +1109,7 @@ let report_and_collect_errors f =
       ({ exns = Exn_set.singleton exn; reproducible } : Collect_errors_monoid.t))
     f
 
-let yield_if_there_are_pending_events = ref Fiber.return
+let check_point = ref (Fiber.return ())
 
 module Exec : sig
   val exec_dep_node : ('i, 'o) Dep_node.t -> 'o Fiber.t
@@ -1203,7 +1203,7 @@ end = struct
         -> stack_frame:Stack_frame_with_state.t
         -> 'o Cached_value.t Fiber.t =
    fun ~dep_node ~old_value ~stack_frame ->
-    let* () = !yield_if_there_are_pending_events () in
+    let* () = !check_point in
     let+ res =
       report_and_collect_errors (fun () ->
           dep_node.without_state.spec.f dep_node.without_state.input)

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -513,4 +513,9 @@ module For_tests : sig
   val clear_memoization_caches : unit -> unit
 end
 
-val yield_if_there_are_pending_events : (unit -> unit Fiber.t) ref
+(** A check point. This fiber should be used to:
+
+    - yield if there are external events that have priority over the current
+      memo computation
+    - raise if the current computation was cancelled so that Memo can avoid unnecessary work *)
+val check_point : unit Fiber.t ref

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -76,4 +76,4 @@ let%expect_test "cancelling a build: effect on other fibers" =
             | Ok () -> "PASS: we can still run things outside the build"
             | Error _ -> "FAIL: other fiber got cancelled");
           Scheduler.shutdown ()));
-  [%expect {| FAIL: other fiber got cancelled |}]
+  [%expect {| PASS: we can still run things outside the build |}]

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -1,0 +1,79 @@
+open Stdune
+open! Dune_tests_common
+open Dune_engine
+open Fiber.O
+
+let go f =
+  let config =
+    { Scheduler.Config.concurrency = 1
+    ; display = { verbosity = Short; status_line = false }
+    ; rpc = None
+    ; stats = None
+    }
+  in
+  try
+    Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ()) f
+  with
+  | Scheduler.Run.Shutdown_requested -> ()
+
+let true_ = Bin.which "true" ~path:(Env.path Env.initial) |> Option.value_exn
+
+let cell = Memo.lazy_cell Memo.Build.return
+
+let%expect_test "cancelling a build" =
+  let build_started = Fiber.Ivar.create () in
+  let build_cancelled = Fiber.Ivar.create () in
+  go (fun () ->
+      Fiber.fork_and_join_unit
+        (fun () ->
+          Scheduler.Run.poll
+            (let* () = Fiber.Ivar.fill build_started () in
+             let* () = Fiber.Ivar.read build_cancelled in
+             let* res =
+               Fiber.collect_errors (fun () ->
+                   Scheduler.with_job_slot (fun _ -> Fiber.return ()))
+             in
+             print_endline
+               (match res with
+               | Ok () -> "FAIL: build wasn't cancelled"
+               | Error _ -> "PASS: build was cancelled");
+             let* () = Scheduler.shutdown () in
+             Fiber.never))
+        (fun () ->
+          let* () = Fiber.Ivar.read build_started in
+          let* () =
+            Scheduler.inject_memo_invalidation
+              (Memo.Cell.invalidate cell ~reason:Unknown)
+          in
+          (* Wait for the scheduler to acknowledge the change *)
+          let* () = Scheduler.wait_for_build_input_change () in
+          Fiber.Ivar.fill build_cancelled ()));
+  [%expect {| PASS: build was cancelled |}]
+
+(* CR-soon jeremiedimino: currently cancelling a build cancels not only this
+   build but also all runing fibers, including ones that are unrelated. *)
+let%expect_test "cancelling a build: effect on other fibers" =
+  let build_started = Fiber.Ivar.create () in
+  go (fun () ->
+      Fiber.fork_and_join_unit
+        (fun () ->
+          Scheduler.Run.poll
+            (let* () = Fiber.Ivar.fill build_started () in
+             Fiber.never))
+        (fun () ->
+          let* () = Fiber.Ivar.read build_started in
+          let* () =
+            Scheduler.inject_memo_invalidation
+              (Memo.Cell.invalidate cell ~reason:Unknown)
+          in
+          let* () = Scheduler.wait_for_build_input_change () in
+          let* res =
+            Fiber.collect_errors (fun () ->
+                Scheduler.with_job_slot (fun _ -> Fiber.return ()))
+          in
+          print_endline
+            (match res with
+            | Ok () -> "PASS: we can still run things outside the build"
+            | Error _ -> "FAIL: other fiber got cancelled");
+          Scheduler.shutdown ()));
+  [%expect {| FAIL: other fiber got cancelled |}]


### PR DESCRIPTION
At the moment, when we restart a build we cancel all fibers, independently of whether they are part of the current build or not. For instance, this means that processes ran by other systems such as the RPC get cancelled as well, which is odd. This is problematic inside Jane Street as we need to run background hg commands.

This PR adds a test exposing this behaviour and then fixes it locally setting a new `Fiber_util.Cancellation.t` in each build.