### PR TITLE
Fix Windows fswatch C warnings

### DIFF
--- a/src/fswatch_win/fswatch_win_stubs.c
+++ b/src/fswatch_win/fswatch_win_stubs.c
@@ -326,7 +326,8 @@ static void remove_watch(struct watch* w, struct watch** lst) {
   free_watch(w);
 }
 
-static DWORD WINAPI watch_thread(struct fsenv* fsenv) {
+static DWORD WINAPI watch_thread(LPVOID lpParameter) {
+  struct fsenv* fsenv = lpParameter;
   struct watch* watches = NULL;
   BOOL shuttingDown = FALSE;
 

--- a/src/fswatch_win/fswatch_win_stubs.c
+++ b/src/fswatch_win/fswatch_win_stubs.c
@@ -94,7 +94,7 @@ static void push_events(struct fsenv* fsenv, struct watch* w) {
   /* Perform [e->next = fsenv->events; fsenv->events = e] atomically */
   do {
     e->next = fsenv->events;
-  } while (InterlockedCompareExchangePointer(&(fsenv->events), e, e->next) != e->next);
+  } while (InterlockedCompareExchangePointer((PVOID volatile *)&(fsenv->events), e, e->next) != e->next);
 
   SetEvent(fsenv->signal); /* wakeup OCaml thread */
 }
@@ -106,7 +106,7 @@ static struct events* pop_events(struct fsenv* fsenv) {
   /* Perform [res = fsenv->events; fsenv->events = NULL] atomically */
   do {
     res = fsenv->events;
-  } while (InterlockedCompareExchangePointer(&(fsenv->events), NULL, res) != res);
+  } while (InterlockedCompareExchangePointer((PVOID volatile *)&(fsenv->events), NULL, res) != res);
 
   return res;
 }


### PR DESCRIPTION
Two little warnings of incompatible pointer types, fixed by explicit and implicit cast.