### PR TITLE
User-configured watch exclusions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ Unreleased
 - Speed up rule generation for libraries and executables with many modules
   (#7187, @jchavarri)
 
-- Add `--watch-exclusions` to dune build options (#7216, @jonahbeckford)
+- Add `--watch-exclusions` to Dune build options (#7216, @jonahbeckford)
 
 - Do not re-render UI on every frame if the UI doesn't change (#7186, fix
   #7184, @rgrinberg)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ Unreleased
 - Speed up rule generation for libraries and executables with many modules
   (#7187, @jchavarri)
 
+- Add `--watch-exclusions` to dune build options (#7216, @jonahbeckford)
+
 - Do not re-render UI on every frame if the UI doesn't change (#7186, fix
   #7184, @rgrinberg)
 

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -130,6 +130,7 @@ let () =
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No
+    ; watch_exclusions = []
     }
   in
   let clean, zero =

--- a/bench/micro/dune_bench/scheduler_bench.ml
+++ b/bench/micro/dune_bench/scheduler_bench.ml
@@ -10,6 +10,7 @@ let config =
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No
+  ; watch_exclusions = []
   }
 
 let setup =

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -530,6 +530,7 @@ module Builder = struct
     ; separate_error_messages : bool
     ; require_dune_project_file : bool
     ; insignificant_changes : [ `React | `Ignore ]
+    ; watch_exclusions : string list
     ; build_dir : string
     ; store_digest_preimage : bool
     ; root : string option
@@ -537,6 +538,19 @@ module Builder = struct
     }
 
   let set_root t root = { t with root = Some root }
+
+  (** Cmdliner documentation markup language
+      (https://erratique.ch/software/cmdliner/doc/tool_man.html#doclang)
+      requires that dollar signs (ex. $(tname)) and backslashes are escaped. *)
+  let docmarkup_escape s =
+    let b = Buffer.create (2 * String.length s) in
+    for i = 0 to String.length s - 1 do
+      match s.[i] with
+      | '$' -> Buffer.add_string b {|\$|}
+      | '\\' -> Buffer.add_string b {|\\|}
+      | c -> Buffer.add_char b c
+    done;
+    String.of_bytes (Buffer.to_bytes b)
 
   let term =
     let docs = copts_sect in
@@ -765,6 +779,28 @@ module Builder = struct
                ])
             Automatic
         & info [ "file-watcher" ] ~doc)
