### PR TITLE
refactor: print shutdown exception

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -28,6 +28,13 @@ module Shutdown = struct
   end
 
   exception E of Reason.t
+
+  let () =
+    Printexc.register_printer (function
+      | E Requested -> Some "shutdown: requested"
+      | E (Signal s) ->
+        Some (sprintf "shutdown: signal %s received" (Signal.name s))
+      | _ -> None)
 end
 
 let blocked_signals : Signal.t list = [ Int; Quit; Term ]


### PR DESCRIPTION
In some buggy tests, this error leaks. It's useful to print what it is
in such cases.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 403a00cb-7113-470d-b6dd-a0ed14ddb8e2