### PR TITLE
refactor: replace (fun x -> x)

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -456,7 +456,7 @@ let cache_debug_flags_term : Cache_debug_flags.t Term.t =
     ; ("fs", fun r -> { r with Cache_debug_flags.fs_cache = true })
     ]
   in
-  let no_layers = ([], fun x -> x) in
+  let no_layers = ([], Fun.id) in
   let combine_layers =
     List.fold_right ~init:no_layers
       ~f:(fun (names, value) (acc_names, acc_value) ->

--- a/bin/describe.ml
+++ b/bin/describe.ml
@@ -688,7 +688,7 @@ module External_lib_deps = struct
                     |> Memo.parallel_map ~f:(fun name ->
                            let name = Lib_name.of_string name in
                            external_resolve db name Kind.Optional)
-                    >>| List.filter_map ~f:(fun x -> x))
+                    >>| List.filter_opt)
              >>| List.concat)
     >>| List.concat
 

--- a/otherlibs/stdune/src/list.ml
+++ b/otherlibs/stdune/src/list.ml
@@ -22,7 +22,7 @@ let filter_map l ~f =
   in
   loop [] l
 
-let filter_opt l = filter_map ~f:(fun x -> x) l
+let filter_opt l = filter_map ~f:Fun.id l
 
 let filteri l ~f =
   let rec filteri l i =

--- a/otherlibs/stdune/src/set.ml
+++ b/otherlibs/stdune/src/set.ml
@@ -52,7 +52,7 @@ module Make (Key : Map_intf.Key) (M : Map_intf.S with type key = Key.t) = struct
         let s = f x in
         union acc s)
 
-  let union_all l = union_map l ~f:(fun x -> x)
+  let union_all l = union_map l ~f:Fun.id
 
   exception Found of elt
 
@@ -165,7 +165,7 @@ struct
         let s = f x in
         union acc s)
 
-  let union_all l = union_map l ~f:(fun x -> x)
+  let union_all l = union_map l ~f:Fun.id
 
   exception Found of elt
 

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -105,8 +105,7 @@ let build_mlds_map stanzas ~dir ~files =
       let+ mlds =
         let+ mlds = Memo.Lazy.force mlds in
         Ordered_set_lang.Unordered_string.eval doc.mld_files ~standard:mlds
-          ~key:(fun x -> x)
-          ~parse:(fun ~loc s ->
+          ~key:Fun.id ~parse:(fun ~loc s ->
             match String.Map.find mlds s with
             | Some s -> s
             | None ->

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -79,7 +79,7 @@ end = struct
 
   let check_no_requires path str =
     List.iteri (String.split str ~on:'\n') ~f:(fun n line ->
-        match Scanf.sscanf line "#require %S" (fun x -> x) with
+        match Scanf.sscanf line "#require %S" Fun.id with
         | Error () -> ()
         | Ok (_ : string) ->
           let loc : Loc.t =

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -682,7 +682,7 @@ let traverse l ~f ctx state =
     (List.fold_map ~init:state l ~f:(fun state x ->
          Tuple.T2.swap (f x ctx state)))
 
-let all = traverse ~f:(fun x -> x)
+let all = traverse ~f:Fun.id
 
 let fields_missing_need_exactly_one loc names =
   User_error.raise ~loc

--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -86,7 +86,7 @@ let%expect_test _ =
 let print_deps memo input =
   let open Dyn in
   Memo.For_tests.get_deps memo input
-  |> option (list (pair (option string) (fun x -> x)))
+  |> option (list (pair (option string) Fun.id))
   |> print_dyn
 
 let%expect_test _ =
@@ -156,11 +156,9 @@ let%expect_test _ =
     !stack
     |> List.map ~f:(fun st ->
            let open Dyn in
-           pair (option string)
-             (fun x -> x)
+           pair (option string) Fun.id
              (Memo.Stack_frame.name st, Memo.Stack_frame.input st))
-    |> Dyn.list (fun x -> x)
-    |> print_dyn;
+    |> Dyn.list Fun.id |> print_dyn;
     [%expect
       {|
       - 2
@@ -260,7 +258,7 @@ struct
 
   let deps () =
     let open Dyn in
-    let conv = option (list (pair (option string) (fun x -> x))) in
+    let conv = option (list (pair (option string) Fun.id)) in
     pair conv conv
       ( Memo.For_tests.get_deps f1_def "foo"
       , Memo.For_tests.get_deps f2_def "foo" )


### PR DESCRIPTION
Replace it with [Fun.id] from the [Stdlib]

Also replace [List.filter_map] and [List.filter_opt] when [~f] is
[Fun.id]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: be1338e9-d2b7-4d03-a949-4f6ba3d1e529 -->