### PR TITLE
Tweaks to Memo docs

### DIFF
--- a/doc/papers/ocaml-2021/memo.md
+++ b/doc/papers/ocaml-2021/memo.md
@@ -4,7 +4,7 @@ bibliography: refs.bib
 csl: refs.csl
 ---
 
-# Memo: the incremental computation library that powers Dune
+# Memo: an incremental computation library that powers Dune
 
 Andrey Mokhov, Arseniy Alekseyev, Jeremie Dimino
 
@@ -12,31 +12,31 @@ Andrey Mokhov, Arseniy Alekseyev, Jeremie Dimino
 
 ### Abstract
 
-We present Memo, an incremental computation library that improves Dune's
-performance on large-scale code bases. The requirements that come from the build
-systems domain make Memo an interesting point in the design space of incremental
-computation libraries. In particular, Memo needs to cope with concurrency,
-dynamic dependencies, dependency cycles, non-determinism, and scale to
-computation graphs containing millions of nodes.
+We present Memo, an incremental computation library that supports the
+file-watching build mode in Dune 3.0. The requirements from the build systems
+domain make Memo a unique point in the design space of incremental computation
+libraries. In particular, Memo needs to cope with concurrency, dynamic
+dependencies, dependency cycles, non-determinism, and scale to computation
+graphs containing tens of millions of incremental nodes.
 
 ## Introduction
 
 The OCaml build system Dune [@dune] supports a continuous file-watching build
 mode, where rebuilds are triggered automatically as the user is editing source
-files. The simplest way to implement this functionality is to restart Dune on
-any file change but that is too slow for large projects. To avoid re-scanning
-the project's file tree, re-parsing all build specification files, and
+files. A simple and naive way to implement this functionality is to restart Dune
+on any file change but that is too slow for large projects. To avoid re-scanning
+the project's source tree, re-parsing all build specification files, and
 re-generating all build rules from scratch every time, Dune uses an incremental
 computation library called Memo. Below we briefly introduce the Memo's API.
 
-Memo's `Memo` monad is implemented on top of the *concurrency monad* `Fiber`.
+Memo provides a monadic API built on top of the *concurrency monad* `Fiber`.
 Dune uses `Fiber` to speed up builds by executing external commands in parallel,
 e.g., running multiple instances of `ocamlopt` to compile independent source
 files. To inject a *fiber* into the `Memo` monad, and to extract it back, one
 can use the following pair of functions:
 
 ```ocaml
-  val of_reproducible_fiber : 'a Fiber.t -> 'a Memo.t
+  val of_fiber : 'a Fiber.t -> 'a Memo.t
   val run : 'a Memo.t -> 'a Fiber.t
 ```
 
@@ -44,36 +44,39 @@ More interestingly, functions in the `Memo` monad can be memoized and cached
 between different build runs:
 
 ```ocaml
-  val create : ('i -> 'o Memo.t) -> ('i, 'o) Memo.Table.t (* A few arguments omitted for simplicity *)
+  val create : ('i -> 'o Memo.t) -> ('i, 'o) Memo.Table.t (* Some arguments are omitted *)
   val exec : ('i, 'o) Memo.Table.t -> 'i -> 'o Memo.t
 ```
 
-Here `Memo.Table.t` is a memoization table that stores the input/output mapping
-computed in the current build run. Outputs are stored alongside their *dependencies*,
-which are automatically captured by Memo when memoized functions call one another.
+Here `Memo.Table.t` is a table that stores the input/output mapping computed in
+the current run, along with the *dependencies* that are automatically captured
+when memoized functions call one another. Such explicit memoization, instead of,
+e.g., memoizing every `Memo.map` and `Memo.bind` call, makes it easy to control
+the degree of incrementality.
+
 Finally, Memo provides a way to *invalidate* a specific input/output pair, or a
 *cell*, via the following API:
 
 ```ocaml
   val cell : ('i, 'o) Memo.Table.t -> 'i -> ('i, 'o) Cell.t
-  val invalidate : ('i, 'o) Cell.t -> unit
-  val restart_current_run : unit -> unit
+  val invalidate : ('i, 'o) Cell.t -> Invalidation.t (* [Invalidation.t]s can be combined *)
+  val restart : Invalidation.t -> unit
 ```
 
-When Dune receives new events from the file-watching backend, it invalidates the
-cells that correspond to the files that have changed. It then cancels the build
-by interrupting the currently running external commands (if any), and finally
-calls `restart_current_run` to notify Memo that a new build run has started and
-hence all outputs that transitively depend on the invalidated cells should now
-be considered out of date.
+When Dune receives new events from the file-watching backend, it cancels the
+build run by interrupting the currently running external commands (if any), and
+then calls `restart` to let Memo know which files changed and initiate a new
+build run. When evaluating future calls to `run`, Memo will consider all outputs
+that transitively depend on the invalidated cells as out of date, and will
+recompute them when/if needed.
 
