### PR TITLE
Check that a test stanza is disabled before generating the rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.5.0 (unreleased)
 ------------------
 
+- Check if a `tests` stanza is disabled before generating the rules (#6134,
+  fixes #6132, @voodoos)
+
 - Shadow alias module `Foo__` when building a library `Foo` (#6126, @rgrinberg)
 
 - Allow dune describe workspace to accept directories as arguments.

--- a/test/blackbox-tests/test-cases/tests-stanza/github6132.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/github6132.t
@@ -16,11 +16,7 @@
   > EOF
   $ touch missing_test.ml
 
-FIXME: both the missing_test and lib_not are disabled so this error could be
-ignored.
+The test [missing_test] depends on a library that is disabled, but that should
+not trigger any error since the test itself is disabled in the same way as the
+library it depends on.
   $ dune build @all
-  File "dune", line 9, characters 10-17:
-  9 |  (modules lib_not)
-                ^^^^^^^
-  Error: Module Lib_not doesn't exist.
-  [1]

--- a/test/blackbox-tests/test-cases/tests-stanza/github6132.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/github6132.t
@@ -1,0 +1,26 @@
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (test
+  >  (name missing_test)
+  >  (modules missing_test)
+  >  (enabled_if false)
+  >  (libraries lib_not))
+  > 
+  > (library
+  >  (name lib_not)
+  >  (modules lib_not)
+  >  (enabled_if false))
+  > EOF
+  $ touch missing_test.ml
+
+FIXME: both the missing_test and lib_not are disabled so this error could be
+ignored.
+  $ dune build @all
+  File "dune", line 9, characters 10-17:
+  9 |  (modules lib_not)
+                ^^^^^^^
+  Error: Module Lib_not doesn't exist.
+  [1]


### PR DESCRIPTION
Unlike the `executables` stanza, Dune attempted to create some rules for a `tests` even if it was disabled. This adds a similar check as the one for `executables` to abort rule generation if the stanza is disabled.

This should fix #6132 
