### PR TITLE
Use [Path.Permissions] for execute permissions too

### DIFF
--- a/otherlibs/stdune/digest.ml
+++ b/otherlibs/stdune/digest.ml
@@ -123,7 +123,9 @@ let path_with_stats ~allow_dirs path (stats : Stats_for_digest.t) :
     Path_digest_result.t =
   match stats.st_kind with
   | S_REG ->
-    let executable = stats.st_perm land 0o100 <> 0 in
+    let executable =
+      Path.Permissions.test Path.Permissions.execute stats.st_perm
+    in
     Dune_filesystem_stubs.Unix_error.Detailed.catch
       (file_with_executable_bit ~executable)
       path

--- a/otherlibs/stdune/path.ml
+++ b/otherlibs/stdune/path.ml
@@ -588,10 +588,13 @@ module Permissions = struct
     ; all_users : int
     }
 
-  (* CR-someday amokhov: add [executable]. *)
+  let execute = { current_user = 0o100; all_users = 0o111 }
+
   let write = { current_user = 0o200; all_users = 0o222 }
 
   let add t perm = perm lor t.current_user
+
+  let test t perm = perm land t.current_user <> 0
 
   let remove t perm = perm land lnot t.all_users
 end

--- a/otherlibs/stdune/path.mli
+++ b/otherlibs/stdune/path.mli
@@ -116,11 +116,17 @@ end
 module Permissions : sig
   type t
 
+  (** Execute permissions. *)
+  val execute : t
+
   (** Write permissions. *)
   val write : t
 
   (** Add permissions to a given mask for the current user. *)
   val add : t -> int -> int
+
+  (** Test permissions of a given mask for the current user. *)
+  val test : t -> int -> bool
 
   (** Remove permissions from a given mask for all users. *)
   val remove : t -> int -> int

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -37,7 +37,7 @@ module Target = struct
     | { Unix.st_kind = Unix.S_REG; st_perm; _ } ->
       Path.Build.chmod path
         ~mode:(Path.Permissions.remove Path.Permissions.write st_perm);
-      let executable = st_perm land 0o100 <> 0 in
+      let executable = Path.Permissions.test Path.Permissions.execute st_perm in
       Some { path; executable }
     | (exception _)
     | _ ->


### PR DESCRIPTION
Clean up bit fiddling with the execute permission bit.

The CI failure is unrelated.