### PR TITLE
fix: dune print-rules should print dir targets

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -50,21 +50,18 @@ let print_rule_sexp ppf (rule : Dune_engine.Reflection.Rule.t) =
   let sexp_of_action action =
     Action.for_shell action |> Action.For_shell.encode
   in
-  let paths ps = Dune_lang.Encoder.list Dpath.encode (Path.Set.to_list ps) in
-  let file_targets = rule.targets.files in
-  if not (Path.Build.Set.is_empty rule.targets.dirs) then
-    User_error.raise
-      [ Pp.text
-          "Printing rules with directory targets is currently not supported"
-      ];
+  let paths ps =
+    Dune_lang.Encoder.list Dpath.Build.encode (Path.Build.Set.to_list ps)
+  in
   let sexp =
     Dune_lang.Encoder.record
       (List.concat
          [ [ ("deps", Dep.Set.encode rule.deps)
            ; ( "targets"
-             , paths
-                 (Path.Build.Set.to_list file_targets
-                 |> Path.set_of_build_paths_list) )
+             , Dune_lang.Encoder.record
+                 [ ("files", paths rule.targets.files)
+                 ; ("directories", paths rule.targets.dirs)
+                 ] )
            ]
          ; (match rule.context with
            | None -> []

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -135,8 +135,13 @@ Print rules: currently works only with Makefiles.
      'mkdir output; cat src_x > output/x; echo y > output/y'
 
   $ dune rules output
-  Error: Printing rules with directory targets is currently not supported
-  [1]
+  ((deps ((File (In_build_dir _build/default/src_x))))
+   (targets ((files ()) (directories (default/output))))
+   (context default)
+   (action
+    (chdir
+     _build/default
+     (bash "mkdir output; cat src_x > output/x; echo y > output/y"))))
 
 Error when requesting a missing subdirectory of a directory target.
 


### PR DESCRIPTION
We can at least print directory targets in sexp mode.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 85d4838a-8f74-459b-a245-dd32ab82ad11