### PR TITLE
refactor: define the .bin magic path once

### DIFF
--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -2,7 +2,9 @@ open Import
 open Memo.O
 
 module Bin = struct
-  let local_bin p = Path.Build.relative p ".bin"
+  let bin_dir_basename = ".bin"
+
+  let local_bin p = Path.Build.relative p bin_dir_basename
 
   type t =
     { context : Context.t

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -3,6 +3,8 @@ open Import
 module Bin : sig
   type t
 
+  val bin_dir_basename : Filename.t
+
   (** [local_bin dir] The directory which contains the local binaries viewed by
       rules defined in [dir] *)
   val local_bin : Path.Build.t -> Path.Build.t

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -342,13 +342,11 @@ type automatic_sub_dir =
   | Formatted
   | Bin
 
-let bin_dir_basename = ".bin"
-
 let automatic_sub_dirs_map =
   String.Map.of_list_exn
     [ (Utop.utop_dir_basename, Utop)
     ; (Format_rules.formatted_dir_basename, Formatted)
-    ; (bin_dir_basename, Bin)
+    ; (Artifacts.Bin.bin_dir_basename, Bin)
     ]
 
 let gen_rules_for_automatic_sub_dir ~sctx ~dir kind =


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: aa7062b3-986e-478e-b1e0-e157d9f0382d