### PR TITLE
fix: dune files from source tree

### DIFF
--- a/src/dune_engine/source_tree.mli
+++ b/src/dune_engine/source_tree.mli
@@ -13,11 +13,13 @@ module Dune_file : sig
 
   type t
 
+  val to_dyn : t -> Dyn.t
+
   val get_static_sexp : t -> Dune_lang.Ast.t list
 
   val kind : t -> kind
 
-  val path : t -> Path.Source.t
+  val path : t -> Path.Source.t option
 end
 
 module Dir : sig

--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -155,10 +155,24 @@ module Dir_map = struct
     ; subdir_status : subdir_stanzas
     }
 
+  let dyn_of_per_dir { sexps; subdir_status = _ } =
+    let open Dyn in
+    record
+      [ ( "sexps"
+        , list Dune_lang.to_dyn (List.map ~f:Dune_lang.Ast.remove_locs sexps) )
+      ]
+
   type t =
     { data : per_dir
     ; nodes : t String.Map.t
     }
+
+  let rec to_dyn { data; nodes } =
+    let open Dyn in
+    record
+      [ ("data", dyn_of_per_dir data)
+      ; ("nodes", String.Map.to_dyn to_dyn nodes)
+      ]
 
   let empty_per_dir =
     { sexps = []; subdir_status = Status.Map.init ~f:(fun _ -> None) }

--- a/src/dune_engine/sub_dirs.mli
+++ b/src/dune_engine/sub_dirs.mli
@@ -59,6 +59,12 @@ module Dir_map : sig
     ; subdir_status : subdir_stanzas
     }
 
+  val dyn_of_per_dir : per_dir -> Dyn.t
+
+  val to_dyn : t -> Dyn.t
+
+  val empty : t
+
   val descend : t -> string -> t option
 
   val sub_dirs : t -> string list

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -9,8 +9,13 @@ open Memo.O
 let loc_of_dune_file st_dir =
   Loc.in_file
     (Path.source
-       (match Source_tree.Dir.dune_file st_dir with
-       | Some d -> Source_tree.Dune_file.path d
+       (match
+          let open Option.O in
+          let* dune_file = Source_tree.Dir.dune_file st_dir in
+          (* TODO not really correct. we need to know the [(subdir ..)] that introduced this *)
+          Source_tree.Dune_file.path dune_file
+        with
+       | Some s -> s
        | None -> Path.Source.relative (Source_tree.Dir.path st_dir) "_unknown_"))
 
 type t =

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -2422,11 +2422,19 @@ module Stanzas = struct
            parse_file_includes ~stanza_parser ~context sexps
          | stanza -> Memo.return [ stanza ])
 
-  let parse ~file (project : Dune_project.t) sexps =
+  let parse ~file ~dir (project : Dune_project.t) sexps =
     let stanza_parser = parser project in
     let open Memo.O in
     let+ stanzas =
-      let context = Include_stanza.in_file file in
+      let context =
+        Include_stanza.in_file
+        @@
+        match file with
+        | Some f -> f
+        | None ->
+          (* TODO this is wrong *)
+          Path.Source.relative dir Source_tree.Dune_file.fname
+      in
       parse_file_includes ~stanza_parser ~context sexps
     in
     let (_ : bool) =
@@ -2476,7 +2484,7 @@ let is_promoted_rule version rule =
 
 let parse sexps ~dir ~file ~project =
   let open Memo.O in
-  let+ stanzas = Stanzas.parse ~file project sexps in
+  let+ stanzas = Stanzas.parse ~file ~dir project sexps in
   let stanzas =
     if !Clflags.ignore_promoted_rules then
       let version = Dune_project.dune_version project in

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -507,7 +507,7 @@ val to_dyn : t -> Dyn.t
 val parse :
      Dune_lang.Ast.t list
   -> dir:Path.Source.t
-  -> file:Path.Source.t
+  -> file:Path.Source.t option
   -> project:Dune_project.t
   -> t Memo.t
 

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -166,7 +166,7 @@ module Script = struct
     Path.build generated_dune_file
     |> Io.Untracked.with_lexbuf_from_file ~f:(Dune_lang.Parser.parse ~mode:Many)
     |> List.rev_append from_parent
-    |> Dune_file.parse ~dir ~file ~project
+    |> Dune_file.parse ~dir ~file:(Some file) ~project
 
   let eval_one =
     let module Input = struct
@@ -196,7 +196,16 @@ module Dune_files = struct
       match Source_tree.Dune_file.kind dune_file with
       | Ocaml_script ->
         Memo.return
-          (Script { script = { dir; project; file }; from_parent = static })
+          (Script
+             { script =
+                 { dir
+                 ; project
+                 ; file =
+                     (* we can't introduce ocaml syntax with [(sudir ..)] *)
+                     Option.value_exn file
+                 }
+             ; from_parent = static
+             })
       | Plain ->
         let open Memo.O in
         let+ stanzas = Dune_file.parse static ~dir ~file ~project in

--- a/src/dune_rules/format_rules.ml
+++ b/src/dune_rules/format_rules.ml
@@ -116,20 +116,22 @@ let gen_rules_output sctx (config : Format_config.t) ~version ~dialects
       | Some source_dir -> (
         match Source_tree.Dir.dune_file source_dir with
         | None -> Memo.return ()
-        | Some f ->
-          let path = Source_tree.Dune_file.path f in
-          let input_basename = Path.Source.basename path in
-          let input = Path.Build.relative dir input_basename in
-          let output = Path.Build.relative output_dir input_basename in
-          Super_context.add_rule sctx ~mode:Standard ~loc ~dir
-            (Action_builder.with_file_targets ~file_targets:[ output ]
-            @@
-            let open Action_builder.O in
-            let input = Path.build input in
-            let+ () = Action_builder.path input in
-            Action.Full.make (action ~version input output))
-          >>> add_diff sctx loc alias_formatted ~dir ~input:(Path.build input)
-                ~output))
+        | Some f -> (
+          match Source_tree.Dune_file.path f with
+          | None -> Memo.return ()
+          | Some path ->
+            let input_basename = Path.Source.basename path in
+            let input = Path.Build.relative dir input_basename in
+            let output = Path.Build.relative output_dir input_basename in
+            Super_context.add_rule sctx ~mode:Standard ~loc ~dir
+              (Action_builder.with_file_targets ~file_targets:[ output ]
+              @@
+              let open Action_builder.O in
+              let input = Path.build input in
+              let+ () = Action_builder.path input in
+              Action.Full.make (action ~version input output))
+            >>> add_diff sctx loc alias_formatted ~dir ~input:(Path.build input)
+                  ~output)))
   in
   Rules.Produce.Alias.add_deps alias_formatted (Action_builder.return ())
 


### PR DESCRIPTION
The dune file path returned by Source_tree.Dune_file is always present.
This is wrong because some dune files are generated using subdir. This
commit tweaks the API to reflect this fact and updates the rest of the
code to handle such virtual dune files.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: b2dfc4df-ea48-491c-987e-b9b3d193e597