### PR TITLE
test(melange): demonstrate bug with nested installed runtime assets

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -49,8 +49,7 @@ module Lib = struct
       | External paths ->
         let lib_dir = Obj_dir.dir obj_dir in
         List.map paths ~f:(fun p ->
-            Path.as_in_build_dir_exn p |> Path.Build.drop_build_context_exn
-            |> Path.append_source lib_dir)
+            Path.append_local lib_dir (Path.local_part p))
     in
     let orig_src_dir = Lib_info.orig_src_dir info in
     let implements = Lib_info.implements info in
@@ -73,12 +72,7 @@ module Lib = struct
       | Local -> None
     in
     let melange_runtime_deps =
-      match Lib_info.melange_runtime_deps info with
-      | Local _ -> assert false
-      | External paths ->
-        let lib_dir = Obj_dir.dir obj_dir in
-        List.map paths ~f:(fun p ->
-            Path.append_local lib_dir (Path.local_part p))
+      additional_paths (Lib_info.melange_runtime_deps info)
     in
     let jsoo_runtime = Lib_info.jsoo_runtime info in
     let virtual_ = Option.is_some (Lib_info.virtual_ info) in

--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -73,7 +73,12 @@ module Lib = struct
       | Local -> None
     in
     let melange_runtime_deps =
-      additional_paths (Lib_info.melange_runtime_deps info)
+      match Lib_info.melange_runtime_deps info with
+      | Local _ -> assert false
+      | External paths ->
+        let lib_dir = Obj_dir.dir obj_dir in
+        List.map paths ~f:(fun p ->
+            Path.append_local lib_dir (Path.local_part p))
     in
     let jsoo_runtime = Lib_info.jsoo_runtime info in
     let virtual_ = Option.is_some (Lib_info.virtual_ info) in

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2007,6 +2007,14 @@ let to_dune_lib ({ info; _ } as lib) ~modules ~foreign_objects
         else Direct (loc, mangled_name lib))
   in
   let name = mangled_name lib in
+  let melange_runtime_deps =
+    let prefix = Lib_info.src_dir lib.info in
+    List.map
+      ~f:(fun melange_runtime_dep ->
+        let local_dep = Path.drop_prefix_exn ~prefix melange_runtime_dep in
+        Path.of_local local_dep)
+      melange_runtime_deps
+  in
   let info =
     Lib_info.for_dune_package info ~name ~ppx_runtime_deps ~requires
       ~foreign_objects ~obj_dir ~implements ~default_implementation ~sub_systems

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -2007,14 +2007,16 @@ let to_dune_lib ({ info; _ } as lib) ~modules ~foreign_objects
         else Direct (loc, mangled_name lib))
   in
   let name = mangled_name lib in
-  let melange_runtime_deps =
+  let remove_public_dep_prefix paths =
     let prefix = Lib_info.src_dir lib.info in
     List.map
-      ~f:(fun melange_runtime_dep ->
-        let local_dep = Path.drop_prefix_exn ~prefix melange_runtime_dep in
+      ~f:(fun path ->
+        let local_dep = Path.drop_prefix_exn ~prefix path in
         Path.of_local local_dep)
-      melange_runtime_deps
+      paths
   in
+  let public_headers = remove_public_dep_prefix public_headers in
+  let melange_runtime_deps = remove_public_dep_prefix melange_runtime_deps in
   let info =
     Lib_info.for_dune_package info ~name ~ppx_runtime_deps ~requires
       ~foreign_objects ~obj_dir ~implements ~default_implementation ~sub_systems

--- a/src/dune_rules/lib_info.ml
+++ b/src/dune_rules/lib_info.ml
@@ -622,7 +622,7 @@ type external_ = Path.t t
 
 type local = Path.Build.t t
 
-let map t ~path_kind ~f_path ~f_obj_dir ~f_melange_deps =
+let map t ~path_kind ~f_path ~f_obj_dir ~f_public_deps =
   let f = f_path in
   let list = List.map ~f in
   let mode_list = Mode.Dict.map ~f:list in
@@ -638,26 +638,25 @@ let map t ~path_kind ~f_path ~f_obj_dir ~f_melange_deps =
   ; archives = mode_list t.archives
   ; plugins = mode_list t.plugins
   ; foreign_objects = Source.map ~f:(List.map ~f) t.foreign_objects
-  ; public_headers = File_deps.map ~f t.public_headers
+  ; public_headers = File_deps.map ~f:f_public_deps t.public_headers
   ; foreign_archives = Mode.Map.Multi.map t.foreign_archives ~f
   ; foreign_dll_files = List.map ~f t.foreign_dll_files
   ; native_archives
   ; jsoo_runtime = List.map ~f t.jsoo_runtime
-  ; melange_runtime_deps =
-      File_deps.map ~f:f_melange_deps t.melange_runtime_deps
+  ; melange_runtime_deps = File_deps.map ~f:f_public_deps t.melange_runtime_deps
   ; path_kind
   }
 
 let map_path t ~f =
