### PR TITLE
Fix early cutoff for directory targets

### DIFF
--- a/otherlibs/stdune/digest.ml
+++ b/otherlibs/stdune/digest.ml
@@ -75,18 +75,10 @@ module Stats_for_digest = struct
   type t =
     { st_kind : Unix.file_kind
     ; st_perm : Unix.file_perm
-    ; st_size : int
-    ; st_mtime : float
-    ; st_ctime : float
     }
 
   let of_unix_stats (stats : Unix.stats) =
-    { st_kind = stats.st_kind
-    ; st_perm = stats.st_perm
-    ; st_size = stats.st_size
-    ; st_mtime = stats.st_mtime
-    ; st_ctime = stats.st_ctime
-    }
+    { st_kind = stats.st_kind; st_perm = stats.st_perm }
 end
 
 module Path_digest_result = struct
@@ -115,7 +107,7 @@ exception
     | `Unexpected_kind
     ]
 
-let directory_digest_version = 1
+let directory_digest_version = 2
 
 let rec path_with_stats ~allow_dirs path (stats : Stats_for_digest.t) :
     Path_digest_result.t =
@@ -155,12 +147,5 @@ let rec path_with_stats ~allow_dirs path (stats : Stats_for_digest.t) :
       | exception E (`Unix_error e) -> Path_digest_result.Unix_error e
       | exception E `Unexpected_kind -> Path_digest_result.Unexpected_kind
       | contents ->
-        Ok
-          (generic
-             ( directory_digest_version
-             , contents
-             , stats.st_size
-             , stats.st_perm
-             , stats.st_mtime
-             , stats.st_ctime ))))
+        Ok (generic (directory_digest_version, contents, stats.st_perm))))
   | S_DIR | S_BLK | S_CHR | S_LNK | S_FIFO | S_SOCK -> Unexpected_kind

--- a/otherlibs/stdune/digest.mli
+++ b/otherlibs/stdune/digest.mli
@@ -32,9 +32,6 @@ module Stats_for_digest : sig
   type t =
     { st_kind : Unix.file_kind
     ; st_perm : Unix.file_perm
-    ; st_size : int
-    ; st_mtime : float
-    ; st_ctime : float
     }
 
   val of_unix_stats : Unix.stats -> t
@@ -56,9 +53,7 @@ end
       as well as the its executable permissions bit.
 
     - If it's a directory and [allow_dirs = true], the function computes the
-      digest of [Stats_for_digest] (except for the [st_kind] field since it's
-      known to be [S_DIR] in this case). This is a poor approach to computing
-      directory digests and we are planning to get rid of it soon.
+      digest of all contained filename/digest pairs, recursively.
 
     - Otherwise, the function returns [Unexpected_kind].
 

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -317,13 +317,12 @@ mtime changes when the rule reruns. We can delete this when switching to (1).
   b:
   new-b
 
-There is no early cutoff on directory targets at the moment. Ideally, we should
-skip the second action since the produced directory has the same contents.
+Dune supports early cutoff for directory targets: it skips the second action
+since the produced directory has the same contents.
 
   $ dune_cmd wait-for-fs-clock-to-advance
   $ echo new-cc > src_c
   $ dune build contents
-  running
   running
   $ cat _build/default/contents
   a:
@@ -331,14 +330,12 @@ skip the second action since the produced directory has the same contents.
   b:
   new-b
 
-There is no shared cache support for directory targets at the moment. Note that
-we rerun both actions: the first one because there is no shared cache support
-and the second one because of the lack of early cutoff.
+There is no shared cache support for directory targets at the moment, which is
+why we rerun the first action.
 
   $ dune_cmd wait-for-fs-clock-to-advance
   $ rm _build/default/output/a
   $ dune build contents
-  running
   running
 
 Check that Dune clears stale files from directory targets.

--- a/test/expect-tests/stdune/digest_tests.ml
+++ b/test/expect-tests/stdune/digest_tests.ml
@@ -6,16 +6,9 @@ let%expect_test "directory digest version" =
 
      The expected value is kept ouside of the expect block on purpose so that it
      must be modified manually. *)
-  let expected = "921844ea7c28cccb9edf40c8fd0245a5" in
+  let expected = "a743ec66ce913ff6587a3816a8acc6ea" in
   let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
-  let stats =
-    { Digest.Stats_for_digest.st_kind = S_DIR
-    ; st_perm = 1
-    ; st_size = 1
-    ; st_mtime = 0.
-    ; st_ctime = 0.
-    }
-  in
+  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; st_perm = 1 } in
   (match Digest.path_with_stats ~allow_dirs:true dir stats with
   | Ok digest ->
     let digest = Digest.to_string digest in
@@ -30,14 +23,7 @@ let%expect_test "directory digest version" =
 
 let%expect_test "reject directories with symlinks (for now)" =
   let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
-  let stats =
-    { Digest.Stats_for_digest.st_kind = S_DIR
-    ; st_perm = 1
-    ; st_size = 1
-    ; st_mtime = 0.
-    ; st_ctime = 0.
-    }
-  in
+  let stats = { Digest.Stats_for_digest.st_kind = S_DIR; st_perm = 1 } in
   Unix.symlink "bar" (Path.to_string (Path.relative dir "foo"));
   (match Digest.path_with_stats ~allow_dirs:true dir stats with
   | Ok _ -> print_endline "[FAIL] failure expected"


### PR DESCRIPTION
@rgrinberg Not sure how I missed this when reviewing your PR for digesting directories, but we clearly don't need to include `mtime` and friends anymore. We did that before only because we didn't have a proper digest. Now that we do, `mtime` stands in the way of early cutoff for directory targets, so this PR fixes that.