### PR TITLE
fix(rules): merge allowed subdirs correctly for Redirect_to_parent rules

### DIFF
--- a/src/dune_engine/build_config.mli
+++ b/src/dune_engine/build_config.mli
@@ -14,13 +14,27 @@ end
 
 module Rules : sig
   (** Rules for a given directory. This type is structured so that all generated
-      sub-directories (either directory targets or internal generated
+      sub-directories (either directory targets or internally generated
       directories such as [.ppx]) are known immediately, while the actual build
       rules are computed in a second stage. The staging is to avoid computation
       cycles created during the computation of the rules. *)
 
+  module Build_only_sub_dirs : sig
+    (** The set of either directory targets or internally generated directories,
+        indexed by their parent build directory. *)
+    type t
+
+    val empty : t
+
+    val singleton : dir:Path.Build.t -> Subdir_set.t -> t
+
+    val find : t -> Path.Build.t -> Subdir_set.t
+
+    val union : t -> t -> t
+  end
+
   type t =
-    { build_dir_only_sub_dirs : Subdir_set.t
+    { build_dir_only_sub_dirs : Build_only_sub_dirs.t
           (** Sub-directories that don't exist in the source tree but exists in
               the build directory. This is for internal directories such as
               [.dune] or [.ppx]. *)

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -530,6 +530,17 @@ end = struct
               ; ("example", Path.Build.to_dyn p)
               ])
 
+    let check_all_sub_dirs_rule_dirs_are_descendant ~of_:dir
+        build_dir_only_sub_dirs =
+      Path.Build.Map.iteri build_dir_only_sub_dirs ~f:(fun p _sub_dirs ->
+          if not (Path.Build.is_descendant p ~of_:dir) then
+            Code_error.raise
+              "[gen_rules] returned sub-directories in a directory that is not \
+               a descendant of the directory it was called for"
+              [ ("dir", Path.Build.to_dyn dir)
+              ; ("example", Path.Build.to_dyn p)
+              ])
+
     let check_all_rules_are_descendant ~of_:dir rules =
       match
         Path.Build.Map.find_key (Rules.to_map rules) ~f:(fun p ->
@@ -569,6 +580,7 @@ end = struct
         { Build_config.Rules.build_dir_only_sub_dirs; directory_targets; rules }
         =
       check_all_directory_targets_are_descendant ~of_ directory_targets;
+      check_all_sub_dirs_rule_dirs_are_descendant ~of_ directory_targets;
       let rules =
         Memo.lazy_ (fun () ->
             let+ rules = rules in

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -501,14 +501,15 @@ end = struct
 
   module Normal = struct
     type t =
-      { build_dir_only_sub_dirs : Subdir_set.t
+      { build_dir_only_sub_dirs : Build_config.Rules.Build_only_sub_dirs.t
       ; directory_targets : Loc.t Path.Build.Map.t
       ; rules : Rules.t Memo.Lazy.t
       }
 
     let combine_exn r { build_dir_only_sub_dirs; directory_targets; rules } =
       { build_dir_only_sub_dirs =
-          Subdir_set.union r.build_dir_only_sub_dirs build_dir_only_sub_dirs
+          Build_config.Rules.Build_only_sub_dirs.union r.build_dir_only_sub_dirs
+            build_dir_only_sub_dirs
       ; directory_targets =
           Path.Build.Map.union_exn r.directory_targets directory_targets
       ; rules =
@@ -660,6 +661,9 @@ end = struct
       Memo.return
         (Loaded.Build_under_directory_target { directory_target_ancestor })
     | Normal { rules; build_dir_only_sub_dirs; directory_targets } ->
+      let build_dir_only_sub_dirs =
+        Build_config.Rules.Build_only_sub_dirs.find build_dir_only_sub_dirs dir
+      in
       Path.Build.Map.iteri directory_targets ~f:(fun dir_target loc ->
           let name = Path.Build.basename dir_target in
           if

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -350,6 +350,13 @@ let automatic_sub_dirs_map =
     ; (Artifacts.Bin.bin_dir_basename, Bin)
     ]
 
+let automatic_subdirs dir =
+  match Path.Build.basename_opt dir with
+  | None -> String.Set.of_keys automatic_sub_dirs_map
+  | Some basename ->
+    if String.Map.mem automatic_sub_dirs_map basename then String.Set.empty
+    else String.Set.of_keys automatic_sub_dirs_map
+
 let gen_rules_for_automatic_sub_dir ~sctx ~dir kind =
   match kind with
   | Utop -> Utop.setup sctx ~dir:(Path.Build.parent_exn dir)
@@ -364,11 +371,12 @@ let gen_rules_for_automatic_sub_dir ~sctx ~dir kind =
         let dst = File_binding.Expanded.dst_path t ~dir in
         Super_context.add_rule sctx ~loc ~dir (Action_builder.symlink ~src ~dst))
 
-let has_rules subdirs f =
+let has_rules ~dir subdirs f =
   let rules = Rules.collect_unit f in
   Memo.return
     (Build_config.Rules
-       { build_dir_only_sub_dirs = subdirs
+       { build_dir_only_sub_dirs =
+           Build_config.Rules.Build_only_sub_dirs.singleton ~dir subdirs
        ; directory_targets = Path.Build.Map.empty
        ; rules
        })
@@ -405,6 +413,14 @@ let rec under_melange_emit_target ~dir =
       | None -> under_melange_emit_target ~dir:parent
       | Some stanza -> Memo.return @@ Some { stanza_dir = parent; stanza }))
 
+let rules_for ~dir rules =
+  { Build_config.Rules.build_dir_only_sub_dirs =
+      Build_config.Rules.Build_only_sub_dirs.singleton ~dir
+        (Subdir_set.These (automatic_subdirs dir))
+  ; directory_targets = Path.Build.Map.empty
+  ; rules
+  }
+
 let melange_emit_rules sctx { stanza_dir; stanza } =
   let rules =
     Rules.collect_unit (fun () ->
@@ -413,11 +429,7 @@ let melange_emit_rules sctx { stanza_dir; stanza } =
         Melange_rules.setup_emit_js_rules ~dir_contents ~dir:stanza_dir ~scope
           ~sctx stanza)
   in
-  { Build_config.Rules.build_dir_only_sub_dirs =
-      Subdir_set.These (String.Set.of_keys automatic_sub_dirs_map)
-  ; directory_targets = Path.Build.Map.empty
-  ; rules
-  }
+  rules_for ~dir:stanza_dir rules
 
 let gen_melange_emit_rules sctx ~dir ({ stanza_dir; stanza } as for_melange) =
   match
@@ -457,20 +469,15 @@ let gen_melange_emit_rules sctx ~dir ({ stanza_dir; stanza } as for_melange) =
                (Path.Source.to_string parent_melange_emit_dir)
            ]))
 
