### PR TITLE
Only run codesign if there have been substitutions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,8 +79,8 @@
   Coq's standard library by including `(stdlib no)`.
   (#6165 #6164, fixes #6163, @ejgallego @Alizter @LasseBlaauwbroek)
 
-- on macOS, sign executables produced by artifact substitution (#6137, fixes
-  #5650, @emillon)
+- on macOS, sign executables produced by artifact substitution (#6137, #6231,
+  fixes #5650, fixes #6226, @emillon)
 
 - Added an (aliases ...) field to the (rules ...) stanza which allows the
   specification of multiple aliases per rule (#6194, @Alizter)

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -696,9 +696,12 @@ let install_uninstall ~what =
                             match special_file with
                             | _ when not create_install_files ->
                               Fiber.return true
-                            | None ->
-                              Dune_rules.Artifact_substitution.test_file
-                                ~src:entry.src ()
+                            | None -> (
+                              let open Dune_rules.Artifact_substitution in
+                              let+ status = test_file ~src:entry.src () in
+                              match status with
+                              | Some_substitution -> true
+                              | No_substitution -> false)
                             | Some Special_file.META
                             | Some Special_file.Dune_package ->
                               Fiber.return true

--- a/src/dune_rules/artifact_substitution.mli
+++ b/src/dune_rules/artifact_substitution.mli
@@ -67,6 +67,10 @@ val copy_file :
   -> unit
   -> unit Fiber.t
 
+type status =
+  | Some_substitution
+  | No_substitution
+
 (** Generic version of [copy_file]. Rather than filenames, it takes an input and
     output functions. Their semantic must match the ones of the [input] and
     [output] functions from the OCaml standard library.
@@ -80,10 +84,10 @@ val copy :
   -> input_file:Path.t
   -> input:(Bytes.t -> int -> int -> int)
   -> output:(Bytes.t -> int -> int -> unit)
-  -> bool Fiber.t
+  -> status Fiber.t
 
 (** Produce the string that would replace the placeholder with the given value .*)
 val encode_replacement : len:int -> repl:string -> string
 
 (** Test if a file contains a substitution placeholder. *)
-val test_file : src:Path.t -> unit -> bool Fiber.t
+val test_file : src:Path.t -> unit -> status Fiber.t

--- a/src/dune_rules/artifact_substitution.mli
+++ b/src/dune_rules/artifact_substitution.mli
@@ -26,7 +26,7 @@ type conf = private
   ; get_config_path : configpath -> Path.t option
   ; hardcoded_ocaml_path : hardcoded_ocaml_path
         (** Initial prefix of installation when relocatable chosen *)
-  ; sign_hook : (Path.t -> unit Fiber.t) option
+  ; sign_hook : (Path.t -> unit Fiber.t) option Lazy.t
         (** Called on binary after if has been edited *)
   }
 

--- a/src/dune_rules/artifact_substitution.mli
+++ b/src/dune_rules/artifact_substitution.mli
@@ -72,13 +72,15 @@ val copy_file :
     [output] functions from the OCaml standard library.
 
     [input_file] is used only for debugging purposes. It must be the name of the
-    source file. *)
+    source file.
+
+    Return whether a substitution happened. *)
 val copy :
      conf:conf
   -> input_file:Path.t
   -> input:(Bytes.t -> int -> int -> int)
   -> output:(Bytes.t -> int -> int -> unit)
-  -> unit Fiber.t
+  -> bool Fiber.t
 
 (** Produce the string that would replace the placeholder with the given value .*)
 val encode_replacement : len:int -> repl:string -> string

--- a/test/unit-tests/artifact_substitution/artifact_substitution.ml
+++ b/test/unit-tests/artifact_substitution/artifact_substitution.ml
@@ -145,7 +145,7 @@ let test input =
        to_copy
      in
      let output = Buffer.add_subbytes buf in
-     let+ (_ : bool) =
+     let+ (_ : Artifact_substitution.status) =
        Artifact_substitution.copy ~conf:Artifact_substitution.conf_dummy
          ~input_file:(Path.of_string "<memory>")
          ~input ~output

--- a/test/unit-tests/artifact_substitution/artifact_substitution.ml
+++ b/test/unit-tests/artifact_substitution/artifact_substitution.ml
@@ -136,6 +136,7 @@ let test input =
   Fiber.run
     ~iter:(fun () -> assert false)
     (let ofs = ref 0 in
+     let open Fiber.O in
      let input buf pos len =
        let to_copy = min len (String.length input - !ofs) in
        Bytes.blit_string ~src:input ~dst:buf ~src_pos:!ofs ~dst_pos:pos
@@ -144,9 +145,12 @@ let test input =
        to_copy
      in
      let output = Buffer.add_subbytes buf in
-     Artifact_substitution.copy ~conf:Artifact_substitution.conf_dummy
-       ~input_file:(Path.of_string "<memory>")
-       ~input ~output);
+     let+ (_ : bool) =
+       Artifact_substitution.copy ~conf:Artifact_substitution.conf_dummy
+         ~input_file:(Path.of_string "<memory>")
+         ~input ~output
+     in
+     ());
   let result = Buffer.contents buf in
   if result <> expected then
     fail


### PR DESCRIPTION
This ensures that we're not running `codesign` in cases we don't strictly need it. This in turn prevents a regression in macos+nix, where the codesign binary is not in PATH.

Closes #6226
