### PR TITLE
Module name hint: produce a valid module name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
   directory containing the associated stanza (#5784, fixes #5552, @ejgallego,
   @rlepigre, @Alizter)
 
+- Fix hint when an invalid module name is found. (#5922, fixes #5273, @emillon)
+
 3.3.1 (19-06-2022)
 ------------------
 

--- a/src/dune_engine/section.ml
+++ b/src/dune_engine/section.ml
@@ -65,6 +65,12 @@ Stringlike.Make (struct
 
   let description_of_valid_string = Some valid_format_doc
 
+  let is_valid_first_char = function
+    | 'A' .. 'Z' | 'a' .. 'z' -> true
+    | _ -> false
+
+  let has_valid_first_char s = is_valid_first_char s.[0]
+
   let hint_valid =
     Some
       (fun name ->
@@ -76,22 +82,10 @@ Stringlike.Make (struct
                 | '.' | '-' -> Some '_'
                 | _ -> None)
         in
-        match name.[0] with
-        | 'A' .. 'Z' | 'a' .. 'z' -> name
-        | _ -> "M" ^ name)
+        if has_valid_first_char name then name else "M" ^ name)
 
   let is_valid_module_name name =
-    match name with
-    | "" -> false
-    | s -> (
-      try
-        (match s.[0] with
-        | 'A' .. 'Z' | 'a' .. 'z' -> ()
-        | _ -> raise_notrace Exit);
-        String.iter s ~f:(fun c ->
-            if not (valid_char c) then raise_notrace Exit);
-        true
-      with Exit -> false)
+    name <> "" && has_valid_first_char name && String.for_all name ~f:valid_char
 
   let of_string_opt s = if is_valid_module_name s then Some (S.make s) else None
 end)

--- a/src/dune_engine/section.ml
+++ b/src/dune_engine/section.ml
@@ -68,12 +68,17 @@ Stringlike.Make (struct
   let hint_valid =
     Some
       (fun name ->
-        String.filter_map name ~f:(fun c ->
-            if valid_char c then Some c
-            else
-              match c with
-              | '.' | '-' -> Some '_'
-              | _ -> None))
+        let name =
+          String.filter_map name ~f:(fun c ->
+              if valid_char c then Some c
+              else
+                match c with
+                | '.' | '-' -> Some '_'
+                | _ -> None)
+        in
+        match name.[0] with
+        | 'A' .. 'Z' | 'a' .. 'z' -> name
+        | _ -> "M" ^ name)
 
   let is_valid_module_name name =
     match name with

--- a/test/blackbox-tests/test-cases/github5273.t
+++ b/test/blackbox-tests/test-cases/github5273.t
@@ -11,5 +11,5 @@
   Error: "03" is an invalid module name.
   Module names must be non-empty and composed only of the following characters:
   'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
-  Hint: 03 would be a correct module name
+  Hint: M03 would be a correct module name
   [1]

--- a/test/blackbox-tests/test-cases/github5273.t
+++ b/test/blackbox-tests/test-cases/github5273.t
@@ -1,0 +1,15 @@
+  $ cat > dune-project << EOF
+  > (lang dune 1.0)
+  > EOF
+  $ cat > dune << EOF
+  > (library (name 03))
+  > EOF
+  $ dune build
+  File "dune", line 1, characters 15-17:
+  1 | (library (name 03))
+                     ^^
+  Error: "03" is an invalid module name.
+  Module names must be non-empty and composed only of the following characters:
+  'A'..'Z', 'a'..'z', '_', ''' or '0'..'9'.
+  Hint: 03 would be a correct module name
+  [1]


### PR DESCRIPTION
This would previously hint "03 is a valid module name" when passed "03". We now prepend "M" when the first character is not valid.
