### PR TITLE
refactor(rules): workspace improvements

### DIFF
--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -59,6 +59,8 @@ module Context : sig
   val env : t -> Dune_env.Stanza.t
 
   val host_context : t -> Context_name.t option
+
+  val to_dyn : t -> Dyn.t
 end
 
 (** Representation of a workspace. The list of context is topologically sorted,


### PR DESCRIPTION
* Improve the [to_dyn] functions
* Rename [t] to [decode] as in the rest of the code base

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 49d55633-8cff-4857-a8c4-714bc1f5c70d -->