### PR TITLE
fix(boot): fix env vars when finding out concurrency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Bootstrap: correctly detect the number of processors by allowing `nproc` to be
+  looked up in `$PATH` (#7272, @Alizter)
+
 - Speed up file copying on macos by using `clonefile` when available
   (@rgrinberg, #7210)
 

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -195,7 +195,7 @@ let exe = if Sys.win32 then ".exe" else ""
 
 let concurrency =
   let try_run_and_capture_line cmd =
-    let ic, oc, ec = Unix.open_process_full cmd [||] in
+    let ic, oc, ec = Unix.open_process_full cmd (Unix.environment ()) in
     let line =
       match input_line ic with
       | s -> Some s


### PR DESCRIPTION
We were passing an empty enviornment to Unix.open_process_full_cmd before. We now pass the full available Unix.environment since we are only querying the concurrency by calling nproc or getconf.

On NixOS this was causing the bootstrap to default to a single processor since nproc wasn't available in the empty environment.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: d620baf8-5e58-4212-8f30-df69780a614b -->