### PR TITLE
Delete [Memo.memo] type alias to improve inferred types

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -41,11 +41,7 @@ let when_ x y =
   | true -> y ()
   | false -> return ()
 
-type 'a memo = 'a t
-
 let of_reproducible_fiber = Fun.id
-
-let of_memo = Fun.id
 
 module Allow_cutoff = struct
   type 'o t =
@@ -1740,12 +1736,17 @@ module Run = struct
 end
 
 module type S = sig
+  type 'a memo = 'a t
+
   include Monad.S
 
   module List : Monad.List with type 'a t := 'a t
 
   val of_memo : 'a memo -> 'a t
 end
+with type 'a memo := 'a t
+
+let of_memo = Fun.id
 
 module List = struct
   include Monad.List (Fiber)

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -4,10 +4,10 @@ open! Stdune
     their dependencies change. *)
 type 'a t
 
+type 'a memo := 'a t
+
 (** A type of Memo-like monads. *)
 module type S = sig
-  type 'a memo
-
   include Monad.S
 
   module List : Monad.List with type 'a t := 'a t
@@ -15,7 +15,6 @@ module type S = sig
   (** Inject a value of type ['a Memo.t] into ['a t]. *)
   val of_memo : 'a memo -> 'a t
 end
-with type 'a memo := 'a t
 
 include S with type 'a t := 'a t
 
@@ -303,8 +302,6 @@ end
 val current_run : unit -> Run.t t
 
 module Cell : sig
-  type 'a memo
-
   type ('i, 'o) t
 
   val input : ('i, _) t -> 'i
@@ -315,7 +312,6 @@ module Cell : sig
       consumers may be recomputed or not, depending on early cutoff. *)
   val invalidate : reason:Invalidation.Reason.t -> _ t -> Invalidation.t
 end
-with type 'a memo := 'a t
 
 (** Create a "memoization cell" that focuses on a single input/output pair of a
     memoized function. *)
@@ -336,8 +332,6 @@ val dump_cached_graph :
   -> Dune_graph.Graph.t Fiber.t
 
 module Lazy : sig
-  type 'a memo
-
   type 'a t
 
   val of_val : 'a -> 'a t
@@ -364,7 +358,6 @@ module Lazy : sig
       -> (unit, 'a) Cell.t * 'a t
   end
 end
-with type 'a memo := 'a t
 
 val lazy_ :
      ?cutoff:('a -> 'a -> bool)
@@ -374,8 +367,6 @@ val lazy_ :
   -> 'a Lazy.t
 
 module Implicit_output : sig
-  type 'a memo
-
   type 'o t
 
   (** [produce] and [produce_opt] are used by effectful functions to produce
@@ -396,11 +387,8 @@ module Implicit_output : sig
   (** Register a new type of implicit output. *)
   val add : (module Implicit_output with type t = 'o) -> 'o t
 end
-with type 'a memo := 'a t
 
 module With_implicit_output : sig
-  type 'a memo
-
   type ('i, 'o) t
 
   val create :
@@ -412,7 +400,6 @@ module With_implicit_output : sig
 
   val exec : ('i, 'o) t -> 'i -> 'o memo
 end
-with type 'a memo := 'a t
 
 (** Memoization of polymorphic functions ['a input -> 'a output t]. The provided
     [id] function must be injective, i.e. there must be a one-to-one


### PR DESCRIPTION
Right now, Merlin infers the type `Memo.memo` everywhere. This PR fixes the problem by getting rid of this alias.