### PR TITLE
feature(chrome-trace): add object output

### DIFF
--- a/otherlibs/chrome-trace/src/chrome_trace.ml
+++ b/otherlibs/chrome-trace/src/chrome_trace.ml
@@ -262,3 +262,36 @@ module Event = struct
   let async ?scope ?args id async common =
     Async { common; args; scope; id; async }
 end
+
+module Output_object = struct
+  type t =
+    { displayTimeUnit : [ `Ms | `Ns ] option
+    ; traceEvents : Event.t list
+    ; extra_fields : (string * Json.t) list option
+    }
+
+  let to_json { displayTimeUnit; traceEvents; extra_fields } =
+    let json =
+      [ ("traceEvents", `List (List.map traceEvents ~f:Event.to_json)) ]
+    in
+    let json =
+      match displayTimeUnit with
+      | None -> json
+      | Some u ->
+        ( "displayTimeUnit"
+        , `String
+            (match u with
+            | `Ms -> "ms"
+            | `Ns -> "ns") )
+        :: json
+    in
+    let json =
+      match extra_fields with
+      | None -> json
+      | Some extra_fields -> json @ extra_fields
+    in
+    `Assoc json
+
+  let create ?displayTimeUnit ?extra_fields ~traceEvents () =
+    { displayTimeUnit; extra_fields; traceEvents }
+end

--- a/otherlibs/chrome-trace/src/chrome_trace.mli
+++ b/otherlibs/chrome-trace/src/chrome_trace.mli
@@ -71,3 +71,18 @@ module Event : sig
 
   val to_json : t -> Json.t
 end
+
+module Output_object : sig
+  (** The object format provided in whole *)
+
+  type t
+
+  val create :
+       ?displayTimeUnit:[ `Ms | `Ns ]
+    -> ?extra_fields:(string * Json.t) list
+    -> traceEvents:Event.t list
+    -> unit
+    -> t
+
+  val to_json : t -> Json.t
+end


### PR DESCRIPTION
Object output allows us to add metadata to traces