### PR TITLE
refactor: move alias deps computation

### DIFF
--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -65,9 +65,7 @@ let interpret_deps md ~unit deps =
                     the library."
                    (Module_name.to_string main_module_name)
                ]);
-  match Modules.alias_for modules unit with
-  | None -> deps
-  | Some m -> m :: deps
+  deps
 
 let deps_of
     ({ sandbox; modules; sctx; dir; obj_dir; vimpl = _; stdlib = _ } as md)


### PR DESCRIPTION
it should be done for all modules even if we don't run ocamldep

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>