### PR TITLE
Move load rules to separate module

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -78,7 +78,7 @@ let term =
              executable, they would be located in a subdirectory of [dir], so
              it's unclear if that's what the user wanted. *)
           let+ candidates =
-            Build_system.file_targets_of ~dir:(Path.build dir)
+            Load_rules.file_targets_of ~dir:(Path.build dir)
             >>| Path.Set.to_list
             >>| List.filter ~f:(fun p -> Path.extension p = ".exe")
             >>| List.map ~f:(fun p -> "./" ^ Path.basename p)
@@ -98,14 +98,14 @@ let term =
               | Ok prog -> build_prog prog)
             | Relative_to_current_dir -> (
               let path = Path.relative (Path.build dir) prog in
-              (Build_system.is_target path >>= function
+              (Load_rules.is_target path >>= function
                | true -> Memo.Build.return (Some path)
                | false -> (
                  if not (Filename.check_suffix prog ".exe") then
                    Memo.Build.return None
                  else
                    let path = Path.extend_basename path ~suffix:".exe" in
-                   Build_system.is_target path >>= function
+                   Load_rules.is_target path >>= function
                    | true -> Memo.Build.return (Some path)
                    | false -> Memo.Build.return None))
               >>= function

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -9,6 +9,7 @@ module Local_install_path = Dune_engine.Local_install_path
 module Lib_name = Dune_engine.Lib_name
 module Build_config = Dune_engine.Build_config
 module Build_system = Dune_engine.Build_system
+module Load_rules = Dune_engine.Load_rules
 module Findlib = Dune_rules.Findlib
 module Package = Dune_engine.Package
 module Dune_package = Dune_rules.Dune_package

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -125,7 +125,7 @@ let term =
           let* request =
             match targets with
             | [] ->
-              Build_system.all_targets ()
+              Load_rules.all_targets ()
               >>| Path.Build.Set.fold ~init:[] ~f:(fun p acc ->
                       Path.build p :: acc)
               >>| Action_builder.paths

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -3,6 +3,7 @@ module Log = Dune_util.Log
 module Context = Dune_rules.Context
 module Action_builder = Dune_engine.Action_builder
 module Build_system = Dune_engine.Build_system
+module Load_rules = Dune_engine.Load_rules
 open Action_builder.O
 
 (* CR-someday amokhov: Split [File] into [File] and [Dir] for clarity. *)
@@ -30,7 +31,7 @@ let target_hint (_setup : Dune_rules.Main.build_system) path =
 
      (2) We currently provide the same hint for all targets. It would be nice to
      indicate whether a hint corresponds to a file or to a directory target. *)
-  let+ candidates = Build_system.all_targets () >>| Path.Build.Set.to_list in
+  let+ candidates = Load_rules.all_targets () >>| Path.Build.Set.to_list in
   let candidates =
     if Path.is_in_build_dir path then
       List.map ~f:Path.build candidates
@@ -72,13 +73,13 @@ let resolve_path path ~(setup : Dune_rules.Main.build_system) =
   let matching_targets src =
     Memo.Build.parallel_map setup.contexts ~f:(fun ctx ->
         let path = Path.append_source (Path.build ctx.Context.build_dir) src in
-        Build_system.is_target path >>| function
+        Load_rules.is_target path >>| function
         | true -> Some (File path)
         | false -> None)
     >>| List.filter_map ~f:Fun.id
   in
   let matching_target () =
-    Build_system.is_target path >>| function
+    Load_rules.is_target path >>| function
     | true -> Some [ File path ]
     | false -> None
   in

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -37,7 +37,7 @@ let term =
             let utop_target =
               Path.build (Path.Build.relative context.build_dir utop_target)
             in
-            Build_system.is_target utop_target >>= function
+            Load_rules.is_target utop_target >>= function
             | false ->
               User_error.raise
                 [ Pp.textf "no library is defined in %s"

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -104,7 +104,7 @@ let if_file_exists p ~then_ ~else_ =
     { f =
         (fun mode ->
           let open Memo.Build.O in
-          Build_system.file_exists p >>= function
+          Load_rules.file_exists p >>= function
           | true -> run then_ mode
           | false -> run else_ mode)
     }
@@ -254,7 +254,7 @@ let dep_on_alias_if_exists alias =
     { f =
         (fun mode ->
           let open Memo.Build.O in
-          let* definition = Build_system.alias_exists alias in
+          let* definition = Load_rules.alias_exists alias in
           match definition with
           | false -> Memo.Build.return (false, Dep.Map.empty)
           | true ->

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -33,53 +33,6 @@ module Context_or_install = Build_config.Context_or_install
 module Error = Build_config.Error
 module Handler = Build_config.Handler
 
-module Loaded = struct
-  type rules_here =
-    { by_file_targets : Rule.t Path.Build.Map.t
-    ; by_directory_targets : Rule.t Path.Build.Map.t
-    }
-
-  let no_rules_here =
-    { by_file_targets = Path.Build.Map.empty
-    ; by_directory_targets = Path.Build.Map.empty
-    }
-
-  type build =
-    { allowed_subdirs : Path.Unspecified.w Dir_set.t
-    ; rules_produced : Rules.t
-    ; rules_here : rules_here
-    ; aliases : (Loc.t * Rules.Dir_rules.Alias_spec.item) list Alias.Name.Map.t
-    }
-
-  type t =
-    | Non_build of Path.Set.t
-    | Build of build
-
-  let no_rules ~allowed_subdirs =
-    Build
-      { allowed_subdirs
-      ; rules_produced = Rules.empty
-      ; rules_here = no_rules_here
-      ; aliases = Alias.Name.Map.empty
-      }
-end
-
-module Rule_fn = struct
-  let loc_decl = Fdecl.create Dyn.opaque
-
-  let loc () = Fdecl.get loc_decl ()
-end
-
-module Dir_triage = struct
-  type t =
-    | Known of Loaded.t
-    | Need_step2 of
-        { dir : Path.Build.t
-        ; context_or_install : Context_or_install.t
-        ; sub_dir : Path.Source.t
-        }
-end
-
 module State = struct
   (* This mutable table is safe: it maps paths to lazily created mutexes. *)
   let locks : (Path.t, Fiber.Mutex.t) Table.t = Table.create (module Path) 32
@@ -93,116 +46,6 @@ module State = struct
 
   let errors = ref ([] : Error.t list)
 end
-
-let get_dir_triage ~dir =
-  match Dpath.analyse_dir dir with
-  | Source dir ->
-    let+ files = Source_tree.files_of dir in
-    Dir_triage.Known (Non_build (Path.set_of_source_paths files))
-  | External _ ->
-    Memo.Build.return
-    @@ Dir_triage.Known
-         (Non_build
-            (match Path.Untracked.readdir_unsorted dir with
-            | Error (Unix.ENOENT, _, _) -> Path.Set.empty
-            | Error (e, _syscall, _arg) ->
-              (* CR-someday amokhov: Print [_syscall] and [_arg] too to help
-                 debugging. *)
-              User_warning.emit
-                [ Pp.textf "Unable to read %s" (Path.to_string_maybe_quoted dir)
-                ; Pp.textf "Reason: %s" (Unix.error_message e)
-                ];
-              Path.Set.empty
-            | Ok filenames -> Path.Set.of_listing ~dir ~filenames))
-  | Build (Regular Root) ->
-    let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
-    let allowed_subdirs =
-      Subdir_set.to_dir_set
-        (Subdir_set.of_list
-           (([ Dpath.Build.anonymous_actions_dir; Dpath.Build.install_dir ]
-            |> List.map ~f:Path.Build.basename)
-           @ (Context_name.Map.keys contexts
-             |> List.map ~f:Context_name.to_string)))
-    in
-    Dir_triage.Known (Loaded.no_rules ~allowed_subdirs)
-  | Build (Install Root) ->
-    let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
-    let allowed_subdirs =
-      Context_name.Map.keys contexts
-      |> List.map ~f:Context_name.to_string
-      |> Subdir_set.of_list |> Subdir_set.to_dir_set
-    in
-    Dir_triage.Known (Loaded.no_rules ~allowed_subdirs)
-  | Build (Anonymous_action p) ->
-    let build_dir = Dpath.Target_dir.build_dir p in
-    Code_error.raise "Called get_dir_triage on an anonymous action directory"
-      [ ("dir", Path.Build.to_dyn build_dir) ]
-  | Build (Invalid _) ->
-    Memo.Build.return
-    @@ Dir_triage.Known (Loaded.no_rules ~allowed_subdirs:Dir_set.empty)
-  | Build (Install (With_context (context_name, sub_dir))) ->
-    (* In this branch, [dir] is in the build directory. *)
-    let dir = Path.as_in_build_dir_exn dir in
-    let context_or_install = Context_or_install.Install context_name in
-    Memo.Build.return
-      (Dir_triage.Need_step2 { dir; context_or_install; sub_dir })
-  | Build (Regular (With_context (context_name, sub_dir))) ->
-    (* In this branch, [dir] is in the build directory. *)
-    let dir = Path.as_in_build_dir_exn dir in
-    let context_or_install = Context_or_install.Context context_name in
-    Memo.Build.return
-      (Dir_triage.Need_step2 { dir; context_or_install; sub_dir })
-
-let describe_rule (rule : Rule.t) =
-  match rule.info with
-  | From_dune_file { start; _ } ->
-    start.pos_fname ^ ":" ^ string_of_int start.pos_lnum
-  | Internal -> "<internal location>"
-  | Source_file_copy _ -> "file present in source tree"
-
-let report_rule_src_dir_conflict dir fn (rule : Rule.t) =
-  let loc =
-    match rule.info with
-    | From_dune_file loc -> loc
-    | Internal
-    | Source_file_copy _ ->
-      let dir =
-        match Path.Build.drop_build_context dir with
-        | None -> Path.build dir
-        | Some s -> Path.source s
-      in
-      Loc.in_dir dir
-  in
-  User_error.raise ~loc
-    [ Pp.textf
-        "This rule defines a target %S whose name conflicts with a source \
-         directory in the same directory."
-        (Path.Build.basename fn)
-    ]
-    ~hints:
-      [ Pp.textf
-          "If you want Dune to generate and replace %S, add (mode promote) to \
-           the rule stanza. Alternatively, you can delete %S from the source \
-           tree or change the rule to generate a different target."
-          (Path.Build.basename fn) (Path.Build.basename fn)
-      ]
-
-let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
-  let fn = Path.build fn in
-  User_error.raise
-    [ Pp.textf "Multiple rules generated for %s:"
-        (Path.to_string_maybe_quoted fn)
-    ; Pp.textf "- %s" (describe_rule rule')
-    ; Pp.textf "- %s" (describe_rule rule)
-    ]
-    ~hints:
-      (match (rule.info, rule'.info) with
-      | Source_file_copy _, _
-      | _, Source_file_copy _ ->
-        [ Pp.textf "rm -f %s"
-            (Path.to_string_maybe_quoted (Path.drop_optional_build_context fn))
-        ]
-      | _ -> [])
 
 (* All file targets of non-sandboxed actions that are currently being executed.
    On exit, we need to delete them as they might contain garbage. There is no
@@ -223,664 +66,6 @@ let rec with_locks ~f = function
     Fiber.Mutex.with_lock
       (Table.find_or_add State.locks m ~f:(fun _ -> Fiber.Mutex.create ()))
       (fun () -> with_locks ~f mutexes)
-
-let remove_old_artifacts ~dir ~rules_here ~(subdirs_to_keep : Subdir_set.t) =
-  match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
-  | exception _ -> ()
-  | Error _ -> ()
-  | Ok files ->
-    List.iter files ~f:(fun (fn, kind) ->
-        let path = Path.Build.relative dir fn in
-        let path_is_a_target =
-          (* CR-someday amokhov: Also check directory targets. *)
-          Path.Build.Map.mem rules_here.Loaded.by_file_targets path
-        in
-        if not path_is_a_target then
-          match kind with
-          | Unix.S_DIR -> (
-            match subdirs_to_keep with
-            | All -> ()
-            | These set ->
-              if not (String.Set.mem set fn) then Path.rm_rf (Path.build path))
-          | _ -> Path.unlink (Path.build path))
-
-(* We don't remove files in there as we don't know upfront if they are stale or
-   not. *)
-let remove_old_sub_dirs_in_anonymous_actions_dir ~dir
-    ~(subdirs_to_keep : Subdir_set.t) =
-  match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
-  | exception _ -> ()
-  | Error _ -> ()
-  | Ok files ->
-    List.iter files ~f:(fun (fn, kind) ->
-        let path = Path.Build.relative dir fn in
-        match kind with
-        | Unix.S_DIR -> (
-          match subdirs_to_keep with
-          | All -> ()
-          | These set ->
-            if not (String.Set.mem set fn) then Path.rm_rf (Path.build path))
-        | _ -> ())
-
-let no_rule_found ~loc fn =
-  let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
-  let fail fn ~loc =
-    User_error.raise ?loc
-      [ Pp.textf "No rule found for %s" (Dpath.describe_target fn) ]
-  in
-  let hints ctx =
-    let candidates =
-      Context_name.Map.keys contexts |> List.map ~f:Context_name.to_string
-    in
-    User_message.did_you_mean (Context_name.to_string ctx) ~candidates
-  in
-  match Dpath.analyse_target fn with
-  | Other _ -> fail fn ~loc
-  | Regular (ctx, _) ->
-    if Context_name.Map.mem contexts ctx then
-      fail fn ~loc
-    else
-      User_error.raise
-        [ Pp.textf "Trying to build %s but build context %s doesn't exist."
-            (Path.Build.to_string_maybe_quoted fn)
-            (Context_name.to_string ctx)
-        ]
-        ~hints:(hints ctx)
-  | Install (ctx, _) ->
-    if Context_name.Map.mem contexts ctx then
-      fail fn ~loc
-    else
-      User_error.raise
-        [ Pp.textf
-            "Trying to build %s for install but build context %s doesn't exist."
-            (Path.Build.to_string_maybe_quoted fn)
-            (Context_name.to_string ctx)
-        ]
-        ~hints:(hints ctx)
-  | Alias (ctx, fn') ->
-    if Context_name.Map.mem contexts ctx then
-      fail fn ~loc
-    else
-      let fn =
-        Path.append_source (Path.build (Context_name.build_dir ctx)) fn'
-      in
-      User_error.raise
-        [ Pp.textf
-            "Trying to build alias %s but build context %s doesn't exist."
-            (Path.to_string_maybe_quoted fn)
-            (Context_name.to_string ctx)
-        ]
-        ~hints:(hints ctx)
-  | Anonymous_action _ ->
-    (* We never lookup such actions by target name, so this should be
-       unreachable *)
-    Code_error.raise ?loc "Build_system.no_rule_found got anonymous action path"
-      [ ("fn", Path.Build.to_dyn fn) ]
-
-(* +-------------------- Adding rules to the system --------------------+ *)
-
-let source_file_digest path =
-  let report_user_error details =
-    let+ loc = Rule_fn.loc () in
-    User_error.raise ?loc
-      ([ Pp.textf "File unavailable: %s" (Path.to_string_maybe_quoted path) ]
-      @ details)
-  in
-  Fs_memo.path_digest path >>= function
-  | Ok digest -> Memo.Build.return digest
-  | No_such_file -> report_user_error []
-  | Broken_symlink -> report_user_error [ Pp.text "Broken symlink" ]
-  | Unexpected_kind st_kind ->
-    report_user_error
-      [ Pp.textf "This is neither a regular file nor a directory (%s)"
-          (File_kind.to_string st_kind)
-      ]
-  | Unix_error (error, _, _) ->
-    report_user_error [ Pp.textf "%s" (Unix.error_message error) ]
-  | Error exn -> report_user_error [ Pp.textf "%s" (Printexc.to_string exn) ]
-
-let eval_source_file :
-    type a. a Action_builder.eval_mode -> Path.t -> a Memo.Build.t =
- fun mode path ->
-  match mode with
-  | Lazy -> Memo.Build.return ()
-  | Eager ->
-    let+ d = source_file_digest path in
-    Dep.Fact.file path d
-
-module rec Load_rules : sig
-  val load_dir : dir:Path.t -> Loaded.t Memo.Build.t
-
-  val file_exists : Path.t -> bool Memo.Build.t
-
-  val file_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
-
-  val directory_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
-
-  val lookup_alias :
-       Alias.t
-    -> (Loc.t * Rules.Dir_rules.Alias_spec.item) list option Memo.Build.t
-
-  val alias_exists : Alias.t -> bool Memo.Build.t
-end = struct
-  open Load_rules
-
-  let create_copy_rules ~ctx_dir ~non_target_source_files =
-    Path.Source.Set.to_list_map non_target_source_files ~f:(fun path ->
-        let ctx_path = Path.Build.append_source ctx_dir path in
-        let build =
-          Action_builder.of_thunk
-            { f =
-                (fun mode ->
-                  let path = Path.source path in
-                  let+ fact = eval_source_file mode path in
-                  ( Action.Full.make
-                      (Action.copy path ctx_path)
-                      (* There's an [assert false] in [prepare_managed_paths]
-                         that blows up if we try to sandbox this. *)
-                      ~sandbox:Sandbox_config.no_sandboxing
-                  , Dep.Map.singleton (Dep.file path) fact ))
-            }
-        in
-        Rule.make ~context:None ~info:(Source_file_copy path)
-          ~targets:(Targets.File.create ctx_path)
-          build)
-
-  let compile_rules ~dir ~source_dirs rules =
-    let file_targets, directory_targets =
-      let check_for_source_dir_conflict rule target =
-        if String.Set.mem source_dirs (Path.Build.basename target) then
-          report_rule_src_dir_conflict dir target rule
-      in
-      List.map rules ~f:(fun rule ->
-          assert (Path.Build.( = ) dir rule.Rule.dir);
-          ( Path.Build.Set.to_list_map rule.targets.files ~f:(fun target ->
-                check_for_source_dir_conflict rule target;
-                (target, rule))
-          , Path.Build.Set.to_list_map rule.targets.dirs ~f:(fun target ->
-                check_for_source_dir_conflict rule target;
-                (target, rule)) ))
-      |> List.unzip
-    in
-    let by_file_targets =
-      List.concat file_targets
-      |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
-    in
-    let by_directory_targets =
-      List.concat directory_targets
-      |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
-    in
-    Path.Build.Map.iter2 by_file_targets by_directory_targets
-      ~f:(fun target rule1 rule2 ->
-        match (rule1, rule2) with
-        | None, _
-        | _, None ->
-          ()
-        | Some rule1, Some rule2 -> report_rule_conflict target rule1 rule2);
-    { Loaded.by_file_targets; by_directory_targets }
-
-  (* Here we are doing a O(log |S|) lookup in a set S of files in the build
-     directory [dir]. We could memoize these lookups, but it doesn't seem to be
-     worth it, since we're unlikely to perform exactly the same lookup many
-     times. As far as I can tell, each lookup will be done twice: when computing
-     static dependencies of a [Action_builder.t] with
-     [Action_builder.static_deps] and when executing the very same
-     [Action_builder.t] with [Action_builder.exec] -- the results of both
-     [Action_builder.static_deps] and [Action_builder.exec] are cached. *)
-  let file_exists fn =
-    load_dir ~dir:(Path.parent_exn fn) >>| function
-    | Non_build targets -> Path.Set.mem targets fn
-    | Build { rules_here; _ } -> (
-      match Path.as_in_build_dir fn with
-      | None -> false
-      | Some fn -> (
-        match Path.Build.Map.mem rules_here.by_file_targets fn with
-        | true -> true
-        | false -> (
-          match Path.Build.parent fn with
-          | None -> false
-          | Some dir -> Path.Build.Map.mem rules_here.by_directory_targets dir))
-      )
-
-  let file_targets_of ~dir =
-    load_dir ~dir >>| function
-    | Non_build file_targets -> file_targets
-    | Build { rules_here; _ } ->
-      Path.Build.Map.keys rules_here.by_file_targets
-      |> Path.Set.of_list_map ~f:Path.build
-
-  let directory_targets_of ~dir =
-    load_dir ~dir >>| function
-    | Non_build _file_targets -> Path.Set.empty
-    | Build { rules_here; _ } ->
-      Path.Build.Map.keys rules_here.by_directory_targets
-      |> Path.Set.of_list_map ~f:Path.build
-
-  let lookup_alias alias =
-    load_dir ~dir:(Path.build (Alias.dir alias)) >>| function
-    | Non_build _ ->
-      Code_error.raise "Alias in a non-build dir"
-        [ ("alias", Alias.to_dyn alias) ]
-    | Build { aliases; _ } -> Alias.Name.Map.find aliases (Alias.name alias)
-
-  let alias_exists alias =
-    lookup_alias alias >>| function
-    | None -> false
-    | Some _ -> true
-
-  let compute_alias_expansions ~(collected : Rules.Dir_rules.ready) ~dir =
-    let aliases = collected.aliases in
-    let+ aliases =
-      if Alias.Name.Map.mem aliases Alias.Name.default then
-        Memo.Build.return aliases
-      else
-        (Build_config.get ()).implicit_default_alias dir >>| function
-        | None -> aliases
-        | Some expansion ->
-          Alias.Name.Map.set aliases Alias.Name.default
-            { expansions =
-                Appendable_list.singleton
-                  (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion)
-            }
-    in
-    Alias.Name.Map.map aliases
-      ~f:(fun { Rules.Dir_rules.Alias_spec.expansions } ->
-        Appendable_list.to_list expansions)
-
-  let filter_out_fallback_rules ~to_copy rules =
-    List.filter rules ~f:(fun (rule : Rule.t) ->
-        match rule.mode with
-        | Standard
-        | Promote _
-        | Ignore_source_files ->
-          true
-        | Fallback ->
-          let source_files_for_targets =
-            if not (Path.Build.Set.is_empty rule.targets.dirs) then
-              Code_error.raise "Unexpected directory target in a Fallback rule"
-                [ ("targets", Targets.Validated.to_dyn rule.targets) ];
-            Path.Build.Set.to_list_map
-              rule.targets.files
-              (* All targets are in a directory of a build context since there
-                 are source files to copy, so this call can't fail. *)
-              ~f:Path.Build.drop_build_context_exn
-            |> Path.Source.Set.of_list
-          in
-          if Path.Source.Set.is_subset source_files_for_targets ~of_:to_copy
-          then
-            (* All targets are present *)
-            false
-          else if
-            Path.Source.Set.is_empty
-              (Path.Source.Set.inter source_files_for_targets to_copy)
-          then
-            (* No target is present *)
-            true
-          else
-            let absent_targets =
-              Path.Source.Set.diff source_files_for_targets to_copy
-            in
-            let present_targets =
-              Path.Source.Set.diff source_files_for_targets absent_targets
-            in
-            User_error.raise ~loc:(Rule.loc rule)
-              [ Pp.text
-                  "Some of the targets of this fallback rule are present in \
-                   the source tree, and some are not. This is not allowed. \
-                   Either none of the targets must be present in the source \
-                   tree, either they must all be."
-              ; Pp.nop
-              ; Pp.text "The following targets are present:"
-              ; Pp.enumerate ~f:Path.pp
-                  (Path.set_of_source_paths present_targets |> Path.Set.to_list)
-              ; Pp.nop
-              ; Pp.text "The following targets are not:"
-              ; Pp.enumerate ~f:Path.pp
-                  (Path.set_of_source_paths absent_targets |> Path.Set.to_list)
-              ])
-
-  (** A directory is only allowed to be generated if its parent knows about it.
-      This restriction is necessary to prevent stale artifact deletion from
-      removing that directory.
-
-      This module encodes that restriction. *)
-  module Generated_directory_restrictions : sig
-    type restriction =
-      | Unrestricted
-      | Restricted of Path.Unspecified.w Dir_set.t Memo.Lazy.t
-
-    (** Used by the child to ask about the restrictions placed by the parent. *)
-    val allowed_by_parent : dir:Path.Build.t -> restriction Memo.Build.t
-  end = struct
-    type restriction =
-      | Unrestricted
-      | Restricted of Path.Unspecified.w Dir_set.t Memo.Lazy.t
-
-    let corresponding_source_dir ~dir =
-      match Dpath.analyse_target dir with
-      | Install _
-      | Alias _
-      | Anonymous_action _
-      | Other _ ->
-        Memo.Build.return None
-      | Regular (_ctx, sub_dir) -> Source_tree.find_dir sub_dir
-
-    let source_subdirs_of_build_dir ~dir =
-      corresponding_source_dir ~dir >>| function
-      | None -> String.Set.empty
-      | Some dir -> Source_tree.Dir.sub_dir_names dir
-
-    let allowed_dirs ~dir ~subdir : restriction Memo.Build.t =
-      let+ subdirs = source_subdirs_of_build_dir ~dir in
-      if String.Set.mem subdirs subdir then
-        Unrestricted
-      else
-        Restricted
-          (Memo.Lazy.create ~name:"allowed_dirs" (fun () ->
-               load_dir ~dir:(Path.build dir) >>| function
-               | Non_build _ -> Dir_set.just_the_root
-               | Build { allowed_subdirs; _ } ->
-                 Dir_set.descend allowed_subdirs subdir))
-
-    let allowed_by_parent ~dir =
-      allowed_dirs
-        ~dir:(Path.Build.parent_exn dir)
-        ~subdir:(Path.Build.basename dir)
-  end
-
-  let load_dir_step2_exn ~dir ~context_or_install ~sub_dir =
-    let sub_dir_components = Path.Source.explode sub_dir in
-    (* Load all the rules *)
-    let (module RG : Build_config.Rule_generator) =
-      (Build_config.get ()).rule_generator
-    in
-    let* extra_subdirs_to_keep, rules_produced =
-      RG.gen_rules context_or_install ~dir sub_dir_components >>| function
-      | None ->
-        Code_error.raise "[gen_rules] did not specify rules for the context"
-          [ ("context_or_install", Context_or_install.to_dyn context_or_install)
-          ]
-      | Some x -> x
-    and* global_rules = Memo.Lazy.force RG.global_rules in
-    let rules =
-      let dir = Path.build dir in
-      Rules.Dir_rules.union
-        (Rules.find rules_produced dir)
-        (Rules.find global_rules dir)
-    in
-    let collected = Rules.Dir_rules.consume rules in
-    let rules = collected.rules in
-    (* Compute the set of sources and targets promoted to the source tree that
-       must not be copied to the build directory. *)
-    let source_files_to_ignore, source_dirnames_to_ignore =
-      List.fold_left rules ~init:(Path.Build.Set.empty, String.Set.empty)
-        ~f:(fun (acc_files, acc_dirnames) { Rule.targets; mode; loc; _ } ->
-          let target_filenames =
-            Path.Build.Set.to_list_map ~f:Path.Build.basename targets.files
-            |> String.Set.of_list
-          in
-          let target_dirnames =
-            Path.Build.Set.to_list_map ~f:Path.Build.basename targets.dirs
-            |> String.Set.of_list
-          in
-          (* Check if this rule defines any directory targets that conflict with
-             internal Dune directories listed in [extra_subdirs_to_keep]. *)
-          (match
-             String.Set.choose
-               (Subdir_set.inter_set extra_subdirs_to_keep
-                  (String.Set.union target_filenames target_dirnames))
-           with
-          | None -> ()
-          | Some target_name ->
-            User_error.raise ~loc
-              [ Pp.textf
-                  "This rule defines a target %S whose name conflicts with an \
-                   internal directory used by Dune. Please use a different \
-                   name."
-                  target_name
-              ]);
-          match mode with
-          | Ignore_source_files ->
-            ( Path.Build.Set.union acc_files targets.files
-            , String.Set.union acc_dirnames target_dirnames )
-          | Promote { only; _ } ->
-            (* Note that the [only] predicate applies to the files inside the
-               directory targets rather than to directory names themselves. *)
-            let target_files =
-              match only with
-              | None -> targets.files
-              | Some pred ->
-                let is_promoted file =
-                  Predicate_lang.Glob.exec pred
-                    (Path.reach (Path.build file) ~from:(Path.build dir))
-                    ~standard:Predicate_lang.any
-                in
-                Path.Build.Set.filter targets.files ~f:is_promoted
-            in
-            ( Path.Build.Set.union acc_files target_files
-            , String.Set.union acc_dirnames target_dirnames )
-          | Standard
-          | Fallback ->
-            (acc_files, acc_dirnames))
-    in
-    (* Take into account the source files *)
-    let* to_copy, source_dirs =
-      match context_or_install with
-      | Install _ -> Memo.Build.return (None, String.Set.empty)
-      | Context context_name ->
-        let+ files, subdirs =
-          Source_tree.find_dir sub_dir >>| function
-          | None -> (Path.Source.Set.empty, String.Set.empty)
-          | Some dir ->
-            (Source_tree.Dir.file_paths dir, Source_tree.Dir.sub_dir_names dir)
-        in
-        let files =
-          let source_files_to_ignore =
-            Path.Build.Set.to_list_map ~f:Path.Build.drop_build_context_exn
-              source_files_to_ignore
-            |> Path.Source.Set.of_list
-          in
-          let source_files_to_ignore =
-            Target_promotion.delete_stale_dot_merlin_file ~dir
-              ~source_files_to_ignore
-          in
-          Path.Source.Set.diff files source_files_to_ignore
-        in
-        let subdirs = String.Set.diff subdirs source_dirnames_to_ignore in
-        if Path.Source.Set.is_empty files then
-          (None, subdirs)
-        else
-          let ctx_path = Context_name.build_dir context_name in
-          (Some (ctx_path, files), subdirs)
-    in
-    (* Filter out fallback rules *)
-    let rules =
-      match to_copy with
-      | None ->
-        (* If there are no source files to copy, fallback rules are
-           automatically kept *)
-        rules
-      | Some (_, to_copy) -> filter_out_fallback_rules ~to_copy rules
-    in
-    (* Compile the rules and cleanup stale artifacts *)
-    let rules =
-      (match to_copy with
-      | None -> []
-      | Some (ctx_dir, source_files) ->
-        create_copy_rules ~ctx_dir ~non_target_source_files:source_files)
-      @ rules
-    in
-    let* allowed_by_parent =
-      match (context_or_install, sub_dir_components) with
-      | Context _, [ ".dune" ] ->
-        (* GROSS HACK: this is to avoid a cycle as the rules for all directories
-           force the generation of ".dune/configurator". We need a better way to
-           deal with such cases. *)
-        Memo.Build.return Generated_directory_restrictions.Unrestricted
-      | _ -> Generated_directory_restrictions.allowed_by_parent ~dir
-    in
-    let* () =
-      match allowed_by_parent with
-      | Unrestricted -> Memo.Build.return ()
-      | Restricted restriction -> (
-        match Path.Build.Map.find (Rules.to_map rules_produced) dir with
-        | None -> Memo.Build.return ()
-        | Some rules ->
-          let+ restriction = Memo.Lazy.force restriction in
-          if not (Dir_set.here restriction) then
-            Code_error.raise
-              "Generated rules in a directory not allowed by the parent"
-              [ ("dir", Path.Build.to_dyn dir)
-              ; ("rules", Rules.Dir_rules.to_dyn rules)
-              ])
-    in
-    let* descendants_to_keep =
-      let rules_generated_in =
-        Rules.to_map rules_produced
-        |> Path.Build.Map.foldi ~init:Dir_set.empty ~f:(fun p _ acc ->
-               match Path.Local_gen.descendant ~of_:dir p with
-               | None -> acc
-               | Some p -> Dir_set.union acc (Dir_set.singleton p))
-      in
-      let subdirs_to_keep =
-        match extra_subdirs_to_keep with
-        | All -> Subdir_set.All
-        | These set -> These (String.Set.union source_dirs set)
-      in
-      let+ allowed_grand_descendants_of_parent =
-        match allowed_by_parent with
-        | Unrestricted ->
-          (* In this case the parent isn't going to be able to create any
-             generated grand descendant directories. Rules that attempt to do so
-             may run into the [allowed_by_parent] check or will be simply
-             ignored. *)
-          Memo.Build.return Dir_set.empty
-        | Restricted restriction -> Memo.Lazy.force restriction
-      in
-      Dir_set.union_all
-        [ rules_generated_in
-        ; Subdir_set.to_dir_set subdirs_to_keep
-        ; allowed_grand_descendants_of_parent
-        ]
-    in
-    let subdirs_to_keep = Subdir_set.of_dir_set descendants_to_keep in
-    let rules_here = compile_rules ~dir ~source_dirs rules in
-    remove_old_artifacts ~dir ~rules_here ~subdirs_to_keep;
-    remove_old_sub_dirs_in_anonymous_actions_dir
-      ~dir:
-        (Path.Build.append_local Dpath.Build.anonymous_actions_dir
-           (Path.Build.local dir))
-      ~subdirs_to_keep;
-    let+ aliases =
-      match context_or_install with
-      | Context _ -> compute_alias_expansions ~collected ~dir
-      | Install _ ->
-        (* There are no aliases in the [_build/install] directory *)
-        Memo.Build.return Alias.Name.Map.empty
-    in
-    { Loaded.allowed_subdirs = descendants_to_keep
-    ; rules_produced
-    ; rules_here
-    ; aliases
-    }
-
-  let load_dir_impl ~dir : Loaded.t Memo.Build.t =
-    get_dir_triage ~dir >>= function
-    | Known l -> Memo.Build.return l
-    | Need_step2 { dir; context_or_install; sub_dir } ->
-      let+ build = load_dir_step2_exn ~dir ~context_or_install ~sub_dir in
-      Loaded.Build build
-
-  let load_dir =
-    let load_dir_impl dir = load_dir_impl ~dir in
-    let memo = Memo.create "load-dir" ~input:(module Path) load_dir_impl in
-    fun ~dir -> Memo.exec memo dir
-end
-
-open Load_rules
-
-let load_dir_and_get_buildable_targets ~dir =
-  load_dir ~dir >>| function
-  | Non_build _ -> Loaded.no_rules_here
-  | Build { rules_here; _ } -> rules_here
-
-type rule_or_source =
-  | Source of Digest.t
-  | Rule of Path.Build.t * Rule.t
-
-let get_rule_for_directory_target path =
-  let rec loop dir =
-    match Path.Build.parent dir with
-    | None -> Memo.Build.return None
-    | Some parent_dir -> (
-      let* rules =
-        load_dir_and_get_buildable_targets ~dir:(Path.build parent_dir)
-      in
-      match Path.Build.Map.find rules.by_directory_targets dir with
-      | None -> loop parent_dir
-      | Some _ as rule -> Memo.Build.return rule)
-  in
-  loop path
-
-let get_rule path =
-  match Path.as_in_build_dir path with
-  | None -> Memo.Build.return None
-  | Some path -> (
-    let dir = Path.Build.parent_exn path in
-    load_dir ~dir:(Path.build dir) >>= function
-    | Non_build _ -> assert false
-    | Build { rules_here; _ } -> (
-      match Path.Build.Map.find rules_here.by_file_targets path with
-      | Some _ as rule -> Memo.Build.return rule
-      | None -> get_rule_for_directory_target path))
-
-let get_rule_or_source path =
-  let dir = Path.parent_exn path in
-  if Path.is_strict_descendant_of_build_dir dir then
-    let* rules = load_dir_and_get_buildable_targets ~dir in
-    let path = Path.as_in_build_dir_exn path in
-    match Path.Build.Map.find rules.by_file_targets path with
-    | Some rule -> Memo.Build.return (Rule (path, rule))
-    | None -> (
-      get_rule_for_directory_target path >>= function
-      | Some rule -> Memo.Build.return (Rule (path, rule))
-      | None ->
-        let* loc = Rule_fn.loc () in
-        no_rule_found ~loc path)
-  else
-    let+ d = source_file_digest path in
-    Source d
-
-module Source_tree_map_reduce =
-  Source_tree.Dir.Make_map_reduce (Memo.Build) (Monoid.Union (Path.Build.Set))
-
-let all_targets () =
-  let* root = Source_tree.root ()
-  and* contexts = Memo.Lazy.force (Build_config.get ()).contexts in
-  Memo.Build.parallel_map (Context_name.Map.values contexts) ~f:(fun ctx ->
-      Source_tree_map_reduce.map_reduce root ~traverse:Sub_dirs.Status.Set.all
-        ~f:(fun dir ->
-          load_dir
-            ~dir:
-              (Path.build
-                 (Path.Build.append_source ctx.Build_context.build_dir
-                    (Source_tree.Dir.path dir)))
-          >>| function
-          | Non_build _ -> Path.Build.Set.empty
-          | Build { rules_here; _ } ->
-            Path.Build.Set.of_list
-              (Path.Build.Map.keys rules_here.by_file_targets
-              @ Path.Build.Map.keys rules_here.by_directory_targets)))
-  >>| Path.Build.Set.union_all
-
-let get_alias_definition alias =
-  lookup_alias alias >>= function
-  | None ->
-    let open Pp.O in
-    let+ loc = Rule_fn.loc () in
-    User_error.raise ?loc
-      [ Pp.text "No rule found for " ++ Alias.describe alias ]
-  | Some x -> Memo.Build.return x
 
 type rule_execution_result =
   { deps : Dep.Fact.t Dep.Map.t
@@ -918,26 +103,6 @@ module type Rec = sig
     val build : File_selector.t -> Dep.Fact.Files.t Memo.Build.t
   end
 end
-
-let is_target file =
-  match Path.is_in_build_dir file with
-  | false -> Memo.Build.return false
-  | true -> (
-    let parent_dir = Path.parent_exn file in
-    let* file_targets = file_targets_of ~dir:parent_dir in
-    match Path.Set.mem file_targets file with
-    | true -> Memo.Build.return true
-    | false ->
-      let rec loop dir =
-        match Path.parent dir with
-        | None -> Memo.Build.return false
-        | Some parent_dir -> (
-          let* directory_targets = directory_targets_of ~dir:parent_dir in
-          match Path.Set.mem directory_targets dir with
-          | true -> Memo.Build.return true
-          | false -> loop parent_dir)
-      in
-      loop file)
 
 (* Separation between [Used_recursively] and [Exported] is necessary because at
    least one module in the recursive module group must be pure (i.e. only expose
@@ -1555,7 +720,7 @@ end = struct
      [build_file_impl] returns both the set of dependencies of the file as well
      as its digest. *)
   let build_file_impl path =
-    get_rule_or_source path >>= function
+    Load_rules.get_rule_or_source path >>= function
     | Source digest -> Memo.Build.return (digest, None)
     | Rule (path, rule) -> (
       let+ { deps = _; targets } =
@@ -1628,7 +793,7 @@ end = struct
 
   let build_alias_impl alias =
     let+ l =
-      get_alias_definition alias
+      Load_rules.get_alias_definition alias
       >>= Memo.Build.parallel_map ~f:(fun (loc, definition) ->
               Memo.push_stack_frame
                 (fun () ->
@@ -1643,7 +808,7 @@ end = struct
     let build_impl g =
       let dir = File_selector.dir g in
       let* build_dir =
-        is_target dir >>= function
+        Load_rules.is_target dir >>= function
         | false -> Memo.Build.return None
         | true -> build_dir dir
       in
@@ -1679,7 +844,7 @@ end = struct
        course, we'd like to eventually fix this. *)
     let eval_impl g =
       let dir = File_selector.dir g in
-      load_dir ~dir >>| function
+      Load_rules.load_dir ~dir >>| function
       | Non_build targets -> Path.Set.filter targets ~f:(File_selector.test g)
       | Build { rules_here; _ } ->
         let only_generated_files = File_selector.only_generated_files g in
@@ -1746,7 +911,7 @@ end = struct
   let execute_rule = Memo.exec execute_rule_memo
 
   let () =
-    Fdecl.set Rule_fn.loc_decl (fun () ->
+    Load_rules.set_current_rule_loc (fun () ->
         let+ stack = Memo.get_call_stack () in
         List.find_map stack ~f:(fun frame ->
             match
@@ -1762,8 +927,6 @@ end
 
 open Exported
 
-type alias_definition = Rules.Dir_rules.Alias_spec.item
-
 let dep_on_alias_definition = dep_on_alias_definition
 
 let eval_pred = Pred.eval
@@ -1771,6 +934,7 @@ let eval_pred = Pred.eval
 let build_pred = Pred.build
 
 let package_deps ~packages_of (pkg : Package.t) files =
+  (* CR-someday amokhov: We should get rid of this mutable state. *)
   let rules_seen = ref Rule.Set.empty in
   let rec loop fn =
     match Path.as_in_build_dir fn with
@@ -1785,7 +949,7 @@ let package_deps ~packages_of (pkg : Package.t) files =
       else
         Memo.Build.return pkgs
   and loop_deps fn =
-    get_rule (Path.build fn) >>= function
+    Load_rules.get_rule (Path.build fn) >>= function
     | None -> Memo.Build.return Package.Id.Set.empty
     | Some rule ->
       if Rule.Set.mem !rules_seen rule then
@@ -1886,20 +1050,9 @@ let read_file p ~f =
 
 let build_deps = build_deps
 
-let file_exists = file_exists
-
-let alias_exists = Load_rules.alias_exists
-
 let execute_action = execute_action
 
 let execute_action_stdout = execute_action_stdout
-
-let load_dir_and_produce_its_rules ~dir =
-  load_dir ~dir >>= function
-  | Non_build _ -> Memo.Build.return ()
-  | Build loaded -> Rules.produce loaded.rules_produced
-
-let load_dir ~dir = load_dir_and_produce_its_rules ~dir
 
 module Progress = struct
   type t =
@@ -1921,7 +1074,5 @@ let get_current_progress () =
   { Progress.number_of_rules_executed = !State.rule_done
   ; number_of_rules_discovered = !State.rule_total
   }
-
-let file_targets_of = file_targets_of
 
 let last_event () = !Handler.last_event

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -16,12 +16,6 @@ val eval_pred : File_selector.t -> Path.Set.t Memo.Build.t
 (** Same as [eval_pred] but also build the resulting set of files. *)
 val build_pred : File_selector.t -> Dep.Fact.Files.t Memo.Build.t
 
-(** Returns the set of file targets in the given directory. *)
-val file_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
-
-(** Load the rules for this directory. *)
-val load_dir : dir:Path.t -> unit Memo.Build.t
-
 (** Assuming [files] is the list of files in [_build/install] that belong to
     package [pkg], [package_deps t pkg files] is the set of direct package
     dependencies of [package]. *)
@@ -39,13 +33,6 @@ val build_file : Path.t -> Digest.t Memo.Build.t
 (** Build a file and return its contents with [f] *)
 val read_file : Path.t -> f:(Path.t -> 'a) -> 'a Memo.Build.t
 
-(** Return [true] if a file exists or is buildable *)
-val file_exists : Path.t -> bool Memo.Build.t
-
-val alias_exists : Alias.t -> bool Memo.Build.t
-
-val is_target : Path.t -> bool Memo.Build.t
-
 val build_deps : Dep.Set.t -> Dep.Facts.t Memo.Build.t
 
 (** Execute a action. The execution is cached. *)
@@ -56,19 +43,8 @@ val execute_action :
 val execute_action_stdout :
   observing_facts:Dep.Facts.t -> Rule.Anonymous_action.t -> string Memo.Build.t
 
-(** Return the rule that has the given file has target, if any *)
-val get_rule : Path.t -> Rule.t option Memo.Build.t
-
-type alias_definition
-
-val dep_on_alias_definition : alias_definition -> unit Action_builder.t
-
-(** Return the definition of an alias *)
-val get_alias_definition :
-  Alias.t -> (Loc.t * alias_definition) list Memo.Build.t
-
-(** List of all buildable targets. *)
-val all_targets : unit -> Path.Build.Set.t Memo.Build.t
+val dep_on_alias_definition :
+  Rules.Dir_rules.Alias_spec.item -> unit Action_builder.t
 
 (** {2 Running a build} *)
 

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -1,52 +1,52 @@
-(** Build rules *)
+(** The core of the build system *)
 
 open! Stdune
 open! Import
 module Action_builder := Action_builder0
 
-(** {1 Setup} *)
+(** {1 Requests} *)
 
-(** {2 Primitive for rule generations} *)
+(** Build a file and return the digest of its contents. *)
+val build_file : Path.t -> Digest.t Memo.Build.t
+
+(** Build a file and access its contents with [f]. *)
+val read_file : Path.t -> f:(Path.t -> 'a) -> 'a Memo.Build.t
+
+(** Build a set of dependencies and return learned facts about them. *)
+val build_deps : Dep.Set.t -> Dep.Facts.t Memo.Build.t
 
 (** [eval_pred glob] returns the list of files in [File_selector.dir glob] that
     matches [File_selector.predicate glob]. The list of files includes the list
-    of targets. *)
+    of file targets. Currently, this function ignores directory targets, which
+    is a limitation we'd like to remove in future. *)
 val eval_pred : File_selector.t -> Path.Set.t Memo.Build.t
 
-(** Same as [eval_pred] but also build the resulting set of files. *)
+(** Like [eval_pred] but also builds the resulting set of files. This function
+    doesn't have [eval_pred]'s limitation about directory targets and takes them
+    into account. *)
 val build_pred : File_selector.t -> Dep.Fact.Files.t Memo.Build.t
 
-(** Assuming [files] is the list of files in [_build/install] that belong to
-    package [pkg], [package_deps t pkg files] is the set of direct package
-    dependencies of [package]. *)
+(** Assuming [files] is a set of files in [_build/install] that belong to a
+    package [pkg], [package_deps packages_of pkg files] is the set of direct
+    package dependencies of [package]. *)
 val package_deps :
      packages_of:(Path.Build.t -> Package.Id.Set.t Memo.Build.t)
   -> Package.t
   -> Path.Set.t
   -> Package.Id.Set.t Memo.Build.t
 
-(** {1 Requests} *)
-
-(** Build a file and return the digest of its contents *)
-val build_file : Path.t -> Digest.t Memo.Build.t
-
-(** Build a file and return its contents with [f] *)
-val read_file : Path.t -> f:(Path.t -> 'a) -> 'a Memo.Build.t
-
-val build_deps : Dep.Set.t -> Dep.Facts.t Memo.Build.t
-
-(** Execute a action. The execution is cached. *)
+(** Execute an action. The execution is cached. *)
 val execute_action :
   observing_facts:Dep.Facts.t -> Rule.Anonymous_action.t -> unit Memo.Build.t
 
-(** Execute a action and capture its output. The execution is cached. *)
+(** Execute an action and capture its stdout. The execution is cached. *)
 val execute_action_stdout :
   observing_facts:Dep.Facts.t -> Rule.Anonymous_action.t -> string Memo.Build.t
 
 val dep_on_alias_definition :
   Rules.Dir_rules.Alias_spec.item -> unit Action_builder.t
 
-(** {2 Running a build} *)
+(** {2 Running the build system} *)
 
 val run :
   (unit -> 'a Memo.Build.t) -> ('a, [ `Already_reported ]) Result.t Fiber.t
@@ -69,10 +69,10 @@ module Progress : sig
   val is_determined : t -> bool
 end
 
-(** The current set of active errors *)
-val errors : unit -> Build_config.Error.t list
-
 val get_current_progress : unit -> Progress.t
 
-(** Returns the last event reported to the handler *)
+(** The current set of active errors. *)
+val errors : unit -> Build_config.Error.t list
+
+(** Returns the last event reported to the handler. *)
 val last_event : unit -> Build_config.Handler.event option

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -41,6 +41,7 @@ module Target_promotion = Target_promotion
 module Build_context = Build_context
 module Build_config = Build_config
 module Build_system = Build_system
+module Load_rules = Load_rules
 module Cram_test = Cram_test
 module Clflags = Clflags
 module Include_stanza = Include_stanza

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -736,7 +736,7 @@ end = struct
     fun ~dir -> Memo.exec memo dir
 end
 
-open Load_rules
+include Load_rules
 
 let load_dir_and_get_buildable_targets ~dir =
   load_dir ~dir >>| function
@@ -821,18 +821,10 @@ let get_alias_definition alias =
       [ Pp.text "No rule found for " ++ Alias.describe alias ]
   | Some x -> Memo.Build.return x
 
-let load_dir = load_dir
-
 let load_dir_and_produce_its_rules ~dir =
   load_dir ~dir >>= function
   | Non_build _ -> Memo.Build.return ()
   | Build loaded -> Rules.produce loaded.rules_produced
-
-let file_exists = file_exists
-
-let alias_exists = alias_exists
-
-let file_targets_of = file_targets_of
 
 let is_target file =
   match Path.is_in_build_dir file with

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -1,0 +1,855 @@
+open! Stdune
+open Import
+open Memo.Build.O
+module Action_builder = Action_builder0
+module Context_or_install = Build_config.Context_or_install
+
+module Current_rule_loc = struct
+  let t = ref (fun () -> Memo.Build.return None)
+
+  let set f = t := f
+
+  let get () = !t ()
+end
+
+let set_current_rule_loc = Current_rule_loc.set
+
+module Loaded = struct
+  type rules_here =
+    { by_file_targets : Rule.t Path.Build.Map.t
+    ; by_directory_targets : Rule.t Path.Build.Map.t
+    }
+
+  let no_rules_here =
+    { by_file_targets = Path.Build.Map.empty
+    ; by_directory_targets = Path.Build.Map.empty
+    }
+
+  type build =
+    { allowed_subdirs : Path.Unspecified.w Dir_set.t
+    ; rules_produced : Rules.t
+    ; rules_here : rules_here
+    ; aliases : (Loc.t * Rules.Dir_rules.Alias_spec.item) list Alias.Name.Map.t
+    }
+
+  type t =
+    | Non_build of Path.Set.t
+    | Build of build
+
+  let no_rules ~allowed_subdirs =
+    Build
+      { allowed_subdirs
+      ; rules_produced = Rules.empty
+      ; rules_here = no_rules_here
+      ; aliases = Alias.Name.Map.empty
+      }
+end
+
+module Dir_triage = struct
+  type t =
+    | Known of Loaded.t
+    | Need_step2 of
+        { dir : Path.Build.t
+        ; context_or_install : Context_or_install.t
+        ; sub_dir : Path.Source.t
+        }
+end
+
+let get_dir_triage ~dir =
+  match Dpath.analyse_dir dir with
+  | Source dir ->
+    let+ files = Source_tree.files_of dir in
+    Dir_triage.Known (Non_build (Path.set_of_source_paths files))
+  | External _ ->
+    Memo.Build.return
+    @@ Dir_triage.Known
+         (Non_build
+            (match Path.Untracked.readdir_unsorted dir with
+            | Error (Unix.ENOENT, _, _) -> Path.Set.empty
+            | Error (e, _syscall, _arg) ->
+              (* CR-someday amokhov: Print [_syscall] and [_arg] too to help
+                 debugging. *)
+              User_warning.emit
+                [ Pp.textf "Unable to read %s" (Path.to_string_maybe_quoted dir)
+                ; Pp.textf "Reason: %s" (Unix.error_message e)
+                ];
+              Path.Set.empty
+            | Ok filenames -> Path.Set.of_listing ~dir ~filenames))
+  | Build (Regular Root) ->
+    let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
+    let allowed_subdirs =
+      Subdir_set.to_dir_set
+        (Subdir_set.of_list
+           (([ Dpath.Build.anonymous_actions_dir; Dpath.Build.install_dir ]
+            |> List.map ~f:Path.Build.basename)
+           @ (Context_name.Map.keys contexts
+             |> List.map ~f:Context_name.to_string)))
+    in
+    Dir_triage.Known (Loaded.no_rules ~allowed_subdirs)
+  | Build (Install Root) ->
+    let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
+    let allowed_subdirs =
+      Context_name.Map.keys contexts
+      |> List.map ~f:Context_name.to_string
+      |> Subdir_set.of_list |> Subdir_set.to_dir_set
+    in
+    Dir_triage.Known (Loaded.no_rules ~allowed_subdirs)
+  | Build (Anonymous_action p) ->
+    let build_dir = Dpath.Target_dir.build_dir p in
+    Code_error.raise "Called get_dir_triage on an anonymous action directory"
+      [ ("dir", Path.Build.to_dyn build_dir) ]
+  | Build (Invalid _) ->
+    Memo.Build.return
+    @@ Dir_triage.Known (Loaded.no_rules ~allowed_subdirs:Dir_set.empty)
+  | Build (Install (With_context (context_name, sub_dir))) ->
+    (* In this branch, [dir] is in the build directory. *)
+    let dir = Path.as_in_build_dir_exn dir in
+    let context_or_install = Context_or_install.Install context_name in
+    Memo.Build.return
+      (Dir_triage.Need_step2 { dir; context_or_install; sub_dir })
+  | Build (Regular (With_context (context_name, sub_dir))) ->
+    (* In this branch, [dir] is in the build directory. *)
+    let dir = Path.as_in_build_dir_exn dir in
+    let context_or_install = Context_or_install.Context context_name in
+    Memo.Build.return
+      (Dir_triage.Need_step2 { dir; context_or_install; sub_dir })
+
+let describe_rule (rule : Rule.t) =
+  match rule.info with
+  | From_dune_file { start; _ } ->
+    start.pos_fname ^ ":" ^ string_of_int start.pos_lnum
+  | Internal -> "<internal location>"
+  | Source_file_copy _ -> "file present in source tree"
+
+let report_rule_src_dir_conflict dir fn (rule : Rule.t) =
+  let loc =
+    match rule.info with
+    | From_dune_file loc -> loc
+    | Internal
+    | Source_file_copy _ ->
+      let dir =
+        match Path.Build.drop_build_context dir with
+        | None -> Path.build dir
+        | Some s -> Path.source s
+      in
+      Loc.in_dir dir
+  in
+  User_error.raise ~loc
+    [ Pp.textf
+        "This rule defines a target %S whose name conflicts with a source \
+         directory in the same directory."
+        (Path.Build.basename fn)
+    ]
+    ~hints:
+      [ Pp.textf
+          "If you want Dune to generate and replace %S, add (mode promote) to \
+           the rule stanza. Alternatively, you can delete %S from the source \
+           tree or change the rule to generate a different target."
+          (Path.Build.basename fn) (Path.Build.basename fn)
+      ]
+
+let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
+  let fn = Path.build fn in
+  User_error.raise
+    [ Pp.textf "Multiple rules generated for %s:"
+        (Path.to_string_maybe_quoted fn)
+    ; Pp.textf "- %s" (describe_rule rule')
+    ; Pp.textf "- %s" (describe_rule rule)
+    ]
+    ~hints:
+      (match (rule.info, rule'.info) with
+      | Source_file_copy _, _
+      | _, Source_file_copy _ ->
+        [ Pp.textf "rm -f %s"
+            (Path.to_string_maybe_quoted (Path.drop_optional_build_context fn))
+        ]
+      | _ -> [])
+
+let remove_old_artifacts ~dir ~rules_here ~(subdirs_to_keep : Subdir_set.t) =
+  match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
+  | exception _ -> ()
+  | Error _ -> ()
+  | Ok files ->
+    List.iter files ~f:(fun (fn, kind) ->
+        let path = Path.Build.relative dir fn in
+        let path_is_a_target =
+          (* CR-someday amokhov: Also check directory targets. *)
+          Path.Build.Map.mem rules_here.Loaded.by_file_targets path
+        in
+        if not path_is_a_target then
+          match kind with
+          | Unix.S_DIR -> (
+            match subdirs_to_keep with
+            | All -> ()
+            | These set ->
+              if not (String.Set.mem set fn) then Path.rm_rf (Path.build path))
+          | _ -> Path.unlink (Path.build path))
+
+(* We don't remove files in there as we don't know upfront if they are stale or
+   not. *)
+let remove_old_sub_dirs_in_anonymous_actions_dir ~dir
+    ~(subdirs_to_keep : Subdir_set.t) =
+  match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
+  | exception _ -> ()
+  | Error _ -> ()
+  | Ok files ->
+    List.iter files ~f:(fun (fn, kind) ->
+        let path = Path.Build.relative dir fn in
+        match kind with
+        | Unix.S_DIR -> (
+          match subdirs_to_keep with
+          | All -> ()
+          | These set ->
+            if not (String.Set.mem set fn) then Path.rm_rf (Path.build path))
+        | _ -> ())
+
+let no_rule_found ~loc fn =
+  let+ contexts = Memo.Lazy.force (Build_config.get ()).contexts in
+  let fail fn ~loc =
+    User_error.raise ?loc
+      [ Pp.textf "No rule found for %s" (Dpath.describe_target fn) ]
+  in
+  let hints ctx =
+    let candidates =
+      Context_name.Map.keys contexts |> List.map ~f:Context_name.to_string
+    in
+    User_message.did_you_mean (Context_name.to_string ctx) ~candidates
+  in
+  match Dpath.analyse_target fn with
+  | Other _ -> fail fn ~loc
+  | Regular (ctx, _) ->
+    if Context_name.Map.mem contexts ctx then
+      fail fn ~loc
+    else
+      User_error.raise
+        [ Pp.textf "Trying to build %s but build context %s doesn't exist."
+            (Path.Build.to_string_maybe_quoted fn)
+            (Context_name.to_string ctx)
+        ]
+        ~hints:(hints ctx)
+  | Install (ctx, _) ->
+    if Context_name.Map.mem contexts ctx then
+      fail fn ~loc
+    else
+      User_error.raise
+        [ Pp.textf
+            "Trying to build %s for install but build context %s doesn't exist."
+            (Path.Build.to_string_maybe_quoted fn)
+            (Context_name.to_string ctx)
+        ]
+        ~hints:(hints ctx)
+  | Alias (ctx, fn') ->
+    if Context_name.Map.mem contexts ctx then
+      fail fn ~loc
+    else
+      let fn =
+        Path.append_source (Path.build (Context_name.build_dir ctx)) fn'
+      in
+      User_error.raise
+        [ Pp.textf
+            "Trying to build alias %s but build context %s doesn't exist."
+            (Path.to_string_maybe_quoted fn)
+            (Context_name.to_string ctx)
+        ]
+        ~hints:(hints ctx)
+  | Anonymous_action _ ->
+    (* We never lookup such actions by target name, so this should be
+       unreachable *)
+    Code_error.raise ?loc "Build_system.no_rule_found got anonymous action path"
+      [ ("fn", Path.Build.to_dyn fn) ]
+
+let source_file_digest path =
+  let report_user_error details =
+    let+ loc = Current_rule_loc.get () in
+    User_error.raise ?loc
+      ([ Pp.textf "File unavailable: %s" (Path.to_string_maybe_quoted path) ]
+      @ details)
+  in
+  Fs_memo.path_digest path >>= function
+  | Ok digest -> Memo.Build.return digest
+  | No_such_file -> report_user_error []
+  | Broken_symlink -> report_user_error [ Pp.text "Broken symlink" ]
+  | Unexpected_kind st_kind ->
+    report_user_error
+      [ Pp.textf "This is neither a regular file nor a directory (%s)"
+          (File_kind.to_string st_kind)
+      ]
+  | Unix_error (error, _, _) ->
+    report_user_error [ Pp.textf "%s" (Unix.error_message error) ]
+  | Error exn -> report_user_error [ Pp.textf "%s" (Printexc.to_string exn) ]
+
+let eval_source_file :
+    type a. a Action_builder.eval_mode -> Path.t -> a Memo.Build.t =
+ fun mode path ->
+  match mode with
+  | Lazy -> Memo.Build.return ()
+  | Eager ->
+    let+ d = source_file_digest path in
+    Dep.Fact.file path d
+
+module rec Load_rules : sig
+  val load_dir : dir:Path.t -> Loaded.t Memo.Build.t
+
+  val file_exists : Path.t -> bool Memo.Build.t
+
+  val file_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
+
+  val directory_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
+
+  val lookup_alias :
+       Alias.t
+    -> (Loc.t * Rules.Dir_rules.Alias_spec.item) list option Memo.Build.t
+
+  val alias_exists : Alias.t -> bool Memo.Build.t
+end = struct
+  open Load_rules
+
+  let create_copy_rules ~ctx_dir ~non_target_source_files =
+    Path.Source.Set.to_list_map non_target_source_files ~f:(fun path ->
+        let ctx_path = Path.Build.append_source ctx_dir path in
+        let build =
+          Action_builder.of_thunk
+            { f =
+                (fun mode ->
+                  let path = Path.source path in
+                  let+ fact = eval_source_file mode path in
+                  ( Action.Full.make
+                      (Action.copy path ctx_path)
+                      (* There's an [assert false] in [prepare_managed_paths]
+                         that blows up if we try to sandbox this. *)
+                      ~sandbox:Sandbox_config.no_sandboxing
+                  , Dep.Map.singleton (Dep.file path) fact ))
+            }
+        in
+        Rule.make ~context:None ~info:(Source_file_copy path)
+          ~targets:(Targets.File.create ctx_path)
+          build)
+
+  let compile_rules ~dir ~source_dirs rules =
+    let file_targets, directory_targets =
+      let check_for_source_dir_conflict rule target =
+        if String.Set.mem source_dirs (Path.Build.basename target) then
+          report_rule_src_dir_conflict dir target rule
+      in
+      List.map rules ~f:(fun rule ->
+          assert (Path.Build.( = ) dir rule.Rule.dir);
+          ( Path.Build.Set.to_list_map rule.targets.files ~f:(fun target ->
+                check_for_source_dir_conflict rule target;
+                (target, rule))
+          , Path.Build.Set.to_list_map rule.targets.dirs ~f:(fun target ->
+                check_for_source_dir_conflict rule target;
+                (target, rule)) ))
+      |> List.unzip
+    in
+    let by_file_targets =
+      List.concat file_targets
+      |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
+    in
+    let by_directory_targets =
+      List.concat directory_targets
+      |> Path.Build.Map.of_list_reducei ~f:report_rule_conflict
+    in
+    Path.Build.Map.iter2 by_file_targets by_directory_targets
+      ~f:(fun target rule1 rule2 ->
+        match (rule1, rule2) with
+        | None, _
+        | _, None ->
+          ()
+        | Some rule1, Some rule2 -> report_rule_conflict target rule1 rule2);
+    { Loaded.by_file_targets; by_directory_targets }
+
+  (* Here we are doing a O(log |S|) lookup in a set S of files in the build
+     directory [dir]. We could memoize these lookups, but it doesn't seem to be
+     worth it, since we're unlikely to perform exactly the same lookup many
+     times. As far as I can tell, each lookup will be done twice: when computing
+     static dependencies of a [Action_builder.t] with
+     [Action_builder.static_deps] and when executing the very same
+     [Action_builder.t] with [Action_builder.exec] -- the results of both
+     [Action_builder.static_deps] and [Action_builder.exec] are cached. *)
+  let file_exists fn =
+    load_dir ~dir:(Path.parent_exn fn) >>| function
+    | Non_build targets -> Path.Set.mem targets fn
+    | Build { rules_here; _ } -> (
+      match Path.as_in_build_dir fn with
+      | None -> false
+      | Some fn -> (
+        match Path.Build.Map.mem rules_here.by_file_targets fn with
+        | true -> true
+        | false -> (
+          match Path.Build.parent fn with
+          | None -> false
+          | Some dir -> Path.Build.Map.mem rules_here.by_directory_targets dir))
+      )
+
+  let file_targets_of ~dir =
+    load_dir ~dir >>| function
+    | Non_build file_targets -> file_targets
+    | Build { rules_here; _ } ->
+      Path.Build.Map.keys rules_here.by_file_targets
+      |> Path.Set.of_list_map ~f:Path.build
+
+  let directory_targets_of ~dir =
+    load_dir ~dir >>| function
+    | Non_build _file_targets -> Path.Set.empty
+    | Build { rules_here; _ } ->
+      Path.Build.Map.keys rules_here.by_directory_targets
+      |> Path.Set.of_list_map ~f:Path.build
+
+  let lookup_alias alias =
+    load_dir ~dir:(Path.build (Alias.dir alias)) >>| function
+    | Non_build _ ->
+      Code_error.raise "Alias in a non-build dir"
+        [ ("alias", Alias.to_dyn alias) ]
+    | Build { aliases; _ } -> Alias.Name.Map.find aliases (Alias.name alias)
+
+  let alias_exists alias =
+    lookup_alias alias >>| function
+    | None -> false
+    | Some _ -> true
+
+  let compute_alias_expansions ~(collected : Rules.Dir_rules.ready) ~dir =
+    let aliases = collected.aliases in
+    let+ aliases =
+      if Alias.Name.Map.mem aliases Alias.Name.default then
+        Memo.Build.return aliases
+      else
+        (Build_config.get ()).implicit_default_alias dir >>| function
+        | None -> aliases
+        | Some expansion ->
+          Alias.Name.Map.set aliases Alias.Name.default
+            { expansions =
+                Appendable_list.singleton
+                  (Loc.none, Rules.Dir_rules.Alias_spec.Deps expansion)
+            }
+    in
+    Alias.Name.Map.map aliases
+      ~f:(fun { Rules.Dir_rules.Alias_spec.expansions } ->
+        Appendable_list.to_list expansions)
+
+  let filter_out_fallback_rules ~to_copy rules =
+    List.filter rules ~f:(fun (rule : Rule.t) ->
+        match rule.mode with
+        | Standard
+        | Promote _
+        | Ignore_source_files ->
+          true
+        | Fallback ->
+          let source_files_for_targets =
+            if not (Path.Build.Set.is_empty rule.targets.dirs) then
+              Code_error.raise "Unexpected directory target in a Fallback rule"
+                [ ("targets", Targets.Validated.to_dyn rule.targets) ];
+            Path.Build.Set.to_list_map
+              rule.targets.files
+              (* All targets are in a directory of a build context since there
+                 are source files to copy, so this call can't fail. *)
+              ~f:Path.Build.drop_build_context_exn
+            |> Path.Source.Set.of_list
+          in
+          if Path.Source.Set.is_subset source_files_for_targets ~of_:to_copy
+          then
+            (* All targets are present *)
+            false
+          else if
+            Path.Source.Set.is_empty
+              (Path.Source.Set.inter source_files_for_targets to_copy)
+          then
+            (* No target is present *)
+            true
+          else
+            let absent_targets =
+              Path.Source.Set.diff source_files_for_targets to_copy
+            in
+            let present_targets =
+              Path.Source.Set.diff source_files_for_targets absent_targets
+            in
+            User_error.raise ~loc:(Rule.loc rule)
+              [ Pp.text
+                  "Some of the targets of this fallback rule are present in \
+                   the source tree, and some are not. This is not allowed. \
+                   Either none of the targets must be present in the source \
+                   tree, either they must all be."
+              ; Pp.nop
+              ; Pp.text "The following targets are present:"
+              ; Pp.enumerate ~f:Path.pp
+                  (Path.set_of_source_paths present_targets |> Path.Set.to_list)
+              ; Pp.nop
+              ; Pp.text "The following targets are not:"
+              ; Pp.enumerate ~f:Path.pp
+                  (Path.set_of_source_paths absent_targets |> Path.Set.to_list)
+              ])
+
+  (** A directory is only allowed to be generated if its parent knows about it.
+      This restriction is necessary to prevent stale artifact deletion from
+      removing that directory.
+
+      This module encodes that restriction. *)
+  module Generated_directory_restrictions : sig
+    type restriction =
+      | Unrestricted
+      | Restricted of Path.Unspecified.w Dir_set.t Memo.Lazy.t
+
+    (** Used by the child to ask about the restrictions placed by the parent. *)
+    val allowed_by_parent : dir:Path.Build.t -> restriction Memo.Build.t
+  end = struct
+    type restriction =
+      | Unrestricted
+      | Restricted of Path.Unspecified.w Dir_set.t Memo.Lazy.t
+
+    let corresponding_source_dir ~dir =
+      match Dpath.analyse_target dir with
+      | Install _
+      | Alias _
+      | Anonymous_action _
+      | Other _ ->
+        Memo.Build.return None
+      | Regular (_ctx, sub_dir) -> Source_tree.find_dir sub_dir
+
+    let source_subdirs_of_build_dir ~dir =
+      corresponding_source_dir ~dir >>| function
+      | None -> String.Set.empty
+      | Some dir -> Source_tree.Dir.sub_dir_names dir
+
+    let allowed_dirs ~dir ~subdir : restriction Memo.Build.t =
+      let+ subdirs = source_subdirs_of_build_dir ~dir in
+      if String.Set.mem subdirs subdir then
+        Unrestricted
+      else
+        Restricted
+          (Memo.Lazy.create ~name:"allowed_dirs" (fun () ->
+               load_dir ~dir:(Path.build dir) >>| function
+               | Non_build _ -> Dir_set.just_the_root
+               | Build { allowed_subdirs; _ } ->
+                 Dir_set.descend allowed_subdirs subdir))
+
+    let allowed_by_parent ~dir =
+      allowed_dirs
+        ~dir:(Path.Build.parent_exn dir)
+        ~subdir:(Path.Build.basename dir)
+  end
+
+  let load_dir_step2_exn ~dir ~context_or_install ~sub_dir =
+    let sub_dir_components = Path.Source.explode sub_dir in
+    (* Load all the rules *)
+    let (module RG : Build_config.Rule_generator) =
+      (Build_config.get ()).rule_generator
+    in
+    let* extra_subdirs_to_keep, rules_produced =
+      RG.gen_rules context_or_install ~dir sub_dir_components >>| function
+      | None ->
+        Code_error.raise "[gen_rules] did not specify rules for the context"
+          [ ("context_or_install", Context_or_install.to_dyn context_or_install)
+          ]
+      | Some x -> x
+    and* global_rules = Memo.Lazy.force RG.global_rules in
+    let rules =
+      let dir = Path.build dir in
+      Rules.Dir_rules.union
+        (Rules.find rules_produced dir)
+        (Rules.find global_rules dir)
+    in
+    let collected = Rules.Dir_rules.consume rules in
+    let rules = collected.rules in
+    (* Compute the set of sources and targets promoted to the source tree that
+       must not be copied to the build directory. *)
+    let source_files_to_ignore, source_dirnames_to_ignore =
+      List.fold_left rules ~init:(Path.Build.Set.empty, String.Set.empty)
+        ~f:(fun (acc_files, acc_dirnames) { Rule.targets; mode; loc; _ } ->
+          let target_filenames =
+            Path.Build.Set.to_list_map ~f:Path.Build.basename targets.files
+            |> String.Set.of_list
+          in
+          let target_dirnames =
+            Path.Build.Set.to_list_map ~f:Path.Build.basename targets.dirs
+            |> String.Set.of_list
+          in
+          (* Check if this rule defines any directory targets that conflict with
+             internal Dune directories listed in [extra_subdirs_to_keep]. *)
+          (match
+             String.Set.choose
+               (Subdir_set.inter_set extra_subdirs_to_keep
+                  (String.Set.union target_filenames target_dirnames))
+           with
+          | None -> ()
+          | Some target_name ->
+            User_error.raise ~loc
+              [ Pp.textf
+                  "This rule defines a target %S whose name conflicts with an \
+                   internal directory used by Dune. Please use a different \
+                   name."
+                  target_name
+              ]);
+          match mode with
+          | Ignore_source_files ->
+            ( Path.Build.Set.union acc_files targets.files
+            , String.Set.union acc_dirnames target_dirnames )
+          | Promote { only; _ } ->
+            (* Note that the [only] predicate applies to the files inside the
+               directory targets rather than to directory names themselves. *)
+            let target_files =
+              match only with
+              | None -> targets.files
+              | Some pred ->
+                let is_promoted file =
+                  Predicate_lang.Glob.exec pred
+                    (Path.reach (Path.build file) ~from:(Path.build dir))
+                    ~standard:Predicate_lang.any
+                in
+                Path.Build.Set.filter targets.files ~f:is_promoted
+            in
+            ( Path.Build.Set.union acc_files target_files
+            , String.Set.union acc_dirnames target_dirnames )
+          | Standard
+          | Fallback ->
+            (acc_files, acc_dirnames))
+    in
+    (* Take into account the source files *)
+    let* to_copy, source_dirs =
+      match context_or_install with
+      | Install _ -> Memo.Build.return (None, String.Set.empty)
+      | Context context_name ->
+        let+ files, subdirs =
+          Source_tree.find_dir sub_dir >>| function
+          | None -> (Path.Source.Set.empty, String.Set.empty)
+          | Some dir ->
+            (Source_tree.Dir.file_paths dir, Source_tree.Dir.sub_dir_names dir)
+        in
+        let files =
+          let source_files_to_ignore =
+            Path.Build.Set.to_list_map ~f:Path.Build.drop_build_context_exn
+              source_files_to_ignore
+            |> Path.Source.Set.of_list
+          in
+          let source_files_to_ignore =
+            Target_promotion.delete_stale_dot_merlin_file ~dir
+              ~source_files_to_ignore
+          in
+          Path.Source.Set.diff files source_files_to_ignore
+        in
+        let subdirs = String.Set.diff subdirs source_dirnames_to_ignore in
+        if Path.Source.Set.is_empty files then
+          (None, subdirs)
+        else
+          let ctx_path = Context_name.build_dir context_name in
+          (Some (ctx_path, files), subdirs)
+    in
+    (* Filter out fallback rules *)
+    let rules =
+      match to_copy with
+      | None ->
+        (* If there are no source files to copy, fallback rules are
+           automatically kept *)
+        rules
+      | Some (_, to_copy) -> filter_out_fallback_rules ~to_copy rules
+    in
+    (* Compile the rules and cleanup stale artifacts *)
+    let rules =
+      (match to_copy with
+      | None -> []
+      | Some (ctx_dir, source_files) ->
+        create_copy_rules ~ctx_dir ~non_target_source_files:source_files)
+      @ rules
+    in
+    let* allowed_by_parent =
+      match (context_or_install, sub_dir_components) with
+      | Context _, [ ".dune" ] ->
+        (* GROSS HACK: this is to avoid a cycle as the rules for all directories
+           force the generation of ".dune/configurator". We need a better way to
+           deal with such cases. *)
+        Memo.Build.return Generated_directory_restrictions.Unrestricted
+      | _ -> Generated_directory_restrictions.allowed_by_parent ~dir
+    in
+    let* () =
+      match allowed_by_parent with
+      | Unrestricted -> Memo.Build.return ()
+      | Restricted restriction -> (
+        match Path.Build.Map.find (Rules.to_map rules_produced) dir with
+        | None -> Memo.Build.return ()
+        | Some rules ->
+          let+ restriction = Memo.Lazy.force restriction in
+          if not (Dir_set.here restriction) then
+            Code_error.raise
+              "Generated rules in a directory not allowed by the parent"
+              [ ("dir", Path.Build.to_dyn dir)
+              ; ("rules", Rules.Dir_rules.to_dyn rules)
+              ])
+    in
+    let* descendants_to_keep =
+      let rules_generated_in =
+        Rules.to_map rules_produced
+        |> Path.Build.Map.foldi ~init:Dir_set.empty ~f:(fun p _ acc ->
+               match Path.Local_gen.descendant ~of_:dir p with
+               | None -> acc
+               | Some p -> Dir_set.union acc (Dir_set.singleton p))
+      in
+      let subdirs_to_keep =
+        match extra_subdirs_to_keep with
+        | All -> Subdir_set.All
+        | These set -> These (String.Set.union source_dirs set)
+      in
+      let+ allowed_grand_descendants_of_parent =
+        match allowed_by_parent with
+        | Unrestricted ->
+          (* In this case the parent isn't going to be able to create any
+             generated grand descendant directories. Rules that attempt to do so
+             may run into the [allowed_by_parent] check or will be simply
+             ignored. *)
+          Memo.Build.return Dir_set.empty
+        | Restricted restriction -> Memo.Lazy.force restriction
+      in
+      Dir_set.union_all
+        [ rules_generated_in
+        ; Subdir_set.to_dir_set subdirs_to_keep
+        ; allowed_grand_descendants_of_parent
+        ]
+    in
+    let subdirs_to_keep = Subdir_set.of_dir_set descendants_to_keep in
+    let rules_here = compile_rules ~dir ~source_dirs rules in
+    remove_old_artifacts ~dir ~rules_here ~subdirs_to_keep;
+    remove_old_sub_dirs_in_anonymous_actions_dir
+      ~dir:
+        (Path.Build.append_local Dpath.Build.anonymous_actions_dir
+           (Path.Build.local dir))
+      ~subdirs_to_keep;
+    let+ aliases =
+      match context_or_install with
+      | Context _ -> compute_alias_expansions ~collected ~dir
+      | Install _ ->
+        (* There are no aliases in the [_build/install] directory *)
+        Memo.Build.return Alias.Name.Map.empty
+    in
+    { Loaded.allowed_subdirs = descendants_to_keep
+    ; rules_produced
+    ; rules_here
+    ; aliases
+    }
+
+  let load_dir_impl ~dir : Loaded.t Memo.Build.t =
+    get_dir_triage ~dir >>= function
+    | Known l -> Memo.Build.return l
+    | Need_step2 { dir; context_or_install; sub_dir } ->
+      let+ build = load_dir_step2_exn ~dir ~context_or_install ~sub_dir in
+      Loaded.Build build
+
+  let load_dir =
+    let load_dir_impl dir = load_dir_impl ~dir in
+    let memo = Memo.create "load-dir" ~input:(module Path) load_dir_impl in
+    fun ~dir -> Memo.exec memo dir
+end
+
+open Load_rules
+
+let load_dir_and_get_buildable_targets ~dir =
+  load_dir ~dir >>| function
+  | Non_build _ -> Loaded.no_rules_here
+  | Build { rules_here; _ } -> rules_here
+
+let get_rule_for_directory_target path =
+  let rec loop dir =
+    match Path.Build.parent dir with
+    | None -> Memo.Build.return None
+    | Some parent_dir -> (
+      let* rules =
+        load_dir_and_get_buildable_targets ~dir:(Path.build parent_dir)
+      in
+      match Path.Build.Map.find rules.by_directory_targets dir with
+      | None -> loop parent_dir
+      | Some _ as rule -> Memo.Build.return rule)
+  in
+  loop path
+
+let get_rule path =
+  match Path.as_in_build_dir path with
+  | None -> Memo.Build.return None
+  | Some path -> (
+    let dir = Path.Build.parent_exn path in
+    load_dir ~dir:(Path.build dir) >>= function
+    | Non_build _ -> assert false
+    | Build { rules_here; _ } -> (
+      match Path.Build.Map.find rules_here.by_file_targets path with
+      | Some _ as rule -> Memo.Build.return rule
+      | None -> get_rule_for_directory_target path))
+
+type rule_or_source =
+  | Source of Digest.t
+  | Rule of Path.Build.t * Rule.t
+
+let get_rule_or_source path =
+  let dir = Path.parent_exn path in
+  if Path.is_strict_descendant_of_build_dir dir then
+    let* rules = load_dir_and_get_buildable_targets ~dir in
+    let path = Path.as_in_build_dir_exn path in
+    match Path.Build.Map.find rules.by_file_targets path with
+    | Some rule -> Memo.Build.return (Rule (path, rule))
+    | None -> (
+      get_rule_for_directory_target path >>= function
+      | Some rule -> Memo.Build.return (Rule (path, rule))
+      | None ->
+        let* loc = Current_rule_loc.get () in
+        no_rule_found ~loc path)
+  else
+    let+ d = source_file_digest path in
+    Source d
+
+module Source_tree_map_reduce =
+  Source_tree.Dir.Make_map_reduce (Memo.Build) (Monoid.Union (Path.Build.Set))
+
+let all_targets () =
+  let* root = Source_tree.root ()
+  and* contexts = Memo.Lazy.force (Build_config.get ()).contexts in
+  Memo.Build.parallel_map (Context_name.Map.values contexts) ~f:(fun ctx ->
+      Source_tree_map_reduce.map_reduce root ~traverse:Sub_dirs.Status.Set.all
+        ~f:(fun dir ->
+          load_dir
+            ~dir:
+              (Path.build
+                 (Path.Build.append_source ctx.Build_context.build_dir
+                    (Source_tree.Dir.path dir)))
+          >>| function
+          | Non_build _ -> Path.Build.Set.empty
+          | Build { rules_here; _ } ->
+            Path.Build.Set.of_list
+              (Path.Build.Map.keys rules_here.by_file_targets
+              @ Path.Build.Map.keys rules_here.by_directory_targets)))
+  >>| Path.Build.Set.union_all
+
+let get_alias_definition alias =
+  lookup_alias alias >>= function
+  | None ->
+    let open Pp.O in
+    let+ loc = Current_rule_loc.get () in
+    User_error.raise ?loc
+      [ Pp.text "No rule found for " ++ Alias.describe alias ]
+  | Some x -> Memo.Build.return x
+
+let load_dir = load_dir
+
+let load_dir_and_produce_its_rules ~dir =
+  load_dir ~dir >>= function
+  | Non_build _ -> Memo.Build.return ()
+  | Build loaded -> Rules.produce loaded.rules_produced
+
+let file_exists = file_exists
+
+let alias_exists = alias_exists
+
+let file_targets_of = file_targets_of
+
+let is_target file =
+  match Path.is_in_build_dir file with
+  | false -> Memo.Build.return false
+  | true -> (
+    let parent_dir = Path.parent_exn file in
+    let* file_targets = file_targets_of ~dir:parent_dir in
+    match Path.Set.mem file_targets file with
+    | true -> Memo.Build.return true
+    | false ->
+      let rec loop dir =
+        match Path.parent dir with
+        | None -> Memo.Build.return false
+        | Some parent_dir -> (
+          let* directory_targets = directory_targets_of ~dir:parent_dir in
+          match Path.Set.mem directory_targets dir with
+          | true -> Memo.Build.return true
+          | false -> loop parent_dir)
+      in
+      loop file)

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -1,10 +1,10 @@
-(** Loading build rules. *)
+(** Loading build rules *)
 
 open! Stdune
 open! Import
 module Action_builder := Action_builder0
 
-(** A way to determine the [Loc.t] of the current rule, set by [Build_system]. *)
+(** A way to determine the [Loc.t] of the current rule. Set by [Build_system]. *)
 val set_current_rule_loc : (unit -> Loc.t option Memo.Build.t) -> unit
 
 module Loaded : sig
@@ -32,9 +32,9 @@ end
 (** Returns the set of file targets in the given directory. *)
 val file_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
 
+(** Load the rules for this directory. *)
 val load_dir : dir:Path.t -> Loaded.t Memo.Build.t
 
-(** Load the rules for this directory. *)
 val load_dir_and_produce_its_rules : dir:Path.t -> unit Memo.Build.t
 
 (** Return [true] if a file exists or is buildable *)

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -1,0 +1,61 @@
+(** Loading build rules. *)
+
+open! Stdune
+open! Import
+module Action_builder := Action_builder0
+
+(** A way to determine the [Loc.t] of the current rule, set by [Build_system]. *)
+val set_current_rule_loc : (unit -> Loc.t option Memo.Build.t) -> unit
+
+module Loaded : sig
+  type rules_here =
+    { by_file_targets : Rule.t Path.Build.Map.t
+    ; by_directory_targets : Rule.t Path.Build.Map.t
+    }
+
+  val no_rules_here : rules_here
+
+  type build =
+    { allowed_subdirs : Path.Unspecified.w Dir_set.t
+    ; rules_produced : Rules.t
+    ; rules_here : rules_here
+    ; aliases : (Loc.t * Rules.Dir_rules.Alias_spec.item) list Alias.Name.Map.t
+    }
+
+  type t =
+    | Non_build of Path.Set.t
+    | Build of build
+
+  val no_rules : allowed_subdirs:Path.Unspecified.w Dir_set.t -> t
+end
+
+(** Returns the set of file targets in the given directory. *)
+val file_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
+
+val load_dir : dir:Path.t -> Loaded.t Memo.Build.t
+
+(** Load the rules for this directory. *)
+val load_dir_and_produce_its_rules : dir:Path.t -> unit Memo.Build.t
+
+(** Return [true] if a file exists or is buildable *)
+val file_exists : Path.t -> bool Memo.Build.t
+
+val alias_exists : Alias.t -> bool Memo.Build.t
+
+val is_target : Path.t -> bool Memo.Build.t
+
+(** Return the rule that has the given file has target, if any *)
+val get_rule : Path.t -> Rule.t option Memo.Build.t
+
+(** Return the definition of an alias. *)
+val get_alias_definition :
+  Alias.t -> (Loc.t * Rules.Dir_rules.Alias_spec.item) list Memo.Build.t
+
+(** List of all buildable targets. *)
+val all_targets : unit -> Path.Build.Set.t Memo.Build.t
+
+type rule_or_source =
+  | Source of Digest.t
+  | Rule of Path.Build.t * Rule.t
+
+val get_rule_or_source : Path.t -> rule_or_source Memo.Build.t

--- a/src/dune_engine/reflection.ml
+++ b/src/dune_engine/reflection.ml
@@ -28,7 +28,7 @@ end = struct
         ~input:(module Alias)
         (fun alias ->
           let* l =
-            Build_system.get_alias_definition alias
+            Load_rules.get_alias_definition alias
             >>= Memo.Build.parallel_map ~f:(fun (loc, definition) ->
                     Memo.push_stack_frame
                       (fun () ->
@@ -79,7 +79,7 @@ let eval ~recursive ~request =
   let rules_of_deps deps =
     Expand.deps deps >>| Path.Set.to_list
     >>= Memo.Build.parallel_map ~f:(fun p ->
-            Build_system.get_rule p >>= function
+            Load_rules.get_rule p >>= function
             | None -> Memo.Build.return None
             | Some rule -> evaluate_rule rule >>| Option.some)
     >>| List.filter_map ~f:Fun.id

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -376,14 +376,16 @@ let gen_rules ~sctx ~dir components =
             if Utop.is_utop_dir dir then
               Utop.setup sctx ~dir:(Path.Build.parent_exn dir)
             else if components <> [] then
-              Build_system.load_dir ~dir:(Path.parent_exn (Path.build dir))
+              Load_rules.load_dir_and_produce_its_rules
+                ~dir:(Path.parent_exn (Path.build dir))
             else
               Memo.Build.return ()
           | Some source_dir -> (
             (* This interprets "rule" and "copy_files" stanzas. *)
             Dir_contents.gen_rules sctx ~dir
             >>= function
-            | Group_part root -> Build_system.load_dir ~dir:(Path.build root)
+            | Group_part root ->
+              Load_rules.load_dir_and_produce_its_rules ~dir:(Path.build root)
             | Standalone_or_root (dir_contents, subs) ->
               let* cctxs = gen_rules sctx dir_contents [] ~source_dir ~dir in
               Memo.Build.parallel_iter subs ~f:(fun dc ->

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -399,7 +399,8 @@ let load_all_odoc_rules_pkg sctx ~pkg =
     Memo.Build.parallel_iter
       (Pkg pkg :: List.map pkg_libs ~f:(fun lib -> Lib lib))
       ~f:(fun target ->
-        Build_system.load_dir ~dir:(Path.build (Paths.odocs ctx target)))
+        Load_rules.load_dir_and_produce_its_rules
+          ~dir:(Path.build (Paths.odocs ctx target)))
   in
   pkg_libs
 
@@ -737,7 +738,7 @@ let gen_rules sctx ~dir:_ rest =
          rules for this library *)
       let info = Lib.info lib in
       let dir = Lib_info.src_dir info in
-      Build_system.load_dir ~dir)
+      Load_rules.load_dir_and_produce_its_rules ~dir)
   | "_html" :: lib_unique_name_or_pkg :: _ ->
     (* TODO we can be a better with the error handling in the case where
        lib_unique_name_or_pkg is neither a valid pkg or lnu *)


### PR DESCRIPTION
The next step in breaking up `build_system.ml` into smaller pieces. Now adding `Load_rules`.

The only non-trivial bit of the split is that `build_system.ml` needs to call `Load_rules.set_current_rule_loc` to set the callback for resolving rule locations, for error messages.

After this PR, `build_system.ml` is down to "just" ~1000 lines.