### PR TITLE
refactor: remove old format for modules

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -146,10 +146,7 @@ module Lib = struct
        and+ orig_src_dir = field_o "orig_src_dir" path
        and+ modules =
          let src_dir = Obj_dir.dir obj_dir in
-         field "modules"
-           (Modules.decode
-              ~implements:(Option.is_some implements)
-              ~src_dir ~version:lang.version)
+         field "modules" (Modules.decode ~src_dir)
        and+ special_builtin_support =
          field_o "special_builtin_support"
            (Dune_lang.Syntax.since Stanza.syntax (1, 10)

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -20,11 +20,7 @@ val lib :
 
 val encode : t -> Dune_lang.t
 
-val decode :
-     version:Dune_lang.Syntax.Version.t
-  -> src_dir:Path.t
-  -> implements:bool
-  -> t Dune_lang.Decoder.t
+val decode : src_dir:Path.t -> t Dune_lang.Decoder.t
 
 val impl : t -> vlib:t -> t
 


### PR DESCRIPTION
It was never really needed because dune-package is not stable, but was added as a convenience to use dune 2.0 without rebuilding everything. This hack is not needed anymore.