### PR TITLE
fix(melange): incompatible libraries

### DIFF
--- a/test/blackbox-tests/test-cases/melange/gh7020.t
+++ b/test/blackbox-tests/test-cases/melange/gh7020.t
@@ -47,8 +47,9 @@ Reproduce github #7020
   >  (module_system es6))
   > EOF
 
-  $ dune build @melange 2>&1 | awk '/Internal error/,/Raised/'
-  Internal error, please report upstream including the contents of _build/log.
-  Description:
-    ("Option.value_exn", {})
-  Raised at Stdune__Code_error.raise in file
+  $ dune build @melange
+  Error: The library dummyfoo was not compiled with Dune or it waas compiled
+  with Dune but published with a META template. Such libraries are not
+  compatible with melange support
+  -> required by alias melange
+  [1]


### PR DESCRIPTION
Libraries that are incompatible with the melange rules are:

* Non dune libraries
* Libraries defined with dune but installed with META templates

We emit a proper erorr message when we encounter such libraries

Ideally, we should discover such incompatibilities where they first
introduced, but this is better than the current hideous error.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8e91d502-662d-402c-bdea-13d9a6d93284 -->