### PR TITLE
Add command to wait until nth watch-mode build completes

### DIFF
--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -10,4 +10,8 @@ let latest_lang_version =
 
 let group =
   Cmd.group (Cmd.info "internal")
-    [ Internal_dump.command; latest_lang_version; Internal_action_runner.group ]
+    [ Internal_dump.command
+    ; latest_lang_version
+    ; Internal_action_runner.group
+    ; Internal_watch_wait.command
+    ]

--- a/bin/internal_watch_wait.ml
+++ b/bin/internal_watch_wait.ml
@@ -1,0 +1,50 @@
+open Import
+module Client = Dune_rpc_client.Client
+
+let doc =
+  "Run alongside `build --watch`, this command will exit after the nth rebuild \
+   has completed"
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P
+      {|Run this while dune is running in watch mode. This command takes an integer argument n and blocks until the nth rebuild has completed since dune was started. |}
+  ; `Blocks Common.help_secs
+  ]
+
+let info = Cmd.info "watch-wait" ~doc ~man
+
+let witness = Dune_rpc_private.Decl.Request.witness
+
+let request_exn client witness n =
+  let open Fiber.O in
+  let* decl = Client.Versioned.prepare_request client witness in
+  match decl with
+  | Error e -> raise (Dune_rpc_private.Version_error.E e)
+  | Ok decl -> Client.request client decl n
+
+let run ~seqno =
+  let open Fiber.O in
+  let where = Rpc.active_server () in
+  let* conn = Client.Connection.connect_exn where in
+  Client.client conn
+    ~private_menu:[ Request Dune_rpc_impl.Decl.watch_mode_event_long_poll ]
+    (Dune_rpc.Initialize.Request.create
+       ~id:(Dune_rpc.Id.make (Csexp.Atom "status")))
+    ~f:(fun client ->
+      let* _response =
+        request_exn client
+          (witness Dune_rpc_impl.Decl.watch_mode_event_long_poll)
+          seqno
+        >>| Result.get_ok
+      in
+      Fiber.return ())
+
+let term =
+  let+ (common : Common.t) = Common.term
+  and+ seqno =
+    Arg.(required & pos 0 (some int) None & Arg.info [] ~docv:"INT")
+  in
+  Rpc.client_term common @@ fun _common -> run ~seqno
+
+let command = Cmd.v info term

--- a/bin/internal_watch_wait.mli
+++ b/bin/internal_watch_wait.mli
@@ -1,0 +1,3 @@
+open Import
+
+val command : unit Cmd.t

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -25,6 +25,17 @@ module Status : sig
   val sexp : (t, Conv.values) Conv.t
 end
 
+module Watch_mode_event_long_poll : sig
+  type event = Build_complete
+
+  type error = Event_no_longer_stored
+
+  type t = (event, error) result
+end
+
 val build : (string list, Build_outcome.t) Decl.Request.t
 
 val status : (unit, Status.t) Decl.Request.t
+
+val watch_mode_event_long_poll :
+  (int, Watch_mode_event_long_poll.t) Decl.Request.t

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -29,3 +29,6 @@ val ready : t -> unit Fiber.t
 val run : t -> unit Fiber.t
 
 val action_runner : t -> Dune_engine.Action_runner.Rpc_server.t
+
+val event_queue :
+  t -> Decl.Watch_mode_event_long_poll.event Dune_util.Event_queue.t

--- a/src/dune_util/dune
+++ b/src/dune_util/dune
@@ -11,6 +11,7 @@
   dune_sexp
   dune_config
   memo
+  fiber
   (re_export unix))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_util/dune_util.ml
+++ b/src/dune_util/dune_util.ml
@@ -8,6 +8,7 @@ module Value = Value
 module Build_path_prefix_map = Build_path_prefix_map0
 module Flock = Flock
 module Global_lock = Global_lock
+module Event_queue = Event_queue
 open Stdune
 
 let xdg =

--- a/src/dune_util/event_queue.ml
+++ b/src/dune_util/event_queue.ml
@@ -1,0 +1,108 @@
+open Stdune
+
+module Map_queue = struct
+  (** A queue storing a maximum number of elements which are automatically
+      dropped as new elements are added. It provides random access via
+      monotonically incrementing integer indices. *)
+  type 'a t =
+    { map : 'a Int.Map.t
+    ; max_size : int
+    }
+
+  let create ~max_size = { map = Int.Map.empty; max_size }
+
+  let next_index { map; _ } =
+    match Int.Map.max_binding map with
+    | None -> 0
+    | Some (max, _) -> max + 1
+
+  let min_stored_index { map; _ } = Option.map ~f:fst (Int.Map.min_binding map)
+
+  let insert t x =
+    let x_index = next_index t in
+    let max_index_to_remove = x_index - t.max_size in
+    let map_below_max_index =
+      Int.Map.filteri t.map ~f:(fun index _ -> index > max_index_to_remove)
+    in
+    let map_with_x = Int.Map.add_exn map_below_max_index x_index x in
+    ({ t with map = map_with_x }, x_index)
+
+  let get t ~index =
+    match Int.Map.find t.map index with
+    | Some x -> `Ok x
+    | None ->
+      if index >= next_index t then `Index_too_high
+      else (
+        assert (Option.value_exn (min_stored_index t) > index);
+        `Index_too_low)
+end
+
+module Event_callbacks = struct
+  (** A queue of events and a collection of callback functions to call on events
+      which haven't yet occurred *)
+  type 'a t =
+    { events : 'a Map_queue.t
+    ; callbacks : ('a -> unit Fiber.t) list Int.Map.t
+    }
+
+  let create ~max_stored_events =
+    { events = Map_queue.create ~max_size:max_stored_events
+    ; callbacks = Int.Map.empty
+    }
+
+  let next_seqno t = Map_queue.next_index t.events
+
+  let add_event t ~event =
+    let open Fiber.O in
+    let events, seqno = Map_queue.insert t.events event in
+    let+ () =
+      match Int.Map.find t.callbacks seqno with
+      | None -> Fiber.return ()
+      | Some callbacks ->
+        List.map callbacks ~f:(fun f -> f event) |> Fiber.all_concurrently_unit
+    in
+    let callbacks = Int.Map.remove t.callbacks seqno in
+    { events; callbacks }
+
+  let add_callback t ~f ~seqno =
+    let callbacks = Int.Map.add_multi t.callbacks seqno f in
+    { t with callbacks }
+
+  let get_event t ~seqno =
+    match Map_queue.get t.events ~index:seqno with
+    | `Ok event -> (t, `Event_stored event)
+    | `Index_too_low -> (t, `Event_no_longer_stored)
+    | `Index_too_high ->
+      let ivar = Fiber.Ivar.create () in
+      let t = add_callback t ~seqno ~f:(Fiber.Ivar.fill ivar) in
+      (t, `Event_not_yet_received (Fiber.Ivar.read ivar))
+
+  let event_fiber t ~seqno =
+    let t, event = get_event t ~seqno in
+    match event with
+    | `Event_no_longer_stored -> (t, Error `Event_no_longer_stored)
+    | `Event_stored event -> (t, Ok (Fiber.return event))
+    | `Event_not_yet_received fiber -> (t, Ok fiber)
+end
+
+module Mutable_event_callbacks = struct
+  (** A convenience wrapper of [Event_callbacks.t] that mutates a ref *)
+  type 'a t = 'a Event_callbacks.t ref
+
+  let create ~max_stored_events =
+    ref (Event_callbacks.create ~max_stored_events)
+
+  let next_seqno t = Event_callbacks.next_seqno !t
+
+  let add_event t ~event =
+    let open Fiber.O in
+    let+ t_new = Event_callbacks.add_event !t ~event in
+    t := t_new
+
+  let event_fiber t ~seqno =
+    let t_new, event = Event_callbacks.event_fiber !t ~seqno in
+    t := t_new;
+    event
+end
+
+include Mutable_event_callbacks

