### PR TITLE
chore(nix): more flake fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1659877975,
@@ -47,6 +63,21 @@
       }
     },
     "flake-utils_3": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -94,13 +125,29 @@
         "type": "github"
       }
     },
+    "mirage-opam-overlays_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661959605,
+        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666333455,
-        "narHash": "sha256-oHXIeLB/sPWxKNcSdV1DQi1ddNVoJ17T1yDiMMeygL4=",
+        "lastModified": 1666424192,
+        "narHash": "sha256-rb/a7Kg9s31jqkvdOQHFrUc5ig5kB+O2ZKB8mjU2kW8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "93e0ac196106dce51878469c9a763c6233af5c57",
+        "rev": "4f8287f3d597c73b0d706cfad028c2d51821f64d",
         "type": "github"
       },
       "original": {
@@ -111,6 +158,38 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1666424192,
+        "narHash": "sha256-rb/a7Kg9s31jqkvdOQHFrUc5ig5kB+O2ZKB8mjU2kW8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4f8287f3d597c73b0d706cfad028c2d51821f64d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1657802959,
+        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1657802959,
         "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
@@ -130,20 +209,16 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "git-subrepo-src": "git-subrepo-src",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "opam-nix": [
-          "opam-nix"
-        ],
+        "nixpkgs": "nixpkgs_2",
+        "opam-nix": "opam-nix",
         "opam-repository": "opam-repository"
       },
       "locked": {
-        "lastModified": 1666390320,
-        "narHash": "sha256-TXxLJkeNToJFIxt6xtTOBQE+3ChdU7nOMEyDNrsjD4I=",
+        "lastModified": 1666461387,
+        "narHash": "sha256-JBfdEtIwVDWcvrhwxfkvNqE844m18mqA3to+z92MHT8=",
         "ref": "refs/heads/master",
-        "rev": "e2fb9d5af6fc37d761241b5fb501ec0c90dfc67d",
-        "revCount": 1842,
+        "rev": "8ee39dfe1617532cf846a1b21a9b80946c07a5fa",
+        "revCount": 1845,
         "submodules": true,
         "type": "git",
         "url": "https://www.github.com/ocaml/ocaml-lsp"
@@ -159,10 +234,39 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_3",
         "mirage-opam-overlays": "mirage-opam-overlays",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "opam-overlays": "opam-overlays",
-        "opam-repository": "opam-repository_2",
+        "opam-repository": [
+          "ocamllsp",
+          "opam-repository"
+        ],
         "opam2json": "opam2json"
+      },
+      "locked": {
+        "lastModified": 1666349768,
+        "narHash": "sha256-5aq31gf/CBH/N75PPgmGfl7zwSslwwI6zfEkycYchKQ=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "877c1175d47c540fdef1caeb48dbb30448c2635f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
+    "opam-nix_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_4",
+        "mirage-opam-overlays": "mirage-opam-overlays_2",
+        "nixpkgs": "nixpkgs_4",
+        "opam-overlays": "opam-overlays_2",
+        "opam-repository": [
+          "opam-repository"
+        ],
+        "opam2json": "opam2json_2"
       },
       "locked": {
         "lastModified": 1666349768,
@@ -194,14 +298,30 @@
         "type": "github"
       }
     },
+    "opam-overlays_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654162756,
+        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1666277927,
-        "narHash": "sha256-M6oNSVTnoqHPCvUhLoElp3977WbaZX7nDG+Oqdi8FAc=",
+        "lastModified": 1666348254,
+        "narHash": "sha256-CBGnheemS5frVA4YE43y3Omd+GpiyUy9sBjI6XBQFlU=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "1dfd60c714f09064879643d539f6261ca4fe1e43",
+        "rev": "a5e83808328a0905a297cae4d1581b31e4494b13",
         "type": "github"
       },
       "original": {
@@ -213,11 +333,11 @@
     "opam-repository_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1661161626,
-        "narHash": "sha256-J3P+mXLwE2oEKTlMnx8sYRxwD/uNGSKM0AkAB7BNTxA=",
+        "lastModified": 1666348254,
+        "narHash": "sha256-CBGnheemS5frVA4YE43y3Omd+GpiyUy9sBjI6XBQFlU=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "54e69ff0949a3aaec0d5e3d67898bb7f279ab09f",
+        "rev": "a5e83808328a0905a297cae4d1581b31e4494b13",
         "type": "github"
       },
       "original": {
@@ -227,6 +347,28 @@
       }
     },
     "opam2json": {
+      "inputs": {
+        "nixpkgs": [
+          "ocamllsp",
+          "opam-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665671715,
+        "narHash": "sha256-7f75C6fIkiLzfkwLpJxlQIKf+YORGsXGV8Dr2LDDi+A=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "32fa2dcd993a27f9e75ee46fb8b78a7cd5d05113",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
+    "opam2json_2": {
       "inputs": {
         "nixpkgs": [
           "opam-nix",
@@ -252,7 +394,8 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "ocamllsp": "ocamllsp",
-        "opam-nix": "opam-nix"
+        "opam-nix": "opam-nix_2",
+        "opam-repository": "opam-repository_2"
       }
     }
   },


### PR DESCRIPTION
* do not reuse inputs from ocamllsp
* do not use opam-repository from opam-nix
* add devShells to allow more than one shell to be defined

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 727091c3-bd27-4253-b868-ad6753f515c2