### PR TITLE
Prevent crash on absolute path in install stanza and glob_files_rec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@ Unreleased
 - Create a fake socket file `_build/.rpc/dune` on windows to allow rpc clients
   to connect using the build directory. (#6329, @rgrinberg)
 
+- Prevent crash if absolute paths are used in the install stanza and in
+  recursive globs. These cases now result in a user error. (#6331, @gridbugs)
+
 3.5.0 (2022-10-19)
 ------------------
 

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -662,6 +662,9 @@ Dune supports globbing files in a single directory via ``(glob_files
 - anything after the last ``/``, or everything if the glob contains no ``/``, is
   interpreted using the glob syntax
 
+Absolute paths are permitted in the ``(glob_files ...)`` term only. It's an error to pass
+an absolute path (i.e., a path beginning with a ``/``) to ``(glob_files_rec ...)```.
+
 The glob syntax is interpreted as follows:
 
 - ``\<char>`` matches exactly ``<char>``, even if it's a special character

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -1416,6 +1416,9 @@ installed in. If the section above is documented as "with the executable bit
 set", they are installed with mode ``0o755`` (``rwxr-xr-x``); otherwise they are
 installed with mode ``0o644`` (``rw-r--r--``).
 
+Note that all files in the install stanza must be specified by relative paths only.
+It is an error to specify files by absolute paths.
+
 Including Files in the Install Stanza
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -140,6 +140,9 @@ let rec dep expander = function
     Other
       (let loc = String_with_vars.loc s in
        let* path = Expander.expand_path expander s in
+       if recursive && not (Path.is_managed path) then
+         User_error.raise ~loc
+           [ Pp.textf "Absolute paths in recursive globs are not supported." ];
        let files_in =
          let glob = Path.basename path |> Glob.of_string_exn loc in
          fun dir ->

--- a/test/blackbox-tests/test-cases/glob_files_rec.t
+++ b/test/blackbox-tests/test-cases/glob_files_rec.t
@@ -82,3 +82,24 @@ Check that generated directories are ignored
 
   $ dune build @x
 
+Check that we get a nice error message if we pass and absolute path to `glob_files_rec`
+---------------------------------------------------------------------------------------
+
+Put $PWD in a file that can be read with the %{read:...} pform, so the underline
+in the error message is of consistent length on different systems.
+  $ printf $PWD > pwd
+
+  $ cat > dune <<EOF
+  > (rule
+  >  (alias x)
+  >  (deps (glob_files_rec %{read:pwd}/*))
+  >  (action (echo %{deps})))
+  > EOF
+
+  $ dune build @x
+  File "dune", line 3, characters 23-36:
+  3 |  (deps (glob_files_rec %{read:pwd}/*))
+                             ^^^^^^^^^^^^^
+  Error: Absolute paths in recursive globs are not supported.
+  [1]
+

--- a/test/blackbox-tests/test-cases/install-absolute-path-error.t
+++ b/test/blackbox-tests/test-cases/install-absolute-path-error.t
@@ -1,0 +1,41 @@
+Report an error when absolute paths appear in the install stanza
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.6)
+  > (package (name foo))
+  > EOF
+
+Put $PWD in a file that can be read with the %{read:...} pform, so the underline
+in the error message is of consistent length on different systems.
+  $ printf $PWD > pwd
+
+  $ touch foo.txt
+
+  $ cat >dune <<EOF
+  > (install
+  >  (files %{read:pwd}/foo.txt)
+  >  (section share))
+  > EOF
+
+  $ dune build @install
+  File "dune", line 2, characters 8-27:
+  2 |  (files %{read:pwd}/foo.txt)
+              ^^^^^^^^^^^^^^^^^^^
+  Error: Absolute paths are not allowed in the install stanza.
+  [1]
+
+  $ mkdir -p bar
+  $ touch bar/bar.txt
+
+  $ cat >dune <<EOF
+  > (install
+  >  (dirs %{read:pwd}/bar)
+  >  (section share))
+  > EOF
+
+  $ dune build @install
+  File "dune", line 2, characters 7-22:
+  2 |  (dirs %{read:pwd}/bar)
+             ^^^^^^^^^^^^^^^
+  Error: Absolute paths are not allowed in the install stanza.
+  [1]


### PR DESCRIPTION
These cases now result in a user error being raised instead of crashing dune.

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>