### PR TITLE
feature(boot): remove reliance on shell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Bootstrap: remove reliance on shell. Previously, we'd use the shell to get
+  the number of processors. (#7274, @rgrinberg)
+
 - Bootstrap: correctly detect the number of processors by allowing `nproc` to be
   looked up in `$PATH` (#7272, @Alizter)
 


### PR DESCRIPTION
Previously, we'd run the shell to discover the number of processes by
using `Unix.open_process_full`. The shell isn't being used for anything,
so we switch to executing the process directly.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f2284477-89a3-4579-baca-cd4c9ff2f26d -->