### PR TITLE
Re-arrange some functions in Load_rules

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -78,7 +78,7 @@ let term =
              executable, they would be located in a subdirectory of [dir], so
              it's unclear if that's what the user wanted. *)
           let+ candidates =
-            Load_rules.file_targets_of ~dir:(Path.build dir)
+            Build_system.files_of ~dir:(Path.build dir)
             >>| Path.Set.to_list
             >>| List.filter ~f:(fun p -> Path.extension p = ".exe")
             >>| List.map ~f:(fun p -> "./" ^ Path.basename p)
@@ -98,14 +98,14 @@ let term =
               | Ok prog -> build_prog prog)
             | Relative_to_current_dir -> (
               let path = Path.relative (Path.build dir) prog in
-              (Load_rules.is_target path >>= function
+              (Build_system.file_exists path >>= function
                | true -> Memo.Build.return (Some path)
                | false -> (
                  if not (Filename.check_suffix prog ".exe") then
                    Memo.Build.return None
                  else
                    let path = Path.extend_basename path ~suffix:".exe" in
-                   Load_rules.is_target path >>= function
+                   Build_system.file_exists path >>= function
                    | true -> Memo.Build.return (Some path)
                    | false -> Memo.Build.return None))
               >>= function

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -125,8 +125,8 @@ let term =
           let* request =
             match targets with
             | [] ->
-              Load_rules.all_targets ()
-              >>| Path.Build.Set.fold ~init:[] ~f:(fun p acc ->
+              Load_rules.all_direct_targets ()
+              >>| Path.Build.Map.foldi ~init:[] ~f:(fun p _ acc ->
                       Path.build p :: acc)
               >>| Action_builder.paths
             | _ ->

--- a/bin/utop.ml
+++ b/bin/utop.ml
@@ -37,7 +37,7 @@ let term =
             let utop_target =
               Path.build (Path.Build.relative context.build_dir utop_target)
             in
-            Load_rules.is_target utop_target >>= function
+            Build_system.file_exists utop_target >>= function
             | false ->
               User_error.raise
                 [ Pp.textf "no library is defined in %s"

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -104,7 +104,7 @@ let if_file_exists p ~then_ ~else_ =
     { f =
         (fun mode ->
           let open Memo.Build.O in
-          Load_rules.file_exists p >>= function
+          Build_system.file_exists p >>= function
           | true -> run then_ mode
           | false -> run else_ mode)
     }

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -12,6 +12,9 @@ val build_file : Path.t -> Digest.t Memo.Build.t
 (** Build a file and access its contents with [f]. *)
 val read_file : Path.t -> f:(Path.t -> 'a) -> 'a Memo.Build.t
 
+(** Return [true] if a file exists or is buildable *)
+val file_exists : Path.t -> bool Memo.Build.t
+
 (** Build a set of dependencies and return learned facts about them. *)
 val build_deps : Dep.Set.t -> Dep.Facts.t Memo.Build.t
 
@@ -20,6 +23,9 @@ val build_deps : Dep.Set.t -> Dep.Facts.t Memo.Build.t
     of file targets. Currently, this function ignores directory targets, which
     is a limitation we'd like to remove in future. *)
 val eval_pred : File_selector.t -> Path.Set.t Memo.Build.t
+
+(** Same as [eval_pred] with [Predicate.true_] as predicate. *)
+val files_of : dir:Path.t -> Path.Set.t Memo.Build.t
 
 (** Like [eval_pred] but also builds the resulting set of files. This function
     doesn't have [eval_pred]'s limitation about directory targets and takes them

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -28,18 +28,10 @@ module Loaded : sig
   val no_rules : allowed_subdirs:Path.Unspecified.w Dir_set.t -> t
 end
 
-(** Returns the set of file targets in the given directory. *)
-val file_targets_of : dir:Path.t -> Path.Set.t Memo.Build.t
-
 (** Load the rules for this directory. *)
 val load_dir : dir:Path.t -> Loaded.t Memo.Build.t
 
-(** Return [true] if a file exists or is buildable *)
-val file_exists : Path.t -> bool Memo.Build.t
-
 val alias_exists : Alias.t -> bool Memo.Build.t
-
-val is_target : Path.t -> bool Memo.Build.t
 
 (** Return the rule that has the given file has target, if any *)
 val get_rule : Path.t -> Rule.t option Memo.Build.t
@@ -48,8 +40,20 @@ val get_rule : Path.t -> Rule.t option Memo.Build.t
 val get_alias_definition :
   Alias.t -> (Loc.t * Rules.Dir_rules.Alias_spec.item) list Memo.Build.t
 
-(** List of all buildable targets. *)
-val all_targets : unit -> Path.Build.Set.t Memo.Build.t
+type target_type =
+  | File
+  | Directory
+
+type is_target =
+  | No
+  | Yes of target_type
+  | Under_directory_target_so_cannot_say
+
+val is_target : Path.t -> is_target Memo.Build.t
+
+(** List of all buildable direct targets. This does not include files and
+    directory produced under a directory target. *)
+val all_direct_targets : unit -> target_type Path.Build.Map.t Memo.Build.t
 
 type rule_or_source =
   | Source of Digest.t


### PR DESCRIPTION
This PR doesn't change the behaviour of Dune, but re-organise the code in preparation for a sub-sequent PR.

It renames `Load_rules.file_exists` to `Build_system.file_exists` and `Load_rules.file_targets_of` to `Build_system.files_of`. This is because these functions are expected to work on the "expanded build directory", i.e. where all files that can be built have been built. Now that we have directory targets, `Load_rules` can no longer answer such questions. Indeed, in order to know if a file under a directory target exists in the expanded view, it would need to build the directory target. However, `Load_rules` comes before `Build_system` so it cannot do that.

This PR doesn't change the implementation of `file_exists` and `files_of`, so these functions still do the wrong thing for paths under a directory target, but a sub-sequent PR will change this.

This commit also makes the signature of `Load_rules.is_target` and `Load_rules.all_targets` more precise, to make their behaviour clearer regarding paths under a directory target. In particular, `Load_rules.is_target` now returns `Under_directory_target_so_cannot_say` for paths that are under a directory target, to make it clear it is not able to give an answer.

This PR then adapts the various call sites, in particular replacing some `Load_rules.is_target` by `Build_system.file_exists` and some `Load_rules.file_targets_of` by `Build_system.files_of` when approriate.
