### PR TITLE
chore: update melange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,8 @@ ppx_inline_test \
 ppxlib \
 ctypes \
 "utop>=2.6.0" \
-"melange>=0.3.1" \
-"mel>=0.3.1"
-
+"melange" \
+"rescript-syntax"
 # Dependencies recommended for developing dune locally,
 # but not wanted in CI
 DEV_DEPS := \
@@ -74,8 +73,9 @@ dev-depext:
 
 .PHONY: melange
 melange:
-	opam pin add -n melange-compiler-libs https://github.com/melange-re/melange-compiler-libs.git#7263bea2285499f5da857f2bb374345a5178791e
-	opam pin add -n melange https://github.com/melange-re/melange.git#68c6eff82ed056feed809d6cc82558e8697b965b
+	opam pin add -n melange-compiler-libs.dev https://github.com/melange-re/melange-compiler-libs.git#575ac4c24b296ea897821f9aaee1146ff258c704
+	opam pin add -n melange.dev https://github.com/melange-re/melange.git#60eabf03d60b1e71f8d5aae72d24d7a1dfcf5bf6
+	opam pin add -n rescript-syntax.dev https://github.com/melange-re/melange.git#60eabf03d60b1e71f8d5aae72d24d7a1dfcf5bf6
 
 .PHONY: dev-deps
 dev-deps: melange

--- a/flake.lock
+++ b/flake.lock
@@ -33,12 +33,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -89,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678832347,
-        "narHash": "sha256-JwRlTPKOZXrqsVgDItVxQ2dIW3wvOetBu6j049CQoxg=",
+        "lastModified": 1682280790,
+        "narHash": "sha256-jMtxPlmu1E/tFuWFPH/skzsqYFM8uCO6gUFaKUi07/c=",
         "owner": "melange-re",
         "repo": "melange",
