### PR TITLE
Add vendor/sha to boot/libs.ml

### DIFF
--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -66,6 +66,7 @@ let local_libraries =
   ; ("otherlibs/build-info/src", Some "Build_info", false,
     Some "Build_info_data")
   ; ("src/dune_rpc_impl", Some "Dune_rpc_impl", false, None)
+  ; ("vendor/sha", None, false, None)
   ]
 
 let link_flags =


### PR DESCRIPTION
This line was added automatically when making https://github.com/ocaml/dune/pull/7668 and it caused an error on windows so I removed it. This PR is mostly an attempt to reproduce that error.