### PR TITLE
RPC(client): better connection handling

### DIFF
--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -15,6 +15,7 @@ let client_term common f =
 let interpret_kind = function
   | Dune_rpc_private.Response.Error.Invalid_request -> "Invalid_request"
   | Code_error -> "Code_error"
+  | Connection_dead -> "Connection_dead"
 
 let raise_rpc_error (e : Dune_rpc_private.Response.Error.t) =
   User_error.raise

--- a/otherlibs/dune-rpc/dune_rpc.mli
+++ b/otherlibs/dune-rpc/dune_rpc.mli
@@ -52,6 +52,7 @@ module V1 : sig
       type kind =
         | Invalid_request
         | Code_error
+        | Connection_dead
 
       type t
 

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -359,7 +359,8 @@ module Client = struct
               ]
           in
           Response.Error.create ~payload
-            ~message:"request sent while connection is dead" ~kind:Code_error ()
+            ~message:"request sent while connection is dead"
+            ~kind:Connection_dead ()
         in
         Error err
       | true ->
@@ -523,7 +524,7 @@ module Client = struct
       | `Connection_dead ->
         let payload = Sexp.record [ ("id", Id.to_sexp id) ] in
         let error =
-          Response.Error.create ~kind:Code_error ~payload
+          Response.Error.create ~kind:Connection_dead ~payload
             ~message:
               "connection terminated. this request will never receive a \
                response"

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -56,6 +56,7 @@ module Response : sig
     type kind =
       | Invalid_request
       | Code_error
+      | Connection_dead
 
     type t =
       { payload : Csexp.t option

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -90,12 +90,14 @@ module Response = struct
     type kind =
       | Invalid_request
       | Code_error
+      | Connection_dead
 
     let dyn_of_kind =
       let open Dyn in
       function
       | Invalid_request -> variant "Invalid_request" []
       | Code_error -> variant "Code_error" []
+      | Connection_dead -> variant "Connection_dead" []
 
     type t =
       { payload : Sexp.t option

--- a/otherlibs/dune-rpc/private/types.mli
+++ b/otherlibs/dune-rpc/private/types.mli
@@ -68,6 +68,7 @@ module Response : sig
     type kind =
       | Invalid_request
       | Code_error
+      | Connection_dead
 
     type t =
       { payload : Sexp.t option


### PR DESCRIPTION
* Long polling should quietly terminate the stream when a connection dies
* Dedicated error kind for connection errors. These are very common so clients should ignore them.