### PR TITLE
refactor(rules): explicit import list

### DIFF
--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -8,7 +8,49 @@ module Persistent = Persistent
 module Stringlike = Stringlike
 module Stringlike_intf = Stringlike_intf
 module Value = Value
-include Dune_engine
+
+include struct
+  open Dune_engine
+  module Dir_set = Dir_set
+  module Rule = Rule
+  module Rules = Rules
+  module Action_builder = Action_builder
+  module Source_tree = Source_tree
+  module Dialect = Dialect
+  module Dune_project = Dune_project
+  module Build_system = Build_system
+  module Context_name = Context_name
+  module Package = Package
+  module Dpath = Dpath
+  module Alias = Alias
+  module Section = Section
+  module Opam_file = Opam_file
+  module File_selector = File_selector
+  module Dep = Dep
+  module Build_config = Build_config
+  module Fs_memo = Fs_memo
+  module Sandbox_config = Sandbox_config
+  module Sandbox_mode = Sandbox_mode
+  module Action = Action
+  module Compound_user_error = Compound_user_error
+  module Fs_cache = Fs_cache
+  module Format_config = Format_config
+  module Process = Process
+  module Execution_parameters = Execution_parameters
+  module Build_context = Build_context
+  module Targets = Targets
+  module Utils = Utils
+  module Sub_dirs = Sub_dirs
+  module Subst_config = Subst_config
+  module Clflags = Clflags
+  module Load_rules = Load_rules
+  module Subdir_set = Subdir_set
+  module Include_stanza = Include_stanza
+  module Cram_test = Cram_test
+  module Vcs = Vcs
+  module Response_file = Response_file
+end
+
 include Ocaml
 module Re = Dune_re
 module Stanza = Dune_lang.Stanza


### PR DESCRIPTION
Use explicit import list from engine.

There's some modules we don't use in the rules so there's no need to
bring them in scope.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cd147b77-76aa-47af-ba56-37e9f7a513b7 -->