### PR TITLE
fix(ocamlc_loc): parse alerts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix the parsing of alerts. They will now show up in diagnostics correctly.
+  (#6678, @rginberg)
+
 - Fix the compilation of modules generated at link time when
   `implicit_transitive_deps` is enabled (#6642, @rgrinberg)
 

--- a/otherlibs/ocamlc_loc/src/lexer.mli
+++ b/otherlibs/ocamlc_loc/src/lexer.mli
@@ -14,6 +14,10 @@ type source =
 type severity =
   | Error of source option
   | Warning of source
+  | Alert of
+      { name : string
+      ; source : string
+      }
 
 type loc =
   { chars : (int * int) option

--- a/otherlibs/ocamlc_loc/src/ocamlc_loc.ml
+++ b/otherlibs/ocamlc_loc/src/ocamlc_loc.ml
@@ -19,6 +19,9 @@ let dyn_of_severity =
   function
   | Error w -> variant "Error" [ option dyn_of_source w ]
   | Warning w -> variant "Warning" [ dyn_of_source w ]
+  | Alert { name; source } ->
+    variant "Alert"
+      [ record [ ("name", string name); ("source", string source) ] ]
 
 let dyn_of_loc { path; lines; chars } =
   let open Dyn in
@@ -86,6 +89,8 @@ end
 let indent_of_severity = function
   | Error _ -> String.length "Error: "
   | Warning _ -> String.length "Warning: "
+  | Alert { name; source } ->
+    String.length "Alert :" + String.length name + String.length source + 1
 
 let severity tokens =
   match Tokens.peek tokens with

--- a/otherlibs/ocamlc_loc/src/ocamlc_loc.mli
+++ b/otherlibs/ocamlc_loc/src/ocamlc_loc.mli
@@ -21,6 +21,10 @@ type loc =
 type severity =
   | Error of source option
   | Warning of source
+  | Alert of
+      { name : string
+      ; source : string
+      }
 
 type report =
   { loc : loc

--- a/otherlibs/ocamlc_loc/test/ocamlc_loc_tests.ml
+++ b/otherlibs/ocamlc_loc/test/ocamlc_loc_tests.ml
@@ -400,7 +400,14 @@ File "foo.ml", line 8, characters 9-12:
 Alert deprecated: A.f
 foo
   |};
-  [%expect {||}];
+  [%expect
+    {|
+    >> error 0
+    { loc = { path = "foo.ml"; line = Single 8; chars = Some (9, 12) }
+    ; message = "foo"
+    ; related = []
+    ; severity = Alert { name = "deprecated"; source = " A.f" }
+    } |}];
   test_error
     {|
 File "foo.ml", line 8, characters 9-12:
@@ -409,4 +416,11 @@ File "foo.ml", line 8, characters 9-12:
 Alert foobar: A.f
 blah
 |};
-  [%expect {||}]
+  [%expect
+    {|
+    >> error 0
+    { loc = { path = "foo.ml"; line = Single 8; chars = Some (9, 12) }
+    ; message = "blah"
+    ; related = []
+    ; severity = Alert { name = "foobar"; source = " A.f" }
+    } |}]


### PR DESCRIPTION
correctly parse alerts and add a new severity kind

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 4ec7db6f-4026-4936-991c-fcfc4d535ba2