### PR TITLE
xdg: default value if env var is not absolute

### DIFF
--- a/otherlibs/xdg/xdg.ml
+++ b/otherlibs/xdg/xdg.ml
@@ -11,8 +11,10 @@ type t =
 let ( / ) = Filename.concat
 
 let make t env_var unix_default win32_default =
+  let default = if t.win32 then win32_default else unix_default in
   match t.env env_var with
-  | None | Some "" -> if t.win32 then win32_default else unix_default
+  | None -> default
+  | Some s when Filename.is_relative s -> default
   | Some s -> s
 
 let cache_dir t =


### PR DESCRIPTION
From the [XDG Base Directory Specification][1]:

> All paths set in these environment variables must be absolute. If an
> implementation encounters a relative path in any of these variables
> it should consider the path invalid and ignore it.

If the env var is empty, `Filename.is_relative` returns `true`, so this is
a more general case that I missed in #5510.

cc @nojb 

[1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html