### PR TITLE
refactor: simplify source dependencies

### DIFF
--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -110,24 +110,13 @@ module Set : sig
   include
     Set.S with type elt = t and type 'a map := 'a Map.t and type t = unit Map.t
 
-  module Source_tree (Union : sig
-    type 'a result
+  (** [of_source_files ~files ~empty_directories] depend on all source files
+      [files].
 
-    val union_all :
-      Path.t -> f:(path:Path.t -> files:Filename.Set.t -> t) -> t result
-  end) : sig
-    (** Dependencies on all source files under a certain source directory.
-
-        Dependency on a [files] requires special care for empty directories.
-        Empty directories need to be loaded so that we clean up stale artifacts
-        in such directories *)
-    val files : Path.t -> t Union.result
-  end
-
-  (** [to_files_set_exn t] returns the set of files in [t]. It will raise if [t]
-      contains anything other than files or the empty predicate. It is safe to
-      call on the value returned by [Source_tree.files] *)
-  val to_files_set_exn : t -> Path.Set.t
+      Dependency on a [files] requires special care for empty directories. Empty
+      directories need to be loaded so that we clean up stale artifacts in such
+      directories. This is why [empty_directories] must be provided *)
+  val of_source_files : files:Path.Set.t -> empty_directories:Path.Set.t -> t
 
   val of_files : Path.t list -> t
 

--- a/src/dune_rules/cram/cram_rules.ml
+++ b/src/dune_rules/cram/cram_rules.ml
@@ -80,13 +80,8 @@ let test_rule ~sctx ~expander ~dir (spec : effective)
           | File _ -> Action_builder.return Path.Set.empty
           | Dir { dir; file = _ } ->
             let deps =
-              let open Memo.O in
-              let+ deps =
-                Path.Build.append_source prefix_with dir
-                |> Path.build |> Source_deps.files
-              in
-              let files = Dep.Set.to_files_set_exn deps in
-              (deps, files)
+              Path.Build.append_source prefix_with dir
+              |> Path.build |> Source_deps.files
             in
             Action_builder.dyn_memo_deps deps
         in

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -137,11 +137,7 @@ let rec dep expander = function
   | Source_tree s ->
     Other
       (let* path = Expander.expand_path expander s in
-       let deps =
-         let open Memo.O in
-         let+ files = Source_deps.files path in
-         (files, Dep.Set.to_files_set_exn files)
-       in
+       let deps = Source_deps.files path in
        Action_builder.dyn_memo_deps deps
        |> Action_builder.map ~f:Path.Set.to_list)
   | Package p ->

--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -118,7 +118,9 @@ module Deps = struct
     | Ok (dirs, files) ->
       let open Memo.O in
       let dep_set = Dep.Set.of_files files in
-      let+ l = Memo.parallel_map dirs ~f:Source_deps.files in
+      let+ l =
+        Memo.parallel_map dirs ~f:(fun dir -> Source_deps.files dir >>| fst)
+      in
       Ok (Dep.Set.union_all (dep_set :: l))
 end
 

--- a/src/dune_rules/source_deps.ml
+++ b/src/dune_rules/source_deps.ml
@@ -1,21 +1,28 @@
 open Import
+module Map_reduce =
+  Source_tree.Dir.Make_map_reduce
+    (Memo)
+    (Monoid.Product (Monoid.Union (Path.Set)) (Monoid.Union (Path.Set)))
 
-include Dep.Set.Source_tree (struct
-  module Map_reduce =
-    Source_tree.Dir.Make_map_reduce (Memo) (Monoid.Union (Dep.Set))
-
-  type 'a result = 'a Memo.t
-
-  let union_all dir ~f =
-    let prefix_with, dir = Path.extract_build_context_dir_exn dir in
-    let open Memo.O in
-    Source_tree.find_dir dir >>= function
-    | None -> Memo.return Dep.Set.empty
-    | Some dir ->
+let files dir =
+  let prefix_with, dir = Path.extract_build_context_dir_exn dir in
+  let open Memo.O in
+  Source_tree.find_dir dir >>= function
+  | None -> Memo.return (Dep.Set.empty, Path.Set.empty)
+  | Some dir ->
+    let+ files, empty_directories =
       Map_reduce.map_reduce dir ~traverse:Sub_dirs.Status.Set.all ~f:(fun dir ->
           let path =
             Path.append_source prefix_with @@ Source_tree.Dir.path dir
           in
-          let files = Source_tree.Dir.files dir in
-          Memo.return @@ f ~path ~files)
-end)
+          let files =
+            Source_tree.Dir.files dir |> String.Set.to_list
+            |> Path.Set.of_list_map ~f:(fun fn -> Path.relative path fn)
+          in
+          let empty_directories =
+            if Path.Set.is_empty files then Path.Set.singleton path
+            else Path.Set.empty
+          in
+          Memo.return (files, empty_directories))
+    in
+    (Dep.Set.of_source_files ~files ~empty_directories, files)

--- a/src/dune_rules/source_deps.mli
+++ b/src/dune_rules/source_deps.mli
@@ -1,5 +1,6 @@
 open Import
 
 (** [files path] returns all the source dependencies starting from [path]. If
-    [path] isn't in the source, the empty dependency set is returned *)
-val files : Path.t -> Dep.Set.t Memo.t
+    [path] isn't in the source, the empty dependency set and an empty path set
+    is returned *)
+val files : Path.t -> (Dep.Set.t * Path.Set.t) Memo.t


### PR DESCRIPTION
Remove the [Source_tree] functor in [Dep.Set] and replace it with a
function [of_source_files]

This simplifies the API everywhere, and removes an assert false.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: ece2eccb-6b3e-450d-891e-e2d0b58f6f59 -->