### PR TITLE
test(melange): show work around for ocamldep issue + melange ppx

### DIFF
--- a/test/blackbox-tests/test-cases/melange/ocamldep-melange-ppx-workaround.t
+++ b/test/blackbox-tests/test-cases/melange/ocamldep-melange-ppx-workaround.t
@@ -1,0 +1,58 @@
+Showcases issues with ocamldep when using melange ppx
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > (using melange 0.1)
+  > EOF
+
+We name the module Z so that its rules are processed after the ones from Main,
+in order to trigger the error
+
+  $ cat > z.ml <<EOF
+  > let some_binding = Some "string"
+  > EOF
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias dist)
+  >  (target dist))
+  > EOF
+  $ cat > main.ml <<EOF
+  > let foo = [%bs.obj { foo = Z.some_binding }]
+  > let () =
+  >   Js.log foo
+  > EOF
+  $ dune build @dist
+  File "main.ml", line 1, characters 27-41:
+  1 | let foo = [%bs.obj { foo = Z.some_binding }]
+                                 ^^^^^^^^^^^^^^
+  Error: The module Z is an alias for module Melange__Z, which is missing
+  [1]
+The error above happens because ocamldep does not show dependencies on Main
+  $ ocamldep -I . main.ml
+  main.cmo :
+  main.cmx :
+
+A workaround is to pre-process the file with the melange ppx first:
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias dist)
+  >  (preprocess
+  >   (action (run melc --as-pp %{input-file})))
+  >  (compile_flags :standard --bs-no-builtin-ppx)
+  >  (target dist))
+  > EOF
+
+  $ dune clean
+  $ dune build @dist
+  $ node _build/default/dist/main.js
+  { foo: 'string' }
+
+The above works as in that case, ocamldep picks up the dependency ok (in the
+pre-processed file)
+
+  $ ocamldep _build/default/main.pp.ml
+  _build/default/main.pp.cmo : \
+      z.cmo
+  _build/default/main.pp.cmx : \
+      z.cmx


### PR DESCRIPTION
This is an alternative version of https://github.com/ocaml/dune/pull/6625/ with a workaround that's not manual.

Right now it's possible to overcome the limitation of `ocamldep` running before the melange PPX by:
- adding a `(preprocess (action melc --as-ppx %{input-file}))` field

This, however, has a pretty significant limitation: it isn't possible to run both actions + ppxes in a `preprocess` field (see https://github.com/ocaml/dune/issues/171).

So, it sounds to me that we need to solve this in melange too:
- expose a melange ppx library that works with the `pps` preprocessing stack
  - https://github.com/melange-re/melange/pull/480 was already a step in this direction, by decoupling a few things in the melange source that make it possible to publish a separate PPX.