### PR TITLE
chore: improve error messages with 2 locations

### DIFF
--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -199,10 +199,21 @@ module Dir_map = struct
     ; subdir_status =
         Status.Map.merge d1.subdir_status d2.subdir_status ~f:(fun l r ->
             Option.merge l r ~f:(fun (loc, _) (loc2, _) ->
-                User_error.raise ~loc
-                  [ Pp.text "This stanza stanza was already specified at:"
-                  ; Pp.verbatim (Loc.to_file_colon_line loc2)
-                  ]))
+                let main_message =
+                  Pp.text "This stanza stanza was already specified at:"
+                in
+                let annots =
+                  let main = User_message.make ~loc [ main_message ] in
+                  let related =
+                    [ User_message.make ~loc:loc2
+                        [ Pp.text "Already defined here" ]
+                    ]
+                  in
+                  User_message.Annots.singleton Compound_user_error.annot
+                    (Compound_user_error.make ~main ~related)
+                in
+                User_error.raise ~loc ~annots
+                  [ main_message; Pp.verbatim (Loc.to_file_colon_line loc2) ]))
     }
 
   let rec merge t1 t2 : t =

--- a/src/dune_rules/foreign.ml
+++ b/src/dune_rules/foreign.ml
@@ -220,8 +220,15 @@ module Objects = struct
     match String.Map.of_list (List.map t ~f:Tuple.T2.swap) with
     | Ok _ -> t
     | Error (name, loc, loc') ->
-      User_error.raise ~loc
-        [ Pp.textf "Duplicate object name: %s. Already appears at:" name
+      let main_message = sprintf "Duplicate object name: %s." name in
+      let annots =
+        let main = User_message.make ~loc [ Pp.text main_message ] in
+        let related = [ User_message.make ~loc:loc' [ Pp.text "" ] ] in
+        User_message.Annots.singleton Compound_user_error.annot
+          (Compound_user_error.make ~main ~related)
+      in
+      User_error.raise ~loc ~annots
+        [ Pp.textf "%s Already appears at:" main_message
         ; Pp.textf "- %s" (Loc.to_file_colon_line loc')
         ]
 

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -134,77 +134,136 @@ let%expect_test "related error" =
     "foo.cma";
   [%expect
     {|
-    Building foo.cma
-    Build foo.cma failed
+  Building foo.cma
+  Build foo.cma failed
+  [ "Add"
+  ; [ [ "directory"; "$CWD" ]
+    ; [ "id"; "0" ]
+    ; [ "loc"
+      ; [ [ "start"
+          ; [ [ "pos_bol"; "0" ]
+            ; [ "pos_cnum"; "0" ]
+            ; [ "pos_fname"; "$CWD/foo.ml" ]
+            ; [ "pos_lnum"; "1" ]
+            ]
+          ]
+        ; [ "stop"
+          ; [ [ "pos_bol"; "0" ]
+            ; [ "pos_cnum"; "0" ]
+            ; [ "pos_fname"; "$CWD/foo.ml" ]
+            ; [ "pos_lnum"; "1" ]
+            ]
+          ]
+        ]
+      ]
+    ; [ "message"
+      ; [ "Verbatim"
+        ; "The implementation foo.ml\n\
+           does not match the interface .foo.objs/byte/foo.cmi: \n\
+           Values do not match: val x : bool is not included in val x : int\n\
+           The type bool is not compatible with the type int\n\
+           "
+        ]
+      ]
+    ; [ "promotion"; [] ]
+    ; [ "related"
+      ; [ [ [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "0" ]
+                  ; [ "pos_fname"; "$CWD/foo.mli" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "11" ]
+                  ; [ "pos_fname"; "$CWD/foo.mli" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ]
+            ]
+          ; [ "message"; [ "Verbatim"; "Expected declaration\n\
+                                        " ] ]
+          ]
+        ; [ [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "4" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "5" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "1" ]
+                  ]
+                ]
+              ]
+            ]
+          ; [ "message"; [ "Verbatim"; "Actual declaration\n\
+                                        " ] ]
+          ]
+        ]
+      ]
+    ; [ "targets"; [] ]
+    ]
+  ] |}];
+  diagnostic_with_build
+    [ ("dune", "(library (name foo)) (executable (name foo))"); ("foo.ml", "") ]
+    "@check";
+  [%expect
+    {|
+    Building @check
+    Build @check failed
     [ "Add"
-    ; [ [ "directory"; "$CWD" ]
-      ; [ "id"; "0" ]
+    ; [ [ "id"; "0" ]
       ; [ "loc"
         ; [ [ "start"
             ; [ [ "pos_bol"; "0" ]
               ; [ "pos_cnum"; "0" ]
-              ; [ "pos_fname"; "$CWD/foo.ml" ]
+              ; [ "pos_fname"; "$CWD/dune" ]
               ; [ "pos_lnum"; "1" ]
               ]
             ]
           ; [ "stop"
             ; [ [ "pos_bol"; "0" ]
-              ; [ "pos_cnum"; "0" ]
-              ; [ "pos_fname"; "$CWD/foo.ml" ]
+              ; [ "pos_cnum"; "20" ]
+              ; [ "pos_fname"; "$CWD/dune" ]
               ; [ "pos_lnum"; "1" ]
               ]
             ]
           ]
         ]
       ; [ "message"
-        ; [ "Verbatim"
-          ; "The implementation foo.ml\n\
-             does not match the interface .foo.objs/byte/foo.cmi: \n\
-             Values do not match: val x : bool is not included in val x : int\n\
-             The type bool is not compatible with the type int\n\
-             "
-          ]
+        ; [ "Verbatim"; "Module \"Foo\" is used in several\n\
+                         stanzas:\n\
+                         " ]
         ]
       ; [ "promotion"; [] ]
       ; [ "related"
         ; [ [ [ "loc"
               ; [ [ "start"
                   ; [ [ "pos_bol"; "0" ]
-                    ; [ "pos_cnum"; "0" ]
-                    ; [ "pos_fname"; "$CWD/foo.mli" ]
+                    ; [ "pos_cnum"; "21" ]
+                    ; [ "pos_fname"; "$CWD/dune" ]
                     ; [ "pos_lnum"; "1" ]
                     ]
                   ]
                 ; [ "stop"
                   ; [ [ "pos_bol"; "0" ]
-                    ; [ "pos_cnum"; "11" ]
-                    ; [ "pos_fname"; "$CWD/foo.mli" ]
+                    ; [ "pos_cnum"; "44" ]
+                    ; [ "pos_fname"; "$CWD/dune" ]
                     ; [ "pos_lnum"; "1" ]
                     ]
                   ]
                 ]
               ]
-            ; [ "message"; [ "Verbatim"; "Expected declaration\n\
-                                          " ] ]
-            ]
-          ; [ [ "loc"
-              ; [ [ "start"
-                  ; [ [ "pos_bol"; "0" ]
-                    ; [ "pos_cnum"; "4" ]
-                    ; [ "pos_fname"; "$CWD/foo.ml" ]
-                    ; [ "pos_lnum"; "1" ]
-                    ]
-                  ]
-                ; [ "stop"
-                  ; [ [ "pos_bol"; "0" ]
-                    ; [ "pos_cnum"; "5" ]
-                    ; [ "pos_fname"; "$CWD/foo.ml" ]
-                    ; [ "pos_lnum"; "1" ]
-                    ]
-                  ]
-                ]
-              ]
-            ; [ "message"; [ "Verbatim"; "Actual declaration\n\
+            ; [ "message"; [ "Verbatim"; "Used in this\n\
+                                          stanza\n\
                                           " ] ]
             ]
           ]


### PR DESCRIPTION
The location of both of the libraries can be included by adding one of
the libraries as a "related" error. The end result is that both error
messages will be available to jump in rpc clients that consume
diagnostics

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a8ff6a59-9c8b-48e9-9bfc-3dbf3907dcf0 -->