### PR TITLE
Add hint to unsandboxed directory target error message.

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -434,7 +434,10 @@ end = struct
            all created files right in the build directory. *)
         if not (Path.Build.Set.is_empty targets.dirs) then
           User_error.raise ~loc
-            [ Pp.text "Rules with directory targets must be sandboxed." ];
+            [ Pp.text "Rules with directory targets must be sandboxed." ]
+            ~hints:
+              [ Pp.text "Add (sandbox always) to the (deps ) field of the rule."
+              ];
         action
       | Some sandbox -> Action.sandbox action sandbox
     in

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -32,6 +32,7 @@ Directory targets are not allowed for non-sandboxed rules.
   2 |   (targets (dir output))
   3 |   (action (bash "true")))
   Error: Rules with directory targets must be sandboxed.
+  Hint: Add (sandbox always) to the (deps ) field of the rule.
   [1]
 
 Ensure directory targets are produced.


### PR DESCRIPTION
Fix #5830

ocamlformat sometimes makes some weird decisions...