### PR TITLE
Fix workspace-local cache for directory targets

### DIFF
--- a/otherlibs/stdune/map.ml
+++ b/otherlibs/stdune/map.ml
@@ -46,6 +46,11 @@ module Make (Key : Key) : S with type key = Key.t = struct
 
   let union a b ~f = union a b ~f
 
+  let union_exn a b =
+    union a b ~f:(fun key _ _ ->
+        Code_error.raise "Map.union_exn: a key appears in both maps"
+          [ ("key", Key.to_dyn key) ])
+
   let compare a b ~compare:f =
     compare a b ~cmp:(fun a b -> Ordering.to_int (f a b)) |> Ordering.of_int
 

--- a/otherlibs/stdune/map_intf.ml
+++ b/otherlibs/stdune/map_intf.ml
@@ -34,6 +34,9 @@ module type S = sig
 
   val union : 'a t -> 'a t -> f:(key -> 'a -> 'a -> 'a option) -> 'a t
 
+  (** Like [union] but raises a code error if a key appears in both maps. *)
+  val union_exn : 'a t -> 'a t -> 'a t
+
   (** [superpose a b] is [b] augmented with bindings of [a] that are not in [b]. *)
   val superpose : 'a t -> 'a t -> 'a t
 

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -352,7 +352,7 @@ end = struct
             | None ->
               (* Directory targets are not allowed for non-sandboxed actions, so
                  the call below should not raise. *)
-              Targets.Produced.of_validated_files targets ~on_dir_target:`Raise
+              Targets.Produced.of_validated_files_exn targets
             | Some sandbox ->
               (* The stamp file for anonymous actions is always created outside
                  the sandbox, so we can't move it. *)

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -72,10 +72,13 @@ module Produced : sig
     ; dirs : 'a String.Map.t Path.Build.Map.t
     }
 
-  (** Returns the given [targets : Validated.t]. Raises a code error if
-      [on_dir_target = `Raise] and [targets.dir] is non-empty. *)
-  val of_validated_files :
-    Validated.t -> on_dir_target:[< `Ignore | `Raise ] -> unit t
+  (** Expand [targets : Validated.t] by recursively traversing directory targets
+      and collecting all contained files. *)
+  val of_validated : Validated.t -> (unit t, Unix_error.Detailed.t) result
+
+  (** Return [targets : Validated.t] with the empty map of [dirs]. Raises a code
+      error if [targets.dir] is not empty. *)
+  val of_validated_files_exn : Validated.t -> unit t
 
   (** Populates only the [files] field, leaving [dirs] empty. Raises a code
       error if the list contains duplicates. *)

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -88,10 +88,11 @@ Build directory target from the command line.
 
 Test that workspace-local cache works for directory targets.
 
-# CR-someday amokhov: Actually, it doesn't work at the moment. We should fix it.
+# CR-someday amokhov: Actually, it doesn't work at the moment, because we clean
+directory targets in [Load_rules.load_dir]. We should fix it.
 
   $ dune build output/x --debug-cache=workspace-local
-  Workspace-local cache miss: _build/default/output: target changed in build dir
+  Workspace-local cache miss: _build/default/output: error while collecting directory targets: Unix error (No such file or directory, opendir, _build/default/output)
 
 Requesting the directory target directly works too.
 


### PR DESCRIPTION
This fixes handling of directory targets when looking them up in the workspace-local cache. Alas, as the error message in the test indicates, we are still getting cache misses because we actually clean up directory targets in `Load_rules.load_dir`.