### PR TITLE
test: add opam dependencies

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -151,3 +151,7 @@
  (applies_to patch-back-source-tree)
  (enabled_if
   (<> %{system} macosx)))
+
+(cram
+ (applies_to workspaces)
+ (deps %{bin:opam}))

--- a/test/blackbox-tests/test-cases/env/dune
+++ b/test/blackbox-tests/test-cases/env/dune
@@ -1,0 +1,3 @@
+(cram
+ (applies_to envs-and-contexts)
+ (deps ${bin:opam}))

--- a/test/blackbox-tests/test-cases/merlin/dune
+++ b/test/blackbox-tests/test-cases/merlin/dune
@@ -5,3 +5,7 @@
 (cram
  (applies_to merlin-tests)
  (deps %{bin:ocamlfind}))
+
+(cram
+ (applies_to github4125)
+ (deps %{bin:opam}))


### PR DESCRIPTION
all of these tests rely on switches so they should depend on opam

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: e5d76705-36ee-4452-a630-8452bbcc879b