### PR TITLE
fix: memo fs access for ocaml syntax dune files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,8 @@
 - Add a fmt command as a shortcut of `dune build @fmt --auto-promote` (#5574,
   @tmattio)
 
-- Watch mode now tracks external directories for dependencies (#5627,
-  @rgrinberg)
+- Watch mode now tracks external directories for dependencies, dune files in
+  OCaml syntax (#5627, #5652, @rgrinberg)
 
 - Improve metrics for cram tests. Include test names in the event and add a
   category for cram tests (#5626, @rgrinberg)

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -280,7 +280,7 @@ let dir_contents ?(force_update = false) path =
    because the result's type depends on [f]. There are only two call sites of
    [with_lexbuf_from_file], so perhaps we could just replace this more general
    function with two simpler ones that can be cached independently. *)
-let with_lexbuf_from_file path ~f =
+let tracking_file_digest path =
   let+ () = Watcher.watch ~try_to_watch_via_parent:true path in
   (* This is a bit of a hack. By reading [file_digest], we cause the [path] to
      be recorded in the [Fs_cache.Untracked.file_digest], so the build will be
@@ -288,7 +288,15 @@ let with_lexbuf_from_file path ~f =
   let (_ : Cached_digest.Digest_result.t) =
     Fs_cache.read Fs_cache.Untracked.file_digest path
   in
+  ()
+
+let with_lexbuf_from_file path ~f =
+  let+ () = tracking_file_digest path in
   Io.Untracked.with_lexbuf_from_file path ~f
+
+let file_contents path =
+  let+ () = tracking_file_digest path in
+  Io.read_file path
 
 (* When a file or directory is created or deleted, we need to also invalidate
    the parent directory, so that the [dir_contents] queries are re-executed. *)

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -35,6 +35,8 @@ val file_digest :
     path. *)
 val with_lexbuf_from_file : Path.t -> f:(Lexing.lexbuf -> 'a) -> 'a Memo.t
 
+val file_contents : Path.t -> string Memo.t
+
 (** Read the contents of a source or external directory and declare a dependency
     on it. When [force_update = true], evict the directory from the file-system
     cache and force the recomputation of the result. This can be useful if Dune


### PR DESCRIPTION
Convert more untracked file system to the memoized code path.