### PR TITLE
doc: make doc warnings fatal

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
     python: "3.10"
 
 sphinx:
+  fail_on_warning: true
   configuration: doc/conf.py
 
 python:


### PR DESCRIPTION
This can be useful for catching doc builds earlier rather than in CI. Most of the time we never build locally anyway. 