### PR TITLE
fix: directory targest and artifact cleanup

### DIFF
--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -181,7 +181,8 @@ let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
         ]
       | _ -> [])
 
-let remove_old_artifacts ~dir ~rules_here ~(subdirs_to_keep : Subdir_set.t) =
+let remove_old_artifacts ~dir ~(rules_here : Loaded.rules_here)
+    ~(subdirs_to_keep : Subdir_set.t) =
   match Path.Untracked.readdir_unsorted_with_kinds (Path.build dir) with
   | exception _ -> ()
   | Error _ -> ()
@@ -189,8 +190,8 @@ let remove_old_artifacts ~dir ~rules_here ~(subdirs_to_keep : Subdir_set.t) =
     List.iter files ~f:(fun (fn, kind) ->
         let path = Path.Build.relative dir fn in
         let path_is_a_target =
-          (* CR-someday amokhov: Also check directory targets. *)
-          Path.Build.Map.mem rules_here.Loaded.by_file_targets path
+          Path.Build.Map.mem rules_here.by_file_targets path
+          || Path.Build.Map.mem rules_here.by_directory_targets path
         in
         if not path_is_a_target then
           match kind with

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -88,11 +88,7 @@ Build directory target from the command line.
 
 Test that workspace-local cache works for directory targets.
 
-# CR-someday amokhov: Actually, it doesn't work at the moment, because we clean
-directory targets in [Load_rules.load_dir]. We should fix it.
-
   $ dune build output/x --debug-cache=workspace-local
-  Workspace-local cache miss: _build/default/output: error while collecting directory targets: opendir(_build/default/output): No such file or directory
 
 Requesting the directory target directly works too.
 


### PR DESCRIPTION
Do not delete all directory when loading rules. Stale artifact deletion
should take directory targets into account