### PR TITLE
Add [Targets.Produced]

### DIFF
--- a/otherlibs/stdune-unstable/interned.ml
+++ b/otherlibs/stdune-unstable/interned.ml
@@ -98,7 +98,7 @@ module Make (R : Settings) () = struct
     let make l = List.fold_left l ~init:empty ~f:(fun acc s -> add acc (make s))
   end
 
-  module Map = Map.Make (T)
+  module Map = O.Map
 end
 
 module No_interning (R : Settings) () = struct

--- a/otherlibs/stdune-unstable/interned_intf.ml
+++ b/otherlibs/stdune-unstable/interned_intf.ml
@@ -20,15 +20,15 @@ module type S = sig
   (** Return the list of all existing [t]s. *)
   val all : unit -> t list
 
+  module Map : Map.S with type key = t
+
   module Set : sig
-    include Set.S with type elt = t
+    include Set.S with type elt = t and type 'a map = 'a Map.t
 
     val to_dyn : t -> Dyn.t
 
     val make : string list -> t
   end
-
-  module Map : Map.S with type key = t
 
   (** Same as a hash table, but optimized for the case where we are using one
       entry for every possible [t] *)

--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -166,14 +166,14 @@ end = struct
     else
       String.is_prefix ~prefix:(to_string a ^ "/") (to_string b)
 
+  module Map = T.Map
+
   module Set = struct
     include T.Set
 
     let of_listing ~dir ~filenames =
       of_list_map filenames ~f:(fun f -> relative dir f)
   end
-
-  module Map = T.Map
 end
 
 module Unspecified = Path_intf.Unspecified
@@ -469,15 +469,15 @@ end = struct
   struct
     type _w = Root.w
 
+    module Table = Table
+    module Map = T.Map
+
     module Set = struct
       include T.Set
 
       let of_listing ~dir ~filenames =
         of_list_map filenames ~f:(fun f -> relative dir f)
     end
-
-    module Map = T.Map
-    module Table = Table
   end
 end
 
@@ -805,8 +805,6 @@ let is_root = function
   | In_build_dir _
   | External _ ->
     false
-
-module Map = Map.Make (T)
 
 let kind = function
   | In_build_dir p -> Kind.append_local (Fdecl.get Build.build_dir) p
@@ -1232,6 +1230,7 @@ let set_extension t ~ext =
   | In_source_tree t -> in_source_tree (Local.set_extension t ~ext)
 
 module O = Comparable.Make (T)
+module Map = O.Map
 
 module Set = struct
   include O.Set

--- a/otherlibs/stdune-unstable/path_intf.ml
+++ b/otherlibs/stdune-unstable/path_intf.ml
@@ -29,15 +29,15 @@ module type S = sig
 
   val extend_basename : t -> suffix:string -> t
 
+  module Map : Map.S with type key = t
+
   module Set : sig
-    include Set.S with type elt = t
+    include Set.S with type elt = t and type 'a map = 'a Map.t
 
     val to_dyn : t Dyn.builder
 
     val of_listing : dir:elt -> filenames:string list -> t
   end
-
-  module Map : Map.S with type key = t
 
   module Table : Hashtbl.S with type key = t
 
@@ -98,15 +98,15 @@ module type Local_gen = sig
   module Fix_root (Root : sig
     type w
   end) : sig
+    module Map : Map.S with type key = Root.w t
+
     module Set : sig
-      include Set.S with type elt = Root.w t
+      include Set.S with type elt = Root.w t and type 'a map = 'a Map.t
 
       val to_dyn : t Dyn.builder
 
       val of_listing : dir:elt -> filenames:string list -> t
     end
-
-    module Map : Map.S with type key = Root.w t
 
     module Table : Hashtbl.S with type key = Root.w t
   end

--- a/otherlibs/stdune-unstable/string.mli
+++ b/otherlibs/stdune-unstable/string.mli
@@ -110,20 +110,20 @@ val findi : string -> f:(char -> bool) -> int option
 (** Find index of last character satisfying [f] *)
 val rfindi : string -> f:(char -> bool) -> int option
 
-module Set : sig
-  include Set.S with type elt = t
-
-  val pp : Format.formatter -> t -> unit
-
-  val to_dyn : t -> Dyn.t
-end
-
 module Map : sig
   include Map.S with type key = t
 
   val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 
   val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