-  map t ~path_kind:External ~f_path:f ~f_obj_dir:Fun.id ~f_melange_deps:Fun.id
+  map t ~path_kind:External ~f_path:f ~f_obj_dir:Fun.id ~f_public_deps:Fun.id
 
 let of_local =
   map ~path_kind:External ~f_path:Path.build ~f_obj_dir:Obj_dir.of_local
-    ~f_melange_deps:Path.build
+    ~f_public_deps:Path.build
 
 let as_local_exn =
   map ~path_kind:Local ~f_path:Path.as_in_build_dir_exn
-    ~f_obj_dir:Obj_dir.as_local_exn ~f_melange_deps:Path.as_in_build_dir_exn
+    ~f_obj_dir:Obj_dir.as_local_exn ~f_public_deps:Path.as_in_build_dir_exn
 
 let to_dyn path
     { loc

--- a/test/blackbox-tests/test-cases/foreign-stubs/public-headers-nested.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/public-headers-nested.t
@@ -1,0 +1,50 @@
+Headers with the same filename cannot be installed together:
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name mypkg))
+  > EOF
+
+  $ mkdir -p packages/lib/mypkg/inc
+
+  $ cat >packages/lib/mypkg/dune <<EOF
+  > (library
+  >  (public_name mypkg)
+  >  (public_headers foo.h inc/foo.h))
+  > EOF
+
+  $ touch packages/lib/mypkg/foo.h packages/lib/mypkg/inc/foo.h
+
+  $ dune build mypkg.install && cat _build/default/mypkg.install | grep ".h"
+    "_build/install/default/lib/mypkg/foo.h"
+    "_build/install/default/lib/mypkg/inc/foo.h" {"inc/foo.h"}
+
+  $ cat _build/install/default/lib/mypkg/dune-package | grep public_headers
+   (public_headers default/lib/mypkg/foo.h default/lib/mypkg/foo.h)
+
+Now we try to use the installed headers:
+
+  $ dune install --prefix _install mypkg
+  $ export OCAMLPATH=$PWD/_install/lib:$OCAMLPATH
+
+  $ mkdir subdir
+  $ cd subdir
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name bar)
+  >  (foreign_stubs
+  >   (language c)
+  >   (include_dirs (lib mypkg))
+  >   (names foo)))
+  > EOF
+  $ touch bar.ml
+  $ cat >foo.c <<EOF
+  > #include <foo.h>
+  > #include <inc/foo.h>
+  > EOF
+  $ dune build bar.exe

--- a/test/blackbox-tests/test-cases/foreign-stubs/public-headers-nested.t
+++ b/test/blackbox-tests/test-cases/foreign-stubs/public-headers-nested.t
@@ -20,7 +20,7 @@ Headers with the same filename cannot be installed together:
     "_build/install/default/lib/mypkg/inc/foo.h" {"inc/foo.h"}
 
   $ cat _build/install/default/lib/mypkg/dune-package | grep public_headers
