### PR TITLE
Fix a typo in faq.rst

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -120,5 +120,5 @@ file:
   val version : unit -> string
   val usage : unit -> unit
 
-The ``ocaml_print-intf`` program has special support for Dune, so it will
+The ``ocaml-print-intf`` program has special support for Dune, so it will
 automatically understand external dependencies.


### PR DESCRIPTION
This fixes a tiny typo in `faq.rst`

Signed-off-by: Jay Lee <jaeho.lee@snu.ac.kr>