+end
+
+module Set : sig
+  include Set.S with type elt = t and type 'a map = 'a Map.t
+
+  val pp : Format.formatter -> t -> unit
+
+  val to_dyn : t -> Dyn.t
 end
 
 module Table : Hashtbl.S with type key = t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -476,7 +476,7 @@ let compute_target_digests (targets : Targets.Validated.t) :
   let targets =
     Targets.Produced.of_validated_files targets ~on_dir_target:`Ignore
   in
-  Targets.Produced.with_digests targets ~f:(fun target ->
+  Targets.Produced.Option.mapi targets ~f:(fun target () ->
       Cached_digest.build_file target |> Cached_digest.Digest_result.to_option)
 
 let compute_target_digests_or_raise_error exec_params ~loc ~produced_targets :
@@ -497,7 +497,7 @@ let compute_target_digests_or_raise_error exec_params ~loc ~produced_targets :
     Cached_digest.refresh ~remove_write_permissions
   in
   match
-    Targets.Produced.with_digests produced_targets ~f:(fun target ->
+    Targets.Produced.Option.mapi produced_targets ~f:(fun target () ->
         compute_digest target |> Cached_digest.Digest_result.to_option)
   with
   | Some result -> result

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -469,17 +469,19 @@ let () =
       pending_file_targets := Path.Build.Set.empty;
       Path.Build.Set.iter fns ~f:(fun p -> Path.Build.unlink_no_err p))
 
-let compute_target_digests (targets : Targets.Validated.t) =
+let compute_target_digests (targets : Targets.Validated.t) :
+    Digest.t Targets.Produced.t option =
   (* CR-someday amokhov: The workspace-local cache currently does not work for
      directory targets because we ignore [targets.dirs] here. *)
-  let file_targets = Path.Build.Set.to_list targets.files in
-  Option.List.traverse file_targets ~f:(fun target ->
-      Cached_digest.build_file target
-      |> Cached_digest.Digest_result.to_option
-      |> Option.map ~f:(fun digest -> (target, digest)))
+  let targets =
+    Targets.Produced.of_validated_files targets ~on_dir_target:`Ignore
+  in
+  Targets.Produced.with_digests targets ~f:(fun target ->
+      Cached_digest.build_file target |> Cached_digest.Digest_result.to_option)
 
-let compute_target_digests_or_raise_error exec_params ~loc file_targets =
-  let remove_write_permissions =
+let compute_target_digests_or_raise_error exec_params ~loc
+    ~(targets : unit Targets.Produced.t) : Digest.t Targets.Produced.t =
+  let compute_digest =
     (* Remove write permissions on targets. A first theoretical reason is that
        the build process should be a computational graph and targets should not
        change state once built. A very practical reason is that enabling the
@@ -488,78 +490,88 @@ let compute_target_digests_or_raise_error exec_params ~loc file_targets =
     (* FIXME: searching the dune version for each single target seems way
        suboptimal. This information could probably be stored in rules
        directly. *)
-    if Path.Build.Set.is_empty file_targets then
-      false
-    else
+    let remove_write_permissions =
       Execution_parameters.should_remove_write_permissions_on_generated_files
         exec_params
-  in
-  let good, missing, errors =
-    let process_target target (good, missing, errors) =
-      let expected_syscall_path = Path.to_string (Path.build target) in
-      match Cached_digest.refresh ~remove_write_permissions target with
-      | Ok digest -> ((target, digest) :: good, missing, errors)
-      | No_such_file -> (good, target :: missing, errors)
-      | Broken_symlink ->
-        let error = [ Pp.verbatim "Broken symlink" ] in
-        (good, missing, (target, error) :: errors)
-      | Unexpected_kind file_kind ->
-        let error =
-          [ Pp.verbatim
-              (sprintf "Unexpected file kind %S (%s)"
-                 (File_kind.to_string file_kind)
-                 (File_kind.to_string_hum file_kind))
-          ]
-        in
-        (good, missing, (target, error) :: errors)
-      | Unix_error (error, syscall, path) ->
-        let error =
-          [ (if String.equal expected_syscall_path path then
-              Pp.verbatim syscall
-            else
-              Pp.concat
-                [ Pp.verbatim syscall
-                ; Pp.verbatim " "
-                ; Pp.verbatim (String.maybe_quoted path)
-                ])
-          ; Pp.text (Unix.error_message error)
-          ]
-        in
-        (good, missing, (target, error) :: errors)
-      | Error exn ->
-        let error =
-          match exn with
-          | Sys_error msg ->
-            [ Pp.verbatim
-                (String.drop_prefix_if_exists
-                   ~prefix:(expected_syscall_path ^ ": ")
-                   msg)
-            ]
-          | exn -> [ Pp.verbatim (Printexc.to_string exn) ]
-        in
-        (good, missing, (target, error) :: errors)
     in
-    Path.Build.Set.fold file_targets ~init:([], [], []) ~f:process_target
+    Cached_digest.refresh ~remove_write_permissions
   in
-  match (missing, errors) with
-  | [], [] -> List.rev good
-  | missing, errors ->
-    User_error.raise ~loc
-      ((match missing with
-       | [] -> []
-       | _ ->
-         [ Pp.textf "Rule failed to generate the following targets:"
-         ; pp_paths (Path.Set.of_list (List.map ~f:Path.build missing))
-         ])
-      @
-      match errors with
-      | [] -> []
-      | _ ->
-        [ Pp.textf "Error trying to read targets after a rule was run:"
-        ; Pp.enumerate (List.rev errors) ~f:(fun (target, error) ->
-              Pp.concat ~sep:(Pp.verbatim ": ")
-                (pp_path (Path.build target) :: error))
-        ])
+  match
+    Targets.Produced.with_digests targets ~f:(fun target ->
+        compute_digest target |> Cached_digest.Digest_result.to_option)
+  with
+  | Some result -> result
+  | None -> (
+    let missing, errors =
+      let process_target target (missing, errors) =
+        let expected_syscall_path = Path.to_string (Path.build target) in
+        match compute_digest target with
+        | Ok (_ : Digest.t) -> (missing, errors)
+        | No_such_file -> (target :: missing, errors)
+        | Broken_symlink ->
+          let error = [ Pp.verbatim "Broken symlink" ] in
+          (missing, (target, error) :: errors)
+        | Unexpected_kind file_kind ->
+          let error =
+            [ Pp.verbatim
+                (sprintf "Unexpected file kind %S (%s)"
+                   (File_kind.to_string file_kind)
+                   (File_kind.to_string_hum file_kind))
+            ]
+          in
+          (missing, (target, error) :: errors)
+        | Unix_error (error, syscall, path) ->
+          let error =
+            [ (if String.equal expected_syscall_path path then
+                Pp.verbatim syscall
+              else
+                Pp.concat
+                  [ Pp.verbatim syscall
+                  ; Pp.verbatim " "
+                  ; Pp.verbatim (String.maybe_quoted path)
+                  ])
+            ; Pp.text (Unix.error_message error)
+            ]
+          in
+          (missing, (target, error) :: errors)
+        | Error exn ->
+          let error =
+            match exn with
+            | Sys_error msg ->
+              [ Pp.verbatim
+                  (String.drop_prefix_if_exists
+                     ~prefix:(expected_syscall_path ^ ": ")
+                     msg)
+              ]
+            | exn -> [ Pp.verbatim (Printexc.to_string exn) ]
+          in
+          (missing, (target, error) :: errors)
+      in
+      Path.Build.Map.foldi (Targets.Produced.all_files targets) ~init:([], [])
+        ~f:(fun target () -> process_target target)
+    in
+    match (missing, errors) with
+    | [], [] ->
+      Code_error.raise
+        "compute_target_digests_or_raise_error: spurious target digest failure"
+        [ ("targets", Targets.Produced.to_dyn targets) ]
+    | missing, errors ->
+      User_error.raise ~loc
+        ((match missing with
+         | [] -> []
+         | _ ->
+           [ Pp.textf "Rule failed to generate the following targets:"
+           ; pp_paths (Path.Set.of_list (List.map ~f:Path.build missing))
+           ])
+        @
+        match errors with
+        | [] -> []
+        | _ ->
+          [ Pp.textf "Error trying to read targets after a rule was run:"
+          ; Pp.enumerate (List.rev errors) ~f:(fun (target, error) ->
+                Pp.concat ~sep:(Pp.verbatim ": ")
+                  (pp_path (Path.build target) :: error))
+          ]))
 
 let rec with_locks t mutexes ~f =
   match mutexes with
@@ -1420,8 +1432,8 @@ end = struct
      to restore artifacts from the shared cache, we should send a download
      request for [rule_digest] to the cloud. *)
   let try_to_restore_from_shared_cache ~debug_shared_cache ~mode ~rule_digest
