### PR TITLE
XDG stubs: require Vista functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@
 - Support `(foreign_objects ...)` field in `(executable ...)` and `(library
   ...)` stanzas (#6084, fixes #4129, @gridbugs)
 
+- Fix compilation of Dune under esy on Windows (#6109, fixes #6098, @nojb)
+
 3.4.1 (26-07-2022)
 ------------------
 

--- a/otherlibs/xdg/xdg_stubs.c
+++ b/otherlibs/xdg/xdg_stubs.c
@@ -5,6 +5,11 @@
 
 #ifdef _WIN32
 
+/*  Windows Vista functions enabled */
+
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+
 #include <Windows.h>
 #include <Knownfolders.h>
 #include <Shlobj.h>


### PR DESCRIPTION
Attempt to fix #6098 