### PR TITLE
fix: add missing depends to ocamlc-loc

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -190,6 +190,7 @@ understood by dune language."))
  (synopsis "Parse ocaml compiler output into structured form")
  (depends
   (ocaml (>= 4.08.0))
+  (dune-private-libs (= :version))
   (dyn (= :version)))
  (description "This library offers no backwards compatibility guarantees. Use at your own risk."))
 

--- a/ocamlc-loc.opam
+++ b/ocamlc-loc.opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08.0"}
+  "dune-private-libs" {= version}
   "dyn" {= version}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
dune-private-libs is needed for our vendored re