### PR TITLE
refactor: introduce source tree library

### DIFF
--- a/src/dune_source_tree/dune
+++ b/src/dune_source_tree/dune
@@ -1,0 +1,3 @@
+(library
+ (name dune_source_tree)
+ (libraries stdune unix ordering dyn memo))

--- a/src/dune_source_tree/dune_source_tree.ml
+++ b/src/dune_source_tree/dune_source_tree.ml
@@ -1,0 +1,16 @@
+module type Reduced_stats = Reduced_stats_intf.S
+
+module Make (Reduced_stats : Reduced_stats) = struct
+  module Readdir = struct
+    type t = Readdir.t
+
+    module type S = Readdir.S with type reduced_stats := Reduced_stats.t
+
+    module Make = Readdir.Make (Reduced_stats)
+  end
+
+  module Source_tree = struct
+    module Dir = Source_tree.Dir
+    module Make = Source_tree.Make (Reduced_stats)
+  end
+end

--- a/src/dune_source_tree/dune_source_tree.mli
+++ b/src/dune_source_tree/dune_source_tree.mli
@@ -1,0 +1,98 @@
+open Stdune
+
+(** Lazily loaded file system.
+
+    The set of modules in this library are designed to represent the source tree
+    of a build system. *)
+
+module type Reduced_stats = sig
+  (** We functorize over this type to avoid pulling the entire engine *)
+
+  type t =
+    { st_dev : int  (** Device number *)
+    ; st_ino : int  (** Inode number *)
+    ; st_kind : File_kind.t  (** Kind of the file *)
+    }
+end
+
+module Make (Reduced_stats : Reduced_stats) : sig
+  module Readdir : sig
+    (** Memoized interaction with the directories in the file system. *)
+
+    type t
+
+    module type S = sig
+      val stat :
+           Path.Outside_build_dir.t
+        -> (Reduced_stats.t, Unix_error.Detailed.t) result Memo.t
+
+      val readdir :
+        Path.Source.t -> (Readdir.t, Unix_error.Detailed.t) result Memo.t
+    end
+
+    (** Construct a directory loading function. *)
+    module Make (Dir_contents : sig
+      type t
+
+      (** The sorted list of file names with kinds. *)
+      val to_list : t -> (Filename.t * File_kind.t) list
+    end) (_ : sig
+      val path_stat :
+           Path.Outside_build_dir.t
+        -> (Reduced_stats.t, Unix_error.Detailed.t) result Memo.t
+
+      val dir_contents :
+           Path.Outside_build_dir.t
+        -> (Dir_contents.t, Unix_error.Detailed.t) result Memo.t
+    end) : S
+  end
+
+  module Source_tree : sig
+    (** Lazily loaded trie based on a directory reading and a stat loading
+        function *)
+    module Dir : sig
+      type 'a t
+
+      val path : _ t -> Path.Source.t
+
+      val files : _ t -> Filename.Set.t
+
+      val file_paths : _ t -> Path.Source.Set.t
+
+      type 'a sub_dir
+
+      val sub_dirs : 'a t -> 'a sub_dir Filename.Map.t
+
+      val sub_dir_as_t : 'a sub_dir -> 'a t Memo.t
+
+      val to_dyn : _ t -> Dyn.t
+
+      module Make_map_reduce (M : Memo.S) (Outcome : Monoid) : sig
+        (** Traverse sub-directories recursively, pass them to [f] and combine
+            intermediate results into a single one via [M.combine]. *)
+        val map_reduce : 'a t -> f:('a t -> Outcome.t M.t) -> Outcome.t M.t
+      end
+
+      val sub_dir_names : _ t -> Filename.Set.t
+    end
+
+    module Make (_ : Readdir.S) : sig
+      type 'a t
+
+      val find_dir : 'a t -> Path.Source.t -> 'a Dir.t option Memo.t
+
+      val root : 'a t -> 'a Dir.t Memo.t
+
+      (** [nearest_dir t fn] returns the directory with the longest path that is
+          an ancestor of [fn]. *)
+      val nearest_dir : 'a t -> Path.Source.t -> 'a Dir.t Memo.t
+
+      (** [true] iff the path is a file *)
+      val file_exists : 'a t -> Path.Source.t -> bool Memo.t
+
+      val files_of : 'a t -> Path.Source.t -> Path.Source.Set.t Memo.t
+
+      val dir_exists : 'a t -> Path.Source.t -> bool Memo.t
+    end
+  end
+end

