### PR TITLE
ci: auto-cancel previous jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,6 +5,10 @@ on:
   - pull_request
   - workflow_dispatch
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -109,9 +113,9 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
-    - run: nix build
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+      - run: nix build
 
   lint-fmt:
     runs-on: ubuntu-latest
@@ -145,7 +149,7 @@ jobs:
 
       - name: Install Coq
         run: opam install coq.8.16.0 coq-native
-      
+
       - run: opam exec -- make test-coq
         env:
           # We disable the Dune cache when running the tests


### PR DESCRIPTION
This concurrency expression allows us to cancel runnings actions when we (force) push new commits.
