### PR TITLE
fix: mkdir with trailing slash

### DIFF
--- a/otherlibs/stdune/src/fpath.ml
+++ b/otherlibs/stdune/src/fpath.ml
@@ -9,6 +9,7 @@ type mkdir_result =
 
 let mkdir ?(perms = 0o777) t_s =
   try
+    let t_s = if String.is_suffix t_s ~suffix:"/" then t_s else t_s ^ "/" in
     Unix.mkdir t_s perms;
     Created
   with


### PR DESCRIPTION
to get us the ENOTDIR error code

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d3c56c0e-bd94-4268-905a-e4bbb6abd1d4 -->