### PR TITLE
feature(pkg): Better API for Fetch

### DIFF
--- a/src/dune_pkg/checksum.ml
+++ b/src/dune_pkg/checksum.ml
@@ -1,0 +1,31 @@
+open Import
+
+type t = OpamHash.t
+
+include (
+  Stringlike.Make (struct
+    type t = OpamHash.t
+
+    let to_string x = OpamHash.to_string x
+
+    let module_ = "Dune_pkg.Checksum"
+
+    let description = "Cryptographic hash of a package"
+
+    let description_of_valid_string = None
+
+    let hint_valid = None
+
+    let of_string_opt s =
+      (* verify through OpamHash *)
+      OpamHash.of_string_opt s
+  end) :
+    Stringlike_intf.S with type t := t)
+
+let to_opam_hash v = v
+
+let of_opam_hash v = v
+
+let pp v =
+  let s = to_string v in
+  Pp.text s

--- a/src/dune_pkg/checksum.mli
+++ b/src/dune_pkg/checksum.mli
@@ -1,0 +1,16 @@
+open Import
+
+(** [t] represents a checksum for a file that is to be fetched or has been
+    fetched already. *)
+type t
+
+include Stringlike_intf.S with type t := t
+
+(** [to_opam_hash c] converts [c] to the representation of has values used by
+    OPAM *)
+val to_opam_hash : t -> OpamHash.t
+
+(** [of_opam_hash h] converts [h] from the representation used by OPAM to Dune's *)
+val of_opam_hash : OpamHash.t -> t
+
+val pp : t -> 'a Pp.t

--- a/src/dune_pkg/dune
+++ b/src/dune_pkg/dune
@@ -1,6 +1,13 @@
 (library
  (name dune_pkg)
  (synopsis "[Internal] Dune's packaging support")
- (libraries stdune fiber dune_engine opam_core opam_repository opam_format)
+ (libraries
+  stdune
+  fiber
+  dune_engine
+  dune_util
+  opam_core
+  opam_repository
+  opam_format)
  (instrumentation
   (backend bisect_ppx)))

--- a/src/dune_pkg/dune_pkg.ml
+++ b/src/dune_pkg/dune_pkg.ml
@@ -1,1 +1,2 @@
 module Fetch = Fetch
+module Checksum = Checksum

--- a/src/dune_pkg/fetch.mli
+++ b/src/dune_pkg/fetch.mli
@@ -1,5 +1,19 @@
 open Stdune
 
-(** [fetch loc url ~target] will fetch [url] into [target]. If there's an error
-    fetching, [loc] will be used as the location for the error. *)
-val fetch : Loc.t -> OpamUrl.t -> target:Path.t -> unit Fiber.t
+type failure =
+  | Checksum_mismatch of Checksum.t
+  | Unavailable of User_message.t option
+
+(** [fetch ~checksum ~target url] will fetch [url] into [target]. It will verify
+    the downloaded file against [checksum], unless it [checksum] is [None].
+
+    @raise Checksum_mismatch
+      When the downloaded file doesn't match the expected [checksum], this will
+      pass the actually computed checksum.
+    @raise Unavailable
+      When the file can't be retrieved, e.g. not available at the location. *)
+val fetch :
+     checksum:Checksum.t option
+  -> target:Path.t
+  -> OpamUrl.t
+  -> (unit, failure) result Fiber.t

--- a/src/dune_pkg/import.ml
+++ b/src/dune_pkg/import.ml
@@ -1,0 +1,3 @@
+include Stdune
+module Stringlike = Dune_util.Stringlike
+module Stringlike_intf = Dune_util.Stringlike_intf


### PR DESCRIPTION
As discussed with @rgrinberg, this

  * Introduces a checksum type
  * Verifies the checksums
  * Adds better error handling

Unfortunately we can't use the OPAM verification because OPAM verifies the file and deletes it immediately on checksum mismatches, without ever propagating the checksum out. I'll talk to OPAM maintainers about improving the API to include better error handling but for now to get the actual checksum we have to calculate it on our side.