### PR TITLE
tui: add more interactions

### DIFF
--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -12,6 +12,6 @@
   (re_export dune_filesystem_stubs))
  (foreign_stubs
   (language c)
-  (names wait3_stubs platform_stubs copyfile_stubs))
+  (names wait3_stubs platform_stubs copyfile_stubs signal_stubs))
  (instrumentation
   (backend bisect_ppx)))

--- a/otherlibs/stdune/src/float.ml
+++ b/otherlibs/stdune/src/float.ml
@@ -10,3 +10,8 @@ let max x y =
   match compare x y with
   | Eq | Gt -> x
   | Lt -> y
+
+let min x y =
+  match compare x y with
+  | Eq | Lt -> x
+  | Gt -> y

--- a/otherlibs/stdune/src/float.mli
+++ b/otherlibs/stdune/src/float.mli
@@ -7,3 +7,5 @@ val to_string : t -> string
 val compare : t -> t -> Ordering.t
 
 val max : t -> t -> t
+
+val min : t -> t -> t

--- a/otherlibs/stdune/src/int.ml
+++ b/otherlibs/stdune/src/int.ml
@@ -29,3 +29,7 @@ let of_string s = int_of_string_opt s
 let shift_left = Stdlib.Int.shift_left
 
 let shift_right = Stdlib.Int.shift_right
+
+let max = Stdlib.max
+
+let min = Stdlib.min

--- a/otherlibs/stdune/src/int.mli
+++ b/otherlibs/stdune/src/int.mli
@@ -21,3 +21,7 @@ module Infix : Comparator.OPS with type t = t
 val shift_left : t -> t -> t
 
 val shift_right : t -> t -> t
+
+val max : t -> t -> t
+
+val min : t -> t -> t

--- a/otherlibs/stdune/src/signal.ml
+++ b/otherlibs/stdune/src/signal.ml
@@ -27,7 +27,10 @@ type t =
   | Urg
   | Xcpu
   | Xfsz
+  | Winch
   | Unknown of int
+
+external sigwinch : unit -> int = "stdune_winch_number" [@@noalloc]
 
 let all =
   let open Sys in
@@ -59,6 +62,7 @@ let all =
   ; (Urg, sigurg)
   ; (Xcpu, sigxcpu)
   ; (Xfsz, sigxfsz)
+  ; (Winch, sigwinch ())
   ]
 
 let name = function
@@ -90,6 +94,7 @@ let name = function
   | Urg -> "URG"
   | Xcpu -> "XCPU"
   | Xfsz -> "XFSZ"
+  | Winch -> "WINCH"
   | Unknown n -> Int.to_string n
 
 let compare (x : t) (y : t) = Poly.compare x y

--- a/otherlibs/stdune/src/signal.mli
+++ b/otherlibs/stdune/src/signal.mli
@@ -29,6 +29,7 @@ type t =
   | Urg
   | Xcpu
   | Xfsz
+  | Winch
   | Unknown of int
 
 (** Get the signal's name, e.g. [Int] maps to "INT", [Term] to "TERM", etc. *)

--- a/otherlibs/stdune/src/signal_stubs.c
+++ b/otherlibs/stdune/src/signal_stubs.c
@@ -1,0 +1,17 @@
+#include <caml/mlvalues.h>
+
+#ifdef _WIN32
+#include <caml/fail.h>
+#else
+#include <signal.h>
+#include <sys/ioctl.h>
+#endif
+
+CAMLprim value stdune_winch_number(value vunit) {
+  (void)vunit;
+#ifdef _WIN32
+  return Val_int(0);
+#else
+  return Val_int(SIGWINCH);
+#endif
+}

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -57,7 +57,9 @@ module Shutdown = struct
       | _ -> None)
 end
 
-let blocked_signals : Signal.t list = [ Int; Quit; Term ]
+let interrupt_signals : Signal.t list = [ Int; Quit; Term ]
+
+let blocked_signals : Signal.t list = Winch :: interrupt_signals
 
 module Thread : sig
   val spawn : signal_watcher:[ `Yes | `No ] -> (unit -> unit) -> unit
@@ -583,7 +585,7 @@ end
 module Signal_watcher : sig
   val init : Event.Queue.t -> unit
 end = struct
