### PR TITLE
refactor(console): split interface

### DIFF
--- a/src/dune_console/backend_intf.ml
+++ b/src/dune_console/backend_intf.ml
@@ -1,0 +1,19 @@
+open Stdune
+
+module type S = sig
+  val start : unit -> unit
+
+  val print_user_message : User_message.t -> unit
+
+  val set_status_line : User_message.Style.t Pp.t option -> unit
+
+  val print_if_no_status_line : User_message.Style.t Pp.t -> unit
+
+  val reset : unit -> unit
+
+  val reset_flush_history : unit -> unit
+
+  val finish : unit -> unit
+end
+
+type t = (module S)

--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -1,25 +1,9 @@
 open Stdune
 
 module Backend = struct
-  module type S = sig
-    val start : unit -> unit
+  type t = Backend_intf.t
 
-    val print_user_message : User_message.t -> unit
-
-    val set_status_line : User_message.Style.t Pp.t option -> unit
-
-    val print_if_no_status_line : User_message.Style.t Pp.t -> unit
-
-    val reset : unit -> unit
-
-    val reset_flush_history : unit -> unit
-
-    val finish : unit -> unit
-  end
-
-  type t = (module S)
-
-  module Dumb_no_flush : S = struct
+  module Dumb_no_flush : Backend_intf.S = struct
     let start () = ()
 
     let finish () = ()
@@ -42,7 +26,7 @@ module Backend = struct
     let reset_flush_history () = prerr_string "\x1b[1;1H\x1b[2J\x1b[3J"
   end
 
-  module Dumb : S = struct
+  module Dumb : Backend_intf.S = struct
     include Dumb_no_flush
 
     let print_if_no_status_line msg =
@@ -62,7 +46,7 @@ module Backend = struct
       flush stderr
   end
 
-  module Progress_no_flush : S = struct
+  module Progress_no_flush : Backend_intf.S = struct
     let status_line = ref Pp.nop
 
     let start () = ()
@@ -102,15 +86,16 @@ module Backend = struct
     let reset_flush_history () = Dumb.reset_flush_history ()
   end
 
-  let dumb = (module Dumb : S)
+  let dumb = (module Dumb : Backend_intf.S)
 
-  let progress = (module Progress_no_flush : S)
+  let progress = (module Progress_no_flush : Backend_intf.S)
 
   let main = ref dumb
 
   let set t = main := t
 
-  let compose (module A : S) (module B : S) : (module S) =
+  let compose (module A : Backend_intf.S) (module B : Backend_intf.S) :
+      (module Backend_intf.S) =
     (module struct
       let start () =
         A.start ();
@@ -139,179 +124,12 @@ module Backend = struct
       let reset_flush_history () =
         A.reset_flush_history ();
         B.reset_flush_history ()
-    end : S)
+    end : Backend_intf.S)
 
