### PR TITLE
test(coq): stop guarding rules with enabled_if

### DIFF
--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -6,9 +6,6 @@
  (enabled_if
   (<> %{system} macosx)))
 
-; An alias that runs all Coq tests
-
 (cram
  (applies_to :whole_subtree)
- (alias all-coq-tests)
- (enabled_if %{bin-available:coqc}))
+ (deps %{bin:coqc} %{bin:coqdep}))


### PR DESCRIPTION
instead of the guard, we depend on the appropriate binaries.

cc @Alizter 