+    and+ watch_exclusions =
+      let std_exclusions = Dune_config.standard_watch_exclusions in
+      let doc =
+        let escaped_std_exclusions =
+          List.map ~f:docmarkup_escape std_exclusions
+        in
+        "Adds a POSIX regular expression that will exclude matching \
+         directories from $(b,`dune build --watch`). The option $(opt) can be \
+         repeated to add multiple exclusions. Semicolons can be also used as a \
+         separator. If no exclusions are provided, then a standard set of \
+         exclusions is used; however, if $(i,one or more) $(opt) are used, \
+         $(b,none) of the standard exclusions are used. The standard \
+         exclusions are: "
+        ^ String.concat ~sep:" " escaped_std_exclusions
+      in
+      let arg =
+        Arg.(
+          value
+          & opt_all (list ~sep:';' string) [ std_exclusions ]
+          & info [ "watch-exclusions" ] ~docs ~docv:"REGEX" ~doc)
+      in
+      Term.(const List.flatten $ arg)
     and+ wait_for_filesystem_clock =
       Arg.(
         value & flag
@@ -853,6 +889,7 @@ module Builder = struct
     ; require_dune_project_file
     ; insignificant_changes =
         (if react_to_insignificant_changes then `React else `Ignore)
+    ; watch_exclusions
     ; build_dir = Option.value ~default:default_build_dir build_dir
     ; store_digest_preimage
     ; root
@@ -904,6 +941,8 @@ let signal_watcher t =
   | `Forbid_builds ->
     (* if we aren't building anything, then we don't mind interrupting dune immediately *)
     `No
+
+let watch_exclusions t = t.builder.watch_exclusions
 
 let stats t = t.stats
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -546,11 +546,12 @@ module Builder = struct
     let b = Buffer.create (2 * String.length s) in
     for i = 0 to String.length s - 1 do
       match s.[i] with
-      | '$' -> Buffer.add_string b {|\$|}
-      | '\\' -> Buffer.add_string b {|\\|}
+      | ('$' | '\\') as c ->
+        Buffer.add_char b '\\';
+        Buffer.add_char b c
       | c -> Buffer.add_char b c
     done;
-    String.of_bytes (Buffer.to_bytes b)
+    Buffer.contents b
 
   let term =
     let docs = copts_sect in

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -19,6 +19,8 @@ val forbid_builds : t -> t
 
 val signal_watcher : t -> [ `Yes | `No ]
 
+val watch_exclusions : t -> string list
+
 val stats : t -> Dune_stats.t option
 
 val print_metrics : t -> bool

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -151,8 +151,9 @@ module Scheduler = struct
     let config =
       let insignificant_changes = Common.insignificant_changes common in
       let signal_watcher = Common.signal_watcher common in
+      let watch_exclusions = Common.watch_exclusions common in
       Dune_config.for_scheduler dune_config stats ~insignificant_changes
-        ~signal_watcher
+        ~signal_watcher ~watch_exclusions
     in
     let f =
       match Common.rpc common with
@@ -174,8 +175,9 @@ module Scheduler = struct
     let config =
       let signal_watcher = Common.signal_watcher common in
       let insignificant_changes = Common.insignificant_changes common in
+      let watch_exclusions = Common.watch_exclusions common in
       Dune_config.for_scheduler dune_config stats ~insignificant_changes
-        ~signal_watcher
+        ~signal_watcher ~watch_exclusions
     in
     let file_watcher = Common.file_watcher common in
     let run () =

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -437,8 +437,8 @@ let term =
   Log.init_disabled ();
   Dune_engine.Scheduler.Run.go
     ~on_event:(fun _ _ -> ())
-    (Dune_config.for_scheduler config None ~insignificant_changes:`React
-       ~signal_watcher:`No)
+    (Dune_config.for_scheduler config ~watch_exclusions:[] None
+       ~insignificant_changes:`React ~signal_watcher:`No)
     subst
 
 let command = Cmd.v info term

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -267,6 +267,23 @@ module Dune_config = struct
         let field f = f
       end)
 
