### PR TITLE
refactor(coq): factor modules and module sources

### DIFF
--- a/src/dune_rules/coq_lib_name.ml
+++ b/src/dune_rules/coq_lib_name.ml
@@ -23,6 +23,8 @@ let dir x = to_dir x
 let decode : (Loc.t * t) Dune_lang.Decoder.t =
   Dune_lang.Decoder.plain_string (fun ~loc s -> (loc, String.split ~on:'.' s))
 
+let of_string s = String.split ~on:'.' s
+
 let encode : t Dune_lang.Encoder.t =
  fun lib -> Dune_lang.Encoder.string (to_string lib)
 

--- a/src/dune_rules/coq_lib_name.mli
+++ b/src/dune_rules/coq_lib_name.mli
@@ -30,4 +30,6 @@ val pp : t -> t Pp.t
 
 val to_dyn : t -> Dyn.t
 
+val of_string : string -> t
+
 module Map : Map.S with type key = t

--- a/src/dune_rules/coq_module.ml
+++ b/src/dune_rules/coq_module.ml
@@ -16,69 +16,132 @@ module Name = struct
   let to_dyn s = Dyn.String s
 
   let to_string s = s
+
+  module Map = String.Map
+
+  module Path = struct
+    module T = struct
+      type nonrec t = t list
+
+      let compare = List.compare ~compare
+
+      let to_dyn = Dyn.list to_dyn
+    end
+
+    include T
+
+    let rec is_prefix t ~prefix =
+      match (t, prefix) with
+      | [], _ | _, [] -> true
+      | x :: xs, p :: prefix -> equal x p && is_prefix xs ~prefix
+
+    let to_list x = x
+
+    let append_name t name = t @ [ name ]
+
+    let to_string_list t = List.map ~f:to_string t
+
+    let of_string_list = List.map ~f:make
+
+    let of_string s = String.split_on_char ~sep:'.' s |> of_string_list
+
+    let of_lib_name lib_name = of_string (Coq_lib_name.to_string lib_name)
+
+    module C = Comparable.Make (T)
+    module Map = C.Map
+  end
 end
 
-module Module = struct
-  (* We keep prefix and name separated as the handling of `From Foo Require
-     Bar.` may benefit from it. *)
+module Source = struct
   type t =
     { source : Path.Build.t
-    ; prefix : string list
+    ; prefix : Name.Path.t
     ; name : Name.t
     }
 
   let compare { source; prefix; name } t =
     let open Ordering.O in
     let= () = Path.Build.compare source t.source in
-    let= () = List.compare prefix t.prefix ~compare:String.compare in
+    let= () = Name.Path.compare prefix t.prefix in
     Name.compare name t.name
 
   let to_dyn { source; prefix; name } =
     Dyn.record
       [ ("source", Path.Build.to_dyn source)
-      ; ("prefix", Dyn.list Dyn.string prefix)
+      ; ("prefix", Name.Path.to_dyn prefix)
       ; ("name", Name.to_dyn name)
+      ]
+
+  let make ~source ~prefix ~name = { source; prefix; name }
+end
+
+module Module = struct
+  type t =
+    { source : Source.t
+    ; theory_prefix : Name.Path.t
+    ; obj_dir : Path.Build.t
+    }
+
+  let compare { source; theory_prefix; obj_dir } t =
+    let open Ordering.O in
+    let= () = Source.compare source t.source in
+    let= () = Name.Path.compare theory_prefix t.theory_prefix in
+    Path.Build.compare obj_dir t.obj_dir
+
+  let to_dyn { source; theory_prefix; obj_dir } =
+    Dyn.record
+      [ ("source", Source.to_dyn source)
+      ; ("theory_prefix", Name.Path.to_dyn theory_prefix)
+      ; ("obj_dir", Path.Build.to_dyn obj_dir)
       ]
 end
 
 include Module
 module Map = Map.Make (Module)
 
-let make ~source ~prefix ~name = { source; prefix; name }
+let make ~source ~prefix ~name ~theory_prefix ~obj_dir =
+  { theory_prefix; source = Source.make ~source ~prefix ~name; obj_dir }
 
