### PR TITLE
refactor: remove [Action_builder.source_tree]

### DIFF
--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -112,9 +112,9 @@ val dep_on_alias_if_exists : Alias.t -> bool t
 val dep_on_alias_rec :
   Alias.Name.t -> Context_name.t -> Source_tree.Dir.t -> bool t
 
-(** Compute the set of source of all files present in the sub-tree starting at
-    [dir] and record them as dependencies. *)
-val source_tree : dir:Path.t -> Path.Set.t t
+(** [dyn_memo_deps m] adds the dependencies computed by [m] while returning the
+    extra value. *)
+val dyn_memo_deps : (Dep.Set.t * 'a) Memo.t -> 'a t
 
 (** Record dynamic dependencies *)
 val dyn_paths : ('a * Path.t list) t -> 'a t

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -79,8 +79,9 @@ let test_rule ~sctx ~expander ~dir (spec : effective)
           match test with
           | File _ -> Action_builder.return Path.Set.empty
           | Dir { dir; file = _ } ->
-            let dir = Path.build (Path.Build.append_source prefix_with dir) in
-            Action_builder.source_tree ~dir
+            Path.Build.append_source prefix_with dir
+            |> Path.build |> Dep.Set.source_tree_with_file_set
+            |> Action_builder.dyn_memo_deps
         in
         Action.Full.make action ~locks ~sandbox:spec.sandbox
       in

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -136,8 +136,9 @@ let rec dep expander = function
   | Source_tree s ->
     Other
       (let* path = Expander.expand_path expander s in
-       Action_builder.map ~f:Path.Set.to_list
-         (Action_builder.source_tree ~dir:path))
+       Dep.Set.source_tree_with_file_set path
+       |> Action_builder.dyn_memo_deps
+       |> Action_builder.map ~f:Path.Set.to_list)
   | Package p ->
     Other
       (let* pkg = Expander.expand_str expander p in


### PR DESCRIPTION
Replace it with the more general [Action_builder.memo_deps]. Previous
uses of [Action_builder.source_tree] are easily replaced with fetching
the dependencies and then applying this function.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d9a39968-1c41-4c81-a139-57e7d4d5140b -->