### PR TITLE
feature(coq): coq macro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,9 @@
 
 - dune install: copy files in an atomic way (#6150, @emillon)
 
+- Add `%{coq:...}` macro for accessing data about the configuration about Coq.
+  For instance `%{coq:version}` (#6049, @Alizter)
+
 3.4.1 (26-07-2022)
 ------------------
 

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -186,6 +186,7 @@ Dune supports the following variables:
   variable ``<var>``, or ``<default>`` if it does not exist.
   For example, ``%{env:BIN=/usr/bin}``.
   Available since Dune 1.4.0.
+- There are some Coq-specific variables detailed in :ref:`coq-variables`.
 
 In addition, ``(action ...)`` fields support the following special variables:
 

--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -543,3 +543,25 @@ Limitations
 * When new dependencies are added to a file (via a Coq ``Require`` vernacular
   command), it is in principle required to save the file and restart to Coq
   toplevel process.
+
+.. _coq-variables:
+
+Coq-Specific Variables
+----------------------
+
+There are some special variables that can be used to access data about the Coq
+configuration. These are:
+
+- ``%{coq:version}`` the version of Coq.
+- ``%{coq:version.major}`` the major version of Coq (e.g., ``8.15.2`` gives
+  ``8``).
+- ``%{coq:version.minor}`` the minor version of Coq (e.g., ``8.15.2`` gives
+  ``15``).
+- ``%{coq:version.suffix}`` the suffix version of Coq (e.g., ``8.15.2`` gives
+  ``.2`` and ``8.15+rc1`` gives ``+rc1``).
+- ``%{coq:ocaml-version}`` the version of OCaml used to compile Coq.
+- ``%{coq:coqlib}`` the output of ``COQLIB`` from ``coqc -config``.
+- ``%{coq:coq_native_compiler_default}`` the output of
+  ``COQ_NATIVE_COMPILER_DEFAULT`` from ``coqc -config``.
+
+See :ref:`variables` for more information on variables supported by Dune.

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -147,6 +147,7 @@ module Macro = struct
     | Read_lines
     | Path_no_dep
     | Ocaml_config
+    | Coq_config
     | Env
     | Artifact of Artifact.t
 
@@ -191,6 +192,9 @@ module Macro = struct
     | Ocaml_config, Ocaml_config -> Eq
     | Ocaml_config, _ -> Lt
     | _, Ocaml_config -> Gt
+    | Coq_config, Coq_config -> Eq
+    | Coq_config, _ -> Lt
+    | _, Coq_config -> Gt
     | Env, Env -> Eq
     | Env, _ -> Lt
     | _, Env -> Gt
@@ -215,6 +219,7 @@ module Macro = struct
     | Read_lines -> string "Read_lines"
     | Path_no_dep -> string "Path_no_dep"
     | Ocaml_config -> string "Ocaml_config"
+    | Coq_config -> string "Coq_config"
     | Env -> string "Env"
     | Artifact ext -> variant "Artifact" [ Artifact.to_dyn ext ]
 end
@@ -320,6 +325,7 @@ let encode_to_latest_dune_lang_version t =
       | Read_lines -> Some "read-lines"
       | Path_no_dep -> None
       | Ocaml_config -> Some "ocaml-config"
+      | Coq_config -> Some "coq"
       | Env -> Some "env"
       | Artifact a -> Some (String.drop (Artifact.ext a) 1)
     with
@@ -409,6 +415,7 @@ module Env = struct
          ; ("path-no-dep", deleted_in ~version:(1, 0) Macro.Path_no_dep)
          ; ("ocaml-config", macro Ocaml_config)
          ; ("env", since ~version:(1, 4) Macro.Env)
+         ; ("coq", macro Coq_config)
          ]
         @ List.map ~f:artifact Artifact.all)
     in

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -85,6 +85,7 @@ module Macro : sig
     | Read_lines
     | Path_no_dep
     | Ocaml_config
+    | Coq_config
     | Env
     | Artifact of Artifact.t
 

