### PR TITLE
support `DUNE_DIFF_COMMAND` environment variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Add a `DUNE_DIFF_COMMAND` environment variable to match `--diff-command`
+  command-line parameter (@raphael-proust, fix #5369, #5375)
+
 - Add support for odoc-link rules (#5045, @lubegasimon)
 
 - Dune will no longer generate documentation for hidden modules (#5045,

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -889,13 +889,15 @@ let term ~default_root_is_cwd =
           ~env:(Arg.env_var ~doc "DUNE_BUILD_DIR")
           ~doc)
   and+ diff_command =
+    let doc = "Shell command to use to diff files.\n\
+              \                   Use - to disable printing the diff."
+    in
     Arg.(
       value
       & opt (some string) None
       & info [ "diff-command" ] ~docs
-          ~doc:
-            "Shell command to use to diff files.\n\
-            \                   Use - to disable printing the diff.")
+          ~env:(Arg.env_var ~doc "DUNE_DIFF_COMMAND")
+          ~doc)
   and+ stats_trace_file =
     Arg.(
       value


### PR DESCRIPTION
https://github.com/ocaml/dune/issues/5369

If `--diff-command` is used, use this.  
Otherwise, if `DUNE_DIFF_COMMAND` is set, use this.  
Otherwise use the same default as before.