### PR TITLE
ignore relative paths in PATH

### DIFF
--- a/otherlibs/stdune/src/bin.ml
+++ b/otherlibs/stdune/src/bin.ml
@@ -4,7 +4,9 @@ let parse_path ?(sep = path_sep) s =
   String.split s ~on:sep
   |> List.filter_map ~f:(function
        | "" -> None
-       | p -> Some (Path.of_filename_relative_to_initial_cwd p))
+       (* Relative paths are ignored in PATH *)
+       | p when Filename.is_relative p -> None
+       | p -> Some (Path.of_string p))
 
 let cons_path p ~_PATH =
   let p = Path.to_absolute_filename p in


### PR DESCRIPTION
Reading relative paths present in PATH is fragile behaviour and leads to issues such as #6907. We explicitly filter any relative paths when reading PATH.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: b71f4ba5-99be-42a7-a830-784811017345 -->