### PR TITLE
test: transitive deps and link time code gen

### DIFF
--- a/test/blackbox-tests/test-cases/dune
+++ b/test/blackbox-tests/test-cases/dune
@@ -140,3 +140,8 @@
  (deps
   (package stdune)
   (package ppx_expect)))
+
+(cram
+ (applies_to link-time-transitive-deps)
+ (deps
+  (package dune-build-info)))

--- a/test/blackbox-tests/test-cases/link-time-transitive-deps.t
+++ b/test/blackbox-tests/test-cases/link-time-transitive-deps.t
@@ -1,0 +1,24 @@
+Link time code generation should work with implicit transitive deps
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.0)
+  > (implicit_transitive_deps false)
+  > EOF
+
+  $ touch foo.ml bar.ml
+  $ cat >dune <<EOF
+  > (library
+  >  (libraries dune-build-info)
+  >  (modules foo)
+  >  (name foo))
+  > (executable
+  >  (modules bar)
+  >  (libraries foo)
+  >  (name bar))
+  > EOF
+
+  $ dune build ./bar.exe
+  File ".bar.eobjs/build_info_data.ml-gen", line 1:
+  Error: Could not find the .cmi file for interface
+         .bar.eobjs/build_info_data.ml-gen.
+  [1]


### PR DESCRIPTION
reproduce the issue in PR #6633

link time code generation doesn't use the correct compilation closure
for the build info module. It uses the compile closure but we should use
the link closure

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 17ab080e-5060-4f3e-9f0c-20d74b58f6ce