### PR TITLE
Rename the `QVar` constructor to `Literal`

### DIFF
--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -145,7 +145,7 @@ let odoc_name = Package.Name.of_string "odoc"
 let insert_dune_dep depends dune_version =
   let constraint_ : Package.Dependency.Constraint.t =
     let dune_version = Dune_lang.Syntax.Version.to_string dune_version in
-    Uop (Gte, QVar dune_version)
+    Uop (Gte, Literal dune_version)
   in
   let rec loop acc = function
     | [] ->

--- a/src/dune_rules/package.ml
+++ b/src/dune_rules/package.ml
@@ -101,28 +101,29 @@ module Dependency = struct
   module Constraint = struct
     module Var = struct
       type t =
-        | QVar of string
+        | Literal of string
         | Var of string
 
       let encode = function
-        | QVar v -> Dune_lang.Encoder.string v
+        | Literal v -> Dune_lang.Encoder.string v
         | Var v -> Dune_lang.Encoder.string (":" ^ v)
 
       let decode =
         let open Dune_lang.Decoder in
         let+ s = string in
-        if String.is_prefix s ~prefix:":" then Var (String.drop s 1) else QVar s
+        if String.is_prefix s ~prefix:":" then Var (String.drop s 1)
+        else Literal s
 
       let to_opam v =
         let value_kind : OpamParserTypes.FullPos.value_kind =
           match v with
-          | QVar x -> String x
+          | Literal x -> String x
           | Var x -> Ident x
         in
         nopos value_kind
 
       let to_dyn = function
-        | QVar v -> Dyn.String v
+        | Literal v -> Dyn.String v
         | Var v -> Dyn.String (":" ^ v)
     end
 

--- a/src/dune_rules/package.mli
+++ b/src/dune_rules/package.mli
@@ -42,8 +42,9 @@ module Dependency : sig
   module Constraint : sig
     module Var : sig
       type t =
-        | QVar of string
-        | Var of string
+        | Literal of string
+            (** A quoted string literal, such as a version number *)
+        | Var of string  (** A variable name such as :version or :with-test *)
     end
 
     type t =


### PR DESCRIPTION
This constructor is for quoted string literals. It took me a while to figure this out so I'm renaming it to make it easier for the next person who works with this code.