### PR TITLE
fix(inotify): watch arbitrary depth

### DIFF
--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -73,7 +73,7 @@ val wait_for_initial_watches_established_blocking : t -> unit
     far. *)
 val emit_sync : t -> Sync_id.t
 
-val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
+val add_watch : t -> Path.t -> unit
 
 module For_tests : sig
   val should_exclude : string -> bool

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -69,4 +69,15 @@ let%expect_test _ =
     {|
   { path = In_source_tree "d/w/y"; kind = "Created" }
   { path = In_source_tree "d/w/y"; kind = "File_changed" }
-|}]
+  |}];
+  (match Dune_file_watcher.add_watch watcher (Path.of_string "e/1/2") with
+  | Error _ -> assert false
+  | Ok () -> ());
+  let (_ : _) = Fpath.mkdir_p "e/1" in
+  Stdio.Out_channel.write_all "e/1/2" ~data:"z";
+  print_events 3;
+  [%expect
+    {|
+    { path = In_source_tree "e"; kind = "Created" }
+    { path = In_source_tree "e/1"; kind = "Created" }
+    { path = In_source_tree "e/1/2"; kind = "Created" } |}]

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -32,9 +32,7 @@ let%expect_test _ =
               | Watcher_terminated -> assert false)))
   in
   let print_events n = print_events ~try_to_get_events ~expected:n in
-  (match Dune_file_watcher.add_watch watcher (Path.of_string ".") with
-  | Error _ -> assert false
-  | Ok () -> ());
+  Dune_file_watcher.add_watch watcher (Path.of_string ".");
   Dune_file_watcher.wait_for_initial_watches_established_blocking watcher;
   Stdio.Out_channel.write_all "x" ~data:"x";
   print_events 2;
@@ -52,9 +50,7 @@ let%expect_test _ =
     { path = In_source_tree "y"; kind = "Created" }
 |}];
   let (_ : _) = Fpath.mkdir_p "d/w" in
-  (match Dune_file_watcher.add_watch watcher (Path.of_string "d/w") with
-  | Error _ -> assert false
-  | Ok () -> ());
+  Dune_file_watcher.add_watch watcher (Path.of_string "d/w");
   Stdio.Out_channel.write_all "d/w/x" ~data:"x";
   print_events 3;
   [%expect
@@ -70,9 +66,7 @@ let%expect_test _ =
   { path = In_source_tree "d/w/y"; kind = "Created" }
   { path = In_source_tree "d/w/y"; kind = "File_changed" }
   |}];
-  (match Dune_file_watcher.add_watch watcher (Path.of_string "e/1/2") with
-  | Error _ -> assert false
-  | Ok () -> ());
+  Dune_file_watcher.add_watch watcher (Path.of_string "e/1/2");
   let (_ : _) = Fpath.mkdir_p "e/1" in
   Stdio.Out_channel.write_all "e/1/2" ~data:"z";
   print_events 3;

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -72,6 +72,9 @@ let%expect_test _ =
   print_events 3;
   [%expect
     {|
+    { path = In_source_tree "e"; kind = "Created" }
+    { path = In_source_tree "e/1"; kind = "Created" }
     { path = In_source_tree "e/1/2"; kind = "Created" }
     { path = In_source_tree "e/1"; kind = "Created" }
-    { path = In_source_tree "e/1/2"; kind = "File_changed" } |}]
+    { path = In_source_tree "e/1/2"; kind = "File_changed" }
+    Got more events than expected: expected 3, saw 5 |}]

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -72,6 +72,6 @@ let%expect_test _ =
   print_events 3;
   [%expect
     {|
-    { path = In_source_tree "e"; kind = "Created" }
+    { path = In_source_tree "e/1/2"; kind = "Created" }
     { path = In_source_tree "e/1"; kind = "Created" }
-    { path = In_source_tree "e/1/2"; kind = "Created" } |}]
+    { path = In_source_tree "e/1/2"; kind = "File_changed" } |}]


### PR DESCRIPTION
This PR fixes the inotify backend to allow watching `x/y/z` even if `y` (or `x`) do not exist. The fix works by watching the topmost directory that exists and then adding more watches as descendants are created. After adding a watch, we rescan the directory (as per the manual) because some events might have already occurred in that directory.