### PR TITLE
test(coq): add test demonstrating missing flags to dune coq top

### DIFF
--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/Test.v
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/Test.v
@@ -1,0 +1,1 @@
+Inductive foo := .

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/dune
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/dune
@@ -1,0 +1,3 @@
+(coq.theory
+ (name minimal)
+ (flags -w -notation-overridden))

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.6)
+(using coq 0.7)

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
@@ -1,0 +1,12 @@
+Testing that the correct flags are being passed to dune coq top
+
+The flags passed to coqc:
+  $ dune build && tail -1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
+  coqc -w -notation-overridden -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . minimal Test.v)
+
+BUG: coqtop flags are missing. Specifically ones from Context.coq_flags in
+coq_rules.ml
+
+The flags passed to coqtop:
+  $ dune coq top --toplevel=echo Test.v
+  -topfile $TESTCASE_ROOT/_build/default/Test.v -R $TESTCASE_ROOT/_build/default minimal


### PR DESCRIPTION
Test demonstrating #6366.

The issue is that `Context.coq_flags` is missing from the coqtop flags in coq_rules. This is not so easy to add however due to that being an `Action_builder`. I've tried refactoring the coqtop stuff to allow for this but it will require more work.