### PR TITLE
melange: interpret `melc --where` as a list of `:`-separated paths

### DIFF
--- a/src/dune_rules/melange/melange_binary.ml
+++ b/src/dune_rules/melange/melange_binary.ml
@@ -32,9 +32,6 @@ let where =
           let+ res = Memo.exec memo melc in
           Some res)
     in
-    Option.map
-      ~f:(fun dirs ->
-        String.split ~on:Bin.path_sep dirs
-        |> List.map ~f:Path.External.of_string)
-      melange_dirs
-    |> Option.value ~default:[]
+    match melange_dirs with
+    | None -> []
+    | Some dirs -> Bin.parse_path dirs

--- a/src/dune_rules/melange/melange_binary.ml
+++ b/src/dune_rules/melange/melange_binary.ml
@@ -13,20 +13,27 @@ let where =
       @@ Process.run_capture_line ~display:Quiet Process.Strict bin
            [ "--where" ]
     in
-    Path.of_string where
+    where
   in
   let memo =
-    Memo.create "melange-where" ~input:(module Path) ~cutoff:Path.equal impl
+    Memo.create "melange-where" ~input:(module Path) ~cutoff:String.equal impl
   in
   fun sctx ~loc ~dir ->
     let open Memo.O in
     let* env = Super_context.env_node sctx ~dir >>= Env_node.external_env in
-    match Env.get env "MELANGELIB" with
-    | Some p -> Memo.return (Some (Path.of_string p))
-    | None -> (
-      let* melc = melc sctx ~loc ~dir in
-      match melc with
-      | Error _ -> Memo.return None
-      | Ok melc ->
-        let+ res = Memo.exec memo melc in
-        Some res)
+    let+ melange_dirs =
+      match Env.get env "MELANGELIB" with
+      | Some p -> Memo.return (Some p)
+      | None -> (
+        let* melc = melc sctx ~loc ~dir in
+        match melc with
+        | Error _ -> Memo.return None
+        | Ok melc ->
+          let+ res = Memo.exec memo melc in
+          Some res)
+    in
+    Option.map
+      ~f:(fun dirs ->
+        String.split ~on:Bin.path_sep dirs |> List.map ~f:Path.of_string)
+      melange_dirs
+    |> Option.value ~default:[]

--- a/src/dune_rules/melange/melange_binary.ml
+++ b/src/dune_rules/melange/melange_binary.ml
@@ -34,6 +34,7 @@ let where =
     in
     Option.map
       ~f:(fun dirs ->
-        String.split ~on:Bin.path_sep dirs |> List.map ~f:Path.of_string)
+        String.split ~on:Bin.path_sep dirs
+        |> List.map ~f:Path.External.of_string)
       melange_dirs
     |> Option.value ~default:[]

--- a/src/dune_rules/melange/melange_binary.mli
+++ b/src/dune_rules/melange/melange_binary.mli
@@ -7,7 +7,4 @@ val melc :
   -> Action.Prog.t Memo.t
 
 val where :
-     Super_context.t
-  -> loc:Loc.t option
-  -> dir:Path.Build.t
-  -> Path.t option Memo.t
+  Super_context.t -> loc:Loc.t option -> dir:Path.Build.t -> Path.t list Memo.t

--- a/src/dune_rules/melange/melange_binary.mli
+++ b/src/dune_rules/melange/melange_binary.mli
@@ -7,4 +7,7 @@ val melc :
   -> Action.Prog.t Memo.t
 
 val where :
-  Super_context.t -> loc:Loc.t option -> dir:Path.Build.t -> Path.t list Memo.t
+     Super_context.t
+  -> loc:Loc.t option
+  -> dir:Path.Build.t
+  -> Path.External.t list Memo.t

--- a/src/dune_rules/melange/melange_binary.mli
+++ b/src/dune_rules/melange/melange_binary.mli
@@ -7,7 +7,4 @@ val melc :
   -> Action.Prog.t Memo.t
 
 val where :
-     Super_context.t
-  -> loc:Loc.t option
-  -> dir:Path.Build.t
-  -> Path.External.t list Memo.t
+  Super_context.t -> loc:Loc.t option -> dir:Path.Build.t -> Path.t list Memo.t

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -476,8 +476,10 @@ module Unprocessed = struct
           let+ dirs = Melange_binary.where sctx ~loc:None ~dir in
           match dirs with
           | [] -> (None, [])
-          | [ stdlib_dir ] -> (Some stdlib_dir, [])
-          | stdlib_dir :: extra_obj_dirs -> (Some stdlib_dir, extra_obj_dirs))
+          | [ stdlib_dir ] -> (Some (Path.external_ stdlib_dir), [])
+          | stdlib_dir :: extra_obj_dirs ->
+            ( Some (Path.external_ stdlib_dir)
+            , List.map ~f:Path.external_ extra_obj_dirs ))
       in
       let* flags = flags
       and* src_dirs, obj_dirs =

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -476,10 +476,8 @@ module Unprocessed = struct
           let+ dirs = Melange_binary.where sctx ~loc:None ~dir in
           match dirs with
           | [] -> (None, [])
-          | [ stdlib_dir ] -> (Some (Path.external_ stdlib_dir), [])
-          | stdlib_dir :: extra_obj_dirs ->
-            ( Some (Path.external_ stdlib_dir)
-            , List.map ~f:Path.external_ extra_obj_dirs ))
+          | [ stdlib_dir ] -> (Some stdlib_dir, [])
+          | stdlib_dir :: extra_obj_dirs -> (Some stdlib_dir, extra_obj_dirs))
       in
       let* flags = flags
       and* src_dirs, obj_dirs =


### PR DESCRIPTION
- This makes editor integration work with https://github.com/melange-re/melange/pull/493
- It can be merged independently, since it works with single paths too