### PR TITLE
refactor(merlin): remove unnecessary read_memo

### DIFF
--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -444,10 +444,8 @@ module Unprocessed = struct
         (Modules.source_dirs modules)
 
   let pp_config t sctx ~expander =
-    Action_builder.of_memo_join
-    @@
-    let open Memo.O in
-    let+ preprocess = Resolve.Memo.read_memo t.config.preprocess in
+    let open Action_builder.O in
+    let* preprocess = Resolve.Memo.read t.config.preprocess in
     Module_name.Per_item.map_action_builder preprocess
       ~f:(pp_flags sctx ~expander t.config.libname)
 


### PR DESCRIPTION
The use is completely unnecessary here as we're inside the action
builder monad anyway

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f86a7943-2139-4dd3-ab05-2ac185b19f6e -->