### PR TITLE
fix(melange): rename `entries` to `modules` in `melange.emit`

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -96,8 +96,7 @@ module Buildable = struct
       located
         (only_in_library
            (field_o "cxx_names" (use_foreign >>> Ordered_set_lang.decode)))
-    and+ modules =
-      Stanza_common.Modules_settings.decode ~modules_field_name:"modules"
+    and+ modules = Stanza_common.Modules_settings.decode
     and+ self_build_stubs_archive_loc, self_build_stubs_archive =
       located
         (only_in_library

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -107,9 +107,7 @@ module Emit = struct
        and+ compile_flags = Ordered_set_lang.Unexpanded.field "compile_flags"
        and+ allow_overlapping_dependencies =
          field_b "allow_overlapping_dependencies"
-       and+ modules =
-         Stanza_common.Modules_settings.decode ~modules_field_name:"entries"
-       in
+       and+ modules = Stanza_common.Modules_settings.decode in
        let preprocess =
          let init =
            let f libname = Preprocess.With_instrumentation.Ordinary libname in

--- a/src/dune_rules/stanza_common.ml
+++ b/src/dune_rules/stanza_common.ml
@@ -190,10 +190,10 @@ module Modules_settings = struct
     ; modules : Ordered_set_lang.t
     }
 
-  let decode ~modules_field_name =
+  let decode =
     let+ root_module = field_o "root_module" Module_name.decode_loc
     and+ modules_without_implementation =
       modules_field "modules_without_implementation"
-    and+ modules = modules_field modules_field_name in
+    and+ modules = modules_field "modules" in
     { root_module; modules; modules_without_implementation }
 end

--- a/src/dune_rules/stanza_common.mli
+++ b/src/dune_rules/stanza_common.mli
@@ -35,5 +35,5 @@ module Modules_settings : sig
     ; modules : Ordered_set_lang.t
     }
 
-  val decode : modules_field_name:string -> t Dune_lang.Decoder.fields_parser
+  val decode : t Dune_lang.Decoder.fields_parser
 end

--- a/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/dune
+++ b/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/dune
@@ -1,5 +1,5 @@
 (melange.emit
  (target dist)
  (alias melange)
- (entries entry_module)
+ (modules entry_module)
  (libraries parent))

--- a/test/blackbox-tests/test-cases/melange/empty-entries-target-dir-exists.t
+++ b/test/blackbox-tests/test-cases/melange/empty-entries-target-dir-exists.t
@@ -1,4 +1,4 @@
-Test (entries) field can be left empty
+Test (modules) field can be left empty
 
   $ cat > dune-project <<EOF
   > (lang dune 3.7)

--- a/test/blackbox-tests/test-cases/melange/empty-entries.t
+++ b/test/blackbox-tests/test-cases/melange/empty-entries.t
@@ -1,4 +1,4 @@
-Test (entries) field can be left empty
+Test (modules) field can be left empty
 
   $ cat > dune-project <<EOF
   > (lang dune 3.7)

--- a/test/blackbox-tests/test-cases/melange/flags.t
+++ b/test/blackbox-tests/test-cases/melange/flags.t
@@ -10,7 +10,7 @@ Using flags field in melange.emit stanzas is not supported
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (flags -w -14-26))
   > EOF
 
@@ -31,7 +31,7 @@ Adds a module that contains unused var (warning 26) and illegal backlash (warnin
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (alias melange))
   > EOF
 
@@ -53,7 +53,7 @@ Let's ignore them using compile_flags
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (alias melange)
   >  (compile_flags -w -14-26))
   > EOF
@@ -67,7 +67,7 @@ Can also pass flags from the env stanza. Let's go back to failing state:
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (alias melange))
   > EOF
 
@@ -91,7 +91,7 @@ Adding env stanza with both warnings silenced allows the build to pass successfu
   > (melange.emit
   >  (alias melange)
   >  (target output)
-  >  (entries main))
+  >  (modules main))
   > EOF
 
   $ dune build @melange
@@ -107,7 +107,7 @@ Warning 102 (Melange only) is available if explicitly set
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (compile_flags -w +a-70))
   > EOF
 
@@ -122,7 +122,7 @@ But it is disabled by default
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main))
+  >  (modules main))
   > EOF
 
   $ dune build output/main.js

--- a/test/blackbox-tests/test-cases/melange/include_subdirs.t/inside/dune
+++ b/test/blackbox-tests/test-cases/melange/include_subdirs.t/inside/dune
@@ -1,5 +1,5 @@
 (melange.emit
  (target output)
  (alias melange)
- (entries c)
+ (modules c)
  (libraries lib))

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -30,7 +30,7 @@
   Foo__
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
 
-All 3 entries (Foo, Foo__ and Bar) contain a ppx directive
+All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
 
   $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
    (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
@@ -41,7 +41,7 @@ All 3 entries (Foo, Foo__ and Bar) contain a ppx directive
   $ cat >dune <<EOF
   > (melange.emit
   >  (target "$target")
-  >  (entries main))
+  >  (modules main))
   > EOF
 
   $ touch main.ml

--- a/test/blackbox-tests/test-cases/melange/missing-melc.t
+++ b/test/blackbox-tests/test-cases/melange/missing-melc.t
@@ -22,7 +22,7 @@ For melange.emit stanzas, an error is shown
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main_melange)
+  >  (modules main_melange)
   >  (alias melange))
   > EOF
 
@@ -30,7 +30,7 @@ For melange.emit stanzas, an error is shown
   File "dune", line 1, characters 0-72:
   1 | (melange.emit
   2 |  (target output)
-  3 |  (entries main_melange)
+  3 |  (modules main_melange)
   4 |  (alias melange))
   Error: Program melc not found in the tree or in PATH
    (context: default)
