### PR TITLE
fix: print "Leaving Directory"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ Unreleased
   0.7. `(mode native)` has been deprecated in favour of detection from the
   configuration of Coq. (#6409, @Alizter)
 
+- Print "Leaving Directory" whenever "Entering Directory" is printed. (#6149,
+  fixes #138, @cpitclaudel, @rgrinberg)
+
 3.6.0 (2022-11-14)
 ------------------
 
@@ -3065,7 +3068,7 @@ Unreleased
 
 - Print `Entering directory '...'` when the workspace root is not the
   current directory. This allows Emacs and Vim to know where relative
-  filenames should be interpreted from. Fixes #138
+  filenames should be interpreted from. (fixes #138, @jeremiedimino)
 
 - Fix a bug related to `menhir` stanzas: `menhir` stanzas with a
   `merge_into` field that were in `jbuild` files in sub-directories

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -118,7 +118,7 @@ let normalize_path path =
 
 let print_entering_message c =
   let cwd = Path.to_absolute_filename Path.root in
-  if cwd <> Fpath.initial_cwd && not c.no_print_directory then
+  if cwd <> Fpath.initial_cwd && not c.no_print_directory then (
     (* Editors such as Emacs parse the output of the build system and interpret
        filenames in error messages relative to where the build system was
        started.
@@ -151,7 +151,10 @@ let print_entering_message c =
             in
             loop ".." (Filename.dirname s)))
     in
-    Console.print [ Pp.verbatim (sprintf "Entering directory '%s'" dir) ]
+    Console.print [ Pp.verbatim (sprintf "Entering directory '%s'" dir) ];
+    at_exit (fun () ->
+        flush stdout;
+        Console.print [ Pp.verbatim (sprintf "Leaving directory '%s'" dir) ]))
 
 let init ?log_file c =
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;

--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -335,9 +335,11 @@ Test compiling an external plugin
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH dune build --root=e
   Entering directory 'e'
+  Leaving directory 'e'
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH PATH=$(pwd)/_install/bin:$PATH dune exec  --root=e -- c
   Entering directory 'e'
+  Leaving directory 'e'
   run a
   a: $TESTCASE_ROOT/_install/share/a/data
   run c: a linked registered:.
@@ -354,6 +356,7 @@ Test compiling an external plugin
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH dune install --root=e --prefix $(pwd)/_install 2>&1 | sed -e "/^Installing/d"
   Entering directory 'e'
+  Leaving directory 'e'
 
   $ OCAMLPATH=_install/lib:$OCAMLPATH _install/bin/c
   run a
@@ -411,6 +414,7 @@ Test %{version:installed-pkg}
 
   $ OCAMLPATH=_install/lib:$OCAMLPATH dune build --root=f
   Entering directory 'f'
+  Leaving directory 'f'
   $ cat $(pwd)/f/_build/default/test.target
   a = 0.a
   e = 
@@ -423,6 +427,7 @@ Test %{version:installed-pkg}
                      ^^^^^^^^^^^^^^^^^
   Error: Library names are not allowed in this position. Only package names are
   allowed
+  Leaving directory 'f'
   [1]
 
   $ rm f/dune

--- a/otherlibs/site/test/run_2_9.t
+++ b/otherlibs/site/test/run_2_9.t
@@ -320,9 +320,11 @@ Test compiling an external plugin
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH dune build --root=e
   Entering directory 'e'
+  Leaving directory 'e'
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH PATH=$(pwd)/_install/bin:$PATH dune exec  --root=e -- c
   Entering directory 'e'
+  Leaving directory 'e'
   run a
   a: $TESTCASE_ROOT/_install/share/a/data
   run c: a linked registered:.
@@ -395,6 +397,7 @@ Test %{version:installed-pkg}
 
   $ OCAMLPATH=_install/lib:$OCAMLPATH dune build --root=f
   Entering directory 'f'
+  Leaving directory 'f'
   $ cat $(pwd)/f/_build/default/test.target
   a = 0.a
   e = 
@@ -407,6 +410,7 @@ Test %{version:installed-pkg}
                      ^^^^^^^^^^^^^^^^^
   Error: Library names are not allowed in this position. Only package names are
   allowed
+  Leaving directory 'f'
   [1]
 
   $ rm f/dune

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
@@ -31,8 +31,10 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
         coqdep dir/bar.v.d
         coqdep dir/foo.v.d
           coqc dir/foo.{glob,vo}
+  Leaving directory '..'
   -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic
   $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v)
   Entering directory '..'
+  Leaving directory '..'
   -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic
 

--- a/test/blackbox-tests/test-cases/depend-on/installed-packages.t
+++ b/test/blackbox-tests/test-cases/depend-on/installed-packages.t
@@ -17,12 +17,14 @@
 
   $ dune build --root a
   Entering directory 'a'
+  Leaving directory 'a'
 
   $ dune install --root a --prefix $(pwd)/prefix
   Entering directory 'a'
   Installing $TESTCASE_ROOT/prefix/lib/a/META
   Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
   Installing $TESTCASE_ROOT/prefix/share/a/CATME
+  Leaving directory 'a'
 
   $ cat >b/dune-project <<EOF
   > (lang dune 2.9)
@@ -36,9 +38,11 @@
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest
   Entering directory 'b'
   Miaou
+  Leaving directory 'b'
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest
   Entering directory 'b'
+  Leaving directory 'b'
 
   $ rm a/CATME
   $ cat >a/CATME <<EOF
@@ -47,6 +51,7 @@
 
   $ dune build --root a
   Entering directory 'a'
+  Leaving directory 'a'
 
   $ dune install --root a --prefix $(pwd)/prefix
   Entering directory 'a'
@@ -56,13 +61,16 @@
   Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
   Deleting $TESTCASE_ROOT/prefix/share/a/CATME
   Installing $TESTCASE_ROOT/prefix/share/a/CATME
+  Leaving directory 'a'
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest
   Entering directory 'b'
   Ouaf
+  Leaving directory 'b'
 
   $ OCAMLPATH=$(pwd)/prefix/lib/:$OCAMLPATH dune build --root b @runtest
   Entering directory 'b'
+  Leaving directory 'b'
 
   $ cat >b/dune-project <<EOF
   > (lang dune 2.8)
@@ -75,4 +83,5 @@
   1 | (rule (alias runtest) (deps (package a)) (action (run cat $TESTCASE_ROOT/prefix/share/a/CATME)))
                                            ^
   Error: Dependency on an installed package requires at least (lang dune 2.9)
+  Leaving directory 'b'
   [1]

--- a/test/blackbox-tests/test-cases/dune-init.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-init.t/run.t
@@ -346,6 +346,7 @@ We can build the project:
 
   $ dune build --root test_exec_proj
   Entering directory 'test_exec_proj'
+  Leaving directory 'test_exec_proj'
 
 And the opam file will be generated as expected
 
@@ -386,12 +387,14 @@ We can build and run the resulting executable:
 
   $ dune exec --root test_exec_proj ./bin/main.exe
   Entering directory 'test_exec_proj'
+  Leaving directory 'test_exec_proj'
   Hello, World!
 
 We can build and run the project's tests:
 
   $ dune exec --root test_exec_proj ./test/test_exec_proj.exe
   Entering directory 'test_exec_proj'
+  Leaving directory 'test_exec_proj'
 
 Initializing library projects
 ================================
@@ -448,6 +451,7 @@ We can build and install the project:
 
   $ dune build --root test_lib_proj @install
   Entering directory 'test_lib_proj'
+  Leaving directory 'test_lib_proj'
 
 And the opam file will be generated as expected
 
@@ -492,6 +496,7 @@ And we we can run the tests:
       ocamlopt test/.test_lib_proj.eobjs/native/dune__exe__Test_lib_proj.{cmx,o}
       ocamlopt test/test_lib_proj.exe
   test_lib_proj alias test/runtest
+  Leaving directory 'test_lib_proj'
 
 Initializing projects using Esy
 ===============================

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -3,6 +3,7 @@
 
   $ dune build --root=a
   Entering directory 'a'
+  Leaving directory 'a'
   $ dune_cmd cat a/_build/install/default/lib/a/dune-package | sed "s/(lang dune .*)/(lang dune <version>)/" | dune_cmd sanitize
   (lang dune <version>)
   (name a)
@@ -106,6 +107,7 @@
 Build with "--store-orig-source-dir" profile
   $ dune build --root=a --store-orig-source-dir
   Entering directory 'a'
+  Leaving directory 'a'
   $ dune_cmd cat a/_build/install/default/lib/a/dune-package | grep -A 1 '(orig_src_dir'
    (orig_src_dir
     $TESTCASE_ROOT/a)
@@ -119,6 +121,7 @@ Build with "--store-orig-source-dir" profile
 Build with "DUNE_STORE_ORIG_SOURCE_DIR=true" profile
   $ DUNE_STORE_ORIG_SOURCE_DIR=true dune build --root=a
   Entering directory 'a'
+  Leaving directory 'a'
   $ dune_cmd cat a/_build/install/default/lib/a/dune-package | grep -A 1 '(orig_src_dir'
    (orig_src_dir
     $TESTCASE_ROOT/a)
@@ -133,6 +136,7 @@ Install the package directly
 
   $ dune install "--prefix=$PWD/prefix" --root=a 2>&1 | grep -v "Installing"
   Entering directory 'a'
+  Leaving directory 'a'
 
   $ dune_cmd cat prefix/lib/a/dune-package | grep -e 'lib/a' -e 'share/a'
     $TESTCASE_ROOT/prefix/lib/a)

