### PR TITLE
melange: set min version to 3.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,6 +150,9 @@ Unreleased
   that have been globally installed, such as those coming from opam
   (@ejgallego, @Alizter)
 
+- Bump minimum version of the dune language for the melange syntax extension
+  from 3.7 to 3.8 (#7665, @jchavarri)
+
 3.7.1 (2023-04-04)
 ------------------
 

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -537,22 +537,7 @@ module Library = struct
       if dune_version >= expected_version then
         Mode_conf.Lib.Set.decode_osl ~stanza_loc project
       else
-        (* Old behavior: if old parser succeeds, return that. Otherwise, if
-           parsing the ordered set language succeeds, ask the user to upgrade to
-           a supported version. Otherwise, fail with the first error. *)
-        try_
-          (Mode_conf.Lib.Set.decode >>| fun modes -> `Modes modes)
-          (fun exn ->
-            try_
-              ( Mode_conf.Lib.Set.decode_osl ~stanza_loc project >>| fun modes ->
-                if dune_version >= expected_version then `Modes modes
-                else `Upgrade )
-              (fun _ -> raise exn))
-        >>| function
-        | `Modes modes -> modes
-        | `Upgrade ->
-          Syntax.Error.since stanza_loc Stanza.syntax expected_version
-            ~what:"Ordered set language for modes"
+        Mode_conf.Lib.Set.decode
   end
 
   type visibility =

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -536,8 +536,7 @@ module Library = struct
       let expected_version = (3, 8) in
       if dune_version >= expected_version then
         Mode_conf.Lib.Set.decode_osl ~stanza_loc project
-      else
-        Mode_conf.Lib.Set.decode
+      else Mode_conf.Lib.Set.decode
   end
 
   type visibility =

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -146,7 +146,7 @@ end
 let syntax =
   Dune_lang.Syntax.create ~name:Dune_project.Melange_syntax.name
     ~desc:"support for Melange compiler"
-    [ ((0, 1), `Since (3, 7)) ]
+    [ ((0, 1), `Since (3, 8)) ]
 
 let () =
   Dune_project.Extension.register_simple syntax

--- a/test/blackbox-tests/test-cases/lib-modes.t
+++ b/test/blackbox-tests/test-cases/lib-modes.t
@@ -1,0 +1,49 @@
+Test library modes field
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.7)
+  > EOF
+
+  $ mkdir lib
+
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (modes :standard \ native)
+  >  (name mylib))
+  > EOF
+
+  $ cat > lib/mylib.ml <<EOF
+  > let some_binding = "string"
+  > EOF
+
+  $ cat > dune <<EOF
+  > (executable
+  >  (name hello)
+  >  (libraries mylib))
+  > EOF
+
+  $ cat > hello.ml <<EOF
+  > let () =
+  >   print_endline Mylib.some_binding
+  > EOF
+
+Fails with an informative error message if we parsed OSL for modes
+in a version of dune lang that does not support them
+
+  $ dune build hello.exe
+  File "lib/dune", line 1, characters 0-51:
+  1 | (library
+  2 |  (modes :standard \ native)
+  3 |  (name mylib))
+  Error: Ordered set language for modes is only available since version 3.8 of
+  the dune language. Please update your dune-project file to have (lang dune
+  3.8).
+  [1]
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > EOF
+
+Works for the most recent version
+
+  $ dune build hello.exe

--- a/test/blackbox-tests/test-cases/melange/add-rules-under-melange-emit-target.t
+++ b/test/blackbox-tests/test-cases/melange/add-rules-under-melange-emit-target.t
@@ -1,7 +1,7 @@
 Test that the target directory exists
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/aliases.t
+++ b/test/blackbox-tests/test-cases/melange/aliases.t
@@ -1,7 +1,7 @@
 Test alias field on melange.emit stanzas
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/basic-install.t
+++ b/test/blackbox-tests/test-cases/melange/basic-install.t
@@ -1,7 +1,7 @@
 Test that we can install melange mode libraries
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name foo))
   > (using melange 0.1)
   > EOF

--- a/test/blackbox-tests/test-cases/melange/copy-files-include-subdirs.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-include-subdirs.t
@@ -6,7 +6,7 @@ Example using melange.emit, copy_files and include_subdirs
   > EOF
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/copy-files-into-emit-target-folder.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-into-emit-target-folder.t
@@ -2,7 +2,7 @@ Example showing melange.emit and copy_files, where the files are copied
 into the melange.emit target folder
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/copy-files-simple.t
+++ b/test/blackbox-tests/test-cases/melange/copy-files-simple.t
@@ -1,7 +1,7 @@
 Test simple interactions between melange.emit and copy_files
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/depend-on-installed.t
+++ b/test/blackbox-tests/test-cases/melange/depend-on-installed.t
@@ -3,7 +3,7 @@ Test dependency on installed package
   $ mkdir a b prefix app
 
   $ cat > a/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name a))
   > (using melange 0.1)
   > EOF
@@ -34,7 +34,7 @@ Test dependency on installed package
   Installing $TESTCASE_ROOT/prefix/lib/a/melange/a__Foo.cmt
 
   $ cat >b/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name b))
   > (using melange 0.1)
   > EOF
@@ -80,7 +80,7 @@ Test dependency on installed package
   Installing $TESTCASE_ROOT/prefix/lib/b/melange/b__Foo.cmt
 
   $ cat >app/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name app))
   > (using melange 0.1)
   > EOF

--- a/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/dune-js-file-unmangling.t/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/dune-package-source-path.t
+++ b/test/blackbox-tests/test-cases/melange/dune-package-source-path.t
@@ -3,7 +3,7 @@ form `foo.bar.baz`
 
   $ mkdir a app
   $ cat > a/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name a))
   > (using melange 0.1)
   > EOF
@@ -39,7 +39,7 @@ form `foo.bar.baz`
         (source (path Foo) (impl (path sub/foo.ml))))))
 
   $ cat >app/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/emit-installed-complex.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-complex.t/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (package
  (name pkg2))

--- a/test/blackbox-tests/test-cases/melange/emit-installed-complex.t/inner/dune-project
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-complex.t/inner/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (package
  (name pkg1))

--- a/test/blackbox-tests/test-cases/melange/emit-installed-two-modes.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-two-modes.t
@@ -3,7 +3,7 @@ Test dependency on installed package
   $ mkdir a b c prefix
 
   $ cat > a/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name a))
   > (using melange 0.1)
   > EOF
@@ -39,7 +39,7 @@ Test dependency on installed package
   Installing $TESTCASE_ROOT/prefix/lib/a/melange/a__Foo.cmt
 
   $ cat >b/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 
@@ -65,7 +65,7 @@ Test dependency on installed package
   foo
 
   $ cat >c/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/emit-installed.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed.t
@@ -3,7 +3,7 @@ Test dependency on installed package
   $ mkdir -p lib-a lib-a/sub b prefix
 
   $ cat > lib-a/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name a))
   > (using melange 0.1)
   > EOF
@@ -43,7 +43,7 @@ Test dependency on installed package
   Installing $TESTCASE_ROOT/prefix/lib/a/sub/sub.ml
 
   $ cat >b/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/emit-private.t
+++ b/test/blackbox-tests/test-cases/melange/emit-private.t
@@ -1,7 +1,7 @@
 Test dependency on a private library in the same package as melange.emit
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package  (name a))
   > (using melange 0.1)
   > EOF

--- a/test/blackbox-tests/test-cases/melange/emit-select.t
+++ b/test/blackbox-tests/test-cases/melange/emit-select.t
@@ -1,7 +1,7 @@
 using `(select ...)` in melange.emit
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
   $ cat >bar.melange.ml <<EOF

--- a/test/blackbox-tests/test-cases/melange/emit-two-dune-projects.t
+++ b/test/blackbox-tests/test-cases/melange/emit-two-dune-projects.t
@@ -3,7 +3,7 @@ Test dependency on installed package
   $ mkdir xyz
 
   $ cat > xyz/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (package (name aa_fe))
   > (using melange 0.1)
   > EOF
@@ -19,12 +19,12 @@ Test dependency on installed package
   > EOF
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 
   $ cat >dune-workspace <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > EOF
 
   $ cat > dune <<EOF

--- a/test/blackbox-tests/test-cases/melange/empty-entries-target-dir-exists.t
+++ b/test/blackbox-tests/test-cases/melange/empty-entries-target-dir-exists.t
@@ -1,7 +1,7 @@
 Test (modules) field can be left empty
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/empty-entries.t
+++ b/test/blackbox-tests/test-cases/melange/empty-entries.t
@@ -1,7 +1,7 @@
 Test (modules) field can be left empty
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/flags.t
+++ b/test/blackbox-tests/test-cases/melange/flags.t
@@ -1,7 +1,7 @@
 Test flags and compile_flags fields on melange.emit stanza
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/gh7020.t
+++ b/test/blackbox-tests/test-cases/melange/gh7020.t
@@ -3,7 +3,7 @@ Reproduce github #7020
   $ dir=_to-install
   $ mkdir $dir
   $ cat >$dir/dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > (package
   >  (name dummyfoo))
@@ -35,7 +35,7 @@ Reproduce github #7020
   $ export OCAMLPATH=$PWD/$dir/_install/lib
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/include_subdirs.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/include_subdirs.t/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/intfonly-entries.t
+++ b/test/blackbox-tests/test-cases/melange/intfonly-entries.t
@@ -1,7 +1,7 @@
 Entry points should not allow mli only modules as entry points.
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/intfonly.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/intfonly.t/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
+++ b/test/blackbox-tests/test-cases/melange/merlin-compile-flags.t
@@ -1,7 +1,7 @@
 Show that the merlin config knows about melange.compile_flags
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -8,7 +8,7 @@
   $ export BUILD_PATH_PREFIX_MAP="/MELC_STDLIB=$(ocamlfind query melange):$BUILD_PATH_PREFIX_MAP"
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/missing-melc.t
+++ b/test/blackbox-tests/test-cases/melange/missing-melc.t
@@ -1,7 +1,7 @@
 Test cases when melc is not available
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/mli.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/mli.t/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)
 

--- a/test/blackbox-tests/test-cases/melange/module-systems.t
+++ b/test/blackbox-tests/test-cases/melange/module-systems.t
@@ -1,7 +1,7 @@
 Parses the full form (<module-system> <extension>)
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/multilib.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/multilib.t/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)
 

--- a/test/blackbox-tests/test-cases/melange/nested-melange-emit-stanzas.t
+++ b/test/blackbox-tests/test-cases/melange/nested-melange-emit-stanzas.t
@@ -1,7 +1,7 @@
 Make sure an error is returned if trying to nest `melange.emit` stanzas
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
   $ mkdir -p a/output/b

--- a/test/blackbox-tests/test-cases/melange/ocaml-flags.t
+++ b/test/blackbox-tests/test-cases/melange/ocaml-flags.t
@@ -1,7 +1,7 @@
 Test melange.compile_flags, ocamlc_flags and ocamlopt_flags fields on melange.emit stanza
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/preprocess.t
+++ b/test/blackbox-tests/test-cases/melange/preprocess.t
@@ -1,7 +1,7 @@
 Test (preprocess) field on melange.emit stanza
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/private-module.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/private-module.t/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/private.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/private.t/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/promote-with-lib.t
+++ b/test/blackbox-tests/test-cases/melange/promote-with-lib.t
@@ -2,7 +2,6 @@ Test melange.emit promotion
 
   $ cat > dune-project <<EOF
   > (lang dune 3.7)
-  > (using melange 0.1)
   > EOF
 
   $ mkdir lib
@@ -17,12 +16,8 @@ Test melange.emit promotion
   > EOF
 
   $ cat > dune <<EOF
-  > (melange.emit
-  >  (alias dist)
-  >  (modules hello)
-  >  (promote (until-clean))
-  >  (target dist)
-  >  (libraries mylib))
+  > (executable
+  >  (name hello))
   > EOF
 
   $ cat > hello.ml <<EOF
@@ -33,14 +28,11 @@ Test melange.emit promotion
 
 Fails with an informative error message if we parsed OSL for modes
 
-  $ dune build @dist
-  File "lib/dune", line 1, characters 0-50:
-  1 | (library
+  $ dune build hello.exe
+  File "lib/dune", line 2, characters 8-17:
   2 |  (modes :standard melange)
-  3 |  (name mylib))
-  Error: Ordered set language for modes is only available since version 3.8 of
-  the dune language. Please update your dune-project file to have (lang dune
-  3.8).
+              ^^^^^^^^^
+  Error: Unknown value :standard
   [1]
 
 
@@ -48,8 +40,17 @@ Fails with an informative error message if we parsed OSL for modes
   > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
-  $ dune build @dist
 
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias dist)
+  >  (modules hello)
+  >  (promote (until-clean))
+  >  (target dist)
+  >  (libraries mylib))
+  > EOF
+
+  $ dune build @dist
 Library has `(modes :standard)` so it also builds for bytecode / native
 
   $ dune build lib/.mylib.objs/byte/mylib.cmo

--- a/test/blackbox-tests/test-cases/melange/promote-with-lib.t
+++ b/test/blackbox-tests/test-cases/melange/promote-with-lib.t
@@ -1,7 +1,8 @@
 Test melange.emit promotion
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
+  > (using melange 0.1)
   > EOF
 
   $ mkdir lib
@@ -16,32 +17,6 @@ Test melange.emit promotion
   > EOF
 
   $ cat > dune <<EOF
-  > (executable
-  >  (name hello))
-  > EOF
-
-  $ cat > hello.ml <<EOF
-  > let the_binding = Mylib.some_binding
-  > let () =
-  >   print_endline "hello"
-  > EOF
-
-Fails with an informative error message if we parsed OSL for modes
-
-  $ dune build hello.exe
-  File "lib/dune", line 2, characters 8-17:
-  2 |  (modes :standard melange)
-              ^^^^^^^^^
-  Error: Unknown value :standard
-  [1]
-
-
-  $ cat > dune-project <<EOF
-  > (lang dune 3.8)
-  > (using melange 0.1)
-  > EOF
-
-  $ cat > dune <<EOF
   > (melange.emit
   >  (alias dist)
   >  (modules hello)
@@ -50,7 +25,14 @@ Fails with an informative error message if we parsed OSL for modes
   >  (libraries mylib))
   > EOF
 
+  $ cat > hello.ml <<EOF
+  > let the_binding = Mylib.some_binding
+  > let () =
+  >   print_endline "hello"
+  > EOF
+
   $ dune build @dist
+
 Library has `(modes :standard)` so it also builds for bytecode / native
 
   $ dune build lib/.mylib.objs/byte/mylib.cmo

--- a/test/blackbox-tests/test-cases/melange/promote.t
+++ b/test/blackbox-tests/test-cases/melange/promote.t
@@ -1,7 +1,7 @@
 Test melange.emit promotion
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/public.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/public.t/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)
 

--- a/test/blackbox-tests/test-cases/melange/rescript-syntax.t
+++ b/test/blackbox-tests/test-cases/melange/rescript-syntax.t
@@ -1,7 +1,7 @@
 Test melange.emit promotion
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/reused-module.t
+++ b/test/blackbox-tests/test-cases/melange/reused-module.t
@@ -1,7 +1,7 @@
 Test error message for modules belonging to melange.emit and another stanza
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/root-module.t
+++ b/test/blackbox-tests/test-cases/melange/root-module.t
@@ -1,7 +1,7 @@
 A library can be shadowed by an internal module name:
 
   $ cat >dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/runtime-deps-in-target-dir.t
+++ b/test/blackbox-tests/test-cases/melange/runtime-deps-in-target-dir.t
@@ -1,6 +1,6 @@
 
   $ cat > dune-project << EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
   $ mkdir output

--- a/test/blackbox-tests/test-cases/melange/simple.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/simple.t/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)

--- a/test/blackbox-tests/test-cases/melange/target-validation.t
+++ b/test/blackbox-tests/test-cases/melange/target-validation.t
@@ -1,7 +1,7 @@
 Validation of target field in melange.emit stanzas
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
+++ b/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
@@ -1,7 +1,7 @@
 Building a project with 2 melange.emit stanzas should add rules to both aliases
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
   $ cat > dune <<EOF

--- a/test/blackbox-tests/test-cases/melange/unmangling.t
+++ b/test/blackbox-tests/test-cases/melange/unmangling.t
@@ -1,7 +1,7 @@
 Test unmangling of js files
 
   $ cat > dune-project <<EOF
-  > (lang dune 3.7)
+  > (lang dune 3.8)
   > (using melange 0.1)
   > EOF
 

--- a/test/blackbox-tests/test-cases/melange/virtual_lib.t/dune-project
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib.t/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.7)
+(lang dune 3.8)
 
 (using melange 0.1)


### PR DESCRIPTION
Discussed with @anmonteiro offline. It makes sense to have 3.8 be the first version that supports Melange. This PR raises the lower limit to match that version.

This change makes some of the logic to handle lang versions in library `modes` OSL to lose relevance, see `promote-with-lib` test.