### PR TITLE
Adds native polling mode support on Windows

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -47,6 +47,7 @@ let local_libraries =
   ; ("vendor/ocaml-inotify/src", Some "Ocaml_inotify", false, None)
   ; ("src/async_inotify_for_dune", Some "Async_inotify_for_dune", false,
     None)
+  ; ("src/winwatch", Some "Winwatch", false, None)
   ; ("src/dune_file_watcher", Some "Dune_file_watcher", false, None)
   ; ("src/dune_engine", Some "Dune_engine", false, None)
   ; ("src/dune_config", Some "Dune_config", false, None)

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -259,9 +259,7 @@ module Server = struct
       match Unix.select fds [] [] timeout with
       | [], [], [] ->
         (* Timeout *)
-        if peek_named_pipe t.r_interrupt_accept then (
-          print_endline "data available!";
-          None)
+        if peek_named_pipe t.r_interrupt_accept then None
         else accept t
       | r, [], [] ->
         let inter, accept =

--- a/src/csexp_rpc/pthread_chdir_stubs.c
+++ b/src/csexp_rpc/pthread_chdir_stubs.c
@@ -36,8 +36,8 @@ CAMLprim value dune_pthread_chdir(value dir) {
   CAMLparam1(dir);
   if (__pthread_chdir(String_val(dir))) {
     uerror("__pthread_chdir", Nothing);
-  } 
-  CAMLreturn (Val_unit); 
+  }
+  CAMLreturn (Val_unit);
 }
 
 #else
@@ -51,7 +51,25 @@ CAMLprim value dune_pthread_chdir_is_osx(value unit)
 CAMLprim value dune_pthread_chdir(value unit) {
   CAMLparam1(unit);
   caml_invalid_argument("__pthread_chdir not implemented");
-  CAMLreturn (Val_unit); 
+  CAMLreturn (Val_unit);
+}
+
+#endif
+
+#ifdef _WIN32
+
+value dune_peek_named_pipe(value fd)
+{
+  DWORD bytesAvail;
+  PeekNamedPipe(Handle_val(fd), NULL, 0, NULL, &bytesAvail, NULL);
+  return Val_bool(bytesAvail > 0);
+}
+
+#else
+
+value dune_peek_named_pipe(value fd)
+{
+  caml_invalid_argument("dune_peek_named_pipe: not implemented");
 }
 
 #endif

--- a/src/dune_file_watcher/dune
+++ b/src/dune_file_watcher/dune
@@ -9,5 +9,7 @@
   threads.posix
   ocaml_inotify
   async_inotify_for_dune
-  dune_re)
+  dune_re
+  winwatch
+  dune_util)
  (synopsis "Internal Dune library, do not use!"))

--- a/src/winwatch/dune
+++ b/src/winwatch/dune
@@ -1,0 +1,6 @@
+(library
+ (name winwatch)
+ (libraries stdune dune_util)
+ (foreign_stubs
+  (language c)
+  (names winwatch_stubs)))

--- a/src/winwatch/winwatch.ml
+++ b/src/winwatch/winwatch.ml
@@ -1,0 +1,25 @@
+module Iocp = struct
+  type t
+
+  external create : unit -> t = "winwatch_iocp_create"
+
+  external run : t -> (unit, exn) result = "winwatch_iocp_run"
+end
+
+module Event = struct
+  type t =
+    | Added
+    | Removed
+    | Modified
+    | Renamed_old
+    | Renamed_new
+end
+
+type t
+
+external create : string -> f:(Event.t -> string -> unit) -> t option
+  = "winwatch_create"
+
+external start : t -> Iocp.t -> unit = "winwatch_start"
+
+external stop : t -> unit = "winwatch_stop"

--- a/src/winwatch/winwatch.mli
+++ b/src/winwatch/winwatch.mli
@@ -17,8 +17,8 @@ end
 
 type t
 
-(** return None if the file does not exit *)
 val create : string -> f:(Event.t -> string -> unit) -> t option
+(** return None if the file does not exit *)
 
 val start : t -> Iocp.t -> unit
 

--- a/src/winwatch/winwatch.mli
+++ b/src/winwatch/winwatch.mli
@@ -1,0 +1,25 @@
+module Iocp : sig
+  type t
+
+  val create : unit -> t
+
+  val run : t -> (unit, exn) result
+end
+
+module Event : sig
+  type t =
+    | Added
+    | Removed
+    | Modified
+    | Renamed_old
+    | Renamed_new
+end
+
+type t
+
+(** return None if the file does not exit *)
+val create : string -> f:(Event.t -> string -> unit) -> t option
+
+val start : t -> Iocp.t -> unit
+
+val stop : t -> unit

