### PR TITLE
refactor(melange): improve build plan

### DIFF
--- a/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/dune
+++ b/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/dune
@@ -1,5 +1,6 @@
 (melange.emit
  (target dist)
+ (alias melange)
  (module_system commonjs)
  (entries entry_module)
  (libraries parent))

--- a/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/run.t
@@ -1,5 +1,5 @@
 Test file unmangling with melange.emit that depends on a library, that depends on another library
 
-  $ dune build dist/entry_module.js
+  $ dune build @melange
   $ node _build/default/dist/entry_module.js
   1

--- a/test/blackbox-tests/test-cases/melange/empty-entries.t
+++ b/test/blackbox-tests/test-cases/melange/empty-entries.t
@@ -8,6 +8,7 @@ Test (entries) field can be left empty
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (alias melange)
   >  (module_system commonjs))
   > EOF
 
@@ -16,6 +17,6 @@ Test (entries) field can be left empty
   >   print_endline "hello"
   > EOF
 
-  $ dune build output/hello.js
+  $ dune build @melange
   $ node _build/default/output/hello.js
   hello

--- a/test/blackbox-tests/test-cases/melange/flags.t
+++ b/test/blackbox-tests/test-cases/melange/flags.t
@@ -15,7 +15,7 @@ Using flags field in melange.emit stanzas is not supported
   >  (flags -w -14-26))
   > EOF
 
-  $ dune build output/main.js
+  $ dune build @melange
   File "dune", line 5, characters 2-7:
   5 |  (flags -w -14-26))
         ^^^^^
@@ -33,12 +33,13 @@ Adds a module that contains unused var (warning 26) and illegal backlash (warnin
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (module_system commonjs))
   > EOF
 
 Trying to build triggers both warnings
 
-  $ dune build output/main.js
+  $ dune build @melange
   File "main.ml", line 1, characters 9-11:
   1 | let t = "\e\n" in
                ^^
@@ -55,11 +56,12 @@ Let's ignore them using compile_flags
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (module_system commonjs)
   >  (compile_flags -w -14-26))
   > EOF
 
-  $ dune build output/main.js
+  $ dune build @melange
   $ node _build/default/output/main.js
   hello
 
@@ -69,10 +71,11 @@ Can also pass flags from the env stanza. Let's go back to failing state:
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (module_system commonjs))
   > EOF
 
-  $ dune build output/main.js
+  $ dune build @melange
   File "main.ml", line 1, characters 9-11:
   1 | let t = "\e\n" in
                ^^
@@ -90,11 +93,12 @@ Adding env stanza with both warnings silenced allows the build to pass successfu
   >  (_
   >   (melange.compile_flags -w -14-26)))
   > (melange.emit
+  >  (alias melange)
   >  (target output)
   >  (entries main)
   >  (module_system commonjs))
   > EOF
 
-  $ dune build output/main.js
+  $ dune build @melange
   $ node _build/default/output/main.js
   hello

--- a/test/blackbox-tests/test-cases/melange/include_subdirs.t/inside/dune
+++ b/test/blackbox-tests/test-cases/melange/include_subdirs.t/inside/dune
@@ -1,5 +1,6 @@
 (melange.emit
  (target output)
+ (alias melange)
  (entries c)
  (libraries lib)
  (module_system commonjs))

