### PR TITLE
More flexible Fiber.run + Caller controlled fiber execution

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -26,9 +26,7 @@ module V1 = struct
 
       let create () = Lwt.task ()
 
-      let fill (_, u) x =
-        Lwt.wakeup u x;
-        Lwt.return_unit
+      let fill (_, u) x = Lwt.wakeup u x
 
       let read (x, _) = x
     end

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -382,7 +382,7 @@ module V1 : sig
 
         val read : 'a t -> 'a fiber
 
-        val fill : 'a t -> 'a -> unit fiber
+        val fill : 'a t -> 'a -> unit
       end
       with type 'a fiber := 'a t
     end) (Chan : sig

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -408,7 +408,7 @@ module type Fiber = sig
 
     val read : 'a t -> 'a fiber
 
-    val fill : 'a t -> 'a -> unit fiber
+    val fill : 'a t -> 'a -> unit
   end
   with type 'a fiber := 'a t
 end

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -516,7 +516,7 @@ module type Fiber = sig
 
     val read : 'a t -> 'a fiber
 
-    val fill : 'a t -> 'a -> unit fiber
+    val fill : 'a t -> 'a -> unit
   end
   with type 'a fiber := 'a t
 end

--- a/otherlibs/dune-rpc/private/types.mli
+++ b/otherlibs/dune-rpc/private/types.mli
@@ -319,7 +319,7 @@ module type Fiber = sig
 
     val read : 'a t -> 'a fiber
 
-    val fill : 'a t -> 'a -> unit fiber
+    val fill : 'a t -> 'a -> unit
   end
   with type 'a fiber := 'a t
 end

--- a/otherlibs/stdune-unstable/hashtbl.ml
+++ b/otherlibs/stdune-unstable/hashtbl.ml
@@ -83,6 +83,8 @@ struct
         | true -> ());
     List.iter !to_delete ~f:(fun k -> remove t k)
 
+  let iteri t ~f = iter t ~f:(fun ~key ~data -> f key data)
+
   let iter t ~f = iter t ~f:(fun ~key:_ ~data -> f data)
 end
 

--- a/otherlibs/stdune-unstable/hashtbl_intf.ml
+++ b/otherlibs/stdune-unstable/hashtbl_intf.ml
@@ -15,6 +15,8 @@ module type S = sig
 
   val iter : 'a t -> f:('a -> unit) -> unit
 
+  val iteri : 'a t -> f:(key -> 'a -> unit) -> unit
+
   val set : 'a t -> key -> 'a -> unit
 
   val add_exn : 'a t -> key -> 'a -> unit

--- a/otherlibs/stdune-unstable/table.ml
+++ b/otherlibs/stdune-unstable/table.ml
@@ -97,6 +97,9 @@ let remove (type input output) ((module T) : (input, output) t) k =
 let iter (type input output) ((module T) : (input, output) t) ~f =
   T.H.iter T.value ~f
 
+let iteri (type input output) ((module T) : (input, output) t) ~f =
+  T.H.iteri T.value ~f
+
 let filteri_inplace (type input output) ((module T) : (input, output) t) ~f =
   T.H.filteri_inplace T.value ~f
 