--- a/test/blackbox-tests/test-cases/dune-ppx-driver-system.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-ppx-driver-system.t/run.t
@@ -15,6 +15,7 @@ No ppx driver found
   5 |  (preprocess (pps)))
                    ^^^^^
   Error: You must specify at least one ppx rewriter.
+  Leaving directory 'no-driver'
   [1]
 
 Too many drivers
@@ -26,6 +27,7 @@ Too many drivers
                    ^^^^^^^^^^^^^^^
   Error: Too many incompatible ppx drivers were found: foo.driver1 and
   foo.driver2.
+  Leaving directory 'driver-tests'
   [1]
 
 Not compatible with Dune
@@ -38,6 +40,7 @@ Not compatible with Dune
   Error: No ppx driver were found. It seems that ppx_other is not compatible
   with Dune. Examples of ppx rewriters that are compatible with Dune are ones
   using ocaml-migrate-parsetree, ppxlib or ppx_driver.
+  Leaving directory 'driver-tests'
   [1]
 
 Incompatible Cookies
@@ -49,6 +52,7 @@ Incompatible Cookies
                     ^^^^^^^^^^^^^^^
   Error: foo.ppx3 and foo.ppx4 have inconsistent requests for cookie "germany";
   foo.ppx3 requests "spritzgeback" and foo.ppx4 requests "lebkuchen"
