### PR TITLE
chore(nix): add bare opam shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,16 @@
               pkgs.ocamlPackages.mel
             ];
           };
+          slim-opam = with pkgs; mkShell {
+            nativeBuildInputs = lib.remove pkgs.ocamlformat testNativeBuildInputs;
+            buildInputs = lib.optionals stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.CoreServices
+            ];
+            meta = {
+              description = "provides a shell with just `opam` and minimal \
+              (external) dependencies to run the testsuite.";
+            };
+          };
 
           coq =
             pkgs.mkShell {


### PR DESCRIPTION
This was useful for me to debug an opam failure in https://github.com/ocaml/dune/pull/7428.

It's, however, fairly easy to write it again if I need it, so I'm not sure whether it belongs in flake.nix or not.