### PR TITLE
Stop caching unused fields in [Fs_cache.Reduced_stats]

### DIFF
--- a/src/dune_engine/fs_cache.ml
+++ b/src/dune_engine/fs_cache.ml
@@ -64,23 +64,13 @@ module Reduced_stats = struct
     { st_dev : int
     ; st_ino : int
     ; st_kind : Unix.file_kind
-    ; st_perm : Unix.file_perm
-    ; st_size : int
-    ; st_mtime : float
-    ; st_ctime : float
     }
 
-  let of_unix_stats
-      { Unix.st_dev; st_ino; st_kind; st_perm; st_size; st_mtime; st_ctime; _ }
-      =
-    { st_dev; st_ino; st_kind; st_perm; st_size; st_mtime; st_ctime }
+  let of_unix_stats { Unix.st_dev; st_ino; st_kind; _ } =
+    { st_dev; st_ino; st_kind }
 
   let equal x y =
-    Ordering.is_eq (Float.compare x.st_mtime y.st_mtime)
-    && Ordering.is_eq (Float.compare x.st_ctime y.st_ctime)
-    && Int.equal x.st_size y.st_size
-    && Int.equal x.st_perm y.st_perm
-    && Int.equal x.st_dev y.st_dev
+    Int.equal x.st_dev y.st_dev
     && Int.equal x.st_ino y.st_ino
     && Dune_filesystem_stubs.File_kind.equal x.st_kind y.st_kind
 end

--- a/src/dune_engine/fs_cache.mli
+++ b/src/dune_engine/fs_cache.mli
@@ -34,16 +34,16 @@ end
 val update : 'a t -> Path.t -> Update_result.t
 
 (** This module caches only a subset of fields of [Unix.stats] because other
-    fields are currently unused. *)
+    fields are currently unused.
+
+    Note that we specifically do not want to cache [mtime] and [ctime] because
+    these fields can change too often: for example, when a temporary file is
+    created in a watched directory. *)
 module Reduced_stats : sig
   type t =
     { st_dev : int  (** Device number *)
     ; st_ino : int  (** Inode number *)
     ; st_kind : Dune_filesystem_stubs.File_kind.t  (** Kind of the file *)
-    ; st_perm : Unix.file_perm  (** Access rights *)
-    ; st_size : int  (** Size in bytes *)
-    ; st_mtime : float  (** Last modification time *)
-    ; st_ctime : float  (** Last status change time *)
     }
 
   val of_unix_stats : Unix.stats -> t

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -141,16 +141,9 @@ let promote ~dir ~(targets : _ Targets.Produced.t) ~promote ~promote_source =
               (Path.Source.to_string into_dir)
           ]
       | true -> (
-        (* CR-someday amokhov: We use an untracked version here for two reasons:
-
-           - We don't have [Fs_memo.is_directory], and using [Fs_memo.path_stat]
-           would lead to unnecessary restarts when the directory's [mtime]
-           changes. We should provide an alternative to [Fs_memo.path_stat] for
-           extracting everything except for [mtime].
-
-           - Using untracked version here is mostly fine. The only potential
-           issue is that Dune won't notice if the user turns a file into a
-           directory while somehow not triggering [Fs_memo.path_exists]. *)
+        (* CR-someday amokhov: We use an untracked version here. The only issue
+           is that Dune won't notice if the user turns a file into a directory
+           while somehow not triggering [Fs_memo.path_exists]. *)
         match Path.Untracked.is_directory (Path.source into_dir) with
         | false ->
           user_error


### PR DESCRIPTION
The `Fs_cache.Reduced_stats` record is too large and some of its fields are currently unused. They cause unnecessary restarts for Dune, so I am removing them. The `mtime` field is particularly problematic because it changes for a directory when we create temporary files inside it, which I believe is the cause for #5170.

I originally included these fields into `Fs_cache.Reduced_stats` because they appeared important for the `Cached_digest` module. However, `Cached_digest` obtains them via untracked file-system access and we are not planning to change that for now. This means, there is no reason to keep them in `Fs_cache.Reduced_stats`.

This fixes a problem in an existing file-watching test and also improves builds in my manual testing.