### PR TITLE
fix: maintain modules sources when installing

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -92,7 +92,7 @@ module Lib = struct
        ; field_o "main_module_name" Module_name.encode main_module_name
        ; field_l "modes" sexp (Lib_mode.Map.Set.encode modes)
        ; field_l "obj_dir" sexp (Obj_dir.encode obj_dir)
-       ; field_o "modules" Modules.encode modules
+       ; field_o "modules" (Modules.encode ~src_dir:package_root) modules
        ; field_o "special_builtin_support"
            Lib_info.Special_builtin_support.encode special_builtin_support
        ; field_o "instrumentation.backend" (no_loc Lib_name.encode)

--- a/src/dune_rules/module.ml
+++ b/src/dune_rules/module.ml
@@ -6,6 +6,17 @@ module File = struct
     ; dialect : Dialect.t
     }
 
+  let decode ~dir =
+    let open Dune_lang.Decoder in
+    fields
+    @@ let+ path = field "path" (Dpath.Local.decode ~dir) in
+       (* TODO do not just assume the dialect is OCaml *)
+       { path; dialect = Dialect.ocaml }
+
+  let encode { path; dialect = _ } ~dir =
+    let open Dune_lang.Encoder in
+    record_fields [ field "path" (Dpath.Local.encode ~dir) path ]
+
   let dialect t = t.dialect
 
   let path t = t.path
@@ -90,6 +101,26 @@ module Source = struct
     { path : Module_name.Path.t
     ; files : File.t option Ml_kind.Dict.t
     }
+
+  let decode ~dir =
+    let open Dune_lang.Decoder in
+    fields
+    @@ let+ path = field "path" Module_name.Path.decode
+       and+ intf = field_o "intf" (File.decode ~dir)
+       and+ impl = field_o "impl" (File.decode ~dir) in
+       { path; files = { Ml_kind.Dict.intf; impl } }
+
+  let encode ~dir { path; files = { Ml_kind.Dict.intf; impl } } =
+    let open Dune_lang.Encoder in
+    let file = function
+      | None -> []
+      | Some x -> File.encode ~dir x
+    in
+    record_fields
+      [ field_l "path" Fun.id (Module_name.Path.encode path)
+      ; field_l "intf" Fun.id (file intf)
+      ; field_l "impl" Fun.id (file impl)
+      ]
 
   let to_dyn { path; files } =
     let open Dyn in
@@ -293,14 +324,8 @@ end
 
 module Obj_map_traversals = Memo.Make_map_traversals (Obj_map)
 
-let encode
-    ({ source = { files = _; path; _ }
-     ; obj_name
-     ; pp = _
-     ; visibility
-     ; kind
-     ; install_as = _
-     } as t) =
+let encode ({ source; obj_name; pp = _; visibility; kind; install_as = _ } as t)
+    ~src_dir =
   let open Dune_lang.Encoder in
   let has_impl = has t ~ml_kind:Impl in
   let kind =
@@ -317,18 +342,12 @@ let encode
   in
   record_fields
     [ field "obj_name" Module_name.Unique.encode obj_name
-    ; field_l "path" (fun x -> x) (Module_name.Path.encode path)
     ; field "visibility" Visibility.encode visibility
     ; field_o "kind" Kind.encode kind
-    ; field_b "impl" has_impl
-    ; field_b "intf" (has t ~ml_kind:Intf)
+    ; field_l "source" Fun.id (Source.encode ~dir:src_dir source)
     ]
 
-let module_basename n ~(ml_kind : Ml_kind.t) ~(dialect : Dialect.t) =
-  let n = Module_name.to_string n in
-  String.lowercase n ^ Dialect.extension dialect ml_kind
-
-let decode ~src_dir =
+let decode_old ~src_dir =
   let open Dune_lang.Decoder in
   fields
     (let+ obj_name = field "obj_name" Module_name.Unique.decode
@@ -354,6 +373,10 @@ let decode ~src_dir =
      in
      let file exists ml_kind =
        if exists then
+         let module_basename n ~(ml_kind : Ml_kind.t) ~(dialect : Dialect.t) =
+           let n = Module_name.to_string n in
+           String.lowercase n ^ Dialect.extension dialect ml_kind
+         in
          let basename = module_basename name ~ml_kind ~dialect:Dialect.ocaml in
          Some (File.make Dialect.ocaml (Path.relative src_dir basename))
        else None
@@ -368,6 +391,22 @@ let decode ~src_dir =
      let impl = file impl Impl in
      let source = Source.make ?impl ?intf path in
      of_source ~obj_name:(Some obj_name) ~visibility ~kind source)
