### PR TITLE
test: custom-build-dir should be reproducible

### DIFF
--- a/test/blackbox-tests/test-cases/cram/custom-build-dir.t
+++ b/test/blackbox-tests/test-cases/cram/custom-build-dir.t
@@ -21,10 +21,7 @@ path
     $TESTCASE_ROOT/tmp/default/foo.t.corrected
     to foo.t.
   [1]
-  $ sed -E 's/\(pid: [0-9]+\)/(pid: ###)/' foo.t
+  $ sed -E '/\(pid: [0-9]+\)/{s//(pid: ###)/; s/instance.*/.../g; q;}' foo.t
     $ echo "  $ echo bar" >bar.t
     $ dune runtest
-    Error: A running dune (pid: ###) instance has locked the build directory.
-    If this is not the case, please delete
-    $TESTCASE_ROOT/tmp/.lock
-    [1]
+    Error: A running dune (pid: ###) ...


### PR DESCRIPTION
The error message printed the pid, which affected the message's wrapping
depending on the pid's number of digits.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: ab179e80-5975-4dc5-acd4-97a79ac285ba