### PR TITLE
fix: wait until output if flushed

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -85,16 +85,20 @@ let default =
             ]
         ] )
 
+let exit_and_flush code =
+  Console.finish ();
+  exit code
+
 let () =
   Colors.setup_err_formatter_colors ();
   try
     match Term.Group.eval default all ~catch:false with
-    | `Error _ -> exit 1
-    | _ -> exit 0
+    | `Error _ -> exit_and_flush 1
+    | _ -> exit_and_flush 0
   with
-  | Scheduler.Run.Shutdown.E Requested -> exit 0
-  | Scheduler.Run.Shutdown.E (Signal _) -> exit 130
+  | Scheduler.Run.Shutdown.E Requested -> exit_and_flush 0
+  | Scheduler.Run.Shutdown.E (Signal _) -> exit_and_flush 130
   | exn ->
     let exn = Exn_with_backtrace.capture exn in
     Dune_util.Report_error.report exn;
-    exit 1
+    exit_and_flush 1

--- a/src/dune_console/dune_console.mli
+++ b/src/dune_console/dune_console.mli
@@ -37,6 +37,8 @@ val reset_flush_history : unit -> unit
 (** Reset the log output *)
 val reset : unit -> unit
 
+val finish : unit -> unit
+
 (** [print paragraphs] is a short-hand for:
 
     {[


### PR DESCRIPTION
wait until all output is flushed before terminating dune

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 4a999aa6-1018-4ec0-a3b2-8f54426e4885