### PR TITLE
refactor: move executable find to own module

### DIFF
--- a/src/dune_rules/which.ml
+++ b/src/dune_rules/which.ml
@@ -1,0 +1,53 @@
+open Import
+open Memo.O
+
+let programs_for_which_we_prefer_opt_ext =
+  [ "ocamlc"; "ocamldep"; "ocamlmklib"; "ocamlobjinfo"; "ocamlopt" ]
+
+let best_path ~dir program =
+  let exe_path program =
+    let fn = Path.relative dir (program ^ Bin.exe) in
+    let+ exists = Fs_memo.file_exists (Path.as_outside_build_dir_exn fn) in
+    if exists then Some fn else None
+  in
+  if List.mem programs_for_which_we_prefer_opt_ext program ~equal:String.equal
+  then
+    let* path = exe_path (program ^ ".opt") in
+    match path with
+    | None -> exe_path program
+    | Some _ as path -> Memo.return path
+  else exe_path program
+
+module rec Rec : sig
+  val which : path:Path.t list -> string -> Path.t option Memo.t
+end = struct
+  open Rec
+
+  let which_impl (path, program) =
+    match path with
+    | [] -> Memo.return None
+    | dir :: path -> (
+      let* res = best_path ~dir program in
+      match res with
+      | None -> which ~path program
+      | Some prog -> Memo.return (Some prog))
+
+  let which =
+    let memo =
+      let module Input = struct
+        type t = Path.t list * string
+
+        let equal = Tuple.T2.equal (List.equal Path.equal) String.equal
+
+        let hash = Tuple.T2.hash (List.hash Path.hash) String.hash
+
+        let to_dyn = Dyn.opaque
+      end in
+      Memo.create "which"
+        ~input:(module Input)
+        ~cutoff:(Option.equal Path.equal) which_impl
+    in
+    fun ~path prog -> Memo.exec memo (path, prog)
+end
+
+include Rec

--- a/src/dune_rules/which.mli
+++ b/src/dune_rules/which.mli
@@ -1,0 +1,8 @@
+open Import
+
+(** [best_path ~dir prog] if [prog] is one of the special programs that can be
+    installed with an .opt extension, look it up in [dir] using this extension *)
+val best_path : dir:Path.t -> Filename.t -> Path.t option Memo.t
+
+(** [which ~path prog] finds the path of [prog] in [path] *)
+val which : path:Path.t list -> Filename.t -> Path.t option Memo.t


### PR DESCRIPTION
Will be used by package management

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d60eaf28-0c94-4611-b04d-a3ec72f45ab8 -->