### PR TITLE
refactor: move digest & metrics

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1014,7 +1014,7 @@ let term ~default_root_is_cwd =
   if store_digest_preimage then Dune_engine.Reversible_digest.enable ();
   if print_metrics then (
     Memo.Perf_counters.enable ();
-    Metrics.enable ());
+    Dune_metrics.enable ());
   { debug_dep_path
   ; debug_findlib
   ; debug_backtraces

--- a/bin/dune
+++ b/bin/dune
@@ -11,6 +11,8 @@
   fiber
   stdune
   unix
+  dune_metrics
+  dune_digest
   dune_cache
   dune_cache_storage
   dune_graph

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -1,5 +1,7 @@
 open Stdune
 open Dune_engine
+module Digest = Dune_digest
+module Metrics = Dune_metrics
 module Term = Cmdliner.Term
 module Manpage = Cmdliner.Manpage
 module Stanza = Dune_lang.Stanza

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -15,6 +15,8 @@ let local_libraries =
   ; ("src/dag", Some "Dag", false, None)
   ; ("src/fiber", Some "Fiber", false, None)
   ; ("src/memo", Some "Memo", false, None)
+  ; ("src/dune_metrics", Some "Dune_metrics", false, None)
+  ; ("src/dune_digest", Some "Dune_digest", false, None)
   ; ("src/dune_sexp", Some "Dune_sexp", false, None)
   ; ("src/ocaml-config", Some "Ocaml_config", false, None)
   ; ("src/ocaml", Some "Ocaml", false, None)

--- a/otherlibs/stdune/stdune.ml
+++ b/otherlibs/stdune/stdune.ml
@@ -44,7 +44,6 @@ module Proc = Proc
 module Type_eq = Type_eq
 module Nothing = Nothing
 module Bin = Bin
-module Digest = Digest
 module Fdecl = Fdecl
 module Unit = Unit
 module Monad = Monad
@@ -68,7 +67,6 @@ module Seq = Seq
 module Temp = Temp
 module Queue = Queue
 module Caller_id = Caller_id
-module Metrics = Metrics
 module Dune_filesystem_stubs = Dune_filesystem_stubs
 module Predicate = Predicate
 

--- a/src/dune_cache/dune
+++ b/src/dune_cache/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_cache)
  (synopsis "[Internal] Dune's local and cloud build cache")
- (libraries csexp dune_cache_storage fiber stdune unix))
+ (libraries csexp dune_digest dune_cache_storage fiber stdune unix))

--- a/src/dune_cache/import.ml
+++ b/src/dune_cache/import.ml
@@ -1,0 +1,3 @@
+module Digest = Dune_digest
+module Restore_result = Dune_cache_storage.Restore_result
+module Store_result = Dune_cache_storage.Store_result

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -1,8 +1,7 @@
 open Stdune
 open Dune_cache_storage.Layout
 open Fiber.O
-module Store_result = Dune_cache_storage.Store_result
-module Restore_result = Dune_cache_storage.Restore_result
+open Import
 
 module Store_artifacts_result = struct
   type t =

--- a/src/dune_cache/local.mli
+++ b/src/dune_cache/local.mli
@@ -16,7 +16,7 @@
    store the mtime in the metadata and complain if it's not what we expected. *)
 
 open Stdune
-module Restore_result := Dune_cache_storage.Restore_result
+open Import
 
 module Store_artifacts_result : sig
   (* Outcomes are ordered in the order of severity. *)

--- a/src/dune_cache_storage/dune
+++ b/src/dune_cache_storage/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_cache_storage)
  (synopsis "[Internal] Dune cache storage, used for local and cloud caches")
- (libraries csexp dune_util fiber fiber_util stdune xdg unix))
+ (libraries csexp dune_util dune_digest fiber fiber_util stdune xdg unix))

--- a/src/dune_cache_storage/dune_cache_storage.ml
+++ b/src/dune_cache_storage/dune_cache_storage.ml
@@ -1,4 +1,5 @@
 open Stdune
+open Import
 module Layout = Layout
 module Mode = Mode
 module Util = Util

--- a/src/dune_cache_storage/dune_cache_storage.mli
+++ b/src/dune_cache_storage/dune_cache_storage.mli
@@ -2,6 +2,7 @@
     local and cloud caches. *)
 
 open Stdune
+open Import
 module Layout = Layout
 module Mode = Mode
 module Util = Util

