### PR TITLE
refactor: path type safety

### DIFF
--- a/otherlibs/stdune/path.mli
+++ b/otherlibs/stdune/path.mli
@@ -78,6 +78,8 @@ module External : sig
   val relative : t -> string -> t
 
   val mkdir_p : ?perms:int -> t -> unit
+
+  val of_filename_relative_to_initial_cwd : string -> t
 end
 
 (** In the source section of the current workspace. *)
@@ -134,6 +136,10 @@ module Outside_build_dir : sig
     | In_source_dir of Source.t
 
   val hash : t -> int
+
+  val relative : t -> string -> t
+
+  val extend_basename : t -> suffix:string -> t
 
   val equal : t -> t -> bool
 

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -359,7 +359,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
     | Some x -> x
   in
   let findlib_config_path =
-    Memo.lazy_ ~cutoff:Path.equal (fun () ->
+    Memo.lazy_ ~cutoff:Path.External.equal (fun () ->
         let* fn = which_exn "ocamlfind" in
         (* When OCAMLFIND_CONF is set, "ocamlfind printconf" does print the
            contents of the variable, but "ocamlfind printconf conf" still prints
@@ -370,7 +370,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
         | None ->
           Memo.of_reproducible_fiber
             (Process.run_capture_line ~env Strict fn [ "printconf"; "conf" ]))
-        >>| Path.of_filename_relative_to_initial_cwd)
+        >>| Path.External.of_filename_relative_to_initial_cwd)
   in
   let create_one ~(name : Context_name.t) ~implicit ~findlib_toolchain ~host
       ~merlin =
@@ -381,7 +381,7 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
         let* path = Memo.Lazy.force findlib_config_path in
         let toolchain = Context_name.to_string toolchain in
         let context = Context_name.to_string name in
-        let+ config = Findlib.Config.load path ~toolchain ~context in
+        let+ config = Findlib.Config.load (External path) ~toolchain ~context in
         Some config
     in
     let get_tool_using_findlib_config prog =

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -113,21 +113,19 @@ module Config = struct
       ]
 
   let load path ~toolchain ~context =
-    let path = Path.extend_basename path ~suffix:".d" in
-    let conf_file = Path.relative path (toolchain ^ ".conf") in
-    let* conf_file_exists =
-      Fs_memo.file_exists (Path.as_outside_build_dir_exn conf_file)
+    let path = Path.Outside_build_dir.extend_basename path ~suffix:".d" in
+    let conf_file =
+      Path.Outside_build_dir.relative path (toolchain ^ ".conf")
     in
+    let* conf_file_exists = Fs_memo.file_exists conf_file in
     if not conf_file_exists then
       User_error.raise
         [ Pp.textf "ocamlfind toolchain %s isn't defined in %s (context: %s)"
             toolchain
-            (Path.to_string_maybe_quoted path)
+            (Path.Outside_build_dir.to_string_maybe_quoted path)
             context
         ];
-    let+ meta =
-      Meta.load ~name:None (Path.as_outside_build_dir_exn conf_file)
-    in
+    let+ meta = Meta.load ~name:None conf_file in
     { vars = String.Map.map meta.vars ~f:Rules.of_meta_rules
     ; preds = Ps.of_list [ P.make toolchain ]
     }

--- a/src/dune_rules/findlib/findlib.mli
+++ b/src/dune_rules/findlib/findlib.mli
@@ -51,7 +51,8 @@ module Config : sig
 
   val to_dyn : t -> Dyn.t
 
-  val load : Path.t -> toolchain:string -> context:string -> t Memo.t
+  val load :
+    Path.Outside_build_dir.t -> toolchain:string -> context:string -> t Memo.t
 
   val get : t -> string -> string option
 

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -10,8 +10,10 @@ requires = "bar"
 requires(ppx_driver) = "baz"
 |}
 
-let db_path =
-  Path.of_filename_relative_to_initial_cwd "../unit-tests/findlib-db"
+let db_path : Path.Outside_build_dir.t =
+  External
+    (Path.External.of_filename_relative_to_initial_cwd
+       "../unit-tests/findlib-db")
 
 let print_pkg ppf pkg =
   let info = Dune_package.Lib.info pkg in
@@ -38,7 +40,8 @@ let findlib =
     ; context_name = Context_name.of_string "default"
     }
   in
-  Memo.lazy_ (fun () -> Findlib.create ~paths:[ db_path ] ~lib_config)
+  Memo.lazy_ (fun () ->
+      Findlib.create ~paths:[ Path.outside_build_dir db_path ] ~lib_config)
 
 let resolve_pkg s =
   (let lib_name = Lib_name.of_string s in
@@ -49,7 +52,7 @@ let resolve_pkg s =
   |> Test_scheduler.(run (create ()))
 
 let elide_db_path path =
-  let prefix = Path.to_string db_path in
+  let prefix = Path.Outside_build_dir.to_string db_path in
   let path = Path.to_string path in
   String.drop_prefix_if_exists path ~prefix
 
@@ -126,7 +129,7 @@ let%expect_test _ =
 
 let conf () =
   Findlib.Config.load
-    (Path.relative db_path "../toolchain")
+    (Path.Outside_build_dir.relative db_path "../toolchain")
     ~toolchain:"tlc" ~context:"<context>"
   |> Memo.run
   |> Test_scheduler.(run (create ()))


### PR DESCRIPTION
use Path.Outside_build_dir.t for findlib config paths

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 2467264d-4ef8-45e3-9a48-dfdf9a62119f