### PR TITLE
Allow 4.14 compilers with the 5.0 layout for otherlibs

### DIFF
--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -87,12 +87,11 @@ let () =
       (compiler, Some "--secondary")
   in
   exit_if_non_zero
-    (runf "%s %s -w -24 -g -o %s -I boot %sunix.cma %s" compiler
+    (runf "%s %s -w -24 -g -o %s -I boot -I +unix unix.cma %s" compiler
        (* Make sure to produce a self-contained binary as dlls tend to cause
           issues *)
        (if v < (4, 10, 1) then "-custom" else "-output-complete-exe")
        prog
-       (if v >= (5, 0, 0) then "-I +unix " else "")
        (List.map modules ~f:(fun m -> m ^ ".ml") |> String.concat ~sep:" "));
   let args = List.tl (Array.to_list Sys.argv) in
   let args =

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -603,8 +603,9 @@ end = struct
   let output_complete_obj_arg =
     if ocaml_version < (4, 10) then "-custom" else "-output-complete-exe"
 
-  let unix_library_flags =
-    if ocaml_version >= (5, 0) then [ "-I"; "+unix" ] else []
+  (* For older releases the directory may not exists,
+     but this shouldn't cause any issues *)
+  let unix_library_flags = [ "-I"; "+unix" ]
 end
 
 let insert_header fn ~header =

--- a/src/ocaml-config/ocaml_config.ml
+++ b/src/ocaml-config/ocaml_config.ml
@@ -672,10 +672,9 @@ let make vars =
     let windows_unicode = get_bool vars "windows_unicode" in
     let natdynlink_supported =
       let lib = "dynlink.cmxa" in
-      let lib =
-        if version >= (5, 0, 0) then Filename.concat "dynlink" lib else lib
-      in
+      let lib_prefixed = Filename.concat "dynlink" lib in
       Sys.file_exists (Filename.concat standard_library lib)
+      || Sys.file_exists (Filename.concat standard_library lib_prefixed)
     in
     let file =
       let stdlib = Path.external_ (Path.External.of_string standard_library) in

--- a/src/ocaml/version.ml
+++ b/src/ocaml/version.ml
@@ -46,6 +46,6 @@ let has_bigarray_library version = version < (5, 0, 0)
 
 let supports_alerts version = version >= (4, 8, 0)
 
-let has_sandboxed_otherlibs version = version >= (5, 0, 0)
+let has_sandboxed_otherlibs version = version >= (4, 14, 0)
 
 let has_META_files version = version >= (5, 0, 0)


### PR DESCRIPTION
Follow-up on #5581: the flambda-backend compilers are now using the new layout for libraries while still based on 4.14. which causes quite a bit of trouble. This PR would let us build dune and dune-based projects again.

It was written as an emergency patch, which means that my proposal may not be the most suitable way to address the issue; I'll be happy to improve it given feedback.