### PR TITLE
fix: use codesign -f to replace existing signature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,6 +118,9 @@ Unreleased
 - Fix regression where Merlin was unable to handle filenames with uppercase
   letters under Windows. (#7577, @nojb)
 
+- On nix+macos, pass `-f` to the codesign hook to avoid errors when the binary
+  is already signed (#7183, fixes #6265, @greedy)
+
 3.7.1 (2023-04-04)
 ------------------
 

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -52,7 +52,14 @@ type conf =
   }
 
 let mac_codesign_hook ~codesign path =
-  Process.run ~display:Quiet Strict codesign [ "-s"; "-"; Path.to_string path ]
+  let stdout_to =
+    Process.Io.make_stdout Execution_parameters.Action_output_on_success.Swallow
+  in
+  let stderr_to =
+    Process.Io.make_stderr Execution_parameters.Action_output_on_success.Swallow
+  in
+  Process.run ~stdout_to ~stderr_to ~display:Quiet Strict codesign
+    [ "-f"; "-s"; "-"; Path.to_string path ]
 
 let sign_hook_of_context (context : Context.t) =
   let config = context.ocaml_config in


### PR DESCRIPTION
When using dune in macOS + nix, the nix tooling adds a codesigning hook so when dune goes to sign files after substitution there is already an existing signature which fails the build as could be seen in the failure of the promote-only-when-needed test.

The failure can be avoided by providing the -f option to codesign which will replace any existing signatures on the file.

However, when -f is used and a signature is replaced, codesign prints a message that it is replacing the existing signature. This additional message pollutes dune's output and causes spurious failures of the cram tests on macOS + nix.

This secondary negative effect is eliminated by running the codesign tool with output swallowed as long as the tool runs successfully.

Fixes #6265