### PR TITLE
[Test] Deactivate stray process test for macos

### DIFF
--- a/test/blackbox-tests/test-cases/actions/dune
+++ b/test/blackbox-tests/test-cases/actions/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to stray-process)
+ (enabled_if
+  (<> %{system} macosx)))


### PR DESCRIPTION
Temporary

@rgrinberg Just to have an all green CI before a proper fix.