--- a/src/dune_source_tree/file.ml
+++ b/src/dune_source_tree/file.ml
@@ -1,0 +1,27 @@
+open Stdune
+
+module T = struct
+  type t =
+    { ino : int
+    ; dev : int
+    }
+
+  let to_dyn { ino; dev } =
+    let open Dyn in
+    record [ ("ino", Int.to_dyn ino); ("dev", Int.to_dyn dev) ]
+
+  let compare { ino; dev } t =
+    let open Ordering.O in
+    let= () = Int.compare ino t.ino in
+    Int.compare dev t.dev
+end
+
+include T
+
+let dummy = { ino = 0; dev = 0 }
+
+module Map = Map.Make (T)
+
+module Make (Reduced_stats : Reduced_stats_intf.S) = struct
+  let of_stats (st : Reduced_stats.t) = { ino = st.st_ino; dev = st.st_dev }
+end

--- a/src/dune_source_tree/file.mli
+++ b/src/dune_source_tree/file.mli
@@ -1,0 +1,18 @@
+open Stdune
+
+type t =
+  { ino : int
+  ; dev : int
+  }
+
+val dummy : t
+
+val to_dyn : t -> Dyn.t
+
+val compare : t -> t -> Ordering.t
+
+module Map : Map.S with type key = t
+
+module Make (Reduced_stats : Reduced_stats_intf.S) : sig
+  val of_stats : Reduced_stats.t -> t
+end

