### PR TITLE
test: wait for dune shutdown

### DIFF
--- a/test/blackbox-tests/test-cases/watching/helpers.sh
+++ b/test/blackbox-tests/test-cases/watching/helpers.sh
@@ -21,8 +21,9 @@ with_timeout () {
 }
 
 stop_dune () {
-    with_timeout dune shutdown
-    cat .#dune-output
+    with_timeout dune shutdown;
+    wait $DUNE_PID;
+    cat .#dune-output;
 }
 
 build () {


### PR DESCRIPTION
Modify stop_dune to wait until dune actually shuts down.

This is needed for tests such as stray-process.t which rely on their
assertions to run after dune's finished.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8b1ac598-fb72-4aa8-bd3e-931af442a87e -->