### PR TITLE
test: modules_without_implementation and modules

### DIFF
--- a/test/blackbox-tests/test-cases/intf-only/excludes-by-modules-field.t
+++ b/test/blackbox-tests/test-cases/intf-only/excludes-by-modules-field.t
@@ -1,0 +1,27 @@
+Specifying a module without implementation that isn't inside the (modules ..)
+field
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (wrapped false)
+  >  (modules_without_implementation x)
+  >  (modules y))
+  > EOF
+
+  $ touch x.mli
+
+  $ cat >y.ml <<EOF
+  > module type F = X
+  > EOF
+
+  $ dune build --display short
+        ocamlc .foo.objs/byte/y.{cmi,cmo,cmt} (exit 2)
+  File "y.ml", line 1, characters 16-17:
+  1 | module type F = X
+                      ^
+  Error: Unbound module type X
+  [1]


### PR DESCRIPTION
demonstrate the behavior when a module is excluded by (modules ..) but
is written inside (modules_without_implementation ..)

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8075951a-3306-48db-ba8e-423bac14a4c9 -->