### PR TITLE
feature: Suggest candidates when alias not found

### DIFF
--- a/test/blackbox-tests/test-cases/alias-candidates.t
+++ b/test/blackbox-tests/test-cases/alias-candidates.t
@@ -1,0 +1,18 @@
+Dune should suggest similar aliases when it cannot find one. 
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.7)
+  > EOF
+  $ cat > dune << EOF
+  > (rule
+  >  (alias foo)
+  >  (action
+  >   (echo "Hello, world from \"foo\"!")))
+  > EOF
+
+We have an alias "foo" but let's try to build something misspeled:
+  $ dune build @fou
+  Error: Alias "fou" specified on the command line is empty.
+  It is not defined in . or any of its descendants.
+  Hint: did you mean fmt or foo?
+  [1]

--- a/test/blackbox-tests/test-cases/generated-source-dir-overlap.t
+++ b/test/blackbox-tests/test-cases/generated-source-dir-overlap.t
@@ -19,6 +19,7 @@ If a generated directory is "overlaid" by a source dir, then things break.
   $ dune build @foo
   Error: Alias "foo" specified on the command line is empty.
   It is not defined in . or any of its descendants.
+  Hint: did you mean fmt?
   [1]
 
 The command above claims that @foo isn't defined, but it clearly is if we


### PR DESCRIPTION
We now suggest candidates when an alias is not found. Error messages look like:
```console
$ dune build @fou
Error: Alias "fou" specified on the command line is empty.
It is not defined in . or any of its descendants.
Hint: did you mean fmt or foo?
[1]
```
- [x] changelog
- [x] tests