### PR TITLE
mdx stanza: record env var dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -261,7 +261,7 @@ Unreleased
 
 - Introduce mdx stanza 0.2, requiring mdx >= 1.9.0, with a new generic `deps`
   field and the possibility to statically link `libraries` in the test
-  executable. (#3956, fixes #3955)
+  executable. (#3956, #5391, fixes #3955)
 
 - Improve lookup of optional or disabled binaries. Previously, we'd treat every
   executable with missing libraries as optional. Now, we treat make sure to

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ core_bench \
 "csexp>=1.3.0" \
 js_of_ocaml \
 js_of_ocaml-compiler \
-mdx \
+"mdx>=2.1.0" \
 menhir \
 "merlin>=3.4.0" \
 ocamlfind \

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -255,6 +255,8 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog
         Dep_conf_eval.unnamed ~expander (mdx_package_deps @ mdx_generic_deps)
       in
       Action_builder.with_no_targets deps
+      >>> Action_builder.with_no_targets
+            (Action_builder.env_var "MDX_RUN_NON_DETERMINISTIC")
       >>> Action_builder.with_no_targets (Action_builder.dyn_deps dyn_deps)
       >>> Command.run ~dir:(Path.build dir) ~stdout_to:files.corrected
             executable command_line

--- a/test/blackbox-tests/test-cases/mdx-stanza/env-variables.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/env-variables.t
@@ -1,0 +1,59 @@
+Dune should know about the fact that mdx reads the MDX_RUN_NON_DETERMINISTIC
+variable. When using the stanza 0.2, it is the mdx driver that reads that
+variable. This is only the case since mdx 2.1.0.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
+  > (using mdx 0.2)
+  > EOF
+
+  $ cat > dune << EOF
+  > (mdx (files README.md))
+  > EOF
+
+  $ cat > README.md << 'EOF'
+  > ```ocaml
+  > # "a";;
+  > ```
+  > 
+  > ```ocaml non-deterministic
+  > # "b";;
+  > ```
+  > EOF
+
+  $ dune runtest --auto-promote
+  File "README.md", line 1, characters 0-0:
+  Error: Files _build/default/README.md and
+  _build/default/.mdx/README.md.corrected differ.
+  Promoting _build/default/.mdx/README.md.corrected to README.md.
+  [1]
+
+  $ cat README.md
+  ```ocaml
+  # "a";;
+  - : string = "a"
+  ```
+  
+  ```ocaml non-deterministic
+  # "b";;
+  ```
+
+  $ dune runtest
+
+  $ MDX_RUN_NON_DETERMINISTIC=1 dune runtest --auto-promote
+  File "README.md", line 1, characters 0-0:
+  Error: Files _build/default/README.md and
+  _build/default/.mdx/README.md.corrected differ.
+  Promoting _build/default/.mdx/README.md.corrected to README.md.
+  [1]
+
+  $ cat README.md
+  ```ocaml
+  # "a";;
+  - : string = "a"
+  ```
+  
+  ```ocaml non-deterministic
+  # "b";;
+  - : string = "b"
+  ```


### PR DESCRIPTION
Since realworldocaml/mdx#366, the executable output by `ocaml-mdx dune-gen` supports `MDX_RUN_NON_DETERMINISTIC` like `ocaml-mdx test` itself. Dune needs to know about that to rerun the tests if the variable has been set in the meantime.
