### PR TITLE
Add an option to replace external-lib-deps command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Revive `$ dune external-lib-deps` under `$ dune describe external-lib-deps`.
+  (#6045, @moyodiallo)
+
 - Fix running inline tests in byteode mode (#5622, fixes #5515, @dariusf)
 
 - [ctypes] always re-run `pkg-config` because we aren't tracking its external

--- a/test/blackbox-tests/test-cases/external-lib-deps.t
+++ b/test/blackbox-tests/test-cases/external-lib-deps.t
@@ -1,5 +1,0 @@
-external-lib-deps is no more.
-
-  $ dune external-lib-deps
-  dune: This subcommand is no longer implemented.
-  [1]

--- a/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/dune
+++ b/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/dune
@@ -1,0 +1,18 @@
+(library
+ (name foo)
+ (modules :standard \ prog)
+ (libraries a________ b________ c________)
+ (preprocess (pps d________ e________ f________)))
+
+(rule
+ (with-stdout-to file.ml
+  (echo %{lib-available:optional})))
+
+(rule (with-stdout-to foo.ml (run prog)))
+
+(executable
+ (name prog)
+ (modules prog)
+ (libraries h________ i________ j________))
+
+(rule (with-stdout-to prog.ml (echo "")))

--- a/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/dune-project
+++ b/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/dune-project
@@ -1,0 +1,4 @@
+(lang dune 1.9)
+(name foo)
+
+(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/run.t
+++ b/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/run.t
@@ -1,0 +1,14 @@
+Expected: To get all required and pps packages
+
+  $ dune describe external-lib-deps
+  (default
+   ((.
+     ((a________ required)
+      (b________ required)
+      (c________ required)
+      (d________ required)
+      (e________ required)
+      (f________ required)
+      (h________ required)
+      (i________ required)
+      (j________ required)))))

--- a/test/blackbox-tests/test-cases/external-lib-deps/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/external-lib-deps/simple.t/run.t
@@ -1,0 +1,11 @@
+external library dependencies of a simple project
+
+  $ echo "(lang dune 2.3)" > dune-project
+  $ touch dummypkg.opam
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name dummypkg)
+  >  (libraries base doesnotexist.foo))
+  > EOF
+  $ dune describe external-lib-deps
+  (default ((. ((base required) (doesnotexist.foo required)))))


### PR DESCRIPTION
This PR is motivate by [dune-opam-lint](https://github.com/ocurrent/opam-dune-lint). The command `dune external-lib-deps` is used by it and this command is removed in dune #4298. Getting the command back is not realistic, I think. Instead of getting all information by doing a static analysis of the build graph. We extract all the information we need during the build, so `dynamically`.

* The first approach is to categorize the Data Base dependencies like `Project_libs` db, `Public_libs` db, `Installed_libs` db. Then, during the resolution catch all libs that searched in `Installed_libs`, potentially there are external libs. Easy to add but you have to propagate the `build_dir` in order to get the dependencies by `build_dir`.
* The second approach, after resolving the lib we could get the necessary needed info from  `Lib_info`. So you don't have to propagate the `build_dir` across many functions, but the issue is you could miss external dependency (like `select` rule). In the case of a dune project not all external deps will be resolved in some particular build.

In this PR the first approach was chosen, why not propagate the `build_dir` and get all external dependencies during the build. 