### PR TITLE
Fix build of configurator with 4.02.3

### DIFF
--- a/otherlibs/configurator/dune
+++ b/otherlibs/configurator/dune
@@ -1,0 +1,3 @@
+(env
+ (_
+  (flags :standard \ -alert=-unstable)))

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -8,8 +8,7 @@
  (flags
   (:standard
    -safe-string
-   (:include flags/flags.sexp)
-   \ -alert=-unstable))
+   (:include flags/flags.sexp)))
  (special_builtin_support
   (configurator
    (api_version 1))))


### PR DESCRIPTION
Remove -alert=-unstable globally, not just for the library.

