### PR TITLE
test: permissions on directory targets

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
+++ b/test/blackbox-tests/test-cases/directory-targets/remove-write-permissions.t
@@ -1,0 +1,21 @@
+Write permissions on directory targets.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.4)
+  > (using directory-targets 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (rule
+  >  (action (system "mkdir -p foo/foo2 && touch foo/foo2/bar"))
+  >  (targets (dir foo)))
+  > EOF
+
+  $ dune build ./foo
+  $ dir=_build/default/foo
+  $ dune_cmd stat permissions $dir
+  755
+  $ dune_cmd stat permissions $dir/foo2
+  755
+  $ dune_cmd stat permissions $dir/foo2/bar
+  444


### PR DESCRIPTION
dune does not make directory targets read only at the moment

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 6cf69909-983b-4440-9286-e33146f183d8