### PR TITLE
Remove Rules.produce_opt/collect_opt

### DIFF
--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -126,9 +126,11 @@ let singleton_rule (rule : Rule.t) =
 
 let implicit_output = Memo.Implicit_output.add (module T)
 
-let produce = Memo.Implicit_output.produce implicit_output
-
-let produce_opt = Memo.Implicit_output.produce_opt implicit_output
+let produce rules =
+  if Path.Build.Map.is_empty rules then
+    Memo.Build.return ()
+  else
+    Memo.Implicit_output.produce implicit_output rules
 
 module Produce = struct
   let rule rule = produce (singleton_rule rule)
@@ -174,11 +176,9 @@ let produce_dir ~dir rules =
   | None -> Memo.Build.return ()
   | Some rules -> produce (Path.Build.Map.singleton dir rules)
 
-let collect_opt f = Memo.Implicit_output.collect implicit_output f
-
 let collect f =
   let open Memo.Build.O in
-  let+ result, out = collect_opt f in
+  let+ result, out = Memo.Implicit_output.collect implicit_output f in
   (result, Option.value out ~default:T.empty)
 
 let collect_unit f =

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -100,15 +100,11 @@ val produce_dir : dir:Path.Build.t -> Dir_rules.t -> unit Memo.Build.t
 
 val produce : t -> unit Memo.Build.t
 
-val produce_opt : t option -> unit Memo.Build.t
-
 val is_subset : t -> of_:t -> bool
 
 val map_rules : t -> f:(Rule.t -> Rule.t) -> t
 
 val collect : (unit -> 'a Memo.Build.t) -> ('a * t) Memo.Build.t
-
-val collect_opt : (unit -> 'a Memo.Build.t) -> ('a * t option) Memo.Build.t
 
 val collect_unit : (unit -> unit Memo.Build.t) -> t Memo.Build.t
 

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -183,7 +183,7 @@ end = struct
   type result0_here =
     { t : t
     ; (* [rules] includes rules for subdirectories too *)
-      rules : Rules.t option
+      rules : Rules.t
     ; (* The [kind] of the nodes must be Group_part *)
       subdirs : t Path.Build.Map.t
     }
@@ -261,13 +261,13 @@ end = struct
       Memo.Build.return
         (Here
            { t = empty Standalone ~dir
-           ; rules = None
+           ; rules = Rules.empty
            ; subdirs = Path.Build.Map.empty
            })
     | Standalone (st_dir, d) ->
       let include_subdirs = (Loc.none, Include_subdirs.No) in
       let+ files, rules =
-        Rules.collect_opt (fun () -> load_text_files sctx st_dir d)
+        Rules.collect (fun () -> load_text_files sctx st_dir d)
       in
       let dirs = [ (dir, [], files) ] in
       let ml =
@@ -304,7 +304,7 @@ end = struct
         (loc, Dune_file.Include_subdirs.Include qualif_mode)
       in
       let+ (files, (subdirs : (Path.Build.t * _ * _) list)), rules =
-        Rules.collect_opt (fun () ->
+        Rules.collect (fun () ->
             Memo.Build.fork_and_join
               (fun () -> load_text_files sctx st_dir d)
               (fun () -> collect_group sctx ~st_dir ~dir))
@@ -382,7 +382,7 @@ end = struct
     Memo.exec memo0 (sctx, dir) >>= function
     | See_above group_root -> Memo.Build.return (Group_part group_root)
     | Here { t; rules; subdirs } ->
-      let+ () = Rules.produce_opt rules in
+      let+ () = Rules.produce rules in
       Standalone_or_root (t, Path.Build.Map.values subdirs)
 end
 


### PR DESCRIPTION
These don't seem useful. Instead, optimise `Rules.produce` when given an empty set of rules.