--- a/src/dune_rules/coq_config.ml
+++ b/src/dune_rules/coq_config.ml
@@ -1,0 +1,253 @@
+open Import
+open Memo.O
+
+module Value = struct
+  type t =
+    | Bool of bool
+    | Int of int
+    | String of string
+    | Strings of string list
+    | Path of Path.t
+end
+
+module Vars : sig
+  type t
+
+  val get : t -> string -> string
+
+  val get_path : t -> string -> Path.t
+
+  val get_bool : t -> ?default:bool -> string -> bool
+
+  val of_lines : string list -> (t, User_message.Style.t Pp.t) result
+
+  exception E of User_message.Style.t Pp.t
+end = struct
+  open Result.O
+
+  type t = string String.Map.t
+
+  let of_lines lines =
+    let rec loop acc = function
+      | [] -> Ok acc
+      | line :: lines -> (
+        match String.index line '=' with
+        | Some i ->
+          let x = (String.take line i, String.drop line (i + 1)) in
+          loop (x :: acc) lines
+        | None -> Error Pp.(textf "Unrecognized line: %S" line))
+    in
+    let* vars = loop [] lines in
+    Result.map_error (String.Map.of_list vars) ~f:(fun (var, _, _) ->
+        Pp.(textf "Variable %S present twice." var))
+
+  exception E of User_message.Style.t Pp.t
+
+  let fail fmt msg = raise (E (Pp.textf fmt msg))
+
+  let get_opt = String.Map.find
+
+  let get t var =
+    match get_opt t var with
+    | Some s -> s
+    | None -> fail "Variable %S not found." var
+
+  let get_path t var = get t var |> Path.of_string
+
+  let get_bool t ?(default = false) var =
+    match get_opt t var with
+    | None -> default
+    | Some s -> (
+      match String.uncapitalize s with
+      | "true" | "yes" | "1" -> true
+      | _ -> default)
+end
+
+module Version = struct
+  module Num = struct
+    type t =
+      { major : int
+      ; minor : int
+      ; suffix : string
+      }
+
+    let make version_string =
+      let open Dune_re in
+      let regex =
+        let open Re in
+        seq
+          [ rep digit |> group
+          ; char '.'
+          ; rep digit |> group
+          ; rep any |> group
+          ]
+        |> compile
+      in
+      let open Result.O in
+      let* groups =
+        Re.exec_opt regex version_string |> function
+        | Some groups -> Result.Ok groups
+        | None -> Result.Error Pp.(textf "Could not parse version string.")
+      in
+      let* major =
+        let major = Group.get groups 1 in
+        major |> Int.of_string |> function
+        | Some major -> Result.Ok major
+        | None -> Result.Error Pp.(textf "Could not parse int: %S." major)
+      in
+      let* minor =
+        let minor = Group.get groups 2 in
+        minor |> Int.of_string |> function
+        | Some minor -> Result.Ok minor
+        | None -> Result.Error Pp.(textf "Could not parse int: %S." minor)
+      in
+      let suffix = Group.get groups 3 in
+      Result.Ok { major; minor; suffix}
+
+    let by_name { major; minor; suffix } name : Value.t option =
+      match name with
+      | "major" -> Some (Int major)
+      | "minor" -> Some (Int minor)
+      | "suffix" -> Some (String suffix)
+      | _ -> None
+  end
+
+  type t =
+    { version_num : Num.t
+    ; version_string : string
+    ; ocaml_version_string : string
+    }
+
+  let impl_version bin =
+    let* _ = Build_system.build_file bin in
+    Memo.of_reproducible_fiber
+    @@ Process.run_capture_line Process.Strict bin [ "--print-version" ]
+
+  let version_memo =
+    Memo.create "coq-and-ocaml-version" ~input:(module Path) impl_version
+
+  let make ~bin =
+    let open Memo.O in
+    let+ coq_and_ocaml_version = Memo.exec version_memo bin in
+    let sbin = Path.to_string bin in
+    let open Result.O in
+    let* version_string, ocaml_version_string =
+      String.lsplit2 ~on:' ' coq_and_ocaml_version |> function
+      | Some (version_string, ocaml_version_string) ->
+        Result.ok (version_string, ocaml_version_string)
+      | None ->
+        Result.Error
+          Pp.(textf "Unable to parse output of %s --print-version." sbin)
+    in
+    let* version_num = Num.make version_string in
+    Result.ok { version_num; version_string; ocaml_version_string }
+
+  let by_name t name : Value.t option =
+    match t with
+    | Error msg ->
+      User_error.raise Pp.[ textf "Could not parse coqc version: "; msg ]
+    | Ok { version_num; version_string; ocaml_version_string } -> (
+      match name with
+      | "version.major" -> Num.by_name version_num "major"
+      | "version.minor" -> Num.by_name version_num "minor"
+      | "version.revision" -> Num.by_name version_num "revision"
+      | "version.suffix" -> Num.by_name version_num "suffix"
+      | "version" -> Some (String version_string)
+      | "ocaml-version" -> Some (String ocaml_version_string)
+      | _ -> None)
+end
+
+type t =
+  { version_info : (Version.t, User_message.Style.t Pp.t) Result.t
+  ; coqlib : Path.t
+  ; coqcorelib : Path.t
+  ; docdir : Path.t
+  ; ocamlfind : Path.t
+  ; camlflags : string
+  ; warn : string
+  ; hasnatdynlink : bool
+  ; coq_src_subdirs : string list
+  ; coq_native_compiler_default : string
+  }
+
+let impl_config bin =
+  let* _ = Build_system.build_file bin in
+  Memo.of_reproducible_fiber
+  @@ Process.run_capture_lines Process.Strict bin [ "--config" ]
+
+let config_memo = Memo.create "coq-config" ~input:(module Path) impl_config
+
+let version ~bin =
+  let open Memo.O in
+  let+ t = Version.make ~bin in
+  let open Result.O in
+  let+ t = t in
+  t.version_string
+
+let make ~bin =
+  let open Memo.O in
+  let+ config_lines = Memo.exec config_memo bin
+  and+ version_info = Version.make ~bin in
+  match Vars.of_lines config_lines with
+  | Error msg ->
+    User_error.raise
+      Pp.
+        [ textf "cannot parse output of %S --config:" (Path.to_string bin)
+        ; msg
+        ]
+  | Ok vars ->
+    let coqlib = Vars.get_path vars "COQLIB" in
+    let coqcorelib = Vars.get_path vars "COQCORELIB" in
+    let docdir = Vars.get_path vars "DOCDIR" in
+    let ocamlfind = Vars.get_path vars "OCAMLFIND" in
+    let camlflags = Vars.get vars "CAMLFLAGS" in
+    let warn = Vars.get vars "WARN" in
+    let hasnatdynlink = Vars.get_bool vars "HASNATDYNLINK" in
+    let coq_src_subdirs =
+      Vars.get vars "COQ_SRC_SUBDIRS" |> String.split ~on:' '
+    in
+    let coq_native_compiler_default =
+      Vars.get vars "COQ_NATIVE_COMPILER_DEFAULT"
+    in
+    { version_info
+    ; coqlib
+    ; coqcorelib
+    ; docdir
+    ; ocamlfind
+    ; camlflags
+    ; warn
+    ; hasnatdynlink
+    ; coq_src_subdirs
+    ; coq_native_compiler_default
+    }
+
+let by_name
+    { version_info
+    ; coqlib
+    ; coqcorelib
+    ; docdir
+    ; ocamlfind
+    ; camlflags
+    ; warn
+    ; hasnatdynlink
+    ; coq_src_subdirs
+    ; coq_native_compiler_default
+    } name : Value.t option =
+  match name with
+  (* TODO check names *)
+  | "version.major"
+  | "version.minor"
+  | "version.revision"
+  | "version.suffix"
+  | "version"
+  | "ocaml-version" -> Version.by_name version_info name
+  | "coqlib" -> Some (Path coqlib)
+  | "coqcorelib" -> Some (Path coqcorelib)
+  | "docdir" -> Some (Path docdir)
+  | "ocamlfind" -> Some (Path ocamlfind)
+  | "camlflags" -> Some (String camlflags)
+  | "warn" -> Some (String warn)
+  | "hasnatdynlink" -> Some (Bool hasnatdynlink)
+  | "coq_src_subdirs" -> Some (Strings coq_src_subdirs)
+  | "coq_native_compiler_default" -> Some (String coq_native_compiler_default)
+  | _ -> None

