### PR TITLE
refactor: use type aliases in type signatures

### DIFF
--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -5,7 +5,7 @@ open! Import
 include module type of Action_builder0
 
 module With_targets : sig
-  type 'a build
+  type 'a build := 'a t
 
   type nonrec 'a t =
     { build : 'a t
@@ -43,7 +43,6 @@ module With_targets : sig
     val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
   end
 end
-with type 'a build := 'a t
 
 (** Add targets to an action builder, turning a target-less [Action_builder.t]
     into [Action_builder.With_targets.t]. *)

--- a/src/dune_engine/dialect.mli
+++ b/src/dune_engine/dialect.mli
@@ -41,7 +41,7 @@ val reason : t
 val ml_suffix : t -> Ml_kind.t -> string option
 
 module DB : sig
-  type dialect
+  type dialect := t
 
   type t
 
@@ -61,4 +61,3 @@ module DB : sig
 
   val builtin : t
 end
-with type dialect := t

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -191,9 +191,9 @@ module Event : sig
     | Timer of Fiber.fill
 
   module Queue : sig
-    type t
+    type event := t
 
-    type event
+    type t
 
     val create : Dune_stats.t option -> t
 
@@ -232,7 +232,6 @@ module Event : sig
 
     val yield_if_there_are_pending_events : t -> unit Fiber.t
   end
-  with type event := t
 end = struct
   type build_input_change =
     | Fs_event of Dune_file_watcher.Fs_memo_event.t

--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -226,9 +226,10 @@ module Dirs_visited : sig
 
   module Per_fn : sig
     (** Stores the directories visited per node (basename) *)
-    type t
 
-    type dirs_visited
+    type dirs_visited := t
+
+    type t
 
     val init : t
 
@@ -236,7 +237,6 @@ module Dirs_visited : sig
 
     val add : t -> dirs_visited -> string * Path.Source.t * File.t -> t
   end
-  with type dirs_visited := t
 end = struct
   type t = Path.Source.t File.Map.t
 

--- a/src/dune_engine/sub_dirs.mli
+++ b/src/dune_engine/sub_dirs.mli
@@ -15,7 +15,7 @@ module Status : sig
   end
 
   module Map : sig
-    type status
+    type status := t
 
     type 'a t =
       { data_only : 'a
@@ -29,7 +29,6 @@ module Status : sig
 
     val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
   end
-  with type status := t
 
   module Set : sig
     type t = bool Map.t

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -118,7 +118,7 @@ val describe_kind : t -> string
 module Map : Map.S with type key = t
 
 module Env : sig
-  type pform = t
+  type pform := t
 
   (** Decoding environment *)
   type t
@@ -149,4 +149,3 @@ module Env : sig
 
   val to_dyn : t -> Dyn.t
 end
-with type pform := t

--- a/src/dune_rules/foreign_language.mli
+++ b/src/dune_rules/foreign_language.mli
@@ -17,7 +17,7 @@ val proper_name : t -> string
 module Map : Map.S with type key = t
 
 module Dict : sig
-  type language
+  type language := t
 
   type 'a t =
     { c : 'a
@@ -44,7 +44,6 @@ module Dict : sig
 
   val get : 'a t -> language -> 'a
 end
-with type language := t
 
 val source_extensions : (t * (int * int)) String.Map.t
 

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -98,9 +98,9 @@ module DB : sig
   val installed : Context.t -> t Memo.t
 
   module Resolve_result : sig
-    type t
+    type db := t
 
-    type db
+    type t
 
     val not_found : t
 
@@ -110,7 +110,6 @@ module DB : sig
 
     val redirect : db option -> Loc.t * Lib_name.t -> t
   end
-  with type db := t
 
   (** Create a new library database. [resolve] is used to resolve library names
       in this database.

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -78,7 +78,7 @@ val set_pp : t -> (string list Action_builder.t * Sandbox_config.t) option -> t
 val wrapped_compat : t -> t
 
 module Name_map : sig
-  type module_
+  type module_ := t
 
   type t = module_ Module_name.Map.t
 
@@ -94,16 +94,14 @@ module Name_map : sig
 
   val add : t -> module_ -> t
 end
-with type module_ := t
 
 module Obj_map : sig
-  type module_
+  type module_ := t
 
   include Map.S with type key = module_
 
   val find_exn : 'a t -> module_ -> 'a
 end
-with type module_ := t
 
 module Obj_map_traversals : sig
   val parallel_iter : 'a Obj_map.t -> f:(t -> 'a -> unit Memo.t) -> unit Memo.t

--- a/src/dune_rules/module_name.mli
+++ b/src/dune_rules/module_name.mli
@@ -31,7 +31,7 @@ val of_local_lib_name : Loc.t * Lib_name.Local.t -> t
 val to_local_lib_name : t -> Lib_name.Local.t
 
 module Unique : sig
-  type name
+  type name := t
 
   (** We use [Unique] module names for OCaml unit names. These must be unique
       across all libraries within a given linkage, so these names often involve
@@ -65,7 +65,6 @@ module Unique : sig
 
   include Comparable_intf.S with type key := t
 end
-with type name := t
 
 val wrap : t -> with_:t -> Unique.t
 

--- a/src/dune_rules/ordered_set_lang.mli
+++ b/src/dune_rules/ordered_set_lang.mli
@@ -42,7 +42,7 @@ val field :
 val equal : t -> t -> bool
 
 module Unexpanded : sig
-  type expanded = t
+  type expanded := t
 
   type t
 
@@ -88,7 +88,6 @@ module Unexpanded : sig
   val fold_strings :
     t -> init:'a -> f:(position -> String_with_vars.t -> 'a -> 'a) -> 'a
 end
-with type expanded := t
 
 module Unordered_string :
   Ordered_set_lang_intf.Unordered_eval with type t = t and module Key := String

--- a/src/dune_rules/resolve.mli
+++ b/src/dune_rules/resolve.mli
@@ -157,7 +157,7 @@ module Option : sig
 end
 
 module Memo : sig
-  type 'a resolve
+  type 'a resolve := 'a t
 
   type 'a t = 'a resolve Memo.t
 
@@ -202,4 +202,3 @@ module Memo : sig
   (** Read the value immediately, ignoring actual errors. *)
   val peek : 'a t -> ('a, unit) result Memo.t
 end
-with type 'a resolve := 'a t

--- a/src/dune_rules/visibility.mli
+++ b/src/dune_rules/visibility.mli
@@ -11,15 +11,14 @@ val is_private : t -> bool
 val to_dyn : t -> Dyn.t
 
 module Map : sig
+  type visibility := t
+
   type 'a t =
     { public : 'a
     ; private_ : 'a
     }
 
-  type visibility
-
   val make_both : 'a -> 'a t
 
   val find : 'a t -> visibility -> 'a
 end
-with type visibility := t

--- a/src/ocaml/cm_kind.mli
+++ b/src/ocaml/cm_kind.mli
@@ -16,7 +16,7 @@ val source : t -> Ml_kind.t
 val to_dyn : t -> Dyn.t
 
 module Dict : sig
-  type cm_kind = t
+  type cm_kind := t
 
   type 'a t =
     { cmi : 'a
@@ -30,4 +30,3 @@ module Dict : sig
 
   val make_all : 'a -> 'a t
 end
-with type cm_kind := t

--- a/src/ocaml/ml_kind.mli
+++ b/src/ocaml/ml_kind.mli
@@ -18,7 +18,7 @@ val to_dyn : t -> Dyn.t
 val cmt_ext : t -> string
 
 module Dict : sig
-  type kind = t
+  type kind := t
 
   type 'a t =
     { impl : 'a
@@ -43,4 +43,3 @@ module Dict : sig
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 end
-with type kind := t

--- a/src/ocaml/mode.mli
+++ b/src/ocaml/mode.mli
@@ -31,7 +31,7 @@ val to_string : t -> string
 val to_dyn : t -> Dyn.t
 
 module Dict : sig
-  type mode = t
+  type mode := t
 
   type 'a t =
     { byte : 'a
@@ -45,7 +45,7 @@ module Dict : sig
   val to_dyn : ('a -> Dyn.t) -> 'a t -> Dyn.t
 
   module List : sig
-    type 'a dict
+    type 'a dict := 'a t
 
     type 'a t = 'a list dict
 
@@ -55,7 +55,6 @@ module Dict : sig
 
     val encode : 'a Dune_sexp.Encoder.t -> 'a t -> Dune_sexp.t list
   end
-  with type 'a dict := 'a t
 
   val get : 'a t -> mode -> 'a
 
@@ -95,11 +94,10 @@ module Dict : sig
     val iter_concurrently : t -> f:(mode -> unit Memo.t) -> unit Memo.t
   end
 end
-with type mode := t
 
 (** [Select] is a utility module that represents a mode selection. *)
 module Select : sig
-  type mode = t
+  type mode := t
 
   type nonrec t =
     | Only of t
@@ -113,14 +111,13 @@ module Select : sig
 
   val is_not_all : t -> bool
 end
-with type mode := t
 
 (** [Map] is a data-structure that can store values that are indexed by keys of
     the type [Select.t]. The key [Select.All] is meant to store values that
     apply to any mode while keys of the form [Select.Only _] designate values
     that apply to specific modes. *)
 module Map : sig
-  type mode = t
+  type mode := t
 
   include Map.S with type key = Select.t
 
@@ -143,4 +140,3 @@ module Map : sig
 
   val decode : 'a Dune_sexp.Decoder.t -> 'a Multi.t Dune_sexp.Decoder.t
 end
-with type mode := t


### PR DESCRIPTION
instead of destructive substitution

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 3ab6fc21-70d4-4f62-aad6-16c320c7f863