### PR TITLE
fix: pre-emptively clear screen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- Pre-emptively clear screen in watch mode (#6987, fixes #6884, @rgrinberg)
+
 - Fix cross compilation configuration when a context with targets is itself a
   host of another context (#6958, fixes #6843, @rgrinberg)
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -986,7 +986,11 @@ let init ?log_file c =
     Dune_config.adapt_display config
       ~output_is_a_tty:(Lazy.force Ansi_color.output_is_a_tty)
   in
-  Dune_config.init config;
+  Dune_config.init config
+    ~watch:
+      (match c.builder.watch with
+      | No -> false
+      | Yes _ -> true);
   Dune_engine.Execution_parameters.init
     (let open Memo.O in
     let+ w = Dune_rules.Workspace.workspace () in

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -433,7 +433,7 @@ let term =
   Path.set_root (Path.External.cwd ());
   Path.Build.set_build_dir
     (Path.Outside_build_dir.of_string Common.default_build_dir);
-  Dune_config.init config;
+  Dune_config.init config ~watch:false;
   Log.init_disabled ();
   Dune_engine.Scheduler.Run.go
     ~on_event:(fun _ _ -> ())

--- a/src/dune_config/dune_config.ml
+++ b/src/dune_config/dune_config.ml
@@ -382,8 +382,13 @@ let adapt_display config ~output_is_a_tty =
     { config with terminal_persistence = Terminal_persistence.Preserve }
   else config
 
-let init t =
+let init t ~watch =
   Console.Backend.set (Display.console_backend t.display);
+  (if watch then
+   match t.terminal_persistence with
+   | Preserve -> ()
+   | Clear_on_rebuild -> Console.reset ()
+   | Clear_on_rebuild_and_flush_history -> Console.reset_flush_history ());
   Log.verbose := t.display.verbosity = Verbose
 
 let auto_concurrency =

--- a/src/dune_config/dune_config.mli
+++ b/src/dune_config/dune_config.mli
@@ -111,7 +111,7 @@ val load_config_file : Path.t -> Partial.t
 val adapt_display : t -> output_is_a_tty:bool -> t
 
 (** Initialises the configuration for the process *)
-val init : t -> unit
+val init : t -> watch:bool -> unit
 
 val to_dyn : t -> Dyn.t
 


### PR DESCRIPTION
When running with fancy terminals in watch mode, we pre-emptively clear
the screen. This is to prevent subsequent clears in watch mode making
the user's screen jump.

Fixes #6884

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0fd9e4d8-547d-4f57-9e9d-aa3462c36bfd -->