### PR TITLE
Update monorepo benchmark to use external runner

### DIFF
--- a/bench/monorepo/Makefile
+++ b/bench/monorepo/Makefile
@@ -1,12 +1,11 @@
-# Intended to be used from inside docker containers built from monorepo-bench.Dockerfile
-RUNNER = _build/default/bench.exe
-DUNE_TO_BENCHMARK = /home/user/dune/_build/default/bin/main.exe
+# Intended to be used from inside docker containers built from bench.Dockerfile
+RUNNER = /home/user/monorepo-benchmark/dune-benchmark-runner/_build/default/src/main.exe
+DUNE_EXE_PATH = /home/user/dune/_build/default/bin/main.exe
+BUILD_TARGET = ./monorepo_bench.exe
+MONOREPO_PATH = /home/user/monorepo-benchmark/benchmark
 
-$(RUNNER): dune bench.ml
-	dune build $@ --release
-
-bench: $(RUNNER)
-	$< $(DUNE_TO_BENCHMARK) build -j auto
+bench:
+	$(RUNNER) --dune-exe-path=$(DUNE_EXE_PATH) --build-target=$(BUILD_TARGET) --monorepo-path=$(MONOREPO_PATH) --print-dune-output
 
 clean:
 	dune clean

--- a/bench/monorepo/README.md
+++ b/bench/monorepo/README.md
@@ -7,7 +7,13 @@ to be consumed by current-bench.
 
 The monorepo will be set up with opam-monorepo using the lockfile
 [here](https://github.com/ocaml-dune/ocaml-monorepo-benchmark/blob/main/benchmark/monorepo-bench.opam.locked)
-which is downloaded during `docker build`. Also during `docker build`,
-a a library is created called `monorepo` with
+which is downloaded during `docker build`. Also during `docker build`, an
+executable dune project is created called `monorepo_bench` with
 [this](https://github.com/ocaml-dune/ocaml-monorepo-benchmark/blob/main/benchmark/dune)
 dune file listing all the libraries to include in the build.
+
+The benchmark runner is a program which invokes dune in a number of
+benchmarking scenarios and prints out the results in a format understood by
+[current-bench](https://github.com/ocurrent/current-bench). The source code for
+the benchmark runner is
+[here](https://github.com/ocaml-dune/ocaml-monorepo-benchmark/tree/main/dune-benchmark-runner).

--- a/bench/monorepo/dune
+++ b/bench/monorepo/dune
@@ -1,4 +1,0 @@
-(executable
- (public_name bench)
- (modules bench)
- (libraries unix))

--- a/bench/monorepo/dune-project
+++ b/bench/monorepo/dune-project
@@ -1,2 +1,0 @@
-(lang dune 3.5)
-(package (name monorepo-bench))


### PR DESCRIPTION
The benchmark runner is now located in:
https://github.com/ocaml-dune/ocaml-monorepo-benchmark/tree/main/dune-benchmark-runner

This updates the monorepo benchmark dockerfile to download and build the benchmark runner and makes some quality of life improvements to the dockerfile.

This also changes the benchmarking scenario to include watch-mode benchmarks.