### PR TITLE
refactor: Dune_project.encode sanity

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -338,7 +338,6 @@ module Component = struct
       in
       let info = Package.Info.example in
       Dune_project.anonymous ~dir ~packages ~info ()
-      |> Dune_project.set_dialects Dialect.DB.empty
       |> Dune_project.set_generate_opam_files opam_file_gen
       |> Dune_project.encode
       |> List.map ~f:(fun exp ->

--- a/src/dune_engine/dialect.ml
+++ b/src/dune_engine/dialect.ml
@@ -266,4 +266,6 @@ module DB = struct
   let to_dyn { by_name; _ } = String.Map.to_dyn to_dyn by_name
 
   let builtin = of_list [ ocaml; reason ]
+
+  let is_default t = t == builtin
 end

--- a/src/dune_engine/dialect.mli
+++ b/src/dune_engine/dialect.mli
@@ -62,4 +62,6 @@ module DB : sig
   val to_dyn : t -> Dyn.t
 
   val builtin : t
+
+  val is_default : t -> bool
 end

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -184,8 +184,6 @@ let use_standard_c_and_cxx_flags t = t.use_standard_c_and_cxx_flags
 
 let dialects t = t.dialects
 
-let set_dialects dialects t = { t with dialects }
-
 let explicit_js_mode t = t.explicit_js_mode
 
 let dune_version t = t.dune_version
@@ -670,7 +668,9 @@ let encode : t -> Dune_lang.t list =
       ]
   in
   let dialects =
-    Dialect.DB.fold ~f:(fun d ls -> Dialect.encode d :: ls) ~init:[] dialects
+    if Dialect.DB.is_default dialects then []
+    else
+      Dialect.DB.fold ~f:(fun d ls -> Dialect.encode d :: ls) ~init:[] dialects
   in
   let formatting =
     Option.bind format_config ~f:Format_config.encode_opt |> Option.to_list

--- a/src/dune_engine/dune_project.mli
+++ b/src/dune_engine/dune_project.mli
@@ -68,8 +68,6 @@ val use_standard_c_and_cxx_flags : t -> bool option
 
 val dialects : t -> Dialect.DB.t
 
-val set_dialects : Dialect.DB.t -> t -> t
-
 val explicit_js_mode : t -> bool
 
 val format_config : t -> Format_config.t


### PR DESCRIPTION
dune init relies on removing all dialects to make sure the serialized
dune-project file doesn't have any dialects. That is weird because
it explicitly relies on serializition/deserialization not being round trip.

Instead of relying on this, we change the serializer to stop outputting
the set of dialects if it's equal to the default.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 75f25746-0290-4182-ac97-e1d9705969ae -->