### PR TITLE
fix: include all diagnostics

### DIFF
--- a/src/dune_engine/build_system.mli
+++ b/src/dune_engine/build_system.mli
@@ -84,8 +84,6 @@ val state : State.t Fiber.Svar.t
 
 (** Errors found when building targets. *)
 module Error : sig
-  type t
-
   module Id : sig
     type t
 
@@ -97,6 +95,20 @@ module Error : sig
 
     val to_dyn : t -> Dyn.t
   end
+
+  type t
+
+  val id : t -> Id.t
+
+  (** the directory where the rule the error is originating from *)
+  val dir : t -> Path.t option
+
+  (** The description of the error. Errors from build rules contain useful
+      metadata that are extracted into [`Diagnostic] *)
+  val description :
+    t -> [ `Exn of Exn_with_backtrace.t | `Diagnostic of Compound_user_error.t ]
+
+  val promotion : t -> Diff_promotion.Annot.t option
 
   module Event : sig
     type nonrec t =
@@ -119,28 +131,6 @@ module Error : sig
 
     val empty : t
   end
-
-  val create : exn:Exn_with_backtrace.t -> t
-
-  (** [info] stores additional information about errors *)
-  type info =
-    { dir : Path.t option
-          (** the directory where the rule the error is originating from *)
-    ; related : User_message.t list
-          (** related errors with additional descriptions and locations. only
-              useful for rpc clients *)
-    ; main : User_message.t
-          (** the main message of the error. this is what is displayed in the
-              console *)
-    }
-
-  (** [info t] returns additional information regarding errors. useful for rich
-      clients that consume errors through rpc *)
-  val info : t -> info
-
-  val promotion : t -> Diff_promotion.Annot.t option
-
-  val id : t -> Id.t
 end
 
 (** The current set of active errors. *)

--- a/src/dune_engine/compound_user_error.mli
+++ b/src/dune_engine/compound_user_error.mli
@@ -9,8 +9,8 @@ type t = private
   ; related : User_message.t list
   }
 
-val annot : t User_message.Annots.Key.t
+val annot : t list User_message.Annots.Key.t
 
 val make : main:User_message.t -> related:User_message.t list -> t
 
-val parse_output : dir:Path.t -> string -> t option
+val parse_output : dir:Path.t -> string -> t list

--- a/src/dune_engine/dune_project.ml
+++ b/src/dune_engine/dune_project.ml
@@ -805,9 +805,10 @@ let parse ~dir ~lang ~file ~dir_status =
                    in
                    let related = [ message loc1; message loc2 ] in
                    User_message.Annots.singleton Compound_user_error.annot
-                     (Compound_user_error.make
-                        ~main:(User_message.make main_message)
-                        ~related)
+                     [ Compound_user_error.make
+                         ~main:(User_message.make main_message)
+                         ~related
+                     ]
                  in
                  User_error.raise ~annots
                    (main_message

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -480,8 +480,9 @@ end = struct
               User_message.Annots.has_embedded_location ()
           in
           match Compound_user_error.parse_output ~dir output.without_color with
-          | None -> annots
-          | Some e -> User_message.Annots.set annots Compound_user_error.annot e
+          | [] -> annots
+          | errors ->
+            User_message.Annots.set annots Compound_user_error.annot errors
         else annots
     in
     (loc, annots)

--- a/src/dune_engine/sub_dirs.ml
+++ b/src/dune_engine/sub_dirs.ml
@@ -210,7 +210,7 @@ module Dir_map = struct
                     ]
                   in
                   User_message.Annots.singleton Compound_user_error.annot
-                    (Compound_user_error.make ~main ~related)
+                    [ Compound_user_error.make ~main ~related ]
                 in
                 User_error.raise ~loc ~annots
                   [ main_message; Pp.verbatim (Loc.to_file_colon_line loc2) ]))

--- a/src/dune_rules/foreign.ml
+++ b/src/dune_rules/foreign.ml
@@ -225,7 +225,7 @@ module Objects = struct
         let main = User_message.make ~loc [ Pp.text main_message ] in
         let related = [ User_message.make ~loc:loc' [ Pp.text "" ] ] in
         User_message.Annots.singleton Compound_user_error.annot
-          (Compound_user_error.make ~main ~related)
+          [ Compound_user_error.make ~main ~related ]
       in
       User_error.raise ~loc ~annots
         [ Pp.textf "%s Already appears at:" main_message

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -209,7 +209,7 @@ let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version
           ]
         in
         User_message.Annots.singleton Compound_user_error.annot
-          (Compound_user_error.make ~main ~related)
+          [ Compound_user_error.make ~main ~related ]
       in
       User_error.raise ~loc ~annots
         [ Pp.textf "%s. See another definition at %s." main_message
@@ -251,7 +251,7 @@ let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version
             [ User_message.make ~loc:loc1 [ Pp.text "Name already used here" ] ]
           in
           User_message.Annots.singleton Compound_user_error.annot
-            (Compound_user_error.make ~main ~related)
+            [ Compound_user_error.make ~main ~related ]
         in
         User_error.raise ~annots ~loc:loc2
           [ Pp.textf "%s; the name has already been taken in %s." main_message

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -121,7 +121,7 @@ module Modules = struct
                 User_message.make ~loc [ Pp.text "Used in this stanza" ])
           in
           User_message.Annots.singleton Compound_user_error.annot
-            (Compound_user_error.make ~main ~related)
+            [ Compound_user_error.make ~main ~related ]
         in
         User_error.raise ~annots ~loc:(Loc.drop_position loc)
           [ main_message
@@ -356,7 +356,7 @@ let make_lib_modules ~dir ~libs ~lookup_vlib ~(lib : Library.t) ~modules
           ]
         in
         User_message.Annots.singleton Compound_user_error.annot
-          (Compound_user_error.make ~main ~related)
+          [ Compound_user_error.make ~main ~related ]
       in
       User_error.raise ~annots ~loc:loc_include_subdirs [ main_message ]
     | _, _ -> ()

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -124,7 +124,7 @@ module DB = struct
                     ]
                   in
                   User_message.Annots.singleton Compound_user_error.annot
-                    (Compound_user_error.make ~main ~related)
+                    [ Compound_user_error.make ~main ~related ]
                 in
                 User_error.raise ~annots
                   [ main_message
@@ -200,7 +200,7 @@ module DB = struct
               [ User_message.make ~loc:loc1 [ Pp.text "Already defined here" ] ]
             in
             User_message.Annots.singleton Compound_user_error.annot
-              (Compound_user_error.make ~main ~related)
+              [ Compound_user_error.make ~main ~related ]
           in
           User_error.raise ~annots ~loc:loc2
             [ Pp.textf "Public library %s is defined twice:"

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_diagnostics.ml
@@ -711,5 +711,86 @@ let g = A.f
           ; [ "related"; [] ]
           ; [ "targets"; [] ]
           ]
+        ]
+        [ "Add"
+        ; [ [ "directory"; "$CWD" ]
+          ; [ "id"; "1" ]
+          ; [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "8" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "12" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "11" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "12" ]
+                  ]
+                ]
+              ]
+            ]
+          ; [ "message"; [ "Verbatim"; "foobar\n\
+                                        " ] ]
+          ; [ "promotion"; [] ]
+          ; [ "related"; [] ]
+          ; [ "targets"; [] ]
+          ]
+        ]
+        [ "Add"
+        ; [ [ "directory"; "$CWD" ]
+          ; [ "id"; "2" ]
+          ; [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "4" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "11" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "5" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "11" ]
+                  ]
+                ]
+              ]
+            ]
+          ; [ "message"; [ "Verbatim"; "unused value f.\n\
+                                        " ] ]
+          ; [ "promotion"; [] ]
+          ; [ "related"; [] ]
+          ; [ "targets"; [] ]
+          ]
+        ]
+        [ "Add"
+        ; [ [ "directory"; "$CWD" ]
+          ; [ "id"; "3" ]
+          ; [ "loc"
+            ; [ [ "start"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "4" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "12" ]
+                  ]
+                ]
+              ; [ "stop"
+                ; [ [ "pos_bol"; "0" ]
+                  ; [ "pos_cnum"; "5" ]
+                  ; [ "pos_fname"; "$CWD/foo.ml" ]
+                  ; [ "pos_lnum"; "12" ]
+                  ]
+                ]
+              ]
+            ]
+          ; [ "message"; [ "Verbatim"; "unused value g.\n\
+                                        " ] ]
+          ; [ "promotion"; [] ]
+          ; [ "related"; [] ]
+          ; [ "targets"; [] ]
+          ]
         ] |}]);
   [%expect {||}]


### PR DESCRIPTION
Some compilation commands emit more than one diagnostic. For example,
ocamlc can emit more than one deprecation or unused error warning.

The previous behavior would be to just take the first error and drop the
others. This PR fixes the behavior to include all errors extracted out
of a command.

cc @ddickstein 