### PR TITLE
Print Unix errors uniformly

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -65,8 +65,9 @@ let resolve_package_install workspace pkg =
 
 let print_unix_error f =
   try f () with
-  | Unix.Unix_error (e, _, _) ->
-    User_message.prerr (User_error.make [ Pp.text (Unix.error_message e) ])
+  | Unix.Unix_error (error, syscall, arg) ->
+    let error = Unix_error.Detailed.create error ~syscall ~arg in
+    User_message.prerr (User_error.make [ Pp.error error ])
 
 module Special_file = struct
   type t =

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -67,7 +67,7 @@ let print_unix_error f =
   try f () with
   | Unix.Unix_error (error, syscall, arg) ->
     let error = Unix_error.Detailed.create error ~syscall ~arg in
-    User_message.prerr (User_error.make [ Pp.error error ])
+    User_message.prerr (User_error.make [ Unix_error.Detailed.pp error ])
 
 module Special_file = struct
   type t =

--- a/otherlibs/action-plugin/src/dune_action_plugin.ml
+++ b/otherlibs/action-plugin/src/dune_action_plugin.ml
@@ -24,8 +24,7 @@ module V1 = struct
       try Ok (f ()) with
       | Unix.Unix_error (error, syscall, arg) ->
         let error = Stdune.Unix_error.Detailed.create error ~syscall ~arg in
-        Error
-          (Stdune.Unix_error.Detailed.to_string_hum ~prefix:(name ^ ": ") error)
+        Error (name ^ ": " ^ Stdune.Unix_error.Detailed.to_string_hum error)
       | Sys_error error -> Error (name ^ ": " ^ error)
 
     let read_directory =

--- a/otherlibs/action-plugin/src/dune_action_plugin.ml
+++ b/otherlibs/action-plugin/src/dune_action_plugin.ml
@@ -22,7 +22,10 @@ module V1 = struct
   end = struct
     let catch_system_exceptions f ~name =
       try Ok (f ()) with
-      | Unix.Unix_error (e, _, _) -> Error (name ^ ": " ^ Unix.error_message e)
+      | Unix.Unix_error (error, syscall, arg) ->
+        let error = Stdune.Unix_error.Detailed.create error ~syscall ~arg in
+        Error
+          (Stdune.Unix_error.Detailed.to_string_hum ~prefix:(name ^ ": ") error)
       | Sys_error error -> Error (name ^ ": " ^ error)
 
     let read_directory =

--- a/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
@@ -293,9 +293,8 @@ module Unix_error = struct
     let equal (a1, b1, c1) (a2, b2, c2) =
       equal a1 a2 && String.equal b1 b2 && String.equal c1 c2
 
-    let to_string_hum ?(prefix = "") (error, syscall, arg) =
-      Format.sprintf "%s%s(%s): %s" prefix syscall arg
-        (Unix.error_message error)
+    let to_string_hum (error, syscall, arg) =
+      Format.sprintf "%s(%s): %s" syscall arg (Unix.error_message error)
   end
 end
 

--- a/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
@@ -293,9 +293,9 @@ module Unix_error = struct
     let equal (a1, b1, c1) (a2, b2, c2) =
       equal a1 a2 && String.equal b1 b2 && String.equal c1 c2
 
-    let to_string (error, syscall, arg) =
-      Format.sprintf "Unix error (%s, %s, %s)" (Unix.error_message error)
-        syscall arg
+    let to_string_hum ?(prefix = "") (error, syscall, arg) =
+      Format.sprintf "%s%s(%s): %s" prefix syscall arg
+        (Unix.error_message error)
   end
 end
 

--- a/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.mli
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.mli
@@ -18,7 +18,7 @@ module Unix_error : sig
 
     val equal : t -> t -> bool
 
-    val to_string : t -> string
+    val to_string_hum : ?prefix:string -> t -> string
   end
 end
 

--- a/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.mli
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.mli
@@ -18,7 +18,7 @@ module Unix_error : sig
 
     val equal : t -> t -> bool
 
-    val to_string_hum : ?prefix:string -> t -> string
+    val to_string_hum : t -> string
   end
 end
 

