### PR TITLE
menhir: support for .conflicts targets when passing --explain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ Unreleased
   `install_c_headers`, but it allows to choose the extension and choose the
   paths for the installed headers. (#7512, @rgrinberg)
 
+- Menhir rules will understand the `--explain` flag when passed and build a
+  `.conflicts` file. Menhir lang has been bumped to 2.2 (#7607, fixes #6865,
+  @Alizter)
+
 - Load the host context `findlib.conf` when cross-compiling (#7428, fixes
   #1701, @rgrinberg, @anmonteiro)
 

--- a/src/dune_rules/menhir/menhir_stanza.ml
+++ b/src/dune_rules/menhir/menhir_stanza.ml
@@ -6,6 +6,7 @@ let syntax =
     ; ((1, 1), `Since (1, 4))
     ; ((2, 0), `Since (1, 4))
     ; ((2, 1), `Since (2, 2))
+    ; ((2, 2), `Since (3, 8))
     ]
 
 open Dune_lang.Decoder
@@ -18,6 +19,7 @@ type t =
   ; loc : Loc.t
   ; infer : bool
   ; enabled_if : Blang.t
+  ; menhir_lang_version : Dune_sexp.Syntax.Version.t
   }
 
 let decode =
@@ -31,13 +33,22 @@ let decode =
      and+ menhir_syntax = Dune_lang.Syntax.get_exn syntax
      and+ enabled_if =
        Enabled_if.decode ~allowed_vars:Any ~since:(Some (1, 4)) ()
-     and+ loc = loc in
+     and+ loc = loc
+     and+ menhir_lang_version = Dune_lang.Syntax.get_exn syntax in
      let infer =
        match infer with
        | Some infer -> infer
        | None -> menhir_syntax >= (2, 0)
      in
-     { merge_into; flags; modules; mode; loc; infer; enabled_if })
+     { merge_into
+     ; flags
+     ; modules
+     ; mode
+     ; loc
+     ; infer
+     ; enabled_if
+     ; menhir_lang_version
+     })
 
 type Stanza.t += T of t
 

--- a/src/dune_rules/menhir/menhir_stanza.mli
+++ b/src/dune_rules/menhir/menhir_stanza.mli
@@ -10,6 +10,7 @@ type t =
   ; loc : Loc.t
   ; infer : bool
   ; enabled_if : Blang.t
+  ; menhir_lang_version : Dune_sexp.Syntax.Version.t
   }
 
 val modules : t -> string list

--- a/src/dune_sexp/syntax.ml
+++ b/src/dune_sexp/syntax.ml
@@ -337,6 +337,18 @@ let get_exn t =
       ; ("context", Univ_map.to_dyn context)
       ]
 
+let get t =
+  get t.key >>= function
+  | Some (Active x) -> return (Some x)
+  | Some (Inactive _) -> return None
+  | None ->
+    let+ context = get_all in
+    Code_error.raise "Syntax identifier is unset"
+      [ ("name", Dyn.string t.name)
+      ; ("supported_versions", Supported_versions.to_dyn t.supported_versions)
+      ; ("context", Univ_map.to_dyn context)
+      ]
+
 let deleted_in ?(extra_info = "") t ver =
   let open Version.Infix in
   let* current_ver = get_exn t in

