### PR TITLE
fix(coq): tests with private plugin name now need public in addition

### DIFF
--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/thy1/a.v
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/thy1/a.v
@@ -1,3 +1,3 @@
-Declare ML Module "ml_plugin_a".
-Declare ML Module "ml_plugin_b".
+Declare ML Module "ml_plugin_a:cplugin.ml_plugin_a".
+Declare ML Module "ml_plugin_b:cplugin.ml_plugin_b".
 

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/thy2/a.v
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/thy2/a.v
@@ -1,3 +1,3 @@
-Declare ML Module "ml_plugin_a".
-Declare ML Module "ml_plugin_b".
+Declare ML Module "ml_plugin_a:cplugin.ml_plugin_a".
+Declare ML Module "ml_plugin_b:cplugin.ml_plugin_b".
 

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/theories/a.v
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/theories/a.v
@@ -1,3 +1,3 @@
-Declare ML Module "ml_plugin_a".
-Declare ML Module "ml_plugin_b".
+Declare ML Module "ml_plugin_a:ml_lib.ml_plugin_a".
+Declare ML Module "ml_plugin_b:ml_lib.ml_plugin_b".
 


### PR DESCRIPTION
In Coq >= 8.15:
```
Declare ML Module "private_name"
```
has now become
```
Declare ML Module "private_name:public_name"
```
Eventually only public name will be accepted, but there still seem to be bugs with public names and plugins and theories being in the same package.

cc @ejgallego 