### PR TITLE
refactor(scheduler): remove duplicate types

### DIFF
--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -19,12 +19,27 @@ type job =
   }
 
 module Shutdown = struct
-  module Signal = Signal
-
   module Reason = struct
-    type t =
-      | Requested
-      | Signal of Signal.t
+    module T = struct
+      type t =
+        | Requested
+        | Signal of Signal.t
+
+      let to_dyn t =
+        match t with
+        | Requested -> Dyn.Variant ("Requested", [])
+        | Signal signal -> Dyn.Variant ("Signal", [ Signal.to_dyn signal ])
+
+      let compare a b =
+        match (a, b) with
+        | Requested, Requested -> Eq
+        | Requested, _ -> Lt
+        | _, Requested -> Gt
+        | Signal a, Signal b -> Signal.compare a b
+    end
+
+    include T
+    include Comparable.Make (T)
   end
 
   exception E of Reason.t
@@ -76,29 +91,6 @@ end = struct
     ()
 end
 
-module Shutdown_reason = struct
-  module T = struct
-    type t =
-      | Shutdown
-      | Signal of Signal.t
-
-    let to_dyn t =
-      match t with
-      | Shutdown -> Dyn.Variant ("Shutdown", [])
-      | Signal signal -> Dyn.Variant ("Signal", [ Signal.to_dyn signal ])
-
-    let compare a b =
-      match (a, b) with
-      | Shutdown, Shutdown -> Eq
-      | Shutdown, _ -> Lt
-      | _, Shutdown -> Gt
-      | Signal a, Signal b -> Signal.compare a b
-  end
-
-  include T
-  include Comparable.Make (T)
-end
-
 (** The event queue *)
 module Event : sig
   type build_input_change =
@@ -110,7 +102,7 @@ module Event : sig
     | Build_inputs_changed of build_input_change Nonempty_list.t
     | File_system_sync of Dune_file_watcher.Sync_id.t
     | File_system_watcher_terminated
-    | Shutdown of Shutdown_reason.t
+    | Shutdown of Shutdown.Reason.t
     | Fiber_fill_ivar of Fiber.fill
 
   module Queue : sig
@@ -149,7 +141,7 @@ module Event : sig
 
     val send_job_completed : t -> job -> Proc.Process_info.t -> unit
 
-    val send_signal : t -> Shutdown_reason.t -> unit
+    val send_shutdown : t -> Shutdown.Reason.t -> unit
 
     val send_timers_completed : t -> Fiber.fill Nonempty_list.t -> unit
 
@@ -165,7 +157,7 @@ end = struct
     | Build_inputs_changed of build_input_change Nonempty_list.t
     | File_system_sync of Dune_file_watcher.Sync_id.t
     | File_system_watcher_terminated
-    | Shutdown of Shutdown_reason.t
+    | Shutdown of Shutdown.Reason.t
     | Fiber_fill_ivar of Fiber.fill
 
   module Invalidation_event = struct
