### PR TITLE
refactor: limit Build_engine use where possible

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -1,6 +1,9 @@
-open! Dune_engine
 open! Stdune
 module Dune_file = Dune_rules.Dune_file
+module Stanza = Dune_engine.Stanza
+module Dune_project = Dune_engine.Dune_project
+module Package = Dune_engine.Package
+module Dialect = Dune_engine.Dialect
 
 (** Because the dune_init utility deals with the addition of stanzas and fields
     to dune projects and files, we need to inspect and manipulate the concrete

--- a/bin/dune_init.mli
+++ b/bin/dune_init.mli
@@ -1,5 +1,4 @@
 (** Initialize dune components *)
-open! Dune_engine
 
 open! Stdune
 
@@ -20,7 +19,7 @@ end
 module Init_context : sig
   type t =
     { dir : Path.t
-    ; project : Dune_project.t
+    ; project : Dune_engine.Dune_project.t
     }
 
   val make : string option -> t Memo.t

--- a/bin/workspace_root.ml
+++ b/bin/workspace_root.ml
@@ -1,5 +1,4 @@
 open Stdune
-open Dune_engine
 open Dune_rules
 
 module Kind = struct
@@ -19,7 +18,8 @@ module Kind = struct
 
   let of_dir_contents files =
     if String.Set.mem files Workspace.filename then Some Dune_workspace
-    else if String.Set.mem files Dune_project.filename then Some Dune_project
+    else if String.Set.mem files Dune_engine.Dune_project.filename then
+      Some Dune_project
     else None
 end
 

--- a/configure.ml
+++ b/configure.ml
@@ -83,7 +83,6 @@ let () =
   | Some _ -> ());
   let oc = open_out out in
   let pr fmt = fprintf oc (fmt ^^ "\n") in
-  pr "open! Dune_engine\n";
   pr "let library_path = %s\n" ((list string) !library_path);
   pr "let roots : string option Install.Section.Paths.Roots.t =";
   pr "  { lib_root = %s" (option string !library_destdir);

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -13,6 +13,7 @@ module Id = Dune_rpc.Id
 module Diagnostic = Dune_rpc.Diagnostic
 module Conv = Dune_rpc.Conv
 module Dep_conf = Dune_rules.Dep_conf
+module Stanza = Dune_engine.Stanza
 module Source_tree = Dune_engine.Source_tree
 module Build_config = Dune_engine.Build_config
 module Dune_project = Dune_engine.Dune_project
@@ -26,7 +27,6 @@ type pending_build_action =
 
 (* TODO un-copy-paste from dune/bin/arg.ml *)
 let dep_parser =
-  let open Dune_engine in
   Dune_lang.Syntax.set Stanza.syntax (Active Stanza.latest_version)
     Dep_conf.decode
 

--- a/src/dune_rules/bootstrap_info.mli
+++ b/src/dune_rules/bootstrap_info.mli
@@ -1,5 +1,4 @@
 (** Generate bootstrap info *)
-open! Dune_engine
 
 (** Generate an OCaml file containing a description of the dune sources for the
     bootstrap procedure *)

--- a/src/dune_rules/setup.defaults.ml
+++ b/src/dune_rules/setup.defaults.ml
@@ -1,5 +1,3 @@
-open! Dune_engine
-
 let library_path = []
 
 let roots : string option Install.Section.Paths.Roots.t =

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -1,5 +1,10 @@
-open! Dune_engine
 open! Stdune
+
+(* XXX explicit export because we want to get rid of the dependency on the
+   engine *)
+module Dune_project = Dune_engine.Dune_project
+module Source_tree = Dune_engine.Source_tree
+module Sub_dirs = Dune_engine.Sub_dirs
 
 type rename_and_edit =
   { original_file : Path.Source.t

--- a/src/upgrader/dune_upgrader.mli
+++ b/src/upgrader/dune_upgrader.mli
@@ -1,5 +1,4 @@
 (** Upgrade projects from jbuilder to Dune *)
-open! Dune_engine
 
 (** Upgrade all projects in this file tree *)
 val upgrade : unit -> unit Fiber.t


### PR DESCRIPTION
Use explicit imports to demonstrate that we depend on things from
[Dune_engine] that shouldn't be there.

EDIT: Needs #5671 merged first.