### PR TITLE
feature(coq): call coqdep once per theory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- coqdep is now called once per theory (#7048, @Alizter)
+
 - Add map_workspace_root dune-project stanza to allow disabling of
   mapping of workspace root to /workspace_root. (#6988, fixes #6929,
   @richardlford)

--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -114,11 +114,23 @@ let term =
               , "DuneExtraction" )
           in
           let* (_ : unit * Dep.Fact.t Dep.Map.t) =
-            let deps =
-              Dune_rules.Coq_rules.deps_of ~dir ~use_stdlib ~wrapper_name
+            let dep_map =
+              Dune_rules.Coq_rules.get_dep_map ~dir ~use_stdlib ~wrapper_name
                 coq_module
             in
-            Action_builder.run deps Eager
+            let vo_target =
+              Path.Build.set_extension ~ext:".vo"
+                (Dune_rules.Coq_module.source coq_module)
+            in
+            Action_builder.(
+              run
+                (bind dep_map ~f:(fun dep_map ->
+                     let vo_deps =
+                       Dune_rules.Coq_rules.Dep_map.find_exn dep_map
+                         (Path.build vo_target)
+                     in
+                     paths vo_deps)))
+              Eager
           in
           let* (args, _) : string list * Dep.Fact.t Dep.Map.t =
             let* args =

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -5,14 +5,15 @@ open Import
 (* (c) INRIA 2020                              *)
 (* Written by: Emilio Jesús Gallego Arias *)
 
-(** [deps_of ~dir ~use_stdlib ~wrapper_name m] produces an action builder that
-    can be run to build all dependencies of the Coq module [m]. *)
-val deps_of :
+module Dep_map : Map.S with type key := Path.t
+
+(** [get_dep_map] produces a dep map for a theory *)
+val get_dep_map :
      dir:Path.Build.t
   -> use_stdlib:bool
   -> wrapper_name:string
   -> Coq_module.t
-  -> unit Dune_engine.Action_builder.t
+  -> Path.t list Dep_map.t Dune_engine.Action_builder.t
 
 val coqdoc_directory_targets :
   dir:Path.Build.t -> Coq_stanza.Theory.t -> Loc.t Path.Build.Map.t

--- a/test/blackbox-tests/test-cases/coq/base-unsound.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/base-unsound.t/run.t
@@ -1,5 +1,4 @@
   $ dune build --display short --profile unsound --debug-dependency-path @all
-        coqdep bar.v.d
-        coqdep foo.v.d
+        coqdep basic.theory.d
           coqc foo.{glob,vo}
           coqc bar.{glob,vo}

--- a/test/blackbox-tests/test-cases/coq/base.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/base.t/run.t
@@ -1,6 +1,5 @@
   $ dune build --display short --debug-dependency-path @all
-        coqdep bar.v.d
-        coqdep foo.v.d
+        coqdep basic.theory.d
           coqc foo.{glob,vo}
           coqc bar.{glob,vo}
 

--- a/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
@@ -4,8 +4,7 @@ We check cycles are detected
      theory A in A
   -> theory B in B
   -> theory A in A
-  -> required by _build/default/A/a.v.d
-  -> required by _build/default/A/a.glob
+  -> required by _build/default/A/A.theory.d
   -> required by alias A/all
   -> required by alias default
   [1]

--- a/test/blackbox-tests/test-cases/coq/compose-installed.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed.t/run.t
@@ -12,8 +12,7 @@ TODO: Currently this is not supported so the output is garbage
                  ^
   Theory B not found
   -> required by theory A in .
-  -> required by _build/default/a.v.d
-  -> required by _build/default/a.glob
+  -> required by _build/default/A.theory.d
   -> required by alias all
   -> required by alias default
   [1]

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
@@ -1,11 +1,11 @@
   $ dune build --display short --debug-dependency-path @all
-        coqdep thy1/a.v.d
+        coqdep thy1/thy1.theory.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Gram.intf.d
       ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Simple.impl.d
-        coqdep thy2/a.v.d
+        coqdep thy2/thy2.theory.d
          coqpp src_a/gram.ml
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}

--- a/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
@@ -7,6 +7,7 @@ dependencies.
   -> theory B in B
   -> theory C in C
   -> theory A in A
+  -> required by _build/default/A/A.theory.d
   -> required by _build/default/A/a.v.d
   -> required by _build/default/A/a.vo
   -> required by _build/install/default/lib/coq/user-contrib/A/a.vo
@@ -21,6 +22,7 @@ dependencies.
   -> theory C in C
   -> theory A in A
   -> theory B in B
+  -> required by _build/default/B/B.theory.d
   -> required by _build/default/B/b.v.d
   -> required by _build/default/B/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/B/b.vo
@@ -35,6 +37,7 @@ dependencies.
   -> theory A in A
   -> theory B in B
   -> theory C in C
+  -> required by _build/default/C/C.theory.d
   -> required by _build/default/C/c.v.d
   -> required by _build/default/C/c.vo
   -> required by _build/install/default/lib/coq/user-contrib/C/c.vo

