### PR TITLE
test: virtual libraries bug

### DIFF
--- a/test/blackbox-tests/test-cases/virtual-libraries/incorrect-archive-7027.t
+++ b/test/blackbox-tests/test-cases/virtual-libraries/incorrect-archive-7027.t
@@ -1,0 +1,53 @@
+Reproduce a bug where an implementation's module archive isn't correctly
+constructed. A virtual module's implementation can be excluded from the
+archive.
+
+https://github.com/ocaml/dune/issues/7027
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+  $ mkdir vlib
+  $ cat >vlib/dune <<EOF
+  > (library
+  >  (name vlib)
+  >  (wrapped false)
+  >  (virtual_modules x))
+  > EOF
+  $ cat >vlib/a.ml <<EOF
+  > let f = X.make ()
+  > EOF
+  $ cat >vlib/x.mli <<EOF
+  > type t
+  > val make : unit -> t
+  > EOF
+
+  $ mkdir impl
+  $ cat >impl/dune <<EOF
+  > (library
+  >  (name impl)
+  >  (implements vlib))
+  > EOF
+  $ cat >impl/x.ml <<EOF
+  > type t = unit
+  > let make () = ()
+  > EOF
+  $ cat >impl/z.ml <<EOF
+  > let g = A.f
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (modes byte)
+  >  (name foo)
+  >  (libraries impl))
+  > EOF
+
+  $ cat >foo.ml <<EOF
+  > let _ = X.make ()
+  > EOF
+
+  $ dune exec ./foo.exe
+  File "_none_", line 1:
+  Error: Module `X' is unavailable (required by `Dune__exe__Foo')
+  [1]


### PR DESCRIPTION
reproduce a bug where an implementation of a virtual library sometimes
doesn't include the virtual module's implementation

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c5f64294-39f3-47f0-aa39-2c9b5a909ac6 -->