-  let spawn_thread = Fdecl.create Dyn.opaque
-
-  (** Backends may have access to an internal state. This type is used by the
-      [Threaded] backends. *)
-  type state =
-    { messages : User_message.t Queue.t
-    ; mutable finish_requested : bool
-    ; mutable finished : bool
-    ; mutable status_line : User_message.Style.t Pp.t option
-    }
-
-  (** [Threaded] is the interface for user interfaces that are rendered in a
-      separate thread. It can be used to directly construct a threaded backend.
-
-      This module interface will be used by both the current console UI and the
-      upcoming terminal UI (TUI).
-
-      Notice that the TUI can also react to keyboard input, so it has the
-      additional [handle_user_events] call. *)
-  module type Threaded = sig
-    (** [start] is called by the main thread to start broadcasting the user
-        interface. Any initial setup should be performed here. *)
-    val start : unit -> unit
-
-    (** [render state] is called by the main thread to render the current state
-        of the user interface. *)
-    val render : state -> unit
-
-    (** [handle_user_events ~now ~time_budget mutex] is called by the main
-        thread to handle user events such as keypresses. The function should
-        return the time at which the next event should be handled. A [mutex] is
-        provided in order to lock the state of the UI. [time_budget] indicates
-        an approximate amount of time that should be spent in this function.
-        This is useful for things like waiting for user input.
-
-        [time_budget] should be as accurate as possible, but if it's not, the
-        only consequence would be modifying the rendering rate. That is, if
-        [time_budget] is an underestimate the actual amount of time spent, we
-        will render faster than the desired frame rate. If it is an
-        overestimate, we will render slower. *)
-    val handle_user_events : now:float -> time_budget:float -> Mutex.t -> float
-
-    (** [reset] is called by the main thread to reset the user interface. *)
-    val reset : unit -> unit
-
-    (** [reset_flush_history] is called by the main thread to reset and flush
-        the user interface. *)
-    val reset_flush_history : unit -> unit
-
-    (** [finish] is called finally by the main thread to finish broadcasting the
-        user interface. Any locks on the terminal should be released here. *)
-    val finish : unit -> unit
-  end
-
-  (** [threaded (module T)] is a backend that renders the user interface in a
-      separate thread. The module [T] must implement the [Threaded] interface.
-      There are special functions included to handle various functions of a user
-      interface. *)
-  let threaded (module Base : Threaded) : (module S) =
-    let module T = struct
-      let mutex = Mutex.create ()
-
-      let finish_cv = Condition.create ()
-
-      let state =
-        { messages = Queue.create ()
-        ; status_line = None
-        ; finished = false
-        ; finish_requested = false
-        }
-
-      let start () =
-        Mutex.lock mutex;
-        Base.start ();
-        Mutex.unlock mutex
-
-      let finish () =
-        Mutex.lock mutex;
-        state.finish_requested <- true;
-        while not state.finished do
-          Condition.wait finish_cv mutex
-        done;
-        Mutex.unlock mutex
-
-      let print_user_message m =
-        Mutex.lock mutex;
-        Queue.push state.messages m;
-        Mutex.unlock mutex
-
-      let set_status_line sl =
-        Mutex.lock mutex;
-        state.status_line <- sl;
-        Mutex.unlock mutex
-
-      let print_if_no_status_line _msg = ()
-
-      let reset () =
-        Mutex.lock mutex;
-        Queue.clear state.messages;
-        state.status_line <- None;
-        Base.reset ();
-        Mutex.unlock mutex
-
-      let reset_flush_history () =
-        Mutex.lock mutex;
-        Queue.clear state.messages;
-        state.status_line <- None;
-        Base.reset_flush_history ();
-        Mutex.unlock mutex
-    end in
-    ( Fdecl.get spawn_thread @@ fun () ->
-      let open T in
-      let last = ref (Unix.gettimeofday ()) in
-      let frame_rate = 1. /. 60. in
-      let cleanup () =
-        state.finished <- true;
-        Base.finish ();
-        Condition.broadcast finish_cv;
-        Mutex.unlock mutex
-      in
-      try
-        Base.start ();
-        (* This is the main event loop for a threaded backend.
-
-           Firstly we lock our mutex, to prevent other threads from mutating our
-           state. Next we ask our implementation to render the given state,
-           afterwards checking if a finish was requested.
-
-           If a finish was requested we exit the loop cleanly.
-
-           We unlock our mutex and go into a time calculation. This calculation
-           gets the current time and compares it with the last recorded time.
-           This lets us compute the elapsed time.
-
-           Next we check that the elapsed time is larger than our specifed
-           [frame_rate]. If this is the case then we can handle any pending user
-           events and continue the loop as soon as possible.
-
-           If we have not yet reached the [frame_rate] then we can handle user
-           events and sleep for the remaining time. *)
-        while true do
-          Mutex.lock mutex;
-          Base.render state;
-          let finish_requested = state.finish_requested in
-          if finish_requested then raise_notrace Exit;
-          Mutex.unlock mutex;
-          let now = Unix.gettimeofday () in
-          let elapsed = now -. !last in
-          let new_time =
-            if elapsed >= frame_rate then
-              Base.handle_user_events ~now ~time_budget:0.0 mutex
-            else
-              let delta = frame_rate -. elapsed in
-              Base.handle_user_events ~now ~time_budget:delta mutex
-          in
-          last := new_time
-        done
-      with
-      | Exit -> cleanup ()
-      | exn ->
-        (* If any unexpected exceptions are encountered, we catch them, make
-           sure we [cleanup] and then re-raise them. *)
-        let exn = Exn_with_backtrace.capture exn in
-        cleanup ();
-        Exn_with_backtrace.reraise exn );
-    (module T)
-
-  module Progress_no_flush_threaded : Threaded = struct
+  module Progress_no_flush_threaded : Threaded_intf.S = struct
     include Progress_no_flush
 
-    let render state =
+    let render (state : Threaded_intf.state) =
       while not (Queue.is_empty state.messages) do
         print_user_message (Queue.pop_exn state.messages)
       done;
@@ -327,12 +145,17 @@ module Backend = struct
   end
 
   let progress_threaded =
-    let t = lazy (threaded (module Progress_no_flush_threaded)) in
+    let t = lazy (Threaded.make (module Progress_no_flush_threaded)) in
     fun () -> Lazy.force t
 end
 
