### PR TITLE
feature: lazy initialize RPC

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1012,7 +1012,15 @@ let term ~default_root_is_cwd =
         at_exit (fun () -> Dune_stats.close stats);
         stats)
   in
-  let rpc = lazy (Dune_rpc_impl.Server.create ~root:root.dir stats) in
+  let rpc =
+    lazy
+      (let registry =
+         match watch with
+         | Yes _ -> `Add
+         | No -> `Skip
+       in
+       Dune_rpc_impl.Server.create ~registry ~root:root.dir stats)
+  in
   if store_digest_preimage then Dune_engine.Reversible_digest.enable ();
   if print_metrics then (
     Memo.Perf_counters.enable ();

--- a/src/csexp_rpc/csexp_rpc.mli
+++ b/src/csexp_rpc/csexp_rpc.mli
@@ -50,6 +50,10 @@ module Server : sig
 
   val create : Unix.sockaddr -> backlog:int -> t
 
+  (** [ready t] returns a fiber that completes when clients can start connecting
+      to the server *)
+  val ready : t -> unit Fiber.t
+
   val stop : t -> unit
 
   val serve : t -> Session.t Fiber.Stream.In.t Fiber.t

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -47,3 +47,4 @@ module Report_errors_config = Report_errors_config
 module Compound_user_error = Compound_user_error
 module Reflection = Reflection
 module No_io = No_io
+module Rpc = Rpc

--- a/src/dune_engine/rpc.ml
+++ b/src/dune_engine/rpc.ml
@@ -1,0 +1,32 @@
+open Fiber.O
+
+type server =
+  { run : unit Fiber.t
+  ; stop : unit Fiber.t
+  ; ready : unit Fiber.t
+  }
+
+type t =
+  { server : server
+  ; pool : Fiber.Pool.t
+  }
+
+let t = Fiber.Var.create ()
+
+let with_background_rpc server f =
+  let pool = Fiber.Pool.create () in
+  Fiber.Var.set t { server; pool } (fun () ->
+      Fiber.fork_and_join_unit
+        (fun () -> Fiber.Pool.run pool)
+        (fun () -> Fiber.finalize f ~finally:(fun () -> Fiber.Pool.stop pool)))
+
+let ensure_ready () =
+  let* { server; pool } = Fiber.Var.get_exn t in
+  let* () = Fiber.Pool.task pool ~f:(fun () -> server.run) in
+  server.ready
+
+let stop () =
+  let* { server; pool } = Fiber.Var.get_exn t in
+  Fiber.fork_and_join_unit
+    (fun () -> Fiber.Pool.stop pool)
+    (fun () -> server.stop)

--- a/src/dune_engine/rpc.mli
+++ b/src/dune_engine/rpc.mli
@@ -1,0 +1,11 @@
+type server =
+  { run : unit Fiber.t
+  ; stop : unit Fiber.t
+  ; ready : unit Fiber.t
+  }
+
+val with_background_rpc : server -> (unit -> 'a Fiber.t) -> 'a Fiber.t
+
+val ensure_ready : unit -> unit Fiber.t
+
+val stop : unit -> unit Fiber.t

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -2,7 +2,8 @@ open Import
 
 type t
 
-val create : root:string -> Dune_stats.t option -> t
+val create :
+  registry:[ `Add | `Skip ] -> root:string -> Dune_stats.t option -> t
 
 val listening_address : t -> Dune_rpc.Where.t
 
@@ -15,6 +16,8 @@ val pending_build_action : t -> pending_build_action Fiber.t
 
 (** Stop accepting new rpc connections. Fiber returns when all existing
     connections terminate *)
-val stop : unit -> unit Fiber.t
+val stop : t -> unit Fiber.t
+
+val ready : t -> unit Fiber.t
 
 val run : t -> unit Fiber.t


### PR DESCRIPTION
Add a mechanism to allow the RPC server to initialized lazily. This is needed for the DAP to use dune rpc. When building something without watch mode (and hence without rpc), dynamic actions must first require the RPC server to be turned before proceeding with execution. This PR satisfies adds the API necessary to ensure this via `Rpc.ensure_ready`