### PR TITLE
fix: module stanza mapping

### DIFF
--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -112,6 +112,8 @@ module Source = struct
 
   let name t = List.last t.path |> Option.value_exn
 
+  let path t = t.path
+
   let choose_file { files = { impl; intf }; path = _ } =
     match (intf, impl) with
     | None, None -> assert false

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -37,6 +37,8 @@ module Source : sig
 
   val files : t -> File.t list
 
+  val path : t -> Module_name.Path.t
+
   val to_dyn : t -> Dyn.t
 
   val src_dir : t -> Path.t

--- a/src/dune_rules/modules_field_evaluator.mli
+++ b/src/dune_rules/modules_field_evaluator.mli
@@ -26,4 +26,4 @@ val eval :
   -> kind:kind
   -> src_dir:Path.Build.t
   -> Stanza_common.Modules_settings.t
-  -> Module.t Module_trie.t
+  -> (Loc.t * Module.Source.t) Module_trie.t * Module.t Module_trie.t

--- a/test/blackbox-tests/test-cases/gh5267.t
+++ b/test/blackbox-tests/test-cases/gh5267.t
@@ -16,16 +16,9 @@ same directory.
   $ cat >bar.ml <<EOF
   > module M = Foo
   > EOF
-  $ touch foo.ml
-  $ touch foo.mli
+  $ touch foo.ml foo.mli
 
   $ dune build ./bar.exe
-  File "dune", line 1, characters 0-0:
-  Error: Module "Foo" is used in several stanzas:
-  - dune:1
-  - dune:4
-  To fix this error, you must specify an explicit "modules" field in every
-  library, executable, and executables stanzas in this dune file. Note that
-  each module cannot appear in more than one "modules" field - it must belong
-  to a single library or executable.
+  File "foo.ml-gen", line 1:
+  Error: Could not find the .cmi file for interface foo.mli.
   [1]


### PR DESCRIPTION
Do not use [Modules.t] to detect if a module is present in more than one
stanza.

This is a source based check so we should just use the sources directly

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 47648397-b5c4-4563-bdd1-0c1e6e98a981 -->