### PR TITLE
fix: better cancelled jobs handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.2.0 (Unreleased)
 -----------------
 
+- The output of jobs that finished but were cancelled is now omitted. (#5631,
+  fixes #5482, @rgrinberg)
+
 - Allows to configure all the default destination directories with `./configure`
   (adds `bin`, `sbin`, `data`, `libexec`). Use `OPAM_SWITCH_PREFIX` instead of
   calling the `opam` binaries in `dune install`. Fix handling of multiple

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -910,7 +910,7 @@ let with_job_slot f =
   let* t = t () in
   Fiber.Throttle.run t.job_throttle ~f:(fun () ->
       check_cancelled t;
-      f t.config)
+      f t.cancel t.config)
 
 (* We use this version privately in this module whenever we can pass the
    scheduler explicitly *)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -113,8 +113,9 @@ type t
 val t : unit -> t Fiber.t
 
 (** [with_job_slot f] waits for one job slot (as per [-j <jobs] to become
-    available and then calls [f]. *)
-val with_job_slot : (Config.t -> 'a Fiber.t) -> 'a Fiber.t
+    available and then calls [f]. The cancellation token is provided to [f] to
+    avoid doing some work if the job's result is no longer necessary. *)
+val with_job_slot : (Fiber.Cancel.t -> Config.t -> 'a Fiber.t) -> 'a Fiber.t
 
 (** Wait for the following process to terminate. If [is_process_group_leader] is
     true, kill the entire process group instead of just the process in case of

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -30,7 +30,7 @@ let%expect_test "cancelling a build" =
              let* () = Fiber.Ivar.read build_cancelled in
              let* res =
                Fiber.collect_errors (fun () ->
-                   Scheduler.with_job_slot (fun _ -> Fiber.return ()))
+                   Scheduler.with_job_slot (fun _ _ -> Fiber.return ()))
              in
              print_endline
                (match res with
@@ -68,7 +68,7 @@ let%expect_test "cancelling a build: effect on other fibers" =
           let* () = Scheduler.wait_for_build_input_change () in
           let* res =
             Fiber.collect_errors (fun () ->
-                Scheduler.with_job_slot (fun _ -> Fiber.return ()))
+                Scheduler.with_job_slot (fun _ _ -> Fiber.return ()))
           in
           print_endline
             (match res with


### PR DESCRIPTION
* do not print output of cancelled jobs
* `Process.run` will not return with a value signalling success if the job was cancelled after the process terminated.

Should help out with #5482.