### PR TITLE
fix(duild-info): reapply flambda fix from #3599 removed in #5049

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 
 - Inline tests are now sandboxed by default (#6079, @rgrinberg)
 
+- Fix build-info version when used with flambda (#6089, fixes #6075, @jberdine)
+
 3.4.1 (26-07-2022)
 ------------------
 

--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -100,9 +100,9 @@ Check what the generated build info module looks like:
       None
   [@@inline never]
   
-  let p1 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:a%%%%%%%%%%%%%%%%%%%%%%%%%%"
-  let p2 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:b%%%%%%%%%%%%%%%%%%%%%%%%%%"
-  let p0 = eval "%%DUNE_PLACEHOLDER:64:vcs-describe:1:c%%%%%%%%%%%%%%%%%%%%%%%%%%"
+  let p1 = eval (Sys.opaque_identity "%%DUNE_PLACEHOLDER:64:vcs-describe:1:a%%%%%%%%%%%%%%%%%%%%%%%%%%")
+  let p2 = eval (Sys.opaque_identity "%%DUNE_PLACEHOLDER:64:vcs-describe:1:b%%%%%%%%%%%%%%%%%%%%%%%%%%")
+  let p0 = eval (Sys.opaque_identity "%%DUNE_PLACEHOLDER:64:vcs-describe:1:c%%%%%%%%%%%%%%%%%%%%%%%%%%")
   
   let version = p0
   


### PR DESCRIPTION
With flambda, Sys.opaque_identity is needed around the placeholder
string or else flambda is able to compile it away. This prevents the
rewriting done by e.g. `dune install` from working.

fix: https://github.com/ocaml/dune/issues/6075