### PR TITLE
fix(melange): installed libraries path

### DIFF
--- a/test/blackbox-tests/test-cases/melange/emit-installed.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed.t
@@ -63,7 +63,7 @@ Test dependency on installed package
   Entering directory 'b'
           melc dist/node_modules/a/a.js
           melc dist/node_modules/a/foo.js
-          melc dist/node_modules/a/sub.js
+          melc dist/node_modules/a/sub/sub.js
           melc .dist.mobjs/melange/melange__Bar.{cmi,cmj,cmt}
           melc dist/bar.js
   Leaving directory 'b'
@@ -75,6 +75,7 @@ Test dependency on installed package
   b/_build/default/dist/node_modules/a
   b/_build/default/dist/node_modules/a/a.js
   b/_build/default/dist/node_modules/a/foo.js
-  b/_build/default/dist/node_modules/a/sub.js
+  b/_build/default/dist/node_modules/a/sub
+  b/_build/default/dist/node_modules/a/sub/sub.js
   $ node b/_build/default/dist/bar.js
   foo


### PR DESCRIPTION
Preserve .js paths of melange artifacts upto the source directory of the
library

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 8f5ad532-672d-440d-9730-0a0fff09767f -->