### PR TITLE
doc: clarify purpose of dune files under "project"

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -61,9 +61,10 @@ Terminology
    `dune-workspace` file.
 
 -  **project**: a collection of source files that must include a `dune-project`
-   file. It may also contain one or more packages. Instructions to build files
-   in a directory are contained in a `dune` file in this directory. Projects can
-   be shared between different applications.
+   file. It may also contain one or more packages. A project consists in a
+   hierarchy of directories. Every directory (at the root, or a subdirectory)
+   can contain a `dune` file that contains instructions to build files in that
+   directory. Projects can be shared between different applications.
 
 -  **package**: a set of libraries and executables that opam builds and installs
    as one.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -61,9 +61,9 @@ Terminology
    `dune-workspace` file.
 
 -  **project**: a collection of source files that must include a `dune-project`
-   file. It may also contain one or more packages. Each directory in the tree,
-   including the root, must have a `dune` file specifying how to build the files
-   in its directory. Projects can be shared between different applications.
+   file. It may also contain one or more packages. Instructions to build files
+   in a directory are contained in a `dune` file in this directory. Projects can
+   be shared between different applications.
 
 -  **package**: a set of libraries and executables that opam builds and installs
    as one.


### PR DESCRIPTION
This sentence means that stanzas go in `dune` - not that `dune` files are mandatory.

Fixes #6845
