### PR TITLE
Remove error about sandboxing with hardlinks not working on Windows

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -163,29 +163,9 @@ end = struct
   let select_sandbox_mode (config : Sandbox_config.t) ~loc
       ~sandboxing_preference =
     let evaluate_sandboxing_preference preference =
-      let use_copy_on_windows mode =
-        match Sandbox_mode.Set.mem config Sandbox_mode.copy with
-        | true ->
-          Some
-            (if Sys.win32 then
-              Sandbox_mode.copy
-            else
-              mode)
-        | false ->
-          User_error.raise ~loc
-            [ Pp.textf
-                "This rule requires sandboxing with %ss, but that won't work \
-                 on Windows."
-                (Sandbox_mode.to_string mode)
-            ]
-      in
       match Sandbox_mode.Set.mem config preference with
       | false -> None
-      | true -> (
-        match preference with
-        | Some Symlink -> use_copy_on_windows Sandbox_mode.symlink
-        | Some Hardlink -> use_copy_on_windows Sandbox_mode.hardlink
-        | _ -> Some preference)
+      | true -> Some preference
     in
     match
       List.find_map sandboxing_preference ~f:evaluate_sandboxing_preference

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -109,7 +109,10 @@ end
 
 (* these should be listed in the default order of preference *)
 let all_except_patch_back_source_tree =
-  [ None; Some Symlink; Some Copy; Some Hardlink ]
+  if Sys.win32 then
+    [ None; Some Copy; Some Symlink; Some Hardlink ]
+  else
+    [ None; Some Symlink; Some Copy; Some Hardlink ]
 
 let all = all_except_patch_back_source_tree @ [ Some Patch_back_source_tree ]
 


### PR DESCRIPTION
The only way to select sandboxing with hardlinks is via the command line. If people do that, we can assume they know what they are doing.
