### PR TITLE
fix: symlinks in directory targets

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/github6168/github6168.t
+++ b/test/blackbox-tests/test-cases/directory-targets/github6168/github6168.t
@@ -16,14 +16,3 @@ Dune not recognizing it
   > EOF
 
   $ dune build @fakenode
-  File "dune", line 1, characters 0-92:
-  1 | (rule
-  2 |  (alias fakenode)
-  3 |  (targets
-  4 |   (dir fakenode_modules))
-  5 |  (action
-  6 |   (run ./fakenpm.exe)))
-  Error: This rule defines a directory target "fakenode_modules" that matches
-  the requested path "fakenode_modules" but the rule's action didn't produce it
-  -> required by alias fakenode
-  [1]

--- a/test/expect-tests/digest/digest_tests.ml
+++ b/test/expect-tests/digest/digest_tests.ml
@@ -22,7 +22,7 @@ let%expect_test "directory digest version" =
     print_endline "[FAIL] unable to calculate digest");
   [%expect {| [PASS] |}]
 
-let%expect_test "reject directories with symlinks (for now)" =
+let%expect_test "directories with symlinks" =
   let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
   let stats = { Digest.Stats_for_digest.st_kind = S_DIR; st_perm = 1 } in
   let sub = Path.relative dir "sub" in
@@ -30,7 +30,7 @@ let%expect_test "reject directories with symlinks (for now)" =
   Unix.symlink "bar" (Path.to_string (Path.relative dir "foo"));
   Unix.symlink "bar" (Path.to_string (Path.relative sub "foo"));
   (match Digest.path_with_stats ~allow_dirs:true dir stats with
-  | Ok _ -> print_endline "[FAIL] failure expected"
-  | Unexpected_kind -> print_endline "[PASS]"
+  | Ok _ -> print_endline "[PASS]"
+  | Unexpected_kind -> print_endline "[FAIL] unexpected kind"
   | Unix_error _ -> print_endline "[FAIL] unable to calculate digest");
   [%expect {| [PASS] |}]


### PR DESCRIPTION
compute digests for symlinks present inside directory targets

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: a0b24bf1-b7da-413f-a2d6-08f977cc8973