### PR TITLE
refactor(engine): remove source tree traversals

### DIFF
--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -103,14 +103,33 @@ val paths_existing : Path.t list -> unit t
     action produced by the action builder. *)
 val env_var : string -> unit t
 
+module Alias_status : sig
+  type t =
+    | Defined
+    | Not_defined
+
+  include Monoid.S with type t := t
+end
+
 val alias : Alias.t -> unit t
 
-val dep_on_alias_if_exists : Alias.t -> bool t
+val dep_on_alias_if_exists : Alias.t -> Alias_status.t t
 
-(** Depend on an alias recursively. Return [true] if the alias is defined in at
-    least one directory, and [false] otherwise. *)
-val dep_on_alias_rec :
-  Alias.Name.t -> Context_name.t -> Source_tree.Dir.t -> bool t
+module Alias_rec (_ : sig
+  (* This API isn't fully baked yet. We might move it to the rules *)
+
+  (** [traverse dir ~f] traverses [dir] and evaluates [f] for every directory.
+      Returns [Defined] if [f] returned [Defined] at least once. [Not_defined]
+      otherwise. *)
+  val traverse :
+       Path.Build.t
+    -> f:(path:Path.Build.t -> Alias_status.t t)
+    -> Alias_status.t t
+end) : sig
+  (** Depend on an alias recursively. Return [Defined] if the alias is defined
+      in at least one directory, and [Not_defined] otherwise. *)
+  val dep_on_alias_rec : Alias.Name.t -> Path.Build.t -> Alias_status.t t
+end
 
 (** [dyn_memo_deps m] adds the dependencies computed by [m] while returning the
     extra value. *)

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -110,19 +110,24 @@ module Set : sig
   include
     Set.S with type elt = t and type 'a map := 'a Map.t and type t = unit Map.t
 
-  (** Return dependencies on all source files under a certain source directory.
+  module Source_tree (Union : sig
+    type 'a result
 
-      Dependency on a source_tree requires special care for empty directory, so
-      you should use this function rather than manually traverse the source
-      tree. *)
-  val source_tree : Path.t -> t Memo.t
+    val union_all :
+      Path.t -> f:(path:Path.t -> files:Filename.Set.t -> t) -> t result
+  end) : sig
+    (** Dependencies on all source files under a certain source directory.
 
-  (** Same as [source_tree] but also return the set of files as a set. Because
-      of the special care for empty directories, the set of dependencies
-      returned contains dependencies other than [File]. So extracting the set of
-      files from the dependency set is a bit awkward. This is why this function
-      exist. *)
-  val source_tree_with_file_set : Path.t -> (t * Path.Set.t) Memo.t
+        Dependency on a [files] requires special care for empty directories.
+        Empty directories need to be loaded so that we clean up stale artifacts
+        in such directories *)
+    val files : Path.t -> t Union.result
+  end
+
+  (** [to_files_set_exn t] returns the set of files in [t]. It will raise if [t]
+      contains anything other than files or the empty predicate. It is safe to
+      call on the value returned by [Source_tree.files] *)
+  val to_files_set_exn : t -> Path.Set.t
 
   val of_files : Path.t list -> t
 

--- a/src/dune_rules/alias_rec.ml
+++ b/src/dune_rules/alias_rec.ml
@@ -1,0 +1,23 @@
+open Import
+
+include Action_builder.Alias_rec (struct
+  module Map_reduce =
+    Source_tree.Dir.Make_map_reduce
+      (Action_builder)
+      (Action_builder.Alias_status)
+
+  let traverse dir ~f =
+    let ctx_name, src_dir = Path.Build.extract_build_context_exn dir in
+    let build_dir = Context_name.build_dir (Context_name.of_string ctx_name) in
+    let f dir =
+      let path =
+        Path.Build.append_source build_dir (Source_tree.Dir.path dir)
+      in
+      f ~path
+    in
+    let open Action_builder.O in
+    Source_tree.find_dir src_dir |> Action_builder.of_memo >>= function
+    | None -> Action_builder.return Action_builder.Alias_status.Not_defined
+    | Some src_dir ->
+      Map_reduce.map_reduce src_dir ~traverse:Sub_dirs.Status.Set.normal_only ~f
+end)

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -79,9 +79,16 @@ let test_rule ~sctx ~expander ~dir (spec : effective)
           match test with
           | File _ -> Action_builder.return Path.Set.empty
           | Dir { dir; file = _ } ->
-            Path.Build.append_source prefix_with dir
-            |> Path.build |> Dep.Set.source_tree_with_file_set
-            |> Action_builder.dyn_memo_deps
+            let deps =
+              let open Memo.O in
+              let+ deps =
+                Path.Build.append_source prefix_with dir
+                |> Path.build |> Source_deps.files
+              in
+              let files = Dep.Set.to_files_set_exn deps in
+              (deps, files)
+            in
+            Action_builder.dyn_memo_deps deps
         in
         Action.Full.make action ~locks ~sandbox:spec.sandbox
       in

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -27,9 +27,7 @@ let to_action_builder = function
   | Other x -> x
 
 let dep_on_alias_rec alias ~loc =
-  let ctx_name, src_dir =
-    Path.Build.extract_build_context_exn (Alias.dir alias)
-  in
+  let src_dir = Path.Build.drop_build_context_exn (Alias.dir alias) in
   Action_builder.of_memo (Source_tree.find_dir src_dir) >>= function
   | None ->
     Action_builder.fail
@@ -40,18 +38,19 @@ let dep_on_alias_rec alias ~loc =
                   (Path.Source.to_string_maybe_quoted src_dir)
               ])
       }
