### PR TITLE
expand-make.t: handle case where gmake is in PATH

### DIFF
--- a/test/blackbox-tests/test-cases/expand-make.t
+++ b/test/blackbox-tests/test-cases/expand-make.t
@@ -2,7 +2,15 @@ On Unix, dune should lookup gmake and followed by make.
 
 Regression test for https://github.com/ocaml/dune/issues/5470 
 
-  $ mkdir make gmake
+This needs special setup to have a PATH which does not contain a gmake binary,
+in case the system PATH has one. Instead of prepending to PATH we create a bin/
+subdirectory with links to all the executables dune needs.
+
+  $ mkdir make gmake bin
+
+  $ for prog in dune ocamlc sh; do
+  >   ln -s $(which $prog) bin/;
+  > done
 
   $ cat >make/make <<EOF
   > #!/usr/bin/env sh
@@ -21,12 +29,13 @@ Regression test for https://github.com/ocaml/dune/issues/5470
   > EOF
 
   $ cat >dune <<EOF
+  > (data_only_dirs bin)
   > (rule
   >  (alias make)
   >  (action (run %{make})))
   > EOF
 
-  $ PATH="$PWD/make:$PATH" dune build @make --force
+  $ PATH="$PWD/make:$PWD/bin" dune build @make --force;
   make
-  $ PATH="$PWD/gmake:$PWD/make:$PATH" dune build @make --force
+  $ PATH="$PWD/gmake:$PWD/make:$PWD/bin" dune build @make --force
   gmake


### PR DESCRIPTION
The logic we're testing is that `make` is picked if `gmake` is not in `PATH`. This is hard to to test if `gmake` is already in `/usr/bin` or the like. So a more precise setup is used.