### PR TITLE
chore(nix): remove `dune_3` from devShells.slim.buildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,6 @@
           nativeBuildInputs = with pkgs; [ pkg-config nodejs-slim ];
           inputsFrom = [ pkgs.ocamlPackages.dune_3 ];
           buildInputs = with pkgs.ocamlPackages; [
-            dune_3
             merlin
             ocamlformat
             ppx_expect


### PR DESCRIPTION
this makes `./dune.exe exec -- $EDITOR` work

Signed-off-by: Antonio Nuno Monteiro <anmonteiro@gmail.com>