### PR TITLE
Add support for cutoff on [Action_builder.memoize] node

### DIFF
--- a/src/dune_engine/action_builder0.ml
+++ b/src/dune_engine/action_builder0.ml
@@ -136,9 +136,15 @@ let force_lazy_or_eager :
   | Lazy -> Memo.Lazy.force (Lazy.force lazy_)
   | Eager -> Memo.Lazy.force (Lazy.force eager)
 
-let memoize name t =
-  let lazy_ = lazy (Memo.lazy_ ~name (fun () -> t.f Lazy))
-  and eager = lazy (Memo.lazy_ ~name (fun () -> t.f Eager)) in
+let memoize ?cutoff name t =
+  let cutoff ~equal =
+    Option.map cutoff ~f:(fun eq -> Tuple.T2.equal eq (Dep.Map.equal ~equal))
+  in
+  let memo ~equal eval_mode =
+    Memo.lazy_ ?cutoff:(cutoff ~equal) ~name (fun () -> t.f eval_mode)
+  in
+  let lazy_ = lazy (memo ~equal:Unit.equal Lazy)
+  and eager = lazy (memo ~equal:Dep.Fact.equal Eager) in
   { f = (fun mode -> force_lazy_or_eager mode lazy_ eager) }
 
 let ignore x = map x ~f:ignore

--- a/src/dune_engine/action_builder0.mli
+++ b/src/dune_engine/action_builder0.mli
@@ -50,9 +50,13 @@ type fail = { fail : 'a. unit -> 'a }
     get a proper backtrace *)
 val fail : fail -> _ t
 
-(** [memoize name t] is an action builder that behaves like [t] except that its
-    result is computed only once. *)
-val memoize : string -> 'a t -> 'a t
+(** [memoize ?cutoff name t] is an action builder that behaves like [t] except
+    that its result is computed only once.
+
+    If the caller provides the [cutoff] equality check, we will use it to check
+    if the result of the computation has changed. If it didn't, we will be able
+    to skip the recomputation of values that depend on it. *)
+val memoize : ?cutoff:('a -> 'a -> bool) -> string -> 'a t -> 'a t
 
 type ('input, 'output) memo
 


### PR DESCRIPTION
Add a way to cutoff on [Action_builder.memoize] node. 

This is needed to implement some internal Jane Street build rules.