### PR TITLE
Don't attempt read from closed fd in dune_rpc_lwt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -125,6 +125,9 @@ Unreleased
 - On nix+macos, pass `-f` to the codesign hook to avoid errors when the binary
   is already signed (#7183, fixes #6265, @greedy)
 
+- Fix bug where RPC clients built with dune-rpc-lwt would crash when closing
+  their connection to the server (#7581, @gridbugs)
+
 3.7.1 (2023-04-04)
 ------------------
 

--- a/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
+++ b/otherlibs/dune-rpc-lwt/test/dune_rpc_lwt_tests.ml
@@ -118,7 +118,8 @@ let%expect_test "run and connect" =
     {|
     started session
     received ping. shutting down.
-    dune build finished with 0 |}]
+    dune build finished with 0
+    success |}]
 
 module Logger = struct
   (* A little helper to make the output from the client and server


### PR DESCRIPTION
This fixes a bug where RPC clients built with dune_rpc_lwt would crash while disconnecting as they attempted to read from a channel whose underlying file descriptor had been closed.

A simple program that reproduces the bug:
```ocaml
let () =
  let init =
    Dune_rpc.V1.Initialize.create ~id:(Dune_rpc.V1.Id.make (Csexp.Atom "hello"))
  in
  let where = Dune_rpc_lwt.V1.Where.default ~build_dir:"_build" () in
  Lwt_main.run
    (let open Lwt.Syntax in
    let* input_channel, output_channel = Dune_rpc_lwt.V1.connect_chan where in
    Dune_rpc_lwt.V1.Client.connect (input_channel, output_channel) init
      ~f:(fun _client -> Lwt.return ()))
```
This program just connects to an RPC server and then immediately disconnects. Prior to this change it would crash while disconnection with the error:
```
Fatal error: exception Unix.Unix_error(Unix.EBADF, "check_descriptor", "")
Raised at Lwt_unix.check_descriptor in file "src/unix/lwt_unix.cppo.ml", line 379, characters 4-64
Called from Lwt_unix.blocking in file "src/unix/lwt_unix.cppo.ml", line 384, characters 2-21
Called from Lwt_unix.read_bigarray in file "src/unix/lwt_unix.cppo.ml", line 682, characters 4-15
Called from Lwt_io.perform_io in file "src/unix/lwt_io.ml", line 236, characters 10-35
Called from Lwt_io.Primitives.read_char in file "src/unix/lwt_io.ml", line 676, characters 6-15
Called from Lwt_io.Primitives.read_char_opt.(fun) in file "src/unix/lwt_io.ml", line 686, characters 17-29
Called from Lwt.Sequential_composition.catch in file "src/core/lwt.ml", line 2008, characters 16-20
Re-raised at Lwt.Miscellaneous.poll in file "src/core/lwt.ml", line 3077, characters 20-29
Called from Lwt_main.run.run_loop in file "src/unix/lwt_main.ml", line 31, characters 10-20
Called from Lwt_main.run in file "src/unix/lwt_main.ml", line 118, characters 8-13
Re-raised at Lwt_main.run in file "src/unix/lwt_main.ml", line 124, characters 4-13
Called from Dune__exe__Hello_rpc in file "hello_rpc.ml", line 6, characters 2-260
```