### PR TITLE
fix: (include_subdirs qualified) and pp

### DIFF
--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -522,15 +522,17 @@ module Module = struct
 
   module Dep = struct
     type t =
-      | Immediate of Module.File.t
+      | Immediate of Module.t * Ml_kind.t
       | Transitive of Module.t * Ml_kind.t
 
+    let make_name m kind ext =
+      let ext = sprintf ".%s.%s" (Ml_kind.to_string kind) ext in
+      let obj = Module.obj_name m in
+      Module_name.Unique.artifact_filename obj ~ext
+
     let basename = function
-      | Immediate f -> Path.basename (Module.File.path f) ^ ".d"
-      | Transitive (m, ml_kind) ->
-        let ext = sprintf ".%s.all-deps" (Ml_kind.to_string ml_kind) in
-        let obj = Module.obj_name m in
-        Module_name.Unique.artifact_filename obj ~ext
+      | Immediate (m, kind) -> make_name m kind "d"
+      | Transitive (m, kind) -> make_name m kind "all-deps"
   end
 
   let dep t dep =

--- a/src/dune_rules/obj_dir.mli
+++ b/src/dune_rules/obj_dir.mli
@@ -144,7 +144,7 @@ module Module : sig
 
   module Dep : sig
     type t =
-      | Immediate of Module.File.t
+      | Immediate of Module.t * Ml_kind.t
       | Transitive of Module.t * Ml_kind.t
   end
 

--- a/src/dune_rules/ocamldep.ml
+++ b/src/dune_rules/ocamldep.ml
@@ -75,7 +75,7 @@ let deps_of
   let dep = Obj_dir.Module.dep obj_dir in
   let context = Super_context.context sctx in
   let all_deps_file = dep (Transitive (unit, ml_kind)) in
-  let ocamldep_output = dep (Immediate source) in
+  let ocamldep_output = dep (Immediate (unit, ml_kind)) in
   let open Memo.O in
   let* () =
     Super_context.add_rule sctx ~dir
@@ -151,7 +151,9 @@ let read_immediate_deps_of ~obj_dir ~modules ~ml_kind unit =
   match Module.source ~ml_kind unit with
   | None -> Action_builder.return []
   | Some source ->
