### PR TITLE
Ctypes: simplify rules

### DIFF
--- a/src/dune_rules/ctypes_rules.mli
+++ b/src/dune_rules/ctypes_rules.mli
@@ -10,8 +10,7 @@ val gen_rules :
   -> unit Memo.t
 
 val ctypes_cclib_flags :
-     standard:string list Action_builder.t
-  -> scope:Scope.t
+     Super_context.t
   -> expander:Expander.t
   -> buildable:Dune_file.Buildable.t
   -> string list Action_builder.t

--- a/src/dune_rules/ctypes_stanza.ml
+++ b/src/dune_rules/ctypes_stanza.ml
@@ -184,13 +184,6 @@ let function_gen_script ctypes (fd : Function_description.t) =
     (module_name_lower_string fd.functor_)
     (module_name_lower_string fd.instance)
 
-let cflags_sexp ctypes =
-  Ctypes_stubs.cflags_sexp ~external_library_name:ctypes.external_library_name
-
-let c_library_flags_sexp ctypes =
-  sprintf "%s__c_library_flags.sexp"
-    (External_lib_name.to_string ctypes.external_library_name)
-
 let c_generated_types_module ctypes =
   sprintf "%s__c_generated_types"
     (ctypes.external_library_name |> External_lib_name.to_module_name
@@ -210,9 +203,6 @@ let c_generated_functions_cout_c ctypes (fd : Function_description.t) =
     (External_lib_name.to_string ctypes.external_library_name)
     (module_name_lower_string fd.functor_)
     (module_name_lower_string fd.instance)
-
-let lib_deps_of_strings ~loc lst =
-  List.map lst ~f:(fun lib -> Lib_dep.Direct (loc, Lib_name.of_string lib))
 
 let type_gen_script_module ctypes =
   type_gen_script ctypes |> Module_name.of_string

--- a/src/dune_rules/ctypes_stanza.mli
+++ b/src/dune_rules/ctypes_stanza.mli
@@ -74,15 +74,7 @@ val generated_ml_and_c_files : t -> string list
 
 val c_generated_functions_module : t -> Function_description.t -> Module_name.t
 
-val lib_deps_of_strings : loc:Loc.t -> string list -> Lib_dep.t list
-
 val c_generated_types_module : t -> Module_name.t
-
-val c_library_flags_sexp : t -> string
-
-val cflags_sexp : t -> string
-
-val type_gen_script_module : t -> Module_name.t
 
 val type_gen_script : t -> string
 

--- a/src/dune_rules/ctypes_stubs.ml
+++ b/src/dune_rules/ctypes_stubs.ml
@@ -1,42 +1,8 @@
 open Import
 
-let cflags_sexp ~external_library_name =
-  sprintf "%s__c_flags.sexp" (External_lib_name.to_string external_library_name)
-
-let c_generated_functions_cout_no_ext ~external_library_name ~functor_ ~instance
-    =
-  sprintf "%s__c_cout_generated_functions__%s__%s"
-    (External_lib_name.to_string external_library_name)
-    (Module_name.to_string functor_ |> String.lowercase)
-    (Module_name.to_string instance |> String.lowercase)
-
-let c_library_flags ~external_library_name =
-  sprintf "%s__c_library_flags.sexp"
-    (External_lib_name.to_string external_library_name)
-
 let lib_deps_of_strings ~loc lst =
   List.map lst ~f:(fun lib -> Lib_dep.Direct (loc, Lib_name.of_string lib))
 
 let libraries_needed_for_ctypes ~loc =
   let libraries = [ "ctypes"; "ctypes.stubs" ] in
   lib_deps_of_strings ~loc libraries
-
-let add ~loc ~parsing_context ~external_library_name ~add_stubs ~functor_
-    ~instance ~foreign_stubs =
-  let pos = ("", 0, 0, 0) in
-  let flags =
-    let cflags_sexp_include =
-      Ordered_set_lang.Unexpanded.include_single ~context:parsing_context ~pos
-        (cflags_sexp ~external_library_name)
-    in
-    Ordered_set_lang.Unexpanded.concat ~context:parsing_context ~pos
-      Ordered_set_lang.Unexpanded.standard cflags_sexp_include
-  in
-  add_stubs Foreign_language.C ~loc
-    ~names:
-      (Some
-         (Ordered_set_lang.of_atoms ~loc
-            [ c_generated_functions_cout_no_ext ~external_library_name ~functor_
-                ~instance
-            ]))
-    ~flags:(Some flags) foreign_stubs

--- a/src/dune_rules/ctypes_stubs.mli
+++ b/src/dune_rules/ctypes_stubs.mli
@@ -3,30 +3,4 @@ open Import
 (* This module would be part of Ctypes_rules, except it creates a circular
    dependency if Dune_file tries to access it. *)
 
-val cflags_sexp : external_library_name:External_lib_name.t -> string
-
-val c_library_flags : external_library_name:External_lib_name.t -> string
-
-val c_generated_functions_cout_no_ext :
-     external_library_name:External_lib_name.t
-  -> functor_:Module_name.t
-  -> instance:Module_name.t
-  -> string
-
 val libraries_needed_for_ctypes : loc:Loc.t -> Lib_dep.t list
-
-val add :
-     loc:Loc.t
-  -> parsing_context:Univ_map.t
-  -> external_library_name:External_lib_name.t
-  -> add_stubs:
-       (   Foreign_language.t
-        -> loc:Loc.t
-        -> names:Ordered_set_lang.t option
-        -> flags:Ordered_set_lang.Unexpanded.t option
-        -> Foreign.Stubs.t list
-        -> Foreign.Stubs.t list)
-  -> functor_:Module_name.t
-  -> instance:Module_name.t
-  -> foreign_stubs:Foreign.Stubs.t list
-  -> Foreign.Stubs.t list

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -146,13 +146,11 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       in
       let+ flags = link_flags
       and+ ctypes_cclib_flags =
-        Ctypes_rules.ctypes_cclib_flags ~scope
-          ~standard:(Action_builder.return []) ~expander
-          ~buildable:exes.buildable
+        Ctypes_rules.ctypes_cclib_flags sctx ~expander ~buildable:exes.buildable
       in
       Command.Args.S
-        [ Command.Args.As flags
-        ; Command.Args.S
+        [ As flags
+        ; S
             (let ext_lib = ctx.lib_config.ext_lib in
              let foreign_archives =
                exes.buildable.foreign_archives |> List.map ~f:snd
@@ -164,8 +162,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
                  Command.Args.S [ A "-cclib"; Dep (Path.build lib) ]))
           (* XXX: don't these need the msvc hack being done in lib_rules? *)
           (* XXX: also the Command.quote_args being done in lib_rules? *)
-        ; Command.Args.As
-            (List.concat_map ctypes_cclib_flags ~f:(fun f -> [ "-cclib"; f ]))
+        ; As (List.concat_map ctypes_cclib_flags ~f:(fun f -> [ "-cclib"; f ]))
         ]
     in
     let* o_files =

--- a/src/dune_rules/foreign.mli
+++ b/src/dune_rules/foreign.mli
@@ -140,14 +140,16 @@ end
 (** A foreign source file that has a [path] and all information of the
     corresponding [Foreign.Stubs.t] declaration. *)
 module Source : sig
-  type t =
-    { stubs : Stubs.t
+  type kind =
+    | Stubs of Stubs.t
+    | Ctypes of Ctypes_stanza.t
+
+  type t = private
+    { kind : kind
     ; path : Path.Build.t
     }
 
   val language : t -> Foreign_language.t
-
-  val flags : t -> Ordered_set_lang.Unexpanded.t
 
   val path : t -> Path.Build.t
 
@@ -155,7 +157,7 @@ module Source : sig
      file [some/path/name.cpp]. *)
   val object_name : t -> string
 
-  val make : stubs:Stubs.t -> path:Path.Build.t -> t
+  val make : kind -> path:Path.Build.t -> t
 end
 
 (** A map from object names to the corresponding sources. *)

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -102,57 +102,70 @@ let include_dir_flags ~expander ~dir (stubs : Foreign.Stubs.t) =
              in
              Command.Args.S [ A "-I"; Path include_dir; dep_args ]))))
 
