### PR TITLE
Handle conflicts for directory targets

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -422,8 +422,10 @@ let report_rule_src_dir_conflict dir fn (rule : Rule.t) =
       Loc.in_dir dir
   in
   User_error.raise ~loc
-    [ Pp.textf "Rule has a target %s" (Path.Build.to_string_maybe_quoted fn)
-    ; Pp.textf "This conflicts with a source directory in the same directory"
+    [ Pp.textf
+        "This rule defines a target %S whose name conflicts with a source \
+         directory in the same directory."
+        (Path.Build.basename fn)
     ]
 
 let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
@@ -732,20 +734,20 @@ end = struct
 
   let compile_rules ~dir ~source_dirs rules =
     let file_targets, directory_targets =
+      let check_for_source_dir_conflict rule target =
+        if String.Set.mem source_dirs (Path.Build.basename target) then
+          report_rule_src_dir_conflict dir target rule
+      in
       List.map rules ~f:(fun rule ->
           assert (Path.Build.( = ) dir rule.Rule.dir);
           ( Path.Build.Set.to_list_map rule.targets.files ~f:(fun target ->
-                if String.Set.mem source_dirs (Path.Build.basename target) then
-                  report_rule_src_dir_conflict dir target rule
-                else
-                  (target, rule))
+                check_for_source_dir_conflict rule target;
+                (target, rule))
           , Path.Build.Set.to_list_map rule.targets.dirs ~f:(fun target ->
-                (* CR-someday amokhov: Check there is no matching source dir. *)
+                check_for_source_dir_conflict rule target;
                 (target, rule)) ))
       |> List.unzip
     in
-    (* CR-someday amokhov: Report rule conflicts for all targets rather than
-       doing it separately for files and directories. *)
     let by_file_targets =
       List.concat file_targets
       |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
@@ -754,6 +756,13 @@ end = struct
       List.concat directory_targets
       |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
     in
+    Path.Build.Map.iter2 by_file_targets by_directory_targets
+      ~f:(fun target rule1 rule2 ->
+        match (rule1, rule2) with
+        | None, _
+        | _, None ->
+          ()
+        | Some rule1, Some rule2 -> report_rule_conflict target rule1 rule2);
     { Loaded.by_file_targets; by_directory_targets }
 
   (* Here we are doing a O(log |S|) lookup in a set S of files in the build

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -427,6 +427,13 @@ let report_rule_src_dir_conflict dir fn (rule : Rule.t) =
          directory in the same directory."
         (Path.Build.basename fn)
     ]
+    ~hints:
+      [ Pp.textf
+          "If you want Dune to generate and replace %S, add (mode promote) to \
+           the rule stanza. Alternatively, you can delete %S from the source \
+           tree or change the rule to generate a different target."
+          (Path.Build.basename fn) (Path.Build.basename fn)
+      ]
 
 let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
   let fn = Path.build fn in

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
@@ -25,8 +25,8 @@ We should not be able to produce a directory in a rule that already exists
   5 | (rule
   6 |  (targets dir)
   7 |  (action (run ./foo.exe dir)))
-  Error: Rule has a target default/dir
-  This conflicts with a source directory in the same directory
+  Error: This rule defines a target "dir" whose name conflicts with a source
+  directory in the same directory.
   [1]
 
 Dune crashes if there's a file named after the directory target
@@ -36,8 +36,8 @@ Dune crashes if there's a file named after the directory target
   1 | (rule
   2 |  (targets dir)
   3 |  (action (bash "mkdir %{targets}")))
-  Error: Rule has a target default/dir
-  This conflicts with a source directory in the same directory
+  Error: This rule defines a target "dir" whose name conflicts with a source
+  directory in the same directory.
   [1]
 
 directory target and (mode promote) results in a crash

--- a/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/dir-target-dep.t/run.t
@@ -27,6 +27,9 @@ We should not be able to produce a directory in a rule that already exists
   7 |  (action (run ./foo.exe dir)))
   Error: This rule defines a target "dir" whose name conflicts with a source
   directory in the same directory.
+  Hint: If you want Dune to generate and replace "dir", add (mode promote) to
+  the rule stanza. Alternatively, you can delete "dir" from the source tree or
+  change the rule to generate a different target.
   [1]
 
 Dune crashes if there's a file named after the directory target
@@ -38,6 +41,9 @@ Dune crashes if there's a file named after the directory target
   3 |  (action (bash "mkdir %{targets}")))
   Error: This rule defines a target "dir" whose name conflicts with a source
   directory in the same directory.
+  Hint: If you want Dune to generate and replace "dir", add (mode promote) to
+  the rule stanza. Alternatively, you can delete "dir" from the source tree or
+  change the rule to generate a different target.
   [1]
 
 directory target and (mode promote) results in a crash

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -424,6 +424,62 @@ File and directory target with the same name.
   Error: "output" is declared as both a file and a directory target.
   [1]
 
+File and directory target with the same name, defined in different rules.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (targets output)
+  >   (action (bash "echo hi > output")))
+  > (rule
+  >   (deps (sandbox always))
+  >   (targets (dir output))
+  >   (action (bash "mkdir output; echo x > output/x; echo y > output/y")))
+  > EOF
+
+  $ dune build output/x
+  Error: Multiple rules generated for _build/default/output:
+  - dune:1
+  - dune:4
+  [1]
+
+Conflict between a target directory and a source directory.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (deps (sandbox always))
+  >   (targets (dir output))
+  >   (action (bash "mkdir output; echo x > output/x; echo y > output/y")))
+  > EOF
+
+  $ mkdir output
+  $ dune build output/x
+  File "dune", line 1, characters 0-128:
+  1 | (rule
+  2 |   (deps (sandbox always))
+  3 |   (targets (dir output))
+  4 |   (action (bash "mkdir output; echo x > output/x; echo y > output/y")))
+  Error: This rule defines a target "output" whose name conflicts with a source
+  directory in the same directory.
+  [1]
+
+Conflict between a target directory and a source file.
+
+  $ cat > dune <<EOF
+  > (rule
+  >   (deps (sandbox always))
+  >   (targets (dir output))
+  >   (action (bash "mkdir output; echo x > output/x; echo y > output/y")))
+  > EOF
+
+  $ rm -rf output
+  $ touch output
+  $ dune build output/x
+  Error: Multiple rules generated for _build/default/output:
+  - file present in source tree
+  - dune:1
+  Hint: rm -f output
+  [1]
+
 Promotion of directory targets.
 
   $ mkdir test; cd test

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -460,6 +460,9 @@ Conflict between a target directory and a source directory.
   4 |   (action (bash "mkdir output; echo x > output/x; echo y > output/y")))
   Error: This rule defines a target "output" whose name conflicts with a source
   directory in the same directory.
+  Hint: If you want Dune to generate and replace "output", add (mode promote)
+  to the rule stanza. Alternatively, you can delete "output" from the source
+  tree or change the rule to generate a different target.
   [1]
 
 Conflict between a target directory and a source file.


### PR DESCRIPTION
Fixing a couple of outstanding CR-somedays for directory targets.

I tweaked the existing error message: we were printing the conflicting directory with the context bit (e.g. `default/dir`) for some reason.