### PR TITLE
refactor: remove Dune_project.parsing_context

### DIFF
--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -468,8 +468,9 @@ module Mode_conf = struct
           ~eq:(fun (a, _) (b, _) -> equal a b)
           ~parse:(fun ~loc s ->
             let mode =
-              Dune_lang.Decoder.parse decode
-                (Dune_project.parsing_context project)
+              Dune_lang.Decoder.parse
+                (Dune_project.set_parsing_context project decode)
+                Univ_map.empty
                 (Atom (loc, Dune_lang.Atom.of_string s))
             in
             (mode, Kind.Requested loc))

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -159,8 +159,6 @@ let equal = ( == )
 
 let hash = Poly.hash
 
-let parsing_context t = t.parsing_context
-
 let packages t = t.packages
 
 let version t = t.version

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -78,8 +78,6 @@ val equal : t -> t -> bool
 
 val hash : t -> int
 
-val parsing_context : t -> Univ_map.t
-
 (** Return the path of the project file. *)
 val file : t -> Path.Source.t
 


### PR DESCRIPTION
Dune_project.set_parsing_context already exists

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ae93884b-5585-4b50-9bd2-3d103f5cbda5 -->