### PR TITLE
refactor(rpc): explicit Versioned.Make interface

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -455,14 +455,16 @@ module Versioned : sig
     type 'payload notification = { encode : 'payload -> Call.t }
   end
 
-  module Make (Fiber : Fiber) : sig
+  module type S = sig
+    type 'a fiber
+
     module Handler : sig
       type 'state t
 
-      val handle_request : 'state t -> 'state -> Request.t -> Response.t Fiber.t
+      val handle_request : 'state t -> 'state -> Request.t -> Response.t fiber
 
       val handle_notification :
-        'state t -> 'state -> Call.t -> (unit, Response.Error.t) result Fiber.t
+        'state t -> 'state -> Call.t -> (unit, Response.Error.t) result fiber
 
       val prepare_request :
            'a t
@@ -510,16 +512,18 @@ module Versioned : sig
       val implement_notification :
            'state t
         -> 'payload Decl.notification
-        -> ('state -> 'payload -> unit Fiber.t)
+        -> ('state -> 'payload -> unit fiber)
         -> unit
 
       val implement_request :
            'state t
         -> ('req, 'resp) Decl.request
-        -> ('state -> 'req -> 'resp Fiber.t)
+        -> ('state -> 'req -> 'resp fiber)
         -> unit
     end
   end
+
+  module Make (Fiber : Fiber) : S with type 'a fiber := 'a Fiber.t
 end
 
 module Server_notifications : sig

--- a/otherlibs/dune-rpc/private/versioned.ml
+++ b/otherlibs/dune-rpc/private/versioned.ml
@@ -41,6 +41,60 @@ let raise_version_bug ~method_ ~selected ~verb ~known =
    listing. *)
 type packed = T : 'a Method.Version.Map.t Univ_map.Key.t -> packed
 
+module type S = sig
+  type 'a fiber
+
+  module Handler : sig
+    type 'state t
+
+    val handle_request : 'state t -> 'state -> Request.t -> Response.t fiber
+
+    val handle_notification :
+      'state t -> 'state -> Call.t -> (unit, Response.Error.t) result fiber
+
+    val prepare_request :
+         'a t
+      -> ('req, 'resp) Decl.Request.witness
+      -> (('req, 'resp) Staged.request, Version_error.t) result
+
+    val prepare_notification :
+         'a t
+      -> 'payload Decl.Notification.witness
+      -> ('payload Staged.notification, Version_error.t) result
+  end
+
+  module Builder : sig
+    type 'state t
+
+    val to_handler :
+         'state t
+      -> session_version:('state -> Version.t)
+      -> menu:Menu.t
+      -> 'state Handler.t
+
+    val create : unit -> 'state t
+
+    val registered_procedures :
+      'a t -> (Method.Name.t * Method.Version.t list) list
+
+    val declare_notification : 'state t -> 'payload Decl.notification -> unit
+
+    val declare_request : 'state t -> ('req, 'resp) Decl.request -> unit
+
+    val implement_notification :
+         'state t
+      -> 'payload Decl.notification
+      -> ('state -> 'payload -> unit fiber)
+      -> unit
+
+    val implement_request :
+         'state t
+      -> ('req, 'resp) Decl.request
+      -> ('state -> 'req -> 'resp fiber)
+      -> unit
+  end
+end
+
 module Make (Fiber : Fiber_intf.S) = struct
   module Handler = struct
     type 'state t =

--- a/otherlibs/dune-rpc/private/versioned.mli
+++ b/otherlibs/dune-rpc/private/versioned.mli
@@ -22,14 +22,16 @@ module Staged : sig
   type 'payload notification = { encode : 'payload -> Call.t }
 end
 
-module Make (Fiber : Fiber_intf.S) : sig
+module type S = sig
+  type 'a fiber
+
   module Handler : sig
     type 'state t
 
-    val handle_request : 'state t -> 'state -> Request.t -> Response.t Fiber.t
+    val handle_request : 'state t -> 'state -> Request.t -> Response.t fiber
 
     val handle_notification :
-      'state t -> 'state -> Call.t -> (unit, Response.Error.t) result Fiber.t
+      'state t -> 'state -> Call.t -> (unit, Response.Error.t) result fiber
 
     val prepare_request :
          'a t
@@ -76,13 +78,15 @@ module Make (Fiber : Fiber_intf.S) : sig
     val implement_notification :
          'state t
       -> 'payload Decl.notification
-      -> ('state -> 'payload -> unit Fiber.t)
+      -> ('state -> 'payload -> unit fiber)
       -> unit
 
     val implement_request :
          'state t
       -> ('req, 'resp) Decl.request
-      -> ('state -> 'req -> 'resp Fiber.t)
+      -> ('state -> 'req -> 'resp fiber)
       -> unit
   end
 end
+
+module Make (Fiber : Fiber_intf.S) : S with type 'a fiber := 'a Fiber.t


### PR DESCRIPTION
We write an explicit interaface for Versioned.Make so that callers can
include it in their signatures.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 1591cce2-128a-4d6e-9d4d-ccc2a6a66d03