--- a/src/dune_source_tree/readdir.ml
+++ b/src/dune_source_tree/readdir.ml
@@ -1,0 +1,109 @@
+open Stdune
+open Memo.O
+
+type t =
+  { path : Path.Source.t
+  ; files : Filename.Set.t
+  ; dirs : (Filename.t * Path.Source.t * File.t) list
+  }
+
+module type S = sig
+  type reduced_stats
+
+  val stat :
+       Path.Outside_build_dir.t
+    -> (reduced_stats, Unix_error.Detailed.t) result Memo.t
+
+  val readdir : Path.Source.t -> (t, Unix_error.Detailed.t) result Memo.t
+end
+
+let equal =
+  let dirs_equal (s1, p1, f1) (s2, p2, f2) =
+    Filename.equal s1 s2 && Path.Source.equal p1 p2 && File.compare f1 f2 = Eq
+  in
+  fun x y ->
+    Path.Source.equal x.path y.path
+    && Filename.Set.equal x.files y.files
+    && List.equal dirs_equal x.dirs y.dirs
+
+let empty path = { path; files = Filename.Set.empty; dirs = [] }
+
+let _to_dyn { path; files; dirs } =
+  let open Dyn in
+  record
+    [ ("path", Path.Source.to_dyn path)
+    ; ("files", Filename.Set.to_dyn files)
+    ; ("dirs", list (triple string Path.Source.to_dyn File.to_dyn) dirs)
+    ]
+
+(* Returns [true] for special files such as character devices of sockets; see
+   #3124 for more on issues caused by special devices *)
+let is_special (st_kind : Unix.file_kind) =
+  match st_kind with
+  | S_CHR | S_BLK | S_FIFO | S_SOCK -> true
+  | _ -> false
+
+module Make
+    (Reduced_stats : Reduced_stats_intf.S) (Dir_contents : sig
+      type t
+
+      (** The sorted list of file names with kinds. *)
+      val to_list : t -> (string * File_kind.t) list
+    end) (Fs_memo : sig
+      val path_stat :
+           Path.Outside_build_dir.t
+        -> (Reduced_stats.t, Unix_error.Detailed.t) result Memo.t
+
+      val dir_contents :
+           Path.Outside_build_dir.t
+        -> (Dir_contents.t, Unix_error.Detailed.t) result Memo.t
+    end) =
+struct
+  module Reduced_stats_of_file = File.Make (Reduced_stats)
+
+  let stat dir =
+    let+ res = Fs_memo.path_stat dir in
+    Result.map res ~f:Reduced_stats_of_file.of_stats
+
+  let of_source_path_impl path =
+    Fs_memo.dir_contents (In_source_dir path) >>= function
+    | Error unix_error -> Memo.return @@ Error unix_error
+    | Ok dir_contents ->
+      let dir_contents = Dir_contents.to_list dir_contents in
+      let+ files, dirs =
+        Memo.parallel_map dir_contents ~f:(fun (fn, kind) ->
+            let path = Path.Source.relative path fn in
+            if Path.Source.is_in_build_dir path then Memo.return List.Skip
+            else
+              let+ is_directory, file =
+                match kind with
+                | S_DIR -> (
+                  stat (In_source_dir path) >>| function
+                  | Ok file -> (true, file)
+                  | Error _ -> (true, File.dummy))
+                | S_LNK -> (
+                  Fs_memo.path_stat (In_source_dir path) >>| function
+                  | Ok ({ st_kind = S_DIR; _ } as st) ->
+                    (true, Reduced_stats_of_file.of_stats st)
+                  | Ok _ | Error _ -> (false, File.dummy))
+                | _ -> Memo.return (false, File.dummy)
+              in
+              if is_directory then List.Right (fn, path, file)
+              else if is_special kind then Skip
+              else Left fn)
+        >>| List.filter_partition_map ~f:Fun.id
+      in
+      { path; files = Filename.Set.of_list files; dirs } |> Result.ok
+
+  (* Having a cutoff here speeds up incremental rebuilds quite a bit when a
+     directory contents is invalidated but the result stays the same. *)
+  let of_source_path_memo =
+    Memo.create "readdir-of-source-path"
+      ~input:(module Path.Source)
+      ~cutoff:(Result.equal equal Unix_error.Detailed.equal)
+      of_source_path_impl
+
+  let readdir = Memo.exec of_source_path_memo
+
+  let stat = Fs_memo.path_stat
+end

--- a/src/dune_source_tree/readdir.mli
+++ b/src/dune_source_tree/readdir.mli
@@ -1,0 +1,35 @@
+open Stdune
+
+type t = private
+  { path : Path.Source.t
+  ; files : Filename.Set.t
+  ; dirs : (Filename.t * Path.Source.t * File.t) list
+  }
+
+val empty : Path.Source.t -> t
+
+module type S = sig
+  type reduced_stats
+
+  val stat :
+       Path.Outside_build_dir.t
+    -> (reduced_stats, Unix_error.Detailed.t) result Memo.t
+
+  val readdir : Path.Source.t -> (t, Unix_error.Detailed.t) result Memo.t
+end
+
+module Make
+    (Reduced_stats : Reduced_stats_intf.S) (Dir_contents : sig
+      type t
+
+      (** The sorted list of file names with kinds. *)
+      val to_list : t -> (Filename.t * File_kind.t) list
+    end) (_ : sig
+      val path_stat :
+           Path.Outside_build_dir.t
+        -> (Reduced_stats.t, Unix_error.Detailed.t) result Memo.t
+
+      val dir_contents :
+           Path.Outside_build_dir.t
+        -> (Dir_contents.t, Unix_error.Detailed.t) result Memo.t
+    end) : S with type reduced_stats := Reduced_stats.t

--- a/src/dune_source_tree/reduced_stats_intf.ml
+++ b/src/dune_source_tree/reduced_stats_intf.ml
@@ -1,0 +1,9 @@
+open Stdune
+
+module type S = sig
+  type t =
+    { st_dev : int  (** Device number *)
+    ; st_ino : int  (** Inode number *)
+    ; st_kind : File_kind.t  (** Kind of the file *)
+    }
+end

--- a/src/dune_source_tree/source_tree.ml
+++ b/src/dune_source_tree/source_tree.ml
@@ -1,0 +1,266 @@
+open Stdune
+open Memo.O
+
+module Dirs_visited : sig
+  (** Unique set of all directories visited *)
+  type t
+
+  val singleton : Path.Source.t -> File.t -> t
+
+  module Per_fn : sig
+    (** Stores the directories visited per node (basename) *)
+
+    type dirs_visited := t
+
+    type t
+
+    val init : t
+
+    val find : t -> Path.Source.t -> dirs_visited
+
+    val add : t -> dirs_visited -> Filename.t * Path.Source.t * File.t -> t
+  end
+end = struct
+  type t = Path.Source.t File.Map.t
+
+  let singleton path file = File.Map.singleton file path
+
+  module Per_fn = struct
+    type nonrec t = t Filename.Map.t
+
+    let init = Filename.Map.empty
+
+    let find t path =
+      Filename.Map.find t (Path.Source.basename path)
+      |> Option.value ~default:File.Map.empty
+
+    let add (acc : t) dirs_visited (fn, path, file) =
+      if Sys.win32 then acc
+      else
+        let new_dirs_visited =
+          File.Map.update dirs_visited file ~f:(function
+            | None -> Some path
+            | Some first_path ->
+              User_error.raise
+                [ Pp.textf
+                    "Path %s has already been scanned. Cannot scan it again \
+                     through symlink %s"
+                    (Path.Source.to_string_maybe_quoted first_path)
+                    (Path.Source.to_string_maybe_quoted path)
+                ])
+        in
+        Filename.Map.add_exn acc fn new_dirs_visited
+  end
+end
+
+module Output = struct
+  type 'a t =
+    { dir : 'a
+    ; visited : Dirs_visited.Per_fn.t
+    }
+end
+
+module Dir = struct
+  type 'a t =
+    { path : Path.Source.t
+    ; files : Filename.Set.t
+    ; sub_dirs : 'a sub_dir Filename.Map.t
+    ; value : 'a
+    }
+
+  and 'a sub_dir =
+    { sub_dir_as_t : (Path.Source.t, 'a t Output.t option) Memo.Cell.t }
+
+  let value t = t.value
+
+  let to_dyn { path; files; sub_dirs; value = _ } =
+    Dyn.record
+      [ ("path", Path.Source.to_dyn path)
+      ; ("files", Filename.Set.to_dyn files)
+      ; ("sub_dirs", Filename.Map.to_dyn Dyn.opaque sub_dirs)
+      ]
+
+  let path t = t.path
+
+  let files t = t.files
+
+  let sub_dirs t = t.sub_dirs
+
+  let file_paths t =
+    Path.Source.Set.of_listing ~dir:t.path
+      ~filenames:(Filename.Set.to_list (files t))
+
+  let sub_dir_names t =
+    Filename.Map.foldi (sub_dirs t) ~init:Filename.Set.empty ~f:(fun s _ acc ->
+        Filename.Set.add acc s)
+
+  let sub_dir_as_t (s : _ sub_dir) =
+    let+ t = Memo.Cell.read s.sub_dir_as_t in
+    (Option.value_exn t).dir
+
+  module Make_map_reduce (M : Memo.S) (Outcome : Monoid) = struct
+    open M.O
+
+    let rec map_reduce t ~f =
+      let+ here = f t
+      and+ in_sub_dirs =
+        Filename.Map.values t.sub_dirs
+        |> M.List.map ~f:(fun s ->
+               let* t = M.of_memo (sub_dir_as_t s) in
+               map_reduce t ~f)
+      in
+      List.fold_left in_sub_dirs ~init:here ~f:Outcome.combine
+  end
+end
+
+module Make
+    (Reduced_stats : Reduced_stats_intf.S)
+    (File_memo : Readdir.S with type reduced_stats := Reduced_stats.t) =
+struct
+  module File_memo = struct
+    module File_of_reduced_stats = File.Make (Reduced_stats)
+    include File_memo
+
+    let stat dir =
+      let open Memo.O in
+      let+ res = stat dir in
+      Result.map res ~f:File_of_reduced_stats.of_stats
+  end
+
+  type 'a t =
+    { root : 'a Dir.t Memo.t
+    ; find_dir : Path.Source.t -> 'a Dir.t option Memo.t
+    }
+
+  let create (type a) (value : a) =
+    let module Non_rec = struct
+      module rec Memoized : sig
+        (* Not part of the interface. Only necessary to call recursively *)
+        val find_dir_raw :
+          Path.Source.t -> (Path.Source.t, a Dir.t Output.t option) Memo.Cell.t
+
+        val find_dir : Path.Source.t -> a Dir.t option Memo.t
+      end = struct
+        open Memoized
+
+        let contents { Readdir.path = _; dirs; files } ~dirs_visited =
+          let dirs_visited, sub_dirs =
+            List.fold_left dirs
+              ~init:(Dirs_visited.Per_fn.init, Filename.Map.empty)
+              ~f:(fun (dirs_visited_acc, subdirs) ((fn, path, _) as dir) ->
+                let dirs_visited_acc =
+                  Dirs_visited.Per_fn.add dirs_visited_acc dirs_visited dir
+                in
+                let sub_dir =
+                  let sub_dir_as_t = find_dir_raw path in
+                  { Dir.sub_dir_as_t }
+                in
+                let subdirs = Filename.Map.add_exn subdirs fn sub_dir in
+                (dirs_visited_acc, subdirs))
+          in
+          (files, sub_dirs, dirs_visited)
+
+        let root () =
+          let path = Path.Source.root in
+          let error_unable_to_load ~path unix_error =
+            User_error.raise
+              [ Pp.textf "Unable to load source %s."
+                  (Path.Source.to_string_maybe_quoted path)
+              ; Unix_error.Detailed.pp ~prefix:"Reason: " unix_error
+              ]
+          in
+          let* readdir =
+            File_memo.readdir path >>| function
+            | Ok dir -> dir
+            | Error unix_error -> error_unable_to_load ~path unix_error
+          in
+          let+ dirs_visited =
+            File_memo.stat (In_source_dir path) >>| function
+            | Error unix_error -> error_unable_to_load ~path unix_error
+            | Ok file -> Dirs_visited.singleton path file
+          in
+          let files, sub_dirs, visited = contents readdir ~dirs_visited in
+          let dir = { Dir.path; files; sub_dirs; value } in
+          { Output.dir; visited }
+
+        let find_dir_raw_impl path : a Dir.t Output.t option Memo.t =
+          match Path.Source.parent path with
+          | None ->
+            let+ root = root () in
+            Some root
+          | Some parent_dir -> (
+            let* parent = Memo.Cell.read (find_dir_raw parent_dir) in
+            match
+              let open Option.O in
+              let+ { Output.dir = _parent_dir; visited = dirs_visited } =
+                parent
+              in
+              dirs_visited
+            with
+            | None -> Memo.return None
+            | Some dirs_visited ->
+              let dirs_visited = Dirs_visited.Per_fn.find dirs_visited path in
+              let+ readdir =
+                File_memo.readdir path >>| function
+                | Ok dir -> dir
+                | Error _ -> Readdir.empty path
+              in
+              let files, sub_dirs, visited = contents readdir ~dirs_visited in
+              let dir = { Dir.path; files; sub_dirs; value } in
+              Some { Output.dir; visited })
+
+        let find_dir_raw =
+          let memo =
+            (* amokhov: After running some experiments, I convinced myself that it's
+               not worth adding a [cutoff] here because we don't recompute this
+               function very often (the [find_dir] calls are probably guarded by other
+               cutoffs). Note also that adding a [cutoff] here is non-trivial because
+               [Dir.t] stores memoization cells in [sub_dir_as_t]. *)
+            Memo.create "find-dir-raw"
+              ~input:(module Path.Source)
+              find_dir_raw_impl
+          in
+          Memo.cell memo
+
+        let find_dir p =
+          Memo.Cell.read (find_dir_raw p) >>| function
+          | Some { Output.dir; visited = _ } -> Some dir
+          | None -> None
+      end
+    end in
+    let open Non_rec.Memoized in
+    let root = find_dir Path.Source.root >>| Option.value_exn in
+    { root; find_dir }
+
+  let root t = t.root
+
+  let find_dir t path = t.find_dir path
+
+  let rec nearest_dir t = function
+    | [] -> Memo.return t
+    | comp :: components -> (
+      match Filename.Map.find (Dir.sub_dirs t) comp with
+      | None -> Memo.return t
+      | Some sub_dir ->
+        let* sub_dir = Dir.sub_dir_as_t sub_dir in
+        nearest_dir sub_dir components)
+
+  let nearest_dir t path =
+    let components = Path.Source.explode path in
+    let* root = t.root in
+    nearest_dir root components
+
+  let files_of t path =
+    find_dir t path >>| function
+    | None -> Path.Source.Set.empty
+    | Some dir ->
+      Dir.files dir |> Filename.Set.to_list
+      |> Path.Source.Set.of_list_map ~f:(Path.Source.relative path)
+
+  let file_exists t path =
+    find_dir t (Path.Source.parent_exn path) >>| function
+    | None -> false
+    | Some dir -> Filename.Set.mem (Dir.files dir) (Path.Source.basename path)
+
+  let dir_exists t path = find_dir t path >>| Option.is_some
+end

--- a/src/dune_source_tree/source_tree.mli
+++ b/src/dune_source_tree/source_tree.mli
@@ -1,0 +1,52 @@
+open Stdune
+
+module Dir : sig
+  type 'a t
+
+  val path : 'a t -> Path.Source.t
+
+  val files : 'a t -> Filename.Set.t
+
+  val file_paths : 'a t -> Path.Source.Set.t
+
+  type 'a sub_dir
+
+  val sub_dirs : 'a t -> 'a sub_dir Filename.Map.t
+
+  val sub_dir_as_t : 'a sub_dir -> 'a t Memo.t
+
+  val to_dyn : 'a t -> Dyn.t
+
+  val value : 'a t -> 'a
+
+  module Make_map_reduce (M : Memo.S) (Outcome : Monoid) : sig
+    (** Traverse sub-directories recursively, pass them to [f] and combine
+        intermediate results into a single one via [M.combine]. *)
+    val map_reduce : 'a t -> f:('a t -> Outcome.t M.t) -> Outcome.t M.t
+  end
+
+  val sub_dir_names : 'a t -> Filename.Set.t
+end
+
+module Make
+    (Reduced_stats : Reduced_stats_intf.S)
+    (_ : Readdir.S with type reduced_stats := Reduced_stats.t) : sig
+  type 'a t
+
+  val create : 'a -> 'a t
+
+  val find_dir : 'a t -> Path.Source.t -> 'a Dir.t option Memo.t
+
+  val root : 'a t -> 'a Dir.t Memo.t
+
+  (** [nearest_dir t fn] returns the directory with the longest path that is an
+      ancestor of [fn]. *)
+  val nearest_dir : 'a t -> Path.Source.t -> 'a Dir.t Memo.t
+
+  (** [true] iff the path is a file *)
+  val file_exists : 'a t -> Path.Source.t -> bool Memo.t
+
+  val files_of : 'a t -> Path.Source.t -> Path.Source.Set.t Memo.t
+
+  val dir_exists : 'a t -> Path.Source.t -> bool Memo.t
+end


### PR DESCRIPTION
Here's a `Dune_source_tree` library that strips `Source_tree` to the bare essentials. There's a bit of functors to make it independent from the engine. I thought that would be a bit more cleaner this way, but it's debatable.

@snowleopard this is the library that you would use internally to reimplement source tree walking. There's one more design decision that I haven't yet made:

Should we add a field for users to attach arbitrary data to `Source_tree.t` nodes making the type `'a Source_tree.t`? That might make it simpler to port existing code. Since it wouldn't require moving data to separate memo tables.