### PR TITLE
test(melange): pin mel package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ dev-depext:
 melange:
 	opam pin add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#426463a77d0b70ecf0108c98e6a86d325cd01472
 	opam pin add melange https://github.com/melange-re/melange.git#685e546e290d317a884a4d48c7835467422c6426
+	opam pin add mel https://github.com/melange-re/melange.git#685e546e290d317a884a4d48c7835467422c6426
 
 dev-deps: melange
 	opam install -y $(TEST_DEPS)


### PR DESCRIPTION
In #6504 a new test was added that relies on `rescript_syntax` command. This command belongs to `mel` package. So I think it is consistent to pin all melange packages to the same commit, as `dev-deps` is being used in ci:

https://github.com/ocaml/dune/blob/4b800bc574960e9877979ebc4dc5694eae6b0df6/.github/workflows/workflow.yml#L86

As a side note, I tried first to remove the pinning of melange packages altogether, and use opam published packages instead, but in that case the tests fail:

```
./_boot/dune.exe build @runtest-melange
File "test/blackbox-tests/test-cases/melange/mli.t/run.t", line 1, characters 0-0:
------ test/blackbox-tests/test-cases/melange/mli.t/run.t
++++++ test/blackbox-tests/test-cases/melange/mli.t/run.t.corrected
File "test/blackbox-tests/test-cases/melange/mli.t/run.t", line 3, characters 0-1:
 |Compilation using melange, with interface files
 |  $ dune build mli/x.js
-|  $ node ./_build/default/mli/x.js
-|  buy it
+|  File "lib/y.ml", line 1:
+|  Error: I/O error: lib/.lib.objs/melange/lib__Y.cmi: Permission denied
+|  [1]
```

So better stay on latest versions for now, which seem to work.

cc @anmonteiro 