-      ~head_target ~target_dir : (_, Shared_cache_miss_reason.t) Cache_result.t
-      =
+      ~head_target ~target_dir :
+      (Digest.t Targets.Produced.t, Shared_cache_miss_reason.t) Cache_result.t =
     let key () = shared_cache_key_string_for_log ~rule_digest ~head_target in
     match Dune_cache.Local.restore_artifacts ~mode ~rule_digest ~target_dir with
     | Restored res ->
@@ -1431,13 +1443,13 @@ end = struct
          directory appeared *)
       if debug_shared_cache then
         Log.info [ Pp.textf "cache restore success %s" (key ()) ];
-      Hit res
+      Hit (Targets.Produced.of_file_list_exn res)
     | Not_found_in_cache -> Miss Not_found_in_cache
     | Error exn -> Miss (Error (Printexc.to_string exn))
 
   module Exec_result = struct
     type t =
-      { files_in_directory_targets : Path.Build.Set.t
+      { produced_targets : unit Targets.Produced.t
       ; action_exec_result : Action_exec.Exec_result.t
       }
   end
@@ -1450,14 +1462,9 @@ end = struct
         ; attached_to_alias : bool
         }
 
-  let remove_stamp_file files = function
-    | Normal_rule -> files
-    | Anonymous_action { stamp_file; _ } ->
-      Path.Build.Set.remove files stamp_file
-
   let execute_action_for_rule t ~rule_kind ~rule_digest ~action ~deps ~loc
       ~(context : Build_context.t option) ~execution_parameters ~sandbox_mode
