### PR TITLE
fix(melange): always use correct env dir

### DIFF
--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -238,7 +238,7 @@ let build_cm cctx ~force_write_cmi ~precompiled_cmi ~cm_kind (m : Module.t)
          |> Scope.project |> Dune_project.dune_version
        in
        (* TODO DUNE4 get rid of the old behavior *)
-       if dune_version >= (3, 7) then dir else ctx.build_dir)
+       if dune_version >= (3, 7) || mode = Melange then dir else ctx.build_dir)
     ?loc:(CC.loc cctx)
     (let open Action_builder.With_targets.O in
     Action_builder.with_no_targets (Action_builder.paths extra_deps)


### PR DESCRIPTION
when compiling melange code, always use the directory where we're
compiling as the env node.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 1101c60f-f13e-4e07-b6f1-ad371bc4cf19