### PR TITLE
Enable formatting when no .ocamlformat file is present

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+3.3.0 (Unreleased)
+------------------
+
+- Enable formatting when no .ocamlformat file is present. (#5768, @tmattio)
+
 3.2.0 (17-05-2022)
 ------------------
 

--- a/src/dune_engine/dialect.ml
+++ b/src/dune_engine/dialect.ml
@@ -112,7 +112,8 @@ let ocaml =
       (S.make_pform Loc.none (Var Workspace_root))
       (Action_dune_lang.run
          (S.make_text Loc.none "ocamlformat")
-         [ S.make_text Loc.none (flag_of_kind kind)
+         [ S.make_text Loc.none "--enable-outside-detected-project"
+         ; S.make_text Loc.none (flag_of_kind kind)
          ; S.make_pform Loc.none (Var Input_file)
          ])
   in


### PR DESCRIPTION
This allows formatting projects that don't contain an `.ocamlformat` file.

The motivation is to reduce the number of files necessary to have a working development environment. I figure larger projects will always have an `.ocamlformat` file (at least to fix ocamlformat to a specific version), but it'd be nice that small projects don't require more than a `dune-project` and `dune` files to provide a complete developer workflow.

cc @gpetiot