### PR TITLE
refactor: catch specific exceptions only

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -169,6 +169,7 @@ module File_ops_real (W : Workspace) : File_operations = struct
       Format.pp_print_flush ppf ();
       Fiber.return ()
     | None -> plain_copy ()
+    (* XXX should we really be catching everything here? *)
     | exception _ ->
       User_warning.emit ~loc:(Loc.in_file src)
         [ Pp.text

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -199,7 +199,7 @@ let concurrency =
     let line =
       match input_line ic with
       | s -> Some s
-      | exception _ -> None
+      | exception End_of_file -> None
     in
     match (Unix.close_process_full (ic, oc, ec), line) with
     | WEXITED 0, Some s -> Some s
@@ -210,9 +210,9 @@ let concurrency =
   | None ->
     (* If no [-j] was given, try to autodetect the number of processors *)
     if Sys.win32 then
-      match Sys.getenv "NUMBER_OF_PROCESSORS" with
-      | exception _ -> 1
-      | s -> (
+      match Sys.getenv_opt "NUMBER_OF_PROCESSORS" with
+      | None -> 1
+      | Some s -> (
         match int_of_string s with
         | exception _ -> 1
         | n -> n)

--- a/otherlibs/configurator/src/import.ml
+++ b/otherlibs/configurator/src/import.ml
@@ -54,11 +54,6 @@ module Option = struct
 
   let some x = Some x
 
-  let try_with f =
-    match f () with
-    | exception _ -> None
-    | x -> Some x
-
   let iter t ~f =
     match t with
     | None -> ()
@@ -92,7 +87,7 @@ module Bool = struct
   let of_string s =
     match bool_of_string s with
     | s -> Some s
-    | exception _ -> None
+    | exception Invalid_argument _ -> None
 end
 
 module Map (S : Map.OrderedType) = struct
@@ -138,7 +133,7 @@ module Int = struct
   let of_string s =
     match int_of_string s with
     | s -> Some s
-    | exception _ -> None
+    | exception Failure _ -> None
 
   module Map = struct
     include Map (struct
@@ -289,7 +284,7 @@ module Io = struct
          avoid an extra memory copy. We expect that most files Dune reads are
          regular files so this optimizations seems worth it. *)
       match in_channel_length t with
-      | exception _ -> read_all_generic t (Buffer.create chunk_size)
+      | exception Sys_error _ -> read_all_generic t (Buffer.create chunk_size)
       | n -> (
         let s = really_input_string t n in
         (* For some files [in_channel_length] returns an invalid value. For

--- a/otherlibs/configurator/src/v1.ml
+++ b/otherlibs/configurator/src/v1.ml
@@ -333,7 +333,12 @@ let create_from_inside_dune ~dest_dir ~log ~build_dir ~name =
     }
 
 let create ?dest_dir ?ocamlc ?(log = ignore) name =
-  match (ocamlc, Option.try_with (fun () -> Sys.getenv "INSIDE_DUNE")) with
+  let inside_dune =
+    match Sys.getenv "INSIDE_DUNE" with
+    | exception Not_found -> None
+    | n -> Some n
+  in
+  match (ocamlc, inside_dune) with
   | None, Some build_dir when build_dir <> "1" ->
     create_from_inside_dune ~dest_dir ~log ~build_dir ~name
   | _ ->

--- a/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
+++ b/otherlibs/stdune/dune_filesystem_stubs/dune_filesystem_stubs.ml
@@ -273,7 +273,7 @@ let read_directory_with_kinds_exn dir_path =
           File_kind.Option.elim kind
             ~none:(fun () ->
               match Unix.lstat (Filename.concat dir_path base) with
-              | exception _ ->
+              | exception Unix.Unix_error _ ->
                 (* File disappeared between readdir & lstat system calls. Handle
                    as if readdir never told us about it *)
                 skip ()

--- a/otherlibs/stdune/io.ml
+++ b/otherlibs/stdune/io.ml
@@ -150,7 +150,7 @@ struct
          avoid an extra memory copy. We expect that most files Dune reads are
          regular files so this optimizations seems worth it. *)
       match in_channel_length t with
-      | exception _ -> read_all_generic t (Buffer.create chunk_size)
+      | exception Sys_error _ -> read_all_generic t (Buffer.create chunk_size)
       | n -> (
         (* For some files [in_channel_length] returns an invalid value. For
            instance for files in /proc it returns [0] and on Windows the
@@ -297,7 +297,7 @@ let portable_symlink ~src ~dst =
            enabled *)
         Unix.unlink dst;
         Unix.symlink src dst)
-    | exception _ -> Unix.symlink src dst
+    | exception Unix.Unix_error _ -> Unix.symlink src dst
 
 let portable_hardlink ~src ~dst =
   let user_error msg =

--- a/otherlibs/stdune/sys.ml
+++ b/otherlibs/stdune/sys.ml
@@ -4,7 +4,7 @@ let linux =
   match Io.String_path.read_file "/proc/sys/kernel/ostype" |> String.trim with
   | "Linux" -> true
   | _ -> false
-  | exception _ -> false
+  | exception Sys_error _ -> false
 
 let force_remove =
   if win32 then (fun fn ->

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -39,7 +39,7 @@ module Target = struct
         ~mode:(Path.Permissions.remove Path.Permissions.write st_perm);
       let executable = Path.Permissions.test Path.Permissions.execute st_perm in
       Some { path; executable }
-    | (exception _) | _ -> None
+    | (exception Unix.Unix_error _) | _ -> None
 end
 
 (* This function is like [Unix.link] but handles the "Too many links" error by

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -406,7 +406,7 @@ let auto_concurrency =
                 ~stderr:(Lazy.force Config.dev_null_out)
                 ()
             with
-            | exception _ ->
+            | exception Unix.Unix_error _ ->
               Unix.close fdw;
               Unix.close fdr;
               loop commands

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -158,7 +158,7 @@ module Fd_count = struct
   let proc_fs () =
     match Sys.readdir "/proc/self/fd" with
     | files -> This (Array.length files - 1 (* -1 for the dirfd *))
-    | exception _ -> Unknown
+    | exception Sys_error _ -> Unknown
 
   let how = ref `Unknown
 


### PR DESCRIPTION
Stop catching Invalid_argument, Code_error and other exceptions that we rarely intend to swallow