### PR TITLE
Better XDG defaults for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 *.ml*             text eol=lf
 *.rst             text eol=lf
+*.c               text eol=lf
 dune              text eol=lf
 dune.inc          text eol=lf
 .gitignore        text eol=lf
+.gitattributes    text eol=lf

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,11 @@
 - env stanza: warn if some rules are ignored because they appear after a
   wildcard rule. (#5898, fixes #5886, @emillon)
 
+- On Windows, XDG_CACHE_HOME is taken to be
+  `%LOCALAPPDATA%\Microsoft\Windows\Temporary Internet Files` if unset, and
+  XDG_CONFIG_HOME and XDG_DATA_HOME are both taken to be %LOCALAPPDATA% if
+  unset.  (#5943, fixes #5808, @nojb)
+
 3.3.1 (19-06-2022)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,10 +35,9 @@
 - env stanza: warn if some rules are ignored because they appear after a
   wildcard rule. (#5898, fixes #5886, @emillon)
 
-- On Windows, XDG_CACHE_HOME is taken to be
-  `%LOCALAPPDATA%\Microsoft\Windows\Temporary Internet Files` if unset, and
-  XDG_CONFIG_HOME and XDG_DATA_HOME are both taken to be %LOCALAPPDATA% if
-  unset.  (#5943, fixes #5808, @nojb)
+- On Windows, XDG_CACHE_HOME is taken to be the `FOLDERID_InternetCache` if
+  unset, and XDG_CONFIG_HOME and XDG_DATA_HOME are both taken to be
+  `FOLDERID_LocalAppData` if unset.  (#5943, fixes #5808, @nojb)
 
 3.3.1 (19-06-2022)
 ------------------

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -63,4 +63,8 @@ let link_flags =
     ; "-cclib"
     ; "-framework CoreServices"
     ])
+  ; ("win32", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
+  ; ("win64", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
+  ; ("mingw32", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
+  ; ("mingw64", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
   ]

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -63,8 +63,12 @@ let link_flags =
     ; "-cclib"
     ; "-framework CoreServices"
     ])
-  ; ("win32", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
-  ; ("win64", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
-  ; ("mingw32", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
-  ; ("mingw64", [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ])
+  ; ("win32",
+    [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
+  ; ("win64",
+    [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
+  ; ("mingw32",
+    [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
+  ; ("mingw64",
+    [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ])
   ]

--- a/otherlibs/xdg/dune
+++ b/otherlibs/xdg/dune
@@ -1,4 +1,8 @@
 (library
  (name xdg)
  (public_name xdg)
+ (c_library_flags -lshell32 -lole32)
+ (foreign_stubs
+  (language c)
+  (names xdg_stubs))
  (synopsis "[Internal] XDG base directories specification implementation"))

--- a/otherlibs/xdg/dune
+++ b/otherlibs/xdg/dune
@@ -1,7 +1,13 @@
+(rule
+ (with-stdout-to
+  c_library_flags.sexp
+  (run gen_flags/gen_flags.exe %{os_type})))
+
 (library
  (name xdg)
  (public_name xdg)
- (c_library_flags -lshell32 -lole32)
+ (c_library_flags
+  (:include c_library_flags.sexp))
  (foreign_stubs
   (language c)
   (names xdg_stubs))

--- a/otherlibs/xdg/gen_flags/dune
+++ b/otherlibs/xdg/gen_flags/dune
@@ -1,0 +1,2 @@
+(executable
+ (name gen_flags))

--- a/otherlibs/xdg/gen_flags/gen_flags.ml
+++ b/otherlibs/xdg/gen_flags/gen_flags.ml
@@ -1,0 +1,4 @@
+let () =
+  match Sys.argv.(1) with
+  | "Win32" -> print_endline "(-lshell32 -lole32)"
+  | _ -> print_endline "()"

--- a/otherlibs/xdg/gen_flags/gen_flags.ml
+++ b/otherlibs/xdg/gen_flags/gen_flags.ml
@@ -1,4 +1,4 @@
 let () =
   match Sys.argv.(1) with
-  | "Win32" -> print_endline "(-lshell32 -lole32)"
+  | "Win32" -> print_endline "(-lshell32 -lole32 -luuid)"
   | _ -> print_endline "()"

--- a/otherlibs/xdg/xdg.ml
+++ b/otherlibs/xdg/xdg.ml
@@ -14,7 +14,8 @@ type known_folder =
   | InternetCache
   | LocalAppData
 
-external get_known_folder_path : known_folder -> string option = "dune_xdg__get_known_folder_path"
+external get_known_folder_path : known_folder -> string option
+  = "dune_xdg__get_known_folder_path"
 
 let make t env_var unix_default win32_folder =
   let default =
@@ -39,8 +40,7 @@ let config_dir t =
 
 let data_dir t =
   let home = t.home_dir in
-  make t "XDG_DATA_HOME"
-    (home / ".local" / "share") LocalAppData
+  make t "XDG_DATA_HOME" (home / ".local" / "share") LocalAppData
 
 let create ?win32 ~env () =
   let win32 =

--- a/otherlibs/xdg/xdg_stubs.c
+++ b/otherlibs/xdg/xdg_stubs.c
@@ -12,7 +12,7 @@
 value dune_xdg__get_known_folder_path(value v_known_folder)
 {
   CAMLparam1(v_known_folder);
-  CAMLlocal1(v_res);
+  CAMLlocal2(v_res, v_path);
   WCHAR* wcp = NULL;
   HRESULT res;
   int wlen, len;
@@ -43,11 +43,14 @@ value dune_xdg__get_known_folder_path(value v_known_folder)
     caml_raise_not_found();
   }
 
-  v_res = caml_alloc_string(len);
+  v_path = caml_alloc_string(len);
 
   if (!WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wcp, wlen, (char *)String_val(v_res), len, NULL, NULL)) {
     CoTaskMemFree(wcp);
-    caml_raise_not_found();
+    v_res = Val_int(0);
+  } else {
+    v_res = caml_alloc_small(1, 0);
+    Store_field(v_res, 0, v_path);
   }
   CoTaskMemFree(wcp);
 

--- a/otherlibs/xdg/xdg_stubs.c
+++ b/otherlibs/xdg/xdg_stubs.c
@@ -7,6 +7,7 @@
 
 #include <Windows.h>
 #include <Knownfolders.h>
+#include <Shlobj.h>
 
 value xdg__get_user_cache_dir(value v_unit)
 {

--- a/otherlibs/xdg/xdg_stubs.c
+++ b/otherlibs/xdg/xdg_stubs.c
@@ -1,0 +1,50 @@
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+
+#ifdef _WIN32
+
+#include <Windows.h>
+#include <Knownfolders.h>
+
+value xdg__get_user_cache_dir(value v_unit)
+{
+  CAMLparam0();
+  CAMLlocal1(v_res);
+  WCHAR* wcp = NULL;
+  HRESULT res;
+  int wlen, len;
+
+  res = SHGetKnownFolderPath(&FOLDERID_InternetCache, 0, NULL, &wcp);
+  if (res != S_OK) {
+    CoTaskMemFree(wcp);
+    caml_raise_not_found();
+  }
+
+  wlen = wcslen(wcp);
+  len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wcp, wlen, NULL, 0, NULL, NULL);
+  if (!len) {
+    CoTaskMemFree(wcp);
+    caml_raise_not_found();
+  }
+
+  v_res = caml_alloc_string(len);
+
+  if (!WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wcp, wlen, (char *)String_val(v_res), len, NULL, NULL)) {
+    CoTaskMemFree(wcp);
+    caml_raise_not_found();
+  }
+  CoTaskMemFree(wcp);
+
+  CAMLreturn(v_res);
+}
+
+#else /* _WIN32 */
+
+value xdg__get_user_cache_dir(value v_unit)
+{
+  caml_invalid_argument("xdg__get_user_cache_dir");
+}
+
+#endif /* _WIN32 */

--- a/otherlibs/xdg/xdg_stubs.c
+++ b/otherlibs/xdg/xdg_stubs.c
@@ -9,15 +9,28 @@
 #include <Knownfolders.h>
 #include <Shlobj.h>
 
-value xdg__get_user_cache_dir(value v_unit)
+value dune_xdg__get_known_folder_path(value v_known_folder)
 {
-  CAMLparam0();
+  CAMLparam1(v_known_folder);
   CAMLlocal1(v_res);
   WCHAR* wcp = NULL;
   HRESULT res;
   int wlen, len;
+  const KNOWNFOLDERID *rfid;
 
-  res = SHGetKnownFolderPath(&FOLDERID_InternetCache, 0, NULL, &wcp);
+  switch (Int_val(v_known_folder)) {
+    case 0:
+      rfid = &FOLDERID_InternetCache;
+      break;
+    case 1:
+      rfid = &FOLDERID_LocalAppData;
+      break;
+    default:
+      caml_invalid_argument("get_known_folder_path");
+      break;
+  }
+
+  res = SHGetKnownFolderPath(rfid, 0, NULL, &wcp);
   if (res != S_OK) {
     CoTaskMemFree(wcp);
     caml_raise_not_found();
@@ -43,9 +56,9 @@ value xdg__get_user_cache_dir(value v_unit)
 
 #else /* _WIN32 */
 
-value xdg__get_user_cache_dir(value v_unit)
+value dune_xdg__get_known_folder_path(value v_unit)
 {
-  caml_invalid_argument("xdg__get_user_cache_dir");
+  caml_invalid_argument("get_known_folder_path: not implemented");
 }
 
 #endif /* _WIN32 */

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -17,7 +17,9 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
         | None -> Right lib)
   in
   let link_flags =
-    let win_link_flags = [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ] in
+    let win_link_flags =
+      [ "-cclib"; "-lshell32"; "-cclib"; "-lole32"; "-cclib"; "-luuid" ]
+    in
     (* additional link flags keyed by the platform *)
     [ ( "macosx"
       , [ "-cclib"

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -17,6 +17,7 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
         | None -> Right lib)
   in
   let link_flags =
+    let win_link_flags = [ "-cclib"; "-lshell32"; "-cclib"; "-lole32" ] in
     (* additional link flags keyed by the platform *)
     [ ( "macosx"
       , [ "-cclib"
@@ -24,6 +25,10 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
         ; "-cclib"
         ; "-framework CoreServices"
         ] )
+    ; ("win32", win_link_flags)
+    ; ("win64", win_link_flags)
+    ; ("mingw32", win_link_flags)
+    ; ("mingw64", win_link_flags)
     ]
   in
   let+ locals =


### PR DESCRIPTION
This sets the following XDG defaults on Windows:

```
XDG_CONFIG_HOME --> %LOCALAPPDATA%
XDG_DATA_HOME --> %LOCALAPPDATA%
XDG_CACHE_HOME --> FOLDERID_InternetCache
```

A C call is needed to get the right path for `FOLDERID_InternetCache`. This is included in the PR, but perhaps it is considered to be too much trouble? Opinions welcome.

cc @dra27 @jonahbeckford

Fixes #5808 