### PR TITLE
Add safe Path.With_check.mkdir_p

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -362,19 +362,13 @@ end) : File_operations = struct
             [ Pp.textf "Please delete non-empty directory %s manually." dir ])
 
   let mkdir_p p =
-    (* CR-someday amokhov: We should really change [Path.mkdir_p dir] to fail if
-       it turns out that [dir] exists and is not a directory. Even better, make
-       [Path.mkdir_p] return an explicit variant to deal with. *)
-    match Fpath.mkdir_p (Path.to_string p) with
-    | Created -> ()
-    | Already_exists -> (
-      match Path.is_directory p with
-      | true -> ()
-      | false ->
-        User_error.raise
-          [ Pp.textf "Please delete file %s manually."
-              (Path.to_string_maybe_quoted p)
-          ])
+    match Path.With_check.mkdir_p p with
+    | Created | Already_exists -> ()
+    | Not_a_directory ->
+      User_error.raise
+        [ Pp.textf "Please delete file %s manually."
+            (Path.to_string_maybe_quoted p)
+        ]
 end
 
 module Sections = struct

--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -3,8 +3,9 @@ let is_root t = Filename.dirname t = t
 let initial_cwd = Stdlib.Sys.getcwd ()
 
 type mkdir_result =
-  | Already_exists
   | Created
+  | Already_exists
+  | Not_a_directory
   | Missing_parent_directory
 
 let mkdir ?(perms = 0o777) t_s =
@@ -14,10 +15,12 @@ let mkdir ?(perms = 0o777) t_s =
   with
   | Unix.Unix_error (EEXIST, _, _) -> Already_exists
   | Unix.Unix_error (ENOENT, _, _) -> Missing_parent_directory
+  | Unix.Unix_error (ENOTDIR, _, _) -> Not_a_directory
 
 type mkdir_p_result =
-  | Already_exists
   | Created
+  | Already_exists
+  | Not_a_directory
 
 let rec mkdir_p ?perms t_s =
   match mkdir ?perms t_s with
@@ -32,17 +35,24 @@ let rec mkdir_p ?perms t_s =
     else
       let parent = Filename.dirname t_s in
       match mkdir_p ?perms parent with
+      | Not_a_directory ->
+        Code_error.raise "failed to create parent directory"
+          [ ("t_s", Dyn.string t_s) ]
       | Created | Already_exists -> (
         (* The [Already_exists] case might happen if some other process managed
            to create the parent directory concurrently. *)
         match mkdir t_s ?perms with
         | Created -> Created
         | Already_exists -> Already_exists
+        | Not_a_directory ->
+          Code_error.raise "failed to create parent directory"
+            [ ("t_s", Dyn.string t_s) ]
         | Missing_parent_directory ->
           (* But we just successfully created the parent directory. So it was
              likely deleted right now. Let's give up *)
           Code_error.raise "failed to create parent directory"
             [ ("t_s", Dyn.string t_s) ]))
+  | Not_a_directory -> Not_a_directory
 
 let resolve_link path =
   match Unix.readlink path with

--- a/otherlibs/stdune/src/fpath.mli
+++ b/otherlibs/stdune/src/fpath.mli
@@ -1,16 +1,18 @@
 (** Functions on paths that are represented as strings *)
 
 type mkdir_result =
-  | Already_exists  (** The directory already exists. No action was taken. *)
   | Created  (** The directory was created. *)
+  | Already_exists  (** The directory already exists. No action was taken. *)
+  | Not_a_directory  (** The path is not a directory. *)
   | Missing_parent_directory
       (** No parent directory, use [mkdir_p] if you want to create it too. *)
 
 val mkdir : ?perms:int -> string -> mkdir_result
 
 type mkdir_p_result =
-  | Already_exists  (** The directory already exists. No action was taken. *)
   | Created  (** The directory was created. *)
+  | Already_exists  (** The directory already exists. No action was taken. *)
+  | Not_a_directory  (** The path is not a directory. *)
 
 val mkdir_p : ?perms:int -> string -> mkdir_p_result
 

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -454,3 +454,7 @@ module Expert : sig
       spitting absolute paths *)
   val try_localize_external : t -> t
 end
+
+module With_check : sig
+  val mkdir_p : ?perms:int -> t -> Fpath.mkdir_p_result
+end

--- a/otherlibs/stdune/src/temp.ml
+++ b/otherlibs/stdune/src/temp.ml
@@ -44,6 +44,7 @@ let create_temp_dir ?perms path =
   match Fpath.mkdir ?perms dir with
   | Created -> Ok ()
   | Already_exists -> Error `Retry
+  | Not_a_directory -> Error `Retry
   | Missing_parent_directory ->
     Code_error.raise "[Temp.create_temp_dir] called in a non-existing directory"
       []

