### PR TITLE
fix(melange): emit rule loading

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -307,12 +307,13 @@ let setup_js_rules_libraries ~dir ~scope ~target_dir ~sctx ~requires_link ~mode
       let* source_modules = impl_only_modules_defined_in_this_lib sctx lib in
       Memo.parallel_iter source_modules ~f:(build_js ~dir ~output ~includes))
 
+let emit_target_dir (emit : Melange_stanzas.Emit.t) ~dir =
+  Path.Build.relative dir emit.target
+
 let setup_emit_js_rules ~dir_contents ~dir ~scope ~sctx mel =
   let open Memo.O in
   let* compile_info = compile_info ~scope mel in
-  let target_dir =
-    Path.Build.relative (Dir_contents.dir dir_contents) mel.target
-  in
+  let target_dir = emit_target_dir ~dir:(Dir_contents.dir dir_contents) mel in
   let mode =
     match mel.promote with
     | None -> Rule.Mode.Standard

--- a/src/dune_rules/melange/melange_rules.mli
+++ b/src/dune_rules/melange/melange_rules.mli
@@ -1,5 +1,7 @@
 open Import
 
+val emit_target_dir : Melange_stanzas.Emit.t -> dir:Path.Build.t -> Path.Build.t
+
 val setup_emit_cmj_rules :
      sctx:Super_context.t
   -> dir:Path.Build.t

--- a/test/blackbox-tests/test-cases/melange/copy-files-include-subdirs.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-include-subdirs.t
@@ -48,7 +48,6 @@ Now add include_subdirs unqualified to show issue
 
   $ dune build @melange
   $ dune build $asset
-  Error: Don't know how to build _build/default/src/app/file.txt
-  [1]
-  $ node $src 2>&1 | grep "no such file or directory"
-  Error: ENOENT: no such file or directory, open '$TESTCASE_ROOT/_build/default/src/app/src/../file.txt'
+  $ node $src
+  hello from file
+  

--- a/test/blackbox-tests/test-cases/melange/copy-files-into-emit-target-folder.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-into-emit-target-folder.t
@@ -37,20 +37,14 @@ Now try copying a file
   >    (files %{project_root}/public/img.png))))
   > EOF
 
-Build fails
+It works:
 
   $ dune build @melange
-  Error: No rule found for src/output/src/.output.mobjs/melange.js
-  -> required by alias src/melange
-  [1]
 
-Adding a module doesn't help
+We add a module and it stays working:
 
   $ cat > src/a.ml <<EOF
   > let () = Js.log "foo"
   > EOF
 
   $ dune build @melange
-  Error: No rule found for src/output/src/a.js
-  -> required by alias src/melange
-  [1]


### PR DESCRIPTION
Correctly load emit rules. Given an emit stanza in $dir with $output:

* We generate the .js rules in $dir/$output
* Anything under $dir/$output, we will load the rules and also redirect
  upwards until we encounter $dir/output

<!-- ps-id: cca5f572-7c43-436c-9b2d-659c475a014b -->