### PR TITLE
Ignore insignificant file system changes by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@
 - Fix handling of the `(deps)` field in `(test)` stanzas when there is an
   `.expected` file. (#5952, #5951, fixes #5950, @emillon)
 
+- Ignore insignificant filesystem events. This stops RPC in watch mode from
+  flashing errors on insignificant file system events such as changes in the
+  `.git/` directory. (#5953, @rgrinberg)
+
 3.3.1 (19-06-2022)
 ------------------
 

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -127,6 +127,7 @@ let () =
     { Scheduler.Config.concurrency = 10
     ; display = { verbosity = Quiet; status_line = false }
     ; stats = None
+    ; insignificant_changes = `React
     }
   in
   let clean, zero =

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -8,6 +8,7 @@ let config =
   { Scheduler.Config.concurrency = 1
   ; display = { verbosity = Short; status_line = false }
   ; stats = None
+  ; insignificant_changes = `React
   }
 
 let setup =

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -49,6 +49,7 @@ type t =
   ; cache_debug_flags : Dune_engine.Cache_debug_flags.t
   ; report_errors_config : Dune_engine.Report_errors_config.t
   ; require_dune_project_file : bool
+  ; insignificant_changes : [ `React | `Ignore ]
   }
 
 let capture_outputs t = t.capture_outputs
@@ -74,6 +75,8 @@ let prefix_target t s = t.root.reach_from_root_prefix ^ s
 let rpc t = Lazy.force t.rpc
 
 let stats t = t.stats
+
+let insignificant_changes t = t.insignificant_changes
 
 let set_print_directory t b = { t with no_print_directory = not b }
 
@@ -977,6 +980,17 @@ let term ~default_root_is_cwd =
              $(b,twice) - report each error twice: once as soon as the error \
              is discovered and then again at the end of the build, in a \
              deterministic order.")
+  and+ react_to_insignificant_changes =
+    Arg.(
+      value & flag
+      & info
+          [ "react-to-insignificant-changes" ]
+          ~doc:
+            "react to insignificant file system changes; this is only useful \
+             for benchmarking dune")
+  in
+  let insignificant_changes =
+    if react_to_insignificant_changes then `React else `Ignore
   in
   let build_dir = Option.value ~default:default_build_dir build_dir in
   let root =
@@ -1032,6 +1046,7 @@ let term ~default_root_is_cwd =
   ; cache_debug_flags
   ; report_errors_config
   ; require_dune_project_file
+  ; insignificant_changes
   }
 
 let term_with_default_root_is_cwd = term ~default_root_is_cwd:true

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -24,6 +24,8 @@ val default_target : t -> Arg.Dep.t
 
 val prefix_target : t -> string -> string
 
