### PR TITLE
mdx: enable colors for debugging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Unreleased
 
 - Fix preprocessing with `staged_pps` (#6748, fixes #6644, @rgrinberg)
 
+- Use colored output with MDX when Dune colors are enabled.
+  (#6462, @MisterDA)
+
 - Make `dune describe workspace` return consistent dependencies for
   executables and for libraries. By default, compile-time dependencies
   towards PPX-rewriters are from now not taken into account (but


### PR DESCRIPTION
With @maiste and @art-w we had a long debugging session with mdx. I think it'd be nice to have #6416 (arbitrary flags for mdx) but in the meantime enabling colors in mdx and having more logs when Dune runs in verbose mode is, imo, a good start.