### PR TITLE
Use SIGTERM when killing processes on non-windows environments

### DIFF
--- a/bin/exec.ml
+++ b/bin/exec.ml
@@ -72,9 +72,7 @@ module Watch = struct
 
   let kill_process pid =
     let pid_int = Pid.to_int pid in
-    (* TODO This logic should exist in one place. Currently it's here and in
-       the scheduler *)
-    let signal = if Sys.win32 then Sys.sigkill else Sys.sigterm in
+    let signal = Signal.to_int Scheduler.kill_signal in
     (* FIXME Since we're reaping in a different thread, this can technically
        cause pid reuse *)
     Unix.kill pid_int signal;

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -159,3 +159,5 @@ val stats : unit -> Dune_stats.t option Fiber.t
 val wait_for_build_input_change : unit -> unit Fiber.t
 
 val spawn_thread : (unit -> 'a) -> unit
+
+val kill_signal : Signal.t


### PR DESCRIPTION
Mentioned in https://github.com/ocaml/dune/issues/7110#issuecomment-1442118412.

When running executables as part of the build process, dune would send SIGKILL in these situations:
- When restarting the build due to changes on inputs
- When shutting down

This PR updates that behavior so that SIGTERM is used on non-Windows systems.