### PR TITLE
Refactor & Optimize Fiber Pool

### DIFF
--- a/otherlibs/fiber/pool.ml
+++ b/otherlibs/fiber/pool.ml
@@ -45,9 +45,13 @@ let task t ~f k =
 let stop t k =
   match t.status with
   | Closed -> k ()
-  | Open ->
+  | Open -> (
     t.status <- Closed;
-    write t Done k
+    match t.reader with
+    | None -> k ()
+    | Some r ->
+      t.reader <- None;
+      resume r Done (fun () -> k ()))
 
 let run t k =
   let n = ref 1 in

--- a/otherlibs/fiber/pool.ml
+++ b/otherlibs/fiber/pool.ml
@@ -6,12 +6,45 @@ type mvar =
   | Done
   | Task of (unit -> unit t)
 
+module Mvar = struct
+  type t =
+    { writers : (mvar * unit k) Queue.t
+    ; readers : mvar k Queue.t
+    ; mutable value : mvar option
+    }
+
+  let create () =
+    { value = None; writers = Queue.create (); readers = Queue.create () }
+
+  let read t k =
+    match t.value with
+    | None -> suspend (fun k -> Queue.push t.readers k) k
+    | Some v -> (
+      match Queue.pop t.writers with
+      | None ->
+        t.value <- None;
+        k v
+      | Some (v', w) ->
+        t.value <- Some v';
+        resume w () (fun () -> k v))
+
+  let write t x k =
+    match t.value with
+    | Some _ -> suspend (fun k -> Queue.push t.writers (x, k)) k
+    | None -> (
+      match Queue.pop t.readers with
+      | None ->
+        t.value <- Some x;
+        k ()
+      | Some r -> resume r x (fun () -> k ()))
+end
+
 type status =
   | Open
   | Closed
 
 type t =
-  { mvar : mvar Mvar.t
+  { mvar : Mvar.t
   ; mutable status : status
   }
 


### PR DESCRIPTION
This a series of commits that optimizes Fiber.Pool by implementing it from scratch on top of fiber's core rather than relying on unrelated primitives. The result is a much simpler implementation that affords a lot of optimizations:

* There's no need for a reader queue because a pool always has one reader.
* We can fuse the mvar and pool fields and get a more compact memory layout
* We don't need to rely on indirection from Fiber.Stream. This shaves off a whole lot of closures and removes the lock/unlock mutations which insert more of the write barrier.
* We inline and reuse a bunch of closures when reading from the queue. We no longer rely on general purpose stream/mvar primitives which allows us to specialize this code path a lot better.

The PR is composed of a series of commits that all do individual specializations/simplifications. I will squash them at the end. 

After this PR I have another PR with even more optimizations/simplifications but it subtly changes the semantics somewhat (for the better IMO). I will submit it after.