### PR TITLE
refactor: use records in recursive include

### DIFF
--- a/src/dune_rules/foreign.ml
+++ b/src/dune_rules/foreign.ml
@@ -119,16 +119,14 @@ module Stubs = struct
   end
 
   module Include_dir = struct
-    include
-      Recursive_include.Make
-        (Include_dir_without_include)
-        (struct
-          let include_keyword = "include"
+    type t = Include_dir_without_include.t Recursive_include.t
 
-          let include_allowed_in_versions = `Since (3, 5)
+    let decode =
+      Recursive_include.decode ~base_term:Include_dir_without_include.decode
+        ~include_keyword:"include" ~non_sexp_behaviour:`Parse_as_base_term
+        ~include_allowed_in_versions:(`Since (3, 5))
 
-          let non_sexp_behaviour = `Parse_as_base_term
-        end)
+    let expand_include = Recursive_include.expand_include
 
     module Without_include = Include_dir_without_include
   end

--- a/src/dune_rules/recursive_include.ml
+++ b/src/dune_rules/recursive_include.ml
@@ -22,77 +22,80 @@ module Include_term = struct
       ]
 end
 
-module Make (Base_term : sig
-  type t
+type 'a t =
+  | Base of 'a
+  | Include of Include_term.t * 'a decoder Lazy.t
 
-  val decode : t Dune_lang.Decoder.t
-end) (Config : sig
-  val include_keyword : string
+and 'a decoder =
+  { decode : 'a t Dune_lang.Decoder.t
+  ; non_sexp_behaviour : [ `User_error | `Parse_as_base_term ]
+  }
 
-  val include_allowed_in_versions : [ `Since of Syntax.Version.t | `All ]
+let of_base base = Base base
 
-  val non_sexp_behaviour : [ `User_error | `Parse_as_base_term ]
-end) =
-struct
-  type t =
-    | Base of Base_term.t
-    | Include of Include_term.t
-
-  let of_base base = Base base
-
-  let decode =
-    let open Dune_lang.Decoder in
-    let base_term_decode =
-      let+ base_term = Base_term.decode in
-      Base base_term
+let decode ~base_term ~include_keyword ~include_allowed_in_versions config =
+  let open Dune_lang.Decoder in
+  let base_term_decode =
+    let+ base_term = base_term in
+    Base base_term
+  in
+  let include_term_decode =
+    let+ include_term =
+      Include_term.decode ~include_keyword
+        ~allowed_in_versions:include_allowed_in_versions
     in
-    let include_term_decode =
-      let+ include_term =
-        Include_term.decode ~include_keyword:Config.include_keyword
-          ~allowed_in_versions:Config.include_allowed_in_versions
+    Include (include_term, config)
+  in
+  include_term_decode <|> base_term_decode
+
+let decode ~base_term ~include_keyword ~include_allowed_in_versions
+    ~non_sexp_behaviour =
+  let rec config =
+    lazy
+      { non_sexp_behaviour
+      ; decode =
+          decode ~base_term ~include_keyword ~include_allowed_in_versions config
+      }
+  in
+  (Lazy.force config).decode
+
+let load_included_file config path ~context =
+  let open Memo.O in
+  let+ contents = Build_system.read_file (Path.build path) ~f:Io.read_file in
+  let ast =
+    Dune_lang.Parser.parse_string contents ~mode:Single
+      ~fname:(Path.Build.to_string path)
+  in
+  let config = Lazy.force config in
+  let parse = Dune_lang.Decoder.parse config.decode context in
+  match ast with
+  | List (_loc, terms) -> List.map terms ~f:parse
+  | other -> (
+    match config.non_sexp_behaviour with
+    | `User_error ->
+      let loc = Dune_sexp.Ast.loc other in
+      User_error.raise ~loc [ Pp.textf "Expected list, got:\n%s" contents ]
+    | `Parse_as_base_term ->
+      let term = Dune_lang.Decoder.parse config.decode context other in
+      [ term ])
+
+let expand_include (type a) (t : a t) ~expand_str ~dir =
+  let rec expand_include t ~seen =
+    match t with
+    | Base base_term -> Memo.return [ base_term ]
+    | Include ({ context; path = path_sw }, config) ->
+      let open Memo.O in
+      let* path =
+        expand_str path_sw
+        >>| Path.Build.relative ~error_loc:(String_with_vars.loc path_sw) dir
       in
