### PR TITLE
fix(rpc): ignore sigpipe on linux

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 Unreleased
 ----------
 
-- RPC: Ignore SIGPIPE when clients suddenly disconnect on OSX (#7299, partially
-  fixes #6879, @rgrinberg)
+- RPC: Ignore SIGPIPE when clients suddenly disconnect (#7299, #7319, fixes
+  #6879, @rgrinberg)
 
 - Always clean up the UI on exit. (#7271, fixes #7142 @rgrinberg)
 

--- a/src/csexp_rpc/csexp_rpc.mli
+++ b/src/csexp_rpc/csexp_rpc.mli
@@ -83,3 +83,7 @@ module Server : sig
 
   val listening_address : t -> Unix.sockaddr
 end
+
+module Private : sig
+  module Io_buffer : module type of Io_buffer
+end

--- a/src/csexp_rpc/dune
+++ b/src/csexp_rpc/dune
@@ -7,6 +7,7 @@
   dune_util
   csexp
   fiber
+  threads.posix
   (re_export unix))
  (foreign_stubs
   (language c)

--- a/src/csexp_rpc/io_buffer.ml
+++ b/src/csexp_rpc/io_buffer.ml
@@ -1,0 +1,98 @@
+open Stdune
+
+type t =
+  { mutable bytes : Bytes.t (* underlying bytes *)
+  ; (* the position we can start reading from (until [pos_w]) *)
+    mutable pos_r : int
+  ; (* the position we can start writing to (until [Bytes.length bytes - 1]) *)
+    mutable pos_w : int
+  ; (* total number of bytes written to this buffer. 2^63 bytes should be
+       enough for anybody *)
+    mutable total_written : int
+  }
+
+type flush_token = int
+
+(* We can't use [Out_channel] for writes on Linux because we want to disable
+   sigpipes. Eventually we'll move to event based IO and ditch the threads,
+   so we'll need this anyway *)
+
+let create ~size =
+  { bytes = Bytes.create size; pos_r = 0; pos_w = 0; total_written = 0 }
+
+let length t = t.pos_w - t.pos_r
+
+let max_buffer_size = 65536
+
+let maybe_resize_to_fit t write_size =
+  let buf_len = Bytes.length t.bytes in
+  let capacity = buf_len - t.pos_w in
+  if capacity < write_size then (
+    let bytes =
+      let new_size =
+        let needed = buf_len + write_size - capacity in
+        max (min max_buffer_size (buf_len * 2)) needed
+      in
+      Bytes.create new_size
+    in
+    let len = length t in
+    Bytes.blit ~src:t.bytes ~src_pos:t.pos_r ~dst:bytes ~dst_pos:0 ~len;
+    t.bytes <- bytes;
+    t.pos_w <- len;
+    t.pos_r <- 0)
+
+let write_char_exn t c =
+  assert (t.pos_w < Bytes.length t.bytes);
+  Bytes.set t.bytes t.pos_w c;
+  t.pos_w <- t.pos_w + 1
+
+let write_string_exn t src =
+  assert (t.pos_w < Bytes.length t.bytes);
+  let len = String.length src in
+  Bytes.blit_string ~src ~src_pos:0 ~dst:t.bytes ~dst_pos:t.pos_w ~len;
+  t.pos_w <- t.pos_w + len
+
+let read t len =
+  let pos_r = t.pos_r + len in
+  if pos_r > t.pos_w then
+    Code_error.raise "not enough bytes in buffer"
+      [ ("len", Dyn.int len); ("length", Dyn.int (length t)) ];
+  t.pos_r <- pos_r;
+  t.total_written <- t.total_written + len
+
+let flush_token t = t.total_written + length t
+
+let flushed t token = t.total_written >= token
+
+let write_csexps =
+  let rec loop t (csexp : Csexp.t) =
+    match csexp with
+    | Atom str ->
+      write_string_exn t (string_of_int (String.length str));
+      write_char_exn t ':';
+      write_string_exn t str
+    | List e ->
+      write_char_exn t '(';
+      List.iter ~f:(loop t) e;
+      write_char_exn t ')'
+  in
+  fun t csexps ->
+    let length =
+      List.fold_left csexps ~init:0 ~f:(fun acc csexp ->
+          acc + Csexp.serialised_length csexp)
+    in
+    maybe_resize_to_fit t length;
+    List.iter ~f:(loop t) csexps
+
+let pos t = t.pos_r
+
+let bytes t = t.bytes
+
+let to_dyn ({ bytes; pos_r; pos_w; total_written } as t) =
+  let open Dyn in
+  record
+    [ ("total_written", int total_written)
+    ; ("contents", string (Bytes.sub_string bytes ~pos:pos_r ~len:(length t)))
+    ; ("pos_w", int pos_w)
+    ; ("pos_r", int pos_r)
+    ]

--- a/src/csexp_rpc/io_buffer.mli
+++ b/src/csexp_rpc/io_buffer.mli
@@ -1,0 +1,33 @@
+(** A resizable IO buffer *)
+
+type t
+
+val to_dyn : t -> Dyn.t
+
+(** create a new io buffer *)
+val create : size:int -> t
+
+(** [read t n] reads [n] bytes *)
+val read : t -> int -> unit
+
+(** [write t csexps] write [csexps] to [t] while resizing [t] as necessary *)
+val write_csexps : t -> Csexp.t list -> unit
+
+(** a flush token is used to determine when a write has been completely flushed *)
+type flush_token
+
+(** [flush_token t] will be flushed whenever everything in [t] will be written *)
+val flush_token : t -> flush_token
+
+(** [flushed t token] will return [true] once all the data that was present in
+    [t] when [token] was created will be written *)
+val flushed : t -> flush_token -> bool
+
+(** underlying raw buffer *)
+val bytes : t -> Bytes.t
+
+(** [pos t] in [bytes t] to read *)
+val pos : t -> int
+
+(** [length t] the number of bytes to read [bytes t] *)
+val length : t -> int

--- a/test/expect-tests/csexp_rpc/io_buffer_tests.ml
+++ b/test/expect-tests/csexp_rpc/io_buffer_tests.ml
@@ -1,0 +1,68 @@
+open Stdune
+module Io_buffer = Csexp_rpc.Private.Io_buffer
+
+let () = Printexc.record_backtrace false
+
+let print_dyn x = Io_buffer.to_dyn x |> Dyn.to_string |> print_endline
+
+let%expect_test "empty buffer is empty" =
+  print_dyn (Io_buffer.create ~size:4);
+  [%expect {| { total_written = 0; contents = ""; pos_w = 0; pos_r = 0 } |}]
+
+let%expect_test "resize" =
+  let buf = Io_buffer.create ~size:2 in
+  Io_buffer.write_csexps buf [ Csexp.Atom "xxx" ];
+  print_dyn buf;
+  [%expect
+    {|
+    { total_written = 0; contents = "3:xxx"; pos_w = 5; pos_r = 0 } |}];
+  Io_buffer.write_csexps buf [ Csexp.Atom "xxxyyy" ];
+  print_dyn buf;
+  [%expect
+    {|
+    { total_written = 0; contents = "3:xxx6:xxxyyy"; pos_w = 13; pos_r = 0 } |}]
+
+let%expect_test "reading" =
+  let buf = Io_buffer.create ~size:10 in
+  Io_buffer.write_csexps buf [ Csexp.Atom "abcde" ];
+  print_dyn buf;
+  [%expect
+    {|
+    { total_written = 0; contents = "5:abcde"; pos_w = 7; pos_r = 0 } |}];
+  Io_buffer.read buf 4;
+  print_dyn buf;
+  [%expect
+    {|
+    { total_written = 4; contents = "cde"; pos_w = 7; pos_r = 4 } |}];
+  Io_buffer.read buf 2;
+  print_dyn buf;
+  [%expect
+    {|
+    { total_written = 6; contents = "e"; pos_w = 7; pos_r = 6 } |}];
+  (* buffer is now empty, this should now error *)
+  Io_buffer.read buf 2;
+  print_dyn buf;
+  [%expect.unreachable]
+  [@@expect.uncaught_exn
+    {|
+  ("(\"not enough bytes in buffer\", { len = 2; length = 1 })") |}]
+
+let%expect_test "reading" =
+  let buf = Io_buffer.create ~size:1 in
+  Io_buffer.write_csexps buf [ Atom "abc" ];
+  print_dyn buf;
+  [%expect
+    {|
+    { total_written = 0; contents = "3:abc"; pos_w = 5; pos_r = 0 } |}];
+  let flush = Io_buffer.flush_token buf in
+  printfn "token: %b" (Io_buffer.flushed buf flush);
+  [%expect {|
+    token: false |}];
+  Io_buffer.read buf 4;
+  printfn "token: %b" (Io_buffer.flushed buf flush);
+  [%expect {|
+    token: false |}];
+  Io_buffer.read buf 1;
+  printfn "token: %b" (Io_buffer.flushed buf flush);
+  [%expect {|
+    token: true |}]


### PR DESCRIPTION
We ignore sigpipe by sending messages with `sendmsg` with the appropriate flag.

All of this requires us to get rid of the `Out_channel`, but this desirable anyway, since we'll need it gone for evented IO.

<!-- ps-id: bca90be1-43e5-4e3f-a56c-08901d4d4863 -->