### PR TITLE
Rename [Memo.t] to [Memo.Table.t]

### DIFF
--- a/src/dune_engine/action_builder0.ml
+++ b/src/dune_engine/action_builder0.ml
@@ -174,8 +174,8 @@ let fail x =
   x.fail ()
 
 type ('input, 'output) memo =
-  { lazy_ : ('input, 'output * Dep.Set.t) Memo.t Lazy.t
-  ; eager : ('input, 'output * Dep.Facts.t) Memo.t Lazy.t
+  { lazy_ : ('input, 'output * Dep.Set.t) Memo.Table.t Lazy.t
+  ; eager : ('input, 'output * Dep.Facts.t) Memo.Table.t Lazy.t
   }
 
 let create_memo name ~input ?cutoff ?human_readable_description f =

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -289,10 +289,13 @@ and Exported : sig
      "Undefined_recursive_module" exception. *)
 
   val build_file_memo :
-    (Path.t, Import.Digest.t * Import.Digest.t Path.Build.Map.t option) Memo.t
+    ( Path.t
+    , Import.Digest.t * Import.Digest.t Path.Build.Map.t option )
+    Memo.Table.t
     [@@warning "-32"]
 
-  val build_alias_memo : (Alias.t, Dep.Fact.Files.t) Memo.t [@@warning "-32"]
+  val build_alias_memo : (Alias.t, Dep.Fact.Files.t) Memo.Table.t
+    [@@warning "-32"]
 
   val dep_on_alias_definition :
     Rules.Dir_rules.Alias_spec.item -> unit Action_builder.t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -289,9 +289,7 @@ and Exported : sig
      "Undefined_recursive_module" exception. *)
 
   val build_file_memo :
-    ( Path.t
-    , Import.Digest.t * Import.Digest.t Path.Build.Map.t option )
-    Memo.Table.t
+    (Path.t, Digest.t * Digest.t Path.Build.Map.t option) Memo.Table.t
     [@@warning "-32"]
 
   val build_alias_memo : (Alias.t, Dep.Fact.Files.t) Memo.Table.t

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -65,7 +65,7 @@ let check_no_module_consumer stanzas =
 module DB = struct
   type nonrec t =
     { stanzas_per_dir : Dune_file.Stanzas.t Dir_with_dune.t Path.Build.Map.t
-    ; fn : (Path.Build.t, t) Memo.t
+    ; fn : (Path.Build.t, t) Memo.Table.t
     }
 
   let stanzas_in db ~dir = Path.Build.Map.find db.stanzas_per_dir dir

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -114,6 +114,7 @@ module Build : sig
   end
 end
 
+(** A table memoizing results of executing a function. *)
 module Table : sig
   type ('input, 'output) t
 end
@@ -264,12 +265,10 @@ end
     If the caller provides the [cutoff] equality check, we will use it to check
     if the function's output is the same as cached in the previous computation.
     If it's the same, we will be able to skip recomputing the functions that
-    depend on it. Note: by default Dune wipes all memoization caches on every
-    run, so this early cutoff optimisation is not effective. To override default
-    behaviour, run Dune with the flag [DUNE_WATCHING_MODE_INCREMENTAL=true].
+    depend on it.
 
     If [human_readable_description] is passed, it will be used when displaying
-    the memo stack to the user.
+    the Memo stack to the user.
 
     Running the computation may raise [Memo.Cycle_error.E] if a dependency cycle
     is detected. *)
@@ -312,8 +311,8 @@ val push_stack_frame :
   -> (unit -> 'a Build.t)
   -> 'a Build.t
 
+(** A single build run. *)
 module Run : sig
-  (** A single build run. *)
   type t
 
   module For_tests : sig


### PR DESCRIPTION
As discussed with @rgrinberg, we're renaming `Memo.t` to `Memo.Table.t` and `Memo.Build.t` to `Memo.t` to make many type signatures in Dune shorter (and also not to bake in the notion of "builds" into the generic Memo library).

This is Step 1 of this renaming.