### PR TITLE
Replace [Fs_memo.path_stat] with more precise functions

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -40,11 +40,14 @@ end = struct
     match Path.as_in_build_dir path with
     | Some path -> mkdir_p path
     | None -> (
-      Fs_memo.path_exists path >>| function
+      Fs_memo.dir_exists path >>| function
       | true -> ()
       | false ->
+        (* CR-someday amokhov: I think this case is impossible because we only
+           call [mkdir_p_or_assert_existence] for directories in [Chdir] actions
+           but those are checked to be in the build directory. *)
         User_error.raise ~loc
-          [ Pp.textf "%S does not exist" (Path.to_string_maybe_quoted path) ])
+          [ Pp.textf "Directory %S does not exist" (Path.to_string path) ])
 end
 
 module Loaded = struct

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -8,17 +8,21 @@ val init : dune_file_watcher:Dune_file_watcher.t option -> Memo.Invalidation.t
 (** All functions in this module raise a code error when given a path in the
     build directory. *)
 
-(* CR-someday amokhov: Note that currently the scheduler calls [handle] only for
-   source paths, because we don't watch external directories. We should try to
-   implement at least a partial support for watching external paths. *)
+(** Check if a source or external file exists and declare a dependency on it. *)
+val file_exists : Path.t -> bool Memo.Build.t
 
-(** Check if a source or external path exists and declare a dependency on it. *)
-val path_exists : Path.t -> bool Memo.Build.t
+(** Check if a source or external directory exists and declare a dependency on
+    it. *)
+val dir_exists : Path.t -> bool Memo.Build.t
 
 (** Call [Path.stat] on a path and declare a dependency on it. *)
 val path_stat :
      Path.t
   -> (Fs_cache.Reduced_stats.t, Unix_error.Detailed.t) result Memo.Build.t
+
+(** Like [path_stat] but extracts the [st_kind] field from the result. *)
+val path_kind :
+  Path.t -> (File_kind.t, Unix_error.Detailed.t) result Memo.Build.t
 
 (** Digest the contents of a source or external path and declare a dependency on
     it. When [force_update = true], evict the path from all digest caches and

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -47,7 +47,7 @@ let create_dirs t ~deps ~chdirs ~rule_dir =
         (* This [path] is not in the build directory, so we do not need to
            create it. If it comes from [deps], it must exist already. If it
            comes from [chdirs], we'll ensure that it exists in the call to
-           [Fs.mkdir_p_or_assert_existence] below. *)
+           [Fs.mkdir_p_or_assert_existence] in [execute_action_for_rule]. *)
         ()
       | Some path ->
         (* There is no point in using the memoized version [Fs.mkdir_p] since

--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -27,8 +27,7 @@ module Bin = struct
 
   let binary_available t name =
     if not (Filename.is_relative name) then
-      let p = Path.of_filename_relative_to_initial_cwd name in
-      Fs_memo.path_exists p
+      Fs_memo.file_exists (Path.of_filename_relative_to_initial_cwd name)
     else
       match String.Map.find t.local_bins name with
       | Some _ -> Memo.Build.return true

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -37,12 +37,9 @@ module Bin = struct
   include Bin
 
   let exists fn =
-    let+ stat = Fs_memo.path_stat fn in
-    match stat with
-    | Error _
-    | Ok { st_kind = S_DIR; _ } ->
-      None
-    | Ok _ -> Some fn
+    Fs_memo.file_exists fn >>| function
+    | true -> Some fn
+    | false -> None
 
   let which ~path prog =
     let prog = add_exe prog in

--- a/src/dune_rules/workspace.ml
+++ b/src/dune_rules/workspace.ml
@@ -616,16 +616,16 @@ let workspace_step1 =
       match clflags.workspace_file with
       | None ->
         let p = Path.of_string filename in
-        let+ exists = Fs_memo.path_exists p in
+        let+ exists = Fs_memo.file_exists p in
         Option.some_if exists p
       | Some p -> (
-        Fs_memo.path_exists p >>| function
+        Fs_memo.file_exists p >>| function
+        | true -> Some p
         | false ->
           User_error.raise
             [ Pp.textf "Workspace file %s does not exist"
                 (Path.to_string_maybe_quoted p)
-            ]
-        | true -> Some p)
+            ])
     in
     let clflags = { clflags with workspace_file } in
     match workspace_file with


### PR DESCRIPTION
As discussed in #5205, all call sites of `Fs_memo.path_stat` can be rewritten to use more precise functions.