### PR TITLE
Fix boot/libs.ml between 4.x/5.x

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -22,6 +22,8 @@
   dune_util
   dune_upgrader
   cmdliner
+  threads
+  ; Kept to keep implicit_transitive_deps false working in 4.x
   threads.posix
   build_info
   dune_config

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -961,8 +961,7 @@ type status =
 let resolve_externals external_libraries =
   let external_libraries, external_includes =
     let convert = function
-      | "threads.posix" ->
-        ("threads" ^ Config.ocaml_archive_ext, [ "-I"; "+threads" ])
+      | "threads" -> ("threads" ^ Config.ocaml_archive_ext, [ "-I"; "+threads" ])
       | "unix" -> ("unix" ^ Config.ocaml_archive_ext, Config.unix_library_flags)
       | s -> fatal "unhandled external library %s" s
     in

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -1,6 +1,6 @@
 let executables = [ "main" ]
 
-let external_libraries = [ "unix"; "threads.posix" ]
+let external_libraries = [ "unix"; "threads" ]
 
 let local_libraries =
   [ ("otherlibs/ordering", Some "Ordering", false, None)

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -70,7 +70,12 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
           ; Pp.nop
           ; def "external_libraries"
               (List
-                 (List.map externals ~f:(fun x -> Lib.name x |> Lib_name.to_dyn)))
+                 (List.filter_map externals ~f:(fun x ->
+                      let name = Lib.name x in
+                      if
+                        Lib_name.equal name (Lib_name.of_string "threads.posix")
+                      then None
+                      else Some (Lib_name.to_dyn name))))
           ; Pp.nop
           ; def "local_libraries" (List locals)
           ; Pp.nop


### PR DESCRIPTION
Dune's bootstrap-info plugin generates a different set of dependencies between 4.x and 5.x since the new `META` files in the compiler deprecate the "threads.posix" package.

Simply changing threads.posix in the various dune files won't work because it would break `implicit_transitive_deps false` on 4.x. For the same reason, the internal `META` used for 4.x can't be changed for the same reason. Including both `threads` and `threads.posix` in `bin/dune` correctly adds both `threads` and `threads.posix` on both, but in a different order, since the compiler's `META` file has `threads.posix` depending on threads, where the legacy 4.x file uses predicates and so has `threads` depending on `threads.posix`.

So this solution, given that it's just for the boostrap-info, suggests adding `threads` to `bin/dune` (with a note that `threads.posix` is there to keep `implicit_transitive_deps false` correct on 4.x) and then filters out `threads.posix` in the resulting list, since it requires special handling in `boot/duneboot.ml` anyway.