### PR TITLE
OCaml 5.0: use the compiler META files when available

### DIFF
--- a/src/ocaml/version.ml
+++ b/src/ocaml/version.ml
@@ -47,3 +47,5 @@ let has_bigarray_library version = version < (5, 0, 0)
 let supports_alerts version = version >= (4, 8, 0)
 
 let has_sandboxed_otherlibs version = version >= (5, 0, 0)
+
+let has_META_files version = version >= (5, 0, 0)

--- a/src/ocaml/version.mli
+++ b/src/ocaml/version.mli
@@ -71,3 +71,6 @@ val supports_alerts : t -> bool
 (** Whether [dynlink], [str] and [unix] are in subdirectories of the standard
     library *)
 val has_sandboxed_otherlibs : t -> bool
+
+(** Whether the compiler distributes META files independently of ocamlfind *)
+val has_META_files : t -> bool


### PR DESCRIPTION
The compiler is considering the option to ship its own META file in ocaml/ocaml#11007 .

This change would remove the need for dune to generate dummy META files for libraries bundled with the compiler when ocamlfind is not installed. 

This draft PR is a proof concept to check that dune can support this new installation process with few changes.