### PR TITLE
refactor: move warnings outside of dune project

### DIFF
--- a/bin/dune_init.ml
+++ b/bin/dune_init.ml
@@ -165,8 +165,8 @@ module Init_context = struct
   let make path =
     let open Memo.O in
     let+ project =
-      Dune_project.load ~dir:Path.Source.root ~files:String.Set.empty
-        ~infer_from_opam_files:true ~dir_status:Normal
+      Dune_project.load ~dir:Path.Source.root ~files:Filename.Set.empty
+        ~infer_from_opam_files:true
       >>| function
       | Some p -> p
       | None -> Dune_project.anonymous ~dir:Path.Source.root ()

--- a/bin/subst.ml
+++ b/bin/subst.ml
@@ -135,12 +135,7 @@ module Dune_project = struct
 
   let load ~dir ~files ~infer_from_opam_files =
     let open Memo.O in
-    let+ project =
-      (* dir_status only affects warning status, but it will not matter here.
-         dune subst will fail with a hard error if the name is missing *)
-      let dir_status = Sub_dirs.Status.Normal in
-      Dune_project.load ~dir ~files ~infer_from_opam_files ~dir_status
-    in
+    let+ project = Dune_project.load ~dir ~files ~infer_from_opam_files in
     let open Option.O in
     let* project = project in
     let file =

--- a/src/dune_rules/dune_project.mli
+++ b/src/dune_rules/dune_project.mli
@@ -134,7 +134,6 @@ val load :
      dir:Path.Source.t
   -> files:Filename.Set.t
   -> infer_from_opam_files:bool
-  -> dir_status:Sub_dirs.Status.t
   -> t option Memo.t
 
 (** Create an anonymous project at the given directory
@@ -200,6 +199,8 @@ val encode : t -> Dune_lang.t list
 val dune_site_extension : unit Extension.t
 
 val opam_file_location : t -> [ `Relative_to_project | `Inside_opam_directory ]
+
+val allow_approximate_merlin : t -> Loc.t option
 
 module Melange_syntax : sig
   val name : string

--- a/src/dune_rules/source_tree.ml
+++ b/src/dune_rules/source_tree.ml
@@ -602,7 +602,7 @@ end = struct
     in
     let* project =
       Dune_project.load ~dir:path ~files:readdir.files
-        ~infer_from_opam_files:true ~dir_status
+        ~infer_from_opam_files:true
       >>| function
       | None -> Dune_project.anonymous ~dir:path ()
       | Some p -> p
@@ -662,7 +662,7 @@ end = struct
           else
             let+ project =
               Dune_project.load ~dir:path ~files:readdir.files
-                ~infer_from_opam_files:false ~dir_status
+                ~infer_from_opam_files:false
             in
             Option.value project ~default:parent_dir.project
         in

--- a/test/blackbox-tests/test-cases/external-lib-deps/exclude-internal-deps.t/dune-project
+++ b/test/blackbox-tests/test-cases/external-lib-deps/exclude-internal-deps.t/dune-project
@@ -1,3 +1,2 @@
 (lang dune 1.9)
 (name foo)
-(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/dune-project
+++ b/test/blackbox-tests/test-cases/external-lib-deps/simple-pps.t/dune-project
@@ -1,4 +1,2 @@
 (lang dune 1.9)
 (name foo)
-
-(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/include-subdirs/test4.t/dune-project
+++ b/test/blackbox-tests/test-cases/include-subdirs/test4.t/dune-project
@@ -1,3 +1,1 @@
 (lang dune 1.9)
-
-(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/meta-gen.t/dune-project
+++ b/test/blackbox-tests/test-cases/meta-gen.t/dune-project
@@ -1,3 +1,1 @@
 (lang dune 1.9)
-
-(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/ppx-driver/basic.t/dune-project
+++ b/test/blackbox-tests/test-cases/ppx-driver/basic.t/dune-project
@@ -1,3 +1,1 @@
 (lang dune 1.10)
-
-(allow_approximate_merlin)

--- a/test/blackbox-tests/test-cases/ppx-driver/installed.t/replaces/dune-project
+++ b/test/blackbox-tests/test-cases/ppx-driver/installed.t/replaces/dune-project
@@ -1,3 +1,1 @@
 (lang dune 1.9)
-
-(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/reason.t/dune-project
+++ b/test/blackbox-tests/test-cases/reason.t/dune-project
@@ -1,3 +1,1 @@
 (lang dune 1.9)
-
-(allow_approximate_merlin true)

--- a/test/blackbox-tests/test-cases/unused-preprocessor-deps.t/run.t
+++ b/test/blackbox-tests/test-cases/unused-preprocessor-deps.t/run.t
@@ -4,7 +4,6 @@ Should warn.
   $ touch a.ml b.ml
 
   $ echo "(lang dune 1.11)" > dune-project
-  $ echo "(allow_approximate_merlin)" >> dune-project
   $ dune build
   File "dune", line 5, characters 1-39:
   5 |  (preprocessor_deps does-not-exist.txt))


### PR DESCRIPTION
vendored_dirs is going to be interpreted per context, so it's wrong to
do it when parsing dune projects (which are the same for all contexts)

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 92554381-324c-4d77-993d-1c4c6ea4ac7f -->