### PR TITLE
fix(nix): conflicting ocamlfind dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -166,7 +166,6 @@
 
       devShells.default =
         pkgs.mkShell {
-          dontDetectOcamlConflicts = true;
           nativeBuildInputs = testNativeBuildInputs;
           buildInputs = testBuildInputs ++ (with pkgs;
             [
@@ -180,7 +179,7 @@
             pkgs.ocamlPackages.melange
             pkgs.ocamlPackages.mel
           ] ++ nixpkgs.lib.attrsets.attrVals (builtins.attrNames devPackages) scope;
-          inputsFrom = [ self.packages.${system}.default ];
+          inputsFrom = [ self.packages.${system}.dune ];
         };
     });
 }


### PR DESCRIPTION
In #7258, we removed opam2nix from the `default` package, but the default shell needs to depend on the correct one (now dune rather than default)