### PR TITLE
[repo health] small comparable refactoring 

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -19,9 +19,7 @@ module Id : sig
 
   val to_sexp : t -> Csexp.t
 
-  module Set : Stdune.Set.S with type elt = t
-
-  module Map : Stdune.Map.S with type key = t
+  include Stdune.Comparable_intf.S with type key := t
 end
 
 module Call : sig

--- a/otherlibs/dune-rpc/private/types.mli
+++ b/otherlibs/dune-rpc/private/types.mli
@@ -19,9 +19,7 @@ module Id : sig
 
   val to_sexp : t -> Sexp.t
 
-  module Set : Set.S with type elt = t
-
-  module Map : Stdune.Map.S with type key = t
+  include Stdune.Comparable_intf.S with type key := t
 end
 
 module Version : sig

--- a/otherlibs/stdune-unstable/comparable.ml
+++ b/otherlibs/stdune-unstable/comparable.ml
@@ -1,5 +1,4 @@
 module Make (Key : Map.Key) = struct
-  module Key = Key
   module Map = Map.Make (Key)
   module Set = Set.Make (Key) (Map)
 end

--- a/otherlibs/stdune-unstable/comparable.mli
+++ b/otherlibs/stdune-unstable/comparable.mli
@@ -1,1 +1,1 @@
-module Make (Key : Map.Key) : Comparable_intf.S with module Key = Key
+module Make (Key : Map.Key) : Comparable_intf.S with type key := Key.t

--- a/otherlibs/stdune-unstable/comparable_intf.ml
+++ b/otherlibs/stdune-unstable/comparable_intf.ml
@@ -1,7 +1,7 @@
 module type S = sig
-  module Key : Map.Key
+  type key
 
-  module Map : Map_intf.S with type key = Key.t
+  module Map : Map_intf.S with type key = key
 
-  module Set : Set_intf.S with type elt = Key.t and type 'a map = 'a Map.t
+  module Set : Set_intf.S with type elt = key and type 'a map = 'a Map.t
 end

--- a/otherlibs/stdune-unstable/digest.mli
+++ b/otherlibs/stdune-unstable/digest.mli
@@ -2,9 +2,7 @@
 
 type t
 
-module Set : Set.S with type elt = t
-
-module Map : Map.S with type key = t
+include Comparable_intf.S with type key := t
 
 val to_dyn : t -> Dyn.t
 

--- a/otherlibs/stdune-unstable/env.ml
+++ b/otherlibs/stdune-unstable/env.ml
@@ -22,6 +22,7 @@ module Var = struct
   include T
 end
 
