### PR TITLE
Factor out rule cache logic into a separate module

### DIFF
--- a/otherlibs/stdune-unstable/path.ml
+++ b/otherlibs/stdune-unstable/path.ml
@@ -1016,6 +1016,9 @@ let drop_optional_build_context t =
   | None -> t
   | Some (_, t) -> in_source_tree t
 
+let pp path =
+  drop_optional_build_context path |> to_string_maybe_quoted |> Pp.verbatim
+
 let drop_optional_build_context_maybe_sandboxed t =
   match extract_build_context_dir_maybe_sandboxed t with
   | None -> t

--- a/otherlibs/stdune-unstable/path.mli
+++ b/otherlibs/stdune-unstable/path.mli
@@ -227,6 +227,8 @@ val of_filename_relative_to_initial_cwd : string -> t
     root has been set. [root] is the root directory of local paths *)
 val to_absolute_filename : t -> string
 
+val pp : t -> _ Pp.t
+
 (** Reach a given path [from] a directory. For example, let [p] be a path to the
     file [some/dir/file] and [d] be a path to the directory [some/another/dir].
     Then [reach p ~from:d] evaluates to [../../dir/file]. *)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -60,91 +60,6 @@ module Loaded = struct
       }
 end
 
-(* Stores information needed to determine if rule need to be reexecuted. *)
-module Trace_db : sig
-  module Entry : sig
-    type t =
-      { rule_digest : Digest.t
-      ; dynamic_deps_stages : (Action_exec.Dynamic_dep.Set.t * Digest.t) list
-      ; targets_digest : Digest.t
-      }
-  end
-
-  val get : Path.t -> Entry.t option
-
-  val set : Path.t -> Entry.t -> unit
-end = struct
-  module Entry = struct
-    type t =
-      { rule_digest : Digest.t
-      ; dynamic_deps_stages : (Action_exec.Dynamic_dep.Set.t * Digest.t) list
-      ; targets_digest : Digest.t
-      }
-
-    let to_dyn { rule_digest; dynamic_deps_stages; targets_digest } =
-      Dyn.Record
-        [ ("rule_digest", Digest.to_dyn rule_digest)
-        ; ( "dynamic_deps_stages"
-          , Dyn.list
-              (Dyn.pair Action_exec.Dynamic_dep.Set.to_dyn Digest.to_dyn)
-              dynamic_deps_stages )
-        ; ("targets_digest", Digest.to_dyn targets_digest)
-        ]
-  end
-
-  (* Keyed by the first target of the rule. *)
-  type t = Entry.t Path.Table.t
-
-  let file = Path.relative Path.build_dir ".db"
-
-  let to_dyn = Path.Table.to_dyn Entry.to_dyn
-
-  module P = Dune_util.Persistent.Make (struct
-    type nonrec t = t
-
-    let name = "INCREMENTAL-DB"
-
-    let version = 4
-
-    let to_dyn = to_dyn
-  end)
-
-  let needs_dumping = ref false
-
-  let t =
-    lazy
-      (match P.load file with
-      | Some t -> t
-      (* This mutable table is safe: it's only used by [execute_rule_impl] to
-         decide whether to rebuild a rule or not; [execute_rule_impl] ensures
-         that the targets are produced deterministically. *)
-      | None -> Path.Table.create 1024)
-
-  let dump () =
-    if !needs_dumping && Path.build_dir_exists () then (
-      needs_dumping := false;
-      Console.Status_line.with_overlay
-        (Live (fun () -> Pp.hbox (Pp.text "Saving build trace db...")))
-        ~f:(fun () -> P.dump file (Lazy.force t))
-    )
-
-  (* CR-someday amokhov: If this happens to be executed after we've cleared the
-     status line and printed some text afterwards, [dump] would overwrite that
-     text by the "Saving..." message. If this hypothetical scenario turns out to
-     be a real problem, we will need to add some synchronisation mechanism to
-     prevent clearing the status line too early. *)
-  let () = at_exit dump
-
-  let get path =
-    let t = Lazy.force t in
-    Path.Table.find t path
-
-  let set path e =
-    let t = Lazy.force t in
-    needs_dumping := true;
-    Path.Table.set t path e
-end
-
 module Subdir_set = struct
   type t =
     | All
@@ -336,12 +251,6 @@ let t () = Fdecl.get t
 
 let errors () = (t ()).errors
 
-let pp_path p =
-  Path.drop_optional_build_context p
-  |> Path.to_string_maybe_quoted |> Pp.verbatim
-
-let pp_paths set = Pp.enumerate (Path.Set.to_list set) ~f:pp_path
-
 let get_dir_triage t ~dir =
   match Dpath.analyse_dir dir with
   | Source dir ->
@@ -464,110 +373,6 @@ let () =
       let fns = !pending_file_targets in
       pending_file_targets := Path.Build.Set.empty;
       Path.Build.Set.iter fns ~f:(fun p -> Path.Build.unlink_no_err p))
