### PR TITLE
Add explicit dependencies on Unix

### DIFF
--- a/dune-action-plugin.opam
+++ b/dune-action-plugin.opam
@@ -23,6 +23,7 @@ depends: [
   "ppx_expect" {with-test}
   "stdune" {= version}
   "dune-private-libs" {= version}
+  "base-unix"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dune-configurator.opam
+++ b/dune-configurator.opam
@@ -20,6 +20,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.04.0"}
+  "base-unix"
   "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -88,6 +88,7 @@ no stability guarantee.
  (synopsis "Helper library for gathering system configuration")
  (depends
   (ocaml (>= 4.04.0))
+  base-unix
   (csexp (>= 1.5.0)))
  (description "\
 dune-configurator is a small library that helps writing OCaml scripts that
@@ -108,7 +109,8 @@ Among other things, dune-configurator allows one to:
   (csexp (>= 1.5.0))
   (ppx_expect :with-test)
   (stdune (= :version))
-  (dune-private-libs (= :version)))
+  (dune-private-libs (= :version))
+  base-unix)
  (description "\
 
 This library is experimental. No backwards compatibility is implied.
@@ -148,7 +150,8 @@ understood by dune language."))
   (dune-rpc (= :version))
   (result (>= 1.5))
   (csexp (>= 1.5.0))
-  (lwt (>= 5.3.0)))
+  (lwt (>= 5.3.0))
+  base-unix)
  (description "Specialization of dune-rpc to Lwt"))
 
 (package
@@ -179,6 +182,7 @@ understood by dune language."))
  (synopsis "Dune's unstable standard library")
  (depends
   (ocaml (>= 4.08.0))
+  base-unix
   (dyn (= :version))
   (ordering (= :version))
   (pp (>= 1.1.0))

--- a/dune-rpc-lwt.opam
+++ b/dune-rpc-lwt.opam
@@ -14,6 +14,7 @@ depends: [
   "result" {>= "1.5"}
   "csexp" {>= "1.5.0"}
   "lwt" {>= "5.3.0"}
+  "base-unix"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/otherlibs/action-plugin/src/dune
+++ b/otherlibs/action-plugin/src/dune
@@ -1,6 +1,6 @@
 (library
  (name dune_action_plugin)
  (public_name dune-action-plugin)
- (libraries stdune csexp dune-glob)
+ (libraries stdune csexp dune-glob unix)
  (synopsis
   "[Internal] Monadic interface for defining scripts with dynamic or complex sets of dependencies."))

--- a/otherlibs/dune-rpc-lwt/src/dune
+++ b/otherlibs/dune-rpc-lwt/src/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_rpc_lwt)
  (public_name dune-rpc-lwt)
- (libraries result csexp dune_rpc lwt lwt.unix))
+ (libraries result csexp dune_rpc lwt lwt.unix unix))

--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -1,7 +1,14 @@
 (library
  (name csexp_rpc)
  (synopsis "Threaded client & server that uses csexp for communication")
- (libraries stdune dyn dune_util csexp dune_engine fiber)
+ (libraries
+  stdune
+  dyn
+  dune_util
+  csexp
+  dune_engine
+  fiber
+  (re_export unix))
  (foreign_stubs
   (language c)
   (names pthread_chdir_stubs)))

--- a/src/dune_cache/dune
+++ b/src/dune_cache/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_cache)
  (synopsis "[Internal] Dune's local and cloud build cache")
- (libraries csexp dune_cache_storage fiber stdune))
+ (libraries csexp dune_cache_storage fiber stdune unix))

--- a/src/dune_cache_storage/dune
+++ b/src/dune_cache_storage/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_cache_storage)
  (synopsis "[Internal] Dune cache storage, used for local and cloud caches")
- (libraries csexp dune_util fiber fiber_util stdune xdg))
+ (libraries csexp dune_util fiber fiber_util stdune xdg unix))

--- a/src/dune_rpc_server/dune
+++ b/src/dune_rpc_server/dune
@@ -1,4 +1,11 @@
 (library
  (name dune_rpc_server)
  (synopsis "Private API to define a dune rpc server")
- (libraries fiber stdune chrome_trace dune_stats dune_util dune_rpc_private))
+ (libraries
+  fiber
+  stdune
+  chrome_trace
+  dune_stats
+  dune_util
+  dune_rpc_private
+  unix))

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -22,7 +22,8 @@
   dune_cache
   build_path_prefix_map
   dune_engine
-  dune_config)
+  dune_config
+  unix)
  (synopsis "Internal Dune library, do not use!"))
 
 (ocamllex ocamlobjinfo cram_lexer)

--- a/src/dune_stats/dune
+++ b/src/dune_stats/dune
@@ -1,3 +1,3 @@
 (library
  (name dune_stats)
- (libraries stdune chrome_trace spawn))
+ (libraries stdune chrome_trace spawn unix))

--- a/src/dune_util/dune
+++ b/src/dune_util/dune
@@ -1,3 +1,9 @@
 (library
  (name dune_util)
- (libraries stdune xdg build_path_prefix_map dune_lang memo))
+ (libraries
+  stdune
+  xdg
+  build_path_prefix_map
+  dune_lang
+  memo
+  (re_export unix)))

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,4 +1,4 @@
 (library
  (name memo)
- (libraries stdune dyn dune_graph dag fiber)
+ (libraries stdune dyn dune_graph dag fiber unix)
  (synopsis "Function memoizer"))

--- a/stdune.opam
+++ b/stdune.opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08.0"}
+  "base-unix"
   "dyn" {= version}
   "ordering" {= version}
   "pp" {>= "1.1.0"}


### PR DESCRIPTION
Hot on the heels of https://github.com/ocaml/ocaml/pull/11198, Dune has quite a few missing dependencies on Unix!

I added `(re_export unix)` in the cases where `Unix` is used in a signature.