### PR TITLE
refactor(console): call start/finish

### DIFF
--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -92,7 +92,11 @@ module Backend = struct
 
   let main = ref dumb
 
-  let set t = main := t
+  let set (module T : Backend_intf.S) =
+    let module Old = (val !main) in
+    Old.finish ();
+    main := (module T);
+    T.start ()
 
   let compose (module A : Backend_intf.S) (module B : Backend_intf.S) :
       (module Backend_intf.S) =


### PR DESCRIPTION
When setting the console backend to a value, call:

* [finish] on the currently set backend
* [start] on the incoming backend

The only change in practice is for the threaded backend. The backend that is being executed in a thread will now be initialized before the thread is launched. That seems like the good thing to do - to make sure everything is initialized before running the UI loop.

<!-- ps-id: 0b5ca454-4263-405f-8fc0-5827d9caa424 -->