### PR TITLE
Do not allow to compute digests of directories via [Fs_memo]

### DIFF
--- a/otherlibs/stdune/digest.ml
+++ b/otherlibs/stdune/digest.ml
@@ -119,7 +119,8 @@ module Path_digest_result = struct
       Dune_filesystem_stubs.Unix_error.Detailed.equal x y
 end
 
-let path_with_stats path (stats : Stats_for_digest.t) : Path_digest_result.t =
+let path_with_stats ~allow_dirs path (stats : Stats_for_digest.t) :
+    Path_digest_result.t =
   match stats.st_kind with
   | S_REG ->
     let executable = stats.st_perm land 0o100 <> 0 in
@@ -127,11 +128,12 @@ let path_with_stats path (stats : Stats_for_digest.t) : Path_digest_result.t =
       (file_with_executable_bit ~executable)
       path
     |> Path_digest_result.of_result
-  | S_DIR ->
+  | S_DIR when allow_dirs ->
     (* CR-someday amokhov: The current digesting scheme has collisions for files
        and directories. It's unclear if this is actually a problem. If it turns
        out to be a problem, we should include [st_kind] into both digests. *)
     Ok (generic (stats.st_size, stats.st_perm, stats.st_mtime, stats.st_ctime))
+  | S_DIR
   | S_BLK
   | S_CHR
   | S_LNK

--- a/otherlibs/stdune/digest.mli
+++ b/otherlibs/stdune/digest.mli
@@ -43,7 +43,7 @@ end
 module Path_digest_result : sig
   type nonrec t =
     | Ok of t
-    | Unexpected_kind  (** Not a regular file or a directory *)
+    | Unexpected_kind
     | Unix_error of Dune_filesystem_stubs.Unix_error.Detailed.t
         (** A Unix error, e.g., [(ENOENT, _, _)] if the path doesn't exist. *)
 
@@ -55,9 +55,10 @@ end
     - If it's a regular file, the resulting digest includes the file's content
       as well as the its executable permissions bit.
 
-    - If it's a directory, the function attempts to do something sensible by
-      digesting [Stats_for_digest] (except for the [st_kind] field since it's
-      known to be [S_DIR] in this case).
+    - If it's a directory and [allow_dirs = true], the function computes the
+      digest of [Stats_for_digest] (except for the [st_kind] field since it's
+      known to be [S_DIR] in this case). This is a poor approach to computing
+      directory digests and we are planning to get rid of it soon.
 
     - Otherwise, the function returns [Unexpected_kind].
 
@@ -65,7 +66,8 @@ end
     may get stale, so [path_with_stats] may return [Unix_error (ENOENT, _, _)]
     even though you've just successfully run [Path.stat] on it. The call sites
     are expected to gracefully handle such races. *)
