### PR TITLE
fix(pkg): install optional entries correctly

### DIFF
--- a/src/dune_rules/install.mli
+++ b/src/dune_rules/install.mli
@@ -95,6 +95,7 @@ module Entry : sig
     ; kind : [ `File | `Directory ]
     ; dst : Dst.t
     ; section : Section.t
+    ; optional : bool
     }
 
   module Sourced : sig

--- a/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
+++ b/test/blackbox-tests/test-cases/pkg/install-missing-entry.t
@@ -23,6 +23,3 @@ This on the other hand shouldn't error because myfile is optional
 
   $ lockfile "?myfile"
   $ dune build .pkg/test/target/
-  Error: No such file or directory
-  -> required by _build/default/.pkg/test/target
-  [1]


### PR DESCRIPTION
Entries prefixed with "?" are optional. We no longer require them to
exist when building a package.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e9a93b6c-e1c4-41b9-93cf-f6598d97907d -->