+module Set = Var.Set
 module Map = Var.Map
 
 (* The use of [mutable] here is safe, since we never call (back) to the
@@ -39,7 +40,7 @@ let make vars = { vars; unix = None }
 
 let empty = make Map.empty
 
-let vars t = Var.Set.of_list (Map.keys t.vars)
+let vars t = Var.Set.of_keys t.vars
 
 let get t k = Map.find t.vars k
 

--- a/otherlibs/stdune-unstable/env.mli
+++ b/otherlibs/stdune-unstable/env.mli
@@ -5,16 +5,14 @@ module Var : sig
 
   val temp_dir : t
 
-  module Set : Set.S with type elt = t
-
-  module Map : Map.S with type key = t
+  include Comparable_intf.S with type key := t
 end
 
 type t
 
 val hash : t -> int
 
-module Map : Map.S with type key = Var.t
+include Comparable_intf.S with type key := Var.t
 
 val equal : t -> t -> bool
 

--- a/otherlibs/stdune-unstable/id.ml
+++ b/otherlibs/stdune-unstable/id.ml
@@ -1,9 +1,7 @@
 module type S = sig
   type t
 
-  module Set : Set.S with type elt = t
-
-  module Map : Map.S with type key = t
+  include Comparable_intf.S with type key := t
 
   module Table : Hashtbl.S with type key = t
 

--- a/otherlibs/stdune-unstable/id.mli
+++ b/otherlibs/stdune-unstable/id.mli
@@ -1,9 +1,7 @@
 module type S = sig
   type t
 
-  module Set : Set.S with type elt = t
-
-  module Map : Map.S with type key = t
+  include Comparable_intf.S with type key := t
 
   module Table : Hashtbl.S with type key = t
 

--- a/otherlibs/stdune-unstable/int.mli
+++ b/otherlibs/stdune-unstable/int.mli
@@ -8,9 +8,7 @@ val hash : t -> int
 
 val to_dyn : t -> Dyn.t
 
-module Set : Set.S with type elt = t
-
-module Map : Map.S with type key = t
+include Comparable_intf.S with type key := t
 
 val of_string_exn : string -> t
 

--- a/otherlibs/stdune-unstable/map_intf.ml
+++ b/otherlibs/stdune-unstable/map_intf.ml
@@ -7,7 +7,7 @@ end
 module type S = sig
   type key
 
-  and +'a t
+  type +'a t
 
   val empty : 'a t
 

--- a/otherlibs/stdune-unstable/string.mli
+++ b/otherlibs/stdune-unstable/string.mli
@@ -110,7 +110,7 @@ val findi : string -> f:(char -> bool) -> int option
 (** Find index of last character satisfying [f] *)
 val rfindi : string -> f:(char -> bool) -> int option
 
-include Comparable_intf.S with type Key.t = t
+include Comparable_intf.S with type key := t
 
 module Table : Hashtbl.S with type key = t
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -48,6 +48,7 @@ module Dynamic_dep = struct
 
   include T
   module O = Comparable.Make (T)
+  module Map = O.Map
 
   module Set = struct
     include O.Set

--- a/src/dune_engine/action_exec.mli
+++ b/src/dune_engine/action_exec.mli
@@ -16,8 +16,10 @@ module Dynamic_dep : sig
 
   val compare : t -> t -> Ordering.t
 
+  module Map : Map.S with type key := t
+
   module Set : sig
-    include Set.S with type elt = t
+    include Set.S with type elt = t and type 'a map = 'a Map.t
 
     val to_dep_set : t -> Dep.Set.t
   end

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -30,9 +30,7 @@ module Name : sig
 
   val parse_local_path : Loc.t * Path.Local.t -> Path.Local.t * t
 
-  module Map : Map.S with type key = t
-
-  module Set : Set.S with type elt = t
+  include Comparable_intf.S with type key := t
 end = struct
   include String
 

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -25,9 +25,7 @@ module Name : sig
 
   val parse_local_path : Loc.t * Path.Local.t -> Path.Local.t * t
 
-  module Map : Map.S with type key = t
-
-  module Set : Set.S with type elt = t
+  include Comparable_intf.S with type key := t
 end
 
 type t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -565,7 +565,7 @@ let compute_target_digests_or_raise_error exec_params ~loc ~produced_targets :
          | [] -> []
          | _ ->
            [ Pp.textf "Rule failed to generate the following targets:"
-           ; pp_paths (Path.Set.of_list (List.map ~f:Path.build missing))
+           ; pp_paths (Path.Set.of_list_map ~f:Path.build missing)
            ])
         @
         match errors with

--- a/src/dune_engine/context_name.mli
+++ b/src/dune_engine/context_name.mli
@@ -18,7 +18,7 @@ include Stringlike_intf.S with type t := t
 
 module Infix : Comparator.OPS with type t = t
 
-include Comparable_intf.S with type Key.t := t
+include Comparable_intf.S with type key := t
 
 module Top_closure :
   Top_closure_intf.S with type key := t and type 'a monad := 'a Monad.Id.t

--- a/src/dune_engine/format_config.ml
+++ b/src/dune_engine/format_config.ml
@@ -11,7 +11,7 @@ let syntax =
     ]
 
 module Language = struct
-  module Key = struct
+  module T = struct
     type t =
       | Dialect of string
       | Dune
@@ -30,9 +30,8 @@ module Language = struct
       | Dune -> variant "dune" []
   end
 
