### PR TITLE
fix: flush terminal history

### DIFF
--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -31,7 +31,7 @@ module Backend = struct
 
     let reset () = prerr_string "\x1b[H\x1b[2J"
 
-    let reset_flush_history () = prerr_string "\x1bc"
+    let reset_flush_history () = prerr_string "\x1b[1;1H\x1b[2J\x1b[3J"
   end
 
   module Dumb : S = struct


### PR DESCRIPTION
improve escape sequence that flushes terminal history

Seems to work fine in tmux.