### PR TITLE
odoc: put odoc support files in odoc.support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@ Unreleased
   This is consistent with how `(executables)` handles this field.
   (#7576 , fixes #5852, @emillon)
 
+- Change directory of odoc assets to `odoc.support` (was `_odoc_support`) so
+  that it works with Github Pages out of the box. (#7588, fixes #7364,
+  @emillon)
+
 3.7.0 (2023-02-17)
 ------------------
 

--- a/src/dune_rules/odoc.ml
+++ b/src/dune_rules/odoc.ml
@@ -85,7 +85,7 @@ let add_rule sctx =
   Super_context.add_rule sctx ~dir
 
 module Paths = struct
-  let odoc_support_dirname = "_odoc_support"
+  let odoc_support_dirname = "odoc.support"
 
   let root (context : Context.t) =
     Path.Build.relative context.Context.build_dir "_doc"

--- a/test/blackbox-tests/test-cases/odoc/multiple-private-libs.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/multiple-private-libs.t/run.t
@@ -1,7 +1,7 @@
 This test checks that there is no clash when two private libraries have the same name
 
   $ dune build --display short @doc-private
-          odoc _doc/_html/_odoc_support
+          odoc _doc/_html/odoc.support
         ocamlc a/.test.objs/byte/test.{cmi,cmo,cmt}
         ocamlc b/.test.objs/byte/test.{cmi,cmo,cmt}
           odoc a/.test.objs/byte/test.odoc

--- a/test/blackbox-tests/test-cases/odoc/odoc-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-simple.t/run.t
@@ -16,7 +16,7 @@ This test if `.odocl` files are generated
   <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
       <title>index</title>
-      <link rel="stylesheet" href="./_odoc_support/odoc.css"/>
+      <link rel="stylesheet" href="./odoc.support/odoc.css"/>
       <meta charset="utf-8"/>
       <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     </head>

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/diff-scope.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/diff-scope.t/run.t
@@ -1,6 +1,6 @@
 Duplicate mld's in different scope
   $ dune build @doc --display short
-          odoc _doc/_html/_odoc_support
+          odoc _doc/_html/odoc.support
           odoc _doc/_odoc/pkg/scope1/page-index.odoc
         ocamlc scope1/.scope1.objs/byte/scope1.{cmi,cmo,cmt}
           odoc _doc/_odoc/pkg/scope2/page-index.odoc

--- a/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/same-scope.t/run.t
+++ b/test/blackbox-tests/test-cases/odoc/odoc-unique-mlds/same-scope.t/run.t
@@ -1,6 +1,6 @@
 Duplicate mld's in the same scope
   $ dune build @doc --display short
-          odoc _doc/_html/_odoc_support
+          odoc _doc/_html/odoc.support
           odoc _doc/_odoc/pkg/root/page-index.odoc
         ocamlc lib1/.root_lib1.objs/byte/root_lib1.{cmi,cmo,cmt}
         ocamlc lib2/.root_lib2.objs/byte/root_lib2.{cmi,cmo,cmt}


### PR DESCRIPTION
Fixes #7364

If the directory is named `_odoc_support` with a leading underscore, it is omitted when deploying to github pages. This is because this system also support the jekyll site generator, which uses this convention for data files.

We can not use any directory name here since we want to avoid conflicts with OCaml identifiers and names of `*.mld` files. Starting with a dot seems to fit the requirements.
