### PR TITLE
refactor(rpc): group method name and version

### DIFF
--- a/otherlibs/dune-rpc/private/menu.ml
+++ b/otherlibs/dune-rpc/private/menu.ml
@@ -5,7 +5,7 @@ open Types
    as of commit [3cd240e], which the initial versioning implementation was based
    on. *)
 let compatibility_menu =
-  Method_name.Map.of_list_exn
+  Method.Name.Map.of_list_exn
     [ ("ping", 1)
     ; ("diagnostics", 1)
     ; ("shutdown", 1)
@@ -19,30 +19,30 @@ let compatibility_menu =
     ; ("notify/progress", 1)
     ]
 
-type t = Method_version.t Method_name.Map.t
+type t = Method.Version.t Method.Name.Map.t
 
 let default = compatibility_menu
 
-let find = Method_name.Map.find
+let find = Method.Name.Map.find
 
 let select_common ~local_versions ~remote_versions =
   let selected_versions =
     List.filter_map remote_versions ~f:(fun (method_, remote_versions) ->
-        let remote_versions = Method_version.Set.of_list remote_versions in
+        let remote_versions = Method.Version.Set.of_list remote_versions in
         let open Option.O in
-        let* local_versions = Method_name.Map.find local_versions method_ in
+        let* local_versions = Method.Name.Map.find local_versions method_ in
         let+ greatest_common_version =
-          Method_version.Set.max_elt
-            (Method_version.Set.inter remote_versions local_versions)
+          Method.Version.Set.max_elt
+            (Method.Version.Set.inter remote_versions local_versions)
         in
         (method_, greatest_common_version))
   in
   match selected_versions with
   | [] -> None
-  | _ :: _ -> Some (Method_name.Map.of_list_exn selected_versions)
+  | _ :: _ -> Some (Method.Name.Map.of_list_exn selected_versions)
 
-let of_list = Method_name.Map.of_list
+let of_list = Method.Name.Map.of_list
 
-let to_list = Method_name.Map.to_list
+let to_list = Method.Name.Map.to_list
 
-let to_dyn = Method_name.Map.to_dyn Int.to_dyn
+let to_dyn = Method.Name.Map.to_dyn Int.to_dyn

--- a/otherlibs/dune-rpc/private/menu.mli
+++ b/otherlibs/dune-rpc/private/menu.mli
@@ -4,19 +4,19 @@ type t
 
 val default : t
 
-val find : t -> Method_name.t -> Method_version.t option
+val find : t -> Method.Name.t -> Method.Version.t option
 
 (** For each method known by both local and remote, choose the highest common
     version number. Returns [None] if the resulting menu would be empty. *)
 val select_common :
-     local_versions:Method_version.Set.t Method_name.Map.t
-  -> remote_versions:(Method_name.t * Method_version.t list) list
+     local_versions:Method.Version.Set.t Method.Name.Map.t
+  -> remote_versions:(Method.Name.t * Method.Version.t list) list
   -> t option
 
 val of_list :
-     (Method_name.t * Method_version.t) list
-  -> (t, Method_name.t * Method_version.t * Method_version.t) result
+     (Method.Name.t * Method.Version.t) list
+  -> (t, Method.Name.t * Method.Version.t * Method.Version.t) result
 
-val to_list : t -> (Method_name.t * Method_version.t) list
+val to_list : t -> (Method.Name.t * Method.Version.t) list
 
 val to_dyn : t -> Dyn.t

--- a/otherlibs/dune-rpc/private/types.ml
+++ b/otherlibs/dune-rpc/private/types.ml
@@ -42,27 +42,29 @@ module Version = struct
     pair int int
 end
 
-module Method_name = struct
-  type t = string
+module Method = struct
+  module Name = struct
+    type t = string
 
-  let sexp : t Conv.value = Conv.string
+    let sexp : t Conv.value = Conv.string
 
-  module Map = String.Map
-  module Table = String.Table
-end
+    module Map = String.Map
+    module Table = String.Table
+  end
 
-module Method_version = struct
-  type t = int
+  module Version = struct
+    type t = int
 
-  let sexp = Conv.int
+    let sexp = Conv.int
 
-  module Set = Int.Set
-  module Map = Int.Map
+    module Set = Int.Set
+    module Map = Int.Map
+  end
 end
 
 module Call = struct
   type t =