-let build_c ~kind ~sctx ~dir ~expander ~include_flags (loc, src, dst) =
+let build_c ~(kind : Foreign_language.t) ~sctx ~dir ~expander ~include_flags
+    (loc, (src : Foreign.Source.t), dst) =
   let ctx = Super_context.context sctx in
   let* project = Scope.DB.find_by_dir dir >>| Scope.project in
   let use_standard_flags = Dune_project.use_standard_c_and_cxx_flags project in
   let base_flags =
     let cfg = ctx.ocaml_config in
     match kind with
-    | Foreign_language.C -> (
+    | Cxx -> Fdo.cxx_flags ctx
+    | C -> (
       match use_standard_flags with
+      | Some true -> Fdo.c_flags ctx
       | None | Some false ->
         (* In dune < 2.8 flags from ocamlc_config are always added *)
         List.concat
           [ Ocaml_config.ocamlc_cflags cfg
           ; Ocaml_config.ocamlc_cppflags cfg
           ; Fdo.c_flags ctx
-          ]
-      | Some true -> Fdo.c_flags ctx)
-    | Foreign_language.Cxx -> Fdo.cxx_flags ctx
+          ])
   in
   let open Memo.O in
   let* with_user_and_std_flags =
-    let flags = Foreign.Source.flags src in
-    (* DUNE3 will have [use_standard_c_and_cxx_flags] enabled by default. To
-       guide users toward this change we emit a warning when dune_lang is >=
-       1.8, [use_standard_c_and_cxx_flags] is not specified in the
-       [dune-project] file (thus defaulting to [true]), the [:standard] set of
-       flags has been overridden and we are not in a vendored project *)
-    let has_standard = Ordered_set_lang.Unexpanded.has_standard flags in
-    let+ is_vendored =
-      match Path.Build.drop_build_context dir with
-      | Some src_dir -> Dune_engine.Source_tree.is_vendored src_dir
-      | None -> Memo.return false
-    in
-    if
-      Dune_project.dune_version project >= (2, 8)
-      && Option.is_none use_standard_flags
-      && (not is_vendored) && not has_standard
-    then
-      User_warning.emit ~loc
-        [ Pp.text
-            "The flag set for these foreign sources overrides the `:standard` \
-             set of flags. However the flags in this standard set are still \
-             added to the compiler arguments by Dune. This might cause \
-             unexpected issues. You can disable this warning by defining the \
-             option `(use_standard_c_and_cxx_flags <bool>)` in your \
-             `dune-project` file. Setting this option to `true` will \
-             effectively prevent Dune from silently adding c-flags to the \
-             compiler arguments which is the new recommended behaviour."
-        ];
-    Super_context.foreign_flags sctx ~dir ~expander ~flags ~language:kind
-    |> Action_builder.map ~f:(List.append base_flags)
+    match src.kind with
+    | Ctypes stanza -> (
+      Memo.return
+      @@
+      match stanza.build_flags_resolver with
+      | Vendored { c_flags; c_library_flags = _ } ->
+        Super_context.foreign_flags sctx ~dir ~expander ~flags:c_flags
+          ~language:C
+      | Pkg_config ->
+        let dir = Path.Build.parent_exn dst in
+        let lib = External_lib_name.to_string stanza.external_library_name in
+        Pkg_config.Query.read ~dir (Cflags lib) sctx)
+    | Stubs { Foreign.Stubs.flags; _ } ->
+      (* DUNE3 will have [use_standard_c_and_cxx_flags] enabled by default. To
+         guide users toward this change we emit a warning when dune_lang is >=
+         1.8, [use_standard_c_and_cxx_flags] is not specified in the
+         [dune-project] file (thus defaulting to [true]), the [:standard] set of
+         flags has been overridden and we are not in a vendored project *)
+      let has_standard = Ordered_set_lang.Unexpanded.has_standard flags in
+      let+ is_vendored =
+        match Path.Build.drop_build_context dir with
+        | Some src_dir -> Dune_engine.Source_tree.is_vendored src_dir
+        | None -> Memo.return false
+      in
+      if
+        Dune_project.dune_version project >= (2, 8)
+        && Option.is_none use_standard_flags
+        && (not is_vendored) && not has_standard
+      then
+        User_warning.emit ~loc
+          [ Pp.text
+              "The flag set for these foreign sources overrides the \
+               `:standard` set of flags. However the flags in this standard \
+               set are still added to the compiler arguments by Dune. This \
+               might cause unexpected issues. You can disable this warning by \
+               defining the option `(use_standard_c_and_cxx_flags <bool>)` in \
+               your `dune-project` file. Setting this option to `true` will \
+               effectively prevent Dune from silently adding c-flags to the \
+               compiler arguments which is the new recommended behaviour."
+          ];
+      Super_context.foreign_flags sctx ~dir ~expander ~flags ~language:kind
+      |> Action_builder.map ~f:(List.append base_flags)
   and* c_compiler =
     Super_context.resolve_program ~loc:None ~dir sctx
       (Ocaml_config.c_compiler ctx.ocaml_config)
