### PR TITLE
refactor: remove Lib.modules and its friends

### DIFF
--- a/bin/top.ml
+++ b/bin/top.ml
@@ -17,10 +17,10 @@ let man =
 
 let info = Term.info "top" ~doc ~man
 
-let link_deps link =
+let link_deps sctx link =
   let open Memo.O in
   Memo.parallel_map link ~f:(fun t ->
-      Dune_rules.Lib_flags.link_deps t Dune_rules.Link_mode.Byte)
+      Dune_rules.Lib_flags.link_deps sctx t Dune_rules.Link_mode.Byte)
   >>| List.concat
 
 let term =
@@ -35,12 +35,12 @@ let term =
       let* setup = Import.Main.setup () in
       Build_system.run_exn (fun () ->
           let open Memo.O in
+          let* setup = setup in
+          let sctx =
+            Dune_engine.Context_name.Map.find setup.scontexts ctx_name
+            |> Option.value_exn
+          in
           let* libs =
-            let* setup = setup in
-            let sctx =
-              Dune_engine.Context_name.Map.find setup.scontexts ctx_name
-              |> Option.value_exn
-            in
             let dir =
               let build_dir = (Super_context.context sctx).build_dir in
               Path.Build.relative build_dir (Common.prefix_target common dir)
@@ -58,7 +58,7 @@ let term =
           let include_paths =
             Dune_rules.Lib_flags.L.toplevel_include_paths requires
           in
-          let* files = link_deps requires in
+          let* files = link_deps sctx requires in
           let+ () =
             Memo.parallel_iter files ~f:(fun file ->
                 let+ (_ : Digest.t) = Build_system.build_file file in

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -259,11 +259,21 @@ let for_plugin_executable t ~embed_in_plugin_libraries =
 
 let without_bin_annot t = { t with bin_annot = false }
 
+let entry_module_names sctx t =
+  match Lib_info.entry_modules (Lib.info t) with
+  | External d -> Resolve.Memo.of_result d
+  | Local ->
+    let open Memo.O in
+    let+ modules = Dir_contents.modules_of_lib sctx t in
+    let modules = Option.value_exn modules in
+    Resolve.return (Modules.entry_modules modules |> List.map ~f:Module.name)
+
 let root_module_entries t =
   let open Action_builder.O in
   let* requires = Resolve.Memo.read t.requires_compile in
   let* l =
     Action_builder.List.map requires ~f:(fun lib ->
-        Action_builder.of_memo (Lib.entry_module_names lib) >>= Resolve.read)
+        Action_builder.of_memo (entry_module_names t.super_context lib)
+        >>= Resolve.read)
   in
   Action_builder.return (List.concat l)

--- a/src/dune_rules/dir_contents.mli
+++ b/src/dune_rules/dir_contents.mli
@@ -34,6 +34,8 @@ val coq : t -> Coq_sources.t Memo.t
 (** Get the directory contents of the given directory. *)
 val get : Super_context.t -> dir:Path.Build.t -> t Memo.t
 
+val modules_of_lib : Super_context.t -> Lib.t -> Modules.t option Memo.t
+
 (** All directories in this group if [t] is a group root or just [t] if it is
     not part of a group. *)
 val dirs : t -> t list

--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -183,7 +183,7 @@ let link_exe ~loc ~name ~(linkage : Linkage.t) ~cm_files ~link_time_code_gen
               in
               Command.Args.S
                 [ As (if force_linkall then [ "-linkall" ] else [])
-                ; Lib_flags.Lib_and_module.L.link_flags to_link
+                ; Lib_flags.Lib_and_module.L.link_flags sctx to_link
                     ~lib_config:ctx.lib_config ~mode:linkage.mode
                 ])
           ; Deps o_files

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -22,10 +22,6 @@ val info : t -> Path.t Lib_info.t
 
 val main_module_name : t -> Module_name.t option Resolve.Memo.t
 
-val entry_module_names : t -> Module_name.t list Resolve.Memo.t
-
-val src_dirs : t -> Path.Set.t Memo.t
-
 val wrapped : t -> Wrapped.t option Resolve.Memo.t
 
 (** Direct library dependencies of this library *)
@@ -44,8 +40,6 @@ val equal : t -> t -> bool
 val hash : t -> int
 
 val project : t -> Dune_project.t option
