### PR TITLE
chore: remove result from configurator

### DIFF
--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -20,7 +20,6 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.04.0"}
-  "result"
   "csexp" {>= "1.3.0"}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -85,7 +85,6 @@ no stability guarantee.
  (name dune-configurator)
  (depends
   (ocaml (>= 4.04.0))
-  result
   (csexp (>= 1.3.0)))
  (synopsis "Helper library for gathering system configuration")
  (description "\

--- a/otherlibs/configurator/src/dune
+++ b/otherlibs/configurator/src/dune
@@ -4,7 +4,7 @@
  (name configurator)
  (public_name dune-configurator)
  (private_modules import dune_lang ocaml_config)
- (libraries unix csexp result)
+ (libraries unix csexp)
  (flags
   (:standard
    -safe-string


### PR DESCRIPTION
we don't support 4.03 anyway, so compatibility isn't needed.
