### PR TITLE
refactor(dune-rpc-lwt): forward compatiblity with upcoming Lwt_result

### DIFF
--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -84,8 +84,12 @@ module V1 = struct
     Where.Make
       (Fiber)
       (struct
+        let lwt_result_catch f =
+          Lwt.catch (fun () -> Lwt_result.ok (f ())) Lwt_result.fail
+
         let read_file s : (string, exn) result Lwt.t =
-          Lwt_result.catch (Lwt_io.with_file ~mode:Input s Lwt_io.read)
+          lwt_result_catch (fun () ->
+              Lwt_io.with_file ~mode:Input s Lwt_io.read)
 
         let analyze_path s =
           Lwt.try_bind

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -84,12 +84,11 @@ module V1 = struct
     Where.Make
       (Fiber)
       (struct
-        let lwt_result_catch f =
-          Lwt.catch (fun () -> Lwt_result.ok (f ())) Lwt_result.fail
-
         let read_file s : (string, exn) result Lwt.t =
-          lwt_result_catch (fun () ->
-              Lwt_io.with_file ~mode:Input s Lwt_io.read)
+          Lwt.catch
+            (fun () ->
+              Lwt_result.ok (Lwt_io.with_file ~mode:Input s Lwt_io.read))
+            Lwt_result.fail
 
         let analyze_path s =
           Lwt.try_bind


### PR DESCRIPTION
- Lwt is introducing a breaking change in `Lwt_result` in the next release (cf. https://github.com/ocsigen/lwt/pull/965).
- This change allows `dune-rpc-lwt` to be forward compatible with that change

Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>