### PR TITLE
fix(coq): make loading of theories in scope lazier 

### DIFF
--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -228,11 +228,9 @@ module DB = struct
           (Dune_project.root project, (dir, stanza)))
       |> Path.Source.Map.of_list_multi
     in
-
     let public_theories = Lazy.force public_theories in
     let parent = Some public_theories in
     let find_db dir = snd (find_by_dir_in_map db_by_project_dir dir) in
-
     Path.Source.Map.merge projects_by_dir coq_stanzas_by_project_dir
       ~f:(fun _dir project coq_stanzas ->
         assert (Option.is_some project);
@@ -290,19 +288,16 @@ module DB = struct
              in
              (project, db))
     in
-
     let coq_scopes_by_dir =
       lazy
         (coq_scopes_by_dir db_by_project_dir projects_by_dir public_theories
            coq_stanzas)
     in
-
     let coq_db_find dir =
       lazy
         (let map = Lazy.force coq_scopes_by_dir in
          Path.Source.Map.find_exn map dir)
     in
-
     Path.Source.Map.mapi db_by_project_dir ~f:(fun dir (project, db) ->
         let root =
           Path.Build.append_source build_dir (Dune_project.root project)

--- a/src/dune_rules/scope.mli
+++ b/src/dune_rules/scope.mli
@@ -13,7 +13,7 @@ val project : t -> Dune_project.t
 (** Return the library database associated to this scope *)
 val libs : t -> Lib.DB.t
 
-val coq_libs : t -> Coq_lib.DB.t
+val coq_libs : t -> Coq_lib.DB.t Memo.t
 
 (** Scope databases *)
 module DB : sig

--- a/test/blackbox-tests/test-cases/coq/compose-installed-compat.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-compat.t/run.t
@@ -13,7 +13,7 @@ We also need to set up a fake Coq install.
   $TESTCASE_ROOT/lib/coq
 
   $ mkdir -p lib/coq/theories/Init/
-  $ echo > lib/coq/theories/Init/Prelude.v << EOF
+  $ cat > lib/coq/theories/Init/Prelude.v << EOF
   > Inductive PreludeLoaded := Yes.
   > EOF
 

--- a/test/blackbox-tests/test-cases/coq/compose-installed-rebuild.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-rebuild.t/run.t
@@ -6,7 +6,7 @@ We test that installed Coq theories, when updated, prompt Dune to rebuild
   $TESTCASE_ROOT/lib/coq
 
   $ mkdir -p lib/coq/theories/Init/
-  $ echo > lib/coq/theories/Init/Prelude.v << EOF
+  $ cat > lib/coq/theories/Init/Prelude.v << EOF
   > Inductive PreludeLoaded := Yes.
   > EOF
 

--- a/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/global/algebra/dune
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/global/algebra/dune
@@ -1,0 +1,3 @@
+(coq.theory
+ (name global.algebra)
+ (package global))

--- a/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/global/dune
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/global/dune
@@ -1,5 +1,0 @@
-(coq.theory
- (name global)
- (package global))
-
-(include_subdirs qualified)

--- a/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/global/field/dune
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/global/field/dune
@@ -1,0 +1,3 @@
+(coq.theory
+ (name global.field)
+ (package global))

--- a/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/run.t
@@ -11,7 +11,7 @@ We also need to set up a fake Coq install.
   $TESTCASE_ROOT/lib/coq
 
   $ mkdir -p lib/coq/theories/Init/
-  $ echo > lib/coq/theories/Init/Prelude.v << EOF
+  $ cat > lib/coq/theories/Init/Prelude.v << EOF
   > Inductive PreludeLoaded := Yes.
   > EOF
 
@@ -22,6 +22,14 @@ We need to manually compile the prelude.
 We also setup some plugins
 
   $ mkdir -p lib/coq-core/plugins
+
+Setting up a subdirectory theory:
+
+  $ cat > user/dune << EOF
+  > (coq.theory
+  >  (name user)
+  >  (theories global.field global.algebra))
+  > EOF
 
 We setup an installed theory. Note that lib/coq/user-contrib doesn't exist yet,
 so this also tests that it won't be a problem.
@@ -155,14 +163,27 @@ any problems. It shouldn't do, as the workspace should take precedence.
 
 We test updating the dune file for user to use the super-theory works:
 
-  $ rm user/dune
-  $ echo > user/dune << EOF
+  $ cat > user/dune << EOF
   > (coq.theory
-  >   (name user)
-  >   (theories global))
+  >  (name user)
+  >  (theories global))
   > EOF
   $ dune build --root user
   Entering directory 'user'
+  Inductive hello_alg : Set :=
+      I : hello_alg
+    | am : hello_alg
+    | an : hello_alg
+    | install : hello_alg
+    | loc : hello_alg
+    | at_alg : hello_alg.
+  Inductive hello_field : Set :=
+      I : hello_field
+    | am : hello_field
+    | an : hello_field
+    | install : hello_field
+    | loc : hello_field
+    | at_field : hello_field.
   Leaving directory 'user'
 
 We test whether installing `global` again in user-contrib will cause Dune to reject the

--- a/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/user/dune
+++ b/test/blackbox-tests/test-cases/coq/compose-installed-sub.t/user/dune
@@ -1,3 +1,0 @@
-(coq.theory
- (name user)
- (theories global.field global.algebra))

