### PR TITLE
[coq] Preliminary test-suite update for 8.16

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,9 @@
 - update vendored copy of cmdliner to 1.1.1. This improves the built-in
   documentation for command groups such as `dune ocaml`. (#6038, @emillon)
 
+- The test suite for Coq now requires Coq >= 8.16 due to changes in the
+  plugin loading mechanism upstream (which now uses findlib).
+
 3.4.1 (26-07-2022)
 ------------------
 

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/src_a/gram.mlg
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/src_a/gram.mlg
@@ -1,4 +1,4 @@
-DECLARE PLUGIN "cplugin.gram"
+DECLARE PLUGIN "cplugin.ml_plugin_a"
 
 {
 

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/src_a/gram.mlg
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/src_a/gram.mlg
@@ -1,4 +1,4 @@
-DECLARE PLUGIN "ml_lib.gram"
+DECLARE PLUGIN "ml_lib.ml_plugin_a"
 
 {
 


### PR DESCRIPTION
Coq 8.16 has changed the syntax for plugins as they are now loaded
using `findlib`, Dune's test-suite needs to be updated slightly.