### PR TITLE
fix(fsevents): allow on older mac sdk's

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 3.5.0 (unreleased)
 ------------------
 
+- Enable file watching on MacOS SDK < 10.13. (#6218, @rgrinberg)
+
 - Sandbox running cinaps actions starting from cinaps 1.1 (#6176, @rgrinberg)
 
 - Add a `runtime_deps` field in the `cinaps` stanza to specify runtime


### PR DESCRIPTION
mainly useful for nixos on macos which is stuck on the old sdk

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 32403256-aef1-41bb-b674-272998e51c3c