### PR TITLE
fix: invalidate timestamps of directories

### DIFF
--- a/src/dune_engine/fs_memo.ml
+++ b/src/dune_engine/fs_memo.ml
@@ -276,7 +276,9 @@ let file_digest ?(force_update = false) path =
   Fs_cache.read Fs_cache.Untracked.file_digest path
 
 let dir_contents ?(force_update = false) path =
-  if force_update then Fs_cache.evict Fs_cache.Untracked.dir_contents path;
+  if force_update then (
+    Cached_digest.Untracked.invalidate_cached_timestamp path;
+    Fs_cache.evict Fs_cache.Untracked.dir_contents path);
   let+ () = Watcher.watch ~try_to_watch_via_parent:false path in
   Fs_cache.read Fs_cache.Untracked.dir_contents path
 


### PR DESCRIPTION
When [~force_update:true], we should invalidate the timestamp of the
directory just like we do with files.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 9b9b9f5c-f6a9-4189-a477-2cb2caf79bef