### PR TITLE
fix: better handling of mkdir races

### DIFF
--- a/otherlibs/stdune/fpath.ml
+++ b/otherlibs/stdune/fpath.ml
@@ -19,8 +19,8 @@ type mkdir_p_result =
   | Already_exists
   | Created
 
-let rec mkdir_p ?(perms = 0o777) t_s =
-  match mkdir ~perms t_s with
+let rec mkdir_p ?perms t_s =
+  match mkdir ?perms t_s with
   | Created -> Created
   | Already_exists -> Already_exists
   | Missing_parent_directory -> (
@@ -31,8 +31,8 @@ let rec mkdir_p ?(perms = 0o777) t_s =
         []
     else
       let parent = Filename.dirname t_s in
-      match mkdir_p ~perms parent with
-      | Created | Already_exists ->
+      match mkdir_p ?perms parent with
+      | Created | Already_exists -> (
         (* The [Already_exists] case might happen if some other process managed
            to create the parent directory concurrently. *)
         Unix.mkdir t_s perms;


### PR DESCRIPTION
This PR fixes the race that occurs when:

1. we want to `$ mkdir -p x/y`
2. `x` does not exist
3. we successfully create `x`
4. we try creating `y`
5. but someone else already created `y` for us

Maybe this fixes #5461?