### PR TITLE
Fix dune site tests when backtrace printing activated

### DIFF
--- a/otherlibs/site/test/plugin_require_thread.t/app.ml
+++ b/otherlibs/site/test/plugin_require_thread.t/app.ml
@@ -1,5 +1,9 @@
 (* load all the available plugins *)
-let () = Sites.Plugins.Plugins.load_all ()
+let () =
+  try
+    Sites.Plugins.Plugins.load_all ()
+  with exn ->
+    Printf.printf "Error during dynamic linking: %s" (Printexc.to_string exn)
 
 let () = print_endline "Main app starts..."
 (* Execute the code registered by the plugins *)

--- a/otherlibs/site/test/plugin_require_thread.t/run.t
+++ b/otherlibs/site/test/plugin_require_thread.t/run.t
@@ -2,10 +2,10 @@
   $ dune build ./app.exe @install
   $ dune exec ./app.exe
   The library is being used by two plugins finished initialization
-  Fatal error: exception Dune_site_plugins__Plugins.Thread_library_required_by_plugin_but_not_required_by_main_executable
-  [2]
+  Error during dynamic linking: Dune_site_plugins__Plugins.Thread_library_required_by_plugin_but_not_required_by_main_executableMain app starts...
 
-  $ sed -i -e "s/;TOREMOVE//" dune
+  $ sed -e "s/;TOREMOVE//" dune > dune.tmp
+  $ mv -f dune.tmp dune
 
   $ dune build ./app.exe @install
   $ dune exec ./app.exe


### PR DESCRIPTION
Instead of using default toplevel exception printing of OCaml catch the exception.

@snowleopard You can merge directly if you are satisfied.