### PR TITLE
Add shell completion

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -60,8 +60,14 @@ module Dep = struct
       let pos, recursive =
         if String.length s >= 2 && s.[1] = '@' then (2, false) else (1, true)
       in
-      let s = String_with_vars.make_text Loc.none (String.drop s pos) in
-      Some (if recursive then Dep_conf.Alias_rec s else Dep_conf.Alias s)
+      let s = String.drop s pos in
+      Some (s, recursive)
+
+  let parse_alias_dep s =
+    let open Option.O in
+    let+ s, recursive = parse_alias s in
+    let sw = String_with_vars.make_text Loc.none s in
+    if recursive then Dep_conf.Alias_rec sw else Alias sw
 
   let dep_parser =
     Dune_lang.Syntax.set Stanza.syntax (Active Stanza.latest_version)
@@ -70,7 +76,7 @@ module Dep = struct
          Dep_conf.decode)
 
   let parser s =
-    match parse_alias s with
+    match parse_alias_dep s with
     | Some dep -> Ok dep
     | None -> (
       match

--- a/bin/arg.mli
+++ b/bin/arg.mli
@@ -32,6 +32,8 @@ module Dep : sig
   val alias_rec : dir:Stdune.Path.Local.t -> Dune_engine.Alias.Name.t -> t
 
   val to_string_maybe_quoted : t -> string
+
+  val parse_alias : string -> (string * bool) option
 end
 
 val bytes : int64 conv

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -3,7 +3,7 @@ open Import
 module Source_tree = Dune_engine.Source_tree
 
 let complete s_opt =
-  let common = Common.default () in
+  let common = Common.for_complete () in
   let config = Common.init common in
   let complete_path path = Target.target_candidates path in
   let best_dir dir =
@@ -201,7 +201,7 @@ let dir' =
       | None -> Path.Source.root
       | Some prefix -> Path.Source.of_string prefix
     in
-    let common = Common.default () in
+    let common = Common.for_complete () in
     let config = Common.init common in
     Scheduler.go ~common ~config (fun () ->
         Build_system.run_exn (fun () ->

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -35,7 +35,9 @@ let complete s_opt =
                 prefix ^ Path.Source.to_string (Path.Source.relative dir s)
               in
               (* TODO compute the list of aliases defined in a directory *)
-              let alias_names = [ "all"; "runtest"; "default"; "fmt" ] in
+              let alias_names =
+                [ "all"; "runtest"; "default"; "fmt"; "install" ]
+              in
               List.map subdirs ~f:(fun subdir -> prefixed subdir ^ "/")
               @ List.map alias_names ~f:(fun alias -> prefixed alias))))
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1142,9 +1142,9 @@ let context_arg ~doc =
     & opt Arg.context_name Dune_engine.Context_name.default
     & info [ "context" ] ~docv:"CONTEXT" ~doc)
 
-let default () =
+let for_complete () =
   let info = Cmd.info "term-default" in
   let cmd = Cmd.v info term in
-  match Cmd.eval_value ~argv:[| Sys.argv.(0) |] cmd with
+  match Cmd.eval_value ~argv:[| Sys.argv.(0); "--display=quiet" |] cmd with
   | Ok (`Ok x) -> x
   | Ok `Version | Ok `Help | Error _ -> (* XXX *) assert false

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1141,3 +1141,10 @@ let context_arg ~doc =
     value
     & opt Arg.context_name Dune_engine.Context_name.default
     & info [ "context" ] ~docv:"CONTEXT" ~doc)
+
+let default () =
+  let info = Cmd.info "term-default" in
+  let cmd = Cmd.v info term in
+  match Cmd.eval_value ~argv:[| Sys.argv.(0) |] cmd with
+  | Ok (`Ok x) -> x
+  | Ok `Version | Ok `Help | Error _ -> (* XXX *) assert false

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -60,6 +60,8 @@ val footer : Cmdliner.Manpage.block
 
 val term : t Cmdliner.Term.t
 
+val default : unit -> t
+
 val term_with_default_root_is_cwd : t Cmdliner.Term.t
 
 val envs : Cmdliner.Cmd.Env.info list

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -60,7 +60,7 @@ val footer : Cmdliner.Manpage.block
 
 val term : t Cmdliner.Term.t
 
-val default : unit -> t
+val for_complete : unit -> t
 
 val term_with_default_root_is_cwd : t Cmdliner.Term.t
 

--- a/bin/complete.ml
+++ b/bin/complete.ml
@@ -170,6 +170,23 @@ module Test = struct
   let group = Cmd.group info [ Several_pos.command; List.command ]
 end
 
