### PR TITLE
feature(cinaps): runtime dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.5.0 (unreleased)
 ------------------
 
+- Add a `runtime_deps` field in the `cinaps` stanza to specify runtime
+  dependencies for running the cinaps preprocessing action (#6175, @rgrinberg)
+
 - Shadow alias module `Foo__` when building a library `Foo` (#6126, @rgrinberg)
 
 - Allow dune describe workspace to accept directories as arguments.

--- a/test/blackbox-tests/test-cases/cinaps/runtime-deps.t
+++ b/test/blackbox-tests/test-cases/cinaps/runtime-deps.t
@@ -1,0 +1,30 @@
+Runtime dependencies for running cinaps
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.5)
+  > (using cinaps 1.1)
+  > EOF
+
+  $ cat > foo <<EOF
+  > hello world
+  > EOF
+
+  $ cat > dune <<EOF
+  > (cinaps
+  >  (files *.ml)
+  >  (runtime_deps foo))
+  > EOF
+
+  $ cat > test.ml <<EOF
+  > (*$ let f = open_in "foo" in print_endline (input_line f); close_in f *)
+  > (*$*)
+  > EOF
+
+  $ dune build @cinaps --auto-promote
+  File "test.ml", line 1, characters 0-0:
+  Error: Files _build/default/test.ml and
+  _build/default/test.ml.cinaps-corrected differ.
+  Promoting _build/default/test.ml.cinaps-corrected to test.ml.
+  [1]
+  $ cat test.ml
+  (*$ let f = open_in "foo" in print_endline (input_line f); close_in f *)hello world


### PR DESCRIPTION
Add a `runtime_deps` field to cinaps stanzas to specify dependencies required for the action executing the cinaps binary.