### PR TITLE
fix(rpc): windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- Fix running the RPC server on windows (#6721 fixes #6720, @rgrinberg)
+
 - Use colored output with GCC and Clang when compiling C stubs. The
   flag `-fdiagnostics-color=always` is added to the `:standard` set of
   flags. (#4083, @MisterDA)

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -260,7 +260,7 @@ module Server = struct
     let create fd sockaddr ~backlog =
       Unix.listen fd backlog;
       let r_interrupt_accept, w_interrupt_accept = Unix.pipe ~cloexec:true () in
-      Unix.set_nonblock r_interrupt_accept;
+      if not Sys.win32 then Unix.set_nonblock r_interrupt_accept;
       let buf = Bytes.make 1 '0' in
       { fd; sockaddr; r_interrupt_accept; w_interrupt_accept; buf }
 


### PR DESCRIPTION
We use the pipe trick to interrupt the accept loop. This needs the pipe
to be non blocking, but non blocking pipes are emulated on windows so we
shouldn't try to set them to non blocking.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 2dac6f72-88da-4456-97ac-0c55e080a10a