### PR TITLE
refactor(scheduler): cleanup scheduler display api

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -125,7 +125,7 @@ let () =
   let module Scheduler = Dune_engine.Scheduler in
   let config =
     { Scheduler.Config.concurrency = 10
-    ; display = { verbosity = Quiet; status_line = false }
+    ; display = Scheduler.Config.Display.quiet
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -6,7 +6,7 @@ module Caml = Stdlib
 
 let config =
   { Scheduler.Config.concurrency = 1
-  ; display = { verbosity = Short; status_line = false }
+  ; display = Scheduler.Config.Display.(no_status_line short)
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -543,7 +543,7 @@ let display_term =
          & info [ "verbose" ] ~docs:copts_sect
              ~doc:"Same as $(b,--display verbose)")
      in
-     Option.some_if verbose { Display.verbosity = Verbose; status_line = true })
+     Option.some_if verbose Display.verbose)
     Arg.(
       value
       & opt (some (enum Display.all)) None

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -425,7 +425,7 @@ let term =
   and+ debug_backtraces = Common.debug_backtraces in
   let config : Dune_config.t =
     { Dune_config.default with
-      display = { verbosity = Quiet; status_line = false }
+      display = Scheduler.Config.Display.quiet
     ; concurrency = Fixed 1
     }
   in

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -261,7 +261,8 @@ let hash = Poly.hash
 let equal a b = Poly.equal a b
 
 let default =
-  { display = { verbosity = Quiet; status_line = not Config.inside_dune }
+  { display =
+      Scheduler.Config.Display.(if Config.inside_dune then quiet else progress)
   ; concurrency = (if Config.inside_dune then Fixed 1 else Auto)
   ; terminal_persistence = Clear_on_rebuild
   ; sandboxing_preference = []
@@ -372,7 +373,10 @@ let adapt_display config ~output_is_a_tty =
     if
       config.display.status_line && (not output_is_a_tty)
       && not Config.inside_emacs
-    then { config with display = { config.display with status_line = false } }
+    then
+      { config with
+        display = Scheduler.Config.Display.no_status_line config.display
+      }
     else config
   in
   (* Similarly, terminal clearing is meaningless if stderr doesn't support ANSI

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -15,14 +15,24 @@ module Config = struct
       ; verbosity : verbosity
       }
 
+    let progress = { verbosity = Quiet; status_line = true }
+
+    let quiet = { verbosity = Quiet; status_line = false }
+
+    let short = { verbosity = Short; status_line = true }
+
+    let verbose = { verbosity = Verbose; status_line = true }
+
+    let no_status_line t = { t with status_line = false }
+
     (* Even though [status_line] is true by default in most of these, the status
        line is actually not shown if the output is redirected to a file or a
        pipe. *)
     let all =
-      [ ("progress", { verbosity = Quiet; status_line = true })
-      ; ("verbose", { verbosity = Verbose; status_line = true })
-      ; ("short", { verbosity = Short; status_line = true })
-      ; ("quiet", { verbosity = Quiet; status_line = false })
+      [ ("progress", progress)
+      ; ("verbose", verbose)
+      ; ("short", short)
+      ; ("quiet", quiet)
       ]
 
     let verbosity_to_dyn : verbosity -> Dyn.t = function

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -9,10 +9,26 @@ module Config : sig
       | Short  (** One line per command *)
       | Verbose  (** Display all commands fully *)
 
-    type t =
+    type t = private
       { status_line : bool
       ; verbosity : verbosity
       }
+
+    (** Displays a status line and any errors. *)
+    val progress : t
+
+    (** Only display errors, no status line. *)
+    val quiet : t
+
+    (** Display a short synopsis of the main process of an action run during the
+        build, together with a status line. *)
+    val short : t
+
+    (** Verbose output together with progress bar. *)
+    val verbose : t
+
+    (** Disable the status line. *)
+    val no_status_line : t -> t
 
     val all : (string * t) list
 

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -81,7 +81,7 @@ let%expect_test "csexp server life cycle" =
   in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = { verbosity = Quiet; status_line = false }
+    ; display = Scheduler.Config.Display.quiet
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -164,7 +164,7 @@ let with_dune_watch ?env f =
 
 let config =
   { Scheduler.Config.concurrency = 1
-  ; display = { verbosity = Quiet; status_line = false }
+  ; display = Scheduler.Config.Display.quiet
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -46,7 +46,7 @@ let run =
   let cwd = Sys.getcwd () in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = { verbosity = Quiet; status_line = false }
+    ; display = Scheduler.Config.Display.quiet
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -5,7 +5,7 @@ open Dune_engine
 let go =
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = { verbosity = Short; status_line = false }
+    ; display = Scheduler.Config.Display.(no_status_line short)
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `Yes

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -5,7 +5,7 @@ open Fiber.O
 
 let default =
   { Scheduler.Config.concurrency = 1
-  ; display = { verbosity = Short; status_line = false }
+  ; display = Scheduler.Config.Display.(no_status_line short)
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -4,7 +4,7 @@ module Scheduler = Dune_engine.Scheduler
 
 let config =
   { Scheduler.Config.concurrency = 1
-  ; display = { verbosity = Short; status_line = false }
+  ; display = Scheduler.Config.Display.(no_status_line short)
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -112,7 +112,7 @@ let run kind script =
   let vcs = { Vcs.kind; root = temp_dir } in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = { verbosity = Short; status_line = false }
+    ; display = Scheduler.Config.Display.(no_status_line short)
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No


### PR DESCRIPTION
We cleanup the Display API in the Scheduler by consolidating the kinds of display. This allows us to tweak the data of `Display.t` in the future (as in #6654) without having to update other parts of the code. It should also make the code read better.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: c8841d58-c436-46b8-849a-d4e42c977af2 -->