### PR TITLE
Preserve the old value when invalidating Memo nodes

### DIFF
--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -460,6 +460,10 @@ module Debug : sig
 
   (** If [true], Memo will perform additional checks of internal invariants. *)
   val check_invariants : bool ref
+
+  (** If [true], Memo will print out some diagnostics. It's convenient to set
+      this flag temporarily while debugging a test. *)
+  val verbose_diagnostics : bool ref
 end
 
 (** Various performance counters. Reset to zero at the start of every run. *)

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -1986,16 +1986,13 @@ let%expect_test "Simple computation chain with a cutoff" =
   Memo.reset (Memo.Cell.invalidate ~reason:Test cell);
   evaluate_and_print f 3;
   print_perf_counters ();
-  (* CR-someday amokhov: Only f(1) should be recomputed because we've just
-     invalidated it. However, for some reason, f(2) gets recomputed too. Only
-     afterwards the cutoff kicks in. *)
+  (* CR-someday amokhov: f(1) is recomputed because we've just invalidated it.
+     Further recomputations are avoided thanks to the early cutoff. *)
   [%expect
     {|
     Started evaluating f(1)
     Evaluated f(1) = 1
-    Started evaluating f(2)
-    Evaluated f(2) = 2
     f 3 = Ok 3
-    Memo graph: 3/2 restored/computed nodes, 4 traversed edges
+    Memo graph: 3/1 restored/computed nodes, 3 traversed edges
     Memo cycle detection graph: 0/0/0 nodes/edges/paths
   |}]


### PR DESCRIPTION
This fixes the issue reported in #5320. It turned out to be not so mysterious after all: before this PR, we forgot the old value when invalidating a Memo node. There was a CR-someday to change this, which is what this PR does.

(I left some debugging infrastructure I used to debug this issue on purpose.)