### PR TITLE
ocaml_flags: filter all warns,alerts from vendored_dirs flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@ Unreleased
 - RPC: Ignore SIGPIPE when clients suddenly disconnect (#7299, #7319, fixes
   #6879, @rgrinberg)
 
+- All warnings and alerts are filtered from the compilation flags for
+  vendored_dirs. (#7304, fixes #7034, @Alizter)
+
 - Always clean up the UI on exit. (#7271, fixes #7142 @rgrinberg)
 
 - Bootstrap: remove reliance on shell. Previously, we'd use the shell to get

--- a/doc/stanzas/vendored_dirs.rst
+++ b/doc/stanzas/vendored_dirs.rst
@@ -19,6 +19,8 @@ Example:
 
 Dune will not resolve aliases in vendored directories. By default, it won't
 build all installable targets, run the tests, format, or lint the code located
-in such a directory while still building your project's dependencies. Libraries
-and executables in vendored directories will also be built with a ``-w -a`` flag
-to suppress all warnings and prevent pollution of your build output.
+in such a directory while still building your project's dependencies.
+
+Libraries and executables in vendored directories will have all warnings and
+alerts flags removed and replaced with a ``-w -a`` or ``-alert -all``` flag to
+suppress all warnings and alerts and prevent pollution of your build output.

--- a/src/dune_rules/ocaml_flags.ml
+++ b/src/dune_rules/ocaml_flags.ml
@@ -167,9 +167,31 @@ let map_common t ~f =
 
 let append_common t flags = map_common t ~f:(fun l -> l @ flags)
 
-let with_vendored_warnings t = append_common t vendored_warnings
+let filter_warnings l =
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | "-w" :: _ :: rest -> loop acc rest
+    | "-w" :: [] -> List.rev acc
+    | "-warn-error" :: _ :: rest -> loop acc rest
+    | "-warn-error" :: [] -> List.rev acc
+    | a :: rest -> loop (a :: acc) rest
+  in
+  loop [] l
 
-let with_vendored_alerts t = append_common t vendored_alerts
+let with_vendored_warnings t =
+  append_common (map_common ~f:filter_warnings t) vendored_warnings
+
+let filter_alerts l =
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | "-alert" :: _ :: rest -> loop acc rest
+    | "-alert" :: [] -> List.rev acc
+    | a :: rest -> loop (a :: acc) rest
+  in
+  loop [] l
+
+let with_vendored_alerts t =
+  append_common (map_common ~f:filter_alerts t) vendored_alerts
 
 let dump t =
   let+ common = t.common

--- a/test/blackbox-tests/test-cases/github7034.t/run.t
+++ b/test/blackbox-tests/test-cases/github7034.t/run.t
@@ -98,12 +98,12 @@ But when lang dune is 3.3 or higher the warning becomes an error:
   Leaving directory 'outer'
   $ dune build --root=outer
   Entering directory 'outer'
-  File "vendored/inner/inner.ml", line 6, characters 11-18:
-  6 | type t = { x : int }
-                 ^^^^^^^
-  Error (warning 69 [unused-field]): unused record field x.
   Leaving directory 'outer'
-  [1]
+
+
+This now builds as expected. Fixed by #7304.
+
+Notes from before:
 
 This is unexpected as vendored projects should be built according to their
 declared dune-project rather than the dune-project of the outer project.


### PR DESCRIPTION
- [x] Fix tests
- [x] Changes
- [x] Documentation - need to check if we mention the disabling of warnings in the doc
- [x] Should fix #7034 