### PR TITLE
refactor(cache): use cmdliner groups in dune cache commands

### DIFF
--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -1,85 +1,28 @@
 open Stdune
 open Import
 
-let name = "cache"
-
 (* CR-someday amokhov: Implement other commands supported by Jenga. *)
 
-let man =
-  [ `S "DESCRIPTION"
-  ; `P
-      {|Dune can share build artifacts between workspaces. Currently, the only
-        action supported by this command is `trim`, but we plan to provide more
-        functionality soon. |}
-  ; `S "ACTIONS"
-  ; `P {|$(b,trim) trim the shared cache to free space.|}
-  ; `S "EXAMPLES"
-  ; `Pre
-      {|Trimming the Dune cache to 1 GB.
-        
-        \$ dune cache trim --trimmed-size=1GB |}
-  ; `Pre
-      {|Trimming 500 MB from the Dune cache.
-        
-        \$ dune cache trim --size=500MB |}
-  ; `Blocks Common.help_secs
-  ]
+let trim =
+  let info =
+    let doc = "Trim the Dune cache" in
+    let man =
+      [ `P "Trim the Dune cache to a specified size or by a specified amount."
+      ; `S "EXAMPLES"
+      ; `Pre
+          {|Trimming the Dune cache to 1 GB.
 
-let doc = "Manage the shared cache of build artifacts"
+           \$ dune cache trim --trimmed-size=1GB |}
+      ; `Pre
+          {|Trimming 500 MB from the Dune cache.
 
-let info = Cmd.info name ~doc ~man
-
-let trim ~trimmed_size ~size =
-  Log.init_disabled ();
-  let open Result.O in
-  match
-    let+ goal =
-      match (trimmed_size, size) with
-      | Some trimmed_size, None -> Result.Ok trimmed_size
-      | None, Some size ->
-        Result.Ok (Int64.sub (Dune_cache.Trimmer.overhead_size ()) size)
-      | _ -> Result.Error "specify either --size or --trimmed-size"
+           \$ dune cache trim --size=500MB |}
+      ]
     in