--- a/otherlibs/stdune-unstable/table.mli
+++ b/otherlibs/stdune-unstable/table.mli
@@ -54,6 +54,8 @@ val remove : ('k, _) t -> 'k -> unit
 
 val iter : (_, 'v) t -> f:('v -> unit) -> unit
 
+val iteri : ('k, 'v) t -> f:('k -> 'v -> unit) -> unit
+
 val filteri_inplace : ('a, 'b) t -> f:(key:'a -> data:'b -> bool) -> unit
 
 val length : (_, _) t -> int

--- a/src/dune_rpc_impl/long_poll.mli
+++ b/src/dune_rpc_impl/long_poll.mli
@@ -1,18 +1,18 @@
 module Instance : sig
   type ('r, 'u) t
 
-  val update : ('r, 'u) t -> 'u -> unit Fiber.t
+  val update : ('r, 'u) t -> 'u -> unit
 
   val poll : ('r, 'u) t -> Dune_rpc_server.Poller.t -> 'r option Fiber.t
 
-  val client_cancel : (_, _) t -> Dune_rpc_server.Poller.t -> unit Fiber.t
+  val client_cancel : (_, _) t -> Dune_rpc_server.Poller.t -> unit
 end
 
 type t
 
 val create : unit -> t
 
-val disconnect_session : t -> _ Dune_rpc_server.Session.t -> unit Fiber.t
+val disconnect_session : t -> _ Dune_rpc_server.Session.t -> unit
 
 val progress :
   t -> (Dune_rpc_private.Progress.t, Dune_rpc_private.Progress.t) Instance.t

--- a/src/dune_rpc_impl/run.mli
+++ b/src/dune_rpc_impl/run.mli
@@ -8,7 +8,6 @@ module Config : sig
     | Client
     | Server of
         { handler : Dune_rpc_server.t
-        ; pool : Fiber.Pool.t
         ; backlog : int
         ; root : string
         }

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -197,10 +197,10 @@ module Ivar : sig
 
   (** Fill the ivar with the following value. This can only be called once for a
       given ivar. *)
-  val fill : 'a t -> 'a -> unit fiber
+  val fill : 'a t -> 'a -> unit
 
   (** Return [Some x] is [fill t x] has been called previously. *)
-  val peek : 'a t -> 'a option fiber
+  val peek : 'a t -> 'a option
 end
 with type 'a fiber := 'a t
 
@@ -356,7 +356,7 @@ module Pool : sig
   val create : unit -> t
 
   (** [running pool] returns whether it's possible to submit tasks to [pool] *)
-  val running : t -> bool fiber
+  val running : t -> bool
 
   (** [task pool ~f] submit [f] to be done in [pool]. Errors raised [pool] will
       not be raised in the current fiber, but inside the [Pool.run] fiber.
@@ -380,9 +380,7 @@ with type 'a fiber := 'a t
 
 (** {1 Running fibers} *)
 
-type fill = Fill : 'a Ivar.t * 'a -> fill
-
 (** [run t ~iter] runs a fiber until it terminates. [iter] is used to implement
-    the scheduler, it should block waiting for an event and return at least one
-    ivar to fill. *)
-val run : 'a t -> iter:(unit -> fill Nonempty_list.t) -> 'a
+    the scheduler, it should block waiting for an event and fill some ivars to
+    allow fibers to make progress. *)
+val run : 'a t -> iter:(unit -> unit) -> 'a

--- a/src/fiber_util/fiber_util.mli
+++ b/src/fiber_util/fiber_util.mli
@@ -32,11 +32,7 @@ module Cancellation : sig
   (** Activate a cancellation.
 
       [fire] is idempotent, so calling [fire t] more than once has no effect. *)
-  val fire : t -> unit Fiber.t
-
-  (** Version of [fire] that is suitable to call from the [iter] callback of
-      [Fiber.run]. *)
-  val fire' : t -> Fiber.fill list
+  val fire : t -> unit
 
   (** Return whether the given cancellation has been fired. *)
   val fired : t -> bool

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -842,11 +842,11 @@ module Computation = struct
          to let the latter get the discovered dependencies [deps_rev]. *)
       Call_stack.push_frame frame (fun () -> fiber frame)
     in
-    let+ () = Fiber.Ivar.fill ivar result in
-    result
+    Fiber.Ivar.fill ivar result;
+    Fiber.return result
 
   let read_but_first_check_for_cycles { ivar; dag_node } ~dep_node =
-    Fiber.Ivar.peek ivar >>= function
+    match Fiber.Ivar.peek ivar with
     | Some res -> Fiber.return (Ok res)
     | None -> (
       let dag_node = Lazy_dag_node.force dag_node ~dep_node in

--- a/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
@@ -6,6 +6,7 @@
   - b
   - a
   - b
+  -> required by _build/default/a/a.v.d
   -> required by _build/default/a/a.vo
   -> required by _build/install/default/lib/coq/user-contrib/a/a.vo
   -> required by _build/default/ccycle.install
@@ -18,6 +19,7 @@
   - a
   - b
   - a
+  -> required by _build/default/b/b.v.d
   -> required by _build/default/b/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/b/b.vo
   -> required by _build/default/ccycle.install

--- a/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
@@ -3,6 +3,7 @@
   4 |  (theories a))
                  ^
   Error: Theory a not found
+  -> required by _build/default/b/b.v.d
   -> required by _build/default/b/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/b/b.vo
   -> required by _build/default/cvendor.install

--- a/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
@@ -4,6 +4,7 @@
                  ^^^^^^^
   Error: Theory "private" is private, it cannot be a dependency of a public
   theory. You need to associate "private" to a package.
+  -> required by _build/default/public/b.v.d
   -> required by _build/default/public/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/public/b.vo
   -> required by _build/default/public.install

--- a/test/blackbox-tests/test-cases/default-implementation/package-mismatch1.t/run.t
+++ b/test/blackbox-tests/test-cases/default-implementation/package-mismatch1.t/run.t
@@ -25,8 +25,8 @@ A default implementation of a library must belong to the same package
                                ^^^^^
   Error: default implementation belongs to package dummyfoo2 while virtual
   library belongs to package dummyfoo1. This is impossible.
-  -> required by _build/default/dummyfoo1.dune-package
-  -> required by _build/install/default/lib/dummyfoo1/dune-package
+  -> required by _build/default/vlib/.vlib.objs/byte/vlib.cmi
+  -> required by _build/install/default/lib/dummyfoo1/bar/vlib.cmi
   -> required by _build/default/dummyfoo1.install
   -> required by alias install
   [1]

--- a/test/blackbox-tests/test-cases/deprecated-library-name/features.t
+++ b/test/blackbox-tests/test-cases/deprecated-library-name/features.t
@@ -95,6 +95,8 @@ that wasn't found:
   1 | (executable (name prog) (libraries a))
                                          ^
   Error: Library "a" not found.
+  -> required by _build/default/c/.prog.eobjs/byte/dune__exe__Prog.cmi
+  -> required by _build/default/c/.prog.eobjs/native/dune__exe__Prog.cmx
   -> required by _build/default/c/prog.exe
   [1]
 

--- a/test/blackbox-tests/test-cases/enabled_if/eif-context_name.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-context_name.t/run.t
@@ -34,6 +34,8 @@ dune >= 2.8
   18 |  (libraries bar))
                    ^^^
   Error: Library "bar" in _build/default is hidden (unsatisfied 'enabled_if').
