### PR TITLE
fsevents: move free to finalizer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,9 @@ Unreleased
 
 - Allow parallel execution of inline tests partitions (#7012, @hhugo)
 
+- Fix segfault on MacOS when dune was being shutdown while in watch mode.
+  (#7312, fixes #6151, @gridbugs, @emillon)
+
 3.7.0 (2023-02-17)
 ------------------
 


### PR DESCRIPTION
Fixes https://github.com/ocaml/dune/issues/6151

This just a copy of https://github.com/ocaml/dune/pull/6215 rebased onto main. I've tested this on both an M1 and x86 mac and it fixes the problem.