### PR TITLE
Implement [Fs_memo.path_exists] via [Fs_cache.path_stat]

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -690,7 +690,7 @@ let source_file_digest path =
   | Unexpected_kind st_kind ->
     report_user_error
       [ Pp.textf "This is neither a regular file nor a directory (%s)"
-          (Dune_filesystem_stubs.File_kind.to_string st_kind)
+          (File_kind.to_string st_kind)
       ]
   | Unix_error (error, _, _) ->
     report_user_error [ Pp.textf "%s" (Unix.error_message error) ]

--- a/src/dune_engine/fs_cache.ml
+++ b/src/dune_engine/fs_cache.ml
@@ -101,9 +101,6 @@ end = struct
 end
 
 module Untracked = struct
-  let path_exists =
-    create "path_exists" ~sample:Path.Untracked.exists ~equal:Bool.equal
-
   let path_stat =
     let sample path =
       Path.Untracked.stat path |> Result.map ~f:Reduced_stats.of_unix_stats

--- a/src/dune_engine/fs_cache.ml
+++ b/src/dune_engine/fs_cache.ml
@@ -72,15 +72,15 @@ module Reduced_stats = struct
   let equal x y =
     Int.equal x.st_dev y.st_dev
     && Int.equal x.st_ino y.st_ino
-    && Dune_filesystem_stubs.File_kind.equal x.st_kind y.st_kind
+    && File_kind.equal x.st_kind y.st_kind
 end
 
 module Dir_contents : sig
   type t
 
-  val of_list : (string * Dune_filesystem_stubs.File_kind.t) list -> t
+  val of_list : (string * File_kind.t) list -> t
 
-  val to_list : t -> (string * Dune_filesystem_stubs.File_kind.t) list
+  val to_list : t -> (string * File_kind.t) list
 
   val equal : t -> t -> bool
 end = struct
@@ -88,16 +88,14 @@ end = struct
      since we'll not need to worry about the invariant that the list is sorted
      and doesn't contain any duplicate file names. Using maps will likely be
      more costly, so we need to do some benchmarking before switching. *)
-  type t = (string * Dune_filesystem_stubs.File_kind.t) list
+  type t = (string * File_kind.t) list
 
   let to_list t = t
 
   (* The names must be unique, so we don't care about comparing file kinds. *)
   let of_list = List.sort ~compare:(fun (x, _) (y, _) -> String.compare x y)
 
-  let equal =
-    List.equal
-      (Tuple.T2.equal String.equal Dune_filesystem_stubs.File_kind.equal)
+  let equal = List.equal (Tuple.T2.equal String.equal File_kind.equal)
 end
 
 module Untracked = struct

--- a/src/dune_engine/fs_cache.mli
+++ b/src/dune_engine/fs_cache.mli
@@ -43,7 +43,7 @@ module Reduced_stats : sig
   type t =
     { st_dev : int  (** Device number *)
     ; st_ino : int  (** Inode number *)
-    ; st_kind : Dune_filesystem_stubs.File_kind.t  (** Kind of the file *)
+    ; st_kind : File_kind.t  (** Kind of the file *)
     }
 
   val of_unix_stats : Unix.stats -> t
@@ -55,7 +55,7 @@ module Dir_contents : sig
   type t
 
   (** The sorted list of file names with kinds. *)
-  val to_list : t -> (string * Dune_filesystem_stubs.File_kind.t) list
+  val to_list : t -> (string * File_kind.t) list
 
   val equal : t -> t -> bool
 end

--- a/src/dune_engine/fs_cache.mli
+++ b/src/dune_engine/fs_cache.mli
@@ -66,8 +66,6 @@ end
 
     See [fs_memo.ml] for tracked versions of these operations. *)
 module Untracked : sig
-  val path_exists : bool t
-
   val path_stat : (Reduced_stats.t, Unix_error.Detailed.t) result t
 
   val path_digest : Cached_digest.Digest_result.t t

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -188,7 +188,7 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
     with
     | Ok files ->
       List.map files ~f:(fun (file, kind) ->
-          match (kind : Dune_filesystem_stubs.File_kind.t) with
+          match (kind : File_kind.t) with
           | S_REG ->
             let src = Path.Build.relative src_dir file in
             let dst = Path.Build.relative dst_dir file in
@@ -201,7 +201,7 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
           | _ ->
             User_error.raise ~loc
               [ Pp.textf "Rule produced a file with unrecognised kind %S"
-                  (Dune_filesystem_stubs.File_kind.to_string kind)
+                  (File_kind.to_string kind)
               ])
       |> Appendable_list.concat
     | Error (ENOENT, _, _) ->

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -176,8 +176,7 @@ Show that Dune ignores the initial "dune-workspace" events (injected by Dune).
   $ cat .#debug-output | grep dune-workspace
   Updating dir_contents cache for "dune-workspace": Skipped
   Updating path_digest cache for "dune-workspace": Skipped
-  Updating path_stat cache for "dune-workspace": Skipped
-  Updating path_exists cache for "dune-workspace": Updated { changed = false }
+  Updating path_stat cache for "dune-workspace": Updated { changed = false }
 
 Show that Dune ignores "promoted" events. Events for ".#promoted.dune-temp" are
 filtered out by Dune's file watcher and don't show up here. The [path_digest]
@@ -189,7 +188,6 @@ avoid unnecessarily restarting after receiving the event that it caused itself.
   Updating dir_contents cache for "promoted": Skipped
   Updating path_digest cache for "promoted": Updated { changed = false }
   Updating path_stat cache for "promoted": Skipped
-  Updating path_exists cache for "promoted": Skipped
 
 Show that Dune ignores events for the . directory: [dir_contents] didn't change
 because [promoted] existed before running the build. Also, the subset of fields
@@ -200,4 +198,3 @@ change but [fs_memo] does not provide a way to subscribe to it).
   Updating dir_contents cache for ".": Updated { changed = false }
   Updating path_digest cache for ".": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
-  Updating path_exists cache for ".": Skipped


### PR DESCRIPTION
This is a follow-up to #5203. As explained in the added comment, the reasons for doing this are:

* Semantically, this is equivalent because `Path.exists` is also implemented by checking that the `stat` call succeeds (see `caml_sys_file_exists`).

* `Fs_cache.path_stat` doesn't change too often because the resulting record `Reduced_stats` doesn't include frequently changing fields like `mtime`. Technically, it can still change while `path_exists` remains constant `true`, for example, if the `st_kind` field changes, in which case Dune will restart unnecessarily, but such changes are rare, so we don't care.

* Reusing `Fs_cache.path_stat` helps us to reduce the number of `stat` calls, i.e. we can do just one call to answer both `path_stat` and `path_exists`.

* Having a smaller number of primitives in `Fs_cache` is better because it makes it easier to think about reasons for restarting the current build and avoids unnecessary cache tables in `Fs_cache`.