-    let ocamldep_output = Obj_dir.Module.dep obj_dir (Immediate source) in
+    let ocamldep_output =
+      Obj_dir.Module.dep obj_dir (Immediate (unit, ml_kind))
+    in
     Action_builder.memoize
       (Path.Build.to_string ocamldep_output)
       (Action_builder.map

--- a/test/blackbox-tests/test-cases/all-alias/private-exe.t/run.t
+++ b/test/blackbox-tests/test-cases/all-alias/private-exe.t/run.t
@@ -1,7 +1,7 @@
 @all builds private exe's
 
   $ dune build @all --display short
-      ocamldep .foo.eobjs/foo.ml.d
+      ocamldep .foo.eobjs/foo.impl.d
         ocamlc .foo.eobjs/byte/foo.{cmi,cmo,cmt}
       ocamlopt .foo.eobjs/native/foo.{cmx,o}
         ocamlc foo.bc

--- a/test/blackbox-tests/test-cases/byte-code-only.t/run.t
+++ b/test/blackbox-tests/test-cases/byte-code-only.t/run.t
@@ -2,7 +2,7 @@
         ocamlc bin/.toto.eobjs/byte/dune__exe__Toto.{cmi,cmo,cmt}
         ocamlc src/.foo.objs/byte/foo.{cmi,cmo,cmt}
         ocamlc build-info/.build_info.objs/byte/build_info.{cmi,cmo,cmt}
-      ocamldep build-info/.build_info.objs/build_info_data.mli.d
+      ocamldep build-info/.build_info.objs/build_info__Build_info_data.intf.d
         ocamlc bin/toto.exe
         ocamlc bin/toto.bc
         ocamlc src/foo.cma

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
@@ -1,17 +1,17 @@
   $ dune build --display short --debug-dependency-path @all
         coqdep thy1/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
-      ocamldep src_b/.ml_plugin_b.objs/simple_b.ml.d
+      ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
-      ocamldep src_a/.ml_plugin_a.objs/gram.mli.d
-      ocamldep src_a/.ml_plugin_a.objs/simple.ml.d
+      ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Gram.intf.d
+      ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Simple.impl.d
         coqdep thy2/a.v.d
          coqpp src_a/gram.ml
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Simple.{cmi,cmo,cmt}
-      ocamldep src_a/.ml_plugin_a.objs/gram.ml.d
+      ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Gram.impl.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b__Simple_b.{cmi,cmo,cmt}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Gram.{cmx,o}

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
@@ -1,16 +1,16 @@
   $ dune build --display short --debug-dependency-path @all
         coqdep theories/a.v.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
-      ocamldep src_b/.ml_plugin_b.objs/simple_b.ml.d
+      ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
-      ocamldep src_a/.ml_plugin_a.objs/gram.mli.d
-      ocamldep src_a/.ml_plugin_a.objs/simple.ml.d
+      ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Gram.intf.d
+      ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Simple.impl.d
          coqpp src_a/gram.ml
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Simple.{cmi,cmo,cmt}
-      ocamldep src_a/.ml_plugin_a.objs/gram.ml.d
+      ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Gram.impl.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b__Simple_b.{cmi,cmo,cmt}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Simple.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a__Gram.{cmx,o}

--- a/test/blackbox-tests/test-cases/cross-compilation.t/run.t
+++ b/test/blackbox-tests/test-cases/cross-compilation.t/run.t
@@ -1,7 +1,7 @@
   $ env OCAMLFIND_CONF=$PWD/etc/findlib.conf dune build --display short -x foo file @install --promote-install-files
-      ocamldep bin/.blah.eobjs/blah.ml.d
+      ocamldep bin/.blah.eobjs/blah.impl.d
         ocamlc lib/.p.objs/byte/p.{cmi,cmo,cmt}
-      ocamldep bin/.blah.eobjs/blah.ml.d [default.foo]
+      ocamldep bin/.blah.eobjs/blah.impl.d [default.foo]
         ocamlc lib/.p.objs/byte/p.{cmi,cmo,cmt} [default.foo]
       ocamlopt lib/.p.objs/native/p.{cmx,o}
         ocamlc bin/.blah.eobjs/byte/blah.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/normal.t/run.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/normal.t/run.t
@@ -1,6 +1,6 @@
   $ dune build --display short file @install
-      ocamldep .p.eobjs/p.ml.d
-      ocamldep .p.eobjs/p.ml.d [cross]
+      ocamldep .p.eobjs/p.impl.d
+      ocamldep .p.eobjs/p.impl.d [cross]
         ocamlc .p.eobjs/byte/p.{cmi,cmo,cmt}
         ocamlc .p.eobjs/byte/p.{cmi,cmo,cmt} [cross]
       ocamlopt .p.eobjs/native/p.{cmx,o}

--- a/test/blackbox-tests/test-cases/include-qualified/pp-github6866.t
+++ b/test/blackbox-tests/test-cases/include-qualified/pp-github6866.t
@@ -8,15 +8,10 @@ Preprocessing should work when there's modules with the same name
   > (include_subdirs qualified)
   > (library
   >  (name foo)
-  >  (preprocess (action (cat system "cat %{input-file}"))))
+  >  (preprocess (action (system "cat %{input-file}"))))
   > EOF
 
   $ mkdir bar/
   $ touch baz.ml bar/baz.ml
 
   $ dune build @check
-  Error: Multiple rules generated for _build/default/.foo.objs/baz.pp.ml.d:
-  - <internal location>
-  - <internal location>
-  -> required by alias check
-  [1]

--- a/test/blackbox-tests/test-cases/intf-only/foo.t/run.t
+++ b/test/blackbox-tests/test-cases/intf-only/foo.t/run.t
@@ -1,9 +1,9 @@
 Successes:
 
   $ dune build --display short --debug-dep
-      ocamldep .foo.objs/foo.ml.d
+      ocamldep .foo.objs/foo.impl.d
         ocamlc .foo.objs/byte/foo__.{cmi,cmo,cmt}
-      ocamldep .foo.objs/intf.mli.d
+      ocamldep .foo.objs/foo__Intf.intf.d
       ocamlopt .foo.objs/native/foo__.{cmx,o}
         ocamlc .foo.objs/byte/foo__Intf.{cmi,cmti}
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/explicit-js-mode-specified.t/run.t
@@ -7,7 +7,7 @@ Check that .bc.js rule is generated only if js mode is used.
 
   $ dune build --display short b.bc.js
    js_of_ocaml .b.eobjs/jsoo/b.bc.runtime.js
-      ocamldep .b.eobjs/b.ml.d
+      ocamldep .b.eobjs/b.impl.d
         ocamlc .b.eobjs/byte/b.{cmi,cmo,cmt}
    js_of_ocaml .js/default/stdlib/std_exit.cmo.js
    js_of_ocaml .js/default/stdlib/stdlib.cma.js
