### PR TITLE
Add Dune debug/trace output

### DIFF
--- a/src/dune_engine/action_exec.ml
+++ b/src/dune_engine/action_exec.ml
@@ -556,6 +556,39 @@ let exec
       with
       | false -> env
       | true ->
+        let debug = false in
+        (if debug then
+         match targets with
+         | None -> ()
+         | Some tgts -> (
+           let hd = Targets.Validated.head tgts in
+           let hd_str = Path.Build.to_string_maybe_quoted hd in
+           let targets_dyn = Targets.Validated.to_dyn tgts in
+           let targets_pp = Dyn.pp targets_dyn in
+           Log.info
+             [ Pp.textf "\n==============\nhead=(%S)" hd_str; targets_pp ];
+           let pp_action =
+             let action' = Action.for_shell t |> Action_to_sh.pp in
+             Pp.concat
+               [ Pp.textf "action ="
+               ; Pp.space
+               ; Pp.char '('
+               ; action'
+               ; Pp.char ')'
+               ]
+           in
+           Log.info [ pp_action ];
+           Log.info [ Pp.textf "root=%S" (Path.to_absolute_filename root) ];
+           Log.info
+             [ Pp.textf "Path.root=%S" (Path.to_absolute_filename Path.root) ];
+           match context with
+           | None -> Log.info [ Pp.textf "No context" ]
+           | Some context' ->
+             Log.info
+               [ Pp.textf "Context: name=%s, build_dir=%S"
+                   (Context_name.to_string context'.name)
+                   (Path.Build.to_string context'.build_dir)
+               ]));
         Dune_util.Build_path_prefix_map.extend_build_path_prefix_map env
           `New_rules_have_precedence
           [ Some

--- a/src/dune_engine/action_to_sh.ml
+++ b/src/dune_engine/action_to_sh.ml
@@ -90,7 +90,9 @@ let simplify act =
            (String.quote_for_shell target))
       :: acc
     | Pipe (outputs, l) -> Pipe (List.map ~f:block l, outputs) :: acc
-    | Extension _ -> Sh "# extensions are not supported" :: acc
+    | Extension ext ->
+      let ext_str = Dune_lang.to_string ext in
+      Sh ("# extensions are not supported=" ^ ext_str) :: acc
   and block act =
     match List.rev (loop act []) with
     | [] -> [ Run ("true", []) ]

--- a/src/dune_engine/rule.ml
+++ b/src/dune_engine/rule.ml
@@ -70,7 +70,11 @@ module T = struct
   let loc t = t.loc
 
   let to_dyn t : Dyn.t =
-    Record [ ("id", Id.to_dyn t.id); ("info", Info.to_dyn t.info) ]
+    Record
+      [ ("id", Id.to_dyn t.id)
+      ; ("info", Info.to_dyn t.info)
+      ; ("loc", Loc.to_dyn t.loc)
+      ]
 end
 
 include T


### PR DESCRIPTION
This PR adds new debug/trace output for Dune that
currently is activated by editing the Dune source
by changing some flags from false to true.

1. src/dune_engine/action_exec.ml Changes produce output in the log showing which
actions were executed.

2. src/dune_engine/action_to_sh.ml Modified to show the extension being executed.

3. src/dune_engine/build_system.ml Tracing the state changed to the build system.

4. src/dune_engine/build_system.ml Include the location of a rule in the to_dyn output.

5. src/memo/memo.ml Add memo_trace flag that enables extra output
to facilitate understanding the memo system.