### PR TITLE
fix(coq): fix duplicate dir targets being detected before theories

### DIFF
--- a/src/dune_rules/coq/coq_rules.ml
+++ b/src/dune_rules/coq/coq_rules.ml
@@ -466,6 +466,12 @@ let coqdoc_directory ~mode ~obj_dir ~name =
     | `Latex -> ".tex")
 
 let coqdoc_directory_targets ~dir:obj_dir (theory : Coq_stanza.Theory.t) =
+  let+ (_ : Coq_lib.DB.t) =
+    (* We force the creation of the coq_lib db here so that errors there can
+       appear before any errors to do with directory targets from coqdoc. *)
+    let+ scope = Scope.DB.find_by_dir obj_dir in
+    Scope.coq_libs scope
+  in
   let loc = theory.buildable.loc in
   let name = snd theory.name in
   Path.Build.Map.of_list_exn

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -16,7 +16,7 @@ val deps_of :
   -> unit Dune_engine.Action_builder.t
 
 val coqdoc_directory_targets :
-  dir:Path.Build.t -> Coq_stanza.Theory.t -> Loc.t Path.Build.Map.t
+  dir:Path.Build.t -> Coq_stanza.Theory.t -> Loc.t Path.Build.Map.t Memo.t
 
 (** ** Rules for Coq stanzas *)
 

--- a/test/blackbox-tests/test-cases/coq/duplicate-theory.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/duplicate-theory.t/run.t
@@ -11,7 +11,7 @@ Duplicate theories should be caught by Dune:
 BUG The directory target is found before the theory
 
   $ dune build
-  Error: the following both define the directory target: _build/default/foo.tex
-  - dune:1
-  - dune:4
+  Error: Coq theory foo is defined twice:
+  - dune:5
+  - dune:2
   [1]


### PR DESCRIPTION
Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: fdca4e56-d4bd-4ac1-a0bd-6c6725189718 -->