### PR TITLE
coq: add preprocess and preprocessor_deps fields to Coq stanzas

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -26,7 +26,7 @@ let decode =
     (let+ loc = loc
      and+ files =
        field "files" Predicate_lang.Glob.decode ~default:Predicate_lang.any
-     and+ preprocess, preprocessor_deps = Dune_file.preprocess_fields
+     and+ preprocess, preprocessor_deps = Preprocess.preprocess_fields
      and+ libraries =
        field "libraries" (Dune_file.Lib_deps.decode Executable) ~default:[]
      and+ runtime_deps =

--- a/src/dune_rules/coq_stanza.ml
+++ b/src/dune_rules/coq_stanza.ml
@@ -36,6 +36,8 @@ module Buildable = struct
     ; use_stdlib : bool
     ; plugins : (Loc.t * Lib_name.t) list  (** ocaml libraries *)
     ; theories : (Loc.t * Coq_lib_name.t) list  (** coq libraries *)
+    ; preprocess : Preprocess.Without_instrumentation.t Preprocess.Per_module.t
+    ; preprocessor_deps : Dep_conf.t list
     ; loc : Loc.t
     }
 
@@ -77,9 +79,18 @@ module Buildable = struct
       field "theories"
         (Dune_lang.Syntax.since coq_syntax (0, 2) >>> repeat Coq_lib_name.decode)
         ~default:[]
-    in
+    and+ preprocess, preprocessor_deps = Preprocess.preprocess_fields in
     let plugins = merge_plugins_libraries ~plugins ~libraries in
-    { flags; mode; use_stdlib; coq_lang_version; plugins; theories; loc }
+    { flags
+    ; mode
+    ; use_stdlib
+    ; coq_lang_version
+    ; plugins
+    ; theories
+    ; preprocess
+    ; preprocessor_deps
+    ; loc
+    }
 end
 
 module Extraction = struct

--- a/src/dune_rules/coq_stanza.mli
+++ b/src/dune_rules/coq_stanza.mli
@@ -8,6 +8,8 @@ module Buildable : sig
     ; use_stdlib : bool
     ; plugins : (Loc.t * Lib_name.t) list  (** ocaml plugins *)
     ; theories : (Loc.t * Coq_lib_name.t) list  (** coq libraries *)
+    ; preprocess : Preprocess.Without_instrumentation.t Preprocess.Per_module.t
+    ; preprocessor_deps : Dep_conf.t list
     ; loc : Loc.t
     }
 end

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -20,12 +20,6 @@ module Lib_deps : sig
   val decode : for_ -> t Dune_lang.Decoder.t
 end
 
-(** [preprocess] and [preprocessor_deps] fields *)
-val preprocess_fields :
-  (Preprocess.Without_instrumentation.t Preprocess.Per_module.t
-  * Dep_conf.t list)
-  Dune_lang.Decoder.fields_parser
-
 module Buildable : sig
   type t =
     { loc : Loc.t

--- a/src/dune_rules/preprocess.mli
+++ b/src/dune_rules/preprocess.mli
@@ -107,3 +107,8 @@ module Per_module : sig
     -> Dep_conf.t list Resolve.Memo.t
 end
 with type 'a preprocess := 'a t
+
+(** [preprocess] and [preprocessor_deps] fields *)
+val preprocess_fields :
+  (Without_instrumentation.t Per_module.t * Dep_conf.t list)
+  Dune_lang.Decoder.fields_parser


### PR DESCRIPTION
We don't currently add any functionality, but using these decoders took some refactoring elsewhere hence the separate patch.
