### PR TITLE
refactor(melange): share mode handling

### DIFF
--- a/src/dune_rules/check_rules.ml
+++ b/src/dune_rules/check_rules.ml
@@ -18,7 +18,7 @@ let add_obj_dir sctx ~obj_dir mode =
         Path.build
           (match mode with
           | `Melange -> Obj_dir.melange_dir obj_dir
-          | `Bytecode -> Obj_dir.byte_dir obj_dir)
+          | `Ocaml -> Obj_dir.byte_dir obj_dir)
       in
       File_selector.create ~dir dev_files
     in

--- a/src/dune_rules/check_rules.mli
+++ b/src/dune_rules/check_rules.mli
@@ -3,7 +3,7 @@ open Import
 val add_obj_dir :
      Super_context.t
   -> obj_dir:Path.Build.t Obj_dir.t
-  -> [ `Melange | `Bytecode ]
+  -> [ `Melange | `Ocaml ]
   -> unit Memo.t
 
 val add_files :

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -102,7 +102,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
     Dir_contents.ocaml dir_contents
     >>| Ml_sources.modules_and_obj_dir ~for_:(Exe { first_exe })
   in
-  let* () = Check_rules.add_obj_dir sctx ~obj_dir `Bytecode in
+  let* () = Check_rules.add_obj_dir sctx ~obj_dir `Ocaml in
   let ctx = Super_context.context sctx in
   let project = Scope.project scope in
   let programs = programs ~modules ~exes in

--- a/src/dune_rules/lib_mode.ml
+++ b/src/dune_rules/lib_mode.ml
@@ -89,5 +89,10 @@ module Map = struct
         [ ("ocaml", Ocaml.Mode.Dict.Set.to_dyn ocaml)
         ; ("melange", bool melange)
         ]
+
+    let for_merlin { ocaml = { byte; native = _ }; melange } =
+      match (byte, melange) with
+      | false, true -> `Melange
+      | _, _ -> `Ocaml
   end
 end

--- a/src/dune_rules/lib_mode.mli
+++ b/src/dune_rules/lib_mode.mli
@@ -57,5 +57,7 @@ module Map : sig
     val to_dyn : t -> Dyn.t
 
     val equal : t -> t -> bool
+
+    val for_merlin : t -> [ `Ocaml | `Melange ]
   end
 end

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -492,11 +492,7 @@ let library_rules (lib : Library.t) ~local_lib ~cctx ~source_modules
   and* lib_info =
     let lib_config = (Super_context.context sctx).lib_config in
     let* info = Library.to_lib_info lib ~dir ~lib_config in
-    let mode =
-      match Lib_info.modes info with
-      | { ocaml = { byte = false; native = _ }; melange = true } -> `Melange
-      | _ -> `Bytecode
-    in
+    let mode = Lib_mode.Map.Set.for_merlin (Lib_info.modes info) in
     let+ () = Check_rules.add_obj_dir sctx ~obj_dir mode in
     info
   in

--- a/src/dune_rules/merlin.ml
+++ b/src/dune_rules/merlin.ml
@@ -340,9 +340,7 @@ module Unprocessed = struct
       match modes with
       | `Exe -> `Ocaml
       | `Melange_emit -> `Melange
-      | `Lib (m : Lib_mode.Map.Set.t) ->
-        if m.melange && (not m.ocaml.byte) && not m.ocaml.native then `Melange
-        else `Ocaml
+      | `Lib (m : Lib_mode.Map.Set.t) -> Lib_mode.Map.Set.for_merlin m
     in
     let requires =
       match Resolve.peek requires with


### PR DESCRIPTION
We select the merlin mode for melange/ocaml in one place and use it on
both merlin and check_rules

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 01ddb83e-0902-40d7-bbde-fb98f7904c66 -->