### PR TITLE
refactor: move /dev/null related stuff

### DIFF
--- a/otherlibs/stdune/src/dev_null.ml
+++ b/otherlibs/stdune/src/dev_null.ml
@@ -1,0 +1,9 @@
+let dev_null_fn = if Sys.win32 then "nul" else "/dev/null"
+
+let path = Path.of_filename_relative_to_initial_cwd dev_null_fn
+
+let open_null flags = lazy (Unix.openfile dev_null_fn flags 0o666)
+
+let in_ = open_null [ Unix.O_RDONLY; Unix.O_CLOEXEC ]
+
+let out = open_null [ Unix.O_WRONLY; Unix.O_CLOEXEC ]

--- a/otherlibs/stdune/src/dev_null.mli
+++ b/otherlibs/stdune/src/dev_null.mli
@@ -1,0 +1,10 @@
+(** Portable access [/dev/null] with some shared fd's to reduce the open fd
+    count *)
+
+val path : Path.t
+
+(** [path] opened in read mode. Do not close this fd. *)
+val in_ : Unix.file_descr Lazy.t
+
+(** [path] opened in write mode. Do not close this fd. *)
+val out : Unix.file_descr Lazy.t

--- a/otherlibs/stdune/src/stdune.ml
+++ b/otherlibs/stdune/src/stdune.ml
@@ -70,6 +70,7 @@ module Caller_id = Caller_id
 module Dune_filesystem_stubs = Dune_filesystem_stubs
 module Predicate = Predicate
 module Bytes_unit = Bytes_unit
+module Dev_null = Dev_null
 
 module Unix_error = struct
   include Dune_filesystem_stubs.Unix_error

--- a/src/dune_config_file/dune_config_file.ml
+++ b/src/dune_config_file/dune_config_file.ml
@@ -453,10 +453,8 @@ module Dune_config = struct
               let fdr, fdw = Unix.pipe () ~cloexec:true in
               match
                 Spawn.spawn ~prog ~argv:(prog :: args)
-                  ~stdin:(Lazy.force Dune_util.Config.dev_null_in)
-                  ~stdout:fdw
-                  ~stderr:(Lazy.force Dune_util.Config.dev_null_out)
-                  ()
+                  ~stdin:(Lazy.force Dev_null.in_) ~stdout:fdw
+                  ~stderr:(Lazy.force Dev_null.out) ()
               with
               | exception Unix.Unix_error _ ->
                 Unix.close fdw;

--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -242,7 +242,7 @@ let compare_files = function
   | Text -> Io.compare_text_files
 
 let diff_eq_files { Diff.optional; mode; file1; file2 } =
-  let file1 = if Path.Untracked.exists file1 then file1 else Config.dev_null in
+  let file1 = if Path.Untracked.exists file1 then file1 else Dev_null.path in
   let file2 = Path.build file2 in
   (optional && not (Path.Untracked.exists file2))
   || compare_files mode file1 file2 = Eq
@@ -280,7 +280,7 @@ let rec exec t ~display ~ectx ~eenv =
     redirect_out t ~display ~ectx ~eenv outputs ~perm fn
   | Redirect_in (inputs, fn, t) -> redirect_in t ~display ~ectx ~eenv inputs fn
   | Ignore (outputs, t) ->
-    redirect_out t ~display ~ectx ~eenv ~perm:Normal outputs Config.dev_null
+    redirect_out t ~display ~ectx ~eenv ~perm:Normal outputs Dev_null.path
   | Progn ts -> exec_list ts ~display ~ectx ~eenv
   | Concurrent ts ->
     Fiber.parallel_map ts ~f:(exec ~display ~ectx ~eenv)

--- a/src/dune_engine/process.ml
+++ b/src/dune_engine/process.ml
@@ -98,8 +98,8 @@ module Io = struct
   let null (type a) (mode : a mode) : a t =
     let fd =
       match mode with
-      | In -> Config.dev_null_in
-      | Out -> Config.dev_null_out
+      | In -> Dev_null.in_
+      | Out -> Dev_null.out
     in
     let channel = lazy (channel_of_descr (Lazy.force fd) mode) in
     { kind = Null; fd; channel; status = Keep_open }
