### PR TITLE
process: add with_execution_context for setting Display.t

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -125,7 +125,6 @@ let () =
   let module Scheduler = Dune_engine.Scheduler in
   let config =
     { Scheduler.Config.concurrency = 10
-    ; display = Simple { verbosity = Quiet; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No
@@ -135,9 +134,12 @@ let () =
     Scheduler.Run.go config
       ~on_event:(fun _ _ -> ())
       (fun () ->
-        let open Fiber.O in
-        let* () = prepare_workspace () in
-        run_bench ())
+        Process.with_execution_context
+          ~display:(Simple { verbosity = Quiet; status_line = false })
+          ~f:(fun () ->
+            let open Fiber.O in
+            let* () = prepare_workspace () in
+            run_bench ()))
   in
   let zero = List.map zero ~f:(fun t -> `Float t) in
   let size =

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -6,7 +6,6 @@ module Caml = Stdlib
 
 let config =
   { Scheduler.Config.concurrency = 1
-  ; display = Simple { verbosity = Short; status_line = false }
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No
@@ -19,7 +18,10 @@ let setup =
 
 let prog = Option.value_exn (Bin.which ~path:(Env_path.path Env.initial) "true")
 
-let run () = Process.run ~env:Env.initial Strict prog []
+let run () =
+  Process.with_execution_context
+    ~display:(Simple { verbosity = Short; status_line = false })
+    ~f:(fun () -> Process.run ~env:Env.initial Strict prog [])
 
 let go ~jobs fiber =
   Scheduler.Run.go

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -445,9 +445,4 @@ let for_scheduler (t : t) stats ~insignificant_changes ~signal_watcher =
       Log.info [ Pp.textf "Auto-detected concurrency: %d" n ];
       n
   in
-  { Scheduler.Config.concurrency
-  ; display = t.display
-  ; stats
-  ; insignificant_changes
-  ; signal_watcher
-  }
+  { Scheduler.Config.concurrency; stats; insignificant_changes; signal_watcher }

--- a/src/dune_engine/dpath.ml
+++ b/src/dune_engine/dpath.ml
@@ -117,6 +117,8 @@ let analyse_dir (fn : Path.t) =
 
 type t = Path.t
 
+let to_dyn = Path.to_dyn
+
 let encode p =
   let make constr arg =
     Dune_lang.List

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -42,6 +42,8 @@ val describe_path : Path.t -> string
 
 include Dune_lang.Conv.S with type t = Path.t
 
+val to_dyn : t -> Dyn.t
+
 module Local : sig
   val encode : dir:Path.t -> Path.t Dune_lang.Encoder.t
 

--- a/src/dune_engine/process.mli
+++ b/src/dune_engine/process.mli
@@ -83,6 +83,12 @@ val create_metadata :
    this behaviour by setting [set_temp_dir_when_running_actions = false]. *)
 val set_temp_dir_when_running_actions : bool ref
 
+(** [with_execution_context ~display ~f] executes [f] where:
+
+    - [display] is the display provider *)
+val with_execution_context :
+  display:Display.t -> f:(unit -> 'a Fiber.t) -> 'a Fiber.t
+
 (** [run ?dir ?stdout_to prog args] spawns a sub-process and wait for its
     termination. [stdout_to] [stderr_to] are released *)
 val run :

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -6,7 +6,6 @@ module Config = struct
 
   type t =
     { concurrency : int
-    ; display : Display.t
     ; stats : Dune_stats.t option
     ; insignificant_changes : [ `Ignore | `React ]
     ; signal_watcher : [ `Yes | `No ]

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -5,7 +5,6 @@ open! Import
 module Config : sig
   type t =
     { concurrency : int
-    ; display : Display.t
     ; stats : Dune_stats.t option
     ; insignificant_changes : [ `Ignore | `React ]
     ; signal_watcher : [ `Yes | `No ]

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -79,9 +79,12 @@ let%expect_test "csexp server life cycle" =
         in
         log "sessions finished")
   in
+  let run () =
+    Dune_engine.Process.with_execution_context ~f:run
+      ~display:(Simple { verbosity = Quiet; status_line = false })
+  in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = Simple { verbosity = Quiet; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -46,7 +46,6 @@ let run =
   let cwd = Sys.getcwd () in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = Simple { verbosity = Quiet; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -2,16 +2,19 @@ open Stdune
 open! Dune_tests_common
 open Dune_engine
 
-let go =
+let go run =
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = Simple { verbosity = Short; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `Yes
     }
   in
-  Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ())
+  let run () =
+    Process.with_execution_context ~f:run
+      ~display:(Simple { verbosity = Short; status_line = false })
+  in
+  Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ()) run
 
 let true_ =
   Bin.which "true" ~path:(Env_path.path Env.initial) |> Option.value_exn

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -5,7 +5,6 @@ open Fiber.O
 
 let default =
   { Scheduler.Config.concurrency = 1
-  ; display = Simple { verbosity = Short; status_line = false }
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -4,7 +4,6 @@ module Scheduler = Dune_engine.Scheduler
 
 let config =
   { Scheduler.Config.concurrency = 1
-  ; display = Simple { verbosity = Short; status_line = false }
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -112,7 +112,6 @@ let run kind script =
   let vcs = { Vcs.kind; root = temp_dir } in
   let config =
     { Scheduler.Config.concurrency = 1
-    ; display = Simple { verbosity = Short; status_line = false }
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No
@@ -121,7 +120,10 @@ let run kind script =
   Scheduler.Run.go
     ~on_event:(fun _ _ -> ())
     config
-    (fun () -> Fiber.sequential_iter script ~f:(run_action vcs))
+    (fun () ->
+      Process.with_execution_context
+        ~display:(Simple { verbosity = Short; status_line = false })
+        ~f:(fun () -> Fiber.sequential_iter script ~f:(run_action vcs)))
 
 let script =
   [ Init


### PR DESCRIPTION
We add a with_execution_context function for setting various parameters of a fiber that will be run by Scheduler.Run.go. For the moment this is just the display.

This is a step towards making the Scheduler more generic and know less.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: deeac405-7538-4407-8cdd-8ecc40a595ef -->