### PR TITLE
Add default cxx link flags to `ocamlmklib` and  `ocamlc` calls

### DIFF
--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -1,16 +1,23 @@
 open! Stdune
 open Dune_engine
 
+type phase =
+  | Compile
+  | Link
+
 type ccomp_type =
   | Gcc
   | Msvc
   | Clang
   | Other of string
 
-let base_cxx_flags = function
-  | Gcc -> [ "-x"; "c++"; "-lstdc++"; "-shared-libgcc" ]
-  | Clang -> [ "-x"; "c++" ]
-  | Msvc -> [ "/TP" ]
+let base_cxx_flags ~for_ cc =
+  match (cc, for_) with
+  | Gcc, Compile -> [ "-x"; "c++" ]
+  | Gcc, Link -> [ "-lstdc++"; "-shared-libgcc" ]
+  | Clang, Compile -> [ "-x"; "c++" ]
+  | Clang, Link -> [ "-lc++" ]
+  | Msvc, Compile -> [ "/TP" ]
   | _ -> []
 
 let preprocessed_filename = "ccomp"
@@ -38,8 +45,8 @@ let check_warn = function
       ]
   | _ -> ()
 
-let get_flags dir =
+let get_flags ~for_ dir =
   let open Action_builder.O in
   let+ ccomp_type = ccomp_type dir in
   check_warn ccomp_type;
-  base_cxx_flags ccomp_type
+  base_cxx_flags ~for_ ccomp_type

--- a/src/dune_rules/cxx_flags.mli
+++ b/src/dune_rules/cxx_flags.mli
@@ -4,10 +4,14 @@ open! Stdune
 
 open Dune_engine
 
+type phase =
+  | Compile
+  | Link
+
 (** The name of the file created in the .dune folder after calling the C
     preprocessor *)
 val preprocessed_filename : string
 
 (** [get_flags c_compiler] returns the necessary flags to turn this compiler
     into a c++ compiler for some of the most common compilers *)
-val get_flags : Path.Build.t -> string list Action_builder.t
+val get_flags : for_:phase -> Path.Build.t -> string list Action_builder.t

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -341,6 +341,11 @@ module Buildable = struct
 
   let has_foreign t =
     List.is_non_empty t.foreign_stubs || List.is_non_empty t.foreign_archives
+
+  let has_foreign_cxx t =
+    List.exists
+      ~f:(fun stub -> Foreign_language.(equal Cxx stub.Foreign.Stubs.language))
+      t.foreign_stubs
 end
 
 module Public_lib = struct
@@ -777,6 +782,8 @@ module Library = struct
       |> String.concat ~sep:"/" |> Option.some
 
   let has_foreign t = Buildable.has_foreign t.buildable
