### PR TITLE
fix: merlin rules with pp's

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -132,11 +132,10 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
   in
   let stdlib_dir = ctx.Context.stdlib_dir in
   let* requires_compile = Compilation_context.requires_compile cctx in
-  let* preprocess =
-    Resolve.Memo.read_memo
-      (Preprocess.Per_module.with_instrumentation exes.buildable.preprocess
-         ~instrumentation_backend:
-           (Lib.DB.instrumentation_backend (Scope.libs scope)))
+  let preprocess =
+    Preprocess.Per_module.with_instrumentation exes.buildable.preprocess
+      ~instrumentation_backend:
+        (Lib.DB.instrumentation_backend (Scope.libs scope))
   in
   let* dep_graphs =
     (* Building an archive for foreign stubs, we link the corresponding object

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -519,11 +519,11 @@ let library_rules (lib : Library.t) ~local_lib ~cctx ~source_modules
       ; source_modules
       ; compile_info
       }
-  and+ preprocess =
-    Resolve.Memo.read_memo
-      (Preprocess.Per_module.with_instrumentation lib.buildable.preprocess
-         ~instrumentation_backend:
-           (Lib.DB.instrumentation_backend (Scope.libs scope)))
+  in
+  let preprocess =
+    Preprocess.Per_module.with_instrumentation lib.buildable.preprocess
+      ~instrumentation_backend:
+        (Lib.DB.instrumentation_backend (Scope.libs scope))
   in
   ( cctx
   , Merlin.make ~requires:requires_compile ~stdlib_dir ~flags ~modules

--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -146,11 +146,10 @@ let add_rules_for_entries ~sctx ~dir ~expander ~dir_contents ~scope
       Rules.Produce.Alias.add_deps alias deps
   in
   let* requires_compile = Compilation_context.requires_compile cctx in
-  let* preprocess =
-    Resolve.Memo.read_memo
-      (Preprocess.Per_module.with_instrumentation mel.preprocess
-         ~instrumentation_backend:
-           (Lib.DB.instrumentation_backend (Scope.libs scope)))
+  let preprocess =
+    Preprocess.Per_module.with_instrumentation mel.preprocess
+      ~instrumentation_backend:
+        (Lib.DB.instrumentation_backend (Scope.libs scope))
   in
   let stdlib_dir = (Super_context.context sctx).stdlib_dir in
   Memo.return

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -231,6 +231,7 @@ module Unprocessed = struct
     ; flags : string list Action_builder.t
     ; preprocess :
         Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+        Resolve.Memo.t
     ; libname : Lib_name.Local.t option
     ; source_dirs : Path.Source.Set.t
     ; objs_dirs : Path.Set.t
@@ -366,7 +367,11 @@ module Unprocessed = struct
         (Modules.source_dirs modules)
 
   let pp_config t sctx ~expander =
-    Module_name.Per_item.map_action_builder t.config.preprocess
+    Action_builder.of_memo_join
+    @@
+    let open Memo.O in
+    let+ preprocess = Resolve.Memo.read_memo t.config.preprocess in
+    Module_name.Per_item.map_action_builder preprocess
       ~f:(pp_flags sctx ~expander t.config.libname)
 
   let process

--- a/src/dune_rules/merlin.mli
+++ b/src/dune_rules/merlin.mli
@@ -46,6 +46,7 @@ val make :
   -> flags:Ocaml_flags.t
   -> preprocess:
        Preprocess.Without_instrumentation.t Preprocess.t Module_name.Per_item.t
+       Resolve.Memo.t
   -> libname:Lib_name.Local.t option
   -> source_dirs:Path.Source.Set.t
   -> modules:Modules.t


### PR DESCRIPTION
Merlin rules shouldn't resolve the preprocessor spec as this breaks lazy
loading.

In particular, if a ppx preprocessor isn't resolved, then all the rules
in that dune file will fail to load.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 3caf59c2-23c5-42cf-8652-8df41dc80bc3