### PR TITLE
feature(coq): change where coqc is resolved

### DIFF
--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -387,7 +387,7 @@ let setup_coqc_rule ~loc ~dir ~sctx ~coqc_dir ~file_targets ~stanza_flags
   (* Process coqdep and generate rules *)
   let* boot_type = boot_type ~dir ~use_stdlib ~wrapper_name coq_module in
   let deps_of = deps_of ~dir ~use_stdlib ~wrapper_name coq_module in
-  let* coqc = coqc ~loc ~dir ~sctx in
+  let* coqc = coqc ~loc ~dir:coqc_dir ~sctx in
   let target_obj_files =
     Command.Args.Hidden_targets
       (Coq_module.obj_files ~wrapper_name ~mode ~obj_files_mode:Coq_module.Build


### PR DESCRIPTION
Another attempt at #6005 #6006

The coqc calls now look like this:
```
prefix$ (cd _build/default && /nix/store/z9xbac8b8zqa0rni8pkiha5qxv00igff-ocaml-base-compiler-4.14.0/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -49 -nopervasives -nostdlib -g -bin-annot -I .c.objs/byte -no-alias-deps -opaque -o .c.objs/byte/c.cmo -c -impl c.ml-gen)
  prefix$ (cd _build/default/A && /nix/store/x4k9020dvlpw1g41rsrqmsd0isxd248q-coq-8.16.1/bin/coqdep -R . A -dyndep opt a.v) > _build/default/A/a.v.d
  prefix$ (cd _build/default/B && /nix/store/x4k9020dvlpw1g41rsrqmsd0isxd248q-coq-8.16.1/bin/coqdep -Q ../A A -R . B -dyndep opt b.v) > _build/default/B/b.v.d
  prefix$ (cd _build/default && /nix/store/z9xbac8b8zqa0rni8pkiha5qxv00igff-ocaml-base-compiler-4.14.0/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -49 -nopervasives -nostdlib -g -I .c.objs/byte -I .c.objs/native -intf-suffix .ml-gen -no-alias-deps -opaque -o .c.objs/native/c.cmx -c -impl c.ml-gen)
  prefix$ (cd _build/default && /nix/store/z9xbac8b8zqa0rni8pkiha5qxv00igff-ocaml-base-compiler-4.14.0/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -a -o c.cma .c.objs/byte/c.cmo)
  prefix$ (cd _build/default && /nix/store/x4k9020dvlpw1g41rsrqmsd0isxd248q-coq-8.16.1/bin/coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R A A A/a.v)
  prefix$ (cd _build/default && /nix/store/z9xbac8b8zqa0rni8pkiha5qxv00igff-ocaml-base-compiler-4.14.0/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -a -o c.cmxa .c.objs/native/c.cmx)
  prefix$ (cd _build/default && /nix/store/x4k9020dvlpw1g41rsrqmsd0isxd248q-coq-8.16.1/bin/coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -Q A A -R B B B/b.v)
  ```

This is closer to how ocamlc does it. I am not claiming things are reproducible however, since in the ocamlc situation, there is a use of `BUILD_PATH_PREFIX_MAP` which is detailed here: https://reproducible-builds.org/specs/build-path-prefix-map/. We could in theory do something similar for Coq.

Coqdep calls are not changed, but that is ok since it is a cheap call and won't affect the cache of coqc.

<s>The removal of the cd should improve sharing of the cache.</s>

cc @Blaisorblade 