### PR TITLE
refactor: move colors into own library

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -24,6 +24,7 @@
   dune_engine
   dune_util
   dune_upgrader
+  dune_cli
   cmdliner
   threads
   ; Kept to keep implicit_transitive_deps false working in 4.x

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -92,7 +92,7 @@ let exit_and_flush code =
   exit (Exit_code.code code)
 
 let () =
-  Dune_rules.Colors.setup_err_formatter_colors ();
+  Dune_cli.Colors.setup_err_formatter_colors ();
   try
     match Cmd.eval_value cmd ~catch:false with
     | Ok _ -> exit_and_flush Success

--- a/boot/libs.ml
+++ b/boot/libs.ml
@@ -67,6 +67,7 @@ let local_libraries =
   ; ("src/dune_config_file", Some "Dune_config_file", false, None)
   ; ("src/dune_rules", Some "Dune_rules", true, None)
   ; ("src/upgrader", Some "Dune_upgrader", false, None)
+  ; ("src/dune_cli", Some "Dune_cli", false, None)
   ; ("vendor/cmdliner/src", None, false, None)
   ; ("otherlibs/build-info/src", Some "Build_info", false,
     Some "Build_info_data")

--- a/src/dune_cli/colors.ml
+++ b/src/dune_cli/colors.ml
@@ -1,4 +1,4 @@
-open Import
+open Stdune
 
 (* We redirect the output of all commands, so by default the various tools will
    disable colors. Since we support colors in the output of commands, we force

--- a/src/dune_cli/colors.mli
+++ b/src/dune_cli/colors.mli
@@ -1,6 +1,7 @@
-open Import
+open Stdune
 
-(** [Env.initial] extended with variables to force a few tools to print colors *)
+(** [setup_env_for_colors env] extends [env] with variables to force a few tools
+    to print colors. *)
 val setup_env_for_colors : Env.t -> Env.t
 
 (** Enable the interpretation of color tags for [Format.err_formatter] *)

--- a/src/dune_cli/dune
+++ b/src/dune_cli/dune
@@ -1,0 +1,3 @@
+(library
+ (name dune_cli)
+ (libraries stdune))

--- a/src/dune_rules/clflags.ml
+++ b/src/dune_rules/clflags.ml
@@ -8,6 +8,8 @@ let display = Dune_engine.Clflags.display
 
 let capture_outputs = Dune_engine.Clflags.capture_outputs
 
+let supports_color = ref false
+
 let debug_artifact_substitution = ref false
 
 type on_missing_dune_project_file =

--- a/src/dune_rules/clflags.mli
+++ b/src/dune_rules/clflags.mli
@@ -13,6 +13,9 @@ val display : Dune_engine.Display.t ref
 (** Re-exported form [Dune_engine] *)
 val capture_outputs : bool ref
 
+(** Whether to try use colors in the output. *)
+val supports_color : bool ref
+
 (** Print debug info about artifact substitution *)
 val debug_artifact_substitution : bool ref
 

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -312,27 +312,8 @@ let ocamlpath (kind : Kind.t) ~env ~findlib_toolchain =
       | Eq -> []
       | _ -> env_ocamlpath))
 
-let context_env env name ocfg findlib env_nodes version ~profile ~host
+let context_env env name ocfg findlib env_nodes ~profile ~host
     ~default_ocamlpath =
-  let env =
-    (* See comment in ansi_color.ml for setup_env_for_colors. For versions
-       where OCAML_COLOR is not supported, but 'color' is in OCAMLPARAM, use
-       the latter. If 'color' is not supported, we just don't force colors
-       with 4.02. *)
-    if
-      !Clflags.capture_outputs
-      && Lazy.force Ansi_color.stderr_supports_color
-      && Ocaml.Version.supports_color_in_ocamlparam version
-      && not (Ocaml.Version.supports_ocaml_color version)
-    then
-      let value =
-        match Env.get env "OCAMLPARAM" with
-        | None -> "color=always,_"
-        | Some s -> "color=always," ^ s
-      in
-      Env.add env ~var:"OCAMLPARAM" ~value
-    else env
-  in
   let extend_var var ?(path_sep = Bin.path_sep) v =
     let v = Path.to_absolute_filename (Path.build v) in
     match Env.get env var with
