### PR TITLE
refactor: add module paths to module sources

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -84,7 +84,7 @@ let gen_rules sctx t ~dir ~scope =
   in
   let main_module_name = Module_name.of_string name in
   let module_ =
-    Module.generated ~kind:Impl main_module_name ~src_dir:cinaps_dir
+    Module.generated ~kind:Impl [ main_module_name ] ~src_dir:cinaps_dir
   in
   let cinaps_ml =
     Module.source ~ml_kind:Ml_kind.Impl module_

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -90,7 +90,7 @@ include Sub_system.Register_end_point (struct
     in
     let main_module =
       let name = Module_name.of_string name in
-      Module.generated ~kind:Impl ~src_dir:inline_test_dir name
+      Module.generated ~kind:Impl ~src_dir:inline_test_dir [ name ]
     in
     let open Memo.O in
     let modules = Modules.singleton_exe main_module in

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -20,7 +20,7 @@ let generate_and_compile_module cctx ~precompiled_cmi ~name ~lib ~code ~requires
       let obj_dir = Compilation_context.obj_dir cctx in
       Obj_dir.obj_dir obj_dir
     in
-    Module.generated ?obj_name ~kind:Impl ~src_dir name
+    Module.generated ?obj_name ~kind:Impl ~src_dir [ name ]
   in
   let* () =
     let dir = Compilation_context.dir cctx in

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -395,7 +395,7 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~expander ~mdx_prog =
      field *)
   let obj_dir = Obj_dir.make_exe ~dir ~name in
   let main_module_name = Module_name.of_string name in
-  let module_ = Module.generated ~kind:Impl ~src_dir:dir main_module_name in
+  let module_ = Module.generated ~kind:Impl ~src_dir:dir [ main_module_name ] in
   let modules = Modules.singleton_exe module_ in
   let flags = Ocaml_flags.default ~dune_version ~profile:Release in
   let lib name = Lib_dep.Direct (loc, Lib_name.of_string name) in

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -196,7 +196,7 @@ module Run (P : PARAMS) = struct
     let mock_module : Module.t =
       let source =
         let impl = Module.File.make Dialect.ocaml (Path.build (mock_ml base)) in
-        Module.Source.make ~impl name
+        Module.Source.make ~impl [ name ]
       in
       Module.of_source ~visibility:Public ~kind:Impl source
     in

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -31,7 +31,7 @@ module Source : sig
 
   val name : t -> Module_name.t
 
-  val make : ?impl:File.t -> ?intf:File.t -> Module_name.t -> t
+  val make : ?impl:File.t -> ?intf:File.t -> Module_name.Path.t -> t
 
   val has : t -> ml_kind:Ml_kind.t -> bool
 
@@ -51,12 +51,7 @@ val to_dyn : t -> Dyn.t
 (** When you initially construct a [t] using [of_source], it assumes no wrapping
     (so reports an incorrect [obj_name] if wrapping is used) and you might need
     to fix it later with [with_wrapper]. *)
-val of_source :
-     ?path:Module_name.Path.t
-  -> visibility:Visibility.t
-  -> kind:Kind.t
-  -> Source.t
-  -> t
+val of_source : visibility:Visibility.t -> kind:Kind.t -> Source.t -> t
 
 val name : t -> Module_name.t
 
@@ -144,8 +139,7 @@ val set_src_dir : t -> src_dir:Path.t -> t
     be used to create the rule to generate this file *)
 val generated :
      ?obj_name:Module_name.Unique.t
-  -> ?path:Module_name.Path.t
   -> kind:Kind.t
   -> src_dir:Path.Build.t
-  -> Module_name.t
+  -> Module_name.Path.t
   -> t

--- a/src/dune_rules/module_name.ml
+++ b/src/dune_rules/module_name.ml
@@ -132,6 +132,8 @@ module Path = struct
 
   include T
 
+  let equal x y = compare x y |> Ordering.is_eq
+
   let uncapitalize s = to_string s |> String.uncapitalize
 
   module C = Comparable.Make (T)

--- a/src/dune_rules/module_name.mli
+++ b/src/dune_rules/module_name.mli
@@ -73,6 +73,8 @@ module Path : sig
 
   val compare : t -> t -> Ordering.t
 
+  val equal : t -> t -> bool
+
   val to_dyn : t -> Dyn.t
 
   val to_string : t -> string

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -207,13 +207,12 @@ module Mangle = struct
       | None -> base
       | Some prefix -> prefix :: base
     in
-    let name =
+    let path =
       if has_lib_interface then
-        Module_name.Unique.to_name ~loc:Loc.none obj_name
-      else interface
+        [ Module_name.Unique.to_name ~loc:Loc.none obj_name ]
+      else path @ [ interface ]
     in
