### PR TITLE
Doc: use a glossary

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -17,8 +17,9 @@ this scope only.
 
 Because scopes are exclusive, if you wish to include your current project's
 dependencies in your workspace, you can copy them in a ``vendor`` directory,
-or any name of your choice. Dune will look for them there rather than in the installed
-world, and there will be no overlap between the various scopes.
+or any name of your choice. Dune will look for them there rather than in the
+:term:`installed world`, and there will be no overlap between the various
+scopes.
 
 .. _ordered-set-language:
 
@@ -207,7 +208,8 @@ In addition, ``(action ...)`` fields support the following special variables:
 - ``lib:<public-library-name>:<file>`` expands to the file's installation path
   ``<file>`` in the library ``<public-library-name>``. If
   ``<public-library-name>`` is available in the current workspace, the local
-  file will be used, otherwise the one from the installed world will be used.
+  file will be used, otherwise the one from the :term:`installed world` will be
+  used.
 - ``lib-private:<library-name>:<file>`` expands to the file's build path
   ``<file>`` in the library ``<library-name>``. Both public and private library
   names are allowed as long as they refer to libraries within the same project.
@@ -221,7 +223,7 @@ In addition, ``(action ...)`` fields support the following special variables:
   whether the library is available or not. A library is available if at least
   one of the following conditions holds:
 
-  -  It's part the installed worlds.
+  -  It's part the :term:`installed world`.
   -  It's available locally and is not optional.
   -  It's available locally, and all its library dependencies are
      available.
@@ -354,12 +356,12 @@ Library dependencies are specified using ``(libraries ...)`` fields in
 ``library`` and ``executables`` stanzas.
 
 For libraries defined in the current scope, you can either use the real name or
-the public name. For libraries that are part of the installed world, or for
-libraries that are part of the current workspace but in another scope, you need
-to use the public name. For instance: ``(libraries base re)``.
+the public name. For libraries that are part of the :term:`installed world`, or
+for libraries that are part of the current workspace but in another scope, you
+need to use the public name. For instance: ``(libraries base re)``.
 
 When resolving libraries, ones that are part of the workspace are always
-preferred to ones that are part of the installed world.
+preferred to ones that are part of the :term:`installed world`.
 
 Alternative Dependencies
 ------------------------
@@ -383,9 +385,9 @@ Select forms are specified as follows:
 ``<literals>`` are lists of literals, where each literal is one of:
 
 - ``<library-name>``, which will evaluate to true if ``<library-name>`` is
-  available, either in the workspace or in the installed world
+  available, either in the workspace or in the :term:`installed world`
 - ``!<library-name>``, which will evaluate to true if ``<library-name>`` is not
-  available in the workspace or in the installed world
+  available in the workspace or in the :term:`installed world`
 
 When evaluating a select form, Dune will create ``<target-filename>`` by
 copying the file given by the first ``(<literals> -> <filename>)`` case where
@@ -593,7 +595,7 @@ Dependencies in ``dune`` files can be specified using one of the following:
   cases where dependencies are too hard to specify. Note that Dune
   will not be able to cache the result of actions that depend on the
   universe. In any case, this is only for dependencies in the
-  installed world. You must still specify all dependencies that come
+  :term:`installed world`. You must still specify all dependencies that come
   from the workspace.
 - ``(package <pkg>)`` depends on all files installed by ``<package>``, as well
   as on the transitive package dependencies of ``<package>``. This can be used

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -572,7 +572,7 @@ the description of an opam switch, as follows:
 
 - ``(merlin)`` instructs Dune to use this build context for Merlin.
 
-- ``(profile <profile>)`` sets a different profile for a build context. This has
+- ``(profile <profile>)`` sets a different profile for a :term:`build context`. This has
   precedence over the command-line option ``--profile``.
 
 - ``(env <env>)`` sets the environment for a particular context. This is of

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -55,8 +55,8 @@ Terminology
      differentiated by variables such as `%{workspace_root}` and
      `%{project_root}`. Dune builds things from this directory. It knows how to
      build targets that are descendants of the root. Anything outside of the tree
-     starting from the root is considered part of the **installed world**. Refer
-     to :ref:`finding-root` to learn how the workspace root is determined.
+     starting from the root is considered part of the :term:`installed world`.
+     Refer to :ref:`finding-root` to learn how the workspace root is determined.
 
    workspace
      The subtree starting from each root. It can contain any number of projects
@@ -79,7 +79,7 @@ Terminology
 
    installation
      The action of copying build artifacts or other files from the
-     ``<root>/_build`` directory to the installed world.
+     ``<root>/_build`` directory to the :term:`installed world`.
 
    scope
      Defined by any directory that contains at least one `<package>.opam` file.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -49,73 +49,84 @@ use the ``dune`` command.
 Terminology
 ===========
 