+val insignificant_changes : t -> [ `React | `Ignore ]
+
 (** [init] executes sequence of side-effecting actions to initialize Dune's
     working environment based on the options determined in a [Common.t]
     record.contents.

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -128,7 +128,8 @@ module Scheduler = struct
   let go ~(common : Common.t) ~config:dune_config f =
     let stats = Common.stats common in
     let config =
-      Dune_config.for_scheduler dune_config stats ~insignificant_changes:`React
+      let insignificant_changes = Common.insignificant_changes common in
+      Dune_config.for_scheduler dune_config stats ~insignificant_changes
     in
     Scheduler.Run.go config ~on_event:(on_event dune_config) f
 
@@ -136,7 +137,8 @@ module Scheduler = struct
       ~config:dune_config run =
     let stats = Common.stats common in
     let config =
-      Dune_config.for_scheduler dune_config stats ~insignificant_changes:`React
+      let insignificant_changes = Common.insignificant_changes common in
+      Dune_config.for_scheduler dune_config stats ~insignificant_changes
     in
     let file_watcher = Common.file_watcher common in
     let rpc = Common.rpc common in

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -127,13 +127,17 @@ module Scheduler = struct
 
   let go ~(common : Common.t) ~config:dune_config f =
     let stats = Common.stats common in
-    let config = Dune_config.for_scheduler dune_config stats in
+    let config =
+      Dune_config.for_scheduler dune_config stats ~insignificant_changes:`React
+    in
     Scheduler.Run.go config ~on_event:(on_event dune_config) f
 
   let go_with_rpc_server_and_console_status_reporting ~(common : Common.t)
       ~config:dune_config run =
     let stats = Common.stats common in
-    let config = Dune_config.for_scheduler dune_config stats in
+    let config =
+      Dune_config.for_scheduler dune_config stats ~insignificant_changes:`React
+    in
     let file_watcher = Common.file_watcher common in
     let rpc = Common.rpc common in
     let run () =

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -436,7 +436,7 @@ let term =
   Log.init_disabled ();
   Dune_engine.Scheduler.Run.go
     ~on_event:(fun _ _ -> ())
-    (Dune_config.for_scheduler config None)
+    (Dune_config.for_scheduler config None ~insignificant_changes:`React)
     subst
 
 let command = (term, info)

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -425,7 +425,7 @@ let auto_concurrency =
       in
       loop commands)
 
-let for_scheduler (t : t) stats =
+let for_scheduler (t : t) stats ~insignificant_changes =
   let concurrency =
     match t.concurrency with
     | Fixed i -> i
@@ -434,4 +434,8 @@ let for_scheduler (t : t) stats =
       Log.info [ Pp.textf "Auto-detected concurrency: %d" n ];
       n
   in
-  { Scheduler.Config.concurrency; display = t.display; stats }
+  { Scheduler.Config.concurrency
+  ; display = t.display
+  ; stats
+  ; insignificant_changes
+  }

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -116,4 +116,8 @@ val hash : t -> int
 
 val equal : t -> t -> bool
 
-val for_scheduler : t -> Dune_stats.t option -> Dune_engine.Scheduler.Config.t
+val for_scheduler :
+     t
+  -> Dune_stats.t option
+  -> insignificant_changes:[ `React | `Ignore ]
+  -> Dune_engine.Scheduler.Config.t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -26,6 +26,7 @@ module Config : sig
     { concurrency : int
     ; display : Display.t
     ; stats : Dune_stats.t option
+    ; insignificant_changes : [ `Ignore | `React ]
     }
 end
 

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -74,6 +74,7 @@ let%expect_test "csexp server life cycle" =
     { Scheduler.Config.concurrency = 1
     ; display = { verbosity = Quiet; status_line = false }
     ; stats = None
+    ; insignificant_changes = `React
     }
   in
   Scheduler.Run.go config run ~on_event:(fun _ _ -> ());

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -164,6 +164,7 @@ let config =
   { Scheduler.Config.concurrency = 1
   ; display = { verbosity = Quiet; status_line = false }
   ; stats = None
+  ; insignificant_changes = `React
   }
 
 let run run =

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -48,6 +48,7 @@ let run =
     { Scheduler.Config.concurrency = 1
     ; display = { verbosity = Quiet; status_line = false }
     ; stats = None
+    ; insignificant_changes = `React
     }
   in
   fun run ->

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -7,6 +7,7 @@ let go =
     { Scheduler.Config.concurrency = 1
     ; display = { verbosity = Short; status_line = false }
     ; stats = None
+    ; insignificant_changes = `React
     }
   in
   Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ())

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -8,6 +8,7 @@ let go f =
     { Scheduler.Config.concurrency = 1
     ; display = { verbosity = Short; status_line = false }
     ; stats = None
+    ; insignificant_changes = `React
     }
   in
   try

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -6,6 +6,7 @@ let config =
   { Scheduler.Config.concurrency = 1
   ; display = { verbosity = Short; status_line = false }
   ; stats = None
+  ; insignificant_changes = `React
   }
 
 let%expect_test "create and wait for timer" =

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -114,6 +114,7 @@ let run kind script =
     { Scheduler.Config.concurrency = 1
     ; display = { verbosity = Short; status_line = false }
     ; stats = None
+    ; insignificant_changes = `React
     }
   in
   Scheduler.Run.go


### PR DESCRIPTION
But leave an option to restore the old behavior for benchmarking.