### PR TITLE
[coq top] Test case for problems with path / dir computation in dune …

### DIFF
--- a/test/blackbox-tests/test-cases/coq/coqtop-nested.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/coqtop-nested.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.0)
+
+(using coq 0.3)

--- a/test/blackbox-tests/test-cases/coq/coqtop-nested.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop-nested.t/run.t
@@ -1,0 +1,22 @@
+Checking that we compute the directory and file for dune coq top correctly
+
+  $ dune build --display=short theories/c.vo
+        coqdep theories/c.v.d
+        coqdep theories/d.v.d
+          coqc theories/.d.aux,theories/d.{glob,vo}
+          coqc theories/.c.aux,theories/c.{glob,vo}
+  $ dune build --display=short theories/b/b.vo
+        coqdep theories/b/b.v.d
+        coqdep theories/a/a.v.d
+          coqc theories/a/.a.aux,theories/a/a.{glob,vo}
+          coqc theories/b/.b.aux,theories/b/b.{glob,vo}
+  $ dune coq top --root . --toplevel=echo theories/c.v
+  Error: path outside the workspace:
+  theories/../../../../../../../../../default/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/c.v
+  from default
+  [1]
+  $ dune coq top --root . --toplevel=echo theories/b/b.v
+  Error: path outside the workspace:
+  theories/b/../../../../../../../../../../default/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/b/b.v
+  from default
+  [1]

--- a/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/a/a.v
+++ b/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/a/a.v
@@ -1,0 +1,1 @@
+Definition bar := 3.

--- a/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/b/b.v
+++ b/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/b/b.v
@@ -1,0 +1,3 @@
+Require a.
+
+Definition moo := a.bar.

--- a/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/c.v
+++ b/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/c.v
@@ -1,0 +1,3 @@
+Require d.
+
+Definition uuhh := d.aike.

--- a/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/d.v
+++ b/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/d.v
@@ -1,0 +1,1 @@
+Definition aike := 3.

--- a/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/dune
+++ b/test/blackbox-tests/test-cases/coq/coqtop-nested.t/theories/dune
@@ -1,0 +1,4 @@
+(coq.theory
+ (name foo))
+
+(include_subdirs qualified)


### PR DESCRIPTION
…coq top

After some more testing, I have found problems finding the directory /
file for `dune coq top`:

```ocaml
        let coq_file_build =
          let p = Common.prefix_target common coq_file_arg in
          Path.Build.relative context.build_dir p
        in
        let dir =
          let dir = Filename.dirname coq_file_arg in
          let p = Common.prefix_target common dir in
          Path.Build.relative context.build_dir p
        in
```

`dune coq top` will also fail on project that have a `theories/a/b.v`
layout, such as in Coq for example, when doing:

```
dune coq top theories/Reals/Real.v
```

in the above snippet, `dir` is set to `theories/Reals` which is
incorrect, as it should be the root of where the stanza is placed.

This makes dune fail with:
```
Error: No rule found for theories/Reals/Reals/Reals.v.d
```
as `dir` is set incorrectly.

We need to think more about this, and fix it because it is currently
only usable on flat layouts.

Let's discuss in this PR cc @rlepigre 