@@ -202,17 +215,22 @@ let build_o_files ~sctx ~foreign_sources ~(dir : Path.Build.t) ~expander
           let+ libs = requires in
           Command.Args.S
             [ Lib_flags.L.c_include_flags libs
-            ; Hidden_deps
-                (Lib_file_deps.deps libs ~groups:[ Lib_file_deps.Group.Header ])
+            ; Hidden_deps (Lib_file_deps.deps libs ~groups:[ Header ])
             ])
       ]
   in
-  String.Map.to_list_map foreign_sources ~f:(fun obj (loc, src) ->
+  String.Map.to_list_map foreign_sources
+    ~f:(fun obj (loc, (src : Foreign.Source.t)) ->
       let dst = Path.Build.relative dir (obj ^ ctx.lib_config.ext_obj) in
-      let stubs = src.Foreign.Source.stubs in
-      let extra_flags = include_dir_flags ~expander ~dir src.stubs in
+      let extra_flags =
+        match src.kind with
+        | Stubs stubs -> include_dir_flags ~expander ~dir stubs
+        | Ctypes _ -> Command.Args.empty
+      in
       let extra_deps, sandbox =
-        Dep_conf_eval.unnamed stubs.extra_deps ~expander
+        match src.kind with
+        | Stubs stubs -> Dep_conf_eval.unnamed stubs.extra_deps ~expander
+        | Ctypes _ -> (Action_builder.return (), Sandbox_config.default)
       in
       (* We don't sandbox the C compiler, see comment in [build_file] about
          this. *)
@@ -223,9 +241,9 @@ let build_o_files ~sctx ~foreign_sources ~(dir : Path.Build.t) ~expander
       let include_flags =
         Command.Args.S [ includes; extra_flags; Dyn extra_deps ]
       in
-      let build_file =
-        match Foreign.Source.language src with
-        | C -> build_c ~kind:Foreign_language.C
-        | Cxx -> build_c ~kind:Foreign_language.Cxx
-      in
-      build_file ~sctx ~dir ~expander ~include_flags (loc, src, dst))
+      build_c
+        ~kind:
+          (match Foreign.Source.language src with
+          | C -> C
+          | Cxx -> Cxx)
+        ~sctx ~dir ~expander ~include_flags (loc, src, dst))

