### PR TITLE
chore: pin but not install melange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ dev-depext:
 
 .PHONY: melange
 melange:
-	opam pin add melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#48ff923f2c25136de8ab96678f623f54cdac438c
-	opam pin add melange https://github.com/melange-re/melange.git#13edf6108d884e64cd510bce077ef2ce73de6a97
+	opam pin add -n melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#48ff923f2c25136de8ab96678f623f54cdac438c
+	opam pin add -n melange https://github.com/melange-re/melange.git#13edf6108d884e64cd510bce077ef2ce73de6a97
 
 .PHONY: dev-deps
 dev-deps: melange


### PR DESCRIPTION
So that we install melange along with the rest of the deps at once

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 88ca4ba3-3e2a-4b53-b303-0cb2b596faba -->