### PR TITLE
Tighten the rule generation API

### DIFF
--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -13,12 +13,17 @@ end
 
 type extra_sub_directories_to_keep = Subdir_set.t
 
+type gen_rules_result =
+  | Rules of extra_sub_directories_to_keep * Rules.t
+  | Unknown_context_or_install
+  | Redirect_to_parent
+
 module type Rule_generator = sig
   val gen_rules :
        Context_or_install.t
     -> dir:Path.Build.t
     -> string list
-    -> (extra_sub_directories_to_keep * Rules.t) option Memo.Build.t
+    -> gen_rules_result Memo.Build.t
 
   val global_rules : Rules.t Memo.Lazy.t
 end

--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -24,8 +24,6 @@ module type Rule_generator = sig
     -> dir:Path.Build.t
     -> string list
     -> gen_rules_result Memo.Build.t
-
-  val global_rules : Rules.t Memo.Lazy.t
 end
 
 module Error = struct

--- a/src/dune_engine/build_config.mli
+++ b/src/dune_engine/build_config.mli
@@ -32,8 +32,7 @@ module type Rule_generator = sig
       addition to the ones that are present in the source tree and the ones that
       already contain rules.
 
-      It is expected that [gen_rules] only generate rules whose targets are
-      descendant of [dir]. *)
+      [gen_rules] may only generate rules whose targets are descendant of [dir]. *)
   val gen_rules :
        Context_or_install.t
     -> dir:Path.Build.t

--- a/src/dune_engine/build_config.mli
+++ b/src/dune_engine/build_config.mli
@@ -15,6 +15,13 @@ end
 
 type extra_sub_directories_to_keep = Subdir_set.t
 
+type gen_rules_result =
+  | Rules of extra_sub_directories_to_keep * Rules.t
+  | Unknown_context_or_install
+  | Redirect_to_parent
+      (** [Redirect_to_parent] means that the parent will generate the rules for
+          this directory. *)
+
 module type Rule_generator = sig
   (** The rule generator.
 
@@ -26,15 +33,12 @@ module type Rule_generator = sig
       already contain rules.
 
       It is expected that [gen_rules] only generate rules whose targets are
-      descendant of [dir].
-
-      The callback should return [None] if it doesn't know about the given
-      [Context_or_install.t]. *)
+      descendant of [dir]. *)
   val gen_rules :
        Context_or_install.t
     -> dir:Path.Build.t
     -> string list
-    -> (extra_sub_directories_to_keep * Rules.t) option Memo.Build.t
+    -> gen_rules_result Memo.Build.t
 
   (** [global_rules] is a way to generate rules in arbitrary directories
       upfront. *)

--- a/src/dune_engine/build_config.mli
+++ b/src/dune_engine/build_config.mli
@@ -39,10 +39,6 @@ module type Rule_generator = sig
     -> dir:Path.Build.t
     -> string list
     -> gen_rules_result Memo.Build.t
-
-  (** [global_rules] is a way to generate rules in arbitrary directories
-      upfront. *)
-  val global_rules : Rules.t Memo.Lazy.t
 end
 
 (** Errors found when building targets. *)

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -579,13 +579,12 @@ end = struct
     let (module RG : Build_config.Rule_generator) =
       (Build_config.get ()).rule_generator
     in
-    let* extra_subdirs_to_keep, rules_produced = Gen_rules.gen_rules build_dir
-    and* global_rules = Memo.Lazy.force RG.global_rules in
+    let* extra_subdirs_to_keep, rules_produced =
+      Gen_rules.gen_rules build_dir
+    in
     let rules =
       let dir = Path.build dir in
-      Rules.Dir_rules.union
-        (Rules.find rules_produced dir)
-        (Rules.find global_rules dir)
+      Rules.find rules_produced dir
     in
     let collected = Rules.Dir_rules.consume rules in
     let rules = collected.rules in

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -17,7 +17,6 @@ module Loaded : sig
 
   type build =
     { allowed_subdirs : Path.Unspecified.w Dir_set.t
-    ; rules_produced : Rules.t
     ; rules_here : rules_here
     ; aliases : (Loc.t * Rules.Dir_rules.Alias_spec.item) list Alias.Name.Map.t
     }
@@ -34,8 +33,6 @@ val file_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
 
 (** Load the rules for this directory. *)
 val load_dir : dir:Path.t -> Loaded.t Memo.Build.t
