### PR TITLE
fix: allow promoting with subdir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Allow promoting into source directories specified by `subdir` (#6404, fixes
+  #3502, @rgrinberg)
+
 - Make dune describe workspace return the correct root path
   (#6380, fixes #6379, @esope)
 

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -618,6 +618,7 @@ let copy_file ~conf ?chmod ?(delete_dst_if_it_is_a_directory = false) ~src ~dst
   Fiber.finalize
     (fun () ->
       let open Fiber.O in
+      Path.parent dst |> Option.iter ~f:Path.mkdir_p;
       let* has_subst =
         copy_file_non_atomic ~conf ?chmod ~src ~dst:temp_file ()
       in

--- a/test/blackbox-tests/test-cases/promote/non-existent-subdir.t
+++ b/test/blackbox-tests/test-cases/promote/non-existent-subdir.t
@@ -11,9 +11,5 @@ Taken from #3502
   >   (action (with-stdout-to y (echo "z")))))
   > EOF
   $ dune build x/y
-  Error: x/.#y.dune-temp: No such file or directory
-  -> required by _build/default/x/y
-  [1]
   $ cat x/y
-  cat: x/y: No such file or directory
-  [1]
+  z


### PR DESCRIPTION
If a subdir stanza defines a rule that promotes into a non-existent
source dir, it would fail. Now we just create the directory in the
source.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: e7b4b471-0c58-480a-a433-2f8aaa207153