### PR TITLE
feature: mdx 0.4 stanza with support for `mld` files out of the box

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,6 +128,9 @@ Unreleased
 - Fix bug where RPC clients built with dune-rpc-lwt would crash when closing
   their connection to the server (#7581, @gridbugs)
 
+- Introduce mdx stanza 0.4 requiring mdx >= 2.3.0 which updates the default
+  list of files to include `*.mld` files (#7582, @Leonidas-from-XIV)
+
 3.7.1 (2023-04-04)
 ------------------
 

--- a/doc/stanzas/mdx.rst
+++ b/doc/stanzas/mdx.rst
@@ -18,9 +18,10 @@ Note that this feature is still experimental and needs to be enabled in your
 
 .. code:: dune
 
-  (using mdx 0.3)
+  (using mdx 0.4)
 
-.. note:: Version ``0.2`` of the stanza requires mdx ``1.9.0``.
+.. note:: Version ``0.2`` of the stanza requires mdx ``1.9.0``. Version ``0.4``
+   of the stanza requires mdx ``2.3.0``.
 
 
 The syntax is as follows:
@@ -33,7 +34,8 @@ Where ``<optional-fields>`` are:
 
 - ``(files <globs>)`` are the files that you want MDX to check, described as a
   list of globs (see the :ref:`Glob language specification <glob>` ). It
-  defaults to ``*.md``.
+  defaults to ``*.md *.mld`` as of version ``0.4`` of the stanza and ``*.md``
+  before.
 
 - ``(deps <deps-conf list>)`` to specify the dependencies of your documentation
   code blocks. See :doc:`concepts/dependency-spec` for more details.

--- a/test/blackbox-tests/test-cases/mdx-stanza/mld-files.t
+++ b/test/blackbox-tests/test-cases/mdx-stanza/mld-files.t
@@ -3,7 +3,6 @@ that that file is not being picked up:
 
   $ cat > dune-project <<EOF
   > (lang dune 3.7)
-  > 
   > (using mdx 0.3)
   > EOF
   $ cat > dune <<EOF
@@ -60,6 +59,79 @@ least as of mdx stanza verion 0.3 and require MDX 2.3.0 at minimum.
 The error in the `.mld` file was found, promoting should work and re-running
 the test should succeed this time.
 
+  $ dune promote
+  Promoting _build/default/.mdx/needs-fixes.mld.corrected to needs-fixes.mld.
+  $ dune runtest
+
+The 0.4 version of the stanza adds support for `.mld` files by default, so bump
+the stanza version.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > (using mdx 0.4)
+  > EOF
+  $ cat > dune <<EOF
+  > (mdx)
+  > EOF
+  $ cat > needs-fixes.mld <<EOF
+  > This is a sample mld file. It has some code that is invalid.
+  >  
+  > {[
+  >   # List.map (fun x -> x * x) [(1 + 9); 2; 3; 4];;
+  >   - : int list = [1; 2; 3; 8]
+  > ]}
+  > 
+  > A run of MDX should output a fixed version.
+  > EOF
+
+0.4 is only supported since dune-lang 3.8, so attempting to use it should fail:
+
+  $ dune runtest
+  File "dune-project", line 2, characters 11-14:
+  2 | (using mdx 0.4)
+                 ^^^
+  Error: Version 0.4 of mdx extension to verify code blocks in .md files is not
+  supported until version 3.8 of the dune language.
+  Supported versions of this extension in version 3.7 of the dune language:
+  - 0.1 to 0.3
+  [1]
+
+Updating the dune-lang should make the test run.
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using mdx 0.4)
+  > EOF
+  $ dune runtest
+  File "needs-fixes.mld", line 1, characters 0-0:
+  Error: Files _build/default/needs-fixes.mld and
+  _build/default/.mdx/needs-fixes.mld.corrected differ.
+  [1]
+  $ dune promote
+  Promoting _build/default/.mdx/needs-fixes.mld.corrected to needs-fixes.mld.
+  $ dune runtest
+
+We also make sure that `:standard` resolves properly:
+
+  $ cat > dune <<EOF
+  > (mdx
+  >   (files :standard))
+  > EOF
+  $ cat > needs-fixes.mld <<EOF
+  > This is a sample mld file. It has some code that is invalid.
+  >  
+  > {[
+  >   # List.map (fun x -> x * x) [(1 + 9); 2; 3; 4];;
+  >   - : int list = [1; 2; 3; 8]
+  > ]}
+  > 
+  > A run of MDX should output a fixed version.
+  > EOF
+  $ dune runtest
+  File "needs-fixes.mld", line 1, characters 0-0:
+  Error: Files _build/default/needs-fixes.mld and
+  _build/default/.mdx/needs-fixes.mld.corrected differ.
+  [1]
   $ dune promote
   Promoting _build/default/.mdx/needs-fixes.mld.corrected to needs-fixes.mld.
   $ dune runtest


### PR DESCRIPTION
MDX 2.3.0 added support for MLD files, the mdx 0.4 stanza adds `*.mld` to the default globs.

Probably it would make sense to add a version check for this and it would be good to land #7569 beforehand.