### PR TITLE
refactor: use `Pp.enumerate` in 2 places

### DIFF
--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -455,8 +455,8 @@ let gen_melange_emit_rules sctx ~dir ({ stanza_dir; stanza } as for_melange) =
       in
       User_error.raise ~loc:stanza.loc ~annots
         [ main_message
-        ; Pp.textf "- %s" (Loc.to_file_colon_line parent_stanza.loc)
-        ; Pp.textf "- %s" (Loc.to_file_colon_line stanza.loc)
+        ; Pp.enumerate ~f:Loc.pp_file_colon_line
+            [ parent_stanza.loc; stanza.loc ]
         ]
         ~hints:
           (let emit_dir = Path.Build.drop_build_context_exn stanza_dir in

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -89,8 +89,7 @@ module Emit = struct
           in
           User_error.raise ~annots ~loc:loc2
             [ main_message
-            ; Pp.textf "- %s" (Loc.to_file_colon_line loc1)
-            ; Pp.textf "- %s" (Loc.to_file_colon_line loc2)
+            ; Pp.enumerate ~f:Loc.pp_file_colon_line [ loc1; loc2 ]
             ; Pp.textf "Extensions must be unique per melange.emit stanza"
             ]
             ~hints:


### PR DESCRIPTION
inspired by https://github.com/ocaml/dune/pull/7250