### PR TITLE
melange: don't pass -bs-jsx flag to merlin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ dev-depext:
 
 .PHONY: melange
 melange:
-	opam pin add -n melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#48ff923f2c25136de8ab96678f623f54cdac438c
-	opam pin add -n melange https://github.com/melange-re/melange.git#a8f50420a548f8323f8be3d9f66ce71336e314fc
+	opam pin add -n melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#7263bea2285499f5da857f2bb374345a5178791e
+	opam pin add -n melange https://github.com/melange-re/melange.git#68c6eff82ed056feed809d6cc82558e8697b965b
 
 .PHONY: dev-deps
 dev-deps: melange

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -514,7 +514,7 @@ module Unprocessed = struct
           | Error _ -> []
           | Ok path ->
             [ Processed.Pp_kind.to_flag Ppx
-            ; Processed.serialize_path path ^ " -as-ppx -bs-jsx 3"
+            ; Processed.serialize_path path ^ " -as-ppx"
             ])
       in
       { Processed.stdlib_dir

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -33,9 +33,9 @@
 All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
 
   $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
 
   $ target=output
   $ cat >dune <<EOF
@@ -52,7 +52,7 @@ All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
 The melange.emit entry contains a ppx directive
 
   $ dune ocaml merlin dump-config $PWD | grep -i "ppx"
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
 
 Dump-dot-merlin includes the melange flags
 
@@ -63,7 +63,7 @@ Dump-dot-merlin includes the melange flags
   B /MELC_STDLIB
   B $TESTCASE_ROOT/_build/default/.output.mobjs/melange
   S $TESTCASE_ROOT
-  # FLG -ppx '/MELC_COMPILER -as-ppx -bs-jsx 3'
+  # FLG -ppx '/MELC_COMPILER -as-ppx'
   # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs
   
 
@@ -118,7 +118,7 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
      --as-ppx
      --cookie
      'library-name="foo"'"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40
@@ -139,7 +139,7 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
      --as-ppx
      --cookie
      'library-name="foo"'"))
-   (FLG (-ppx "/MELC_COMPILER -as-ppx -bs-jsx 3"))
+   (FLG (-ppx "/MELC_COMPILER -as-ppx"))
    (FLG
     (-w
      @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40


### PR DESCRIPTION
Melange was updated recently to remove the need to pass `bs-jsx` flag, and instead model that transformation as a proper ppx:
- https://github.com/melange-re/melange/pull/517
- https://github.com/melange-re/melange/pull/525

This PR updates dune so the flag is not passed to merlin.