### PR TITLE
fix `dune clean` on esy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - Show auto-detected concurrency on Windows too (#5502, @MisterDA)
 
+- Fix operations that remove folders with absolute path. This happens when using esy (#5507, @EduardoRFS)
+
 3.0.3 (Unreleased)
 ------------------
 

--- a/otherlibs/stdune/fpath.ml
+++ b/otherlibs/stdune/fpath.ml
@@ -116,9 +116,7 @@ and rm_rf_dir path =
          deleted the directory. *)
       ())
 
-let rm_rf ?(allow_external = false) fn =
-  if (not allow_external) && not (Filename.is_relative fn) then
-    Code_error.raise "Path.rm_rf called on external dir" [ ("fn", String fn) ];
+let rm_rf fn =
   match Unix.lstat fn with
   | exception Unix.Unix_error (ENOENT, _, _) -> ()
   | { Unix.st_kind = S_DIR; _ } -> rm_rf_dir fn

--- a/otherlibs/stdune/fpath.mli
+++ b/otherlibs/stdune/fpath.mli
@@ -34,6 +34,6 @@ type clear_dir_result =
 val clear_dir : string -> clear_dir_result
 
 (** If the path does not exist, this function is a no-op. *)
-val rm_rf : ?allow_external:bool -> string -> unit
+val rm_rf : string -> unit
 
 val is_root : string -> bool

--- a/otherlibs/stdune/path.ml
+++ b/otherlibs/stdune/path.ml
@@ -1049,7 +1049,7 @@ let clear_dir dir = Fpath.clear_dir (to_string dir)
 let rm_rf ?(allow_external = false) t =
   if (not allow_external) && not (is_managed t) then
     Code_error.raise "Path.rm_rf called on external dir" [ ("t", to_dyn t) ];
-  Fpath.rm_rf ~allow_external (to_string t)
+  Fpath.rm_rf (to_string t)
 
 let mkdir_p ?perms = function
   | External s -> External.mkdir_p s ?perms


### PR DESCRIPTION
## Problem
esy uses `DUNE_BUILD_DIR` pointing to an absolute directory, but since https://github.com/ocaml/dune/commit/0f31294fe7eb361f7bfe1b9c4bc8cb54e8ad7f41 dune rejects removing any absolute directory, as a new checking was added.

Leading to `dune clean` to fail, and also basic functionality such as `dune build -w`.

## Solution

This PR removes the checking, as the patch was likely a mistaken and not all absolute directories are external.