### PR TITLE
dune-rpc: use loopback address on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,8 @@ Unreleased
 - Introduce mdx stanza 0.4 requiring mdx >= 2.3.0 which updates the default
   list of files to include `*.mld` files (#7582, @Leonidas-from-XIV)
 
+- Fix RPC server on Windows (used for OCaml-LSP). (#7666, @nojb)
+
 3.7.1 (2023-04-04)
 ------------------
 

--- a/otherlibs/dune-rpc/private/where.ml
+++ b/otherlibs/dune-rpc/private/where.ml
@@ -119,7 +119,7 @@ end) (IO : sig
     string -> ([ `Unix_socket | `Normal_file | `Other ], exn) result Fiber.t
 end) : S with type 'a fiber := 'a Fiber.t = struct
   let default ?(win32 = win32) ~build_dir () =
-    if win32 then `Ip (`Host "0.0.0.0", `Port default_port)
+    if win32 then `Ip (`Host (Unix.string_of_inet_addr Unix.inet_addr_loopback), `Port default_port)
     else `Unix (Filename.concat build_dir rpc_socket_relative_to_build_dir)
 
   let ( let** ) x f =

--- a/otherlibs/dune-rpc/private/where.ml
+++ b/otherlibs/dune-rpc/private/where.ml
@@ -119,7 +119,10 @@ end) (IO : sig
     string -> ([ `Unix_socket | `Normal_file | `Other ], exn) result Fiber.t
 end) : S with type 'a fiber := 'a Fiber.t = struct
   let default ?(win32 = win32) ~build_dir () =
-    if win32 then `Ip (`Host (Unix.string_of_inet_addr Unix.inet_addr_loopback), `Port default_port)
+    if win32 then
+      `Ip
+        ( `Host (Unix.string_of_inet_addr Unix.inet_addr_loopback)
+        , `Port default_port )
     else `Unix (Filename.concat build_dir rpc_socket_relative_to_build_dir)
 
   let ( let** ) x f =


### PR DESCRIPTION
`0.0.0.0` is a dummy address that is interpreted in different ways by the various APIs. We should use the `loopback` (= `127.0.0.1`) address which always denotes the local host.

This is needed to use the RPC protocol on Windows.