--- a/src/dune_rules/ordered_set_lang.ml
+++ b/src/dune_rules/ordered_set_lang.ml
@@ -262,9 +262,6 @@ module Unexpanded = struct
     ; context
     }
 
-  let concat ~context ~pos a b =
-    { ast = Ast.Union [ a.ast; b.ast ]; loc = Some (Loc.of_pos pos); context }
-
   let field ?check name =
     let decode =
       match check with

--- a/src/dune_rules/ordered_set_lang.mli
+++ b/src/dune_rules/ordered_set_lang.mli
@@ -59,8 +59,6 @@ module Unexpanded : sig
   val include_single :
     context:Univ_map.t -> pos:string * int * int * int -> string -> t
 
-  val concat : context:Univ_map.t -> pos:string * int * int * int -> t -> t -> t
-
   val field :
        ?check:unit Dune_lang.Decoder.t
     -> string

--- a/src/dune_rules/pkg_config.ml
+++ b/src/dune_rules/pkg_config.ml
@@ -1,0 +1,42 @@
+open Import
+
+module Query = struct
+  type t =
+    | Libs of string
+    | Cflags of string
+
+  let _file t ~dir =
+    let dir = Path.Build.relative dir ".pkg-config" in
+    Path.Build.relative dir
+    @@
+    match t with
+    | Libs s -> sprintf "%s.libs" s
+    | Cflags s -> sprintf "%s.cflags" s
+
+  let to_args t : _ Command.Args.t list =
+    Hidden_deps Dep.(Set.singleton universe)
+    ::
+    (match t with
+    | Libs lib -> [ A "--libs"; A lib ]
+    | Cflags lib -> [ A "--cflags"; A lib ])
+end
+
+let gen_rule sctx ~loc ~dir query ~target =
+  let open Memo.O in
+  let* bin =
+    Super_context.resolve_program sctx ~loc:(Some loc) ~dir "pkg-config"
+  in
+  match bin with
+  | Error _ -> Memo.return @@ Error `Not_found
+  | Ok _ as bin ->
+    let command =
+      Command.run ~dir:(Path.build dir) ~stdout_to:target bin
+        (Query.to_args query)
+    in
+    let+ () = Super_context.add_rule sctx ~loc ~dir command in
+    Ok ()
+
+let read_flags ~file =
+  let open Action_builder.O in
+  let+ contents = Action_builder.contents (Path.build file) in
+  String.split_lines contents |> List.hd |> String.extract_blank_separated_words

--- a/src/dune_rules/pkg_config.mli
+++ b/src/dune_rules/pkg_config.mli
@@ -4,6 +4,11 @@ module Query : sig
   type t =
     | Libs of string
     | Cflags of string
+
+  val file : t -> dir:Path.Build.t -> Path.Build.t
+
+  val read :
+    t -> Super_context.t -> dir:Path.Build.t -> string list Action_builder.t
 end
 
 val gen_rule :
@@ -11,7 +16,6 @@ val gen_rule :
   -> loc:Loc.t
   -> dir:Path.Build.t
   -> Query.t
-  -> target:Path.Build.t
   -> (unit, [ `Not_found ]) result Memo.t
 
 val read_flags : file:Path.Build.t -> string list Action_builder.t

