### PR TITLE
refactor: remove dead code

### DIFF
--- a/src/dune_engine/utils.ml
+++ b/src/dune_engine/utils.ml
@@ -36,9 +36,6 @@ let program_not_found_message ?context ?hint ~loc prog =
 let program_not_found ?context ?hint ~loc prog =
   raise (User_error.E (program_not_found_message ?context ?hint ~loc prog))
 
-let library_not_found ?context ?hint lib =
-  raise (User_error.E (not_found "Library %s not found" ?context ?hint lib))
-
 let install_file ~(package : Package.Name.t) ~findlib_toolchain =
   let package = Package.Name.to_string package in
   match findlib_toolchain with

--- a/src/dune_engine/utils.mli
+++ b/src/dune_engine/utils.mli
@@ -17,9 +17,6 @@ val program_not_found_message :
   -> string
   -> User_message.t
 
-(** Raise an error about a library not found *)
-val library_not_found : ?context:Context_name.t -> ?hint:string -> string -> _
-
 val install_file :
   package:Package.Name.t -> findlib_toolchain:Context_name.t option -> string
 


### PR DESCRIPTION
Utils.library_not_found isn't used anywhere