### PR TITLE
Set CLICOLOR_FORCE=0

### DIFF
--- a/dune-file
+++ b/dune-file
@@ -48,4 +48,5 @@
  (_
   (flags :standard -alert -unstable)
   (env-vars
+   ; Workaround for #6607
    (CLICOLOR_FORCE 0))))

--- a/dune-file
+++ b/dune-file
@@ -46,4 +46,6 @@
 
 (env
  (_
-  (flags :standard -alert -unstable)))
+  (flags :standard -alert -unstable)
+  (env-vars
+   (CLICOLOR_FORCE 0))))


### PR DESCRIPTION
Since #6340 we're considering `CLICOLOR_FORCE` to determine whether stderr supports color. However this changes behavior observable from the test suite, so `CLICOLOR_FORCE=1 make test` fails (this is tracked as #6607).

The issue is that ocaml/setup-ocaml#631, this variable is set in the CI environment. So we disable it until the situation is fixed (and this variable does not have observable changes anymore).
