### PR TITLE
Support ocamldep -strict

### DIFF
--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -79,6 +79,10 @@ let deps_of md ~ml_kind unit =
   let parse_module_names = parse_module_names ~modules in
   let all_deps_file = dep (Transitive (unit, ml_kind)) in
   let ocamldep_output = dep (Immediate source) in
+  let strict =
+    if Ocaml.Version.ocamldep_supports_strict context.version then [ "-strict" ]
+    else []
+  in
   let open Memo.O in
   let* () =
     SC.add_rule sctx ~dir
@@ -90,6 +94,7 @@ let deps_of md ~ml_kind unit =
       Command.run context.ocamldep
         ~dir:(Path.build context.build_dir)
         [ A "-modules"
+        ; As strict
         ; Command.Args.dyn flags
         ; Command.Ml_kind.flag ml_kind
         ; Dep (Module.File.path source)

--- a/src/ocaml/version.ml
+++ b/src/ocaml/version.ml
@@ -45,3 +45,7 @@ let has_vmthreads version = version < (4, 9, 0)
 let has_bigarray_library version = version < (5, 0, 0)
 
 let supports_alerts version = version >= (4, 8, 0)
+
+let ocamldep_supports_strict _ =
+  (* TODO *)
+  true

--- a/src/ocaml/version.mli
+++ b/src/ocaml/version.mli
@@ -67,3 +67,6 @@ val has_bigarray_library : t -> bool
 
 (** Whether the compiler supports alerts and the corresponding [-alert] option *)
 val supports_alerts : t -> bool
+
+(** Whether [ocamldep] supports the [-strict] flag. *)
+val ocamldep_supports_strict : t -> bool

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -4,7 +4,7 @@ This captures the commands that are being run:
 
   $ <trace.json grep '"X"' | cut -c 2- | sed -E 's/:[0-9]+/:.../g'
   {"args":{"process_args":["-config"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
-  {"args":{"process_args":["-modules","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
+  {"args":{"process_args":["-modules","-strict","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamldep.opt","cat":"process","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-bin-annot","-I",".prog.eobjs/byte","-no-alias-deps","-opaque","-o",".prog.eobjs/byte/prog.cmo","-c","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamlc.opt","cat":"process","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-I",".prog.eobjs/byte","-I",".prog.eobjs/native","-intf-suffix",".ml","-no-alias-deps","-opaque","-o",".prog.eobjs/native/prog.cmx","-c","-impl","prog.ml"],"pid":...},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}
   {"args":{"process_args":["-w","@1..3@5..28@30..39@43@46..47@49..57@61..62-40","-strict-sequence","-strict-formats","-short-paths","-keep-locs","-g","-o","prog.exe",".prog.eobjs/native/prog.cmx"],"pid":...},"ph":"X","dur":...,"name":"ocamlopt.opt","cat":"process","ts":...,"pid":...,"tid":...}


### PR DESCRIPTION
This passes `-strict` to compilers that support it, to make sure we catch more error cases.

This can be tested with <https://github.com/emillon/ocaml#ocamldep-strict>, though the branch is not stable.