### PR TITLE
test: make installed-headers reproducible

### DIFF
--- a/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
@@ -60,12 +60,5 @@ Now we try to use the installed headers:
   > #include <foo.h>
   > #include <inc/bar.h>
   > EOF
-  $ dune build bar.exe
-  File "dune", line 6, characters 9-12:
-  6 |   (names foo)))
-               ^^^
-  foo.c:2:10: fatal error: inc/bar.h: No such file or directory
-      2 | #include <inc/bar.h>
-        |          ^~~~~~~~~~~
-  compilation terminated.
+  $ dune build bar.exe 2>/dev/null
   [1]


### PR DESCRIPTION
we don't need the error message. knowning the compilation command fails
is enough

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 15410db9-c39d-46ae-b5db-e4dd3927fc0a -->