### PR TITLE
refactor: remove some cruft from Source_tree

### DIFF
--- a/src/dune_rules/source_tree.mli
+++ b/src/dune_rules/source_tree.mli
@@ -94,12 +94,3 @@ val is_vendored : Path.Source.t -> bool Memo.t
 
 (** [true] iff the path is a file *)
 val file_exists : Path.Source.t -> bool Memo.t
-
-(**/**)
-
-(* Hook to describe how to filter source files. This can be used by forks of
-   Dune to implement different filtering strategies.
-
-   This is currently used inside Jane Street. *)
-val filter_source_files :
-  (Dune_project.t -> (Path.Source.t -> Filename.t -> bool) Memo.t) ref


### PR DESCRIPTION
The soure tree contained some hacks for janestreet specific
customization. We no longer share this module, so these hooks aren't
necessary.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d7c00f93-b8d5-4c2e-bad5-a025a0c9321e -->