### PR TITLE
doc: move lexical conventions to reference

### DIFF
--- a/doc/dune-files.rst
+++ b/doc/dune-files.rst
@@ -669,7 +669,8 @@ dune
 ``dune`` files are the main part of Dune. They are used to describe libraries,
 executables, tests, and everything Dune needs to know about.
 
-The syntax of ``dune`` files is described in :ref:`metadata-format` section.
+The syntax of ``dune`` files is described in
+:doc:`reference/lexical-conventions`.
 
 ``dune`` files are composed of stanzas, as shown below:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,7 @@ Welcome to Dune's Documentation!
    :caption: Reference Guides
    :maxdepth: 3
 
+   reference/lexical-conventions
    reference/ordered-set-language
    reference/boolean-language
    reference/predicate-language
@@ -50,7 +51,6 @@ Welcome to Dune's Documentation!
    sites
    instrumentation
    jsoo
-   lexical-conventions
    opam
    toplevel-integration
    variants

--- a/doc/reference/lexical-conventions.rst
+++ b/doc/reference/lexical-conventions.rst
@@ -1,3 +1,5 @@
+.. highlight:: dune
+
 *******************
 Lexical Conventions
 *******************
@@ -16,11 +18,9 @@ Comments
 
 The Dune language only has end of line comments. A semicolon introduces end of
 line comments and span up to the end of the current line. The system ignores
-everything from the semicolon to the end of the line. For instance:
+everything from the semicolon to the end of the line. For instance::
 
-.. code:: dune
-
-   ; This is a comment
+  ; This is a comment
 
 Atoms
 =====
@@ -59,13 +59,11 @@ and interprets the following escape sequences:
 
 Additionally, you can use a backslash just before the end of the line. This
 skips the newline leading up to the next non-space character. For instance, the
-following two strings represent the same text:
+following two strings represent the same text::
 
-.. code:: dune
-
-   "abcdef"
-   "abc\
-      def"
+  "abcdef"
+  "abc\
+     def"
 
 In most places where Dune expects a string, it will also accept an atom. As a
 result, it's possible to write most Dune configuration files using very few
@@ -83,12 +81,10 @@ Dune reads it as a continuation of the same string. For readability, either
 leave the text following the delimiter empty or start it with a space (that
 will be ignored).
 
-For instance:
+For instance::
 
-.. code:: dune
-
-   "\| this is a block
-   "\| of text
+  "\| this is a block
+  "\| of text
 
 represents the same text as the string ``"this is a block\nof text"``.
 
@@ -104,11 +100,9 @@ Lists are sequences of values enclosed by parentheses. For instance
 ``z``. Lists can be empty, for instance: ``()``.
 
 Lists can be nested, allowing arbitrary representation for complex
-descriptions. For instance:
+descriptions. For instance::
 
-.. code:: dune
-
-   (html
-    (head (title "Hello world!"))
-    (body
-      This is a simple example of using S-expressions))
+  (html
+   (head (title "Hello world!"))
+   (body
+     This is a simple example of using S-expressions))

--- a/doc/reference/lexical-conventions.rst
+++ b/doc/reference/lexical-conventions.rst
@@ -1,5 +1,3 @@
-.. _metadata-format:
-
 *******************
 Lexical Conventions
 *******************
@@ -57,7 +55,7 @@ and interprets the following escape sequences:
 - ``\xHH``, a backslash followed by two hexadecimal characters to
   represent the character with ASCII code ``HH`` in hexadecimal
 - ``\\``, a double backslash to represent a single backslash
-- ``\%{`` to represent ``%{`` (see :doc:`concepts/variables`)
+- ``\%{`` to represent ``%{`` (see :doc:`../concepts/variables`)
 
 Additionally, you can use a backslash just before the end of the line. This
 skips the newline leading up to the next non-space character. For instance, the


### PR DESCRIPTION
This is a reference guide. Contents are unchanged except for a tiny rst shortcut.
