### PR TITLE
Reproducing example for failing coq cram test.

### DIFF
--- a/test/blackbox-tests/test-cases/cram/coq-theory-dep.t
+++ b/test/blackbox-tests/test-cases/cram/coq-theory-dep.t
@@ -1,0 +1,56 @@
+  $ mkdir -p theory test/usetheory.t
+
+  $ cat >dune-project<<EOF
+  > (lang dune 3.4)
+  > (using coq 0.5)
+  > EOF
+
+  $ touch hello-world.opam
+
+  $ cat >theory/dune<<EOF
+  > (coq.theory
+  >  (name hello.world)
+  >  (package hello-world))
+  > EOF
+
+  $ cat >theory/hello_world.v<<EOF
+  > From Coq.Strings Require Import String.
+  > 
+  > Definition hello_world : string := "Hello, World!".
+  > EOF
+
+  $ cat >test/dune<<EOF
+  > (cram
+  >  (deps
+  >   (package hello-world)))
+  > EOF
+
+  $ cat >test/usetheory.t/dune<<EOF
+  > (coq.theory
+  >  (name hello)
+  >  (theories hello.world))
+  > EOF
+
+  $ cat >test/usetheory.t/dune-project<<EOF
+  > (lang dune 3.4)
+  > (using coq 0.5)
+  > EOF
+
+  $ cat >test/usetheory.t/hello.v<<EOF
+  > From hello.world Require Import hello_world.
+  > 
+  > Eval simpl in hello_world.
+  > EOF
+
+  $ cat >test/usetheory.t/run.t<<EOF
+  >   $ dune build
+  >   XXX
+  > EOF
+
+The following should succeed.
+
+  $ dune build @usetheory
+  File "test/usetheory.t/run.t", line 1, characters 0-0:
+  Error: Files _build/default/test/usetheory.t/run.t and
+  _build/default/test/usetheory.t/run.t.corrected differ.
+  [1]


### PR DESCRIPTION
A similar example works for OCaml (see working code in https://github.com/ocaml/dune/pull/6011), so this should probably also work for Coq to give us reasonable cram test support. Such tests are probably not intended for that kind of usage, but that would still be better than nothing.