### PR TITLE
test(pkg): install action

### DIFF
--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -727,7 +727,11 @@ end
 
 open Resolve
 
-module Install = struct
+module Install_action = struct
+  let installable_sections =
+    Section.(Set.diff all (Set.of_list [ Misc; Libexec; Libexec_root ]))
+    |> Section.Set.to_list
+
   module Spec = struct
     type ('path, 'target) t =
       { install_file : 'path
@@ -818,55 +822,52 @@ module Install = struct
 
     let section_map_of_dir install_paths =
       let get = Install.Section.Paths.get install_paths in
-      Section.(Set.diff all (Set.of_list [ Misc; Libexec; Libexec_root ]))
-      |> Section.Set.to_list
-      |> List.concat_map ~f:(fun section ->
-             let path = get section in
-             let acc, dirs =
-               match section with
-               | Lib_root -> skip path [ get Toplevel; get Stublibs; get Lib ]
-               | Share_root -> skip path [ get Share ]
-               | _ -> ([], [ path ])
-             in
-             collect dirs acc
-             |> List.rev_map ~f:(fun file ->
-                    let entry =
-                      let dst =
-                        Path.drop_prefix_exn ~prefix:path file
-                        |> Path.Local.to_string
-                      in
-                      let file =
-                        match
-                          Path.extract_build_context_dir_maybe_sandboxed file
-                        with
-                        | None -> Path.as_in_build_dir_exn file
-                        | Some (sandbox, source) ->
-                          let ctx =
-                            let name = Path.basename sandbox in
-                            Path.relative (Path.build Path.Build.root) name
-                          in
-                          Path.append_source ctx source
-                          |> Path.as_in_build_dir_exn
-                      in
-                      let entry =
-                        Install.Entry.make section ~dst ~kind:`File file
-                      in
-                      Install.Entry.set_src entry (Path.build file)
-                    in
-                    let section =
-                      match
-                        match section with
-                        | Lib_root -> Some Section.Libexec_root
-                        | Lib -> Some Libexec
-                        | _ -> None
-                      with
-                      | None -> section
-                      | Some section' ->
-                        let perm = (Path.Untracked.stat_exn file).st_perm in
-                        if Path.Permissions.(test execute perm) then section'
-                        else section
-                    in
-                    (section, entry)))
+      List.concat_map installable_sections ~f:(fun section ->
+          let path = get section in
+          let acc, dirs =
+            match section with
+            | Lib_root -> skip path [ get Toplevel; get Stublibs; get Lib ]
+            | Share_root -> skip path [ get Share ]
+            | _ -> ([], [ path ])
+          in
+          collect dirs acc
+          |> List.rev_map ~f:(fun file ->
+                 let entry =
+                   let dst =
+                     Path.drop_prefix_exn ~prefix:path file
+                     |> Path.Local.to_string
+                   in
+                   let file =
+                     match
+                       Path.extract_build_context_dir_maybe_sandboxed file
+                     with
+                     | None -> Path.as_in_build_dir_exn file
+                     | Some (sandbox, source) ->
+                       let ctx =
+                         let name = Path.basename sandbox in
+                         Path.relative (Path.build Path.Build.root) name
+                       in
+                       Path.append_source ctx source |> Path.as_in_build_dir_exn
+                   in
+                   let entry =
+                     Install.Entry.make section ~dst ~kind:`File file
+                   in
+                   Install.Entry.set_src entry (Path.build file)
+                 in
+                 let section =
+                   match
+                     match section with
+                     | Lib_root -> Some Section.Libexec_root
+                     | Lib -> Some Libexec
+                     | _ -> None
+                   with
+                   | None -> section
+                   | Some section' ->
+                     let perm = (Path.Untracked.stat_exn file).st_perm in
+                     if Path.Permissions.(test execute perm) then section'
+                     else section
+                 in
+                 (section, entry)))
       |> Section.Map.of_list_multi
 
     let action
@@ -1072,10 +1073,19 @@ let gen_rules context_name (pkg : Pkg.t) =
         | None -> Memo.return [ build_action ]
         | Some install_action ->
           let+ install_action = install_action in
-          [ build_action; install_action ]
+          let mkdir_install_dirs =
+            let install_paths = Paths.install_paths pkg.paths in
+            Install_action.installable_sections
+            |> List.rev_map ~f:(fun section ->
+                   Install.Section.Paths.get install_paths section
+                   |> Path.as_in_build_dir_exn |> Action.mkdir)
+            |> Action.progn |> Action.Full.make
+            |> Action_builder.With_targets.return
+          in
+          [ build_action; mkdir_install_dirs; install_action ]
       in
       let install_file_action =
-        Install.action pkg.paths
+        Install_action.action pkg.paths
           (match install_action with
           | None -> `No_install_action
           | Some _ -> `Has_install_action)

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -10,4 +10,17 @@ Install actions should have the switch directory prepared:
   > EOF
 
   $ dune build .pkg/test/target/
-  find: '../target': No such file or directory
+  ../target
+  ../target/bin
+  ../target/doc
+  ../target/doc/test
+  ../target/etc
+  ../target/etc/test
+  ../target/lib
+  ../target/lib/stublibs
+  ../target/lib/test
+  ../target/lib/toplevel
+  ../target/man
+  ../target/sbin
+  ../target/share
+  ../target/share/test

--- a/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action-dirs.t
@@ -1,0 +1,13 @@
+Install actions should have the switch directory prepared:
+
+  $ mkdir dune.lock
+  $ cat >dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > EOF
+  $ cat >dune.lock/test <<'EOF'
+  > (build (run true))
+  > (install (system "find %{prefix} | sort"))
+  > EOF
+
+  $ dune build .pkg/test/target/
+  find: '../target': No such file or directory

--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -11,9 +11,21 @@ Testing install actions
 
   $ find _build/default/.pkg/test/target | sort
   _build/default/.pkg/test/target
+  _build/default/.pkg/test/target/bin
   _build/default/.pkg/test/target/cookie
+  _build/default/.pkg/test/target/doc
+  _build/default/.pkg/test/target/doc/test
+  _build/default/.pkg/test/target/etc
+  _build/default/.pkg/test/target/etc/test
   _build/default/.pkg/test/target/lib
+  _build/default/.pkg/test/target/lib/stublibs
+  _build/default/.pkg/test/target/lib/test
+  _build/default/.pkg/test/target/lib/toplevel
   _build/default/.pkg/test/target/lib/xxx
+  _build/default/.pkg/test/target/man
+  _build/default/.pkg/test/target/sbin
+  _build/default/.pkg/test/target/share
+  _build/default/.pkg/test/target/share/test
 
   $ dune internal dump _build/default/.pkg/test/target/cookie
   { files =


### PR DESCRIPTION
First, show that the directory structure of the %{prefix} isn't created.

Then make sure all the directories are created before running the install action.