### PR TITLE
feature: add an empty alias

### DIFF
--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -27,6 +27,8 @@ module Name : sig
 
   val fmt : t
 
+  val empty : t
+
   val all : t
 
   val parse_local_path : Loc.t * Path.Local.t -> Path.Local.t * t
@@ -73,6 +75,8 @@ end = struct
   let to_string s = s
 
   let default = "default"
+
+  let empty = "empty"
 
   let runtest = "runtest"
 
@@ -157,6 +161,8 @@ let make_standard name =
 let register_as_standard name =
   let (_ : (unit, _) result) = Table.add standard_aliases name () in
   ()
+
+let empty = make_standard Name.empty
 
 let default = make_standard Name.default
 

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -25,6 +25,8 @@ module Name : sig
 
   val all : t
 
+  val empty : t
+
   val parse_local_path : Loc.t * Path.Local.t -> Path.Local.t * t
 
   include Comparable_intf.S with type key := t
@@ -54,6 +56,8 @@ val encode : t Dune_lang.Encoder.t
 val of_user_written_path : loc:Loc.t -> Path.t -> t
 
 val fully_qualified_name : t -> Path.Build.t
+
+val empty : dir:Path.Build.t -> t
 
 val default : dir:Path.Build.t -> t
 

--- a/src/dune_engine/rules.ml
+++ b/src/dune_engine/rules.ml
@@ -150,6 +150,10 @@ module Produce = struct
       produce
         (let dir = Alias.dir t in
          let name = Alias.name t in
+         if Alias.Name.equal name Alias.Name.empty then
+           Code_error.raise
+             "it is forbidden to add dependency to the empty alias"
+             [ ("dir", Path.Build.to_dyn dir) ];
          Path.Build.Map.singleton dir
            (Dir_rules.Nonempty.singleton (Alias { name; spec })))
 


### PR DESCRIPTION
A special alias to which actions and dependencies cannot be attached

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 03e203b4-34d8-4c8f-b763-89f7a7b210c4 -->