### PR TITLE
mdx stanza: improve error messages for path errors

### DIFF
--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -72,7 +72,7 @@ module Deps = struct
     try
       let (_ : Path.Local.t) = Path.Local.of_string str in
       false
-    with _ -> true
+    with User_error.E _ -> true
 
   let to_path ~dir str =
     if not (Filename.is_relative str) then Error (`Absolute str)

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -109,7 +109,7 @@ module Deps = struct
       let open Memo.O in
       let dep_set = Dep.Set.of_files files in
       let+ l = Memo.parallel_map dirs ~f:(fun dir -> Dep.Set.source_tree dir) in
-      Ok (List.fold_left l ~init:dep_set ~f:Dep.Set.union)
+      Ok (Dep.Set.union_all (dep_set :: l))
 end
 
 module Prelude = struct

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -78,11 +78,10 @@ module Deps = struct
     if not (Filename.is_relative str) then Error (`Absolute str)
     else
       let path = Path.relative_to_source_in_build_or_external ~dir str in
-      if not (Path.is_managed path) then Error (`Escapes_workspace str)
-      else if path_escapes_dir str then Error (`Escapes_dir str)
-      else
-        let build = Path.as_in_build_dir_exn path in
-        Ok (Path.build build)
+      match path with
+      | In_build_dir _ ->
+        if path_escapes_dir str then Error (`Escapes_dir str) else Ok path
+      | _ -> Error (`Escapes_workspace str)
 
   let add_acc (dirs, files) kind path =
     match kind with

--- a/test/blackbox-tests/test-cases/mdx-stanza/paths.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/paths.t
@@ -13,12 +13,14 @@ Absolute paths cause an error.
   > ```
   > EOF
 
-  $ dune runtest 2>&1 | awk '/Internal error/,/Raised at/'
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("Local.relative: received absolute path",
-    { t = "."; path = "/etc/passwd" })
-  Raised at Stdune__Code_error.raise in file "otherlibs/stdune/code_error.ml",
+  $ dune runtest
+  File "dune", line 1, characters 0-5:
+  1 | (mdx)
+      ^^^^^
+  Error: Paths referenced in mdx files must be relative. This stanza refers to
+  the following absolute path:
+  /etc/passwd
+  [1]
 
 Relative paths that go over the root cause an error.
 
@@ -28,12 +30,15 @@ Relative paths that go over the root cause an error.
   > EOF
 
   $ dune runtest
-  Error: path outside the workspace: ../x from .
-  -> required by _build/default/.mdx/README.md.corrected
-  -> required by alias runtest in dune:1
+  File "dune", line 1, characters 0-5:
+  1 | (mdx)
+      ^^^^^
+  Error: Paths referenced in mdx files must stay within the workspace. This
+  stanza refers to the following path which escapes:
+  ../x
   [1]
 
-Relative paths within the workspace should work.
+Relative paths within the workspace do not work.
 
   $ mkdir a b
   $ mv dune a/
@@ -48,9 +53,12 @@ Relative paths within the workspace should work.
   > EOF
 
   $ dune runtest
-  Error: path outside the workspace: ../b/src.ml from .
-  -> required by _build/default/a/.mdx/README.md.corrected
-  -> required by alias a/runtest in a/dune:1
+  File "a/dune", line 1, characters 0-5:
+  1 | (mdx)
+      ^^^^^
+  Error: Paths referenced in mdx files cannot escape the directory. This stanza
+  refers to the following path which escapes:
+  ../b/src.ml
   [1]
 
 Files in the same directory work.

--- a/test/blackbox-tests/test-cases/mdx-stanza/paths.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/paths.t
@@ -19,7 +19,8 @@ Absolute paths cause an error.
       ^^^^^
   Error: Paths referenced in mdx files must be relative. This stanza refers to
   the following absolute path:
-  /etc/passwd
+  Source path: README.md
+  Included path: /etc/passwd
   [1]
 
 Relative paths that go over the root cause an error.
@@ -35,7 +36,8 @@ Relative paths that go over the root cause an error.
       ^^^^^
   Error: Paths referenced in mdx files must stay within the workspace. This
   stanza refers to the following path which escapes:
-  ../x
+  Source path: README.md
+  Included path: ../x
   [1]
 
 Relative paths within the workspace do not work.
@@ -58,7 +60,8 @@ Relative paths within the workspace do not work.
       ^^^^^
   Error: Paths referenced in mdx files cannot escape the directory. This stanza
   refers to the following path which escapes:
-  ../b/src.ml
+  Source path: a/README.md
+  Included path: ../b/src.ml
   [1]
 
 Files in the same directory work.


### PR DESCRIPTION
This fixes part of #5596 by providing error messages instead of crashes. The locs are not great but this is the best we can do without modifying mdx.
