### PR TITLE
WIP on #6005: let compositional Coq builds reuse artifacts regardless of current root

### DIFF
--- a/test/blackbox-tests/test-cases/coq/compose-projects-private-ambiguous.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-private-ambiguous.t/run.t
@@ -10,7 +10,7 @@ which complains.
 
   $ dune build B
   *** Warning: in file b.v, library a is required from root A and has not been found in the loadpath!
-  File "./B/b.v", line 2, characters 0-24:
+  File "./b.v", line 2, characters 0-24:
   Error: Cannot find a physical path bound to logical path a with prefix A.
   
   [1]
@@ -18,7 +18,7 @@ which complains.
   $ dune build C
   *** Warning: in file c.v, library a is required from root A and has not been found in the loadpath!
   *** Warning: in file a.v, library A is required from root C and has not been found in the loadpath!
-  File "./C/c.v", line 2, characters 0-24:
+  File "./c.v", line 2, characters 0-24:
   Error: Cannot find a physical path bound to logical path a with prefix A.
   
   File "C/A_vendored/dune", line 1, characters 0-36:
@@ -29,7 +29,7 @@ which complains.
   $TESTCASE_ROOT/_build/default/C/A_vendored
   was previously bound to C.A_vendored; it is remapped to A
   [overriding-logical-loadpath,loadpath]
-  File "./C/A_vendored/a.v", line 1, characters 0-24:
+  File "./a.v", line 1, characters 0-24:
   Error: Cannot find a physical path bound to logical path A with prefix C.
   
   [1]
@@ -45,7 +45,7 @@ which complains.
   $TESTCASE_ROOT/_build/default/C/A_vendored
   was previously bound to C.A_vendored; it is remapped to A
   [overriding-logical-loadpath,loadpath]
-  File "./C/A_vendored/a.v", line 1, characters 0-24:
+  File "./a.v", line 1, characters 0-24:
   Error: Cannot find a physical path bound to logical path A with prefix C.
   
   [1]


### PR DESCRIPTION
In this MR, I try changing the current folder used for building so that it does not vary in compositional builds.

That appears to make some difference — the `coqc` command-line is the same as hoped! But the cache seems to still not share results, possibly because the `cd` command is part of the command line used for caching?

Building with `--root stdpp` — see we `cd _build/default/theories`
```
Running[64]: (cd _build/default/theories && /Users/pgiarrusso1/.opam/dune-dev/bin/coqc -q -w -deprecated-hint-rewrite-without-locality -w -deprecated-typeclasses-transparency-without-locality -w -deprecated-syntactic-definition -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . stdpp list.v)
```

Building with `--root .`
```
Running[64]: (cd _build/default/stdpp/theories && /Users/pgiarrusso1/.opam/dune-dev/bin/coqc -q -w -deprecated-hint-rewrite-without-locality -w -deprecated-typeclasses-transparency-without-locality -w -deprecated-syntactic-definition -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . stdpp list.v)
```