--  **root**: the top-most directory in a GitHub repo, workspace, and project,
-   differentiated by variables such as `%{workspace_root}` and
-   `%{project_root}`. Dune builds things from this directory. It knows how to
-   build targets that are descendants of the root. Anything outside of the tree
-   starting from the root is considered part of the **installed world**. Refer
-   to :ref:`finding-root` to learn how the workspace root is determined.
+.. glossary::
+   root
+     The top-most directory in a GitHub repo, workspace, and project,
+     differentiated by variables such as `%{workspace_root}` and
+     `%{project_root}`. Dune builds things from this directory. It knows how to
+     build targets that are descendants of the root. Anything outside of the tree
+     starting from the root is considered part of the **installed world**. Refer
+     to :ref:`finding-root` to learn how the workspace root is determined.
 
--  **workspace**: the subtree starting from each root. It can contain any number
-   of projects that will be built simultaneously by Dune, and it must contain a
-   `dune-workspace` file.
+   workspace
+     The subtree starting from each root. It can contain any number of projects
+     that will be built simultaneously by Dune, and it must contain a
+     `dune-workspace` file.
 
--  **project**: a collection of source files that must include a `dune-project`
-   file. It may also contain one or more packages. A project consists in a
-   hierarchy of directories. Every directory (at the root, or a subdirectory)
-   can contain a `dune` file that contains instructions to build files in that
-   directory. Projects can be shared between different applications.
+   project
+     A collection of source files that must include a `dune-project` file. It
+     may also contain one or more packages. A project consists in a hierarchy
+     of directories. Every directory (at the root, or a subdirectory) can
+     contain a `dune` file that contains instructions to build files in that
+     directory. Projects can be shared between different applications.
 
--  **package**: a set of libraries and executables that opam builds and installs
-   as one.
+   package
+     A set of libraries and executables that opam builds and installs as one.
 
--  **installed world**: anything outside of the workspace. Dune doesn't know how
-   to build things in the installed world.
+   installed world
+     Anything outside of the workspace. Dune doesn't know how to build things
+     in the installed world.
 
--  **installation**: the action of copying build artifacts or other files from
-   the ``<root>/_build`` directory to the installed world.
+   installation
+     The action of copying build artifacts or other files from the
+     ``<root>/_build`` directory to the installed world.
 
--  **scope**: defined by any directory that contains at least one
-   `<package>.opam` file. Typically, every project defines a single scope that
-   is a subtree starting from this directory. Moreover, scopes are separate from
-   your project's dependencies. The scope also determines where private items
-   are visible. Private items include libraries or binaries that will not be
-   installed.  See :ref:`scopes` for more details.
+   scope
+     Defined by any directory that contains at least one `<package>.opam` file.
+     Typically, every project defines a single scope that is a subtree starting
+     from this directory. Moreover, scopes are separate from your project's
+     dependencies. The scope also determines where private items are visible.
+     Private items include libraries or binaries that will not be installed.
+     See :ref:`scopes` for more details.
 
--  **build context**: a specific configuration written in a
-   :ref:`dune-workspace` file, which has a corresponding subdirectory in the
-   ``<root>/_build`` directory. It contains all the workspace's build artifacts.
-   Without this specific configuration from the user, there is always a
-   ``default`` build context that corresponds to the executed Dune environment. 
+   build context
+     A specific configuration written in a :ref:`dune-workspace` file, which
+     has a corresponding subdirectory in the ``<root>/_build`` directory. It
+     contains all the workspace's build artifacts. Without this specific
+     configuration from the user, there is always a ``default`` build context
+     that corresponds to the executed Dune environment.
 
--  **build context root**: the root of a build context named ``foo`` is
-   ``<root>/_build/<foo>``.
+   build context root
+     The root of a build context named ``foo`` is ``<root>/_build/<foo>``.
 
--  **build target**: specified on the command line, e.g., `dune build
-   <target_path.exe>`. All targets that Dune knows how to build live in the
-   `_build` directory.
+   build target
+     Specified on the command line, e.g., `dune build <target_path.exe>`. All
+     targets that Dune knows how to build live in the `_build` directory.
 
-- **alias**: a build target that doesn't produce any file and has configurable
-  dependencies. Targets starting with `@` on the command line are interpreted as
-  aliases (e.g., `dune build @src/runtest`). Aliases are per-directory. However,
-  asking to build an alias in a given directory will also trigger alias
-  construction in all children directories recursively. If no target is
-  specified, Dune builds the `default` alias.  Dune defines several
-  :ref:`builtin-aliases`.
+   alias
+     A build target that doesn't produce any file and has configurable
+     dependencies. Targets starting with `@` on the command line are
+     interpreted as aliases (e.g., `dune build @src/runtest`). Aliases are
+     per-directory. However, asking to build an alias in a given directory will
+     also trigger alias construction in all children directories recursively.
+     If no target is specified, Dune builds the `default` alias.  Dune defines
+     several :ref:`builtin-aliases`.
 
-- **environment**: determines the default values of various parameters, such as
-  the compilation flags. In Dune, each directory has an environment attached to
-  it. Inside a scope, each directory inherits the environment from its parent.
-  At the root of every scope, a default environment is used. At any point, the
-  environment can be altered using an :ref:`dune-env` stanza.
+   environment
+     Determines the default values of various parameters, such as the
+     compilation flags. In Dune, each directory has an environment attached to
+     it. Inside a scope, each directory inherits the environment from its
+     parent. At the root of every scope, a default environment is used. At any
+     point, the environment can be altered using an :ref:`dune-env` stanza.
 
