### PR TITLE
WIP handling for broken symlinks

### DIFF
--- a/src/dune_digest/dune_digest.ml
+++ b/src/dune_digest/dune_digest.ml
@@ -124,10 +124,10 @@ exception
     | `Unexpected_kind
     ]
 
-let directory_digest_version = 2
+let directory_digest_version = 3
 
-let path_with_stats ~allow_dirs path (stats : Stats_for_digest.t) :
-    Path_digest_result.t =
+let path_with_stats ~allow_dirs ~allow_broken_symlinks path
+    (stats : Stats_for_digest.t) : Path_digest_result.t =
   let rec loop path (stats : Stats_for_digest.t) =
     match stats.st_kind with
     | S_LNK ->
@@ -180,5 +180,6 @@ let path_with_stats ~allow_dirs path (stats : Stats_for_digest.t) :
   in
   match stats.st_kind with
   | S_DIR when not allow_dirs -> Unexpected_kind
-  | S_BLK | S_CHR | S_LNK | S_FIFO | S_SOCK -> Unexpected_kind
+  | S_LNK when not allow_broken_symlinks -> Unexpected_kind
+  | S_BLK | S_CHR | S_FIFO | S_SOCK -> Unexpected_kind
   | _ -> loop path stats

--- a/src/dune_digest/dune_digest.mli
+++ b/src/dune_digest/dune_digest.mli
@@ -57,6 +57,9 @@ end
     - If it's a directory and [allow_dirs = true], the function computes the
       digest of all contained filename/digest pairs, recursively.
 
+    - If it's a broken symlink and [allow_broken_symlinks = true], the function
+      computes the digest of the symlink rather than failing.
+
     - Otherwise, the function returns [Unexpected_kind].
 
     Note that this interface is prone to races: the provided [Stats_for_digest]
@@ -64,7 +67,11 @@ end
     even though you've just successfully run [Path.stat] on it. The call sites
     are expected to gracefully handle such races. *)
 val path_with_stats :
-  allow_dirs:bool -> Path.t -> Stats_for_digest.t -> Path_digest_result.t
+     allow_dirs:bool
+  -> allow_broken_symlinks:bool
+  -> Path.t
+  -> Stats_for_digest.t
+  -> Path_digest_result.t
 
 (** Digest a file taking the [executable] bit into account. Should not be called
     on a directory. *)

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -892,7 +892,8 @@ end = struct
       | Some digest -> (digest, File_target)
       | None -> (
         match
-          Cached_digest.build_file ~allow_dirs:true ~allow_broken_symlinks:false
+          (* TODO: handle broken symlinks *)
+          Cached_digest.build_file ~allow_dirs:false ~allow_broken_symlinks:true
             path
         with
         | Ok digest ->

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -891,7 +891,10 @@ end = struct
       match Path.Build.Map.find targets path with
       | Some digest -> (digest, File_target)
       | None -> (
-        match Cached_digest.build_file ~allow_dirs:true path with
+        match
+          Cached_digest.build_file ~allow_dirs:true ~allow_broken_symlinks:false
+            path
+        with
         | Ok digest ->
           (digest, Dir_target { generated_file_digests = targets })
           (* Must be a directory target *)

--- a/src/dune_engine/cached_digest.ml
+++ b/src/dune_engine/cached_digest.ml
@@ -235,9 +235,9 @@ let refresh_without_removing_write_permissions ~allow_dirs
       | exception Unix.Unix_error (ENOENT, _, _) -> (
         (* Test if this is a broken symlink for better error messages. *)
         match Path.Untracked.lstat_exn path with
-        | exception Unix.Unix_error (ENOENT, _, _) -> No_such_file
         | stats when allow_broken_symlinks ->
           refresh stats ~allow_dirs ~allow_broken_symlinks path
+        | exception Unix.Unix_error (ENOENT, _, _) -> No_such_file
         | _stats_so_must_be_a_symlink -> Broken_symlink))
 
 (* CR-someday amokhov: We do [lstat] followed by [stat] only because we do not
@@ -339,9 +339,13 @@ let peek_file ~allow_dirs ~allow_broken_symlinks path =
             digest_result))
 
 let peek_or_refresh_file ~allow_dirs ~allow_broken_symlinks path =
+  Printf.printf "peek_or_refresh_file:\n - bs: %b\n - path: %s\n"
+    allow_broken_symlinks
+    (Path.to_dyn path |> Dyn.to_string);
   match peek_file ~allow_dirs ~allow_broken_symlinks path with
   | Some digest_result -> digest_result
   | None ->
+    Printf.printf "refresh_without_removing case\n";
     refresh_without_removing_write_permissions ~allow_dirs
       ~allow_broken_symlinks path
 

--- a/src/dune_engine/cached_digest.mli
+++ b/src/dune_engine/cached_digest.mli
@@ -22,23 +22,38 @@ end
 (** Digest the contents of a build artifact.
 
     If [allow_dirs = false], this function returns [Unexpected_kind] if the path
-    points to a directory. *)
-val build_file : allow_dirs:bool -> Path.Build.t -> Digest_result.t
+    points to a directory.
+
+    If [allow_broken_symlinks = false], this function returns [Ok] for broken
+    symlinks. *)
+val build_file :
+     allow_dirs:bool
+  -> allow_broken_symlinks:bool
+  -> Path.Build.t
+  -> Digest_result.t
 
 (** Same as [build_file], but forces the digest of the file to be re-computed.
 
     If [remove_write_permissions] is true, also remove write permissions on the
-    file. *)
+    file.
+
+    If [allow_broken_symlinks = false], this function returns [Ok] for broken
+    symlinks. *)
 val refresh :
      allow_dirs:bool
   -> remove_write_permissions:bool
+  -> allow_broken_symlinks:bool
   -> Path.Build.t
   -> Digest_result.t
 
 module Untracked : sig
   (** Digest the contents of a source or external file. This function doesn't
-      track the source file. For a tracked version, see [fs_memo.mli]. *)
-  val source_or_external_file : Path.t -> Digest_result.t
+      track the source file. For a tracked version, see [fs_memo.mli].
+
+      If [allow_broken_symlinks = false], this function returns [Ok] for broken
+      symlinks. *)
+  val source_or_external_file :
+    allow_broken_symlinks:bool -> Path.t -> Digest_result.t
 
   (** Invalidate the cached [stat] value. This causes the subsequent call to
       [source_or_external_file] to incur an additional [stat] call. *)

--- a/src/dune_engine/fs_cache.ml
+++ b/src/dune_engine/fs_cache.ml
@@ -121,7 +121,13 @@ module Untracked = struct
      two separate tables. We should find a way to merge the tables into one. *)
   let file_digest =
     let sample p =
-      Cached_digest.Untracked.source_or_external_file (Path.outside_build_dir p)
+      (* TODO: handle broken symlinks *)
+      Cached_digest.Untracked.source_or_external_file
+        ~allow_broken_symlinks:true (Path.outside_build_dir p)
+      |> fun result ->
+      Printf.printf "result: %s\n"
+        (Cached_digest.Digest_result.to_dyn result |> Dyn.to_string);
+      result
     in
     let update_hook p =
       Cached_digest.Untracked.invalidate_cached_timestamp

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -127,7 +127,8 @@ module Workspace_local = struct
     | Ok targets -> (
       match
         Targets.Produced.Option.mapi targets ~f:(fun target () ->
-            Cached_digest.build_file ~allow_dirs:true target
+            Cached_digest.build_file ~allow_dirs:true
+              ~allow_broken_symlinks:false target
             |> Cached_digest.Digest_result.to_option)
       with
       | Some produced_targets -> Hit produced_targets
@@ -368,7 +369,9 @@ module Shared = struct
         Execution_parameters.should_remove_write_permissions_on_generated_files
           exec_params
       in
+      (* TODO: handle broken symlinks *)
       Cached_digest.refresh ~allow_dirs:true ~remove_write_permissions
+        ~allow_broken_symlinks:false
     in
     match
       Targets.Produced.Option.mapi produced_targets ~f:(fun target () ->

--- a/src/dune_engine/rule_cache.ml
+++ b/src/dune_engine/rule_cache.ml
@@ -128,7 +128,7 @@ module Workspace_local = struct
       match
         Targets.Produced.Option.mapi targets ~f:(fun target () ->
             Cached_digest.build_file ~allow_dirs:true
-              ~allow_broken_symlinks:false target
+              ~allow_broken_symlinks:true target
             |> Cached_digest.Digest_result.to_option)
       with
       | Some produced_targets -> Hit produced_targets
@@ -371,7 +371,7 @@ module Shared = struct
       in
       (* TODO: handle broken symlinks *)
       Cached_digest.refresh ~allow_dirs:true ~remove_write_permissions
-        ~allow_broken_symlinks:false
+        ~allow_broken_symlinks:true
     in
     match
       Targets.Produced.Option.mapi produced_targets ~f:(fun target () ->

--- a/test/blackbox-tests/test-cases/github7573.t
+++ b/test/blackbox-tests/test-cases/github7573.t
@@ -14,8 +14,28 @@ broken symbollic links, even in data_only_dirs.
 
   $ (cd foo && ln -s doesnt_exist bar)
 
-  $ dune build foo/bar
+  $ dune build foo/bar --debug-digest --debug-cache=shared,workspace-local,fs
+  Workspace-local cache miss: _build/default/.dune/configurator: never seen this target before
+  Shared cache miss [464c107d149be4e276c1b307136d2461] (_build/default/.dune/configurator): cache disabled
+  Workspace-local cache miss: _build/default/.dune/configurator.v2: never seen this target before
+  Shared cache miss [39cdfe356740bbb5db762f5afad29bb5] (_build/default/.dune/configurator.v2): cache disabled
   File "foo/bar", line 1, characters 0-0:
   Error: File unavailable: foo/bar
-  Broken symbolic link
+  peek_or_refresh_file:
+   - bs: true
+   - path: In_source_tree "dune-project"
+  refresh_without_removing case
+  result: Ok digest "7ddb0f449bf0945e9b4c83281633c698"
+  peek_or_refresh_file:
+   - bs: true
+   - path: In_source_tree "dune"
+  refresh_without_removing case
+  result: Ok digest "e8b8642beda7ac787266c4d773cfb4b5"
+  peek_or_refresh_file:
+   - bs: true
+   - path: In_source_tree "foo/bar"
+  refresh_without_removing case
+  here
+  exn: Unix.Unix_error(Unix.ENOENT, "open", "foo/bar")
+  result: No_such_file
   [1]

--- a/test/blackbox-tests/test-cases/github7573.t
+++ b/test/blackbox-tests/test-cases/github7573.t
@@ -1,0 +1,21 @@
+Test case for https://github.com/ocaml/dune/issues/7573
+
+This test case demonstrates build failures given the existence of intentially
+broken symbollic links, even in data_only_dirs.
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.8)
+  > EOF
+
+  $ mkdir foo
+  $ cat > dune << EOF
+  > (data_only_dirs foo)
+  > EOF
+
+  $ (cd foo && ln -s doesnt_exist bar)
+
+  $ dune build foo/bar
+  File "foo/bar", line 1, characters 0-0:
+  Error: File unavailable: foo/bar
+  Broken symbolic link
+  [1]

--- a/test/expect-tests/digest/digest_tests.ml
+++ b/test/expect-tests/digest/digest_tests.ml
@@ -10,7 +10,10 @@ let%expect_test "directory digest version" =
   let expected = "a743ec66ce913ff6587a3816a8acc6ea" in
   let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
   let stats = { Digest.Stats_for_digest.st_kind = S_DIR; st_perm = 1 } in
-  (match Digest.path_with_stats ~allow_dirs:true dir stats with
+  (match
+     Digest.path_with_stats ~allow_dirs:true ~allow_broken_symlinks:false dir
+       stats
+   with
   | Ok digest ->
     let digest = Digest.to_string digest in
     if String.equal digest expected then print_endline "[PASS]"
@@ -29,7 +32,10 @@ let%expect_test "directories with symlinks" =
   Path.mkdir_p sub;
   Unix.symlink "bar" (Path.to_string (Path.relative dir "foo"));
   Unix.symlink "bar" (Path.to_string (Path.relative sub "foo"));
-  (match Digest.path_with_stats ~allow_dirs:true dir stats with
+  (match
+     Digest.path_with_stats ~allow_dirs:true ~allow_broken_symlinks:false dir
+       stats
+   with
   | Ok _ -> print_endline "[PASS]"
   | Unexpected_kind -> print_endline "[FAIL] unexpected kind"
   | Unix_error _ -> print_endline "[FAIL] unable to calculate digest");

--- a/test/expect-tests/digest/digest_tests.ml
+++ b/test/expect-tests/digest/digest_tests.ml
@@ -11,7 +11,7 @@ let%expect_test "directory digest version" =
   let dir = Temp.create Dir ~prefix:"digest-tests" ~suffix:"" in
   let stats = { Digest.Stats_for_digest.st_kind = S_DIR; st_perm = 1 } in
   (match
-     Digest.path_with_stats ~allow_dirs:true ~allow_broken_symlinks:false dir
+     Digest.path_with_stats ~allow_dirs:true ~allow_broken_symlinks:true dir
        stats
    with
   | Ok digest ->


### PR DESCRIPTION
This is an attempt at fixing #7573. I am stuck trying to work out how to digest a symlink when we know it is broken. Unix documentation seems to indicate that I need the `O_PATH` and `O_NOFOLLOW` file open modes which don't seem to exist in the Unix Ocaml stdlib API. Therefore this is only a WIP until I can work out how to digest broken symlinks.