### PR TITLE
xdg: default value if env var is either not set or empty

### DIFF
--- a/otherlibs/xdg/xdg.ml
+++ b/otherlibs/xdg/xdg.ml
@@ -12,8 +12,8 @@ let ( / ) = Filename.concat
 
 let make t env_var unix_default win32_default =
   match t.env env_var with
+  | None | Some "" -> if t.win32 then win32_default else unix_default
   | Some s -> s
-  | None -> if t.win32 then win32_default else unix_default
 
 let cache_dir t =
   let home = t.home_dir in


### PR DESCRIPTION
From the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):

> If `$XDG_DATA_HOME` is either not set or empty, a default equal to
> `$HOME/.local/share` should be used.

and this is also true for the other env vars.