@@ -25,7 +25,7 @@ every dependency of an executable.
 
   $ dune build --display short _build/default/.foo.objs/jsoo/default/foo.cma.js
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
-      ocamldep .foo.objs/c.ml.d
+      ocamldep .foo.objs/foo__C.impl.d
         ocamlc .foo.objs/byte/foo__C.{cmi,cmo,cmt}
         ocamlc foo.cma
    js_of_ocaml .foo.objs/jsoo/default/foo.cma.js
@@ -50,9 +50,9 @@ Check that building a JS-enabled executable that depends on a library works.
   $ dune clean
   $ dune build --display short e.bc.js
    js_of_ocaml .e.eobjs/jsoo/e.bc.runtime.js
-      ocamldep .e.eobjs/e.ml.d
+      ocamldep .e.eobjs/e.impl.d
         ocamlc .foo.objs/byte/foo.{cmi,cmo,cmt}
-      ocamldep .foo.objs/c.ml.d
+      ocamldep .foo.objs/foo__C.impl.d
    js_of_ocaml .js/default/stdlib/std_exit.cmo.js
    js_of_ocaml .js/default/stdlib/stdlib.cma.js
         ocamlc .foo.objs/byte/foo__C.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/no-check-prim.t/run.t
@@ -3,11 +3,11 @@ Compilation using jsoo
   $ dune build --display short bin/technologic.bc.js @install  2>&1 | \
   > sed s,^\ *$(ocamlc -config-var c_compiler),\ \ C_COMPILER,g
    js_of_ocaml bin/.technologic.eobjs/jsoo/technologic.bc.runtime.js
-      ocamldep bin/.technologic.eobjs/technologic.ml.d
-      ocamldep lib/.x.objs/x.ml.d
+      ocamldep bin/.technologic.eobjs/technologic.impl.d
+      ocamldep lib/.x.objs/x.impl.d
         ocamlc lib/.x.objs/byte/x__.{cmi,cmo,cmt}
-      ocamldep lib/.x.objs/y.ml.d
-      ocamldep bin/.technologic.eobjs/z.ml.d
+      ocamldep lib/.x.objs/x__Y.impl.d
+      ocamldep bin/.technologic.eobjs/z.impl.d
       ocamlopt lib/.x.objs/native/x__.{cmx,o}
         ocamlc lib/.x.objs/byte/x__Y.{cmi,cmo,cmt}
    js_of_ocaml .js/default/js_of_ocaml-compiler.runtime/jsoo_runtime.cma.js

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed.t
@@ -52,7 +52,7 @@ Test dependency on installed package
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root b @install --display=short
   Entering directory 'b'
-      ocamldep .b.objs/bar.ml.d
+      ocamldep .b.objs/b__Bar.impl.d
           melc .b.objs/melange/b.{cmi,cmj,cmt}
           melc .b.objs/melange/b__Bar.{cmi,cmj,cmt}
   Leaving directory 'b'

--- a/test/blackbox-tests/test-cases/no-installable-mode/private.t/run.t
+++ b/test/blackbox-tests/test-cases/no-installable-mode/private.t/run.t
@@ -1,7 +1,7 @@
 However, it is possible to build a private one explicitly.
 
   $ dune build --display=short myprivatelib.so 2>&1 | dune_cmd sanitize
-      ocamldep .myprivatelib.eobjs/myprivatelib.ml.d
+      ocamldep .myprivatelib.eobjs/myprivatelib.impl.d
         ocamlc .myprivatelib.eobjs/byte/myprivatelib.{cmi,cmo,cmt}
       ocamlopt .myprivatelib.eobjs/native/myprivatelib.{cmx,o}
       ocamlopt myprivatelib$ext_dll

--- a/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
+++ b/test/blackbox-tests/test-cases/variables-for-artifacts.t/run.t
@@ -18,10 +18,10 @@ prefixed and unprefixed modules are built.
 
   $ ./sdune clean
   $ ./sdune build --display short @t1
-      ocamldep .a1.objs/a.ml.d
+      ocamldep .a1.objs/a1__A.impl.d
         ocamlc .b.eobjs/byte/dune__exe__B.{cmi,cmo,cmt}
         ocamlc .c1.objs/byte/c.{cmi,cmo,cmt}
-      ocamldep .c2.objs/d.ml.d
+      ocamldep .c2.objs/c2__D.impl.d
         ocamlc .a1.objs/byte/a1.{cmi,cmo,cmt}
         ocamlc .c2.objs/byte/c2.{cmi,cmo,cmt}
         ocamlc .a1.objs/byte/a1__A.{cmi,cmo,cmt}
@@ -39,7 +39,7 @@ The next test tries to build a .cmi file (of a module in a wrapped library).
 
   $ ./sdune clean
   $ ./sdune build --display short @t2
