### PR TITLE
melange: add test for ocaml flags

### DIFF
--- a/test/blackbox-tests/test-cases/melange/ocaml-flags.t
+++ b/test/blackbox-tests/test-cases/melange/ocaml-flags.t
@@ -1,0 +1,52 @@
+Test ocamlc_flags and ocamlopt_flags fields on melange.emit stanza
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.6)
+  > (using melange 0.1)
+  > EOF
+
+Create dune file that uses ocamlc_flags
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (entries main)
+  >  (module_system commonjs)
+  >  (ocamlc_flags -w -14-26))
+  > EOF
+
+The code in main contains unused var (warning 26) and illegal backlash (warning 14)
+
+  $ cat > main.ml <<EOF
+  > let t = "\e\n" in
+  > print_endline "hello"
+  > EOF
+
+Building does not fail, warnings are silenced as melange builds reuse ocamlc flags
+
+  $ dune build output/main.js
+  $ node _build/default/output/main.js
+  hello
+
+Update dune file to use ocamlopt_flags
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (entries main)
+  >  (module_system commonjs)
+  >  (ocamlopt_flags -w -14-26))
+  > EOF
+
+Building should fail as ocamlopt flags are ignored in melange builds
+
+  $ dune build output/main.js
+  File "main.ml", line 1, characters 9-11:
+  1 | let t = "\e\n" in
+               ^^
+  Error (warning 14 [illegal-backslash]): illegal backslash escape in string.
+  File "main.ml", line 1, characters 4-5:
+  1 | let t = "\e\n" in
+          ^
+  Error (warning 26 [unused-var]): unused variable t.
+  [1]


### PR DESCRIPTION
It is useful to have a test that covers the way `ocamlc_flags` and `ocamlopt_flags` fields interact with Melange builds. This PR adds it, in addition to the existing `flags.t` test.