### PR TITLE
refactor: move module settings to a common type

### DIFF
--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -23,8 +23,7 @@ end
 module Buildable : sig
   type t =
     { loc : Loc.t
-    ; modules : Ordered_set_lang.t
-    ; modules_without_implementation : Ordered_set_lang.t
+    ; modules : Stanza_common.Modules_settings.t
     ; empty_module_interface_if_absent : bool
     ; libraries : Lib_dep.t list
     ; foreign_archives : (Loc.t * Foreign.Archive.t) list
@@ -37,7 +36,6 @@ module Buildable : sig
     ; js_of_ocaml : Js_of_ocaml.In_buildable.t
     ; allow_overlapping_dependencies : bool
     ; ctypes : Ctypes_stanza.t option
-    ; root_module : (Loc.t * Module_name.t) option
     }
 
   (** Check if the buildable has any foreign stubs or archives. *)

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -51,7 +51,7 @@ let programs ~modules ~(exes : Executables.t) =
             ]
       | None ->
         let msg =
-          match Ordered_set_lang.loc exes.buildable.modules with
+          match Ordered_set_lang.loc exes.buildable.modules.modules with
           | None ->
             Pp.textf "Module %S doesn't exist." (Module_name.to_string mod_name)
           | Some _ ->

--- a/src/dune_rules/melange_stanzas.ml
+++ b/src/dune_rules/melange_stanzas.ml
@@ -7,15 +7,13 @@ module Emit = struct
     ; target : string
     ; alias : Alias.Name.t option
     ; module_system : Melange.Module_system.t
-    ; entries : Ordered_set_lang.t
+    ; modules : Stanza_common.Modules_settings.t
     ; libraries : Lib_dep.t list
     ; package : Package.t option
     ; preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
     ; preprocessor_deps : Dep_conf.t list
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t
-    ; root_module : (Loc.t * Module_name.t) option
-    ; modules_without_implementation : Ordered_set_lang.t
     ; allow_overlapping_dependencies : bool
     ; javascript_extension : string
     }
@@ -86,19 +84,17 @@ module Emit = struct
        and+ module_system =
          field "module_system"
            (enum [ ("es6", Melange.Module_system.Es6); ("commonjs", CommonJs) ])
-       and+ entries = Stanza_common.modules_field "entries"
        and+ libraries = field "libraries" decode_lib ~default:[]
        and+ package = field_o "package" Stanza_common.Pkg.decode
        and+ preprocess, preprocessor_deps = Stanza_common.preprocess_fields
        and+ promote = field_o "promote" Rule_mode_decoder.Promote.decode
        and+ loc_instrumentation, instrumentation = Stanza_common.instrumentation
        and+ compile_flags = Ordered_set_lang.Unexpanded.field "compile_flags"
-       and+ root_module = field_o "root_module" Module_name.decode_loc
        and+ javascript_extension = extension_field "javascript_extension"
        and+ allow_overlapping_dependencies =
          field_b "allow_overlapping_dependencies"
-       and+ modules_without_implementation =
-         Stanza_common.modules_field "modules_without_implementation"
+       and+ modules =
+         Stanza_common.Modules_settings.decode ~modules_field_name:"entries"
        in
        let preprocess =
          let init =
@@ -114,17 +110,15 @@ module Emit = struct
        ; target
        ; alias
        ; module_system
-       ; entries
+       ; modules
        ; libraries
        ; package
        ; preprocess
        ; preprocessor_deps
        ; promote
        ; compile_flags
-       ; root_module
        ; javascript_extension
        ; allow_overlapping_dependencies
-       ; modules_without_implementation
        })
 end
 

--- a/src/dune_rules/melange_stanzas.mli
+++ b/src/dune_rules/melange_stanzas.mli
@@ -7,15 +7,13 @@ module Emit : sig
     ; target : string
     ; alias : Alias.Name.t option
     ; module_system : Melange.Module_system.t
-    ; entries : Ordered_set_lang.t
+    ; modules : Stanza_common.Modules_settings.t
     ; libraries : Lib_dep.t list
     ; package : Package.t option
     ; preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
     ; preprocessor_deps : Dep_conf.t list
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t
-    ; root_module : (Loc.t * Module_name.t) option
-    ; modules_without_implementation : Ordered_set_lang.t
     ; allow_overlapping_dependencies : bool
     ; javascript_extension : string
     }

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -285,19 +285,13 @@ let make_lib_modules ~dir ~libs ~lookup_vlib ~(lib : Library.t) ~modules =
       (kind, main_module_name, wrapped)
   in
   let modules =
-    let { Buildable.loc = stanza_loc
-        ; modules = modules_field
-        ; modules_without_implementation
-        ; root_module
-        ; _
-        } =
+    let { Buildable.loc = stanza_loc; modules = modules_settings; _ } =
       lib.buildable
     in