+  let standard_watch_exclusions =
+    [ {|^_opam|}
+    ; {|/_opam|}
+    ; {|^_esy|}
+    ; {|/_esy|}
+    ; {|^\.#.*|} (* Such files can be created by Emacs and also Dune itself. *)
+    ; {|/\.#.*|}
+    ; {|~$|}
+    ; {|^#[^#]*#$|}
+    ; {|/#[^#]*#$|}
+    ; {|^4913$|} (* https://github.com/neovim/neovim/issues/3460 *)
+    ; {|/4913$|}
+    ; {|/.git|}
+    ; {|/.hg|}
+    ; {|:/windows|}
+    ]
+
   let hash = Poly.hash
 
   let equal a b = Poly.equal a b
@@ -460,7 +477,8 @@ module Dune_config = struct
         in
         loop commands)
 
-  let for_scheduler (t : t) stats ~insignificant_changes ~signal_watcher =
+  let for_scheduler (t : t) ?(watch_exclusions = standard_watch_exclusions)
+      stats ~insignificant_changes ~signal_watcher =
     let concurrency =
       match t.concurrency with
       | Fixed i -> i
@@ -477,5 +495,6 @@ module Dune_config = struct
     ; stats
     ; insignificant_changes
     ; signal_watcher
+    ; watch_exclusions
     }
 end

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -477,8 +477,8 @@ module Dune_config = struct
         in
         loop commands)
 
-  let for_scheduler (t : t) ?(watch_exclusions = standard_watch_exclusions)
-      stats ~insignificant_changes ~signal_watcher =
+  let for_scheduler (t : t) ~watch_exclusions stats ~insignificant_changes
+      ~signal_watcher =
     let concurrency =
       match t.concurrency with
       | Fixed i -> i

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -88,6 +88,9 @@ module Dune_config : sig
     val to_dyn : t -> Dyn.t
   end
 
+  (** A standard list of watch exclusions *)
+  val standard_watch_exclusions : string list
+
   val decode : Partial.t Dune_lang.Decoder.t
 
   (** Decode the same fields as the one accepted in the configuration file, but
@@ -122,8 +125,16 @@ module Dune_config : sig
 
   val equal : t -> t -> bool
 
+  (** [for_scheduler config ?watch_exclusions stats_opt ~insignificant_changes
+      ~signal_watcher]
+      creates a configuration for a scheduler from the user-visible Dune
+      [config].
+
+      [watch_exclusions] defaults to {!standard_watch_exclusions} if not
+      specified. *)
   val for_scheduler :
        t
+    -> ?watch_exclusions:string list
     -> Dune_stats.t option
     -> insignificant_changes:[ `React | `Ignore ]
     -> signal_watcher:[ `Yes | `No ]

--- a/src/dune_config_file/dune_config_file.mli
+++ b/src/dune_config_file/dune_config_file.mli
@@ -128,13 +128,10 @@ module Dune_config : sig
   (** [for_scheduler config ?watch_exclusions stats_opt ~insignificant_changes
       ~signal_watcher]
       creates a configuration for a scheduler from the user-visible Dune
-      [config].
-
-      [watch_exclusions] defaults to {!standard_watch_exclusions} if not
-      specified. *)
+      [config]. *)
   val for_scheduler :
        t
-    -> ?watch_exclusions:string list
+    -> watch_exclusions:string list
     -> Dune_stats.t option
     -> insignificant_changes:[ `React | `Ignore ]
     -> signal_watcher:[ `Yes | `No ]

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -10,6 +10,7 @@ module Config = struct
     ; stats : Dune_stats.t option
     ; insignificant_changes : [ `Ignore | `React ]
     ; signal_watcher : [ `Yes | `No ]
+    ; watch_exclusions : string list
     }
 end
 
@@ -1234,7 +1235,7 @@ module Run = struct
                ; thread_safe_send_emit_events_job =
                    (fun job -> Event_queue.send_file_watcher_task events job)
                }
-             ())
+             ~watch_exclusions:config.watch_exclusions ())
     in
     let t = prepare ~file_watcher in
     let initial_invalidation = Fs_memo.init ~dune_file_watcher:file_watcher in

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -8,6 +8,7 @@ module Config : sig
     ; stats : Dune_stats.t option
     ; insignificant_changes : [ `Ignore | `React ]
     ; signal_watcher : [ `Yes | `No ]
+    ; watch_exclusions : string list
     }
 end
 

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -153,7 +153,7 @@ module Re = Dune_re
 let exclude_regex watch_exclusions =
   Re.compile (Re.alt (List.map watch_exclusions ~f:Re.Posix.re))
 
-let should_exclude path watch_exclusions =
+let should_exclude path ~watch_exclusions =
   Re.execp (exclude_regex watch_exclusions) path
 
 module For_tests = struct
@@ -163,7 +163,7 @@ end
 let process_inotify_event (event : Async_inotify_for_dune.Async_inotify.Event.t)
     watch_exclusions : Event.t list =
   let create_event_unless_excluded ~kind ~path =
-    match should_exclude path watch_exclusions with
+    match should_exclude path ~watch_exclusions with
     | true -> []
     | false ->
       let path = Path.of_string path in
@@ -598,7 +598,7 @@ let fswatch_win_callback ~(scheduler : Scheduler.t) ~sync_table
       String.concat ~sep:"/"
         (String.split_on_char ~sep:'\\' (String.lowercase_ascii filename))
     in
