### PR TITLE
Add module dependency graphs to Compilation_context.t

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -109,7 +109,7 @@ let gen_rules sctx t ~dir ~scope =
       ~dune_version
   in
   let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
-  let cctx =
+  let* cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info in
     let requires_link = Lib.Compile.requires_link compile_info in
     Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir

--- a/src/dune_rules/compilation_context.mli
+++ b/src/dune_rules/compilation_context.mli
@@ -40,10 +40,10 @@ val create :
   -> ?modes:Dune_file.Mode_conf.Set.Details.t Mode.Dict.t
   -> ?bin_annot:bool
   -> unit
-  -> t
+  -> t Memo.Build.t
 
 (** Return a compilation context suitable for compiling the alias module. *)
-val for_alias_module : t -> t
+val for_alias_module : t -> Module.t -> t
 
 val super_context : t -> Super_context.t
 
@@ -89,7 +89,7 @@ val modes : t -> Mode.Dict.Set.t
 
 val for_wrapped_compat : t -> t
 
-val for_root_module : t -> t
+val for_root_module : t -> Module.t -> t
 
 val for_module_generated_at_link_time :
   t -> requires:Lib.t list Resolve.Build.t -> module_:Module.t -> t
@@ -102,3 +102,8 @@ val bin_annot : t -> bool
 val without_bin_annot : t -> t
 
 val root_module_entries : t -> Module_name.t list Action_builder.t
+
+(** The dependency graph for the modules of the library. *)
+val dep_graphs : t -> Dep_graph.t Ml_kind.Dict.t
+
+val ocamldep_modules_data : t -> Ocamldep.Modules_data.t

--- a/src/dune_rules/ctypes_rules.mli
+++ b/src/dune_rules/ctypes_rules.mli
@@ -6,8 +6,7 @@ val generated_ml_and_c_files : Ctypes_stanza.t -> string list
 val non_installable_modules : Ctypes_stanza.t -> Module_name.t list
 
 val gen_rules :
-     dep_graphs:Dep_graph.t Ml_kind.Dict.t
-  -> cctx:Compilation_context.t
+     cctx:Compilation_context.t
   -> buildable:Dune_file.Buildable.t
   -> loc:Loc.t
   -> scope:Scope.t

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -116,7 +116,8 @@ let dict_of_func_concurrently f =
 let for_module cctx module_ =
   dict_of_func_concurrently (deps_of cctx (Normal module_))
 
-let rules cctx ~modules =
+let rules cctx =
+  let modules = Compilation_context.modules cctx in
   match Modules.as_singleton modules with
   | Some m -> Memo.Build.return (Dep_graph.Ml_kind.dummy m)
   | None ->

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -8,7 +8,4 @@ val for_module :
   -> Module.t
   -> Module.t list Action_builder.t Ml_kind.Dict.t Memo.Build.t
 
-val rules :
-     Compilation_context.t
-  -> modules:Modules.t
-  -> Dep_graph.t Ml_kind.Dict.t Memo.Build.t
+val rules : Compilation_context.t -> Dep_graph.t Ml_kind.Dict.t Memo.Build.t

--- a/src/dune_rules/dep_rules.mli
+++ b/src/dune_rules/dep_rules.mli
@@ -4,8 +4,8 @@ open! Dune_engine
 open Import
 
 val for_module :
-     Compilation_context.t
+     Ocamldep.Modules_data.t
   -> Module.t
   -> Module.t list Action_builder.t Ml_kind.Dict.t Memo.Build.t
 
-val rules : Compilation_context.t -> Dep_graph.t Ml_kind.Dict.t Memo.Build.t
+val rules : Ocamldep.Modules_data.t -> Dep_graph.t Ml_kind.Dict.t Memo.Build.t

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -277,8 +277,7 @@ let link_many ?link_args ?o_files ?(embed_in_plugin_libraries = []) ?sandbox
 let build_and_link_many ?link_args ?o_files ?embed_in_plugin_libraries ?sandbox
     ~programs ~linkages ~promote cctx =
   let open Memo.Build.O in
-  let modules = Compilation_context.modules cctx in
-  let* dep_graphs = Dep_rules.rules cctx ~modules in
+  let* dep_graphs = Dep_rules.rules cctx in
   let* () = Module_compilation.build_all cctx ~dep_graphs in
   link_many ?link_args ?o_files ?embed_in_plugin_libraries ?sandbox ~dep_graphs
     ~programs ~linkages ~promote cctx

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -240,8 +240,7 @@ let link_js ~name ~cm_files ~promote ~link_time_code_gen cctx =
     ~link_time_code_gen:other_cm
 
 let link_many ?link_args ?o_files ?(embed_in_plugin_libraries = []) ?sandbox
