### PR TITLE
feature: Show number of failed jobs during build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Unreleased
 - Introduce experimental support for the melange compiler (#6268, fixes #6230,
   @jchavarri)
 
+- Build progress status now shows number of failed jobs (#6242, @Alizter)
+
 3.5.0 (2022-10-19)
 ------------------
 

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -72,11 +72,13 @@ end = struct
            | Building
                { Build_system.Progress.number_of_rules_executed = done_
                ; number_of_rules_discovered = total
+               ; number_of_rules_failed = failed
                } ->
              Pp.verbatim
-               (sprintf "Done: %u%% (%u/%u, %u left) (jobs: %u)"
+               (sprintf "Done: %u%% (%u/%u, %u left%s) (jobs: %u)"
                   (if total = 0 then 0 else done_ * 100 / total)
                   done_ total (total - done_)
+                  (if failed = 0 then "" else sprintf ", %u failed" failed)
                   (Dune_engine.Scheduler.running_jobs_count scheduler))));
     Fiber.return (Memo.of_thunk get)
 end

--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -62,6 +62,7 @@ module Progress : sig
   type t =
     { number_of_rules_discovered : int
     ; number_of_rules_executed : int
+    ; number_of_rules_failed : int
     }
 
   (** Initialize with zeros on all measures. *)


### PR DESCRIPTION
Looks like this if there are failures:
```sh
Done: 83% (3217/3849, 632 left, 1 failed) (jobs: 0)
```
and looks like this if there are none:
```sh
Done: 83% (3217/3849, 632 left) (jobs: 0)
```
