### PR TITLE
fix: do not re-render unless needed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Do not re-render UI on every frame if the UI doesn't change (#7186, fix
+  #7184, @rgrinberg)
+
 - Fix preludes not being recorded as dependencies in the `(mdx)` stanza (#7109,
   fixes #7077, @emillon).
 

--- a/src/dune_threaded_console/dune_threaded_console_intf.ml
+++ b/src/dune_threaded_console/dune_threaded_console_intf.ml
@@ -7,6 +7,7 @@ type state =
   ; mutable finish_requested : bool
   ; mutable finished : bool
   ; mutable status_line : User_message.Style.t Pp.t option
+  ; mutable dirty : bool
   }
 
 (** [Threaded] is the interface for user interfaces that are rendered in a


### PR DESCRIPTION
Previously, dune would re-render on every frame even when it wasn't
necessary.

Now, dune will make sure we have at least one modification before
re-rendering

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ee31acc5-380b-4c55-83e6-0db6d84d0b18 -->