### PR TITLE
fix(dyn): don't break boxes when printing strings

### DIFF
--- a/otherlibs/dyn/dyn.ml
+++ b/otherlibs/dyn/dyn.ml
@@ -52,7 +52,7 @@ let string_in_ocaml_syntax str =
     | None -> Pp.verbatim (Printf.sprintf "%S" first)
     | Some (middle, last) ->
       Pp.vbox
-        (Pp.concat ~sep:Pp.newline
+        (Pp.concat ~sep:Pp.cut
            (List.map ~f:Pp.verbatim
               (("\"" ^ String.escaped first ^ "\\n\\")
                :: List.map middle ~f:(fun s ->


### PR DESCRIPTION
Use [Pp.cut] rather than [Pp.newline] as the seperator. This should
output a box respecting newline since we're in a vertical box.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7358b512-6ad8-47be-92c8-8ba401a4c390 -->