### PR TITLE
Fix bug in drop_suffix

### DIFF
--- a/otherlibs/stdune/string.ml
+++ b/otherlibs/stdune/string.ml
@@ -73,7 +73,7 @@ let drop_prefix_if_exists s ~prefix =
 
 let drop_suffix s ~suffix =
   if is_suffix s ~suffix then
-    if length s = length suffix then Some s
+    if length s = length suffix then Some ""
     else Some (sub s ~pos:0 ~len:(length s - length suffix))
   else None
 

--- a/test/expect-tests/stdune/string_tests.ml
+++ b/test/expect-tests/stdune/string_tests.ml
@@ -105,3 +105,27 @@ let%expect_test _ =
   [%expect {|
 "foo"
 |}]
+
+let%expect_test _ =
+  String.drop_suffix "foobar" ~suffix:"bar" |> option string |> print_dyn;
+  [%expect {|
+Some "foo"
+|}]
+
+let%expect_test _ =
+  String.drop_suffix "foobar" ~suffix:"foobar" |> option string |> print_dyn;
+  [%expect {|
+Some ""
+|}]
+
+let%expect_test _ =
+  String.drop_suffix "foobar" ~suffix:"" |> option string |> print_dyn;
+  [%expect {|
+Some "foobar"
+|}]
+
+let%expect_test _ =
+  String.drop_suffix "foobar" ~suffix:"foo" |> option string |> print_dyn;
+  [%expect {|
+None
+|}]


### PR DESCRIPTION
Previously if the suffix was the entire string, drop_suffix would return the original string. This changes its behaviour to return the empty string instead in this case.

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>