### PR TITLE
Stop generation the same rules over and over

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -32,7 +32,7 @@ val build_pred : File_selector.t -> Dep.Fact.Files.t Memo.Build.t
 val package_deps :
      packages_of:(Path.Build.t -> Package.Id.Set.t Memo.Build.t)
   -> Package.t
-  -> Path.Set.t
+  -> Path.Build.t list
   -> Package.Id.Set.t Memo.Build.t
 
 (** Execute an action. The execution is cached. *)

--- a/src/dune_engine/install.ml
+++ b/src/dune_engine/install.ml
@@ -365,9 +365,6 @@ module Metadata = struct
     | UserDefinedEntry of 'src Entry.t
 end
 
-let files entries =
-  Path.Set.of_list_map entries ~f:(fun (entry : Path.t Entry.t) -> entry.src)
-
 let group entries =
   List.map entries ~f:(fun (entry : _ Entry.t) -> (entry.section, entry))
   |> Section.Map.of_list_multi

--- a/src/dune_engine/install.mli
+++ b/src/dune_engine/install.mli
@@ -134,8 +134,6 @@ module Metadata : sig
     | UserDefinedEntry of 'src Entry.t
 end
 
-val files : Path.t Entry.t list -> Path.Set.t
-
 val gen_install_file : Path.t Entry.t list -> string
 
 val load_install_file : Path.t -> Path.t Entry.t list

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -96,7 +96,9 @@ val empty : t
 
 val union : t -> t -> t
 
-val produce_dir : dir:Path.Build.t -> Dir_rules.t -> unit Memo.Build.t
+val of_dir_rules : dir:Path.Build.t -> Dir_rules.t -> t
+
+val of_rules : Rule.t list -> t
 
 val produce : t -> unit Memo.Build.t
 

--- a/src/dune_engine/subdir_set.ml
+++ b/src/dune_engine/subdir_set.ml
@@ -20,6 +20,10 @@ let of_list l = These (String.Set.of_list l)
 
 let empty = These String.Set.empty
 
+let is_empty = function
+  | All -> false
+  | These set -> String.Set.is_empty set
+
 let mem t dir =
   match t with
   | All -> true

--- a/src/dune_engine/subdir_set.mli
+++ b/src/dune_engine/subdir_set.mli
@@ -14,6 +14,8 @@ val of_list : string list -> t
 
 val empty : t
 
+val is_empty : t -> bool
+
 val mem : t -> string -> bool
 
 val union : t -> t -> t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -444,7 +444,7 @@ let gen_rules ctx_or_install ~dir components =
   | Install ctx ->
     Super_context.find ctx
     >>= Memo.Build.Option.map ~f:(fun sctx ->
-            Rules.collect (fun () -> Install_rules.gen_rules sctx ~dir))
+            Install_rules.symlink_rules sctx ~dir)
   | Context ctx ->
     Super_context.find ctx
     >>= Memo.Build.Option.map ~f:(fun sctx ->

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -322,9 +322,14 @@ let gen_rules sctx dir_contents cctxs ~source_dir ~dir :
     in
     []
 
+(* To be called once per project, when we are generating the rules for the root
+   diretory of the project *)
+let gen_project_rules sctx project =
+  let* () = Opam_create.add_rules sctx project in
+  Install_rules.meta_and_dune_package_rules sctx project
+
 let gen_rules ~sctx ~dir components =
   let module S = Subdir_set in
-  let* () = Install_rules.meta_and_dune_package_rules sctx ~dir in
   let+ subdirs_to_keep1 = Install_rules.gen_rules sctx ~dir
   and+ (subdirs_to_keep2 : Build_config.extra_sub_directories_to_keep) =
     match components with
@@ -389,7 +394,7 @@ let gen_rules ~sctx ~dir components =
                      (Dune_project.root project))
                   dir
               then
-                Opam_create.add_rules sctx project
+                gen_project_rules sctx project
               else
                 Memo.Build.return ()
             in

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -326,12 +326,11 @@ let gen_rules sctx dir_contents cctxs ~source_dir ~dir :
    diretory of the project *)
 let gen_project_rules sctx project =
   let* () = Opam_create.add_rules sctx project in
-  Install_rules.meta_and_dune_package_rules sctx project
+  Install_rules.gen_project_rules sctx project
 
 let gen_rules ~sctx ~dir components =
   let module S = Subdir_set in
-  let+ subdirs_to_keep1 = Install_rules.gen_rules sctx ~dir
-  and+ (subdirs_to_keep2 : Build_config.extra_sub_directories_to_keep) =
+  let+ (subdirs_to_keep1 : Build_config.extra_sub_directories_to_keep) =
     match components with
     | [ ".dune"; "ccomp" ] ->
       (* Add rules for C compiler detection *)
