### PR TITLE
test(melange): fix copy-files-lib test

### DIFF
--- a/test/blackbox-tests/test-cases/melange/copy-files-emit-folder.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-emit-folder.t
@@ -21,7 +21,7 @@ Showcase issue with melange.emit inside folder and copy_files
   > (subdir
   >  app
   >  (copy_files
-  >   (files ../../assets/file.txt))
+  >   (files %{project_root}/assets/file.txt))
   >  (alias
   >   (name melange)
   >   (deps file.txt)))
@@ -51,7 +51,7 @@ Now add include_subdirs unqualified to show issue
   > (subdir
   >  app
   >  (copy_files
-  >   (files ../../assets/file.txt))
+  >   (files %{project_root}/assets/file.txt))
   >  (alias
   >   (name melange)
   >   (deps file.txt)))

--- a/test/blackbox-tests/test-cases/melange/copy-files-lib.t/app/dune
+++ b/test/blackbox-tests/test-cases/melange/copy-files-lib.t/app/dune
@@ -11,7 +11,7 @@
   (subdir
    assets
    (copy_files
-    (files ../../../../lib/assets/file.txt))
+    (files %{project_root}/lib/assets/file.txt))
    (alias
     (name melange)
-    (deps ../../../../lib/assets/file.txt)))))
+    (deps file.txt)))))

--- a/test/blackbox-tests/test-cases/melange/copy-files.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files.t
@@ -42,7 +42,7 @@ Copy the file into the output folder, so we can use same path as in-source
   > 
   > (subdir output
   >  (subdir assets
-  >   (copy_files (alias mel) (files ../../assets/file.txt))))
+  >   (copy_files (alias mel) (files %{project_root}/assets/file.txt))))
   > EOF
 
   $ cat > main.ml <<EOF

--- a/test/blackbox-tests/test-cases/melange/not-found-melange-js-rule.t
+++ b/test/blackbox-tests/test-cases/melange/not-found-melange-js-rule.t
@@ -33,7 +33,7 @@ Now try copying a file
   >  (subdir
   >   src
   >   (copy_files
-  >    (files ../../../public/img.png))))
+  >    (files %{project_root}/public/img.png))))
   > EOF
 
 Build fails


### PR DESCRIPTION
* Refer to to artifacts using %{project_root}
* Add dependency for the melange alias on the target rather than the
  dependency

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5a79443d-2420-4761-b339-7cfda789111a -->