### PR TITLE
refactor: remove functions from signature

### DIFF
--- a/src/dune_rules/ordered_set_lang_intf.ml
+++ b/src/dune_rules/ordered_set_lang_intf.ml
@@ -5,7 +5,18 @@ module type Key = sig
 
   val compare : t -> t -> Ordering.t
 
-  module Map : Map.S with type key = t
+  module Map : sig
+    type key := t
+
+    type 'a t
+
+    val singleton : key -> 'a -> 'a t
+
+    val empty : 'a t
+
+    val merge :
+      'a t -> 'b t -> f:(key -> 'a option -> 'b option -> 'c option) -> 'c t
+  end
 end
 
 module type Unordered_eval = sig


### PR DESCRIPTION
[Ordered_set_lang_intf.Key] doesn't need the vast majority of map
functions so we shouldn't require them

ps-id: 24b6276a-10e3-465e-a40f-c1dc70928031