### PR TITLE
[coq_rules] Refactor boot flag handling.

### DIFF
--- a/src/dune_rules/coq_lib.ml
+++ b/src/dune_rules/coq_lib.ml
@@ -235,17 +235,6 @@ module DB = struct
 
               (loc, theory))
         in
-        let theories =
-          let open Resolve.O in
-          let* boot = boot in
-          match boot with
-          | None -> theories
-          | Some boot ->
-            let+ theories = theories in
-            (* TODO: if lib is boot, don't add boot dep *)
-            (* maybe use the loc for boot? *)
-            (Loc.none, boot) :: theories
-        in
         let map_error x =
           let human_readable_description () = Id.pp id in
           Resolve.push_stack_frame ~human_readable_description x


### PR DESCRIPTION
Instead of doing an special case in Coq_lib, we handle the boot
library directly in the flags.

This allows us to handle coqdoc-specific flags related to `-boot`, and
is more in line with what we expect the future theory model will be.

Downside is that `-boot` is now not included in the closure dep, but
that seems fine, actually we should forbid `(boot)` libraries from
declaring `(theories ...)` deps, but as we are getting rid of it
eventually maybe it is not worth the effort.