-      ~dir ~(targets : Targets.Validated.t) =
+      ~dir ~(targets : Targets.Validated.t) : Exec_result.t Fiber.t =
     let open Fiber.O in
     let { Action.Full.action
         ; env
@@ -1534,17 +1541,25 @@ end = struct
             Action_exec.exec ~root ~context ~env ~targets:(Some targets)
               ~rule_loc:loc ~build_deps ~execution_parameters action
           in
-          let files_in_directory_targets =
+          let produced_targets =
             match sandbox with
-            | None -> Path.Build.Set.empty
+            | None ->
+              (* Directory targets are not allowed for non-sandboxed actions, so
+                 the call below should not raise. *)
+              Targets.Produced.of_validated_files targets ~on_dir_target:`Raise
             | Some sandbox ->
               (* The stamp file for anonymous actions is always created outside
                  the sandbox, so we can't move it. *)
-              let files = remove_stamp_file targets.files rule_kind in
-              Sandbox.move_targets_to_build_dir sandbox ~loc ~files
-                ~dirs:targets.dirs
+              let should_be_skipped =
+                match rule_kind with
+                | Normal_rule -> fun (_ : Path.Build.t) -> false
+                | Anonymous_action { stamp_file; _ } ->
+                  Path.Build.equal stamp_file
+              in
+              Sandbox.move_targets_to_build_dir sandbox ~loc ~should_be_skipped
+                ~targets
           in
-          { Exec_result.files_in_directory_targets; action_exec_result })
+          { Exec_result.produced_targets; action_exec_result })
     in
     (match sandbox with
     | Some sandbox -> Sandbox.destroy sandbox
@@ -1554,7 +1569,8 @@ end = struct
         Path.Build.Set.diff !pending_file_targets targets.files);
     exec_result
 
-  let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~file_targets =
+  let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~file_targets :
+      Digest.t Targets.Produced.t option Fiber.t =
     let open Fiber.O in
     let hex = Digest.to_string rule_digest in
     let pp_error msg =
@@ -1569,10 +1585,12 @@ end = struct
     in
     let update_cached_digests ~targets_and_digests =
       List.iter targets_and_digests ~f:(fun (target, digest) ->
-          Cached_digest.set target digest)
+          Cached_digest.set target digest);
+      Some (Targets.Produced.of_file_list_exn targets_and_digests)
     in
     match
-      Path.Build.Set.to_list_map file_targets ~f:Dune_cache.Local.Target.create
+      Path.Build.Map.to_list_map file_targets ~f:(fun target () ->
+          Dune_cache.Local.Target.create target)
       |> Option.List.all
     with
     | None -> Fiber.return None
@@ -1589,12 +1607,10 @@ end = struct
         (* CR-someday amokhov: Here and in the case below we can inform the
            cloud daemon that a new cache entry can be uploaded to the cloud. *)
         Log.info [ Pp.textf "cache store success [%s]" hex ];
-        update_cached_digests ~targets_and_digests;
-        Some targets_and_digests
+        update_cached_digests ~targets_and_digests
       | Already_present targets_and_digests ->
         Log.info [ Pp.textf "cache store skipped [%s]: already present" hex ];
-        update_cached_digests ~targets_and_digests;
-        Some targets_and_digests
+        update_cached_digests ~targets_and_digests
       | Error exn ->
         Log.info [ pp_error (Printexc.to_string exn) ];
         None
@@ -1659,18 +1675,14 @@ end = struct
                   reason)
            ])
 
-  (* We do not include target names, as they are part of the rule digest. *)
-  let digest_of_target_digests (list : (Path.Build.t * Digest.t) list) =
-    Digest.generic (List.map list ~f:snd)
-
   (* Check if the workspace-local cache contains up-to-date results for a rule
      using the information stored in [Trace_db]. *)
   let lookup_workspace_local_cache ~rule_digest ~targets ~env :
-      ((Path.Build.t * Digest.t) list, _) Cache_result.t Fiber.t =
+      (Digest.t Targets.Produced.t, _) Cache_result.t Fiber.t =
     (* [prev_trace] will be [None] if [head_target] was never built before. *)
     let head_target = Targets.Validated.head targets in
     let prev_trace = Trace_db.get (Path.build head_target) in
-    let prev_trace_with_targets_and_digests =
+    let prev_trace_with_produced_targets =
       match prev_trace with
       | None -> Cache_result.Miss `No_previous_record
       | Some prev_trace -> (
@@ -1683,24 +1695,24 @@ end = struct
              available in the workspace-local cache. *)
           match compute_target_digests targets with
           | None -> Cache_result.Miss `Targets_missing
-          | Some targets_and_digests -> (
+          | Some produced_targets -> (
             match
               Digest.equal prev_trace.targets_digest
-                (digest_of_target_digests targets_and_digests)
+                (Targets.Produced.digest produced_targets)
             with
-            | true -> Hit (prev_trace, targets_and_digests)
+            | true -> Hit (prev_trace, produced_targets)
             | false -> Cache_result.Miss `Targets_changed)))
     in
-    match prev_trace_with_targets_and_digests with
+    match prev_trace_with_produced_targets with
     | Cache_result.Miss reason -> Fiber.return (Cache_result.Miss reason)
-    | Hit (prev_trace, targets_and_digests) ->
+    | Hit (prev_trace, produced_targets) ->
       (* CR-someday aalekseyev: If there's a change at one of the last stages,
          we still re-run all the previous stages, which is a bit of a waste. We
          could remember what stage needs re-running and only re-run that (and
          later stages). *)
       let rec loop stages =
         match stages with
