### PR TITLE
test: spec of Path.mkdir_p w.r.t existing file / dir

### DIFF
--- a/otherlibs/stdune/test/io_tests.ml
+++ b/otherlibs/stdune/test/io_tests.ml
@@ -72,3 +72,14 @@ let%expect_test "copy file - dst is a directory" =
     in
     print_endline s;
     [%expect {| $DIR: Is a directory |}]
+
+let%expect_test "making a directory for an existing file" =
+  let dir = temp_dir () in
+  let fn = Path.relative dir "foo" in
+  Io.write_file fn "";
+  (* This does not error, but it will if it ends with a "/" on MacOS *)
+  ignore (Fpath.mkdir (Path.to_string fn));
+  [%expect {| |}];
+  Path.mkdir_p fn;
+  (* This in turn does not error *)
+  [%expect {| |}]


### PR DESCRIPTION
We demonstrate that `Path.mkdir_p` silently does nothing when trying to create a directory which exists but is a file. This is an issue that stems from the underlying `Fpath` implementation).