### PR TITLE
refactor(coq): add rules directly

### DIFF
--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -421,7 +421,7 @@ let setup_rules ~sctx ~dir ~dir_contents (s : Theory.t) =
   let coq_lib_db = Scope.coq_libs scope in
   let theory = Coq_lib.DB.resolve coq_lib_db s.name |> Result.ok_exn in
   let* coq_dir_contents = Dir_contents.coq dir_contents in
-  let+ cctx =
+  let* cctx =
     let wrapper_name = Coq_lib.wrapper theory in
     let theories_deps =
       Coq_lib.DB.requires coq_lib_db theory |> Resolve.of_result
@@ -446,6 +446,7 @@ let setup_rules ~sctx ~dir ~dir_contents (s : Theory.t) =
       let cctx = Context.for_module cctx m in
       let { Module_rule.coqc; coqdep } = setup_rule cctx ~source_rule m in
       [ coqc; coqdep ])
+  |> Super_context.add_rules ~loc:s.buildable.loc ~dir sctx
 
 let coqtop_args_theory ~sctx ~dir ~dir_contents (s : Theory.t) coq_module =
   let name = snd s.name in
@@ -551,8 +552,8 @@ let install_rules ~sctx ~dir s =
            make_entry vfile vfile_dst :: obj_files)
     |> List.rev_append coq_plugins_install_rules
 
-let coqpp_rules ~sctx ~dir (s : Coqpp.t) =
-  let+ coqpp = resolve_program sctx ~dir ~loc:s.loc "coqpp" in
+let setup_coqpp_rules ~sctx ~dir (s : Coqpp.t) =
+  let* coqpp = resolve_program sctx ~dir ~loc:s.loc "coqpp" in
   let mlg_rule m =
     let source = Path.build (Path.Build.relative dir (m ^ ".mlg")) in
     let target = Path.Build.relative dir (m ^ ".ml") in
@@ -560,9 +561,10 @@ let coqpp_rules ~sctx ~dir (s : Coqpp.t) =
     let build_dir = (Super_context.context sctx).build_dir in
     Command.run ~dir:(Path.build build_dir) coqpp args
   in
-  List.map ~f:mlg_rule s.modules
+  List.rev_map ~f:mlg_rule s.modules
+  |> Super_context.add_rules ~loc:s.loc ~dir sctx
 
-let extraction_rules ~sctx ~dir ~dir_contents (s : Extraction.t) =
+let setup_extraction_rules ~sctx ~dir ~dir_contents (s : Extraction.t) =
   let* cctx =
     let wrapper_name = "DuneExtraction" in
     let theories_deps =
@@ -575,7 +577,7 @@ let extraction_rules ~sctx ~dir ~dir_contents (s : Extraction.t) =
     Context.create sctx ~coqc_dir:dir ~dir ~wrapper_name ~theories_deps
       ~theory_dirs s.buildable
   in
-  let+ coq_module =
+  let* coq_module =
     let+ coq = Dir_contents.coq dir_contents in
     Coq_sources.extract coq s
   in
@@ -589,7 +591,7 @@ let extraction_rules ~sctx ~dir ~dir_contents (s : Extraction.t) =
   in
   let { Module_rule.coqc; coqdep } = setup_rule cctx ~source_rule coq_module in
   let coqc = Action_builder.With_targets.add coqc ~file_targets:ml_targets in
-  [ coqdep; coqc ]
+  [ coqdep; coqc ] |> Super_context.add_rules ~loc:s.buildable.loc ~dir sctx
 
 let coqtop_args_extraction ~sctx ~dir ~dir_contents (s : Extraction.t) =
   let* cctx =

--- a/src/dune_rules/coq_rules.mli
+++ b/src/dune_rules/coq_rules.mli
@@ -23,7 +23,7 @@ val setup_rules :
   -> dir:Path.Build.t
   -> dir_contents:Dir_contents.t
   -> Theory.t
-  -> Action.Full.t Action_builder.With_targets.t list Memo.t
+  -> unit Memo.t
 
 val install_rules :
      sctx:Super_context.t
@@ -31,18 +31,15 @@ val install_rules :
   -> Theory.t
   -> Install.Entry.Sourced.t list Memo.t
 
-val coqpp_rules :
-     sctx:Super_context.t
-  -> dir:Path.Build.t
-  -> Coqpp.t
-  -> Action.Full.t Action_builder.With_targets.t list Memo.t
+val setup_coqpp_rules :
+  sctx:Super_context.t -> dir:Path.Build.t -> Coqpp.t -> unit Memo.t
 
-val extraction_rules :
+val setup_extraction_rules :
      sctx:Super_context.t
   -> dir:Path.Build.t
   -> dir_contents:Dir_contents.t
   -> Extraction.t
-  -> Action.Full.t Action_builder.With_targets.t list Memo.t
+  -> unit Memo.t
 
 (** [deps_of ~dir ~boot_type m] produces an action builder that can be run to
     build all dependencies of the Coq module [m]. *)

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -267,15 +267,11 @@ let gen_rules sctx dir_contents cctxs expander
         | Coq_stanza.Theory.T m -> (
           Expander.eval_blang expander m.enabled_if >>= function
           | false -> Memo.return ()
-          | true ->
-            Coq_rules.setup_rules ~sctx ~dir:ctx_dir ~dir_contents m
-            >>= Super_context.add_rules ~loc:m.buildable.loc ~dir:ctx_dir sctx)
+          | true -> Coq_rules.setup_rules ~sctx ~dir:ctx_dir ~dir_contents m)
         | Coq_stanza.Extraction.T m ->
-          Coq_rules.extraction_rules ~sctx ~dir:ctx_dir ~dir_contents m
-          >>= Super_context.add_rules ~loc:m.buildable.loc ~dir:ctx_dir sctx
+          Coq_rules.setup_extraction_rules ~sctx ~dir:ctx_dir ~dir_contents m
         | Coq_stanza.Coqpp.T m ->
-          Coq_rules.coqpp_rules ~sctx ~dir:ctx_dir m
-          >>= Super_context.add_rules ~loc:m.loc ~dir:ctx_dir sctx
+          Coq_rules.setup_coqpp_rules ~sctx ~dir:ctx_dir m
         | _ -> Memo.return ())
   in
   let+ () = define_all_alias ~dir:ctx_dir ~scope ~js_targets in


### PR DESCRIPTION
Instead of returning them, we add them directly with Super_context. This
is our standard practice in every other rules module and is also required for generating directory targets.