+  -> required by _build/default/.bar_exe.eobjs/byte/dune__exe__Bar_exe.cmi
+  -> required by _build/default/.bar_exe.eobjs/native/dune__exe__Bar_exe.cmx
   -> required by _build/default/bar_exe.exe
   [1]
 

--- a/test/blackbox-tests/test-cases/enabled_if/eif-ocaml_version.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-ocaml_version.t/run.t
@@ -10,5 +10,7 @@ This one is disabled (version too low)
                    ^^^^^^^^^^
   Error: Library "futurecaml" in _build/default is hidden (unsatisfied
   'enabled_if').
+  -> required by _build/default/.main2.eobjs/byte/dune__exe__Main2.cmi
+  -> required by _build/default/.main2.eobjs/native/dune__exe__Main2.cmx
   -> required by _build/default/main2.exe
   [1]

--- a/test/blackbox-tests/test-cases/forbidden_libraries.t/run.t
+++ b/test/blackbox-tests/test-cases/forbidden_libraries.t/run.t
@@ -24,5 +24,7 @@ Test the `forbidden_libraries` feature
   -> required by library "b" in _build/default
   -> required by library "c" in _build/default
   -> required by executable main in dune:5
+  -> required by _build/default/.main.eobjs/byte/dune__exe__Main.cmi
+  -> required by _build/default/.main.eobjs/native/dune__exe__Main.cmx
   -> required by _build/default/main.exe
   [1]

--- a/test/blackbox-tests/test-cases/invalid-dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/invalid-dune-package.t/run.t
@@ -17,5 +17,7 @@ Now we attempt to use an invalid dune-package library:
   $ OCAMLPATH=$PWD/findlib dune exec ./foo.exe
   File "$TESTCASE_ROOT/findlib/baz/dune-package", line 1, characters 0-0:
   Error: Invalid first line, expected: (lang <lang> <version>)
+  -> required by _build/default/.foo.eobjs/byte/dune__exe__Foo.cmi
+  -> required by _build/default/.foo.eobjs/native/dune__exe__Foo.cmx
   -> required by _build/default/foo.exe
   [1]

--- a/test/blackbox-tests/test-cases/lib.t/run.t
+++ b/test/blackbox-tests/test-cases/lib.t/run.t
@@ -253,7 +253,10 @@ But will fail when we release it, as it will need to run with -p:
   Error: Library "lib1" not found.
   -> required by %{lib-private:lib1:lib1.ml} at lib2/dune:5
   -> required by _build/default/lib2/lib2.ml
-  -> required by _build/install/default/lib/public_lib2/lib2.ml
+  -> required by _build/default/lib2/.lib2.objs/byte/lib2.cmi
+  -> required by _build/default/lib2/.lib2.objs/native/lib2.cmx
+  -> required by _build/default/lib2/lib2.a
+  -> required by _build/install/default/lib/public_lib2/lib2.a
   -> required by _build/default/public_lib2.install
   -> required by alias install
   [1]

