### PR TITLE
dune exec: support pform syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@
 
 - Fix compilation of Dune under esy on Windows (#6109, fixes #6098, @nojb)
 
+- `dune exec`: support syntax like `%{bin:program}`. This can appear anywhere
+  in the command line, so things like `dune exec time %{bin:program}` now work.
+  (#6035, fixes #2691, @emillon)
+
 3.4.1 (26-07-2022)
 ------------------
 

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -38,7 +38,7 @@ type program_name =
 
 let parse_program_name s =
   match Arg.conv_parser Arg.dep s with
-  | Ok (File sw) when String.starts_with ~prefix:"%" s -> Sw sw
+  | Ok (File sw) when Dune_lang.String_with_vars.has_pforms sw -> Sw sw
   | _ -> String s
 
 type cli_item =

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -102,7 +102,7 @@ let resolve_path path ~(setup : Dune_rules.Main.build_system) =
     | Some res -> Memo.return (Ok res)
     | None -> can't_build path)
 
-let expand_path (root : Workspace_root.t)
+let expand_path_from_root (root : Workspace_root.t)
     ~(setup : Dune_rules.Main.build_system) ctx sv =
   let sctx =
     Dune_engine.Context_name.Map.find_exn setup.scontexts (Context.name ctx)
@@ -118,7 +118,11 @@ let expand_path (root : Workspace_root.t)
     Dune_rules.Dir_contents.add_sources_to_expander sctx expander
   in
   let+ s = Dune_rules.Expander.expand_str expander sv in
-  Path.relative Path.root (root.reach_from_root_prefix ^ s)
+  root.reach_from_root_prefix ^ s
+
+let expand_path root ~setup ctx sv =
+  let+ s = expand_path_from_root root ~setup ctx sv in
+  Path.relative Path.root s
 
 let resolve_alias root ~recursive sv ~(setup : Dune_rules.Main.build_system) =
   match Dune_lang.String_with_vars.text_only sv with

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -6,3 +6,10 @@ val interpret_targets :
   -> Dune_rules.Main.build_system
   -> Arg.Dep.t list
   -> unit Dune_engine.Action_builder.t
+
+val expand_path_from_root :
+     Workspace_root.t
+  -> setup:Dune_rules.Main.build_system
+  -> Dune_rules.Context.t
+  -> Dune_lang.String_with_vars.t
+  -> string Dune_engine.Action_builder.t

--- a/test/blackbox-tests/test-cases/exec-bin.t
+++ b/test/blackbox-tests/test-cases/exec-bin.t
@@ -1,0 +1,76 @@
+  $ cat > dune-project << EOF
+  > (lang dune 1.1)
+  > 
+  > (package
+  >  (name e))
+  > EOF
+  $ cat > dune << EOF
+  > (executable
+  >  (public_name e))
+  > EOF
+
+The executable just displays "Hello" and its arguments.
+
+  $ cat > e.ml << EOF
+  > let () =
+  >   print_endline "Hello";
+  >   Array.iteri (fun i s ->
+  >     Printf.printf "argv[%d] = %s\n" i s
+  >     ) Sys.argv
+  > EOF
+
+By default, e is executed with the program name and arguments in argv.
+
+  $ dune exec ./e.exe a b c
+  Hello
+  argv[0] = _build/default/e.exe
+  argv[1] = a
+  argv[2] = b
+  argv[3] = c
+
+The special form %{bin:public_name} is supported.
+
+  $ dune exec %{bin:e} a b c
+  Hello
+  argv[0] = _build/install/default/bin/e
+  argv[1] = a
+  argv[2] = b
+  argv[3] = c
+
+This wrapper parses its own arguments and executes the rest.
+
+  $ cat > wrap.sh << 'EOF'
+  > #!/bin/bash
+  > while getopts "xy" o; do
+  >   echo "Got option: $o"
+  > done
+  > shift $((OPTIND-1))
+  > echo Before
+  > "$@"
+  > echo After
+  > EOF
+  $ chmod +x wrap.sh
+
+It is possible to put the %{bin:...} pform in arguments rather than first.
+
+  $ dune exec -- ./wrap.sh -x -y %{bin:e} a b c
+  Got option: x
+  Got option: y
+  Before
+  Hello
+  argv[0] = _build/install/default/bin/e
+  argv[1] = a
+  argv[2] = b
+  argv[3] = c
+  After
+
+The first item is still looked up in PATH.
+
+  $ dune exec ls %{bin:e}
+  _build/install/default/bin/e
+
+Pforms can appear several times.
+
+  $ dune exec ls %{bin:e} %{bin:e}
+  _build/install/default/bin/e
+  _build/install/default/bin/e


### PR DESCRIPTION
This supports things like `dune exec time %{bin:e}`.

The syntax is consistent with what support in `dune build` and backwards compatible in cases where no arguments start with `%`.

The resolution mechanism is slightly different for the program and the rest of the arguments:

- the program is always considered a possible dependency, either in pform syntax (`%{bin:e}` or in string syntax (`./path/to/e`, `_build/default/path/to/e`).
- arguments are only interpreted as dependencies if they are in pform syntax.

Closes #2691
