### PR TITLE
refactor: minor source fetching cleanups

### DIFF
--- a/src/dune_pkg/fetch.ml
+++ b/src/dune_pkg/fetch.ml
@@ -3,51 +3,43 @@ module Process = Dune_engine.Process
 module Display = Dune_engine.Display
 
 module Fiber_job = struct
-  let opam_style_read_file path =
-    path |> Io.read_file
-    |> String.drop_suffix_if_exists ~suffix:"\n"
-    |> String.split ~on:'\n'
-
-  let run command =
+  let run (command : OpamProcess.command) =
     let open Fiber.O in
-    let prog =
-      command.OpamProcess.cmd |> Path.External.of_string |> Path.external_
-    in
-    let args = command.args in
-    let dir =
-      command.cmd_dir
-      |> Option.map ~f:(fun path ->
-             path |> Path.Outside_build_dir.of_string |> Path.outside_build_dir)
-    in
-    let display = Display.Quiet in
-    let env = command.cmd_env |> Option.map ~f:Env.of_unix in
-    let stdin_from =
-      match command.cmd_stdin with
-      | Some true -> Some Process.Io.stdin
-      | None | Some false -> None
-    in
-    let stderr_file =
-      Temp.create Temp.File ~prefix:"source-fetch" ~suffix:"stderr"
-    in
+    let prefix = "dune-source-fetch" in
+    let stderr_file = Temp.create File ~prefix ~suffix:"stderr" in
     let stdout_file =
       match command.cmd_stdout with
-      | None -> Temp.create Temp.File ~prefix:"source-fetch" ~suffix:"stdout"
+      | None -> Temp.create File ~prefix ~suffix:"stdout"
       | Some path -> path |> Path.External.of_string |> Path.external_
     in
-
     let stderr_to = Process.Io.file stderr_file Out in
     let stdout_to = Process.Io.file stdout_file Out in
     let* times =
-      Process.run_with_times ~display ?dir ?env ?stdin_from ~stderr_to
+      let prog = command.cmd |> Path.External.of_string |> Path.external_ in
+      let args = command.args in
+      let stdin_from =
+        match command.cmd_stdin with
+        | Some true -> Some Process.Io.stdin
+        | None | Some false -> None
+      in
+      let dir =
+        command.cmd_dir
+        |> Option.map ~f:(fun path ->
+               path |> Path.Outside_build_dir.of_string
+               |> Path.outside_build_dir)
+      in
+      let env = command.cmd_env |> Option.map ~f:Env.of_unix in
+      Process.run_with_times ~display:Quiet ?dir ?env ?stdin_from ~stderr_to
         ~stdout_to prog args
     in
-
-    let r_stdout = opam_style_read_file stdout_file in
-    let r_stderr = opam_style_read_file stderr_file in
-    (* Process.run_with_times forces Strict failure-mode, so the return code is 0 *)
-    let r_code = 0 in
-    let r_duration = times.elapsed_time in
     let result : OpamProcess.result =
+      let r_stdout = Io.lines_of_file stdout_file in
+      let r_stderr = Io.lines_of_file stderr_file in
+      Temp.destroy File stderr_file;
+      Temp.destroy File stdout_file;
+      (* Process.run_with_times forces Strict failure-mode, so the return code is 0 *)
+      let r_code = 0 in
+      let r_duration = times.elapsed_time in
       { r_code
       ; r_signal = None
       ; r_duration


### PR DESCRIPTION
* Cleanup temporary files as soon as we read them
* Remove opam_style_read_file in favor of stdune's equivalent
* do not qualify some constructors
* include dune in the name of temp files

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d6451f07-de64-4591-ad62-830aba7276f5 -->