### PR TITLE
melange: test to demonstrate that library js artifacts don't honor `javascript_extension` 

### DIFF
--- a/test/blackbox-tests/test-cases/melange/javascript-extension.t
+++ b/test/blackbox-tests/test-cases/melange/javascript-extension.t
@@ -40,3 +40,34 @@ Errors out if extension starts with dot
                              ^^^^^^
   Error: extension must not start with '.'
   [1]
+
+Should apply the settig to libraries as well
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name lib)
+  >  (modules lib)
+  >  (modes melange))
+  > (melange.emit
+  >  (target output)
+  >  (alias melange)
+  >  (libraries lib)
+  >  (entries foo)
+  >  (module_system commonjs)
+  >  (javascript_extension bs.js))
+  > EOF
+
+  $ cat >lib.ml <<EOF
+  > let greeting = "Hello World"
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > print_endline Lib.greeting
+  > EOF
+
+  $ dune build @melange
+  $ ls _build/default/output/ | sort
+  _build/default/output/foo.bs.js
+  _build/default/output/lib.bs.js
+  $ grep '.js' _build/default/output/foo.bs.js
+  var Lib = require("./lib.js");


### PR DESCRIPTION
The case for `javascript_extension` field with libraries was missing from the `javascript_extension.t` test file. This case is currently broken for some reason, the libraries artifacts are generated with the default `.js` extension, rather than the one picked in the `melange.emit` stanza.