### PR TITLE
fix(melange): merlin support for melange only libs

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -215,7 +215,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       ~preprocess ~obj_dir
       ~dialects:(Dune_project.dialects (Scope.project scope))
       ~ident:(Lib.Compile.merlin_ident compile_info)
-      () )
+      ~modes:`Exe () )
 
 let compile_info ~scope (exes : Dune_file.Executables.t) =
   let dune_version = Scope.project scope |> Dune_project.dune_version in

--- a/src/dune_rules/merlin.mli
+++ b/src/dune_rules/merlin.mli
@@ -40,6 +40,7 @@ val make :
   -> obj_dir:Path.Build.t Obj_dir.t
   -> dialects:Dialect.DB.t
   -> ident:Merlin_ident.t
+  -> modes:[ `Lib of Lib_mode.Map.Set.t | `Exe ]
   -> unit
   -> t
 

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -1,0 +1,26 @@
+ Temporary special merlin support for melange only libs
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.6)
+  > (using melange 0.1)
+  > EOF
+
+  $ lib=foo
+  $ cat >dune <<EOF
+  > (library
+  >  (name $lib)
+  >  (private_modules bar)
+  >  (modes melange))
+  > EOF
+
+  $ touch bar.ml $lib.ml
+  $ dune build @check
+  $ dune ocaml-merlin --dump-config="$(pwd)" | grep -i "$lib"
+  Foo
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+     Foo__
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+     Foo__
+  Foo__
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+     Foo__


### PR DESCRIPTION
If a library is defined only for melange, we tell merlin to use the
melange object dir to lookup cmi's