### PR TITLE
refactor: move rule printing (#7101

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -119,7 +119,7 @@ let term =
           let* request =
             match targets with
             | [] ->
-              Load_rules.all_direct_targets None
+              Target.all_direct_targets None
               >>| Path.Build.Map.foldi ~init:[] ~f:(fun p _ acc ->
                       Path.build p :: acc)
               >>| Action_builder.paths

--- a/bin/target.mli
+++ b/bin/target.mli
@@ -1,5 +1,17 @@
 open! Stdune
 
+type target_type =
+  | File
+  | Directory
+
+(** List of all buildable direct targets. This does not include files and
+    directories produced under a directory target.
+
+    If argument is [None], load the root, otherwise only load targets from the
+    nearest subdirectory. *)
+val all_direct_targets :
+  Path.Source.t option -> target_type Path.Build.Map.t Memo.t
+
 val interpret_targets :
      Workspace_root.t
   -> Dune_config.t

--- a/src/dune_engine/load_rules.mli
+++ b/src/dune_engine/load_rules.mli
@@ -68,14 +68,6 @@ val is_target : Path.t -> is_target Memo.t
     opportunities for creating computation cycles. *)
 val is_under_directory_target : Path.t -> bool Memo.t
 
-(** List of all buildable direct targets. This does not include files and
-    directories produced under a directory target.
-
-    If argument is [None], load the root, otherwise only load targets from the
-    nearest subdirectory. *)
-val all_direct_targets :
-  Path.Source.t option -> target_type Path.Build.Map.t Memo.t
-
 type rule_or_source =
   | Source of Digest.t
   | Rule of Path.Build.t * Rule.t


### PR DESCRIPTION
Rule printing is only needed for a single sub command (dune rules).
Therefore, traversing the rules can done directly in the cli instead of
the engine.

This removes a source tree traversal from the engine and reduces the
dependency between the engine and the source tree.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 41474e1f-c4a2-4f22-9d10-ed73823d7fdc -->