### PR TITLE
fix: make lib mode `:standard` match defaults

### DIFF
--- a/test/blackbox-tests/test-cases/melange/library-modes.t
+++ b/test/blackbox-tests/test-cases/melange/library-modes.t
@@ -1,0 +1,66 @@
+Test library modes
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+Build a regular library and an executable
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+
+  $ cat > lib/mylib.ml <<EOF
+  > let some_binding = "string"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (modes byte exe)
+  >  (libraries mylib))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let () =
+  >   print_endline Mylib.some_binding
+  > EOF
+
+  $ dune build main.bc
+
+Now let's make the library compatible with melange
+
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (modes :standard melange))
+  > EOF
+
+  $ cat > main_melange.ml <<EOF
+  > let () =
+  >   print_endline Mylib.some_binding
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name main)
+  >  (modes byte exe)
+  >  (modules main)
+  >  (libraries mylib))
+  > (melange.emit
+  >  (alias dist)
+  >  (modules main_melange)
+  >  (target dist)
+  >  (libraries mylib))
+  > EOF
+
+  $ dune build @dist
+
+  $ dune build main.bc
+  File "_none_", line 1:
+  Error: Module `Mylib' is unavailable (required by `Dune__exe__Main')
+  [1]
+

--- a/test/blackbox-tests/test-cases/melange/library-modes.t
+++ b/test/blackbox-tests/test-cases/melange/library-modes.t
@@ -60,7 +60,4 @@ Now let's make the library compatible with melange
   $ dune build @dist
 
   $ dune build main.bc
-  File "_none_", line 1:
-  Error: Module `Mylib' is unavailable (required by `Dune__exe__Main')
-  [1]
 

--- a/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/run.t
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/run.t
@@ -3,10 +3,10 @@ Test virtual lib in an exe / melange environment
 The native build passes
 
   $ dune exec ./ml.exe --display=short
-      ocamldep impl_ml/.impl_ml.objs/virt.impl.d
       ocamldep vlib/.vlib.objs/shared.impl.d
       ocamldep vlib/.vlib.objs/virt.intf.d
       ocamldep vlib/.vlib.objs/vlib_impl.impl.d
+      ocamldep impl_ml/.impl_ml.objs/virt.impl.d
         ocamlc vlib/.vlib.objs/byte/virt.{cmi,cmti}
         ocamlc vlib/.vlib.objs/byte/vlib_impl.{cmi,cmo,cmt}
       ocamlopt vlib/.vlib.objs/native/vlib_impl.{cmx,o}
@@ -24,8 +24,8 @@ needs to consult the `.cmj` files of dependencies to know where the require
 call should be emitted
 
   $ dune build @mel --display=short 2>&1 | grep -v 'node_modules/melange'
-      ocamldep impl_melange/.impl_melange.objs/virt.impl.d
           melc vlib/.vlib.objs/melange/virt.{cmi,cmti}
+      ocamldep impl_melange/.impl_melange.objs/virt.impl.d
           melc vlib/.vlib.objs/melange/vlib_impl.{cmi,cmj,cmt} (exit 2)
   File "vlib/vlib_impl.ml", line 1:
   Error: Virt not found, it means either the module does not exist or it is a namespace


### PR DESCRIPTION
It seems the `:standard` mode for libraries was not including the "inherited" values for `byte` mode.

This would lead to some errors like the following, when trying to build libraries for an executable with explicit `byte` mode:

```
File "_none_", line 1:
Error: Module `Mylib' is unavailable (required by `Dune__exe__Main')
```

The redundancy of default values makes the code a bit brittle, I added comments to prevent future breakages.