### PR TITLE
fix: do not impose no_sandboxing on ocamldep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,9 @@ Unreleased
 - Remove spurious build dir created when running `dune init proj ...` (#6707,
   fixes #5429, @gridbugs)
 
+- Allow `--sandbox` to affect `ocamldep` invocations. Previously, they were
+  wrongly marked as incompatible (#6749, @rgrinberg)
+
 3.6.1 (2022-11-24)
 ------------------
 

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -167,7 +167,7 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
   let opaque = eval_opaque (Super_context.context super_context) opaque in
   let ocamldep_modules_data : Ocamldep.Modules_data.t =
     { dir = Obj_dir.dir obj_dir
-    ; sandbox
+    ; sandbox = Sandbox_config.no_special_requirements
     ; obj_dir
     ; sctx = super_context
     ; vimpl


### PR DESCRIPTION
ocamlc and ocamlopt don't play well with sandboxing, but ocamldep is
fine

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: cd518774-0ed7-4f52-9169-a709ac1ab7a7