### PR TITLE
fix(melange): intf only modules

### DIFF
--- a/src/dune_rules/melange_stanzas.ml
+++ b/src/dune_rules/melange_stanzas.ml
@@ -15,6 +15,7 @@ module Emit = struct
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t
     ; root_module : (Loc.t * Module_name.t) option
+    ; modules_without_implementation : Ordered_set_lang.t
     ; allow_overlapping_dependencies : bool
     ; javascript_extension : string
     }
@@ -94,6 +95,8 @@ module Emit = struct
        and+ javascript_extension = extension_field "javascript_extension"
        and+ allow_overlapping_dependencies =
          field_b "allow_overlapping_dependencies"
+       and+ modules_without_implementation =
+         Stanza_common.modules_field "modules_without_implementation"
        in
        let preprocess =
          let init =
@@ -119,5 +122,6 @@ module Emit = struct
        ; root_module
        ; javascript_extension
        ; allow_overlapping_dependencies
+       ; modules_without_implementation
        })
 end

--- a/src/dune_rules/melange_stanzas.mli
+++ b/src/dune_rules/melange_stanzas.mli
@@ -15,6 +15,7 @@ module Emit : sig
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t
     ; root_module : (Loc.t * Module_name.t) option
+    ; modules_without_implementation : Ordered_set_lang.t
     ; allow_overlapping_dependencies : bool
     ; javascript_extension : string
     }

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -383,7 +383,7 @@ let modules_of_stanzas dune_file ~dir ~scope ~lookup_vlib ~modules =
           let modules =
             Modules_field_evaluator.eval ~modules ~stanza_loc:mel.loc
               ~modules_field:mel.entries
-              ~modules_without_implementation:Ordered_set_lang.standard
+              ~modules_without_implementation:mel.modules_without_implementation
               ~root_module:mel.root_module
               ~kind:Modules_field_evaluator.Exe_or_normal_lib
               ~private_modules:Ordered_set_lang.standard ~src_dir:dir

--- a/test/blackbox-tests/test-cases/melange/intfonly-entries.t
+++ b/test/blackbox-tests/test-cases/melange/intfonly-entries.t
@@ -1,0 +1,20 @@
+Entry points should not allow mli only modules as entry points.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (module_system commonjs)
+  >  (modules_without_implementation foo)
+  >  (alias melange))
+  > EOF
+
+  $ touch foo.mli bar.ml
+  $ dune build @melange
+  $ ls _build/default/output/*.js | sort
+  _build/default/output/bar.js
+  _build/default/output/melange.js


### PR DESCRIPTION
When intf only modules are included in melange.emit, we shouldn't
generate js rules for them

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: ef68aca1-e36b-42b9-8bf9-00564ee968d3