### PR TITLE
refactor: clarify matching for path comparison and add a docstring

### DIFF
--- a/otherlibs/stdune/path.ml
+++ b/otherlibs/stdune/path.ml
@@ -707,6 +707,9 @@ module T : sig
 
   val to_dyn : t -> Dyn.t
 
+  (** [External _] < [In_source_tree _] < [In_build_dir _]
+
+      Path of the same kind are compared using the standard lexical order *)
   val compare : t -> t -> Ordering.t
 
   val equal : t -> t -> bool
@@ -730,8 +733,8 @@ end = struct
     | External _, _ -> Lt
     | _, External _ -> Gt
     | In_source_tree x, In_source_tree y -> Local.compare x y
-    | In_source_tree _, _ -> Lt
-    | _, In_source_tree _ -> Gt
+    | In_source_tree _, In_build_dir _ -> Lt
+    | In_build_dir _, In_source_tree _ -> Gt
     | In_build_dir x, In_build_dir y -> Local.compare x y
 
   let equal (x : t) (y : t) = x = y


### PR DESCRIPTION
I was searching for the ordering of the keys in a `Path.Set` and thought the pattern matching could be easier to read by refining some of the wildcards `_`.

I also added a docstring explaining how paths are compared. I wonder if it would be useful to add this information to `Path.Set`'s description and to he ones of other collections over paths.