### PR TITLE
test: promote and subdir

### DIFF
--- a/test/blackbox-tests/test-cases/promote/non-existent-subdir.t
+++ b/test/blackbox-tests/test-cases/promote/non-existent-subdir.t
@@ -1,0 +1,19 @@
+Test of a rule that tries to promote to a source directory that doesn't exist.
+
+Taken from #3502
+  $ cat >dune-project <<EOF
+  > (lang dune 3.4)
+  > EOF
+  $ cat >dune <<EOF
+  > (subdir x
+  >  (rule
+  >   (mode (promote (until-clean)))
+  >   (action (with-stdout-to y (echo "z")))))
+  > EOF
+  $ dune build x/y
+  Error: x/.#y.dune-temp: No such file or directory
+  -> required by _build/default/x/y
+  [1]
+  $ cat x/y
+  cat: x/y: No such file or directory
+  [1]


### PR DESCRIPTION
Try to promote into a source directory that doesn't exist by setting up
the rule with `subdir`.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 0cdd5220-e880-4ed1-a586-dd4133b17900