--- a/otherlibs/stdune/stdune.ml
+++ b/otherlibs/stdune/stdune.ml
@@ -27,6 +27,7 @@ module Map = Map
 module Option = Option
 module Or_exn = Or_exn
 module Ordering = Ordering
+module Pp = Pp
 module Result = Result
 module Set = Set
 module Signal = Signal
@@ -84,14 +85,10 @@ module Unix_error = struct
         ; ("syscall", String syscall)
         ; ("arg", String arg)
         ]
+
+    let pp ?(prefix = "") unix_error =
+      Pp.verbatim (prefix ^ to_string_hum unix_error)
   end
-end
-
-module Pp = struct
-  include Pp
-
-  let error ?prefix unix_error =
-    Pp.verbatim (Unix_error.Detailed.to_string_hum ?prefix unix_error)
 end
 
 module File_kind = struct

--- a/otherlibs/stdune/stdune.ml
+++ b/otherlibs/stdune/stdune.ml
@@ -27,7 +27,6 @@ module Map = Map
 module Option = Option
 module Or_exn = Or_exn
 module Ordering = Ordering
-module Pp = Pp
 module Result = Result
 module Set = Set
 module Signal = Signal
@@ -86,6 +85,13 @@ module Unix_error = struct
         ; ("arg", String arg)
         ]
   end
+end
+
+module Pp = struct
+  include Pp
+
+  let error ?prefix unix_error =
+    Pp.verbatim (Unix_error.Detailed.to_string_hum ?prefix unix_error)
 end
 
 module File_kind = struct

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -46,9 +46,7 @@ let list_entries ~storage =
   match Path.readdir_unsorted storage >>= Result.List.concat_map ~f:entries with
   | Ok res -> res
   | Error (ENOENT, _, _) -> []
-  | Error (e, _syscall, _arg) ->
-    (* CR-someday amokhov: Print [_syscall] and [_arg] too to help debugging. *)
-    User_error.raise [ Pp.text (Unix.error_message e) ]
+  | Error unix_error -> User_error.raise [ Pp.error unix_error ]
 
 module Versioned = struct
   let metadata_storage_dir t = root_dir / "meta" / Version.Metadata.to_string t

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -46,7 +46,7 @@ let list_entries ~storage =
   match Path.readdir_unsorted storage >>= Result.List.concat_map ~f:entries with
   | Ok res -> res
   | Error (ENOENT, _, _) -> []
-  | Error unix_error -> User_error.raise [ Pp.error unix_error ]
+  | Error unix_error -> User_error.raise [ Unix_error.Detailed.pp unix_error ]
 
 module Versioned = struct
   let metadata_storage_dir t = root_dir / "meta" / Version.Metadata.to_string t

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -69,7 +69,7 @@ let get_dir_triage ~dir =
             | Error unix_error ->
               User_warning.emit
                 [ Pp.textf "Unable to read %s" (Path.to_string_maybe_quoted dir)
-                ; Pp.error ~prefix:"Reason: " unix_error
+                ; Unix_error.Detailed.pp ~prefix:"Reason: " unix_error
                 ];
               Path.Set.empty
             | Ok filenames -> Path.Set.of_listing ~dir ~filenames))

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -66,12 +66,10 @@ let get_dir_triage ~dir =
          (Non_build
             (match Path.Untracked.readdir_unsorted dir with
             | Error (Unix.ENOENT, _, _) -> Path.Set.empty
-            | Error (e, _syscall, _arg) ->
-              (* CR-someday amokhov: Print [_syscall] and [_arg] too to help
-                 debugging. *)
+            | Error unix_error ->
               User_warning.emit
                 [ Pp.textf "Unable to read %s" (Path.to_string_maybe_quoted dir)
-                ; Pp.textf "Reason: %s" (Unix.error_message e)
+                ; Pp.error ~prefix:"Reason: " unix_error
                 ];
               Path.Set.empty
             | Ok filenames -> Path.Set.of_listing ~dir ~filenames))

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -109,8 +109,8 @@ module Workspace_local = struct
         | Always_rerun -> "not trying to use the cache"
         | Dynamic_deps_changed -> "dynamic dependencies changed"
         | Error_while_collecting_directory_targets unix_error ->
