### PR TITLE
test: loading inside directory target

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -22,6 +22,7 @@ type t =
   ; debug_findlib : bool
   ; debug_backtraces : bool
   ; debug_artifact_substitution : bool
+  ; debug_load_dir : bool
   ; debug_digests : bool
   ; wait_for_filesystem_clock : bool
   ; root : Workspace_root.t
@@ -187,6 +188,7 @@ let init ?log_file c =
   Clflags.debug_findlib := c.debug_findlib;
   Clflags.debug_backtraces c.debug_backtraces;
   Clflags.debug_artifact_substitution := c.debug_artifact_substitution;
+  Clflags.debug_load_dir := c.debug_load_dir;
   Clflags.debug_digests := c.debug_digests;
   Clflags.debug_fs_cache := c.cache_debug_flags.fs_cache;
   Clflags.wait_for_filesystem_clock := c.wait_for_filesystem_clock;
@@ -745,6 +747,11 @@ let term ~default_root_is_cwd =
       & info
           [ "debug-artifact-substitution" ]
           ~docs ~doc:"Print debugging info about artifact substitution")
+  and+ debug_load_dir =
+    Arg.(
+      value & flag
+      & info [ "debug-load-dir" ] ~docs
+          ~doc:"Print debugging info about directory loading")
   and+ debug_digests =
     Arg.(
       value & flag
@@ -1012,6 +1019,7 @@ let term ~default_root_is_cwd =
   ; debug_findlib
   ; debug_backtraces
   ; debug_artifact_substitution
+  ; debug_load_dir
   ; debug_digests
   ; wait_for_filesystem_clock
   ; capture_outputs = not no_buffer

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -22,6 +22,8 @@ let debug_backtraces b =
   Dune_util.Report_error.report_backtraces b;
   Memo.Debug.track_locations_of_lazy_values := b
 
+let debug_load_dir = ref false
+
 let diff_command = ref None
 
 let promote = ref None

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -20,6 +20,9 @@ val debug_digests : bool ref
 (** Print debug info for cached file-system operations *)
 val debug_fs_cache : bool ref
 
+(** Print debug info when loading rules in directories *)
+val debug_load_dir : bool ref
+
 (** Wait for the filesystem clock to advance rather than dropping cached digest
     entries *)
 val wait_for_filesystem_clock : bool ref

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -830,6 +830,10 @@ end = struct
         { Loaded.allowed_subdirs = descendants_to_keep; rules_here; aliases }
 
   let load_dir_impl ~dir : Loaded.t Memo.t =
+    if !Clflags.debug_load_dir then
+      Console.print_user_message
+        (User_message.make
+           [ Pp.textf "Loading build directory %s" (Path.to_string dir) ]);
     get_dir_triage ~dir >>= function
     | Known l -> Memo.return l
     | Build_directory x -> load_build_directory_exn x

--- a/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/loading-inside-directory-target.t
@@ -1,0 +1,57 @@
+This test tries to load the rules in a directory that is a target of another
+rule.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.4)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (deps (sandbox always))
+  >  (targets (dir output))
+  >  (action (bash "echo creating output dir && mkdir -p output/a && touch output/a/b")))
+  > EOF
+
+  $ dune build --debug-load-dir output/
+  Loading build directory _build/default
+  Loading build directory _build/default/.dune
+  Loading build directory _build
+  creating output dir
+  $ find _build/default/output
+  _build/default/output
+  _build/default/output/a
+  _build/default/output/a/b
+
+We are loading the rules in output/a and while making sure that we don't delete
+and re-create output/b. The following should not re-run the rule that recreates
+output/
+
+  $ dune build --debug-load-dir output/a/b
+  Loading build directory _build/default/output/a
+  Loading build directory _build/default
+  Loading build directory _build/default/.dune
+  Loading build directory _build
+  $ find _build/default/output
+  _build/default/output
+  _build/default/output/a
+  _build/default/output/a/b
+
+Now we try loading the rules in output/a and make sure that nothing is deleted:
+
+  $ dune rules --debug-load-dir output/a/
+  Loading build directory _build/default/output
+  Loading build directory _build/default
+  Loading build directory _build/default/.dune
+  Loading build directory _build
+  ((deps ())
+   (targets ((files ()) (directories (default/output))))
+   (context default)
+   (action
+    (chdir
+     _build/default
+     (bash "echo creating output dir && mkdir -p output/a && touch output/a/b"))))
+  $ find _build/default/output
+  _build/default/output
+  _build/default/output/a
+  _build/default/output/a/b


### PR DESCRIPTION
Load a subdir inside a directory target and make sure that stale
artifact clean up works correctly.

https://github.com/ocaml/dune/pull/5599#issuecomment-1105819683

Needs #6055 for loading rules by printing the rules in a directory.