### PR TITLE
test(coq): remove macos coq native restriction

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -134,7 +134,13 @@ jobs:
 
   coq:
     name: Coq 8.16.0
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -1,14 +1,6 @@
-; Coq for macos does not support native compilation yet.
-; TODO Enable tests when ready
-
 (cram
  (applies_to :whole_subtree)
  (deps %{bin:coqc} %{bin:coqdep})
  (alias runtest-coq)
  (enabled_if
   (= %{env:DUNE_COQ_TEST=disable} enable)))
-
-(cram
- (applies_to native-compose native-single)
- (enabled_if
-  (<> %{system} macosx)))


### PR DESCRIPTION
We don't test on macos and it shouldn't be Dune's job to do so anyway.