### PR TITLE
refactor(engine): remove status line from display

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -128,7 +128,7 @@ let () =
   Path.Build.set_build_dir (Path.Outside_build_dir.of_string "_build");
   let module Scheduler = Dune_engine.Scheduler in
   let config =
-    Dune_engine.Clflags.display := Dune_engine.Display.quiet;
+    Dune_engine.Clflags.display := Dune_engine.Display.Quiet;
     { Scheduler.Config.concurrency = 10
     ; stats = None
     ; insignificant_changes = `React

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -5,7 +5,7 @@ open Dune_engine
 module Caml = Stdlib
 
 let config =
-  Dune_engine.Clflags.display := Dune_engine.Display.short_no_status;
+  Dune_engine.Clflags.display := Short;
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -288,7 +288,7 @@ module Options_implied_by_dash_p = struct
 end
 
 let display_term =
-  let module Display = Dune_engine.Display in
+  let module Display = Dune_config.Display in
   one_of
     (let+ verbose =
        Arg.(

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -70,7 +70,7 @@ val debug_backtraces : bool Cmdliner.Term.t
 
 val config_from_config_file : Dune_config.Partial.t Cmdliner.Term.t
 
-val display_term : Dune_engine.Display.t option Cmdliner.Term.t
+val display_term : Dune_config.Display.t option Cmdliner.Term.t
 
 val context_arg : doc:string -> Dune_engine.Context_name.t Cmdliner.Term.t
 

--- a/src/dune_config/display.ml
+++ b/src/dune_config/display.ml
@@ -1,0 +1,37 @@
+module Display = Dune_engine.Display
+
+type t =
+  { status_line : bool
+  ; verbosity : Display.t
+  }
+
+let progress = { status_line = true; verbosity = Quiet }
+
+let verbose = { status_line = true; verbosity = Verbose }
+
+let short = { status_line = true; verbosity = Short }
+
+let quiet = { status_line = false; verbosity = Quiet }
+
+let short_no_status = { status_line = false; verbosity = Short }
+
+(* Even though [status_line] is true by default in most of these, the status
+    line is actually not shown if the output is redirected to a file or a
+    pipe. *)
+let all =
+  [ ("progress", progress)
+  ; ("verbose", verbose)
+  ; ("short", short)
+  ; ("quiet", quiet)
+  ]
+
+let to_dyn { status_line; verbosity } : Dyn.t =
+  Record
+    [ ("status_line", Dyn.Bool status_line)
+    ; ("verbosity", Display.to_dyn verbosity)
+    ]
+
+let console_backend t =
+  match t.status_line with
+  | false -> Dune_console.Backend.dumb
+  | true -> Dune_console.Backend.progress_threaded ()

--- a/src/dune_config/display.mli
+++ b/src/dune_config/display.mli
@@ -1,0 +1,32 @@
+(** Type of display modes.
+
+    - [status_line] indictates if a status line is shown.
+    - [verbosity] indicates how verbose the display will be. *)
+type t =
+  { status_line : bool
+  ; verbosity : Dune_engine.Display.t
+  }
+
+(** All the supported display modes for setting from the command line. *)
+val all : (string * t) list
+
+(** Shows a progress bar together with any errors. *)
+val progress : t
+
+(** Shows a progress bar with a verbose output showng all commands. &*)
+val verbose : t
+
+(** Shows a progress bar with a single line output for all the commands run. *)
+val short : t
+
+(** Shows only errors without a progress bar. *)
+val quiet : t
+
+(** Shows a single line output for commands run without a progress bar. Isn't
+    exposed to the user, used internally for testing. *)
+val short_no_status : t
+
+val to_dyn : t -> Dyn.t
+
+(** The console backend corresponding to the selected display mode *)
+val console_backend : t -> Dune_console.Backend.t

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -1,6 +1,6 @@
 open Stdune
 open Dune_lang.Decoder
-module Display = Dune_engine.Display
+module Display = Display
 module Scheduler = Dune_engine.Scheduler
 module Sandbox_mode = Dune_engine.Sandbox_mode
 module Console = Dune_console
@@ -442,5 +442,5 @@ let for_scheduler (t : t) stats ~insignificant_changes ~signal_watcher =
       Log.info [ Pp.textf "Auto-detected concurrency: %d" n ];
       n
   in
-  Dune_engine.Clflags.display := t.display;
+  Dune_engine.Clflags.display := t.display.verbosity;
   { Scheduler.Config.concurrency; stats; insignificant_changes; signal_watcher }

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -2,6 +2,8 @@
 
 open Stdune
 
+module Display : module type of Display
+
 module Concurrency : sig
   type t =
     | Fixed of int
@@ -59,7 +61,7 @@ module type S = sig
   type 'a field
 
   type t =
-    { display : Dune_engine.Display.t field
+    { display : Display.t field
     ; concurrency : Concurrency.t field
     ; terminal_persistence : Terminal_persistence.t field
     ; sandboxing_preference : Sandboxing_preference.t field

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -47,4 +47,4 @@ type on_missing_dune_project_file =
 
 let on_missing_dune_project_file = ref Warn
 
-let display = ref Display.quiet
+let display = ref Display.Quiet

--- a/src/dune_engine/display.ml
+++ b/src/dune_engine/display.ml
@@ -1,47 +1,9 @@
-open Import
-
-type verbosity =
+type t =
   | Quiet
   | Short
   | Verbose
 
-type t =
-  { status_line : bool
-  ; verbosity : verbosity
-  }
-
-let progress = { status_line = true; verbosity = Quiet }
-
-let verbose = { status_line = true; verbosity = Verbose }
-
-let short = { status_line = true; verbosity = Short }
-
-let quiet = { status_line = false; verbosity = Quiet }
-
-let short_no_status = { status_line = false; verbosity = Short }
-
-(* Even though [status_line] is true by default in most of these, the status
-    line is actually not shown if the output is redirected to a file or a
-    pipe. *)
-let all =
-  [ ("progress", progress)
-  ; ("verbose", verbose)
-  ; ("short", short)
-  ; ("quiet", quiet)
-  ]
-
-let verbosity_to_dyn : verbosity -> Dyn.t = function
+let to_dyn : t -> Dyn.t = function
   | Quiet -> Variant ("Quiet", [])
   | Short -> Variant ("Short", [])
   | Verbose -> Variant ("Verbose", [])
-
-let to_dyn { status_line; verbosity } : Dyn.t =
-  Record
-    [ ("status_line", Dyn.Bool status_line)
-    ; ("verbosity", verbosity_to_dyn verbosity)
-    ]
-
-let console_backend t =
-  match t.status_line with
-  | false -> Console.Backend.dumb
-  | true -> Console.Backend.progress_threaded ()

--- a/src/dune_engine/display.mli
+++ b/src/dune_engine/display.mli
@@ -1,39 +1,13 @@
-open Import
+(** Controls the verbosity of process display *)
 
-type verbosity =
-  | Quiet  (** Only display errors *)
-  | Short  (** One line per command *)
-  | Verbose  (** Display all commands fully *)
+(* Not defined in [process.ml] to avoid dependency cycles *)
 
-(** Type of display modes.
+(* TODO eventually separate displaying processes from running them so that
+   these UI concerns live outside the engine *)
 
-    - [status_line] indictates if a status line is shown.
-    - [verbosity] indicates how verbose the display will be. *)
 type t =
-  { status_line : bool
-  ; verbosity : verbosity
-  }
-
-(** All the supported display modes for setting from the command line. *)
-val all : (string * t) list
-
-(** Shows a progress bar together with any errors. *)
-val progress : t
-
-(** Shows a progress bar with a verbose output showng all commands. &*)
-val verbose : t
-
-(** Shows a progress bar with a single line output for all the commands run. *)
-val short : t
-
-(** Shows only errors without a progress bar. *)
-val quiet : t
-
-(** Shows a single line output for commands run without a progress bar. Isn't
-    exposed to the user, used internally for testing. *)
-val short_no_status : t
+  | Quiet
+  | Short
+  | Verbose
 
 val to_dyn : t -> Dyn.t
-
-(** The console backend corresponding to the selected display mode *)
-val console_backend : t -> Console.Backend.t

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -429,7 +429,7 @@ module Handle_exit_status : sig
 
   val non_verbose :
        ('a, error) result
-    -> verbosity:Display.verbosity
+    -> verbosity:Display.t
     -> metadata:metadata
     -> output:string
     -> prog:string
@@ -521,7 +521,7 @@ end = struct
            ++ Pp.char ' ' ++ command_line
         :: pp_output output)
 
-  let non_verbose t ~(verbosity : Display.verbosity) ~metadata ~output ~prog
+  let non_verbose t ~(verbosity : Display.t) ~metadata ~output ~prog
       ~command_line ~dir ~has_unexpected_stdout ~has_unexpected_stderr =
     let output = parse_output output in
     let show_command =
@@ -615,7 +615,7 @@ let run_internal ?dir ~(display : Display.t) ?(stdout_to = Io.stdout)
         command_line ~prog:prog_str ~args ~dir ~stdout_to ~stderr_to ~stdin_from
       in
       let fancy_command_line =
-        match display.verbosity with
+        match display with
         | Verbose ->
           let open Pp.O in
           let cmdline =
@@ -796,14 +796,14 @@ let run_internal ?dir ~(display : Display.t) ?(stdout_to = Io.stdout)
         let output = stdout ^ stderr in
         Log.command ~command_line ~output ~exit_status:process_info.status;
         let res =
-          match (display.verbosity, exit_status', output) with
+          match (display, exit_status', output) with
           | Quiet, Ok n, "" -> n (* Optimisation for the common case *)
           | Verbose, _, _ ->
             Handle_exit_status.verbose exit_status' ~id ~metadata ~dir
               ~command_line:fancy_command_line ~output
           | _ ->
             Handle_exit_status.non_verbose exit_status' ~prog:prog_str ~dir
-              ~command_line ~output ~metadata ~verbosity:display.verbosity
+              ~command_line ~output ~metadata ~verbosity:display
               ~has_unexpected_stdout ~has_unexpected_stderr
         in
         (res, times))

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -79,7 +79,7 @@ let%expect_test "csexp server life cycle" =
         in
         log "sessions finished")
   in
-  Dune_engine.Clflags.display := Dune_engine.Display.quiet;
+  Dune_engine.Clflags.display := Quiet;
   let config =
     { Scheduler.Config.concurrency = 1
     ; stats = None

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -163,7 +163,7 @@ let with_dune_watch ?env f =
   res
 
 let config =
-  Dune_engine.Clflags.display := Dune_engine.Display.quiet;
+  Dune_engine.Clflags.display := Quiet;
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -44,7 +44,7 @@ let try_ ~times ~delay ~f =
 
 let run =
   let cwd = Sys.getcwd () in
-  Dune_engine.Clflags.display := Dune_engine.Display.quiet;
+  Dune_engine.Clflags.display := Quiet;
   let config =
     { Scheduler.Config.concurrency = 1
     ; stats = None

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -4,7 +4,7 @@ open Dune_engine
 
 let go =
   let config =
-    Clflags.display := Display.short_no_status;
+    Clflags.display := Short;
     { Scheduler.Config.concurrency = 1
     ; stats = None
     ; insignificant_changes = `React

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -4,7 +4,7 @@ open Dune_engine
 open Fiber.O
 
 let default =
-  Clflags.display := Display.short_no_status;
+  Clflags.display := Short;
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -3,7 +3,7 @@ open Fiber.O
 module Scheduler = Dune_engine.Scheduler
 
 let config =
-  Dune_engine.Clflags.display := Dune_engine.Display.short_no_status;
+  Dune_engine.Clflags.display := Short;
   { Scheduler.Config.concurrency = 1
   ; stats = None
   ; insignificant_changes = `React

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -110,7 +110,7 @@ let run kind script =
   Path.rm_rf temp_dir;
   Path.mkdir_p temp_dir;
   let vcs = { Vcs.kind; root = temp_dir } in
-  Dune_engine.Clflags.display := Display.short_no_status;
+  Dune_engine.Clflags.display := Short;
   let config =
     { Scheduler.Config.concurrency = 1
     ; stats = None


### PR DESCRIPTION
Whether the display mode contains the status line isn't something that
is ever inspect in the engine. We can safely move it to the
[Dune_config] and leave the [Display] in [Dune_engine] to be the subset
that concerns the process display.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0a061e8a-358f-4a24-aa1f-8fdc6214af49 -->