### PR TITLE
feature(scheduler): events for watch mode

### DIFF
--- a/otherlibs/chrome-trace/src/chrome_trace.ml
+++ b/otherlibs/chrome-trace/src/chrome_trace.ml
@@ -310,6 +310,8 @@ module Event = struct
 
   let async ?scope ?args id async common =
     Async { common; args; scope; id; async }
+
+  let instant ?args ?scope common = Instant (common, scope, args)
 end
 
 module Output_object = struct

--- a/otherlibs/chrome-trace/src/chrome_trace.mli
+++ b/otherlibs/chrome-trace/src/chrome_trace.mli
@@ -87,6 +87,16 @@ module Event : sig
     ?tdur:Timestamp.t -> ?args:args -> dur:Timestamp.t -> common_fields -> t
 
   val to_json : t -> Json.t
+
+  (** The scope of an instant event. The scopes below come from the standard
+      reference for this format *)
+  type scope =
+    | Global
+    | Process
+    | Thread
+
+  (** Create an instant event. *)
+  val instant : ?args:args -> ?scope:scope -> common_fields -> t
 end
 
 module Output_object : sig


### PR DESCRIPTION
Introduce an instant event for every watch mode iteration. This event
allows us to separate build commmands from different iterations of the
polling loop.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 816bc92c-9d40-4ba2-b36d-6831accf6b70 -->