### PR TITLE
refactor(rules): move findlib from super_context

### DIFF
--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -468,7 +468,7 @@ module Sanitize_for_tests = struct
     let really_sanitize (context : Context.t) items =
       let rename_path =
         let findlib_paths =
-          Findlib.paths context.findlib |> List.map ~f:Path.to_string
+          context.findlib_paths |> List.map ~f:Path.to_string
         in
         function
         (* we have found a path for OCaml's root: let's define the renaming

--- a/bin/installed_libraries.ml
+++ b/bin/installed_libraries.ml
@@ -19,7 +19,9 @@ let term =
        let open Memo.O in
        let* ctxs = Context.DB.all () in
        let ctx = List.hd ctxs in
-       let findlib = ctx.findlib in
+       let* findlib =
+         Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.lib_config
+       in
        let* all_packages = Findlib.all_packages findlib in
        if na then (
          let+ broken =

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -90,7 +90,7 @@ type t =
   ; ocamlmklib : Action.Prog.t
   ; ocamlobjinfo : Action.Prog.t
   ; env : Env.t
-  ; findlib : Findlib.t
+  ; findlib_paths : Path.t list
   ; findlib_toolchain : Context_name.t option
   ; default_ocamlpath : Path.t list
   ; arch_sixtyfour : bool
@@ -132,7 +132,7 @@ let to_dyn t : Dyn.t =
     ; ("ocamldep", Action.Prog.to_dyn t.ocamldep)
     ; ("ocamlmklib", Action.Prog.to_dyn t.ocamlmklib)
     ; ("env", Env.to_dyn (Env.diff t.env Env.initial))
-    ; ("findlib_path", list path (Findlib.paths t.findlib))
+    ; ("findlib_paths", list path t.findlib_paths)
     ; ("arch_sixtyfour", Bool t.arch_sixtyfour)
     ; ( "natdynlink_supported"
       , Bool (Dynlink_supported.By_the_os.get t.lib_config.natdynlink_supported)
@@ -579,11 +579,10 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
             | Some _ as s -> Memo.return s
             | None -> Memo.Lazy.force make)
     in
-    let* t =
+    let t =
       let build_context =
         Build_context.create ~name ~host:(Option.map host ~f:(fun c -> c.name))
       in
-      let+ findlib = Findlib.create ~paths:findlib_paths ~lib_config in
       { name
       ; implicit
       ; kind
@@ -607,7 +606,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; ocamlmklib
       ; ocamlobjinfo
       ; env
-      ; findlib
+      ; findlib_paths
       ; findlib_toolchain
       ; default_ocamlpath
       ; arch_sixtyfour

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -78,7 +78,7 @@ type t = private
   ; ocamlmklib : Action.Prog.t
   ; ocamlobjinfo : Action.Prog.t
   ; env : Env.t
-  ; findlib : Findlib.t
+  ; findlib_paths : Path.t list
   ; findlib_toolchain : Context_name.t option  (** Misc *)
   ; default_ocamlpath : Path.t list
   ; arch_sixtyfour : bool

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -639,7 +639,7 @@ let all_packages t =
            (Dune_package.Entry.name a)
            (Dune_package.Entry.name b))
 
-let create ~paths ~(lib_config : Lib_config.t) : t Memo.t =
+let create ~paths ~(lib_config : Lib_config.t) =
   let stdlib_dir = lib_config.stdlib_dir in
   let version = lib_config.ocaml_version in
   let+ builtins = Meta.builtins ~stdlib_dir ~version in
@@ -654,3 +654,21 @@ let all_broken_packages t =
       | Ok _ | Error Unavailable_reason.Not_found -> acc
       | Error (Invalid_dune_package exn) -> (name, exn) :: acc)
   |> List.sort ~compare:(fun (a, _) (b, _) -> Package.Name.compare a b)
+
+let create =
+  let module Input = struct
+    type t = Path.t list * Lib_config.t
+
+    let equal (paths, libs) (paths', libs') =
+      List.equal Path.equal paths paths' && Lib_config.equal libs libs'
+
+    let hash = Tuple.T2.hash (List.hash Path.hash) Lib_config.hash
+
+    let to_dyn = Dyn.pair (Dyn.list Path.to_dyn) Lib_config.to_dyn
+  end in
+  let memo =
+    Memo.create "lib-installed"
+      ~input:(module Input)
+      (fun (paths, lib_config) -> create ~paths ~lib_config)
+  in
+  fun ~paths ~lib_config -> Memo.exec memo (paths, lib_config)

--- a/src/dune_rules/jsoo_rules.ml
+++ b/src/dune_rules/jsoo_rules.ml
@@ -137,7 +137,8 @@ let setup_separate_compilation_rules sctx components =
     let pkg = Lib_name.parse_string_exn (Loc.none, pkg) in
     let ctx = SC.context sctx in
     let open Memo.O in
-    Lib.DB.find (SC.installed_libs sctx) pkg >>= function
+    let* installed_libs = Lib.DB.installed ctx in
+    Lib.DB.find installed_libs pkg >>= function
     | None -> Memo.return ()
     | Some pkg ->
       let info = Lib.info pkg in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1739,6 +1739,13 @@ module DB = struct
         let open Memo.O in
         Findlib.all_packages findlib >>| List.map ~f:Dune_package.Entry.name)
 