+  Leaving directory 'driver-tests'
   [1]
 
 Same, but with error pointing to .ppx
@@ -56,11 +60,13 @@ Same, but with error pointing to .ppx
   $ dune build --root driver-tests .ppx/foo.ppx1+foo.ppx2/ppx.exe
   Entering directory 'driver-tests'
   Error: invalid ppx key for _build/default/.ppx/foo.ppx1+foo.ppx2/ppx.exe
+  Leaving directory 'driver-tests'
   [1]
 
   $ dune build --root driver-tests .ppx/foo.ppx-other/ppx.exe
   Entering directory 'driver-tests'
   Error: invalid ppx key for _build/default/.ppx/foo.ppx-other/ppx.exe
+  Leaving directory 'driver-tests'
   [1]
 
 Test the argument syntax
@@ -90,6 +96,7 @@ Test the argument syntax
   95 |     -foo bar %{env:ENGLAND=undefined})))
   Error: Rule failed to generate the following targets:
   - test_ppx_args.pp.ml
+  Leaving directory 'driver-tests'
   [1]
 
 Test the argument syntax with list expansion allowed (dune > 3.2)
@@ -123,6 +130,7 @@ Test the argument syntax with list expansion allowed (dune > 3.2)
   24 |     -foo bar %{env:ENGLAND=undefined} %{read-lines:ppx-args})))
   Error: Rule failed to generate the following targets:
   - test_ppx_args.pp.ml
+  Leaving directory 'driver-tests-list-args'
   [1]
 
 Test that going through the -ppx option of the compiler works