-    Dune_cache.Trimmer.trim ~goal
-  with
-  | Error s -> User_error.raise [ Pp.text s ]
-  | Ok { trimmed_bytes } ->
-    User_message.print
-      (User_message.make [ Pp.textf "Freed %s" (Bytes_unit.pp trimmed_bytes) ])
-
-type mode =
-  | Trim
-  | Start_deprecated
-  | Stop_deprecated
-
-let modes =
-  [ ("start", Start_deprecated); ("stop", Stop_deprecated); ("trim", Trim) ]
-
-(* CR-someday amokhov: See https://github.com/ocaml/dune/issues/4471. *)
-
-(* We don't want to list deprecated subcommands in help. *)
-let non_deprecated_modes = [ ("trim", Trim) ]
-
-(* We do want to print a nice error message if a deprecated subcommand is
-   run. *)
-let deprecated_error () =
-  User_error.raise
-    [ Pp.text
-        "Dune no longer uses the cache daemon, and so the `start` and `stop` \
-         subcommands of `dune cache` were removed."
-    ]
-
-let term =
-  Term.ret
-  @@ let+ mode =
-       Arg.(
-         value
-         & pos 0 (some (enum modes)) None
-         & info [] ~docv:"ACTION"
-             ~doc:
-               (Printf.sprintf "The cache action to perform (%s)"
-                  (Arg.doc_alts_enum non_deprecated_modes)))
-     and+ trimmed_size =
+    Cmd.info "trim" ~doc ~man
+  in
+  Cmd.v info
+  @@ let+ trimmed_size =
        Arg.(
          value
          & opt (some bytes) None
@@ -91,9 +34,35 @@ let term =
          & opt (some bytes) None
          & info ~docv:"BYTES" [ "size" ] ~doc:"Size to trim the cache to.")
      in
-     match mode with
-     | Some Trim -> `Ok (trim ~trimmed_size ~size)
-     | Some Start_deprecated | Some Stop_deprecated -> deprecated_error ()
-     | None -> `Help (`Pager, Some name)
+     Log.init_disabled ();
+     let open Result.O in
+     match
+       let+ goal =
+         match (trimmed_size, size) with
+         | Some trimmed_size, None -> Result.Ok trimmed_size
+         | None, Some size ->
+           Result.Ok (Int64.sub (Dune_cache.Trimmer.overhead_size ()) size)
+         | _ -> Result.Error "please specify either --size or --trimmed-size"
+       in
+       Dune_cache.Trimmer.trim ~goal
+     with
+     | Error s -> User_error.raise [ Pp.text s ]
+     | Ok { trimmed_bytes } ->
+       User_message.print
+         (User_message.make
+            [ Pp.textf "Freed %s" (Bytes_unit.pp trimmed_bytes) ])
 
-let command = Cmd.v info term
+let command =
+  let info =
+    let doc = "Manage the shared cache of build artifacts" in
+    let man =
+      [ `S "DESCRIPTION"
+      ; `P
+          "Dune can share build artifacts between workspaces. Currently, the \
+           only action supported by this command is `trim`, but we plan to \
+           provide more functionality soon."
+      ]
+    in
+    Cmd.info "cache" ~doc ~man
+  in
+  Cmd.group info [ trim ]

--- a/test/blackbox-tests/test-cases/dune-cache/cache-man.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-man.t
@@ -5,39 +5,18 @@ Here we observe the documentation for the dune cache commands.
          dune-cache - Manage the shared cache of build artifacts
   
   SYNOPSIS
-         dune cache [--size=BYTES] [--trimmed-size=BYTES] [OPTION]… [ACTION]
+         dune cache COMMAND …
   
   DESCRIPTION
          Dune can share build artifacts between workspaces. Currently, the only
          action supported by this command is `trim`, but we plan to provide
-         more functionality soon. 
+         more functionality soon.
   
-  ACTIONS
-         trim trim the shared cache to free space.
-  
-  ARGUMENTS
-         ACTION
-             The cache action to perform (trim)
-  
-  OPTIONS
-         --size=BYTES
-             Size to trim the cache to.
-  
-         --trimmed-size=BYTES
-             Size to trim from the cache.
-  
-  EXAMPLES
-         Trimming the Dune cache to 1 GB.
-                 
-                 $ dune cache trim --trimmed-size=1GB 
-  
-         Trimming 500 MB from the Dune cache.
-                 
-                 $ dune cache trim --size=500MB 
+  COMMANDS
+         trim [--size=BYTES] [--trimmed-size=BYTES] [OPTION]…
+             Trim the Dune cache
   
   COMMON OPTIONS
-         These options are common to all commands.
-  
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
@@ -45,9 +24,6 @@ Here we observe the documentation for the dune cache commands.
   
          --version
              Show version information.
-  
-  MORE HELP
-         Use `dune COMMAND --help' for help on a single command.
   
   EXIT STATUS
          cache exits with the following status:
@@ -60,23 +36,9 @@ Here we observe the documentation for the dune cache commands.
   
          125 on unexpected internal errors (bugs).
   
-  BUGS
-         Check bug reports at https://github.com/ocaml/dune/issues
-  
   SEE ALSO
          dune(1)
   
-Test the error message when using removed subcommands [start] and [stop].
-
-  $ dune cache start
-  Error: Dune no longer uses the cache daemon, and so the `start` and `stop`
-  subcommands of `dune cache` were removed.
-  [1]
-
-  $ dune cache stop
-  Error: Dune no longer uses the cache daemon, and so the `start` and `stop`
-  subcommands of `dune cache` were removed.
-  [1]
 
 Man pages of the deprecated start and stop commands.
 
@@ -85,39 +47,18 @@ Man pages of the deprecated start and stop commands.
          dune-cache - Manage the shared cache of build artifacts
   
   SYNOPSIS
-         dune cache [--size=BYTES] [--trimmed-size=BYTES] [OPTION]… [ACTION]
+         dune cache COMMAND …
   
   DESCRIPTION
          Dune can share build artifacts between workspaces. Currently, the only
          action supported by this command is `trim`, but we plan to provide
-         more functionality soon. 
+         more functionality soon.
   
-  ACTIONS
-         trim trim the shared cache to free space.
-  
-  ARGUMENTS
-         ACTION
-             The cache action to perform (trim)
-  
-  OPTIONS
-         --size=BYTES
-             Size to trim the cache to.
-  
-         --trimmed-size=BYTES
-             Size to trim from the cache.
-  
-  EXAMPLES
-         Trimming the Dune cache to 1 GB.
-                 
-                 $ dune cache trim --trimmed-size=1GB 
-  
-         Trimming 500 MB from the Dune cache.
-                 
-                 $ dune cache trim --size=500MB 
+  COMMANDS
+         trim [--size=BYTES] [--trimmed-size=BYTES] [OPTION]…
+             Trim the Dune cache
   
   COMMON OPTIONS
-         These options are common to all commands.
-  
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
@@ -125,9 +66,6 @@ Man pages of the deprecated start and stop commands.
   
          --version
              Show version information.
-  
-  MORE HELP
-         Use `dune COMMAND --help' for help on a single command.
   
   EXIT STATUS
          cache exits with the following status:
@@ -139,9 +77,6 @@ Man pages of the deprecated start and stop commands.
          124 on command line parsing errors.
   
          125 on unexpected internal errors (bugs).
-  
-  BUGS
-         Check bug reports at https://github.com/ocaml/dune/issues
   
   SEE ALSO
          dune(1)
@@ -152,39 +87,18 @@ Man pages of the deprecated start and stop commands.
          dune-cache - Manage the shared cache of build artifacts
   
   SYNOPSIS
-         dune cache [--size=BYTES] [--trimmed-size=BYTES] [OPTION]… [ACTION]
+         dune cache COMMAND …
   
   DESCRIPTION
          Dune can share build artifacts between workspaces. Currently, the only
          action supported by this command is `trim`, but we plan to provide
-         more functionality soon. 
+         more functionality soon.
   
-  ACTIONS
-         trim trim the shared cache to free space.
-  
-  ARGUMENTS
-         ACTION
-             The cache action to perform (trim)
-  
-  OPTIONS
-         --size=BYTES
-             Size to trim the cache to.
-  
-         --trimmed-size=BYTES
-             Size to trim from the cache.
-  
-  EXAMPLES
-         Trimming the Dune cache to 1 GB.
-                 
-                 $ dune cache trim --trimmed-size=1GB 
-  
-         Trimming 500 MB from the Dune cache.
-                 
-                 $ dune cache trim --size=500MB 
+  COMMANDS
+         trim [--size=BYTES] [--trimmed-size=BYTES] [OPTION]…
+             Trim the Dune cache
   
   COMMON OPTIONS
-         These options are common to all commands.
-  
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
@@ -192,9 +106,6 @@ Man pages of the deprecated start and stop commands.
   
          --version
              Show version information.
-  
-  MORE HELP
-         Use `dune COMMAND --help' for help on a single command.
   
   EXIT STATUS
          cache exits with the following status:
@@ -206,9 +117,6 @@ Man pages of the deprecated start and stop commands.
          124 on command line parsing errors.
   
          125 on unexpected internal errors (bugs).
-  
-  BUGS
-         Check bug reports at https://github.com/ocaml/dune/issues
   
   SEE ALSO
          dune(1)
@@ -218,22 +126,12 @@ Testing the output of dune cache trim.
 
   $ dune cache trim --help=plain
   NAME
-         dune-cache - Manage the shared cache of build artifacts
+         dune-cache-trim - Trim the Dune cache
   
   SYNOPSIS
-         dune cache [--size=BYTES] [--trimmed-size=BYTES] [OPTION]… [ACTION]
+         dune cache trim [--size=BYTES] [--trimmed-size=BYTES] [OPTION]…
   
-  DESCRIPTION
-         Dune can share build artifacts between workspaces. Currently, the only
-         action supported by this command is `trim`, but we plan to provide
-         more functionality soon. 
-  
-  ACTIONS
-         trim trim the shared cache to free space.
-  
-  ARGUMENTS
-         ACTION
-             The cache action to perform (trim)
+         Trim the Dune cache to a specified size or by a specified amount.
   
   OPTIONS
          --size=BYTES
@@ -242,18 +140,7 @@ Testing the output of dune cache trim.
          --trimmed-size=BYTES
              Size to trim from the cache.
   
-  EXAMPLES
-         Trimming the Dune cache to 1 GB.
-                 
-                 $ dune cache trim --trimmed-size=1GB 
-  
-         Trimming 500 MB from the Dune cache.
-                 
-                 $ dune cache trim --size=500MB 
-  
   COMMON OPTIONS
-         These options are common to all commands.
-  
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
@@ -262,11 +149,8 @@ Testing the output of dune cache trim.
          --version
              Show version information.
   
-  MORE HELP
-         Use `dune COMMAND --help' for help on a single command.
-  
   EXIT STATUS
-         cache exits with the following status:
+         trim exits with the following status:
   
          0   on success.
   
@@ -276,8 +160,14 @@ Testing the output of dune cache trim.
   
          125 on unexpected internal errors (bugs).
   
-  BUGS
-         Check bug reports at https://github.com/ocaml/dune/issues
+  EXAMPLES
+         Trimming the Dune cache to 1 GB.
+         
+                    $ dune cache trim --trimmed-size=1GB 
+  
+         Trimming 500 MB from the Dune cache.
+         
+                    $ dune cache trim --size=500MB 
   
   SEE ALSO
          dune(1)

--- a/test/blackbox-tests/test-cases/dune-cache/trim.t
+++ b/test/blackbox-tests/test-cases/dune-cache/trim.t
@@ -192,3 +192,5 @@ are part of the same rule.
 
 TODO: Test trimming priority in the [copy] mode. In PR #4497 we added a test but
 it turned out to be flaky so we subsequently deleted it in #4511.
+
+


### PR DESCRIPTION
We also do some cleanup of the documentation. This will make adding more subcommands easier in the future.

The (deprecated and removed) commands start and stop have also been completely removed.

closes #4471

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 60b331a0-d183-498b-9bba-5ea3d4538fb2 -->