### PR TITLE
refactor(scheduler): remove dead code

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1399,10 +1399,6 @@ let sleep duration =
     (* cancellation mechanism isn't exposed to the user *)
     assert false
 
-let flush_file_watcher () =
-  let* t = t () in
-  flush_file_watcher t
-
 let wait_for_build_input_change () =
   let* t = t () in
   wait_for_build_input_change t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -177,10 +177,6 @@ val inject_memo_invalidation : Memo.Invalidation.t -> unit Fiber.t
     this long. *)
 val sleep : float -> unit Fiber.t
 
-(** Wait until all file system changes that happened so far have been
-    acknowledged by the scheduler. *)
-val flush_file_watcher : unit -> unit Fiber.t
-
 (** Wait for a build input to change. If a build input change was seen but
     hasn't been handled yet, return immediately.
 


### PR DESCRIPTION
[Scheduler.flush_file_watcher] isn't used anywhere

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 7305f061-b5cc-4ab9-b79a-8010940e715c