### PR TITLE
refactor: improve fetching error messages

### DIFF
--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -1,3 +1,5 @@
 open Stdune
 
-val fetch : OpamUrl.t -> target:Path.t -> unit Fiber.t
+(** [fetch loc url ~target] will fetch [url] into [target]. If there's an error
+    fetching, [loc] will be used as the location for the error. *)
+val fetch : Loc.t -> OpamUrl.t -> target:Path.t -> unit Fiber.t

--- a/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
+++ b/test/expect-tests/dune_pkg/dune_pkg_unit_tests.ml
@@ -30,7 +30,7 @@ let url ~port ~filename =
 let download ~port ~filename ~target () =
   let open Fiber.O in
   let url = url ~port ~filename in
-  let* () = Fetch.fetch url ~target in
+  let* () = Fetch.fetch Loc.none url ~target in
   print_endline "Done downloading";
   Fiber.return ()
 


### PR DESCRIPTION
* Include location in the error message
* Do not include verbose message
* Format errors using the correct dune primitives

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a0a4ce03-cb51-418b-ab38-b453a90f46cb -->