### PR TITLE
loc: make pp_file_colon_line polymorphic

### DIFF
--- a/otherlibs/stdune/src/loc.mli
+++ b/otherlibs/stdune/src/loc.mli
@@ -27,7 +27,7 @@ val of_pos : string * int * int * int -> t
 
 val to_file_colon_line : t -> string
 
-val pp_file_colon_line : t -> unit Pp.t
+val pp_file_colon_line : t -> 'a Pp.t
 
 val to_dyn_hum : t -> Dyn.t
 


### PR DESCRIPTION
I wanted to use this in a User_message and this needs to be done. There is no point restricting to `unit` anyway.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: aa376b70-6b79-4c74-b557-e3a045f10f65 -->