### PR TITLE
Fix configurator MSVC invocations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@ Unreleased
 - Remove "Entering Directory" messages for `$ dune install`. (#6513,
   @rgrinberg)
 
+- Fix configurator when using the MSVC compiler (#6538, @nojb)
+
 3.6.0 (2022-11-14)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ Unreleased
 - Remove "Entering Directory" messages for `$ dune install`. (#6513,
   @rgrinberg)
 
-- Fix configurator when using the MSVC compiler (#6538, @nojb)
+- Fix configurator when using the MSVC compiler (#6538, fixes #6537, @nojb)
 
 3.6.0 (2022-11-14)
 ------------------


### PR DESCRIPTION
When using MSVC, the output flag should be `-Fe<exe name>` and `-Fo<obj name>` instead of `-o <exe name>` and `-o <obj name>`.

Also removed some MSVC-specific logic that doesn't seem to be needed.

cc @jonahbeckford

Fixes #6537 