### PR TITLE
[ctypes] Add support for cstubs codegen errno parameter

### DIFF
--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -270,6 +270,11 @@ descriptions by referencing them as the module specified in optional
   ``ctypes`` library. If ``concurrency`` is not specified, the default of
   ``sequential`` will be used.
 
+- ``(errno_policy <ignore_errno|return_errno>)`` specifies the errno_policy_
+  passed to the code generator. With ``ignore_errno``, the errno variable is
+  not accessed or returned by function calls. With ``return_errno``, all
+  functions will return the tuple ``(retval, errno)``.
+
 ``<vendored-stanza>`` is:
 
 - ``(vendored (c_flags <flags>) (c_library_flags <flags>))`` provide the build
@@ -370,3 +375,4 @@ this project to see a full working example.
 
 .. _ctypes: https://github.com/ocamllabs/ocaml-ctypes
 .. _pkg-config: https://www.freedesktop.org/wiki/Software/pkg-config/
+.. _errno_policy: https://ocaml.org/p/ctypes/0.20.1/doc/Cstubs/index.html#type-errno_policy

--- a/src/dune_rules/ctypes_rules.ml
+++ b/src/dune_rules/ctypes_rules.ml
@@ -170,7 +170,7 @@ let type_gen_gen ~expander ~headers ~type_description_functor =
     ]
 
 let function_gen_gen ~expander ~(concurrency : Ctypes.Concurrency_policy.t)
-    ~headers ~function_description_functor =
+    ~errno_policy ~headers ~function_description_functor =
   let open Action_builder.O in
   let module_name = Module_name.to_string function_description_functor in
   let concurrency =
@@ -180,18 +180,26 @@ let function_gen_gen ~expander ~(concurrency : Ctypes.Concurrency_policy.t)
     | Lwt_jobs -> "Cstubs.lwt_jobs"
     | Lwt_preemptive -> "Cstubs.lwt_preemptive"
   in
+  let errno_policy =
+    match errno_policy with
+    | Ctypes.Errno_policy.Ignore_errno -> "Cstubs.ignore_errno"
+    | Ctypes.Errno_policy.Return_errno -> "Cstubs.return_errno"
+  in
   let+ headers = gen_headers ~expander headers in
   Pp.concat
     [ verbatimf "let () ="
     ; verbatimf "  let concurrency = %s in" concurrency
+    ; verbatimf "  let errno = %s in" errno_policy
     ; verbatimf "  let prefix = Sys.argv.(2) in"
     ; verbatimf "  match Sys.argv.(1) with"
     ; verbatimf "  | \"ml\" ->"
     ; verbatimf "    Cstubs.write_ml ~concurrency Format.std_formatter ~prefix"
+    ; verbatimf "      ~errno"
     ; verbatimf "      (module %s.Functions)" module_name
     ; verbatimf "  | \"c\" ->"
     ; headers
     ; verbatimf "    Cstubs.write_c ~concurrency Format.std_formatter ~prefix"
+    ; verbatimf "      ~errno"
     ; verbatimf "      (module %s.Functions)" module_name
     ; verbatimf "  | s -> failwith (\"unknown functions \"^s)"
     ]
@@ -218,9 +226,9 @@ let write_type_gen_script ~headers ~dir ~filename ~sctx
     (type_gen_gen ~headers ~type_description_functor)
 
 let write_function_gen_script ~headers ~sctx ~dir ~name
-    ~function_description_functor ~concurrency =
+    ~function_description_functor ~concurrency ~errno_policy =
   add_rule_gen ~dir ~filename:(name ^ ".ml") ~sctx
-    (function_gen_gen ~concurrency ~headers ~function_description_functor)
+    (function_gen_gen ~concurrency ~errno_policy ~headers ~function_description_functor)
 
 let rule ?(deps = []) ?stdout_to ?(args = []) ?(targets = []) ~exe ~sctx ~dir ()
     =
@@ -513,6 +521,7 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
         let* () =
           write_function_gen_script ~headers ~sctx ~dir
             ~name:function_gen_script ~concurrency:fd.concurrency
+            ~errno_policy:fd.errno_policy
             ~function_description_functor:fd.functor_
         in
         let* () = exe_link_only function_gen_script in

--- a/src/dune_rules/ctypes_stanza.ml
+++ b/src/dune_rules/ctypes_stanza.ml
@@ -1,6 +1,13 @@
 open Import
 open Dune_lang.Decoder
 
+let name = "ctypes"
+
+let syntax =
+  Dune_lang.Syntax.create ~name ~desc:"the ctypes extension"
+    [ ((0, 1), `Since (3, 0))
+    ; ((0, 2), `Since (3, 4)) ]
+
 module Build_flags_resolver = struct
   module Vendored = struct
     type t =
@@ -49,6 +56,20 @@ module Concurrency_policy = struct
   let default = Sequential
 end
 
+module Errno_policy = struct
+  type t =
+    | Ignore_errno
+    | Return_errno
+
+  let decode =
+    enum
+      [ ("ignore_errno", Ignore_errno)
+      ; ("return_errno", Return_errno)
+      ]
+
+  let default = Ignore_errno
+end
+
 module Headers = struct
   type t =
     | Include of Ordered_set_lang.Unexpanded.t
