### PR TITLE
test: incorrect private/public check

### DIFF
--- a/test/blackbox-tests/test-cases/private-package-lib/private-public-overlap.t
+++ b/test/blackbox-tests/test-cases/private-package-lib/private-public-overlap.t
@@ -1,0 +1,20 @@
+We should forbid private libraries that belong to a package from depending on a
+private library
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.5)
+  > (package (name pkg))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (libraries bar)
+  >  (package pkg)
+  >  (modules))
+  > (library
+  >  (name bar)
+  >  (modules))
+  > EOF
+
+  $ dune build foo.cma


### PR DESCRIPTION
Add a test that demonstrates that a private library that's part of a
package can't depend on a library on that doesn't belong to any
packages.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 833856c5-1297-44ea-b5f5-23da4b440ec3