### PR TITLE
fix: raise when virtual library / implementations are in the same directory

### DIFF
--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -217,7 +217,7 @@ let modules t ~for_ = modules_and_obj_dir t ~for_ |> fst
 
 let find_origin (t : t) name = Module_name.Map.find t.modules.rev_map name
 
-let virtual_modules lookup_vlib vlib =
+let virtual_modules ~lookup_vlib vlib =
   let info = Lib.info vlib in
   let+ modules =
     match Option.value_exn (Lib_info.virtual_ info) with
@@ -277,7 +277,7 @@ let make_lib_modules ~dir ~libs ~lookup_vlib ~(lib : Library.t) ~modules =
       let* wrapped = Lib.wrapped resolved in
       let wrapped = Option.value_exn wrapped in
       let* main_module_name = Lib.main_module_name resolved in
-      let+ impl = Resolve.Memo.lift_memo (virtual_modules lookup_vlib vlib) in
+      let+ impl = Resolve.Memo.lift_memo (virtual_modules ~lookup_vlib vlib) in
       let kind : Modules_field_evaluator.kind = Implementation impl in
       (kind, main_module_name, wrapped)
   in
@@ -335,6 +335,7 @@ let modules_of_stanzas dune_file ~dir ~scope ~lookup_vlib ~modules =
            the library is not built. We should change this to carry the
            [Or_exn.t] a bit longer. *)
         let+ modules =
+          let lookup_vlib = lookup_vlib ~loc:lib.buildable.loc in
           make_lib_modules ~dir ~libs:(Scope.libs scope) ~lookup_vlib ~modules
             ~lib
           >>= Resolve.read_memo

--- a/src/dune_rules/ml_sources.mli
+++ b/src/dune_rules/ml_sources.mli
@@ -58,7 +58,7 @@ val make :
   -> scope:Scope.t
   -> lib_config:Lib_config.t
   -> loc:Loc.t
-  -> lookup_vlib:(dir:Path.Build.t -> t Memo.t)
+  -> lookup_vlib:(loc:Loc.t -> dir:Path.Build.t -> t Memo.t)
   -> include_subdirs:Loc.t * Dune_file.Include_subdirs.t
   -> dirs:(Path.Build.t * 'a list * String.Set.t) list
   -> t Memo.t

--- a/test/blackbox-tests/test-cases/virtual-libraries/same-directory.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/same-directory.t
@@ -12,45 +12,10 @@ Test that includes vlib and implementations all in the same folder.
   >  (virtual_modules empty))
   > EOF
   $ dune build
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("internal dependency cycle", { frames = [ ("<unnamed>", ()) ] })
-  Raised at Memo.Exec.exec_dep_node.(fun) in file "src/memo/memo.ml", line
-    1329, characters 31-64
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
-    characters 8-11
-  Re-raised at Stdune__Exn.raise_with_backtrace in file
-    "otherlibs/stdune/exn.ml", line 36, characters 27-56
-  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
-    characters 8-11
-  -> required by ("<unnamed>", ())
-  -> required by ("load-dir", In_build_dir "default")
-  -> required by ("build-alias", { dir = "default"; name = "default" })
-  -> required by ("toplevel", ())
-
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases.
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
+  File "dune", line 1, characters 0-45:
+  1 | (library
+  2 |  (name impl_one)
+  3 |  (implements vlib))
+  Error: Virtual library and its implementation(s) cannot be defined in the
+  same directory
   [1]

--- a/test/blackbox-tests/test-cases/virtual-libraries/same-directory.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/same-directory.t
@@ -1,0 +1,56 @@
+Test that includes vlib and implementations all in the same folder.
+
+  $ echo "(lang dune 3.6)" > dune-project
+
+  $ touch empty.mli
+  $ cat >dune <<EOF
+  > (library
+  >  (name impl_one)
+  >  (implements vlib))
+  > (library
+  >  (name vlib)
+  >  (virtual_modules empty))
+  > EOF
+  $ dune build
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("internal dependency cycle", { frames = [ ("<unnamed>", ()) ] })
+  Raised at Memo.Exec.exec_dep_node.(fun) in file "src/memo/memo.ml", line
+    1329, characters 31-64
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
+    characters 8-11
+  Re-raised at Stdune__Exn.raise_with_backtrace in file
+    "otherlibs/stdune/exn.ml", line 36, characters 27-56
+  Called from Fiber__Scheduler.exec in file "src/fiber/scheduler.ml", line 73,
+    characters 8-11
+  -> required by ("<unnamed>", ())
+  -> required by ("load-dir", In_build_dir "default")
+  -> required by ("build-alias", { dir = "default"; name = "default" })
+  -> required by ("toplevel", ())
+
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+  little-death that brings total obliteration.  I will fully express my cases.
+  Execution will pass over me and through me.  And when it has gone past, I
+  will unwind the stack along its path.  Where the cases are handled there will
+  be nothing.  Only I will remain.
+  [1]


### PR DESCRIPTION
This is a follow-up to https://github.com/ocaml/dune/pull/6550