### PR TITLE
fix: handle missing CLICOLOR_FORCE correctly

### DIFF
--- a/otherlibs/stdune/ansi_color.ml
+++ b/otherlibs/stdune/ansi_color.ml
@@ -215,7 +215,7 @@ let supports_color isatty =
     | _ -> true
   and clicolor_force =
     match Env.(get initial) "CLICOLOR_FORCE" with
-    | Some "0" -> false
+    | None | Some "0" -> false
     | _ -> true
   in
   clicolor_force || (is_smart && clicolor && Lazy.force isatty)


### PR DESCRIPTION
when this variable is absent, we should not force colors

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: a96f4cc6-068c-4b53-946d-8a9986ca986c