### PR TITLE
test(rules): include_subdirs and install

### DIFF
--- a/test/blackbox-tests/test-cases/include-qualified/install-sources.t
+++ b/test/blackbox-tests/test-cases/include-qualified/install-sources.t
@@ -11,6 +11,19 @@ It should be possible to install sources with the same file name when
   > (library
   >  (public_name foo))
   > EOF
+
+First we tests the case without any sources. To make sure we can at least
+install empty libraries.
+
+  $ dune build foo.install
+  File "dune", line 1, characters 0-27:
+  1 | (include_subdirs qualified)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: (include_subdirs qualified) is only meant for OCaml and Coq sources
+  [1]
+
+Now we add some source with duplicate base names and test again:
+
   $ mkdir bar
   $ touch baz.ml bar/baz.ml
   $ dune build foo.install


### PR DESCRIPTION
Tests should exercise libraries without sources

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2f5cf8a7-2bb8-4609-bfd0-1df4ba21f0a3 -->