### PR TITLE
refactor(rules): remove unused type

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2155,10 +2155,6 @@ type Stanza.t +=
 module Stanzas = struct
   type t = Stanza.t list
 
-  type syntax =
-    | OCaml
-    | Plain
-
   let rules l = List.map l ~f:(fun x -> Rule x)
 
   let execs exe = [ Executables exe ]

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -437,10 +437,6 @@ val stanza_package : Stanza.t -> Package.t option
 module Stanzas : sig
   type t = Stanza.t list
 
-  type syntax =
-    | OCaml
-    | Plain
-
   (** [of_ast project ast] is the list of [Stanza.t]s derived from decoding the
       [ast] according to the syntax given by [kind] in the context of the
       [project] *)


### PR DESCRIPTION
[Dune_file.Stanza.syntax] isn't used anywhere