--- a/src/dune_rules/coq_config.mli
+++ b/src/dune_rules/coq_config.mli
@@ -1,0 +1,18 @@
+open Import
+
+type t
+
+val version : bin:Path.t -> (string, User_message.Style.t Pp.t) Result.t Memo.t
+
+val make : bin:Path.t -> t Memo.t
+
+module Value : sig
+  type t =
+    | Bool of bool
+    | Int of int
+    | String of string
+    | Strings of string list
+    | Path of Path.t
+end
+
+val by_name : t -> string -> Value.t option

--- a/test/blackbox-tests/test-cases/coq/coq-config.t/dune
+++ b/test/blackbox-tests/test-cases/coq/coq-config.t/dune
@@ -4,25 +4,26 @@
    config.output
    (progn
     (echo "COQLIB=%{coq:coqlib}\n")
-    (echo "COQCORELIB=%{coq:coqcorelib}\n")
-    (echo "DOCDIR=%{coq:docdir}\n")
-    (echo "OCAMLFIND=%{coq:ocamlfind}\n")
-    (echo "CAMLFLAGS=%{coq:camlflags}\n")
-    (echo "WARN=%{coq:warn}\n")
-    (echo "HASNATDYNLINK=%{coq:hasnatdynlink}\n")
-    (echo "COQ_SRC_SUBDIRS=%{coq:coq_src_subdirs}\n")
     (echo "COQ_NATIVE_COMPILER_DEFAULT=%{coq:coq_native_compiler_default}\n")
     (echo "")
-    (echo "The Coq Proof Assistant, version %{coq:version}\n")
-    (echo "compiled with OCaml %{coq:ocaml-version}\n")
-    (echo "The Coq Proof Assistant, version %{coq:version.major}.%{coq:version.minor}%{coq:version.suffix}\n")
-    (echo "compiled with OCaml %{coq:ocaml-version}\n")))))
+    (echo "%{coq:version} %{coq:ocaml-version}\n")
+    (echo
+     "%{coq:version.major}.%{coq:version.minor}%{coq:version.suffix} %{coq:ocaml-version}\n")))))
 
 (rule
  (action
   (with-outputs-to
    config.expected
    (progn
-    (run %{bin:coqc} --config)
-    (run %{bin:coqc} --version)
-    (run %{bin:coqc} --version)))))
+    (pipe-outputs
+     ; We need to scrub ignored config values
+     (run %{bin:coqc} --config)
+     (run sed "/^COQCORELIB=/d")
+     (run sed "/^DOCDIR=/d")
+     (run sed "/^OCAMLFIND=/d")
+     (run sed "/^CAMLFLAGS=/d")
+     (run sed "/^WARN=/d")
+     (run sed "/^HASNATDYNLINK=/d")
+     (run sed "/^COQ_SRC_SUBDIRS=/d"))
+    (run %{bin:coqc} -print-version)
+    (run %{bin:coqc} -print-version)))))