-      ocamldep .a1.objs/a.ml.d
+      ocamldep .a1.objs/a1__A.impl.d
         ocamlc .a1.objs/byte/a1.{cmi,cmo,cmt}
         ocamlc .a1.objs/byte/a1__A.{cmi,cmo,cmt}
 
@@ -79,7 +79,7 @@ The next test builds a native .cmxa.
   $ ./sdune clean
   $ ./sdune build --display short @t4
         ocamlc .a1.objs/byte/a1.{cmi,cmo,cmt}
-      ocamldep .a1.objs/a.ml.d
+      ocamldep .a1.objs/a1__A.impl.d
       ocamlopt .a1.objs/native/a1.{cmx,o}
         ocamlc .a1.objs/byte/a1__A.{cmi,cmo,cmt}
       ocamlopt .a1.objs/native/a1__A.{cmx,o}
@@ -122,7 +122,7 @@ defined. The library is public in this case, but we use the local name.
   $ ./sdune clean
   $ ./sdune build --display short @t6
         ocamlc sub2/.bar2.objs/byte/bar2.{cmi,cmo,cmt}
-      ocamldep sub2/.bar2.objs/y2.ml.d
+      ocamldep sub2/.bar2.objs/bar2__Y2.impl.d
         ocamlc sub2/.bar2.objs/byte/bar2__Y2.{cmi,cmo,cmt}
         ocamlc sub2/bar2.cma
 
@@ -136,7 +136,7 @@ This test builds a .cmo in a subdirectory (same project).
 
   $ ./sdune clean
   $ ./sdune build --display short @t7
-      ocamldep sub/.bar.objs/x.ml.d
+      ocamldep sub/.bar.objs/bar__X.impl.d
         ocamlc sub/.bar.objs/byte/bar.{cmi,cmo,cmt}
         ocamlc sub/.bar.objs/byte/bar__X.{cmi,cmo,cmt}
 
@@ -151,7 +151,7 @@ private library.
 
   $ ./sdune clean
   $ ./sdune build --display short @t8
-      ocamldep sub3/.c1.objs/x.ml.d
+      ocamldep sub3/.c1.objs/c1__X.impl.d
         ocamlc sub3/.c1.objs/byte/c1.{cmi,cmo,cmt}
         ocamlc sub3/.c1.objs/byte/c1__X.{cmi,cmo,cmt}
 
@@ -167,7 +167,7 @@ project.
   $ ./sdune clean
   $ ./sdune build --display short @t9
         ocamlc sub3/.c1.objs/byte/c1.{cmi,cmo,cmt}
-      ocamldep sub3/.c1.objs/x.ml.d
+      ocamldep sub3/.c1.objs/c1__X.impl.d
         ocamlc sub3/.c1.objs/byte/c1__X.{cmi,cmo,cmt}
         ocamlc sub3/c1.cma
 
@@ -202,7 +202,7 @@ This test checks that everything still works if we invoke dune from a
 subdirectory.
 
   $ (cd sub && dune build --display short %{cmx:x})
-      ocamldep .bar.objs/x.ml.d
+      ocamldep .bar.objs/bar__X.impl.d
         ocamlc .bar.objs/byte/bar.{cmi,cmo,cmt}
         ocamlc .bar.objs/byte/bar__X.{cmi,cmo,cmt}
       ocamlopt .bar.objs/native/bar__X.{cmx,o}
@@ -212,9 +212,9 @@ of a (rule).
 
   $ ./sdune build --display short _build/default/my.cmxs
         ocamlc .plugin.objs/byte/plugin.{cmi,cmo,cmt}
-      ocamldep .plugin.objs/x1.ml.d
-      ocamldep .plugin.objs/x2.ml.d
-      ocamldep .dummy.objs/x3.ml.d
+      ocamldep .plugin.objs/plugin__X1.impl.d
+      ocamldep .plugin.objs/plugin__X2.impl.d
+      ocamldep .dummy.objs/dummy__X3.impl.d
       ocamlopt .plugin.objs/native/plugin.{cmx,o}
         ocamlc .plugin.objs/byte/plugin__X1.{cmi,cmo,cmt}
         ocamlc .plugin.objs/byte/plugin__X2.{cmi,cmo,cmt}


### PR DESCRIPTION
To store the output of ocamldep, we'd choose the following path:

$obj_dir/$module-basename.$ext.d

This scheme doesn't work for (include_subdirs qualified) because base
filenames are no longer unique.

We now choose the file path to be $obj_dir/%module-obj-name.$kind.d

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d2ba2d31-4891-40c3-92a5-6b52696e4e51 -->