### PR TITLE
Tweak the progress display

### DIFF
--- a/bin/import.ml
+++ b/bin/import.ml
@@ -49,11 +49,18 @@ end = struct
     Console.Status_line.set
       (Live
          (fun () ->
-           let progression = Build_system.get_current_progress () in
+           let { Build_system.Progress.number_of_rules_executed = done_
+               ; number_of_rules_discovered = total
+               } =
+             Build_system.get_current_progress ()
+           in
            Pp.verbatim
-             (sprintf "Done: %u/%u (jobs: %u)"
-                progression.number_of_rules_executed
-                progression.number_of_rules_discovered
+             (sprintf "Done: %u%% (%u/%u, %u left) (jobs: %u)"
+                (if total = 0 then
+                  0
+                else
+                  done_ * 100 / total)
+                done_ total (total - done_)
                 (Scheduler.running_jobs_count scheduler))));
     Fiber.return (Memo.Build.of_thunk get)
 end


### PR DESCRIPTION
Instead of:

```
Done: <done>/<total> (jobs: <jobs>)
```

print:

```
Done: <percent-done>% (<done>/<total>, <left> left) (jobs: <jobs>)
```

For instance:

```
Done: 10% (10/100, 90 left) (jobs: 20)
```

This is the style we use in Emacs inside Jane Street, and I like it a bit better than the one we currently have. In particular it's nice to see the percentage and the number of rules left.