### PR TITLE
fix: link time code gen

### DIFF
--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -315,8 +315,12 @@ let ml_source =
 
 let set_src_dir t ~src_dir = map_files t ~f:(fun _ -> File.set_src_dir ~src_dir)
 
-let generated ~(kind : Kind.t) ~src_dir name =
-  let obj_name = Module_name.Unique.of_name_assuming_needs_no_mangling name in
+let generated ?obj_name ~(kind : Kind.t) ~src_dir name =
+  let obj_name =
+    match obj_name with
+    | Some obj_name -> obj_name
+    | None -> Module_name.Unique.of_name_assuming_needs_no_mangling name
+  in
   let source =
     let impl =
       let basename = String.uncapitalize (Module_name.to_string name) in

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -130,4 +130,9 @@ val set_src_dir : t -> src_dir:Path.t -> t
 
     XXX should this return the path of the source as well? it will almost always
     be used to create the rule to generate this file *)
-val generated : kind:Kind.t -> src_dir:Path.Build.t -> Module_name.t -> t
+val generated :
+     ?obj_name:Module_name.Unique.t
+  -> kind:Kind.t
+  -> src_dir:Path.Build.t
+  -> Module_name.t
+  -> t


### PR DESCRIPTION
do not "guess" object names when generating link time modules.
Actually look up the generated module and find the object name

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 8cd946aa-9f0d-4895-8f98-9bc1320a82a1