### PR TITLE
refactor(memo): optimize Memo.Lazy.create

### DIFF
--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -1592,10 +1592,8 @@ module Lazy = struct
   end
 
   let create ?cutoff ?name ?human_readable_description f =
-    let (_ : (unit, 'a) Cell.t), t =
-      Expert.create ?cutoff ?name ?human_readable_description f
-    in
-    t
+    let cell = lazy_cell ?cutoff ?name ?human_readable_description f in
+    fun () -> Cell.read cell
 
   let force f = f ()
 


### PR DESCRIPTION
Do not allocate a tuple that gets thrown away immediately

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 50a3bfe1-ea76-43a8-a4e4-ccaff30c88d9