### PR TITLE
Findlib: interpret META.pkg even when no pkg directory exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,13 @@
 - Dune-site.plugin: add support for `archive(native|byte, plugin)` used in the
   wild before findlib documented `plugin(native|byte)` in 2015 (#5518, @bobot)
 
+- Dune-site.plugin: add support for `archive(native|byte, plugin)` used in the wild before
+  findlib documented `plugin(native|byte)` in 2015 (#5518, @bobot)
+
+- Fix a bug where Dune would not correctly interpret `META` files in alternative
+  layout (ie when the META file is named `META.$pkg`). The `Llvm` bindings were
+  affected by this issue. (#5619, fixes #5616, @nojb)
+
 3.1.1 (19/04/2022)
 ------------------
 

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -71,11 +71,11 @@ let print_pkg_archives pkg =
 
 let%expect_test _ =
   print_pkg_archives "qux";
-  [%expect {| Error Not_found |}]
+  [%expect {| Ok { byte = [ "/qux/qux.cma" ]; native = [] } |}]
 
 let%expect_test _ =
   print_pkg_archives "xyz";
-  [%expect {| Error Not_found |}]
+  [%expect {| Ok { byte = [ "/xyz.cma" ]; native = [] } |}]
 
 let%expect_test _ =
   let pkg =

--- a/test/unit-tests/findlib-db/META.qux
+++ b/test/unit-tests/findlib-db/META.qux
@@ -1,0 +1,2 @@
+directory = "qux"
+archive(byte) = "qux.cma"

--- a/test/unit-tests/findlib-db/META.xyz
+++ b/test/unit-tests/findlib-db/META.xyz
@@ -1,0 +1,1 @@
+archive(byte) = "xyz.cma"


### PR DESCRIPTION
Currently Dune will correctly interpret `META` files for `$pkg` in the following cases:

- `$libdir/$pkg/META` ("standard" case)
- `$libdir/META.$pkg` if `$libdir/$pkg` exists and does not itself contain a `META` file

This PR adds one more case:

- `$libdir/META.$pkg` and there is no `$libdir/$pkg`; instead, the `directory` variable in `META.$pkg` specifies which directory `$pkg` lives in

This layout is used by the `llvm` backend libraries.

Fixes #5616 