### PR TITLE
test: reproducibility of sigpipe.t

### DIFF
--- a/test/blackbox-tests/test-cases/watching/sigpipe.t
+++ b/test/blackbox-tests/test-cases/watching/sigpipe.t
@@ -1,6 +1,7 @@
 We demonstrate that dune can be turned off by sigpipe
 
   $ echo '(lang dune 3.0)' > dune-project
+  $ touch dout
   $ dune build --passive-watch-mode > dout 2>&1 &
   $ pid=$!
   $ kill -s PIPE $pid


### PR DESCRIPTION
Create the output file before running dune so that the final `cat` never
fails.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f95e7a20-622a-4e24-be18-25f119d68ef8 -->