### PR TITLE
feature: make `modes` field an Ordered_set_lang instance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ Unreleased
 - Add the `--display-separate-messages` flag to separate the error messages
   produced by commands with a blank line. (#6823, fixes #6158, @esope)
 
+- Accept the Ordered Set Language for the `modes` field in `library` stanzas
+  (#6611, @anmonteiro).
+
 3.7.0 (2023-02-17)
 ------------------
 

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -574,7 +574,7 @@ module Library = struct
   end
 
   module Modes = struct
-    let parser ~stanza_loc ~dune_version project =
+    let decode ~stanza_loc ~dune_version project =
       let expected_version = (3, 8) in
       if dune_version >= expected_version then
         Mode_conf.Lib.Set.decode_osl ~stanza_loc project
@@ -653,7 +653,7 @@ module Library = struct
          field "virtual_deps" (repeat (located Lib_name.decode)) ~default:[]
        and+ modes =
          field "modes"
-           (Modes.parser ~stanza_loc ~dune_version project)
+           (Modes.decode ~stanza_loc ~dune_version project)
            ~default:(Mode_conf.Lib.Set.default stanza_loc)
        and+ kind = field "kind" Lib_kind.decode ~default:Lib_kind.Normal
        and+ optional = field_b "optional"

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -557,49 +557,47 @@ module Library = struct
     let field = field_o "wrapped" (located decode)
   end
 
-  let library_mode_field ~stanza_loc ~dune_version project =
-    let default = Mode_conf.Lib.Set.default stanza_loc in
-    let ordered_mode_field ~stanza_loc project =
-      let+ modes = field_o "modes" Ordered_set_lang.decode in
-      match modes with
-      | None -> default
-      | Some modes ->
-        let modes =
-          Ordered_set_lang.eval modes
-            ~parse:(fun ~loc s ->
-              let mode =
-                Dune_lang.Decoder.parse Mode_conf.Lib.decode
-                  (Dune_project.parsing_context project)
-                  (Atom (loc, Dune_lang.Atom.of_string s))
-              in
-              (mode, Mode_conf.Kind.Requested loc))
-            ~eq:(fun (a, _) (b, _) -> Mode_conf.Lib.equal a b)
-            ~standard:[ (Ocaml Best, Mode_conf.Kind.Requested stanza_loc) ]
-        in
-        Mode_conf.Lib.Set.of_list modes
-    in
-    let expected_version = (3, 8) in
-    if dune_version >= expected_version then
-      ordered_mode_field ~stanza_loc project
-    else
-      (* Old behavior: if old parser succeeds, return that. Otherwise, if
-         parsing the ordered set language succeeds, ask the user to upgrade to
-         a supported version. Otherwise, fail with the first error. *)
-      try_
-        (field "modes"
-           (Mode_conf.Lib.Set.decode >>| fun modes -> `Old modes)
-           ~default:(`Old default))
-        (fun exn ->
+  module Modes = struct
+    let osl_mode_field ~stanza_loc project =
+      let+ modes = Ordered_set_lang.decode in
+      let modes =
+        Ordered_set_lang.eval modes
+          ~parse:(fun ~loc s ->
+            let mode =
+              Dune_lang.Decoder.parse Mode_conf.Lib.decode
+                (Dune_project.parsing_context project)
+                (Atom (loc, Dune_lang.Atom.of_string s))
+            in
+            (mode, Mode_conf.Kind.Requested loc))
+          ~eq:(fun (a, _) (b, _) -> Mode_conf.Lib.equal a b)
+          ~standard:[ (Ocaml Best, Mode_conf.Kind.Requested stanza_loc) ]
+      in
+      Mode_conf.Lib.Set.of_list modes
+
+    let field ~stanza_loc ~dune_version project =
+      let expected_version = (3, 8) in
+      field "modes"
+        ~default:(Mode_conf.Lib.Set.default stanza_loc)
+        (if dune_version >= expected_version then
+         osl_mode_field ~stanza_loc project
+        else
+          (* Old behavior: if old parser succeeds, return that. Otherwise, if
+             parsing the ordered set language succeeds, ask the user to upgrade to
+             a supported version. Otherwise, fail with the first error. *)
           try_
-            ( ordered_mode_field ~stanza_loc project >>| fun modes ->
-              if dune_version >= expected_version then `New modes else `Upgrade
-            )
-            (fun _ -> raise exn))
-      >>| function
-      | `Old modes | `New modes -> modes
-      | `Upgrade ->
-        Syntax.Error.since stanza_loc Stanza.syntax expected_version
-          ~what:"Ordered set language for modes"
+            (Mode_conf.Lib.Set.decode >>| fun modes -> `Modes modes)
+            (fun exn ->
+              try_
+                ( osl_mode_field ~stanza_loc project >>| fun modes ->
+                  if dune_version >= expected_version then `Modes modes
+                  else `Upgrade )
+                (fun _ -> raise exn))
+          >>| function
+          | `Modes modes -> modes
+          | `Upgrade ->
+            Syntax.Error.since stanza_loc Stanza.syntax expected_version
+              ~what:"Ordered set language for modes")
+  end
 
   type visibility =
     | Public of Public_lib.t
@@ -655,7 +653,7 @@ module Library = struct
          Ordered_set_lang.Unexpanded.field "c_library_flags"
        and+ virtual_deps =
          field "virtual_deps" (repeat (located Lib_name.decode)) ~default:[]
-       and+ modes = library_mode_field ~stanza_loc ~dune_version project
+       and+ modes = Modes.field ~stanza_loc ~dune_version project
        and+ kind = field "kind" Lib_kind.decode ~default:Lib_kind.Normal
        and+ optional = field_b "optional"
        and+ no_dynlink = field_b "no_dynlink"

--- a/test/blackbox-tests/test-cases/melange/promote-with-lib.t
+++ b/test/blackbox-tests/test-cases/melange/promote-with-lib.t
@@ -8,7 +8,7 @@ Test melange.emit promotion
   $ mkdir lib
   $ cat > lib/dune <<EOF
   > (library
-  >  (modes melange)
+  >  (modes :standard melange)
   >  (name mylib))
   > EOF
 
@@ -33,6 +33,11 @@ Test melange.emit promotion
   > EOF
 
   $ dune build @dist
+
+Library has `(modes :standard)` so it also builds for bytecode / native
+
+  $ dune build lib/.mylib.objs/byte/mylib.cmo
+  $ dune build lib/.mylib.objs/native/mylib.cmx
 
 Targets are promoted to the source tree
 

--- a/test/blackbox-tests/test-cases/melange/promote-with-lib.t
+++ b/test/blackbox-tests/test-cases/melange/promote-with-lib.t
@@ -32,6 +32,23 @@ Test melange.emit promotion
   >   print_endline "hello"
   > EOF
 
+Fails with an informative error message if we parsed OSL for modes
+
+  $ dune build @dist
+  File "lib/dune", line 1, characters 0-50:
+  1 | (library
+  2 |  (modes :standard melange)
+  3 |  (name mylib))
+  Error: Ordered set language for modes is only available since version 3.8 of
+  the dune language. Please update your dune-project file to have (lang dune
+  3.8).
+  [1]
+
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
   $ dune build @dist
 
 Library has `(modes :standard)` so it also builds for bytecode / native


### PR DESCRIPTION
Allows writing `(modes :standard melange)` which will be useful when converting libraries in existing repositories.

Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>