-let source x = x.source
+let prefix x = x.source.prefix
 
-let prefix x = x.prefix
+let name x = x.source.name
 
-let name x = x.name
+let theory_prefix x = x.theory_prefix
 
-let build_vo_dir ~obj_dir x =
-  List.fold_left x.prefix ~init:obj_dir ~f:Path.Build.relative
+let source x = x.source.source
+
+let of_source source ~obj_dir ~theory =
+  { source; theory_prefix = Name.Path.of_lib_name theory; obj_dir }
+
+let build_vo_dir x =
+  List.fold_left (prefix x) ~init:x.obj_dir ~f:Path.Build.relative
 
 let cmxs_of_mod ~wrapper_name x =
   let wrapper_split = String.split wrapper_name ~on:'.' in
   let native_base =
-    "N" ^ String.concat ~sep:"_" (wrapper_split @ x.prefix @ [ x.name ])
+    "N"
+    ^ String.concat ~sep:"_"
+        (wrapper_split @ x.source.prefix @ [ x.source.name ])
   in
   [ native_base ^ Cm_kind.ext Cmi; native_base ^ Mode.plugin_ext Native ]
 
-let dep_file x ~obj_dir =
-  let vo_dir = build_vo_dir ~obj_dir x in
-  Path.Build.relative vo_dir (x.name ^ ".v.d")
+let dep_file x =
+  let vo_dir = build_vo_dir x in
+  Path.Build.relative vo_dir (name x ^ ".v.d")
+
+let glob_file x =
+  let vo_dir = build_vo_dir x in
+  Path.Build.relative vo_dir (name x ^ ".glob")
 
 type obj_files_mode =
   | Build
   | Install
 
-let glob_file x ~obj_dir =
-  let vo_dir = build_vo_dir ~obj_dir x in
-  Path.Build.relative vo_dir (x.name ^ ".glob")
-
 (* XXX: Remove the install .coq-native hack once rules can output targets in
    multiple subdirs *)
-let obj_files x ~wrapper_name ~mode ~obj_dir ~obj_files_mode =
-  let vo_dir = build_vo_dir ~obj_dir x in
-  let install_vo_dir = String.concat ~sep:"/" x.prefix in
+let obj_files x ~wrapper_name ~mode ~obj_files_mode =
+  let vo_dir = build_vo_dir x in
+  let install_vo_dir = String.concat ~sep:"/" (prefix x) in
   let native_objs =
     match mode with
     | Coq_mode.Native ->
@@ -92,33 +155,30 @@ let obj_files x ~wrapper_name ~mode ~obj_dir ~obj_files_mode =
   in
   let obj_files =
     match obj_files_mode with
-    | Build -> [ x.name ^ ".vo"; x.name ^ ".glob" ]
-    | Install -> [ x.name ^ ".vo" ]
+    | Build -> [ name x ^ ".vo"; name x ^ ".glob" ]
+    | Install -> [ name x ^ ".vo" ]
   in
   List.map obj_files ~f:(fun fname ->
       (Path.Build.relative vo_dir fname, Filename.concat install_vo_dir fname))
   @ native_objs
 
-let to_dyn { source; prefix; name } =
-  let open Dyn in
-  record
-    [ ("source", Path.Build.to_dyn source)
-    ; ("prefix", list string prefix)
-    ; ("name", Name.to_dyn name)
-    ]
-
-let parse ~dir ~loc s =
+let parse ~dir ~loc ~theory_prefix ~obj_dir s =
+  (* TODO parsing incorrect, need to find out theory name *)
   let clist = List.rev @@ String.split s ~on:'.' in
   match clist with
-  | [] -> User_error.raise ~loc [ Pp.text "Invalid coq module" ]
+  | [] -> User_error.raise ~loc [ Pp.text "Coq module name cannot be empty." ]
   | name :: prefix ->
     let prefix = List.rev prefix in
     let source = List.fold_left prefix ~init:dir ~f:Path.Build.relative in
     let source = Path.Build.relative source (name ^ ".v") in
-    make ~name ~source ~prefix
+    make ~name ~source ~prefix ~theory_prefix ~obj_dir
 
 let eval =
