### PR TITLE
chore: remove unused nix stuff from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,3 @@ dune-release:
 	DUNE_RELEASE_DELEGATE=github-dune-release-delegate dune-release publish distrib --verbose
 	dune-release opam pkg
 	dune-release opam submit
-
-# see nix/default.nix for details
-.PHONY: nix/opam-selection.nix
-nix/opam-selection.nix: Makefile
-	nix-shell -A resolve ./


### PR DESCRIPTION
we now use opam-nix instead of opam2nix

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: f735414d-6f43-43bd-a458-c18b19afa557