### PR TITLE
fix: custom log file path

### DIFF
--- a/src/dune_util/log.ml
+++ b/src/dune_util/log.ml
@@ -20,7 +20,9 @@ let init ?(file = File.Default) () =
     match file with
     | No_log_file -> None
     | Out_channel s -> Some s
-    | This path -> Some (Io.open_out path)
+    | This path ->
+      Path.mkdir_p (Path.parent_exn path);
+      Some (Io.open_out path)
     | Default ->
       Path.ensure_build_dir_exists ();
       Some (Io.open_out (Path.relative Path.build_dir "log"))


### PR DESCRIPTION
Create directory when using a custom path for the log file

It's not possible to customize this directory via dune, but I'm using this feature in action runners.

<!-- ps-id: e8c4b148-0c95-4491-bf7e-83a35ec258d7 -->