-      Include include_term
-    in
-    include_term_decode <|> base_term_decode
-
-  let load_included_file path ~context =
-    let open Memo.O in
-    let+ contents = Build_system.read_file (Path.build path) ~f:Io.read_file in
-    let ast =
-      Dune_lang.Parser.parse_string contents ~mode:Single
-        ~fname:(Path.Build.to_string path)
-    in
-    let parse = Dune_lang.Decoder.parse decode context in
-    match ast with
-    | List (_loc, terms) -> List.map terms ~f:parse
-    | other -> (
-      match Config.non_sexp_behaviour with
-      | `User_error ->
-        let loc = Dune_sexp.Ast.loc other in
-        User_error.raise ~loc [ Pp.textf "Expected list, got:\n%s" contents ]
-      | `Parse_as_base_term ->
-        let term = Dune_lang.Decoder.parse decode context other in
-        [ term ])
-
-  let expand_include t ~expand_str ~dir =
-    let rec expand_include t ~seen =
-      match t with
-      | Base base_term -> Memo.return [ base_term ]
-      | Include { context; path = path_sw } ->
-        let open Memo.O in
-        let* path =
-          expand_str path_sw
-          >>| Path.Build.relative ~error_loc:(String_with_vars.loc path_sw) dir
-        in
-        if Path.Build.Set.mem seen path then
-          User_error.raise
-            ~loc:(String_with_vars.loc path_sw)
-            [ Pp.textf "Include loop detected via: %s"
-                (Path.Build.to_string path)
-            ];
-        let seen = Path.Build.Set.add seen path in
-        let* contents = load_included_file path ~context in
-        Memo.List.concat_map contents ~f:(expand_include ~seen)
-    in
-    expand_include t ~seen:Path.Build.Set.empty
-end
+      if Path.Build.Set.mem seen path then
+        User_error.raise
+          ~loc:(String_with_vars.loc path_sw)
+          [ Pp.textf "Include loop detected via: %s" (Path.Build.to_string path)
+          ];
+      let seen = Path.Build.Set.add seen path in
+      let* contents = load_included_file config path ~context in
+      Memo.List.concat_map contents ~f:(expand_include ~seen)
+  in
+  expand_include t ~seen:Path.Build.Set.empty

--- a/src/dune_rules/recursive_include.mli
+++ b/src/dune_rules/recursive_include.mli
@@ -8,44 +8,37 @@
 
 open! Import
 
-module Make (Base_term : sig
-  (** The type of a term in the configuration language without (include ...)
-      terms *)
-  type t
+(** The type of terms in the configuration language obtained by adding (include
+    ...) statements to the base language *)
+type 'a t
 
-  val decode : t Dune_lang.Decoder.t
-end) (_ : sig
-  (** The keyword that will be used to identify an include statement (ie. the
-      "include" in (include ...)) *)
-  val include_keyword : string
+val of_base : 'a -> 'a t
 
-  (** An expected use case for this module is adding (include ...) statements to
-      existing configuration languages used in dune fields, and in such cases
-      we'll want to assert that (include ...) statements are only used beyond a
-      particular version of dune. An error will be throw during parsing if an
-      (include ...) statement is encountered in versions of dune that don't
-      satisfy this predicate. *)
-  val include_allowed_in_versions : [ `Since of Syntax.Version.t | `All ]
+val decode :
+     base_term:'a Dune_lang.Decoder.t
+       (** The type of a term in the configuration language without (include
+           ...) terms *)
+  -> include_keyword:string
+       (** The keyword that will be used to identify an include statement (ie.
+           the "include" in (include ...)) *)
+  -> include_allowed_in_versions:[ `Since of Syntax.Version.t | `All ]
+       (** An expected use case for this module is adding (include ...)
+           statements to existing configuration languages used in dune fields,
+           and in such cases we'll want to assert that (include ...) statements
+           are only used beyond a particular version of dune. An error will be
+           throw during parsing if an (include ...) statement is encountered in
+           versions of dune that don't satisfy this predicate. *)
+  -> non_sexp_behaviour:[ `User_error | `Parse_as_base_term ]
+       (** What to do if the included file doesn't contain a sexp *)
+  -> 'a t Dune_lang.Decoder.t
 
-  (** What to do if the included file doesn't contain a sexp *)
-  val non_sexp_behaviour : [ `User_error | `Parse_as_base_term ]
-end) : sig
-  (** The type of terms in the configuration language obtained by adding
-      (include ...) statements to the base language *)
-  type t
-
-  val of_base : Base_term.t -> t
-
-  val decode : t Dune_lang.Decoder.t
-
-  (** Recursively expands (include ...) terms in the language, producing a list
-      of terms in the original language (the language without (include ...)
-      statements). Paths referred to by (include <path>) are resolved relative
-      to [dir]. Paths are given as [String_with_vars.t], and the [expand_str]
-      function is used to resolve them to strings. *)
-  val expand_include :
-       t
-    -> expand_str:(String_with_vars.t -> string Memo.t)
-    -> dir:Path.Build.t
-    -> Base_term.t list Memo.t
-end
+(** Recursively expands (include ...) terms in the language, producing a list of
+    terms in the original language (the language without (include ...)
+    statements). Paths referred to by (include <path>) are resolved relative to
+    [dir]. Paths are given as [String_with_vars.t], and the [expand_str]
+    function is used to resolve them to strings. *)
+val expand_include :
+     'a t
+  -> expand_str:(String_with_vars.t -> string Memo.t)
+  -> dir:Path.Build.t
+  -> 'a list Memo.t


### PR DESCRIPTION
We need to be able to customize the [include_allowed_in_versions] on a
per caller basis. This is easier when the config is in a record rather
than a functor.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 229f18da-51ff-4115-acb2-d6e281806631 -->