-    ~dep_graphs ~programs ~linkages ~promote cctx =
-  let dep_graphs : Dep_graph.t Ml_kind.Dict.t = dep_graphs in
+    ~programs ~linkages ~promote cctx =
   let open Memo.Build.O in
   let modules = Compilation_context.modules cctx in
   let* link_time_code_gen = Link_time_code_gen.handle_special_libs cctx in
@@ -253,7 +252,8 @@ let link_many ?link_args ?o_files ?(embed_in_plugin_libraries = []) ?sandbox
         let obj_dir = CC.obj_dir cctx in
         let top_sorted_modules =
           let main = Option.value_exn (Modules.find modules main_module_name) in
-          Dep_graph.top_closed_implementations dep_graphs.impl [ main ]
+          Dep_graph.top_closed_implementations (CC.dep_graphs cctx).impl
+            [ main ]
         in
         Cm_files.make ~obj_dir ~modules ~top_sorted_modules
           ~ext_obj:ctx.lib_config.ext_obj ()
@@ -277,10 +277,9 @@ let link_many ?link_args ?o_files ?(embed_in_plugin_libraries = []) ?sandbox
 let build_and_link_many ?link_args ?o_files ?embed_in_plugin_libraries ?sandbox
     ~programs ~linkages ~promote cctx =
   let open Memo.Build.O in
-  let* dep_graphs = Dep_rules.rules cctx in
-  let* () = Module_compilation.build_all cctx ~dep_graphs in
-  link_many ?link_args ?o_files ?embed_in_plugin_libraries ?sandbox ~dep_graphs
-    ~programs ~linkages ~promote cctx
+  let* () = Module_compilation.build_all cctx in
+  link_many ?link_args ?o_files ?embed_in_plugin_libraries ?sandbox ~programs
+    ~linkages ~promote cctx
 
 let build_and_link ?link_args ?o_files ?embed_in_plugin_libraries ?sandbox
     ~program ~linkages ~promote cctx =

--- a/src/dune_rules/exe.mli
+++ b/src/dune_rules/exe.mli
@@ -52,7 +52,6 @@ val link_many :
   -> ?o_files:Path.t list
   -> ?embed_in_plugin_libraries:(Loc.t * Lib_name.t) list
   -> ?sandbox:Sandbox_config.t
-  -> dep_graphs:Dep_graph.t Import.Ml_kind.Dict.t
   -> programs:Program.t list
   -> linkages:Linkage.t list
   -> promote:Rule.Promote.t option

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -146,7 +146,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   let explicit_js_mode = Dune_project.explicit_js_mode project in
   let linkages = linkages ctx ~exes ~explicit_js_mode in
   let* flags = Super_context.ocaml_flags sctx ~dir exes.buildable.flags in
-  let cctx =
+  let* cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info in
     let requires_link = Lib.Compile.requires_link compile_info in
     let js_of_ocaml =
@@ -226,14 +226,12 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
          run bits from [Exe.build_and_link_many] and run them here, then pass
          that to the [Exe.link_many] call here as well as the Ctypes_rules. This
          dance is done to avoid triggering duplicate rule exceptions. *)
-      let* dep_graphs = Dep_rules.rules cctx in
       let* () =
         let loc = fst (List.hd exes.Executables.names) in
-        Ctypes_rules.gen_rules ~dep_graphs ~cctx ~buildable ~loc ~sctx ~scope
-          ~dir
+        Ctypes_rules.gen_rules ~cctx ~buildable ~loc ~sctx ~scope ~dir
       in
-      let* () = Module_compilation.build_all cctx ~dep_graphs in
-      Exe.link_many ~programs ~dep_graphs ~linkages ~link_args ~o_files
+      let* () = Module_compilation.build_all cctx in
+      Exe.link_many ~programs ~linkages ~link_args ~o_files
         ~promote:exes.promote ~embed_in_plugin_libraries cctx ~sandbox
   in
   ( cctx

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -226,9 +226,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
          run bits from [Exe.build_and_link_many] and run them here, then pass
          that to the [Exe.link_many] call here as well as the Ctypes_rules. This
          dance is done to avoid triggering duplicate rule exceptions. *)
-      let* dep_graphs =
-        Dep_rules.rules cctx ~modules:(Compilation_context.modules cctx)
-      in
+      let* dep_graphs = Dep_rules.rules cctx in
       let* () =
         let loc = fst (List.hd exes.Executables.names) in
         Ctypes_rules.gen_rules ~dep_graphs ~cctx ~buildable ~loc ~sctx ~scope

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -153,7 +153,7 @@ include Sub_system.Register_end_point (struct
          Action_builder.With_targets.add ~file_targets:[ target ] action)
     and* cctx =
       let package = Dune_file.Library.package lib in
