### PR TITLE
refactor: use Dune_sexp in Dune_engine

### DIFF
--- a/src/dune_engine/action.ml
+++ b/src/dune_engine/action.ml
@@ -155,11 +155,11 @@ module For_shell = struct
       with type path = string
       with type target = string
       with type string = string
-      with type ext = Dune_lang.t
+      with type ext = Dune_sexp.t
 
   module rec Ast : Ast = Ast
 
-  include Make (String) (String) (String) (String) (Dune_lang) (Ast)
+  include Make (String) (String) (String) (String) (Dune_sexp) (Ast)
 end
 
 module Relativise = Action_mapper.Make (Ast) (For_shell.Ast)
@@ -186,8 +186,8 @@ let for_shell t =
     ~f_path ~f_target
     ~f_ext:(fun ~dir (module A) ->
       A.Spec.encode A.v
-        (fun p -> Dune_lang.atom_or_quoted_string (f_path p ~dir))
-        (fun p -> Dune_lang.atom_or_quoted_string (f_target p ~dir)))
+        (fun p -> Dune_sexp.atom_or_quoted_string (f_path p ~dir))
+        (fun p -> Dune_sexp.atom_or_quoted_string (f_target p ~dir)))
     ~f_program:(fun ~dir x ->
       match x with
       | Ok p -> Path.reach p ~from:dir

--- a/src/dune_engine/action.mli
+++ b/src/dune_engine/action.mli
@@ -83,7 +83,7 @@ module For_shell : sig
       with type path := string
       with type target := string
       with type string := string
-      with type ext := Dune_lang.t
+      with type ext := Dune_sexp.t
 end
 
 (** Convert the action to a format suitable for printing *)

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -107,7 +107,7 @@ let lines_of p =
 
 let read_sexp p =
   let+ s = contents p in
-  Dune_lang.Parser.parse_string s ~fname:(Path.to_string p) ~mode:Single
+  Dune_sexp.Parser.parse_string s ~fname:(Path.to_string p) ~mode:Single
 
 let if_file_exists p ~then_ ~else_ =
   of_thunk

--- a/src/dune_engine/action_builder.mli
+++ b/src/dune_engine/action_builder.mli
@@ -153,7 +153,7 @@ val contents : Path.t -> string t
 val lines_of : Path.t -> string list t
 
 (** Load an S-expression from a file *)
-val read_sexp : Path.t -> Dune_lang.Ast.t t
+val read_sexp : Path.t -> Dune_sexp.Ast.t t
 
 (** Evaluates to [true] if the file is present on the file system or is the
     target of a rule. It doesn't add the path as dependency *)

--- a/src/dune_engine/action_intf.ml
+++ b/src/dune_engine/action_intf.ml
@@ -144,7 +144,7 @@ module Ext = struct
     val is_useful_to : distribute:bool -> memoize:bool -> bool
 
     val encode :
-      ('p, 't) t -> ('p -> Dune_lang.t) -> ('t -> Dune_lang.t) -> Dune_lang.t
+      ('p, 't) t -> ('p -> Dune_sexp.t) -> ('t -> Dune_sexp.t) -> Dune_sexp.t
 
     val bimap : ('a, 'b) t -> ('a -> 'x) -> ('b -> 'y) -> ('x, 'y) t
 

--- a/src/dune_engine/alias.ml
+++ b/src/dune_engine/alias.ml
@@ -3,7 +3,7 @@ open Import
 module Name : sig
   type t
 
-  include Dune_lang.Conv.S with type t := t
+  include Dune_sexp.Conv.S with type t := t
 
   val equal : t -> t -> bool
 
@@ -55,11 +55,11 @@ end = struct
     | None -> User_error.raise ~loc [ invalid_alias s ]
     | Some s -> s
 
-  let encode = Dune_lang.Encoder.string
+  let encode = Dune_sexp.Encoder.string
 
   let decode =
-    let open Dune_lang.Decoder in
-    let* syntax = Dune_lang.Syntax.get_exn Dune_lang.Stanza.syntax in
+    let open Dune_sexp.Decoder in
+    let* syntax = Dune_sexp.Syntax.get_exn Dune_lang.Stanza.syntax in
     plain_string (fun ~loc s -> parse_string_exn ~syntax (loc, s))
 
   let parse_string_exn =
@@ -177,7 +177,7 @@ let check = make_standard (Name.of_string "check")
 let fmt = make_standard Name.fmt
 
 let encode { dir; name } =
-  let open Dune_lang.Encoder in
+  let open Dune_sexp.Encoder in
   record [ ("dir", Dpath.encode (Path.build dir)); ("name", Name.encode name) ]
 
 let get_ctx (path : Path.Build.t) =

--- a/src/dune_engine/alias.mli
+++ b/src/dune_engine/alias.mli
@@ -3,7 +3,7 @@ open Import
 module Name : sig
   type t
 
-  val decode : t Dune_lang.Decoder.t
+  val decode : t Dune_sexp.Decoder.t
 
   val of_string : string -> t
 
@@ -49,7 +49,7 @@ val dir : t -> Path.Build.t
 
 val to_dyn : t -> Dyn.t
 
-val encode : t Dune_lang.Encoder.t
+val encode : t Dune_sexp.Encoder.t
 
 val of_user_written_path : loc:Loc.t -> Path.t -> t
 

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -49,7 +49,7 @@ module T = struct
     | Universe, Universe -> Ordering.Eq
 
   let encode t =
-    let open Dune_lang.Encoder in
+    let open Dune_sexp.Encoder in
     match t with
     | File_selector g -> pair string File_selector.encode ("glob", g)
     | Env e -> pair string string ("Env", e)
@@ -57,7 +57,7 @@ module T = struct
     | Alias a -> pair string Alias.encode ("Alias", a)
     | Universe -> string "Universe"
 
-  let to_dyn t = Dyn.String (Dune_lang.to_string (encode t))
+  let to_dyn t = Dyn.String (Dune_sexp.to_string (encode t))
 end
 
 include T
@@ -305,7 +305,7 @@ module Set = struct
   let add_paths t paths =
     Path.Set.fold paths ~init:t ~f:(fun p set -> add set (File p))
 
-  let encode t = Dune_lang.Encoder.list encode (to_list t)
+  let encode t = Dune_sexp.Encoder.list encode (to_list t)
 
   (* This is to force the rules to be loaded for directories without files when
      depending on [(source_tree x)]. Otherwise, we wouldn't clean up stale

--- a/src/dune_engine/dep.mli
+++ b/src/dune_engine/dep.mli
@@ -122,7 +122,7 @@ module Set : sig
 
   val of_files_set : Path.Set.t -> t
 
-  val encode : t -> Dune_lang.t
+  val encode : t -> Dune_sexp.t
 
   val add_paths : t -> Path.Set.t -> t
 

--- a/src/dune_engine/dpath.ml
+++ b/src/dune_engine/dpath.ml
@@ -119,8 +119,8 @@ type t = Path.t
 
 let encode p =
   let make constr arg =
-    Dune_lang.List
-      [ Dune_lang.atom constr; Dune_lang.atom_or_quoted_string arg ]
+    Dune_sexp.List
+      [ Dune_sexp.atom constr; Dune_sexp.atom_or_quoted_string arg ]
   in
   let open Path in
   match p with
@@ -129,7 +129,7 @@ let encode p =
   | External p -> make "External" (Path.External.to_string p)
 
 let decode =
-  let open Dune_lang.Decoder in
+  let open Dune_sexp.Decoder in
   let external_ =
     plain_string (fun ~loc t ->
         if Filename.is_relative t then
@@ -144,11 +144,11 @@ let decode =
 
 module Local = struct
   let encode ~dir:from p =
-    let open Dune_lang.Encoder in
+    let open Dune_sexp.Encoder in
     string (Path.reach ~from p)
 
   let decode ~dir =
-    let open Dune_lang.Decoder in
+    let open Dune_sexp.Decoder in
     let+ error_loc, path = located string in
     Path.relative ~error_loc dir path
 end
@@ -158,10 +158,10 @@ module Build = struct
 
   let encode p =
     let str = Path.reach ~from:Path.build_dir (Path.build p) in
-    Dune_lang.atom_or_quoted_string str
+    Dune_sexp.atom_or_quoted_string str
 
   let decode =
-    let open Dune_lang.Decoder in
+    let open Dune_sexp.Decoder in
     let+ base = string in
     Path.Build.(relative root) base
 
@@ -173,10 +173,10 @@ module Build = struct
 end
 
 module External = struct
-  let encode p = Dune_lang.Encoder.string (Path.External.to_string p)
+  let encode p = Dune_sexp.Encoder.string (Path.External.to_string p)
 
   let decode =
-    let open Dune_lang.Decoder in
+    let open Dune_sexp.Decoder in
     let+ path = string in
     Path.External.of_string path
 end

--- a/src/dune_engine/dpath.mli
+++ b/src/dune_engine/dpath.mli
@@ -40,16 +40,16 @@ val describe_target : Path.Build.t -> string
 
 val describe_path : Path.t -> string
 
-include Dune_lang.Conv.S with type t = Path.t
+include Dune_sexp.Conv.S with type t = Path.t
 
 module Local : sig
-  val encode : dir:Path.t -> Path.t Dune_lang.Encoder.t
+  val encode : dir:Path.t -> Path.t Dune_sexp.Encoder.t
 
-  val decode : dir:Path.t -> Path.t Dune_lang.Decoder.t
+  val decode : dir:Path.t -> Path.t Dune_sexp.Decoder.t
 end
 
 module Build : sig
-  include Dune_lang.Conv.S with type t = Path.Build.t
+  include Dune_sexp.Conv.S with type t = Path.Build.t
 
   val is_dev_null : t -> bool
 
@@ -59,7 +59,7 @@ module Build : sig
 end
 
 module External : sig
-  val encode : Path.External.t Dune_lang.Encoder.t
+  val encode : Path.External.t Dune_sexp.Encoder.t
 
-  val decode : Path.External.t Dune_lang.Decoder.t
+  val decode : Path.External.t Dune_sexp.Decoder.t
 end

--- a/src/dune_engine/execution_parameters.ml
+++ b/src/dune_engine/execution_parameters.ml
@@ -20,7 +20,7 @@ module Action_output_on_success = struct
 end
 
 type t =
-  { dune_version : Dune_lang.Syntax.Version.t
+  { dune_version : Dune_sexp.Syntax.Version.t
   ; action_stdout_on_success : Action_output_on_success.t
   ; action_stderr_on_success : Action_output_on_success.t
   ; expand_aliases_in_sandbox : bool
@@ -34,7 +34,7 @@ let equal
     ; expand_aliases_in_sandbox
     ; add_workspace_root_to_build_path_prefix_map
     } t =
-  Dune_lang.Syntax.Version.equal dune_version t.dune_version
+  Dune_sexp.Syntax.Version.equal dune_version t.dune_version
   && Action_output_on_success.equal action_stdout_on_success
        t.action_stdout_on_success
   && Action_output_on_success.equal action_stderr_on_success
@@ -51,7 +51,7 @@ let hash
     ; add_workspace_root_to_build_path_prefix_map
     } =
   Poly.hash
-    ( Dune_lang.Syntax.Version.hash dune_version
+    ( Dune_sexp.Syntax.Version.hash dune_version
     , Action_output_on_success.hash action_stdout_on_success
     , Action_output_on_success.hash action_stderr_on_success
     , expand_aliases_in_sandbox
@@ -65,7 +65,7 @@ let to_dyn
     ; add_workspace_root_to_build_path_prefix_map
     } =
   Dyn.Record
-    [ ("dune_version", Dune_lang.Syntax.Version.to_dyn dune_version)
+    [ ("dune_version", Dune_sexp.Syntax.Version.to_dyn dune_version)
     ; ( "action_stdout_on_success"
       , Action_output_on_success.to_dyn action_stdout_on_success )
     ; ( "action_stderr_on_success"

--- a/src/dune_engine/execution_parameters.mli
+++ b/src/dune_engine/execution_parameters.mli
@@ -44,7 +44,7 @@ end
 
 val builtin_default : t
 
-val set_dune_version : Dune_lang.Syntax.Version.t -> t -> t
+val set_dune_version : Dune_sexp.Syntax.Version.t -> t -> t
 
 val set_action_stdout_on_success : Action_output_on_success.t -> t -> t
 
@@ -61,7 +61,7 @@ val default : t Memo.t
 
 (** {1 Accessors} *)
 
-val dune_version : t -> Dune_lang.Syntax.Version.t
+val dune_version : t -> Dune_sexp.Syntax.Version.t
 
 val should_remove_write_permissions_on_generated_files : t -> bool
 

--- a/src/dune_engine/file_selector.ml
+++ b/src/dune_engine/file_selector.ml
@@ -63,7 +63,7 @@ let to_dyn { dir; predicate; only_generated_files } =
     ]
 
 let encode { dir; predicate; only_generated_files } =
-  let open Dune_lang.Encoder in
+  let open Dune_sexp.Encoder in
   record
     [ ("dir", Dpath.encode dir)
     ; ("predicate", Predicate_with_id.encode predicate)

--- a/src/dune_engine/file_selector.mli
+++ b/src/dune_engine/file_selector.mli
@@ -47,7 +47,7 @@ val hash : t -> int
 
 val compare : t -> t -> Ordering.t
 
-val encode : t Dune_lang.Encoder.t
+val encode : t Dune_sexp.Encoder.t
 
 (** [to_dyn] is used as a marshallable representation of [t] (to compute
     digests), so it must be injective *)

--- a/src/dune_engine/sandbox_mode.ml
+++ b/src/dune_engine/sandbox_mode.ml
@@ -131,7 +131,7 @@ let copy = Some Copy
 let hardlink = Some Hardlink
 
 let decode =
-  let open Dune_lang.Decoder in
+  let open Dune_sexp.Decoder in
   enum
     [ ("none", None)
     ; ("symlink", Some Symlink)

--- a/src/dune_engine/sandbox_mode.mli
+++ b/src/dune_engine/sandbox_mode.mli
@@ -95,7 +95,7 @@ val copy : t
 
 val hardlink : t
 
-val decode : t Dune_lang.Decoder.t
+val decode : t Dune_sexp.Decoder.t
 
 val to_string : t -> string
 


### PR DESCRIPTION
Use Dune_sexp instead of Dune_lang whenever possible in the engine

The end goal is to get rid of Dune_lang entirely in the engine.

<!-- ps-id: abbc0dd8-9f06-4d4c-917a-76cb829bde74 -->