### PR TITLE
chore: update flakes, melange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ dev-depext:
 
 .PHONY: melange
 melange:
-	opam pin add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#426463a77d0b70ecf0108c98e6a86d325cd01472
-	opam pin add melange https://github.com/melange-re/melange.git#685e546e290d317a884a4d48c7835467422c6426
+	opam pin add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#48ff923f2c25136de8ab96678f623f54cdac438c
+	opam pin add melange https://github.com/melange-re/melange.git#13edf6108d884e64cd510bce077ef2ce73de6a97
 
 .PHONY: dev-deps
 dev-deps: melange

--- a/flake.lock
+++ b/flake.lock
@@ -90,14 +90,15 @@
           "nixpkgs"
         ],
         "poetry2nix": "poetry2nix",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "pruned-racket-catalog": "pruned-racket-catalog"
       },
       "locked": {
-        "lastModified": 1674289703,
-        "narHash": "sha256-EyEazU548J/ML3LWInP0B0ZpusCWu5NIzDkTr9Irrjc=",
+        "lastModified": 1676992344,
+        "narHash": "sha256-TEn5kEi/jL9Dt6O+ZZ7kQwnlAgEv0r4VgQZnav/cfV4=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "759c70ed33bb289023daa4a75d3dedfcc7b6dd4d",
+        "rev": "db72710500a80bdf4589b6807d2491a4a0dae3ad",
         "type": "github"
       },
       "original": {
@@ -164,14 +165,18 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "melange",
+          "dream2nix",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1668450977,
-        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
+        "lastModified": 1675933616,
+        "narHash": "sha256-/rczJkJHtx16IFxMmAWu5nNYcSXNg1YYXTHoGjLrLUA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
+        "rev": "47478a4a003e745402acf63be7f9a092d51b83d7",
         "type": "github"
       },
       "original": {
@@ -182,11 +187,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -212,11 +217,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -242,21 +247,6 @@
     },
     "flake-utils_4": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
-      "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
@@ -270,7 +260,7 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_5": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -351,17 +341,21 @@
     "melange": {
       "inputs": {
         "dream2nix": "dream2nix",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "melange-compiler-libs": "melange-compiler-libs",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nix-overlays"
+        ]
       },
       "locked": {
-        "lastModified": 1673903864,
-        "narHash": "sha256-QNwvAieqe6ssAo6B76zrpui9KyBX4LqKtxE8zdJEqdo=",
+        "lastModified": 1677881899,
+        "narHash": "sha256-c4rONqHxGaW31WmFDPSWCJ5Z+IKJXiAUei6n4VaqqXQ=",
         "owner": "melange-re",
         "repo": "melange",
-        "rev": "0be7b2866486f395ba459aae39c64b33bda69475",
+        "rev": "0c1aa1f8e1754c6810222a7a54e02e1adc337abe",
         "type": "github"
       },
       "original": {
@@ -382,11 +376,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669333226,
-        "narHash": "sha256-7yik4uYRAsCngs8AeZeYESCtU3LfCjjEaIQj7Sbjwhk=",
+        "lastModified": 1677175105,
+        "narHash": "sha256-jPp5jpjT9oD2YzAzEBSaQUBBf7+zUU/A3KDwNVuV32A=",
         "owner": "melange-re",
         "repo": "melange-compiler-libs",
-        "rev": "426463a77d0b70ecf0108c98e6a86d325cd01472",
+        "rev": "48ff923f2c25136de8ab96678f623f54cdac438c",
         "type": "github"
       },
       "original": {
@@ -429,11 +423,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1666547822,
-        "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
+        "lastModified": 1676294984,
+        "narHash": "sha256-hdLUa/3RH1VJ+gMUysQE0JGM4F2Q/tIIFbtoxAOurJQ=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "1a3b735e13e90a8d2fd5629f2f8363bd7ffbbec7",
+        "rev": "fc282c5478e4141842f9644c239a41cfe9586732",
         "type": "github"
       },
       "original": {
@@ -444,19 +438,19 @@
     },
     "nix-overlays": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1674835915,
