### PR TITLE
Refactor RPC

### DIFF
--- a/src/dune_rpc_impl/client.ml
+++ b/src/dune_rpc_impl/client.ml
@@ -1,11 +1,2 @@
 open Import
-
-module Fiber = struct
-  include Fiber
-
-  let parallel_iter t ~f =
-    let stream = Fiber.Stream.In.create t in
-    Fiber.Stream.In.parallel_iter stream ~f
-end
-
-include Dune_rpc.Client.Make (Fiber) (Csexp_rpc.Session)
+include Dune_rpc.Client.Make (Private.Fiber) (Csexp_rpc.Session)

--- a/src/dune_rpc_impl/client.mli
+++ b/src/dune_rpc_impl/client.mli
@@ -1,0 +1,6 @@
+open Import
+
+include
+  Dune_rpc.Client.S
+    with type 'a fiber := 'a Fiber.t
+     and type chan := Csexp_rpc.Session.t

--- a/src/dune_rpc_impl/private.ml
+++ b/src/dune_rpc_impl/private.ml
@@ -1,0 +1,7 @@
+module Fiber = struct
+  include Fiber
+
+  let parallel_iter t ~f =
+    let stream = Fiber.Stream.In.create t in
+    Fiber.Stream.In.parallel_iter stream ~f
+end

--- a/test/expect-tests/dune_rpc/dune_rpc_tests.ml
+++ b/test/expect-tests/dune_rpc/dune_rpc_tests.ml
@@ -39,7 +39,7 @@ module Chan = struct
 end
 
 module Drpc = struct
-  module Client = Dune_rpc.Client.Make (Dune_rpc_impl.Client.Fiber) (Chan)
+  module Client = Dune_rpc.Client.Make (Dune_rpc_impl.Private.Fiber) (Chan)
   module Server = Dune_rpc_server.Make (Chan)
 end
 


### PR DESCRIPTION
Get rid of the useless `Run` module as very little is shared between client and server.