### PR TITLE
ci: Add documentation job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -133,6 +133,14 @@ jobs:
         run: opam exec -- make install-ocamlformat
       - run: opam exec -- make fmt
 
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+      - run: nix develop .#doc -c make doc
+
   coq:
     name: Coq 8.16.0
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ distclean: clean
 
 .PHONY: doc
 doc:
-	sphinx-build doc doc/_build
+	sphinx-build -W doc doc/_build
 
 # livedoc-deps: you may need to [pip3 install sphinx-autobuild] and [pip3 install sphinx-rtd-theme]
 livedoc:

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -1296,14 +1296,13 @@ Here is a complete list of supported subfields:
   - ``dir3`` which would add ``dir3`` to the list of include directories
   - ``((lib lib3) dir4 (include inc2))`` which would add the source directory of
     the library ``lib3``, the directory ``dir4``, and the result of recursively
-    including the contents of the file ``inc2``
-  The contents of included
-  directories are tracked recursively, e.g., if you use ``(include_dir dir)``
-  and have headers ``dir/base.h`` and ``dir/lib/lib.h``, they both will
-  be tracked as dependencies.
-- ``extra_deps`` specifies any other dependencies that should be tracked.
-  This is useful when dealing with ``#include`` statements that escape into
-  a parent directory like ``#include "../a.h"``.
+    including the contents of the file ``inc2``.
+    The contents of included directories are tracked recursively, e.g., if you
+    use ``(include_dir dir)`` and have headers ``dir/base.h`` and
+    ``dir/lib/lib.h``, they both will be tracked as dependencies.
+  - ``extra_deps`` specifies any other dependencies that should be tracked.
+    This is useful when dealing with ``#include`` statements that escape into
+    a parent directory like ``#include "../a.h"``.
 
 
 Mode-Dependent Stubs
@@ -1396,7 +1395,7 @@ libraries or linked into OCaml executables. Do this by using the
 ``extra_objects`` field of the ``library`` or ``executable`` stanzas.
 For example:
 
-.. code:: scheme
+.. code:: lisp
 
     (executable
      (public_name main)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ author = u'Jérémie Dimino'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
We also make `make doc` more strict with respect to Sphinx warnings and fix a few warnings.