### PR TITLE
melange: change flag directives ordering for merlin

### DIFF
--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -146,19 +146,19 @@ module Processed = struct
           ]
       in
       let flags =
-        match pp with
-        | None -> flags
-        | Some { flag; args } ->
-          make_directive "FLG"
-            (Sexp.List [ Atom (Pp_kind.to_flag flag); Atom args ])
-          :: flags
-      in
-      let flags =
         match melc_flags with
         | [] -> flags
         | melc_flags ->
           make_directive "FLG"
             (Sexp.List (List.map ~f:(fun s -> Sexp.Atom s) melc_flags))
+          :: flags
+      in
+      let flags =
+        match pp with
+        | None -> flags
+        | Some { flag; args } ->
+          make_directive "FLG"
+            (Sexp.List [ Atom (Pp_kind.to_flag flag); Atom args ])
           :: flags
       in
       match opens with

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -110,13 +110,13 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
    (S
     $TESTCASE_ROOT)
    (FLG (-open Foo))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
    (FLG
     (-ppx
      "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
      --as-ppx
      --cookie
      'library-name="foo"'"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
@@ -131,13 +131,13 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (S
     $TESTCASE_ROOT)
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
    (FLG
     (-ppx
      "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
      --as-ppx
      --cookie
      'library-name="foo"'"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -1,5 +1,7 @@
  Temporary special merlin support for melange only libs
 
+  $ ocamlc_where="$(ocamlc -where)"
+  $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
   $ melc_where="$(melc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE=$melc_where:$BUILD_PATH_PREFIX_MAP"
   $ melc_compiler="$(which melc)"
@@ -54,6 +56,8 @@ The melange.emit entry contains a ppx directive
   $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
    (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
 
+Dump-dot-merlin includes the melange flags
+
   $ dune ocaml dump-dot-merlin $PWD
   EXCLUDE_QUERY_DIR
   STDLIB /MELC_WHERE
@@ -62,3 +66,96 @@ The melange.emit entry contains a ppx directive
   # FLG -ppx '/MELC_COMPILER -as-ppx -bs-jsx 3'
   # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs
   
+
+Check for flag directives ordering when another preprocessor is defined
+
+  $ cat >fooppx.ml <<EOF
+  > open Ppxlib
+  > 
+  > let rules =
+  >   let extension =
+  >     Extension.declare "test" Expression Ast_pattern.__ (fun ~loc ~path:_ _ ->
+  >       Ast_builder.Default.eint ~loc 42)
+  >   in
+  >   [ Context_free.Rule.extension extension ]
+  > 
+  > let () = Ppxlib.Driver.register_transformation "rules" ~rules
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name $lib)
+  >  (private_modules bar)
+  >  (modules bar)
+  >  (preprocess (pps fooppx))
+  >  (modes melange))
+  > (library
+  >  (name fooppx)
+  >  (modules fooppx)
+  >  (libraries ppxlib)
+  >  (kind ppx_rewriter))
+  > EOF
+
+  $ dune build @check
+
+Melange ppx should appear after user ppx, so that Merlin applies the former first
+(the flags seem to be applied in reversed order)
+
+  $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S "
+  Bar
+  ((STDLIB /MELC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-open Foo))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="foo"'"))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs)))
+  Foo
+  ((STDLIB /MELC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.foo.objs/melange)
+   (S
+    $TESTCASE_ROOT)
+   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
+   (FLG
+    (-ppx
+     "$TESTCASE_ROOT/_build/default/.ppx/4128e43a9cfb141a37f547484cc9bf46/ppx.exe
+     --as-ppx
+     --cookie
+     'library-name="foo"'"))
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs)))
+  Fooppx
+  ((STDLIB /OCAMLC_WHERE)
+   (EXCLUDE_QUERY_DIR)
+   (B
+    $TESTCASE_ROOT/_build/default/.fooppx.objs/byte)
+   (S
+    $TESTCASE_ROOT)
+   (FLG
+    (-w
+     @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
+     -strict-sequence
+     -strict-formats
+     -short-paths
+     -keep-locs)))


### PR DESCRIPTION
This PR changes the ordering in which melange flag directive and user preprocessing directive are applied.

By inverting this order, Merlin will apply Melange ppx first, so it does not fail when encountering "melange-isms" like pipe first operator.

Tested on a couple of projects with a couple dozen files with different ppxs applied, seems Merlin integration works smoothly, modulo hovering over Melange stdlib values as reported on #6467.