### PR TITLE
refactor(merlin): dump config sub command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Move `$ dune ocaml-merlin -dump-config=$dir` to `$ dune ocaml merlin
+  dump-config $dir`. (#6547, @rgrinberg)
+
 - Allow compilation rules to be impacted by `(env ..)` stanzas that modify the
   environment or set binaries. (#6527, @rgrinberg)
 

--- a/bin/ocaml_cmd.ml
+++ b/bin/ocaml_cmd.ml
@@ -9,4 +9,5 @@ let group =
     ; Ocaml_merlin.Dump_dot_merlin.command
     ; Top.command
     ; Top.module_command
+    ; Ocaml_merlin.group
     ]

--- a/bin/ocaml_merlin.mli
+++ b/bin/ocaml_merlin.mli
@@ -5,3 +5,5 @@ val command : unit Cmd.t
 module Dump_dot_merlin : sig
   val command : unit Cmd.t
 end
+
+val group : unit Cmd.t

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -558,7 +558,7 @@ purposes:
 
 ::
 
-    $ dune ocaml-merlin --dump-config
+    $ dune ocaml merlin dump-config
 
 This command prints the distinct configuration of each module present in the
 current directory. This directory must be in a Dune workspace and the project

--- a/test/blackbox-tests/test-cases/github1946.t/run.t
+++ b/test/blackbox-tests/test-cases/github1946.t/run.t
@@ -5,7 +5,7 @@ in the same dune file, but require different ppx specifications
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build @all --profile release
-  $ dune ocaml-merlin --dump-config=$PWD
+  $ dune ocaml merlin dump-config $PWD
   Usesppx1
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/github2206.t/run.t
+++ b/test/blackbox-tests/test-cases/github2206.t/run.t
@@ -1,6 +1,6 @@
 copy_files would break the generation of the preprocessing flags
   $ dune build copy_files/.merlin-conf/exe-foo
-  $ dune ocaml-merlin --dump-config=$PWD/copy_files |
+  $ dune ocaml merlin dump-config $PWD/copy_files |
   > grep -B 1 -A 0 "pp"
    (FLG
     (-pp

--- a/test/blackbox-tests/test-cases/github759.t/run.t
+++ b/test/blackbox-tests/test-cases/github759.t/run.t
@@ -2,7 +2,7 @@
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build foo.cma --profile release
-  $ dune ocaml-merlin --dump-config=$PWD
+  $ dune ocaml merlin dump-config $PWD
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -14,7 +14,7 @@
 
   $ rm -f .merlin
   $ dune build foo.cma --profile release
-  $ dune ocaml-merlin --dump-config=$PWD
+  $ dune ocaml merlin dump-config $PWD
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -26,7 +26,7 @@
 
   $ echo toto > .merlin
   $ dune build foo.cma --profile release
-  $ dune ocaml-merlin --dump-config=$PWD
+  $ dune ocaml merlin dump-config $PWD
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -15,7 +15,7 @@
 
   $ touch bar.ml $lib.ml
   $ dune build @check
-  $ dune ocaml-merlin --dump-config="$PWD" | grep -i "$lib"
+  $ dune ocaml merlin dump-config "$PWD" | grep -i "$lib"
   Foo
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
      Foo__
@@ -35,5 +35,5 @@
 
   $ touch main.ml
   $ dune build @check
-  $ dune ocaml-merlin --dump-config="$PWD" | grep -i "$target"
+  $ dune ocaml merlin dump-config "$PWD" | grep -i "$target"
     $TESTCASE_ROOT/_build/default/.output.mobjs/melange)

--- a/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/default-based-context.t/run.t
@@ -21,7 +21,7 @@ If Merlin field is absent, default context is chosen
   ..
   lib-foo
 
-  $ dune ocaml-merlin --dump-config="$PWD"
+  $ dune ocaml merlin dump-config "$PWD"
   Foo
   ((STDLIB OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)
@@ -58,7 +58,7 @@ If Merlin field is present, this context is chosen
   $ [ ! -d _build/default/.merlin-conf ] && echo "No config in default"
   No config in default
 
-  $ dune ocaml-merlin --dump-config="$PWD"
+  $ dune ocaml merlin dump-config "$PWD"
   Foo
   ((STDLIB OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/github4125.t/run.t
@@ -20,7 +20,7 @@ We call `$(opam switch show)` so that this test always uses an existing switch
   ..
   lib-foo
 
-  $ dune ocaml-merlin --dump-config="$PWD"
+  $ dune ocaml merlin dump-config "$PWD"
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-from-subdir.t/run.t
@@ -6,7 +6,7 @@ We build the project
   bar
 
 Verify that merlin configuration was generated...
-  $ dune ocaml-merlin --dump-config=$PWD
+  $ dune ocaml merlin dump-config $PWD
   Test
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -43,7 +43,7 @@ Verify that merlin configuration was generated...
      -keep-locs)))
 
 ...but not in the sub-folder whose content was copied
-  $ dune ocaml-merlin --dump-config=$PWD/411
+  $ dune ocaml merlin dump-config $PWD/411
 
 Now we check that both querying from the root and the subfolder works
   $ FILE=$PWD/foo.ml

--- a/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/merlin-tests.t/run.t
@@ -5,7 +5,7 @@
 
 CRAM sanitization
   $ dune build ./exe/.merlin-conf/exe-x --profile release
-  $ dune ocaml-merlin --dump-config=$PWD/exe
+  $ dune ocaml merlin dump-config $PWD/exe
   X
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -27,7 +27,7 @@ CRAM sanitization
    (FLG (-w -40)))
 
   $ dune build ./lib/.merlin-conf/lib-foo ./lib/.merlin-conf/lib-bar --profile release
-  $ dune ocaml-merlin --dump-config=$PWD/lib
+  $ dune ocaml merlin dump-config $PWD/lib
   File
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -102,12 +102,12 @@ CRAM sanitization
    (FLG (-open Foo -w -40)))
 
 Make sure a ppx directive is generated (if not, the [grep ppx] step fails)
