### PR TITLE
stdlib: include dependencies for stdlib alias, decode correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ Unreleased
   be used as dependencies of libraries in the workspace (eg when compiling to
   bytecode and/or Javascript).  This is now fixed. (#7151, @nojb)
 
+- Allow the main module of a library with `(stdlib ...)` to depend on other
+  libraries (#7154, @anmonteiro).
+
 3.7.0 (2023-02-17)
 ------------------
 

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -224,21 +224,21 @@ let for_alias_module t alias_module =
       Sandbox_config.needs_sandboxing
     else Sandbox_config.no_special_requirements
   in
-  let modules : modules =
+  let (modules, includes) : modules * Includes.t =
     match Modules.is_stdlib_alias t.modules.modules alias_module with
-    | false -> singleton_modules alias_module
+    | false -> (singleton_modules alias_module, Includes.empty)
     | true ->
       (* The stdlib alias module is different from the alias modules usually
          produced by Dune: it contains code and depends on a few other
          [CamlinnternalXXX] modules from the stdlib, so we need the full set of
          modules to compile it. *)
-      t.modules
+      (t.modules, t.includes)
   in
   { t with
     flags =
       Ocaml_flags.append_common flags
         [ "-w"; "-49"; "-nopervasives"; "-nostdlib" ]
-  ; includes = Includes.empty
+  ; includes
   ; stdlib = None
   ; sandbox
   ; modules

--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -49,7 +49,7 @@ module Stdlib = struct
        and+ modules = modules ~src_dir ()
        and+ exit_module = field_o "exit_module" Module_name.decode
        and+ unwrapped =
-         field ~default:[] "unwrapped" (repeat (enter Module_name.decode))
+         field ~default:[] "unwrapped" (repeat Module_name.decode)
        in
        let unwrapped = Module_name.Set.of_list unwrapped in
        { modules; main_module_name; exit_module; unwrapped })

--- a/test/blackbox-tests/test-cases/stdlib-compilation-depend-on-library.t
+++ b/test/blackbox-tests/test-cases/stdlib-compilation-depend-on-library.t
@@ -64,15 +64,10 @@ Test dependency on installed package
         ocamlc .b.objs/byte/b.{cmi,cmo,cmt}
       ocamldep .b.objs/b__Bar.impl.d
       ocamlopt .b.objs/native/b.{cmx,o}
-  File "$TESTCASE_ROOT/prefix/lib/a/dune-package", line 40, characters 14-38:
-  40 |    (unwrapped CamlinternalFormatBasics))))
-                     ^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: List expected
-  -> required by library "b" in _build/default
-  -> required by _build/default/META.b
-  -> required by _build/install/default/lib/b/META
-  -> required by _build/default/b.install
-  -> required by alias install
+        ocamlc .b.objs/byte/b__Bar.{cmi,cmo,cmt}
+      ocamlopt .b.objs/native/b__Bar.{cmx,o}
+        ocamlc b.cma
+      ocamlopt b.{a,cmxa}
+      ocamlopt b.cmxs
   Leaving directory 'b'
-  [1]
 


### PR DESCRIPTION
- the stdlib alias module is different from dune's because it contains code
  - this change allows that code to depend on modules in `(libraries ..)`
  - this allows the melange stdlib (which depends on another, bootstrapping lib) to be compiled using `(stdlib ...)`

- fix decoding  stdlib in dune-package, which expected an extra sexp