### PR TITLE
Handle EACCES on Fpath.mkdir* functions

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -332,8 +332,7 @@ module File_ops_real (W : Workspace) : File_operations = struct
       User_error.raise
         [ Pp.textf "Cannot create directory %s. Permission Denied."
             (Path.to_string_maybe_quoted p)
-        ; Pp.text
-            (Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e)
+        ; Pp.text (Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e)
         ]
 end
 

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -328,10 +328,12 @@ module File_ops_real (W : Workspace) : File_operations = struct
           [ Pp.textf "Please delete file %s manually."
               (Path.to_string_maybe_quoted p)
           ])
-    | Permission_denied ->
+    | Unix_error e ->
       User_error.raise
         [ Pp.textf "Cannot create directory %s. Permission Denied."
             (Path.to_string_maybe_quoted p)
+        ; Pp.text
+            (Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e)
         ]
 end
 

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -328,6 +328,11 @@ module File_ops_real (W : Workspace) : File_operations = struct
           [ Pp.textf "Please delete file %s manually."
               (Path.to_string_maybe_quoted p)
           ])
+    | Permission_denied ->
+      User_error.raise
+        [ Pp.textf "Cannot create directory %s. Permission Denied."
+            (Path.to_string_maybe_quoted p)
+        ]
 end
 
 module Sections = struct

--- a/otherlibs/stdune/fpath.ml
+++ b/otherlibs/stdune/fpath.ml
@@ -15,7 +15,8 @@ let mkdir ?(perms = 0o777) t_s =
     Created
   with
   | Unix.Unix_error (EEXIST, _, _) -> Already_exists
-  | Unix.Unix_error (errtyp, syscall, arg) -> Unix_error (FSError.create errtyp ~syscall ~arg)
+  | Unix.Unix_error (errtyp, syscall, arg) ->
+    Unix_error (FSError.create errtyp ~syscall ~arg)
 
 let rec mkdir_p ?(perms = 0o777) t_s =
   match mkdir ~perms t_s with
@@ -35,8 +36,7 @@ let rec mkdir_p ?(perms = 0o777) t_s =
            to create the parent directory concurrently. *)
         Unix.mkdir t_s perms;
         Created
-      | e -> e
-  )
+      | e -> e)
   | e -> e
 
 let resolve_link path =

--- a/otherlibs/stdune/fpath.mli
+++ b/otherlibs/stdune/fpath.mli
@@ -3,7 +3,8 @@
 type mkdir_result =
   | Already_exists  (** The directory already exists. No action was taken. *)
   | Created  (** The directory was created. *)
-  | Unix_error of Dune_filesystem_stubs.Unix_error.Detailed.t (** Unix errors to be handled by caller. *)
+  | Unix_error of Dune_filesystem_stubs.Unix_error.Detailed.t
+      (** Unix errors to be handled by caller. *)
 
 val mkdir : ?perms:int -> string -> mkdir_result
 

--- a/otherlibs/stdune/fpath.mli
+++ b/otherlibs/stdune/fpath.mli
@@ -3,18 +3,11 @@
 type mkdir_result =
   | Already_exists  (** The directory already exists. No action was taken. *)
   | Created  (** The directory was created. *)
-  | Missing_parent_directory
-      (** No parent directory, use [mkdir_p] if you want to create it too. *)
-  | Permission_denied (** Not enough permissions to create the directory *)
+  | Unix_error of Dune_filesystem_stubs.Unix_error.Detailed.t (** Unix errors to be handled by caller. *)
 
 val mkdir : ?perms:int -> string -> mkdir_result
 
-type mkdir_p_result =
-  | Already_exists  (** The directory already exists. No action was taken. *)
-  | Created  (** The directory was created. *)
-  | Permission_denied (** Not enough permissions to create the directory *)
-
-val mkdir_p : ?perms:int -> string -> mkdir_p_result
+val mkdir_p : ?perms:int -> string -> mkdir_result
 
 type follow_symlink_error =
   | Not_a_symlink

