### PR TITLE
feature(dune-rpc): bidirectional communication

### DIFF
--- a/otherlibs/dune-rpc/private/conv.ml
+++ b/otherlibs/dune-rpc/private/conv.ml
@@ -452,3 +452,5 @@ let required x = Required x
 let optional x = Optional x
 
 let fdecl x = Fdecl x
+
+let error e = raise (Of_sexp e)

--- a/otherlibs/dune-rpc/private/conv.mli
+++ b/otherlibs/dune-rpc/private/conv.mli
@@ -131,6 +131,8 @@ type error =
       ; payload : (string * Sexp.t) list
       }
 
+val error : error -> 'a
+
 val dyn_of_error : error -> Dyn.t
 
 val to_sexp : ('a, values) t -> 'a -> Sexp.t

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -400,21 +400,12 @@ module Client : sig
 end
 
 module Packet : sig
-  module Reply : sig
-    type t =
-      | Response of (Id.t * Response.t)
-      | Notification of Call.t
+  type t =
+    | Request of Request.t
+    | Response of (Id.t * Response.t)
+    | Notification of Call.t
 
-    val sexp : t Conv.value
-  end
-
-  module Query : sig
-    type t =
-      | Request of Request.t
-      | Notification of Call.t
-
-    val sexp : t Conv.value
-  end
+  val sexp : t Conv.value
 end
 
 module Version : sig

--- a/otherlibs/dune-rpc/private/types.mli
+++ b/otherlibs/dune-rpc/private/types.mli
@@ -190,21 +190,12 @@ module Persistent : sig
 end
 
 module Packet : sig
-  module Query : sig
-    type t =
-      | Request of Request.t
-      | Notification of Call.t
+  type t =
+    | Request of Request.t
+    | Response of (Id.t * Response.t)
+    | Notification of Call.t
 
-    val sexp : t Conv.value
-  end
-
-  module Reply : sig
-    type t =
-      | Response of (Id.t * Response.t)
-      | Notification of Call.t
-
-    val sexp : t Conv.value
-  end
+  val sexp : t Conv.value
 end
 
 module Decl : sig

--- a/src/dune_rpc_server/dune_rpc_server.ml
+++ b/src/dune_rpc_server/dune_rpc_server.ml
@@ -43,9 +43,9 @@ module Session = struct
 
   module Stage1 = struct
     type 'a t =
-      { queries : Packet.Query.t Fiber.Stream.In.t
+      { queries : Packet.t Fiber.Stream.In.t
       ; id : Id.t
-      ; send : Packet.Reply.t list option -> unit Fiber.t
+      ; send : Packet.t list option -> unit Fiber.t
       ; pool : Fiber.Pool.t
       ; mutable state : 'a state
       ; mutable on_upgrade : (Menu.t -> unit) option
@@ -325,18 +325,16 @@ module H = struct
     let open Fiber.O in
     let* () =
       Fiber.Stream.In.parallel_iter (Session.queries session)
-        ~f:(fun (message : Packet.Query.t) ->
-          let meth_ =
-            match message with
-            | Notification c | Request (_, c) -> c.method_
-          in
+        ~f:(fun (message : Packet.t) ->
           match message with
+          | Response _ ->
+            Code_error.raise "the server is unable to make requests yet" []
           | Notification n ->
             Fiber.Pool.task session.base.pool
-              ~f:(dispatch_notification t stats session meth_ n)
+              ~f:(dispatch_notification t stats session n.method_ n)
           | Request (id, r) ->
             Fiber.Pool.task session.base.pool
-              ~f:(dispatch_request t stats session meth_ r id))
+              ~f:(dispatch_request t stats session r.method_ r id))
     in
     let* () = Session.request_close session in
     let+ () = t.base.on_terminate session in
@@ -349,7 +347,10 @@ module H = struct
     match query with
     | None -> session.send None
     | Some client_versions -> (
-      match (client_versions : Packet.Query.t) with
+      match (client_versions : Packet.t) with
+      | Response _ ->
+        abort session
+          ~message:"Response unexpected. No requests before negotiation"
       | Notification _ ->
         abort session
           ~message:
@@ -384,7 +385,9 @@ module H = struct
     match query with
     | None -> session.send None
     | Some init -> (
-      match (init : Packet.Query.t) with
+      match (init : Packet.t) with
+      | Response _ ->
+        abort session ~message:"Response unexpected. You must initialize first."
       | Notification _ ->
         abort session
           ~message:"Notification unexpected. You must initialize first."
@@ -568,13 +571,13 @@ struct
     Fiber.Stream.In.parallel_iter sessions ~f:(fun session ->
         let session =
           let send packets =
-            Option.map packets ~f:(List.map ~f:(Conv.to_sexp Packet.Reply.sexp))
+            Option.map packets ~f:(List.map ~f:(Conv.to_sexp Packet.sexp))
             |> S.write session
           in
           let queries =
             create_sequence
               (fun () -> S.read session)
-              ~version:(version server) Packet.Query.sexp
+              ~version:(version server) Packet.sexp
           in
           new_session server stats ~queries ~send
         in


### PR DESCRIPTION
This adds the ability to for RPC servers to send requests to the server. In other words, it makes the RPC protocol bidirectional. This is needed for dune to distribute actions among forkers. To send an action to a forker, dune will now make a request to the appropriate forker client.

This PR only adds the machinery at the level of RPC packets being sent. To finish this, I'll add version negotiation for server -> client requests in a subsequent PR.