### PR TITLE
refactor(engine): move types to action_types

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -1,14 +1,5 @@
 open Import
-module Outputs = Action_ast.Outputs
-module Inputs = Action_ast.Inputs
-
-module File_perm = struct
-  include Action_intf.File_perm
-
-  let to_unix_perm = function
-    | Normal -> 0o666
-    | Executable -> 0o777
-end
+include Action_types
 
 module Prog = struct
   module Not_found = struct

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -1,22 +1,6 @@
 open! Import
 
-module Outputs : sig
-  include module type of Action_intf.Outputs
-
-  val to_string : t -> string
-end
-
-module Inputs : module type of struct
-  include Action_intf.Inputs
-end
-
-module File_perm : sig
-  include module type of struct
-    include Action_intf.File_perm
-  end
-
-  val to_unix_perm : t -> int
-end
+include module type of Action_types
 
 (** result of the lookup of a program, the path to it or information about the
     failure and possibly a hint how to fix it *)

--- a/src/dune_engine/action_ast.ml
+++ b/src/dune_engine/action_ast.ml
@@ -1,35 +1,12 @@
 open Import
 open Dune_lang.Decoder
+open Action_types
 module Stanza = Dune_lang.Stanza
-
-module Outputs = struct
-  include Action_intf.Outputs
-
-  let to_string = function
-    | Stdout -> "stdout"
-    | Stderr -> "stderr"
-    | Outputs -> "outputs"
-end
-
-module Inputs = struct
-  include Action_intf.Inputs
-
-  let to_string = function
-    | Stdin -> "stdin"
-end
 
 module type Target_intf = sig
   include Dune_lang.Conv.S
 
   val is_dev_null : t -> bool
-end
-
-module File_perm = struct
-  include Action_intf.File_perm
-
-  let suffix = function
-    | Normal -> ""
-    | Executable -> "-executable"
 end
 
 module Make

--- a/src/dune_engine/action_ast.mli
+++ b/src/dune_engine/action_ast.mli
@@ -11,16 +11,6 @@ module type Target_intf = sig
   val is_dev_null : t -> bool
 end
 
-module Inputs : module type of struct
-  include Action_intf.Inputs
-end
-
-module Outputs : sig
-  include module type of Action_intf.Outputs
-
-  val to_string : t -> string
-end
-
 module Make
     (Program : Dune_lang.Conv.S)
     (Path : Dune_lang.Conv.S)

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -1,23 +1,5 @@
 open Import
-
-module Outputs = struct
-  type t =
-    | Stdout
-    | Stderr
-    | Outputs  (** Both Stdout and Stderr *)
-end
-
-module Inputs = struct
-  type t = Stdin
-end
-
-module File_perm = struct
-  (** File mode, for when creating files. We only allow what Dune takes into
-      account when memoizing commands. *)
-  type t =
-    | Normal
-    | Executable
-end
+open Action_types
 
 module type Ast = sig
   type program

--- a/src/dune_engine/action_types.ml
+++ b/src/dune_engine/action_types.ml
@@ -1,0 +1,32 @@
+module Outputs = struct
+  type t =
+    | Stdout
+    | Stderr
+    | Outputs
+
+  let to_string = function
+    | Stdout -> "stdout"
+    | Stderr -> "stderr"
+    | Outputs -> "outputs"
+end
+
+module Inputs = struct
+  type t = Stdin
+
+  let to_string = function
+    | Stdin -> "stdin"
+end
+
+module File_perm = struct
+  type t =
+    | Normal
+    | Executable
+
+  let suffix = function
+    | Normal -> ""
+    | Executable -> "-executable"
+
+  let to_unix_perm = function
+    | Normal -> 0o666
+    | Executable -> 0o777
+end

--- a/src/dune_engine/action_types.mli
+++ b/src/dune_engine/action_types.mli
@@ -1,0 +1,27 @@
+module Outputs : sig
+  type t =
+    | Stdout
+    | Stderr
+    | Outputs  (** Both Stdout and Stderr *)
+
+  val to_string : t -> string
+end
+
+module Inputs : sig
+  type t = Stdin
+
+  val to_string : t -> string
+end
+
+module File_perm : sig
+  (** File mode, for when creating files. We only allow what Dune takes into
+      account when memoizing commands. *)
+
+  type t =
+    | Normal
+    | Executable
+
+  val suffix : t -> string
+
+  val to_unix_perm : t -> int
+end


### PR DESCRIPTION
These types aren't related to the Ast and this will simplify subsequent PR's that add custom actions and split the frontend the backend better.