### PR TITLE
feature(pkg): set environment in build rules

### DIFF
--- a/src/dune_lang/action.mli
+++ b/src/dune_lang/action.mli
@@ -66,6 +66,26 @@ module File_perm : sig
   val to_unix_perm : t -> int
 end
 
+module Env_update : sig
+  type op =
+    | Eq
+    | PlusEq
+    | EqPlus
+    | ColonEq
+    | EqColon
+    | EqPlusEq
+
+  type 'a t =
+    { op : op
+    ; var : Env.Var.t
+    ; value : 'a
+    }
+
+  val decode : String_with_vars.t t Decoder.t
+
+  val encode : String_with_vars.t t -> Dune_sexp.t
+end
+
 type t =
   | Run of String_with_vars.t * String_with_vars.t list
   | With_accepted_exit_codes of int Predicate_lang.t * t
@@ -95,6 +115,7 @@ type t =
   | Cram of String_with_vars.t
   | Patch of String_with_vars.t
   | Substitute of String_with_vars.t * String_with_vars.t
+  | Withenv of String_with_vars.t Env_update.t list * t
 
 val encode : t Encoder.t
 

--- a/src/dune_pkg/lock_dir.mli
+++ b/src/dune_pkg/lock_dir.mli
@@ -21,16 +21,6 @@ module Pkg_info : sig
     }
 end
 
-module Env_update : sig
-  type 'a t =
-    { op : OpamParserTypes.env_update_op
-    ; var : Env.Var.t
-    ; value : 'a
-    }
-
-  val decode : String_with_vars.t t Dune_sexp.Decoder.t
-end
-
 module Pkg : sig
   type t =
     { build_command : Action.t option
@@ -38,7 +28,7 @@ module Pkg : sig
     ; deps : Package_name.t list
     ; info : Pkg_info.t
     ; lock_dir : Path.Source.t
-    ; exported_env : String_with_vars.t Env_update.t list
+    ; exported_env : String_with_vars.t Action.Env_update.t list
     }
 
   val decode :

--- a/src/dune_rules/action_unexpanded.ml
+++ b/src/dune_rules/action_unexpanded.ml
@@ -481,7 +481,7 @@ let rec expand (t : Dune_lang.Action.t) ~context : Action.t Action_expander.t =
   | Cram script ->
     let+ script = E.dep script in
     Cram_exec.action script
-  | Substitute _ | Patch _ ->
+  | Withenv _ | Substitute _ | Patch _ ->
     (* these can only be provided by the package language which isn't expanded here *)
     assert false
 

--- a/test/blackbox-tests/test-cases/pkg/withenv.t
+++ b/test/blackbox-tests/test-cases/pkg/withenv.t
@@ -1,0 +1,22 @@
+Setting environment variables in actions
+
+  $ mkdir dune.lock
+  $ cat >dune.lock/lock.dune <<EOF
+  > (lang package 0.1)
+  > EOF
+  $ cat >dune.lock/test <<'EOF'
+  > (build
+  >  (withenv
+  >   ((= FOO myfoo)
+  >    (= XYZ 000)
+  >    (+= XYZ 111)
+  >    (= BAR xxx)
+  >    (+= BAR yyy)
+  >    (:= BAR "")
+  >    (+= BAR ""))
+  >   (system "echo XYZ=$XYZ; echo FOO=$FOO; echo BAR=$BAR")))
+  > EOF
+  $ dune build .pkg/test/target/
+  XYZ=111:000
+  FOO=myfoo
+  BAR=yyy:xxx


### PR DESCRIPTION
I've added the `(withenv ..)` action to replicate opam's env operations. The implementation isn't 100% done yet (we don't handle removals of env vars yet), but it's good enough for most packages.

@Leonidas-from-XIV  @gridbugs i've added you as reviewers so that you're familiar with the code and are aware of this feature. 