### PR TITLE
Fix dune-project cram stanza documentation

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -67,7 +67,7 @@ details.
 
    (cram <status>)
 
-Where status is either ``enabled`` or ``disabled``.
+Where status is either ``enable`` or ``disable``.
 
 .. _implicit_transitive_deps:
 


### PR DESCRIPTION
Recently had to disable the cram test project-wide and got the following error after I followed the doc:
```
$ dune runtest
File "dune-project", line 43, characters 6-14:
43 | (cram disabled)
           ^^^^^^^^
Error: must be 'disable' or 'enable'
```