### PR TITLE
refactor: avoid Path.as_outside_build_dir_exn

### DIFF
--- a/bin/arg.ml
+++ b/bin/arg.ml
@@ -10,6 +10,16 @@ module Context_name = Dune_engine.Context_name
 let package_name = conv Package.Name.conv
 
 module Path = struct
+  module External = struct
+    type t = string
+
+    let path p = Path.External.of_filename_relative_to_initial_cwd p
+
+    let arg s = s
+
+    let conv = conv ((fun p -> Ok p), Format.pp_print_string)
+  end
+
   type t = string
 
   let path p = Path.of_filename_relative_to_initial_cwd p
@@ -20,6 +30,8 @@ module Path = struct
 end
 
 let path = Path.conv
+
+let external_path = Path.External.conv
 
 let profile = conv Dune_rules.Profile.conv
 

--- a/bin/arg.mli
+++ b/bin/arg.mli
@@ -7,6 +7,14 @@ include module type of struct
 end
 
 module Path : sig
+  module External : sig
+    type t
+
+    val path : t -> Path.External.t
+
+    val arg : t -> string
+  end
+
   type t
 
   val path : t -> Path.t
@@ -35,6 +43,8 @@ val dep : Dep.t conv
 val graph_format : Dune_graph.Graph.File_format.t conv
 
 val path : Path.t conv
+
+val external_path : Path.External.t conv
 
 val package_name : Package.Name.t conv
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -600,7 +600,7 @@ module Builder = struct
       let doc = "Use this specific workspace file instead of looking it up." in
       Arg.(
         value
-        & opt (some path) None
+        & opt (some external_path) None
         & info [ "workspace" ] ~docs ~docv:"FILE" ~doc
             ~env:(Cmd.Env.info ~doc "DUNE_WORKSPACE"))
     and+ promote =
@@ -838,7 +838,9 @@ module Builder = struct
         { x
         ; profile
         ; instrument_with
-        ; workspace_file = Option.map workspace_file ~f:Arg.Path.path
+        ; workspace_file =
+            Option.map workspace_file ~f:(fun p ->
+                Path.Outside_build_dir.External (Arg.Path.External.path p))
         ; config_from_command_line
         ; config_from_config_file
         }

--- a/src/dune_rules/workspace.mli
+++ b/src/dune_rules/workspace.mli
@@ -91,7 +91,7 @@ module Clflags : sig
     { x : Context_name.t option
     ; profile : Profile.t option
     ; instrument_with : Lib_name.t list option
-    ; workspace_file : Path.t option
+    ; workspace_file : Path.Outside_build_dir.t option
     ; config_from_command_line : Dune_config.Partial.t
     ; config_from_config_file : Dune_config.Partial.t
     }


### PR DESCRIPTION
Use Path.Outside_build_dir.t to represent workspace paths

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2e70c6dd-084f-485e-960a-b1618d32ac5a -->