### PR TITLE
fix: disable build path prefix map pre 3.0

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -504,12 +504,18 @@ let exec ~targets ~root ~context ~env ~rule_loc ~build_deps
     ~execution_parameters t =
   let purpose = Process.Build_job (None, User_message.Annots.empty, targets) in
   let env =
-    extend_build_path_prefix_map env `New_rules_have_precedence
-      [ Some
-          { source = Path.to_absolute_filename root
-          ; target = "/workspace_root"
-          }
-      ]
+    match
+      Execution_parameters.add_workspace_root_to_build_path_prefix_map
+        execution_parameters
+    with
+    | false -> env
+    | true ->
+      extend_build_path_prefix_map env `New_rules_have_precedence
+        [ Some
+            { source = Path.to_absolute_filename root
+            ; target = "/workspace_root"
+            }
+        ]
   in
   let ectx = { targets; purpose; context; rule_loc; build_deps }
   and eenv =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -360,7 +360,7 @@ end = struct
 
   (* The current version of the rule digest scheme. We should increment it when
      making any changes to the scheme, to avoid collisions. *)
-  let rule_digest_version = 10
+  let rule_digest_version = 11
 
   let compute_rule_digest (rule : Rule.t) ~deps ~action ~sandbox_mode
       ~execution_parameters =
@@ -388,7 +388,8 @@ end = struct
       , can_go_in_shared_cache
       , List.map locks ~f:Path.to_string
       , Execution_parameters.action_stdout_on_success execution_parameters
-      , Execution_parameters.action_stderr_on_success execution_parameters )
+      , Execution_parameters.action_stderr_on_success execution_parameters
+      , Execution_parameters.expand_aliases_in_sandbox execution_parameters )
     in
     Digest.generic trace
 

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -86,6 +86,8 @@ let dune_version t = t.dune_version
 let should_remove_write_permissions_on_generated_files t =
   t.dune_version >= (2, 4)
 
+let add_workspace_root_to_build_path_prefix_map t = t.dune_version >= (3, 0)
+
 let expand_aliases_in_sandbox t = t.expand_aliases_in_sandbox
 
 let action_stdout_on_success t = t.action_stdout_on_success

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -52,6 +52,8 @@ val set_action_stderr_on_success : Action_output_on_success.t -> t -> t
 
 val set_expand_aliases_in_sandbox : bool -> t -> t
 
+val add_workspace_root_to_build_path_prefix_map : t -> bool
+
 (** As configured by [init] *)
 val default : t Memo.Build.t
 

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t/run.t
@@ -36,9 +36,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [bfd46d3e78576b3273cc8897339fb1fb] (_build/default/source): not found in cache
+  Shared cache miss [ef66d7d3ff4264a591dc96ff4eac1f3a] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [418f8da32eb95ade2c3c399acbdd7ba3] (_build/default/target1): not found in cache
+  Shared cache miss [b7a99c68d779884507df259e4aa83ad3] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   1

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t/run.t
@@ -35,9 +35,9 @@ never built [target1] before.
   $ dune build --config-file=config target1 --debug-cache=shared,workspace-local \
   >   2>&1 | grep '_build/default/source\|_build/default/target'
   Workspace-local cache miss: _build/default/source: never seen this target before
-  Shared cache miss [bfd46d3e78576b3273cc8897339fb1fb] (_build/default/source): not found in cache
+  Shared cache miss [ef66d7d3ff4264a591dc96ff4eac1f3a] (_build/default/source): not found in cache
   Workspace-local cache miss: _build/default/target1: never seen this target before
-  Shared cache miss [418f8da32eb95ade2c3c399acbdd7ba3] (_build/default/target1): not found in cache
+  Shared cache miss [b7a99c68d779884507df259e4aa83ad3] (_build/default/target1): not found in cache
 
   $ dune_cmd stat hardlinks _build/default/source
   3

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t/run.t
@@ -67,7 +67,7 @@ Set 'cache-check-probability' to 1.0, which should trigger the check
   > EOF
   $ rm -rf _build
   $ dune build --config-file config reproducible non-reproducible
-  Warning: cache store error [bc44ce73b59c0f57bdf081b00fab6c00]: ((in_cache
+  Warning: cache store error [2522fd3dc29664b37f7c36af43b54479]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -119,7 +119,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ DUNE_CACHE_CHECK_PROBABILITY=1.0 dune build --cache=enabled reproducible non-reproducible
-  Warning: cache store error [bc44ce73b59c0f57bdf081b00fab6c00]: ((in_cache
+  Warning: cache store error [2522fd3dc29664b37f7c36af43b54479]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)
@@ -131,7 +131,7 @@ Test that the environment variable and the command line flag work too
 
   $ rm -rf _build
   $ dune build --cache=enabled --cache-check-probability=1.0 reproducible non-reproducible
-  Warning: cache store error [bc44ce73b59c0f57bdf081b00fab6c00]: ((in_cache
+  Warning: cache store error [2522fd3dc29664b37f7c36af43b54479]: ((in_cache
   ((non-reproducible 1c8fc4744d4cef1bd2b8f5e915b36be9))) (computed
   ((non-reproducible 6cfaa7a90747882bcf4ffe7252c1cf89)))) after executing
   (echo 'build non-reproducible';cp dep non-reproducible)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t/run.t
@@ -77,10 +77,10 @@ You will also need to make sure that the cache trimmer treats new and old cache
 entries uniformly.
 
   $ (cd "$PWD/.xdg-cache/dune/db/meta/v5"; grep -rws . -e 'metadata' | sort)
-  ./51/51a45667e2e30bf7625cded8dee3af12:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
-  ./ef/ef724517861c7ec3645a4b4183e01831:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./7f/7fa490191ab9b44e14146673ef811ece:((8:metadata)(5:files(8:target_b32:8a53bfae3829b48866079fa7f2d97781)))
+  ./90/90ed6e6f2741da06a6643d77ad1126a2:((8:metadata)(5:files(8:target_a32:5637dd9730e430c7477f52d46de3909c)))
 
-  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/ef/ef724517861c7ec3645a4b4183e01831"
+  $ dune_cmd stat size "$PWD/.xdg-cache/dune/db/meta/v5/90/90ed6e6f2741da06a6643d77ad1126a2"
   70
 
 Trimming the cache at this point should not remove any file entries because all


### PR DESCRIPTION
This breaks existing ppx rewriters which rely on real paths existing in
build artifacts.