### PR TITLE
Fix bigarray support for OCaml 5.x [2.9]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 
 - Support new locations of unix, str, dynlink in OCaml >= 5.0 (#5582, @dra27)
 
+- Ignore `bigarray` in `(libraries)` with OCaml >= 5.0. (#5526, fixes #5494,
+  @moyodiallo)
+
 2.9.3 (26/01/2022)
 ------------------
 


### PR DESCRIPTION
For Dune 2.9.4, a back-port of https://github.com/ocaml/dune/pull/5526.
