### PR TITLE
Assert that actions only [chdir] inside the build directory

### DIFF
--- a/otherlibs/stdune-unstable/set_intf.ml
+++ b/otherlibs/stdune-unstable/set_intf.ml
@@ -61,6 +61,8 @@ module type S = sig
 
   val to_list : t -> elt list
 
+  val to_seq : t -> elt Seq.t
+
   (** Convert to a list and map every element. *)
   val to_list_map : t -> f:(elt -> 'a) -> 'a list
 

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -15,7 +15,6 @@ val create :
   -> rule_loc:Loc.t
   -> deps:Dep.Facts.t
   -> rule_dir:Path.Build.t
-  -> chdirs:Path.Set.t
   -> rule_digest:Digest.t
   -> expand_aliases:bool
   -> t


### PR DESCRIPTION
As discussed in #5209. 

We could also change `Action.chdirs` to return `Path.Build.Set.t` but that seems more invasive. 