### PR TITLE
feature: use clonefile on macos

### DIFF
--- a/bench/micro/copyfile.ml
+++ b/bench/micro/copyfile.ml
@@ -1,0 +1,14 @@
+open Stdune
+
+let dir = Temp.create Dir ~prefix:"copyfile" ~suffix:"bench"
+
+let contents = String.make 50_000 '0'
+
+let () =
+  let src = Path.relative dir "initial" in
+  Io.write_file (Path.relative dir "initial") contents;
+  let chmod _ = 444 in
+  for i = 1 to 10_000 do
+    let dst = Path.relative dir (sprintf "dst-%d" i) in
+    Io.copy_file ~chmod ~src ~dst ()
+  done

--- a/bench/micro/dune
+++ b/bench/micro/dune
@@ -1,4 +1,9 @@
 (executable
+ (name copyfile)
+ (modules copyfile)
+ (libraries stdune))
+
+(executable
  (name main)
  (modules main)
  (enabled_if

--- a/otherlibs/stdune/src/copyfile_stubs.c
+++ b/otherlibs/stdune/src/copyfile_stubs.c
@@ -1,0 +1,69 @@
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE
+
+#include <caml/alloc.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+
+#include <copyfile.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syslimits.h>
+
+CAMLprim value stdune_copyfile(value v_from, value v_to) {
+  CAMLparam2(v_from, v_to);
+  caml_unix_check_path(v_from, "copyfile");
+  caml_unix_check_path(v_to, "copyfile");
+  char from[PATH_MAX];
+  char to[PATH_MAX];
+  char real_from[PATH_MAX];
+  int from_len = caml_string_length(v_from);
+  int to_len = caml_string_length(v_to);
+  memcpy(from, String_val(v_from), from_len);
+  memcpy(to, String_val(v_to), to_len);
+  from[from_len] = '\0';
+  to[to_len] = '\0';
+
+  caml_release_runtime_system();
+  /* clonefile doesn't follow symlinks automatically */
+  char *realpath_result = realpath(from, real_from);
+  if (realpath_result == NULL) {
+    caml_acquire_runtime_system();
+    uerror("realpath", v_from);
+  }
+  /* nor does it automatically overwrite the target */
+  int ret = unlink(to);
+  if (ret < 0 && errno != ENOENT) {
+    caml_acquire_runtime_system();
+    uerror("unlink", v_to);
+  }
+  ret = copyfile(real_from, to, NULL, COPYFILE_CLONE);
+  caml_acquire_runtime_system();
+  if (ret < 0) {
+    uerror("copyfile", v_to);
+  }
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value stdune_is_darwin(value v_unit) {
+  CAMLparam1(v_unit);
+  CAMLreturn(Val_true);
+}
+
+#else
+
+CAMLprim value stdune_copyfile(value v_from, value v_to) {
+  caml_failwith("copyfile: only on macos");
+}
+
+CAMLprim value stdune_is_darwin(value v_unit) {
+  CAMLparam1(v_unit);
+  CAMLreturn(Val_false);
+}
+
+#endif

--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -12,6 +12,6 @@
   (re_export dune_filesystem_stubs))
  (foreign_stubs
   (language c)
-  (names wait3_stubs))
+  (names wait3_stubs copyfile_stubs))
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
Use mac's [clonefile] instead of manually copying. [clonefile] is like
hardlink but it will copy-on-write when edited.

The attached benchmark before the optimization:

```
real    0m3.593s
user    0m0.249s
sys     0m2.849s
```

And after:

```
real    0m2.044s
user    0m0.083s
sys     0m1.954s
```

So about a 45% reduction. Not bad. The benchmark also includes how long it took to delete the temp directory at the end (Around 10k additional unlinks), so 45% is likely pessimistic.