### PR TITLE
Add a test for relocatable site installation

### DIFF
--- a/test/blackbox-tests/test-cases/relocatable-site.t/dune
+++ b/test/blackbox-tests/test-cases/relocatable-site.t/dune
@@ -1,0 +1,9 @@
+(executable
+ (public_name test)
+ (name test)
+ (modules test site)
+ (libraries dune-site))
+
+(generate_sites_module
+ (module site)
+ (sites test))

--- a/test/blackbox-tests/test-cases/relocatable-site.t/dune-project
+++ b/test/blackbox-tests/test-cases/relocatable-site.t/dune-project
@@ -1,0 +1,7 @@
+(lang dune 3.0)
+(using dune_site 0.1)
+(name test)
+
+(package
+ (name test)
+ (sites (share contents)))

--- a/test/blackbox-tests/test-cases/relocatable-site.t/run.t
+++ b/test/blackbox-tests/test-cases/relocatable-site.t/run.t
@@ -1,0 +1,7 @@
+  $ dune build @install
+  $ mkdir install
+  $ dune install --prefix /tmp/install --relocatable 2> /dev/null
+Expect the placeholder to be replaced by 'share/test',
+not by '/tmp/install/share/test'.
+  $ grep /tmp/install/bin/test -e "=10:share/test"
+  Binary file /tmp/install/bin/test matches

--- a/test/blackbox-tests/test-cases/relocatable-site.t/test.ml
+++ b/test/blackbox-tests/test-cases/relocatable-site.t/test.ml
@@ -1,0 +1,3 @@
+Format.printf "%a@."
+  (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_string)
+  Site.Sites.contents;;


### PR DESCRIPTION
The relocation process does not work when the executable is installed out of the build context.

Regardless of the `--relocatable` flag, the site location placeholder will be replaced by an absolute path.

The reason is that `conf_for_install` produce `External` paths.
 https://github.com/ocaml/dune/blob/0f3f1729b6e92a25b8ec34b808f08acc277620de/src/dune_rules/artifact_substitution.ml#L79-L99

Then, when the location is evaluated, the code calls the function `Path.reach`.
https://github.com/ocaml/dune/blob/0f3f1729b6e92a25b8ec34b808f08acc277620de/src/dune_rules/artifact_substitution.ml#L123-L129

Yet, the first case of the function is:
https://github.com/ocaml/dune/blob/38a48560a01f1033bc6e7691a5a75e44ad954341/otherlibs/stdune/path.ml#L844-L846
So, the path will never be rebased.