-        "narHash": "sha256-gKQJMX5aGkyWc1sonA8PCxDH7ajXYPixNj0HAx2evIg=",
-        "owner": "anmonteiro",
+        "lastModified": 1678045605,
+        "narHash": "sha256-eSbG6LkKAj6fJ+9pCJ3uF6KL02Zw2AFRkHVBXFiZHhg=",
+        "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "ee088939adc793ee7af946adcec73fdf69ef347c",
+        "rev": "cdfe1fe56180dc4136cee7fe2296ec1313420b2e",
         "type": "github"
       },
       "original": {
-        "owner": "anmonteiro",
+        "owner": "nix-ocaml",
         "repo": "nix-overlays",
         "type": "github"
       }
@@ -478,84 +472,28 @@
       }
     },
     "nixpkgs": {
-      "inputs": {
-        "flake-utils": [
-          "melange",
-          "flake-utils"
-        ],
-        "nixpkgs": "nixpkgs_2"
-      },
       "locked": {
-        "lastModified": 1673369367,
-        "narHash": "sha256-w+NQkhcUvwVhMB0Q9psIzXzNHCufVPsrbX+rlKCDLmU=",
-        "owner": "anmonteiro",
-        "repo": "nix-overlays",
-        "rev": "6b5187a3e3b91a81b4b1f3a9165be3c8a27b900d",
+        "lastModified": 1677932085,
+        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
         "type": "github"
       },
       "original": {
-        "owner": "anmonteiro",
-        "repo": "nix-overlays",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
+        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1673179929,
-        "narHash": "sha256-mkDqQat24NMqf4z5rK6M4Y+68qVauCSDYouqD3hl66c=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1673179929,
-        "narHash": "sha256-mkDqQat24NMqf4z5rK6M4Y+68qVauCSDYouqD3hl66c=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1673947312,
-        "narHash": "sha256-xx/2nRwRy3bXrtry6TtydKpJpqHahjuDB5sFkQ/XNDE=",
+        "lastModified": 1677852945,
+        "narHash": "sha256-liiVJjkBTuBTAkRW3hrI8MbPD2ImYzwUpa7kvteiKhM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d38b664b4400335086a713a0036aafaa002c003",
+        "rev": "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb",
         "type": "github"
       },
       "original": {
@@ -565,7 +503,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1673466167,
         "narHash": "sha256-1HzUCtWwHRGzTOHCIKGG0lVL6wvsyPSSyBuIqZWYowc=",
@@ -581,7 +519,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1671359686,
         "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
@@ -597,7 +535,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1671359686,
         "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
@@ -615,17 +553,17 @@
     },
     "ocamllsp": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_5",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository"
       },
       "locked": {
-        "lastModified": 1674804192,
-        "narHash": "sha256-6bH9uG8ItFDRCrK9iIX0yiySdckGGP+vJQHsk1aKy+4=",
+        "lastModified": 1675751905,
+        "narHash": "sha256-lhxhMKdbxGKXy6sSHUQKYM97nJ8G7f3ym6p2abBNxhU=",
         "ref": "refs/heads/master",
-        "rev": "82dc380ec7ecb6fe4545d90732f75ec222f2b851",
-        "revCount": 1964,
+        "rev": "1dc8c324aa5aae2f94f6c92e238966312e45e039",
+        "revCount": 1965,
         "submodules": true,
         "type": "git",
         "url": "https://www.github.com/ocaml/ocaml-lsp"
@@ -639,9 +577,9 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "mirage-opam-overlays": "mirage-opam-overlays",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_4",
         "opam-overlays": "opam-overlays",
         "opam-repository": [
           "ocamllsp",
@@ -666,9 +604,9 @@
     "opam-nix_2": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "mirage-opam-overlays": "mirage-opam-overlays_2",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_5",
         "opam-overlays": "opam-overlays_2",
         "opam-repository": [
           "opam-repository"
@@ -676,11 +614,11 @@
         "opam2json": "opam2json_2"
       },
       "locked": {
-        "lastModified": 1674593932,
-        "narHash": "sha256-it6OdxUuM1Dq7TAGMs9A0og9MBOwEaUfj8nLEfcbI3I=",
+        "lastModified": 1677575814,
+        "narHash": "sha256-Lc1GXBw0AiXGukJqzwtVEqBYv+DLUqcsqc8Lc3OtgUA=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "5486c7425c5e60a6836ee8778cd5a4cd861e64db",
+        "rev": "4bb1a4c372f639f44fc6745f13c86f4397e82d34",
         "type": "github"
       },
       "original": {
@@ -740,11 +678,11 @@
     "opam-repository_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1674839464,
-        "narHash": "sha256-Nqmwub7lKB7Dl9pTUm4X2NJVAdflg1TjTrNw+GTlvNQ=",
+        "lastModified": 1678031116,
+        "narHash": "sha256-+5ecaSuby0cyMtP3cjYWt4FWei67vBJdNTjgaE5AIuU=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "a9fb5a379794b0d5d7f663ff3a3bed5d4672a5d3",
+        "rev": "962a2fa95538805b0d4b26fd4dd08b798d3af93b",
         "type": "github"
       },
       "original": {
@@ -840,12 +778,29 @@
         "type": "github"
       }
     },
+    "pruned-racket-catalog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672537287,
+        "narHash": "sha256-SuOvXVcLfakw18oJB/PuRMyvGyGG1+CQD3R+TGHIv44=",
+        "owner": "nix-community",
+        "repo": "pruned-racket-catalog",
+        "rev": "c8b89557fb53b36efa2ee48a769c7364df0f6262",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "catalog",
+        "repo": "pruned-racket-catalog",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "melange": "melange",
         "nix-overlays": "nix-overlays",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_2",
         "ocamllsp": "ocamllsp",
         "opam-nix": "opam-nix_2",
         "opam-repository": "opam-repository_2"

--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1678045605,
-        "narHash": "sha256-eSbG6LkKAj6fJ+9pCJ3uF6KL02Zw2AFRkHVBXFiZHhg=",
+        "lastModified": 1678134388,
+        "narHash": "sha256-B908rT6KqqGkKvJAveh2Em9SUlj59G0Dq9x4MaU7z5o=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "cdfe1fe56180dc4136cee7fe2296ec1313420b2e",
+        "rev": "695f82d8c6ecbaee6545ada16121955cfcff72ca",
         "type": "github"
       },
       "original": {
@@ -473,27 +473,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677932085,
-        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
+        "lastModified": 1678101937,
+        "narHash": "sha256-Trmgbc6DTXaofJHbegtN1YCJUIjBOg5ByRHYtxLf1qU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
+        "rev": "b6cc2f2979a19ec2983cef156d5d44b2fe0e545f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
+        "rev": "b6cc2f2979a19ec2983cef156d5d44b2fe0e545f",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1677852945,
-        "narHash": "sha256-liiVJjkBTuBTAkRW3hrI8MbPD2ImYzwUpa7kvteiKhM=",
+        "lastModified": 1678086707,
+        "narHash": "sha256-y1uXdxzinIne4FW3TF7DCtxEB9gAbQ4qnbpYzhvkFm8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb",
+        "rev": "21eda9bc80bef824a037582b1e5a43ba74e92daa",
         "type": "github"
       },
       "original": {
@@ -559,11 +559,11 @@
         "opam-repository": "opam-repository"
       },
       "locked": {
-        "lastModified": 1675751905,
-        "narHash": "sha256-lhxhMKdbxGKXy6sSHUQKYM97nJ8G7f3ym6p2abBNxhU=",
+        "lastModified": 1678131196,
+        "narHash": "sha256-ADDIn4qhLf1DEi638FAmJBgZQ7ud2PAcvMhYyiNR69g=",
         "ref": "refs/heads/master",
-        "rev": "1dc8c324aa5aae2f94f6c92e238966312e45e039",
-        "revCount": 1965,
+        "rev": "a2fe6ffa00c422610d693ef761d92c769a139b27",
+        "revCount": 1966,
         "submodules": true,
         "type": "git",
         "url": "https://www.github.com/ocaml/ocaml-lsp"
@@ -678,11 +678,11 @@
     "opam-repository_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1678031116,
-        "narHash": "sha256-+5ecaSuby0cyMtP3cjYWt4FWei67vBJdNTjgaE5AIuU=",
+        "lastModified": 1678132807,
+        "narHash": "sha256-oOZ1IZeCPBUDaVvBzSdOI3mkT0rUBEZcdLZLRxgNMbQ=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "962a2fa95538805b0d4b26fd4dd08b798d3af93b",
+        "rev": "30146f6643f250e1cc494a88095a48e62e1322a1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nix-overlays.url = "github:anmonteiro/nix-overlays";
+    nix-overlays.url = "github:nix-ocaml/nix-overlays";
     flake-utils.url = "github:numtide/flake-utils";
     ocamllsp.url = "git+https://www.github.com/ocaml/ocaml-lsp?submodules=1";
     opam-nix = {
@@ -12,7 +12,11 @@
       url = "github:ocaml/opam-repository";
       flake = false;
     };
-    melange.url = "github:melange-re/melange";
+    melange = {
+      url = "github:melange-re/melange";
+      inputs.nixpkgs.follows = "nix-overlays";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
   outputs =
     { self

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -4,9 +4,9 @@
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
   $ melc_where="$(melc -where)"
   $ IFS=: read -r melc_stdlib melc_stdlib2 melc_stdlib3 <<< "$melc_where"
-  $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE1=$melc_stdlib:$BUILD_PATH_PREFIX_MAP"
-  $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE2=$melc_stdlib2:$BUILD_PATH_PREFIX_MAP"
-  $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE3=$melc_stdlib3:$BUILD_PATH_PREFIX_MAP"
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_STDLIB=$melc_stdlib:$BUILD_PATH_PREFIX_MAP"
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_STDLIB=$melc_stdlib2:$BUILD_PATH_PREFIX_MAP"
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_STDLIB=$melc_stdlib3:$BUILD_PATH_PREFIX_MAP"
   $ melc_compiler="$(which melc)"
   $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
 
@@ -62,12 +62,15 @@ Dump-dot-merlin includes the melange flags
 
   $ dune ocaml dump-dot-merlin $PWD
   EXCLUDE_QUERY_DIR
-  STDLIB /MELC_WHERE
+  STDLIB /MELC_STDLIB
+  B /MELC_STDLIB
+  B /MELC_STDLIB
   B $TESTCASE_ROOT/_build/default/.output.mobjs/melange
   S $TESTCASE_ROOT
   # FLG -ppx '/MELC_COMPILER -as-ppx -bs-jsx 3'
   # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs
   
+
 
 
 Check for flag directives ordering when another preprocessor is defined
@@ -106,8 +109,13 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
 
   $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S "
   Bar
-  ((STDLIB /MELC_WHERE)
+  ((STDLIB
+    /MELC_STDLIB)
    (EXCLUDE_QUERY_DIR)
+   (B
+    /MELC_STDLIB)
+   (B
+    /MELC_STDLIB)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (S
@@ -128,8 +136,13 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
      -short-paths
      -keep-locs)))
   Foo
-  ((STDLIB /MELC_WHERE)
+  ((STDLIB
+    /MELC_STDLIB)
    (EXCLUDE_QUERY_DIR)
+   (B
+    /MELC_STDLIB)
+   (B
+    /MELC_STDLIB)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
    (S

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -3,7 +3,10 @@
   $ ocamlc_where="$(ocamlc -where)"
   $ export BUILD_PATH_PREFIX_MAP="/OCAMLC_WHERE=$ocamlc_where:$BUILD_PATH_PREFIX_MAP"
   $ melc_where="$(melc -where)"
-  $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE=$melc_where:$BUILD_PATH_PREFIX_MAP"
+  $ IFS=: read -r melc_stdlib melc_stdlib2 melc_stdlib3 <<< "$melc_where"
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE1=$melc_stdlib:$BUILD_PATH_PREFIX_MAP"
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE2=$melc_stdlib2:$BUILD_PATH_PREFIX_MAP"
+  $ export BUILD_PATH_PREFIX_MAP="/MELC_WHERE3=$melc_stdlib3:$BUILD_PATH_PREFIX_MAP"
   $ melc_compiler="$(which melc)"
   $ export BUILD_PATH_PREFIX_MAP="/MELC_COMPILER=$melc_compiler:$BUILD_PATH_PREFIX_MAP"
 


### PR DESCRIPTION
- run `nix flake update` to get the newest melange hash
  - tests dune with the most recent melange, using dune to compile its own stdlib / runtime