-  $ dune ocaml-merlin --dump-config=$PWD/lib | grep ppx > /dev/null
+  $ dune ocaml merlin dump-config $PWD/lib | grep ppx > /dev/null
 
 Make sure pp flag is correct and variables are expanded
 
   $ dune build ./pp-with-expand/.merlin-conf/exe-foobar --profile release
-  $ dune ocaml-merlin --dump-config=$PWD/pp-with-expand
+  $ dune ocaml merlin dump-config $PWD/pp-with-expand
   Foobar
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -123,7 +123,7 @@ Make sure pp flag is correct and variables are expanded
 
 Check hash of executables names if more than one
   $ dune build ./exes/.merlin-conf/exe-x-6562915302827c6dce0630390bfa68b7
-  $ dune ocaml-merlin --dump-config=$PWD/exes
+  $ dune ocaml merlin dump-config $PWD/exes
   Y
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/per-module-pp.t/run.t
@@ -6,7 +6,7 @@
 We dump the config for Foo and Bar modules but the pp.exe preprocessor
 should appear only once since only Foo is using it.
 
-  $ dune ocaml-merlin --dump-config=$PWD
+  $ dune ocaml merlin dump-config $PWD
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
+++ b/test/blackbox-tests/test-cases/merlin/src-dirs-of-deps.t
@@ -18,7 +18,7 @@ library also has more than one src dir.
   $ export BUILD_PATH_PREFIX_MAP="/OPAM_PREFIX=$opam_prefix:$BUILD_PATH_PREFIX_MAP"
 
   $ dune build lib2/.merlin-conf/lib-lib2
-  $ dune ocaml-merlin --dump-config=$PWD/lib2
+  $ dune ocaml merlin dump-config $PWD/lib2
   Lib2
   ((STDLIB /OPAM_PREFIX)
    (EXCLUDE_QUERY_DIR)

--- a/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/suffix.t/run.t
@@ -1,5 +1,5 @@
   $ dune build @check
 
-  $ dune ocaml-merlin --dump-config=$(pwd) | grep SUFFIX
+  $ dune ocaml merlin dump-config $PWD | grep SUFFIX
    (SUFFIX ".aml .amli")
    (SUFFIX ".baml .bamli"))

--- a/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/symlinks.t/run.t
@@ -10,18 +10,18 @@ directory in these tests.
 
 Absolute path with symlinks won't match with Dune's root path in which symlinks
 are resolved:
-  $ dune ocaml-merlin --dump-config="$PWD/realsrc" --root="."
+  $ dune ocaml merlin dump-config "$PWD/realsrc" --root="."
   Path $TESTCASE_ROOT/linkroot/realsrc is not in dune workspace ($TESTCASE_ROOT/realroot).
 
 Absolute path with resolved symlinks will match with Dune's root path:
-  $ dune ocaml-merlin \
-  > --dump-config="$(pwd | sed 's/linkroot/realroot/')/realsrc" \
+  $ dune ocaml merlin \
+  > dump-config "$(pwd | sed 's/linkroot/realroot/')/realsrc" \
   > --root="." | head -n 1
   Foo
 
 
 Dune ocaml-merlin also accepts paths relative to the current directory
-  $ dune ocaml-merlin --dump-config="realsrc" --root="." | head -n 1
+  $ dune ocaml merlin dump-config "realsrc" --root="." | head -n 1
   Foo
 
   $ cd realsrc
@@ -29,6 +29,6 @@ Dune ocaml-merlin also accepts paths relative to the current directory
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
 
-  $ dune ocaml-merlin --dump-config="." --root=".." | head -n 2
+  $ dune ocaml merlin dump-config "." --root=".." | head -n 2
   Foo
   ((STDLIB /OCAMLC_WHERE)

--- a/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
+++ b/test/blackbox-tests/test-cases/merlin/unit-names-merlin-gh1233.t/run.t
@@ -4,7 +4,7 @@
   $ dune exec ./foo.exe
   42
 
-  $ dune ocaml-merlin --dump-config=$PWD
+  $ dune ocaml merlin dump-config $PWD
   Foo
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)
@@ -24,7 +24,7 @@
      -short-paths
      -keep-locs)))
 
-  $ dune ocaml-merlin --dump-config=$PWD/foo
+  $ dune ocaml merlin dump-config $PWD/foo
   Bar
   ((STDLIB /OCAMLC_WHERE)
    (EXCLUDE_QUERY_DIR)


### PR DESCRIPTION
Now dump-config is a subcommand rather than an option. That's consistent with how we handle commands everywhere else.