### PR TITLE
refactor: remove vcs from source tree

### DIFF
--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -95,12 +95,7 @@ let conf_of_context (context : Context.t option) =
       Hardcoded (install_dir :: context.default_ocamlpath)
     in
     let sign_hook = lazy (sign_hook_of_context context) in
-    { get_vcs = Source_tree.nearest_vcs
-    ; get_location
-    ; get_config_path
-    ; hardcoded_ocaml_path
-    ; sign_hook
-    }
+    { get_vcs; get_location; get_config_path; hardcoded_ocaml_path; sign_hook }
 
 let conf_for_install ~relocatable ~roots ~(context : Context.t) =
   let get_vcs = Source_tree.nearest_vcs in

--- a/src/dune_rules/source_tree.mli
+++ b/src/dune_rules/source_tree.mli
@@ -80,11 +80,11 @@ val find_dir : Path.Source.t -> Dir.t option Memo.t
     ancestor of [fn]. *)
 val nearest_dir : Path.Source.t -> Dir.t Memo.t
 
-(** [nearest_vcs t fn] returns the version control system with the longest root
-    path that is an ancestor of [fn]. *)
-val nearest_vcs : Path.Source.t -> Vcs.t option Memo.t
-
 val files_of : Path.Source.t -> Path.Source.Set.t Memo.t
 
 (** [true] iff the path is a vendored directory *)
 val is_vendored : Path.Source.t -> bool Memo.t
+
+(** [nearest_vcs t fn] returns the version control system with the longest root
+    path that is an ancestor of [fn]. *)
+val nearest_vcs : Path.Source.t -> Vcs.t option Memo.t

--- a/src/dune_vcs/vcs.ml
+++ b/src/dune_vcs/vcs.ml
@@ -7,10 +7,17 @@ module Kind = struct
     | Git
     | Hg
 
-  let of_dir_contents files =
-    if Filename.Set.mem files ".git" then Some Git
-    else if Filename.Set.mem files ".hg" then Some Hg
-    else None
+  let of_dir_name = function
+    | ".git" -> Some Git
+    | ".hg" -> Some Hg
+    | _ -> None
+
+  let of_dir_contents set =
+    match
+      Filename.Set.find set ~f:(fun s -> Option.is_some (of_dir_name s))
+    with
+    | None -> None
+    | Some s -> Some (Option.value_exn (of_dir_name s))
 
   let to_dyn t =
     Dyn.Variant

--- a/src/dune_vcs/vcs.mli
+++ b/src/dune_vcs/vcs.mli
@@ -7,6 +7,8 @@ module Kind : sig
     | Git
     | Hg
 
+  val of_dir_name : Filename.t -> t option
+
   val of_dir_contents : Filename.Set.t -> t option
 end
 


### PR DESCRIPTION
It can be implemented on top of more primitive source tree functionality
and is not worth storing as its computed quickly.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 394a99df-53af-481a-a298-9925beba384d -->