### PR TITLE
refactor(rules): simplify project/package map

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -376,7 +376,6 @@ type db =
   ; instrument_with : Lib_name.t list
   ; modules_of_lib :
       (dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.t) Fdecl.t
-  ; projects_by_package : Dune_project.t Package.Name.Map.t
   }
 
 and resolve_result =
@@ -834,6 +833,18 @@ module rec Resolve_names : sig
 end = struct
   open Resolve_names
 
+  let projects_by_package =
+    Memo.lazy_ (fun () ->
+        let open Memo.O in
+        let+ conf = Dune_load.load () in
+        List.concat_map conf.projects ~f:(fun project ->
+            Dune_project.packages project
+            |> Package.Name.Map.values
+            |> List.map ~f:(fun (pkg : Package.t) ->
+                   let name = Package.name pkg in
+                   (name, project)))
+        |> Package.Name.Map.of_list_exn)
+
   let instantiate_impl (db, name, info, hidden) =
     let open Memo.O in
     let unique_id = Id.make ~name ~path:(Lib_info.src_dir info) in
@@ -962,14 +973,15 @@ end = struct
     in
     let requires = map_error requires in
     let ppx_runtime_deps = map_error ppx_runtime_deps in
-    let project =
+    let* project =
       let status = Lib_info.status info in
       match Lib_info.Status.project status with
-      | Some _ as project -> project
+      | Some _ as project -> Memo.return project
       | None ->
+        let+ projects_by_package = Memo.Lazy.force projects_by_package in
         let open Option.O in
         let* package = Lib_info.package info in
-        Package.Name.Map.find db.projects_by_package package
+        Package.Name.Map.find projects_by_package package
     in
     let modules =
       match Path.as_in_build_dir (Lib_info.src_dir info) with
@@ -1692,19 +1704,17 @@ module DB = struct
 
   type t = db
 
-  let create ~parent ~resolve ~projects_by_package ~all ~modules_of_lib
-      ~lib_config () =
+  let create ~parent ~resolve ~all ~modules_of_lib ~lib_config () =
     { parent
     ; resolve
     ; all = Memo.lazy_ all
     ; lib_config
     ; instrument_with = lib_config.Lib_config.instrument_with
-    ; projects_by_package
     ; modules_of_lib
     }
 
-  let create_from_findlib ~lib_config ~projects_by_package findlib =
-    create () ~parent:None ~lib_config ~projects_by_package
+  let create_from_findlib ~lib_config findlib =
+    create () ~parent:None ~lib_config
       ~modules_of_lib:
         (let t = Fdecl.create Dyn.opaque in
          Fdecl.set t (fun ~dir ~name ->

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -126,7 +126,6 @@ module DB : sig
   val create :
        parent:t option
     -> resolve:(Lib_name.t -> Resolve_result.t Memo.t)
-    -> projects_by_package:Dune_project.t Package.Name.Map.t
     -> all:(unit -> Lib_name.t list Memo.t)
     -> modules_of_lib:
          (dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.t) Fdecl.t
@@ -134,11 +133,7 @@ module DB : sig
     -> unit
     -> t
 
-  val create_from_findlib :
-       lib_config:Lib_config.t
-    -> projects_by_package:Dune_project.t Package.Name.Map.t
-    -> Findlib.t
-    -> t
+  val create_from_findlib : lib_config:Lib_config.t -> Findlib.t -> t
 
   val find : t -> Lib_name.t -> lib option Memo.t
 

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -24,7 +24,6 @@ module DB : sig
   (** Return the new scope database as well as the public libraries database *)
   val create_from_stanzas :
        projects:Dune_project.t list
-    -> projects_by_package:Dune_project.t Package.Name.Map.t
     -> context:Context.t
     -> installed_libs:Lib.DB.t
     -> modules_of_lib:

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -563,27 +563,15 @@ let create_lib_entries_by_package ~public_libs stanzas =
          (List.sort ~compare:(fun a b ->
               Lib_name.compare (Lib_entry.name a) (Lib_entry.name b)))
 
-let create_projects_by_package projects : Dune_project.t Package.Name.Map.t =
-  List.concat_map projects ~f:(fun project ->
-      Dune_project.packages project
-      |> Package.Name.Map.values
-      |> List.map ~f:(fun (pkg : Package.t) ->
-             let name = Package.name pkg in
-             (name, project)))
-  |> Package.Name.Map.of_list_exn
-
 let modules_of_lib = Fdecl.create Dyn.opaque
 
 let create ~(context : Context.t) ~host ~projects ~packages ~stanzas =
   let lib_config = Context.lib_config context in
-  let projects_by_package = create_projects_by_package projects in
-  let installed_libs =
-    Lib.DB.create_from_findlib context.findlib ~lib_config ~projects_by_package
-  in
+  let installed_libs = Lib.DB.create_from_findlib context.findlib ~lib_config in
   let modules_of_lib_for_scope = Fdecl.create Dyn.opaque in
   let* scopes, public_libs =
-    Scope.DB.create_from_stanzas ~projects ~projects_by_package ~context
-      ~installed_libs ~modules_of_lib:modules_of_lib_for_scope stanzas
+    Scope.DB.create_from_stanzas ~projects ~context ~installed_libs
+      ~modules_of_lib:modules_of_lib_for_scope stanzas
   in
   let stanzas =
     List.map stanzas ~f:(fun { Dune_file.dir; project; stanzas } ->


### PR DESCRIPTION
move into the library database as it's the only place where it's being
used. Also remove more stuff from the junk yard that is Super_context