### PR TITLE
feature(melange): fix merlin for emit stanza

### DIFF
--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -58,7 +58,9 @@ let get_installed_binaries ~(context : Context.t) stanzas =
                            (Lib.DB.instrumentation_backend (Scope.libs scope)))
                     >>| Preprocess.Per_module.pps
                   in
-                  let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+                  let merlin_ident =
+                    Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names)
+                  in
                   Lib.DB.resolve_user_written_deps (Scope.libs scope)
                     (`Exe exes.names) exes.buildable.libraries ~pps
                     ~dune_version

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -58,10 +58,13 @@ let get_installed_binaries ~(context : Context.t) stanzas =
                            (Lib.DB.instrumentation_backend (Scope.libs scope)))
                     >>| Preprocess.Per_module.pps
                   in
-                  Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
-                    exes.names exes.buildable.libraries ~pps ~dune_version
+                  let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+                  Lib.DB.resolve_user_written_deps (Scope.libs scope)
+                    (`Exe exes.names) exes.buildable.libraries ~pps
+                    ~dune_version
                     ~allow_overlaps:
                       exes.buildable.allow_overlapping_dependencies
+                    ~merlin_ident
                 in
                 let* available =
                   let open Memo.O in

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -115,12 +115,13 @@ let gen_rules sctx t ~dir ~scope =
     |> Modules.map_user_written ~f:(Pp_spec.pp_module preprocess)
   in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
+  let names = [ (t.loc, name) ] in
+  let merlin_ident = Merlin_ident.for_exes ~names in
   let compile_info =
-    Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
-      [ (t.loc, name) ]
+    Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
       (Lib_dep.Direct (loc, Lib_name.of_string "cinaps.runtime") :: t.libraries)
       ~pps:(Preprocess.Per_module.pps t.preprocess)
-      ~dune_version
+      ~dune_version ~merlin_ident
   in
   let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
   let* cctx =

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -116,7 +116,7 @@ let gen_rules sctx t ~dir ~scope =
   in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let names = [ (t.loc, name) ] in
-  let merlin_ident = Merlin_ident.for_exes ~names in
+  let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
   let compile_info =
     Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
       (Lib_dep.Direct (loc, Lib_name.of_string "cinaps.runtime") :: t.libraries)

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -227,7 +227,9 @@ let compile_info ~scope (exes : Dune_file.Executables.t) =
            (Lib.DB.instrumentation_backend (Scope.libs scope)))
     >>| Preprocess.Per_module.pps
   in
-  let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+  let merlin_ident =
+    Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names)
+  in
   Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe exes.names)
     exes.buildable.libraries ~pps ~dune_version
     ~allow_overlaps:exes.buildable.allow_overlapping_dependencies

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -227,10 +227,11 @@ let compile_info ~scope (exes : Dune_file.Executables.t) =
            (Lib.DB.instrumentation_backend (Scope.libs scope)))
     >>| Preprocess.Per_module.pps
   in
-  Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope) exes.names
+  let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+  Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe exes.names)
     exes.buildable.libraries ~pps ~dune_version
     ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
-    ~forbidden_libraries:exes.forbidden_libraries
+    ~forbidden_libraries:exes.forbidden_libraries ~merlin_ident
 
 let rules ~sctx ~dir ~dir_contents ~scope ~expander
     (exes : Dune_file.Executables.t) =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -251,9 +251,11 @@ end = struct
                     (Lib.DB.instrumentation_backend (Scope.libs scope))
                 |> Resolve.Memo.read_memo >>| Preprocess.Per_module.pps
               in
