### PR TITLE
doc: Improve documentation for dune cache

### DIFF
--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -13,6 +13,15 @@ let man =
         functionality soon. |}
   ; `S "ACTIONS"
   ; `P {|$(b,trim) trim the shared cache to free space.|}
+  ; `S "EXAMPLES"
+  ; `Pre
+      {|Trimming the Dune cache to 1 GB.
+        
+        \$ dune cache trim --trimmed-size=1GB |}
+  ; `Pre
+      {|Trimming 500 MB from the Dune cache.
+        
+        \$ dune cache trim --size=500MB |}
   ; `Blocks Common.help_secs
   ]
 
@@ -75,12 +84,12 @@ let term =
          value
          & opt (some bytes) None
          & info ~docv:"BYTES" [ "trimmed-size" ]
-             ~doc:"size to trim from the cache")
+             ~doc:"Size to trim from the cache.")
      and+ size =
        Arg.(
          value
          & opt (some bytes) None
-         & info ~docv:"BYTES" [ "size" ] ~doc:"size to trim the cache to")
+         & info ~docv:"BYTES" [ "size" ] ~doc:"Size to trim the cache to.")
      in
      match mode with
      | Some Trim -> `Ok (trim ~trimmed_size ~size)


### PR DESCRIPTION
Looks like:
```

EXAMPLES
       Trimming the Dune cache to 1 GB.

               $ dune cache trim --trimmed-size=1GB

       Trimming 500 MB from the Dune cache.

               $ dune cache trim --size=500MB

```