### PR TITLE
add test to showcase wasteful cm* lib artifacts

### DIFF
--- a/test/blackbox-tests/test-cases/lib-wasteful-cms.t
+++ b/test/blackbox-tests/test-cases/lib-wasteful-cms.t
@@ -1,0 +1,48 @@
+Testsuite to show wasteful rules being generated for some cm* files.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.6)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name a)
+  >  (modules a)
+  >  (libraries foo))
+  > EOF
+
+  $ cat > a.ml <<EOF
+  > let () =
+  >   Foo.Z.f ()
+  > EOF
+
+  $ cat > b.ml <<EOF
+  > let () =
+  >   Foo.f ()
+  > EOF
+
+  $ mkdir foo
+
+  $ cat > foo/dune <<EOF
+  > (library
+  >  (name foo))
+  > EOF
+
+  $ cat > foo/z.ml <<EOF
+  > let f () =
+  >   print_endline "12"
+  > EOF
+
+  $ cat > foo/y.ml <<EOF
+  > let g () =
+  >   print_endline "22"
+  > EOF
+
+Rules for foo__Y are created and the targets generated even if it is never used
+  $ dune build --display short @all 2>&1 | dune_cmd sanitize | grep foo__Y
+        ocamlc foo/.foo.objs/byte/foo__Y.{cmi,cmo,cmt}
+      ocamlopt foo/.foo.objs/native/foo__Y.{cmx,o}
+
+  $ (cd _build/default && ./a.exe)
+  12
+


### PR DESCRIPTION
In https://github.com/ocaml/dune/pull/6349#discussion_r1008764988, @rgrinberg mentioned the downsides of eagerly (wastefully) generating `.js` artifacts for modules that are never part of the build.

This test shows the problem is shared with any artifacts of a library in byte and native generation, not something specific to melange js artifacts.