### PR TITLE
fix(ci): build @install to build dune

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,7 +78,7 @@ jobs:
       - run: opam exec -- make dune.exe
 
       # Ensure Dune can build itself
-      - run: opam exec -- ./dune.exe build -p dune --profile dune-bootstrap
+      - run: opam exec -- ./dune.exe build @install -p dune --profile dune-bootstrap
 
       - name: Install deps on Unix
         run: |


### PR DESCRIPTION
instead of @all which pull in a lot of other stuff

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 62e27328-da02-4bae-a278-5164627aa917