### PR TITLE
fix: tweak flags for 3.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Add warnings 67-69 to dune's default set of warnings. These are warnings of
+  the form "unused X.." (#5844, @rgrinbreg)
+
 - Introduce project "composition" for coq theories. Coq theories in separate
   projects can now refer to each other when in the same workspace (#5784,
   @Alitzer, @rgrinberg)

--- a/src/dune_rules/ocaml_flags.ml
+++ b/src/dune_rules/ocaml_flags.ml
@@ -45,7 +45,12 @@ let dev_mode_warnings =
     |> List.rev_map ~f:wrange_to_flag
     |> String.concat ~sep:""
   in
-  fun ~dune_version:_ -> warnings_range all
+  let pre_3_3 = lazy (warnings_range all) in
+  let post_3_3 =
+    lazy (warnings_range (Int.Set.union all (Int.Set.of_list [ 67; 69 ])))
+  in
+  fun ~dune_version ->
+    if dune_version >= (3, 3) then Lazy.force post_3_3 else Lazy.force pre_3_3
 
 let vendored_warnings = [ "-w"; "-a" ]
 


### PR DESCRIPTION
Enable flags that are of the "unused X" form. This is consistent with
our other flags

This was discussed and approved at the dune meeting at some point, but I forgot to submit the PR.