### PR TITLE
feature: new terminal persistence mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 3.5.0 (unreleased)
 ------------------
 
+- Add a terminal persistence mode that attempts to clear the terminal history.
+  It is enabled by setting terminal persistence to
+  `clear-on-rebuild-and-flush-history` (#6065, @rgrinberg)
+
 - Disallow generating targets in sub direcories in inferred rules. The check to
   forbid this was accidentally done only for manually specified targets (#6031,
   @rgrinberg)

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -80,6 +80,7 @@ module Scheduler = struct
     | false -> (
       match dune_config.terminal_persistence with
       | Clear_on_rebuild -> Console.reset ()
+      | Clear_on_rebuild_and_flush_history -> Console.reset_flush_history ()
       | Preserve ->
         let message =
           sprintf "********** NEW BUILD (%s) **********"

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -17,15 +17,21 @@ module Terminal_persistence = struct
   type t =
     | Preserve
     | Clear_on_rebuild
+    | Clear_on_rebuild_and_flush_history
 
-  let all = [ ("preserve", Preserve); ("clear-on-rebuild", Clear_on_rebuild) ]
+  let all =
+    [ ("preserve", Preserve)
+    ; ("clear-on-rebuild", Clear_on_rebuild)
+    ; ("clear-on-rebuild-and-flush-history", Clear_on_rebuild_and_flush_history)
+    ]
 
   let to_dyn = function
     | Preserve -> Dyn.Variant ("Preserve", [])
     | Clear_on_rebuild -> Dyn.Variant ("Clear_on_rebuild", [])
+    | Clear_on_rebuild_and_flush_history ->
+      Variant ("Clear_on_rebuild_and_flush_history", [])
 
-  let decode =
-    enum [ ("perserve", Preserve); ("clear-on-rebuild", Clear_on_rebuild) ]
+  let decode = enum all
 end
 
 module Concurrency = struct

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -44,6 +44,7 @@ module Terminal_persistence : sig
   type t =
     | Preserve
     | Clear_on_rebuild
+    | Clear_on_rebuild_and_flush_history
 
   val all : (string * t) list
 end

--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -9,6 +9,8 @@ module Backend = struct
     val print_if_no_status_line : User_message.Style.t Pp.t -> unit
 
     val reset : unit -> unit
+
+    val reset_flush_history : unit -> unit
   end
 
   type t = (module S)
@@ -28,6 +30,8 @@ module Backend = struct
         (Pp.seq (Pp.map_tags msg ~f:User_message.Print_config.default) Pp.cut)
 
     let reset () = prerr_string "\x1b[H\x1b[2J"
+
+    let reset_flush_history () = prerr_string "\x1bc"
   end
 
   module Dumb : S = struct
@@ -43,6 +47,10 @@ module Backend = struct
 
     let reset () =
       reset ();
+      flush stderr
+
+    let reset_flush_history () =
+      reset_flush_history ();
       flush stderr
   end
 
@@ -81,6 +89,8 @@ module Backend = struct
       flush stderr
 
     let reset () = Dumb.reset ()
+
+    let reset_flush_history () = Dumb.reset_flush_history ()
   end
 
   let dumb = (module Dumb : S)
@@ -108,6 +118,10 @@ module Backend = struct
       let reset () =
         A.reset ();
         B.reset ()
+
+      let reset_flush_history () =
+        A.reset_flush_history ();
+        B.reset_flush_history ()
     end : S)
 end
 
@@ -130,6 +144,10 @@ let print_if_no_status_line line =
 let reset () =
   let (module M : Backend.S) = !Backend.main in
   M.reset ()
+
+let reset_flush_history () =
+  let (module M : Backend.S) = !Backend.main in
+  M.reset_flush_history ()
 
 module Status_line = struct
   type t =

--- a/src/dune_console/dune_console.mli
+++ b/src/dune_console/dune_console.mli
@@ -22,6 +22,8 @@ module Backend : sig
 
     (** Reset the log output *)
     val reset : unit -> unit
+
+    val reset_flush_history : unit -> unit
   end
 
   type t = (module S)


### PR DESCRIPTION
[clear-on-rebuild-and-flush-history] is added for situations where in
fact we do prefer to flush the terminal history. Note that some
emulators will maintain the history regardless.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 2ecb488c-d1ae-4ef8-947a-649091419b2f