### PR TITLE
fix: delete stale directory targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- When a rule's action is interrupted, delete any leftover directory targets.
+  This is consistent with how we treat file targets. (@rgrinberg, 7564)
+
 - Fix plugin loading with findlib. The functionality was broken in 3.7.0.
   (#7556, @anmonteiro)
 

--- a/src/dune_engine/targets.ml
+++ b/src/dune_engine/targets.ml
@@ -27,6 +27,11 @@ let combine x y =
   ; dirs = Path.Build.Set.union x.dirs y.dirs
   }
 
+let diff t { files; dirs } =
+  { files = Path.Build.Set.diff t.files files
+  ; dirs = Path.Build.Set.diff t.dirs dirs
+  }
+
 let is_empty { files; dirs } =
   Path.Build.Set.is_empty files && Path.Build.Set.is_empty dirs
 
@@ -55,6 +60,10 @@ let pp { files; dirs } =
 let exists { files; dirs } ~f =
   Path.Build.Set.exists files ~f || Path.Build.Set.exists dirs ~f
 
+let iter { files; dirs } ~file ~dir =
+  Path.Build.Set.iter files ~f:file;
+  Path.Build.Set.iter dirs ~f:dir
+
 module Validated = struct
   type nonrec t = t =
     { files : Path.Build.Set.t
@@ -64,6 +73,8 @@ module Validated = struct
   let to_dyn = to_dyn
 
   let head = head_exn
+
+  let unvalidate t = t
 end
 
 module Validation_result = struct

--- a/src/dune_engine/targets.mli
+++ b/src/dune_engine/targets.mli
@@ -13,6 +13,11 @@ val is_empty : t -> bool
 (** Combine the sets of file and directory targets. *)
 val combine : t -> t -> t
 
+val diff : t -> t -> t
+
+val iter :
+  t -> file:(Path.Build.t -> unit) -> dir:(Path.Build.t -> unit) -> unit
+
 module File : sig
   (** A single file target. *)
   val create : Path.Build.t -> t
@@ -27,6 +32,8 @@ end
 val create : files:Path.Build.Set.t -> dirs:Path.Build.Set.t -> t
 
 module Validated : sig
+  type unvalidated := t
+
   (** A rule can produce a set of files whose names are known upfront, as well
       as a set of "opaque" directories whose contents is initially unknown. *)
   type t = private
@@ -39,6 +46,8 @@ module Validated : sig
   val head : t -> Path.Build.t
 
   val to_dyn : t -> Dyn.t
+
+  val unvalidate : t -> unvalidated
 end
 
 module Validation_result : sig


### PR DESCRIPTION
For unsandboxed rules, directory targets weren't being cleared when
running rules were interrupted. This PR treats files and directories in
the same way.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: f204fa03-a1ad-4185-8910-e4867713ca9f -->