-    { method_ : Method_name.t
+    { method_ : Method.Name.t
     ; params : Sexp.t
     }
 
@@ -76,7 +78,7 @@ module Call = struct
     let open Conv in
     let to_ (method_, params) = { method_; params } in
     let from { method_; params } = (method_, params) in
-    let method_ = field "method" (required Method_name.sexp) in
+    let method_ = field "method" (required Method.Name.sexp) in
     let params = field "params" (required sexp) in
     iso (both method_ params) to_ from
 end
@@ -388,7 +390,7 @@ end
 
 module Decl = struct
   type 'gen t =
-    { method_ : Method_name.t
+    { method_ : Method.Name.t
     ; key : 'gen Int.Map.t Univ_map.Key.t
     }
 
@@ -409,7 +411,7 @@ module Decl = struct
   end
 
   module Request = struct
-    type ('req, 'resp) gen = Method_version.t * ('req, 'resp) Generation.t
+    type ('req, 'resp) gen = Method.Version.t * ('req, 'resp) Generation.t
 
     let make_gen ~req ~resp ~upgrade_req ~downgrade_req ~upgrade_resp
         ~downgrade_resp ~version =
@@ -449,7 +451,7 @@ module Decl = struct
   end
 
   module Notification = struct
-    type 'payload gen = Method_version.t * ('payload, unit) Generation.t
+    type 'payload gen = Method.Version.t * ('payload, unit) Generation.t
 
     let make_gen (type a b) ~(conv : a Conv.value) ~(upgrade : a -> b)
         ~(downgrade : b -> a) ~version : b gen =

--- a/otherlibs/dune-rpc/private/types.mli
+++ b/otherlibs/dune-rpc/private/types.mli
@@ -30,35 +30,37 @@ module Version : sig
   val sexp : t Conv.value
 end
 
-module Method_name : sig
-  type t = string
+module Method : sig
+  module Name : sig
+    type t = string
 
-  val sexp : t Conv.value
+    val sexp : t Conv.value
 
-  module Map = String.Map
-  module Table = String.Table
-end
+    module Map = String.Map
+    module Table = String.Table
+  end
 
-module Method_version : sig
-  type t = int
+  module Version : sig
+    type t = int
 
-  val sexp : t Conv.value
+    val sexp : t Conv.value
 
-  module Set = Int.Set
-  module Map = Int.Map
+    module Set = Int.Set
+    module Map = Int.Map
+  end
 end
 
 module Call : sig
   (** Represents a single rpc call. Request or notification. *)
 
   type t =
-    { method_ : Method_name.t
+    { method_ : Method.Name.t
     ; params : Sexp.t
     }
 
   val to_dyn : t -> Dyn.t
 
-  val create : ?params:Sexp.t -> method_:Method_name.t -> unit -> t
+  val create : ?params:Sexp.t -> method_:Method.Name.t -> unit -> t
 
   val fields : (t, Conv.fields) Conv.t
 end
@@ -207,7 +209,7 @@ end
 
 module Decl : sig
   type 'gen t =
-    { method_ : Method_name.t
+    { method_ : Method.Name.t
     ; key : 'gen Int.Map.t Univ_map.Key.t
     }
 
@@ -228,7 +230,7 @@ module Decl : sig
   end
 
   module Request : sig
-    type ('req, 'resp) gen = Method_version.t * ('req, 'resp) Generation.t
+    type ('req, 'resp) gen = Method.Version.t * ('req, 'resp) Generation.t
 
     val make_gen :
          req:'wire_req Conv.value
@@ -237,13 +239,13 @@ module Decl : sig
       -> downgrade_req:('req -> 'wire_req)
       -> upgrade_resp:('wire_resp -> 'resp)
       -> downgrade_resp:('resp -> 'wire_resp)
-      -> version:Method_version.t
+      -> version:Method.Version.t
       -> ('req, 'resp) gen
 
     val make_current_gen :
          req:'req Conv.value
       -> resp:'resp Conv.value
-      -> version:Method_version.t
+      -> version:Method.Version.t
       -> ('req, 'resp) gen
 
     type ('req, 'resp) witness = ('req, 'resp) Generation.t t
@@ -254,7 +256,7 @@ module Decl : sig
       }
 
     val make :
-         method_:Method_name.t
+         method_:Method.Name.t
       -> generations:('req, 'resp) gen list
       -> ('req, 'resp) t
 
@@ -262,17 +264,17 @@ module Decl : sig
   end
 
   module Notification : sig
-    type 'payload gen = Method_version.t * ('payload, unit) Generation.t
+    type 'payload gen = Method.Version.t * ('payload, unit) Generation.t
 
     val make_gen :
          conv:'wire Conv.value
       -> upgrade:('wire -> 'model)
       -> downgrade:('model -> 'wire)
