### PR TITLE
Log whether the shared cache is enabled or not

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -179,6 +179,10 @@ let init ?log_file c =
         ; reproducibility_check = config.cache_reproducibility_check
         }
   in
+  Dune_util.Log.info
+    [ Pp.textf "Shared cache: %s"
+        (Dune_config.Cache.Enabled.to_string config.cache_enabled)
+    ];
   Dune_rules.Main.init ~stats:c.stats
     ~sandboxing_preference:config.sandboxing_preference ~cache_config
     ~cache_debug_flags:c.cache_debug_flags


### PR DESCRIPTION
We recently had an issue inside Jane Street where Dune was running with the shared cache enabled by default inside cram tests. This was causing failures in the CI.

This PR logs the shared cache status so that we can check that the cache is disabled. Plus, it seems generally useful to know in reports whether the shared cache was in use or not.