### PR TITLE
test: fix non portable use of xargs

### DIFF
--- a/test/blackbox-tests/test-cases/watching/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/fs-memo.t
@@ -34,7 +34,8 @@ when necessary.
   >  (target result)
   >  (action (bash "\| echo Executing rule...
   >                "\| echo %{deps}       |
-  >                "\|   xargs -d' ' -n 1 |
+  >                "\|   tr ' ' '\n'      |
+  >                "\|   xargs -n 1       |
   >                "\|   grep -v dep      |
   >                "\|   xargs cat > result
   > )))


### PR DESCRIPTION
-d is only avilable on GNU

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 8f485986-bcb7-4df5-8eea-c29b0e9622e6