### PR TITLE
Refactor: add a Locks module

### DIFF
--- a/src/dune_rules/cram_rules.ml
+++ b/src/dune_rules/cram_rules.ml
@@ -167,9 +167,8 @@ let rules ~sctx ~expander ~dir tests =
               let+ locks =
                 (* Locks must be relative to the cram stanza directory and not
                    the individual tests directories *)
-                Memo.List.map spec.locks ~f:(fun lock ->
-                    Expander.No_deps.expand_str expander lock
-                    >>| Path.relative (Path.build dir))
+                let base = `This (Path.build dir) in
+                Expander.expand_locks ~base expander spec.locks
                 >>| Path.Set.of_list >>| Path.Set.union acc.locks
               in
               { acc with enabled_if; locks; deps; alias; packages; sandbox })

--- a/src/dune_rules/cram_stanza.ml
+++ b/src/dune_rules/cram_stanza.ml
@@ -25,7 +25,7 @@ type t =
   ; alias : Alias.Name.t option
   ; deps : Dep_conf.t Bindings.t option
   ; enabled_if : Blang.t
-  ; locks : String_with_vars.t list
+  ; locks : Locks.t
   ; package : Package.t option
   }
 
@@ -38,10 +38,7 @@ let decode =
      and+ deps = field_o "deps" (Bindings.decode Dep_conf.decode)
      and+ enabled_if = Enabled_if.decode ~allowed_vars:Any ~since:None ()
      and+ locks =
-       field "locks"
-         (Dune_lang.Syntax.since Stanza.syntax (2, 9)
-         >>> repeat String_with_vars.decode)
-         ~default:[]
+       Locks.field ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 9)) ()
      and+ package =
        Stanza_common.Pkg.field_opt
          ~check:(Dune_lang.Syntax.since Stanza.syntax (2, 8))

--- a/src/dune_rules/cram_stanza.mli
+++ b/src/dune_rules/cram_stanza.mli
@@ -11,7 +11,7 @@ type t =
   ; alias : Alias.Name.t option
   ; deps : Dep_conf.t Bindings.t option
   ; enabled_if : Blang.t
-  ; locks : String_with_vars.t list
+  ; locks : Locks.t
   ; package : Package.t option
   }
 

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1541,7 +1541,7 @@ module Rule = struct
     ; action : Loc.t * Action_dune_lang.t
     ; mode : Rule.Mode.t
     ; patch_back_source_tree : bool
-    ; locks : String_with_vars.t list
+    ; locks : Locks.t
     ; loc : Loc.t
     ; enabled_if : Blang.t
     ; alias : Alias.Name.t option
@@ -1621,7 +1621,7 @@ module Rule = struct
       (let+ loc = loc
        and+ action = field "action" (located Action_dune_lang.decode)
        and+ targets = Targets_spec.field ~allow_directory_targets
-       and+ locks = field "locks" (repeat String_with_vars.decode) ~default:[]
+       and+ locks = Locks.field ()
        and+ () =
          let+ fallback =
            field_b
@@ -1818,7 +1818,7 @@ module Alias_conf = struct
     { name : Alias.Name.t
     ; deps : Dep_conf.t Bindings.t
     ; action : (Loc.t * Action_dune_lang.t) option
-    ; locks : String_with_vars.t list
+    ; locks : Locks.t
     ; package : Package.t option
     ; enabled_if : Blang.t
     ; loc : Loc.t
@@ -1842,8 +1842,7 @@ module Alias_conf = struct
                in
                located Action_dune_lang.decode)
           and+ loc = loc
-          and+ locks =
-            field "locks" (repeat String_with_vars.decode) ~default:[]
+          and+ locks = Locks.field ()
           and+ enabled_if =
             field "enabled_if" Blang.decode ~default:Blang.true_
           in
@@ -1853,7 +1852,7 @@ end
 module Tests = struct
   type t =
     { exes : Executables.t
-    ; locks : String_with_vars.t list
+    ; locks : Locks.t
     ; package : Package.t option
     ; deps : Dep_conf.t Bindings.t
     ; enabled_if : Blang.t
@@ -1871,8 +1870,7 @@ module Tests = struct
           and+ link_flags = Link_flags.Spec.decode ~since:None
           and+ names = names
           and+ package = field_o "package" Stanza_common.Pkg.decode
-          and+ locks =
-            field "locks" (repeat String_with_vars.decode) ~default:[]
+          and+ locks = Locks.field ()
           and+ modes =
             field "modes" Executables.Link_mode.Map.decode
               ~default:

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -301,7 +301,7 @@ module Rule : sig
     ; action : Loc.t * Action_dune_lang.t
     ; mode : Rule.Mode.t
     ; patch_back_source_tree : bool
-    ; locks : String_with_vars.t list
+    ; locks : Locks.t
     ; loc : Loc.t
     ; enabled_if : Blang.t
     ; alias : Alias.Name.t option
@@ -314,7 +314,7 @@ module Alias_conf : sig
     { name : Alias.Name.t
     ; deps : Dep_conf.t Bindings.t
     ; action : (Loc.t * Action_dune_lang.t) option
-    ; locks : String_with_vars.t list
+    ; locks : Locks.t
     ; package : Package.t option
     ; enabled_if : Blang.t
     ; loc : Loc.t
@@ -332,7 +332,7 @@ end
 module Tests : sig
   type t =
     { exes : Executables.t
-    ; locks : String_with_vars.t list
+    ; locks : Locks.t
     ; package : Package.t option
     ; deps : Dep_conf.t Bindings.t
     ; enabled_if : Blang.t

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -808,3 +808,14 @@ let eval_blang t blang =
   Blang.eval ~f:(No_deps.expand_pform t) ~dir:(Path.build t.dir) blang
 
 let find_package t pkg = t.find_package pkg
+
+let expand_lock ~base expander (Locks.Lock sw) =
+  let open Memo.O in
+  match base with
+  | `Of_expander -> No_deps.expand_path expander sw
+  | `This base ->
+    let+ str = No_deps.expand_str expander sw in
+    Path.relative base str
+
+let expand_locks ~base expander locks =
+  Memo.List.map locks ~f:(expand_lock ~base expander)

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -145,3 +145,6 @@ val map_exe : t -> Path.t -> Path.t
 val artifacts : t -> Artifacts.Bin.t
 
 val find_package : t -> Package.Name.t -> any_package option Memo.t
+
+val expand_locks :
+  base:[ `Of_expander | `This of Path.t ] -> t -> Locks.t -> Path.t list Memo.t

--- a/src/dune_rules/locks.ml
+++ b/src/dune_rules/locks.ml
@@ -1,0 +1,14 @@
+open! Import
+
+type lock = Lock of String_with_vars.t
+
+type t = lock list
+
+let decode_one =
+  let open Dune_lang.Decoder in
+  let+ sw = Dune_engine.String_with_vars.decode in
+  Lock sw
+
+let field ?(check = Dune_lang.Decoder.return ()) () =
+  let open Dune_lang.Decoder in
+  field "locks" (check >>> repeat decode_one) ~default:[]

--- a/src/dune_rules/locks.mli
+++ b/src/dune_rules/locks.mli
@@ -1,0 +1,10 @@
+open! Import
+
+(** Abstract locks. Use [Expander.expand_locks] to get paths suitable for
+    [Action.Full.add_locks] or [Action.Full.make]. *)
+type lock = private Lock of String_with_vars.t
+
+type t = lock list
+
+val field :
+  ?check:unit Dune_lang.Decoder.t -> unit -> t Dune_lang.Decoder.fields_parser

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -128,7 +128,7 @@ type t =
   ; enabled_if : Blang.t
   ; package : Package.t option
   ; libraries : Lib_dep.t list
-  ; locks : String_with_vars.t list
+  ; locks : Locks.t
   }
 
 let enabled_if t = t.enabled_if
@@ -174,10 +174,7 @@ let decode =
          (Dune_lang.Syntax.since syntax (0, 2)
          >>> Dune_file.Lib_deps.decode Executable)
      and+ locks =
-       field "locks"
-         (Dune_lang.Syntax.since syntax (0, 3)
-         >>> repeat String_with_vars.decode)
-         ~default:[]
+       Locks.field ~check:(Dune_lang.Syntax.since syntax (0, 3)) ()
      in
      { loc
      ; version
@@ -224,9 +221,7 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog
   let files = Files.from_source_file ~mdx_dir src in
   (* Add the rule for generating the .mdx.deps file with ocaml-mdx deps *)
   let open Memo.O in
-  let* locks =
-    Memo.List.map stanza.locks ~f:(Expander.No_deps.expand_path expander)
-  in
+  let* locks = Expander.expand_locks expander ~base:`Of_expander stanza.locks in
   let* () =
     Super_context.add_rule sctx ~loc ~dir (Deps.rule ~dir ~mdx_prog files)
   and* () =

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -51,7 +51,7 @@ let rule_kind ~(rule : Rule.t) ~(action : _ Action_builder.With_targets.t) =
     | Some target -> Alias_with_targets (alias, target))
 
 let interpret_and_add_locks ~expander locks action =
-  let+ locks = Memo.List.map locks ~f:(Expander.No_deps.expand_path expander) in
+  let+ locks = Expander.expand_locks expander ~base:`Of_expander locks in
   match locks with
   | [] -> action
   | _ ->


### PR DESCRIPTION
It contains a field parser and a type to be consumed by the new `Expander.expand_locks` function.
