### PR TITLE
refactor: remove [Rule.find_source_dir] (#7103

### DIFF
--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -119,10 +119,6 @@ let set_action t action =
   let action = Action_builder.memoize "Rule.set_action" action in
   { t with action }
 
-let find_source_dir rule =
-  let _, src_dir = Path.Build.extract_build_context_dir_exn rule.dir in
-  Source_tree.nearest_dir src_dir
-
 module Anonymous_action = struct
   type t =
     { context : Build_context.t option

--- a/src/dune_engine/rule.mli
+++ b/src/dune_engine/rule.mli
@@ -87,11 +87,6 @@ val set_action : t -> Action.Full.t Action_builder.t -> t
 
 val loc : t -> Loc.t
 
-(** [find_source_dir rule] is the closest source directory corresponding to
-    rule.dir. Eg. [src/dune] for a rule with dir
-    [_build/default/src/dune/.dune.objs]. *)
-val find_source_dir : t -> Source_tree.Dir.t Memo.t
-
 module Anonymous_action : sig
   (* jeremiedimino: this type correspond to a subset of [Rule.t]. We should
      eventually share the code. *)


### PR DESCRIPTION
It's not used anywhere and it depends on [Source_tree.nearest_dir]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cb433677-6b2f-4860-860c-7dc0c2994b7a -->