-  let signos = List.map blocked_signals ~f:Signal.to_int
+  let signos = List.map interrupt_signals ~f:Signal.to_int
 
   let warning =
     {|

--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -61,6 +61,7 @@ let make (module Base : S) : (module Dune_console.Backend) =
     let start () =
       Base.start ();
       Dune_engine.Scheduler.spawn_thread @@ fun () ->
+      ignore (Unix.sigprocmask SIG_UNBLOCK [ Signal.to_int Winch ] : int list);
       let last = ref (Unix.gettimeofday ()) in
       let frame_rate = 1. /. 60. in
       let cleanup () =
@@ -102,10 +103,10 @@ let make (module Base : S) : (module Dune_console.Backend) =
           let elapsed = now -. !last in
           let new_time =
             if elapsed >= frame_rate then
-              Base.handle_user_events ~now ~time_budget:0.0 mutex
+              Base.handle_user_events ~now ~time_budget:0.0 mutex state
             else
               let delta = frame_rate -. elapsed in
-              Base.handle_user_events ~now ~time_budget:delta mutex
+              Base.handle_user_events ~now ~time_budget:delta mutex state
           in
           last := new_time
         done
@@ -135,7 +136,7 @@ let progress () =
       (* The current console doesn't react to user events so we just sleep until
           the next loop iteration. Because it doesn't react to user input, it cannot
           modify the UI state, and as a consequence doesn't need the mutex. *)
-      let handle_user_events ~now ~time_budget _ =
+      let handle_user_events ~now ~time_budget _mutex _state =
         Unix.sleepf time_budget;
         now +. time_budget
     end)

--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -103,10 +103,10 @@ let make (module Base : S) : (module Dune_console.Backend) =
           let elapsed = now -. !last in
           let new_time =
             if elapsed >= frame_rate then
-              Base.handle_user_events ~now ~time_budget:0.0 mutex state
+              Base.handle_user_events ~now ~time_budget:0.0 ~mutex state
             else
               let delta = frame_rate -. elapsed in
-              Base.handle_user_events ~now ~time_budget:delta mutex state
+              Base.handle_user_events ~now ~time_budget:delta ~mutex state
           in
           last := new_time
         done
@@ -136,7 +136,7 @@ let progress () =
       (* The current console doesn't react to user events so we just sleep until
           the next loop iteration. Because it doesn't react to user input, it cannot
           modify the UI state, and as a consequence doesn't need the mutex. *)
-      let handle_user_events ~now ~time_budget _mutex _state =
+      let handle_user_events ~now ~time_budget ~mutex:_ _ =
         Unix.sleepf time_budget;
         now +. time_budget
     end)

--- a/src/dune_threaded_console/dune_threaded_console_intf.ml
+++ b/src/dune_threaded_console/dune_threaded_console_intf.ml
@@ -39,7 +39,8 @@ module type S = sig
       underestimation of the actual amount of time spent, we will render faster
       than the desired frame rate. If it is an overestimation, we will render
       slower. *)
-  val handle_user_events : now:float -> time_budget:float -> Mutex.t -> float
+  val handle_user_events :
+    now:float -> time_budget:float -> Mutex.t -> state -> float
 
   (** [reset] is called by the main thread to reset the user interface. *)
   val reset : unit -> unit

--- a/src/dune_threaded_console/dune_threaded_console_intf.ml
+++ b/src/dune_threaded_console/dune_threaded_console_intf.ml
@@ -27,12 +27,13 @@ module type S = sig
       the user interface. *)
   val render : state -> unit
 
