### PR TITLE
fix: handle empty output from getconf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
 
 - Add direct dependencies to $ dune describe output (#5412, @esope)
 
+- Handle empty output from `getconf` (#5473, @mndrix)
+
 3.0.3 (Unreleased)
 ------------------
 

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -413,7 +413,10 @@ let auto_concurrency =
             | pid -> (
               Unix.close fdw;
               let ic = Unix.in_channel_of_descr fdr in
-              let n = input_line ic |> String.trim |> Int.of_string in
+              let n = match input_line ic with
+                | line -> String.trim line |> Int.of_string
+                | exception End_of_file -> None
+              in
               close_in ic;
               match (n, snd (Unix.waitpid [] pid)) with
               | Some n, WEXITED 0 -> n


### PR DESCRIPTION
If getconf prints nothing to its standard output, input_line raises
End_of_file instead of returning a string. That, or any other problem
while capturing the CPU count, should cause auto_concurrency to
attempt the next approach for detecting concurrency.

Fixes #5471

Signed-off-by: Michael Hendricks <michael@ndrix.org>