@@ -78,7 +78,7 @@ If melange.emit stanza is found, but no rules are executed, build does not fail
   >  (libraries lib1))
   > (melange.emit
   >  (target output)
-  >  (entries main_melange)
+  >  (modules main_melange)
   >  (libraries lib1))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/mli.t/dune
+++ b/test/blackbox-tests/test-cases/melange/mli.t/dune
@@ -1,5 +1,5 @@
 (melange.emit
  (target mli)
- (entries x)
+ (modules x)
  (libraries lib)
  (alias melange))

--- a/test/blackbox-tests/test-cases/melange/multilib.t/dune
+++ b/test/blackbox-tests/test-cases/melange/multilib.t/dune
@@ -1,5 +1,5 @@
 (melange.emit
  (target multilib)
- (entries c)
+ (modules c)
  (libraries x)
  (alias melange))

--- a/test/blackbox-tests/test-cases/melange/ocaml-flags.t
+++ b/test/blackbox-tests/test-cases/melange/ocaml-flags.t
@@ -11,7 +11,7 @@ Create dune file that uses melange.compile_flags
   > (melange.emit
   >  (target output)
   >  (alias melange)
-  >  (entries main)
+  >  (modules main)
   >  (compile_flags -w -14-26))
   > EOF
 
@@ -33,7 +33,7 @@ Update dune file to use ocamlc_flags
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (ocamlc_flags -w -14-26))
   > EOF
 
@@ -51,7 +51,7 @@ Update dune file to use ocamlopt_flags
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (ocamlopt_flags -w -14-26))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/preprocess.t
+++ b/test/blackbox-tests/test-cases/melange/preprocess.t
@@ -8,7 +8,7 @@ Test (preprocess) field on melange.emit stanza
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
-  >  (entries main)
+  >  (modules main)
   >  (alias melange)
   >  (preprocess
   >   (action

--- a/test/blackbox-tests/test-cases/melange/private-module.t/dune
+++ b/test/blackbox-tests/test-cases/melange/private-module.t/dune
@@ -1,4 +1,4 @@
 (melange.emit
  (target private-module)
- (entries foo)
+ (modules foo)
  (libraries lib))

--- a/test/blackbox-tests/test-cases/melange/private.t/inside/dune
+++ b/test/blackbox-tests/test-cases/melange/private.t/inside/dune
@@ -1,6 +1,6 @@
 (melange.emit
  (target output)
- (entries c)
+ (modules c)
  (libraries app)
  (alias melange)
  (module_systems

--- a/test/blackbox-tests/test-cases/melange/promote-with-lib.t
+++ b/test/blackbox-tests/test-cases/melange/promote-with-lib.t
@@ -19,7 +19,7 @@ Test melange.emit promotion
   $ cat > dune <<EOF
   > (melange.emit
   >  (alias dist)
-  >  (entries hello)
+  >  (modules hello)
   >  (promote (until-clean))
   >  (target dist)
   >  (libraries mylib))

--- a/test/blackbox-tests/test-cases/melange/promote.t
+++ b/test/blackbox-tests/test-cases/melange/promote.t
@@ -8,7 +8,7 @@ Test melange.emit promotion
   $ cat > dune <<EOF
   > (melange.emit
   >  (alias dist)
-  >  (entries hello)
+  >  (modules hello)
   >  (promote (until-clean))
   >  (target dist))
   > EOF

--- a/test/blackbox-tests/test-cases/melange/public.t/my_project/dune
+++ b/test/blackbox-tests/test-cases/melange/public.t/my_project/dune
@@ -1,5 +1,5 @@
 (melange.emit
  (target output)
- (entries c)
+ (modules c)
  (alias melange)
  (libraries app))

--- a/test/blackbox-tests/test-cases/melange/rescript-syntax.t
+++ b/test/blackbox-tests/test-cases/melange/rescript-syntax.t
@@ -8,7 +8,7 @@ Test melange.emit promotion
   $ cat > dune <<EOF
   > (melange.emit
   >  (alias dist)
-  >  (entries hello)
+  >  (modules hello)
   >  (target dist))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/simple.t/lib/dune
+++ b/test/blackbox-tests/test-cases/melange/simple.t/lib/dune
@@ -6,5 +6,5 @@
 (melange.emit
  (target simple)
  (alias melange)
- (entries x)
+ (modules x)
  (libraries lib))

--- a/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
+++ b/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
@@ -9,7 +9,7 @@ Building a project with 2 melange.emit stanzas should add rules to both aliases
   >  (target dist)
   >  (alias mel)
   >  (promote (until-clean))
-  >  (entries)
+  >  (modules)
   >  (module_systems
   >   (commonjs js)))
   > 
@@ -17,7 +17,7 @@ Building a project with 2 melange.emit stanzas should add rules to both aliases
   >  (target dist-es6)
   >  (alias second)
   >  (promote (until-clean))
-  >  (entries)
+  >  (modules)
   >  (module_systems
   >   (es6 mjs)))
   > EOF

--- a/test/blackbox-tests/test-cases/melange/virtual_lib.t/dune
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib.t/dune
@@ -1,5 +1,5 @@
 (melange.emit
  (target output)
  (alias melange)
- (entries mel)
+ (modules mel)
  (libraries impl_melange))

--- a/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/dune
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/dune
@@ -6,5 +6,5 @@
 (melange.emit
  (target output)
  (alias melange)
- (entries mel)
+ (modules mel)
  (libraries vlib impl_melange))


### PR DESCRIPTION
- these are OCaml modules
- explaining the distinction between `modules` and `entries` is extra cognitive overhead