### PR TITLE
Call [Dune_util.Log.init] as soon as possible

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -158,6 +158,9 @@ let init ?log_file c =
   if c.root.dir <> Filename.current_dir_name then Sys.chdir c.root.dir;
   Path.set_root (normalize_path (Path.External.cwd ()));
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string c.build_dir);
+  (* Once we have the build directory set, initialise the logging. We can't do
+     this earlier, because the build log typically goes into [_build/log]. *)
+  Dune_util.Log.init () ?file:log_file;
   (* We need to print this before reading the workspace file, so that the editor
      can interpret errors in the workspace file. *)
   print_entering_message c;
@@ -173,7 +176,6 @@ let init ?log_file c =
       ~output_is_a_tty:(Lazy.force Ansi_color.output_is_a_tty)
   in
   Dune_config.init config;
-  Dune_util.Log.init () ?file:log_file;
   Dune_engine.Execution_parameters.init
     (let open Memo.O in
     let+ w = Dune_rules.Workspace.workspace () in


### PR DESCRIPTION
I somehow corrupted the digest database and hit the following exception on Dune startup:

```
Description:
  ("Fdecl.get: not set", {})
Raised at Stdune__Code_error.raise in file "code_error.ml", line 10,
  characters 30-62
Called from Stdune__Fdecl.get in file "fdecl.ml" (inlined), line 23,
  characters 13-53
Called from Dune_util__Log.t in file "log.ml" (inlined), line 41, characters
  11-22
Called from Dune_util__Log.info_user_message in file "log.ml", line 44,
  characters 8-12
Called from Dune_util__Persistent.Make.load.(fun) in file "persistent.ml",
  line 72, characters 14-345
Called from Stdune__Exn.protectx in file "exn.ml" (inlined), line 10,
  characters 8-11
Called from Stdune__Io.Make.with_file_in in file "io.ml" (inlined), line 102,
  characters 35-89
Called from Dune_util__Persistent.Make.load in file "persistent.ml", line 64,
[...]
```

This PR moves the call to `Dune_util.Log.init` as early as possible.

This fixed the build for me and I saw the following in the log:

```
# Failed to load corrupted file _build/.digest-db: input_value: truncated
# object
```