### PR TITLE
doc: use production lists

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -66,13 +66,13 @@ Boolean Language
 The Boolean language allows the user to define simple Boolean expressions that
 Dune can evaluate. Here's a semi-formal specification of the language:
 
-.. productionlist::
+.. productionlist:: blang
    op : '=' | '<' | '>' | '<>' | '>=' | '<='
-   expr : (and `expr`+)
-        : (or `expr`+)
-        : (`op` `template` `template`)
-        : (not `expr`)
-        : `template`
+   expr : (and <expr>+)
+        : (or <expr>+)
+        : (<op> <template> <template>)
+        : (not <expr>)
+        : <template>
 
 After an expression is evaluated, it must be exactly the string ``true`` or
 ``false`` to be considered as a Boolean. Any other value will be treated as an

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -66,15 +66,13 @@ Boolean Language
 The Boolean language allows the user to define simple Boolean expressions that
 Dune can evaluate. Here's a semi-formal specification of the language:
 
-.. code::
-
-   op := '=' | '<' | '>' | '<>' | '>=' | '<='
-
-   expr := (and <expr>+)
-         | (or <expr>+)
-         | (<op> <template> <template>)
-         | (not <expr>)
-         | <template>
+.. productionlist::
+   op : '=' | '<' | '>' | '<>' | '>=' | '<='
+   expr : (and `expr`+)
+        : (or `expr`+)
+        : (<op> `template` `template`)
+        : (not `expr`)
+        : `template`
 
 After an expression is evaluated, it must be exactly the string ``true`` or
 ``false`` to be considered as a Boolean. Any other value will be treated as an
@@ -97,19 +95,18 @@ The predicate language allows the user to define simple predicates
 (Boolean-valued functions) that Dune can evaluate. Here is a semi-formal
 specification of the predicate language:
 
-.. code::
+.. productionlist::
+   pred : (and `pred` `pred`)
+        : (or `pred` `pred`)
+        : (not `pred`)
+        : :standard
+        : `element`
 
-   pred := (and <pred> <pred>)
-         | (or <pred> <pred>)
-         | (not <pred>)
-         | :standard
-         | <element>
-
-The exact meaning of ``:standard`` and the nature of ``<element>`` depends on
-the context. For example, in the case of the :ref:`dune-subdirs`, an
-``<element>`` corresponds to file glob patterns. Another example is the user
-action :ref:`(with-accepted-exit-codes ...) <user-actions>`, where an ``<element>``
-corresponds to a literal integer.
+The exact meaning of ``:standard`` and the nature of :token:`element` depends
+on the context. For example, in the case of the :ref:`dune-subdirs`, an
+:token:`element` corresponds to file glob patterns. Another example is the user
+action :ref:`(with-accepted-exit-codes ...) <user-actions>`, where an
+:token:`element` corresponds to a literal integer.
 
 .. _variables:
 

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -70,7 +70,7 @@ Dune can evaluate. Here's a semi-formal specification of the language:
    op : '=' | '<' | '>' | '<>' | '>=' | '<='
    expr : (and `expr`+)
         : (or `expr`+)
-        : (<op> `template` `template`)
+        : (`op` `template` `template`)
         : (not `expr`)
         : `template`
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -326,28 +326,22 @@ stanza. It contains the following fields:
 Adding libraries to different packages is done via the ``public_name`` field.
 See :ref:`library` section for details.
 
-The list of dependencies ``<dep-specification>`` is modelled after opam's own
+The list of dependencies :token:`dep_specification` is modelled after opam's own
 language. The syntax is a list of the following elements:
 
-.. code::
-
-   op := '=' | '<' | '>' | '<>' | '>=' | '<='
-
-   filter := :dev | :build | :with-test | :with-doc | :post
-
-   constr := (<op> <version>)
-
-   logop := or | and
-
-   dep := name
-        | (name <filter>)
-        | (name <constr>)
-        | (name (<logop> (<filter> | <constr>))*)
-
-   dep-specification = dep+
+.. productionlist::
+   op : '=' | '<' | '>' | '<>' | '>=' | '<='
+   filter : :dev | :build | :with-test | :with-doc | :post
+   constr : (`op` `version`)
+   logop : or | and
+   dep : `name`
+       : (`name` `filter`)
+       : (`name` `constr`)
+       : (`name` (`logop` (`filter` | `constr`))*)
+   dep_specification : `dep`+
 
 Filters will expand to any opam variable name if prefixed by ``:``, not just the
-ones listed above. This also applies to version numbers. For example, to
+ones listed in :token:`filter`. This also applies to version numbers. For example, to
 generate ``depends: [ pkg { = version } ]``, use ``(depends (pkg (=
 :version)))``.
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -329,16 +329,16 @@ See :ref:`library` section for details.
 The list of dependencies :token:`dep_specification` is modelled after opam's own
 language. The syntax is a list of the following elements:
 
-.. productionlist::
+.. productionlist:: pkg-dep
    op : '=' | '<' | '>' | '<>' | '>=' | '<='
    filter : :dev | :build | :with-test | :with-doc | :post
-   constr : (`op` `version`)
+   constr : (<op> <version>)
    logop : or | and
-   dep : `name`
-       : (`name` `filter`)
-       : (`name` `constr`)
-       : (`name` (`logop` (`filter` | `constr`))*)
-   dep_specification : `dep`+
+   dep : <name>
+       : (<name> <filter>)
+       : (<name> <constr>)
+       : (<name> (<logop> (<filter> | <constr>))*)
+   dep_specification : <dep>+
 
 Filters will expand to any opam variable name if prefixed by ``:``, not just the
 ones listed in :token:`filter`. This also applies to version numbers. For example, to


### PR DESCRIPTION
Instead of using code blocks, we use sphinx's built-in support for this.
This looks slightly better but the advantage is that we can use the
following syntax to refer to items:

    :token:`dep`
