### PR TITLE
refactor: remove the extra digest table

### DIFF
--- a/src/dune_engine/cached_digest.mli
+++ b/src/dune_engine/cached_digest.mli
@@ -38,11 +38,13 @@ val refresh :
 module Untracked : sig
   (** Digest the contents of a source or external file. This function doesn't
       track the source file. For a tracked version, see [fs_memo.mli]. *)
-  val source_or_external_file : Path.t -> Digest_result.t
+  val source_or_external_file : Path.Outside_build_dir.t -> Digest_result.t
 
   (** Invalidate the cached [stat] value. This causes the subsequent call to
       [source_or_external_file] to incur an additional [stat] call. *)
-  val invalidate_cached_timestamp : Path.t -> unit
+  val invalidate_cached_timestamp : Path.Outside_build_dir.t -> unit
+
+  val update : Path.Outside_build_dir.t -> Fs_cache_update_result.t
 end
 
 (** {1 Managing the cache} *)

--- a/src/dune_engine/fs_cache.mli
+++ b/src/dune_engine/fs_cache.mli
@@ -16,22 +16,8 @@ val read : 'a t -> Path.Outside_build_dir.t -> 'a
 (** Evict an entry from the cache. *)
 val evict : 'a t -> Path.Outside_build_dir.t -> unit
 
-(** Result of updating a cache entry. *)
-module Update_result : sig
-  type t =
-    | Skipped  (** No need to update a given entry because it has no readers *)
-    | Updated of { changed : bool }
-
-  (** [Skipped] is the "empty" update. *)
-  val empty : t
-
-  val combine : t -> t -> t
-
-  val to_dyn : t -> Dyn.t
-end
-
 (** Perform an operation and update the result stored in the cache. *)
-val update : 'a t -> Path.Outside_build_dir.t -> Update_result.t
+val update : 'a t -> Path.Outside_build_dir.t -> Fs_cache_update_result.t
 
 (** This module caches only a subset of fields of [Unix.stats] because other
     fields are currently unused.
@@ -69,8 +55,6 @@ end
     See [fs_memo.ml] for tracked versions of these operations. *)
 module Untracked : sig
   val path_stat : (Reduced_stats.t, Unix_error.Detailed.t) result t
-
-  val file_digest : Cached_digest.Digest_result.t t
 
   val dir_contents : (Dir_contents.t, Unix_error.Detailed.t) result t
 end

--- a/src/dune_engine/fs_cache_update_result.ml
+++ b/src/dune_engine/fs_cache_update_result.ml
@@ -1,0 +1,28 @@
+open Import
+
+type t =
+  | Skipped (* No need to update a given entry because it has no readers *)
+  | Updated of { changed : bool }
+
+let combine x y =
+  match (x, y) with
+  | Skipped, res | res, Skipped -> res
+  | Updated { changed = x }, Updated { changed = y } ->
+    Updated { changed = x || y }
+
+let empty = Skipped
+
+let to_dyn = function
+  | Skipped -> Dyn.Variant ("Skipped", [])
+  | Updated { changed } ->
+    Dyn.Variant ("Updated", [ Dyn.Record [ ("changed", Dyn.Bool changed) ] ])
+
+let log_update t ~name path =
+  if !Clflags.debug_fs_cache then
+    Console.print_user_message
+      (User_message.make
+         [ Pp.hbox
+             (Pp.textf "Updating %s cache for %S: %s" name
+                (Path.Outside_build_dir.to_string path)
+                (Dyn.to_string (to_dyn t)))
+         ])

--- a/src/dune_engine/fs_cache_update_result.mli
+++ b/src/dune_engine/fs_cache_update_result.mli
@@ -1,0 +1,16 @@
+open Import
+
+(** Result of updating a cache entry. *)
+
+type t =
+  | Skipped  (** No need to update a given entry because it has no readers *)
+  | Updated of { changed : bool }
+
+(** [Skipped] is the "empty" update. *)
+val empty : t
+
+val combine : t -> t -> t
+
+val to_dyn : t -> Dyn.t
+
+val log_update : t -> name:string -> Path.Outside_build_dir.t -> unit

--- a/src/dune_engine/target_promotion.ml
+++ b/src/dune_engine/target_promotion.ml
@@ -97,7 +97,7 @@ let promote_target_if_not_up_to_date ~src ~src_digest ~dst ~promote_source
      the tracked [Fs_memo.file_digest] to subscribe to the promotion result. *)
   let* promoted =
     match
-      Fs_cache.read Fs_cache.Untracked.file_digest (In_source_dir dst)
+      Cached_digest.Untracked.source_or_external_file (In_source_dir dst)
       |> Cached_digest.Digest_result.to_option
     with
     | Some dst_digest when Digest.equal src_digest dst_digest ->

--- a/test/blackbox-tests/test-cases/watching/fs-memo.t
+++ b/test/blackbox-tests/test-cases/watching/fs-memo.t
@@ -431,8 +431,11 @@ However, deleting [another-dir] isn't handled correctly.
 
   $ test "rm another-dir/file-7; sleep 0.001; rmdir another-dir"
   ------------------------------------------
+  Failure
   Success, waiting for filesystem changes...
-  Success, waiting for filesystem changes...
+  File "dir/file-7", line 1, characters 0-0:
+  Error: File unavailable: dir/file-7
+  Had errors, waiting for filesystem changes...
   ------------------------------------------
   result = '357' -> '357' -> '357'
   ------------------------------------------


### PR DESCRIPTION
This PR was a preliminary refactoring PR but I ended up just merging it with the final goal which is to remove the extra digest table. This PR removes the extra table in the most direct way possible: by replacing it with `Cached_digest` where needed. This required extending `Cached_digest` somewhat, but the changes were modest. In the future, I have some ideas on how to improve the situation further, for example, extend persistence to things in Fs_cache. For now, this PR sticks to just removing the double book keeping.