### PR TITLE
refactor(chrome-trace): use a single [Id] type

### DIFF
--- a/otherlibs/chrome-trace/src/chrome_trace.ml
+++ b/otherlibs/chrome-trace/src/chrome_trace.ml
@@ -32,22 +32,24 @@ end = struct
     `Int n
 end
 
+module Id = struct
+  type t =
+    [ `Int of int
+    | `String of string
+    ]
+
+  let create x = x
+
+  let to_string = function
+    | `String s -> s
+    | `Int i -> string_of_int i
+
+  let to_json (t : t) = (t :> Json.t)
+
+  let field id = ("id", to_json id)
+end
+
 module Stack_frame = struct
-  module Id = struct
-    type t =
-      [ `String of string
-      | `Int of int
-      ]
-
-    let to_json (t : t) : Json.t = (t :> Json.t)
-
-    let to_string = function
-      | `String s -> s
-      | `Int i -> string_of_int i
-
-    let create x : t = x
-  end
-
   module Raw = struct
     type t = string list
 
@@ -87,8 +89,7 @@ module Event = struct
     ; pid : int
     ; tid : int
     ; cname : string option
-    ; stackframe :
-        [ `Id of Stack_frame.Id.t | `Raw of Stack_frame.Raw.t ] option
+    ; stackframe : [ `Id of Id.t | `Raw of Stack_frame.Raw.t ] option
     }
 
   let common_fields ?tts ?cname ?(cat = []) ?(pid = 0) ?(tid = 0) ?stackframe
@@ -110,18 +111,6 @@ module Event = struct
     | End
 
   type args = (string * Json.t) list
-
-  module Id = struct
-    type t =
-      | Int of int
-      | String of string
-
-    let to_json = function
-      | Int i -> `Int i
-      | String s -> `String s
-
-    let field id = ("id", to_json id)
-  end
 
   type object_kind =
     | New
@@ -213,7 +202,7 @@ module Event = struct
     add_field_opt
       (fun stackframe ->
         match stackframe with
-        | `Id id -> ("sf", Stack_frame.Id.to_json id)
+        | `Id id -> ("sf", Id.to_json id)
         | `Raw r -> ("stack", Stack_frame.Raw.to_json r))
       stackframe fields
 
@@ -327,7 +316,7 @@ module Output_object = struct
   type t =
     { displayTimeUnit : [ `Ms | `Ns ] option
     ; traceEvents : Event.t list
-    ; stackFrames : (Stack_frame.Id.t * Stack_frame.t) list option
+    ; stackFrames : (Id.t * Stack_frame.t) list option
     ; extra_fields : (string * Json.t) list option
     }
 
@@ -352,7 +341,7 @@ module Output_object = struct
       | Some frames ->
         let frames =
           List.map frames ~f:(fun (id, frame) ->
-              let id = Stack_frame.Id.to_string id in
+              let id = Id.to_string id in
               (id, Stack_frame.to_json frame))
         in
         ("stackFrames", `Assoc frames) :: json

--- a/otherlibs/chrome-trace/src/chrome_trace.mli
+++ b/otherlibs/chrome-trace/src/chrome_trace.mli
@@ -24,13 +24,13 @@ module Json : sig
     ]
 end
 
+module Id : sig
+  type t
+
+  val create : [ `String of string | `Int of int ] -> t
+end
+
 module Stack_frame : sig
-  module Id : sig
-    type t
-
-    val create : [ `String of string | `Int of int ] -> t
-  end
-
   module Raw : sig
     type t
 
@@ -53,12 +53,6 @@ module Event : sig
     val to_float_seconds : t -> float
   end
 
-  module Id : sig
-    type t =
-      | Int of int
-      | String of string
-  end
-
   type common_fields
 
   val common_fields :
@@ -67,7 +61,7 @@ module Event : sig
     -> ?cat:string list
     -> ?pid:int
     -> ?tid:int
-    -> ?stackframe:[ `Id of Stack_frame.Id.t | `Raw of Stack_frame.Raw.t ]
+    -> ?stackframe:[ `Id of Id.t | `Raw of Stack_frame.Raw.t ]
     -> ts:Timestamp.t
     -> name:string
     -> unit
@@ -103,7 +97,7 @@ module Output_object : sig
   val create :
        ?displayTimeUnit:[ `Ms | `Ns ]
     -> ?extra_fields:(string * Json.t) list
-    -> ?stackFrames:(Stack_frame.Id.t * Stack_frame.t) list
+    -> ?stackFrames:(Id.t * Stack_frame.t) list
     -> traceEvents:Event.t list
     -> unit
     -> t

--- a/otherlibs/chrome-trace/test/chrome_trace_tests.ml
+++ b/otherlibs/chrome-trace/test/chrome_trace_tests.ml
@@ -12,7 +12,7 @@ let c =
 
 let () =
   let module Event = Chrome_trace.Event in
-  let module Id = Event.Id in
+  let module Id = Chrome_trace.Id in
   let module Timestamp = Event.Timestamp in
   let events =
     [ Event.complete
@@ -26,7 +26,9 @@ let () =
            ~ts:(Timestamp.of_float_seconds 0.5)
            ~name:"cnt" ())
         [ ("bar", `Int 250) ]
-    ; Event.async (Id.String "foo") Event.Start
+    ; Event.async
+        (Id.create (`String "foo"))
+        Event.Start
         (Event.common_fields
            ~ts:(Timestamp.of_float_seconds 0.5)
            ~name:"async" ())

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -591,7 +591,9 @@ let report_process_start stats ~metadata ~id ~pid ~prog ~args ~now =
     ; ("pid", `Int (Pid.to_int pid))
     ]
   in
-  let event = Event.async (Int id) ~args Start common in
+  let event =
+    Event.async (Chrome_trace.Id.create (`Int id)) ~args Start common
+  in
   Dune_stats.emit stats event;
   (common, args)
 

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -234,7 +234,7 @@ module Event = struct
             let ts = Event.Timestamp.of_float_seconds (Unix.gettimeofday ()) in
             Event.common_fields ~ts ~name ()
           in
-          let id = Event.Id.Int (Session.Id.to_int id) in
+          let id = Chrome_trace.Id.create (`Int (Session.Id.to_int id)) in
           Event.async ?args id kind common
         in
         Dune_stats.emit stats event)


### PR DESCRIPTION
There's already a functional Id type in this library. The stack frame id
was introduced by accident.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 03190f5c-cc17-42e2-b990-510eb356f76e