--- a/otherlibs/stdune/test/io_tests.ml
+++ b/otherlibs/stdune/test/io_tests.ml
@@ -82,4 +82,11 @@ let%expect_test "making a directory for an existing file" =
   [%expect {| |}];
   Path.mkdir_p fn;
   (* This in turn does not error *)
-  [%expect {| |}]
+  [%expect {| |}];
+  (* The solution is to use a mkdir with an extra syscall that will check if the
+     path is a file or a directory *)
+  (match (Path.With_check.mkdir_p fn : Fpath.mkdir_p_result) with
+  | Created -> ()
+  | Already_exists -> Printf.printf "already exists"
+  | Not_a_directory -> Printf.printf "not a directory");
+  [%expect {| not a directory |}]

--- a/src/dune_engine/diff_promotion.ml
+++ b/src/dune_engine/diff_promotion.ml
@@ -54,7 +54,14 @@ module File = struct
 
   let register_intermediate ~source_file ~correction_file =
     let staging = in_staging_area source_file in
-    Path.mkdir_p (Path.build (Option.value_exn (Path.Build.parent staging)));
+    let build_path =
+      Path.build (Option.value_exn (Path.Build.parent staging))
+    in
+    (match (Path.With_check.mkdir_p build_path : Fpath.mkdir_p_result) with
+    | Already_exists | Created -> ()
+    | Not_a_directory ->
+      Path.rm_rf build_path;
+      Path.mkdir_p build_path);
     Unix.rename
       (Path.Build.to_string correction_file)
       (Path.Build.to_string staging);

--- a/src/dune_file_watcher/dune_file_watcher.ml
+++ b/src/dune_file_watcher/dune_file_watcher.ml
@@ -353,7 +353,11 @@ let prepare_sync () =
   | Cleared -> ()
   | Directory_does_not_exist -> (
     match Fpath.mkdir_p dir with
-    | Already_exists | Created -> ())
+    | Already_exists | Created -> ()
+    | Not_a_directory ->
+      Code_error.raise
+        "Dune_file_watcher.prepare_sync: path to dir exists and is not a dir" []
+    )
 
 let spawn_external_watcher ~root ~backend ~watch_exclusions =
   prepare_sync ();

--- a/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
+++ b/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
@@ -33,11 +33,9 @@ Run the cram test, should fail and file should be promoted
   File "my_cram.t/run.t", line 1, characters 0-0:
   Error: Files _build/default/my_cram.t/run.t and
   _build/default/my_cram.t/run.t.corrected differ.
-  Error:
-  rename(_build/.sandbox/0245365c460757194b9738dd89cd8dd2/default/my_cram.t/run.t.corrected): Not a directory
-  -> required by alias runtest
   [1]
 
 We cannot promote:
 
   $ dune promote
+  Promoting _build/default/my_cram.t/run.t.corrected to my_cram.t/run.t.

--- a/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
+++ b/test/blackbox-tests/test-cases/promote/promote-file-to-dir.t
@@ -1,0 +1,43 @@
+Demonstrate issue with changing a file for promotion from a file to a directory
+whilst in the staging area. This causes Dune to get confused and stuck.
+
+Create a cram test:
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.8)
+  > EOF
+
+  $ cat > my_cram.t << EOF
+  >   $ echo hello
+  > EOF
+
+Run the cram test, should fail and file should be staged for promotion
+
+  $ dune build @runtest
+  File "my_cram.t", line 1, characters 0-0:
+  Error: Files _build/default/my_cram.t and _build/default/my_cram.t.corrected
+  differ.
+  [1]
+
+Change cram test to a directory cram test
+
+  $ rm my_cram.t
+  $ mkdir my_cram.t
+  $ cat > my_cram.t/run.t << EOF
+  >   $ echo hello
+  > EOF
+
+Run the cram test, should fail and file should be promoted
+
+  $ dune build @runtest
+  File "my_cram.t/run.t", line 1, characters 0-0:
+  Error: Files _build/default/my_cram.t/run.t and
+  _build/default/my_cram.t/run.t.corrected differ.
+  Error:
+  rename(_build/.sandbox/0245365c460757194b9738dd89cd8dd2/default/my_cram.t/run.t.corrected): Not a directory
+  -> required by alias runtest
+  [1]
+
+We cannot promote:
+
+  $ dune promote


### PR DESCRIPTION
We add a `Path.With_check.mkdir_p` which does an extra syscall when the file exists to make sure it is actually a directory.