### PR TITLE
Make (public_name -) equivalent to no public name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -156,6 +156,10 @@ Unreleased
 - Handle "Too many links" errors when using Dune cache on Windows.  The fix in
   3.7.0 for this same issue was not effective due to a typo. (#7472, @nojb)
 
+- In `(executable)`, `(public_name -)` is now equivalent to no `(public_name)`.
+  This is consistent with how `(executables)` handles this field.
+  (#...., fixes #5852, @emillon)
+
 3.7.0 (2023-02-17)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,7 +158,7 @@ Unreleased
 
 - In `(executable)`, `(public_name -)` is now equivalent to no `(public_name)`.
   This is consistent with how `(executables)` handles this field.
-  (#...., fixes #5852, @emillon)
+  (#7576 , fixes #5852, @emillon)
 
 3.7.0 (2023-02-17)
 ------------------

--- a/doc/stanzas/executable.rst
+++ b/doc/stanzas/executable.rst
@@ -54,6 +54,9 @@ files for executables. See `executables_implicit_empty_intf`_.
        (section bin)
        (files (<name>.exe as <public-name>)))
 
+  As a special case, ``(public_name -)`` is the same as if the field was
+  absent.
+
 .. _shared-exe-fields:
 
 - ``(package <package>)`` if there is a ``(public_name ...)`` field, this

--- a/test/blackbox-tests/test-cases/public-name-empty.t
+++ b/test/blackbox-tests/test-cases/public-name-empty.t
@@ -1,0 +1,40 @@
+This test is about the semantics of `(public_name -)`.
+
+  $ set_ver() {
+  > cat > dune-project << EOF
+  > (lang dune $1)
+  > (package
+  >  (name e)
+  >  (allow_empty))
+  > EOF
+  > }
+  $ cat > dune << EOF
+  > (executable
+  >  (public_name -)
+  >  (name e))
+  > EOF
+  $ touch e.ml
+
+In 3.7, this declares a public name of "-":
+
+  $ set_ver 3.7
+  $ dune build @install
+  $ cat _build/default/e.install
+  lib: [
+    "_build/install/default/lib/e/META"
+    "_build/install/default/lib/e/dune-package"
+  ]
+  bin: [
+    "_build/install/default/bin/-"
+  ]
+
+In 3.8, this is equivalent to no `(public_name)` field, consistently with what
+happens with `(executables)`.
+
+  $ set_ver 3.8
+  $ dune build @install
+  $ cat _build/default/e.install
+  lib: [
+    "_build/install/default/lib/e/META"
+    "_build/install/default/lib/e/dune-package"
+  ]


### PR DESCRIPTION
Fixes #5852

This brings consistency with `(public_names)` in `(executables)`: a plural stanza with only `-` in `(public_names)` installs nothing.
