### PR TITLE
doc: point at the official docs in odoc

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -29,3 +29,6 @@
   (with-stdout-to
    dune.inc
    (run bash %{dep:update-jbuild.sh}))))
+
+(documentation
+ (package dune))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,6 @@
+{1 [dune] - Fast, portable, and opinionated build system }
+
+The documentation for [dune] is available here:
+
+- {{: https://dune.readthedocs.io/en/stable/} latest release}
+- {{: https://dune.readthedocs.io/en/latest/} development version}


### PR DESCRIPTION
This page is used by ocaml.org to display the docs for dune.