--- a/test/blackbox-tests/test-cases/coq/coq-config.t/dune
+++ b/test/blackbox-tests/test-cases/coq/coq-config.t/dune
@@ -1,0 +1,28 @@
+(rule
+ (action
+  (with-outputs-to
+   config.output
+   (progn
+    (echo "COQLIB=%{coq:coqlib}\n")
+    (echo "COQCORELIB=%{coq:coqcorelib}\n")
+    (echo "DOCDIR=%{coq:docdir}\n")
+    (echo "OCAMLFIND=%{coq:ocamlfind}\n")
+    (echo "CAMLFLAGS=%{coq:camlflags}\n")
+    (echo "WARN=%{coq:warn}\n")
+    (echo "HASNATDYNLINK=%{coq:hasnatdynlink}\n")
+    (echo "COQ_SRC_SUBDIRS=%{coq:coq_src_subdirs}\n")
+    (echo "COQ_NATIVE_COMPILER_DEFAULT=%{coq:coq_native_compiler_default}\n")
+    (echo "")
+    (echo "The Coq Proof Assistant, version %{coq:version}\n")
+    (echo "compiled with OCaml %{coq:ocaml-version}\n")
+    (echo "The Coq Proof Assistant, version %{coq:version.major}.%{coq:version.minor}%{coq:version.suffix}\n")
+    (echo "compiled with OCaml %{coq:ocaml-version}\n")))))
+
+(rule
+ (action
+  (with-outputs-to
+   config.expected
+   (progn
+    (run %{bin:coqc} --config)
+    (run %{bin:coqc} --version)
+    (run %{bin:coqc} --version)))))

--- a/test/blackbox-tests/test-cases/coq/coq-config.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/coq-config.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.4)
+(using coq 0.4)

--- a/test/blackbox-tests/test-cases/coq/coq-config.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coq-config.t/run.t
@@ -1,0 +1,6 @@
+We test the coq-config macro
+
+  $ dune build
+
+  $ diff  _build/default/config.output _build/default/config.expected
+

--- a/test/blackbox-tests/test-cases/coq/coq-config.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coq-config.t/run.t
@@ -1,6 +1,8 @@
-We test the coq-config macro
+Testing the Coq macro
 
   $ dune build
 
-  $ diff  _build/default/config.output _build/default/config.expected
+  $ cd _build/default
 
+Testing the output of the version and configuration values
+  $ diff config.output config.expected


### PR DESCRIPTION
This is a continuation of #5967. The difference here is that the extra variables have been removed in a following commit. We now only expose:

Coq configuration variables:
```ocaml
%{coq:coqlib}
%{coq:coq_native_compiler_default}
```

Version numbers for Coq:
```ocaml
%{coq:version}
%{coq:ocaml-version}
%{coq:version.major}
%{coq:version.minor}
%{coq:version.suffix}
```

- close https://github.com/ocaml/dune/pull/5967
- close https://github.com/ocaml/dune/pull/5913
