### PR TITLE
Fix alert message for unstable library APIs

### DIFF
--- a/otherlibs/stdune/stdune.ml
+++ b/otherlibs/stdune/stdune.ml
@@ -1,5 +1,5 @@
 [@@@alert
-unstable "The Fiber API is not stabilized yet and might break without notice."]
+unstable "The API of this library is not stable and may change without notice."]
 
 [@@@alert "-unstable"]
 

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -1,5 +1,5 @@
 [@@@alert
-unstable "The Fiber API is not stabilized yet and might break without notice."]
+unstable "The API of this library is not stable and may change without notice."]
 
 [@@@alert "-unstable"]
 


### PR DESCRIPTION
The alert for Stdune was talking about Fiber due to a copy/paste error. This PR fixes this and also changes the message so that it can be used in any library, so we can just copy unchanged next time.