--- a/src/dune_util/event_queue.mli
+++ b/src/dune_util/event_queue.mli
@@ -1,0 +1,28 @@
+(** Stores an association between monotonically increasing integer sequence
+    numbers and events. There is a limit to the number of events that can be
+    stored, and once this limit is reached, adding a new event will cause the
+    oldest event to be removed. *)
+type 'a t
+
+(** Create a new event queue *)
+val create : max_stored_events:int -> 'a t
+
+(** Returns the sequence number that will be assigned to the next event added to
+    the queue *)
+val next_seqno : 'a t -> int
+
+(** Add an event to the queue. This function returns a fiber which becomes
+    determined immediately. Binding/mapping on this fiber is necessary for the
+    fibers returned by [event_fiber] to become determined (its behaviour is
+    similar to that of [Fiber.Ivar.fill]. *)
+val add_event : 'a t -> event:'a -> unit Fiber.t
+
+(** Look up an event by its sequence number. If the event was once stored in the
+    queue but has been dropped due to new events arriving after the maximum size
+    is reached, this function returns [Error `Event_no_longer_stored]. Otherwise
+    it returns a fiber which becomes determined to the event with the requested
+    sequence number. If the event has not been added yet (ie.
+    [seqno >= next_seqno t]) then the returned fiber will become determined when
+    the requested event is added. *)
+val event_fiber :
+  'a t -> seqno:int -> ('a Fiber.t, [ `Event_no_longer_stored ]) result


### PR DESCRIPTION
This is an experiment to make it easier to benchmark dune in watch mode. This adds a command `dune internal watch-wait N` which when run alongside `dune build --watch`, blocks until the Nth (re)build has completed by dune in watch mode (since dune was started - not since `dune internal watch-wait N` was run).

My plan for benchmarking dune in watch mode is to make a benchmark runner program that runs `dune build --watch` in the background, and repeatedly changes files to trigger rebuilds. Dune will write out benchmarking results through the existing `--trace-file` mechanism. The benchmark runner needs a way of waiting until a build is complete before making additional changes to files, otherwise the in-progress build could be interrupted. The `dune internal watch-wait` command is intended to solve this problem.