### PR TITLE
chore(ci): add OCaml 5.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,6 +30,14 @@ jobs:
         ocaml-compiler:
           - 4.14.x
         include:
+          # OCaml 5:
+          - ocaml-compiler: 5.0.x
+            os: ubuntu-latest
+            skip_test: true
+          - ocaml-compiler: 5.0.x
+            os: macos-latest
+            skip_test: true
+          # OCaml 4:
           - ocaml-compiler: 4.13.x
             os: ubuntu-latest
             skip_test: true


### PR DESCRIPTION
I originally tried bumping our test suite to run on 5.0, but Windows is problematic since the opam repo is discontinued and we have to wait for OPAM 2.2 and also melange doesn't work on 5.0.

Therefore I have added a 5.0 job next to the others and we continue to test on 4.14. 