### PR TITLE
feature(melange): alias field for `melange.emit`

### DIFF
--- a/src/dune_rules/melange_stanzas.ml
+++ b/src/dune_rules/melange_stanzas.ml
@@ -5,6 +5,7 @@ module Emit = struct
   type t =
     { loc : Loc.t
     ; target : string
+    ; alias : Alias.Name.t option
     ; module_system : Melange.Module_system.t
     ; entries : Ordered_set_lang.t
     ; libraries : Lib_dep.t list
@@ -67,6 +68,7 @@ module Emit = struct
                  ])
          in
          field "target" (plain_string (fun ~loc s -> of_string ~loc s))
+       and+ alias = field_o "alias" Alias.Name.decode
        and+ module_system =
          field "module_system"
            (enum [ ("es6", Melange.Module_system.Es6); ("commonjs", CommonJs) ])
@@ -90,6 +92,7 @@ module Emit = struct
        in
        { loc
        ; target
+       ; alias
        ; module_system
        ; entries
        ; libraries

--- a/src/dune_rules/melange_stanzas.mli
+++ b/src/dune_rules/melange_stanzas.mli
@@ -5,6 +5,7 @@ module Emit : sig
   type t =
     { loc : Loc.t
     ; target : string
+    ; alias : Alias.Name.t option
     ; module_system : Melange.Module_system.t
     ; entries : Ordered_set_lang.t
     ; libraries : Lib_dep.t list

--- a/test/blackbox-tests/test-cases/melange/aliases.t
+++ b/test/blackbox-tests/test-cases/melange/aliases.t
@@ -1,0 +1,22 @@
+Test (preprocess) field on melange.emit stanza
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.6)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (alias app)
+  >  (module_system commonjs))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_endline "hello"
+  > EOF
+
+  $ dune build @app
+  $ node _build/default/output/melange__Main.js
+  hello


### PR DESCRIPTION
Adds field `alias` to `melange.emit` so the stanza can be written as follows:

```
(melange.emit
 (target output)
 (alias app)
 (module_system commonjs))
```

The alias rule has only the `melange.emit` `entries` as deps, not the modules resulting from depending on other libraries.