@@ -131,11 +139,13 @@ Test that going through the -ppx option of the compiler works
   Entering directory 'driver-tests'
   tool name: ocamlc
   args:--as-ppx -arg1 -arg2 -arg3=Oreo -foo bar Snickerdoodle --cookie france="Petit Beurre" --cookie italy="Biscotti" --cookie library-name="test_ppx_staged"
+  Leaving directory 'driver-tests'
 
 Test using installed drivers
 
   $ dune build --root driver @install
   Entering directory 'driver'
+  Leaving directory 'driver'
   $ OCAMLPATH=driver/_build/install/default/lib dune build --root use-external-driver driveruser.cma
   Entering directory 'use-external-driver'
   .ppx/35d69311d5da258d073875db2b34f33b/ppx.exe
@@ -155,6 +165,7 @@ Test using installed drivers
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Rule failed to generate the following targets:
   - driveruser.pp.ml
+  Leaving directory 'use-external-driver'
   [1]
 
   $ OCAMLPATH=driver/_build/install/default/lib dune build --root replaces driveruser.cma
@@ -177,10 +188,12 @@ Test using installed drivers
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Rule failed to generate the following targets:
   - driveruser.pp.ml
+  Leaving directory 'replaces'
   [1]
 
   $ OCAMLPATH=driver/_build/install/default/lib dune build --root driver-replaces @install
   Entering directory 'driver-replaces'
+  Leaving directory 'driver-replaces'
   $ OCAMLPATH=driver/_build/install/default/lib:driver-replaces/_build/install/default/lib dune build --root replaces-external driveruser.cma
   Entering directory 'replaces-external'
   replacesdriver
@@ -201,4 +214,5 @@ Test using installed drivers
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Rule failed to generate the following targets:
   - driveruser.pp.ml
+  Leaving directory 'replaces-external'
   [1]

--- a/test/blackbox-tests/test-cases/dup-fields.t/run.t
+++ b/test/blackbox-tests/test-cases/dup-fields.t/run.t
@@ -6,4 +6,5 @@ Duplicating a field in a dune file is an error:
   4 |  (action (echo bar)))
        ^^^^^^^^^^^^^^^^^^^
   Error: Field "action" is present too many times
+  Leaving directory 'dune'
   [1]

--- a/test/blackbox-tests/test-cases/exec-cmd.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-cmd.t/run.t
@@ -23,6 +23,7 @@
 
   $ (cd test; dune exec --root .. -- dunetestbar)
   Entering directory '..'
+  Leaving directory '..'
   Bar
 
   $ ls -a test/_build

--- a/test/blackbox-tests/test-cases/exes-with-c.t/run.t
+++ b/test/blackbox-tests/test-cases/exes-with-c.t/run.t
@@ -21,4 +21,5 @@
   4 |  (foreign_stubs (language c) (names stubs)))
   Error: Pure bytecode executables cannot contain foreign stubs.
   Hint: If you only need to build a native executable use "(modes exe)".
+  Leaving directory 'err'
   [1]

--- a/test/blackbox-tests/test-cases/findlib-error.t/run.t
+++ b/test/blackbox-tests/test-cases/findlib-error.t/run.t
@@ -7,4 +7,5 @@ We are dropping support for findlib in dune
                              ^^^^^^^^^^^^^^
   Error: %{findlib:..} was renamed to '%{lib:..}' in the 1.0 version of the
   dune language
+  Leaving directory 'in-dune'
   [1]

--- a/test/blackbox-tests/test-cases/foreign-library.t
+++ b/test/blackbox-tests/test-cases/foreign-library.t
@@ -743,6 +743,7 @@ Testsuite for the (foreign_library ...) stanza.
 
   $ export OCAMLPATH=$PWD/external/install/lib; ./sdune exec ./main.exe --root=some/dir
   Entering directory 'some/dir'
+  Leaving directory 'some/dir'
   Answer = 42
 
 ----------------------------------------------------------------------------------
@@ -791,6 +792,7 @@ Testsuite for the (foreign_library ...) stanza.
   2 |  (archive_name some/path/id)
                      ^^^^^^^^^^^^
   Error: Path separators are not allowed in archive names.