-    let path = if has_lib_interface then [ name ] else path @ [ interface ] in
-    Module.generated ~path ~obj_name ~kind ~src_dir name
+    Module.generated path ~obj_name ~kind ~src_dir
 
   let wrap_module t m ~interface =
     let is_lib_interface =

--- a/src/dune_rules/modules_field_evaluator.ml
+++ b/src/dune_rules/modules_field_evaluator.ml
@@ -288,7 +288,7 @@ let eval ~modules:(all_modules : Module.Source.t Module_trie.t) ~stanza_loc
     ~intf_only ~modules ~virtual_modules ~private_modules
     ~existing_virtual_modules ~allow_new_public_modules;
   let all_modules =
-    Module_trie.mapi modules ~f:(fun path (_, m) ->
+    Module_trie.mapi modules ~f:(fun _path (_, m) ->
         let name = [ Module.Source.name m ] in
         let visibility =
           if Module_trie.mem private_modules name then Visibility.Private
@@ -303,10 +303,11 @@ let eval ~modules:(all_modules : Module.Source.t Module_trie.t) ~stanza_loc
             else Impl
           else Intf_only
         in
-        Module.of_source m ~path ~kind ~visibility)
+        Module.of_source m ~kind ~visibility)
   in
   match root_module with
   | None -> all_modules
   | Some (_, name) ->
-    let module_ = Module.generated ~kind:Root ~src_dir name in
-    Module_trie.set all_modules [ name ] module_
+    let path = [ name ] in
+    let module_ = Module.generated ~kind:Root ~src_dir path in
+    Module_trie.set all_modules path module_

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -299,7 +299,7 @@ let build_ppx_driver sctx ~scope ~target ~pps ~pp_names =
   let main_module_name =
     Module_name.of_string_allow_invalid (Loc.none, "_ppx")
   in
-  let module_ = Module.generated ~kind:Impl ~src_dir:dir main_module_name in
+  let module_ = Module.generated ~kind:Impl ~src_dir:dir [ main_module_name ] in
   let ml_source =
     Module.file ~ml_kind:Impl module_
     |> Option.value_exn |> Path.as_in_build_dir_exn

--- a/src/dune_rules/toplevel.ml
+++ b/src/dune_rules/toplevel.ml
@@ -14,7 +14,7 @@ module Source = struct
     let main_module_name =
       Module_name.of_string_allow_invalid (t.loc, t.name)
     in
-    Module.generated ~kind:Impl ~src_dir:t.dir main_module_name
+    Module.generated ~kind:Impl ~src_dir:t.dir [ main_module_name ]
 
   let source_path t =
     Module.file (main_module t) ~ml_kind:Impl

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -57,16 +57,9 @@
    (modules
     (wrapped
      (group
-      (alias
-       (name A)
-       (obj_name a)
-       (path A)
-       (visibility public)
-       (kind alias)
-       (impl))
+      (alias (obj_name a) (path A) (visibility public) (kind alias) (impl))
       (name A)
-      (modules
-       (module (name X) (obj_name a__X) (path X) (visibility public) (impl))))
+      (modules (module (obj_name a__X) (path X) (visibility public) (impl))))
      (wrapped true))))
   (library
    (name a.b.c)
@@ -80,22 +73,10 @@
    (modules
     (wrapped
      (group
-      (alias
-       (name C)
-       (obj_name c)
-       (path C)
-       (visibility public)
-       (kind alias)
-       (impl))
+      (alias (obj_name c) (path C) (visibility public) (kind alias) (impl))
       (name C)
       (modules
-       (module
-        (name Y)
-        (obj_name c__Y)
-        (path Y)
-        (visibility private)
-        (impl)
-        (intf))))
+       (module (obj_name c__Y) (path Y) (visibility private) (impl) (intf))))
      (wrapped true))))
   (library
    (name a.byte_only)
@@ -107,16 +88,9 @@
    (modules
     (wrapped
      (group
-      (alias
-       (name D)
-       (obj_name d)
-       (path D)
-       (visibility public)
-       (kind alias)
-       (impl))
+      (alias (obj_name d) (path D) (visibility public) (kind alias) (impl))
       (name D)
-      (modules
-       (module (name Z) (obj_name d__Z) (path Z) (visibility public) (impl))))
+      (modules (module (obj_name d__Z) (path Z) (visibility public) (impl))))
      (wrapped true))))
 
 Build with "--store-orig-source-dir" profile