+
+let decode ~src_dir =
+  let open Dune_lang.Decoder in
+  fields
+    (let+ obj_name = field "obj_name" Module_name.Unique.decode
+     and+ visibility = field "visibility" Visibility.decode
+     and+ kind = field_o "kind" Kind.decode
+     and+ source = field "source" (Source.decode ~dir:src_dir) in
+     let kind =
+       match kind with
+       | Some k -> k
+       | None when Option.is_some source.files.impl -> Impl
+       | None -> Intf_only
+     in
+     { install_as = None; source; obj_name; pp = None; kind; visibility })
+  <|> decode_old ~src_dir
 
 let pped =
   map_files ~f:(fun _kind (file : File.t) ->
@@ -423,8 +462,9 @@ module Name_map = struct
     let+ modules = repeat (enter (decode ~src_dir)) in
     Module_name.Map.of_list_map_exn ~f:(fun m -> (name m, m)) modules
 
-  let encode t =
-    Module_name.Map.to_list_map t ~f:(fun _ x -> Dune_lang.List (encode x))
+  let encode t ~src_dir =
+    Module_name.Map.to_list_map t ~f:(fun _ x ->
+        Dune_lang.List (encode ~src_dir x))
 
   let of_list_exn modules =
     List.rev_map modules ~f:(fun m -> (name m, m))

--- a/src/dune_rules/module.mli
+++ b/src/dune_rules/module.mli
@@ -95,7 +95,7 @@ module Name_map : sig
 
   val decode : src_dir:Path.t -> t Dune_lang.Decoder.t
 
-  val encode : t -> Dune_lang.t list
+  val encode : t -> src_dir:Path.t -> Dune_lang.t list
 
   val to_dyn : t -> Dyn.t
 
@@ -123,7 +123,7 @@ val sources : t -> Path.t list
 
 val visibility : t -> Visibility.t
 
-val encode : t -> Dune_lang.t list
+val encode : t -> src_dir:Path.t -> Dune_lang.t list
 
 val decode : src_dir:Path.t -> t Dune_lang.Decoder.t
 

--- a/src/dune_rules/modules.mli
+++ b/src/dune_rules/modules.mli
@@ -18,7 +18,7 @@ val lib :
   -> modules:Module.t Module_trie.t
   -> t
 
-val encode : t -> Dune_lang.t
+val encode : t -> src_dir:Path.t -> Dune_lang.t
 
 val decode : src_dir:Path.t -> t Dune_lang.Decoder.t
 

--- a/test/blackbox-tests/test-cases/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/dune-package.t/run.t
@@ -57,9 +57,17 @@
    (modules
     (wrapped
      (group
-      (alias (obj_name a) (path A) (visibility public) (kind alias) (impl))
+      (alias
+       (obj_name a)
+       (visibility public)
+       (kind alias)
+       (source (path A) (impl (path a.ml-gen))))
       (name A)
-      (modules (module (obj_name a__X) (path X) (visibility public) (impl))))
+      (modules
+       (module
+        (obj_name a__X)
+        (visibility public)
+        (source (path X) (impl (path x.ml))))))
      (wrapped true))))
   (library
    (name a.b.c)
@@ -73,10 +81,17 @@
    (modules
     (wrapped
      (group
-      (alias (obj_name c) (path C) (visibility public) (kind alias) (impl))
+      (alias
+       (obj_name c)
+       (visibility public)
+       (kind alias)
+       (source (path C) (impl (path b/c/c.ml-gen))))
       (name C)
       (modules
-       (module (obj_name c__Y) (path Y) (visibility private) (impl) (intf))))
+       (module
+        (obj_name c__Y)
+        (visibility private)
+        (source (path Y) (intf (path b/c/y.mli)) (impl (path b/c/y.ml))))))
      (wrapped true))))
   (library
    (name a.byte_only)
@@ -88,9 +103,17 @@
    (modules
     (wrapped
      (group
-      (alias (obj_name d) (path D) (visibility public) (kind alias) (impl))
+      (alias
+       (obj_name d)
+       (visibility public)
+       (kind alias)
+       (source (path D) (impl (path byte_only/d.ml-gen))))
       (name D)
-      (modules (module (obj_name d__Z) (path Z) (visibility public) (impl))))
+      (modules
+       (module
+        (obj_name d__Z)
+        (visibility public)
+        (source (path Z) (impl (path byte_only/z.ml))))))
      (wrapped true))))
 
 Build with "--store-orig-source-dir" profile

--- a/test/blackbox-tests/test-cases/github1549.t/run.t
+++ b/test/blackbox-tests/test-cases/github1549.t/run.t
@@ -34,10 +34,9 @@ Reproduction case for #1549: too many parentheses in installed .dune files
      (group
       (alias
        (obj_name simple_tests)
-       (path Simple_tests)
        (visibility public)
        (kind alias)
-       (impl))
+       (source (path Simple_tests) (impl (path simple_tests.ml-gen))))
       (name Simple_tests))
      (wrapped true)))
    (inline_tests.backend

--- a/test/blackbox-tests/test-cases/melange/basic-install.t
+++ b/test/blackbox-tests/test-cases/melange/basic-install.t
@@ -38,7 +38,11 @@ Test that we can install melange mode libraries
    (kind normal)
    (main_module_name Foo)
    (modes melange)
-   (modules (singleton (obj_name foo) (path Foo) (visibility public) (impl))))
+   (modules
+    (singleton
+     (obj_name foo)
+     (visibility public)
+     (source (path Foo) (impl (path foo.ml))))))
 
   $ dune install --prefix prefix
   Installing prefix/lib/foo/META

