### PR TITLE
test: add a test exercising nesting in directory targets

### DIFF
--- a/test/blackbox-tests/test-cases/directory-targets/install-dir-target.t
+++ b/test/blackbox-tests/test-cases/directory-targets/install-dir-target.t
@@ -10,6 +10,9 @@ Allow directories to be installable
   > (install
   >  (dirs rules/bar)
   >  (section share))
+  > (install
+  >  (dirs (rules/another-dir as renamed) (rules/nested as some/nesting/here))
+  >  (section lib))
   > EOF
 
   $ mkdir rules
@@ -18,6 +21,14 @@ Allow directories to be installable
   >  (target (dir bar))
   >  (deps (sandbox always))
   >  (action (bash "mkdir -p %{target}/baz && touch %{target}/{x,y,z} && touch %{target}/baz/{a,b}")))
+  > (rule
+  >  (target (dir another-dir))
+  >  (deps (sandbox always))
+  >  (action (chdir %{target} (run touch x))))
+  > (rule
+  >  (target (dir nested))
+  >  (deps (sandbox always))
+  >  (action (chdir %{target} (run touch x))))
   > EOF
 
   $ dune build foo.install
@@ -25,6 +36,8 @@ Allow directories to be installable
   lib: [
     "_build/install/default/lib/foo/META"
     "_build/install/default/lib/foo/dune-package"
+    "_build/install/default/lib/foo/renamed/x" {"renamed/x"}
+    "_build/install/default/lib/foo/some/nesting/here/x" {"some/nesting/here/x"}
   ]
   share: [
     "_build/install/default/share/foo/bar/baz/a" {"bar/baz/a"}
@@ -33,3 +46,22 @@ Allow directories to be installable
     "_build/install/default/share/foo/bar/y" {"bar/y"}
     "_build/install/default/share/foo/bar/z" {"bar/z"}
   ]
+
+  $ mkdir ./installation
+  $ dune install --prefix ./installation
+  Installing installation/lib/foo/META
+  Installing installation/lib/foo/dune-package
+  Installing installation/lib/foo/renamed/x
+  Installing installation/lib/foo/some/nesting/here/x
+  Installing installation/share/foo/bar/baz/a
+  Installing installation/share/foo/bar/baz/b
+  Installing installation/share/foo/bar/x
+  Installing installation/share/foo/bar/y
+  Installing installation/share/foo/bar/z
+  $ ls ./installation/lib/foo
+  META
+  dune-package
+  renamed
+  some
+  $ ls ./installation/lib/foo/some/nesting/here
+  x


### PR DESCRIPTION
I thought I saw a bug in dune related to nesting directories, but the output looks right.