### PR TITLE
test: modules and private_modules

### DIFF
--- a/test/blackbox-tests/test-cases/private-modules/private-module-excluded-by-modules-field.t
+++ b/test/blackbox-tests/test-cases/private-modules/private-module-excluded-by-modules-field.t
@@ -1,0 +1,31 @@
+Demonstrate the behavior when a module is listed by private_modules by not by
+modules:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name foo)
+  >  (wrapped false)
+  >  (modules y)
+  >  (private_modules x))
+  > EOF
+
+  $ cat >x.ml <<EOF
+  > let foo = ()
+  > EOF
+
+  $ cat >y.ml <<EOF
+  > let () = X.foo ()
+  > EOF
+
+X is silently ignored:
+
+  $ dune build
+  File "y.ml", line 1, characters 9-14:
+  1 | let () = X.foo ()
+               ^^^^^
+  Error: Unbound module X
+  [1]


### PR DESCRIPTION
demonstrate the behavior when a module is listed by (private_modules ..)
but is exlucded by (modules ..)

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ff4e8808-e916-488c-8655-841d4898d16f -->