@@ -407,9 +388,27 @@ let create ~(kind : Kind.t) ~path ~env ~env_nodes ~name ~merlin ~targets
         stdlib_dir :: default_ocamlpath
       else default_ocamlpath
     in
+    (* Setting up colors for OCaml in case the version is too old. *)
     let env =
-      context_env env name ocaml.ocaml_config findlib env_nodes ocaml.version
-        ~profile ~host ~default_ocamlpath
+      (* For versions where OCAML_COLOR is not supported, but 'color' is in
+         OCAMLPARAM, use the latter. If 'color' is not supported, we just don't
+         force colors with 4.02. *)
+      if
+        !Clflags.supports_color
+        && Ocaml.Version.supports_color_in_ocamlparam ocaml.version
+        && not (Ocaml.Version.supports_ocaml_color ocaml.version)
+      then
+        let value =
+          match Env.get env "OCAMLPARAM" with
+          | None -> "color=always,_"
+          | Some s -> "color=always," ^ s
+        in
+        Env.add env ~var:"OCAMLPARAM" ~value
+      else env
+    in
+    let env =
+      context_env env name ocaml.ocaml_config findlib env_nodes ~profile ~host
+        ~default_ocamlpath
     in
     let lib_config =
       { Lib_config.has_native = Result.is_ok ocaml.ocamlopt

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -3,7 +3,6 @@ module Context = Context
 module Super_context = Super_context
 module Compilation_context = Compilation_context
 module Findlib = Findlib
-module Colors = Colors
 module Profile = Profile
 module Workspace = Workspace
 module Dune_package = Dune_package

--- a/src/dune_rules/global.ml
+++ b/src/dune_rules/global.ml
@@ -2,21 +2,15 @@ open Import
 
 let env = Fdecl.create Env.to_dyn
 
-let init ~capture_outputs =
+let init initenv =
   Fdecl.set env
-    (let env =
-       if
-         (not capture_outputs)
-         || not (Lazy.force Ansi_color.stderr_supports_color)
-       then Env.initial
-       else Colors.setup_env_for_colors Env.initial
-     in
-     let env = Env.add env ~var:"INSIDE_DUNE" ~value:"1" in
-     (* To improve reproducibility, we don't let command executed by Dune
-        observe whether Dune is run inside emacs or not. One such program that
-        behave differently when run inside emacs is Dune itself and we sometimes
-        run Dune from inside Dune, for instance in cram tests, so it is
-        important to do this. *)
-     Env.remove env ~var:"INSIDE_EMACS")
+    (initenv
+    |> Env.add ~var:"INSIDE_DUNE" ~value:"1"
+       (* To improve reproducibility, we don't let command executed by Dune
+          observe whether Dune is run inside emacs or not. One such program that
+          behave differently when run inside emacs is Dune itself and we sometimes
+          run Dune from inside Dune, for instance in cram tests, so it is
+          important to do this. *)
+    |> Env.remove ~var:"INSIDE_EMACS")
 
 let env () = Fdecl.get env

--- a/src/dune_rules/global.mli
+++ b/src/dune_rules/global.mli
@@ -5,4 +5,4 @@ open Import
 val env : unit -> Env.t
 
 (** Initialises this module. *)
-val init : capture_outputs:bool -> unit
+val init : Env.t -> unit


### PR DESCRIPTION
We move color handling code in dune_rules to a separate library called `dune_cli` which is then used in `bin/` rather than in `dune_rules` allowing `dune_cli` and `dune_rules` to be independent.

There is only a single piece of colour handling code left in `dune_rules` which tries to support colours when the compiler version is 4.02.

fix #7759