### PR TITLE
chore(engine): Add [Rules.to_dyn]

### DIFF
--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -28,7 +28,7 @@ module Dir_rules = struct
 
   type t = data Id.Map.t
 
-  let data_to_dyn = function
+  let dyn_of_data = function
     | Rule rule ->
       Dyn.Variant
         ( "Rule"
@@ -37,7 +37,7 @@ module Dir_rules = struct
       Dyn.Variant
         ("Alias", [ Record [ ("name", Alias.Name.to_dyn alias.name) ] ])
 
-  let to_dyn t = Dyn.(list data_to_dyn) (Id.Map.values t)
+  let to_dyn t = Dyn.(list dyn_of_data) (Id.Map.values t)
 
   type ready =
     { rules : Rule.t list
@@ -89,6 +89,8 @@ module Dir_rules = struct
 
     val create : maybe_empty -> t option
 
+    val to_dyn : t -> Dyn.t
+
     val union : t -> t -> t
 
     val singleton : data -> t
@@ -98,6 +100,8 @@ module Dir_rules = struct
     type maybe_empty = t
 
     type nonrec t = t
+
+    let to_dyn = to_dyn
 
     let create t = if is_empty t then None else Some t
 
@@ -123,6 +127,8 @@ module T = struct
 end
 
 include T
+
+let to_dyn = Path.Build.Map.to_dyn Dir_rules.Nonempty.to_dyn
 
 let singleton_rule (rule : Rule.t) =
   let dir = rule.dir in

--- a/src/dune_engine/rules.mli
+++ b/src/dune_engine/rules.mli
@@ -94,6 +94,8 @@ val implicit_output : t Memo.Implicit_output.t
 
 val empty : t
 
+val to_dyn : t -> Dyn.t
+
 val union : t -> t -> t
 
 val of_dir_rules : dir:Path.Build.t -> Dir_rules.t -> t


### PR DESCRIPTION
useful for printf debugging

also rename [data_to_dyn] to [dyn_of_data] to match our convention
elsewhere.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7991a8d7-ff09-4d5f-a430-11c77d058ee2 -->