### PR TITLE
fix: add a dependency on current build run in `Source_tree.root`

### DIFF
--- a/src/dune_engine/source_tree.ml
+++ b/src/dune_engine/source_tree.ml
@@ -586,6 +586,7 @@ end = struct
     | Some kind -> Dir0.This { Vcs.kind; root = Path.(append_source root) path }
 
   let root () =
+    let* (_ : Memo.Run.t) = Memo.current_run () in
     let path = Path.Source.root in
     let dir_status : Sub_dirs.Status.t = Normal in
     let error_unable_to_load ~path unix_error =


### PR DESCRIPTION
Fixes #5549.

Adds a dependency on current build run in `Source_tree.root`. The fix was found by bisecting until I found the place where the parallelism in `dune watch` regressed (more details on original issue conversation). Hopefully the fix is correct, and someone with more knowledge can explain what the issue was, and why this fixes it 😅 Debugging and understanding memoization issues is not straightforward to me.

- The dependency on current build run was originally added in https://github.com/ocaml/dune/pull/2706.
- Then removed in https://github.com/ocaml/dune/pull/4422, where dune watch parallelism regressed.