### PR TITLE
`opam_constraint t` result should respect precedence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,9 @@ Unreleased
 - Add `(build_if)` to the `(test)` stanza. When it evaluates to false, the
   executable is not built. (#7899, fixes #6938, @emillon)
 
+- Add necessary parentheses in generated opam constraints (#7682, fixes #3431,
+  @Lucccyo)
+
 3.8.2 (2023-06-16)
 ------------------
 

--- a/test/blackbox-tests/test-cases/opam-constraints.t
+++ b/test/blackbox-tests/test-cases/opam-constraints.t
@@ -23,9 +23,9 @@ constraints.
   >   ; or
   >   (p_or2 (or :a :b))
   >   (p_or1 (or :a))
-  >   (p_or3 (or :a :b :c)) ; buggy output
+  >   (p_or3 (or :a :b :c))
   >   ; mixed operations
-  >   (p_and_in_or (or :a (and :b :c))) ; buggy output, see #3431
+  >   (p_and_in_or (or :a (and :b :c)))
   >   (p_or_in_and (and :a (or :b :c)))
   >   ))
   > EOF
@@ -49,9 +49,9 @@ constraints.
     "p_and3" {a & b & c}
     "p_or2" {a | b}
     "p_or1" {a}
-    "p_or3" {a | b & c}
+    "p_or3" {a | b | c}
     "p_and_in_or" {a | b & c}
-    "p_or_in_and" {a & b | c}
+    "p_or_in_and" {a & (b | c)}
   ]
   build: [
     ["dune" "subst"] {pinned}


### PR DESCRIPTION
`add_group` appends parenthesis to the result of `opam_constraint` in order to handle precedence of `opamBaseParser.mly` in `opam-file-format` (https://github.com/ocaml/opam-file-format).

Fixes [#3431](https://github.com/ocaml/dune/issues/3431)