### PR TITLE
Remove uchar and seq dummy modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Remove `uchar` and `seq` dummy ocamlfind libraries from dune's builtin
+  library database (#5260, @kit-ty-kate)
+
 - Add a `DUNE_DIFF_COMMAND` environment variable to match `--diff-command`
   command-line parameter (@raphael-proust, fix #5369, #5375)
 

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -232,8 +232,6 @@ let builtins ~stdlib_dir ~version:ocaml_version =
   in
   let dynlink = simple "dynlink" [] ~dir:"+" in
   let bytes = dummy "bytes" in
-  let uchar = dummy "uchar" in
-  let seq = dummy "seq" in
   let threads =
     { name = Some (Lib_name.of_string "threads")
     ; entries =
@@ -278,14 +276,6 @@ let builtins ~stdlib_dir ~version:ocaml_version =
     in
     let base =
       if Ocaml_version.has_bigarray_library ocaml_version then bigarray :: base
-      else base
-    in
-    let base =
-      if Ocaml_version.stdlib_includes_uchar ocaml_version then uchar :: base
-      else base
-    in
-    let base =
-      if Ocaml_version.stdlib_includes_seq ocaml_version then seq :: base
       else base
     in
     let base =

--- a/src/dune_rules/ocaml_version.ml
+++ b/src/dune_rules/ocaml_version.ml
@@ -20,11 +20,7 @@ let supports_response_file version = version >= (4, 05, 0)
 
 let ocamlmklib_supports_response_file version = version >= (4, 08, 0)
 
-let stdlib_includes_uchar version = version >= (4, 03, 0)
-
 let stdlib_includes_bigarray version = version >= (4, 07, 0)
-
-let stdlib_includes_seq version = version >= (4, 07, 0)
 
 let ooi_supports_no_approx version = version >= (4, 05, 0)
 

--- a/src/dune_rules/ocaml_version.mli
+++ b/src/dune_rules/ocaml_version.mli
@@ -29,14 +29,8 @@ val supports_response_file : t -> bool
 (** Does ocamlmklib support [-args0]? *)
 val ocamlmklib_supports_response_file : t -> bool
 
-(** Whether the standard library includes the [Uchar] module *)
-val stdlib_includes_uchar : t -> bool
-
 (** Whether the standard library includes the [Bigarray] module *)
 val stdlib_includes_bigarray : t -> bool
-
-(** Whether the standard library includes the [Seq] module *)
-val stdlib_includes_seq : t -> bool
 
 (** Whether ocamlobjinfo supports -no-approx*)
 val ooi_supports_no_approx : t -> bool


### PR DESCRIPTION
They all have their own opam package and were never defined in neither the compiler on ocamlfind.
`result` was removed from dune 3.0 for the same reason, I think uchar and seq should probably go too.