### PR TITLE
better cram test metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.2.0 (Unreleased)
 -----------------
 
+- Improve metrics for cram tests. Include test names in the event and add a
+  category for cram tests (#5626, @rgrinberg)
+
 - Allow specifying multiple licenses in project file (#5579, fixes #5574,
   @liyishuai)
 

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -514,12 +514,7 @@ let extend_build_path_prefix_map env how map =
 let exec ~targets ~root ~context ~env ~rule_loc ~build_deps
     ~execution_parameters t =
   let ectx =
-    let metadata =
-      { Process.purpose = Build_job targets
-      ; loc = None
-      ; annots = User_message.Annots.empty
-      }
-    in
+    let metadata = Process.create_metadata ~purpose:(Build_job targets) () in
     { targets; metadata; context; rule_loc; build_deps }
   and eenv =
     let env =

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -28,8 +28,9 @@ let print ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
   in
   let loc = Loc.in_file file1 in
   let run_process ?(dir = dir)
-      ?(metadata = { Process.purpose = Internal_job; loc = Some loc; annots })
-      prog args =
+      ?(metadata =
+        Process.create_metadata ~purpose:Internal_job ~loc ~annots ()) prog args
+      =
     Process.run ~dir ~env:Env.initial Strict prog args ~metadata
   in
   let file1, file2 = Path.(to_string file1, to_string file2) in
@@ -103,19 +104,18 @@ let print ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
               else [ "-ascii" ])
             @ [ file1; file2 ])
             ~metadata:
-              { (* Because of the [-location-style omake], patdiff will print
-                   the location of each hunk in a format that the editor should
-                   understand. However, the location won't be the first line of
-                   the output, so the [process] module won't recognise that the
-                   output has a location.
+              ((* Because of the [-location-style omake], patdiff will print the
+                  location of each hunk in a format that the editor should
+                  understand. However, the location won't be the first line of
+                  the output, so the [process] module won't recognise that the
+                  output has a location.
 
-                   For this reason, we manually pass the below annotation. *)
-                Process.purpose = Internal_job
-              ; loc = Some loc
-              ; annots =
-                  User_message.Annots.set annots
-                    User_message.Annots.has_embedded_location ()
-              }
+                  For this reason, we manually pass the below annotation. *)
+               Process.create_metadata ~purpose:Internal_job ~loc
+                 ~annots:
+                   (User_message.Annots.set annots
+                      User_message.Annots.has_embedded_location ())
+                 ())
         in
         (* Use "diff" if "patdiff" reported no differences *)
         normal_diff ())

--- a/src/dune_engine/print_diff.ml
+++ b/src/dune_engine/print_diff.ml
@@ -28,8 +28,9 @@ let print ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
   in
   let loc = Loc.in_file file1 in
   let run_process ?(dir = dir)
-      ?(purpose = Process.Internal_job (Some loc, annots)) prog args =
-    Process.run ~dir ~env:Env.initial Strict prog args ~purpose
+      ?(metadata = { Process.purpose = Internal_job; loc = Some loc; annots })
+      prog args =
+    Process.run ~dir ~env:Env.initial Strict prog args ~metadata
   in
   let file1, file2 = Path.(to_string file1, to_string file2) in
   let fallback () =
@@ -101,18 +102,20 @@ let print ?(skip_trailing_cr = Sys.win32) annots path1 path2 =
             @ (if Lazy.force Ansi_color.stderr_supports_color then []
               else [ "-ascii" ])
             @ [ file1; file2 ])
-            ~purpose:
-              ((* Because of the [-location-style omake], patdiff will print the
-                  location of each hunk in a format that the editor should
-                  understand. However, the location won't be the first line of
-                  the output, so the [process] module won't recognise that the
-                  output has a location.
+            ~metadata:
+              { (* Because of the [-location-style omake], patdiff will print
+                   the location of each hunk in a format that the editor should
+                   understand. However, the location won't be the first line of
+                   the output, so the [process] module won't recognise that the
+                   output has a location.
 
-                  For this reason, we manually pass the below annotation. *)
-                 Internal_job
-                 ( Some loc
-                 , User_message.Annots.set annots
-                     User_message.Annots.has_embedded_location () ))
+                   For this reason, we manually pass the below annotation. *)
+                Process.purpose = Internal_job
+              ; loc = Some loc
+              ; annots =
+                  User_message.Annots.set annots
+                    User_message.Annots.has_embedded_location ()
+              }
         in
         (* Use "diff" if "patdiff" reported no differences *)
         normal_diff ())

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -52,12 +52,18 @@ module Io : sig
   val multi_use : 'a t -> 'a t
 end
 
