### PR TITLE
ocamlc-loc: correctly skip excerpts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@
   flashing errors on insignificant file system events such as changes in the
   `.git/` directory. (#5953, @rgrinberg)
 
+- Fix parsing more more error messages emitted by the OCaml compiler. In
+  particular, messages where the excerpt line number started with a blank
+  character were skipped. (#5981, @rgrinberg)
+
 3.3.1 (19-06-2022)
 ------------------
 

--- a/otherlibs/ocamlc_loc/src/lexer.mll
+++ b/otherlibs/ocamlc_loc/src/lexer.mll
@@ -50,7 +50,7 @@ let digits = ['0' - '9']+
 let range = digits "-" digits
 
 rule skip_excerpt = parse
-  | digits " | " [^ '\n']* "\n"
+  | blank digits " | " [^ '\n']* "\n"
     { skip_excerpt lexbuf }
   | blank '^'+ blank "\n"
     { () }

--- a/otherlibs/ocamlc_loc/test/ocamlc_loc_tests.ml
+++ b/otherlibs/ocamlc_loc/test/ocamlc_loc_tests.ml
@@ -271,3 +271,19 @@ Will be removed past 2020-20-20. Use Mylib.Intf_only instead.
     ; related = []
     ; severity = Error Some "deprecated"
     } |}]
+
+let%expect_test "undefined fields" =
+  let raw_error =
+    {|
+File "test/expect-tests/timer_tests.ml", lines 6-10, characters 2-3:
+ 6 | ..{ Scheduler.Config.concurrency = 1
+ 7 |   ; display = { verbosity = Short; status_line = false }
+ 8 |   ; stats = None
+ 9 |   ; insignificant_changes = `React
+10 |   }
+Error: Some record fields are undefined: signal_watcher
+|}
+    |> String.trim
+  in
+  Ocamlc_loc.parse raw_error |> Test.print_errors;
+  [%expect {| |}]

--- a/otherlibs/ocamlc_loc/test/ocamlc_loc_tests.ml
+++ b/otherlibs/ocamlc_loc/test/ocamlc_loc_tests.ml
@@ -286,4 +286,15 @@ Error: Some record fields are undefined: signal_watcher
     |> String.trim
   in
   Ocamlc_loc.parse raw_error |> Test.print_errors;
-  [%expect {| |}]
+  [%expect
+    {|
+    >> error 0
+    { loc =
+        { path = "test/expect-tests/timer_tests.ml"
+        ; line = Range 6,10
+        ; chars = Some (2, 3)
+        }
+    ; message = "Some record fields are undefined: signal_watcher"
+    ; related = []
+    ; severity = Error None
+    } |}]


### PR DESCRIPTION
excerpts may start with blank characters