-              Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
-                exes.names exes.buildable.libraries ~pps ~dune_version
+              let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+              Lib.DB.resolve_user_written_deps (Scope.libs scope)
+                (`Exe exes.names) exes.buildable.libraries ~pps ~dune_version
                 ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
+                ~merlin_ident
             in
             let+ requires = Lib.Compile.direct_requires compile_info in
             Resolve.is_ok requires)

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -251,7 +251,9 @@ end = struct
                     (Lib.DB.instrumentation_backend (Scope.libs scope))
                 |> Resolve.Memo.read_memo >>| Preprocess.Per_module.pps
               in
-              let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+              let merlin_ident =
+                Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names)
+              in
               Lib.DB.resolve_user_written_deps (Scope.libs scope)
                 (`Exe exes.names) exes.buildable.libraries ~pps ~dune_version
                 ~allow_overlaps:exes.buildable.allow_overlapping_dependencies

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1836,7 +1836,7 @@ module DB = struct
                 ~forbidden_libraries res)
             ~human_readable_description:(fun () ->
               match targets with
-              | `Melange name -> Pp.textf "melange target %s" name
+              | `Melange_emit name -> Pp.textf "melange target %s" name
               | `Exe [ (loc, name) ] ->
                 Pp.textf "executable %s in %s" name (Loc.to_file_colon_line loc)
               | `Exe names ->

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1801,7 +1801,7 @@ module DB = struct
         [ ("name", Lib_name.to_dyn name) ]
     | Some lib -> (lib, Compile.for_lib ~allow_overlaps t lib)
 
-  let resolve_user_written_deps t modules ?(allow_overlaps = false)
+  let resolve_user_written_deps t targets ?(allow_overlaps = false)
       ?(forbidden_libraries = []) deps ~pps ~dune_version ~merlin_ident =
     let resolved =
       Memo.lazy_ (fun () ->
@@ -1835,10 +1835,11 @@ module DB = struct
                 (Option.some_if (not allow_overlaps) t)
                 ~forbidden_libraries res)
             ~human_readable_description:(fun () ->
-              match modules with
-              | [ (loc, name) ] ->
+              match targets with
+              | `Melange name -> Pp.textf "melange target %s" name
+              | `Exe [ (loc, name) ] ->
                 Pp.textf "executable %s in %s" name (Loc.to_file_colon_line loc)
-              | names ->
+              | `Exe names ->
                 let loc, _ = List.hd names in
                 Pp.textf "executables %s in %s"
                   (String.enumerate_and (List.map ~f:snd names))
@@ -1866,20 +1867,6 @@ module DB = struct
     ; sub_systems = Sub_system_name.Map.empty
     ; merlin_ident
     }
-
-  let resolve_user_written_deps_for_exes t exes ?allow_overlaps
-      ?forbidden_libraries deps ~pps ~dune_version =
-    let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd exes) in
-    resolve_user_written_deps t exes ?allow_overlaps ?forbidden_libraries deps
-      ~pps ~dune_version ~merlin_ident
-
-  let resolve_user_written_deps_for_melange t entries ?allow_overlaps
-      ?forbidden_libraries deps ~pps ~dune_version =
-    let merlin_ident =
-      Merlin_ident.for_melange ~names:(List.map ~f:snd entries)
-    in
-    resolve_user_written_deps t entries ?allow_overlaps ?forbidden_libraries
-      deps ~pps ~dune_version ~merlin_ident
 
   (* Here we omit the [only_ppx_deps_allowed] check because by the time we reach
      this point, all preprocess dependencies should have been checked

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -152,7 +152,7 @@ module DB : sig
       This function is for executables or melange.emit stanzas. *)
   val resolve_user_written_deps :
        t
-    -> [ `Exe of (Import.Loc.t * string) list | `Melange of string ]
+    -> [ `Exe of (Import.Loc.t * string) list | `Melange_emit of string ]
     -> ?allow_overlaps:bool
     -> ?forbidden_libraries:(Loc.t * Lib_name.t) list
     -> Lib_dep.t list

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -149,30 +149,16 @@ module DB : sig
       of libraries is transitively closed and sorted by the order of
       dependencies.
 
-      This function is for executables stanzas. *)
-  val resolve_user_written_deps_for_exes :
+      This function is for executables or melange.emit stanzas. *)
+  val resolve_user_written_deps :
        t
-    -> (Loc.t * string) list
+    -> [ `Exe of (Import.Loc.t * string) list | `Melange of string ]
     -> ?allow_overlaps:bool
     -> ?forbidden_libraries:(Loc.t * Lib_name.t) list
     -> Lib_dep.t list
     -> pps:(Loc.t * Lib_name.t) list
     -> dune_version:Dune_lang.Syntax.Version.t
-    -> Compile.t
-
-  (** Resolve libraries written by the user in a [dune] file. The resulting list
-      of libraries is transitively closed and sorted by the order of
-      dependencies.
-
-      This function is for melange.emit stanzas. *)
-  val resolve_user_written_deps_for_melange :
-       t
-    -> (Loc.t * string) list
-    -> ?allow_overlaps:bool
-    -> ?forbidden_libraries:(Loc.t * Lib_name.t) list
-    -> Lib_dep.t list
-    -> pps:(Loc.t * Lib_name.t) list
-    -> dune_version:Dune_lang.Syntax.Version.t
+    -> merlin_ident:Merlin_ident.t
     -> Compile.t
 
   val resolve_pps : t -> (Loc.t * Lib_name.t) list -> lib list Resolve.Memo.t

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -160,6 +160,21 @@ module DB : sig
     -> dune_version:Dune_lang.Syntax.Version.t
     -> Compile.t
 
+  (** Resolve libraries written by the user in a [dune] file. The resulting list
+      of libraries is transitively closed and sorted by the order of
+      dependencies.
+
+      This function is for melange.emit stanzas. *)
+  val resolve_user_written_deps_for_melange :
+       t
+    -> (Loc.t * string) list
+    -> ?allow_overlaps:bool
+    -> ?forbidden_libraries:(Loc.t * Lib_name.t) list
+    -> Lib_dep.t list
+    -> pps:(Loc.t * Lib_name.t) list
+    -> dune_version:Dune_lang.Syntax.Version.t
+    -> Compile.t
+
   val resolve_pps : t -> (Loc.t * Lib_name.t) list -> lib list Resolve.Memo.t
 
   (** Return the list of all libraries in this database. If [recursive] is true,

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -384,7 +384,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
   let flags = Ocaml_flags.default ~dune_version ~profile:Release in
   let lib name = Lib_dep.Direct (loc, Lib_name.of_string name) in
   let names = [ (t.loc, name) ] in
-  let merlin_ident = Merlin_ident.for_exes ~names in
+  let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
   let compile_info =
     Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
       (lib "mdx.test" :: lib "mdx.top" :: t.libraries)

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -383,11 +383,12 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
   let modules = Modules.singleton_exe module_ in
   let flags = Ocaml_flags.default ~dune_version ~profile:Release in
   let lib name = Lib_dep.Direct (loc, Lib_name.of_string name) in
+  let names = [ (t.loc, name) ] in
+  let merlin_ident = Merlin_ident.for_exes ~names in
   let compile_info =
-    Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
-      [ (t.loc, name) ]
+    Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
       (lib "mdx.test" :: lib "mdx.top" :: t.libraries)
-      ~pps:[] ~dune_version
+      ~pps:[] ~dune_version ~merlin_ident
   in
   let* cctx =
     let requires_compile = Lib.Compile.direct_requires compile_info

--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -218,9 +218,9 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
            (Lib.DB.instrumentation_backend (Scope.libs scope)))
     >>| Preprocess.Per_module.pps
   in
-  Lib.DB.resolve_user_written_deps_for_melange (Scope.libs scope)
-    [ (mel.loc, mel.target) ]
-    mel.libraries ~pps ~dune_version
+  let merlin_ident = Merlin_ident.for_melange ~target:mel.target in
+  Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Melange mel.target)
+    mel.libraries ~pps ~dune_version ~merlin_ident
 
 let emit_rules ~dir_contents ~dir ~scope ~sctx ~expander mel =
   let open Memo.O in

--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -218,22 +218,27 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
            (Lib.DB.instrumentation_backend (Scope.libs scope)))
     >>| Preprocess.Per_module.pps
   in
-  Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
+  Lib.DB.resolve_user_written_deps_for_melange (Scope.libs scope)
     [ (mel.loc, mel.target) ]
     mel.libraries ~pps ~dune_version
 
 let emit_rules ~dir_contents ~dir ~scope ~sctx ~expander mel =
   let open Memo.O in
   let* compile_info = compile_info ~scope mel in
-  let+ cctx_and_merlin =
-    add_rules_for_entries ~sctx ~dir ~expander ~dir_contents ~scope
-      ~compile_info mel
-  and+ () =
-    let* requires_link =
-      Memo.Lazy.force (Lib.Compile.requires_link compile_info)
+  let f () =
+    let+ cctx_and_merlin =
+      add_rules_for_entries ~sctx ~dir ~expander ~dir_contents ~scope
+        ~compile_info mel
+    and+ () =
+      let* requires_link =
+        Memo.Lazy.force (Lib.Compile.requires_link compile_info)
+      in
+      let* requires_link = Resolve.read_memo requires_link in
+      add_rules_for_libraries ~dir ~scope ~emit_stanza_dir:dir ~sctx
+        ~requires_link mel
     in
-    let* requires_link = Resolve.read_memo requires_link in
-    add_rules_for_libraries ~dir ~scope ~emit_stanza_dir:dir ~sctx
-      ~requires_link mel
+    cctx_and_merlin
   in
-  cctx_and_merlin
+  Buildable_rules.with_lib_deps
+    (Super_context.context sctx)
+    compile_info ~dir ~f

--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -204,7 +204,7 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
     >>| Preprocess.Per_module.pps
   in
   let merlin_ident = Merlin_ident.for_melange ~target:mel.target in
-  Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Melange mel.target)
+  Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Melange_emit mel.target)
     mel.libraries ~pps ~dune_version ~merlin_ident
 
 let emit_rules ~dir_contents ~dir ~scope ~sctx ~expander mel =

--- a/src/dune_rules/merlin_ident.ml
+++ b/src/dune_rules/merlin_ident.ml
@@ -3,10 +3,13 @@ open Import
 type t =
   | Lib of Lib_name.t
   | Exes of string list
+  | Melange_entries of string list
 
 let for_lib l = Lib l
 
 let for_exes ~names = Exes names
+
+let for_melange ~names = Melange_entries names
 
 (* For debug purposes we use the name of one library or executable and the hash
    of the others if there are multiple executables to name the merlin file *)
@@ -15,7 +18,10 @@ let to_string = function
   | Exes [ name ] -> sprintf "exe-%s" name
   | Exes (name :: names) ->
     sprintf "exe-%s-%s" name Digest.(generic names |> to_string)
-  | Exes [] -> assert false
+  | Melange_entries [ name ] -> sprintf "melange-%s" name
+  | Melange_entries (name :: names) ->
+    sprintf "melange-%s-%s" name Digest.(generic names |> to_string)
+  | Exes [] | Melange_entries [] -> assert false
 
 let merlin_folder_name = ".merlin-conf"
 

--- a/src/dune_rules/merlin_ident.ml
+++ b/src/dune_rules/merlin_ident.ml
@@ -3,13 +3,13 @@ open Import
 type t =
   | Lib of Lib_name.t
   | Exes of string list
-  | Melange_entries of string list
+  | Melange_entries of string
 
 let for_lib l = Lib l
 
-let for_exes ~names = Exes names
+let for_exes ~names = Exes (List.map ~f:snd names)
 
-let for_melange ~names = Melange_entries names
+let for_melange ~target = Melange_entries target
 
 (* For debug purposes we use the name of one library or executable and the hash
    of the others if there are multiple executables to name the merlin file *)
@@ -18,10 +18,8 @@ let to_string = function
   | Exes [ name ] -> sprintf "exe-%s" name
   | Exes (name :: names) ->
     sprintf "exe-%s-%s" name Digest.(generic names |> to_string)
-  | Melange_entries [ name ] -> sprintf "melange-%s" name
-  | Melange_entries (name :: names) ->
-    sprintf "melange-%s-%s" name Digest.(generic names |> to_string)
-  | Exes [] | Melange_entries [] -> assert false
+  | Melange_entries name -> sprintf "melange-%s" name
+  | Exes [] -> assert false
 
 let merlin_folder_name = ".merlin-conf"
 

--- a/src/dune_rules/merlin_ident.ml
+++ b/src/dune_rules/merlin_ident.ml
@@ -7,7 +7,7 @@ type t =
 
 let for_lib l = Lib l
 
-let for_exes ~names = Exes (List.map ~f:snd names)
+let for_exes ~names = Exes names
 
 let for_melange ~target = Melange_entries target
 

--- a/src/dune_rules/merlin_ident.mli
+++ b/src/dune_rules/merlin_ident.mli
@@ -6,7 +6,7 @@ type t
 
 val for_lib : Lib_name.t -> t
 
-val for_exes : names:('a * string) list -> t
+val for_exes : names:string list -> t
 
 val for_melange : target:string -> t
 

--- a/src/dune_rules/merlin_ident.mli
+++ b/src/dune_rules/merlin_ident.mli
@@ -6,9 +6,9 @@ type t
 
 val for_lib : Lib_name.t -> t
 
-val for_exes : names:string list -> t
+val for_exes : names:('a * string) list -> t
 
-val for_melange : names:string list -> t
+val for_melange : target:string -> t
 
 (** Merlin config folder name *)
 val merlin_folder_name : string

--- a/src/dune_rules/merlin_ident.mli
+++ b/src/dune_rules/merlin_ident.mli
@@ -8,6 +8,8 @@ val for_lib : Lib_name.t -> t
 
 val for_exes : names:string list -> t
 
+val for_melange : names:string list -> t
+
 (** Merlin config folder name *)
 val merlin_folder_name : string
 

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -173,7 +173,7 @@ module Stanza = struct
         Lib_name.parse_string_exn (source.loc, "compiler-libs.toplevel")
       in
       let names = [ (source.loc, source.name) ] in
-      let merlin_ident = Merlin_ident.for_exes ~names in
+      let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
       Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
         (Lib_dep.Direct (source.loc, compiler_libs)
         :: List.map toplevel.libraries ~f:(fun d -> Lib_dep.Direct d))

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -172,11 +172,12 @@ module Stanza = struct
       let compiler_libs =
         Lib_name.parse_string_exn (source.loc, "compiler-libs.toplevel")
       in
-      Lib.DB.resolve_user_written_deps_for_exes (Scope.libs scope)
-        [ (source.loc, source.name) ]
+      let names = [ (source.loc, source.name) ] in
+      let merlin_ident = Merlin_ident.for_exes ~names in
+      Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
         (Lib_dep.Direct (source.loc, compiler_libs)
         :: List.map toplevel.libraries ~f:(fun d -> Lib_dep.Direct d))
-        ~pps ~dune_version ~allow_overlaps:false
+        ~pps ~dune_version ~allow_overlaps:false ~merlin_ident
     in
     let requires_compile = Lib.Compile.direct_requires compile_info in
     let requires_link = Lib.Compile.requires_link compile_info in

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -100,7 +100,9 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
                            (Lib.DB.instrumentation_backend (Scope.libs scope)))
                     >>| Preprocess.Per_module.pps
                   in
-                  let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+                  let merlin_ident =
+                    Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names)
+                  in
                   Lib.DB.resolve_user_written_deps db (`Exe exes.names)
                     exes.buildable.libraries ~pps ~dune_version
                     ~allow_overlaps:

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -100,11 +100,12 @@ let libs_and_ppx_under_dir sctx ~db ~dir =
                            (Lib.DB.instrumentation_backend (Scope.libs scope)))
                     >>| Preprocess.Per_module.pps
                   in
