### PR TITLE
fix(rpc): bidirectional communication

### DIFF
--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -501,8 +501,13 @@ module Client : sig
 
     type proc =
       | Request : ('a, 'b) Decl.request -> proc
+          (** The client may send the declared request *)
       | Notification : 'a Decl.notification -> proc
+          (** The client may send the declared notification *)
       | Poll : 'a Procedures.Poll.t -> proc
+          (** The client may start the declared polling loop *)
+      | Handle_request : ('a, 'b) Decl.request * ('a -> 'b fiber) -> proc
+          (** The client can handle the declared request *)
 
     val connect_with_menu :
          ?handler:Handler.t

--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -34,6 +34,18 @@ module Session : sig
       [session] *)
   val notification : _ t -> 'a Decl.Notification.witness -> 'a -> unit Fiber.t
 
+  (** [request t r id payload] sends a request [r] to [t] with [id] and
+      [payload].
+
+      Note that any request must be declared with [declare_request] before
+      sending it *)
+  val request :
+       _ t
+    -> ('a, 'b) Decl.Request.witness
+    -> Dune_rpc_private.Id.t
+    -> 'a
+    -> 'b Fiber.t
+
   val compare : 'a t -> 'a t -> Ordering.t
 
   val request_close : 'a t -> unit Fiber.t
@@ -101,6 +113,10 @@ module Handler : sig
   (** [declare_notification handler decl] Declares that this server may send
       notifications according to metadata [decl]. *)
   val declare_notification : 's t -> 'a Decl.notification -> unit
+
+  (** [declare_request handle decl] declares that this server may send requests
+      according to the metadata [decl]. *)
+  val declare_request : 's t -> ('a, 'b) Decl.request -> unit
 
   val implement_long_poll :
        _ t


### PR DESCRIPTION
This is needed for action runners.

Previously, only clients were allowed to make requests to servers. With this PR, the connection is completely symmetric and servers can also make requests to clients.

Note all the duplication between dune_rpc_private.ml and dune_rpc_server.ml. This is temporary and I'm going to fix this in time. We'll need a general `Session` module that can be used both the client and the server.