### PR TITLE
test: reproduce bug with (opam_file_location inside_opam_directory)

### DIFF
--- a/test/blackbox-tests/test-cases/opam-directory/build-install-file.t
+++ b/test/blackbox-tests/test-cases/opam-directory/build-install-file.t
@@ -1,0 +1,13 @@
+Generating .install files when opam files are in opam/ dir
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (generate_opam_files true)
+  > (opam_file_location inside_opam_directory)
+  > (package
+  >  (name foobar))
+  > EOF
+
+  $ dune build foobar.install
+  Error: Don't know how to build foobar.install
+  [1]


### PR DESCRIPTION
When this mode is set, the .install file is now generate in the opam/
dir/

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a1c75a1c-a643-4726-b10d-81973e753a5b -->