--- a/test/blackbox-tests/test-cases/melange/include_subdirs.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/include_subdirs.t/run.t
@@ -3,6 +3,6 @@ Test that libs using `(include_subdirs unqualified) work well with
 
 Build js files
   $ output=inside/output
-  $ dune build $output/inside/c.js
+  $ dune build @melange
   $ node _build/default/$output/inside/c.js
   buy it

--- a/test/blackbox-tests/test-cases/melange/intfonly.t/dune
+++ b/test/blackbox-tests/test-cases/melange/intfonly.t/dune
@@ -1,4 +1,5 @@
 (melange.emit
  (target output)
+ (alias melange)
  (libraries lib)
  (module_system commonjs))

--- a/test/blackbox-tests/test-cases/melange/intfonly.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/intfonly.t/run.t
@@ -1,6 +1,6 @@
 Test melange libs flow when using `modules_without_implementation` stanza
 
 Build js files
-  $ dune build output/b.js
+  $ dune build @melange
   $ node _build/default/output/b.js
   buy it

--- a/test/blackbox-tests/test-cases/melange/javascript-extension.t
+++ b/test/blackbox-tests/test-cases/melange/javascript-extension.t
@@ -15,11 +15,12 @@ Can use extension with dots
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (alias melange)
   >  (module_system commonjs)
   >  (javascript_extension bs.js))
   > EOF
 
-  $ dune build output/hello.bs.js
+  $ dune build @melange
   $ node _build/default/output/hello.bs.js
   hello
 
@@ -28,13 +29,14 @@ Errors out if extension starts with dot
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (alias melange)
   >  (module_system commonjs)
   >  (javascript_extension .bs.js))
   > EOF
 
-  $ dune build output/hello.js
-  File "dune", line 4, characters 23-29:
-  4 |  (javascript_extension .bs.js))
+  $ dune build @melange
+  File "dune", line 5, characters 23-29:
+  5 |  (javascript_extension .bs.js))
                              ^^^^^^
   Error: extension must not start with '.'
   [1]

--- a/test/blackbox-tests/test-cases/melange/missing-melc.t
+++ b/test/blackbox-tests/test-cases/melange/missing-melc.t
@@ -23,15 +23,17 @@ For melange.emit stanzas, an error is shown
   > (melange.emit
   >  (target output)
   >  (entries main_melange)
+  >  (alias melange)
   >  (module_system commonjs))
   > EOF
 
-  $ (unset INSIDE_DUNE; PATH=_path dune build --always-show-command-line --root . output/main_melange.js)
-  File "dune", line 1, characters 0-81:
+  $ (unset INSIDE_DUNE; PATH=_path dune build --always-show-command-line --root . @melange)
+  File "dune", line 1, characters 0-98:
   1 | (melange.emit
   2 |  (target output)
   3 |  (entries main_melange)
-  4 |  (module_system commonjs))
+  4 |  (alias melange)
+  5 |  (module_system commonjs))
   Error: Program melc not found in the tree or in PATH
    (context: default)
   Hint: opam install melange

--- a/test/blackbox-tests/test-cases/melange/mli.t/dune
+++ b/test/blackbox-tests/test-cases/melange/mli.t/dune
@@ -2,4 +2,5 @@
  (target mli)
  (entries x)
  (libraries lib)
+ (alias melange)
  (module_system commonjs))

--- a/test/blackbox-tests/test-cases/melange/mli.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/mli.t/run.t
@@ -1,4 +1,4 @@
 Compilation using melange, with interface files
-  $ dune build mli/x.js
+  $ dune build @melange
   $ node ./_build/default/mli/x.js
   buy it

--- a/test/blackbox-tests/test-cases/melange/multilib.t/dune
+++ b/test/blackbox-tests/test-cases/melange/multilib.t/dune
@@ -2,4 +2,5 @@
  (target multilib)
  (entries c)
  (libraries x)
+ (alias melange)
  (module_system commonjs))

--- a/test/blackbox-tests/test-cases/melange/multilib.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/multilib.t/run.t
@@ -10,6 +10,6 @@ Make sure no byte folders are included.
 
 Test resulting file
 
-  $ dune build multilib/c.js
+  $ dune build @melange
   $ node ./_build/default/multilib/c.js
   done

--- a/test/blackbox-tests/test-cases/melange/ocaml-flags.t
+++ b/test/blackbox-tests/test-cases/melange/ocaml-flags.t
@@ -10,6 +10,7 @@ Create dune file that uses melange.compile_flags
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (alias melange)
   >  (entries main)
   >  (module_system commonjs)
   >  (compile_flags -w -14-26))
@@ -24,7 +25,7 @@ The code in main contains unused var (warning 26) and illegal backlash (warning 
 
 Building does not fail, warnings are silenced
 
-  $ dune build output/main.js
+  $ dune build @melange
   $ node _build/default/output/main.js
   hello
 

--- a/test/blackbox-tests/test-cases/melange/preprocess.t
+++ b/test/blackbox-tests/test-cases/melange/preprocess.t
@@ -9,6 +9,7 @@ Test (preprocess) field on melange.emit stanza
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (module_system commonjs)
   >  (preprocess
   >   (action
@@ -20,6 +21,6 @@ Test (preprocess) field on melange.emit stanza
   >   print_endline "hello"
   > EOF
 
-  $ dune build output/main.js
+  $ dune build @melange
   $ node _build/default/output/main.js
   hello

--- a/test/blackbox-tests/test-cases/melange/private.t/inside/dune
+++ b/test/blackbox-tests/test-cases/melange/private.t/inside/dune
@@ -2,5 +2,6 @@
  (target output)
  (entries c)
  (libraries app)
+ (alias melange)
  (module_system es6)
  (javascript_extension mjs))

--- a/test/blackbox-tests/test-cases/melange/private.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/private.t/run.t
@@ -21,6 +21,6 @@ Js rules should include module type
       es6
 
 Build js files
-  $ dune build $output/inside/c.mjs
+  $ dune build @melange
   $ node _build/default/$output/inside/c.mjs
   buy it

--- a/test/blackbox-tests/test-cases/melange/public.t/my_project/dune
+++ b/test/blackbox-tests/test-cases/melange/public.t/my_project/dune
@@ -2,5 +2,6 @@
  (package pkg)
  (target output)
  (entries c)
+ (alias melange)
  (libraries app)
  (module_system commonjs))

--- a/test/blackbox-tests/test-cases/melange/public.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/public.t/run.t
@@ -27,7 +27,7 @@ Js rules should include --bs-package-name
       pkg
 
 Build js files
-  $ dune build $output/my_project/c.js
+  $ dune build @melange
 
 Path to app_B is non-relative (broken)
   $ node _build/default/$output/my_project/c.js

--- a/test/blackbox-tests/test-cases/melange/root-module.t
+++ b/test/blackbox-tests/test-cases/melange/root-module.t
@@ -57,6 +57,7 @@ The same for melange.emit:
 
   $ cat > dune <<EOF
   > (melange.emit
+  >  (alias melange)
   >  (target output)
   >  (libraries lib1)
   >  (root_module root)
@@ -81,6 +82,6 @@ Use root_module to fix:
   $ cat >foo.ml <<EOF
   > print_endline Root.Lib1.greeting
   > EOF
-  $ dune build output/foo.js
+  $ dune build @melange
   $ node _build/default/output/foo.js
   Hello World

--- a/test/blackbox-tests/test-cases/melange/simple.t/lib/dune
+++ b/test/blackbox-tests/test-cases/melange/simple.t/lib/dune
@@ -5,6 +5,7 @@
 
 (melange.emit
  (target simple)
+ (alias melange)
  (entries x)
  (libraries lib)
  (module_system commonjs))

--- a/test/blackbox-tests/test-cases/melange/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/simple.t/run.t
@@ -1,6 +1,6 @@
 Using `melange.emit` inside the same folder as the library works fine
 
   $ output=lib/simple
-  $ dune build $output/lib/x.js
+  $ dune build @melange
   $ node _build/default/$output/lib/x.js
   buy it

--- a/test/blackbox-tests/test-cases/melange/unmangling.t
+++ b/test/blackbox-tests/test-cases/melange/unmangling.t
@@ -8,6 +8,7 @@ Test unmangling of js files
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (alias melange)
   >  (module_system commonjs))
   > EOF
 
@@ -27,6 +28,6 @@ Using lowercase produces uppercase artifacts
   > print_endline "hello"
   > EOF
 
-  $ dune build output/lower.js
+  $ dune build @melange
   $ node _build/default/output/lower.js
   hello

--- a/test/blackbox-tests/test-cases/melange/virtual_lib.t/dune
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib.t/dune
@@ -1,5 +1,6 @@
 (melange.emit
  (target output)
+ (alias melange)
  (entries mel)
  (libraries impl_melange)
  (module_system commonjs))

--- a/test/blackbox-tests/test-cases/melange/virtual_lib.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib.t/run.t
@@ -1,6 +1,6 @@
 Test virtual lib in an exe / melange environment
 
-  $ dune build output/mel.js
+  $ dune build @melange
   $ output=_build/default/output/mel.js
   $ test -f "$output" && node "$output"
   Hello from melange


### PR DESCRIPTION
## Changes:

* Build all js artifacts concurrently
* Use glob dependencies to represent dep graph more efficiently

## WIP

- [x] test suite

## Disadvantages

Now we are pretty much required to introduce an alias to make the melange.emit usable, as we no longer require runtime dependencies to build dependencies as well.