### PR TITLE
test: demonstrate dune build bug

### DIFF
--- a/test/blackbox-tests/test-cases/build-percent-form-bin.t
+++ b/test/blackbox-tests/test-cases/build-percent-form-bin.t
@@ -1,0 +1,19 @@
+Build a binary using a %{bin:..}` form
+
+  $  cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > (package
+  >  (name randompkg))
+  > EOF
+
+  $ mkdir bin
+  $ touch bin/bar.ml
+  $ cat >bin/dune <<EOF
+  > (executable
+  >  (public_name bar))
+  > EOF
+
+  $ dune build '%{bin:bar}'
+  Error: File unavailable:
+  $TESTCASE_ROOT/../install/default/bin/bar
+  [1]


### PR DESCRIPTION
The command $ dune build %{bin:..} doesn't work correctly

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: dc34b284-e534-4b73-a300-63a91fe8ff85