### PR TITLE
ctypes 0.3: run commands in stanza directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,9 @@ Unreleased
   not set then the cinaps actions will be attached to both `@cinaps` and
   `@runtest` (#6988, @rgrinberg)
 
+- Add `(using ctypes 0.3)`. When used, paths in `(ctypes)` are interpreted
+  relative to where the stanza is defined. (#6883, fixes #5325, @emillon)
+
 3.6.2 (2022-12-21)
 ------------------
 

--- a/src/dune_rules/ctypes/ctypes_field.ml
+++ b/src/dune_rules/ctypes/ctypes_field.ml
@@ -5,7 +5,10 @@ let name = "ctypes"
 
 let syntax =
   Dune_lang.Syntax.create ~name ~desc:"the ctypes extension"
-    [ ((0, 1), `Since (3, 0)); ((0, 2), `Since (3, 4)) ]
+    [ ((0, 1), `Since (3, 0))
+    ; ((0, 2), `Since (3, 4))
+    ; ((0, 3), `Since (3, 7))
+    ]
 
 module Build_flags_resolver = struct
   module Vendored = struct
@@ -140,6 +143,7 @@ type t =
   ; generated_types : Module_name.t
   ; generated_entry_point : Module_name.t
   ; deps : Dep_conf.t list
+  ; version : Syntax.Version.t
   }
 
 type Stanza.t += T of t
@@ -157,7 +161,8 @@ let decode =
      and+ generated_types = field_o "generated_types" Module_name.decode
      and+ generated_entry_point =
        field "generated_entry_point" Module_name.decode
-     and+ deps = field_o "deps" (repeat Dep_conf.decode) in
+     and+ deps = field_o "deps" (repeat Dep_conf.decode)
+     and+ version = Syntax.get_exn syntax in
      let external_library_name =
        External_lib_name.of_string external_library_name
      in
@@ -187,6 +192,7 @@ let decode =
            ~default:(Module_name.of_string "Types_generated")
      ; generated_entry_point
      ; deps = Option.value ~default:[] deps
+     ; version
      })
 
 let () =

--- a/src/dune_rules/ctypes/ctypes_field.mli
+++ b/src/dune_rules/ctypes/ctypes_field.mli
@@ -58,6 +58,7 @@ type t =
   ; generated_types : Module_name.t
   ; generated_entry_point : Module_name.t
   ; deps : Dep_conf.t list
+  ; version : Syntax.Version.t
   }
 
 type Stanza.t += T of t

--- a/src/dune_rules/ctypes/ctypes_rules.mli
+++ b/src/dune_rules/ctypes/ctypes_rules.mli
@@ -7,6 +7,7 @@ val gen_rules :
   -> scope:Scope.t
   -> dir:Path.Build.t
   -> sctx:Super_context.t
+  -> version:Syntax.Version.t
   -> unit Memo.t
 
 val ctypes_cclib_flags :

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -191,7 +191,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
     | None ->
       Exe.build_and_link_many cctx ~programs ~linkages ~link_args ~o_files
         ~promote:exes.promote ~embed_in_plugin_libraries ~sandbox
-    | Some _ctypes ->
+    | Some { version; _ } ->
       (* Ctypes stubgen builds utility .exe files that need to share modules
          with this compilation context. To support that, we extract the one-time
          run bits from [Exe.build_and_link_many] and run them here, then pass
@@ -199,7 +199,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
          dance is done to avoid triggering duplicate rule exceptions. *)
       let* () =
         let loc = fst (List.hd exes.Executables.names) in
-        Ctypes_rules.gen_rules ~cctx ~buildable ~loc ~sctx ~scope ~dir
+        Ctypes_rules.gen_rules ~cctx ~buildable ~loc ~sctx ~scope ~dir ~version
       in
       let* () = Module_compilation.build_all cctx in
       Exe.link_many ~programs ~linkages ~link_args ~o_files

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -561,9 +561,9 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~dir ~expander ~scope =
     let* () =
       match buildable.ctypes with
       | None -> Memo.return ()
-      | Some _ctypes ->
+      | Some { version; _ } ->
         Ctypes_rules.gen_rules ~loc:(fst lib.name) ~cctx ~buildable ~sctx ~scope
-          ~dir
+          ~dir ~version
     in
     library_rules lib ~local_lib ~cctx ~source_modules ~dir_contents
       ~compile_info

--- a/test/blackbox-tests/test-cases/ctypes/directories.t
+++ b/test/blackbox-tests/test-cases/ctypes/directories.t
@@ -74,3 +74,13 @@ We ensure that just `-I lib` or `-I .` are not enough on their own.
   $ echo "(-I .)" > lib/extra_flags.sexp
   $ dune build > /dev/null 2>&1
   [1]
+
+With 0.3, everything is relative to the directory.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.7)
+  > (using ctypes 0.3)
+  > EOF
+
+  $ echo "(-I .)" > lib/extra_flags.sexp
+  $ dune build


### PR DESCRIPTION
This creates version 0.3 of the ctypes field.

When used, commands are run in the directory where the corresponding stanza is defined. This makes it possible to use relative directories.

Fixes #5325