### PR TITLE
refactor(rpc): put menu into rpc session

### DIFF
--- a/src/dune_rpc_server/dune_rpc_server.mli
+++ b/src/dune_rpc_server/dune_rpc_server.mli
@@ -52,6 +52,8 @@ module Session : sig
 
     val id : _ t -> Id.t
 
+    val menu : _ t -> Menu.t option
+
     val initialize : _ t -> Initialize.Request.t
 
     val get : 'a t -> 'a


### PR DESCRIPTION
rather than managing it through a callback

I haven't removed the callback here because #6801 still depends on it. I'll get rid of the callback once the other PR is done.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 50d0fbed-32d8-4a6e-a00e-50d05191f177 -->