### PR TITLE
doc: add API docs for dune-build-info

### DIFF
--- a/otherlibs/build-info/src/build_info.mli
+++ b/otherlibs/build-info/src/build_info.mli
@@ -1,18 +1,37 @@
-(** Provide build information *)
+(** See {!V1} for the current version. *)
 
 module V1 : sig
+  (** Provide build-time information.
+
+      The entry points in this module are {!version} and
+      {!Statically_linked_libraries.to_list}.
+
+      {e Implementation note:} this module is implemented using special support
+      from Dune. When an executable is linked, a special "blank" placeholder is
+      stored as a string. A special post-link phase called
+      {e artifact substitution} can replace this placeholder with encoded data
+      that will be decoded by this library.
+
+      Artifact substitution happens when an executable is installed or promoted
+      to the source tree. *)
+
   module Version : sig
+    (** Version numbers. *)
+
     type t
 
     val to_string : t -> string
   end
 
-  (** The version at which the current executable was built. The version is
-      [None] during development, it is only [Some _] once the executable is
-      installed or promoted to the source tree. *)
+  (** The version at which the current executable was built.
+
+      The version is [None] during development, it is only [Some _] once
+      artifact substitution happened. *)
   val version : unit -> Version.t option
 
   module Statically_linked_library : sig
+    (** A library with an optional version number. *)
+
     type t
 
     (** The most visible name of the library. If it is a public library, this
@@ -23,10 +42,12 @@ module V1 : sig
   end
 
   module Statically_linked_libraries : sig
-    (** All the libraries that where statically linked in *)
+    (** Entry points to find {!Statically_linked_library} values. *)
 
+    (** All the libraries that where statically linked in *)
     val to_list : unit -> Statically_linked_library.t list
 
+    (** Find a particular library by name. *)
     val find : name:string -> Statically_linked_library.t option
   end
 end

--- a/otherlibs/build-info/src/dune
+++ b/otherlibs/build-info/src/dune
@@ -8,3 +8,6 @@
    (api_version 1)))
  (instrumentation
   (backend bisect_ppx)))
+
+(documentation
+ (package dune-build-info))

--- a/otherlibs/build-info/src/index.mld
+++ b/otherlibs/build-info/src/index.mld
@@ -1,0 +1,39 @@
+{1 [dune-build-info] - access information generated at build time. }
+
+{2 Introduction}
+
+This library exposes some functions to query pieces of information generated at
+build time, in particular:
+
+- the version of the project being built. You can use [dune-build-info] to
+  implement a [--version] flag.
+- the list of libraries an executable is linked against. You can use
+  [dune-build-info] to write a [--build-info] flag that will display a software
+  bill of materials listing the libraries used to build an executable.
+
+{2 Example}
+
+This displays the version number and the libraries the executable is statically
+linked with:
+
+{[
+  let version_string v =
+    match Build_info.V1.version v with
+    | None -> "n/a"
+    | Some v -> Build_info.V1.Version.to_string v
+  in
+  let version = Build_info.V1.version ();
+  Printf.printf "version: %s\n" (version_string version);
+  let libs = Build_info.V1.Statically_linked_libraries.to_list () in
+  Printf.printf "statically linked libraries:\n";
+  List.iter
+    (fun lib ->
+       let name = Build_info.V1.Statically_linked_library.name lib in
+       let version = Build_info.V1.Statically_linked_library.version lib in
+       Printf.printf "- %s (%s)\n" name (version_string version)
+    ) libs
+]}
+
+{2 API documentation}
+
+The entry point for this library is {!Build_info.V1}.


### PR DESCRIPTION
The goal is to have great docs for this feature directly on <https://ocaml.org/p/dune-build-info/latest/doc/index.html>
