### PR TITLE
Export every libraries in the dune-private-libs package

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -39,16 +39,14 @@ let local_libraries =
   ; ("src/ocamlc_loc", Some "Ocamlc_loc", false, None)
   ; ("src/fsevents", Some "Fsevents", false, None)
   ; ("vendor/ocaml-inotify/src", Some "Ocaml_inotify", false, None)
-  ; ("src/async_inotify_for_dune", Some "Async_inotify_for_dune", false,
-    None)
+  ; ("src/async_inotify_for_dune", Some "Async_inotify_for_dune", false, None)
   ; ("src/dune_file_watcher", Some "Dune_file_watcher", false, None)
   ; ("src/dune_engine", Some "Dune_engine", false, None)
   ; ("src/dune_config", Some "Dune_config", false, None)
   ; ("src/dune_rules", Some "Dune_rules", true, None)
   ; ("src/upgrader", Some "Dune_upgrader", false, None)
   ; ("vendor/cmdliner/src", None, false, None)
-  ; ("otherlibs/build-info/src", Some "Build_info", false,
-    Some "Build_info_data")
+  ; ("otherlibs/build-info/src", Some "Build_info", false, Some "Build_info_data")
   ; ("src/csexp_rpc", Some "Csexp_rpc", false, None)
   ; ("src/dune_rpc_impl", Some "Dune_rpc_impl", false, None)
   ]

--- a/src/async_inotify_for_dune/dune
+++ b/src/async_inotify_for_dune/dune
@@ -1,3 +1,4 @@
 (library
  (name async_inotify_for_dune)
+ (public_name dune-private-libs.async_inotify_for_dune)
  (libraries stdune unix ocaml_inotify threads.posix))

--- a/src/chrome_trace/dune
+++ b/src/chrome_trace/dune
@@ -1,4 +1,5 @@
 (library
  (name chrome_trace)
+ (public_name dune-private-libs.chrome_trace)
  (libraries unix)
  (synopsis "Emit catapult trace files, compatible with chrome://tracing"))

