### PR TITLE
fix: correctly generate .install files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,10 @@ Unreleased
 - Allow `(package ...)` in any position within `(rule ...)` stanza (#7445,
   @Leonidas-from-XIV)
 
+- Always include `opam` files in the generated `.install` file. Previously, it
+  would not be included whenever `(generate_opam_files true)` was set and the
+  `.install` file wasn't yet generated. (#7547, @rgrinberg)
+
 3.7.1 (2023-04-04)
 ------------------
 

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -10,16 +10,14 @@ let install_file ~(package : Package.Name.t) ~findlib_toolchain =
 
 module Package_paths = struct
   let opam_file (ctx : Context.t) (pkg : Package.t) =
-    match pkg.has_opam_file with
-    | Exists false -> Memo.return None
-    | Exists true ->
-      Memo.return
-      @@ Some (Path.Build.append_source ctx.build_dir (Package.opam_file pkg))
-    | Look_inside_opam_dir -> (
-      let opam_file = Package.opam_file pkg in
-      Source_tree.file_exists opam_file >>| function
-      | true -> Some (Path.Build.append_source ctx.build_dir opam_file)
-      | false -> None)
+    let opam_file = Package.opam_file pkg in
+    let exists =
+      match pkg.has_opam_file with
+      | Exists b -> b
+      | Generated -> true
+    in
+    if exists then Some (Path.Build.append_source ctx.build_dir opam_file)
+    else None
 
   let meta_file (ctx : Context.t) pkg =
     Path.Build.append_source ctx.build_dir (Package.meta_file pkg)
@@ -419,7 +417,7 @@ end = struct
     let+ init =
       Package.Name.Map_traversals.parallel_map packages
         ~f:(fun _name (pkg : Package.t) ->
-          let* opam_file = Package_paths.opam_file ctx pkg in
+          let opam_file = Package_paths.opam_file ctx pkg in
           let init =
             let file section local_file dst =
               Install.Entry.make section local_file ~kind:`File ~dst

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -549,7 +549,7 @@ end
 
 type opam_file =
   | Exists of bool
-  | Look_inside_opam_dir
+  | Generated
 
 type t =
   { id : Id.t
@@ -579,10 +579,7 @@ let name t = t.id.name
 let dir t = t.id.dir
 
 let set_inside_opam_dir t ~dir =
-  { t with
-    has_opam_file = Look_inside_opam_dir
-  ; opam_file = Path.Source.relative dir (Name.opam_fn t.id.name)
-  }
+  { t with opam_file = Path.Source.relative dir (Name.opam_fn t.id.name) }
 
 let encode (name : Name.t)
     { id = _
@@ -687,7 +684,7 @@ let dyn_of_opam_file =
   let open Dyn in
   function
   | Exists b -> variant "Exists" [ bool b ]
-  | Look_inside_opam_dir -> variant "Look_inside_opam_dir" []
+  | Generated -> variant "Generated" []
 
 let to_dyn
     { id

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -142,7 +142,7 @@ end
 
 type opam_file =
   | Exists of bool
-  | Look_inside_opam_dir
+  | Generated
 
 type t =
   { id : Id.t

--- a/test/blackbox-tests/test-cases/dune-project-meta/fresh-build.t
+++ b/test/blackbox-tests/test-cases/dune-project-meta/fresh-build.t
@@ -16,7 +16,7 @@ source tree if (generate_opam_files true) is enabled.
 
   $ dune build foo.install
   $ grep opam _build/default/foo.install
-  [1]
+    "_build/install/default/lib/foo/opam"
 
   $ dune build @check
   $ dune build foo.install

--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail.t
@@ -153,6 +153,7 @@ This is not allowed in toplevels, so it fails.
   $ dune install --prefix _install --display short
   Installing _install/lib/top-plugin1/META
   Installing _install/lib/top-plugin1/dune-package
+  Installing _install/lib/top-plugin1/opam
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cma
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cmi
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cmt
@@ -160,6 +161,7 @@ This is not allowed in toplevels, so it fails.
   Installing _install/lib/top_with_plugins/top_plugins/plugin1/META
   Installing _install/lib/top-plugin2/META
   Installing _install/lib/top-plugin2/dune-package
+  Installing _install/lib/top-plugin2/opam
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cma
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cmi
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cmt

--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail2.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin-fail2.t
@@ -154,6 +154,7 @@ This is not allowed in toplevels, so it fails.
   $ dune install --prefix _install --display short
   Installing _install/lib/top-plugin1/META
   Installing _install/lib/top-plugin1/dune-package
+  Installing _install/lib/top-plugin1/opam
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cma
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cmi
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cmt
@@ -161,6 +162,7 @@ This is not allowed in toplevels, so it fails.
   Installing _install/lib/top_with_plugins/top_plugins/plugin1/META
   Installing _install/lib/top-plugin2/META
   Installing _install/lib/top-plugin2/dune-package
+  Installing _install/lib/top-plugin2/opam
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cma
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cmi
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cmt

--- a/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin.t
+++ b/test/blackbox-tests/test-cases/toplevel-plugin/toplevel-plugin.t
@@ -151,6 +151,7 @@ Testsuite for (toplevel that loads plugins).
   $ dune install --prefix _install --display short
   Installing _install/lib/top-plugin1/META
   Installing _install/lib/top-plugin1/dune-package
+  Installing _install/lib/top-plugin1/opam
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cma
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cmi
   Installing _install/lib/top-plugin1/plugin1_impl/plugin1_impl.cmt
@@ -158,6 +159,7 @@ Testsuite for (toplevel that loads plugins).
   Installing _install/lib/top_with_plugins/top_plugins/plugin1/META
   Installing _install/lib/top-plugin2/META
   Installing _install/lib/top-plugin2/dune-package
+  Installing _install/lib/top-plugin2/opam
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cma
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cmi
   Installing _install/lib/top-plugin2/plugin2_impl/plugin2_impl.cmt


### PR DESCRIPTION
Previously, the contents of the .install file would depend on whether
the .opam install file would be present in the source.

This check is wrong whenever we generate the .opam file ourselves. This
commit checks if we are generating the .opam file.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ce2222c8-7d98-418a-9345-340bdaa32baf -->