### PR TITLE
fix: Improve dune-project skeleton package element

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -328,7 +328,7 @@ Some or all of these fields may be overridden for each package of the project, s
 package
 -------
 
-Package specific information is specified in the ``(package <package>)`` stanza.
+Package specific information is specified in the ``(package <package-fields>)`` stanza.
 It contains the following fields:
 
 - ``(name <string>)`` is the name of the package. This must be specified.


### PR DESCRIPTION
The old spelling made it seem that some kind of identifier
or name was expected after "(package ", which was super
confusing because it was immediately followed by discussion
of the various fields, including "(name ".