### PR TITLE
Add command to wait until the next watch-mode build completes

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -73,6 +73,13 @@ let run_build_system ~common ~request =
       in
       res)
     ~finally:(fun () ->
+      let* () =
+        match Common.rpc common with
+        | `Allow server ->
+          Dune_rpc_impl.Server.Watch_mode_waiters.wake_all
+            (Dune_rpc_impl.Server.watch_mode_waiters server)
+        | `Forbid_builds -> Fiber.return ()
+      in
       Hooks.End_of_build.run ();
       Fiber.return ())
 

--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -10,4 +10,8 @@ let latest_lang_version =
 
 let group =
   Cmd.group (Cmd.info "internal")
-    [ Internal_dump.command; latest_lang_version; Internal_action_runner.group ]
+    [ Internal_dump.command
+    ; latest_lang_version
+    ; Internal_action_runner.group
+    ; Internal_watch_mode_wait.command
+    ]

--- a/bin/internal_watch_mode_wait.ml
+++ b/bin/internal_watch_mode_wait.ml
@@ -1,0 +1,45 @@
+open Import
+module Client = Dune_rpc_client.Client
+
+let doc =
+  "Run alongside `build --watch`, this command will exit after the next \
+   rebuild has completed"
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P
+      {|Run this while dune is running in watch mode. This command blocks until the next rebuild has completed. |}
+  ; `Blocks Common.help_secs
+  ]
+
+let info = Cmd.info "watch-wait" ~doc ~man
+
+let witness = Dune_rpc_private.Decl.Request.witness
+
+let request_exn client witness =
+  let open Fiber.O in
+  let* decl = Client.Versioned.prepare_request client witness in
+  match decl with
+  | Error e -> raise (Dune_rpc_private.Version_error.E e)
+  | Ok decl -> Client.request client decl ()
+
+let run () =
+  let open Fiber.O in
+  let where = Rpc.active_server () in
+  let* conn = Client.Connection.connect_exn where in
+  Client.client conn
+    ~private_menu:[ Request Dune_rpc_impl.Decl.watch_mode_wait ]
+    (Dune_rpc.Initialize.Request.create
+       ~id:(Dune_rpc.Id.make (Csexp.Atom "status")))
+    ~f:(fun client ->
+      let* () =
+        request_exn client (witness Dune_rpc_impl.Decl.watch_mode_wait)
+        >>| Result.get_ok
+      in
+      Fiber.return ())
+
+let term =
+  let+ (common : Common.t) = Common.term in
+  Rpc.client_term common @@ fun _common -> run ()
+
+let command = Cmd.v info term

--- a/bin/internal_watch_mode_wait.mli
+++ b/bin/internal_watch_mode_wait.mli
@@ -1,0 +1,3 @@
+open Import
+
+val command : unit Cmd.t

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -53,6 +53,15 @@ module Build = struct
   let decl = Decl.Request.make ~method_:"build" ~generations:[ v1 ]
 end
 
+module Watch_mode_wait = struct
+  let v1 =
+    Decl.Request.make_current_gen ~req:Conv.unit ~resp:Conv.unit ~version:1
+
+  let decl = Decl.Request.make ~method_:"watch_mode_wait" ~generations:[ v1 ]
+end
+
 let build = Build.decl
 
 let status = Status.decl
+
+let watch_mode_wait = Watch_mode_wait.decl

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -28,3 +28,5 @@ end
 val build : (string list, Build_outcome.t) Decl.Request.t
 
 val status : (unit, Status.t) Decl.Request.t
+
+val watch_mode_wait : (unit, unit) Decl.Request.t

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -1,5 +1,11 @@
 open Import
 
+module Watch_mode_waiters : sig
+  type t
+
+  val wake_all : t -> unit Fiber.t
+end
+
 type t
 
 val create :
@@ -29,3 +35,5 @@ val ready : t -> unit Fiber.t
 val run : t -> unit Fiber.t
 
 val action_runner : t -> Dune_engine.Action_runner.Rpc_server.t
+
+val watch_mode_waiters : t -> Watch_mode_waiters.t


### PR DESCRIPTION
This is a refinement of https://github.com/ocaml/dune/pull/7443. It adds an RPC command "watch_mode_wait" which only returns the next time a build completes when dune is running in watch mode. For the moment this RPC is internal and not part of the publicly-visible RPC interface. There is an accompanying command `dune internal watch-wait` which returns when the current watch-mode build completes by using the new RPC method.