### PR TITLE
test: installed headers and dir preservation

### DIFF
--- a/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
@@ -1,0 +1,36 @@
+Headers with the same filename cannot be installed together:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name mypkg))
+  > EOF
+
+  $ mkdir inc
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name mypkg)
+  >  (install_c_headers foo inc/foo))
+  > EOF
+
+  $ touch foo.h inc/foo.h
+
+  $ dune build mypkg.install && cat _build/default/mypkg.install | grep ".h"
+  Error: Multiple rules generated for _build/install/default/lib/mypkg/foo.h:
+  - dune:1
+  - dune:1
+  -> required by _build/default/mypkg.install
+  [1]
+
+Now we demonstrate that header paths get squashed when installed
+
+  $ mv inc/foo.h inc/bar.h
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name mypkg)
+  >  (install_c_headers foo inc/bar))
+  > EOF
+
+  $ dune build mypkg.install && cat _build/default/mypkg.install | grep ".h"
+    "_build/install/default/lib/mypkg/bar.h"
+    "_build/install/default/lib/mypkg/foo.h"


### PR DESCRIPTION
Demonstrate that we cannot install headers with the same basename if
they exist in different directories.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 840e831d-eb7f-4429-9c76-b8cee3e2ff8b -->