-  | Some dir ->
+  | Some _ -> (
     let name = Dune_engine.Alias.name alias in
-    let+ is_nonempty =
-      Action_builder.dep_on_alias_rec name (Context_name.of_string ctx_name) dir
-    in
-    if (not is_nonempty) && not (Alias.is_standard name) then
-      User_error.raise ~loc
-        [ Pp.text "This alias is empty."
-        ; Pp.textf "Alias %S is not defined in %s or any of its descendants."
-            (Alias.Name.to_string name)
-            (Path.Source.to_string_maybe_quoted src_dir)
-        ]
+    let+ alias_status = Alias_rec.dep_on_alias_rec name (Alias.dir alias) in
+    match alias_status with
+    | Defined -> ()
+    | Not_defined ->
+      if not (Alias.is_standard name) then
+        User_error.raise ~loc
+          [ Pp.text "This alias is empty."
+          ; Pp.textf "Alias %S is not defined in %s or any of its descendants."
+              (Alias.Name.to_string name)
+              (Path.Source.to_string_maybe_quoted src_dir)
+          ])
 
 let relative d s = Path.build (Path.Build.relative d s)
 
@@ -136,8 +135,12 @@ let rec dep expander = function
   | Source_tree s ->
     Other
       (let* path = Expander.expand_path expander s in
-       Dep.Set.source_tree_with_file_set path
-       |> Action_builder.dyn_memo_deps
+       let deps =
+         let open Memo.O in
+         let+ files = Source_deps.files path in
+         (files, Dep.Set.to_files_set_exn files)
+       in
+       Action_builder.dyn_memo_deps deps
        |> Action_builder.map ~f:Path.Set.to_list)
   | Package p ->
     Other

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -7,6 +7,7 @@ module Colors = Colors
 module Profile = Profile
 module Workspace = Workspace
 module Dune_package = Dune_package
+module Alias_rec = Alias_rec
 module Dep_conf = Dep_conf
 module Dir_contents = Dir_contents
 module Expander = Expander

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -118,7 +118,7 @@ module Deps = struct
     | Ok (dirs, files) ->
       let open Memo.O in
       let dep_set = Dep.Set.of_files files in
-      let+ l = Memo.parallel_map dirs ~f:(fun dir -> Dep.Set.source_tree dir) in
+      let+ l = Memo.parallel_map dirs ~f:Source_deps.files in
       Ok (Dep.Set.union_all (dep_set :: l))
 end
 

--- a/src/dune_rules/source_deps.ml
+++ b/src/dune_rules/source_deps.ml
@@ -1,0 +1,21 @@
+open Import
+
+include Dep.Set.Source_tree (struct
+  module Map_reduce =
+    Source_tree.Dir.Make_map_reduce (Memo) (Monoid.Union (Dep.Set))
+
+  type 'a result = 'a Memo.t
+
+  let union_all dir ~f =
+    let prefix_with, dir = Path.extract_build_context_dir_exn dir in
+    let open Memo.O in
+    Source_tree.find_dir dir >>= function
+    | None -> Memo.return Dep.Set.empty
+    | Some dir ->
+      Map_reduce.map_reduce dir ~traverse:Sub_dirs.Status.Set.all ~f:(fun dir ->
+          let path =
+            Path.append_source prefix_with @@ Source_tree.Dir.path dir
+          in
+          let files = Source_tree.Dir.files dir in
+          Memo.return @@ f ~path ~files)
+end)


### PR DESCRIPTION
Previously, the engine would know about directories for computing
source_tree, and recursive aliases.

With this PR, these operations are generalized to work over arbitrary
directory traversals.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1ada65f3-5f49-474d-957e-c95412063582 -->