### PR TITLE
Defer computation of local_bin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,9 @@ Unreleased
 
 - Add 4.14.0 MSVC to CI (#6917, @jonahbeckford)
 
+- Fix dependency cycle when installing files to the bin section with
+  `glob_files` (#6764, fixes #6708, @gridbugs)
+
 3.6.2 (2022-12-21)
 ------------------
 

--- a/src/dune_rules/artifacts.mli
+++ b/src/dune_rules/artifacts.mli
@@ -3,6 +3,11 @@ open Import
 module Bin : sig
   type t
 
+  (** Force the computation of the internal list of binaries. This is exposed as
+      some error checking is only performed during this computation and some
+      errors will go unreported unless this computation takes place. *)
+  val force : t -> unit Memo.t
+
   val bin_dir_basename : Filename.t
 
   (** [local_bin dir] The directory which contains the local binaries viewed by
@@ -24,7 +29,7 @@ module Bin : sig
     val create : Path.Build.Set.t -> t
   end
 
-  val create : context:Context.t -> local_bins:Local.t -> t
+  val create : context:Context.t -> local_bins:Local.t Memo.Lazy.t -> t
 
   val add_binaries : t -> dir:Path.Build.t -> File_binding.Expanded.t list -> t
 end
@@ -46,4 +51,5 @@ type t = private
   ; bin : Bin.t
   }
 
-val create : Context.t -> public_libs:Lib.DB.t -> local_bins:Bin.Local.t -> t
+val create :
+  Context.t -> public_libs:Lib.DB.t -> local_bins:Bin.Local.t Memo.Lazy.t -> t

--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -89,8 +89,11 @@ let all =
       let artifacts =
         Memo.lazy_ @@ fun () ->
         let* public_libs = Scope.DB.public_libs context in
-        let* stanzas = Only_packages.filtered_stanzas context in
-        let+ local_bins = get_installed_binaries ~context stanzas in
+        let+ stanzas = Only_packages.filtered_stanzas context in
+        let local_bins =
+          Memo.lazy_ ~name:"get_installed_binaries" (fun () ->
+              get_installed_binaries ~context stanzas)
+        in
         Artifacts.create context ~public_libs ~local_bins
       in
       (context.name, artifacts))

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -56,6 +56,7 @@ let get () =
   let* conf = Dune_load.load () in
   let* contexts = Context.DB.all () in
   let* scontexts = Memo.Lazy.force Super_context.all in
+  let* () = Super_context.all_init_deferred () in
   Memo.return { conf; contexts; scontexts }
 
 let find_context_exn t ~name =

--- a/src/dune_rules/super_context.mli
+++ b/src/dune_rules/super_context.mli
@@ -9,6 +9,10 @@ type t
 
 val all : t Context_name.Map.t Memo.Lazy.t
 
+(** In order to break circular dependencies within [all], some initialization is
+    deferred *)
+val all_init_deferred : unit -> unit Memo.t
+
 (** Find a super context by name. *)
 val find : Context_name.t -> t option Memo.t
 

--- a/test/blackbox-tests/test-cases/install-bin-glob.t
+++ b/test/blackbox-tests/test-cases/install-bin-glob.t
@@ -1,0 +1,36 @@
+Referring to files with a glob in the bin section of the install stanza
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.6)
+  > (package (name foo))
+  > EOF
+
+Make some scripts to install in bin.
+  $ cat >hello.sh <<EOF
+  > #!/bin/sh
+  > echo "Hello, World!"
+  > EOF
+
+  $ cat >foo.sh <<EOF
+  > #!/bin/sh
+  > echo foo
+  > EOF
+
+Refer to the scripts with a glob.
+  $ cat >dune <<EOF
+  > (install
+  >  (section bin)
+  >  (files (glob_files *.sh)))
+  > EOF
+
+  $ dune build @install
+
+  $ find _build/install/default | sort
+  _build/install/default
+  _build/install/default/bin
+  _build/install/default/bin/foo.sh
+  _build/install/default/bin/hello.sh
+  _build/install/default/lib
+  _build/install/default/lib/foo
+  _build/install/default/lib/foo/META
+  _build/install/default/lib/foo/dune-package

--- a/test/blackbox-tests/test-cases/install-bin-include.t
+++ b/test/blackbox-tests/test-cases/install-bin-include.t
@@ -1,0 +1,47 @@
+Referring to files with an include in the bin section of the install stanza
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.6)
+  > (package (name foo))
+  > EOF
+
+Make some scripts to install in bin.
+  $ cat >hello.sh <<EOF
+  > #!/bin/sh
+  > echo "Hello, World!"
+  > EOF
+
+  $ cat >foo.sh <<EOF
+  > #!/bin/sh
+  > echo foo
+  > EOF
+
+Refer to the scripts with an include statement.
+  $ echo '(hello.sh foo.sh)' > files.sexp
+  $ cat >dune <<EOF
+  > (install
+  >  (section bin)
+  >  (files (include files.sexp)))
+  > EOF
+
+  $ dune build @install
+
+Refer to the scripts literally.
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section bin)
+  >  (files hello.sh foo.sh))
+  > EOF
+
+  $ dune build @install
+
+  $ find _build/install/default | sort
+  _build/install/default
+  _build/install/default/bin
+  _build/install/default/bin/foo.sh
+  _build/install/default/bin/hello.sh
+  _build/install/default/lib
+  _build/install/default/lib/foo
+  _build/install/default/lib/foo/META
+  _build/install/default/lib/foo/dune-package


### PR DESCRIPTION
This fixes a memo dependency cycle between evaluating globs in install stanzas and populating the artifacts database. Populating the artifacts database involves enumerating all files installed in the "bin" section which involves expanding globs as these files can be specified as globs rather than literal files. Expanding globs in the install stanza requires loading the rules for the directory containing the glob, and doing so depends on the artifacts database.

Fixes #6708 