### PR TITLE
feature(melange): allow overlapping dependencies

### DIFF
--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -209,7 +209,7 @@ let add_rules_for_libraries ~dir ~scope ~target_dir ~sctx ~requires_link ~mode
       let lib_name = Lib.name lib in
       let* lib, lib_compile_info =
         Lib.DB.get_compile_info (Scope.libs scope) lib_name
-          ~allow_overlaps:false
+          ~allow_overlaps:mel.allow_overlapping_dependencies
       in
       let info = local_of_lib ~loc:mel.loc lib |> Lib.Local.info in
       let loc = Lib_info.loc info in
@@ -235,7 +235,9 @@ let add_rules_for_libraries ~dir ~scope ~target_dir ~sctx ~requires_link ~mode
           in
           let* lib_deps_js_includes =
             let+ requires_link =
-              Lib.Compile.for_lib ~allow_overlaps:false (Scope.libs scope) vlib
+              Lib.Compile.for_lib
+                ~allow_overlaps:mel.allow_overlapping_dependencies
+                (Scope.libs scope) vlib
               |> Lib.Compile.requires_link |> Memo.Lazy.force
             in
             js_includes ~loc:mel.loc ~sctx ~target_dir ~requires_link ~scope
@@ -270,8 +272,8 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
   in
   let merlin_ident = Merlin_ident.for_melange ~target:mel.target in
   Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Melange_emit mel.target)
-    ~allow_overlaps:false ~forbidden_libraries:[] mel.libraries ~pps
-    ~dune_version ~merlin_ident
+    ~allow_overlaps:mel.allow_overlapping_dependencies ~forbidden_libraries:[]
+    mel.libraries ~pps ~dune_version ~merlin_ident
 
 let emit_rules ~dir_contents ~dir ~scope ~sctx ~expander mel =
   let open Memo.O in

--- a/src/dune_rules/melange_stanzas.ml
+++ b/src/dune_rules/melange_stanzas.ml
@@ -15,6 +15,7 @@ module Emit = struct
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t
     ; root_module : (Loc.t * Module_name.t) option
+    ; allow_overlapping_dependencies : bool
     ; javascript_extension : string
     }
 
@@ -90,7 +91,10 @@ module Emit = struct
        and+ loc_instrumentation, instrumentation = Stanza_common.instrumentation
        and+ compile_flags = Ordered_set_lang.Unexpanded.field "compile_flags"
        and+ root_module = field_o "root_module" Module_name.decode_loc
-       and+ javascript_extension = extension_field "javascript_extension" in
+       and+ javascript_extension = extension_field "javascript_extension"
+       and+ allow_overlapping_dependencies =
+         field_b "allow_overlapping_dependencies"
+       in
        let preprocess =
          let init =
            let f libname = Preprocess.With_instrumentation.Ordinary libname in
@@ -114,5 +118,6 @@ module Emit = struct
        ; compile_flags
        ; root_module
        ; javascript_extension
+       ; allow_overlapping_dependencies
        })
 end

--- a/src/dune_rules/melange_stanzas.mli
+++ b/src/dune_rules/melange_stanzas.mli
@@ -15,6 +15,7 @@ module Emit : sig
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t
     ; root_module : (Loc.t * Module_name.t) option
+    ; allow_overlapping_dependencies : bool
     ; javascript_extension : string
     }
 


### PR DESCRIPTION
Overlapping dependencies allow for the same dependency to be pulled both
from the workspace and installed libraries, as long as they aren't used
in the same closure.

This feature isn't particularly useful, but I've added it because for parity executable and because it's very easy to do so.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>