-      let+ ocaml_flags =
+      let* ocaml_flags =
         Super_context.ocaml_flags sctx ~dir info.executable_ocaml_flags
       in
       let flags = Ocaml_flags.append_common ocaml_flags [ "-w"; "-24"; "-g" ] in

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -509,9 +509,7 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope =
     let* cctx =
       cctx lib ~sctx ~source_modules ~dir ~scope ~expander ~compile_info
     in
-    let* dep_graphs =
-      Dep_rules.rules cctx ~modules:(Compilation_context.modules cctx)
-    in
+    let* dep_graphs = Dep_rules.rules cctx in
     let* () =
       let buildable = lib.Library.buildable in
       match buildable.Buildable.ctypes with

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -44,11 +44,7 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name ~lib ~code ~requires
     Compilation_context.for_module_generated_at_link_time cctx ~requires
       ~module_
   in
-  let+ () =
-    Module_compilation.build_module
-      ~dep_graphs:(Dep_graph.Ml_kind.dummy module_)
-      ~precompiled_cmi cctx module_
-  in
+  let+ () = Module_compilation.build_module ~precompiled_cmi cctx module_ in
   Resolve.return module_
 
 let pr buf fmt = Printf.bprintf buf (fmt ^^ "\n")

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -320,7 +320,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
       (Lib_dep.Direct (loc, Lib_name.of_string "mdx.test") :: t.libraries)
       ~pps:[] ~dune_version
   in
-  let cctx =
+  let* cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info
     and requires_link = Lib.Compile.requires_link compile_info in
     Compilation_context.create ~super_context:sctx ~scope ~expander ~obj_dir

--- a/src/dune_rules/menhir.ml
+++ b/src/dune_rules/menhir.ml
@@ -208,7 +208,11 @@ module Run (P : PARAMS) = struct
       Compilation_context.set_sandbox cctx Sandbox_config.needs_sandboxing
       |> Compilation_context.without_bin_annot
     in
-    let* deps = Dep_rules.for_module cctx mock_module in
+    let* deps =
+      Dep_rules.for_module
+        (Compilation_context.ocamldep_modules_data cctx)
+        mock_module
+    in
     let* () =
       Module_compilation.ocamlc_i ~deps cctx mock_module
         ~output:(inferred_mli base)

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -316,11 +316,11 @@ let alias_source modules =
   |> String.concat ~sep:"\n\n"
 
 let build_alias_module cctx alias_module =
+  let modules = Compilation_context.modules cctx in
+  let alias_file () = alias_source modules in
   let cctx = Compilation_context.for_alias_module cctx alias_module in
   let sctx = Compilation_context.super_context cctx in
   let file = Option.value_exn (Module.file alias_module ~ml_kind:Impl) in
-  let modules = Compilation_context.modules cctx in
-  let alias_file () = alias_source modules in
   let dir = Compilation_context.dir cctx in
   let open Memo.Build.O in
   let* () =
@@ -340,6 +340,7 @@ let root_source entries =
   Buffer.contents b
 
 let build_root_module cctx root_module =
+  let entries = Compilation_context.root_module_entries cctx in
   let cctx = Compilation_context.for_root_module cctx root_module in
   let sctx = Compilation_context.super_context cctx in
   let file = Option.value_exn (Module.file root_module ~ml_kind:Impl) in
@@ -350,7 +351,7 @@ let build_root_module cctx root_module =
       (let target = Path.as_in_build_dir_exn file in
        Action_builder.write_file_dyn target
          (let open Action_builder.O in
-         let+ entries = Compilation_context.root_module_entries cctx in
+         let+ entries = entries in
          root_source entries))
   in
   build_module cctx root_module

--- a/src/dune_rules/module_compilation.mli
+++ b/src/dune_rules/module_compilation.mli
@@ -5,8 +5,7 @@ open Import
 
 (** Setup rules to build a single module.*)
 val build_module :
-     dep_graphs:Dep_graph.Ml_kind.t
-  -> ?precompiled_cmi:bool
+     ?precompiled_cmi:bool
   -> Compilation_context.t
   -> Module.t
   -> unit Memo.Build.t
@@ -19,8 +18,7 @@ val ocamlc_i :
   -> output:Path.Build.t
   -> unit Memo.Build.t
 
-val build_all :
-  Compilation_context.t -> dep_graphs:Dep_graph.Ml_kind.t -> unit Memo.Build.t
+val build_all : Compilation_context.t -> unit Memo.Build.t
 
 val with_empty_intf :
   sctx:Super_context.t -> dir:Path.Build.t -> Module.t -> Module.t Memo.Build.t

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -453,6 +453,8 @@ module Old_format = struct
              [ Pp.text "Cannot wrap without main module name or alias module" ]))
 end
 
