### PR TITLE
Add support for `flags` field

### DIFF
--- a/src/dune_engine/opam_file.ml
+++ b/src/dune_engine/opam_file.ml
@@ -63,6 +63,8 @@ let existing_variables t =
       | Variable (_, var, _) -> String.Set.add acc var)
 
 module Create = struct
+  let ident s = Ident (nopos, s)
+
   let string s = String (nopos, s)
 
   let list f xs = List (nopos, List.map ~f xs)

--- a/src/dune_engine/opam_file.mli
+++ b/src/dune_engine/opam_file.mli
@@ -24,6 +24,8 @@ val nopos : OpamParserTypes.pos
 val existing_variables : t -> String.Set.t
 
 module Create : sig
+  val ident : string -> value
+
   val string : string -> value
 
   val list : ('a -> value) -> 'a list -> value

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -638,7 +638,7 @@ let decode ~dir =
      and+ tags = field "tags" (enter (repeat string)) ~default:[]
      and+ flags =
        field ~default:[] "flags"
-         (Dune_lang.Syntax.since Stanza.syntax (3, 8) >>> repeat ident)
+         (Dune_lang.Syntax.since Stanza.syntax (3, 8) >>> repeat1 ident)
      and+ deprecated_package_names =
        name_map
          (Dune_lang.Syntax.since Stanza.syntax (2, 0))

--- a/src/dune_engine/package.ml
+++ b/src/dune_engine/package.ml
@@ -556,6 +556,7 @@ type t =
   ; version : string option
   ; has_opam_file : bool
   ; tags : string list
+  ; flags : string list
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Section.t Section.Site.Map.t
   ; allow_empty : bool
@@ -582,6 +583,7 @@ let encode (name : Name.t)
     ; info
     ; version
     ; tags
+    ; flags
     ; deprecated_package_names
     ; sites
     ; allow_empty
@@ -598,6 +600,7 @@ let encode (name : Name.t)
         ; field_l "depopts" Dependency.encode depopts
         ; field_o "version" string version
         ; field "tags" (list string) ~default:[] tags
+        ; field_l "flags" string flags
         ; field_l "deprecated_package_names" Name.encode
             (Name.Map.keys deprecated_package_names)
         ; field_l "sits"
@@ -633,6 +636,9 @@ let decode ~dir =
      and+ depopts = field ~default:[] "depopts" (repeat Dependency.decode)
      and+ info = Info.decode ~since:(2, 0) ()
      and+ tags = field "tags" (enter (repeat string)) ~default:[]
+     and+ flags =
+       field ~default:[] "flags"
+         (Dune_lang.Syntax.since Stanza.syntax (3, 8) >>> repeat ident)
      and+ deprecated_package_names =
        name_map
          (Dune_lang.Syntax.since Stanza.syntax (2, 0))
@@ -661,6 +667,7 @@ let decode ~dir =
      ; version
      ; has_opam_file = false
      ; tags
+     ; flags
      ; deprecated_package_names
      ; sites
      ; allow_empty
@@ -677,6 +684,7 @@ let to_dyn
     ; info
     ; has_opam_file
     ; tags
+    ; flags
     ; loc = _
     ; deprecated_package_names
     ; sites
@@ -693,6 +701,7 @@ let to_dyn
     ; ("info", Info.to_dyn info)
     ; ("has_opam_file", Bool has_opam_file)
     ; ("tags", list string tags)
+    ; ("flags", list string flags)
     ; ("version", option string version)
     ; ( "deprecated_package_names"
       , Name.Map.to_dyn Loc.to_dyn_hum deprecated_package_names )
@@ -727,6 +736,7 @@ let default name dir =
   ; depopts = []
   ; has_opam_file = false
   ; tags = [ "topics"; "to describe"; "your"; "project" ]
+  ; flags = []
   ; deprecated_package_names = Name.Map.empty
   ; sites = Section.Site.Map.empty
   ; allow_empty = false
@@ -798,6 +808,7 @@ let load_opam_file file name =
   ; description = get_one "description"
   ; has_opam_file = true
   ; tags = Option.value (get_many "tags") ~default:[]
+  ; flags = Option.value (get_many "flags") ~default:[]
   ; deprecated_package_names = Name.Map.empty
   ; sites = Section.Site.Map.empty
   ; allow_empty = true

--- a/src/dune_engine/package.mli
+++ b/src/dune_engine/package.mli
@@ -152,6 +152,7 @@ type t =
   ; version : string option
   ; has_opam_file : bool
   ; tags : string list
+  ; flags : string list
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Section.t Section.Site.Map.t
   ; allow_empty : bool

--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -108,6 +108,7 @@ let package_fields
     ; version = _
     ; has_opam_file = _
     ; tags
+    ; flags
     ; loc = _
     ; deprecated_package_names = _
     ; sites = _
@@ -122,6 +123,14 @@ let package_fields
            | None -> None
            | Some v -> Some (k, string v))
   in