-          sprintf "error while collecting directory targets: %s"
-            (Unix_error.Detailed.to_string unix_error)
+          Unix_error.Detailed.to_string_hum
+            ~prefix:"error while collecting directory targets: " unix_error
       in
       Console.print_user_message
         (User_message.make
@@ -372,41 +372,28 @@ module Shared = struct
           | Ok (_ : Digest.t) -> (missing, errors)
           | No_such_file -> (target :: missing, errors)
           | Broken_symlink ->
-            let error = [ Pp.verbatim "Broken symlink" ] in
+            let error = Pp.verbatim "Broken symlink" in
             (missing, (target, error) :: errors)
           | Unexpected_kind file_kind ->
             let error =
-              [ Pp.verbatim
-                  (sprintf "Unexpected file kind %S (%s)"
-                     (File_kind.to_string file_kind)
-                     (File_kind.to_string_hum file_kind))
-              ]
+              Pp.verbatim
+                (sprintf "Unexpected file kind %S (%s)"
+                   (File_kind.to_string file_kind)
+                   (File_kind.to_string_hum file_kind))
             in
             (missing, (target, error) :: errors)
-          | Unix_error (error, syscall, path) ->
-            let error =
-              [ (if String.equal expected_syscall_path path then
-                  Pp.verbatim syscall
-                else
-                  Pp.concat
-                    [ Pp.verbatim syscall
-                    ; Pp.verbatim " "
-                    ; Pp.verbatim (String.maybe_quoted path)
-                    ])
-              ; Pp.text (Unix.error_message error)
-              ]
-            in
-            (missing, (target, error) :: errors)
+          | Unix_error (error, syscall, arg) ->
+            let unix_error = Unix_error.Detailed.create error ~syscall ~arg in
+            (missing, (target, Pp.error unix_error) :: errors)
           | Error exn ->
             let error =
               match exn with
               | Sys_error msg ->
-                [ Pp.verbatim
-                    (String.drop_prefix_if_exists
-                       ~prefix:(expected_syscall_path ^ ": ")
-                       msg)
-                ]
-              | exn -> [ Pp.verbatim (Printexc.to_string exn) ]
+                Pp.verbatim
+                  (String.drop_prefix_if_exists
+                     ~prefix:(expected_syscall_path ^ ": ")
+                     msg)
+              | exn -> Pp.verbatim (Printexc.to_string exn)
             in
             (missing, (target, error) :: errors)
         in
@@ -434,7 +421,7 @@ module Shared = struct
             [ Pp.textf "Error trying to read targets after a rule was run:"
             ; Pp.enumerate (List.rev errors) ~f:(fun (target, error) ->
                   Pp.concat ~sep:(Pp.verbatim ": ")
-                    (Path.pp (Path.build target) :: error))
+                    [ Path.pp (Path.build target); error ])
             ]))
 
   let examine_targets_and_store ~can_go_in_shared_cache ~loc ~rule_digest

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -109,8 +109,8 @@ module Workspace_local = struct
         | Always_rerun -> "not trying to use the cache"
         | Dynamic_deps_changed -> "dynamic dependencies changed"
         | Error_while_collecting_directory_targets unix_error ->
-          Unix_error.Detailed.to_string_hum
-            ~prefix:"error while collecting directory targets: " unix_error
+          sprintf "error while collecting directory targets: %s"
+            (Unix_error.Detailed.to_string_hum unix_error)
       in
       Console.print_user_message
         (User_message.make
@@ -384,7 +384,7 @@ module Shared = struct
             (missing, (target, error) :: errors)
           | Unix_error (error, syscall, arg) ->
             let unix_error = Unix_error.Detailed.create error ~syscall ~arg in
-            (missing, (target, Pp.error unix_error) :: errors)
+            (missing, (target, Unix_error.Detailed.pp unix_error) :: errors)
           | Error exn ->
             let error =
               match exn with

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -174,7 +174,7 @@ end = struct
                (Path.Source.relative
                   (Path.Source.parent_exn path)
                   Dune_file.fname))
-        ; Pp.error ~prefix:"Reason: " unix_error
+        ; Unix_error.Detailed.pp ~prefix:"Reason: " unix_error
         ];
       Memo.Build.return (Error unix_error)
     | Ok dir_contents ->
