### PR TITLE
Fix sexp lexer for escaped sequences such `\000` followed by another digit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix the parsing of decimal and hexadecimal escape literals in `dune`,
+  `dune-package`, and other dune s-expression based files (#6710, @shym)
+
 - Report an error if `dune init ...` would create a "dune" file in a location
   which already contains a "dune" directory (#6705, @gridbugs)
 

--- a/src/dune_sexp/lexer.mll
+++ b/src/dune_sexp/lexer.mll
@@ -320,7 +320,7 @@ and escape_sequence = parse
   | digit digit digit
     { error lexbuf "escape sequence in quoted string out of range" ~delta:(-1);
     }
-  | digit*
+  | digit digit?
     { error lexbuf "unterminated decimal escape sequence" ~delta:(-1);
     }
   | 'x' (hexdigit as c1) (hexdigit as c2)
@@ -328,7 +328,7 @@ and escape_sequence = parse
       Template.Buffer.add_text_c (Char.chr v);
       Other
     }
-  | 'x' hexdigit*
+  | 'x' hexdigit?
     { error lexbuf "unterminated hexadecimal escape sequence" ~delta:(-1);
     }
   | _

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -192,6 +192,18 @@ let%expect_test _ =
 Ok [ "bar%foo" ]
 |}]
 
+let%expect_test _ =
+  parse {|"\0000"|};
+  [%expect {|
+Error "unterminated decimal escape sequence"
+|}]
+
+let%expect_test _ =
+  parse {|"\x000"|};
+  [%expect {|
+Error "unterminated hexadecimal escape sequence"
+|}]
+
 (* Printing tests *)
 
 let loc = Loc.none

--- a/test/expect-tests/dune_lang/sexp_tests.ml
+++ b/test/expect-tests/dune_lang/sexp_tests.ml
@@ -195,13 +195,13 @@ Ok [ "bar%foo" ]
 let%expect_test _ =
   parse {|"\0000"|};
   [%expect {|
-Error "unterminated decimal escape sequence"
+Ok [ "\0000" ]
 |}]
 
 let%expect_test _ =
   parse {|"\x000"|};
   [%expect {|
-Error "unterminated hexadecimal escape sequence"
+Ok [ "\0000" ]
 |}]
 
 (* Printing tests *)


### PR DESCRIPTION
This PR adds two tests that the sexp lexer for strings errors out on digit escape sequences such as "\0000" and "\x000" and fixes the issue.
I stumbled upon that issue by trying to install a locally-pinned opam package into a switch named “5β2”, which generated a `dune-package` containing `5\206\1782` which did not parse correctly.
