### PR TITLE
Fix alert flags so that Merlin understands them

### DIFF
--- a/dune
+++ b/dune
@@ -33,4 +33,4 @@
 
 (env
  (_
-  (flags :standard -alert=-unstable)))
+  (flags :standard -alert -unstable)))

--- a/otherlibs/configurator/dune
+++ b/otherlibs/configurator/dune
@@ -1,3 +1,3 @@
 (env
  (_
-  (flags :standard \ -alert=-unstable)))
+  (flags :standard \ -alert -unstable)))


### PR DESCRIPTION
As discussed on Slack, it seems that Merlin behaves differently from the compiler when interpreting `alert` flags. As suggested by @voodoos, I'm tweaking the flags to help Merlin a bit. This solves the issue for me locally.