### PR TITLE
refactor(ci): put Coq in its own job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -126,3 +126,25 @@ jobs:
       - name: Install ocamlformat
         run: opam exec -- make install-ocamlformat
       - run: opam exec -- make fmt
+
+  coq:
+    name: Coq 8.16.0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Use OCaml 4.14.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14.x
+          opam-pin: false
+          opam-depext: false
+          dune-cache: true
+
+      - name: Install Coq
+        run: opam install coq.8.16.0 coq-native
+      
+      - run: opam exec -- make test-coq
+        env:
+          # We disable the Dune cache when running the tests
+          DUNE_CACHE: disabled

--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -2,10 +2,12 @@
 ; TODO Enable tests when ready
 
 (cram
+ (alias runtest-coq)
  (applies_to native-compose native-single)
  (enabled_if
   (<> %{system} macosx)))
 
 (cram
+ (alias runtest-coq)
  (applies_to :whole_subtree)
  (deps %{bin:coqc} %{bin:coqdep}))

--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -18,11 +18,6 @@
   (alias test-deps)))
 
 (subdir
- coq
- (cram
-  (alias runtest-coq)))
-
-(subdir
  jsoo
  (cram
   (deps %{bin:node})


### PR DESCRIPTION
Coq gets its own job that takes around 12min to run all the tests. We could definitely cut this time down further by making use of the cache or dropping the dep on the Coq stdlib.

This at least let's us ignore Coq tests during main CI runs.

@rgrinberg I've subsumed #6270 since it needed an extra modification.