### PR TITLE
refactor: unify print dir and forbid_builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ Unreleased
   remove the `.lock` file. Also, bring the implementation of the global lock
   under Windows closer to that of Unix. (#6523, @nojb)
 
+- Remove "Entering Directory" messages for `$ dune install`. (#6513,
+  @rgrinberg)
+
 3.6.0 (2022-11-14)
 ------------------
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -80,7 +80,7 @@ let rpc t =
   | `Forbid_builds -> `Forbid_builds
   | `Allow rpc -> `Allow (Lazy.force rpc)
 
-let forbid_builds t = { t with rpc = `Forbid_builds }
+let forbid_builds t = { t with rpc = `Forbid_builds; no_print_directory = true }
 
 let signal_watcher t =
   match t.rpc with
@@ -92,8 +92,6 @@ let signal_watcher t =
 let stats t = t.stats
 
 let insignificant_changes t = t.insignificant_changes
-
-let set_print_directory t b = { t with no_print_directory = not b }
 
 let set_promote t v = { t with promote = Some v }
 

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -64,9 +64,6 @@ val term_with_default_root_is_cwd : t Cmdliner.Term.t
 
 val envs : Cmdliner.Cmd.Env.info list
 
-(** Set whether Dune should print the "Entering directory '<dir>'" message *)
-val set_print_directory : t -> bool -> t
-
 val set_promote : t -> Dune_engine.Clflags.Promote.t -> t
 
 val debug_backtraces : bool Cmdliner.Term.t

--- a/bin/ocaml_merlin.ml
+++ b/bin/ocaml_merlin.ml
@@ -207,9 +207,7 @@ let term =
              debugging purposes only and should not be considered as a stable \
              output.")
   in
-  let common =
-    Common.set_print_directory common false |> Common.forbid_builds
-  in
+  let common = Common.forbid_builds common in
   let config = Common.init common ~log_file:No_log_file in
   Scheduler.go ~common ~config (fun () ->
       match dump_config with
@@ -245,9 +243,7 @@ module Dump_dot_merlin = struct
               "The path to the folder of which the configuration should be \
                printed. Defaults to the current directory.")
     in
-    let common =
-      Common.set_print_directory common false |> Common.forbid_builds
-    in
+    let common = Common.forbid_builds common in
     let config = Common.init common ~log_file:No_log_file in
     Scheduler.go ~common ~config (fun () ->
         match path with

--- a/bin/rpc.ml
+++ b/bin/rpc.ml
@@ -8,7 +8,6 @@ let active_server () =
 
 let client_term common f =
   let common = Common.forbid_builds common in
-  let common = Common.set_print_directory common false in
   let config = Common.init ~log_file:No_log_file common in
   Scheduler.go ~common ~config f
 

--- a/otherlibs/site/test/run.t
+++ b/otherlibs/site/test/run.t
@@ -355,8 +355,6 @@ Test compiling an external plugin
   run c: registered:e,b.
 
   $ OCAMLPATH=$(pwd)/_install/lib:$OCAMLPATH dune install --root=e --prefix $(pwd)/_install 2>&1 | sed -e "/^Installing/d"
-  Entering directory 'e'
-  Leaving directory 'e'
 
   $ OCAMLPATH=_install/lib:$OCAMLPATH _install/bin/c
   run a

--- a/test/blackbox-tests/test-cases/depend-on/installed-packages.t
+++ b/test/blackbox-tests/test-cases/depend-on/installed-packages.t
@@ -20,11 +20,9 @@
   Leaving directory 'a'
 
   $ dune install --root a --prefix $PWD/prefix
-  Entering directory 'a'
   Installing $TESTCASE_ROOT/prefix/lib/a/META
   Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
   Installing $TESTCASE_ROOT/prefix/share/a/CATME
-  Leaving directory 'a'
 
   $ cat >b/dune-project <<EOF
   > (lang dune 2.9)
@@ -54,14 +52,12 @@
   Leaving directory 'a'
 
   $ dune install --root a --prefix $PWD/prefix
-  Entering directory 'a'
   Deleting $TESTCASE_ROOT/prefix/lib/a/META
   Installing $TESTCASE_ROOT/prefix/lib/a/META
   Deleting $TESTCASE_ROOT/prefix/lib/a/dune-package
   Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
   Deleting $TESTCASE_ROOT/prefix/share/a/CATME
   Installing $TESTCASE_ROOT/prefix/share/a/CATME
-  Leaving directory 'a'
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root b @runtest
   Entering directory 'b'

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -135,8 +135,7 @@ Build with "DUNE_STORE_ORIG_SOURCE_DIR=true" profile
 Install the package directly
 
   $ dune install "--prefix=$PWD/prefix" --root=a 2>&1 | grep -v "Installing"
-  Entering directory 'a'
-  Leaving directory 'a'
+  [1]
 
   $ dune_cmd cat prefix/lib/a/dune-package | grep -e 'lib/a' -e 'share/a'
     $TESTCASE_ROOT/prefix/lib/a)

--- a/test/blackbox-tests/test-cases/write-permissions.t
+++ b/test/blackbox-tests/test-cases/write-permissions.t
@@ -52,13 +52,11 @@ Check that dune >= 2.4 removes target write permissions.
   $ dune_cmd stat permissions 2.4/_build/default/foo.exe | head -c1
   5
   $ dune install --root 2.4 --prefix ./
-  Entering directory '2.4'
   Installing lib/foo/META
   Installing lib/foo/dune-package
   Installing bin/foo
   Installing bin/foo.exe
   Installing share/foo/target
-  Leaving directory '2.4'
   $ dune_cmd stat permissions 2.4/bin/foo.exe | head -c1
   7
   $ dune_cmd stat permissions 2.4/share/foo/target | head -c1


### PR DESCRIPTION
these two setting should always be set together

coincidentally, this also correctly removes the `Entering Directory` messages for install commands. This is expected as those commands do not build or print errors.