### PR TITLE
x-compilation: take host findlib.conf into account when cross-compiling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Load the host context `findlib.conf` when cross-compiling (#7428, fixes
+  #1701, @rgrinberg, @anmonteiro)
+
 - Resolve `ppx_runtime_libraries` in the target context when cross compiling
   (#7450, fixes #2794, @anmonteiro)
 

--- a/src/dune_rules/findlib/findlib.mli
+++ b/src/dune_rules/findlib/findlib.mli
@@ -51,10 +51,26 @@ module Config : sig
 
   val to_dyn : t -> Dyn.t
 
-  val load :
-    Path.Outside_build_dir.t -> toolchain:string -> context:string -> t Memo.t
+  (** Finds the library search paths for this configuration, prepending
+      [OCAMLPATH] if set *)
+  val path : t -> Path.t list
 
-  val get : t -> string -> string option
+  (** Finds program [prog] for this configuration, if it exists *)
+  val tool : t -> prog:string -> Path.t option Memo.t
 
+  val ocamlpath_sep : char
+
+  (** Read and parse the [OCAMLPATH] environment variable *)
+  val ocamlpath : Env.t -> Path.t list option
+
+  (** Interpret [env] findlib predicates in findlib configuration files. *)
   val env : t -> Env.t
+
+  (** Load the findlib configuration for this [findlib_toolchain], if any. *)
+  val discover_from_env :
+       env:Env.t
+    -> which:(Filename.t -> Path.t option Memo.t)
+    -> ocamlpath:Path.t list
+    -> findlib_toolchain:string option
+    -> t option Memo.t
 end

--- a/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
+++ b/test/blackbox-tests/test-cases/custom-cross-compilation/no-ocamlfind-in-path.t
@@ -1,0 +1,43 @@
+Dune shows an error message when ocamlfind isn't in PATH and OCAMLFIND_CONF
+isn't set
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name repro))
+  > EOF
+  $ cat > dune <<EOF
+  > (executable
+  >  (name gen)
+  >  (modules gen)
+  >  (enabled_if
+  >   (= %{context_name} "default"))
+  >  (libraries libdep))
+  > (rule
+  >  (with-stdout-to
+  >   gen.ml
+  >   (echo "let () = Format.printf \"let x = 1\"")))
+  > (library
+  >  (name repro)
+  >  (public_name repro)
+  >  (modules foo))
+  > EOF
+
+  $ mkdir ocaml-bin
+  $ cat > ocaml-bin/ocamlc <<EOF
+  > #!/usr/bin/env sh
+  > export PATH="\$ORIG_PATH"
+  > exec ocamlc "\$@"
+  > EOF
+  $ chmod +x ocaml-bin/ocamlc
+
+  $ DUNE_PATH=$(dirname `which dune`)
+  $ SH_PATH=$(dirname `which sh`)
+  $ env ORIG_PATH="$PATH" PATH="$SH_PATH:$DUNE_PATH:$PWD/ocaml-bin" dune build @install -x foo
+  Error: Could not find `ocamlfind' in PATH or an environment variable
+  `OCAMLFIND_CONF' while cross-compiling with toolchain `foo'
+  Hint:
+  - `opam install ocamlfind' and/or:
+  - Point `OCAMLFIND_CONF' to the findlib configuration that defines this
+    toolchain
+  [1]
+


### PR DESCRIPTION
- The first 3 commits are a port of https://github.com/ocaml/dune/pull/1707 to the new dune codebase. I couldn't cherry pick the commits because the branch seems gone and git can't find the SHAs anywhere
- the 4th commit fixes the bug after the setup in the first 3, and promotes the newly passing test

fixes https://github.com/ocaml/dune/issues/1701