### PR TITLE
doc: add button to copy code blocks in Dune manual

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: doc/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ distclean: clean
 doc:
 	sphinx-build -W doc doc/_build
 
-# livedoc-deps: you may need to [pip3 install sphinx-autobuild] and [pip3 install sphinx-rtd-theme]
+# livedoc-deps: you may need to [pip3 install sphinx-autobuild] and [pip3 install -r doc/requirements.txt]
 livedoc:
 	cd doc && sphinx-autobuild . _build --port 8888 -q --re-ignore '\.#.*'
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,9 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'sphinx_copybutton'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+sphinx >= 4.5.0
+sphinx_rtd_theme >= 1.0.0
+sphinx-copybutton >= 0.5.0

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
               [
                 sphinx
                 sphinx-autobuild
+                python310Packages.sphinx-copybutton
                 python310Packages.sphinx-rtd-theme
               ]
             );


### PR DESCRIPTION
This is imo a nice usability improvement ;-)

Using sphinx-copybutton <https://sphinx-copybutton.readthedocs.io/en/latest/>.

Hope I've setup nix flakes correctly. Building works locally but I haven't tested nix stuff.