-        "rev": "2393b2d61e330f45d383640b1837bb9108567428",
+        "rev": "799f5d964d525b633419e7e15c4b7c23752983c1",
         "type": "github"
       },
       "original": {
@@ -114,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677175105,
-        "narHash": "sha256-jPp5jpjT9oD2YzAzEBSaQUBBf7+zUU/A3KDwNVuV32A=",
+        "lastModified": 1682222594,
+        "narHash": "sha256-icjQmfRUpo2nexX4XseQLPMhyffIxCftd0LHFW+LOwM=",
         "owner": "melange-re",
         "repo": "melange-compiler-libs",
-        "rev": "48ff923f2c25136de8ab96678f623f54cdac438c",
+        "rev": "575ac4c24b296ea897821f9aaee1146ff258c704",
         "type": "github"
       },
       "original": {
@@ -161,11 +164,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1678109515,
-        "narHash": "sha256-C2X+qC80K2C1TOYZT8nabgo05Dw2HST/pSn6s+n6BO8=",
+        "lastModified": 1681154353,
+        "narHash": "sha256-MCJ5FHOlbfQRFwN0brqPbCunLEVw05D/3sRVoNVt2tI=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "aa9ff6ce4a7f19af6415fb3721eaa513ea6c763c",
+        "rev": "f529f42792ade8e32c4be274af6b6d60857fbee7",
         "type": "github"
       },
       "original": {
@@ -176,11 +179,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678724065,
-        "narHash": "sha256-MjeRjunqfGTBGU401nxIjs7PC9PZZ1FBCZp/bRB3C2M=",
+        "lastModified": 1682109806,
+        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b8afc8489dc96f29f69bec50fdc51e27883f89c1",
+        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
         "type": "github"
       },
       "original": {
@@ -236,11 +239,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678382189,
-        "narHash": "sha256-P2nnT36PfuKUUpoPVC+aiH9AMcl7YQDgbtZjXVRj7Mc=",
+        "lastModified": 1679588234,
+        "narHash": "sha256-X0zKG9MF3I/71TA+cSSKCxHANsuFDZED1hcjjZDADFU=",
         "ref": "refs/heads/master",
-        "rev": "18f5b9a3e166f06f1d2bb50a23a8b41555ad9030",
-        "revCount": 1973,
+        "rev": "66539c162dc49010d73535a40c439bc5a3a2b39f",
+        "revCount": 1977,
         "submodules": true,
         "type": "git",
         "url": "https://www.github.com/ocaml/ocaml-lsp"
@@ -291,11 +294,11 @@
         "opam2json": "opam2json_2"
       },
       "locked": {
-        "lastModified": 1677575814,
-        "narHash": "sha256-Lc1GXBw0AiXGukJqzwtVEqBYv+DLUqcsqc8Lc3OtgUA=",
+        "lastModified": 1681998787,
+        "narHash": "sha256-SCGFATFXNsE8SVNSrq4Xf8uxpqc5AEqCM0jnAfdOOMQ=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "4bb1a4c372f639f44fc6745f13c86f4397e82d34",
+        "rev": "13b68fa2d6e50f0f668750e2180763eb0c3b808f",
         "type": "github"
       },
       "original": {
@@ -339,11 +342,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1678829224,
-        "narHash": "sha256-aqzDMgn2MbzBU4VDriDWCeUVf9nHPz7TKhKpBvHdOXo=",
+        "lastModified": 1682021363,
+        "narHash": "sha256-nDUDFwyOTZDALeqqEDnF2PTPIHT4sVYdQXUbRt03oNs=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "a4829b79154f5ef226969b530a75d52e12289468",
+        "rev": "786c55fa77c37f07eceea7d6a9bec04d2225e302",
         "type": "github"
       },
       "original": {
@@ -403,6 +406,21 @@
         "ocamllsp": "ocamllsp",
         "opam-nix": "opam-nix_2",
         "opam-repository": "opam-repository"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -170,7 +170,7 @@
           slim-melange = mkSlim {
             extraBuildInputs = [
               pkgs.ocamlPackages.melange
-              pkgs.ocamlPackages.mel
+              pkgs.ocamlPackages.rescript-syntax
             ];
             meta.description = ''
               Provides a minimal shell environment built purely from nixpkgs
@@ -214,7 +214,7 @@
                 ++ [
                 ocamllsp.outputs.packages.${system}.ocaml-lsp-server
                 pkgs.ocamlPackages.melange
-                pkgs.ocamlPackages.mel
+                pkgs.ocamlPackages.rescript-syntax
               ] ++ nixpkgs.lib.attrsets.attrVals (builtins.attrNames devPackages) scope;
               inputsFrom = [ self.packages.${system}.dune ];
               meta.description = ''

--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -90,7 +90,7 @@ module Prog = struct
         match program with
         | "refmt" -> Some (Option.value ~default:"opam install reason" hint)
         | "rescript_syntax" ->
-          Some (Option.value ~default:"opam install mel" hint)
+          Some (Option.value ~default:"opam install rescript-syntax" hint)
         | _ -> hint
       in
       Utils.program_not_found_message ?hint ~loc ~context program

--- a/test/blackbox-tests/test-cases/melange/copy-files-include-subdirs.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-include-subdirs.t
@@ -15,6 +15,8 @@ Example using melange.emit, copy_files and include_subdirs
   $ cat > src/dune <<EOF
   > (melange.emit
   >  (target app)
+  >  (preprocess (pps melange.ppx))
+  >  (emit_stdlib false)
   >  (alias mel))
   > 
   > (subdir
@@ -41,7 +43,6 @@ Example using melange.emit, copy_files and include_subdirs
   $ node $src
   hello from file
   
-
 Now add include_subdirs unqualified to show issue
 
   $ echo "(include_subdirs unqualified)" >> src/dune
@@ -51,4 +52,3 @@ Now add include_subdirs unqualified to show issue
   $ node $src
   hello from file
   
-

--- a/test/blackbox-tests/test-cases/melange/copy-files-simple.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-simple.t
@@ -8,6 +8,8 @@ Test simple interactions between melange.emit and copy_files
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (alias mel))
   > 
   > (copy_files
@@ -32,11 +34,14 @@ Test simple interactions between melange.emit and copy_files
   hello from file
   
 
+
 Copy the file into the output folder, so we can use same path as in-source
 
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)
+  >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (alias mel))
   > 
   > (subdir output
@@ -55,4 +60,3 @@ Copy the file into the output folder, so we can use same path as in-source
   $ node _build/default/output/main.js
   hello from file
   
-

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-dir-target.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-dir-target.t
@@ -15,6 +15,7 @@ Test simple interactions between melange.emit and copy_files
   >  (alias mel)
   >  (target output)
   >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps ./some_dir))
   > EOF
 
@@ -25,11 +26,7 @@ Test simple interactions between melange.emit and copy_files
   > let () = Js.log file_content
   > EOF
 
