### PR TITLE
refactor(stdune): move [Console] to own library

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1,5 +1,6 @@
 open Stdune
 module Config = Dune_util.Config
+module Console = Dune_console
 module Colors = Dune_rules.Colors
 module Clflags = Dune_engine.Clflags
 module Graph = Dune_graph.Graph

--- a/bin/dune
+++ b/bin/dune
@@ -10,6 +10,7 @@
   dune_lang
   fiber
   stdune
+  dune_console
   unix
   dune_metrics
   dune_digest

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -2,6 +2,7 @@ open Stdune
 open Dune_engine
 module Digest = Dune_digest
 module Metrics = Dune_metrics
+module Console = Dune_console
 module Term = Cmdliner.Term
 module Manpage = Cmdliner.Manpage
 module Stanza = Dune_lang.Stanza

--- a/bin/internal_dump.ml
+++ b/bin/internal_dump.ml
@@ -1,4 +1,3 @@
-open Stdune
 open Import
 module Persistent = Dune_util.Persistent
 

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -14,6 +14,7 @@ let local_libraries =
   ; ("vendor/incremental-cycles/src", Some "Incremental_cycles", false, None)
   ; ("src/dag", Some "Dag", false, None)
   ; ("src/fiber", Some "Fiber", false, None)
+  ; ("src/dune_console", Some "Dune_console", false, None)
   ; ("src/memo", Some "Memo", false, None)
   ; ("src/dune_metrics", Some "Dune_metrics", false, None)
   ; ("src/dune_digest", Some "Dune_digest", false, None)

--- a/otherlibs/stdune/stdune.ml
+++ b/otherlibs/stdune/stdune.ml
@@ -10,7 +10,6 @@ module Array = Array
 module Bytes = Bytes
 module Char = Char
 module Comparator = Comparator
-module Console = Console
 module Either = Either
 module Exn = Exn
 module Exn_with_backtrace = Exn_with_backtrace

--- a/src/dune_config/dune
+++ b/src/dune_config/dune
@@ -3,6 +3,7 @@
  (libraries
   stdune
   xdg
+  dune_console
   dune_lang
   dune_cache
   dune_cache_storage

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -2,6 +2,7 @@ open Stdune
 open Dune_lang.Decoder
 module Scheduler = Dune_engine.Scheduler
 module Sandbox_mode = Dune_engine.Sandbox_mode
+module Console = Dune_console
 module Stanza = Dune_lang.Stanza
 module Config = Dune_util.Config
 module String_with_vars = Dune_lang.String_with_vars

--- a/src/dune_console/dune
+++ b/src/dune_console/dune
@@ -1,0 +1,3 @@
+(library
+ (name dune_console)
+ (libraries stdune))

--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -1,3 +1,5 @@
+open Stdune
+
 module Backend = struct
   module type S = sig
     val print_user_message : User_message.t -> unit

--- a/src/dune_console/dune_console.mli
+++ b/src/dune_console/dune_console.mli
@@ -1,3 +1,5 @@
+open Stdune
+
 (** Manages the console *)
 
 (** The console is a system than can report messages and a status to the user.

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -5,6 +5,7 @@
  (libraries
   unix
   stdune
+  dune_console
   dyn
   fiber
   incremental_cycles

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -1,5 +1,6 @@
 include Stdune
 module Digest = Dune_digest
+module Console = Dune_console
 module Metrics = Dune_metrics
 module Log = Dune_util.Log
 module Re = Dune_re

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -3,6 +3,7 @@
  (libraries
   spawn
   fsevents
+  dune_console
   unix
   stdune
   threads.posix

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -1,5 +1,6 @@
 open! Stdune
 module Inotify_lib = Async_inotify_for_dune.Async_inotify
+module Console = Dune_console
 
 module Fs_memo_event = struct
   type kind =

--- a/src/dune_rules/dune
+++ b/src/dune_rules/dune
@@ -9,7 +9,7 @@
   memo
   ocaml
   dune_re
-  console
+  dune_console
   dune_digest
   opam_file_format
   dune_lang

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -1,6 +1,7 @@
 include Stdune
 open Dune_util
 module Digest = Dune_digest
+module Console = Dune_console
 module Config = Config
 module Log = Log
 module Persistent = Persistent

--- a/src/dune_util/dune
+++ b/src/dune_util/dune
@@ -3,6 +3,7 @@
  (libraries
   stdune
   xdg
+  dune_console
   build_path_prefix_map
   dune_sexp
   memo

--- a/src/dune_util/import.ml
+++ b/src/dune_util/import.ml
@@ -1,0 +1,1 @@
+module Console = Dune_console

--- a/src/dune_util/log.ml
+++ b/src/dune_util/log.ml
@@ -1,4 +1,5 @@
 open Stdune
+module Console = Dune_console
 
 module File = struct
   type t =

--- a/src/dune_util/report_error.ml
+++ b/src/dune_util/report_error.ml
@@ -1,4 +1,5 @@
 open Stdune
+open Import
 
 exception Already_reported
 

--- a/src/memo/dune
+++ b/src/memo/dune
@@ -1,4 +1,4 @@
 (library
  (name memo)
- (libraries stdune dyn dune_graph dag fiber unix)
+ (libraries stdune dyn dune_graph dag fiber dune_console unix)
  (synopsis "Incremental computation library that powers Dune"))

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1,6 +1,7 @@
 open! Stdune
 open Fiber.O
 module Graph = Dune_graph.Graph
+module Console = Dune_console
 
 module Debug = struct
   let track_locations_of_lazy_values = ref false

--- a/src/upgrader/dune
+++ b/src/upgrader/dune
@@ -1,4 +1,11 @@
 (library
  (name dune_upgrader)
- (libraries stdune memo opam_file_format dune_lang dune_engine fiber)
+ (libraries
+  stdune
+  dune_console
+  memo
+  opam_file_format
+  dune_lang
+  dune_engine
+  fiber)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/upgrader/dune_upgrader.ml
+++ b/src/upgrader/dune_upgrader.ml
@@ -4,6 +4,7 @@ open! Stdune
    engine *)
 module Dune_project = Dune_engine.Dune_project
 module Source_tree = Dune_engine.Source_tree
+module Console = Dune_console
 module Sub_dirs = Dune_engine.Sub_dirs
 
 type rename_and_edit =

--- a/test/expect-tests/common/dune
+++ b/test/expect-tests/common/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_tests_common)
  (modules dune_tests_common)
- (libraries stdune dune_util))
+ (libraries stdune dune_console dune_util))

--- a/test/expect-tests/common/dune_tests_common.ml
+++ b/test/expect-tests/common/dune_tests_common.ml
@@ -1,4 +1,5 @@
 open Stdune
+module Console = Dune_console
 
 let print pp = Format.printf "%a@." Pp.to_fmt pp
 


### PR DESCRIPTION
[Console] isn't general purpose enough to live in [Stdune]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: ebd1cb41-98fd-4acc-b2a8-0a33ce911772