### PR TITLE
Depend on any provided foreign_archives for ctypes stub generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Unreleased
 
 - Look up `gmake` before `make` (#.., fixes #5470, @rgrinberg)
 
+- Depend on any provided `foreign_archives` for ctypes stub generation (#5475,
+  @mbacarella)
+
 3.0.2 (17/02/2022)
 ------------------
 


### PR DESCRIPTION
This PR sequences `ctypes` stub generation to depend on `foreign_archives` if they're provided in the enclosing `executable` or `library` stanza.

The use case this supports is a C library vendored in your project with complicated build rules that must run to completion before the rest of `ctypes` evaluation can proceed, like a lengthy `./configure` script that produces the vendored library's header files that must be included by the generated C stubs.

This doesn't change the dune `ctypes` extension language at all, and it should only fix functionality that was previously broken, so I don't believe it warrants bumping the ctypes extension version.