### PR TITLE
chore(ci): remove building 4.09-4.12

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,18 +30,6 @@ jobs:
           - ocaml-compiler: 4.13.x
             os: ubuntu-latest
             skip_test: true
-          - ocaml-compiler: 4.12.x
-            os: ubuntu-latest
-            skip_test: true
-          - ocaml-compiler: 4.11.x
-            os: ubuntu-latest
-            skip_test: true
-          - ocaml-compiler: 4.10.x
-            os: ubuntu-latest
-            skip_test: true
-          - ocaml-compiler: 4.09.x
-            os: ubuntu-latest
-            skip_test: true
           - ocaml-compiler: 4.08.x
             os: ubuntu-latest
             skip_test: true


### PR DESCRIPTION
These CI jobs only make sure that OCaml is built which is pretty much
guaranteed by building 4.08.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 0aee90aa-b568-4314-9347-721330c40093