### PR TITLE
test: demonstrate regression depending on a ppx by its private name

### DIFF
--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -80,7 +80,7 @@ let set_local_env_var t ~var ~value =
 
 let set_dir t ~dir = { t with dir }
 
-let set_scope t ~scope = { t with scope }
+let set_scope t ~scope ~scope_host = { t with scope; scope_host }
 
 let set_bin_artifacts t ~bin_artifacts_host = { t with bin_artifacts_host }
 

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -32,7 +32,7 @@ val set_local_env_var : t -> var:string -> value:string Action_builder.t -> t
 
 val set_dir : t -> dir:Path.Build.t -> t
 
-val set_scope : t -> scope:Scope.t -> t
+val set_scope : t -> scope:Scope.t -> scope_host:Scope.t -> t
 
 val set_bin_artifacts : t -> bin_artifacts_host:Artifacts.Bin.t -> t
 

--- a/test/blackbox-tests/test-cases/ppx-runtime-lib-scope.t
+++ b/test/blackbox-tests/test-cases/ppx-runtime-lib-scope.t
@@ -1,0 +1,69 @@
+Create ppx1, ppx2 and exe:
+- ppx1 is a regular ppx rewriter
+- ppx2 is also a ppx rewriter, preprocessed with ppx1
+- exe depends on ppx2
+
+  $ mkdir -p project/ppx/ppx1 project/ppx/ppx2 project/exe
+  $ cat > project/ppx/dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name the-ppx))
+  > EOF
+  $ cat > project/ppx/ppx1/dune <<EOF
+  > (library
+  >  (name ppx1)
+  >  (public_name the-ppx.ppx1)
+  >  (kind ppx_rewriter)
+  >  (ppx.driver (main Ppx1.main)))
+  > EOF
+  $ cat > project/ppx/ppx1/ppx1.ml <<EOF
+  > let main () =
+  >   let out = ref "" in
+  >   let args =
+  >     [ ("-o", Arg.Set_string out, "")
+  >     ; ("--impl", Arg.Set_string (ref ""), "")
+  >     ; ("--as-ppx", Arg.Set (ref false), "")
+  >     ; ("--cookie", Arg.Set (ref false), "")
+  >     ]
+  >   in
+  >   let anon _ = () in
+  >   Arg.parse (Arg.align args) anon "";
+  >   let out = open_out !out in
+  >   close_out out;
+  > EOF
+  $ cat > project/ppx/ppx2/dune <<EOF
+  > (library
+  >  (name ppx2)
+  >  (public_name the-ppx.ppx2)
+  >  (preprocess (pps ppx1)) ; changing to the-ppx.ppx1 makes it work
+  >  (kind ppx_rewriter))
+  > EOF
+  $ cat > project/ppx/ppx2/ppx2.ml <<EOF
+  > let main () = ()
+  > EOF
+
+  $ cat > project/dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name the-exe))
+  > EOF
+  $ cat > project/exe/dune <<EOF
+  > (executable
+  >  (name the_exe)
+  >  (public_name the-exe)
+  >  (libraries the-ppx.ppx2))
+  > EOF
+  $ touch project/exe/the_exe.ml
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root project --display short ./exe/the_exe.exe
+  Entering directory 'project'
+  File "ppx/ppx2/dune", line 4, characters 18-22:
+  4 |  (preprocess (pps ppx1)) ; changing to the-ppx.ppx1 makes it work
+                        ^^^^
+  Error: Library "ppx1" not found.
+  -> required by _build/default/ppx/ppx2/ppx2.pp.ml
+  -> required by _build/default/ppx/ppx2/.ppx2.objs/byte/ppx2.cmi
+  -> required by _build/default/exe/.the_exe.eobjs/byte/dune__exe__The_exe.cmi
+  -> required by
+     _build/default/exe/.the_exe.eobjs/native/dune__exe__The_exe.cmx
+  -> required by _build/default/exe/the_exe.exe
+  Leaving directory 'project'
+  [1]

--- a/test/blackbox-tests/test-cases/ppx-runtime-lib-scope.t
+++ b/test/blackbox-tests/test-cases/ppx-runtime-lib-scope.t
@@ -53,17 +53,6 @@ Create ppx1, ppx2 and exe:
   > EOF
   $ touch project/exe/the_exe.ml
 
-  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root project --display short ./exe/the_exe.exe
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root project ./exe/the_exe.exe
   Entering directory 'project'
-  File "ppx/ppx2/dune", line 4, characters 18-22:
-  4 |  (preprocess (pps ppx1)) ; changing to the-ppx.ppx1 makes it work
-                        ^^^^
-  Error: Library "ppx1" not found.
-  -> required by _build/default/ppx/ppx2/ppx2.pp.ml
-  -> required by _build/default/ppx/ppx2/.ppx2.objs/byte/ppx2.cmi
-  -> required by _build/default/exe/.the_exe.eobjs/byte/dune__exe__The_exe.cmi
-  -> required by
-     _build/default/exe/.the_exe.eobjs/native/dune__exe__The_exe.cmx
-  -> required by _build/default/exe/the_exe.exe
   Leaving directory 'project'
-  [1]


### PR DESCRIPTION
- Reproduces https://github.com/ocaml/dune/issues/7543 and is a lighter weight alternative to https://github.com/ocaml/dune/pull/7544
- the issue seems to be about depending on the private name of a ppx within the same scope
  - this was possible before #7415, and is now broken