### PR TITLE
refactor: move `modules: Modules.t` from `Dune_package.Lib` to `Lib_info`

### DIFF
--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -468,15 +468,12 @@ end
 include Load
 
 let modules_of_lib sctx lib =
-  let dir = Lib_info.src_dir (Lib.info lib) in
   let info = Lib.info lib in
   match Lib_info.modules info with
   | External modules -> Memo.return modules
-  | Local -> (
-    match Path.as_in_build_dir dir with
-    | None -> Memo.return None
-    | Some dir ->
-      let* t = get sctx ~dir in
-      let+ ml_sources = ocaml t in
-      let name = Lib.name lib in
-      Some (Ml_sources.modules ml_sources ~for_:(Library name)))
+  | Local ->
+    let dir = Lib_info.src_dir info |> Path.as_in_build_dir_exn in
+    let* t = get sctx ~dir in
+    let+ ml_sources = ocaml t in
+    let name = Lib.name lib in
+    Some (Ml_sources.modules ml_sources ~for_:(Library name))

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -469,10 +469,14 @@ include Load
 
 let modules_of_lib sctx lib =
   let dir = Lib_info.src_dir (Lib.info lib) in
-  match Path.as_in_build_dir dir with
-  | None -> Memo.return None
-  | Some dir ->
-    let* t = get sctx ~dir in
-    let+ ml_sources = ocaml t in
-    let name = Lib.name lib in
-    Some (Ml_sources.modules ml_sources ~for_:(Library name))
+  let info = Lib.info lib in
+  match Lib_info.modules info with
+  | External modules -> Memo.return modules
+  | Local -> (
+    match Path.as_in_build_dir dir with
+    | None -> Memo.return None
+    | Some dir ->
+      let* t = get sctx ~dir in
+      let+ ml_sources = ocaml t in
+      let name = Lib.name lib in
+      Some (Ml_sources.modules ml_sources ~for_:(Library name)))

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -988,8 +988,8 @@ module Library = struct
       ~requires ~foreign_objects ~plugins ~archives ~ppx_runtime_deps
       ~foreign_archives ~native_archives ~foreign_dll_files ~jsoo_runtime
       ~jsoo_archive ~preprocess ~enabled ~virtual_deps ~dune_version ~virtual_
-      ~entry_modules ~implements ~default_implementation ~modes ~wrapped
-      ~special_builtin_support ~exit_module ~instrumentation_backend
+      ~entry_modules ~implements ~default_implementation ~modes ~modules:Local
+      ~wrapped ~special_builtin_support ~exit_module ~instrumentation_backend
 end
 
 module Plugin = struct

--- a/src/dune_rules/dune_package.mli
+++ b/src/dune_rules/dune_package.mli
@@ -8,8 +8,6 @@ val fn : string
 module Lib : sig
   type t
 
-  val modules : t -> Modules.t option
-
   val main_module_name : t -> Module_name.t option
 
   val dir_of_name : Lib_name.t -> Path.Local.t
@@ -21,10 +19,7 @@ module Lib : sig
   val of_findlib : Path.t Lib_info.t -> t
 
   val of_dune_lib :
-       info:Path.t Lib_info.t
-    -> main_module_name:Module_name.t option
-    -> modules:Modules.t
-    -> t
+    info:Path.t Lib_info.t -> main_module_name:Module_name.t option -> t
 
   val to_dyn : t Dyn.builder
 end

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -438,6 +438,7 @@ end = struct
                         | Ok s -> Ok (Some s)
                         | Error e -> Error (User_error.E e)))))
         in
+        let modules = Lib_info.Source.External None in
         Lib_info.create ~path_kind:External ~loc ~name:t.name ~kind ~status
           ~src_dir ~orig_src_dir ~obj_dir ~version ~synopsis ~main_module_name
           ~sub_systems ~requires ~foreign_objects ~plugins ~archives
@@ -445,7 +446,7 @@ end = struct
           ~native_archives:(Files native_archives) ~foreign_dll_files:[]
           ~jsoo_runtime ~jsoo_archive ~preprocess ~enabled ~virtual_deps
           ~dune_version ~virtual_ ~implements ~default_implementation ~modes
-          ~wrapped ~special_builtin_support ~exit_module:None
+          ~modules ~wrapped ~special_builtin_support ~exit_module:None
           ~instrumentation_backend:None ~entry_modules
       in
       Dune_package.Lib.of_findlib info

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1945,7 +1945,7 @@ let to_dune_lib ({ info; _ } as lib) ~modules ~foreign_objects ~dir :
       ~foreign_objects ~obj_dir ~implements ~default_implementation ~sub_systems
       ~modules
   in
-  Dune_package.Lib.of_dune_lib ~info ~modules ~main_module_name
+  Dune_package.Lib.of_dune_lib ~info ~main_module_name
 
 module Local : sig
   type t = private lib

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -150,6 +150,8 @@ val special_builtin_support : _ t -> Special_builtin_support.t option
 
 val modes : _ t -> Lib_mode.Map.Set.t
 
+val modules : _ t -> Modules.t option Source.t
+
 val implements : _ t -> (Loc.t * Lib_name.t) option
 
 val requires : _ t -> Lib_dep.t list
@@ -236,6 +238,7 @@ val create :
   -> implements:(Loc.t * Lib_name.t) option
   -> default_implementation:(Loc.t * Lib_name.t) option
   -> modes:Lib_mode.Map.Set.t
+  -> modules:Modules.t option Source.t
   -> wrapped:Wrapped.t Inherited.t option
   -> special_builtin_support:Special_builtin_support.t option
   -> exit_module:Module_name.t option


### PR DESCRIPTION
Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>