+  Leaving directory 'github2914/dir'
   [1]
 
 ----------------------------------------------------------------------------------
@@ -902,5 +904,6 @@ Testsuite for the (foreign_library ...) stanza.
   > EOF
   $ dune build --root stubs_in_libs
   Entering directory 'stubs_in_libs'
+  Leaving directory 'stubs_in_libs'
   $ stubs_in_libs/_build/default/main.exe
   12

--- a/test/blackbox-tests/test-cases/github1549.t/run.t
+++ b/test/blackbox-tests/test-cases/github1549.t/run.t
@@ -2,6 +2,7 @@ Reproduction case for #1549: too many parentheses in installed .dune files
 
   $ dune build @install --root backend
   Entering directory 'backend'
+  Leaving directory 'backend'
 
   $ dune_cmd cat backend/_build/install/default/lib/dune_inline_tests/dune-package | sed "s/(lang dune .*)/(lang dune <version>)/" | dune_cmd sanitize
   (lang dune <version>)
@@ -45,3 +46,4 @@ Reproduction case for #1549: too many parentheses in installed .dune files
 
   $ env OCAMLPATH=backend/_build/install/default/lib dune runtest --root example
   Entering directory 'example'
+  Leaving directory 'example'

--- a/test/blackbox-tests/test-cases/github1616.t/run.t
+++ b/test/blackbox-tests/test-cases/github1616.t/run.t
@@ -3,3 +3,4 @@ Regression test for #1616
   $ env PATH="$PWD/bin2:$PWD/bin1:$PATH" dune build --root root
   Entering directory 'root'
   Hello, World!
+  Leaving directory 'root'

--- a/test/blackbox-tests/test-cases/inline_tests/dune-file.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/dune-file.t/run.t
@@ -28,3 +28,4 @@ package:
   $ export OCAMLPATH=$PWD/_install/lib; dune runtest --root dune-file-user
   Entering directory 'dune-file-user'
   414243
+  Leaving directory 'dune-file-user'

--- a/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/inline_tests/executable-flags.t/run.t
@@ -7,6 +7,7 @@ to be successful.
   $ dune runtest valid_options --root ./test-project
   Entering directory 'test-project'
   backend_foo
+  Leaving directory 'test-project'
 
 Lastly, we pass an invalid option to flags field expecting compilation
 to fail.

--- a/test/blackbox-tests/test-cases/instrumentation.t/run.t
+++ b/test/blackbox-tests/test-cases/instrumentation.t/run.t
@@ -187,5 +187,6 @@ Next, we check the backend can be used when it is installed.
   > EOF
   $ OCAMLPATH=$PWD/_install/lib:$OCAMLPATH dune build --root installed
   Entering directory 'installed'
+  Leaving directory 'installed'
   $ installed/_build/default/main.exe
   Hello from Main!

--- a/test/blackbox-tests/test-cases/lib.t
+++ b/test/blackbox-tests/test-cases/lib.t
@@ -177,6 +177,7 @@ Testsuite for the %{lib...} and %{lib-private...} variable.
   Error: The variable "lib-private" can only refer to libraries within the same
   project. The current project's name is "test-lib", but the reference is to an
   external library.
+  Leaving directory 'src'
   [1]
 
 ----------------------------------------------------------------------------------

--- a/test/blackbox-tests/test-cases/libexec.t
+++ b/test/blackbox-tests/test-cases/libexec.t
@@ -202,6 +202,7 @@ Testsuite for the %{libexec...} and %{libexec-private...} variable.
   Error: The variable "libexec-private" can only refer to libraries within the
   same project. The current project's name is "test-lib", but the reference is
   to an external library.
+  Leaving directory 'src'
   [1]
 
   $ export OCAMLPATH=$PWD/external/install/lib; ./sdune build @find-a-from-target --root=src --workspace=./dune-workspace
@@ -212,6 +213,7 @@ Testsuite for the %{libexec...} and %{libexec-private...} variable.
   Error: The variable "libexec-private" can only refer to libraries within the
   same project. The current project's name is "test-lib", but the reference is
   to an external library.
+  Leaving directory 'src'
   [1]
 
 ----------------------------------------------------------------------------------

