### PR TITLE
feature(rules): custom alias for cinaps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,10 @@ Unreleased
 
 - Handle "Too many links" errors when using Dune cache on Windows (#6993, @nojb)
 
+- Allow the `cinaps` stanza to set a custom alias. By default, if the alias is
+  not set then the cinaps actions will be attached to both `@cinaps` and
+  `@runtest` (#6988, @rgrinberg)
+
 3.6.2 (2022-12-21)
 ------------------
 

--- a/test/blackbox-tests/test-cases/cinaps/custom-alias.t
+++ b/test/blackbox-tests/test-cases/cinaps/custom-alias.t
@@ -1,0 +1,21 @@
+Custom alias for the cinaps
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > (using cinaps 1.2)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (cinaps
+  >  (files foo.ml)
+  >  (alias foo))
+  > EOF
+
+  $ touch foo.ml
+
+  $ dune build @foo --display short
+        cinaps .cinaps.a7811055/cinaps.ml-gen
+        ocamlc .cinaps.a7811055/.cinaps.eobjs/byte/dune__exe__Cinaps.{cmi,cmo,cmt}
+      ocamlopt .cinaps.a7811055/.cinaps.eobjs/native/dune__exe__Cinaps.{cmx,o}
+      ocamlopt .cinaps.a7811055/cinaps.exe
+        cinaps alias foo


### PR DESCRIPTION
Allow setting the alias used to run cinaps actions.

This is done to override the behavior of attaching the cinaps action to
both the `cinaps` and `runtest` aliases.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d35a6315-e4ef-40d1-9527-783dcd82029a -->