### PR TITLE
fix: disable cutoff where it hurts concurrency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Dune in watch mode no longer builds concurrent rules in serial (#7395
+  @rgrinberg, @jchavarri)
+
 - `dune coq top` now correctly respects the project root when called from a
   subdirectory. However, absolute filenames passed to `dune coq top` are no
   longer supported (due to being buggy) (#7357, fixes #7344, @rlepigre and

--- a/src/dune_config/config.ml
+++ b/src/dune_config/config.ml
@@ -72,3 +72,13 @@ let global_lock =
   in
   register t;
   t
+
+let cutoffs_that_reduce_concurrency_in_watch_mode =
+  let t =
+    { name = "cutoffs_that_reduce_concurrency_in_watch_mode"
+    ; of_string = Toggle.of_string
+    ; value = `Disabled
+    }
+  in
+  register t;
+  t

--- a/src/dune_config/config.mli
+++ b/src/dune_config/config.mli
@@ -23,6 +23,10 @@ val get : 'a t -> 'a
 (** should dune acquire the global lock before building *)
 val global_lock : Toggle.t t
 
+(** whether dune should add cutoff to various memoized functions where it
+    reduces concurrency *)
+val cutoffs_that_reduce_concurrency_in_watch_mode : Toggle.t t
+
 (** Before any configuration value is accessed, this function must be called
     with all the configuration values from the relevant config file
     ([dune-workspace], or [dune-config]).

--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -6,6 +6,7 @@
   unix
   csexp
   stdune
+  dune_config
   dune_console
   dyn
   fiber


### PR DESCRIPTION
Make it possible to enable it with the "speculative_cutoff" internal
config option

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: fc9651ba-0bd5-401f-9568-fdddc647611e -->