### PR TITLE
Error on "dune init" if dir exists named "dune"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Report an error if `dune init ...` would create a "dune" file in a location
+  which already contains a "dune" directory (#6705, @gridbugs)
+
 - Fix the parsing of alerts. They will now show up in diagnostics correctly.
   (#6678, @rginberg)
 

--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -118,6 +118,11 @@ module File = struct
     let full_path = Path.relative path name in
     let content =
       if not (Path.exists full_path) then []
+      else if Path.is_directory full_path then
+        User_error.raise
+          [ Pp.textf "\"%s\" already exists and is a directory"
+              (Path.to_absolute_filename full_path)
+          ]
       else
         match Io.with_lexbuf_from_file ~f:Dune_lang.Format.parse full_path with
         | Dune_lang.Format.Sexps content -> content

--- a/test/blackbox-tests/test-cases/init-error-if-dune-is-directory.t
+++ b/test/blackbox-tests/test-cases/init-error-if-dune-is-directory.t
@@ -1,0 +1,22 @@
+Report an error if `dune init ...` would create a "dune" file in a location
+which already has a "dune" directory.
+
+  $ mkdir dune
+
+  $ dune init exe foo
+  Error:
+  "$TESTCASE_ROOT/dune"
+  already exists and is a directory
+  [1]
+
+  $ dune init lib foo
+  Error:
+  "$TESTCASE_ROOT/dune"
+  already exists and is a directory
+  [1]
+
+  $ dune init test foo
+  Error:
+  "$TESTCASE_ROOT/dune"
+  already exists and is a directory
+  [1]


### PR DESCRIPTION
When running `dune init (exe|lib|test)` in a directory which contains a directory named "dune", prior to this change, the error would be: Error: Is a directory

Following this change, the error is now:
Error: "/path/to/dune" already exists and is a directory

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>