### PR TITLE
test: unintentionally visible headers

### DIFF
--- a/test/blackbox-tests/test-cases/foreign-stubs/installed-headers-sub-library.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/installed-headers-sub-library.t
@@ -1,0 +1,52 @@
+Headers of libraries are accidentally visibile
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name mypkg))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library
+  >  (public_name mypkg))
+  > EOF
+
+  $ mkdir sub
+  $ touch sub/foo.h
+
+foo.h should only be visible when we use mypkg.sub
+
+  $ cat >sub/dune <<EOF
+  > (library
+  >  (name mypkg_sub)
+  >  (public_name mypkg.sub)
+  >  (install_c_headers foo))
+  > EOF
+
+  $ dune build mypkg.install
+
+  $ dune install --prefix _install mypkg
+  $ export OCAMLPATH=$PWD/_install/lib:$OCAMLPATH
+
+  $ mkdir subdir
+  $ cd subdir
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > EOF
+
+We depend on mypkg, but we can see the header of mypkg.sub
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name bar)
+  >  (foreign_stubs
+  >   (language c)
+  >   (include_dirs (lib mypkg))
+  >   (names foo)))
+  > EOF
+  $ touch bar.ml
+  $ cat >foo.c <<EOF
+  > // This header shouldn't be visible
+  > #include <sub/foo.h>
+  > EOF
+  $ dune build bar.exe


### PR DESCRIPTION
When we have two libraries in the same package, depending on the parent
library makes the headers of the sub libraries visible.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 45a08f51-406c-44b5-9276-4509e54e9992 -->