### PR TITLE
nix: upgrade to patch that track `doc` section

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678388492,
-        "narHash": "sha256-ckGWLERU7oTTDtstQroFzflYtFiN7uSE2BrmvH1D+50=",
+        "lastModified": 1678435585,
+        "narHash": "sha256-au+wluZ3bmhN3IpPkH7d4tnCYNaRm39uYqN1CnwxfIk=",
         "owner": "melange-re",
         "repo": "melange",
-        "rev": "7fd78af1a874386ebe00a2787bd398af0cd756d7",
+        "rev": "47a2971b65d5abf996457bdcc9fc483bdb9551e6",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678377668,
-        "narHash": "sha256-0TkDQ243lVd2UjOKQm6+4qwIUgZlKpsEyreImIhXBIE=",
+        "lastModified": 1678511767,
+        "narHash": "sha256-rtONLdHGwgSmZ0Dp43O/VeadgdaU3rFLG5i06xrPyUY=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "4cdf6c9d9e69e79b0867bc15b731970289dce265",
+        "rev": "866b368ab9e74596ff1995c4bc4e3965c0d2efc0",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678298120,
-        "narHash": "sha256-iaV5xqgn29xy765Js3EoZePQyZIlLZA3pTYtTnKkejg=",
+        "lastModified": 1678478120,
+        "narHash": "sha256-F+Ib9UsuhU8U1On8fXhu41NS/gJsd+xasU5qPAiufoQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e383aada51b416c6c27d4884d2e258df201bc11",
+        "rev": "3a9aec4691d49c98c26626e535236fd933d738dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR showcases how https://github.com/NixOS/nixpkgs/pull/220592 allows dune's cinaps tests to be run.

example of setup:

```shell
$ nix develop .#slim -c $SHELL

$ ./dune.exe build @test/blackbox-tests/test-cases/cinaps/runtest
```