--- a/src/winwatch/winwatch_stubs.c
+++ b/src/winwatch/winwatch_stubs.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/src/winwatch/winwatch_stubs.c
+++ b/src/winwatch/winwatch_stubs.c
@@ -1,0 +1,207 @@
+#include <stdio.h>
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+#include <caml/osdeps.h>
+#include <caml/memory.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+#include <caml/custom.h>
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#define BUFF_SIZE 1024
+
+typedef struct
+{
+    char *buffer;
+    HANDLE handle;
+    OVERLAPPED *overlapped;
+    value func;
+} dune_t;
+
+static void winwatch_watch(dune_t *t)
+{
+    memset(t->overlapped, 0, sizeof(OVERLAPPED));
+
+    BOOL watch_path = ReadDirectoryChangesW(
+            t->handle, t->buffer, BUFF_SIZE, TRUE,
+            FILE_NOTIFY_CHANGE_FILE_NAME  |
+            FILE_NOTIFY_CHANGE_DIR_NAME   |
+            FILE_NOTIFY_CHANGE_LAST_WRITE,
+            NULL, t->overlapped, NULL);
+}
+
+value winwatch_iocp_create(value v_unit)
+{
+    CAMLparam1(v_unit);
+    HANDLE port = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 1);
+    if (port == NULL)
+      caml_failwith("CreateIoCompletionPort failed");
+    CAMLreturn(caml_copy_nativeint((intnat)port));
+}
+
+value winwatch_iocp_run(value v_iocp)
+{
+    CAMLparam1(v_iocp);
+    CAMLlocal2(v_file_name, v_action);
+    HANDLE iocp = (HANDLE)Nativeint_val(v_iocp);
+    DWORD num_bytes, name_len;
+    WCHAR* file_name;
+    OVERLAPPED *overlapped;
+    FILE_NOTIFY_INFORMATION *event;
+    dune_t *t;
+
+    while (TRUE)
+    {
+        caml_release_runtime_system();
+        BOOL ok = GetQueuedCompletionStatus(iocp, &num_bytes, (PULONG_PTR)&t, &overlapped, 100);
+        caml_acquire_runtime_system();
+
+        if (ok == FALSE && overlapped == NULL) /* Timeout */
+            continue;
+
+        if (ok == FALSE)
+            /* Ignore errors */
+            continue;
+
+        event = (FILE_NOTIFY_INFORMATION*)t->buffer;
+
+        for (;;)
+        {
+            name_len = event->FileNameLength / sizeof(WCHAR);
+
+            switch (event->Action)
+            {
+                case FILE_ACTION_ADDED:
+                    v_action = Val_int(0);
+                    break;
+                case FILE_ACTION_REMOVED:
+                    v_action = Val_int(1);
+                    break;
+                case FILE_ACTION_MODIFIED:
+                    v_action = Val_int(2);
+                    break;
+                case FILE_ACTION_RENAMED_OLD_NAME:
+                    v_action = Val_int(3);
+                    break;
+                case FILE_ACTION_RENAMED_NEW_NAME:
+                    v_action = Val_int(4);
+                    break;
+            }
+
+            file_name = malloc(sizeof(WCHAR) * (name_len + 1));
+            memcpy(file_name, event->FileName, sizeof(WCHAR) * name_len);
+            file_name[name_len] = 0;
+            v_file_name = caml_copy_string_of_utf16(file_name);
+
+            caml_callback2(t->func, v_action, v_file_name);
+
+            if (event->NextEntryOffset)
+            {
+                *((char**)&event) += event->NextEntryOffset;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        winwatch_watch(t);
+    }
+
+    CAMLreturn(Val_unit);
+}
+
+value winwatch_create(value v_path, value v_func)
+{
+    CAMLparam2(v_path, v_func);
+    CAMLlocal2(v_t, v_res);
+    dune_t *t = caml_stat_alloc(sizeof(dune_t));
+    WCHAR *path = caml_stat_strdup_to_utf16(String_val(v_path));
+
+    HANDLE handle = CreateFileW(path,
+            FILE_LIST_DIRECTORY,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            NULL,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+            NULL);
+    caml_stat_free(path);
+
+    if (handle == INVALID_HANDLE_VALUE)
+    {
+        v_res = Val_int(0);
+        goto fail;
+    }
+
+    t->func = v_func;
+    t->buffer = caml_stat_alloc(BUFF_SIZE);
+    t->overlapped = caml_stat_alloc(sizeof(OVERLAPPED));
+    t->handle = handle;
+
+    caml_register_generational_global_root(&t->func);
+
+    v_t = caml_copy_nativeint((intnat)t);
+    v_res = caml_alloc_tuple(1);
+
+    Store_field(v_res, 0, v_t);
+
+fail:
+    CAMLreturn(v_res);
+}
+
+value winwatch_start(value v_t, value v_iocp)
+{
+    CAMLparam2(v_t, v_iocp);
+    HANDLE iocp = (HANDLE)Nativeint_val(v_iocp);
+    dune_t *t = (dune_t *)Nativeint_val(v_t);
+    iocp = CreateIoCompletionPort(t->handle, iocp, (ULONG_PTR)t, 1);
+    if (iocp == NULL)
+    {
+        caml_failwith("File could not be added to completion port.");
+    }
+    winwatch_watch(t);
+    CAMLreturn(Val_unit);
+}
+
+value winwatch_stop(value v_t)
+{
+    CAMLparam1(v_t);
+    dune_t *t = (dune_t *)Nativeint_val(v_t);
+    CancelIo(t->handle);
+    CloseHandle(t->handle);
+    CAMLreturn(Val_unit);
+}
+
+#else
+
+value winwatch_iocp_create(value v_unit)
+{
+  caml_failwith("winwatch_iocp_create: not implemented");
+}
+
+value winwatch_iocp_run(value v_iocp)
+{
+  caml_failwith("winwatch_iocp_run: not implemented");
+}
+
+value winwatch_create(value v_path, value v_func)
+{
+  caml_failwith("winwatch_create: not implemented");
+}
+
+value winwatch_start(value v_t, value v_iocp)
+{
+  caml_failwith("winwatch_start: not implemented");
+}
+
+value winwatch_stop(value v_t)
+{
+  caml_failwith("winwatch_stop: not implemented");
+}
+
+#endif

--- a/src/winwatch/winwatch_stubs.c
+++ b/src/winwatch/winwatch_stubs.c
@@ -63,16 +63,13 @@ value winwatch_iocp_run(value v_iocp)
         if (ok == FALSE && overlapped == NULL) /* Timeout */
             continue;
 
-        if (ok == FALSE)
-            /* Ignore errors */
+        if (ok == FALSE) /* Ignore errors */
             continue;
 
         event = (FILE_NOTIFY_INFORMATION*)t->buffer;
 
         for (;;)
         {
-            name_len = event->FileNameLength / sizeof(WCHAR);
-
             switch (event->Action)
             {
                 case FILE_ACTION_ADDED:
@@ -92,6 +89,7 @@ value winwatch_iocp_run(value v_iocp)
                     break;
             }
 
+            name_len = event->FileNameLength / sizeof(WCHAR);
             file_name = malloc(sizeof(WCHAR) * (name_len + 1));
             memcpy(file_name, event->FileName, sizeof(WCHAR) * name_len);
             file_name[name_len] = 0;
@@ -99,14 +97,9 @@ value winwatch_iocp_run(value v_iocp)
 
             caml_callback2(t->func, v_action, v_file_name);
 
-            if (event->NextEntryOffset)
-            {
-                *((char**)&event) += event->NextEntryOffset;
-            }
-            else
-            {
-                break;
-            }
+            if (event->NextEntryOffset == 0) break;
+
+            *((char**)&event) += event->NextEntryOffset;
         }
 
         winwatch_watch(t);


### PR DESCRIPTION
Adds support for polling mode on Windows using a new internal library `winwatch`, which takes inspiration for its structure from `fsevents`. `winwatch` uses the Windows ReadDirectoryChangesW API to watch for file changes and an I/O Completion Port to report notifications in a callback. `dune_file_watcher` now uses `winwatch` instead of `fswatch` on native Windows, and notifications received in `dune_file_watcher` are filtered for relevance before they are passed to `scheduler.thread_safe_send_emit_events_job`.

One additional change was made for compatibility on Windows: 
The rpc server typically uses `Unix.pipe` in non-blocking mode, but non-blocking mode is not supported on Windows. The proposed solution instead uses a blocking pipe that times out every 0.1 second and reblocks.

Potential areas for improvement: 
The proposed solution does not prevent the same path from being watched multiple times. A potential solution would be a trie that stores paths, like `Watch_trie` used by for `fsevents`.
 
Signed-off-by: Uma Kothuri <uma@kothuri.net>