### PR TITLE
refactor(rules): bootstrap info

### DIFF
--- a/src/dune_rules/bootstrap_info.mli
+++ b/src/dune_rules/bootstrap_info.mli
@@ -10,5 +10,5 @@ val gen_rules :
      Super_context.t
   -> Dune_file.Executables.t
   -> dir:Path.Build.t
-  -> Lib.Compile.t
+  -> requires_link:Lib.t list Resolve.t Memo.Lazy.t
   -> unit Memo.t

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -243,7 +243,10 @@ let rules ~sctx ~dir ~dir_contents ~scope ~expander
       ~compile_info ~embed_in_plugin_libraries:exes.embed_in_plugin_libraries
   in
   let* () = Buildable_rules.gen_select_rules sctx compile_info ~dir
-  and* () = Bootstrap_info.gen_rules sctx exes ~dir compile_info in
+  and* () =
+    let requires_link = Lib.Compile.requires_link compile_info in
+    Bootstrap_info.gen_rules sctx exes ~dir ~requires_link
+  in
   Buildable_rules.with_lib_deps
     (Super_context.context sctx)
     compile_info ~dir ~f


### PR DESCRIPTION
only pass the linking closure because that is the only thing that is
being used.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: caffdf1e-eaeb-4c28-b72b-138eb36b535d -->