### PR TITLE
coq_config: Add coqcorelib

### DIFF
--- a/src/dune_rules/coq/coq_config.ml
+++ b/src/dune_rules/coq/coq_config.ml
@@ -153,6 +153,7 @@ end
 type t =
   { version_info : (Version.t, User_message.Style.t Pp.t) Result.t
   ; coqlib : Path.t
+  ; coqcorelib : Path.t
   ; coq_native_compiler_default : string
   }
 
@@ -182,10 +183,11 @@ let make_res ~(coqc : Action.Prog.t) =
       match Vars.of_lines config_lines with
       | Ok vars ->
         let coqlib = Vars.get_path vars "COQLIB" in
+        let coqcorelib = Vars.get_path vars "COQCORELIB" in
         let coq_native_compiler_default =
           Vars.get vars "COQ_NATIVE_COMPILER_DEFAULT"
         in
-        Ok { version_info; coqlib; coq_native_compiler_default }
+        Ok { version_info; coqlib; coqcorelib; coq_native_compiler_default }
       | Error msg ->
         User_error.raise
           Pp.
@@ -210,7 +212,8 @@ let make ~coqc =
         ; textf "Output:\n%s" (String.concat ~sep:"\n" config_lines)
         ]
 
-let by_name { version_info; coqlib; coq_native_compiler_default } name =
+let by_name { version_info; coqlib; coqcorelib; coq_native_compiler_default }
+    name =
   match name with
   | "version.major"
   | "version.minor"
@@ -219,6 +222,7 @@ let by_name { version_info; coqlib; coq_native_compiler_default } name =
   | "version"
   | "ocaml-version" -> Version.by_name version_info name
   | "coqlib" -> Some (Value.Path coqlib)
+  | "coqcorelib" -> Some (Value.Path coqcorelib)
   | "coq_native_compiler_default" ->
     Some (Value.String coq_native_compiler_default)
   | _ -> None

--- a/src/dune_rules/coq/coq_config.mli
+++ b/src/dune_rules/coq/coq_config.mli
@@ -28,5 +28,6 @@ end
     - version
     - ocaml-version
     - coqlib
+    - coqcorelib
     - coq_native_compiler_default *)
 val by_name : t -> string -> Value.t Option.t


### PR DESCRIPTION
We read the value of COQCORELIB from `coqc --config`. This is needed in install composition when passing `-I` flags for installed plugins.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 1d5e63eb-4cb5-466f-8270-bf05bd1fe056 -->