+module Target = struct
+  let info = Cmd.info "target"
+
+  let term =
+    let+ () = Term.const () in
+    let common = Common.default () in
+    let config = Common.init common in
+    Scheduler.go ~common ~config (fun () ->
+        Build_system.run_exn (fun () ->
+            let open Memo.O in
+            let+ targets = Target.target_candidates Path.root in
+            List.iter ~f:print_endline targets))
+
+  let command = Cmd.v info term
+end
+
 let info = Cmd.info "complete"
 
-let command = Cmd.group info [ Script.command; Command.command; Test.group ]
+let command =
+  Cmd.group info [ Script.command; Command.command; Test.group; Target.command ]

--- a/bin/complete.ml
+++ b/bin/complete.ml
@@ -170,23 +170,6 @@ module Test = struct
   let group = Cmd.group info [ Several_pos.command; List.command ]
 end
 
-module Target = struct
-  let info = Cmd.info "target"
-
-  let term =
-    let+ () = Term.const () in
-    let common = Common.default () in
-    let config = Common.init common in
-    Scheduler.go ~common ~config (fun () ->
-        Build_system.run_exn (fun () ->
-            let open Memo.O in
-            let+ targets = Target.target_candidates Path.root in
-            List.iter ~f:print_endline targets))
-
-  let command = Cmd.v info term
-end
-
 let info = Cmd.info "complete"
 
-let command =
-  Cmd.group info [ Script.command; Command.command; Test.group; Target.command ]
+let command = Cmd.group info [ Script.command; Command.command; Test.group ]

--- a/bin/complete.ml
+++ b/bin/complete.ml
@@ -1,0 +1,175 @@
+open Import
+open Stdune
+
+let all = Fdecl.create Dyn.opaque
+
+module Script = struct
+  let script =
+    {|
+_dune () {
+    COMPREPLY=( $(dune complete command --position $COMP_CWORD -- ${COMP_WORDS[*]}) )
+}
+
+complete -F _dune dune
+|}
+
+  let term =
+    let+ () = Term.const () in
+    print_endline script
+
+  let info = Cmd.info ~doc:"Output a bash completion script for dune." "script"
+
+  let command = Cmd.v info term
+end
+
+module Command = struct
+  let split_at n l =
+    let rec go n l acc =
+      match l with
+      | h :: t when n > 0 -> go (n - 1) t (h :: acc)
+      | _ -> (acc, l)
+    in
+    let rev_head, tail = go n l [] in
+    (List.rev rev_head, tail)
+
+  let compute_prefix cword cmdline =
+    let first, next = split_at cword cmdline in
+    (first, List.hd_opt next)
+
+  let match_prefix word_at_completion_point w =
+    match word_at_completion_point with
+    | None -> true
+    | Some prefix -> String.is_prefix ~prefix w
+
+  let complete_using_cline cmd args =
+    let cmd_args = cmd |> Cmdliner_cmd.get_info |> Cmdliner_info.Cmd.args in
+    match Cmdliner_cline.create cmd_args args with
+    | Ok cline -> Some (Cmdliner_cline.complete cline args)
+    | Error _ -> None
+
+  (** TODO: this does not handle ~rev args *)
+  let arg_fits k i =
+    let start = Cmdliner_info.Arg.pos_start k in
+    let len = Cmdliner_info.Arg.pos_len k in
+    i >= start
+    &&
+    match len with
+    | None -> true
+    | Some l -> i < start + l
+
+  let complete_args cmd ~pos_only ~index word =
+    let opt_args, pos_args =
+      cmd |> Cmdliner_cmd.get_info |> Cmdliner_info.Cmd.args
+      |> Cmdliner_info.Arg.Set.elements
+      |> List.partition ~f:Cmdliner_info.Arg.is_opt
+    in
+    (if pos_only then []
+    else List.concat_map ~f:Cmdliner_info.Arg.opt_names opt_args)
+    @ List.concat_map pos_args ~f:(fun arg ->
+          let pos_kind = Cmdliner_info.Arg.pos_kind arg in
+          if arg_fits pos_kind index then Cmdliner_info.Arg.complete arg word
+          else [])
+
+  let rec find_cmd cmdline cmds =
+    match cmdline with
+    | [] -> Error (List.map cmds ~f:Cmdliner_cmd.name)
+    | first :: other_args -> (
+      match
+        List.find_opt cmds ~f:(fun cmd ->
+            String.equal first (Cmdliner_cmd.name cmd))
+      with
+      | None -> Error []
+      | Some cmd -> (
+        match cmd with
+        | Cmd _ -> Ok (cmd, other_args)
+        | Group (_, (_, cmds)) -> find_cmd other_args cmds))
+
+  let completions_at cmds position cmdline =
+    let args, word_at_completion_point = compute_prefix position cmdline in
+    let completing = Option.is_some word_at_completion_point in
+    let completions =
+      match find_cmd (List.tl args) cmds with
+      | Error words -> words
+      | Ok (cmd, other_args) -> (
+        match complete_using_cline cmd other_args with
+        | None -> []
+        | Some (Arg_value { arg; optional; index }) -> (
+          match (optional, completing) with
+          | false, _ | true, false ->
+            Cmdliner_info.Arg.complete arg word_at_completion_point
+          | true, true ->
+            complete_args cmd ~pos_only:false ~index word_at_completion_point)
+        | Some (Flag_or_pos_arg { index; pos_only }) ->
+          complete_args cmd
+            ~pos_only:(pos_only || not completing)
+            ~index word_at_completion_point)
+    in
+    List.filter completions ~f:(match_prefix word_at_completion_point)
+
+  let term =
+    let+ cmdline =
+      let open Arg in
+      value & pos_all string [] & info ~doc:"The command line to complete" []
+    and+ position =
+      let open Arg in
+      required
+      & opt (some int) None
+      & info
+          ~doc:
+            "The 0-indexed position at which to complete the command-line. For \
+             example, when typing $(b,dune bui<tab>), the position is 1 and \
+             when typing $(b,dune build <tab>) it is 2."
+          [ "position" ]
+    in
+    let cmds = Fdecl.get all |> List.map ~f:Cmd.inspect in
+    completions_at cmds position cmdline
+    |> String.Set.of_list
+    |> String.Set.iter ~f:print_endline
+
+  let info =
+    Cmd.info ~doc:"Output possible completions of a partial dune command line."
+      "command"
+
+  let command = Cmd.v info term
+end
+
+module Test = struct
+  module Several_pos = struct
+    let info = Cmd.info "several-pos"
+
+    let term =
+      let c completions =
+        Arg.conv
+          ~complete:(fun _ -> completions)
+          ((fun _ -> Ok ()), fun _ () -> ())
+      in
+      let+ () = Arg.(value & pos 0 (c [ "a1"; "a2" ]) () & info [])
+      and+ () = Arg.(value & pos 1 (c [ "b1"; "b2" ]) () & info []) in
+      ()
+
+    let command = Cmd.v info term
+  end
+
+  module List = struct
+    let info = Cmd.info "list"
+
+    let term =
+      let c =
+        Arg.conv
+          ~complete:(fun _ -> [ "aa"; "bb" ])
+          ((fun _ -> Ok ()), fun _ () -> ())
+      in
+      let+ (_ : unit list) = Arg.(value & pos 0 (list c) [] & info []) in
+      ()
+
+    let command = Cmd.v info term
+  end
+
+  let info = Cmd.info "test"
+
+  let group = Cmd.group info [ Several_pos.command; List.command ]
+end
+
+let info = Cmd.info "complete"
+
+let command = Cmd.group info [ Script.command; Command.command; Test.group ]

