### PR TITLE
Support for Coq "vos" builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Unreleased
 ----------
 
+- Preliminary support for Coq compiled intefaces (`.vos` files) enabled via
+  `(mode vos)` in `coq.theory` stanzas. This can be used in combination with
+  `dune coq top` to obtain fast re-building of dependencies (with no checking
+  of proofs) prior to stepping into a file. (#7406, @rlepigre)
+
 - Fix `dune install` when cross compiling (#7410, fixes #6191, @anmonteiro,
   @rizo)
 

--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -152,6 +152,12 @@ The semantics of the fields are:
   Previous versions of Dune before 3.7 would disable the native rules depending
   on whether or not the ``dev`` profile was selected.
 
+- From version :ref:`Coq lang 0.8<coq-lang>` onwards, ``(mode vos)`` makes it
+  so that only Coq compiled interface files are produced for the theory. This
+  is mainly useful in conjunction with ``dune coq top``, since this makes the
+  compilation of dependencies much faster (thought the proofs they contain are
+  not checked).
+
 Coq Dependencies
 ~~~~~~~~~~~~~~~~
 

--- a/src/dune_rules/coq/coq_mode.ml
+++ b/src/dune_rules/coq/coq_mode.ml
@@ -10,11 +10,13 @@ type t =
   | Legacy
   | VoOnly
   | Native
+  | VosOnly
 
 let decode ~coq_syntax =
   Dune_lang.Decoder.(
     enum'
       [ ("vo", return VoOnly)
+      ; ("vos", return VosOnly)
       ; ( "native"
         , Dune_sexp.Syntax.deprecated_in coq_syntax (0, 7)
             ~extra_info:

--- a/src/dune_rules/coq/coq_mode.mli
+++ b/src/dune_rules/coq/coq_mode.mli
@@ -10,5 +10,6 @@ type t =
   | Legacy
   | VoOnly
   | Native
+  | VosOnly
 
 val decode : coq_syntax:Dune_lang.Syntax.t -> t Dune_lang.Decoder.t

--- a/src/dune_rules/coq/coq_module.ml
+++ b/src/dune_rules/coq/coq_module.ml
@@ -88,11 +88,13 @@ let obj_files x ~wrapper_name ~mode ~obj_dir ~obj_files_mode =
           ( Path.Build.relative vo_dir x
           , Filename.(concat (concat install_vo_dir ".coq-native") x) ))
         cmxs_obj
-    | VoOnly | Legacy -> []
+    | VoOnly | VosOnly | Legacy -> []
   in
   let obj_files =
     match obj_files_mode with
+    | Build when mode = VosOnly -> [ x.name ^ ".vos" ]
     | Build -> [ x.name ^ ".vo"; x.name ^ ".glob" ]
+    | Install when mode = VosOnly -> [ x.name ^ ".vos" ]
     | Install -> [ x.name ^ ".vo" ]
   in
   List.map obj_files ~f:(fun fname ->

--- a/src/dune_rules/coq/coq_rules.mli
+++ b/src/dune_rules/coq/coq_rules.mli
@@ -11,6 +11,7 @@ val deps_of :
      dir:Path.Build.t
   -> use_stdlib:bool
   -> wrapper_name:string
+  -> mode:Coq_mode.t
   -> coq_lang_version:Dune_sexp.Syntax.Version.t
   -> Coq_module.t
   -> unit Dune_engine.Action_builder.t

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -44,6 +44,7 @@ module Dep_rules = Dep_rules
 module Dep_graph = Dep_graph
 module Preprocess = Preprocess
 module Preprocessing = Preprocessing
+module Coq_mode = Coq_mode
 module Coq_rules = Coq_rules
 module Coq_module = Coq_module
 module Coq_sources = Coq_sources

--- a/test/blackbox-tests/test-cases/coq/vos-build.t/bar.v
+++ b/test/blackbox-tests/test-cases/coq/vos-build.t/bar.v
@@ -1,0 +1,3 @@
+From basic Require Import foo.
+
+Definition mynum (i : mynat) := 3.

--- a/test/blackbox-tests/test-cases/coq/vos-build.t/dune
+++ b/test/blackbox-tests/test-cases/coq/vos-build.t/dune
@@ -1,0 +1,10 @@
+(coq.theory
+ (name basic)
+ (package base)
+ (modules :standard)
+ (mode vos)
+ (synopsis "Test Coq library"))
+
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))

--- a/test/blackbox-tests/test-cases/coq/vos-build.t/dune-project
+++ b/test/blackbox-tests/test-cases/coq/vos-build.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.8)
+(using coq 0.8)

--- a/test/blackbox-tests/test-cases/coq/vos-build.t/dune-vo
+++ b/test/blackbox-tests/test-cases/coq/vos-build.t/dune-vo
@@ -1,0 +1,10 @@
+(coq.theory
+ (name basic)
+ (package base)
+ (modules :standard)
+ (mode vo)
+ (synopsis "Test Coq library"))
+
+(rule
+ (alias default)
+ (action (echo "%{read:base.install}")))

--- a/test/blackbox-tests/test-cases/coq/vos-build.t/foo.v
+++ b/test/blackbox-tests/test-cases/coq/vos-build.t/foo.v
@@ -1,0 +1,1 @@
+Definition mynat := nat.

--- a/test/blackbox-tests/test-cases/coq/vos-build.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/vos-build.t/run.t
@@ -1,0 +1,51 @@
+  $ dune build --display short foo.vos
+        coqdep .basic.theory.d
+          coqc foo.vos
+
+  $ dune clean
+  $ dune build --display short bar.vos
+        coqdep .basic.theory.d
+          coqc foo.vos
+          coqc bar.vos
+
+  $ cat foo.v | dune coq top -- foo.v 2>/dev/null | sed '/^Welcome to Coq/d'
+  mynat is defined
+  $ cat bar.v | dune coq top -- bar.v 2>/dev/null | sed '/^Welcome to Coq/d'
+  mynum is defined
+
+  $ dune clean
+  $ dune build --display short --debug-dependency-path @all
+        coqdep .basic.theory.d
+          coqc foo.vos
+          coqc bar.vos
+  $ dune build --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+    "_build/install/default/lib/base/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/basic/bar.v" {"coq/user-contrib/basic/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/bar.vos" {"coq/user-contrib/basic/bar.vos"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.v" {"coq/user-contrib/basic/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.vos" {"coq/user-contrib/basic/foo.vos"}
+  ]
+
+Checking that we can go back to vo mode (without cleaning).
+
+  $ mv dune-vo dune
+  $ dune build --display short --debug-dependency-path @all
+          coqc foo.{glob,vo}
+          coqc bar.{glob,vo}
+  $ dune build --debug-dependency-path @default
+  lib: [
+    "_build/install/default/lib/base/META"
+    "_build/install/default/lib/base/dune-package"
+    "_build/install/default/lib/base/opam"
+  ]
+  lib_root: [
+    "_build/install/default/lib/coq/user-contrib/basic/bar.v" {"coq/user-contrib/basic/bar.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/bar.vo" {"coq/user-contrib/basic/bar.vo"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.v" {"coq/user-contrib/basic/foo.v"}
+    "_build/install/default/lib/coq/user-contrib/basic/foo.vo" {"coq/user-contrib/basic/foo.vo"}
+  ]


### PR DESCRIPTION
This is an alternative to https://github.com/ocaml/dune/pull/4050, implementing @ejgallego's idea from https://github.com/ocaml/dune/pull/4050#issuecomment-1300916807.

The "vos" mode is enabled using `(mode vos)` in `coq.theory` stanzas.

CC @Alizter.