### PR TITLE
RPC that returns the number of completed builds

### DIFF
--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -73,6 +73,9 @@ let run_build_system ~common ~request =
       in
       res)
     ~finally:(fun () ->
+      (match Common.rpc common with
+      | `Allow server -> Dune_rpc_impl.Server.report_build_complete server
+      | `Forbid_builds -> ());
       Hooks.End_of_build.run ();
       Fiber.return ())
 

--- a/bin/internal.ml
+++ b/bin/internal.ml
@@ -10,4 +10,8 @@ let latest_lang_version =
 
 let group =
   Cmd.group (Cmd.info "internal")
-    [ Internal_dump.command; latest_lang_version; Internal_action_runner.group ]
+    [ Internal_dump.command
+    ; latest_lang_version
+    ; Internal_action_runner.group
+    ; Internal_build_count.command
+    ]

--- a/bin/internal_build_count.ml
+++ b/bin/internal_build_count.ml
@@ -1,0 +1,46 @@
+open Import
+module Client = Dune_rpc_client.Client
+
+let doc =
+  "When dune is running in watch-mode this command prints out the number of \
+   builds that have completed since dune started"
+
+let man =
+  [ `S "DESCRIPTION"
+  ; `P
+      {|When dune is running in watch-mode this command prints out the number of builds that have completed since dune started|}
+  ; `Blocks Common.help_secs
+  ]
+
+let info = Cmd.info "build-count" ~doc ~man
+
+let witness = Dune_rpc_private.Decl.Request.witness
+
+let request_exn client witness =
+  let open Fiber.O in
+  let* decl = Client.Versioned.prepare_request client witness in
+  match decl with
+  | Error e -> raise (Dune_rpc_private.Version_error.E e)
+  | Ok decl -> Client.request client decl ()
+
+let run () =
+  let open Fiber.O in
+  let where = Rpc.active_server () in
+  let* conn = Client.Connection.connect_exn where in
+  Client.client conn
+    ~private_menu:[ Request Dune_rpc_impl.Decl.build_count ]
+    (Dune_rpc.Initialize.Request.create
+       ~id:(Dune_rpc.Id.make (Csexp.Atom "status ")))
+    ~f:(fun client ->
+      let* count =
+        request_exn client (witness Dune_rpc_impl.Decl.build_count)
+        >>| Result.get_ok
+      in
+      print_endline (Printf.sprintf "%d" count);
+      Fiber.return ())
+
+let term =
+  let+ (common : Common.t) = Common.term in
+  Rpc.client_term common @@ fun _common -> run ()
+
+let command = Cmd.v info term

--- a/bin/internal_build_count.mli
+++ b/bin/internal_build_count.mli
@@ -1,0 +1,3 @@
+open Import
+
+val command : unit Cmd.t

--- a/src/dune_rpc_impl/decl.ml
+++ b/src/dune_rpc_impl/decl.ml
@@ -53,6 +53,15 @@ module Build = struct
   let decl = Decl.Request.make ~method_:"build" ~generations:[ v1 ]
 end
 
+module Build_count = struct
+  let v1 =
+    Decl.Request.make_current_gen ~req:Conv.unit ~resp:Conv.int ~version:1
+
+  let decl = Decl.Request.make ~method_:"build_count" ~generations:[ v1 ]
+end
+
 let build = Build.decl
 
 let status = Status.decl
+
+let build_count = Build_count.decl

--- a/src/dune_rpc_impl/decl.mli
+++ b/src/dune_rpc_impl/decl.mli
@@ -28,3 +28,5 @@ end
 val build : (string list, Build_outcome.t) Decl.Request.t
 
 val status : (unit, Status.t) Decl.Request.t
+
+val build_count : (unit, int) Decl.Request.t

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -29,3 +29,5 @@ val ready : t -> unit Fiber.t
 val run : t -> unit Fiber.t
 
 val action_runner : t -> Dune_engine.Action_runner.Rpc_server.t
+
+val report_build_complete : t -> unit


### PR DESCRIPTION
Next iteration of https://github.com/ocaml/dune/pull/7473. This is much simpler and doesn't have any synchronization. It just returns the number of builds that have completed since dune was started in watch mode. The idea is that this can be used by the benchmark runner to check when a build has completed.