### PR TITLE
test: foreign stubs and include directories

### DIFF
--- a/test/blackbox-tests/test-cases/foreign-stubs/dep-without-include.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/dep-without-include.t
@@ -1,0 +1,40 @@
+We demonstrate a strange property of the foreign stubs.
+
+Although we introduce a dependency on all header files found in all source
+directories, we do not add include directories, so they aren't accessible.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (include_subdirs unqualified)
+  > (executable
+  >  (name foo)
+  >  (foreign_stubs
+  >   (language c)
+  >   (names bar)))
+  > EOF
+
+  $ touch foo.ml
+  $ cat >bar.c <<EOF
+  > void foo { }
+  > EOF
+
+  $ mkdir subdir
+  $ cat >subdir/dune <<EOF
+  > (rule (with-stdout-to foo.h (system "exit 1")))
+  > EOF
+
+  $ dune build foo.exe
+  File "subdir/dune", line 1, characters 0-47:
+  1 | (rule (with-stdout-to foo.h (system "exit 1")))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Command exited with code 1.
+  [1]
+
+The rules include the dependency on foo.h, but the include directory has to be
+added manually.
+
+  $ dune rules _build/default/bar.o | grep subdir
+     (File (In_build_dir _build/default/subdir/foo.h))))


### PR DESCRIPTION
demonstrate the weirdness of depending on a header file without making
it available.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 05b05e4f-842d-4b74-a1ea-f9fd418decd8 -->