### PR TITLE
refactor: rename pthread_chdir_stubs

### DIFF
--- a/src/csexp_rpc/csexp_rpc_stubs.c
+++ b/src/csexp_rpc/csexp_rpc_stubs.c
@@ -1,32 +1,30 @@
-#include <caml/mlvalues.h>
-#include <caml/memory.h>
 #include <caml/alloc.h>
+#include <caml/callback.h>
 #include <caml/custom.h>
 #include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
 #include <caml/signals.h>
-#include <caml/callback.h>
 #include <caml/unixsupport.h>
 
 #if defined(__APPLE__)
 
+#include <fcntl.h>
+#include <sys/socket.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <unistd.h>
-#include <fcntl.h>
 
-CAMLprim value dune_pthread_chdir_is_osx(value unit)
-{
+CAMLprim value dune_pthread_chdir_is_osx(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_true);
 }
 
 #ifndef SYS___pthread_chdir
-# define SYS___pthread_chdir 348
+#define SYS___pthread_chdir 348
 #endif
 
-int __pthread_chdir(const char *path)
-{
+int __pthread_chdir(const char *path) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
   return syscall(SYS___pthread_chdir, path);
@@ -37,8 +35,8 @@ CAMLprim value dune_pthread_chdir(value dir) {
   CAMLparam1(dir);
   if (__pthread_chdir(String_val(dir))) {
     uerror("__pthread_chdir", Nothing);
-  } 
-  CAMLreturn (Val_unit); 
+  }
+  CAMLreturn(Val_unit);
 }
 
 CAMLprim value dune_set_nosigpipe(value v_socket) {
@@ -58,8 +56,7 @@ CAMLprim value dune_set_nosigpipe(value v_socket) {
   caml_invalid_argument("only implemented on macos");
 }
 
-CAMLprim value dune_pthread_chdir_is_osx(value unit)
-{
+CAMLprim value dune_pthread_chdir_is_osx(value unit) {
   CAMLparam1(unit);
   CAMLreturn(Val_false);
 }
@@ -67,7 +64,7 @@ CAMLprim value dune_pthread_chdir_is_osx(value unit)
 CAMLprim value dune_pthread_chdir(value unit) {
   CAMLparam1(unit);
   caml_invalid_argument("__pthread_chdir not implemented");
-  CAMLreturn (Val_unit); 
+  CAMLreturn(Val_unit);
 }
 
 #endif

--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -10,6 +10,6 @@
   (re_export unix))
  (foreign_stubs
   (language c)
-  (names pthread_chdir_stubs))
+  (names csexp_rpc_stubs))
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
it no longer just contains stubs for chdir

also take the opportunity to format it automatically

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: fcf97a84-ad51-426d-9a5c-babacf598699 -->