### PR TITLE
Format disable

### DIFF
--- a/src/dune_engine/format_config.ml
+++ b/src/dune_engine/format_config.ml
@@ -118,7 +118,7 @@ module Generic = struct
   type 'files t = 'files generic_t
 
   let dune2_record_syntax ~files =
-    let+ files = files
+    let+ files = Dune_lang.Syntax.since Dune_lang.Stanza.syntax (3, 5) >>> files
     and+ ef = Enabled_for.field in
     ( files
     , match ef with
@@ -141,8 +141,8 @@ module Generic = struct
       (Dune_lang.Syntax.since Dune_lang.Stanza.syntax since
       >>> dune2_dec ~default_files ~files)
 
-  let equal ~files t1 t2 =
-    Enabled_for.equal t1.enabled_for t2.enabled_for && files t1.files t2.files
+  let equal ~files { enabled_for; files = f; loc = _ } t =
+    Enabled_for.equal enabled_for t.enabled_for && files f t.files
 
   let files { files; _ } = files
 

--- a/src/dune_engine/format_config.ml
+++ b/src/dune_engine/format_config.ml
@@ -118,7 +118,7 @@ module Generic = struct
   type 'files t = 'files generic_t
 
   let dune2_record_syntax ~files =
-    let+ files = Dune_lang.Syntax.since Dune_lang.Stanza.syntax (3, 5) >>> files
+    let+ files = Dune_lang.Syntax.since Dune_lang.Stanza.syntax (3, 7) >>> files
     and+ ef = Enabled_for.field in
     ( files
     , match ef with

--- a/src/dune_engine/format_config.mli
+++ b/src/dune_engine/format_config.mli
@@ -15,14 +15,15 @@ module Generic : sig
 
   val field :
        since:Dune_lang.Syntax.Version.t
-    -> files:('files, Dune_lang.Decoder.values) Dune_lang.Decoder.parser
+    -> default_files:'files
+    -> files:('files, Dune_lang.Decoder.fields) Dune_lang.Decoder.parser
     -> 'files t option Dune_lang.Decoder.fields_parser
 
   val equal : files:('files -> 'files -> bool) -> 'files t -> 'files t -> bool
 
   val set_files : 'files1 t -> 'files2 -> 'files2 t
 
-  val files : 'files t -> 'files  
+  val files : 'files t -> 'files
 end
 
 type t = unit Generic.t

--- a/src/dune_engine/format_config.mli
+++ b/src/dune_engine/format_config.mli
@@ -10,7 +10,22 @@ module Language : sig
     | Dune
 end
 
-type t
+module Generic : sig
+  type 'files t
+
+  val field :
+       since:Dune_lang.Syntax.Version.t
+    -> files:('files, Dune_lang.Decoder.values) Dune_lang.Decoder.parser
+    -> 'files t option Dune_lang.Decoder.fields_parser
+
+  val equal : files:('files -> 'files -> bool) -> 'files t -> 'files t -> bool
+
+  val set_files : 'files1 t -> 'files2 -> 'files2 t
+
+  val files : 'files t -> 'files  
+end
+
+type t = unit Generic.t
 
 val of_config :
   ext:t option -> dune_lang:t option -> version:Dune_lang.Syntax.Version.t -> t
@@ -20,12 +35,12 @@ val syntax : Dune_lang.Syntax.t
 
 (** Where the configuration was defined. Can be [Loc.none] if formatting is done
     by default. *)
-val loc : t -> Loc.t
+val loc : 'files Generic.t -> Loc.t
 
 (** Should we emit formatting rules for a particular [language]? *)
-val includes : t -> Language.t -> bool
+val includes : 'files Generic.t -> Language.t -> bool
 
-val is_empty : t -> bool
+val is_empty : 'files Generic.t -> bool
 
 (** Parse arguments for the 1.x extension. *)
 val dparse_args : (t * Dune_lang.Stanza.Parser.t list) Dune_lang.Decoder.t

--- a/src/dune_rules/dune_env.ml
+++ b/src/dune_rules/dune_env.ml
@@ -205,7 +205,7 @@ module Stanza = struct
     and+ coq = coq_field
     and+ format_config =
       Format_config.Generic.field ~since:(2, 8)
-      ~default_files:Ordered_set_lang.standard
+        ~default_files:Ordered_set_lang.standard
         ~files:
           (field ~default:Ordered_set_lang.standard "files"
              Ordered_set_lang.decode)

--- a/src/dune_rules/dune_env.ml
+++ b/src/dune_rules/dune_env.ml
@@ -79,7 +79,7 @@ module Stanza = struct
     ; odoc : Odoc.t
     ; js_of_ocaml : Ordered_set_lang.Unexpanded.t Js_of_ocaml.Env.t
     ; coq : Ordered_set_lang.Unexpanded.t
-    ; format_config : Format_config.t option
+    ; format_config : Ordered_set_lang.t Format_config.Generic.t option
     ; error_on_use : User_message.t option
     ; warn_on_load : User_message.t option
     }
@@ -109,7 +109,9 @@ module Stanza = struct
     && Ordered_set_lang.Unexpanded.equal menhir_flags t.menhir_flags
     && Odoc.equal odoc t.odoc
     && Ordered_set_lang.Unexpanded.equal coq t.coq
-    && Option.equal Format_config.equal format_config t.format_config
+    && Option.equal
+         (Format_config.Generic.equal ~files:Ordered_set_lang.equal)
+         format_config t.format_config
     && Js_of_ocaml.Env.equal js_of_ocaml t.js_of_ocaml
     && Option.equal User_message.equal error_on_use t.error_on_use
     && Option.equal User_message.equal warn_on_load t.warn_on_load
@@ -201,7 +203,10 @@ module Stanza = struct
     and+ odoc = odoc_field
     and+ js_of_ocaml = js_of_ocaml_field
     and+ coq = coq_field
-    and+ format_config = Format_config.field ~since:(2, 8) in
+    and+ format_config =
+      Format_config.Generic.field ~since:(2, 8)
+        ~files:(fields @@ field ~default:Ordered_set_lang.standard "files" Ordered_set_lang.decode)
+    in
     { flags
     ; foreign_flags
     ; link_flags

--- a/src/dune_rules/dune_env.ml
+++ b/src/dune_rules/dune_env.ml
@@ -205,7 +205,10 @@ module Stanza = struct
     and+ coq = coq_field
     and+ format_config =
       Format_config.Generic.field ~since:(2, 8)
-        ~files:(fields @@ field ~default:Ordered_set_lang.standard "files" Ordered_set_lang.decode)
+      ~default_files:Ordered_set_lang.standard
+        ~files:
+          (field ~default:Ordered_set_lang.standard "files"
+             Ordered_set_lang.decode)
     in
     { flags
     ; foreign_flags

--- a/src/dune_rules/dune_env.mli
+++ b/src/dune_rules/dune_env.mli
@@ -35,7 +35,7 @@ module Stanza : sig
     ; odoc : Odoc.t
     ; js_of_ocaml : Ordered_set_lang.Unexpanded.t Js_of_ocaml.Env.t
     ; coq : Ordered_set_lang.Unexpanded.t
-    ; format_config : Format_config.t option
+    ; format_config : Ordered_set_lang.t Format_config.Generic.t option
     ; error_on_use : User_message.t option
     ; warn_on_load : User_message.t option
     }

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2103,6 +2103,7 @@ module Copy_files = struct
     ; syntax_version
     }
 
+    (* POI *)
   let decode =
     peek_exn >>= function
     | List _ -> fields long_form

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2103,7 +2103,6 @@ module Copy_files = struct
     ; syntax_version
     }
 
-    (* POI *)
   let decode =
     peek_exn >>= function
     | List _ -> fields long_form

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -25,7 +25,7 @@ type t =
   ; odoc : Odoc.t Memo.Lazy.t
   ; js_of_ocaml : string list Action_builder.t Js_of_ocaml.Env.t Memo.Lazy.t
   ; coq : Coq.t Action_builder.t Memo.Lazy.t
-  ; format_config : Format_config.t Memo.Lazy.t
+  ; format_config : Ordered_set_lang.t Format_config.Generic.t Memo.Lazy.t
   }
 
 let scope t = t.scope

--- a/src/dune_rules/env_node.mli
+++ b/src/dune_rules/env_node.mli
@@ -54,6 +54,6 @@ val coq : t -> Coq.t Action_builder.t Memo.t
 
 val menhir_flags : t -> string list Action_builder.t
 
-val format_config : t -> Format_config.t Memo.t
+val format_config : t -> Ordered_set_lang.t Format_config.Generic.t Memo.t
 
-val set_format_config : t -> Format_config.t -> t
+val set_format_config : t -> Ordered_set_lang.t Format_config.Generic.t -> t

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -105,13 +105,13 @@ let gen_rules_output sctx (config : Ordered_set_lang.t Format_config.Generic.t)
   in
   let* () =
     let osl = Format_config.Generic.files config in
-    (let+ files = Source_tree.files_of source_dir in
-     Ordered_set_lang.eval
-       ~parse:(fun ~loc name -> Path.Source.parse_string_exn ~loc name)
-       ~eq:Path.Source.equal
-       ~standard:(Path.Source.Set.to_list files)
-       osl)
-    >>= Memo.parallel_iter ~f:setup_formatting
+    let* files =
+      let+ standard_set = Source_tree.files_of source_dir in
+      let standard = Path.Source.Set.to_list standard_set in
+      let parse ~loc name = Path.Source.parse_string_exn ~loc name in
+      Ordered_set_lang.eval ~parse ~eq:Path.Source.equal ~standard osl
+    in
+    Memo.parallel_iter ~f:setup_formatting files
   in
   let* () =
     match Format_config.includes config Dune with

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -118,6 +118,10 @@ end = struct
     let inherit_from =
       if Path.Build.equal dir (Scope.root scope) then
         let format_config = Dune_project.format_config (Scope.project scope) in
+        let format_config =
+          Format_config.Generic.set_files format_config
+            Ordered_set_lang.standard
+        in
         Memo.lazy_ (fun () ->
             let+ default_env = Memo.Lazy.force t.default_env in
             Env_node.set_format_config default_env format_config)

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -73,7 +73,8 @@ val odoc : t -> dir:Path.Build.t -> Env_node.Odoc.t Memo.t
 val coq : t -> dir:Path.Build.t -> Env_node.Coq.t Action_builder.t Memo.t
 
 (** Formatting settings in the corresponding [(env)] stanza. *)
-val format_config : t -> dir:Path.Build.t -> Format_config.t Memo.t
+val format_config :
+  t -> dir:Path.Build.t -> Ordered_set_lang.t Format_config.Generic.t Memo.t
 
 (** Dump a directory environment in a readable form *)
 val dump_env : t -> dir:Path.Build.t -> Dune_lang.t list Action_builder.t

--- a/test/blackbox-tests/test-cases/formatting-error.t
+++ b/test/blackbox-tests/test-cases/formatting-error.t
@@ -1,0 +1,27 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.5)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name l))
+  > 
+  > (env
+  >  (_
+  >   (formatting (enabled-with-typo a b c))))
+  > EOF
+
+  $ touch .ocamlformat
+
+  $ cat > a.ml << EOF
+  > let x = 1
+  > EOF
+
+  $ cp a.ml b.ml
+
+  $ dune build @fmt
+  File "dune", line 6, characters 15-32:
+  6 |   (formatting (enabled-with-typo a b c))))
+                     ^^^^^^^^^^^^^^^^^
+  Error: Unknown field enabled-with-typo
+  [1]

