### PR TITLE
fix: allow dump-dot-merlin in watch mode

### DIFF
--- a/bin/ocaml_merlin.ml
+++ b/bin/ocaml_merlin.ml
@@ -245,6 +245,9 @@ module Dump_dot_merlin = struct
               "The path to the folder of which the configuration should be \
                printed. Defaults to the current directory.")
     in
+    let common =
+      Common.set_print_directory common false |> Common.forbid_builds
+    in
     let config = Common.init common ~log_file:No_log_file in
     Scheduler.go ~common ~config (fun () ->
         match path with


### PR DESCRIPTION
previous, this command would wait for the lock

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 29d01307-9cff-4cf6-bc45-a6fe064e9f61