### PR TITLE
Fix EMLINK on Windows (again)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,9 @@ Unreleased
 - Allow `(package ...)` in any position within `(rule ...)` stanza (#7445,
   @Leonidas-from-XIV)
 
+- Handle "Too many links" errors when using Dune cache on Windows.  The fix in
+  3.7.0 for this same issue was not effective due to a typo. (#7472, @nojb)
+
 3.7.0 (2023-02-17)
 ------------------
 

--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -372,7 +372,9 @@ let portable_hardlink ~src ~dst =
          filter out the duplicates first. *)
       Path.unlink dst;
       Path.link src dst
-    | Unix.Unix_error (Unix.EMLINK, _, _) ->
+    | Unix.Unix_error (Unix.EMLINK, _, _)
+    | Unix.Unix_error (Unix.EUNKNOWNERR -1142, _, _)
+    (* Needed for OCaml < 5.1 *) ->
       (* If we can't make a new hard link because we reached the limit on the
          number of hard links per file, we fall back to copying. We expect that
          this happens very rarely (probably only for empty files). *)

--- a/src/dune_cache/local.ml
+++ b/src/dune_cache/local.ml
@@ -61,7 +61,7 @@ let link_even_if_there_are_too_many_links_already ~src ~dst =
   try Path.link src dst
   with
   | Unix.Unix_error (Unix.EMLINK, _, _)
-  | Unix.Unix_error (Unix.EUNKNOWNERR -1442, _, _) (* Needed for OCaml < 5.1 *)
+  | Unix.Unix_error (Unix.EUNKNOWNERR -1142, _, _) (* Needed for OCaml < 5.1 *)
   ->
     Temp.with_temp_file ~dir:temp_dir ~prefix:"dune" ~suffix:"copy" ~f:(function
       | Error e -> raise e


### PR DESCRIPTION
This is a follow-up to #6993. Unfortunately, a typo (1142 -> 1442) meant that the fix there was useless. Also add a similar fix in the other place where `EMLINK` is handled.

For background (this is also explained in #6993), the Windows error code corresponding to `EMLINK` is `ERROR_TOO_MANY_LINKS` (= 1142). The mapping was fixed upstream https://github.com/ocaml/ocaml/pull/11991, but is only available for OCaml >= 5.1, so we need a mitigation in Dune for previous versions.

![image](https://user-images.githubusercontent.com/113560/229464318-e308cede-fcbf-486b-83ed-e81f281fcb71.png)

@emillon this should be backported to 3.7.1.
