### PR TITLE
refactor: get rid of context.toplevel_path

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -109,7 +109,6 @@ type t =
   ; build_dir : Path.Build.t
   ; env_nodes : Env_nodes.t
   ; path : Path.t list
-  ; toplevel_path : Path.t option
   ; ocaml_bin : Path.t
   ; ocaml : Action.Prog.t
   ; ocamlc : Path.t
@@ -149,7 +148,6 @@ let to_dyn t : Dyn.t =
       )
     ; ("fdo_target_exe", option path t.fdo_target_exe)
     ; ("build_dir", Path.Build.to_dyn t.build_dir)
-    ; ("toplevel_path", option path t.toplevel_path)
     ; ("ocaml_bin", path t.ocaml_bin)
     ; ("ocaml", Action.Prog.to_dyn t.ocaml)
     ; ("ocamlc", path t.ocamlc)
@@ -608,10 +606,6 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
       ; for_host = host
       ; build_dir = Context_name.build_dir name
       ; path
-      ; toplevel_path =
-          Option.map
-            (Env.get env "OCAML_TOPLEVEL_PATH")
-            ~f:Path.of_filename_relative_to_initial_cwd
       ; ocaml_bin
       ; ocaml
       ; ocamlc

--- a/src/dune_rules/context.mli
+++ b/src/dune_rules/context.mli
@@ -66,11 +66,9 @@ type t = private
         (** Directory where artifact are stored, for instance "_build/default" *)
   ; build_dir : Path.Build.t
         (** env node that this context was initialized with *)
-  ; env_nodes : Env_nodes.t  (** [PATH] *)
-  ; path : Path.t list  (** [OCAML_TOPLEVEL_PATH] *)
-  ; toplevel_path : Path.t option
-        (** Ocaml bin directory with all ocaml tools *)
-  ; ocaml_bin : Path.t
+  ; env_nodes : Env_nodes.t
+  ; path : Path.t list  (** [PATH] *)
+  ; ocaml_bin : Path.t  (** Ocaml bin directory with all ocaml tools *)
   ; ocaml : Action.Prog.t
   ; ocamlc : Path.t
   ; ocamlopt : Action.Prog.t


### PR DESCRIPTION
It was never used

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 307c6a66-8ea1-45bd-bf71-647c8362c429 -->