--- a/test/blackbox-tests/test-cases/libexec.t/run.t
+++ b/test/blackbox-tests/test-cases/libexec.t/run.t
@@ -315,7 +315,10 @@ But will fail when we release it, as it will need to run with -p:
   Error: Library "lib1" not found.
   -> required by %{libexec-private:lib1:lib1.ml} at lib2/dune:5
   -> required by _build/target/lib2/lib2.ml
-  -> required by _build/install/target/lib/public_lib2/lib2.ml
+  -> required by _build/target/lib2/.lib2.objs/byte/lib2.cmi
+  -> required by _build/target/lib2/.lib2.objs/native/lib2.cmx
+  -> required by _build/target/lib2/lib2.a
+  -> required by _build/install/target/lib/public_lib2/lib2.a
   -> required by _build/target/public_lib2.install
   -> required by alias install (context target)
   -> required by alias target (context target) in dune:5

--- a/test/blackbox-tests/test-cases/ocamldep-error-check.t
+++ b/test/blackbox-tests/test-cases/ocamldep-error-check.t
@@ -21,6 +21,7 @@ Dune uses ocamldep to prevent a module from depending on itself.
   of the library. Consequently, it should be the one depending on all the other
   modules in the library.
   -> required by _build/default/lib/.foo.objs/foo__Bar.impl.all-deps
+  -> required by _build/default/lib/.foo.objs/byte/foo__Bar.cmo
   -> required by _build/default/lib/foo.cma
   -> required by alias lib/all
   [1]

--- a/test/blackbox-tests/test-cases/optional-executable.t/run.t
+++ b/test/blackbox-tests/test-cases/optional-executable.t/run.t
@@ -26,6 +26,8 @@ Test optional executable
   3 |  (libraries does-not-exist)
                   ^^^^^^^^^^^^^^
   Error: Library "does-not-exist" not found.
+  -> required by _build/default/.x.eobjs/byte/dune__exe__X.cmi
+  -> required by _build/default/.x.eobjs/native/dune__exe__X.cmx
   -> required by _build/default/x.exe
   -> required by alias all
   [1]
@@ -35,6 +37,8 @@ Test optional executable
   3 |  (libraries does-not-exist)
                   ^^^^^^^^^^^^^^
   Error: Library "does-not-exist" not found.
+  -> required by _build/default/.x.eobjs/byte/dune__exe__X.cmi
+  -> required by _build/default/.x.eobjs/native/dune__exe__X.cmx
   -> required by _build/default/x.exe
   -> required by %{exe:x.exe} at dune:8
   -> required by alias run-x in dune:6
@@ -56,6 +60,8 @@ The following command should fail because the executable is not optional:
   3 |  (libraries does-not-exist))
                   ^^^^^^^^^^^^^^
   Error: Library "does-not-exist" not found.
+  -> required by _build/default/.x.eobjs/byte/dune__exe__X.cmi
+  -> required by _build/default/.x.eobjs/native/dune__exe__X.cmx
   -> required by _build/default/x.exe
   -> required by _build/install/default/bin/x
   -> required by _build/default/x.install
@@ -139,6 +145,8 @@ present even if the binary is not optional.
   3 |  (libraries doesnotexistatall)
                   ^^^^^^^^^^^^^^^^^
   Error: Library "doesnotexistatall" not found.
+  -> required by _build/default/exe/.bar.eobjs/byte/dune__exe__Bar.cmi
+  -> required by _build/default/exe/.bar.eobjs/native/dune__exe__Bar.cmx
   -> required by _build/default/exe/bar.exe
   -> required by _build/install/default/bin/dunetestbar
   -> required by %{bin:dunetestbar} at dune:3

--- a/test/blackbox-tests/test-cases/overlapping-deps.t
+++ b/test/blackbox-tests/test-cases/overlapping-deps.t
@@ -106,5 +106,7 @@ We also make sure the error exists for executables:
     -> required by library "some_package1" in
        $TESTCASE_ROOT/use/../external/_build/install/default/lib/some_package1
   -> required by executable bar in proj2/dune:2
+  -> required by _build/default/proj2/.bar.eobjs/byte/dune__exe__Bar.cmi
+  -> required by _build/default/proj2/.bar.eobjs/native/dune__exe__Bar.cmx
   -> required by _build/default/proj2/bar.exe
   [1]

