### PR TITLE
test: demonstrate crash in link-time codegen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Fix plugin loading with findlib. The functionality was broken in 3.7.0.
+  (#7556, @anmonteiro)
+
 - Introduce a `public_headers` field on libraries. This field is like
   `install_c_headers`, but it allows to choose the extension and choose the
   paths for the installed headers. (#7512, @rgrinberg)

--- a/test/blackbox-tests/test-cases/builtin-support-override.t
+++ b/test/blackbox-tests/test-cases/builtin-support-override.t
@@ -1,0 +1,40 @@
+Create a library called `findlib.dynload`
+
+  $ mkdir findlib
+  $ cat > findlib/dune-project <<EOF
+  > (lang dune 3.7)
+  > (package (name findlib))
+  > EOF
+  $ cat > findlib/dune <<EOF
+  > (library
+  >   (name findlib_dynload)
+  >   (public_name findlib.dynload)
+  >   (wrapped false)
+  >   (special_builtin_support findlib_dynload))
+  > EOF
+  $ touch findlib/fl_dynload.ml
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name foo_dynload)
+  >  (libraries findlib.dynload))
+  > EOF
+  $ touch lib/foo_dynload.ml
+
+  $ mkdir exe
+  $ cat > exe/dune <<EOF
+  > (executable
+  >  (name the_exe)
+  >  (libraries foo_dynload))
+  > EOF
+  $ touch exe/the_exe.ml
+
+  $ dune build --display short ./exe/the_exe.exe 2>&1 | grep crash
+  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
+
+

--- a/test/blackbox-tests/test-cases/builtin-support-override.t
+++ b/test/blackbox-tests/test-cases/builtin-support-override.t
@@ -7,10 +7,20 @@ Create a library called `findlib.dynload`
   > EOF
   $ cat > findlib/dune <<EOF
   > (library
-  >   (name findlib_dynload)
-  >   (public_name findlib.dynload)
-  >   (wrapped false)
-  >   (special_builtin_support findlib_dynload))
+  >  (name findlib_dynload)
+  >  (public_name findlib.dynload)
+  >  (wrapped false)
+  >  (libraries findlib dynlink)
+  >  (modules fl_dynload)
+  >  (special_builtin_support findlib_dynload))
+  > (library
+  >  (public_name findlib)
+  >  (modules findlib))
+  > EOF
+  $ cat >findlib/findlib.ml <<EOF
+  > type x = Record_core
+  > let record_package _ _ = assert false
+  > let record_package_predicates _ _ = assert false
   > EOF
   $ touch findlib/fl_dynload.ml
 
@@ -34,7 +44,4 @@ Create a library called `findlib.dynload`
   > EOF
   $ touch exe/the_exe.ml
 
-  $ dune build --display short ./exe/the_exe.exe 2>&1 | grep crash
-  I must not crash.  Uncertainty is the mind-killer. Exceptions are the
-
-
+  $ dune build


### PR DESCRIPTION
- demonstrates a crash in link-time codegen when there's a library called `findlib.dynload`
- this is extracted from a real case (`caqti-dynload`) when consumed within an opam monorepo, which uses https://github.com/dune-universe/lib-findlib