### PR TITLE
fix(melange): check rules

### DIFF
--- a/src/dune_rules/check_rules.ml
+++ b/src/dune_rules/check_rules.ml
@@ -11,10 +11,15 @@ let dev_files =
       let ext = Filename.extension p in
       List.mem exts ext ~equal:String.equal)
 
-let add_obj_dir sctx ~obj_dir =
+let add_obj_dir sctx ~obj_dir mode =
   if (Super_context.context sctx).merlin then
     let dir_glob =
-      let dir = Path.build (Obj_dir.byte_dir obj_dir) in
+      let dir =
+        Path.build
+          (match mode with
+          | `Melange -> Obj_dir.melange_dir obj_dir
+          | `Bytecode -> Obj_dir.byte_dir obj_dir)
+      in
       File_selector.create ~dir dev_files
     in
     Rules.Produce.Alias.add_deps

--- a/src/dune_rules/check_rules.mli
+++ b/src/dune_rules/check_rules.mli
@@ -1,7 +1,10 @@
 open Import
 
 val add_obj_dir :
-  Super_context.t -> obj_dir:Path.Build.t Obj_dir.t -> unit Memo.t
+     Super_context.t
+  -> obj_dir:Path.Build.t Obj_dir.t
+  -> [ `Melange | `Bytecode ]
+  -> unit Memo.t
 
 val add_files :
   Super_context.t -> dir:Path.Build.t -> Path.t list -> unit Memo.t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -102,7 +102,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
     Dir_contents.ocaml dir_contents
     >>| Ml_sources.modules_and_obj_dir ~for_:(Exe { first_exe })
   in
-  let* () = Check_rules.add_obj_dir sctx ~obj_dir in
+  let* () = Check_rules.add_obj_dir sctx ~obj_dir `Bytecode in
   let ctx = Super_context.context sctx in
   let project = Scope.project scope in
   let programs = programs ~modules ~exes in

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -485,14 +485,20 @@ let library_rules (lib : Library.t) ~local_lib ~cctx ~source_modules
     Memo.Option.iter vimpl
       ~f:(Virtual_rules.setup_copy_rules_for_impl ~sctx ~dir)
   in
-  let* () = Check_rules.add_obj_dir sctx ~obj_dir in
   let* () = Check_rules.add_cycle_check sctx ~dir top_sorted_modules in
   let* () = gen_wrapped_compat_modules lib cctx
   and* () = Module_compilation.build_all cctx
   and* expander = Super_context.expander sctx ~dir
   and* lib_info =
     let lib_config = (Super_context.context sctx).lib_config in
-    Library.to_lib_info lib ~dir ~lib_config
+    let* info = Library.to_lib_info lib ~dir ~lib_config in
+    let mode =
+      match Lib_info.modes info with
+      | { ocaml = { byte = false; native = _ }; melange = true } -> `Melange
+      | _ -> `Bytecode
+    in
+    let+ () = Check_rules.add_obj_dir sctx ~obj_dir mode in
+    info
   in
   let+ () =
     Memo.when_

--- a/src/dune_rules/melange_rules.ml
+++ b/src/dune_rules/melange_rules.ml
@@ -145,7 +145,7 @@ let setup_emit_cmj_rules ~sctx ~dir ~scope ~expander ~dir_contents
       Dir_contents.ocaml dir_contents
       >>| Ml_sources.modules_and_obj_dir ~for_:(Melange { target = mel.target })
     in
-    let* () = Check_rules.add_obj_dir sctx ~obj_dir in
+    let* () = Check_rules.add_obj_dir sctx ~obj_dir `Melange in
     let* modules, pp =
       Buildable_rules.modules_rules sctx
         (Melange


### PR DESCRIPTION
We need to add the correct set of .cmi files to the check alias depending on which mode we're working with.