### PR TITLE
csexp_rpc.ml: small simplification

### DIFF
--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -279,7 +279,6 @@ module Server = struct
           Some fd)
         else assert false
       | _, _, _ -> assert false
-      | exception Unix.Unix_error (Unix.EAGAIN, _, _) -> accept t
       | exception Unix.Unix_error (Unix.EBADF, _, _) -> None
 
     let stop t =

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -263,7 +263,7 @@ module Server = struct
       let buf = Bytes.make 1 '0' in
       { fd; sockaddr; r_interrupt_accept; w_interrupt_accept; buf }
 
-    let rec accept t =
+    let accept t =
       match Unix.select [ t.r_interrupt_accept; t.fd ] [] [] (-1.0) with
       | r, [], [] ->
         let inter, accept =

--- a/src/csexp_rpc/csexp_rpc.ml
+++ b/src/csexp_rpc/csexp_rpc.ml
@@ -260,7 +260,6 @@ module Server = struct
     let create fd sockaddr ~backlog =
       Unix.listen fd backlog;
       let r_interrupt_accept, w_interrupt_accept = Unix.pipe ~cloexec:true () in
-      if not Sys.win32 then Unix.set_nonblock r_interrupt_accept;
       let buf = Bytes.make 1 '0' in
       { fd; sockaddr; r_interrupt_accept; w_interrupt_accept; buf }
 


### PR DESCRIPTION
As discussed,

- There does not seem to be any need to set `r_interrupt_accept` to non-blocking (no data is actually read from it)
- `Unix.select` should not raise `EAGAIN`