### PR TITLE
fix(cached_digest): symlinking to target dirs

### DIFF
--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -248,7 +248,7 @@ let refresh_and_remove_write_permissions ~allow_dirs path =
         match stats.st_kind with
         | S_LNK -> (
           match Path.Untracked.stat_exn path with
-          | stats -> refresh stats ~allow_dirs:false path
+          | stats -> refresh stats ~allow_dirs path
           | exception Unix.Unix_error (ELOOP, _, _) -> Cyclic_symlink
           | exception Unix.Unix_error (ENOENT, _, _) -> Broken_symlink)
         | S_REG ->


### PR DESCRIPTION
before, this was forbidden. Now we allow it by passing [allow_dirs]
correctly.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 025a1fa2-5edc-47ff-8413-76ab5bbb5819