### PR TITLE
melange: improve extension name

### DIFF
--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -145,7 +145,7 @@ end
 
 let syntax =
   Dune_lang.Syntax.create ~name:Dune_project.Melange_syntax.name
-    ~desc:"support for Melange compiler"
+    ~desc:"the Melange extension"
     [ ((0, 1), `Since (3, 7)) ]
 
 let () =


### PR DESCRIPTION
Previously, error messages would show:

```
Error: Version 0.1 of support for Melange compiler is not supported until
version 3.8 of the dune language.
```

After this PR:

```
Error: Version 0.1 of the Melange extension is not supported until
version 3.8 of the dune language.
```

See similar cases:

https://github.com/ocaml/dune/blob/69541075d26ad1892925da2d8d8deaebededcc2e/src/dune_rules/coq/coq_stanza.ml#L5

https://github.com/ocaml/dune/blob/69541075d26ad1892925da2d8d8deaebededcc2e/src/dune_rules/ctypes/ctypes_field.ml#L7