### PR TITLE
test(melange): merlin generation

### DIFF
--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -476,27 +476,6 @@ module Unprocessed = struct
           | [] -> None
           | stdlib_dir :: _ -> Some stdlib_dir)
       in
-      let* requires =
-        match t.config.mode with
-        | Ocaml _ -> Action_builder.return requires
-        | Melange ->
-          Action_builder.of_memo
-            (let open Memo.O in
-            let scope = Expander.scope expander in
-            let libs = Scope.libs scope in
-            Lib.DB.find libs (Lib_name.of_string "melange") >>= function
-            | Some lib ->
-              let+ libs =
-                let linking =
-                  Dune_project.implicit_transitive_deps (Scope.project scope)
-                in
-                Lib.closure [ lib ] ~linking |> Resolve.Memo.peek >>| function
-                | Ok libs -> libs
-                | Error _ -> []
-              in
-              Lib.Set.union requires (Lib.Set.of_list libs)
-            | None -> Memo.return requires)
-      in
       let* flags = flags
       and* src_dirs, obj_dirs =
         Action_builder.of_memo

--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -476,6 +476,27 @@ module Unprocessed = struct
           | [] -> None
           | stdlib_dir :: _ -> Some stdlib_dir)
       in
+      let* requires =
+        match t.config.mode with
+        | Ocaml _ -> Action_builder.return requires
+        | Melange ->
+          Action_builder.of_memo
+            (let open Memo.O in
+            let scope = Expander.scope expander in
+            let libs = Scope.libs scope in
+            Lib.DB.find libs (Lib_name.of_string "melange") >>= function
+            | Some lib ->
+              let+ libs =
+                let linking =
+                  Dune_project.implicit_transitive_deps (Scope.project scope)
+                in
+                Lib.closure [ lib ] ~linking |> Resolve.Memo.peek >>| function
+                | Ok libs -> libs
+                | Error _ -> []
+              in
+              Lib.Set.union requires (Lib.Set.of_list libs)
+            | None -> Memo.return requires)
+      in
       let* flags = flags
       and* src_dirs, obj_dirs =
         Action_builder.of_memo

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -34,7 +34,13 @@
 Paths to Melange stdlib appear in B and S entries without melange.emit stanza
 
   $ dune ocaml dump-dot-merlin $PWD | grep -e "^B " -e "^S "
+  B /MELC_STDLIB/melange
+  B /MELC_STDLIB/melange
+  B /MELC_STDLIB/melange
   B $TESTCASE_ROOT/_build/default/.foo.objs/melange
+  S /MELC_STDLIB
+  S /MELC_STDLIB
+  S /MELC_STDLIB
   S $TESTCASE_ROOT
 
 All 3 modules (Foo, Foo__ and Bar) contain a ppx directive

--- a/test/blackbox-tests/test-cases/melange/merlin.t
+++ b/test/blackbox-tests/test-cases/melange/merlin.t
@@ -31,6 +31,12 @@
   Foo__
     $TESTCASE_ROOT/_build/default/.foo.objs/melange)
 
+Paths to Melange stdlib appear in B and S entries without melange.emit stanza
+
+  $ dune ocaml dump-dot-merlin $PWD | grep -e "^B " -e "^S "
+  B $TESTCASE_ROOT/_build/default/.foo.objs/melange
+  S $TESTCASE_ROOT
+
 All 3 modules (Foo, Foo__ and Bar) contain a ppx directive
 
   $ dune ocaml merlin dump-config $PWD | grep -i "ppx"


### PR DESCRIPTION
While testing some stuff in merlin for melange projects, I noticed that this explicit handling of `modes melange` has no apparent effect.

I believe that after the changes in https://github.com/ocaml/dune/pull/7362, this is not necessary because `melange` is just part of the closure.

Worst case my assumption is wrong, in that case I can revert the change and add a test that exercises this functionality.