### PR TITLE
doc: improve synopsis for all commands

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -156,9 +156,7 @@ let runtest_term =
 let runtest = Cmd.v runtest_info runtest_term
 
 let build =
-  let doc =
-    "Build the given targets, or all installable targets if none are given."
-  in
+  let doc = "Build the given targets, or the default ones if none are given." in
   let man =
     [ `S "DESCRIPTION"
     ; `P {|Targets starting with a $(b,@) are interpreted as aliases.|}

--- a/bin/cache.ml
+++ b/bin/cache.ml
@@ -5,7 +5,7 @@ open Import
 
 let trim =
   let info =
-    let doc = "Trim the Dune cache" in
+    let doc = "Trim the Dune cache." in
     let man =
       [ `P "Trim the Dune cache to a specified size or by a specified amount."
       ; `S "EXAMPLES"
@@ -54,7 +54,7 @@ let trim =
 
 let size =
   let info =
-    let doc = "Query the size of the Dune cache" in
+    let doc = "Query the size of the Dune cache." in
     let man =
       [ `P
           "Compute the total size of files in the Dune cache which are not \
@@ -80,7 +80,7 @@ let size =
 
 let command =
   let info =
-    let doc = "Manage the shared cache of build artifacts" in
+    let doc = "Manage Dune's shared cache of build artifacts." in
     let man =
       [ `S "DESCRIPTION"
       ; `P

--- a/bin/coq/coqtop.ml
+++ b/bin/coq/coqtop.ml
@@ -1,7 +1,7 @@
 open Stdune
 open Import
 
-let doc = "Execute the Coq toplevel with the local configuration."
+let doc = "Execute a Coq toplevel with the local configuration."
 
 let man =
   [ `S "DESCRIPTION"

--- a/bin/diagnostics.ml
+++ b/bin/diagnostics.ml
@@ -52,7 +52,7 @@ let exec () =
   | Error e -> Rpc.raise_rpc_error e
 
 let info =
-  let doc = "fetch and return errors from the current build" in
+  let doc = "Fetch and return errors from the current build." in
   Cmd.info "diagnostics" ~doc
 
 let term =

--- a/bin/format_dune_file.ml
+++ b/bin/format_dune_file.ml
@@ -1,7 +1,7 @@
 open Import
 open Stdune
 
-let doc = "Format dune files"
+let doc = "Format dune files."
 
 let man =
   [ `S "DESCRIPTION"

--- a/bin/help.ml
+++ b/bin/help.ml
@@ -87,7 +87,7 @@ type what =
 
 let commands = [ ("config", Man config); ("topics", List_topics) ]
 
-let doc = "Additional Dune help"
+let doc = "Additional Dune help."
 
 let man =
   [ `S "DESCRIPTION"

--- a/bin/init.ml
+++ b/bin/init.ml
@@ -207,7 +207,7 @@ let project =
      print_completion "project" common.name
 
 let group =
-  let doc = "Command group for initializing dune components" in
+  let doc = "Command group for initializing Dune components." in
   let synopsis =
     Common.command_synopsis
       [ "init proj NAME [PATH] [OPTION]... "

--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -434,7 +434,9 @@ let cmd_what = function
   | Uninstall -> "uninstall"
 
 let install_uninstall ~what =
-  let doc = Format.asprintf "%a packages." pp_what what in
+  let doc =
+    Format.asprintf "%a packages defined in the workspace." pp_what what
+  in
   let name_ = Arg.info [] ~docv:"PACKAGE" in
   let absolute_path =
     Arg.conv'

--- a/bin/ocaml/ocaml_cmd.ml
+++ b/bin/ocaml/ocaml_cmd.ml
@@ -1,6 +1,6 @@
 open Import
 
-let info = Cmd.info "ocaml"
+let info = Cmd.info "ocaml" ~doc:"Command group related to OCaml."
 
 let group =
   Cmdliner.Cmd.group info

--- a/bin/ocaml/ocaml_merlin.ml
+++ b/bin/ocaml/ocaml_merlin.ml
@@ -177,7 +177,7 @@ module Dump_config = struct
   let info =
     Cmd.info
       ~doc:
-        "Prints the entire content of the merlin configuration for the given \
+        "Print the entire content of the merlin configuration for the given \
          folder in a user friendly form. This is for testing and debugging \
          purposes only and should not be considered as a stable output."
       "dump-config"
@@ -192,7 +192,7 @@ module Dump_config = struct
   let command = Cmd.v info term
 end
 
-let doc = "Start a merlin configuration server"
+let doc = "Start a merlin configuration server."
 
 let man =
   [ `S "DESCRIPTION"
@@ -252,7 +252,8 @@ module Dump_dot_merlin = struct
 end
 
 let group =
-  Cmdliner.Cmd.group (Cmd.info "merlin")
+  Cmdliner.Cmd.group
+    (Cmd.info "merlin" ~doc:"Command group related to merlin")
     [ Dump_config.command
     ; Cmd.v (start_session_info "start-session") start_session_term
     ]

--- a/bin/ocaml/utop.ml
+++ b/bin/ocaml/utop.ml
@@ -2,7 +2,7 @@ open Stdune
 open Import
 module Utop = Dune_rules.Utop
 
-let doc = "Load library in utop"
+let doc = "Load library in utop."
 
 let man =
   [ `S "DESCRIPTION"

--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -1,13 +1,13 @@
 open Stdune
 open Import
 
-let doc = "Dump internal rules."
+let doc = "Dump rules."
 
 let man =
   [ `S "DESCRIPTION"
   ; `P
-      {|Dump Dune internal rules for the given targets.
-           If no targets are given, dump all the internal rules.|}
+      {|Dump Dune rules for the given targets.
+           If no targets are given, dump all the rules.|}
   ; `P
       {|By default the output is a list of S-expressions,
            one S-expression per rule. Each S-expression is of the form:|}

--- a/bin/shutdown.ml
+++ b/bin/shutdown.ml
@@ -21,7 +21,7 @@ let exec common =
        ~id:(Dune_rpc_private.Id.make (Sexp.Atom "shutdown_cmd")))
 
 let info =
-  let doc = "cancel and shutdown any builds in the current workspace" in
+  let doc = "Cancel and shutdown any builds in the current workspace." in
   Cmd.info "shutdown" ~doc
 
 let term =

--- a/bin/upgrade.ml
+++ b/bin/upgrade.ml
@@ -1,13 +1,13 @@
 open! Stdune
 open Import
 
-let doc = "Upgrade jbuilder projects to dune"
+let doc = "Upgrade projects across major Dune versions."
 
 let man =
   [ `S "DESCRIPTION"
   ; `P
-      {|$(b,dune upgrade) upgrade all the jbuilder projects
-         in the workspace to Dune|}
+      "$(b,dune upgrade) upgrades all the projects in the workspace to the \
+       latest major version of Dune"
   ; `Blocks Common.help_secs
   ]
 

--- a/test/blackbox-tests/test-cases/dune-cache/cache-man.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-man.t
@@ -2,7 +2,7 @@ Here we observe the documentation for the dune cache commands.
 
   $ dune cache --help=plain
   NAME
-         dune-cache - Manage the shared cache of build artifacts
+         dune-cache - Manage Dune's shared cache of build artifacts.
   
   SYNOPSIS
          dune cache COMMAND …
@@ -14,10 +14,10 @@ Here we observe the documentation for the dune cache commands.
   
   COMMANDS
          size [--machine-readable] [OPTION]…
-             Query the size of the Dune cache
+             Query the size of the Dune cache.
   
          trim [--size=BYTES] [--trimmed-size=BYTES] [OPTION]…
-             Trim the Dune cache
+             Trim the Dune cache.
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)
@@ -44,7 +44,7 @@ Testing the output of `dune cache size --machine-readable`
 
   $ dune cache size --help=plain
   NAME
-         dune-cache-size - Query the size of the Dune cache
+         dune-cache-size - Query the size of the Dune cache.
   
   SYNOPSIS
          dune cache size [--machine-readable] [OPTION]…
@@ -82,7 +82,7 @@ Testing the output of dune cache trim.
 
   $ dune cache trim --help=plain
   NAME
-         dune-cache-trim - Trim the Dune cache
+         dune-cache-trim - Trim the Dune cache.
   
   SYNOPSIS
          dune cache trim [--size=BYTES] [--trimmed-size=BYTES] [OPTION]…


### PR DESCRIPTION
There are several improvements in there:

- build: do not mention "installable targets"
- ensure all command groups are documented
- rules: dune rules dumps all rules, not just internal ones
- upgrade: is not specific to jbuilder
- use a fixed style of command docs (Capital, dot)