--- a/test/blackbox-tests/test-cases/formatting-only-files.t
+++ b/test/blackbox-tests/test-cases/formatting-only-files.t
@@ -8,7 +8,8 @@
   > 
   > (env
   >  (_
-  >   (formatting (files :standard \ a.ml))))
+  >   (formatting
+  >    (files :standard \ a.ml))))
   > EOF
 
   $ touch .ocamlformat
@@ -20,9 +21,6 @@
   $ cp a.ml b.ml
 
   $ dune build @fmt
-  File "a.ml", line 1, characters 0-0:
-  Error: Files _build/default/a.ml and _build/default/.formatted/a.ml differ.
   File "b.ml", line 1, characters 0-0:
   Error: Files _build/default/b.ml and _build/default/.formatted/b.ml differ.
   [1]
-'

--- a/test/blackbox-tests/test-cases/formatting-only-files.t
+++ b/test/blackbox-tests/test-cases/formatting-only-files.t
@@ -1,0 +1,28 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.5)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name l))
+  > 
+  > (env
+  >  (_
+  >   (formatting (files :standard \ a.ml))))
+  > EOF
+
+  $ touch .ocamlformat
+
+  $ cat > a.ml << EOF
+  > let x      =1
+  > EOF
+
+  $ cp a.ml b.ml
+
+  $ dune build @fmt
+  File "a.ml", line 1, characters 0-0:
+  Error: Files _build/default/a.ml and _build/default/.formatted/a.ml differ.
+  File "b.ml", line 1, characters 0-0:
+  Error: Files _build/default/b.ml and _build/default/.formatted/b.ml differ.
+  [1]
+'