-                  Lib.DB.resolve_user_written_deps_for_exes db exes.names
+                  let merlin_ident = Merlin_ident.for_exes ~names:exes.names in
+                  Lib.DB.resolve_user_written_deps db (`Exe exes.names)
                     exes.buildable.libraries ~pps ~dune_version
                     ~allow_overlaps:
                       exes.buildable.allow_overlapping_dependencies
-                    ~forbidden_libraries:exes.forbidden_libraries
+                    ~forbidden_libraries:exes.forbidden_libraries ~merlin_ident
                 in
                 let+ available = Lib.Compile.direct_requires compile_info in
                 Resolve.peek available

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -14,7 +14,7 @@
   > EOF
 
   $ touch bar.ml $lib.ml
-  $ dune build .merlin-conf/lib-"$lib"
+  $ dune build @check
   $ dune ocaml-merlin --dump-config="$(pwd)" | grep -i "$lib"
   Foo
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
@@ -34,6 +34,6 @@
   > EOF
 
   $ touch main.ml
-  $ dune build .merlin-conf/melange-"$target"
+  $ dune build @check
   $ dune ocaml-merlin --dump-config="$(pwd)" | grep -i "$target"
     $TESTCASE_ROOT/_build/default/.output.mobjs/melange)

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -14,7 +14,7 @@
   > EOF
 
   $ touch bar.ml $lib.ml
-  $ dune build @check
+  $ dune build .merlin-conf/lib-"$lib"
   $ dune ocaml-merlin --dump-config="$(pwd)" | grep -i "$lib"
   Foo
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
@@ -24,3 +24,16 @@
   Foo__
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
      Foo__
+
+  $ target=output
+  $ cat >dune <<EOF
+  > (melange.emit
+  >  (target "$target")
+  >  (entries main)
+  >  (module_system commonjs))
+  > EOF
+
+  $ touch main.ml
+  $ dune build .merlin-conf/melange-"$target"
+  $ dune ocaml-merlin --dump-config="$(pwd)" | grep -i "$target"
+    $TESTCASE_ROOT/_build/default/.output.mobjs/melange)


### PR DESCRIPTION
Makes sure that a merlin conf is generated for `melange.emit` stanzas.

Added some additional test, and tested on a demo project, seems to work fine.