### PR TITLE
Refactor Sub_dirs.eval

### DIFF
--- a/test/blackbox-tests/test-cases/vendor/main.t/run.t
+++ b/test/blackbox-tests/test-cases/vendor/main.t/run.t
@@ -36,7 +36,7 @@ The same directory cannot be marked as both vendored and data-only
 
   $ dune build --root conflicts-with-data-only
   Entering directory 'conflicts-with-data-only'
-  Error: Directory dir was marked as vendored and data_only, it can't be marked
+  Error: Directory dir was marked as data_only and vendored, it can't be marked
   as both.
   [1]
 


### PR DESCRIPTION
Make it more generic against the list of statuses. This is to prepare for an upcoming feature adding a new directory status (for generated directories).

There is no change in behaviour except for the ordering of statuses in error messages. I didn't try to preserve it since any order works fine.