@@ -85,6 +106,7 @@ end
 module Function_description = struct
   type t =
     { concurrency : Concurrency_policy.t
+    ; errno_policy : Errno_policy.t
     ; functor_ : Module_name.t
     ; instance : Module_name.t
     }
@@ -93,10 +115,14 @@ module Function_description = struct
     let open Dune_lang.Decoder in
     fields
       (let+ concurrency = field_o "concurrency" Concurrency_policy.decode
+       and+ errno_policy = field_o "errno_policy"
+         (Dune_lang.Syntax.since syntax (0, 2) >>> Errno_policy.decode)
        and+ functor_ = field "functor" Module_name.decode
        and+ instance = field "instance" Module_name.decode in
        { concurrency =
            Option.value concurrency ~default:Concurrency_policy.default
+       ; errno_policy =
+           Option.value errno_policy ~default:Errno_policy.default
        ; functor_
        ; instance
        })
@@ -113,13 +139,8 @@ type t =
   ; deps : Dep_conf.t list
   }
 
-let name = "ctypes"
 
 type Stanza.t += T of t
-
-let syntax =
-  Dune_lang.Syntax.create ~name ~desc:"the ctypes extension"
-    [ ((0, 1), `Since (3, 0)) ]
 
 let decode =
   let open Dune_lang.Decoder in

--- a/src/dune_rules/ctypes_stanza.mli
+++ b/src/dune_rules/ctypes_stanza.mli
@@ -21,6 +21,12 @@ module Concurrency_policy : sig
     | Lwt_preemptive
 end
 
+module Errno_policy : sig
+  type t =
+    | Ignore_errno
+    | Return_errno
+end
+
 module Headers : sig
   type t =
     | Include of Ordered_set_lang.Unexpanded.t
@@ -37,6 +43,7 @@ end
 module Function_description : sig
   type t =
     { concurrency : Concurrency_policy.t
+    ; errno_policy : Errno_policy.t
     ; functor_ : Module_name.t
     ; instance : Module_name.t
     }

--- a/test/blackbox-tests/test-cases/ctypes/dune
+++ b/test/blackbox-tests/test-cases/ctypes/dune
@@ -21,6 +21,11 @@
   (package ctypes)))
 
 (cram
+ (applies_to lib-return-errno)
+ (deps
+  (package integers)))
+
+(cram
  (applies_to
   lib-pkg_config
   lib-pkg_config-multiple-fd

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/dune
@@ -1,0 +1,3 @@
+(executable
+  (name example)
+  (libraries integers examplelib))

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/dune-project
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.0)
+(using ctypes 0.2)

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/example.ml
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/example.ml
@@ -1,0 +1,6 @@
+let () =
+  let r1 = Examplelib.C.Functions_default_policy.add2 0 in
+  let ((r2:int), (_:Signed.SInt.t)) =
+    Examplelib.C.Functions_return_errno.add4 r1
+  in
+  Printf.printf "%d\n" r2

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/run.t
@@ -1,0 +1,7 @@
+Generate cstubs for an example executable exercising the `return_errno` and the
+default `ignore_errno` errno policies, build an executable, and run it.
+
+  $ LIBEX=$(realpath "$PWD/../libexample")
+  $ awk "BEGIN{print \"prefix=$LIBEX\"} 1" $LIBEX/libexample.pc > libexample.pc
+  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$PWD:$PKG_CONIG_PATH" dune exec ./example.exe
+  6

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/dune
@@ -1,0 +1,17 @@
+(library
+  (name examplelib)
+  (flags (:standard -w -9-27))
+  (ctypes
+    (external_library_name libexample)
+    (headers (include "example.h"))
+    (type_description
+      (instance Types)
+      (functor Type_description))
+    (function_description
+      (instance Functions_default_policy)
+      (functor Function_description_default_policy))
+    (function_description
+      (errno_policy return_errno)
+      (instance Functions_return_errno)
+      (functor Function_description_return_errno))
+    (generated_entry_point C)))

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/function_description_default_policy.ml
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/function_description_default_policy.ml
@@ -1,0 +1,6 @@
+open Ctypes
+
+module Functions (F : Ctypes.FOREIGN) = struct
+  open F
+  let add2 = foreign "example_add2" (int @-> returning int)
+end

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/function_description_return_errno.ml
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/function_description_return_errno.ml
@@ -1,0 +1,6 @@
+open Ctypes
+
+module Functions ( F : Ctypes.FOREIGN ) = struct
+  open F
+  let add4 = foreign "example_add4" (int @-> returning int)
+end

--- a/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/type_description.ml
+++ b/test/blackbox-tests/test-cases/ctypes/lib-return-errno.t/stubgen/type_description.ml
@@ -1,0 +1,1 @@
+module Types (F : Ctypes.TYPE) = struct end


### PR DESCRIPTION
This parameter dates back to 2016, and switches the generated
code between returning just the C function's return value, to a tuple
of (retval, errno).

Signed-off-by: David Arroyo <david@aqwari.net>