### PR TITLE
Disable dune cache for test suite

### DIFF
--- a/otherlibs/action-plugin/test/depends-on-directory-with-glob/run.t
+++ b/otherlibs/action-plugin/test/depends-on-directory-with-glob/run.t
@@ -1,3 +1,5 @@
+  $ export DUNE_CACHE=disabled
+
   $ cat > dune-project << EOF
   > (lang dune 2.0)
   > (using action-plugin 0.1)

--- a/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/run.t
+++ b/otherlibs/action-plugin/test/do-not-rebuild-unneeded-dependency/run.t
@@ -1,3 +1,5 @@
+  $ export DUNE_CACHE=disabled
+
 This test checks that in case the dependency of multi staged computation changes,
 only the dependencies up to this stage are rebuilt.
 

--- a/otherlibs/action-plugin/test/one-target/run.t
+++ b/otherlibs/action-plugin/test/one-target/run.t
@@ -1,3 +1,5 @@
+  $ export DUNE_CACHE=disabled
+
   $ cat > dune-project << EOF
   > (lang dune 2.0)
   > (using action-plugin 0.1)

--- a/otherlibs/action-plugin/test/simple-copy/run.t
+++ b/otherlibs/action-plugin/test/simple-copy/run.t
@@ -1,3 +1,5 @@
+  $ export DUNE_CACHE=disabled
+
   $ cat > dune-project << EOF
   > (lang dune 2.0)
   > (using action-plugin 0.1)

--- a/otherlibs/action-plugin/test/target-in-parent-directory/run.t
+++ b/otherlibs/action-plugin/test/target-in-parent-directory/run.t
@@ -1,3 +1,5 @@
+  $ export DUNE_CACHE=disabled
+
   $ cat > dune-project << EOF
   > (lang dune 2.0)
   > (using action-plugin 0.1)

--- a/otherlibs/action-plugin/test/two-stages-dependency-choose/run.t
+++ b/otherlibs/action-plugin/test/two-stages-dependency-choose/run.t
@@ -1,3 +1,5 @@
+  $ export DUNE_CACHE=disabled
+
 In this test client choose what to depend
 on based on dependency from the previous stage.
 

--- a/otherlibs/configurator/test/blackbox-tests/pkg-config-quoting.t/run.t
+++ b/otherlibs/configurator/test/blackbox-tests/pkg-config-quoting.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 These tests show how various pkg-config invocations get quotes:
   $ dune build 2>&1 | awk '/run:.*bin\/pkg-config/{a=1}/stderr/{a=0}a'
   run: $TESTCASE_ROOT/_build/install/default/bin/pkg-config --print-errors gtk+-quartz-3.0

--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test embedding of sites locations information
 -----------------------------------
 

--- a/otherlibs/site/test/run_2_9.t
+++ b/otherlibs/site/test/run_2_9.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test embedding of sites locations information
 -----------------------------------
 

--- a/test/blackbox-tests/test-cases/action-modifying-a-dependency.t/run.t
+++ b/test/blackbox-tests/test-cases/action-modifying-a-dependency.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 In this test the "x" alias depends on the file "data" but the action
 associated to "x" appends a line to "data". The expected behavior is
 an error from Dune telling the user that this is not allowed, however

--- a/test/blackbox-tests/test-cases/actions/action-stdxxx-on-success.t
+++ b/test/blackbox-tests/test-cases/actions/action-stdxxx-on-success.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test for --action-stdxxx-on-success
 ====================================
 

--- a/test/blackbox-tests/test-cases/actions/cat-multiple.t
+++ b/test/blackbox-tests/test-cases/actions/cat-multiple.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ cat > dune-project << EOF
   > (lang dune 3.4)
   > EOF

--- a/test/blackbox-tests/test-cases/all-alias/install-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias/install-alias.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 @all includes user defined install alias
 
   $ dune build --display short @all

--- a/test/blackbox-tests/test-cases/all-alias/private-exe.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias/private-exe.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 @all builds private exe's
 
   $ dune build @all --display short

--- a/test/blackbox-tests/test-cases/all-alias/private-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias/private-lib.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 @all builds private libs
 
   $ dune build --display short @all

