### PR TITLE
Fix misplaced "inlined" attributes

### DIFF
--- a/otherlibs/stdune/applicative.ml
+++ b/otherlibs/stdune/applicative.ml
@@ -23,7 +23,7 @@ module Make (A : Applicative_intf.Basic) = struct
       and+ xs = all xs in
       x :: xs
 end
-[@@inlined always]
+[@@inline always]
 
 module Id = struct
   include Make (struct

--- a/otherlibs/stdune/monad.ml
+++ b/otherlibs/stdune/monad.ml
@@ -32,7 +32,7 @@ module Make (M : Basic) = struct
     let ( and* ) = ( and+ )
   end
 end
-[@@inlined always]
+[@@inline always]
 
 module Id = Make (struct
   type 'a t = 'a

--- a/otherlibs/stdune/monoid.ml
+++ b/otherlibs/stdune/monoid.ml
@@ -14,7 +14,7 @@ module Make (M : Basic) : Monoid_intf.S with type t = M.t = struct
   let map_reduce ~f =
     List.fold_left ~init:empty ~f:(fun acc a -> combine acc (f a))
 end
-[@@inlined always]
+[@@inline always]
 
 module Exists = Make (struct
   type t = bool

--- a/otherlibs/stdune/top_closure.ml
+++ b/otherlibs/stdune/top_closure.ml
@@ -26,7 +26,7 @@ module Make (Keys : Top_closure_intf.Keys) (Monad : Monad_intf.S) = struct
     | Ok (res, _visited) -> Monad.return (Ok (List.rev res))
     | Error elts -> Monad.return (Error elts)
 end
-[@@inlined always]
+[@@inline always]
 
 module Int = Make (Int.Set) (Monad.Id)
 module String = Make (String.Set) (Monad.Id)

--- a/src/fiber/core.ml
+++ b/src/fiber/core.ml
@@ -98,7 +98,7 @@ let apply2 f x y =
     let exn = Exn_with_backtrace.capture exn in
     Reraise exn
 
-let[@inlined always] fork a b =
+let[@inline always] fork a b =
   match apply a () with
   | End_of_fiber () -> b ()
   | eff -> Fork (eff, b)


### PR DESCRIPTION
This fixes several places where `[@@inlined]` was written but `[@@inline]` was intended.  Per [the manual](https://v2.ocaml.org/manual/attributes.html#ss:builtin-attributes), the former goes on specific application sites, while the latter goes on function definitions.  The attributes are currently having no effect - the compiler just ignores them.

Of course, inlining something doesn't always affect performance in the direction one expects.  I don't know if there are dune benchmarks somewhere that could be used to test this change.  An alternative is to just delete these attributes, preserving the current performance behavior.