### PR TITLE
Watch files via parent

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -2,160 +2,171 @@ open! Stdune
 open! Import
 open Memo.Build.O
 
-(* [Fs_memo] can be in three possible states:
+(* A low-level interface for watching paths. It is the responsibility of the
+   caller of [watch] and [invalidate] functions to decide whether to watch a
+   path directly or do it via its parent. *)
+module Watcher : sig
+  val init : dune_file_watcher:Dune_file_watcher.t option -> Memo.Invalidation.t
 
-   - It starts in [Waiting_for_file_watcher], accumulating [paths_to_watch] to
-   pass them to the file watcher once it has been initialised.
+  val watch : Path.t -> unit Memo.Build.t
 
-   - If the file watcher turns out to be missing, the state [No_file_watcher] is
-   used to indicate that there is no need to accumulate [paths_to_watch].
+  val invalidate : Path.t -> Memo.Invalidation.t
+end = struct
+  (* This module can be in three possible states:
 
-   - [File_watcher] holds [Dune_file_watcher.t] once it has been initialised and
-   all previously collected [paths_to_watch] have been passed to it. *)
-type state =
-  | Waiting_for_file_watcher of { paths_to_watch : Path.t list }
-  | No_file_watcher
-  | File_watcher of Dune_file_watcher.t
+     - It starts in [Waiting_for_file_watcher], accumulating [paths_to_watch] to
+     pass them to the file watcher once it has been initialised.
 
-(* Ideally this should be an [Fdecl], but there are currently two reasons why
-   it's not:
+     - If the file watcher turns out to be missing, the state [No_file_watcher]
+     is used to indicate that there is no need to accumulate [paths_to_watch].
 
-   - We read the workspace file before the file watcher has been initialised, so
-   [init] is called after [state] is used. Hence, we accumulate [paths_to_watch]
-   to invalidate and start watching them when [init] is called.
+     - [File_watcher] holds [Dune_file_watcher.t] once it has been initialised
+     and all previously collected [paths_to_watch] have been passed to it. *)
+  type state =
+    | Waiting_for_file_watcher of { paths_to_watch : Path.t list }
+    | No_file_watcher
+    | File_watcher of Dune_file_watcher.t
 
-   - There are tests that call [Scheduler.go] multiple times, therefore [init]
-   gets called multiple times. Since these tests don't use the file watcher, it
-   shouldn't be a problem. *)
-let state = ref (Waiting_for_file_watcher { paths_to_watch = [] })
+  (* Ideally this should be an [Fdecl], but there are currently two reasons why
+     it's not:
 
-(* CR-someday aalekseyev: For [watch_path] to work correctly we need to ensure
-   that the parent directory of [path] exists. That is certainly not guaranteed
-   by the [Fs_memo] API, so we should do something to make it more robust, but I
-   believe that is masked by the fact that we usually (always?) look at the
-   source directory before looking for files in that directory.
+     - We read the workspace file before the file watcher has been initialised,
+     so [init] is called after [state] is used. Hence, we accumulate
+     [paths_to_watch] to invalidate and start watching them when [init] is
+     called.
 
-   It might seem that the [`Does_not_exist] "fall back to the containing dir"
-   trick used below can be extended to fall back all the way to the root, but it
-   can't be because watching the root is not sufficient to receive events for
-   creation of "root/a/b/c/d" -- for that we need to watch "root/a/b/c". *)
-let watch_path watcher path =
-  match Dune_file_watcher.add_watch watcher path with
-  | Ok () -> ()
-  | Error `Does_not_exist -> (
-    (* If we're at the root of the workspace (or the Unix root) then we can't
-       get [`Does_not_exist] because Dune can't start without a workspace and
-       the Unix root always exists. Hence, the [_exn] below can't raise, except
-       if the user deletes the workspace directory under our feet, in which case
-       all bets are off. *)
-    let containing_dir = Path.parent_exn path in
-    (* If the [path] is absent, we need to wait for it to be created by watching
-       the parent. We still try to add a watch for the [path] itself after that
-       succeeds, in case the [path] was created already before we started
-       watching its parent. *)
-    (match Dune_file_watcher.add_watch watcher containing_dir with
-    | Ok () -> ()
-    | Error `Does_not_exist ->
-      Log.info
-        [ Pp.textf "Attempted to add watch to non-existent directory %s."
-            (Path.to_string containing_dir)
-        ]);
+     - There are tests that call [Scheduler.go] multiple times, therefore [init]
+     gets called multiple times. Since these tests don't use the file watcher,
+     it shouldn't be a problem. *)
+  let state = ref (Waiting_for_file_watcher { paths_to_watch = [] })
+
+  (* CR-someday aalekseyev: For [watch_path] to work correctly we need to ensure
+     that the parent directory of [path] exists. That's certainly not guaranteed
+     by the [Fs_memo] API, so we should do something to make it more robust, but
+     I believe that is masked by the fact that we usually (always?) look at the
+     source directory before looking for files in that directory.
+
+     It might seem that the [`Does_not_exist] "fall back to the containing dir"
+     trick used below can be extended to fall back all the way to the root, but
+     it can't be because watching the root is not sufficient to receive events
+     for creation of "root/a/b/c" -- for that we need to watch "root/a/b". *)
+  let watch_path watcher path =
     match Dune_file_watcher.add_watch watcher path with
-    | Error `Does_not_exist
-    | Ok () ->
-      ())
+    | Ok () -> ()
+    | Error `Does_not_exist -> (
+      (* If we're at the root of the workspace (or the Unix root) then we can't
+         get [`Does_not_exist] because Dune can't start without a workspace and
+         the Unix root always exists. Hence, the [_exn] below can't raise,
+         except if the user deletes the workspace directory under our feet, in
+         which case all bets are off. *)
+      let containing_dir = Path.parent_exn path in
+      (* If the [path] is absent, we need to wait for it to be created by
+         watching the parent. We still try to add a watch for the [path] itself
+         after that succeeds, in case the [path] was created already before we
+         started watching its parent. *)
+      (match Dune_file_watcher.add_watch watcher containing_dir with
+      | Ok () -> ()
+      | Error `Does_not_exist ->
+        Log.info
+          [ Pp.textf "Attempted to add watch to non-existent directory %s."
+              (Path.to_string containing_dir)
+          ]);
+      match Dune_file_watcher.add_watch watcher path with
+      | Error `Does_not_exist
+      | Ok () ->
+        ())
 
-let watch_or_record_path path =
-  match !state with
-  | Waiting_for_file_watcher { paths_to_watch } ->
-    state :=
-      Waiting_for_file_watcher { paths_to_watch = path :: paths_to_watch }
-  | No_file_watcher -> ()
-  | File_watcher dune_file_watcher -> watch_path dune_file_watcher path
+  (* Files and directories have non-overlapping sets of paths, so we can track
+     them using the same memoization table. *)
+  let memo =
+    let watch_or_record_path path =
+      match !state with
+      | Waiting_for_file_watcher { paths_to_watch } ->
+        state :=
+          Waiting_for_file_watcher { paths_to_watch = path :: paths_to_watch }
+      | No_file_watcher -> ()
+      | File_watcher dune_file_watcher -> watch_path dune_file_watcher path
+    in
+    Memo.create "fs_memo"
+      ~input:(module Path)
+      (fun path ->
+        (* It may seem weird that we are adding a watch on every invalidation of
+           the cell. This is OK because [add_watch] is idempotent, in the sense
+           that we are not accumulating watches.
 
-(* Files and directories have non-overlapping sets of paths, so we can track
-   them using the same memoization table. *)
-let memo =
-  Memo.create "fs_memo"
-    ~input:(module Path)
-    (fun path ->
-      (* It may seem weird that we are adding a watch on every invalidation of
-         the cell. This is OK because [add_watch] is idempotent, in the sense
-         that we are not accumulating watches.
+           In fact, if path disappears then we lose the watch and have to
+           re-establish it, so doing it on every computation is sometimes
+           necessary. *)
+        watch_or_record_path path;
+        Memo.Build.return ())
 
-         In fact, if path disappears then we lose the watch and have to
-         re-establish it, so doing it on every computation is sometimes
-         necessary. *)
-      watch_or_record_path path;
-      Memo.Build.return ())
+  (* Watch a path. You should call this function *before* accessing the file
+     system to prevent possible races. *)
+  let watch path =
+    if Path.is_in_build_dir path then
+      Code_error.raise "Fs_memo.Watcher.watch called on a build path" [];
+    Memo.exec memo path
 
-module Update_all = Monoid.Function (Path) (Fs_cache.Update_result)
+  module Update_all = Monoid.Function (Path) (Fs_cache.Update_result)
 
-let update_all : Path.t -> Fs_cache.Update_result.t =
-  let update t path =
-    let result = Fs_cache.update t path in
-    if !Clflags.debug_fs_cache then
-      Console.print_user_message
-        (User_message.make
-           [ Pp.hbox
-               (Pp.textf "Updating %s cache for %S: %s" (Fs_cache.Debug.name t)
-                  (Path.to_string path)
-                  (Dyn.to_string (Fs_cache.Update_result.to_dyn result)))
-           ]);
-    result
-  in
-  Update_all.reduce
-    [ update Fs_cache.Untracked.path_stat
-    ; update Fs_cache.Untracked.file_digest
-    ; update Fs_cache.Untracked.dir_contents
-    ]
+  let update_all : Path.t -> Fs_cache.Update_result.t =
+    let update t path =
+      let result = Fs_cache.update t path in
+      if !Clflags.debug_fs_cache then
+        Console.print_user_message
+          (User_message.make
+             [ Pp.hbox
+                 (Pp.textf "Updating %s cache for %S: %s"
+                    (Fs_cache.Debug.name t) (Path.to_string path)
+                    (Dyn.to_string (Fs_cache.Update_result.to_dyn result)))
+             ]);
+      result
+    in
+    Update_all.reduce
+      [ update Fs_cache.Untracked.path_stat
+      ; update Fs_cache.Untracked.file_digest
+      ; update Fs_cache.Untracked.dir_contents
+      ]
 
-(* CR-someday amokhov: We use the same Memo table [memo] for tracking different
-   file-system operations. This saves us some memory, but leads to recomputing
-   more memoized functions than necessary. We could create a separate Memo table
-   for each [Fs_cache] operation, or even better use [Fs_cache] tables in Memo
-   directory, perhaps via [Memo.create_with_store]. *)
-let invalidate_path path =
-  match update_all path with
-  | Skipped
-  | Updated { changed = false } ->
-    Memo.Invalidation.empty
-  | Updated { changed = true } ->
-    Memo.Cell.invalidate (Memo.cell memo path) ~reason:(Path_changed path)
+  (* CR-someday amokhov: We use the same Memo table [memo] for tracking
+     different file-system operations. This saves us some memory, but leads to
+     recomputing more memoized functions than necessary. We could create a
+     separate Memo table for each [Fs_cache] operation, or even better use
+     [Fs_cache] tables in Memo directory, e.g. via [Memo.create_with_store]. *)
+  let invalidate path =
+    match update_all path with
+    | Skipped
+    | Updated { changed = false } ->
+      Memo.Invalidation.empty
+    | Updated { changed = true } ->
+      Memo.Cell.invalidate (Memo.cell memo path) ~reason:(Path_changed path)
 
-let init ~dune_file_watcher =
-  match !state with
-  | File_watcher _ ->
-    Code_error.raise
-      "Called [Fs_memo.init] a second time after a file watcher was already \
-       set up"
-      []
-  | No_file_watcher ->
-    (* It would be nice to disallow this branch to simplify things, but there
-       are tests that call [Scheduler.go] multiple times, therefore [init] gets
-       called multiple times with [dune_file_watcher = None]. Since they don't
-       use the file watcher, it shouldn't be a problem. *)
-    if Option.is_some dune_file_watcher then
+  let init ~dune_file_watcher =
+    match !state with
+    | File_watcher _ ->
       Code_error.raise
         "Called [Fs_memo.init] a second time after a file watcher was already \
-         declared as missing"
-        [];
-    Memo.Invalidation.empty
-  | Waiting_for_file_watcher { paths_to_watch } ->
-    (match dune_file_watcher with
-    | None -> state := No_file_watcher
-    | Some watcher ->
-      state := File_watcher watcher;
-      List.iter paths_to_watch ~f:(fun path -> watch_path watcher path));
-    Memo.Invalidation.reduce (List.map paths_to_watch ~f:invalidate_path)
-
-(* Declare a dependency on a path. Instead of calling [depend] directly, you
-   should prefer using the helper function [declaring_dependency], because it
-   calls [depend] and uses the corresponding path in the right order. *)
-let depend path =
-  if Path.is_in_build_dir path then
-    Code_error.raise "Fs_memo.depend called on a build path" [];
-  Memo.exec memo path
+         set up"
+        []
+    | No_file_watcher ->
+      (* It would be nice to disallow this branch to simplify things, but there
+         are tests that call [Scheduler.go] multiple times, therefore [init]
+         gets called multiple times with [dune_file_watcher = None]. Since they
+         don't use the file watcher, it shouldn't be a problem. *)
+      if Option.is_some dune_file_watcher then
+        Code_error.raise
+          "Called [Fs_memo.init] a second time after a file watcher was \
+           already declared as missing"
+          [];
+      Memo.Invalidation.empty
+    | Waiting_for_file_watcher { paths_to_watch } ->
+      (match dune_file_watcher with
+      | None -> state := No_file_watcher
+      | Some watcher ->
+        state := File_watcher watcher;
+        List.iter paths_to_watch ~f:(fun path -> watch_path watcher path));
+      Memo.Invalidation.reduce (List.map paths_to_watch ~f:invalidate)
+end
 
 (* This does two things, in this order:
 
@@ -171,7 +182,7 @@ let depend path =
    Currently, we do not expose this low-level primitive. If you need it, perhaps
    you could add a higher-level primitive instead, such as [file_exists]? *)
 let declaring_dependency path ~f =
-  let+ () = depend path in
+  let+ () = Watcher.watch path in
   f path
 
 let path_stat = declaring_dependency ~f:Fs_cache.(read Untracked.path_stat)
@@ -249,10 +260,10 @@ let with_lexbuf_from_file path ~f =
 (* When a file or directory is created or deleted, we need to also invalidate
    the parent directory, so that the [dir_contents] queries are re-executed. *)
 let invalidate_path_and_its_parent path =
-  Memo.Invalidation.combine (invalidate_path path)
+  Memo.Invalidation.combine (Watcher.invalidate path)
     (match Path.parent path with
     | None -> Memo.Invalidation.empty
-    | Some path -> invalidate_path path)
+    | Some path -> Watcher.invalidate path)
 
 (* CR-someday amokhov: The way we currently treat file system events is simple
    and robust but doesn't take advantage of all the information we receive. Here
@@ -271,8 +282,10 @@ let invalidate_path_and_its_parent path =
 let handle_fs_event ({ kind; path } : Dune_file_watcher.Fs_memo_event.t) :
     Memo.Invalidation.t =
   match kind with
-  | File_changed -> invalidate_path path
+  | File_changed -> Watcher.invalidate path
   | Created
   | Deleted
   | Unknown ->
     invalidate_path_and_its_parent path
+
+let init = Watcher.init

--- a/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
+++ b/test/blackbox-tests/test-cases/watching/dir-target-promotion.t
@@ -127,9 +127,26 @@ Dune correctly notices that the contents of . changed because [d1] was created.
   Updating file_digest cache for ".": Skipped
   Updating path_stat cache for ".": Updated { changed = false }
 
-Here [path_stat] of [d1] changed, because it didn't exist before the build.
 
-  $ cat .#debug-output | grep d1
+Here [path_stat] of [d1] changed, because it didn't exist before the build. Dune
+later recomputed [path_stat] once again, when [d1/b] was modified, and the
+result remained unchanged (because fields like [mtime] are ignored). The result
+of [dir_contents] also remained unchanged because Dune fixed the listing of [d1]
+by re-promoting the directory target.
+
+  $ cat .#debug-output | grep \"d1\"
   Updating dir_contents cache for "d1": Updated { changed = false }
   Updating file_digest cache for "d1": Skipped
   Updating path_stat cache for "d1": Updated { changed = true }
+  Updating dir_contents cache for "d1": Updated { changed = false }
+  Updating file_digest cache for "d1": Skipped
+  Updating path_stat cache for "d1": Updated { changed = false }
+
+Events below occurred because we replaced file [d1/b] with a directory. Dune
+undid this change to bring the promoted directory target up to date, which
+explains why [file_digest] remained unchanged.
+
+  $ cat .#debug-output | grep d1/b
+  Updating dir_contents cache for "d1/b": Skipped
+  Updating file_digest cache for "d1/b": Updated { changed = false }
+  Updating path_stat cache for "d1/b": Skipped

--- a/test/blackbox-tests/test-cases/watching/what-dune-watches.t
+++ b/test/blackbox-tests/test-cases/watching/what-dune-watches.t
@@ -17,16 +17,16 @@ Show what Dune watches via inotify
   $ dune shutdown
   $ wait
 
-The below pattern excludes absolute files as Dune currently watches
+The pattern below excludes absolute files as Dune currently watches
 everything in the PATH, which is not very reproducible.
 
   $ sed -nE 's/inotify_add_watch\([0-9]*, "([^/].*)", .*\) (=.*)/watch \1 \2/p' ../log
   watch _build/.sync = 1
-  watch dune-workspace = -1 ENOENT (No such file or directory)
   watch . = 2
-  watch dune-workspace = -1 ENOENT (No such file or directory)
+  watch . = 2
   watch . = 2
   watch src = 3
-  watch src/dune = 4
-  watch src/a.ml = 15
-  watch src/b.ml = 16
+  watch . = 2
+  watch src = 3
+  watch src = 3
+  watch src = 3


### PR DESCRIPTION
This continues the work started in #5233: we now watch files by watching their parent directories.

The first commit moves the code around to prepare the change, the second commit makes the change, the third one does some clean up and simplification.