### PR TITLE
refactor(engine): move stanza filtering

### DIFF
--- a/src/dune_rules/cram_rules.ml
+++ b/src/dune_rules/cram_rules.ml
@@ -170,7 +170,7 @@ let rules ~sctx ~expander ~dir tests =
               { acc with enabled_if; locks; deps; alias; packages; sandbox })
       in
       let test_rule () = test_rule ~sctx ~expander ~dir effective test in
-      Only_packages.get () >>= function
+      Only_packages.get_mask () >>= function
       | None -> test_rule ()
       | Some only ->
         let only = Package.Name.Map.keys only |> Package.Name.Set.of_list in

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -422,7 +422,7 @@ let gen_rules t ~sctx ~dir ~scope ~expander =
         (gen_rules_for_single_file t ~sctx ~dir ~expander ~mdx_prog
            ~mdx_prog_gen)
   in
-  let* only_packages = Only_packages.get () in
+  let* only_packages = Only_packages.get_mask () in
   let do_it =
     match (only_packages, t.package) with
     | None, _ | Some _, None -> true

--- a/src/dune_rules/only_packages.mli
+++ b/src/dune_rules/only_packages.mli
@@ -15,10 +15,14 @@ module Clflags : sig
   val set : t -> unit
 end
 
-type t = Package.t Package.Name.Map.t option
+(** Returns the filtered set of packages. This function is memoized. *)
+val get : unit -> Package.t Package.Name.Map.t Memo.t
 
 (** Returns the package restrictions. This function is memoized. *)
-val get : unit -> t Memo.t
+val get_mask : unit -> Package.t Package.Name.Map.t option Memo.t
 
 (** Apply the package mask to the packages defined by the project *)
 val packages_of_project : Dune_project.t -> Package.t Package.Name.Map.t Memo.t
+
+(** Apply the package mask to the stanzas in the workspace *)
+val filtered_stanzas : Context.t -> Dune_file.t list Memo.t


### PR DESCRIPTION
In continuation of the quest of making Super_context less of a junk yard, we move stanza filtering into [Only_packages].