### PR TITLE
copy_file_portable: use binary mode to avoid corruption

### DIFF
--- a/otherlibs/stdune/src/io.ml
+++ b/otherlibs/stdune/src/io.ml
@@ -73,7 +73,7 @@ let copy_channels =
   loop
 
 let setup_copy ?(chmod = Fun.id) ~src ~dst () =
-  let ic = open_in src in
+  let ic = Stdlib.open_in_bin src in
   let oc =
     try
       let perm = (Unix.fstat (Unix.descr_of_in_channel ic)).st_perm |> chmod in


### PR DESCRIPTION
A regression in #7257 meant that the "portable" file copying routine was using text mode channels, corrupting binary files when copying them (under Windows). This explains the current Windows failures in the CI.

cc @rgrinberg 