+  let optionals =
+    [ ("flags", flags) ]
+    |> List.filter_map ~f:(fun (k, v) ->
+           match v with
+           | [] -> None
+           | [ v ] -> Some (k, ident v)
+           | vs -> Some (k, (list ident) vs))
+  in
   let dep_fields =
     [ ("depends", depends); ("conflicts", conflicts); ("depopts", depopts) ]
     |> List.filter_map ~f:(fun (k, v) ->
@@ -129,7 +138,7 @@ let package_fields
            | [] -> None
            | _ :: _ -> Some (k, list Package.Dependency.opam_depend v))
   in
-  let fields = [ optional; dep_fields ] in
+  let fields = [ optional; optionals; dep_fields ] in
   let fields =
     let dune_version = Dune_project.dune_version project in
     if dune_version >= (2, 0) && tags <> [] then tags :: fields else fields

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -456,6 +456,10 @@ let basic desc f = basic_loc desc (fun ~loc:_ -> f)
 
 let string = plain_string (fun ~loc:_ x -> x)
 
+let ident =
+  plain_string (fun ~loc:_ s ->
+      if String.is_prefix s ~prefix:":" then String.drop s 1 else s)
+
 let int = basic "Integer" Int.of_string
 
 let float = basic "Float" Float.of_string

--- a/src/dune_sexp/decoder.mli
+++ b/src/dune_sexp/decoder.mli
@@ -141,6 +141,8 @@ val fields : 'a fields_parser -> 'a t
 (** Consume the next element of the input as a string, int, bool, ... *)
 val string : string t
 
+val ident : string t
+
 val int : int t
 
 val float : float t

--- a/test/blackbox-tests/test-cases/dune-project-meta/flags.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/flags.t
@@ -1,0 +1,77 @@
+Reject flags in version [1.10, 3.8)
+----------------------------------------------
+
+  $ mkdir flags-unsupported
+  $ cat > flags-unsupported/dune-project <<EOF
+  > (lang dune 1.10)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (flags :plugin))
+  > EOF
+
+  $ dune build --root=flags-unsupported
+  Entering directory 'flags-unsupported'
+  File "dune-project", line 4, characters 20-35:
+  4 | (package (name foo) (flags :plugin))
+                          ^^^^^^^^^^^^^^^
+  Error: 'flags' is only available since version 3.8 of the dune language.
+  Please update your dune-project file to have (lang dune 3.8).
+  Leaving directory 'flags-unsupported'
+  [1]
+
+
+Allow flags in >= 3.8
+-----------------------------------------
+
+  $ mkdir flags-supported
+  $ cat > flags-supported/dune-project <<EOF
+  > (lang dune 3.8)
+  > (name foo)
+  > (generate_opam_files true)
+  > (license MIT ISC)
+  > (package (name foo) (flags :plugin) (allow_empty))
+  > EOF
+
+  $ dune build --root=flags-supported
+  Entering directory 'flags-supported'
+  Leaving directory 'flags-supported'
+  $ grep "flags:" flags-supported/foo.opam
+  flags: plugin
+
+Allow multiple flags
+---------------------------------------
+
+  $ mkdir multi-flags
+  $ cat > multi-flags/dune-project <<EOF
+  > (lang dune 3.8)
+  > (name foo)
+  > (generate_opam_files true)
+  > (license ISC)
+  > (package (name foo) (flags :plugin :compiler) (allow_empty))
+  > EOF
+
+  $ dune build --root=multi-flags
+  Entering directory 'multi-flags'
+  Leaving directory 'multi-flags'
+  $ grep "flags:" multi-flags/foo.opam
+  flags: [plugin compiler]
+
+Reject empty flags
+---------------------------------------
+
+  $ mkdir empty-flags
+  $ cat > empty-flags/dune-project <<EOF
+  > (lang dune 3.8)
+  > (name foo)
+  > (generate_opam_files true)
+  > (package (name foo) (flags) (allow_empty))
+  > EOF
+
+  $ dune build --root=empty-flags
+  Entering directory 'empty-flags'
+  Leaving directory 'empty-flags'
+  File "dune-project", line 4, characters 0-9:
+  4 | (flags)
+      ^^^^^^^^^
+  Error: Not enough arguments for flags
+  [1]

--- a/test/blackbox-tests/test-cases/dune-project-meta/flags.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/flags.t
@@ -69,9 +69,9 @@ Reject empty flags
 
   $ dune build --root=empty-flags
   Entering directory 'empty-flags'
-  Leaving directory 'empty-flags'
-  File "dune-project", line 4, characters 0-9:
-  4 | (flags)
-      ^^^^^^^^^
+  File "dune-project", line 4, characters 20-27:
+  4 | (package (name foo) (flags) (allow_empty))
+                          ^^^^^^^
   Error: Not enough arguments for flags
+  Leaving directory 'empty-flags'
   [1]


### PR DESCRIPTION
This implements the simplest missing field from the proposal #7059: `flags` that writes the OPAM field `flags`.

I am not sure I am doing things correctly here - in particular the way `ident` in the Dune sexp parser is probably not right but I am not sure how to parse `:keywords` - `keyword` seems to expect a specific keyword and not return one.