-
-let compute_target_digests (targets : Targets.Validated.t) :
-    Digest.t Targets.Produced.t option =
-  (* CR-someday amokhov: The workspace-local cache currently does not work for
-     directory targets because we ignore [targets.dirs] here. *)
-  let targets =
-    Targets.Produced.of_validated_files targets ~on_dir_target:`Ignore
-  in
-  Targets.Produced.Option.mapi targets ~f:(fun target () ->
-      Cached_digest.build_file target |> Cached_digest.Digest_result.to_option)
-
-let compute_target_digests_or_raise_error exec_params ~loc ~produced_targets :
-    Digest.t Targets.Produced.t =
-  let compute_digest =
-    (* Remove write permissions on targets. A first theoretical reason is that
-       the build process should be a computational graph and targets should not
-       change state once built. A very practical reason is that enabling the
-       cache will remove write permission because of hardlink sharing anyway, so
-       always removing them enables to catch mistakes earlier. *)
-    (* FIXME: searching the dune version for each single target seems way
-       suboptimal. This information could probably be stored in rules
-       directly. *)
-    let remove_write_permissions =
-      Execution_parameters.should_remove_write_permissions_on_generated_files
-        exec_params
-    in
-    Cached_digest.refresh ~remove_write_permissions
-  in
-  match
-    Targets.Produced.Option.mapi produced_targets ~f:(fun target () ->
-        compute_digest target |> Cached_digest.Digest_result.to_option)
-  with
-  | Some result -> result
-  | None -> (
-    let missing, errors =
-      let process_target target (missing, errors) =
-        let expected_syscall_path = Path.to_string (Path.build target) in
-        match compute_digest target with
-        | Ok (_ : Digest.t) -> (missing, errors)
-        | No_such_file -> (target :: missing, errors)
-        | Broken_symlink ->
-          let error = [ Pp.verbatim "Broken symlink" ] in
-          (missing, (target, error) :: errors)
-        | Unexpected_kind file_kind ->
-          let error =
-            [ Pp.verbatim
-                (sprintf "Unexpected file kind %S (%s)"
-                   (File_kind.to_string file_kind)
-                   (File_kind.to_string_hum file_kind))
-            ]
-          in
-          (missing, (target, error) :: errors)
-        | Unix_error (error, syscall, path) ->
-          let error =
-            [ (if String.equal expected_syscall_path path then
-                Pp.verbatim syscall
-              else
-                Pp.concat
-                  [ Pp.verbatim syscall
-                  ; Pp.verbatim " "
-                  ; Pp.verbatim (String.maybe_quoted path)
-                  ])
-            ; Pp.text (Unix.error_message error)
-            ]
-          in
-          (missing, (target, error) :: errors)
-        | Error exn ->
-          let error =
-            match exn with
-            | Sys_error msg ->
-              [ Pp.verbatim
-                  (String.drop_prefix_if_exists
-                     ~prefix:(expected_syscall_path ^ ": ")
-                     msg)
-              ]
-            | exn -> [ Pp.verbatim (Printexc.to_string exn) ]
-          in
-          (missing, (target, error) :: errors)
-      in
-      Path.Build.Map.foldi (Targets.Produced.all_files produced_targets)
-        ~init:([], []) ~f:(fun target () -> process_target target)
-    in
-    match (missing, errors) with
-    | [], [] ->
-      Code_error.raise
-        "compute_target_digests_or_raise_error: spurious target digest failure"
-        [ ("targets", Targets.Produced.to_dyn produced_targets) ]
-    | missing, errors ->
-      User_error.raise ~loc
-        ((match missing with
-         | [] -> []
-         | _ ->
-           [ Pp.textf "Rule failed to generate the following targets:"
-           ; pp_paths (Path.Set.of_list_map ~f:Path.build missing)
-           ])
-        @
-        match errors with
-        | [] -> []
-        | _ ->
-          [ Pp.textf "Error trying to read targets after a rule was run:"
-          ; Pp.enumerate (List.rev errors) ~f:(fun (target, error) ->
-                Pp.concat ~sep:(Pp.verbatim ": ")
-                  (pp_path (Path.build target) :: error))
-          ]))
 
 let rec with_locks t mutexes ~f =
   match mutexes with
@@ -884,10 +689,12 @@ end = struct
                    tree, either they must all be."
               ; Pp.nop
               ; Pp.text "The following targets are present:"
-              ; pp_paths (Path.set_of_source_paths present_targets)
+              ; Pp.enumerate ~f:Path.pp
+                  (Path.set_of_source_paths present_targets |> Path.Set.to_list)
               ; Pp.nop
               ; Pp.text "The following targets are not:"
-              ; pp_paths (Path.set_of_source_paths absent_targets)
+              ; Pp.enumerate ~f:Path.pp
+                  (Path.set_of_source_paths absent_targets |> Path.Set.to_list)
               ])
 
   (** A directory is only allowed to be generated if its parent knows about it.
@@ -1434,47 +1241,6 @@ end = struct
         in
         Dune_stats.emit stats event)
 
-  (** A type isomorphic to Result, but without the negative connotations
-      associated with the word Error. *)
-  module Cache_result = struct
-    type ('hit, 'miss) t =
-      | Hit of 'hit
-      | Miss of 'miss
-  end
-
-  let shared_cache_key_string_for_log ~rule_digest ~head_target =
-    sprintf "[%s] (%s)"
-      (Digest.to_string rule_digest)
-      (Path.Build.to_string head_target)
-
-  module Shared_cache_miss_reason = struct
-    type t =
-      | Cache_disabled
-      | Can't_go_in_shared_cache
-      | Rerunning_for_reproducibility_check
-      | Not_found_in_cache
-      | Error of string
-  end
-
-  (* CR-someday amokhov: If the cloud cache is enabled, then before attempting
-     to restore artifacts from the shared cache, we should send a download
-     request for [rule_digest] to the cloud. *)
-  let try_to_restore_from_shared_cache ~debug_shared_cache ~mode ~rule_digest
-      ~head_target ~target_dir :
-      (Digest.t Targets.Produced.t, Shared_cache_miss_reason.t) Cache_result.t =
-    let key () = shared_cache_key_string_for_log ~rule_digest ~head_target in
-    match Dune_cache.Local.restore_artifacts ~mode ~rule_digest ~target_dir with
-    | Restored res ->
-      (* it's a small departure from the general "debug cache" semantics that
-         we're also printing successes, but it can be useful to see successes
-         too if the goal is to understand when and how the file in the build
-         directory appeared *)
-      if debug_shared_cache then
-        Log.info [ Pp.textf "cache restore success %s" (key ()) ];
-      Hit (Targets.Produced.of_file_list_exn res)
-    | Not_found_in_cache -> Miss Not_found_in_cache
-    | Error exn -> Miss (Error (Printexc.to_string exn))
-
   module Exec_result = struct
     type t =
       { produced_targets : unit Targets.Produced.t
@@ -1601,208 +1367,6 @@ end = struct
         Path.Build.Set.diff !pending_file_targets targets.files);
     exec_result
 
-  (* If this function fails to store the rule to the shared cache, it returns
-     [None] because we don't want this to be a catastrophic error. We simply log
-     this incident and continue without saving the rule to the shared cache. *)
-  let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~file_targets :
-      Digest.t Targets.Produced.t option Fiber.t =
-    let open Fiber.O in
-    let hex = Digest.to_string rule_digest in
-    let pp_error msg =
-      let action = Action.for_shell action |> Action_to_sh.pp in
-      Pp.concat
-        [ Pp.textf "cache store error [%s]: %s after executing" hex msg
-        ; Pp.space
-        ; Pp.char '('
-        ; action
-        ; Pp.char ')'
-        ]
-    in
-    let update_cached_digests ~targets_and_digests =
-      List.iter targets_and_digests ~f:(fun (target, digest) ->
-          Cached_digest.set target digest);
-      Some (Targets.Produced.of_file_list_exn targets_and_digests)
-    in
-    match
-      Path.Build.Map.to_list_map file_targets ~f:(fun target () ->
-          Dune_cache.Local.Target.create target)
-      |> Option.List.all
-    with
-    | None -> Fiber.return None
-    | Some targets -> (
-      let compute_digest ~executable path =
-        Result.try_with (fun () ->
-            Digest.file_with_executable_bit ~executable path)
-        |> Fiber.return
-      in
-      Dune_cache.Local.store_artifacts ~mode ~rule_digest ~compute_digest
-        targets
-      >>| function
-      | Stored targets_and_digests ->
-        (* CR-someday amokhov: Here and in the case below we can inform the
-           cloud daemon that a new cache entry can be uploaded to the cloud. *)
-        Log.info [ Pp.textf "cache store success [%s]" hex ];
-        update_cached_digests ~targets_and_digests
-      | Already_present targets_and_digests ->
-        Log.info [ Pp.textf "cache store skipped [%s]: already present" hex ];
-        update_cached_digests ~targets_and_digests
-      | Error exn ->
-        Log.info [ pp_error (Printexc.to_string exn) ];
-        None
-      | Will_not_store_due_to_non_determinism sexp ->
-        (* CR-someday amokhov: We should systematically log all warnings. *)
-        Log.info [ pp_error (Sexp.to_string sexp) ];
-        User_warning.emit [ pp_error (Sexp.to_string sexp) ];
-        None)
-
-  let report_workspace_local_cache_miss
-      ~(cache_debug_flags : Cache_debug_flags.t) ~head_target reason =
-    match cache_debug_flags.workspace_local_cache with
-    | false -> ()
-    | true ->
-      let reason =
-        match reason with
-        | `No_previous_record -> "never seen this target before"
-        | `Rule_changed (before, after) ->
-          sprintf "rule or dependencies changed: %s -> %s"
-            (Digest.to_string before) (Digest.to_string after)
-        | `Targets_missing -> "target missing from build dir"
-        | `Targets_changed -> "target changed in build dir"
-        | `Always_rerun -> "not trying to use the cache"
-        | `Dynamic_deps_changed -> "dynamic dependencies changed"
-      in
-      Console.print_user_message
-        (User_message.make
-           [ Pp.hbox
-               (Pp.textf "Workspace-local cache miss: %s: %s"
-                  (Path.Build.to_string head_target)
-                  reason)
-           ])
-
-  let report_shared_cache_miss ~(cache_debug_flags : Cache_debug_flags.t)
-      ~rule_digest ~head_target (reason : Shared_cache_miss_reason.t) =
-    let should_print =
-      match (cache_debug_flags.shared_cache, reason) with
-      | true, _ -> true
-      | false, Error _ ->
-        (* always log errors because they are not expected as a part of normal
-           operation and might indicate a problem *)
-        true
-      | false, _ -> false
-    in
-    match should_print with
-    | false -> ()
-    | true ->
-      let reason =
-        match reason with
-        | Cache_disabled -> "cache disabled"
-        | Can't_go_in_shared_cache -> "can't go in shared cache"
-        | Error exn -> sprintf "error: %s" exn
-        | Rerunning_for_reproducibility_check ->
-          "rerunning for reproducibility check"
-        | Not_found_in_cache -> "not found in cache"
-      in
-      Console.print_user_message
-        (User_message.make
-           [ Pp.hbox
-               (Pp.textf "Shared cache miss %s: %s"
-                  (shared_cache_key_string_for_log ~rule_digest ~head_target)
-                  reason)
-           ])
-
-  (* Check if the workspace-local cache contains up-to-date results for a rule
-     using the information stored in [Trace_db]. *)
-  let lookup_workspace_local_cache ~rule_digest ~targets ~env :
-      (Digest.t Targets.Produced.t, _) Cache_result.t Fiber.t =
-    (* [prev_trace] will be [None] if [head_target] was never built before. *)
-    let head_target = Targets.Validated.head targets in
-    let prev_trace = Trace_db.get (Path.build head_target) in
-    let prev_trace_with_produced_targets =
-      match prev_trace with
-      | None -> Cache_result.Miss `No_previous_record
-      | Some prev_trace -> (
-        match Digest.equal prev_trace.rule_digest rule_digest with
-        | false ->
-          Cache_result.Miss
-            (`Rule_changed (prev_trace.rule_digest, rule_digest))
-        | true -> (
-          (* [compute_target_digests] returns [None] if not all targets are
-             available in the workspace-local cache. *)
-          match compute_target_digests targets with
-          | None -> Cache_result.Miss `Targets_missing
-          | Some produced_targets -> (
-            match
-              Digest.equal prev_trace.targets_digest
-                (Targets.Produced.digest produced_targets)
-            with
-            | true -> Hit (prev_trace, produced_targets)
-            | false -> Cache_result.Miss `Targets_changed)))
-    in
-    match prev_trace_with_produced_targets with
-    | Cache_result.Miss reason -> Fiber.return (Cache_result.Miss reason)
-    | Hit (prev_trace, produced_targets) ->
-      (* CR-someday aalekseyev: If there's a change at one of the last stages,
-         we still re-run all the previous stages, which is a bit of a waste. We
-         could remember what stage needs re-running and only re-run that (and
-         later stages). *)
-      let rec loop stages =
-        match stages with
-        | [] -> Fiber.return (Cache_result.Hit produced_targets)
-        | (deps, old_digest) :: rest -> (
-          let deps = Action_exec.Dynamic_dep.Set.to_dep_set deps in
-          let open Fiber.O in
-          let* deps = Memo.Build.run (build_deps deps) in
-          let new_digest = Dep.Facts.digest deps ~env in
-          match Digest.equal old_digest new_digest with
-          | true -> loop rest
-          | false -> Fiber.return (Cache_result.Miss `Dynamic_deps_changed))
-      in
-      loop prev_trace.dynamic_deps_stages
-
-  (* Check if the shared cache contains results for a rule and decide whether to
-     use these results or rerun the rule for a reproducibility check. *)
-  let lookup_shared_cache t ~rule_digest ~targets ~target_dir :
-      (Digest.t Targets.Produced.t, Shared_cache_miss_reason.t) Cache_result.t =
-    match t.cache_config with
-    | Disabled -> Miss Shared_cache_miss_reason.Cache_disabled
-    | Enabled { storage_mode = mode; reproducibility_check } -> (
-      match
-        Dune_cache.Config.Reproducibility_check.sample reproducibility_check
-      with
-      | true ->
-        (* CR-someday amokhov: Here we re-execute the rule, as in Jenga. To make
-           [check_probability] more meaningful, we could first make sure that
-           the shared cache actually does contain an entry for [rule_digest]. *)
-        Cache_result.Miss
-          Shared_cache_miss_reason.Rerunning_for_reproducibility_check
-      | false ->
-        try_to_restore_from_shared_cache
-          ~debug_shared_cache:t.cache_debug_flags.shared_cache ~mode
-          ~head_target:(Targets.Validated.head targets)
-          ~rule_digest ~target_dir)
-
-  let examine_targets_and_update_shared_cache t ~loc ~can_go_in_shared_cache
-      ~rule_digest ~execution_parameters ~action ~exec_result :
-      Digest.t Targets.Produced.t Fiber.t =
-    let produced_targets = exec_result.Exec_result.produced_targets in
-    match t.cache_config with
-    | Enabled { storage_mode = mode; reproducibility_check = _ }
-      when can_go_in_shared_cache -> (
-      let open Fiber.O in
-      let+ produced_targets_with_digests =
-        try_to_store_to_shared_cache ~mode ~rule_digest
-          ~file_targets:produced_targets.files ~action
-      in
-      match produced_targets_with_digests with
-      | Some produced_targets_with_digests -> produced_targets_with_digests
-      | None ->
-        compute_target_digests_or_raise_error execution_parameters ~loc
-          ~produced_targets)
-    | _ ->
-      Fiber.return
-        (compute_target_digests_or_raise_error execution_parameters ~loc
-           ~produced_targets)
-
   let promote_targets t ~rule_mode ~dir ~targets ~context =
     match (rule_mode, !Clflags.promote) with
     | (Rule.Mode.Standard | Fallback | Ignore_source_files), _
@@ -1906,38 +1470,31 @@ end = struct
             false
           | _ -> true
         in
-        (* Step I. Check if the workspace-local cache is up to date. *)
-        let* (produced_targets :
-               (Digest.t Targets.Produced.t, _) Cache_result.t) =
-          match always_rerun with
-          | true -> Fiber.return (Cache_result.Miss `Always_rerun)
-          | false ->
-            lookup_workspace_local_cache ~rule_digest ~targets ~env:action.env
-        in
         let* (produced_targets : Digest.t Targets.Produced.t) =
-          match produced_targets with
+          (* Step I. Check if the workspace-local cache is up to date. *)
+          Rule_cache.Workspace_local.lookup ~always_rerun ~rule_digest ~targets
+            ~env:action.env ~build_deps
+          >>= function
           | Hit x -> Fiber.return x
           | Miss miss_reason ->
-            report_workspace_local_cache_miss
-              ~cache_debug_flags:t.cache_debug_flags ~head_target miss_reason;
+            if t.cache_debug_flags.workspace_local_cache then
+              Rule_cache.Workspace_local.report_miss ~head_target miss_reason;
             (* Step II. Remove stale targets both from the digest table and from
-               the buld directiory. *)
+               the build directory. *)
             Path.Build.Set.iter targets.files ~f:(fun file ->
                 Cached_digest.remove file;
                 Path.Build.unlink_no_err file);
             Path.Build.Set.iter targets.dirs ~f:(fun dir ->
                 Cached_digest.remove dir;
                 Path.rm_rf (Path.build dir));
-            (* Step III. Try to restore artifacts from the shared cache. *)
-            let produced_targets_from_cache :
-                (Digest.t Targets.Produced.t, _) Cache_result.t =
-              match can_go_in_shared_cache with
-              | false -> Miss Shared_cache_miss_reason.Can't_go_in_shared_cache
-              | true ->
-                lookup_shared_cache t ~rule_digest ~targets ~target_dir:rule.dir
-            in
             let* produced_targets, dynamic_deps_stages =
-              match produced_targets_from_cache with
+              (* Step III. Try to restore artifacts from the shared cache. *)
+              match
+                Rule_cache.Shared_cache.lookup ~can_go_in_shared_cache
+                  ~cache_config:t.cache_config
+                  ~debug_shared_cache:t.cache_debug_flags.shared_cache
+                  ~rule_digest ~targets ~target_dir:rule.dir
+              with
               | Hit produced_targets ->
                 (* Rules with dynamic deps can't be stored to the shared cache
                    (see the [is_action_dynamic] check above), so we know this is
@@ -1947,28 +1504,29 @@ end = struct
                    the shared cache. *)
                 let dynamic_deps_stages = [] in
                 Fiber.return (produced_targets, dynamic_deps_stages)
-              | Miss shared_cache_miss_reason ->
-                report_shared_cache_miss ~cache_debug_flags:t.cache_debug_flags
-                  ~rule_digest ~head_target shared_cache_miss_reason;
+              | Miss miss_reason ->
+                (match (t.cache_debug_flags.shared_cache, miss_reason) with
+                | true, _
+                | false, Error _ ->
+                  (* Always log errors because they are not expected as a part
+                     of normal operation and might indicate a problem. *)
+                  Rule_cache.Shared_cache.report_miss ~rule_digest ~head_target
+                    miss_reason
+                | false, _ -> ());
                 (* Step IV. Execute the build action. *)
                 let* exec_result =
                   execute_action_for_rule t ~rule_kind ~rule_digest ~action
                     ~deps ~loc ~context ~execution_parameters ~sandbox_mode ~dir
                     ~targets
                 in
-                (* Step V. Examine produced targets:
-
-                   - Check that action produced all expected targets;
-
-                   - Compute their digests;
-
-                   - Remove write permissions;
-
-                   - Store results to the shared cache if needed. *)
+                (* Step V. Examine produced targets and store them to the shared
+                   cache if needed. *)
                 let* produced_targets =
-                  examine_targets_and_update_shared_cache t ~loc
-                    ~can_go_in_shared_cache ~rule_digest ~execution_parameters
-                    ~exec_result ~action:action.action
+                  Rule_cache.Shared_cache.examine_targets_and_store
+                    ~cache_config:t.cache_config ~can_go_in_shared_cache ~loc
+                    ~rule_digest ~execution_parameters
+                    ~produced_targets:exec_result.produced_targets
+                    ~action:action.action
                 in
                 let dynamic_deps_stages =
                   List.map exec_result.action_exec_result.dynamic_deps_stages
@@ -1977,16 +1535,11 @@ end = struct
                 in
                 Fiber.return (produced_targets, dynamic_deps_stages)
             in
-            let trace_db_entry =
-              { Trace_db.Entry.rule_digest
-              ; dynamic_deps_stages
-              ; targets_digest =
-                  (* We do not include target names here, as they are already
-                     included into the rule digest. *)
-                  Targets.Produced.digest produced_targets
-              }
-            in
-            Trace_db.set (Path.build head_target) trace_db_entry;
+            (* We do not include target names into [targets_digest] because they
+               are already included into the rule digest. *)
+            Rule_cache.Workspace_local.store ~head_target ~rule_digest
+              ~dynamic_deps_stages
+              ~targets_digest:(Targets.Produced.digest produced_targets);
             Fiber.return produced_targets
         in
         let* () =

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -1,0 +1,424 @@
+open! Stdune
+open Import
+
+module Result = struct
+  type ('hit, 'miss) t =
+    | Hit of 'hit
+    | Miss of 'miss
+end
+
+module Workspace_local = struct
+  (* Stores information for deciding if a rule needs to be re-executed. *)
+  module Database = struct
+    module Entry = struct
+      type t =
+        { rule_digest : Digest.t
+        ; dynamic_deps_stages : (Action_exec.Dynamic_dep.Set.t * Digest.t) list
+        ; targets_digest : Digest.t
+        }
+
+      let to_dyn { rule_digest; dynamic_deps_stages; targets_digest } =
+        Dyn.Record
+          [ ("rule_digest", Digest.to_dyn rule_digest)
+          ; ( "dynamic_deps_stages"
+            , Dyn.list
+                (Dyn.pair Action_exec.Dynamic_dep.Set.to_dyn Digest.to_dyn)
+                dynamic_deps_stages )
+          ; ("targets_digest", Digest.to_dyn targets_digest)
+          ]
+    end
+
+    (* Keyed by the first target of the rule. *)
+    type t = Entry.t Path.Table.t
+
+    let file = Path.relative Path.build_dir ".db"
+
+    let to_dyn = Path.Table.to_dyn Entry.to_dyn
+
+    module P = Dune_util.Persistent.Make (struct
+      type nonrec t = t
+
+      let name = "INCREMENTAL-DB"
+
+      let version = 4
+
+      let to_dyn = to_dyn
+    end)
+
+    let needs_dumping = ref false
+
+    let t =
+      lazy
+        (match P.load file with
+        | Some t -> t
+        (* This mutable table is safe: it's only used by [execute_rule_impl] to
+           decide whether to rebuild a rule or not; [execute_rule_impl] ensures
+           that the targets are produced deterministically. *)
+        | None -> Path.Table.create 1024)
+
+    let dump () =
+      if !needs_dumping && Path.build_dir_exists () then (
+        needs_dumping := false;
+        Console.Status_line.with_overlay
+          (Live (fun () -> Pp.hbox (Pp.text "Saving build trace db...")))
+          ~f:(fun () -> P.dump file (Lazy.force t))
+      )
+
+    (* CR-someday amokhov: If this happens to be executed after we've cleared
+       the status line and printed some text afterwards, [dump] would overwrite
+       that text by the "Saving..." message. If this hypothetical scenario turns
+       out to be a real problem, we will need to add some synchronisation
+       mechanism to prevent clearing the status line too early. *)
+    let () = at_exit dump
+
+    let get path =
+      let t = Lazy.force t in
+      Path.Table.find t path
+
+    let set path e =
+      let t = Lazy.force t in
+      needs_dumping := true;
+      Path.Table.set t path e
+  end
+
+  let store ~head_target ~rule_digest ~dynamic_deps_stages ~targets_digest =
+    Database.set (Path.build head_target)
+      { rule_digest; dynamic_deps_stages; targets_digest }
+
+  module Miss_reason = struct
+    type t =
+      | No_previous_record
+      | Rule_changed of Digest.t * Digest.t
+      | Targets_changed
+      | Targets_missing
+      | Dynamic_deps_changed
+      | Always_rerun
+  end
+
+  let compute_target_digests (targets : Targets.Validated.t) :
+      Digest.t Targets.Produced.t option =
+    (* CR-someday amokhov: The workspace-local cache currently does not work for
+       directory targets because we ignore [targets.dirs] here. *)
+    let targets =
+      Targets.Produced.of_validated_files targets ~on_dir_target:`Ignore
+    in
+    Targets.Produced.Option.mapi targets ~f:(fun target () ->
+        Cached_digest.build_file target |> Cached_digest.Digest_result.to_option)
+
+  let lookup ~always_rerun ~rule_digest ~targets ~env ~build_deps :
+      (Digest.t Targets.Produced.t, Miss_reason.t) Result.t Fiber.t =
+    match always_rerun with
+    | true -> Fiber.return (Result.Miss Miss_reason.Always_rerun)
+    | false -> (
+      (* [prev_trace] will be [None] if [head_target] was never built before. *)
+      let head_target = Targets.Validated.head targets in
+      let prev_trace = Database.get (Path.build head_target) in
+      let prev_trace_with_produced_targets =
+        match prev_trace with
+        | None -> Result.Miss Miss_reason.No_previous_record
+        | Some prev_trace -> (
+          match Digest.equal prev_trace.rule_digest rule_digest with
+          | false ->
+            Result.Miss (Rule_changed (prev_trace.rule_digest, rule_digest))
+          | true -> (
+            (* [compute_target_digests] returns [None] if not all targets are
+               available in the workspace-local cache. *)
+            match compute_target_digests targets with
+            | None -> Result.Miss Targets_missing
+            | Some produced_targets -> (
+              match
+                Digest.equal prev_trace.targets_digest
+                  (Targets.Produced.digest produced_targets)
+              with
+              | true -> Hit (prev_trace, produced_targets)
+              | false -> Result.Miss Targets_changed)))
+      in
+      match prev_trace_with_produced_targets with
+      | Result.Miss reason -> Fiber.return (Result.Miss reason)
+      | Hit (prev_trace, produced_targets) ->
+        (* CR-someday aalekseyev: If there's a change at one of the last stages,
+           we still re-run all the previous stages, which is a bit of a waste.
+           We could remember what stage needs re-running and only re-run that
+           (and later stages). *)
+        let rec loop stages =
+          match stages with
+          | [] -> Fiber.return (Result.Hit produced_targets)
+          | (deps, old_digest) :: rest -> (
+            let deps = Action_exec.Dynamic_dep.Set.to_dep_set deps in
+            let open Fiber.O in
+            let* deps = Memo.Build.run (build_deps deps) in
+            let new_digest = Dep.Facts.digest deps ~env in
+            match Digest.equal old_digest new_digest with
+            | true -> loop rest
+            | false ->
+              Fiber.return (Result.Miss Miss_reason.Dynamic_deps_changed))
+        in
+        loop prev_trace.dynamic_deps_stages)
+
+  let report_miss ~head_target reason =
+    let reason =
+      match (reason : Miss_reason.t) with
+      | No_previous_record -> "never seen this target before"
+      | Rule_changed (before, after) ->
+        sprintf "rule or dependencies changed: %s -> %s"
+          (Digest.to_string before) (Digest.to_string after)
+      | Targets_missing -> "target missing from build dir"
+      | Targets_changed -> "target changed in build dir"
+      | Always_rerun -> "not trying to use the cache"
+      | Dynamic_deps_changed -> "dynamic dependencies changed"
+    in
+    Console.print_user_message
+      (User_message.make
+         [ Pp.hbox
+             (Pp.textf "Workspace-local cache miss: %s: %s"
+                (Path.Build.to_string head_target)
+                reason)
+         ])
+end
+
+module Shared_cache = struct
+  module Miss_reason = struct
+    type t =
+      | Cache_disabled
+      | Cannot_go_in_shared_cache
+      | Rerunning_for_reproducibility_check
+      | Not_found_in_cache
+      | Error of string
+  end
+
+  let shared_cache_key_string_for_log ~rule_digest ~head_target =
+    sprintf "[%s] (%s)"
+      (Digest.to_string rule_digest)
+      (Path.Build.to_string head_target)
+
+  (* CR-someday amokhov: If the cloud cache is enabled, then before attempting
+     to restore artifacts from the shared cache, we should send a download
+     request for [rule_digest] to the cloud. *)
+  let try_to_restore_from_shared_cache ~debug_shared_cache ~mode ~rule_digest
+      ~head_target ~target_dir :
+      (Digest.t Targets.Produced.t, Miss_reason.t) Result.t =
+    let key () = shared_cache_key_string_for_log ~rule_digest ~head_target in
+    match Dune_cache.Local.restore_artifacts ~mode ~rule_digest ~target_dir with
+    | Restored res ->
+      (* it's a small departure from the general "debug cache" semantics that
+         we're also printing successes, but it can be useful to see successes
+         too if the goal is to understand when and how the file in the build
+         directory appeared *)
+      if debug_shared_cache then
+        Log.info [ Pp.textf "cache restore success %s" (key ()) ];
+      Hit (Targets.Produced.of_file_list_exn res)
+    | Not_found_in_cache -> Miss Not_found_in_cache
+    | Error exn -> Miss (Error (Printexc.to_string exn))
+
+  let lookup ~can_go_in_shared_cache ~cache_config ~debug_shared_cache
+      ~rule_digest ~targets ~target_dir :
+      (Digest.t Targets.Produced.t, Miss_reason.t) Result.t =
+    match can_go_in_shared_cache with
+    | false -> Miss Cannot_go_in_shared_cache
+    | true -> (
+      match (cache_config : Dune_cache.Config.t) with
+      | Disabled -> Miss Miss_reason.Cache_disabled
+      | Enabled { storage_mode = mode; reproducibility_check } -> (
+        match
+          Dune_cache.Config.Reproducibility_check.sample reproducibility_check
+        with
+        | true ->
+          (* CR-someday amokhov: Here we re-execute the rule, as in Jenga. To
+             make [check_probability] more meaningful, we could first make sure
+             that the shared cache actually does contain an entry for
+             [rule_digest]. *)
+          Result.Miss Miss_reason.Rerunning_for_reproducibility_check
+        | false ->
+          try_to_restore_from_shared_cache ~debug_shared_cache ~mode
+            ~head_target:(Targets.Validated.head targets)
+            ~rule_digest ~target_dir))
+
+  let report_miss ~rule_digest ~head_target (reason : Miss_reason.t) =
+    let reason =
+      match reason with
+      | Cache_disabled -> "cache disabled"
+      | Cannot_go_in_shared_cache -> "can't go in shared cache"
+      | Error exn -> sprintf "error: %s" exn
+      | Rerunning_for_reproducibility_check ->
+        "rerunning for reproducibility check"
+      | Not_found_in_cache -> "not found in cache"
+    in
+    Console.print_user_message
+      (User_message.make
+         [ Pp.hbox
+             (Pp.textf "Shared cache miss %s: %s"
+                (shared_cache_key_string_for_log ~rule_digest ~head_target)
+                reason)
+         ])
+
+  (* If this function fails to store the rule to the shared cache, it returns
+     [None] because we don't want this to be a catastrophic error. We simply log
+     this incident and continue without saving the rule to the shared cache. *)
+  let try_to_store_to_shared_cache ~mode ~rule_digest ~action ~file_targets :
+      Digest.t Targets.Produced.t option Fiber.t =
+    let open Fiber.O in
+    let hex = Digest.to_string rule_digest in
+    let pp_error msg =
+      let action = Action.for_shell action |> Action_to_sh.pp in
+      Pp.concat
+        [ Pp.textf "cache store error [%s]: %s after executing" hex msg
+        ; Pp.space
+        ; Pp.char '('
+        ; action
+        ; Pp.char ')'
+        ]
+    in
+    let update_cached_digests ~targets_and_digests =
+      List.iter targets_and_digests ~f:(fun (target, digest) ->
+          Cached_digest.set target digest);
+      Some (Targets.Produced.of_file_list_exn targets_and_digests)
+    in
+    match
+      Path.Build.Map.to_list_map file_targets ~f:(fun target () ->
+          Dune_cache.Local.Target.create target)
+      |> Option.List.all
+    with
+    | None -> Fiber.return None
+    | Some targets -> (
+      let compute_digest ~executable path =
+        Stdune.Result.try_with (fun () ->
+            Digest.file_with_executable_bit ~executable path)
+        |> Fiber.return
+      in
+      Dune_cache.Local.store_artifacts ~mode ~rule_digest ~compute_digest
+        targets
+      >>| function
+      | Stored targets_and_digests ->
+        (* CR-someday amokhov: Here and in the case below we can inform the
+           cloud daemon that a new cache entry can be uploaded to the cloud. *)
+        Log.info [ Pp.textf "cache store success [%s]" hex ];
+        update_cached_digests ~targets_and_digests
+      | Already_present targets_and_digests ->
+        Log.info [ Pp.textf "cache store skipped [%s]: already present" hex ];
+        update_cached_digests ~targets_and_digests
+      | Error exn ->
+        Log.info [ pp_error (Printexc.to_string exn) ];
+        None
+      | Will_not_store_due_to_non_determinism sexp ->
+        (* CR-someday amokhov: We should systematically log all warnings. *)
+        Log.info [ pp_error (Sexp.to_string sexp) ];
+        User_warning.emit [ pp_error (Sexp.to_string sexp) ];
+        None)
+
+  let compute_target_digests_or_raise_error exec_params ~loc ~produced_targets :
+      Digest.t Targets.Produced.t =
+    let compute_digest =
+      (* Remove write permissions on targets. A first theoretical reason is that
+         the build process should be a computational graph and targets should
+         not change state once built. A very practical reason is that enabling
+         the cache will remove write permission because of hardlink sharing
+         anyway, so always removing them enables to catch mistakes earlier. *)
+      (* FIXME: searching the dune version for each single target seems way
+         suboptimal. This information could probably be stored in rules
+         directly. *)
+      let remove_write_permissions =
+        Execution_parameters.should_remove_write_permissions_on_generated_files
+          exec_params
+      in
+      Cached_digest.refresh ~remove_write_permissions
+    in
+    match
+      Targets.Produced.Option.mapi produced_targets ~f:(fun target () ->
+          compute_digest target |> Cached_digest.Digest_result.to_option)
+    with
+    | Some result -> result
+    | None -> (
+      let missing, errors =
+        let process_target target (missing, errors) =
+          let expected_syscall_path = Path.to_string (Path.build target) in
+          match compute_digest target with
+          | Ok (_ : Digest.t) -> (missing, errors)
+          | No_such_file -> (target :: missing, errors)
+          | Broken_symlink ->
+            let error = [ Pp.verbatim "Broken symlink" ] in
+            (missing, (target, error) :: errors)
+          | Unexpected_kind file_kind ->
+            let error =
+              [ Pp.verbatim
+                  (sprintf "Unexpected file kind %S (%s)"
+                     (File_kind.to_string file_kind)
+                     (File_kind.to_string_hum file_kind))
+              ]
+            in
+            (missing, (target, error) :: errors)
+          | Unix_error (error, syscall, path) ->
+            let error =
+              [ (if String.equal expected_syscall_path path then
+                  Pp.verbatim syscall
+                else
+                  Pp.concat
+                    [ Pp.verbatim syscall
+                    ; Pp.verbatim " "
+                    ; Pp.verbatim (String.maybe_quoted path)
+                    ])
+              ; Pp.text (Unix.error_message error)
+              ]
+            in
+            (missing, (target, error) :: errors)
+          | Error exn ->
+            let error =
+              match exn with
+              | Sys_error msg ->
+                [ Pp.verbatim
+                    (String.drop_prefix_if_exists
+                       ~prefix:(expected_syscall_path ^ ": ")
+                       msg)
+                ]
+              | exn -> [ Pp.verbatim (Printexc.to_string exn) ]
+            in
+            (missing, (target, error) :: errors)
+        in
+        Path.Build.Map.foldi (Targets.Produced.all_files produced_targets)
+          ~init:([], []) ~f:(fun target () -> process_target target)
+      in
+      match (missing, errors) with
+      | [], [] ->
+        Code_error.raise
+          "compute_target_digests_or_raise_error: spurious target digest \
+           failure"
+          [ ("targets", Targets.Produced.to_dyn produced_targets) ]
+      | missing, errors ->
+        User_error.raise ~loc
+          ((match missing with
+           | [] -> []
+           | _ ->
+             [ Pp.textf "Rule failed to generate the following targets:"
+             ; Pp.enumerate ~f:Path.pp (List.rev_map ~f:Path.build missing)
+             ])
+          @
+          match errors with
+          | [] -> []
+          | _ ->
+            [ Pp.textf "Error trying to read targets after a rule was run:"
+            ; Pp.enumerate (List.rev errors) ~f:(fun (target, error) ->
+                  Pp.concat ~sep:(Pp.verbatim ": ")
+                    (Path.pp (Path.build target) :: error))
+            ]))
+
+  let examine_targets_and_store ~cache_config ~can_go_in_shared_cache ~loc
+      ~rule_digest ~execution_parameters ~action
+      ~(produced_targets : unit Targets.Produced.t) :
+      Digest.t Targets.Produced.t Fiber.t =
+    match (cache_config : Dune_cache.Config.t) with
+    | Enabled { storage_mode = mode; reproducibility_check = _ }
+      when can_go_in_shared_cache -> (
+      let open Fiber.O in
+      let+ produced_targets_with_digests =
+        try_to_store_to_shared_cache ~mode ~rule_digest
+          ~file_targets:produced_targets.files ~action
+      in
+      match produced_targets_with_digests with
+      | Some produced_targets_with_digests -> produced_targets_with_digests
+      | None ->
+        compute_target_digests_or_raise_error execution_parameters ~loc
+          ~produced_targets)
+    | _ ->
+      Fiber.return
+        (compute_target_digests_or_raise_error execution_parameters ~loc
+           ~produced_targets)
+end

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -1,0 +1,88 @@
+(** Workspace-local and shared caches for rules. *)
+
+open! Stdune
+open! Import
+
+(** A type isomorphic to [Result], but without the negative connotations
+    associated with the word "error". *)
+module Result : sig
+  type ('hit, 'miss) t =
+    | Hit of 'hit
+    | Miss of 'miss
+end
+
+module Workspace_local : sig
+  module Miss_reason : sig
+    type t =
+      | No_previous_record
+      | Rule_changed of Digest.t * Digest.t
+      | Targets_changed
+      | Targets_missing
+      | Dynamic_deps_changed
+      | Always_rerun
+  end
+
+  (** Check if the workspace-local cache contains up-to-date results for a rule
+      using the information stored in the rule database. *)
+  val lookup :
+       always_rerun:bool
+    -> rule_digest:Digest.t
+    -> targets:Targets.Validated.t
+    -> env:Env.t
+    -> build_deps:(Dep.Set.t -> Dep.Facts.t Memo.Build.t)
+    -> (Digest.t Targets.Produced.t, Miss_reason.t) Result.t Fiber.t
+
+  val report_miss : head_target:Path.Build.t -> Miss_reason.t -> unit
+
+  (** Add a new record to the rule database. *)
+  val store :
+       head_target:Path.Build.t
+    -> rule_digest:Digest.t
+    -> dynamic_deps_stages:(Action_exec.Dynamic_dep.Set.t * Digest.t) list
+    -> targets_digest:Digest.t
+    -> unit
+end
+
+module Shared_cache : sig
+  module Miss_reason : sig
+    type t =
+      | Cache_disabled
+      | Cannot_go_in_shared_cache
+      | Rerunning_for_reproducibility_check
+      | Not_found_in_cache
+      | Error of string
+  end
+
+  (** Check if the shared cache contains results for a rule and decide whether
+      to use these results or rerun the rule for a reproducibility check. *)
+  val lookup :
+       can_go_in_shared_cache:bool
+    -> cache_config:Dune_cache.Config.t
+    -> debug_shared_cache:bool
+    -> rule_digest:Digest.t
+    -> targets:Targets.Validated.t
+    -> target_dir:Path.Build.t
+    -> (Digest.t Targets.Produced.t, Miss_reason.t) Result.t
+
+  val report_miss :
+    rule_digest:Digest.t -> head_target:Path.Build.t -> Miss_reason.t -> unit
+
+  (** This function performs the following steps:
+
+      - Check that action produced all expected targets;
+
+      - Compute their digests;
+
+      - Remove write permissions from the targets;
+
+      - Store results to the shared cache if needed. *)
+  val examine_targets_and_store :
+       cache_config:Dune_cache.Config.t
+    -> can_go_in_shared_cache:bool
+    -> loc:Loc.t
+    -> rule_digest:Digest.t
+    -> execution_parameters:Execution_parameters.t
+    -> action:Action.t
+    -> produced_targets:unit Targets.Produced.t
+    -> Digest.t Targets.Produced.t Fiber.t
+end

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -3,36 +3,17 @@
 open! Stdune
 open! Import
 
-(** A type isomorphic to [Result], but without the negative connotations
-    associated with the word "error". *)
-module Result : sig
-  type ('hit, 'miss) t =
-    | Hit of 'hit
-    | Miss of 'miss
-end
-
 module Workspace_local : sig
-  module Miss_reason : sig
-    type t =
-      | No_previous_record
-      | Rule_changed of Digest.t * Digest.t
-      | Targets_changed
-      | Targets_missing
-      | Dynamic_deps_changed
-      | Always_rerun
-  end
-
   (** Check if the workspace-local cache contains up-to-date results for a rule
       using the information stored in the rule database. *)
   val lookup :
        always_rerun:bool
+    -> print_debug_info:bool
     -> rule_digest:Digest.t
     -> targets:Targets.Validated.t
     -> env:Env.t
     -> build_deps:(Dep.Set.t -> Dep.Facts.t Memo.Build.t)
-    -> (Digest.t Targets.Produced.t, Miss_reason.t) Result.t Fiber.t
-
-  val report_miss : head_target:Path.Build.t -> Miss_reason.t -> unit
+    -> Digest.t Targets.Produced.t option Fiber.t
 
   (** Add a new record to the rule database. *)
   val store :
@@ -43,29 +24,17 @@ module Workspace_local : sig
     -> unit
 end
 
-module Shared_cache : sig
-  module Miss_reason : sig
-    type t =
-      | Cache_disabled
-      | Cannot_go_in_shared_cache
-      | Rerunning_for_reproducibility_check
-      | Not_found_in_cache
-      | Error of string
-  end
-
+module Shared : sig
   (** Check if the shared cache contains results for a rule and decide whether
       to use these results or rerun the rule for a reproducibility check. *)
   val lookup :
        can_go_in_shared_cache:bool
     -> cache_config:Dune_cache.Config.t
-    -> debug_shared_cache:bool
+    -> print_debug_info:bool
     -> rule_digest:Digest.t
     -> targets:Targets.Validated.t
     -> target_dir:Path.Build.t
-    -> (Digest.t Targets.Produced.t, Miss_reason.t) Result.t
-
-  val report_miss :
-    rule_digest:Digest.t -> head_target:Path.Build.t -> Miss_reason.t -> unit
+    -> Digest.t Targets.Produced.t option
 
   (** This function performs the following steps:
 
@@ -77,8 +46,8 @@ module Shared_cache : sig
 
       - Store results to the shared cache if needed. *)
   val examine_targets_and_store :
-       cache_config:Dune_cache.Config.t
-    -> can_go_in_shared_cache:bool
+       can_go_in_shared_cache:bool
+    -> cache_config:Dune_cache.Config.t
     -> loc:Loc.t
     -> rule_digest:Digest.t
     -> execution_parameters:Execution_parameters.t

--- a/src/dune_engine/rule_cache.mli
+++ b/src/dune_engine/rule_cache.mli
@@ -3,6 +3,14 @@
 open! Stdune
 open! Import
 
+(** The workspace-local cache consists of two components:
+
+    - Build artifacts currently available in the build directory.
+
+    - A database [_build/.db] that maps rule digests to their target digests.
+
+    The database makes it possible to decide if the build directory contains up
+    to date results for a given rule. *)
 module Workspace_local : sig
   (** Check if the workspace-local cache contains up-to-date results for a rule
       using the information stored in the rule database. *)
@@ -24,6 +32,9 @@ module Workspace_local : sig
     -> unit
 end
 
+(** The shared cache is a separate directory that contains historical build
+    artifacts produced in different workspaces. To restore results from the
+    shared cache, Dune copes or hardlinks them into the build directory. *)
 module Shared : sig
   (** Check if the shared cache contains results for a rule and decide whether
       to use these results or rerun the rule for a reproducibility check. *)


### PR DESCRIPTION
Move ~500 lines for dealing with the rule caches out of `build_system.ml`.

No change in behaviour apart from no longer sorting missing targets in errors.