### PR TITLE
feature: md5'ing files without GC lock

### DIFF
--- a/src/dune_digest/dune
+++ b/src/dune_digest/dune
@@ -1,5 +1,8 @@
 (library
  (name dune_digest)
  (libraries dune_metrics stdune)
+ (foreign_stubs
+  (names dune_digest_stubs)
+  (language c))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_digest/dune_digest_stubs.c
+++ b/src/dune_digest/dune_digest_stubs.c
@@ -1,0 +1,49 @@
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/bigarray.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+#include <errno.h>
+#define CAML_INTERNALS
+#include <caml/md5.h>
+#undef CAML_INTERNALS
+
+/* yanked from:
+ * https://github.com/janestreet/core/blob/master/core/src/md5_stubs.c
+ */
+CAMLprim value dune_md5_fd(value v_fd) {
+  CAMLparam1(v_fd);
+  CAMLlocal1(v_res);
+#ifdef _WIN32
+  int fd = win_CRT_fd_of_filedescr(v_fd);
+#else
+  int fd = Int_val(v_fd);
+#endif
+  struct MD5Context ctx;
+  caml_release_runtime_system();
+  {
+    char buffer[UNIX_BUFFER_SIZE];
+
+    intnat bytes_read;
+    caml_MD5Init(&ctx);
+    while (1) {
+      bytes_read = read(fd, buffer, sizeof(buffer));
+      if (bytes_read == 0) {
+        break;
+      } else if (bytes_read < 0) {
+        if (errno == EINTR)
+          continue;
+        caml_acquire_runtime_system();
+        uerror("read", Nothing);
+      } else {
+        caml_MD5Update(&ctx, (unsigned char *)buffer, bytes_read);
+      }
+    }
+  }
+  caml_acquire_runtime_system();
+  v_res = caml_alloc_string(16);
+  caml_MD5Final(&Byte_u(v_res, 0), &ctx);
+  CAMLreturn(v_res);
+}


### PR DESCRIPTION
Directly md5 the files in C. This allows us to release the runtime lock
while md5'ing large files, which allows other OCaml threads to make
progress.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ad6d7706-eaf6-4e5a-b8a2-9669b8122db8 -->