### PR TITLE
Add watch-mode benchmarks of dune monorepo

### DIFF
--- a/bench/monorepo/Makefile
+++ b/bench/monorepo/Makefile
@@ -1,12 +1,11 @@
-# Intended to be used from inside docker containers built from monorepo-bench.Dockerfile
-RUNNER = _build/default/bench.exe
-DUNE_TO_BENCHMARK = /home/user/dune/_build/default/bin/main.exe
+# Intended to be used from inside docker containers built from bench.Dockerfile
+RUNNER = /home/user/monorepo-benchmark/dune-benchmark-runner/_build/default/src/main.exe
+DUNE_EXE_PATH = /home/user/dune/_build/default/bin/main.exe
+BUILD_TARGET = ./monorepo_bench.exe
+MONOREPO_PATH = /home/user/monorepo-benchmark/benchmark
 
-$(RUNNER): dune bench.ml
-	dune build $@ --release
-
-bench: $(RUNNER)
-	$< $(DUNE_TO_BENCHMARK) build -j auto
+bench:
+	$(RUNNER) --dune-exe-path=$(DUNE_EXE_PATH) --build-target=$(BUILD_TARGET) --monorepo-path=$(MONOREPO_PATH) --print-dune-output
 
 clean:
 	dune clean

--- a/bench/monorepo/README.md
+++ b/bench/monorepo/README.md
@@ -7,7 +7,13 @@ to be consumed by current-bench.
 
 The monorepo will be set up with opam-monorepo using the lockfile
 [here](https://github.com/ocaml-dune/ocaml-monorepo-benchmark/blob/main/benchmark/monorepo-bench.opam.locked)
-which is downloaded during `docker build`. Also during `docker build`,
-a a library is created called `monorepo` with
+which is downloaded during `docker build`. Also during `docker build`, an
+executable dune project is created called `monorepo_bench` with
 [this](https://github.com/ocaml-dune/ocaml-monorepo-benchmark/blob/main/benchmark/dune)
 dune file listing all the libraries to include in the build.
+
+The benchmark runner is a program which invokes dune in a number of
+benchmarking scenarios and prints out the results in a format understood by
+[current-bench](https://github.com/ocurrent/current-bench). The source code for
+the benchmark runner is
+[here](https://github.com/ocaml-dune/ocaml-monorepo-benchmark/tree/main/dune-benchmark-runner).

--- a/bench/monorepo/bench.Dockerfile
+++ b/bench/monorepo/bench.Dockerfile
@@ -113,6 +113,8 @@ RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   qtdeclarative5-dev \
   libgpiod-dev \
   libzstd-dev \
+  neovim \
+  tmux \
   ;
 
 # create a non-root user
@@ -131,16 +133,15 @@ RUN opam install -y dune ocamlbuild
 
 # make an opam switch for preparing the files for the benchmark
 RUN opam switch create prepare 4.14.1
-RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl
-
-# Make a directory to store the monorepo benchmark project
-RUN mkdir -p $HOME/monorepo-bench
+RUN opam install -y opam-monorepo ppx_sexp_conv ocamlfind ctypes ctypes-foreign re sexplib menhir camlp-streams zarith stdcompat refl yojson logs fmt
 
 # Download the monorepo benchmark and copy files into the benchmark project
-ENV MONOREPO_BENCHMARK_TAG=2023-03-16.0
-RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && tar xf ocaml-monorepo-benchmark.tar.gz && mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG ocaml-monorepo-benchmark
-WORKDIR $HOME/monorepo-bench
-RUN mkdir -p monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/dune $HOME/ocaml-monorepo-benchmark/benchmark/monorepo.ml monorepo && cp -r $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam $HOME/ocaml-monorepo-benchmark/benchmark/monorepo-bench.opam.locked $HOME/ocaml-monorepo-benchmark/benchmark/patches .
+ENV MONOREPO_BENCHMARK_TAG=2023-04-20.0
+RUN wget https://github.com/ocaml-dune/ocaml-monorepo-benchmark/archive/refs/tags/$MONOREPO_BENCHMARK_TAG.tar.gz -O ocaml-monorepo-benchmark.tar.gz && \
+  tar xf ocaml-monorepo-benchmark.tar.gz && \
+  mv ocaml-monorepo-benchmark-$MONOREPO_BENCHMARK_TAG monorepo-benchmark
+
+WORKDIR $HOME/monorepo-benchmark/benchmark
 
 # Running `opam monorepo pull` with a large package set is very likely to fail on at least
 # one package in a non-deterministic manner. Repeating it several times reduces the chance
@@ -159,21 +160,43 @@ RUN cd duniverse/batsat-ocaml && ./build_rust.sh
 RUN rm -r duniverse/coq-of-ocaml
 RUN rm -r duniverse/coq
 
-# Bulid the dune binary that we'll be benchmarking
+# Build the dune binary that we'll be benchmarking.
+# Only copy the files needed to build dune so that changes to other files in this project
+# don't cause the docker image cache to be invalidated.
 RUN mkdir -p $HOME/dune
 WORKDIR $HOME/dune
-ADD --chown=user:users . .
+COPY --chown=user:users bin bin
+COPY --chown=user:users src src
+COPY --chown=user:users otherlibs otherlibs
+COPY --chown=user:users vendor vendor
+COPY --chown=user:users dune-project dune-project
+COPY --chown=user:users dune-file dune-file
+COPY --chown=user:users dune-rpc.opam dune-rpc.opam
+COPY --chown=user:users dune-rpc-lwt.opam dune-rpc-lwt.opam
+COPY --chown=user:users dune-private-libs.opam.template dune-private-libs.opam.template
 RUN . ~/.profile && dune build bin/main.exe --release
-
-# Copy the remaininder of the files needed for the monorepo benchmark
-WORKDIR $HOME/monorepo-bench
-COPY --chown=user:users bench/monorepo/bench.ml .
-COPY --chown=user:users bench/monorepo/Makefile .
-COPY --chown=user:users bench/monorepo/dune .
-COPY --chown=user:users bench/monorepo/dune-project .
+RUN . ~/.profile && opam pin add dune-rpc /home/user/dune -y
+RUN . ~/.profile && opam pin add dune-rpc-lwt /home/user/dune -y
+RUN . ~/.profile && opam reinstall dune-rpc dune-rpc-lwt -y --working-dir
 
 # Apply some custom packages to some packages
+WORKDIR $HOME/monorepo-benchmark/benchmark
 RUN bash -c 'for f in patches/*; do p=$(basename ${f%.diff}); patch -p1 -d duniverse/$p < $f; done'
+
+# Setting PREBUILD will build the monorepo during `docker build` which can be useful for speeding up interactive experiments
+ENV PREBUILD=
+RUN opam switch bench && \
+    . ~/.profile && \
+    bash -c 'if [ "$PREBUILD" != "" ]; then /home/user/dune/_build/default/bin/main.exe build ./monorepo_bench.exe -j auto; fi' && \
+    opam switch prepare
+
+# Copy the custom makefile into the project
+COPY --chown=user:users bench/monorepo/Makefile .
+
+# Build the benchmark runner
+RUN . ~/.profile && \
+    cd /home/user/monorepo-benchmark/dune-benchmark-runner && \
+    dune build src/main.exe --release
 
 # Change to the benchmarking switch to run the benchmark
 RUN opam switch bench

--- a/bench/monorepo/dune
+++ b/bench/monorepo/dune
@@ -1,4 +1,0 @@
-(executable
- (public_name bench)
- (modules bench)
- (libraries unix))

--- a/bench/monorepo/dune-project
+++ b/bench/monorepo/dune-project
@@ -1,2 +1,0 @@
-(lang dune 3.5)
-(package (name monorepo-bench))

--- a/bin/build_cmd.ml
+++ b/bin/build_cmd.ml
@@ -108,6 +108,12 @@ let run_build_command_poll_eager ~(common : Common.t) ~config ~request : unit =
   let { Eager_watch_mode_build_complete_trace.before; after } =
     Eager_watch_mode_build_complete_trace.create common
   in
+  let after () =
+    after ();
+    match Common.rpc common with
+    | `Allow server -> Dune_rpc_impl.Server.report_build_complete server
+    | `Forbid_builds -> ()
+  in
   Scheduler.go_with_rpc_server_and_console_status_reporting ~common ~config
     (fun () ->
       Scheduler.Run.poll_hooks ~before ~after

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -1,132 +1,128 @@
-open Dune_rpc.V1
 open Lwt.Syntax
 
-module V1 = struct
-  module Fiber = struct
-    include Lwt
+module Fiber = struct
+  include Lwt
 
-    let fork_and_join_unit (x : unit -> unit Lwt.t) y =
-      let open Lwt in
-      Lwt.both (x ()) (y ()) >|= snd
+  let fork_and_join_unit (x : unit -> unit Lwt.t) y =
+    let open Lwt in
+    Lwt.both (x ()) (y ()) >|= snd
 
-    let finalize f ~finally = Lwt.finalize f finally
+  let finalize f ~finally = Lwt.finalize f finally
 
-    let rec parallel_iter ls ~f =
-      let open Lwt.Syntax in
-      let* res = ls () in
-      match res with
-      | None -> Lwt.return_unit
-      | Some x ->
-        let+ () = f x
-        and+ () = parallel_iter ls ~f in
-        ()
+  let rec parallel_iter ls ~f =
+    let open Lwt.Syntax in
+    let* res = ls () in
+    match res with
+    | None -> Lwt.return_unit
+    | Some x ->
+      let+ () = f x
+      and+ () = parallel_iter ls ~f in
+      ()
 
-    module Ivar = struct
-      type 'a t = 'a Lwt.t * 'a Lwt.u
+  module Ivar = struct
+    type 'a t = 'a Lwt.t * 'a Lwt.u
 
-      let create () = Lwt.task ()
+    let create () = Lwt.task ()
 
-      let fill (_, u) x =
-        Lwt.wakeup u x;
-        Lwt.return_unit
+    let fill (_, u) x =
+      Lwt.wakeup u x;
+      Lwt.return_unit
 
-      let read (x, _) = x
-    end
-
-    module O = Syntax
+    let read (x, _) = x
   end
 
-  module Client =
-    Client.Make
-      (Fiber)
-      (struct
-        type t = Lwt_io.input_channel * Lwt_io.output_channel
+  module O = Syntax
+end
 
-        let read (i, o) =
-          (* The input and output channels share the same file descriptor. If
-             the output channel has been closed, reading from the input channel
-             will result in an error. *)
-          let is_channel_closed () = Lwt_io.is_closed o in
-          let open Csexp.Parser in
-          let lexer = Lexer.create () in
-          let rec loop depth stack =
+module Chan = struct
+  type t = Lwt_io.input_channel * Lwt_io.output_channel
+
+  let read (i, o) =
+    (* The input and output channels share the same file descriptor. If
+       the output channel has been closed, reading from the input channel
+       will result in an error. *)
+    let is_channel_closed () = Lwt_io.is_closed o in
+    let open Csexp.Parser in
+    let lexer = Lexer.create () in
+    let rec loop depth stack =
+      if is_channel_closed () then (
+        Lexer.feed_eoi lexer;
+        Lwt.return_none)
+      else
+        let* res = Lwt_io.read_char_opt i in
+        match res with
+        | None ->
+          Lexer.feed_eoi lexer;
+          Lwt.return_none
+        | Some c -> (
+          match Lexer.feed lexer c with
+          | Await -> loop depth stack
+          | Lparen -> loop (depth + 1) (Stack.open_paren stack)
+          | Rparen ->
+            let stack = Stack.close_paren stack in
+            let depth = depth - 1 in
+            if depth = 0 then
+              let sexps = Stack.to_list stack in
+              sexps |> List.hd |> Lwt.return_some
+            else loop depth stack
+          | Atom count ->
             if is_channel_closed () then (
               Lexer.feed_eoi lexer;
               Lwt.return_none)
             else
-              let* res = Lwt_io.read_char_opt i in
-              match res with
-              | None ->
-                Lexer.feed_eoi lexer;
-                Lwt.return_none
-              | Some c -> (
-                match Lexer.feed lexer c with
-                | Await -> loop depth stack
-                | Lparen -> loop (depth + 1) (Stack.open_paren stack)
-                | Rparen ->
-                  let stack = Stack.close_paren stack in
-                  let depth = depth - 1 in
-                  if depth = 0 then
-                    let sexps = Stack.to_list stack in
-                    sexps |> List.hd |> Lwt.return_some
-                  else loop depth stack
-                | Atom count ->
-                  if is_channel_closed () then (
-                    Lexer.feed_eoi lexer;
-                    Lwt.return_none)
-                  else
-                    let* atom =
-                      let bytes = Bytes.create count in
-                      let+ () = Lwt_io.read_into_exactly i bytes 0 count in
-                      Bytes.to_string bytes
-                    in
-                    loop depth (Stack.add_atom atom stack))
-          in
-          loop 0 Stack.Empty
-
-        let write (_, o) = function
-          | None -> Lwt_io.close o
-          | Some csexps ->
-            Lwt_list.iter_s
-              (fun sexp -> Lwt_io.write o (Csexp.to_string sexp))
-              csexps
-      end)
-
-  module Where =
-    Where.Make
-      (Fiber)
-      (struct
-        let read_file s : (string, exn) result Lwt.t =
-          Lwt.catch
-            (fun () ->
-              Lwt_result.ok (Lwt_io.with_file ~mode:Input s Lwt_io.read))
-            Lwt_result.fail
-
-        let analyze_path s =
-          Lwt.try_bind
-            (fun () -> Lwt_unix.stat s)
-            (fun stat ->
-              Lwt.return
-                (match stat.st_kind with
-                | Unix.S_SOCK -> Ok `Unix_socket
-                | S_REG -> Ok `Normal_file
-                | _ -> Ok `Other))
-            (fun e -> Lwt.return (Error e))
-      end)
-
-  let connect_chan where =
-    let+ fd =
-      let domain, sockaddr =
-        match where with
-        | `Unix socket -> (Unix.PF_UNIX, Unix.ADDR_UNIX socket)
-        | `Ip (`Host host, `Port port) ->
-          let addr = Unix.inet_addr_of_string host in
-          (Unix.PF_INET, Unix.ADDR_INET (addr, port))
-      in
-      let fd = Lwt_unix.socket domain Unix.SOCK_STREAM 0 in
-      let+ () = Lwt_unix.connect fd sockaddr in
-      fd
+              let* atom =
+                let bytes = Bytes.create count in
+                let+ () = Lwt_io.read_into_exactly i bytes 0 count in
+                Bytes.to_string bytes
+              in
+              loop depth (Stack.add_atom atom stack))
     in
-    let fd mode = Lwt_io.of_fd fd ~mode in
-    (fd Input, fd Output)
+    loop 0 Stack.Empty
+
+  let write (_, o) = function
+    | None -> Lwt_io.close o
+    | Some csexps ->
+      Lwt_list.iter_s (fun sexp -> Lwt_io.write o (Csexp.to_string sexp)) csexps
+end
+
+module IO = struct
+  let read_file s : (string, exn) result Lwt.t =
+    Lwt.catch
+      (fun () -> Lwt_result.ok (Lwt_io.with_file ~mode:Input s Lwt_io.read))
+      Lwt_result.fail
+
+  let analyze_path s =
+    Lwt.try_bind
+      (fun () -> Lwt_unix.stat s)
+      (fun stat ->
+        Lwt.return
+          (match stat.st_kind with
+          | Unix.S_SOCK -> Ok `Unix_socket
+          | S_REG -> Ok `Normal_file
+          | _ -> Ok `Other))
+      (fun e -> Lwt.return (Error e))
+end
+
+let connect_chan where =
+  let+ fd =
+    let domain, sockaddr =
+      match where with
+      | `Unix socket -> (Unix.PF_UNIX, Unix.ADDR_UNIX socket)
+      | `Ip (`Host host, `Port port) ->
+        let addr = Unix.inet_addr_of_string host in
+        (Unix.PF_INET, Unix.ADDR_INET (addr, port))
+    in
+    let fd = Lwt_unix.socket domain Unix.SOCK_STREAM 0 in
+    let+ () = Lwt_unix.connect fd sockaddr in
+    fd
+  in
+  let fd mode = Lwt_io.of_fd fd ~mode in
+  (fd Input, fd Output)
+
+module V1 = struct
+  open Dune_rpc.V1
+  module Client = Client.Make (Fiber) (Chan)
+  module Where = Where.Make (Fiber) (IO)
+
+  let connect_chan = connect_chan
 end

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.ml
@@ -126,3 +126,11 @@ module V1 = struct
 
   let connect_chan = connect_chan
 end
+
+module Private = struct
+  open Dune_rpc_private
+  module Client = Client.Make (Fiber) (Chan)
+  module Where = Where.Make (Fiber) (IO)
+
+  let connect_chan = connect_chan
+end

--- a/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
+++ b/otherlibs/dune-rpc-lwt/src/dune_rpc_lwt.mli
@@ -11,3 +11,17 @@ module V1 : sig
   val connect_chan :
     Dune_rpc.V1.Where.t -> (Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
 end
+
+module Private : sig
+  open Dune_rpc_private
+
+  module Client :
+    Client.S
+      with type 'a fiber := 'a Lwt.t
+       and type chan := Lwt_io.input_channel * Lwt_io.output_channel
+
+  module Where : Where.S with type 'a fiber := 'a Lwt.t
+
+  val connect_chan :
+    Dune_rpc.V1.Where.t -> (Lwt_io.input_channel * Lwt_io.output_channel) Lwt.t
+end

--- a/otherlibs/dune-rpc/private/dune_rpc_private.ml
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.ml
@@ -26,6 +26,8 @@ module Public = struct
     let promote = Procedures.Public.promote.decl
 
     let build_dir = Procedures.Public.build_dir.decl
+
+    let build_count = Procedures.Public.build_count.decl
   end
 
   module Notification = struct
@@ -623,6 +625,7 @@ module Client = struct
       Builder.declare_request t Procedures.Public.format_dune_file;
       Builder.declare_request t Procedures.Public.promote;
       Builder.declare_request t Procedures.Public.build_dir;
+      Builder.declare_request t Procedures.Public.build_count;
       Builder.implement_notification t Procedures.Server_side.abort (fun () ->
           handler.abort);
       Builder.implement_notification t Procedures.Server_side.log (fun () ->

--- a/otherlibs/dune-rpc/private/dune_rpc_private.mli
+++ b/otherlibs/dune-rpc/private/dune_rpc_private.mli
@@ -227,6 +227,8 @@ module Procedures : sig
     val promote : (Path.t, unit) Decl.Request.t
 
     val build_dir : (unit, Path.t) Decl.Request.t
+
+    val build_count : (unit, int) Decl.Request.t
   end
 
   module Server_side : sig
@@ -280,6 +282,8 @@ module Public : sig
     val promote : (Path.t, unit) t
 
     val build_dir : (unit, Path.t) t
+
+    val build_count : (unit, int) t
   end
 
   module Notification : sig

--- a/otherlibs/dune-rpc/private/procedures.ml
+++ b/otherlibs/dune-rpc/private/procedures.ml
@@ -56,6 +56,13 @@ module Public = struct
     let decl = Decl.Request.make ~method_:"build_dir" ~generations:[ v1 ]
   end
 
+  module Build_count = struct
+    let v1 =
+      Decl.Request.make_current_gen ~req:Conv.unit ~resp:Conv.int ~version:1
+
+    let decl = Decl.Request.make ~method_:"build_count" ~generations:[ v1 ]
+  end
+
   let ping = Ping.decl
 
   let diagnostics = Diagnostics.decl
@@ -67,6 +74,8 @@ module Public = struct
   let promote = Promote.decl
 
   let build_dir = Build_dir.decl
+
+  let build_count = Build_count.decl
 end
 
 module Server_side = struct

--- a/otherlibs/dune-rpc/private/procedures.mli
+++ b/otherlibs/dune-rpc/private/procedures.mli
@@ -14,6 +14,14 @@ module Public : sig
   val promote : (Path.t, unit) Decl.Request.t
 
   val build_dir : (unit, Path.t) Decl.Request.t
+
+  (** Returns the count of the number of builds that have completed since the
+      RPC server started. This is intended to be used to find out when builds
+      are completed by dune when it's running in watch mode (which also runs an
+      RPC server) for the purposes of synchronizing multiple successive changes
+      to files to trigger rebuilds in non-interactive settings such as
+      benchmarks and tests. *)
+  val build_count : (unit, int) Decl.Request.t
 end
 
 module Server_side : sig

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -1182,15 +1182,19 @@ module Run = struct
         Dune_stats.emit stats event;
         Dune_stats.flush stats)
 
-  let poll step =
+  let poll_hooks ~before ~after step =
     let* t = poll_init () in
     let rec loop () =
+      before ();
       let* _res = poll_iter t step in
       run_when_idle t.config.stats;
+      after ();
       let* () = wait_for_build_input_change t in
       loop ()
     in
     loop ()
+
+  let poll = poll_hooks ~before:(fun () -> ()) ~after:(fun () -> ())
 
   let poll_passive ~get_build_request =
     let* t = poll_init () in

--- a/src/dune_engine/scheduler.mli
+++ b/src/dune_engine/scheduler.mli
@@ -57,6 +57,16 @@ module Run : sig
       will not start. *)
   val poll : step -> unit Fiber.t
 
+  (** [poll_hooks ~before ~after once] behaves the same as [poll once] except
+      that the hooks [before] and [after] are called respectively before and
+      after each invocation of [once].
+
+      If any source files change in the middle of an iteration, the iteration is
+      restarted but neither [before] nor [after] are called again. [after] is
+      only called after an iteration has run to completion. *)
+  val poll_hooks :
+    before:(unit -> unit) -> after:(unit -> unit) -> step -> unit Fiber.t
+
   (** [poll_passive] is similar to [poll], but it can be used to drive the
       polling loop explicitly instead of starting new iterations automatically.
 

--- a/src/dune_rpc_impl/server.mli
+++ b/src/dune_rpc_impl/server.mli
@@ -29,3 +29,7 @@ val ready : t -> unit Fiber.t
 val run : t -> unit Fiber.t
 
 val action_runner : t -> Dune_engine.Action_runner.Rpc_server.t
+
+(** Call this when a build completes to increment the server's internal count of
+    completed builds. *)
+val report_build_complete : t -> unit


### PR DESCRIPTION
This updates the monorepo benchmark to invoke the external benchmark runner [here](https://github.com/ocaml-dune/ocaml-monorepo-benchmark/tree/main/dune-benchmark-runner). It works by adding a new trace-file entry for builds in eager watch mode and adding an RPC which returns the number of builds that have completed since the RPC server started which is used by the benchmark runner to run dune in watch mode and sequentially change files and wait for builds to complete. See the commit descriptions for details about each part.

The scenarios implemented by the runner and sample output:
```
{
  "results": [
    {
      "name": "dune monorepo benchmarks",
      "metrics": [
        {
          "name": "build from scratch",
          "value": 616.247878074646,
          "units": "sec"
        },
        { "name": "null build", "value": 32.72038006782532, "units": "sec" },
        {
          "name": "watch mode: initial build",
          "value": 34.548771,
          "units": "sec"
        },
        {
          "name": "watch mode: changing file in 'base' library",
          "value": 53.681128,
          "units": "sec"
        },
        {
          "name": "watch mode: introducing error in file in 'base' library",
          "value": 29.321947,
          "units": "sec"
        },
        {
          "name": "watch mode: fixing error in file in 'base' library",
          "value": 54.447027,
          "units": "sec"
        },
        {
          "name": "watch mode: changing file in 'file_path' library",
          "value": 37.868993,
          "units": "sec"
        },
        {
          "name": "watch mode: introducing error in file in 'file_path' library",
          "value": 33.622908,
          "units": "sec"
        },
        {
          "name": "watch mode: fixing error in file in 'file_path' library",
          "value": 37.516952,
          "units": "sec"
        }
      ]
    }
  ]
}
```

Note that when running the benchmarks from the `monorepo-benchmarks` branch you'll currently get this error:
```
File "duniverse/ppxlib/traverse/dune", line 9, characters 7-22:
9 |   (pps ppxlib_metaquot)))
           ^^^^^^^^^^^^^^^
Error: Library "ppxlib_metaquot" not found.
```

This is a known issue: https://github.com/ocaml/dune/issues/7543. The temporary workaround is to revert commit 16a7e883ef2b2283f8a636fbf2c8bade3da92754.