### PR TITLE
[coq] Deprecate Coq Lang < 0.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,6 +144,12 @@ Unreleased
 
 - Fix RPC server on Windows (used for OCaml-LSP). (#7666, @nojb)
 
+- Coq language versions less 0.8 are deprecated, and will be removed
+  in an upcoming Dune version. All users are required to migrate to
+  `(coq lang 0.8)` which provides the right semantics for theories
+  that have been globally installed, such as those coming from opam
+  (@ejgallego, @Alizter)
+
 3.7.1 (2023-04-04)
 ------------------
 

--- a/doc/coq.rst
+++ b/doc/coq.rst
@@ -304,6 +304,11 @@ file:
 
 The supported Coq language versions (not the version of Coq) are:
 
+- ``0.8``: Support for composition with installed Coq theories;
+  support for ``vos`` builds.
+
+Deprecated experimental Coq language versions are:
+
 - ``0.1``: Basic Coq theory support.
 - ``0.2``: Support for the ``theories`` field and composition of theories in the
   same scope.
@@ -316,18 +321,17 @@ The supported Coq language versions (not the version of Coq) are:
 - ``0.7``: ``(mode )`` is automatically detected from the configuration of Coq
   and ``(mode native)`` is deprecated. The ``dev`` profile also no longer
   disables native compilation.
-- ``0.8``: Support for composition of installed theories; support for vos
-  builds.
 
 .. _coq-lang-1.0:
 
 Coq Language Version 1.0
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Guarantees with respect to stability are not yet provided. However, as the
-development of features progresses, we hope to reach ``1.0`` soon. The ``1.0``
-version of Coq lang will commit to a stable set of functionality. All the
-features below are expected to reach ``1.0`` unchanged or minimally modified.
+Guarantees with respect to stability are not yet provided, but we
+intend that the ``(0.8)`` version of the language becomes ``1.0``.
+The ``1.0`` version of Coq lang will commit to a stable set of
+functionality. All the features below are expected to reach ``1.0``
+unchanged or minimally modified.
 
 .. _coq-extraction:
 

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -252,7 +252,7 @@ Such languages must be enabled in the ``dune`` project file separately:
 .. code:: dune
 
    (lang dune 3.8)
-   (using coq 0.7)
+   (using coq 0.8)
 
 If such extensions are experimental, it's recommended that they pass
 ``~experimental:true``, and that their versions are below 1.0.

--- a/src/dune_rules/coq/coq_stanza.ml
+++ b/src/dune_rules/coq/coq_stanza.ml
@@ -13,6 +13,19 @@ let coq_syntax =
     ; ((0, 8), `Since (3, 8))
     ]
 
+let already_warned = ref false
+
+let get_coq_syntax () =
+  let* version = Dune_lang.Syntax.get_exn coq_syntax in
+  if version < (0, 8) && not !already_warned then (
+    already_warned := true;
+    User_warning.emit
+      [ Pp.text
+          "Coq Language Versions lower than 0.8 have been deprecated in Dune \
+           3.8 and will be removed in an upcoming Dune version."
+      ]);
+  return version
+
 module Coqpp = struct
   type t =
     { modules : Ordered_set_lang.t
@@ -54,7 +67,7 @@ module Buildable = struct
         ]
 
   let decode =
-    let* coq_lang_version = Dune_lang.Syntax.get_exn coq_syntax in
+    let* coq_lang_version = get_coq_syntax () in
     let+ loc = loc
     and+ flags = Ordered_set_lang.Unexpanded.field "flags"
     and+ mode =

--- a/test/blackbox-tests/test-cases/coq/base-unsound.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/base-unsound.t/run.t
@@ -1,4 +1,6 @@
   $ dune build --display short --profile unsound --debug-dependency-path @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep .basic.theory.d
           coqc foo.{glob,vo}
           coqc bar.{glob,vo}

--- a/test/blackbox-tests/test-cases/coq/base.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/base.t/run.t
@@ -1,9 +1,13 @@
   $ dune build --display short --debug-dependency-path @all --always-show-command-line
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep .basic.theory.d
           coqc foo.{glob,vo}
           coqc bar.{glob,vo}
 
   $ dune build --debug-dependency-path @default
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   lib: [
     "_build/install/default/lib/base/META"
     "_build/install/default/lib/base/dune-package"

--- a/test/blackbox-tests/test-cases/coq/compose-boot-nodeps.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-boot-nodeps.t/run.t
@@ -1,6 +1,8 @@
 Testing composition with two boot libraries
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "A/dune", line 4, characters 11-12:
   4 |  (theories B)
                  ^

--- a/test/blackbox-tests/test-cases/coq/compose-boot-nodups.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-boot-nodups.t/run.t
@@ -1,6 +1,8 @@
 Testing composition with two boot libraries
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Error: Cannot have more than one boot theory in scope:
   - B at B/dune:1
   - A at A/dune:1

--- a/test/blackbox-tests/test-cases/coq/compose-boot-nostdlib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-boot-nostdlib.t/run.t
@@ -4,6 +4,8 @@ importing ``stdlib`` enabled or disabled.
 Composing library A depending on Coq but having `(stdlib no)`:
 
   $ dune build A
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Module
   Prelude
   := Struct Inductive BootType : Set :=  boot : BootType | type : BootType. End
@@ -14,6 +16,8 @@ Composing library A depending on Coq but having `(stdlib no)`:
 Composing library B depending on Coq but having `(stdlib yes)`:
 
   $ dune build B
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Module
   Prelude
   := Struct Inductive BootType : Set :=  boot : BootType | type : BootType. End

--- a/test/blackbox-tests/test-cases/coq/compose-boot-plugins.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-boot-plugins.t/run.t
@@ -1,5 +1,7 @@
 Testing composition with a boot library with plugins
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   plugin loaded
   plugin loaded

--- a/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-cycle.t/run.t
@@ -1,5 +1,7 @@
 We check cycles are detected
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Error: Dependency cycle between:
      theory A in A/dune:2
   -> theory B in B/dune:2

--- a/test/blackbox-tests/test-cases/coq/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-compat.t/run.t
@@ -30,8 +30,12 @@ so this also tests that it won't be a problem.
 
   $ dune build --root B @install
   Entering directory 'B'
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Leaving directory 'B'
   $ dune install --root B --prefix=$PWD --display=short
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Installing $TESTCASE_ROOT/lib/B/META
   Installing $TESTCASE_ROOT/lib/B/dune-package
   Installing $TESTCASE_ROOT/lib/coq/user-contrib/B/.coq-native/NB_b.cmi

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
@@ -1,4 +1,6 @@
   $ dune build --display short --debug-dependency-path @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep thy1/.thy1.theory.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d

--- a/test/blackbox-tests/test-cases/coq/compose-private-ambiguous.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-private-ambiguous.t/run.t
@@ -3,11 +3,15 @@ private plugin B and the public package C will pick up.
 
 B will pick up the private one:
   $ dune build B
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   message = "I am the the private A "
        : string
 
 C picks up the private one too:
   $ dune build C
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "C/dune", line 4, characters 11-12:
   4 |  (theories A))
                  ^

--- a/test/blackbox-tests/test-cases/coq/compose-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-private.t/run.t
@@ -3,6 +3,8 @@ theory. As expected, the private theories build, but the public theory fails
 because a public theory cannot depend on a private theory. 
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Hello
        : Set
   File "C/dune", line 4, characters 11-12:

--- a/test/blackbox-tests/test-cases/coq/compose-projects-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-boot.t/run.t
@@ -8,6 +8,8 @@ When composing with a (boot) library, every library must have -boot passed to
 coqdep and coqc.
 
   $ dune build A
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Module
   Prelude
   := Struct Inductive BootType : Set :=  boot : BootType | type : BootType. End
@@ -26,6 +28,8 @@ private boot library will be loaded implicitly.
   > EOF
 
   $ dune build B
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   private_boot
        : PrivateBootType
 
@@ -40,6 +44,8 @@ However if this boot library is public Dune will complain
   > EOF
 
   $ dune build B
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Error: Cannot have more than one boot theory in scope:
   - Coq at Coq/dune:1
   - Coq at B/Coq/dune:2

--- a/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-cycle.t/run.t
@@ -2,6 +2,8 @@ Testing composition of theories across a dune workspace with cyclic
 dependencies.
 
   $ dune build A
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Error: Dependency cycle between:
      theory A in A/dune:2
   -> theory B in B/dune:2
@@ -13,6 +15,8 @@ dependencies.
   [1]
 
   $ dune build B
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Error: Dependency cycle between:
      theory B in B/dune:2
   -> theory C in C/dune:2
@@ -24,6 +28,8 @@ dependencies.
   [1]
 
   $ dune build C
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Error: Dependency cycle between:
      theory C in C/dune:2
   -> theory A in A/dune:2

--- a/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-missing.t/run.t
@@ -2,6 +2,8 @@ Testing composition of theories across a dune workspace with a missing
 dependency.
 
   $ dune build C
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "B/dune", line 4, characters 11-12:
   4 |  (theories A))
                  ^

--- a/test/blackbox-tests/test-cases/coq/compose-projects-private-ambiguous.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-private-ambiguous.t/run.t
@@ -9,6 +9,8 @@ Currently Dune does not detect this issue, so passes invalid flags to coqdep
 which complains.
 
   $ dune build B
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   *** Warning: in file b.v, library a is required from root A and has not been found in the loadpath!
   File "./B/b.v", line 2, characters 0-24:
   Error: Cannot find a physical path bound to logical path a with prefix A.
@@ -16,6 +18,8 @@ which complains.
   [1]
 
   $ dune build C
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   *** Warning: in file c.v, library a is required from root A and has not been found in the loadpath!
   *** Warning: in file a.v, library A is required from root C and has not been found in the loadpath!
   File "./C/c.v", line 2, characters 0-24:
@@ -35,8 +39,12 @@ which complains.
   [1]
 
   $ dune build A
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
   $ dune build C/A_vendored
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "C/A_vendored/dune", line 1, characters 0-36:
   1 | (coq.theory
   2 |  (name A)

--- a/test/blackbox-tests/test-cases/coq/compose-projects.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects.t/run.t
@@ -1,5 +1,7 @@
 Testing composition of theories across a dune workspace
   $ dune build B
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Hello
        : Set
 

--- a/test/blackbox-tests/test-cases/coq/compose-self.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-self.t/run.t
@@ -1,5 +1,7 @@
 Composing a theory with itself should cause a cycle
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Error: Dependency cycle between:
      theory A in A/dune:2
   -> required by _build/default/A/.A.theory.d

--- a/test/blackbox-tests/test-cases/coq/compose-simple.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-simple.t/run.t
@@ -2,6 +2,8 @@ Testing a simple composition of theories. We have two theories A and B and B
 depends on A.
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 We inspect the contents of the build directory.
 

--- a/test/blackbox-tests/test-cases/coq/compose-sub-theory.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-sub-theory.t/run.t
@@ -2,6 +2,8 @@ Testing dependencies on subtheories. We have two theories A and B, but A is
 defined as Foo.A. This changes the install layout of A.
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Inspecting the build and install directory
   $ ls _build/install/default/lib/coq/user-contrib/Foo/A/a.vo

--- a/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-two-scopes.t/run.t
@@ -1,5 +1,7 @@
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   lib: [
     "_build/install/default/lib/cvendor/META"
     "_build/install/default/lib/cvendor/dune-package"

--- a/test/blackbox-tests/test-cases/coq/coqdep-on-rebuild.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdep-on-rebuild.t/run.t
@@ -14,6 +14,8 @@
   > Definition doo := a.foo.
   > EOF
   $ dune build --display short --debug-dependency-path
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep a/.a.theory.d
         coqdep b/.b.theory.d
           coqc a/Na_a.{cmi,cmxs},a/a.{glob,vo}
@@ -25,5 +27,7 @@
   > Definition zoo := 4.
   > EOF
   $ dune build --display short --debug-dependency-path
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep b/.b.theory.d
           coqc b/Nb_b.{cmi,cmxs},b/b.{glob,vo}

--- a/test/blackbox-tests/test-cases/coq/coqdoc-dir-target-clash.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-dir-target-clash.t/run.t
@@ -1,6 +1,8 @@
 We try to build the documentation but there will be a clash between the
 directory targets. Notice how the tex one fails before html one.
   $ dune build @check
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "dune", line 9, characters 0-116:
    9 | (rule
   10 |  (targets

--- a/test/blackbox-tests/test-cases/coq/coqdoc-multi-theory.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-multi-theory.t/run.t
@@ -3,6 +3,8 @@ HTML
 
 First we build the doc alias for the first theory
   $ dune build @A/doc
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 The first theory doc is built
   $ ls _build/default/A/A.html
   A.AA.aa.html
@@ -18,6 +20,8 @@ Clean
 
 Next we build the doc for the second theory
   $ dune build @B/doc
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 Check that the first theory doc is not built
   $ ls _build/default/A/
   AA
@@ -37,6 +41,8 @@ LaTeX
 
 Next we test the LaTeX targets in the same manner
   $ dune build @A/doc-latex
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 The first theory doc is built
   $ ls _build/default/A/A.tex
   A.AA.aa.tex
@@ -50,6 +56,8 @@ Clean
 
 Next we build the doc for the second theory
   $ dune build @B/doc-latex
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 Check that the first theory doc is not built
   $ ls _build/default/A
   AA

--- a/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc-with-boot.t/run.t
@@ -1,6 +1,8 @@
 Testing coqdoc when composed with a boot library
 
   $ dune build A/A.html
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
   $ ls _build/default/A
   A.html

--- a/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqdoc.t/run.t
@@ -1,5 +1,7 @@
 We build the coqdoc html target:
   $ dune build basic.html/
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Now we inspect it:
   $ ls _build/default/basic.html
@@ -11,6 +13,8 @@ Now we inspect it:
 
 We build the coqdoc latex target:
   $ dune build basic.tex/
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Now we inspect it:
   $ ls _build/default/basic.tex
@@ -21,6 +25,8 @@ Now we inspect it:
 Next from a clean build we make sure that @all does *not* build any doc targets:
   $ dune clean
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 Note that this currently works due to a bug in @all detecting directory targets.
   $ ls _build/default
   META.base

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-flags.t/run.t
@@ -2,6 +2,8 @@ Testing that the correct flags are being passed to dune coq top
 
 The flags passed to coqc:
   $ dune build && tail -1 _build/log | ../../scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc
   -w -notation-overridden
   -w -deprecated-native-compiler-option -native-output-dir .
@@ -32,6 +34,8 @@ The flags passed to coqc:
 
 The flags passed to coqtop:
   $ dune coq top --toplevel=echo Test.v | ../../scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   -topfile $TESTCASE_ROOT/_build/default/Test.v
   -w -notation-overridden
   -w -deprecated-native-compiler-option -native-output-dir .

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-nested.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-nested.t/run.t
@@ -1,8 +1,14 @@
 Checking that we compute the directory and file for dune coq top correctly
 
   $ dune build theories/c.vo
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   $ dune build theories/b/b.vo
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   $ dune coq top --toplevel=echo theories/c.v | ../../scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   -topfile $TESTCASE_ROOT/_build/default/theories/c.v
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -29,6 +35,8 @@ Checking that we compute the directory and file for dune coq top correctly
   -R $TESTCASE_ROOT/_build/default/theories foo
 
   $ dune coq top --toplevel=echo theories/b/b.v | ../../scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   -topfile $TESTCASE_ROOT/_build/default/theories/b/b.v
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-recomp.t
@@ -19,6 +19,8 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
   > (using coq 0.3)
   > EOF
   $ dune coq top --display short --toplevel echo dir/bar.v | ../scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep dir/.basic.theory.d
           coqc dir/foo.{glob,vo}
   -topfile $TESTCASE_ROOT/_build/default/dir/bar.v
@@ -46,6 +48,8 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
   -R coq/theories Coq
   -R $TESTCASE_ROOT/_build/default/dir basic
   $ dune coq top --display short --toplevel echo dir/bar.v | ../scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   -topfile $TESTCASE_ROOT/_build/default/dir/bar.v
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -73,6 +77,8 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
   $ dune clean
   $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v) | ../scrub_coq_args.sh
   Entering directory '..'
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep dir/.basic.theory.d
           coqc dir/foo.{glob,vo}
   Leaving directory '..'
@@ -102,6 +108,8 @@ https://github.com/ocaml/dune/pull/5457#issuecomment-1084161587).
   -R $TESTCASE_ROOT/_build/default/dir basic
   $ (cd dir && dune coq top --root .. --display short --toplevel echo dir/bar.v) | ../scrub_coq_args.sh
   Entering directory '..'
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Leaving directory '..'
   -topfile $TESTCASE_ROOT/_build/default/dir/bar.v
   -w -deprecated-native-compiler-option

--- a/test/blackbox-tests/test-cases/coq/coqtop/coqtop-root.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/coqtop/coqtop-root.t/run.t
@@ -1,6 +1,8 @@
 All dune commands work when you run them in sub-directories, so this should be no exception.
 
   $ dune coq top --toplevel=echo -- theories/foo.v | ../../scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   -topfile $TESTCASE_ROOT/_build/default/theories/foo.v
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled

--- a/test/blackbox-tests/test-cases/coq/deprecate-libraries.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/deprecate-libraries.t/run.t
@@ -10,6 +10,8 @@ The libraries field is deprecated
   > EOF
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "dune", line 7, characters 1-20:
   7 |  (libraries bar.foo))
        ^^^^^^^^^^^^^^^^^^^
@@ -29,6 +31,8 @@ Having both a libraries and plugins field is an error
   > EOF
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "dune", line 7, characters 1-20:
   7 |  (libraries bar.foo)
        ^^^^^^^^^^^^^^^^^^^

--- a/test/blackbox-tests/test-cases/coq/deprecate-public_name.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/deprecate-public_name.t/run.t
@@ -11,6 +11,8 @@ public_name field is deprecated
        ^^^^^^^^^^^^^^^^^
   Warning: 'public_name' was deprecated in version 0.5 of the Coq language.
   Please use 'package' instead.
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 both package and public_name field is an error
   $ cat > dune << EOF
@@ -26,6 +28,8 @@ both package and public_name field is an error
        ^^^^^^^^^^^^^^^^^
   Warning: 'public_name' was deprecated in version 0.5 of the Coq language.
   Please use 'package' instead.
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "dune", line 3, characters 14-17:
   3 |  (public_name Foo)
                     ^^^

--- a/test/blackbox-tests/test-cases/coq/empty-modules.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/empty-modules.t/run.t
@@ -9,3 +9,5 @@ correctly.
 
 Builds fine as expected.
   $ dune build 2>&1
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.

--- a/test/blackbox-tests/test-cases/coq/env.t
+++ b/test/blackbox-tests/test-cases/coq/env.t
@@ -46,6 +46,8 @@ Case A / A
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -54,6 +56,8 @@ Case A / A
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -69,6 +73,8 @@ Case A / I
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -77,6 +83,8 @@ Case A / I
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -92,6 +100,8 @@ Case A / N
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -100,6 +110,8 @@ Case A / N
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -115,6 +127,8 @@ Case A / Y
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -123,6 +137,8 @@ Case A / Y
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Cases for I
 
@@ -139,6 +155,8 @@ Case I / A
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -147,6 +165,8 @@ Case I / A
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -162,6 +182,8 @@ Case I / I
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -170,6 +192,8 @@ Case I / I
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -185,6 +209,8 @@ Case I / N
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -193,6 +219,8 @@ Case I / N
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -208,6 +236,8 @@ Case I / Y
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -216,6 +246,8 @@ Case I / Y
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Cases for N
 
@@ -232,6 +264,8 @@ Case N / A
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -240,6 +274,8 @@ Case N / A
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -255,6 +291,8 @@ Case N / I
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -263,6 +301,8 @@ Case N / I
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -278,6 +318,8 @@ Case N / N
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -286,6 +328,8 @@ Case N / N
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -301,6 +345,8 @@ Case N / Y
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -309,6 +355,8 @@ Case N / Y
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -330,6 +378,8 @@ Case Y / A
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -338,6 +388,8 @@ Case Y / A
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Case Y / I
 
@@ -347,6 +399,8 @@ Case Y / I
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -355,6 +409,8 @@ Case Y / I
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Case Y / N
 
@@ -364,6 +420,8 @@ Case Y / N
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -372,6 +430,8 @@ Case Y / N
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
 Case Y / Y
 
@@ -381,6 +441,8 @@ Case Y / Y
   > EOF
 
   $ dune build @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "./foo.v", line 3, characters 24-25:
   Error:
   The term "t" has type "Type" while it is expected to have type 
@@ -389,3 +451,5 @@ Case Y / Y
   [1]
 
   $ dune build @all --profile unsound
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.

--- a/test/blackbox-tests/test-cases/coq/extract.t
+++ b/test/blackbox-tests/test-cases/coq/extract.t
@@ -34,6 +34,8 @@
   > EOF
 
   $ dune exec ./foo.exe
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   false
   $ ls _build/default
   Datatypes.ml

--- a/test/blackbox-tests/test-cases/coq/extraction-patch.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/extraction-patch.t/run.t
@@ -1,5 +1,7 @@
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
 
   $ ls _build/default
   Datatypes.ml
@@ -18,4 +20,6 @@
   | Coq_false
 
   $ dune exec -- ./my_prog.exe
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   Result: false

--- a/test/blackbox-tests/test-cases/coq/flags.t
+++ b/test/blackbox-tests/test-cases/coq/flags.t
@@ -17,6 +17,8 @@ Test case: default flags
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -q
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -53,6 +55,8 @@ TC: :standard
 
   $ rm _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -q
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -88,6 +92,8 @@ TC: override :standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -123,6 +129,8 @@ TC: add to :standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -q -type-in-type
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -163,6 +171,8 @@ TC: extend in workspace + override standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -type-in-type
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -197,6 +207,8 @@ TC: extend in workspace + override standard
   > EOF
 
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -q -type-in-type
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -233,6 +245,8 @@ TC: extend in dune (env) + override standard
 
   $ rm -rf _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -type-in-type
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -269,6 +283,8 @@ TC: extend in dune (env) + standard
 
   $ rm -rf _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -q -type-in-type -type-in-type
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled
@@ -310,6 +326,8 @@ TC: extend in dune (env) + workspace + standard
 
   $ rm -rf _build/default/foo.vo
   $ dune build foo.vo && tail -n 1 _build/log | ./scrub_coq_args.sh
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   coqc -q -type-in-type -bt
   -w -deprecated-native-compiler-option
   -w -native-compiler-disabled

--- a/test/blackbox-tests/test-cases/coq/github5532.t
+++ b/test/blackbox-tests/test-cases/coq/github5532.t
@@ -16,6 +16,8 @@ Reproducing test case for #5532.
   > EOF
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "dune", line 1, characters 0-26:
   1 | (coq.theory
   2 |  (name basic))

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
@@ -1,4 +1,6 @@
   $ dune build --display short --debug-dependency-path @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep theories/.Plugin.theory.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d

--- a/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-compose.t/run.t
@@ -1,4 +1,6 @@
   $ dune build --profile=release --display short --debug-dependency-path @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep bar/.bar.theory.d
         coqdep foo/.foo.theory.d
           coqc foo/Nfoo_foo.{cmi,cmxs},foo/foo.{glob,vo}
@@ -6,6 +8,8 @@
           coqc bar/Nbar_baz_bar.{cmi,cmxs},bar/bar.{glob,vo}
 
   $ dune build --profile=release --debug-dependency-path @default
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   lib: [
     "_build/install/default/lib/base/META"
     "_build/install/default/lib/base/dune-package"

--- a/test/blackbox-tests/test-cases/coq/native-single.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/native-single.t/run.t
@@ -1,9 +1,13 @@
   $ dune build --profile=release --display short --debug-dependency-path @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep .basic.theory.d
           coqc Nbasic_foo.{cmi,cmxs},foo.{glob,vo}
           coqc Nbasic_bar.{cmi,cmxs},bar.{glob,vo}
 
   $ dune build --profile=release --debug-dependency-path @default
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   lib: [
     "_build/install/default/lib/base/META"
     "_build/install/default/lib/base/dune-package"

--- a/test/blackbox-tests/test-cases/coq/no-stdlib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/no-stdlib.t/run.t
@@ -2,10 +2,14 @@ Test that when `(stdlib no)` is provided, the standard library is not bound to `
 and the prelude is not imported
 
   $ dune build --display=short foo.vo
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep .basic.theory.d
           coqc foo.{glob,vo}
 
   $ dune build --display=short bar.vo
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
           coqc bar.{glob,vo} (exit 1)
   File "./bar.v", line 1, characters 20-23:
   Error: The reference nat was not found in the current environment.

--- a/test/blackbox-tests/test-cases/coq/plugin-meta.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/plugin-meta.t/run.t
@@ -10,6 +10,8 @@ The META file for plugins is built before calling coqdep
   > EOF
 
   $ dune build .bar.theory.d
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   $ ls _build/install/default/lib/bar
   META
 

--- a/test/blackbox-tests/test-cases/coq/plugin-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/plugin-private.t/run.t
@@ -9,6 +9,8 @@ In Coq >= 0.6, depending on a private library as a plugin is an error.
   > EOF
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "dune", line 6, characters 10-13:
   6 |  (plugins foo))
                 ^^^

--- a/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/public-dep-on-private.t/run.t
@@ -1,4 +1,6 @@
   $ dune build --display short --debug-dependency-path
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "public/dune", line 4, characters 11-18:
   4 |  (theories private))
                  ^^^^^^^

--- a/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
@@ -1,4 +1,6 @@
   $ dune build --display short --debug-dependency-path @all
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
         coqdep .rec_module.theory.d
           coqc b/foo.{glob,vo}
           coqc c/d/bar.{glob,vo}
@@ -6,6 +8,8 @@
           coqc a/bar.{glob,vo}
 
   $ dune build --debug-dependency-path @default
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   lib: [
     "_build/install/default/lib/rec/META"
     "_build/install/default/lib/rec/dune-package"

--- a/test/blackbox-tests/test-cases/coq/theory-stanza-duplicate-module.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/theory-stanza-duplicate-module.t/run.t
@@ -7,6 +7,8 @@ Dune should warn about duplicate modules declared inside a coq.theory stanza
   > EOF
 
   $ dune build
+  Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
+  3.8 and will be removed in an upcoming Dune version.
   File "dune", line 1, characters 0-47:
   1 | (coq.theory
   2 |  (name foo)


### PR DESCRIPTION
As discussed with Ali, we want the previous semantics with implicit global theories to go away ASAP as they don't provide a usable workflow in general.