### PR TITLE
fix: track io in foreign rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,8 +39,9 @@
 
 - Watch mode now tracks copied external files, external directories for
   dependencies, dune files in OCaml syntax, files used by `include` stanzas,
-  dune-project, opam files, and libraries builtin with compiler (#5627, #5645,
-  #5652, #5656, #5672, #5691, fixes #5331, @rgrinberg)
+  dune-project, opam files, libraries builtin with compiler, and foreign
+  sources (#5627, #5645, #5652, #5656, #5672, #5691, #5722, fixes #5331,
+  @rgrinberg)
 
 - Improve metrics for cram tests. Include test names in the event and add a
   category for cram tests (#5626, @rgrinberg)

--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -253,6 +253,11 @@ let file_exists path =
   | Ok kind -> File_kind.equal kind S_REG
   | Error (_ : Unix_error.Detailed.t) -> false
 
+let is_directory path =
+  path_kind path >>| function
+  | Ok kind -> Ok (File_kind.equal kind S_DIR)
+  | Error e -> Error e
+
 let dir_exists path =
   path_kind path >>| function
   | Ok kind -> File_kind.equal kind S_DIR

--- a/src/dune_engine/fs_memo.mli
+++ b/src/dune_engine/fs_memo.mli
@@ -15,6 +15,8 @@ val file_exists : Path.t -> bool Memo.t
     it. *)
 val dir_exists : Path.t -> bool Memo.t
 
+val is_directory : Path.t -> (bool, Unix_error.Detailed.t) result Memo.t
+
 (** Call [Path.stat] on a path and declare a dependency on it. *)
 val path_stat :
   Path.t -> (Fs_cache.Reduced_stats.t, Unix_error.Detailed.t) result Memo.t

--- a/test/blackbox-tests/test-cases/foreign-library.t
+++ b/test/blackbox-tests/test-cases/foreign-library.t
@@ -252,7 +252,7 @@ Testsuite for the (foreign_library ...) stanza.
   12 |  (include_dirs headers /some/path)
                               ^^^^^^^^^^
   Error: Unable to read the include directory.
-  Reason: /some/path: No such file or directory.
+  Reason: stat(/some/path): No such file or directory.
   [1]
 
 ----------------------------------------------------------------------------------


### PR DESCRIPTION
the check for include directories should use tracked io to work in watch
mode
