### PR TITLE
refactor(csexp_rpc): remove dune_engine dep

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -40,6 +40,7 @@ let local_libraries =
   ; ("src/section", Some "Dune_section", false, None)
   ; ("otherlibs/site/src/private", Some "Dune_site_private", false, None)
   ; ("src/meta_parser", Some "Dune_meta_parser", false, None)
+  ; ("src/csexp_rpc", Some "Csexp_rpc", false, None)
   ; ("src/dune_rpc_server", Some "Dune_rpc_server", false, None)
   ; ("src/thread_worker", Some "Thread_worker", false, None)
   ; ("otherlibs/ocamlc_loc/src", Some "Ocamlc_loc", false, None)
@@ -55,7 +56,6 @@ let local_libraries =
   ; ("vendor/cmdliner/src", None, false, None)
   ; ("otherlibs/build-info/src", Some "Build_info", false,
     Some "Build_info_data")
-  ; ("src/csexp_rpc", Some "Csexp_rpc", false, None)
   ; ("src/dune_rpc_impl", Some "Dune_rpc_impl", false, None)
   ]
 

--- a/src/csexp_rpc/csexp_rpc.mli
+++ b/src/csexp_rpc/csexp_rpc.mli
@@ -15,6 +15,31 @@
 
 open Stdune
 
+module type Worker = sig
+  (** [Csexp_rpc] relies on background threads for all blocking operations.
+
+      This is the signature for all the operation it needs for such background
+      threads. *)
+
+  (** A worker doing tasks in a background thread *)
+  type t
+
+  (** Create a worker doing tasks in a new background thread *)
+  val create : unit -> t Fiber.t
+
+  (** Stop the worker. Tasks that aren't yet started will not be completed. *)
+  val stop : t -> unit
+
+  (** [task t ~f] enqueue task [f] for worker [t] *)
+  val task :
+       t
+    -> f:(unit -> 'a)
+    -> ('a, [ `Exn of Exn_with_backtrace.t | `Stopped ]) result Fiber.t
+end
+
+(** Hack until we move [Dune_engine.Scheduler] into own library *)
+val worker : (module Worker) Fdecl.t
+
 module Session : sig
   (** Rpc session backed by two threads. One thread for reading, and another for
       writing *)

--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -6,7 +6,6 @@
   dyn
   dune_util
   csexp
-  dune_engine
   fiber
   (re_export unix))
  (foreign_stubs

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -28,6 +28,7 @@
   dune_util
   build_path_prefix_map
   dune_section
+  csexp_rpc
   dune_rpc_private
   dune_rpc_server
   thread_worker

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1184,6 +1184,8 @@ module Worker = struct
     | Error (`Exn e) -> Exn_with_backtrace.reraise e
 end
 
+let () = Fdecl.set Csexp_rpc.worker (module Worker)
+
 let flush_file_watcher t =
   match t.file_watcher with
   | None -> Fiber.return ()


### PR DESCRIPTION
Use an ugly forward declaration to break the dependency cycle. We need
to do this because we want to use RPC inside the engine, and this is
currently impossible because [Csexp_rpc] cannot be included.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 3700019c-b2be-4913-8f28-b85e0a6eb594