--- a/src/dune_rules/pkg_config.mli
+++ b/src/dune_rules/pkg_config.mli
@@ -1,0 +1,17 @@
+open Import
+
+module Query : sig
+  type t =
+    | Libs of string
+    | Cflags of string
+end
+
+val gen_rule :
+     Super_context.t
+  -> loc:Loc.t
+  -> dir:Path.Build.t
+  -> Query.t
+  -> target:Path.Build.t
+  -> (unit, [ `Not_found ]) result Memo.t
+
+val read_flags : file:Path.Build.t -> string list Action_builder.t

--- a/test/blackbox-tests/test-cases/ctypes/lib-pkg_config-multiple-fd.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/lib-pkg_config-multiple-fd.t/run.t
@@ -14,5 +14,6 @@ This silly looking hack is to make sure the .pc file points to the sandbox. We
 cannot set ${prefix} to be interpreted relative to the .pc itself ufortunately
   $ awk "BEGIN{print \"prefix=$LIBEX\"} {print}" $LIBEX/libexample.pc > libexample.pc
 
-  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$PWD:$PKG_CONFIG_PATH" dune exec ./example.exe
+  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX" PKG_CONFIG_PATH="$PWD:$PKG_CONFIG_PATH" dune exec ./example.exe --always-show-command-line 
   6
+$ grep -F 'c.' _build/log | tr -d '$'


### PR DESCRIPTION
replaces #5932 

I removed uses of configurator and replaced it with native pkg-config support. This is more correct, faster, and drops an unnecessary dependency.

Additionally, I removed the layer of indirection for passing flags. This again simplifies the code.

As I've noted on discord, I think the ctypes support would benefit from living in its own stanza. There's quite a bit of duplicated logic at the moment because the field exists for executables and libraries.