### PR TITLE
fix(memo): optimize node invalidation

### DIFF
--- a/test/expect-tests/memo/memoize_tests.ml
+++ b/test/expect-tests/memo/memoize_tests.ml
@@ -670,12 +670,12 @@ let%expect_test "diamond with non-uniform cutoff structure" =
     {|
     Started evaluating base
     Evaluated base: 2
+    Started evaluating yes_cutoff
+    Evaluated yes_cutoff: 1
     Started evaluating after_no_cutoff
     Started evaluating no_cutoff
     Evaluated no_cutoff: 1
     Evaluated after_no_cutoff: 2
-    Started evaluating yes_cutoff
-    Evaluated yes_cutoff: 1
     f 0 = Ok 4
     Memo graph: 6/5 restored/computed nodes, 11 traversed edges
     Memo cycle detection graph: 0/0/0 nodes/edges/paths


### PR DESCRIPTION
Invalidating memoized dependency nodes has the following property:

1. We scan all the dependnecy nodes in order
2. Whenever we need to check for a node that has cutoff, we compute its
   value

This can make invalidation needlessly slow if recopmuting a cutoff node
is slow.

This commit modifies the algorithm to check for all non cutoff nodes
first, and only then start evaluating the nodes that require cutoff.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7846c54a-af46-42dd-ac96-aec98652423c -->