### PR TITLE
fix(stdune): copy file error message on macos

### DIFF
--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -271,9 +271,7 @@ struct
         let src_stats =
           match Unix.stat src with
           | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-            let message =
-              Printf.sprintf "error: %s: No such file or directory" src
-            in
+            let message = Printf.sprintf "%s: No such file or directory" src in
             raise (Sys_error message)
           | { st_kind = S_DIR; _ } -> raise (Sys_error "Is a directory")
           | stats -> stats


### PR DESCRIPTION
Remoe the additional "error:" prefix

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 759a4dea-1244-4591-ad38-cecd44adea5b -->