### PR TITLE
chore: leave some TODO's for rule loading

### DIFF
--- a/src/dune_rules/artifacts_db.ml
+++ b/src/dune_rules/artifacts_db.ml
@@ -51,6 +51,9 @@ let get_installed_binaries ~(context : Context.t) stanzas =
                   let project = Scope.project scope in
                   let dune_version = Dune_project.dune_version project in
                   let+ pps =
+                    (* Instead of making the binary unavailable, this will just
+                       fail when loading artifacts. This is clearly bad but
+                       "optional" executables shouldn't be used. *)
                     Resolve.Memo.read_memo
                       (Preprocess.Per_module.with_instrumentation
                          exes.buildable.preprocess

--- a/src/dune_rules/buildable_rules.ml
+++ b/src/dune_rules/buildable_rules.ml
@@ -45,11 +45,13 @@ let modules_rules ~preprocess ~preprocessor_deps ~lint
       Lib.DB.instrumentation_backend (Scope.libs scope)
     in
     let* preprocess_with_instrumentation =
+      (* TODO wrong and blocks loading all the rules in this directory *)
       Resolve.Memo.read_memo
         (Preprocess.Per_module.with_instrumentation preprocess
            ~instrumentation_backend)
     in
     let+ instrumentation_deps =
+      (* TODO wrong and blocks loading all the rules in this directory *)
       Resolve.Memo.read_memo
         (Preprocess.Per_module.instrumentation_deps preprocess
            ~instrumentation_backend)

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -220,6 +220,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
 let compile_info ~scope (exes : Dune_file.Executables.t) =
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let+ pps =
+    (* TODO resolution should be delayed *)
     Resolve.Memo.read_memo
       (Preprocess.Per_module.with_instrumentation exes.buildable.preprocess
          ~instrumentation_backend:

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -252,6 +252,9 @@ end = struct
                 Scope.project scope |> Dune_project.dune_version
               in
               let+ pps =
+                (* This is wrong. If the preprocessors fail to resolve,
+                   we shouldn't install the binary rather than failing outright
+                *)
                 Preprocess.Per_module.with_instrumentation
                   exes.buildable.preprocess
                   ~instrumentation_backend:
@@ -461,6 +464,8 @@ end = struct
     Section.Set.to_map sections ~f:(fun section ->
         Install.Section.Paths.get_local_location ctx_name section pkg_name)
 
+  (* TODO delay the library resolution errors here. We should still be load
+     the [dune-package] file rule even if some libraries are missing *)
   let make_dune_package sctx lib_entries (pkg : Package.t) =
     let pkg_name = Package.name pkg in
     let ctx = Super_context.context sctx in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -520,6 +520,9 @@ module Sub_system = struct
 
   let public_info =
     let open Memo.O in
+    (* TODO this should continue using [Resolve]. Not doing so
+       will prevent generating the [dune-package] rule if the sub system is
+       missing *)
     let module M = Memo.Make_map_traversals (Sub_system_name.Map) in
     fun lib ->
       M.parallel_map lib.sub_systems ~f:(fun _name inst ->

--- a/src/dune_rules/virtual_rules.ml
+++ b/src/dune_rules/virtual_rules.ml
@@ -89,6 +89,7 @@ let impl sctx ~(lib : Dune_file.Library.t) ~scope =
           in
           let* modules =
             let* preprocess =
+              (* TODO wrong, this should be delayed *)
               Resolve.Memo.read_memo
                 (Preprocess.Per_module.with_instrumentation
                    lib.buildable.preprocess


### PR DESCRIPTION
Document a a few places where our rule loading is not lazy enough and
prevents all the rules in a particular directory from being loaded.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0b62b296-9a15-49cd-8b68-ec321d48aa1a -->