+
+  let has_foreign_cxx t = Buildable.has_foreign_cxx t.buildable
 
   let foreign_archives t =
     (if List.is_empty t.buildable.foreign_stubs then
@@ -1525,6 +1532,8 @@ module Executables = struct
     (make false, make true)
 
   let has_foreign t = Buildable.has_foreign t.buildable
+
+  let has_foreign_cxx t = Buildable.has_foreign_cxx t.buildable
 
   let obj_dir t ~dir = Obj_dir.make_exe ~dir ~name:(snd (List.hd t.names))
 end

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -49,6 +49,9 @@ module Buildable : sig
 
   (** Check if the buildable has any foreign stubs or archives. *)
   val has_foreign : t -> bool
+
+  (** Check if the buildable has any c++ foreign stubs. *)
+  val has_foreign_cxx : t -> bool
 end
 
 module Public_lib : sig
@@ -162,6 +165,9 @@ module Library : sig
   (** Check if the library has any foreign stubs or archives. *)
   val has_foreign : t -> bool
 
+  (** Check if the library has any c++ foreign stubs. *)
+  val has_foreign_cxx : t -> bool
+
   (** The list of all foreign archives, including the foreign stubs archive. *)
   val foreign_archives : t -> Foreign.Archive.t list
 
@@ -261,6 +267,9 @@ module Executables : sig
 
   (** Check if the executables have any foreign stubs or archives. *)
   val has_foreign : t -> bool
+
+  (** Check if the executables have any c++ foreign stubs. *)
+  val has_foreign_cxx : t -> bool
 
   val obj_dir : t -> dir:Path.Build.t -> Path.Build.t Obj_dir.t
 end

--- a/src/dune_rules/foreign.ml
+++ b/src/dune_rules/foreign.ml
@@ -191,6 +191,10 @@ module Sources = struct
     String.Map.keys t
     |> List.map ~f:(fun c -> Path.Build.relative dir (c ^ ext_obj))
 
+  let has_cxx_sources (t : t) =
+    String.Map.exists t ~f:(fun (_loc, source) ->
+        Foreign_language.(equal Cxx source.stubs.language))
+
   module Unresolved = struct
     type t = (Foreign_language.t * Path.Build.t) String.Map.Multi.t
 

--- a/src/dune_rules/foreign.mli
+++ b/src/dune_rules/foreign.mli
@@ -166,6 +166,8 @@ module Sources : sig
   val object_files :
     t -> dir:Path.Build.t -> ext_obj:string -> Path.Build.t list
 
+  val has_cxx_sources : t -> bool
+
   (** A map from object names to lists of possible language/path combinations. *)
   module Unresolved : sig
     type t = (Foreign_language.t * Path.Build.t) String.Map.Multi.t

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -16,7 +16,7 @@ let default_context_flags (ctx : Context.t) ~project =
       let c = cflags @ Ocaml_config.ocamlc_cppflags ctx.ocaml_config in
       let cxx =
         let open Action_builder.O in
-        let+ db_flags = Cxx_flags.get_flags ctx.build_dir in
+        let+ db_flags = Cxx_flags.get_flags ~for_:Compile ctx.build_dir in
         db_flags @ cxxflags
       in
       (Action_builder.return c, cxx)

--- a/test/blackbox-tests/test-cases/cxx-flags.t/baz.cpp
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/baz.cpp
@@ -1,2 +1,12 @@
 #include <caml/mlvalues.h>
+#include <caml/io.h>
+#include <iostream>
+
 extern "C" value baz(value unit) { return Val_int(2046); }
+
+extern "C" void hello_world_baz ();
+
+void hello_world_baz ()
+{
+  std::cout << "Hello World Baz!\n";
+}

--- a/test/blackbox-tests/test-cases/cxx-flags.t/bazexe.cpp
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/bazexe.cpp
@@ -1,0 +1,11 @@
+#include <caml/mlvalues.h>
+#include <iostream>
+
+extern "C" value bazexe(value unit) { return Val_int(4096); }
+
+extern "C" void hello_world_bazexe ();
+
+void hello_world_bazexe ()
+{
+  std::cout << "Hello World Bazexe!";
+}

--- a/test/blackbox-tests/test-cases/cxx-flags.t/dune
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/dune
@@ -6,5 +6,5 @@
 (executable
  (name main)
  (libraries quad)
+ (foreign_stubs (language cxx) (names bazexe))
  (modules main))
-

--- a/test/blackbox-tests/test-cases/cxx-flags.t/main.ml
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/main.ml
@@ -1,1 +1,9 @@
-let () = Printf.printf "%d" (Quad.quad ())
+external bazexe : unit -> int = "bazexe"
+external hello_world_bazexe : unit -> unit = "hello_world_bazexe"
+
+let () = Quad.hello (); hello_world_bazexe ()
+
+
+let () = Printf.printf "%d\n%d\n"
+  (Quad.quad ())
+  (bazexe ())

--- a/test/blackbox-tests/test-cases/cxx-flags.t/quad.ml
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/quad.ml
@@ -1,2 +1,6 @@
 external baz : unit -> int = "baz"
+
+external hello_world_baz : unit -> unit = "hello_world_baz"
+
 let quad x = baz x
+let hello () = hello_world_baz ()

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -5,10 +5,18 @@ Default: use_standard_c_and_cxx_flags = false
   > (lang dune 2.8)
   > EOF
 
-> The flags that Dune should use
-  $ GCCF="-x c++ -lstdc++ -shared-libgcc"
-  $ ClangF="-x c++"
-  $ MsvcF="/TP"
+> The flags that Dune should use for compilation
+  $ GCC_CF="-x c++"
+  $ Clang_CF="-x c++"
+  $ Msvc_CF="/TP"
+
+> And linking
+  $ GCC_LF_OPT=" -ldopt -lstdc++ -ldopt -shared-libgcc"
+  $ Clang_LF_OPT=" -ldopt -lc++"
+  $ Msvc_LF_OPT=""
+  $ GCC_LF_LIB=" -cclib -lstdc++ -cclib -shared-libgcc"
+  $ Clang_LF_LIB=" -cclib -lc++"
+  $ Msvc_LF_LIB=""
 
 > Check that compiler detection is done
   $ dune build .dune/ccomp/ccomp
@@ -17,12 +25,25 @@ Default: use_standard_c_and_cxx_flags = false
   > grep -ce "clang\|gcc\|msvc"
   1
 
-> No specific flags added
+> No specific flags added for compilation...
   $ dune rules baz.o | tr -s '\n' ' ' |
-  > grep -ce "$GCCF\|$ClangF|$MsvcF"
+  > grep -ce "$GCC_CF\|$Clang_CF|$Msvc_CF"
   0
   [1]
 
+  $ dune rules bazexe.o  | tr -s '\n' ' ' |
+  > grep -ce "$GCC_CF\|$Clang_CF\|$Msvc_CF"
+  0
+  [1]
+
+> ...nor linking
+  $ dune rules libquad_stubs.a  | tr -s '\n' ' ' |
+  > grep -ce "quad_stubs baz.o)"
+  1
+
+  $ dune rules main.exe  | tr -s '\n' ' ' |
+  > grep -ce "Main.cmx)"
+  1
 
 With use_standard_c_and_cxx_flags = false
 =========================================
@@ -32,11 +53,25 @@ With use_standard_c_and_cxx_flags = false
   > (use_standard_c_and_cxx_flags false)
   > EOF
 
-> No specific flags added
+> No specific flags added for compilation...
   $ dune rules baz.o | tr -s '\n' ' ' |
-  > grep -ce "$GCCF\|$ClangF|$MsvcF"
+  > grep -ce "$GCC_CF\|$Clang_CF|$Msvc_CF"
   0
   [1]
+
+  $ dune rules bazexe.o  | tr -s '\n' ' ' |
+  > grep -ce "$GCC_CF\|$Clang_CF\|$Msvc_CF"
+  0
+  [1]
+
+> ...nor linking
+  $ dune rules libquad_stubs.a  | tr -s '\n' ' ' |
+  > grep -ce "quad_stubs baz.o)"
+  1
+
+  $ dune rules main.exe  | tr -s '\n' ' ' |
+  > grep -ce "Main.cmx)"
+  1
 
 With use_standard_c_and_cxx_flags = true
 ========================================
@@ -53,10 +88,26 @@ With use_standard_c_and_cxx_flags = true
   > grep -ce "clang\|gcc\|msvc"
   1
 
-> Specific flags added
+> Specific flags added for compilation...
   $ dune rules baz.o  | tr -s '\n' ' ' |
-  > grep -ce "$GCCF\|$ClangF\|$MsvcF"
+  > grep -ce "$GCC_CF\|$Clang_CF\|$Msvc_CF"
+  1
+
+  $ dune rules bazexe.o  | tr -s '\n' ' ' |
+  > grep -ce "$GCC_CF\|$Clang_CF\|$Msvc_CF"
+  1
+
+> ..and link
+  $ dune rules libquad_stubs.a  | tr -s '\n' ' ' |
+  > grep -ce "quad_stubs baz.o$GCC_LF_OPT)\|quad_stubs baz.o$Clang_LF_OPT)\|quad_stubs baz.o$Msvc_LF_OPT)"
+  1
+
+  $ dune rules main.exe  | tr -s '\n' ' ' |
+  > grep -ce "Main.cmx$GCC_LF)\|Main.cmx$Clang_LF)\|Main.cmx$Msvc_LF)"
   1
 
   $ dune exec ./main.exe
   2046
+  4096
+  Hello World Baz!
+  Hello World Bazexe!


### PR DESCRIPTION
In Dune 3.0 the option `use_standard_c_and_cxx_flags` will be enabled by default.
However an issue exist with the current implementations: all the default flags were provided at compile time and none during the link. Discussion about that issue can be found in PR #4846.

This PR fixes that by adding link time flags like `-lstdc++` or `-shared-libgcc` (depending on the detected compiler) to 
`ocamlmklib` and `ocamlc/opt` invocations when one or more stubs is in C++.

CC @recoules