-  $ dune build @mel --display=short
-          melc .output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
-          melc output/main.js
-            sh some_dir
-            sh some_dir
+  $ dune build @mel
   Error: Is a directory
   -> required by _build/default/output/some_dir
   -> required by alias output/mel

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps-edge-cases.t
@@ -12,6 +12,7 @@ Test simple interactions between melange.emit and copy_files
   >  (alias mel)
   >  (target output)
   >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps assets/file.txt assets/file.txt))
   > EOF
 
@@ -34,9 +35,7 @@ Rules created for the assets in the output directory
    (targets ((files (default/a/output/a/assets/file.txt)) (directories ())))
     (chdir _build/default (copy a/assets/file.txt a/output/a/assets/file.txt))))
 
-  $ dune build @mel --display=short
-          melc a/.output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
-          melc a/output/a/main.js
+  $ dune build @mel
 
 The runtime_dep index.txt was copied to the build folder
 
@@ -52,6 +51,7 @@ The runtime_dep index.txt was copied to the build folder
   hello from file
   
 
+
 Test depending on non-existing paths
 
   $ mkdir another
@@ -61,16 +61,18 @@ Test depending on non-existing paths
   >  (alias non-existing-mel)
   >  (target another-output)
   >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps doesnt-exist.txt))
   > EOF
 
   $ dune build @non-existing-mel
-  File "another/dune", line 1, characters 0-119:
+  File "another/dune", line 1, characters 0-151:
   1 | (melange.emit
   2 |  (alias non-existing-mel)
   3 |  (target another-output)
   4 |  (emit_stdlib false)
-  5 |  (runtime_deps doesnt-exist.txt))
+  5 |  (preprocess (pps melange.ppx))
+  6 |  (runtime_deps doesnt-exist.txt))
   Error: No rule found for another/doesnt-exist.txt
   [1]
 
@@ -81,11 +83,12 @@ Test depend on non-file dependencies
   >  (alias non-existing-mel)
   >  (target another-output)
   >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps (sandbox none)))
   > EOF
   $ dune build @non-existing-mel
-  File "another/dune", line 5, characters 15-29:
-  5 |  (runtime_deps (sandbox none)))
+  File "another/dune", line 6, characters 15-29:
+  6 |  (runtime_deps (sandbox none)))
                      ^^^^^^^^^^^^^^
   Error: only files are allowed in this position
   [1]
@@ -98,6 +101,7 @@ Test depending on paths that "escape" the melange.emit directory
   >  (alias mel)
   >  (target another-output)
   >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps ../a/assets/file.txt))
   > EOF
   $ cat > another/main.ml <<EOF
@@ -117,11 +121,7 @@ Need to create the source dir first for the alias to be picked up
     ((files (default/another/another-output/a/assets/file.txt))
      (copy a/assets/file.txt another/another-output/a/assets/file.txt))))
 
-  $ dune build @mel --display=short
-          melc a/.output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
-          melc another/.another-output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
-          melc a/output/a/main.js
-          melc another/another-output/another/main.js
+  $ dune build @mel
 
 Path ends ups being emitted "correctly", but outside the target dir.
   $ ls _build/default/another/another-output/another
@@ -137,6 +137,7 @@ Test depending on external paths
   >  (alias mel)
   >  (target external-output)
   >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps /etc/hosts))
   > EOF
   $ cat > external/main.ml <<EOF
@@ -147,6 +148,7 @@ Test depending on external paths
   > EOF
 
   $ dune build @mel --display=short
+           ppx external/main.pp.ml
           melc external/.external-output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
           melc external/external-output/external/main.js
 

