### PR TITLE
doc: add todos for new structure

### DIFF
--- a/doc/advanced/custom-cmxs.rst
+++ b/doc/advanced/custom-cmxs.rst
@@ -1,6 +1,8 @@
 Building an Ad Hoc ``.cmxs``
 ----------------------------
 
+.. TODO(diataxis) howto: Building an Ad Hoc ``.cmxs``
+
 In the model exposed by Dune, a ``.cmxs`` target is created for each
 library. However, the ``.cmxs`` format itself is more flexible and is
 capable to containing arbitrary ``.cmxa`` and ``.cmx`` files.

--- a/doc/advanced/findlib-dynamic.rst
+++ b/doc/advanced/findlib-dynamic.rst
@@ -1,6 +1,8 @@
 Dynamic Loading of Packages with Findlib
 ========================================
 
+.. TODO(diataxis) this is an howto
+
 The preferred way for new development is to use :ref:`plugins`.
 
 Dune supports the ``findlib.dynload`` package from `Findlib

--- a/doc/advanced/ocaml-syntax.rst
+++ b/doc/advanced/ocaml-syntax.rst
@@ -1,6 +1,10 @@
 OCaml Syntax
 ============
 
+.. TODO(diataxis)
+   - reference: files
+   - howto: using dynamic features
+
 If a ``dune`` file starts with ``(* -*- tuareg -*- *)``, then it is
 interpreted as an OCaml script that generates the ``dune`` file as described
 in the rest of this section. The code in the script will have access to a

--- a/doc/advanced/package-version.rst
+++ b/doc/advanced/package-version.rst
@@ -1,6 +1,9 @@
 Package Version
 ===============
 
+.. TODO(diataxis)
+   - reference: environment - packages
+
 Dune determines a package's version by looking at the ``version``
 field in the :ref:`package stanza <package>`. If the version field isn't 
 set, it looks at the toplevel ``version`` field in the

--- a/doc/advanced/profiling-dune.rst
+++ b/doc/advanced/profiling-dune.rst
@@ -1,6 +1,10 @@
 Profiling Dune
 ==============
 
+.. TODO(diataxis)
+   - reference: the CLI
+   - howto: profiling a dune build
+
 If ``--trace-file FILE`` is passed, Dune will write detailed data about internal
 operations, such as the timing of commands that Dune runs.
 

--- a/doc/advanced/variables-artifacts.rst
+++ b/doc/advanced/variables-artifacts.rst
@@ -3,6 +3,8 @@
 Variables for Artifacts
 -----------------------
 
+.. TODO(diataxis) move to :doc:`../concepts/variables`
+
 For specific situations where one needs to refer to individual compilation
 artifacts, special variables (see :doc:`../concepts/variables`) are provided,
 so the user doesn't need to be aware of the particular naming conventions or

--- a/doc/caching.rst
+++ b/doc/caching.rst
@@ -2,6 +2,8 @@
 Dune Cache
 **********
 
+.. TODO(diataxis) This is reference material with some explanation.
+
 Dune implements a cache of build results that is shared across different
 workspaces. Before executing a build rule, Dune looks it up in the shared
 cache, and if it finds a matching entry, Dune skips the rule's execution and

--- a/doc/concepts/dependency-spec.rst
+++ b/doc/concepts/dependency-spec.rst
@@ -1,6 +1,10 @@
 Dependency Specification
 ========================
 
+.. TODO(diataxis)
+   - reference - dependency spec
+   - reference - globbing
+
 Dependencies in ``dune`` files can be specified using one of the following:
 
 .. _source_tree:

--- a/doc/concepts/locks.rst
+++ b/doc/concepts/locks.rst
@@ -1,6 +1,10 @@
 Locks
 =====
 
+.. TODO(diataxis)
+   - howto: testing in general (note about concurrency)
+   - reference: locks
+
 Given two rules that are independent, Dune will assume that their
 associated actions can be run concurrently. Two rules are considered
 independent if neither of them depend on the other, either directly or

--- a/doc/concepts/package-spec.rst
+++ b/doc/concepts/package-spec.rst
@@ -1,6 +1,11 @@
 Package Specification
 =====================
 
+.. TODO(diataxis)
+   - reference: packages
+   - howto: preparing an opam package
+   - tutorial: from zero to opam
+
 Installation is the process of copying freshly built libraries,
 binaries, and other files from the build directory to the system. Dune
 offers two ways of doing this: via opam or directly via the ``install``

--- a/doc/concepts/promotion.rst
+++ b/doc/concepts/promotion.rst
@@ -1,6 +1,10 @@
 Diffing and Promotion
 =====================
 
+.. TODO(diataxis)
+   - howto: diffing and promotion
+   - reference: diffing
+
 ``(diff <file1> <file2>)`` is very similar to ``(run diff <file1>
 <file2>)``. In particular it behaves in the same way:
 

--- a/doc/concepts/sandboxing.rst
+++ b/doc/concepts/sandboxing.rst
@@ -1,6 +1,10 @@
 Sandboxing
 ==========
 
+.. TODO(diataxis)
+   - explanation: sandboxing
+   - reference: sandboxing
+
 The user actions that run external commands (``run``, ``bash``, ``system``)
 are opaque to Dune, so Dune has to rely on manual specification of dependencies
 and targets. One problem with manual specification is that it's error-prone.

--- a/doc/concepts/scopes.rst
+++ b/doc/concepts/scopes.rst
@@ -1,6 +1,10 @@
 Scopes
 ======
 
+.. TODO(diataxis)
+   - reference: library lookup
+   - howto: vendoring
+
 Any directory containing at least one ``<package>.opam`` file defines
 a scope. This scope is the subtree starting from this directory,
 excluding any other scopes rooted in subdirectories.

--- a/doc/concepts/variables.rst
+++ b/doc/concepts/variables.rst
@@ -1,6 +1,10 @@
 Variables
 =========
 
+.. TODO(diataxis)
+   - reference: variables
+   - explanation: rule loading
+
 Some fields can contains variables that are expanded by Dune.
 The syntax of variables is as follows:
 

--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -4,6 +4,13 @@
 Coq
 ***
 
+.. TODO(diataxis)
+
+   This looks like there are several components in there:
+
+   - reference info for stanzas and variables
+   - tutorials (the examples part)
+
 .. contents:: Table of Contents
     :depth: 3
 

--- a/doc/cross-compilation.rst
+++ b/doc/cross-compilation.rst
@@ -4,6 +4,10 @@
 Cross-Compilation
 *****************
 
+.. TODO(diataxis)
+
+   This can be turned into an how-to guide.
+
 Dune allows for cross-compilation by defining build contexts with multiple
 targets. Targets are specified by adding a ``targets`` field to the build
 context definition.

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -4,6 +4,13 @@
 Generating Documentation
 ************************
 
+.. TODO(diataxis)
+
+   Split between:
+
+   - a "generating API documentation" how-to guide
+   - some reference documentation
+
 Prerequisites
 =============
 

--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -2,6 +2,13 @@
 Stanza Reference
 ****************
 
+.. TODO(diataxis)
+
+   Recycle this content into:
+
+   - :doc:`reference/stanzas`
+   - :doc:`reference/files`
+
 .. _dune-project:
 
 dune-project

--- a/doc/dune-libs.rst
+++ b/doc/dune-libs.rst
@@ -2,6 +2,8 @@
 Dune Libraries
 **************
 
+.. TODO(diataxis) Move into :doc:`reference/dune-libs`
+
 .. _configurator:
 
 Configurator

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -2,6 +2,12 @@
 FAQ
 ***
 
+.. TODO(diataxis)
+
+   This is an odd one - most of these questions are not frequently asked at all.
+
+   Some of these are mini how-to guides, or sections of existing guides.
+
 Why Do Many Dune Projects Contain a ``Makefile``?
 =================================================
 

--- a/doc/foreign-code.rst
+++ b/doc/foreign-code.rst
@@ -2,6 +2,14 @@
 Dealing with Foreign Libraries
 ******************************
 
+.. TODO(diataxis)
+
+   There are various types of content here:
+
+   - how-to guide for adding C stubs to an existing library
+   - tutorial for ctypes
+   - reference for ctypes field
+
 The OCaml programming language can interface with libraries written in foreign
 languages such as C. This section explains how to do this with Dune. Note that
 it does not cover how to write the C stubs themselves, but this is covered by

--- a/doc/goals.rst
+++ b/doc/goals.rst
@@ -2,6 +2,10 @@
 Goal of Dune
 ************
 
+.. TODO(diataxis)
+   This is an important page and should go in a sort of meta section together
+   with the history of the project and the glossary for example.
+
 The Dune project strives to provide the best possible build tool for the entire
 OCaml community, including individual developers contributing to open source
 projects in their free time, larger companies (such as Jane Street), and

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -2,6 +2,9 @@
 Working on the Dune Codebase
 ****************************
 
+.. TODO(diataxis)
+   This can be folded either in a meta section or as an how-to guide.
+
 This section gives guidelines for working on Dune itself. Many of these are
 general guidelines specific to Dune. However, given that Dune is a large project
 developed by many different people, it's important to follow these guidelines in

--- a/doc/instrumentation.rst
+++ b/doc/instrumentation.rst
@@ -2,6 +2,14 @@
 Instrumentation
 ***************
 
+.. TODO(diataxis)
+
+   Split between:
+
+   - reference about ``(instrumentation)``
+   - :doc:`howto/code-coverage`
+   - specific reference about ``(instrumentation.backend)``
+
 In this section, we'll explain how to define and use instrumentation backends
 (such as ``bisect_ppx`` or ``landmarks``) so that you can enable and disable
 coverage via ``dune-workspace`` files or by passing a command-line flag or

--- a/doc/jsoo.rst
+++ b/doc/jsoo.rst
@@ -4,6 +4,10 @@
 JavaScript Compilation With Js_of_ocaml
 ***************************************
 
+.. TODO(diataxis)
+
+   This is an how-to guide.
+
 Js_of_ocaml_ is a compiler from OCaml to JavaScript. The compiler works by
 translating OCaml bytecode to JS files. The compiler can be installed with opam:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -2,6 +2,15 @@
 Overview
 ********
 
+.. TODO(diataxis)
+
+   Split into:
+
+   - info on the index page
+   - :doc:`glossary`
+   - :doc:`reference/files`
+   - a history page that could also explain the various actors
+
 Introduction
 ============
 

--- a/doc/quick-start.rst
+++ b/doc/quick-start.rst
@@ -2,6 +2,17 @@
 Quickstart
 **********
 
+.. TODO(diataxis)
+
+   Split this into:
+
+   - :doc:`tutorials/from-zero-to-opam`
+   - :doc:`tutorials/developing-with-dune`
+   - :doc:`howto/changing-flags`
+   - an how-to guide about ``cppo``
+   - an how-to guide about staged programming / generators
+   - an how-to guide about testing
+
 This document gives simple usage examples of Dune. You can also look at
 `examples <https://github.com/ocaml/dune/tree/master/example>`__ for complete
 examples of projects using Dune with `CRAM stanzas <https://ocaml.org/p/craml/1.0.0>`__.

