### PR TITLE
[coq lib] Some more cleanup

### DIFF
--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -97,7 +97,7 @@ let term =
           let stanza =
             Dune_rules.Coq_sources.lookup_module coq_src coq_module
           in
-          let args, use_stdlib, wrapper_name =
+          let args, use_stdlib, coq_lang_version, wrapper_name =
             match stanza with
             | None ->
               User_error.raise
@@ -106,17 +106,19 @@ let term =
               ( Dune_rules.Coq_rules.coqtop_args_theory ~sctx ~dir
                   ~dir_contents:dc theory coq_module
               , theory.buildable.use_stdlib
+              , theory.buildable.coq_lang_version
               , Dune_rules.Coq_lib_name.wrapper (snd theory.name) )
             | Some (`Extraction extr) ->
               ( Dune_rules.Coq_rules.coqtop_args_extraction ~sctx ~dir extr
                   coq_module
               , extr.buildable.use_stdlib
+              , extr.buildable.coq_lang_version
               , "DuneExtraction" )
           in
           let* (_ : unit * Dep.Fact.t Dep.Map.t) =
             let deps_of =
               Dune_rules.Coq_rules.deps_of ~dir ~use_stdlib ~wrapper_name
-                coq_module
+                ~coq_lang_version coq_module
             in
             Action_builder.(run deps_of) Eager
           in

--- a/src/dune_rules/coq/coq_lib.mli
+++ b/src/dune_rules/coq/coq_lib.mli
@@ -43,7 +43,10 @@ module DB : sig
     -> coq_lang_version:Dune_sexp.Syntax.Version.t
     -> lib list Resolve.Memo.t
 
-  val boot_library : t -> (Loc.t * lib) option Resolve.Memo.t
+  val resolve_boot :
+       t
+    -> coq_lang_version:Dune_sexp.Syntax.Version.t
+    -> (Loc.t * lib) option Resolve.Memo.t
 
   val resolve :
        t

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -11,6 +11,7 @@ val deps_of :
      dir:Path.Build.t
   -> use_stdlib:bool
   -> wrapper_name:string
+  -> coq_lang_version:Dune_sexp.Syntax.Version.t
   -> Coq_module.t
   -> unit Dune_engine.Action_builder.t
 


### PR DESCRIPTION
In particular we bring a simpliciation in terms of the boot lib, we just store its name and use the regular resolve path for it.

That avoids the hack we had with a forward ref for having it resolve "early"

cc @Alizter , should help with the user-contrib PR.