### PR TITLE
feature(melange): more flexible layout for emit

### DIFF
--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -1,11 +1,9 @@
 open Import
 module CC = Compilation_context
 
-let lib_output_dir ~emit_stanza_dir ~lib_dir ~target =
-  let rel_path =
-    Path.reach (Path.build lib_dir) ~from:(Path.build emit_stanza_dir)
-  in
-  Path.Build.relative (Path.Build.relative emit_stanza_dir target) rel_path
+let lib_output_dir ~target_dir ~lib_dir =
+  Path.Build.append_source target_dir
+    (Path.Build.drop_build_context_exn lib_dir)
 
 let make_js_name ~dst_dir m =
   let name =
@@ -13,7 +11,7 @@ let make_js_name ~dst_dir m =
   in
   Path.Build.relative dst_dir name
 
-let js_includes ~sctx ~emit_stanza_dir ~target ~requires_link ~scope =
+let js_includes ~sctx ~target_dir ~requires_link ~scope =
   let open Resolve.Memo.O in
   Command.Args.memo
     (Resolve.Memo.args
@@ -24,7 +22,7 @@ let js_includes ~sctx ~emit_stanza_dir ~target ~requires_link ~scope =
           let lib = Lib.Local.of_lib_exn lib in
           let info = Lib.Local.info lib in
           let lib_dir = Lib_info.src_dir info in
-          let dst_dir = lib_output_dir ~emit_stanza_dir ~lib_dir ~target in
+          let dst_dir = lib_output_dir ~target_dir ~lib_dir in
           let open Memo.O in
           let modules_group =
             Dir_contents.get sctx ~dir:lib_dir
@@ -48,10 +46,10 @@ let js_includes ~sctx ~emit_stanza_dir ~target ~requires_link ~scope =
              ])))
 
 let build_js ~loc ~dir ~pkg_name ~module_system ~dst_dir ~obj_dir ~sctx
-    ~build_dir ~lib_deps_js_includes m =
+    ~lib_deps_js_includes m =
   let cm_kind = Lib_mode.Cm_kind.Melange Cmj in
   let open Memo.O in
-  let* compiler = Melange_binary.melc sctx ~dir:build_dir in
+  let* compiler = Melange_binary.melc sctx ~dir in
   let src = Obj_dir.Module.cm_file_exn obj_dir m ~kind:cm_kind in
   let output = make_js_name ~dst_dir m in
   let obj_dir =
@@ -70,7 +68,9 @@ let build_js ~loc ~dir ~pkg_name ~module_system ~dst_dir ~obj_dir ~sctx
   in
   let lib_deps_js_includes = Command.Args.as_any lib_deps_js_includes in
   Super_context.add_rule sctx ~dir ?loc
-    (Command.run ~dir:(Path.build build_dir) compiler
+    (Command.run
+       ~dir:(Path.build (Super_context.context sctx).build_dir)
+       compiler
        [ Command.Args.S obj_dir
        ; lib_deps_js_includes
        ; As melange_package_args
@@ -80,7 +80,7 @@ let build_js ~loc ~dir ~pkg_name ~module_system ~dst_dir ~obj_dir ~sctx
        ])
 
 let add_rules_for_entries ~sctx ~dir ~expander ~dir_contents ~scope
-    ~compile_info (mel : Melange_stanzas.Emit.t) =
+    ~compile_info ~target_dir (mel : Melange_stanzas.Emit.t) =
   let open Memo.O in
   (* Use "mobjs" rather than "objs" to avoid a potential conflict with a library
      of the same name *)
@@ -116,23 +116,23 @@ let add_rules_for_entries ~sctx ~dir ~expander ~dir_contents ~scope
         }
   in
   let pkg_name = Option.map mel.package ~f:Package.name in
-  let dst_dir = Path.Build.relative dir mel.target in
   let loc = mel.loc in
   let requires_link = Memo.Lazy.force requires_link in
   let lib_deps_js_includes =
-    js_includes ~sctx ~emit_stanza_dir:dir ~target:mel.target ~requires_link
-      ~scope
+    js_includes ~sctx ~target_dir ~requires_link ~scope
   in
-  let build_dir = (Super_context.context sctx).build_dir in
   let* () = Module_compilation.build_all cctx in
   let module_list =
     Modules.fold_no_vlib modules ~init:[] ~f:(fun x acc -> x :: acc)
