### PR TITLE
fix(melange): unify public libraries (in-workspace vs external)

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -20,23 +20,13 @@ let output_of_lib ~target_dir lib =
   let info = Lib.info lib in
   match Lib_info.status info with
   | Private _ -> `Private_library_or_emit target_dir
-  | Installed | Installed_private ->
+  | Installed | Installed_private | Public _ ->
     let lib_name = Lib_info.name info in
     let src_dir = Lib_info.src_dir info in
     `Public_library
       ( src_dir
       , Path.Build.L.relative target_dir
           [ "node_modules"; Lib_name.to_string lib_name ] )
-  | Public _ ->
-    let lib_name = Lib_info.name info in
-    let src_dir = Lib_info.src_dir info in
-    `Public_library
-      ( src_dir
-      , Path.Build.L.relative target_dir
-          [ "node_modules"
-          ; Lib_name.to_string lib_name
-          ; Path.Source.to_string (Path.drop_build_context_exn src_dir)
-          ] )
 
 let make_js_name ~js_ext ~output m =
   let basename = Melange.js_basename m ^ js_ext in

--- a/test/blackbox-tests/test-cases/melange/public.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/public.t/run.t
@@ -4,7 +4,7 @@ Cmj rules should include --bs-package-output
   $ dune rules my_project/app/.app.objs/melange/app.cmj |
   > grep -e "--bs-package-output" --after-context=1
       --bs-package-output
-      my_project/app
+      .
 
 Cmj rules should include --bs-package-name
   $ dune rules my_project/app/.app.objs/melange/app.cmj |
@@ -15,13 +15,13 @@ Cmj rules should include --bs-package-name
   $ output=my_project/output
 
 Js rules should include --bs-module-type
-  $ dune rules $output/node_modules/pkg.app/my_project/app/b.js |
+  $ dune rules $output/node_modules/pkg.app/b.js |
   > grep -e "--bs-module-type" --after-context=1
       --bs-module-type
       commonjs
 
 Js rules should include --bs-package-name
-  $ dune rules $output/node_modules/pkg.app/my_project/app/b.js |
+  $ dune rules $output/node_modules/pkg.app/b.js |
   > grep -e "--bs-package-name" --after-context=1
       --bs-package-name
       pkg


### PR DESCRIPTION
- this change unifies the handling of public libraries in melange, whether they're local to the workspace or externally installed
  - the `--bs-package-output` argument for these libraries is now their relative path from the library root, rather than the path from the root of the project.
  - this effectively implements the suggestion added in https://github.com/ocaml/dune/pull/6602#discussion_r1036606112