### PR TITLE
fix(metrics): output correct process metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+- Fix `--trace-file` output. Dune now emits a single *complete* event for every
+  executed process. Unterminated *async* events are no longer written. (#6892,
+  @rgrinberg)
+
 - Fix preprocessing with `staged_pps` (#6748, fixes #6644, @rgrinberg)
 
 - Make `dune describe workspace` return consistent dependencies for


### PR DESCRIPTION
Before this commit we would output an "async" start event when a process
awould start nd then a "complete" event when it would be finished.

The "async" start event is unnecessary and this commit removes it. All
the information recorded in the "async" start event is therefore moved
to the complete event.

The new output is now properly displayed by the various visualization
tools (perfetto, chrome)

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d5f448b8-a896-4612-bc4e-e8d16c41fc51 -->