### PR TITLE
Test the behavior of the mdx 0.3 stanza wrt `.mld` files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ core_bench \
 "csexp>=1.3.0" \
 js_of_ocaml \
 js_of_ocaml-compiler \
-"mdx>=2.1.0" \
+"mdx>=2.3.0" \
 menhir \
 ocamlfind \
 ocamlformat.$$(awk -F = '$$1 == "version" {print $$2}' .ocamlformat) \

--- a/test/blackbox-tests/test-cases/mdx-stanza/mld-files.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/mld-files.t
@@ -1,0 +1,65 @@
+The project has an `.mld` file that needs to be fixed. At first, we determine
+that that file is not being picked up:
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > 
+  > (using mdx 0.3)
+  > EOF
+  $ cat > dune <<EOF
+  > (mdx)
+  > EOF
+  > cat > needs-fixes.md <<'EOF'
+  > This is a sample md file. It has some code that is invalid.
+  > 
+  > ```ocaml
+  >    # List.map (fun x -> x * x) [(1 + 9); 2; 3; 4];;
+  >    - : int list = [1; 2; 3; 8]
+  > ```
+  > 
+  > A run of MDX should output a fixed version.
+  > EOF
+  $ cat > needs-fixes.mld <<EOF
+  > This is a sample mld file. It has some code that is invalid.
+  >  
+  > {[
+  >   # List.map (fun x -> x * x) [(1 + 9); 2; 3; 4];;
+  >   - : int list = [1; 2; 3; 8]
+  > ]}
+  > 
+  > A run of MDX should output a fixed version.
+  > EOF
+  $ dune runtest
+  File "needs-fixes.md", line 1, characters 0-0:
+  Error: Files _build/default/needs-fixes.md and
+  _build/default/.mdx/needs-fixes.md.corrected differ.
+  [1]
+
+It did pick up the error in the `.md` file, so let's promote the fix.
+
+  $ dune promote
+  Promoting _build/default/.mdx/needs-fixes.md.corrected to needs-fixes.md.
+  $ dune runtest
+
+So the tests pass now, but it only uses the default `.md` glob for files to
+process.
+
+Let's also run the test for `.mld` files. These need to be manually passed, at
+least as of mdx stanza verion 0.3 and require MDX 2.3.0 at minimum.
+
+  $ cat > dune <<EOF
+  > (mdx
+  >   (files needs-fixes.md needs-fixes.mld))
+  > EOF
+  $ dune runtest
+  File "needs-fixes.mld", line 1, characters 0-0:
+  Error: Files _build/default/needs-fixes.mld and
+  _build/default/.mdx/needs-fixes.mld.corrected differ.
+  [1]
+
+The error in the `.mld` file was found, promoting should work and re-running
+the test should succeed this time.
+
+  $ dune promote
+  Promoting _build/default/.mdx/needs-fixes.mld.corrected to needs-fixes.mld.
+  $ dune runtest


### PR DESCRIPTION
As MDX 2.3.0 was released it added support for `.mld` files. Dune currently just supports `.md` files by default in the 0.3 version of the mdx stanza. OTOH `.mld` files can be passed in and dune uses MDX to generate a corrected version.