### PR TITLE
Add a hook to [process.ml] for not overriding TMPDIR

### DIFF
--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -67,3 +67,4 @@ module Reversible_digest = Reversible_digest
 module Report_errors_config = Report_errors_config
 module Compound_user_error = Compound_user_error
 module Reflection = Reflection
+module Dtemp = Dtemp

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -59,6 +59,10 @@ type purpose =
   | Build_job of
       Loc.t option * User_message.Annots.t * Targets.Validated.t option
 
+(* Dune overrides the TMPDIR for all running actions. At Jane Street, we change
+   this behaviour by setting [set_temp_dir_when_running_actions = false]. *)
+val set_temp_dir_when_running_actions : bool ref
+
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its
     termination. [stdout_to] [stderr_to] are released *)
 val run :


### PR DESCRIPTION
We need this for our internal Dune rules because we sometimes need to set `TMPDIR` to other locations.