### PR TITLE
test(coq): add test for empty modules field

### DIFF
--- a/test/blackbox-tests/test-cases/coq/empty-modules.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/empty-modules.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.7)
+(using coq 0.7)

--- a/test/blackbox-tests/test-cases/coq/empty-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/empty-modules.t/run.t
@@ -1,0 +1,12 @@
+We test that the empty modules field in a coq.theory stanza is handled
+correctly.
+
+  $ cat > dune << EOF
+  > (coq.theory
+  >  (name foo)
+  >  (modules))
+  > EOF
+
+Currently raises an internal excpetion.
+  $ dune build 2>&1 | head -n 1
+  Error: exception Failure("hd")


### PR DESCRIPTION
Currently raises an internal error.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 321899da-3c3c-4be4-9b2f-3c5afe19b4ca -->