### PR TITLE
refactor(rpc): distinguish Timeout from Shutdown

### DIFF
--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -35,6 +35,7 @@ module Run : sig
     module Reason : sig
       type t =
         | Requested
+        | Timeout
         | Signal of Signal.t
     end
 

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -98,8 +98,13 @@ let%expect_test "empty invalidation wakes up waiter" =
     awaiting invalidation
     awaited invalidation |}];
   test `Ignore;
-  [%expect {|
-    awaiting invalidation |}]
+  [%expect.unreachable]
+  [@@expect.uncaught_exn
+    {|
+  ("shutdown: timeout")
+  Trailing output
+  ---------------
+  awaiting invalidation |}]
 
 let%expect_test "raise inside Scheduler.Run.go" =
   (try


### PR DESCRIPTION
When the scheduler shuts down due to a timeout (during testing), we
clarify this in the error message.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 34599c13-64db-448e-9c64-816940fc4889 -->