### PR TITLE
fix(docs): Move `(include <file>)` documentation after sandbox doc

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -610,14 +610,14 @@ Dependencies in ``dune`` files can be specified using one of the following:
   will be rebuilt.
 - ``(sandbox <config>)`` requires a particular sandboxing configuration.
   ``<config>`` can be one (or many) of:
-- ``(include <file>)`` read the s-expression in ``<file>`` and intepret it as
-  additional dependencies. The s-expression is expected to be a list of the
-  same constructs enumerated here.
 
   - ``always``: the action requires a clean environment
   - ``none``: the action must run in the build directory
   - ``preserve_file_kind``: the action needs the files it reads to look
     like normal files (so Dune won't use symlinks for sandboxing)
+- ``(include <file>)`` read the s-expression in ``<file>`` and intepret it as
+  additional dependencies. The s-expression is expected to be a list of the
+  same constructs enumerated here.
 
 In all these cases, the argument supports :ref:`variables`.
 


### PR DESCRIPTION
introduced after https://github.com/ocaml/dune/commit/23cff6ebebabd6a894955611f86a39299d5f5ad5#diff-9718f66e50394e604b467ec4a30f1dfd922b22cb141da906961faacf359b8e61R613-R615

cc @rgrinberg 