### PR TITLE
refactor: remove no-infer from engine actions

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -87,7 +87,6 @@ struct
         ; List (List.map ~f:string extras)
         ; target into
         ]
-    | No_infer r -> List [ atom "no-infer"; encode r ]
     | Pipe (outputs, l) ->
       List
         (atom (sprintf "pipe-%s" (Outputs.to_string outputs))
@@ -287,8 +286,7 @@ let fold_one_step t ~init:acc ~f =
   | Redirect_out (_, _, _, t)
   | Redirect_in (_, _, t)
   | Ignore (_, t)
-  | With_accepted_exit_codes (_, t)
-  | No_infer t -> f acc t
+  | With_accepted_exit_codes (_, t) -> f acc t
   | Progn l | Pipe (_, l) -> List.fold_left l ~init:acc ~f
   | Run _
   | Dynamic_run _
@@ -336,8 +334,7 @@ let rec is_dynamic = function
   | Redirect_out (_, _, _, t)
   | Redirect_in (_, _, t)
   | Ignore (_, t)
-  | With_accepted_exit_codes (_, t)
-  | No_infer t -> is_dynamic t
+  | With_accepted_exit_codes (_, t) -> is_dynamic t
   | Progn l | Pipe (_, l) -> List.exists l ~f:is_dynamic
   | Run _
   | System _
@@ -386,7 +383,7 @@ let is_useful_to distribute memoize =
     | Setenv (_, _, t) -> loop t
     | Redirect_out (_, _, _, t) -> memoize || loop t
     | Redirect_in (_, _, t) -> loop t
-    | Ignore (_, t) | With_accepted_exit_codes (_, t) | No_infer t -> loop t
+    | Ignore (_, t) | With_accepted_exit_codes (_, t) -> loop t
     | Progn l | Pipe (_, l) -> List.exists l ~f:loop
     | Echo _ -> false
     | Cat _ -> memoize

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -391,7 +391,6 @@ let rec exec t ~ectx ~eenv =
     let target = Path.build target in
     Io.write_lines target (String.Set.to_list lines);
     Fiber.return Done
-  | No_infer t -> exec t ~ectx ~eenv
   | Pipe (outputs, l) -> exec_pipe ~ectx ~eenv outputs l
   | Extension (module A) ->
     let* () =

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -54,7 +54,6 @@ module type Ast = sig
     | Mkdir of path
     | Diff of (path, target) Diff.t
     | Merge_files_into of path list * string list * target
-    | No_infer of t
     | Pipe of Outputs.t * t list
     | Extension of ext
 end

--- a/src/dune_engine/action_mapper.ml
+++ b/src/dune_engine/action_mapper.ml
@@ -49,7 +49,6 @@ module Make (Src : Action_intf.Ast) (Dst : Action_intf.Ast) = struct
         ( List.map sources ~f:(f_path ~dir)
         , List.map extras ~f:(f_string ~dir)
         , f_target ~dir target )
-    | No_infer t -> No_infer (f t ~dir)
     | Pipe (outputs, l) -> Pipe (outputs, List.map l ~f:(fun t -> f t ~dir))
     | Extension ext -> Extension (f_ext ~dir ext)
 

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -86,7 +86,6 @@ let simplify act =
            (List.map srcs ~f:String.quote_for_shell |> String.concat ~sep:" ")
            (String.quote_for_shell target))
       :: acc
-    | No_infer act -> loop act acc
     | Pipe (outputs, l) -> Pipe (List.map ~f:block l, outputs) :: acc
     | Extension _ -> Sh "# extensions are not supported" :: acc
   and block act =


### PR DESCRIPTION
This "action" is only used by the dune language to turn off dep/target
inference. It does nothing useful inside the engine