### PR TITLE
refactor(alias): create doc-latex alias and use in coq_rules

### DIFF
--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -166,6 +166,8 @@ let install = make_standard Name.install
 
 let doc = make_standard (Name.of_string "doc")
 
+let doc_latex = make_standard (Name.of_string "doc-latex")
+
 let private_doc = make_standard (Name.of_string "doc-private")
 
 let lint = make_standard (Name.of_string "lint")

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -63,6 +63,8 @@ val install : dir:Path.Build.t -> t
 
 val doc : dir:Path.Build.t -> t
 
+val doc_latex : dir:Path.Build.t -> t
+
 val private_doc : dir:Path.Build.t -> t
 
 val lint : dir:Path.Build.t -> t

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -495,7 +495,7 @@ let setup_coqdoc_rules ~sctx ~dir ~theories_deps (s : Coq_stanza.Theory.t)
       let alias =
         match mode with
         | `Html -> Alias.doc ~dir
-        | `Latex -> Alias.make (Alias.Name.of_string "doc-latex") ~dir
+        | `Latex -> Alias.doc_latex ~dir
       in
       coqdoc_directory ~mode ~obj_dir:dir ~name
       |> Path.build |> Action_builder.path


### PR DESCRIPTION
This can also be used by #5366.

No rush merging this for the moment.