### PR TITLE
Framework for running multiple monorepo benchmark scenarios

### DIFF
--- a/bench/monorepo/.ocamlformat
+++ b/bench/monorepo/.ocamlformat
@@ -1,0 +1,12 @@
+version=0.24.1
+profile=conventional
+ocaml-version=4.08.0
+break-separators=before
+dock-collection-brackets=false
+doc-comments=before
+let-and=sparse
+type-decl=sparse
+cases-exp-indent=2
+break-cases=fit-or-vertical
+parse-docstrings=true
+module-item-spacing=sparse

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -137,10 +137,10 @@ RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign 
 RUN mkdir -p $HOME/monorepo-bench
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-03-17.1
+ENV MONOREPO_BENCHMARK_TAG=2023-03-21.0
 RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && tar xf ocaml-monorepo-benchmark.tar.gz && mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG ocaml-monorepo-benchmark
 WORKDIR $HOME/monorepo-bench
-RUN mkdir -p monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/dune $HOME/ocaml-monorepo-benchmark/benchmark/monorepo.ml monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam.locked $HOME/ocaml-monorepo-benchmark/benchmark/patches .
+RUN mkdir -p monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/dune $HOME/ocaml-monorepo-benchmark/benchmark/monorepo.ml monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam.locked $HOME/ocaml-monorepo-benchmark/benchmark/patches $HOME/ocaml-monorepo-benchmark/benchmark/bench-patches .
 
 # Running `opam monorepo pull` with a large package set is very likely to fail on at least
 # one package in a non-deterministic manner. Repeating it several times reduces the chance

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -137,7 +137,7 @@ RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign 
 RUN mkdir -p $HOME/monorepo-bench
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-03-16.0
+ENV MONOREPO_BENCHMARK_TAG=2023-03-17.1
 RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && tar xf ocaml-monorepo-benchmark.tar.gz && mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG ocaml-monorepo-benchmark
 WORKDIR $HOME/monorepo-bench
 RUN mkdir -p monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/dune $HOME/ocaml-monorepo-benchmark/benchmark/monorepo.ml monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam.locked $HOME/ocaml-monorepo-benchmark/benchmark/patches .

--- a/bench/monorepo/bench.ml
+++ b/bench/monorepo/bench.ml
@@ -1,49 +1,84 @@
 (* Monorepo benchmark runner *)
 
-(* Run a program on a list of arguments, returning the wallclock duration of
-   the program in seconds. *)
-let time_run_blocking program args =
+(* Run a program on a list of arguments *)
+let run_blocking program args =
   let args_arr = Array.of_list (program :: args) in
-  let timestamp_before = Unix.gettimeofday () in
   let child_pid =
     Unix.create_process program args_arr Unix.stdin Unix.stdout Unix.stderr
   in
   let got_pid, status = Unix.waitpid [] child_pid in
-  let timestamp_after = Unix.gettimeofday () in
   if got_pid <> child_pid then failwith "wait returned unexpected pid";
-  let () =
-    match status with
-    | Unix.WEXITED 0 -> ()
-    | _ ->
-      let command_string = String.concat " " (program :: args) in
-      failwith (Printf.sprintf "`%s` did not exit successfully" command_string)
-  in
+  match status with
+  | Unix.WEXITED 0 -> ()
+  | _ ->
+    let command_string = String.concat " " (program :: args) in
+    failwith (Printf.sprintf "`%s` did not exit successfully" command_string)
+
+(* Run a program on a list of arguments, returning the wallclock duration of
+   the program in seconds. *)
+let time_run_blocking program args =
+  let timestamp_before = Unix.gettimeofday () in
+  let () = run_blocking program args in
+  let timestamp_after = Unix.gettimeofday () in
   timestamp_after -. timestamp_before
 
