### PR TITLE
fix: atomically copy dir targets from sandbox

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/create-dir-with-symlink.t
+++ b/test/blackbox-tests/test-cases/directory-targets/create-dir-with-symlink.t
@@ -25,5 +25,12 @@ Test creating directory targets by symlinking:
   Error: Rule produced a file with unrecognised kind "S_LNK"
   [1]
 
-  $ ls _build/default/symlinked
-
+  $ {
+  > if [ -e _build/default/symlinked ]
+  > then
+  >   echo symlink exists
+  > else
+  >   echo symlink does not exist
+  > fi
+  > }
+  symlink does not exist


### PR DESCRIPTION
Instead of manually traversing the directory and moving things file by
file, we rely on one call of [Unix.rename].

The advantage is that we move the direcory atomically. Previously, an
error could interrupt the recursive rename and leave _build/ with some
partially copied directory.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 39a65638-5953-4ed5-bcae-bbb13c63e46f