--- a/test/blackbox-tests/test-cases/coq/compose-installed.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-installed.t/run.t
@@ -11,7 +11,7 @@ We also need to set up a fake Coq install.
   $TESTCASE_ROOT/lib/coq
 
   $ mkdir -p lib/coq/theories/Init/
-  $ echo > lib/coq/theories/Init/Prelude.v << EOF
+  $ cat > lib/coq/theories/Init/Prelude.v << EOF
   > Inductive PreludeLoaded := Yes.
   > EOF
 

--- a/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-plugin.t/run.t
@@ -1,14 +1,14 @@
   $ dune build --display short --debug-dependency-path @all
   Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
   3.8 and will be removed in an upcoming Dune version.
-        coqdep thy1/.thy1.theory.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Gram.intf.d
       ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Simple.impl.d
-        coqdep thy2/.thy2.theory.d
          coqpp src_a/gram.ml
+        coqdep thy1/.thy1.theory.d
+        coqdep thy2/.thy2.theory.d
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}

--- a/test/blackbox-tests/test-cases/coq/compose-projects-boot.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/compose-projects-boot.t/run.t
@@ -43,13 +43,23 @@ However if this boot library is public Dune will complain
   >  (boot))
   > EOF
 
+Due to lazy loading of installed theories, the error messages for having more
+than one boot theory is a bit delayed and comes with the multiple rules error
+message together. This is some extra noise for the user, but we are not sure how
+to fix this currently.
+
   $ dune build B
   Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
   3.8 and will be removed in an upcoming Dune version.
   Error: Cannot have more than one boot theory in scope:
   - Coq at Coq/dune:1
   - Coq at B/Coq/dune:2
-  -> required by _build/default/B/Foo.dune-package
+  -> required by alias B/default
+  Error: Multiple rules generated for
+  _build/install/default/lib/coq/theories/Init/Prelude.v:
+  - Coq/dune:1
+  - B/Coq/dune:2
+  -> required by _build/default/B/Foo.install
   -> required by alias B/all
   -> required by alias B/default
   [1]

--- a/test/blackbox-tests/test-cases/coq/lazy-lib.t
+++ b/test/blackbox-tests/test-cases/coq/lazy-lib.t
@@ -1,0 +1,27 @@
+We test that the calls to coqc -config in scope.ml is lazy enough that it will
+not be called unless necessary.
+
+We test this using a dummy coqc that will fail if it is called.
+
+  $ cat > coqc << EOF
+  > #!/bin/sh
+  > exit 5
+  > EOF
+  $ chmod +x coqc
+
+We add this to path:
+
+  $ export PATH=$PWD:$PATH
+
+Next we create an empty coq project:
+
+  $ cat > dune-project << EOF
+  > (lang dune 3.8)
+  > (using coq 0.8)
+  > EOF
+
+Finally we run dune build:
+
+  $ dune build
+  Command exited with code 5.
+  [1]

--- a/test/blackbox-tests/test-cases/coq/lazy-lib.t
+++ b/test/blackbox-tests/test-cases/coq/lazy-lib.t
@@ -23,5 +23,3 @@ Next we create an empty coq project:
 Finally we run dune build:
 
   $ dune build
-  Command exited with code 5.
-  [1]

--- a/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/ml-lib.t/run.t
@@ -1,13 +1,13 @@
   $ dune build --display short --debug-dependency-path @all
   Warning: Coq Language Versions lower than 0.8 have been deprecated in Dune
   3.8 and will be removed in an upcoming Dune version.
-        coqdep theories/.Plugin.theory.d
         ocamlc src_b/.ml_plugin_b.objs/byte/ml_plugin_b.{cmi,cmo,cmt}
       ocamldep src_b/.ml_plugin_b.objs/ml_plugin_b__Simple_b.impl.d
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a.{cmi,cmo,cmt}
       ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Gram.intf.d
       ocamldep src_a/.ml_plugin_a.objs/ml_plugin_a__Simple.impl.d
          coqpp src_a/gram.ml
+        coqdep theories/.Plugin.theory.d
       ocamlopt src_b/.ml_plugin_b.objs/native/ml_plugin_b.{cmx,o}
       ocamlopt src_a/.ml_plugin_a.objs/native/ml_plugin_a.{cmx,o}
         ocamlc src_a/.ml_plugin_a.objs/byte/ml_plugin_a__Gram.{cmi,cmti}

--- a/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
+++ b/test/blackbox-tests/test-cases/coq/rec-module.t/run.t
@@ -3,8 +3,8 @@
   3.8 and will be removed in an upcoming Dune version.
         coqdep .rec_module.theory.d
           coqc b/foo.{glob,vo}
-          coqc c/d/bar.{glob,vo}
           coqc c/ooo.{glob,vo}
+          coqc c/d/bar.{glob,vo}
           coqc a/bar.{glob,vo}
 
   $ dune build --debug-dependency-path @default


### PR DESCRIPTION
We make the loading of theories even lazier in scope.ml. This required refactoring the coq db into a Memo.Lazy.t. I'm open to a better way of doing this but this at least fixes the bug observed in #7747 and #7748.

I added a test case for #7747 and showed that this patch fixes it also.

This PR fixes the following issues, however they will be closed on a new run of the opam ci:
- #7747 
- #7748