--- a/test/blackbox-tests/test-cases/all-alias/user-defined.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias/user-defined.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 @all builds user defined rules
 
   $ dune build --display short @all

--- a/test/blackbox-tests/test-cases/byte-code-only.t/run.t
+++ b/test/blackbox-tests/test-cases/byte-code-only.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ env ORIG_PATH="$PATH" PATH="$PWD/ocaml-bin:$PATH" dune build @all --display short
         ocamlc bin/.toto.eobjs/byte/dune__exe__Toto.{cmi,cmo,cmt}
         ocamlc src/.foo.objs/byte/foo.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/check-alias/ocamldep-cycles.t
+++ b/test/blackbox-tests/test-cases/check-alias/ocamldep-cycles.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 The @check alias should detect dependency cycles
 
   $ cat >dune-project <<EOF

--- a/test/blackbox-tests/test-cases/copy_files.t/run.t
+++ b/test/blackbox-tests/test-cases/copy_files.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test that (copy_files ...) works
 
   $ dune build --root test1 test.exe .merlin-conf/lib-foo .merlin-conf/exe-test

--- a/test/blackbox-tests/test-cases/coq/base-unsound.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/base-unsound.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --display short --profile unsound --debug-dependency-path @all
         coqdep bar.v.d
         coqdep foo.v.d

--- a/test/blackbox-tests/test-cases/coq/base.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/base.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --display short --debug-dependency-path @all
         coqdep bar.v.d
         coqdep foo.v.d

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --display short --debug-dependency-path @all
         coqdep thy1/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/coq/compose-private-ambiguous.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-private-ambiguous.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 We have two theories, A and A_vendored both called A. We test which one a
 private plugin B and the public package C will pick up.
 

--- a/test/blackbox-tests/test-cases/coq/compose-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-private.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Testing composition of theories with two private theories and a third public
 theory. As expected, the private theories build, but the public theory fails
 because a public theory cannot depend on a private theory. 

--- a/test/blackbox-tests/test-cases/coq/compose-projects-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-boot.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Testing composition of theories accross a dune workspace with a boot library. A
 boot library must have the following:
 

--- a/test/blackbox-tests/test-cases/coq/compose-projects-private-ambiguous.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-private-ambiguous.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Testing ambiguous composition of private and public theories
 
 1. theory `A` is public belonging to `A/dune-project`

--- a/test/blackbox-tests/test-cases/coq/compose-projects.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Testing composition of theories accross a dune workspace
   $ dune build B
   Hello

--- a/test/blackbox-tests/test-cases/coq/coqdep-on-rebuild.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdep-on-rebuild.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ mkdir b
   $ cat > b/dune <<EOF
   > (coq.theory

--- a/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 We build the coqdoc html target:
   $ dune build basic.html/
 

--- a/test/blackbox-tests/test-cases/coq/coqtop-recomp.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop-recomp.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Check that dependencies are not recompiled when this is not necessary. This
 was initially an issue, and was reported by @MackieLoeffel in #5457 (see
 https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).

--- a/test/blackbox-tests/test-cases/coq/extract.t
+++ b/test/blackbox-tests/test-cases/coq/extract.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ cat >dune-project <<EOF
   > (lang dune 2.5)
   > (using coq 0.2)

--- a/test/blackbox-tests/test-cases/coq/flags.t
+++ b/test/blackbox-tests/test-cases/coq/flags.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test cases to check Coq's flag setting is correct:
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --display short --debug-dependency-path @all
         coqdep theories/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --profile=release --display short --debug-dependency-path @all
         coqdep bar/bar.v.d
         coqdep foo/foo.v.d

--- a/test/blackbox-tests/test-cases/coq/native-single.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --profile=release --display short --debug-dependency-path @all
         coqdep bar.v.d
         coqdep foo.v.d

--- a/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --display short --debug-dependency-path @all
         coqdep a/bar.v.d
         coqdep b/foo.v.d

--- a/test/blackbox-tests/test-cases/corrections.t
+++ b/test/blackbox-tests/test-cases/corrections.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ echo '(lang dune 2.0)' > dune-project
   $ echo file-contents > text-file
 

