### PR TITLE
tests: Show bug with configurator.v2 not being available

### DIFF
--- a/test/blackbox-tests/test-cases/github6936.t/config/discover.ml
+++ b/test/blackbox-tests/test-cases/github6936.t/config/discover.ml
@@ -1,0 +1,7 @@
+module C = Configurator.V1
+
+let () =
+  C.main ~name:"taglib-pkg-config" (fun c ->
+    C.C_define.gen_header_file c ~fname:"config.h" [];
+    C.Flags.write_sexp "c_flags.sexp" []
+  )

--- a/test/blackbox-tests/test-cases/github6936.t/config/dune
+++ b/test/blackbox-tests/test-cases/github6936.t/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune.configurator))

--- a/test/blackbox-tests/test-cases/github6936.t/dune
+++ b/test/blackbox-tests/test-cases/github6936.t/dune
@@ -1,0 +1,15 @@
+(library
+ (public_name taglib)
+ (foreign_stubs
+  (language cxx)
+  (names taglib_stubs)
+  (extra_deps config.h)
+  (flags
+   :standard (:include c_flags.sexp))))
+
+(rule
+ (targets
+   config.h
+   c_flags.sexp)
+ (action
+  (run ./config/discover.exe)))

--- a/test/blackbox-tests/test-cases/github6936.t/run.t
+++ b/test/blackbox-tests/test-cases/github6936.t/run.t
@@ -1,0 +1,11 @@
+Reproduction of https://github.com/savonet/ocaml-taglib/issues/10
+
+  $ cat > dune-project <<EOF
+  > (lang dune 2.8)
+  > (use_standard_c_and_cxx_flags true)
+  > EOF
+
+  $ touch taglib.opam
+
+Build fine
+  $ dune build -p taglib -j 1

--- a/test/blackbox-tests/test-cases/github6936.t/taglib_stubs.cc
+++ b/test/blackbox-tests/test-cases/github6936.t/taglib_stubs.cc
@@ -1,0 +1,4 @@
+#include "config.h"
+
+void foo(void)
+{}


### PR DESCRIPTION
It cause failure on 2.9 but not on main.

Signed-off-by: Élie BRAMI <cadeaudeelie@gmail.com>