### PR TITLE
fix: disable signal handling for subst/merlin

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -128,6 +128,7 @@ let () =
     ; display = { verbosity = Quiet; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
+    ; signal_watcher = `No
     }
   in
   let clean, zero =

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -9,6 +9,7 @@ let config =
   ; display = { verbosity = Short; status_line = false }
   ; stats = None
   ; insignificant_changes = `React
+  ; signal_watcher = `No
   }
 
 let setup =

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -130,6 +130,7 @@ module Scheduler = struct
     let config =
       let insignificant_changes = Common.insignificant_changes common in
       Dune_config.for_scheduler dune_config stats ~insignificant_changes
+        ~signal_watcher:`Yes
     in
     Scheduler.Run.go config ~on_event:(on_event dune_config) f
 
@@ -139,6 +140,7 @@ module Scheduler = struct
     let config =
       let insignificant_changes = Common.insignificant_changes common in
       Dune_config.for_scheduler dune_config stats ~insignificant_changes
+        ~signal_watcher:`Yes
     in
     let file_watcher = Common.file_watcher common in
     let rpc = Common.rpc common in

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -436,7 +436,8 @@ let term =
   Log.init_disabled ();
   Dune_engine.Scheduler.Run.go
     ~on_event:(fun _ _ -> ())
-    (Dune_config.for_scheduler config None ~insignificant_changes:`React)
+    (Dune_config.for_scheduler config None ~insignificant_changes:`React
+       ~signal_watcher:`No)
     subst
 
 let command = (term, info)

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -425,7 +425,7 @@ let auto_concurrency =
       in
       loop commands)
 
-let for_scheduler (t : t) stats ~insignificant_changes =
+let for_scheduler (t : t) stats ~insignificant_changes ~signal_watcher =
   let concurrency =
     match t.concurrency with
     | Fixed i -> i
@@ -438,4 +438,5 @@ let for_scheduler (t : t) stats ~insignificant_changes =
   ; display = t.display
   ; stats
   ; insignificant_changes
+  ; signal_watcher
   }

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -120,4 +120,5 @@ val for_scheduler :
      t
   -> Dune_stats.t option
   -> insignificant_changes:[ `React | `Ignore ]
+  -> signal_watcher:[ `Yes | `No ]
   -> Dune_engine.Scheduler.Config.t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -27,6 +27,7 @@ module Config : sig
     ; display : Display.t
     ; stats : Dune_stats.t option
     ; insignificant_changes : [ `Ignore | `React ]
+    ; signal_watcher : [ `Yes | `No ]
     }
 end
 

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -75,6 +75,7 @@ let%expect_test "csexp server life cycle" =
     ; display = { verbosity = Quiet; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
+    ; signal_watcher = `No
     }
   in
   Scheduler.Run.go config run ~on_event:(fun _ _ -> ());

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -167,6 +167,7 @@ let config =
   ; display = { verbosity = Quiet; status_line = false }
   ; stats = None
   ; insignificant_changes = `React
+  ; signal_watcher = `No
   }
 
 let run run =

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -49,6 +49,7 @@ let run =
     ; display = { verbosity = Quiet; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
+    ; signal_watcher = `No
     }
   in
   fun run ->

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -8,6 +8,7 @@ let go =
     ; display = { verbosity = Short; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
+    ; signal_watcher = `Yes
     }
   in
   Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ())

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -8,6 +8,7 @@ let default =
   ; display = { verbosity = Short; status_line = false }
   ; stats = None
   ; insignificant_changes = `React
+  ; signal_watcher = `No
   }
 
 let go ?(timeout = 0.3) ?(config = default) f =

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -7,6 +7,7 @@ let config =
   ; display = { verbosity = Short; status_line = false }
   ; stats = None
   ; insignificant_changes = `React
+  ; signal_watcher = `No
   }
 
 let%expect_test "create and wait for timer" =

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -115,6 +115,7 @@ let run kind script =
     ; display = { verbosity = Short; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
+    ; signal_watcher = `No
     }
   in
   Scheduler.Run.go


### PR DESCRIPTION
These subcommands do not build anything and hence should be
interruptible with C-c

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: d4aae9a9-9625-42c4-82df-3f30213ab0b0