### PR TITLE
refactor: remove context.stdlib_dir

### DIFF
--- a/bin/install_uninstall.ml
+++ b/bin/install_uninstall.ml
@@ -718,7 +718,7 @@ let install_uninstall ~what =
               let conf =
                 Dune_rules.Artifact_substitution.conf_for_install ~relocatable
                   ~default_ocamlpath:context.default_ocamlpath
-                  ~stdlib_dir:context.stdlib_dir ~roots ~context
+                  ~stdlib_dir:context.lib_config.stdlib_dir ~roots ~context
               in
               Fiber.sequential_iter entries_per_package
                 ~f:(fun (package, entries) ->

--- a/src/dune_rules/artifact_substitution.ml
+++ b/src/dune_rules/artifact_substitution.ml
@@ -87,7 +87,7 @@ let conf_of_context (context : Context.t option) =
     let get_location = Install.Section.Paths.get_local_location context.name in
     let get_config_path = function
       | Sourceroot -> Some (Path.source Path.Source.root)
-      | Stdlib -> Some context.stdlib_dir
+      | Stdlib -> Some context.lib_config.stdlib_dir
     in
     let hardcoded_ocaml_path =
       let install_dir = Local_install_path.dir ~context:context.name in

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -125,7 +125,6 @@ type t =
   ; ocaml_config : Ocaml_config.t
   ; ocaml_config_vars : Ocaml_config.Vars.t
   ; version : Ocaml.Version.t
-  ; stdlib_dir : Path.t
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; lib_config : Lib_config.t
   ; build_context : Build_context.t
@@ -621,7 +620,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; findlib_toolchain
       ; default_ocamlpath
       ; arch_sixtyfour
-      ; stdlib_dir
       ; ocaml_config = ocfg
       ; ocaml_config_vars
       ; version

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -85,7 +85,6 @@ type t = private
   ; ocaml_config : Ocaml_config.t
   ; ocaml_config_vars : Ocaml_config.Vars.t
   ; version : Ocaml.Version.t
-  ; stdlib_dir : Path.t
   ; supports_shared_libraries : Dynlink_supported.By_the_os.t
   ; lib_config : Lib_config.t
   ; build_context : Build_context.t

--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -189,7 +189,7 @@ let build_c_program ~foreign_archives_deps ~sctx ~dir ~source_files ~scope
     Command.Args.S [ base_flags; As foreign_flags ]
   in
   let include_args =
-    let ocaml_where = ctx.stdlib_dir in
+    let ocaml_where = ctx.lib_config.stdlib_dir in
     (* XXX: need glob dependency *)
     let open Action_builder.O in
     let ctypes = Lib_name.of_string "ctypes" in

--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -128,7 +128,7 @@ let executables_rules ~sctx ~dir ~expander ~dir_contents ~scope ~compile_info
       ~preprocessing:pp ~js_of_ocaml ~opaque:Inherit_from_settings
       ~package:exes.package
   in
-  let stdlib_dir = ctx.Context.stdlib_dir in
+  let stdlib_dir = ctx.lib_config.stdlib_dir in
   let* requires_compile = Compilation_context.requires_compile cctx in
   let preprocess =
     Preprocess.Per_module.with_instrumentation exes.buildable.preprocess

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -446,7 +446,8 @@ let expand_pform_gen ~(context : Context.t) ~bindings ~dir ~source
       | Ocaml_bin_dir -> static [ Dir context.ocaml_bin ]
       | Ocaml_version ->
         static (string (Ocaml_config.version_string context.ocaml_config))
-      | Ocaml_stdlib_dir -> static (string (Path.to_string context.stdlib_dir))
+      | Ocaml_stdlib_dir ->
+        static (string (Path.to_string context.lib_config.stdlib_dir))
       | Dev_null -> static (string (Path.to_string Dev_null.path))
       | Ext_obj -> static (string context.lib_config.ext_obj)
       | Ext_asm -> static (string (Ocaml_config.ext_asm context.ocaml_config))

--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -193,7 +193,7 @@ let build_c ~(kind : Foreign_language.t) ~sctx ~dir ~expander ~include_flags
        produced in the current directory *)
     Command.run ~dir:(Path.build dir) c_compiler
       ([ Command.Args.dyn with_user_and_std_flags
-       ; S [ A "-I"; Path ctx.stdlib_dir ]
+       ; S [ A "-I"; Path ctx.lib_config.stdlib_dir ]
        ; include_flags
        ]
       @ output_param @ [ A "-c"; Dep src ])

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -485,7 +485,7 @@ let library_rules (lib : Library.t) ~local_lib ~cctx ~source_modules
   let dir = Compilation_context.dir cctx in
   let scope = Compilation_context.scope cctx in
   let* requires_compile = Compilation_context.requires_compile cctx in
-  let stdlib_dir = (Compilation_context.context cctx).Context.stdlib_dir in
+  let stdlib_dir = (Compilation_context.context cctx).lib_config.stdlib_dir in
   let top_sorted_modules =
     let impl_only = Modules.impl_only modules in
     Dep_graph.top_closed_implementations

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -222,7 +222,7 @@ let setup_emit_cmj_rules ~sctx ~dir ~scope ~expander ~dir_contents
         ~instrumentation_backend:
           (Lib.DB.instrumentation_backend (Scope.libs scope))
     in
-    let stdlib_dir = ctx.stdlib_dir in
+    let stdlib_dir = ctx.lib_config.stdlib_dir in
     let+ () =
       let emit_and_libs_deps =
         let target_dir = Path.Build.relative dir mel.target in


### PR DESCRIPTION
it's already present in lib_config

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 2d10228f-5468-4404-a9e6-a25f604ab6ec -->