--- a/bin/complete.ml
+++ b/bin/complete.ml
@@ -3,11 +3,13 @@ open Stdune
 
 let all = Fdecl.create Dyn.opaque
 
-module Script = struct
-  let script =
+module Setup = struct
+  let info = Cmd.info ~doc:"Output a bash completion script for dune." "setup"
+
+  let setup =
     {|
 _dune () {
-    COMPREPLY=( $(dune complete command --position $COMP_CWORD -- ${COMP_WORDS[*]}) )
+    eval $(dune complete script)
 }
 
 complete -F _dune dune
@@ -15,9 +17,23 @@ complete -F _dune dune
 
   let term =
     let+ () = Term.const () in
+    print_endline setup
+
+  let command = Cmd.v info term
+end
+
+module Script = struct
+  let script =
+    {|COMPREPLY=( $(dune complete command --position $COMP_CWORD -- ${COMP_WORDS[*]}) )|}
+
+  let term =
+    let+ () = Term.const () in
     print_endline script
 
-  let info = Cmd.info ~doc:"Output a bash completion script for dune." "script"
+  let info =
+    Cmd.info
+      ~doc:"Output the (potentially unstable) completion invokation for dune."
+      "script"
 
   let command = Cmd.v info term
 end
@@ -202,4 +218,5 @@ end
 
 let info = Cmd.info "complete"
 
-let command = Cmd.group info [ Script.command; Command.command; Test.group ]
+let command =
+  Cmd.group info [ Setup.command; Script.command; Command.command; Test.group ]

--- a/bin/complete.mli
+++ b/bin/complete.mli
@@ -1,0 +1,5 @@
+open Import
+
+val all : unit Cmd.t list Stdune.Fdecl.t
+
+val command : unit Cmd.t

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -829,6 +829,8 @@ module What = struct
       , return External_lib_deps )
     ]
 
