### PR TITLE
fix(rpc): improve error handling

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -290,7 +290,11 @@ module Client = struct
     let terminate_with_error t message info =
       Fiber.fork_and_join_unit
         (fun () -> terminate t)
-        (fun () -> Code_error.raise message info)
+        (fun () ->
+          (* TODO stop using code error here. If [terminate_with_error] is
+             called, it's because the other side is doing something unexpected,
+             not because we have a bug *)
+          Code_error.raise message info)
 
     let send conn (packet : Packet.Query.t list option) =
       let sexps =
@@ -702,7 +706,7 @@ module Client = struct
                 in
                 Version_negotiation.Request.to_call request
               in
-              let+ resp = request_untyped client (id, supported_versions) in
+              let* resp = request_untyped client (id, supported_versions) in
               (* we don't allow cancelling negotiation *)
               match no_cancel_raise_connection_dead id resp with
               | Error e -> raise (Response.Error.E e)
@@ -714,9 +718,9 @@ module Client = struct
                 | Error e -> raise (Abort (Invalid_session e))
                 | Ok (Selected methods) -> (
                   match Menu.of_list methods with
-                  | Ok m -> m
+                  | Ok m -> Fiber.return m
                   | Error (method_, a, b) ->
-                    Code_error.raise
+                    terminate_with_error client
                       "server responded with invalid version menu"
                       [ ( "duplicated"
                         , Dyn.Tuple [ Dyn.String method_; Dyn.Int a; Dyn.Int b ]


### PR DESCRIPTION
If version negotiation fails due to an unexpected response from the
server, we cleanly terminate the connection.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 3c00ded6-eec7-4cce-a841-40705ac99aad