### PR TITLE
perf: switch digest to Stdlib.Hashtbl.hash

### DIFF
--- a/src/dune_digest/dune_digest.ml
+++ b/src/dune_digest/dune_digest.ml
@@ -64,7 +64,7 @@ let to_string_raw s = s
    or to different memory locations. *)
 let generic a =
   Metrics.Timer.record "generic_digest" ~f:(fun () ->
-      string (Marshal.to_string a [ No_sharing ]))
+      string (Stdlib.Hashtbl.hash a |> string_of_int))
 
 let path_with_executable_bit =
   (* We follow the digest scheme used by Jenga. *)


### PR DESCRIPTION
Out of curiosity I looked at how Dune is creating digests. Marshal was chosen due to being polymorphic however I think that marshalling is slow. Instead I replaced it with the hashing function for `Hashtbl` and `string_of_int`ed it. An initial bench backs up my hypothesis.

There are many other polymorphic hash functions we could experiment with and we can decide if it is worth doing by benching some larger builds.

## Results from `make bench`:

### Clean build

| Marshal            | Hashtbl            |
| ------------------ | ------------------ |
| 104.49534511566162 | 104.17923498153687 |

### Nuill build

| Marshal            | Hashtbl            |
| ------------------ | ------------------ |
| 0.9530911445617676 | 0.9136919975280762 |
| 0.9156889915466309 | 0.899960994720459  |
| 0.9156849384307861 | 0.9299650192260742 |
| 0.9156849384307861 | 0.8821189403533936 |
| 0.8968338966369629 | 0.8888070583343506 |
| Mean               |                    |
| 0.92698            | 0.90291            |

cc @rgrinberg  @snowleopard 

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: fe097461-9b5f-49e0-8ca4-bfc16d2fa9a1 -->