### PR TITLE
refactor(rules): modify generated source name

### DIFF
--- a/otherlibs/build-info/test/run.t
+++ b/otherlibs/build-info/test/run.t
@@ -84,7 +84,7 @@ Once installed, we have the version information:
 
 Check what the generated build info module looks like:
 
-  $ cat _build/default/c/.c.eobjs/build_info_data.ml-gen \
+  $ cat _build/default/c/.c.eobjs/build_info__Build_info_data.ml-gen \
   >   | sed 's/"dune-build-info".*/"dune-build-info", Some "XXX"/'
   let eval s =
     let s = Bytes.unsafe_to_string (Bytes.unsafe_of_string s) in

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -370,8 +370,10 @@ let generated ?obj_name ?path ~(kind : Kind.t) ~src_dir name =
   in
   let source =
     let impl =
-      let basename = String.uncapitalize (Module_name.to_string name) in
-      Path.Build.relative src_dir (basename ^ ml_gen)
+      let basename =
+        Module_name.Unique.artifact_filename obj_name ~ext:".ml-gen"
+      in
+      Path.Build.relative src_dir basename
       |> Path.build |> File.make Dialect.ocaml
     in
     Source.make ~impl name


### PR DESCRIPTION
We choose the source name of generated files to be based on the object
name rather than the module name.

With (include_subdirs qualified), it's easy to generate a source name
that will collide with anothera generated module's name.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 84ee3e6b-38a6-45f4-84c0-b5b0762f6d68 -->