### PR TITLE
Silence dynlink alert for findlib.dynload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ Unreleased
 - Allow list expansion in the `pps` specification for preprocessing (#5820,
   @Firobe)
 
+- Ensure that auto-generated modules are compiled with the correct dependencies
+  even with `(implicit_transitive_deps false)` (#5881, @dra27)
+
 - Add warnings 67-69 to dune's default set of warnings. These are warnings of
   the form "unused X.." (#5844, @rgrinbreg)
 

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -233,6 +233,7 @@ let for_root_module t root_module =
   }
 
 let for_module_generated_at_link_time cctx ~requires ~module_ =
+  let project = Scope.project cctx.scope in
   let opaque =
     (* Cmi's of link time generated modules are compiled with -opaque, hence
        their implementation must also be compiled with -opaque *)
@@ -244,6 +245,7 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
     opaque
   ; flags = Ocaml_flags.empty
   ; requires_link = Memo.lazy_ (fun () -> requires)
+  ; includes = Includes.make ~project ~opaque ~requires
   ; requires_compile = requires
   ; modules
   }

--- a/test/blackbox-tests/test-cases/findlib-dynload.t/dune
+++ b/test/blackbox-tests/test-cases/findlib-dynload.t/dune
@@ -14,6 +14,7 @@
 (library
   (name mytool)
   (public_name mytool)
+  (libraries dynlink)
   (modules register)
 )
 
@@ -59,5 +60,5 @@
   (name c_thread)
   (public_name c_thread)
   (modules c_thread)
-  (libraries threads mytool)
+  (libraries threads.posix mytool)
 )

--- a/test/blackbox-tests/test-cases/findlib-dynload.t/dune-project
+++ b/test/blackbox-tests/test-cases/findlib-dynload.t/dune-project
@@ -1,1 +1,4 @@
-(lang dune 1.0)
+(lang dune 2.0)
+; The use of (implicit_transitive_deps false) tests that the auto-generated
+; modules are compiled with the correct dependencies.
+(implicit_transitive_deps false)

--- a/test/blackbox-tests/test-cases/findlib-dynload.t/main.ml
+++ b/test/blackbox-tests/test-cases/findlib-dynload.t/main.ml
@@ -7,6 +7,8 @@ let () =
     with
     | Fl_package_base.No_such_package(pkg, _) ->
       Printf.printf "The package %S can't be found.\n%!" pkg
-    | Dynlink.Error error ->
-      Printf.printf "Error during dynlink: %s\n%!" (Dynlink.error_message error)
+    | e ->
+      (* This is just a convoluted way to avoid this module directly depending on
+         Dynlink *)
+      Mytool.Register.handle_dynlink_error e
   done

--- a/test/blackbox-tests/test-cases/findlib-dynload.t/register.ml
+++ b/test/blackbox-tests/test-cases/findlib-dynload.t/register.ml
@@ -1,1 +1,6 @@
 let register s f = print_endline (s^": registering"); f ()
+
+let handle_dynlink_error = function
+| Dynlink.Error error ->
+  Printf.printf "Error during dynlink: %s\n%!" (Dynlink.error_message error)
+| e -> raise e


### PR DESCRIPTION
The auto-generated module for `findlib.dynload` support needs to include `-I +dynlink`

The fix - I think - is simply to initialise the `includes` in `Compilation.for_module_generated_at_link_time`.

Spotted in ppxlib (see https://github.com/ocaml-ppx/ppxlib/pull/348#discussion_r896048162)