### PR TITLE
chore(nix): add `devShells.slim`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,23 @@
             );
           };
 
+        devShells.slim = with pkgs.ocamlPackages; pkgs.mkShell {
+          inputsFrom = [ dune_3 ];
+          nativeBuildInputs = with pkgs; [ pkg-config nodejs-slim ];
+          buildInputs = [
+            merlin
+            ocamlformat
+            ppx_expect
+            ctypes
+            integers
+            mdx
+            cinaps
+            menhir
+            odoc
+            lwt
+          ];
+        };
+
         devShells.default =
           pkgs.mkShell {
             nativeBuildInputs = [ pkgs.opam ];


### PR DESCRIPTION
- Add a lighter version of the default shell that can bootstrap an environment with `nix develop .#slim`
- This is a little more cache-friendly with upstream, and avoids resolving all of opam-repository
  - Useful for a quick env bootstrap to test something out


Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>