### PR TITLE
[coq] Hide implementation of dependency maps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 Unreleased
 ----------
 
-- coqdep is now called once per theory (#7048, @Alizter)
+- `coqdep` is now called once per theory, instead of one time per Coq
+  file. This should significantly speed up some builds, as `coqdep`
+  startup time is often heavy (#7048, @Alizter, @ejgallego)
 
 - Add map_workspace_root dune-project stanza to allow disabling of
   mapping of workspace root to /workspace_root. (#6988, fixes #6929,

--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -114,23 +114,11 @@ let term =
               , "DuneExtraction" )
           in
           let* (_ : unit * Dep.Fact.t Dep.Map.t) =
-            let dep_map =
-              Dune_rules.Coq_rules.get_dep_map ~dir ~use_stdlib ~wrapper_name
+            let deps_of =
+              Dune_rules.Coq_rules.deps_of ~dir ~use_stdlib ~wrapper_name
                 coq_module
             in
-            let vo_target =
-              Path.Build.set_extension ~ext:".vo"
-                (Dune_rules.Coq_module.source coq_module)
-            in
-            Action_builder.(
-              run
-                (bind dep_map ~f:(fun dep_map ->
-                     let vo_deps =
-                       Dune_rules.Coq_rules.Dep_map.find_exn dep_map
-                         (Path.build vo_target)
-                     in
-                     paths vo_deps)))
-              Eager
+            Action_builder.(run deps_of) Eager
           in
           let* (args, _) : string list * Dep.Fact.t Dep.Map.t =
             let* args =

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -5,15 +5,14 @@ open Import
 (* (c) INRIA 2020                              *)
 (* Written by: Emilio Jesús Gallego Arias *)
 
-module Dep_map : Map.S with type key := Path.t
-
-(** [get_dep_map] produces a dep map for a theory *)
-val get_dep_map :
+(** [deps_of ~dir ~use_stdlib ~wrapper_name coq_module] action that builds the
+    deps of [coq_module] *)
+val deps_of :
      dir:Path.Build.t
   -> use_stdlib:bool
   -> wrapper_name:string
   -> Coq_module.t
-  -> Path.t list Dep_map.t Dune_engine.Action_builder.t
+  -> unit Dune_engine.Action_builder.t
 
 val coqdoc_directory_targets :
   dir:Path.Build.t -> Coq_stanza.Theory.t -> Loc.t Path.Build.Map.t


### PR DESCRIPTION
This allow us to share the error codepath, plus provides a much cleaner setup IMO.