### PR TITLE
coq: more resilient config query

### DIFF
--- a/src/dune_rules/coq_config.mli
+++ b/src/dune_rules/coq_config.mli
@@ -7,5 +7,7 @@ val version :
 
 val make : coqc:Action.Prog.t -> t Memo.t
 
+val make_opt : coqc:Action.Prog.t -> t Option.t Memo.t
+
 val by_name :
-  t -> string -> [> `Int of int | `Path of Path.t | `String of string ] option
+  t -> string -> [> `Int of int | `Path of Path.t | `String of string ] Option.t

--- a/src/dune_rules/coq_rules.ml
+++ b/src/dune_rules/coq_rules.ml
@@ -191,10 +191,13 @@ let select_native_mode ~sctx ~dir (buildable : Coq_stanza.Buildable.t) =
     else if buildable.coq_lang_version < (0, 7) then Memo.return Coq_mode.VoOnly
     else
       let* coqc = resolve_program sctx ~dir ~loc:buildable.loc "coqc" in
-      let+ config = Coq_config.make ~coqc in
-      match Coq_config.by_name config "coq_native_compiler_default" with
-      | Some (`String "yes") | Some (`String "ondemand") -> Coq_mode.Native
-      | _ -> Coq_mode.VoOnly)
+      let+ config = Coq_config.make_opt ~coqc in
+      match config with
+      | None -> Coq_mode.VoOnly
+      | Some config -> (
+        match Coq_config.by_name config "coq_native_compiler_default" with
+        | Some (`String "yes") | Some (`String "ondemand") -> Coq_mode.Native
+        | _ -> Coq_mode.VoOnly))
 
 let rec resolve_first lib_db = function
   | [] -> assert false


### PR DESCRIPTION
Before we were failing if for some reason `coqc --config` failed when selecting the native mode. This makes it so that if for whatever reason `coqc --config` doesn't succeed then we default to vo mode.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: b7e30052-8c48-411a-b2b1-32b3b60604f8 -->