### PR TITLE
dune-config docs for jobs: document autodetection

### DIFF
--- a/bin/help.ml
+++ b/bin/help.ml
@@ -70,7 +70,7 @@ let config =
     ; `P
         {|Set the maximum number of jobs Dune might run in parallel.
            This can also be set from the command line via $(b,-j NUMBER).|}
-    ; `P {|The default for this value is 4.|}
+    ; `P {|The default for this value is the number of processors.|}
     ; `S "SANDBOXING"
     ; `P {|Syntax: $(b,\(sandboxing_preference MODE ...\))|}
     ; `P


### PR DESCRIPTION
Autodetection was implemented in 53202d0a09 for #530, but this piece of doc was
not updated.

Signed-off-by: Paolo G. Giarrusso <p.giarrusso@gmail.com>