-  module Map = Map.Make (Key)
-  module Set = Set.Make (Key) (Map)
-  include Key
+  include Comparable.Make (T)
+  include T
 
   let of_string = function
     | "dune" -> Dune

--- a/src/dune_engine/install.mli
+++ b/src/dune_engine/install.mli
@@ -36,7 +36,7 @@ end
 module Section : sig
   type t = Section.t
 
-  module Set : Set.S with type elt = t
+  include Comparable_intf.S with type key := t
 
   val to_string : t -> string
 

--- a/src/dune_engine/lib_name.mli
+++ b/src/dune_engine/lib_name.mli
@@ -42,7 +42,7 @@ val mangled : Package.Name.t -> Local.t -> t
 module Map : Map.S with type key = t
 
 module Set : sig
-  include Set.S with type elt = t
+  include Set.S with type elt = t and type 'a map = 'a Map.t
 
   val to_string_list : t -> string list
 end

--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -15,7 +15,7 @@ module Name : sig
 
   val hash : t -> int
 
-  include Comparable_intf.S with type Key.t := t
+  include Comparable_intf.S with type key := t
 
   include Dune_lang.Conv.S with type t := t
 
@@ -39,9 +39,7 @@ module Id : sig
 
   val name : t -> Name.t
 
-  module Set : Set.S with type elt = t
-
-  module Map : Map.S with type key = t
+  include Comparable_intf.S with type key := t
 end
 
 module Dependency : sig

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -75,8 +75,7 @@ module T = struct
 end
 
 include T
-module O = Comparable.Make (T)
-module Set = O.Set
+include Comparable.Make (T)
 
 let make ?(mode = Mode.Standard) ~context ?(info = Info.Internal) ~targets
     action =

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -52,9 +52,7 @@ module Id : sig
 
   val compare : t -> t -> Ordering.t
 
-  module Map : Map.S with type key = t
-
-  module Set : Set.S with type elt = t
+  include Comparable_intf.S with type key := t
 end
 
 type t = private
@@ -68,7 +66,7 @@ type t = private
   ; (* Directory where all the targets are produced. *) dir : Path.Build.t
   }
 
-module Set : Set.S with type elt = t
+include Comparable_intf.S with type key := t
 
 val equal : t -> t -> bool
 

--- a/src/dune_engine/section.mli
+++ b/src/dune_engine/section.mli
@@ -18,7 +18,7 @@ type t =
 
 val compare : t -> t -> Ordering.t
 
-include Comparable_intf.S with type Key.t = t
+include Comparable_intf.S with type key := t
 
 val enum_decoder : (string * t) list
 
@@ -43,7 +43,7 @@ val should_set_executable_bit : t -> bool
 module Site : sig
   type t
 
-  include Comparable_intf.S with type Key.t := t
+  include Comparable_intf.S with type key := t
 
   include Dune_lang.Conv.S with type t := t
 

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -182,7 +182,7 @@ end = struct
     | Ok dir_contents ->
       let dir_contents = Fs_cache.Dir_contents.to_list dir_contents in
       let+ files, dirs =