-      -> version:Method_version.t
+      -> version:Method.Version.t
       -> 'model gen
 
     val make_current_gen :
-      conv:'model Conv.value -> version:Method_version.t -> 'model gen
+      conv:'model Conv.value -> version:Method.Version.t -> 'model gen
 
     type 'payload witness = ('payload, unit) Generation.t t
 
@@ -282,7 +284,7 @@ module Decl : sig
       }
 
     val make :
-      method_:Method_name.t -> generations:'payload gen list -> 'payload t
+      method_:Method.Name.t -> generations:'payload gen list -> 'payload t
 
     val witness : 'a t -> 'a witness
   end

--- a/otherlibs/dune-rpc/private/versioned.ml
+++ b/otherlibs/dune-rpc/private/versioned.ml
@@ -39,7 +39,7 @@ let raise_version_bug ~method_ ~selected ~verb ~known =
 (* Pack a universal map key. See below. We can afford to erase the type of
    the key, because we only care about the keyset of the stored generation
    listing. *)
-type packed = T : 'a Method_version.Map.t Univ_map.Key.t -> packed
+type packed = T : 'a Method.Version.Map.t Univ_map.Key.t -> packed
 
 module Make (Fiber : Fiber_intf.S) = struct
   module Handler = struct
@@ -80,7 +80,7 @@ module Make (Fiber : Fiber_intf.S) = struct
     (* A [('req, 'resp) Decl.Generation.t] contains the information necessary to
        convert from a [Csexp.t] to a ['req]. The [_handler] packings are to
        enable storing the callbacks in a homogeneous data structure (namely, the
-       [Method_name.Table.t]. It's alright to erase these types, because these
+       [Method.Name.Table.t]. It's alright to erase these types, because these
        callbacks are intended to be used by the receiving endpoint, which only
        sees a [Csexp.t], and we only discover the correct type to deserialize to
        at runtime. *)
@@ -115,18 +115,18 @@ module Make (Fiber : Fiber_intf.S) = struct
        mapping of all known keys and their associated method names, which we use
        to construct the initial version menu, then discard. *)
     type 'state t =
-      { mutable declared_requests : packed list Method_name.Map.t * Univ_map.t
+      { mutable declared_requests : packed list Method.Name.Map.t * Univ_map.t
       ; mutable declared_notifications :
-          packed list Method_name.Map.t * Univ_map.t
+          packed list Method.Name.Map.t * Univ_map.t
       ; implemented_requests :
-          'state r_handler Method_version.Map.t Method_name.Table.t
+          'state r_handler Method.Version.Map.t Method.Name.Table.t
       ; implemented_notifications :
-          'state n_handler Method_version.Map.t Method_name.Table.t
+          'state n_handler Method.Version.Map.t Method.Name.Table.t
       }
 
     (* A [('state, 'key, 'output) field_witness] is a first-class representation
        of a field of a ['state t]. Each field is morally a mutable table holding
-       ['output Method_version.Map.t]s (mapping generation numbers to
+       ['output Method.Version.Map.t]s (mapping generation numbers to
        ['output]s), indexed by ['key]s.
 
        The mental model isn't strictly correct (mostly due to needing the "all
@@ -150,22 +150,22 @@ module Make (Fiber : Fiber_intf.S) = struct
     type (_, _, _) field_witness =
       | Declared_requests
           : ( _
-            , Method_name.t
-              * ('req, 'resp) Decl.Generation.t Method_version.Map.t
+            , Method.Name.t
+              * ('req, 'resp) Decl.Generation.t Method.Version.Map.t
                 Univ_map.Key.t
             , ('req, 'resp) Decl.Generation.t )
             field_witness
       | Declared_notifs
           : ( _
-            , Method_name.t
-              * ('a, unit) Decl.Generation.t Method_version.Map.t Univ_map.Key.t
+            , Method.Name.t
+              * ('a, unit) Decl.Generation.t Method.Version.Map.t Univ_map.Key.t
             , ('a, unit) Decl.Generation.t )
             field_witness
       | Impl_requests : ('state, string, 'state r_handler) field_witness
       | Impl_notifs : ('state, string, 'state n_handler) field_witness
 
     let get (type st a b) (t : st t) (witness : (st, a, b) field_witness)
-        (key : a) : b Method_version.Map.t option =
+        (key : a) : b Method.Version.Map.t option =
       match witness with
       | Declared_requests ->
         let _, key = key in
@@ -175,27 +175,27 @@ module Make (Fiber : Fiber_intf.S) = struct
         let _, key = key in
         let _, table = t.declared_notifications in
         Univ_map.find table key
-      | Impl_requests -> Method_name.Table.find t.implemented_requests key
-      | Impl_notifs -> Method_name.Table.find t.implemented_notifications key
+      | Impl_requests -> Method.Name.Table.find t.implemented_requests key
+      | Impl_notifs -> Method.Name.Table.find t.implemented_notifications key
 
     let set (type st a b) (t : st t) (witness : (st, a, b) field_witness)
-        (key : a) (value : b Method_version.Map.t) =
+        (key : a) (value : b Method.Version.Map.t) =
       match witness with
       | Declared_requests ->
         let name, key = key in
         let known_keys, table = t.declared_requests in
         t.declared_requests <-
-          ( Method_name.Map.add_multi known_keys name (T key)
+          ( Method.Name.Map.add_multi known_keys name (T key)
           , Univ_map.set table key value )
       | Declared_notifs ->
         let name, key = key in
         let known_keys, table = t.declared_notifications in
         t.declared_notifications <-
-          ( Method_name.Map.add_multi known_keys name (T key)
+          ( Method.Name.Map.add_multi known_keys name (T key)
           , Univ_map.set table key value )
-      | Impl_requests -> Method_name.Table.set t.implemented_requests key value
+      | Impl_requests -> Method.Name.Table.set t.implemented_requests key value
       | Impl_notifs ->
-        Method_name.Table.set t.implemented_notifications key value
+        Method.Name.Table.set t.implemented_notifications key value
 
     let registered_procedures
         { declared_requests = declared_request_keys, declared_request_table
@@ -205,11 +205,11 @@ module Make (Fiber : Fiber_intf.S) = struct
         ; implemented_notifications
         } =
       let batch_declarations which declared_keys declaration_table =
-        Method_name.Map.foldi declared_keys ~init:[] ~f:(fun name keys acc ->
+        Method.Name.Map.foldi declared_keys ~init:[] ~f:(fun name keys acc ->
             let generations =
               List.fold_left keys ~init:[] ~f:(fun acc (T key) ->
                   match Univ_map.find declaration_table key with
-                  | Some listing -> Method_version.Map.keys listing @ acc
+                  | Some listing -> Method.Version.Map.keys listing @ acc
                   | None ->
                     Code_error.raise
                       "versioning: method found in versioning table without \
@@ -229,8 +229,8 @@ module Make (Fiber : Fiber_intf.S) = struct
           declared_notification_table
       in
       let batch_implementations table =
-        Method_name.Table.foldi table ~init:[] ~f:(fun name listing acc ->
-            (name, Method_version.Map.keys listing) :: acc)
+        Method.Name.Table.foldi table ~init:[] ~f:(fun name listing acc ->
+            (name, Method.Version.Map.keys listing) :: acc)
       in
       let implemented_requests = batch_implementations implemented_requests in
       let implemented_notifications =
@@ -244,10 +244,10 @@ module Make (Fiber : Fiber_intf.S) = struct
         ]
 
     let create () =
-      let declared_requests = (Method_name.Map.empty, Univ_map.empty) in
-      let declared_notifications = (Method_name.Map.empty, Univ_map.empty) in
-      let implemented_requests = Method_name.Table.create 16 in
-      let implemented_notifications = Method_name.Table.create 16 in
+      let declared_requests = (Method.Name.Map.empty, Univ_map.empty) in
+      let declared_notifications = (Method.Name.Map.empty, Univ_map.empty) in
+      let implemented_requests = Method.Name.Table.create 16 in
+      let implemented_notifications = Method.Name.Table.create 16 in
       { declared_requests
       ; declared_notifications
       ; implemented_requests
@@ -264,23 +264,23 @@ module Make (Fiber : Fiber_intf.S) = struct
       in
       let prior_registered_generations =
         get t registry registry_key
-        |> Option.value ~default:Method_version.Map.empty
+        |> Option.value ~default:Method.Version.Map.empty
       in
       let all_generations, duplicate_generations =
         List.fold_left generations
-          ~init:(prior_registered_generations, Method_version.Set.empty)
+          ~init:(prior_registered_generations, Method.Version.Set.empty)
           ~f:(fun (acc, dups) (n, gen) ->
-            match Method_version.Map.add acc n (pack gen) with
-            | Error _ -> (acc, Method_version.Set.add dups n)
+            match Method.Version.Map.add acc n (pack gen) with
+            | Error _ -> (acc, Method.Version.Set.add dups n)
             | Ok acc' -> (acc', dups))
       in
-      if Method_version.Set.is_empty duplicate_generations then
+      if Method.Version.Set.is_empty duplicate_generations then
         set t registry registry_key all_generations
       else
         Code_error.raise
           "attempted to register duplicate generations for RPC method"
           [ ("method", Dyn.String method_)
-          ; ("duplicated", Method_version.Set.to_dyn duplicate_generations)
+          ; ("duplicated", Method.Version.Set.to_dyn duplicate_generations)
           ]
 
     let declare_request t proc =
@@ -328,11 +328,11 @@ module Make (Fiber : Fiber_intf.S) = struct
           ~method_:n.method_
           (fun e -> Fiber.return (Error (Version_error.to_response_error e)))
           (fun (handlers, version) ->
-            match Method_version.Map.find handlers version with
+            match Method.Version.Map.find handlers version with
             | None ->
               raise_version_bug ~method_:n.method_ ~selected:version
                 ~verb:"unimplemented"
-                ~known:(Method_version.Map.keys handlers)
+                ~known:(Method.Version.Map.keys handlers)
             | Some (R (f, T gen)) -> (
               match
                 Conv.of_sexp gen.req ~version:(session_version state) n.params
@@ -347,11 +347,11 @@ module Make (Fiber : Fiber_intf.S) = struct
           ~method_:n.method_
           (fun e -> Fiber.return (Error (Version_error.to_response_error e)))
           (fun (handlers, version) ->
-            match Method_version.Map.find handlers version with
+            match Method.Version.Map.find handlers version with
             | None ->
               raise_version_bug ~method_:n.method_ ~selected:version
                 ~verb:"unimplemented"
-                ~known:(Method_version.Map.keys handlers)
+                ~known:(Method.Version.Map.keys handlers)
             | Some (N (f, T gen)) -> (
               match
                 Conv.of_sexp gen.req ~version:(session_version state) n.params
@@ -368,10 +368,10 @@ module Make (Fiber : Fiber_intf.S) = struct
           ~key:(method_, decl.key) ~method_
           (fun e -> Error e)
           (fun (decls, version) ->
-            match Method_version.Map.find decls version with
+            match Method.Version.Map.find decls version with
             | None ->
               raise_version_bug ~method_ ~selected:version ~verb:"undeclared"
-                ~known:(Method_version.Map.keys decls)
+                ~known:(Method.Version.Map.keys decls)
             | Some (T gen) ->
               let encode_req (req : a) =
                 { Call.method_
@@ -393,10 +393,10 @@ module Make (Fiber : Fiber_intf.S) = struct
           ~key:(method_, decl.key) ~method_
           (fun e -> Error e)
           (fun (decls, version) ->
-            match Method_version.Map.find decls version with
+            match Method.Version.Map.find decls version with
             | None ->
               raise_version_bug ~method_ ~selected:version ~verb:"undeclared"
-                ~known:(Method_version.Map.keys decls)
+                ~known:(Method.Version.Map.keys decls)
             | Some (T gen) ->
               let encode (req : a) =
                 { Call.method_

--- a/otherlibs/dune-rpc/private/versioned.mli
+++ b/otherlibs/dune-rpc/private/versioned.mli
@@ -54,7 +54,7 @@ module Make (Fiber : Fiber_intf.S) : sig
     val create : unit -> 'state t
 
     val registered_procedures :
-      'a t -> (Method_name.t * Method_version.t list) list
+      'a t -> (Method.Name.t * Method.Version.t list) list
 
     (** A *declaration* of a procedure is a claim that this side of the session
         is able to *initiate* that procedure. Correspondingly, *implementing* a


### PR DESCRIPTION
Method.Name and Method.Version instead of Method_name and Method_version

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 14d0884d-2343-4dee-a6a4-a2d0d62fa173