### PR TITLE
refactor(rules): remove unnecessary field

### DIFF
--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -375,7 +375,6 @@ type db =
   ; resolve : Lib_name.t -> resolve_result Memo.t
   ; all : Lib_name.t list Memo.Lazy.t
   ; lib_config : Lib_config.t
-  ; instrument_with : Lib_name.t list
   }
 
 and resolve_result =
@@ -853,7 +852,7 @@ end = struct
       let open Resolve.Memo.O in
       let* pps =
         let instrumentation_backend =
-          instrumentation_backend db.instrument_with resolve
+          instrumentation_backend db.lib_config.instrument_with resolve
         in
         Lib_info.preprocess info
         |> Preprocess.Per_module.with_instrumentation ~instrumentation_backend
@@ -1735,12 +1734,7 @@ module DB = struct
   type t = db
 
   let create ~parent ~resolve ~all ~lib_config () =
-    { parent
-    ; resolve
-    ; all = Memo.lazy_ all
-    ; lib_config
-    ; instrument_with = lib_config.Lib_config.instrument_with
-    }
+    { parent; resolve; all = Memo.lazy_ all; lib_config }
 
   let create_from_findlib findlib =
     let lib_config = Findlib.lib_config findlib in
@@ -1892,7 +1886,7 @@ module DB = struct
     | _ -> Memo.return l
 
   let instrumentation_backend t libname =
-    instrumentation_backend t.instrument_with (resolve t) libname
+    instrumentation_backend t.lib_config.instrument_with (resolve t) libname
 end
 
 let to_dune_lib ({ info; _ } as lib) ~modules ~foreign_objects ~dir :


### PR DESCRIPTION
[instrument_with] is already used inside [lib_config]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3f05db41-472d-4a14-bd82-aeac0978a5d2 -->