### PR TITLE
refactor(rpc): hide Session.create

### DIFF
--- a/src/csexp_rpc/csexp_rpc.mli
+++ b/src/csexp_rpc/csexp_rpc.mli
@@ -45,8 +45,6 @@ module Session : sig
       writing *)
   type t
 
-  val create : socket:bool -> in_channel -> out_channel -> t Fiber.t
-
   (* [write t x] writes the s-expression when [x] is [Some sexp], and closes the
      session if [x = None ] *)
   val write : t -> Sexp.t list option -> unit Fiber.t


### PR DESCRIPTION
It was never used outside of the Csexp_rpc module

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2e9af807-a204-4174-bb99-29a0769c8a9e -->