### PR TITLE
feature: async digest handling

### DIFF
--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -96,3 +96,13 @@ let copy_file =
   in
   register t;
   t
+
+let background_digests =
+  let t =
+    { name = "background_digests"
+    ; of_string = Toggle.of_string
+    ; value = `Disabled
+    }
+  in
+  register t;
+  t

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -37,4 +37,7 @@ val copy_file : [ `Portable | `Best ] t
     Note that environment variables take precedence over the values passed here
     for easy overriding. *)
 
+(** Compute digests of files in a background thread *)
+val background_digests : Toggle.t t
+
 val init : (Loc.t * string) String.Map.t -> unit

--- a/src/dune_engine/import.ml
+++ b/src/dune_engine/import.ml
@@ -9,6 +9,7 @@ module Persistent = Dune_util.Persistent
 module Execution_env = Dune_util.Execution_env
 module Glob = Dune_glob.V1
 include No_io
+include Dune_config
 
 (* To make bug reports usable *)
 let () = Printexc.record_backtrace true


### PR DESCRIPTION
Move the computation of digests to a background thread. For now, this is guarded behind a configuration option that requires this to be enabled.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: fa4d841b-d0ce-412e-b84b-d2d53c0d7eb6 -->