### PR TITLE
fix: merlin and private_modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,10 @@ Unreleased
 - Allow `:standard` in the `(modules)` field of the `coq.pp` stanza (#6229,
   fixes #2414, @Alizter)
 
+- Fix merlin integration when private modules are used. Expose the private
+  directory to merlin which contains all cmt and cmti files. (#6405, fixes
+  #4892, @rgrinberg)
+
 3.5.0 (2022-10-19)
 ------------------
 

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -207,25 +207,20 @@ module Processed = struct
            extensions)
 end
 
-let obj_dir_of_lib kind modes obj_dir =
+let obj_dir_of_lib modes obj_dir =
   (match
-     let mode =
-       match modes with
-       | `Exe -> `Byte
-       | `Melange_emit -> `Melange
-       | `Lib modes ->
-         if
-           Lib_mode.Map.Set.equal modes
-             { ocaml = Ocaml.Mode.Dict.make_both false; melange = true }
-         then `Melange
-         else `Byte
-     in
-     (kind, mode)
+     match modes with
+     | `Exe -> `Byte
+     | `Melange_emit -> `Melange
+     | `Lib modes ->
+       if
+         Lib_mode.Map.Set.equal modes
+           { ocaml = Ocaml.Mode.Dict.make_both false; melange = true }
+       then `Melange
+       else `Byte
    with
-  | `Private, `Byte -> Obj_dir.byte_dir
-  | `Public, `Byte -> Obj_dir.public_cmi_ocaml_dir
-  | `Private, `Melange -> Obj_dir.melange_dir
-  | `Public, `Melange -> Obj_dir.public_cmi_melange_dir)
+  | `Byte -> Obj_dir.byte_dir
+  | `Melange -> Obj_dir.melange_dir)
     obj_dir
 
 module Unprocessed = struct
@@ -262,8 +257,7 @@ module Unprocessed = struct
       | Error () -> Lib.Set.empty
     in
     let objs_dirs =
-      Path.Set.singleton
-      @@ obj_dir_of_lib `Private modes (Obj_dir.of_local obj_dir)
+      Path.Set.singleton @@ obj_dir_of_lib modes (Obj_dir.of_local obj_dir)
     in
     let flags =
       Ocaml_flags.common
@@ -398,7 +392,7 @@ module Unprocessed = struct
                   ( Path.Set.union src_dirs more_src_dirs
                   , let public_cmi_dir =
                       let info = Lib.info lib in
-                      obj_dir_of_lib `Public
+                      obj_dir_of_lib
                         (`Lib (Lib_info.modes info))
                         (Lib_info.obj_dir info)
                     in

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -14,7 +14,7 @@ CRAM sanitization
    (B
     $TESTCASE_ROOT/_build/default/exe/.x.eobjs/byte)
    (B
-    $TESTCASE_ROOT/_build/default/lib/.foo.objs/public_cmi)
+    $TESTCASE_ROOT/_build/default/lib/.foo.objs/byte)
    (S lib/findlib)
    (S /OCAMLC_WHERE)
    (S


### PR DESCRIPTION
When private modules are enabled, only the public cmi directory was
passed to merlin. The end result is that all .cmt and .cmti files were
hidden causing a degraded experience. We fix this by providing the
private dir to merlin.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: dc5a051b-ca65-48cf-a63f-8a61128b2cf2