### PR TITLE
fix: track external directory IO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.2.0 (Unreleased)
 -----------------
 
+- Watch mode now tracks external directories for dependencies (#5627,
+  @rgrinberg)
+
 - Improve metrics for cram tests. Include test names in the event and add a
   category for cram tests (#5626, @rgrinberg)
 


### PR DESCRIPTION
this is needed to use globs on external dirs in watch mode