### PR TITLE
Turn off shimmed META files for OCaml 5.0+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
 
 - The `(cat)` action now supports several files. (#5928, fixes #5795, @emillon)
 
+- Dune no longer uses shimmed `META` files for OCaml 5.x, solely using the ones
+  installed by the compiler. (#5916, @dra27)
+
 3.3.1 (19-06-2022)
 ------------------
 

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -486,8 +486,14 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
               (vars, ocfg)
             | Error msg -> Error (Ocamlc_config, msg)))
     in
-    let findlib_paths = ocamlpath @ default_ocamlpath in
+    let stdlib_dir = Path.of_string (Ocaml_config.standard_library ocfg) in
     let version = Ocaml.Version.of_ocaml_config ocfg in
+    let default_ocamlpath =
+      if Ocaml.Version.has_META_files version then
+        stdlib_dir :: default_ocamlpath
+      else default_ocamlpath
+    in
+    let findlib_paths = ocamlpath @ default_ocamlpath in
     let env =
       (* See comment in ansi_color.ml for setup_env_for_colors. For versions
          where OCAML_COLOR is not supported, but 'color' is in OCAMLPARAM, use
@@ -551,7 +557,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
               (Option.map findlib_config ~f:Findlib.Config.env))
       |> Env.extend_env (Env_nodes.extra_env ~profile env_nodes)
     in
-    let stdlib_dir = Path.of_string (Ocaml_config.standard_library ocfg) in
     let natdynlink_supported = Ocaml_config.natdynlink_supported ocfg in
     let arch_sixtyfour = Ocaml_config.word_size ocfg = 64 in
     let* ocamlopt = get_ocaml_tool "ocamlopt" in

--- a/src/dune_rules/findlib/meta.ml
+++ b/src/dune_rules/findlib/meta.ml
@@ -159,7 +159,7 @@ let main_modules names =
   List.map ~f:String.capitalize_ascii names
   |> String.concat ~sep:" " |> rule "main_modules" [] Set
 
-let builtins ~stdlib_dir ~version:ocaml_version =
+let pre_ocaml_5_builtins ~stdlib_dir ~version:ocaml_version =
   let version = version "[distributed with OCaml]" in
   let simple name ?(labels = false) ?dir ?archive_name ?kind ?exists_if_ext deps
       =
@@ -301,6 +301,11 @@ let builtins ~stdlib_dir ~version:ocaml_version =
       Option.map t.name ~f:(fun name ->
           (Lib_name.package_name name, simplify t)))
   |> Package.Name.Map.of_list_exn
+
+let builtins ~stdlib_dir ~version =
+  if Ocaml.Version.has_META_files version then
+    Memo.return Package.Name.Map.empty
+  else pre_ocaml_5_builtins ~stdlib_dir ~version
 
 let string_of_action = function
   | Set -> "="

--- a/src/ocaml/version.ml
+++ b/src/ocaml/version.ml
@@ -47,3 +47,5 @@ let has_bigarray_library version = version < (5, 0, 0)
 let supports_alerts version = version >= (4, 8, 0)
 
 let has_sandboxed_otherlibs version = version >= (5, 0, 0)
+
+let has_META_files version = version >= (5, 0, 0)

--- a/src/ocaml/version.mli
+++ b/src/ocaml/version.mli
@@ -71,3 +71,6 @@ val supports_alerts : t -> bool
 (** Whether [dynlink], [str] and [unix] are in subdirectories of the standard
     library *)
 val has_sandboxed_otherlibs : t -> bool
+
+(** Whether the compiler distributes META files independently of ocamlfind *)
+val has_META_files : t -> bool


### PR DESCRIPTION
This is an update of #5824, compatible with the latest version pushed to ocaml/ocaml#11007. The current proposal is that from OCaml 5.0.0~alpha1, the compiler installs its own `META` files in directories under the Standard Library directory.

The previous version was not able to guarantee the operation of Dune or opam's `ocaml-system` because there wasn't a mechanism for reliably determining the location of the compiler's `META` files. The latest revision proposes that the compiler's `META` are therefore _always_ installed in the same place, with Dune and ocamlfind using that fact to change their default search paths for packages accordingly.

This PR, therefore:
- Disables the automatic generation of the compiler's `META` files used for OCaml 4.x.
- Adds the Standard Library directory to the _start_ of `default_ocamlpath` (i.e. the compiler's `META` files cannot be overridden by other findlib packages, as in Dune's behaviour for OCaml 4.x).

There is one outstanding question, which is what to do about the `bytes` shim package. OCaml is _not_ proposing installing this package, partly because it doesn't reflect an actual library (the `bytes` package expresses a property of the `stdlib` package) and also because it relates to back-porting, which is not something the compiler should directly be part of (i.e. the compiler proposes to own its packages, but the `bytes` package has always been owned by findlib).

There are several possible courses of action:
1. `Meta.builtins` could continue to return a dummy a `bytes` package on 5.0
2. `bytes` could be handled in a similar way to `bigarray` - so pruned at the `libraries` stanza for 5.x
3. Do nothing, and require the user's opam files to have a dependency on `base-bytes` or `ocamlfind` in order to pull in **findlib**'s support for the `bytes` package

I'd personally advocate option 3, which is what the PR presently does, because, it's daft that `jbuild` or `dune` files have ever referred to the `bytes` library. No version of jbuilder or Dune has ever targeted OCaml 4.01 or earlier, so adding `bytes` to a `libraries` field has always implied a no-op (unless I've missed something??). The fact it's _always_ been a no-op makes option 2's proposal for `bytes` different from `bigarray`. Dune is now correctly handling the ability to get `Bigarray` in a consistent way for OCaml 4.02-5.x, but the consistent way to get `Bytes` for OCaml 4.02-5.x is, um, not to do anything! It's a shame to do option 1 because it's yet another compatibility shim with no sunset.