### PR TITLE
fix: render pending messages

### DIFF
--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -304,9 +304,9 @@ module Backend = struct
         Base.start ();
         while true do
           Mutex.lock mutex;
+          Base.render state;
           let finish_requested = state.finish_requested in
           if finish_requested then raise_notrace Exit;
-          Base.render state;
           Mutex.unlock mutex;
           let now = Unix.gettimeofday () in
           let elapsed = now -. !last in


### PR DESCRIPTION
previous behavior: an exit request would immediately quit the
rendering loop

new behavior: render the UI and then serve the exit request

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: c95407f2-18ce-483c-8a6e-33878d45f106