### PR TITLE
Added .git-ps to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ _perf
 # vscode settings
 .vscode
 
+# git-ps hooks
+.git-ps
+
 .duneboot.*
 /boot/*.cm*
 dune.exe


### PR DESCRIPTION
This should let us have our own hooks. Ignoring them for now.

I don't know we should be sharing them. I made a small hook for checking `@fmt`, `@check` and `@runtest` which will get run when `gps` isolates a commit.
