### PR TITLE
melange: add test to show flags passed from env

### DIFF
--- a/test/blackbox-tests/test-cases/melange/flags.t
+++ b/test/blackbox-tests/test-cases/melange/flags.t
@@ -31,7 +31,7 @@ Building should not fail as warnings are silenced
   Error: Unknown field flags
   [1]
 
-Should use compile_flags
+Can pass flags from compile_flags field in melange.emit 
 
   $ cat > dune <<EOF
   > (melange.emit
@@ -39,6 +39,22 @@ Should use compile_flags
   >  (entries main)
   >  (module_system commonjs)
   >  (compile_flags -w -14-26))
+  > EOF
+
+  $ dune build output/main.js
+  $ node _build/default/output/main.js
+  hello
+
+Can also pass flags from env
+
+  $ cat > dune <<EOF
+  > (env
+  >  (_
+  >   (melange.compile_flags -w -14-26)))
+  > (melange.emit
+  >  (target output)
+  >  (entries main)
+  >  (module_system commonjs))
   > EOF
 
   $ dune build output/main.js


### PR DESCRIPTION
Fixes #6572. The PR just adds a test to demonstrate the functionality, but the implementation was added in #6569 inadvertently, as `Dune_env` and `Dune_file` both decode using the same function in `Ocaml_flags`:

https://github.com/ocaml/dune/blob/1798cc6a4d8fa65d6f2fddc59f848f07f0c5d2b3/src/dune_rules/dune_env.ml#L191

https://github.com/ocaml/dune/blob/1798cc6a4d8fa65d6f2fddc59f848f07f0c5d2b3/src/dune_rules/dune_file.ml#L172

Unless I'm missing something.