-
-val load_dir_and_produce_its_rules : dir:Path.t -> unit Memo.Build.t
 
 (** Return [true] if a file exists or is buildable *)
 val file_exists : Path.t -> bool Memo.Build.t

--- a/src/dune_rules/dir_contents.mli
+++ b/src/dune_rules/dir_contents.mli
@@ -40,8 +40,12 @@ val get : Super_context.t -> dir:Path.Build.t -> t Memo.Build.t
     not part of a group. *)
 val dirs : t -> t list
 
-type gen_rules_result =
-  | Standalone_or_root of t * t list  (** Sub-directories part of the group *)
+type triage =
+  | Standalone_or_root of
+      { root : t
+      ; subdirs : t list  (** Sub-directories part of the group *)
+      ; rules : Rules.t
+      }
   | Group_part of Path.Build.t
 
 (** In order to compute the directory contents, we need to interpret stanzas
@@ -50,13 +54,11 @@ type gen_rules_result =
     rules.
 
     As a result, we proceed as follow: we interpret the stanza into rules and
-    extract the targets of the computed rule. This function simply emits these
-    rules so that they can be collected by [Build_system].
+    extract the targets of the computed rule. This function returns these rules.
 
     However, if the directory is part of a group, this function simply returns
-    the root of the group without emitting any rule. *)
-val gen_rules :
-  Super_context.t -> dir:Path.Build.t -> gen_rules_result Memo.Build.t
+    the root of the group. *)
+val triage : Super_context.t -> dir:Path.Build.t -> triage Memo.Build.t
 
 (** Add expansion that depend on OCaml artifacts/sources.
 

--- a/src/dune_rules/format_rules.mli
+++ b/src/dune_rules/format_rules.mli
@@ -3,14 +3,13 @@ open Import
 
 (** Setup automatic format rules for the given dir. If tools like ocamlformat
     are not available in $PATH, just display an error message when the alias is
-    built. *)
-val gen_rules : dir:Path.Build.t -> unit Memo.Build.t
+    built.
 
-val gen_rules_output :
-     Super_context.t
-  -> Format_config.t
-  -> version:Dune_lang.Syntax.Version.t
-  -> dialects:Dialect.DB.t
-  -> expander:Expander.t
-  -> output_dir:Path.Build.t
-  -> unit Memo.Build.t
+    This must be called from inside the [formatted_dir_basename] sub-directory. *)
+val gen_rules : Super_context.t -> output_dir:Path.Build.t -> unit Memo.Build.t
+
+(** This must be called from the main directory, i.e. the ones containing the
+    source files and the the [formatted_dir_basename] sub-directory. *)
+val setup_alias : Super_context.t -> dir:Path.Build.t -> unit Memo.Build.t
+
+val formatted_dir_basename : string

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -1011,17 +1011,7 @@ let gen_install_alias sctx (package : Package.t) =
 
 let gen_project_rules sctx project =
   let* () = meta_and_dune_package_rules sctx project in
-  let* only_packages = Only_packages.get () in
-  let packages = Dune_project.packages project in
-  let packages =
-    match only_packages with
-    | None -> packages
-    | Some mask ->
-      Package.Name.Map.merge packages mask ~f:(fun _ p mask ->
-          match (p, mask) with
-          | Some _, Some _ -> p
-          | _ -> None)
-  in
+  let* packages = Only_packages.packages_of_project project in
   Package.Name.Map_traversals.parallel_iter packages ~f:(fun _name package ->
       let* () = gen_package_install_file_rules sctx package in
       gen_install_alias sctx package)

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -798,18 +798,6 @@ let packages_file_is_part_of path =
     let+ map = packages sctx in
     Option.value (Path.Build.Map.find map path) ~default:Package.Id.Set.empty
 
-module Sctx_and_package = struct
-  module Super_context = Super_context.As_memo_key
-
-  type t = Super_context.t * Package.t
-
-  let hash (x, y) = Hashtbl.hash (Super_context.hash x, Package.hash y)
-
-  let equal (x1, y1) (x2, y2) = x1 == x2 && y1 == y2
-
-  let to_dyn _ = Dyn.Opaque
-end
-
 let symlinked_entries sctx package =
   let package_name = Package.name package in
   let install_paths =
@@ -823,7 +811,7 @@ let symlinked_entries sctx package =
 let symlinked_entries =
   let memo =
     Memo.create
