### PR TITLE
doc: melange dune version

### DIFF
--- a/doc/melange.rst
+++ b/doc/melange.rst
@@ -19,7 +19,7 @@ must declare the ``melange`` extension in your ``dune-project`` file:
 
 .. code:: scheme
 
-  (lang dune 3.5)
+  (lang dune 3.6)
   (using melange 0.1)
 
 Then, given this example:


### PR DESCRIPTION
should be 3.6 instead of 3.5

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 40e630f4-d251-4b33-87d6-4b902af5c1f9