### PR TITLE
Fix a typo in the documentation's diff test section

### DIFF
--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -466,7 +466,7 @@ command. For instance, let's consider this test:
 
    (rule
     (alias runtest)
-    (action (diff tests.expected test.output)))
+    (action (diff tests.expected tests.output)))
 
 After having run ``tests.exe`` and dumping its output to ``tests.output``, Dune
 will compare the latter to ``tests.expected``. In case of mismatch, Dune will


### PR DESCRIPTION
This is a simple adjustment, the `test.output` should really be `tests.output`, as defined in the previous code snippet here:
```
(rule (with-stdout-to tests.output (run ./tests.exe)))

(rule
 (alias runtest)
 (action (diff tests.expected test.output)))
 ```
 