### PR TITLE
test: re-enable stray-proces test on macos

### DIFF
--- a/test/blackbox-tests/test-cases/actions/dune
+++ b/test/blackbox-tests/test-cases/actions/dune
@@ -1,4 +1,0 @@
-(cram
- (applies_to stray-process)
- (enabled_if
-  (<> %{system} macosx)))


### PR DESCRIPTION
it's flaky everywhere, not just on macos

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: ac670f7d-7914-4eb1-be0a-e800a542142a