### PR TITLE
test(melange): demonstrate incorrect include paths compiling external lib

### DIFF
--- a/test/blackbox-tests/test-cases/melange/depend-on-installed.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed.t
@@ -99,10 +99,7 @@ Test dependency on installed package
           melc dist/node_modules/a/foo.js
           melc dist/node_modules/b/b.js
           melc dist/node_modules/b/bar.js
+          melc dist/node_modules/b/foo.js
           melc .dist.mobjs/melange/melange.{cmi,cmj,cmt}
           melc dist/.dist.mobjs/melange.js
-          melc dist/node_modules/b/foo.js (exit 2)
-  File "_none_", line 1:
-  Error: B__Bar not found, it means either the module does not exist or it is a namespace
   Leaving directory 'app'
-  [1]

--- a/test/blackbox-tests/test-cases/melange/emit-private.t
+++ b/test/blackbox-tests/test-cases/melange/emit-private.t
@@ -24,13 +24,13 @@ Test dependency on a private library in the same package as melange.emit
   $ dune install --prefix $PWD/prefix
   Installing $TESTCASE_ROOT/prefix/lib/a/META
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a.cmi
-  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a.cmj
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a.cmt
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a__Foo.cmi
-  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a__Foo.cmj
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a__Foo.cmt
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/a.ml
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/foo.ml
+  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/a.cmj
+  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/a__Foo.cmj
   Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
 
   $ cat > b/dune <<EOF


### PR DESCRIPTION
I'm working on fixing this. The path returned here is wrong: https://github.com/ocaml/dune/blob/f5a5a9c17be60b1cf2ec22fee35d35ccc3bb5e5e/src/dune_rules/melange/melange_rules.ml#L151