-      ~input:(module Sctx_and_package)
+      ~input:(module Super_context.As_memo_key.And_package)
       ~human_readable_description:(fun (_, pkg) ->
         Pp.textf "Computing installable artifacts for package %s"
           (Package.Name.to_string (Package.name pkg)))
@@ -956,7 +944,7 @@ let gen_package_install_file_rules sctx (package : Package.t) =
 
 let memo =
   Memo.create
-    ~input:(module Sctx_and_package)
+    ~input:(module Super_context.As_memo_key.And_package)
     ~human_readable_description:(fun (_, pkg) ->
       Pp.textf "Computing installable artifacts for package %s"
         (Package.Name.to_string (Package.name pkg)))

--- a/src/dune_rules/odoc.mli
+++ b/src/dune_rules/odoc.mli
@@ -18,4 +18,7 @@ val setup_private_library_doc_alias :
   -> unit Memo.build
 
 val gen_rules :
-  Super_context.t -> dir:Path.Build.t -> string list -> unit Memo.Build.t
+     Super_context.t
+  -> dir:Path.Build.t
+  -> string list
+  -> Build_config.gen_rules_result Memo.Build.t

--- a/src/dune_rules/odoc.mli
+++ b/src/dune_rules/odoc.mli
@@ -8,7 +8,14 @@ open Dune_file
 val setup_library_odoc_rules :
   Compilation_context.t -> Library.t -> unit Memo.Build.t
 
-val global_rules : Super_context.t -> unit Memo.Build.t
+val gen_project_rules : Super_context.t -> Dune_project.t -> unit Memo.Build.t
+
+val setup_private_library_doc_alias :
+     Super_context.t
+  -> scope:Scope.t
+  -> dir:Stdune.Path.Build.t
+  -> Dune_file.Library.t
+  -> unit Memo.build
 
 val gen_rules :
   Super_context.t -> dir:Path.Build.t -> string list -> unit Memo.Build.t

--- a/src/dune_rules/only_packages.ml
+++ b/src/dune_rules/only_packages.ml
@@ -66,3 +66,14 @@ let conf =
         >>| Option.some)
 
 let get () = Memo.Lazy.force conf
+
+let packages_of_project project =
+  let+ t = get () in
+  let packages = Dune_project.packages project in
+  match t with
+  | None -> packages
+  | Some mask ->
+    Package.Name.Map.merge packages mask ~f:(fun _ p mask ->
+        match (p, mask) with
+        | Some _, Some _ -> p
+        | _ -> None)

--- a/src/dune_rules/only_packages.mli
+++ b/src/dune_rules/only_packages.mli
@@ -19,3 +19,7 @@ type t = Package.t Package.Name.Map.t option
 
 (** Returns the package restrictions. This function is memoized. *)
 val get : unit -> t Memo.Build.t
+
+(** Apply the package mask to the packages defined by the project *)
+val packages_of_project :
+  Dune_project.t -> Package.t Package.Name.Map.t Memo.Build.t

--- a/src/dune_rules/packages.ml
+++ b/src/dune_rules/packages.ml
@@ -4,6 +4,8 @@ open Import
 open Dune_file
 open Memo.Build.O
 
+(* CR-someday jeremiedimino: This should be a memoized function [Super_context.t
+   -> Package.t -> Path.Build.t list Memo.Build.t]. *)
 let mlds_by_package_def =
   Memo.With_implicit_output.create "mlds by package"
     ~implicit_output:Rules.implicit_output

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -827,4 +827,14 @@ module As_memo_key = struct
   let hash = hash
 
   let to_dyn = to_dyn_concise
+
+  module And_package = struct
+    type nonrec t = t * Package.t
+
+    let hash (x, y) = Hashtbl.hash (hash x, Package.hash y)
+
+    let equal (x1, y1) (x2, y2) = equal x1 x2 && y1 == y2
+
+    let to_dyn (s, p) = Dyn.Tuple [ to_dyn s; Package.to_dyn p ]
+  end
 end

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -166,11 +166,7 @@ val expander : t -> dir:Path.Build.t -> Expander.t Memo.Build.t
 val dir_status_db : t -> Dir_status.DB.t
 
 module As_memo_key : sig
-  type nonrec t = t
+  include Memo.Input with type t = t
 
-  val to_dyn : t -> Dyn.t
-
-  val equal : t -> t -> bool
-
-  val hash : t -> int
+  module And_package : Memo.Input with type t = t * Package.t
 end

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -21,8 +21,6 @@ let source ~dir =
     ~loc:(Loc.in_dir (Path.build dir))
     ~main:"UTop_main.main ();" ~name:exe_name
 
