### PR TITLE
refactor: add missing dyn & ordering dependencies

### DIFF
--- a/src/dune_rpc_server/dune
+++ b/src/dune_rpc_server/dune
@@ -5,6 +5,8 @@
   fiber
   stdune
   chrome_trace
+  dyn
+  ordering
   dune_stats
   dune_util
   dune_rpc_private


### PR DESCRIPTION
do not rely on stdune exporting them

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 31ba6b1c-69f7-4cf6-90fe-575616a3b1b3