### PR TITLE
fix: staged_pps should work

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- Fix preprocessing with `staged_pps` (#6748, fixes #6644, @rgrinberg)
+
 - Make `dune describe workspace` return consistent dependencies for
   executables and for libraries. By default, compile-time dependencies
   towards PPX-rewriters are from now not taken into account (but

--- a/test/blackbox-tests/test-cases/github6644.t
+++ b/test/blackbox-tests/test-cases/github6644.t
@@ -26,8 +26,5 @@ Regression test for #6644
   > EOF
   $ touch foo.ml
 
-  $ dune build foo.cma
-  File ".foo.objs/byte/_unknown_", line 1, characters 0-0:
-  Error: This rule forbids all sandboxing modes (but it also requires
-  sandboxing)
-  [1]
+  $ dune build foo.cma 2>&1 | grep Assert_failure | sed 's/\(.* Assert_failure\).*/\1/g'
+  Fatal error: exception Assert_failure


### PR DESCRIPTION
Setting sandboxing by default would break staged_pps because it would
transitively make various compilation commands to be sandboxed as well
which is not supported.

We restore the old (no sandboxing) default to staged_pps

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 592a0185-83e3-4572-aac0-9fbc11d999f9