+  let parsers = List.map parsers_with_docs ~f:(fun (n, _, _, _) -> n)
+
   (* The list of documentation strings (one for each command) *)
   let docs =
     List.map parsers_with_docs ~f:(fun (stag, args, doc, _parser) ->
@@ -1001,10 +1003,15 @@ let print_as_sexp dyn =
     (Dune_lang.Format.pp_top_sexps ~version [ cst ])
 
 let term : unit Term.t =
+  let converter =
+    Arg.conv
+      ~complete:(fun _ -> What.parsers)
+      (Arg.conv_parser Arg.string, Arg.conv_printer Arg.string)
+  in
   let+ common = Common.term
   and+ what =
     Arg.(
-      value & pos_all string []
+      value & pos_all converter []
       & info [] ~docv:"STRING"
           ~doc:
             ("What to describe. The syntax of this description is tied to the \

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -27,6 +27,7 @@ let all : _ Cmdliner.Cmd.t list =
     ; Ocaml_merlin.command
     ; Shutdown.command
     ; Diagnostics.command
+    ; Complete.command
     ]
   in
   let groups =
@@ -85,7 +86,9 @@ let info =
           ]
       ]
 
-let cmd = Cmd.group info all
+let cmd =
+  Fdecl.set Complete.all all;
+  Cmd.group info all
 
 let exit_and_flush code =
   Console.finish ();

--- a/bin/target.ml
+++ b/bin/target.ml
@@ -72,7 +72,7 @@ let all_direct_targets dir =
           | Build_under_directory_target _ -> All_targets.empty))
   >>| All_targets.reduce
 
-let target_hint (_setup : Dune_rules.Main.build_system) path =
+let target_candidates path =
   let open Memo.O in
   let sub_dir = Option.value ~default:path (Path.parent path) in
   (* CR-someday amokhov:
@@ -104,7 +104,11 @@ let target_hint (_setup : Dune_rules.Main.build_system) path =
           Some (Path.to_string path)
         else None)
   in
-  let candidates = String.Set.of_list candidates |> String.Set.to_list in
+  String.Set.of_list candidates |> String.Set.to_list
+
+let target_hint path =
+  let open Memo.O in
+  let+ candidates = target_candidates path in
   User_message.did_you_mean (Path.to_string path) ~candidates
 
 let resolve_path path ~(setup : Dune_rules.Main.build_system) :
@@ -112,7 +116,7 @@ let resolve_path path ~(setup : Dune_rules.Main.build_system) :
   let open Memo.O in
   let checked = Util.check_path setup.contexts path in
   let can't_build path =
-    let+ hint = target_hint setup path in
+    let+ hint = target_hint path in
     Error hint
   in
   let as_source_dir src =

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -18,3 +18,5 @@ val interpret_targets :
   -> Dune_rules.Main.build_system
   -> Arg.Dep.t list
   -> unit Dune_engine.Action_builder.t
+
+val target_candidates : Path.t -> string list Memo.t

--- a/doc/dune.inc
+++ b/doc/dune.inc
@@ -45,6 +45,15 @@
  (files   dune-clean.1))
 
 (rule
+ (with-stdout-to dune-complete.1
+  (run dune complete --help=groff)))
+
+(install
+ (section man)
+ (package dune)
+ (files   dune-complete.1))
+
+(rule
  (with-stdout-to dune-coq.1
   (run dune coq --help=groff)))
 

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -310,10 +310,6 @@ List completion:
 
 Completion of targets:
 
-  $ dune complete target
-  complete.sh
-  test
-
   $ cat > dune-project << EOF
   > (lang dune 3.0)
   > EOF

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -247,6 +247,15 @@ expect to see the list of commands that start with 'bui' (ie, just "build")
   --debug-load-dir
   --debug-store-digest-preimage
 
