### PR TITLE
Update dependency syntax spec

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -374,7 +374,8 @@ language. The syntax is a list of the following elements:
 
    logop := or | and
 
-   dep := (name <stage>)
+   dep := name
+        | (name <stage>)
         | (name <constr>)
         | (name (<logop> (<stage> | <constr>)*))
 


### PR DESCRIPTION
To show that names by themselves can be dependencies, e.g.

```
  (depends
    abc
    def...
```