### PR TITLE
fix: create fake socket rpc file on windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ Unreleased
 - Allow absolute build directories to find public executables. For example,
   those specified with `(deps %{bin:...})` (#6326, @anmonteiro)
 
+- Create a fake socket file `_build/.rpc/dune` on windows to allow rpc clients
+  to connect using the build directory. (#6329, @rgrinberg)
+
 3.5.0 (2022-10-19)
 ------------------
 

--- a/otherlibs/dune-rpc/private/where.mli
+++ b/otherlibs/dune-rpc/private/where.mli
@@ -5,6 +5,8 @@ type t =
   | `Ip of [ `Host of string ] * [ `Port of int ]
   ]
 
+val rpc_socket_relative_to_build_dir : string
+
 val to_string : t -> string
 
 val compare : t -> t -> Ordering.t

--- a/src/dune_rpc_impl/server.ml
+++ b/src/dune_rpc_impl/server.ml
@@ -57,6 +57,11 @@ module Run = struct
   let t_var : t Fiber.Var.t = Fiber.Var.create ()
 
   let of_config { Config.handler; backlog; pool; root; where } stats =
+    let () =
+      let socket_file = Where.rpc_socket_file () in
+      Path.mkdir_p (Path.build (Path.Build.parent_exn socket_file));
+      at_exit (fun () -> Path.Build.unlink_no_err socket_file)
+    in
     let server = Csexp_rpc.Server.create (Where.to_socket where) ~backlog in
     { server; handler; stats; pool; root; where }
 

--- a/src/dune_rpc_impl/where.ml
+++ b/src/dune_rpc_impl/where.ml
@@ -48,3 +48,11 @@ let to_socket = function
 let to_string = function
   | `Unix p -> sprintf "unix://%s" p
   | `Ip (`Host host, `Port port) -> sprintf "%s:%d" host port
+
+let rpc_socket_file =
+  let f =
+    lazy
+      (Path.Build.(relative root)
+         Dune_rpc_private.Where.rpc_socket_relative_to_build_dir)
+  in
+  fun () -> Lazy.force f

--- a/src/dune_rpc_impl/where.mli
+++ b/src/dune_rpc_impl/where.mli
@@ -8,4 +8,6 @@ val get : unit -> Dune_rpc.Where.t option
 
 val to_socket : Dune_rpc.Where.t -> Unix.sockaddr
 
+val rpc_socket_file : unit -> Path.Build.t
+
 val to_string : Dune_rpc.Where.t -> string

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -9,7 +9,14 @@ type event =
   | Fill of Fiber.fill
   | Abort
 
-let server where = Server.create where ~backlog:10
+let server (where : Unix.sockaddr) =
+  (match where with
+  | ADDR_UNIX p ->
+    let p = Path.of_string p in
+    Path.unlink_no_err p;
+    Path.mkdir_p (Path.parent_exn p)
+  | _ -> ());
+  Server.create where ~backlog:10
 
 let client where = Csexp_rpc.Client.create where
 


### PR DESCRIPTION
To allow connections to an rpc instance that isn't in the registry.
Previously, the socket file was only created on Unix. So windows users
couldn't point their clients at _build/.rpc/dune and connect.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: c7483b66-9ba3-430e-b5c3-2c3e52a2b1ca