### PR TITLE
Add support for eager watch mode for `dune exec`

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -34,7 +34,8 @@
   csexp
   csexp_rpc
   dune_rpc_impl
-  dune_rpc_private)
+  dune_rpc_private
+  spawn)
  (bootstrap_info bootstrap-info))
 
 ; Installing the dune binary depends on the kind of build:

--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -32,6 +32,218 @@ let man =
 
 let info = Cmd.info "exec" ~doc ~man
 
+module Command_to_exec = struct
+  (* A command to execute, which knows how to (re)build the program and then
+     run it with some arguments in an enivorment *)
+
+  type t =
+    { get_path_and_build_if_necessary :
+        unit -> (Path.t, [ `Already_reported ]) result Fiber.t
+    ; args : string list
+    ; env : Env.t
+    }
+
+  (* Helper function to spawn a new process running a command in an
+     environment, returning the new process' pid *)
+  let spawn_process path ~args ~env =
+    let path = Path.to_string path in
+    let env = Env.to_unix env |> Spawn.Env.of_list in
+    let argv = path :: args in
+    let pid = Spawn.spawn ~prog:path ~env ~argv () in
+    Pid.of_int pid
+
+  (* Run the command, first (re)building the program which the command is
+     invoking *)
+  let build_and_run_in_child_process
+      { get_path_and_build_if_necessary; args; env } =
+    get_path_and_build_if_necessary ()
+    |> Fiber.map ~f:(Result.map ~f:(spawn_process ~args ~env))
+end
+
+module Watch = struct
+  (* When running `dune exec` in watch mode, this will keep track of the pid of
+     the process created to run the program in the previous iteration so that
+     it can be killed (for long running programs, e.g. servers) and restarted
+     when its source is changed. *)
+
+  type state = { currently_running_pid : Pid.t option ref }
+
+  let init_state () = { currently_running_pid = ref None }
+
+  let kill_process pid =
+    let pid_int = Pid.to_int pid in
+    (* TODO This logic should exist in one place. Currently it's here and in
+       the scheduler *)
+    let signal = if Sys.win32 then Sys.sigkill else Sys.sigterm in
+    (* FIXME Since we're reaping in a different thread, this can technically
+       cause pid reuse *)
+    Unix.kill pid_int signal;
+    let do_wait () =
+      Scheduler.wait_for_process ~timeout:1. pid
+      |> Fiber.map ~f:(fun (_ : Proc.Process_info.t) -> ())
+    in
+    let on_error (e : Exn_with_backtrace.t) =
+      (* Ignore [Build_cancelled] exception we expect the build to be cancelled
+         if the source is changed during compilation. *)
+      match e.exn with
+      | Memo.Non_reproducible Scheduler.Run.Build_cancelled -> Fiber.return ()
+      | _ -> Exn_with_backtrace.reraise e
+    in
+    Fiber.map_reduce_errors (module Monoid.Unit) ~on_error do_wait
+    |> Fiber.map ~f:(function Ok () | Error () -> ())
+
+  let kill_currently_running_process { currently_running_pid } =
+    match !currently_running_pid with
+    | None -> Fiber.return ()
+    | Some pid ->
+      currently_running_pid := None;
+      kill_process pid
+
+  (* Kills the currently running process, then runs the given command after
+     (re)building the program which it will invoke *)
+  let run state ~command_to_exec =
+    let open Fiber.O in
+    let* () = Fiber.return () in
+    let* () = kill_currently_running_process state in
+    Command_to_exec.build_and_run_in_child_process command_to_exec
+    >>| Result.map ~f:(fun pid -> state.currently_running_pid := Some pid)
+
+  let loop ~command_to_exec =
+    let state = init_state () in
+    Scheduler.Run.poll (run state ~command_to_exec)
+end
+
+let build_prog ~no_rebuild ~prog p =
+  if no_rebuild then
+    if Path.exists p then Memo.return p
+    else
+      User_error.raise
+        [ Pp.textf
+            "Program %S isn't built yet. You need to build it first or remove \
+             the --no-build option."
+            prog
+        ]
+  else
+    let open Memo.O in
+    let+ () = Build_system.build_file p in
+    p
+
+let not_found ~dir ~prog =
+  let open Memo.O in
+  let+ hints =
+    (* Good candidates for the "./x.exe" instead of "x.exe" error are
+        executables present in the current directory. Note: we do not
+        check directory targets here; even if they do indeed include a
+        matching executable, they would be located in a subdirectory of
+        [dir], so it's unclear if that's what the user wanted. *)
+    let+ candidates =
+      Build_system.files_of ~dir:(Path.build dir)
+      >>| Path.Set.to_list
+      >>| List.filter ~f:(fun p -> Path.extension p = ".exe")
+      >>| List.map ~f:(fun p -> "./" ^ Path.basename p)
+    in
+    User_message.did_you_mean prog ~candidates
+  in
+  User_error.raise ~hints [ Pp.textf "Program %S not found!" prog ]
+
+let get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog =
+  let open Memo.O in
+  match Filename.analyze_program_name prog with
+  | In_path -> (
+    Super_context.resolve_program sctx ~dir ~loc:None prog >>= function
+    | Error (_ : Action.Prog.Not_found.t) -> not_found ~dir ~prog
+    | Ok p -> build_prog ~no_rebuild ~prog p)
+  | Relative_to_current_dir -> (
+    let path = Path.relative_to_source_in_build_or_external ~dir prog in
+    (Build_system.file_exists path >>= function
+     | true -> Memo.return (Some path)
+     | false -> (
+       if not (Filename.check_suffix prog ".exe") then Memo.return None
+       else
+         let path = Path.extend_basename path ~suffix:".exe" in
+         Build_system.file_exists path >>| function
+         | true -> Some path
+         | false -> None))
+    >>= function
+    | Some path -> build_prog ~no_rebuild ~prog path
+    | None -> not_found ~dir ~prog)
+  | Absolute -> (
+    match
+      let prog = Path.of_string prog in
+      if Path.exists prog then Some prog
+      else if not Sys.win32 then None
+      else
+        let prog = Path.extend_basename prog ~suffix:Bin.exe in
+        Option.some_if (Path.exists prog) prog
+    with
+    | Some prog -> Memo.return prog
+    | None -> not_found ~dir ~prog)
+
+module Exec_context = struct
+  type t =
+    { common : Common.t
+    ; config : Dune_config.t
+    ; args : string list
+    ; env : Env.t Fiber.t
+    ; get_path_and_build_if_necessary : (unit -> Path.t Memo.t) Fiber.t
+    }
+
+  let init ~common ~context ~no_rebuild ~prog ~args =
+    (* The initialization of some fields is deferred until the fiber scheduler
+       has been started. *)
+    let config = Common.init common in
+    let sctx =
+      let open Fiber.O in
+      let* setup = Import.Main.setup () in
+      let+ setup = Memo.run setup in
+      Import.Main.find_scontext_exn setup ~name:context
+    in
+    let dir =
+      Fiber.map sctx ~f:(fun sctx ->
+          let context = Dune_rules.Super_context.context sctx in
+          Path.Build.relative context.build_dir (Common.prefix_target common ""))
+    in
+    let env = Fiber.map sctx ~f:Super_context.context_env in
+    let get_path_and_build_if_necessary =
+      let open Fiber.O in
+      let* sctx = sctx in
+      let+ dir = dir in
+      fun () -> get_path_and_build_if_necessary sctx ~no_rebuild ~dir ~prog
+    in
+    { common; config; env; args; get_path_and_build_if_necessary }
+
+  let run_once { common; config; env; args; get_path_and_build_if_necessary; _ }
+      =
+    Scheduler.go ~common ~config @@ fun () ->
+    let open Fiber.O in
+    let* get_path_and_build_if_necessary = get_path_and_build_if_necessary in
+    let* env = env in
+    let+ path = Build_system.run_exn get_path_and_build_if_necessary in
+    let prog = Path.to_string path in
+    let argv = prog :: args in
+    restore_cwd_and_execve common prog argv env
+
+  let run_eager_watch
+      { common; config; env; args; get_path_and_build_if_necessary; _ } =
+    Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config
+    @@ fun () ->
+    let open Fiber.O in
+    let* get_path_and_build_if_necessary = get_path_and_build_if_necessary in
+    let* env = env in
+    let command_to_exec =
+      { Command_to_exec.get_path_and_build_if_necessary =
+          (fun () ->
+            (* TODO we should release the dune lock. But we aren't doing it
+               because we don't unload the database files we've marshalled.
+            *)
+            Build_system.run get_path_and_build_if_necessary)
+      ; args
+      ; env
+      }
+    in
+    Watch.loop ~command_to_exec
+end
+
 let term =
   let+ common = Common.term
   and+ context =
@@ -43,93 +255,16 @@ let term =
       value & flag
       & info [ "no-build" ] ~doc:"don't rebuild target before executing")
   and+ args = Arg.(value & pos_right 0 string [] (Arg.info [] ~docv:"ARGS")) in
-  let config = Common.init common in
-  let prog, argv, env =
-    Scheduler.go ~common ~config (fun () ->
-        let open Fiber.O in
-        let* setup = Import.Main.setup () in
-        let* setup = Memo.run setup in
-        let sctx = Import.Main.find_scontext_exn setup ~name:context in
-        let context = Dune_rules.Super_context.context sctx in
-        let dir =
-          Path.Build.relative context.build_dir (Common.prefix_target common "")
-        in
-        let build_prog p =
-          let open Memo.O in
-          if no_rebuild then
-            if Path.exists p then Memo.return p
-            else
-              User_error.raise
-                [ Pp.textf
-                    "Program %S isn't built yet. You need to build it first or \
-                     remove the --no-build option."
-                    prog
-                ]
-          else
-            let+ () = Build_system.build_file p in
-            p
-        in
-        let not_found () =
-          let open Memo.O in
-          let+ hints =
-            (* Good candidates for the "./x.exe" instead of "x.exe" error are
-               executables present in the current directory. Note: we do not
-               check directory targets here; even if they do indeed include a
-               matching executable, they would be located in a subdirectory of
-               [dir], so it's unclear if that's what the user wanted. *)
-            let+ candidates =
-              Build_system.files_of ~dir:(Path.build dir)
-              >>| Path.Set.to_list
-              >>| List.filter ~f:(fun p -> Path.extension p = ".exe")
-              >>| List.map ~f:(fun p -> "./" ^ Path.basename p)
-            in
-            User_message.did_you_mean prog ~candidates
-          in
-          User_error.raise ~hints [ Pp.textf "Program %S not found!" prog ]
-        in
-        let* prog =
-          let open Memo.O in
-          Build_system.run_exn (fun () ->
-              match Filename.analyze_program_name prog with
-              | In_path -> (
-                Super_context.resolve_program sctx ~dir ~loc:None prog
-                >>= function
-                | Error (_ : Action.Prog.Not_found.t) -> not_found ()
-                | Ok prog -> build_prog prog)
-              | Relative_to_current_dir -> (
-                let path =
-                  Path.relative_to_source_in_build_or_external ~dir prog
-                in
-                (Build_system.file_exists path >>= function
-                 | true -> Memo.return (Some path)
-                 | false -> (
-                   if not (Filename.check_suffix prog ".exe") then
-                     Memo.return None
-                   else
-                     let path = Path.extend_basename path ~suffix:".exe" in
-                     Build_system.file_exists path >>= function
-                     | true -> Memo.return (Some path)
-                     | false -> Memo.return None))
-                >>= function
-                | Some path -> build_prog path
-                | None -> not_found ())
-              | Absolute -> (
-                match
-                  let prog = Path.of_string prog in
-                  if Path.exists prog then Some prog
-                  else if not Sys.win32 then None
-                  else
-                    let prog = Path.extend_basename prog ~suffix:Bin.exe in
-                    Option.some_if (Path.exists prog) prog
-                with
-                | Some prog -> Memo.return prog
-                | None -> not_found ()))
-        in
-        let prog = Path.to_string prog in
-        let argv = prog :: args in
-        let env = Super_context.context_env sctx in
-        Fiber.return (prog, argv, env))
+  (* TODO we should make sure to finalize the current backend before exiting dune.
+     For watch mode, we should finalize the backend and then restart it in between
+     runs. *)
+  let exec_context =
+    Exec_context.init ~common ~context ~no_rebuild ~prog ~args
   in
-  restore_cwd_and_execve common prog argv env
+  match Common.watch common with
+  | Yes Passive ->
+    User_error.raise [ Pp.textf "passive watch mode is unsupported by exec" ]
+  | Yes Eager -> Exec_context.run_eager_watch exec_context
+  | No -> Exec_context.run_once exec_context
 
 let command = Cmd.v info term

--- a/test/blackbox-tests/test-cases/exec-watch/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/dune
@@ -1,0 +1,13 @@
+(cram
+ (enabled_if
+  ; On macos it looks like dune has a chance to miss filesystem events if they
+  ; occur too close together in time. Tests of `dune exec -w` run a program with a
+  ; visible side effect (touching a file), and wait for the side effect before
+  ; modifying the program to trigger a rebuild/rerun. On macos, these changes can
+  ; sometimes go undetected. Adding a delay (e.g. `sleep 1`) before modifying the
+  ; program seems to guarantee a rebuild will be triggered, but that is too
+  ; unreliable to depend on in a test so these tests are disabled on macos.
+  (<> "macosx" %{ocaml-config:system})))
+
+(cram
+ (deps wait-for-file.sh))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/dune
@@ -1,0 +1,3 @@
+(executable
+ (public_name foo)
+ (libraries unix))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/dune-project
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.6)
+(package (name foo))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/run.t
@@ -1,0 +1,51 @@
+Test exec --watch with a program that terminates immediately.
+
+File created by the program being exec'd. In between each experiment we'll wait
+until the file exists so that dune has enough time to build and run the program
+between each change to its code.
+  $ export DONE_FLAG=_build/done_flag
+
+  $ cat >foo.ml <<EOF
+  > let () = print_endline "foo"; Touch.touch "$DONE_FLAG"
+  > EOF
+
+  $ dune exec --watch ./foo.exe &
+  Success, waiting for filesystem changes...
+  foo
+  Success, waiting for filesystem changes...
+  bar
+  File "foo.ml", line 1, characters 23-24:
+  1 | let () = print_endline "baz
+                             ^
+  Error: String literal not terminated
+  Had errors, waiting for filesystem changes...
+  Success, waiting for filesystem changes...
+  baz
+  $ PID=$!
+
+Wait for the $DONE_FLAG file to exist, then delete the file. This file is
+created by the program being exec'd, so when it exists we know that it's safe to
+change the code and proceed with the test.
+  $ ../wait-for-file.sh $DONE_FLAG
+
+  $ cat >foo.ml <<EOF
+  > let () = print_endline "bar"; Touch.touch "$DONE_FLAG"
+  > EOF
+
+  $ ../wait-for-file.sh $DONE_FLAG
+
+  $ cat >foo.ml <<EOF
+  > let () = print_endline "baz
+  > EOF
+
+Wait until the error shows up in the log
+  $ until grep 'print_endline "baz' _build/log > /dev/null; do sleep 0.1; done
+
+  $ cat >foo.ml <<EOF
+  > let () = print_endline "baz"; Touch.touch "$DONE_FLAG"
+  > EOF
+
+  $ ../wait-for-file.sh $DONE_FLAG
+
+Prevent the test from leaking the dune process.
+  $ kill $PID

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/touch.ml
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-basic.t/touch.ml
@@ -1,0 +1,3 @@
+let touch path =
+  let fd = Unix.openfile path [ Unix.O_CREAT ] 777 in
+  Unix.close fd

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/dune
@@ -1,0 +1,3 @@
+(executable
+ (public_name foo)
+ (libraries unix))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/dune-project
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.6)
+(package (name foo))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/foo.ml
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/foo.ml
@@ -1,0 +1,9 @@
+let touch path =
+  let fd = Unix.openfile path [ Unix.O_CREAT ] 777 in
+  Unix.close fd
+
+let () =
+  let _ = Unix.sigprocmask Unix.SIG_BLOCK [ Sys.sigterm ] in
+  print_endline "1: before";
+  touch "_build/done_flag";
+  Unix.sleep 1000

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-ignore-sigterm.t/run.t
@@ -1,0 +1,17 @@
+Test exec --watch with a program that ignores sigterm.
+
+  $ dune exec --watch ./foo.exe &
+  Success, waiting for filesystem changes...
+  1: before
+  Success, waiting for filesystem changes...
+  2: before
+  $ PID=$!
+
+  $ ../wait-for-file.sh _build/done_flag
+
+  $ sed -i -e 's/1: before/2: before/' foo.ml
+
+  $ ../wait-for-file.sh _build/done_flag
+
+Prevent the test from leaking the dune process.
+  $ kill $PID

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-no-passive.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-no-passive.t
@@ -1,0 +1,19 @@
+Trying to run exec in passive watch mode produces and error.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.6)
+  > (package (name foo))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (public_name foo))
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > let () = print_endline "foo"
+  > EOF
+
+  $ dune exec --passive-watch-mode ./foo.exe
+  Error: passive watch mode is unsupported by exec
+  [1]

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/dune
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/dune
@@ -1,0 +1,3 @@
+(executable
+ (public_name foo)
+ (libraries unix))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/dune-project
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.6)
+(package (name foo))

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/run.t
@@ -1,0 +1,51 @@
+Test exec --watch with a program that doesn't terminate immediately.
+
+File created by the program being exec'd. In between each experiment we'll wait
+until the file exists so that dune has enough time to build and run the program
+between each change to its code.
+  $ export DONE_FLAG=_build/done_flag
+
+  $ cat >foo.ml <<EOF
+  > let () =
+  >   print_endline "0: before";
+  >   Touch.touch "$DONE_FLAG";
+  >   Unix.sleep 1000;
+  >   print_endline "0: after"
+  > EOF
+
+  $ dune exec --watch ./foo.exe &
+  Success, waiting for filesystem changes...
+  0: before
+  Success, waiting for filesystem changes...
+  1: before
+  1: after
+  Success, waiting for filesystem changes...
+  2: before
+  $ PID=$!
+
+  $ ../wait-for-file.sh $DONE_FLAG
+
+Change the program so that it terminates immediately.
+  $ cat >foo.ml <<EOF
+  > let () =
+  >   print_endline "1: before";
+  >   Unix.sleep 0;
+  >   print_endline "1: after";
+  >   Touch.touch "$DONE_FLAG"
+  > EOF
+
+  $ ../wait-for-file.sh $DONE_FLAG
+
+Change the program so that it no longer terminates immediately.
+  $ cat >foo.ml <<EOF
+  > let () =
+  >   print_endline "2: before";
+  >   Touch.touch "$DONE_FLAG";
+  >   Unix.sleep 1000;
+  >   print_endline "2: after"
+  > EOF
+
+  $ ../wait-for-file.sh $DONE_FLAG
+
+Prevent the test from leaking the dune process.
+  $ kill $PID

--- a/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/touch.ml
+++ b/test/blackbox-tests/test-cases/exec-watch/exec-watch-server.t/touch.ml
@@ -1,0 +1,3 @@
+let touch path =
+  let fd = Unix.openfile path [ Unix.O_CREAT ] 777 in
+  Unix.close fd

--- a/test/blackbox-tests/test-cases/exec-watch/wait-for-file.sh
+++ b/test/blackbox-tests/test-cases/exec-watch/wait-for-file.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Wait until a file exists, then delete the file and exit
+#
+
+set -u
+FILE=$1
+until test -e $FILE
+do
+    sleep 0.1
+done
+rm $FILE


### PR DESCRIPTION
This is the second attempt at adding this feature. The problem with the first attempt was that replacing the call to `Scheduler.go` with `Scheduler.go_with_rpc_server_and_console_status_reporting` caused occasional non-deterministic seg faults on macos. There's some info about the problem on the PR which reverts the previous attempt at adding this feature: https://github.com/ocaml/dune/pull/6867. At the time of writing we don't know the cause of this problem.

The difference this time around is that we maintain the call to `Scheduler.go` when running `dune exec` not in watch mode, and only invoke `Scheduler.go_with_rpc_server_and_console_status_reporting` when running in watch mode. There is some additional refactoring done to make this split more ergonomic. We may see seg faults on macos when running exec in watch mode but at least we won't introduce the potential for seg faults into the existing use case of running exec not in watch mode (assuming of course that there is a causal link between `go_with_rpc_server_and_console_status_reporting` and the seg fault on macos, which is not necessarily the case).

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>