### PR TITLE
Preview: upgrade ocamlformat to 0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.20.1
+version=0.21.0
 profile=conventional
 ocaml-version=4.08.0
 break-separators=before

--- a/otherlibs/action-plugin/src/dune_action_plugin.mli
+++ b/otherlibs/action-plugin/src/dune_action_plugin.mli
@@ -58,7 +58,9 @@ module V1 : sig
 
         is equivalent to:
 
-        {[ map g ~f:(fun a -> h) ]} *)
+        {[
+          map g ~f:(fun a -> h)
+        ]} *)
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
 
     (** {[
@@ -69,7 +71,9 @@ module V1 : sig
 
         is equivalent to:
 
-        {[ both g1 g2 |> map ~f:(fun (a1, a2) -> h) ]} *)
+        {[
+          both g1 g2 |> map ~f:(fun (a1, a2) -> h)
+        ]} *)
     val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
   end
 

--- a/otherlibs/configurator/src/v1.mli
+++ b/otherlibs/configurator/src/v1.mli
@@ -55,7 +55,9 @@ module C_define : sig
   (** Generate a C header file containing the following #define.
       [protection_var] is used to enclose the file with:
 
-      {[ #ifndef BLAH #define BLAH ... #endif ]}
+      {[
+        #ifndef BLAH #define BLAH ... #endif
+      ]}
 
       If not specified, it is inferred from the name given to [create] and the
       filename. *)

--- a/otherlibs/stdune/console.mli
+++ b/otherlibs/stdune/console.mli
@@ -43,13 +43,17 @@ include Backend.S
 
 (** [print paragraphs] is a short-hand for:
 
-    {[ print_user_message (User_message.make paragraphs) ]} *)
+    {[
+      print_user_message (User_message.make paragraphs)
+    ]} *)
 val print : User_message.Style.t Pp.t list -> unit
 
 (** [printf fmt] is a convenient function for debugging. It formats a string and
     then print it raw followed by a newline. It is the same as:
 
-    {[ print [Pp.verbatim (sprintf fmt ...)] ]}
+    {[
+      print [Pp.verbatim (sprintf fmt ...)]
+    ]}
 
     For properly formatted output you should use [print]. *)
 val printf : ('a, unit, string, unit) format4 -> 'a

--- a/otherlibs/stdune/map_intf.ml
+++ b/otherlibs/stdune/map_intf.ml
@@ -95,13 +95,17 @@ module type S = sig
 
   (** Return a map of [(k, v)] bindings such that:
 
-      {[ v = f init @@ f v1 @@ fv2 @@ ... @@ f vn ]}
+      {[
+        v = f init @@ f v1 @@ fv2 @@ ... @@ f vn
+      ]}
 
       where [v1], [v2], ... [vn] are the values associated to [k] in the input
       list, in the order in which they appear. This is essentially a more
       efficient version of:
 
-      {[ of_list_multi l |> map ~f:(List.fold_left ~init ~f) ]} *)
+      {[
+        of_list_multi l |> map ~f:(List.fold_left ~init ~f)
+      ]} *)
   val of_list_fold : (key * 'a) list -> init:'b -> f:('b -> 'a -> 'b) -> 'b t
 
   val keys : 'a t -> key list

--- a/otherlibs/stdune/path.mli
+++ b/otherlibs/stdune/path.mli
@@ -258,7 +258,9 @@ val extend_basename : t -> suffix:string -> t
 (** Extract the build context from a path. For instance, representing paths as
     strings:
 
-    {[ extract_build_context "_build/blah/foo/bar" = Some ("blah", "foo/bar") ]}
+    {[
+      extract_build_context "_build/blah/foo/bar" = Some ("blah", "foo/bar")
+    ]}
 
     It doesn't work correctly (doesn't return a sensible source path) for build
     directories that are not build contexts, e.g. "_build/install" and

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -143,7 +143,9 @@ module Full : sig
   (** The various [add_xxx] functions merge the given value with existing field
       of the action. Put another way, [add_xxx x t] is the same as:
 
-      {[ combine t (make ~xxx:x (Progn [])) ]} *)
+      {[
+        combine t (make ~xxx:x (Progn []))
+      ]} *)
 
   val add_env : Env.t -> t -> t
 

--- a/src/dune_engine/dir_set.mli
+++ b/src/dune_engine/dir_set.mli
@@ -20,7 +20,9 @@ val universal : 'w t
 
 (** [trivial b] is such that for all path [p]:
 
-    {[ mem (trivial b) p = b ]}
+    {[
+      mem (trivial b) p = b
+    ]}
 
     i.e. [trivial false] is [empty] and [trivial true] is [universal]. *)
 val trivial : bool -> 'w t

--- a/src/dune_engine/dune_project.mli
+++ b/src/dune_engine/dune_project.mli
@@ -90,7 +90,9 @@ module Lang : sig
   (** [register id stanzas_parser] register a new language. Users will select
       this language by writing:
 
-      {[ (lang <name> <version>) ]}
+      {[
+        (lang <name> <version>)
+      ]}
 
       as the first line of their [dune-project] file. [stanza_parsers] defines
       what stanzas the user can write in [dune] files. *)
@@ -103,7 +105,9 @@ module Extension : sig
   (** [register id parser] registers a new extension. Users will enable this
       extension by writing:
 
-      {[ (using <name> <version> <args>) ]}
+      {[
+        (using <name> <version> <args>)
+      ]}
 
       in their [dune-project] file. [parser] is used to describe what [<args>]
       might be. *)

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -27,7 +27,7 @@ module Dir_rules : sig
 
            When passing [--force] to Dune, these are exactly the actions that
            will be re-executed. *)
-          Action of
+        Action of
           Rule.Anonymous_action.t Action_builder.t
 
     type t = { expansions : (Loc.t * item) Appendable_list.t } [@@unboxed]

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -711,7 +711,7 @@ end
 type status =
   | (* We are not doing a build. Just accumulating invalidations until the next
        build starts. *)
-      Standing_by of
+    Standing_by of
       { invalidation : Memo.Invalidation.t
       ; saw_insignificant_changes : bool
             (* Whether we saw build input changes that are insignificant for the
@@ -721,10 +721,10 @@ type status =
                change. *)
       }
   | (* Running a build *)
-      Building of Fiber_util.Cancellation.t
+    Building of Fiber_util.Cancellation.t
   | (* Cancellation requested. Build jobs are immediately rejected in this
        state *)
-      Restarting_build of
+    Restarting_build of
       Memo.Invalidation.t
 
 module Build_outcome = struct

--- a/src/dune_lang/decoder.mli
+++ b/src/dune_lang/decoder.mli
@@ -98,7 +98,9 @@ val atom_matching : (string -> 'a option) -> desc:string -> 'a t
 
 (** [keyword s] is a short-hand for
 
-    {[ atom_matching (String.equal s) ~desc:(sprintf "'%s'" s) ]} *)
+    {[
+      atom_matching (String.equal s) ~desc:(sprintf "'%s'" s)
+    ]} *)
 val keyword : string -> unit t
 
 (** Use [before] to parse elements until the keyword is reached. Then use

--- a/src/dune_lang/lexer.mli
+++ b/src/dune_lang/lexer.mli
@@ -18,7 +18,9 @@ module Token : sig
 
             is represented as:
 
-            {[ Lines [ " abc"; " def" ] ]} *)
+            {[
+              Lines [ " abc"; " def" ]
+            ]} *)
 end
 
 type t = with_comments:bool -> Lexing.lexbuf -> Token.t

--- a/src/dune_lang/versioned_file.mli
+++ b/src/dune_lang/versioned_file.mli
@@ -10,7 +10,9 @@ module type S = sig
     (** [register id data] registers a new language. Users will select this
         language by writing:
 
-        {[ (lang <name> <version>) ]}
+        {[
+          (lang <name> <version>)
+        ]}
 
         as the first line of the versioned file. *)
     val register : Syntax.t -> data -> unit

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -12,15 +12,15 @@ module T = struct
     | Generated
     | Source_only of Source_tree.Dir.t
     | (* Directory not part of a multi-directory group *)
-        Standalone of
+      Standalone of
         Source_tree.Dir.t * Stanza.t list Dir_with_dune.t
     | (* Directory with [(include_subdirs x)] where [x] is not [no] *)
-        Group_root of
+      Group_root of
         Source_tree.Dir.t
         * (Loc.t * Include_subdirs.qualification)
         * Stanza.t list Dir_with_dune.t
     | (* Sub-directory of a [Group_root _] *)
-        Is_component_of_a_group_but_not_the_root of
+      Is_component_of_a_group_but_not_the_root of
         is_component_of_a_group_but_not_the_root
 end
 

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -388,7 +388,7 @@ and resolve_result =
   | Hidden of Lib_info.external_ Hidden.t
   | Invalid of exn
   | (* Redirect (None, lib) looks up lib in the same database *)
-      Redirect of
+    Redirect of
       db option * (Loc.t * Lib_name.t)
 
 let lib_config (t : lib) = t.lib_config

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -175,13 +175,14 @@ module Processed = struct
             , init.config.src_dirs
             , [ init.config.flags ]
             , init.config.extensions )