+  in
+  let dst_dir =
+    Path.Build.append_source target_dir (Path.Build.drop_build_context_exn dir)
   in
   let* () =
     Memo.parallel_iter module_list ~f:(fun m ->
         (* Should we check module kind? *)
         build_js ~dir ~loc:(Some loc) ~pkg_name ~module_system:mel.module_system
-          ~dst_dir ~obj_dir ~sctx ~build_dir ~lib_deps_js_includes m)
+          ~dst_dir ~obj_dir ~sctx ~lib_deps_js_includes m)
   in
   let* () =
     match mel.alias with
@@ -162,7 +162,7 @@ let add_rules_for_entries ~sctx ~dir ~expander ~dir_contents ~scope
         ~ident:(Lib.Compile.merlin_ident compile_info)
         ~modes:`Melange_emit () )
 
-let add_rules_for_libraries ~dir ~scope ~emit_stanza_dir ~sctx ~requires_link
+let add_rules_for_libraries ~dir ~scope ~target_dir ~sctx ~requires_link
     (mel : Melange_stanzas.Emit.t) =
   Memo.parallel_iter requires_link ~f:(fun lib ->
       let open Memo.O in
@@ -174,20 +174,7 @@ let add_rules_for_libraries ~dir ~scope ~emit_stanza_dir ~sctx ~requires_link
       let info = Lib.Local.info lib in
       let lib_dir = Lib_info.src_dir info in
       let obj_dir = Lib_info.obj_dir info in
-      let () =
-        if not (Path.Build.is_descendant lib_dir ~of_:emit_stanza_dir) then
-          User_error.raise
-            [ Pp.textf
-                "The library %s is used by a melange.emit stanza but the \
-                 library folder %s is not a descendant of the stanza folder %s"
-                (Lib_name.to_string (Lib_info.name info))
-                (Path.Build.to_string lib_dir)
-                (Path.Build.to_string emit_stanza_dir)
-            ]
-      in
-      let dst_dir =
-        lib_output_dir ~emit_stanza_dir ~lib_dir ~target:mel.target
-      in
+      let dst_dir = lib_output_dir ~target_dir ~lib_dir in
       let modules_group =
         Dir_contents.get sctx ~dir:lib_dir
         >>= Dir_contents.ocaml
@@ -199,14 +186,12 @@ let add_rules_for_libraries ~dir ~scope ~emit_stanza_dir ~sctx ~requires_link
         Memo.Lazy.force (Lib.Compile.requires_link lib_compile_info)
       in
       let lib_deps_js_includes =
-        js_includes ~sctx ~emit_stanza_dir ~target:mel.target ~requires_link
-          ~scope
+        js_includes ~sctx ~target_dir ~requires_link ~scope
       in
-      let build_dir = (Super_context.context sctx).build_dir in
       Memo.parallel_iter source_modules
         ~f:
           (build_js ~loc:None ~dir ~pkg_name ~module_system:mel.module_system
-             ~dst_dir ~obj_dir ~sctx ~build_dir ~lib_deps_js_includes))
+             ~dst_dir ~obj_dir ~sctx ~lib_deps_js_includes))
 
 let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
   let open Memo.O in
@@ -225,15 +210,15 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
 let emit_rules ~dir_contents ~dir ~scope ~sctx ~expander mel =
   let open Memo.O in
   let* compile_info = compile_info ~scope mel in
+  let target_dir = Path.Build.relative dir mel.target in
   let+ cctx_and_merlin =
     add_rules_for_entries ~sctx ~dir ~expander ~dir_contents ~scope
-      ~compile_info mel
+      ~compile_info ~target_dir mel
   and+ () =
     let* requires_link =
       Memo.Lazy.force (Lib.Compile.requires_link compile_info)
     in
     let* requires_link = Resolve.read_memo requires_link in
-    add_rules_for_libraries ~dir ~scope ~emit_stanza_dir:dir ~sctx
-      ~requires_link mel
+    add_rules_for_libraries ~dir ~scope ~target_dir ~sctx ~requires_link mel
   in
   cctx_and_merlin

--- a/test/blackbox-tests/test-cases/melange/include_subdirs.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/include_subdirs.t/run.t
@@ -1,6 +1,8 @@
-Test that libs using `(include_subdirs unqualified) work well with `melange.emit` stanza
+Test that libs using `(include_subdirs unqualified) work well with
+`melange.emit` stanza
 
 Build js files
-  $ dune build inside/output/melange__C.js
-  $ node _build/default/inside/output/melange__C.js
+  $ output=inside/output
+  $ dune build $output/inside/melange__C.js
+  $ node _build/default/$output/inside/melange__C.js
   buy it

--- a/test/blackbox-tests/test-cases/melange/outside.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/outside.t/dune-project
@@ -1,3 +1,0 @@
-(lang dune 3.6)
-
-(using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/outside.t/inside/c.ml
+++ b/test/blackbox-tests/test-cases/melange/outside.t/inside/c.ml
@@ -1,1 +1,0 @@
-let () = Js.log Lib.B.buy_it

--- a/test/blackbox-tests/test-cases/melange/outside.t/inside/dune
+++ b/test/blackbox-tests/test-cases/melange/outside.t/inside/dune
@@ -1,5 +1,0 @@
-(melange.emit
- (target output)
- (entries c)
- (libraries lib)
- (module_system es6))

--- a/test/blackbox-tests/test-cases/melange/outside.t/lib/b.ml
+++ b/test/blackbox-tests/test-cases/melange/outside.t/lib/b.ml
@@ -1,1 +1,0 @@
-let buy_it = "buy it"

--- a/test/blackbox-tests/test-cases/melange/outside.t/lib/b.mli
+++ b/test/blackbox-tests/test-cases/melange/outside.t/lib/b.mli
@@ -1,1 +1,0 @@
-val buy_it : string

--- a/test/blackbox-tests/test-cases/melange/outside.t/lib/dune
+++ b/test/blackbox-tests/test-cases/melange/outside.t/lib/dune
@@ -1,3 +1,0 @@
-(library
- (name lib)
- (modes melange))

--- a/test/blackbox-tests/test-cases/melange/outside.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/outside.t/run.t
@@ -1,8 +1,0 @@
-Melange stanza does not support consuming a library being placed outside the stanza folder
-
-  $ dune build
-  Error: The library lib is used by a melange.emit stanza but the library
-  folder _build/default/lib is not a descendant of the stanza folder
-  _build/default/inside
-  -> required by alias default
-  [1]

--- a/test/blackbox-tests/test-cases/melange/private.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/private.t/run.t
@@ -12,13 +12,15 @@ Cmj rules should not include --bs-package-name
   0
   [1]
 
+  $ output=inside/output
+
 Js rules should include module type
-  $ dune rules inside/output/app/app__B.js | 
+  $ dune rules $output/inside/app/app__B.js | 
   > grep -e "--bs-module-type" --after-context=1 
       --bs-module-type
       es6
 
 Build js files
-  $ dune build inside/output/melange__C.js
-  $ node _build/default/inside/output/melange__C.js
+  $ dune build $output/inside/melange__C.js
+  $ node _build/default/$output/inside/melange__C.js
   buy it

--- a/test/blackbox-tests/test-cases/melange/public.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/public.t/run.t
@@ -12,21 +12,23 @@ Cmj rules should include --bs-package-name
       --bs-package-name
       pkg
 
+  $ output=my_project/output
+
 Js rules should include --bs-module-type
-  $ dune rules my_project/output/app/app__B.js | 
+  $ dune rules $output/my_project/app/app__B.js | 
   > grep -e "--bs-module-type" --after-context=1 
       --bs-module-type
       commonjs
 
 Js rules should include --bs-package-name
-  $ dune rules my_project/output/app/app__B.js | 
+  $ dune rules $output/my_project/app/app__B.js | 
   > grep -e "--bs-package-name" --after-context=1 
       --bs-package-name
       pkg
 
 Build js files
-  $ dune build my_project/output/melange__C.js
+  $ dune build $output/my_project/melange__C.js
 
 Path to app_B is non-relative (broken)
-  $ node _build/default/my_project/output/melange__C.js
+  $ node _build/default/$output/my_project/melange__C.js
   buy it

--- a/test/blackbox-tests/test-cases/melange/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/simple.t/run.t
@@ -1,5 +1,6 @@
 Using `melange.emit` inside the same folder as the library works fine
 
-  $ dune build lib/simple/melange__X.js
-  $ node _build/default/lib/simple/melange__X.js
+  $ output=lib/simple
+  $ dune build $output/lib/melange__X.js
+  $ node _build/default/$output/lib/melange__X.js
   buy it


### PR DESCRIPTION
Introduce a new layout that allows any library from the workspace to be
used in emit. The new layout now follows these rules:

* $emit_stanza/$target defines the root
* any library in $path will now be in $emit_stanza/$target/$path
* entry module $x will now be in $emit_stanza/$target/$emit_stanza/$x

The scheme is quite ugly but it lifts the annoying limitation of
re-arranging the project.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: a4c025e6-eedb-4b1e-8d55-ec5b6a1eeeae