### PR TITLE
refactor: remove Super_context alias

### DIFF
--- a/src/dune_rules/exe.ml
+++ b/src/dune_rules/exe.ml
@@ -1,6 +1,5 @@
 open Import
 module CC = Compilation_context
-module SC = Super_context
 
 module Program = struct
   type t =
@@ -134,7 +133,7 @@ let link_exe ~loc ~name ~(linkage : Linkage.t) ~cm_files ~link_time_code_gen
     ~promote ?(link_args = Action_builder.return Command.Args.empty)
     ?(o_files = []) ?(sandbox = Sandbox_config.default) cctx =
   let sctx = CC.super_context cctx in
-  let ctx = SC.context sctx in
+  let ctx = Super_context.context sctx in
   let dir = CC.dir cctx in
   let mode = Link_mode.mode linkage.mode in
   let exe = exe_path_from_name cctx ~name ~linkage in
@@ -195,7 +194,7 @@ let link_exe ~loc ~name ~(linkage : Linkage.t) ~cm_files ~link_time_code_gen
           ]
     >>| Action.Full.add_sandbox sandbox
   in
-  SC.add_rule sctx ~loc ~dir
+  Super_context.add_rule sctx ~loc ~dir
     ~mode:
       (match promote with
       | None -> Standard
@@ -241,7 +240,7 @@ let link_many ?link_args ?o_files ?(embed_in_plugin_libraries = []) ?sandbox
         in
         let cm_files =
           let sctx = CC.super_context cctx in
-          let ctx = SC.context sctx in
+          let ctx = Super_context.context sctx in
           let obj_dir = CC.obj_dir cctx in
           Cm_files.make ~obj_dir ~modules ~top_sorted_modules
             ~ext_obj:ctx.lib_config.ext_obj ()

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -1,5 +1,4 @@
 open Import
-module SC = Super_context
 
 module Backend = struct
   module M = struct
@@ -113,7 +112,7 @@ include Sub_system.Register_end_point (struct
     in
     (* Generate the runner file *)
     let* () =
-      SC.add_rule sctx ~dir ~loc
+      Super_context.add_rule sctx ~dir ~loc
         (let target =
            Module.file main_module ~ml_kind:Impl
            |> Option.value_exn |> Path.as_in_build_dir_exn
@@ -224,7 +223,7 @@ include Sub_system.Register_end_point (struct
           | Native | Best | Byte -> Memo.return Alias.Name.runtest
           | Javascript -> Super_context.js_of_ocaml_runtest_alias sctx ~dir
         in
-        SC.add_alias_action sctx ~dir ~loc:(Some info.loc)
+        Super_context.add_alias_action sctx ~dir ~loc:(Some info.loc)
           (Alias.make ~dir runtest_alias)
           (let exe =
              Path.build (Path.Build.relative inline_test_dir (name ^ ext))

--- a/src/dune_rules/jsoo_rules.ml
+++ b/src/dune_rules/jsoo_rules.ml
@@ -1,5 +1,4 @@
 open Import
-module SC = Super_context
 
 let install_jsoo_hint = "opam install js_of_ocaml-compiler"
 
@@ -7,7 +6,8 @@ let in_build_dir ~ctx args =
   Path.Build.L.relative ctx.Context.build_dir (".js" :: args)
 
 let jsoo ~dir sctx =
-  SC.resolve_program sctx ~dir ~loc:None ~hint:install_jsoo_hint "js_of_ocaml"
+  Super_context.resolve_program sctx ~dir ~loc:None ~hint:install_jsoo_hint
+    "js_of_ocaml"
 
 type sub_command =
   | Compile
@@ -135,7 +135,7 @@ let setup_separate_compilation_rules sctx components =
   | [] | _ :: _ :: _ -> Memo.return ()
   | [ pkg ] -> (
     let pkg = Lib_name.parse_string_exn (Loc.none, pkg) in
-    let ctx = SC.context sctx in
+    let ctx = Super_context.context sctx in
     let open Memo.O in
     let* installed_libs = Lib.DB.installed ctx in
     Lib.DB.find installed_libs pkg >>= function
@@ -171,7 +171,7 @@ let setup_separate_compilation_rules sctx components =
             js_of_ocaml_rule sctx ~sub_command:Compile ~dir
               ~flags:Js_of_ocaml.Flags.standard ~spec ~target
           in
-          SC.add_rule sctx ~dir action_with_targets))
+          Super_context.add_rule sctx ~dir action_with_targets))
 
 let build_exe cc ~loc ~in_context ~src ~(cm : Path.t list Action_builder.t)
     ~promote ~link_time_code_gen =
@@ -192,12 +192,12 @@ let build_exe cc ~loc ~in_context ~src ~(cm : Path.t list Action_builder.t)
   | Separate_compilation ->
     standalone_runtime_rule cc ~javascript_files ~target:standalone_runtime
       ~flags
-    >>= SC.add_rule ~loc sctx ~dir
+    >>= Super_context.add_rule ~loc sctx ~dir
     >>> link_rule cc ~runtime:standalone_runtime ~target cm ~flags
           ~link_time_code_gen
-    >>= SC.add_rule sctx ~loc ~dir ~mode
+    >>= Super_context.add_rule sctx ~loc ~dir ~mode
   | Whole_program ->
     exe_rule cc ~javascript_files ~src ~target ~flags
-    >>= SC.add_rule sctx ~loc ~dir ~mode
+    >>= Super_context.add_rule sctx ~loc ~dir ~mode
 
 let runner = "node"

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -1,6 +1,5 @@
 open Import
 module CC = Compilation_context
-module SC = Super_context
 
 type t =
   { to_link : Lib_flags.Lib_and_module.L.t
@@ -32,7 +31,7 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name ~lib ~code ~requires
   in
   let open Memo.O in
   let* () =
-    SC.add_rule ~dir sctx
+    Super_context.add_rule ~dir sctx
       (let ml =
          Module.file module_ ~ml_kind:Impl
          |> Option.value_exn |> Path.as_in_build_dir_exn

--- a/src/dune_rules/menhir_rules.ml
+++ b/src/dune_rules/menhir_rules.ml
@@ -1,6 +1,5 @@
 open Import
 open! Action_builder.O
-module SC = Super_context
 
 (* This module interprets [(menhir ...)] stanzas -- that is, it provides build
    rules for Menhir parsers. *)
@@ -94,7 +93,8 @@ module Run (P : PARAMS) = struct
   (* Rule generation. *)
 
   let menhir_binary =
-    SC.resolve_program sctx ~dir "menhir" ~loc:None ~hint:"opam install menhir"
+    Super_context.resolve_program sctx ~dir "menhir" ~loc:None
+      ~hint:"opam install menhir"
 
   (* Reminder (from command.mli):
 
@@ -113,7 +113,7 @@ module Run (P : PARAMS) = struct
 
   let rule ?(mode = stanza.mode) :
       Action.Full.t Action_builder.With_targets.t -> unit Memo.t =
-    SC.add_rule sctx ~dir ~mode ~loc:stanza.loc
+    Super_context.add_rule sctx ~dir ~mode ~loc:stanza.loc
 
   let expand_flags flags = Super_context.menhir_flags sctx ~dir ~expander ~flags
 

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -1,6 +1,5 @@
 open Import
 module CC = Compilation_context
-module SC = Super_context
 
 (* Arguments for the compiler to prevent it from being too clever.
 
@@ -38,7 +37,7 @@ let copy_interface ~sctx ~dir ~obj_dir m =
     (Module.visibility m <> Visibility.Private
     && Obj_dir.need_dedicated_public_dir obj_dir)
     (fun () ->
-      SC.add_rule sctx ~dir
+      Super_context.add_rule sctx ~dir
         (Action_builder.symlink
            ~src:(Path.build (Obj_dir.Module.cm_file_exn obj_dir m ~kind:Cmi))
            ~dst:(Obj_dir.Module.cm_public_file_exn obj_dir m ~kind:Cmi)))
@@ -47,7 +46,7 @@ let build_cm cctx ~precompiled_cmi ~cm_kind (m : Module.t) ~phase =
   let sctx = CC.super_context cctx in
   let dir = CC.dir cctx in
   let obj_dir = CC.obj_dir cctx in
-  let ctx = SC.context sctx in
+  let ctx = Super_context.context sctx in
   let stdlib = CC.stdlib cctx in
   let mode = Mode.of_cm_kind cm_kind in
   let sandbox =
@@ -159,7 +158,7 @@ let build_cm cctx ~precompiled_cmi ~cm_kind (m : Module.t) ~phase =
     |> List.concat_map ~f:(fun p ->
            [ Command.Args.A "-I"; Path (Path.build p) ])
   in
-  SC.add_rule sctx ~dir ?loc:(CC.loc cctx)
+  Super_context.add_rule sctx ~dir ?loc:(CC.loc cctx)
     (let open Action_builder.With_targets.O in
     Action_builder.with_no_targets (Action_builder.paths extra_deps)
     >>> Action_builder.with_no_targets other_cm_files
@@ -223,13 +222,13 @@ let build_module ?(precompiled_cmi = false) cctx m =
            let action_with_targets =
              Jsoo_rules.build_cm cctx ~in_context ~src ~target
            in
-           action_with_targets >>= SC.add_rule sctx ~dir)
+           action_with_targets >>= Super_context.add_rule sctx ~dir)
 
 let ocamlc_i ?(flags = []) ~deps cctx (m : Module.t) ~output =
   let sctx = CC.super_context cctx in
   let obj_dir = CC.obj_dir cctx in
   let dir = CC.dir cctx in
-  let ctx = SC.context sctx in
+  let ctx = Super_context.context sctx in
   let src = Option.value_exn (Module.file m ~ml_kind:Impl) in
   let sandbox = Compilation_context.sandbox cctx in
   let cm_deps =
@@ -241,7 +240,7 @@ let ocamlc_i ?(flags = []) ~deps cctx (m : Module.t) ~output =
   in
   let ocaml_flags = Ocaml_flags.get (CC.flags cctx) Mode.Byte in
   let modules = Compilation_context.modules cctx in
-  SC.add_rule sctx ~dir
+  Super_context.add_rule sctx ~dir
     (Action_builder.With_targets.add ~file_targets:[ output ]
        (let open Action_builder.With_targets.O in
        Action_builder.with_no_targets cm_deps

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -1,5 +1,4 @@
 open Import
-module SC = Super_context
 
 module Modules_data = struct
   type t =
@@ -75,13 +74,13 @@ let deps_of
     ~ml_kind unit =
   let source = Option.value_exn (Module.source unit ~ml_kind) in
   let dep = Obj_dir.Module.dep obj_dir in
-  let context = SC.context sctx in
+  let context = Super_context.context sctx in
   let parse_module_names = parse_module_names ~modules in
   let all_deps_file = dep (Transitive (unit, ml_kind)) in
   let ocamldep_output = dep (Immediate source) in
   let open Memo.O in
   let* () =
-    SC.add_rule sctx ~dir
+    Super_context.add_rule sctx ~dir
       (let open Action_builder.With_targets.O in
       let flags, sandbox =
         Option.value (Module.pp_flags unit)
@@ -130,7 +129,7 @@ let deps_of
        Action.Merge_files_into (sources, extras, all_deps_file))
   in
   let+ () =
-    SC.add_rule sctx ~dir
+    Super_context.add_rule sctx ~dir
       (Action_builder.With_targets.map ~f:Action.Full.make action)
   in
   let all_deps_file = Path.build all_deps_file in

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -1,7 +1,6 @@
 open Import
 open Dune_file
 open Memo.O
-module SC = Super_context
 
 let ( ++ ) = Path.Build.relative
 
@@ -189,7 +188,8 @@ end
 
 let odoc sctx =
   let dir = (Super_context.context sctx).build_dir in
-  SC.resolve_program sctx ~dir "odoc" ~loc:None ~hint:"opam install odoc"
+  Super_context.resolve_program sctx ~dir "odoc" ~loc:None
+    ~hint:"opam install odoc"
 
 let odoc_base_flags sctx build_dir =
   let open Memo.O in

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -1,12 +1,11 @@
 open Import
 open Dune_file
-module SC = Super_context
 open Memo.O
 
 module Alias_rules = struct
   let add sctx ~alias ~loc build =
     let dir = Alias.dir alias in
-    SC.add_alias_action sctx alias ~dir ~loc build
+    Super_context.add_alias_action sctx alias ~dir ~loc build
 
   let add_empty sctx ~loc ~alias =
     let action = Action_builder.return (Action.Full.make Action.empty) in
@@ -62,7 +61,8 @@ let add_user_rule sctx ~dir ~(rule : Rule.t)
     ~(action : _ Action_builder.With_targets.t) ~expander =
   let* build = interpret_and_add_locks ~expander rule.locks action.build in
   let action = { action with Action_builder.With_targets.build } in
-  SC.add_rule_get_targets sctx ~dir ~mode:rule.mode ~loc:rule.loc action
+  Super_context.add_rule_get_targets sctx ~dir ~mode:rule.mode ~loc:rule.loc
+    action
 
 let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
   Expander.eval_blang expander rule.enabled_if >>= function
@@ -199,7 +199,7 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
       ~f:(fun file_src ->
         let basename = Path.basename file_src in
         let file_dst = Path.Build.relative dir basename in
-        SC.add_rule sctx ~loc ~dir ~mode:def.mode
+        Super_context.add_rule sctx ~loc ~dir ~mode:def.mode
           ((if def.add_line_directive then Copy_line_directive.builder
            else Action_builder.copy)
              ~src:file_src ~dst:file_dst))


### PR DESCRIPTION
it's used too infrequently to be useful

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: e83f3210-69e4-42cf-95e3-fc64d556ba80