### PR TITLE
fix: boostrap generation

### DIFF
--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -49,7 +49,8 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
           | _ -> false
         in
         Dyn.Tuple
-          [ Path.Source.to_dyn (Path.Build.drop_build_context_exn dir)
+          [ Path.Build.drop_build_context_exn dir
+            |> Path.Source.to_local |> Path.Local.to_dyn
           ; Dyn.option Module_name.to_dyn
               (match Lib_info.main_module_name info with
               | From _ -> None


### PR DESCRIPTION
We shouldn't emit `In_source_tree`, but rather raw relative paths as
strings

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 5807da91-5c6e-43f7-a1b0-c3d33472eaa7