### PR TITLE
Fix cinaps (link_flags) support version check

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -23,6 +23,7 @@ let syntax =
     [ ((1, 0), `Since (1, 11))
     ; ((1, 1), `Since (3, 5))
     ; ((1, 2), `Since (3, 7))
+    ; ((1, 3), `Since (3, 8))
     ]
 
 let decode =
@@ -39,7 +40,9 @@ let decode =
          (Dune_lang.Syntax.since syntax (1, 1) >>> repeat Dep_conf.decode)
      and+ cinaps_version = Dune_lang.Syntax.get_exn syntax
      and+ alias = field_o "alias" Alias.Name.decode
-     and+ link_flags = Link_flags.Spec.decode ~since:(Some (3, 8))
+     and+ link_flags =
+       Dune_lang.Syntax.since syntax (1, 3)
+       >>> Link_flags.Spec.decode ~since:None
      (* TODO use this field? *)
      and+ _flags = Ocaml_flags.Spec.decode in
      { loc

--- a/test/blackbox-tests/test-cases/cinaps/link-flags.t
+++ b/test/blackbox-tests/test-cases/cinaps/link-flags.t
@@ -2,7 +2,7 @@ Link-time flags for running cinaps
 
   $ cat > dune-project <<EOF
   > (lang dune 3.8)
-  > (using cinaps 1.1)
+  > (using cinaps 1.3)
   > EOF
 
   $ cat > dune <<EOF
@@ -15,3 +15,40 @@ Link-time flags for running cinaps
 
   $ dune build --verbose @cinaps 2>&1 | sed -n 's#.*/cinaps.exe.*\(-linkall\).*#\1#p'
   -linkall
+
+Check that the version guard is correct.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > (using cinaps 1.3)
+  > EOF
+
+  $ dune build --verbose @cinaps
+  Shared cache: disabled
+  Workspace root:
+  $TESTCASE_ROOT
+  File "dune-project", line 2, characters 14-17:
+  2 | (using cinaps 1.3)
+                    ^^^
+  Error: Version 1.3 of the cinaps extension is not supported until version 3.8
+  of the dune language.
+  Supported versions of this extension in version 3.7 of the dune language:
+  - 1.0 to 1.2
+  [1]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using cinaps 1.2)
+  > EOF
+
+  $ dune build --verbose @cinaps
+  Shared cache: disabled
+  Workspace root:
+  $TESTCASE_ROOT
+  File "dune", line 1, characters 0-45:
+  1 | (cinaps
+  2 |  (files *.ml)
+  3 |  (link_flags -linkall))
+  Error: Field 'cinaps' is only available since version 1.3 of the cinaps
+  extension. Please update your dune-project file to have (using cinaps 1.3).
+  [1]


### PR DESCRIPTION
A mistake in #7423 meant that the new feature was versioned in terms of the version of the Dune language, instead of the version of the `cinaps` extension. This PR fixes that.