-        | [] -> Fiber.return (Cache_result.Hit targets_and_digests)
+        | [] -> Fiber.return (Cache_result.Hit produced_targets)
         | (deps, old_digest) :: rest -> (
           let deps = Action_exec.Dynamic_dep.Set.to_dep_set deps in
           let open Fiber.O in
@@ -1715,7 +1727,7 @@ end = struct
   (* Check if the shared cache contains results for a rule and decide whether to
      use these results or rerun the rule for a reproducibility check. *)
   let lookup_shared_cache t ~rule_digest ~targets ~target_dir :
-      ((Path.Build.t * Digest.t) list, _) Cache_result.t =
+      (Digest.t Targets.Produced.t, _) Cache_result.t =
     match t.cache_config with
     | Disabled -> Miss Shared_cache_miss_reason.Cache_disabled
     | Enabled { storage_mode = mode; reproducibility_check } -> (
@@ -1735,39 +1747,34 @@ end = struct
           ~rule_digest ~target_dir)
 
   let examine_targets_and_update_shared_cache t ~loc ~can_go_in_shared_cache
-      ~rule_digest ~(targets : Targets.Validated.t) ~execution_parameters
-      ~action ~exec_result =
+      ~rule_digest ~execution_parameters ~action ~exec_result :
+      Digest.t Targets.Produced.t Fiber.t =
+    let produced_targets = exec_result.Exec_result.produced_targets in
     match t.cache_config with
     | Enabled { storage_mode = mode; reproducibility_check = _ }
       when can_go_in_shared_cache -> (
       let open Fiber.O in
-      let+ targets_and_digests =
+      let+ produced_targets_with_digests =
         try_to_store_to_shared_cache ~mode ~rule_digest
-          ~file_targets:targets.files ~action
+          ~file_targets:produced_targets.files ~action
       in
-      match targets_and_digests with
-      | Some targets_and_digests -> targets_and_digests
+      match produced_targets_with_digests with
+      | Some produced_targets_with_digests -> produced_targets_with_digests
       | None ->
         compute_target_digests_or_raise_error execution_parameters ~loc
-          targets.files)
+          ~targets:produced_targets)
     | _ ->
-      let targets =
-        Path.Build.Set.union targets.files
-          exec_result.Exec_result.files_in_directory_targets
-      in
       Fiber.return
-        (compute_target_digests_or_raise_error execution_parameters ~loc targets)
+        (compute_target_digests_or_raise_error execution_parameters ~loc
+           ~targets:produced_targets)
 
-  let promote_targets t ~rule_mode ~dir ~targets_and_digests ~context =
+  let promote_targets t ~rule_mode ~dir ~targets ~context =
     match (rule_mode, !Clflags.promote) with
     | (Rule.Mode.Standard | Fallback | Ignore_source_files), _
     | Promote _, Some Never ->
       Fiber.return ()
     | Promote promote, (Some Automatically | None) ->
-      (* Note that [files_to_promote] includes both [targets.files] and all
-         files discovered inside directory targets. *)
-      let files_to_promote = List.map targets_and_digests ~f:fst in
-      Target_promotion.promote ~dir ~files_to_promote ~promote
+      Target_promotion.promote ~dir ~targets ~promote
         ~promote_source:(fun ~chmod -> t.promote_source ~chmod context)
 
   let execute_rule_impl ~rule_kind rule =
@@ -1865,14 +1872,14 @@ end = struct
           | _ -> true
         in
         (* Step I. Check if the workspace-local cache is up to date. *)
