### PR TITLE
Remove scopes from various source modules

### DIFF
--- a/src/dune_rules/coq_sources.ml
+++ b/src/dune_rules/coq_sources.ml
@@ -56,14 +56,12 @@ let check_no_unqualified (loc, (qualif_mode : Dune_file.Include_subdirs.t)) =
 let extract t (stanza : Extraction.t) =
   Loc.Map.find_exn t.extract stanza.buildable.loc
 
-let of_dir (d : _ Dir_with_dune.t) ~include_subdirs ~dirs =
+let of_dir stanzas ~dir ~include_subdirs ~dirs =
   check_no_unqualified include_subdirs;
   let modules = coq_modules_of_files ~dirs in
-  List.fold_left d.data ~init:empty ~f:(fun acc -> function
+  List.fold_left stanzas ~init:empty ~f:(fun acc -> function
     | Theory.T coq ->
-      let modules =
-        Coq_module.eval ~dir:d.ctx_dir coq.modules ~standard:modules
-      in
+      let modules = Coq_module.eval ~dir coq.modules ~standard:modules in
       let directories =
         Coq_lib_name.Map.add_exn acc.directories (snd coq.name)
           (List.map dirs ~f:(fun (d, _, _) -> d))

--- a/src/dune_rules/coq_sources.mli
+++ b/src/dune_rules/coq_sources.mli
@@ -15,7 +15,8 @@ val directories : t -> name:Coq_lib_name.t -> Path.Build.t list
 val extract : t -> Extraction.t -> Coq_module.t
 
 val of_dir :
-     Stanza.t list Dir_with_dune.t
+     Stanza.t list
+  -> dir:Path.Build.t
   -> include_subdirs:Loc.t * Dune_file.Include_subdirs.t
   -> dirs:(Path.Build.t * string list * String.Set.t) list
   -> t

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -319,8 +319,10 @@ end = struct
                        ; mlds = Memo.lazy_ (fun () -> build_mlds_map d ~files)
                        ; foreign_sources =
                            Memo.lazy_ (fun () ->
-                               Foreign_sources.make d ~lib_config:ctx.lib_config
-                                 ~include_subdirs ~dirs
+                               Foreign_sources.make d.data
+                                 ~dune_version:d.dune_version
+                                 ~lib_config:ctx.lib_config ~include_subdirs
+                                 ~dirs
                                |> Memo.return)
                        ; coq =
                            Memo.lazy_ (fun () ->
@@ -373,8 +375,8 @@ end = struct
             in
             let foreign_sources =
               Memo.lazy_ (fun () ->
-                  Foreign_sources.make d ~include_subdirs
-                    ~lib_config:ctx.lib_config ~dirs
+                  Foreign_sources.make d.data ~dune_version:d.dune_version
+                    ~include_subdirs ~lib_config:ctx.lib_config ~dirs
                   |> Memo.return)
             in
             let coq =

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -326,7 +326,8 @@ end = struct
                                |> Memo.return)
                        ; coq =
                            Memo.lazy_ (fun () ->
-                               Coq_sources.of_dir d ~include_subdirs ~dirs
+                               Coq_sources.of_dir d.data ~dir:d.ctx_dir
+                                 ~include_subdirs ~dirs
                                |> Memo.return)
                        }
                    ; rules
@@ -381,7 +382,9 @@ end = struct
             in
             let coq =
               Memo.lazy_ (fun () ->
-                  Coq_sources.of_dir d ~dirs ~include_subdirs |> Memo.return)
+                  Coq_sources.of_dir d.data ~dir:d.ctx_dir ~dirs
+                    ~include_subdirs
+                  |> Memo.return)
             in
             let subdirs =
               List.map subdirs ~f:(fun (dir, _local, files) ->

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -38,7 +38,7 @@ let valid_name language ~loc s =
       ]
   | _ -> s
 
-let eval_foreign_stubs (d : _ Dir_with_dune.t) foreign_stubs
+let eval_foreign_stubs foreign_stubs ~dune_version
     ~(sources : Foreign.Sources.Unresolved.t) : Foreign.Sources.t =
   let multiple_sources_error ~name ~loc ~paths =
     User_error.raise ~loc
