### PR TITLE
ctypes: support external lib name that isn't a valid ocaml module name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,9 @@
   paths, and provide better error messages when paths are invalid (#5703, #5704,
   fixes #5596, @emillon)
 
+- Fix ctypes rules for external lib names which aren't valid ocaml names
+  (#5667, fixes #5511, @Khady)
+
 3.1.1 (19/04/2022)
 ------------------
 

--- a/src/dune_rules/ctypes_rules.ml
+++ b/src/dune_rules/ctypes_rules.ml
@@ -63,18 +63,21 @@ module Stanza_util = struct
 
   let discover_script ctypes =
     sprintf "%s__ctypes_discover"
-      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
+      (ctypes.Ctypes.external_library_name |> External_lib_name.clean
+     |> External_lib_name.to_string)
 
   let type_gen_script ctypes =
     sprintf "%s__type_gen"
-      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
+      (ctypes.Ctypes.external_library_name |> External_lib_name.clean
+     |> External_lib_name.to_string)
 
   let module_name_lower_string module_name =
     String.lowercase (Module_name.to_string module_name)
 
   let function_gen_script ctypes fd =
     sprintf "%s__function_gen__%s__%s"
-      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
+      (ctypes.Ctypes.external_library_name |> External_lib_name.clean
+     |> External_lib_name.to_string)
       (module_name_lower_string fd.Ctypes.Function_description.functor_)
       (module_name_lower_string fd.Ctypes.Function_description.instance)
 
@@ -94,12 +97,14 @@ module Stanza_util = struct
 
   let c_generated_types_module ctypes =
     sprintf "%s__c_generated_types"
-      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
+      (ctypes.Ctypes.external_library_name |> External_lib_name.to_module_name
+     |> Module_name.to_string)
     |> Module_name.of_string
 
   let c_generated_functions_module ctypes fd =
     sprintf "%s__c_generated_functions__%s__%s"
-      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
+      (ctypes.Ctypes.external_library_name |> External_lib_name.clean
+     |> External_lib_name.to_string)
       (module_name_lower_string fd.Ctypes.Function_description.functor_)
       (module_name_lower_string fd.Ctypes.Function_description.instance)
     |> Module_name.of_string

--- a/src/dune_rules/ctypes_rules.ml
+++ b/src/dune_rules/ctypes_rules.ml
@@ -619,7 +619,8 @@ let gen_rules ~cctx ~buildable ~loc ~scope ~dir ~sctx =
   let* () =
     memo_list_iter ctypes.Ctypes.function_description ~f:(fun fd ->
         let stubs_prefix =
-          External_lib_name.to_string external_library_name ^ "_stubs"
+          External_lib_name.(external_library_name |> clean |> to_string)
+          ^ "_stubs"
         in
         let c_generated_functions_cout_c =
           Stanza_util.c_generated_functions_cout_c ctypes fd

--- a/src/dune_rules/ctypes_rules.ml
+++ b/src/dune_rules/ctypes_rules.ml
@@ -62,16 +62,19 @@ module Stanza_util = struct
   let sprintf = Printf.sprintf
 
   let discover_script ctypes =
-    sprintf "%s__ctypes_discover" ctypes.Ctypes.external_library_name
+    sprintf "%s__ctypes_discover"
+      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
 
   let type_gen_script ctypes =
-    sprintf "%s__type_gen" ctypes.Ctypes.external_library_name
+    sprintf "%s__type_gen"
+      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
 
   let module_name_lower_string module_name =
     String.lowercase (Module_name.to_string module_name)
 
   let function_gen_script ctypes fd =
-    sprintf "%s__function_gen__%s__%s" ctypes.Ctypes.external_library_name
+    sprintf "%s__function_gen__%s__%s"
+      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
       (module_name_lower_string fd.Ctypes.Function_description.functor_)
       (module_name_lower_string fd.Ctypes.Function_description.instance)
 
@@ -86,15 +89,17 @@ module Stanza_util = struct
       ~external_library_name:ctypes.Ctypes.external_library_name
 
   let c_library_flags_sexp ctypes =
-    sprintf "%s__c_library_flags.sexp" ctypes.Ctypes.external_library_name
+    sprintf "%s__c_library_flags.sexp"
+      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
 
   let c_generated_types_module ctypes =
-    sprintf "%s__c_generated_types" ctypes.Ctypes.external_library_name
+    sprintf "%s__c_generated_types"
+      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
     |> Module_name.of_string
 
   let c_generated_functions_module ctypes fd =
     sprintf "%s__c_generated_functions__%s__%s"
-      ctypes.Ctypes.external_library_name
+      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
       (module_name_lower_string fd.Ctypes.Function_description.functor_)
       (module_name_lower_string fd.Ctypes.Function_description.instance)
     |> Module_name.of_string
@@ -105,7 +110,7 @@ module Stanza_util = struct
 
   let c_generated_functions_cout_c ctypes fd =
     sprintf "%s__c_cout_generated_functions__%s__%s.c"
-      ctypes.Ctypes.external_library_name
+      (External_lib_name.to_string ctypes.Ctypes.external_library_name)
       (module_name_lower_string fd.Ctypes.Function_description.functor_)
       (module_name_lower_string fd.Ctypes.Function_description.instance)
 
@@ -213,16 +218,18 @@ let discover_gen ~external_library_name:lib ~cflags_sexp ~c_library_flags_sexp =
   Pp.concat
     [ verbatimf "module C = Configurator.V1"
     ; verbatimf "let () ="
-    ; verbatimf "  C.main ~name:\"%s\" (fun c ->" lib
+    ; verbatimf "  C.main ~name:\"%s\" (fun c ->"
+        (External_lib_name.to_string lib)
     ; verbatimf "    let default : C.Pkg_config.package_conf ="
-    ; verbatimf "      { libs   = [\"-l%s\"];" lib
+    ; verbatimf "      { libs   = [\"-l%s\"];" (External_lib_name.to_string lib)
     ; verbatimf "        cflags = [\"-I/usr/include\"] }"
     ; verbatimf "    in"
     ; verbatimf "    let conf ="
     ; verbatimf "      match C.Pkg_config.get c with"
     ; verbatimf "      | None -> default"
     ; verbatimf "      | Some pc ->"
-    ; verbatimf "        match C.Pkg_config.query pc ~package:\"%s\" with" lib
+    ; verbatimf "        match C.Pkg_config.query pc ~package:\"%s\" with"
+        (External_lib_name.to_string lib)
     ; verbatimf "        | None -> default"
     ; verbatimf "        | Some deps -> deps"
     ; verbatimf "    in"
@@ -570,10 +577,12 @@ let gen_rules ~cctx ~buildable ~loc ~scope ~dir ~sctx =
      data/types produced in this step. *)
   let* () =
     let c_generated_types_cout_c =
-      sprintf "%s__c_cout_generated_types.c" external_library_name
+      sprintf "%s__c_cout_generated_types.c"
+        (External_lib_name.to_string external_library_name)
     in
     let c_generated_types_cout_exe =
-      sprintf "%s__c_cout_generated_types.exe" external_library_name
+      sprintf "%s__c_cout_generated_types.exe"
+        (External_lib_name.to_string external_library_name)
     in
     let type_gen_script = Stanza_util.type_gen_script ctypes in
     let* () =
@@ -604,7 +613,9 @@ let gen_rules ~cctx ~buildable ~loc ~scope ~dir ~sctx =
      in the code generator. *)
   let* () =
     memo_list_iter ctypes.Ctypes.function_description ~f:(fun fd ->
-        let stubs_prefix = external_library_name ^ "_stubs" in
+        let stubs_prefix =
+          External_lib_name.to_string external_library_name ^ "_stubs"
+        in
         let c_generated_functions_cout_c =
           Stanza_util.c_generated_functions_cout_c ctypes fd
         in

--- a/src/dune_rules/ctypes_stanza.ml
+++ b/src/dune_rules/ctypes_stanza.ml
@@ -103,7 +103,7 @@ module Function_description = struct
 end
 
 type t =
-  { external_library_name : string
+  { external_library_name : External_lib_name.t
   ; build_flags_resolver : Build_flags_resolver.t
   ; headers : Headers.t
   ; type_description : Type_description.t
@@ -135,7 +135,7 @@ let decode =
      and+ generated_entry_point =
        field "generated_entry_point" Module_name.decode
      and+ deps = field_o "deps" (repeat Dep_conf.decode) in
-     { external_library_name
+     { external_library_name = External_lib_name.of_string external_library_name
      ; build_flags_resolver =
          Option.value build_flags_resolver ~default:Build_flags_resolver.default
      ; headers = Option.value headers ~default:Headers.default

--- a/src/dune_rules/ctypes_stanza.mli
+++ b/src/dune_rules/ctypes_stanza.mli
@@ -43,7 +43,7 @@ module Function_description : sig
 end
 
 type t =
-  { external_library_name : string
+  { external_library_name : External_lib_name.t
   ; build_flags_resolver : Build_flags_resolver.t
   ; headers : Headers.t
   ; type_description : Type_description.t

--- a/src/dune_rules/ctypes_stubs.ml
+++ b/src/dune_rules/ctypes_stubs.ml
@@ -1,16 +1,18 @@
 open Import
 
 let cflags_sexp ~external_library_name =
-  sprintf "%s__c_flags.sexp" external_library_name
+  sprintf "%s__c_flags.sexp" (External_lib_name.to_string external_library_name)
 
 let c_generated_functions_cout_no_ext ~external_library_name ~functor_ ~instance
     =
-  sprintf "%s__c_cout_generated_functions__%s__%s" external_library_name
+  sprintf "%s__c_cout_generated_functions__%s__%s"
+    (External_lib_name.to_string external_library_name)
     (Module_name.to_string functor_ |> String.lowercase)
     (Module_name.to_string instance |> String.lowercase)
 
 let c_library_flags ~external_library_name =
-  sprintf "%s__c_library_flags.sexp" external_library_name
+  sprintf "%s__c_library_flags.sexp"
+    (External_lib_name.to_string external_library_name)
 
 let lib_deps_of_strings ~loc lst =
   List.map lst ~f:(fun lib -> Lib_dep.Direct (loc, Lib_name.of_string lib))

--- a/src/dune_rules/ctypes_stubs.mli
+++ b/src/dune_rules/ctypes_stubs.mli
@@ -3,12 +3,12 @@ open Import
 (* This module would be part of Ctypes_rules, except it creates a circular
    dependency if Dune_file tries to access it. *)
 
-val cflags_sexp : external_library_name:string -> string
+val cflags_sexp : external_library_name:External_lib_name.t -> string
 
-val c_library_flags : external_library_name:string -> string
+val c_library_flags : external_library_name:External_lib_name.t -> string
 
 val c_generated_functions_cout_no_ext :
-     external_library_name:string
+     external_library_name:External_lib_name.t
   -> functor_:Module_name.t
   -> instance:Module_name.t
   -> string
@@ -18,7 +18,7 @@ val libraries_needed_for_ctypes : loc:Loc.t -> Lib_dep.t list
 val add :
      loc:Loc.t
   -> parsing_context:Univ_map.t
-  -> external_library_name:string
+  -> external_library_name:External_lib_name.t
   -> add_stubs:
        (   Foreign_language.t
         -> loc:Loc.t

--- a/src/dune_rules/external_lib_name.ml
+++ b/src/dune_rules/external_lib_name.ml
@@ -1,0 +1,27 @@
+open! Import
+open! Dune_engine
+open Stdune
+
+include Stringlike.Make (struct
+  type t = string
+
+  let description = "external lib name"
+
+  let module_ = "External_lib_name"
+
+  let description_of_valid_string = None
+
+  let hint_valid = None
+
+  let to_string s = s
+
+  let of_string_opt s = Some s
+end)
+
+let equal = String.equal
+
+let compare = String.compare
+
+let to_module_name t =
+  (* TODO: correctly mangle the name to make it a valid module *)
+  Module_name.of_string t

--- a/src/dune_rules/external_lib_name.ml
+++ b/src/dune_rules/external_lib_name.ml
@@ -22,6 +22,10 @@ let equal = String.equal
 
 let compare = String.compare
 
-let to_module_name t =
-  (* TODO: correctly mangle the name to make it a valid module *)
-  Module_name.of_string t
+let clean t =
+  String.init (String.length t) ~f:(fun i ->
+      match t.[i] with
+      | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'') as c -> c
+      | _ -> 'c')
+
+let to_module_name t = Module_name.of_string (clean t)

--- a/src/dune_rules/external_lib_name.ml
+++ b/src/dune_rules/external_lib_name.ml
@@ -26,6 +26,6 @@ let clean t =
   String.init (String.length t) ~f:(fun i ->
       match t.[i] with
       | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'') as c -> c
-      | _ -> 'c')
+      | _ -> '_')
 
 let to_module_name t = Module_name.of_string (clean t)

--- a/src/dune_rules/external_lib_name.mli
+++ b/src/dune_rules/external_lib_name.mli
@@ -1,0 +1,12 @@
+open Import
+
+(** Represents a valid external lib name *)
+type t
+
+include Stringlike_intf.S with type t := t
+
+val equal : t -> t -> bool
+
+val compare : t -> t -> Ordering.t
+
+val to_module_name : t -> Module_name.t

--- a/src/dune_rules/external_lib_name.mli
+++ b/src/dune_rules/external_lib_name.mli
@@ -10,3 +10,5 @@ val equal : t -> t -> bool
 val compare : t -> t -> Ordering.t
 
 val to_module_name : t -> Module_name.t
+
+val clean : t -> t

--- a/test/blackbox-tests/test-cases/ctypes/dune
+++ b/test/blackbox-tests/test-cases/ctypes/dune
@@ -10,9 +10,21 @@
   (package ctypes)))
 
 (cram
+ (applies_to :whole_subtree)
+ (deps
+  libneed-mangling/libneed-mangling.a
+  libneed-mangling/libneed-mangling.so
+  libneed-mangling/example.h
+  libneed-mangling/need-mangling.pc
+  %{bin:install}
+  %{bin:awk}
+  (package ctypes)))
+
+(cram
  (applies_to
   lib-pkg_config
   lib-pkg_config-multiple-fd
+  lib-external-name-need-mangling
   exe-pkg_config-multiple-fd
   exe-pkg_config)
  (deps %{bin:pkg-config}))

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/dune
@@ -1,0 +1,3 @@
+(executable
+  (name example)
+  (libraries examplelib))

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/dune-project
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.0)
+(using ctypes 0.1)
+(use_standard_c_and_cxx_flags false)

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/example.ml
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/example.ml
@@ -1,0 +1,2 @@
+let () =
+  Printf.printf "%d\n" (Examplelib.C.Functions.add2 2)

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
@@ -7,92 +7,18 @@ cannot set ${prefix} to be interpreted relative to the .pc itself ufortunately
   $ awk "BEGIN{print \"prefix=$LIBEX\"} {print}" $LIBEX/need-mangling.pc > need-mangling.pc
 
   $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$PWD:$PKG_CONFIG_PATH" dune exec ./example.exe
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("Invalid Module_name.t", { s = "need-mangling__c_generated_types" })
-  Raised at Stdune__Code_error.raise in file "otherlibs/stdune/code_error.ml",
-    line 11, characters 30-62
-  Called from Dune_rules__Ctypes_rules.Stanza_util.generated_modules in file
-    "src/dune_rules/ctypes_rules.ml", line 134, characters 8-39
-  Called from Dune_rules__Ctypes_rules.Stanza_util.generated_ml_and_c_files in
-    file "src/dune_rules/ctypes_rules.ml", line 147, characters 6-30
-  Called from Dune_rules__Dir_contents.Load.load_text_files.(fun) in file
-    "src/dune_rules/dir_contents.ml", line 180, characters 31-75
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
-    characters 8-11
-  -> required by ("<unnamed>", ())
-  -> required by ("<unnamed>", ())
-  -> required by ("<unnamed>", ())
-  -> required by ("Rule.make", ())
-  -> required by ("execute-rule", { id = 7; info = Internal })
-  -> required by ("<unnamed>", ())
-  -> required by
-     ("build-file", In_build_dir "default/.merlin-conf/exe-example")
-  -> required by ("Rule.set_action", ())
-  -> required by
-     ("execute-rule",
-     { id = 6
-     ; info =
-         From_dune_file
-           { pos_fname = "dune"
-           ; start = { pos_lnum = 2; pos_bol = 12; pos_cnum = 20 }
-           ; stop = { pos_lnum = 2; pos_bol = 12; pos_cnum = 27 }
-           }
-     })
-  -> required by ("<unnamed>", ())
-  -> required by ("build-file", In_build_dir "default/example.exe")
-  
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
+  File "stubgen/needcmangling__c_generated_functions__function_description__functions.ml", line 3, characters 13-14:
+  3 | external need-mangling_stubs_1_example_add2 : int -> int
+                   ^
+  Error: Syntax error
+  File "stubgen/dune", line 1, characters 0-365:
+   1 | (library
+   2 |  (name examplelib)
+   3 |  (flags
+  ....14 |    (instance Functions)
+  15 |    (functor Function_description))
+  16 |   (generated_entry_point C)))
+  need-mangling__c_cout_generated_functions__function_description__functions.c:3:11: error: expected '=', ',', ';', 'asm' or '__attribute__' before '-' token
+   value need-mangling_stubs_1_example_add2(value x1)
+             ^
   [1]

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
@@ -13,9 +13,9 @@ cannot set ${prefix} to be interpreted relative to the .pc itself ufortunately
   Raised at Stdune__Code_error.raise in file "otherlibs/stdune/code_error.ml",
     line 11, characters 30-62
   Called from Dune_rules__Ctypes_rules.Stanza_util.generated_modules in file
-    "src/dune_rules/ctypes_rules.ml", line 129, characters 8-39
+    "src/dune_rules/ctypes_rules.ml", line 134, characters 8-39
   Called from Dune_rules__Ctypes_rules.Stanza_util.generated_ml_and_c_files in
-    file "src/dune_rules/ctypes_rules.ml", line 142, characters 6-30
+    file "src/dune_rules/ctypes_rules.ml", line 147, characters 6-30
   Called from Dune_rules__Dir_contents.Load.load_text_files.(fun) in file
     "src/dune_rules/dir_contents.ml", line 180, characters 31-75
   Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
@@ -1,0 +1,98 @@
+Bind to a C library which has a name invalid in ocaml
+
+  $ LIBEX=$(realpath "$PWD/../libneed-mangling")
+
+This silly looking hack is to make sure the .pc file points to the sandbox. We
+cannot set ${prefix} to be interpreted relative to the .pc itself ufortunately
+  $ awk "BEGIN{print \"prefix=$LIBEX\"} {print}" $LIBEX/need-mangling.pc > need-mangling.pc
+
+  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$PWD:$PKG_CONFIG_PATH" dune exec ./example.exe
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("Invalid Module_name.t", { s = "need-mangling__c_generated_types" })
+  Raised at Stdune__Code_error.raise in file "otherlibs/stdune/code_error.ml",
+    line 11, characters 30-62
+  Called from Dune_rules__Ctypes_rules.Stanza_util.generated_modules in file
+    "src/dune_rules/ctypes_rules.ml", line 129, characters 8-39
+  Called from Dune_rules__Ctypes_rules.Stanza_util.generated_ml_and_c_files in
+    file "src/dune_rules/ctypes_rules.ml", line 142, characters 6-30
+  Called from Dune_rules__Dir_contents.Load.load_text_files.(fun) in file
+    "src/dune_rules/dir_contents.ml", line 180, characters 31-75
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 69,
+    characters 8-11
+  -> required by ("<unnamed>", ())
+  -> required by ("<unnamed>", ())
+  -> required by ("<unnamed>", ())
+  -> required by ("Rule.make", ())
+  -> required by ("execute-rule", { id = 7; info = Internal })
+  -> required by ("<unnamed>", ())
+  -> required by
+     ("build-file", In_build_dir "default/.merlin-conf/exe-example")
+  -> required by ("Rule.set_action", ())
+  -> required by
+     ("execute-rule",
+     { id = 6
+     ; info =
+         From_dune_file
+           { pos_fname = "dune"
+           ; start = { pos_lnum = 2; pos_bol = 12; pos_cnum = 20 }
+           ; stop = { pos_lnum = 2; pos_bol = 12; pos_cnum = 27 }
+           }
+     })
+  -> required by ("<unnamed>", ())
+  -> required by ("build-file", In_build_dir "default/example.exe")
+  
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases. 
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
+  [1]

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/run.t
@@ -7,18 +7,4 @@ cannot set ${prefix} to be interpreted relative to the .pc itself ufortunately
   $ awk "BEGIN{print \"prefix=$LIBEX\"} {print}" $LIBEX/need-mangling.pc > need-mangling.pc
 
   $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$PWD:$PKG_CONFIG_PATH" dune exec ./example.exe
-  File "stubgen/needcmangling__c_generated_functions__function_description__functions.ml", line 3, characters 13-14:
-  3 | external need-mangling_stubs_1_example_add2 : int -> int
-                   ^
-  Error: Syntax error
-  File "stubgen/dune", line 1, characters 0-365:
-   1 | (library
-   2 |  (name examplelib)
-   3 |  (flags
-  ....14 |    (instance Functions)
-  15 |    (functor Function_description))
-  16 |   (generated_entry_point C)))
-  need-mangling__c_cout_generated_functions__function_description__functions.c:3:11: error: expected '=', ',', ';', 'asm' or '__attribute__' before '-' token
-   value need-mangling_stubs_1_example_add2(value x1)
-             ^
-  [1]
+  4

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/stubgen/dune
@@ -1,0 +1,16 @@
+(library
+ (name examplelib)
+ (flags
+  (:standard -w -9-27))
+ (ctypes
+  (external_library_name need-mangling)
+  (build_flags_resolver pkg_config)
+  (headers
+   (include "example.h"))
+  (type_description
+   (instance Types)
+   (functor Type_description))
+  (function_description
+   (instance Functions)
+   (functor Function_description))
+  (generated_entry_point C)))

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/stubgen/function_description.ml
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/stubgen/function_description.ml
@@ -1,0 +1,8 @@
+open Ctypes
+
+module Types = Types_generated
+
+module Functions (F : Ctypes.FOREIGN) = struct
+  open F
+  let add2 = foreign "example_add2" (int @-> returning int)
+end

--- a/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/stubgen/type_description.ml
+++ b/test/blackbox-tests/test-cases/ctypes/lib-external-name-need-mangling.t/stubgen/type_description.ml
@@ -1,0 +1,3 @@
+module Types (F : Ctypes.TYPE) = struct
+
+end

--- a/test/blackbox-tests/test-cases/ctypes/libneed-mangling/dune
+++ b/test/blackbox-tests/test-cases/ctypes/libneed-mangling/dune
@@ -1,0 +1,19 @@
+(rule
+ (deps
+  (:c example.c)
+  example.h)
+ (target example.o)
+ (action
+  (run cc -c -fPIC -o %{target} %{c})))
+
+(rule
+ (deps example.o)
+ (target libneed-mangling.a)
+ (action
+  (run ar rcs %{target} %{deps})))
+
+(rule
+ (deps example.o)
+ (target libneed-mangling.so)
+ (action
+  (run cc -shared -o %{target} %{deps})))

--- a/test/blackbox-tests/test-cases/ctypes/libneed-mangling/example.c
+++ b/test/blackbox-tests/test-cases/ctypes/libneed-mangling/example.c
@@ -1,0 +1,2 @@
+int example_add2(int x) { return x+2; }
+int example_add4(int x) { return x+4; }

--- a/test/blackbox-tests/test-cases/ctypes/libneed-mangling/example.h
+++ b/test/blackbox-tests/test-cases/ctypes/libneed-mangling/example.h
@@ -1,0 +1,2 @@
+int example_add2(int);
+int example_add4(int);

--- a/test/blackbox-tests/test-cases/ctypes/libneed-mangling/need-mangling.pc
+++ b/test/blackbox-tests/test-cases/ctypes/libneed-mangling/need-mangling.pc
@@ -1,0 +1,11 @@
+# pos-config does not interpret prefix relative to the .pc file so we need to
+# insert it everywhere.
+exec_prefix=${prefix}
+libdir=${prefix}
+includedir=${prefix}
+Name: need-mangling
+Description: An example library for testing dune ctypes
+Requires:
+Version: 1.00.00
+Libs: -L${prefix} -lneed-mangling
+Cflags: -I${prefix}


### PR DESCRIPTION
The current implementation of the ctypes rules doesn't treat the external lib name specially. There are no validation checks and no mangling. Because of that it is impossible to use the ctypes stanza with a C library that has a name containing characters disallowed in an ocaml module.

fix #5511

This work is sponsored by Ahrefs