### PR TITLE
ci bench mark: increase synth watch threshold

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -71,8 +71,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Ratio indicating how worse the current benchmark result is.
-          # 150% means if last build took 40s and current takes >60s, it will trigger an alert
-          alert-threshold: "150%"
+          # 175% means if last build took 40s and current takes >70s, it will trigger an alert
+          alert-threshold: "175%"
           fail-on-alert: true
           # Enable alert commit comment
           comment-on-alert: true


### PR DESCRIPTION
It seems there are some false positives being triggered by this benchmark: https://github.com/ocaml/dune/commit/c28b2c6b051d20646df3ca708df3de23b63600f3#commitcomment-112135144