### PR TITLE
Support `CLICOLOR` and `CLICOLOR_FORCE` to manage ANSI colors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Support `CLICOLOR` and `CLICOLOR_FORCE` to enable/disable/force ANSI
+  colors. (#6340, fixes #6323, @MisterDA).
+
 - Allow `Byte_complete` binaries to be installable (#4873, @AltGr, @rgrinberg)
 
 - Revive `$ dune external-lib-deps` under `$ dune describe external-lib-deps`.

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -131,7 +131,7 @@ let runtest_info =
         ]
     ]
   in
-  Cmd.info "runtest" ~doc ~man
+  Cmd.info "runtest" ~doc ~man ~envs:Common.envs
 
 let runtest_term =
   let name_ = Arg.info [] ~docv:"DIR" in
@@ -184,7 +184,7 @@ let build =
     in
     run_build_command ~common ~config ~request
   in
-  Cmd.v (Cmd.info "build" ~doc ~man) term
+  Cmd.v (Cmd.info "build" ~doc ~man ~envs:Common.envs) term
 
 let fmt =
   let doc = "Format source code." in
@@ -209,4 +209,4 @@ let fmt =
     in
     run_build_command ~common ~config ~request
   in
-  Cmd.v (Cmd.info "fmt" ~doc ~man) term
+  Cmd.v (Cmd.info "fmt" ~doc ~man ~envs:Common.envs) term

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1063,6 +1063,21 @@ let term_with_default_root_is_cwd = term ~default_root_is_cwd:true
 
 let term = term ~default_root_is_cwd:false
 
+let envs =
+  Cmd.Env.
+    [ info
+        ~doc:
+          "If different than $(b,0), ANSI colors are supported and should be \
+           used when the program isn’t piped. If equal to $(b,0), don’t output \
+           ANSI color escape codes"
+        "CLICOLOR"
+    ; info
+        ~doc:
+          "If different than $(b,0), ANSI colors should be enabled no matter \
+           what."
+        "CLICOLOR_FORCE"
+    ]
+
 let config_from_config_file = Options_implied_by_dash_p.config_term
 
 let context_arg ~doc =

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -52,6 +52,8 @@ val term : t Cmdliner.Term.t
 
 val term_with_default_root_is_cwd : t Cmdliner.Term.t
 
+val envs : Cmdliner.Cmd.Env.info list
+
 (** Set whether Dune should print the "Entering directory '<dir>'" message *)
 val set_print_directory : t -> bool -> t
 

--- a/bin/help.ml
+++ b/bin/help.ml
@@ -102,7 +102,7 @@ let man =
   ; Common.footer
   ]
 
-let info = Cmd.info "help" ~doc ~man
+let info = Cmd.info "help" ~doc ~man ~envs:Common.envs
 
 let term =
   Term.ret

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -47,7 +47,7 @@ let common_commands_synopsis =
 
 let info =
   let doc = "composable build system for OCaml" in
-  Cmd.info "dune" ~doc
+  Cmd.info "dune" ~doc ~envs:Common.envs
     ~version:
       (match Build_info.V1.version () with
       | None -> "n/a"


### PR DESCRIPTION
The patch follows the spec at <https://bixense.com/clicolors/> that has been implemented by multiple build systems and compilers already.

When Dune is not run in a tty (such as a CI system or a script), it will strip ANSI colors from the output of targets (such a tests runs). This is often undesirable.

Dune will now recognize the following environment variables and act according to the spec:

- `CLICOLOR != 0`
  ANSI colors are supported and should be used when the program isn’t piped.
- `CLICOLOR == 0`
  Don’t output ANSI color escape codes.
- `CLICOLOR_FORCE != 0`
  ANSI colors should be enabled no matter what.

The behaviour regarding `TERM=dumb` is also retained.

This allows toggling from the global state the output of colors.

Fixes #6323.