### PR TITLE
Clean up promoted directory targets more aggressively

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -111,7 +111,8 @@ val init :
      stats:Dune_stats.t option
   -> contexts:Build_context.t list Memo.Lazy.t
   -> promote_source:
-       (   ?chmod:(int -> int)
+       (   chmod:(int -> int)
+        -> delete_dst_if_it_is_a_directory:bool
         -> src:Path.Build.t
         -> dst:Path.Source.t
         -> Build_context.t option

--- a/src/dune_engine/target_promotion.mli
+++ b/src/dune_engine/target_promotion.mli
@@ -10,6 +10,7 @@ val promote :
   -> promote:Rule.Promote.t
   -> promote_source:
        (   chmod:(int -> int)
+        -> delete_dst_if_it_is_a_directory:bool
         -> src:Path.Build.t
         -> dst:Path.Source.t
         -> unit Fiber.t)

--- a/src/dune_rules/artifact_substitution.mli
+++ b/src/dune_rules/artifact_substitution.mli
@@ -62,6 +62,7 @@ val decode : string -> t option
 val copy_file :
      conf:conf
   -> ?chmod:(int -> int)
+  -> ?delete_dst_if_it_is_a_directory:bool
   -> src:Path.t
   -> dst:Path.t
   -> unit

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -35,7 +35,7 @@ let implicit_default_alias dir =
 
 let init ~stats ~sandboxing_preference ~cache_config ~cache_debug_flags ~handler
     =
-  let promote_source ?chmod ~src ~dst ctx =
+  let promote_source ~chmod ~delete_dst_if_it_is_a_directory ~src ~dst ctx =
     let open Fiber.O in
     let* ctx =
       Memo.Build.run
@@ -45,7 +45,8 @@ let init ~stats ~sandboxing_preference ~cache_config ~cache_debug_flags ~handler
     let conf = Artifact_substitution.conf_of_context ctx in
     let src = Path.build src in
     let dst = Path.source dst in
-    Artifact_substitution.copy_file ?chmod ~src ~dst ~conf ()
+    Artifact_substitution.copy_file ~chmod ~delete_dst_if_it_is_a_directory ~src
+      ~dst ~conf ()
   in
   Build_system.init ~stats ~sandboxing_preference ~promote_source
     ~contexts:

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -451,29 +451,29 @@ Promotion of directory targets.
   c
   d
 
-Test error message if a destination directory is taken up by a file.
+If a destination directory is taken up by a file, Dune deletes it.
 
   $ rm -rf dir
   $ mkdir dir
   $ touch dir/subdir
   $ dune build a
-  File "dune", line 1, characters 0-263:
-   1 | (rule
-   2 |   (mode promote)
-   3 |   (deps (sandbox always))
-   4 |   (targets a (dir dir))
-   5 |   (action (bash "\| echo a > a;
-   6 |                 "\| mkdir -p dir/subdir;
-   7 |                 "\| echo b > dir/b;
-   8 |                 "\| echo c > dir/c;
-   9 |                 "\| echo d > dir/subdir/d
-  10 | )))
-  Error: Cannot promote files to "dir/subdir".
-  Reason: "dir/subdir" is not a directory.
-  -> required by _build/default/a
-  [1]
+  $ cat a dir/b dir/c dir/subdir/d
+  a
+  b
+  c
+  d
 
-  $ rm dir/subdir
+If a destination file is taken up by a directory, Dune deletes it.
+
+  $ rm dir/b
+  $ mkdir -p dir/b
+  $ touch dir/b
+  $ dune build a
+  $ cat a dir/b dir/c dir/subdir/d
+  a
+  b
+  c
+  d
 
 Test error message for (promote (into <dir>)) if <dir> is missing.
 


### PR DESCRIPTION
As discussed in #5202.

I also investigated the spurious errors in file-watching promotion test and clarified the reason by expanding the CR-someday.