### PR TITLE
fix: improve locations for [installed_c_headers]

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -561,7 +561,7 @@ module Library = struct
     { name : Loc.t * Lib_name.Local.t
     ; visibility : visibility
     ; synopsis : string option
-    ; install_c_headers : string list
+    ; install_c_headers : (Loc.t * string) list
     ; ppx_runtime_libraries : (Loc.t * Lib_name.t) list
     ; modes : Mode_conf.Lib.Set.t
     ; kind : Lib_kind.t
@@ -598,7 +598,7 @@ module Library = struct
          field_o "public_name" (Public_lib.decode ~allow_deprecated_names:false)
        and+ synopsis = field_o "synopsis" string
        and+ install_c_headers =
-         field "install_c_headers" (repeat string) ~default:[]
+         field "install_c_headers" (repeat (located string)) ~default:[]
        and+ ppx_runtime_libraries =
          field "ppx_runtime_libraries"
            (repeat (located Lib_name.decode))

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -147,7 +147,7 @@ module Library : sig
     { name : Loc.t * Lib_name.Local.t
     ; visibility : visibility
     ; synopsis : string option
-    ; install_c_headers : string list
+    ; install_c_headers : (Loc.t * string) list
     ; ppx_runtime_libraries : (Loc.t * Lib_name.t) list
     ; modes : Mode_conf.Lib.Set.t
     ; kind : Lib_kind.t

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -110,7 +110,7 @@ end = struct
             | None -> subdir
             | Some lib_subdir -> Filename.concat lib_subdir subdir)
       in
-      fun section ?sub_dir ?dst fn ->
+      fun section ?(loc = loc) ?sub_dir ?dst fn ->
         let entry =
           Install.Entry.make section fn ~kind:`File
             ~dst:
@@ -268,8 +268,9 @@ end = struct
     in
     let+ execs = lib_ppxs ctx ~scope ~lib in
     let install_c_headers =
-      List.map lib.install_c_headers ~f:(fun base ->
-          Path.Build.relative dir (base ^ Foreign_language.header_extension))
+      List.rev_map lib.install_c_headers ~f:(fun (loc, base) ->
+          Path.Build.relative dir (base ^ Foreign_language.header_extension)
+          |> make_entry ~loc Lib)
     in
     List.concat
       [ sources
@@ -281,7 +282,7 @@ end = struct
       ; List.map dll_files ~f:(fun a ->
             let entry = Install.Entry.make ~kind:`File Stublibs a in
             Install.Entry.Sourced.create ~loc entry)
-      ; List.map ~f:(make_entry Lib) install_c_headers
+      ; install_c_headers
       ]
 
   let keep_if expander ~scope stanza =

--- a/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/installed-headers.t
@@ -17,8 +17,8 @@ Headers with the same filename cannot be installed together:
 
   $ dune build mypkg.install && cat _build/default/mypkg.install | grep ".h"
   Error: Multiple rules generated for _build/install/default/lib/mypkg/foo.h:
-  - dune:1
-  - dune:1
+  - dune:3
+  - dune:3
   -> required by _build/default/mypkg.install
   [1]
 


### PR DESCRIPTION
Use exact locations for [installed_c_headers] entry rules

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a790b77a-0a4e-4a87-877a-98a9aab8fc95 -->