### PR TITLE
Enable use of stublibs of _installed_ libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ Unreleased
 - Accept the Ordered Set Language for the `modes` field in `library` stanzas
   (#6611, @anmonteiro).
 
+- Stub shared libraries (dllXXX_stubs.so) in Dune-installed libraries could not
+  be used as dependencies of libraries in the workspace (eg when compiling to
+  bytecode and/or Javascript).  This is now fixed. (#7151, @nojb)
+
 3.7.0 (2023-02-17)
 ------------------
 

--- a/test/blackbox-tests/test-cases/install-stublibs.t/run.t
+++ b/test/blackbox-tests/test-cases/install-stublibs.t/run.t
@@ -58,6 +58,7 @@ Begin by installing a library with C stubs.
    (plugins (byte libA.cma) (native libA.cmxs))
    (foreign_objects stubs.o)
    (foreign_archives (archives (for all) (files liblibA_stubs.a)))
+   (foreign_dll_files ../stublibs/dlllibA_stubs.so)
    (native_archives libA.a)
    (main_module_name LibA)
    (modes byte native)
@@ -85,6 +86,3 @@ Now let us define an executable using that installed library.
   > EOF
   $ touch exeA.ml
   $ OCAMLPATH=./install/lib dune build
-  File "_none_", line 1:
-  Error: I/O error: dlllibA_stubs.so: No such file or directory
-  [1]

--- a/test/blackbox-tests/test-cases/install-stublibs.t/run.t
+++ b/test/blackbox-tests/test-cases/install-stublibs.t/run.t
@@ -1,0 +1,90 @@
+Begin by installing a library with C stubs.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name libA))
+  > EOF
+  $ cat >dune <<EOF
+  > (library
+  >  (name libA)
+  >  (public_name libA)
+  >  (foreign_stubs
+  >   (language c)
+  >   (names stubs)))
+  > EOF
+  $ touch stubs.c
+  $ dune build
+  $ dune install --prefix ./install
+  Installing install/lib/libA/META
+  Installing install/lib/libA/dune-package
+  Installing install/lib/libA/libA.a
+  Installing install/lib/libA/libA.cma
+  Installing install/lib/libA/libA.cmi
+  Installing install/lib/libA/libA.cmt
+  Installing install/lib/libA/libA.cmx
+  Installing install/lib/libA/libA.cmxa
+  Installing install/lib/libA/libA.ml
+  Installing install/lib/libA/liblibA_stubs.a
+  Installing install/lib/libA/libA.cmxs
+  Installing install/lib/stublibs/dlllibA_stubs.so
+  $ cat ./install/lib/libA/dune-package
+  (lang dune 3.8)
+  (name libA)
+  (sections
+   (lib
+    $TESTCASE_ROOT/install/lib/libA)
+   (libexec
+    $TESTCASE_ROOT/install/lib/libA)
+   (stublibs
+    $TESTCASE_ROOT/install/lib/stublibs))
+  (files
+   (lib
+    (META
+     dune-package
+     libA.a
+     libA.cma
+     libA.cmi
+     libA.cmt
+     libA.cmx
+     libA.cmxa
+     libA.ml
+     liblibA_stubs.a))
+   (libexec (libA.cmxs))
+   (stublibs (dlllibA_stubs.so)))
+  (library
+   (name libA)
+   (kind normal)
+   (archives (byte libA.cma) (native libA.cmxa))
+   (plugins (byte libA.cma) (native libA.cmxs))
+   (foreign_objects stubs.o)
+   (foreign_archives (archives (for all) (files liblibA_stubs.a)))
+   (native_archives libA.a)
+   (main_module_name LibA)
+   (modes byte native)
+   (modules
+    (wrapped
+     (group
+      (alias
+       (obj_name libA)
+       (visibility public)
+       (kind alias)
+       (source (path LibA) (impl (path libA.ml-gen))))
+      (name LibA))
+     (wrapped true))))
+
+Now let us define an executable using that installed library.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+  $ cat >dune <<EOF
+  > (executable
+  >  (name exeA)
+  >  (libraries libA)
+  >  (modes byte))
+  > EOF
+  $ touch exeA.ml
+  $ OCAMLPATH=./install/lib dune build
+  File "_none_", line 1:
+  Error: I/O error: dlllibA_stubs.so: No such file or directory
+  [1]


### PR DESCRIPTION
Currently, libraries installed by Dune (ie carrying a `dune-package` file) do not record the information about the library's stublibs (`dllXXX_stubs.$ext_dll`), which make it impossible to depend on these libraries to build bytecode or JS executables in the workspace.

This PR fills records the necessary information in a new field `foreign_dll_files` of the `dune-package` file (using a path relative to the package root to maintain relocatibility).