### PR TITLE
fix(melange): copy, don't symlink, runtime_deps

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -287,7 +287,7 @@ let setup_runtime_assets_rules sctx ~dir ~target_dir ~mode
     let loc = mel.loc in
     Memo.parallel_iter copy ~f:(fun (src, dst) ->
         Super_context.add_rule ~loc ~dir ~mode sctx
-          (Action_builder.symlink ~src ~dst))
+          (Action_builder.copy ~src ~dst))
   and+ () =
     match mel.alias with
     | None -> Memo.return ()

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-dir-target.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-dir-target.t
@@ -33,11 +33,7 @@ Rules created for the assets in the output directory
   $ dune build @mel --display=short
           melc .output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
           melc output/main.js
-  File "dune", line 5, characters 0-71:
-  5 | (melange.emit
-  6 |  (alias mel)
-  7 |  (target output)
-  8 |  (runtime_deps ./some_dir))
-  Error: Error trying to read targets after a rule was run:
-  - output/some_dir: Unexpected file kind "S_DIR" (directory)
+  Error: Is a directory
+  -> required by _build/default/output/some_dir
+  -> required by alias output/mel
   [1]

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
@@ -32,7 +32,7 @@ Rules created for the assets in the output directory
   $ dune rules @mel | grep file.txt
   ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
    (targets ((files (default/a/output/a/assets/file.txt)) (directories ())))
-     (symlink ../../../assets/file.txt a/output/a/assets/file.txt))))
+    (chdir _build/default (copy a/assets/file.txt a/output/a/assets/file.txt))))
 
   $ dune build @mel --display=short
           melc a/.output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
@@ -95,11 +95,10 @@ Need to create the source dir first for the alias to be picked up
   $ dune rules @mel | grep .txt
   ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
    (targets ((files (default/a/output/a/assets/file.txt)) (directories ())))
-     (symlink ../../../assets/file.txt a/output/a/assets/file.txt))))
+    (chdir _build/default (copy a/assets/file.txt a/output/a/assets/file.txt))))
   ((deps ((File (In_build_dir _build/default/a/assets/file.txt))))
     ((files (default/another/another-output/a/assets/file.txt))
-      ../../../../a/assets/file.txt
-      another/another-output/a/assets/file.txt))))
+     (copy a/assets/file.txt another/another-output/a/assets/file.txt))))
 
   $ dune build @mel --display=short
           melc a/.output.mobjs/melange/melange__Main.{cmi,cmj,cmt}

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
@@ -47,7 +47,7 @@ Creating the source directory makes it appear in the alias
   $ dune rules @mel | grep file.txt
   ((deps ((File (In_build_dir _build/default/assets/file.txt))))
    (targets ((files (default/output/assets/file.txt)) (directories ())))
-     (symlink ../../assets/file.txt output/assets/file.txt))))
+   (action (chdir _build/default (copy assets/file.txt output/assets/file.txt))))
 
   $ dune build @mel --display=short
           melc .output.mobjs/melange/melange__Main.{cmi,cmj,cmt}


### PR DESCRIPTION
Bundlers will follow symlinks, and if a runtime_dep is a `.js` file that points to another file in source, that reference can now be broken. 

We want the relative requires to be relative to the melange target directory rather than anything in source.

~Incidentally, this ends up fixing the directory targets test.~ this was an instance of https://github.com/ocaml/dune/pull/7270