-        let* targets_and_digests =
+        let* produced_targets =
           match always_rerun with
           | true -> Fiber.return (Cache_result.Miss `Always_rerun)
           | false ->
             lookup_workspace_local_cache ~rule_digest ~targets ~env:action.env
         in
-        let* targets_and_digests =
-          match targets_and_digests with
+        let* produced_targets =
+          match produced_targets with
           | Hit x -> Fiber.return x
           | Miss miss_reason ->
             report_workspace_local_cache_miss
@@ -1884,16 +1891,16 @@ end = struct
                 Cached_digest.remove target;
                 Path.Build.unlink_no_err target);
             (* Step III. Try to restore artifacts from the shared cache. *)
-            let targets_and_digests_from_cache :
+            let produced_targets_from_cache :
                 (_, Shared_cache_miss_reason.t) Cache_result.t =
               match can_go_in_shared_cache with
               | false -> Miss Shared_cache_miss_reason.Can't_go_in_shared_cache
               | true ->
                 lookup_shared_cache t ~rule_digest ~targets ~target_dir:rule.dir
             in
-            let* targets_and_digests, dynamic_deps_stages =
-              match targets_and_digests_from_cache with
-              | Hit targets_and_digests ->
+            let* produced_targets, dynamic_deps_stages =
+              match produced_targets_from_cache with
+              | Hit produced_targets ->
                 (* Rules with dynamic deps can't be stored to the shared cache
                    (see the [is_action_dynamic] check above), so we know this is
                    not a dynamic action, so returning an empty list is correct.
@@ -1901,7 +1908,7 @@ end = struct
                    is precisely the reason why we don't store dynamic actions in
                    the shared cache. *)
                 let dynamic_deps_stages = [] in
-                Fiber.return (targets_and_digests, dynamic_deps_stages)
+                Fiber.return (produced_targets, dynamic_deps_stages)
               | Miss shared_cache_miss_reason ->
                 report_shared_cache_miss ~cache_debug_flags:t.cache_debug_flags
                   ~rule_digest ~head_target shared_cache_miss_reason;
@@ -1920,42 +1927,46 @@ end = struct
                    - Remove write permissions;
 
                    - Store results to the shared cache if needed. *)
-                let* targets_and_digests =
+                let* produced_targets =
                   examine_targets_and_update_shared_cache t ~loc
-                    ~can_go_in_shared_cache ~rule_digest ~targets
-                    ~execution_parameters ~exec_result ~action:action.action
+                    ~can_go_in_shared_cache ~rule_digest ~execution_parameters
+                    ~exec_result ~action:action.action
                 in
                 let dynamic_deps_stages =
                   List.map exec_result.action_exec_result.dynamic_deps_stages
                     ~f:(fun (deps, fact_map) ->
                       (deps, Dep.Facts.digest fact_map ~env:action.env))
                 in
-                Fiber.return (targets_and_digests, dynamic_deps_stages)
+                Fiber.return (produced_targets, dynamic_deps_stages)
             in
             let trace_db_entry =
               { Trace_db.Entry.rule_digest
               ; dynamic_deps_stages
-              ; targets_digest = digest_of_target_digests targets_and_digests
+              ; targets_digest =
+                  (* We do not include target names here, as they are already
+                     included into the rule digest. *)
+                  Targets.Produced.digest produced_targets
               }
             in
             Trace_db.set (Path.build head_target) trace_db_entry;
-            Fiber.return targets_and_digests
+            Fiber.return produced_targets
         in
         let* () =
-          promote_targets t ~rule_mode:mode ~dir ~targets_and_digests ~context
+          promote_targets t ~rule_mode:mode ~dir ~targets:produced_targets
+            ~context
         in
         t.rule_done <- t.rule_done + 1;
         let+ () =
           Handler.report_progress t.handler ~rule_done:t.rule_done
             ~rule_total:t.rule_total
         in
-        targets_and_digests)
+        produced_targets)
     (* jeremidimino: We need to include the dependencies discovered while
        running the action here. Otherwise, package dependencies are broken in
        the presence of dynamic actions. *)
     >>|
-    fun targets_and_digests ->
-    { deps; targets = Path.Build.Map.of_list_exn targets_and_digests }
+    fun produced_targets ->
+    { deps; targets = Targets.Produced.all_files produced_targets }
 
   module Anonymous_action = struct
     type t =

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -187,13 +187,13 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
         (Path.Build.to_string src_dir)
     with
     | Ok files ->
-      List.concat_map files ~f:(fun (file, kind) ->
+      List.map files ~f:(fun (file, kind) ->
           match (kind : Dune_filesystem_stubs.File_kind.t) with
           | S_REG ->
             let src = Path.Build.relative src_dir file in
             let dst = Path.Build.relative dst_dir file in
             Unix.rename (Path.Build.to_string src) (Path.Build.to_string dst);
-            [ dst ]
+            Appendable_list.singleton (dst_dir, dst)
           | S_DIR ->
             loop
               ~src_dir:(Path.Build.relative src_dir file)
@@ -203,6 +203,7 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
               [ Pp.textf "Rule produced a file with unrecognised kind %S"
                   (Dune_filesystem_stubs.File_kind.to_string kind)
               ])
+      |> Appendable_list.concat
     | Error (ENOENT, _, _) ->
       User_error.raise ~loc
         [ Pp.textf "Rule failed to produce directory %S"
@@ -217,7 +218,7 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
         ; Pp.verbatim (Unix.error_message unix_error)
         ]
   in
-  loop ~src_dir ~dst_dir |> Path.Build.Set.of_list
+  loop ~src_dir ~dst_dir
 
 let apply_changes_to_source_tree t ~old_snapshot =
   let new_snapshot = snapshot t in
@@ -249,14 +250,18 @@ let apply_changes_to_source_tree t ~old_snapshot =
         | Gt ->
           copy_file p))
 
-let move_targets_to_build_dir t ~loc ~files ~dirs =
+let move_targets_to_build_dir t ~loc ~should_be_skipped
+    ~(targets : Targets.Validated.t) : _ Targets.Produced.t =
   Option.iter t.snapshot ~f:(fun old_snapshot ->
       apply_changes_to_source_tree t ~old_snapshot);
-  Path.Build.Set.iter files ~f:(fun target ->
-      rename_optional_file ~src:(map_path t target) ~dst:target);
-  Path.Build.Set.fold dirs ~init:Path.Build.Set.empty ~f:(fun target acc ->
-      Path.Build.Set.union acc
-        (rename_dir_recursively ~loc ~src_dir:(map_path t target)
-           ~dst_dir:target))
+  Path.Build.Set.iter targets.files ~f:(fun target ->
+      if not (should_be_skipped target) then
+        rename_optional_file ~src:(map_path t target) ~dst:target);
+  let discovered_targets =
+    Path.Build.Set.to_list_map targets.dirs ~f:(fun target ->
+        rename_dir_recursively ~loc ~src_dir:(map_path t target) ~dst_dir:target)
+    |> Appendable_list.concat |> Appendable_list.to_list
+  in
+  Targets.Produced.expand_validated_exn targets discovered_targets
 
 let destroy t = Path.rm_rf (Path.build t.dir)

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -193,7 +193,7 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
             let src = Path.Build.relative src_dir file in
             let dst = Path.Build.relative dst_dir file in
             Unix.rename (Path.Build.to_string src) (Path.Build.to_string dst);
-            Appendable_list.singleton (dst_dir, dst)
+            Appendable_list.singleton (dst_dir, file)
           | S_DIR ->
             loop
               ~src_dir:(Path.Build.relative src_dir file)

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -251,7 +251,7 @@ let apply_changes_to_source_tree t ~old_snapshot =
           copy_file p))
 
 let move_targets_to_build_dir t ~loc ~should_be_skipped
-    ~(targets : Targets.Validated.t) : _ Targets.Produced.t =
+    ~(targets : Targets.Validated.t) : unit Targets.Produced.t =
   Option.iter t.snapshot ~f:(fun old_snapshot ->
       apply_changes_to_source_tree t ~old_snapshot);
   Path.Build.Set.iter targets.files ~f:(fun target ->

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -20,13 +20,15 @@ val create :
   -> expand_aliases:bool
   -> t
 
-(** Move the targets created by the action from the sandbox to the build
-    directory. Returns the set of files discovered in directory targets. *)
+(** Move all targets created by the action from the sandbox to the build
+    directory, skipping the files for which [should_be_skipped] returns [true].
+
+    Expands [targets] with the set of files discovered in directory targets. *)
 val move_targets_to_build_dir :
      t
   -> loc:Loc.t
-  -> files:Path.Build.Set.t
-  -> dirs:Path.Build.Set.t
-  -> Path.Build.Set.t
+  -> should_be_skipped:(Path.Build.t -> bool)
+  -> targets:Targets.Validated.t
+  -> unit Targets.Produced.t
 
 val destroy : t -> unit

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -109,7 +109,8 @@ let delete_stale_dot_merlin_file ~dir ~source_files_to_ignore =
    somehow batch file promotions. Another approach is to make restarts really
    cheap, so that we don't care any more, for example, by introducing reverse
    dependencies in Memo (and/or by having smarter cancellations). *)
-let promote ~dir ~files_to_promote ~promote ~promote_source =
+let promote ~dir ~targets ~promote ~promote_source =
+  let files_to_promote = Path.Build.Map.keys targets.Targets.Produced.files in
   let selected_for_promotion =
     match promote.Rule.Promote.only with
     | None -> fun (_ : Path.Build.t) -> true

--- a/src/dune_engine/target_promotion.mli
+++ b/src/dune_engine/target_promotion.mli
@@ -6,7 +6,7 @@ open! Stdune
 
 val promote :
      dir:Path.Build.t
-  -> files_to_promote:Path.Build.t list
+  -> targets:_ Targets.Produced.t
   -> promote:Rule.Promote.t
   -> promote_source:
        (   chmod:(int -> int)

--- a/src/dune_engine/targets.ml
+++ b/src/dune_engine/targets.ml
@@ -91,3 +91,95 @@ let validate t =
       with
       | true -> Inconsistent_parent_dir
       | false -> Valid { parent_dir; targets = t }))
+
+module Produced = struct
+  (* CR-someday amokhov: A hierarchical representation of the produced file
+     trees may be better. It would allow for hierarchical traversals and reduce
+     the number of internal invariants. *)
+  type 'a t =
+    { files : 'a Path.Build.Map.t
+    ; dirs : 'a Path.Build.Map.t Path.Build.Map.t
+    }
+
+  let of_validated_files (validated : Validated.t) ~on_dir_target =
+    (if not (Path.Build.Set.is_empty validated.dirs) then
+      match on_dir_target with
+      | `Raise ->
+        Code_error.raise
+          "Targets.Produced.of_validated_files: Non-empty set of directory \
+           targets."
+          [ ("validated", Validated.to_dyn validated) ]
+      | `Ignore -> ());
+    let files =
+      Path.Build.Set.to_map validated.files ~f:(fun (_ : Path.Build.t) -> ())
+    in
+    { files; dirs = Path.Build.Map.empty }
+
+  let of_file_list_exn list =
+    { files = Path.Build.Map.of_list_exn list; dirs = Path.Build.Map.empty }
+
+  let expand_validated_exn (validated : Validated.t) dir_file_pairs =
+    let files =
+      Path.Build.Set.to_map validated.files ~f:(fun (_ : Path.Build.t) -> ())
+    in
+    let dirs =
+      Path.Build.Map.of_list_multi dir_file_pairs
+      |> Path.Build.Map.map
+           ~f:(Path.Build.Map.of_list_map_exn ~f:(fun file -> (file, ())))
+    in
+    let is_unexpected dir =
+      not
+        (Path.Build.Set.exists validated.dirs ~f:(fun validated_dir ->
+             Path.Build.is_descendant dir ~of_:validated_dir))
+    in
+    List.iter (Path.Build.Map.keys dirs) ~f:(fun dir ->
+        if is_unexpected dir then
+          Code_error.raise
+            "Targets.Produced.expand_validated_exn: Unexpected directory."
+            [ ("validated", Validated.to_dyn validated)
+            ; ("dir", Path.Build.to_dyn dir)
+            ]);
+    { files; dirs }
+
+  let all_files { files; dirs } =
+    let disallow_duplicates file _payload1 _payload2 =
+      Code_error.raise
+        (sprintf "Targets.Produced.all_files: duplicate file %S"
+           (Path.Build.to_string file))
+        [ ("files", Path.Build.Map.to_dyn Dyn.opaque files)
+        ; ("dirs", Path.Build.Map.to_dyn (Path.Build.Map.to_dyn Dyn.opaque) dirs)
+        ]
+    in
+    let files_in_dirs =
+      Path.Build.Map.fold dirs ~init:Path.Build.Map.empty
+        ~f:(Path.Build.Map.union ~f:disallow_duplicates)
+    in
+    Path.Build.Map.union ~f:disallow_duplicates files files_in_dirs
+
+  let digest { files; dirs } =
+    let all_digests =
+      Path.Build.Map.values files
+      :: Path.Build.Map.to_list_map dirs ~f:(fun _ -> Path.Build.Map.values)
+    in
+    Digest.generic (List.concat all_digests)
+
+  let with_digests { files; dirs } ~(f : Path.Build.t -> Digest.t option) =
+    let exception Short_circuit in
+    let f path () =
+      match f path with
+      | Some digest -> digest
+      | None -> raise Short_circuit
+    in
+    try
+      let (files : Digest.t Path.Build.Map.t) = Path.Build.Map.mapi files ~f in
+      let dirs = Path.Build.Map.map dirs ~f:(Path.Build.Map.mapi ~f) in
+      Some { files; dirs }
+    with
+    | Short_circuit -> None
+
+  let to_dyn { files; dirs } =
+    Dyn.record
+      [ ("files", Path.Build.Map.to_dyn Dyn.opaque files)
+      ; ("dirs", Path.Build.Map.to_dyn (Path.Build.Map.to_dyn Dyn.opaque) dirs)
+      ]
+end

--- a/src/dune_engine/targets.ml
+++ b/src/dune_engine/targets.ml
@@ -169,7 +169,7 @@ module Produced = struct
     let f path () =
       match f path with
       | Some digest -> digest
-      | None -> raise Short_circuit
+      | None -> raise_notrace Short_circuit
     in
     try
       let (files : Digest.t Path.Build.Map.t) = Path.Build.Map.mapi files ~f in

--- a/src/dune_engine/targets.ml
+++ b/src/dune_engine/targets.ml
@@ -163,6 +163,7 @@ module Produced = struct
     in
     Digest.generic (List.concat all_digests)
 
+  (* This can be generalised to a more polymorphic [f] if needed. *)
   let with_digests { files; dirs } ~(f : Path.Build.t -> Digest.t option) =
     let exception Short_circuit in
     let f path () =

--- a/src/dune_engine/targets.ml
+++ b/src/dune_engine/targets.ml
@@ -163,9 +163,9 @@ module Produced = struct
     in
     Digest.generic (List.concat all_digests)
 
-  (* This can be generalised to a more polymorphic [f] if needed. *)
+  exception Short_circuit
+
   let with_digests { files; dirs } ~(f : Path.Build.t -> Digest.t option) =
-    let exception Short_circuit in
     let f path () =
       match f path with
       | Some digest -> digest

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -69,7 +69,7 @@ val pp : t -> _ Pp.t
 module Produced : sig
   type 'a t = private
     { files : 'a Path.Build.Map.t
-    ; dirs : 'a Path.Build.Map.t Path.Build.Map.t
+    ; dirs : 'a String.Map.t Path.Build.Map.t
     }
 
   (** Returns the given [targets : Validated.t]. Raises a code error if
@@ -81,10 +81,10 @@ module Produced : sig
       error if the list contains duplicates. *)
   val of_file_list_exn : (Path.Build.t * Digest.t) list -> Digest.t t
 
-  (** Add a list of discovered directory-file pairs to [Validated.t]. Raises a
-      code error on an unexpected directory. *)
+  (** Add a list of discovered directory-filename pairs to [Validated.t]. Raises
+      a code error on an unexpected directory. *)
   val expand_validated_exn :
-    Validated.t -> (Path.Build.t * Path.Build.t) list -> unit t
+    Validated.t -> (Path.Build.t * string) list -> unit t
 
   (** Union of [t.files] and all files in [t.dirs]. *)
   val all_files : 'a t -> 'a Path.Build.Map.t

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -92,6 +92,11 @@ module Produced : sig
   (** Aggregate all content digests. *)
   val digest : Digest.t t -> Digest.t
 
+  (* We could generalise [with_digests] to [mapi] with a more polymorphic [f]
+     but that complicates the existing call sites that would need to deal with
+     an extra () argument. *)
+
+  (** Tag each produced file with a digest. *)
   val with_digests :
     unit t -> f:(Path.Build.t -> Digest.t option) -> Digest.t t option
 

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -92,13 +92,9 @@ module Produced : sig
   (** Aggregate all content digests. *)
   val digest : Digest.t t -> Digest.t
 
-  (* We could generalise [with_digests] to [mapi] with a more polymorphic [f]
-     but that complicates the existing call sites that would need to deal with
-     an extra () argument. *)
-
-  (** Tag each produced file with a digest. *)
-  val with_digests :
-    unit t -> f:(Path.Build.t -> Digest.t option) -> Digest.t t option
+  module Option : sig
+    val mapi : 'a t -> f:(Path.Build.t -> 'a -> 'b option) -> 'b t option
+  end
 
   val to_dyn : _ t -> Dyn.t
 end


### PR DESCRIPTION
A refactoring that makes the code working with directory targets more uniform.

This also fixes a few `Set` modules by exposing a missing type equality.