### PR TITLE
Fix #5267

### DIFF
--- a/test/blackbox-tests/test-cases/gh5267.t
+++ b/test/blackbox-tests/test-cases/gh5267.t
@@ -1,0 +1,25 @@
+This issue demonstrates a bug when there's a library without any modules and an
+executable with a module with the same name as the library's entry point in the
+same directory.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 1.2)
+  > EOF
+  $ cat >dune<<EOF
+  > (library
+  >  (name foo)
+  >  (modules))
+  > (executable
+  >  (name bar)
+  >  (libraries foo))
+  > EOF
+  $ cat >bar.ml <<EOF
+  > module M = Foo
+  > EOF
+  $ touch foo.ml
+  $ touch foo.mli
+
+  $ dune build ./bar.exe
+  File "foo.ml-gen", line 1:
+  Error: Could not find the .cmi file for interface foo.mli.
+  [1]


### PR DESCRIPTION
The idea is to represent all empty libraries the same way. This almost works but needs a workaround for odoc. Since it's an empty library, we shouldn't be generating a module index section.