### PR TITLE
refactor(fiber): optimize reader enqueue

### DIFF
--- a/src/fiber/scheduler.ml
+++ b/src/fiber/scheduler.ml
@@ -26,8 +26,9 @@ module Jobs = struct
     | Empty ->
       ivar.state <- Full x;
       jobs
-    | Empty_with_readers _ as readers ->
+    | Empty_with_readers (ctx, k, readers) ->
       ivar.state <- Full x;
+      let jobs = Job (ctx, k, x, jobs) in
       enqueue_readers readers x jobs
 
   let rec exec_fills fills acc =


### PR DESCRIPTION
we know that case [Empty_with_readers] has at least one job to enqueue,
so we enqueue it manually ourselves before enqueuing the rest.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: de9dbcec-fc09-426c-a9e2-811f5f38f430