--- a/test/blackbox-tests/test-cases/link-includes.t
+++ b/test/blackbox-tests/test-cases/link-includes.t
@@ -20,6 +20,7 @@ Test linktime includes for an external library with C stubs
   > EOF
   $ dune build --root lib1 @install
   Entering directory 'lib1'
+  Leaving directory 'lib1'
 
 First we create an external library and implementation
   $ mkdir exe
@@ -34,5 +35,6 @@ First we create an external library and implementation
 Then we make sure that it works fine.
   $ env OCAMLPATH=lib1/_build/install/default/lib: dune exec --root exe ./bar.exe
   Entering directory 'exe'
+  Leaving directory 'exe'
   lib1: 42
 

--- a/test/blackbox-tests/test-cases/meta-template-version-bug.t
+++ b/test/blackbox-tests/test-cases/meta-template-version-bug.t
@@ -47,4 +47,5 @@ custom version:
 
   $ OCAMLPATH=$PWD/_install/lib dune exec --root external ./main.exe
   Entering directory 'external'
+  Leaving directory 'external'
   foobarlib

--- a/test/blackbox-tests/test-cases/old-dune-subsystem.t/run.t
+++ b/test/blackbox-tests/test-cases/old-dune-subsystem.t/run.t
@@ -13,4 +13,5 @@ we understand the old files.
   3 |   (inline_tests (backend dune_inline_tests)))
                                ^^^^^^^^^^^^^^^^^
   Error: dune_inline_tests is not an inline tests backend
+  Leaving directory 'example'
   [1]

--- a/test/blackbox-tests/test-cases/private-package-lib/main.t
+++ b/test/blackbox-tests/test-cases/private-package-lib/main.t
@@ -157,6 +157,7 @@ Now we make sure such libraries are transitively usable when installed:
   $ export OCAMLPATH=$PWD/_build/install/default/lib
   $ dune exec --root use -- ./run.exe
   Entering directory 'use'
+  Leaving directory 'use'
   Using library foo: from library foo secret string
 
 But we cannot use such libraries directly:
@@ -170,4 +171,5 @@ But we cannot use such libraries directly:
   1 | print_endline ("direct access attempt: " ^ Secret.secret)
                                                  ^^^^^^^^^^^^^
   Error: Unbound module Secret
+  Leaving directory 'use'
   [1]

--- a/test/blackbox-tests/test-cases/reason.t/run.t
+++ b/test/blackbox-tests/test-cases/reason.t/run.t
@@ -24,3 +24,4 @@ We make sure to install reason source files:
 virtual libraries in reason
   $ PATH="_build/install/default/bin:$PATH" dune build --root vlib-impl @all
   Entering directory 'vlib-impl'
+  Leaving directory 'vlib-impl'

--- a/test/blackbox-tests/test-cases/rule/dependency-external.t
+++ b/test/blackbox-tests/test-cases/rule/dependency-external.t
@@ -22,9 +22,11 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
   $ dune build --root=a/b @test
   Entering directory 'a/b'
+  Leaving directory 'a/b'
 
   $ cat >external.txt <<EOF
   > txt2
@@ -33,6 +35,7 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt2
+  Leaving directory 'a/b'
 
 ## Test copy files absolute
   $ cat >a/b/dune <<EOF
@@ -49,10 +52,12 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 # Check that nothing is done when nothing change
   $ dune build --root=a/b @test
   Entering directory 'a/b'
+  Leaving directory 'a/b'
 
   $ cat >external.txt <<EOF
   > txt2
@@ -61,6 +66,7 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt2
+  Leaving directory 'a/b'
 
 ### 1 level below
 
@@ -78,10 +84,12 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 # Check that nothing is done when nothing change
   $ dune build --root=a/b @test
   Entering directory 'a/b'
+  Leaving directory 'a/b'
 
   $ cat >a/external.txt <<EOF
   > txt2
@@ -90,6 +98,7 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt2
+  Leaving directory 'a/b'
 
 ## Test copy files 1 level below
   $ cat >a/b/dune <<EOF
@@ -106,10 +115,12 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 # Check that nothing is done when nothing change
   $ dune build --root=a/b @test
   Entering directory 'a/b'
+  Leaving directory 'a/b'
 
   $ cat >a/external.txt <<EOF
   > txt2
