### PR TITLE
fix: keep configurator.v2 to use dune-configurator

### DIFF
--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -300,6 +300,8 @@ let gen_rules ~sctx ~dir components : Build_system.extra_sub_directories_to_keep
          attached to [write_dot_dune_dir] in context.ml *)
       Super_context.add_rule sctx ~dir
         (Build.write_file (Path.Build.relative dir "configurator") "");
+      Super_context.add_rule sctx ~dir
+        (Build.write_file (Path.Build.relative dir "configurator.v2") "");
       (* Add rules for C compiler detection *)
       Cxx_rules.rules ~sctx ~dir;
       These String.Set.empty

--- a/test/blackbox-tests/test-cases/github6936.t/config/discover.ml
+++ b/test/blackbox-tests/test-cases/github6936.t/config/discover.ml
@@ -1,0 +1,7 @@
+module C = Configurator.V1
+
+let () =
+  C.main ~name:"taglib-pkg-config" (fun c ->
+    C.C_define.gen_header_file c ~fname:"config.h" [];
+    C.Flags.write_sexp "c_flags.sexp" []
+  )

--- a/test/blackbox-tests/test-cases/github6936.t/config/dune
+++ b/test/blackbox-tests/test-cases/github6936.t/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune.configurator))

--- a/test/blackbox-tests/test-cases/github6936.t/dune
+++ b/test/blackbox-tests/test-cases/github6936.t/dune
@@ -1,0 +1,15 @@
+(library
+ (public_name taglib)
+ (foreign_stubs
+  (language cxx)
+  (names taglib_stubs)
+  (extra_deps config.h)
+  (flags
+   :standard (:include c_flags.sexp))))
+
+(rule
+ (targets
+   config.h
+   c_flags.sexp)
+ (action
+  (run ./config/discover.exe)))

--- a/test/blackbox-tests/test-cases/github6936.t/run.t
+++ b/test/blackbox-tests/test-cases/github6936.t/run.t
@@ -1,0 +1,11 @@
+Reproduction of https://github.com/savonet/ocaml-taglib/issues/10
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.8)
+  > (use_standard_c_and_cxx_flags true)
+  > EOF
+
+  $ touch taglib.opam
+
+Build fine
+  $ dune build -p taglib -j 1

--- a/test/blackbox-tests/test-cases/github6936.t/taglib_stubs.cc
+++ b/test/blackbox-tests/test-cases/github6936.t/taglib_stubs.cc
@@ -1,0 +1,4 @@
+#include "config.h"
+
+void foo(void)
+{}


### PR DESCRIPTION
So I come after this issue: https://github.com/savonet/ocaml-taglib/issues/10

I intend to add this patch in nixpkgs so send it for review here

When I apply modification with dune3 it build fine. However with dune2 I have a very strange behavior:

```sh
$ dune build -p taglib
# fail because `_build/default/.dune/configurator.v2` doesn't exist only `_build/default/.dune/configurator` exist
# replace true with false for use_standard_c_and_cxx_flags
$ dune build -p taglib
# fail because : standard is now empty
# but `_build/default/.dune/configurator.v2` does now exist, IIRC the v1 file still exist
# replace false with true for use_standard_c_and_cxx_flags
$ dune build -p taglib
# succeed 😀
```

I think my patch is correct because I see something similar in dune3.6 https://github.com/ocaml/dune/blob/c939c2b0f7a470cedd189988c61cd307a3cedace/src/dune_rules/context.ml#L979

Signed-off-by: Élie BRAMI <cadeaudeelie@gmail.com>