### PR TITLE
chore(nix): use nix-overlays for the slim devShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -222,6 +222,21 @@
     },
     "flake-utils_4": {
       "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
@@ -235,7 +250,7 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_6": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -407,6 +422,25 @@
         "type": "github"
       }
     },
+    "nix-overlays": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1669153672,
+        "narHash": "sha256-tixGuv26m/gFKuFPnlVFJWkOknTlgZV5lYSpOJxTpZY=",
+        "owner": "anmonteiro",
+        "repo": "nix-overlays",
+        "rev": "48403bf49f57bccf942e421f499e37bc1109231c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anmonteiro",
+        "repo": "nix-overlays",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "inputs": {
         "flake-utils": [
@@ -447,6 +481,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1669067947,
+        "narHash": "sha256-DbTlGzUSj2j+3tMJ7UwV5ExGSg1WeZ+XZq6eAGpyd40=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "802115d0227228b66b691f3b85b30b868976e8eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "802115d0227228b66b691f3b85b30b868976e8eb",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1669076005,
         "narHash": "sha256-uzMji2q9Pk3jUH+e5nEFtoOZCP4VV1PDRJRLVmriY0M=",
         "owner": "nixos",
@@ -461,7 +511,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1668681245,
         "narHash": "sha256-IH8t+b9hCfNwEvdC55UEymn8jL457Fo/hx3N/kNTZso=",
@@ -473,22 +523,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1657802959,
-        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -509,19 +543,35 @@
         "type": "github"
       }
     },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1657802959,
+        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "ocamllsp": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_4",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_5",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository"
       },
       "locked": {
-        "lastModified": 1669128077,
-        "narHash": "sha256-m0eQ1v9buGi53j8XLvQ4eJJ94U5cirFsAPIUMvOMQew=",
+        "lastModified": 1669129897,
+        "narHash": "sha256-PJN0SBJHShc+glORz8X0/jTSdMqg2/qhDYuDlrhdXto=",
         "ref": "refs/heads/master",
-        "rev": "c918e3f314d578ff2853401cd1c02026c78155c2",
-        "revCount": 1877,
+        "rev": "7bffb3a5eabd2584573476a24a909672bb5d4113",
+        "revCount": 1878,
         "submodules": true,
         "type": "git",
         "url": "https://www.github.com/ocaml/ocaml-lsp"
@@ -535,9 +585,9 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "mirage-opam-overlays": "mirage-opam-overlays",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_6",
         "opam-overlays": "opam-overlays",
         "opam-repository": [
           "ocamllsp",
@@ -562,9 +612,9 @@
     "opam-nix_2": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "mirage-opam-overlays": "mirage-opam-overlays_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "opam-overlays": "opam-overlays_2",
         "opam-repository": [
           "opam-repository"
@@ -636,11 +686,11 @@
     "opam-repository_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1669044906,
-        "narHash": "sha256-/6Zm7VIGM3uukyBQaX5tfJTAzvCbf59+0T+Laq+9Gck=",
+        "lastModified": 1669135050,
+        "narHash": "sha256-a3kRBkuRXidmxEsk6u38VmKKlPwoNaM4hgY8u+kRFdw=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "8442f8ad6d43961031c032e7d98d63312cd06b80",
+        "rev": "ab8d6d9033637382c11429e5b155148ad49127a5",
         "type": "github"
       },
       "original": {
@@ -740,7 +790,8 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "melange": "melange",
-        "nixpkgs": "nixpkgs_3",
+        "nix-overlays": "nix-overlays",
+        "nixpkgs": "nixpkgs_4",
         "ocamllsp": "ocamllsp",
         "opam-nix": "opam-nix_2",
         "opam-repository": "opam-repository_2"

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nix-overlays.url = "github:anmonteiro/nix-overlays";
     flake-utils.url = "github:numtide/flake-utils";
     ocamllsp.url = "git+https://www.github.com/ocaml/ocaml-lsp?submodules=1";
     opam-nix = {
@@ -21,6 +22,7 @@
     , ocamllsp
     , opam-repository
     , melange
+    , nix-overlays
     }@inputs:
     let package = "dune";
     in flake-utils.lib.eachDefaultSystem (system:
@@ -93,22 +95,26 @@
           buildInputs = [ ocamlformat ];
         };
 
-      devShells.slim = with pkgs.ocamlPackages; pkgs.mkShell {
-        inputsFrom = [ dune_3 ];
-        nativeBuildInputs = with pkgs; [ pkg-config nodejs-slim ];
-        buildInputs = [
-          merlin
-          ocamlformat
-          ppx_expect
-          ctypes
-          integers
-          mdx
-          cinaps
-          menhir
-          odoc
-          lwt
-        ];
-      };
+      devShells.slim =
+        let pkgs = nix-overlays.legacyPackages.${system};
+        in
+        pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [ pkg-config nodejs-slim ];
+          inputsFrom = [ pkgs.ocamlPackages.dune_3 ];
+          buildInputs = with pkgs.ocamlPackages; [
+            dune_3
+            merlin
+            ocamlformat
+            ppx_expect
+            ctypes
+            integers
+            mdx
+            cinaps
+            menhir
+            odoc
+            lwt
+          ];
+        };
 
       devShells.coq =
         pkgs.mkShell {


### PR DESCRIPTION
I noticed a few problems with the regular shell:

- every time the source tree changes, opam2nix does full resolution again and rebuilds everything
- somehow, using the `nixpkgs` input doesn't give me editor completion on the slim shell, but using `nix-overlays` as the input fixes it for me

Steps to reproduce:

```shell
$ nix develop .#slim -c zsh
$ make clean && make dev

# In another tmux window, for me
$ nix develop .#slim -c nvim
```

Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>