### PR TITLE
Various markup fixes

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -206,7 +206,7 @@ In addition, ``(action ...)`` fields support the following special variables:
 - ``bin-available:<program>`` expands to ``true`` or ``false``, depending
   on whether ``<program>`` is available or not.
 - ``lib:<public-library-name>:<file>`` expands to the file's installation path 
-``<file>`` in the library ``<public-library-name>``. If
+  ``<file>`` in the library ``<public-library-name>``. If
   ``<public-library-name>`` is available in the current workspace, the local
   file will be used, otherwise the one from the installed world will be used.
 - ``lib-private:<library-name>:<file>`` expands to the file's build path 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -496,8 +496,6 @@ to use the :ref:`include_subdirs` stanza.
 
 - ``(package <package>)`` installs a private library under the specified package.
   Such a library is now usable by public libraries defined in the same project.
-
-=======
   The Findlib name for this library will be ``<package>.__private__.<name>``;
   however, the library's interface will be hidden from consumers outside the
   project.
@@ -990,7 +988,7 @@ It shares the same fields as the ``executable`` stanza, except that instead of
   of each executable.
 
 - ``(public_names <names>)`` describes under what name to install each executable.
-The list of names must be of the same length as the list in the
+  The list of names must be of the same length as the list in the
   ``(names ...)`` field. Moreover, you can use ``-`` for executables that
   shouldn't be installed.
 
@@ -1564,7 +1562,7 @@ Fields supported in ``<settings>`` are:
   whether to use separate compilation or not.
 
 - ``(js_of_ocaml (runtest_alias <alias-name>))`` is used to specify
-  the alias under which `inline_tests`_ and tests (`tests-stanza`_)
+  the alias under which :ref:`inline_tests` and tests (`tests-stanza`_)
   run for the `js` mode.
 
 - ``(binaries <binaries>)``, where ``<binaries>`` is a list of entries

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -190,10 +190,10 @@ Creating Rules
 A Dune rule consists of 3 components:
 
 - *Dependencies* that the rule may read when executed (files, aliases, etc.), 
-described by ``'a Action_builder.t`` values.
+  described by ``'a Action_builder.t`` values.
 
 - *Targets* that the rule produces (files and/or directories), 
-described by ``'a Action_builder.With_targets.t'`` values.
+  described by ``'a Action_builder.With_targets.t'`` values.
 
 - *Action* that Dune must execute (external programs, redirects, etc.).
   Actions are represented by ``Action.t`` values.

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -50,7 +50,7 @@ to all Opam packages that rely on the ``jbuilder`` binary or Jbuilder
 configuration files.
 
 January 2020: The ``jbuilder`` Binary Goes Away
----------------------------------------------
+-----------------------------------------------
 
 The ``dune`` package no longer installs a ``jbuilder`` binary. The rest is
 unchanged.
@@ -209,7 +209,7 @@ should be rewritten to the following ``dune`` file:
 
 
 ``jbuild-ignore`` (Deprecated)
---------------------------
+------------------------------
 
 ``jbuild-ignore`` files are deprecated and replaced by :ref:`dune-subdirs`
 stanzas in ``dune`` files.

--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -369,7 +369,7 @@ this ``dune`` file:
      (c_library_flags (-lblah)))
 
 Defining a Library with C Stubs using ``pkg-config``
-==================================================
+====================================================
 
 Same context as before, but using ``pkg-config`` to query the
 compilation and link flags. Write this ``dune`` file:

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -487,16 +487,16 @@ This provides a nice way of dealing with the usual *write code*,
 
 .. code:: bash
 
-$ dune runtest
-   [...]
-   -tests.expected
-   +tests.output
-   File "tests.expected", line 1, characters 0-1:
-   -Hello, world!
-   +Good bye!
-   $ dune promote
-
-   Promoting _build/default/tests.output to tests.expected.
+    $ dune runtest
+       [...]
+       -tests.expected
+       +tests.output
+       File "tests.expected", line 1, characters 0-1:
+       -Hello, world!
+       +Good bye!
+       $ dune promote
+    
+       Promoting _build/default/tests.output to tests.expected.
 
 Note that if available, the diffing is done using the patdiff_ tool,
 which displays nicer looking diffs than the standard ``diff``
@@ -629,7 +629,7 @@ This introduces a dependency on ``foo.exe`` on all Cram tests in this directory.
 To apply the stanza to a particular test, it's possible to use ``applies_to``
 field:
 
-.. code:: scheme
+.. code::
 
    (cram
     (applies_to * \ foo bar)
@@ -651,7 +651,7 @@ The ``cram`` stanza accepts the following fields:
   holding the following locks. See the :ref:`locks` section for more details.
 - ``deps`` - dependencies of the test
 - ``(package <package-name>)`` - attach the tests selected by this stanza to the
-specified package
+  specified package
 
 A single test may be configured by more than one ``cram`` stanza. In such cases,
 the values from all applicable ``cram`` stanzas are merged together to get the
@@ -672,7 +672,7 @@ in Dune. For example:
 
 To use this binary in the Cram test, we should depend on the binary in the test:
 
-.. code:: scheme
+.. code::
 
    (cram
     (deps %{bin:wc}))


### PR DESCRIPTION
This fixes missing refs, bad markup, etc. This makes `make doc` clean.
