### PR TITLE
fix(tui): support resizing

### DIFF
--- a/otherlibs/stdune/src/dune
+++ b/otherlibs/stdune/src/dune
@@ -12,6 +12,6 @@
   (re_export dune_filesystem_stubs))
  (foreign_stubs
   (language c)
-  (names wait3_stubs platform_stubs copyfile_stubs))
+  (names wait3_stubs platform_stubs copyfile_stubs signal_stubs))
  (instrumentation
   (backend bisect_ppx)))

--- a/otherlibs/stdune/src/signal.ml
+++ b/otherlibs/stdune/src/signal.ml
@@ -27,7 +27,10 @@ type t =
   | Urg
   | Xcpu
   | Xfsz
+  | Winch
   | Unknown of int
+
+external sigwinch : unit -> int = "stdune_winch_number" [@@noalloc]
 
 let all =
   let open Sys in
@@ -59,6 +62,7 @@ let all =
   ; (Urg, sigurg)
   ; (Xcpu, sigxcpu)
   ; (Xfsz, sigxfsz)
+  ; (Winch, sigwinch ())
   ]
 
 let name = function
@@ -90,6 +94,7 @@ let name = function
   | Urg -> "URG"
   | Xcpu -> "XCPU"
   | Xfsz -> "XFSZ"
+  | Winch -> "WINCH"
   | Unknown n -> Int.to_string n
 
 let compare (x : t) (y : t) = Poly.compare x y

--- a/otherlibs/stdune/src/signal.mli
+++ b/otherlibs/stdune/src/signal.mli
@@ -29,6 +29,7 @@ type t =
   | Urg
   | Xcpu
   | Xfsz
+  | Winch
   | Unknown of int
 
 (** Get the signal's name, e.g. [Int] maps to "INT", [Term] to "TERM", etc. *)

--- a/otherlibs/stdune/src/signal_stubs.c
+++ b/otherlibs/stdune/src/signal_stubs.c
@@ -1,0 +1,17 @@
+#include <caml/mlvalues.h>
+
+#ifdef _WIN32
+#include <caml/fail.h>
+#else
+#include <signal.h>
+#include <sys/ioctl.h>
+#endif
+
+CAMLprim value stdune_winch_number(value vunit) {
+  (void)vunit;
+#ifdef _WIN32
+  return Val_int(0);
+#else
+  return Val_int(SIGWINCH);
+#endif
+}

--- a/src/dune_engine/scheduler.ml
+++ b/src/dune_engine/scheduler.ml
@@ -57,7 +57,12 @@ module Shutdown = struct
       | _ -> None)
 end
 
-let blocked_signals : Signal.t list = [ Int; Quit; Term ]
+(* These are the signals that will make the scheduler attempt to terminate dune *)
+let interrupt_signals : Signal.t list = [ Int; Quit; Term ]
+
+(* In addition, the scheduler also blocks some other signals so that only
+   designated threads can handle them by unblocking *)
+let blocked_signals : Signal.t list = Winch :: interrupt_signals
 
 module Thread : sig
   val spawn : signal_watcher:[ `Yes | `No ] -> (unit -> unit) -> unit
@@ -583,7 +588,7 @@ end
 module Signal_watcher : sig
   val init : Event.Queue.t -> unit
 end = struct
-  let signos = List.map blocked_signals ~f:Signal.to_int
+  let signos = List.map interrupt_signals ~f:Signal.to_int
 
   let warning =
     {|

--- a/src/dune_threaded_console/dune_threaded_console_intf.ml
+++ b/src/dune_threaded_console/dune_threaded_console_intf.ml
@@ -39,7 +39,8 @@ module type S = sig
       underestimation of the actual amount of time spent, we will render faster
       than the desired frame rate. If it is an overestimation, we will render
       slower. *)
-  val handle_user_events : now:float -> time_budget:float -> Mutex.t -> float
+  val handle_user_events :
+    now:float -> time_budget:float -> Mutex.t -> state -> float
 
   (** [reset] is called by the main thread to reset the user interface. *)
   val reset : unit -> unit


### PR DESCRIPTION
This PR allows the tui to be rerendered on resize events. This change is twofold:

* Allow handling sigwinch in the tui thread by blocking it in every other thread.
* Calling render whenever we get the winch.

Adding @snowleopard as a reviewer for the insignificant changes to scheduler to allow us to handle sigwinch.