### PR TITLE
melange: test dune rules subcommand

### DIFF
--- a/test/blackbox-tests/test-cases/melange/dune-rules.t
+++ b/test/blackbox-tests/test-cases/melange/dune-rules.t
@@ -1,0 +1,71 @@
+Test dune rules
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+Using flags field in melange.emit stanzas is not supported
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (modules main))
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > print_endline "hello"
+  > EOF
+
+Calling dune rules with the alias works fine
+
+  $ dune rules @melange
+  ((deps
+    ((File (External /home/me/code/dune/_opam/bin/melc))
+     (File
+      (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
+   (targets ((files (default/output/main.js)) (directories ())))
+   (context default)
+   (action
+    (chdir
+     _build/default
+     (run
+      /home/me/code/dune/_opam/bin/melc
+      -I
+      .output.mobjs/melange
+      --bs-module-type
+      commonjs
+      -o
+      output/main.js
+      .output.mobjs/melange/melange__Main.cmj))))
+
+Using output folder fails
+
+  $ dune rules output
+  Error: Don't know how to build output
+  [1]
+
+Creating dir fixes the problem
+
+  $ mkdir output
+
+  $ dune rules output
+  ((deps
+    ((File (External /home/me/code/dune/_opam/bin/melc))
+     (File
+      (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
+   (targets ((files (default/output/main.js)) (directories ())))
+   (context default)
+   (action
+    (chdir
+     _build/default
+     (run
+      /home/me/code/dune/_opam/bin/melc
+      -I
+      .output.mobjs/melange
+      --bs-module-type
+      commonjs
+      -o
+      output/main.js
+      .output.mobjs/melange/melange__Main.cmj))))

--- a/test/blackbox-tests/test-cases/melange/dune-rules.t
+++ b/test/blackbox-tests/test-cases/melange/dune-rules.t
@@ -18,25 +18,8 @@ Test dune rules
 
 Calling dune rules with the alias works fine
 
-  $ dune rules @melange
-  ((deps
-    ((File (External /home/me/code/dune/_opam/bin/melc))
-     (File
+  $ dune rules @melange | grep In_build_dir
       (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
-   (targets ((files (default/output/main.js)) (directories ())))
-   (context default)
-   (action
-    (chdir
-     _build/default
-     (run
-      /home/me/code/dune/_opam/bin/melc
-      -I
-      .output.mobjs/melange
-      --bs-module-type
-      commonjs
-      -o
-      output/main.js
-      .output.mobjs/melange/melange__Main.cmj))))
 
 Using output folder fails
 
@@ -48,22 +31,5 @@ Creating dir fixes the problem
 
   $ mkdir output
 
-  $ dune rules output
-  ((deps
-    ((File (External /home/me/code/dune/_opam/bin/melc))
-     (File
+  $ dune rules output | grep In_build_dir
       (In_build_dir _build/default/.output.mobjs/melange/melange__Main.cmj))))
-   (targets ((files (default/output/main.js)) (directories ())))
-   (context default)
-   (action
-    (chdir
-     _build/default
-     (run
-      /home/me/code/dune/_opam/bin/melc
-      -I
-      .output.mobjs/melange
-      --bs-module-type
-      commonjs
-      -o
-      output/main.js
-      .output.mobjs/melange/melange__Main.cmj))))

--- a/test/blackbox-tests/test-cases/melange/dune-rules.t
+++ b/test/blackbox-tests/test-cases/melange/dune-rules.t
@@ -5,8 +5,6 @@ Test dune rules
   > (using melange 0.1)
   > EOF
 
-Using flags field in melange.emit stanzas is not supported
-
   $ cat > dune <<EOF
   > (melange.emit
   >  (target output)


### PR DESCRIPTION
Due to the way melange target dirs work, it is not possible to get `dune rules <target_folder>` to return the rules inside that folder, unless it is created manually. This PR adds a test to document that behavior.