### PR TITLE
refactor(melange): propagate runtime_deps `loc` in Melange_rules

### DIFF
--- a/src/dune_rules/melange/melange_rules.mli
+++ b/src/dune_rules/melange/melange_rules.mli
@@ -19,7 +19,15 @@ val setup_emit_js_rules :
   -> Melange_stanzas.Emit.t
   -> unit Memo.t
 
-val eval_runtime_deps :
-  expander:Expander.t -> Dep_conf.t list -> Path.Set.t Memo.t
+module Runtime_deps : sig
+  type path_specification =
+    | Allow_all
+    | Disallow_external of Lib_name.t
 
-val raise_external_runtime_dep_error : loc:Loc.t -> Lib_name.t -> Path.t -> 'a
+  val eval :
+       loc:Loc.t
+    -> expander:Expander.t
+    -> paths:path_specification
+    -> Dep_conf.t list
+    -> Path.Set.t Memo.t
+end

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -11,7 +11,7 @@ module Emit = struct
     ; libraries : Lib_dep.t list
     ; package : Package.t option
     ; preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
-    ; runtime_deps : Dep_conf.t list
+    ; runtime_deps : Loc.t * Dep_conf.t list
     ; preprocessor_deps : Dep_conf.t list
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t
@@ -72,8 +72,8 @@ module Emit = struct
       module_systems
     in
     fields
-      (let+ loc = loc
-       and+ target =
+      (let* loc = loc in
+       let+ target =
          let of_string ~loc s =
            match String.is_empty s with
            | true ->
@@ -100,7 +100,9 @@ module Emit = struct
          field "libraries" (Lib_dep.L.decode ~allow_re_export:false) ~default:[]
        and+ package = field_o "package" Stanza_common.Pkg.decode
        and+ runtime_deps =
-         field "runtime_deps" (repeat Dep_conf.decode) ~default:[]
+         field "runtime_deps"
+           (located (repeat Dep_conf.decode))
+           ~default:(loc, [])
        and+ preprocess, preprocessor_deps = Stanza_common.preprocess_fields
        and+ promote = field_o "promote" Rule_mode_decoder.Promote.decode
        and+ loc_instrumentation, instrumentation = Stanza_common.instrumentation

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -11,7 +11,7 @@ module Emit : sig
     ; libraries : Lib_dep.t list
     ; package : Package.t option
     ; preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
-    ; runtime_deps : Dep_conf.t list
+    ; runtime_deps : Loc.t * Dep_conf.t list
     ; preprocessor_deps : Dep_conf.t list
     ; promote : Rule.Promote.t option
     ; compile_flags : Ordered_set_lang.Unexpanded.t


### PR DESCRIPTION
- some cleanup after both #7234   #7199 
- we still had a TODO to thread a `loc` for the `(runtime_deps (sandbox ...` error.