### PR TITLE
refactor: move some flags to rules (#7080

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1014,7 +1014,8 @@ let init ?log_file c =
   Dune_util.Report_error.print_memo_stacks := c.builder.debug_dep_path;
   Clflags.report_errors_config := c.builder.report_errors_config;
   Clflags.debug_backtraces c.builder.debug_backtraces;
-  Clflags.debug_artifact_substitution := c.builder.debug_artifact_substitution;
+  Dune_rules.Clflags.debug_artifact_substitution :=
+    c.builder.debug_artifact_substitution;
   Clflags.debug_load_dir := c.builder.debug_load_dir;
   Clflags.debug_digests := c.builder.debug_digests;
   Clflags.debug_fs_cache := c.builder.cache_debug_flags.fs_cache;
@@ -1023,10 +1024,10 @@ let init ?log_file c =
   Clflags.diff_command := c.builder.diff_command;
   Clflags.promote := c.builder.promote;
   Clflags.force := c.builder.force;
-  Clflags.store_orig_src_dir := c.builder.store_orig_src_dir;
-  Clflags.promote_install_files := c.builder.promote_install_files;
+  Dune_rules.Clflags.store_orig_src_dir := c.builder.store_orig_src_dir;
+  Dune_rules.Clflags.promote_install_files := c.builder.promote_install_files;
   Clflags.always_show_command_line := c.builder.always_show_command_line;
-  Clflags.ignore_promoted_rules := c.builder.ignore_promoted_rules;
+  Dune_rules.Clflags.ignore_promoted_rules := c.builder.ignore_promoted_rules;
   Clflags.on_missing_dune_project_file :=
     if c.builder.require_dune_project_file then Error else Warn;
   Dune_util.Log.info

--- a/src/dune_engine/clflags.ml
+++ b/src/dune_engine/clflags.ml
@@ -6,8 +6,6 @@ end
 
 let report_errors_config = ref Report_errors_config.default
 
-let debug_artifact_substitution = ref false
-
 let debug_digests = ref false
 
 let debug_fs_cache = ref false
@@ -28,13 +26,7 @@ let promote = ref None
 
 let force = ref false
 
-let store_orig_src_dir = ref false
-
 let always_show_command_line = ref false
-
-let promote_install_files = ref false
-
-let ignore_promoted_rules = ref false
 
 type on_missing_dune_project_file =
   | Error

--- a/src/dune_engine/clflags.mli
+++ b/src/dune_engine/clflags.mli
@@ -8,9 +8,6 @@ val capture_outputs : bool ref
 (** Always print backtraces, to help debugging dune itself *)
 val debug_backtraces : bool -> unit
 
-(** Print debug info about artifact substitution *)
-val debug_artifact_substitution : bool ref
-
 (** Print debug info for cached digests *)
 val debug_digests : bool ref
 
@@ -39,17 +36,8 @@ val promote : Promote.t option ref
 (** Force re-running actions associated to aliases *)
 val force : bool ref
 
-(** Store original source directory in dune-package metadata *)
-val store_orig_src_dir : bool ref
-
 (** Always show full command on error *)
 val always_show_command_line : bool ref
-
-(** Promote the generated [<package>.install] files to the source tree *)
-val promote_install_files : bool ref
-
-(** Whether we are ignoring rules with [(mode promote)] *)
-val ignore_promoted_rules : bool ref
 
 type on_missing_dune_project_file =
   | Error

--- a/src/dune_rules/clflags.ml
+++ b/src/dune_rules/clflags.ml
@@ -1,0 +1,11 @@
+let store_orig_src_dir = ref false
+
+let ignore_promoted_rules = ref false
+
+let promote_install_files = ref false
+
+let display = Dune_engine.Clflags.display
+
+let capture_outputs = Dune_engine.Clflags.capture_outputs
+
+let debug_artifact_substitution = ref false

--- a/src/dune_rules/clflags.mli
+++ b/src/dune_rules/clflags.mli
@@ -1,0 +1,17 @@
+(** Store original source directory in dune-package metadata *)
+val store_orig_src_dir : bool ref
+
+(** Whether we are ignoring rules with [(mode promote)] *)
+val ignore_promoted_rules : bool ref
+
+(** Promote the generated [<package>.install] files to the source tree *)
+val promote_install_files : bool ref
+
+(** Re-exported form [Dune_engine] *)
+val display : Dune_engine.Display.t ref
+
+(** Re-exported form [Dune_engine] *)
+val capture_outputs : bool ref
+
+(** Print debug info about artifact substitution *)
+val debug_artifact_substitution : bool ref

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -52,6 +52,7 @@ module Command = Command
 module Install = Install
 module Lib_name = Lib_name
 module Diff = Dune_lang.Action.Diff
+module Clflags = Clflags
 
 module Install_rules = struct
   let install_file = Install_rules.install_file

--- a/src/dune_rules/import.ml
+++ b/src/dune_rules/import.ml
@@ -42,7 +42,6 @@ include struct
   module Utils = Utils
   module Sub_dirs = Sub_dirs
   module Subst_config = Subst_config
-  module Clflags = Clflags
   module Load_rules = Load_rules
   module Subdir_set = Subdir_set
   module Include_stanza = Include_stanza


### PR DESCRIPTION
Some flags are only used in the rules, so they should live there instead
of the engine.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: fe52918f-e2c6-463a-a074-9d79f60c6896 -->