@@ -411,13 +410,13 @@ let gen_rules ~sctx ~dir components =
       in
       S.These (String.Set.of_list subdirs)
   in
-  let subdirs_to_keep3 =
+  let subdirs_to_keep2 =
     match components with
     | [] ->
       Subdir_set.These (String.Set.of_list [ ".js"; "_doc"; ".ppx"; ".dune" ])
     | _ -> These String.Set.empty
   in
-  Subdir_set.union_all [ subdirs_to_keep1; subdirs_to_keep2; subdirs_to_keep3 ]
+  Subdir_set.union_all [ subdirs_to_keep1; subdirs_to_keep2 ]
 
 let gen_rules ~sctx ~dir components =
   let module S = Subdir_set in

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -728,7 +728,7 @@ let symlink_installed_artifacts_to_build_install sctx
     (entries : Install.Entry.Sourced.t list) ~install_paths =
   let ctx = Super_context.context sctx in
   let install_dir = Local_install_path.dir ~context:ctx.name in
-  Memo.Build.parallel_map entries ~f:(fun (s : Install.Entry.Sourced.t) ->
+  Memo.Build.sequential_map entries ~f:(fun (s : Install.Entry.Sourced.t) ->
       let entry = s.entry in
       let dst =
         let relative =
@@ -747,7 +747,7 @@ let symlink_installed_artifacts_to_build_install sctx
         Super_context.add_rule sctx ~loc ~dir:ctx.build_dir
           (Action_builder.symlink ~src:(Path.build entry.src) ~dst)
       in
-      Install.Entry.set_src entry (Path.build dst))
+      { s with entry = Install.Entry.set_src entry dst })
 
 let promote_install_file (ctx : Context.t) =
   !Clflags.promote_install_files
@@ -794,19 +794,50 @@ let packages_file_is_part_of path =
     let+ map = packages sctx in
     Option.value (Path.Build.Map.find map path) ~default:Package.Id.Set.empty
 
-let install_rules sctx (package : Package.t) =
+module Sctx_and_package = struct
+  module Super_context = Super_context.As_memo_key
+
+  type t = Super_context.t * Package.t
+
+  let hash (x, y) = Hashtbl.hash (Super_context.hash x, Package.hash y)
+
+  let equal (x1, y1) (x2, y2) = x1 == x2 && y1 == y2
+
+  let to_dyn _ = Dyn.Opaque
+end
+
+let symlinked_entries sctx package =
+  Rules.collect (fun () ->
+      let package_name = Package.name package in
+      let install_paths =
+        Install.Section.Paths.make ~package:package_name ~destdir:Path.root ()
+      in
+      install_entries sctx package
+      >>= symlink_installed_artifacts_to_build_install sctx ~install_paths)
+
+let symlinked_entries =
+  let memo =
+    Memo.create
+      ~input:(module Sctx_and_package)
+      ~human_readable_description:(fun (_, pkg) ->
+        Pp.textf "Computing installable artifacts for package %s"
+          (Package.Name.to_string (Package.name pkg)))
+      "symlinked_entries"
+      (fun (sctx, pkg) -> symlinked_entries sctx pkg)
+  in
+  fun sctx pkg -> Memo.exec memo (sctx, pkg)
+
+let gen_package_install_file_rules sctx (package : Package.t) =
   let package_name = Package.name package in
   let install_paths =
     Install.Section.Paths.make ~package:package_name ~destdir:Path.root ()
   in
-  let* entries_with_metadata = install_entries sctx package in
-  let* entries =
-    entries_with_metadata
-    |> symlink_installed_artifacts_to_build_install sctx ~install_paths
-  in
+  let* entries = symlinked_entries sctx package >>| fst in
   let ctx = Super_context.context sctx in
   let pkg_build_dir = Package_paths.build_dir ctx package in
-  let files = Install.files entries in
+  let files =
+    List.map entries ~f:(fun (e : Install.Entry.Sourced.t) -> e.entry.src)
+  in
   let dune_project =
     let scope = Super_context.find_scope_by_dir sctx pkg_build_dir in
     Scope.project scope
@@ -841,6 +872,7 @@ let install_rules sctx (package : Package.t) =
                    Pp.text (Package.Name.to_string name))
           ]
   in
+  let files = Path.Set.of_list_map files ~f:Path.build in
   let* () =
     let context = Context.build_context ctx in
     let target_alias = Alias.package_install ~context ~pkg:package in
@@ -881,13 +913,16 @@ let install_rules sctx (package : Package.t) =
          | Some toolchain ->
            let toolchain = Context_name.to_string toolchain in
            let prefix = Path.of_string (toolchain ^ "-sysroot") in
