### PR TITLE
test(coq): add coq_scrub_args.sh script

### DIFF
--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
@@ -1,9 +1,19 @@
 Testing that the correct flags are being passed to dune coq top
 
 The flags passed to coqc:
-  $ dune build && tail -1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //' | sed 's/-nI .*coq-core/some-coq-core/'
-  coqc -w -notation-overridden -w -deprecated-native-compiler-option -native-output-dir . -native-compiler on some-coq-core/kernel -nI . -R . minimal Test.v)
+  $ dune build && tail -1 _build/log | ../../scrub_coq_args.sh
+  coqc
+  -w -notation-overridden
+  -w -deprecated-native-compiler-option -native-output-dir . -native-compiler on
+  -I coq-core/kernel
+  -nI .
+  -R . minimal Test.v)
 
 The flags passed to coqtop:
-  $ dune coq top --toplevel=echo Test.v | sed 's/-nI .*coq-core/some-coq-core/'
-  -topfile $TESTCASE_ROOT/_build/default/Test.v -w -notation-overridden -w -deprecated-native-compiler-option -native-output-dir . -native-compiler on some-coq-core/kernel -nI $TESTCASE_ROOT/_build/default -R $TESTCASE_ROOT/_build/default minimal
+  $ dune coq top --toplevel=echo Test.v | ../../scrub_coq_args.sh
+  -topfile $TESTCASE_ROOT/_build/default/Test.v
+  -w -notation-overridden
+  -w -deprecated-native-compiler-option -native-output-dir . -native-compiler on
+  -I coq-core/kernel
+  -nI $TESTCASE_ROOT/_build/default
+  -R coqtop-flags.t/_build/default minimal

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-nested.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-nested.t/run.t
@@ -2,7 +2,15 @@ Checking that we compute the directory and file for dune coq top correctly
 
   $ dune build theories/c.vo
   $ dune build theories/b/b.vo
-  $ dune coq top --toplevel=echo theories/c.v
-  -topfile $TESTCASE_ROOT/_build/default/theories/c.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/theories foo
-  $ dune coq top --toplevel=echo theories/b/b.v
-  -topfile $TESTCASE_ROOT/_build/default/theories/b/b.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/theories foo
+  $ dune coq top --toplevel=echo theories/c.v | ../../scrub_coq_args.sh
+  -topfile $TESTCASE_ROOT/_build/default/theories/c.v
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R coqtop-nested.t/_build/default/theories foo
+
+  $ dune coq top --toplevel=echo theories/b/b.v | ../../scrub_coq_args.sh
+  -topfile $TESTCASE_ROOT/_build/default/theories/b/b.v
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R coqtop-nested.t/_build/default/theories foo
+

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
@@ -18,21 +18,33 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
   > (lang dune 3.0)
   > (using coq 0.3)
   > EOF
-  $ dune coq top --display short --toplevel echo dir/bar.v
+  $ dune coq top --display short --toplevel echo dir/bar.v | ../scrub_coq_args.sh
         coqdep dir/.basic.theory.d
           coqc dir/foo.{glob,vo}
-  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic
-  $ dune coq top --display short --toplevel echo dir/bar.v
-  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic
+  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R coqtop/_build/default/dir basic
+  $ dune coq top --display short --toplevel echo dir/bar.v | ../scrub_coq_args.sh
+  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R coqtop/_build/default/dir basic
   $ dune clean
-  $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v)
+  $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v) | ../scrub_coq_args.sh
   Entering directory '..'
         coqdep dir/.basic.theory.d
           coqc dir/foo.{glob,vo}
   Leaving directory '..'
-  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic
-  $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v)
+  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R coqtop/_build/default/dir basic
+  $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v) | ../scrub_coq_args.sh
   Entering directory '..'
   Leaving directory '..'
-  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/dir basic
+  -topfile $TESTCASE_ROOT/_build/default/dir/bar.v
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R coqtop/_build/default/dir basic
 

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-root.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-root.t/run.t
@@ -1,7 +1,10 @@
 All dune commands work when you run them in sub-directories, so this should be no exception.
 
