### PR TITLE
test: demonstrate `Io.copy_file` difference between macOS / other OS

### DIFF
--- a/otherlibs/stdune/test/io_tests.ml
+++ b/otherlibs/stdune/test/io_tests.ml
@@ -32,3 +32,14 @@ let%expect_test "copy file chmod" =
   [%expect {|
     foobarbaz
     permissions: 428 |}]
+
+let%expect_test "copy file on a directory" =
+  let dir = temp_dir () in
+  let src = Path.relative dir "initial" in
+  let dst = Path.relative dir "final" in
+  Unix.mkdir (Path.to_string src) 0o755;
+  Io.copy_file ~src ~dst ();
+  let dst = Path.to_string dst in
+  Format.printf "exists: %B; is directory: %B @." (Sys.file_exists dst)
+    (Sys.is_directory dst);
+  [%expect {| exists: true; is directory: true |}]

--- a/otherlibs/stdune/test/io_tests.ml
+++ b/otherlibs/stdune/test/io_tests.ml
@@ -39,7 +39,5 @@ let%expect_test "copy file on a directory" =
   let dst = Path.relative dir "final" in
   Unix.mkdir (Path.to_string src) 0o755;
   Io.copy_file ~src ~dst ();
-  let dst = Path.to_string dst in
-  Format.printf "exists: %B; is directory: %B @." (Sys.file_exists dst)
-    (Sys.is_directory dst);
-  [%expect {| exists: true; is directory: true |}]
+  [%expect.unreachable]
+  [@@expect.uncaught_exn {| (Sys_error "Is a directory") |}]


### PR DESCRIPTION
It looks like `clonefile` (#7210) will succeed if we ask it to create a directory.

This is best looked at without whitespace: https://github.com/ocaml/dune/pull/7270/files?w=1