### PR TITLE
refactor: Build_system.Error.info

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -122,7 +122,21 @@ module Error : sig
 
   val create : exn:Exn_with_backtrace.t -> t
 
-  val info : t -> User_message.t * User_message.t list * Path.t option
+  (** [info] stores additional information about errors *)
+  type info =
+    { dir : Path.t option
+          (** the directory where the rule the error is originating from *)
+    ; related : User_message.t list
+          (** related errors with additional descriptions and locations. only
+              useful for rpc clients *)
+    ; main : User_message.t
+          (** the main message of the error. this is what is displayed in the
+              console *)
+    }
+
+  (** [info t] returns additional information regarding errors. useful for rich
+      clients that consume errors through rpc *)
+  val info : t -> info
 
   val promotion : t -> Diff_promotion.Annot.t option
 

--- a/src/dune_rpc_impl/diagnostics.ml
+++ b/src/dune_rpc_impl/diagnostics.ml
@@ -25,7 +25,9 @@ let absolutize_paths ~dir (loc : Loc.t) =
 let diagnostic_of_error : Build_system.Error.t -> Dune_rpc_private.Diagnostic.t
     =
  fun m ->
-  let message, related, dir = Build_system.Error.info m in
+  let { Build_system.Error.main = message; related; dir } =
+    Build_system.Error.info m
+  in
   let dir =
     Option.map dir ~f:Path.drop_optional_build_context_maybe_sandboxed
   in


### PR DESCRIPTION
Previously, [Build_system.Error.info] would return a tuple that was hard
to read. We convert it into a record to make it easier.

<!-- ps-id: f8e37f71-4ef9-4a9a-b71d-5b2f0492a124 -->