### PR TITLE
In flake, switch buildInputs back to NativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             pkgs = nixpkgs.legacyPackages.${system};
           in
           pkgs.mkShell {
-            buildInputs = (with pkgs;
+            nativeBuildInputs = (with pkgs;
               [
                 # dev tools
                 ocamlformat_0_21_0


### PR DESCRIPTION
This fixes an issue where opam resolves to opam-nix's fake-opam which just prints "2.0.0".

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>