### PR TITLE
feature: allow opam files in opam/

### DIFF
--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -201,6 +201,8 @@ val encode : t -> Dune_lang.t list
 
 val dune_site_extension : unit Extension.t
 
+val opam_file_location : t -> [ `Relative_to_project | `Inside_opam_directory ]
+
 module Melange_syntax : sig
   val name : string
 end

--- a/src/dune_rules/opam_create.mli
+++ b/src/dune_rules/opam_create.mli
@@ -11,3 +11,5 @@ val generate :
   Dune_project.t -> Package.t -> template:(Path.t * string) option -> string
 
 val add_rules : Super_context.t -> Dune_project.t -> unit Memo.t
+
+val add_opam_file_rules : Super_context.t -> Dune_project.t -> unit Memo.t

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -140,6 +140,10 @@ module Info : sig
   val superpose : t -> t -> t
 end
 
+type opam_file =
+  | Exists of bool
+  | Look_inside_opam_dir
+
 type t =
   { id : Id.t
   ; loc : Loc.t
@@ -150,7 +154,7 @@ type t =
   ; depopts : Dependency.t list
   ; info : Info.t
   ; version : string option
-  ; has_opam_file : bool
+  ; has_opam_file : opam_file
   ; tags : string list
   ; deprecated_package_names : Loc.t Name.Map.t
   ; sites : Section.t Section.Site.Map.t
@@ -162,6 +166,8 @@ val equal : t -> t -> bool
 val name : t -> Name.t
 
 val dir : t -> Path.Source.t
+
+val set_inside_opam_dir : t -> dir:Path.Source.t -> t
 
 val file : dir:Path.t -> name:Name.t -> Path.t
 

--- a/test/blackbox-tests/test-cases/opam-directory/generate-opam-file.t
+++ b/test/blackbox-tests/test-cases/opam-directory/generate-opam-file.t
@@ -1,0 +1,31 @@
+Generate opam files in the opam/ sub directory
+
+First the case when opam/ doesn't exist in the source
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (generate_opam_files true)
+  > (opam_file_location inside_opam_directory)
+  > (package
+  >  (name foobar))
+  > EOF
+
+  $ dune build @check
+  $ ls opam/foobar.opam
+  opam/foobar.opam
+
+Now we test the case whenever opam is a sourec directory
+
+  $ rm opam/foobar.opam
+  $ dune build @check
+  $ ls opam/foobar.opam
+  opam/foobar.opam
+
+We forbid .opam files in the root directory:
+
+  $ touch bar.opam
+  $ dune build @check
+  Error: When (opam_file_location inside_opam_directory) is set, all opam files
+  must live in the opam/ subdirecotry. The following opam files must be moved:
+  - bar.opam
+  [1]


### PR DESCRIPTION
When we set (opam_file_location inside_opam_directory), we are allowed
to put all the opam file in the opam/ directory relative to the project.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 08a5a1ae-9c85-4081-80bb-ff9b79aacb70 -->