### PR TITLE
feature: add -a flag for --auto-promote

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -604,7 +604,7 @@ module Builder = struct
         (let+ auto =
            Arg.(
              value & flag
-             & info [ "auto-promote" ] ~docs
+             & info [ "auto-promote"; "a" ] ~docs
                  ~doc:
                    "Automatically promote files. This is similar to running\n\
                    \                   $(b,dune promote) after the build.")


### PR DESCRIPTION
This lets users easily do `-wa` for instance.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 8ebfdf55-47f7-4504-a3c1-b43838db5b9e -->