### PR TITLE
chore: use opam 2.1 in docker images

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,5 +1,7 @@
 # little dockerfile to debug CI issues
 FROM ocaml/opam
+RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
+RUN opam init --reinit -ni
 RUN mkdir -p /home/opam/dune/_boot /home/opam/dune/_build && chown opam:opam /home/opam/dune/_boot /home/opam/dune/_build
 COPY Makefile Makefile
 COPY .ocamlformat .ocamlformat


### PR DESCRIPTION
kate's workaround to set the image to use 2.1

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 2169cac7-ee84-4c22-8186-9f1e0f5a1535