### PR TITLE
fix(scheduler): flush stats when idle

### DIFF
--- a/otherlibs/chrome-trace/test/chrome_trace_tests.ml
+++ b/otherlibs/chrome-trace/test/chrome_trace_tests.ml
@@ -8,7 +8,8 @@ let buf = Buffer.create 0
 let c =
   let write s = Buffer.add_string buf s in
   let close () = () in
-  Dune_stats.create (Custom { write; close })
+  let flush () = () in
+  Dune_stats.create (Custom { write; close; flush })
 
 let () =
   let module Event = Chrome_trace.Event in

--- a/src/dune_stats/dune_stats.ml
+++ b/src/dune_stats/dune_stats.ml
@@ -64,11 +64,13 @@ type dst =
   | Custom of
       { write : string -> unit
       ; close : unit -> unit
+      ; flush : unit -> unit
       }
 
 type t =
   { print : string -> unit
   ; close : unit -> unit
+  ; flush : unit -> unit
   ; mutable after_first_event : bool
   }
 
@@ -89,7 +91,14 @@ let create dst =
     | Out out -> fun () -> Stdlib.close_out out
     | Custom c -> c.close
   in
-  { print; close; after_first_event = false }
+  let flush =
+    match dst with
+    | Out out -> fun () -> flush out
+    | Custom c -> c.flush
+  in
+  { print; close; after_first_event = false; flush }
+
+let flush t = t.flush ()
 
 let next_leading_char t =
   match t.after_first_event with

--- a/src/dune_stats/dune_stats.mli
+++ b/src/dune_stats/dune_stats.mli
@@ -9,6 +9,7 @@ type dst =
   | Custom of
       { write : string -> unit
       ; close : unit -> unit
+      ; flush : unit -> unit
       }
 
 val create : dst -> t
@@ -30,6 +31,8 @@ type event_data =
 val start : t option -> (unit -> event_data) -> event option
 
 val finish : event option -> unit
+
+val flush : t -> unit
 
 module Private : sig
   module Fd_count : sig


### PR DESCRIPTION
[dune --trace-file] currently relies on the output channel to flush the
events when it's internal buffer is full. This isn't a problem for a
normal build, because we only want to observe the trace file once dune
terminates, but it is a problem for watch mode. In watch mode, we have
to wait an arbitrary amount of time until the buffer gets filled up and
is flushed.

This commit flushes the events output channel in watch mode whenever
we're idling and waiting for file system events to arrive.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 78413271-d3b0-48a5-998b-c3db0ca4979d -->