--- a/doc/rpc.rst
+++ b/doc/rpc.rst
@@ -4,6 +4,11 @@
 Dune RPC
 ********
 
+.. TODO(diataxis)
+
+   This one could be split into :doc:`reference/dune-libs` for the API part and
+   a how-to guide which is missing.
+
 Starting from dune 3.0, dune's watch mode also runs an RPC server. This is a
 general mechanism introduced to integrate with various dune functionality. Some
 use cases we have in mind are:

--- a/doc/sites.rst
+++ b/doc/sites.rst
@@ -4,6 +4,13 @@
 How to Load Additional Files at Runtime
 ***************************************
 
+.. TODO(diataxis)
+
+   Split between:
+
+   - an how-to guide
+   - some reference material
+
 There are many ways for applications to load files at runtime and Dune provides
 a well-tested, key-in-hand portable system for doing so. The Dune model works by
 defining ``sites`` where files will be installed and looked up at runtime. At

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -4,6 +4,18 @@
 Writing and Running Tests
 *************************
 
+.. TODO(diataxis)
+
+   This is mostly a guide, or rather several of them. There is also some
+   reference in it.
+
+   Something we can do is split this into:
+
+   - one how-to guide per test technique
+   - a "choosing a test technique" how-to guide
+   - reference for ``inline_tests.backend``
+   - reference for cram tests
+
 Dune tries to streamline the testing story as much as possible, so
 you can focus on the tests themselves and not bother with setting
 up various test frameworks.

