### PR TITLE
refactor: simplify cwd when expanding actions

### DIFF
--- a/src/dune_rules/action_unexpanded.mli
+++ b/src/dune_rules/action_unexpanded.mli
@@ -20,6 +20,7 @@ val remove_locs : t -> t
 val expand :
      t
   -> loc:Loc.t
+  -> chdir:Path.Build.t
   -> deps:Dep_conf.t Bindings.t
   -> targets_dir:Path.Build.t
   -> targets:Path.Build.t Targets_spec.t
@@ -31,6 +32,7 @@ val expand :
 val expand_no_targets :
      t
   -> loc:Loc.t
+  -> chdir:Path.Build.t
   -> deps:Dep_conf.t Bindings.t
   -> expander:Expander.t
   -> what:string

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -389,8 +389,9 @@ module Unprocessed = struct
       | None -> Action_builder.return None
       | Some args ->
         let action =
-          let action = Preprocessing.chdir (Run (exe, args)) in
-          Action_unexpanded.expand_no_targets ~loc ~expander ~deps:[]
+          let action = Action_unexpanded.Run (exe, args) in
+          let chdir = (Expander.context expander).build_dir in
+          Action_unexpanded.expand_no_targets ~loc ~expander ~deps:[] ~chdir
             ~what:"preprocessing actions" action
         in
         let pp_of_action exe args =

--- a/src/dune_rules/preprocessing.mli
+++ b/src/dune_rules/preprocessing.mli
@@ -31,8 +31,6 @@ val get_ppx_driver :
 
 val gen_rules : Super_context.t -> string list -> unit Memo.t
 
-val chdir : Action_unexpanded.t -> Action_unexpanded.t
-
 val action_for_pp_with_target :
      sandbox:Sandbox_config.t
   -> loc:Loc.t

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -97,7 +97,8 @@ let user_rule sctx ?extra_bindings ~dir ~expander (rule : Rule.t) =
       | Some bindings -> Expander.add_bindings expander ~bindings
     in
     let* (action : _ Action_builder.With_targets.t) =
-      Action_unexpanded.expand (snd rule.action) ~loc:(fst rule.action)
+      let chdir = Expander.dir expander in
+      Action_unexpanded.expand (snd rule.action) ~loc:(fst rule.action) ~chdir
         ~expander ~deps:rule.deps ~targets ~targets_dir:dir
     in
     let action =
@@ -246,8 +247,9 @@ let alias sctx ?extra_bindings ~dir ~expander (alias_conf : Alias_conf.t) =
           | None -> expander
           | Some bindings -> Expander.add_bindings expander ~bindings
         in
+        let chdir = Expander.dir expander in
         Action_unexpanded.expand_no_targets action ~loc:action_loc ~expander
-          ~deps:alias_conf.deps ~what:"aliases"
+          ~chdir ~deps:alias_conf.deps ~what:"aliases"
       in
       let* action = interpret_and_add_locks ~expander alias_conf.locks action in
       Alias_rules.add sctx ~loc action ~alias)


### PR DESCRIPTION
Add an explicit chdir argument when expanding actions.

This makes it unnecessary to have Preprocesisng.chdir and the other
post-processing Chdir actions.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: b657ad64-22ae-4741-80d7-a5524ec71944 -->