@@ -181,7 +173,7 @@ end = struct
       { jobs_completed : (job * Proc.Process_info.t) Queue.t
       ; file_watcher_tasks : (unit -> Dune_file_watcher.Event.t list) Queue.t
       ; mutable invalidation_events : Invalidation_event.t list
-      ; mutable signals : Shutdown_reason.Set.t
+      ; mutable shutdown_reasons : Shutdown.Reason.Set.t
       ; mutex : Mutex.t
       ; cond : Condition.t
       ; mutable pending_jobs : int
@@ -198,7 +190,7 @@ end = struct
       let file_watcher_tasks = Queue.create () in
       let worker_tasks_completed = Queue.create () in
       let invalidation_events = [] in
-      let signals = Shutdown_reason.Set.empty in
+      let shutdown_reasons = Shutdown.Reason.Set.empty in
       let mutex = Mutex.create () in
       let cond = Condition.create () in
       let pending_jobs = 0 in
@@ -208,7 +200,7 @@ end = struct
       ; file_watcher_tasks
       ; invalidation_events
       ; timers
-      ; signals
+      ; shutdown_reasons
       ; mutex
       ; cond
       ; pending_jobs
@@ -247,7 +239,7 @@ end = struct
 
       type t
 
-      val signal : t
+      val shutdown : t
 
       val file_watcher_task : t
 
@@ -271,11 +263,13 @@ end = struct
 
       let run t q = t q
 
-      let signal : t =
+      let shutdown : t =
        fun q ->
-        Option.map (Shutdown_reason.Set.choose q.signals) ~f:(fun signal ->
-            q.signals <- Shutdown_reason.Set.remove q.signals signal;
-            Shutdown signal)
+        Option.map (Shutdown.Reason.Set.choose q.shutdown_reasons)
+          ~f:(fun reason ->
+            q.shutdown_reasons <-
+              Shutdown.Reason.Set.remove q.shutdown_reasons reason;
+            Shutdown reason)
 
       let file_watcher_task q =
         Option.map (Queue.pop q.file_watcher_tasks) ~f:(fun job ->
@@ -356,7 +350,7 @@ end = struct
                     latency is also important. [jobs_completed] and [yield] are
                     where the bulk of the work is done, so they are the lowest
                     priority to avoid starving other things. *)
-                 [ signal
+                 [ shutdown
                  ; file_watcher_task
                  ; invalidation
                  ; worker_tasks_completed
@@ -395,9 +389,10 @@ end = struct
     let send_job_completed q job proc_info =
       add_event q (fun q -> Queue.push q.jobs_completed (job, proc_info))
 
-    let send_signal q signal =
+    let send_shutdown q signal =
       add_event q (fun q ->
-          q.signals <- Shutdown_reason.Set.add q.signals signal)
+          q.shutdown_reasons <-
+            Shutdown.Reason.Set.add q.shutdown_reasons signal)
 
     let send_file_watcher_task q job =
       add_event q (fun q -> Queue.push q.file_watcher_tasks job)
@@ -612,7 +607,7 @@ end = struct
     let wait_signal = Staged.unstage (signal_waiter ()) in
     while true do
       let signal = wait_signal () in
-      Event.Queue.send_signal q (Signal signal);
+      Event.Queue.send_shutdown q (Signal signal);
       match signal with
       | Int | Quit | Term ->
         let now = Unix.gettimeofday () in
@@ -859,28 +854,28 @@ let wait_for_process t pid =
   | Cancelled () -> cancelled ()
   | Not_cancelled -> res
 
-let got_signal signal =
+let got_shutdown reason =
   if !Log.verbose then
-    match (signal : Shutdown_reason.t) with
-    | Shutdown -> Log.info [ Pp.textf "Shutting down." ]
+    match (reason : Shutdown.Reason.t) with
+    | Requested -> Log.info [ Pp.textf "Shutting down." ]
     | Signal signal ->
       Log.info [ Pp.textf "Got signal %s, exiting." (Signal.name signal) ]
 
 let filesystem_watcher_terminated () =
   Log.info [ Pp.textf "Filesystem watcher terminated, exiting." ]
 
-type saw_signal =
+type saw_shutdown =
   | Ok
-  | Got_signal
+  | Got_shutdown
 
 let kill_and_wait_for_all_processes t =
   Process_watcher.killall t.process_watcher Sys.sigkill;
   let saw_signal = ref Ok in
   while Event.Queue.pending_jobs t.events > 0 do
     match Event.Queue.next t.events with
-    | Shutdown signal ->
-      got_signal signal;
-      saw_signal := Got_signal
+    | Shutdown reason ->
+      got_shutdown reason;
+      saw_signal := Got_shutdown
     | _ -> ()
   done;
   !saw_signal
@@ -974,14 +969,9 @@ end = struct
       filesystem_watcher_terminated ();
       raise (Abort Already_reported)
     | Fiber_fill_ivar fill -> [ fill ]
-    | Shutdown signal ->
-      got_signal signal;
-      raise
-      @@ Abort
-           (Shutdown_requested
-              (match signal with
-              | Shutdown -> Requested
-              | Signal s -> Signal s))
+    | Shutdown reason ->
+      got_shutdown reason;
+      raise @@ Abort (Shutdown_requested reason)
 
   and build_input_change (t : t) events =
     let invalidation = handle_invalidation_events events in
@@ -1050,7 +1040,7 @@ end = struct
     let res = run t f in
     Console.Status_line.clear ();
     match kill_and_wait_for_all_processes t with
-    | Got_signal -> Error Already_reported
+    | Got_shutdown -> Error Already_reported
     | Ok -> res
 end
 
@@ -1249,7 +1239,7 @@ module Run = struct
               (fun () ->
                 let+ res = Alarm_clock.await sleep in
                 match res with
-                | `Finished -> Event_queue.send_signal t.events Shutdown
+                | `Finished -> Event_queue.send_shutdown t.events Requested
                 | `Cancelled -> ())
               (fun () ->
                 Fiber.finalize run ~finally:(fun () ->
@@ -1269,7 +1259,7 @@ module Run = struct
         | `Kill pid -> ignore (wait_for_process t pid : _ Fiber.t)
         | `Thunk f -> f ()
         | `No_op -> ());
-    ignore (kill_and_wait_for_all_processes t : saw_signal);
+    ignore (kill_and_wait_for_all_processes t : saw_shutdown);
     if Lazy.is_val t.alarm_clock then
       Alarm_clock.close (Lazy.force t.alarm_clock);
     match result with
@@ -1280,7 +1270,7 @@ end
 
 let shutdown () =
   let+ t = t () in
-  Event.Queue.send_signal t.events Shutdown
+  Event.Queue.send_shutdown t.events Requested
 
 let inject_memo_invalidation invalidation =
   let* t = t () in


### PR DESCRIPTION
[Shutdown.Reason.t] and [Shutdown_reason.t] are the same modulo
constructor names.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: d75c7609-cd02-4fe2-9c30-d08cd71ea60f