### PR TITLE
fix: files recorded by sandboxed cinaps action in action builder

### DIFF
--- a/src/dune_rules/cinaps.ml
+++ b/src/dune_rules/cinaps.ml
@@ -172,7 +172,11 @@ let gen_rules sctx t ~dir ~scope =
       Dep_conf_eval.unnamed ~sandbox ~expander t.runtime_deps
     in
     let* () = runtime_deps in
-    let+ () = Action_builder.path cinaps_exe in
+    let+ () =
+      Action_builder.deps
+        (Dep.Set.of_files
+           (cinaps_exe :: List.rev_map cinapsed_files ~f:Path.build))
+    in
     Action.Full.make ~sandbox
     @@ A.chdir (Path.build dir)
          (A.progn


### PR DESCRIPTION
We forgot to record the source files as part of the action which was causing them to not be added to the sandbox. This fix adds them and the example in the original report becomes resolved. I was unable to reproduce this issue in a cram test so it was tested manually.

fix #7376

