### PR TITLE
test(melange): melange public dir depending on private lib

### DIFF
--- a/otherlibs/stdune/src/path.ml
+++ b/otherlibs/stdune/src/path.ml
@@ -1265,6 +1265,18 @@ let chmod t ~mode = Unix.chmod (to_string t) mode
 let follow_symlink path =
   Fpath.follow_symlink (to_string path) |> Result.map ~f:of_string
 
+let drop_prefix path ~prefix =
+  String.drop_prefix (to_string path) ~prefix:(to_string prefix)
+  |> Option.map ~f:(fun p ->
+         String.drop_prefix_if_exists ~prefix:"/" p |> Local.of_string)
+
+let drop_prefix_exn t ~prefix =
+  match drop_prefix t ~prefix with
+  | None ->
+    Code_error.raise "Path.drop_prefix_exn"
+      [ ("t", to_dyn t); ("prefix", to_dyn prefix) ]
+  | Some p -> p
+
 module Expert = struct
   let drop_absolute_prefix ~prefix p =
     match

--- a/otherlibs/stdune/src/path.mli
+++ b/otherlibs/stdune/src/path.mli
@@ -447,6 +447,14 @@ val chmod : t -> mode:int -> unit
 (** Attempts to resolve a symlink. Returns [None] if the path isn't a symlink *)
 val follow_symlink : t -> (t, Fpath.follow_symlink_error) result
 
+(** [drop_prefix_exn t ~prefix] drops the [prefix] from a path, including any
+    leftover `/` prefix. Raises a [Code_error.t] if the prefix wasn't found. *)
+val drop_prefix_exn : t -> prefix:t -> Local.t
+
+(** [drop_prefix t ~prefix] drops the [prefix] from a path, including any
+    leftover `/` prefix. Returns [None] if the prefix wasn't found. *)
+val drop_prefix : t -> prefix:t -> Local.t option
+
 module Expert : sig
   (** Attempt to convert external paths to source/build paths. Don't use this
       function unless strictly necessary. It's not completely reliable and we

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -206,7 +206,12 @@ end = struct
           let visibility = Module.visibility m in
           let dir' = Obj_dir.cm_dir external_obj_dir cm_kind visibility in
           if Path.equal (Path.build dir) dir' then None
-          else Path.basename dir' |> Option.some
+          else
+            String.drop_prefix (Path.to_string dir')
+              ~prefix:(Path.Build.to_string dir)
+            |> Option.value_exn
+            |> String.drop_prefix_if_exists ~prefix:"/"
+            |> Option.some
       in
       let if_ b (cm_kind, f) =
         if b then

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -207,11 +207,8 @@ end = struct
           let dir' = Obj_dir.cm_dir external_obj_dir cm_kind visibility in
           if Path.equal (Path.build dir) dir' then None
           else
-            String.drop_prefix (Path.to_string dir')
-              ~prefix:(Path.Build.to_string dir)
-            |> Option.value_exn
-            |> String.drop_prefix_if_exists ~prefix:"/"
-            |> Option.some
+            Path.drop_prefix_exn dir' ~prefix:(Path.build dir)
+            |> Path.Local.to_string |> Option.some
       in
       let if_ b (cm_kind, f) =
         if b then

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -29,14 +29,9 @@ let output_of_lib ~target_dir lib =
           [ "node_modules"; Lib_name.to_string lib_name ] )
 
 let lib_output_path ~output_dir ~lib_dir src =
-  let dir =
-    let src_dir = Path.to_string src in
-    let lib_dir = Path.to_string lib_dir in
-    String.drop_prefix src_dir ~prefix:lib_dir
-    |> Option.value_exn
-    |> String.drop_prefix_if_exists ~prefix:"/"
-  in
-  if dir = "" then output_dir else Path.Build.relative output_dir dir
+  match Path.drop_prefix_exn src ~prefix:lib_dir |> Path.Local.to_string with
+  | "" -> output_dir
+  | dir -> Path.Build.relative output_dir dir
 
 let make_js_name ~js_ext ~output m =
   let basename = Melange.js_basename m ^ js_ext in

--- a/src/dune_rules/module_compilation.ml
+++ b/src/dune_rules/module_compilation.ml
@@ -63,17 +63,14 @@ let melange_args (cctx : Compilation_context.t) (cm_kind : Lib_mode.Cm_kind.t)
       | Some lib_name ->
         let dir =
           let package_output = Path.as_in_build_dir_exn package_output in
-          let lib_root_dir =
-            Path.Build.to_string (Compilation_context.dir cctx)
-          in
-          let src_dir = Path.Build.to_string package_output in
+          let lib_root_dir = Path.build (Compilation_context.dir cctx) in
+          let src_dir = Path.build package_output in
           let build_dir =
             (Compilation_context.super_context cctx |> Super_context.context)
               .build_dir
           in
-          String.drop_prefix src_dir ~prefix:lib_root_dir
-          |> Option.value_exn
-          |> String.drop_prefix_if_exists ~prefix:"/"
+          Path.drop_prefix_exn src_dir ~prefix:lib_root_dir
+          |> Path.Local.to_string
           |> Path.Build.relative build_dir
         in
 

--- a/test/blackbox-tests/test-cases/melange/emit-private.t
+++ b/test/blackbox-tests/test-cases/melange/emit-private.t
@@ -38,6 +38,7 @@ Test dependency on a private library in the same package as melange.emit
   >  (target dist)
   >  (alias dist)
   >  (libraries a)
+  >  (emit_stdlib false)
   >  (package a))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/emit-private.t
+++ b/test/blackbox-tests/test-cases/melange/emit-private.t
@@ -23,12 +23,12 @@ Test dependency on a private library in the same package as melange.emit
 
   $ dune install --prefix $PWD/prefix --display short
   Installing $TESTCASE_ROOT/prefix/lib/a/META
-  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a.cmi
-  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a.cmt
-  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a__Foo.cmi
-  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/.public_cmi_melange/a__Foo.cmt
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/a.ml
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/foo.ml
+  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/.public_cmi_melange/a.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/.public_cmi_melange/a.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/.public_cmi_melange/a__Foo.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/.public_cmi_melange/a__Foo.cmt
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/a.cmj
   Installing $TESTCASE_ROOT/prefix/lib/a/__private__/a/melange/a__Foo.cmj
   Installing $TESTCASE_ROOT/prefix/lib/a/dune-package

--- a/test/blackbox-tests/test-cases/melange/installed-private-lib-dep.t
+++ b/test/blackbox-tests/test-cases/melange/installed-private-lib-dep.t
@@ -32,8 +32,8 @@ Melange (installed) library depends on private library
   Leaving directory 'lib'
   $ dune install --prefix $PWD/prefix --root lib --display short
   Installing $TESTCASE_ROOT/prefix/lib/foo/META
-  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/.public_cmi_melange/priv.cmi
-  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/.public_cmi_melange/priv.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/melange/.public_cmi_melange/priv.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/melange/.public_cmi_melange/priv.cmt
   Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/melange/priv.cmj
   Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/priv.ml
   Installing $TESTCASE_ROOT/prefix/lib/foo/dune-package
@@ -53,7 +53,6 @@ Melange (installed) library depends on private library
   > (melange.emit
   >  (target output)
   >  (libraries foo)
-  >  (compile_flags -bs-diagnose -verbose)
   >  (emit_stdlib false))
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/installed-private-lib-dep.t
+++ b/test/blackbox-tests/test-cases/melange/installed-private-lib-dep.t
@@ -1,0 +1,76 @@
+Melange (installed) library depends on private library
+
+  $ mkdir -p lib/lib lib/priv
+  $ cat > lib/dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name foo))
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > lib/priv/dune <<EOF
+  > (library
+  >  (name priv)
+  >  (package foo)
+  >  (modes melange))
+  > EOF
+  $ cat > lib/priv/priv.ml <<EOF
+  > let x = "private"
+  > EOF
+
+  $ cat > lib/lib/dune <<EOF
+  > (library
+  >  (public_name foo)
+  >  (modes melange)
+  >  (libraries priv))
+  > EOF
+  $ cat > lib/lib/foo.ml <<EOF
+  > let x = "public lib uses " ^ Priv.x
+  > EOF
+
+  $ dune build @install --root lib
+  Entering directory 'lib'
+  Leaving directory 'lib'
+  $ dune install --prefix $PWD/prefix --root lib --display short
+  Installing $TESTCASE_ROOT/prefix/lib/foo/META
+  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/.public_cmi_melange/priv.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/.public_cmi_melange/priv.cmt
+  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/melange/priv.cmj
+  Installing $TESTCASE_ROOT/prefix/lib/foo/__private__/priv/priv.ml
+  Installing $TESTCASE_ROOT/prefix/lib/foo/dune-package
+  Installing $TESTCASE_ROOT/prefix/lib/foo/foo.ml
+  Installing $TESTCASE_ROOT/prefix/lib/foo/melange/foo.cmi
+  Installing $TESTCASE_ROOT/prefix/lib/foo/melange/foo.cmj
+  Installing $TESTCASE_ROOT/prefix/lib/foo/melange/foo.cmt
+
+  $ mkdir app
+  $ cat > app/dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name foo))
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > app/dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (libraries foo)
+  >  (compile_flags -bs-diagnose -verbose)
+  >  (emit_stdlib false))
+  > EOF
+
+  $ cat > app/entry.ml <<EOF
+  > let () = Js.log Foo.x
+  > EOF
+
+An issue similar to #7104 still present because the `.cmj` is not visible.
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build @melange --root app --display=short
+  Entering directory 'app'
+          melc output/node_modules/foo.__private__.priv/priv.js
+          melc .output.mobjs/melange/melange__Entry.{cmi,cmj,cmt}
+          melc output/entry.js
+          melc output/node_modules/foo/foo.js (exit 2)
+  File "_none_", line 1:
+  Error: Priv not found, it means either the module does not exist or it is a namespace
+  Leaving directory 'app'
+  [1]
+


### PR DESCRIPTION
- demonstrates 2 bugs:
1. the `.cmi` install location should be `melange/.public_cmi_melange/priv.cmi` rather than just `melange/.public_cmi_melange/priv.cmi`
2. an issue similar to #7104 where the `.cmj` for the private library isn't in the include paths, so we can't generate the .js file for it.