### PR TITLE
fix(rules): cross compilation bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix cross compilation configuration when a context with targets is itself a
+  host of another context (#6958, fixes #6843, @rgrinberg)
+
 - Fix parsing of the `<=` operator in *blang* expressions of `dune` files.
   Previously, the operator would be interpreted as `,`. (#6928, @tatchi)
 

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/github6843.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/github6843.t
@@ -21,9 +21,9 @@ Cross compilation setup that causes dune to crash
   $ export OCAMLFIND_CONF=$PWD/etc/findlib.conf
   $ mkdir -p etc/findlib.conf.d
   $ touch etc/findlib.conf etc/findlib.conf.d/esperanto.conf
-  $ dune build -x esperanto ./cat.exe 2>&1 | awk '/I must not/,/Only I will remain/'
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-  little-death that brings total obliteration.  I will fully express my cases. 
-  Execution will pass over me and through me.  And when it has gone past, I
-  will unwind the stack along its path.  Where the cases are handled there will
-  be nothing.  Only I will remain.
+  $ dune build -x esperanto ./cat.exe
+  File "dune", line 1, characters 18-21:
+  1 | (executable (name cat))
+                        ^^^
+  Error: Module "Cat" doesn't exist.
+  [1]


### PR DESCRIPTION
It's possible for a context with targets to be a cross compilation
context for other contexts. Previously, we'd assume that wasn't the
case.

fixes #6843

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e7ed7d4e-717a-402a-8cc2-00b9392d7fbb -->