-           List.map entries
-             ~f:(Install.Entry.add_install_prefix ~paths:install_paths ~prefix)
+           List.map entries ~f:(fun (e : Install.Entry.Sourced.t) ->
+               { e with
+                 entry =
+                   Install.Entry.add_install_prefix e.entry ~paths:install_paths
+                     ~prefix
+               })
        in
        (if not package.allow_empty then
          if
-           List.for_all entries_with_metadata
-             ~f:(fun (e : Install.Entry.Sourced.t) ->
+           List.for_all entries ~f:(fun (e : Install.Entry.Sourced.t) ->
                match e.source with
                | Dune -> true
                | User _ -> false)
@@ -900,7 +935,9 @@ let install_rules sctx (package : Package.t) =
                   the package definition in the dune-project file"
                  (Package.Name.to_string package_name)
              ]);
-       Install.gen_install_file entries)
+       Install.gen_install_file
+         (List.map entries ~f:(fun (e : Install.Entry.Sourced.t) ->
+              Install.Entry.set_src e.entry (Path.build e.entry.src))))
   in
   Super_context.add_rule sctx ~dir:pkg_build_dir
     ~mode:
@@ -913,32 +950,6 @@ let install_rules sctx (package : Package.t) =
     action
 
 let memo =
-  let module Sctx_and_package = struct
-    module Super_context = Super_context.As_memo_key
-
-    type t = Super_context.t * Package.t
-
-    let hash (x, y) = Hashtbl.hash (Super_context.hash x, Package.hash y)
-
-    let equal (x1, y1) (x2, y2) = x1 == x2 && y1 == y2
-
-    let to_dyn _ = Dyn.Opaque
-  end in
-  let install_alias (ctx : Context.t) (package : Package.t) =
-    let name = Package.name package in
-    if not ctx.implicit then
-      let install_fn =
-        Utils.install_file ~package:name
-          ~findlib_toolchain:ctx.findlib_toolchain
-      in
-      let path = Package_paths.build_dir ctx package in
-      let install_alias = Alias.install ~dir:path in
-      let install_file = Path.relative (Path.build path) install_fn in
-      Rules.Produce.Alias.add_deps install_alias
-        (Action_builder.path install_file)
-    else
-      Memo.Build.return ()
-  in
   Memo.create
     ~input:(module Sctx_and_package)
     ~human_readable_description:(fun (_, pkg) ->
@@ -949,24 +960,11 @@ let memo =
       Memo.Build.return
         (let ctx = Super_context.context sctx in
          let context_name = ctx.name in
-         let rules =
-           Memo.lazy_ ~name:"install-rules-and-pkg-entries-rules"
-             ~human_readable_description:(fun () ->
-               Pp.textf "Computing rules for package %s"
-                 (Package.Name.to_string (Package.name pkg)))
-             (fun () ->
-               Rules.collect_unit (fun () ->
-                   let* () = install_rules sctx pkg in
-                   install_alias ctx pkg))
-         in
          Scheme.Approximation
-           ( Dir_set.union_all
-               [ Dir_set.subtree (Local_install_path.dir ~context:context_name)
-               ; Dir_set.singleton (Package_paths.build_dir ctx pkg)
-               ]
+           ( Dir_set.subtree (Local_install_path.dir ~context:context_name)
            , Thunk
                (fun () ->
-                 let+ rules = Memo.Lazy.force rules in
+                 let+ rules = symlinked_entries sctx pkg >>| snd in
                  Scheme.Finite (Rules.to_map rules)) )))
 
 let scheme sctx pkg = Memo.exec memo (sctx, pkg)
@@ -989,3 +987,35 @@ let gen_rules sctx ~dir =
     Rules.produce_dir ~dir (Option.value ~default:Rules.Dir_rules.empty rules)
   in
   Subdir_set.These subdirs
+
+let gen_install_alias sctx (package : Package.t) =
+  let ctx = Super_context.context sctx in
+  let name = Package.name package in
+  if ctx.implicit then
+    Memo.Build.return ()
+  else
+    let install_fn =
+      Utils.install_file ~package:name ~findlib_toolchain:ctx.findlib_toolchain
+    in
+    let path = Package_paths.build_dir ctx package in
+    let install_alias = Alias.install ~dir:path in
+    let install_file = Path.relative (Path.build path) install_fn in
+    Rules.Produce.Alias.add_deps install_alias
+      (Action_builder.path install_file)
+
+let gen_project_rules sctx project =
+  let* () = meta_and_dune_package_rules sctx project in
+  let* only_packages = Only_packages.get () in
+  let packages = Dune_project.packages project in
+  let packages =
+    match only_packages with
+    | None -> packages
+    | Some mask ->
+      Package.Name.Map.merge packages mask ~f:(fun _ p mask ->
+          match (p, mask) with
+          | Some _, Some _ -> p
+          | _ -> None)
+  in
+  Package.Name.Map_traversals.parallel_iter packages ~f:(fun _name package ->
+      let* () = gen_package_install_file_rules sctx package in
+      gen_install_alias sctx package)

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -1,7 +1,8 @@
 open! Dune_engine
 open Stdune
 
-val gen_rules : Super_context.t -> dir:Path.Build.t -> Subdir_set.t Memo.Build.t
+val symlink_rules :
+  Super_context.t -> dir:Path.Build.t -> (Subdir_set.t * Rules.t) Memo.Build.t
 
 (** Generate rules for [.dune-package], [META.<package-name>] files. and
     [<package-name>.install] files. *)

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -3,19 +3,6 @@ open Stdune
 
 val gen_rules : Super_context.t -> dir:Path.Build.t -> Subdir_set.t Memo.Build.t
 
-(** Generate rules for [.dune-package] and [META.<package-name>] files in a
-    given super context and directory. Surprisingly, the current implementation
-    generates rules for {b all} directories of the project, which are filtered
-    out later in the [build_system.ml]. This function is called multiple times
-    for the same project (with different [dir]), so we memoize it to avoid
-    duplicating work. *)
+(** Generate rules for [.dune-package] and [META.<package-name>] files. *)
 val meta_and_dune_package_rules :
-  Super_context.t -> dir:Path.Build.t -> unit Memo.Build.t
-
-(* TODO: A seemingly more sensible approach for [meta_and_dune_package_rules] is
-   to only generate rules for the given directory, or stop taking [dir]
-   altogether and take [project] instead.
-
-   aalekseyev: actually I think we should just remove
-   [meta_and_dune_package_rules] from the interface and have [gen_rules] do
-   everything. *)
+  Super_context.t -> Dune_project.t -> unit Memo.Build.t

--- a/src/dune_rules/install_rules.mli
+++ b/src/dune_rules/install_rules.mli
@@ -3,6 +3,6 @@ open Stdune
 
 val gen_rules : Super_context.t -> dir:Path.Build.t -> Subdir_set.t Memo.Build.t
 
-(** Generate rules for [.dune-package] and [META.<package-name>] files. *)
-val meta_and_dune_package_rules :
-  Super_context.t -> Dune_project.t -> unit Memo.Build.t
+(** Generate rules for [.dune-package], [META.<package-name>] files. and
+    [<package-name>.install] files. *)
+val gen_project_rules : Super_context.t -> Dune_project.t -> unit Memo.Build.t

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -332,8 +332,7 @@ let add_rule sctx ~project ~pkg =
   Memo.Build.sequential_iter aliases ~f:(fun alias ->
       Rules.Produce.Alias.add_deps alias (Action_builder.path_set deps))
 
-let add_rules sctx ~dir =
-  let project = Super_context.find_scope_by_dir sctx dir |> Scope.project in
+let add_rules sctx project =
   Memo.Build.when_ (Dune_project.generate_opam_files project) (fun () ->
       let packages = Dune_project.packages project in
       Package.Name.Map_traversals.parallel_iter packages

--- a/src/dune_rules/opam_create.mli
+++ b/src/dune_rules/opam_create.mli
@@ -11,4 +11,4 @@ val template_file : Path.t -> Path.t
 val generate :
   Dune_project.t -> Package.t -> template:(Path.t * string) option -> string
 
-val add_rules : Super_context.t -> dir:Path.Build.t -> unit Memo.Build.t
+val add_rules : Super_context.t -> Dune_project.t -> unit Memo.Build.t

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
@@ -80,9 +80,9 @@ This is a reproduction case from issue #4345
   > EOF
   $ dune build --root .
   Error: Dependency cycle between:
-     Computing rules for package lib
+     Computing installable artifacts for package lib
   -> Evaluating predicate in directory _build/default
   -> Computing directory contents of _build/default/lib
-  -> Computing rules for package lib
+  -> Computing installable artifacts for package lib
   [1]
   $ cd ..


### PR DESCRIPTION
We were generating the following rules for every single directory, which is a waste of CPU:

- all the rules for generation the opam files for all packages in the worksapce
- all the rules for generating the `META` and `dune-package` files for all packages in the workspace

Now, we generate them only once at the root of each project, and only for the packages of the project.

I also refactored a bit `install_rules` to split the generation of files inside `_build/default` and `_build/install`, and also to avoid unnecessary bouncing between `Rules.produce` and `Rules.collect`.

After this, we could split `install_rules.ml` between:

- the computation of the install entries
- the symlink rules
- the generation of the <package>.install files
- the generation of the META and dune-package files