### PR TITLE
test(melange): demonstrate build failure when target dir exists

### DIFF
--- a/test/blackbox-tests/test-cases/melange/empty-entries-target-dir-exists.t
+++ b/test/blackbox-tests/test-cases/melange/empty-entries-target-dir-exists.t
@@ -1,0 +1,22 @@
+Test (entries) field can be left empty
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.6)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias melange-dist)
+  >  (target dist)
+  >  (module_system commonjs))
+  > EOF
+
+Create the dist folder
+
+  $ mkdir ./dist
+
+  $ dune build @melange-dist
+  Error: No rule found for dist/melange.js
+  -> required by alias melange-dist
+  [1]


### PR DESCRIPTION
This tests demonstrates an unintuitive error message when the `melange.emit` target directory exists. 

I'm not sure what can be done about this, perhaps @rgrinberg has ideas.