### PR TITLE
refactor(scheduler): move [Signal] to [Stdune]

### DIFF
--- a/otherlibs/stdune/signal.ml
+++ b/otherlibs/stdune/signal.ml
@@ -1,37 +1,121 @@
-let name =
-  let table =
-    let open Sys in
-    [ (sigabrt, "ABRT")
-    ; (sigalrm, "ALRM")
-    ; (sigfpe, "FPE")
-    ; (sighup, "HUP")
-    ; (sigill, "ILL")
-    ; (sigint, "INT")
-    ; (sigkill, "KILL")
-    ; (sigpipe, "PIPE")
-    ; (sigquit, "QUIT")
-    ; (sigsegv, "SEGV")
-    ; (sigterm, "TERM")
-    ; (sigusr1, "USR1")
-    ; (sigusr2, "USR2")
-    ; (sigchld, "CHLD")
-    ; (sigcont, "CONT")
-    ; (sigstop, "STOP")
-    ; (sigtstp, "TSTP")
-    ; (sigttin, "TTIN")
-    ; (sigttou, "TTOU")
-    ; (sigvtalrm, "VTALRM")
-    ; (sigprof, "PROF")
-    ; (sigbus, "BUS")
-    ; (sigpoll, "POLL")
-    ; (sigsys, "SYS")
-    ; (sigtrap, "TRAP")
-    ; (sigurg, "URG")
-    ; (sigxcpu, "XCPU")
-    ; (sigxfsz, "XFSZ")
-    ]
-  in
-  fun n ->
-    match List.assoc table n with
-    | None -> Printf.sprintf "%d\n" n
-    | Some s -> s
+type t =
+  | Int
+  | Term
+  | Abrt
+  | Alrm
+  | Fpe
+  | Hup
+  | Ill
+  | Kill
+  | Pipe
+  | Quit
+  | Segv
+  | Usr1
+  | Usr2
+  | Chld
+  | Cont
+  | Stop
+  | Tstp
+  | Ttin
+  | Ttou
+  | Vtalrm
+  | Prof
+  | Bus
+  | Poll
+  | Sys
+  | Trap
+  | Urg
+  | Xcpu
+  | Xfsz
+  | Unknown of int
+
+let all =
+  let open Sys in
+  [ (Abrt, sigabrt)
+  ; (Alrm, sigalrm)
+  ; (Fpe, sigfpe)
+  ; (Hup, sighup)
+  ; (Ill, sigill)
+  ; (Int, sigint)
+  ; (Kill, sigkill)
+  ; (Pipe, sigpipe)
+  ; (Quit, sigquit)
+  ; (Segv, sigsegv)
+  ; (Term, sigterm)
+  ; (Usr1, sigusr1)
+  ; (Usr2, sigusr2)
+  ; (Chld, sigchld)
+  ; (Cont, sigcont)
+  ; (Stop, sigstop)
+  ; (Tstp, sigtstp)
+  ; (Ttin, sigttin)
+  ; (Ttou, sigttou)
+  ; (Vtalrm, sigvtalrm)
+  ; (Prof, sigprof)
+  ; (Bus, sigbus)
+  ; (Poll, sigpoll)
+  ; (Sys, sigsys)
+  ; (Trap, sigtrap)
+  ; (Urg, sigurg)
+  ; (Xcpu, sigxcpu)
+  ; (Xfsz, sigxfsz)
+  ]
+
+let name = function
+  | Abrt -> "ABRT"
+  | Alrm -> "ALRM"
+  | Fpe -> "FPE"
+  | Hup -> "HUP"
+  | Ill -> "ILL"
+  | Int -> "INT"
+  | Kill -> "KILL"
+  | Pipe -> "PIPE"
+  | Quit -> "QUIT"
+  | Segv -> "SEGV"
+  | Term -> "TERM"
+  | Usr1 -> "USR1"
+  | Usr2 -> "USR2"
+  | Chld -> "CHLD"
+  | Cont -> "CONT"
+  | Stop -> "STOP"
+  | Tstp -> "TSTP"
+  | Ttin -> "TTIN"
+  | Ttou -> "TTOU"
+  | Vtalrm -> "VTALRM"
+  | Prof -> "PROF"
+  | Bus -> "BUS"
+  | Poll -> "POLL"
+  | Sys -> "SYS"
+  | Trap -> "TRAP"
+  | Urg -> "URG"
+  | Xcpu -> "XCPU"
+  | Xfsz -> "XFSZ"
+  | Unknown n -> Int.to_string n
+
+let compare (x : t) (y : t) = Poly.compare x y
+
+let to_dyn =
+  let open Dyn in
+  function
+  | Unknown n -> variant "Unknown" [ int n ]
+  | t -> variant (name t) []
+
+include Comparable.Make (struct
+  type nonrec t = t
+
+  let compare = compare
+
+  let to_dyn = to_dyn
+end)
+
+let to_int =
+  let table = Map.of_list_exn all in
+  function
+  | Unknown n -> n
+  | t -> Map.find_exn table t
+
+let of_int i =
+  let table = Int.Map.of_list_exn (List.map all ~f:(fun (t, i) -> (i, t))) in
+  match Int.Map.find table i with
+  | None -> Unknown i
+  | Some s -> s

--- a/otherlibs/stdune/signal.mli
+++ b/otherlibs/stdune/signal.mli
@@ -1,4 +1,43 @@
 (** Unix Signal helpers *)
 
-(** Convert a signal number to a name: "INT", "TERM", ... *)
-val name : int -> string
+type t =
+  | Int
+  | Term
+  | Abrt
+  | Alrm
+  | Fpe
+  | Hup
+  | Ill
+  | Kill
+  | Pipe
+  | Quit
+  | Segv
+  | Usr1
+  | Usr2
+  | Chld
+  | Cont
+  | Stop
+  | Tstp
+  | Ttin
+  | Ttou
+  | Vtalrm
+  | Prof
+  | Bus
+  | Poll
+  | Sys
+  | Trap
+  | Urg
+  | Xcpu
+  | Xfsz
+  | Unknown of int
+
+(** Get the signal's name, e.g. [Int] maps to "INT", [Term] to "TERM", etc. *)
+val name : t -> string
+
+val to_int : t -> int
+
+val to_dyn : t -> Dyn.t
+
+val compare : t -> t -> Ordering.t
+
+val of_int : int -> t

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -32,14 +32,6 @@ module Run : sig
     | No_watcher
 
   module Shutdown : sig
-    module Signal : sig
-      (* TODO move this stuff into stdune? *)
-      type t =
-        | Int
-        | Quit
-        | Term
-    end
-
     module Reason : sig
       type t =
         | Requested

--- a/src/dune_util/log.ml
+++ b/src/dune_util/log.ml
@@ -65,6 +65,8 @@ let command ~command_line ~output ~exit_status =
     (match (exit_status : Unix.process_status) with
     | WEXITED 0 -> ()
     | WEXITED n -> Printf.fprintf oc "[%d]\n" n
-    | WSIGNALED n -> Printf.fprintf oc "[got signal %s]\n" (Signal.name n)
+    | WSIGNALED n ->
+      let name = Signal.of_int n |> Signal.name in
+      Printf.fprintf oc "[got signal %s]\n" name
     | WSTOPPED _ -> assert false);
     flush oc


### PR DESCRIPTION
The `Signal` module is general purpose enough to live in `Stdune`. I've also expanded it to cover all known signals.