### PR TITLE
refactor: remove more deps from dune_engine

### DIFF
--- a/src/dune_engine/dune
+++ b/src/dune_engine/dune
@@ -36,10 +36,8 @@
   ocamlc_loc
   dune_file_watcher
   dune_filesystem_stubs
-  ocaml_inotify
   dune_digest
-  dune_metrics
-  async_inotify_for_dune)
+  dune_metrics)
  (synopsis "Internal Dune library, do not use!")
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
[ocaml_inotify], [async_inotify_for_dune] are encapsulated by
[dune_file_watcher]

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9a7e9efd-2184-4558-91d8-67a96850207d -->