### PR TITLE
refactor: remove context_name from lib_config

### DIFF
--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -418,11 +418,9 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
            Dynlink_supported.By_the_os.of_bool natdynlink_supported)
       ; stdlib_dir
       ; ccomp_type = Ocaml_config.ccomp_type ocaml.ocaml_config
-      ; profile
       ; ocaml_version_string = Ocaml_config.version_string ocaml.ocaml_config
       ; ocaml_version = Ocaml.Version.of_ocaml_config ocaml.ocaml_config
       ; instrument_with
-      ; context_name = name
       }
     in
     if Option.is_some fdo_target_exe then

--- a/src/dune_rules/lib_config.ml
+++ b/src/dune_rules/lib_config.ml
@@ -12,11 +12,9 @@ type t =
   ; ext_dll : string
   ; stdlib_dir : Path.t
   ; ccomp_type : Ocaml_config.Ccomp_type.t
-  ; profile : Profile.t
   ; ocaml_version_string : string
   ; ocaml_version : Ocaml.Version.t
   ; instrument_with : Lib_name.t list
-  ; context_name : Context_name.t
   }
 
 let allowed_in_enabled_if =
@@ -25,9 +23,7 @@ let allowed_in_enabled_if =
   ; ("model", (1, 0))
   ; ("os_type", (1, 0))
   ; ("ccomp_type", (2, 0))
-  ; ("profile", (2, 5))
   ; ("ocaml_version", (2, 5))
-  ; ("context_name", (2, 8))
   ]
 
 let get_for_enabled_if t (pform : Pform.t) =
@@ -37,9 +33,7 @@ let get_for_enabled_if t (pform : Pform.t) =
   | Var Model -> t.model
   | Var Os_type -> Ocaml_config.Os_type.to_string t.os_type
   | Var Ccomp_type -> Ocaml_config.Ccomp_type.to_string t.ccomp_type
-  | Var Profile -> Profile.to_string t.profile
   | Var Ocaml_version -> t.ocaml_version_string
-  | Var Context_name -> Context_name.to_string t.context_name
   | _ ->
     Code_error.raise "Lib_config.get_for_enabled_if: var not allowed"
       [ ("var", Pform.to_dyn pform) ]

--- a/src/dune_rules/lib_config.mli
+++ b/src/dune_rules/lib_config.mli
@@ -12,11 +12,9 @@ type t =
   ; ext_dll : string
   ; stdlib_dir : Path.t
   ; ccomp_type : Ocaml_config.Ccomp_type.t
-  ; profile : Profile.t
   ; ocaml_version_string : string
   ; ocaml_version : Ocaml.Version.t
   ; instrument_with : Lib_name.t list
-  ; context_name : Context_name.t
   }
 
 val allowed_in_enabled_if : (string * Dune_lang.Syntax.Version.t) list

--- a/test/blackbox-tests/test-cases/enabled_if/eif-forbidden_var.t/run.t
+++ b/test/blackbox-tests/test-cases/enabled_if/eif-forbidden_var.t/run.t
@@ -3,8 +3,8 @@ This one uses forbidden variables
   File "dune", line 3, characters 16-31:
   3 |  (enabled_if (= %{project_root} "")))
                       ^^^^^^^^^^^^^^^
-  Error: Only architecture, system, model, os_type, ccomp_type, profile,
-  ocaml_version and context_name variables are allowed in this 'enabled_if'
+  Error: Only context_name, profile, architecture, system, model, os_type,
+  ccomp_type and ocaml_version variables are allowed in this 'enabled_if'
   field. If you think that project_root should also be allowed, please file an
   issue about it.
   [1]

--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -37,8 +37,8 @@
   dune_tests_common
   stdune
   dune_engine
-  dune_lang
   dune_rules
+  dune_lang
   memo
   test_scheduler
   ;; This is because of the (implicit_transitive_deps false)

--- a/test/expect-tests/findlib_tests.ml
+++ b/test/expect-tests/findlib_tests.ml
@@ -2,7 +2,6 @@ open Stdune
 open Dune_rules
 open Dune_rules.For_tests
 open Dune_tests_common
-module Context_name = Dune_engine.Context_name
 
 let () = init ()
 
@@ -34,11 +33,9 @@ let findlib =
     ; ext_dll = ".so"
     ; stdlib_dir = Path.root
     ; ccomp_type = Other "gcc"
-    ; profile = Dev
     ; ocaml_version_string = "4.02.3"
     ; ocaml_version = Ocaml.Version.make (4, 2, 3)
     ; instrument_with = []
-    ; context_name = Context_name.of_string "default"
     }
   in
   Memo.lazy_ (fun () ->


### PR DESCRIPTION
It has nothing to do with library settings

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 9f908882-cb0a-441e-894f-340341bea649 -->