### PR TITLE
fix(ctypes): remove unnecessary case changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- [ctypes] do not mangle user written names in the ctypes stanza (#6374, fixes
+  #5561, @rgrinberg)
+
 - Support `CLICOLOR` and `CLICOLOR_FORCE` to enable/disable/force ANSI
   colors. (#6340, fixes #6323, @MisterDA).
 

--- a/src/dune_rules/ctypes_stanza.ml
+++ b/src/dune_rules/ctypes_stanza.ml
@@ -170,19 +170,15 @@ let () =
     (return [ (name, decode >>| fun x -> [ T x ]) ])
 
 let type_gen_script ctypes =
-  sprintf "%s__type_gen"
-    (ctypes.external_library_name |> External_lib_name.clean
-   |> External_lib_name.to_string)
-
-let module_name_lower_string module_name =
-  String.lowercase (Module_name.to_string module_name)
+  ctypes.external_library_name |> External_lib_name.clean
+  |> External_lib_name.to_string |> sprintf "%s__type_gen"
 
 let function_gen_script ctypes (fd : Function_description.t) =
   sprintf "%s__function_gen__%s__%s"
     (ctypes.external_library_name |> External_lib_name.clean
    |> External_lib_name.to_string)
-    (module_name_lower_string fd.functor_)
-    (module_name_lower_string fd.instance)
+    (Module_name.to_string fd.functor_)
+    (Module_name.to_string fd.instance)
 
 let c_generated_types_module ctypes =
   sprintf "%s__c_generated_types"
@@ -194,15 +190,15 @@ let c_generated_functions_module ctypes (fd : Function_description.t) =
   sprintf "%s__c_generated_functions__%s__%s"
     (ctypes.external_library_name |> External_lib_name.clean
    |> External_lib_name.to_string)
-    (module_name_lower_string fd.functor_)
-    (module_name_lower_string fd.instance)
+    (Module_name.to_string fd.functor_)
+    (Module_name.to_string fd.instance)
   |> Module_name.of_string
 
 let c_generated_functions_cout_c ctypes (fd : Function_description.t) =
   sprintf "%s__c_cout_generated_functions__%s__%s.c"
     (External_lib_name.to_string ctypes.external_library_name)
-    (module_name_lower_string fd.functor_)
-    (module_name_lower_string fd.instance)
+    (Module_name.to_string fd.functor_)
+    (Module_name.to_string fd.instance)
 
 let type_gen_script_module ctypes =
   type_gen_script ctypes |> Module_name.of_string
@@ -226,7 +222,8 @@ let non_installable_modules ctypes =
   :: List.map ctypes.function_description ~f:(fun function_description ->
          function_gen_script_module ctypes function_description)
 
-let ml_of_module_name mn = Module_name.to_string mn ^ ".ml" |> String.lowercase
+let ml_of_module_name mn =
+  Module_name.to_string mn ^ ".ml" |> String.uncapitalize_ascii
 
 let generated_ml_and_c_files ctypes =
   let ml_files = generated_modules ctypes |> List.map ~f:ml_of_module_name in

--- a/test/blackbox-tests/test-cases/ctypes/github-5561-name-mangle.t
+++ b/test/blackbox-tests/test-cases/ctypes/github-5561-name-mangle.t
@@ -14,6 +14,26 @@
   >    (functor Type_description))))
   > EOF
 
-  $ dune build 2>&1 | head -n 2
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
+  $ dune build
+  File "fooBar__type_gen.ml", line 3, characters 12-34:
+  3 |     (module Type_description.Types)
+                  ^^^^^^^^^^^^^^^^^^^^^^
+  Error: Unbound module Type_description
+  File "dune", line 1, characters 0-177:
+  1 | (library
+  2 |  (name foo)
+  3 |  (ctypes
+  4 |   (external_library_name fooBar)
+  5 |   (generated_entry_point Types_generated2)
+  6 |   (type_description
+  7 |    (instance Type)
+  8 |    (functor Type_description))))
+  Error: No rule found for libfoo_stubs.a
+  File "dune", line 2, characters 7-10:
+  2 |  (name foo)
+             ^^^
+  Package fooBar was not found in the pkg-config search path.
+  Perhaps you should add the directory containing `fooBar.pc'
+  to the PKG_CONFIG_PATH environment variable
+  No package 'fooBar' found
+  [1]


### PR DESCRIPTION
Causes an issue when external_library_name has mixed cases

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>