--- a/test/blackbox-tests/test-cases/cross-compilation.t/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf dune build --display short -x foo file @install --promote-install-files
       ocamldep bin/.blah.eobjs/blah.ml.d
         ocamlc lib/.p.objs/byte/p.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/normal.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/normal.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build --display short file @install
       ocamldep .p.eobjs/p.ml.d
       ocamldep .p.eobjs/p.ml.d [cross]

--- a/test/blackbox-tests/test-cases/cxx-extension.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-extension.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ cat >dune <<EOF
   > (library
   >  (name foo)

--- a/test/blackbox-tests/test-cases/default-targets.t/run.t
+++ b/test/blackbox-tests/test-cases/default-targets.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Generates targets when modes is set for binaries:
   $ dune build --root bins --display short @all 2>&1 | grep '\.bc\|\.exe'
         ocamlc byteandnative.bc

--- a/test/blackbox-tests/test-cases/dep-on-dir-that-does-not-exist.t/run.t
+++ b/test/blackbox-tests/test-cases/dep-on-dir-that-does-not-exist.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 # Here we test that actions depending on a glob correctly
 # depend on the directory existence as well.
 #

--- a/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t
+++ b/test/blackbox-tests/test-cases/depend-on/dep-on-alias.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 
   $ mkdir a
   $ cd a

--- a/test/blackbox-tests/test-cases/depend-on/installed-packages.t
+++ b/test/blackbox-tests/test-cases/depend-on/installed-packages.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 # Test dependency on installed package
 
   $ mkdir a b prefix

--- a/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t
+++ b/test/blackbox-tests/test-cases/depend-on/no-deps-in-cwd.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 
   $ cat >dune-project <<EOF
   > (lang dune 3.0)

--- a/test/blackbox-tests/test-cases/dialects/good.t/run.t
+++ b/test/blackbox-tests/test-cases/dialects/good.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test the (dialect ...) stanza inside the dune-project file.
 
   $ dune exec ./main.exe

--- a/test/blackbox-tests/test-cases/directory-targets/main.t
+++ b/test/blackbox-tests/test-cases/directory-targets/main.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Tests for directory targets.
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/directory-targets/no-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/no-sandboxing.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Tests for directory targets that are produced by unsandboxed rule
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/directory-targets/old-style/target.t/run.t
+++ b/test/blackbox-tests/test-cases/directory-targets/old-style/target.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build && cat _build/default/dir/*
   bar contents
   foo contents

--- a/test/blackbox-tests/test-cases/display.t
+++ b/test/blackbox-tests/test-cases/display.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Document how Dune displays various things
 =========================================
 

--- a/test/blackbox-tests/test-cases/dune-cache/config.t
+++ b/test/blackbox-tests/test-cases/dune-cache/config.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test cache configuration.
 
 Check that old cache configuration format works fine with an old language

--- a/test/blackbox-tests/test-cases/dune-cache/missing-cache-entries.t
+++ b/test/blackbox-tests/test-cases/dune-cache/missing-cache-entries.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Check that Dune cache can cope with missing file/metadata entries.
 
   $ export DUNE_CACHE_ROOT=$PWD/.cache

--- a/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-copy.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test basic cache store/restore functionality in the [copy] mode.
 
 Dune supports setting the cache directory in two ways, via the [XDG_CACHE_HOME]

--- a/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
+++ b/test/blackbox-tests/test-cases/dune-cache/mode-hardlink.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test basic cache store/restore functionality in the default [hardlink] mode.
 
 Dune supports setting the cache directory in two ways, via the [XDG_CACHE_HOME]

--- a/test/blackbox-tests/test-cases/dune-cache/repro-check.t
+++ b/test/blackbox-tests/test-cases/dune-cache/repro-check.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test reproducibility check
 
   $ export DUNE_CACHE_ROOT=$PWD/.cache

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Setup mutable files
 -------------------
 

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 No ppx driver found
 
   $ mkdir -p no-driver

--- a/test/blackbox-tests/test-cases/dynamic-dependencies.t
+++ b/test/blackbox-tests/test-cases/dynamic-dependencies.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Tests for dynamic dependencies computed from the `%{read:...}` family of macros
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/dynamic-dependencies/read-macro-produces-dyn-deps.t
+++ b/test/blackbox-tests/test-cases/dynamic-dependencies/read-macro-produces-dyn-deps.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Tests for dynamic dependencies computed from the `%{read:...}` family of macros
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/enabled_if/eif-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-simple.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test that `enabled_if` fields work as expected.
 
 This alias is disabled, building it should do nothing:

--- a/test/blackbox-tests/test-cases/env/env-bin-pform.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-bin-pform.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 %{exe:foo.exe} should not be veisible if foo.exe is added to PATH via the
 binaries stanza. %{bin:foo} is visible on the other hand.
   $ dune build

--- a/test/blackbox-tests/test-cases/env/env-bins.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-bins.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Basic test that we can use private binaries as public ones
   $ dune build --root private-bin-import
   Entering directory 'private-bin-import'

--- a/test/blackbox-tests/test-cases/env/env-tracking.t/run.t
+++ b/test/blackbox-tests/test-cases/env/env-tracking.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Aliases without a (env) dependency are not rebuilt when the environment
 changes:
 

--- a/test/blackbox-tests/test-cases/env/env-unused.t
+++ b/test/blackbox-tests/test-cases/env/env-unused.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ cat > dune-project << EOF
   > (lang dune 3.3)
   > EOF

--- a/test/blackbox-tests/test-cases/exe-name-mangle/multi-module.t/run.t
+++ b/test/blackbox-tests/test-cases/exe-name-mangle/multi-module.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 These tests show that (wrapped_executables true) addresses the problem of compilation
 units of exes colliding with libraries.
 

--- a/test/blackbox-tests/test-cases/exe-name-mangle/single-module.t/run.t
+++ b/test/blackbox-tests/test-cases/exe-name-mangle/single-module.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 These tests show that (wrapped_executables true) addresses the problem of compilation
 units of exes colliding with libraries.
 

--- a/test/blackbox-tests/test-cases/exec-missing.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-missing.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 When using dune exec, the external-lib-deps command refers to the executable:
 
   $ dune exec ./x.exe

--- a/test/blackbox-tests/test-cases/force-test.t/run.t
+++ b/test/blackbox-tests/test-cases/force-test.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Running a test and then forcing a re-run will only re-run the test exe:
 
   $ dune runtest

--- a/test/blackbox-tests/test-cases/gh5267.t
+++ b/test/blackbox-tests/test-cases/gh5267.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 This issue demonstrates a bug when there's a library without any modules and an
 executable with a module with the same name as the library's entry point in the
 same directory.

--- a/test/blackbox-tests/test-cases/github1342.t
+++ b/test/blackbox-tests/test-cases/github1342.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Reproduction case for #1342. Check that when the user edits files in
 _build, things are rebuild as expected.
 

--- a/test/blackbox-tests/test-cases/github1426.t/run.t
+++ b/test/blackbox-tests/test-cases/github1426.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Changing write permissions of a dependency doesn't cause a re-run
   $ chmod -w ./script.sh
   $ dune build a_target --display short

--- a/test/blackbox-tests/test-cases/github1616.t/run.t
+++ b/test/blackbox-tests/test-cases/github1616.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Regression test for #1616
 
   $ env PATH="$PWD/bin2:$PWD/bin1:$PATH" dune build --root root

--- a/test/blackbox-tests/test-cases/github2228.t/run.t
+++ b/test/blackbox-tests/test-cases/github2228.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Regression test for installing mli only modules. Previously, the install step
 would fail because the .cmi wasn't correctly copied to the _build/install dir.
 

--- a/test/blackbox-tests/test-cases/github5264.t
+++ b/test/blackbox-tests/test-cases/github5264.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Reproduction case for #5264
 
 Before Dune 3.0, it was possible to abuse the

--- a/test/blackbox-tests/test-cases/github568.t/run.t
+++ b/test/blackbox-tests/test-cases/github568.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune runtest -p lib1 --debug-dependency-path
   (cd _build/default && ./test1.exe)
   running test 1

--- a/test/blackbox-tests/test-cases/github660/explicit-interfaces.t/run.t
+++ b/test/blackbox-tests/test-cases/github660/explicit-interfaces.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 When there are explicit interfaces, modules must be rebuilt.
   $ echo 'let hello = "hello"' > lib_sub.ml
 

--- a/test/blackbox-tests/test-cases/github660/no-interfaces.t/run.t
+++ b/test/blackbox-tests/test-cases/github660/no-interfaces.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 When there are no interfaces, the situation is the same, but it
 is not possible to rely on these.
 

--- a/test/blackbox-tests/test-cases/glob_files_rec.t
+++ b/test/blackbox-tests/test-cases/glob_files_rec.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Tests for (glob_files_rec <dir>/<glob>). This feature is not meat to
 be release as it. We plan to replace it by recursive globs for 3.0.0.
 

--- a/test/blackbox-tests/test-cases/include-subdirs/test1.t/run.t
+++ b/test/blackbox-tests/test-cases/include-subdirs/test1.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Simple test with a multi dir exe
 --------------------------------
 

--- a/test/blackbox-tests/test-cases/include-subdirs/test2.t/run.t
+++ b/test/blackbox-tests/test-cases/include-subdirs/test2.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test that include_subdirs stop the recursion
 --------------------------------------------
 

--- a/test/blackbox-tests/test-cases/incremental-rebuilds.t
+++ b/test/blackbox-tests/test-cases/incremental-rebuilds.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ echo '(lang dune 2.0)' > dune-project
   $ echo '(rule (target b) (deps a) (action (progn (echo "running") (with-stdout-to b (cat a)))))' >> dune
 

--- a/test/blackbox-tests/test-cases/inline_tests-multi-mode.t
+++ b/test/blackbox-tests/test-cases/inline_tests-multi-mode.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test running inline tests in multiple modes at once
 
 Reproduction case for #3347

--- a/test/blackbox-tests/test-cases/inline_tests/dune-file.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/dune-file.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 This test makes sure that inline_tests backends are functional when they are
 externally installed.
 

--- a/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 This test ensures that compilation fails when an invalid option is supplied
 to flags field in executable field in inline_tests field.
 

--- a/test/blackbox-tests/test-cases/inline_tests/many-backends-choose.t
+++ b/test/blackbox-tests/test-cases/inline_tests/many-backends-choose.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ cat >dune-project <<EOF
   > (lang dune 2.6)
   > EOF

--- a/test/blackbox-tests/test-cases/inline_tests/multiple-inline-tests.t
+++ b/test/blackbox-tests/test-cases/inline_tests/multiple-inline-tests.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test for multiple libraries with inline_tests set in the same directory
 
   $ cat >dune-project <<EOF

--- a/test/blackbox-tests/test-cases/installable-dup-private-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/installable-dup-private-libs.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build @install --display short
         ocamlc a1/.a.objs/byte/a.{cmi,cmo,cmt}
         ocamlc a2/.a.objs/byte/a.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/intf-only.t/run.t
+++ b/test/blackbox-tests/test-cases/intf-only.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Successes:
 
   $ dune build --display short --root foo --debug-dep

--- a/test/blackbox-tests/test-cases/invalid-module-name.t
+++ b/test/blackbox-tests/test-cases/invalid-module-name.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Dune does not report an invalid module name as an error
   $ echo "(lang dune 2.2)" > dune-project
   $ cat >dune <<EOF

--- a/test/blackbox-tests/test-cases/jsoo/build-info.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/build-info.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Jsoo and build-info
 
   $ echo "(lang dune 3.0)" > dune-project

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-anon.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-anon.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Anonymous projects have explicit_js_mode enabled
 
   $ echo '(lang dune 2.8)' > dune-project

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Check that .bc.js rule is generated only if js mode is used.
 
   $ dune build --display short a.bc.js

--- a/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/inline-tests.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Run inline tests using node js
 
   $ cat >dune-project <<EOF

--- a/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Compilation using jsoo
 
   $ dune build --display short bin/technologic.bc.js @install  2>&1 | \

--- a/test/blackbox-tests/test-cases/jsoo/tests.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/tests.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 tests stanza with jsoo
 
   $ dune build @default @runtest-js

--- a/test/blackbox-tests/test-cases/lib-available.t/run.t
+++ b/test/blackbox-tests/test-cases/lib-available.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build @runtest --display short --debug-dependency-path 2>&1 | sed "s/ cmd /  sh /"
             sh alias runtest
             sh alias runtest

--- a/test/blackbox-tests/test-cases/misc.t/run.t
+++ b/test/blackbox-tests/test-cases/misc.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune runtest --display short
           diff alias runtest
           diff alias runtest

--- a/test/blackbox-tests/test-cases/no-installable-mode.t/run.t
+++ b/test/blackbox-tests/test-cases/no-installable-mode.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 When a public executable is built in shared_object mode, a specific error
 message is displayed:
 

--- a/test/blackbox-tests/test-cases/ocamldep-error-check.t
+++ b/test/blackbox-tests/test-cases/ocamldep-error-check.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Dune uses ocamldep to prevent a module from depending on itself.
 
   $ cat >dune-project <<EOF

--- a/test/blackbox-tests/test-cases/odoc/multiple-private-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/multiple-private-libs.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 This test checks that there is no clash when two private libraries have the same name
 
   $ dune build --display short @doc-private

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/diff-scope.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/diff-scope.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Duplicate mld's in different scope
   $ dune build @doc --display short
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/same-scope.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/same-scope.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Duplicate mld's in the same scope
   $ dune build @doc --display short
           odoc _doc/_html/highlight.pack.js,_doc/_html/odoc.css

--- a/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/warnings.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ export BUILD_PATH_PREFIX_MAP=odoc=`command -v odoc`
 
 As configured in the `dune` file at the root, this should be an error:

--- a/test/blackbox-tests/test-cases/output-obj.t/run.t
+++ b/test/blackbox-tests/test-cases/output-obj.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build @all
   $ dune build @runtest 2>&1 | dune_cmd sanitize
   OK: ./static.exe

--- a/test/blackbox-tests/test-cases/package-dep.t/run.t
+++ b/test/blackbox-tests/test-cases/package-dep.t/run.t
@@ -1,2 +1,4 @@
+  $ unset DUNE_CACHE
+
   $ dune runtest
   42 42

--- a/test/blackbox-tests/test-cases/path-rewriting.t
+++ b/test/blackbox-tests/test-cases/path-rewriting.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Check that Dune help commands that understand BUILD_PATH_PREFIX_MAP to
 rewrite the current working directory:
 

--- a/test/blackbox-tests/test-cases/path-variables.t/run.t
+++ b/test/blackbox-tests/test-cases/path-variables.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 dune files
 ==========
 

--- a/test/blackbox-tests/test-cases/pipe-actions.t/run.t
+++ b/test/blackbox-tests/test-cases/pipe-actions.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 The new pipe actions are only available since dune 2.7:
 
   $ cat >dune-project <<EOF

--- a/test/blackbox-tests/test-cases/plugin-mode.t
+++ b/test/blackbox-tests/test-cases/plugin-mode.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Testsuite for (mode plugin).
 
   $ cat > dune-project <<EOF

--- a/test/blackbox-tests/test-cases/pp-cwd.t/run.t
+++ b/test/blackbox-tests/test-cases/pp-cwd.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 We test two different aspects of preprocessors:
 
 * The directory in which they run

--- a/test/blackbox-tests/test-cases/ppx-cross-context-issue.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx-cross-context-issue.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 # Using a ppx in a cross-compiled build context makes dune try to build the ppx
 # in the target context instead of the host, then fail.
   $ dune build --debug-dependency-path

--- a/test/blackbox-tests/test-cases/ppx-rewriter.t/run.t
+++ b/test/blackbox-tests/test-cases/ppx-rewriter.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build ./w_omp_driver.exe
   -arg: omp
 

--- a/test/blackbox-tests/test-cases/preprocess-with-action.t/run.t
+++ b/test/blackbox-tests/test-cases/preprocess-with-action.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 This test check that we can preprocess source code with actions
 
   $ dune runtest --display short 2>&1 | grep "  pp"

--- a/test/blackbox-tests/test-cases/private-modules/accessible-via-public.t/run.t
+++ b/test/blackbox-tests/test-cases/private-modules/accessible-via-public.t/run.t
@@ -1,2 +1,4 @@
+  $ unset DUNE_CACHE
+
   $ dune build
   private module bar

--- a/test/blackbox-tests/test-cases/private-public-overlap/private-rewriter.t/run.t
+++ b/test/blackbox-tests/test-cases/private-public-overlap/private-rewriter.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 On the other hand, public libraries may have private preprocessors
   $ dune build --display short
         ocamlc .ppx_internal.objs/byte/ppx_internal.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/quoting.t/run.t
+++ b/test/blackbox-tests/test-cases/quoting.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 This behavior is surprising, we should get an error about the fact
 that ${@} is not quoted and doesn't contain exactly 1 element
 

--- a/test/blackbox-tests/test-cases/reason.t/run.t
+++ b/test/blackbox-tests/test-cases/reason.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Tests for reason
 
 Build and run a reason binary:

--- a/test/blackbox-tests/test-cases/redirections.t/run.t
+++ b/test/blackbox-tests/test-cases/redirections.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune runtest --display short 2>&1 | sed "s/ cmd /  sh /"
             sh stderr,stdout
             sh both

--- a/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
+++ b/test/blackbox-tests/test-cases/reporting-of-cycles.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 These tests is a regression test for the detection of dynamic cycles.
 
 In all tests, we have a cycle that only becomes apparent after we

--- a/test/blackbox-tests/test-cases/rule-target-inferrence.t/run.t
+++ b/test/blackbox-tests/test-cases/rule-target-inferrence.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 When a rule target can be be inferred from the rule action, the target or targets field can be omitted.
 This works with the short form of the rule stanza:
 

--- a/test/blackbox-tests/test-cases/rule/dependency-external.t
+++ b/test/blackbox-tests/test-cases/rule/dependency-external.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 rules with dependencies outside the build dir are allowed
 
   $ mkdir -p a/b

--- a/test/blackbox-tests/test-cases/sandboxing.t
+++ b/test/blackbox-tests/test-cases/sandboxing.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 If an action does not respect the dependency specification, it results in a broken
 build. Dune fails to detect that:
 

--- a/test/blackbox-tests/test-cases/select.t/run.t
+++ b/test/blackbox-tests/test-cases/select.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ echo '(lang dune 1.0)' > dune-project
   $ cat >dune <<EOF
   > (executable

--- a/test/blackbox-tests/test-cases/targets-with-vars.t/run.t
+++ b/test/blackbox-tests/test-cases/targets-with-vars.t/run.t
@@ -1,2 +1,4 @@
+  $ unset DUNE_CACHE
+
   $ dune runtest --root .
   hola

--- a/test/blackbox-tests/test-cases/tests-stanza-action.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza-action.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 If there is an (action) field, it is used to invoke to the executable (in both
 regular and expect modes:
 

--- a/test/blackbox-tests/test-cases/tests-stanza/plural.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/plural.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune runtest
   regular test
   regular test2

--- a/test/blackbox-tests/test-cases/tests-stanza/singular.t/run.t
+++ b/test/blackbox-tests/test-cases/tests-stanza/singular.t/run.t
@@ -1,2 +1,4 @@
+  $ unset DUNE_CACHE
+
   $ dune runtest
   singular test

--- a/test/blackbox-tests/test-cases/trace-file.t/run.t
+++ b/test/blackbox-tests/test-cases/trace-file.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ dune build prog.exe --trace-file trace.json
 
 This captures the commands that are being run:

--- a/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Most tests have two versions: one where the variable is used inside a dune file,
 and one where the same variables are used in the command line.
 

--- a/test/blackbox-tests/test-cases/vendor/alerts.t/run.t
+++ b/test/blackbox-tests/test-cases/vendor/alerts.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 When compiling vendored code, all alerts should be disabled
 
   $ cat > dune << EOF

--- a/test/blackbox-tests/test-cases/vendor/main.t/run.t
+++ b/test/blackbox-tests/test-cases/vendor/main.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Vendored directories should be traversed to find targets so that they are built when they are depend upon
 
   $ dune build --root duniverse --debug-dependency-path

--- a/test/blackbox-tests/test-cases/virtual-libraries/double-implementation.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/double-implementation.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Executable that tries to use two implementations for the same virtual lib
   $ dune build
   Error: Conflicting implementations for virtual library "vlib" in

--- a/test/blackbox-tests/test-cases/virtual-libraries/github2896.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/github2896.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Reproduction of the issue in #2896
 
 We have a dependency cycle of the form impl <- lib <- vlib

--- a/test/blackbox-tests/test-cases/virtual-libraries/impl-private-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/impl-private-modules.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 They can only introduce private modules:
   $ dune build --debug-dependency-path
   Private module Baz

--- a/test/blackbox-tests/test-cases/virtual-libraries/impl-using-vlib-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/impl-using-vlib-modules.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Implementations may refer to virtual library's modules
   $ dune build
   bar from vlib

--- a/test/blackbox-tests/test-cases/virtual-libraries/implements-external.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/implements-external.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test that we can implement external libraries.
 
 First we create an external library

--- a/test/blackbox-tests/test-cases/virtual-libraries/missing-implementation.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/missing-implementation.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Executable that tries to build against a virtual library without an implementation
   $ dune build
   Error: No implementation found for virtual library "vlib" in

--- a/test/blackbox-tests/test-cases/virtual-libraries/preprocess.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/preprocess.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Virtual libraries and preprocessed source
   $ dune build
   foo

--- a/test/blackbox-tests/test-cases/virtual-libraries/private-modules-overlapping-names.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/private-modules-overlapping-names.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Implementations may have private modules that have overlapping names with the
 virtual lib
   $ dune build

--- a/test/blackbox-tests/test-cases/virtual-libraries/unwrapped.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/unwrapped.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Unwrapped virtual library
   $ dune build
   Running from vlib_more

--- a/test/blackbox-tests/test-cases/virtual-libraries/variants-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/variants-simple.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Virtual library with a single module
   $ dune build
   running implementation

--- a/test/blackbox-tests/test-cases/virtual-libraries/variants-sub-module.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/variants-sub-module.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Virtual library where a wrapped module is virtual
   $ dune build
   Impl's Vmd.run ()

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/default-impl.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/default-impl.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Basic sample selecting implementation according to default library.
 
   $ dune build

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/external.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/external.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test default implementation for an external library
 
 First we create an external library and implementation

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-wrong-default-impl.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-wrong-default-impl.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Check that dune makes a proper error if the default implementation of a virtual
 library is not actually an implementation of the virtual library.
 

--- a/test/blackbox-tests/test-cases/watching/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/fs-memo.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Tests for [Fs_memo] module.
 
   $ . ./helpers.sh

--- a/test/blackbox-tests/test-cases/watching/retriggering.t
+++ b/test/blackbox-tests/test-cases/watching/retriggering.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Modify an input file during the build so that Dune interrupts the build once.
 
   $ . ./helpers.sh

--- a/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
+++ b/test/blackbox-tests/test-cases/watching/sandbox-mkdir.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Test that Dune mkdirs the right set of directories in the sandbox.
 
   $ . ./helpers.sh

--- a/test/blackbox-tests/test-cases/with-exit-codes.t
+++ b/test/blackbox-tests/test-cases/with-exit-codes.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ cat > dune-project << EOF
   > (lang dune 2.0)
   > (using action-plugin 0.1)

--- a/test/blackbox-tests/test-cases/with-nested-exit-codes.t
+++ b/test/blackbox-tests/test-cases/with-nested-exit-codes.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
   $ cat > dune-project << EOF
   > (lang dune 2.2)
   > (using action-plugin 0.1)

--- a/test/blackbox-tests/test-cases/workspaces/workspace-paths.t/run.t
+++ b/test/blackbox-tests/test-cases/workspaces/workspace-paths.t/run.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Duplicate hello.exe before writing to it, as modifying a produced file
 is prohibited.
 

--- a/test/blackbox-tests/test-cases/write-permissions.t
+++ b/test/blackbox-tests/test-cases/write-permissions.t
@@ -1,3 +1,5 @@
+  $ unset DUNE_CACHE
+
 Check that dune <= 2.3 leaves write permissions alone.
 
   $ mkdir 2.3 2.4


### PR DESCRIPTION
The test suite does not behave correctly when `DUNE_CACHE=enabled` is present in the environment. So we set it to `disabled` locally or unset it in some cases.
