### PR TITLE
Fix Dune performance regression in incremental builds

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -914,7 +914,11 @@ let check_point =
   t_opt () >>= function
   | None -> Fiber.return ()
   | Some t ->
-    check_cancelled t;
+    (* CR-someday amokhov: we used to call [check_cancelled t] here but that led
+       to a significant performance regression. Raising [Build_cancelled] saves
+       some unnecessary recomputation but also destroys early cutoffs. We should
+       change Memo to store previous successes to make such early cancellations
+       preserve the early cutoff behaviour. *)
     Event.Queue.yield_if_there_are_pending_events t.events
 
 let () = Memo.check_point := check_point


### PR DESCRIPTION
While debugging a large performance regression that we were seeing in our internal incremental builds, I found that #5181 made our incremental builds very slow in the case where Dune receives multiple file-system events in quick succession (which does often happen in practice, e.g. when creating new files).

The idea of calling `check_cancelled t` was to save some work by raising the `Build_cancelled` exception during Memo node recomputation. This does save the work but also destroys early cutoffs (we throw away earlier successes and replace them with `Build_cancelled` exceptions), which means the next build is going to be very slow.

The change in this commit fixes the regression, but of course we want to find a way to keep the `check_cancelled t` optimisation: we just need to preserve cutoffs in the presence of cancellations. I have some ideas how to do that.