### PR TITLE
test: demonstrate byte_complete executable not printing backtrace

### DIFF
--- a/test/blackbox-tests/test-cases/byte-complete-locations.t
+++ b/test/blackbox-tests/test-cases/byte-complete-locations.t
@@ -1,0 +1,32 @@
+Demonstrate byte_complete executables not printing backtraces
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > EOF
+  $ cat >dune <<EOF
+  > (executable
+  >  (name foo)
+  >  (modes byte_complete byte native))
+  > EOF
+  $ cat > foo.ml <<EOF
+  > let () =
+  >   Printexc.record_backtrace true;
+  >   raise Not_found
+  > EOF
+
+Both native and bytecode modes print the backtrace
+
+  $ dune exec ./foo.exe
+  Fatal error: exception Not_found
+  Raised at Dune__exe__Foo in file "foo.ml", line 3, characters 2-17
+  [2]
+  $ dune exec ./foo.bc
+  Fatal error: exception Not_found
+  Raised at Dune__exe__Foo in file "foo.ml", line 3, characters 2-17
+  [2]
+
+byte_complete does not print the backtrace
+
+  $ dune exec ./foo.bc.exe
+  Fatal error: exception Not_found
+  [2]


### PR DESCRIPTION
- test shows how `.exe` and `.bc` print the backtrace for exceptions, while `.bc.exe` doesn't.