### PR TITLE
do not use lsof on macos

### DIFF
--- a/src/dune_stats/dune
+++ b/src/dune_stats/dune
@@ -1,3 +1,6 @@
 (library
  (name dune_stats)
+ (foreign_stubs
+  (language c)
+  (names dune_stats_stubs))
  (libraries stdune chrome_trace spawn unix))

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -210,3 +210,7 @@ let record_gc_and_fd stats =
       Event.counter common args
     in
     emit stats event
+
+module Private = struct
+  module Fd_count = Fd_count
+end

--- a/src/dune_stats/dune_stats.mli
+++ b/src/dune_stats/dune_stats.mli
@@ -18,3 +18,13 @@ val emit : t -> Chrome_trace.Event.t -> unit
 val record_gc_and_fd : t -> unit
 
 val close : t -> unit
+
+module Private : sig
+  module Fd_count : sig
+    type t =
+      | Unknown
+      | This of int
+
+    val get : unit -> t
+  end
+end

--- a/src/dune_stats/dune_stats_stubs.c
+++ b/src/dune_stats/dune_stats_stubs.c
@@ -1,0 +1,41 @@
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#if defined(__APPLE__)
+#include <libproc.h>
+
+CAMLprim value dune_stats_open_fds(value v_pid) {
+  CAMLparam1(v_pid);
+  pid_t pid = Int_val(v_pid);
+  int size = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
+  if (size < 0) {
+    caml_failwith("proc_pidinfo failed");
+  }
+  struct proc_fdinfo *fdinfo = (struct proc_fdinfo *)malloc(size);
+  size = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fdinfo, size);
+  if (size < 0) {
+    caml_failwith("proc_pidinfo failed");
+  }
+  int fds = size / PROC_PIDLISTFD_SIZE;
+  free(fdinfo);
+  CAMLreturn(Val_int(fds));
+}
+
+CAMLprim value dune_stats_available(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_true);
+}
+
+#else
+
+CAMLprim value dune_stats_available(value unit) {
+  CAMLparam1(unit);
+  CAMLreturn(Val_false);
+}
+
+CAMLprim value dune_stats_open_fds(value v_pid) {
+  caml_failwith("function is available only on macos");
+}
+
+#endif

--- a/test/expect-tests/dune_stats/dune
+++ b/test/expect-tests/dune_stats/dune
@@ -1,0 +1,17 @@
+(library
+ (name dune_stats_tests)
+ (inline_tests
+  (deps
+   (sandbox always)))
+ (libraries
+  dune_stats
+  stdune
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  ppx_expect.common
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))

--- a/test/expect-tests/dune_stats/dune_stats_tests.ml
+++ b/test/expect-tests/dune_stats/dune_stats_tests.ml
@@ -1,0 +1,20 @@
+open Stdune
+
+let%expect_test "fd counting" =
+  let module Fd_count = Dune_stats.Private.Fd_count in
+  let get () =
+    match Fd_count.get () with
+    | This n -> n
+    | Unknown -> failwith "no fd counting available"
+  in
+  let base = get () in
+  let r, w = Unix.pipe () in
+  let log () = printfn "fd count: %d" (get () - base) in
+  log ();
+  [%expect {| fd count: 2 |}];
+  Unix.close r;
+  log ();
+  [%expect {| fd count: 1 |}];
+  Unix.close w;
+  log ();
+  [%expect {| fd count: 0 |}]


### PR DESCRIPTION
using lsof is bad for two reasons:
* it's buggy b/c we swallow sigchld's in the signal watching thread
* it's quite slow
We replace lsof with a native api for getting the number of open fd's for a process.
