### PR TITLE
refactor: assume Cmdliner.Arg.conv is abstract

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -59,15 +59,15 @@ module Dep = struct
 
   let parser s =
     match parse_alias s with
-    | Some dep -> `Ok dep
+    | Some dep -> Ok dep
     | None -> (
       match
         Dune_lang.Decoder.parse dep_parser Univ_map.empty
           (Dune_lang.Parser.parse_string ~fname:"command line"
              ~mode:Dune_lang.Parser.Mode.Single s)
       with
-      | x -> `Ok x
-      | exception User_error.E msg -> `Error (User_message.to_string msg))
+      | x -> Ok x
+      | exception User_error.E msg -> Error (User_message.to_string msg))
 
   let string_of_alias ~recursive sv =
     let prefix = if recursive then "@" else "@@" in
@@ -88,7 +88,7 @@ module Dep = struct
     in
     Format.pp_print_string ppf s
 
-  let conv = (parser, printer)
+  let conv = conv' (parser, printer)
 
   let to_string_maybe_quoted t =
     String.maybe_quoted (Format.asprintf "%a" printer t)

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -419,11 +419,12 @@ let install_uninstall ~what =
   let doc = Format.asprintf "%a packages." pp_what what in
   let name_ = Arg.info [] ~docv:"PACKAGE" in
   let absolute_path =
-    ( (fun path ->
-        if Filename.is_relative path then
-          `Error "the path must be absolute to avoid ambiguity"
-        else `Ok path)
-    , snd Arg.string )
+    Arg.conv'
+      ( (fun path ->
+          if Filename.is_relative path then
+            Error "the path must be absolute to avoid ambiguity"
+          else Ok path)
+      , Arg.conv_printer Arg.string )
   in
   let term =
     let+ common = Common.term


### PR DESCRIPTION
`Cmdliner.Arg.conv` happens to be a pair of `parser` and `printer` but is marked as to be made abstract. Actually the work on completion requires making it abstract and modify it. So this PR switches to using just the public API.
