### PR TITLE
feature(coq): generate plugin deps from plugins field in stanza

### DIFF
--- a/bin/coqtop.ml
+++ b/bin/coqtop.ml
@@ -110,7 +110,9 @@ let term =
               let* (_ : unit * Dep.Fact.t Dep.Map.t) =
                 let deps =
                   let boot_type = Resolve.Memo.return boot_type in
-                  Dune_rules.Coq_rules.deps_of ~dir ~boot_type coq_module
+                  let plugin_deps = Action_builder.return () in
+                  Dune_rules.Coq_rules.deps_of ~dir ~boot_type ~plugin_deps
+                    coq_module
                 in
                 Action_builder.run deps Eager
               in

--- a/src/dune_rules/coq_rules.mli
+++ b/src/dune_rules/coq_rules.mli
@@ -48,6 +48,7 @@ val setup_extraction_rules :
 val deps_of :
      dir:Path.Build.t
   -> boot_type:Bootstrap.t Resolve.Memo.t
+  -> plugin_deps:unit Action_builder.t
   -> Coq_module.t
   -> unit Dune_engine.Action_builder.t
 

--- a/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
@@ -4,7 +4,6 @@ We check cycles are detected
      theory A in A
   -> theory B in B
   -> theory A in A
-  -> required by _build/default/A/a.v.d
   -> required by _build/default/A/.a.aux
   -> required by alias A/all
   -> required by alias default

--- a/test/blackbox-tests/test-cases/coq/compose-installed.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed.t/run.t
@@ -12,7 +12,6 @@ TODO: Currently this is not supported so the output is garbage
                  ^
   Theory B not found
   -> required by theory A in .
-  -> required by _build/default/a.v.d
   -> required by _build/default/.a.aux
   -> required by alias all
   -> required by alias default

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
@@ -1,10 +1,10 @@
   $ dune build --display short --debug-dependency-path @all
-        coqdep thy1/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/simple_b.ml.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/gram.mli.d
       ocamldep src_a/.ml_plugin_a.objs/simple.ml.d
+        coqdep thy1/a.v.d
         coqdep thy2/a.v.d
          coqpp src_a/gram.ml
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}

--- a/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
@@ -7,7 +7,6 @@ dependencies.
   -> theory B in B
   -> theory C in C
   -> theory A in A
-  -> required by _build/default/A/a.v.d
   -> required by _build/default/A/.a.aux
   -> required by alias A/all
   -> required by alias A/default
@@ -19,7 +18,6 @@ dependencies.
   -> theory C in C
   -> theory A in A
   -> theory B in B
-  -> required by _build/default/B/b.v.d
   -> required by _build/default/B/.b.aux
   -> required by alias B/all
   -> required by alias B/default
@@ -31,7 +29,6 @@ dependencies.
   -> theory A in A
   -> theory B in B
   -> theory C in C
-  -> required by _build/default/C/c.v.d
   -> required by _build/default/C/.c.aux
   -> required by alias C/all
   -> required by alias C/default

--- a/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
@@ -8,7 +8,6 @@ dependency.
   Theory A not found
   -> required by theory B in B
   -> required by theory C in C
-  -> required by _build/default/C/c.v.d
   -> required by _build/default/C/.c.aux
   -> required by alias C/all
   -> required by alias C/default

--- a/test/blackbox-tests/test-cases/coq/compose-self.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-self.t/run.t
@@ -2,7 +2,6 @@ Composing a theory with itself should cause a cycle
   $ dune build
   Error: Dependency cycle between:
      theory A in A
-  -> required by _build/default/A/a.v.d
   -> required by _build/default/A/.a.aux
   -> required by alias A/all
   -> required by alias default

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
@@ -1,10 +1,10 @@
   $ dune build --display short --debug-dependency-path @all
-        coqdep theories/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/simple_b.ml.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/gram.mli.d
       ocamldep src_a/.ml_plugin_a.objs/simple.ml.d
+        coqdep theories/a.v.d
          coqpp src_a/gram.ml
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}

--- a/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
@@ -5,7 +5,6 @@
   Theory "private" is private, it cannot be a dependency of a public theory.
   You need to associate "private" to a package.
   -> required by theory public in public
-  -> required by _build/default/public/b.v.d
   -> required by _build/default/public/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/public/b.vo
   -> required by _build/default/public.install


### PR DESCRIPTION
We add the dependencies on plugins using the ones declared in the dune file.

Currently we require the user to add their ml libraries in the plugins field of the Coq stanza. Afterwards we add cmxs deps on files using the files declared by coqdep.

Since we have the full list of plugins, we might as well compute the cmxs deps (of the transitive closure) ourselves and add them to the Coq rules. Whether or not these files actually load these cmxs files is irrelevant but making them present is important.
