### PR TITLE
fix: link time code gen + implicit transtive deps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix the compilation of modules generated at link time when
+  `implicit_transitive_deps` is enabled (#6642, @rgrinberg)
+
 - Allow `$ dune utop` to load libraries defined in data only directories
   defined using `(subdir ..)` (#6631, @rgrinberg)
 

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -257,11 +257,15 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
     Ocaml.Version.supports_opaque_for_mli ctx.version
   in
   let modules = singleton_modules module_ in
+  let includes =
+    Includes.make ~project:(Scope.project cctx.scope) ~opaque ~requires
+  in
   { cctx with
     opaque
   ; flags = Ocaml_flags.empty
   ; requires_link = Memo.lazy_ (fun () -> requires)
   ; requires_compile = requires
+  ; includes
   ; modules
   }
 

--- a/test/blackbox-tests/test-cases/link-time-transitive-deps.t
+++ b/test/blackbox-tests/test-cases/link-time-transitive-deps.t
@@ -18,7 +18,3 @@ Link time code generation should work with implicit transitive deps
   > EOF
 
   $ dune build ./bar.exe
-  File ".bar.eobjs/build_info_data.ml-gen", line 1:
-  Error: Could not find the .cmi file for interface
-         .bar.eobjs/build_info_data.ml-gen.
-  [1]


### PR DESCRIPTION
correctly set the includes when computing the compilation context for
link time modules

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 80738955-dbfe-4717-b014-1d4544b2d4bc