### PR TITLE
fix: ignore sigpipe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Unreleased
 ----------
 
+- Ignore `SIGPIPE` raised when we write to suddenly disonnected RPC clients
+  (#7221, fixes #6870, @rgrinberg)
+
+- Speed up file copying on macos by using `clonefile` when available
+  (@rgrinberg, #7210)
+
 - Support commands that output 8-bit and 24-bit colors in the terminal (#7188,
   @Alizter)
 

--- a/src/dune_console/combinators.mli
+++ b/src/dune_console/combinators.mli
@@ -3,3 +3,6 @@ val flush : Backend_intf.t -> Backend_intf.t
 
 (** Creates a backend that writes to both backends in sequence *)
 val compose : Backend_intf.t -> Backend_intf.t -> Backend_intf.t
+
+(** A backend that will signal [Sys.sigusr1] on an [EPIPE] error *)
+val signal_usr1_on_pipe : Backend_intf.t -> Backend_intf.t

--- a/src/dune_console/dune_console.ml
+++ b/src/dune_console/dune_console.ml
@@ -5,9 +5,9 @@ module type Backend = Backend_intf.S
 module Backend = struct
   type t = Backend_intf.t
 
-  let dumb = (module Dumb : Backend_intf.S)
+  let dumb = Combinators.signal_usr1_on_pipe (module Dumb : Backend_intf.S)
 
-  let progress = Progress.flush
+  let progress = Combinators.signal_usr1_on_pipe Progress.flush
 
   let compose = Combinators.compose
 

--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -111,6 +111,8 @@ let make (module Base : S) : (module Dune_console.Backend) =
         done
       with
       | Exit -> cleanup ()
+      | Unix.Unix_error (Unix.EPIPE, _, _) ->
+        Unix.kill (Unix.getpid ()) Sys.sigusr1
       | exn ->
         (* If any unexpected exceptions are encountered, we catch them, make
            sure we [cleanup] and then re-raise them. *)


### PR DESCRIPTION
Dune would disconnect on writes to clients that suddenly disconnected
because of a sigpipe. We ignore sigpipe and manually shutdown the
scheduler

fixes #6870

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2d62e5a9-470f-4df8-8f45-cbdd035142ea -->