-val path_with_stats : Path.t -> Stats_for_digest.t -> Path_digest_result.t
+val path_with_stats :
+  allow_dirs:bool -> Path.t -> Stats_for_digest.t -> Path_digest_result.t
 
 (** Digest a file taking the [executable] bit into account. Should not be called
     on a directory. *)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -731,7 +731,12 @@ end = struct
       match Path.Build.Map.find targets path with
       | Some digest -> (digest, None)
       | None -> (
-        match Cached_digest.build_file path with
+        (* CR-someday amokhov: [Cached_digest.build_file] doesn't do a good job
+           for computing directory digests -- it relies on [mtime] instead of
+           actually computing the digest of the directory's content. As one of
+           the consequences, we currently can't support the early cutoff for
+           directory targets. *)
+        match Cached_digest.build_file ~allow_dirs:true path with
         | Ok digest -> (digest, Some targets) (* Must be a directory target *)
         | No_such_file
         | Broken_symlink

--- a/src/dune_engine/cached_digest.mli
+++ b/src/dune_engine/cached_digest.mli
@@ -17,8 +17,21 @@ module Digest_result : sig
   val to_dyn : t -> Dyn.t
 end
 
-(** Digest the contents of a build artifact. *)
-val build_file : Path.Build.t -> Digest_result.t
+(** Digest the contents of a build artifact.
+
+    If [allow_dirs = false], this function returns [Unexpected_kind] if the path
+    points to a directory. *)
+val build_file : allow_dirs:bool -> Path.Build.t -> Digest_result.t
+
+(** Same as [build_file], but forces the digest of the file to be re-computed.
+
+    If [remove_write_permissions] is true, also remove write permissions on the
+    file. *)
+val refresh :
+     allow_dirs:bool
+  -> remove_write_permissions:bool
+  -> Path.Build.t
+  -> Digest_result.t
 
 module Untracked : sig
   (** Digest the contents of a source or external file. This function doesn't
@@ -29,12 +42,6 @@ module Untracked : sig
       [source_or_external_file] to incur an additional [stat] call. *)
   val invalidate_cached_timestamp : Path.t -> unit
 end
-
-(** Same as [build_file], but forces the digest of the file to be re-computed.
-
-    If [remove_write_permissions] is true, also remove write permissions on the
-    file. *)
-val refresh : Path.Build.t -> remove_write_permissions:bool -> Digest_result.t
 
 (** {1 Managing the cache} *)
 

--- a/src/dune_engine/fs_cache.ml
+++ b/src/dune_engine/fs_cache.ml
@@ -113,10 +113,10 @@ module Untracked = struct
   (* CR-someday amokhov: There is an overlap in functionality between this
      module and [cached_digest.ml]. In particular, digests are stored twice, in
      two separate tables. We should find a way to merge the tables into one. *)
-  let path_digest =
+  let file_digest =
     let sample = Cached_digest.Untracked.source_or_external_file in
     let update_hook = Cached_digest.Untracked.invalidate_cached_timestamp in
-    create "path_digest" ~sample ~update_hook
+    create "file_digest" ~sample ~update_hook
       ~equal:Cached_digest.Digest_result.equal
 
   let dir_contents =

--- a/src/dune_engine/fs_cache.mli
+++ b/src/dune_engine/fs_cache.mli
@@ -70,7 +70,7 @@ end
 module Untracked : sig
   val path_stat : (Reduced_stats.t, Unix_error.Detailed.t) result t
 
-  val path_digest : Cached_digest.Digest_result.t t
+  val file_digest : Cached_digest.Digest_result.t t
 
   val dir_contents : (Dir_contents.t, Unix_error.Detailed.t) result t
 end

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -106,7 +106,7 @@ let update_all : Path.t -> Fs_cache.Update_result.t =
   in
   Update_all.reduce
     [ update Fs_cache.Untracked.path_stat
-    ; update Fs_cache.Untracked.path_digest
+    ; update Fs_cache.Untracked.file_digest
     ; update Fs_cache.Untracked.dir_contents
     ]
 
@@ -222,13 +222,13 @@ let dir_exists path =
    watching, and we should expose this function from the [Cached_digest] module
    instead. For now, we keep it here because it seems nice to group all tracked
    file system access functions in one place, and exposing an uncached version
-   of [path_digest] seems error-prone. We may need to rethink this decision. *)
-let path_digest ?(force_update = false) path =
+   of [file_digest] seems error-prone. We may need to rethink this decision. *)
+let file_digest ?(force_update = false) path =
   if force_update then (
     Cached_digest.Untracked.invalidate_cached_timestamp path;
-    Fs_cache.evict Fs_cache.Untracked.path_digest path
+    Fs_cache.evict Fs_cache.Untracked.file_digest path
   );
-  declaring_dependency path ~f:Fs_cache.(read Untracked.path_digest)
+  declaring_dependency path ~f:Fs_cache.(read Untracked.file_digest)
 
 let dir_contents ?(force_update = false) path =
   if force_update then Fs_cache.evict Fs_cache.Untracked.dir_contents path;
