### PR TITLE
melange: make alias non-optional in `melange.emit`

### DIFF
--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -5,7 +5,7 @@ module Emit = struct
   type t =
     { loc : Loc.t
     ; target : string
-    ; alias : Alias.Name.t option
+    ; alias : Alias.Name.t
     ; module_systems : (Melange.Module_system.t * Filename.Extension.t) list
     ; modules : Stanza_common.Modules_settings.t
     ; libraries : Lib_dep.t list
@@ -92,7 +92,7 @@ module Emit = struct
                  ])
          in
          field "target" (plain_string (fun ~loc s -> of_string ~loc s))
-       and+ alias = field_o "alias" Alias.Name.decode
+       and+ alias = field "alias" Alias.Name.decode
        and+ module_systems =
          field "module_systems" module_systems
            ~default:[ Melange.Module_system.default ]

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -5,7 +5,7 @@ module Emit : sig
   type t =
     { loc : Loc.t
     ; target : string
-    ; alias : Alias.Name.t option
+    ; alias : Alias.Name.t
     ; module_systems : (Melange.Module_system.t * string) list
     ; modules : Stanza_common.Modules_settings.t
     ; libraries : Lib_dep.t list

--- a/test/blackbox-tests/test-cases/melange/flags.t
+++ b/test/blackbox-tests/test-cases/melange/flags.t
@@ -11,6 +11,7 @@ Using flags field in melange.emit stanzas is not supported
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (flags -w -14-26))
   > EOF
 
@@ -108,6 +109,7 @@ Warning 102 (Melange only) is available if explicitly set
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (compile_flags -w +a-70))
   > EOF
 
@@ -122,6 +124,7 @@ But it is disabled by default
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (alias melange)
   >  (entries main))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -41,7 +41,8 @@ All 3 entries (Foo, Foo__ and Bar) contain a ppx directive
   $ cat >dune <<EOF
   > (melange.emit
   >  (target "$target")
-  >  (entries main))
+  >  (entries main)
+  >  (alias melange))
   > EOF
 
   $ touch main.ml

--- a/test/blackbox-tests/test-cases/melange/missing-melc.t
+++ b/test/blackbox-tests/test-cases/melange/missing-melc.t
@@ -79,6 +79,7 @@ If melange.emit stanza is found, but no rules are executed, build does not fail
   > (melange.emit
   >  (target output)
   >  (entries main_melange)
+  >  (alias melange)
   >  (libraries lib1))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/ocaml-flags.t
+++ b/test/blackbox-tests/test-cases/melange/ocaml-flags.t
@@ -34,6 +34,7 @@ Update dune file to use ocamlc_flags
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (ocamlc_flags -w -14-26))
   > EOF
 
@@ -52,6 +53,7 @@ Update dune file to use ocamlopt_flags
   > (melange.emit
   >  (target output)
   >  (entries main)
+  >  (alias melange)
   >  (ocamlopt_flags -w -14-26))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/private-module.t/dune
+++ b/test/blackbox-tests/test-cases/melange/private-module.t/dune
@@ -1,4 +1,5 @@
 (melange.emit
  (target private-module)
  (entries foo)
+ (alias melange)
  (libraries lib))

--- a/test/blackbox-tests/test-cases/melange/reused-module.t
+++ b/test/blackbox-tests/test-cases/melange/reused-module.t
@@ -10,7 +10,8 @@ Test error message for modules belonging to melange.emit and another stanza
   >  (name lib)
   >  (modes melange))
   > (melange.emit
-  >  (target output))
+  >  (target output)
+  >  (alias melange))
   > EOF
 
   $ cat > main.ml <<EOF


### PR DESCRIPTION
As shown in https://github.com/ocaml/dune/pull/7261, building Melange projects without using aliases will lead users to confusing situations, as the dependencies between modules are not tracked between `js` targets. One just needs to:
- have a `melange.emit` stanza with 2 modules where one depends on the other
- try to build using the `.js` target of the first

To run into this situation.

See https://github.com/ocaml/dune/pull/7261#issuecomment-1466393229:

> This PR demonstrates expected behavior. When you do `dune build x`, dune will only build x and its dependencies. Other things such as runtime dependencies are not expected to build. This is why we introduced the alias to the melange.emit stanza