### PR TITLE
fix: declare deps for ccomp detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@ Unreleased
 
 - Fix configurator when using the MSVC compiler (#6538, fixes #6537, @nojb)
 
+- Fix missing dependencies when detecting the kind of C compiler we're using
+  (#6610, fixes #6415, @emillon)
+
 3.6.0 (2022-11-14)
 ------------------
 

--- a/src/dune_rules/cxx_rules.ml
+++ b/src/dune_rules/cxx_rules.ml
@@ -31,7 +31,7 @@ let rules ~sctx ~dir =
     [ (match Ocaml_config.ccomp_type ocfg with
       | Msvc -> A "/EP"
       | Other _ -> As [ "-E"; "-P" ])
-    ; A Path.(to_absolute_filename (build header_file))
+    ; Path (Path.build header_file)
     ]
   in
   let action =

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -116,6 +116,13 @@ With use_standard_c_and_cxx_flags = true
 
   $ [ -f _build/default/.dune/ccomp/ccomp ]
 
+(this also works with sandbox=symlink, #6415)
+
+  $ dune exec --sandbox symlink ./main.exe
+  File ".dune/ccomp/_unknown_", line 1, characters 0-0:
+  cc1: fatal error: $TESTCASE_ROOT/_build/default/.dune/ccomp/header_check.h: No such file or directory
+  compilation terminated.
+  [1]
 
 ccomp is not computed if not required
 =====================================

--- a/test/blackbox-tests/test-cases/cxx-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/cxx-flags.t/run.t
@@ -119,10 +119,10 @@ With use_standard_c_and_cxx_flags = true
 (this also works with sandbox=symlink, #6415)
 
   $ dune exec --sandbox symlink ./main.exe
-  File ".dune/ccomp/_unknown_", line 1, characters 0-0:
-  cc1: fatal error: $TESTCASE_ROOT/_build/default/.dune/ccomp/header_check.h: No such file or directory
-  compilation terminated.
-  [1]
+  2046
+  4096
+  Hello World Baz!
+  Hello World Bazexe!
 
 ccomp is not computed if not required
 =====================================


### PR DESCRIPTION
This ensures that c++ compiler can be detected even with an explicit `--sandbox`.

Fixes #6415
