### PR TITLE
feature(coq): enable -color on for coqc in supported environments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Dune now passes `-color on`to coqc allowing for output to be colored when
+  supported. (#7052, @Alizter)
+
 - Add map_workspace_root dune-project stanza to allow disabling of
   mapping of workspace root to /workspace_root. (#6988, fixes #6929,
   @richardlford)

--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -372,10 +372,16 @@ let generic_coq_args ~sctx ~dir ~wrapper_name ~boot_type ~mode ~coq_prog
   let file_flags =
     coqc_file_flags ~dir ~theories_deps ~wrapper_name ~boot_type ~ml_flags
   in
+  let color_flags =
+    if Lazy.force Ansi_color.stderr_supports_color then
+      Command.Args.As [ "-color"; "on" ]
+    else Command.Args.empty
+  in
   match coq_prog with
   | `Coqc ->
     [ coq_stanza_flags
     ; coq_native_flags
+    ; color_flags
     ; S file_flags
     ; Dep (Path.build (Coq_module.source coq_module))
     ]


### PR DESCRIPTION
We use Dune's console color detection to decide whether or not to pass `-color on` to coqc.

I have tested this myself and it works.

<s>Since this is a strict quality of life improvement, would you consider it for 3.7 @emillon?</s>

SkySkimmer pointed out that `-color` in the args will invalidate the digest of the command meaning rebuilds when switching from non-color-supported terminals. OCaml appears to deal with this issue by using environment variables, however I am uncertain if we have such variables in Coq.

I will therefore suggest not including this in 3.7.

- [x] Changelog