--- a/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
@@ -8,7 +8,6 @@ dependencies.
   -> theory C in C
   -> theory A in A
   -> required by _build/default/A/A.theory.d
-  -> required by _build/default/A/a.v.d
   -> required by _build/default/A/a.vo
   -> required by _build/install/default/lib/coq/user-contrib/A/a.vo
   -> required by _build/default/A/A.install
@@ -23,7 +22,6 @@ dependencies.
   -> theory A in A
   -> theory B in B
   -> required by _build/default/B/B.theory.d
-  -> required by _build/default/B/b.v.d
   -> required by _build/default/B/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/B/b.vo
   -> required by _build/default/B/B.install
@@ -38,7 +36,6 @@ dependencies.
   -> theory B in B
   -> theory C in C
   -> required by _build/default/C/C.theory.d
-  -> required by _build/default/C/c.v.d
   -> required by _build/default/C/c.vo
   -> required by _build/install/default/lib/coq/user-contrib/C/c.vo
   -> required by _build/default/C/C.install

--- a/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
@@ -9,7 +9,6 @@ dependency.
   -> required by theory B in B
   -> required by theory C in C
   -> required by _build/default/C/C.theory.d
-  -> required by _build/default/C/c.v.d
   -> required by _build/default/C/c.vo
   -> required by _build/install/default/lib/coq/user-contrib/C/c.vo
   -> required by _build/default/C/C.install

--- a/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
@@ -8,6 +8,7 @@ dependency.
   Theory A not found
   -> required by theory B in B
   -> required by theory C in C
+  -> required by _build/default/C/C.theory.d
   -> required by _build/default/C/c.v.d
   -> required by _build/default/C/c.vo
   -> required by _build/install/default/lib/coq/user-contrib/C/c.vo

--- a/test/blackbox-tests/test-cases/coq/compose-self.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-self.t/run.t
@@ -2,8 +2,7 @@ Composing a theory with itself should cause a cycle
   $ dune build
   Error: Dependency cycle between:
      theory A in A
-  -> required by _build/default/A/a.v.d
-  -> required by _build/default/A/a.glob
+  -> required by _build/default/A/A.theory.d
   -> required by alias A/all
   -> required by alias default
   [1]

--- a/test/blackbox-tests/test-cases/coq/coqdep-on-rebuild.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdep-on-rebuild.t/run.t
@@ -14,9 +14,8 @@
   > Definition doo := a.foo.
   > EOF
   $ dune build --display short --debug-dependency-path
-        coqdep a/a.v.d
-        coqdep b/b.v.d
-        coqdep b/d.v.d
+        coqdep a/a.theory.d
+        coqdep b/b.theory.d
           coqc a/Na_a.{cmi,cmxs},a/a.{glob,vo}
           coqc b/Nb_b.{cmi,cmxs},b/b.{glob,vo}
           coqc b/Nb_d.{cmi,cmxs},b/d.{glob,vo}
@@ -26,5 +25,5 @@
   > Definition zoo := 4.
   > EOF
   $ dune build --display short --debug-dependency-path
-        coqdep b/b.v.d
+        coqdep b/b.theory.d
           coqc b/Nb_b.{cmi,cmxs},b/b.{glob,vo}

--- a/test/blackbox-tests/test-cases/coq/coqdoc-multi-theory.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-multi-theory.t/run.t
@@ -20,6 +20,7 @@ Next we build the doc for the second theory
   $ dune build @B/doc
 Check that the first theory doc is not built
   $ ls _build/default/A/
+  A.theory.d
   AA
   AB
 Check that the second theory doc is built
@@ -52,6 +53,7 @@ Next we build the doc for the second theory
   $ dune build @B/doc-latex
 Check that the first theory doc is not built
   $ ls _build/default/A
+  A.theory.d
   AA
   AB
 Check that the second theory doc is built

--- a/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
@@ -7,7 +7,6 @@ Testing coqdoc when composed with a boot library
   A.theory.d
   a.glob
   a.v
-  a.v.d
   a.vo
   a.vok
   a.vos

--- a/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
@@ -4,6 +4,7 @@ Testing coqdoc when composed with a boot library
 
   $ ls _build/default/A
   A.html
+  A.theory.d
   a.glob
   a.v
   a.v.d

--- a/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
@@ -26,7 +26,6 @@ Note that this currently works due to a bug in @all detecting directory targets.
   META.base
   bar.glob
   bar.v
-  bar.v.d
   bar.vo
   bar.vok
   bar.vos
@@ -35,7 +34,6 @@ Note that this currently works due to a bug in @all detecting directory targets.
   basic.theory.d
   foo.glob
   foo.v
-  foo.v.d
   foo.vo
   foo.vok
   foo.vos

--- a/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
@@ -32,6 +32,7 @@ Note that this currently works due to a bug in @all detecting directory targets.
   bar.vos
   base.dune-package
   base.install
+  basic.theory.d
   foo.glob
   foo.v
   foo.v.d

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
@@ -19,8 +19,7 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
   > (using coq 0.3)
   > EOF
   $ dune coq top --display short --toplevel echo dir/bar.v
