### PR TITLE
Remove [patch_back_source_tree] from default sandboxing preferences

### DIFF
--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -144,7 +144,8 @@ let set ~stats ~contexts ~promote_source ~cache_config ~cache_debug_flags
   Fdecl.set t
     { contexts
     ; rule_generator
-    ; sandboxing_preference = sandboxing_preference @ Sandbox_mode.all
+    ; sandboxing_preference =
+        sandboxing_preference @ Sandbox_mode.all_except_patch_back_source_tree
     ; handler = Option.value handler ~default:Handler.do_nothing
     ; promote_source
     ; stats

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -162,25 +162,30 @@ end = struct
 
   let select_sandbox_mode (config : Sandbox_config.t) ~loc
       ~sandboxing_preference =
-    let evaluate_sandboxing_preference preference =
-      match Sandbox_mode.Set.mem config preference with
-      | false -> None
-      | true -> Some preference
-    in
-    match
-      List.find_map sandboxing_preference ~f:evaluate_sandboxing_preference
-    with
-    | Some choice -> choice
-    | None ->
-      (* This is not trivial to reach because the user rules are checked at
-         parse time and [sandboxing_preference] always includes all possible
-         modes. However, it can still be reached if multiple sandbox config
-         specs are combined into an unsatisfiable one. *)
-      User_error.raise ~loc
-        [ Pp.text
-            "This rule forbids all sandboxing modes (but it also requires \
-             sandboxing)"
-        ]
+    (* Rules with (mode patch-back-source-tree) are special and are not affected
+       by sandboxing preferences. *)
+    match Sandbox_mode.Set.is_patch_back_source_tree_only config with
+    | true -> Some Sandbox_mode.Patch_back_source_tree
+    | false -> (
+      let evaluate_sandboxing_preference preference =
+        match Sandbox_mode.Set.mem config preference with
+        | false -> None
+        | true -> Some preference
+      in
+      match
+        List.find_map sandboxing_preference ~f:evaluate_sandboxing_preference
+      with
+      | Some choice -> choice
+      | None ->
+        (* This is not trivial to reach because the user rules are checked at
+           parse time and [sandboxing_preference] always includes all possible
+           modes. However, it can still be reached if multiple sandbox config
+           specs are combined into an unsatisfiable one. *)
+        User_error.raise ~loc
+          [ Pp.text
+              "This rule forbids all sandboxing modes (but it also requires \
+               sandboxing)"
+          ])
 
   let start_rule _rule = State.rule_total := !State.rule_total + 1
 

--- a/src/dune_engine/sandbox_config.ml
+++ b/src/dune_engine/sandbox_config.ml
@@ -5,7 +5,12 @@ let no_special_requirements = of_func (fun _ -> true)
 
 let no_sandboxing = of_func Option.is_none
 
-let needs_sandboxing = of_func Option.is_some
+let needs_sandboxing =
+  of_func (function
+    | None
+    | Some Patch_back_source_tree ->
+      false
+    | Some _ -> true)
 
 let default = no_special_requirements
 

--- a/src/dune_engine/sandbox_config.mli
+++ b/src/dune_engine/sandbox_config.mli
@@ -23,6 +23,7 @@ val no_special_requirements : t
 
 val no_sandboxing : t
 
+(** Allow any sandboxing mode, except [Patch_back_source_tree] *)
 val needs_sandboxing : t
 
 (** The default sandboxing config for actions that don't bother specifying it.

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -79,6 +79,16 @@ module Set = struct
 
   let singleton k = of_func (equal k)
 
+  (* CR-someday amokhov: [Patch_back_source_tree] is a bit special in that it
+     can only appear as a singleton. Perhaps, it should be treated differently
+     than other sandboxing modes to make meaningless states
+     non-representable. *)
+  let patch_back_source_tree_only = singleton (Some Patch_back_source_tree)
+
+  let is_patch_back_source_tree_only (t : t) =
+    t.patch_back_source_tree && (not t.none) && (not t.copy) && (not t.symlink)
+    && not t.hardlink
+
   let equal a b =
     match compare a b with
     | Eq -> true
@@ -107,7 +117,8 @@ module Set = struct
       ]
 end
 
-(* these should be listed in the default order of preference *)
+(* The order of sandboxing modes in this list determines the order in which Dune
+   will try to use them when satisfying sandboxing constraints. *)
 let all_except_patch_back_source_tree =
   if Sys.win32 then
     [ None; Some Copy; Some Symlink; Some Hardlink ]

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -85,9 +85,12 @@ module Set = struct
      non-representable. *)
   let patch_back_source_tree_only = singleton (Some Patch_back_source_tree)
 
