### PR TITLE
fix(console): Make [Backend.progress] flush (#7141

### DIFF
--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -7,7 +7,7 @@ module Backend = struct
 
   let dumb = (module Dumb : Backend_intf.S)
 
-  let progress = Progress.no_flush
+  let progress = Progress.flush
 
   let compose = Combinators.compose
 


### PR DESCRIPTION
Some time ago, it was accidentally changed not to flush. The change was
never noticed because dune used the threaded version of this backend
that did flush.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e6f9ba80-fa72-46e4-871a-e475b4533f6f -->