@@ -240,10 +240,10 @@ let dir_contents ?(force_update = false) path =
    with two simpler one that can be cached independently. *)
 let with_lexbuf_from_file path ~f =
   declaring_dependency path ~f:(fun path ->
-      (* This is a bit of a hack. By reading [path_digest], we cause the [path]
-         to be recorded in the [Fs_cache.Untracked.path_digest], so the build
+      (* This is a bit of a hack. By reading [file_digest], we cause the [path]
+         to be recorded in the [Fs_cache.Untracked.file_digest], so the build
          will be restarted if the digest changes. *)
-      ignore Fs_cache.(read Untracked.path_digest path);
+      ignore Fs_cache.(read Untracked.file_digest path);
       Io.Untracked.with_lexbuf_from_file path ~f)
 
 (* When a file or directory is created or deleted, we need to also invalidate

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -2,23 +2,32 @@ open! Stdune
 open! Import
 open Memo.Build.O
 
-module Initialization_state = struct
-  type t =
-    | Uninitialized of Path.t list
-    | Initialized of { dune_file_watcher : Dune_file_watcher.t option }
-end
+(* [Fs_memo] can be in three possible states:
+
+   - It starts in [Waiting_for_file_watcher], accumulating [paths_to_watch] to
+   pass them to the file watcher once it has been initialised.
+
+   - If the file watcher turns out to be missing, the state [No_file_watcher] is
+   used to indicate that there is no need to accumulate [paths_to_watch].
+
+   - [File_watcher] holds [Dune_file_watcher.t] once it has been initialised and
+   all previously collected [paths_to_watch] have been passed to it. *)
+type state =
+  | Waiting_for_file_watcher of { paths_to_watch : Path.t list }
+  | No_file_watcher
+  | File_watcher of Dune_file_watcher.t
 
 (* Ideally this should be an [Fdecl], but there are currently two reasons why
    it's not:
 
-   - We read the workspace file before we start the inotify watcher, so [init]
-   is called after [t_ref] is used. This means we have to invalidate some
-   entries of t when [init] is called and set up subscriptions.
+   - We read the workspace file before the file watcher has been initialised, so
+   [init] is called after [state] is used. Hence, we accumulate [paths_to_watch]
+   to invalidate and start watching them when [init] is called.
 
    - There are tests that call [Scheduler.go] multiple times, therefore [init]
-   gets called multiple times. Since they don't use file watcher, it shouldn't
-   be a problem. *)
-let t_ref = ref (Initialization_state.Uninitialized [])
+   gets called multiple times. Since these tests don't use the file watcher, it
+   shouldn't be a problem. *)
+let state = ref (Waiting_for_file_watcher { paths_to_watch = [] })
 
 (* CR-someday aalekseyev: For [watch_path] to work correctly we need to ensure
    that the parent directory of [path] exists. That is certainly not guaranteed
@@ -26,41 +35,43 @@ let t_ref = ref (Initialization_state.Uninitialized [])
    believe that is masked by the fact that we usually (always?) look at the
    source directory before looking for files in that directory.
 
-   It might seem that the [ENOENT] "fall back" trick used below can be extended
-   to fall back all the way to the root, but it can't because subscribing to the
-   root is not sufficient to receive events for creation of "root/a/b/c/d".
-   (however, subscribing to "root/a/b/c" is sufficient for that) *)
-let watch_path dune_file_watcher path =
-  match Dune_file_watcher.add_watch dune_file_watcher path with
+   It might seem that the [`Does_not_exist] "fall back to the containing dir"
+   trick used below can be extended to fall back all the way to the root, but it
+   can't be because watching the root is not sufficient to receive events for
+   creation of "root/a/b/c/d" -- for that we need to watch "root/a/b/c". *)
+let watch_path watcher path =
+  match Dune_file_watcher.add_watch watcher path with
   | Ok () -> ()
   | Error `Does_not_exist -> (
-    (* If we're at the root of the workspace (or the unix root) then we can't
-       get ENOENT because dune can't start without a workspace and unix root
-       always exists, so this [_exn] can't raise (except if the user deletes the
-       workspace dir under our feet, in which case all bets are off). *)
+    (* If we're at the root of the workspace (or the Unix root) then we can't
+       get [`Does_not_exist] because Dune can't start without a workspace and
+       the Unix root always exists. Hence, the [_exn] below can't raise, except
+       if the user deletes the workspace directory under our feet, in which case
+       all bets are off. *)
     let containing_dir = Path.parent_exn path in
-    (* If the file is absent, we need to wait for it to be created by watching
-       the parent. We still try to add a watch for the file itself after that
-       succeeds, in case the file was created already before we started watching
-       its parent. *)
-    (match Dune_file_watcher.add_watch dune_file_watcher containing_dir with
+    (* If the [path] is absent, we need to wait for it to be created by watching
+       the parent. We still try to add a watch for the [path] itself after that
+       succeeds, in case the [path] was created already before we started
+       watching its parent. *)
+    (match Dune_file_watcher.add_watch watcher containing_dir with
     | Ok () -> ()
     | Error `Does_not_exist ->
       Log.info
-        [ Pp.textf "attempted to add watch to non-existant directory %s"
+        [ Pp.textf "Attempted to add watch to non-existent directory %s."
             (Path.to_string containing_dir)
         ]);
-    match Dune_file_watcher.add_watch dune_file_watcher path with
+    match Dune_file_watcher.add_watch watcher path with
     | Error `Does_not_exist
     | Ok () ->
       ())
 
-let watch_path_using_ref path =
-  match !t_ref with
-  | Initialized { dune_file_watcher = None } -> ()
-  | Initialized { dune_file_watcher = Some watcher } -> watch_path watcher path
-  | Uninitialized paths_to_watch ->
-    t_ref := Uninitialized (path :: paths_to_watch)
+let watch_or_record_path path =
+  match !state with
+  | Waiting_for_file_watcher { paths_to_watch } ->
+    state :=
+      Waiting_for_file_watcher { paths_to_watch = path :: paths_to_watch }
+  | No_file_watcher -> ()
+  | File_watcher dune_file_watcher -> watch_path dune_file_watcher path
 
 (* Files and directories have non-overlapping sets of paths, so we can track
    them using the same memoization table. *)
@@ -75,7 +86,7 @@ let memo =
          In fact, if path disappears then we lose the watch and have to
          re-establish it, so doing it on every computation is sometimes
          necessary. *)
-      watch_path_using_ref path;
+      watch_or_record_path path;
       Memo.Build.return ())
 
 module Update_all = Monoid.Function (Path) (Fs_cache.Update_result)
@@ -113,26 +124,30 @@ let invalidate_path path =
     Memo.Cell.invalidate (Memo.cell memo path) ~reason:(Path_changed path)
 
 let init ~dune_file_watcher =
-  match !t_ref with
-  | Initialized { dune_file_watcher = Some _ } ->
+  match !state with
+  | File_watcher _ ->
     Code_error.raise
       "Called [Fs_memo.init] a second time after a file watcher was already \
-       set up "
+       set up"
       []
-  | Initialized { dune_file_watcher = None } ->
-    (* It would be nice to disallow this to simplify things, but there are tests
-       that call [Scheduler.go] multiple times, therefore [init] gets called
-       multiple times. Since they don't use the file watcher, it shouldn't be a
-       problem. *)
+  | No_file_watcher ->
+    (* It would be nice to disallow this branch to simplify things, but there
+       are tests that call [Scheduler.go] multiple times, therefore [init] gets
+       called multiple times with [dune_file_watcher = None]. Since they don't
+       use the file watcher, it shouldn't be a problem. *)
+    if Option.is_some dune_file_watcher then
+      Code_error.raise
+        "Called [Fs_memo.init] a second time after a file watcher was already \
+         declared as missing"
+        [];
     Memo.Invalidation.empty
-  | Uninitialized accessed_paths ->
-    let res =
-      Memo.Invalidation.reduce (List.map accessed_paths ~f:invalidate_path)
-    in
-    t_ref := Initialized { dune_file_watcher };
-    Option.iter dune_file_watcher ~f:(fun watcher ->
-        List.iter accessed_paths ~f:(fun path -> watch_path watcher path));
-    res
+  | Waiting_for_file_watcher { paths_to_watch } ->
+    (match dune_file_watcher with
+    | None -> state := No_file_watcher
+    | Some watcher ->
+      state := File_watcher watcher;
+      List.iter paths_to_watch ~f:(fun path -> watch_path watcher path));
+    Memo.Invalidation.reduce (List.map paths_to_watch ~f:invalidate_path)
 
 (* Declare a dependency on a path. Instead of calling [depend] directly, you
    should prefer using the helper function [declaring_dependency], because it
@@ -154,7 +169,7 @@ let depend path =
    out explicitly by doing things in the right order.
 
    Currently, we do not expose this low-level primitive. If you need it, perhaps
-   you could add a higher-level primitive instead, such as [path_exists]? *)
+   you could add a higher-level primitive instead, such as [file_exists]? *)
 let declaring_dependency path ~f =
   let+ () = depend path in
   f path
@@ -243,11 +258,11 @@ let invalidate_path_and_its_parent path =
    and robust but doesn't take advantage of all the information we receive. Here
    are some ideas for future optimisation:
 
-   - Don't invalidate [path_exists] queries on [File_changed] events.
+   - Don't invalidate [file_exists] queries on [File_changed] events.
 
-   - If [path_exists] currently returns [true] and we receive a corresponding
+   - If [file_exists] currently returns [true] and we receive a corresponding
    [Deleted] event, we can change the result to [false] without rerunning the
-   [Path.exists] function. Similarly for the case where [path_exists] is [false]
+   [Path.exists] function. Similarly for the case where [file_exists] is [false]
    and we receive a corresponding [Created] event.
 
    - Finally, the result of [dir_contents] queries can be updated without

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -24,13 +24,13 @@ val path_stat :
 val path_kind :
   Path.t -> (File_kind.t, Unix_error.Detailed.t) result Memo.Build.t
 
-(** Digest the contents of a source or external path and declare a dependency on
-    it. When [force_update = true], evict the path from all digest caches and
+(** Digest the contents of a source or external file and declare a dependency on
+    it. When [force_update = true], evict the file from all digest caches and
     force the recomputation of the digest. This can be useful if Dune made a
-    change to the path and therefore knows that the cached digest is stale and
+    change to the file and therefore knows that the cached digest is stale and
     is about to be invalidated by an incoming file-system event. By not using
     the cache in this situation, it's possible to avoid unnecessary restarts. *)
-val path_digest :
+val file_digest :
   ?force_update:bool -> Path.t -> Cached_digest.Digest_result.t Memo.Build.t
 
 (** Like [Io.Untracked.with_lexbuf_from_file] but declares a dependency on the

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -265,14 +265,13 @@ let source_file_digest path =
       ([ Pp.textf "File unavailable: %s" (Path.to_string_maybe_quoted path) ]
       @ details)
   in
-  Fs_memo.path_digest path >>= function
+  Fs_memo.file_digest path >>= function
   | Ok digest -> Memo.Build.return digest
   | No_such_file -> report_user_error []
   | Broken_symlink -> report_user_error [ Pp.text "Broken symlink" ]
   | Unexpected_kind st_kind ->
     report_user_error
-      [ Pp.textf "This is neither a regular file nor a directory (%s)"
-          (File_kind.to_string st_kind)
+      [ Pp.textf "This is not a regular file (%s)" (File_kind.to_string st_kind)
       ]
   | Unix_error (error, _, _) ->
     report_user_error [ Pp.textf "%s" (Unix.error_message error) ]

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -125,7 +125,8 @@ module Workspace_local = struct
       Targets.Produced.of_validated_files targets ~on_dir_target:`Ignore
     in
     Targets.Produced.Option.mapi targets ~f:(fun target () ->
-        Cached_digest.build_file target |> Cached_digest.Digest_result.to_option)
+        Cached_digest.build_file ~allow_dirs:true target
+        |> Cached_digest.Digest_result.to_option)
 
   let lookup_impl ~rule_digest ~targets ~env ~build_deps =
     (* [prev_trace] will be [None] if [head_target] was never built before. *)
@@ -350,7 +351,7 @@ module Shared = struct
         Execution_parameters.should_remove_write_permissions_on_generated_files
           exec_params
       in
-      Cached_digest.refresh ~remove_write_permissions
+      Cached_digest.refresh ~allow_dirs:true ~remove_write_permissions
     in
     match
       Targets.Produced.Option.mapi produced_targets ~f:(fun target () ->

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -218,7 +218,7 @@ let promote ~dir ~(targets : _ Targets.Produced.t) ~promote ~promote_source =
           in
           let+ dst_digest_result =
             Memo.Build.run
-              (Fs_memo.path_digest ~force_update:true (Path.source dst))
+              (Fs_memo.file_digest ~force_update:true (Path.source dst))
           in
           match Cached_digest.Digest_result.to_option dst_digest_result with
           | Some dst_digest ->

--- a/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
@@ -117,19 +117,19 @@ Show that Dune ignores the initial "dune-workspace" events (injected by Dune).
 
   $ cat .#debug-output | grep dune-workspace
   Updating dir_contents cache for "dune-workspace": Skipped
-  Updating path_digest cache for "dune-workspace": Skipped
+  Updating file_digest cache for "dune-workspace": Skipped
   Updating path_stat cache for "dune-workspace": Updated { changed = false }
 
 Dune correctly notices that the contents of . changed because [d1] was created.
 
   $ cat .#debug-output | grep '"."'
   Updating dir_contents cache for ".": Updated { changed = true }
-  Updating path_digest cache for ".": Skipped
+  Updating file_digest cache for ".": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
 
 Here [path_stat] of [d1] changed, because it didn't exist before the build.
 
   $ cat .#debug-output | grep d1
   Updating dir_contents cache for "d1": Updated { changed = false }
-  Updating path_digest cache for "d1": Skipped
+  Updating file_digest cache for "d1": Skipped
   Updating path_stat cache for "d1": Updated { changed = true }

--- a/test/blackbox-tests/test-cases/watching/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/fs-memo.t
@@ -40,9 +40,9 @@ directly and via its parent.
   Updating dir_contents cache for ".": Updated { changed = true }
   Updating dir_contents cache for "file-2": Skipped
   Updating dir_contents cache for "file-2": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for "file-2": Skipped
-  Updating path_digest cache for "file-2": Skipped
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for "file-2": Skipped
+  Updating file_digest cache for "file-2": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
   Updating path_stat cache for "file-2": Skipped
   Updating path_stat cache for "file-2": Skipped
@@ -57,8 +57,8 @@ the glob remains unchanged.
   ------------------------------------------
   Updating dir_contents cache for ".": Updated { changed = true }
   Updating dir_contents cache for "dir": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for "dir": Skipped
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for "dir": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
   Updating path_stat cache for "dir": Skipped
 
@@ -73,9 +73,9 @@ Again, duplicate events for [dir/file-3].
   Updating dir_contents cache for "dir": Updated { changed = true }
   Updating dir_contents cache for "dir/file-3": Skipped
   Updating dir_contents cache for "dir/file-3": Skipped
-  Updating path_digest cache for "dir": Skipped
-  Updating path_digest cache for "dir/file-3": Skipped
-  Updating path_digest cache for "dir/file-3": Skipped
+  Updating file_digest cache for "dir": Skipped
+  Updating file_digest cache for "dir/file-3": Skipped
+  Updating file_digest cache for "dir/file-3": Skipped
   Updating path_stat cache for "dir": Updated { changed = false }
   Updating path_stat cache for "dir/file-3": Skipped
   Updating path_stat cache for "dir/file-3": Skipped
@@ -90,8 +90,8 @@ Again, duplicate events for [file-2].
   ------------------------------------------
   Updating dir_contents cache for "file-2": Skipped
   Updating dir_contents cache for "file-2": Skipped
-  Updating path_digest cache for "file-2": Updated { changed = false }
-  Updating path_digest cache for "file-2": Updated { changed = true }
+  Updating file_digest cache for "file-2": Updated { changed = false }
+  Updating file_digest cache for "file-2": Updated { changed = true }
   Updating path_stat cache for "file-2": Skipped
   Updating path_stat cache for "file-2": Skipped
 
@@ -105,8 +105,8 @@ On deletion of a file, we receive events for the file and the parent directory.
   ------------------------------------------
   Updating dir_contents cache for ".": Updated { changed = true }
   Updating dir_contents cache for "file-2": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for "file-2": Updated { changed = true }
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for "file-2": Updated { changed = true }
   Updating path_stat cache for ".": Updated { changed = false }
   Updating path_stat cache for "file-2": Skipped
 
@@ -127,12 +127,12 @@ we also receive an event about a file inside, which we propagate to the parent.
   Updating dir_contents cache for "dir/file-3": Skipped
   Updating dir_contents cache for "dir/file-3": Skipped
   Updating dir_contents cache for "file-3": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for "dir": Skipped
-  Updating path_digest cache for "dir": Skipped
-  Updating path_digest cache for "dir/file-3": Updated { changed = false }
-  Updating path_digest cache for "dir/file-3": Updated { changed = true }
-  Updating path_digest cache for "file-3": Skipped
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for "dir": Skipped
+  Updating file_digest cache for "dir": Skipped
+  Updating file_digest cache for "dir/file-3": Updated { changed = false }
+  Updating file_digest cache for "dir/file-3": Updated { changed = true }
+  Updating file_digest cache for "file-3": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
   Updating path_stat cache for "dir": Updated { changed = false }
   Updating path_stat cache for "dir": Updated { changed = false }
@@ -147,8 +147,8 @@ we also receive an event about a file inside, which we propagate to the parent.
   ------------------------------------------
   Updating dir_contents cache for "dir": Updated { changed = true }
   Updating dir_contents cache for "dir/subdir": Skipped
-  Updating path_digest cache for "dir": Skipped
-  Updating path_digest cache for "dir/subdir": Skipped
+  Updating file_digest cache for "dir": Skipped
+  Updating file_digest cache for "dir/subdir": Skipped
   Updating path_stat cache for "dir": Updated { changed = false }
   Updating path_stat cache for "dir/subdir": Skipped
 
@@ -163,9 +163,9 @@ Again, duplicate events for [file-4].
   Updating dir_contents cache for "dir/subdir": Updated { changed = true }
   Updating dir_contents cache for "dir/subdir/file-4": Skipped
   Updating dir_contents cache for "dir/subdir/file-4": Skipped
-  Updating path_digest cache for "dir/subdir": Skipped
-  Updating path_digest cache for "dir/subdir/file-4": Skipped
-  Updating path_digest cache for "dir/subdir/file-4": Skipped
+  Updating file_digest cache for "dir/subdir": Skipped
+  Updating file_digest cache for "dir/subdir/file-4": Skipped
+  Updating file_digest cache for "dir/subdir/file-4": Skipped
   Updating path_stat cache for "dir/subdir": Updated { changed = false }
   Updating path_stat cache for "dir/subdir/file-4": Skipped
   Updating path_stat cache for "dir/subdir/file-4": Skipped
@@ -183,12 +183,12 @@ Here we are getting duplicate events for directories [dir] and [dir/subdir].
   Updating dir_contents cache for "dir/subdir": Updated { changed = false }
   Updating dir_contents cache for "dir/subdir": Updated { changed = true }
   Updating dir_contents cache for "subdir": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for "dir": Skipped
-  Updating path_digest cache for "dir": Skipped
-  Updating path_digest cache for "dir/subdir": Skipped
-  Updating path_digest cache for "dir/subdir": Skipped
-  Updating path_digest cache for "subdir": Skipped
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for "dir": Skipped
+  Updating file_digest cache for "dir": Skipped
+  Updating file_digest cache for "dir/subdir": Skipped
+  Updating file_digest cache for "dir/subdir": Skipped
+  Updating file_digest cache for "subdir": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
   Updating path_stat cache for "dir": Updated { changed = false }
   Updating path_stat cache for "dir": Updated { changed = false }
@@ -278,14 +278,14 @@ We receive three events for [file-1] when moving it within the same directory.
   Updating dir_contents cache for "file-1": Skipped
   Updating dir_contents cache for "file-5": Skipped
   Updating dir_contents cache for "file-5": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for ".": Skipped
-  Updating path_digest cache for "file-1": Updated { changed = false }
-  Updating path_digest cache for "file-1": Updated { changed = false }
-  Updating path_digest cache for "file-1": Updated { changed = true }
-  Updating path_digest cache for "file-5": Skipped
-  Updating path_digest cache for "file-5": Skipped
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for ".": Skipped
+  Updating file_digest cache for "file-1": Updated { changed = false }
+  Updating file_digest cache for "file-1": Updated { changed = false }
+  Updating file_digest cache for "file-1": Updated { changed = true }
+  Updating file_digest cache for "file-5": Skipped
+  Updating file_digest cache for "file-5": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
   Updating path_stat cache for ".": Updated { changed = false }
   Updating path_stat cache for ".": Updated { changed = false }

--- a/test/blackbox-tests/test-cases/watching/target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/target-promotion.t
@@ -175,7 +175,7 @@ Show that Dune ignores the initial "dune-workspace" events (injected by Dune).
 
   $ cat .#debug-output | grep dune-workspace
   Updating dir_contents cache for "dune-workspace": Skipped
-  Updating path_digest cache for "dune-workspace": Skipped
+  Updating file_digest cache for "dune-workspace": Skipped
   Updating path_stat cache for "dune-workspace": Updated { changed = false }
 
 Show that Dune ignores "promoted" events. Events for ".#promoted.dune-temp" are
@@ -186,7 +186,7 @@ avoid unnecessarily restarting after receiving the event that it caused itself.
 
   $ cat .#debug-output | grep promoted
   Updating dir_contents cache for "promoted": Skipped
-  Updating path_digest cache for "promoted": Updated { changed = false }
+  Updating file_digest cache for "promoted": Updated { changed = false }
   Updating path_stat cache for "promoted": Skipped
 
 Show that Dune ignores events for the . directory: [dir_contents] didn't change
@@ -196,5 +196,5 @@ change but [fs_memo] does not provide a way to subscribe to it).
 
   $ cat .#debug-output | grep '"."'
   Updating dir_contents cache for ".": Updated { changed = false }
-  Updating path_digest cache for ".": Skipped
+  Updating file_digest cache for ".": Skipped
   Updating path_stat cache for ".": Updated { changed = false }


### PR DESCRIPTION
While working on optimising watching as in #5233, I noticed that `Fs_memo.path_digest` is only called for files (not directories), so I'm changing the API to reflect that. This means it's sufficient to watch such queries only via the parent directory, so it simplifies the upcoming optimisation.

The first commit updates comments in `Fs_memo` and strengthens an assertion: `Fs_memo.init` is now only allowed to be called multiple times if `dune_file_watcher = None`.

The second commit does the actual change.