### PR TITLE
fix(nix): move opam to nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,11 +43,11 @@
             pkgs = nixpkgs.legacyPackages.${system};
           in
           pkgs.mkShell {
+            nativeBuildInputs = [ pkgs.opam ];
             buildInputs = (with pkgs;
               [
                 # dev tools
                 ocamlformat_0_21_0
-                opam
                 coq_8_16
                 nodejs-slim
                 pkg-config


### PR DESCRIPTION
because opam-nix is overriding opam to be a dummy package

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 7a3c55dc-7552-4b10-88e2-398bead48c2d