-    if not (should_exclude normalized_filename watch_exclusions) then
+    if not (should_exclude normalized_filename ~watch_exclusions) then
       scheduler.thread_safe_send_emit_events_job (fun () ->
           let kind =
             match Fswatch_win.Event.action event with

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -151,6 +151,8 @@ type t =
 module Re = Dune_re
 
 let create_should_exclude_predicate ~watch_exclusions =
+  (* TODO we should really take the predicate directly and not depend on
+     regular expressions in our file watching component *)
   Re.execp (Re.compile (Re.alt (List.map watch_exclusions ~f:Re.Posix.re)))
 
 module For_tests = struct

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -80,5 +80,5 @@ val emit_sync : t -> Sync_id.t
 val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
 
 module For_tests : sig
-  val should_exclude : string -> string list -> bool
+  val should_exclude : string -> watch_exclusions:string list -> bool
 end

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -61,7 +61,11 @@ end
 
 (** Create a new file watcher with default settings. *)
 val create_default :
-  ?fsevents_debounce:float -> scheduler:Scheduler.t -> unit -> t
+     ?fsevents_debounce:float
+  -> watch_exclusions:string list
+  -> scheduler:Scheduler.t
+  -> unit
+  -> t
 
 (** The action that needs to be taken to shutdown the watcher. *)
 val shutdown : t -> [ `Kill of Pid.t | `No_op | `Thunk of unit -> unit ]
@@ -76,5 +80,5 @@ val emit_sync : t -> Sync_id.t
 val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
 
 module For_tests : sig
-  val should_exclude : string -> bool
+  val should_exclude : string -> string list -> bool
 end

--- a/src/dune_file_watcher/dune_file_watcher.mli
+++ b/src/dune_file_watcher/dune_file_watcher.mli
@@ -80,5 +80,5 @@ val emit_sync : t -> Sync_id.t
 val add_watch : t -> Path.t -> (unit, [ `Does_not_exist ]) result
 
 module For_tests : sig
-  val should_exclude : string -> watch_exclusions:string list -> bool
+  val should_exclude : watch_exclusions:string list -> string -> bool
 end

--- a/test/blackbox-tests/test-cases/watching/what-dune-watches.t
+++ b/test/blackbox-tests/test-cases/watching/what-dune-watches.t
@@ -21,6 +21,6 @@ The pattern below excludes absolute files as Dune currently watches
 everything in the PATH, which is not very reproducible.
 
   $ sed -nE 's/inotify_add_watch\([0-9]*, "([^/].*)", .*\) (=.*)/watch \1 \2/p' ../log | sort -u
-  watch . = 2
+  watch . = 1
   watch _build/.sync = 1
-  watch src = 3
+  watch src = 2

--- a/test/blackbox-tests/test-cases/watching/what-dune-watches.t
+++ b/test/blackbox-tests/test-cases/watching/what-dune-watches.t
@@ -21,17 +21,17 @@ The pattern below excludes absolute files as Dune currently watches
 everything in the PATH, which is not very reproducible.
 
   $ sed -nE 's/inotify_add_watch\([0-9]*, "([^/].*)", .*\) (=.*)/watch \1 \2/p' ../log | sort -u
-  watch . = 1
+  watch . = 2
   watch _build/.sync = 1
-  watch src = 2
+  watch src = 3
 
 Since the pattern above is not reproducible, uncomment the next lines
 to see what it is really doing
 #  $ sed -nE 's/inotify_add_watch\([0-9]*, "(.*)", .*\) (=.*)/watch \1 \2/p' ../log | sort -u -k4n -k2 | sed "s,$OPAM_SWITCH_PREFIX,OPAM_SWITCH_PREFIX," | sed "s,$DUNE_SOURCEROOT,DUNE_SOURCEROOT,"
-#  watch . = 1
 #  watch _build/.sync = 1
-#  watch src = 2
-#  watch DUNE_SOURCEROOT/_build/default/test/blackbox-tests/test-cases/.bin = 3
-#  watch DUNE_SOURCEROOT/_build/install/default/bin = 4
-#  watch OPAM_SWITCH_PREFIX/bin = 5
-#  watch OPAM_SWITCH_PREFIX/lib/ocaml = 6
+#  watch . = 2
+#  watch src = 3
+#  watch DUNE_SOURCEROOT/_build/default/test/blackbox-tests/test-cases/.bin = 4
+#  watch DUNE_SOURCEROOT/_build/install/default/bin = 5
+#  watch OPAM_SWITCH_PREFIX/bin = 6
+#  watch OPAM_SWITCH_PREFIX/lib/ocaml = 7

