### PR TITLE
refactor: use Pp.enumerate more

### DIFF
--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -179,8 +179,7 @@ let report_rule_conflict fn (rule' : Rule.t) (rule : Rule.t) =
   User_error.raise
     [ Pp.textf "Multiple rules generated for %s:"
         (Path.to_string_maybe_quoted fn)
-    ; Pp.textf "- %s" (describe_rule rule')
-    ; Pp.textf "- %s" (describe_rule rule)
+    ; Pp.enumerate ~f:(fun x -> describe_rule x |> Pp.text) [ rule; rule' ]
     ]
     ~hints:
       (match (rule.info, rule'.info) with

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -303,10 +303,9 @@ let load () =
                 User_error.raise
                   [ Pp.textf "Too many opam files for package %S:"
                       (Package.Name.to_string name)
-                  ; Pp.textf "- %s"
-                      (Path.Source.to_string_maybe_quoted (Package.opam_file a))
-                  ; Pp.textf "- %s"
-                      (Path.Source.to_string_maybe_quoted (Package.opam_file b))
+                  ; Pp.enumerate [ a; b ] ~f:(fun x ->
+                        Pp.text @@ Path.Source.to_string_maybe_quoted
+                        @@ Package.opam_file x)
                   ])))
   in
   let+ dune_files =

--- a/src/dune_rules/dune_project.ml
+++ b/src/dune_rules/dune_project.ml
@@ -754,10 +754,10 @@ let parse_packages (name : Name.t option) ~info ~dir ~version packages
       | _, _ -> ());
       let package_defined_twice name loc1 loc2 =
         let main_message =
-          [ Pp.textf "Package name %s is defined twice:"
-              (Package.Name.to_string name)
-          ]
+          Pp.textf "Package name %s is defined twice:"
+            (Package.Name.to_string name)
         in
+
         let name = Package.Name.to_string name in
         let annots =
           let message loc =
@@ -766,15 +766,14 @@ let parse_packages (name : Name.t option) ~info ~dir ~version packages
           let related = [ message loc1; message loc2 ] in
           User_message.Annots.singleton Compound_user_error.annot
             [ Compound_user_error.make
-                ~main:(User_message.make main_message)
+                ~main:(User_message.make [ main_message ])
                 ~related
             ]
         in
         User_error.raise ~annots
-          (main_message
-          @ [ Pp.textf "- %s" (Loc.to_file_colon_line loc1)
-            ; Pp.textf "- %s" (Loc.to_file_colon_line loc2)
-            ])
+          [ main_message
+          ; Pp.enumerate [ loc1; loc2 ] ~f:Loc.pp_file_colon_line
+          ]
       in
       let deprecated_package_names =
         List.fold_left packages ~init:Package.Name.Map.empty

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -219,8 +219,8 @@ let modules_of_files ~path ~dialects ~dir ~files =
         [ Pp.textf "Too many files for module %s in %s:"
             (Module_name.to_string name)
             (Path.Source.to_string_maybe_quoted src_dir)
-        ; Pp.textf "- %s" (Path.to_string_maybe_quoted (Module.File.path f1))
-        ; Pp.textf "- %s" (Path.to_string_maybe_quoted (Module.File.path f2))
+        ; Pp.enumerate [ f1; f2 ] ~f:(fun x ->
+              Pp.text @@ Path.to_string_maybe_quoted @@ Module.File.path x)
         ]
   in
   let impls = parse_one_set impl_files in
@@ -482,8 +482,8 @@ let make dune_file ~dir ~scope ~lib_config ~loc ~lookup_vlib
                     "The following module and module group cannot co-exist in \
                      the same executable or library because they correspond to \
                      the same module path"
-                ; Pp.textf "- module %s" module_
-                ; Pp.textf "- module group %s" group
+                ; Pp.enumerate ~f:Pp.text
+                    [ "module " ^ module_; "module group " ^ group ]
                 ])
       | No | Include Unqualified ->
         List.fold_left dirs ~init:Module_name.Map.empty
@@ -493,10 +493,9 @@ let make dune_file ~dir ~scope ~lib_config ~loc ~lookup_vlib
                 User_error.raise ~loc
                   [ Pp.textf "Module %S appears in several directories:"
                       (Module_name.to_string name)
-                  ; Pp.textf "- %s"
-                      (Path.to_string_maybe_quoted (Module.Source.src_dir x))
-                  ; Pp.textf "- %s"
-                      (Path.to_string_maybe_quoted (Module.Source.src_dir y))
+                  ; Pp.enumerate [ x; y ] ~f:(fun x ->
+                        Pp.text @@ Path.to_string_maybe_quoted
+                        @@ Module.Source.src_dir x)
                   ; Pp.text "This is not allowed, please rename one of them."
                   ]))
         |> Module_trie.of_map

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -629,8 +629,7 @@ let decode ~dir =
     | Error (name, (loc1, _), (loc2, _)) ->
       User_error.raise
         [ Pp.textf "%s %s is declared twice:" error_msg (to_string name)
-        ; Pp.textf "- %s" (print_value loc1)
-        ; Pp.textf "- %s" (print_value loc2)
+        ; Pp.enumerate [ loc1; loc2 ] ~f:print_value
         ]
   in
   fields
@@ -649,13 +648,16 @@ let decode ~dir =
        name_map
          (Dune_lang.Syntax.since Stanza.syntax (2, 0))
          Name.Map.of_list_map Name.to_string "deprecated_package_names"
-         (located Name.decode) Loc.to_file_colon_line "Deprecated package name"
+         (located Name.decode)
+         (fun x -> Pp.text (Loc.to_file_colon_line x))
+         "Deprecated package name"
      and+ sites =
        name_map
          (Dune_lang.Syntax.since Stanza.syntax (2, 8))
          Section.Site.Map.of_list_map Section.Site.to_string "sites"
          (pair Section.decode Section.Site.decode)
-         Section.to_string "Site location name"
+         (fun x -> Pp.text (Section.to_string x))
+         "Site location name"
      and+ allow_empty =
        field_b "allow_empty"
          ~check:(Dune_lang.Syntax.since Stanza.syntax (3, 0))

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -128,8 +128,8 @@ module DB = struct
                 in
                 User_error.raise ~annots
                   [ main_message
-                  ; Pp.textf "- %s" (Loc.to_file_colon_line loc1)
-                  ; Pp.textf "- %s" (Loc.to_file_colon_line loc2)
+                  ; Pp.enumerate [ loc1; loc2 ] ~f:(fun x ->
+                        Pp.text (Loc.to_file_colon_line x))
                   ])
     in
     Lib.DB.create () ~parent:(Some parent) ~host
@@ -209,8 +209,8 @@ module DB = struct
           User_error.raise ~annots ~loc:loc2
             [ Pp.textf "Public library %s is defined twice:"
                 (Lib_name.to_string name)
-            ; Pp.textf "- %s" (Loc.to_file_colon_line loc1)
-            ; Pp.textf "- %s" (Loc.to_file_colon_line loc2)
+            ; Pp.enumerate [ loc1; loc2 ] ~f:(fun x ->
+                  Pp.text (Loc.to_file_colon_line x))
             ])
     in
     let resolve lib = Memo.return (resolve t public_libs lib) in


### PR DESCRIPTION
We use Pp.enumerate more and clean up some code.

(Previously we introduced Pp.enumerate_str but then decided against).