### PR TITLE
fix(rule): include_subdirs and foreign sources

### DIFF
--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -332,8 +332,7 @@ end = struct
                        ; foreign_sources =
                            Memo.lazy_ (fun () ->
                                Foreign_sources.make d.stanzas ~dune_version
-                                 ~lib_config:ctx.lib_config ~include_subdirs
-                                 ~dirs
+                                 ~lib_config:ctx.lib_config ~dirs
                                |> Memo.return)
                        ; coq =
                            Memo.lazy_ (fun () ->
@@ -393,7 +392,7 @@ end = struct
             let dune_version = Dune_project.dune_version d.project in
             let foreign_sources =
               Memo.lazy_ (fun () ->
-                  Foreign_sources.make d.stanzas ~dune_version ~include_subdirs
+                  Foreign_sources.make d.stanzas ~dune_version
                     ~lib_config:ctx.lib_config ~dirs
                   |> Memo.return)
             in

--- a/src/dune_rules/foreign_sources.ml
+++ b/src/dune_rules/foreign_sources.ml
@@ -153,13 +153,6 @@ let eval_foreign_stubs foreign_stubs (ctypes : Ctypes_field.t option)
           multiple_sources_error ~name ~loc ~mode
             ~paths:Foreign.Source.[ path src1; path src2 ]))
 
-let check_no_qualified (loc, include_subdirs) =
-  if include_subdirs = Dune_file.Include_subdirs.Include Qualified then
-    User_error.raise ~loc
-      [ Pp.text
-          "(include_subdirs qualified) is only meant for OCaml and Coq sources"
-      ]
-
 let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version
     ~(lib_config : Lib_config.t) =
   let libs, foreign_libs, exes =
@@ -268,9 +261,7 @@ let make stanzas ~(sources : Foreign.Sources.Unresolved.t) ~dune_version
   in
   { libraries; archives; executables }
 
-let make stanzas ~dune_version ~include_subdirs ~(lib_config : Lib_config.t)
-    ~dirs =
-  check_no_qualified include_subdirs;
+let make stanzas ~dune_version ~(lib_config : Lib_config.t) ~dirs =
   let init = String.Map.empty in
   let sources =
     List.fold_left dirs ~init ~f:(fun acc (dir, _local, files) ->

--- a/src/dune_rules/foreign_sources.mli
+++ b/src/dune_rules/foreign_sources.mli
@@ -15,7 +15,6 @@ val for_exes : t -> first_exe:string -> Foreign.Sources.t
 val make :
      Stanza.t list
   -> dune_version:Syntax.Version.t
-  -> include_subdirs:Loc.t * Dune_file.Include_subdirs.t
   -> lib_config:Lib_config.t
   -> dirs:(Path.Build.t * 'a * String.Set.t) list
   -> t

--- a/test/blackbox-tests/test-cases/include-qualified/install-sources.t
+++ b/test/blackbox-tests/test-cases/include-qualified/install-sources.t
@@ -16,11 +16,6 @@ First we tests the case without any sources. To make sure we can at least
 install empty libraries.
 
   $ dune build foo.install
-  File "dune", line 1, characters 0-27:
-  1 | (include_subdirs qualified)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: (include_subdirs qualified) is only meant for OCaml and Coq sources
-  [1]
 
 Now we add some source with duplicate base names and test again:
 
@@ -33,5 +28,4 @@ Now we add some source with duplicate base names and test again:
   -> required by _build/default/foo.install
   [1]
   $ cat _build/default/foo.install | grep baz.ml
-  cat: _build/default/foo.install: No such file or directory
   [1]


### PR DESCRIPTION
Previously, we were not allowing `(include_subdirs qualified)` for
foreign sources. Now that (include_subdirs qualified) is supported, this
check doesn't make sense.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 086cc759-b287-44ee-aa10-30e9e06633d4 -->