### PR TITLE
test(melange): interaction between melange_runtime_deps and include_subdirs

### DIFF
--- a/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-include-qualified.t
+++ b/test/blackbox-tests/test-cases/melange/installed-library-with-runtime-deps-include-qualified.t
@@ -1,0 +1,73 @@
+Test `melange.runtime_deps` for installed libraries where the dune file is
+nested more than the dune-project file
+
+  $ mkdir lib app prefix
+  $ cat > lib/dune-project <<EOF
+  > (lang dune 3.8)
+  > (package (name foo))
+  > (using melange 0.1)
+  > EOF
+
+  $ mkdir -p lib/packages/foo/src/runtime
+  $ echo "function foo() { return 42; }" > lib/packages/foo/src/runtime/runtime.js
+  $ cat > lib/packages/foo/src/dune <<EOF
+  > (include_subdirs unqualified)
+  > (library
+  >  (public_name foo)
+  >  (name foo)
+  >  (modes melange)
+  >  (preprocess (pps melange.ppx))
+  >  (melange.runtime_deps ./runtime/runtime.js))
+  > EOF
+  $ cat > lib/packages/foo/src/foo.ml <<EOF
+  > let dirname = [%bs.raw "__dirname"]
+  > let () = Js.log2 "dirname:" dirname
+  > let read_asset () = Node.Fs.readFileSync (dirname ^ "/runtime/runtime.js") \`utf8
+  > EOF
+
+  $ dune build --root lib
+  Entering directory 'lib'
+  Leaving directory 'lib'
+
+  $ cat lib/_build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+    "_build/install/default/lib/foo/foo.ml"
+    "_build/install/default/lib/foo/melange/foo.cmi" {"melange/foo.cmi"}
+    "_build/install/default/lib/foo/melange/foo.cmj" {"melange/foo.cmj"}
+    "_build/install/default/lib/foo/melange/foo.cmt" {"melange/foo.cmt"}
+    "_build/install/default/lib/foo/runtime/runtime.js" {"runtime/runtime.js"}
+  ]
+
+  $ grep melange_runtime_deps lib/_build/install/default/lib/foo/dune-package
+   (melange_runtime_deps runtime/runtime.js))
+
+  $ cat > lib/packages/foo/src/dune <<EOF
+  > (include_subdirs qualified)
+  > (library
+  >  (public_name foo)
+  >  (name foo)
+  >  (modes melange)
+  >  (preprocess (pps melange.ppx))
+  >  (melange.runtime_deps ./runtime/runtime.js))
+  > EOF
+  $ dune build --root lib
+  Entering directory 'lib'
+  Leaving directory 'lib'
+
+  $ cat lib/_build/default/foo.install
+  lib: [
+    "_build/install/default/lib/foo/META"
+    "_build/install/default/lib/foo/dune-package"
+    "_build/install/default/lib/foo/foo.ml"
+    "_build/install/default/lib/foo/melange/foo.cmi" {"melange/foo.cmi"}
+    "_build/install/default/lib/foo/melange/foo.cmj" {"melange/foo.cmj"}
+    "_build/install/default/lib/foo/melange/foo.cmt" {"melange/foo.cmt"}
+    "_build/install/default/lib/foo/runtime/runtime.js" {"runtime/runtime.js"}
+  ]
+
+  $ grep melange_runtime_deps lib/_build/install/default/lib/foo/dune-package
+   (melange_runtime_deps runtime/runtime.js))
+
+


### PR DESCRIPTION
- tests the interaction between `melange_runtime_deps` and `include_subdirs {un,}qualified`
- part of https://github.com/ocaml/dune/issues/7164