### PR TITLE
test: vendored and public libs

### DIFF
--- a/test/blackbox-tests/test-cases/vendor/public-libs.t
+++ b/test/blackbox-tests/test-cases/vendor/public-libs.t
@@ -1,0 +1,30 @@
+A public library shouldn't be allowed to depend on a vendored library.
+
+A public library that depends on a vendored library is impossible to install,
+since we cannot install the vendored artifacts.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name foo))
+  > EOF
+
+  $ mkdir -p vendor/mypkg
+  $ cat >vendor/mypkg/dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name mypkg))
+  > EOF
+
+  $ cat >vendor/mypkg/dune <<EOF
+  > (library
+  >  (name invendor)
+  >  (public_name mypkg.invendor))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (vendored_dirs vendor)
+  > (library
+  >  (libraries mypkg.invendor)
+  >  (public_name foo))
+  > EOF
+
+  $ dune build foo.cma


### PR DESCRIPTION
Demonstrate that a public library is currently allowed to depend on a
public library that is vendored. This should not work.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f09081d7-cadb-4fa8-b1ca-594745994060 -->