### PR TITLE
refactor(engine): fetching execution parameters

### DIFF
--- a/src/dune_engine/build_config.ml
+++ b/src/dune_engine/build_config.ml
@@ -65,12 +65,14 @@ type t =
   ; cache_config : Dune_cache.Config.t
   ; cache_debug_flags : Cache_debug_flags.t
   ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t
+  ; execution_parameters : dir:Path.Source.t -> Execution_parameters.t Memo.t
   }
 
 let t = Fdecl.create Dyn.opaque
 
 let set ~stats ~contexts ~promote_source ~cache_config ~cache_debug_flags
-    ~sandboxing_preference ~rule_generator ~implicit_default_alias =
+    ~sandboxing_preference ~rule_generator ~implicit_default_alias
+    ~execution_parameters =
   let contexts =
     Memo.lazy_ ~name:"Build_config.set" (fun () ->
         let open Memo.O in
@@ -93,6 +95,7 @@ let set ~stats ~contexts ~promote_source ~cache_config ~cache_debug_flags
     ; cache_config
     ; cache_debug_flags
     ; implicit_default_alias
+    ; execution_parameters
     }
 
 let get () = Fdecl.get t

--- a/src/dune_engine/build_config.mli
+++ b/src/dune_engine/build_config.mli
@@ -80,6 +80,7 @@ type t = private
   ; cache_config : Dune_cache.Config.t
   ; cache_debug_flags : Cache_debug_flags.t
   ; implicit_default_alias : Path.Build.t -> unit Action_builder.t option Memo.t
+  ; execution_parameters : dir:Path.Source.t -> Execution_parameters.t Memo.t
   }
 
 (** Initialise the build system. This must be called before running the build
@@ -100,6 +101,7 @@ val set :
   -> rule_generator:(module Rule_generator)
   -> implicit_default_alias:
        (Path.Build.t -> unit Action_builder.t option Memo.t)
+  -> execution_parameters:(dir:Path.Source.t -> Execution_parameters.t Memo.t)
   -> unit
 
 val get : unit -> t

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -503,19 +503,6 @@ end = struct
     | Promote promote, (Some Automatically | None) ->
       Target_promotion.promote ~dir ~targets ~promote ~promote_source
 
-  let execution_parameters_of_dir =
-    let f path =
-      let+ dir = Source_tree.nearest_dir path
-      and+ ep = Execution_parameters.default in
-      Dune_project.update_execution_parameters (Source_tree.Dir.project dir) ep
-    in
-    let memo =
-      Memo.create "execution-parameters-of-dir"
-        ~input:(module Path.Source)
-        ~cutoff:Execution_parameters.equal f
-    in
-    Memo.exec memo
-
   let execute_rule_impl ~rule_kind rule =
     let { Rule.id = _; targets; dir; context; mode; action; info = _; loc } =
       rule
@@ -530,7 +517,7 @@ end = struct
       match Dpath.Target_dir.of_target dir with
       | Regular (With_context (_, dir))
       | Anonymous_action (With_context (_, dir)) ->
-        execution_parameters_of_dir dir
+        (Build_config.get ()).execution_parameters ~dir
       | _ -> Execution_parameters.default
     in
     (* Note: we do not run the below in parallel with the above: if we fail to


### PR DESCRIPTION
Move the fetching of execution parameters to the rules.

Currently, the execution parameters are obtained from the dune-project
file. Therefore, this is part of the frontend and not the engine.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 4558da89-86ae-446c-af3c-3d1f417ea6be -->