### PR TITLE
Add documentation on how to run a single cram test

### DIFF
--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -51,6 +51,16 @@ exec`` to run the test executable (for the sake of this example,
 
    dune exec project/tests/myTest.exe
 
+To run :ref:`cram-tests`, you can use the alias that is created for the test.
+The name of the alias corresponds to the name of the test without the ``.t``
+extension. For directory tests, this is the name of the directory without the
+``.t`` extension. Assuming a ``cram-test.t`` or ``cram-test.t/run.t`` file
+exists, it can be run with:
+
+.. code:: bash
+
+   $ dune build @cram-test
+
 
 Running Tests in a Directory
 ----------------------------


### PR DESCRIPTION
I had difficulty to figure out how to run a single Cram test (my codebase has a lot of tests and if I add e.g. a debug print all kinds of tests fail, thus filling my terminal with a lot of noise) so I thought it would be good to add this info for future users and future me to know.

I assumed the process would be like it is, but instead of `dune build @alias` I mistakenly used `dune runtest @alias` which did not do what I thought.