### PR TITLE
refactor: findlib path type safety

### DIFF
--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -505,7 +505,7 @@ module Sanitize_for_tests = struct
     let really_sanitize (context : Context.t) items =
       let rename_path =
         let findlib_paths =
-          context.findlib_paths |> List.map ~f:Path.to_string
+          context.findlib_paths |> List.map ~f:Path.Outside_build_dir.to_string
         in
         function
         (* we have found a path for OCaml's root: let's define the renaming

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -118,7 +118,7 @@ type t =
   ; ocamlmklib : Action.Prog.t
   ; ocamlobjinfo : Action.Prog.t
   ; env : Env.t
-  ; findlib_paths : Path.t list
+  ; findlib_paths : Path.Outside_build_dir.t list
   ; findlib_toolchain : Context_name.t option
   ; default_ocamlpath : Path.t list
   ; arch_sixtyfour : bool
@@ -159,7 +159,7 @@ let to_dyn t : Dyn.t =
     ; ("ocamldep", Action.Prog.to_dyn t.ocamldep)
     ; ("ocamlmklib", Action.Prog.to_dyn t.ocamlmklib)
     ; ("env", Env.to_dyn (Env.diff t.env Env.initial))
-    ; ("findlib_paths", list path t.findlib_paths)
+    ; ("findlib_paths", list Path.Outside_build_dir.to_dyn t.findlib_paths)
     ; ("arch_sixtyfour", Bool t.arch_sixtyfour)
     ; ( "natdynlink_supported"
       , Bool (Dynlink_supported.By_the_os.get t.lib_config.natdynlink_supported)
@@ -493,7 +493,9 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
         stdlib_dir :: default_ocamlpath
       else default_ocamlpath
     in
-    let findlib_paths = ocamlpath @ default_ocamlpath in
+    let findlib_paths =
+      List.map ~f:Path.as_outside_build_dir_exn (ocamlpath @ default_ocamlpath)
+    in
     let env =
       (* See comment in ansi_color.ml for setup_env_for_colors. For versions
          where OCAML_COLOR is not supported, but 'color' is in OCAMLPARAM, use

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -78,7 +78,7 @@ type t = private
   ; ocamlmklib : Action.Prog.t
   ; ocamlobjinfo : Action.Prog.t
   ; env : Env.t
-  ; findlib_paths : Path.t list
+  ; findlib_paths : Path.Outside_build_dir.t list
   ; findlib_toolchain : Context_name.t option  (** Misc *)
   ; default_ocamlpath : Path.t list
   ; arch_sixtyfour : bool

--- a/src/dune_rules/findlib/findlib.mli
+++ b/src/dune_rules/findlib/findlib.mli
@@ -7,12 +7,13 @@ type t
 
 val meta_fn : string
 
-val create : paths:Path.t list -> lib_config:Lib_config.t -> t Memo.t
+val create :
+  paths:Path.Outside_build_dir.t list -> lib_config:Lib_config.t -> t Memo.t
 
 val lib_config : t -> Lib_config.t
 
 (** The search path for this DB *)
-val paths : t -> Path.t list
+val paths : t -> Path.Outside_build_dir.t list
 
 (** The builtins packages *)
 val builtins : t -> Meta.Simplified.t Package.Name.Map.t

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -40,8 +40,7 @@ let findlib =
     ; context_name = Context_name.of_string "default"
     }
   in
-  Memo.lazy_ (fun () ->
-      Findlib.create ~paths:[ Path.outside_build_dir db_path ] ~lib_config)
+  Memo.lazy_ (fun () -> Findlib.create ~paths:[ db_path ] ~lib_config)
 
 let resolve_pkg s =
   (let lib_name = Lib_name.of_string s in


### PR DESCRIPTION
use Path.Outside_build_dir.t for more findlib paths

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: cfd033dc-4c42-4b32-a012-b09440f47e8d