### PR TITLE
Make what-dune-watches tests more reproducible

### DIFF
--- a/test/blackbox-tests/test-cases/watching/what-dune-watches.t
+++ b/test/blackbox-tests/test-cases/watching/what-dune-watches.t
@@ -20,13 +20,7 @@ Show what Dune watches via inotify
 The pattern below excludes absolute files as Dune currently watches
 everything in the PATH, which is not very reproducible.
 
-  $ sed -nE 's/inotify_add_watch\([0-9]*, "([^/].*)", .*\) (=.*)/watch \1 \2/p' ../log
+  $ sed -nE 's/inotify_add_watch\([0-9]*, "([^/].*)", .*\) (=.*)/watch \1 \2/p' ../log | sort -u
+  watch . = 2
   watch _build/.sync = 1
-  watch . = 2
-  watch . = 2
-  watch . = 2
-  watch src = 3
-  watch . = 2
-  watch src = 3
-  watch src = 3
   watch src = 3


### PR DESCRIPTION
I guess the order and repeated entries don't matter, so let's dedup and sort.