-   (public_headers default/lib/mypkg/foo.h default/lib/mypkg/foo.h)
+   (public_headers foo.h inc/foo.h)
 
 Now we try to use the installed headers:
 

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
@@ -1,0 +1,71 @@
+Test `melange.runtime_deps` in a library that has been installed
+
+  $ mkdir lib app prefix
+  $ cat > lib/dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name foo))
+  > (using melange 0.1)
+  > EOF
+
+  $ mkdir -p lib/packages/foo/src/
+  $ echo "function foo() { return 42; }" > lib/packages/foo/src/runtime.js
+  $ cat > lib/packages/foo/src/dune <<EOF
+  > (library
+  >  (public_name foo)
+  >  (name foo)
+  >  ;(wrapped false)
+  >  (modes melange)
+  >  (preprocess (pps melange.ppx))
+  >  (melange.runtime_deps ./runtime.js))
+  > EOF
+  $ cat > lib/packages/foo/src/foo.ml <<EOF
+  > let dirname = [%bs.raw "__dirname"]
+  > let () = Js.log2 "dirname:" dirname
+  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/runtime.js") \`utf8
+  > EOF
+
+  $ dune build --root lib
+  Entering directory 'lib'
+  Leaving directory 'lib'
+
+  $ cat lib/_build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+    "_build/install/default/lib/foo/foo.ml"
+    "_build/install/default/lib/foo/melange/foo.cmi" {"melange/foo.cmi"}
+    "_build/install/default/lib/foo/melange/foo.cmj" {"melange/foo.cmj"}
+    "_build/install/default/lib/foo/melange/foo.cmt" {"melange/foo.cmt"}
+    "_build/install/default/lib/foo/runtime.js"
+  ]
+
+  $ dune install --root lib --prefix $PWD/prefix
+
+  $ mkdir -p app
+  $ cat > app/dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name app))
+  > (using melange 0.1)
+  > EOF
+  $ cat > app/dune <<EOF
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (libraries foo))
+  > EOF
+
+  $ cat > app/main.ml <<EOF
+  > let () = Js.log (Foo.read_asset ())
+  > EOF
+
+  $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @melange
+  Entering directory 'app'
+  File "dune", line 1, characters 0-69:
+  1 | (melange.emit
+  2 |  (target output)
+  3 |  (emit_stdlib false)
+  4 |  (libraries foo))
+  Error: File unavailable:
+  $TESTCASE_ROOT/prefix/lib/foo/packages/foo/src/runtime.js
+  Leaving directory 'app'
+  [1]

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
@@ -1,4 +1,5 @@
-Test `melange.runtime_deps` in a library that has been installed
+Test `melange.runtime_deps` for installed libraries where the dune file is
+nested more than the dune-project file
 
   $ mkdir lib app prefix
   $ cat > lib/dune-project <<EOF
@@ -13,7 +14,6 @@ Test `melange.runtime_deps` in a library that has been installed
   > (library
   >  (public_name foo)
   >  (name foo)
-  >  ;(wrapped false)
   >  (modes melange)
   >  (preprocess (pps melange.ppx))
   >  (melange.runtime_deps ./runtime.js))
@@ -60,12 +60,10 @@ Test `melange.runtime_deps` in a library that has been installed
 
   $ OCAMLPATH=$PWD/prefix/lib/:$OCAMLPATH dune build --root app @melange
   Entering directory 'app'
-  File "dune", line 1, characters 0-69:
-  1 | (melange.emit
-  2 |  (target output)
-  3 |  (emit_stdlib false)
-  4 |  (libraries foo))
-  Error: File unavailable:
-  $TESTCASE_ROOT/prefix/lib/foo/packages/foo/src/runtime.js
   Leaving directory 'app'
-  [1]
+
+File exists in output dir
+
+  $ ls app/_build/default/output/node_modules/foo
+  foo.js
+  runtime.js

--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-nested.t
@@ -39,6 +39,9 @@ nested more than the dune-project file
     "_build/install/default/lib/foo/runtime.js"
   ]
 
+  $ cat lib/_build/install/default/lib/foo/dune-package | grep melange_runtime_deps
+   (melange_runtime_deps runtime.js))
+
   $ dune install --root lib --prefix $PWD/prefix
 
   $ mkdir -p app


### PR DESCRIPTION
- When a library dune file is nested under the `dune-project` file, dune was writing information to `dune-package` about `melange.runtime_deps` relative to the root.
- these paths should, however, be recorded relative to the `dune` file that defines the library.