### PR TITLE
refactor(engine): move execution_parameters_of_dir

### DIFF
--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -507,6 +507,19 @@ end = struct
     | Promote promote, (Some Automatically | None) ->
       Target_promotion.promote ~dir ~targets ~promote ~promote_source
 
+  let execution_parameters_of_dir =
+    let f path =
+      let+ dir = Source_tree.nearest_dir path
+      and+ ep = Execution_parameters.default in
+      Dune_project.update_execution_parameters (Source_tree.Dir.project dir) ep
+    in
+    let memo =
+      Memo.create "execution-parameters-of-dir"
+        ~input:(module Path.Source)
+        ~cutoff:Execution_parameters.equal f
+    in
+    Memo.exec memo
+
   let execute_rule_impl ~rule_kind rule =
     let { Rule.id = _; targets; dir; context; mode; action; info = _; loc } =
       rule
@@ -521,7 +534,7 @@ end = struct
       match Dpath.Target_dir.of_target dir with
       | Regular (With_context (_, dir))
       | Anonymous_action (With_context (_, dir)) ->
-        Source_tree.execution_parameters_of_dir dir
+        execution_parameters_of_dir dir
       | _ -> Execution_parameters.default
     in
     (* Note: we do not run the below in parallel with the above: if we fail to

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -693,19 +693,6 @@ let nearest_dir path =
   let* root = root () in
   nearest_dir root components
 
-let execution_parameters_of_dir =
-  let f path =
-    let+ dir = nearest_dir path
-    and+ ep = Execution_parameters.default in
-    Dune_project.update_execution_parameters (Dir0.project dir) ep
-  in
-  let memo =
-    Memo.create "execution-parameters-of-dir"
-      ~input:(module Path.Source)
-      ~cutoff:Execution_parameters.equal f
-  in
-  Memo.exec memo
-
 let nearest_vcs path =
   let* dir = nearest_dir path in
   match Dir0.vcs dir with

--- a/src/dune_engine/source_tree.mli
+++ b/src/dune_engine/source_tree.mli
@@ -95,9 +95,6 @@ val is_vendored : Path.Source.t -> bool Memo.t
 (** [true] iff the path is a file *)
 val file_exists : Path.Source.t -> bool Memo.t
 
-(** Return the execution parameters for the following directory *)
-val execution_parameters_of_dir : Path.Source.t -> Execution_parameters.t Memo.t
-
 (**/**)
 
 (* Hook to describe how to filter source files. This can be used by forks of


### PR DESCRIPTION
Move it into [Build_system] as this is only place where this is used.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: a12ab53c-2569-45ba-973b-cb18ae92715d