-  (** [handle_user_events ~now ~time_budget mutex] is called by the main thread
-      to handle user events such as keypresses. The function should return the
-      time at which the next event should be handled. A [mutex] is provided in
-      order to lock the state of the UI. [time_budget] indicates an approximate
-      amount of time that should be spent in this function. This is useful for
-      things like waiting for user input.
+  (** [handle_user_events ~now ~time_budget ~mutex state] is called by the main
+      thread to handle user events such as keypresses. The function should
+      return the time at which the next event should be handled. A [mutex] is
+      provided in order to lock the state of the UI. [time_budget] indicates an
+      approximate amount of time that should be spent in this function. This is
+      useful for things like waiting for user input. The current [state] is also
+      provided so that any user events affect the staate can do so.
 
       [time_budget] should be as accurate as possible, but if it's not, the only
       consequence would be modifying the rendering rate. If [time_budget] is an
@@ -40,7 +41,7 @@ module type S = sig
       than the desired frame rate. If it is an overestimation, we will render
       slower. *)
   val handle_user_events :
-    now:float -> time_budget:float -> Mutex.t -> state -> float
+    now:float -> time_budget:float -> mutex:Mutex.t -> state -> float
 
   (** [reset] is called by the main thread to reset the user interface. *)
   val reset : unit -> unit

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -100,41 +100,86 @@ let attr_of_user_message_style fmt t (pp : User_message.Style.t Pp.t) : unit =
   in
   Notty.I.pp_attr attr Pp.to_fmt fmt pp
 
-let image_of_user_message_style_pp =
-  Notty.I.strf "%a@."
+let image_of_user_message_style_pp ?attr =
+  Notty.I.strf ?attr "%a@."
     (Pp.to_fmt_with_tags ~tag_handler:attr_of_user_message_style)
 
 module Tui () = struct
   module Term = Notty_unix.Term
+  module A = Notty.A
+  module I = Notty.I
 
   let term = Term.create ~nosig:false ()
 
   let start () = Unix.set_nonblock Unix.stdin
 
-  let user_feedback = ref None
+  type ui_state =
+    { mutable user_feedback : User_message.Style.t Pp.t option
+    ; mutable debug : bool
+    ; mutable reset_count : int
+    ; mutable help_screen : bool
+    ; mutable hscroll_pos : float
+    ; mutable vscroll_pos : float
+    ; mutable hscroll_speed : float
+    ; mutable vscroll_speed : float
+    ; mutable hscroll_grabbed : bool
+    ; mutable vscroll_grabbed : bool
+    }
 
-  let reset_count = ref 0
+  let ui_state =
+    { user_feedback = None
+    ; debug = false
+    ; reset_count = 0
+    ; help_screen = false
+    ; hscroll_pos = 0.
+    ; vscroll_pos = 0.
+    ; hscroll_speed = 0.1
+    ; vscroll_speed = 0.1
+    ; hscroll_grabbed = false
+    ; vscroll_grabbed = false
+    }
 
-  let horizontal_line_with_count total index =
-    let module A = Notty.A in
-    let module I = Notty.I in
-    let twidth, _ = Term.size term in
+  let debug_image () =
+    I.vcat
+      [ ui_state.reset_count |> string_of_int
+        |> (fun x -> "Reset count: " ^ x)
+        |> I.string A.(fg red)
+      ; ui_state.help_screen |> string_of_bool
+        |> (fun x -> "Help screen: " ^ x)
+        |> I.string A.(fg red)
+      ; ui_state.hscroll_pos |> string_of_float
+        |> (fun x -> "Hscroll pos: " ^ x)
+        |> I.string A.(fg red)
+      ; ui_state.vscroll_pos |> string_of_float
+        |> (fun x -> "Vscroll pos: " ^ x)
+        |> I.string A.(fg red)
+      ; ui_state.hscroll_speed |> string_of_float
+        |> (fun x -> "Hscroll speed: " ^ x)
+        |> I.string A.(fg red)
+      ; ui_state.vscroll_speed |> string_of_float
+        |> (fun x -> "Vscroll speed: " ^ x)
+        |> I.string A.(fg red)
+      ; ui_state.user_feedback
+        |> Option.value ~default:(Pp.text "None")
+        |> image_of_user_message_style_pp ~attr:A.(fg red)
+      ]
+
+  let horizontal_line_with_count ~w total index =
     let status =
-      let left = I.uchar A.(fg red) (Uchar.of_int 0x169c) 1 1 in
-      let index = I.string A.(fg blue) (string_of_int (index + 1)) in
-      let mid = I.string A.(fg red) "/" in
-      let total = I.string A.(fg blue) (string_of_int total) in
-      let right = I.uchar A.(fg red) (Uchar.of_int 0x169B) 1 1 in
-      I.(left <|> index <|> mid <|> total <|> right)
+      I.hcat
+        [ I.uchar A.(fg red) (Uchar.of_int 0x169c) 1 1
+        ; I.string A.(fg blue) (string_of_int (index + 1))
+        ; I.string A.(fg red) "/"
+        ; I.string A.(fg blue) (string_of_int total)
+        ; I.uchar A.(fg red) (Uchar.of_int 0x169B) 1 1
+        ]
     in
     I.(
-      hsnap ~align:`Left twidth status
-      </> uchar A.(fg red) (Uchar.of_int 0x2015) twidth 1)
+      hsnap ~align:`Left w status </> uchar A.(fg red) (Uchar.of_int 0x2015) w 1)
 
   let line_separated_message ~total index msg =
-    Notty.I.(
-      image_of_user_message_style_pp (User_message.pp msg)
-      <-> horizontal_line_with_count total index)
+    let img = image_of_user_message_style_pp (User_message.pp msg) in
+    I.vcat [ img; horizontal_line_with_count ~w:(I.width img) total index ]
 
   let image ~status_line ~messages =
     let status =
@@ -146,27 +191,153 @@ module Tui () = struct
       List.mapi messages
         ~f:(line_separated_message ~total:(List.length messages))
     in
-    let reset_count =
-      image_of_user_message_style_pp
-      @@ Pp.tag User_message.Style.Debug
-      @@ Pp.hbox
-      @@ Pp.textf "Reset count %d" !reset_count
+    let debug_image =
+      if ui_state.debug then [ I.empty; debug_image () ] else []
     in
-    Notty.I.vcat
-      (messages @ status
-      @ List.map ~f:image_of_user_message_style_pp
-          (Option.to_list !user_feedback)
-      @ [ reset_count ])
+    Notty.I.vcat (messages @ status @ debug_image)
+
+  let border_box image =
+    let w, h = I.(width image, height image) in
+    let border_element ?(attr = A.(fg red)) ?(width = 1) ?(height = 1) unicode
+        valign halign =
+      I.uchar attr (Uchar.of_int unicode) width height
+      |> I.vsnap ~align:valign (h + 2)
+      |> I.hsnap ~align:halign (w + 2)
+    in
+    I.zcat
+      [ border_element 0x2554 `Top `Left (* top left corner *)
+      ; border_element 0x2557 `Top `Right (* top right corner *)
+      ; border_element 0x255A `Bottom `Left (* bottom left corner *)
+      ; border_element 0x255D `Bottom `Right (* bottom right corner *)
+      ; border_element ~width:w 0x2550 `Top `Middle (* top border *)
+      ; border_element ~width:w 0x2550 `Bottom `Middle (* bottom border *)
+      ; border_element ~height:h 0x2551 `Middle `Left (* left border *)
+      ; border_element ~height:h 0x2551 `Middle `Right (* right border *)
+      ; I.pad ~l:1 ~t:1 ~r:1 ~b:1 image
+      ; I.char A.(bg black) ' ' (w + 2) (h + 2)
+      ]
+
+  let dialogue_box ~title ?(title_attr = Notty.A.(bg blue ++ fg black)) image =
+    let title =
+      I.(
+        string title_attr title
+        |> hsnap ~align:`Middle (I.width image + 2)
+        |> vsnap ~align:`Top (I.height image + 2))
+    in
+    I.(title </> border_box image)
+
+  let horizontal_scroll_bar width =
+    let twidth, theight = Term.size term in
+    I.vsnap ~align:`Bottom theight
+    @@
+    if width > twidth then
+      let nib =
+        let l =
+          int_of_float (ui_state.hscroll_pos *. float_of_int (twidth - 6)) + 1
+        in
+        I.uchar A.(fg blue) (Uchar.of_int 0x25AC) 3 1 |> I.pad ~l
+      in
+      I.zcat
+        [ nib
+        ; I.uchar A.(fg yellow) (Uchar.of_int 0x25C0) 1 1
+        ; I.uchar A.(fg yellow) (Uchar.of_int 0x25B6) 1 1
+          |> I.hsnap ~align:`Right (twidth - 1)
+        ; I.uchar A.(fg yellow) (Uchar.of_int 0x2500) (twidth - 1) 1
+        ; I.char A.(fg yellow ++ bg black) ' ' 1 1
+          |> I.hsnap ~align:`Right (twidth - 1)
+        ]
+    else I.empty
+
+  let vertical_scroll_bar height =
+    let twidth, theight = Term.size term in
+    I.hsnap ~align:`Right twidth
+    @@
+    if height > theight then
+      let nib =
+        let t =
+          int_of_float (ui_state.vscroll_pos *. float_of_int (theight - 5)) + 1
+        in
+        I.uchar A.(fg blue) (Uchar.of_int 0x2588) 1 2 |> I.pad ~t
+      in
+      I.zcat
+        [ nib
+        ; I.uchar A.(fg yellow) (Uchar.of_int 0x25B2) 1 1
+        ; I.uchar A.(fg yellow) (Uchar.of_int 0x25BC) 1 1
+          |> I.vsnap ~align:`Bottom (theight - 1)
+        ; I.uchar A.(fg yellow) (Uchar.of_int 0x2502) 1 (theight - 1)
+        ; I.char A.(fg yellow ++ bg black) ' ' 1 1
+          |> I.vsnap ~align:`Bottom (theight - 1)
+        ]
+    else I.empty
+
+  let help_screen () =
+    let twidth, theight = Term.size term in
+    if ui_state.help_screen then
+      let hsnap_or_leave img =
+        if I.width img < twidth then I.hsnap ~align:`Middle twidth img else img
+      in
+      let vsnap_or_leave img =
+        if I.height img < theight then I.vsnap ~align:`Middle theight img
+        else img
+      in
+      List.map
+        ~f:(I.string A.(fg yellow))
+        [ "Press 'q' to quit"
+        ; "Press 'h' or '?' to toggle this screen"
+        ; "Navigate with the mouse or arrow keys"
+        ; "Press 'd' to toggle debug mode"
+        ]
+      |> I.vcat
+      |> fun img ->
+      [ img
+      ; I.string A.empty ""
+      ; I.string A.(fg yellow) "🐪 Developed by the Dune team 🐪"
+        |> I.hsnap ~align:`Middle (I.width img)
+      ]
+      |> I.vcat |> I.pad ~l:1 ~r:1 ~t:1 ~b:1
+      |> dialogue_box ~title:"Help Screen" ~title_attr:A.(fg yellow)
+      |> vsnap_or_leave |> hsnap_or_leave
+    else I.empty
+
+  let top_frame image =
+    (* The top frame is our main UI element. It contains all other widgets that
+       we may wish to interact with. *)
+    let tw, th = Term.size term in
+    let w, h = I.(width image, height image) in
+    (* We do a quick calculation of the scrolling speed and update them. *)
+    ui_state.hscroll_speed <- Float.max 0. (4. /. float_of_int w);
+    ui_state.vscroll_speed <- Float.max 0. (2. /. float_of_int h);
+    let image =
+      (* if our image spills over the size of the terminal, then we crop it
+         according to the scrolling position. *)
+      let l, r =
+        if w < tw then (0, 0)
+        else
+          let l =
+            int_of_float (ui_state.hscroll_pos *. float_of_int (w - tw + 1))
+          in
+          (l, w - tw - l)
+      in
+      let t, b =
+        if h < th then (0, 0)
+        else
+          let t =
+            int_of_float (ui_state.vscroll_pos *. float_of_int (h - th + 1))
+          in
+          (t, h - th - t)
+      in
+      I.crop ~l ~r ~t ~b image
+    in
+    I.zcat
+      [ help_screen (); vertical_scroll_bar h; horizontal_scroll_bar w; image ]
 
   let render (state : Dune_threaded_console.state) =
     let messages = Queue.to_list state.messages in
-    let image = image ~status_line:state.status_line ~messages in
+    let image = top_frame @@ image ~status_line:state.status_line ~messages in
     Term.image term image
 
   (* Current TUI issues
      - Ctrl-Z and then 'fg' will stop inputs from being captured.
-     - Resizing from full screen to a small size will not update the screen
-       causing it not to be drawn.
   *)
 
   (** Update any local state and finish *)
@@ -180,11 +351,119 @@ module Tui () = struct
     finish_interaction ()
 
   let give_user_feedback ?(style = User_message.Style.Ok) message =
-    user_feedback := Some Pp.(tag style @@ hbox @@ message)
+    ui_state.user_feedback <- Some Pp.(tag style @@ hbox @@ message)
 
-  let resize ~width ~height ~mutex (state : Dune_threaded_console.state) =
+  let handle_resize ~width ~height ~mutex state =
     give_user_feedback ~style:User_message.Style.Debug
       (Pp.textf "You have just resized to (%d, %d)!" width height);
+    finish_dirty_interaction ~mutex state
+
+  let handle_quit () =
+    (* When we encounter q we make sure to quit by signaling termination. *)
+    Unix.kill (Unix.getpid ()) Sys.sigterm;
+    Unix.gettimeofday ()
+
+  let handle_help ~mutex state =
+    ui_state.help_screen <- not ui_state.help_screen;
+    finish_dirty_interaction ~mutex state
+
+  let handle_horizontal_scroll ~direction ~mutex state =
+    ui_state.hscroll_pos <-
+      (match direction with
+      | `Up -> Float.max 0. (ui_state.hscroll_pos -. ui_state.hscroll_speed)
+      | `Down -> Float.min 1. (ui_state.hscroll_pos +. ui_state.hscroll_speed));
+    finish_dirty_interaction ~mutex state
+
+  let handle_vertical_scroll ~direction ~mutex state =
+    ui_state.vscroll_pos <-
+      (match direction with
+      | `Up -> Float.max 0. (ui_state.vscroll_pos -. ui_state.vscroll_speed)
+      | `Down -> Float.min 1. (ui_state.vscroll_pos +. ui_state.vscroll_speed));
+    finish_dirty_interaction ~mutex state
+
+  let handle_debug ~mutex state =
+    ui_state.debug <- not ui_state.debug;
+    finish_dirty_interaction ~mutex state
+
+  let lipsum =
+    User_message.make
+      [ Pp.textf "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      ; Pp.textf
+          "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      ; Pp.textf
+          "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris \
+           nisi ut aliquip ex ea commodo consequat."
+      ; Pp.textf
+          "Duis aute irure dolor in reprehenderit in voluptate velit esse \
+           cillum dolore eu fugiat nulla pariatur."
+      ; Pp.textf
+          "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \
+           officia deserunt mollit anim id est laborum."
+      ]
+
+  let handle_unknown_input ~mutex (state : Dune_threaded_console.state) event =
+    match event with
+    (* lorem ipsum for testing *)
+    | `Key (`ASCII 'l', [ `Meta ]) ->
+      Mutex.lock mutex;
+      Queue.push state.messages lipsum;
+      Mutex.unlock mutex;
+      finish_dirty_interaction ~mutex state
+    (* Unknown ascii key presses *)
+    | `Key (`ASCII c, _) ->
+      give_user_feedback ~style:User_message.Style.Kwd
+        (Pp.textf "You have just pressed '%c' but this does nothing!" c);
+      finish_dirty_interaction ~mutex state
+    (* Mouse interaction *)
+    | `Mouse (`Press button, (x, y), _) ->
+      give_user_feedback ~style:User_message.Style.Kwd
+        (Pp.textf
+           "You have just %s the mouse at (%d, %d) but this does nothing!"
+           (match button with
+           | `Left -> "left clicked"
+           | `Middle -> "middle clicked"
+           | `Right -> "right clicked"
+           | `Scroll `Up -> "scrolled up with"
+           | `Scroll `Down -> "scrolled down with")
+           x y);
+      finish_dirty_interaction ~mutex state
+    (* We have no more events to handle, we finish the interaction. *)
+    | _ -> finish_interaction ()
+
+  let handle_mouse_release ~mutex state =
+    ui_state.vscroll_grabbed <- false;
+    ui_state.hscroll_grabbed <- false;
+    finish_dirty_interaction ~mutex state
+
+  let update_hscroll_pos ~x ~width =
+    ui_state.hscroll_pos <-
+      Float.max 0. (Float.min 1. (float_of_int x /. float_of_int (width - 1)))
+
+  let update_vscroll_pos ~y ~height =
+    ui_state.vscroll_pos <-
+      Float.max 0. (Float.min 1. (float_of_int y /. float_of_int (height - 1)))
+
+  let handle_mouse_press ~pos:(x, y) ~button ~mutex state =
+    (* To handle mouse presses we need to workout which widget we are trying to
+       interact with. At the moment there are only two scrollbars so this is
+       simple enough, but in the future a more principled approach is warranted.
+    *)
+    let tw, th = Term.size term in
+    (match (button, x = tw - 1, y = th - 1) with
+    | `Left, true, true -> ()
+    | `Left, true, false ->
+      ui_state.vscroll_grabbed <- true;
+      update_vscroll_pos ~y ~height:th
+    | `Left, false, true ->
+      ui_state.hscroll_grabbed <- true;
+      update_hscroll_pos ~x ~width:tw
+    | _ -> ());
+    finish_dirty_interaction ~mutex state
+
+  let handle_mouse_drag ~pos:(x, y) ~mutex state =
+    let tw, th = Term.size term in
+    if ui_state.vscroll_grabbed then update_vscroll_pos ~y ~height:th
+    else if ui_state.hscroll_grabbed then update_hscroll_pos ~x ~width:tw;
     finish_dirty_interaction ~mutex state
 
   let rec handle_user_events ~now ~time_budget ~mutex
@@ -202,35 +481,40 @@ module Tui () = struct
       now +. time_budget
       (* Nothing to do, we return the time at the end of the time budget. *)
     | `Event -> (
-      (* TODO if anything fancy is done in the UI in the future we need to lock
-         the state with the provided mutex *)
       match Term.event term with
-      (* quit when sure *)
-      | `Key (`ASCII 'q', _) ->
-        (* When we encounter q we make sure to quit by signaling termination. *)
-        Unix.kill (Unix.getpid ()) Sys.sigterm;
-        Unix.gettimeofday ()
+      (* quit *)
+      | `Key (`ASCII 'q', _) -> handle_quit ()
+      (* toggle help screen *)
+      | `Key (`ASCII ('h' | '?'), _) -> handle_help ~mutex state
+      (* toggle debug info *)
+      | `Key (`ASCII 'd', _) -> handle_debug ~mutex state
       (* on resize we wish to redraw so the state is set to dirty *)
-      | `Resize (width, height) -> resize ~width ~height ~mutex state
-      (* Unknown ascii key presses *)
-      | `Key (`ASCII c, _) ->
-        give_user_feedback ~style:User_message.Style.Kwd
-          (Pp.textf "You have just pressed '%c' but this does nothing!" c);
-        finish_dirty_interaction ~mutex state
-      (* Mouse interaction *)
-      | `Mouse (`Press button, (x, y), _) ->
-        give_user_feedback ~style:User_message.Style.Kwd
-          (Pp.textf
-             "You have just %s the mouse at (%d, %d) but this does nothing!"
-             (match button with
-             | `Left -> "left clicked"
-             | `Middle -> "middle clicked"
-             | `Right -> "right clicked"
-             | `Scroll `Up -> "scrolled up with"
-             | `Scroll `Down -> "scrolled down with")
-             x y);
-        finish_dirty_interaction ~mutex state
-      | _ -> finish_interaction ()
+      | `Resize (width, height) -> handle_resize ~width ~height ~mutex state
+      (* when the mouse is scrolled we scroll the vertical scrollbar *)
+      | `Mouse (`Press (`Scroll direction), _, []) ->
+        handle_vertical_scroll ~direction ~mutex state
+      (* when the mouse is alt scrolled we scroll the horizontal scrollbar *)
+      | `Mouse (`Press (`Scroll direction), _, [ `Meta ]) ->
+        handle_horizontal_scroll ~direction ~mutex state
+      (* arrow keys and partial vim bindings can also scroll *)
+      | `Key ((`Arrow `Up | `ASCII 'k'), _) ->
+        handle_vertical_scroll ~direction:`Up ~mutex state
+      | `Key ((`Arrow `Down | `ASCII 'j'), _) ->
+        handle_vertical_scroll ~direction:`Down ~mutex state
+      | `Key (`Arrow `Left, _) ->
+        handle_horizontal_scroll ~direction:`Up ~mutex state
+      | `Key (`Arrow `Right, _) ->
+        handle_horizontal_scroll ~direction:`Down ~mutex state
+      (* when the mouse is pressed we update our state *)
+      | `Mouse (`Press button, pos, _) ->
+        handle_mouse_press ~pos ~button ~mutex state
+      (* when the mouse is dragged we update our state *)
+      | `Mouse (`Drag, pos, _) -> handle_mouse_drag ~pos ~mutex state
+      (* when the mouse is released we update our state *)
+      | `Mouse (`Release, _, _) -> handle_mouse_release ~mutex state
+      (* Finally, given an unknown event, we try to handle it with nice user
+         feedback if we can make sense of it and do nothing otherwise. *)
+      | _ as event -> handle_unknown_input ~mutex state event
       | exception Unix.Unix_error ((EAGAIN | EWOULDBLOCK), _, _) ->
         (* If we encounter an exception, we make sure to rehandle user events
            with a corrected time budget. *)
@@ -241,7 +525,7 @@ module Tui () = struct
         handle_user_events ~now ~time_budget ~mutex state)
 
   let reset () =
-    reset_count := !reset_count + 1;
+    ui_state.reset_count <- ui_state.reset_count + 1;
     ()
 
   let reset_flush_history () = ()

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -115,6 +115,27 @@ module Tui () = struct
 
   let reset_count = ref 0
 
+  let horizontal_line_with_count total index =
+    let module A = Notty.A in
+    let module I = Notty.I in
+    let twidth, _ = Term.size term in
+    let status =
+      let left = I.uchar A.(fg red) (Uchar.of_int 0x169c) 1 1 in
+      let index = I.string A.(fg blue) (string_of_int (index + 1)) in
+      let mid = I.string A.(fg red) "/" in
+      let total = I.string A.(fg blue) (string_of_int total) in
+      let right = I.uchar A.(fg red) (Uchar.of_int 0x169B) 1 1 in
+      I.(left <|> index <|> mid <|> total <|> right)
+    in
+    I.(
+      hsnap ~align:`Left twidth status
+      </> uchar A.(fg red) (Uchar.of_int 0x2015) twidth 1)
+
+  let line_separated_message ~total index msg =
+    Notty.I.(
+      image_of_user_message_style_pp (User_message.pp msg)
+      <-> horizontal_line_with_count total index)
+
   let image ~status_line ~messages =
     let status =
       match (status_line : User_message.Style.t Pp.t option) with
@@ -122,8 +143,8 @@ module Tui () = struct
       | Some message -> List.map ~f:image_of_user_message_style_pp [ message ]
     in
     let messages =
-      List.map messages ~f:(fun msg ->
-          image_of_user_message_style_pp (User_message.pp msg))
+      List.mapi messages
+        ~f:(line_separated_message ~total:(List.length messages))
     in
     let reset_count =
       image_of_user_message_style_pp

--- a/src/dune_tui/dune_tui.ml
+++ b/src/dune_tui/dune_tui.ml
@@ -179,7 +179,11 @@ module Tui () = struct
 
   let line_separated_message ~total index msg =
     let img = image_of_user_message_style_pp (User_message.pp msg) in
-    I.vcat [ img; horizontal_line_with_count ~w:(I.width img) total index ]
+    I.vcat
+      [ img
+      ; horizontal_line_with_count total index
+          ~w:(Stdlib.Int.max (I.width img) (fst (Term.size term)))
+      ]
 
   let image ~status_line ~messages =
     let status =


### PR DESCRIPTION
We add some more features to the `--display tui` mode.

Waiting for #7663 

Features:
- Messages to the user a separated with a rule and include a numbering together with total number of messages.
- Horizontal and vertical scroll bars which can be controlled using the arrow keys, `j` and `k` or by interacting with the mouse including scrolling and clicking. (Horizontal scrolling is done with Meta (alt) + Scroll.
- Help screen activated with `h` or `?` explaining what keys do what.
- Debug features:
  - Pressing 'd' will output some debug info about the state of the UI.
  - Pressing Meta + `l` will make dune output a lorem ipsum, allowing to quickly test any issues with scrolling. (I want to keep this in as it is harmless and out of the way).

<img src="https://user-images.githubusercontent.com/8614547/235651225-e4aab871-c578-47e6-96ff-f9446c877d87.png" width="500">
<img src="https://user-images.githubusercontent.com/8614547/235651220-dc99467a-1467-4736-b982-08d4c42dd158.png" width="500">

#### How to test:
Just run
```console
./dune.exe build @install
_build/install/bin/dune build @check -w --display tui
```

#### Compatibility
- Linux
  - [x] Alacritty, works fine, this is in the screenshots
  - [x] xterm, works but meta + l is sometimes ignored
  - [x] gnome console, works fine
- [ ] macos
- [ ] windows
  - [ ] cmd
  - [ ] wsl

#### Issues
- [ ] Exceptions are not printed when in tui mode. We need to have a fallback display. For example, running two watch mode tui's will cause the second one to crash silently and return to the prompt since Dune will complain about the _build lock. We should probably add a way internal exceptions can be displayed or printed nicely.
- [x] Needs to look good on light terminals, the colors used are somewhat ad-hoc. We need to make them more configurable and then adapt based on terminal colors chosen.