### PR TITLE
chore(nix): remove the opam2nix dependency on the default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,24 @@
           });
     in
     {
-      packages.default = scope.dune;
+      packages = {
+        dune = scope.dune;
+        default = with pkgs; stdenv.mkDerivation rec {
+          pname = package;
+          version = "n/a";
+          src = ./.;
+          nativeBuildInputs = with ocamlPackages; [ ocaml findlib ];
+          buildInputs = lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.CoreServices
+          ];
+          strictDeps = true;
+          buildFlags = [ "release" ];
+          dontAddPrefix = true;
+          dontAddStaticConfigureFlags = true;
+          configurePlatforms = [ ];
+          installFlags = [ "PREFIX=${placeholder "out"}" "LIBDIR=$(OCAMLFIND_DESTDIR)" ];
+        };
+      };
 
       devShells.doc =
         pkgs.mkShell {


### PR DESCRIPTION
I followed the derivation here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/ocaml/dune/3.nix

Inspired by the changes in https://github.com/ocaml/ocaml-lsp/pull/1040