### PR TITLE
refactor: move action encoders

### DIFF
--- a/bin/print_rules.ml
+++ b/bin/print_rules.ml
@@ -46,10 +46,80 @@ let print_rule_makefile ppf (rule : Dune_engine.Reflection.Rule.t) =
           Format.fprintf ppf "@ %s" (Path.to_string dep)))
     Pp.to_fmt (Action_to_sh.pp action)
 
+let rec encode : Action.For_shell.t -> Dune_lang.t =
+  let module Outputs = Dune_lang.Action.Outputs in
+  let module File_perm = Dune_lang.Action.File_perm in
+  let module Inputs = Dune_lang.Action.Inputs in
+  let open Dune_lang in
+  let program = Encoder.string in
+  let string = Encoder.string in
+  let path = Encoder.string in
+  let target = Encoder.string in
+  function
+  | Run (a, xs) -> List (atom "run" :: program a :: List.map xs ~f:string)
+  | With_accepted_exit_codes (pred, t) ->
+    List
+      [ atom "with-accepted-exit-codes"
+      ; Predicate_lang.encode Dune_lang.Encoder.int pred
+      ; encode t
+      ]
+  | Dynamic_run (a, xs) ->
+    List (atom "run_dynamic" :: program a :: List.map xs ~f:string)
+  | Chdir (a, r) -> List [ atom "chdir"; path a; encode r ]
+  | Setenv (k, v, r) -> List [ atom "setenv"; string k; string v; encode r ]
+  | Redirect_out (outputs, fn, perm, r) ->
+    List
+      [ atom
+          (sprintf "with-%s-to%s"
+             (Outputs.to_string outputs)
+             (File_perm.suffix perm))
+      ; target fn
+      ; encode r
+      ]
+  | Redirect_in (inputs, fn, r) ->
+    List
+      [ atom (sprintf "with-%s-from" (Inputs.to_string inputs))
+      ; path fn
+      ; encode r
+      ]
+  | Ignore (outputs, r) ->
+    List [ atom (sprintf "ignore-%s" (Outputs.to_string outputs)); encode r ]
+  | Progn l -> List (atom "progn" :: List.map l ~f:encode)
+  | Concurrent l -> List (atom "concurrent" :: List.map l ~f:encode)
+  | Echo xs -> List (atom "echo" :: List.map xs ~f:string)
+  | Cat xs -> List (atom "cat" :: List.map xs ~f:path)
+  | Copy (x, y) -> List [ atom "copy"; path x; target y ]
+  | Symlink (x, y) -> List [ atom "symlink"; path x; target y ]
+  | Hardlink (x, y) -> List [ atom "hardlink"; path x; target y ]
+  | System x -> List [ atom "system"; string x ]
+  | Bash x -> List [ atom "bash"; string x ]
+  | Write_file (x, perm, y) ->
+    List [ atom ("write-file" ^ File_perm.suffix perm); target x; string y ]
+  | Rename (x, y) -> List [ atom "rename"; target x; target y ]
+  | Remove_tree x -> List [ atom "remove-tree"; target x ]
+  | Mkdir x -> List [ atom "mkdir"; target x ]
+  | Diff { optional; file1; file2; mode = Binary } ->
+    assert (not optional);
+    List [ atom "cmp"; path file1; target file2 ]
+  | Diff { optional = false; file1; file2; mode = _ } ->
+    List [ atom "diff"; path file1; target file2 ]
+  | Diff { optional = true; file1; file2; mode = _ } ->
+    List [ atom "diff?"; path file1; target file2 ]
+  | Merge_files_into (srcs, extras, into) ->
+    List
+      [ atom "merge-files-into"
+      ; List (List.map ~f:path srcs)
+      ; List (List.map ~f:string extras)
+      ; target into
+      ]
+  | Pipe (outputs, l) ->
+    List
+      (atom (sprintf "pipe-%s" (Outputs.to_string outputs))
+      :: List.map l ~f:encode)
+  | Extension ext -> List [ atom "ext"; ext ]
+
 let print_rule_sexp ppf (rule : Dune_engine.Reflection.Rule.t) =
-  let sexp_of_action action =
-    Action.for_shell action |> Action.For_shell.encode
-  in
+  let sexp_of_action action = Action.for_shell action |> encode in
   let paths ps =
     Dune_lang.Encoder.list Dpath.Build.encode (Path.Build.Set.to_list ps)
   in

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -84,8 +84,6 @@ module For_shell : sig
       with type target := string
       with type string := string
       with type ext := Dune_lang.t
-
-  val encode : t Dune_lang.Encoder.t
 end
 
 (** Convert the action to a format suitable for printing *)


### PR DESCRIPTION
Action.For_shell.t encoders are only used for printing rules in `$ dune
rules`. Therefore, we can just move them to the module that implements
rule printing.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b9e0ffb5-113e-4601-affd-4fbea25f106f -->