-let is_utop_dir dir = Path.Build.basename dir = utop_dir_basename
-
 module Libs_and_ppxs =
   Monoid.Product
     (Monoid.Appendable_list (struct

--- a/src/dune_rules/utop.mli
+++ b/src/dune_rules/utop.mli
@@ -7,7 +7,7 @@ open! Stdune
     are defined. *)
 val utop_exe : string
 
-val is_utop_dir : Path.Build.t -> bool
+val utop_dir_basename : string
 
 val libs_under_dir :
   Super_context.t -> db:Lib.DB.t -> dir:Path.t -> Lib.L.t Memo.Build.t

--- a/test/blackbox-tests/test-cases/lib-errors.t/run.t
+++ b/test/blackbox-tests/test-cases/lib-errors.t/run.t
@@ -5,10 +5,10 @@ Cycle detection
 
   $ dune build cycle.exe
   Error: Dependency cycle between:
-     library "a" in _build/default
+     library "b" in _build/default
+  -> library "a" in _build/default
   -> library "c" in _build/default
   -> library "b" in _build/default
-  -> library "a" in _build/default
   [1]
 
 Select with no solution

--- a/test/blackbox-tests/test-cases/ppx-runtime-dependencies.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx-runtime-dependencies.t/run.t
@@ -60,10 +60,10 @@ Handling ppx_runtime_libraries dependencies correctly
 
   $ ./sdune exec bin/main.exe
   Error: Dependency cycle between:
-     library "a" in _build/default
-  -> library "c" in _build/default
+     library "c" in _build/default
   -> library "b" in _build/default
   -> library "a" in _build/default
+  -> library "c" in _build/default
   [1]
 
 ----------------------------------------------------------------------------------
@@ -163,8 +163,8 @@ Note that pps dependencies are separated by a runtime dependency.
 
   $ ./sdune exec bin/main.exe
   Error: Dependency cycle between:
-     library "gen_c" in _build/default
-  -> library "c" in _build/default
+     library "c" in _build/default
   -> library "ppx" in _build/default
   -> library "gen_c" in _build/default
+  -> library "c" in _build/default
   [1]


### PR DESCRIPTION
Up to know, there were complex and mostly unknown and unchecked invariants for producing the build rules. This PR replaces them by saner and checked invariants:

- `gen_rules ~dir` is only allowed to produce rules for descendant of `dir`. This is now checked
- a directory can declare that its parent will generate its rules by having `gen_rules` return `Redirect_to_parent`

There is still an opportunity for messing things up: if `gen_rules ~dir` produces rules for a descendant `dir'` and `gen_rules ~dir:dir'` doesn't return `Redirect_to_parent`, then these rules will simply be lost. In the future, I would like to change things so that the rules for a directory are the union of all the rules generated in this directory by all the calls to `gen_rules` on the ancestor of the directory. This will make sure that we never loose rules and will remove the need for `Redirect_to_parent`.

The PR is organised as follow:

### 1: remove `Load_rules.load_dir_and_produce_its_sources`

The first commit removes `Load_rules.load_dir_and_produce_its_sources` which was a free for all function allowing any directory to fetch its rules from any another directory. In practice, this function was mostly misused and generated useless work.

Instead, this commit introduce the `Redirect_to_parent` result for `gen_rules`. This commit adapts `gen_rules.ml` to cope with the API change.

### 2: remove `global_rules` from the `Rule_generator` signature

It wasn't necessary. It was used by the odoc rules to iterate over all packages and setup a bunch of rules at the root of each packages. We now do this as part of setting up the project-wide rules in the `gen_project_rules` function in `gen_rules.ml`.

The code is just as clear without `global_rules` and it is also more incremental.

### 3: enforce that `gen_rules` produces rules only in descendants

This check exposed a few more places where:

- we were generating the same rules over and over, such as the odoc rules. We were generating all the odoc rules for all subdirectories of `_build/default/_doc/{_odoc/pkg,_mlds}`
- we were generating rules that were never used, such as a symlink rules for `utop.exe` in each and every directory

I did some refactoring of `gen_rules.ml` in this commit and changed one thing: the automatic `.bin`, `.utop` and `.formatted` sub-directories are now only created for directory that have a corresponding source tree, since there is no point generating them absolutely everywhere.