--- a/test/blackbox-tests/test-cases/watching/what-dune-watches.t
+++ b/test/blackbox-tests/test-cases/watching/what-dune-watches.t
@@ -24,3 +24,14 @@ everything in the PATH, which is not very reproducible.
   watch . = 1
   watch _build/.sync = 1
   watch src = 2
+
+Since the pattern above is not reproducible, uncomment the next lines
+to see what it is really doing
+#  $ sed -nE 's/inotify_add_watch\([0-9]*, "(.*)", .*\) (=.*)/watch \1 \2/p' ../log | sort -u -k4n -k2 | sed "s,$OPAM_SWITCH_PREFIX,OPAM_SWITCH_PREFIX," | sed "s,$DUNE_SOURCEROOT,DUNE_SOURCEROOT,"
+#  watch . = 1
+#  watch _build/.sync = 1
+#  watch src = 2
+#  watch DUNE_SOURCEROOT/_build/default/test/blackbox-tests/test-cases/.bin = 3
+#  watch DUNE_SOURCEROOT/_build/install/default/bin = 4
+#  watch OPAM_SWITCH_PREFIX/bin = 5
+#  watch OPAM_SWITCH_PREFIX/lib/ocaml = 6

--- a/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
+++ b/test/expect-tests/csexp_rpc/csexp_rpc_tests.ml
@@ -85,6 +85,7 @@ let%expect_test "csexp server life cycle" =
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No
+    ; watch_exclusions = []
     }
   in
   Scheduler.Run.go config run ~on_event:(fun _ _ -> ());

--- a/test/expect-tests/dune_action_runner/dune_action_runner.ml
+++ b/test/expect-tests/dune_action_runner/dune_action_runner.ml
@@ -109,6 +109,7 @@ let%expect_test "run an action runner and dispatch one job to it" =
     ; stats = None
     ; insignificant_changes = `Ignore
     ; signal_watcher = `No
+    ; watch_exclusions = []
     }
   in
   Scheduler.Run.go config ~timeout:2.0 ~on_event run;

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -59,6 +59,7 @@
    (sandbox always)))
  (libraries
   base
+  dune_config_file
   dune_file_watcher
   ppx_expect.config
   ppx_expect.config_types

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -59,6 +59,7 @@
    (sandbox always)))
  (libraries
   base
+  dune_config
   dune_file_watcher
   ppx_expect.config
   ppx_expect.config_types

--- a/test/expect-tests/dune_file_watcher/dune
+++ b/test/expect-tests/dune_file_watcher/dune
@@ -59,7 +59,6 @@
    (sandbox always)))
  (libraries
   base
-  dune_config
   dune_file_watcher
   ppx_expect.config
   ppx_expect.config_types

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_linux.ml
@@ -16,7 +16,7 @@ let%expect_test _ =
                   let events = job () in
                   events_buffer := !events_buffer @ events))
         }
-      ()
+      ~watch_exclusions:[] ()
   in
   let try_to_get_events () =
     critical_section mutex ~f:(fun () ->

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_macos.ml
@@ -16,7 +16,7 @@ let%expect_test _ =
                   let events = job () in
                   events_buffer := !events_buffer @ events))
         }
-      ()
+      ~watch_exclusions:[] ()
   in
   let try_to_get_events () =
     critical_section mutex ~f:(fun () ->

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
@@ -1,10 +1,9 @@
 let printf = Printf.printf
 
 let test string =
-  printf "should_exclude(%s) = %s\n" string
+  printf "should_exclude(%s) = %b\n" string
     (Dune_file_watcher.For_tests.should_exclude string
-       Dune_config.standard_watch_exclusions
-    |> Bool.to_string)
+       Dune_config.standard_watch_exclusions)
 
 let%expect_test _ =
   test "file.ml";

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
@@ -2,7 +2,9 @@ let printf = Printf.printf
 
 let test string =
   printf "should_exclude(%s) = %s\n" string
