### PR TITLE
Fix hint message for 'data_only_dirs'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix hint message for ``data_only_dirs`` that wrongly mentions the unknown
+  constructor ``data_only`` (#5803, @lambdaxdotx)
+
 - Fix creating sandbox directory trees by getting rid of buggy memoization
   (@5794, @rgrinberg, @snowleopard)
 

--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -268,7 +268,7 @@ let decode =
   let data_only_dirs =
     located
       (Dune_lang.Syntax.since Stanza.syntax (1, 6)
-      >>> strict_subdir_glob "data_only")
+      >>> strict_subdir_glob "data_only_dirs")
   in
   let vendored_dirs =
     (* let decode = Predicate_lang.Glob.decode in *)

--- a/test/blackbox-tests/test-cases/vendor/main.t/run.t
+++ b/test/blackbox-tests/test-cases/vendor/main.t/run.t
@@ -59,7 +59,7 @@ The current directory cannot be marked as data-only
   1 | (data_only_dirs .)
                       ^
   Error: invalid sub-directory name "."
-  Hint: did you mean (data_only *)?
+  Hint: did you mean (data_only_dirs *)?
   [1]
 
 Only direct subdirectories can be marked as vendored
@@ -81,7 +81,7 @@ Only direct subdirectories can be marked as data-only
   1 | (data_only_dirs a/b/c)
                       ^^^^^
   Error: only immediate sub-directories may be specified.
-  Hint: to ignore a/b/c, write "(data_only c)" in a/b/dune
+  Hint: to ignore a/b/c, write "(data_only_dirs c)" in a/b/dune
   [1]
 
 Multiple direct subdirectories can be marked as data-only or vendored


### PR DESCRIPTION
Having the following in a `dune` file:
```
(data_only_dirs path/to/dir)
```
will make `dune` display the message:
```
Error: only immediate sub-directories may be specified.
Hint: to ignore path/to/dir, write "(data_only dir)" in path/to/dune
```
Now, the `data_only` constructor is unknown, as `dune` says if one tries to follow that hint:
```
Error: Unknown constructor data_only
```
This PR fixes such message to display `[...], write "(data_only_dirs dir)" [...]` instead.