@@ -537,7 +537,7 @@ end = struct
       User_error.raise
         [ Pp.textf "Unable to load source %s."
             (Path.Source.to_string_maybe_quoted path)
-        ; Pp.error ~prefix:"Reason: " unix_error
+        ; Unix_error.Detailed.pp ~prefix:"Reason: " unix_error
         ]
     in
     let* readdir =

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -163,9 +163,7 @@ end = struct
 
   let of_source_path_impl path =
     Fs_memo.dir_contents (Path.source path) >>= function
-    | Error ((unix_error, _syscall, _arg) as detailed_unix_error) ->
-      (* CR-someday amokhov: Print [_syscall] and [_arg] too to help
-         debugging. *)
+    | Error unix_error ->
       User_warning.emit
         [ Pp.textf "Unable to read directory %s. Ignoring."
             (Path.Source.to_string_maybe_quoted path)
@@ -176,9 +174,9 @@ end = struct
                (Path.Source.relative
                   (Path.Source.parent_exn path)
                   Dune_file.fname))
-        ; Pp.textf "Reason: %s" (Unix.error_message unix_error)
+        ; Pp.error ~prefix:"Reason: " unix_error
         ];
-      Memo.Build.return (Error detailed_unix_error)
+      Memo.Build.return (Error unix_error)
     | Ok dir_contents ->
       let dir_contents = Fs_cache.Dir_contents.to_list dir_contents in
       let+ files, dirs =
@@ -535,20 +533,17 @@ end = struct
   let root () =
     let path = Path.Source.root in
     let dir_status : Sub_dirs.Status.t = Normal in
-    let error_unable_to_load ~path error =
+    let error_unable_to_load ~path unix_error =
       User_error.raise
