### PR TITLE
fix: set exit code on signal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
-3.3.0 (unreleased)
-------------------
+Unreleased
+----------
 
-- Support new locations of unix, str, dynlink in OCaml >= 5.0
-  (#5582, @dra27)
+- Set the exit code to 130 when dune is terminated with a signal (#5769, fixes
+  #5757)
+
+- Support new locations of unix, str, dynlink in OCaml >= 5.0 (#5582, @dra27)
 
 3.2.0 (17-05-2022)
 ------------------

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -92,7 +92,8 @@ let () =
     | `Error _ -> exit 1
     | _ -> exit 0
   with
-  | Scheduler.Run.Shutdown_requested -> exit 0
+  | Scheduler.Run.Shutdown.E Requested -> exit 0
+  | Scheduler.Run.Shutdown.E (Signal _) -> exit 130
   | exn ->
     let exn = Exn_with_backtrace.capture exn in
     Dune_util.Report_error.report exn;

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -53,10 +53,26 @@ module Run : sig
     | Automatic
     | No_watcher
 
-  (** Raised when [go] terminates due to the user requesting a shutdown via rpc.
-      The caller needs to know about this to set the exit code to 0 for such
-      cases *)
-  exception Shutdown_requested
+  module Shutdown : sig
+    module Signal : sig
+      (* TODO move this stuff into stdune? *)
+      type t =
+        | Int
+        | Quit
+        | Term
+    end
+
+    module Reason : sig
+      type t =
+        | Requested
+        | Signal of Signal.t
+    end
+
+    (** Raised when [go] terminates due to the user requesting a shutdown via
+        rpc or raising a signal. The caller needs to know about this to set the
+        exit code correctly *)
+    exception E of Reason.t
+  end
 
   exception Build_cancelled
 

--- a/test/blackbox-tests/test-cases/signal-exit-code.t
+++ b/test/blackbox-tests/test-cases/signal-exit-code.t
@@ -1,0 +1,14 @@
+Demonstrate the exit code once dune is interrupted by a signal
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.2)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (alias all)
+  >  (action (system "kill -s INT \$PPID")))
+  > EOF
+
+  $ dune build @all
+  [1]

--- a/test/blackbox-tests/test-cases/signal-exit-code.t
+++ b/test/blackbox-tests/test-cases/signal-exit-code.t
@@ -11,4 +11,4 @@ Demonstrate the exit code once dune is interrupted by a signal
   > EOF
 
   $ dune build @all
-  [1]
+  [130]

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -124,5 +124,5 @@ let%expect_test "turn on dune watch and wait until the connection is listed" =
   run case;
   [%expect
     {|
-    $PATH/dune build --passive-watch-mode --root . returned 1
+    $PATH/dune build --passive-watch-mode --root . returned 130
     [PASS] found . at unix:path=%24CWD/_build/.rpc/dune |}]

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -13,7 +13,7 @@ let go f =
   in
   try
     Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ()) f
-  with Scheduler.Run.Shutdown_requested -> ()
+  with Scheduler.Run.Shutdown.E Requested -> ()
 
 let true_ = Bin.which "true" ~path:(Env.path Env.initial) |> Option.value_exn
 


### PR DESCRIPTION
set the exit code to 130 when dune is terminated with a signal