### PR TITLE
test: fix macOS test suite

### DIFF
--- a/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
+++ b/test/blackbox-tests/test-cases/jsoo/simple.t/run.t
@@ -29,4 +29,4 @@ disable_dynamically_linked_foreign_archives = true:
 
 We expect a runtime error when running this bc-for-jsoo file.
 
-  $ ! dune exe bin/technologic.bc-for-jsoo >/dev/null 2>&1
+  $ ! if dune exe bin/technologic.bc-for-jsoo ; then true ; else false ; fi 2> /dev/null


### PR DESCRIPTION
- macOS tests are currently printing an `Abort trap: 6` message ([example run](https://github.com/ocaml/dune/actions/runs/4356406454/jobs/7614372124))
- this seems to have been introduced in https://github.com/ocaml/dune/pull/7156
- this PR keeps the same behavior but suppresses the abort output by running the relevant command inside a shell `if`