@@ -118,6 +129,7 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt2
+  Leaving directory 'a/b'
 
 ### 2 level below
 
@@ -137,10 +149,12 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 # Check that nothing is done when nothing change
   $ dune build --root=a/b @test
   Entering directory 'a/b'
+  Leaving directory 'a/b'
 
   $ cat >external.txt <<EOF
   > txt2
@@ -149,6 +163,7 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt2
+  Leaving directory 'a/b'
 
 ## Test copy files 2 level below
   $ cat >a/b/dune <<EOF
@@ -165,10 +180,12 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt1
+  Leaving directory 'a/b'
 
 # Check that nothing is done when nothing change
   $ dune build --root=a/b @test
   Entering directory 'a/b'
+  Leaving directory 'a/b'
 
   $ cat >external.txt <<EOF
   > txt2
@@ -177,6 +194,7 @@ rules with dependencies outside the build dir are allowed
   $ dune build --root=a/b @test
   Entering directory 'a/b'
   txt2
+  Leaving directory 'a/b'
 
 ## Test dune exec absolute
   $ cat >a/script.sh <<EOF
@@ -188,11 +206,13 @@ rules with dependencies outside the build dir are allowed
 
   $ dune exec --root=a/b -- $(pwd)/a/script.sh
   Entering directory 'a/b'
+  Leaving directory 'a/b'
   txt1
 
 ## Test dune exec 1 level below
   $ dune exec --root=a/b -- ../script.sh
   Entering directory 'a/b'
+  Leaving directory 'a/b'
   txt1
 
 ## Test dune exec 2 level below
@@ -200,10 +220,12 @@ rules with dependencies outside the build dir are allowed
 
   $ dune exec --root=a/b -- ../../script.sh
   Entering directory 'a/b'
+  Leaving directory 'a/b'
   txt1
 
 # Regression test for #5572
   $ dune exec --root=a/b -- ../
   Entering directory 'a/b'
   Error: Program "../" not found!
+  Leaving directory 'a/b'
   [1]

--- a/test/blackbox-tests/test-cases/target-dir-alias.t/run.t
+++ b/test/blackbox-tests/test-cases/target-dir-alias.t/run.t
@@ -2,4 +2,4 @@ Building a directory results in the default target being built
 
   $ dune build foo --root dir-target-works
   Entering directory 'dir-target-works'
-  default target works
+  default target worksLeaving directory 'dir-target-works'

--- a/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
@@ -64,6 +64,7 @@ The next test tries to build a module that does not exist.
   3 |  (deps %{cmo:foo}))
              ^^^^^^^^^^
   Error: Module Foo does not exist.
+  Leaving directory 'ex1'
   [1]
 
 Command line version; note that the error message is slightly different.
@@ -105,6 +106,7 @@ This test tries to build a non-existent .cma.
   3 |  (deps %{cma:bar}))
              ^^^^^^^^^^
   Error: Library bar does not exist.
+  Leaving directory 'ex2'
   [1]
 
 Command line version.
@@ -244,6 +246,7 @@ This test is no longer failing. It should fail because
   3 |  (deps %{cmo:x2})
              ^^^^^^^^^
   Error: Module X2 does not exist.
+  Leaving directory 'deps-fail'
   [1]
 
 The above restriction also applies to other stanzas. Any stanzas that introduces
@@ -258,4 +261,5 @@ new files for Dir_contents, for example copy_files:
   1 | (copy_files "%{cmo:x2}")
                    ^^^^^^^^^
   Error: %{cmo:..} isn't allowed in this position.
+  Leaving directory 'deps-fail'
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/impl-not-virtual-external.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/impl-not-virtual-external.t
@@ -9,6 +9,7 @@ an appropriate error message.
   > EOF
   $ dune build --root external @install
   Entering directory 'external'
+  Leaving directory 'external'
   $ mkdir test
   $ echo "(lang dune 2.5)" > test/dune-project
   $ cat >test/dune <<EOF
@@ -20,4 +21,5 @@ an appropriate error message.
   1 | (library (implements foodummy) (name bar))
                            ^^^^^^^^
   Error: Library "foodummy" is not virtual. It cannot be implemented by "bar".