-  let key x = String.concat ~sep:"." (x.prefix @ [ x.name ]) in
+  let key x = String.concat ~sep:"." (prefix x @ [ name x ]) in
   let eq_key x y = String.equal (key x) (key y) in
-  fun ~dir ~standard osl ->
-    Ordered_set_lang.eval ~parse:(parse ~dir) ~standard ~eq:eq_key osl
+  fun ~dir ~standard ~theory_prefix ~obj_dir osl ->
+    Ordered_set_lang.eval
+      ~parse:(parse ~dir ~theory_prefix ~obj_dir)
+      ~standard ~eq:eq_key osl
+
+module Path = Name.Path

--- a/src/dune_rules/coq_module.mli
+++ b/src/dune_rules/coq_module.mli
@@ -9,13 +9,35 @@ module Name : sig
 
   val make : string -> t
 
-  val compare : t -> t -> Ordering.t
-
   val equal : t -> t -> bool
 
   val to_dyn : t -> Dyn.t
+end
 
-  val to_string : t -> string
+module Path : sig
+  type t
+
+  val to_list : t -> Name.t list
+
+  (** Returns true if there is at least one segment of the prefix that is
+      shared. For instance A.B.C and A.B aggree*)
+  val is_prefix : t -> prefix:t -> bool
+
+  val to_dyn : t -> Dyn.t
+
+  val append_name : t -> Name.t -> t
+
+  val of_string_list : string list -> t
+
+  val to_string_list : t -> string list
+
+  val of_lib_name : Coq_lib_name.t -> t
+end
+
+module Source : sig
+  type t
+
+  val make : source:Stdune.Path.Build.t -> prefix:Path.t -> name:Name.t -> t
 end
 
 type t
@@ -24,23 +46,31 @@ module Map : Map.S with type key = t
 
 (** A Coq module [a.b.foo] defined in file [a/b/foo.v] *)
 val make :
-     source:Path.Build.t
+     source:Stdune.Path.Build.t
        (** file = .v source file; module name has to be the same so far *)
-  -> prefix:string list (** Library-local qualified prefix *)
+  -> prefix:Path.t (** Library-local qualified prefix *)
   -> name:Name.t (** Name of the module *)
+  -> theory_prefix:Path.t
+  -> obj_dir:Stdune.Path.Build.t
   -> t
+
+(* Change to take [Source.t] *)
+val of_source :
+  Source.t -> obj_dir:Stdune.Path.Build.t -> theory:Coq_lib_name.t -> t
 
 (** Coq does enforce some invariants wrt module vs file names *)
 
-val source : t -> Path.Build.t
-
-val prefix : t -> string list
+val prefix : t -> Path.t
 
 val name : t -> Name.t
 
-val dep_file : t -> obj_dir:Path.Build.t -> Path.Build.t
+val theory_prefix : t -> Path.t
 
-val glob_file : t -> obj_dir:Path.Build.t -> Path.Build.t
+val source : t -> Stdune.Path.Build.t
+
+val dep_file : t -> Stdune.Path.Build.t
+
+val glob_file : t -> Stdune.Path.Build.t
 
 (** Some of the object files should not be installed, we control this with the
     following parameter *)
@@ -52,12 +82,15 @@ type obj_files_mode =
     having a different install location *)
 val obj_files :
      t
-  -> wrapper_name:string
+  -> wrapper_name:string (* TODO: remove *)
   -> mode:Coq_mode.t
-  -> obj_dir:Path.Build.t
   -> obj_files_mode:obj_files_mode
-  -> (Path.Build.t * string) list
+  -> (Stdune.Path.Build.t * string) list
 
-val to_dyn : t -> Dyn.t
-
-val eval : dir:Path.Build.t -> standard:t list -> Ordered_set_lang.t -> t list
+val eval :
+     dir:Stdune.Path.Build.t
+  -> standard:t list
+  -> theory_prefix:Path.t
+  -> obj_dir:Stdune.Path.Build.t
+  -> Ordered_set_lang.t
+  -> t list


### PR DESCRIPTION
This lets us reason about the intermediate state of modules with no theory name associated with them. Such modules appear in extraction for instance.
