### PR TITLE
Add (locks) to (mdx) stanza

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,8 @@
 - Support `(binaries)` in `(env)` in dune-workspace files (#5560, fix #5555,
   @emillon)
 
+- (mdx) stanza: add support for (locks). (#5628, fixes #5489, @emillon)
+
 3.1.1 (19/04/2022)
 ------------------
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -2003,6 +2003,9 @@ Where ``<optional-fields>`` are:
   Note that this feature is completely separate from ``(packages)``, which
   specifies some dependencies.
 
+- ``(locks <lock-names>)`` specifies that the action of running the tests
+  holds the specified locks.  See the :ref:`locks` section for more details.
+
 Upgrading from Version 0.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/blackbox-tests/test-cases/mdx-stanza/locks.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/locks.t
@@ -1,0 +1,29 @@
+Version 0.2 of the mdx stanza does not support (locks):
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.2)
+  > (using mdx 0.2)
+  > EOF
+
+  $ cat > dune << EOF
+  > (mdx
+  >  (locks l))
+  > EOF
+
+  $ dune build
+  File "dune", line 2, characters 1-10:
+  2 |  (locks l))
+       ^^^^^^^^^
+  Error: 'locks' is only available since version 0.3 of mdx extension to verify
+  code blocks in .md files. Please update your dune-project file to have (using
+  mdx 0.3).
+  [1]
+
+In version 0.3, it is accepted:
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.2)
+  > (using mdx 0.3)
+  > EOF
+
+  $ dune build


### PR DESCRIPTION
This adds a (locks) field to the mdx stanza. This field is versioned against the extension.