-  $ dune coq top --toplevel=echo -- theories/foo.v
-  -topfile $TESTCASE_ROOT/_build/default/theories/foo.v -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R $TESTCASE_ROOT/_build/default/theories foo
+  $ dune coq top --toplevel=echo -- theories/foo.v | ../../scrub_coq_args.sh
+  -topfile $TESTCASE_ROOT/_build/default/theories/foo.v
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R coqtop-root.t/_build/default/theories foo
   $ cd theories
 
 This test is currently broken due to the workspace resolution being faulty #5899.

--- a/test/blackbox-tests/test-cases/coq/dune
+++ b/test/blackbox-tests/test-cases/coq/dune
@@ -3,7 +3,7 @@
 
 (cram
  (applies_to :whole_subtree)
- (deps %{bin:coqc} %{bin:coqdep})
+ (deps %{bin:coqc} %{bin:coqdep} scrub_coq_args.sh)
  (alias runtest-coq)
  (enabled_if
   (= %{env:DUNE_COQ_TEST=disable} enable)))

--- a/test/blackbox-tests/test-cases/coq/flags.t
+++ b/test/blackbox-tests/test-cases/coq/flags.t
@@ -16,8 +16,11 @@ Test case: default flags
   >  (name foo))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -q
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: :standard
 
@@ -28,8 +31,11 @@ TC: :standard
   > EOF
 
   $ rm _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -q
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: override :standard
 
@@ -39,8 +45,11 @@ TC: override :standard
   >  (flags ))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: add to :standard
 
@@ -50,8 +59,11 @@ TC: add to :standard
   >  (flags :standard -type-in-type))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -q -type-in-type
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: extend in workspace + override standard
 
@@ -66,8 +78,11 @@ TC: extend in workspace + override standard
   > (env (dev (coq (flags -type-in-type))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -type-in-type
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: extend in workspace + override standard
 
@@ -76,8 +91,11 @@ TC: extend in workspace + override standard
   > (env (dev (coq (flags :standard -type-in-type))))
   > EOF
 
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -q -type-in-type
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: extend in dune (env) + override standard
 
@@ -88,8 +106,11 @@ TC: extend in dune (env) + override standard
   > EOF
 
   $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -type-in-type
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: extend in dune (env) + standard
 
@@ -100,8 +121,11 @@ TC: extend in dune (env) + standard
   > EOF
 
   $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -type-in-type -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -q -type-in-type -type-in-type
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)
 
 TC: extend in dune (env) + workspace + standard
 
@@ -117,5 +141,8 @@ TC: extend in dune (env) + workspace + standard
   > EOF
 
   $ rm -rf _build/default/foo.vo
-  $ dune build foo.vo && tail -n 1 _build/log | sed 's/(cd .*coqc/coqc/' | sed 's/$ //'
-  coqc -q -type-in-type -bt -w -deprecated-native-compiler-option -w -native-compiler-disabled -native-compiler ondemand -R . foo foo.v)
+  $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  coqc -q -type-in-type -bt
+  -w -deprecated-native-compiler-option
+  -w -native-compiler-disabled -native-compiler ondemand
+  -R . foo foo.v)

--- a/test/blackbox-tests/test-cases/coq/scrub_coq_args.sh
+++ b/test/blackbox-tests/test-cases/coq/scrub_coq_args.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+sed 's/$ (cd .*coqc/coqc/' $1 | \
+sed 's/$ (cd .*coqdep/coqdep/' $1 | \
+sed 's/$ (cd .*coqdoc/coqdoc/' $1 | \
+sed 's/ -I/\n-I/g' | \
+sed 's/ -nI/\n-nI/g' | \
+sed 's/ -R/\n-R/g' | \
+sed 's/ -w/\n-w/g' | \
+sed 's/-I [^\n]*coq-core/-I coq-core/g' | \
+sed 's/-nI [^\n]*coq-core/-I coq-core/' | \
+sed 's/-I [^\n]*findlib/-I findlib/g' | \
+sed 's/-I [^\n]*zarith/-I zarith/g' | \
+sed 's/-I [^\n].*ocaml/-I ocaml/' | \
+sed 's/-R [^\n]*coq/-R coq/g'
+  


### PR DESCRIPTION
Added a script `coq_scrub_args.sh` which will scrub the output of common command printing. This is useful for checking that the correct flags are being passed and saves us from having to mess around with sed everytime we wish to test something like this.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 8094efc6-2696-432b-9fa4-a55abd3d6946 -->