### PR TITLE
Fix hanging introduced by f171cca9b439072817dd6834914ad0b1b482149b

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1203,9 +1203,9 @@ end = struct
         -> stack_frame:Stack_frame_with_state.t
         -> 'o Cached_value.t Fiber.t =
    fun ~dep_node ~old_value ~stack_frame ->
-    let* () = !check_point in
     let+ res =
       report_and_collect_errors (fun () ->
+          let* () = !check_point in
           dep_node.without_state.spec.f dep_node.without_state.input)
     in
     let value =


### PR DESCRIPTION
Move the call to `check_point` in memo.ml inside `report_and_collect_errors` so that exceptions are caught. Otherwise we were leaving memo in a bad state in case of cancellation.
