### PR TITLE
doc: remove spurious bold styling in ctypes doc

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -486,7 +486,6 @@ The following sections describe the available stanzas and their meanings.
 .. include:: stanzas/include_subdirs.rst
 .. include:: stanzas/install.rst
 .. include:: stanzas/jbuild_version.rst
-.. include:: stanzas/js_of_ocaml.rst
 .. include:: stanzas/library.rst
 .. include:: stanzas/mdx.rst
 .. include:: stanzas/menhir.rst

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -252,6 +252,7 @@ descriptions by referencing them as the module specified in optional
   under. We suggest calling it ``C``.
 
 - Headers can be added to the generated C files:
+
    - ``(headers (include "include1" "include2" ...))`` adds ``#include
      <include1>``, ``#include <include2>``. It uses the :ref:`ordered-set-language`.
    - ``(headers (preamble <preamble>)`` adds directly the preamble. Variables


### PR DESCRIPTION
This prevents the previous line to be interpreted as a header.