### PR TITLE
[Draft] Add possibility to include whole archive in .cmxs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 - Add `(deps <deps>)` in ctype field (#5346, @bobot)
 
+- Add `(foreign_archives ((path <path>)(mode whole))` to ensure that all the
+  archives are included in the `.cmxs`, otherwise only the symbols accessed from
+  the OCaml library are linked ( @bobot )
+
 - Add `(include <file>)` constructor to dependency specifications. This can be
   used to introduce dynamic dependencies (#5442, @anmonteiro)
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -554,9 +554,16 @@ to use the :ref:`include_subdirs` stanza.
   and ``cxx_flags``.
 
 - ``(foreign_archives <foreign-archives-list>)`` specifies archives of foreign
-  object files to be packaged with the library. See the section
-  :ref:`foreign-archives` for more details. This field replaces the now-deleted
-  field ``self_build_stubs_archive``.
+  object files to be packaged with the library. ``<foreign-archives-list>`` can
+  be :
+
+    - ``<path>`` : ``path/foo`` (for the files: ``dllfoo.so`` and ``libfoo.a``)
+    - ``((path <path>)(mode <mode>))``: ``<mode>`` could be ``as_needed``
+      (default) only the symbols used by the OCaml library are included or
+      ``whole`` all the symbols of the archive are included.
+
+  See the section :ref:`foreign-archives` for more details. This field replaces
+  the now-deleted field ``self_build_stubs_archive``.
 
 - ``(install_c_headers (<names>))`` - if your library has public C header files
   that must be installed, you must list them in this field, without the ``.h``
@@ -990,7 +997,7 @@ It shares the same fields as the ``executable`` stanza, except that instead of
   of each executable.
 
 - ``(public_names <names>)`` describes under what name to install each executable.
-The list of names must be of the same length as the list in the
+  The list of names must be of the same length as the list in the
   ``(names ...)`` field. Moreover, you can use ``-`` for executables that
   shouldn't be installed.
 

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -347,8 +347,10 @@ The last step is to attach these archives to an OCaml library as follows:
     (name bar)
     (foreign_archives foo))
 
-Then, whenever you use the ``bar`` library, you'll also be able to
-use C functions from ``libfoo``.
+Then, the C functions from ``libfoo`` can be accessed from ``bar`` as external.
+In order to be able to use the C functions from ``libfoo`` even if they are not
+used by ``bar``, the mode ``whole`` must be used ``(foreign_archives ((path
+foo)(mode whole))``.
 
 Limitations
 -----------

--- a/src/dune_rules/cxx_flags.ml
+++ b/src/dune_rules/cxx_flags.ml
@@ -23,19 +23,6 @@ let base_cxx_flags ~for_ cc =
 
 let preprocessed_filename = "ccomp"
 
-let ccomp_type build_dir =
-  let open Action_builder.O in
-  let filepath =
-    Path.Build.(
-      relative (relative build_dir ".dune/ccomp") preprocessed_filename)
-  in
-  let+ ccomp = Action_builder.contents (Path.build filepath) in
-  match String.trim ccomp with
-  | "clang" -> Clang
-  | "gcc" -> Gcc
-  | "msvc" -> Msvc
-  | s -> Other s
-
 let check_warn = function
   | Other s ->
     User_warning.emit
@@ -47,8 +34,25 @@ let check_warn = function
       ]
   | _ -> ()
 
+let ccomp_type ctx =
+  let build_dir = ctx.Context.build_dir in
+  let open Action_builder.O in
+  let filepath =
+    Path.Build.(
+      relative (relative build_dir ".dune/ccomp") preprocessed_filename)
+  in
+  let+ ccomp = Action_builder.contents (Path.build filepath) in
+  let ccomp_type =
+    match String.trim ccomp with
+    | "clang" -> Clang
+    | "gcc" -> Gcc
+    | "msvc" -> Msvc
+    | s -> Other s
+  in
+  check_warn ccomp_type;
+  ccomp_type
+
 let get_flags ~for_ ctx =
   let open Action_builder.O in
-  let+ ccomp_type = ccomp_type ctx.Context.build_dir in
-  check_warn ccomp_type;
+  let+ ccomp_type = ccomp_type ctx in
   base_cxx_flags ~for_ ccomp_type

--- a/src/dune_rules/cxx_flags.mli
+++ b/src/dune_rules/cxx_flags.mli
@@ -12,6 +12,15 @@ type phase =
     preprocessor *)
 val preprocessed_filename : string
 
+type ccomp_type =
+  | Gcc
+  | Msvc
+  | Clang
+  | Other of string
+
+(** Get the kind of C processor *)
+val ccomp_type : Context.t -> ccomp_type Action_builder.t
+
 (** [get_flags c_compiler] returns the necessary flags to turn this compiler
     into a c++ compiler for some of the most common compilers *)
 val get_flags : for_:phase -> Context.t -> string list Action_builder.t

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -40,6 +40,9 @@ let rules ~sctx ~dir =
     let+ run_preprocessor =
       Command.run ~dir:(Path.build dir) ~stdout_to:file prog args
     in
-    Action.Full.reduce [ Action.Full.make write_test_file; run_preprocessor ]
+    Action.Full.reduce
+      [ Action.Full.make ~sandbox:Sandbox_config.no_sandboxing write_test_file
+      ; run_preprocessor
+      ]
   in
   Super_context.add_rule sctx ~dir action

--- a/src/dune_rules/foreign.mli
+++ b/src/dune_rules/foreign.mli
@@ -61,6 +61,12 @@ module Archive : sig
 
   val name : t -> Name.t
 
+  type mode =
+    | Whole
+    | As_needed
+
+  val mode : t -> mode
+
   val stubs : string -> t
 
   val decode : t Dune_lang.Decoder.t


### PR DESCRIPTION
`foreign_archive foo` doesn't ensure that all the symbols of foo will be in the .cmxs of the library. It uses  `-Wl,--whole_archive` for gcc, `-Wl,--force_load`and `\WHOLEARCHIVE`for MSVC (@dra27, is it okay?). 