### PR TITLE
refactor: dune file evaluation

### DIFF
--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -162,6 +162,7 @@ module Dune_files = struct
           in
           let ocaml = Action.Prog.ok_exn context.ocaml in
           let* () =
+            let* (_ : Memo.Run.t) = Memo.current_run () in
             Memo.of_reproducible_fiber
               (Process.run Strict ~dir:(Path.source dir) ~env:context.env ocaml
                  args)


### PR DESCRIPTION
Dune files written in OCaml syntax must be evaluated once per run. While
this was maintained by keeping all the stanzas in one data structure in
the super context, now any memoizing function can get the list of
stanzas. This change makes sure that we don't memoize the evaluated
stanzas incorrectly.
