### PR TITLE
(test): skip rule creation if enabled_if is false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
 
 - Fix operations that remove folders with absolute path. This happens when using esy (#5507, @EduardoRFS)
 
+- When a `(test)` stanza is disabled through `(enabled_if)`, do not create any rule. This removes spurious "Library X is hidden (unsatisfied `enabled_if`)" error messages. (#5529, fixes #5505, @emillon)
+
 3.0.3 (Unreleased)
 ------------------
 

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -117,15 +117,18 @@ end = struct
     | Alias alias ->
       let+ () = Simple_rules.alias sctx alias ~dir ~expander in
       empty_none
-    | Tests tests ->
-      let+ cctx, merlin =
-        Test_rules.rules tests ~sctx ~dir ~scope ~expander ~dir_contents
-      in
-      { merlin = Some merlin
-      ; cctx = Some (tests.exes.buildable.loc, cctx)
-      ; js = None
-      ; source_dirs = None
-      }
+    | Tests tests -> (
+      Expander.eval_blang expander tests.enabled_if >>= function
+      | false -> Memo.Build.return empty_none
+      | true ->
+        let+ cctx, merlin =
+          Test_rules.rules tests ~sctx ~dir ~scope ~expander ~dir_contents
+        in
+        { merlin = Some merlin
+        ; cctx = Some (tests.exes.buildable.loc, cctx)
+        ; js = None
+        ; source_dirs = None
+        })
     | Copy_files { files = glob; _ } ->
       let* source_dirs =
         let loc = String_with_vars.loc glob in

--- a/test/blackbox-tests/test-cases/github5505.t
+++ b/test/blackbox-tests/test-cases/github5505.t
@@ -1,0 +1,27 @@
+When a test is disabled through enabled_if, it should not generate any rule. In
+particular, in #5505 it would try to use a disabled library and this would print
+a "Library X is hidden (unsatisfied `enabled_if`)" message.
+
+  $ cat > dune-project << EOF
+  > (lang dune 2.3)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name l)
+  >  (modules l)
+  >  (foreign_stubs
+  >   (language c)
+  >   (names stubs))
+  >  (enabled_if false))
+  > 
+  > (test
+  >  (name t)
+  >  (modules t)
+  >  (libraries l)
+  >  (enabled_if false))
+  > EOF
+
+  $ touch t.ml l.ml stubs.c
+
+  $ dune build


### PR DESCRIPTION
When a `(test)` stanza is disabled through `(enabled_if)`, do not create any rule. This removes spurious "Library X is hidden (unsatisfied `enabled_if`)" error messages.
