### PR TITLE
chore: add docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,3 +169,11 @@ dune-release:
 	DUNE_RELEASE_DELEGATE=github-dune-release-delegate dune-release publish distrib --verbose
 	dune-release opam pkg
 	dune-release opam submit
+
+.PHONY: docker-build-image
+docker-build-image:
+	docker build -f docker/dev.Dockerfile -t dune .
+
+.PHONY: docker-compose
+docker-compose:
+	docker compose -f docker/dev.yml run dune bash

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,9 +1,0 @@
-# little dockerfile to debug CI issues
-FROM ocaml/opam
-COPY Makefile Makefile
-COPY .ocamlformat .ocamlformat
-RUN sudo apt-get install -y pkg-config nodejs strace file && make dev-depext
-# XXX not really correct as we should copy dune's source and pin it first. But
-# this docker file is mostly useful for quickly figuring out CI issues, so we
-# aren't too concerned
-RUN make dev-deps && rm .ocamlformat Makefile

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,0 +1,10 @@
+# little dockerfile to debug CI issues
+FROM ocaml/opam
+RUN mkdir -p /home/opam/dune/_boot /home/opam/dune/_build && chown opam:opam /home/opam/dune/_boot /home/opam/dune/_build
+COPY Makefile Makefile
+COPY .ocamlformat .ocamlformat
+RUN --mount=type=cache,target=/var/cache/apt sudo apt-get install -y pkg-config nodejs strace file && make dev-depext
+# XXX not really correct as we should copy dune's source and pin it first. But
+# this docker file is mostly useful for quickly figuring out CI issues, so we
+# aren't too concerned
+RUN opam update && make dev-deps && rm .ocamlformat Makefile

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -1,0 +1,13 @@
+volumes:
+  _build:
+  _boot:
+services:
+  dune:
+    image: dune
+    user: opam
+    tty: true
+    stdin_open: true
+    volumes:
+      - ../:/home/opam/dune
+      - _build:/home/opam/dune/_build/
+      - _boot:/home/opam/dune/_boot/


### PR DESCRIPTION
Use it to setup some named volumes to make it easy to share _build and
_boot between containers.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 3cdb09fc-2d1f-4e2c-8f70-452a6c3370c9