### PR TITLE
fix(ci): restrict jsoo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ cinaps \
 core_bench \
 "csexp>=1.3.0" \
 js_of_ocaml \
-js_of_ocaml-compiler \
+"js_of_ocaml-compiler<5.1.0" \
 "mdx>=2.1.0" \
 menhir \
 ocamlfind \


### PR DESCRIPTION
Our test suite is incompatible with 5.1.0.
This ensures it is not picked by CI.
This bound is to be removed once a fixed version has been released.

Signed-off-by: Etienne Millon <me@emillon.org>