@@ -168,7 +168,7 @@ let create_metadata ?loc ?(annots = default_metadata.annots) ?name
 let io_to_redirection_path (kind : Io.kind) =
   match kind with
   | Terminal _ -> None
-  | Null -> Some (Path.to_string Config.dev_null)
+  | Null -> Some (Path.to_string Dev_null.path)
   | File fn -> Some (Path.to_string fn)
 
 let command_line_enclosers ~dir ~(stdout_to : Io.output Io.t)

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -333,7 +333,7 @@ let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source
       | Ocaml_version ->
         static (string (Ocaml_config.version_string context.ocaml_config))
       | Ocaml_stdlib_dir -> static (string (Path.to_string context.stdlib_dir))
-      | Dev_null -> static (string (Path.to_string Config.dev_null))
+      | Dev_null -> static (string (Path.to_string Dev_null.path))
       | Ext_obj -> static (string context.lib_config.ext_obj)
       | Ext_asm -> static (string (Ocaml_config.ext_asm context.ocaml_config))
       | Ext_lib -> static (string context.lib_config.ext_lib)

--- a/src/dune_util/config.ml
+++ b/src/dune_util/config.ml
@@ -1,15 +1,5 @@
 open Stdune
 
-let dev_null_fn = if Sys.win32 then "nul" else "/dev/null"
-
-let dev_null = Path.of_filename_relative_to_initial_cwd dev_null_fn
-
-let open_null flags = lazy (Unix.openfile dev_null_fn flags 0o666)
-
-let dev_null_in = open_null [ Unix.O_RDONLY; Unix.O_CLOEXEC ]
-
-let dev_null_out = open_null [ Unix.O_WRONLY; Unix.O_CLOEXEC ]
-
 let inside_emacs = Option.is_some (Env.get Env.initial "INSIDE_EMACS")
 
 let inside_dune = Option.is_some (Env.get Env.initial "INSIDE_DUNE")

--- a/src/dune_util/config.mli
+++ b/src/dune_util/config.mli
@@ -1,13 +1,3 @@
-open Stdune
-
-val dev_null : Path.t
-
-(** [dev_null] opened in read mode *)
-val dev_null_in : Unix.file_descr Lazy.t
-
-(** [dev_null] opened in write mode *)
-val dev_null_out : Unix.file_descr Lazy.t
-
 (** Are we running inside an emacs shell? *)
 val inside_emacs : bool
 

--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -77,7 +77,7 @@ let run_git t args =
   let res =
     Process.run_capture (git_accept ()) ~display:Quiet (prog t) args ~dir:t.root
       ~env:Env.initial
-      ~stderr_to:(Process.Io.file Config.dev_null Out)
+      ~stderr_to:(Process.Io.file Dev_null.path Out)
   in
   let open Fiber.O in
   let+ res = res in

--- a/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
+++ b/test/expect-tests/dune_rpc_e2e/dune_rpc_e2e.ml
@@ -94,8 +94,7 @@ let run ?env ~prog ~argv () =
     let argv = prog :: argv in
     let env = Option.map ~f:Spawn.Env.of_list env in
     Spawn.spawn ~prog ~argv ~stdout:stdout_w ~stderr:stderr_w
-      ~stdin:(Lazy.force Config.dev_null_in)
-      ?env ()
+      ~stdin:(Lazy.force Dev_null.in_) ?env ()
     |> Pid.of_int
   in
   Unix.close stdout_w;

--- a/test/expect-tests/vcs_tests.ml
+++ b/test/expect-tests/vcs_tests.ml
@@ -46,7 +46,7 @@ let run (vcs : Vcs.t) args =
        Env.add Env.initial ~var:"GIT_DIR"
          ~value:(Filename.concat (Path.to_absolute_filename vcs.root) ".git"))
     ~dir:vcs.root
-    ~stdout_to:(Process.Io.file Config.dev_null Process.Io.Out)
+    ~stdout_to:(Process.Io.file Dev_null.path Process.Io.Out)
 
 type action =
   | Init


### PR DESCRIPTION
Now it lives in [Stdune.Dev_null] rather than [Dune_util.Config]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a9eb52e1-375f-48a7-8b59-6cd434eae298 -->