### PR TITLE
fix: parallel dune file interpretation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.2.0 (Unreleased)
 -----------------
 
+- Report dune file evaluation errors concurrently. In the same way we report
+  build errors. (#5655, @rgrinberg)
+
 - Watch mode now default to clearing the terminal on rebuild (#5636, fixes,
   #5216, @rgrinberg)
 

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -249,7 +249,7 @@ let load () =
   in
   let+ dune_files =
     Appendable_list.to_list dune_files
-    |> Memo.sequential_map ~f:(fun (dir, project, dune_file) ->
+    |> Memo.parallel_map ~f:(fun (dir, project, dune_file) ->
            interpret ~dir ~project ~dune_file)
   in
   { dune_files; packages; projects }

--- a/test/blackbox-tests/test-cases/include-qualified.t/run.t
+++ b/test/blackbox-tests/test-cases/include-qualified.t/run.t
@@ -26,6 +26,11 @@ We can nested modules virtual
                        ^^^^^^^^^
   Error: Unknown value qualified
   Hint: did you mean unqualified?
+  File "vlib/dune", line 1, characters 17-26:
+  1 | (include_subdirs qualified)
+                       ^^^^^^^^^
+  Error: Unknown value qualified
+  Hint: did you mean unqualified?
   [1]
 
 We can set preprocessing options for nested modules


### PR DESCRIPTION
This allows to view dune errors from different files concurrently,
rather than one a time. Which is consistent with how we present build
errors.