### PR TITLE
test: directory targets cannot generate sources

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/dir-contents.t
+++ b/test/blackbox-tests/test-cases/directory-targets/dir-contents.t
@@ -1,0 +1,31 @@
+Directory targets and ocaml/coq/etc sources
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.2)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >produce.sh <<EOF
+  > mkdir sources
+  > cd sources
+  > echo "print_endline Foo.bar;;" > main.ml
+  > echo "let bar = "hello world" > main.ml
+  > EOF
+
+  $ chmod +x produce.sh
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (targets (dir sources))
+  >  (action (run ./produce.sh)))
+  > (include_subdirs unqualified)
+  > (executable (name main))
+  > EOF
+
+  $ dune exec ./main.exe
+  File "dune", line 5, characters 18-22:
+  5 | (executable (name main))
+                        ^^^^
+  Error: Module "Main" doesn't exist.
+  [1]
+


### PR DESCRIPTION
It's an issue we need to fix before allowing coq to use directory targets for extraction. For now, this is just a test demonstrating the issue.