--- a/src/dune_cache_storage/import.ml
+++ b/src/dune_cache_storage/import.ml
@@ -1,0 +1,1 @@
+module Digest = Dune_digest

--- a/src/dune_cache_storage/layout.ml
+++ b/src/dune_cache_storage/layout.ml
@@ -1,4 +1,5 @@
 open Stdune
+open Import
 
 let default_root_dir () =
   let cache_dir = Xdg.cache_dir (Lazy.force Dune_util.xdg) in

--- a/src/dune_cache_storage/layout.mli
+++ b/src/dune_cache_storage/layout.mli
@@ -6,6 +6,7 @@
    decision in 6 months. *)
 
 open Stdune
+open Import
 
 (** The path to the root directory of the cache. *)
 val root_dir : Path.t

--- a/src/dune_digest/dune
+++ b/src/dune_digest/dune
@@ -1,0 +1,3 @@
+(library
+ (name dune_digest)
+ (libraries dune_metrics stdune))

--- a/src/dune_digest/dune_digest.ml
+++ b/src/dune_digest/dune_digest.ml
@@ -1,8 +1,11 @@
+open Stdune
+
 type t = string
 
 module D = Stdlib.Digest
 module Set = String.Set
 module Map = String.Map
+module Metrics = Dune_metrics
 
 module type Digest_impl = sig
   val file : string -> t

--- a/src/dune_digest/dune_digest.mli
+++ b/src/dune_digest/dune_digest.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 (** Digests (MD5) *)
 
 type t

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -34,5 +34,7 @@
   dune_file_watcher
   dune_filesystem_stubs
   ocaml_inotify
+  dune_digest
+  dune_metrics
   async_inotify_for_dune)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -1,4 +1,6 @@
 include Stdune
+module Digest = Dune_digest
+module Metrics = Dune_metrics
 module Log = Dune_util.Log
 module Re = Dune_re
 module Stringlike = Dune_util.Stringlike

--- a/src/dune_metrics/dune
+++ b/src/dune_metrics/dune
@@ -1,0 +1,3 @@
+(library
+ (name dune_metrics)
+ (libraries stdune))

--- a/src/dune_metrics/dune_metrics.ml
+++ b/src/dune_metrics/dune_metrics.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 let enabled = ref false
 
 let enable () = enabled := true

--- a/src/dune_metrics/dune_metrics.mli
+++ b/src/dune_metrics/dune_metrics.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 (** Utilities for collecting performance metrics *)
 
 (** This function must be called to enable all performance metrics. *)

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -9,6 +9,8 @@
   memo
   ocaml
   dune_re
+  console
+  dune_digest
   opam_file_format
   dune_lang
   dune_glob

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -1,5 +1,6 @@
 include Stdune
 open Dune_util
+module Digest = Dune_digest
 module Config = Config
 module Log = Log
 module Persistent = Persistent

--- a/src/dune_sexp/atom.ml
+++ b/src/dune_sexp/atom.ml
@@ -1,4 +1,5 @@
 open Stdune
+open Import
 
 type t = A of string [@@unboxed]
 

--- a/src/dune_sexp/atom.mli
+++ b/src/dune_sexp/atom.mli
@@ -1,4 +1,4 @@
-open Stdune
+open Import
 
 type t = private A of string [@@unboxed]
 

--- a/src/dune_sexp/dune
+++ b/src/dune_sexp/dune
@@ -1,6 +1,6 @@
 (library
  (name dune_sexp)
  (synopsis "[Internal] S-expression library")
- (libraries stdune))
+ (libraries dune_digest stdune))
 
 (ocamllex lexer versioned_file_first_line)

--- a/src/dune_sexp/import.ml
+++ b/src/dune_sexp/import.ml
@@ -1,0 +1,1 @@
+module Digest = Dune_digest

--- a/test/expect-tests/digest/digest_tests.ml
+++ b/test/expect-tests/digest/digest_tests.ml
@@ -1,4 +1,5 @@
 open Stdune
+module Digest = Dune_digest
 
 let%expect_test "directory digest version" =
   (* If this test fails with a new digest value, make sure to update to update

--- a/test/expect-tests/digest/dune
+++ b/test/expect-tests/digest/dune
@@ -1,0 +1,14 @@
+(library
+ (name digest_unit_tests)
+ (libraries
+  stdune
+  dune_digest
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  ppx_expect.common
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))


### PR DESCRIPTION
[Digest] and [Metrics] are dune specific and should live as their own
libraries.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 1118a547-86f7-480d-b778-46e3b7d246e5