### PR TITLE
refactor: introduce [Path.Outside_build_dir.t]

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -121,7 +121,7 @@ let () =
   let dir = Temp.create Dir ~prefix:"dune" ~suffix:"bench" in
   Sys.chdir (Path.to_string dir);
   Path.as_external dir |> Option.value_exn |> Path.set_root;
-  Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");
+  Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build");
   let module Scheduler = Dune_engine.Scheduler in
   let config =
     { Scheduler.Config.concurrency = 10

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -15,7 +15,7 @@ let config =
 let setup =
   lazy
     (Path.set_root (Path.External.cwd ());
-     Path.Build.set_build_dir (Path.Build.Kind.of_string "_build"))
+     Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build"))
 
 let prog = Option.value_exn (Bin.which ~path:(Env.path Env.initial) "true")
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -141,7 +141,7 @@ let print_entering_message c =
 let init ?log_file c =
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;
   Path.set_root (normalize_path (Path.External.cwd ()));
-  Path.Build.set_build_dir (Path.Build.Kind.of_string c.build_dir);
+  Path.Build.set_build_dir (Path.Outside_build_dir.of_string c.build_dir);
   (* We need to print this before reading the workspace file, so that the editor
      can interpret errors in the workspace file. *)
   print_entering_message c;

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -431,7 +431,7 @@ let term =
   in
   Dune_engine.Clflags.debug_backtraces debug_backtraces;
   Path.set_root (Path.External.cwd ());
-  Path.Build.set_build_dir (Path.Build.Kind.of_string Common.default_build_dir);
+  Path.Build.set_build_dir (Path.Outside_build_dir.of_string Common.default_build_dir);
   Dune_config.init config;
   Log.init_disabled ();
   Dune_engine.Scheduler.Run.go

--- a/otherlibs/stdune/path.mli
+++ b/otherlibs/stdune/path.mli
@@ -134,6 +134,16 @@ module Permissions : sig
   val remove : t -> int -> int
 end
 
+module Outside_build_dir : sig
+  type t =
+    | External of External.t
+    | In_source_dir of Source.t
+
+  val of_string : string -> t
+
+  val to_string_maybe_quoted : t -> string
+end
+
 module Build : sig
   type w
 
@@ -182,17 +192,9 @@ module Build : sig
       "righter" type. *)
   val extract_first_component : t -> (string * Local.t) option
 
-  module Kind : sig
-    type t = private
-      | External of External.t
-      | In_source_dir of Local.t
-
-    val of_string : string -> t
-  end
-
   (** Set the build directory. Can only be called once and must be done before
       paths are converted to strings elsewhere. *)
-  val set_build_dir : Kind.t -> unit
+  val set_build_dir : Outside_build_dir.t -> unit
 
   val split_sandbox_root : t -> t option * t
 

--- a/test/expect-tests/common/dune_tests_common.ml
+++ b/test/expect-tests/common/dune_tests_common.ml
@@ -9,7 +9,7 @@ let init =
     lazy
       (Printexc.record_backtrace false;
        Path.set_root (Path.External.cwd ());
-       Path.Build.set_build_dir (Path.Build.Kind.of_string "_build");
+       Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build");
        Console.Backend.(set dumb);
        Dune_util.Log.init ())
   in

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_lib.ml
@@ -12,7 +12,7 @@ let init () =
   let () = try Unix.mkdir tmp_dir 0o777 with _ -> () in
   Unix.chdir tmp_dir;
   Path.set_root (Path.External.of_string tmp_dir);
-  Path.Build.set_build_dir (Path.Build.Kind.of_string "_build")
+  Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build")
 
 let now () = Unix.gettimeofday ()
 

--- a/test/unit-tests/artifact_substitution/artifact_substitution.ml
+++ b/test/unit-tests/artifact_substitution/artifact_substitution.ml
@@ -4,7 +4,7 @@ module Re = Dune_re
 
 let () =
   Path.set_root (Path.External.cwd ());
-  Path.Build.set_build_dir (Path.Build.Kind.of_string "_build")
+  Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build")
 
 let fail fmt =
   Printf.ksprintf


### PR DESCRIPTION
This is clearer than [Path.Build.Kind] and is useful in other contexts
as well

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 18030879-bae6-43eb-8283-1cac3f5340ea