### PR TITLE
test: split findlib tests into separate stanza

### DIFF
--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -1,10 +1,6 @@
 (library
  (name dune_unit_tests)
- (inline_tests
-  (deps
-   (source_tree ../unit-tests/findlib-db)
-   (source_tree ../unit-tests/toolchain.d)))
- (modules :standard \ vcs_tests)
+ (modules :standard \ vcs_tests findlib_tests)
  (libraries
   ocaml_config
   spawn
@@ -15,6 +11,31 @@
   dune_rules
   fiber
   dune_lang
+  memo
+  test_scheduler
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  ppx_expect.common
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))
+
+(library
+ (name findlib_tests)
+ (inline_tests
+  (deps
+   (source_tree ../unit-tests/findlib-db)
+   (source_tree ../unit-tests/toolchain.d)))
+ (modules findlib_tests)
+ (libraries
+  ocaml_config
+  dune_tests_common
+  stdune
+  dune_engine
+  dune_rules
   memo
   test_scheduler
   ;; This is because of the (implicit_transitive_deps false)


### PR DESCRIPTION
so that the rest of the tests do not depend on the findlib fixtures