### PR TITLE
feature(coq): split native compilation

### DIFF
--- a/src/dune_rules/coq_mode.ml
+++ b/src/dune_rules/coq_mode.ml
@@ -10,6 +10,7 @@ type t =
   | Legacy
   | VoOnly
   | Native
+  | Native_split
 
 let decode ~coq_syntax =
   Dune_lang.Decoder.(
@@ -21,4 +22,5 @@ let decode ~coq_syntax =
               "Since Coq lang 0.7 native mode is automatically inferred from \
                the configuration of Coq."
           >>> return Native )
+      ; ("native-split", return Native_split)
       ])

--- a/src/dune_rules/coq_mode.mli
+++ b/src/dune_rules/coq_mode.mli
@@ -10,5 +10,6 @@ type t =
   | Legacy
   | VoOnly
   | Native
+  | Native_split
 
 val decode : coq_syntax:Dune_lang.Syntax.t -> t Dune_lang.Decoder.t

--- a/src/dune_rules/coq_module.ml
+++ b/src/dune_rules/coq_module.ml
@@ -66,7 +66,12 @@ let dep_file x ~obj_dir =
   let vo_dir = build_vo_dir ~obj_dir x in
   Path.Build.relative vo_dir (x.name ^ ".v.d")
 
+let vo_file x ~obj_dir =
+  let vo_dir = build_vo_dir ~obj_dir x in
+  Path.Build.relative vo_dir (name x ^ ".vo")
+
 type obj_files_mode =
+  | No_obj
   | Build
   | Install
 
@@ -81,7 +86,7 @@ let obj_files x ~wrapper_name ~mode ~obj_dir ~obj_files_mode =
   let install_vo_dir = String.concat ~sep:"/" x.prefix in
   let native_objs =
     match mode with
-    | Coq_mode.Native ->
+    | Coq_mode.Native | Native_split ->
       let cmxs_obj = cmxs_of_mod ~wrapper_name x in
       List.map
         ~f:(fun x ->
@@ -94,6 +99,7 @@ let obj_files x ~wrapper_name ~mode ~obj_dir ~obj_files_mode =
     match obj_files_mode with
     | Build -> [ x.name ^ ".vo"; x.name ^ ".glob" ]
     | Install -> [ x.name ^ ".vo" ]
+    | No_obj -> []
   in
   List.map obj_files ~f:(fun fname ->
       (Path.Build.relative vo_dir fname, Filename.concat install_vo_dir fname))

--- a/src/dune_rules/coq_module.mli
+++ b/src/dune_rules/coq_module.mli
@@ -42,9 +42,12 @@ val dep_file : t -> obj_dir:Path.Build.t -> Path.Build.t
 
 val glob_file : t -> obj_dir:Path.Build.t -> Path.Build.t
 
+val vo_file : t -> obj_dir:Path.Build.t -> Path.Build.t
+
 (** Some of the object files should not be installed, we control this with the
     following parameter *)
 type obj_files_mode =
+  | No_obj
   | Build
   | Install
 

--- a/test/blackbox-tests/test-cases/coq/native-split.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-split.t/run.t
@@ -1,0 +1,76 @@
+Testing split compilation of native
+
+  $ cat > a.v << EOF
+  > Inductive a := A.
+  > EOF
+
+  $ cat > b.v << EOF
+  > Require Import a.
+  > Inductive b := B.
+  > EOF
+
+  $ cat > c.v << EOF
+  > Require Import b.
+  > Inductive c := C.
+  > EOF
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.7)
+  > (using coq 0.7)
+  > EOF
+
+  $ cat > dune << EOF
+  > (coq.theory
+  >  (name foo)
+  >  (mode native-split)
+  > )
+  > EOF
+
+  $ dune build --display=short --always-show-command-line
+        coqdep a.v.d
+        coqdep b.v.d
+        coqdep c.v.d
+          coqc a.{glob,vo}
+     coqnative Nfoo_a.{cmi,cmxs}
+          coqc b.{glob,vo}
+     coqnative Nfoo_b.{cmi,cmxs}
+          coqc c.{glob,vo}
+     coqnative Nfoo_c.{cmi,cmxs}
+
+  $ ls -a _build/default/
+  .
+  ..
+  .a.aux
+  .b.aux
+  .c.aux
+  .dune
+  Nfoo_a.cmi
+  Nfoo_a.cmx
+  Nfoo_a.cmxs
+  Nfoo_a.o
+  Nfoo_b.cmi
+  Nfoo_b.cmx
+  Nfoo_b.cmxs
+  Nfoo_b.o
+  Nfoo_c.cmi
+  Nfoo_c.cmx
+  Nfoo_c.cmxs
+  Nfoo_c.o
+  a.glob
+  a.v
+  a.v.d
+  a.vo
+  a.vok
+  a.vos
+  b.glob
+  b.v
+  b.v.d
+  b.vo
+  b.vok
+  b.vos
+  c.glob
+  c.v
+  c.v.d
+  c.vo
+  c.vok
+  c.vos


### PR DESCRIPTION
We add a new mode to the coq.theory stanza allowing a user to use split compilation for compiling native Coq files. Split compilation is generally slower than doing it at once, however it can lead to a finer build which some users may want.

TODO:
- [ ] doc
- [ ] changelog