### PR TITLE
Make permissions abstract

### DIFF
--- a/otherlibs/stdune/path.ml
+++ b/otherlibs/stdune/path.ml
@@ -583,11 +583,17 @@ module Kind = struct
 end
 
 module Permissions = struct
-  let write = 0o222
+  type t =
+    { current_user : int
+    ; all_users : int
+    }
 
-  let add ~mode perm = perm lor mode
+  (* CR-someday amokhov: add [executable]. *)
+  let write = { current_user = 0o200; all_users = 0o222 }
 
-  let remove ~mode perm = perm land lnot mode
+  let add t perm = perm lor t.current_user
+
+  let remove t perm = perm land lnot t.all_users
 end
 
 module Build = struct

--- a/otherlibs/stdune/path.mli
+++ b/otherlibs/stdune/path.mli
@@ -114,14 +114,16 @@ module Source : sig
 end
 
 module Permissions : sig
+  type t
+
   (** Write permissions. *)
-  val write : int
+  val write : t
 
-  (** Add [mode] permissions to a given mask. *)
-  val add : mode:int -> int -> int
+  (** Add permissions to a given mask for the current user. *)
+  val add : t -> int -> int
 
-  (** Remove [mode] permissions from a given mask. *)
-  val remove : mode:int -> int -> int
+  (** Remove permissions from a given mask for all users. *)
+  val remove : t -> int -> int
 end
 
 module Build : sig

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -36,7 +36,7 @@ module Target = struct
     match Path.Build.lstat path with
     | { Unix.st_kind = Unix.S_REG; st_perm; _ } ->
       Path.Build.chmod path
-        ~mode:(Path.Permissions.remove ~mode:Path.Permissions.write st_perm);
+        ~mode:(Path.Permissions.remove Path.Permissions.write st_perm);
       let executable = st_perm land 0o100 <> 0 in
       Some { path; executable }
     | (exception _)

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -269,7 +269,7 @@ let refresh_and_remove_write_permissions ~allow_dirs path =
           | exception Unix.Unix_error (ENOENT, _, _) -> Broken_symlink)
         | S_REG ->
           let perm =
-            Path.Permissions.remove ~mode:Path.Permissions.write stats.st_perm
+            Path.Permissions.remove Path.Permissions.write stats.st_perm
           in
           Path.chmod ~mode:perm path;
           refresh ~allow_dirs { stats with st_perm = perm } path

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -56,7 +56,7 @@ module File = struct
 
   let do_promote ~correction_file ~dst =
     Path.Source.unlink_no_err dst;
-    let chmod = Path.Permissions.add ~mode:Path.Permissions.write in
+    let chmod = Path.Permissions.add Path.Permissions.write in
     Io.copy_file ~chmod
       ~src:(Path.build correction_file)
       ~dst:(Path.source dst) ()

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -76,7 +76,7 @@ let link_function ~(mode : Sandbox_mode.some) =
     | Patch_back_source_tree ->
       (* We need to let the action modify its dependencies, so we copy
          dependencies and make them writable. *)
-      let chmod = Path.Permissions.add ~mode:Path.Permissions.write in
+      let chmod = Path.Permissions.add Path.Permissions.write in
       fun src dst -> Io.copy_file ~src ~dst ~chmod ())
 
 let link_deps t ~mode ~deps =

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -130,7 +130,7 @@ let promote_target_if_not_up_to_date ~src ~src_digest ~dst ~promote_source
       (* The file in the build directory might be read-only if it comes from the
          shared cache. However, we want the file in the source tree to be
          writable by the user, so we explicitly set the user writable bit. *)
-      let chmod = Path.Permissions.add ~mode:Path.Permissions.write in
+      let chmod = Path.Permissions.add Path.Permissions.write in
       let+ () =
         promote_source ~chmod ~delete_dst_if_it_is_a_directory:true ~src ~dst
       in


### PR DESCRIPTION
I realised that my previous PR #5300 actually changed behaviour (we started setting write permissions for all users!), so to avoid such mistakes in future, I'm making the type abstract and the comments, hopefully, clearer.