### PR TITLE
Env stanza: warn if some rules are ignored

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@
   particular, messages where the excerpt line number started with a blank
   character were skipped. (#5981, @rgrinberg)
 
+- env stanza: warn if some rules are ignored because they appear after a
+  wildcard rule. (#5898, fixes #5886, @emillon)
+
 3.3.1 (19-06-2022)
 ------------------
 

--- a/test/blackbox-tests/test-cases/env/env-unused.t
+++ b/test/blackbox-tests/test-cases/env/env-unused.t
@@ -1,0 +1,41 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.3)
+  > EOF
+
+(env) is evaluated sequentially:
+
+  $ cat > dune << 'EOF'
+  > (rule
+  >  (alias runtest)
+  >  (action (system "echo $VAR")))
+  > 
+  > (env
+  >  (_   (env-vars (VAR default )))
+  >  (dev (env-vars (VAR specific))))
+  > EOF
+
+A warning is displayed when there are unreachable cases.
+
+  $ dune runtest
+  File "dune", line 5, characters 0-71:
+  5 | (env
+  6 |  (_   (env-vars (VAR default )))
+  7 |  (dev (env-vars (VAR specific))))
+  Warning: This env stanza contains rules after a wildcard rule. These are
+  going to be ignored.
+  default
+
+In 3.4, this warning becomes fatal.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.4)
+  > EOF
+
+  $ dune runtest
+  File "dune", line 5, characters 0-71:
+  5 | (env
+  6 |  (_   (env-vars (VAR default )))
+  7 |  (dev (env-vars (VAR specific))))
+  Error: This env stanza contains rules after a wildcard rule. These are going
+  to be ignored.
+  [1]


### PR DESCRIPTION
Since matching is sequential, anything after `_` cannot be reached.

Closes #5886
