### PR TITLE
refactor: remove optional arguments from lib

### DIFF
--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -63,7 +63,7 @@ let get_installed_binaries ~(context : Context.t) stanzas =
                   in
                   Lib.DB.resolve_user_written_deps (Scope.libs scope)
                     (`Exe exes.names) exes.buildable.libraries ~pps
-                    ~dune_version
+                    ~dune_version ~forbidden_libraries:exes.forbidden_libraries
                     ~allow_overlaps:
                       exes.buildable.allow_overlapping_dependencies
                     ~merlin_ident

--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -121,7 +121,7 @@ let gen_rules sctx t ~dir ~scope =
     Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
       (Lib_dep.Direct (loc, Lib_name.of_string "cinaps.runtime") :: t.libraries)
       ~pps:(Preprocess.Per_module.pps t.preprocess)
-      ~dune_version ~merlin_ident
+      ~dune_version ~merlin_ident ~allow_overlaps:false ~forbidden_libraries:[]
   in
   let obj_dir = Obj_dir.make_exe ~dir:cinaps_dir ~name in
   let* cctx =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -255,7 +255,8 @@ end = struct
                 Merlin_ident.for_exes ~names:(List.map ~f:snd exes.names)
               in
               Lib.DB.resolve_user_written_deps (Scope.libs scope)
-                (`Exe exes.names) exes.buildable.libraries ~pps ~dune_version
+                ~forbidden_libraries:[] (`Exe exes.names)
+                exes.buildable.libraries ~pps ~dune_version
                 ~allow_overlaps:exes.buildable.allow_overlapping_dependencies
                 ~merlin_ident
             in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1792,7 +1792,7 @@ module DB = struct
 
   let available t name = Resolve_names.available_internal t name
 
-  let get_compile_info t ?(allow_overlaps = false) name =
+  let get_compile_info t ~allow_overlaps name =
     let open Memo.O in
     let+ find = find_even_when_hidden t name in
     match find with
@@ -1801,8 +1801,8 @@ module DB = struct
         [ ("name", Lib_name.to_dyn name) ]
     | Some lib -> (lib, Compile.for_lib ~allow_overlaps t lib)
 
-  let resolve_user_written_deps t targets ?(allow_overlaps = false)
-      ?(forbidden_libraries = []) deps ~pps ~dune_version ~merlin_ident =
+  let resolve_user_written_deps t targets ~allow_overlaps ~forbidden_libraries
+      deps ~pps ~dune_version ~merlin_ident =
     let resolved =
       Memo.lazy_ (fun () ->
           Resolve_names.resolve_deps_and_add_runtime_deps t deps ~pps

--- a/src/dune_rules/lib.mli
+++ b/src/dune_rules/lib.mli
@@ -139,7 +139,7 @@ module DB : sig
   (** Retrieve the compile information for the given library. Works for
       libraries that are optional and not available as well. *)
   val get_compile_info :
-    t -> ?allow_overlaps:bool -> Lib_name.t -> (lib * Compile.t) Memo.t
+    t -> allow_overlaps:bool -> Lib_name.t -> (lib * Compile.t) Memo.t
 
   val resolve : t -> Loc.t * Lib_name.t -> lib Resolve.Memo.t
 
@@ -156,8 +156,8 @@ module DB : sig
   val resolve_user_written_deps :
        t
     -> [ `Exe of (Import.Loc.t * string) list | `Melange_emit of string ]
-    -> ?allow_overlaps:bool
-    -> ?forbidden_libraries:(Loc.t * Lib_name.t) list
+    -> allow_overlaps:bool
+    -> forbidden_libraries:(Loc.t * Lib_name.t) list
     -> Lib_dep.t list
     -> pps:(Loc.t * Lib_name.t) list
     -> dune_version:Dune_lang.Syntax.Version.t

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -387,6 +387,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
   let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
   let compile_info =
     Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
+      ~allow_overlaps:false ~forbidden_libraries:[]
       (lib "mdx.test" :: lib "mdx.top" :: t.libraries)
       ~pps:[] ~dune_version ~merlin_ident
   in

--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -209,6 +209,7 @@ let add_rules_for_libraries ~dir ~scope ~target_dir ~sctx ~requires_link ~mode
       let lib_name = Lib.name lib in
       let* lib, lib_compile_info =
         Lib.DB.get_compile_info (Scope.libs scope) lib_name
+          ~allow_overlaps:false
       in
       let info = local_of_lib ~loc:mel.loc lib |> Lib.Local.info in
       let loc = Lib_info.loc info in
@@ -269,7 +270,8 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
   in
   let merlin_ident = Merlin_ident.for_melange ~target:mel.target in
   Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Melange_emit mel.target)
-    mel.libraries ~pps ~dune_version ~merlin_ident
+    ~allow_overlaps:false ~forbidden_libraries:[] mel.libraries ~pps
+    ~dune_version ~merlin_ident
 
 let emit_rules ~dir_contents ~dir ~scope ~sctx ~expander mel =
   let open Memo.O in

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -174,6 +174,7 @@ module Stanza = struct
       let names = [ (source.loc, source.name) ] in
       let merlin_ident = Merlin_ident.for_exes ~names:(List.map ~f:snd names) in
       Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Exe names)
+        ~forbidden_libraries:[]
         (Lib_dep.Direct (source.loc, compiler_libs)
         :: List.map toplevel.libraries ~f:(fun d -> Lib_dep.Direct d))
         ~pps ~dune_version ~allow_overlaps:false ~merlin_ident


### PR DESCRIPTION
[allow_overlaps] and [forbidden_libraries] must always be provided

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: fbc63255-6f69-4d6b-8a4d-862ee22bdd23