--- a/test/blackbox-tests/test-cases/github1549.t/run.t
+++ b/test/blackbox-tests/test-cases/github1549.t/run.t
@@ -33,7 +33,6 @@ Reproduction case for #1549: too many parentheses in installed .dune files
     (wrapped
      (group
       (alias
-       (name Simple_tests)
        (obj_name simple_tests)
        (path Simple_tests)
        (visibility public)

--- a/test/blackbox-tests/test-cases/melange/basic-install.t
+++ b/test/blackbox-tests/test-cases/melange/basic-install.t
@@ -38,8 +38,7 @@ Test that we can install melange mode libraries
    (kind normal)
    (main_module_name Foo)
    (modes melange)
-   (modules
-    (singleton (name Foo) (obj_name foo) (path Foo) (visibility public) (impl))))
+   (modules (singleton (obj_name foo) (path Foo) (visibility public) (impl))))
 
   $ dune install --prefix prefix
   Installing prefix/lib/foo/META

--- a/test/blackbox-tests/test-cases/re-exported-deps/transitive.t/run.t
+++ b/test/blackbox-tests/test-cases/re-exported-deps/transitive.t/run.t
@@ -43,8 +43,7 @@ transitive deps expressed in the dune-package
    (requires pkg.ccc (re_export pkg.bbb))
    (main_module_name Aaa)
    (modes byte native)
-   (modules
-    (singleton (name Aaa) (obj_name aaa) (path Aaa) (visibility public) (impl))))
+   (modules (singleton (obj_name aaa) (path Aaa) (visibility public) (impl))))
   (library
    (name pkg.bbb)
    (kind normal)
@@ -54,8 +53,7 @@ transitive deps expressed in the dune-package
    (requires (re_export pkg.ccc))
    (main_module_name Bbb)
    (modes byte native)
-   (modules
-    (singleton (name Bbb) (obj_name bbb) (path Bbb) (visibility public) (impl))))
+   (modules (singleton (obj_name bbb) (path Bbb) (visibility public) (impl))))
   (library
    (name pkg.ccc)
    (kind normal)
@@ -64,5 +62,4 @@ transitive deps expressed in the dune-package
    (native_archives ccc/ccc$ext_lib)
    (main_module_name Ccc)
    (modes byte native)
-   (modules
-    (singleton (name Ccc) (obj_name ccc) (path Ccc) (visibility public) (impl))))
+   (modules (singleton (obj_name ccc) (path Ccc) (visibility public) (impl))))

--- a/test/blackbox-tests/test-cases/virtual-libraries/dune-package-info.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/dune-package-info.t/run.t
@@ -45,7 +45,6 @@ Include variants and implementation information in dune-package
     (wrapped
      (group
       (alias
-       (name Vlib__impl__)
        (obj_name vlib__impl__)
        (path Vlib__impl__)
        (visibility public)
@@ -54,7 +53,6 @@ Include variants and implementation information in dune-package
       (name Vlib)
       (modules
        (module
-        (name Vmod)
         (obj_name vlib__Vmod)
         (path Vmod)
         (visibility public)
@@ -71,7 +69,6 @@ Include variants and implementation information in dune-package
     (wrapped
      (group
       (alias
-       (name Vlib)
        (obj_name vlib)
        (path Vlib)
        (visibility public)
@@ -80,7 +77,6 @@ Include variants and implementation information in dune-package
       (name Vlib)
       (modules
        (module
-        (name Vmod)
         (obj_name vlib__Vmod)
         (path Vmod)
         (visibility public)

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/dune-package.t/run.t
@@ -43,17 +43,10 @@ Check that default implementation data is installed in the dune package file.
    (modules
     (wrapped
      (group
-      (alias
-       (name A)
-       (obj_name a)
-       (path A)
-       (visibility public)
-       (kind alias)
-       (impl))
+      (alias (obj_name a) (path A) (visibility public) (kind alias) (impl))
       (name A)
       (modules
        (module
-        (name X)
         (obj_name a__X)
         (path X)
         (visibility public)
@@ -78,7 +71,6 @@ Check that default implementation data is installed in the dune package file.
     (wrapped
      (group
       (alias
-       (name A__a_default__)
        (obj_name a__a_default__)
        (path A__a_default__)
        (visibility public)
@@ -87,7 +79,6 @@ Check that default implementation data is installed in the dune package file.
       (name A)
       (modules
        (module
-        (name X)
         (obj_name a__X)
         (path X)
         (visibility public)


### PR DESCRIPTION
The module paths are based on the source path of the module itself.
Therefore, we should compute them as early as possible.

This will allow for doing various error checks that depend on the module
path without constructing complete [Modules.t] values

<!-- ps-id: 7c938225-164a-4f07-a9c5-1f112b2a5724 -->