### PR TITLE
chore: remove unnecessary workaround

### DIFF
--- a/dune-file
+++ b/dune-file
@@ -46,7 +46,4 @@
 
 (env
  (_
-  (flags :standard -alert -unstable)
-  (env-vars
-   ; Workaround for #6607
-   (CLICOLOR_FORCE 0))))
+  (flags :standard -alert -unstable)))


### PR DESCRIPTION
It was actually a terminal detection bug that was fixed in #6781

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 35ca5b3f-5361-4d1a-9b5b-62e69c46de84 -->