### PR TITLE
fix: terminal persistence and scrollback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.2.0 (Unreleased)
 -----------------
 
+- `--terminal-persistence=clear-on-rebuild` will no longer destroy scrollback
+  on some terminals (#5646, @rgrinberg)
+
 - Add a fmt command as a shortcut of `dune build @fmt --auto-promote` (#5574,
   @tmattio)
 

--- a/otherlibs/stdune/console.ml
+++ b/otherlibs/stdune/console.ml
@@ -25,7 +25,7 @@ module Backend = struct
       Ansi_color.prerr
         (Pp.seq (Pp.map_tags msg ~f:User_message.Print_config.default) Pp.cut)
 
-    let reset () = prerr_string "\x1bc"
+    let reset () = prerr_string "\x1b[H\x1b[2J"
   end
 
   module Dumb : S = struct


### PR DESCRIPTION
[--terminal-persistence=clear-on-rebuild] will no longer destroy scrollback on some faulty terminals