### PR TITLE
bench: enable macos when running benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - bench/add-synthetic-benchmark
+      - bench/enable-macos
 
 permissions:
   # deployments permission to deploy GitHub pages website
@@ -21,6 +21,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
         ocaml-compiler:
           - 4.14.x
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Install opam deps
         run: |
           opam install . --deps-only
+          opam exec -- make melange # rescript_syntax is needed for pupilfirst
 
       - name: Install hyperfine on macOS
         run: brew install hyperfine

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,8 +43,7 @@ jobs:
 
       - name: Install opam deps
         run: |
-          opam install . --deps-only --with-test
-          opam exec -- make dev-deps
+          opam install . --deps-only
 
       - name: Install hyperfine on macOS
         run: brew install hyperfine

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -41,13 +41,20 @@ jobs:
       # away this makes it possible to see build errors as soon as possible
       - run: opam exec -- make _boot/dune.exe
 
-      - name: Install deps on Unix
+      - name: Install opam deps
         run: |
           opam install . --deps-only --with-test
           opam exec -- make dev-deps
-          # Install hyperfine
+
+      - name: Install hyperfine on macOS
+        run: brew install hyperfine
+        if: ${{ matrix.os == 'macos-latest' }}
+        
+      - name: Install hyperfine on Linux
+        run: |
           wget https://github.com/sharkdp/hyperfine/releases/download/v1.14.0/hyperfine_1.14.0_amd64.deb
           sudo dpkg -i hyperfine_1.14.0_amd64.deb
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Clone pupilfirst repo
         run: git clone https://github.com/jchavarri/pupilfirst.git

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ dev-depext:
 melange:
 	opam pin add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#426463a77d0b70ecf0108c98e6a86d325cd01472
 	opam pin add melange https://github.com/melange-re/melange.git#685e546e290d317a884a4d48c7835467422c6426
+	opam pin add mel https://github.com/melange-re/melange.git#685e546e290d317a884a4d48c7835467422c6426
 
 .PHONY: dev-deps
 dev-deps: melange


### PR DESCRIPTION
Now that there are more benchmarks, it'd be interesting to see differences between linux and mac.