### PR TITLE
doc: fix version indication for "dune ocaml top-module"

### DIFF
--- a/doc/toplevel-integration.rst
+++ b/doc/toplevel-integration.rst
@@ -25,7 +25,7 @@ you type in the toplevel will be rewritten with these PPX rewriters.
 
 This command became available with Dune 2.5.0.
 
-It's also possible to load individual modules (since dune 3.4.0) for
+It's also possible to load individual modules (since dune 3.6.0) for
 interactive development. Use the following dune command:
 
 .. code:: ocaml


### PR DESCRIPTION
Signed-off-by: Armaël Guéneau <Armael@users.noreply.github.com>

According to the changelog, `dune ocaml top-module` was in fact introduced in dune 3.6.0 (and indeed the command doesn't seem to exist in dune 3.4.0).