### PR TITLE
update melange pin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dev-depext:
 	opam depext -y $(TEST_DEPS)
 
 melange:
-	opam pin add melange https://github.com/melange-re/melange.git#d97908651f5798855ff61922f1f9ca9513bc1f42
+	opam pin add melange https://github.com/melange-re/melange.git#2f561d73268e2ec64844fa9f03e88a8727b23b48
 
 dev-deps: melange
 	opam install -y $(TEST_DEPS)


### PR DESCRIPTION
Gets rid of the opam warnings for missing fields:

```
    error 23: Missing field 'maintainer'
  warning 25: Missing field 'authors'
  warning 35: Missing field 'homepage'
  warning 36: Missing field 'bug-reports'
  warning 56: It is discouraged for non-compiler packages to use 'setenv:'
    error 57: Synopsis and description must not be both empty
```

Signed-off-by: Javier Chavarri <javier.chavarri@gmail.com>