### PR TITLE
doc: mention correct exit codes in the manpage

### DIFF
--- a/bin/exit_code.ml
+++ b/bin/exit_code.ml
@@ -1,0 +1,18 @@
+type t =
+  | Success
+  | Error
+  | Signal
+
+let all = [ Success; Error; Signal ]
+
+let code = function
+  | Success -> 0
+  | Error -> 1
+  | Signal -> 130
+
+let doc = function
+  | Success -> "on success."
+  | Error -> "if an error happened."
+  | Signal -> "if it was interrupted by a signal."
+
+let info e = Cmdliner.Cmd.Exit.info (code e) ~doc:(doc e)

--- a/bin/exit_code.mli
+++ b/bin/exit_code.mli
@@ -1,0 +1,10 @@
+type t =
+  | Success
+  | Error
+  | Signal
+
+val all : t list
+
+val info : t -> Cmdliner.Cmd.Exit.info
+
+val code : t -> int

--- a/bin/import.ml
+++ b/bin/import.ml
@@ -38,7 +38,15 @@ include struct
   open Cmdliner
   module Term = Term
   module Manpage = Manpage
-  module Cmd = Cmd
+
+  module Cmd = struct
+    include Cmd
+
+    let default_exits = List.map ~f:Exit_code.info Exit_code.all
+
+    let info ?docs ?doc ?man ?envs ?version name =
+      info ?docs ?doc ?man ?envs ?version ~exits:default_exits name
+  end
 end
 
 module Digest = Dune_digest

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -89,18 +89,18 @@ let cmd = Cmd.group info all
 
 let exit_and_flush code =
   Console.finish ();
-  exit code
+  exit (Exit_code.code code)
 
 let () =
   Dune_rules.Colors.setup_err_formatter_colors ();
   try
     match Cmd.eval_value cmd ~catch:false with
-    | Ok _ -> exit_and_flush 0
-    | Error _ -> exit_and_flush 1
+    | Ok _ -> exit_and_flush Success
+    | Error _ -> exit_and_flush Error
   with
-  | Scheduler.Run.Shutdown.E Requested -> exit_and_flush 0
-  | Scheduler.Run.Shutdown.E (Signal _) -> exit_and_flush 130
+  | Scheduler.Run.Shutdown.E Requested -> exit_and_flush Success
+  | Scheduler.Run.Shutdown.E (Signal _) -> exit_and_flush Signal
   | exn ->
     let exn = Exn_with_backtrace.capture exn in
     Dune_util.Report_error.report exn;
-    exit_and_flush 1
+    exit_and_flush Error

--- a/test/blackbox-tests/test-cases/dune-cache/cache-man.t
+++ b/test/blackbox-tests/test-cases/dune-cache/cache-man.t
@@ -33,11 +33,9 @@ Here we observe the documentation for the dune cache commands.
   
          0   on success.
   
-         123 on indiscriminate errors reported on standard error.
+         1   if an error happened.
   
-         124 on command line parsing errors.
-  
-         125 on unexpected internal errors (bugs).
+         130 if it was interrupted by a signal.
   
   SEE ALSO
          dune(1)
@@ -73,11 +71,9 @@ Testing the output of `dune cache size --machine-readable`
   
          0   on success.
   
-         123 on indiscriminate errors reported on standard error.
+         1   if an error happened.
   
-         124 on command line parsing errors.
-  
-         125 on unexpected internal errors (bugs).
+         130 if it was interrupted by a signal.
   
   SEE ALSO
          dune(1)
@@ -114,11 +110,9 @@ Testing the output of dune cache trim.
   
          0   on success.
   
-         123 on indiscriminate errors reported on standard error.
+         1   if an error happened.
   
-         124 on command line parsing errors.
-  
-         125 on unexpected internal errors (bugs).
+         130 if it was interrupted by a signal.
   
   EXAMPLES
          Trimming the Dune cache to 1 GB.


### PR DESCRIPTION
Fixes #7296

This passes the correct `~exits` docs to cmdliner.
In addition this adds a tiny abstraction layer to exit codes so that we keep this in sync.
