### PR TITLE
fix: add locations to link time code gen

### DIFF
--- a/src/dune_rules/bootstrap_info.ml
+++ b/src/dune_rules/bootstrap_info.ml
@@ -37,7 +37,7 @@ let rule sctx ~requires_link (exes : Dune_file.Executables.t) =
         let dir = Lib_info.src_dir info in
         let special_builtin_support =
           match Lib_info.special_builtin_support info with
-          | Some (Build_info { data_module; _ }) -> Some data_module
+          | Some (_loc, Build_info { data_module; _ }) -> Some data_module
           | _ -> None
         in
         let open Memo.O in

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -509,7 +509,8 @@ module Library = struct
     let make ~wrapped ~implements ~special_builtin_support :
         t Lib_info.Inherited.t =
       (match (wrapped, special_builtin_support) with
-      | Some (loc, Yes_with_transition _), Some _ ->
+      | Some (loc, Yes_with_transition _), Some (_loc, _) ->
+        (* TODO use _loc *)
         User_error.raise ~loc
           [ Pp.text
               "Cannot have transition modules for libraries with special \
@@ -582,7 +583,8 @@ module Library = struct
     ; default_implementation : (Loc.t * Lib_name.t) option
     ; private_modules : Ordered_set_lang.t option
     ; stdlib : Ocaml_stdlib.t option
-    ; special_builtin_support : Lib_info.Special_builtin_support.t option
+    ; special_builtin_support :
+        (Loc.t * Lib_info.Special_builtin_support.t) option
     ; enabled_if : Blang.t
     ; instrumentation_backend : (Loc.t * Lib_name.t) option
     ; melange_runtime_deps : Loc.t * Dep_conf.t list
@@ -657,7 +659,7 @@ module Library = struct
        and+ special_builtin_support =
          field_o "special_builtin_support"
            (Dune_lang.Syntax.since Stanza.syntax (1, 10)
-           >>> Lib_info.Special_builtin_support.decode)
+           >>> located Lib_info.Special_builtin_support.decode)
        and+ enabled_if =
          let open Enabled_if in
          let allowed_vars = Only Lib_config.allowed_in_enabled_if in

--- a/src/dune_rules/dune_file.mli
+++ b/src/dune_rules/dune_file.mli
@@ -172,7 +172,8 @@ module Library : sig
     ; default_implementation : (Loc.t * Lib_name.t) option
     ; private_modules : Ordered_set_lang.t option
     ; stdlib : Ocaml_stdlib.t option
-    ; special_builtin_support : Lib_info.Special_builtin_support.t option
+    ; special_builtin_support :
+        (Loc.t * Lib_info.Special_builtin_support.t) option
     ; enabled_if : Blang.t
     ; instrumentation_backend : (Loc.t * Lib_name.t) option
     ; melange_runtime_deps : Loc.t * Dep_conf.t list

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -118,7 +118,8 @@ module Lib = struct
        ; field_o "modules" (Modules.encode ~src_dir:package_root) modules
        ; paths "melange_runtime_deps" melange_runtime_deps
        ; field_o "special_builtin_support"
-           Lib_info.Special_builtin_support.encode special_builtin_support
+           Lib_info.Special_builtin_support.encode
+           (Option.map ~f:snd special_builtin_support)
        ; field_o "instrumentation.backend" (no_loc Lib_name.encode)
            instrumentation_backend
        ]
@@ -186,7 +187,7 @@ module Lib = struct
        and+ special_builtin_support =
          field_o "special_builtin_support"
            (Dune_lang.Syntax.since Stanza.syntax (1, 10)
-           >>> Lib_info.Special_builtin_support.decode)
+           >>> located Lib_info.Special_builtin_support.decode)
        and+ instrumentation_backend =
          field_o "instrumentation.backend" (located Lib_name.decode)
        in

--- a/src/dune_rules/findlib/findlib.ml
+++ b/src/dune_rules/findlib/findlib.ml
@@ -478,12 +478,12 @@ end = struct
           requires t |> List.map ~f:(fun name -> Lib_dep.direct (add_loc name))
         in
         let ppx_runtime_deps = List.map ~f:add_loc (ppx_runtime_deps t) in
-        let special_builtin_support : Lib_info.Special_builtin_support.t option
-            =
+        let special_builtin_support :
+            (Loc.t * Lib_info.Special_builtin_support.t) option =
           (* findlib has been around for much longer than dune, so it is
              acceptable to have a special case in dune for findlib. *)
           match Lib_name.to_string t.name with