-(** Why a Fiber.t was run. The location and annotations will be attached to
-    error messages. *)
+(** Why a Fiber.t was run.*)
 type purpose =
-  | Internal_job of Loc.t option * User_message.Annots.t
-  | Build_job of
-      Loc.t option * User_message.Annots.t * Targets.Validated.t option
+  | Internal_job
+  | Build_job of Targets.Validated.t option
+
+(** Additional metadata attached to processes. The location and annotations will
+    be attached to error messages. *)
+type metadata =
+  { loc : Loc.t option
+  ; annots : User_message.Annots.t
+  ; purpose : purpose
+  }
 
 (* Dune overrides the TMPDIR for all running actions. At Jane Street, we change
    this behaviour by setting [set_temp_dir_when_running_actions = false]. *)
@@ -71,7 +77,7 @@ val run :
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
   -> ?env:Env.t
-  -> ?purpose:purpose
+  -> ?metadata:metadata
   -> (unit, 'a) failure_mode
   -> Path.t
   -> string list
@@ -83,7 +89,7 @@ val run_with_times :
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
   -> ?env:Env.t
-  -> ?purpose:purpose
+  -> ?metadata:metadata
   -> Path.t
   -> string list
   -> Proc.Times.t Fiber.t
@@ -94,7 +100,7 @@ val run_capture :
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
   -> ?env:Env.t
-  -> ?purpose:purpose
+  -> ?metadata:metadata
   -> (string, 'a) failure_mode
   -> Path.t
   -> string list
@@ -105,7 +111,7 @@ val run_capture_line :
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
   -> ?env:Env.t
-  -> ?purpose:purpose
+  -> ?metadata:metadata
   -> (string, 'a) failure_mode
   -> Path.t
   -> string list
@@ -116,7 +122,7 @@ val run_capture_lines :
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
   -> ?env:Env.t
-  -> ?purpose:purpose
+  -> ?metadata:metadata
   -> (string list, 'a) failure_mode
   -> Path.t
   -> string list
@@ -127,7 +133,7 @@ val run_capture_zero_separated :
   -> ?stderr_to:Io.output Io.t
   -> ?stdin_from:Io.input Io.t
   -> ?env:Env.t
-  -> ?purpose:purpose
+  -> ?metadata:metadata
   -> (string list, 'a) failure_mode
   -> Path.t
   -> string list

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -62,8 +62,20 @@ type purpose =
 type metadata =
   { loc : Loc.t option
   ; annots : User_message.Annots.t
+  ; name : string option
+        (** name when emitting stats. defaults to the basename of the executable *)
+  ; categories : string list  (** additional categories when emitting stats *)
   ; purpose : purpose
   }
+
+val create_metadata :
+     ?loc:Loc.t
+  -> ?annots:User_message.Annots.t
+  -> ?name:string
+  -> ?categories:string list
+  -> ?purpose:purpose
+  -> unit
+  -> metadata
 
 (* Dune overrides the TMPDIR for all running actions. At Jane Street, we change
    this behaviour by setting [set_temp_dir_when_running_actions = false]. *)

--- a/src/dune_rules/cram_exec.ml
+++ b/src/dune_rules/cram_exec.ml
@@ -415,7 +415,20 @@ let run ~env ~script lexbuf : string Fiber.t =
       let path = Env.path Env.initial in
       Option.value_exn (Bin.which ~path "sh")
     in
-    Process.run ~dir:cwd ~env Strict sh [ Path.to_string sh_script.script ]
+    let metadata =
+      let name =
+        let base = Path.basename sh_script.script in
+        match String.equal base "run.t" with
+        | false -> base
+        | true ->
+          sprintf "%s/%s"
+            (Path.basename (Path.parent_exn sh_script.script))
+            base
+      in
+      Process.create_metadata ~name ~categories:[ "cram" ] ()
+    in
+    Process.run ~metadata ~dir:cwd ~env Strict sh
+      [ Path.to_string sh_script.script ]
   in
   let raw = read_and_attach_exit_codes sh_script in
   let sanitized = sanitize ~parent_script:sh_script.script raw in


### PR DESCRIPTION
Instead of labelling everything as `sh`, add the names of cram tests to metrics. I also added some unrelated cleanups along the way (in separate commits)