### PR TITLE
refactor: optimize `Ansi_color.strip` perf by copying substrings

### DIFF
--- a/otherlibs/stdune/ansi_color.ml
+++ b/otherlibs/stdune/ansi_color.ml
@@ -162,22 +162,24 @@ let prerr =
 let strip str =
   let len = String.length str in
   let buf = Buffer.create len in
-  let rec loop i =
-    if i = len then Buffer.contents buf
+  let rec loop start i =
+    if i = len then (
+      if i - start > 0 then Buffer.add_substring buf str start (i - start);
+      Buffer.contents buf)
     else
-      match str.[i] with
-      | '\027' -> skip (i + 1)
-      | c ->
-        Buffer.add_char buf c;
-        loop (i + 1)
+      match String.unsafe_get str i with
+      | '\027' ->
+        if i - start > 0 then Buffer.add_substring buf str start (i - start);
+        skip (i + 1)
+      | _ -> loop start (i + 1)
   and skip i =
     if i = len then Buffer.contents buf
     else
-      match str.[i] with
-      | 'm' -> loop (i + 1)
+      match String.unsafe_get str i with
+      | 'm' -> loop (i + 1) (i + 1)
       | _ -> skip (i + 1)
   in
-  loop 0
+  loop 0 0
 
 let index_from_any str start chars =
   let n = String.length str in

--- a/test/expect-tests/stdune/ansi_color_tests.ml
+++ b/test/expect-tests/stdune/ansi_color_tests.ml
@@ -107,3 +107,19 @@ let%expect_test "reproduce #2664" =
                                                                     [ "34" ],
                                                                     Verbatim
                                                                       "20" |}]
+
+let%expect_test "Ansi_color.strip" =
+  print_string
+    (String.concat ~sep:"\n"
+       (List.map ~f:Ansi_color.strip
+          [ "\027[34mthe lazy fox\027[39m jumps over the brown dog\027[0m"
+          ; "the lazy fox \027[34mjumps over\027[39m the brown dog\027[0m"
+          ; "\027[34mthe lazy fox\027[39m jumps over \027[0mthe brown dog"
+          ; "\027[34mthe lazy fox \027[39mjumps over\027[0thebrown dog"
+          ]));
+  [%expect
+    {|
+the lazy fox jumps over the brown dog
+the lazy fox jumps over the brown dog
+the lazy fox jumps over the brown dog
+the lazy fox jumps over|}]


### PR DESCRIPTION
`Ansi_color.strip` removes ANSI escape sequences of colors[¹].

They start with the ASCII ESC (escape) character and end with the m character. The function used to copy valid characters character by character, but that is inefficient as we can copy to the destination buffer the whole valid substring at once.
Switching to unsafe string access in the inner loop yields another improvement.

The two combined show an improvement of 50% in a micro-benchmark realistic test case:

String of 562895 bytes with 1740 ANSI escape sequences. 
```
╭─────────────────────────┬───────────────────────────╮
│name                     │  monotonic-clock          │
├─────────────────────────┼───────────────────────────┤
│  strip strip_char       │        3090329.2703 ns/run│
│  strip strip_substring  │        1499787.6293 ns/run│
╰─────────────────────────┴───────────────────────────╯
```
[¹]: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters