### PR TITLE
test(melange): include_subdirs

### DIFF
--- a/test/blackbox-tests/test-cases/melange/include_subdirs.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/include_subdirs.t/run.t
@@ -4,5 +4,14 @@ Test that libs using `(include_subdirs unqualified) work well with
 Build js files
   $ output=inside/output
   $ dune build @melange
+
+The directory structure of the .js should mimic the directory structure of the
+source:
+
+  $ find _build/default/$output -iname "*.js" | sort
+  _build/default/inside/output/inside/app/a.js
+  _build/default/inside/output/inside/app/b.js
+  _build/default/inside/output/inside/app/lib.js
+  _build/default/inside/output/inside/c.js
   $ node _build/default/$output/inside/c.js
   buy it


### PR DESCRIPTION
test should include .js paths to show that they're currently wrong

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 76c9d5a5-3c9c-471a-9bc0-bb36f0a6454d -->