### PR TITLE
refactor(scheduler): remove unused function

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -858,11 +858,6 @@ let stats () =
 
 let running_jobs_count t = Event.Queue.pending_jobs t.events
 
-let yield_if_there_are_pending_events () =
-  t_opt () >>= function
-  | None -> Fiber.return ()
-  | Some t -> Event.Queue.yield_if_there_are_pending_events t.events
-
 exception Build_cancelled
 
 let cancelled () = raise (Memo.Non_reproducible Build_cancelled)

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -119,8 +119,6 @@ val wait_for_process :
   -> Pid.t
   -> Proc.Process_info.t Fiber.t
 
-val yield_if_there_are_pending_events : unit -> unit Fiber.t
-
 (** If the current build was cancelled, raise
     [Memo.Non_reproducible Run.Build_cancelled]. *)
 val abort_if_build_was_cancelled : unit Fiber.t


### PR DESCRIPTION
yield_if_there_are_pending_events is unused

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 631072bf-8a7f-48e7-a093-fd20c5554e0e