+  $ ./test 'dune build --sandbox=symlink --debug'
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+
   $ ./test 'dune build --promote-install-files '
   false
   true

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -332,7 +332,11 @@ Completion of targets:
   > 
   > (subdir src
   >  (rule
-  >   (write-file target contents)))
+  >   (write-file target contents))
+  > 
+  >  (rule
+  >   (alias custom)
+  >   (action (progn))))
   > 
   > (subdir src/sub
   >  (rule
@@ -357,18 +361,16 @@ Completion of targets:
   
   $ ./test 'dune build @'
   @all
+  @check
   @default
   @fmt
-  @install
-  @runtest
   @src/
 
   $ ./test 'dune build @src/'
   @src/all
+  @src/custom
   @src/default
   @src/fmt
-  @src/install
-  @src/runtest
   @src/sub/
 
   $ ./test 'dune build @src/a'
@@ -376,8 +378,7 @@ Completion of targets:
 
   $ ./test 'dune build @@'
   @@all
+  @@check
   @@default
   @@fmt
-  @@install
-  @@runtest
   @@src/

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -382,3 +382,9 @@ Completion of targets:
   @@default
   @@fmt
   @@src/
+
+  $ ./test 'dune runtest '
+  src
+
+  $ ./test 'dune runtest src/'
+  src/sub

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -1,0 +1,308 @@
+  $ dune complete script > complete.sh
+
+`test` calls `_dune` defined in `complete.sh`. Usually, bash itself would fill
+`COMP_*` but we have to do that by hand.
+
+The convention is that if the command line does not end with a space, we're
+completing the last word. Otherwise we're completing the next word.
+
+Examples: `test 'dune '` corresponds to 'dune <tab>' (space, tab). We expect to
+see a list of commands. `test 'dune bui'` corresponds to 'dune bui<tab>'. We
+expect to see the list of commands that start with 'bui' (ie, just "build")
+
+  $ cat > test << 'EOF'
+  > #!/usr/bin/env bash
+  > COMP_LINE=$1
+  > 
+  > . complete.sh
+  > 
+  > COMP_WORDS=( $COMP_LINE )
+  > COMP_POINT=${#COMP_LINE}
+  > COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
+  > [[ $COMP_LINE =~ .*" "$ ]] && ((++COMP_CWORD))
+  > 
+  > _dune
+  > 
+  > printf '%s\n' "${COMPREPLY[@]}"
+  > EOF
+  $ chmod +x test
+
+  $ ./test 'dune '
+  build
+  cache
+  clean
+  complete
+  coq
+  describe
+  diagnostics
+  exec
+  external-lib-deps
+  fmt
+  format-dune-file
+  help
+  init
+  install
+  installed-libraries
+  internal
+  ocaml
+  ocaml-merlin
+  printenv
+  promote
+  promotion
+  rpc
+  rules
+  runtest
+  shutdown
+  subst
+  test
+  top
+  uninstall
+  upgrade
+  utop
+
+  $ ./test 'dune b'
+  build
+
+  $ ./test 'dune ocaml '
+  dump-dot-merlin
+  merlin
+  ocaml-merlin
+  top
+  top-module
+  utop
+
+  $ ./test 'dune ocaml t'
+  top
+  top-module
+
+  $ ./test 'dune ocaml bad '
+  
+  $ ./test 'dune build '
+  
+
+  $ ./test 'dune build --debug'
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+
+  $ ./test 'dune describe '
+  external-lib-deps
+  opam-files
+  pp
+  workspace
+
+  $ ./test 'dune describe work'
+  workspace
+
+  $ ./test 'dune describe -'
+  --action-stderr-on-success
+  --action-stdout-on-success
+  --always-show-command-line
+  --auto-promote
+  --build-dir
+  --build-info
+  --cache
+  --cache-check-probability
+  --cache-storage-mode
+  --config-file
+  --context
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+  --default-target
+  --diff-command
+  --disable-promotion
+  --display
+  --dump-memo-graph
+  --dump-memo-graph-format
+  --dump-memo-graph-with-timing
+  --error-reporting
+  --file-watcher
+  --for-release-of-packages
+  --force
+  --format
+  --ignore-promoted-rules
+  --instrument-with
+  --lang
+  --no-buffer
+  --no-config
+  --no-print-directory
+  --only-packages
+  --passive-watch-mode
+  --print-metrics
+  --profile
+  --promote-install-files
+  --react-to-insignificant-changes
+  --release
+  --require-dune-project-file
+  --root
+  --sandbox
+  --sanitize-for-tests
+  --store-orig-source-dir
+  --terminal-persistence
+  --trace-file
+  --verbose
+  --wait-for-filesystem-clock
+  --watch
+  --with-deps
+  --with-pps
+  --workspace
+  -f
+  -j
+  -p
+  -w
+  -x
+
+  $ ./test 'dune describe workspace --'
+  --action-stderr-on-success
+  --action-stdout-on-success
+  --always-show-command-line
+  --auto-promote
+  --build-dir
+  --build-info
+  --cache
+  --cache-check-probability
+  --cache-storage-mode
+  --config-file
+  --context
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+  --default-target
+  --diff-command
+  --disable-promotion
+  --display
+  --dump-memo-graph
+  --dump-memo-graph-format
+  --dump-memo-graph-with-timing
+  --error-reporting
+  --file-watcher
+  --for-release-of-packages
+  --force
+  --format
+  --ignore-promoted-rules
+  --instrument-with
+  --lang
+  --no-buffer
+  --no-config
+  --no-print-directory
+  --only-packages
+  --passive-watch-mode
+  --print-metrics
+  --profile
+  --promote-install-files
+  --react-to-insignificant-changes
+  --release
+  --require-dune-project-file
+  --root
+  --sandbox
+  --sanitize-for-tests
+  --store-orig-source-dir
+  --terminal-persistence
+  --trace-file
+  --verbose
+  --wait-for-filesystem-clock
+  --watch
+  --with-deps
+  --with-pps
+  --workspace
+
+  $ ./test 'dune build --sandbox '
+  copy
+  hardlink
+  none
+  symlink
+
+  $ ./test 'dune build --sandbox sym'
+  symlink
+
+  $ ./test 'dune build --no-config --debug'
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+
+  $ ./test 'dune build --sandbox symlink --debug'
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+
+  $ ./test 'dune build --promote-install-files '
+  false
+  true
+
+  $ ./test 'dune build --promote-install-files --debug'
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+
+  $ ./test 'dune build --promote-install-files --sandbox symlink --debug'
+  --debug-artifact-substitution
+  --debug-backtraces
+  --debug-cache
+  --debug-dependency-path
+  --debug-digests
+  --debug-load-dir
+  --debug-store-digest-preimage
+
+  $ ./test 'dune describe -- --debug'
+  
+
+  $ ./test 'dune describe -- --debug work'
+  workspace
+
+  $ ./test 'dune describe --doesnotexist '
+  
+
+It only completes the positional argument at point:
+
+  $ ./test 'dune complete test several-pos '
+  a1
+  a2
+
+  $ ./test 'dune complete test several-pos a1 '
+  b1
+  b2
+
+List completion:
+
+  $ ./test 'dune complete test list '
+  aa
+  bb
+
+  $ ./test 'dune complete test list a'
+  aa
+
+  $ ./test 'dune complete test list aa,'
+  aa,aa
+  aa,bb
+
+  $ ./test 'dune complete test list aa,b'
+  aa,bb
+
+  $ ./test 'dune complete test list aa,bb,'
+  aa,bb,aa
+  aa,bb,bb

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -324,6 +324,14 @@ Completion of targets:
   > 
   > (rule
   >  (write-file target contents))
+  > 
+  > (subdir src
+  >  (rule
+  >   (write-file target contents)))
+  > 
+  > (subdir src/sub
+  >  (rule
+  >   (write-file target contents)))
   > EOF
 
   $ touch e.ml
@@ -333,3 +341,35 @@ Completion of targets:
 
   $ ./test 'dune build tar'
   target
+
+  $ ./test 'dune build src/tar'
+  src/target
+
+  $ ./test 'dune build /'
+  
+
+  $ ./test 'dune build ..'
+  
+  $ ./test 'dune build @'
+  @all
+  @default
+  @fmt
+  @runtest
+  @src/
+
+  $ ./test 'dune build @src/'
+  @src/all
+  @src/default
+  @src/fmt
+  @src/runtest
+  @src/sub/
+
+  $ ./test 'dune build @src/a'
+  @src/all
+
+  $ ./test 'dune build @@'
+  @@all
+  @@default
+  @@fmt
+  @@runtest
+  @@src/

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -359,6 +359,7 @@ Completion of targets:
   @all
   @default
   @fmt
+  @install
   @runtest
   @src/
 
@@ -366,6 +367,7 @@ Completion of targets:
   @src/all
   @src/default
   @src/fmt
+  @src/install
   @src/runtest
   @src/sub/
 
@@ -376,5 +378,6 @@ Completion of targets:
   @@all
   @@default
   @@fmt
+  @@install
   @@runtest
   @@src/

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -1,4 +1,4 @@
-  $ dune complete script > complete.sh
+  $ dune complete setup > complete.sh
 
 `test` calls `_dune` defined in `complete.sh`. Usually, bash itself would fill
 `COMP_*` but we have to do that by hand.

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -256,6 +256,12 @@ expect to see the list of commands that start with 'bui' (ie, just "build")
   --debug-load-dir
   --debug-store-digest-preimage
 
+  $ ./test 'dune build --sandbox='
+  --sandbox=copy
+  --sandbox=hardlink
+  --sandbox=none
+  --sandbox=symlink
+
   $ ./test 'dune build --promote-install-files '
   false
   true

--- a/test/blackbox-tests/test-cases/completion.t
+++ b/test/blackbox-tests/test-cases/completion.t
@@ -78,7 +78,8 @@ expect to see the list of commands that start with 'bui' (ie, just "build")
   $ ./test 'dune ocaml bad '
   
   $ ./test 'dune build '
-  
+  complete.sh
+  test
 
   $ ./test 'dune build --debug'
   --debug-artifact-substitution
@@ -306,3 +307,29 @@ List completion:
   $ ./test 'dune complete test list aa,bb,'
   aa,bb,aa
   aa,bb,bb
+
+Completion of targets:
+
+  $ dune complete target
+  complete.sh
+  test
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat > dune << EOF
+  > (executable
+  >  (name e))
+  > 
+  > (rule
+  >  (write-file target contents))
+  > EOF
+
+  $ touch e.ml
+
+  $ ./test 'dune build e.e'
+  e.exe
+
+  $ ./test 'dune build tar'
+  target

--- a/vendor/cmdliner/src/cmdliner.mli
+++ b/vendor/cmdliner/src/cmdliner.mli
@@ -773,6 +773,8 @@ module Cmd : sig
       specification of the command line: we can't tell apart a
       positional argument from the value of an unknown optional
       argument.  *)
+
+  val inspect : 'a t -> 'a Cmdliner_cmd.t
 end
 
 (** Terms for command line arguments.
@@ -800,9 +802,11 @@ module Arg : sig
   type 'a printer = Format.formatter -> 'a -> unit
   (** The type for converted argument printers. *)
 
+  type complete = string option -> string list
+
   [@@@alert "-deprecated"] (* Need to be able to mention them ! *)
 
-  type 'a conv = 'a parser * 'a printer
+  type 'a conv
   (** The type for argument converters.
 
       {b Warning.} Do not use directly, use {!val-conv} or {!val-conv'}.
@@ -811,6 +815,7 @@ module Arg : sig
   [@@@alert "+deprecated"] (* Need to be able to mention them ! *)
 
   val conv :
+    ?complete:complete ->
     ?docv:string -> (string -> ('a, [`Msg of string]) result) * 'a printer ->
     'a conv
   (** [conv ~docv (parse, print)] is an argument converter
@@ -820,6 +825,7 @@ module Arg : sig
       ["VALUE"]. *)
 
   val conv' :
+    ?complete:complete ->
     ?docv:string -> (string -> ('a, string) result) * 'a printer ->
     'a conv
   (** [conv'] is like {!val-conv} but the [Error] case has an unlabelled

--- a/vendor/cmdliner/src/cmdliner_arg.mli
+++ b/vendor/cmdliner/src/cmdliner_arg.mli
@@ -7,14 +7,17 @@
 
 type 'a parser = string -> [ `Ok of 'a | `Error of string ]
 type 'a printer = Format.formatter -> 'a -> unit
-type 'a conv = 'a parser * 'a printer
+type complete = string option -> string list
+type 'a conv = 'a parser * 'a printer * complete option
 type 'a converter = 'a conv
 
 val conv :
+  ?complete:complete ->
   ?docv:string -> (string -> ('a, [`Msg of string]) result) * 'a printer ->
   'a conv
 
 val conv' :
+  ?complete:complete ->
   ?docv:string -> (string -> ('a, string) result) * 'a printer -> 'a conv
 
 val pconv : ?docv:string -> 'a parser * 'a printer -> 'a conv

--- a/vendor/cmdliner/src/cmdliner_base.mli
+++ b/vendor/cmdliner/src/cmdliner_base.mli
@@ -32,7 +32,8 @@ val err_multi_def :
 
 type 'a parser = string -> [ `Ok of 'a | `Error of string ]
 type 'a printer = Format.formatter -> 'a -> unit
-type 'a conv = 'a parser * 'a printer
+type complete = string option -> string list
+type 'a conv = 'a parser * 'a printer * complete option
 
 val some : ?none:string -> 'a conv -> 'a option conv
 val some' : ?none:'a -> 'a conv -> 'a option conv

--- a/vendor/cmdliner/src/cmdliner_cline.mli
+++ b/vendor/cmdliner/src/cmdliner_cline.mli
@@ -19,6 +19,12 @@ val actual_args : t -> Cmdliner_info.Arg.t -> string list
 val is_opt : string -> bool
 val deprecated_msgs : t -> string list
 
+type completion =
+  | Arg_value of { arg : Cmdliner_info.Arg.t; optional : bool; index : int }
+  | Flag_or_pos_arg of { index : int; pos_only : bool }
+
+val complete : t -> string list -> completion
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 The cmdliner programmers
 

--- a/vendor/cmdliner/src/cmdliner_cmd.ml
+++ b/vendor/cmdliner/src/cmdliner_cmd.ml
@@ -29,6 +29,8 @@ let group ?default i cmds =
 
 let name c = Cmdliner_info.Cmd.name (get_info c)
 
+let inspect c = c
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2022 The cmdliner programmers
 

--- a/vendor/cmdliner/src/cmdliner_cmd.mli
+++ b/vendor/cmdliner/src/cmdliner_cmd.mli
@@ -22,6 +22,7 @@ val v : info -> 'a Cmdliner_term.t -> 'a t
 val group : ?default:'a Cmdliner_term.t -> info -> 'a t list -> 'a t
 val name : 'a t -> string
 val get_info : 'a t -> info
+val inspect : 'a t -> 'a t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2022 The cmdliner programmers

--- a/vendor/cmdliner/src/cmdliner_info.ml
+++ b/vendor/cmdliner/src/cmdliner_info.ml
@@ -90,6 +90,7 @@ module Arg = struct
       docv : string; (* variable name for the argument in help. *)
       docs : string; (* title of help section where listed. *)
       pos : pos_kind; (* positional arg kind. *)
+      complete: string option -> string list;
       opt_kind : opt_kind; (* optional arg kind. *)
       opt_names : string list; (* names (for opt args). *)
       opt_all : bool; (* repeatable (for opt args). *)
@@ -109,11 +110,14 @@ module Arg = struct
         | [] -> Cmdliner_manpage.s_arguments
         | _ -> Cmdliner_manpage.s_options
     in
+    let complete _ = [] in
     { id = Cmdliner_base.uid (); deprecated; absent = Doc absent;
       env; doc; docv; docs; pos = dumb_pos; opt_kind = Flag; opt_names;
+      complete;
       opt_all = false;
     opt_alias = fun _ _ -> Ok [] }
 
+  let complete a s = a.complete s
   let id a = a.id
   let deprecated a = a.deprecated
   let absent a = a.absent
@@ -140,6 +144,8 @@ module Arg = struct
   let make_opt ~absent ~kind:opt_kind a = { a with absent; opt_kind }
   let make_opt_all ~absent ~kind:opt_kind a =
     { a with absent; opt_kind; opt_all = true  }
+
+  let add_complete ~complete a = { a with complete }
 
   let make_pos ~pos a = { a with pos }
   let make_pos_abs ~absent ~pos a = { a with absent; pos }

--- a/vendor/cmdliner/src/cmdliner_info.mli
+++ b/vendor/cmdliner/src/cmdliner_info.mli
@@ -67,6 +67,8 @@ module Arg : sig
     ?doc:string -> ?env:Env.info -> string list -> t
 
   val id : t -> int
+  val complete : t -> string option -> string list
+  val add_complete : complete:(string option -> string list) -> t -> t
   val deprecated : t -> string option
   val absent : t -> absence
   val env : t -> Env.info option


### PR DESCRIPTION
This provides a shell completion mechanism for dune. This relies on the bash completion API, which can be used with zsh as well.

The architecture is:

- `dune complete script` outputs a script to be sourced in the user's shell. It is comprised of a `_dune` function and the `complete -F _dune dune` command to register it. The `_dune` function can be used in cram tests to write natural-looking tests for this feature.
- this script calls `dune complete command` with the partial command-line. This internal command parses it to determine what the word being completed refers to: a command name, an argument name, or an argument value. The first two ones are part of the metadata `cmdliner` knows about; the last one is provided through a completion function that can be passed in one the `Arg` functions.
- the interface between `bash` and `dune complete command` is simple: it passes the command line and a position to complete at (this is necessary to encode the difference between `dune bui<tab>` and `dune build <tab>` for example), and reads an array from the output of the command.

The things I'm happy with:

- it is small!
- coverage is pretty good: command names, arguments (positional and optional, including optional arguments with optional names), and the `--` construct are supported. So, this is likely to improve the user experience already.
- it is easy to test through cram or unit tests (I chose the former).

Now, for the ugly bits...

- this effectively is a partial reimplementation of cmdliner inside `complete.ml`. If the exact parsing rules are different, it means that we can complete to something with different or wrong semantics.
- the vendored copy of cmdliner is patched to expose so that it is possible to use the private APIs. these two points need to be resolved before we can think about how to upstream this.
- some bits of the cmdliner API need to be modified to provide completion automatically. For example for things like `enum` it's easy to provide a completion function automatically.
- it is difficult to define the right API for the completion functions. `unit -> string list` is a first approximation but with some limitations. For example, getting a list of buildable targets needs to run under `Fiber`, but we can't pollute the API with it. Interestingly enough, algebraic effects seem like they would be an interesting solution for this.
- at the moment, we're not relying on the shell's completion helpers to complete things like filenames. To support this we would either need to implement that in OCaml, or extend the bash/dune interface so that the completion function could call `compgen -f` based on the dune output.
- as a way to tie the two previous points: if we wanted to complete `dune build dir/file<tab>`, it would be a lot more efficient to pass the prefix to the build system and let it compute just the targets that match this, rather than compute everything and filter it afterwards. So that prefix would need to appear in the completion API.
