### PR TITLE
[emacs] adapt dune-watch-minor-mode to change of header

### DIFF
--- a/editor-integration/emacs/dune-watch.el
+++ b/editor-integration/emacs/dune-watch.el
@@ -69,8 +69,8 @@
 (defconst dune-watch-process-name "*dune-watch-process*"
   "Name of process used to run dune watch.")
 
-(defconst dune-watch-header "********** NEW BUILD **********"
-  "Header of dune watch output.")
+(defconst dune-watch-header "********** NEW BUILD"
+  "Prefix of the header of dune watch output.")
 
 (defconst dune-watch-read-prompt "dune task (default: %s): "
   "Prompt displayed to the user to dune task.")


### PR DESCRIPTION
The header printed by dune watch contains variable information (file that changed).

As the dune-watch mode search for the header to erase from the buffer the previous compilation output, we should just search for the prefix of the header. If not, the header is never found and thus the successive compilation results are not erased but stacked in the buffer.