### PR TITLE
bootstrap.ml: ignore errors when trying to remove generated files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -305,6 +305,9 @@ Unreleased
 
 - Add link_flags in the env stanza (#5215)
 
+- Bootstrap: ignore errors when trying to remove generated files. (#5407,
+  @damiendoligez)
+
 2.9.3 (unreleased)
 ------------------
 

--- a/bootstrap.ml
+++ b/bootstrap.ml
@@ -45,7 +45,7 @@ let () =
               String.length fn >= String.length duneboot
               && String.sub fn ~pos:0 ~len:(String.length duneboot) = duneboot
             then
-              Sys.remove fn))
+              try Sys.remove fn with Sys_error _ -> ()))
 
 let runf fmt =
   ksprintf


### PR DESCRIPTION
The `bootstrap.ml` script tries to remove generated files when it exits. It does so by calling `Sys.remove`. Unfortunately, `Sys.remove` cannot remove directories, and on Macos the C compiler and linker generate a directory (in this case, `.duneboot.exe.dSYM`) to hold debugging information. This breaks `make release`.

To reproduce, just run this on Macos:
```
OCAMLPARAM=_,cclib=-g make release
```
To solve this problem, the best solution is to just ignore errors when removing the generated files.