-          | "findlib.dynload" -> Some Findlib_dynload
+          | "findlib.dynload" -> Some (loc, Findlib_dynload)
           | _ -> None
         in
         let foreign_objects = Lib_info.Source.External [] in

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -345,7 +345,7 @@ type 'path t =
   ; main_module_name : Main_module_name.t
   ; modes : Lib_mode.Map.Set.t
   ; modules : Modules.t option Source.t
-  ; special_builtin_support : Special_builtin_support.t option
+  ; special_builtin_support : (Loc.t * Special_builtin_support.t) option
   ; exit_module : Module_name.t option
   ; instrumentation_backend : (Loc.t * Lib_name.t) option
   ; path_kind : 'path path
@@ -439,8 +439,9 @@ let equal (type a) (t : a t)
   && Main_module_name.equal main_module_name t.main_module_name
   && Lib_mode.Map.Set.equal modes t.modes
   && Source.equal (Option.equal Modules.equal) modules t.modules
-  && Option.equal Special_builtin_support.equal special_builtin_support
-       t.special_builtin_support
+  && Option.equal
+       (Tuple.T2.equal Loc.equal Special_builtin_support.equal)
+       special_builtin_support t.special_builtin_support
   && Option.equal Module_name.equal exit_module t.exit_module
   && Option.equal
        (Tuple.T2.equal Loc.equal Lib_name.equal)
@@ -734,7 +735,7 @@ let to_dyn path
     ; ("modes", Lib_mode.Map.Set.to_dyn modes)
     ; ("modules", Source.to_dyn (Dyn.option Modules.to_dyn) modules)
     ; ( "special_builtin_support"
-      , option Special_builtin_support.to_dyn special_builtin_support )
+      , option (snd Special_builtin_support.to_dyn) special_builtin_support )
     ; ("exit_module", option Module_name.to_dyn exit_module)
     ; ( "instrumentation_backend"
       , option (snd Lib_name.to_dyn) instrumentation_backend )

--- a/src/dune_rules/lib_info.mli
+++ b/src/dune_rules/lib_info.mli
@@ -154,7 +154,7 @@ val main_module_name : _ t -> Main_module_name.t
 
 val wrapped : _ t -> Wrapped.t Inherited.t option
 
-val special_builtin_support : _ t -> Special_builtin_support.t option
+val special_builtin_support : _ t -> (Loc.t * Special_builtin_support.t) option
 
 val modes : _ t -> Lib_mode.Map.Set.t
 
@@ -250,7 +250,7 @@ val create :
   -> modes:Lib_mode.Map.Set.t
   -> modules:Modules.t option Source.t
   -> wrapped:Wrapped.t Inherited.t option
-  -> special_builtin_support:Special_builtin_support.t option
+  -> special_builtin_support:(Loc.t * Special_builtin_support.t) option
   -> exit_module:Module_name.t option
   -> instrumentation_backend:(Loc.t * Lib_name.t) option
   -> melange_runtime_deps:'a File_deps.t

--- a/src/dune_rules/link_time_code_gen.ml
+++ b/src/dune_rules/link_time_code_gen.ml
@@ -237,7 +237,7 @@ let handle_special_libs cctx =
       match Lib_info.special_builtin_support (Lib.info lib) with
       | None ->
         process_libs libs ~to_link_rev:(Lib lib :: to_link_rev) ~force_linkall
-      | Some special -> (
+      | Some (loc, special) -> (
         match special with
         | Build_info { data_module; api_version } ->
           let& module_ =
@@ -260,10 +260,9 @@ let handle_special_libs cctx =
                findlib. That's why it's ok to use a dummy location. *)
             let* db = Scope.DB.public_libs ctx in
             let open Resolve.Memo.O in
-            let+ dynlink =
-              Lib.DB.resolve db (Loc.none, Lib_name.of_string "dynlink")
+            let+ dynlink = Lib.DB.resolve db (loc, Lib_name.of_string "dynlink")
             and+ findlib =
-              Lib.DB.resolve db (Loc.none, Lib_name.of_string "findlib")
+              Lib.DB.resolve db (loc, Lib_name.of_string "findlib")
             in
             [ dynlink; findlib ]
           in


### PR DESCRIPTION
improves library resolution errors for dynlinkg and findlib

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d0708d3e-33ab-4cfc-9bf9-2362d9f31975 -->