--- a/test/blackbox-tests/test-cases/formatting-only-files.t
+++ b/test/blackbox-tests/test-cases/formatting-only-files.t
@@ -1,5 +1,5 @@
   $ cat > dune-project << EOF
-  > (lang dune 3.5)
+  > (lang dune 3.7)
   > EOF
 
   $ cat > dune << EOF


### PR DESCRIPTION
## Support `(env (formatting (files)))` in `dune` files

This extends the `(formatting)` field of env nodes with a OSL field `(files)` that controls which source files get formatted.
The goal is to disable formatting of certain files within `dune` itself, as opposed to the formatting tool (`.ocamlformat-disable` / `.ocamlformat-enable` files).

One design difficulty with this feature is that `(env)` nodes can also appear in `(dune-project)` files, but env nodes there can not talk about files, and do not have access to OSL (which is defined in `dune_rules/` whereas `dune-project` is defined in `dune_engine/`). So `Format_config` is made parametric and the `dune-project` variant gets a `unit` files field.

Another remark is that while we believe that `(env)` is the right place to configure this kind of per-directory operation, the syntax is a bit heavy for a task such as "disable formatting for a.ml":

```
(env (_ (formatting (files :standard \ a.ml))))
```

So, even if this is the right place to put this configuration, maybe we could add some lighter syntax to express this. (note that this also supports formatting a different set of files depending on the profile - maybe that's not a great thing).