### PR TITLE
refactor: remove Source_tree.dir_exists

### DIFF
--- a/bin/target.ml
+++ b/bin/target.ml
@@ -112,14 +112,12 @@ let resolve_path path ~(setup : Dune_rules.Main.build_system) :
     Error hint
   in
   let as_source_dir src =
-    Source_tree.dir_exists src >>| function
-    | true ->
-      Some
-        [ Request.Alias
-            (Alias.in_dir ~name:Dune_engine.Alias.Name.default ~recursive:true
-               ~contexts:setup.contexts path)
-        ]
-    | false -> None
+    Source_tree.find_dir src
+    >>| Option.map ~f:(fun _ ->
+            [ Request.Alias
+                (Alias.in_dir ~name:Dune_engine.Alias.Name.default
+                   ~recursive:true ~contexts:setup.contexts path)
+            ])
   in
   let matching_targets src =
     Memo.parallel_map setup.contexts ~f:(fun ctx ->

--- a/src/dune_rules/simple_rules.ml
+++ b/src/dune_rules/simple_rules.ml
@@ -176,9 +176,9 @@ let copy_files sctx ~dir ~expander ~src_dir (def : Copy_files.t) =
     | In_build_dir _ -> assert false
     | External ext -> Fs_memo.dir_exists (External ext)
     | In_source_tree src_in_src -> (
-      Source_tree.dir_exists src_in_src >>= function
-      | true -> Memo.return true
-      | false -> Load_rules.is_under_directory_target src_in_build)
+      Source_tree.find_dir src_in_src >>= function
+      | Some _ -> Memo.return true
+      | None -> Load_rules.is_under_directory_target src_in_build)
   in
   if not exists_or_generated then
     User_error.raise ~loc

--- a/src/dune_rules/source_tree.ml
+++ b/src/dune_rules/source_tree.ml
@@ -712,8 +712,6 @@ let files_of path =
     Dir0.files dir |> Filename.Set.to_list
     |> Path.Source.Set.of_list_map ~f:(Path.Source.relative path)
 
-let dir_exists path = find_dir path >>| Option.is_some
-
 module Dir = struct
   include Dir0
 

--- a/src/dune_rules/source_tree.mli
+++ b/src/dune_rules/source_tree.mli
@@ -86,8 +86,5 @@ val nearest_vcs : Path.Source.t -> Vcs.t option Memo.t
 
 val files_of : Path.Source.t -> Path.Source.Set.t Memo.t
 
-(** [true] iff the path is a directory *)
-val dir_exists : Path.Source.t -> bool Memo.t
-
 (** [true] iff the path is a vendored directory *)
 val is_vendored : Path.Source.t -> bool Memo.t


### PR DESCRIPTION
not useful enough and easily replaced by a one-liner

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3691d7da-f62d-443c-8c55-09ae71d762e5 -->