-let empty_rules =
-  { Build_config.Rules.build_dir_only_sub_dirs =
-      Subdir_set.These (String.Set.of_keys automatic_sub_dirs_map)
-  ; directory_targets = Path.Build.Map.empty
-  ; rules = Memo.return Rules.empty
-  }
-
-let gen_melange_emit_rules_or_empty_redirect sctx ~dir = function
-  | None -> Memo.return Build_config.(Redirect_to_parent empty_rules)
+let gen_melange_emit_rules_or_empty_redirect sctx ~dir under_melange_emit =
+  let empty_rules ~dir = rules_for ~dir (Memo.return Rules.empty) in
+  match under_melange_emit with
+  | None -> Memo.return Build_config.(Redirect_to_parent (empty_rules ~dir))
   | Some for_melange -> (
     let+ melange_rules = gen_melange_emit_rules sctx ~dir for_melange in
     match melange_rules with
     | Some r -> Build_config.Redirect_to_parent r
-    | None -> Build_config.(Redirect_to_parent empty_rules))
+    | None -> Build_config.(Redirect_to_parent (empty_rules ~dir)))
 
 (* Once [gen_rules] has decided what to do with the directory, it should end
    with [has_rules] or [redirect_to_parent] *)
@@ -478,28 +485,28 @@ let gen_rules ~sctx ~dir components : Build_config.gen_rules_result Memo.t =
   let module S = Subdir_set in
   match components with
   | [ ".dune"; "ccomp" ] ->
