### PR TITLE
Fix status line enabled when ANSI colors are forced

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- Fix status line enabled when ANSI colors are forced. (#6503, @MisterDA)
+
 - Coq native mode is now automatically detected by Dune starting with Coq lang
   0.7. `(mode native)` has been deprecated in favour of detection from the
   configuration of Coq. (#6409, @Alizter)

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -162,7 +162,7 @@ let init ?log_file c =
   in
   let config =
     Dune_config.adapt_display config
-      ~output_is_a_tty:(Lazy.force Ansi_color.stderr_supports_color)
+      ~output_is_a_tty:(Lazy.force Ansi_color.output_is_a_tty)
   in
   Dune_config.init config;
   Dune_util.Log.init () ?file:log_file;

--- a/otherlibs/stdune/ansi_color.ml
+++ b/otherlibs/stdune/ansi_color.ml
@@ -146,6 +146,8 @@ let stdout_supports_color = lazy (supports_color Unix.stdout)
 
 let stderr_supports_color = lazy (supports_color Unix.stderr)
 
+let output_is_a_tty = lazy (Unix.isatty Unix.stderr)
+
 let rec tag_handler current_styles ppf styles pp =
   Format.pp_print_as ppf 0 (Style.escape_sequence_no_reset styles);
   Pp.to_fmt_with_tags ppf pp

--- a/otherlibs/stdune/ansi_color.mli
+++ b/otherlibs/stdune/ansi_color.mli
@@ -95,6 +95,8 @@ val stdout_supports_color : bool Lazy.t
 
 val stderr_supports_color : bool Lazy.t
 
+val output_is_a_tty : bool Lazy.t
+
 (** Filter out escape sequences in a string *)
 val strip : string -> string
 


### PR DESCRIPTION
We want to enable the status line if and only if stderr is a tty. ANSI color usage was tweaked in 3.6.0 with #6340 to allow users to force colors. As status line activation actually depended on whether ANSI colors were enabled or not, this change had the side effect to always enable the status line even when ANSI colors were requested for something that's not a tty.

Fix this by exposing a simple lazy wrapper of `Unix.isatty` to use instead of `Ansi_color.stderr_supports_color`.