### PR TITLE
fix(melange): handle include_subdirs unqualified

### DIFF
--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -50,10 +50,11 @@ let get_include_subdirs stanzas =
 let check_no_module_consumer stanzas =
   List.iter stanzas ~f:(fun stanza ->
       match stanza with
-      | Library { buildable; _ }
-      | Executables { buildable; _ }
-      | Tests { exes = { buildable; _ }; _ } ->
-        User_error.raise ~loc:buildable.loc
+      | Melange_emit { loc; _ }
+      | Library { buildable = { loc; _ }; _ }
+      | Executables { buildable = { loc; _ }; _ }
+      | Tests { exes = { buildable = { loc; _ }; _ }; _ } ->
+        User_error.raise ~loc
           [ Pp.text
               "This stanza is not allowed in a sub-directory of directory with \
                (include_subdirs unqualified)."


### PR DESCRIPTION
forbid [(melange.emit ..)] from appearing under [(include_subdirs
unqualified)]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 5e380e59-4bf5-4847-9344-07db138b8f60