### PR TITLE
refactor(rpc): move proc outside functor

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -50,6 +50,11 @@ module Server_notifications = struct
 end
 
 module Client = struct
+  type proc =
+    | Request : ('a, 'b) Decl.request -> proc
+    | Notification : 'a Decl.notification -> proc
+    | Poll : 'a Procedures.Poll.t -> proc
+
   module type S = sig
     type t
 
@@ -123,11 +128,6 @@ module Client = struct
         -> unit
         -> t
     end
-
-    type proc =
-      | Request : ('a, 'b) Decl.request -> proc
-      | Notification : 'a Decl.notification -> proc
-      | Poll : 'a Procedures.Poll.t -> proc
 
     val connect_with_menu :
          ?handler:Handler.t
@@ -598,11 +598,6 @@ module Client = struct
         in
         t
     end
-
-    type proc =
-      | Request : ('a, 'b) Decl.request -> proc
-      | Notification : 'a Decl.notification -> proc
-      | Poll : 'a Procedures.Poll.t -> proc
 
     let setup_versioning ~private_menu ~(handler : Handler.t) =
       let module Builder = V.Builder in

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -421,6 +421,11 @@ module Versioned : sig
 end
 
 module Client : sig
+  type proc =
+    | Request : ('a, 'b) Decl.request -> proc
+    | Notification : 'a Decl.notification -> proc
+    | Poll : 'a Procedures.Poll.t -> proc
+
   module type S = sig
     type t
 
@@ -494,11 +499,6 @@ module Client : sig
         -> unit
         -> t
     end
-
-    type proc =
-      | Request : ('a, 'b) Decl.request -> proc
-      | Notification : 'a Decl.notification -> proc
-      | Poll : 'a Procedures.Poll.t -> proc
 
     val connect_with_menu :
          ?handler:Handler.t


### PR DESCRIPTION
it doesn't depend on any of the functor arguments

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 63abcb61-bc13-483a-9e60-9394829cbe69