### PR TITLE
Jsoo: recognize toplevel variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,7 +85,7 @@ Unreleased
   enabled (#6645, @hhugo)
 
 - Fix *js_of_ocaml* separate compilation rules when `--enable=effects`
-  or `--enable=use-js-string` is used. (#6714, #6828, @hhugo)
+  ,`--enable=use-js-string` or `--toplevel` is used. (#6714, #6828, #6920, @hhugo)
 
 - Fix *js_of_ocaml* separate compilation in presence of linkall (#6832, #6916, @hhugo)
 

--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -61,7 +61,17 @@ end = struct
     let rec loop acc = function
       | [] -> acc
       | "--enable" :: name :: rest -> loop (set acc name true) rest
+      | maybe_enable :: rest
+        when String.is_prefix maybe_enable ~prefix:"--enable=" -> (
+        match String.drop_prefix maybe_enable ~prefix:"--enable=" with
+        | Some name -> loop (set acc name true) rest
+        | _ -> assert false)
       | "--disable" :: name :: rest -> loop (set acc name false) rest
+      | maybe_disable :: rest
+        when String.is_prefix maybe_disable ~prefix:"--disable=" -> (
+        match String.drop_prefix maybe_disable ~prefix:"--disable=" with
+        | Some name -> loop (set acc name false) rest
+        | _ -> assert false)
       | _ :: rest -> loop acc rest
     in
     loop default l


### PR DESCRIPTION
This should help to build jsoo toplevels using separate compilation.
See https://github.com/ocsigen/js_of_ocaml/pull/1380

Sadly, this multiply the number of jsoo targets by ~2.
