### PR TITLE
feature: async sandboxing

### DIFF
--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -106,3 +106,13 @@ let background_digests =
   in
   register t;
   t
+
+let background_sandboxes =
+  let t =
+    { name = "background_sandboxes"
+    ; of_string = Toggle.of_string
+    ; value = `Disabled
+    }
+  in
+  register t;
+  t

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -40,4 +40,7 @@ val copy_file : [ `Portable | `Best ] t
 (** Compute digests of files in a background thread *)
 val background_digests : Toggle.t t
 
+(** Build and destroy sandboxes in background threads *)
+val background_sandboxes : Toggle.t t
+
 val init : (Loc.t * string) String.Map.t -> unit

--- a/src/dune_engine/sandbox.mli
+++ b/src/dune_engine/sandbox.mli
@@ -18,7 +18,7 @@ val create :
   -> rule_dir:Path.Build.t
   -> rule_digest:Digest.t
   -> expand_aliases:bool
-  -> t
+  -> t Fiber.t
 
 (** Move all targets created by the action from the sandbox to the build
     directory, skipping the files for which [should_be_skipped] returns [true].
@@ -29,6 +29,6 @@ val move_targets_to_build_dir :
   -> loc:Loc.t
   -> should_be_skipped:(Path.Build.t -> bool)
   -> targets:Targets.Validated.t
-  -> unit Targets.Produced.t
+  -> unit Targets.Produced.t Fiber.t
 
-val destroy : t -> unit
+val destroy : t -> unit Fiber.t


### PR DESCRIPTION
We construct and remove sandboxes in background threads to allow the build engine to proceed while sandboxes are still being prepared.

I still need to do some benchmarking to show this is useful.