### PR TITLE
[doc] Minor formatting issue

### DIFF
--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -674,7 +674,7 @@ To use this binary in the Cram test, we should depend on the binary in the test:
 
 .. code:: scheme
 
-	(cram
+   (cram
     (deps %{bin:wc}))
 
 


### PR DESCRIPTION
In the `Testing an OCaml Program` section about cram tests, there was a `tab`
being used instead of spaces. It might seem fine when edited with a tab-stop
setting of `4` but the markup parser translates it to 8 spaces. To avoid this
kind of issues (and because consistency feels nice) I changed it to spaces.

Signed-off-by: Eduardo Costa <m4c0@users.noreply.github.com>

Screenshot of the issue:

![Screenshot 2022-02-25 at 12 18 36](https://user-images.githubusercontent.com/1664510/155714138-8c654b0d-b89c-4094-abed-9b3f9fdc4482.png)