-## Implementation notes
+## Key features
 
-The above introduction covers only a small part of the Memo's API, yet it gives
-us enough context to discuss the most interesting aspects of the implementation.
+This section discusses the most interesting features of Memo and some aspects of
+the implementation.
 
 Firstly, to *capture dependencies*, Memo maintains a call stack, where stack
-frames correspond to `exec` calls. The call stack is also useful for reporting
+frames correspond to `exec` calls. The call stack is also used for reporting
 good error messages: when a user-supplied function raises an exception, we
 extend it with the current Memo stack trace using human-readable annotations
 provided to `create` via an optional argument.
@@ -81,18 +84,13 @@ provided to `create` via an optional argument.
 Memo supports two ways of *error reporting*: *early* (to show errors to the user
 as soon as they occur during a build), and *deterministic* (to provide a stable
 error summary at the end of the build). To speed up rebuilds, Memo also supports
-*error caching*: by default, it doesn't recompute a `Build` function that
+*error caching*: by default, it doesn't recompute a `Memo` function that
 previously failed if its dependencies are up to date. This behaviour can be
 overridden for *non-reproducible errors* that should not be cached, for example,
 the errors that occur while Dune cancels the current build by interrupting the
-execution of external commands. Another source of complexity when dealing with
-errors is that memoized functions can form diamond-shaped call graphs, so to
-avoid reporting the same error multiple times, Memo needs to deduplicate them.
+execution of external commands.
 
-<!-- aalekseyev says: diamond-shaped call graphs introduce a lot of complexity
-     in Memo implementation, so singling out error handling may be misleading. -->
-
-One of the most interesting aspects of Memo is *dependency cycle detection*.
+One of the most interesting features of Memo is *dependency cycle detection*.
 Since Dune supports *dynamic build dependencies* [@mokhov2020build], the
 dependency graph is not known before the build starts. During the build, new
 computation nodes and dependency edges are discovered concurrently, and Memo
@@ -107,19 +105,22 @@ approach used by Tenacious is conceptually simple but introduces a delay between
 the creation of a dependency cycle and its detection.
 
 Compared to the incremental computation libraries mentioned above, the current
-implementation of Memo makes one controversial design choice. Incremental,
-Adapton and Tenacious are all *push based*, i.e., they trigger recomputation
-starting from the leaves of the computation graph. Memo is *pull based*:
-`invalidate` calls merely mark leaves (cells) as out of date, but recomputation
-is driven from the top-level `run` calls. The main drawback of this approach is
-that Memo needs to traverse the whole graph on each rebuild. The main benefits
-are: (i) Memo doesn't need to store reverse dependencies, which saves space and
-eliminates various garbage collection pitfalls; (ii) the pull based approach
-makes it easier to avoid "spurious" recomputations, where a node is recomputed
-but subsequently becomes unreachable from the top due to a new dependency
-structure. We may reconsider this design choice in future, but for now
-traversing the whole graph on each rebuild isn't a bottleneck even for
-large-scale builds where graphs contain millions of nodes.
+implementation of Memo makes one unusual design choice. Incremental, Adapton and
+Tenacious are all *push based*, i.e., they trigger recomputation starting from
+the leaves of the computation graph. Memo is *pull based*: `invalidate` calls
+merely mark leaves (cells) as out of date, but recomputation is driven from the
+top-level `run` calls. The main drawback of our approach is that Memo needs to
+traverse the whole graph on each rebuild. The main benefits are: (i) Memo
+doesn't need to store reverse dependencies, which saves space and eliminates
+various garbage collection pitfalls; (ii) the pull based approach makes it
+easier to avoid "spurious" recomputations, where a node is recomputed but
+subsequently becomes unreachable from the top due to a new dependency structure.
+Our current experiments show that traversing the whole graph on each rebuild
+isn't prohibitively expensive even for large builds where computation graphs
+contain tens of millions of nodes. We may reconsider this design choice in
+future as Dune and Memo need to scale to larger projects. Having said that, we
+consider the pull based approach to incrementality to be a under-researched, and
+are keen to investigate how far we can take it in practice.
 
 ## Development status
 

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,4 +1,4 @@
 (library
  (name memo)
  (libraries stdune dyn dune_graph dag fiber unix)
- (synopsis "Function memoizer"))
+ (synopsis "Incremental computation library that powers Dune"))


### PR DESCRIPTION
Just freshening up the abstract, plus a drive-by change to the Memo's description in `dune` file. It's far more than just a "function memoizer" these days.