### PR TITLE
melange: allow to define multiple alias-libraries in a single melange.emit 

### DIFF
--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -179,7 +179,13 @@ end = struct
               | Some ctypes -> Ctypes_field.generated_ml_and_c_files ctypes
             in
             Memo.return (select_deps_files @ ctypes_files)
-          | Melange_stanzas.Emit.T { libraries; _ } ->
+          | Melange_stanzas.Emit.T { aliases; _ } ->
+            let libraries =
+              List.concat
+                (List.map
+                   ~f:(fun aliases -> aliases.Melange_stanzas.Emit.libraries)
+                   aliases)
+            in
             let select_deps_files = select_deps_files libraries in
             Memo.return select_deps_files
           | _ -> Memo.return [])

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -92,7 +92,7 @@ let cmj_includes ~(requires_link : Lib.t list Resolve.t) ~scope =
        ; Hidden_deps deps
        ]
 
-let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
+let compile_info ~scope ~libraries (mel : Melange_stanzas.Emit.t) =
   let open Memo.O in
   let dune_version = Scope.project scope |> Dune_project.dune_version in
   let+ pps =
@@ -105,7 +105,7 @@ let compile_info ~scope (mel : Melange_stanzas.Emit.t) =
   let merlin_ident = Merlin_ident.for_melange ~target:mel.target in
   Lib.DB.resolve_user_written_deps (Scope.libs scope) (`Melange_emit mel.target)
     ~allow_overlaps:mel.allow_overlapping_dependencies ~forbidden_libraries:[]
-    mel.libraries ~pps ~dune_version ~merlin_ident
+    libraries ~pps ~dune_version ~merlin_ident
 
 let js_targets_of_modules modules ~module_systems ~output =
   List.map module_systems ~f:(fun (_, js_ext) ->
@@ -233,7 +233,8 @@ let setup_emit_cmj_rules ~sctx ~dir ~scope ~expander ~dir_contents
         in
         Action_builder.paths deps
       in
-      let register_alias { Melange_stanzas.Emit.alias; libs = _TODO_use_this } =
+      let register_alias
+          { Melange_stanzas.Emit.alias; libraries = _TODO_use_this } =
         let alias = Alias.make alias ~dir in
         let* () = Rules.Produce.Alias.add_deps alias emit_deps in
         Rules.Produce.Alias.add_deps alias lib_deps
@@ -339,7 +340,8 @@ let setup_runtime_assets_rules sctx ~dir ~target_dir ~mode
       Action_builder.paths
         (non_copy @ List.rev_map copy ~f:(fun (_, target) -> Path.build target))
     in
-    let register_alias { Melange_stanzas.Emit.alias; libs = _TODO_use_this } =
+    let register_alias
+        { Melange_stanzas.Emit.alias; libraries = _TODO_use_this } =
       let alias = Alias.make alias ~dir:target_dir in
       Rules.Produce.Alias.add_deps alias deps
     in

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -4,7 +4,7 @@ open Import
 module Emit : sig
   type alias_with_libs =
     { alias : Alias.Name.t
-    ; libs : Lib_dep.L.t
+    ; libraries : Lib_dep.L.t
     }
 
   type t =
@@ -13,7 +13,6 @@ module Emit : sig
     ; aliases : alias_with_libs list
     ; module_systems : (Melange.Module_system.t * string) list
     ; modules : Stanza_common.Modules_settings.t
-    ; libraries : Lib_dep.t list
     ; package : Package.t option
     ; preprocess : Preprocess.With_instrumentation.t Preprocess.Per_module.t
     ; runtime_deps : Dep_conf.t list

--- a/src/dune_rules/melange/melange_stanzas.mli
+++ b/src/dune_rules/melange/melange_stanzas.mli
@@ -2,10 +2,15 @@ open Import
 
 (** Stanza to produce JavaScript targets from Melange libraries *)
 module Emit : sig
+  type alias_with_libs =
+    { alias : Alias.Name.t
+    ; libs : Lib_dep.L.t
+    }
+
   type t =
     { loc : Loc.t
     ; target : string
-    ; alias : Alias.Name.t option
+    ; aliases : alias_with_libs list
     ; module_systems : (Melange.Module_system.t * string) list
     ; modules : Stanza_common.Modules_settings.t
     ; libraries : Lib_dep.t list


### PR DESCRIPTION
Eventually should fix #7339.

For now it's wip, as I am realizing the changes required are larger than I expected: the closure of libraries is passed around in multiple places, including the compilation context, which has to be returned by functions like `setup_emit_cmj_rules` when called from `gen_rules`.

I am not sure how to tackle the refactor in a way that we can keep returning a single compilation context, as I understand there would many (one for each `{alias; libraries}` record).

Another thing I'm wondering is if we'll run into issues caused by rules being set multiple times for the same dir / path.

One final question is what to do with current `alias` and `libraries` field. For now the code is removing `libraries` and only allowing aliases defined with `libraries` inside of them.