-let current_bench_json_string ~command ~wallclock_duration_secs =
-  let command_str = String.concat " " command in
-  Printf.sprintf
-    {|{
+module Metric = struct
+  type t = { string : string }
+
+  let benchmark_run_blocking ~name program args =
+    let time_secs = time_run_blocking program args in
+    let string =
+      Printf.sprintf {|{
+  "name": "%s",
+  "value": %f,
+  "units": "seconds"
+}|}
+        name time_secs
+    in
+    { string }
+
+  let as_string { string } = string
+end
+
+module Current_bench_results = struct
+  type t =
+    { name : string
+    ; metrics : Metric.t list
+    }
+
+  let of_metrics ~name metrics = { name; metrics }
+
+  let as_string { name; metrics } =
+    let metrics_string =
+      List.map Metric.as_string metrics |> String.concat ",\n"
+    in
+    Printf.sprintf
+      {|{
   "results": [
     {
-      "name": "running command: %s",
+      "name": "%s",
       "metrics": [
-        {
-            "name": "wallclock duration",
-            "value": %f,
-            "units": "sec"
-        }
+%s
       ]
     }
   ]
 }|}
-    command_str wallclock_duration_secs
+      name metrics_string
+end
+
+let run_benchmarks build_program build_args =
+  let run_build_metric name =
+    Metric.benchmark_run_blocking ~name build_program build_args
+  in
+  let build_from_scratch = run_build_metric "Build from scratch" in
+  let null_build = run_build_metric "Null build" in
+  let metrics = [ build_from_scratch; null_build ] in
+  let name = "Dune Monorepo Benchmark" in
+  Current_bench_results.(of_metrics ~name metrics |> as_string)
 
 let () =
   let argv = Array.to_list Sys.argv in
   let usage () = Printf.sprintf "%s <program> [<arg>, ...]" (List.hd argv) in
   match Array.to_list Sys.argv |> List.tl with
   | [] -> Printf.eprintf "Usage: %s\n" (usage ())
-  | program :: args as command ->
-    let wallclock_duration_secs = time_run_blocking program args in
-    print_endline (current_bench_json_string ~command ~wallclock_duration_secs)
+  | program :: args -> print_endline (run_benchmarks program args)

--- a/bench/monorepo/bench.ml
+++ b/bench/monorepo/bench.ml
@@ -2,6 +2,7 @@
 
 (* Run a program on a list of arguments *)
 let run_blocking program args =
+  Printf.printf "running: %s %s\n" program (String.concat " " args);
   let args_arr = Array.of_list (program :: args) in
   let child_pid =
     Unix.create_process program args_arr Unix.stdin Unix.stdout Unix.stderr
@@ -9,10 +10,10 @@ let run_blocking program args =
   let got_pid, status = Unix.waitpid [] child_pid in
   if got_pid <> child_pid then failwith "wait returned unexpected pid";
   match status with
-  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED _status -> ()
   | _ ->
     let command_string = String.concat " " (program :: args) in
-    failwith (Printf.sprintf "`%s` did not exit successfully" command_string)
+    failwith (Printf.sprintf "`%s` unexpected process status" command_string)
 
 (* Run a program on a list of arguments, returning the wallclock duration of
    the program in seconds. *)
@@ -66,13 +67,67 @@ module Current_bench_results = struct
       name metrics_string
 end
 
+module Patch = struct
+  type t =
+    { input : string
+    ; directory : string
+    }
+
+  let apply_extra_args { input; directory } args =
+    let input_abs = Printf.sprintf "%s/%s" (Unix.getcwd ()) input in
+    run_blocking "patch"
+      ([ "-p1"
+       ; Printf.sprintf "--input=%s" input_abs
+       ; Printf.sprintf "--directory=%s" directory
+       ]
+      @ args)
+
+  let apply t = apply_extra_args t []
+
+  let reverse t = apply_extra_args t [ "--reverse" ]
+end
+
 let run_benchmarks build_program build_args =
+  let patch_core_new_function =
+    { Patch.input = "bench-patches/core/core-new-function.diff"
+    ; directory = "duniverse/core"
+    }
+  in
+  let patch_core_error =
+    { Patch.input = "bench-patches/core/core-error.diff"
+    ; directory = "duniverse/core"
+    }
+  in
   let run_build_metric name =
     Metric.benchmark_run_blocking ~name build_program build_args
   in
   let build_from_scratch = run_build_metric "Build from scratch" in
   let null_build = run_build_metric "Null build" in
-  let metrics = [ build_from_scratch; null_build ] in
+  Patch.apply patch_core_new_function;
+  let build_after_changing_core =
+    run_build_metric "Build after changing core"
+  in
+  Patch.reverse patch_core_new_function;
+  let build_after_undo_changing_core =
+    run_build_metric "Build after undoing changing core"
+  in
+  Patch.apply patch_core_error;
+  let build_after_breaking_core =
+    run_build_metric "Build after adding error to core"
+  in
+  Patch.reverse patch_core_error;
+  let build_after_fixing_core =
+    run_build_metric "Build after fixing error in core"
+  in
+  let metrics =
+    [ build_from_scratch
+    ; null_build
+    ; build_after_changing_core
+    ; build_after_undo_changing_core
+    ; build_after_breaking_core
+    ; build_after_fixing_core
+    ]
+  in
   let name = "Dune Monorepo Benchmark" in
   Current_bench_results.(of_metrics ~name metrics |> as_string)
 


### PR DESCRIPTION
Based on some feedback on the monorepo benchmarks from @snowleopard we're going to add multiple scenarios for benchmarking the monorepo. This changes the benchmark runner script to make it possible to run multiple benchmarks in sequence and demonstrates running an initial build from scratch and a second build after making no changes to the monorepo, printing a current-bench json object with the results.

Putting this up for review in its current state to get early feedback on my approach. The plan is to add additional scenarios that apply patches to change some of the packages in the monorepo and measure the time it takes to rebuild which I'll do in a subsequent PR.