### PR TITLE
Ansi_color.parse: handle CSI n K

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,9 @@
 
 - Allow include statement in install stanza (#6139, fixes #256, @gridbugs)
 
+- Handle CSI n K code in ANSI escape codes from commands. (#6214, fixes #5528,
+  @emillon)
+
 3.4.1 (26-07-2022)
 ------------------
 

--- a/test/blackbox-tests/test-cases/github5528.t
+++ b/test/blackbox-tests/test-cases/github5528.t
@@ -1,0 +1,37 @@
+  $ cat > dune-project <<EOF
+  > (lang dune 1.0)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (test
+  >   (name t))
+  > EOF
+
+  $ cat > t.ml <<EOF
+  > type color =  Normal | Cyan
+  > 
+  > let int_of_color = function
+  >   | Normal -> 0
+  >   | Cyan   -> 6
+  > 
+  > let in_color c pp out x =
+  >   let n = int_of_color c in
+  >   Printf.fprintf out "\x1b[3%dm" n;
+  >   pp out x;
+  >   Printf.fprintf out "\x1b[0m"
+  > 
+  > let reset_line = "\x1b[2K\r"
+  > 
+  > let () =
+  >   Printf.printf "%sVery Secret!\n%!" reset_line;
+  >   Printf.printf "%s\n%!" (String.make 15 '-');
+  >   Printf.printf "%a\n%!" (in_color Cyan output_string) "Can you see it?"
+  > EOF
+
+  $ dune runtest -f
+  Very Secret!
+  ---------------
+  Can you see it?
+
+  $ dune exec ./t.exe
+  Can you see it?


### PR DESCRIPTION
CSI n K is used to clear the current line. It was not properly parsed by `Ansi_color.parse`. It is now ignored.

Closes #5528