--- a/otherlibs/stdune/fpath.mli
+++ b/otherlibs/stdune/fpath.mli
@@ -5,12 +5,14 @@ type mkdir_result =
   | Created  (** The directory was created. *)
   | Missing_parent_directory
       (** No parent directory, use [mkdir_p] if you want to create it too. *)
+  | Permission_denied (** Not enough permissions to create the directory *)
 
 val mkdir : ?perms:int -> string -> mkdir_result
 
 type mkdir_p_result =
   | Already_exists  (** The directory already exists. No action was taken. *)
   | Created  (** The directory was created. *)
+  | Permission_denied (** Not enough permissions to create the directory *)
 
 val mkdir_p : ?perms:int -> string -> mkdir_p_result
 

--- a/otherlibs/stdune/path.ml
+++ b/otherlibs/stdune/path.ml
@@ -1030,9 +1030,7 @@ let ensure_build_dir_exists () =
     | Unix_error e ->
       let e = Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e in
       User_error.raise
-        [ Pp.textf "Cannot create external build directory %s." p
-        ; Pp.text e
-        ])
+        [ Pp.textf "Cannot create external build directory %s." p; Pp.text e ])
 
 let extend_basename t ~suffix =
   match t with

--- a/otherlibs/stdune/path.ml
+++ b/otherlibs/stdune/path.ml
@@ -1026,6 +1026,12 @@ let ensure_build_dir_exists () =
             "Cannot create external build directory %s. Make sure that the \
              parent dir %s exists."
             p (Filename.dirname p)
+        ]
+    | Permission_denied ->
+      User_error.raise
+        [ Pp.textf
+            "Cannot create external build directory %s. Permission Denied."
+            p
         ])
 
 let extend_basename t ~suffix =

