### PR TITLE
build: needs CoreFoundation instead of Foundation

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -62,7 +62,7 @@ let local_libraries =
 let link_flags =
   [ ("macosx",
     [ "-cclib"
-    ; "-framework Foundation"
+    ; "-framework CoreFoundation"
     ; "-cclib"
     ; "-framework CoreServices"
     ])

--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -23,7 +23,7 @@ let rule sctx compile (exes : Dune_file.Executables.t) () =
     (* additional link flags keyed by the platform *)
     [ ( "macosx"
       , [ "-cclib"
-        ; "-framework Foundation"
+        ; "-framework CoreFoundation"
         ; "-cclib"
         ; "-framework CoreServices"
         ] )

--- a/src/fsevents/flags/gen_flags.ml
+++ b/src/fsevents/flags/gen_flags.ml
@@ -1,5 +1,5 @@
 let () =
   if Sys.argv.(1) = "macosx" then
     Printf.printf
-      {|(-cclib "-framework Foundation" -cclib "-framework CoreServices")|}
+      {|(-cclib "-framework CoreFoundation" -cclib "-framework CoreServices")|}
   else print_string "()"


### PR DESCRIPTION
Found while reviewing https://github.com/NixOS/nixpkgs/pull/208957#pullrequestreview-1236361465

Signed-off-by: Élie BRAMI <cadeaudeelie@gmail.com>