-          ~f:
-            (fun (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
-                 { modules = _
-                 ; pp_config
-                 ; config =
-                     { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
-                 } ->
+          ~f:(fun
+               (acc_pp, acc_obj, acc_src, acc_flags, acc_ext)
+               { modules = _
+               ; pp_config
+               ; config =
+                   { stdlib_dir = _; obj_dirs; src_dirs; flags; extensions }
+               }
+             ->
             ( pp_config :: acc_pp
             , Path.Set.union acc_obj obj_dirs
             , Path.Set.union acc_src src_dirs

--- a/src/dune_util/log.mli
+++ b/src/dune_util/log.mli
@@ -21,7 +21,9 @@ val info_user_message : User_message.t -> unit
 
 (** [info paragraphs] is a short-hand for:
 
-    {[ info_user_message (User_message.make paragraphs) ]} *)
+    {[
+      info_user_message (User_message.make paragraphs)
+    ]} *)
 val info : User_message.Style.t Pp.t list -> unit
 
 (** Print an executed command in the log *)

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -149,7 +149,9 @@ module Var : sig
 
       For instance, the following fiber always evaluate to [true]:
 
-      {[ set v x (get_exn v >>| fun y -> x = y) ]} *)
+      {[
+        set v x (get_exn v >>| fun y -> x = y)
+      ]} *)
   val set : 'a t -> 'a -> (unit -> 'b fiber) -> 'b fiber
 
   val unset : 'a t -> (unit -> 'b fiber) -> 'b fiber

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -107,9 +107,7 @@ module Spec = struct
     let name =
       match name with
       | None when !Debug.track_locations_of_lazy_values ->
-        Option.map
-          (Caller_id.get ~skip:[ __FILE__ ])
-          ~f:(fun loc ->
+        Option.map (Caller_id.get ~skip:[ __FILE__ ]) ~f:(fun loc ->
             sprintf "lazy value created at %s" (Loc.to_file_colon_line loc))
       | _ -> name
     in

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -76,7 +76,9 @@ module Common = struct
       | List
           ( loc
           , (Atom (_, A "lang") as lang)
-            :: (Atom (_, A "dune") as dune) :: Atom (loc3, A _) :: tll )
+            :: (Atom (_, A "dune") as dune)
+            :: Atom (loc3, A _)
+            :: tll )
         :: tl ->
         List
           (loc, lang :: dune :: Atom (loc3, Dune_lang.Atom.of_string v) :: tll)


### PR DESCRIPTION
~Built on top of #5018~

This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

As always, we are happy to hear your feedback! Thank you for using ocamlformat!