-
-val modules : t -> Modules.t Memo.Lazy.t option
 
 (** Operations on list of libraries *)
 module L : sig
@@ -129,8 +123,6 @@ module DB : sig
        parent:t option
     -> resolve:(Lib_name.t -> Resolve_result.t Memo.t)
     -> all:(unit -> Lib_name.t list Memo.t)
-    -> modules_of_lib:
-         (dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.t) Fdecl.t
     -> lib_config:Lib_config.t
     -> unit
     -> t

--- a/src/dune_rules/lib_flags.mli
+++ b/src/dune_rules/lib_flags.mli
@@ -10,7 +10,11 @@ module Lib_and_module : sig
     type nonrec t = t list
 
     val link_flags :
-      t -> lib_config:Lib_config.t -> mode:Link_mode.t -> _ Command.Args.t
+         Super_context.t
+      -> t
+      -> lib_config:Lib_config.t
+      -> mode:Link_mode.t
+      -> _ Command.Args.t
   end
 end
 
@@ -31,4 +35,4 @@ end
 
 (** The list of files that will be read by the compiler when linking an
     executable against this library *)
-val link_deps : Lib.t -> Link_mode.t -> Path.t list Memo.t
+val link_deps : Super_context.t -> Lib.t -> Link_mode.t -> Path.t list Memo.t

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -25,8 +25,6 @@ module DB : sig
   val create_from_stanzas :
        projects:Dune_project.t list
     -> context:Context.t
-    -> modules_of_lib:
-         (dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.t) Fdecl.t
     -> Dune_file.t list
     -> (t * Lib.DB.t) Memo.t
 

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -562,13 +562,9 @@ let create_lib_entries_by_package ~public_libs stanzas =
          (List.sort ~compare:(fun a b ->
               Lib_name.compare (Lib_entry.name a) (Lib_entry.name b)))
 
-let modules_of_lib = Fdecl.create Dyn.opaque
-
 let create ~(context : Context.t) ~host ~projects ~packages ~stanzas =
-  let modules_of_lib_for_scope = Fdecl.create Dyn.opaque in
   let* scopes, public_libs =
-    Scope.DB.create_from_stanzas ~projects ~context
-      ~modules_of_lib:modules_of_lib_for_scope stanzas
+    Scope.DB.create_from_stanzas ~projects ~context stanzas
   in
   let stanzas =
     List.map stanzas ~f:(fun { Dune_file.dir; project; stanzas } ->
@@ -720,27 +716,22 @@ let create ~(context : Context.t) ~host ~projects ~packages ~stanzas =
   let+ lib_entries_by_package =
     create_lib_entries_by_package ~public_libs stanzas
   in
-  let t =
-    { context
-    ; root_expander
-    ; host
-    ; scopes
-    ; public_libs
-    ; findlib
-    ; stanzas
-    ; stanzas_per_dir
-    ; packages
-    ; artifacts
-    ; lib_entries_by_package
-    ; env_tree
-    ; default_env
-    ; dir_status_db
-    ; projects_by_key
-    }
-  in
-  Fdecl.set modules_of_lib_for_scope (fun ~dir ~name ->
-      Fdecl.get modules_of_lib t ~dir ~name);
-  t
+  { context
+  ; root_expander
+  ; host
+  ; scopes
+  ; public_libs
+  ; findlib
+  ; stanzas
+  ; stanzas_per_dir
+  ; packages
+  ; artifacts
+  ; lib_entries_by_package
+  ; env_tree
+  ; default_env
+  ; dir_status_db
+  ; projects_by_key
+  }
 
 let all =
   Memo.lazy_ (fun () ->

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -12,10 +12,6 @@ val all : t Context_name.Map.t Memo.Lazy.t
 (** Find a super context by name. *)
 val find : Context_name.t -> t option Memo.t
 
-val modules_of_lib :
-  (* to avoid a cycle with [Dir_contents] *)
-  (t -> dir:Path.Build.t -> name:Lib_name.t -> Modules.t Memo.t) Fdecl.t
-
 val to_dyn : t -> Dyn.t
 
 val context : t -> Context.t


### PR DESCRIPTION
Gets rid of a bunch of ugly forward declarations. Although it requires us to pass more Sctx in some places, it's better than sneakily passing it through forward declarations. I have upcoming pr's to get rid of much of this anyway.