--- a/otherlibs/stdune/temp.ml
+++ b/otherlibs/stdune/temp.ml
@@ -44,11 +44,14 @@ let create_temp_dir ?perms path =
   match Fpath.mkdir ?perms dir with
   | Created -> Ok ()
   | Already_exists -> Error `Retry
-  | Missing_parent_directory ->
+  | Unix_error (ENOENT, _, _) ->
     Code_error.raise "[Temp.create_temp_dir] called in a non-existing directory"
       []
-  | Permission_denied ->
-    Code_error.raise "[Temp.create_temp_dir] called without sufficient permissions"
+  | Unix_error e ->
+    Code_error.raise
+      ( "[Temp.create_temp_dir] "
+      ^ Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e
+      )
       []
 
 let set = function

--- a/otherlibs/stdune/temp.ml
+++ b/otherlibs/stdune/temp.ml
@@ -47,6 +47,9 @@ let create_temp_dir ?perms path =
   | Missing_parent_directory ->
     Code_error.raise "[Temp.create_temp_dir] called in a non-existing directory"
       []
+  | Permission_denied ->
+    Code_error.raise "[Temp.create_temp_dir] called without sufficient permissions"
+      []
 
 let set = function
   | Dir -> tmp_dirs

--- a/otherlibs/stdune/temp.ml
+++ b/otherlibs/stdune/temp.ml
@@ -49,9 +49,8 @@ let create_temp_dir ?perms path =
       []
   | Unix_error e ->
     Code_error.raise
-      ( "[Temp.create_temp_dir] "
-      ^ Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e
-      )
+      ("[Temp.create_temp_dir] "
+      ^ Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e)
       []
 
 let set = function

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -92,4 +92,4 @@ let create_cache_directories () =
   List.iter
     [ temp_dir; metadata_storage_dir; file_storage_dir; value_storage_dir ]
     ~f:(fun path ->
-      ignore (Fpath.mkdir_p (Path.to_string path) : Fpath.mkdir_p_result))
+      ignore (Fpath.mkdir_p (Path.to_string path) : Fpath.mkdir_result))

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -170,7 +170,7 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
          action, so this branch should be unreachable. *)
       Code_error.raise "Stale directory target in the build directory"
         [ ("dst_dir", Path.Build.to_dyn dst_dir) ]
-    | Missing_parent_directory | Permission_denied (* TODO *) -> assert false);
+    | Unix_error _ (* TODO *) -> assert false);
     match
       Dune_filesystem_stubs.read_directory_with_kinds
         (Path.Build.to_string src_dir)

--- a/src/dune_engine/sandbox.ml
+++ b/src/dune_engine/sandbox.ml
@@ -170,7 +170,7 @@ let rename_dir_recursively ~loc ~src_dir ~dst_dir =
          action, so this branch should be unreachable. *)
       Code_error.raise "Stale directory target in the build directory"
         [ ("dst_dir", Path.Build.to_dyn dst_dir) ]
-    | Missing_parent_directory -> assert false);
+    | Missing_parent_directory | Permission_denied (* TODO *) -> assert false);
     match
       Dune_filesystem_stubs.read_directory_with_kinds
         (Path.Build.to_string src_dir)

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -361,7 +361,8 @@ let prepare_sync () =
   | Cleared -> ()
   | Directory_does_not_exist -> (
     match Fpath.mkdir_p dir with
-    | Already_exists | Created -> ())
+    | Already_exists | Created -> ()
+    | Permission_denied (* TODO *) -> assert false)
 
 let spawn_external_watcher ~root ~backend =
   prepare_sync ();

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -362,7 +362,7 @@ let prepare_sync () =
   | Directory_does_not_exist -> (
     match Fpath.mkdir_p dir with
     | Already_exists | Created -> ()
-    | Permission_denied (* TODO *) -> assert false)
+    | Unix_error _ (* TODO *) -> assert false)
 
 let spawn_external_watcher ~root ~backend =
   prepare_sync ();

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -86,12 +86,11 @@ let run config stats =
                      match Fpath.mkdir_p dirname with
                      | Unix_error e ->
                        let e =
-                         Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e
+                         Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum
+                           e
                        in
                        User_warning.emit
-                         [ Pp.textf "Cannot create path %S" dirname
-                         ; Pp.text e
-                         ]
+                         [ Pp.textf "Cannot create path %S" dirname; Pp.text e ]
                      | Created | Already_exists ->
                        Io.String_path.write_file path contents;
                        cleanup_registry := Some path;

--- a/src/dune_rpc_impl/run.ml
+++ b/src/dune_rpc_impl/run.ml
@@ -84,10 +84,13 @@ let run config stats =
                      in
                      let dirname = Filename.dirname path in
                      match Fpath.mkdir_p dirname with
-                     | Permission_denied ->
+                     | Unix_error e ->
+                       let e =
+                         Dune_filesystem_stubs.Unix_error.Detailed.to_string_hum e
+                       in
                        User_warning.emit
-                         [ Pp.textf "Cannot create path %S: Permission Denied"
-                             dirname
+                         [ Pp.textf "Cannot create path %S" dirname
+                         ; Pp.text e
                          ]
                      | Created | Already_exists ->
                        Io.String_path.write_file path contents;

--- a/test/expect-tests/fsevents/fsevents_tests.ml
+++ b/test/expect-tests/fsevents/fsevents_tests.ml
@@ -257,7 +257,7 @@ let%expect_test "set exclusion paths" =
     test_with_operations
       ~exclusion_paths:(fun cwd -> [ paths cwd ignored ])
       (fun () ->
-        let (_ : Fpath.mkdir_p_result) = Fpath.mkdir_p ignored in
+        let (_ : Fpath.mkdir_result) = Fpath.mkdir_p ignored in
         Io.String_path.write_file (Filename.concat ignored "old") "foobar")
   in
   (* absolute paths work *)


### PR DESCRIPTION
This PR adds a new variant `Permission_denied` to the result types of `Fpath.mkdir*` functions, and handles said variant in all invocations of the functions.

NOTES:
- Alternative approach would be to only change `mkdir`'s return type, and `User_error.raise` at `mkdir_p` instead of propagating the error condition. This results in less granularity i.e. we still get backtraces where we may want to get just warnings.
  - one way around this is to raise then catch where we want to override behaviour. I'm preparing an alternative patchset exploring this, just in case.
  - we could also return `Result.t` or equivalent, but then we're just adding a layer of indirection to this exact solution.
- some invocations are `TODO` and require maintainer attention on how to best handle them.