--- a/src/dune_sexp/syntax.mli
+++ b/src/dune_sexp/syntax.mli
@@ -121,4 +121,6 @@ val key : t -> Key.t Univ_map.Key.t
 
 val get_exn : t -> (Version.t, 'k) Decoder.parser
 
+val get : t -> (Version.t option, 'k) Decoder.parser
+
 val experimental : t -> bool

--- a/test/blackbox-tests/test-cases/menhir/explain.t/run.t
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/run.t
@@ -1,0 +1,51 @@
+Testing the detection of the --explain flag when executing the menhir rules.
+
+The menhir rules check for the --explain flag in a menhir stanza or any provided
+via an env stanza using the menhir_flags field.
+
+Build and run a source file that requires a menhir parser.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (using menhir 2.1)
+  > EOF
+
+  $ dune build ./src/test.exe
+  $ ls _build/default/src/test.exe
+  _build/default/src/test.exe
+
+Check for .conflicts files in stanza with --explain. This will fail because the
+menhir lang version is not 2.2 or above.
+
+  $ find _build/default/src -name '*.conflicts'
+
+Try building again with 2.2
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (using menhir 2.2)
+  > EOF
+  $ dune build ./src/test.exe
+
+Check for .conflicts files in stanza with --explain.
+
+  $ find _build/default/src -name '*.conflicts'
+  _build/default/src/test_base.conflicts
+
+Now we test for --explain provided via an env stanza:
+
+  $ cat > dune << EOF
+  > (env (_ (menhir_flags :standard "--explain")))
+  > EOF
+
+Passing --explain through menhir_flags is prohibited for the moment.
+
+  $ dune build ./src/test.exe
+  File "dune", line 1, characters 32-43:
+  1 | (env (_ (menhir_flags :standard "--explain")))
+                                      ^^^^^^^^^^^
+  Error: The --explain flag is not supported in the env stanza as it currently
+  does not allow Dune's menhir support to produce the correct targets.
+  Hint: Add --explain to the (flags) field of the (menhir) stanza. This will
+  produce the correct .conflict files.
+  [1]

--- a/test/blackbox-tests/test-cases/menhir/explain.t/src/dune
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/src/dune
@@ -1,0 +1,13 @@
+(ocamllex lexer1 lexer2)
+
+(menhir
+ (modules test_menhir1)
+ (flags :standard --unused-tokens))
+
+(menhir
+ (merge_into test_base)
+ (flags --explain)
+ (modules tokens parser))
+
+(executables
+ (names test))

--- a/test/blackbox-tests/test-cases/menhir/explain.t/src/lexer1.mll
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/src/lexer1.mll
@@ -1,0 +1,7 @@
+{
+open Test_menhir1
+}
+
+rule lex = parse
+  | 'c' { TOKEN 'c' }
+  | eof { EOF }

--- a/test/blackbox-tests/test-cases/menhir/explain.t/src/lexer2.mll
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/src/lexer2.mll
@@ -1,0 +1,7 @@
+{
+open Test_base
+}
+
+rule lex = parse
+  | 'c' { TOKEN 'c' }
+  | eof { EOF }

--- a/test/blackbox-tests/test-cases/menhir/explain.t/src/parser.mly
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/src/parser.mly
@@ -1,0 +1,7 @@
+%start <char list> main
+
+%%
+
+main:
+| c = TOKEN EOF { [c] }
+| c = TOKEN xs = main  { c :: xs }

--- a/test/blackbox-tests/test-cases/menhir/explain.t/src/test.ml
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/src/test.ml
@@ -1,0 +1,8 @@
+
+let s = "foo bar baz"
+
+let () =
+  let lex1 = Lexing.from_string s in
+  let lex2 = Lexing.from_string s in
+  ignore (Test_menhir1.main Lexer1.lex lex1);
+  ignore (Test_base.main Lexer2.lex lex2)

--- a/test/blackbox-tests/test-cases/menhir/explain.t/src/test_menhir1.mly
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/src/test_menhir1.mly
@@ -1,0 +1,10 @@
+%token <char> TOKEN
+%token EOF
+
+%start <char list> main
+
+%%
+
+main:
+| c = TOKEN EOF { [c] }
+| c = TOKEN xs = main  { c :: xs }

--- a/test/blackbox-tests/test-cases/menhir/explain.t/src/tokens.mly
+++ b/test/blackbox-tests/test-cases/menhir/explain.t/src/tokens.mly
@@ -1,0 +1,5 @@
+%token <char> TOKEN
+%token EOF
+
+%%
+

--- a/test/blackbox-tests/test-cases/menhir/general-2.0.t/run.t
+++ b/test/blackbox-tests/test-cases/menhir/general-2.0.t/run.t
@@ -3,3 +3,8 @@ Test the menhir extension version 2.0
   $ dune build ./src/test.exe --debug-dependency-path
   $ ls _build/default/src/test.exe
   _build/default/src/test.exe
+
+Check for .conflicts files in stanza with --explain
+
+  $ ls _build/default/src/test_base.conflicts
+  _build/default/src/test_base.conflicts


### PR DESCRIPTION
We now generate the .conflicts target if `--explain` was passed.

This allows for `--explain` to be passed in the menhir stanza and Dune will be aware of and expect a .conflict file. However, it is forbidden to pass using the `menhir_flags` field in an `env` stanza.

Previously I tried to allow for it in the env stanza, but we will need Dune to improve on some other fronts. Specifically rules are loaded per directory which makes it difficult to have slight variations of rules with different targets in the same directory. If we had more fine-grained rule loading, then we could choose which targets we want depending on the flags in the env stanza.


fix https://github.com/ocaml/dune/issues/6865