+  Leaving directory 'test'
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/implements-external.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/implements-external.t/run.t
@@ -3,28 +3,33 @@ Test that we can implement external libraries.
 First we create an external library
   $ dune build --root vlib @install
   Entering directory 'vlib'
+  Leaving directory 'vlib'
 
 Then we make sure that we can implement it
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build @default @install --root impl
   Entering directory 'impl'
   bar from vlib
   Foo.run implemented
+  Leaving directory 'impl'
 
 Make sure that we can also implement native only variants
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl-native-only --debug-dependency-path
   Entering directory 'impl-native-only'
   implement virtual module
+  Leaving directory 'impl-native-only'
 
 We can implement external variants with mli only modules
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl-intf-only --debug-dependency-path
   Entering directory 'impl-intf-only'
   implemented mli only
   magic number: 42
+  Leaving directory 'impl-intf-only'
 
 Implement external virtual libraries with private modules
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl-private-module --debug-dependency-path
   Entering directory 'impl-private-module'
   Name: implement virtual module. Magic number: 42
+  Leaving directory 'impl-private-module'
 
 Now we test the following use case:
 - A virtual library and its implementation are installed

--- a/test/blackbox-tests/test-cases/virtual-libraries/unwrapped.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/unwrapped.t/run.t
@@ -6,7 +6,9 @@ Unwrapped virtual library
 Unwrapped virtual library
   $ dune build @install --root vlib
   Entering directory 'vlib'
+  Leaving directory 'vlib'
   $ env OCAMLPATH=vlib/_build/install/default/lib dune build --root impl --debug-dependency-path
   Entering directory 'impl'
   Running from vlib_more
   running implementation
+  Leaving directory 'impl'

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/external.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/external.t/run.t
@@ -3,8 +3,10 @@ Test default implementation for an external library
 First we create an external library and implementation
   $ dune build --root lib @install
   Entering directory 'lib'
+  Leaving directory 'lib'
 
 Then we make sure that it works fine.
   $ env OCAMLPATH=lib/_build/install/default/lib dune build --root exe --debug-dependency-path
   Entering directory 'exe'
   hey
+  Leaving directory 'exe'

--- a/test/blackbox-tests/test-cases/workspaces/workspace-paths.t/run.t
+++ b/test/blackbox-tests/test-cases/workspaces/workspace-paths.t/run.t
@@ -23,4 +23,5 @@ is prohibited.
   4 |    (paths (FOO a) (FOO b))))
                          ^^^
   Error: the variable "FOO" can appear at most once in this stanza.
+  Leaving directory 'sub'
   [1]

--- a/test/blackbox-tests/test-cases/write-permissions.t
+++ b/test/blackbox-tests/test-cases/write-permissions.t
@@ -15,6 +15,7 @@ Check that dune <= 2.3 leaves write permissions alone.
   > EOF
   $ dune build --root 2.3 target | head -c1
   Entering directory '2.3'
+  Leaving directory '2.3'
   $ dune_cmd stat permissions 2.3/_build/default/target | head -c1
   6
 
@@ -47,6 +48,7 @@ Check that dune >= 2.4 removes target write permissions.
   > EOF
   $ dune build --root 2.4 foo.exe @install
   Entering directory '2.4'
+  Leaving directory '2.4'
   $ dune_cmd stat permissions 2.4/_build/default/foo.exe | head -c1
   5
   $ dune install --root 2.4 --prefix ./
@@ -56,6 +58,7 @@ Check that dune >= 2.4 removes target write permissions.
   Installing bin/foo
   Installing bin/foo.exe
   Installing share/foo/target
+  Leaving directory '2.4'
   $ dune_cmd stat permissions 2.4/bin/foo.exe | head -c1
   7
   $ dune_cmd stat permissions 2.4/share/foo/target | head -c1


### PR DESCRIPTION
Print "Leaving Directory '%s'" in addition to "Entering Directory"

Fixes #138

The original PR didn't flush to stdout so the output was garbled.

There's still a small issue with `dune exec`. Because we're execing a program, we're not unable to write the "Leaving Directory" after the program exits. @emillon @cpitclaudel should we leave it this way or just get rid of the "Leaving" for such cases?