### PR TITLE
refactor(dune_engine): move [Display]

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -535,7 +535,7 @@ module Options_implied_by_dash_p = struct
 end
 
 let display_term =
-  let module Display = Dune_engine.Scheduler.Config.Display in
+  let module Display = Dune_engine.Display in
   one_of
     (let+ verbose =
        Arg.(

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -70,7 +70,7 @@ val debug_backtraces : bool Cmdliner.Term.t
 
 val config_from_config_file : Dune_config.Partial.t Cmdliner.Term.t
 
-val display_term : Dune_engine.Scheduler.Config.Display.t option Cmdliner.Term.t
+val display_term : Dune_engine.Display.t option Cmdliner.Term.t
 
 val context_arg : doc:string -> Dune_engine.Context_name.t Cmdliner.Term.t
 

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -1,5 +1,6 @@
 open Stdune
 open Dune_lang.Decoder
+module Display = Dune_engine.Display
 module Scheduler = Dune_engine.Scheduler
 module Sandbox_mode = Dune_engine.Sandbox_mode
 module Console = Dune_console
@@ -128,7 +129,7 @@ module type S = sig
   type 'a field
 
   type t =
-    { display : Scheduler.Config.Display.t field
+    { display : Display.t field
     ; concurrency : Concurrency.t field
     ; terminal_persistence : Terminal_persistence.t field
     ; sandboxing_preference : Sandboxing_preference.t field
@@ -186,7 +187,7 @@ struct
       ; action_stderr_on_success
       } =
     Dyn.record
-      [ ("display", field Scheduler.Config.Display.to_dyn display)
+      [ ("display", field Display.to_dyn display)
       ; ("concurrency", field Concurrency.to_dyn concurrency)
       ; ( "terminal_persistence"
         , field Terminal_persistence.to_dyn terminal_persistence )
@@ -278,7 +279,7 @@ let decode_generic ~min_dune_version =
     Dune_lang.Syntax.since Stanza.syntax ver
   in
   let field_o n v d = field_o n (check v >>> d) in
-  let+ display = field_o "display" (1, 0) (enum Scheduler.Config.Display.all)
+  let+ display = field_o "display" (1, 0) (enum Display.all)
   and+ concurrency = field_o "jobs" (1, 0) Concurrency.decode
   and+ terminal_persistence =
     field_o "terminal-persistence" (1, 0) Terminal_persistence.decode
@@ -382,7 +383,7 @@ let adapt_display config ~output_is_a_tty =
   else config
 
 let init t =
-  Console.Backend.set (Scheduler.Config.Display.console_backend t.display);
+  Console.Backend.set (Display.console_backend t.display);
   Log.verbose := t.display.verbosity = Verbose
 
 let auto_concurrency =

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -59,7 +59,7 @@ module type S = sig
   type 'a field
 
   type t =
-    { display : Dune_engine.Scheduler.Config.Display.t field
+    { display : Dune_engine.Display.t field
     ; concurrency : Concurrency.t field
     ; terminal_persistence : Terminal_persistence.t field
     ; sandboxing_preference : Sandboxing_preference.t field

--- a/src/dune_engine/display.ml
+++ b/src/dune_engine/display.ml
@@ -1,0 +1,37 @@
+open Import
+
+type verbosity =
+  | Quiet
+  | Short
+  | Verbose
+
+type t =
+  { status_line : bool
+  ; verbosity : verbosity
+  }
+
+(* Even though [status_line] is true by default in most of these, the status
+    line is actually not shown if the output is redirected to a file or a
+    pipe. *)
+let all =
+  [ ("progress", { verbosity = Quiet; status_line = true })
+  ; ("verbose", { verbosity = Verbose; status_line = true })
+  ; ("short", { verbosity = Short; status_line = true })
+  ; ("quiet", { verbosity = Quiet; status_line = false })
+  ]
+
+let verbosity_to_dyn : verbosity -> Dyn.t = function
+  | Quiet -> Variant ("Quiet", [])
+  | Short -> Variant ("Short", [])
+  | Verbose -> Variant ("Verbose", [])
+
+let to_dyn { status_line; verbosity } : Dyn.t =
+  Record
+    [ ("status_line", Dyn.Bool status_line)
+    ; ("verbosity", verbosity_to_dyn verbosity)
+    ]
+
+let console_backend t =
+  match t.status_line with
+  | false -> Console.Backend.dumb
+  | true -> Console.Backend.progress ()

--- a/src/dune_engine/display.mli
+++ b/src/dune_engine/display.mli
@@ -1,0 +1,18 @@
+open Import
+
+type verbosity =
+  | Quiet  (** Only display errors *)
+  | Short  (** One line per command *)
+  | Verbose  (** Display all commands fully *)
+
+type t =
+  { status_line : bool
+  ; verbosity : verbosity
+  }
+
+val all : (string * t) list
+
+val to_dyn : t -> Dyn.t
+
+(** The console backend corresponding to the selected display mode *)
+val console_backend : t -> Console.Backend.t

--- a/src/dune_engine/dune_engine.ml
+++ b/src/dune_engine/dune_engine.ml
@@ -1,3 +1,4 @@
+module Display = Display
 module Vcs = Vcs
 module Context_name = Context_name
 module Action_builder = Action_builder

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -430,7 +430,7 @@ module Handle_exit_status : sig
 
   val non_verbose :
        ('a, error) result
-    -> verbosity:Scheduler.Config.Display.verbosity
+    -> verbosity:Display.verbosity
     -> metadata:metadata
     -> output:string
     -> prog:string
@@ -522,9 +522,8 @@ end = struct
            ++ Pp.char ' ' ++ command_line
         :: pp_output output)
 
-  let non_verbose t ~(verbosity : Scheduler.Config.Display.verbosity) ~metadata
-      ~output ~prog ~command_line ~dir ~has_unexpected_stdout
-      ~has_unexpected_stderr =
+  let non_verbose t ~(verbosity : Display.verbosity) ~metadata ~output ~prog
+      ~command_line ~dir ~has_unexpected_stdout ~has_unexpected_stderr =
     let output = parse_output output in
     let show_command =
       !Clflags.always_show_command_line

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -4,44 +4,6 @@ open Fiber.O
 module Config = struct
   include Config
 
-  module Display = struct
-    type verbosity =
-      | Quiet
-      | Short
-      | Verbose
-
-    type t =
-      { status_line : bool
-      ; verbosity : verbosity
-      }
-
-    (* Even though [status_line] is true by default in most of these, the status
-       line is actually not shown if the output is redirected to a file or a
-       pipe. *)
-    let all =
-      [ ("progress", { verbosity = Quiet; status_line = true })
-      ; ("verbose", { verbosity = Verbose; status_line = true })
-      ; ("short", { verbosity = Short; status_line = true })
-      ; ("quiet", { verbosity = Quiet; status_line = false })
-      ]
-
-    let verbosity_to_dyn : verbosity -> Dyn.t = function
-      | Quiet -> Variant ("Quiet", [])
-      | Short -> Variant ("Short", [])
-      | Verbose -> Variant ("Verbose", [])
-
-    let to_dyn { status_line; verbosity } : Dyn.t =
-      Record
-        [ ("status_line", Dyn.Bool status_line)
-        ; ("verbosity", verbosity_to_dyn verbosity)
-        ]
-
-    let console_backend t =
-      match t.status_line with
-      | false -> Console.Backend.dumb
-      | true -> Console.Backend.progress ()
-  end
-
   type t =
     { concurrency : int
     ; display : Display.t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -3,25 +3,6 @@
 open! Import
 
 module Config : sig
-  module Display : sig
-    type verbosity =
-      | Quiet  (** Only display errors *)
-      | Short  (** One line per command *)
-      | Verbose  (** Display all commands fully *)
-
-    type t =
-      { status_line : bool
-      ; verbosity : verbosity
-      }
-
-    val all : (string * t) list
-
-    val to_dyn : t -> Dyn.t
-
-    (** The console backend corresponding to the selected display mode *)
-    val console_backend : t -> Console.Backend.t
-  end
-
   type t =
     { concurrency : int
     ; display : Display.t


### PR DESCRIPTION
Now it lives in its own module. Later to be decoupled from [Scheduler]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 6ed60e23-799a-4f75-a101-8b408a60b2e7