### PR TITLE
test: installed stublibs

### DIFF
--- a/test/blackbox-tests/test-cases/install-stublibs.t/run.t
+++ b/test/blackbox-tests/test-cases/install-stublibs.t/run.t
@@ -12,7 +12,11 @@ Begin by installing a library with C stubs.
   >   (language c)
   >   (names stubs)))
   > EOF
-  $ touch stubs.c
+  $ cat >stubs.c <<EOF
+  > int dummy() {
+  >   return 0;
+  > }
+  > EOF
   $ dune build
   $ dune install --prefix ./install
   Installing install/lib/libA/META


### PR DESCRIPTION
add some dummy code to the test stub to avoid warnings on macos

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 32bc50ae-7177-4998-938d-902aa1f5dd0d -->