### PR TITLE
feature(ocamlc_loc): messages without location

### DIFF
--- a/otherlibs/ocamlc_loc/src/lexer.mli
+++ b/otherlibs/ocamlc_loc/src/lexer.mli
@@ -27,18 +27,16 @@ type line =
   }
 
 type token =
-  | Toplevel of
-      { indent : int
-      ; loc : loc
-      ; severity : severity
-      ; message : string
-      }
-  | Related of
+  | Loc of
       { indent : int
       ; loc : loc
       ; message : string
       }
   | Line of line
   | Eof
+
+val severity : Lexing.lexbuf -> (severity * string) option
+
+val skip_excerpt : Lexing.lexbuf -> [ `Stop | `Continue ]
 
 val token : Lexing.lexbuf -> token

--- a/otherlibs/ocamlc_loc/src/ocamlc_loc.ml
+++ b/otherlibs/ocamlc_loc/src/ocamlc_loc.ml
@@ -49,6 +49,8 @@ module Tokens : sig
 
   val junk : t -> unit
 
+  val push : t -> Lexer.token -> unit
+
   val next : t -> Lexer.token
 end = struct
   type t =
@@ -57,6 +59,8 @@ end = struct
     }
 
   let create lexbuf = { lexbuf; unread = [] }
+
+  let push t token = t.unread <- token :: t.unread
 
   let next t =
     match t.unread with
@@ -79,47 +83,106 @@ end = struct
     | _ -> ignore (Lexer.token t.lexbuf)
 end
 
-let parse lexbuf =
+let indent_of_severity = function
+  | Error _ -> String.length "Error: "
+  | Warning _ -> String.length "Warning: "
+
+let severity tokens =
+  match Tokens.peek tokens with
+  | Line { contents; indent } -> (
+    match Lexer.severity (Lexing.from_string contents) with
+    | None -> raise Unknown_format
+    | Some (severity, new_contents) ->
+      Tokens.junk tokens;
+      let indent = indent_of_severity severity + indent in
+      Tokens.push tokens (Line { indent; contents = new_contents });
+      severity)
+  | _ -> raise Unknown_format
+
+let rec skip_excerpt tokens =
+  match Tokens.peek tokens with
+  | Line { contents; indent = _ } -> (
+    match Lexer.skip_excerpt (Lexing.from_string contents) with
+    | `Continue ->
+      Tokens.junk tokens;
+      skip_excerpt tokens
+    | `Stop -> ())
+  | _ -> ()
+
+let rec acc_message tokens min_indent acc =
+  match Tokens.peek tokens with
+  | Line line ->
+    Tokens.junk tokens;
+    let min_indent = min min_indent line.indent in
+    acc_message tokens min_indent (line :: acc)
+  | _ ->
+    List.rev_map acc ~f:(fun { indent; contents } ->
+        let prefix = String.make (indent - min_indent) ' ' in
+        prefix ^ contents)
+    |> String.concat "\n" |> String.trim
+
+let rec related tokens acc =
+  match Tokens.peek tokens with
+  | Loc { indent; message; loc } ->
+    if indent = 0 then List.rev acc
+    else (
+      Tokens.junk tokens;
+      let message =
+        acc_message tokens indent [ { indent; contents = message } ]
+      in
+      let acc = (loc, message) :: acc in
+      related tokens acc)
+  | _ -> List.rev acc
+
+let toplevel tokens =
+  match Tokens.next tokens with
+  | Loc { indent; message; loc } ->
+    if indent > 0 then raise Unknown_format;
+    skip_excerpt tokens;
+    let severity = severity tokens in
+    let indent = indent + indent_of_severity severity in
+    let message =
+      acc_message tokens indent [ { indent; contents = message } ]
+    in
+    let related = related tokens [] in
+    { loc; severity; message; related }
+  | _ -> raise Unknown_format
+
+let parse s =
+  let lexbuf = Lexing.from_string s in
   let tokens = Tokens.create lexbuf in
-  let rec acc_message min_indent acc =
+  let rec loop acc =
+    match toplevel tokens with
+    | exception Unknown_format -> List.rev acc
+    | t -> loop (t :: acc)
+  in
+  loop []
+
+let dyn_of_raw =
+  Dyn.list (function
+    | `Loc loc -> dyn_of_loc loc
+    | `Message m -> Dyn.string m)
+
+let parse_raw s =
+  let lexbuf = Lexing.from_string s in
+  let tokens = Tokens.create lexbuf in
+  let rec loop acc =
     match Tokens.peek tokens with
+    | Loc { loc; message; indent } ->
+      Tokens.junk tokens;
+      let acc = `Loc loc :: acc in
+      let message =
+        acc_message tokens indent [ { contents = message; indent } ]
+      in
+      let acc = `Message message :: acc in
+      loop acc
     | Line line ->
       Tokens.junk tokens;
-      let min_indent = min min_indent line.indent in
-      acc_message min_indent (line :: acc)
-    | _ ->
-      List.rev_map acc ~f:(fun { indent; contents } ->
-          let prefix = String.make (indent - min_indent) ' ' in
-          prefix ^ contents)
-      |> String.concat "\n" |> String.trim
-  in
-  let rec related acc =
-    match Tokens.peek tokens with
-    | Related { indent; loc; message } ->
+      let message = acc_message tokens line.indent [ line ] in
+      let acc = `Message message :: acc in
+      loop acc
+    | Eof ->
       Tokens.junk tokens;
-      let message = acc_message indent [ { indent; contents = message } ] in
-      related ((loc, message) :: acc)
-    | _ -> List.rev acc
+      List.rev acc
   in
-  let rec toplevel acc =
-    match Tokens.next tokens with
-    | Toplevel { indent; loc; severity; message } ->
-      let message =
-        let indent =
-          indent
-          +
-          match severity with
-          | Error _ -> String.length "Error: "
-          | Warning _ -> String.length "Warning: "
-        in
-        acc_message indent [ { indent; contents = message } ]
-      in
-      let related = related [] in
-      let acc = { severity; loc; message; related } :: acc in
-      toplevel acc
-    | Eof -> acc
-    | _ -> raise Unknown_format
-  in
-  try List.rev @@ toplevel [] with Unknown_format -> []
-
-let parse s = parse (Lexing.from_string s)
+  loop []

--- a/otherlibs/ocamlc_loc/src/ocamlc_loc.mli
+++ b/otherlibs/ocamlc_loc/src/ocamlc_loc.mli
@@ -31,4 +31,8 @@ type report =
 
 val dyn_of_report : report -> Dyn.t
 
+val dyn_of_raw : [ `Loc of loc | `Message of string ] list -> Dyn.t
+
+val parse_raw : string -> [ `Loc of loc | `Message of string ] list
+
 val parse : string -> report list


### PR DESCRIPTION
This is needed for ocamllsp to reuse the library to parse the error messages produced by merlin.