### PR TITLE
Fix dune exec dump in wrong directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 3.1.0 (Unreleased)
 ------------------
 
+- Fix dune exec dumping database in wrong directory (#5544, @bobot)
+
 - Always output absolute paths for locations in RPC reported diagnostics
   (#5539, @rgrinberg)
 

--- a/otherlibs/stdune/proc.ml
+++ b/otherlibs/stdune/proc.ml
@@ -8,6 +8,8 @@ external sys_exit : int -> 'a = "caml_sys_exit"
 let restore_cwd_and_execve prog argv ~env =
   let env = Env.to_unix env |> Array.of_list in
   let argv = Array.of_list argv in
+  (* run at_exit before changing the working directory *)
+  Stdlib.do_at_exit ();
   Sys.chdir (Path.External.to_string Path.External.initial_cwd);
   if Sys.win32 then
     let pid =
@@ -19,7 +21,6 @@ let restore_cwd_and_execve prog argv ~env =
     | WSTOPPED _ -> assert false
   else (
     ignore (Unix.sigprocmask SIG_SETMASK [] : int list);
-    Stdlib.do_at_exit ();
     Unix.execve prog argv env)
 
 module Resource_usage = struct

--- a/test/blackbox-tests/test-cases/exec-cmd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-cmd.t/run.t
@@ -28,6 +28,3 @@
   $ ls -a test/_build
   .
   ..
-  .db
-  .digest-db
-  .filesystem-clock

--- a/test/blackbox-tests/test-cases/exec-cmd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-cmd.t/run.t
@@ -13,3 +13,21 @@
   [1]
   $ dune exec dunetestbar
   Bar
+
+#Test the at exit bookkeeping of dune is done in the right directory
+  $ dune clean
+
+  $ mkdir test
+
+  $ mkdir test/_build
+
+  $ (cd test; dune exec --root .. -- dunetestbar)
+  Entering directory '..'
+  Bar
+
+  $ ls -a test/_build
+  .
+  ..
+  .db
+  .digest-db
+  .filesystem-clock


### PR DESCRIPTION
The `.db` of the wrong `_build` was modified when using `--root` with `dune exec`.