### PR TITLE
doc: fix jobs field in config

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -764,16 +764,16 @@ where ``<setting>`` is one of:
 - ``copy`` copies entries to the cache. This is less efficient than using hard
   links.
 
-.. _concurrency:
+.. _jobs:
 
-concurrency
------------
+jobs
+----
 
 Maximum number of concurrent jobs Dune is allowed to have.
 
 .. code:: dune
 
-    (concurrency <setting>)
+    (jobs <setting>)
 
 where ``<setting>`` is one of:
 


### PR DESCRIPTION
In https://github.com/ocaml/dune/pull/6392 we introduce the config options into the main doc. There was a typo where the `jobs` stanza was written as `concurrency`. Here we fix that.

@emillon could you get this fix into the stable version of the docs?

I only noticed this after some users were confused about it.