### PR TITLE
mdx stanza: support paths that point outside directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,10 @@
 
 - (mdx) stanza: add support for (locks). (#5628, fixes #5489, @emillon)
 
+- (mdx) stanza: support including files in different directories using relative
+  paths, and provide better error messages when paths are invalid (#5703, #5704,
+  fixes #5596, @emillon)
+
 3.1.1 (19/04/2022)
 ------------------
 

--- a/test/blackbox-tests/test-cases/mdx-stanza/paths.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/paths.t
@@ -1,9 +1,14 @@
 Absolute paths cause an error.
 
+  $ set_version () {
+  >   sed -i.bak "s/using mdx .../using mdx $1/" dune-project
+  > }
+
   $ cat > dune-project << EOF
-  > (lang dune 3.0)
-  > (using mdx 0.2)
+  > (lang dune 3.2)
+  > (using mdx ---)
   > EOF
+  $ set_version 0.2
   $ cat > dune << EOF
   > (mdx)
   > EOF
@@ -63,6 +68,16 @@ Relative paths within the workspace do not work.
   Source path: a/README.md
   Included path: ../b/src.ml
   [1]
+
+But this works with stanza 0.3:
+
+  $ set_version 0.3
+  $ dune runtest
+  File "a/README.md", line 1, characters 0-0:
+  Error: Files _build/default/a/README.md and
+  _build/default/a/.mdx/README.md.corrected differ.
+  [1]
+  $ set_version 0.2
 
 Files in the same directory work.
 


### PR DESCRIPTION
This supports paths that go up a directory while staying in the workspace (only in stanza 0.3).
