### PR TITLE
Refactor: use copy_file in install/uninstall

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@
 - odoc rules now about `ODOC_SYNTAX` and will re-run accordingly (#6010, fixes
   #1117, @emillon)
 
+- dune install: copy files in an atomic way (#6150, @emillon)
+
 3.4.1 (26-07-2022)
 ------------------
 


### PR DESCRIPTION
This refactors `copy_file` in `Install_uninstall` so that it uses `Artifact_substitution.copy_file`. This ensures that these copies are atomic at least for non-special files. It also allows hooks to trigger on install (#6137).
