### PR TITLE
fix(stdlib): pass flags when building stdlib.ml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Unreleased
 - Bootstrap: correctly detect the number of processors by allowing `nproc` to be
   looked up in `$PATH` (#7272, @Alizter)
 
+- Pass correct flags when compiling `stdlib.ml`. (#7241, @emillon)
+
 - Speed up file copying on macos by using `clonefile` when available
   (@rgrinberg, #7210)
 

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -209,11 +209,16 @@ let create ~super_context ~scope ~expander ~obj_dir ~modules ~flags
   }
 
 let for_alias_module t alias_module =
+  let keep_flags = Modules.is_stdlib_alias (modules t) alias_module in
   let flags =
-    let project = Scope.project t.scope in
-    let dune_version = Dune_project.dune_version project in
-    let profile = (Super_context.context t.super_context).profile in
-    Ocaml_flags.default ~dune_version ~profile
+    if keep_flags then
+      (* in the case of stdlib, these flags can be written by the user *)
+      t.flags
+    else
+      let project = Scope.project t.scope in
+      let dune_version = Dune_project.dune_version project in
+      let profile = (Super_context.context t.super_context).profile in
+      Ocaml_flags.default ~dune_version ~profile
   in
   let sandbox =
     let ctx = Super_context.context t.super_context in

--- a/test/blackbox-tests/test-cases/stdlib/stdlib-flags.t
+++ b/test/blackbox-tests/test-cases/stdlib/stdlib-flags.t
@@ -1,0 +1,18 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.7)
+  > (using experimental_building_ocaml_compiler_with_dune 0.1)
+  > EOF
+
+  $ cat > dune << EOF
+  > (library
+  >  (name mystdlib)
+  >  (stdlib)
+  >  (flags :standard -w -8))
+  > EOF
+
+  $ cat > mystdlib.ml << EOF
+  > (* This triggers warning 8 *)
+  > let None = None
+  > EOF
+
+  $ dune build


### PR DESCRIPTION
Reported by @gretay-js.

This ensures that when building `stdlib.ml` (the main module of a library with `(stdlib)`), flags set in the corresponding stanza `(library)` are correctly passed.
