### PR TITLE
[coq] [coqdep] Better error handling, inject prelude dep in post-process

### DIFF
--- a/test/blackbox-tests/test-cases/coq/empty-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/empty-modules.t/run.t
@@ -7,6 +7,5 @@ correctly.
   >  (modules))
   > EOF
 
-Currently raises an internal excpetion.
-  $ dune build 2>&1 | head -n 1
-  Error: exception Failure("hd")
+Builds fine as expected.
+  $ dune build 2>&1


### PR DESCRIPTION
Some further tweaks, in particular we handle errors better, and inject
the prelude dependency at module dep time, instead of when building
the dep map, which is the wrong phase.

This will allow us to not to need boot_type to call coqdep when
`-boot` becomes the default in the installed_theories PR.
