### PR TITLE
fix: release build of dune

### DIFF
--- a/dune.opam
+++ b/dune.opam
@@ -40,7 +40,7 @@ build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
   ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
-  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+  ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,

--- a/dune.opam.template
+++ b/dune.opam.template
@@ -2,7 +2,7 @@ build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
   ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
-  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+  ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,


### PR DESCRIPTION
there's no reason to filter out other pacakges with -p as dune depends
on them

Fix #5190 