### PR TITLE
Make `dune describe` correctly handle overlapping implementations for virtual libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.4.0 (Unreleased)
 ------------------
 
+- Make `dune describe` correctly handle overlapping implementations
+  for virtual libraries (#5971, fixes #5747, @esope)
+
 - Building the `@check` alias should make sure the libraries and executables
   don't have dependency cycles (#5892, @rgrinberg)
 

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -176,6 +176,14 @@ end
 
 val closure : t list -> linking:bool -> t list Resolve.Memo.t
 
+(** [descriptive_closure libs] computes the smallest set of libraries that
+    contains the libraries in the list [libs], and that is transitively closed.
+    The output list is guaranteed to have no duplicates and to be sorted. The
+    difference with [closure libs] is that the latter may raise an error when
+    overlapping implementations of virtual libraries are detected.
+    [descriptive_closure libs] makes no such check. *)
+val descriptive_closure : t list -> t list Memo.t
+
 (** {1 Sub-systems} *)
 
 module Sub_system : sig

--- a/test/blackbox-tests/test-cases/describe.t
+++ b/test/blackbox-tests/test-cases/describe.t
@@ -185,6 +185,28 @@ Setup
 
   $ touch re_lib1.re re_lib2.re re_lib2.rei
 
+  $ mkdir virtual
+  $ cat >virtual/dune <<EOF
+  > (library
+  >  (name virtual)
+  >  (virtual_modules virtual))
+  > EOF
+  $ touch virtual/virtual.mli
+  $ mkdir virtual_impl1
+  $ cat >virtual_impl1/dune <<EOF
+  > (library
+  >  (name virtual_impl1)
+  >  (implements virtual))
+  > EOF
+  $ touch virtual_impl1/virtual.ml
+  $ mkdir virtual_impl2
+  $ cat >virtual_impl2/dune <<EOF
+  > (library
+  >  (name virtual_impl2)
+  >  (implements virtual))
+  > EOF
+  $ touch virtual_impl2/virtual.ml
+
 Describe various things
 -----------------------
 
@@ -598,7 +620,60 @@ not stable across different setups.
      (requires ())
      (source_dir /FINDLIB//stdlib-shims)
      (modules ())
-     (include_dirs (/FINDLIB//stdlib-shims)))))
+     (include_dirs (/FINDLIB//stdlib-shims))))
+   (library
+    ((name virtual)
+     (uid f0299ba46dc29b8d4bd2f5d1cf82587c)
+     (local true)
+     (requires ())
+     (source_dir _build/default/virtual)
+     (modules
+      (((name Virtual)
+        (impl ())
+        (intf (_build/default/virtual/virtual.mli))
+        (cmt ())
+        (cmti (_build/default/virtual/.virtual.objs/byte/virtual.cmti)))))
+     (include_dirs (_build/default/virtual/.virtual.objs/byte))))
+   (library
+    ((name virtual_impl1)
+     (uid 243949502d62f27969aff867fdfb0c6a)
+     (local true)
+     (requires (f0299ba46dc29b8d4bd2f5d1cf82587c))
+     (source_dir _build/default/virtual_impl1)
+     (modules
+      (((name Virtual)
+        (impl (_build/default/virtual_impl1/virtual.ml))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl1/.virtual_impl1.objs/byte/virtual.cmt))
+        (cmti ()))
+       ((name Virtual__virtual_impl1__)
+        (impl (_build/default/virtual_impl1/virtual__virtual_impl1__.ml-gen))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl1/.virtual_impl1.objs/byte/virtual__virtual_impl1__.cmt))
+        (cmti ()))))
+     (include_dirs (_build/default/virtual_impl1/.virtual_impl1.objs/byte))))
+   (library
+    ((name virtual_impl2)
+     (uid bfe8d16a00ac2473ce3fc5fc99d7c6cb)
+     (local true)
+     (requires (f0299ba46dc29b8d4bd2f5d1cf82587c))
+     (source_dir _build/default/virtual_impl2)
+     (modules
+      (((name Virtual)
+        (impl (_build/default/virtual_impl2/virtual.ml))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl2/.virtual_impl2.objs/byte/virtual.cmt))
+        (cmti ()))
+       ((name Virtual__virtual_impl2__)
+        (impl (_build/default/virtual_impl2/virtual__virtual_impl2__.ml-gen))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl2/.virtual_impl2.objs/byte/virtual__virtual_impl2__.cmt))
+        (cmti ()))))
+     (include_dirs (_build/default/virtual_impl2/.virtual_impl2.objs/byte)))))
 
   $ dune describe workspace --lang 0.1 --with-deps --sanitize-for-tests
   ((executables
@@ -1104,7 +1179,73 @@ not stable across different setups.
      (requires ())
      (source_dir /FINDLIB//stdlib-shims)
      (modules ())
-     (include_dirs (/FINDLIB//stdlib-shims)))))
+     (include_dirs (/FINDLIB//stdlib-shims))))
+   (library
+    ((name virtual)
+     (uid f0299ba46dc29b8d4bd2f5d1cf82587c)
+     (local true)
+     (requires ())
+     (source_dir _build/default/virtual)
+     (modules
+      (((name Virtual)
+        (impl ())
+        (intf (_build/default/virtual/virtual.mli))
+        (cmt ())
+        (cmti (_build/default/virtual/.virtual.objs/byte/virtual.cmti))
+        (module_deps ((for_intf ()) (for_impl ()))))))
+     (include_dirs (_build/default/virtual/.virtual.objs/byte))))
+   (library
+    ((name virtual_impl1)
+     (uid 243949502d62f27969aff867fdfb0c6a)
+     (local true)
+     (requires (f0299ba46dc29b8d4bd2f5d1cf82587c))
+     (source_dir _build/default/virtual_impl1)
+     (modules
+      (((name Virtual)
+        (impl (_build/default/virtual_impl1/virtual.ml))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl1/.virtual_impl1.objs/byte/virtual.cmt))
+        (cmti ())
+        (module_deps
+         ((for_intf ())
+          (for_impl ()))))
+       ((name Virtual__virtual_impl1__)
+        (impl (_build/default/virtual_impl1/virtual__virtual_impl1__.ml-gen))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl1/.virtual_impl1.objs/byte/virtual__virtual_impl1__.cmt))
+        (cmti ())
+        (module_deps
+         ((for_intf ())
+          (for_impl ()))))))
+     (include_dirs (_build/default/virtual_impl1/.virtual_impl1.objs/byte))))
+   (library
+    ((name virtual_impl2)
+     (uid bfe8d16a00ac2473ce3fc5fc99d7c6cb)
+     (local true)
+     (requires (f0299ba46dc29b8d4bd2f5d1cf82587c))
+     (source_dir _build/default/virtual_impl2)
+     (modules
+      (((name Virtual)
+        (impl (_build/default/virtual_impl2/virtual.ml))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl2/.virtual_impl2.objs/byte/virtual.cmt))
+        (cmti ())
+        (module_deps
+         ((for_intf ())
+          (for_impl ()))))
+       ((name Virtual__virtual_impl2__)
+        (impl (_build/default/virtual_impl2/virtual__virtual_impl2__.ml-gen))
+        (intf ())
+        (cmt
+         (_build/default/virtual_impl2/.virtual_impl2.objs/byte/virtual__virtual_impl2__.cmt))
+        (cmti ())
+        (module_deps
+         ((for_intf ())
+          (for_impl ()))))))
+     (include_dirs (_build/default/virtual_impl2/.virtual_impl2.objs/byte)))))
 
 
 Test other formats


### PR DESCRIPTION
Fixes issue #5747

Here is what happened before this fix: if your project was using a
virtual library and at least two implementations for that virtual
library, then dune describe would not produce any information for the
libraries of your project (it would only show information about the
executables, if there were any). The issue was in the computation of
the transitive closure of libraires, that raised an error by default
in the presence of overlapping implementations of virtual libraries.
In such a case, the error was treated by discarding all information
about the libraries.

The fix consists in computing the transitive closure of libraries
without performing any overlap checks between implementations of a
virtual library. We have defined the `descriptive_closure` function
for this very purpose.

The overlap check is necessary when you compute the transitive closure
of libraries that you intend to build (otherwise you do not know which
implementation should be picked).

In dune describe, you want to describe the whole workspace, regardless
of what you want to build or not, which means that you need to handle
all the libraries of your workspace, that may include several
implementations for virtual modules.

If you absolutely want to perform the overlap check in dune describe,
then will not always be able to describe the whole workspace.

Signed-off-by: Benoît Montagu <benoit.montagu@inria.fr>