### PR TITLE
Fix global evaluation in external dirs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.2.0 (Unreleased)
 -----------------
 
+- Match `glob_files` only against files in external directories (#5614, fixes
+  #5540, @rgrinberg)
+
 - Add pid's to chrome trace output (#5617, @rgrinberg)
 
 - Fix race when creating local cache directory (#5613, fixes #5461, @rgrinberg)

--- a/otherlibs/stdune/path.ml
+++ b/otherlibs/stdune/path.ml
@@ -896,6 +896,10 @@ let as_in_build_dir_exn t =
       [ ("t", to_dyn t) ]
   | In_build_dir p -> p
 
+let as_external = function
+  | External s -> Some s
+  | In_build_dir _ | In_source_tree _ -> None
+
 let extract_build_context = function
   | In_source_tree _ | External _ -> None
   | In_build_dir p when Local.is_root p -> None
@@ -1162,6 +1166,9 @@ let set_of_source_paths set =
 
 let set_of_build_paths_list =
   List.fold_left ~init:Set.empty ~f:(fun acc e -> Set.add acc (build e))
+
+let set_of_external_paths set =
+  External.Set.to_list set |> Set.of_list_map ~f:external_
 
 let rename old_path new_path =
   Sys.rename (to_string old_path) (to_string new_path)

--- a/otherlibs/stdune/path.mli
+++ b/otherlibs/stdune/path.mli
@@ -320,6 +320,8 @@ val as_in_build_dir : t -> Build.t option
 
 val as_in_build_dir_exn : t -> Build.t
 
+val as_external : t -> External.t option
+
 (** [is_strict_descendant_of_build_dir t = is_in_build_dir t && t <> build_dir] *)
 val is_strict_descendant_of_build_dir : t -> bool
 
@@ -408,6 +410,8 @@ val lstat_exn : t -> Unix.stats
 val set_of_source_paths : Source.Set.t -> Set.t
 
 val set_of_build_paths_list : Build.t list -> Set.t
+
+val set_of_external_paths : External.Set.t -> Set.t
 
 (** Rename a file. [rename oldpath newpath] renames the file called [oldpath] to
     [newpath], moving it between directories if needed. If [newpath] already

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -1007,8 +1007,8 @@ end = struct
     let eval_impl g =
       let dir = File_selector.dir g in
       Load_rules.load_dir ~dir >>= function
-      | Non_build targets ->
-        Memo.return (Path.Set.filter targets ~f:(File_selector.test g))
+      | Non_build { files } ->
+        Memo.return (Path.Set.filter files ~f:(File_selector.test g))
       | Build { rules_here; _ } ->
         let only_generated_files = File_selector.only_generated_files g in
         (* We look only at [by_file_targets] because [File_selector] does not
@@ -1106,7 +1106,7 @@ let build_pred = Pred.build
    are cached. *)
 let file_exists fn =
   Load_rules.load_dir ~dir:(Path.parent_exn fn) >>= function
-  | Non_build targets -> Memo.return (Path.Set.mem targets fn)
+  | Non_build { files } -> Memo.return (Path.Set.mem files fn)
   | Build { rules_here; _ } ->
     Memo.return
       (Path.Build.Map.mem rules_here.by_file_targets
@@ -1117,7 +1117,7 @@ let file_exists fn =
 
 let files_of ~dir =
   Load_rules.load_dir ~dir >>= function
-  | Non_build file_targets -> Memo.return file_targets
+  | Non_build { files } -> Memo.return files
   | Build { rules_here; _ } ->
     Memo.return
       (Path.Build.Map.keys rules_here.by_file_targets

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -22,7 +22,7 @@ module Loaded : sig
     }
 
   type t =
-    | Non_build of Path.Set.t
+    | Non_build of { files : Path.Set.t }
     | Build of build
     | Build_under_directory_target of
         { directory_target_ancestor : Path.Build.t }

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -22,7 +22,8 @@ module Loaded : sig
     }
 
   type t =
-    | Non_build of { files : Path.Set.t }
+    | Source of { files : Path.Source.Set.t }
+    | External of { files : Path.External.Set.t }
     | Build of build
     | Build_under_directory_target of
         { directory_target_ancestor : Path.Build.t }

--- a/test/blackbox-tests/test-cases/glob-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/glob-deps.t/run.t
@@ -8,3 +8,26 @@ to the output but [foo/new-dir] is ignored.
   $ mkdir foo/new-dir
   $ dune build @glob | dune_cmd sanitize
   foo/dune foo/foo$ext_lib foo/foo.cma foo/foo.cmxa foo/foo.cmxs foo/foo.ml foo/new-file
+
+Globs should not match directories when matching in external folders either:
+
+  $ DIR=glob-external-dir
+  $ mkdir $DIR
+  $ cd $DIR
+  $ cat >dune-project <<EOF
+  > (lang dune 3.2)
+  > EOF
+  $ mkdir -p _foo/dir
+  $ touch _foo/file
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias foo)
+  >  (deps (glob_files $PWD/_foo/*))
+  >  (action (echo %{deps})))
+  > EOF
+  $ dune build @foo
+  Error: File unavailable:
+  $TESTCASE_ROOT/glob-external-dir/_foo/dir
+  This is not a regular file (S_DIR)
+  -> required by alias foo in dune:1
+  [1]

--- a/test/blackbox-tests/test-cases/glob-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/glob-deps.t/run.t
@@ -26,8 +26,4 @@ Globs should not match directories when matching in external folders either:
   >  (action (echo %{deps})))
   > EOF
   $ dune build @foo
-  Error: File unavailable:
-  $TESTCASE_ROOT/glob-external-dir/_foo/dir
-  This is not a regular file (S_DIR)
-  -> required by alias foo in dune:1
-  [1]
+  $TESTCASE_ROOT/glob-external-dir/_foo/file


### PR DESCRIPTION
As mentioned in the test, globs should only match against files.

Fix #5540 