### PR TITLE
refactor: move bash_exn to caller

### DIFF
--- a/src/dune_engine/utils.ml
+++ b/src/dune_engine/utils.ml
@@ -16,15 +16,6 @@ let system_shell_exn =
             cmd needed_to cmd os
         ]
 
-let bash_exn =
-  let bin = lazy (Bin.which ~path:(Env.path Env.initial) "bash") in
-  fun ~needed_to ->
-    match Lazy.force bin with
-    | Some path -> path
-    | None ->
-      User_error.raise
-        [ Pp.textf "I need bash to %s but I couldn't find it :(" needed_to ]
-
 let not_found fmt ?loc ?context ?hint x =
   User_error.make ?loc
     (Pp.textf fmt (String.maybe_quoted x)

--- a/src/dune_engine/utils.mli
+++ b/src/dune_engine/utils.mli
@@ -6,9 +6,6 @@ open! Stdune
     /c). Raise in case in cannot be found. *)
 val system_shell_exn : needed_to:string -> Path.t * string
 
-(** Same as [system_shell_exn] but for bash *)
-val bash_exn : needed_to:string -> Path.t
-
 (** Raise an error about a program not found in the PATH or in the tree *)
 val program_not_found :
   ?context:Context_name.t -> ?hint:string -> loc:Loc.t option -> string -> _


### PR DESCRIPTION
it's the only place where it's used and it removes one function from the
ugly Utils module