--- a/doc/toplevel-integration.rst
+++ b/doc/toplevel-integration.rst
@@ -2,6 +2,11 @@
 Toplevel Integration
 ********************
 
+.. TODO(diataxis)
+
+   This is an how-to guide (but the list of commands should be in a reference
+   article somewhere).
+
 OCaml provides a small REPL to use the language interactively. We
 generally call this tool a `toplevel`. The compiler distribution comes
 with a small REPL called simply ``ocaml``, and the community has

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -2,6 +2,15 @@
 Command-Line Interface
 **********************
 
+.. TODO(diataxis)
+
+   There are mixed types of contents in this document, including:
+
+   - an how-to about ``dune init``
+   - reference info about finding the root and libraries
+   - reference info about the CLI
+   - how-to info about overriding what ``dune build`` does
+
 This section describes using ``dune`` from the shell.
 
 .. _initializing_components:

--- a/doc/variants.rst
+++ b/doc/variants.rst
@@ -2,6 +2,8 @@
 Virtual Libraries & Variants
 ****************************
 
+.. TODO(diataxis) This is a guide, with reference info in it.
+
 Virtual libraries correspond to Dune's ability to compile parameterised
 libraries and delay the selection of concrete implementations until linking an
 executable.


### PR DESCRIPTION
This PR adds todo notes to finish migrating to a new structure for our documentation.
    
It is based on the [Diátaxis](https://diataxis.fr/) framework. The core idea is to organize documentation based on what the user is after when reading it. 4 categories emerge:
    
- tutorials ("can you teach me how to...")
- how-to guides ("how do I...")
- reference guide ("what is...")
- explanations ("why...")
    
An example of docs where this has been used is [the gatsby docs](https://www.gatsbyjs.com/docs/).
    
Our existing docs have a lot of good content in it but it is difficult to find because these concerns are mixed in the various documentation pages.
    
For example, all these aspects tend to be grouped together in a single page dedicated to a particular feature. But a reader rarely needs to refer to every aspect of the docs for that feature.
    
We also have some pages ("concepts" and "advanced topics") that are really several pages concatenated together with no strong unifying theme.
    
This shows how to go to both a desired "complete" state (see <https://diataxis.fr/how-to-use-diataxis/#complete-not-finished>).
    