-  let is_patch_back_source_tree_only (t : t) =
-    t.patch_back_source_tree && (not t.none) && (not t.copy) && (not t.symlink)
-    && not t.hardlink
+  let is_patch_back_source_tree_only t =
+    match compare t patch_back_source_tree_only with
+    | Eq -> true
+    | Lt
+    | Gt ->
+      false
 
   let equal a b =
     match compare a b with

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -62,6 +62,11 @@ module Set : sig
 
   val singleton : key -> t
 
+  (** For rules with (mode patch-back-source-tree). *)
+  val patch_back_source_tree_only : t
+
+  val is_patch_back_source_tree_only : t -> bool
+
   val equal : t -> t -> bool
 
   val compare : t -> t -> Ordering.t

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1733,8 +1733,8 @@ module Rule = struct
              User_error.raise ~loc
                [ Pp.text
                    "Rules with (mode patch-back-source-tree) cannot have an \
-                    explicit sandbox configuration has it is implied by (mode \
-                    patch-back-source-tree)."
+                    explicit sandbox configuration because it is implied by \
+                    (mode patch-back-source-tree)."
                ];
            (Standard, true)
        in

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -117,8 +117,7 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
                something that didn't permit [Some Patch_back_source_tree], Dune
                would crash in a way that would be difficult for the user to
                understand. *)
-            Action.Full.add_sandbox
-              (Sandbox_mode.Set.singleton (Some Patch_back_source_tree))
+            Action.Full.add_sandbox Sandbox_mode.Set.patch_back_source_tree_only
               action)
       else
         action

--- a/test/blackbox-tests/test-cases/patch-back-source-tree.t
+++ b/test/blackbox-tests/test-cases/patch-back-source-tree.t
@@ -71,7 +71,6 @@ Non-modified dependencies are not promoted
   >  (alias default)
   >  (deps x)
   >  (action (system "echo 'Hello, world!'")))
-  > 
   > (rule (with-stdout-to x (progn)))
   > EOF
 
@@ -127,7 +126,7 @@ Interaction with explicit sandboxing
   4 |  (alias default)
   5 |  (action (system "echo 'Hello, world!'")))
   Error: Rules with (mode patch-back-source-tree) cannot have an explicit
-  sandbox configuration has it is implied by (mode patch-back-source-tree).
+  sandbox configuration because it is implied by (mode patch-back-source-tree).
   [1]
 
 Selecting an explicit sandbox mode via the command line doesn't affect
@@ -204,8 +203,7 @@ This is the internal stamp file:
   $ ls _build/.actions/default/blah*
   _build/.actions/default/blah-3209c92f18c7050c580114796b6023bd
 
-And we check that it isn't copied in the soure tree:
+And we check that it isn't copied in the source tree:
 
   $ if [ -d default ]; then echo "Failure"; else echo "Success"; fi
   Success
-


### PR DESCRIPTION
As discussed [here](https://github.com/ocaml/dune/pull/5271#discussion_r762006776), listing `patch_back_source_tree` in default sandboxing preferences is odd because Dune might pick it up as a sensible sandboxing mode. It should only be allowed via an explicit opt-in by writing `(mode patch-back-source-tree)`.