-    (Dune_file_watcher.For_tests.should_exclude string |> Bool.to_string)
+    (Dune_file_watcher.For_tests.should_exclude string
+       Dune_config.standard_watch_exclusions
+    |> Bool.to_string)
 
 let%expect_test _ =
   test "file.ml";

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
@@ -1,9 +1,19 @@
 let printf = Printf.printf
 
 let test string =
+  let watch_exclusions =
+    [ {|^_opam|}
+    ; {|/_opam|}
+    ; {|^\.#.*|}
+    ; {|/\.#.*|}
+    ; {|^#[^#]*#$|}
+    ; {|/#[^#]*#$|}
+    ; {|^4913$|}
+    ; {|/4913$|}
+    ]
+  in
   printf "should_exclude(%s) = %b\n" string
-    (Dune_file_watcher.For_tests.should_exclude string
-       Dune_config.standard_watch_exclusions)
+    (Dune_file_watcher.For_tests.should_exclude string ~watch_exclusions)
 
 let%expect_test _ =
   test "file.ml";

--- a/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
+++ b/test/expect-tests/dune_file_watcher/dune_file_watcher_tests_patterns.ml
@@ -1,19 +1,9 @@
 let printf = Printf.printf
 
 let test string =
-  let watch_exclusions =
-    [ {|^_opam|}
-    ; {|/_opam|}
-    ; {|^\.#.*|}
-    ; {|/\.#.*|}
-    ; {|^#[^#]*#$|}
-    ; {|/#[^#]*#$|}
-    ; {|^4913$|}
-    ; {|/4913$|}
-    ]
-  in
   printf "should_exclude(%s) = %b\n" string
-    (Dune_file_watcher.For_tests.should_exclude string ~watch_exclusions)
+    (Dune_file_watcher.For_tests.should_exclude string
+       ~watch_exclusions:Dune_config_file.Dune_config.standard_watch_exclusions)
 
 let%expect_test _ =
   test "file.ml";

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -165,6 +165,7 @@ let config =
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No
+  ; watch_exclusions = []
   }
 
 let run run =

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_registry_test.ml
@@ -50,6 +50,7 @@ let run =
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No
+    ; watch_exclusions = []
     }
   in
   fun run ->

--- a/test/expect-tests/process_tests.ml
+++ b/test/expect-tests/process_tests.ml
@@ -9,6 +9,7 @@ let go =
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `Yes
+    ; watch_exclusions = []
     }
   in
   Scheduler.Run.go config ~file_watcher:No_watcher ~on_event:(fun _ _ -> ())

--- a/test/expect-tests/scheduler_tests.ml
+++ b/test/expect-tests/scheduler_tests.ml
@@ -9,6 +9,7 @@ let default =
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No
+  ; watch_exclusions = []
   }
 
 let go ?(timeout = 0.3) ?(config = default) f =

--- a/test/expect-tests/timer_tests.ml
+++ b/test/expect-tests/timer_tests.ml
@@ -8,6 +8,7 @@ let config =
   ; stats = None
   ; insignificant_changes = `React
   ; signal_watcher = `No
+  ; watch_exclusions = []
   }
 
 let%expect_test "create and wait for timer" =

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -116,6 +116,7 @@ let run kind script =
     ; stats = None
     ; insignificant_changes = `React
     ; signal_watcher = `No
+    ; watch_exclusions = []
     }
   in
   Scheduler.Run.go


### PR DESCRIPTION
This PR allows the command line option `--exclude-from-watch` to exclude directories from dune build --watch. ~~It should exclude more directories if those are listed in dune-workspace: (context (default (watch_exclusions node_modules doc)))~~

~~However I got lost in the Dune code base and can't figure out a way to get the Dune workspace information into the Dune file watcher. Need help with that!~~

(This is a continuation of https://github.com/ocaml/dune/pull/7086 by @nojb that was reviewed by @rgrinberg )