### PR TITLE
test: demonstrate the "misc" section

### DIFF
--- a/test/blackbox-tests/test-cases/install/misc-section.t
+++ b/test/blackbox-tests/test-cases/install/misc-section.t
@@ -1,0 +1,19 @@
+The misc install section isn't supported:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > (package
+  >  (name xxx))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section misc)
+  >  (files foo))
+  > EOF
+
+  $ dune build xxx.install 2>&1 | awk '/Internal error/,/Raised/'
+  Internal error, please report upstream including the contents of _build/log.
+  Description:
+    ("Install.Paths.get", {})
+  Raised at Stdune__Code_error.raise in file


### PR DESCRIPTION
The "misc" section isn't currently supported by dune. Probably because
it breaks the sandboxing guarantees of switches.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9039eb43-0d22-40d4-95b1-d5103a9bd8d7 -->