-        coqdep dir/bar.v.d
-        coqdep dir/foo.v.d
+        coqdep dir/basic.theory.d
           coqc dir/foo.{glob,vo}
   -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic
   $ dune coq top --display short --toplevel echo dir/bar.v
@@ -28,8 +27,7 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
   $ dune clean
   $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v)
   Entering directory '..'
-        coqdep dir/bar.v.d
-        coqdep dir/foo.v.d
+        coqdep dir/basic.theory.d
           coqc dir/foo.{glob,vo}
   Leaving directory '..'
   -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic

--- a/test/blackbox-tests/test-cases/coq/extract.t
+++ b/test/blackbox-tests/test-cases/coq/extract.t
@@ -38,11 +38,11 @@
   $ ls _build/default
   Datatypes.ml
   Datatypes.mli
+  DuneExtraction.theory.d
   extract.glob
   extract.ml
   extract.mli
   extract.v
-  extract.v.d
   extract.vo
   extract.vok
   extract.vos

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
@@ -1,5 +1,5 @@
   $ dune build --display short --debug-dependency-path @all
-        coqdep theories/a.v.d
+        coqdep theories/Plugin.theory.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
@@ -1,7 +1,6 @@
   $ dune build --profile=release --display short --debug-dependency-path @all
-        coqdep bar/bar.v.d
-        coqdep foo/foo.v.d
-        coqdep foo/a/a.v.d
+        coqdep bar/bar.theory.d
+        coqdep foo/foo.theory.d
           coqc foo/Nfoo_foo.{cmi,cmxs},foo/foo.{glob,vo}
           coqc foo/a/Nfoo_a_a.{cmi,cmxs},foo/a/a.{glob,vo}
           coqc bar/Nbar_baz_bar.{cmi,cmxs},bar/bar.{glob,vo}

--- a/test/blackbox-tests/test-cases/coq/native-single.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/run.t
@@ -1,6 +1,5 @@
   $ dune build --profile=release --display short --debug-dependency-path @all
-        coqdep bar.v.d
-        coqdep foo.v.d
+        coqdep basic.theory.d
           coqc Nbasic_foo.{cmi,cmxs},foo.{glob,vo}
           coqc Nbasic_bar.{cmi,cmxs},bar.{glob,vo}
 

--- a/test/blackbox-tests/test-cases/coq/no-stdlib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/no-stdlib.t/run.t
@@ -2,7 +2,7 @@ Test that when `(stdlib no)` is provided, the standard library is not bound to `
 and the prelude is not imported
 
   $ dune build --display=short foo.vo
-        coqdep foo.v.d
+        coqdep basic.theory.d
   *** Warning: in file foo.v, library Prelude is required from root Coq and has not been found in the loadpath!
           coqc foo.{glob,vo} (exit 1)
   File "./foo.v", line 1, characters 0-32:
@@ -12,7 +12,6 @@ and the prelude is not imported
   [1]
 
   $ dune build --display=short bar.vo
-        coqdep bar.v.d
           coqc bar.{glob,vo} (exit 1)
   File "./bar.v", line 1, characters 20-23:
   Error: The reference nat was not found in the current environment.

--- a/test/blackbox-tests/test-cases/coq/plugin-meta.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/plugin-meta.t/run.t
@@ -9,7 +9,7 @@ The META file for plugins is built before calling coqdep
   >  (plugins bar.foo))
   > EOF
 
-  $ dune build bar.v.d
+  $ dune build bar.theory.d
   $ ls _build/install/default/lib/bar
   META
 

--- a/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
@@ -6,7 +6,6 @@
   You need to associate "private" to a package.
   -> required by theory public in public
   -> required by _build/default/public/public.theory.d
-  -> required by _build/default/public/b.v.d
   -> required by _build/default/public/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/public/b.vo
   -> required by _build/default/public.install

--- a/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
@@ -5,6 +5,7 @@
   Theory "private" is private, it cannot be a dependency of a public theory.
   You need to associate "private" to a package.
   -> required by theory public in public
+  -> required by _build/default/public/public.theory.d
   -> required by _build/default/public/b.v.d
   -> required by _build/default/public/b.vo
   -> required by _build/install/default/lib/coq/user-contrib/public/b.vo

--- a/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
@@ -1,8 +1,5 @@
   $ dune build --display short --debug-dependency-path @all
-        coqdep a/bar.v.d
-        coqdep b/foo.v.d
-        coqdep c/d/bar.v.d
-        coqdep c/ooo.v.d
+        coqdep rec_module.theory.d
           coqc b/foo.{glob,vo}
           coqc c/d/bar.{glob,vo}
           coqc c/ooo.{glob,vo}


### PR DESCRIPTION
We now call coqdep once per theory. Each theory produces a `mytheory.theory.d` file which is then further interpreted into an internal dependency map.

This is joint work with @ejgallego.

TODO:
- [x] Measure performance (in coq-universe)
  + https://github.com/ejgallego/coq-universe/pull/32 
  + It appears in total ~5min of coqdep calls are saved.
- [x] Cleanup parts of code
- [ ] Documentation
- [x] Changelog