--- a/test/blackbox-tests/test-cases/private-package-lib/main.t
+++ b/test/blackbox-tests/test-cases/private-package-lib/main.t
@@ -87,6 +87,7 @@ We want to see mangled names in the dune-package file as well:
     (byte __private__/secret/secret.cma)
     (native __private__/secret/secret.cmxs))
    (native_archives __private__/secret/secret.a)
+     (source (path Secret) (impl (path __private__/secret/secret.ml))))))
 
 Cmi for secret library must not be visible for normal users. Hence they must be
 hidden.

--- a/test/blackbox-tests/test-cases/re-exported-deps/transitive.t/run.t
+++ b/test/blackbox-tests/test-cases/re-exported-deps/transitive.t/run.t
@@ -43,7 +43,11 @@ transitive deps expressed in the dune-package
    (requires pkg.ccc (re_export pkg.bbb))
    (main_module_name Aaa)
    (modes byte native)
-   (modules (singleton (obj_name aaa) (path Aaa) (visibility public) (impl))))
+   (modules
+    (singleton
+     (obj_name aaa)
+     (visibility public)
+     (source (path Aaa) (impl (path aaa/aaa.ml))))))
   (library
    (name pkg.bbb)
    (kind normal)
@@ -53,7 +57,11 @@ transitive deps expressed in the dune-package
    (requires (re_export pkg.ccc))
    (main_module_name Bbb)
    (modes byte native)
-   (modules (singleton (obj_name bbb) (path Bbb) (visibility public) (impl))))
+   (modules
+    (singleton
+     (obj_name bbb)
+     (visibility public)
+     (source (path Bbb) (impl (path bbb/bbb.ml))))))
   (library
    (name pkg.ccc)
    (kind normal)
@@ -62,4 +70,8 @@ transitive deps expressed in the dune-package
    (native_archives ccc/ccc$ext_lib)
    (main_module_name Ccc)
    (modes byte native)
-   (modules (singleton (obj_name ccc) (path Ccc) (visibility public) (impl))))
+   (modules
+    (singleton
+     (obj_name ccc)
+     (visibility public)
+     (source (path Ccc) (impl (path ccc/ccc.ml))))))

--- a/test/blackbox-tests/test-cases/virtual-libraries/dune-package-info.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/dune-package-info.t/run.t
@@ -46,18 +46,16 @@ Include variants and implementation information in dune-package
      (group
       (alias
        (obj_name vlib__impl__)
-       (path Vlib__impl__)
        (visibility public)
        (kind alias)
-       (impl))
+       (source (path Vlib__impl__) (impl (path impl/vlib__impl__.ml-gen))))
       (name Vlib)
       (modules
        (module
         (obj_name vlib__Vmod)
-        (path Vmod)
         (visibility public)
         (kind impl_vmodule)
-        (impl))))
+        (source (path Vmod) (impl (path impl/vmod.ml))))))
      (wrapped true))))
   (library
    (name foo.vlib)
@@ -70,16 +68,14 @@ Include variants and implementation information in dune-package
      (group
       (alias
        (obj_name vlib)
-       (path Vlib)
        (visibility public)
        (kind alias)
-       (impl))
+       (source (path Vlib) (impl (path vlib/vlib.ml-gen))))
       (name Vlib)
       (modules
        (module
         (obj_name vlib__Vmod)
-        (path Vmod)
         (visibility public)
         (kind virtual)
-        (intf))))
+        (source (path Vmod) (intf (path vlib/vmod.mli))))))
      (wrapped true))))

--- a/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/dune-package.t/run.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/vlib-default-impl/dune-package.t/run.t
@@ -43,15 +43,18 @@ Check that default implementation data is installed in the dune package file.
    (modules
     (wrapped
      (group
-      (alias (obj_name a) (path A) (visibility public) (kind alias) (impl))
+      (alias
+       (obj_name a)
+       (visibility public)
+       (kind alias)
+       (source (path A) (impl (path a.ml-gen))))
       (name A)
       (modules
        (module
         (obj_name a__X)
-        (path X)
         (visibility public)
         (kind virtual)
-        (intf))))
+        (source (path X) (intf (path x.mli))))))
      (wrapped true))))
   (library
    (name a.default-impl)
@@ -72,16 +75,16 @@ Check that default implementation data is installed in the dune package file.
      (group
       (alias
        (obj_name a__a_default__)
-       (path A__a_default__)
        (visibility public)
        (kind alias)
-       (impl))
+       (source
+        (path A__a_default__)
+        (impl (path default-impl/a__a_default__.ml-gen))))
       (name A)
       (modules
        (module
         (obj_name a__X)
-        (path X)
         (visibility public)
         (kind impl_vmodule)
-        (impl))))
+        (source (path X) (impl (path default-impl/x.ml))))))
      (wrapped true))))


### PR DESCRIPTION
When installing module sources, we would do the following:

* Flatten them all into a single directory
* Forget the original filenames (in particular, their case)

This PR saves this information when installing modules.

The information will be useful in two ways:

* Recreating the directory structure when emitting .js for melange
* Browsing installed sources will be less awkward

<!-- ps-id: c54d298b-3003-4689-9f5d-59058a377a28 -->