### PR TITLE
Unix.link: catch EMLINK also on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,6 +114,8 @@ Unreleased
 - Fix dependency cycle when installing files to the bin section with
   `glob_files` (#6764, fixes #6708, @gridbugs)
 
+- Handle "Too many links" errors when using Dune cache on Windows (#6993, @nojb)
+
 3.6.2 (2022-12-21)
 ------------------
 

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -61,7 +61,7 @@ let link_even_if_there_are_too_many_links_already ~src ~dst =
   try Path.link src dst
   with
   | Unix.Unix_error (Unix.EMLINK, _, _)
-  | Unix.Unix_error (Unix.EUNKNOWNERR, -1442, _) (* Needed for OCaml < 5.1 *)
+  | Unix.Unix_error (Unix.EUNKNOWNERR (-1442), _, _) (* Needed for OCaml < 5.1 *)
   ->
     Temp.with_temp_file ~dir:temp_dir ~prefix:"dune" ~suffix:"copy" ~f:(function
       | Error e -> raise e

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -61,7 +61,7 @@ let link_even_if_there_are_too_many_links_already ~src ~dst =
   try Path.link src dst
   with
   | Unix.Unix_error (Unix.EMLINK, _, _)
-  | Unix.Unix_error (Unix.EUNKNOWNERR (-1442), _, _) (* Needed for OCaml < 5.1 *)
+  | Unix.Unix_error (Unix.EUNKNOWNERR -1442, _, _) (* Needed for OCaml < 5.1 *)
   ->
     Temp.with_temp_file ~dir:temp_dir ~prefix:"dune" ~suffix:"copy" ~f:(function
       | Error e -> raise e

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -59,7 +59,10 @@ end
    hard links on [$file] will be allowed, triggering the [EMLINK] code path. *)
 let link_even_if_there_are_too_many_links_already ~src ~dst =
   try Path.link src dst
-  with Unix.Unix_error (Unix.EMLINK, _, _) ->
+  with
+  | Unix.Unix_error (Unix.EMLINK, _, _)
+  | Unix.Unix_error (Unix.EUNKNOWNERR, -1442, _) (* Needed for OCaml < 5.1 *)
+  ->
     Temp.with_temp_file ~dir:temp_dir ~prefix:"dune" ~suffix:"copy" ~f:(function
       | Error e -> raise e
       | Ok temp_file ->


### PR DESCRIPTION
Fixes #6992 