+let singleton m = Singleton m
+
 let decode ~version ~src_dir ~implements =
   if version <= (1, 10) then
     Old_format.decode ~implements ~src_dir

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -37,6 +37,11 @@ val compat_for_exn : t -> Module.t -> Module.t
 
 val impl_only : t -> Module.t list
 
+(** A set of modules from a single module. Not suitable for single module exe as
+    this produce an unwrapped set of modules. Use [singleton_exe] instead for
+    executables. *)
+val singleton : Module.t -> t
+
 val singleton_exe : Module.t -> t
 
 val fold_no_vlib : t -> init:'acc -> f:(Module.t -> 'acc -> 'acc) -> 'acc

--- a/src/dune_rules/ocamldep.mli
+++ b/src/dune_rules/ocamldep.mli
@@ -3,8 +3,24 @@
 open! Dune_engine
 open Import
 
+module Modules_data : sig
+  (** Various information needed about a set of modules.
+
+      This is a subset of [Compilation_context]. We don't use
+      [Compilation_context] directory as this would create a circular
+      dependency. *)
+  type t =
+    { dir : Path.Build.t
+    ; obj_dir : Path.Build.t Obj_dir.t
+    ; sctx : Super_context.t
+    ; vimpl : Vimpl.t option
+    ; modules : Modules.t
+    ; stdlib : Ocaml_stdlib.t option
+    }
+end
+
 val deps_of :
-     cctx:Compilation_context.t
+     Modules_data.t
   -> ml_kind:Ml_kind.t
   -> Module.t
   -> Module.t list Action_builder.t Memo.Build.t

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -292,7 +292,7 @@ let setup_html sctx (odoc_file : odoc) ~pkg ~requires =
                ]
           :: dummy))
 
-let setup_library_odoc_rules cctx (library : Library.t) ~dep_graphs =
+let setup_library_odoc_rules cctx (library : Library.t) =
   let open Memo.Build.O in
   let* lib =
     let scope = Compilation_context.scope cctx in
@@ -318,7 +318,9 @@ let setup_library_odoc_rules cctx (library : Library.t) ~dep_graphs =
   let modules_and_odoc_files =
     Modules.fold_no_vlib modules ~init:[] ~f:(fun m acc ->
         let compiled =
-          compile_module sctx ~includes ~dep_graphs ~obj_dir ~pkg_or_lnu m
+          compile_module sctx ~includes
+            ~dep_graphs:(Compilation_context.dep_graphs cctx)
+            ~obj_dir ~pkg_or_lnu m
         in
         compiled :: acc)
   in

--- a/src/dune_rules/odoc.mli
+++ b/src/dune_rules/odoc.mli
@@ -6,10 +6,7 @@ open Import
 open Dune_file
 
 val setup_library_odoc_rules :
-     Compilation_context.t
-  -> Library.t
-  -> dep_graphs:Dep_graph.Ml_kind.t
-  -> unit Memo.Build.t
+  Compilation_context.t -> Library.t -> unit Memo.Build.t
 
 val global_rules : Super_context.t -> unit Memo.Build.t
 

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -334,7 +334,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
   in
   let obj_dir = Obj_dir.for_pp ~dir in
   let* cctx =
-    let+ expander = Super_context.expander sctx ~dir in
+    let* expander = Super_context.expander sctx ~dir in
     let requires_compile = Resolve.map driver_and_libs ~f:snd in
     let requires_link =
       Memo.lazy_ (fun () -> Memo.Build.return requires_compile)

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -180,7 +180,7 @@ module Stanza = struct
         [ "-w"; "-24" ]
     in
     let* modules = Source.modules source preprocessing in
-    let cctx =
+    let* cctx =
       Compilation_context.create () ~super_context:sctx ~scope ~obj_dir
         ~expander ~modules ~opaque:(Explicit false) ~requires_compile
         ~requires_link ~flags ~js_of_ocaml:None ~package:None ~preprocessing

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -182,7 +182,7 @@ let setup sctx ~dir =
       (Ocaml_flags.default ~dune_version ~profile)
       [ "-w"; "-24" ]
   in
-  let cctx =
+  let* cctx =
     let requires_link = Memo.lazy_ (fun () -> requires) in
     Compilation_context.create () ~super_context:sctx ~expander ~scope ~obj_dir
       ~modules ~opaque:(Explicit false) ~requires_link


### PR DESCRIPTION
`Compilation_context` represents all the compilation information for a set of modules, so it seems natural to put the dependency graphs there. This simplify the code as it removes a lot of passing along of the dep graphs manually and will help with another PR I'm working on.