-        [ Pp.textf "Unable to load source %s.@.Reason:%s@."
+        [ Pp.textf "Unable to load source %s."
             (Path.Source.to_string_maybe_quoted path)
-            (Unix.error_message error)
+        ; Pp.error ~prefix:"Reason: " unix_error
         ]
     in
     let* readdir =
       Readdir.of_source_path path >>| function
       | Ok dir -> dir
-      | Error (e, _syscall, _arg) ->
-        (* CR-someday amokhov: Print [_syscall] and [_arg] too to help
-           debugging. *)
-        error_unable_to_load ~path e
+      | Error unix_error -> error_unable_to_load ~path unix_error
     in
     let project =
       match
@@ -563,7 +558,7 @@ end = struct
     let* dirs_visited =
       File.of_source_path path >>| function
       | Ok file -> Dirs_visited.singleton path file
-      | Error (e, _, _) -> error_unable_to_load ~path e
+      | Error unix_error -> error_unable_to_load ~path unix_error
     in
     let+ contents, visited =
       contents readdir ~dirs_visited ~project ~dir_status

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -134,8 +134,7 @@ let promote ~dir ~(targets : _ Targets.Produced.t) ~promote ~promote_source =
         let extra_messages =
           match unix_error with
           | None -> []
-          | Some error ->
-            [ Pp.textf "Reason: %s." (Unix_error.Detailed.to_string error) ]
+          | Some error -> [ Pp.error ~prefix:"Reason: " error ]
         in
         User_error.raise ~loc
           (msg (Path.Source.to_string into_dir) :: extra_messages)
@@ -158,8 +157,7 @@ let promote ~dir ~(targets : _ Targets.Produced.t) ~promote ~promote_source =
     let msgs =
       match unix_error with
       | None -> msgs
-      | Some error ->
-        Pp.textf "Reason: %s." (Unix_error.Detailed.to_string error) :: msgs
+      | Some error -> Pp.error ~prefix:"Reason: " error :: msgs
     in
     User_error.raise
       (Pp.textf "Cannot promote files to %S." (Path.to_string dst_dir) :: msgs)

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -134,7 +134,7 @@ let promote ~dir ~(targets : _ Targets.Produced.t) ~promote ~promote_source =
         let extra_messages =
           match unix_error with
           | None -> []
-          | Some error -> [ Pp.error ~prefix:"Reason: " error ]
+          | Some error -> [ Unix_error.Detailed.pp ~prefix:"Reason: " error ]
         in
         User_error.raise ~loc
           (msg (Path.Source.to_string into_dir) :: extra_messages)
@@ -157,7 +157,7 @@ let promote ~dir ~(targets : _ Targets.Produced.t) ~promote ~promote_source =
     let msgs =
       match unix_error with
       | None -> msgs
-      | Some error -> Pp.error ~prefix:"Reason: " error :: msgs
+      | Some error -> Unix_error.Detailed.pp ~prefix:"Reason: " error :: msgs
     in
     User_error.raise
       (Pp.textf "Cannot promote files to %S." (Path.to_string dst_dir) :: msgs)

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -67,11 +67,11 @@ let get_error_from_exn = function
     { responsible = User; msg; has_embedded_location; needs_stack_trace }
   | Code_error.E e ->
     code_error ~loc:e.loc ~dyn_without_loc:(Code_error.to_dyn_without_loc e)
-  | Unix.Unix_error (err, func, fname) ->
+  | Unix.Unix_error (error, syscall, arg) ->
     { responsible = User
     ; msg =
         User_error.make
-          [ Pp.textf "%s: %s: %s" func fname (Unix.error_message err) ]
+          [ Pp.error (Unix_error.Detailed.create error ~syscall ~arg) ]
     ; has_embedded_location = false
     ; needs_stack_trace = false
     }

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -71,7 +71,9 @@ let get_error_from_exn = function
     { responsible = User
     ; msg =
         User_error.make
-          [ Pp.error (Unix_error.Detailed.create error ~syscall ~arg) ]
+          [ Unix_error.Detailed.pp
+              (Unix_error.Detailed.create error ~syscall ~arg)
+          ]
     ; has_embedded_location = false
     ; needs_stack_trace = false
     }

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -92,7 +92,7 @@ Test that workspace-local cache works for directory targets.
 directory targets in [Load_rules.load_dir]. We should fix it.
 
   $ dune build output/x --debug-cache=workspace-local
-  Workspace-local cache miss: _build/default/output: error while collecting directory targets: Unix error (No such file or directory, opendir, _build/default/output)
+  Workspace-local cache miss: _build/default/output: error while collecting directory targets: opendir(_build/default/output): No such file or directory
 
 Requesting the directory target directly works too.
 

--- a/test/blackbox-tests/test-cases/unreadable-src.t/run.t
+++ b/test/blackbox-tests/test-cases/unreadable-src.t/run.t
@@ -4,5 +4,5 @@
   Remove this message by ignoring by adding:
   (dirs \ foo)
   to the dune file: dune
-  Reason: Permission denied
+  Reason: opendir(foo): Permission denied
   $ chmod +r foo && rm -rf foo

--- a/test/blackbox-tests/test-cases/watching/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/fs-memo.t
@@ -199,9 +199,9 @@ If we repeat the test, we finally see the failure.
   How about now?
   Failure
   ------------------------------------------
-  Error: inotify_add_watch: subdir: Permission denied
+  Error: inotify_add_watch(subdir): Permission denied
   Had errors, waiting for filesystem changes...
-  Error: inotify_add_watch: subdir: Permission denied
+  Error: inotify_add_watch(subdir): Permission denied
   Had errors, waiting for filesystem changes...
   ------------------------------------------
 
@@ -211,9 +211,9 @@ Same problem in the other direction.
   Failure
   Failure
   ------------------------------------------
-  Error: inotify_add_watch: subdir: Permission denied
+  Error: inotify_add_watch(subdir): Permission denied
   Had errors, waiting for filesystem changes...
-  Error: inotify_add_watch: subdir: Permission denied
+  Error: inotify_add_watch(subdir): Permission denied
   Had errors, waiting for filesystem changes...
   ------------------------------------------
 

--- a/test/expect-tests/dune_action_plugin/dune_action_test.ml
+++ b/test/expect-tests/dune_action_plugin/dune_action_test.ml
@@ -61,8 +61,9 @@ let%expect_test _ =
     |> map ~f:ignore
   in
   run_action_expect_throws action;
-  [%expect {|
-    read_directory: No such file or directory
+  [%expect
+    {|
+    read_directory: opendir(directory_that_does_not_exist): No such file or directory
   |}]
 
 let%expect_test _ =


### PR DESCRIPTION
As suggested by @jeremiedimino, I'm making the way we print Unix errors more uniform.

This also addresses a few CR-somedays in the code.