+module Threaded = struct
+  include Threaded_intf
+  include Threaded
+end
+
 let print_user_message msg =
-  let (module M : Backend.S) = !Backend.main in
+  let (module M : Backend_intf.S) = !Backend.main in
   M.print_user_message msg
 
 let print paragraphs = print_user_message (User_message.make paragraphs)
@@ -340,23 +163,23 @@ let print paragraphs = print_user_message (User_message.make paragraphs)
 let printf fmt = Printf.ksprintf (fun msg -> print [ Pp.verbatim msg ]) fmt
 
 let set_status_line line =
-  let (module M : Backend.S) = !Backend.main in
+  let (module M : Backend_intf.S) = !Backend.main in
   M.set_status_line line
 
 let print_if_no_status_line line =
-  let (module M : Backend.S) = !Backend.main in
+  let (module M : Backend_intf.S) = !Backend.main in
   M.print_if_no_status_line line
 
 let reset () =
-  let (module M : Backend.S) = !Backend.main in
+  let (module M : Backend_intf.S) = !Backend.main in
   M.reset ()
 
 let reset_flush_history () =
-  let (module M : Backend.S) = !Backend.main in
+  let (module M : Backend_intf.S) = !Backend.main in
   M.reset_flush_history ()
 
 let finish () =
-  let (module M : Backend.S) = !Backend.main in
+  let (module M : Backend_intf.S) = !Backend.main in
   M.finish ()
 
 module Status_line = struct

--- a/src/dune_console/dune_console.mli
+++ b/src/dune_console/dune_console.mli
@@ -26,12 +26,18 @@ module Backend : sig
   (** A backend that displays the status line in the terminal, with the
       processing logic happening in a separate thread. *)
   val progress_threaded : unit -> t
+end
+
+module Threaded : sig
+  include module type of Threaded_intf
 
   (** [spawn_thread f] is called by the main thread to spawn a new thread. The
       thread should call [f] to start the user interface. This forward
       declaration allows the function to be set much later in the scheduler when
       the operation is defined. This is only useful for threaded backends. *)
   val spawn_thread : ((unit -> unit) -> unit) Fdecl.t
+
+  val make : (module S) -> Backend.t
 end
 
 (** Format and print a user message to the console. *)

--- a/src/dune_console/threaded.ml
+++ b/src/dune_console/threaded.ml
@@ -1,0 +1,116 @@
+open Stdune
+
+let spawn_thread = Fdecl.create Dyn.opaque
+
+(** [threaded (module T)] is a backend that renders the user interface in a
+    separate thread. The module [T] must implement the [Threaded] interface.
+    There are special functions included to handle various functions of a user
+    interface. *)
+let make (module Base : Threaded_intf.S) : (module Backend_intf.S) =
+  let module T = struct
+    let mutex = Mutex.create ()
+
+    let finish_cv = Condition.create ()
+
+    let state =
+      { Threaded_intf.messages = Queue.create ()
+      ; status_line = None
+      ; finished = false
+      ; finish_requested = false
+      }
+
+    let start () =
+      Mutex.lock mutex;
+      Base.start ();
+      Mutex.unlock mutex
+
+    let finish () =
+      Mutex.lock mutex;
+      state.finish_requested <- true;
+      while not state.finished do
+        Condition.wait finish_cv mutex
+      done;
+      Mutex.unlock mutex
+
+    let print_user_message m =
+      Mutex.lock mutex;
+      Queue.push state.messages m;
+      Mutex.unlock mutex
+
+    let set_status_line sl =
+      Mutex.lock mutex;
+      state.status_line <- sl;
+      Mutex.unlock mutex
+
+    let print_if_no_status_line _msg = ()
+
+    let reset () =
+      Mutex.lock mutex;
+      Queue.clear state.messages;
+      state.status_line <- None;
+      Base.reset ();
+      Mutex.unlock mutex
+
+    let reset_flush_history () =
+      Mutex.lock mutex;
+      Queue.clear state.messages;
+      state.status_line <- None;
+      Base.reset_flush_history ();
+      Mutex.unlock mutex
+  end in
+  ( Fdecl.get spawn_thread @@ fun () ->
+    let open T in
+    let last = ref (Unix.gettimeofday ()) in
+    let frame_rate = 1. /. 60. in
+    let cleanup () =
+      state.finished <- true;
+      Base.finish ();
+      Condition.broadcast finish_cv;
+      Mutex.unlock mutex
+    in
+    try
+      Base.start ();
+      (* This is the main event loop for a threaded backend.
+
+         Firstly we lock our mutex, to prevent other threads from mutating our
+         state. Next we ask our implementation to render the given state,
+         afterwards checking if a finish was requested.
+
+         If a finish was requested we exit the loop cleanly.
+
+         We unlock our mutex and go into a time calculation. This calculation
+         gets the current time and compares it with the last recorded time.
+         This lets us compute the elapsed time.
+
+         Next we check that the elapsed time is larger than our specifed
+         [frame_rate]. If this is the case then we can handle any pending user
+         events and continue the loop as soon as possible.
+
+         If we have not yet reached the [frame_rate] then we can handle user
+         events and sleep for the remaining time. *)
+      while true do
+        Mutex.lock mutex;
+        Base.render state;
+        let finish_requested = state.finish_requested in
+        if finish_requested then raise_notrace Exit;
+        Mutex.unlock mutex;
+        let now = Unix.gettimeofday () in
+        let elapsed = now -. !last in
+        let new_time =
+          if elapsed >= frame_rate then
+            Base.handle_user_events ~now ~time_budget:0.0 mutex
+          else
+            let delta = frame_rate -. elapsed in
+            Base.handle_user_events ~now ~time_budget:delta mutex
+        in
+        last := new_time
+      done
+    with
+    | Exit -> cleanup ()
+    | exn ->
+      (* If any unexpected exceptions are encountered, we catch them, make
+         sure we [cleanup] and then re-raise them. *)
+      let exn = Exn_with_backtrace.capture exn in
+      cleanup ();
+      Exn_with_backtrace.reraise exn );
+  (module T)

