### PR TITLE
doc: fixed capitalization of Dune in manual

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,7 +46,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'dune'
+project = 'Dune'
 copyright = u'2017, Jérémie Dimino'
 author = u'Jérémie Dimino'
 
@@ -118,7 +118,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'dune.tex', 'dune Documentation',
+    (master_doc, 'dune.tex', 'Dune Documentation',
      u'Jérémie Dimino', 'manual'),
 ]
 
@@ -128,7 +128,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'dune', 'dune Documentation',
+    (master_doc, 'dune', 'Dune Documentation',
      [author], 1)
 ]
 
@@ -139,7 +139,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'dune', 'dune Documentation',
+    (master_doc, 'dune', 'Dune Documentation',
      author, 'dune', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to dune's documentation!
+Welcome to Dune's Documentation!
 ================================
 
 .. toctree::


### PR DESCRIPTION
@christinerose I noticed that these mentions of Dune were not capitalized correct in the manual.

Looks like this now:
https://dune--6200.org.readthedocs.build/en/6200/