### PR TITLE
Bump odoc lower bound to 2.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ menhir \
 "merlin>=3.4.0" \
 ocamlfind \
 ocamlformat.0.19.0 \
-"odoc>=2.0.0" \
+"odoc>=2.0.1" \
 "ppx_expect>=v0.14" \
 ppx_inline_test \
 ppxlib \

--- a/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
@@ -4,7 +4,7 @@ As configured in the `dune` file at the root, this should be an error:
 
   $ dune build --only-packages=foo_doc @doc
   File "../../../../foo_doc/foo.mld", line 4, characters 0-0:
-  End of text is not allowed in '[...]' (code).
+  Error: End of text is not allowed in '[...]' (code).
   ERROR: Warnings have been generated.
   [1]
 
@@ -12,7 +12,7 @@ Same for documentation in mli files:
 
   $ dune build --only-packages=foo_lib @doc
   File "foo_lib/foo.mli", line 1, characters 7-7:
-  End of text is not allowed in '[...]' (code).
+  Error: End of text is not allowed in '[...]' (code).
   ERROR: Warnings have been generated.
   [1]
 
@@ -20,16 +20,16 @@ These packages are in a nested env, the option is disabled, should success with 
 
   $ dune build --only-packages=bar_doc,bar_lib @doc
   File "../../../../sub_env/bar_doc/bar.mld", line 4, characters 0-0:
-  End of text is not allowed in '[...]' (code).
+  Warning: End of text is not allowed in '[...]' (code).
   File "sub_env/bar_lib/bar.mli", line 1, characters 7-7:
-  End of text is not allowed in '[...]' (code).
+  Warning: End of text is not allowed in '[...]' (code).
 
 In release mode, no error:
 
   $ dune build -p foo_doc,foo_lib @doc
   (cd _build/default/_doc/_odoc/pkg/foo_doc && odoc compile --pkg foo_doc -o page-foo.odoc ../../../../foo_doc/foo.mld)
   File "../../../../foo_doc/foo.mld", line 4, characters 0-0:
-  End of text is not allowed in '[...]' (code).
+  Warning: End of text is not allowed in '[...]' (code).
   (cd _build/default/foo_lib/.foo.objs/byte && odoc compile -I . -I ../../../_doc/_odoc/pkg/foo_lib --pkg foo_lib -o foo.odoc foo.cmti)
   File "foo_lib/foo.mli", line 1, characters 7-7:
-  End of text is not allowed in '[...]' (code).
+  Warning: End of text is not allowed in '[...]' (code).


### PR DESCRIPTION
Our CI jobs started failing with errors [like this](https://github.com/ocaml/dune/runs/4374419587?check_suite_focus=true).

This PR should fix things by switching to newer `odoc`.