+  let installed (context : Context.t) =
+    let open Memo.O in
+    let+ findlib =
+      Findlib.create ~paths:context.findlib_paths ~lib_config:context.lib_config
+    in
+    create_from_findlib findlib
+
   let find t name =
     let open Memo.O in
     Resolve_names.find_internal t name >>| function

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -101,6 +101,8 @@ module DB : sig
   (** A database allow to resolve library names *)
   type t
 
+  val installed : Context.t -> t Memo.t
+
   module Resolve_result : sig
     type t
 
@@ -132,8 +134,6 @@ module DB : sig
     -> lib_config:Lib_config.t
     -> unit
     -> t
-
-  val create_from_findlib : Findlib.t -> t
 
   val find : t -> Lib_name.t -> lib option Memo.t
 

--- a/src/dune_rules/lib_config.ml
+++ b/src/dune_rules/lib_config.ml
@@ -52,3 +52,5 @@ let linker_can_create_empty_archives t =
 let hash = Poly.hash
 
 let equal = Poly.equal
+
+let to_dyn = Dyn.opaque

--- a/src/dune_rules/lib_config.mli
+++ b/src/dune_rules/lib_config.mli
@@ -28,3 +28,5 @@ val linker_can_create_empty_archives : t -> bool
 val hash : t -> int
 
 val equal : t -> t -> bool
+
+val to_dyn : t -> Dyn.t

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -222,6 +222,13 @@ let handle_special_libs cctx =
   let obj_dir = Compilation_context.obj_dir cctx |> Obj_dir.of_local in
   let sctx = CC.super_context cctx in
   let ctx = Super_context.context sctx in
+  let open Memo.O in
+  let* builtins =
+    let+ findlib =
+      Findlib.create ~paths:ctx.findlib_paths ~lib_config:ctx.lib_config
+    in
+    Findlib.builtins findlib
+  in
   let rec process_libs ~to_link_rev ~force_linkall libs =
     match libs with
     | [] ->
@@ -279,8 +286,7 @@ let handle_special_libs cctx =
           let code =
             if plugins then
               Action_builder.return
-                (dune_site_plugins_code ~libs:all_libs
-                   ~builtins:(Findlib.builtins ctx.Context.findlib))
+                (dune_site_plugins_code ~libs:all_libs ~builtins)
             else Action_builder.return (dune_site_code ())
           in
           let& module_ =

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -25,7 +25,6 @@ module DB : sig
   val create_from_stanzas :
        projects:Dune_project.t list
     -> context:Context.t
-    -> installed_libs:Lib.DB.t
     -> modules_of_lib:
          (dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.t) Fdecl.t
     -> Dune_file.t list

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -50,9 +50,6 @@ val lib_entries_of_package : t -> Package.Name.t -> Lib_entry.t list
 (** All public libraries of the workspace *)
 val public_libs : t -> Lib.DB.t
 
-(** Installed libraries that are not part of the workspace *)
-val installed_libs : t -> Lib.DB.t
-
 (** Compute the ocaml flags based on the directory environment and a buildable
     stanza *)
 val ocaml_flags :


### PR DESCRIPTION
Callers can now create it without referring to the super context. One less thing stuffed into the super context is always a good thing. Additionally, we don't need to flush the findlib DB on every build iteration now.
