### PR TITLE
[Ctypes] fix compilation in byte-only

### DIFF
--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -285,8 +285,11 @@ let exe_link_only ~dir ~shared_cctx ~sandbox program ~deps =
     Command.Args.empty
   in
   let program = program_of_module_and_dir ~dir program in
-  Exe.link_many ~link_args ~programs:[ program ]
-    ~linkages:[ Exe.Linkage.native ] ~promote:None shared_cctx ~sandbox
+  let linkage =
+    Exe.Linkage.native_or_custom (Compilation_context.context shared_cctx)
+  in
+  Exe.link_many ~link_args ~programs:[ program ] ~linkages:[ linkage ]
+    ~promote:None shared_cctx ~sandbox
 
 let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx ~version =
   let ctypes = Option.value_exn buildable.ctypes in


### PR DESCRIPTION
When the native compilation is not present, the compilation of the generators for ctypes fails since it only use native compilation. For example https://ocaml.ci.dev/github/bobot/ocaml-flint/commit/24ee67cb3939b936777d5f9899d558de3773816d/variant/debian-11-5.0_s390x_opam-2.1#L313-313

This fix is better than the current code, but perhaps we should use one of the compilation modes selected for the library.


CC @kit-ty-kate 