### PR TITLE
Warn if constraint is duplicate with lang dune

### DIFF
--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -58,12 +58,21 @@ module Dependency : sig
         | Var of string
     end
 
+    module Kind : sig
+      type t =
+        | Bvar of Var.t
+        | Uop of Op.t * Var.t
+        | Bop of Op.t * Var.t * Var.t
+        | And of t list
+        | Or of t list
+
+      val equal : t -> t -> bool
+    end
+
     type t =
-      | Bvar of Var.t
-      | Uop of Op.t * Var.t
-      | Bop of Op.t * Var.t * Var.t
-      | And of t list
-      | Or of t list
+      { kind : Kind.t
+      ; loc : Loc.t option
+      }
   end
 
   type t =

--- a/test/blackbox-tests/test-cases/github6597.t
+++ b/test/blackbox-tests/test-cases/github6597.t
@@ -1,0 +1,18 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.6)
+  > (generate_opam_files)
+  > (package
+  >  (allow_empty)
+  >  (name p)
+  >  (depends
+  >   (dune (>= 3.6))))
+  > EOF
+
+  $ dune build
+  File "dune-project", line 7, characters 8-16:
+  7 |   (dune (>= 3.6))))
+              ^^^^^^^^
+  Warning: This constraint is redundant with the project's (lang dune).
+
+  $ grep '>=' p.opam
+    "dune" {>= "3.6" & >= "3.6"}


### PR DESCRIPTION
Constraints are augmented with a loc to help with the error message. When a redundant constraint is computed (`>= x & >= x`), a warning is printed.

Fixes #6597
