### PR TITLE
refactor: remove [Fiber.record_metrics]

### DIFF
--- a/src/fiber/core.ml
+++ b/src/fiber/core.ml
@@ -349,13 +349,6 @@ let parallel_iter_set (type a s)
     (module S : Set.S with type elt = a and type t = s) set ~(f : a -> unit t) =
   parallel_iter_seq (S.to_seq set) ~f
 
-let record_metrics t ~tag =
-  of_thunk (fun () ->
-      let timer = Metrics.Timer.start tag in
-      let+ res = t in
-      Metrics.Timer.stop timer;
-      res)
-
 module Make_map_traversals (Map : Map.S) = struct
   let parallel_iter t ~f =
     parallel_iter_seq (Map.to_seq t) ~f:(fun (k, v) -> f k v)

--- a/src/fiber/fiber.mli
+++ b/src/fiber/fiber.mli
@@ -114,13 +114,6 @@ val parallel_iter_set :
 
 val sequential_iter_seq : 'a Seq.t -> f:('a -> unit t) -> unit t
 
-(** Returns a fiber which wraps the given fiber with calls to
-    Metrics.Timer.start/stop.
-
-    Note: This will measure the wall clock time between when the fiber starts
-    and finishes, including any time that it is inactive *)
-val record_metrics : 'a t -> tag:string -> 'a t
-
 (** Provide efficient parallel iter/map functions for maps. *)
 module Make_map_traversals (Map : Map.S) : sig
   val parallel_iter : 'a Map.t -> f:(Map.key -> 'a -> unit t) -> unit t


### PR DESCRIPTION
This function is quite specialized to our metrics module and is just
easily implemented externally.

The motivation for this is to move `Stdune.Metrics` into its own private library as its quite specialized.