### PR TITLE
test: glob deps referring to outside the directory

### DIFF
--- a/test/blackbox-tests/test-cases/glob-deps-outside-directory.t
+++ b/test/blackbox-tests/test-cases/glob-deps-outside-directory.t
@@ -1,0 +1,20 @@
+Glob deps in a subdirectory that refer to a path outside that subdirectory
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.6)
+  > EOF
+
+  $ mkdir -p foo bar
+
+  $ cat > foo/dune <<EOF
+  > (rule
+  >  (alias x)
+  >  (deps (glob_files ../bar/*.txt))
+  >  (action (system "for i in %{deps}; do printf \"\$i\\n\"; done")))
+  > EOF
+
+  $ touch bar/a.txt bar/b.txt
+
+  $ dune build @foo/x
+  ../bar/a.txt
+  ../bar/b.txt


### PR DESCRIPTION
This adds a test that exercises our ability to handle globs that begin with ".." in preparation for a change that generalizes our implementation of globs

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>