### PR TITLE
Fixed Makefile so that the dev-switch rule works with a shell different than bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ dev-deps:
 dev-switch:
 	opam update
 # Ensuring that either a dev switch already exists or a new one is created
-	test "$(shell opam switch show) == $(shell pwd)" || \
+	test "$(shell opam switch show)" = "$(shell pwd)" || \
 		opam switch create -y . 4.12.0 --deps-only --with-test
 	opam install -y $(TEST_DEPS) $(DEV_DEPS)
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ dev-deps:
 dev-switch:
 	opam update
 # Ensuring that either a dev switch already exists or a new one is created
-	[[ $(shell opam switch show) == $(shell pwd) ]] || \
+	test "$(shell opam switch show) == $(shell pwd)" || \
 		opam switch create -y . 4.12.0 --deps-only --with-test
 	opam install -y $(TEST_DEPS) $(DEV_DEPS)
 


### PR DESCRIPTION
The command "[[ ... ]]" is supported by bash, but not by sh or dash
(these shell are used by default in Ubuntu, for example).

Signed-off-by: Benoît Montagu <benoit.montagu@inria.fr>