--- a/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/emit-with-runtime-deps.t
@@ -10,6 +10,7 @@ Test simple interactions between melange.emit and copy_files
   >  (alias mel)
   >  (emit_stdlib false)
   >  (target output)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps assets/file.txt (glob_files_rec ./globbed/*.txt)))
   > EOF
 
@@ -51,9 +52,7 @@ Creating the source directory makes it appear in the alias
    (targets ((files (default/output/assets/file.txt)) (directories ())))
    (action (chdir _build/default (copy assets/file.txt output/assets/file.txt))))
 
-  $ dune build @mel --display=short
-          melc .output.mobjs/melange/melange__Main.{cmi,cmj,cmt}
-          melc output/main.js
+  $ dune build @mel
 
 The runtime_dep index.txt was copied to the build folder
 
@@ -61,6 +60,7 @@ The runtime_dep index.txt was copied to the build folder
   assets
   globbed
   main.ml
+  main.pp.ml
   output
   $ ls _build/default/output
   assets
@@ -79,3 +79,4 @@ The runtime_dep index.txt was copied to the build folder
   $ node _build/default/output/main.js
   hello from file
   
+

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps.t
@@ -14,6 +14,7 @@ Test `melange.runtime_deps` in a library that has been installed
   > (library
   >  (public_name foo)
   >  (modes melange)
+  >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps index.txt nested/hello.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
@@ -58,6 +59,8 @@ Test `melange.runtime_deps` in a library that has been installed
   > (melange.emit
   >  (target output)
   >  (alias mel)
+  >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (libraries foo))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
@@ -10,6 +10,8 @@ Test `melange.runtime_deps` in a private library
   >  (target output)
   >  (alias mel)
   >  (libraries foo)
+  >  (emit_stdlib false)
+  >  (preprocess (pps melange.ppx))
   >  (runtime_deps assets/file.txt))
   > EOF
 
@@ -19,6 +21,7 @@ Test `melange.runtime_deps` in a private library
   > (library
   >  (name foo)
   >  (modes melange)
+  >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps index.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
@@ -46,6 +49,7 @@ The runtime_dep index.txt was copied to the library build folder
 
   $ ls _build/default/lib
   foo.ml
+  foo.pp.ml
   index.txt
 
 The runtime_dep index.txt was copied to the build folder

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -59,14 +59,14 @@ Dump-dot-merlin includes the melange flags
 
   $ dune ocaml dump-dot-merlin $PWD
   EXCLUDE_QUERY_DIR
-  STDLIB /MELC_STDLIB/runtime/melange
-  B /MELC_STDLIB/belt/melange
+  STDLIB /MELC_STDLIB/melange
   B /MELC_STDLIB/melange
-  B /MELC_STDLIB/runtime/melange
+  B /MELC_STDLIB/melange
+  B /MELC_STDLIB/melange
   B $TESTCASE_ROOT/_build/default/.output.mobjs/melange
   S /MELC_STDLIB
-  S /MELC_STDLIB/belt
-  S /MELC_STDLIB/runtime
+  S /MELC_STDLIB
+  S /MELC_STDLIB
   S $TESTCASE_ROOT
   # FLG -ppx '/MELC_COMPILER -as-ppx'
   # FLG -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -g
@@ -111,7 +111,7 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
 
   $ dune ocaml merlin dump-config $PWD | grep -v "(B "  | grep -v "(S "
   Bar
-  ((STDLIB /MELC_STDLIB/runtime/melange)
+  ((STDLIB /MELC_STDLIB/melange)
    (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
@@ -134,7 +134,7 @@ Melange ppx should appear after user ppx, so that Merlin applies the former firs
      -keep-locs
      -g)))
   Foo
-  ((STDLIB /MELC_STDLIB/runtime/melange)
+  ((STDLIB /MELC_STDLIB/melange)
    (EXCLUDE_QUERY_DIR)
    (B
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)

--- a/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/public-library-with-runtime-deps.t
@@ -14,6 +14,7 @@ Test `melange.runtime_deps` in a public library in the workspace
   > (library
   >  (public_name foo)
   >  (modes melange)
+  >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps index.txt nested/hello.txt))
   > EOF
   $ cat > lib/foo.ml <<EOF
@@ -46,6 +47,7 @@ Test `melange.runtime_deps` in a public library in the workspace
   >  (alias mel)
   >  (target output)
   >  (libraries foo)
+  >  (preprocess (pps melange.ppx))
   >  (emit_stdlib false)
   >  (runtime_deps assets/file.txt))
   > EOF
@@ -64,6 +66,7 @@ The runtime_dep index.txt was copied to the build folder
 
   $ ls _build/default/lib
   foo.ml
+  foo.pp.ml
   index.txt
   nested
   $ ls _build/default/output/node_modules/foo/
@@ -76,7 +79,6 @@ The runtime_dep index.txt was copied to the build folder
   
   Some text
   
-
 The same does not work for non-recursive aliases
 
   $ dune clean


### PR DESCRIPTION
- melange ppx and compiler are separate now
- the `mel` package is gone, rescript-syntax is installable with `opam install rescript-syntax`
- works across more compiler versions, unblocks moving test suite to 5.0 / 5.1