### PR TITLE
benchmark: add warm run

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - bench/add-synthetic-benchmark
+      - bench/add-warm-run
 
 permissions:
   # deployments permission to deploy GitHub pages website
@@ -95,17 +95,44 @@ jobs:
         working-directory: bench
         run: opam exec -- ../_boot/dune.exe exec ./gen_synthetic.exe -- -n 2000 synthetic
 
-      - name: Run synthetic benchmark
+      - name: Run cold synthetic benchmark
         working-directory: bench/synthetic
-        run: ../gen-benchmark.sh 'opam exec -- ../../_boot/dune.exe build @all' 'opam exec -- ../../_boot/dune.exe clean' 'synthetic build time (${{ runner.os }})' > synthetic-benchmark-result.json
+        run: ../gen-benchmark.sh 'opam exec -- ../../_boot/dune.exe build @all' 'opam exec -- ../../_boot/dune.exe clean' 'synthetic build time (cold, ${{ runner.os }})' > synthetic-benchmark-result.json
 
-      - name: Print synthetic benchmark results
+      - name: Print cold synthetic benchmark results
         working-directory: bench/synthetic
         run: |
           cat bench.json
           cat synthetic-benchmark-result.json
 
-      - name: Store synthetic benchmark result
+      - name: Store cold synthetic benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Synthetic Benchmark
+          tool: "customSmallerIsBetter"
+          output-file-path: bench/synthetic/synthetic-benchmark-result.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Ratio indicating how worse the current benchmark result is.
+          # 150% means if last build took 40s and current takes >60s, it will trigger an alert
+          alert-threshold: "150%"
+          fail-on-alert: true
+          # Enable alert commit comment
+          comment-on-alert: true
+          # Mention @jchavarri in the commit comment
+          alert-comment-cc-users: '@jchavarri'
+
+      - name: Run warm synthetic benchmark
+        working-directory: bench/synthetic
+        run: ../gen-benchmark.sh 'opam exec -- ../../_boot/dune.exe build @all' 'true' 'synthetic build time (warm, ${{ runner.os }})' > synthetic-benchmark-result.json
+
+      - name: Print warm synthetic benchmark results
+        working-directory: bench/synthetic
+        run: |
+          cat bench.json
+          cat synthetic-benchmark-result.json
+
+      - name: Store warm synthetic benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Synthetic Benchmark


### PR DESCRIPTION
Continuation of #7189.

I am looking at the first results of cold synthetic benchmarks and I am afraid any regressions or improvements on dune specific code might be hard to see because most time in cold builds is spent on calls to ocamlopt.

As [discussed](https://github.com/ocaml/dune/pull/7189#discussion_r1120567355), this PR adds another bench that measures build time for warm builds. It is essentially the same code except the `dune clean` step between runs is replaced with just `true`.

Sample rendered chart: https://jchavarri.github.io/dune/dev/bench/