### PR TITLE
refactor(pkg): simplify entries in cookie

### DIFF
--- a/test/blackbox-tests/test-cases/pkg/install-action.t
+++ b/test/blackbox-tests/test-cases/pkg/install-action.t
@@ -32,14 +32,6 @@ Testing install actions
 
   $ dune internal dump _build/default/.pkg/test/target/cookie
   { files =
-      map
-        { LIB_ROOT :
-            [ { src = In_build_dir "default/.pkg/test/target/lib/xxx"
-              ; kind = File
-              ; dst = "xxx"
-              ; section = LIB_ROOT
-              }
-            ]
-        }
+      map { LIB_ROOT : [ In_build_dir "default/.pkg/test/target/lib/xxx" ] }
   ; variables = []
   }

--- a/test/blackbox-tests/test-cases/pkg/installed-binary.t
+++ b/test/blackbox-tests/test-cases/pkg/installed-binary.t
@@ -43,34 +43,12 @@ Test that installed binaries are visible in dependent packages
   $ dune internal dump _build/default/.pkg/test/target/cookie
   { files =
       map
-        { LIB :
-            [ { src = In_source_tree "libxxx"
-              ; kind = File
-              ; dst = "libxxx"
-              ; section = LIB
-              }
-            ]
+        { LIB : [ In_build_dir "default/.pkg/test/target/lib/test/libxxx" ]
         ; LIB_ROOT :
-            [ { src = In_source_tree "lib_rootxxx"
-              ; kind = File
-              ; dst = "lib_rootxxx"
-              ; section = LIB_ROOT
-              }
-            ]
-        ; BIN :
-            [ { src = In_source_tree "foo"
-              ; kind = File
-              ; dst = "foo"
-              ; section = BIN
-              }
-            ]
+            [ In_build_dir "default/.pkg/test/target/lib/lib_rootxxx" ]
+        ; BIN : [ In_build_dir "default/.pkg/test/target/bin/foo" ]
         ; SHARE_ROOT :
-            [ { src = In_source_tree "lib_rootxxx"
-              ; kind = File
-              ; dst = "lib_rootxxx"
-              ; section = SHARE_ROOT
-              }
-            ]
+            [ In_build_dir "default/.pkg/test/target/share/lib_rootxxx" ]
         }
   ; variables = []
   }


### PR DESCRIPTION
Don't store original .install file information we aren't going to use.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: a3e0cea0-b32d-40d4-8c98-aab63926a34b -->