### PR TITLE
Only enable `package` in short-form rules on dune lang 3.8+

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1740,15 +1740,15 @@ module Rule = struct
           ~hints:
             (User_message.did_you_mean s
                ~candidates:(String.Map.keys atom_table))
-      | Some Field -> (
-        match s with
-        | "package" ->
-          let* () =
+      | Some Field ->
+        let* () =
+          match s with
+          | "package" ->
             Dune_lang.Syntax.since ~what:"'package' in short-form 'rule'"
               Stanza.syntax (3, 8)
-          in
-          fields long_form
-        | _ -> fields long_form)
+          | _ -> return ()
+        in
+        fields long_form
       | Some Action -> short_form)
     | sexp ->
       User_error.raise ~loc:(Dune_lang.Ast.loc sexp)

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1740,7 +1740,15 @@ module Rule = struct
           ~hints:
             (User_message.did_you_mean s
                ~candidates:(String.Map.keys atom_table))
-      | Some Field -> fields long_form
+      | Some Field -> (
+        match s with
+        | "package" ->
+          let* () =
+            Dune_lang.Syntax.since ~what:"'package' in short-form 'rule'"
+              Stanza.syntax (3, 8)
+          in
+          fields long_form
+        | _ -> fields long_form)
       | Some Action -> short_form)
     | sexp ->
       User_error.raise ~loc:(Dune_lang.Ast.loc sexp)

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -1588,6 +1588,7 @@ module Rule = struct
   type action_or_field =
     | Action
     | Field
+    | Since of Syntax.Version.t * action_or_field
 
   let atom_table =
     String.Map.of_list_exn
@@ -1622,7 +1623,7 @@ module Rule = struct
       ; ("aliases", Field)
       ; ("alias", Field)
       ; ("enabled_if", Field)
-      ; ("package", Field)
+      ; ("package", Since ((3, 8), Field))
       ]
 
   let short_form =
@@ -1731,6 +1732,14 @@ module Rule = struct
        })
 
   let decode =
+    let rec interpret atom = function
+      | Field -> fields long_form
+      | Action -> short_form
+      | Since (version, inner) ->
+        let what = Printf.sprintf "'%s' in short-form 'rule'" atom in
+        let* () = Dune_lang.Syntax.since ~what Stanza.syntax version in
+        interpret atom inner
+    in
     peek_exn >>= function
     | List (_, Atom (loc, A s) :: _) -> (
       match String.Map.find atom_table s with
@@ -1740,16 +1749,7 @@ module Rule = struct
           ~hints:
             (User_message.did_you_mean s
                ~candidates:(String.Map.keys atom_table))
-      | Some Field ->
-        let* () =
-          match s with
-          | "package" ->
-            Dune_lang.Syntax.since ~what:"'package' in short-form 'rule'"
-              Stanza.syntax (3, 8)
-          | _ -> return ()
-        in
-        fields long_form
-      | Some Action -> short_form)
+      | Some w -> interpret s w)
     | sexp ->
       User_error.raise ~loc:(Dune_lang.Ast.loc sexp)
         [ Pp.textf "S-expression of the form (<atom> ...) expected" ]

--- a/test/blackbox-tests/test-cases/package-rule.t/run.t
+++ b/test/blackbox-tests/test-cases/package-rule.t/run.t
@@ -1,5 +1,21 @@
-When --only-packages is passed, it runs
+When --only-packages is passed, it runs, as long as the version is new enough
 
+  $ dune build --only-packages a @runtest
+  File "dune", line 10, characters 0-61:
+  10 | (rule
+  11 |   (package a)
+  12 |   (action (copy test_temp.ml test_b.ml)))
+  Error: 'package' in short-form 'rule' is only available since version 3.8 of
+  the dune language. Please update your dune-project file to have (lang dune
+  3.8).
+  [1]
+
+The version is too old, bump it to 3.8 where this was fixed:
+
+  $ cat > dune-project-3.8 <<EOF
+  > (lang dune 3.8)
+  > EOF
+  $ mv dune-project-3.8 dune-project
   $ dune build --only-packages a @runtest
   A
   A


### PR DESCRIPTION
Closes #7471, as discussed in #7461 to only allow the #7445 feature on dune-lang 3.8.

This fixes the issue that #7445 by itself fixes a language quirk that is only fixed in 3.8, but without actually requiring dune-lang 3.8. It revises the previous test that uses an older dune-lang to fail.