--- a/test/blackbox-tests/test-cases/ppx-runtime-dependencies.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx-runtime-dependencies.t/run.t
@@ -115,6 +115,8 @@ not been marked with (kind ppx_rewriter).
                         ^
   Error: Ppx dependency on a non-ppx library "b". If "b" is in fact a ppx
   rewriter library, it should have (kind ppx_rewriter) in its dune file.
+  -> required by _build/default/bin/.main.eobjs/byte/dune__exe__Main.cmi
+  -> required by _build/default/bin/.main.eobjs/native/dune__exe__Main.cmx
   -> required by _build/default/bin/main.exe
   [1]
 

--- a/test/blackbox-tests/test-cases/virtual-libraries/github2896.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/github2896.t/run.t
@@ -37,5 +37,7 @@ The implementation impl was built, but it's not usable:
   -> required by library "lib" in _build/default/lib
   -> required by library "impl" in _build/default/impl
   -> required by executable foo in dune:1
+  -> required by _build/default/.foo.eobjs/byte/dune__exe__Foo.cmi
+  -> required by _build/default/.foo.eobjs/native/dune__exe__Foo.cmx
   -> required by _build/default/foo.exe
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-wrong-default-impl.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-wrong-default-impl.t/run.t
@@ -4,6 +4,8 @@ library is not actually an implementation of the virtual library.
   $ dune build @default
   Error: "not_an_implem" is not an implementation of "vlibfoo".
   -> required by executable exe in exe/dune:2
+  -> required by _build/default/exe/.exe.eobjs/byte/dune__exe__Exe.cmi
+  -> required by _build/default/exe/.exe.eobjs/native/dune__exe__Exe.cmx
   -> required by _build/default/exe/exe.exe
   -> required by alias exe/default in exe/dune:5
   [1]

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -6,7 +6,7 @@ module Scheduler = Dune_engine.Scheduler
 let () = Dune_tests_common.init ()
 
 type event =
-  | Fill of Fiber.fill
+  | Fill : 'a Fiber.Ivar.t * 'a -> event
   | Abort
 
 let server where = Server.create where ~backlog:10

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -27,7 +27,8 @@ let%expect_test "cancelling a build" =
       Fiber.fork_and_join_unit
         (fun () ->
           Scheduler.Run.poll
-            (let* () = Fiber.Ivar.fill build_started () in
+            (let* () = Fiber.return () in
+             Fiber.Ivar.fill build_started ();
              let* () = Fiber.Ivar.read build_cancelled in
              let* res =
                Fiber.collect_errors (fun () ->
@@ -46,7 +47,7 @@ let%expect_test "cancelling a build" =
               (Memo.Cell.invalidate cell ~reason:Unknown)
           in
           (* Wait for the scheduler to acknowledge the change *)
-          let* () = Scheduler.wait_for_build_input_change () in
+          let+ () = Scheduler.wait_for_build_input_change () in
           Fiber.Ivar.fill build_cancelled ()));
   [%expect {| PASS: build was cancelled |}]
 
@@ -58,7 +59,8 @@ let%expect_test "cancelling a build: effect on other fibers" =
       Fiber.fork_and_join_unit
         (fun () ->
           Scheduler.Run.poll
-            (let* () = Fiber.Ivar.fill build_started () in
+            (let* () = Fiber.return () in
+             Fiber.Ivar.fill build_started ();
              Fiber.never))
         (fun () ->
           let* () = Fiber.Ivar.read build_started in

--- a/test/expect-tests/test_scheduler/test_scheduler.ml
+++ b/test/expect-tests/test_scheduler/test_scheduler.ml
@@ -27,4 +27,4 @@ let run (t : t) fiber =
       | None -> raise Never
       | Some (Job (job, ivar)) ->
         let v = job () in
-        [ Fiber.Fill (ivar, v) ])
+        Fiber.Ivar.fill ivar v)


### PR DESCRIPTION
The first commit changes `Fiber.Ivar.fill` to return `unit`, which makes `Fiber.run` more flexible. In particular, we no longer need a special version of `Fiber_util.Cancellation.fire` that can be called from within the `iter` callback of `Fiber.run`. Instead, we can call any function that fills ivars.

The second commit adds a step-by-step fiber execution mechanism that gives back the control to the caller and should be useful for situations where there is no central place to call `Fiber.run` (such as in vscode, IIRC). Instead of calling `Fiber.run` with a blocking `iter` callback, one creates a `Fiber.Execution.t` and repeatedly calls `Fiber.Execution.advance` on it, filling ivars in between.