-    has_rules S.empty (fun () ->
+    has_rules ~dir S.empty (fun () ->
         (* Add rules for C compiler detection *)
         Cxx_rules.rules ~sctx ~dir)
   | [ ".dune" ] ->
-    has_rules
+    has_rules ~dir
       (S.These (String.Set.of_list [ "ccomp" ]))
       (fun () -> Context.gen_configurator_rules (Super_context.context sctx))
   | ".js" :: rest ->
-    has_rules
+    has_rules ~dir
       (match rest with
       | [] -> S.All
       | _ -> S.empty)
       (fun () -> Jsoo_rules.setup_separate_compilation_rules sctx rest)
   | "_doc" :: rest -> Odoc.gen_rules sctx rest ~dir
   | ".topmod" :: comps ->
-    has_rules
+    has_rules ~dir
       (match comps with
       | [] -> S.All
       | _ -> S.empty)
       (fun () -> Top_module.gen_rules sctx ~dir ~comps)
   | ".ppx" :: rest ->
-    has_rules
+    has_rules ~dir
       (match rest with
       | [] -> S.All
       | _ -> S.empty)
@@ -521,7 +528,7 @@ let gen_rules ~sctx ~dir components : Build_config.gen_rules_result Memo.t =
           String.Map.find automatic_sub_dirs_map (Path.Source.basename src_dir)
         with
         | Some kind ->
-          has_rules Subdir_set.empty (fun () ->
+          has_rules ~dir Subdir_set.empty (fun () ->
               gen_rules_for_automatic_sub_dir ~sctx ~dir kind)
         | None ->
           gen_melange_emit_rules_or_empty_redirect sctx ~dir
@@ -565,15 +572,10 @@ let gen_rules ~sctx ~dir components : Build_config.gen_rules_result Memo.t =
         let* directory_targets =
           collect_directory_targets ~dir ~init:directory_targets
         in
-        let automatic_subdirs =
-          match List.last components with
-          | None -> String.Set.of_keys automatic_sub_dirs_map
-          | Some comp ->
-            if String.Map.mem automatic_sub_dirs_map comp then String.Set.empty
-            else String.Set.of_keys automatic_sub_dirs_map
-        in
+        let automatic_subdirs = automatic_subdirs dir in
         let build_config subdirs =
-          { Build_config.Rules.build_dir_only_sub_dirs = subdirs
+          { Build_config.Rules.build_dir_only_sub_dirs =
+              Build_config.Rules.Build_only_sub_dirs.singleton ~dir subdirs
           ; directory_targets
           ; rules
           }
@@ -621,7 +623,8 @@ let gen_rules ctx_or_install ~dir components =
         let+ subdirs, rules = Install_rules.symlink_rules sctx ~dir in
         let directory_targets = Rules.directory_targets rules in
         Build_config.Rules
-          { build_dir_only_sub_dirs = subdirs
+          { build_dir_only_sub_dirs =
+              Build_config.Rules.Build_only_sub_dirs.singleton ~dir subdirs
           ; directory_targets
           ; rules = Memo.return rules
           })

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -801,7 +801,10 @@ let has_rules ?(directory_targets = Path.Build.Map.empty) m =
   let rules = Rules.collect_unit (fun () -> m) in
   Memo.return
     (Build_config.Rules
-       { rules; build_dir_only_sub_dirs = Subdir_set.empty; directory_targets })
+       { rules
+       ; build_dir_only_sub_dirs = Build_config.Rules.Build_only_sub_dirs.empty
+       ; directory_targets
+       })
 
 let with_package pkg ~f =
   let pkg = Package.Name.of_string pkg in
@@ -812,17 +815,20 @@ let with_package pkg ~f =
     Memo.return
       (Build_config.Rules
          { rules = Memo.return Rules.empty
-         ; build_dir_only_sub_dirs = Subdir_set.empty
+         ; build_dir_only_sub_dirs =
+             Build_config.Rules.Build_only_sub_dirs.empty
          ; directory_targets = Path.Build.Map.empty
          })
 
-let gen_rules sctx ~dir:_ rest =
+let gen_rules sctx ~dir rest =
   match rest with
   | [] ->
     Memo.return
       (Build_config.Rules
          { rules = Memo.return Rules.empty
-         ; build_dir_only_sub_dirs = Subdir_set.All
+         ; build_dir_only_sub_dirs =
+             Build_config.Rules.Build_only_sub_dirs.singleton ~dir
+               Subdir_set.All
          ; directory_targets = Path.Build.Map.empty
          })
   | [ "_html" ] ->

--- a/test/blackbox-tests/test-cases/formatting/load-automatic-dirs.t
+++ b/test/blackbox-tests/test-cases/formatting/load-automatic-dirs.t
@@ -1,0 +1,19 @@
+
+  $ touch .ocamlformat
+  $ cat > dune-project << EOF
+  > (lang dune 3.7)
+  > EOF
+  $ mkdir bin
+  $ cat > bin/ocaml_file.ml << EOF
+  > let  y=()
+  > EOF
+  $ cat > dune << EOF
+  > (include_subdirs unqualified)
+  > (library (name lib_reason))
+  > EOF
+  $ dune build ./bin/.formatted/ocaml_file.ml
+
+.formatted dir is loaded
+
+  $ ls _build/default/bin/.formatted
+  ocaml_file.ml


### PR DESCRIPTION
- After https://github.com/ocaml/dune/pull/6637, the engine may redirect rule loading to the parent if it finds that it needs to find rules in the parent directory
- Part of generating rules in a directory is also finding out which sub-directories Dune is allowed to traverse; we store that in the record fields `build_dir_only_sub_dirs`
- However, while `Build_config.Rules.t` can now contain rules for multiple directories, `build_dir_only_sub_dirs` is still a flat set of sub-directories, leading Dune to (wrongly) assume that both directories which had their rules combined can traverse the same set of sub-directories, when that's not the case.
- This diff fixes that inconsistency by tracking the allowed set of sub-directories at each level
  - Specifically, this change unlocks traversing all directories when finding rules for recursive aliases, not just the directories in the source tree.