### PR TITLE
add: Path.as_outside_build_dir

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -950,6 +950,11 @@ let as_in_source_tree_exn t =
       "[as_in_source_tree_exn] called on something not in source tree"
       [ ("t", to_dyn t) ]
 
+let as_outside_build_dir : t -> Outside_build_dir.t option = function
+  | In_source_tree s -> Some (In_source_dir s)
+  | External s -> Some (External s)
+  | In_build_dir _ -> None
+
 let as_outside_build_dir_exn : t -> Outside_build_dir.t = function
   | In_source_tree s -> In_source_dir s
   | External s -> External s

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -228,6 +228,8 @@ type t = private
 
 include Path_intf.S with type t := t
 
+val as_outside_build_dir : t -> Outside_build_dir.t option
+
 val as_outside_build_dir_exn : t -> Outside_build_dir.t
 
 val destruct_build_dir :


### PR DESCRIPTION
We already had Path.as_outside_build_dir_exn so we add the option variant so we can decide what to do with it.

This is used in Coq's installed composition, specifically due to a use of Fs_memo.dir_contents and adding a nice user message if _build/ was somehow passed.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 5a69d470-6010-4b36-8da2-a0b0cb733ede -->