### PR TITLE
test: directory target and symlink

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/create-dir-with-symlink.t
+++ b/test/blackbox-tests/test-cases/directory-targets/create-dir-with-symlink.t
@@ -1,0 +1,29 @@
+Test creating directory targets by symlinking:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.3)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (targets (dir symlinked))
+  >  ;; not exactly correcty, but it's just a test
+  >  (deps bar/foo (sandbox always))
+  >  (action (system "ln -s ./bar symlinked")))
+  > EOF
+
+  $ mkdir bar && touch bar/foo
+
+  $ dune build ./symlinked
+  File "dune", line 1, characters 0-156:
+  1 | (rule
+  2 |  (targets (dir symlinked))
+  3 |  ;; not exactly correcty, but it's just a test
+  4 |  (deps bar/foo (sandbox always))
+  5 |  (action (system "ln -s ./bar symlinked")))
+  Error: Rule produced a file with unrecognised kind "S_LNK"
+  [1]
+
+  $ ls _build/default/symlinked
+


### PR DESCRIPTION
add a test that demonstrates creating a directory target by symlinking
another directory.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 242b2743-2c72-44dc-97e4-532f04e162df