### PR TITLE
Allow providing installation --prefix via environment variable

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -390,7 +390,9 @@ let install_uninstall ~what =
       Arg.(
         value
         & opt (some string) None
-        & info [ "prefix" ] ~docv:"PREFIX"
+        & info [ "prefix" ]
+            ~env:(env_var "DUNE_INSTALL_PREFIX")
+            ~docv:"PREFIX"
             ~doc:
               "Directory where files are copied. For instance binaries are \
                copied into $(i,\\$prefix/bin), library files into \


### PR DESCRIPTION
With `dune install` you must either provide the installation `--prefix`
or have `opam` installed. Unfortunately in some cases neither is an
option because we're in a non-Opam environment (e.g. Nix) and don't
control the invocation of Dune.

Providing an environment variable `DUNE_INSTALL_PREFIX` may alleviate
that pain.

Might help some suffering from #5455.

Signed-off-by: Ole Krüger <ole@vprsm.de>