-- **build profile**: a global setting that influences various defaults. It can
-  be set from the command line using ``--profile <profile>`` or from
-  ``dune-workspace`` files. The following profiles are standard:
+   build profile
+     A global setting that influences various defaults. It can be set from the
+     command line using ``--profile <profile>`` or from ``dune-workspace``
+     files. The following profiles are standard:
 
-  -  ``release`` which is the profile used for opam releases
-  -  ``dev`` which is the default profile when none is set explicitly, it has
-     stricter warnings than the ``release`` one
+     -  ``release`` which is the profile used for opam releases
+     -  ``dev`` which is the default profile when none is set explicitly, it has
+        stricter warnings than the ``release`` one
 
 Project Layout
 ==============

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -52,8 +52,8 @@ Terminology
 .. glossary::
    root
      The top-most directory in a GitHub repo, workspace, and project,
-     differentiated by variables such as `%{workspace_root}` and
-     `%{project_root}`. Dune builds things from this directory. It knows how to
+     differentiated by variables such as ``%{workspace_root}`` and
+     ``%{project_root}``. Dune builds things from this directory. It knows how to
      build targets that are descendants of the root. Anything outside of the tree
      starting from the root is considered part of the :term:`installed world`.
      Refer to :ref:`finding-root` to learn how the workspace root is determined.
@@ -61,13 +61,13 @@ Terminology
    workspace
      The subtree starting from each root. It can contain any number of projects
      that will be built simultaneously by Dune, and it must contain a
-     `dune-workspace` file.
+     ``dune-workspace`` file.
 
    project
-     A collection of source files that must include a `dune-project` file. It
+     A collection of source files that must include a ``dune-project`` file. It
      may also contain one or more packages. A project consists in a hierarchy
      of directories. Every directory (at the root, or a subdirectory) can
-     contain a `dune` file that contains instructions to build files in that
+     contain a ``dune`` file that contains instructions to build files in that
      directory. Projects can be shared between different applications.
 
    package
@@ -100,16 +100,16 @@ Terminology
      The root of a build context named ``foo`` is ``<root>/_build/<foo>``.
 
    build target
-     Specified on the command line, e.g., `dune build <target_path.exe>`. All
-     targets that Dune knows how to build live in the `_build` directory.
+     Specified on the command line, e.g., ``dune build <target_path.exe>``. All
+     targets that Dune knows how to build live in the ``_build`` directory.
 
    alias
      A build target that doesn't produce any file and has configurable
-     dependencies. Targets starting with `@` on the command line are
-     interpreted as aliases (e.g., `dune build @src/runtest`). Aliases are
+     dependencies. Targets starting with ``@`` on the command line are
+     interpreted as aliases (e.g., ``dune build @src/runtest``). Aliases are
      per-directory. However, asking to build an alias in a given directory will
      also trigger alias construction in all children directories recursively.
-     If no target is specified, Dune builds the `default` alias.  Dune defines
+     If no target is specified, Dune builds the ``default`` alias. Dune defines
      several :ref:`builtin-aliases`.
 
    environment

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -179,10 +179,10 @@ targets upon starting:
 Aliases
 -------
 
-Targets starting with a ``@`` are interpreted as aliases. For instance
-``@src/runtest`` means the alias ``runtest`` in all descendants of
-``src`` in all build contexts where it is defined. If you want to
-refer to a target starting with a ``@``, simply write: ``./@foo``.
+Targets starting with a ``@`` are interpreted as :term:`aliases <alias>`. For
+instance ``@src/runtest`` means the alias ``runtest`` in all descendants of
+``src`` in all build contexts where it is defined. If you want to refer to a
+target starting with a ``@``, simply write: ``./@foo``.
 
 To build and run the tests for a particular build context, use
 ``@_build/default/runtest`` instead.
@@ -222,8 +222,8 @@ where you need to do that, you can declare an alias like so:
 Default Alias
 -------------
 
-When no targets are given to ``dune build``, it builds the special
-``default`` alias. Effectively ``dune build`` is equivalent to:
+When no targets are given to ``dune build``, it builds the special ``default``
+:term:`alias`. Effectively ``dune build`` is equivalent to:
 
 .. code::
 
@@ -260,7 +260,8 @@ Is equivalent to:
 Built-in Aliases
 ----------------
 
-There are a few aliases that Dune automatically creates for the user:
+There are a few :term:`aliases <alias>` that Dune automatically creates for the
+user:
 
 * ``default`` includes all the targets that Dune will build if a
   target isn't specified, i.e., ``$ dune build``. By default, this is set to the


### PR DESCRIPTION
This switches our handmade *Terminology* section to a Sphinx glossary:

<https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#glossary>

The glossary itself is formatted in a better way, and it makes it possible to
link to definitions using the special syntax:

    :term:`library`
    :term:`libraries <library>`

Some examples are added. We probably do not want to link all instances of a
term, but this looks like it can be useful at the beginning of a section.
