### PR TITLE
refactor: remove use of format

### DIFF
--- a/src/dune_rules/dune_package.ml
+++ b/src/dune_rules/dune_package.ml
@@ -467,8 +467,8 @@ module Or_meta = struct
   let pp ~dune_version ppf t =
     let t = encode ~dune_version t in
     Format.fprintf ppf "%a@."
-      (Format.pp_print_list ~pp_sep:Format.pp_print_newline
-         Dune_lang.Deprecated.pp)
+      (Format.pp_print_list ~pp_sep:Format.pp_print_newline (fun fmt lang ->
+           Dune_lang.pp lang |> Pp.to_fmt fmt))
       t
 
   let to_dyn x =

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -694,11 +694,10 @@ end = struct
           in
           let action_with_targets =
             Action_builder.write_file
-              (Package_paths.deprecated_dune_package_file ctx pkg
-                 dune_pkg.Dune_package.name)
+              (Package_paths.deprecated_dune_package_file ctx pkg dune_pkg.name)
               (Format.asprintf "%a"
                  (Dune_package.Or_meta.pp ~dune_version)
-                 (Dune_package.Or_meta.Dune_package dune_pkg))
+                 (Dune_package dune_pkg))
           in
           Super_context.add_rule sctx ~dir:ctx.build_dir ~loc
             action_with_targets)


### PR DESCRIPTION
Use pp instead of the deprecated formatters

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1da375c3-a6c4-4a84-be63-6afe66aa9637 -->