### PR TITLE
fix(opam): remove bigarray dependency

### DIFF
--- a/vendor/opam/src/core/dune
+++ b/vendor/opam/src/core/dune
@@ -1,5 +1,5 @@
 (library
   (name        opam_core)
   (synopsis    "OCaml Package Manager core internal stdlib")
-  (libraries   dune_re unix bigarray sha dune_uutf)
+  (libraries   dune_re unix sha dune_uutf)
   (wrapped     false))


### PR DESCRIPTION
bigarray has been moved to stdlib, so mentioning it as an external
library breaks bootstrap

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 324c9641-9139-4c62-a584-420fce2cb560 -->