### PR TITLE
macOS codesign hook: use nix-compatible CLI flags

### DIFF
--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -52,7 +52,7 @@ type conf =
   }
 
 let mac_codesign_hook ~codesign path =
-  Process.run Strict codesign [ "--sign"; "-"; Path.to_string path ]
+  Process.run Strict codesign [ "-s"; "-"; "-f"; Path.to_string path ]
 
 let sign_hook_of_context (context : Context.t) =
   let config = context.ocaml_config in


### PR DESCRIPTION
Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>

Looks like Nix exposes a `darwin.sigtool` binary that is compatible with `/usr/bin/codesign`, but it doesn't support `--sign`. We also need to pass `-f` because the binary might already be signed.

This is how dune 3.5 will be able to be patched for nix: https://github.com/nix-ocaml/nix-overlays/pull/501/commits/db5f507528cf1577d8f44fd0773075391a7cff8a