### PR TITLE
fix(mdx): record runtime dependency to prelude

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+- Fix preludes not being recorded as dependencies in the `(mdx)` stanza (#7109,
+  fixes #7077, @emillon).
+
 3.7.0 (2023-02-17)
 ------------------
 

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -145,13 +145,20 @@ module Prelude = struct
     in
     enter decode_env <|> decode_default
 
-  let to_args ~dir t : _ Command.Args.t list =
-    let bpath p = Path.build (Path.Build.append_local dir p) in
+  (** Generated program will read some files when it runs. *)
+  let runtime_deps ~dir t : _ Command.Args.t =
     match t with
-    | Default file -> [ A "--prelude"; Dep (bpath file) ]
+    | Default file | Env { env = _; file } ->
+      Hidden_deps
+        (Dep.Set.of_files [ Path.build (Path.Build.append_local dir file) ])
+
+  let to_args ~dir t : _ Command.Args.t list =
+    match t with
+    | Default file ->
+      [ A "--prelude"; Dep (Path.build (Path.Build.append_local dir file)) ]
     | Env { env; file } ->
       let arg = sprintf "%s:%s" env (Path.Local.to_string file) in
-      [ A "--prelude"; A arg; Hidden_deps (Dep.Set.of_files [ bpath file ]) ]
+      [ A "--prelude"; A arg; runtime_deps ~dir t ]
 end
 
 type t =
@@ -317,7 +324,11 @@ let gen_rules_for_single_file stanza ~sctx ~dir ~expander ~mdx_prog
            generated executable *)
         let open Command.Args in
         match mdx_prog_gen with
-        | Some prog -> (Ok (Path.build prog), [ Dep (Path.build files.src) ])
+        | Some prog ->
+          ( Ok (Path.build prog)
+          , [ Dep (Path.build files.src)
+            ; S (List.map ~f:(Prelude.runtime_deps ~dir) stanza.preludes)
+            ] )
         | None ->
           let prelude_args =
             List.concat_map stanza.preludes ~f:(Prelude.to_args ~dir)

--- a/test/blackbox-tests/test-cases/mdx-stanza/github7077.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/github7077.t
@@ -1,0 +1,39 @@
+When mdx is used to generate a program, the program will read the preludes at
+run time. This test makes sure that this is recorded as a dependency.
+
+  $ cat > dune << EOF
+  > (mdx (preludes prelude.ml))
+  > EOF
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.6)
+  > (using mdx 0.3)
+  > EOF
+
+  $ cat > prelude.ml << EOF
+  > let foo () = 1
+  > EOF
+
+  $ cat > README.md << 'EOF'
+  > ```ocaml
+  > # foo ();;
+  > - : int = 1
+  > ```
+  > EOF
+
+  $ dune runtest
+
+  $ echo 'let foo () = 2' > prelude.ml
+
+  $ dune runtest --auto-promote
+  File "README.md", line 1, characters 0-0:
+  Error: Files _build/default/README.md and
+  _build/default/.mdx/README.md.corrected differ.
+  Promoting _build/default/.mdx/README.md.corrected to README.md.
+  [1]
+
+  $ cat README.md
+  ```ocaml
+  # foo ();;
+  - : int = 2
+  ```


### PR DESCRIPTION
When mdx is used in program-generation mode (version >= 0.2), the paths used as preludes are recorded in the executable, but the contents of files are only read when the program is executed. This adds the missing dependencies.

Fixes #7077
