### PR TITLE
fix: Revert "fix: Invoke preprocessor commands from local dir"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,6 @@ Unreleased
 - Non-user proccesses such as version control or config checking are now run
   silently. (#6994, fixes #4066, @Alizter)
 
-- Invoke preprocessor commands from directory of dune file containing the
-  commands rather than from the workspace root (#7057, fixes #7043, @gridbugs)
-
 - Add the `--display-separate-messages` flag to separate the error messages
   produced by commands with a blank line. (#6823, fixes #6158, @esope)
 

--- a/src/dune_rules/preprocessing.ml
+++ b/src/dune_rules/preprocessing.ml
@@ -705,11 +705,8 @@ let pp_one_module sctx ~lib_name ~scope ~preprocessor_deps
                     (let open Action_builder.O in
                     preprocessor_deps
                     >>> let* exe, flags, args = driver_and_flags in
-                        let project = Scope.project scope in
-                        let dune_version = Dune_project.dune_version project in
                         let dir =
-                          if dune_version >= (3, 8) then Path.build dir
-                          else Path.build (Super_context.context sctx).build_dir
+                          Path.build (Super_context.context sctx).build_dir
                         in
                         Command.run' ~dir
                           (Ok (Path.build exe))

--- a/test/blackbox-tests/test-cases/preprocessor-directory.t/run.t
+++ b/test/blackbox-tests/test-cases/preprocessor-directory.t/run.t
@@ -3,21 +3,13 @@ the preprocessor command. There are two rewrite.sh scripts in this test: one in
 the root directory which rewrites the source to print "foo ..." and one in the
 src directory which writes the source to print "bar ...".
 
-Initially the project uses dune lang 3.7 so the preprocessor command is invoked
-from the project root:
+The preprocessor command is invoked from the workspace root:
   $ cat dune-project
   (lang dune 3.7)
   (package (name foo))
   $ dune exec ./src/foo.exe
   foo (from the rewrite.sh script in the project root directory)
 
-Change the versiono of the dune language to 3.8:
-  $ sed -i.bak 's/(lang dune 3.7)/(lang dune 3.8)/' $(readlink dune-project)
-
-Now the preprocessor should be invoked from the src directory because the dune
-file which specifies the preprocessor is located there:
-  $ cat dune-project
-  (lang dune 3.8)
-  (package (name foo))
+This is unintended. We should be printing bar:
   $ dune exec ./src/foo.exe
-  bar (from the rewrite.sh script in the src directory)
+  foo (from the rewrite.sh script in the project root directory)


### PR DESCRIPTION
Running the preprocessor from cwd breaks the error messages outputted by
the preprocessor.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ee712e04-2c00-41d2-b32a-d8e1e82b08a2 -->