@@ -101,8 +101,7 @@ let eval_foreign_stubs (d : _ Dir_with_dune.t) foreign_stubs
           User_error.raise ~loc
             [ Pp.textf "Object %S has no source; %s must be present." name
                 (String.enumerate_one_of
-                   (Foreign.possible_sources ~language name
-                      ~dune_version:d.dune_version
+                   (Foreign.possible_sources ~language name ~dune_version
                    |> List.map ~f:(fun s -> sprintf "%S" s)))
             ])
   in
@@ -119,27 +118,31 @@ let check_no_qualified (loc, include_subdirs) =
           "(include_subdirs qualified) is only meant for OCaml and Coq sources"
       ]
 
-let make (d : _ Dir_with_dune.t) ~(sources : Foreign.Sources.Unresolved.t)
+let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version
     ~(lib_config : Lib_config.t) =
   let libs, foreign_libs, exes =
     let libs, foreign_libs, exes =
-      List.fold_left d.data ~init:([], [], [])
+      List.fold_left stanzas ~init:([], [], [])
         ~f:(fun ((libs, foreign_libs, exes) as acc) stanza ->
           match (stanza : Stanza.t) with
           | Library lib ->
             let all =
-              eval_foreign_stubs d lib.buildable.foreign_stubs ~sources
+              eval_foreign_stubs ~dune_version lib.buildable.foreign_stubs
+                ~sources
             in
             ((lib, all) :: libs, foreign_libs, exes)
           | Foreign_library library ->
-            let all = eval_foreign_stubs d [ library.stubs ] ~sources in
+            let all =
+              eval_foreign_stubs ~dune_version [ library.stubs ] ~sources
+            in
             ( libs
             , (library.archive_name, (library.archive_name_loc, all))
               :: foreign_libs
             , exes )
           | Executables exe | Tests { exes = exe; _ } ->
             let all =
-              eval_foreign_stubs d exe.buildable.foreign_stubs ~sources
+              eval_foreign_stubs ~dune_version exe.buildable.foreign_stubs
+                ~sources
             in
             (libs, foreign_libs, (exe, all) :: exes)
           | _ -> acc)
@@ -213,10 +216,9 @@ let make (d : _ Dir_with_dune.t) ~(sources : Foreign.Sources.Unresolved.t)
   in
   { libraries; archives; executables }
 
-let make (d : _ Dir_with_dune.t) ~include_subdirs ~(lib_config : Lib_config.t)
+let make stanzas ~dune_version ~include_subdirs ~(lib_config : Lib_config.t)
     ~dirs =
   check_no_qualified include_subdirs;
-  let dune_version = d.dune_version in
   let init = String.Map.empty in
   let sources =
     List.fold_left dirs ~init ~f:(fun acc (dir, _local, files) ->
@@ -225,4 +227,4 @@ let make (d : _ Dir_with_dune.t) ~include_subdirs ~(lib_config : Lib_config.t)
         in
         String.Map.Multi.rev_union sources acc)
   in
-  make d ~sources ~lib_config
+  make stanzas ~dune_version ~sources ~lib_config

--- a/src/dune_rules/foreign_sources.mli
+++ b/src/dune_rules/foreign_sources.mli
@@ -13,7 +13,8 @@ val for_archive : t -> archive_name:Foreign.Archive.Name.t -> Foreign.Sources.t
 val for_exes : t -> first_exe:string -> Foreign.Sources.t
 
 val make :
-     Stanza.t list Dir_with_dune.t
+     Stanza.t list
+  -> dune_version:Syntax.Version.t
   -> include_subdirs:Loc.t * Dune_file.Include_subdirs.t
   -> lib_config:Lib_config.t
   -> dirs:(Path.Build.t * 'a * String.Set.t) list

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -17,4 +17,5 @@ module Pform = Dune_lang.Pform
 module Glob = Dune_lang.Glob
 module Diff = Dune_lang.Action.Diff
 module Outputs = Dune_lang.Action.Outputs
+module Syntax = Dune_sexp.Syntax
 include Dune_engine.No_io


### PR DESCRIPTION
It's good to know that generating the sources for a directory does not depend on the state of libraries in anyway. This applies to all sources except the OCaml ones which need to resolve the virtual library to properly initialize the modules for vlib implementations.