### PR TITLE
doc: use sphinx version metadata instead of titles

### DIFF
--- a/doc/stanzas/data_only_dirs.rst
+++ b/doc/stanzas/data_only_dirs.rst
@@ -1,7 +1,9 @@
 .. _dune-data_only_dirs:
 
-data_only_dirs (Since 1.6)
---------------------------
+data_only_dirs
+--------------
+
+.. versionadded:: 1.6
 
 Dune allows the user to treat directories as *data only*. ``dune`` files in
 these directories won't be evaluated for their rules, but the contents of these

--- a/doc/stanzas/dirs.rst
+++ b/doc/stanzas/dirs.rst
@@ -1,7 +1,9 @@
 .. _dune-subdirs:
 
-dirs (Since 1.6)
-----------------
+dirs
+----
+
+.. versionadded:: 1.6
 
 The ``dirs`` stanza allows specifying the subdirectories Dune will include in a
 build. The syntax is based on Dune's :ref:`predicate-lang` and allows the user

--- a/doc/stanzas/generate_sites_module.rst
+++ b/doc/stanzas/generate_sites_module.rst
@@ -1,7 +1,9 @@
 .. _generate_sites_module:
 
-generate_sites_module (Since 2.8)
----------------------------------
+generate_sites_module
+---------------------
+
+.. versionadded:: 2.8
 
 Dune proposes some facilities for dealing with :ref:`sites<sites>` in a program.
 The ``generate_sites_module`` stanza will generate code for looking up the

--- a/doc/stanzas/ignored_subdirs.rst
+++ b/doc/stanzas/ignored_subdirs.rst
@@ -1,7 +1,9 @@
 .. _dune-ignored_subdirs:
 
-ignored_subdirs (Deprecated in 1.6)
------------------------------------
+ignored_subdirs
+---------------
+
+.. deprecated:: 1.6
 
 One may also specify *data only* directories using the ``ignored_subdirs``
 stanza, meaning it's the same as ``data_only_dirs``, but the syntax isn't as

--- a/doc/stanzas/mdx.rst
+++ b/doc/stanzas/mdx.rst
@@ -1,5 +1,7 @@
-MDX (Since 2.4)
----------------
+mdx
+---
+
+.. versionadded:: 2.4
 
 MDX is a tool that helps you keep your markdown documentation up-to-date by
 checking that its code examples are correct. When setting an MDX stanza, the MDX

--- a/doc/stanzas/plugin.rst
+++ b/doc/stanzas/plugin.rst
@@ -1,7 +1,9 @@
 .. _plugin:
 
-plugin (Since 2.8)
-------------------
+plugin
+------
+
+.. versionadded:: 2.8
 
 Plugins are a way to load OCaml libraries at runtime. The ``plugin`` stanza
 allows you to declare the plugin's name, which :ref:`sites<sites>` should be

--- a/doc/stanzas/vendored_dirs.rst
+++ b/doc/stanzas/vendored_dirs.rst
@@ -1,7 +1,9 @@
 .. _dune-vendored_dirs:
 
-vendored_dirs (Since 1.11)
---------------------------
+vendored_dirs
+-------------
+
+.. versionadded:: 1.11
 
 Dune supports vendoring other Dune-based projects natively, since simply copying
 a project into a subdirectory of your own project will work. Simply doing that


### PR DESCRIPTION
This removes "since x.y" from titles, in particular this unclutters the TOC.