-        Memo.Build.sequential_map dir_contents ~f:(fun (fn, kind) ->
+        Memo.Build.parallel_map dir_contents ~f:(fun (fn, kind) ->
             let path = Path.Source.relative path fn in
             if Path.Source.is_in_build_dir path then
               Memo.Build.return List.Skip

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -182,7 +182,7 @@ end = struct
     | Ok dir_contents ->
       let dir_contents = Fs_cache.Dir_contents.to_list dir_contents in
       let+ files, dirs =
-        Memo.Build.parallel_map dir_contents ~f:(fun (fn, kind) ->
+        Memo.Build.sequential_map dir_contents ~f:(fun (fn, kind) ->
             let path = Path.Source.relative path fn in
             if Path.Source.is_in_build_dir path then
               Memo.Build.return List.Skip

--- a/src/dune_engine/variant.mli
+++ b/src/dune_engine/variant.mli
@@ -9,7 +9,7 @@ open Stdune
 
 type t = private string
 
-include Comparable_intf.S with type Key.t := t
+include Comparable_intf.S with type key := t
 
 val make : string -> t
 

--- a/src/dune_graph/graph.ml
+++ b/src/dune_graph/graph.ml
@@ -76,8 +76,7 @@ module Edge = struct
   end
 
   include T
-  module Map = Map.Make (T)
-  module Set = Set.Make (T) (Map)
+  include Comparable.Make (T)
 end
 
 type t =

--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -84,6 +84,7 @@ module Mode_conf = struct
       [ ("byte", Byte); ("js", Javascript); ("native", Native); ("best", Best) ]
 
   module O = Comparable.Make (T)
+  module Map = O.Map
 
   module Set = struct
     include O.Set

--- a/src/dune_rules/inline_tests_info.mli
+++ b/src/dune_rules/inline_tests_info.mli
@@ -27,8 +27,10 @@ module Mode_conf : sig
 
   val decode : t Dune_lang.Decoder.t
 
+  module Map : Map.S with type key = t
+
   module Set : sig
-    include Set.S with type elt = t
+    include Set.S with type elt = t and type 'a map = 'a Map.t
 
     val decode : t Dune_lang.Decoder.t
 

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -255,9 +255,7 @@ module Id : sig
 
   val make : path:Path.t -> name:Lib_name.t -> t
 
-  module Set : Set.S with type elt = t
-
-  module Map : Map.S with type key = t
+  include Comparable_intf.S with type key := t
 
   module Top_closure :
     Top_closure_intf.S
@@ -2184,9 +2182,7 @@ module Local : sig
 
   val hash : t -> int
 
-  module Set : Stdune.Set.S with type elt = t
-
-  module Map : Stdune.Map.S with type key = t
+  include Comparable_intf.S with type key := t
 end = struct
   type nonrec t = t
 

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -52,9 +52,7 @@ end
 
 val unique_id : t -> Id.t
 
-module Set : Set.S with type elt = t
-
-module Map : Map.S with type key = t
+include Comparable_intf.S with type key := t
 
 val equal : t -> t -> bool
 
@@ -311,8 +309,6 @@ module Local : sig
 
   val obj_dir : t -> Path.Build.t Obj_dir.t
 
-  module Set : Stdune.Set.S with type elt = t
-
-  module Map : Stdune.Map.S with type key = t
+  include Comparable_intf.S with type key := t
 end
 with type lib := t

--- a/src/dune_rules/module_name.mli
+++ b/src/dune_rules/module_name.mli
@@ -61,15 +61,13 @@ module Unique : sig
 
   include Dune_lang.Conv.S with type t := t
 
-  module Map : Map.S with type key = t
-
-  module Set : Set.S with type elt = t
+  include Comparable_intf.S with type key := t
 end
 with type name := t
 
 val wrap : t -> with_:t -> Unique.t
 
-module Map : Map.S with type key = t
+include Comparable_intf.S with type key := t
 
 module Map_traversals : sig
   val parallel_iter :
@@ -77,12 +75,6 @@ module Map_traversals : sig
 
   val parallel_map :
     'a Map.t -> f:(t -> 'a -> 'b Memo.Build.t) -> 'b Map.t Memo.Build.t
-end
-
-module Set : sig
-  include Set.S with type elt = t
-
-  val to_dyn : t -> Dyn.t
 end
 
 val of_string_allow_invalid : Loc.t * string -> t

--- a/src/dune_rules/sub_system_name.mli
+++ b/src/dune_rules/sub_system_name.mli
@@ -6,6 +6,6 @@ val make : string -> t
 
 val to_string : t -> string
 
-include Comparable_intf.S with type Key.t = t
+include Comparable_intf.S with type key := t
 
 module Table : Hashtbl.S with type key := t

--- a/xdg.opam
+++ b/xdg.opam
@@ -22,11 +22,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/xdg.opam
+++ b/xdg.opam
@@ -22,9 +22,11 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"


### PR DESCRIPTION
Extracted from #5200:

- remove `Comparable.Make().Key` which was not useful and sometimes annoying
- use `Comparable.Make` and `Comparable_intf.S` more consistently across the code base