--- a/src/dune_console/threaded.mli
+++ b/src/dune_console/threaded.mli
@@ -1,0 +1,5 @@
+open Stdune
+
+val spawn_thread : ((unit -> unit) -> unit) Fdecl.t
+
+val make : (module Threaded_intf.S) -> Backend_intf.t

--- a/src/dune_console/threaded_intf.ml
+++ b/src/dune_console/threaded_intf.ml
@@ -1,0 +1,53 @@
+open Stdune
+
+(** Backends may have access to an internal state. This type is used by the
+    [Threaded] backends. *)
+type state =
+  { messages : User_message.t Queue.t
+  ; mutable finish_requested : bool
+  ; mutable finished : bool
+  ; mutable status_line : User_message.Style.t Pp.t option
+  }
+
+(** [Threaded] is the interface for user interfaces that are rendered in a
+    separate thread. It can be used to directly construct a threaded backend.
+
+    This module interface will be used by both the current console UI and the
+    upcoming terminal UI (TUI).
+
+    Notice that the TUI can also react to keyboard input, so it has the
+    additional [handle_user_events] call. *)
+module type S = sig
+  (** [start] is called by the main thread to start broadcasting the user
+      interface. Any initial setup should be performed here. *)
+  val start : unit -> unit
+
+  (** [render state] is called by the main thread to render the current state of
+      the user interface. *)
+  val render : state -> unit
+
+  (** [handle_user_events ~now ~time_budget mutex] is called by the main thread
+      to handle user events such as keypresses. The function should return the
+      time at which the next event should be handled. A [mutex] is provided in
+      order to lock the state of the UI. [time_budget] indicates an approximate
+      amount of time that should be spent in this function. This is useful for
+      things like waiting for user input.
+
+      [time_budget] should be as accurate as possible, but if it's not, the only
+      consequence would be modifying the rendering rate. That is, if
+      [time_budget] is an underestimate the actual amount of time spent, we will
+      render faster than the desired frame rate. If it is an overestimate, we
+      will render slower. *)
+  val handle_user_events : now:float -> time_budget:float -> Mutex.t -> float
+
+  (** [reset] is called by the main thread to reset the user interface. *)
+  val reset : unit -> unit
+
+  (** [reset_flush_history] is called by the main thread to reset and flush the
+      user interface. *)
+  val reset_flush_history : unit -> unit
+
+  (** [finish] is called finally by the main thread to finish broadcasting the
+      user interface. Any locks on the terminal should be released here. *)
+  val finish : unit -> unit
+end

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -87,7 +87,7 @@ end = struct
       Thread.create f x
 
   let () =
-    Fdecl.set Console.Backend.spawn_thread (fun f ->
+    Fdecl.set Console.Threaded.spawn_thread (fun f ->
         let (_ : Thread.t) = create ~signal_watcher:`Yes f () in
         ())
 


### PR DESCRIPTION
Split the interface to multiple files and allow threaded backends to be
defined outside the [dune_console]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1bb9522f-6580-4ec1-8725-096d5d04d979 -->