--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -1,5 +1,6 @@
 (library
  (name csexp_rpc)
+ (public_name dune-private-libs.csexp_rpc)
  (synopsis "Threaded client & server that uses csexp for communication")
  (libraries stdune dyn dune_util csexp dune_engine fiber)
  (foreign_stubs

--- a/src/dag/dune
+++ b/src/dag/dune
@@ -1,4 +1,5 @@
 (library
  (name dag)
+ (public_name dune-private-libs.dag)
  (libraries stdune incremental_cycles)
  (synopsis "Directed Acyclic Graph library"))

--- a/src/dune_cache/dune
+++ b/src/dune_cache/dune
@@ -1,4 +1,5 @@
 (library
  (name dune_cache)
+ (public_name dune-private-libs.cache)
  (synopsis "[Internal] Dune's local and cloud build cache")
  (libraries csexp dune_cache_storage fiber stdune))

--- a/src/dune_cache_storage/dune
+++ b/src/dune_cache_storage/dune
@@ -1,4 +1,5 @@
 (library
  (name dune_cache_storage)
+ (public_name dune-private-libs.cache_storage)
  (synopsis "[Internal] Dune cache storage, used for local and cloud caches")
  (libraries csexp dune_util fiber fiber_util stdune xdg))

--- a/src/dune_config/dune
+++ b/src/dune_config/dune
@@ -1,5 +1,6 @@
 (library
  (name dune_config)
+ (public_name dune-private-libs.config)
  (libraries
   stdune
   xdg

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -2,6 +2,7 @@
 
 (library
  (name dune_engine)
+ (public_name dune-private-libs.engine)
  (libraries
   unix
   stdune

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -1,5 +1,6 @@
 (library
  (name dune_file_watcher)
+ (public_name dune-private-libs.file_watcher)
  (libraries
   spawn
   fsevents

--- a/src/dune_lang/dune
+++ b/src/dune_lang/dune
@@ -1,5 +1,6 @@
 (library
  (name dune_lang)
+ (public_name dune-private-libs.lang)
  (synopsis "[Internal] S-expression library")
  (libraries stdune))
 

--- a/src/dune_rpc_impl/dune
+++ b/src/dune_rpc_impl/dune
@@ -1,5 +1,6 @@
 (library
  (name dune_rpc_impl)
+ (public_name dune-private-libs.rpc_impl)
  (libraries
   stdune
   unix

--- a/src/dune_rpc_server/dune
+++ b/src/dune_rpc_server/dune
@@ -1,4 +1,5 @@
 (library
  (name dune_rpc_server)
+ (public_name dune-private-libs.rpc_server)
  (synopsis "Private API to define a dune rpc server")
  (libraries fiber stdune chrome_trace dune_stats dune_util dune_rpc_private))

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -2,6 +2,7 @@
 
 (library
  (name dune_rules)
+ (public_name dune-private-libs.rules)
  (libraries
   stdune
   csexp

--- a/src/dune_stats/dune
+++ b/src/dune_stats/dune
@@ -1,3 +1,4 @@
 (library
  (name dune_stats)
+ (public_name dune-private-libs.stats)
  (libraries stdune chrome_trace spawn))

--- a/src/dune_util/dune
+++ b/src/dune_util/dune
@@ -1,3 +1,4 @@
 (library
  (name dune_util)
+ (public_name dune-private-libs.util)
  (libraries stdune xdg dune_lang memo))

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,4 +1,5 @@
 (library
  (name memo)
+ (public_name dune-private-libs.memo)
  (libraries stdune dyn dune_graph dune_lang dag fiber)
  (synopsis "Function memoizer"))

--- a/src/ocamlc_loc/dune
+++ b/src/ocamlc_loc/dune
@@ -1,3 +1,4 @@
 (library
  (name ocamlc_loc)
+ (public_name dune-private-libs.ocamlc_loc)
  (libraries dune_re dyn))

--- a/src/thread_worker/dune
+++ b/src/thread_worker/dune
@@ -1,3 +1,4 @@
 (library
  (name thread_worker)
+ (public_name dune-private-libs.thread_worker)
  (libraries stdune threads.posix))

--- a/src/upgrader/dune
+++ b/src/upgrader/dune
@@ -1,4 +1,5 @@
 (library
  (name dune_upgrader)
+ (public_name dune-private-libs.upgrader)
  (libraries stdune memo opam_file_format dune_lang dune_engine fiber)
  (synopsis "Internal Dune library, do not use!"))

--- a/vendor/build_path_prefix_map/src/dune
+++ b/vendor/build_path_prefix_map/src/dune
@@ -1,2 +1,3 @@
 (library
- (name build_path_prefix_map))
+ (name build_path_prefix_map)
+ (public_name dune-private-libs.build_path_prefix_map))

--- a/vendor/cmdliner/src/dune
+++ b/vendor/cmdliner/src/dune
@@ -1,4 +1,5 @@
 (library
  (name      cmdliner)
+ (public_name dune-private-libs.cmdliner)
  (wrapped   false)
  (flags     (-w -3-6-27-32-33-35-50)))

--- a/vendor/incremental-cycles/src/dune
+++ b/vendor/incremental-cycles/src/dune
@@ -1,2 +1,3 @@
 (library
+  (public_name dune-private-libs.incremental_cycles)
   (name incremental_cycles))

--- a/vendor/ocaml-inotify/src/dune
+++ b/vendor/ocaml-inotify/src/dune
@@ -1,5 +1,6 @@
 (library
  (name ocaml_inotify)
+ (public_name dune-private-libs.ocaml_inotify)
  (wrapped   true)
  (foreign_stubs (language c) (names inotify_stubs))
  (flags     (-w -3-6-27-32-33-35-50)))

--- a/vendor/opam-file-format/src/dune
+++ b/vendor/opam-file-format/src/dune
@@ -1,5 +1,6 @@
 (library
  (name opam_file_format)
+ (public_name dune-private-libs.opam_file_format)
  (modules_without_implementation opamParserTypes)
  (wrapped false))
 

--- a/vendor/spawn/src/dune
+++ b/vendor/spawn/src/dune
@@ -1,5 +1,6 @@
 (library
  (name spawn)
+ (public_name dune-private-libs.spawn)
  (foreign_stubs
   (language c)
   (names spawn_stubs))


### PR DESCRIPTION
This PR exposes the internal dune libraries under `dune-private-libs` and allows users to use dune as a library. 