### PR TITLE
fix: sub-library paths in `dune-package`

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -165,9 +165,7 @@ module Lib = struct
        and+ virtual_ = field_b "virtual"
        and+ sub_systems = Sub_system_info.record_parser ()
        and+ orig_src_dir = field_o "orig_src_dir" path
-       and+ modules =
-         let src_dir = Obj_dir.dir obj_dir in
-         field "modules" (Modules.decode ~src_dir)
+       and+ modules = field "modules" (Modules.decode ~src_dir:base)
        and+ special_builtin_support =
          field_o "special_builtin_support"
            (Dune_lang.Syntax.since Stanza.syntax (1, 10)

--- a/test/blackbox-tests/test-cases/dune-package-source-path.t
+++ b/test/blackbox-tests/test-cases/dune-package-source-path.t
@@ -1,0 +1,41 @@
+Test paths on public libraries with `.` are correct
+
+  $ mkdir a
+
+  $ cat > a/dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name a))
+  > EOF
+  $ cat > a/dune <<EOF
+  > (library
+  >  (name a)
+  >  (public_name a.sub))
+  > EOF
+
+  $ cat > a/foo.ml <<EOF
+  > let x = "foo"
+  > EOF
+
+  $ dune build --root a
+  Entering directory 'a'
+  Leaving directory 'a'
+
+  $ dune install --root a --prefix $PWD/prefix
+  Installing $TESTCASE_ROOT/prefix/lib/a/META
+  Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.a
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cma
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmx
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmxa
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.ml
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a__Foo.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a__Foo.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a__Foo.cmx
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/foo.ml
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmxs
+
+  $ cat prefix/lib/a/dune-package | grep path
+       (source (path A) (impl (path sub/a.ml-gen))))
+        (source (path Foo) (impl (path sub/foo.ml))))))

--- a/test/blackbox-tests/test-cases/dune-package-source-path.t
+++ b/test/blackbox-tests/test-cases/dune-package-source-path.t
@@ -16,26 +16,30 @@ Test paths on public libraries with `.` are correct
   > let x = "foo"
   > EOF
 
-  $ dune build --root a
+  $ dune build a.install --root a
   Entering directory 'a'
   Leaving directory 'a'
 
-  $ dune install --root a --prefix $PWD/prefix
-  Installing $TESTCASE_ROOT/prefix/lib/a/META
-  Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.a
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cma
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmi
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmt
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmx
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmxa
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.ml
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a__Foo.cmi
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a__Foo.cmt
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a__Foo.cmx
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/foo.ml
-  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.cmxs
+  $ cat a/_build/default/a.install
+  lib: [
+    "_build/install/default/lib/a/META"
+    "_build/install/default/lib/a/dune-package"
+    "_build/install/default/lib/a/sub/a.a" {"sub/a.a"}
+    "_build/install/default/lib/a/sub/a.cma" {"sub/a.cma"}
+    "_build/install/default/lib/a/sub/a.cmi" {"sub/a.cmi"}
+    "_build/install/default/lib/a/sub/a.cmt" {"sub/a.cmt"}
+    "_build/install/default/lib/a/sub/a.cmx" {"sub/a.cmx"}
+    "_build/install/default/lib/a/sub/a.cmxa" {"sub/a.cmxa"}
+    "_build/install/default/lib/a/sub/a.ml" {"sub/a.ml"}
+    "_build/install/default/lib/a/sub/a__Foo.cmi" {"sub/a__Foo.cmi"}
+    "_build/install/default/lib/a/sub/a__Foo.cmt" {"sub/a__Foo.cmt"}
+    "_build/install/default/lib/a/sub/a__Foo.cmx" {"sub/a__Foo.cmx"}
+    "_build/install/default/lib/a/sub/foo.ml" {"sub/foo.ml"}
+  ]
+  libexec: [
+    "_build/install/default/lib/a/sub/a.cmxs" {"sub/a.cmxs"}
+  ]
 
-  $ cat prefix/lib/a/dune-package | grep path
+  $ cat a/_build/install/default/lib/a/dune-package | grep path
        (source (path A) (impl (path sub/a.ml-gen))))
         (source (path Foo) (impl (path sub/foo.ml))))))

--- a/test/blackbox-tests/test-cases/melange/dune-package-source-path.t
+++ b/test/blackbox-tests/test-cases/melange/dune-package-source-path.t
@@ -1,0 +1,69 @@
+Test that paths in `node_modules` are correct for sub-libraries of the
+form `foo.bar.baz`
+
+  $ mkdir a app
+  $ cat > a/dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name a))
+  > (using melange 0.1)
+  > EOF
+  $ cat > a/dune <<EOF
+  > (library
+  >  (modes melange)
+  >  (name a)
+  >  (public_name a.sub))
+  > EOF
+
+  $ cat > a/foo.ml <<EOF
+  > let x = "foo"
+  > EOF
+
+  $ dune build --root a
+  Entering directory 'a'
+  Leaving directory 'a'
+
+  $ dune install --root a --prefix $PWD/prefix
+  Installing $TESTCASE_ROOT/prefix/lib/a/META
+  Installing $TESTCASE_ROOT/prefix/lib/a/dune-package
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/a.ml
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/foo.ml
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/melange/a.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/melange/a.cmj
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/melange/a.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/melange/a__Foo.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/melange/a__Foo.cmj
+  Installing $TESTCASE_ROOT/prefix/lib/a/sub/melange/a__Foo.cmt
+
+  $ cat prefix/lib/a/dune-package | grep path
+       (source (path A) (impl (path sub/a.ml-gen))))
+        (source (path Foo) (impl (path sub/foo.ml))))))
+
+  $ cat >app/dune-project <<EOF
+  > (lang dune 3.7)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > app/dune <<EOF
+  > (melange.emit
+  >  (target dist)
+  >  (alias dist)
+  >  (libraries a.sub)
+  >  (module_system commonjs))
+  > EOF
+
+  $ cat > app/bar.ml <<EOF
+  > let x = Js.log A.Foo.x
+  > EOF
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @dist --display=short
+  Entering directory 'app'
+          melc dist/node_modules/a.sub/a.js
+          melc dist/node_modules/a.sub/foo.js
+          melc .dist.mobjs/melange/melange__Bar.{cmi,cmj,cmt}
+          melc dist/bar.js
+  Leaving directory 'app'
+
+
+  $ ls app/_build/default/dist/node_modules/a.sub
+  a.js
+  foo.js


### PR DESCRIPTION
turns out there wasn't anything wrong with #7072, but rather a perhaps more invasive issue:

- it looks like we're passing the wrong `src_dir` for sub-libraries of the form `foo.bar` when encoding a `dune-package` file.