### PR TITLE
refactor: remove no_print_directory from global flags

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1023,7 +1023,6 @@ let init ?log_file c =
   Clflags.diff_command := c.builder.diff_command;
   Clflags.promote := c.builder.promote;
   Clflags.force := c.builder.force;
-  Clflags.no_print_directory := c.builder.no_print_directory;
   Clflags.store_orig_src_dir := c.builder.store_orig_src_dir;
   Clflags.promote_install_files := c.builder.promote_install_files;
   Clflags.always_show_command_line := c.builder.always_show_command_line;

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -28,8 +28,6 @@ let promote = ref None
 
 let force = ref false
 
-let no_print_directory = ref false
-
 let store_orig_src_dir = ref false
 
 let always_show_command_line = ref false

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -39,9 +39,6 @@ val promote : Promote.t option ref
 (** Force re-running actions associated to aliases *)
 val force : bool ref
 
-(** Do not print "Entering directory" messages *)
-val no_print_directory : bool ref
-
 (** Store original source directory in dune-package metadata *)
 val store_orig_src_dir : bool ref
 


### PR DESCRIPTION
it's only used in one place so it doesn't need to be global

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d9befd76-67d2-4705-b333-2a66120a472e -->