-    Modules_field_evaluator.eval ~modules ~stanza_loc ~modules_field
-      ~modules_without_implementation ~root_module ~kind
+    Modules_field_evaluator.eval ~modules ~stanza_loc ~kind
       ~private_modules:
         (Option.value ~default:Ordered_set_lang.standard lib.private_modules)
-      ~src_dir:dir
+      ~src_dir:dir modules_settings
   in
   let stdlib = lib.stdlib in
   let implements = Option.is_some lib.implements in
@@ -347,19 +341,14 @@ let modules_of_stanzas dune_file ~dir ~scope ~lookup_vlib ~modules =
         `Library (lib, modules, obj_dir)
       | Executables exes | Tests { exes; _ } ->
         let modules =
-          let { Buildable.loc = stanza_loc
-              ; modules = modules_field
-              ; modules_without_implementation
-              ; root_module
-              ; _
-              } =
+          let { Buildable.loc = stanza_loc; modules = modules_settings; _ } =
             exes.buildable
           in
           let modules =
-            Modules_field_evaluator.eval ~modules ~stanza_loc ~modules_field
-              ~modules_without_implementation ~root_module
+            Modules_field_evaluator.eval ~modules ~stanza_loc
               ~kind:Modules_field_evaluator.Exe_or_normal_lib
               ~private_modules:Ordered_set_lang.standard ~src_dir:dir
+              modules_settings
           in
           let project = Scope.project scope in
           if Dune_project.wrapped_executables project then
@@ -382,11 +371,9 @@ let modules_of_stanzas dune_file ~dir ~scope ~lookup_vlib ~modules =
         let modules =
           let modules =
             Modules_field_evaluator.eval ~modules ~stanza_loc:mel.loc
-              ~modules_field:mel.entries
-              ~modules_without_implementation:mel.modules_without_implementation
-              ~root_module:mel.root_module
               ~kind:Modules_field_evaluator.Exe_or_normal_lib
               ~private_modules:Ordered_set_lang.standard ~src_dir:dir
+              mel.modules
           in
           Modules_group.make_wrapped ~src_dir:dir ~modules `Melange
         in

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -249,8 +249,11 @@ let check_invalid_module_listing ~stanza_loc ~modules_without_implementation
       spurious_modules_virtual [])
 
 let eval ~modules:(all_modules : Module.Source.t Module_trie.t) ~stanza_loc
-    ~modules_field ~modules_without_implementation ~root_module ~private_modules
-    ~kind ~src_dir =
+    ~private_modules ~kind ~src_dir
+    { Stanza_common.Modules_settings.modules = modules_field
+    ; root_module
+    ; modules_without_implementation
+    } =
   (* Fake modules are modules that do not exist but it doesn't matter because
      they are only removed from a set (for jbuild file compatibility) *)
   let fake_modules = ref Module_name.Map.empty in

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -22,10 +22,8 @@ type kind =
 val eval :
      modules:Module.Source.t Module_trie.t
   -> stanza_loc:Loc.t
-  -> modules_field:Ordered_set_lang.t
-  -> modules_without_implementation:Ordered_set_lang.t
-  -> root_module:('a * Module_name.t) option
   -> private_modules:Ordered_set_lang.t
   -> kind:kind
   -> src_dir:Path.Build.t
+  -> Stanza_common.Modules_settings.t
   -> Module.t Module_trie.t

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -182,3 +182,18 @@ let instrumentation =
                   >>> repeat Dep_conf.decode)
               in
               (backend, deps))))
+
+module Modules_settings = struct
+  type t =
+    { root_module : (Loc.t * Module_name.t) option
+    ; modules_without_implementation : Ordered_set_lang.t
+    ; modules : Ordered_set_lang.t
+    }
+
+  let decode ~modules_field_name =
+    let+ root_module = field_o "root_module" Module_name.decode_loc
+    and+ modules_without_implementation =
+      modules_field "modules_without_implementation"
+    and+ modules = modules_field modules_field_name in
+    { root_module; modules; modules_without_implementation }
+end

--- a/src/dune_rules/stanza_common.mli
+++ b/src/dune_rules/stanza_common.mli
@@ -27,3 +27,13 @@ val instrumentation :
   (Loc.t
   * (((Loc.t * Lib_name.t) * String_with_vars.t list) * Dep_conf.t list) list)
   fields_parser
+
+module Modules_settings : sig
+  type t =
+    { root_module : (Loc.t * Module_name.t) option
+    ; modules_without_implementation : Ordered_set_lang.t
+    ; modules : Ordered_set_lang.t
+    }
+
+  val decode : modules_field_name:string -> t Dune_lang.Decoder.fields_parser
+end


### PR DESCRIPTION
Module settings are now stored in a single record. These settings are
shared between melange stanzas, executables, and libraries.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b37db17a-2fd4-4148-9f81-5367835492f1 -->