### PR TITLE
Fix dropped suffix in command line printing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@
 - The mdx stanza 0.2 can now be used with `(implicit_transitive_deps false)`
   (#5558, fixes #5499, @emillon)
 
+- Fix missing parenthesis in printing of corresponding terminal command for
+  `(with-outputs-to )` (#5551, fixes #5546, @Alizter)
+
 3.0.3 (Unreleased)
 ------------------
 

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -182,7 +182,7 @@ let command_line_enclosers ~dir ~(stdout_to : Io.output Io.t)
       , io_to_redirection_path stderr_to.kind )
     with
     | Some fn1, Some fn2 when String.equal fn1 fn2 ->
-      " &> " ^ String.quote_for_shell fn1
+      suffix ^ " &> " ^ String.quote_for_shell fn1
     | path_out, path_err ->
       let add_to_suffix suffix path redirect =
         match path with

--- a/test/blackbox-tests/test-cases/display.t
+++ b/test/blackbox-tests/test-cases/display.t
@@ -145,3 +145,118 @@ Successful commands with output
             sh alias default
   (cd _build/default && SH -c 'echo '\''Hello, world!'\''')
   Hello, world!
+
+Errors with-stdout-to
+---------------------
+
+  $ cat >dune<<"EOF"
+  > (rule
+  >  (alias default)
+  >  (action (with-stdout-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+  > EOF
+
+  $ dune clean; dune build
+  File "dune", line 1, characters 0-108:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-stdout-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+  Command exited with code 42.
+  [1]
+
+  $ dune clean; dune build --always-show-command-line
+  File "dune", line 1, characters 0-108:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-stdout-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42') > _build/default/bar
+  Command exited with code 42.
+  [1]
+
+  $ dune clean; dune build --display short
+  File "dune", line 1, characters 0-108:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-stdout-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+            sh bar (exit 42)
+  [1]
+
+  $ dune clean; dune build --display short --always-show-command-line
+  File "dune", line 1, characters 0-108:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-stdout-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+            sh bar (exit 42)
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42') > _build/default/bar
+  [1]
+
+Errors with-stderr-to
+---------------------
+
+  $ cat >dune<<"EOF"
+  > (rule
+  >  (alias default)
+  >  (action (with-stderr-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+  > EOF
+
+  $ dune clean; dune build
+  File "foo", line 1: blah
+  [1]
+
+  $ dune clean; dune build --always-show-command-line
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42') 2> _build/default/bar
+  File "foo", line 1: blah
+  [1]
+
+  $ dune clean; dune build --display short
+            sh bar (exit 42)
+  File "foo", line 1: blah
+  [1]
+
+  $ dune clean; dune build --display short --always-show-command-line
+            sh bar (exit 42)
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42') 2> _build/default/bar
+  File "foo", line 1: blah
+  [1]
+
+Errors with-outputs-to
+---------------------
+
+  $ cat >dune<<"EOF"
+  > (rule
+  >  (alias default)
+  >  (action (with-outputs-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+  > EOF
+
+  $ dune clean; dune build
+  File "dune", line 1, characters 0-109:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-outputs-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+  Command exited with code 42.
+  [1]
+
+  $ dune clean; dune build --always-show-command-line
+  File "dune", line 1, characters 0-109:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-outputs-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42') &> _build/default/bar
+  Command exited with code 42.
+  [1]
+
+  $ dune clean; dune build --display short
+  File "dune", line 1, characters 0-109:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-outputs-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+            sh bar (exit 42)
+  [1]
+
+  $ dune clean; dune build --display short --always-show-command-line
+  File "dune", line 1, characters 0-109:
+  1 | (rule
+  2 |  (alias default)
+  3 |  (action (with-outputs-to bar (system "echo 'File \"foo\", line 1: blah'; exit 42"))))
+            sh bar (exit 42)
+  (cd _build/default && SH -c 'echo '\''File "foo", line 1: blah'\''; exit 42') &> _build/default/bar
+  [1]


### PR DESCRIPTION
We fix a dropped suffix when printing the command line.

fix #5546

Should I add some tests?