### PR TITLE
test: directory targets and chdir

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/create-target-chdir.t
+++ b/test/blackbox-tests/test-cases/directory-targets/create-target-chdir.t
@@ -1,0 +1,31 @@
+Attempt to create a directory with chdir + with-stdout-to:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.1)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (targets (dir output))
+  >  (deps (sandbox always))
+  >  (action
+  >   (progn
+  >    (chdir output
+  >     (with-stdout-to x (echo foobar))))))
+  > EOF
+
+  $ dune build foobar/
+  File "dune", line 1, characters 0-130:
+  1 | (rule
+  2 |  (targets (dir output))
+  3 |  (deps (sandbox always))
+  4 |  (action
+  5 |   (progn
+  6 |    (chdir output
+  7 |     (with-stdout-to x (echo foobar))))))
+  Error: Rule has targets in different directories.
+  Targets:
+  - output/x
+  - output
+  [1]


### PR DESCRIPTION
add a test that tries to create a directory target using chdir +
without-stdout-to